### PR TITLE
Add Test Cases for fs, net_inet, kernel, libc modules

### DIFF
--- a/apps/examples/testcase/le_tc/filesystem/fs_main.c
+++ b/apps/examples/testcase/le_tc/filesystem/fs_main.c
@@ -814,6 +814,13 @@ static void fs_vfs_closedir_tc(void)
 
 	ret = closedir(dirp);
 	TC_ASSERT_EQ("closedir", ret, OK);
+
+	dirp = opendir("nodir");
+	TC_ASSERT_EQ("opendir", dirp, NULL);
+
+	ret = closedir(NULL);
+	TC_ASSERT_EQ("closedir", ret, ERROR);
+
 	TC_SUCCESS_RESULT();
 }
 

--- a/apps/examples/testcase/le_tc/kernel/tc_clock.c
+++ b/apps/examples/testcase/le_tc/kernel/tc_clock.c
@@ -64,6 +64,9 @@ static void tc_clock_clock_getres(void)
 	TC_ASSERT_EQ("clock_getres", st_res.tv_sec, 0);
 	TC_ASSERT_EQ("clock_getres", st_res.tv_nsec, NSEC_PER_TICK);
 
+	ret_chk = clock_getres(33 , &st_res);
+	TC_ASSERT_EQ("clock_getres", ret_chk, ERROR);
+
 	TC_SUCCESS_RESULT();
 }
 
@@ -135,6 +138,10 @@ static void tc_clock_clock_gettimeofday(void)
 	if (tv2.tv_sec == tv1.tv_sec + SEC_2) {
 		TC_ASSERT_GEQ("gettimeofday", tv2.tv_usec, tv1.tv_usec);
 	}
+#ifdef CONFIG_DEBUG
+	ret_chk = gettimeofday(NULL, NULL);
+	TC_ASSERT_EQ("gettimeofday", ret_chk, ERROR);
+#endif
 
 	TC_SUCCESS_RESULT();
 }

--- a/apps/examples/testcase/le_tc/kernel/tc_environ.c
+++ b/apps/examples/testcase/le_tc/kernel/tc_environ.c
@@ -51,10 +51,9 @@ static void tc_environ_setenv_getenv_unsetenv(void)
 	const char *psz_name = "abc";
 	const char *psz_value = "xyz";
 	const char *pusz_name = "arv";
-	int overwrite_num = 1;
 	char *psz_getvalue = NULL;
 
-	ret_chk = setenv(psz_name, psz_value, overwrite_num);
+	ret_chk = setenv(psz_name, psz_value, 1);
 	TC_ASSERT_EQ_CLEANUP("setenv", ret_chk, OK, clearenv());
 
 	psz_getvalue = getenv(psz_name);
@@ -63,8 +62,7 @@ static void tc_environ_setenv_getenv_unsetenv(void)
 	/* with overwrite_num = 0, psz_value should not be updated */
 
 	psz_value = "pqr";
-	overwrite_num = 0;
-	ret_chk = setenv(psz_name, psz_value, overwrite_num);
+	ret_chk = setenv(psz_name, psz_value, 0);
 	TC_ASSERT_EQ_CLEANUP("setenv", ret_chk, OK, clearenv());
 
 	/* set and get value should not be equal as overwrite is 0 */
@@ -86,6 +84,15 @@ static void tc_environ_setenv_getenv_unsetenv(void)
 
 	psz_getvalue = getenv("arv");
 	TC_ASSERT_EQ("getenv", psz_getvalue, NULL);
+
+	ret_chk = setenv(NULL, psz_value, 0);
+	TC_ASSERT_EQ("setenv", ret_chk, ERROR);
+
+	ret_chk = setenv(psz_name, NULL, 1);
+	TC_ASSERT_EQ("setenv", ret_chk, OK);
+
+	ret_chk = setenv(psz_name, NULL, 0);
+	TC_ASSERT_EQ("setenv", ret_chk, OK);
 
 	clearenv();
 	TC_SUCCESS_RESULT();
@@ -150,6 +157,9 @@ static void tc_environ_putenv(void)
 
 	psz_getvalue = getenv("PATH");
 	TC_ASSERT_EQ("getenv", strcmp(psz_getvalue, "D:"), 0);
+
+	ret_chk = putenv(NULL);
+	TC_ASSERT_EQ("putenv", ret_chk, ERROR);
 
 	clearenv();
 	TC_SUCCESS_RESULT();

--- a/apps/examples/testcase/le_tc/kernel/tc_libc_libgen.c
+++ b/apps/examples/testcase/le_tc/kernel/tc_libc_libgen.c
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- * Copyright 2016-2017 Samsung Electronics All Rights Reserved.
+ * Copyright 2016 Samsung Electronics All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -109,6 +109,10 @@ static void tc_libc_libgen_dirname(void)
 	path = "basename";
 	ret_chk = dirname(path);
 	TC_ASSERT_EQ("dirname", strncmp(ret_chk, ".", strlen(".")), 0);
+
+	path = "/dirname ";
+	ret_chk = dirname(path);
+	TC_ASSERT_EQ("dirname", strncmp(ret_chk, "/", strlen("/")), 0);
 
 	TC_SUCCESS_RESULT();
 }

