### PR TITLE
modify version.sh

### DIFF
--- a/os/tools/version.sh
+++ b/os/tools/version.sh
@@ -135,12 +135,13 @@ if [ -z "${BUILD}" ]; then
 	GITINFO=`git log 2>/dev/null | head -1`
 	if [ -z "${GITINFO}" ]; then
 		echo "GIT version information is not available"
-		exit 3
-	fi
-	BUILD=`echo ${GITINFO} | cut -d' ' -f2`
-	if [ -z "${BUILD}" ]; then
-		echo "GIT build information not found"
-		exit 4
+		BUILD=NA
+	else
+		BUILD=`echo ${GITINFO} | cut -d' ' -f2`
+		if [ -z "${BUILD}" ]; then
+			echo "GIT build information not found"
+			BUILD=NA
+		fi
 	fi
 fi
 


### PR DESCRIPTION
If Tizen RT is tried to build without .git, below error is shown.
We should make Tizen RT can be built regardless of existing of .git.
No .version file found, creating one
GIT version information is not available
chmod: cannot access ‘.version’: No such file or directory
make: *** [/os/.version] Error 1