### PR TITLE
Libc pthread Modify return value as per POSIX standard

### DIFF
--- a/apps/examples/testcase/le_tc/kernel/tc_libc_pthread.c
+++ b/apps/examples/testcase/le_tc/kernel/tc_libc_pthread.c
@@ -1229,6 +1229,88 @@ static void tc_libc_pthread_pthread_rwlock_trywrlock(void)
 	TC_SUCCESS_RESULT();
 }
 
+/**
+* @fn                   :tc_libc_pthread_pthread_setcancelstate
+* @brief                :This tc tests pthread_setcancelstate()
+* @Scenario             :The function shall atomically both set the calling thread's cancelability state to the indicated state 
+*                        and return the previous cancelability state at the location referenced by oldstate
+*                        If successful pthread_setcancelstate() function shall return zero;
+*                        otherwise, an error number shall be returned to indicate the error.
+* @API'scovered         :pthread_setcancelstate
+* @Preconditions        :none
+* @Postconditions       :none
+* @return               :void
+*/
+static void tc_libc_pthread_pthread_setcancelstate(void)
+{
+	int state;
+	int oldstate;
+	int ret_chk;
+
+	state = PTHREAD_CANCEL_ENABLE;
+	ret_chk = pthread_setcancelstate(state, &oldstate);
+	TC_ASSERT_EQ("pthread_setcancelstate", ret_chk, OK);
+
+	state = PTHREAD_CANCEL_DISABLE;
+	ret_chk = pthread_setcancelstate(state, &oldstate);
+	TC_ASSERT_EQ("pthread_setcancelstate", oldstate, PTHREAD_CANCEL_ENABLE);
+
+	TC_SUCCESS_RESULT();
+}
+
+/**
+* @fn                   :tc_libc_pthread_pthread_setcanceltype
+* @brief                :This tc tests pthread_setcanceltype()
+* @Scenario             :The function shall atomically both set the calling thread's cancelability type to the indicated type 
+*                        and return the previous cancelability type at the location referenced by oldtype
+*                        If successful pthread_setcanceltype() function shall return zero;
+*                        otherwise, an error number shall be returned to indicate the error.
+* @API'scovered         :pthread_setcanceltype
+* @Preconditions        :none
+* @Postconditions       :none
+* @return               :void
+*/
+#ifndef CONFIG_CANCELLATION_POINTS
+static void tc_libc_pthread_pthread_setcanceltype(void)
+{
+	int type;
+	int oldtype;
+	int ret_chk;
+
+	type = PTHREAD_CANCEL_ASYNCHRONOUS;
+	oldtype = PTHREAD_CANCEL_DEFERRED;
+	ret_chk = pthread_setcanceltype(type, &oldtype);
+	TC_ASSERT_EQ("pthread_setcanceltype", ret_chk, OK);
+	TC_ASSERT_EQ("pthread_setcanceltype", oldtype, PTHREAD_CANCEL_ASYNCHRONOUS);
+
+	type = PTHREAD_CANCEL_DEFERRED;
+	ret_chk = pthread_setcanceltype(type, &oldtype);
+	TC_ASSERT_EQ("pthread_setcanceltype", ret_chk, ENOSYS);
+	TC_ASSERT_EQ("pthread_setcanceltype", oldtype, PTHREAD_CANCEL_ASYNCHRONOUS);
+
+	TC_SUCCESS_RESULT();
+}
+#endif
+
+/**
+* @fn                   :tc_libc_pthread_pthread_testcancel
+* @brief                :This tc tests pthread_testcancel()
+* @Scenario             :The function shall create a cancellation point in the calling thread
+                         It has no effect if cancelability is disabled.
+* @API'scovered         :pthread_testcancel
+* @Preconditions        :none
+* @Postconditions       :none
+* @return               :void
+*/
+#ifndef CONFIG_CANCELLATION_POINTS
+static void tc_libc_pthread_pthread_testcancel(void)
+{
+	pthread_testcancel();
+
+	TC_SUCCESS_RESULT();
+}
+#endif
+
 /****************************************************************************
  * Name: libc_pthread
  ****************************************************************************/
@@ -1266,6 +1348,11 @@ int libc_pthread_main(void)
 	tc_libc_pthread_pthread_rwlock_trywrlock();
 	tc_libc_pthread_pthread_rwlock_rdlock_wrlock();
 	tc_libc_pthread_pthread_rwlock_test_timeout();
+	tc_libc_pthread_pthread_setcancelstate();
+#ifndef CONFIG_CANCELLATION_POINTS
+	tc_libc_pthread_pthread_setcanceltype();
+	tc_libc_pthread_pthread_testcancel();
+#endif
 
 	return 0;
 }

--- a/apps/examples/testcase/le_tc/kernel/tc_libc_pthread.c
+++ b/apps/examples/testcase/le_tc/kernel/tc_libc_pthread.c
@@ -766,11 +766,13 @@ static void tc_libc_pthread_pthread_mutexattr_getprotocol(void)
 	TC_ASSERT_EQ("pthread_mutexattr_init", ret_chk, OK);
 
 #ifdef CONFIG_PRIORITY_INHERITANCE
+	attr.proto = PTHREAD_PRIO_INHERIT;
 	ret_chk = pthread_mutexattr_getprotocol(&attr, &mutexattr_protocol);
