### PR TITLE
posix_spawnattr_init:Return EIVNAL when attr is NULL

### DIFF
--- a/lib/libc/spawn/lib_psa_init.c
+++ b/lib/libc/spawn/lib_psa_init.c
@@ -93,6 +93,10 @@ int posix_spawnattr_init(posix_spawnattr_t *attr)
 
 	DEBUGASSERT(attr);
 
+	if (attr == NULL) {
+		return EINVAL;
+	}
+
 	/* Flags: None */
 
 	attr->flags = 0;


### PR DESCRIPTION
If attr is invalid, posix_spawnattr_init return EINVAL