### PR TITLE
s5jt200: remove wrong string in error output

### DIFF
--- a/os/arch/arm/src/sidk_s5jt200/src/s5jt200_led.c
+++ b/os/arch/arm/src/sidk_s5jt200/src/s5jt200_led.c
@@ -120,7 +120,7 @@ int s5jt200_rgbled_setup(void)
 		/* Call s5j_pwminitialize() to get an instance of the PWM interface */
 		ledb = (struct pwm_lowerhalf_s*)s5j_pwminitialize(1);
 		if (!ledb) {
-			lldbg("ERROR: Failed to get the STM32 PWM lower half to LEDR\n");
+			lldbg("ERROR: Failed to get PWM lower half to LEDR\n");
 			return -ENODEV;
 		}
 
@@ -135,7 +135,7 @@ int s5jt200_rgbled_setup(void)
 		/* Call s5j_pwminitialize() to get an instance of the PWM interface */
 		ledg = (struct pwm_lowerhalf_s*)s5j_pwminitialize(2);
 		if (!ledg) {
-			lldbg("ERROR: Failed to get the STM32 PWM lower half to LEDG\n");
+			lldbg("ERROR: Failed to get PWM lower half to LEDG\n");
 			return -ENODEV;
 		}
 
@@ -146,7 +146,7 @@ int s5jt200_rgbled_setup(void)
 		/* Call s5j_pwminitialize() to get an instance of the PWM interface */
 		ledr = (struct pwm_lowerhalf_s*)s5j_pwminitialize(3);
 		if (!ledr) {
-			lldbg("ERROR: Failed to get the STM32 PWM lower half to LEDB\n");
+			lldbg("ERROR: Failed to get PWM lower half to LEDB\n");
 			return -ENODEV;
 		}
 


### PR DESCRIPTION
fix not appropriate string to s5jt200

Change-Id: Ic11084af6a1e6ca73d0d45a20b443f5dae6ba66c
Signed-off-by: Jihoon Park <jh6186.park@samsung.com>