### PR TITLE
Fix: use task_delete() to kill kernel threads and tasks

### DIFF
--- a/apps/system/utils/kdbg_kill.c
+++ b/apps/system/utils/kdbg_kill.c
@@ -160,10 +160,11 @@ static int send_signal(pid_t pid, int signo)
 		} else {
 			switch ((tcb->flags & TCB_FLAG_TTYPE_MASK) >> TCB_FLAG_TTYPE_SHIFT) {
 			case TCB_FLAG_TTYPE_TASK:
+			case TCB_FLAG_TTYPE_KERNEL:
+				/* tasks and kernel threads has to use this interface */
 				ret = task_delete(pid) == OK ? OK : ERROR;
 				break;
 			case TCB_FLAG_TTYPE_PTHREAD:
-			case TCB_FLAG_TTYPE_KERNEL:
 				ret = pthread_cancel(pid) == OK ? OK : ERROR;
 				pthread_join(pid, NULL);
 				break;


### PR DESCRIPTION
pthread_cancel() shouldn't be used to kill kernel threads, it raises
assert if tcb type is other than TCB_FLAG_TTYPE_PTHREAD. refer line no
125 in pthread_cancel.c
task_delete() API takes care of deleting tasks and kernel threads.
refer lineno 151 in task_delete.c
we can verify it using following commands from TASH
killall -9 <kernel thread name> or
kill -9 <pid of kernel thread>

Signed-off-by: pradeep.ns <pradeep.ns@samsung.com>