### PR TITLE
Changes format of function for clean up in tc macros and add new tc macro

### DIFF
--- a/apps/examples/testcase/le_tc/filesystem/fs_main.c
+++ b/apps/examples/testcase/le_tc/filesystem/fs_main.c
@@ -95,19 +95,6 @@
 
 #define LONG_FILE_LOOP_COUNT 24
 
-/* Error message for CLEANUP MACRO */
-#define ERROR_MSG_BAD_FD "wrong fd value"
-
-#define ERROR_MSG_BAD_SIZE "wrong size"
-
-#define ERROR_MSG_DIFFRENT_CONTENTS "diffrent contents"
-
-#define ERROR_MSG_DIFFRENT_FLAG "diffrent flag"
-
-#define ERROR_MSG_OP_FAILED "operation failed"
-
-#define ERROR_MSG_NEGATIVE_OP_FAILED "operation failed with invalid arguements"
-
 #if defined(CONFIG_PIPES) && (CONFIG_DEV_PIPE_SIZE > 11)
 #define FIFO_FILE_PATH "/dev/fifo_test"
 
@@ -251,7 +238,7 @@ static void fs_vfs_open_tc(void)
 
 	/* Nagative case with invalid argument, not existing pathname. It will return ERROR */
 	fd = open(VFS_INVALID_FILE_PATH, O_WROK);
-	TC_ASSERT_LT_CLEANUP("open", fd, 0, ERROR_MSG_NEGATIVE_OP_FAILED, close(fd));
+	TC_ASSERT_LT_CLEANUP("open", fd, 0, close(fd));
 
 	TC_SUCCESS_RESULT();
 }
@@ -279,7 +266,7 @@ static void fs_vfs_write_tc(void)
 	fd = open(VFS_FILE_PATH, O_RDONLY);
 	TC_ASSERT_GEQ("open", fd, 0);
 	ret = write(fd, buf, sizeof(buf));
-	TC_ASSERT_LT_CLEANUP("write", ret, 0, ERROR_MSG_NEGATIVE_OP_FAILED, close(fd));
+	TC_ASSERT_LT_CLEANUP("write", ret, 0, close(fd));
 	close(fd);
 
 	/* Nagative case with invalid argument, fd. It will return ERROR */
@@ -315,7 +302,7 @@ static void fs_vfs_read_tc(void)
 	TC_ASSERT_GEQ("open", fd, 0);
 	memset(buf, 0, sizeof(buf));
 	ret = read(fd, buf, sizeof(buf));
-	TC_ASSERT_LT_CLEANUP("read", ret, 0, ERROR_MSG_NEGATIVE_OP_FAILED, close(fd));
+	TC_ASSERT_LT_CLEANUP("read", ret, 0, close(fd));
 	close(fd);
 
 	/* Nagative case with invalid argument, fd. It will return ERROR */
@@ -367,10 +354,10 @@ static void fs_vfs_dup_tc(void)
 
 	len = strlen(str1);
 	ret = write(fd1, str1, len);
-	TC_ASSERT_EQ_CLEANUP("write", ret, len, ERROR_MSG_BAD_SIZE, close(fd1));
+	TC_ASSERT_EQ_CLEANUP("write", ret, len, close(fd1));
 
 	fd2 = dup(fd1);
-	TC_ASSERT_GEQ_CLEANUP("dup", fd2, 0, ERROR_MSG_OP_FAILED,  close(fd1));
+	TC_ASSERT_GEQ_CLEANUP("dup", fd2, 0,  close(fd1));
 
 	len = strlen(str2);
 	ret = write(fd2, str2, strlen(str2));
@@ -384,8 +371,8 @@ static void fs_vfs_dup_tc(void)
 	len = strlen(str1);
 	ret = read(fd1, buf, len);
 
-	TC_ASSERT_GT_CLEANUP("read", ret, 0, ERROR_MSG_BAD_SIZE, close(fd1));
-	TC_ASSERT_EQ_CLEANUP("read", strcmp(buf, VFS_TEST_CONTENTS_1), 0, ERROR_MSG_DIFFRENT_CONTENTS, close(fd1));
+	TC_ASSERT_GT_CLEANUP("read", ret, 0, close(fd1));
+	TC_ASSERT_EQ_CLEANUP("read", strcmp(buf, VFS_TEST_CONTENTS_1), 0, close(fd1));
 
 	memset(buf, 0, sizeof(buf));
 	len = strlen(str2);
@@ -438,12 +425,12 @@ static void fs_vfs_dup2_tc(void)
 
 	/* now fd1 points fd2 */
 	ret = dup2(fd2, fd1);
-	TC_ASSERT_GEQ_CLEANUP("dup2", ret, 0, ERROR_MSG_BAD_FD, close(fd2));
+	TC_ASSERT_GEQ_CLEANUP("dup2", ret, 0, close(fd2));
 
 	len = strlen(VFS_TEST_CONTENTS_3);
 	ret = write(fd1, str, len);
 	close(fd1);
-	TC_ASSERT_EQ_CLEANUP("write", ret, len, ERROR_MSG_BAD_SIZE, close(fd2));
+	TC_ASSERT_EQ_CLEANUP("write", ret, len, close(fd2));
 	close(fd2);
 
 	fd2 = open(filename2, O_RDONLY);
@@ -457,7 +444,7 @@ static void fs_vfs_dup2_tc(void)
 
 	/* Nagative case with invalid argument, invalid fd. It will return ERROR */
 	ret = dup2(CONFIG_NFILE_DESCRIPTORS + CONFIG_NSOCKET_DESCRIPTORS, fd1);
-	TC_ASSERT_LT_CLEANUP("dup2", fd1, 0, ERROR_MSG_NEGATIVE_OP_FAILED, close(fd1));
+	TC_ASSERT_LT_CLEANUP("dup2", fd1, 0, close(fd1));
 	TC_ASSERT_EQ("dup2", ret, ERROR);
 
 	TC_SUCCESS_RESULT();
@@ -482,10 +469,10 @@ static void fs_vfs_fsync_tc(void)
 
 	len = strlen(str);
 	ret = write(fd, str, len);
-	TC_ASSERT_EQ_CLEANUP("write", ret, len, ERROR_MSG_BAD_SIZE, close(fd));
+	TC_ASSERT_EQ_CLEANUP("write", ret, len, close(fd));
 
 	ret = fsync(fd);
-	TC_ASSERT_GEQ_CLEANUP("fsync", ret, 0, ERROR_MSG_OP_FAILED, close(fd));
+	TC_ASSERT_GEQ_CLEANUP("fsync", ret, 0, close(fd));
 	close(fd);
 
 	/* Nagative case with invalid argument, no write access. It will return ERROR */
@@ -493,12 +480,12 @@ static void fs_vfs_fsync_tc(void)
 	TC_ASSERT_GEQ("open", fd, 0);
 
 	ret = fsync(fd);
-	TC_ASSERT_EQ_CLEANUP("fsync", ret, ERROR, ERROR_MSG_NEGATIVE_OP_FAILED, close(fd));
+	TC_ASSERT_EQ_CLEANUP("fsync", ret, ERROR, close(fd));
 	close(fd);
 
 	/* Nagative case with invalid argument, fd. It will return ERROR */
 	ret = fsync(CONFIG_NFILE_DESCRIPTORS);
-	TC_ASSERT_EQ_CLEANUP("fsync", ret, ERROR, ERROR_MSG_NEGATIVE_OP_FAILED, close(fd));
+	TC_ASSERT_EQ_CLEANUP("fsync", ret, ERROR, close(fd));
 
 	TC_SUCCESS_RESULT();
 }
@@ -521,7 +508,7 @@ static void fs_vfs_lseek_tc(void)
 	TC_ASSERT_GEQ("open", fd, 0);
 
 	ret = lseek(fd, 5, SEEK_SET);
-	TC_ASSERT_EQ_CLEANUP("lseek", ret, 5, ERROR_MSG_OP_FAILED, close(fd));
+	TC_ASSERT_EQ_CLEANUP("lseek", ret, 5, close(fd));
 
 	memset(buf, 0, sizeof(buf));
 	ret = read(fd, buf, sizeof(buf));
@@ -730,10 +717,10 @@ static void fs_vfs_seekdir_tc(void)
 
 	offset = 2;
 	seekdir(dirp, offset);
-	TC_ASSERT_CLEANUP("seekdir", dirp, ERROR_MSG_OP_FAILED, closedir(dirp));
+	TC_ASSERT_CLEANUP("seekdir", dirp, closedir(dirp));
 	dirent = readdir(dirp);
-	TC_ASSERT_CLEANUP("readdir", dirent, ERROR_MSG_OP_FAILED, closedir(dirp));
-	TC_ASSERT_EQ_CLEANUP("readdir", dirent->d_type, DTYPE_DIRECTORY, ERROR_MSG_OP_FAILED, closedir(dirp));
+	TC_ASSERT_CLEANUP("readdir", dirent, closedir(dirp));
+	TC_ASSERT_EQ_CLEANUP("readdir", dirent->d_type, DTYPE_DIRECTORY, closedir(dirp));
 
 	ret = closedir(dirp);
 	TC_ASSERT_EQ("closedir", ret, OK);
@@ -795,9 +782,9 @@ static void fs_libc_dirent_telldir_tc(void)
 
 	offset = 2;
 	seekdir(dirp, offset);
-	TC_ASSERT_CLEANUP("seekdir", dirp, ERROR_MSG_OP_FAILED, closedir(dirp));
+	TC_ASSERT_CLEANUP("seekdir", dirp, closedir(dirp));
 	res = telldir(dirp);
-	TC_ASSERT_EQ_CLEANUP("telldir", res, offset, ERROR_MSG_OP_FAILED, closedir(dirp));
+	TC_ASSERT_EQ_CLEANUP("telldir", res, offset, closedir(dirp));
 	ret = closedir(dirp);
 	TC_ASSERT_EQ("closedir", ret, OK);
 
@@ -970,7 +957,7 @@ static void fs_vfs_mkfifo_tc(void)
 	TC_ASSERT_GEQ("open", fd, 0);
 
 	ret = pthread_create(&tid, NULL, (pthread_startroutine_t)mkfifo_test_listener, NULL);
-	TC_ASSERT_EQ_CLEANUP("pthread_create", ret, 0, ERROR_MSG_OP_FAILED, close(fd));
+	TC_ASSERT_EQ_CLEANUP("pthread_create", ret, 0, close(fd));
 
 	size = strlen(FIFO_DATA) + 2;
 	count = 1;
@@ -980,7 +967,7 @@ static void fs_vfs_mkfifo_tc(void)
 		}
 		snprintf(buf, size, "%s%d\0", FIFO_DATA, count);
 		ret = write(fd, buf, size);
-		TC_ASSERT_GT_CLEANUP("write", ret, 0, ERROR_MSG_BAD_SIZE, goto errout);
+		TC_ASSERT_GT_CLEANUP("write", ret, 0, goto errout);
 		count++;
 		sleep(5);
 	}
@@ -1016,11 +1003,11 @@ static void fs_vfs_sendfile_tc(void)
 	TC_ASSERT_GEQ("open", fd1, 0);
 
 	ret = stat(src_file, &st);
-	TC_ASSERT_EQ_CLEANUP("stat", ret, OK, ERROR_MSG_OP_FAILED, close(fd1));
+	TC_ASSERT_EQ_CLEANUP("stat", ret, OK, close(fd1));
 
 	size = st.st_size;
 	fd2 = open(dest_file, O_WRONLY | O_CREAT);
-	TC_ASSERT_GEQ_CLEANUP("open", fd2, 0, ERROR_MSG_BAD_FD, close(fd1));
+	TC_ASSERT_GEQ_CLEANUP("open", fd2, 0, close(fd1));
 
 	ret = sendfile(fd2, fd1, 0, size);
 	close(fd1);
@@ -1137,7 +1124,7 @@ static void fs_vfs_select_tc(void)
 		tv.tv_sec = 5;
 		tv.tv_usec = 0;
 	}
-	TC_ASSERT_NEQ_CLEANUP("select", errcnt, VFS_LOOP_COUNT, ERROR_MSG_OP_FAILED, FD_CLR(STDIN_FILENO, &readfds));
+	TC_ASSERT_NEQ_CLEANUP("select", errcnt, VFS_LOOP_COUNT, FD_CLR(STDIN_FILENO, &readfds));
 	TC_SUCCESS_RESULT();
 }
 #endif
@@ -1222,14 +1209,14 @@ static void libc_stdio_fdopen_tc(void)
 	TC_ASSERT_GEQ("open", fd, 0);
 
 	fp = fdopen(fd, "r");
-	TC_ASSERT_CLEANUP("fdopen", fp, ERROR_MSG_OP_FAILED, close(fd));
+	TC_ASSERT_CLEANUP("fdopen", fp, close(fd));
 	close(fd);
-	TC_ASSERT_EQ_CLEANUP("fdopen", fp->fs_oflags, O_RDONLY, ERROR_MSG_DIFFRENT_FLAG, fclose(fp));
+	TC_ASSERT_EQ_CLEANUP("fdopen", fp->fs_oflags, O_RDONLY, fclose(fp));
 	fclose(fp);
 
 	/* Nagative case with invalid argument, negative fd value. It will return NULL */
 	fp = fdopen(-1, "r");
-	TC_ASSERT_EQ_CLEANUP("fdopen", fp, NULL, ERROR_MSG_NEGATIVE_OP_FAILED, fclose(fp));
+	TC_ASSERT_EQ_CLEANUP("fdopen", fp, NULL, fclose(fp));
 
 	TC_SUCCESS_RESULT();
 }
@@ -1265,25 +1252,25 @@ static void libc_stdio_fopen_tc(void)
 
 	/* Nagative cases with invalid mode. It will return NULL */
 	fp = fopen(filename, "b");
-	TC_ASSERT_EQ_CLEANUP("fopen", fp, NULL, ERROR_MSG_NEGATIVE_OP_FAILED, fclose(fp));
+	TC_ASSERT_EQ_CLEANUP("fopen", fp, NULL, fclose(fp));
 
 	fp = fopen(filename, "x");
-	TC_ASSERT_EQ_CLEANUP("fopen", fp, NULL, ERROR_MSG_NEGATIVE_OP_FAILED, fclose(fp));
+	TC_ASSERT_EQ_CLEANUP("fopen", fp, NULL, fclose(fp));
 
 	fp = fopen(filename, "z");
-	TC_ASSERT_EQ_CLEANUP("fopen", fp, NULL, ERROR_MSG_NEGATIVE_OP_FAILED, fclose(fp));
+	TC_ASSERT_EQ_CLEANUP("fopen", fp, NULL, fclose(fp));
 
 	fp = fopen(filename, "+");
-	TC_ASSERT_EQ_CLEANUP("fopen", fp, NULL, ERROR_MSG_NEGATIVE_OP_FAILED, fclose(fp));
+	TC_ASSERT_EQ_CLEANUP("fopen", fp, NULL, fclose(fp));
 
 	fp = fopen(filename, "rw");
-	TC_ASSERT_EQ_CLEANUP("fopen", fp, NULL, ERROR_MSG_NEGATIVE_OP_FAILED, fclose(fp));
+	TC_ASSERT_EQ_CLEANUP("fopen", fp, NULL, fclose(fp));
 
 	fp = fopen(filename, "wr");
-	TC_ASSERT_EQ_CLEANUP("fopen", fp, NULL, ERROR_MSG_NEGATIVE_OP_FAILED, fclose(fp));
+	TC_ASSERT_EQ_CLEANUP("fopen", fp, NULL, fclose(fp));
 
 	fp = fopen(filename, "wa");
-	TC_ASSERT_EQ_CLEANUP("fopen", fp, NULL, ERROR_MSG_NEGATIVE_OP_FAILED, fclose(fp));
+	TC_ASSERT_EQ_CLEANUP("fopen", fp, NULL, fclose(fp));
 
 	TC_SUCCESS_RESULT();
 }
@@ -1325,10 +1312,10 @@ static void libc_stdio_fputs_tc(void)
 
 	fp = fopen(filename, "w");
 	TC_ASSERT("fopen", fp);
-	TC_ASSERT_EQ_CLEANUP("fputs", fputs(str, fp), strlen(str), ERROR_MSG_OP_FAILED, fclose(fp));
+	TC_ASSERT_EQ_CLEANUP("fputs", fputs(str, fp), strlen(str), fclose(fp));
 
 	/* Nagative case with invalid argument, NULL stream. It will return EOF */
-	TC_ASSERT_EQ_CLEANUP("fputs", fputs(NULL, fp), EOF, ERROR_MSG_NEGATIVE_OP_FAILED, fclose(fp));
+	TC_ASSERT_EQ_CLEANUP("fputs", fputs(NULL, fp), EOF, fclose(fp));
 
 	fclose(fp);
 	TC_SUCCESS_RESULT();
@@ -1352,11 +1339,11 @@ static void libc_stdio_fgets_tc(void)
 	TC_ASSERT("fopen", fp);
 
 	memset(buf, 0, sizeof(buf));
