### PR TITLE
[Title] Modified Kconfig in external to add DM WiFi settings

### DIFF
--- a/apps/examples/testcase/ta_tc/device_management/utc/Kconfig
+++ b/apps/examples/testcase/ta_tc/device_management/utc/Kconfig
@@ -12,29 +12,6 @@ menuconfig EXAMPLES_TESTCASE_DM_UTC
 
 if EXAMPLES_TESTCASE_DM_UTC
 
-menuconfig EXAMPLES_TESTCASE_DM_WIFI
-	bool "Set Up Wifi Info For DM Demo"
-	default n
-	---help---
-		Enable the artik demo example
-
-if EXAMPLES_TESTCASE_DM_WIFI
-
-config DM_AP_SSID
-	string "wifi ap ssid"
-	default "SSID"
-
-config DM_AP_PASS
-	string "wifi ap password"
-	default "PASSWORD"
-
-config DM_AP_SECURITY
-	string "wifi join security"
-	default "wpa2_aes"
-
-endif #EXAMPLES_TESTCASE_DM_WIFI
-
-
 config TC_DM_START
 	bool "Start API"
 	default n

--- a/external/Kconfig
+++ b/external/Kconfig
@@ -42,6 +42,29 @@ config LWM2M_SECURITY
 	---help---
 		This definition is for enabling COAP over TLS and DTLS.
 endif
+
+menuconfig DM_WIFI
+	bool "Set Up Wifi Info For DM Demo"
+	default n
+	---help---
+		Enable the artik demo example
+
+if DM_WIFI
+
+config DM_AP_SSID
+	string "wifi ap ssid"
+	default "SSID"
+
+config DM_AP_PASS
+	string "wifi ap password"
+	default "PASSWORD"
+
+config DM_AP_SECURITY
+	string "wifi join security"
+	default "wpa2_aes"
+
+endif #DM_WIFI
+
 endif
 
 config ENABLE_IOTIVITY


### PR DESCRIPTION
[Description] WiFi settings for Device Management were defined under apps/examples folder. They are now moved to external folder where they should belong.