### PR TITLE
pthread : Add null check at pthread_getstacksize

### DIFF
--- a/lib/libc/pthread/pthread_attrgetstacksize.c
+++ b/lib/libc/pthread/pthread_attrgetstacksize.c
@@ -106,7 +106,7 @@ int pthread_attr_getstacksize(FAR const pthread_attr_t *attr, FAR long *stacksiz
 
 	sdbg("attr=0x%p stacksize=0x%p\n", attr, stacksize);
 
-	if (!stacksize) {
+	if (!attr || !stacksize) {
 		ret = EINVAL;
 	} else {
 		*stacksize = attr->stacksize;


### PR DESCRIPTION
Without this condition, null dereference assert will occur