### PR TITLE
Fix testcase

### DIFF
--- a/apps/examples/testcase/le_tc/kernel/tc_libc_timer.c
+++ b/apps/examples/testcase/le_tc/kernel/tc_libc_timer.c
@@ -376,16 +376,16 @@ static void tc_libc_timer_clock_daysbeforemonth(void)
 	/* test with not leapyear */
 
 	for (month_iter = 1; month_iter < 12; month_iter++) {
-		prev_month = clock_daysbeforemonth(month_iter, FALSE);
-		cur_month = clock_daysbeforemonth(month_iter+1, FALSE);
+		prev_month = clock_daysbeforemonth(month_iter - 1, FALSE);
+		cur_month = clock_daysbeforemonth(month_iter, FALSE);
 		TC_ASSERT_EQ("clock_daysbeforemonth", cur_month-prev_month, notleapyear_days[month_iter]);
 	}
 
 	/* test with leapyear */
 
 	for (month_iter = 1; month_iter < 12; month_iter++) {
-		prev_month = clock_daysbeforemonth(month_iter, TRUE);
-		cur_month = clock_daysbeforemonth(month_iter+1, TRUE);
+		prev_month = clock_daysbeforemonth(month_iter - 1, TRUE);
+		cur_month = clock_daysbeforemonth(month_iter, TRUE);
 		TC_ASSERT_EQ("clock_daysbeforemonth", cur_month-prev_month, leapyear_days[month_iter]);
 	}
 

--- a/apps/examples/testcase/le_tc/network/tc_net_inet.c
+++ b/apps/examples/testcase/le_tc/network/tc_net_inet.c
@@ -92,7 +92,7 @@ static void tc_net_inet_ntoa_p(void)
 	addr_inet.sin_addr.s_addr = 0x6601a8c0;
 	ret = inet_ntoa(addr_inet.sin_addr);
 
-	TC_ASSERT_NEQ("inet", ret, -1);
+	TC_ASSERT_NEQ("inet", *ret, -1);
 	TC_SUCCESS_RESULT();
 
 }


### PR DESCRIPTION
I have tested the tc examples of the kernel and network symbols. This patch includes examples that fix build errors and correspond to modified kernels.