### PR TITLE
Fix the param name mismatch and defines based on POSIX

### DIFF
--- a/lib/libc/signal/sig_hold.c
+++ b/lib/libc/signal/sig_hold.c
@@ -64,12 +64,12 @@
  * Name: sighold
  *
  * Description:
- *   The sighold() function will add 'signo' to the calling process' signal
+ *   The sighold() function will add 'sig' to the calling process' signal
  *   mask.
  *
  ****************************************************************************/
 
-int sighold(int signo)
+int sighold(int sig)
 {
 	sigset_t set;
 	int ret;
@@ -77,7 +77,7 @@ int sighold(int signo)
 	/* Create a set of signals with only the signal to be blocked */
 
 	(void)sigemptyset(&set);
-	ret = sigaddset(&set, signo);
+	ret = sigaddset(&set, sig);
 	if (ret == OK) {
 		/* Block the signal */
 

--- a/lib/libc/signal/sig_relse.c
+++ b/lib/libc/signal/sig_relse.c
@@ -64,12 +64,12 @@
  * Name: sigrelse
  *
  * Description:
- *   The sigrelse() function will remove 'signo' from the calling process'
+ *   The sigrelse() function will remove 'sig' from the calling process'
  *   signal mask.
  *
  ****************************************************************************/
 
-int sigrelse(int signo)
+int sigrelse(int sig)
 {
 	sigset_t set;
 	int ret;
@@ -77,7 +77,7 @@ int sigrelse(int signo)
 	/* Create a set of signals with only the signal to be unblocked */
 
 	(void)sigemptyset(&set);
-	ret = sigaddset(&set, signo);
+	ret = sigaddset(&set, sig);
 	if (ret == OK) {
 		/* Unblock the signal */
 

--- a/os/include/signal.h
+++ b/os/include/signal.h
@@ -200,9 +200,9 @@
 
 /* Special values of sigaction (all treated like NULL) */
 
-#define SIG_ERR         ((CODE void*)-1)
-#define SIG_DFL         ((CODE void*)0)
-#define SIG_IGN         ((CODE void*)0)
+#define SIG_ERR         ((_sa_handler_t)-1)
+#define SIG_DFL         ((_sa_handler_t)0)
+#define SIG_IGN         ((_sa_handler_t)0)
 #define SIG_HOLD        ((_sa_handler_t)1)   /* Used only with sigset() */
 
 /********************************************************************************
@@ -297,7 +297,7 @@ extern "C" {
  * @details [SYSTEM CALL API]
  * @since Tizen RT v1.0
  */
-int kill(pid_t, int);
+int kill(pid_t pid, int sig);
 
 /**
  * @addtogroup SIGNAL_KERNEL
@@ -332,7 +332,7 @@ int sigismember(FAR const sigset_t *set, int signo);
  * @brief  POSIX APIs (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
-int sighold(int signo);
+int sighold(int sig);
 /**
  * @brief  POSIX APIs (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
@@ -352,7 +352,7 @@ int raise(int sig);
  * @brief  POSIX APIs (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
-int sigrelse(int signo);
+int sigrelse(int sig);
 /**
  * @brief  POSIX APIs (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0


### PR DESCRIPTION
signo -> sig, kill(pid_t pid, int sig), (_sa_handler_t) type

Change-Id: I0cf026fe99731134ff0a9fcda5c0bda2fae4b51e
Signed-off-by: jc_.kim <jc_.kim@samsung.com>