-	TC_ASSERT_CLEANUP("fgets", fgets(buf, 20, fp), ERROR_MSG_OP_FAILED, fclose(fp));
-	TC_ASSERT_EQ_CLEANUP("fgets", strcmp(buf, VFS_TEST_CONTENTS_1), 0, ERROR_MSG_DIFFRENT_CONTENTS, fclose(fp));
+	TC_ASSERT_CLEANUP("fgets", fgets(buf, 20, fp), fclose(fp));
+	TC_ASSERT_EQ_CLEANUP("fgets", strcmp(buf, VFS_TEST_CONTENTS_1), 0, fclose(fp));
 
 	/* Nagative case with invalid argument, negative buffer size. It will return NULL */
-	TC_ASSERT_EQ_CLEANUP("fgets", fgets(buf, -1, fp), NULL, ERROR_MSG_NEGATIVE_OP_FAILED, fclose(fp));
+	TC_ASSERT_EQ_CLEANUP("fgets", fgets(buf, -1, fp), NULL, fclose(fp));
 	fclose(fp);
 	TC_SUCCESS_RESULT();
 }
@@ -1380,10 +1367,10 @@ static void libc_stdio_fseek_tc(void)
 	TC_ASSERT("fopen", fp);
 
 	ret = fseek(fp, 5, SEEK_SET);
-	TC_ASSERT_EQ_CLEANUP("fseek", ret, OK, ERROR_MSG_OP_FAILED, fclose(fp));
+	TC_ASSERT_EQ_CLEANUP("fseek", ret, OK, fclose(fp));
 
 	memset(buf, 0, sizeof(buf));
-	TC_ASSERT_CLEANUP("fgets", fgets(buf, 20, fp), ERROR_MSG_OP_FAILED, fclose(fp));
+	TC_ASSERT_CLEANUP("fgets", fgets(buf, 20, fp), fclose(fp));
 	fclose(fp);
 	TC_ASSERT_EQ("fgets", strcmp(buf, "IS VFS TEST 1"), 0);
 
@@ -1412,7 +1399,7 @@ static void libc_stdio_ftell_tc(void)
 	TC_ASSERT("fopen", fp);
 
 	ret = fseek(fp, 5, SEEK_SET);
-	TC_ASSERT_EQ_CLEANUP("fseek", ret, OK, ERROR_MSG_OP_FAILED, fclose(fp));
+	TC_ASSERT_EQ_CLEANUP("fseek", ret, OK, fclose(fp));
 
 	ret = ftell(fp);
 	fclose(fp);
@@ -1498,17 +1485,17 @@ static void libc_stdio_fsetpos_tc(void)
 	TC_ASSERT("fopen", fp);
 
 	ret = fsetpos(fp, &pos);
-	TC_ASSERT_EQ_CLEANUP("fsetpos", ret, OK, ERROR_MSG_OP_FAILED, fclose(fp));
+	TC_ASSERT_EQ_CLEANUP("fsetpos", ret, OK, fclose(fp));
 
 	ch = fgetc(fp);
 
-	TC_ASSERT_NEQ_CLEANUP("fgetc", ch, EOF, ERROR_MSG_OP_FAILED, fclose(fp));
+	TC_ASSERT_NEQ_CLEANUP("fgetc", ch, EOF, fclose(fp));
 	/* 'S' is 4th position of "THIS IS VFS TEST 2" */
-	TC_ASSERT_EQ_CLEANUP("fgetc", ch, 'S', ERROR_MSG_OP_FAILED, fclose(fp));
+	TC_ASSERT_EQ_CLEANUP("fgetc", ch, 'S', fclose(fp));
 
 	/* Nagative case with invalid arguments, NULL position. It will return ERROR */
 	ret = fsetpos(fp, NULL);
-	TC_ASSERT_EQ_CLEANUP("fsetpos", ret, ERROR, ERROR_MSG_NEGATIVE_OP_FAILED, fclose(fp));
+	TC_ASSERT_EQ_CLEANUP("fsetpos", ret, ERROR, fclose(fp));
 	fclose(fp);
 
 	TC_SUCCESS_RESULT();
@@ -1533,7 +1520,7 @@ static void libc_stdio_fgetpos_tc(void)
 	TC_ASSERT("fopen", fp);
 
 	ret = fsetpos(fp, &pos);
-	TC_ASSERT_EQ_CLEANUP("fsetpos", ret, OK, ERROR_MSG_OP_FAILED, fclose(fp));
+	TC_ASSERT_EQ_CLEANUP("fsetpos", ret, OK, fclose(fp));
 
 	ret = fgetpos(fp, &pos);
 	fclose(fp);
@@ -1612,15 +1599,15 @@ static void libc_stdio_fwrite_tc(void)
 
 	len = strlen(VFS_TEST_CONTENTS_1);
 	ret = fwrite(VFS_TEST_CONTENTS_1, 1, len, fp);
-	TC_ASSERT_EQ_CLEANUP("fwrite", ret, len, ERROR_MSG_BAD_SIZE, fclose(fp));
+	TC_ASSERT_EQ_CLEANUP("fwrite", ret, len, fclose(fp));
 
 	len = strlen(VFS_TEST_CONTENTS_2);
 	ret = fwrite(VFS_TEST_CONTENTS_2, 1, len, fp);
-	TC_ASSERT_EQ_CLEANUP("fwrite", ret, len, ERROR_MSG_BAD_SIZE, fclose(fp));
+	TC_ASSERT_EQ_CLEANUP("fwrite", ret, len, fclose(fp));
 
 	len = strlen(VFS_TEST_CONTENTS_3);
 	ret = fwrite(VFS_TEST_CONTENTS_3, 1, len, fp);
-	TC_ASSERT_EQ_CLEANUP("fwrite", ret, len, ERROR_MSG_BAD_SIZE, fclose(fp));
+	TC_ASSERT_EQ_CLEANUP("fwrite", ret, len, fclose(fp));
 
 	fclose(fp);
 	TC_SUCCESS_RESULT();
@@ -1647,20 +1634,20 @@ static void libc_stdio_fread_tc(void)
 	len = strlen(VFS_TEST_CONTENTS_1);
 	memset(buf, 0, sizeof(buf));
 	ret = fread(buf, 1, len, fp);
-	TC_ASSERT_EQ_CLEANUP("fread", ret, len, ERROR_MSG_BAD_SIZE, fclose(fp));
-	TC_ASSERT_EQ_CLEANUP("fread", strcmp(buf, VFS_TEST_CONTENTS_1), 0, ERROR_MSG_DIFFRENT_CONTENTS, fclose(fp));
+	TC_ASSERT_EQ_CLEANUP("fread", ret, len, fclose(fp));
+	TC_ASSERT_EQ_CLEANUP("fread", strcmp(buf, VFS_TEST_CONTENTS_1), 0, fclose(fp));
 
 	len = strlen(VFS_TEST_CONTENTS_2);
 	memset(buf, 0, sizeof(buf));
 	ret = fread(buf, 1, len, fp);
-	TC_ASSERT_EQ_CLEANUP("fread", ret, len, ERROR_MSG_BAD_SIZE, fclose(fp));
-	TC_ASSERT_EQ_CLEANUP("fread", strcmp(buf, VFS_TEST_CONTENTS_2), 0, ERROR_MSG_DIFFRENT_CONTENTS, fclose(fp));
+	TC_ASSERT_EQ_CLEANUP("fread", ret, len, fclose(fp));
+	TC_ASSERT_EQ_CLEANUP("fread", strcmp(buf, VFS_TEST_CONTENTS_2), 0, fclose(fp));
 
 	len = strlen(VFS_TEST_CONTENTS_3);
 	memset(buf, 0, sizeof(buf));
 	ret = fread(buf, 1, len, fp);
-	TC_ASSERT_EQ_CLEANUP("fread", ret, len, ERROR_MSG_BAD_SIZE, fclose(fp));
-	TC_ASSERT_EQ_CLEANUP("fread", strcmp(buf, VFS_TEST_CONTENTS_3), 0, ERROR_MSG_DIFFRENT_CONTENTS, fclose(fp));
+	TC_ASSERT_EQ_CLEANUP("fread", ret, len, fclose(fp));
+	TC_ASSERT_EQ_CLEANUP("fread", strcmp(buf, VFS_TEST_CONTENTS_3), 0, fclose(fp));
 
 	fclose(fp);
 	TC_SUCCESS_RESULT();
@@ -1684,7 +1671,7 @@ static void libc_stdio_ferror_tc(void)
 	TC_ASSERT("fopen", fp);
 
 	ret = fputc(32, fp);
-	TC_ASSERT_EQ_CLEANUP("fputc", ret, EOF, ERROR_MSG_OP_FAILED, fclose(fp));
+	TC_ASSERT_EQ_CLEANUP("fputc", ret, EOF, fclose(fp));
 
 	ret = ferror(fp);
 	fclose(fp);
@@ -1712,10 +1699,10 @@ static void libc_stdio_clearerr_tc(void)
 	TC_ASSERT("fopen", fp);
 
 	ret = fputc(32, fp);
-	TC_ASSERT_EQ_CLEANUP("fputc", ret, EOF, ERROR_MSG_OP_FAILED, fclose(fp));
+	TC_ASSERT_EQ_CLEANUP("fputc", ret, EOF, fclose(fp));
 
 	ret = ferror(fp);
-	TC_ASSERT_NEQ_CLEANUP("ferror", ret, OK, ERROR_MSG_OP_FAILED, fclose(fp));
+	TC_ASSERT_NEQ_CLEANUP("ferror", ret, OK, fclose(fp));
 
 	clearerr(fp);
 
@@ -1815,10 +1802,10 @@ static void libc_stdio_ungetc_tc(void)
 	TC_ASSERT("fopen", fp);
 
 	ch1 = fgetc(fp);
-	TC_ASSERT_NEQ_CLEANUP("fgetc", ch1, EOF, ERROR_MSG_DIFFRENT_CONTENTS, fclose(fp));
+	TC_ASSERT_NEQ_CLEANUP("fgetc", ch1, EOF, fclose(fp));
 
 	ret = ungetc(64, fp);
-	TC_ASSERT_NEQ_CLEANUP("ungetc", ret, EOF, ERROR_MSG_OP_FAILED, fclose(fp));
+	TC_ASSERT_NEQ_CLEANUP("ungetc", ret, EOF, fclose(fp));
 
 	ch2 = fgetc(fp);
 	fclose(fp);

--- a/apps/examples/testcase/le_tc/kernel/tc_environ.c
+++ b/apps/examples/testcase/le_tc/kernel/tc_environ.c
@@ -55,22 +55,22 @@ static void tc_environ_setenv_getenv_unsetenv(void)
 	char *psz_getvalue = NULL;
 
 	ret_chk = setenv(psz_name, psz_value, overwrite_num);
-	TC_ASSERT_EQ_CLEANUP("setenv", ret_chk, OK, get_errno(), clearenv());
+	TC_ASSERT_EQ_CLEANUP("setenv", ret_chk, OK, clearenv());
 
 	psz_getvalue = getenv(psz_name);
-	TC_ASSERT_EQ_CLEANUP("getenv", strcmp(psz_getvalue, psz_value), 0, get_errno(), clearenv());
+	TC_ASSERT_EQ_CLEANUP("getenv", strcmp(psz_getvalue, psz_value), 0, clearenv());
 
 	/* with overwrite_num = 0, psz_value should not be updated */
 
 	psz_value = "pqr";
 	overwrite_num = 0;
 	ret_chk = setenv(psz_name, psz_value, overwrite_num);
-	TC_ASSERT_EQ_CLEANUP("setenv", ret_chk, OK, get_errno(), clearenv());
+	TC_ASSERT_EQ_CLEANUP("setenv", ret_chk, OK, clearenv());
 
 	/* set and get value should not be equal as overwrite is 0 */
 
 	psz_getvalue = getenv(psz_name);
-	TC_ASSERT_NEQ_CLEANUP("getenv", strcmp(psz_getvalue, psz_value), 0, get_errno(), clearenv());
+	TC_ASSERT_NEQ_CLEANUP("getenv", strcmp(psz_getvalue, psz_value), 0, clearenv());
 
 	/* random value, getenv should fail */
 

--- a/apps/examples/testcase/le_tc/kernel/tc_group.c
+++ b/apps/examples/testcase/le_tc/kernel/tc_group.c
@@ -80,7 +80,6 @@ static void tc_group_group_add_find_remove_child(void)
 	TC_ASSERT_EQ_CLEANUP("group_removechild",
 						 child_returned,
 						 NULL,
-						 get_errno(),
 						 (group_removechild(group, child_pid), group_freechild(child)));
 
 	group_freechild(child);

--- a/apps/examples/testcase/le_tc/kernel/tc_libc_mqueue.c
+++ b/apps/examples/testcase/le_tc/kernel/tc_libc_mqueue.c
@@ -37,17 +37,17 @@ static void tc_libc_mqueue_mq_getattr(void)
 	TC_ASSERT_NEQ("mq_open", mqdes, (mqd_t)ERROR);
 
 	ret_chk = mq_getattr(NULL, &mq_stat);
-	TC_ASSERT_EQ_CLEANUP("mq_getattr", ret_chk, ERROR, "not ERROR", goto errout);
+	TC_ASSERT_EQ_CLEANUP("mq_getattr", ret_chk, ERROR, goto errout);
 
 	ret_chk = mq_getattr(mqdes, NULL);
-	TC_ASSERT_EQ_CLEANUP("mq_getattr", ret_chk, ERROR, "not ERROR", goto errout);
+	TC_ASSERT_EQ_CLEANUP("mq_getattr", ret_chk, ERROR, goto errout);
 
 	ret_chk = mq_getattr(mqdes, &mq_stat);
-	TC_ASSERT_EQ_CLEANUP("mq_getattr", ret_chk, OK, "not OK", goto errout);
-	TC_ASSERT_EQ_CLEANUP("mq_getattr", mq_stat.mq_maxmsg, mqdes->msgq->maxmsgs, "ERROR", goto errout);
-	TC_ASSERT_EQ_CLEANUP("mq_getattr", mq_stat.mq_msgsize, mqdes->msgq->maxmsgsize, "ERROR", goto errout);
-	TC_ASSERT_EQ_CLEANUP("mq_getattr", mq_stat.mq_flags, mqdes->oflags, "ERROR", goto errout);
-	TC_ASSERT_EQ_CLEANUP("mq_getattr", mq_stat.mq_curmsgs, (size_t)mqdes->msgq->nmsgs, "ERROR", goto errout);
+	TC_ASSERT_EQ_CLEANUP("mq_getattr", ret_chk, OK, goto errout);
+	TC_ASSERT_EQ_CLEANUP("mq_getattr", mq_stat.mq_maxmsg, mqdes->msgq->maxmsgs, goto errout);
+	TC_ASSERT_EQ_CLEANUP("mq_getattr", mq_stat.mq_msgsize, mqdes->msgq->maxmsgsize, goto errout);
+	TC_ASSERT_EQ_CLEANUP("mq_getattr", mq_stat.mq_flags, mqdes->oflags, goto errout);
+	TC_ASSERT_EQ_CLEANUP("mq_getattr", mq_stat.mq_curmsgs, (size_t)mqdes->msgq->nmsgs, goto errout);
 
 	mq_close(mqdes);
 	mq_unlink("mqgetattr");
@@ -70,26 +70,26 @@ static void tc_libc_mqueue_mq_setattr(void)
 	TC_ASSERT_NEQ("mq_open", mqdes, (mqd_t)ERROR);
 
 	ret_chk = mq_getattr(mqdes, &mq_stat);
-	TC_ASSERT_EQ_CLEANUP("mq_getattr", ret_chk, OK, "not OK", goto errout);
+	TC_ASSERT_EQ_CLEANUP("mq_getattr", ret_chk, OK, goto errout);
 
 	ret_chk = mq_setattr(NULL, &mq_stat, &oldstat);
-	TC_ASSERT_EQ_CLEANUP("mq_setattr", ret_chk, ERROR, "not ERROR", goto errout);
+	TC_ASSERT_EQ_CLEANUP("mq_setattr", ret_chk, ERROR, goto errout);
 
 	ret_chk = mq_setattr(mqdes, NULL, &oldstat);
