### PR TITLE
Decrement the g_wdnfree variable only if there is a valid wdog node i…

### DIFF
--- a/os/kernel/wdog/wd_create.c
+++ b/os/kernel/wdog/wd_create.c
@@ -130,18 +130,23 @@ WDOG_ID wd_create(void)
 		 */
 
 		wdog = (FAR struct wdog_s *)sq_remfirst(&g_wdfreelist);
-		DEBUGASSERT(g_wdnfree > 0);
-		g_wdnfree--;
-		irqrestore(state);
 
 		/* Did we get one? */
 
 		if (wdog) {
+			DEBUGASSERT(g_wdnfree > 0);
+			g_wdnfree--;
+
 			/* Yes.. Clear the forward link and all flags */
 
 			wdog->next = NULL;
 			wdog->flags = 0;
 		}
+		else {
+			/* If wdog is Null, g_wdnfree must be zero, else assert */
+			DEBUGASSERT(g_wdnfree == 0);
+		}
+		irqrestore(state);
 	}
 
 	/* We are in a normal tasking context AND there are not enough unreserved,


### PR DESCRIPTION
…n g_wdfreelist

If the g_wdfreelist doesn't contain any node, it will return NULL and
decrementing the g_wdnfree variable would lead to wrong logic.
Decrement the g_wdnfree variable only if there is a valid wdog is returned from g_wdfreelist

Signed-off-by: pradeep.ns <pradeep.ns@samsung.com>