### PR TITLE
Force tinyara_head.bin creation for Artik05x boards

### DIFF
--- a/os/arch/Kconfig.board
+++ b/os/arch/Kconfig.board
@@ -15,12 +15,14 @@ choice
 config ARCH_BOARD_ARTIK053
 	bool "Samsung ARTIK-053 Starter Kit"
 	depends on ARCH_CHIP_S5JT200
+	select SAMSUNG_NS2
 	---help---
 		Samsung ARTIK-053 Starter Kit based on S5JT200 IoT WiFi MCU
 
 config ARCH_BOARD_SIDK_S5JT200
 	bool "Samsung S5JT200 sidk board"
 	depends on ARCH_CHIP_S5JT200
+	select SAMSUNG_NS2
 	select ARCH_HAVE_BUTTONS
 	select ARCH_HAVE_IRQBUTTONS
 	---help---


### PR DESCRIPTION
The binary to upload with OpenOCD is tinyara_head.bin.
That binary is created when (and only when) SAMSUNG_NS2 is selected in the config.
