### PR TITLE
Code coverage: Add test cases for various API's

### DIFF
--- a/apps/examples/testcase/le_tc/kernel/tc_libc_sched.c
+++ b/apps/examples/testcase/le_tc/kernel/tc_libc_sched.c
@@ -82,6 +82,34 @@ static void tc_libc_sched_sched_get_priority_min(void)
 	TC_SUCCESS_RESULT();
 }
 
+/**
+ * @fn                   :tc_libc_sched_task_setcanceltype
+ * @brief                :This tc tests tc_libc_sched_task_setcanceltype()
+ * @Scenario             :The task_setcanceltype() function atomically both sets the calling
+ *                        task's cancelability type to the indicated type and returns the
+ *                        previous cancelability type at the location referenced by oldtype
+ *                        If successful pthread_setcanceltype() function shall return zero;
+ *                        otherwise, an error number shall be returned to indicate the error.
+ * @API'scovered         :task_setcanceltype
+ * @Preconditions        :none
+ * @Postconditions       :none
+ * @return               :void
+ */
+#ifndef CONFIG_CANCELLATION_POINTS
+static void tc_libc_sched_task_setcanceltype(void)
+{
+	int type;
+	int oldtype;
+	int ret_chk;
+
+	type = TASK_CANCEL_ASYNCHRONOUS;
+	ret_chk = task_setcanceltype(type, &oldtype);
+	TC_ASSERT_EQ("task_setcanceltype", ret_chk, OK);
+
+	TC_SUCCESS_RESULT();
+}
+#endif
+
 /****************************************************************************
  * Name: libc_sched
  ****************************************************************************/
@@ -90,6 +118,8 @@ int libc_sched_main(void)
 {
 	tc_libc_sched_sched_get_priority_max();
 	tc_libc_sched_sched_get_priority_min();
-
+#ifndef CONFIG_CANCELLATION_POINTS
+	tc_libc_sched_task_setcanceltype();
+#endif
 	return 0;
 }

--- a/apps/examples/testcase/le_tc/kernel/tc_libc_spawn.c
+++ b/apps/examples/testcase/le_tc/kernel/tc_libc_spawn.c
@@ -261,6 +261,8 @@ static void tc_libc_spawn_posix_spawnattr_dump(void)
 	pid_t pid;
 	posix_spawnattr_t st_attr;
 
+	posix_spawnattr_dump(&st_attr);
+
 	ret_chk = posix_spawnattr_init(&st_attr);
 	TC_ASSERT_EQ("posix_spawnattr_init", ret_chk, OK);
 
@@ -272,6 +274,35 @@ static void tc_libc_spawn_posix_spawnattr_dump(void)
 	TC_ASSERT_EQ("task_spawn", ret_chk, OK);
 
 	posix_spawnattr_dump(&st_attr);
+
+	ret_chk = posix_spawnattr_setschedpolicy(&st_attr, SCHED_FIFO);
+	TC_ASSERT_EQ("posix_spawnattr_setschedpolicy", ret_chk, OK);
+	posix_spawnattr_dump(&st_attr);
+
+	ret_chk = posix_spawnattr_setflags(&st_attr, POSIX_SPAWN_SETSCHEDPARAM);
+	TC_ASSERT_EQ("posix_spawnattr_setflags", ret_chk, OK);
+	posix_spawnattr_dump(&st_attr);
+
+	ret_chk = posix_spawnattr_setflags(&st_attr, POSIX_SPAWN_RESETIDS);
+	TC_ASSERT_EQ("posix_spawnattr_setflags", ret_chk, OK);
+	posix_spawnattr_dump(&st_attr);
+
+	ret_chk = posix_spawnattr_setflags(&st_attr, POSIX_SPAWN_SETPGROUP);
+	TC_ASSERT_EQ("posix_spawnattr_setflags", ret_chk, OK);
+	posix_spawnattr_dump(&st_attr);
+
+	ret_chk = posix_spawnattr_setflags(&st_attr, POSIX_SPAWN_SETSCHEDULER);
+	TC_ASSERT_EQ("posix_spawnattr_setflags", ret_chk, OK);
+	posix_spawnattr_dump(&st_attr);
+
+	ret_chk = posix_spawnattr_setflags(&st_attr, POSIX_SPAWN_SETSIGDEF);
+	TC_ASSERT_EQ("posix_spawnattr_setflags", ret_chk, OK);
+	posix_spawnattr_dump(&st_attr);
+
+	ret_chk = posix_spawnattr_setflags(&st_attr, POSIX_SPAWN_SETSIGMASK);
+	TC_ASSERT_EQ("posix_spawnattr_setflags", ret_chk, OK);
+	posix_spawnattr_dump(&st_attr);
+
 	TC_SUCCESS_RESULT();
 }
 
