### PR TITLE
examples/telnetd: fix compile error

### DIFF
--- a/apps/examples/telnetd/Makefile
+++ b/apps/examples/telnetd/Makefile
@@ -56,7 +56,7 @@ include $(APPDIR)/Make.defs
 
 # built-in application info
 
-APPNAME = telnetd 
+APPNAME = telnetd
 THREADEXEC = TASH_EXECMD_ASYNC
 
 # telnet daemon example


### PR DESCRIPTION
There is a white space in APPNAME, and there is a problem in creating
BuiltinApps. This patch fixes such a bug.

Signed-off-by: Junhwan Park <junhwan.park@samsung.com>