### PR TITLE
irq_dispatch : Set the arg variable to NULL so that interrupt handler…

### DIFF
--- a/os/kernel/irq/irq_dispatch.c
+++ b/os/kernel/irq/irq_dispatch.c
@@ -112,6 +112,7 @@ void irq_dispatch(int irq, FAR void *context)
 	}
 #else
 	vector = irq_unexpected_isr;
+	arg    = NULL;
 #endif
 
 	/* Then dispatch to the interrupt handler */


### PR DESCRIPTION
… does not pass junk value as argument

Signed-off-by: pradeep.ns <pradeep.ns@samsung.com>