-	TC_ASSERT_EQ_CLEANUP("mq_setattr", ret_chk, ERROR, "not ERROR", goto errout);
+	TC_ASSERT_EQ_CLEANUP("mq_setattr", ret_chk, ERROR, goto errout);
 
 	if (mq_stat.mq_flags & O_NONBLOCK) {
 		mq_stat.mq_flags = mq_stat.mq_flags & (~O_NONBLOCK);
 		ret_chk = mq_setattr(mqdes, &mq_stat, &oldstat);
-		TC_ASSERT_EQ_CLEANUP("mq_setattr", ret_chk, OK, "not OK", goto errout);
-		TC_ASSERT_EQ_CLEANUP("mq_setattr", oldstat.mq_flags & O_NONBLOCK, O_NONBLOCK, "ERROR", goto errout);
-		TC_ASSERT_EQ_CLEANUP("mq_setattr", mqdes->oflags & O_NONBLOCK, 0, "ERROR", goto errout);
+		TC_ASSERT_EQ_CLEANUP("mq_setattr", ret_chk, OK, goto errout);
+		TC_ASSERT_EQ_CLEANUP("mq_setattr", oldstat.mq_flags & O_NONBLOCK, O_NONBLOCK, goto errout);
+		TC_ASSERT_EQ_CLEANUP("mq_setattr", mqdes->oflags & O_NONBLOCK, 0, goto errout);
 	} else {
 		mq_stat.mq_flags = mq_stat.mq_flags | O_NONBLOCK;
 		ret_chk = mq_setattr(mqdes, &mq_stat, &oldstat);
-		TC_ASSERT_EQ_CLEANUP("mq_setattr", ret_chk, OK, "not OK", goto errout);
-		TC_ASSERT_EQ_CLEANUP("mq_setattr", oldstat.mq_flags & O_NONBLOCK, 0, "ERROR", goto errout);
-		TC_ASSERT_EQ_CLEANUP("mq_setattr", mqdes->oflags & O_NONBLOCK, O_NONBLOCK, "ERROR", goto errout);
+		TC_ASSERT_EQ_CLEANUP("mq_setattr", ret_chk, OK, goto errout);
+		TC_ASSERT_EQ_CLEANUP("mq_setattr", oldstat.mq_flags & O_NONBLOCK, 0, goto errout);
+		TC_ASSERT_EQ_CLEANUP("mq_setattr", mqdes->oflags & O_NONBLOCK, O_NONBLOCK, goto errout);
 	}
 
 	mq_close(mqdes);

--- a/apps/examples/testcase/le_tc/kernel/tc_libc_signal.c
+++ b/apps/examples/testcase/le_tc/kernel/tc_libc_signal.c
@@ -224,7 +224,7 @@ static void tc_libc_signal_sigpause(void)
 	st_timer_spec_val.it_value.tv_sec = 2;
 
 	ret_chk = timer_settime(timer_id, 0, &st_timer_spec_val, NULL);
-	TC_ASSERT_NEQ_CLEANUP("timer_settime", ret_chk, ERROR, errno, timer_delete(timer_id));
+	TC_ASSERT_EQ_ERROR_CLEANUP("timer_settime", ret_chk, OK, errno, timer_delete(timer_id));
 
 	printf("sigpause test : Before Pause\n");
 	ret_chk = sigpause(SIG1);

--- a/apps/examples/testcase/le_tc/kernel/tc_libc_stdio.c
+++ b/apps/examples/testcase/le_tc/kernel/tc_libc_stdio.c
@@ -99,11 +99,9 @@ static void tc_libc_stdio_avsprintf(const char *format, ...)
 	TC_ASSERT_NOT_NULL("avsprintf", buffer);
 	TC_ASSERT_EQ_CLEANUP("avsprintf",
 						 ret_chk, strlen(printable_chars),
-						 get_errno(),
 						 TC_FREE_MEMORY(buffer));
 	TC_ASSERT_EQ_CLEANUP("avsprintf",
 						 strcmp(printable_chars, buffer), 0,
-						 get_errno(),
 						 TC_FREE_MEMORY(buffer));
 
 	TC_FREE_MEMORY(buffer);
@@ -552,11 +550,9 @@ static void tc_libc_stdio_asprintf(void)
 	TC_ASSERT_NOT_NULL("asprintf", buffer);
 	TC_ASSERT_EQ_CLEANUP("asprintf",
 						 ret_chk, strlen(printable_chars),
-						 get_errno(),
 						 TC_FREE_MEMORY(buffer));
 	TC_ASSERT_EQ_CLEANUP("asprintf",
 						 strcmp(printable_chars, buffer), 0,
-						 get_errno(),
 						 TC_FREE_MEMORY(buffer));
 
 	TC_FREE_MEMORY(buffer);

--- a/apps/examples/testcase/le_tc/kernel/tc_libc_string.c
+++ b/apps/examples/testcase/le_tc/kernel/tc_libc_string.c
@@ -365,7 +365,6 @@ static void tc_libc_string_strdup(void)
 	TC_ASSERT_NOT_NULL("strdup", dest_arr);
 	TC_ASSERT_EQ_CLEANUP("strdup",
 						 strncmp(dest_arr, src, BUFF_SIZE), OK,
-						 get_errno(),
 						 TC_FREE_MEMORY(dest_arr));
 
 	TC_FREE_MEMORY(dest_arr);
@@ -542,7 +541,6 @@ static void tc_libc_string_strndup(void)
 	TC_ASSERT_NOT_NULL("strndup", dest_arr);
 	TC_ASSERT_EQ_CLEANUP("strndup",
 						 strncmp(dest_arr, src, BUFF_SIZE), 0,
-						 get_errno(),
 						 TC_FREE_MEMORY(dest_arr));
 
 	TC_FREE_MEMORY(dest_arr);

--- a/apps/examples/testcase/le_tc/kernel/tc_libc_unistd.c
+++ b/apps/examples/testcase/le_tc/kernel/tc_libc_unistd.c
@@ -37,7 +37,7 @@
 #define MSG_SIZE 30
 
 sem_t pipe_sem;
-int pipe_tc_chk;
+int pipe_tc_chk = OK;
 int pipe_fd[2];
 const char msg[MSG_SIZE + 1] = "012345678901234567890123456789";
 char pipe_buf[MSG_SIZE + 1];
@@ -200,14 +200,14 @@ static void tc_libc_unistd_pipe(void)
 
 	sem_init(&pipe_sem, 0, 0);
 	pid[0] = task_create("tx", 99, 1024, pipe_tx_func, NULL);
-	TC_ASSERT_GEQ_CLEANUP("task_create", pid[0], 0, get_errno(), goto cleanup_pipe);
+	TC_ASSERT_GEQ_CLEANUP("task_create", pid[0], 0, goto cleanup_pipe);
 
 	pid[1] = task_create("rx", 99, 1024, pipe_rx_func, NULL);
-	TC_ASSERT_GEQ_CLEANUP("task_create", pid[1], 0, get_errno(), goto cleanup_pipe);
+	TC_ASSERT_GEQ_CLEANUP("task_create", pid[1], 0, goto cleanup_pipe);
 
 	sem_wait(&pipe_sem);
 
-	TC_ASSERT_NEQ_CLEANUP("pipe", pipe_tc_chk, ERROR, get_errno(), goto cleanup_pipe);
+	TC_ASSERT_EQ_CLEANUP("pipe", pipe_tc_chk, OK, goto cleanup_pipe);
 
 	TC_SUCCESS_RESULT();
 

--- a/apps/examples/testcase/le_tc/kernel/tc_mqueue.c
+++ b/apps/examples/testcase/le_tc/kernel/tc_mqueue.c
@@ -532,12 +532,12 @@ static void tc_mqueue_mq_notify(void)
 	sa.sa_flags = 0;
 	sigaction(SIGUSR1, &sa, NULL);
 
