### PR TITLE
Sidk s5jt200 romfs dev

### DIFF
--- a/build/configs/sidk_s5jt200/tools/openocd/partition_gen.sh
+++ b/build/configs/sidk_s5jt200/tools/openocd/partition_gen.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+
+###########################################################################
+#
+# Copyright 2016-2017 Samsung Electronics All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+#
+###########################################################################
+
+# This script reads partition size and name list from .config and
+# creates a partition map cfg file for openocd.
+# Created partition map cfg file can be included in the main openocd cfg script
+# for flashing.
+
+source .config
+
+# Path ENV
+BOARD_NAME=${CONFIG_ARCH_BOARD}
+OS_DIR_PATH=${PWD}
+BUILD_DIR_PATH=${OS_DIR_PATH}/../build
+BOARD_DIR_PATH=${BUILD_DIR_PATH}/configs/${BOARD_NAME}
+OPENOCD_DIR_PATH=${BOARD_DIR_PATH}/tools/openocd
+
+#FLASH BASE ADDRESS (Can it be made to read dynamically from .config?)
+FLASH_BASE=0x04000000
+
+partsize_list=${CONFIG_SIDK_S5JT200_FLASH_PART_LIST}
+partname_list=${CONFIG_SIDK_S5JT200_FLASH_PART_NAME}
+
+# OpenOCD cfg file to be created for flashing
+PARTITION_MAP_CFG=${OPENOCD_DIR_PATH}/partition_map.cfg
+
+#Comma Separator
+IFS=","
+
+#Variables
+total=1
+count=1
+id=1
+romfs_part_exist=0
+
+#Array to hold partition size of all partitions
+part_size[$count]=0
+
+#Array to hold partition start address  of all partitions
+part_start[$count]=0
+
+#Loop partition size list
+for psize in $partsize_list
+do
+	while [ "$count" -le "$total" ];
+	do
+		sum=`expr $sum + $psize`
+		let "count += 1"
+	done
+
+	part_size[$count-1]=`expr $psize \\* 1024`
+	part_start[$count]=`expr $sum \\* 1024`
+	let "total += 1"
+done
+
+#Generate cfg file by looping partition name list
+
+echo -n "Generating Partition Map CFG file ..."
+
+echo "# Partition Map (Auto generated)" > ${PARTITION_MAP_CFG}
+echo "set FLASH_START $FLASH_BASE" >> ${PARTITION_MAP_CFG}
+for pname in $partname_list
+do
+	if [ "$pname" == "romfs" ]; then
+		romfs_part_exist=1
+	fi
+
+	echo "set ${pname}_part_start [expr $(printf 0x%X ${part_start[$id]})+""$""FLASH_START]" >> ${PARTITION_MAP_CFG}
+	echo "set ${pname}_part_size $(printf 0x%X ${part_size[$id]})">> ${PARTITION_MAP_CFG}
+	let "id += 1"
+done
+
+echo "# Configuration Variables" >> ${PARTITION_MAP_CFG}
+
+if [ "${CONFIG_FS_ROMFS}" == "y" ] && [ "${romfs_part_exist}" == "1" ]; then
+	echo "set romfs_partition_enable 1" >> ${PARTITION_MAP_CFG}
+else
+	echo "set romfs_partition_enable 0" >> ${PARTITION_MAP_CFG}
+fi
+
+echo "Done"

--- a/build/configs/sidk_s5jt200/tools/openocd/s5jt200_silicon_evt0_fusing_flash_all.cfg
+++ b/build/configs/sidk_s5jt200/tools/openocd/s5jt200_silicon_evt0_fusing_flash_all.cfg
@@ -34,6 +34,7 @@ ftdi_layout_signal nSRST -data 0x0080 -oe 0x0080
 
 reset_config trst_and_srst srst_push_pull trst_push_pull
 
+source [find partition_map.cfg]
 set _CHIPNAME s5jt200
 set _ENDIAN little
 set _CPUTAPID 0x4BA00477