--- a/apps/examples/testcase/le_tc/kernel/tc_libc_semaphore.c
+++ b/apps/examples/testcase/le_tc/kernel/tc_libc_semaphore.c
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- * Copyright 2016-2017 Samsung Electronics All Rights Reserved.
+ * Copyright 2016 Samsung Electronics All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,15 +37,15 @@
  ****************************************************************************/
 
 /**
-* @fn                   :tc_libc_semaphore_sem_init
-* @brief                :this tc test sem_init function
-* @Scenario             :If sem is NULL or sem value is bigger then SEM_VALUE_MAX, it return ERROR and errno EINVAL is set.
-*                        Else sem is intialized to the default value.
-* API's covered         :sem_init
-* Preconditions         :NA
-* Postconditions        :NA
-* @return               :total_pass on success.
-*/
+ * @fn                   :tc_libc_semaphore_sem_init
+ * @brief                :this tc test sem_init function
+ * @Scenario             :If sem is NULL or sem value is bigger then SEM_VALUE_MAX, it return ERROR and errno EINVAL is set.
+ *                        Else sem is intialized to the default value.
+ * API's covered         :sem_init
+ * Preconditions         :NA
+ * Postconditions        :NA
+ * @return               :total_pass on success.
+ */
 static void tc_libc_semaphore_sem_init(void)
 {
 	sem_t sem;
@@ -79,15 +79,15 @@ static void tc_libc_semaphore_sem_init(void)
 
 
 /**
-* @fn                   :tc_libc_semaphore_sem_getvalue
-* @brief                :this tc test sem_init function
-* @Scenario             :If sem or sval is NULL, it return ERROR and errno EINVAL is set.
-*                        Else sval get sem->semcount.
-* API's covered         :sem_getvalue
-* Preconditions         :NA
-* Postconditions        :NA
-* @return               :total_pass on success.
-*/
+ * @fn                   :tc_libc_semaphore_sem_getvalue
+ * @brief                :this tc test sem_init function
+ * @Scenario             :If sem or sval is NULL, it return ERROR and errno EINVAL is set.
+ *                        Else sval get sem->semcount.
+ * API's covered         :sem_getvalue
+ * Preconditions         :NA
+ * Postconditions        :NA
+ * @return               :total_pass on success.
+ */
 static void tc_libc_semaphore_sem_getvalue(void)
 {
 	sem_t sem;
@@ -114,14 +114,41 @@ static void tc_libc_semaphore_sem_getvalue(void)
 	return;
 }
 
+/**
+ * @fn                   :tc_libc_semaphore_sem_getprotocol
+ * @brief                :this tc test sem_getprotocol function
+ * @Scenario             :Return the value of the semaphore protocol attribute.
+ * API's covered         :sem_init, sem_getprotocol
+ * Preconditions         :NA
+ * Postconditions        :NA
+ * @return               :total_pass on success.
+ */
+static void tc_libc_semaphore_sem_getprotocol(void)
+{
+	sem_t sem;
+	unsigned int value = SEM_VALUE;
+	int protocol;
+	int ret_chk;
+
+	ret_chk = sem_init(&sem, PSHARED, value);
+	TC_ASSERT_EQ("sem_init", ret_chk, OK);
+
+	ret_chk = sem_getprotocol(&sem, &protocol);
+	TC_ASSERT_EQ("sem_getprotocol", ret_chk, OK);
+
+	TC_SUCCESS_RESULT();
+	return;
+}
+
 /****************************************************************************
  * Name: libc_semaphore
  ****************************************************************************/
 
 int libc_semaphore_main(void)
 {
-	tc_libc_semaphore_sem_init();
 	tc_libc_semaphore_sem_getvalue();
+	tc_libc_semaphore_sem_getprotocol();
+	tc_libc_semaphore_sem_init();
 
 	return 0;
 }

--- a/apps/examples/testcase/le_tc/kernel/tc_libc_stdlib.c
+++ b/apps/examples/testcase/le_tc/kernel/tc_libc_stdlib.c
@@ -46,24 +46,35 @@
 #define BSEARCH_ARRSIZE 10
 
 /**
-* @fn                   :compare
-* @description          :Function for tc_libc_stdlib_qsort
-* @return               :int
-*/
+ *@fn					:thread_func
+ *@description			:Function for tc_libc_stdlib_abort
+ *@return				:void*
+ */
+static void *thread_func(void *arg)
+{
+	abort();
+	return NULL;
+}
+
+/**
+ * @fn                   :compare
+ * @description          :Function for tc_libc_stdlib_qsort
+ * @return               :int
+ */
 static int compare(const void *a, const void *b)
 {
 	return (*(int *)a - *(int *)b);
 }
 
 /**
-* @fn                   :tc_abs_labs_llabs
-* @brief                :Returns the absolute value of parameter
-* @Scenario             :Returns the absolute value of parameter
-* API's covered         :abs, labs, llabs
-* Preconditions         :None
-* Postconditions        :None
-* @return               :void
-*/
+ * @fn                   :tc_abs_labs_llabs
+ * @brief                :Returns the absolute value of parameter
+ * @Scenario             :Returns the absolute value of parameter
+ * API's covered         :abs, labs, llabs
+ * Preconditions         :None
+ * Postconditions        :None
+ * @return               :void
+ */
 static void tc_libc_stdlib_abs_labs_llabs(void)
 {
 	int val;
@@ -113,14 +124,14 @@ static void tc_libc_stdlib_abs_labs_llabs(void)
 }
 
 /**
-* @fn                   :tc_imaxabs
-* @brief                :Calculate the absolute value of the argument of the appropriate integer type
-* @Scenario             :Compute the absolute value of the argument of the appropriate integer type for the function
-* API's covered         :imaxabs
-* Preconditions         :None
-* Postconditions        :None
-* @return               :void
-*/
+ * @fn                   :tc_libc_stdlib_imaxabs
+ * @brief                :Calculate the absolute value of the argument of the appropriate integer type
+ * @Scenario             :Compute the absolute value of the argument of the appropriate integer type for the function
+ * API's covered         :imaxabs
+ * Preconditions         :None
+ * Postconditions        :None
+ * @return               :void
+ */
 static void tc_libc_stdlib_imaxabs(void)
 {
 	intmax_t val = -NVAL1;
@@ -131,15 +142,15 @@ static void tc_libc_stdlib_imaxabs(void)
 }
 
 /**
-* @fn                   :tc_itoa
-* @brief                :Convert integer to string
-* @Scenario             :Converts an integer value to a null-terminated string using the specified base and
-*                        stores the result in the array given by str parameter.
-* API's covered         :itoa
-* Preconditions         :None
-* Postconditions        :None
-* @return               :void
-*/
+ * @fn                   :tc_libc_stdlib_itoa
+ * @brief                :Convert integer to string
+ * @Scenario             :Converts an integer value to a null-terminated string using the specified base and
+ *                        stores the result in the array given by str parameter.
+ * API's covered         :itoa
+ * Preconditions         :None
+ * Postconditions        :None
+ * @return               :void
+ */
 static void tc_libc_stdlib_itoa(void)
 {
 	/* ITOA_VAL = 12 */
@@ -151,6 +162,9 @@ static void tc_libc_stdlib_itoa(void)
 
 	itoa(val, buffer, DECIMAL);
 	TC_ASSERT_EQ("itoa", strcmp(buffer, "12"), 0);
+
+	itoa(-val, buffer, DECIMAL);
+	TC_ASSERT_EQ("itoa", strcmp(buffer, "-12"), 0);
 
 	/* conversion in hexadecimal */
 
@@ -166,20 +180,23 @@ static void tc_libc_stdlib_itoa(void)
 }
 
 /**
-* @fn                   :tc_qsort
-* @brief                :Sorts the elements of the array
-* @Scenario             :Sorts the num elements of the array pointed to by base, each element size bytes long,
-*                        using the compar function to determine the order.
-* API's covered         :qsort
-* Preconditions         :None
-* Postconditions        :None
-* @return               :void
-*/
+ * @fn                   :tc_libc_stdlib_qsort
+ * @brief                :Sorts the elements of the array
+ * @Scenario             :Sorts the num elements of the array pointed to by base, each element size bytes long,
+ *                        using the compar function to determine the order.
+ * API's covered         :qsort
+ * Preconditions         :None
+ * Postconditions        :None
+ * @return               :void
+ */
 static void tc_libc_stdlib_qsort(void)
 {
 	/* qsort checks that the number of data is greater than 7 or not.
 	  So tc checks with 7 data and 40 data for magic numbers.  */
 	int qsort_smalldata[QSORT_SMALL_ARRSIZE] = { 40, 10, 100, 90, 20, 25 };
+	int  qsort_smalldata1[QSORT_SMALL_ARRSIZE + 1] = { 1, 2, 3 };
+	long lqsort_smalldata[QSORT_SMALL_ARRSIZE + 1] = { 10, 40, 10, 100, 90, 20, 25 };
+	long lqsort_smalldata1[QSORT_SMALL_ARRSIZE + 1] = { 7, 6, 5, 4, 3, 2, 1 };
 	int qsort_bigdata[QSORT_BIG_ARRSIZE] = { 16, 10, 27, 49, 18, 82, 27, 31, 11, 13, 101, 2, 99, 32, 51,
 				72, 182, 939, 1, 61, 83, 5, 60, 131, 52, 39, 33, 127, 29, 19,
 				12, 81, 281, 8, 931, 17, 111, 356, 14, 93, 20, 40, 30, 37, 73 };
@@ -189,6 +206,22 @@ static void tc_libc_stdlib_qsort(void)
 	qsort(qsort_smalldata, QSORT_SMALL_ARRSIZE, sizeof(int), compare);
 	for (data_idx = 0; data_idx < QSORT_SMALL_ARRSIZE - 1; data_idx++) {
 		TC_ASSERT_LEQ("qsort", qsort_smalldata[data_idx], qsort_smalldata[data_idx + 1]);
+	}
+
+	/* check that the number of data is equal to 7 */
+	qsort(qsort_smalldata1, QSORT_SMALL_ARRSIZE + 1, sizeof(int), compare);
+	for (data_idx = 0; data_idx < QSORT_SMALL_ARRSIZE; data_idx++) {
+		TC_ASSERT_LEQ("qsort", qsort_smalldata1[data_idx], qsort_smalldata1[data_idx + 1]);
+	}
+
+	qsort(lqsort_smalldata, QSORT_SMALL_ARRSIZE + 1, sizeof(long), compare);
+	for (data_idx = 0; data_idx < QSORT_SMALL_ARRSIZE; data_idx++) {
+		TC_ASSERT_LEQ("qsort", lqsort_smalldata[data_idx], lqsort_smalldata[data_idx + 1]);
+	}
+
+	qsort(lqsort_smalldata1, QSORT_SMALL_ARRSIZE + 1, sizeof(long), compare);
+	for (data_idx = 0; data_idx < QSORT_SMALL_ARRSIZE; data_idx++) {
+		TC_ASSERT_LEQ("qsort", lqsort_smalldata1[data_idx], lqsort_smalldata1[data_idx + 1]);
 	}
 
 	/* check that the number of data is bigger than 40 */
@@ -201,14 +234,14 @@ static void tc_libc_stdlib_qsort(void)
 }
 
 /**
-* @fn                   :tc_rand
-* @brief                :Returns a pseudo-random integral number
-* @Scenario             :Returns a pseudo-random integral number in the range between 0 and RAND_MAX.
-* API's covered         :rand, frand1, frand3, nrand, fgenerate1
-* Preconditions         :None
-* Postconditions        :None
-* @return               :void
-*/
+ * @fn                   :tc_libc_stdlib_rand
+ * @brief                :Returns a pseudo-random integral number
+ * @Scenario             :Returns a pseudo-random integral number in the range between 0 and RAND_MAX.
+ * API's covered         :rand, frand1, frand3, nrand, fgenerate1
+ * Preconditions         :None
+ * Postconditions        :None
+ * @return               :void
+ */
 static void tc_libc_stdlib_rand(void)
 {
 	int ret_chk = ERROR;
@@ -229,19 +262,19 @@ static void tc_libc_stdlib_rand(void)
 }
 
 /**
-* @fn                   :tc_strtol
-* @brief                :converts the string to a long integer value
-* @Scenario             :The strtol() function converts the initial part of the string in nptr to a long integer value
-*                        according to the given base, which must be between 2 and 36 inclusive, or be the special value 0.
-* API's covered         :strtol
-* Preconditions         :None
-* Postconditions        :None
-* @return               :void
-*/
+ * @fn                   :tc_libc_stdlib_strtol
+ * @brief                :converts the string to a long integer value
+ * @Scenario             :The strtol() function converts the initial part of the string in nptr to a long integer value
+ *                        according to the given base, which must be between 2 and 36 inclusive, or be the special value 0.
+ * API's covered         :strtol
+ * Preconditions         :None
+ * Postconditions        :None
+ * @return               :void
+ */
 static void tc_libc_stdlib_strtol(void)
 {
 	/* random string used for conversion */
-	char str_lnum[] = "2001 60c0c0 -1101110100110100100000 0x6fffff";
+	char str_lnum[] = "+2001 60c0c0 -1101110100110100100000 0x6fffff";
 	char *end_ptr;
 	long int ret_chk;
 
@@ -269,17 +302,17 @@ static void tc_libc_stdlib_strtol(void)
 }
 
 /**
-* @fn                   :tc_strtoll
-* @brief                :converts the string to a long long integer value
-* @Scenario             :The strtoll() function works just like the strtol() function but returns a long long integer value.
-* API's covered         :strtoll
-* Preconditions         :None
-* Postconditions        :None
-* @return               :void
-*/
+ * @fn                   :tc_libc_stdlib_strtoll
+ * @brief                :converts the string to a long long integer value
+ * @Scenario             :The strtoll() function works just like the strtol() function but returns a long long integer value.
+ * API's covered         :strtoll
+ * Preconditions         :None
+ * Postconditions        :None
+ * @return               :void
+ */
 static void tc_libc_stdlib_strtoll(void)
 {
-	char str_llnum[] = "1856892505 17b00a12b -01100011010110000010001101100 0x6fffff";
+	char str_llnum[] = "+1856892505 17b00a12b -01100011010110000010001101100 0x6fffff";
 	char *end_ptr;
 	long long int ret_chk;
 
@@ -307,18 +340,18 @@ static void tc_libc_stdlib_strtoll(void)
 }
 
 /**
-* @fn                   :tc_strtoul
-* @brief                :converts the string to a unsigned long integer value
-* @Scenario             :The strtoul() function converts the initial part of the string in nptr to an unsigned long int value
-*                        according to the given base, which must be between 2 and 36 inclusive, or be the special value 0.
-* API's covered         :strtoul
-* Preconditions         :None
-* Postconditions        :None
-* @return               :void
-*/
+ * @fn                   :tc_libc_stdlib_strtoul
+ * @brief                :converts the string to a unsigned long integer value
+ * @Scenario             :The strtoul() function converts the initial part of the string in nptr to an unsigned long int value
+ *                        according to the given base, which must be between 2 and 36 inclusive, or be the special value 0.
+ * API's covered         :strtoul
+ * Preconditions         :None
+ * Postconditions        :None
+ * @return               :void
+ */
 static void tc_libc_stdlib_strtoul(void)
 {
-	char str_ulnum[] = "201 60 1100 0x6f";
+	char str_ulnum[] = "201 0x60 1100 0x6f";
 	char *end_ptr;
 	unsigned long int ret_chk;
 
@@ -346,14 +379,14 @@ static void tc_libc_stdlib_strtoul(void)
 }
 
 /**
-* @fn                   :tc_strtoull
-* @brief                :converts the string to a unsigned long long integer value
-* @Scenario             :The strtoull() function works just like the strtoul() function but returns an unsigned long long int value.
-* API's covered         :strtoull
-* Preconditions         :None
-* Postconditions        :None
-* @return               :void
-*/
+ * @fn                   :tc_libc_stdlib_strtoull
+ * @brief                :converts the string to a unsigned long long integer value
+ * @Scenario             :The strtoull() function works just like the strtoul() function but returns an unsigned long long int value.
+ * API's covered         :strtoull
+ * Preconditions         :None
+ * Postconditions        :None
+ * @return               :void
+ */
 static void tc_libc_stdlib_strtoull(void)
 {
 	char str_ullnum[] = "250068492 7b06af00 1100011011110101010001100000 0x6fffff";
@@ -383,10 +416,20 @@ static void tc_libc_stdlib_strtoull(void)
 	TC_SUCCESS_RESULT();
 }
 
+/**
+ * @fn                   :tc_libc_stdlib_strtod
+ * @brief                :convert ASCII string to floating-point number
+ * @Scenario             :convert ASCII string to floating-point number
+ * API's covered         :strtod
+ * Preconditions         :None
+ * Postconditions        :None
+ * @return               :void
+ */
 static void tc_libc_stdlib_strtod(void)
 {
 	char *pos = NULL;
 	double ret_chk = 0;
+	const double inf = (1.0/0.0);
 
 	ret_chk = strtod("1234.56abcd", &pos);
 	TC_ASSERT_EQ("strtod", ret_chk, 1234.56);
@@ -406,9 +449,27 @@ static void tc_libc_stdlib_strtod(void)
 	ret_chk = strtod("-1.1E4abcd", &pos);
 	TC_ASSERT_EQ("strtod", ret_chk, -1.1E4);
 
+	ret_chk = strtod("   ", &pos);
+	TC_ASSERT_EQ("strtod", ret_chk, 0.0);
+
+	ret_chk = strtod("+1.1e+1040", &pos);
+	TC_ASSERT_EQ("strtod", ret_chk, inf);
+
+	ret_chk = strtod("+1.1e+1024", &pos);
+	TC_ASSERT_EQ("strtod", ret_chk, inf);
+
 	TC_SUCCESS_RESULT();
 }
 
+/**
+ * @fn                   :tc_libc_stdlib_atoi
+ * @brief                :convert a string to an integer
+ * @Scenario             :convert a string to an integer
+ * API's covered         :atoi
+ * Preconditions         :None
+ * Postconditions        :None
+ * @return               :void
+ */
 static void tc_libc_stdlib_atoi(void)
 {
 	/* random string used for conversion */
@@ -421,6 +482,15 @@ static void tc_libc_stdlib_atoi(void)
 	TC_SUCCESS_RESULT();
 }
 
+/**
+ * @fn                   :tc_libc_stdlib_atol
+ * @brief                :convert a string to an long integer
+ * @Scenario             :convert a string to an long integer
+ * API's covered         :atol
+ * Preconditions         :None
+ * Postconditions        :None
+ * @return               :void
+ */
 static void tc_libc_stdlib_atol(void)
 {
 	/* random string used for conversion */
@@ -433,6 +503,15 @@ static void tc_libc_stdlib_atol(void)
 	TC_SUCCESS_RESULT();
 }
 
+/**
+ * @fn                   :tc_libc_stdlib_atoll
+ * @brief                :convert a string to an long long integer
+ * @Scenario             :convert a string to an long long integer
+ * API's covered         :atoll
+ * Preconditions         :None
+ * Postconditions        :None
+ * @return               :void
+ */
 static void tc_libc_stdlib_atoll(void)
 {
 	/* random string used for conversion */
@@ -445,6 +524,15 @@ static void tc_libc_stdlib_atoll(void)
 	TC_SUCCESS_RESULT();
 }
 
+/**
+ * @fn                   :tc_libc_stdlib_srand
+ * @brief                :pseudo-random number generator
+ * @Scenario             :pseudo-random number generator
+ * API's covered         :srand
+ * Preconditions         :None
+ * Postconditions        :None
+ * @return               :void
+ */
 static void tc_libc_stdlib_srand(void)
 {
 	unsigned int test_num = 1234;
@@ -469,6 +557,15 @@ static void tc_libc_stdlib_srand(void)
 	TC_SUCCESS_RESULT();
 }
 
+/**
+ * @fn                   :tc_libc_stdlib_atof
+ * @brief                :Convert a string to a double
+ * @Scenario             :Convert a string to a double
+ * API's covered         :atof
+ * Preconditions         :None
+ * Postconditions        :None
+ * @return               :void
+ */
 static void tc_libc_stdlib_atof(void)
 {
 	char target[100] = "1234.56abcd";
@@ -480,6 +577,15 @@ static void tc_libc_stdlib_atof(void)
 	TC_SUCCESS_RESULT();
 }
 
+/**
+ * @fn                   :tc_libc_stdlib_bsearch
+ * @brief                :Binary search of a sorted array
+ * @Scenario             :Binary search of a sorted array
+ * API's covered         :bsearch
+ * Preconditions         :None
+ * Postconditions        :None
+ * @return               :void
+ */
 static void tc_libc_stdlib_bsearch(void)
 {
 	/* bsearch can find the result when data is ordered. So now using ordered data. */
@@ -499,12 +605,77 @@ static void tc_libc_stdlib_bsearch(void)
 
 	TC_SUCCESS_RESULT();
 }
+
+/**
+ * @fn                   :tc_libc_stdlib_abort
+ * @brief                :Cause abnormal process termination
+ * @Scenario             :Cause abnormal process termination
+ * API's covered         :abort
+ * Preconditions         :None
+ * Postconditions        :None
+ * @return               :void
+ */
+static void tc_libc_stdlib_abort(void)
+{
+	pthread_t th_id;
+	int ret_chk;
+
+	ret_chk = pthread_create(&th_id, NULL, thread_func, NULL);
+	TC_ASSERT_EQ("pthread_create", ret_chk, OK);
+
+	ret_chk = pthread_join(th_id, NULL);
+	TC_ASSERT_EQ("pthread_join", ret_chk, OK);
+
+	TC_SUCCESS_RESULT();
+}
+
+/**
+ * @fn                   :tc_libc_stdlib_div
+ * @brief                :Compute quotient and remainder of an integer division
+ * @Scenario             :Compute quotient and remainder of an integer division
+ * API's covered         :div, ldiv, lldiv
+ * Preconditions         :None
+ * Postconditions        :None
+ * @return               :void
+ */
+static void tc_libc_stdlib_div(void)
+{
+	int num = 2147483647;
+	int denom = 28672;
+	int ret_quot = 74898;
+	int ret_rem = 8191;
+	div_t ret_val;
+	ldiv_t lret_val;
+	lldiv_t llret_val;
+
+	ret_val = div(num, denom);
+	TC_ASSERT_EQ("div", ret_val.quot, ret_quot);
+	TC_ASSERT_EQ("div", ret_val.rem, ret_rem);
+
+	lret_val = ldiv(num, denom);
+	TC_ASSERT_EQ("ldiv", lret_val.quot, ret_quot);
+	TC_ASSERT_EQ("ldiv", lret_val.rem, ret_rem);
+
+	llret_val = lldiv(num, denom);
+	TC_ASSERT_EQ("lldiv", llret_val.quot, ret_quot);
+	TC_ASSERT_EQ("lldiv", llret_val.rem, ret_rem);
+
+	TC_SUCCESS_RESULT();
+}
+
 /****************************************************************************
  * Name: libc_stdlib
  ****************************************************************************/
 int libc_stdlib_main(void)
 {
+	tc_libc_stdlib_abort();
 	tc_libc_stdlib_abs_labs_llabs();
+	tc_libc_stdlib_atof();
+	tc_libc_stdlib_atoi();
+	tc_libc_stdlib_atol();
+	tc_libc_stdlib_atoll();
+	tc_libc_stdlib_bsearch();
+	tc_libc_stdlib_div();
 	tc_libc_stdlib_imaxabs();
 	tc_libc_stdlib_itoa();
 	tc_libc_stdlib_qsort();
@@ -514,12 +685,7 @@ int libc_stdlib_main(void)
 	tc_libc_stdlib_strtoull();
 	tc_libc_stdlib_strtoul();
 	tc_libc_stdlib_strtod();
-	tc_libc_stdlib_atoi();
-	tc_libc_stdlib_atol();
-	tc_libc_stdlib_atoll();
 	tc_libc_stdlib_srand();
-	tc_libc_stdlib_atof();
-	tc_libc_stdlib_bsearch();
 
 	return 0;
 }

--- a/apps/examples/testcase/le_tc/kernel/tc_libc_string.c
+++ b/apps/examples/testcase/le_tc/kernel/tc_libc_string.c
@@ -158,6 +158,11 @@ static void tc_libc_string_memmove(void)
 	TC_ASSERT_EQ("memmove", strncmp(res_ptr, buffer2, BUFF_SIZE), 0);
 	TC_ASSERT_EQ("memmove", strncmp(buffer1, buffer2, BUFF_SIZE), 0);
 
+	res_ptr = (char *)memmove(buffer2, buffer1, sizeof(buffer1));
+	TC_ASSERT_NOT_NULL("memmove", res_ptr);
+	TC_ASSERT_EQ("memmove", strncmp(res_ptr, buffer1, BUFF_SIZE), 0);
+	TC_ASSERT_EQ("memmove", strncmp(buffer2, buffer1, BUFF_SIZE), 0);
+
 	TC_SUCCESS_RESULT();
 }
 
