### PR TITLE
Stop the watchdog timer in error case of sem_wait failure

### DIFF
--- a/apps/examples/telnetd/Makefile
+++ b/apps/examples/telnetd/Makefile
@@ -56,7 +56,7 @@ include $(APPDIR)/Make.defs
 
 # built-in application info
 
-APPNAME = telnetd 
+APPNAME = telnetd
 THREADEXEC = TASH_EXECMD_ASYNC
 
 # telnet daemon example

--- a/build/configs/artik053/artik053_download.sh
+++ b/build/configs/artik053/artik053_download.sh
@@ -58,7 +58,7 @@ main()
 			# check existence of firmware binaries
 			if [ ! -f "${FW_DIR_PATH}/bl1.bin" ] ||\
 				[ ! -f "${FW_DIR_PATH}/bl2.bin" ] ||\
-				[ ! -f "${FW_DIR_PATH}/sssfw.bin"] ||\
+				[ ! -f "${FW_DIR_PATH}/sssfw.bin" ] ||\
 				[ ! -f "${FW_DIR_PATH}/wlanfw.bin" ]; then
 				echo "Firmware binaries for ARTIK 053 are not existed"
 				exit 1

--- a/os/arch/Kconfig
+++ b/os/arch/Kconfig
@@ -10,6 +10,7 @@ choice
 config ARCH_ARM
 	bool "ARM"
 	select ARCH_HAVE_INTERRUPTSTACK
+	select ARCH_HAVE_DABORTSTACK
 	select ARCH_HAVE_VFORK
 	select ARCH_HAVE_STACKCHECK
 	select ARCH_HAVE_CUSTOMOPT
@@ -661,6 +662,24 @@ config ARCH_INT_DISABLEALL
 		standard interrupt handling, prohibiting nesting.  Fix is simple:  Need
 		to used more priority levels so that we can make a cleaner distinction
 		with the standard interrupt handler.
+
+comment "Exception stack options"
+
+config ARCH_HAVE_DABORTSTACK
+	bool
+	default n
+
+config ARCH_DABORTSTACK
+	int "Dabort Stack Size"
+	depends on ARCH_HAVE_DABORTSTACK
+	default 0
+	---help---
+		This architecture supports an data abort stack. If defined, this symbol
+		will be the size of the data abort stack in bytes.  If not defined (or
+		defined to be zero or less than 512 bytes), the user task stacks
+		will be used during data abort handling. Recommended data abort stack
+		size is 1K.
+
 
 comment "Boot options"
 

--- a/os/arch/arm/src/armv7-r/arm_vectors.S
+++ b/os/arch/arm/src/armv7-r/arm_vectors.S
@@ -81,6 +81,9 @@ g_undeftmp:
 g_aborttmp:
 	.word	0		/* Saved lr */
 	.word	0		/* Saved spsr */
+#if defined(CONFIG_ARCH_DABORTSTACK) && CONFIG_ARCH_DABORTSTACK >= 512
+	.word	0		/* Saved r0 */
+#endif
 #ifdef CONFIG_ARMV7R_DECODEFIQ
 g_fiqtmp:
 	.word	0		/* Saved lr */
