### PR TITLE
Added missing stdio APIs: freopen,setbuf,setvbuf,remove

### DIFF
--- a/lib/libc/Kconfig
+++ b/lib/libc/Kconfig
@@ -9,8 +9,10 @@ config STDIO_BUFFER_SIZE
 	int "C STDIO buffer size"
 	default 64
 	---help---
-		Size of buffers using within the C buffered I/O interfaces.
-		(printf, putchar, fwrite, etc.).
+		Size of buffers using within the C buffered I/O interfaces (printf,
+		putchar, fwrite, etc.).  This function sets the initial I/O buffer
+		size.  Zero disables I/O buffering.  That size may be subsequently
+		modified using setvbuf().
 
 config STDIO_LINEBUFFER
 	bool "STDIO line buffering"

--- a/lib/libc/lib_internal.h
+++ b/lib/libc/lib_internal.h
@@ -170,6 +170,10 @@ void stream_semgive(FAR struct streamlist *list);
 char *__dtoa(double d, int mode, int ndigits, int *decpt, int *sign, char **rve);
 #endif
 
+/* Defined in lib_fopen.c */
+
+int lib_mode2oflags(FAR const char *mode);
+
 /* Defined in lib_libwrite.c */
 
 ssize_t lib_fwrite(FAR const void *ptr, size_t count, FAR FILE *stream);

