### PR TITLE
Replace sprintf with secure API snprintf for security reasons

### DIFF
--- a/os/arch/arm/src/artik053/src/artik053_tash.c
+++ b/os/arch/arm/src/artik053/src/artik053_tash.c
@@ -181,14 +181,14 @@ static void artik053_configure_partitions(void)
 #if defined(CONFIG_MTD_SMART) && defined(CONFIG_FS_SMARTFS)
 			if (!strncmp(types, "smartfs,", 8)) {
 				char partref[4];
-				sprintf(partref, "p%d", partno);
+				snprintf(partref, sizeof(partref), "p%d", partno);
 				smart_initialize(CONFIG_ARTIK053_FLASH_MINOR, mtd_part, partref);
 			} else
 #endif
 #if defined(CONFIG_FS_ROMFS) && defined(CONFIG_FS_SMARTFS)
 			if (!strncmp(types, "romfs,", 6)) {
 				char partref[6];
-				sprintf(partref, "rom%d", partno);
+				snprintf(partref, sizeof(partref), "rom%d", partno);
 				smart_initialize(MTD_ROMFS, mtd_part, partref);
 			} else
 #endif
@@ -339,7 +339,7 @@ int board_app_initialize(void)
 		char path[CONFIG_PATH_MAX];
 
 		for (i = 0; i < CONFIG_S5J_MCT_NUM; i++) {
-			sprintf(path, "/dev/timer%d", i);
+			snprintf(path, sizeof(path), "/dev/timer%d", i);
 			s5j_timer_initialize(path, i);
 		}
 	}

--- a/os/arch/arm/src/sidk_s5jt200/src/s5jt200_tash.c
+++ b/os/arch/arm/src/sidk_s5jt200/src/s5jt200_tash.c
@@ -186,7 +186,7 @@ static void sidk_s5jt200_configure_partitions(void)
 #if defined(CONFIG_MTD_SMART) && defined(CONFIG_FS_SMARTFS)
 		if (!strncmp(types, "smartfs,", 8)) {
 			char partref[4];
-			sprintf(partref, "p%d", partno);
+			snprintf(partref, sizeof(partref), "p%d", partno);
 			smart_initialize(CONFIG_SIDK_S5JT200_FLASH_MINOR,
 					mtd_part, partref);
 		} else
@@ -380,7 +380,7 @@ int board_app_initialize(void)
 		char path[CONFIG_PATH_MAX];
 
 		for (i = 0; i < CONFIG_S5J_MCT_NUM; i++) {
-			sprintf(path, "/dev/timer%d", i);
+			snprintf(path, sizeof(path), "/dev/timer%d", i);
 			s5j_timer_initialize(path, i);
 		}
 	}

--- a/os/drivers/pipes/pipe.c
+++ b/os/drivers/pipes/pipe.c
@@ -224,7 +224,7 @@ int pipe(int fd[2])
 
 	/* Create a pathname to the pipe device */
 
-	sprintf(devname, "/dev/pipe%d", pipeno);
+	snprintf(devname, sizeof(devname), "/dev/pipe%d", pipeno);
 
 	/* Check if the pipe device has already been created */
 

--- a/os/drivers/usbdev/cdcacm.c
+++ b/os/drivers/usbdev/cdcacm.c
@@ -2150,7 +2150,7 @@ int cdcacm_classobject(int minor, FAR struct usbdevclass_driver_s **classdev)
 
 	/* Register the CDC/ACM TTY device */
 
