### PR TITLE
Add !BUILD_PROTECTED && !BUILD_KERNEL dependency for ENABLE_STACKMONITOR flag

### DIFF
--- a/apps/system/utils/Kconfig
+++ b/apps/system/utils/Kconfig
@@ -107,12 +107,13 @@ config ENABLE_PS
 config ENABLE_STACKMONITOR
 	bool "Stack monitor"
 	default n
+	depends on !BUILD_PROTECTED && !BUILD_KERNEL
 	select STACK_COLORATION
 	---help---
 		The stack monitor is a daemon that will periodically assess
 		stack usage by all tasks and threads in the system.  This
 		feature depends on internal OS features and, hence, is
-		not available if the kernel build is selected.
+		not available if the kernel build or protected build is selected.
 
 if ENABLE_STACKMONITOR
 config STACKMONITOR_PRIORITY


### PR DESCRIPTION
Stack monitoring feature is enabled from TASH with "stkmon" command. however
this file is getting built even though TASH shell is disabled and it's been
referenced from sched_releasetcb() API in sched_releasetcb.c file. Thus it's
symbols have been included in final image.
Without having the TASH shell prompt, there is no purpose of building this file and
having it's symbols in the final binary. This patch saves 2048 bytes in the
final tinyara binary. Also this feature shouldn't be available for protected build.
Thus adding both TASH and !BUILD_PROTECTED dependency to Kconfig

without patch : -rwxrwxr-x 1 pradeep pradeep  175104 Jul 13 23:10 tinyara.bin
with patch    : -rwxrwxr-x 1 pradeep pradeep  173056 Jul 13 23:44 tinyara.bin

Signed-off-by: pradeep.ns <pradeep.ns@samsung.com>