### PR TITLE
Fix  lseek's bug in smartfs

### DIFF
--- a/os/fs/smartfs/smartfs_smart.c
+++ b/os/fs/smartfs/smartfs_smart.c
@@ -1040,7 +1040,7 @@ static off_t smartfs_seek_internal(struct smartfs_mountpt_s *fs, struct smartfs_
 		break;
 
 	case SEEK_END:
-		newpos = sf->entry.datlen - offset;
+		newpos = sf->entry.datlen + offset;
 		break;
 	}
 


### PR DESCRIPTION
lseek should set the file offset to the size of the file plus offset