### PR TITLE
Non-compliant gettimeofday prototype fixed.

### DIFF
--- a/apps/examples/testcase/le_tc/kernel/tc_libc_stdlib.c
+++ b/apps/examples/testcase/le_tc/kernel/tc_libc_stdlib.c
@@ -203,15 +203,15 @@ static void tc_libc_stdlib_rand(void)
 
 	ret_chk = rand();
 	TC_ASSERT_GEQ("rand", ret_chk, 0);
-	TC_ASSERT_LT("rand", ret_chk, MAX_RAND);
+	TC_ASSERT_LT("rand", ret_chk, RAND_MAX);
 
 	ret_chk = rand();
 	TC_ASSERT_GEQ("rand", ret_chk, 0);
-	TC_ASSERT_LT("rand", ret_chk, MAX_RAND);
+	TC_ASSERT_LT("rand", ret_chk, RAND_MAX);
 
 	ret_chk = rand();
 	TC_ASSERT_GEQ("rand", ret_chk, 0);
-	TC_ASSERT_LT("rand", ret_chk, MAX_RAND);
+	TC_ASSERT_LT("rand", ret_chk, RAND_MAX);
 
 	TC_SUCCESS_RESULT();
 }

--- a/framework/src/arastorage/random.c
+++ b/framework/src/arastorage/random.c
@@ -64,8 +64,8 @@ void random_init(unsigned short seed)
 }
 unsigned short random_rand(void)
 {
-	/* In gcc int rand() uses MAX_RAND and long random() uses RANDOM_MAX=0x7FFFFFFF */
-	/* MAX_RAND varies depending on the architecture */
+	/* In gcc int rand() uses RAND_MAX and long random() uses RANDOM_MAX=0x7FFFFFFF */
+	/* RAND_MAX varies depending on the architecture */
 
 	return (unsigned short)rand();
 }

--- a/framework/src/arastorage/random.h
+++ b/framework/src/arastorage/random.h
@@ -52,7 +52,7 @@
 /****************************************************************************
 * Pre-processor Definitions
 ****************************************************************************/
-/* In gcc int rand() uses MAX_RAND and long random() uses RANDOM_MAX */
+/* In gcc int rand() uses RAND_MAX and long random() uses RANDOM_MAX */
 /* Since random_rand casts to unsigned short, we'll use this maxmimum */
 #define RANDOM_RAND_MAX 65535U
 

--- a/os/include/stdlib.h
+++ b/os/include/stdlib.h
@@ -89,7 +89,7 @@
 
 /* Maximum value returned by rand() */
 
-#define MAX_RAND 32767
+#define RAND_MAX 32767
 
 /* Integer expression whose value is the maximum number of bytes in a
  * character specified by the current locale.

--- a/os/include/sys/time.h
+++ b/os/include/sys/time.h
@@ -89,7 +89,7 @@ extern "C" {
  * @brief  POSIX APIs (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
-EXTERN int gettimeofday(struct timeval *tp, FAR void *tzp);
+EXTERN int gettimeofday(struct timeval *tp, FAR struct timezone *tzp);
 
 #undef EXTERN
 #if defined(__cplusplus)

--- a/os/include/time.h
+++ b/os/include/time.h
@@ -162,6 +162,11 @@ struct timeval {
 	long tv_usec;				/* Microseconds */
 };
 
+struct timezone {
+	int tz_minuteswest;			/* munutes west of Greenwich */
+	int tz_dsttime;				/* type of DST correction */
+};
+
 /**
  * @ingroup TIME_KERNEL
  * @brief Structure containing a calendar date and time */

--- a/os/kernel/clock/clock_gettimeofday.c
+++ b/os/kernel/clock/clock_gettimeofday.c
@@ -102,7 +102,7 @@
  *
  ****************************************************************************/
 
-int gettimeofday(struct timeval *tp, void *tzp)
+int gettimeofday(struct timeval *tp, FAR struct timezone *tzp)
 {
 	struct timespec ts;
 	int ret;

--- a/os/syscall/syscall.csv
+++ b/os/syscall/syscall.csv
@@ -27,7 +27,7 @@
 "get_environ_ptr", "stdlib.h", "!defined(CONFIG_DISABLE_ENVIRON)", "FAR char*", "size_t *"
 "getpid", "unistd.h", "", "pid_t"
 "getsockopt", "sys/socket.h", "CONFIG_NSOCKET_DESCRIPTORS > 0 && defined(CONFIG_NET)", "int", "int", "int", "int", "FAR void*", "FAR socklen_t*"
-"gettimeofday", "sys/time.h", "", "int", "struct timeval*", "FAR void*"
+"gettimeofday", "sys/time.h", "", "int", "struct timeval*", "FAR struct timezone*"
 "ioctl", "sys/ioctl.h", "!defined(CONFIG_LIBC_IOCTL_VARIADIC) && (CONFIG_NSOCKET_DESCRIPTORS > 0 || CONFIG_NFILE_DESCRIPTORS > 0)", "int", "int", "int", "unsigned long"
 "kill", "signal.h", "!defined(CONFIG_DISABLE_SIGNALS)", "int", "pid_t", "int"
 "listen", "sys/socket.h", "CONFIG_NSOCKET_DESCRIPTORS > 0 && defined(CONFIG_NET)", "int", "int", "int"


### PR DESCRIPTION
Provided POSIX-mandated RAND_MAX definition.
Provided setjmp/longjmp not present in nuttx/tinyara.

Change-Id: I77b0250cd4277154635232cdfd0fd1ab3458ec68
Signed-off-by: Tomasz Wozniak <t.wozniak@samsung.com>