### PR TITLE
pthread_setcancelstate.c : Change g_readytorun.head to this_task()

### DIFF
--- a/os/kernel/pthread/pthread_setcancelstate.c
+++ b/os/kernel/pthread/pthread_setcancelstate.c
@@ -93,7 +93,7 @@
 
 int pthread_setcancelstate(int state, FAR int *oldstate)
 {
-	struct tcb_s *tcb = (struct tcb_s *)g_readytorun.head;
+	FAR struct tcb_s *tcb = this_task();
 	int ret = OK;
 
 	trace_begin(TTRACE_TAG_TASK, "pthread_setcancelstate");


### PR DESCRIPTION
This change is required to support the SMP feature in future.

Signed-off-by: pradeep.ns <pradeep.ns@samsung.com>