-	TC_ASSERT_EQ_CLEANUP("mq_notify", mq_notify(mqdes, &notification), OK, get_errno(), {
+	TC_ASSERT_EQ_ERROR_CLEANUP("mq_notify", mq_notify(mqdes, &notification), OK, get_errno(), {
 		goto cleanup;
 	}
 						);
 
-	TC_ASSERT_NEQ_CLEANUP("mq_send", mq_send(mqdes, s_msg_ptr, 15, prio), ERROR, get_errno(), {
+	TC_ASSERT_EQ_CLEANUP("mq_send", mq_send(mqdes, s_msg_ptr, 15, prio), OK, {
 		goto cleanup;
 	}
 						 );
@@ -574,17 +574,13 @@ static void tc_mqueue_mq_unlink(void)
 	TC_ASSERT_NEQ("mq_open", mqdes, (mqd_t)-1);
 
 	ret = mq_unlink("mqunlink");
-	TC_ASSERT_EQ_CLEANUP("mq_unlink", ret, OK, get_errno(), {
+	TC_ASSERT_EQ_ERROR_CLEANUP("mq_unlink", ret, OK, get_errno(), {
 		mq_close(mqdes);
 	});
 
 	ret = mq_unlink("mqunlink");
-	TC_ASSERT_EQ_CLEANUP("mq_unlink", ret, ERROR, get_errno(), {
-		mq_close(mqdes);
-	});
-	TC_ASSERT_EQ_CLEANUP("mq_unlink", errno, ENOENT, get_errno(), {
-		mq_close(mqdes);
-	});
+	TC_ASSERT_EQ_CLEANUP("mq_unlink", ret, ERROR, mq_close(mqdes));
+	TC_ASSERT_EQ_CLEANUP("mq_unlink", errno, ENOENT, mq_close(mqdes));
 
 	mq_close(mqdes);
 	TC_SUCCESS_RESULT();

--- a/apps/examples/testcase/le_tc/kernel/tc_pthread.c
+++ b/apps/examples/testcase/le_tc/kernel/tc_pthread.c
@@ -641,8 +641,8 @@ static void tc_pthread_pthread_kill(void)
 
 	ret_chk = pthread_kill(g_thread1, SIGUSR1);
 	sleep(SEC_1);
-	TC_ASSERT_EQ_CLEANUP("pthread_kill", ret_chk, OK, get_errno(), pthread_detach(g_thread1));
-	TC_ASSERT_EQ_CLEANUP("pthread_kill", g_bpthreadcallback, true, get_errno(), pthread_detach(g_thread1));
+	TC_ASSERT_EQ_CLEANUP("pthread_kill", ret_chk, OK, pthread_detach(g_thread1));
+	TC_ASSERT_EQ_CLEANUP("pthread_kill", g_bpthreadcallback, true, pthread_detach(g_thread1));
 	pthread_join(g_thread1, NULL);
 
 	TC_SUCCESS_RESULT();
@@ -670,11 +670,11 @@ static void tc_pthread_pthread_cond_broadcast(void)
 	TC_ASSERT_EQ("pthread_mutex_init", ret_chk, OK);
 
 	ret_chk = pthread_cond_init(&g_cond, NULL);
-	TC_ASSERT_EQ_CLEANUP("pthread_cond_init", ret_chk, OK, get_errno(), pthread_mutex_destroy(&g_mutex));
+	TC_ASSERT_EQ_CLEANUP("pthread_cond_init", ret_chk, OK, pthread_mutex_destroy(&g_mutex));
 
 	for (ipthread_id = 0; ipthread_id < PTHREAD_CNT; ipthread_id++) {
 		ret_chk = pthread_create(&rgthread[ipthread_id], NULL, pthread_wait_callback, NULL);
-		TC_ASSERT_EQ_CLEANUP("pthread_create", ret_chk, OK, get_errno(), goto cleanup_cond);
+		TC_ASSERT_EQ_CLEANUP("pthread_create", ret_chk, OK, goto cleanup_cond);
 	}
 
 	/* To check all thread block conditional lock */
@@ -684,25 +684,25 @@ static void tc_pthread_pthread_cond_broadcast(void)
 
 	/* To make sure all waiter are currently block on pthread_cond_wait */
 	ret_chk = pthread_mutex_lock(&g_mutex);
-	TC_ASSERT_EQ_CLEANUP("pthread_mutex_lock", ret_chk, OK, get_errno(), goto cleanup_mutex);
+	TC_ASSERT_EQ_CLEANUP("pthread_mutex_lock", ret_chk, OK, goto cleanup_mutex);
 
 	ret_chk = pthread_mutex_unlock(&g_mutex);
-	TC_ASSERT_EQ_CLEANUP("pthread_mutex_unlock", ret_chk, OK, get_errno(), goto cleanup_mutex);
+	TC_ASSERT_EQ_CLEANUP("pthread_mutex_unlock", ret_chk, OK, goto cleanup_mutex);
 
 	ret_chk = pthread_cond_broadcast(&g_cond);
-	TC_ASSERT_EQ_CLEANUP("pthread_cond_broadcast", ret_chk, OK, get_errno(), goto cleanup_cond);
+	TC_ASSERT_EQ_CLEANUP("pthread_cond_broadcast", ret_chk, OK, goto cleanup_cond);
 
 	sleep(SEC_1);
-	TC_ASSERT_GEQ_CLEANUP("pthread_cond_broadcast", g_barrier_count_out, PTHREAD_CNT, get_errno(), goto cleanup_cond);
+	TC_ASSERT_GEQ_CLEANUP("pthread_cond_broadcast", g_barrier_count_out, PTHREAD_CNT, goto cleanup_cond);
 
 	/* Wait till terminate all thread */
 	for (ipthread_id = 0; ipthread_id < PTHREAD_CNT; ipthread_id++) {
 		ret_chk = pthread_join(rgthread[ipthread_id], NULL);
-		TC_ASSERT_EQ_CLEANUP("pthread_join", ret_chk, OK, get_errno(), goto cleanup_cond);
+		TC_ASSERT_EQ_CLEANUP("pthread_join", ret_chk, OK, goto cleanup_cond);
 	}
 
 	ret_chk = pthread_cond_destroy(&g_cond);
-	TC_ASSERT_EQ_CLEANUP("pthread_cond_destroy", ret_chk, OK, ret_chk, pthread_mutex_destroy(&g_mutex));
+	TC_ASSERT_EQ_CLEANUP("pthread_cond_destroy", ret_chk, OK, pthread_mutex_destroy(&g_mutex));
 
 	ret_chk = pthread_mutex_destroy(&g_mutex);
 	TC_ASSERT_EQ("pthread_mutex_destroy", ret_chk, OK);
@@ -784,21 +784,21 @@ static void tc_pthread_pthread_set_get_schedparam(void)
 	st_setparam.sched_priority = SCHED_PRIORITY;
 
 	ret_chk = pthread_create(&g_thread1, NULL, threadfunc_sched, NULL);
-	TC_ASSERT_EQ_CLEANUP("pthread_create", ret_chk, OK, errno, pthread_detach(g_thread1));
+	TC_ASSERT_EQ_CLEANUP("pthread_create", ret_chk, OK, pthread_detach(g_thread1));
 	sleep(SEC_2);
 
 	ret_chk = pthread_setschedparam(g_thread1, setpolicy, &st_setparam);
-	TC_ASSERT_EQ_CLEANUP("pthread_setschedparam", ret_chk, OK, errno, pthread_detach(g_thread1));
+	TC_ASSERT_EQ_CLEANUP("pthread_setschedparam", ret_chk, OK, pthread_detach(g_thread1));
 
 	sleep(SEC_1);
 
 	ret_chk = pthread_getschedparam(g_thread1, &getpolicy, &st_getparam);
-	TC_ASSERT_EQ_CLEANUP("pthread_getschedparam", ret_chk, OK, errno, pthread_detach(g_thread1));
-	TC_ASSERT_EQ_CLEANUP("pthread_getschedparam", getpolicy, setpolicy, errno, pthread_detach(g_thread1));
-	TC_ASSERT_EQ_CLEANUP("pthread_getschedparam", st_getparam.sched_priority, st_setparam.sched_priority, errno, pthread_detach(g_thread1));
+	TC_ASSERT_EQ_CLEANUP("pthread_getschedparam", ret_chk, OK, pthread_detach(g_thread1));
+	TC_ASSERT_EQ_CLEANUP("pthread_getschedparam", getpolicy, setpolicy, pthread_detach(g_thread1));
+	TC_ASSERT_EQ_CLEANUP("pthread_getschedparam", st_getparam.sched_priority, st_setparam.sched_priority, pthread_detach(g_thread1));
 
 	ret_chk = pthread_join(g_thread1, NULL);
-	TC_ASSERT_EQ_CLEANUP("pthread_join", ret_chk, OK, errno, pthread_detach(g_thread1));
+	TC_ASSERT_EQ_CLEANUP("pthread_join", ret_chk, OK, pthread_detach(g_thread1));
 
 	TC_SUCCESS_RESULT();
 }
@@ -828,14 +828,10 @@ static void tc_pthread_pthread_key_create_set_getspecific(void)
 	sleep(SEC_2);
 
 	ret_chk = pthread_create(&g_thread1, NULL, func_set_get_callback, NULL);
-	TC_ASSERT_EQ_CLEANUP("pthread_create", ret_chk, OK, errno, {
-		pthread_detach(g_thread1);
-	});
+	TC_ASSERT_EQ_CLEANUP("pthread_create", ret_chk, OK, pthread_detach(g_thread1));
 
 	ret_chk = pthread_join(g_thread1, NULL);
-	TC_ASSERT_EQ_CLEANUP("pthread_join", ret_chk, OK, errno, {
-		pthread_detach(g_thread1);
-	});
+	TC_ASSERT_EQ_CLEANUP("pthread_join", ret_chk, OK, pthread_detach(g_thread1));
 
 	TC_ASSERT_EQ("pthread_join", g_bpthreadcallback, true);
 
@@ -861,16 +857,12 @@ static void tc_pthread_pthread_cancel_setcancelstate(void)
 	g_bpthreadcallback = false;
 
 	ret_chk = pthread_create(&g_thread1, NULL, cancel_state_func, NULL);
-	TC_ASSERT_EQ_CLEANUP("pthread_create", ret_chk, OK, errno, {
-		pthread_detach(g_thread1);
-	});
+	TC_ASSERT_EQ_CLEANUP("pthread_create", ret_chk, OK, pthread_detach(g_thread1));
 
 	sleep(SEC_1);
 	/* this cancel request goes to pending if cancel is disabled */
 	ret_chk = pthread_cancel(g_thread1);
-	TC_ASSERT_EQ_CLEANUP("pthread_cancel", ret_chk, OK, errno, {
-		pthread_detach(g_thread1);
-	});
+	TC_ASSERT_EQ_CLEANUP("pthread_cancel", ret_chk, OK, pthread_detach(g_thread1));
 
 	sleep(SEC_3);
 	TC_ASSERT("pthread_cancel", g_bpthreadcallback);
@@ -989,14 +981,10 @@ static void tc_pthread_pthread_findjoininfo_destroyjoin(void)
 	g_bpthreadcallback = false;
 
 	ret_chk = pthread_create(&g_thread1, NULL, findjoininfo_callback, NULL);
-	TC_ASSERT_EQ_CLEANUP("pthread_create", ret_chk, OK, errno, {
-		pthread_detach(g_thread1);
-	});
+	TC_ASSERT_EQ_CLEANUP("pthread_create", ret_chk, OK, pthread_detach(g_thread1));
 
 	pthread_join(g_thread1, NULL);
-	TC_ASSERT_EQ_CLEANUP("pthread_join", g_bpthreadcallback, true, errno, {
-		pthread_detach(g_thread1);
-	});
+	TC_ASSERT_EQ_CLEANUP("pthread_join", g_bpthreadcallback, true, pthread_detach(g_thread1));
 
 	TC_SUCCESS_RESULT();
 }
@@ -1024,9 +1012,7 @@ static void tc_pthread_pthread_mutex_lock_unlock_trylock(void)
 	TC_ASSERT_EQ("pthread_mutex_lock", ret_chk, OK);
 
 	ret_chk = pthread_mutex_trylock(&g_mutex);
-	TC_ASSERT_EQ_CLEANUP("pthread_mutex_trylock", ret_chk, EBUSY, errno, {
-		pthread_mutex_unlock(&g_mutex);
-	});
+	TC_ASSERT_EQ_CLEANUP("pthread_mutex_trylock", ret_chk, EBUSY, pthread_mutex_unlock(&g_mutex));
 
 	ret_chk = pthread_mutex_unlock(&g_mutex);
 	TC_ASSERT_EQ("pthread_mutex_unlock", ret_chk, OK);
@@ -1242,11 +1228,11 @@ static void tc_pthread_pthread_yield(void)
 
 	sleep(SEC_1);
 
-	TC_ASSERT_EQ_CLEANUP("pthread_yield", g_bpthreadcallback, true, get_errno(), {pthread_detach(g_thread1);});
+	TC_ASSERT_EQ_CLEANUP("pthread_yield", g_bpthreadcallback, true, pthread_detach(g_thread1));
 
 	ret_chk = pthread_create(&g_thread2, NULL, thread_yield_callback, NULL);
-	TC_ASSERT_EQ_CLEANUP("pthread_create", ret_chk, OK, get_errno(), {pthread_detach(g_thread2);});
-	TC_ASSERT_EQ_CLEANUP("pthread_create", g_bpthreadcallback, true, get_errno(), {pthread_detach(g_thread2);});
+	TC_ASSERT_EQ_CLEANUP("pthread_create", ret_chk, OK, pthread_detach(g_thread2));
+	TC_ASSERT_EQ_CLEANUP("pthread_create", g_bpthreadcallback, true, pthread_detach(g_thread2));
 
 	/* wait for threads to exit */
 	sleep(SEC_5);

--- a/apps/examples/testcase/le_tc/kernel/tc_sched.c
+++ b/apps/examples/testcase/le_tc/kernel/tc_sched.c
@@ -307,8 +307,7 @@ static void tc_sched_waitpid(void)
 	TC_ASSERT_GT("task_create", child_pid, 0);
 
 	ret_chk = waitpid(child_pid, status, 0);
-	TC_ASSERT_NEQ_CLEANUP("waitpid", ret_chk, ERROR, errno, TC_FREE_MEMORY(status));
-	TC_ASSERT_EQ_CLEANUP("waitpid", ret_chk, child_pid, errno, free(status));
+	TC_ASSERT_EQ_ERROR_CLEANUP("waitpid", ret_chk, child_pid, errno, TC_FREE_MEMORY(status));
 
 	free(status);
 	TC_SUCCESS_RESULT();

--- a/apps/examples/testcase/le_tc/kernel/tc_semaphore.c
+++ b/apps/examples/testcase/le_tc/kernel/tc_semaphore.c
@@ -134,27 +134,27 @@ static void tc_semaphore_sem_post_wait(void)
 	/* sem_wait & sem post ping-pong test */
 
 	ret_chk = sem_init(&g_empty, PSHARED, 1);
-	TC_ASSERT_EQ_CLEANUP("sem_init", ret_chk, OK, "fail to init semaphore", goto cleanup);
+	TC_ASSERT_EQ_CLEANUP("sem_init", ret_chk, OK, goto cleanup);
 
 	ret_chk = sem_init(&g_full, PSHARED, 0);
-	TC_ASSERT_EQ_CLEANUP("sem_init", ret_chk, OK, "fail to init semaphore", goto cleanup);
+	TC_ASSERT_EQ_CLEANUP("sem_init", ret_chk, OK, goto cleanup);
 
 	ret_chk = sem_init(&g_sem, PSHARED, 1);
-	TC_ASSERT_EQ_CLEANUP("sem_init", ret_chk, OK, "fail to init semaphore", goto cleanup);
+	TC_ASSERT_EQ_CLEANUP("sem_init", ret_chk, OK, goto cleanup);
 
 	ret_chk = pthread_create(&pid, NULL, producer_func, NULL);
-	TC_ASSERT_EQ_CLEANUP("pthread_create", ret_chk, OK, "fail to create pthread", goto cleanup);
+	TC_ASSERT_EQ_CLEANUP("pthread_create", ret_chk, OK, goto cleanup);
 
 	ret_chk = pthread_create(&cid, NULL, consumer_func, NULL);
-	TC_ASSERT_EQ_CLEANUP("pthread_create", ret_chk, OK, "fail to create pthread", goto cleanup);
+	TC_ASSERT_EQ_CLEANUP("pthread_create", ret_chk, OK, goto cleanup);
 
 	ret_chk = pthread_join(pid, &pexit_value);
-	TC_ASSERT_EQ_CLEANUP("pthread_join", ret_chk, OK, "fail to join pthread", goto cleanup);
-	TC_ASSERT_EQ_CLEANUP("pthread_join", pexit_value, NULL, "unexpected exit value", goto cleanup);
+	TC_ASSERT_EQ_CLEANUP("pthread_join", ret_chk, OK, goto cleanup);
+	TC_ASSERT_EQ_CLEANUP("pthread_join", pexit_value, NULL, goto cleanup);
 
 	ret_chk = pthread_join(cid, &pexit_value);
-	TC_ASSERT_EQ_CLEANUP("pthread_join", ret_chk, OK, "fail to join pthread", goto cleanup);
-	TC_ASSERT_EQ_CLEANUP("pthread_join", pexit_value, NULL, "unexpected exit value", goto cleanup);
+	TC_ASSERT_EQ_CLEANUP("pthread_join", ret_chk, OK,goto cleanup);
+	TC_ASSERT_EQ_CLEANUP("pthread_join", pexit_value, NULL, goto cleanup);
 
 	TC_SUCCESS_RESULT();
 

--- a/apps/examples/testcase/le_tc/kernel/tc_signal.c
+++ b/apps/examples/testcase/le_tc/kernel/tc_signal.c
@@ -329,7 +329,7 @@ static void tc_signal_sigsuspend(void)
 	/* Save the current sigprocmask */
 
 	ret_chk = sigprocmask(SIG_SETMASK, &newmask, &saved);
-	TC_ASSERT_EQ_CLEANUP("sigprocmask", ret_chk, OK, errno, {
+	TC_ASSERT_EQ_CLEANUP("sigprocmask", ret_chk, OK, {
 		tckndbg("ERROR sigprocmask failed: %d\n", get_errno()); goto errout;
 	}
 						);
@@ -341,21 +341,18 @@ static void tc_signal_sigsuspend(void)
 	/* Wait for a signal */
 
 	ret_chk = sigsuspend(&newmask);
-	TC_ASSERT_EQ_CLEANUP("sigsuspend", ret_chk, ERROR, get_errno(), {
+	TC_ASSERT_EQ_CLEANUP("sigsuspend", ret_chk, ERROR, {
 		tckndbg("ERROR sigsuspend failed: %d\n", get_errno()); goto errout_with_mask;
 	}
 						);
 
 	clock_gettime(clock_id, &st_final_timespec);
-	TC_ASSERT_GEQ_CLEANUP("clock_gettime", st_final_timespec.tv_sec - st_init_timespec.tv_sec, SEC_5, "Difference less than 5", {
-		goto errout_with_mask;
-	}
-						 );
+	TC_ASSERT_GEQ_CLEANUP("clock_gettime", st_final_timespec.tv_sec - st_init_timespec.tv_sec, SEC_5, goto errout_with_mask);
 
 	/* Restore sigprocmask */
 
 	ret_chk = sigprocmask(SIG_SETMASK, &saved, NULL);
-	TC_ASSERT_EQ_CLEANUP("sigprocmask", ret_chk, OK, errno, {
+	TC_ASSERT_EQ_CLEANUP("sigprocmask", ret_chk, OK, {
 		tckndbg("ERROR sognprocmask failed: %d\n", get_errno()); goto errout;
 	}
 						);

--- a/apps/examples/testcase/le_tc/kernel/tc_task.c
+++ b/apps/examples/testcase/le_tc/kernel/tc_task.c
@@ -412,11 +412,11 @@ static void tc_task_prctl(void)
 	/* get taskname */
 
 	ret_chk = prctl(PR_GET_NAME, getname, 0, 0, 0);
-	TC_ASSERT_EQ_CLEANUP("prctl", ret_chk, OK, get_errno(), prctl(PR_SET_NAME, oldname, 0, 0, 0));
+	TC_ASSERT_EQ_ERROR_CLEANUP("prctl", ret_chk, OK, get_errno(), prctl(PR_SET_NAME, oldname, 0, 0, 0));
 
 	/* compare getname and setname */
 
-	TC_ASSERT_EQ_CLEANUP("prctl", strncmp(getname, setname, CONFIG_TASK_NAME_SIZE), 0, get_errno(), prctl(PR_SET_NAME, oldname, 0, 0, 0));
+	TC_ASSERT_EQ_ERROR_CLEANUP("prctl", strncmp(getname, setname, CONFIG_TASK_NAME_SIZE), 0, get_errno(), prctl(PR_SET_NAME, oldname, 0, 0, 0));
 
 	prctl(PR_SET_NAME, oldname, 0, 0, 0);
 	TC_SUCCESS_RESULT();

--- a/apps/examples/testcase/le_tc/kernel/tc_timer.c
+++ b/apps/examples/testcase/le_tc/kernel/tc_timer.c
@@ -58,11 +58,11 @@ static void tc_timer_timer_create_delete(void)
 	TC_ASSERT_NOT_NULL("timer_create", timer_id);
 
 	st_ret_prt = (struct posix_timer_s *)timer_id;
-	TC_ASSERT_EQ_CLEANUP("timer_create", st_ret_prt->pt_value.sival_ptr, st_sigevent.sigev_value.sival_ptr, "posix_timer_s for sigevent not available", timer_delete(timer_id));
-	TC_ASSERT_EQ_CLEANUP("timer_create", st_ret_prt->pt_signo, st_sigevent.sigev_signo, "posix_timer_s for sigevent not available", timer_delete(timer_id));
-	TC_ASSERT_EQ_CLEANUP("timer_create", st_ret_prt->pt_crefs, 1, "posix_timer_s for sigevent not available", timer_delete(timer_id));
-	TC_ASSERT_EQ_CLEANUP("timer_create", st_ret_prt->pt_owner, getpid(), "posix_timer_s for sigevent not available", timer_delete(timer_id));
-	TC_ASSERT_EQ_CLEANUP("timer_create", st_ret_prt->pt_delay, 0, "posix_timer_s for sigevent not available", timer_delete(timer_id));
+	TC_ASSERT_EQ_CLEANUP("timer_create", st_ret_prt->pt_value.sival_ptr, st_sigevent.sigev_value.sival_ptr, timer_delete(timer_id));
+	TC_ASSERT_EQ_CLEANUP("timer_create", st_ret_prt->pt_signo, st_sigevent.sigev_signo, timer_delete(timer_id));
+	TC_ASSERT_EQ_CLEANUP("timer_create", st_ret_prt->pt_crefs, 1, timer_delete(timer_id));
+	TC_ASSERT_EQ_CLEANUP("timer_create", st_ret_prt->pt_owner, getpid(), timer_delete(timer_id));
+	TC_ASSERT_EQ_CLEANUP("timer_create", st_ret_prt->pt_delay, 0, timer_delete(timer_id));
 
 	st_timer_spec_val.it_value.tv_sec = 1;
 	st_timer_spec_val.it_value.tv_nsec = 0;
@@ -71,7 +71,7 @@ static void tc_timer_timer_create_delete(void)
 	st_timer_spec_val.it_interval.tv_nsec = 0;
 
 	ret_chk = timer_settime(timer_id, 0, &st_timer_spec_val, NULL);
-	TC_ASSERT_NEQ_CLEANUP("timer_settime", ret_chk, ERROR, errno, timer_delete(timer_id));
+	TC_ASSERT_EQ_ERROR_CLEANUP("timer_settime", ret_chk, OK, errno, timer_delete(timer_id));
 
 	ret_chk = timer_delete(timer_id);
 	TC_ASSERT_NEQ("timer_delete", ret_chk, ERROR);
@@ -81,10 +81,10 @@ static void tc_timer_timer_create_delete(void)
 
 	st_ret_prt = (struct posix_timer_s *)gtimer_id;
 
-	TC_ASSERT_EQ_CLEANUP("timer_create", st_ret_prt->pt_value.sival_ptr, st_ret_prt, "posix_timer_s for NULL not available", timer_delete(gtimer_id));
-	TC_ASSERT_EQ_CLEANUP("timer_create", st_ret_prt->pt_crefs, 1, "posix_timer_s for NULL not available", timer_delete(gtimer_id));
-	TC_ASSERT_EQ_CLEANUP("timer_create", st_ret_prt->pt_owner, getpid(), "posix_timer_s for NULL not available", timer_delete(gtimer_id));
-	TC_ASSERT_EQ_CLEANUP("timer_create", st_ret_prt->pt_delay, 0, "posix_timer_s for NULL not available", timer_delete(gtimer_id));
+	TC_ASSERT_EQ_CLEANUP("timer_create", st_ret_prt->pt_value.sival_ptr, st_ret_prt, timer_delete(gtimer_id));
+	TC_ASSERT_EQ_CLEANUP("timer_create", st_ret_prt->pt_crefs, 1, timer_delete(gtimer_id));
+	TC_ASSERT_EQ_CLEANUP("timer_create", st_ret_prt->pt_owner, getpid(), timer_delete(gtimer_id));
+	TC_ASSERT_EQ_CLEANUP("timer_create", st_ret_prt->pt_delay, 0, timer_delete(gtimer_id));
 
 	ret_chk = timer_delete(gtimer_id);
 	TC_ASSERT_NEQ("timer_delete", ret_chk, ERROR);
@@ -123,16 +123,16 @@ static void tc_timer_timer_set_get_time(void)
 	st_timer_spec_set.it_value.tv_nsec = 0;	/* expire; */
 
 	ret_chk = timer_settime(timer_id, 0, &st_timer_spec_set, NULL);	/* Flag =1 :TIMER_ABSTIME */
-	TC_ASSERT_EQ_CLEANUP("timer_settime", ret_chk, OK, errno, timer_delete(timer_id));
+	TC_ASSERT_EQ_ERROR_CLEANUP("timer_settime", ret_chk, OK, errno, timer_delete(timer_id));
 
 	usleep(USECINT);
 
 	ret_chk = timer_gettime(timer_id, &st_timer_spec_get);
-	TC_ASSERT_NEQ_CLEANUP("timer_gettime", ret_chk, ERROR, errno, timer_delete(timer_id));
-	TC_ASSERT_GEQ_CLEANUP("timer_gettime", st_timer_spec_get.it_interval.tv_nsec, st_timer_spec_set.it_interval.tv_nsec, errno, timer_delete(timer_id));
-	TC_ASSERT_GEQ_CLEANUP("timer_gettime", st_timer_spec_get.it_interval.tv_sec, st_timer_spec_set.it_interval.tv_sec, errno, timer_delete(timer_id));
-	TC_ASSERT_GEQ_CLEANUP("timer_gettime", st_timer_spec_get.it_value.tv_sec, st_timer_spec_set.it_value.tv_sec, errno, timer_delete(timer_id));
-	TC_ASSERT_GEQ_CLEANUP("timer_gettime", st_timer_spec_get.it_value.tv_nsec, st_timer_spec_set.it_value.tv_nsec, errno, timer_delete(timer_id));
+	TC_ASSERT_EQ_ERROR_CLEANUP("timer_gettime", ret_chk, OK, errno, timer_delete(timer_id));
+	TC_ASSERT_GEQ_CLEANUP("timer_gettime", st_timer_spec_get.it_interval.tv_nsec, st_timer_spec_set.it_interval.tv_nsec, timer_delete(timer_id));
+	TC_ASSERT_GEQ_CLEANUP("timer_gettime", st_timer_spec_get.it_interval.tv_sec, st_timer_spec_set.it_interval.tv_sec, timer_delete(timer_id));
+	TC_ASSERT_GEQ_CLEANUP("timer_gettime", st_timer_spec_get.it_value.tv_sec, st_timer_spec_set.it_value.tv_sec, timer_delete(timer_id));
+	TC_ASSERT_GEQ_CLEANUP("timer_gettime", st_timer_spec_get.it_value.tv_nsec, st_timer_spec_set.it_value.tv_nsec, timer_delete(timer_id));
 
 	timer_delete(timer_id);
 	TC_SUCCESS_RESULT();
@@ -206,10 +206,10 @@ static void tc_timer_timer_initialize(void)
 		finalfree_cnt++;
 	}
 
-	TC_ASSERT_EQ_CLEANUP("timer_initialise", initalloc_cnt, finalalloc_cnt, "Timer ID not available", timer_delete(timer_id));
-	TC_ASSERT_EQ_CLEANUP("timer_initialise", initfree_cnt, finalfree_cnt, "Timer ID not available", timer_delete(timer_id));
-	TC_ASSERT_NEQ_CLEANUP("timer_initialise", createalloc_cnt, finalalloc_cnt, "Timer ID not available", timer_delete(timer_id));
-	TC_ASSERT_NEQ_CLEANUP("timer_initialise", createfree_cnt, finalfree_cnt, "Timer ID not available", timer_delete(timer_id));
+	TC_ASSERT_EQ_CLEANUP("timer_initialise", initalloc_cnt, finalalloc_cnt, timer_delete(timer_id));
+	TC_ASSERT_EQ_CLEANUP("timer_initialise", initfree_cnt, finalfree_cnt, timer_delete(timer_id));
+	TC_ASSERT_NEQ_CLEANUP("timer_initialise", createalloc_cnt, finalalloc_cnt, timer_delete(timer_id));
+	TC_ASSERT_NEQ_CLEANUP("timer_initialise", createfree_cnt, finalfree_cnt, timer_delete(timer_id));
 
 	timer_delete(timer_id);
 	TC_SUCCESS_RESULT();

--- a/apps/examples/testcase/le_tc/kernel/tc_umm_heap.c
+++ b/apps/examples/testcase/le_tc/kernel/tc_umm_heap.c
@@ -71,7 +71,7 @@ static void tc_umm_heap_malloc_free(struct tcb_s *st_tcb)
 			mem_ptr[alloc_cnt] = (int *)malloc(ALLOC_SIZE_VAL * sizeof(int));
 			TC_ASSERT_NOT_NULL("malloc", mem_ptr[alloc_cnt]);
 		}
-		TC_ASSERT_EQ_CLEANUP("malloc", st_tcb->curr_alloc_size, TOTAL_ALLOC_SIZE, get_errno(), mem_deallocate_func(mem_ptr, ALLOC_FREE_TIMES));
+		TC_ASSERT_EQ_ERROR_CLEANUP("malloc", st_tcb->curr_alloc_size, TOTAL_ALLOC_SIZE, get_errno(), mem_deallocate_func(mem_ptr, ALLOC_FREE_TIMES));
 		mem_deallocate_func(mem_ptr, ALLOC_FREE_TIMES);
 		TC_ASSERT_EQ("malloc", st_tcb->curr_alloc_size, ALL_FREE);
 	}
@@ -100,7 +100,7 @@ static void tc_umm_heap_calloc(struct tcb_s *st_tcb)
 			TC_ASSERT_NOT_NULL("calloc", mem_ptr[alloc_cnt]);
 		}
 
-		TC_ASSERT_EQ_CLEANUP("calloc", st_tcb->curr_alloc_size, TOTAL_ALLOC_SIZE, get_errno(), mem_deallocate_func(mem_ptr, ALLOC_FREE_TIMES));
+		TC_ASSERT_EQ_ERROR_CLEANUP("calloc", st_tcb->curr_alloc_size, TOTAL_ALLOC_SIZE, get_errno(), mem_deallocate_func(mem_ptr, ALLOC_FREE_TIMES));
 		mem_deallocate_func(mem_ptr, ALLOC_FREE_TIMES);
 
 		TC_ASSERT_EQ("calloc", st_tcb->curr_alloc_size, ALL_FREE);
@@ -131,7 +131,7 @@ static void tc_umm_heap_realloc(struct tcb_s *st_tcb)
 			mem_ptr[alloc_cnt] = (int *)realloc(val, ALLOC_SIZE_VAL * sizeof(int));
 			TC_ASSERT_NOT_NULL("realloc", mem_ptr[alloc_cnt]);
 		}
-		TC_ASSERT_EQ_CLEANUP("realloc", st_tcb->curr_alloc_size, TOTAL_ALLOC_SIZE, get_errno(), mem_deallocate_func(mem_ptr, ALLOC_FREE_TIMES));
+		TC_ASSERT_EQ_ERROR_CLEANUP("realloc", st_tcb->curr_alloc_size, TOTAL_ALLOC_SIZE, get_errno(), mem_deallocate_func(mem_ptr, ALLOC_FREE_TIMES));
 		mem_deallocate_func(mem_ptr, ALLOC_FREE_TIMES);
 
 		TC_ASSERT_EQ("realloc", st_tcb->curr_alloc_size, ALL_FREE);
@@ -160,7 +160,7 @@ static void tc_umm_heap_memalign(struct tcb_s *st_tcb)
 			mem_ptr[alloc_cnt] = (int *)memalign(sizeof(int), ALLOC_SIZE_VAL * sizeof(int));
 			TC_ASSERT_NOT_NULL("memalign", mem_ptr[alloc_cnt]);
 		}
-		TC_ASSERT_EQ_CLEANUP("memalign", st_tcb->curr_alloc_size, TOTAL_ALLOC_SIZE, get_errno(), mem_deallocate_func(mem_ptr, ALLOC_FREE_TIMES));
+		TC_ASSERT_EQ_ERROR_CLEANUP("memalign", st_tcb->curr_alloc_size, TOTAL_ALLOC_SIZE, get_errno(), mem_deallocate_func(mem_ptr, ALLOC_FREE_TIMES));
 		mem_deallocate_func(mem_ptr, ALLOC_FREE_TIMES);
 
 		TC_ASSERT_EQ("memalign", st_tcb->curr_alloc_size, ALL_FREE);
@@ -201,7 +201,7 @@ static void tc_umm_heap_random_malloc(struct tcb_s *st_tcb)
 			   because of the chunk size */
 			allocated_size += MM_ALIGN_UP(allocated[alloc_cnt] + SIZEOF_MM_ALLOCNODE);
 		}
-		TC_ASSERT_EQ_CLEANUP("malloc", st_tcb->curr_alloc_size, allocated_size, get_errno(), mem_deallocate_func(mem_ptr, ALLOC_FREE_TIMES));
+		TC_ASSERT_EQ_ERROR_CLEANUP("malloc", st_tcb->curr_alloc_size, allocated_size, get_errno(), mem_deallocate_func(mem_ptr, ALLOC_FREE_TIMES));
 		mem_deallocate_func(mem_ptr, ALLOC_FREE_TIMES);
 		TC_ASSERT_EQ("random_malloc", st_tcb->curr_alloc_size, ALL_FREE);
 	}
@@ -231,7 +231,7 @@ static void tc_umm_heap_mallinfo(void)
 		TC_ASSERT_NOT_NULL("malloc", mem_ptr);
 
 		st_mallinfo = mallinfo();
-		TC_ASSERT_GT_CLEANUP("mallinfo", st_mallinfo.fordblks, 0, get_errno(), TC_FREE_MEMORY(mem_ptr));
+		TC_ASSERT_GT_CLEANUP("mallinfo", st_mallinfo.fordblks, 0, TC_FREE_MEMORY(mem_ptr));
 		TC_FREE_MEMORY(mem_ptr);
 	}
 	TC_SUCCESS_RESULT();
@@ -245,7 +245,7 @@ static void tc_umm_heap_zalloc(void)
 	TC_ASSERT_NOT_NULL("zalloc", mem_ptr);
 
 	for (mem_idx = 0; mem_idx < 5; mem_idx++) {
-		TC_ASSERT_EQ_CLEANUP("zalloc", mem_ptr[mem_idx], 0, get_errno(), TC_FREE_MEMORY(mem_ptr));
+		TC_ASSERT_EQ_ERROR_CLEANUP("zalloc", mem_ptr[mem_idx], 0, get_errno(), TC_FREE_MEMORY(mem_ptr));
 	}
 	TC_FREE_MEMORY(mem_ptr);
 	TC_SUCCESS_RESULT();

--- a/apps/examples/testcase/ta_tc/arastorage/itc/itc_arastorage_main.c
+++ b/apps/examples/testcase/ta_tc/arastorage/itc/itc_arastorage_main.c
@@ -233,7 +233,7 @@ void itc_arastorage_db_print_header_p(void)
 	g_cursor = db_query(g_query);
 	TC_ASSERT_NOT_NULL("db_query", g_cursor);
 	ret = db_print_header(g_cursor);
-	TC_ASSERT_EQ_CLEANUP("db_print_header", DB_ERROR(ret), 0, "db_print_header failed\n", db_cursor_free(g_cursor));
+	TC_ASSERT_EQ_CLEANUP("db_print_header", DB_ERROR(ret), 0, db_cursor_free(g_cursor));
 	db_cursor_free(g_cursor);
 	g_cursor = NULL;
 	TC_SUCCESS_RESULT();

--- a/apps/examples/testcase/ta_tc/device_management/itc/itc_dm_conn.c
+++ b/apps/examples/testcase/ta_tc/device_management/itc/itc_dm_conn.c
@@ -123,7 +123,7 @@ static void itc_dm_conn_set_get_tx_power_p(void)
     TC_ASSERT_EQ("dm_conn_set_tx_power" , ret , DM_ERROR_NONE);
     ret = dm_conn_get_tx_power(&getVal);
     TC_ASSERT_EQ("dm_conn_get_tx_power" , ret, DM_ERROR_NONE);
-    TC_ASSERT_EQ_CLEANUP("itc_dm_conn_set_get_power" , setVal , getVal, "set and get value mismatch", dm_conn_set_tx_power(&defaultvalue));
+    TC_ASSERT_EQ_CLEANUP("itc_dm_conn_set_get_power" , setVal , getVal, dm_conn_set_tx_power(&defaultvalue));
     dm_conn_set_tx_power(&defaultvalue);
     TC_SUCCESS_RESULT();
 }

