### PR TITLE
Fix the wrong dbg in pthread_mutexattr_set/getprotocol

### DIFF
--- a/lib/libc/pthread/pthread_mutexattr_getprotocol.c
+++ b/lib/libc/pthread/pthread_mutexattr_getprotocol.c
@@ -86,10 +86,10 @@ int pthread_mutexattr_getprotocol(FAR const pthread_mutexattr_t *attr,
 	DEBUGASSERT(attr != NULL && protocol != NULL);
 
 #ifdef CONFIG_PRIORITY_INHERITANCE
-	linfo("Returning %d\n", attr->proto);
+	svdbg("Returning %d\n", attr->proto);
 	return attr->proto;
 #else
-	linfo("Returning %d\n", PTHREAD_PRIO_NONE);
+	svdbg("Returning %d\n", PTHREAD_PRIO_NONE);
 	return PTHREAD_PRIO_NONE;
 #endif
 }

--- a/lib/libc/pthread/pthread_mutexattr_setprotocol.c
+++ b/lib/libc/pthread/pthread_mutexattr_setprotocol.c
@@ -83,7 +83,7 @@
 int pthread_mutexattr_setprotocol(FAR pthread_mutexattr_t *attr,
 				  int protocol)
 {
-	linfo("attr=0x%p protocol=%d\n", attr, protocol);
+	svdbg("attr=0x%p protocol=%d\n", attr, protocol);
 	DEBUGASSERT(attr != NULL);
 
 #ifdef CONFIG_PRIORITY_INHERITANCE


### PR DESCRIPTION
linfo is not defined, but want to show the info for debugging

Change-Id: I8802e9cfbc0147f39795c38b1c3a8f5482ce1584
Signed-off-by: jc_.kim <jc_.kim@samsung.com>