### PR TITLE
Set correct errno in task_schedsetup and pthread_schedsetup

### DIFF
--- a/os/kernel/pthread/pthread_create.c
+++ b/os/kernel/pthread/pthread_create.c
@@ -343,7 +343,7 @@ int pthread_create(FAR pthread_t *thread, FAR const pthread_attr_t *attr, pthrea
 
 	ret = pthread_schedsetup(ptcb, param.sched_priority, pthread_start, start_routine);
 	if (ret != OK) {
-		errcode = EBUSY;
+		errcode = get_errno();
 		goto errout_with_join;
 	}
 

--- a/os/kernel/task/task_create.c
+++ b/os/kernel/task/task_create.c
@@ -170,7 +170,7 @@ static int thread_create(FAR const char *name, uint8_t ttype, int priority, int 
 
 	ret = task_schedsetup(tcb, priority, task_start, entry, ttype);
 	if (ret < OK) {
-		errcode = -ret;
+		errcode = get_errno();
 		goto errout_with_tcb;
 	}
 

--- a/os/kernel/task/task_init.c
+++ b/os/kernel/task/task_init.c
@@ -169,7 +169,7 @@ int task_init(FAR struct tcb_s *tcb, const char *name, int priority, FAR uint32_
 
 	ret = task_schedsetup(ttcb, priority, task_start, entry, TCB_FLAG_TTYPE_TASK);
 	if (ret < OK) {
-		errcode = -ret;
+		errcode = get_errno();
 		goto errout_with_group;
 	}
 

--- a/os/kernel/task/task_setup.c
+++ b/os/kernel/task/task_setup.c
@@ -117,7 +117,8 @@ static int task_assignpid(FAR struct tcb_s *tcb);
  *   tcb - TCB of task
  *
  * Return:
- *   OK on success; ERROR on failure (errno is not set)
+ *   OK on success; ERROR on failure.
+ *   errno is set as EBUSY, if already CONFIG_MAX_TASKS are running in system
  *
  ****************************************************************************/
 
@@ -176,6 +177,7 @@ static int task_assignpid(FAR struct tcb_s *tcb)
 	 */
 
 	(void)sched_unlock();
+	set_errno(EBUSY);
 	trace_end(TTRACE_TAG_TASK);
 	return ERROR;
 }
@@ -344,8 +346,10 @@ static inline void task_dupdspace(FAR struct tcb_s *tcb)
  * Return Value:
  *   OK on success; ERROR on failure.
  *
- *   This function can only failure is it is unable to assign a new, unique
- *   task ID to the TCB (errno is not set).
+ *   This function can fail for two reasons.
+ *   1) If requested priority is beyond the allowed range, errno = EINVAL
+ *   2) If it is unable to assign a new, unique task ID to the TCB. errno = EBUSY
+ *   errno is set accodingly.
  *
  ****************************************************************************/
 
@@ -625,8 +629,10 @@ static inline int task_stackargsetup(FAR struct task_tcb_s *tcb, FAR char *const
  * Return Value:
  *   OK on success; ERROR on failure.
  *
- *   This function can only failure is it is unable to assign a new, unique
- *   task ID to the TCB (errno is not set).
+ *   This function can fail for two reasons.
+ *   1) If requested priority is beyond the allowed range, errno = EINVAL
+ *   2) If it is unable to assign a new, unique task ID to the TCB. errno = EBUSY
+ *   errno is set accodingly.
  *
  ****************************************************************************/
 
@@ -665,8 +671,10 @@ int task_schedsetup(FAR struct task_tcb_s *tcb, int priority, start_t start, mai
  * Return Value:
  *   OK on success; ERROR on failure.
  *
- *   This function can only failure is it is unable to assign a new, unique
- *   task ID to the TCB (errno is not set).
+ *   This function can fail for two reasons.
+ *   1) If requested priority is beyond the allowed range, errno = EINVAL
+ *   2) If it is unable to assign a new, unique task ID to the TCB. errno = EBUSY
+ *   errno is set accodingly.
  *
  ****************************************************************************/
 

--- a/os/kernel/task/task_vfork.c
+++ b/os/kernel/task/task_vfork.c
@@ -311,6 +311,7 @@ FAR struct task_tcb_s *task_vforksetup(start_t retaddr)
 	svdbg("Child priority=%d start=%p\n", priority, retaddr);
 	ret = task_schedsetup(child, priority, retaddr, parent->entry.main, ttype);
 	if (ret < OK) {
+		ret = -get_errno();
 		goto errout_with_tcb;
 	}
 


### PR DESCRIPTION
Both task_schedsetup() and pthread_schedsetup() sets wrong
error number incase of failure. error no set during invalid
priority check is not considered. And proper error no was not
set if system fails to assign unique new pid to task/thread.

This patch fixes the wrong error no set and sets the correct
error no.

Signed-off-by: pradeep.ns <pradeep.ns@samsung.com>