### PR TITLE
fix build error on procfs

### DIFF
--- a/os/fs/procfs/fs_procfs.c
+++ b/os/fs/procfs/fs_procfs.c
@@ -436,7 +436,9 @@ static int procfs_opendir(FAR struct inode *mountpt, FAR const char *relpath, FA
 	FAR struct procfs_level0_s *level0;
 	FAR struct procfs_dir_priv_s *dirpriv;
 	FAR void *priv = NULL;
+#ifndef CONFIG_FS_PROCFS_EXCLUDE_PROCESS
 	irqstate_t flags;
+#endif
 
 	fvdbg("relpath: \"%s\"\n", relpath ? relpath : "NULL");
 	DEBUGASSERT(mountpt && relpath && dir && !dir->u.procfs);
@@ -583,11 +585,13 @@ static int procfs_readdir(struct inode *mountpt, struct fs_dirent_s *dir)
 {
 	FAR struct procfs_dir_priv_s *priv;
 	FAR struct procfs_level0_s *level0;
-	FAR struct tcb_s *tcb;
 	FAR const char *name = NULL;
 	unsigned int index;
+#ifndef CONFIG_FS_PROCFS_EXCLUDE_PROCESS
+	FAR struct tcb_s *tcb;
 	irqstate_t flags;
 	pid_t pid;
+#endif
 	int ret = -ENOENT;
 
 	DEBUGASSERT(mountpt && dir && dir->u.procfs);


### PR DESCRIPTION
Some variables are only used when CONFIG_FS_PROCFS_EXCLUDE_PROCESS is disabled.
procfs/fs_procfs.c: In function 'procfs_opendir':
procfs/fs_procfs.c:439:13: error: unused variable 'flags' [-Werror=unused-variable]
  irqstate_t flags;
             ^
procfs/fs_procfs.c: In function 'procfs_readdir':
procfs/fs_procfs.c:590:8: error: unused variable 'pid' [-Werror=unused-variable]
  pid_t pid;
        ^
procfs/fs_procfs.c:589:13: error: unused variable 'flags' [-Werror=unused-variable]
  irqstate_t flags;
             ^
procfs/fs_procfs.c:586:20: error: unused variable 'tcb' [-Werror=unused-variable]
  FAR struct tcb_s *tcb;