### PR TITLE
Limit the g_irqvector size to NR_IRQS

### DIFF
--- a/os/kernel/irq/irq.h
+++ b/os/kernel/irq/irq.h
@@ -76,7 +76,7 @@ struct irq {
 	FAR void *arg;
 };
 
-extern struct irq g_irqvector[NR_IRQS + 1];
+extern struct irq g_irqvector[NR_IRQS];
 
 /****************************************************************************
  * Public Variables

--- a/os/kernel/irq/irq_initialize.c
+++ b/os/kernel/irq/irq_initialize.c
@@ -72,7 +72,7 @@
  * Global Variables
  ****************************************************************************/
 
-struct irq g_irqvector[NR_IRQS + 1];
+struct irq g_irqvector[NR_IRQS];
 
 /****************************************************************************
  * Private Variables


### PR DESCRIPTION
NR_IRQS value is already incremented by last irq + 1
hence, there is no need to initialize g_irqvector as
NR_IRQS + 1. Save memory by limiting the g_irqvector
size to NR_IRQS

Signed-off-by: pradeep.ns <pradeep.ns@samsung.com>