@@ -677,7 +682,21 @@ static void tc_libc_string_strstr(void)
 
 	res_ptr = strstr(dest_arr, psz);
 	TC_ASSERT_NOT_NULL("strstr", res_ptr);
-	TC_ASSERT_EQ("strspn", strncmp(res_ptr, dest_arr, BUFF_SIZE_10), 0);
+	TC_ASSERT_EQ("strstr", strncmp(res_ptr, dest_arr, BUFF_SIZE_10), 0);
+
+	psz = "test";
+	res_ptr = strstr(dest_arr, psz);
+	TC_ASSERT_NOT_NULL("strstr", res_ptr);
+	TC_ASSERT_EQ("strstr", strncmp(res_ptr, dest_arr + 4, BUFF_SIZE_10), 0);
+
+	psz = "notfound";
+	res_ptr = strstr(dest_arr, psz);
+	TC_ASSERT_EQ("strstr", res_ptr, NULL);
+
+	psz = "";
+	res_ptr = strstr(dest_arr, psz);
+	TC_ASSERT_NOT_NULL("strstr", res_ptr);
+	TC_ASSERT_EQ("strstr", strncmp(res_ptr, dest_arr, BUFF_SIZE_10), 0);
 
 	TC_SUCCESS_RESULT();
 }
@@ -765,6 +784,20 @@ static void tc_libc_string_strcasestr(void)
 	char *res_ptr = NULL;
 	char *psz = "str";
 
