### PR TITLE
Stop the watchdog timer even when sem_wait() fails

### DIFF
--- a/os/kernel/semaphore/sem_tickwait.c
+++ b/os/kernel/semaphore/sem_tickwait.c
@@ -183,7 +183,6 @@ int sem_tickwait(FAR sem_t *sem, systime_t start, uint32_t delay)
 		/* Return the errno from sem_wait() */
 
 		ret = -get_errno();
-		goto errout_with_irqdisabled;
 	}
 
 	/* Stop the watchdog timer */


### PR DESCRIPTION
Since wdog_timer has been started before waiting for semaphore and
if Sem_wait fails, wdog timer should be canceled before attempting
for delete operation. Though wdog_delete API takes care of canceling
an active timer, One must consider canceling the timer as soon as
possible to avoid calling wdog timeout handler and overwrite the
sem_wait error value as ETIMEOUT.

Signed-off-by: pradeep.ns <pradeep.ns@samsung.com>