### PR TITLE
fix compilation error

### DIFF
--- a/apps/include/builtin.h
+++ b/apps/include/builtin.h
@@ -1,0 +1,26 @@
+/****************************************************************************
+ *
+ * Copyright 2017 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+#ifndef __APPS_INCLUDE_BUILTIN_H
+#define __APPS_INCLUDE_BUILTIN_H
+#include <tinyara/config.h>
+
+#ifdef CONFIG_BUILTIN_APPS
+void register_examples_cmds(void);
+#endif
+
+#endif							/* __APPS_INCLUDE_BUILTIN_H */

--- a/apps/system/init/init.c
+++ b/apps/system/init/init.c
@@ -27,6 +27,9 @@
 #include <apps/shell/tash.h>
 #include <apps/system/utils.h>
 #endif
+#ifdef CONFIG_BUILTIN_APPS
+#include <apps/builtin.h>
+#endif
 #ifdef CONFIG_SYSTEM_INFORMATION
 #include <apps/system/sysinfo.h>
 #endif
@@ -69,7 +72,9 @@ static void tash_register_cmds(void)
 	net_register_appcmds();
 #endif
 
+#ifdef CONFIG_BUILTIN_APPS
 	register_examples_cmds();
+#endif
 }
 #endif							/* CONFIG_TASH */
 


### PR DESCRIPTION
TizenRT/os/../build/output/libraries/libapps.a(init.o): In function `tash_register_cmds':
TizenRT/apps/system/init/init.c:72: undefined reference to `register_examples_cmds'
make[1]: *** [../build/output/bin/tinyara] Error 1