+	res_ptr = strcasestr(dest_arr, psz);
+	TC_ASSERT_NOT_NULL("strcasestr", res_ptr);
+	TC_ASSERT_EQ("strcasestr", strncmp(res_ptr, dest_arr, BUFF_SIZE_10), 0);
+
+	psz = "test";
+	res_ptr = strcasestr(dest_arr, psz);
+	TC_ASSERT_NOT_NULL("strcasestr", res_ptr);
+	TC_ASSERT_EQ("strcasestr", strncmp(res_ptr, dest_arr + 4, BUFF_SIZE_10), 0);
+
+	psz = "notfound";
+	res_ptr = strcasestr(dest_arr, psz);
+	TC_ASSERT_EQ("strcasestr", res_ptr, NULL);
+
+	psz = "";
 	res_ptr = strcasestr(dest_arr, psz);
 	TC_ASSERT_NOT_NULL("strcasestr", res_ptr);
 	TC_ASSERT_EQ("strcasestr", strncmp(res_ptr, dest_arr, BUFF_SIZE_10), 0);

--- a/apps/examples/testcase/le_tc/kernel/tc_libc_timer.c
+++ b/apps/examples/testcase/le_tc/kernel/tc_libc_timer.c
@@ -30,8 +30,10 @@
 #include <signal.h>
 #include <spawn.h>
 #include <syslog.h>
