### PR TITLE
Fix rtc

### DIFF
--- a/lib/libc/time/lib_daysbeforemonth.c
+++ b/lib/libc/time/lib_daysbeforemonth.c
@@ -107,11 +107,11 @@ static const uint16_t g_daysbeforemonth[13] = {
 
 int clock_daysbeforemonth(int month, bool leapyear)
 {
-	int retval;
-	retval = g_daysbeforemonth[month - 1];
+	int retval = g_daysbeforemonth[month];
 
-	if (month > 2 && leapyear) {
+	if (month >= 2 && leapyear) {
 		retval++;
 	}
+
 	return retval;
 }

--- a/os/arch/arm/src/s5j/s5j_rtc.c
+++ b/os/arch/arm/src/s5j/s5j_rtc.c
@@ -433,6 +433,11 @@ int up_rtc_initialize(void)
 		putreg32(1, S5J_RTC_BCDMON);
 	}
 
+	/* OS supports to convert epoch only after 1970. Set year to 2010. */
+	if (getreg32(S5J_RTC_BCDYEAR) == 0) {
+		putreg32(0x110, S5J_RTC_BCDYEAR);
+	}
+
 	rtc_wprlock();
 
 	g_rtc_enabled = true;

--- a/os/arch/arm/src/s5j/s5j_rtc.c
+++ b/os/arch/arm/src/s5j/s5j_rtc.c
@@ -424,6 +424,15 @@ int up_rtc_initialize(void)
 			RTC_RTCCON_CNTSEL_MERGE_BCDCNT |
 			RTC_RTCCON_CLKSEL_DIV32768);
 
+	/* Fix invalid reset value of BCDDAY and BCDMON which is based 1. */
+	if (getreg32(S5J_RTC_BCDDAY) == 0) {
+		putreg32(1, S5J_RTC_BCDDAY);
+	}
+
+	if (getreg32(S5J_RTC_BCDMON) == 0) {
+		putreg32(1, S5J_RTC_BCDMON);
+	}
+
 	rtc_wprlock();
 
 	g_rtc_enabled = true;


### PR DESCRIPTION
I've found that several problems on RTC. First, epoch timestamp is being converted incorrectly by clock_gettime(). Second, RTC subsystem in S5J has some errata that some of BCD registers are not initialized properly on power-on-reset. Finally, we set the BCDYEAR to 2010 at boot in order to workaround the problem that the OS cannot handle date/time before 1970. This patchset fixes them all.