### PR TITLE
Add missing boundary validation for pid

### DIFF
--- a/os/kernel/sched/sched_gettcb.c
+++ b/os/kernel/sched/sched_gettcb.c
@@ -101,7 +101,7 @@ FAR struct tcb_s *sched_gettcb(pid_t pid)
 
 	/* Verify that the PID is within range */
 
-	if (pid >= 0) {
+	if (pid >= 0 && pid <= g_lastpid) {
 		/* Get the hash_ndx associated with the pid */
 
 		hash_ndx = PIDHASH(pid);


### PR DESCRIPTION
valid pid range is from 0 to g_lastpid. anything beyond
this range is invalid pid. Hence add proper validation

Signed-off-by: pradeep.ns <pradeep.ns@samsung.com>