-	TC_ASSERT_EQ("pthread_mutexattr_getprotocol", ret_chk, PTHREAD_PRIO_INHERIT);
+	TC_ASSERT_EQ("pthread_mutexattr_getprotocol", ret_chk, OK);
+	TC_ASSERT_EQ("pthread_mutexattr_getprotocol", mutexattr_protocol, attr.proto);
 #else
 	ret_chk = pthread_mutexattr_getprotocol(&attr, &mutexattr_protocol);
-	TC_ASSERT_EQ("pthread_mutexattr_getprotocol", ret_chk, PTHREAD_PRIO_NONE);
+	TC_ASSERT_EQ("pthread_mutexattr_getprotocol", ret_chk, OK);
 #endif
 	TC_SUCCESS_RESULT();
 }

--- a/apps/examples/testcase/le_tc/kernel/tc_pthread.c
+++ b/apps/examples/testcase/le_tc/kernel/tc_pthread.c
@@ -1458,6 +1458,59 @@ static void tc_pthread_pthread_setgetname_np(void)
 	TC_SUCCESS_RESULT();
 }
 
+/**
+* @fn                   :tc_pthread_pthread_setcanceltype
+* @brief                :This tc tests pthread_setcanceltype()
+* @Scenario             :The function shall atomically both set the calling thread's cancelability type to the indicated type 
+*                        and return the previous cancelability type at the location referenced by oldtype
+*                        If successful pthread_setcanceltype() function shall return zero;
+*                        otherwise, an error number shall be returned to indicate the error.
+* @API'scovered         :pthread_setcanceltype
+* @Preconditions        :none
+* @Postconditions       :none
+* @return               :void
+*/
+#ifdef CONFIG_CANCELLATION_POINTS
+static void tc_pthread_pthread_setcanceltype(void)
+{
+	int type;
+	int oldtype;
+	int ret_chk;
+
+	type = PTHREAD_CANCEL_ASYNCHRONOUS;
+	oldtype = PTHREAD_CANCEL_DEFERRED;
+	ret_chk = pthread_setcanceltype(type, &oldtype);
+	TC_ASSERT_EQ("pthread_setcanceltype", ret_chk, OK);
+	TC_ASSERT_EQ("pthread_setcanceltype", oldtype, PTHREAD_CANCEL_ASYNCHRONOUS);
+
+	type = PTHREAD_CANCEL_DEFERRED;
+	ret_chk = pthread_setcanceltype(type, &oldtype);
+	TC_ASSERT_EQ("pthread_setcanceltype", ret_chk, ENOSYS);
+	TC_ASSERT_EQ("pthread_setcanceltype", oldtype, PTHREAD_CANCEL_ASYNCHRONOUS);
+
+	TC_SUCCESS_RESULT();
+}
+#endif
+
+/**
+* @fn                   :tc_libc_pthread_pthread_testcancel
+* @brief                :This tc tests pthread_testcancel()
+* @Scenario             :The function shall create a cancellation point in the calling thread
+                         It has no effect if cancelability is disabled.
+* @API'scovered         :pthread_testcancel
+* @Preconditions        :none
+* @Postconditions       :none
+* @return               :void
+*/
+#ifdef CONFIG_CANCELLATION_POINTS
+static void tc_pthread_pthread_testcancel(void)
+{
+	pthread_testcancel();
+
+	TC_SUCCESS_RESULT();
+}
+#endif
+
 /****************************************************************************
  * Name: pthread
  ****************************************************************************/
@@ -1489,6 +1542,10 @@ int pthread_main(void)
 	tc_pthread_pthread_self();
 	tc_pthread_pthread_equal();
 	tc_pthread_pthread_setgetname_np();
+#ifdef CONFIG_CANCELLATION_POINTS
+	tc_pthread_pthread_setcanceltype();
+	tc_pthread_pthread_testcancel();
+#endif
 
 	return 0;
 }

--- a/lib/libc/pthread/pthread_mutexattr_getprotocol.c
+++ b/lib/libc/pthread/pthread_mutexattr_getprotocol.c
@@ -59,6 +59,7 @@
 #include <pthread.h>
 #include <assert.h>
 #include <debug.h>
+#include <errno.h>
 
 /****************************************************************************
  * Public Functions
@@ -80,16 +81,18 @@
  *
  ****************************************************************************/
 
-int pthread_mutexattr_getprotocol(FAR const pthread_mutexattr_t *attr,
-				  FAR int *protocol)
+int pthread_mutexattr_getprotocol(FAR const pthread_mutexattr_t *attr, FAR int *protocol)
 {
-	DEBUGASSERT(attr != NULL && protocol != NULL);
-
+	if (attr != NULL && protocol != NULL) {
 #ifdef CONFIG_PRIORITY_INHERITANCE
-	svdbg("Returning %d\n", attr->proto);
-	return attr->proto;
+		svdbg("Returning %d\n", attr->proto);
+		*protocol = attr->proto;
 #else
-	svdbg("Returning %d\n", PTHREAD_PRIO_NONE);
-	return PTHREAD_PRIO_NONE;
+		svdbg("Returning %d\n", PTHREAD_PRIO_NONE);
+		*protocol = PTHREAD_PRIO_NONE;
 #endif
+		return 0;
+	}
+
+	return EINVAL;
 }


### PR DESCRIPTION
Modified return value and test cases for:
pthread_mutexattr_getprotocol()
pthread_mutexattr_setprotocol()
pthread_setcancelstate()
pthread_setcanceltype()
pthread_testcancel()