### PR TITLE
drivers: modify author's email address

### DIFF
--- a/os/drivers/usbdev/Make.defs
+++ b/os/drivers/usbdev/Make.defs
@@ -19,7 +19,7 @@
 # drivers/usbdev/Make.defs
 #
 #   Copyright (C) 2008, 2010-2013 Gregory Nutt. All rights reserved.
-#   Author: Gregory Nutt <gnutt@tinyara.org>
+#   Author: Gregory Nutt <gnutt@nuttx.org>
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/os/drivers/usbdev/cdcacm.c
+++ b/os/drivers/usbdev/cdcacm.c
@@ -19,7 +19,7 @@
  * drivers/usbdev/cdcacm.c
  *
  *   Copyright (C) 2011-2013 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@tinyara.org>
+ *   Author: Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/os/drivers/usbdev/cdcacm.h
+++ b/os/drivers/usbdev/cdcacm.h
@@ -19,7 +19,7 @@
  * drivers/usbdev/cdcacm.h
  *
  *   Copyright (C) 2011-2012, 2015 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@tinyara.org>
+ *   Author: Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/os/drivers/usbdev/cdcacm_desc.c
+++ b/os/drivers/usbdev/cdcacm_desc.c
@@ -19,7 +19,7 @@
  * drivers/usbdev/cdcacm_desc.c
  *
  *   Copyright (C) 2011-2012, 2015 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@tinyara.org>
+ *   Author: Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/os/drivers/usbdev/composite.c
+++ b/os/drivers/usbdev/composite.c
@@ -19,7 +19,7 @@
  * drivers/usbdev/composite.c
  *
  *   Copyright (C) 2012 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@tinyara.org>
+ *   Author: Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/os/drivers/usbdev/composite.h
+++ b/os/drivers/usbdev/composite.h
@@ -19,7 +19,7 @@
  * drivers/usbdev/composite.h
  *
  *   Copyright (C) 2011-2012 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@tinyara.org>
+ *   Author: Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/os/drivers/usbdev/composite_desc.c
+++ b/os/drivers/usbdev/composite_desc.c
@@ -19,7 +19,7 @@
  * drivers/usbdev/composite_desc.c
  *
  *   Copyright (C) 2011-2012 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@tinyara.org>
+ *   Author: Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/os/drivers/usbdev/pl2303.c
+++ b/os/drivers/usbdev/pl2303.c
@@ -19,7 +19,7 @@
  * drivers/usbdev/pl2303.c
  *
  *   Copyright (C) 2008-2013, 2015 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@tinyara.org>
+ *   Author: Gregory Nutt <gnutt@nuttx.org>
  *
  * This logic emulates the Prolific PL2303 serial/USB converter
  *

--- a/os/drivers/usbdev/usbdev_strings.c
+++ b/os/drivers/usbdev/usbdev_strings.c
@@ -19,7 +19,7 @@
  * drivers/usbdev/usbdev_strings.c
  *
  *   Copyright (C) 2013 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@tinyara.org>
+ *   Author: Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/os/drivers/usbdev/usbdev_trace.c
+++ b/os/drivers/usbdev/usbdev_trace.c
@@ -19,7 +19,7 @@
  * drivers/usbdev/usbdev_trace.c
  *
  *   Copyright (C) 2008-2010, 2012 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@tinyara.org>
+ *   Author: Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/os/drivers/usbdev/usbdev_trprintf.c
+++ b/os/drivers/usbdev/usbdev_trprintf.c
@@ -19,7 +19,7 @@
  * drivers/usbdev/usbdev_trprintf.c
  *
  *   Copyright (C) 2008-2010, 2012-2013 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@tinyara.org>
+ *   Author: Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/os/drivers/usbdev/usbmsc.c
+++ b/os/drivers/usbdev/usbmsc.c
@@ -19,7 +19,7 @@
  * drivers/usbdev/usbmsc.c
  *
  *   Copyright (C) 2008-2012 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@tinyara.org>
+ *   Author: Gregory Nutt <gnutt@nuttx.org>
  *
  * Mass storage class device.  Bulk-only with SCSI subclass.
  *

--- a/os/drivers/usbdev/usbmsc.h
+++ b/os/drivers/usbdev/usbmsc.h
@@ -19,7 +19,7 @@
  * drivers/usbdev/usbmsc.h
  *
  *   Copyright (C) 2008-2013, 2015 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@tinyara.org>
+ *   Author: Gregory Nutt <gnutt@nuttx.org>
  *
  * Mass storage class device.  Bulk-only with SCSI subclass.
  *

--- a/os/drivers/usbdev/usbmsc_desc.c
+++ b/os/drivers/usbdev/usbmsc_desc.c
@@ -19,7 +19,7 @@
  * drivers/usbdev/usbmsc_desc.c
  *
  *   Copyright (C) 2011-2012, 2015 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@tinyara.org>
+ *   Author: Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/os/drivers/usbdev/usbmsc_scsi.c
+++ b/os/drivers/usbdev/usbmsc_scsi.c
@@ -19,7 +19,7 @@
  * drivers/usbdev/usbmsc_scsi.c
  *
  *   Copyright (C) 2008-2010, 2012 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@tinyara.org>
+ *   Author: Gregory Nutt <gnutt@nuttx.org>
  *
  * Mass storage class device.  Bulk-only with SCSI subclass.
  *

--- a/os/drivers/wireless/scsc/Make.defs
+++ b/os/drivers/wireless/scsc/Make.defs
@@ -2,7 +2,7 @@
 # drivers/wireless/Make.defs
 #
 #   Copyright (C) 2013 Gregory Nutt. All rights reserved.
-#   Author: Gregory Nutt <gnutt@tinyara.org>
+#   Author: Gregory Nutt <gnutt@nuttx.org>
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions


### PR DESCRIPTION
The e-mail address of the author of the file is incorrect. I think it is
a bug that occurred when changing nuttx to tinyara in batch.

Signed-off-by: Junhwan Park <junhwan.park@samsung.com>