### PR TITLE
modify dependancies of examples, proc_test and hello_tash

### DIFF
--- a/apps/examples/hello_tash/Kconfig
+++ b/apps/examples/hello_tash/Kconfig
@@ -6,6 +6,7 @@
 config EXAMPLES_HELLO_TASH
 	bool "\"Hello, World!\" example in tash"
 	default n
+	depends on TASH
 	---help---
 		Enable the \"Hello, World!\" example in tash
 

--- a/apps/examples/hello_tash/hello_tash_main.c
+++ b/apps/examples/hello_tash/hello_tash_main.c
@@ -141,8 +141,7 @@ int main(int argc, FAR char *argv[])
 int hello_tash_main(int argc, char **args)
 #endif
 {
-#ifdef CONFIG_TASH
 	tash_cmd_install("hello_tash", hello_tash_cb, TASH_EXECMD_ASYNC);
-#endif
+
 	return 0;
 }

--- a/apps/examples/proc_test/Kconfig
+++ b/apps/examples/proc_test/Kconfig
@@ -6,6 +6,7 @@
 config EXAMPLES_PROC_TEST
 	bool "\"Procfs\" example"
 	default n
+	depends on !DISABLE_MOUNTPOINT && FS_PROCFS
 	---help---
 		Enable the \"Procfs\" example
 

--- a/apps/examples/proc_test/proc_test_main.c
+++ b/apps/examples/proc_test/proc_test_main.c
@@ -49,7 +49,7 @@ char g_proc_iobuffer[PROC_BUFFER_LEN];
 /****************************************************************************
  * Private Functions
  ****************************************************************************/
-#if !defined(CONFIG_DISABLE_MOUNTPOINT) && defined(CONFIG_FS_PROCFS)
+
 int proc_read_entry(direntry_handler_t handler)
 {
 	DIR *dirp;
@@ -340,7 +340,7 @@ int proc_version_test()
 	return OK;
 }
 #endif
-#endif
+
 static int my_task(int argc, char *argv[])
 {
 	while (1) {
@@ -378,7 +378,6 @@ int proc_test_main(int argc, char *argv[])
 	}
 
 	while (1) {
-#if !defined(CONFIG_DISABLE_MOUNTPOINT) && defined(CONFIG_FS_PROCFS)
 #ifndef CONFIG_FS_PROCFS_EXCLUDE_PROCESS
 		proc_read_entry(proc_pid);
 #ifdef CONFIG_SCHED_CPULOAD
@@ -393,7 +392,6 @@ int proc_test_main(int argc, char *argv[])
 #endif
 #ifndef CONFIG_FS_PROCFS_EXCLUDE_VERSION
 		proc_version_test();
-#endif
 #endif
 		sleep(INTERVAL_UPDATE_SEC);
 	}


### PR DESCRIPTION
TASH for hello_tash and DISABLE_MOUNTPOINT, FS_PROCFS for proc_test are needed.
There is no meaningful operation without those configs.