### PR TITLE
armv7-r : use appropriate DECODEFIQ config in armv7-r

### DIFF
--- a/os/arch/arm/include/armv7-r/irq.h
+++ b/os/arch/arm/include/armv7-r/irq.h
@@ -400,7 +400,7 @@ static inline irqstate_t irqsave(void)
 	(
 		"\tmrs    %0, cpsr\n"
 		"\tcpsid  i\n"
-#if defined(CONFIG_ARMV7A_DECODEFIQ)
+#if defined(CONFIG_ARMV7R_DECODEFIQ)
 		"\tcpsid  f\n"
 #endif
 		: "=r"(cpsr)
@@ -421,7 +421,7 @@ static inline irqstate_t irqenable(void)
 	(
 		"\tmrs    %0, cpsr\n"
 		"\tcpsie  i\n"
-#if defined(CONFIG_ARMV7A_DECODEFIQ)
+#if defined(CONFIG_ARMV7R_DECODEFIQ)
 		"\tcpsie  f\n"
 #endif
 		: "=r"(cpsr)


### PR DESCRIPTION
Currently wrong configuration CONFIG_ARMV7A_DECODEFIQ is used in armv7-r
This patch changes it to use the appropriate config CONFIG_ARMV7R_DECODEFIQ.

Signed-off-by: Manohara HK <manohara.hk@samsung.com>