### PR TITLE
fix compilation warning at arastorage

### DIFF
--- a/framework/src/arastorage/index_manager.c
+++ b/framework/src/arastorage/index_manager.c
@@ -443,7 +443,7 @@ db_result_t db_indexing(relation_t *rel)
 	index = get_next_index_to_load();
 	if (index == NULL) {
 		DB_LOG_E("DB: Request to load an index, but no index is set to be loaded\n");
-		goto errout;
+		return DB_INDEX_ERROR;
 	}
 
 	row = NULL;

--- a/framework/src/arastorage/storage_interface.c
+++ b/framework/src/arastorage/storage_interface.c
@@ -569,13 +569,18 @@ db_result_t storage_flush_insert_buffer()
 {
 	ssize_t r;
 	int fd;
-	if (g_storage_write_buffer.data_size > 0) {
-		fd = storage_open(g_storage_write_buffer.file_name, O_APPEND | O_RDWR);
-		if (fd < 0) {
-			DB_LOG_D("Failed to open %s\n", g_storage_write_buffer.file_name);
-			return DB_STORAGE_ERROR;
-		}
+
+	if (g_storage_write_buffer.data_size <= 0) {
+		/* There is no data to flush, return here */
+		return DB_OK;
 	}
+
+	fd = storage_open(g_storage_write_buffer.file_name, O_APPEND | O_RDWR);
+	if (fd < 0) {
+		DB_LOG_D("Failed to open %s\n", g_storage_write_buffer.file_name);
+		return DB_STORAGE_ERROR;
+	}
+
 	r = storage_write(fd, g_storage_write_buffer.buffer, g_storage_write_buffer.data_size);
 	if (r < 0) {
 		storage_close(fd);


### PR DESCRIPTION
src/arastorage/index_manager.c:506:5: warning: 'row' may be used uninitialized in this function [-Wmaybe-uninitialized]
  if (row != NULL) {

src/arastorage/storage_interface.c:579:4: warning: 'fd' may be used uninitialized in this function [-Wmaybe-uninitialized]
  r = storage_write(fd, g_storage_write_buffer.buffer, g_storage_write_buffer.data_size);