--- a/apps/examples/testcase/ta_tc/device_management/itc/itc_dm_lwm2m.c
+++ b/apps/examples/testcase/ta_tc/device_management/itc/itc_dm_lwm2m.c
@@ -52,7 +52,7 @@ static int display_resource(FAR void *arg)
     strcpy(argbuffer, "/8/0");
 
     ret = dm_lwm2m_display_client_resource(argbuffer);
-    TC_ASSERT_EQ_CLEANUP("dm_lwm2m_display_client_resource", ret, DM_ERROR_NONE, "UNEXPECTED_ERROR", dm_lwm2m_stop_client());
+    TC_ASSERT_EQ_CLEANUP("dm_lwm2m_display_client_resource", ret, DM_ERROR_NONE, dm_lwm2m_stop_client());
     ret = dm_lwm2m_stop_client();
     TC_ASSERT_EQ("dm_lwm2m_stop_client" , ret , DM_ERROR_NONE);
 }
@@ -93,8 +93,8 @@ static void itc_dm_lwm2m_get_client_lifetime_p(void)
     TC_ASSERT_EQ("dm_lwm2m_start_client" , ret , DM_ERROR_NONE);
 
     ret = dm_lwm2m_get_client_lifetime(&life);
-    TC_ASSERT_EQ_CLEANUP("dm_lwm2m_get_client_lifetime", ret, DM_ERROR_NONE, "UNEXPECTED_ERROR", dm_lwm2m_stop_client());
-    TC_ASSERT_EQ_CLEANUP("dm_lwm2m_get_client_lifetime", (life < 0), false,"invalid lifetime", dm_lwm2m_stop_client());
+    TC_ASSERT_EQ_CLEANUP("dm_lwm2m_get_client_lifetime", ret, DM_ERROR_NONE, dm_lwm2m_stop_client());
+    TC_ASSERT_EQ_CLEANUP("dm_lwm2m_get_client_lifetime", (life < 0), false, dm_lwm2m_stop_client());
 
     ret = dm_lwm2m_stop_client();
     TC_ASSERT_EQ("dm_lwm2m_stop_client" , ret , DM_ERROR_NONE);
@@ -117,8 +117,8 @@ static void itc_dm_lwm2m_get_server_address_p(void)
 
     char ipAddr[ITC_DM_IPADDR_LEN];
     ret = dm_lwm2m_get_server_address(ipAddr);
-    TC_ASSERT_EQ_CLEANUP("dm_lwm2m_get_server_address", ret, DM_ERROR_NONE, "UNEXPECTED_ERROR", dm_lwm2m_stop_client());
-    TC_ASSERT_EQ_CLEANUP("dm_lwm2m_get_server_address" , ipAddr[3] , '.', "UNEXPECTED_ERROR", dm_lwm2m_stop_client());
+    TC_ASSERT_EQ_CLEANUP("dm_lwm2m_get_server_address", ret, DM_ERROR_NONE, dm_lwm2m_stop_client());
+    TC_ASSERT_EQ_CLEANUP("dm_lwm2m_get_server_address" , ipAddr[3] , '.', dm_lwm2m_stop_client());
 
     ret = dm_lwm2m_stop_client();
     TC_ASSERT_EQ("dm_lwm2m_stop_client" , ret , DM_ERROR_NONE);
@@ -141,8 +141,8 @@ static void itc_dm_lwm2m_get_server_port_p(void)
     TC_ASSERT_EQ("dm_lwm2m_start_client" , ret , DM_ERROR_NONE);
 
     ret = dm_lwm2m_get_server_port(port);
-    TC_ASSERT_EQ_CLEANUP("dm_lwm2m_get_server_port", ret, DM_ERROR_NONE, "UNEXPECTED_ERROR", dm_lwm2m_stop_client());
-    TC_ASSERT_EQ_CLEANUP("dm_lwm2m_get_server_port", (port[0] < 0), false,"INVALID_PORT", dm_lwm2m_stop_client());
+    TC_ASSERT_EQ_CLEANUP("dm_lwm2m_get_server_port", ret, DM_ERROR_NONE, dm_lwm2m_stop_client());
+    TC_ASSERT_EQ_CLEANUP("dm_lwm2m_get_server_port", (port[0] < 0), false, dm_lwm2m_stop_client());
 
     ret = dm_lwm2m_stop_client();
     TC_ASSERT_EQ("dm_lwm2m_stop_client" , ret , DM_ERROR_NONE);
@@ -165,8 +165,8 @@ static void itc_dm_lwm2m_get_client_state_p(void)
     TC_ASSERT_EQ("dm_lwm2m_start_client" , ret , DM_ERROR_NONE);
 
     ret = dm_lwm2m_get_client_state(&state);
-    TC_ASSERT_EQ_CLEANUP("dm_lwm2m_get_client_state", ret, DM_ERROR_NONE, "UNEXPECTED_ERROR", dm_lwm2m_stop_client());
-    TC_ASSERT_EQ_CLEANUP("dm_lwm2m_get_client_state", (state < 0), false,"INVALID_STATE", dm_lwm2m_stop_client());
+    TC_ASSERT_EQ_CLEANUP("dm_lwm2m_get_client_state", ret, DM_ERROR_NONE, dm_lwm2m_stop_client());
+    TC_ASSERT_EQ_CLEANUP("dm_lwm2m_get_client_state", (state < 0), false, dm_lwm2m_stop_client());
 
     ret = dm_lwm2m_stop_client();
     TC_ASSERT_EQ("dm_lwm2m_stop_client" , ret , DM_ERROR_NONE);

--- a/apps/examples/testcase/ta_tc/systemio/itc/itc_gpio.c
+++ b/apps/examples/testcase/ta_tc/systemio/itc/itc_gpio.c
@@ -75,14 +75,14 @@ void itc_gpio_open_close_p(void)
     g_gpio = iotbus_gpio_open(gpiopin);
     TC_ASSERT_NOT_NULL ("iotbus_gpio_open" , g_gpio);
 
-    gpiopin = 14;
-    g_gpio2 = iotbus_gpio_open(gpiopin);
-    TC_ASSERT_NEQ_CLEANUP ("iotbus_gpio_open", g_gpio2 , NULL ,"ERROR_RETURNED_NULL",iotbus_gpio_close(g_gpio));
+	gpiopin = 14;
+	g_gpio2 = iotbus_gpio_open(gpiopin);
+	TC_ASSERT_NEQ_CLEANUP("iotbus_gpio_open", g_gpio2 , NULL , iotbus_gpio_close(g_gpio));
 
