### PR TITLE
fix violations of coding style in wdog

### DIFF
--- a/os/kernel/wdog/wd_delete.c
+++ b/os/kernel/wdog/wd_delete.c
@@ -160,15 +160,12 @@ int wd_delete(WDOG_ID wdog)
 		g_wdnfree++;
 		DEBUGASSERT(g_wdnfree <= CONFIG_PREALLOC_WDOGS);
 		irqrestore(state);
-	}
-	else
-	{
+	} else {
 		/* There is no guarantee that, this API is not called for statically 
 		 * allocated timers as wd_delete is a global function. So restore the
 		 * irq properly so that it does not break the system */
 
 		irqrestore(state);
-
 	}
 
 	/* Return success */


### PR DESCRIPTION
Positions of 'else' and parentheses near the else are fixed following coding rules.