### PR TITLE
libc/stdlib: Error Fixes

### DIFF
--- a/lib/libc/stdlib/lib_mkstemp.c
+++ b/lib/libc/stdlib/lib_mkstemp.c
@@ -138,7 +138,7 @@ static void incr_base62(void)
 {
 	int i;
 
-	for (i = 0; i < MAX_XS; i++) {
+	for (i = MAX_XS - 1; i >= 0; i--) {
 		if (g_base62[i] < MAX_LOWERCASE) {
 			g_base62[i]++;
 			return;
@@ -176,11 +176,8 @@ static void get_base62(FAR uint8_t *ptr)
  *
  ****************************************************************************/
 
-static void copy_base62(FAR char *dest, int len)
+static void copy_base62(FAR const uint8_t *src, FAR char *dest, int len)
 {
-	FAR const uint8_t *src;
-
-	src = g_base62;
 	if (len < MAX_XS) {
 		src += MAX_XS - len;
 	}
@@ -263,7 +260,7 @@ int mkstemp(FAR char *path_template)
 
 		/* Form the candidate file name */
 
-		copy_base62(xptr, xlen);
+		copy_base62(base62, xptr, xlen);
 
 		/* Attempt to open the candidate file -- creating it exclusively
 		 *
@@ -277,6 +274,7 @@ int mkstemp(FAR char *path_template)
 
 			return fd;
 		}
+		retries--;
 	}
 
 	/* We could not find an unique filename */


### PR DESCRIPTION
       1.Fix an error in mkstemp() the could result in an infinite loop.
       2.Fix for wrong output in some cases.
         For Example:
         input: "FILEXX"
         output: "FILE00" and repeating same output for further invocations of mkstemp().
         But, the ouput has to be FILE01, FILE02, ...., FILEZZ.

Signed-off-by: Lokesh B V <lokesh.bv@partner.samsung.com>