-    ret = iotbus_gpio_close(g_gpio);
-    TC_ASSERT_EQ_CLEANUP("iotbus_gpio_close", ret, 0, "UNEXPECTED_ERROR", iotbus_gpio_close(g_gpio2));
-    ret = iotbus_gpio_close(g_gpio2);
-    TC_ASSERT_EQ("iotbus_gpio_close", ret, 0);
+	ret = iotbus_gpio_close(g_gpio);
+	TC_ASSERT_EQ_CLEANUP("iotbus_gpio_close", ret, 0, iotbus_gpio_close(g_gpio2));
+	ret = iotbus_gpio_close(g_gpio2);
+	TC_ASSERT_EQ("iotbus_gpio_close", ret, 0);
 
     TC_SUCCESS_RESULT();
 }
@@ -97,40 +97,40 @@ void itc_gpio_open_close_p(void)
 */
 void itc_gpio_set_get_direction_p(void)
 {
-    int ret, index, ncount, gpiopin;
-    iotbus_gpio_direction_e getDirection;
-    iotbus_gpio_direction_e setDirection[] = { IOTBUS_GPIO_DIRECTION_NONE, IOTBUS_GPIO_DIRECTION_OUT, IOTBUS_GPIO_DIRECTION_IN };
-    ncount = sizeof(setDirection) / sizeof(setDirection[0]);
-    bool check = true;
-    gpiopin = 12;
-    g_gpio = iotbus_gpio_open(gpiopin);
-    TC_ASSERT_NOT_NULL("iotbus_gpio_open" , g_gpio);
+	int ret, index, ncount, gpiopin;
+	iotbus_gpio_direction_e getDirection;
+	iotbus_gpio_direction_e setDirection[] = { IOTBUS_GPIO_DIRECTION_NONE, IOTBUS_GPIO_DIRECTION_OUT, IOTBUS_GPIO_DIRECTION_IN };
+	ncount = sizeof(setDirection) / sizeof(setDirection[0]);
+	bool check = true;
+	gpiopin = 12;
+	g_gpio = iotbus_gpio_open(gpiopin);
+	TC_ASSERT_NOT_NULL("iotbus_gpio_open" , g_gpio);
 
-    for (index = 0; index < ncount; index++) {
-        ret = iotbus_gpio_set_direction(g_gpio, setDirection[index]);
+	for (index = 0; index < ncount; index++) {
+		ret = iotbus_gpio_set_direction(g_gpio, setDirection[index]);
 
-        if (ret != 0) {
-            SYSIO_ITC_PRINT("\nitc_gpio_set_get_direction: iotbus_gpio_set_direction FAIL for array index : %d\n", index);
-            check = false;
-            continue;
-        }
+		if (ret != 0) {
+			SYSIO_ITC_PRINT("\nitc_gpio_set_get_direction: iotbus_gpio_set_direction FAIL for array index : %d\n", index);
+			check = false;
+			continue;
+		}
 
-        ret = iotbus_gpio_get_direction(g_gpio, &getDirection);
-        if (ret != 0) {
-            SYSIO_ITC_PRINT("\nitc_gpio_set_get_direction: iotbus_gpio_get_direction FAIL for array index : %d\n", index);
-            check = false;
-            continue;
-        }
+		ret = iotbus_gpio_get_direction(g_gpio, &getDirection);
+		if (ret != 0) {
+			SYSIO_ITC_PRINT("\nitc_gpio_set_get_direction: iotbus_gpio_get_direction FAIL for array index : %d\n", index);
+			check = false;
+			continue;
+		}
 
-        if (getDirection != setDirection[index]) {
-            SYSIO_ITC_PRINT("\nitc_gpio_set_get_direction: FAIL, set and get values not same for array index : %d\n", index);
-            check = false;
-        }
-    }
+		if (getDirection != setDirection[index]) {
+			SYSIO_ITC_PRINT("\nitc_gpio_set_get_direction: FAIL, set and get values not same for array index : %d\n", index);
+			check = false;
+		}
+	}
 
-    TC_ASSERT_EQ_CLEANUP("iotbus_gpio_set_get_direction", check , true , "MISMATCH_VALUE" , iotbus_gpio_close(g_gpio));
-    iotbus_gpio_close(g_gpio);
-    TC_SUCCESS_RESULT();
+	TC_ASSERT_EQ_CLEANUP("iotbus_gpio_set_get_direction", check , true , iotbus_gpio_close(g_gpio));
+	iotbus_gpio_close(g_gpio);
+	TC_SUCCESS_RESULT();
 }
 
 /**
@@ -143,37 +143,37 @@ void itc_gpio_set_get_direction_p(void)
 */
 void itc_gpio_set_get_edge_mode_p(void)
 {
-    int ret, index, ncount, gpiopin;
-    iotbus_gpio_edge_e getEdge;
-    iotbus_gpio_edge_e setEdge[] = { IOTBUS_GPIO_EDGE_NONE, IOTBUS_GPIO_EDGE_BOTH, IOTBUS_GPIO_EDGE_RISING, IOTBUS_GPIO_EDGE_FALLING };
-    ncount = sizeof(setEdge) / sizeof(setEdge[0]);
-    bool check = true;
-    gpiopin = 12;
-    g_gpio = iotbus_gpio_open(gpiopin);
-    TC_ASSERT_NOT_NULL("iotbus_gpio_open" , g_gpio);
+	int ret, index, ncount, gpiopin;
+	iotbus_gpio_edge_e getEdge;
+	iotbus_gpio_edge_e setEdge[] = { IOTBUS_GPIO_EDGE_NONE, IOTBUS_GPIO_EDGE_BOTH, IOTBUS_GPIO_EDGE_RISING, IOTBUS_GPIO_EDGE_FALLING };
+	ncount = sizeof(setEdge) / sizeof(setEdge[0]);
+	bool check = true;
+	gpiopin = 12;
+	g_gpio = iotbus_gpio_open(gpiopin);
+	TC_ASSERT_NOT_NULL("iotbus_gpio_open" , g_gpio);
 
-    for (index = 0; index < ncount; index++) {
-        ret = iotbus_gpio_set_edge_mode(g_gpio, setEdge[index]);
-        if (ret != 0) {
-            SYSIO_ITC_PRINT("\nitc_gpio_set_get_edge_mode: iotbus_gpio_set_edge_mode FAIL for array index : %d\n", index);
-            check = false;
-            continue;
-        }
-        ret = iotbus_gpio_get_edge_mode(g_gpio, &getEdge);
-        if (ret != 0) {
-            SYSIO_ITC_PRINT("\nitc_gpio_set_get_edge_mode: iotbus_gpio_get_edge_mode FAIL for array index : %d\n", index);
-            check = false;
-            continue;
-        }
-        if (getEdge != setEdge[index]) {
-            SYSIO_ITC_PRINT("\nitc_gpio_set_get_edge_mode: FAIL, set and get values not same for array index : %d\n", index);
-            check = false;
-        }
-    }
+	for (index = 0; index < ncount; index++) {
+		ret = iotbus_gpio_set_edge_mode(g_gpio, setEdge[index]);
+		if (ret != 0) {
+			SYSIO_ITC_PRINT("\nitc_gpio_set_get_edge_mode: iotbus_gpio_set_edge_mode FAIL for array index : %d\n", index);
+			check = false;
+			continue;
+		}
+		ret = iotbus_gpio_get_edge_mode(g_gpio, &getEdge);
+		if (ret != 0) {
+			SYSIO_ITC_PRINT("\nitc_gpio_set_get_edge_mode: iotbus_gpio_get_edge_mode FAIL for array index : %d\n", index);
+			check = false;
+			continue;
+		}
+		if (getEdge != setEdge[index]) {
+			SYSIO_ITC_PRINT("\nitc_gpio_set_get_edge_mode: FAIL, set and get values not same for array index : %d\n", index);
+			check = false;
+		}
+	}
 
-    TC_ASSERT_EQ_CLEANUP("iotbus_gpio_set_get_edge", check , true , "MISMATCH_VALUE" , iotbus_gpio_close(g_gpio));
-    iotbus_gpio_close(g_gpio);
-    TC_SUCCESS_RESULT();
+	TC_ASSERT_EQ_CLEANUP("iotbus_gpio_set_get_edge", check , true , iotbus_gpio_close(g_gpio));
+	iotbus_gpio_close(g_gpio);
+	TC_SUCCESS_RESULT();
 }
 
 /**
@@ -186,39 +186,38 @@ void itc_gpio_set_get_edge_mode_p(void)
 */
 void itc_gpio_set_get_drive_mode_p(void)
 {
-    int gpiopin = 12;
-    int ret, index, ncount;
-    iotbus_gpio_drive_e getDrive;
-    iotbus_gpio_drive_e setDrive[] = { IOTBUS_GPIO_DRIVE_NONE, IOTBUS_GPIO_DRIVE_PULLUP, IOTBUS_GPIO_DRIVE_PULLDOWN, IOTBUS_GPIO_DRIVE_FLOAT, IOTBUS_GPIO_DRIVE_PUSHPULL };
-    ncount = sizeof(setDrive) / sizeof(setDrive[0]);
-    bool check = true;
+	int gpiopin = 12;
+	int ret, index, ncount;
+	iotbus_gpio_drive_e getDrive;
+	iotbus_gpio_drive_e setDrive[] = { IOTBUS_GPIO_DRIVE_NONE, IOTBUS_GPIO_DRIVE_PULLUP, IOTBUS_GPIO_DRIVE_PULLDOWN, IOTBUS_GPIO_DRIVE_FLOAT, IOTBUS_GPIO_DRIVE_PUSHPULL };
+	ncount = sizeof(setDrive) / sizeof(setDrive[0]);
+	bool check = true;
 
-    g_gpio = iotbus_gpio_open(gpiopin);
-    TC_ASSERT_NOT_NULL("iotbus_gpio_open" , g_gpio);
+	g_gpio = iotbus_gpio_open(gpiopin);
+	TC_ASSERT_NOT_NULL("iotbus_gpio_open" , g_gpio);
 
-    for (index = 0; index < ncount; index++) {
-        ret = iotbus_gpio_set_drive_mode(g_gpio, setDrive[index]);
-        if (ret != 0) {
-            SYSIO_ITC_PRINT("\nitc_gpio_set_get_drive_mode: iotbus_gpio_set_drive_mode FAIL for array index : %d\n", index);
-            check = false;
-            continue;
-        }
-        ret = iotbus_gpio_get_drive_mode(g_gpio, &getDrive);
-        if (ret != 0) {
-            SYSIO_ITC_PRINT("\nitc_gpio_set_get_drive_mode: iotbus_gpio_get_drive_mode FAIL for array index : %d\n", index);
-            check = false;
-            continue;
-        }
-        if (getDrive != setDrive[index]) {
-            SYSIO_ITC_PRINT("\nitc_gpio_set_get_drive_mode: FAIL, set and get values not same for array index : %d\n", index);
-            check = false;
-        }
-    }
+	for (index = 0; index < ncount; index++) {
+		ret = iotbus_gpio_set_drive_mode(g_gpio, setDrive[index]);
+		if (ret != 0) {
+			SYSIO_ITC_PRINT("\nitc_gpio_set_get_drive_mode: iotbus_gpio_set_drive_mode FAIL for array index : %d\n", index);
+			check = false;
+			continue;
+		}
+		ret = iotbus_gpio_get_drive_mode(g_gpio, &getDrive);
+		if (ret != 0) {
+			SYSIO_ITC_PRINT("\nitc_gpio_set_get_drive_mode: iotbus_gpio_get_drive_mode FAIL for array index : %d\n", index);
+			check = false;
+			continue;
+		}
+		if (getDrive != setDrive[index]) {
+			SYSIO_ITC_PRINT("\nitc_gpio_set_get_drive_mode: FAIL, set and get values not same for array index : %d\n", index);
+			check = false;
+		}
+	}
 
-    TC_ASSERT_EQ_CLEANUP("iotbus_gpio_set_get_drive_mode", check , true , "MISMATCH_VALUE" , iotbus_gpio_close(g_gpio));
-    iotbus_gpio_close(g_gpio);
-    TC_SUCCESS_RESULT();
-
+	TC_ASSERT_EQ_CLEANUP("iotbus_gpio_set_get_drive_mode", check , true , iotbus_gpio_close(g_gpio));
+	iotbus_gpio_close(g_gpio);
+	TC_SUCCESS_RESULT();
 }
 
 /**
@@ -236,8 +235,8 @@ void itc_gpio_get_pin_p(void)
     iotbus_gpio_context_h m_gpio = iotbus_gpio_open(gpioSetpin);
     TC_ASSERT_NOT_NULL("iotbus_gpio_open" , m_gpio);
 
-    gpioGetpin = iotbus_gpio_get_pin(m_gpio);
-    TC_ASSERT_EQ_CLEANUP("iotbus_gpio_get_pin", gpioGetpin, gpioSetpin, "MISMATCH_PIN_NUMBER", iotbus_gpio_close(m_gpio));
+	gpioGetpin = iotbus_gpio_get_pin(m_gpio);
+	TC_ASSERT_EQ_CLEANUP("iotbus_gpio_get_pin", gpioGetpin, gpioSetpin, iotbus_gpio_close(m_gpio));
 
     iotbus_gpio_close(m_gpio);
     TC_SUCCESS_RESULT();
@@ -257,11 +256,11 @@ void itc_gpio_read_write_p(void)
     g_gpio = iotbus_gpio_open(gpiopin);
     TC_ASSERT_NOT_NULL("iotbus_gpio_open" , g_gpio);
 
-    ret = iotbus_gpio_read(g_gpio);
-    TC_ASSERT_EQ_CLEANUP("iotbus_gpio_read", (ret < 0), false, "UNEXPECTED_ERROR", iotbus_gpio_close(g_gpio));
+	ret = iotbus_gpio_read(g_gpio);
+	TC_ASSERT_EQ_CLEANUP("iotbus_gpio_read", (ret < 0), false, iotbus_gpio_close(g_gpio));
 
-    ret = iotbus_gpio_write(g_gpio, 1);
-    TC_ASSERT_EQ_CLEANUP("iotbus_gpio_write", (ret < 0), false, "UNEXPECTED_ERROR", iotbus_gpio_close(g_gpio));
+	ret = iotbus_gpio_write(g_gpio, 1);
+	TC_ASSERT_EQ_CLEANUP("iotbus_gpio_write", (ret < 0), false, iotbus_gpio_close(g_gpio));
 
     iotbus_gpio_close(g_gpio);
     TC_SUCCESS_RESULT();
@@ -284,14 +283,14 @@ void itc_gpio_register_unregister_callback_p(void)
     g_gpio = iotbus_gpio_open(gpio_pin1);
     TC_ASSERT_NOT_NULL ("iotbus_gpio_open" , g_gpio);
 
-    g_gpio2 = iotbus_gpio_open(gpio_pin2);
-    TC_ASSERT_NEQ_CLEANUP ("iotbus_gpio_open", g_gpio2 , NULL ,"ERROR_RETURNED_NULL" ,iotbus_gpio_close(g_gpio));
+	g_gpio2 = iotbus_gpio_open(gpio_pin2);
+	TC_ASSERT_NEQ_CLEANUP("iotbus_gpio_open", g_gpio2 , NULL , iotbus_gpio_close(g_gpio));
 
     iotbus_gpio_set_direction(g_gpio, IOTBUS_GPIO_DIRECTION_OUT);
     iotbus_gpio_set_direction(g_gpio2, IOTBUS_GPIO_DIRECTION_IN);
 
-    ret = iotbus_gpio_register_cb(g_gpio2, IOTBUS_GPIO_EDGE_RISING, gpio_event_callback, (void *)g_gpio2);
-    TC_ASSERT_EQ_CLEANUP ("iotbus_gpio_register_cb", ret , 0 ,"UNEXPECTED_ERROR" ,iotbus_gpio_close(g_gpio2); iotbus_gpio_close(g_gpio));
+	ret = iotbus_gpio_register_cb(g_gpio2, IOTBUS_GPIO_EDGE_RISING, gpio_event_callback, (void *)g_gpio2);
+	TC_ASSERT_EQ_CLEANUP("iotbus_gpio_register_cb", ret , 0, iotbus_gpio_close(g_gpio2); iotbus_gpio_close(g_gpio));
 
     // To trigger event for callback
     iotbus_gpio_write(g_gpio, data);
@@ -300,13 +299,13 @@ void itc_gpio_register_unregister_callback_p(void)
     iotbus_gpio_write(g_gpio, data);
     sleep(2);
 
-    TC_ASSERT_EQ_CLEANUP ("iotbus_gpio_register_cb", gpio_flag_callback , 1 ,"callback not invoked" , iotbus_gpio_unregister_cb(g_gpio); iotbus_gpio_close(g_gpio2); iotbus_gpio_close(g_gpio));
+	TC_ASSERT_EQ_CLEANUP("iotbus_gpio_register_cb", gpio_flag_callback, 1, iotbus_gpio_unregister_cb(g_gpio); iotbus_gpio_close(g_gpio2); iotbus_gpio_close(g_gpio));
 
-    ret = iotbus_gpio_unregister_cb(g_gpio);
-    TC_ASSERT_EQ_CLEANUP ("iotbus_gpio_unregister_cb", ret , 0 ,"UNEXPECTED_ERROR" ,iotbus_gpio_close(g_gpio2); iotbus_gpio_close(g_gpio));
+	ret = iotbus_gpio_unregister_cb(g_gpio);
+	TC_ASSERT_EQ_CLEANUP("iotbus_gpio_unregister_cb", ret, 0, iotbus_gpio_close(g_gpio2); iotbus_gpio_close(g_gpio));
 
-    ret = iotbus_gpio_close(g_gpio2);
-    TC_ASSERT_EQ_CLEANUP ("iotbus_gpio_close", ret , 0 ,"not able to close g_gpio2 pin" , iotbus_gpio_close(g_gpio));
+	ret = iotbus_gpio_close(g_gpio2);
+	TC_ASSERT_EQ_CLEANUP("iotbus_gpio_close", ret, 0 , iotbus_gpio_close(g_gpio));
 
     ret = iotbus_gpio_close(g_gpio);
     TC_ASSERT_EQ(iotbus_gpio_close, ret, 0)

--- a/apps/examples/testcase/ta_tc/systemio/itc/itc_i2c.c
+++ b/apps/examples/testcase/ta_tc/systemio/itc/itc_i2c.c
@@ -62,22 +62,22 @@ void itc_iotbus_i2c_init_stop_p(void)
 */
 void itc_iotbus_i2c_set_frequency_p(void)
 {
-    int ret = IOTBUS_ERROR_NONE;
-    int szFreqMode[] = { IOTBUS_I2C_STD, IOTBUS_I2C_FAST, IOTBUS_I2C_HIGH };
-    int numModes = sizeof(szFreqMode) / sizeof(int);
-    int index = 0;
-    iotbus_i2c_context_h h_i2c = iotbus_i2c_init(g_bus);
-    TC_ASSERT_NOT_NULL("iotbus_i2c_init", h_i2c);
+	int ret = IOTBUS_ERROR_NONE;
+	int szFreqMode[] = { IOTBUS_I2C_STD, IOTBUS_I2C_FAST, IOTBUS_I2C_HIGH };
+	int numModes = sizeof(szFreqMode) / sizeof(int);
+	int index = 0;
+	iotbus_i2c_context_h h_i2c = iotbus_i2c_init(g_bus);
+	TC_ASSERT_NOT_NULL("iotbus_i2c_init", h_i2c);
 
-    for (index = 0; index < numModes; index++) {
-        ret = iotbus_i2c_set_frequency(h_i2c, szFreqMode[index]);
-        TC_ASSERT_EQ_CLEANUP("iotbus_i2c_set_frequency", ret, IOTBUS_ERROR_NONE, "Not able to set frequency", iotbus_i2c_stop(h_i2c));
-    }
+	for (index = 0; index < numModes; index++) {
+		ret = iotbus_i2c_set_frequency(h_i2c, szFreqMode[index]);
+		TC_ASSERT_EQ_CLEANUP("iotbus_i2c_set_frequency", ret, IOTBUS_ERROR_NONE, iotbus_i2c_stop(h_i2c));
+	}
 
-    ret = iotbus_i2c_stop(h_i2c);
-    TC_ASSERT_EQ("iotbus_i2c_stop", ret, IOTBUS_ERROR_NONE);
+	ret = iotbus_i2c_stop(h_i2c);
+	TC_ASSERT_EQ("iotbus_i2c_stop", ret, IOTBUS_ERROR_NONE);
 
-    TC_SUCCESS_RESULT();
+	TC_SUCCESS_RESULT();
 }
 
 /**
@@ -95,8 +95,8 @@ void itc_iotbus_i2c_set_address_p(void)
     iotbus_i2c_context_h h_i2c = iotbus_i2c_init(g_bus);
     TC_ASSERT_NOT_NULL("iotbus_i2c_init", h_i2c);
 
-    ret = iotbus_i2c_set_address(h_i2c, address);
-    TC_ASSERT_EQ_CLEANUP("iotbus_i2c_set_address", ret, IOTBUS_ERROR_NONE, "Not able to set address", iotbus_i2c_stop(h_i2c));
+	ret = iotbus_i2c_set_address(h_i2c, address);
+	TC_ASSERT_EQ_CLEANUP("iotbus_i2c_set_address", ret, IOTBUS_ERROR_NONE, iotbus_i2c_stop(h_i2c));
 
     ret = iotbus_i2c_stop(h_i2c);
     TC_ASSERT_EQ("iotbus_i2c_stop", ret, IOTBUS_ERROR_NONE);
@@ -120,11 +120,11 @@ void itc_iotbus_i2c_write_read_p(void)
     iotbus_i2c_context_h h_i2c = iotbus_i2c_init(g_bus);
     TC_ASSERT_NOT_NULL("iotbus_i2c_init", h_i2c);
 
-    ret = iotbus_i2c_write(h_i2c, szCmd, 1);
-    TC_ASSERT_EQ_CLEANUP("iotbus_i2c_write", (ret < 0), false, "Not able to write", iotbus_i2c_stop(h_i2c));
+	ret = iotbus_i2c_write(h_i2c, szCmd, 1);
+	TC_ASSERT_EQ_CLEANUP("iotbus_i2c_write", (ret < 0), false, iotbus_i2c_stop(h_i2c));
 
-    ret = iotbus_i2c_read(h_i2c, szReadBuf, 10);
-    TC_ASSERT_EQ_CLEANUP("iotbus_i2c_read", ret, IOTBUS_ERROR_NONE, "Not able to read", iotbus_i2c_stop(h_i2c));
+	ret = iotbus_i2c_read(h_i2c, szReadBuf, 10);
+	TC_ASSERT_EQ_CLEANUP("iotbus_i2c_read", ret, IOTBUS_ERROR_NONE, iotbus_i2c_stop(h_i2c));
 
     ret = iotbus_i2c_stop(h_i2c);
     TC_ASSERT_EQ("iotbus_i2c_stop", ret, IOTBUS_ERROR_NONE);

--- a/apps/examples/testcase/ta_tc/systemio/itc/itc_pwm.c
+++ b/apps/examples/testcase/ta_tc/systemio/itc/itc_pwm.c
@@ -68,11 +68,11 @@ void itc_pwm_set_get_duty_cycle_p(void)
     iotbus_pwm_context_h h_pwm = iotbus_pwm_open(device, channel);
     TC_ASSERT_NOT_NULL("iotbus_pwm_open", h_pwm);
 
-    ret = iotbus_pwm_set_duty_cycle(h_pwm, cycle);
-    TC_ASSERT_EQ_CLEANUP("iotbus_pwm_set_duty_cycle", ret, OK, "Not able to set duty cycle", iotbus_pwm_close(h_pwm));
+	ret = iotbus_pwm_set_duty_cycle(h_pwm, cycle);
+	TC_ASSERT_EQ_CLEANUP("iotbus_pwm_set_duty_cycle", ret, OK, iotbus_pwm_close(h_pwm));
 
-    ret = iotbus_pwm_get_duty_cycle(h_pwm);
-    TC_ASSERT_EQ_CLEANUP("iotbus_pwm_get_duty_cycle", ret, cycle, "set and get cycle value mismatch", iotbus_pwm_close(h_pwm));
+	ret = iotbus_pwm_get_duty_cycle(h_pwm);
+	TC_ASSERT_EQ_CLEANUP("iotbus_pwm_get_duty_cycle", ret, cycle, iotbus_pwm_close(h_pwm));
 
     ret = iotbus_pwm_close(h_pwm);
     TC_ASSERT_EQ("iotbus_pwm_close", ret, OK);
@@ -97,11 +97,11 @@ void itc_pwm_set_get_period_p(void)
     iotbus_pwm_context_h h_pwm = iotbus_pwm_open(device, channel);
     TC_ASSERT_NOT_NULL("iotbus_pwm_open", h_pwm);
 
-    ret = iotbus_pwm_set_period(h_pwm, period);
-    TC_ASSERT_EQ_CLEANUP("iotbus_pwm_set_period", ret, OK, "Not able to set period", iotbus_pwm_close(h_pwm));
+	ret = iotbus_pwm_set_period(h_pwm, period);
+	TC_ASSERT_EQ_CLEANUP("iotbus_pwm_set_period", ret, OK, iotbus_pwm_close(h_pwm));
 
-    ret = iotbus_pwm_get_period(h_pwm);
-    TC_ASSERT_EQ_CLEANUP("iotbus_pwm_get_period", ret, period, "set and get period value mismatch", iotbus_pwm_close(h_pwm));
+	ret = iotbus_pwm_get_period(h_pwm);
+	TC_ASSERT_EQ_CLEANUP("iotbus_pwm_get_period", ret, period, iotbus_pwm_close(h_pwm));
 
     ret = iotbus_pwm_close(h_pwm);
     TC_ASSERT_EQ("iotbus_pwm_close", ret, OK);
@@ -119,50 +119,50 @@ void itc_pwm_set_get_period_p(void)
 */
 void itc_pwm_set_enabled_is_enabled_p(void)
 {
-    int device = 0;
-    int channel = 1;
-    int period = 1000;
-    int ret = 0;
-    int default_state = 0;
-    int get_state = 0;
-    iotbus_pwm_context_h h_pwm = iotbus_pwm_open(device, channel);
-    TC_ASSERT_NOT_NULL("iotbus_pwm_open", h_pwm);
+	int device = 0;
+	int channel = 1;
+	int period = 1000;
+	int ret = 0;
+	int default_state = 0;
+	int get_state = 0;
+	iotbus_pwm_context_h h_pwm = iotbus_pwm_open(device, channel);
+	TC_ASSERT_NOT_NULL("iotbus_pwm_open", h_pwm);
 
-    ret = iotbus_pwm_set_period(h_pwm, period);
-    TC_ASSERT_EQ_CLEANUP("iotbus_pwm_set_period", ret, OK, "Not able to set period", iotbus_pwm_close(h_pwm));
+	ret = iotbus_pwm_set_period(h_pwm, period);
+	TC_ASSERT_EQ_CLEANUP("iotbus_pwm_set_period", ret, OK, iotbus_pwm_close(h_pwm));
 
-    ret = iotbus_pwm_get_period(h_pwm);
-    TC_ASSERT_EQ_CLEANUP("iotbus_pwm_get_period", ret, period, "set and get period value mismatch", iotbus_pwm_close(h_pwm));
+	ret = iotbus_pwm_get_period(h_pwm);
+	TC_ASSERT_EQ_CLEANUP("iotbus_pwm_get_period", ret, period, iotbus_pwm_close(h_pwm));
 
-    default_state = iotbus_pwm_is_enabled(h_pwm);
-    TC_ASSERT_EQ_CLEANUP("iotbus_pwm_is_enabled", default_state < OK, false, "unexpected error", iotbus_pwm_close(h_pwm));
+	default_state = iotbus_pwm_is_enabled(h_pwm);
+	TC_ASSERT_EQ_CLEANUP("iotbus_pwm_is_enabled", default_state < OK, false, iotbus_pwm_close(h_pwm));
 
-    iotbus_pwm_state_e e_state = IOTBUS_PWM_ENABLE;
-    if (default_state == IOTBUS_PWM_DISABLE) {
-        ret = iotbus_pwm_set_enabled(h_pwm, e_state);
-        TC_ASSERT_EQ_CLEANUP("iotbus_pwm_set_enabled", ret, OK, "unexpected error", iotbus_pwm_close(h_pwm));
+	iotbus_pwm_state_e e_state = IOTBUS_PWM_ENABLE;
+	if (default_state == IOTBUS_PWM_DISABLE) {
+		ret = iotbus_pwm_set_enabled(h_pwm, e_state);
+		TC_ASSERT_EQ_CLEANUP("iotbus_pwm_set_enabled", ret, OK, iotbus_pwm_close(h_pwm));
 
-        get_state = iotbus_pwm_is_enabled(h_pwm);
-        TC_ASSERT_EQ_CLEANUP("iotbus_pwm_is_enabled", get_state, e_state, "state value mismatch", iotbus_pwm_close(h_pwm); iotbus_pwm_set_enabled(h_pwm, default_state));
+		get_state = iotbus_pwm_is_enabled(h_pwm);
+		TC_ASSERT_EQ_CLEANUP("iotbus_pwm_is_enabled", get_state, e_state, iotbus_pwm_close(h_pwm); iotbus_pwm_set_enabled(h_pwm, default_state));
 
-        // Restoring default state
-        iotbus_pwm_set_enabled(h_pwm, default_state);
-    } else {
-        e_state = IOTBUS_PWM_DISABLE;
-        ret = iotbus_pwm_set_enabled(h_pwm, e_state);
-        TC_ASSERT_EQ_CLEANUP("iotbus_pwm_set_enabled", ret, OK, "unexpected error", iotbus_pwm_close(h_pwm));
+		// Restoring default state
+		iotbus_pwm_set_enabled(h_pwm, default_state);
+	} else {
+		e_state = IOTBUS_PWM_DISABLE;
+		ret = iotbus_pwm_set_enabled(h_pwm, e_state);
+		TC_ASSERT_EQ_CLEANUP("iotbus_pwm_set_enabled", ret, OK, iotbus_pwm_close(h_pwm));
 
-        get_state = iotbus_pwm_is_enabled(h_pwm);
-        TC_ASSERT_EQ_CLEANUP("iotbus_pwm_is_enabled", get_state, e_state, "state value mismatch", iotbus_pwm_close(h_pwm); iotbus_pwm_set_enabled(h_pwm, default_state));
+		get_state = iotbus_pwm_is_enabled(h_pwm);
+		TC_ASSERT_EQ_CLEANUP("iotbus_pwm_is_enabled", get_state, e_state, iotbus_pwm_close(h_pwm); iotbus_pwm_set_enabled(h_pwm, default_state));
 
-        // Restoring default state
-        iotbus_pwm_set_enabled(h_pwm, default_state);
-    }
+		// Restoring default state
+		iotbus_pwm_set_enabled(h_pwm, default_state);
+	}
 
-    ret = iotbus_pwm_close(h_pwm);
-    TC_ASSERT_NOT_NULL("iotbus_pwm_close", h_pwm);
+	ret = iotbus_pwm_close(h_pwm);
+	TC_ASSERT_NOT_NULL("iotbus_pwm_close", h_pwm);
 
-    TC_SUCCESS_RESULT();
+	TC_SUCCESS_RESULT();
 }
 
 int itc_pwm_main(void)

