### PR TITLE
arch : move dataabort stack config to arm/Kconfig

### DIFF
--- a/os/arch/Kconfig
+++ b/os/arch/Kconfig
@@ -10,7 +10,6 @@ choice
 config ARCH_ARM
 	bool "ARM"
 	select ARCH_HAVE_INTERRUPTSTACK
-	select ARCH_HAVE_DABORTSTACK
 	select ARCH_HAVE_VFORK
 	select ARCH_HAVE_STACKCHECK
 	select ARCH_HAVE_CUSTOMOPT
@@ -662,23 +661,6 @@ config ARCH_INT_DISABLEALL
 		standard interrupt handling, prohibiting nesting.  Fix is simple:  Need
 		to used more priority levels so that we can make a cleaner distinction
 		with the standard interrupt handler.
-
-comment "Exception stack options"
-
-config ARCH_HAVE_DABORTSTACK
-	bool
-	default n
-
-config ARCH_DABORTSTACK
-	int "Dabort Stack Size"
-	depends on ARCH_HAVE_DABORTSTACK
-	default 0
-	---help---
-		This architecture supports an data abort stack. If defined, this symbol
-		will be the size of the data abort stack in bytes.  If not defined (or
-		defined to be zero or less than 512 bytes), the user task stacks
-		will be used during data abort handling. Recommended data abort stack
-		size is 1K.
 
 
 comment "Boot options"

--- a/os/arch/arm/Kconfig
+++ b/os/arch/arm/Kconfig
@@ -41,6 +41,7 @@ config ARCH_CORTEXR4
 	default n
 	select ARCH_HAVE_MPU
 	select ARCH_HAVE_COHERENT_DCACHE if ELF || MODULE
+	select ARCH_HAVE_DABORTSTACK
 
 config ARCH_FAMILY
 	string
@@ -129,6 +130,23 @@ config DEBUG_HARDFAULT
 		Enables verbose debug output when a hard fault is occurs.  This verbose
 		output is sometimes helpful when debugging difficult hard fault problems,
 		but may be more than you typcially want to see.
+
+comment "Exception stack options"
+
+config ARCH_HAVE_DABORTSTACK
+	bool
+	default n
+
+config ARCH_DABORTSTACK
+	int "Dabort Stack Size"
+	depends on ARCH_HAVE_DABORTSTACK
+	default 0
+	---help---
+		This architecture supports an data abort stack. If defined, this symbol
+		will be the size of the data abort stack in bytes.  If not defined (or
+		defined to be zero or less than 512 bytes), the user task stacks
+		will be used during data abort handling. Recommended data abort stack
+		size is 1K.
 
 if ARCH_CORTEXM3 || ARCH_CORTEXM4
 source arch/arm/src/armv7-m/Kconfig


### PR DESCRIPTION
seperate dataabort stack is implemented only for armv7-r.
This patch moves dataabort stack config to arm/Kconfig and enables
only for armv7-r processors

Change-Id: Icf703dac4904a595a8420e4039527b8795614573
Signed-off-by: Manohara HK <manohara.hk@samsung.com>