### PR TITLE
libc/math: Fix for wrong ouput in ceil() API

### DIFF
--- a/lib/libc/math/lib_ceil.c
+++ b/lib/libc/math/lib_ceil.c
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- * Copyright 2016 Samsung Electronics All Rights Reserved.
+ * Copyright 2016-2017 Samsung Electronics All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -57,8 +57,10 @@
 #ifdef CONFIG_HAVE_DOUBLE
 double ceil(double x)
 {
+	double x1 = x;
+
 	modf(x, &x);
-	if (x > 0.0) {
+	if (x1 > 0.0 && fabs(x1 - x) > 0.0) {
 		x += 1.0;
 	}
 

--- a/lib/libc/math/lib_ceilf.c
+++ b/lib/libc/math/lib_ceilf.c
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- * Copyright 2016 Samsung Electronics All Rights Reserved.
+ * Copyright 2016-2017 Samsung Electronics All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -54,8 +54,10 @@
 
 float ceilf(float x)
 {
+	float x1 = x;
+
 	modff(x, &x);
-	if (x > 0.0) {
+	if (x1 > 0.0 && fabsf(x1 - x) > 0.0) {
 		x += 1.0;
 	}
 

--- a/lib/libc/math/lib_ceill.c
+++ b/lib/libc/math/lib_ceill.c
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- * Copyright 2016 Samsung Electronics All Rights Reserved.
+ * Copyright 2016-2017 Samsung Electronics All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -57,8 +57,10 @@
 #ifdef CONFIG_HAVE_LONG_DOUBLE
 long double ceill(long double x)
 {
+	long double x1 = x;
+
 	modfl(x, &x);
-	if (x > 0.0) {
+	if (x1 > 0.0 && fabsl(x1 - x) > 0.0) {
 		x += 1.0;
 	}
 


### PR DESCRIPTION
_Ex_:for input **x = 1.0**, the ouput should be **1.0**, but the ouput was **2.0**.
This wrong ouput is fixed.

Signed-off-by: Lokesh B V <lokesh.bv@partner.samsung.com>