### PR TITLE
Fix missing ROM partition type

### DIFF
--- a/os/arch/arm/src/artik053/src/artik053_tash.c
+++ b/os/arch/arm/src/artik053/src/artik053_tash.c
@@ -185,6 +185,13 @@ static void artik053_configure_partitions(void)
 				smart_initialize(CONFIG_ARTIK053_FLASH_MINOR, mtd_part, partref);
 			} else
 #endif
+#if defined(CONFIG_FS_ROMFS) && defined(CONFIG_FS_SMARTFS)
+			if (!strncmp(types, "romfs,", 6)) {
+				char partref[6];
+				sprintf(partref, "rom%d", partno);
+				smart_initialize(MTD_ROMFS, mtd_part, partref);
+			} else
+#endif
 			{
 			}
 


### PR DESCRIPTION
With this fix ROM partition will be handled.
To test it:
1. In os/.config add line:
  `CONFIG_FS_ROMFS=y`
2. Adjust partitions, eg:
  ```
CONFIG_ARTIK053_FLASH_PART_LIST="16,48,192,32,512,2400,1536,1536,1000,400,8,512,"
CONFIG_ARTIK053_FLASH_PART_TYPE="none,ftl,none,none,none,none,none,ftl,smartfs,romfs,config,none,"
CONFIG_ARTIK053_FLASH_PART_NAME="bl1,sssro,bl2,sssfw,wlanfw,os,factory,ota,user,rom,nvram,sssrw,"
```
above lines change size of main user partition from 1400 * 1KB to 1000 * 1KB
and add new 400 * 1KB partition. Type is romfs.
3. call make to build image
4. prepare ROM image using genromfs
  `genromfs -f bin/rom.img -d /path/to/rom_fs/folder -V "NuttXBootVol"`
5. in openocd/partition_map.cfg add line corresponding with point 2
 ```
user	{ "USER R/W"		0x04620000	0x000FA000  0 }
rom  	{ "ROM FS"  		0x0471A000	0x00064000  0 }
```
6. flash os & rom
 ```
flash_write os     ../bin/tinyara_head.bin;       \
flash_write rom    ../bin/rom.img;       \
```
7. mount on device
  `mount -t romfs /dev/smart4rom9 /rom`