### PR TITLE
Correct the SIZEOF_MM_ALLOCNODE incase of CONFIG_MM_SMALL is defined

### DIFF
--- a/os/include/tinyara/mm/mm.h
+++ b/os/include/tinyara/mm/mm.h
@@ -257,13 +257,22 @@ struct mm_allocnode_s {
 /* What is the size of the allocnode? */
 
 #ifdef CONFIG_MM_SMALL
-#define SIZEOF_MM_ALLOCNODE   4
+#ifdef CONFIG_DEBUG_MM_HEAPINFO
+/* 10 = (uint16_t + uint16_t + uint16_t + uint16_t + uint16_t ) */
+#define SIZEOF_MM_ALLOCNODE   (sizeof(mmsize_t) + sizeof(mmsize_t) + SIZEOF_MM_MALLOC_DEBUG_INFO)
+#else
+/* 4 = (uint16_t + uint16_t) */
+#define SIZEOF_MM_ALLOCNODE   (sizeof(mmsize_t) + sizeof(mmsize_t))
+#endif
+
 #else
 
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
-#define SIZEOF_MM_ALLOCNODE   16	/* 8 Bytes added for storing memory allocation info  */
+/* 16 = (uint32_t + uint32_t + uint32_t + uint16_t + uint16_t ) */
+#define SIZEOF_MM_ALLOCNODE  (sizeof(mmsize_t) + sizeof(mmsize_t) + SIZEOF_MM_MALLOC_DEBUG_INFO)
 #else
-#define SIZEOF_MM_ALLOCNODE   8
+/* 8 = (uint32_t + uint32_t) */
+#define SIZEOF_MM_ALLOCNODE   (sizeof(mmsize_t) + sizeof(mmsize_t))
 #endif
 #endif
 


### PR DESCRIPTION
When CONFIG_MM_SMALL is defined, SIZEOF_MM_ALLOCNODE is not set properly
and thus set it properly and remove the hard coded values to real time values

Signed-off-by: pradeep.ns <pradeep.ns@samsung.com>