-#include <tinyara/time.h>
+#include <time.h>
 #include <sys/types.h>
+#include <math.h>
+#include <float.h>
 #include "tc_internal.h"
 
 #define BUFF_SIZE 64
@@ -325,7 +327,7 @@ static void tc_libc_timer_strftime(void)
 	TC_ASSERT_EQ("strftime", atoi(buffer), st_time.tm_mon + 1);
 
 	/* Check the abbreviated month name */
-	strftime(buffer, BUFF_SIZE, "%b", &st_time);
+	strftime(buffer, BUFF_SIZE, "%h", &st_time);
 	TC_ASSERT_EQ("strftime", strcmp(buffer, "Jun"), 0);
 
 	/* Check the full month name */
@@ -340,6 +342,12 @@ static void tc_libc_timer_strftime(void)
 	strftime(buffer, BUFF_SIZE, "%d", &st_time);
 	TC_ASSERT_EQ("strftime", atoi(buffer), st_time.tm_mday);
 
+	/* Check the day of month as a decimal number but a leading zero
+	 * is replaced by a space. (range 1 to 31)
+	 */
+	strftime(buffer, BUFF_SIZE, "%e", &st_time);
+	TC_ASSERT_EQ("strftime", atoi(buffer), st_time.tm_mday);
+
 	/* Check the hour as a decimal number using a 24-hour clock (range 00 to 23) */
 	strftime(buffer, BUFF_SIZE, "%H", &st_time);
 	TC_ASSERT_EQ("strftime", atoi(buffer), st_time.tm_hour);
