### PR TITLE
Modify the return type check for sem_wait() sem_trywait() sem_timedwa…

### DIFF
--- a/apps/examples/kernel_sample/cancel.c
+++ b/apps/examples/kernel_sample/cancel.c
@@ -91,7 +91,7 @@ static FAR void *thread_waiter(FAR void *parameter)
 
 	printf("thread_waiter: Taking mutex\n");
 	status = pthread_mutex_lock(&mutex);
-	if (status != 0) {
+	if (status != OK) {
 		printf("thread_waiter: ERROR pthread_mutex_lock failed, status=%d\n", status);
 	}
 
@@ -438,7 +438,7 @@ void cancel_test(void)
 	 */
 
 	status = pthread_mutex_lock(&mutex);
-	if (status != 0) {
+	if (status != OK) {
 		printf("cancel_test: ERROR pthread_mutex_lock failed, status=%d\n", status);
 	}
 

--- a/apps/examples/kernel_sample/cond.c
+++ b/apps/examples/kernel_sample/cond.c
@@ -85,7 +85,7 @@ static void *thread_waiter(void *parameter)
 		status       = pthread_mutex_lock(&mutex);
 		waiter_state = RUNNING;
 
-		if (status != 0) {
+		if (status != OK) {
 			printf("waiter_thread: ERROR pthread_mutex_lock failed, status=%d\n", status);
 			waiter_nerrors++;
 		}
@@ -152,7 +152,7 @@ static void *thread_signaler(void *parameter)
 		 */
 
 		status = pthread_mutex_lock(&mutex);
-		if (status != 0) {
+		if (status != OK) {
 			printf("thread_signaler: ERROR pthread_mutex_lock failed, status=%d\n", status);
 			signaler_nerrors++;
 		}

--- a/apps/examples/kernel_sample/nsem.c
+++ b/apps/examples/kernel_sample/nsem.c
@@ -185,7 +185,7 @@ void nsem_test(void)
 
 	printf("nsem_test: Wait on semaphore 1\n");
 	status = sem_wait(sem1);
-	if (status < 0) {
+	if (status != OK) {
 		int errcode = errno;
 		printf("nsem_test: ERROR: sem_wait(1) failed: %d\n",  errcode);
 		pthread_cancel(peer);
@@ -214,7 +214,7 @@ void nsem_test(void)
 
 	printf("nsem_test: Wait on semaphore 2\n");
 	status = sem_wait(sem2);
-	if (status < 0) {
+	if (status != OK) {
 		int errcode = errno;
 		printf("nsem_test: ERROR: sem_wait(1) failed: %d\n",  errcode);
 		pthread_cancel(peer);

--- a/apps/examples/kernel_sample/posixtimer.c
+++ b/apps/examples/kernel_sample/posixtimer.c
@@ -223,7 +223,7 @@ void timer_test(void)
 		printf("timer_test: Waiting on semaphore\n");
 		FFLUSH();
 		status = sem_wait(&sem);
-		if (status != 0) {
+		if (status != OK) {
 			int error = errno;
 			if (error == EINTR) {
 				printf("timer_test: sem_wait() successfully interrupted by signal\n");

--- a/apps/examples/kernel_sample/prioinherit.c
+++ b/apps/examples/kernel_sample/prioinherit.c
@@ -177,7 +177,7 @@ static void *highpri_thread(void *parameter)
 	ret                     = sem_wait(&g_sem);
 	g_highstate[threadno - 1] = DONE;
 
-	if (ret != 0) {
+	if (ret != OK) {
 		printf("highpri_thread-%d: sem_take failed: %d\n", threadno, ret);
 	} else if (g_middlestate == RUNNING) {
 		printf("highpri_thread-%d: SUCCESS midpri_thread is still running!\n", threadno);
@@ -275,7 +275,7 @@ static void *lowpri_thread(void *parameter)
 
 	g_lowstate[threadno - 1] = WAITING;
 	ret = sem_wait(&g_sem);
-	if (ret != 0) {
+	if (ret != OK) {
 		printf("lowpri_thread-%d: sem_take failed: %d\n", threadno, ret);
 	} else {
 		/* Hang on to the thread until the middle priority thread runs */
@@ -301,7 +301,7 @@ static void *lowpri_thread(void *parameter)
 		nwaiting = nhighpri_waiting();
 		sched_unlock();
 
-		if (ret < 0) {
+		if (ret != OK) {
 			printf("lowpri_thread-%d: ERROR sem_getvalue failed: %d\n", threadno, errno);
 		}
 		printf("lowpri_thread-%d: Sem count: %d, No. highpri thread: %d\n", threadno, count, nwaiting);

--- a/apps/examples/kernel_sample/rmutex.c
+++ b/apps/examples/kernel_sample/rmutex.c
@@ -72,7 +72,7 @@ static void thread_inner(int id, int level)
 
 		printf("thread_inner[%d, %d]: Locking\n", id, level);
 		status = pthread_mutex_lock(&mut);
-		if (status != 0) {
+		if (status != OK) {
 			printf("thread_inner[%d, %d]: ERROR pthread_mutex_lock failed: %d\n",
 				   id, level, status);
 		}

--- a/apps/examples/kernel_sample/sem.c
+++ b/apps/examples/kernel_sample/sem.c
@@ -89,7 +89,7 @@ static void *waiter_func(void *parameter)
 	/* Take the semaphore */
 
 	status = sem_getvalue(&sem, &value);
-	if (status < 0) {
+	if (status != OK) {
 		printf("waiter_func: ERROR thread %d could not get semaphore value\n",  id);
 	} else {
 		printf("waiter_func: Thread %d initial semaphore value = %d\n",  id, value);
@@ -97,13 +97,13 @@ static void *waiter_func(void *parameter)
 
 	printf("waiter_func: Thread %d waiting on semaphore\n",  id);
 	status = sem_wait(&sem);
-	if (status != 0) {
+	if (status != OK) {
 		printf("waiter_func: ERROR thread %d sem_wait failed\n",  id);
 	}
 	printf("waiter_func: Thread %d awakened\n",  id);
 
 	status = sem_getvalue(&sem, &value);
-	if (status < 0) {
+	if (status != OK) {
 		printf("waiter_func: ERROR thread %d could not get semaphore value\n",  id);
 	} else {
 		printf("waiter_func: Thread %d new semaphore value = %d\n",  id, value);
@@ -125,7 +125,7 @@ static void *poster_func(void *parameter)
 
 	do {
 		status = sem_getvalue(&sem, &value);
-		if (status < 0) {
+		if (status != OK) {
 			printf("poster_func: ERROR thread %d could not get semaphore value\n",  id);
 		} else {
 			printf("poster_func: Thread %d semaphore value = %d\n",  id, value);
@@ -134,14 +134,14 @@ static void *poster_func(void *parameter)
 		if (value < 0) {
 			printf("poster_func: Thread %d posting semaphore\n",  id);
 			status = sem_post(&sem);
-			if (status != 0) {
+			if (status != OK) {
 				printf("poster_func: ERROR thread %d sem_wait failed\n",  id);
 			}
 
 			pthread_yield();
 
 			status = sem_getvalue(&sem, &value);
-			if (status < 0) {
+			if (status != OK) {
 				printf("poster_func: ERROR thread %d could not get semaphore value\n",  id);
 			} else {
 				printf("poster_func: Thread %d new semaphore value = %d\n",  id, value);

--- a/apps/examples/kernel_sample/sighand.c
+++ b/apps/examples/kernel_sample/sighand.c
@@ -189,7 +189,7 @@ static int waiter_main(int argc, char *argv[])
 	FFLUSH();
 
 	status = sem_wait(&sem);
-	if (status != 0) {
+	if (status != OK) {
 		int error = errno;
 		if (error == EINTR) {
 			printf("waiter_main: sem_wait() successfully interrupted by signal\n");

--- a/apps/examples/kernel_sample/timedwait.c
+++ b/apps/examples/kernel_sample/timedwait.c
@@ -86,7 +86,7 @@ static void *thread_waiter(void *parameter)
 
 	printf("thread_waiter: Taking mutex\n");
 	status = pthread_mutex_lock(&mutex);
-	if (status != 0) {
+	if (status != OK) {
 		printf("thread_waiter: ERROR pthread_mutex_lock failed, status=%d\n", status);
 	}
 

--- a/apps/netutils/telnetd/telnetd_daemon.c
+++ b/apps/netutils/telnetd/telnetd_daemon.c
@@ -405,10 +405,10 @@ int telnetd_start(FAR struct telnetd_config_s *config)
 		 * a receipt of a signal.
 		 */
 
-		if (ret < 0) {
+		if (ret != OK) {
 			DEBUGASSERT(errno == -EINTR);
 		}
-	} while (ret < 0);
+	} while (ret != OK);
 
 	/* Return success */
 

--- a/external/libtuv/source/unix/uv_unix_thread.c
+++ b/external/libtuv/source/unix/uv_unix_thread.c
@@ -213,7 +213,7 @@ void uv_sem_wait(uv_sem_t *sem)
 
 	do {
 		r = sem_wait(sem);
-	} while (r == -1 && errno == EINTR);
+	} while (r == ERROR && errno == EINTR);
 
 	if (r) {
 		TDLOG("uv_sem_wait abort");
@@ -227,7 +227,7 @@ int uv_sem_trywait(uv_sem_t *sem)
 
 	do {
 		r = sem_trywait(sem);
-	} while (r == -1 && errno == EINTR);
+	} while (r == ERROR && errno == EINTR);
 
 	if (r) {
 		if (errno == EAGAIN) {

--- a/lib/libc/misc/lib_filesem.c
+++ b/lib/libc/misc/lib_filesem.c
@@ -111,7 +111,7 @@ void lib_take_semaphore(FAR struct file_struct *stream)
 	} else {
 		/* Take the semaphore (perhaps waiting) */
 
-		while (sem_wait(&stream->fs_sem) != 0) {
+		while (sem_wait(&stream->fs_sem) != OK) {
 			/* The only case that an error should occr here is if the wait
 			 * was awakened by a signal.
 			 */

--- a/lib/libc/misc/lib_streamsem.c
+++ b/lib/libc/misc/lib_streamsem.c
@@ -89,7 +89,7 @@ void stream_semtake(FAR struct streamlist *list)
 {
 	/* Take the semaphore (perhaps waiting) */
 
-	while (sem_wait(&list->sl_sem) != 0) {
+	while (sem_wait(&list->sl_sem) != OK) {
 		/* The only case that an error should occr here is if
 		 * the wait was awakened by a signal.
 		 */

--- a/lib/libc/netdb/lib_dnsinit.c
+++ b/lib/libc/netdb/lib_dnsinit.c
@@ -169,11 +169,11 @@ void dns_semtake(void)
 
 	do {
 		ret = sem_wait(&g_dns_sem);
-		if (ret < 0) {
+		if (ret != OK) {
 			errcode = get_errno();
 			DEBUGASSERT(errcode == EINTR);
 		}
-	} while (ret < 0 && errcode == EINTR);
+	} while (ret != OK && errcode == EINTR);
 }
 
 /****************************************************************************

--- a/lib/libc/stdlib/lib_mkstemp.c
+++ b/lib/libc/stdlib/lib_mkstemp.c
@@ -158,7 +158,7 @@ static void incr_base62(void)
 
 static void get_base62(FAR uint8_t *ptr)
 {
-	while (sem_wait(&g_b62sem) < 0) {
+	while (sem_wait(&g_b62sem) != OK) {
 		DEBUGASSERT(errno == EINTR);
 	}
 

--- a/lib/libc/wqueue/work_lock.c
+++ b/lib/libc/wqueue/work_lock.c
@@ -112,13 +112,13 @@ int work_lock(void)
 
 #ifdef CONFIG_BUILD_PROTECTED
 	ret = sem_wait(&g_usrsem);
-	if (ret < 0) {
+	if (ret != OK) {
 		DEBUGASSERT(errno == EINTR);
 		return -EINTR;
 	}
 #else
 	ret = pthread_mutex_lock(&g_usrmutex);
-	if (ret != 0) {
+	if (ret != OK) {
 		DEBUGASSERT(ret == EINTR);
 		return -EINTR;
 	}

--- a/os/arch/arm/src/s5j/s5j_i2c.c
+++ b/os/arch/arm/src/s5j/s5j_i2c.c
@@ -925,7 +925,7 @@ static int hsi2c_cleanup(struct s5j_i2c_priv_s *priv)
 
 static inline void s5j_i2c_sem_wait(struct s5j_i2c_priv_s *priv)
 {
-	while (sem_wait(&priv->exclsem) != 0) {
+	while (sem_wait(&priv->exclsem) != OK) {
 		ASSERT(errno == EINTR);
 	}
 }

--- a/os/arch/arm/src/s5j/s5j_spi.c
+++ b/os/arch/arm/src/s5j/s5j_spi.c
@@ -268,7 +268,7 @@ static int spi_lock(struct spi_dev_s *dev, bool lock)
 	FAR struct s5j_spidev_s *priv = (FAR struct s5j_spidev_s *)dev;
 
 	if (lock) {
-		while (sem_wait(&priv->exclsem) != 0) {
+		while (sem_wait(&priv->exclsem) != OK) {
 			DEBUGASSERT(errno == EINTR);
 		}
 	} else {

--- a/os/arch/arm/src/sidk_s5jt200/src/s5jt200_eeprom.c
+++ b/os/arch/arm/src/sidk_s5jt200/src/s5jt200_eeprom.c
@@ -451,7 +451,7 @@ static void ee_semtake(FAR struct ee_dev_s *eedev)
 {
 	/* Take the semaphore (perhaps waiting) */
 
-	while (sem_wait(&eedev->sem) != 0) {
+	while (sem_wait(&eedev->sem) != OK) {
 		/*
 		 * The only case that an error should occur here is if
 		 * the wait was awakened by a signal.

--- a/os/drivers/analog/adc.c
+++ b/os/drivers/analog/adc.c
@@ -269,7 +269,7 @@ static ssize_t adc_read(FAR struct file *filep, FAR char *buffer,
 			dev->ad_nrxwaiters++;
 			ret = sem_wait(&dev->ad_recv.af_sem);
 			dev->ad_nrxwaiters--;
-			if (ret < 0) {
+			if (ret != OK) {
 				ret = -errno;
 				goto return_with_irqdisabled;
 			}

--- a/os/drivers/analog/dac.c
+++ b/os/drivers/analog/dac.c
@@ -351,11 +351,11 @@ static ssize_t dac_write(FAR struct file *filep, FAR const char *buffer, size_t 
 
 			do {
 				ret = sem_wait(&fifo->af_sem);
-				if (ret < 0 && errno != EINTR) {
+				if (ret != OK && errno != EINTR) {
 					ret = -errno;
 					goto return_with_irqdisabled;
 				}
-			} while (ret < 0);
+			} while (ret != OK);
 
 			/* Re-check the FIFO state */
 

--- a/os/drivers/bch/bchlib_sem.c
+++ b/os/drivers/bch/bchlib_sem.c
@@ -87,7 +87,7 @@
 void bchlib_semtake(FAR struct bchlib_s *bch)
 {
 	/* Take the semaphore (perhaps waiting) */
-	while (sem_wait(&bch->sem) != 0) {
+	while (sem_wait(&bch->sem) != OK) {
 		/*
 		 * The only case that an error should occur here is if
 		 * the wait was awakened by a signal.

--- a/os/drivers/can.c
+++ b/os/drivers/can.c
@@ -309,7 +309,7 @@ static ssize_t can_read(FAR struct file *filep, FAR char *buffer, size_t buflen)
 			/* Wait for a message to be received */
 
 			ret = sem_wait(&dev->cd_recv.rx_sem);
-			if (ret < 0) {
+			if (ret != OK) {
 				ret = -get_errno();
 				goto return_with_irqdisabled;
 			}
@@ -499,11 +499,11 @@ static ssize_t can_write(FAR struct file *filep, FAR const char *buffer, size_t 
 				ret = sem_wait(&fifo->tx_sem);
 				dev->cd_ntxwaiters--;
 
-				if (ret < 0 && get_errno() != EINTR) {
+				if (ret != OK && get_errno() != EINTR) {
 					ret = -get_errno();
 					goto return_with_irqdisabled;
 				}
-			} while (ret < 0);
+			} while (ret != OK);
 
 			/* Re-check the FIFO state */
 

--- a/os/drivers/gpio/gpio.c
+++ b/os/drivers/gpio/gpio.c
@@ -137,7 +137,7 @@ static int sem_reinit(FAR sem_t *sem, int pshared, unsigned int value)
 static inline int gpio_takesem(FAR sem_t *sem)
 {
 	/* Take a count from the semaphore, possibly waiting */
-	if (sem_wait(sem) < 0) {
+	if (sem_wait(sem) != OK) {
 		/* EINTR is the only error that we expect */
 		int errcode = get_errno();
 		DEBUGASSERT(errcode == EINTR);

--- a/os/drivers/loop.c
+++ b/os/drivers/loop.c
@@ -144,7 +144,7 @@ static int loop_semtake(FAR struct loop_struct_s *dev)
 	/* Take the semaphore (perhaps waiting) */
 
 	ret = sem_wait(&dev->sem);
-	if (ret < 0) {
+	if (ret != OK) {
 		int errcode = get_errno();
 
 		/* The only case that an error should occur here is if

--- a/os/drivers/net/phy_notify.c
+++ b/os/drivers/net/phy_notify.c
@@ -181,7 +181,7 @@ static void phy_semtake(void)
 {
 	/* Take the semaphore (perhaps waiting) */
 
-	while (sem_wait(&g_notify_clients_sem) != 0) {
+	while (sem_wait(&g_notify_clients_sem) != OK) {
 		/* The only case that an error should occur here is if
 		 * the wait was awakened by a signal.
 		 */

--- a/os/drivers/net/telnet.c
+++ b/os/drivers/net/telnet.c
@@ -454,7 +454,7 @@ static int telnet_open(FAR struct file *filep)
 	/* Get exclusive access to the device structures */
 
 	ret = sem_wait(&priv->td_exclsem);
-	if (ret < 0) {
+	if (ret != OK) {
 		ret = -errno;
 		goto errout;
 	}
@@ -500,7 +500,7 @@ static int telnet_close(FAR struct file *filep)
 	/* Get exclusive access to the device structures */
 
 	ret = sem_wait(&priv->td_exclsem);
-	if (ret < 0) {
+	if (ret != OK) {
 		ret = -errno;
 		goto errout;
 	}
@@ -761,10 +761,10 @@ static int telnet_session(FAR struct telnet_session_s *session)
 
 	do {
 		ret = sem_wait(&g_telnet_common.tc_exclsem);
-		if (ret < 0 && errno != -EINTR) {
+		if (ret != OK && errno != -EINTR) {
 			goto errout_with_clone;
 		}
-	} while (ret < 0);
+	} while (ret != OK);
 
 	/* Loop until the device name is verified to be unique. */
 

--- a/os/drivers/pipes/pipe.c
+++ b/os/drivers/pipes/pipe.c
@@ -142,7 +142,7 @@ static inline void pipe_free(int pipeno)
 	int ret;
 
 	ret = sem_wait(&g_pipesem);
-	if (ret == 0) {
+	if (ret == OK) {
 		g_pipeset &= ~(1 << pipeno);
 		(void)sem_post(&g_pipesem);
 	}
@@ -207,7 +207,7 @@ int pipe(int fd[2])
 	/* Get exclusive access to the pipe allocation data */
 
 	ret = sem_wait(&g_pipesem);
-	if (ret < 0) {
+	if (ret != OK) {
 		/* sem_wait() will have already set errno */
 
 		return ERROR;

--- a/os/drivers/power/battery_charger.c
+++ b/os/drivers/power/battery_charger.c
@@ -173,7 +173,7 @@ static int bat_charger_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
 	/* Inforce mutually exclusive access to the battery driver */
 
 	ret = sem_wait(&dev->batsem);
-	if (ret < 0) {
+	if (ret != OK) {
 		return -errno;			/* Probably EINTR */
 	}
 

--- a/os/drivers/power/battery_gauge.c
+++ b/os/drivers/power/battery_gauge.c
@@ -173,7 +173,7 @@ static int bat_gauge_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
 	/* Inforce mutually exclusive access to the battery driver */
 
 	ret = sem_wait(&dev->batsem);
-	if (ret < 0) {
+	if (ret != OK) {
 		return -errno;			/* Probably EINTR */
 	}
 

--- a/os/drivers/pwm.c
+++ b/os/drivers/pwm.c
@@ -173,7 +173,7 @@ static int pwm_open(FAR struct file *filep)
 	/* Get exclusive access to the device structures */
 
 	ret = sem_wait(&upper->exclsem);
-	if (ret < 0) {
+	if (ret != OK) {
 		ret = -get_errno();
 		goto errout;
 	}
@@ -244,7 +244,7 @@ static int pwm_close(FAR struct file *filep)
 	/* Get exclusive access to the device structures */
 
 	ret = sem_wait(&upper->exclsem);
-	if (ret < 0) {
+	if (ret != OK) {
 		ret = -get_errno();
 		goto errout;
 	}
@@ -426,7 +426,7 @@ static int pwm_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
 	/* Get exclusive access to the device structures */
 
 	ret = sem_wait(&upper->exclsem);
-	if (ret < 0) {
+	if (ret != OK) {
 		return ret;
 	}
 

--- a/os/drivers/rwbuffer.c
+++ b/os/drivers/rwbuffer.c
@@ -111,7 +111,7 @@ static void rwb_semtake(sem_t *sem)
 {
 	/* Take the semaphore (perhaps waiting) */
 
-	while (sem_wait(sem) != 0) {
+	while (sem_wait(sem) != OK) {
 		/* The only case that an error should occr here is if
 		 * the wait was awakened by a signal.
 		 */

--- a/os/drivers/spi/spi_bitbang.c
+++ b/os/drivers/spi/spi_bitbang.c
@@ -207,7 +207,7 @@ static int spi_lock(FAR struct spi_dev_s *dev, bool lock)
 	if (lock) {
 		/* Take the semaphore (perhaps waiting) */
 
-		while (sem_wait(&priv->exclsem) != 0) {
+		while (sem_wait(&priv->exclsem) != OK) {
 			/* The only case that an error should occur here is if the wait was awakened
 			 * by a signal.
 			 */

--- a/os/drivers/syslog/ramlog.c
+++ b/os/drivers/syslog/ramlog.c
@@ -275,7 +275,7 @@ static ssize_t ramlog_read(FAR struct file *filep, FAR char *buffer, size_t len)
 	/* Get exclusive access to the rl_tail index */
 
 	ret = sem_wait(&priv->rl_exclsem);
-	if (ret < 0) {
+	if (ret != OK) {
 		return ret;
 	}
 
@@ -336,7 +336,7 @@ static ssize_t ramlog_read(FAR struct file *filep, FAR char *buffer, size_t len)
 
 			/* Did we successfully get the rl_waitsem? */
 
-			if (ret >= 0) {
+			if (ret == OK) {
 				/* Yes... then retake the mutual exclusion semaphore */
 
 				ret = sem_wait(&priv->rl_exclsem);
@@ -346,7 +346,7 @@ static ssize_t ramlog_read(FAR struct file *filep, FAR char *buffer, size_t len)
 			 * mutual exclusion semaphore?
 			 */
 
-			if (ret < 0) {
+			if (ret != OK) {
 				/* No.. One of the two sem_wait's failed. */
 
 				int errval = errno;
@@ -533,7 +533,7 @@ int ramlog_poll(FAR struct file *filep, FAR struct pollfd *fds, bool setup)
 	/* Get exclusive access to the poll structures */
 
 	ret = sem_wait(&priv->rl_exclsem);
-	if (ret < 0) {
+	if (ret != OK) {
 		int errval = errno;
 		return -errval;
 	}

--- a/os/drivers/usbhost/usbhost_cdcacm.c
+++ b/os/drivers/usbhost/usbhost_cdcacm.c
@@ -470,7 +470,7 @@ static void usbhost_takesem(sem_t *sem)
 {
 	/* Take the semaphore (perhaps waiting) */
 
-	while (sem_wait(sem) != 0) {
+	while (sem_wait(sem) != OK) {
 		/* The only case that an error should occur here is if the wait was
 		 * awakened by a signal.
 		 */

--- a/os/drivers/usbhost/usbhost_devaddr.c
+++ b/os/drivers/usbhost/usbhost_devaddr.c
@@ -86,7 +86,7 @@ static void usbhost_takesem(FAR struct usbhost_devaddr_s *devgen)
 {
 	/* Take the semaphore (perhaps waiting) */
 
-	while (sem_wait(&devgen->exclsem) != 0) {
+	while (sem_wait(&devgen->exclsem) != OK) {
 		/* The only case that an error should occur here is if the wait was
 		 * awakened by a signal.
 		 */

--- a/os/drivers/usbhost/usbhost_hidkbd.c
+++ b/os/drivers/usbhost/usbhost_hidkbd.c
@@ -605,7 +605,7 @@ static void usbhost_takesem(sem_t *sem)
 {
 	/* Take the semaphore (perhaps waiting) */
 
-	while (sem_wait(sem) != 0) {
+	while (sem_wait(sem) != OK) {
 		/* The only case that an error should occur here is if the wait was
 		 * awakened by a signal.
 		 */

--- a/os/drivers/usbhost/usbhost_hidmouse.c
+++ b/os/drivers/usbhost/usbhost_hidmouse.c
@@ -461,7 +461,7 @@ static void usbhost_takesem(sem_t *sem)
 {
 	/* Take the semaphore (perhaps waiting) */
 
-	while (sem_wait(sem) != 0) {
+	while (sem_wait(sem) != OK) {
 		/* The only case that an error should occur here is if the wait was
 		 * awakened by a signal.
 		 */
@@ -1313,7 +1313,7 @@ static int usbhost_waitsample(FAR struct usbhost_state_s *priv, FAR struct mouse
 		ret = sem_wait(&priv->waitsem);
 		priv->nwaiters--;
 
-		if (ret < 0) {
+		if (ret != OK) {
 			/* If we are awakened by a signal, then we need to return
 			 * the failure now.
 			 */

--- a/os/drivers/usbhost/usbhost_skeleton.c
+++ b/os/drivers/usbhost/usbhost_skeleton.c
@@ -224,7 +224,7 @@ static void usbhost_takesem(sem_t *sem)
 {
 	/* Take the semaphore (perhaps waiting) */
 
-	while (sem_wait(sem) != 0) {
+	while (sem_wait(sem) != OK) {
 		/* The only case that an error should occur here is if the wait was
 		 * awakened by a signal.
 		 */

--- a/os/drivers/usbhost/usbhost_storage.c
+++ b/os/drivers/usbhost/usbhost_storage.c
@@ -327,7 +327,7 @@ static void usbhost_takesem(sem_t *sem)
 {
 	/* Take the semaphore (perhaps waiting) */
 
-	while (sem_wait(sem) != 0) {
+	while (sem_wait(sem) != OK) {
 		/* The only case that an error should occur here is if the wait was
 		 * awakened by a signal.
 		 */

--- a/os/drivers/watchdog.c
+++ b/os/drivers/watchdog.c
@@ -157,7 +157,7 @@ static int wdog_open(FAR struct file *filep)
 	/* Get exclusive access to the device structures */
 
 	ret = sem_wait(&upper->exclsem);
-	if (ret < 0) {
+	if (ret != OK) {
 		ret = -get_errno();
 		goto errout;
 	}
@@ -206,7 +206,7 @@ static int wdog_close(FAR struct file *filep)
 	/* Get exclusive access to the device structures */
 
 	ret = sem_wait(&upper->exclsem);
-	if (ret < 0) {
+	if (ret != OK) {
 		ret = -get_errno();
 		goto errout;
 	}
@@ -276,7 +276,7 @@ static int wdog_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
 	/* Get exclusive access to the device structures */
 
 	ret = sem_wait(&upper->exclsem);
-	if (ret < 0) {
+	if (ret != OK) {
 		return ret;
 	}
 

--- a/os/drivers/wireless/scsc/tinyara_wrapper.c
+++ b/os/drivers/wireless/scsc/tinyara_wrapper.c
@@ -38,7 +38,7 @@ unsigned long wait_for_completion_timeout(struct completion *x, unsigned long ti
 			timeout.tv_sec++;
 			timeout.tv_nsec -= NSEC_PER_SEC;
 		}
-		while (sem_timedwait(&x->sem, &timeout) != 0) {
+		while (sem_timedwait(&x->sem, &timeout) != OK) {
 			ret = get_errno();
 			if (ret == ETIMEDOUT) {
 				ret = 1;
@@ -46,7 +46,7 @@ unsigned long wait_for_completion_timeout(struct completion *x, unsigned long ti
 			}
 		}
 	} else {
-		while (sem_wait(&x->sem) != 0) {
+		while (sem_wait(&x->sem) != OK) {
 			sem_post(&x->sem);
 		}
 	}

--- a/os/fs/aio/aio_initialize.c
+++ b/os/fs/aio/aio_initialize.c
@@ -183,7 +183,7 @@ void aio_lock(void)
 	} else {
 		/* No.. take the semaphore */
 
-		while (sem_wait(&g_aio_exclsem) < 0) {
+		while (sem_wait(&g_aio_exclsem) != OK) {
 			DEBUGASSERT(get_errno() == EINTR);
 		}
 
@@ -240,7 +240,7 @@ FAR struct aio_container_s *aioc_alloc(void)
 	 * container set aside for us.
 	 */
 
-	while (sem_wait(&g_aioc_freesem) < 0) {
+	while (sem_wait(&g_aioc_freesem) != OK) {
 		DEBUGASSERT(get_errno() == EINTR);
 	}
 

--- a/os/fs/driver/block/fs_blockproxy.c
+++ b/os/fs/driver/block/fs_blockproxy.c
@@ -112,7 +112,7 @@ static FAR char *unique_chardev(void)
 	/* Loop until we get a unique device name */
 	for (; ; ) {
 		/* Get the semaphore protecting the path number */
-		while (sem_wait(&g_devno_sem) < 0) {
+		while (sem_wait(&g_devno_sem) != OK) {
 			DEBUGASSERT(errno == EINTR);
 		}
 

--- a/os/fs/driver/block/fs_devsyslog.c
+++ b/os/fs/driver/block/fs_devsyslog.c
@@ -159,7 +159,7 @@ static inline int syslog_takesem(void)
 	 */
 
 	ret = sem_wait(&g_sysdev.sl_sem);
-	if (ret < 0) {
+	if (ret != OK) {
 		return -get_errno();
 	}
 

--- a/os/fs/driver/mtd/mtd_config.c
+++ b/os/fs/driver/mtd/mtd_config.c
@@ -834,7 +834,7 @@ static int mtdconfig_open(FAR struct file *filep)
 	/* Get exclusive access to the device */
 
 	ret = sem_wait(&dev->exclsem);
-	if (ret < 0) {
+	if (ret != OK) {
 		ret = -errno;
 		goto errout;
 	}

--- a/os/fs/inode/fs_files.c
+++ b/os/fs/inode/fs_files.c
@@ -96,7 +96,7 @@ static void _files_semtake(FAR struct filelist *list)
 {
 	/* Take the semaphore (perhaps waiting) */
 
-	while (sem_wait(&list->fl_sem) != 0) {
+	while (sem_wait(&list->fl_sem) != OK) {
 		/* The only case that an error should occr here is if
 		 * the wait was awakened by a signal.
 		 */

--- a/os/fs/inode/fs_inode.c
+++ b/os/fs/inode/fs_inode.c
@@ -226,7 +226,7 @@ void inode_semtake(void)
 	/* Take the semaphore (perhaps waiting) */
 
 	else {
-		while (sem_wait(&g_inode_sem.sem) != 0) {
+		while (sem_wait(&g_inode_sem.sem) != OK) {
 			/* The only case that an error should occr here is if
 			 * the wait was awakened by a signal.
 			 */

--- a/os/fs/romfs/fs_romfsutil.c
+++ b/os/fs/romfs/fs_romfsutil.c
@@ -361,7 +361,7 @@ void romfs_semtake(struct romfs_mountpt_s *rm)
 {
 	/* Take the semaphore (perhaps waiting) */
 
-	while (sem_wait(&rm->rm_sem) != 0) {
+	while (sem_wait(&rm->rm_sem) != OK) {
 		/* The only case that an error should occur here is if
 		 * the wait was awakened by a signal.
 		 */

--- a/os/fs/smartfs/smartfs_utils.c
+++ b/os/fs/smartfs/smartfs_utils.c
@@ -198,7 +198,7 @@ void smartfs_semtake(struct smartfs_mountpt_s *fs)
 {
 	/* Take the semaphore (perhaps waiting) */
 
-	while (sem_wait(fs->fs_sem) != 0) {
+	while (sem_wait(fs->fs_sem) != OK) {
 		/* The only case that an error should occur here is if
 		 * the wait was awakened by a signal.
 		 */

--- a/os/fs/vfs/fs_poll.c
+++ b/os/fs/vfs/fs_poll.c
@@ -97,7 +97,7 @@ static int poll_semtake(FAR sem_t *sem)
 {
 	/* Take the semaphore (perhaps waiting) */
 
-	if (sem_wait(sem) < 0) {
+	if (sem_wait(sem) != OK) {
 		int err = get_errno();
 
 		/* The only case that an error should occur here is if the wait were
@@ -365,7 +365,7 @@ int poll(FAR struct pollfd *fds, nfds_t nfds, int timeout)
 			}
 
 			ret = sem_timedwait(&sem, &abstime);
-			if (ret < 0) {
+			if (ret != OK) {
 				int err = get_errno();
 
 				if (err == ETIMEDOUT) {

--- a/os/kernel/sched/sched_waitpid.c
+++ b/os/kernel/sched/sched_waitpid.c
@@ -252,7 +252,7 @@ pid_t waitpid(pid_t pid, int *stat_loc, int options)
 	/* Then wait for the task to exit */
 
 	ret = sem_wait(&group->tg_exitsem);
-	if (ret < 0) {
+	if (ret != OK) {
 		/* Unlock pre-emption and return the ERROR (sem_wait has already set
 		 * the errno).  Handle the awkward case of whether or not we need to
 		 * nullify the stat_loc value.

--- a/os/kernel/semaphore/sem_tickwait.c
+++ b/os/kernel/semaphore/sem_tickwait.c
@@ -179,7 +179,7 @@ int sem_tickwait(FAR sem_t *sem, systime_t start, uint32_t delay)
 	/* Now perform the blocking wait */
 
 	ret = sem_wait(sem);
-	if (ret < 0) {
+	if (ret != OK) {
 		/* Return the errno from sem_wait() */
 
 		ret = -get_errno();

--- a/os/kernel/semaphore/sem_timedwait.c
+++ b/os/kernel/semaphore/sem_timedwait.c
@@ -273,7 +273,7 @@ int sem_timedwait(FAR sem_t *sem, FAR const struct timespec *abstime)
 	/* Now perform the blocking wait */
 
 	ret = sem_wait(sem);
-	if (ret < 0) {
+	if (ret != OK) {
 		/* sem_wait() failed.  Save the errno value */
 
 		errcode = get_errno();
@@ -296,7 +296,7 @@ int sem_timedwait(FAR sem_t *sem, FAR const struct timespec *abstime)
 	 * cases.
 	 */
 
-	if (ret < 0) {
+	if (ret < OK) {
 		/* On failure, restore the errno value returned by sem_wait */
 
 		set_errno(errcode);

--- a/os/kernel/task/task_spawnparms.c
+++ b/os/kernel/task/task_spawnparms.c
@@ -195,8 +195,8 @@ void spawn_semtake(FAR sem_t *sem)
 
 	do {
 		ret = sem_wait(sem);
-		ASSERT(ret == 0 || get_errno() == EINTR);
-	} while (ret != 0);
+		ASSERT(ret == OK || get_errno() == EINTR);
+	} while (ret != OK);
 }
 
 /****************************************************************************

--- a/os/mm/mm_heap/mm_sem.c
+++ b/os/mm/mm_heap/mm_sem.c
@@ -137,7 +137,7 @@ int mm_trysemaphore(FAR struct mm_heap_s *heap)
 	} else {
 		/* Try to take the semaphore (perhaps waiting) */
 
-		if (sem_trywait(&heap->mm_semaphore) != 0) {
+		if (sem_trywait(&heap->mm_semaphore) != OK) {
 			return ERROR;
 		}
 
@@ -172,7 +172,7 @@ void mm_takesemaphore(FAR struct mm_heap_s *heap)
 		/* Take the semaphore (perhaps waiting) */
 
 		msemdbg("PID=%d taking\n", my_pid);
-		while (sem_wait(&heap->mm_semaphore) != 0) {
+		while (sem_wait(&heap->mm_semaphore) != OK) {
 			/* The only case that an error should occur here is if
 			 * the wait was awakened by a signal.
 			 */

--- a/os/mm/shm/shmat.c
+++ b/os/mm/shm/shmat.c
@@ -166,7 +166,7 @@ FAR void *shmat(int shmid, FAR const void *shmaddr, int shmflg)
 	/* Get exclusive access to the region data structure */
 
 	ret = sem_wait(&region->sr_sem);
-	if (ret < 0) {
+	if (ret != OK) {
 		shmdbg("sem_wait failed: %d\n", ret);
 		goto errout;
 	}

--- a/os/mm/shm/shmctl.c
+++ b/os/mm/shm/shmctl.c
@@ -165,7 +165,7 @@ int shmctl(int shmid, int cmd, struct shmid_ds *buf)
 	/* Get exclusive access to the region data structure */
 
 	ret = sem_wait(&region->sr_sem);
-	if (ret < 0) {
+	if (ret != OK) {
 		shmdbg("sem_wait failed: %d\n", ret);
 		return ret;
 	}

--- a/os/mm/shm/shmdt.c
+++ b/os/mm/shm/shmdt.c
@@ -148,7 +148,7 @@ int shmdt(FAR const void *shmaddr)
 	/* Get exclusive access to the region data structure */
 
 	ret = sem_wait(&region->sr_sem);
-	if (ret < 0) {
+	if (ret != OK) {
 		shmdbg("sem_wait failed: %d\n", ret);
 		goto errout;
 	}

--- a/os/mm/shm/shmget.c
+++ b/os/mm/shm/shmget.c
@@ -401,7 +401,7 @@ int shmget(key_t key, size_t size, int shmflg)
 	/* Get exclusive access to the global list of shared memory regions */
 
 	ret = sem_wait(&g_shminfo.si_sem);
-	if (ret >= 0) {
+	if (ret == OK) {
 		/* Find the requested memory region */
 
 		ret = shm_find(key);

--- a/os/net/utils/net_lock.c
+++ b/os/net/utils/net_lock.c
@@ -98,7 +98,7 @@ static unsigned int g_count = 0;
 
 static void _net_takesem(void)
 {
-	while (sem_wait(&g_netlock) != 0) {
+	while (sem_wait(&g_netlock) != OK) {
 		/* The only case that an error should occur here is if the wait was
 		 * awakened by a signal.
 		 */


### PR DESCRIPTION
…it() sem_getvalue() pthread_mutex_lock()

 It's not recommended to use hardcoded values when there exist as #define
 #define OK 0
 Return value is set as OK incase of success for semaphore APIs.
 However return type check is done with hardcoded value 0.
 This can cause problem if #define OK value changes to value other than 0.
 Hence, correct the return type check with OK across the src code.

Signed-off-by: pradeep.ns <pradeep.ns@samsung.com>