### PR TITLE
Fix a problem in pthread_trylock()

### DIFF
--- a/apps/examples/testcase/le_tc/kernel/tc_pthread.c
+++ b/apps/examples/testcase/le_tc/kernel/tc_pthread.c
@@ -882,27 +882,27 @@ static void tc_pthread_pthread_cancel_setcancelstate(void)
 * @fn                   :tc_pthread_pthread_take_give_semaphore
 * @brief                :Support managed access to the private data sets.
 * @Scenario             :Support managed access to the private data sets.
-* API's covered         :pthread_takesemaphore, pthread_givesemaphore
+* API's covered         :pthread_sem_take, pthread_sem_give
 * Preconditions         :none
 * Postconditions        :none
 * @return               :void
  */
 #if !defined(CONFIG_BUILD_PROTECTED)
-static void tc_pthread_pthread_take_give_semaphore(void)
+static void tc_pthread_pthread_sem_take_give(void)
 {
 	int ret_chk;
 	int get_value;
 	sem_t sem;
 	sem_init(&sem, 0, VAL_THREE);
 
-	ret_chk = pthread_takesemaphore(&sem, false);
-	TC_ASSERT_EQ("pthread_takesemaphore", ret_chk, OK);
+	ret_chk = pthread_sem_take(&sem, false);
+	TC_ASSERT_EQ("pthread_sem_take", ret_chk, OK);
 
 	sem_getvalue(&sem, &get_value);
 	TC_ASSERT_EQ("sem_getvalue", get_value, VAL_TWO);
 
-	ret_chk = pthread_givesemaphore(&sem);
-	TC_ASSERT_EQ("pthread_givesemaphore", ret_chk, OK);
+	ret_chk = pthread_sem_give(&sem);
+	TC_ASSERT_EQ("pthread_sem_give", ret_chk, OK);
 
 	sem_getvalue(&sem, &get_value);
 	TC_ASSERT_EQ("sem_getvalue", get_value, VAL_THREE);
@@ -1411,7 +1411,7 @@ int pthread_main(void)
 	tc_pthread_pthread_key_create_set_getspecific();
 	tc_pthread_pthread_cancel_setcancelstate();
 #if !defined(CONFIG_BUILD_PROTECTED)
-	tc_pthread_pthread_take_give_semaphore();
+	tc_pthread_pthread_sem_take_give();
 	tc_pthread_pthread_findjoininfo_destroyjoin();
 	tc_pthread_pthread_setschedprio();
 #endif

--- a/os/kernel/pthread/pthread.h
+++ b/os/kernel/pthread/pthread.h
@@ -121,11 +121,11 @@ int pthread_completejoin(pid_t pid, FAR void *exit_value);
 void pthread_destroyjoin(FAR struct task_group_s *group, FAR struct join_s *pjoin);
 FAR struct join_s *pthread_findjoininfo(FAR struct task_group_s *group, pid_t pid);
 void pthread_release(FAR struct task_group_s *group);
-int pthread_takesemaphore(sem_t *sem, bool intr);
+int pthread_sem_take(sem_t *sem, bool intr);
 #ifdef CONFIG_PTHREAD_MUTEX_UNSAFE
 int pthread_sem_trytake(sem_t *sem);
 #endif
-int pthread_givesemaphore(sem_t *sem);
+int pthread_sem_give(sem_t *sem);
 
 #ifndef CONFIG_PTHREAD_MUTEX_UNSAFE
 int pthread_mutex_take(FAR struct pthread_mutex_s *mutex, bool intr);
@@ -133,9 +133,9 @@ int pthread_mutex_trytake(FAR struct pthread_mutex_s *mutex);
 int pthread_mutex_give(FAR struct pthread_mutex_s *mutex);
 void pthread_mutex_inconsistent(FAR struct pthread_tcb_s *tcb);
 #else
-#define pthread_mutex_take(m,i) pthread_takesemaphore(&(m)->sem,(i))
+#define pthread_mutex_take(m,i) pthread_sem_take(&(m)->sem,(i))
 #define pthread_mutex_trytake(m) pthread_sem_trytake(&(m)->sem)
-#define pthread_mutex_give(m)   pthread_givesemaphore(&(m)->sem)
+#define pthread_mutex_give(m)   pthread_sem_give(&(m)->sem)
 #endif
 
 #if defined(CONFIG_CANCELLATION_POINTS) && !defined(CONFIG_PTHREAD_MUTEX_UNSAFE)

--- a/os/kernel/pthread/pthread.h
+++ b/os/kernel/pthread/pthread.h
@@ -122,6 +122,9 @@ void pthread_destroyjoin(FAR struct task_group_s *group, FAR struct join_s *pjoi
 FAR struct join_s *pthread_findjoininfo(FAR struct task_group_s *group, pid_t pid);
 void pthread_release(FAR struct task_group_s *group);
 int pthread_takesemaphore(sem_t *sem, bool intr);
+#ifdef CONFIG_PTHREAD_MUTEX_UNSAFE
+int pthread_sem_trytake(sem_t *sem);
+#endif
 int pthread_givesemaphore(sem_t *sem);
 
 #ifndef CONFIG_PTHREAD_MUTEX_UNSAFE
@@ -131,7 +134,7 @@ int pthread_mutex_give(FAR struct pthread_mutex_s *mutex);
 void pthread_mutex_inconsistent(FAR struct pthread_tcb_s *tcb);
 #else
 #define pthread_mutex_take(m,i) pthread_takesemaphore(&(m)->sem,(i))
-#define pthread_mutex_trytake(m) sem_trywait(&(m)->sem)
+#define pthread_mutex_trytake(m) pthread_sem_trytake(&(m)->sem)
 #define pthread_mutex_give(m)   pthread_givesemaphore(&(m)->sem)
 #endif
 

--- a/os/kernel/pthread/pthread_completejoin.c
+++ b/os/kernel/pthread/pthread_completejoin.c
@@ -118,7 +118,7 @@ static bool pthread_notifywaiters(FAR struct join_s *pjoin)
 		 */
 
 		do {
-			status = pthread_givesemaphore(&pjoin->exit_sem);
+			status = pthread_sem_give(&pjoin->exit_sem);
 			if (status == OK) {
 				status = sem_getvalue(&pjoin->exit_sem, &ntasks_waiting);
 			}
@@ -128,7 +128,7 @@ static bool pthread_notifywaiters(FAR struct join_s *pjoin)
 		 * value.
 		 */
 
-		(void)pthread_takesemaphore(&pjoin->data_sem, false);
+		(void)pthread_sem_take(&pjoin->data_sem, false);
 		return true;
 	}
 
@@ -230,11 +230,11 @@ int pthread_completejoin(pid_t pid, FAR void *exit_value)
 
 	/* First, find thread's structure in the private data set. */
 
-	(void)pthread_takesemaphore(&group->tg_joinsem, false);
+	(void)pthread_sem_take(&group->tg_joinsem, false);
 	pjoin = pthread_findjoininfo(group, pid);
 	if (!pjoin) {
 		sdbg("Could not find join info, pid=%d\n", pid);
-		(void)pthread_givesemaphore(&group->tg_joinsem);
+		(void)pthread_sem_give(&group->tg_joinsem);
 		return ERROR;
 	} else {
 		bool waiters;
@@ -262,7 +262,7 @@ int pthread_completejoin(pid_t pid, FAR void *exit_value)
 		 * to call pthread_destroyjoin.
 		 */
 
-		(void)pthread_givesemaphore(&group->tg_joinsem);
+		(void)pthread_sem_give(&group->tg_joinsem);
 	}
 
 	return OK;

--- a/os/kernel/pthread/pthread_condbroadcast.c
+++ b/os/kernel/pthread/pthread_condbroadcast.c
@@ -133,7 +133,7 @@ int pthread_cond_broadcast(FAR pthread_cond_t *cond)
 				 * Only the highest priority waiting thread will get to execute
 				 */
 
-				ret = pthread_givesemaphore((sem_t *)&cond->sem);
+				ret = pthread_sem_give((sem_t *)&cond->sem);
 
 				/* Increment the semaphore count (as was done by the
 				 * above post).

--- a/os/kernel/pthread/pthread_condsignal.c
+++ b/os/kernel/pthread/pthread_condsignal.c
@@ -136,7 +136,7 @@ int pthread_cond_signal(FAR pthread_cond_t *cond)
 			svdbg("sval=%d\n", sval);
 			if (sval < 0) {
 				svdbg("Signalling...\n");
-				ret = pthread_givesemaphore((sem_t *)&cond->sem);
+				ret = pthread_sem_give((sem_t *)&cond->sem);
 			}
 		}
 	}

--- a/os/kernel/pthread/pthread_condwait.c
+++ b/os/kernel/pthread/pthread_condwait.c
@@ -118,7 +118,7 @@ int pthread_cond_wait(FAR pthread_cond_t *cond, FAR pthread_mutex_t *mutex)
 
 		/* Take the semaphore */
 
-		status = pthread_takesemaphore((FAR sem_t *)&cond->sem, false);
+		status = pthread_sem_take((FAR sem_t *)&cond->sem, false);
 		if (ret == OK) {
 			/* Report the first failure that occurs */
 

--- a/os/kernel/pthread/pthread_create.c
+++ b/os/kernel/pthread/pthread_create.c
@@ -189,14 +189,14 @@ static void pthread_start(void)
 
 	/* Sucessfully spawned, add the pjoin to our data set. */
 
-	(void)pthread_takesemaphore(&group->tg_joinsem, false);
+	(void)pthread_sem_take(&group->tg_joinsem, false);
 	pthread_addjoininfo(group, pjoin);
-	(void)pthread_givesemaphore(&group->tg_joinsem);
+	(void)pthread_sem_give(&group->tg_joinsem);
 
 	/* Report to the spawner that we successfully started. */
 
 	pjoin->started = true;
-	(void)pthread_givesemaphore(&pjoin->data_sem);
+	(void)pthread_sem_give(&pjoin->data_sem);
 
 	/* Pass control to the thread entry point. In the kernel build this has to
 	 * be handled differently if we are starting a user-space pthread; we have
@@ -429,7 +429,7 @@ int pthread_create(FAR pthread_t *thread, FAR const pthread_attr_t *attr, pthrea
 		 * its join structure.
 		 */
 
-		(void)pthread_takesemaphore(&pjoin->data_sem, false);
+		(void)pthread_sem_take(&pjoin->data_sem, false);
 
 		/* Return the thread information to the caller */
 

--- a/os/kernel/pthread/pthread_detach.c
+++ b/os/kernel/pthread/pthread_detach.c
@@ -126,7 +126,7 @@ int pthread_detach(pthread_t thread)
 
 	/* Find the entry associated with this pthread. */
 
-	(void)pthread_takesemaphore(&group->tg_joinsem, false);
+	(void)pthread_sem_take(&group->tg_joinsem, false);
 	pjoin = pthread_findjoininfo(group, (pid_t)thread);
 	if (!pjoin) {
 		sdbg("Could not find thread entry\n");
@@ -152,7 +152,7 @@ int pthread_detach(pthread_t thread)
 		ret = OK;
 	}
 
-	(void)pthread_givesemaphore(&group->tg_joinsem);
+	(void)pthread_sem_give(&group->tg_joinsem);
 
 	svdbg("Returning %d\n", ret);
 	trace_end(TTRACE_TAG_TASK);

--- a/os/kernel/pthread/pthread_initialize.c
+++ b/os/kernel/pthread/pthread_initialize.c
@@ -157,6 +157,25 @@ int pthread_takesemaphore(sem_t *sem, bool intr)
 	}
 }
 
+#ifdef CONFIG_PTHREAD_MUTEX_UNSAFE
+int pthread_sem_trytake(sem_t *sem)
+{
+	int ret = EINVAL;
+
+	/* Verify input parameters */
+
+	DEBUGASSERT(sem != NULL);
+	if (sem != NULL) {
+		/* Try to take the semaphore */
+
+		int status = sem_trywait(sem);
+		ret = status < 0 ? get_errno() : OK;
+	}
+
+	return ret;
+}
+#endif
+
 int pthread_givesemaphore(sem_t *sem)
 {
 	/* Verify input parameters */

--- a/os/kernel/pthread/pthread_initialize.c
+++ b/os/kernel/pthread/pthread_initialize.c
@@ -112,10 +112,17 @@ void pthread_initialize(void)
 }
 
 /****************************************************************************
- * Name: pthread_takesemaphore and pthread_givesemaphore
+ * Name: pthread_sem_take, pthread_sem_trytake, and
+ * 	pthread_sem_give
  *
  * Description:
  *   Support managed access to the private data sets.
+ *
+ *   REVISIT : These functions really do nothing more than match the return
+ *   value of the semaphore functions (0 or -1 with errno set) to the
+ *   return value of more pthread functions (0 or errno).  A better solution
+ *   would be to use an internal version of the semaphore functions that
+ *   return the error value in the correct form.
  *
  * Parameters:
  *  sem  - The semaphore to lock or unlock
@@ -127,9 +134,9 @@ void pthread_initialize(void)
  *
  ****************************************************************************/
 
-int pthread_takesemaphore(sem_t *sem, bool intr)
+int pthread_sem_take(sem_t *sem, bool intr)
 {
-	trace_begin(TTRACE_TAG_IPC, "pthread_takesemaphore");
+	trace_begin(TTRACE_TAG_IPC, "pthread_sem_take");
 	/* Verify input parameters */
 
 	DEBUGASSERT(sem != NULL);
@@ -176,7 +183,7 @@ int pthread_sem_trytake(sem_t *sem)
 }
 #endif
 
-int pthread_givesemaphore(sem_t *sem)
+int pthread_sem_give(sem_t *sem)
 {
 	/* Verify input parameters */
 

--- a/os/kernel/pthread/pthread_join.c
+++ b/os/kernel/pthread/pthread_join.c
@@ -150,7 +150,7 @@ int pthread_join(pthread_t thread, FAR pthread_addr_t *pexit_value)
 	 * because it will also attempt to get this semaphore.
 	 */
 
-	(void)pthread_takesemaphore(&group->tg_joinsem, false);
+	(void)pthread_sem_take(&group->tg_joinsem, false);
 
 	/* Find the join information associated with this thread.
 	 * This can fail for one of three reasons:  (1) There is no
@@ -181,7 +181,7 @@ int pthread_join(pthread_t thread, FAR pthread_addr_t *pexit_value)
 			ret = EINVAL;
 		}
 
-		(void)pthread_givesemaphore(&group->tg_joinsem);
+		(void)pthread_sem_give(&group->tg_joinsem);
 	} else {
 		/* We found the join info structure.  Increment for the reference
 		 * to the join structure that we have.  This will keep things
@@ -216,7 +216,7 @@ int pthread_join(pthread_t thread, FAR pthread_addr_t *pexit_value)
 			 * semaphore.
 			 */
 
-			(void)pthread_givesemaphore(&group->tg_joinsem);
+			(void)pthread_sem_give(&group->tg_joinsem);
 
 			/* Take the thread's thread exit semaphore.  We will sleep here
 			 * until the thread exits.  We need to exercise caution because
@@ -224,7 +224,7 @@ int pthread_join(pthread_t thread, FAR pthread_addr_t *pexit_value)
 			 * pthread to exit.
 			 */
 
-			(void)pthread_takesemaphore(&pjoin->exit_sem, false);
+			(void)pthread_sem_take(&pjoin->exit_sem, false);
 
 			/* The thread has exited! Get the thread exit value */
 
@@ -237,13 +237,13 @@ int pthread_join(pthread_t thread, FAR pthread_addr_t *pexit_value)
 			 * will know that we have received the data.
 			 */
 
-			(void)pthread_givesemaphore(&pjoin->data_sem);
+			(void)pthread_sem_give(&pjoin->data_sem);
 
 			/* Retake the join semaphore, we need to hold this when
 			 * pthread_destroyjoin is called.
 			 */
 
-			(void)pthread_takesemaphore(&group->tg_joinsem, false);
+			(void)pthread_sem_take(&group->tg_joinsem, false);
 		}
 
 		/* Pre-emption is okay now. The logic still cannot be re-entered
@@ -260,7 +260,7 @@ int pthread_join(pthread_t thread, FAR pthread_addr_t *pexit_value)
 			(void)pthread_destroyjoin(group, pjoin);
 		}
 
-		(void)pthread_givesemaphore(&group->tg_joinsem);
+		(void)pthread_sem_give(&group->tg_joinsem);
 		ret = OK;
 	}
 

--- a/os/kernel/pthread/pthread_mutex.c
+++ b/os/kernel/pthread/pthread_mutex.c
@@ -138,11 +138,11 @@ int pthread_mutex_take(FAR struct pthread_mutex_s *mutex, bool intr)
 		if ((mutex->flags & _PTHREAD_MFLAGS_INCONSISTENT) != 0) {
 			ret = EOWNERDEAD;
 		} else {
-			/* Take semaphore underlying the mutex.  pthread_takesemaphore
+			/* Take semaphore underlying the mutex.  pthread_sem_take
 			 * returns zero on success and a positive errno value on failure.
 			 */
 
-			ret = pthread_takesemaphore(&mutex->sem, intr);
+			ret = pthread_sem_take(&mutex->sem, intr);
 			if (ret == OK) {
 				/* Check if the holder of the mutex has terminated without
 				 * releasing.  In that case, the state of the mutex is
@@ -270,7 +270,7 @@ int pthread_mutex_give(FAR struct pthread_mutex_s *mutex)
 
 		/* Now release the underlying semaphore */
 
-		ret = pthread_givesemaphore(&mutex->sem);
+		ret = pthread_sem_give(&mutex->sem);
 	}
 
 	return ret;

--- a/os/kernel/pthread/pthread_mutexinconsistent.c
+++ b/os/kernel/pthread/pthread_mutexinconsistent.c
@@ -111,7 +111,7 @@ void pthread_mutex_inconsistent(FAR struct pthread_tcb_s *tcb)
 		/* Mark the mutex as INCONSISTENT and wake up any waiting thread */
 
 		mutex->flags |= _PTHREAD_MFLAGS_INCONSISTENT;
-		(void)pthread_givesemaphore(&mutex->sem);
+		(void)pthread_sem_give(&mutex->sem);
 	}
 
 	sched_unlock();


### PR DESCRIPTION
When CONFIG_PTHREAD_MUTEX_UNSAFE=y, the special return value
EAGAIN was not being detected due to differences in reporting of returned values.