### PR TITLE
fix compilation errors on i2c of artik

### DIFF
--- a/os/arch/arm/src/artik053/src/artik053_boot.c
+++ b/os/arch/arm/src/artik053/src/artik053_boot.c
@@ -126,7 +126,7 @@ static void board_gpio_initialize(void)
  ****************************************************************************/
 static void board_i2c_initialize(void)
 {
-#ifdef CONFIG_I2C
+#ifdef CONFIG_S5J_I2C
 	s5j_i2c_register(0);
 	s5j_i2c_register(1);
 #endif

--- a/os/arch/arm/src/s5j/Kconfig
+++ b/os/arch/arm/src/s5j/Kconfig
@@ -145,7 +145,7 @@ config S5J_ADC
 config S5J_I2C
 	bool "I2C"
 	default n
-	depends on S5J_HAVE_I2C
+	depends on S5J_HAVE_I2C && I2C_USERIO
 
 config S5J_MCT
 	bool


### PR DESCRIPTION
1. The s5j_i2c_register function will be compiled when CONFIG_S5J_I2C is enabled.
  But board_i2c_initialize function calling s5j_i2c_register is executed when CONFIG_I2C is enabled.
2. Because s5j_i2c_register function calls i2c_uioregister, S5J_I2C should have a dependancy of I2C_USERIO

/os/arch/arm/src/board/libboard.a(artik053_boot.o): In function `board_i2c_initialize':
/os/arch/arm/src/artik053/src/artik053_boot.c:130: undefined reference to `s5j_i2c_register'
/os/arch/arm/src/artik053/src/artik053_boot.c:131: undefined reference to `s5j_i2c_register'