--- a/apps/examples/testcase/ta_tc/systemio/itc/itc_spi.c
+++ b/apps/examples/testcase/ta_tc/systemio/itc/itc_spi.c
@@ -78,17 +78,17 @@ void itc_iotbus_spi_write_recv_trasfer_p(void)
     iotbus_spi_context_h h_spi = iotbus_spi_open(gBus, &_g_st_config);
     TC_ASSERT_NOT_NULL("iotbus_spi_open", h_spi);
 
-    ret = iotbus_spi_write(h_spi, sz_txbuf, 8);
-    TC_ASSERT_EQ_CLEANUP("iotbus_spi_write", ret, IOTBUS_ERROR_NONE, "Not able to write", iotbus_spi_close(h_spi));
+	ret = iotbus_spi_write(h_spi, sz_txbuf, 8);
+	TC_ASSERT_EQ_CLEANUP("iotbus_spi_write", ret, IOTBUS_ERROR_NONE, iotbus_spi_close(h_spi));
 
-    ret = iotbus_spi_recv(h_spi, sz_rxbuf, 8);
-    TC_ASSERT_EQ_CLEANUP("iotbus_spi_recv", ret, IOTBUS_ERROR_NONE, "Not able to recv", iotbus_spi_close(h_spi));
+	ret = iotbus_spi_recv(h_spi, sz_rxbuf, 8);
+	TC_ASSERT_EQ_CLEANUP("iotbus_spi_recv", ret, IOTBUS_ERROR_NONE, iotbus_spi_close(h_spi));
 
     ret = iotbus_spi_transfer_buf(h_spi, sz_txbuf, sz_rxbuf, 16);
 #ifdef CONFIG_SPI_EXCHANGE
-    TC_ASSERT_EQ_CLEANUP("iotbus_spi_transfer_buf", ret, IOTBUS_ERROR_NONE, "Not able to transfer", iotbus_spi_close(h_spi));
+	TC_ASSERT_EQ_CLEANUP("iotbus_spi_transfer_buf", ret, IOTBUS_ERROR_NONE, iotbus_spi_close(h_spi));
 #else
-    TC_ASSERT_EQ_CLEANUP("iotbus_spi_transfer_buf", ret, IOTBUS_ERROR_NOT_SUPPORTED, "Unexpected Error", iotbus_spi_close(h_spi));
+	TC_ASSERT_EQ_CLEANUP("iotbus_spi_transfer_buf", ret, IOTBUS_ERROR_NOT_SUPPORTED, iotbus_spi_close(h_spi));
 #endif
 
     ret = iotbus_spi_close(h_spi);

