### PR TITLE
Change the irq_detach argument from isr to irq

### DIFF
--- a/os/include/tinyara/irq.h
+++ b/os/include/tinyara/irq.h
@@ -68,7 +68,7 @@
  */
 
 #ifndef __ASSEMBLY__
-#define irq_detach(isr) irq_attach(isr, NULL, NULL)
+#define irq_detach(irq) irq_attach(irq, NULL, NULL)
 #endif
 
 /****************************************************************************


### PR DESCRIPTION
irq_detach API expects irq as argument but naming it as isr
is confusing. Change it to appropriate name as irq

Signed-off-by: pradeep.ns <pradeep.ns@samsung.com>