-	sprintf(devname, CDCACM_DEVNAME_FORMAT, minor);
+	snprintf(devname, sizeof(devname), CDCACM_DEVNAME_FORMAT, minor);
 	ret = uart_register(devname, &priv->serdev);
 	if (ret < 0) {
 		usbtrace(TRACE_CLSERROR(USBSER_TRACEERR_UARTREGISTER), (uint16_t)-ret);
@@ -2269,7 +2269,7 @@ void cdcacm_uninitialize(FAR void *handle)
 
 	/* Un-register the CDC/ACM TTY device */
 
-	sprintf(devname, CDCACM_DEVNAME_FORMAT, priv->minor);
+	snprintf(devname, sizeof(devname), CDCACM_DEVNAME_FORMAT, priv->minor);
 	ret = unregister_driver(devname);
 	if (ret < 0) {
 		usbtrace(TRACE_CLSERROR(USBSER_TRACEERR_UARTUNREGISTER), (uint16_t)-ret);

--- a/os/drivers/usbdev/pl2303.c
+++ b/os/drivers/usbdev/pl2303.c
@@ -2200,7 +2200,7 @@ int usbdev_serialinitialize(int minor)
 
 	/* Register the single port supported by this implementation */
 
-	sprintf(devname, "/dev/ttyUSB%d", minor);
+	snprintf(devname, sizeof(devname), "/dev/ttyUSB%d", minor);
 	ret = uart_register(devname, &priv->serdev);
 	if (ret) {
 		usbtrace(TRACE_CLSERROR(USBSER_TRACEERR_UARTREGISTER), (uint16_t)-ret);

--- a/os/include/tls/configs/ssl_client1.c
+++ b/os/include/tls/configs/ssl_client1.c
@@ -224,7 +224,7 @@ int main_ssl_client(void)
 	mbedtls_printf("  > Write to server:");
 	fflush(stdout);
 
-	len = sprintf((char *)buf, GET_REQUEST);
+	len = snprintf((char *)buf, sizeof(buf), GET_REQUEST);
 
 	while ((ret = mbedtls_ssl_write(&ssl, buf, len)) <= 0) {
 		if (ret != MBEDTLS_ERR_SSL_WANT_READ && ret != MBEDTLS_ERR_SSL_WANT_WRITE) {

--- a/os/include/tls/configs/ssl_server.c
+++ b/os/include/tls/configs/ssl_server.c
@@ -316,7 +316,7 @@ reset:
 	mbedtls_printf("  > Write to client:");
 	fflush(stdout);
 
-	len = sprintf((char *)buf, HTTP_RESPONSE, mbedtls_ssl_get_ciphersuite(&ssl));
+	len = snprintf((char *)buf, sizeof(buf), HTTP_RESPONSE, mbedtls_ssl_get_ciphersuite(&ssl));
 
 	while ((ret = mbedtls_ssl_write(&ssl, buf, len)) <= 0) {
 		if (ret == MBEDTLS_ERR_NET_CONN_RESET) {

--- a/os/kernel/environ/env_setenv.c
+++ b/os/kernel/environ/env_setenv.c
@@ -179,7 +179,7 @@ int setenv(FAR const char *name, FAR const char *value, int overwrite)
 		pvar = &newenvp[group->tg_envsize];
 	} else {
 		newsize = varlen;
-		newenvp = (FAR char *)kumm_malloc(varlen);
+		newenvp = (FAR char *)kumm_malloc(newsize);
 		if (!newenvp) {
 			ret = ENOMEM;
 			goto errout_with_lock;
@@ -195,7 +195,7 @@ int setenv(FAR const char *name, FAR const char *value, int overwrite)
 
 	/* Now, put the new name=value string into the environment buffer */
 
-	sprintf(pvar, "%s=%s", name, value);
+	snprintf(pvar, varlen, "%s=%s", name, value);
 	sched_unlock();
 	return OK;
 

--- a/os/pm/pm_procfs.c
+++ b/os/pm/pm_procfs.c
@@ -627,7 +627,7 @@ static int power_readdir(struct fs_dirent_s *dir)
 		/* Listing the contents of domains */
 		if (index >= 0 && index < CONFIG_PM_NDOMAINS) {
 			dir->fd_dir.d_type = DTYPE_DIRECTORY;
-			sprintf(dir->fd_dir.d_name, "%d", index);
+			snprintf(dir->fd_dir.d_name, sizeof(dir->fd_dir.d_name), "%d", index);
 			powerdir->base.index++;
 			return OK;
 		}


### PR DESCRIPTION
Usage of sprintf can help hackers to cause buffer overflows and even
developers may unnotice the size of the destination buffer before
passing the formatted string and thus cause buffer overflow scenarios.
It's wise to use snprintf to avoid any such scenarios.

This patch takes care of sprintf usage inside OS folder only.

Signed-off-by: pradeep.ns <pradeep.ns@samsung.com>