@@ -352,6 +360,18 @@ static void tc_libc_timer_strftime(void)
 	strftime(buffer, BUFF_SIZE, "%j", &st_time);
 	TC_ASSERT_EQ("strftime", atoi(buffer), clock_daysbeforemonth(st_time.tm_mon, false) + st_time.tm_mday);
 
+	/* Check the hour as a decimal number using a 24-hour clock (range 0 to 23)
+	 * single digits are preceded by a blank.
+	 */
+	strftime(buffer, BUFF_SIZE, "%k", &st_time);
+	TC_ASSERT_EQ("strftime", atoi(buffer), st_time.tm_hour);
+
+	/* Check the hour as a decimal number using a 12-hour clock (range 01 to 12)
+	 * single digits are preceded by a blank.
+	 */
+	strftime(buffer, BUFF_SIZE, "%l", &st_time);
+	TC_ASSERT_EQ("strftime", atoi(buffer), st_time.tm_hour - 12);
+
 	/* Check either "AM" or "PM" according to the given time value, Noon is treated as "PM" and midnight as "AM" */
 	strftime(buffer, BUFF_SIZE, "%p", &st_time);
 	TC_ASSERT_EQ("strftime", strcmp(buffer, "PM"), 0);
@@ -359,6 +379,15 @@ static void tc_libc_timer_strftime(void)
 	/* Check either "am" or "pm" according to the given time value, Noon is treated as "pm" and midnight as "am" */
 	strftime(buffer, BUFF_SIZE, "%P", &st_time);
 	TC_ASSERT_EQ("strftime", strcmp(buffer, "pm"), 0);