@@ -484,6 +487,10 @@ arm_vectordata:
 	mrs		lr, spsr				/* Get SPSR */
 	str		lr, [r13, #4]			/* Save in temp storage */
 
+#if defined(CONFIG_ARCH_DABORTSTACK) && CONFIG_ARCH_DABORTSTACK >= 512
+	str		r0, [r13, #8]
+#endif
+
 	/* Then switch back to SVC mode */
 
 	bic		lr, lr, #PSR_MODE_MASK	/* Keep F and T bits */
@@ -494,6 +501,15 @@ arm_vectordata:
 	 * and store r0-r12 into the frame.
 	 */
 
+#if defined(CONFIG_ARCH_DABORTSTACK) && CONFIG_ARCH_DABORTSTACK >= 512
+	mov		r0, sp			/* Preserve SVC mode stack */
+	ldr		sp, .Ldabtstackbase	/* Set DABT mode stack */
+	str		r0, [sp]		/* save SVC stack pointer DABT mode stack */
+	ldr		sp, .Ldaborttmp		/* Points to temp storage */
+	ldr		r0, [sp, #8]		/* Recover r0 */
+	ldr		sp, .Ldabtstackbase	/* Set back DABT mode stack */
+	bic		sp, sp, #7		/* Force 8-byte alignment */
+#endif
 	sub		sp, sp, #XCPTCONTEXT_SIZE
 	stmia	sp, {r0-r12}			/* Save the SVC mode regs */
 
@@ -526,7 +542,12 @@ arm_vectordata:
 	 * and r2.
 	 */
 
+#if defined(CONFIG_ARCH_DABORTSTACK) && CONFIG_ARCH_DABORTSTACK >= 512
+	ldr		r5, .Ldabtstackbase	/* Set DABT mode stack base */
+	ldr		r1, [r5]		/* Read SVC stack pointer */
+#else
 	add		r1, sp, #XCPTCONTEXT_SIZE
+#endif
 	mov		r2, r14
 
 	/* Save r13(sp), r14(lr), r15(pc), and the CPSR */
@@ -539,7 +560,12 @@ arm_vectordata:
 #else
 	/* Get the correct values of SVC r13(sp) and r14(lr) in r1 and r2 */
 
+#if defined(CONFIG_ARCH_DABORTSTACK) && CONFIG_ARCH_DABORTSTACK >= 512
+	ldr		r5, .Ldabtstackbase	/* Set DABT mode stack base */
+	ldr		r1, [r5]		/* Read SVC stack pointer */
+#else
 	add		r1, sp, #XCPTCONTEXT_SIZE
+#endif
 	mov		r2, r14
 
 	/* Save r13(sp), r14(lr), r15(pc), and the CPSR */
@@ -560,6 +586,12 @@ arm_vectordata:
 	bic		sp, sp, #7				/* Force 8-byte alignment */
 	bl		arm_dataabort			/* Call the handler */
 	mov		sp, r4					/* Restore the possibly unaligned stack pointer */
+
+#if defined(CONFIG_ARCH_DABORTSTACK) && CONFIG_ARCH_DABORTSTACK >= 512
+	ldr		sp, .Ldabtstackbase		/* Set DABT mode stack */
+	ldr		r4, [sp]			/* Recover SVC mode stack */
+	mov		sp, r4				/* Restore SVC mode stack */
+#endif
 
 	/* Upon return from arm_dataabort, r0 holds the pointer to the register
 	 * state save area to use to restore the registers.  This may or may not
@@ -600,6 +632,10 @@ arm_vectordata:
 
 .Ldaborttmp:
 	.word	g_aborttmp
+#if defined(CONFIG_ARCH_DABORTSTACK) && CONFIG_ARCH_DABORTSTACK >= 512
+.Ldabtstackbase:
+	.word	g_dabtstackbase
+#endif
 	.size	arm_vectordata, . - arm_vectordata
 
 	.align	5
@@ -1069,4 +1105,25 @@ g_intstackbase:
 	.size	g_intstackalloc, (CONFIG_ARCH_INTERRUPTSTACK & ~3)
 
 #endif /* CONFIG_ARCH_INTERRUPTSTACK > 3 */
+
+/************************************************************************************
+ *  Name: g_dabtstackalloc/g_dabtstackbase
+ ************************************************************************************/
+#if defined(CONFIG_ARCH_DABORTSTACK) && CONFIG_ARCH_DABORTSTACK >= 512
+	.bss
+	.align	4
+
+	.globl	g_dabtstackalloc
+	.type	g_dabtstackalloc, object
+	.globl	g_dabtstackbase
+	.type	g_dabtstackbase, object
+
+g_dabtstackalloc:
+	.skip	((CONFIG_ARCH_DABORTSTACK & ~3) - 4)
+g_dabtstackbase:
+	.skip	4
+	.size	g_dabtstackbase, 4
+	.size	g_dabtstackalloc, (CONFIG_ARCH_DABORTSTACK & ~3)
+
+#endif /* defined(CONFIG_ARCH_DABORTSTACK) && CONFIG_ARCH_DABORTSTACK >= 512 */
 	.end

--- a/os/arch/arm/src/common/up_internal.h
+++ b/os/arch/arm/src/common/up_internal.h
@@ -239,6 +239,11 @@ EXTERN uint32_t g_intstackalloc;	/* Allocated stack base */
 EXTERN uint32_t g_intstackbase;	/* Initial top of interrupt stack */
 #endif
 
+#if defined(CONFIG_ARCH_DABORTSTACK) && CONFIG_ARCH_DABORTSTACK >= 512
+EXTERN uint32_t g_dabtstackalloc;	/* Allocated data abort stack base */
+EXTERN uint32_t g_dabtstackbase;	/* Initial top of data abort stack */
+#endif
+
 /* These 'addresses' of these values are setup by the linker script.  They are
  * not actual uint32_t storage locations! They are only used meaningfully in the
  * following way:

--- a/os/drivers/usbdev/Make.defs
+++ b/os/drivers/usbdev/Make.defs
@@ -19,7 +19,7 @@
 # drivers/usbdev/Make.defs
 #
 #   Copyright (C) 2008, 2010-2013 Gregory Nutt. All rights reserved.
-#   Author: Gregory Nutt <gnutt@tinyara.org>
+#   Author: Gregory Nutt <gnutt@nuttx.org>
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/os/drivers/usbdev/cdcacm.c
+++ b/os/drivers/usbdev/cdcacm.c
@@ -19,7 +19,7 @@
  * drivers/usbdev/cdcacm.c
  *
  *   Copyright (C) 2011-2013 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@tinyara.org>
+ *   Author: Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/os/drivers/usbdev/cdcacm.h
+++ b/os/drivers/usbdev/cdcacm.h
@@ -19,7 +19,7 @@
  * drivers/usbdev/cdcacm.h
  *
  *   Copyright (C) 2011-2012, 2015 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@tinyara.org>
+ *   Author: Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/os/drivers/usbdev/cdcacm_desc.c
+++ b/os/drivers/usbdev/cdcacm_desc.c
@@ -19,7 +19,7 @@
  * drivers/usbdev/cdcacm_desc.c
  *
  *   Copyright (C) 2011-2012, 2015 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@tinyara.org>
+ *   Author: Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/os/drivers/usbdev/composite.c
+++ b/os/drivers/usbdev/composite.c
@@ -19,7 +19,7 @@
  * drivers/usbdev/composite.c
  *
  *   Copyright (C) 2012 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@tinyara.org>
+ *   Author: Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/os/drivers/usbdev/composite.h
+++ b/os/drivers/usbdev/composite.h
@@ -19,7 +19,7 @@
  * drivers/usbdev/composite.h
  *
  *   Copyright (C) 2011-2012 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@tinyara.org>
+ *   Author: Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/os/drivers/usbdev/composite_desc.c
+++ b/os/drivers/usbdev/composite_desc.c
@@ -19,7 +19,7 @@
  * drivers/usbdev/composite_desc.c
  *
  *   Copyright (C) 2011-2012 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@tinyara.org>
+ *   Author: Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/os/drivers/usbdev/pl2303.c
+++ b/os/drivers/usbdev/pl2303.c
@@ -19,7 +19,7 @@
  * drivers/usbdev/pl2303.c
  *
  *   Copyright (C) 2008-2013, 2015 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@tinyara.org>
+ *   Author: Gregory Nutt <gnutt@nuttx.org>
  *
  * This logic emulates the Prolific PL2303 serial/USB converter
  *

--- a/os/drivers/usbdev/usbdev_strings.c
+++ b/os/drivers/usbdev/usbdev_strings.c
@@ -19,7 +19,7 @@
  * drivers/usbdev/usbdev_strings.c
  *
  *   Copyright (C) 2013 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@tinyara.org>
+ *   Author: Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/os/drivers/usbdev/usbdev_trace.c
+++ b/os/drivers/usbdev/usbdev_trace.c
@@ -19,7 +19,7 @@
  * drivers/usbdev/usbdev_trace.c
  *
  *   Copyright (C) 2008-2010, 2012 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@tinyara.org>
+ *   Author: Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/os/drivers/usbdev/usbdev_trprintf.c
+++ b/os/drivers/usbdev/usbdev_trprintf.c
@@ -19,7 +19,7 @@
  * drivers/usbdev/usbdev_trprintf.c
  *
  *   Copyright (C) 2008-2010, 2012-2013 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@tinyara.org>
+ *   Author: Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/os/drivers/usbdev/usbmsc.c
+++ b/os/drivers/usbdev/usbmsc.c
@@ -19,7 +19,7 @@
  * drivers/usbdev/usbmsc.c
  *
  *   Copyright (C) 2008-2012 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@tinyara.org>
+ *   Author: Gregory Nutt <gnutt@nuttx.org>
  *
  * Mass storage class device.  Bulk-only with SCSI subclass.
  *

--- a/os/drivers/usbdev/usbmsc.h
+++ b/os/drivers/usbdev/usbmsc.h
@@ -19,7 +19,7 @@
  * drivers/usbdev/usbmsc.h
  *
  *   Copyright (C) 2008-2013, 2015 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@tinyara.org>
+ *   Author: Gregory Nutt <gnutt@nuttx.org>
  *
  * Mass storage class device.  Bulk-only with SCSI subclass.
  *

--- a/os/drivers/usbdev/usbmsc_desc.c
+++ b/os/drivers/usbdev/usbmsc_desc.c
@@ -19,7 +19,7 @@
  * drivers/usbdev/usbmsc_desc.c
  *
  *   Copyright (C) 2011-2012, 2015 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@tinyara.org>
+ *   Author: Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/os/drivers/usbdev/usbmsc_scsi.c
+++ b/os/drivers/usbdev/usbmsc_scsi.c
@@ -19,7 +19,7 @@
  * drivers/usbdev/usbmsc_scsi.c
  *
  *   Copyright (C) 2008-2010, 2012 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@tinyara.org>
+ *   Author: Gregory Nutt <gnutt@nuttx.org>
  *
  * Mass storage class device.  Bulk-only with SCSI subclass.
  *

--- a/os/drivers/wireless/scsc/Make.defs
+++ b/os/drivers/wireless/scsc/Make.defs
@@ -2,7 +2,7 @@
 # drivers/wireless/Make.defs
 #
 #   Copyright (C) 2013 Gregory Nutt. All rights reserved.
-#   Author: Gregory Nutt <gnutt@tinyara.org>
+#   Author: Gregory Nutt <gnutt@nuttx.org>
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/os/include/tinyara/irq.h
+++ b/os/include/tinyara/irq.h
@@ -68,7 +68,7 @@
  */
 
 #ifndef __ASSEMBLY__
-#define irq_detach(isr) irq_attach(isr, NULL, NULL)
+#define irq_detach(irq) irq_attach(irq, NULL, NULL)
 #endif
 
 /****************************************************************************

--- a/os/kernel/irq/irq.h
+++ b/os/kernel/irq/irq.h
@@ -76,7 +76,7 @@ struct irq {
 	FAR void *arg;
 };
 
-extern struct irq g_irqvector[NR_IRQS + 1];
+extern struct irq g_irqvector[NR_IRQS];
 
 /****************************************************************************
  * Public Variables

--- a/os/kernel/irq/irq_dispatch.c
+++ b/os/kernel/irq/irq_dispatch.c
@@ -112,6 +112,7 @@ void irq_dispatch(int irq, FAR void *context)
 	}
 #else
 	vector = irq_unexpected_isr;
+	arg    = NULL;
 #endif
 
 	/* Then dispatch to the interrupt handler */

--- a/os/kernel/irq/irq_initialize.c
+++ b/os/kernel/irq/irq_initialize.c
@@ -72,7 +72,7 @@
  * Global Variables
  ****************************************************************************/
 
-struct irq g_irqvector[NR_IRQS + 1];
+struct irq g_irqvector[NR_IRQS];
 
 /****************************************************************************
  * Private Variables

--- a/os/kernel/semaphore/sem_tickwait.c
+++ b/os/kernel/semaphore/sem_tickwait.c
@@ -183,7 +183,6 @@ int sem_tickwait(FAR sem_t *sem, systime_t start, uint32_t delay)
 		/* Return the errno from sem_wait() */
 
 		ret = -get_errno();
-		goto errout_with_irqdisabled;
 	}
 
 	/* Stop the watchdog timer */

--- a/os/kernel/wdog/wd_create.c
+++ b/os/kernel/wdog/wd_create.c
@@ -130,18 +130,23 @@ WDOG_ID wd_create(void)
 		 */
 
 		wdog = (FAR struct wdog_s *)sq_remfirst(&g_wdfreelist);
-		DEBUGASSERT(g_wdnfree > 0);
-		g_wdnfree--;
-		irqrestore(state);
 
 		/* Did we get one? */
 
 		if (wdog) {
+			DEBUGASSERT(g_wdnfree > 0);
+			g_wdnfree--;
+
 			/* Yes.. Clear the forward link and all flags */
 
 			wdog->next = NULL;
 			wdog->flags = 0;
 		}
+		else {
+			/* If wdog is Null, g_wdnfree must be zero, else assert */
+			DEBUGASSERT(g_wdnfree == 0);
+		}
+		irqrestore(state);
 	}
 
 	/* We are in a normal tasking context AND there are not enough unreserved,

--- a/os/kernel/wdog/wd_delete.c
+++ b/os/kernel/wdog/wd_delete.c
@@ -161,6 +161,15 @@ int wd_delete(WDOG_ID wdog)
 		DEBUGASSERT(g_wdnfree <= CONFIG_PREALLOC_WDOGS);
 		irqrestore(state);
 	}
+	else
+	{
+		/* There is no guarantee that, this API is not called for statically 
+		 * allocated timers as wd_delete is a global function. So restore the
+		 * irq properly so that it does not break the system */
+
+		irqrestore(state);
+
+	}
 
 	/* Return success */
 


### PR DESCRIPTION
Since wdog_timer has been started before waiting for semaphore and
if Sem_wait fails, wdog timer should be canceled before attempting
for delete operation. Though wdog_delete API takes care of canceling
an active timer, One must consider canceling the timer as soon as
possible to avoid calling wdog timeout handler and overwrite the
sem_wait error value as ETIMEOUT .

Signed-off-by: pradeep.ns <pradeep.ns@samsung.com>