### PR TITLE
FIONREAD macro namespace clash resolved for IOCTL and SOCKETS

### DIFF
--- a/os/include/net/lwip/sockets.h
+++ b/os/include/net/lwip/sockets.h
@@ -57,6 +57,7 @@
 #include <stddef.h>				/* for size_t */
 #include <string.h>				/* for memset used by FD_ZERO */
 #include <fcntl.h>
+#include <tinyara/fs/ioctl.h> 
 #if LWIP_TIMEVAL_PRIVATE
 #include <time.h>
 #endif


### PR DESCRIPTION
There is macro with the same name but different content
within two basic OS headers - sockets.h and ioctl.h.
It is necessary to fix this by extending macro name with prefix
so it will be clear, which header's macros is use where.