--- a/apps/examples/testcase/ta_tc/systemio/itc/itc_uart.c
+++ b/apps/examples/testcase/ta_tc/systemio/itc/itc_uart.c
@@ -76,8 +76,8 @@ void itc_iotbus_uart_set_baudrate_p(void)
     iotbus_uart_context_h h_uart = iotbus_uart_init(DEVPATH);
     TC_ASSERT_NOT_NULL("iotbus_uart_init", h_uart);
 
-    ret = iotbus_uart_set_baudrate(h_uart, i_baudrate);
-    TC_ASSERT_EQ_CLEANUP("iotbus_uart_set_baudrate", ret, IOTBUS_ERROR_NONE, "Not able to set baudrate", iotbus_uart_stop(h_uart));
+	ret = iotbus_uart_set_baudrate(h_uart, i_baudrate);
+	TC_ASSERT_EQ_CLEANUP("iotbus_uart_set_baudrate", ret, IOTBUS_ERROR_NONE, iotbus_uart_stop(h_uart));
 
     ret = iotbus_uart_stop(h_uart);
     TC_ASSERT_EQ("iotbus_uart_stop", ret, IOTBUS_ERROR_NONE);
@@ -95,24 +95,24 @@ void itc_iotbus_uart_set_baudrate_p(void)
 */
 void itc_iotbus_uart_set_mode_p(void)
 {
-    int i_bytesize = 8;
-    int i_stop_bits = 1;
-    int ret = IOTBUS_ERROR_NONE;
-    int mode[] = { IOTBUS_UART_PARITY_NONE, IOTBUS_UART_PARITY_EVEN, IOTBUS_UART_PARITY_ODD };
-    int i_modes = sizeof(mode) / sizeof(int);
-    int index = 0;
-    iotbus_uart_context_h h_uart = iotbus_uart_init(DEVPATH);
-    TC_ASSERT_NOT_NULL("iotbus_uart_init", h_uart);
+	int i_bytesize = 8;
+	int i_stop_bits = 1;
+	int ret = IOTBUS_ERROR_NONE;
+	int mode[] = { IOTBUS_UART_PARITY_NONE, IOTBUS_UART_PARITY_EVEN, IOTBUS_UART_PARITY_ODD };
+	int i_modes = sizeof(mode) / sizeof(int);
+	int index = 0;
+	iotbus_uart_context_h h_uart = iotbus_uart_init(DEVPATH);
+	TC_ASSERT_NOT_NULL("iotbus_uart_init", h_uart);
 
-    for (index = 0; index < i_modes; index++) {
-        ret = iotbus_uart_set_mode(h_uart, i_bytesize, mode[index], i_stop_bits);
-        TC_ASSERT_EQ_CLEANUP("iotbus_uart_set_mode", ret, IOTBUS_ERROR_NONE, "Not able to set mode", iotbus_uart_stop(h_uart));
-    }
+	for (index = 0; index < i_modes; index++) {
+		ret = iotbus_uart_set_mode(h_uart, i_bytesize, mode[index], i_stop_bits);
+		TC_ASSERT_EQ_CLEANUP("iotbus_uart_set_mode", ret, IOTBUS_ERROR_NONE, iotbus_uart_stop(h_uart));
+	}
 
-    ret = iotbus_uart_stop(h_uart);
-    TC_ASSERT_EQ("iotbus_uart_stop", ret, IOTBUS_ERROR_NONE);
+	ret = iotbus_uart_stop(h_uart);
+	TC_ASSERT_EQ("iotbus_uart_stop", ret, IOTBUS_ERROR_NONE);
 
-    TC_SUCCESS_RESULT();
+	TC_SUCCESS_RESULT();
 }
 
 /**
@@ -125,22 +125,22 @@ void itc_iotbus_uart_set_mode_p(void)
 */
 void itc_iotbus_uart_set_flowcontrol_p(void)
 {
-    int i_size = 4;
-    int ret = IOTBUS_ERROR_NONE;
-    int rtscts[4][2] = { {1, 0}, {0, 1}, {1, 1}, {0, 0} };
-    int index = 0;
-    iotbus_uart_context_h h_uart = iotbus_uart_init(DEVPATH);
-    TC_ASSERT_NOT_NULL("iotbus_uart_init", h_uart);
+	int i_size = 4;
+	int ret = IOTBUS_ERROR_NONE;
+	int rtscts[4][2] = { {1, 0}, {0, 1}, {1, 1}, {0, 0} };
+	int index = 0;
+	iotbus_uart_context_h h_uart = iotbus_uart_init(DEVPATH);
+	TC_ASSERT_NOT_NULL("iotbus_uart_init", h_uart);
 
-    for (index = 0; index < i_size; index++) {
-        ret = iotbus_uart_set_flowcontrol(h_uart, rtscts[index][0], rtscts[index][1]);
-        TC_ASSERT_EQ_CLEANUP("iotbus_uart_set_flowcontrol", ret, IOTBUS_ERROR_NONE, "Not able to set flowcontrol", iotbus_uart_stop(h_uart));
-    }
+	for (index = 0; index < i_size; index++) {
+		ret = iotbus_uart_set_flowcontrol(h_uart, rtscts[index][0], rtscts[index][1]);
+		TC_ASSERT_EQ_CLEANUP("iotbus_uart_set_flowcontrol", ret, IOTBUS_ERROR_NONE, iotbus_uart_stop(h_uart));
+	}
 
-    ret = iotbus_uart_stop(h_uart);
-    TC_ASSERT_EQ("iotbus_uart_stop", ret, IOTBUS_ERROR_NONE);
+	ret = iotbus_uart_stop(h_uart);
+	TC_ASSERT_EQ("iotbus_uart_stop", ret, IOTBUS_ERROR_NONE);
 
-    TC_SUCCESS_RESULT();
+	TC_SUCCESS_RESULT();
 }
 
 /**
@@ -159,15 +159,15 @@ void itc_iotbus_uart_write_read_p(void)
     iotbus_uart_context_h h_uart = iotbus_uart_init(DEVPATH);
     TC_ASSERT_NOT_NULL("iotbus_uart_init", h_uart);
 
-    ret = iotbus_uart_write(h_uart, szInputText, sizeof(szInputText));
-    TC_ASSERT_EQ_CLEANUP("iotbus_uart_write", ret < 0, false, "Not able to write", iotbus_uart_stop(h_uart));
+	ret = iotbus_uart_write(h_uart, szInputText, sizeof(szInputText));
+	TC_ASSERT_EQ_CLEANUP("iotbus_uart_write", ret < 0, false, iotbus_uart_stop(h_uart));
 
     usleep(MICROSECOND);
 
-    ret = iotbus_uart_read(h_uart, szOutputText, sizeof(szOutputText));
-    TC_ASSERT_EQ_CLEANUP("iotbus_uart_read", ret < 0, false, "Not able to read", iotbus_uart_stop(h_uart));
+	ret = iotbus_uart_read(h_uart, szOutputText, sizeof(szOutputText));
+	TC_ASSERT_EQ_CLEANUP("iotbus_uart_read", ret < 0, false, iotbus_uart_stop(h_uart));
 
-    TC_ASSERT_EQ_CLEANUP("iotbus_uart_read", strcmp(szInputText, szOutputText), 0, "mismatched in read buffer / write buffer", iotbus_uart_stop(h_uart));
+	TC_ASSERT_EQ_CLEANUP("iotbus_uart_read", strcmp(szInputText, szOutputText), 0, iotbus_uart_stop(h_uart));
 
     ret = iotbus_uart_stop(h_uart);
     TC_ASSERT_EQ("iotbus_uart_stop", ret, IOTBUS_ERROR_NONE);
@@ -189,8 +189,8 @@ void itc_iotbus_uart_flush_p(void)
     iotbus_uart_context_h h_uart = iotbus_uart_init(DEVPATH);
     TC_ASSERT_NOT_NULL("iotbus_uart_init", h_uart);
 
-    ret = iotbus_uart_flush(h_uart);
-    TC_ASSERT_EQ_CLEANUP("iotbus_uart_flush", ret, IOTBUS_ERROR_NONE, "Not able to flush", iotbus_uart_stop(h_uart));
+	ret = iotbus_uart_flush(h_uart);
+	TC_ASSERT_EQ_CLEANUP("iotbus_uart_flush", ret, IOTBUS_ERROR_NONE, iotbus_uart_stop(h_uart));
 
     ret = iotbus_uart_stop(h_uart);
     TC_ASSERT_EQ("iotbus_uart_stop", ret, IOTBUS_ERROR_NONE);

--- a/apps/examples/testcase/tc_common.h
+++ b/apps/examples/testcase/tc_common.h
@@ -24,29 +24,32 @@
 int total_pass;
 int total_fail;
 
-#define TC_ASSERT_CLEANUP(api_name, var, error, freeResource) \
+#define TC_ASSERT_CLEANUP(api_name, var, freeResource) \
 {\
 	if (!(var)) {\
-		printf("\n[%s][Line : %d] FAIL, %s : API error returned = %s [%s]\n", __func__, __LINE__, api_name, error, #var); \
+		printf("\n[%s][Line : %d] FAIL, %s : Following expression is not true: %s\n", __func__, __LINE__, api_name, #var); \
 		total_fail++; \
 		freeResource; \
 		return; \
 	} \
 }
 
-#define TC_ASSERT(api_name, var) \
+#define TC_ASSERT(api_name, var) TC_ASSERT_CLEANUP(api_name, var,)
+
+#define TC_ASSERT_EQ_CLEANUP(api_name, var, ref, freeResource) \
 {\
-	if (!(var)) {\
-		printf("\n[%s][Line : %d] FAIL, %s : Following expression is not true: %s\n", __func__, __LINE__, api_name, #var); \
+	if ((var) != (ref)) {\
+		printf("\n[%s][Line : %d] FAIL, %s : Values (%s == 0x%x) and (%s == 0x%x) are not equal\n", __func__, __LINE__, api_name, #var, (int)(var), #ref, (int)(ref)); \
 		total_fail++; \
+		freeResource; \
 		return; \
 	} \
 }
 
-#define TC_ASSERT_EQ_CLEANUP(api_name, var, ref, error, freeResource) \
+#define TC_ASSERT_EQ_ERROR_CLEANUP(api_name, var, ref, error, freeResource) \
 {\
 	if ((var) != (ref)) {\
-		printf("\n[%s][Line : %d] FAIL, %s : API error returned = %s, (%s == 0x%x) and (%s == 0x%x) are not equal\n", __func__, __LINE__, api_name, error, #var, (int)(var), #ref, (int)(ref)); \
+		printf("\n[%s][Line : %d] FAIL, %s : API returned = %d, Values (%s == 0x%x) and (%s == 0x%x) are not equal\n", __func__, __LINE__, api_name, error, #var, (int)(var), #ref, (int)(ref)); \
 		total_fail++; \
 		freeResource; \
 		return; \
@@ -64,100 +67,65 @@ int total_fail;
 
 #define TC_ASSERT_EQ(api_name, var, ref) TC_ASSERT_EQ_RETURN(api_name, var, ref,)
 
-#define TC_ASSERT_NEQ_CLEANUP(api_name, var, ref, error, freeResource) \
-{\
-	if ((var) == (ref)) {\
-		printf("\n[%s][Line : %d] FAIL, %s : API error returned = %s, (%s == 0x%x) and (%s == 0x%x) are equal\n", __func__, __LINE__, api_name, error, #var, (int)(var), #ref, (int)(ref)); \
-		total_fail++; \
-		freeResource; \
-		return; \
-	} \
-}
-
-#define TC_ASSERT_NEQ(api_name, var, ref) \
+#define TC_ASSERT_NEQ_CLEANUP(api_name, var, ref, freeResource) \
 {\
 	if ((var) == (ref)) {\
 		printf("\n[%s][Line : %d] FAIL, %s : Values (%s == 0x%x) and (%s == 0x%x) are equal\n", __func__, __LINE__, api_name, #var, (int)(var), #ref, (int)(ref)); \
 		total_fail++; \
+		freeResource; \
 		return; \
 	} \
 }
 
-#define TC_ASSERT_GT_CLEANUP(api_name, var, ref, error, freeResource) \
+#define TC_ASSERT_NEQ(api_name, var, ref) TC_ASSERT_NEQ_CLEANUP(api_name, var, ref,)
+
+#define TC_ASSERT_GT_CLEANUP(api_name, var, ref, freeResource) \
 {\
 	if ((var) <= (ref)) {\
-		printf("\n[%s][Line : %d] FAIL, %s : API error returned = %s, (%s == 0x%x) is not greater than (%s == 0x%x)\n", __func__, __LINE__, api_name, error, #var, (int)(var), #ref, (int)(ref)); \
-		total_fail++; \
-		freeResource; \
-		return; \
-	} \
-}
-
-#define TC_ASSERT_GT(api_name, var, ref) \
-{\
-	if ((var) <= (ref))    {\
 		printf("\n[%s][Line : %d] FAIL, %s : Values (%s == 0x%x) is not greater than (%s == 0x%x)\n", __func__, __LINE__, api_name, #var, (int)(var), #ref, (int)(ref)); \
 		total_fail++; \
-		return; \
-	} \
-}
-
-#define TC_ASSERT_GEQ_CLEANUP(api_name, var, ref, error, freeResource) \
-{\
-	if ((var) < (ref)) {\
-		printf("\n[%s][Line : %d] FAIL, %s : API error returned = %s, (%s == 0x%x) is not greater than or equal to (%s == 0x%x)\n", __func__, __LINE__, api_name, error, #var, (int)(var), #ref, (int)(ref)); \
-		total_fail++; \
 		freeResource; \
 		return; \
 	} \
 }
 
-#define TC_ASSERT_GEQ(api_name, var, ref) \
+#define TC_ASSERT_GT(api_name, var, ref) TC_ASSERT_GT_CLEANUP(api_name, var, ref,)
+
+#define TC_ASSERT_GEQ_CLEANUP(api_name, var, ref, freeResource) \
 {\
 	if ((var) < (ref)) {\
 		printf("\n[%s][Line : %d] FAIL, %s : Values (%s == 0x%x) is not greater than or equal to (%s == 0x%x)\n", __func__, __LINE__, api_name, #var, (int)(var), #ref, (int)(ref)); \
 		total_fail++; \
-		return; \
-	} \
-}
-
-#define TC_ASSERT_LT_CLEANUP(api_name, var, ref, error, freeResource) \
-{\
-	if ((var) >= (ref)) {\
-		printf("\n[%s][Line : %d] FAIL, %s : API error returned = %s, (%s == 0x%x) is not lower than (%s == 0x%x)\n", __func__, __LINE__, api_name, error, #var, (int)(var), #ref, (int)(ref)); \
-		total_fail++; \
 		freeResource; \
 		return; \
 	} \
 }
 
-#define TC_ASSERT_LT(api_name, var, ref) \
+#define TC_ASSERT_GEQ(api_name, var, ref) TC_ASSERT_GEQ_CLEANUP(api_name, var, ref,)
+
+#define TC_ASSERT_LT_CLEANUP(api_name, var, ref, freeResource) \
 {\
 	if ((var) >= (ref)) {\
 		printf("\n[%s][Line : %d] FAIL, %s : Values (%s == 0x%x) is not lower than (%s == 0x%x)\n", __func__, __LINE__, api_name, #var, (int)(var), #ref, (int)(ref)); \
 		total_fail++; \
+		freeResource; \
 		return; \
 	} \
 }
 
-#define TC_ASSERT_LEQ_CLEANUP(api_name, var, ref, error, freeResource) \
+#define TC_ASSERT_LT(api_name, var, ref) TC_ASSERT_LT_CLEANUP(api_name, var, ref,)
+
+#define TC_ASSERT_LEQ_CLEANUP(api_name, var, ref, freeResource) \
 {\
 	if ((var) > (ref)) {\
-		printf("\n[%s][Line : %d] FAIL, %s : API error returned = %s, (%s == 0x%x) is not lower than or equal to (%s == 0x%x)\n", __func__, __LINE__, api_name, error, #var, (int)(var), #ref, (int)(ref)); \
+		printf("\n[%s][Line : %d] FAIL, %s : Values (%s == 0x%x) is not lower than or equal to (%s == 0x%x)\n", __func__, __LINE__, api_name, #var, (int)(var), #ref, (int)(ref)); \
 		total_fail++; \
 		freeResource; \
 		return; \
 	} \
 }
 
-#define TC_ASSERT_LEQ(api_name, var, ref) \
-{\
-	if ((var) > (ref)) {\
-		printf("\n[%s][Line : %d] FAIL, %s : Values (%s == 0x%x) is not lower than or equal to (%s == 0x%x)\n", __func__, __LINE__, api_name, #var, (int)(var), #ref, (int)(ref)); \
-		total_fail++; \
-		return; \
-	} \
-}
+#define TC_ASSERT_LEQ(api_name, var, ref) TC_ASSERT_LEQ_CLEANUP(api_name, var, ref,)
 
 #define TC_ASSERT_NOT_NULL(api_name, handle) \
 {\


### PR DESCRIPTION
Remove error parameter of clean up functions in tc macros because this is not useful
Leave a function which checks whether values are equal and rename it to TC_ASSERT_EQ_ERROR_CLEANUP to show error type