@@ -261,6 +262,7 @@ proc fusing_image_all {} {
 	fusing_image_os
 	fusing_image_sss
 	fusing_image_wlan
+	fusing_image_romfs
 }
 
 proc fusing_image_boot {} {
@@ -305,4 +307,17 @@ proc fusing_image_wlan {} {
 	set WLAN_PATH "../../boot_bin/t20.wlan.bin"
 	load_image $WLAN_PATH 0x04048000
 	echo "Done"
+}
+
+proc fusing_image_romfs {} {
+	global romfs_partition_enable
+	if { $romfs_partition_enable == 1 } {
+		echo "----------------------------------------------------------------------"
+		echo "Fusing ROMFS Image.."
+		echo "----------------------------------------------------------------------"
+		set ROMFS_IMG_PATH "../../../../../build/output/bin/romfs.img"
+		global romfs_part_start
+		load_image $ROMFS_IMG_PATH $romfs_part_start
+		echo "Done"
+	}
 }

--- a/os/arch/arm/src/sidk_s5jt200/Kconfig
+++ b/os/arch/arm/src/sidk_s5jt200/Kconfig
@@ -99,6 +99,31 @@ config SIDK_S5JT200_AUTOMOUNT
 	---help---
 		If enabled, mount userrw and sssrw partitions at boot.
 
+config SIDK_S5JT200_AUTOMOUNT_ROMFS
+	bool "Automount ROM read only partiton"
+	default n
+	depends on SIDK_S5JT200_AUTOMOUNT
+	depends on FS_ROMFS
+	---help---
+		If enabled, rom readonly partition will be mounted automatically
+		at boot.
+
+config SIDK_S5JT200_AUTOMOUNT_ROMFS_DEVNAME
+	string "Device name of the partition for rom readonly file system"
+	default "/dev/smart0p15"
+	depends on SIDK_S5JT200_AUTOMOUNT_ROMFS
+	---help---
+		Specifies the device name (/dev/smart0pX) of the partition
+		for rom readonly file system.
+
+config SIDK_S5JT200_AUTOMOUNT_ROMFS_MOUNTPOINT
+	string "Mountpoint of the partition for rom read only file system"
+	default "/rom"
+	depends on SIDK_S5JT200_AUTOMOUNT_ROMFS
+	---help---
+		Specifies the mount point where rom readonly file system
+		will be mounted at.
+
 config SIDK_S5JT200_AUTOMOUNT_USERFS
 	bool "Automount user r/w partiton"
 	default n

--- a/os/arch/arm/src/sidk_s5jt200/src/s5jt200_tash.c
+++ b/os/arch/arm/src/sidk_s5jt200/src/s5jt200_tash.c
@@ -273,6 +273,17 @@ int board_app_initialize(void)
 
 	sidk_s5jt200_configure_partitions();
 
+#if defined(CONFIG_SIDK_S5JT200_AUTOMOUNT_ROMFS_DEVNAME)
+	ret = mount(CONFIG_SIDK_S5JT200_AUTOMOUNT_ROMFS_DEVNAME,
+			CONFIG_SIDK_S5JT200_AUTOMOUNT_ROMFS_MOUNTPOINT,
+			"romfs", 0, NULL);
+
+	if (ret != OK) {
+		lldbg("ERROR: mounting '%s'(ROMFS) failed\n",
+			CONFIG_SIDK_S5JT200_AUTOMOUNT_ROMFS_DEVNAME);
+	}
+#endif /* CONFIG_SIDK_S5JT200_AUTOMOUNT_ROMFS_DEVNAME */
+
 #ifdef CONFIG_SIDK_S5JT200_AUTOMOUNT_USERFS_DEVNAME
 	/* Initialize and mount user partition (if we have) */
 	ret = mksmartfs(CONFIG_SIDK_S5JT200_AUTOMOUNT_USERFS_DEVNAME, false);


### PR DESCRIPTION
This series of patches for supporting romfs  in sidk_s5jt200 board.
    To test it,
    1. configure for sidk_s5jt200/hello_with_tash
    2. make menuconfig
        - Enable CONFIG_FS_ROMFS
        - Split last partition size to (256,256) in CONFIG_SIDK_S5JT200_FLASH_PART_LIST
        - Append "smartfs" at the end to CONFIG_SIDK_S5JT200_FLASH_PART_TYPE
        - Append "romfs" at the end to CONFIG_SIDK_S5JT200_FLASH_PART_NAME
          (Above 3 steps created romfs partition with size 256K at the end,
                where romfs device is a smart device and romfs filesystem will be
                mounted on smartdevice "/dev/smart0p15" )
    
        - Enable CONFIG_SIDK_S5JT200_AUTOMOUNT_ROMFS
    3. make
    4. Put "contents" into "external/contents" directory
    4. make download ALL