### PR TITLE
Restore the interrupts if wdog is created statically

### DIFF
--- a/os/kernel/wdog/wd_delete.c
+++ b/os/kernel/wdog/wd_delete.c
@@ -161,6 +161,15 @@ int wd_delete(WDOG_ID wdog)
 		DEBUGASSERT(g_wdnfree <= CONFIG_PREALLOC_WDOGS);
 		irqrestore(state);
 	}
+	else
+	{
+		/* There is no guarantee that, this API is not called for statically 
+		 * allocated timers as wd_delete is a global function. So restore the
+		 * irq properly so that it does not break the system */
+
+		irqrestore(state);
+
+	}
 
 	/* Return success */
 


### PR DESCRIPTION
Interrupts has been restored only under 2 conditions
1) pre-allocated wdog free list
2) Allocated from heap memory
If the wdog has been statically allocated from wd_static API,and
wd_delete API is invoked, interrupts have not been restored. Since
wd_delete is global API, system can't guarantee that it will not
be called for statically created wdog timers

Signed-off-by: pradeep.ns <pradeep.ns@samsung.com>