+
+	st_time.tm_hour = 3;
+	/* Check either "AM" or "PM" according to the given time value, Noon is treated as "PM" and midnight as "AM" */
+	strftime(buffer, BUFF_SIZE, "%p", &st_time);
+	TC_ASSERT_EQ("strftime", strcmp(buffer, "AM"), 0);
+
+	/* Check either "am" or "pm" according to the given time value, Noon is treated as "pm" and midnight as "am" */
+	strftime(buffer, BUFF_SIZE, "%P", &st_time);
+	TC_ASSERT_EQ("strftime", strcmp(buffer, "am"), 0);
 
 	/* Check the second as a decimal number (range 00 to 60) */
 	strftime(buffer, BUFF_SIZE, "%S", &st_time);

--- a/apps/examples/testcase/le_tc/kernel/tc_pthread.c
+++ b/apps/examples/testcase/le_tc/kernel/tc_pthread.c
@@ -48,6 +48,7 @@
 #define INTHREAD                0
 #define INMAIN                  1
 #define SIGQUIT                 3
+#define NOSIG                   333
 
 struct mallinfo mem;
 
@@ -1344,6 +1345,9 @@ static void tc_pthread_pthread_sigmask(void)
 
 	sigemptyset(&st_newmask);
 	sigaddset(&st_newmask, SIGQUIT);
+
+	ret_chk = pthread_sigmask(NOSIG, &st_newmask, &st_oldmask);
+	TC_ASSERT_EQ("pthread_sigmask", ret_chk, EINVAL);
 
 	ret_chk = pthread_sigmask(SIG_BLOCK, &st_newmask, &st_oldmask);
 	TC_ASSERT_GEQ("pthread_sigmask", ret_chk, 0);

--- a/apps/examples/testcase/le_tc/kernel/tc_semaphore.c
+++ b/apps/examples/testcase/le_tc/kernel/tc_semaphore.c
@@ -358,10 +358,10 @@ static void tc_semaphore_sem_destroy(void)
 
 int semaphore_main(void)
 {
+	tc_semaphore_sem_destroy();
 	tc_semaphore_sem_post_wait();
 	tc_semaphore_sem_trywait();
 	tc_semaphore_sem_timedwait();
-	tc_semaphore_sem_destroy();
 
 	return 0;
 }

--- a/apps/examples/testcase/le_tc/kernel/tc_termios.c
+++ b/apps/examples/testcase/le_tc/kernel/tc_termios.c
@@ -45,6 +45,19 @@ static void tc_termios_tcsetattr_tcgetattr(void)
 	}
 
 	sleep(1);
+	/* isatty() returns 1 if fd is an open file descriptor referring to a terminal */
+	ret_chk = isatty(fileno(stdin));
+	TC_ASSERT_EQ("isatty", ret_chk, 1);
+
+	ret_chk = cfgetspeed(&prev_tio);
+	TC_ASSERT_GEQ("cfgetspeed", ret_chk, 0);
+
+	/* Failure case: invalid option */
+	sleep(1);
+	ret_chk = tcsetattr(fileno(stdin), 33, &prev_tio);
+	TC_ASSERT_LT("tcsetattr", ret_chk, 0);
+
+	sleep(1);
 	prev_tio.c_oflag &= ~ONLCR;
 	ret_chk = tcsetattr(fileno(stdin), TCSANOW, &prev_tio);
 	TC_ASSERT_EQ("tcsetattr", ret_chk, 0);

--- a/apps/examples/testcase/le_tc/network/tc_net_inet.c
+++ b/apps/examples/testcase/le_tc/network/tc_net_inet.c
@@ -42,14 +42,12 @@
 */
 static void tc_net_inet_addr_p(void)
 {
-
 	unsigned int ret;
 
 	ret = inet_addr("127.0.0.1");
 
 	TC_ASSERT_NEQ("inet", ret, -1);
 	TC_SUCCESS_RESULT();
-
 }
 
 
@@ -63,7 +61,6 @@ static void tc_net_inet_addr_p(void)
 */
 static void tc_net_inet_aton_p(void)
 {
-
 	struct sockaddr_in addr_inet;
 	unsigned long ret;
 
@@ -71,7 +68,6 @@ static void tc_net_inet_aton_p(void)
 
 	TC_ASSERT_NEQ("inet", ret, 0);
 	TC_SUCCESS_RESULT();
-
 }
 
 
@@ -85,7 +81,6 @@ static void tc_net_inet_aton_p(void)
 */
 static void tc_net_inet_ntoa_p(void)
 {
-
 	struct sockaddr_in addr_inet;
 	char *ret;
 
@@ -94,7 +89,74 @@ static void tc_net_inet_ntoa_p(void)
 
 	TC_ASSERT_NEQ("inet", *ret, -1);
 	TC_SUCCESS_RESULT();
+}
 
