### PR TITLE
fix incorrect config dependency in fs_procfsuptime.c

### DIFF
--- a/os/fs/procfs/fs_procfsuptime.c
+++ b/os/fs/procfs/fs_procfsuptime.c
@@ -77,7 +77,7 @@
 #include <tinyara/fs/procfs.h>
 
 #if !defined(CONFIG_DISABLE_MOUNTPOINT) && defined(CONFIG_FS_PROCFS)
-#ifndef CONFIG_FS_PROCFS_EXCLUDE_PROCESS
+#ifndef CONFIG_FS_PROCFS_EXCLUDE_UPTIME
 
 /****************************************************************************
  * Pre-processor Definitions


### PR DESCRIPTION
It brings build error that uptime_operations is not found when CONFIG_FS_PROCFS_EXCLUDE_PROCESS is enabled