### PR TITLE
Set stkmon_started=FALSE in error case

### DIFF
--- a/apps/system/utils/kdbg_stackmonitor.c
+++ b/apps/system/utils/kdbg_stackmonitor.c
@@ -272,6 +272,8 @@ int kdbg_stackmonitor(int argc, char **args)
 		if (ret != OK) {
 			printf(STKMON_PREFIX "ERROR: Failed to detach the stack monitor: %d\n", errno);
 			pthread_cancel(stkmon);
+			stkmon_started = FALSE;
+			return ERROR;
 		}
 	} else {
 		printf(STKMON_PREFIX "already started\n");


### PR DESCRIPTION
pthread_cancel kills the thread and stkmon logging will be stopped immediately.
hence set the variable stkmon_started to FALSE so that user can re-attempt
command "stkmon" from tash

Signed-off-by: pradeep.ns <pradeep.ns@samsung.com>