### PR TITLE
remove unnecessary wlan comment (title) on Kconfig

### DIFF
--- a/os/Kconfig
+++ b/os/Kconfig
@@ -669,8 +669,6 @@ config DEBUG_SYSCALL_INFO
 
 endif #DEBUG_SYSCALL
 
-comment "SLSI WLAN Debug Options"
-
 config DEBUG_WLAN
 	bool "WLAN Debug Output"
 	default y


### PR DESCRIPTION
This comment makes defconfig ugly.
When we disable DEBUG_WLAN, it shows unncessary title at defconfig.
DEBUG_WLAN should be under subsystem debug options and
there are enough titles at wlan's subsystem like FW, driver and wpa_supplicant.