### PR TITLE
Correct the datatype mismatch

### DIFF
--- a/os/include/tinyara/mm/mm.h
+++ b/os/include/tinyara/mm/mm.h
@@ -235,7 +235,7 @@ typedef size_t mmaddress_t;		/* 32 bit address space */
 #endif
 
 #define SIZEOF_MM_MALLOC_DEBUG_INFO \
-	(sizeof(mmaddress_t) + sizeof(int16_t) + sizeof(uint16_t))
+	(sizeof(mmaddress_t) + sizeof(pid_t) + sizeof(uint16_t))
 #endif
 
 /* This describes an allocated chunk.  An allocated chunk is
@@ -247,8 +247,8 @@ struct mm_allocnode_s {
 	mmsize_t size;					/* Size of this chunk */
 	mmsize_t preceding;				/* Size of the preceding chunk */
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
-	mmaddress_t alloc_call_addr;	/* malloc call address */
-	int16_t pid;					/* PID info */
+	mmaddress_t alloc_call_addr;			/* malloc call address */
+	pid_t pid;					/* PID info */
 	uint16_t reserved;				/* Reserved for future use. */
 #endif
 
@@ -592,13 +592,13 @@ int mm_size2ndx(size_t size);
 
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
 /* Functions contained in kmm_mallinfo.c . Used to display memory allocation details */
-void heapinfo_parse(FAR struct mm_heap_s *heap, int mode, int pid);
+void heapinfo_parse(FAR struct mm_heap_s *heap, int mode, pid_t pid);
 /* Funciton to add memory allocation info */
 void heapinfo_update_node(FAR struct mm_allocnode_s *node, mmaddress_t caller_retaddr);
 
-void heapinfo_add_size(int16_t pid, size_t size);
-void heapinfo_subtract_size(int16_t pid, size_t size);
-void heapinfo_update_total_size(struct mm_heap_s *heap, int size);
+void heapinfo_add_size(pid_t pid, mmsize_t size);
+void heapinfo_subtract_size(pid_t pid, mmsize_t size);
+void heapinfo_update_total_size(struct mm_heap_s *heap, mmsize_t size);
 #endif
 
 #ifdef CONFIG_DEBUG_MM_HEAPINFO

--- a/os/mm/mm_heap/mm_heapinfo.c
+++ b/os/mm/mm_heap/mm_heapinfo.c
@@ -75,7 +75,7 @@
  * Description:
  *   This function walk through heap and displays alloc info.
  ****************************************************************************/
-void heapinfo_parse(FAR struct mm_heap_s *heap, int mode, int pid)
+void heapinfo_parse(FAR struct mm_heap_s *heap, int mode, pid_t pid)
 {
 	struct mm_allocnode_s *node;
 	size_t mxordblk = 0;
@@ -191,7 +191,7 @@ void heapinfo_parse(FAR struct mm_heap_s *heap, int mode, int pid)
  * Description:
  * Add the allocated size in tcb
  ****************************************************************************/
-void heapinfo_add_size(int16_t pid, size_t size)
+void heapinfo_add_size(pid_t pid, mmsize_t size)
 {
 	struct tcb_s *rtcb = sched_gettcb(pid);
 	if (rtcb) {
@@ -209,7 +209,7 @@ void heapinfo_add_size(int16_t pid, size_t size)
  * Description:
  * Subtract the allocated size in tcb
  ****************************************************************************/
-void heapinfo_subtract_size(int16_t pid, size_t size)
+void heapinfo_subtract_size(pid_t pid, mmsize_t size)
 {
 	struct tcb_s *rtcb = sched_gettcb(pid);
 
@@ -225,7 +225,7 @@ void heapinfo_subtract_size(int16_t pid, size_t size)
  * Description:
  * Calculate the total allocated size and update the peak allocated size for heap
  ****************************************************************************/
-void heapinfo_update_total_size(struct mm_heap_s *heap, int size)
+void heapinfo_update_total_size(struct mm_heap_s *heap, mmsize_t size)
 {
 	heap->total_alloc_size += size;
 	if (heap->total_alloc_size > heap->peak_alloc_size) {


### PR DESCRIPTION
Inside struct mm_allocnode_s in mm.h file, the size and preceding are declared as mmsize_t.
heapinfo_add_size is getting called from mm_malloc.c by referencing to it's own structures
as below. heapinfo_add_size(((struct mm_allocnode_s *)node)->pid, node->size);

This was the concern to change the data type to mmsize_t to keep the same reference across
src files to keep the code robust.

Signed-off-by: pradeep.ns <pradeep.ns@samsung.com>