@@ -292,6 +323,37 @@ static void tc_libc_spawn_posix_spawn_file_actions_init(void)
 	ret_chk = posix_spawn_file_actions_init(&st_fileactions);
 	TC_ASSERT_EQ("posix_spawn_file_actions_init", ret_chk, OK);
 	TC_ASSERT_EQ("posix_spawn_file_actions_init", st_fileactions, NULL);
+
+	ret_chk = posix_spawn_file_actions_destroy(&st_fileactions);
+	TC_ASSERT_EQ("posix_spawn_file_actions_destroy", ret_chk, OK);
+
+	TC_SUCCESS_RESULT();
+}
+
+/**
+ * @fn                   : tc_libc_spawn_posix_spawn_file_actions_adddup2()
+ * @brief                : adds a dup2 operation to the object referenced by file_actions, for subsequent use in a call to posix_spawn()/posix_spawnp()
+ * @scenario             : The descriptor referred to by fd2 is created as if dup2() had been called on fd1 prior to the new child process starting execution.
+ *                         On success, these functions return 0; on failure they return an error
+ * @API's covered        : posix_spawn_file_actions_adddup2
+ * @Preconditions        : posix_spawnattr_init,posix_spawn_file_actions_init
+ * @Postconditions       : posix_spawn_file_actions_destroy
+ * @Return               : void
+ */
+static void tc_libc_spawn_posix_spawn_file_actions_adddup2(void)
+{
+	posix_spawn_file_actions_t st_fileactions;
+	posix_spawnattr_t st_attr;
+	int ret_chk = ERROR;
+
+	ret_chk = posix_spawnattr_init(&st_attr);
+	TC_ASSERT_EQ("posix_spawnattr_init", ret_chk, OK);
+
+	ret_chk = posix_spawn_file_actions_init(&st_fileactions);
+	TC_ASSERT_EQ("posix_spawn_file_actions_init", ret_chk, OK);
+
+	ret_chk = posix_spawn_file_actions_adddup2(&st_fileactions, 1, 2);
+	TC_ASSERT_EQ("posix_spawn_file_actions_adddup2", ret_chk, OK);
 
 	ret_chk = posix_spawn_file_actions_destroy(&st_fileactions);
 	TC_ASSERT_EQ("posix_spawn_file_actions_destroy", ret_chk, OK);
@@ -381,11 +443,21 @@ static void tc_libc_spawn_posix_spawn_file_actions_dump(void)
 	ret_chk = posix_spawn_file_actions_init(&st_fileactions);
 	TC_ASSERT_EQ("posix_spawn_file_actions_init", ret_chk, OK);
 
+	posix_spawn_file_actions_dump(&st_fileactions);
+
 	ret_chk = posix_spawn_file_actions_addopen(&st_fileactions, 1, szfilepath, O_WRONLY, 0644);
 	TC_ASSERT_EQ("posix_spawn_file_actions_addopen", ret_chk, OK);
 
 	/* posix_spawn_file_actions_dump returns (void) */
 
+	posix_spawn_file_actions_dump(&st_fileactions);
+
+	ret_chk = posix_spawn_file_actions_adddup2(&st_fileactions, 1, 2);
+	TC_ASSERT_EQ("posix_spawn_file_actions_adddup2", ret_chk, OK);
+	posix_spawn_file_actions_dump(&st_fileactions);
+
+	ret_chk = posix_spawn_file_actions_addclose(&st_fileactions, 1);
+	TC_ASSERT_EQ("posix_spawn_file_actions_addclose", ret_chk, OK);
 	posix_spawn_file_actions_dump(&st_fileactions);
 
 	ret_chk = posix_spawn_file_actions_destroy(&st_fileactions);
@@ -459,6 +531,7 @@ int libc_spawn_main(void)
 	tc_libc_spawn_task_spawnattr_setgetstacksize();
 	tc_libc_spawn_posix_spawn_file_actions_init();
 	tc_libc_spawn_add_file_action();
+	tc_libc_spawn_posix_spawn_file_actions_adddup2();
 	tc_libc_spawn_posix_spawn_file_actions_addopenclose();
 	tc_libc_spawn_posix_spawn_file_actions_destroy();
 	tc_libc_spawn_posix_spawn_file_actions_dump();


### PR DESCRIPTION
This patch adds TC's for API's in:
libc/sched: task_setcanceltype()
libc/spawn: posix_spawn_file_actions_adddup2()

Signed-off-by: Vidisha Thapa <thapa.v@samsung.com>