### PR TITLE
Correct the comment description for better understanding

### DIFF
--- a/os/kernel/semaphore/sem_recover.c
+++ b/os/kernel/semaphore/sem_recover.c
@@ -144,7 +144,7 @@ void sem_recover(FAR struct tcb_s *tcb)
 		sem_canceled(tcb, sem);
 
 		/* And increment the count on the semaphore.  This releases the count
-		 * that was taken by sem_post().  This count decremented the semaphore
+		 * that was taken by sem_wait().  This count decremented the semaphore
 		 * count to negative and caused the thread to be blocked in the first
 		 * place.
 		 */

--- a/os/kernel/semaphore/sem_tickwait.c
+++ b/os/kernel/semaphore/sem_tickwait.c
@@ -180,7 +180,7 @@ int sem_tickwait(FAR sem_t *sem, systime_t start, uint32_t delay)
 
 	ret = sem_wait(sem);
 	if (ret < 0) {
-		/* Return the errno from sem_wait() */
+		/* Return the errno from sem_wait() or from sem_timeout() */
 
 		ret = -get_errno();
 	}

--- a/os/kernel/semaphore/sem_timedwait.c
+++ b/os/kernel/semaphore/sem_timedwait.c
@@ -291,9 +291,12 @@ int sem_timedwait(FAR sem_t *sem, FAR const struct timespec *abstime)
 	leave_cancellation_point();
 
 	/* We are either returning success or an error detected by sem_wait()
-	 * or the timeout detected by sem_timeout().  The 'errno' value has
-	 * been set appropriately by sem_wait() or sem_timeout() in those
-	 * cases.
+	 * or the timeout detected by sem_timeout() or sem_trywait() called from
+	 * wd_delete(). The 'errno' value has been set appropriately by sem_wait()
+	 * or sem_timeout() or sem_trywait() in those cases.
+	 *
+	 * wd_delete()->sched_kfree->kmm_trysemaphore->mm_trysemaphore->sem_trywait
+	 * wd_delete()->sched_ufree->kumm_trysemaphore->mm_trysemaphore->sem_trywait
 	 */
 
 	if (ret < 0) {


### PR DESCRIPTION
sem_recover() => sem_post has been changed to sem_wait
sem_tickwait() => sem_timeout() return value is also considered
sem_timedwait() => hidden call to sem_trywait() is mentioned

Signed-off-by: pradeep.ns <pradeep.ns@samsung.com>