--- a/lib/libc/misc/lib_stream.c
+++ b/lib/libc/misc/lib_stream.c
@@ -117,13 +117,16 @@ void lib_stream_initialize(FAR struct task_group_s *group)
 	/* Initialize each FILE structure */
 
 	for (i = 0; i < CONFIG_NFILE_STREAMS; i++) {
+
+		FAR struct file_struct *stream = &list->sl_streams[i];
+
 		/* Clear the IOB */
 
-		memset(&list->sl_streams[i], 0, sizeof(FILE));
+		memset(stream, 0, sizeof(FILE));
 
 		/* Indicate not opened */
 
-		list->sl_streams[i].fs_fd = -1;
+		stream->fs_fd = -1;
 
 		/* Initialize the stream semaphore to one to support one-at-
 		 * a-time access to private data sets.
@@ -169,17 +172,20 @@ void lib_stream_release(FAR struct task_group_s *group)
 
 #if CONFIG_STDIO_BUFFER_SIZE > 0
 	for (i = 0; i < CONFIG_NFILE_STREAMS; i++) {
+
+		FAR struct file_struct *stream = &list->sl_streams[i];
+
 		/* Destroy the semaphore that protects the IO buffer */
 
-		(void)sem_destroy(&list->sl_streams[i].fs_sem);
+		(void)sem_destroy(&stream->fs_sem);
 
 		/* Release the IO buffer */
 
-		if (list->sl_streams[i].fs_bufstart) {
+		if (stream->fs_bufstart != NULL && (stream->fs_flags & __FS_FLAG_UBF) == 0) {
 #ifndef CONFIG_BUILD_KERNEL
 			/* Release memory from the user heap */
 
-			sched_ufree(list->sl_streams[i].fs_bufstart);
+			sched_ufree(stream->fs_bufstart);
 #else
 			/* If the exiting group is unprivileged, then it has an address
 			 * environment.  Don't bother to release the memory in this case...
@@ -190,7 +196,7 @@ void lib_stream_release(FAR struct task_group_s *group)
 			 */
 
 			if ((group->tg_flags & GROUP_FLAG_PRIVILEGED) != 0) {
-				sched_kfree(list->sl_streams[i].fs_bufstart);
+				sched_kfree(stream->fs_bufstart);
 			}
 #endif
 		}

--- a/lib/libc/stdio/Make.defs
+++ b/lib/libc/stdio/Make.defs
@@ -73,7 +73,7 @@ CSRCS += lib_rawsostream.c
 
 ifneq ($(CONFIG_NFILE_STREAMS),0)
 
-CSRCS += lib_fopen.c lib_fclose.c lib_fread.c lib_libfread.c lib_fseek.c
+CSRCS += lib_fopen.c lib_freopen.c lib_fclose.c lib_fread.c lib_libfread.c lib_fseek.c
 CSRCS += lib_ftell.c lib_fsetpos.c lib_fgetpos.c lib_fgetc.c lib_fgets.c
 CSRCS += lib_gets_s.c lib_gets.c lib_libfgets.c lib_fwrite.c lib_libfwrite.c
 CSRCS += lib_fflush.c lib_libflushall.c lib_libfflush.c lib_rdflush.c
@@ -81,7 +81,7 @@ CSRCS += lib_wrflush.c lib_fputc.c lib_puts.c lib_fputs.c lib_ungetc.c
 CSRCS += lib_vprintf.c lib_fprintf.c lib_vfprintf.c lib_stdinstream.c
 CSRCS += lib_stdoutstream.c lib_stdsistream.c lib_stdsostream.c lib_perror.c
 CSRCS += lib_feof.c lib_ferror.c lib_clearerr.c
-
+CSRCS += lib_setbuf.c lib_setvbuf.c lib_remove.c
 endif
 
 ifeq ($(CONFIG_FS_WRITABLE),y)

--- a/lib/libc/stdio/lib_fopen.c
+++ b/lib/libc/stdio/lib_fopen.c
@@ -97,7 +97,7 @@
  * Name: lib_mode2oflags
  ****************************************************************************/
 
-static int lib_mode2oflags(FAR const char *mode)
+int lib_mode2oflags(FAR const char *mode)
 {
 	unsigned int state;
 	int oflags;

--- a/lib/libc/stdio/lib_setvbuf.c
+++ b/lib/libc/stdio/lib_setvbuf.c
@@ -1,0 +1,272 @@
+/****************************************************************************
+ *
+ * Copyright 2017 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+/****************************************************************************
+ * libc/stdio/lib_setvbuf.c
+ *
+ *   Copyright (C) 2017 Gregory Nutt. All rights reserved.
+ *   Author: Alan Carvalho de Assis <acassis@gmail.com>
+ *           Gregory Nutt <gnutt@nuttx.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT will THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <tinyara/config.h>
+
+#include <sys/types.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <errno.h>
+
+#include <tinyara/fs/fs.h>
+
+#include "lib_internal.h"
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: setvbuf
+ *
+ * Description:
+ *   The setvbuf() function may be used after the stream pointed to by
+ *   stream is associated with an open file but before any other operation
+ *   (other than an unsuccessful call to setvbuf()) is performed on the
+ *   stream. The argument type determines how stream will be buffered, as
+ *   follows:
+ *
+ *   _IOFBF - Will cause input/output to be fully buffered.
+ *   _IOLBF - Will cause input/output to be line buffered.
+ *   _IONBF - Will cause input/output to be unbuffered.
+ *
+ * If buf is not a null pointer, the array it points to may be used instead
+ * of a buffer allocated by setvbuf() and the argument size specifies the size
+ * of the array; otherwise, size may determine the size of a buffer allocated
+ * by the setvbuf() function. The contents of the array at any time are
+ * unspecified.
+ *
+ * Input Parameters:
+ *   stream - the stream to flush
+ *   buffer - the user allocate buffer. If NULL, will allocates a buffer of
+ *            specified size
+ *   mode   - specifies a mode for file buffering
+ *   size   - size of buffer
+ *
+ * Returned Value:
+ *   Upon successful completion, setvbuf() will return 0. Otherwise, it will
+ *   return a non-zero value if an invalid value is given for type or if the
+ *   request cannot be honored, [CX] and may set errno to indicate the error
+ *
+ ****************************************************************************/
+
+#if CONFIG_STDIO_BUFFER_SIZE > 0
+int setvbuf(FAR FILE *stream, FAR char *buffer, int mode, size_t size)
+{
+	FAR unsigned char *newbuf;
+	uint8_t flags;
+	int errcode;
+
+	/* Verify arguments */
+	/* Make sure that a valid mode was provided */
+
+	if (mode != _IOFBF && mode != _IOLBF && mode != _IONBF) {
+		errcode = EINVAL;
+		goto errout;
+	}
+
+	/* If a buffer pointer is provided, then it must have a non-zero size */
+
+	if (buffer != NULL && size == 0) {
+		errcode = EINVAL;
+		goto errout;
+	}
+
+	/* My assumption is that if size is zero for modes {_IOFBF, _IOLBF} the
+	 * caller is only attempting to change the buffering mode.  In this case,
+	 * the existing buffer should be re-used (if there is one).  If there is no
+	 * existing buffer, then I suppose we should allocate one of the default
+	 * size?
+	 */
+
+	if ((mode == _IOFBF || mode == _IOLBF) && size == 0 && stream->fs_bufstart == NULL) {
+		size = BUFSSIZ;
+	}
+
+	/* A non-zero size (or a non-NULL buffer) with mode = _IONBF makes no
+	 * sense but is, apparently, permissible. We simply force the buffer to
+	 * NULL and size to zero in this case without complaining.
+	 */
+
+	else if (mode == _IONBF) {
+		buffer = NULL;
+		size = 0;
+	}
+
+	/* Make sure that we have exclusive access to the stream */
+
+	lib_take_semaphore(stream);
+
+	/* setvbuf() may only be called AFTER the file has been opened and BEFORE
+	 * any operations have been performed on the string.
+	 */
+
+	/* Return EBADF if the file is not open */
+
+	if (stream->fs_fd < 0) {
+		errcode = EBADF;
+		goto errout_with_semaphore;
+	}
+
+	/* Return EBUSY if operations have already been performed on the buffer.
+	 * Here we really only verify that there is no valid data in the existing
+	 * buffer.
+	 *
+	 * REVIST:  There could be race conditions here, could there not?
+	 */
+
+	if (stream->fs_bufpos != stream->fs_bufstart) {
+		errcode = EBUSY;
+		goto errout_with_semaphore;
+	}
+
+	/* Initialize by clearing related flags.  We try to avoid any permanent
+	 * changes to the stream structure until we know that we will be
+	 * successful.
+	 */
+
+	flags = stream->fs_flags & ~(__FS_FLAG_LBF | __FS_FLAG_UBF);
+
+	/* Allocate a new buffer if one is needed or reuse the existing buffer it
+	 * is appropriate to do so.
+	 */
+
+	switch (mode) {
+	case _IOLBF:
+		flags |= __FS_FLAG_LBF;
+
+		/* Fall through */
+
+	case _IOFBF:
+		/* Use the existing buffer if size == 0 */
+
+		if (size > 0) {
+			/* A new buffer is needed.  Did the caller provide the buffer
+			 * memory?
+			 */
+
+			if (buffer != NULL) {
+				newbuf = (FAR unsigned char *)buffer;
+
+				/* Indicate that we have an I/O buffer managed by the caller of
+				 * setvbuf.
+				 */
+
+				flags |= __FS_FLAG_UBF;
+			} else {
+				newbuf = (FAR unsigned char *)lib_malloc(size);
+				if (newbuf == NULL) {
+					errcode = ENOMEM;
+					goto errout_with_semaphore;
+				}
+			}
+		} else {
+			/* Re-use the existing buffer and retain some existing flags.
+			 * This supports changing the buffering mode without changing
+			 * the buffer.
+			 */
+
+			DEBUGASSERT(stream->fs_bufstart != NULL);
+			flags |= stream->fs_flags & __FS_FLAG_UBF;
+			goto reuse_buffer;
+		}
+
+		break;
+
+	case _IONBF:
+		/* No buffer needed... We must be performing unbuffered I/O */
+
+		newbuf = NULL;
+		break;
+
+	default:
+		PANIC();
+	}
+
+	/* Do not release the previous buffer if it was allocated by the user
+	 * on a previous call to setvbuf().
+	 */
+
+	if (stream->fs_bufstart != NULL && (stream->fs_flags & __FS_FLAG_UBF) == 0) {
+		lib_free(stream->fs_bufstart);
+	}
+
+	/* Set the new buffer information */
+
+	stream->fs_bufstart = newbuf;
+	stream->fs_bufpos = newbuf;
+	stream->fs_bufread = newbuf;
+	stream->fs_bufend = newbuf + size;
+
+	/* Update the stream flags and return success */
+
+reuse_buffer:
+
+	stream->fs_flags = flags;
+	lib_give_semaphore(stream);
+	return OK;
+
+errout_with_semaphore:
+	lib_give_semaphore(stream);
+
+errout:
+	set_errno(errcode);
+	return ERROR;
+}
+#endif

--- a/os/fs/vfs/fs_fcntl.c
+++ b/os/fs/vfs/fs_fcntl.c
@@ -281,8 +281,8 @@ int fcntl(int fd, int cmd, ...)
 #endif
 		{
 			/* No.. this descriptor number is out of range */
-
-			ret = EBADF;
+			set_errno(EBADF);
+			ret = ERROR;
 		}
 	}
 

--- a/os/include/stdio.h
+++ b/os/include/stdio.h
@@ -89,6 +89,20 @@
 
 #define FILENAME_MAX _POSIX_NAME_MAX
 
+/* The (default) size of the I/O buffers */
+
+#if (CONFIG_STDIO_BUFFER_SIZE > 0)
+#  define BUFSSIZ   CONFIG_STDIO_BUFFER_SIZE
+#else
+#  define BUFSSIZ   64
+#endif
+
+/* The following three definitions are for ANSI C, used by setvbuf */
+
+#define _IOFBF     0               /* Fully buffered */
+#define _IOLBF     1               /* Line buffered */
+#define _IONBF     2               /* Unbuffered */
+
 /* File system error values *************************************************/
 
 #define EOF        (-1)
@@ -232,6 +246,26 @@ char *fgets(FAR char *s, int n, FAR FILE *stream);
  * @since Tizen RT v1.0
  */
 FAR FILE *fopen(FAR const char *path, FAR const char *type);
+/**
+ * @brief  Reopen stream with different file or mode
+ * @cond
+ * @internal
+ */
+FAR FILE *freopen(FAR const char *path, FAR const char *mode, FAR FILE *stream);
+/**
+ * @brief  Set stream buffer
+ * @internal
+ */
+void   setbuf(FAR FILE *stream, FAR char *buf);
+/**
+ * @brief  Change stream buffering
+ * @internal
+ */
+int    setvbuf(FAR FILE *stream, FAR char *buffer, int mode, size_t size);
+/**
+ * @endcond
+ */
+
 /**
  * @brief  POSIX APIs (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
@@ -423,9 +457,13 @@ FAR char *tmpnam(FAR char *s);
  */
 FAR char *tempnam(FAR const char *dir, FAR const char *pfx);
 /**
+ * @brief  Remove file
+ * @internal
+ */
+int remove(FAR const char *path);
+/**
  * @endcond
  */
-
 #undef EXTERN
 #if defined(__cplusplus)
 }

--- a/os/include/tinyara/fs/fs.h
+++ b/os/include/tinyara/fs/fs.h
@@ -80,6 +80,8 @@
 
 #define __FS_FLAG_EOF   (1 << 0)	/* EOF detected by a read operation */
 #define __FS_FLAG_ERROR (1 << 1)	/* Error detected by any operation */
+#define __FS_FLAG_LBF   (1 << 2)	/* Line buffered */
+#define __FS_FLAG_UBF   (1 << 3)	/* Buffer allocated by caller of setvbuf */
 #ifndef CONFIG_MOUNT_POINT
 #define CONFIG_MOUNT_POINT "/mnt/"
 #endif


### PR DESCRIPTION
This patch adds missing stdio API's namely 'freopen', 'setbuf', 'setvbuf', 'remove' to Tinyara.
These API's are ported by referring to the latest Nuttx.

Signed-off-by: Vidisha Thapa <thapa.v@samsung.com>