+/**
+* @testcase     tc_net_inet_ntop
+* @brief
+* @scenario
+* @apicovered       inet_ntop()
+* @precondition
+* @postcondition
+*/
+static void tc_net_inet_ntop(void)
+{
+	struct in_addr in_addr;
+	char dst[INET_ADDRSTRLEN];
+	const char *ret;
+
+	in_addr.s_addr = 0x17071994;
+
+#ifdef CONFIG_NET_IPv4
+	ret = inet_ntop(AF_INET, &in_addr, dst, INET_ADDRSTRLEN);
+	TC_ASSERT_NEQ("inet_ntop", ret, NULL);
+
+	/* Failure case: size of destination buffer less than INET_ADDRSTRLEN bytes */
+	ret = inet_ntop(AF_INET, &in_addr, dst, 7);
+	TC_ASSERT_EQ("inet_ntop", ret, NULL);
+#endif
+#ifdef CONFIG_NET_IPv6
+	ret = inet_ntop(AF_INET6, &in_addr, dst, INET_ADDRSTRLEN);
+	TC_ASSERT_NEQ("inet_ntop", ret, NULL);
+#endif
+	/* Failure case: invalid address family */
+	ret = inet_ntop(33, &in_addr, dst, INET_ADDRSTRLEN);
+	TC_ASSERT_EQ("inet_ntop", ret, NULL);
+
+
+	TC_SUCCESS_RESULT();
+}
+
+/**
+* @testcase		tc_net_inet_pton
+* @brief
+* @scenario
+* @apicovered		inet_pton()
+* @precondition
+* @postcondition
+*/
+static void tc_net_inet_pton(void)
+{
+	struct sockaddr_in addr_inet;
+	int ret;
+
+#ifdef CONFIG_NET_IPv4
+	ret = inet_pton(AF_INET, "107.108.218.83", &(addr_inet.sin_addr));
+	TC_ASSERT_EQ("inet_pton", ret, 1);
+
+	/* Failure case: invalid network address */
+	ret = inet_pton(AF_INET, "30051995", &(addr_inet.sin_addr));
+	TC_ASSERT_EQ("inet_pton", ret, 0);
+#endif
+#ifdef CONFIG_NET_IPv6
+	ret = inet_pton(AF_INET6, "0:0:0:0:0:0:0:1", &(addr_inet.sin_addr));
+	TC_ASSERT_EQ("inet_pton", ret, 1);
+#endif
+	/* Failure case: invalid address family */
+	ret = inet_pton(33, "107.108.218.83", &(addr_inet.sin_addr));
+	TC_ASSERT_EQ("inet_pton", ret, -1);
+
+	TC_SUCCESS_RESULT();
 }
 
 /**
@@ -107,7 +169,6 @@ static void tc_net_inet_ntoa_p(void)
 */
 static void tc_net_htons(void)
 {
-
 	uint16_t var = 20;
 	uint16_t ret;
 	uint16_t ref;
@@ -117,7 +178,6 @@ static void tc_net_htons(void)
 
 	TC_ASSERT_EQ("inet", ret, ref);
 	TC_SUCCESS_RESULT();
-
 }
 
 /**
@@ -130,7 +190,6 @@ static void tc_net_htons(void)
 */
 static void tc_net_ntohs(void)
 {
-
 	uint16_t var = 0x1400;
 	uint16_t ret;
 	uint16_t ref;
@@ -140,7 +199,6 @@ static void tc_net_ntohs(void)
 
 	TC_ASSERT_EQ("inet", ret, ref);
 	TC_SUCCESS_RESULT();
-
 }
 
 /**
@@ -153,7 +211,6 @@ static void tc_net_ntohs(void)
 */
 static void tc_net_htonl(void)
 {
-
 	uint32_t var = 10;
 	uint32_t ret;
 	uint32_t ref;
@@ -163,7 +220,6 @@ static void tc_net_htonl(void)
 
 	TC_ASSERT_EQ("inet", ret, ref);
 	TC_SUCCESS_RESULT();
-
 }
 
 /**
@@ -176,7 +232,6 @@ static void tc_net_htonl(void)
 */
 static void tc_net_ntohl(void)
 {
-
 	uint32_t var = 0xa000000;
 	uint32_t ret;
 	uint32_t ref;
@@ -186,7 +241,6 @@ static void tc_net_ntohl(void)
 
 	TC_ASSERT_EQ("inet", ret, ref);
 	TC_SUCCESS_RESULT();
-
 }
 
 
@@ -196,13 +250,17 @@ static void tc_net_ntohl(void)
 
 int net_inet_main(void)
 {
+	tc_net_htonl();
+	tc_net_htons();
 	tc_net_inet_addr_p();
 	tc_net_inet_aton_p();
+#ifdef CONFIG_NET_IPv4
 	tc_net_inet_ntoa_p();
-	tc_net_htons();
-	tc_net_ntohs();
-	tc_net_htonl();
+#endif
+	tc_net_inet_ntop();
+	tc_net_inet_pton();
 	tc_net_ntohl();
+	tc_net_ntohs();
 
 	return 0;
 }


### PR DESCRIPTION
Expands/Adds test cases for following API's,
**fs**: opendir(), closedir()
**net_inet**: ntop() and pton()
**kernel/pthread**: pthread_sigmask() 
**kernel/clock**: clock_getres() and gettimeofday()
**kernel/environ**: setenv() and putenv()
**libc/libgen**: dirname()
**libc/termios**: isatty(), cfgetspeed() and tcsetattr()
**libc/timer**: strftime()
**libc/string**: memmove(), strstr() and strcasestr()
**libc/unistd**: getcwd(), chdir(), access(), getopt() getoptargp(), getoptindp() and getoptoptp()
**libc/stdlib**: itoa(), qsort(), abort(), strtod(), strtol(), strtoll(), strtoul()
**libc/semaphore**: sem_getprotocol()
