### PR TITLE
TC: Add test cases for Libc Math

### DIFF
--- a/apps/examples/testcase/le_tc/kernel/tc_libc_math.c
+++ b/apps/examples/testcase/le_tc/kernel/tc_libc_math.c
@@ -587,6 +587,84 @@ static void tc_libc_math_atan2l(void)
 }
 
 /**
+ * @fn                   :tc_libc_math_cbrt
+ * @brief                :Returns the cube root of parameter
+ * @Scenario             :Returns the cube root of parameter
+ * API's covered         :cbrt
+ * Preconditions         :None
+ * Postconditions        :None
+ * @return               :void
+ */
+static void tc_libc_math_cbrt(void)
+{
+	const double in_val[6] = { ZERO, VAL1, -VAL1, INFINITY, -INFINITY, NAN };
+	const double sol_val[6] = { ZERO, 131072.0, -131072.0, INFINITY, -INFINITY, NAN };
+	double ret_val[6];
+	int cbrt_idx;
+
+	for (cbrt_idx = 0; cbrt_idx < 6; cbrt_idx++) {
+		ret_val[cbrt_idx] = cbrt(in_val[cbrt_idx]);
+		if (!(isnan(sol_val[cbrt_idx]) && isnan(ret_val[cbrt_idx]))) {
+			TC_ASSERT_LEQ("cbrt", fabs(sol_val[cbrt_idx] - ret_val[cbrt_idx]), FLT_EPSILON);
+		}
+	}
+
+	TC_SUCCESS_RESULT();
+}
+
+/**
+ * @fn                   :tc_libc_math_cbrtf
+ * @brief                :Returns the cube root of parameter
+ * @Scenario             :Returns the cube root of parameter
+ * API's covered         :cbrtf
+ * Preconditions         :None
+ * Postconditions        :None
+ * @return               :void
+ */
+static void tc_libc_math_cbrtf(void)
+{
+	const float in_val[6] = { ZERO, VAL1, -VAL1, INFINITY, -INFINITY, NAN };
+	const float sol_val[6] = { ZERO, 131072.0, -131072.0, INFINITY, -INFINITY, NAN };
+	float ret_val[6];
+	int cbrtf_idx;
+
+	for (cbrtf_idx = 0; cbrtf_idx < 6; cbrtf_idx++) {
+		ret_val[cbrtf_idx] = cbrtf(in_val[cbrtf_idx]);
+		if (!(isnan(sol_val[cbrtf_idx]) && isnan(ret_val[cbrtf_idx]))) {
+			TC_ASSERT_LEQ("cbrtf", fabsf((float)sol_val[cbrtf_idx] - ret_val[cbrtf_idx]), FLT_EPSILON);
+		}
+	}
+
+	TC_SUCCESS_RESULT();
+}
+
+/**
+ * @fn                   :tc_libc_math_cbrtl
+ * @brief                :Returns the cube root of parameter
+ * @Scenario             :Returns the cube root of parameter
+ * API's covered         :cbrtl
+ * Preconditions         :None
+ * Postconditions        :None
+ * @return               :void
+ */
+static void tc_libc_math_cbrtl(void)
+{
+	const long double in_val[6] = { ZERO, VAL1, -VAL1, INFINITY, -INFINITY, NAN };
+	const long double sol_val[6] = { ZERO, 131072.0, -131072.0, INFINITY, -INFINITY, NAN };
+	long double ret_val[6];
+	int cbrtl_idx;
+
+	for (cbrtl_idx = 0; cbrtl_idx < 6; cbrtl_idx++) {
+		ret_val[cbrtl_idx] = cbrtl(in_val[cbrtl_idx]);
+		if (!(isnan(sol_val[cbrtl_idx]) && isnan(ret_val[cbrtl_idx]))) {
+			TC_ASSERT_LEQ("cbrtl", fabsl(sol_val[cbrtl_idx] - ret_val[cbrtl_idx]), FLT_EPSILON);
+		}
+	}
+
+	TC_SUCCESS_RESULT();
+}
+
+/**
  * @fn                   :tc_libc_math_ceil
  * @brief                :Rounds x upward, returning the smallest integral value that is not less than x
  * @Scenario             :Rounds x upward, returning the smallest integral value that is not less than x
@@ -980,25 +1058,77 @@ static void tc_libc_math_erfl(void)
 }
 
 /**
- * @fn                   :tc_libc_math_cbrt
- * @brief                :Returns the cube root of parameter
- * @Scenario             :Returns the cube root of parameter
- * API's covered         :cbrt
+ * @fn                   :tc_libc_math_exp
+ * @brief                :Returns the base-e exponential value
+ * @Scenario             :Returns the base-e exponential value
+ * API's covered         :exp
  * Preconditions         :None
  * Postconditions        :None
  * @return               :void
  */
-static void tc_libc_math_cbrt(void)
+static void tc_libc_math_exp(void)
 {
-	const double in_val[6] = { ZERO, VAL1, -VAL1, INFINITY, -INFINITY, NAN };
-	const double sol_val[6] = { ZERO, 131072.0, -131072.0, INFINITY, -INFINITY, NAN };
-	double ret_val[6];
-	int cbrt_idx;
+	const double in_val[8] = { ZERO, INFINITY, -INFINITY, NAN, VAL1, -VAL1, VAL2, -VAL2 };
+	const double sol_val[8] = { 1.0, INFINITY, ZERO, NAN, INFINITY, ZERO, INFINITY, ZERO };
+	double ret_val[8];
+	int exp_idx;
 
-	for (cbrt_idx = 0; cbrt_idx < 6; cbrt_idx++) {
-		ret_val[cbrt_idx] = cbrt(in_val[cbrt_idx]);
-		if (!(isnan(sol_val[cbrt_idx]) && isnan(ret_val[cbrt_idx]))) {
-			TC_ASSERT_LEQ("cbrt", fabs(sol_val[cbrt_idx] - ret_val[cbrt_idx]), FLT_EPSILON);
+	for (exp_idx = 0; exp_idx < 8; exp_idx++) {
+		ret_val[exp_idx] = exp(in_val[exp_idx]);
+		if (!(isnan(sol_val[exp_idx]) && isnan(ret_val[exp_idx]))) {
+			TC_ASSERT_LEQ("exp", fabs(sol_val[exp_idx] - ret_val[exp_idx]), FLT_EPSILON);
+		}
+	}
+
+	TC_SUCCESS_RESULT();
+}
+
+/**
+ * @fn                   :tc_libc_math_expf
+ * @brief                :Returns the base-e exponential value
+ * @Scenario             :Returns the base-e exponential value
+ * API's covered         :expf
+ * Preconditions         :None
+ * Postconditions        :None
+ * @return               :void
+ */
+static void tc_libc_math_expf(void)
+{
+	const float in_val[8] = { ZERO, INFINITY, -INFINITY, NAN, VAL1, -VAL1, VAL2, -VAL2 };
+	const float sol_val[8] = { 1.0, INFINITY, ZERO, NAN, INFINITY, ZERO, INFINITY, ZERO };
+	float ret_val[8];
+	int expf_idx;
+
+	for (expf_idx = 0; expf_idx < 8; expf_idx++) {
+		ret_val[expf_idx] = expf(in_val[expf_idx]);
+		if (!(isnan(sol_val[expf_idx]) && isnan(ret_val[expf_idx]))) {
+			TC_ASSERT_LEQ("expf", fabsf(sol_val[expf_idx] - ret_val[expf_idx]), FLT_EPSILON);
+		}
+	}
+
+	TC_SUCCESS_RESULT();
+}
+
+/**
+ * @fn                   :tc_libc_math_expl
+ * @brief                :Returns the base-e exponential value
+ * @Scenario             :Returns the base-e exponential value
+ * API's covered         :expl
+ * Preconditions         :None
+ * Postconditions        :None
+ * @return               :void
+ */
+static void tc_libc_math_expl(void)
+{
+	const long double in_val[8] = { ZERO, INFINITY, -INFINITY, NAN, VAL1, -VAL1, VAL2, -VAL2 };
+	const long double sol_val[8] = { 1.0, INFINITY, ZERO, NAN, INFINITY, ZERO, INFINITY, ZERO };
+	long double ret_val[8];
+	int expl_idx;
+
+	for (expl_idx = 0; expl_idx < 8; expl_idx++) {
+		ret_val[expl_idx] = expl(in_val[expl_idx]);
+		if (!(isnan(sol_val[expl_idx]) && isnan(ret_val[expl_idx]))) {
+			TC_ASSERT_LEQ("expl", fabsl(sol_val[expl_idx] - ret_val[expl_idx]), FLT_EPSILON);
 		}
 	}
 
@@ -1032,6 +1162,58 @@ static void tc_libc_math_exp2(void)
 }
 
 /**
+ * @fn                   :tc_libc_math_exp2f
+ * @brief                :Returns the base-2 exponential value
+ * @Scenario             :Returns the base-2 exponential value
+ * API's covered         :exp2f
+ * Preconditions         :None
+ * Postconditions        :None
+ * @return               :void
+ */
+static void tc_libc_math_exp2f(void)
+{
+	const float in_val[8] = { ZERO, VAL1, -VAL1, VAL2, -VAL2, INFINITY, -INFINITY, NAN };
+	const float sol_val[8] = { 1.0, INFINITY, ZERO, INFINITY, ZERO, INFINITY, ZERO, NAN };
+	float ret_val[8];
+	int exp2f_idx;
+
+	for (exp2f_idx = 0; exp2f_idx < 8; exp2f_idx++) {
+		ret_val[exp2f_idx] = exp2f(in_val[exp2f_idx]);
+		if (!(isnan(sol_val[exp2f_idx]) && isnan(ret_val[exp2f_idx]))) {
+			TC_ASSERT_LEQ("exp2f", fabsf(sol_val[exp2f_idx] - ret_val[exp2f_idx]), FLT_EPSILON);
+		}
+	}
+
+	TC_SUCCESS_RESULT();
+}
+
+/**
+ * @fn                   :tc_libc_math_exp2l
+ * @brief                :Returns the base-2 exponential value
+ * @Scenario             :Returns the base-2 exponential value
+ * API's covered         :exp2l
+ * Preconditions         :None
+ * Postconditions        :None
+ * @return               :void
+ */
+static void tc_libc_math_exp2l(void)
+{
+	const long double in_val[8] = { ZERO, VAL1, -VAL1, VAL2, -VAL2, INFINITY, -INFINITY, NAN };
+	const long double sol_val[8] = { 1.0, INFINITY, ZERO, INFINITY, ZERO, INFINITY, ZERO, NAN };
+	long double ret_val[8];
+	int exp2l_idx;
+
+	for (exp2l_idx = 0; exp2l_idx < 8; exp2l_idx++) {
+		ret_val[exp2l_idx] = exp2l(in_val[exp2l_idx]);
+		if (!(isnan(sol_val[exp2l_idx]) && isnan(ret_val[exp2l_idx]))) {
+			TC_ASSERT_LEQ("exp2l", fabsl(sol_val[exp2l_idx] - ret_val[exp2l_idx]), FLT_EPSILON);
+		}
+	}
+
+	TC_SUCCESS_RESULT();
+}
+
+/**
  * @fn                   :tc_libc_math_fabs
  * @brief                :Returns the absolute value of parameter
  * @Scenario             :Returns the absolute value of parameter
@@ -1042,14 +1224,66 @@ static void tc_libc_math_exp2(void)
  */
 static void tc_libc_math_fabs(void)
 {
-	const double in_val[5] = { ZERO, VAL1, -VAL1, INFINITY, -INFINITY };
-	const double sol_val[5] = { ZERO, 2251799813685248.5, 2251799813685248.5, INFINITY, INFINITY };
-	double ret_val[5];
+	const double in_val[7] = { ZERO, -ZERO, VAL1, -VAL1, INFINITY, -INFINITY, NAN };
+	const double sol_val[7] = { ZERO, ZERO, 2251799813685248.5, 2251799813685248.5, INFINITY, INFINITY, NAN };
+	double ret_val[7];
 	int fabs_idx;
 
-	for (fabs_idx = 0; fabs_idx < 5; fabs_idx++) {
+	for (fabs_idx = 0; fabs_idx < 7; fabs_idx++) {
 		ret_val[fabs_idx] = fabs(in_val[fabs_idx]);
-		TC_ASSERT_EQ("fabs", sol_val[fabs_idx], ret_val[fabs_idx]);
+		if (!(isnan(sol_val[fabs_idx]) && isnan(ret_val[fabs_idx]))) {
+			TC_ASSERT_EQ("fabs", sol_val[fabs_idx], ret_val[fabs_idx]);
+		}
+	}
+
+	TC_SUCCESS_RESULT();
+}
+
+/**
+ * @fn                   :tc_libc_math_fabsf
+ * @brief                :Returns the absolute value of parameter
+ * @Scenario             :Returns the absolute value of parameter
+ * API's covered         :fabsf
+ * Preconditions         :None
+ * Postconditions        :None
+ * @return               :void
+ */
+static void tc_libc_math_fabsf(void)
+{
+	const float in_val[7] = { ZERO, -ZERO, VAL1, -VAL1, INFINITY, -INFINITY, NAN };
+	const float sol_val[7] = { ZERO, ZERO, 2251799813685248.5, 2251799813685248.5, INFINITY, INFINITY, NAN };
+	float ret_val[7];
+	int fabsf_idx;
+	for (fabsf_idx = 0; fabsf_idx < 7; fabsf_idx++) {
+		ret_val[fabsf_idx] = fabsf(in_val[fabsf_idx]);
+		if (!(isnan(sol_val[fabsf_idx]) && isnan(ret_val[fabsf_idx]))) {
+			TC_ASSERT_EQ("fabsf", sol_val[fabsf_idx], ret_val[fabsf_idx]);
+		}
+	}
+
+	TC_SUCCESS_RESULT();
+}
+
+/**
+ * @fn                   :tc_libc_math_fabsl
+ * @brief                :Returns the absolute value of parameter
+ * @Scenario             :Returns the absolute value of parameter
+ * API's covered         :fabsl
+ * Preconditions         :None
+ * Postconditions        :None
+ * @return               :void
+ */
+static void tc_libc_math_fabsl(void)
+{
+	const long double in_val[7] = { ZERO, -ZERO, VAL1, -VAL1, INFINITY, -INFINITY, NAN };
+	const long double sol_val[7] = { ZERO, ZERO, 2251799813685248.5, 2251799813685248.5, INFINITY, INFINITY, NAN };
+	long double ret_val[7];
+	int fabsl_idx;
+	for (fabsl_idx = 0; fabsl_idx < 7; fabsl_idx++) {
+		ret_val[fabsl_idx] = fabsl(in_val[fabsl_idx]);
+		if (!(isnan(sol_val[fabsl_idx]) && isnan(ret_val[fabsl_idx]))) {
+			TC_ASSERT_EQ("fabsl", sol_val[fabsl_idx], ret_val[fabsl_idx]);
+		}
 	}
 
 	TC_SUCCESS_RESULT();
@@ -1066,16 +1300,70 @@ static void tc_libc_math_fabs(void)
  */
 static void tc_libc_math_fdim(void)
 {
-	const double in_val1[9] = { ZERO, -ZERO, VAL1, -VAL1, VAL2, -VAL2, INFINITY, -INFINITY, NAN };
-	const double in_val2[9] = { -INFINITY, INFINITY, -VAL2, VAL2, -VAL1, VAL1, -ZERO, ZERO, NAN };
-	const double sol_val[9] = { INFINITY, ZERO, 6755399441055744.0, ZERO, 6755399441055744.0, ZERO, INFINITY, ZERO, NAN };
-	double ret_val[9];
+	const double in_val1[10] = { ZERO, -ZERO, VAL1, -VAL1, VAL2, -VAL2, INFINITY, -INFINITY, NAN, VAL1 };
+	const double in_val2[10] = { -INFINITY, INFINITY, -VAL2, VAL2, -VAL1, VAL1, -ZERO, ZERO, NAN, NAN };
+	const double sol_val[10] = { INFINITY, ZERO, 6755399441055744.0, ZERO, 6755399441055744.0, ZERO, INFINITY, ZERO, NAN, NAN };
+	double ret_val[10];
 	int fdim_idx;
 
-	for (fdim_idx = 0; fdim_idx < 9; fdim_idx++) {
+	for (fdim_idx = 0; fdim_idx < 10; fdim_idx++) {
 		ret_val[fdim_idx] = fdim(in_val1[fdim_idx], in_val2[fdim_idx]);
 		if (!(isnan(sol_val[fdim_idx]) && isnan(ret_val[fdim_idx]))) {
 			TC_ASSERT_LEQ("fdim", fabs(sol_val[fdim_idx] - ret_val[fdim_idx]), FLT_EPSILON);
+		}
+	}
+
+	TC_SUCCESS_RESULT();
+}
+
+/**
+ * @fn                   :tc_libc_math_fdimf
+ * @brief                :Returns the positive  difference max(x-y,0),  between thier arguments
+ * @Scenario             :Returns the positive  difference max(x-y,0),  between their arguments
+ * API's covered         :fdimf
+ * Preconditions         :None
+ * Postconditions        :None
+ * @return               :void
+ */
+static void tc_libc_math_fdimf(void)
+{
+	const float in_val1[10] = { ZERO, -ZERO, VAL1, -VAL1, VAL2, -VAL2, INFINITY, -INFINITY, NAN, VAL1 };
+	const float in_val2[10] = { -INFINITY, INFINITY, -VAL2, VAL2, -VAL1, VAL1, -ZERO, ZERO, NAN, NAN };
+	const float sol_val[10] = { INFINITY, ZERO, 6755399441055744.0, ZERO, 6755399441055744.0, ZERO, INFINITY, ZERO, NAN, NAN };
+	float ret_val[10];
+	int fdimf_idx;
+
+	for (fdimf_idx = 0; fdimf_idx < 10; fdimf_idx++) {
+		ret_val[fdimf_idx] = fdimf(in_val1[fdimf_idx], in_val2[fdimf_idx]);
+		if (!(isnan(sol_val[fdimf_idx]) && isnan(ret_val[fdimf_idx]))) {
+			TC_ASSERT_LEQ("fdimf", fabsf(sol_val[fdimf_idx] - ret_val[fdimf_idx]), FLT_EPSILON);
+		}
+	}
+
+	TC_SUCCESS_RESULT();
+}
+
+/**
+ * @fn                   :tc_libc_math_fdiml
+ * @brief                :Returns the positive  difference max(x-y,0),  between thier arguments
+ * @Scenario             :Returns the positive  difference max(x-y,0),  between their arguments
+ * API's covered         :fdiml
+ * Preconditions         :None
+ * Postconditions        :None
+ * @return               :void
+ */
+static void tc_libc_math_fdiml(void)
+{
+	const long double in_val1[10] = { ZERO, -ZERO, VAL1, -VAL1, VAL2, -VAL2, INFINITY, -INFINITY, NAN, VAL1 };
+	const long double in_val2[10] = { -INFINITY, INFINITY, -VAL2, VAL2, -VAL1, VAL1, -ZERO, ZERO, NAN, NAN };
+	const long double sol_val[10] = { INFINITY, ZERO, 6755399441055744.0, ZERO, 6755399441055744.0, ZERO, INFINITY, ZERO, NAN, NAN };
+	long double ret_val[10];
+	int fdiml_idx;
+
+	for (fdiml_idx = 0; fdiml_idx < 10; fdiml_idx++) {
+		ret_val[fdiml_idx] = fdiml(in_val1[fdiml_idx], in_val2[fdiml_idx]);
+		if (!(isnan(sol_val[fdiml_idx]) && isnan(ret_val[fdiml_idx]))) {
+			TC_ASSERT_LEQ("fdiml", fabsl(sol_val[fdiml_idx] - ret_val[fdiml_idx]), FLT_EPSILON);
 		}
 	}
 
@@ -1095,12 +1383,65 @@ static void tc_libc_math_floor(void)
 {
 	const double in_val[8] = { ZERO, -ZERO, VAL1, -VAL1, VAL2, -VAL2, INFINITY, -INFINITY };
 	const double sol_val[8] = { ZERO, -ZERO, 2251799813685248.0, -2251799813685249.0, 4503599627370496.0, -4503599627370497.0, INFINITY, -INFINITY };
-	double ret_val[8];
+	double ret_val[8] = { ZERO };
 	int floor_idx;
 
 	for (floor_idx = 0; floor_idx < 8; floor_idx++) {
 		ret_val[floor_idx] = floor(in_val[floor_idx]);
-		TC_ASSERT_EQ("floor", sol_val[floor_idx], ret_val[floor_idx]);
+		if (!(isnan(sol_val[floor_idx]) && isnan(ret_val[floor_idx]))) {
+			TC_ASSERT_EQ("floor", sol_val[floor_idx], ret_val[floor_idx]);
+		}
+	}
+
+	TC_SUCCESS_RESULT();
+}
+
+/**
+ * @fn                   :tc_libc_math_floorf
+ * @brief                :Returns the floor value of parameter
+ * @Scenario             :Returns the floor value of parameter
+ * API's covered         :floorf
+ * Preconditions         :None
+ * Postconditions        :None
+ * @return               :void
+ */
+static void tc_libc_math_floorf(void)
+{
+	const float in_val[8] = { ZERO, -ZERO, VAL1, -VAL1, VAL2, -VAL2, INFINITY, -INFINITY };
+	const float sol_val[8] = { ZERO, -ZERO, 2251799813685248.0, -2251799813685249.0, 4503599627370496.0, -4503599627370497.0, INFINITY, -INFINITY };
+	float ret_val[8] = { ZERO };
+	int floorf_idx;
+
+	for (floorf_idx = 0; floorf_idx < 8; floorf_idx++) {
+		ret_val[floorf_idx] = floorf(in_val[floorf_idx]);
+		if (!(isnan(sol_val[floorf_idx]) && isnan(ret_val[floorf_idx]))) {
+			TC_ASSERT_EQ("floorf", sol_val[floorf_idx], ret_val[floorf_idx]);
+		}
+	}
+
+	TC_SUCCESS_RESULT();
+}
+
+/**
+ * @fn                   :tc_libc_math_floorl
+ * @brief                :Returns the floor value of parameter
+ * @Scenario             :Returns the floor value of parameter
+ * API's covered         :floorl
+ * Preconditions         :None
+ * Postconditions        :None
+ * @return               :void
+ */
+static void tc_libc_math_floorl(void)
+{
+	const long double in_val[8] = { ZERO, -ZERO, VAL1, -VAL1, VAL2, -VAL2, INFINITY, -INFINITY };
+	const long double sol_val[8] = { ZERO, -ZERO, 2251799813685248.0, -2251799813685249.0, 4503599627370496.0, -4503599627370497.0, INFINITY, -INFINITY };
+	long double ret_val[8] = { ZERO };
+	int floorl_idx;
+	for (floorl_idx = 0; floorl_idx < 8; floorl_idx++) {
+		ret_val[floorl_idx] = floorl(in_val[floorl_idx]);
+		if (!(isnan(sol_val[floorl_idx]) && isnan(ret_val[floorl_idx]))) {
+			TC_ASSERT_EQ("floorl", sol_val[floorl_idx], ret_val[floorl_idx]);
+		}
 	}
 
 	TC_SUCCESS_RESULT();
@@ -1134,6 +1475,60 @@ static void tc_libc_math_fmax(void)
 }
 
 /**
+ * @fn                   :tc_libc_math_fmaxf
+ * @brief                :Returns the maximum value of argument1 and argument2
+ * @Scenario             :Returns the maximum value of argument1 and argument2
+ * API's covered         :fmaxf
+ * Preconditions         :None
+ * Postconditions        :None
+ * @return               :void
+ */
+static void tc_libc_math_fmaxf(void)
+{
+	const float in_val1[7] = { ZERO, VAL1, -VAL1, INFINITY, -INFINITY, NAN, VAL1 };
+	const float in_val2[7] = { -INFINITY, INFINITY, -VAL1, VAL1, ZERO, NAN, NAN };
+	const float sol_val[7] = { ZERO, INFINITY, -VAL1, INFINITY, ZERO, NAN, VAL1 };
+	float ret_val[7];
+	int fmaxf_idx;
+
+	for (fmaxf_idx = 0; fmaxf_idx < 7; fmaxf_idx++) {
+		ret_val[fmaxf_idx] = fmaxf(in_val1[fmaxf_idx], in_val2[fmaxf_idx]);
+		if (!(isnan(sol_val[fmaxf_idx]) && isnan(ret_val[fmaxf_idx]))) {
+			TC_ASSERT_LEQ("fmaxf", fabsf(sol_val[fmaxf_idx] - ret_val[fmaxf_idx]), FLT_EPSILON);
+		}
+	}
+
+	TC_SUCCESS_RESULT();
+}
+
+/**
+ * @fn                   :tc_libc_math_fmaxl
+ * @brief                :Returns the maximum value of argument1 and argument2
+ * @Scenario             :Returns the maximum value of argument1 and argument2
+ * API's covered         :fmaxl
+ * Preconditions         :None
+ * Postconditions        :None
+ * @return               :void
+ */
+static void tc_libc_math_fmaxl(void)
+{
+	const long double in_val1[7] = { ZERO, VAL1, -VAL1, INFINITY, -INFINITY, NAN, VAL1 };
+	const long double in_val2[7] = { -INFINITY, INFINITY, -VAL1, VAL1, ZERO, NAN, NAN };
+	const long double sol_val[7] = { ZERO, INFINITY, -VAL1, INFINITY, ZERO, NAN, VAL1 };
+	long double ret_val[7];
+	int fmaxl_idx;
+
+	for (fmaxl_idx = 0; fmaxl_idx < 7; fmaxl_idx++) {
+		ret_val[fmaxl_idx] = fmaxl(in_val1[fmaxl_idx], in_val2[fmaxl_idx]);
+		if (!(isnan(sol_val[fmaxl_idx]) && isnan(ret_val[fmaxl_idx]))) {
+			TC_ASSERT_LEQ("fmaxl", fabsl(sol_val[fmaxl_idx] - ret_val[fmaxl_idx]), FLT_EPSILON);
+		}
+	}
+
+	TC_SUCCESS_RESULT();
+}
+
+/**
  * @fn                   :tc_libc_math_fmin
  * @brief                :Returns the minimum value of argument1 and argument2
  * @Scenario             :Returns the minimum value of argument1 and argument2
@@ -1154,6 +1549,60 @@ static void tc_libc_math_fmin(void)
 		ret_val[fmin_idx] = fmin(in_val1[fmin_idx], in_val2[fmin_idx]);
 		if (!(isnan(sol_val[fmin_idx]) && isnan(ret_val[fmin_idx]))) {
 			TC_ASSERT_LEQ("fmin", fabs(sol_val[fmin_idx] - ret_val[fmin_idx]), FLT_EPSILON);
+		}
+	}
+
+	TC_SUCCESS_RESULT();
+}
+
+/**
+ * @fn                   :tc_libc_math_fminf
+ * @brief                :Returns the minimum value of argument1 and argument2
+ * @Scenario             :Returns the minimum value of argument1 and argument2
+ * API's covered         :fminf
+ * Preconditions         :None
+ * Postconditions        :None
+ * @return               :void
+ */
+static void tc_libc_math_fminf(void)
+{
+	const float in_val1[7] = { ZERO, VAL1, -VAL1, INFINITY, -INFINITY, NAN, VAL1 };
+	const float in_val2[7] = { -INFINITY, INFINITY, -VAL1, VAL1, ZERO, NAN, NAN };
+	const float sol_val[7] = { -INFINITY, VAL1, -VAL1, VAL1, -INFINITY, NAN, VAL1 };
+	float ret_val[7];
+	int fminf_idx;
+
+	for (fminf_idx = 0; fminf_idx < 7; fminf_idx++) {
+		ret_val[fminf_idx] = fminf(in_val1[fminf_idx], in_val2[fminf_idx]);
+		if (!(isnan(sol_val[fminf_idx]) && isnan(ret_val[fminf_idx]))) {
+			TC_ASSERT_LEQ("fminf", fabsf(sol_val[fminf_idx] - ret_val[fminf_idx]), FLT_EPSILON);
+		}
+	}
+
+	TC_SUCCESS_RESULT();
+}
+
+/**
+ * @fn                   :tc_libc_math_fminl
+ * @brief                :Returns the minimum value of argument1 and argument2
+ * @Scenario             :Returns the minimum value of argument1 and argument2
+ * API's covered         :fminl
+ * Preconditions         :None
+ * Postconditions        :None
+ * @return               :void
+ */
+static void tc_libc_math_fminl(void)
+{
+	const long double in_val1[7] = { ZERO, VAL1, -VAL1, INFINITY, -INFINITY, NAN, VAL1 };
+	const long double in_val2[7] = { -INFINITY, INFINITY, -VAL1, VAL1, ZERO, NAN, NAN };
+	const long double sol_val[7] = { -INFINITY, VAL1, -VAL1, VAL1, -INFINITY, NAN, VAL1 };
+	long double ret_val[7];
+	int fminl_idx;
+
+	for (fminl_idx = 0; fminl_idx < 7; fminl_idx++) {
+		ret_val[fminl_idx] = fminl(in_val1[fminl_idx], in_val2[fminl_idx]);
+		if (!(isnan(sol_val[fminl_idx]) && isnan(ret_val[fminl_idx]))) {
+			TC_ASSERT_LEQ("fminl", fabsl(sol_val[fminl_idx] - ret_val[fminl_idx]), FLT_EPSILON);
 		}
 	}
 
@@ -1275,6 +1724,64 @@ static void tc_libc_math_hypot(void)
 }
 
 /**
+ * @fn                   :tc_libc_math_hypotf
+ * @brief                :Returns the length of a right-angled  triangle
+ *						  with sides of length parameter1 and parameter2
+ * @Scenario             :Returns the length of a right-angled  triangle
+ *                        with sides of length parameter1 and parameter2
+ * API's covered         :hypotf
+ * Preconditions         :None
+ * Postconditions        :None
+ * @return               :void
+ */
+static void tc_libc_math_hypotf(void)
+{
+	const float in_val1[11] = { ZERO, -ZERO, VAL1, -VAL1, VAL2, -VAL2, INFINITY, -INFINITY, NAN, VAL1, 0x5fe };
+	const float in_val2[11] = { -INFINITY, INFINITY, -VAL2, VAL2, -VAL1, VAL1, -ZERO, ZERO, INFINITY, NAN, 0x1p-700 };
+	const float sol_val[11] = { INFINITY, INFINITY, 5035177455121576.0, 5035177455121576.0, 5035177455121576.0, 5035177455121576.0, INFINITY, INFINITY, INFINITY, NAN, 0x5fe };
+	float ret_val[11];
+	int hypotf_idx;
+
+	for (hypotf_idx = 0; hypotf_idx < 11; hypotf_idx++) {
+		ret_val[hypotf_idx] = hypotf(in_val1[hypotf_idx], in_val2[hypotf_idx]);
+		if (!(isnan(sol_val[hypotf_idx]) && isnan(ret_val[hypotf_idx]))) {
+			TC_ASSERT_LEQ("hypotf", fabsf(sol_val[hypotf_idx] - ret_val[hypotf_idx]), FLT_EPSILON);
+		}
+	}
+
+	TC_SUCCESS_RESULT();
+}
+
+/**
+ * @fn                   :tc_libc_math_hypotl
+ * @brief                :Returns the length of a right-angled  triangle
+ *						  with sides of length parameter1 and parameter2
+ * @Scenario             :Returns the length of a right-angled  triangle
+ *                        with sides of length parameter1 and parameter2
+ * API's covered         :hypotl
+ * Preconditions         :None
+ * Postconditions        :None
+ * @return               :void
+ */
+static void tc_libc_math_hypotl(void)
+{
+	const long double in_val1[11] = { ZERO, -ZERO, VAL1, -VAL1, VAL2, -VAL2, INFINITY, -INFINITY, NAN, VAL1, 0x5fe };
+	const long double in_val2[11] = { -INFINITY, INFINITY, -VAL2, VAL2, -VAL1, VAL1, -ZERO, ZERO, INFINITY, NAN, 0x1p-700 };
+	const long double sol_val[11] = { INFINITY, INFINITY, 5035177455121576.0, 5035177455121576.0, 5035177455121576.0, 5035177455121576.0, INFINITY, INFINITY, INFINITY, NAN, 0x5fe };
+	long double ret_val[11];
+	int hypotl_idx;
+
+	for (hypotl_idx = 0; hypotl_idx < 11; hypotl_idx++) {
+		ret_val[hypotl_idx] = hypotl(in_val1[hypotl_idx], in_val2[hypotl_idx]);
+		if (!(isnan(sol_val[hypotl_idx]) && isnan(ret_val[hypotl_idx]))) {
+			TC_ASSERT_LEQ("hypotl", fabsl(sol_val[hypotl_idx] - ret_val[hypotl_idx]), FLT_EPSILON);
+		}
+	}
+
+	TC_SUCCESS_RESULT();
+}
+
+/**
  * @fn                   :tc_libc_math_j0
  * @brief                :Returns the bessel value of 1st kind of order 0
  * @Scenario             :Returns the bessel value of 1st kind of order 0
@@ -1294,6 +1801,32 @@ static void tc_libc_math_j0(void)
 		ret_val[j0_idx] = j0(in_val[j0_idx]);
 		if (!(isnan(sol_val[j0_idx]) && isnan(ret_val[j0_idx]))) {
 			TC_ASSERT_LEQ("j0", fabs(sol_val[j0_idx] - ret_val[j0_idx]), FLT_EPSILON);
+		}
+	}
+
+	TC_SUCCESS_RESULT();
+}
+
+/**
+ * @fn                   :tc_libc_math_j0f
+ * @brief                :Returns the bessel value of 1st kind of order 0
+ * @Scenario             :Returns the bessel value of 1st kind of order 0
+ * API's covered         :j0f
+ * Preconditions         :None
+ * Postconditions        :None
+ * @return               :void
+ */
+static void tc_libc_math_j0f(void)
+{
+	const float in_val[8] = { ZERO, VAL1, -VAL1, VAL2, -VAL2, INFINITY, -INFINITY, NAN };
+	const float sol_val[8] = { 1.0, ZERO, ZERO, ZERO, ZERO, ZERO, ZERO, NAN };
+	float ret_val[8] = { ZERO };
+	int j0f_idx;
+
+	for (j0f_idx = 0; j0f_idx < 8; j0f_idx++) {
+		ret_val[j0f_idx] = j0f(in_val[j0f_idx]);
+		if (!(isnan(sol_val[j0f_idx]) && isnan(ret_val[j0f_idx]))) {
+			TC_ASSERT_LEQ("j0f", fabsf(sol_val[j0f_idx] - ret_val[j0f_idx]), FLT_EPSILON);
 		}
 	}
 
@@ -1327,6 +1860,32 @@ static void tc_libc_math_j1(void)
 }
 
 /**
+ * @fn                   :tc_libc_math_j1f
+ * @brief                :Returns the bessel value of 1st kind of order 1
+ * @Scenario             :Returns the bessel value of 1st kind of order 1
+ * API's covered         :j1f
+ * Preconditions         :None
+ * Postconditions        :None
+ * @return               :void
+ */
+static void tc_libc_math_j1f(void)
+{
+	const float in_val[8] = { ZERO, VAL1, -VAL1, VAL2, -VAL2, INFINITY, -INFINITY, NAN };
+	const float sol_val[8] = { ZERO, ZERO, -ZERO, ZERO, -ZERO, ZERO, -ZERO, NAN };
+	float ret_val[8] = { ZERO };
+	int j1f_idx;
+
+	for (j1f_idx = 0; j1f_idx < 8; j1f_idx++) {
+		ret_val[j1f_idx] = j1f(in_val[j1f_idx]);
+		if (!(isnan(sol_val[j1f_idx]) && isnan(ret_val[j1f_idx]))) {
+			TC_ASSERT_LEQ("j1f", fabsf(sol_val[j1f_idx] - ret_val[j1f_idx]), FLT_EPSILON);
+		}
+	}
+
+	TC_SUCCESS_RESULT();
+}
+
+/**
  * @fn                   :tc_libc_math_jn
  * @brief                :Returns the bessel value of 1st kind of order n
  * @Scenario             :Returns the bessel value of 1st kind of order n
@@ -1347,6 +1906,33 @@ static void tc_libc_math_jn(void)
 		ret_val[jn_idx] = jn(order, in_val[jn_idx]);
 		if (!(isnan(sol_val[jn_idx]) && isnan(ret_val[jn_idx]))) {
 			TC_ASSERT_LEQ("jn", fabs(sol_val[jn_idx] - ret_val[jn_idx]), FLT_EPSILON);
+		}
+	}
+
+	TC_SUCCESS_RESULT();
+}
+
+/**
+ * @fn                   :tc_libc_math_jnf
+ * @brief                :Returns the bessel value of 1st kind of order n
+ * @Scenario             :Returns the bessel value of 1st kind of order n
+ * API's covered         :jnf
+ * Preconditions         :None
+ * Postconditions        :None
+ * @return               :void
+ */
+static void tc_libc_math_jnf(void)
+{
+	const float in_val[8] = { ZERO, VAL1, -VAL1, VAL2, -VAL2, INFINITY, -INFINITY, NAN };
+	const float sol_val[8] = { ZERO, -ZERO, -ZERO, -ZERO, -ZERO, ZERO, ZERO, NAN };
+	float ret_val[8];
+	int jnf_idx;
+	int order = 2;
+
+	for (jnf_idx = 0; jnf_idx < 8; jnf_idx++) {
+		ret_val[jnf_idx] = jnf(order, in_val[jnf_idx]);
+		if (!(isnan(sol_val[jnf_idx]) && isnan(ret_val[jnf_idx]))) {
+			TC_ASSERT_LEQ("jnf", fabsf(sol_val[jnf_idx] - ret_val[jnf_idx]), FLT_EPSILON);
 		}
 	}
 
@@ -1540,6 +2126,64 @@ static void tc_libc_math_nextafter(void)
 }
 
 /**
+ * @fn                   :tc_libc_math_nextafterf
+ * @brief                :Returns the next representable floating-point
+ *						  value following argument1 in the direction of argument2
+ * @Scenario             :Returns the next representable floating-point
+ *						  value following argument1 in the direction of argument2
+ * API's covered         :nextafterf
+ * Preconditions         :None
+ * Postconditions        :None
+ * @return               :void
+ */
+static void tc_libc_math_nextafterf(void)
+{
+	const float in_val1[7] = { VAL1, VAL1, ZERO, -VAL1, -VAL2 , VAL1, NAN };
+	const float in_val2[7] = { VAL1, VAL2, VAL1, -VAL2, ZERO, NAN, VAL2 };
+	const float sol_val[7] = { 2251799813685248.0, 2251800082120704.0, ZERO, -2251800082120704.0, -4503599358935040.0, NAN, NAN };
+	float ret_val[7];
+	int nextafterf_idx;
+
+	for (nextafterf_idx = 0; nextafterf_idx < 7; nextafterf_idx++) {
+		ret_val[nextafterf_idx] = nextafterf(in_val1[nextafterf_idx], in_val2[nextafterf_idx]);
+		if (!(isnan(sol_val[nextafterf_idx]) && isnan(ret_val[nextafterf_idx]))) {
+			TC_ASSERT_LEQ("nextafterf", fabsf(sol_val[nextafterf_idx] - ret_val[nextafterf_idx]), FLT_EPSILON);
+		}
+	}
+
+	TC_SUCCESS_RESULT();
+}
+
+/**
+ * @fn                   :tc_libc_math_nextafterl
+ * @brief                :Returns the next representable floating-point
+ *						  value following argument1 in the direction of argument2
+ * @Scenario             :Returns the next representable floating-point
+ *						  value following argument1 in the direction of argument2
+ * API's covered         :nextafterl
+ * Preconditions         :None
+ * Postconditions        :None
+ * @return               :void
+ */
+static void tc_libc_math_nextafterl(void)
+{
+	const long double in_val1[7] = { VAL1, VAL1, ZERO, -VAL1, -VAL2 , VAL1, NAN };
+	const long double in_val2[7] = { VAL1, VAL2, VAL1, -VAL2, ZERO, NAN, VAL2 };
+	const long double sol_val[7] = { VAL1, 2251799813685249.0, ZERO, -2251799813685249.0, -4503599627370495.5, NAN, NAN };
+	long double ret_val[7];
+	int nextafterl_idx;
+
+	for (nextafterl_idx = 0; nextafterl_idx < 7; nextafterl_idx++) {
+		ret_val[nextafterl_idx] = nextafterl(in_val1[nextafterl_idx], in_val2[nextafterl_idx]);
+		if (!(isnan(sol_val[nextafterl_idx]) && isnan(ret_val[nextafterl_idx]))) {
+			TC_ASSERT_LEQ("nextafterl", fabsl(sol_val[nextafterl_idx] - ret_val[nextafterl_idx]), FLT_EPSILON);
+		}
+	}
+
+	TC_SUCCESS_RESULT();
+}
+
+/**
  * @fn                   :tc_libc_math_nexttoward
  * @brief                :Returns the next representable floating-point value following argument1 in the direction of argument2
  * @Scenario             :Returns the next representable floating-point value following argument1 in the direction of argument2
@@ -1567,6 +2211,64 @@ static void tc_libc_math_nexttoward(void)
 }
 
 /**
+ * @fn                   :tc_libc_math_nexttowardf
+ * @brief                :Returns the next representable floating-point
+ *						  value following argument1 in the direction of argument2
+ * @Scenario             :Returns the next representable floating-point
+ *						  value following argument1 in the direction of argument2
+ * API's covered         :nexttowardf
+ * Preconditions         :None
+ * Postconditions        :None
+ * @return               :void
+ */
+static void tc_libc_math_nexttowardf(void)
+{
+	const float in_val1[7] = { VAL1, VAL1, ZERO, -VAL1, -VAL2 , VAL1, NAN };
+	const long double in_val2[7] = { VAL1, VAL2, VAL1, -VAL2, ZERO, NAN, VAL2 };
+	const float sol_val[7] = { 2251800082120704.0, 2251800082120704.0, ZERO, -2251800082120704.0, -4503599358935040.0, NAN, NAN };
+	float ret_val[7];
+	int nexttowardf_idx;
+
+	for (nexttowardf_idx = 0; nexttowardf_idx < 7; nexttowardf_idx++) {
+		ret_val[nexttowardf_idx] = nexttowardf(in_val1[nexttowardf_idx], in_val2[nexttowardf_idx]);
+		if (!(isnan(sol_val[nexttowardf_idx]) && isnan(ret_val[nexttowardf_idx]))) {
+			TC_ASSERT_LEQ("nexttowardf", fabsf(sol_val[nexttowardf_idx] - ret_val[nexttowardf_idx]), FLT_EPSILON);
+		}
+	}
+
+	TC_SUCCESS_RESULT();
+}
+
+/**
+ * @fn                   :tc_libc_math_nexttowardl
+ * @brief                :Returns the next representable floating-point
+ *						  value following argument1 in the direction of argument2
+ * @Scenario             :Returns the next representable floating-point
+ *						  value following argument1 in the direction of argument2
+ * API's covered         :nexttowardl
+ * Preconditions         :None
+ * Postconditions        :None
+ * @return               :void
+ */
+static void tc_libc_math_nexttowardl(void)
+{
+	const long double in_val1[7] = { VAL1, VAL1, ZERO, -VAL1, -VAL2 , VAL1, NAN };
+	const long double in_val2[7] = { VAL1, VAL2, VAL1, -VAL2, ZERO, NAN, VAL2 };
+	const long double sol_val[7] = { VAL1, 2251799813685249.0, ZERO, -2251799813685249.0, -4503599627370495.5, NAN, NAN };
+	long double ret_val[7];
+	int nexttowardl_idx;
+
+	for (nexttowardl_idx = 0; nexttowardl_idx < 7; nexttowardl_idx++) {
+		ret_val[nexttowardl_idx] = nexttowardl(in_val1[nexttowardl_idx], in_val2[nexttowardl_idx]);
+		if (!(isnan(sol_val[nexttowardl_idx]) && isnan(ret_val[nexttowardl_idx]))) {
+			TC_ASSERT_LEQ("nexttowardl", fabsl(sol_val[nexttowardl_idx] - ret_val[nexttowardl_idx]), FLT_EPSILON);
+		}
+	}
+
+	TC_SUCCESS_RESULT();
+}
+
+/**
  * @fn                   :tc_libc_math_pow
  * @brief                :Returns the power value of parameter
  * @Scenario             :Returns the power value of parameter
@@ -1575,7 +2277,6 @@ static void tc_libc_math_nexttoward(void)
  * Postconditions        :None
  * @return               :void
  */
-
 static void tc_libc_math_pow(void)
 {
 	const double in_val[13][2] = { { 2, 2 }, { 2, 0.5 }, { 2, -2 }, { 2, -0.5 }, { 1, NAN }, { ZERO, 0.5 }, { ZERO, -2 }, { -ZERO, -1 }, { -ZERO, -2 }, { -2, -1 }, { -2, -2 }, { 0.5, INFINITY }, { 2, INFINITY } };
@@ -1623,6 +2324,60 @@ static void tc_libc_math_remainder(void)
 }
 
 /**
+ * @fn                   :tc_libc_math_remainderf
+ * @brief                :Returns the floating-point remainder of dividing argument1 by argument2
+ * @Scenario             :Returns the floating-point remainder of dividing argument1 by argument2
+ * API's covered         :remainderf
+ * Preconditions         :None
+ * Postconditions        :None
+ * @return               :void
+ */
+static void tc_libc_math_remainderf(void)
+{
+	const float in_val1[10] = { ZERO, -ZERO, VAL1, -VAL1, VAL2, -VAL2, INFINITY, -INFINITY, NAN, INFINITY };
+	const float in_val2[10] = { -INFINITY, INFINITY, -VAL2, VAL2, -VAL1, VAL1, -ZERO, ZERO, NAN, VAL2 };
+	const float sol_val[10] = { ZERO, -ZERO, 2251799813685248.0, -2251799813685248.0, ZERO, -ZERO, -NAN, -NAN, NAN, -NAN };
+	float ret_val[10];
+	int remainderf_idx;
+
+	for (remainderf_idx = 0; remainderf_idx < 10; remainderf_idx++) {
+		ret_val[remainderf_idx] = remainderf(in_val1[remainderf_idx], in_val2[remainderf_idx]);
+		if (!(isnan(sol_val[remainderf_idx]) && isnan(ret_val[remainderf_idx]))) {
+			TC_ASSERT_LEQ("remainderf", fabsf(sol_val[remainderf_idx] - ret_val[remainderf_idx]), FLT_EPSILON);
+		}
+	}
+
+	TC_SUCCESS_RESULT();
+}
+
+/**
+ * @fn                   :tc_libc_math_remainderl
+ * @brief                :Returns the floating-point remainder of dividing argument1 by argument2
+ * @Scenario             :Returns the floating-point remainder of dividing argument1 by argument2
+ * API's covered         :remainderl
+ * Preconditions         :None
+ * Postconditions        :None
+ * @return               :void
+ */
+static void tc_libc_math_remainderl(void)
+{
+	const long double in_val1[10] = { ZERO, -ZERO, VAL1, -VAL1, VAL2, -VAL2, INFINITY, -INFINITY, NAN, INFINITY };
+	const long double in_val2[10] = { -INFINITY, INFINITY, -VAL2, VAL2, -VAL1, VAL1, -ZERO, ZERO, NAN, VAL2 };
+	const long double sol_val[10] = { ZERO, -ZERO, -2251799813685247.5, 2251799813685247.5, -1.0, 1.0, -NAN, -NAN, NAN, -NAN };
+	long double ret_val[10];
+	int remainderl_idx;
+
+	for (remainderl_idx = 0; remainderl_idx < 10; remainderl_idx++) {
+		ret_val[remainderl_idx] = remainderl(in_val1[remainderl_idx], in_val2[remainderl_idx]);
+		if (!(isnan(sol_val[remainderl_idx]) && isnan(ret_val[remainderl_idx]))) {
+			TC_ASSERT_LEQ("remainderl", fabsl(sol_val[remainderl_idx] - ret_val[remainderl_idx]), FLT_EPSILON);
+		}
+	}
+
+	TC_SUCCESS_RESULT();
+}
+
+/**
  * @fn                   :tc_libc_math_remquo
  * @brief                :Returns the floating-point remainder and stores part of quotient in argument3
  * @Scenario             :Returns the floating-point remainder and stores part of quotient in argument3
@@ -1636,7 +2391,7 @@ static void tc_libc_math_remquo(void)
 	const double in_val1[10] = { ZERO, -ZERO, VAL1, -VAL1, VAL2, -VAL2, INFINITY, -INFINITY, NAN, INFINITY };
 	const double in_val2[10] = { -INFINITY, INFINITY, -VAL2, VAL2, -VAL1, VAL1, -ZERO, ZERO, NAN, VAL2 };
 	const double sol_val[10] = { ZERO, -ZERO, -2251799813685247.5, 2251799813685247.5, -1.0, 1.0, -NAN, -NAN, NAN, -NAN };
-	int sol_quo[10] = { 0, 0, -1, -1, -2, -2, 0, 0, 0, 0 };
+	const int sol_quo[10] =  { 0, 0, -1, -1, -2, -2, 0, 0, 0, 0 };
 	double ret_val[10];
 	int ret_quo[10];
 	int remquo_idx;
@@ -1646,6 +2401,222 @@ static void tc_libc_math_remquo(void)
 		if (!(isnan(sol_val[remquo_idx]) && isnan(ret_val[remquo_idx]))) {
 			TC_ASSERT_LEQ("remquo", fabs(sol_val[remquo_idx] - ret_val[remquo_idx]), FLT_EPSILON);
 			TC_ASSERT_EQ("remquo", sol_quo[remquo_idx], ret_quo[remquo_idx]);
+		}
+	}
+
+	TC_SUCCESS_RESULT();
+}
+
+/**
+ * @fn                   :tc_libc_math_remquof
+ * @brief                :Returns the floating-point remainder and stores part of quotient in argument3
+ * @Scenario             :Returns the floating-point remainder and stores part of quotient in argument3
+ * API's covered         :remquof
+ * Preconditions         :None
+ * Postconditions        :None
+ * @return               :void
+ */
+static void tc_libc_math_remquof(void)
+{
+	const float in_val1[10] = { ZERO, -ZERO, VAL1, -VAL1, VAL2, -VAL2, INFINITY, -INFINITY, NAN, INFINITY };
+	const float in_val2[10] = { -INFINITY, INFINITY, -VAL2, VAL2, -VAL1, VAL1, -ZERO, ZERO, NAN, VAL2 };
+	const float sol_val[10] = { ZERO, -ZERO, 2251799813685248.0, -2251799813685248.0, ZERO, -ZERO, -NAN, -NAN, NAN, -NAN };
+	const int sol_quo[10] =  { 0, 0, 0, 0, -2, -2, 0, 0, 0, 0 };
+	float ret_val[10];
+	int ret_quo[10] = { 0 };
+	int remquof_idx;
+
+	for (remquof_idx = 0; remquof_idx < 10; remquof_idx++) {
+		ret_val[remquof_idx] = remquof(in_val1[remquof_idx], in_val2[remquof_idx], &ret_quo[remquof_idx]);
+		if (!(isnan(sol_val[remquof_idx]) && isnan(ret_val[remquof_idx]))) {
+			TC_ASSERT_LEQ("remquof", fabsf(sol_val[remquof_idx] - ret_val[remquof_idx]), FLT_EPSILON);
+			TC_ASSERT_EQ("remquof", sol_quo[remquof_idx], ret_quo[remquof_idx]);
+		}
+	}
+
+	TC_SUCCESS_RESULT();
+}
+
+/**
+ * @fn                   :tc_libc_math_remquol
+ * @brief                :Returns the floating-point remainder and stores part of quotient in argument3
+ * @Scenario             :Returns the floating-point remainder and stores part of quotient in argument3
+ * API's covered         :remquol
+ * Preconditions         :None
+ * Postconditions        :None
+ * @return               :void
+ */
+static void tc_libc_math_remquol(void)
+{
+	const long double in_val1[10] = { ZERO, -ZERO, VAL1, -VAL1, VAL2, -VAL2, INFINITY, -INFINITY, NAN, INFINITY };
+	const long double in_val2[10] = { -INFINITY, INFINITY, -VAL2, VAL2, -VAL1, VAL1, -ZERO, ZERO, NAN, VAL2 };
+	const long double sol_val[10] = { ZERO, -ZERO, -2251799813685247.5, 2251799813685247.5, -1.0, 1.0, -NAN, -NAN, NAN, -NAN };
+	const int sol_quo[10] =  { 0, 0, -1, -1, -2, -2, 0, 0, 0, 0 };
+	long double ret_val[10];
+	int ret_quo[10] = { 0 };
+	int remquol_idx;
+
+	for (remquol_idx = 0; remquol_idx < 10; remquol_idx++) {
+		ret_val[remquol_idx] = remquol(in_val1[remquol_idx], in_val2[remquol_idx], &ret_quo[remquol_idx]);
+		if (!(isnan(sol_val[remquol_idx]) && isnan(ret_val[remquol_idx]))) {
+			TC_ASSERT_LEQ("remquol", fabsl(sol_val[remquol_idx] - ret_val[remquol_idx]), FLT_EPSILON);
+			TC_ASSERT_EQ("remquol", sol_quo[remquol_idx], ret_quo[remquol_idx]);
+		}
+	}
+
+	TC_SUCCESS_RESULT();
+}
+
+/**
+ * @fn                   :tc_libc_math_rint
+ * @brief                :Returns the rounded integer value
+ * @Scenario             :round their argument to an integer value in floating-point format
+ * API's covered         :rint
+ * Preconditions         :None
+ * Postconditions        :None
+ * @return               :void
+ */
+static void tc_libc_math_rint(void)
+{
+	const double in_val[6] = { ZERO, -ZERO, 1073741823.5, -1073741820.5, 2147483645.5, -2147483642.5 };
+	const double sol_val[6] = { ZERO, -ZERO, 1073741824.0, -1073741820.0, 2147483646.0, -2147483642.0 };
+	double ret_val[6];
+	int rint_idx;
+
+	for (rint_idx = 0; rint_idx < 6; rint_idx++) {
+		ret_val[rint_idx] = rint(in_val[rint_idx]);
+		if (!(isnan(sol_val[rint_idx]) && isnan(ret_val[rint_idx]))) {
+			TC_ASSERT_LEQ("rint", fabs(sol_val[rint_idx] - ret_val[rint_idx]), FLT_EPSILON);
+		}
+	}
+
+	TC_SUCCESS_RESULT();
+}
+
+/**
+ * @fn                   :tc_libc_math_rintf
+ * @brief                :Returns the rounded integer value
+ * @Scenario             :round their argument to an integer value in floating-point format
+ * API's covered         :rintf
+ * Preconditions         :None
+ * Postconditions        :None
+ * @return               :void
+ */
+static void tc_libc_math_rintf(void)
+{
+	const float in_val[6] = { ZERO, -ZERO, 1073741823.5, -1073741820.5, 2147483645.5, -2147483642.5 };
+	const float sol_val[6] = { ZERO, -ZERO, 1073741824.0, -1073741820.0, 2147483646.0, -2147483642.0 };
+	float ret_val[6];
+	int rintf_idx;
+
+	for (rintf_idx = 0; rintf_idx < 6; rintf_idx++) {
+		ret_val[rintf_idx] = rintf(in_val[rintf_idx]);
+		if (!(isnan(sol_val[rintf_idx]) && isnan(ret_val[rintf_idx]))) {
+			TC_ASSERT_LEQ("rintf", fabsf(sol_val[rintf_idx] - ret_val[rintf_idx]), FLT_EPSILON);
+		}
+	}
+
+	TC_SUCCESS_RESULT();
+}
+
+/**
+ * @fn                   :tc_libc_math_rintl
+ * @brief                :Returns the rounded integer value
+ * @Scenario             :round their argument to an integer value in floating-point format
+ * API's covered         :rintl
+ * Preconditions         :None
+ * Postconditions        :None
+ * @return               :void
+ */
+static void tc_libc_math_rintl(void)
+{
+	const long double in_val[6] = { ZERO, -ZERO, VAL1, -VAL1, VAL2, -VAL2 };
+	const long double sol_val[6] = { ZERO, -ZERO, 2251799813685248.0, -2251799813685248.0, 4503599627370496.0, -4503599627370496.0 };
+	long double ret_val[6];
+	int rintl_idx;
+
+	for (rintl_idx = 0; rintl_idx < 6; rintl_idx++) {
+		ret_val[rintl_idx] = rintl(in_val[rintl_idx]);
+		if (!(isnan(sol_val[rintl_idx]) && isnan(ret_val[rintl_idx]))) {
+			TC_ASSERT_LEQ("rintl", fabsl(sol_val[rintl_idx] - ret_val[rintl_idx]), FLT_EPSILON);
+		}
+	}
+
+	TC_SUCCESS_RESULT();
+}
+
+/**
+ * @fn                   :tc_libc_math_round
+ * @brief                :Returns the rounded integer value
+ * @Scenario             :round their argument to nearest integer, away from zero
+ * API's covered         :round
+ * Preconditions         :None
+ * Postconditions        :None
+ * @return               :void
+ */
+static void tc_libc_math_round(void)
+{
+	const double in_val[10] = { ZERO, -ZERO, VAL1, -VAL1, VAL2, -VAL2, INFINITY, -INFINITY, NAN, INFINITY };
+	const double sol_val[10] = { ZERO, -ZERO, 2251799813685249.0, -2251799813685249.0, 4503599627370496.0, -4503599627370496.0, INFINITY, -INFINITY, NAN, INFINITY };
+	double ret_val[10];
+	int round_idx;
+
+	for (round_idx = 0; round_idx < 10; round_idx++) {
+		ret_val[round_idx] = round(in_val[round_idx]);
+		if (!(isnan(sol_val[round_idx]) && isnan(ret_val[round_idx]))) {
+			TC_ASSERT_LEQ("round", fabs(sol_val[round_idx] - ret_val[round_idx]), FLT_EPSILON);
+		}
+	}
+
+	TC_SUCCESS_RESULT();
+}
+
+/**
+ * @fn                   :tc_libc_math_roundf
+ * @brief                :Returns the rounded integer value
+ * @Scenario             :round their argument to nearest integer, away from zero
+ * API's covered         :roundf
+ * Preconditions         :None
+ * Postconditions        :None
+ * @return               :void
+ */
+static void tc_libc_math_roundf(void)
+{
+	const float in_val[10] = { ZERO, -ZERO, VAL1, -VAL1, VAL2, -VAL2, INFINITY, -INFINITY, NAN, INFINITY };
+	const float sol_val[10] = { ZERO, -ZERO, 2251799813685248.0, -2251799813685248.0, 4503599627370496.0, -4503599627370496.0, INFINITY, -INFINITY, NAN, INFINITY };
+	float ret_val[10];
+	int roundf_idx;
+
+	for (roundf_idx = 0; roundf_idx < 10; roundf_idx++) {
+		ret_val[roundf_idx] = roundf(in_val[roundf_idx]);
+		if (!(isnan(sol_val[roundf_idx]) && isnan(ret_val[roundf_idx]))) {
+			TC_ASSERT_LEQ("roundf", fabsf(sol_val[roundf_idx] - ret_val[roundf_idx]), FLT_EPSILON);
+		}
+	}
+
+	TC_SUCCESS_RESULT();
+}
+
+/**
+ * @fn                   :tc_libc_math_roundl
+ * @brief                :Returns the rounded integer value
+ * @Scenario             :round their argument to nearest integer, away from zero
+ * API's covered         :roundl
+ * Preconditions         :None
+ * Postconditions        :None
+ * @return               :void
+ */
+static void tc_libc_math_roundl(void)
+{
+	const long double in_val[10] = { ZERO, -ZERO, VAL1, -VAL1, VAL2, -VAL2, INFINITY, -INFINITY, NAN, INFINITY };
+	const long double sol_val[10] = { ZERO, -ZERO, 2251799813685249.0, -2251799813685249.0, 4503599627370496.0, -4503599627370496.0, INFINITY, -INFINITY, NAN, INFINITY };
+	long double ret_val[10];
+	int roundl_idx;
+
+	for (roundl_idx = 0; roundl_idx < 10; roundl_idx++) {
+		ret_val[roundl_idx] = roundl(in_val[roundl_idx]);
+		if (!(isnan(sol_val[roundl_idx]) && isnan(ret_val[roundl_idx]))) {
+			TC_ASSERT_LEQ("roundl", fabsl(sol_val[roundl_idx] - ret_val[roundl_idx]), FLT_EPSILON);
 		}
 	}
 
@@ -1664,10 +2635,10 @@ static void tc_libc_math_remquo(void)
 static void tc_libc_math_scalbn(void)
 {
 	const double in_val[8] = { ZERO, VAL1, -VAL1, VAL2, -VAL2, INFINITY, -INFINITY, NAN };
-	const double sol_val[8][6] = { {ZERO, ZERO, ZERO, ZERO, ZERO, ZERO}, {9007199254740994.0, 17592186044416.003906250, ZERO, INFINITY, INFINITY, ZERO}, { -9007199254740994.0, -17592186044416.003906250, -ZERO, -INFINITY, -INFINITY, -ZERO}, {18014398509481984.0, 35184372088832.0, ZERO, INFINITY, INFINITY, ZERO}, { -18014398509481984.0, -35184372088832.0, -ZERO, -INFINITY, -INFINITY, -ZERO}, {INFINITY, INFINITY, INFINITY, INFINITY, INFINITY, INFINITY}, { -INFINITY, -INFINITY, -INFINITY, -INFINITY, -INFINITY, -INFINITY}, {NAN, NAN, NAN, NAN, NAN, NAN} };
+	const double sol_val[8][6] = { { ZERO, ZERO, ZERO, ZERO, ZERO, ZERO }, { 9007199254740994.0, 17592186044416.003906250, ZERO, INFINITY, INFINITY, ZERO }, { -9007199254740994.0, -17592186044416.003906250, -ZERO, -INFINITY, -INFINITY, -ZERO }, { 18014398509481984.0, 35184372088832.0, ZERO, INFINITY, INFINITY, ZERO }, { -18014398509481984.0, -35184372088832.0, -ZERO, -INFINITY, -INFINITY, -ZERO }, { INFINITY, INFINITY, INFINITY, INFINITY, INFINITY, INFINITY }, { -INFINITY, -INFINITY, -INFINITY, -INFINITY, -INFINITY, -INFINITY }, { NAN, NAN, NAN, NAN, NAN, NAN } };
+	const int exp[6] = { 2, -7, -1024, 1024, 3072, -3072 };
 	double ret_val[8][6];
 	int scalbn_idx;
-	long int exp[6] = { 2, -7, -1024, 1024, 3072, -3072 };
 	int exp_idx;
 
 	for (scalbn_idx = 0; scalbn_idx < 8; scalbn_idx++) {
@@ -1675,6 +2646,66 @@ static void tc_libc_math_scalbn(void)
 			ret_val[scalbn_idx][exp_idx] = scalbn(in_val[scalbn_idx], exp[exp_idx]);
 			if (!(isnan(sol_val[scalbn_idx][exp_idx]) && isnan(ret_val[scalbn_idx][exp_idx]))) {
 				TC_ASSERT_LEQ("scalbn", fabs(sol_val[scalbn_idx][exp_idx] - ret_val[scalbn_idx][exp_idx]), FLT_EPSILON);
+			}
+		}
+	}
+
+	TC_SUCCESS_RESULT();
+}
+
+/**
+ * @fn                   :tc_libc_math_scalbnf
+ * @brief                :Returns the multiply of argument1 by FLT_RADIX (probably 2) to the power of argument2
+ * @Scenario             :Returns the multiply of argument1 by FLT_RADIX (probably 2) to the power of argument2
+ * API's covered         :scalbnf
+ * Preconditions         :None
+ * Postconditions        :None
+ * @return               :void
+ */
+static void tc_libc_math_scalbnf(void)
+{
+	const float in_val[8] = { ZERO, VAL1, -VAL1, VAL2, -VAL2, INFINITY, -INFINITY, NAN };
+	const float sol_val[8][6] = { { ZERO, ZERO, ZERO, ZERO, ZERO, ZERO }, { 9007199254740994.0, 17592186044416.003906250, ZERO, INFINITY, INFINITY, ZERO }, { -9007199254740994.0, -17592186044416.003906250, -ZERO, -INFINITY, -INFINITY, -ZERO }, { 18014398509481984.0, 35184372088832.0, ZERO, INFINITY, INFINITY, ZERO }, { -18014398509481984.0, -35184372088832.0, -ZERO, -INFINITY, -INFINITY, -ZERO }, { INFINITY, INFINITY, INFINITY, INFINITY, INFINITY, INFINITY }, { -INFINITY, -INFINITY, -INFINITY, -INFINITY, -INFINITY, -INFINITY }, { NAN, NAN, NAN, NAN, NAN, NAN } };
+	const int exp[6] = { 2, -7, -1024, 1024, 3072, -3072 };
+	float ret_val[8][6];
+	int scalbnf_idx;
+	int exp_idx;
+
+	for (scalbnf_idx = 0; scalbnf_idx < 8; scalbnf_idx++) {
+		for (exp_idx = 0; exp_idx < 6; exp_idx++) {
+			ret_val[scalbnf_idx][exp_idx] = scalbnf(in_val[scalbnf_idx], exp[exp_idx]);
+			if (!(isnan(sol_val[scalbnf_idx][exp_idx]) && isnan(ret_val[scalbnf_idx][exp_idx]))) {
+				TC_ASSERT_LEQ("scalbnf", fabsf(sol_val[scalbnf_idx][exp_idx] - ret_val[scalbnf_idx][exp_idx]), FLT_EPSILON);
+			}
+		}
+	}
+
+	TC_SUCCESS_RESULT();
+}
+
+/**
+ * @fn                   :tc_libc_math_scalbnl
+ * @brief                :Returns the multiply of argument1 by FLT_RADIX (probably 2) to the power of argument2
+ * @Scenario             :Returns the multiply of argument1 by FLT_RADIX (probably 2) to the power of argument2
+ * API's covered         :scalbnl
+ * Preconditions         :None
+ * Postconditions        :None
+ * @return               :void
+ */
+static void tc_libc_math_scalbnl(void)
+{
+	const long double in_val[8] = { ZERO, VAL1, -VAL1, VAL2, -VAL2, INFINITY, -INFINITY, NAN };
+	const long double sol_val[8][6] = { { ZERO, ZERO, ZERO, ZERO, ZERO, ZERO }, { 9007199254740994.0, 17592186044416.003906250, ZERO, INFINITY, INFINITY, ZERO }, { -9007199254740994.0, -17592186044416.003906250, -ZERO, -INFINITY, -INFINITY, -ZERO }, { 18014398509481984.0, 35184372088832.0, ZERO, INFINITY, INFINITY, ZERO }, { -18014398509481984.0, -35184372088832.0, -ZERO, -INFINITY, -INFINITY, -ZERO }, { INFINITY, INFINITY, INFINITY, INFINITY, INFINITY, INFINITY }, { -INFINITY, -INFINITY, -INFINITY, -INFINITY, -INFINITY, -INFINITY }, { NAN, NAN, NAN, NAN, NAN, NAN } };
+	const int exp[6] = { 2, -7, -1024, 1024, 3072, -3072 };
+	long double ret_val[8][6];
+	int scalbnl_idx;
+	int exp_idx;
+
+	for (scalbnl_idx = 0; scalbnl_idx < 8; scalbnl_idx++) {
+		for (exp_idx = 0; exp_idx < 6; exp_idx++) {
+			ret_val[scalbnl_idx][exp_idx] = scalbnl(in_val[scalbnl_idx], exp[exp_idx]);
+			if (!(isnan(sol_val[scalbnl_idx][exp_idx]) && isnan(ret_val[scalbnl_idx][exp_idx]))) {
+				TC_ASSERT_LEQ("scalbnl", fabsl(sol_val[scalbnl_idx][exp_idx] - ret_val[scalbnl_idx][exp_idx]), FLT_EPSILON);
 			}
 		}
 	}
@@ -1839,6 +2870,84 @@ static void tc_libc_math_sinl(void)
 }
 
 /**
+ * @fn                   :tc_libc_math_sqrt
+ * @brief                :Returns the square root of argument1
+ * @Scenario             :Returns the square root of argument1
+ * API's covered         :sqrt
+ * Preconditions         :None
+ * Postconditions        :None
+ * @return               :void
+ */
+static void tc_libc_math_sqrt(void)
+{
+	const double in_val[8] = { ZERO, VAL1, -VAL1, VAL2, -VAL2, INFINITY, -INFINITY, NAN };
+	const double sol_val[8] = { ZERO, 47453132.8121257797, -NAN, 67108864.0, -NAN, INFINITY, -NAN, NAN };
+	double ret_val[8];
+	int sqrt_idx;
+
+	for (sqrt_idx = 0; sqrt_idx < 8; sqrt_idx++) {
+		ret_val[sqrt_idx] = sqrt(in_val[sqrt_idx]);
+		if (!(isnan(sol_val[sqrt_idx]) && isnan(ret_val[sqrt_idx]))) {
+			TC_ASSERT_LEQ("sqrt", fabs(sol_val[sqrt_idx] - ret_val[sqrt_idx]), FLT_EPSILON);
+		}
+	}
+
+	TC_SUCCESS_RESULT();
+}
+
+/**
+ * @fn                   :tc_libc_math_sqrtf
+ * @brief                :Returns the square root of argument1
+ * @Scenario             :Returns the square root of argument1
+ * API's covered         :sqrtf
+ * Preconditions         :None
+ * Postconditions        :None
+ * @return               :void
+ */
+static void tc_libc_math_sqrtf(void)
+{
+	const float in_val[8] = { ZERO, VAL1, -VAL1, VAL2, -VAL2, INFINITY, -INFINITY, NAN };
+	const float sol_val[8] = { ZERO, 47453132.8121257797, -NAN, 67108864.0, -NAN, INFINITY, -NAN, NAN };
+	float ret_val[8];
+	int sqrtf_idx;
+
+	for (sqrtf_idx = 0; sqrtf_idx < 8; sqrtf_idx++) {
+		ret_val[sqrtf_idx] = sqrtf(in_val[sqrtf_idx]);
+		if (!(isnan(sol_val[sqrtf_idx]) && isnan(ret_val[sqrtf_idx]))) {
+			TC_ASSERT_LEQ("sqrtf", fabsf(sol_val[sqrtf_idx] - ret_val[sqrtf_idx]), FLT_EPSILON);
+		}
+	}
+
+	TC_SUCCESS_RESULT();
+}
+
+/**
+ * @fn                   :tc_libc_math_sqrtl
+ * @brief                :Returns the square root of argument1
+ * @Scenario             :Returns the square root of argument1
+ * API's covered         :sqrtl
+ * Preconditions         :None
+ * Postconditions        :None
+ * @return               :void
+ */
+static void tc_libc_math_sqrtl(void)
+{
+	const long double in_val[8] = { ZERO, VAL1, -VAL1, VAL2, -VAL2, INFINITY, -INFINITY, NAN };
+	const long double sol_val[8] = { ZERO, 47453132.8121257797, -NAN, 67108864.0, -NAN, INFINITY, -NAN, NAN };
+	long double ret_val[8];
+	int sqrtl_idx;
+
+	for (sqrtl_idx = 0; sqrtl_idx < 8; sqrtl_idx++) {
+		ret_val[sqrtl_idx] = sqrtl(in_val[sqrtl_idx]);
+		if (!(isnan(sol_val[sqrtl_idx]) && isnan(ret_val[sqrtl_idx]))) {
+			TC_ASSERT_LEQ("sqrtl", fabsl(sol_val[sqrtl_idx] - ret_val[sqrtl_idx]), FLT_EPSILON);
+		}
+	}
+
+	TC_SUCCESS_RESULT();
+}
+
+/**
  * @fn                   :tc_libc_math_trunc
  * @brief                :Round to truncated integer value
  * @Scenario             :Round to truncated integer value
@@ -1917,6 +3026,32 @@ static void tc_libc_math_y0(void)
 }
 
 /**
+ * @fn                   :tc_libc_math_y0f
+ * @brief                :Returns the bessel value of 2nd kind of order 0
+ * @Scenario             :Returns the bessel value of 2nd kind of order 0
+ * API's covered         :y0f
+ * Preconditions         :None
+ * Postconditions        :None
+ * @return               :void
+ */
+static void tc_libc_math_y0f(void)
+{
+	const float in_val[8] = { ZERO, VAL1, -VAL1, VAL2, -VAL2, INFINITY, -INFINITY, NAN };
+	const float sol_val[8] = { -INFINITY, ZERO, NAN, ZERO, NAN, ZERO, NAN, NAN };
+	float ret_val[8];
+	int y0f_idx;
+
+	for (y0f_idx = 0; y0f_idx < 8; y0f_idx++) {
+		ret_val[y0f_idx] = y0f(in_val[y0f_idx]);
+		if (!(isnan(sol_val[y0f_idx]) && isnan(ret_val[y0f_idx]))) {
+			TC_ASSERT_LEQ("y0f", fabsf(sol_val[y0f_idx] - ret_val[y0f_idx]), FLT_EPSILON);
+		}
+	}
+
+	TC_SUCCESS_RESULT();
+}
+
+/**
  * @fn                   :tc_libc_math_y1
  * @brief                :Returns the bessel value of 2nd kind of order 1
  * @Scenario             :Returns the bessel value of 2nd kind of order 1
@@ -1936,6 +3071,32 @@ static void tc_libc_math_y1(void)
 		ret_val[y1_idx] = y1(in_val[y1_idx]);
 		if (!(isnan(sol_val[y1_idx]) && isnan(ret_val[y1_idx]))) {
 			TC_ASSERT_LEQ("y1", fabs(sol_val[y1_idx] - ret_val[y1_idx]), FLT_EPSILON);
+		}
+	}
+
+	TC_SUCCESS_RESULT();
+}
+
+/**
+ * @fn                   :tc_libc_math_y1f
+ * @brief                :Returns the bessel value of 2nd kind of order 1
+ * @Scenario             :Returns the bessel value of 2nd kind of order 1
+ * API's covered         :y1f
+ * Preconditions         :None
+ * Postconditions        :None
+ * @return               :void
+ */
+static void tc_libc_math_y1f(void)
+{
+	const float in_val[8] = { ZERO, VAL1, -VAL1, VAL2, -VAL2, INFINITY, -INFINITY, NAN };
+	const float sol_val[8] = { -INFINITY, -ZERO, NAN, -ZERO, NAN, ZERO, NAN, NAN };
+	float ret_val[8];
+	int y1f_idx;
+
+	for (y1f_idx = 0; y1f_idx < 8; y1f_idx++) {
+		ret_val[y1f_idx] = y1f(in_val[y1f_idx]);
+		if (!(isnan(sol_val[y1f_idx]) && isnan(ret_val[y1f_idx]))) {
+			TC_ASSERT_LEQ("y1f", fabsf(sol_val[y1f_idx] - ret_val[y1f_idx]), FLT_EPSILON);
 		}
 	}
 
@@ -1963,6 +3124,33 @@ static void tc_libc_math_yn(void)
 		ret_val[yn_idx] = yn(order, in_val[yn_idx]);
 		if (!(isnan(sol_val[yn_idx]) && isnan(ret_val[yn_idx]))) {
 			TC_ASSERT_LEQ("yn", fabs(sol_val[yn_idx] - ret_val[yn_idx]), FLT_EPSILON);
+		}
+	}
+
+	TC_SUCCESS_RESULT();
+}
+
+/**
+ * @fn                   :tc_libc_math_ynf
+ * @brief                :Returns the bessel value of 2nd kind of order n
+ * @Scenario             :Returns the bessel value of 2nd kind of order n
+ * API's covered         :ynf
+ * Preconditions         :None
+ * Postconditions        :None
+ * @return               :void
+ */
+static void tc_libc_math_ynf(void)
+{
+	const float in_val[8] = { ZERO, VAL1, -VAL1, VAL2, -VAL2, INFINITY, -INFINITY, NAN };
+	const float sol_val[8] = { -INFINITY, ZERO, NAN, ZERO, NAN, ZERO, NAN, NAN };
+	float ret_val[8];
+	int ynf_idx;
+	int order = 3;
+
+	for (ynf_idx = 0; ynf_idx < 8; ynf_idx++) {
+		ret_val[ynf_idx] = ynf(order, in_val[ynf_idx]);
+		if (!(isnan(sol_val[ynf_idx]) && isnan(ret_val[ynf_idx]))) {
+			TC_ASSERT_LEQ("ynf", fabsf(sol_val[ynf_idx] - ret_val[ynf_idx]), FLT_EPSILON);
 		}
 	}
 
@@ -1999,6 +3187,8 @@ int libc_math_main(void)
 	tc_libc_math_atan2f();
 	tc_libc_math_atan2l();
 	tc_libc_math_cbrt();
+	tc_libc_math_cbrtf();
+	tc_libc_math_cbrtl();
 	tc_libc_math_ceil();
 	tc_libc_math_ceilf();
 	tc_libc_math_ceill();
@@ -2014,19 +3204,39 @@ int libc_math_main(void)
 	tc_libc_math_erf();
 	tc_libc_math_erff();
 	tc_libc_math_erfl();
+	tc_libc_math_exp();
+	tc_libc_math_expf();
+	tc_libc_math_expl();
 	tc_libc_math_exp2();
+	tc_libc_math_exp2f();
+	tc_libc_math_exp2l();
 	tc_libc_math_fabs();
+	tc_libc_math_fabsf();
+	tc_libc_math_fabsl();
 	tc_libc_math_fdim();
+	tc_libc_math_fdimf();
+	tc_libc_math_fdiml();
 	tc_libc_math_floor();
+	tc_libc_math_floorf();
+	tc_libc_math_floorl();
 	tc_libc_math_fmax();
+	tc_libc_math_fmaxf();
+	tc_libc_math_fmaxl();
 	tc_libc_math_fmin();
+	tc_libc_math_fminf();
+	tc_libc_math_fminl();
 	tc_libc_math_frexp();
 	tc_libc_math_frexpf();
 	tc_libc_math_frexpl();
 	tc_libc_math_hypot();
+	tc_libc_math_hypotf();
+	tc_libc_math_hypotl();
 	tc_libc_math_j0();
+	tc_libc_math_j0f();
 	tc_libc_math_j1();
+	tc_libc_math_j1f();
 	tc_libc_math_jn();
+	tc_libc_math_jnf();
 	tc_libc_math_ldexp();
 	tc_libc_math_ldexpf();
 	tc_libc_math_ldexpl();
@@ -2034,22 +3244,44 @@ int libc_math_main(void)
 	tc_libc_math_log2f();
 	tc_libc_math_log2l();
 	tc_libc_math_nextafter();
+	tc_libc_math_nextafterf();
+	tc_libc_math_nextafterl();
 	tc_libc_math_nexttoward();
+	tc_libc_math_nexttowardf();
+	tc_libc_math_nexttowardl();
 	tc_libc_math_pow();
 	tc_libc_math_remainder();
+	tc_libc_math_remainderf();
+	tc_libc_math_remainderl();
 	tc_libc_math_remquo();
+	tc_libc_math_remquof();
+	tc_libc_math_remquol();
+	tc_libc_math_rint();
+	tc_libc_math_rintf();
+	tc_libc_math_rintl();
+	tc_libc_math_round();
+	tc_libc_math_roundf();
+	tc_libc_math_roundl();
 	tc_libc_math_scalbn();
+	tc_libc_math_scalbnf();
+	tc_libc_math_scalbnl();
 	tc_libc_math_sin();
 	tc_libc_math_sinf();
 	tc_libc_math_sinh();
 	tc_libc_math_sinhf();
 	tc_libc_math_sinhl();
 	tc_libc_math_sinl();
+	tc_libc_math_sqrt();
+	tc_libc_math_sqrtf();
+	tc_libc_math_sqrtl();
 	tc_libc_math_trunc();
 	tc_libc_math_truncf();
 	tc_libc_math_y0();
+	tc_libc_math_y0f();
 	tc_libc_math_y1();
+	tc_libc_math_y1f();
 	tc_libc_math_yn();
+	tc_libc_math_ynf();
 #else
 	printf("tc_libc_math will not be executed. CONFIG_HAVE_DOUBLE is not set.\n");
 #endif

--- a/apps/examples/testcase/le_tc/kernel/tc_libc_math.c
+++ b/apps/examples/testcase/le_tc/kernel/tc_libc_math.c
@@ -36,6 +36,7 @@
 #define ZERO 0.0
 #define VAL1 2251799813685248.5
 #define VAL2 4503599627370496.5
+#define SIZE(var, type) (sizeof(var) / sizeof(type))
 
 /**
  * @fn                  :tc_libc_math_acos
@@ -48,14 +49,14 @@
  */
 static void tc_libc_math_acos(void)
 {
-	const double in_val[5] = { 0.64, -0.4, ZERO, -1, 1 };
-	const double sol_val[5] = { 0.87629806116834, 1.9823131728624, 1.5707963267949, 3.1415926535898, 0 };
-	double ret_val[5];
+	const double in_val[] = { 0.64, -0.4, ZERO, -1, 1 };
+	const double sol_val[] = { 0.87629806116834, 1.9823131728624, 1.5707963267949, 3.1415926535898, 0 };
+	double ret_val[SIZE(in_val, double)];
 	int acos_idx;
 
 	/* Returns the principal value of the arc cosine of x */
 
-	for (acos_idx = 0; acos_idx < 5; acos_idx++) {
+	for (acos_idx = 0; acos_idx < SIZE(in_val, double); acos_idx++) {
 		ret_val[acos_idx] = acos(in_val[acos_idx]);
 		TC_ASSERT_LEQ("acos", fabs(sol_val[acos_idx] - ret_val[acos_idx]), FLT_EPSILON);
 	}
@@ -74,14 +75,14 @@ static void tc_libc_math_acos(void)
  */
 static void tc_libc_math_acosf(void)
 {
-	const float in_val[5] = { 0.64, -0.4, 0, -1, 1 };
-	const float sol_val[5] = { 0.8762981295586, 1.9823131561279, 1.5707963705063, 3.1412079334259, 0.0004112283350 };
-	float ret_val[5];
+	const float in_val[] = { 0.64, -0.4, 0, -1, 1 };
+	const float sol_val[] = { 0.8762981295586, 1.9823131561279, 1.5707963705063, 3.1412079334259, 0.0004112283350 };
+	float ret_val[SIZE(in_val, float)];
 	int acosf_idx;
 
 	/* Returns the nonnegative area hyperbolic cosine of x */
 
-	for (acosf_idx = 0; acosf_idx < 5; acosf_idx++) {
+	for (acosf_idx = 0; acosf_idx < SIZE(in_val, float); acosf_idx++) {
 		ret_val[acosf_idx] = acosf(in_val[acosf_idx]);
 		TC_ASSERT_LEQ("acosf", fabsf(sol_val[acosf_idx] - ret_val[acosf_idx]), FLT_EPSILON);
 	}
@@ -100,14 +101,14 @@ static void tc_libc_math_acosf(void)
  */
 static void tc_libc_math_acosh(void)
 {
-	const double in_val[5] = { 0.64, -0.4, ZERO, -1, 1 };
-	const double sol_val[5] = { 0.87629806116834, 1.9823131728624, 1.5707963267949, 3.1415926535898, 0 };
-	double ret_val[5];
+	const double in_val[] = { 0.64, -0.4, ZERO, -1, 1 };
+	const double sol_val[] = { 0.87629806116834, 1.9823131728624, 1.5707963267949, 3.1415926535898, 0 };
+	double ret_val[SIZE(in_val, double)];
 	int acosh_idx;
 
 	/* Returns the nonnegative area hyperbolic cosine of x */
 
-	for (acosh_idx = 0; acosh_idx < 5; acosh_idx++) {
+	for (acosh_idx = 0; acosh_idx < SIZE(in_val, double); acosh_idx++) {
 		ret_val[acosh_idx] = acosh(in_val[acosh_idx]);
 		TC_ASSERT_LEQ("acosh", fabs(sol_val[acosh_idx] - ret_val[acosh_idx]), FLT_EPSILON);
 	}
@@ -126,14 +127,14 @@ static void tc_libc_math_acosh(void)
  */
 static void tc_libc_math_acoshf(void)
 {
-	const float in_val[3] = { 7, 28, 2.45 };
-	const float sol_val[3] = { 2.6339157938496, 4.0250325202942, 1.5447131178707 };
-	float ret_val[3];
+	const float in_val[] = { 7, 28, 2.45 };
+	const float sol_val[] = { 2.6339157938496, 4.0250325202942, 1.5447131178707 };
+	float ret_val[SIZE(in_val, float)];
 	int acoshf_idx;
 
 	/* Returns the nonnegative area hyperbolic cosine of x */
 
-	for (acoshf_idx = 0; acoshf_idx < 3; acoshf_idx++) {
+	for (acoshf_idx = 0; acoshf_idx < SIZE(in_val, float); acoshf_idx++) {
 		ret_val[acoshf_idx] = acoshf(in_val[acoshf_idx]);
 		TC_ASSERT_LEQ("acoshf", fabsf(sol_val[acoshf_idx] - ret_val[acoshf_idx]), FLT_EPSILON);
 	}
@@ -152,14 +153,14 @@ static void tc_libc_math_acoshf(void)
  */
 static void tc_libc_math_acoshl(void)
 {
-	const long double in_val[3] = { 7, 56, 2.45 };
-	const long double sol_val[3] = { 2.6339157938496, 4.7184191423729, 1.5447131178707 };
-	long double ret_val[3];
+	const long double in_val[] = { 7, 56, 2.45 };
+	const long double sol_val[] = { 2.6339157938496, 4.7184191423729, 1.5447131178707 };
+	long double ret_val[SIZE(in_val, long double)];
 	int acoshl_idx;
 
 	/* Returns the nonnegative area hyperbolic cosine of x */
 
-	for (acoshl_idx = 0; acoshl_idx < 3; acoshl_idx++) {
+	for (acoshl_idx = 0; acoshl_idx < SIZE(in_val, long double); acoshl_idx++) {
 		ret_val[acoshl_idx] = acoshl(in_val[acoshl_idx]);
 		TC_ASSERT_LEQ("acoshl", fabs(sol_val[acoshl_idx] - ret_val[acoshl_idx]), FLT_EPSILON);
 	}
@@ -178,14 +179,14 @@ static void tc_libc_math_acoshl(void)
  */
 static void tc_libc_math_acosl(void)
 {
-	const long double in_val[5] = { 0.64, -0.4, ZERO, -1, 1 };
-	const long double sol_val[5] = { 0.87629806116834, 1.9823131728624, 1.5707963267949, 3.1415926535898, 0 };
-	long double ret_val[5];
+	const long double in_val[] = { 0.64, -0.4, ZERO, -1, 1 };
+	const long double sol_val[] = { 0.87629806116834, 1.9823131728624, 1.5707963267949, 3.1415926535898, 0 };
+	long double ret_val[SIZE(sol_val, long double)];
 	int acosl_idx;
 
 	/* Returns the nonnegative area hyperbolic cosine of x */
 
-	for (acosl_idx = 0; acosl_idx < 5; acosl_idx++) {
+	for (acosl_idx = 0; acosl_idx < SIZE(in_val, long double); acosl_idx++) {
 		ret_val[acosl_idx] = acosl(in_val[acosl_idx]);
 		TC_ASSERT_LEQ("acosl", fabsl(sol_val[acosl_idx] - ret_val[acosl_idx]), FLT_EPSILON);
 	}
@@ -204,14 +205,14 @@ static void tc_libc_math_acosl(void)
  */
 static void tc_libc_math_asin(void)
 {
-	const double in_val[5] = { 0.64, -0.4, ZERO, -1, 1 };
-	const double sol_val[5] = { 0.69449826562656, -0.41151684606749, 0, -1.5707963267949, 1.5707963267949 };
-	double ret_val[5];
+	const double in_val[] = { 0.64, -0.4, ZERO, -1, 1 };
+	const double sol_val[] = { 0.69449826562656, -0.41151684606749, 0, -1.5707963267949, 1.5707963267949 };
+	double ret_val[SIZE(sol_val, double)];
 	int asin_idx;
 
 	/* Returns the principal value of the arc sine of x */
 
-	for (asin_idx = 0; asin_idx < 5; asin_idx++) {
+	for (asin_idx = 0; asin_idx < SIZE(in_val, double); asin_idx++) {
 		ret_val[asin_idx] = asin(in_val[asin_idx]);
 		TC_ASSERT_LEQ("asin", fabs(sol_val[asin_idx] - ret_val[asin_idx]), FLT_EPSILON);
 	}
@@ -230,14 +231,14 @@ static void tc_libc_math_asin(void)
  */
 static void tc_libc_math_asinf(void)
 {
-	const float in_val[5] = { 0.64, -0.4, ZERO, -1, 1 };
-	const float sol_val[5] = { 0.6944981813431, -0.4115168154240, 0.0000000000000, -1.5704115629196, 1.5703850984573 };
-	float ret_val[5];
+	const float in_val[] = { 0.64, -0.4, ZERO, -1, 1 };
+	const float sol_val[] = { 0.6944981813431, -0.4115168154240, 0.0000000000000, -1.5704115629196, 1.5703850984573 };
+	float ret_val[SIZE(sol_val, float)];
 	int asinf_idx;
 
 	/* Returns the principal value of the arc sine of x */
 
-	for (asinf_idx = 0; asinf_idx < 5; asinf_idx++) {
+	for (asinf_idx = 0; asinf_idx < SIZE(in_val, float); asinf_idx++) {
 		ret_val[asinf_idx] = asinf(in_val[asinf_idx]);
 		TC_ASSERT_LEQ("asinf", fabsf(sol_val[asinf_idx] - ret_val[asinf_idx]), FLT_EPSILON);
 	}
@@ -256,14 +257,14 @@ static void tc_libc_math_asinf(void)
  */
 static void tc_libc_math_asinh(void)
 {
-	const double in_val[3] = { 7, 56, 2.45 };
-	const double sol_val[3] = { 2.6441207610586, 4.7185785811518, 1.6284998192842 };
-	double ret_val[3];
+	const double in_val[] = { 7, 56, 2.45 };
+	const double sol_val[] = { 2.6441207610586, 4.7185785811518, 1.6284998192842 };
+	double ret_val[SIZE(sol_val, double)];
 	int asinh_idx;
 
 	/* Returns the area hyperbolic sine of x */
 
-	for (asinh_idx = 0; asinh_idx < 3; asinh_idx++) {
+	for (asinh_idx = 0; asinh_idx < SIZE(in_val, double); asinh_idx++) {
 		ret_val[asinh_idx] = asinh(in_val[asinh_idx]);
 		TC_ASSERT_LEQ("asinh", fabs(sol_val[asinh_idx] - ret_val[asinh_idx]), FLT_EPSILON);
 	}
@@ -282,14 +283,14 @@ static void tc_libc_math_asinh(void)
  */
 static void tc_libc_math_asinhf(void)
 {
-	const float in_val[3] = { 7, 56, 2.45 };
-	const float sol_val[3] = { 2.6441207610586, 4.7185785811518, 1.6284998192842 };
-	float ret_val[3];
+	const float in_val[] = { 7, 56, 2.45 };
+	const float sol_val[] = { 2.6441207610586, 4.7185785811518, 1.6284998192842 };
+	float ret_val[SIZE(sol_val, float)];
 	int asinhf_idx;
 
 	/* Returns the area hyperbolic sine of x */
 
-	for (asinhf_idx = 0; asinhf_idx < 3; asinhf_idx++) {
+	for (asinhf_idx = 0; asinhf_idx < SIZE(in_val, float); asinhf_idx++) {
 		ret_val[asinhf_idx] = asinhf(in_val[asinhf_idx]);
 		TC_ASSERT_LEQ("asinhf", fabsf(sol_val[asinhf_idx] - ret_val[asinhf_idx]), FLT_EPSILON);
 	}
@@ -308,14 +309,14 @@ static void tc_libc_math_asinhf(void)
  */
 static void tc_libc_math_asinhl(void)
 {
-	const long double in_val[3] = { 7, 56, 2.45 };
-	const long double sol_val[3] = { 2.6441207610586, 4.7185785811518, 1.6284998192842 };
-	long double ret_val[3];
+	const long double in_val[] = { 7, 56, 2.45 };
+	const long double sol_val[] = { 2.6441207610586, 4.7185785811518, 1.6284998192842 };
+	long double ret_val[SIZE(sol_val, long double)];
 	int asinhl_idx;
 
 	/* Returns the area hyperbolic sine of x */
 
-	for (asinhl_idx = 0; asinhl_idx < 3; asinhl_idx++) {
+	for (asinhl_idx = 0; asinhl_idx < SIZE(in_val, long double); asinhl_idx++) {
 		ret_val[asinhl_idx] = asinhl(in_val[asinhl_idx]);
 		TC_ASSERT_LEQ("asinhl", fabsl(sol_val[asinhl_idx] - ret_val[asinhl_idx]), FLT_EPSILON);
 	}
@@ -334,14 +335,14 @@ static void tc_libc_math_asinhl(void)
  */
 static void tc_libc_math_asinl(void)
 {
-	const long double in_val[5] = { 0.64, -0.4, ZERO, -1, 1 };
-	const long double sol_val[5] = { 0.69449826562656, -0.41151684606749, 0, -1.5707963267949, 1.5707963267949 };
-	long double ret_val[5];
+	const long double in_val[] = { 0.64, -0.4, ZERO, -1, 1 };
+	const long double sol_val[] = { 0.69449826562656, -0.41151684606749, 0, -1.5707963267949, 1.5707963267949 };
+	long double ret_val[SIZE(sol_val, long double)];
 	int asinl_idx;
 
 	/* Returns the principal value of the arc sine of x */
 
-	for (asinl_idx = 0; asinl_idx < 5; asinl_idx++) {
+	for (asinl_idx = 0; asinl_idx < SIZE(in_val, long double); asinl_idx++) {
 		ret_val[asinl_idx] = asinl(in_val[asinl_idx]);
 		TC_ASSERT_LEQ("asinl", fabsl(sol_val[asinl_idx] - ret_val[asinl_idx]), FLT_EPSILON);
 	}
@@ -360,14 +361,14 @@ static void tc_libc_math_asinl(void)
  */
 static void tc_libc_math_atan(void)
 {
-	const double in_val[6] = { 0.50, -0.50, 5, -5, 100, -100 };
-	const double sol_val[6] = { 0.46364760900081, -0.46364760900081, 1.373400766945, -1.373400766945, 1.5607966601082, -1.5607966601082 };
-	double ret_val[6];
+	const double in_val[] = { 0.50, -0.50, 5, -5, 100, -100 };
+	const double sol_val[] = { 0.46364760900081, -0.46364760900081, 1.373400766945, -1.373400766945, 1.5607966601082, -1.5607966601082 };
+	double ret_val[SIZE(sol_val, double)];
 	int atan_idx;
 
 	/* Returns the principal value of the arc tangent of x */
 
-	for (atan_idx = 0; atan_idx < 6; atan_idx++) {
+	for (atan_idx = 0; atan_idx < SIZE(in_val, double); atan_idx++) {
 		ret_val[atan_idx] = atan(in_val[atan_idx]);
 		TC_ASSERT_LEQ("atan", fabs(sol_val[atan_idx] - ret_val[atan_idx]), FLT_EPSILON);
 	}
@@ -386,14 +387,14 @@ static void tc_libc_math_atan(void)
  */
 static void tc_libc_math_atanf(void)
 {
-	const float in_val[6] = { 0.50, -0.50, 5, -5, 100, -100 };
-	const float sol_val[6] = { 0.4636476039886, -0.4636476039886, 1.3734011650085, -1.3734012842178, 1.5608066320419, -1.5607856512070 };
-	float ret_val[6];
+	const float in_val[] = { 0.50, -0.50, 5, -5, 100, -100 };
+	const float sol_val[] = { 0.4636476039886, -0.4636476039886, 1.3734011650085, -1.3734012842178, 1.5608066320419, -1.5607856512070 };
+	float ret_val[SIZE(sol_val, float)];
 	int atanf_idx;
 
 	/* Returns the principal value of the arc tangent of x */
 
-	for (atanf_idx = 0; atanf_idx < 6; atanf_idx++) {
+	for (atanf_idx = 0; atanf_idx < SIZE(in_val, float); atanf_idx++) {
 		ret_val[atanf_idx] = atanf(in_val[atanf_idx]);
 		TC_ASSERT_LEQ("atanf", fabsf(sol_val[atanf_idx] - ret_val[atanf_idx]), FLT_EPSILON);
 	}
@@ -412,14 +413,14 @@ static void tc_libc_math_atanf(void)
  */
 static void tc_libc_math_atanh(void)
 {
-	const double in_val[5] = { M_PI_4, 0.50, -0.50, 1, -1 };
-	const double sol_val[5] = { 1.0593061708232, 0.54930614433405, -0.54930614433405, INFINITY, -INFINITY };
-	double ret_val[5];
+	const double in_val[] = { M_PI_4, 0.50, -0.50, 1, -1 };
+	const double sol_val[] = { 1.0593061708232, 0.54930614433405, -0.54930614433405, INFINITY, -INFINITY };
+	double ret_val[SIZE(sol_val, double)];
 	int atanh_idx;
 
 	/* Returns the area hyperbolic tangent of x */
 
-	for (atanh_idx = 0; atanh_idx < 5; atanh_idx++) {
+	for (atanh_idx = 0; atanh_idx < SIZE(in_val, double); atanh_idx++) {
 		ret_val[atanh_idx] = atanh(in_val[atanh_idx]);
 		TC_ASSERT_LEQ("atanh", fabs(sol_val[atanh_idx] - ret_val[atanh_idx]), FLT_EPSILON);
 	}
@@ -438,14 +439,14 @@ static void tc_libc_math_atanh(void)
  */
 static void tc_libc_math_atanhf(void)
 {
-	const float in_val[5] = { M_PI_4, 0.50, -0.50, 1, -1 };
-	const float sol_val[5] = { 1.0593061708232, 0.54930614433405, -0.54930614433405, INFINITY, -INFINITY };
-	float ret_val[5];
+	const float in_val[] = { M_PI_4, 0.50, -0.50, 1, -1 };
+	const float sol_val[] = { 1.0593061708232, 0.54930614433405, -0.54930614433405, INFINITY, -INFINITY };
+	float ret_val[SIZE(sol_val, float)];
 	int atanhf_idx;
 
 	/* Returns the area hyperbolic tangent of x */
 
-	for (atanhf_idx = 0; atanhf_idx < 5; atanhf_idx++) {
+	for (atanhf_idx = 0; atanhf_idx < SIZE(in_val, float); atanhf_idx++) {
 		ret_val[atanhf_idx] = atanhf(in_val[atanhf_idx]);
 		TC_ASSERT_LEQ("atanhf", fabsf(sol_val[atanhf_idx] - ret_val[atanhf_idx]), FLT_EPSILON);
 	}
@@ -464,14 +465,14 @@ static void tc_libc_math_atanhf(void)
  */
 static void tc_libc_math_atanhl(void)
 {
-	const long double in_val[5] = { M_PI_4, 0.50, -0.50, 1, -1 };
-	const long double sol_val[5] = { 1.0593061708232, 0.54930614433405, -0.54930614433405, INFINITY, INFINITY };
-	long double ret_val[5];
+	const long double in_val[] = { M_PI_4, 0.50, -0.50, 1, -1 };
+	const long double sol_val[] = { 1.0593061708232, 0.54930614433405, -0.54930614433405, INFINITY, INFINITY };
+	long double ret_val[SIZE(sol_val, long double)];
 	int atanhl_idx;
 
 	/* Returns the area hyperbolic tangent of x */
 
-	for (atanhl_idx = 0; atanhl_idx < 5; atanhl_idx++) {
+	for (atanhl_idx = 0; atanhl_idx < SIZE(in_val, long double); atanhl_idx++) {
 		ret_val[atanhl_idx] = atanhl(in_val[atanhl_idx]);
 		TC_ASSERT_LEQ("atanhl", fabsl(sol_val[atanhl_idx] - ret_val[atanhl_idx]), FLT_EPSILON);
 	}
@@ -490,14 +491,14 @@ static void tc_libc_math_atanhl(void)
  */
 static void tc_libc_math_atanl(void)
 {
-	const long double in_val[6] = { 0.50, -0.50, 5, -5, 100, -100 };
-	const long double sol_val[6] = { 0.46364760900081, -0.46364760900081, 1.373400766945, -1.373400766945, 1.5607966601082, -1.5607966601082 };
-	long double ret_val[6];
+	const long double in_val[] = { 0.50, -0.50, 5, -5, 100, -100 };
+	const long double sol_val[] = { 0.46364760900081, -0.46364760900081, 1.373400766945, -1.373400766945, 1.5607966601082, -1.5607966601082 };
+	long double ret_val[SIZE(sol_val, long double)];
 	int atanl_idx;
 
 	/* Returns the principal value of the arc tangent of x */
 
-	for (atanl_idx = 0; atanl_idx < 6; atanl_idx++) {
+	for (atanl_idx = 0; atanl_idx < SIZE(in_val, long double); atanl_idx++) {
 		ret_val[atanl_idx] = atanl(in_val[atanl_idx]);
 		TC_ASSERT_LEQ("atanl", fabsl(sol_val[atanl_idx] - ret_val[atanl_idx]), FLT_EPSILON);
 	}
@@ -516,15 +517,15 @@ static void tc_libc_math_atanl(void)
  */
 static void tc_libc_math_atan2(void)
 {
-	const double in_val1[6] = { 0.50, -0.50, 5, 10, -5, -10 };
-	const double in_val2[6] = { 0.50, -0.50, 5, 20, -5, 10 };
-	const double sol_val[6] = { 0.78539816339745, -2.3561944901923, 0.78539816339745, 0.46364760900081, -2.3561944901923, -0.78539816339745 };
-	double ret_val[6];
+	const double in_val1[] = { 0.50, -0.50, 5, 10, -5, -10 };
+	const double in_val2[] = { 0.50, -0.50, 5, 20, -5, 10 };
+	const double sol_val[] = { 0.78539816339745, -2.3561944901923, 0.78539816339745, 0.46364760900081, -2.3561944901923, -0.78539816339745 };
+	double ret_val[SIZE(sol_val, double)];
 	int atan2_idx;
 
 	/* Returns the principal value of the arc tangent of y/x */
 
-	for (atan2_idx = 0; atan2_idx < 6; atan2_idx++) {
+	for (atan2_idx = 0; atan2_idx < SIZE(sol_val, double); atan2_idx++) {
 		ret_val[atan2_idx] = atan2(in_val1[atan2_idx], in_val2[atan2_idx]);
 		TC_ASSERT_LEQ("atan2", fabs(sol_val[atan2_idx] - ret_val[atan2_idx]), FLT_EPSILON);
 	}
@@ -543,15 +544,15 @@ static void tc_libc_math_atan2(void)
  */
 static void tc_libc_math_atan2f(void)
 {
-	const float in_val1[6] = { 0.50, -0.50, 5, 10, -5, -10 };
-	const float in_val2[6] = { 0.50, -0.50, 5, 20, -5, 10 };
-	const float sol_val[6] = { 0.78539816339745, -2.3561944901923, 0.78539816339745, 0.46364760900081, -2.3561944901923, -0.78539816339745 };
-	float ret_val[6];
+	const float in_val1[] = { 0.50, -0.50, 5, 10, -5, -10 };
+	const float in_val2[] = { 0.50, -0.50, 5, 20, -5, 10 };
+	const float sol_val[] = { 0.78539816339745, -2.3561944901923, 0.78539816339745, 0.46364760900081, -2.3561944901923, -0.78539816339745 };
+	float ret_val[SIZE(sol_val, float)];
 	int atan2f_idx;
 
 	/* Returns the principal value of the arc tangent of y/x */
 
-	for (atan2f_idx = 0; atan2f_idx < 6; atan2f_idx++) {
+	for (atan2f_idx = 0; atan2f_idx < SIZE(sol_val, float); atan2f_idx++) {
 		ret_val[atan2f_idx] = atan2f(in_val1[atan2f_idx], in_val2[atan2f_idx]);
 		TC_ASSERT_LEQ("atan2f", fabsf(sol_val[atan2f_idx] - ret_val[atan2f_idx]), FLT_EPSILON);
 	}
@@ -570,15 +571,15 @@ static void tc_libc_math_atan2f(void)
  */
 static void tc_libc_math_atan2l(void)
 {
-	const long double in_val1[6] = { 0.50, -0.50, 5, 10, -5, -10 };
-	const long double in_val2[6] = { 0.50, -0.50, 5, 20, -5, 10 };
-	const long double sol_val[6] = { 0.78539816339745, -2.3561944901923, 0.78539816339745, 0.46364760900081, -2.3561944901923, -0.78539816339745 };
-	long double ret_val[6];
+	const long double in_val1[] = { 0.50, -0.50, 5, 10, -5, -10 };
+	const long double in_val2[] = { 0.50, -0.50, 5, 20, -5, 10 };
+	const long double sol_val[] = { 0.78539816339745, -2.3561944901923, 0.78539816339745, 0.46364760900081, -2.3561944901923, -0.78539816339745 };
+	long double ret_val[SIZE(sol_val, long double)];
 	int atan2l_idx;
 
 	/* Returns the principal value of the arc tangent of y/x */
 
-	for (atan2l_idx = 0; atan2l_idx < 6; atan2l_idx++) {
+	for (atan2l_idx = 0; atan2l_idx < SIZE(sol_val, long double); atan2l_idx++) {
 		ret_val[atan2l_idx] = atan2l(in_val1[atan2l_idx], in_val2[atan2l_idx]);
 		TC_ASSERT_LEQ("atan2l", fabsl(sol_val[atan2l_idx] - ret_val[atan2l_idx]), FLT_EPSILON);
 	}
@@ -597,12 +598,12 @@ static void tc_libc_math_atan2l(void)
  */
 static void tc_libc_math_cbrt(void)
 {
-	const double in_val[6] = { ZERO, VAL1, -VAL1, INFINITY, -INFINITY, NAN };
-	const double sol_val[6] = { ZERO, 131072.0, -131072.0, INFINITY, -INFINITY, NAN };
-	double ret_val[6];
+	const double in_val[] = { ZERO, VAL1, -VAL1, INFINITY, -INFINITY, NAN };
+	const double sol_val[] = { ZERO, 131072.0, -131072.0, INFINITY, -INFINITY, NAN };
+	double ret_val[SIZE(sol_val, double)];
 	int cbrt_idx;
 
-	for (cbrt_idx = 0; cbrt_idx < 6; cbrt_idx++) {
+	for (cbrt_idx = 0; cbrt_idx < SIZE(in_val, double); cbrt_idx++) {
 		ret_val[cbrt_idx] = cbrt(in_val[cbrt_idx]);
 		if (!(isnan(sol_val[cbrt_idx]) && isnan(ret_val[cbrt_idx]))) {
 			TC_ASSERT_LEQ("cbrt", fabs(sol_val[cbrt_idx] - ret_val[cbrt_idx]), FLT_EPSILON);
@@ -623,12 +624,12 @@ static void tc_libc_math_cbrt(void)
  */
 static void tc_libc_math_cbrtf(void)
 {
-	const float in_val[6] = { ZERO, VAL1, -VAL1, INFINITY, -INFINITY, NAN };
-	const float sol_val[6] = { ZERO, 131072.0, -131072.0, INFINITY, -INFINITY, NAN };
-	float ret_val[6];
+	const float in_val[] = { ZERO, VAL1, -VAL1, INFINITY, -INFINITY, NAN };
+	const float sol_val[] = { ZERO, 131072.0, -131072.0, INFINITY, -INFINITY, NAN };
+	float ret_val[SIZE(sol_val, float)];
 	int cbrtf_idx;
 
-	for (cbrtf_idx = 0; cbrtf_idx < 6; cbrtf_idx++) {
+	for (cbrtf_idx = 0; cbrtf_idx < SIZE(in_val, float); cbrtf_idx++) {
 		ret_val[cbrtf_idx] = cbrtf(in_val[cbrtf_idx]);
 		if (!(isnan(sol_val[cbrtf_idx]) && isnan(ret_val[cbrtf_idx]))) {
 			TC_ASSERT_LEQ("cbrtf", fabsf((float)sol_val[cbrtf_idx] - ret_val[cbrtf_idx]), FLT_EPSILON);
@@ -649,12 +650,12 @@ static void tc_libc_math_cbrtf(void)
  */
 static void tc_libc_math_cbrtl(void)
 {
-	const long double in_val[6] = { ZERO, VAL1, -VAL1, INFINITY, -INFINITY, NAN };
-	const long double sol_val[6] = { ZERO, 131072.0, -131072.0, INFINITY, -INFINITY, NAN };
-	long double ret_val[6];
+	const long double in_val[] = { ZERO, VAL1, -VAL1, INFINITY, -INFINITY, NAN };
+	const long double sol_val[] = { ZERO, 131072.0, -131072.0, INFINITY, -INFINITY, NAN };
+	long double ret_val[SIZE(sol_val, long double)];
 	int cbrtl_idx;
 
-	for (cbrtl_idx = 0; cbrtl_idx < 6; cbrtl_idx++) {
+	for (cbrtl_idx = 0; cbrtl_idx < SIZE(in_val, long double); cbrtl_idx++) {
 		ret_val[cbrtl_idx] = cbrtl(in_val[cbrtl_idx]);
 		if (!(isnan(sol_val[cbrtl_idx]) && isnan(ret_val[cbrtl_idx]))) {
 			TC_ASSERT_LEQ("cbrtl", fabsl(sol_val[cbrtl_idx] - ret_val[cbrtl_idx]), FLT_EPSILON);
@@ -675,14 +676,14 @@ static void tc_libc_math_cbrtl(void)
  */
 static void tc_libc_math_ceil(void)
 {
-	const double in_val[5] = { 2.3, 0.3, 1.0, -2.3, -8.0 };
-	const double sol_val[5] = { 3.0, 1.0, 1.0, -2.0, -8.0 };
-	double ret_val[5];
+	const double in_val[] = { 2.3, 0.3, 1.0, -2.3, -8.0 };
+	const double sol_val[] = { 3.0, 1.0, 1.0, -2.0, -8.0 };
+	double ret_val[SIZE(sol_val, double)];
 	int ceil_idx;
 
 	/* Rounds x upward, returning the smallest integral value that is not less than x */
 
-	for (ceil_idx = 0; ceil_idx < 5; ceil_idx++) {
+	for (ceil_idx = 0; ceil_idx < SIZE(in_val, long double); ceil_idx++) {
 		ret_val[ceil_idx] = ceil(in_val[ceil_idx]);
 		TC_ASSERT_LEQ("ceil", fabs(sol_val[ceil_idx] - ret_val[ceil_idx]), FLT_EPSILON);
 	}
@@ -701,14 +702,14 @@ static void tc_libc_math_ceil(void)
  */
 static void tc_libc_math_ceilf(void)
 {
-	const float in_val[5] = { 2.3, 3.8, 1.0, -2.3, -8.0 };
-	const float sol_val[5] = { 3.0, 4.0, 1.0, -2.0, -8.0 };
-	float ret_val[5];
+	const float in_val[] = { 2.3, 3.8, 1.0, -2.3, -8.0 };
+	const float sol_val[] = { 3.0, 4.0, 1.0, -2.0, -8.0 };
+	float ret_val[SIZE(sol_val, float)];
 	int ceilf_idx;
 
 	/* Rounds x upward, returning the smallest integral value that is not less than x */
 
-	for (ceilf_idx = 0; ceilf_idx < 5; ceilf_idx++) {
+	for (ceilf_idx = 0; ceilf_idx < SIZE(in_val, float); ceilf_idx++) {
 		ret_val[ceilf_idx] = ceilf(in_val[ceilf_idx]);
 		TC_ASSERT_LEQ("ceilf", fabsf(sol_val[ceilf_idx] - ret_val[ceilf_idx]), FLT_EPSILON);
 	}
@@ -727,14 +728,14 @@ static void tc_libc_math_ceilf(void)
  */
 static void tc_libc_math_ceill(void)
 {
-	const long double in_val[5] = { 2.3, 3.8, 1.0, -2.3, -8.0 };
-	const long double sol_val[5] = { 3.0, 4.0, 1.0, -2.0, -8.0 };
-	long double ret_val[5];
+	const long double in_val[] = { 2.3, 3.8, 1.0, -2.3, -8.0 };
+	const long double sol_val[] = { 3.0, 4.0, 1.0, -2.0, -8.0 };
+	long double ret_val[SIZE(sol_val, long double)];
 	int ceill_idx;
 
 	/* Rounds x upward, returning the smallest integral value that is not less than x */
 
-	for (ceill_idx = 0; ceill_idx < 5; ceill_idx++) {
+	for (ceill_idx = 0; ceill_idx < SIZE(in_val, long double); ceill_idx++) {
 		ret_val[ceill_idx] = ceill(in_val[ceill_idx]);
 		TC_ASSERT_LEQ("ceill", fabsl(sol_val[ceill_idx] - ret_val[ceill_idx]), FLT_EPSILON);
 	}
@@ -753,15 +754,15 @@ static void tc_libc_math_ceill(void)
  */
 static void tc_libc_math_copysign(void)
 {
-	const double in_val1[3] = { 10.0, -10.0, -10.0 };
-	const double in_val2[3] = { -1.0, -1.0, 1.0 };
-	const double sol_val[3] = { -10.0, -10.0, 10.0 };
-	double ret_val[3];
+	const double in_val1[] = { 10.0, -10.0, -10.0 };
+	const double in_val2[] = { -1.0, -1.0, 1.0 };
+	const double sol_val[] = { -10.0, -10.0, 10.0 };
+	double ret_val[SIZE(sol_val, double)];
 	int copysign_idx;
 
 	/* Returns a value with the magnitude of x and the sign of y */
 
-	for (copysign_idx = 0; copysign_idx < 3; copysign_idx++) {
+	for (copysign_idx = 0; copysign_idx < SIZE(sol_val, double); copysign_idx++) {
 		ret_val[copysign_idx] = copysign(in_val1[copysign_idx], in_val2[copysign_idx]);
 		TC_ASSERT_LEQ("copysign", fabs(sol_val[copysign_idx] - ret_val[copysign_idx]), FLT_EPSILON);
 	}
@@ -780,15 +781,15 @@ static void tc_libc_math_copysign(void)
  */
 static void tc_libc_math_copysignf(void)
 {
-	const float in_val1[3] = { 10.0, -10.0, -10.0 };
-	const float in_val2[3] = { -1.0, -1.0, 1.0 };
-	const float sol_val[3] = { -10.0, -10.0, 10.0 };
-	float ret_val[3];
+	const float in_val1[] = { 10.0, -10.0, -10.0 };
+	const float in_val2[] = { -1.0, -1.0, 1.0 };
+	const float sol_val[] = { -10.0, -10.0, 10.0 };
+	float ret_val[SIZE(sol_val, float)];
 	int copysignf_idx;
 
 	/* Returns a value with the magnitude of x and the sign of y */
 
-	for (copysignf_idx = 0; copysignf_idx < 3; copysignf_idx++) {
+	for (copysignf_idx = 0; copysignf_idx < SIZE(sol_val, float); copysignf_idx++) {
 		ret_val[copysignf_idx] = copysignf(in_val1[copysignf_idx], in_val2[copysignf_idx]);
 		TC_ASSERT_LEQ("copysignf", fabsf(sol_val[copysignf_idx] - ret_val[copysignf_idx]), FLT_EPSILON);
 	}
@@ -807,15 +808,15 @@ static void tc_libc_math_copysignf(void)
  */
 static void tc_libc_math_copysignl(void)
 {
-	const long double in_val1[3] = { 10.0, -10.0, -10.0 };
-	const long double in_val2[3] = { -1.0, -1.0, 1.0 };
-	const long double sol_val[3] = { -10.0, -10.0, 10.0 };
-	long double ret_val[3];
+	const long double in_val1[] = { 10.0, -10.0, -10.0 };
+	const long double in_val2[] = { -1.0, -1.0, 1.0 };
+	const long double sol_val[] = { -10.0, -10.0, 10.0 };
+	long double ret_val[SIZE(sol_val, long double)];
 	int copysignl_idx;
 
 	/* Returns a value with the magnitude of x and the sign of y */
 
-	for (copysignl_idx = 0; copysignl_idx < 3; copysignl_idx++) {
+	for (copysignl_idx = 0; copysignl_idx < SIZE(sol_val, long double); copysignl_idx++) {
 		ret_val[copysignl_idx] = copysignl(in_val1[copysignl_idx], in_val2[copysignl_idx]);
 		TC_ASSERT_LEQ("copysignl", fabsl(sol_val[copysignl_idx] - ret_val[copysignl_idx]), FLT_EPSILON);
 	}
@@ -834,14 +835,14 @@ static void tc_libc_math_copysignl(void)
  */
 static void tc_libc_math_cos(void)
 {
-	const double in_val[5] = { 3, -3, 0, M_PI, (2 * M_PI) };
-	const double sol_val[5] = { -0.98999249660045, -0.98999249660045, 1, -1, 1 };
-	double ret_val[5];
+	const double in_val[] = { 3, -3, 0, M_PI, (2 * M_PI) };
+	const double sol_val[] = { -0.98999249660045, -0.98999249660045, 1, -1, 1 };
+	double ret_val[SIZE(sol_val, double)];
 	int cos_idx;
 
 	/* Returns the cosine of an angle of x radians */
 
-	for (cos_idx = 0; cos_idx < 5; cos_idx++) {
+	for (cos_idx = 0; cos_idx < SIZE(in_val, double); cos_idx++) {
 		ret_val[cos_idx] = cos(in_val[cos_idx]);
 		TC_ASSERT_LEQ("cos", fabs(sol_val[cos_idx] - ret_val[cos_idx]), FLT_EPSILON);
 	}
@@ -860,14 +861,14 @@ static void tc_libc_math_cos(void)
  */
 static void tc_libc_math_cosf(void)
 {
-	const float in_val[5] = { 3, -3, 0, M_PI, (2 * M_PI) };
-	const float sol_val[5] = { -0.98999249660045, -0.98999249660045, 1, -1, 1 };
-	float ret_val[5];
+	const float in_val[] = { 3, -3, 0, M_PI, (2 * M_PI) };
+	const float sol_val[] = { -0.98999249660045, -0.98999249660045, 1, -1, 1 };
+	float ret_val[SIZE(sol_val, float)];
 	int cosf_idx;
 
 	/* Returns the cosine of an angle of x radians */
 
-	for (cosf_idx = 0; cosf_idx < 5; cosf_idx++) {
+	for (cosf_idx = 0; cosf_idx < SIZE(in_val, float); cosf_idx++) {
 		ret_val[cosf_idx] = cosf(in_val[cosf_idx]);
 		TC_ASSERT_LEQ("cosf", fabsf(sol_val[cosf_idx] - ret_val[cosf_idx]), FLT_EPSILON);
 	}
@@ -886,14 +887,14 @@ static void tc_libc_math_cosf(void)
  */
 static void tc_libc_math_cosh(void)
 {
-	const double in_val[5] = { 3, -3, 0, M_PI, (2 * M_PI) };
-	const double sol_val[5] = { 10.067661995778, 10.067661995778, 1, 11.591953275522, 267.74676148375 };
-	double ret_val[5];
+	const double in_val[] = { 3, -3, 0, M_PI, (2 * M_PI) };
+	const double sol_val[] = { 10.067661995778, 10.067661995778, 1, 11.591953275522, 267.74676148375 };
+	double ret_val[SIZE(sol_val, double)];
 	int cosh_idx;
 
 	/* Returns the hyperbolic cosine of x */
 
-	for (cosh_idx = 0; cosh_idx < 5; cosh_idx++) {
+	for (cosh_idx = 0; cosh_idx < SIZE(in_val, double); cosh_idx++) {
 		ret_val[cosh_idx] = cosh(in_val[cosh_idx]);
 		TC_ASSERT_LEQ("cosh", fabs(sol_val[cosh_idx] - ret_val[cosh_idx]), FLT_EPSILON);
 	}
@@ -912,14 +913,14 @@ static void tc_libc_math_cosh(void)
  */
 static void tc_libc_math_coshf(void)
 {
-	const float in_val[5] = { 3, -3, 0, M_PI, (2 * M_PI) };
-	const float sol_val[5] = { 10.0676622390747, 10.0676622390747, 1.0000000000000, 11.5919551849365, 267.7468261718750 };
-	float ret_val[5];
+	const float in_val[] = { 3, -3, 0, M_PI, (2 * M_PI) };
+	const float sol_val[] = { 10.0676622390747, 10.0676622390747, 1.0000000000000, 11.5919551849365, 267.7468261718750 };
+	float ret_val[SIZE(sol_val, float)];
 	int coshf_idx;
 
 	/* Returns the hyperbolic cosine of x */
 
-	for (coshf_idx = 0; coshf_idx < 5; coshf_idx++) {
+	for (coshf_idx = 0; coshf_idx < SIZE(in_val, float); coshf_idx++) {
 		ret_val[coshf_idx] = coshf(in_val[coshf_idx]);
 		TC_ASSERT_LEQ("coshf", fabsf(sol_val[coshf_idx] - ret_val[coshf_idx]), FLT_EPSILON);
 	}
@@ -938,14 +939,14 @@ static void tc_libc_math_coshf(void)
  */
 static void tc_libc_math_coshl(void)
 {
-	const long double in_val[5] = { 3, -3, 0, M_PI, (2 * M_PI) };
-	const long double sol_val[5] = { 10.067661995778, 10.067661995778, 1, 11.591953275522, 267.74676148375 };
-	long double ret_val[5];
+	const long double in_val[] = { 3, -3, 0, M_PI, (2 * M_PI) };
+	const long double sol_val[] = { 10.067661995778, 10.067661995778, 1, 11.591953275522, 267.74676148375 };
+	long double ret_val[SIZE(sol_val, long double)];
 	int coshl_idx;
 
 	/* Returns the hyperbolic cosine of x */
 
-	for (coshl_idx = 0; coshl_idx < 5; coshl_idx++) {
+	for (coshl_idx = 0; coshl_idx < SIZE(in_val, long double); coshl_idx++) {
 		ret_val[coshl_idx] = coshl(in_val[coshl_idx]);
 		TC_ASSERT_LEQ("coshl", fabsl(sol_val[coshl_idx] - ret_val[coshl_idx]), FLT_EPSILON);
 	}
@@ -964,14 +965,14 @@ static void tc_libc_math_coshl(void)
  */
 static void tc_libc_math_cosl(void)
 {
-	const long double in_val[5] = { 3, -3, 0, M_PI, (2 * M_PI) };
-	const long double sol_val[5] = { -0.98999249660045, -0.98999249660045, 1, -1, 1 };
-	long double ret_val[5];
+	const long double in_val[] = { 3, -3, 0, M_PI, (2 * M_PI) };
+	const long double sol_val[] = { -0.98999249660045, -0.98999249660045, 1, -1, 1 };
+	long double ret_val[SIZE(sol_val, long double)];
 	int cosl_idx;
 
 	/* Returns the cosine of an angle of x radians */
 
-	for (cosl_idx = 0; cosl_idx < 5; cosl_idx++) {
+	for (cosl_idx = 0; cosl_idx < SIZE(in_val, long double); cosl_idx++) {
 		ret_val[cosl_idx] = cosl(in_val[cosl_idx]);
 		TC_ASSERT_LEQ("cosl", fabsl(sol_val[cosl_idx] - ret_val[cosl_idx]), FLT_EPSILON);
 	}
@@ -990,14 +991,14 @@ static void tc_libc_math_cosl(void)
  */
 static void tc_libc_math_erf(void)
 {
-	const double in_val[5] = { 1, -1, ZERO, 0.5, -0.5 };
-	const double sol_val[5] = { 0.8427006858353, -217.6481312007792, 0, 0.52049987781, -132.8284539391262 };
-	double ret_val[5];
+	const double in_val[] = { 1, -1, ZERO, 0.5, -0.5 };
+	const double sol_val[] = { 0.8427006858353, -217.6481312007792, 0, 0.52049987781, -132.8284539391262 };
+	double ret_val[SIZE(sol_val, double)];
 	int erf_idx;
 
 	/* Returns the error function value for x */
 
-	for (erf_idx = 0; erf_idx < 5; erf_idx++) {
+	for (erf_idx = 0; erf_idx < SIZE(in_val, double); erf_idx++) {
 		ret_val[erf_idx] = erf(in_val[erf_idx]);
 		TC_ASSERT_LEQ("erf", fabs(sol_val[erf_idx] - ret_val[erf_idx]), FLT_EPSILON);
 	}
@@ -1016,14 +1017,14 @@ static void tc_libc_math_erf(void)
  */
 static void tc_libc_math_erff(void)
 {
-	const float in_val[5] = { 1, -1, ZERO, 0.5, -0.5 };
-	const float sol_val[5] = { 0.8427006858353, -217.6480102539062, 0, 0.52049987781, -132.8285064697266 };
-	float ret_val[5];
+	const float in_val[] = { 1, -1, ZERO, 0.5, -0.5 };
+	const float sol_val[] = { 0.8427006858353, -217.6480102539062, 0, 0.52049987781, -132.8285064697266 };
+	float ret_val[SIZE(sol_val, float)];
 	int erff_idx;
 
 	/* Returns the error function value for x */
 
-	for (erff_idx = 0; erff_idx < 5; erff_idx++) {
+	for (erff_idx = 0; erff_idx < SIZE(in_val, float); erff_idx++) {
 		ret_val[erff_idx] = erff(in_val[erff_idx]);
 		TC_ASSERT_LEQ("erff", fabsf(sol_val[erff_idx] - ret_val[erff_idx]), FLT_EPSILON);
 	}
@@ -1042,14 +1043,14 @@ static void tc_libc_math_erff(void)
  */
 static void tc_libc_math_erfl(void)
 {
-	const long double in_val[5] = { 1, -1, ZERO, 0.5, -0.5 };
-	const long double sol_val[5] = { 0.8427006858353, -217.6481312007792, 0, 0.52049987781, -132.8284539391262 };
-	long double ret_val[5];
+	const long double in_val[] = { 1, -1, ZERO, 0.5, -0.5 };
+	const long double sol_val[] = { 0.8427006858353, -217.6481312007792, 0, 0.52049987781, -132.8284539391262 };
+	long double ret_val[SIZE(sol_val, long double)];
 	int erfl_idx;
 
 	/* Returns the error function value for x */
 
-	for (erfl_idx = 0; erfl_idx < 5; erfl_idx++) {
+	for (erfl_idx = 0; erfl_idx < SIZE(in_val, long double); erfl_idx++) {
 		ret_val[erfl_idx] = erfl(in_val[erfl_idx]);
 		TC_ASSERT_LEQ("erfl", fabsl(sol_val[erfl_idx] - ret_val[erfl_idx]), FLT_EPSILON);
 	}
@@ -1068,12 +1069,12 @@ static void tc_libc_math_erfl(void)
  */
 static void tc_libc_math_exp(void)
 {
-	const double in_val[8] = { ZERO, INFINITY, -INFINITY, NAN, VAL1, -VAL1, VAL2, -VAL2 };
-	const double sol_val[8] = { 1.0, INFINITY, ZERO, NAN, INFINITY, ZERO, INFINITY, ZERO };
-	double ret_val[8];
+	const double in_val[] = { ZERO, INFINITY, -INFINITY, NAN, VAL1, -VAL1, VAL2, -VAL2 };
+	const double sol_val[] = { 1.0, INFINITY, ZERO, NAN, INFINITY, ZERO, INFINITY, ZERO };
+	double ret_val[SIZE(sol_val, double)];
 	int exp_idx;
 
-	for (exp_idx = 0; exp_idx < 8; exp_idx++) {
+	for (exp_idx = 0; exp_idx < SIZE(in_val, double); exp_idx++) {
 		ret_val[exp_idx] = exp(in_val[exp_idx]);
 		if (!(isnan(sol_val[exp_idx]) && isnan(ret_val[exp_idx]))) {
 			TC_ASSERT_LEQ("exp", fabs(sol_val[exp_idx] - ret_val[exp_idx]), FLT_EPSILON);
@@ -1094,12 +1095,12 @@ static void tc_libc_math_exp(void)
  */
 static void tc_libc_math_expf(void)
 {
-	const float in_val[8] = { ZERO, INFINITY, -INFINITY, NAN, VAL1, -VAL1, VAL2, -VAL2 };
-	const float sol_val[8] = { 1.0, INFINITY, ZERO, NAN, INFINITY, ZERO, INFINITY, ZERO };
-	float ret_val[8];
+	const float in_val[] = { ZERO, INFINITY, -INFINITY, NAN, VAL1, -VAL1, VAL2, -VAL2 };
+	const float sol_val[] = { 1.0, INFINITY, ZERO, NAN, INFINITY, ZERO, INFINITY, ZERO };
+	float ret_val[SIZE(sol_val, float)];
 	int expf_idx;
 
-	for (expf_idx = 0; expf_idx < 8; expf_idx++) {
+	for (expf_idx = 0; expf_idx < SIZE(in_val, float); expf_idx++) {
 		ret_val[expf_idx] = expf(in_val[expf_idx]);
 		if (!(isnan(sol_val[expf_idx]) && isnan(ret_val[expf_idx]))) {
 			TC_ASSERT_LEQ("expf", fabsf(sol_val[expf_idx] - ret_val[expf_idx]), FLT_EPSILON);
@@ -1120,12 +1121,12 @@ static void tc_libc_math_expf(void)
  */
 static void tc_libc_math_expl(void)
 {
-	const long double in_val[8] = { ZERO, INFINITY, -INFINITY, NAN, VAL1, -VAL1, VAL2, -VAL2 };
-	const long double sol_val[8] = { 1.0, INFINITY, ZERO, NAN, INFINITY, ZERO, INFINITY, ZERO };
-	long double ret_val[8];
+	const long double in_val[] = { ZERO, INFINITY, -INFINITY, NAN, VAL1, -VAL1, VAL2, -VAL2 };
+	const long double sol_val[] = { 1.0, INFINITY, ZERO, NAN, INFINITY, ZERO, INFINITY, ZERO };
+	long double ret_val[SIZE(sol_val, long double)];
 	int expl_idx;
 
-	for (expl_idx = 0; expl_idx < 8; expl_idx++) {
+	for (expl_idx = 0; expl_idx < SIZE(in_val, long double); expl_idx++) {
 		ret_val[expl_idx] = expl(in_val[expl_idx]);
 		if (!(isnan(sol_val[expl_idx]) && isnan(ret_val[expl_idx]))) {
 			TC_ASSERT_LEQ("expl", fabsl(sol_val[expl_idx] - ret_val[expl_idx]), FLT_EPSILON);
@@ -1146,12 +1147,12 @@ static void tc_libc_math_expl(void)
  */
 static void tc_libc_math_exp2(void)
 {
-	const double in_val[8] = { ZERO, VAL1, -VAL1, VAL2, -VAL2, INFINITY, -INFINITY, NAN };
-	const double sol_val[8] = { 1.0, INFINITY, ZERO, INFINITY, ZERO, INFINITY, ZERO, NAN };
-	double ret_val[8];
+	const double in_val[] = { ZERO, VAL1, -VAL1, VAL2, -VAL2, INFINITY, -INFINITY, NAN };
+	const double sol_val[] = { 1.0, INFINITY, ZERO, INFINITY, ZERO, INFINITY, ZERO, NAN };
+	double ret_val[SIZE(sol_val, double)];
 	int exp2_idx;
 
-	for (exp2_idx = 0; exp2_idx < 8; exp2_idx++) {
+	for (exp2_idx = 0; exp2_idx < SIZE(in_val, double); exp2_idx++) {
 		ret_val[exp2_idx] = exp2(in_val[exp2_idx]);
 		if (!(isnan(sol_val[exp2_idx]) && isnan(ret_val[exp2_idx]))) {
 			TC_ASSERT_LEQ("exp2", fabs(sol_val[exp2_idx] - ret_val[exp2_idx]), FLT_EPSILON);
@@ -1172,12 +1173,12 @@ static void tc_libc_math_exp2(void)
  */
 static void tc_libc_math_exp2f(void)
 {
-	const float in_val[8] = { ZERO, VAL1, -VAL1, VAL2, -VAL2, INFINITY, -INFINITY, NAN };
-	const float sol_val[8] = { 1.0, INFINITY, ZERO, INFINITY, ZERO, INFINITY, ZERO, NAN };
-	float ret_val[8];
+	const float in_val[] = { ZERO, VAL1, -VAL1, VAL2, -VAL2, INFINITY, -INFINITY, NAN };
+	const float sol_val[] = { 1.0, INFINITY, ZERO, INFINITY, ZERO, INFINITY, ZERO, NAN };
+	float ret_val[SIZE(sol_val, float)];
 	int exp2f_idx;
 
-	for (exp2f_idx = 0; exp2f_idx < 8; exp2f_idx++) {
+	for (exp2f_idx = 0; exp2f_idx < SIZE(in_val, float); exp2f_idx++) {
 		ret_val[exp2f_idx] = exp2f(in_val[exp2f_idx]);
 		if (!(isnan(sol_val[exp2f_idx]) && isnan(ret_val[exp2f_idx]))) {
 			TC_ASSERT_LEQ("exp2f", fabsf(sol_val[exp2f_idx] - ret_val[exp2f_idx]), FLT_EPSILON);
@@ -1198,12 +1199,12 @@ static void tc_libc_math_exp2f(void)
  */
 static void tc_libc_math_exp2l(void)
 {
-	const long double in_val[8] = { ZERO, VAL1, -VAL1, VAL2, -VAL2, INFINITY, -INFINITY, NAN };
-	const long double sol_val[8] = { 1.0, INFINITY, ZERO, INFINITY, ZERO, INFINITY, ZERO, NAN };
-	long double ret_val[8];
+	const long double in_val[] = { ZERO, VAL1, -VAL1, VAL2, -VAL2, INFINITY, -INFINITY, NAN };
+	const long double sol_val[] = { 1.0, INFINITY, ZERO, INFINITY, ZERO, INFINITY, ZERO, NAN };
+	long double ret_val[SIZE(sol_val, long double)];
 	int exp2l_idx;
 
-	for (exp2l_idx = 0; exp2l_idx < 8; exp2l_idx++) {
+	for (exp2l_idx = 0; exp2l_idx < SIZE(in_val, long double); exp2l_idx++) {
 		ret_val[exp2l_idx] = exp2l(in_val[exp2l_idx]);
 		if (!(isnan(sol_val[exp2l_idx]) && isnan(ret_val[exp2l_idx]))) {
 			TC_ASSERT_LEQ("exp2l", fabsl(sol_val[exp2l_idx] - ret_val[exp2l_idx]), FLT_EPSILON);
@@ -1224,12 +1225,12 @@ static void tc_libc_math_exp2l(void)
  */
 static void tc_libc_math_fabs(void)
 {
-	const double in_val[7] = { ZERO, -ZERO, VAL1, -VAL1, INFINITY, -INFINITY, NAN };
-	const double sol_val[7] = { ZERO, ZERO, 2251799813685248.5, 2251799813685248.5, INFINITY, INFINITY, NAN };
-	double ret_val[7];
+	const double in_val[] = { ZERO, -ZERO, VAL1, -VAL1, INFINITY, -INFINITY, NAN };
+	const double sol_val[] = { ZERO, ZERO, 2251799813685248.5, 2251799813685248.5, INFINITY, INFINITY, NAN };
+	double ret_val[SIZE(sol_val, double)];
 	int fabs_idx;
 
-	for (fabs_idx = 0; fabs_idx < 7; fabs_idx++) {
+	for (fabs_idx = 0; fabs_idx < SIZE(in_val, double); fabs_idx++) {
 		ret_val[fabs_idx] = fabs(in_val[fabs_idx]);
 		if (!(isnan(sol_val[fabs_idx]) && isnan(ret_val[fabs_idx]))) {
 			TC_ASSERT_EQ("fabs", sol_val[fabs_idx], ret_val[fabs_idx]);
@@ -1250,11 +1251,11 @@ static void tc_libc_math_fabs(void)
  */
 static void tc_libc_math_fabsf(void)
 {
-	const float in_val[7] = { ZERO, -ZERO, VAL1, -VAL1, INFINITY, -INFINITY, NAN };
-	const float sol_val[7] = { ZERO, ZERO, 2251799813685248.5, 2251799813685248.5, INFINITY, INFINITY, NAN };
-	float ret_val[7];
+	const float in_val[] = { ZERO, -ZERO, VAL1, -VAL1, INFINITY, -INFINITY, NAN };
+	const float sol_val[] = { ZERO, ZERO, 2251799813685248.5, 2251799813685248.5, INFINITY, INFINITY, NAN };
+	float ret_val[SIZE(sol_val, float)];
 	int fabsf_idx;
-	for (fabsf_idx = 0; fabsf_idx < 7; fabsf_idx++) {
+	for (fabsf_idx = 0; fabsf_idx < SIZE(in_val, float); fabsf_idx++) {
 		ret_val[fabsf_idx] = fabsf(in_val[fabsf_idx]);
 		if (!(isnan(sol_val[fabsf_idx]) && isnan(ret_val[fabsf_idx]))) {
 			TC_ASSERT_EQ("fabsf", sol_val[fabsf_idx], ret_val[fabsf_idx]);
@@ -1275,11 +1276,11 @@ static void tc_libc_math_fabsf(void)
  */
 static void tc_libc_math_fabsl(void)
 {
-	const long double in_val[7] = { ZERO, -ZERO, VAL1, -VAL1, INFINITY, -INFINITY, NAN };
-	const long double sol_val[7] = { ZERO, ZERO, 2251799813685248.5, 2251799813685248.5, INFINITY, INFINITY, NAN };
-	long double ret_val[7];
+	const long double in_val[] = { ZERO, -ZERO, VAL1, -VAL1, INFINITY, -INFINITY, NAN };
+	const long double sol_val[] = { ZERO, ZERO, 2251799813685248.5, 2251799813685248.5, INFINITY, INFINITY, NAN };
+	long double ret_val[SIZE(sol_val, long double)];
 	int fabsl_idx;
-	for (fabsl_idx = 0; fabsl_idx < 7; fabsl_idx++) {
+	for (fabsl_idx = 0; fabsl_idx < SIZE(in_val, long double); fabsl_idx++) {
 		ret_val[fabsl_idx] = fabsl(in_val[fabsl_idx]);
 		if (!(isnan(sol_val[fabsl_idx]) && isnan(ret_val[fabsl_idx]))) {
 			TC_ASSERT_EQ("fabsl", sol_val[fabsl_idx], ret_val[fabsl_idx]);
@@ -1300,13 +1301,13 @@ static void tc_libc_math_fabsl(void)
  */
 static void tc_libc_math_fdim(void)
 {
-	const double in_val1[10] = { ZERO, -ZERO, VAL1, -VAL1, VAL2, -VAL2, INFINITY, -INFINITY, NAN, VAL1 };
-	const double in_val2[10] = { -INFINITY, INFINITY, -VAL2, VAL2, -VAL1, VAL1, -ZERO, ZERO, NAN, NAN };
-	const double sol_val[10] = { INFINITY, ZERO, 6755399441055744.0, ZERO, 6755399441055744.0, ZERO, INFINITY, ZERO, NAN, NAN };
-	double ret_val[10];
+	const double in_val1[] = { ZERO, -ZERO, VAL1, -VAL1, VAL2, -VAL2, INFINITY, -INFINITY, NAN, VAL1 };
+	const double in_val2[] = { -INFINITY, INFINITY, -VAL2, VAL2, -VAL1, VAL1, -ZERO, ZERO, NAN, NAN };
+	const double sol_val[] = { INFINITY, ZERO, 6755399441055744.0, ZERO, 6755399441055744.0, ZERO, INFINITY, ZERO, NAN, NAN };
+	double ret_val[SIZE(sol_val, double)];
 	int fdim_idx;
 
-	for (fdim_idx = 0; fdim_idx < 10; fdim_idx++) {
+	for (fdim_idx = 0; fdim_idx < SIZE(sol_val, double); fdim_idx++) {
 		ret_val[fdim_idx] = fdim(in_val1[fdim_idx], in_val2[fdim_idx]);
 		if (!(isnan(sol_val[fdim_idx]) && isnan(ret_val[fdim_idx]))) {
 			TC_ASSERT_LEQ("fdim", fabs(sol_val[fdim_idx] - ret_val[fdim_idx]), FLT_EPSILON);
@@ -1327,13 +1328,13 @@ static void tc_libc_math_fdim(void)
  */
 static void tc_libc_math_fdimf(void)
 {
-	const float in_val1[10] = { ZERO, -ZERO, VAL1, -VAL1, VAL2, -VAL2, INFINITY, -INFINITY, NAN, VAL1 };
-	const float in_val2[10] = { -INFINITY, INFINITY, -VAL2, VAL2, -VAL1, VAL1, -ZERO, ZERO, NAN, NAN };
-	const float sol_val[10] = { INFINITY, ZERO, 6755399441055744.0, ZERO, 6755399441055744.0, ZERO, INFINITY, ZERO, NAN, NAN };
-	float ret_val[10];
+	const float in_val1[] = { ZERO, -ZERO, VAL1, -VAL1, VAL2, -VAL2, INFINITY, -INFINITY, NAN, VAL1 };
+	const float in_val2[] = { -INFINITY, INFINITY, -VAL2, VAL2, -VAL1, VAL1, -ZERO, ZERO, NAN, NAN };
+	const float sol_val[] = { INFINITY, ZERO, 6755399441055744.0, ZERO, 6755399441055744.0, ZERO, INFINITY, ZERO, NAN, NAN };
+	float ret_val[SIZE(sol_val, float)];
 	int fdimf_idx;
 
-	for (fdimf_idx = 0; fdimf_idx < 10; fdimf_idx++) {
+	for (fdimf_idx = 0; fdimf_idx < SIZE(sol_val, float); fdimf_idx++) {
 		ret_val[fdimf_idx] = fdimf(in_val1[fdimf_idx], in_val2[fdimf_idx]);
 		if (!(isnan(sol_val[fdimf_idx]) && isnan(ret_val[fdimf_idx]))) {
 			TC_ASSERT_LEQ("fdimf", fabsf(sol_val[fdimf_idx] - ret_val[fdimf_idx]), FLT_EPSILON);
@@ -1354,13 +1355,13 @@ static void tc_libc_math_fdimf(void)
  */
 static void tc_libc_math_fdiml(void)
 {
-	const long double in_val1[10] = { ZERO, -ZERO, VAL1, -VAL1, VAL2, -VAL2, INFINITY, -INFINITY, NAN, VAL1 };
-	const long double in_val2[10] = { -INFINITY, INFINITY, -VAL2, VAL2, -VAL1, VAL1, -ZERO, ZERO, NAN, NAN };
-	const long double sol_val[10] = { INFINITY, ZERO, 6755399441055744.0, ZERO, 6755399441055744.0, ZERO, INFINITY, ZERO, NAN, NAN };
-	long double ret_val[10];
+	const long double in_val1[] = { ZERO, -ZERO, VAL1, -VAL1, VAL2, -VAL2, INFINITY, -INFINITY, NAN, VAL1 };
+	const long double in_val2[] = { -INFINITY, INFINITY, -VAL2, VAL2, -VAL1, VAL1, -ZERO, ZERO, NAN, NAN };
+	const long double sol_val[] = { INFINITY, ZERO, 6755399441055744.0, ZERO, 6755399441055744.0, ZERO, INFINITY, ZERO, NAN, NAN };
+	long double ret_val[SIZE(sol_val, long double)];
 	int fdiml_idx;
 
-	for (fdiml_idx = 0; fdiml_idx < 10; fdiml_idx++) {
+	for (fdiml_idx = 0; fdiml_idx < SIZE(sol_val, long double); fdiml_idx++) {
 		ret_val[fdiml_idx] = fdiml(in_val1[fdiml_idx], in_val2[fdiml_idx]);
 		if (!(isnan(sol_val[fdiml_idx]) && isnan(ret_val[fdiml_idx]))) {
 			TC_ASSERT_LEQ("fdiml", fabsl(sol_val[fdiml_idx] - ret_val[fdiml_idx]), FLT_EPSILON);
@@ -1381,12 +1382,12 @@ static void tc_libc_math_fdiml(void)
  */
 static void tc_libc_math_floor(void)
 {
-	const double in_val[8] = { ZERO, -ZERO, VAL1, -VAL1, VAL2, -VAL2, INFINITY, -INFINITY };
-	const double sol_val[8] = { ZERO, -ZERO, 2251799813685248.0, -2251799813685249.0, 4503599627370496.0, -4503599627370497.0, INFINITY, -INFINITY };
-	double ret_val[8] = { ZERO };
+	const double in_val[] = { ZERO, -ZERO, VAL1, -VAL1, VAL2, -VAL2, INFINITY, -INFINITY };
+	const double sol_val[] = { ZERO, -ZERO, 2251799813685248.0, -2251799813685249.0, 4503599627370496.0, -4503599627370497.0, INFINITY, -INFINITY };
+	double ret_val[SIZE(sol_val, double)] = { ZERO };
 	int floor_idx;
 
-	for (floor_idx = 0; floor_idx < 8; floor_idx++) {
+	for (floor_idx = 0; floor_idx < SIZE(in_val, double); floor_idx++) {
 		ret_val[floor_idx] = floor(in_val[floor_idx]);
 		if (!(isnan(sol_val[floor_idx]) && isnan(ret_val[floor_idx]))) {
 			TC_ASSERT_EQ("floor", sol_val[floor_idx], ret_val[floor_idx]);
@@ -1407,12 +1408,12 @@ static void tc_libc_math_floor(void)
  */
 static void tc_libc_math_floorf(void)
 {
-	const float in_val[8] = { ZERO, -ZERO, VAL1, -VAL1, VAL2, -VAL2, INFINITY, -INFINITY };
-	const float sol_val[8] = { ZERO, -ZERO, 2251799813685248.0, -2251799813685249.0, 4503599627370496.0, -4503599627370497.0, INFINITY, -INFINITY };
-	float ret_val[8] = { ZERO };
+	const float in_val[] = { ZERO, -ZERO, VAL1, -VAL1, VAL2, -VAL2, INFINITY, -INFINITY };
+	const float sol_val[] = { ZERO, -ZERO, 2251799813685248.0, -2251799813685249.0, 4503599627370496.0, -4503599627370497.0, INFINITY, -INFINITY };
+	float ret_val[SIZE(sol_val, float)] = { ZERO };
 	int floorf_idx;
 
-	for (floorf_idx = 0; floorf_idx < 8; floorf_idx++) {
+	for (floorf_idx = 0; floorf_idx < SIZE(in_val, float); floorf_idx++) {
 		ret_val[floorf_idx] = floorf(in_val[floorf_idx]);
 		if (!(isnan(sol_val[floorf_idx]) && isnan(ret_val[floorf_idx]))) {
 			TC_ASSERT_EQ("floorf", sol_val[floorf_idx], ret_val[floorf_idx]);
@@ -1433,11 +1434,11 @@ static void tc_libc_math_floorf(void)
  */
 static void tc_libc_math_floorl(void)
 {
-	const long double in_val[8] = { ZERO, -ZERO, VAL1, -VAL1, VAL2, -VAL2, INFINITY, -INFINITY };
-	const long double sol_val[8] = { ZERO, -ZERO, 2251799813685248.0, -2251799813685249.0, 4503599627370496.0, -4503599627370497.0, INFINITY, -INFINITY };
-	long double ret_val[8] = { ZERO };
+	const long double in_val[] = { ZERO, -ZERO, VAL1, -VAL1, VAL2, -VAL2, INFINITY, -INFINITY };
+	const long double sol_val[] = { ZERO, -ZERO, 2251799813685248.0, -2251799813685249.0, 4503599627370496.0, -4503599627370497.0, INFINITY, -INFINITY };
+	long double ret_val[SIZE(sol_val, long double)] = { ZERO };
 	int floorl_idx;
-	for (floorl_idx = 0; floorl_idx < 8; floorl_idx++) {
+	for (floorl_idx = 0; floorl_idx < SIZE(in_val, long double); floorl_idx++) {
 		ret_val[floorl_idx] = floorl(in_val[floorl_idx]);
 		if (!(isnan(sol_val[floorl_idx]) && isnan(ret_val[floorl_idx]))) {
 			TC_ASSERT_EQ("floorl", sol_val[floorl_idx], ret_val[floorl_idx]);
@@ -1458,13 +1459,13 @@ static void tc_libc_math_floorl(void)
  */
 static void tc_libc_math_fmax(void)
 {
-	const double in_val1[7] = { ZERO, VAL1, -VAL1, INFINITY, -INFINITY, NAN, VAL1 };
-	const double in_val2[7] = { -INFINITY, INFINITY, -VAL1, VAL1, ZERO, NAN, NAN };
-	const double sol_val[7] = { ZERO, INFINITY, -VAL1, INFINITY, ZERO, NAN, VAL1 };
-	double ret_val[7];
+	const double in_val1[] = { ZERO, VAL1, -VAL1, INFINITY, -INFINITY, NAN, VAL1 };
+	const double in_val2[] = { -INFINITY, INFINITY, -VAL1, VAL1, ZERO, NAN, NAN };
+	const double sol_val[] = { ZERO, INFINITY, -VAL1, INFINITY, ZERO, NAN, VAL1 };
+	double ret_val[SIZE(sol_val, double)];
 	int fmax_idx;
 
-	for (fmax_idx = 0; fmax_idx < 7; fmax_idx++) {
+	for (fmax_idx = 0; fmax_idx < SIZE(sol_val, double); fmax_idx++) {
 		ret_val[fmax_idx] = fmax(in_val1[fmax_idx], in_val2[fmax_idx]);
 		if (!(isnan(sol_val[fmax_idx]) && isnan(ret_val[fmax_idx]))) {
 			TC_ASSERT_LEQ("fmax", fabs(sol_val[fmax_idx] - ret_val[fmax_idx]), FLT_EPSILON);
@@ -1485,13 +1486,13 @@ static void tc_libc_math_fmax(void)
  */
 static void tc_libc_math_fmaxf(void)
 {
-	const float in_val1[7] = { ZERO, VAL1, -VAL1, INFINITY, -INFINITY, NAN, VAL1 };
-	const float in_val2[7] = { -INFINITY, INFINITY, -VAL1, VAL1, ZERO, NAN, NAN };
-	const float sol_val[7] = { ZERO, INFINITY, -VAL1, INFINITY, ZERO, NAN, VAL1 };
-	float ret_val[7];
+	const float in_val1[] = { ZERO, VAL1, -VAL1, INFINITY, -INFINITY, NAN, VAL1 };
+	const float in_val2[] = { -INFINITY, INFINITY, -VAL1, VAL1, ZERO, NAN, NAN };
+	const float sol_val[] = { ZERO, INFINITY, -VAL1, INFINITY, ZERO, NAN, VAL1 };
+	float ret_val[SIZE(sol_val, float)];
 	int fmaxf_idx;
 
-	for (fmaxf_idx = 0; fmaxf_idx < 7; fmaxf_idx++) {
+	for (fmaxf_idx = 0; fmaxf_idx < SIZE(sol_val, float); fmaxf_idx++) {
 		ret_val[fmaxf_idx] = fmaxf(in_val1[fmaxf_idx], in_val2[fmaxf_idx]);
 		if (!(isnan(sol_val[fmaxf_idx]) && isnan(ret_val[fmaxf_idx]))) {
 			TC_ASSERT_LEQ("fmaxf", fabsf(sol_val[fmaxf_idx] - ret_val[fmaxf_idx]), FLT_EPSILON);
@@ -1512,13 +1513,13 @@ static void tc_libc_math_fmaxf(void)
  */
 static void tc_libc_math_fmaxl(void)
 {
-	const long double in_val1[7] = { ZERO, VAL1, -VAL1, INFINITY, -INFINITY, NAN, VAL1 };
-	const long double in_val2[7] = { -INFINITY, INFINITY, -VAL1, VAL1, ZERO, NAN, NAN };
-	const long double sol_val[7] = { ZERO, INFINITY, -VAL1, INFINITY, ZERO, NAN, VAL1 };
-	long double ret_val[7];
+	const long double in_val1[] = { ZERO, VAL1, -VAL1, INFINITY, -INFINITY, NAN, VAL1 };
+	const long double in_val2[] = { -INFINITY, INFINITY, -VAL1, VAL1, ZERO, NAN, NAN };
+	const long double sol_val[] = { ZERO, INFINITY, -VAL1, INFINITY, ZERO, NAN, VAL1 };
+	long double ret_val[SIZE(sol_val, double)];
 	int fmaxl_idx;
 
-	for (fmaxl_idx = 0; fmaxl_idx < 7; fmaxl_idx++) {
+	for (fmaxl_idx = 0; fmaxl_idx < SIZE(sol_val, long double); fmaxl_idx++) {
 		ret_val[fmaxl_idx] = fmaxl(in_val1[fmaxl_idx], in_val2[fmaxl_idx]);
 		if (!(isnan(sol_val[fmaxl_idx]) && isnan(ret_val[fmaxl_idx]))) {
 			TC_ASSERT_LEQ("fmaxl", fabsl(sol_val[fmaxl_idx] - ret_val[fmaxl_idx]), FLT_EPSILON);
@@ -1539,13 +1540,13 @@ static void tc_libc_math_fmaxl(void)
  */
 static void tc_libc_math_fmin(void)
 {
-	const double in_val1[7] = { ZERO, VAL1, -VAL1, INFINITY, -INFINITY, NAN, VAL1 };
-	const double in_val2[7] = { -INFINITY, INFINITY, -VAL1, VAL1, ZERO, NAN, NAN };
-	const double sol_val[7] = { -INFINITY, VAL1, -VAL1, VAL1, -INFINITY, NAN, VAL1 };
-	double ret_val[7];
+	const double in_val1[] = { ZERO, VAL1, -VAL1, INFINITY, -INFINITY, NAN, VAL1 };
+	const double in_val2[] = { -INFINITY, INFINITY, -VAL1, VAL1, ZERO, NAN, NAN };
+	const double sol_val[] = { -INFINITY, VAL1, -VAL1, VAL1, -INFINITY, NAN, VAL1 };
+	double ret_val[SIZE(sol_val, double)];
 	int fmin_idx;
 
-	for (fmin_idx = 0; fmin_idx < 7; fmin_idx++) {
+	for (fmin_idx = 0; fmin_idx < SIZE(sol_val, double); fmin_idx++) {
 		ret_val[fmin_idx] = fmin(in_val1[fmin_idx], in_val2[fmin_idx]);
 		if (!(isnan(sol_val[fmin_idx]) && isnan(ret_val[fmin_idx]))) {
 			TC_ASSERT_LEQ("fmin", fabs(sol_val[fmin_idx] - ret_val[fmin_idx]), FLT_EPSILON);
@@ -1566,13 +1567,13 @@ static void tc_libc_math_fmin(void)
  */
 static void tc_libc_math_fminf(void)
 {
-	const float in_val1[7] = { ZERO, VAL1, -VAL1, INFINITY, -INFINITY, NAN, VAL1 };
-	const float in_val2[7] = { -INFINITY, INFINITY, -VAL1, VAL1, ZERO, NAN, NAN };
-	const float sol_val[7] = { -INFINITY, VAL1, -VAL1, VAL1, -INFINITY, NAN, VAL1 };
-	float ret_val[7];
+	const float in_val1[] = { ZERO, VAL1, -VAL1, INFINITY, -INFINITY, NAN, VAL1 };
+	const float in_val2[] = { -INFINITY, INFINITY, -VAL1, VAL1, ZERO, NAN, NAN };
+	const float sol_val[] = { -INFINITY, VAL1, -VAL1, VAL1, -INFINITY, NAN, VAL1 };
+	float ret_val[SIZE(sol_val, float)];
 	int fminf_idx;
 
-	for (fminf_idx = 0; fminf_idx < 7; fminf_idx++) {
+	for (fminf_idx = 0; fminf_idx < SIZE(sol_val, float); fminf_idx++) {
 		ret_val[fminf_idx] = fminf(in_val1[fminf_idx], in_val2[fminf_idx]);
 		if (!(isnan(sol_val[fminf_idx]) && isnan(ret_val[fminf_idx]))) {
 			TC_ASSERT_LEQ("fminf", fabsf(sol_val[fminf_idx] - ret_val[fminf_idx]), FLT_EPSILON);
@@ -1593,13 +1594,13 @@ static void tc_libc_math_fminf(void)
  */
 static void tc_libc_math_fminl(void)
 {
-	const long double in_val1[7] = { ZERO, VAL1, -VAL1, INFINITY, -INFINITY, NAN, VAL1 };
-	const long double in_val2[7] = { -INFINITY, INFINITY, -VAL1, VAL1, ZERO, NAN, NAN };
-	const long double sol_val[7] = { -INFINITY, VAL1, -VAL1, VAL1, -INFINITY, NAN, VAL1 };
-	long double ret_val[7];
+	const long double in_val1[] = { ZERO, VAL1, -VAL1, INFINITY, -INFINITY, NAN, VAL1 };
+	const long double in_val2[] = { -INFINITY, INFINITY, -VAL1, VAL1, ZERO, NAN, NAN };
+	const long double sol_val[] = { -INFINITY, VAL1, -VAL1, VAL1, -INFINITY, NAN, VAL1 };
+	long double ret_val[SIZE(sol_val, long double)];
 	int fminl_idx;
 
-	for (fminl_idx = 0; fminl_idx < 7; fminl_idx++) {
+	for (fminl_idx = 0; fminl_idx < SIZE(sol_val, long double); fminl_idx++) {
 		ret_val[fminl_idx] = fminl(in_val1[fminl_idx], in_val2[fminl_idx]);
 		if (!(isnan(sol_val[fminl_idx]) && isnan(ret_val[fminl_idx]))) {
 			TC_ASSERT_LEQ("fminl", fabsl(sol_val[fminl_idx] - ret_val[fminl_idx]), FLT_EPSILON);
@@ -1620,16 +1621,16 @@ static void tc_libc_math_fminl(void)
  */
 static void tc_libc_math_frexp(void)
 {
-	const double in_val[3] = { 8.0, 2.3, -10.0 };
-	const double sol_val[3] = { 0.5, 0.575, -10 };
-	const double n_val[3] = { 4, 2, 0 };
-	double ret_val[3];
-	int n[3];
+	const double in_val[] = { 8.0, 2.3, -10.0 };
+	const double sol_val[] = { 0.5, 0.575, -10 };
+	const double n_val[] = { 4, 2, 0 };
+	double ret_val[SIZE(sol_val, double)];
+	int n[SIZE(in_val, double)];
 	int frexp_idx;
 
 	/* Breaks the floating point number x into its binary significand and an integral exponent for 2 */
 
-	for (frexp_idx = 0; frexp_idx < 3; frexp_idx++) {
+	for (frexp_idx = 0; frexp_idx < SIZE(in_val, double); frexp_idx++) {
 		ret_val[frexp_idx] = frexp(in_val[frexp_idx], &n[frexp_idx]);
 		TC_ASSERT_LEQ("frexp", fabs(sol_val[frexp_idx] - ret_val[frexp_idx]), FLT_EPSILON);
 		TC_ASSERT_LEQ("frexp", fabs(n[frexp_idx] - n_val[frexp_idx]), FLT_EPSILON);
@@ -1649,16 +1650,16 @@ static void tc_libc_math_frexp(void)
  */
 static void tc_libc_math_frexpf(void)
 {
-	const float in_val[3] = { 8.0, 2.3, -10.0 };
-	const float sol_val[3] = { 1, 0.575, 0 };
-	const float n_val[3] = { 3, 2, 2147483647 };
-	float ret_val[3];
-	int n[3];
+	const float in_val[] = { 8.0, 2.3, -10.0 };
+	const float sol_val[] = { 1, 0.575, 0 };
+	const float n_val[] = { 3, 2, 2147483647 };
+	float ret_val[SIZE(sol_val, float)];
+	int n[SIZE(in_val, float)];
 	int frexpf_idx;
 
 	/* Breaks the floating point number x into its binary significand and an integral exponent for 2 */
 
-	for (frexpf_idx = 0; frexpf_idx < 3; frexpf_idx++) {
+	for (frexpf_idx = 0; frexpf_idx < SIZE(in_val, float); frexpf_idx++) {
 		ret_val[frexpf_idx] = frexpf(in_val[frexpf_idx], &n[frexpf_idx]);
 		TC_ASSERT_LEQ("frexp", fabsf(sol_val[frexpf_idx] - ret_val[frexpf_idx]), FLT_EPSILON);
 		TC_ASSERT_LEQ("frexp", fabsf(n[frexpf_idx] - n_val[frexpf_idx]), FLT_EPSILON);
@@ -1678,16 +1679,16 @@ static void tc_libc_math_frexpf(void)
  */
 static void tc_libc_math_frexpl(void)
 {
-	const long double in_val[3] = { 8.0, 2.3, -10.0 };
-	const long double sol_val[3] = { 0.5, 0.575, -10 };
-	const long double n_val[3] = { 4, 2, 0 };
-	long double ret_val[3];
-	int n[3];
+	const long double in_val[] = { 8.0, 2.3, -10.0 };
+	const long double sol_val[] = { 0.5, 0.575, -10 };
+	const long double n_val[] = { 4, 2, 0 };
+	long double ret_val[SIZE(sol_val, long double)];
+	int n[SIZE(in_val, long double)];
 	int frexpl_idx;
 
 	/* Breaks the floating point number x into its binary significand and an integral exponent for 2 */
 
-	for (frexpl_idx = 0; frexpl_idx < 3; frexpl_idx++) {
+	for (frexpl_idx = 0; frexpl_idx < SIZE(in_val, long double); frexpl_idx++) {
 		ret_val[frexpl_idx] = frexpl(in_val[frexpl_idx], &n[frexpl_idx]);
 		TC_ASSERT_LEQ("frexp", fabsl(sol_val[frexpl_idx] - ret_val[frexpl_idx]), FLT_EPSILON);
 		TC_ASSERT_LEQ("frexp", fabsl(n[frexpl_idx] - n_val[frexpl_idx]), FLT_EPSILON);
@@ -1707,13 +1708,13 @@ static void tc_libc_math_frexpl(void)
  */
 static void tc_libc_math_hypot(void)
 {
-	const double in_val1[10] = { ZERO, -ZERO, VAL1, -VAL1, VAL2, -VAL2, INFINITY, -INFINITY, NAN, VAL1 };
-	const double in_val2[10] = { -INFINITY, INFINITY, -VAL2, VAL2, -VAL1, VAL1, -ZERO, ZERO, INFINITY, NAN };
-	const double sol_val[10] = { INFINITY, INFINITY, 5035177455121576.0, 5035177455121576.0, 5035177455121576.0, 5035177455121576.0, INFINITY, INFINITY, INFINITY, NAN };
-	double ret_val[10];
+	const double in_val1[] = { ZERO, -ZERO, VAL1, -VAL1, VAL2, -VAL2, INFINITY, -INFINITY, NAN, VAL1 };
+	const double in_val2[] = { -INFINITY, INFINITY, -VAL2, VAL2, -VAL1, VAL1, -ZERO, ZERO, INFINITY, NAN };
+	const double sol_val[] = { INFINITY, INFINITY, 5035177455121576.0, 5035177455121576.0, 5035177455121576.0, 5035177455121576.0, INFINITY, INFINITY, INFINITY, NAN };
+	double ret_val[SIZE(sol_val, double)];
 	int hypot_idx;
 
-	for (hypot_idx = 0; hypot_idx < 10; hypot_idx++) {
+	for (hypot_idx = 0; hypot_idx < SIZE(sol_val, double); hypot_idx++) {
 		ret_val[hypot_idx] = hypot(in_val1[hypot_idx], in_val2[hypot_idx]);
 		if (!(isnan(sol_val[hypot_idx]) && isnan(ret_val[hypot_idx]))) {
 			TC_ASSERT_LEQ("hypot", fabs(sol_val[hypot_idx] - ret_val[hypot_idx]), FLT_EPSILON);
@@ -1736,13 +1737,13 @@ static void tc_libc_math_hypot(void)
  */
 static void tc_libc_math_hypotf(void)
 {
-	const float in_val1[11] = { ZERO, -ZERO, VAL1, -VAL1, VAL2, -VAL2, INFINITY, -INFINITY, NAN, VAL1, 0x5fe };
-	const float in_val2[11] = { -INFINITY, INFINITY, -VAL2, VAL2, -VAL1, VAL1, -ZERO, ZERO, INFINITY, NAN, 0x1p-700 };
-	const float sol_val[11] = { INFINITY, INFINITY, 5035177455121576.0, 5035177455121576.0, 5035177455121576.0, 5035177455121576.0, INFINITY, INFINITY, INFINITY, NAN, 0x5fe };
-	float ret_val[11];
+	const float in_val1[] = { ZERO, -ZERO, VAL1, -VAL1, VAL2, -VAL2, INFINITY, -INFINITY, NAN, VAL1, 0x5fe };
+	const float in_val2[] = { -INFINITY, INFINITY, -VAL2, VAL2, -VAL1, VAL1, -ZERO, ZERO, INFINITY, NAN, 0x1p-700 };
+	const float sol_val[] = { INFINITY, INFINITY, 5035177455121576.0, 5035177455121576.0, 5035177455121576.0, 5035177455121576.0, INFINITY, INFINITY, INFINITY, NAN, 0x5fe };
+	float ret_val[SIZE(sol_val, float)];
 	int hypotf_idx;
 
-	for (hypotf_idx = 0; hypotf_idx < 11; hypotf_idx++) {
+	for (hypotf_idx = 0; hypotf_idx < SIZE(sol_val, float); hypotf_idx++) {
 		ret_val[hypotf_idx] = hypotf(in_val1[hypotf_idx], in_val2[hypotf_idx]);
 		if (!(isnan(sol_val[hypotf_idx]) && isnan(ret_val[hypotf_idx]))) {
 			TC_ASSERT_LEQ("hypotf", fabsf(sol_val[hypotf_idx] - ret_val[hypotf_idx]), FLT_EPSILON);
@@ -1765,13 +1766,13 @@ static void tc_libc_math_hypotf(void)
  */
 static void tc_libc_math_hypotl(void)
 {
-	const long double in_val1[11] = { ZERO, -ZERO, VAL1, -VAL1, VAL2, -VAL2, INFINITY, -INFINITY, NAN, VAL1, 0x5fe };
-	const long double in_val2[11] = { -INFINITY, INFINITY, -VAL2, VAL2, -VAL1, VAL1, -ZERO, ZERO, INFINITY, NAN, 0x1p-700 };
-	const long double sol_val[11] = { INFINITY, INFINITY, 5035177455121576.0, 5035177455121576.0, 5035177455121576.0, 5035177455121576.0, INFINITY, INFINITY, INFINITY, NAN, 0x5fe };
-	long double ret_val[11];
+	const long double in_val1[] = { ZERO, -ZERO, VAL1, -VAL1, VAL2, -VAL2, INFINITY, -INFINITY, NAN, VAL1, 0x5fe };
+	const long double in_val2[] = { -INFINITY, INFINITY, -VAL2, VAL2, -VAL1, VAL1, -ZERO, ZERO, INFINITY, NAN, 0x1p-700 };
+	const long double sol_val[] = { INFINITY, INFINITY, 5035177455121576.0, 5035177455121576.0, 5035177455121576.0, 5035177455121576.0, INFINITY, INFINITY, INFINITY, NAN, 0x5fe };
+	long double ret_val[SIZE(sol_val, long double)];
 	int hypotl_idx;
 
-	for (hypotl_idx = 0; hypotl_idx < 11; hypotl_idx++) {
+	for (hypotl_idx = 0; hypotl_idx < SIZE(sol_val, long double); hypotl_idx++) {
 		ret_val[hypotl_idx] = hypotl(in_val1[hypotl_idx], in_val2[hypotl_idx]);
 		if (!(isnan(sol_val[hypotl_idx]) && isnan(ret_val[hypotl_idx]))) {
 			TC_ASSERT_LEQ("hypotl", fabsl(sol_val[hypotl_idx] - ret_val[hypotl_idx]), FLT_EPSILON);
@@ -1792,12 +1793,12 @@ static void tc_libc_math_hypotl(void)
  */
 static void tc_libc_math_j0(void)
 {
-	const double in_val[8] = { ZERO, VAL1, -VAL1, VAL2, -VAL2, INFINITY, -INFINITY, NAN };
-	const double sol_val[8] = { 1.0, ZERO, ZERO, ZERO, ZERO, ZERO, ZERO, NAN };
-	double ret_val[8] = { ZERO };
+	const double in_val[] = { ZERO, VAL1, -VAL1, VAL2, -VAL2, INFINITY, -INFINITY, NAN };
+	const double sol_val[] = { 1.0, ZERO, ZERO, ZERO, ZERO, ZERO, ZERO, NAN };
+	double ret_val[SIZE(sol_val, double)] = { ZERO };
 	int j0_idx;
 
-	for (j0_idx = 0; j0_idx < 8; j0_idx++) {
+	for (j0_idx = 0; j0_idx < SIZE(in_val, double); j0_idx++) {
 		ret_val[j0_idx] = j0(in_val[j0_idx]);
 		if (!(isnan(sol_val[j0_idx]) && isnan(ret_val[j0_idx]))) {
 			TC_ASSERT_LEQ("j0", fabs(sol_val[j0_idx] - ret_val[j0_idx]), FLT_EPSILON);
@@ -1818,12 +1819,12 @@ static void tc_libc_math_j0(void)
  */
 static void tc_libc_math_j0f(void)
 {
-	const float in_val[8] = { ZERO, VAL1, -VAL1, VAL2, -VAL2, INFINITY, -INFINITY, NAN };
-	const float sol_val[8] = { 1.0, ZERO, ZERO, ZERO, ZERO, ZERO, ZERO, NAN };
-	float ret_val[8] = { ZERO };
+	const float in_val[] = { ZERO, VAL1, -VAL1, VAL2, -VAL2, INFINITY, -INFINITY, NAN };
+	const float sol_val[] = { 1.0, ZERO, ZERO, ZERO, ZERO, ZERO, ZERO, NAN };
+	float ret_val[SIZE(sol_val, float)] = { ZERO };
 	int j0f_idx;
 
-	for (j0f_idx = 0; j0f_idx < 8; j0f_idx++) {
+	for (j0f_idx = 0; j0f_idx < SIZE(in_val, float); j0f_idx++) {
 		ret_val[j0f_idx] = j0f(in_val[j0f_idx]);
 		if (!(isnan(sol_val[j0f_idx]) && isnan(ret_val[j0f_idx]))) {
 			TC_ASSERT_LEQ("j0f", fabsf(sol_val[j0f_idx] - ret_val[j0f_idx]), FLT_EPSILON);
@@ -1844,12 +1845,12 @@ static void tc_libc_math_j0f(void)
  */
 static void tc_libc_math_j1(void)
 {
-	const double in_val[8] = { ZERO, VAL1, -VAL1, VAL2, -VAL2, INFINITY, -INFINITY, NAN };
-	const double sol_val[8] = { ZERO, ZERO, -ZERO, ZERO, -ZERO, ZERO, -ZERO, NAN };
-	double ret_val[8] = { ZERO };
+	const double in_val[] = { ZERO, VAL1, -VAL1, VAL2, -VAL2, INFINITY, -INFINITY, NAN };
+	const double sol_val[] = { ZERO, ZERO, -ZERO, ZERO, -ZERO, ZERO, -ZERO, NAN };
+	double ret_val[SIZE(sol_val, double)] = { ZERO };
 	int j1_idx;
 
-	for (j1_idx = 0; j1_idx < 8; j1_idx++) {
+	for (j1_idx = 0; j1_idx < SIZE(in_val, double); j1_idx++) {
 		ret_val[j1_idx] = j1(in_val[j1_idx]);
 		if (!(isnan(sol_val[j1_idx]) && isnan(ret_val[j1_idx]))) {
 			TC_ASSERT_LEQ("j1", fabs(sol_val[j1_idx] - ret_val[j1_idx]), FLT_EPSILON);
@@ -1870,12 +1871,12 @@ static void tc_libc_math_j1(void)
  */
 static void tc_libc_math_j1f(void)
 {
-	const float in_val[8] = { ZERO, VAL1, -VAL1, VAL2, -VAL2, INFINITY, -INFINITY, NAN };
-	const float sol_val[8] = { ZERO, ZERO, -ZERO, ZERO, -ZERO, ZERO, -ZERO, NAN };
-	float ret_val[8] = { ZERO };
+	const float in_val[] = { ZERO, VAL1, -VAL1, VAL2, -VAL2, INFINITY, -INFINITY, NAN };
+	const float sol_val[] = { ZERO, ZERO, -ZERO, ZERO, -ZERO, ZERO, -ZERO, NAN };
+	float ret_val[SIZE(sol_val, float)] = { ZERO };
 	int j1f_idx;
 
-	for (j1f_idx = 0; j1f_idx < 8; j1f_idx++) {
+	for (j1f_idx = 0; j1f_idx < SIZE(in_val, float); j1f_idx++) {
 		ret_val[j1f_idx] = j1f(in_val[j1f_idx]);
 		if (!(isnan(sol_val[j1f_idx]) && isnan(ret_val[j1f_idx]))) {
 			TC_ASSERT_LEQ("j1f", fabsf(sol_val[j1f_idx] - ret_val[j1f_idx]), FLT_EPSILON);
@@ -1896,13 +1897,13 @@ static void tc_libc_math_j1f(void)
  */
 static void tc_libc_math_jn(void)
 {
-	const double in_val[8] = { ZERO, VAL1, -VAL1, VAL2, -VAL2, INFINITY, -INFINITY, NAN };
-	const double sol_val[8] = { ZERO, -ZERO, -ZERO, -ZERO, -ZERO, ZERO, ZERO, NAN };
-	double ret_val[8];
+	const double in_val[] = { ZERO, VAL1, -VAL1, VAL2, -VAL2, INFINITY, -INFINITY, NAN };
+	const double sol_val[] = { ZERO, -ZERO, -ZERO, -ZERO, -ZERO, ZERO, ZERO, NAN };
+	double ret_val[SIZE(sol_val, double)];
 	int jn_idx;
 	int order = 2;
 
-	for (jn_idx = 0; jn_idx < 8; jn_idx++) {
+	for (jn_idx = 0; jn_idx < SIZE(in_val, double); jn_idx++) {
 		ret_val[jn_idx] = jn(order, in_val[jn_idx]);
 		if (!(isnan(sol_val[jn_idx]) && isnan(ret_val[jn_idx]))) {
 			TC_ASSERT_LEQ("jn", fabs(sol_val[jn_idx] - ret_val[jn_idx]), FLT_EPSILON);
@@ -1923,13 +1924,13 @@ static void tc_libc_math_jn(void)
  */
 static void tc_libc_math_jnf(void)
 {
-	const float in_val[8] = { ZERO, VAL1, -VAL1, VAL2, -VAL2, INFINITY, -INFINITY, NAN };
-	const float sol_val[8] = { ZERO, -ZERO, -ZERO, -ZERO, -ZERO, ZERO, ZERO, NAN };
-	float ret_val[8];
+	const float in_val[] = { ZERO, VAL1, -VAL1, VAL2, -VAL2, INFINITY, -INFINITY, NAN };
+	const float sol_val[] = { ZERO, -ZERO, -ZERO, -ZERO, -ZERO, ZERO, ZERO, NAN };
+	float ret_val[SIZE(sol_val, float)];
 	int jnf_idx;
 	int order = 2;
 
-	for (jnf_idx = 0; jnf_idx < 8; jnf_idx++) {
+	for (jnf_idx = 0; jnf_idx < SIZE(in_val, float); jnf_idx++) {
 		ret_val[jnf_idx] = jnf(order, in_val[jnf_idx]);
 		if (!(isnan(sol_val[jnf_idx]) && isnan(ret_val[jnf_idx]))) {
 			TC_ASSERT_LEQ("jnf", fabsf(sol_val[jnf_idx] - ret_val[jnf_idx]), FLT_EPSILON);
@@ -1950,15 +1951,15 @@ static void tc_libc_math_jnf(void)
  */
 static void tc_libc_math_ldexp(void)
 {
-	const double in_val[3] = { 0.95, 0.0, -10.0 };
-	const double sol_val[3] = { 15.2, 0, -10240 };
-	double ret_val[3];
-	int n[3] = { 4, -2, 10 };
+	const double in_val[] = { 0.95, 0.0, -10.0 };
+	const double sol_val[] = { 15.2, 0, -10240 };
+	double ret_val[SIZE(sol_val, double)];
+	int n[] = { 4, -2, 10 };
 	int ldexp_idx;
 
 	/* Breaks the floating point number x into its binary significand and an integral exponent for 2 */
 
-	for (ldexp_idx = 0; ldexp_idx < 3; ldexp_idx++) {
+	for (ldexp_idx = 0; ldexp_idx < SIZE(in_val, double); ldexp_idx++) {
 		ret_val[ldexp_idx] = ldexp(in_val[ldexp_idx], n[ldexp_idx]);
 		TC_ASSERT_LEQ("ldexp", fabs(sol_val[ldexp_idx] - ret_val[ldexp_idx]), FLT_EPSILON);
 	}
@@ -1977,15 +1978,15 @@ static void tc_libc_math_ldexp(void)
  */
 static void tc_libc_math_ldexpf(void)
 {
-	const float in_val[3] = { 0.95, 0, -10 };
-	const float sol_val[3] = { 15.1999998092651, 0, -10239.9990234375000 };
-	float ret_val[3];
-	int n[3] = { 4, -2, 10 };
+	const float in_val[] = { 0.95, 0, -10 };
+	const float sol_val[] = { 15.1999998092651, 0, -10239.9990234375000 };
+	float ret_val[SIZE(sol_val, float)];
+	int n[] = { 4, -2, 10 };
 	int ldexpf_idx;
 
 	/* Breaks the floating point number x into its binary significand and an integral exponent for 2 */
 
-	for (ldexpf_idx = 0; ldexpf_idx < 3; ldexpf_idx++) {
+	for (ldexpf_idx = 0; ldexpf_idx < SIZE(in_val, float); ldexpf_idx++) {
 		ret_val[ldexpf_idx] = ldexpf(in_val[ldexpf_idx], n[ldexpf_idx]);
 		TC_ASSERT_LEQ("ldexpf", fabsf(sol_val[ldexpf_idx] - ret_val[ldexpf_idx]), FLT_EPSILON);
 	}
@@ -2004,15 +2005,15 @@ static void tc_libc_math_ldexpf(void)
  */
 static void tc_libc_math_ldexpl(void)
 {
-	const long double in_val[3] = { 0.95, 0.0, -10.0 };
-	const long double sol_val[3] = { 15.2, 0, -10240 };
-	long double ret_val[3];
-	int n[3] = { 4, -2, 10 };
+	const long double in_val[] = { 0.95, 0.0, -10.0 };
+	const long double sol_val[] = { 15.2, 0, -10240 };
+	long double ret_val[SIZE(sol_val, long double)];
+	int n[] = { 4, -2, 10 };
 	int ldexpl_idx;
 
 	/* Breaks the floating point number x into its binary significand and an integral exponent for 2 */
 
-	for (ldexpl_idx = 0; ldexpl_idx < 3; ldexpl_idx++) {
+	for (ldexpl_idx = 0; ldexpl_idx < SIZE(in_val, long double); ldexpl_idx++) {
 		ret_val[ldexpl_idx] = ldexpl(in_val[ldexpl_idx], n[ldexpl_idx]);
 		TC_ASSERT_LEQ("ldexpl", fabsl(sol_val[ldexpl_idx] - ret_val[ldexpl_idx]), FLT_EPSILON);
 	}
@@ -2031,14 +2032,14 @@ static void tc_libc_math_ldexpl(void)
  */
 static void tc_libc_math_log2(void)
 {
-	const double in_val[3] = { 1024, 5.5, -10.0 };
-	const double sol_val[3] = { 10.0, 2.4594316186373, NAN };
-	double ret_val[3];
+	const double in_val[] = { 1024, 5.5, -10.0 };
+	const double sol_val[] = { 10.0, 2.4594316186373, NAN };
+	double ret_val[SIZE(sol_val, double)];
 	int log2_idx;
 
 	/* Returns the binary (base-2) logarithm of x */
 
-	for (log2_idx = 0; log2_idx < 3; log2_idx++) {
+	for (log2_idx = 0; log2_idx < SIZE(in_val, double); log2_idx++) {
 		ret_val[log2_idx] = log2(in_val[log2_idx]);
 		TC_ASSERT_LEQ("log2", fabs(sol_val[log2_idx] - ret_val[log2_idx]), FLT_EPSILON);
 	}
@@ -2057,14 +2058,14 @@ static void tc_libc_math_log2(void)
  */
 static void tc_libc_math_log2f(void)
 {
-	const float in_val[3] = { 1024, 5.5, -10.0 };
-	const float sol_val[3] = { 10.0, 2.4594316186373, NAN };
-	float ret_val[3];
+	const float in_val[] = { 1024, 5.5, -10.0 };
+	const float sol_val[] = { 10.0, 2.4594316186373, NAN };
+	float ret_val[SIZE(sol_val, float)];
 	int log2f_idx;
 
 	/* Returns the binary (base-2) logarithm of x */
 
-	for (log2f_idx = 0; log2f_idx < 3; log2f_idx++) {
+	for (log2f_idx = 0; log2f_idx < SIZE(in_val, float); log2f_idx++) {
 		ret_val[log2f_idx] = log2f(in_val[log2f_idx]);
 		TC_ASSERT_LEQ("log2f", fabsf(sol_val[log2f_idx] - ret_val[log2f_idx]), FLT_EPSILON);
 	}
@@ -2083,14 +2084,14 @@ static void tc_libc_math_log2f(void)
  */
 static void tc_libc_math_log2l(void)
 {
-	const long double in_val[3] = { 1024, 5.5, -10.0 };
-	const long double sol_val[3] = { 10.0, 2.4594316186373, NAN };
-	long double ret_val[3];
+	const long double in_val[] = { 1024, 5.5, -10.0 };
+	const long double sol_val[] = { 10.0, 2.4594316186373, NAN };
+	long double ret_val[SIZE(sol_val, long double)];
 	int log2l_idx;
 
 	/* Returns the binary (base-2) logarithm of x */
 
-	for (log2l_idx = 0; log2l_idx < 3; log2l_idx++) {
+	for (log2l_idx = 0; log2l_idx < SIZE(in_val, long double); log2l_idx++) {
 		ret_val[log2l_idx] = log2l(in_val[log2l_idx]);
 		TC_ASSERT_LEQ("log2l", fabsl(sol_val[log2l_idx] - ret_val[log2l_idx]), FLT_EPSILON);
 	}
@@ -2109,13 +2110,13 @@ static void tc_libc_math_log2l(void)
  */
 static void tc_libc_math_nextafter(void)
 {
-	const double in_val1[7] = { VAL1, VAL1, ZERO, -VAL1, -VAL2, VAL1, NAN };
-	const double in_val2[7] = { VAL1, VAL2, VAL1, -VAL2, ZERO, NAN, VAL2 };
-	const double sol_val[7] = { VAL1, 2251799813685249.0, ZERO, -2251799813685249.0, -4503599627370495.5, NAN, NAN };
-	double ret_val[7];
+	const double in_val1[] = { VAL1, VAL1, ZERO, -VAL1, -VAL2, VAL1, NAN };
+	const double in_val2[] = { VAL1, VAL2, VAL1, -VAL2, ZERO, NAN, VAL2 };
+	const double sol_val[] = { VAL1, 2251799813685249.0, ZERO, -2251799813685249.0, -4503599627370495.5, NAN, NAN };
+	double ret_val[SIZE(sol_val, double)];
 	int nextafter_idx;
 
-	for (nextafter_idx = 0; nextafter_idx < 7; nextafter_idx++) {
+	for (nextafter_idx = 0; nextafter_idx < SIZE(sol_val, double); nextafter_idx++) {
 		ret_val[nextafter_idx] = nextafter(in_val1[nextafter_idx], in_val2[nextafter_idx]);
 		if (!(isnan(sol_val[nextafter_idx]) && isnan(ret_val[nextafter_idx]))) {
 			TC_ASSERT_LEQ("nextafter", fabs(sol_val[nextafter_idx] - ret_val[nextafter_idx]), FLT_EPSILON);
@@ -2138,13 +2139,13 @@ static void tc_libc_math_nextafter(void)
  */
 static void tc_libc_math_nextafterf(void)
 {
-	const float in_val1[7] = { VAL1, VAL1, ZERO, -VAL1, -VAL2 , VAL1, NAN };
-	const float in_val2[7] = { VAL1, VAL2, VAL1, -VAL2, ZERO, NAN, VAL2 };
-	const float sol_val[7] = { 2251799813685248.0, 2251800082120704.0, ZERO, -2251800082120704.0, -4503599358935040.0, NAN, NAN };
-	float ret_val[7];
+	const float in_val1[] = { VAL1, VAL1, ZERO, -VAL1, -VAL2 , VAL1, NAN };
+	const float in_val2[] = { VAL1, VAL2, VAL1, -VAL2, ZERO, NAN, VAL2 };
+	const float sol_val[] = { 2251799813685248.0, 2251800082120704.0, ZERO, -2251800082120704.0, -4503599358935040.0, NAN, NAN };
+	float ret_val[SIZE(sol_val, float)];
 	int nextafterf_idx;
 
-	for (nextafterf_idx = 0; nextafterf_idx < 7; nextafterf_idx++) {
+	for (nextafterf_idx = 0; nextafterf_idx < SIZE(sol_val, float); nextafterf_idx++) {
 		ret_val[nextafterf_idx] = nextafterf(in_val1[nextafterf_idx], in_val2[nextafterf_idx]);
 		if (!(isnan(sol_val[nextafterf_idx]) && isnan(ret_val[nextafterf_idx]))) {
 			TC_ASSERT_LEQ("nextafterf", fabsf(sol_val[nextafterf_idx] - ret_val[nextafterf_idx]), FLT_EPSILON);
@@ -2167,13 +2168,13 @@ static void tc_libc_math_nextafterf(void)
  */
 static void tc_libc_math_nextafterl(void)
 {
-	const long double in_val1[7] = { VAL1, VAL1, ZERO, -VAL1, -VAL2 , VAL1, NAN };
-	const long double in_val2[7] = { VAL1, VAL2, VAL1, -VAL2, ZERO, NAN, VAL2 };
-	const long double sol_val[7] = { VAL1, 2251799813685249.0, ZERO, -2251799813685249.0, -4503599627370495.5, NAN, NAN };
-	long double ret_val[7];
+	const long double in_val1[] = { VAL1, VAL1, ZERO, -VAL1, -VAL2 , VAL1, NAN };
+	const long double in_val2[] = { VAL1, VAL2, VAL1, -VAL2, ZERO, NAN, VAL2 };
+	const long double sol_val[] = { VAL1, 2251799813685249.0, ZERO, -2251799813685249.0, -4503599627370495.5, NAN, NAN };
+	long double ret_val[SIZE(sol_val, long double)];
 	int nextafterl_idx;
 
-	for (nextafterl_idx = 0; nextafterl_idx < 7; nextafterl_idx++) {
+	for (nextafterl_idx = 0; nextafterl_idx < SIZE(sol_val, long double); nextafterl_idx++) {
 		ret_val[nextafterl_idx] = nextafterl(in_val1[nextafterl_idx], in_val2[nextafterl_idx]);
 		if (!(isnan(sol_val[nextafterl_idx]) && isnan(ret_val[nextafterl_idx]))) {
 			TC_ASSERT_LEQ("nextafterl", fabsl(sol_val[nextafterl_idx] - ret_val[nextafterl_idx]), FLT_EPSILON);
@@ -2194,13 +2195,13 @@ static void tc_libc_math_nextafterl(void)
  */
 static void tc_libc_math_nexttoward(void)
 {
-	const double in_val1[7] = { VAL1, VAL1, ZERO, -VAL1, -VAL2, VAL1, NAN };
-	const long double in_val2[7] = { VAL1, VAL2, VAL1, -VAL2, ZERO, NAN, VAL2 };
-	const double sol_val[7] = { VAL1, 2251799813685249.0, ZERO, -2251799813685249.0, -4503599627370495.5, NAN, NAN };
-	double ret_val[7];
+	const double in_val1[] = { VAL1, VAL1, ZERO, -VAL1, -VAL2, VAL1, NAN };
+	const long double in_val2[] = { VAL1, VAL2, VAL1, -VAL2, ZERO, NAN, VAL2 };
+	const double sol_val[] = { VAL1, 2251799813685249.0, ZERO, -2251799813685249.0, -4503599627370495.5, NAN, NAN };
+	double ret_val[SIZE(sol_val, double)];
 	int nexttoward_idx;
 
-	for (nexttoward_idx = 0; nexttoward_idx < 7; nexttoward_idx++) {
+	for (nexttoward_idx = 0; nexttoward_idx < SIZE(sol_val, double); nexttoward_idx++) {
 		ret_val[nexttoward_idx] = nexttoward(in_val1[nexttoward_idx], in_val2[nexttoward_idx]);
 		if (!(isnan(sol_val[nexttoward_idx]) && isnan(ret_val[nexttoward_idx]))) {
 			TC_ASSERT_LEQ("nexttoward", fabs(sol_val[nexttoward_idx] - ret_val[nexttoward_idx]), FLT_EPSILON);
@@ -2223,13 +2224,13 @@ static void tc_libc_math_nexttoward(void)
  */
 static void tc_libc_math_nexttowardf(void)
 {
-	const float in_val1[7] = { VAL1, VAL1, ZERO, -VAL1, -VAL2 , VAL1, NAN };
-	const long double in_val2[7] = { VAL1, VAL2, VAL1, -VAL2, ZERO, NAN, VAL2 };
-	const float sol_val[7] = { 2251800082120704.0, 2251800082120704.0, ZERO, -2251800082120704.0, -4503599358935040.0, NAN, NAN };
-	float ret_val[7];
+	const float in_val1[] = { VAL1, VAL1, ZERO, -VAL1, -VAL2 , VAL1, NAN };
+	const long double in_val2[] = { VAL1, VAL2, VAL1, -VAL2, ZERO, NAN, VAL2 };
+	const float sol_val[] = { 2251800082120704.0, 2251800082120704.0, ZERO, -2251800082120704.0, -4503599358935040.0, NAN, NAN };
+	float ret_val[SIZE(sol_val, float)];
 	int nexttowardf_idx;
 
-	for (nexttowardf_idx = 0; nexttowardf_idx < 7; nexttowardf_idx++) {
+	for (nexttowardf_idx = 0; nexttowardf_idx < SIZE(sol_val, float); nexttowardf_idx++) {
 		ret_val[nexttowardf_idx] = nexttowardf(in_val1[nexttowardf_idx], in_val2[nexttowardf_idx]);
 		if (!(isnan(sol_val[nexttowardf_idx]) && isnan(ret_val[nexttowardf_idx]))) {
 			TC_ASSERT_LEQ("nexttowardf", fabsf(sol_val[nexttowardf_idx] - ret_val[nexttowardf_idx]), FLT_EPSILON);
@@ -2252,13 +2253,13 @@ static void tc_libc_math_nexttowardf(void)
  */
 static void tc_libc_math_nexttowardl(void)
 {
-	const long double in_val1[7] = { VAL1, VAL1, ZERO, -VAL1, -VAL2 , VAL1, NAN };
-	const long double in_val2[7] = { VAL1, VAL2, VAL1, -VAL2, ZERO, NAN, VAL2 };
-	const long double sol_val[7] = { VAL1, 2251799813685249.0, ZERO, -2251799813685249.0, -4503599627370495.5, NAN, NAN };
-	long double ret_val[7];
+	const long double in_val1[] = { VAL1, VAL1, ZERO, -VAL1, -VAL2 , VAL1, NAN };
+	const long double in_val2[] = { VAL1, VAL2, VAL1, -VAL2, ZERO, NAN, VAL2 };
+	const long double sol_val[] = { VAL1, 2251799813685249.0, ZERO, -2251799813685249.0, -4503599627370495.5, NAN, NAN };
+	long double ret_val[SIZE(sol_val, long double)];
 	int nexttowardl_idx;
 
-	for (nexttowardl_idx = 0; nexttowardl_idx < 7; nexttowardl_idx++) {
+	for (nexttowardl_idx = 0; nexttowardl_idx < SIZE(sol_val, long double); nexttowardl_idx++) {
 		ret_val[nexttowardl_idx] = nexttowardl(in_val1[nexttowardl_idx], in_val2[nexttowardl_idx]);
 		if (!(isnan(sol_val[nexttowardl_idx]) && isnan(ret_val[nexttowardl_idx]))) {
 			TC_ASSERT_LEQ("nexttowardl", fabsl(sol_val[nexttowardl_idx] - ret_val[nexttowardl_idx]), FLT_EPSILON);
@@ -2279,12 +2280,12 @@ static void tc_libc_math_nexttowardl(void)
  */
 static void tc_libc_math_pow(void)
 {
-	const double in_val[13][2] = { { 2, 2 }, { 2, 0.5 }, { 2, -2 }, { 2, -0.5 }, { 1, NAN }, { ZERO, 0.5 }, { ZERO, -2 }, { -ZERO, -1 }, { -ZERO, -2 }, { -2, -1 }, { -2, -2 }, { 0.5, INFINITY }, { 2, INFINITY } };
-	const double sol_val[13] = { 4.0, M_SQRT2, 0.25, M_SQRT1_2, 1, ZERO, INFINITY, -INFINITY, INFINITY, -0.5, 0.25, ZERO, INFINITY };
-	double ret_val[13];
+	const double in_val[][2] = { { 2, 2 }, { 2, 0.5 }, { 2, -2 }, { 2, -0.5 }, { 1, NAN }, { ZERO, 0.5 }, { ZERO, -2 }, { -ZERO, -1 }, { -ZERO, -2 }, { -2, -1 }, { -2, -2 }, { 0.5, INFINITY }, { 2, INFINITY } };
+	const double sol_val[] = { 4.0, M_SQRT2, 0.25, M_SQRT1_2, 1, ZERO, INFINITY, -INFINITY, INFINITY, -0.5, 0.25, ZERO, INFINITY };
+	double ret_val[SIZE(sol_val, double)];
 	int pow_idx;
 
-	for (pow_idx = 0; pow_idx < 13; pow_idx++) {
+	for (pow_idx = 0; pow_idx < SIZE(sol_val, double); pow_idx++) {
 		ret_val[pow_idx] = pow(in_val[pow_idx][0], in_val[pow_idx][1]);
 		if (isinf(sol_val[pow_idx])) {
 			TC_ASSERT_EQ("pow", sol_val[pow_idx], ret_val[pow_idx]);
@@ -2307,13 +2308,13 @@ static void tc_libc_math_pow(void)
  */
 static void tc_libc_math_remainder(void)
 {
-	const double in_val1[10] = { ZERO, -ZERO, VAL1, -VAL1, VAL2, -VAL2, INFINITY, -INFINITY, NAN, INFINITY };
-	const double in_val2[10] = { -INFINITY, INFINITY, -VAL2, VAL2, -VAL1, VAL1, -ZERO, ZERO, NAN, VAL2 };
-	const double sol_val[10] = { ZERO, -ZERO, -2251799813685247.5, 2251799813685247.5, -1.0, 1.0, -NAN, -NAN, NAN, -NAN };
-	double ret_val[10];
+	const double in_val1[] = { ZERO, -ZERO, VAL1, -VAL1, VAL2, -VAL2, INFINITY, -INFINITY, NAN, INFINITY };
+	const double in_val2[] = { -INFINITY, INFINITY, -VAL2, VAL2, -VAL1, VAL1, -ZERO, ZERO, NAN, VAL2 };
+	const double sol_val[] = { ZERO, -ZERO, -2251799813685247.5, 2251799813685247.5, -1.0, 1.0, -NAN, -NAN, NAN, -NAN };
+	double ret_val[SIZE(sol_val, double)];
 	int remainder_idx;
 
-	for (remainder_idx = 0; remainder_idx < 10; remainder_idx++) {
+	for (remainder_idx = 0; remainder_idx < SIZE(sol_val, double); remainder_idx++) {
 		ret_val[remainder_idx] = remainder(in_val1[remainder_idx], in_val2[remainder_idx]);
 		if (!(isnan(sol_val[remainder_idx]) && isnan(ret_val[remainder_idx]))) {
 			TC_ASSERT_LEQ("remainder", fabs(sol_val[remainder_idx] - ret_val[remainder_idx]), FLT_EPSILON);
@@ -2334,13 +2335,13 @@ static void tc_libc_math_remainder(void)
  */
 static void tc_libc_math_remainderf(void)
 {
-	const float in_val1[10] = { ZERO, -ZERO, VAL1, -VAL1, VAL2, -VAL2, INFINITY, -INFINITY, NAN, INFINITY };
-	const float in_val2[10] = { -INFINITY, INFINITY, -VAL2, VAL2, -VAL1, VAL1, -ZERO, ZERO, NAN, VAL2 };
-	const float sol_val[10] = { ZERO, -ZERO, 2251799813685248.0, -2251799813685248.0, ZERO, -ZERO, -NAN, -NAN, NAN, -NAN };
-	float ret_val[10];
+	const float in_val1[] = { ZERO, -ZERO, VAL1, -VAL1, VAL2, -VAL2, INFINITY, -INFINITY, NAN, INFINITY };
+	const float in_val2[] = { -INFINITY, INFINITY, -VAL2, VAL2, -VAL1, VAL1, -ZERO, ZERO, NAN, VAL2 };
+	const float sol_val[] = { ZERO, -ZERO, 2251799813685248.0, -2251799813685248.0, ZERO, -ZERO, -NAN, -NAN, NAN, -NAN };
+	float ret_val[SIZE(sol_val, float)];
 	int remainderf_idx;
 
-	for (remainderf_idx = 0; remainderf_idx < 10; remainderf_idx++) {
+	for (remainderf_idx = 0; remainderf_idx < SIZE(sol_val, float); remainderf_idx++) {
 		ret_val[remainderf_idx] = remainderf(in_val1[remainderf_idx], in_val2[remainderf_idx]);
 		if (!(isnan(sol_val[remainderf_idx]) && isnan(ret_val[remainderf_idx]))) {
 			TC_ASSERT_LEQ("remainderf", fabsf(sol_val[remainderf_idx] - ret_val[remainderf_idx]), FLT_EPSILON);
@@ -2361,13 +2362,13 @@ static void tc_libc_math_remainderf(void)
  */
 static void tc_libc_math_remainderl(void)
 {
-	const long double in_val1[10] = { ZERO, -ZERO, VAL1, -VAL1, VAL2, -VAL2, INFINITY, -INFINITY, NAN, INFINITY };
-	const long double in_val2[10] = { -INFINITY, INFINITY, -VAL2, VAL2, -VAL1, VAL1, -ZERO, ZERO, NAN, VAL2 };
-	const long double sol_val[10] = { ZERO, -ZERO, -2251799813685247.5, 2251799813685247.5, -1.0, 1.0, -NAN, -NAN, NAN, -NAN };
-	long double ret_val[10];
+	const long double in_val1[] = { ZERO, -ZERO, VAL1, -VAL1, VAL2, -VAL2, INFINITY, -INFINITY, NAN, INFINITY };
+	const long double in_val2[] = { -INFINITY, INFINITY, -VAL2, VAL2, -VAL1, VAL1, -ZERO, ZERO, NAN, VAL2 };
+	const long double sol_val[] = { ZERO, -ZERO, -2251799813685247.5, 2251799813685247.5, -1.0, 1.0, -NAN, -NAN, NAN, -NAN };
+	long double ret_val[SIZE(sol_val, long double)];
 	int remainderl_idx;
 
-	for (remainderl_idx = 0; remainderl_idx < 10; remainderl_idx++) {
+	for (remainderl_idx = 0; remainderl_idx < SIZE(sol_val, long double); remainderl_idx++) {
 		ret_val[remainderl_idx] = remainderl(in_val1[remainderl_idx], in_val2[remainderl_idx]);
 		if (!(isnan(sol_val[remainderl_idx]) && isnan(ret_val[remainderl_idx]))) {
 			TC_ASSERT_LEQ("remainderl", fabsl(sol_val[remainderl_idx] - ret_val[remainderl_idx]), FLT_EPSILON);
@@ -2379,8 +2380,8 @@ static void tc_libc_math_remainderl(void)
 
 /**
  * @fn                   :tc_libc_math_remquo
- * @brief                :Returns the floating-point remainder and stores part of quotient in argument3
- * @Scenario             :Returns the floating-point remainder and stores part of quotient in argument3
+ * @brief                :Returns the floating-point remainder and stores part of quotient in argument/
+ * @Scenario             :Returns the floating-point remainder and stores part of quotient in argument/
  * API's covered         :remquo
  * Preconditions         :None
  * Postconditions        :None
@@ -2388,15 +2389,15 @@ static void tc_libc_math_remainderl(void)
  */
 static void tc_libc_math_remquo(void)
 {
-	const double in_val1[10] = { ZERO, -ZERO, VAL1, -VAL1, VAL2, -VAL2, INFINITY, -INFINITY, NAN, INFINITY };
-	const double in_val2[10] = { -INFINITY, INFINITY, -VAL2, VAL2, -VAL1, VAL1, -ZERO, ZERO, NAN, VAL2 };
-	const double sol_val[10] = { ZERO, -ZERO, -2251799813685247.5, 2251799813685247.5, -1.0, 1.0, -NAN, -NAN, NAN, -NAN };
-	const int sol_quo[10] =  { 0, 0, -1, -1, -2, -2, 0, 0, 0, 0 };
-	double ret_val[10];
-	int ret_quo[10];
+	const double in_val1[] = { ZERO, -ZERO, VAL1, -VAL1, VAL2, -VAL2, INFINITY, -INFINITY, NAN, INFINITY };
+	const double in_val2[] = { -INFINITY, INFINITY, -VAL2, VAL2, -VAL1, VAL1, -ZERO, ZERO, NAN, VAL2 };
+	const double sol_val[] = { ZERO, -ZERO, -2251799813685247.5, 2251799813685247.5, -1.0, 1.0, -NAN, -NAN, NAN, -NAN };
+	const int sol_quo[] =  { 0, 0, -1, -1, -2, -2, 0, 0, 0, 0 };
+	double ret_val[SIZE(sol_val, double)];
+	int ret_quo[SIZE(sol_quo, int)];
 	int remquo_idx;
 
-	for (remquo_idx = 0; remquo_idx < 10; remquo_idx++) {
+	for (remquo_idx = 0; remquo_idx < SIZE(sol_val, double); remquo_idx++) {
 		ret_val[remquo_idx] = remquo(in_val1[remquo_idx], in_val2[remquo_idx], &ret_quo[remquo_idx]);
 		if (!(isnan(sol_val[remquo_idx]) && isnan(ret_val[remquo_idx]))) {
 			TC_ASSERT_LEQ("remquo", fabs(sol_val[remquo_idx] - ret_val[remquo_idx]), FLT_EPSILON);
@@ -2409,8 +2410,8 @@ static void tc_libc_math_remquo(void)
 
 /**
  * @fn                   :tc_libc_math_remquof
- * @brief                :Returns the floating-point remainder and stores part of quotient in argument3
- * @Scenario             :Returns the floating-point remainder and stores part of quotient in argument3
+ * @brief                :Returns the floating-point remainder and stores part of quotient in argument/
+ * @Scenario             :Returns the floating-point remainder and stores part of quotient in argument/
  * API's covered         :remquof
  * Preconditions         :None
  * Postconditions        :None
@@ -2418,15 +2419,15 @@ static void tc_libc_math_remquo(void)
  */
 static void tc_libc_math_remquof(void)
 {
-	const float in_val1[10] = { ZERO, -ZERO, VAL1, -VAL1, VAL2, -VAL2, INFINITY, -INFINITY, NAN, INFINITY };
-	const float in_val2[10] = { -INFINITY, INFINITY, -VAL2, VAL2, -VAL1, VAL1, -ZERO, ZERO, NAN, VAL2 };
-	const float sol_val[10] = { ZERO, -ZERO, 2251799813685248.0, -2251799813685248.0, ZERO, -ZERO, -NAN, -NAN, NAN, -NAN };
-	const int sol_quo[10] =  { 0, 0, 0, 0, -2, -2, 0, 0, 0, 0 };
-	float ret_val[10];
-	int ret_quo[10] = { 0 };
+	const float in_val1[] = { ZERO, -ZERO, VAL1, -VAL1, VAL2, -VAL2, INFINITY, -INFINITY, NAN, INFINITY };
+	const float in_val2[] = { -INFINITY, INFINITY, -VAL2, VAL2, -VAL1, VAL1, -ZERO, ZERO, NAN, VAL2 };
+	const float sol_val[] = { ZERO, -ZERO, 2251799813685248.0, -2251799813685248.0, ZERO, -ZERO, -NAN, -NAN, NAN, -NAN };
+	const int sol_quo[] =  { 0, 0, 0, 0, -2, -2, 0, 0, 0, 0 };
+	float ret_val[SIZE(sol_val, float)];
+	int ret_quo[SIZE(sol_quo, int)] = { 0 };
 	int remquof_idx;
 
-	for (remquof_idx = 0; remquof_idx < 10; remquof_idx++) {
+	for (remquof_idx = 0; remquof_idx < SIZE(sol_val, float); remquof_idx++) {
 		ret_val[remquof_idx] = remquof(in_val1[remquof_idx], in_val2[remquof_idx], &ret_quo[remquof_idx]);
 		if (!(isnan(sol_val[remquof_idx]) && isnan(ret_val[remquof_idx]))) {
 			TC_ASSERT_LEQ("remquof", fabsf(sol_val[remquof_idx] - ret_val[remquof_idx]), FLT_EPSILON);
@@ -2439,8 +2440,8 @@ static void tc_libc_math_remquof(void)
 
 /**
  * @fn                   :tc_libc_math_remquol
- * @brief                :Returns the floating-point remainder and stores part of quotient in argument3
- * @Scenario             :Returns the floating-point remainder and stores part of quotient in argument3
+ * @brief                :Returns the floating-point remainder and stores part of quotient in argument/
+ * @Scenario             :Returns the floating-point remainder and stores part of quotient in argument/
  * API's covered         :remquol
  * Preconditions         :None
  * Postconditions        :None
@@ -2448,15 +2449,15 @@ static void tc_libc_math_remquof(void)
  */
 static void tc_libc_math_remquol(void)
 {
-	const long double in_val1[10] = { ZERO, -ZERO, VAL1, -VAL1, VAL2, -VAL2, INFINITY, -INFINITY, NAN, INFINITY };
-	const long double in_val2[10] = { -INFINITY, INFINITY, -VAL2, VAL2, -VAL1, VAL1, -ZERO, ZERO, NAN, VAL2 };
-	const long double sol_val[10] = { ZERO, -ZERO, -2251799813685247.5, 2251799813685247.5, -1.0, 1.0, -NAN, -NAN, NAN, -NAN };
-	const int sol_quo[10] =  { 0, 0, -1, -1, -2, -2, 0, 0, 0, 0 };
-	long double ret_val[10];
-	int ret_quo[10] = { 0 };
+	const long double in_val1[] = { ZERO, -ZERO, VAL1, -VAL1, VAL2, -VAL2, INFINITY, -INFINITY, NAN, INFINITY };
+	const long double in_val2[] = { -INFINITY, INFINITY, -VAL2, VAL2, -VAL1, VAL1, -ZERO, ZERO, NAN, VAL2 };
+	const long double sol_val[] = { ZERO, -ZERO, -2251799813685247.5, 2251799813685247.5, -1.0, 1.0, -NAN, -NAN, NAN, -NAN };
+	const int sol_quo[] =  { 0, 0, -1, -1, -2, -2, 0, 0, 0, 0 };
+	long double ret_val[SIZE(sol_val, long double)];
+	int ret_quo[SIZE(sol_quo, int)] = { 0 };
 	int remquol_idx;
 
-	for (remquol_idx = 0; remquol_idx < 10; remquol_idx++) {
+	for (remquol_idx = 0; remquol_idx < SIZE(sol_val, long double); remquol_idx++) {
 		ret_val[remquol_idx] = remquol(in_val1[remquol_idx], in_val2[remquol_idx], &ret_quo[remquol_idx]);
 		if (!(isnan(sol_val[remquol_idx]) && isnan(ret_val[remquol_idx]))) {
 			TC_ASSERT_LEQ("remquol", fabsl(sol_val[remquol_idx] - ret_val[remquol_idx]), FLT_EPSILON);
@@ -2478,12 +2479,12 @@ static void tc_libc_math_remquol(void)
  */
 static void tc_libc_math_rint(void)
 {
-	const double in_val[6] = { ZERO, -ZERO, 1073741823.5, -1073741820.5, 2147483645.5, -2147483642.5 };
-	const double sol_val[6] = { ZERO, -ZERO, 1073741824.0, -1073741820.0, 2147483646.0, -2147483642.0 };
-	double ret_val[6];
+	const double in_val[] = { ZERO, -ZERO, 1073741823.5, -1073741820.5, 2147483645.5, -2147483642.5 };
+	const double sol_val[] = { ZERO, -ZERO, 1073741824.0, -1073741820.0, 2147483646.0, -2147483642.0 };
+	double ret_val[SIZE(sol_val, double)];
 	int rint_idx;
 
-	for (rint_idx = 0; rint_idx < 6; rint_idx++) {
+	for (rint_idx = 0; rint_idx < SIZE(in_val, double); rint_idx++) {
 		ret_val[rint_idx] = rint(in_val[rint_idx]);
 		if (!(isnan(sol_val[rint_idx]) && isnan(ret_val[rint_idx]))) {
 			TC_ASSERT_LEQ("rint", fabs(sol_val[rint_idx] - ret_val[rint_idx]), FLT_EPSILON);
@@ -2504,12 +2505,12 @@ static void tc_libc_math_rint(void)
  */
 static void tc_libc_math_rintf(void)
 {
-	const float in_val[6] = { ZERO, -ZERO, 1073741823.5, -1073741820.5, 2147483645.5, -2147483642.5 };
-	const float sol_val[6] = { ZERO, -ZERO, 1073741824.0, -1073741820.0, 2147483646.0, -2147483642.0 };
-	float ret_val[6];
+	const float in_val[] = { ZERO, -ZERO, 1073741823.5, -1073741820.5, 2147483645.5, -2147483642.5 };
+	const float sol_val[] = { ZERO, -ZERO, 1073741824.0, -1073741820.0, 2147483646.0, -2147483642.0 };
+	float ret_val[SIZE(sol_val, float)];
 	int rintf_idx;
 
-	for (rintf_idx = 0; rintf_idx < 6; rintf_idx++) {
+	for (rintf_idx = 0; rintf_idx < SIZE(in_val, float); rintf_idx++) {
 		ret_val[rintf_idx] = rintf(in_val[rintf_idx]);
 		if (!(isnan(sol_val[rintf_idx]) && isnan(ret_val[rintf_idx]))) {
 			TC_ASSERT_LEQ("rintf", fabsf(sol_val[rintf_idx] - ret_val[rintf_idx]), FLT_EPSILON);
@@ -2530,12 +2531,12 @@ static void tc_libc_math_rintf(void)
  */
 static void tc_libc_math_rintl(void)
 {
-	const long double in_val[6] = { ZERO, -ZERO, VAL1, -VAL1, VAL2, -VAL2 };
-	const long double sol_val[6] = { ZERO, -ZERO, 2251799813685248.0, -2251799813685248.0, 4503599627370496.0, -4503599627370496.0 };
-	long double ret_val[6];
+	const long double in_val[] = { ZERO, -ZERO, VAL1, -VAL1, VAL2, -VAL2 };
+	const long double sol_val[] = { ZERO, -ZERO, 2251799813685248.0, -2251799813685248.0, 4503599627370496.0, -4503599627370496.0 };
+	long double ret_val[SIZE(sol_val, long double)];
 	int rintl_idx;
 
-	for (rintl_idx = 0; rintl_idx < 6; rintl_idx++) {
+	for (rintl_idx = 0; rintl_idx < SIZE(in_val, long double); rintl_idx++) {
 		ret_val[rintl_idx] = rintl(in_val[rintl_idx]);
 		if (!(isnan(sol_val[rintl_idx]) && isnan(ret_val[rintl_idx]))) {
 			TC_ASSERT_LEQ("rintl", fabsl(sol_val[rintl_idx] - ret_val[rintl_idx]), FLT_EPSILON);
@@ -2556,12 +2557,12 @@ static void tc_libc_math_rintl(void)
  */
 static void tc_libc_math_round(void)
 {
-	const double in_val[10] = { ZERO, -ZERO, VAL1, -VAL1, VAL2, -VAL2, INFINITY, -INFINITY, NAN, INFINITY };
-	const double sol_val[10] = { ZERO, -ZERO, 2251799813685249.0, -2251799813685249.0, 4503599627370496.0, -4503599627370496.0, INFINITY, -INFINITY, NAN, INFINITY };
-	double ret_val[10];
+	const double in_val[] = { ZERO, -ZERO, VAL1, -VAL1, VAL2, -VAL2, INFINITY, -INFINITY, NAN, INFINITY };
+	const double sol_val[] = { ZERO, -ZERO, 2251799813685249.0, -2251799813685249.0, 4503599627370496.0, -4503599627370496.0, INFINITY, -INFINITY, NAN, INFINITY };
+	double ret_val[SIZE(sol_val, double)];
 	int round_idx;
 
-	for (round_idx = 0; round_idx < 10; round_idx++) {
+	for (round_idx = 0; round_idx < SIZE(in_val, double); round_idx++) {
 		ret_val[round_idx] = round(in_val[round_idx]);
 		if (!(isnan(sol_val[round_idx]) && isnan(ret_val[round_idx]))) {
 			TC_ASSERT_LEQ("round", fabs(sol_val[round_idx] - ret_val[round_idx]), FLT_EPSILON);
@@ -2582,12 +2583,12 @@ static void tc_libc_math_round(void)
  */
 static void tc_libc_math_roundf(void)
 {
-	const float in_val[10] = { ZERO, -ZERO, VAL1, -VAL1, VAL2, -VAL2, INFINITY, -INFINITY, NAN, INFINITY };
-	const float sol_val[10] = { ZERO, -ZERO, 2251799813685248.0, -2251799813685248.0, 4503599627370496.0, -4503599627370496.0, INFINITY, -INFINITY, NAN, INFINITY };
-	float ret_val[10];
+	const float in_val[] = { ZERO, -ZERO, VAL1, -VAL1, VAL2, -VAL2, INFINITY, -INFINITY, NAN, INFINITY };
+	const float sol_val[] = { ZERO, -ZERO, 2251799813685248.0, -2251799813685248.0, 4503599627370496.0, -4503599627370496.0, INFINITY, -INFINITY, NAN, INFINITY };
+	float ret_val[SIZE(sol_val, float)];
 	int roundf_idx;
 
-	for (roundf_idx = 0; roundf_idx < 10; roundf_idx++) {
+	for (roundf_idx = 0; roundf_idx < SIZE(in_val, float); roundf_idx++) {
 		ret_val[roundf_idx] = roundf(in_val[roundf_idx]);
 		if (!(isnan(sol_val[roundf_idx]) && isnan(ret_val[roundf_idx]))) {
 			TC_ASSERT_LEQ("roundf", fabsf(sol_val[roundf_idx] - ret_val[roundf_idx]), FLT_EPSILON);
@@ -2608,12 +2609,12 @@ static void tc_libc_math_roundf(void)
  */
 static void tc_libc_math_roundl(void)
 {
-	const long double in_val[10] = { ZERO, -ZERO, VAL1, -VAL1, VAL2, -VAL2, INFINITY, -INFINITY, NAN, INFINITY };
-	const long double sol_val[10] = { ZERO, -ZERO, 2251799813685249.0, -2251799813685249.0, 4503599627370496.0, -4503599627370496.0, INFINITY, -INFINITY, NAN, INFINITY };
-	long double ret_val[10];
+	const long double in_val[] = { ZERO, -ZERO, VAL1, -VAL1, VAL2, -VAL2, INFINITY, -INFINITY, NAN, INFINITY };
+	const long double sol_val[] = { ZERO, -ZERO, 2251799813685249.0, -2251799813685249.0, 4503599627370496.0, -4503599627370496.0, INFINITY, -INFINITY, NAN, INFINITY };
+	long double ret_val[SIZE(sol_val, long double)];
 	int roundl_idx;
 
-	for (roundl_idx = 0; roundl_idx < 10; roundl_idx++) {
+	for (roundl_idx = 0; roundl_idx < SIZE(in_val, long double); roundl_idx++) {
 		ret_val[roundl_idx] = roundl(in_val[roundl_idx]);
 		if (!(isnan(sol_val[roundl_idx]) && isnan(ret_val[roundl_idx]))) {
 			TC_ASSERT_LEQ("roundl", fabsl(sol_val[roundl_idx] - ret_val[roundl_idx]), FLT_EPSILON);
@@ -2634,15 +2635,15 @@ static void tc_libc_math_roundl(void)
  */
 static void tc_libc_math_scalbn(void)
 {
-	const double in_val[8] = { ZERO, VAL1, -VAL1, VAL2, -VAL2, INFINITY, -INFINITY, NAN };
-	const double sol_val[8][6] = { { ZERO, ZERO, ZERO, ZERO, ZERO, ZERO }, { 9007199254740994.0, 17592186044416.003906250, ZERO, INFINITY, INFINITY, ZERO }, { -9007199254740994.0, -17592186044416.003906250, -ZERO, -INFINITY, -INFINITY, -ZERO }, { 18014398509481984.0, 35184372088832.0, ZERO, INFINITY, INFINITY, ZERO }, { -18014398509481984.0, -35184372088832.0, -ZERO, -INFINITY, -INFINITY, -ZERO }, { INFINITY, INFINITY, INFINITY, INFINITY, INFINITY, INFINITY }, { -INFINITY, -INFINITY, -INFINITY, -INFINITY, -INFINITY, -INFINITY }, { NAN, NAN, NAN, NAN, NAN, NAN } };
-	const int exp[6] = { 2, -7, -1024, 1024, 3072, -3072 };
-	double ret_val[8][6];
+	const double in_val[] = { ZERO, VAL1, -VAL1, VAL2, -VAL2, INFINITY, -INFINITY, NAN };
+	const double sol_val[][6] = { { ZERO, ZERO, ZERO, ZERO, ZERO, ZERO }, { 9007199254740994.0, 17592186044416.003906250, ZERO, INFINITY, INFINITY, ZERO }, { -9007199254740994.0, -17592186044416.003906250, -ZERO, -INFINITY, -INFINITY, -ZERO }, { 18014398509481984.0, 35184372088832.0, ZERO, INFINITY, INFINITY, ZERO }, { -18014398509481984.0, -35184372088832.0, -ZERO, -INFINITY, -INFINITY, -ZERO }, { INFINITY, INFINITY, INFINITY, INFINITY, INFINITY, INFINITY }, { -INFINITY, -INFINITY, -INFINITY, -INFINITY, -INFINITY, -INFINITY }, { NAN, NAN, NAN, NAN, NAN, NAN } };
+	const int exp[] = { 2, -7, -1024, 1024, 3072, -3072 };
+	double ret_val[SIZE(in_val, double)][6];
 	int scalbn_idx;
 	int exp_idx;
 
-	for (scalbn_idx = 0; scalbn_idx < 8; scalbn_idx++) {
-		for (exp_idx = 0; exp_idx < 6; exp_idx++) {
+	for (scalbn_idx = 0; scalbn_idx < SIZE(in_val, double); scalbn_idx++) {
+		for (exp_idx = 0; exp_idx < SIZE(exp, int); exp_idx++) {
 			ret_val[scalbn_idx][exp_idx] = scalbn(in_val[scalbn_idx], exp[exp_idx]);
 			if (!(isnan(sol_val[scalbn_idx][exp_idx]) && isnan(ret_val[scalbn_idx][exp_idx]))) {
 				TC_ASSERT_LEQ("scalbn", fabs(sol_val[scalbn_idx][exp_idx] - ret_val[scalbn_idx][exp_idx]), FLT_EPSILON);
@@ -2664,15 +2665,15 @@ static void tc_libc_math_scalbn(void)
  */
 static void tc_libc_math_scalbnf(void)
 {
-	const float in_val[8] = { ZERO, VAL1, -VAL1, VAL2, -VAL2, INFINITY, -INFINITY, NAN };
-	const float sol_val[8][6] = { { ZERO, ZERO, ZERO, ZERO, ZERO, ZERO }, { 9007199254740994.0, 17592186044416.003906250, ZERO, INFINITY, INFINITY, ZERO }, { -9007199254740994.0, -17592186044416.003906250, -ZERO, -INFINITY, -INFINITY, -ZERO }, { 18014398509481984.0, 35184372088832.0, ZERO, INFINITY, INFINITY, ZERO }, { -18014398509481984.0, -35184372088832.0, -ZERO, -INFINITY, -INFINITY, -ZERO }, { INFINITY, INFINITY, INFINITY, INFINITY, INFINITY, INFINITY }, { -INFINITY, -INFINITY, -INFINITY, -INFINITY, -INFINITY, -INFINITY }, { NAN, NAN, NAN, NAN, NAN, NAN } };
-	const int exp[6] = { 2, -7, -1024, 1024, 3072, -3072 };
-	float ret_val[8][6];
+	const float in_val[] = { ZERO, VAL1, -VAL1, VAL2, -VAL2, INFINITY, -INFINITY, NAN };
+	const float sol_val[][6] = { { ZERO, ZERO, ZERO, ZERO, ZERO, ZERO }, { 9007199254740994.0, 17592186044416.003906250, ZERO, INFINITY, INFINITY, ZERO }, { -9007199254740994.0, -17592186044416.003906250, -ZERO, -INFINITY, -INFINITY, -ZERO }, { 18014398509481984.0, 35184372088832.0, ZERO, INFINITY, INFINITY, ZERO }, { -18014398509481984.0, -35184372088832.0, -ZERO, -INFINITY, -INFINITY, -ZERO }, { INFINITY, INFINITY, INFINITY, INFINITY, INFINITY, INFINITY }, { -INFINITY, -INFINITY, -INFINITY, -INFINITY, -INFINITY, -INFINITY }, { NAN, NAN, NAN, NAN, NAN, NAN } };
+	const int exp[] = { 2, -7, -1024, 1024, 3072, -3072 };
+	float ret_val[SIZE(in_val, float)][6];
 	int scalbnf_idx;
 	int exp_idx;
 
-	for (scalbnf_idx = 0; scalbnf_idx < 8; scalbnf_idx++) {
-		for (exp_idx = 0; exp_idx < 6; exp_idx++) {
+	for (scalbnf_idx = 0; scalbnf_idx < SIZE(in_val, float); scalbnf_idx++) {
+		for (exp_idx = 0; exp_idx < SIZE(exp, int); exp_idx++) {
 			ret_val[scalbnf_idx][exp_idx] = scalbnf(in_val[scalbnf_idx], exp[exp_idx]);
 			if (!(isnan(sol_val[scalbnf_idx][exp_idx]) && isnan(ret_val[scalbnf_idx][exp_idx]))) {
 				TC_ASSERT_LEQ("scalbnf", fabsf(sol_val[scalbnf_idx][exp_idx] - ret_val[scalbnf_idx][exp_idx]), FLT_EPSILON);
@@ -2694,15 +2695,15 @@ static void tc_libc_math_scalbnf(void)
  */
 static void tc_libc_math_scalbnl(void)
 {
-	const long double in_val[8] = { ZERO, VAL1, -VAL1, VAL2, -VAL2, INFINITY, -INFINITY, NAN };
-	const long double sol_val[8][6] = { { ZERO, ZERO, ZERO, ZERO, ZERO, ZERO }, { 9007199254740994.0, 17592186044416.003906250, ZERO, INFINITY, INFINITY, ZERO }, { -9007199254740994.0, -17592186044416.003906250, -ZERO, -INFINITY, -INFINITY, -ZERO }, { 18014398509481984.0, 35184372088832.0, ZERO, INFINITY, INFINITY, ZERO }, { -18014398509481984.0, -35184372088832.0, -ZERO, -INFINITY, -INFINITY, -ZERO }, { INFINITY, INFINITY, INFINITY, INFINITY, INFINITY, INFINITY }, { -INFINITY, -INFINITY, -INFINITY, -INFINITY, -INFINITY, -INFINITY }, { NAN, NAN, NAN, NAN, NAN, NAN } };
-	const int exp[6] = { 2, -7, -1024, 1024, 3072, -3072 };
-	long double ret_val[8][6];
+	const long double in_val[] = { ZERO, VAL1, -VAL1, VAL2, -VAL2, INFINITY, -INFINITY, NAN };
+	const long double sol_val[][6] = { { ZERO, ZERO, ZERO, ZERO, ZERO, ZERO }, { 9007199254740994.0, 17592186044416.003906250, ZERO, INFINITY, INFINITY, ZERO }, { -9007199254740994.0, -17592186044416.003906250, -ZERO, -INFINITY, -INFINITY, -ZERO }, { 18014398509481984.0, 35184372088832.0, ZERO, INFINITY, INFINITY, ZERO }, { -18014398509481984.0, -35184372088832.0, -ZERO, -INFINITY, -INFINITY, -ZERO }, { INFINITY, INFINITY, INFINITY, INFINITY, INFINITY, INFINITY }, { -INFINITY, -INFINITY, -INFINITY, -INFINITY, -INFINITY, -INFINITY }, { NAN, NAN, NAN, NAN, NAN, NAN } };
+	const int exp[] = { 2, -7, -1024, 1024, 3072, -3072 };
+	long double ret_val[SIZE(in_val, long double)][6];
 	int scalbnl_idx;
 	int exp_idx;
 
-	for (scalbnl_idx = 0; scalbnl_idx < 8; scalbnl_idx++) {
-		for (exp_idx = 0; exp_idx < 6; exp_idx++) {
+	for (scalbnl_idx = 0; scalbnl_idx < SIZE(in_val, long double); scalbnl_idx++) {
+		for (exp_idx = 0; exp_idx < SIZE(exp, int); exp_idx++) {
 			ret_val[scalbnl_idx][exp_idx] = scalbnl(in_val[scalbnl_idx], exp[exp_idx]);
 			if (!(isnan(sol_val[scalbnl_idx][exp_idx]) && isnan(ret_val[scalbnl_idx][exp_idx]))) {
 				TC_ASSERT_LEQ("scalbnl", fabsl(sol_val[scalbnl_idx][exp_idx] - ret_val[scalbnl_idx][exp_idx]), FLT_EPSILON);
@@ -2724,14 +2725,14 @@ static void tc_libc_math_scalbnl(void)
  */
 static void tc_libc_math_sin(void)
 {
-	const double in_val[5] = { 3, -3, 0, M_PI, M_PI_2 };
-	const double sol_val[5] = { 0.14112000805987, -0.14112000805987, 0, 1.2246467991474e-16, 1 };
-	double ret_val[5];
+	const double in_val[] = { 3, -3, 0, M_PI, M_PI_2 };
+	const double sol_val[] = { 0.14112000805987, -0.14112000805987, 0, 1.2246467991474e-16, 1 };
+	double ret_val[SIZE(sol_val, double)];
 	int sin_idx;
 
 	/* Returns the sine of an angle of x radians */
 
-	for (sin_idx = 0; sin_idx < 5; sin_idx++) {
+	for (sin_idx = 0; sin_idx < SIZE(in_val, double); sin_idx++) {
 		ret_val[sin_idx] = sin(in_val[sin_idx]);
 		TC_ASSERT_LEQ("sin", fabs(sol_val[sin_idx] - ret_val[sin_idx]), FLT_EPSILON);
 	}
@@ -2750,14 +2751,14 @@ static void tc_libc_math_sin(void)
  */
 static void tc_libc_math_sinf(void)
 {
-	const float in_val[4] = { 3, -3, 0, M_PI_2 };
-	const float sol_val[4] = { 0.141120, -0.141120, 0.000000, 1 };
-	float ret_val[4];
+	const float in_val[] = { 3, -3, 0, M_PI_2 };
+	const float sol_val[] = { 0.141120, -0.141120, 0.000000, 1 };
+	float ret_val[SIZE(sol_val, float)];
 	int sinf_idx;
 
 	/* Returns the sine of an angle of x radians */
 
-	for (sinf_idx = 0; sinf_idx < 4; sinf_idx++) {
+	for (sinf_idx = 0; sinf_idx < SIZE(in_val, float); sinf_idx++) {
 		ret_val[sinf_idx] = sinf(in_val[sinf_idx]);
 		TC_ASSERT_LEQ("sinf", fabsf(sol_val[sinf_idx] - ret_val[sinf_idx]), FLT_EPSILON);
 	}
@@ -2776,14 +2777,14 @@ static void tc_libc_math_sinf(void)
  */
 static void tc_libc_math_sinh(void)
 {
-	const double in_val[5] = { 3, -3, 0, M_PI, M_PI_2 };
-	const double sol_val[5] = { 10.01787492741, -10.01787492741, 0, 11.548739357258, 2.3012989023073 };
-	double ret_val[5];
+	const double in_val[] = { 3, -3, 0, M_PI, M_PI_2 };
+	const double sol_val[] = { 10.01787492741, -10.01787492741, 0, 11.548739357258, 2.3012989023073 };
+	double ret_val[SIZE(sol_val, double)];
 	int sinh_idx;
 
 	/* Returns the hyperbolic sine of x */
 
-	for (sinh_idx = 0; sinh_idx < 5; sinh_idx++) {
+	for (sinh_idx = 0; sinh_idx < SIZE(in_val, double); sinh_idx++) {
 		ret_val[sinh_idx] = sinh(in_val[sinh_idx]);
 		TC_ASSERT_LEQ("sinh", fabs(sol_val[sinh_idx] - ret_val[sinh_idx]), FLT_EPSILON);
 	}
@@ -2802,14 +2803,14 @@ static void tc_libc_math_sinh(void)
  */
 static void tc_libc_math_sinhf(void)
 {
-	const float in_val[5] = { 3, -3, 0, M_PI, M_PI_2 };
-	const float sol_val[5] = { 10.0178747177124, -10.0178756713867, 0.0000000000000, 11.5487403869629, 2.3012990951538 };
-	float ret_val[5];
+	const float in_val[] = { 3, -3, 0, M_PI, M_PI_2 };
+	const float sol_val[] = { 10.0178747177124, -10.0178756713867, 0.0000000000000, 11.5487403869629, 2.3012990951538 };
+	float ret_val[SIZE(sol_val, float)];
 	int sinhf_idx;
 
 	/* Returns the hyperbolic sine of x */
 
-	for (sinhf_idx = 0; sinhf_idx < 5; sinhf_idx++) {
+	for (sinhf_idx = 0; sinhf_idx < SIZE(in_val, float); sinhf_idx++) {
 		ret_val[sinhf_idx] = sinhf(in_val[sinhf_idx]);
 		TC_ASSERT_LEQ("sinhf", fabsf(sol_val[sinhf_idx] - ret_val[sinhf_idx]), FLT_EPSILON);
 	}
@@ -2828,14 +2829,14 @@ static void tc_libc_math_sinhf(void)
  */
 static void tc_libc_math_sinhl(void)
 {
-	const long double in_val[5] = { 3, -3, 0, M_PI, M_PI_2 };
-	const long double sol_val[5] = { 10.01787492741, -10.01787492741, 0, 11.548739357258, 2.3012989023073 };
-	long double ret_val[5];
+	const long double in_val[] = { 3, -3, 0, M_PI, M_PI_2 };
+	const long double sol_val[] = { 10.01787492741, -10.01787492741, 0, 11.548739357258, 2.3012989023073 };
+	long double ret_val[SIZE(sol_val, long double)];
 	int sinhl_idx;
 
 	/* Returns the hyperbolic sine of x */
 
-	for (sinhl_idx = 0; sinhl_idx < 5; sinhl_idx++) {
+	for (sinhl_idx = 0; sinhl_idx < SIZE(in_val, long double); sinhl_idx++) {
 		ret_val[sinhl_idx] = sinhl(in_val[sinhl_idx]);
 		TC_ASSERT_LEQ("sinhl", fabsl(sol_val[sinhl_idx] - ret_val[sinhl_idx]), FLT_EPSILON);
 	}
@@ -2854,14 +2855,14 @@ static void tc_libc_math_sinhl(void)
  */
 static void tc_libc_math_sinl(void)
 {
-	const long double in_val[5] = { 3, -3, 0, M_PI, M_PI_2 };
-	const long double sol_val[5] = { 0.14112000805987, -0.14112000805987, 0, 1.2246467991474e-16, 1 };
-	long double ret_val[5];
+	const long double in_val[] = { 3, -3, 0, M_PI, M_PI_2 };
+	const long double sol_val[] = { 0.14112000805987, -0.14112000805987, 0, 1.2246467991474e-16, 1 };
+	long double ret_val[SIZE(sol_val, long double)];
 	int sinl_idx;
 
 	/* Returns the sine of an angle of x radians */
 
-	for (sinl_idx = 0; sinl_idx < 5; sinl_idx++) {
+	for (sinl_idx = 0; sinl_idx < SIZE(in_val, long double); sinl_idx++) {
 		ret_val[sinl_idx] = sinl(in_val[sinl_idx]);
 		TC_ASSERT_LEQ("sinl", fabsl(sol_val[sinl_idx] - ret_val[sinl_idx]), FLT_EPSILON);
 	}
@@ -2880,12 +2881,12 @@ static void tc_libc_math_sinl(void)
  */
 static void tc_libc_math_sqrt(void)
 {
-	const double in_val[8] = { ZERO, VAL1, -VAL1, VAL2, -VAL2, INFINITY, -INFINITY, NAN };
-	const double sol_val[8] = { ZERO, 47453132.8121257797, -NAN, 67108864.0, -NAN, INFINITY, -NAN, NAN };
-	double ret_val[8];
+	const double in_val[] = { ZERO, VAL1, -VAL1, VAL2, -VAL2, INFINITY, -INFINITY, NAN };
+	const double sol_val[] = { ZERO, 47453132.8121257797, -NAN, 67108864.0, -NAN, INFINITY, -NAN, NAN };
+	double ret_val[SIZE(sol_val, double)];
 	int sqrt_idx;
 
-	for (sqrt_idx = 0; sqrt_idx < 8; sqrt_idx++) {
+	for (sqrt_idx = 0; sqrt_idx < SIZE(in_val, double); sqrt_idx++) {
 		ret_val[sqrt_idx] = sqrt(in_val[sqrt_idx]);
 		if (!(isnan(sol_val[sqrt_idx]) && isnan(ret_val[sqrt_idx]))) {
 			TC_ASSERT_LEQ("sqrt", fabs(sol_val[sqrt_idx] - ret_val[sqrt_idx]), FLT_EPSILON);
@@ -2906,12 +2907,12 @@ static void tc_libc_math_sqrt(void)
  */
 static void tc_libc_math_sqrtf(void)
 {
-	const float in_val[8] = { ZERO, VAL1, -VAL1, VAL2, -VAL2, INFINITY, -INFINITY, NAN };
-	const float sol_val[8] = { ZERO, 47453132.8121257797, -NAN, 67108864.0, -NAN, INFINITY, -NAN, NAN };
-	float ret_val[8];
+	const float in_val[] = { ZERO, VAL1, -VAL1, VAL2, -VAL2, INFINITY, -INFINITY, NAN };
+	const float sol_val[] = { ZERO, 47453132.8121257797, -NAN, 67108864.0, -NAN, INFINITY, -NAN, NAN };
+	float ret_val[SIZE(sol_val, float)];
 	int sqrtf_idx;
 
-	for (sqrtf_idx = 0; sqrtf_idx < 8; sqrtf_idx++) {
+	for (sqrtf_idx = 0; sqrtf_idx < SIZE(in_val, float); sqrtf_idx++) {
 		ret_val[sqrtf_idx] = sqrtf(in_val[sqrtf_idx]);
 		if (!(isnan(sol_val[sqrtf_idx]) && isnan(ret_val[sqrtf_idx]))) {
 			TC_ASSERT_LEQ("sqrtf", fabsf(sol_val[sqrtf_idx] - ret_val[sqrtf_idx]), FLT_EPSILON);
@@ -2932,12 +2933,12 @@ static void tc_libc_math_sqrtf(void)
  */
 static void tc_libc_math_sqrtl(void)
 {
-	const long double in_val[8] = { ZERO, VAL1, -VAL1, VAL2, -VAL2, INFINITY, -INFINITY, NAN };
-	const long double sol_val[8] = { ZERO, 47453132.8121257797, -NAN, 67108864.0, -NAN, INFINITY, -NAN, NAN };
-	long double ret_val[8];
+	const long double in_val[] = { ZERO, VAL1, -VAL1, VAL2, -VAL2, INFINITY, -INFINITY, NAN };
+	const long double sol_val[] = { ZERO, 47453132.8121257797, -NAN, 67108864.0, -NAN, INFINITY, -NAN, NAN };
+	long double ret_val[SIZE(sol_val, long double)];
 	int sqrtl_idx;
 
-	for (sqrtl_idx = 0; sqrtl_idx < 8; sqrtl_idx++) {
+	for (sqrtl_idx = 0; sqrtl_idx < SIZE(in_val, long double); sqrtl_idx++) {
 		ret_val[sqrtl_idx] = sqrtl(in_val[sqrtl_idx]);
 		if (!(isnan(sol_val[sqrtl_idx]) && isnan(ret_val[sqrtl_idx]))) {
 			TC_ASSERT_LEQ("sqrtl", fabsl(sol_val[sqrtl_idx] - ret_val[sqrtl_idx]), FLT_EPSILON);
@@ -2958,14 +2959,14 @@ static void tc_libc_math_sqrtl(void)
  */
 static void tc_libc_math_trunc(void)
 {
-	const double in_val[4] = { 4.243, 0, -10.990, -INFINITY };
-	const double sol_val[4] = { 4.000, 0, -10.000, -INFINITY };
-	double ret_val[4];
+	const double in_val[] = { 4.243, 0, -10.990, -INFINITY };
+	const double sol_val[] = { 4.000, 0, -10.000, -INFINITY };
+	double ret_val[SIZE(sol_val, double)];
 	int trunc_idx;
 
 	/* Round to truncated integer value */
 
-	for (trunc_idx = 0; trunc_idx < 4; trunc_idx++) {
+	for (trunc_idx = 0; trunc_idx < SIZE(in_val, double); trunc_idx++) {
 		ret_val[trunc_idx] = trunc(in_val[trunc_idx]);
 		TC_ASSERT_LEQ("trunc", fabs(sol_val[trunc_idx] - ret_val[trunc_idx]), FLT_EPSILON);
 	}
@@ -2984,14 +2985,14 @@ static void tc_libc_math_trunc(void)
  */
 static void tc_libc_math_truncf(void)
 {
-	const float in_val[4] = { 4.243, 0, -10.990, -INFINITY };
-	const float sol_val[4] = { 4.000, 0, -10.000, -INFINITY };
-	float ret_val[4];
+	const float in_val[] = { 4.243, 0, -10.990, -INFINITY };
+	const float sol_val[] = { 4.000, 0, -10.000, -INFINITY };
+	float ret_val[SIZE(sol_val, float)];
 	int truncf_idx;
 
 	/* Round to truncated integer value */
 
-	for (truncf_idx = 0; truncf_idx < 4; truncf_idx++) {
+	for (truncf_idx = 0; truncf_idx < SIZE(in_val, float); truncf_idx++) {
 		ret_val[truncf_idx] = truncf(in_val[truncf_idx]);
 		TC_ASSERT_LEQ("truncf", fabs(sol_val[truncf_idx] - ret_val[truncf_idx]), FLT_EPSILON);
 	}
@@ -3010,12 +3011,12 @@ static void tc_libc_math_truncf(void)
  */
 static void tc_libc_math_y0(void)
 {
-	const double in_val[8] = { ZERO, VAL1, -VAL1, VAL2, -VAL2, INFINITY, -INFINITY, NAN };
-	const double sol_val[8] = { -INFINITY, ZERO, NAN, ZERO, NAN, ZERO, NAN, NAN };
-	double ret_val[8];
+	const double in_val[] = { ZERO, VAL1, -VAL1, VAL2, -VAL2, INFINITY, -INFINITY, NAN };
+	const double sol_val[] = { -INFINITY, ZERO, NAN, ZERO, NAN, ZERO, NAN, NAN };
+	double ret_val[SIZE(sol_val, double)];
 	int y0_idx;
 
-	for (y0_idx = 0; y0_idx < 8; y0_idx++) {
+	for (y0_idx = 0; y0_idx < SIZE(in_val, double); y0_idx++) {
 		ret_val[y0_idx] = y0(in_val[y0_idx]);
 		if (!(isnan(sol_val[y0_idx]) && isnan(ret_val[y0_idx]))) {
 			TC_ASSERT_LEQ("y0", fabs(sol_val[y0_idx] - ret_val[y0_idx]), FLT_EPSILON);
@@ -3036,12 +3037,12 @@ static void tc_libc_math_y0(void)
  */
 static void tc_libc_math_y0f(void)
 {
-	const float in_val[8] = { ZERO, VAL1, -VAL1, VAL2, -VAL2, INFINITY, -INFINITY, NAN };
-	const float sol_val[8] = { -INFINITY, ZERO, NAN, ZERO, NAN, ZERO, NAN, NAN };
-	float ret_val[8];
+	const float in_val[] = { ZERO, VAL1, -VAL1, VAL2, -VAL2, INFINITY, -INFINITY, NAN };
+	const float sol_val[] = { -INFINITY, ZERO, NAN, ZERO, NAN, ZERO, NAN, NAN };
+	float ret_val[SIZE(sol_val, float)];
 	int y0f_idx;
 
-	for (y0f_idx = 0; y0f_idx < 8; y0f_idx++) {
+	for (y0f_idx = 0; y0f_idx < SIZE(in_val, float); y0f_idx++) {
 		ret_val[y0f_idx] = y0f(in_val[y0f_idx]);
 		if (!(isnan(sol_val[y0f_idx]) && isnan(ret_val[y0f_idx]))) {
 			TC_ASSERT_LEQ("y0f", fabsf(sol_val[y0f_idx] - ret_val[y0f_idx]), FLT_EPSILON);
@@ -3062,12 +3063,12 @@ static void tc_libc_math_y0f(void)
  */
 static void tc_libc_math_y1(void)
 {
-	const double in_val[8] = { ZERO, VAL1, -VAL1, VAL2, -VAL2, INFINITY, -INFINITY, NAN };
-	const double sol_val[8] = { -INFINITY, -ZERO, NAN, -ZERO, NAN, ZERO, NAN, NAN };
-	double ret_val[8];
+	const double in_val[] = { ZERO, VAL1, -VAL1, VAL2, -VAL2, INFINITY, -INFINITY, NAN };
+	const double sol_val[] = { -INFINITY, -ZERO, NAN, -ZERO, NAN, ZERO, NAN, NAN };
+	double ret_val[SIZE(sol_val, double)];
 	int y1_idx;
 
-	for (y1_idx = 0; y1_idx < 8; y1_idx++) {
+	for (y1_idx = 0; y1_idx < SIZE(in_val, double); y1_idx++) {
 		ret_val[y1_idx] = y1(in_val[y1_idx]);
 		if (!(isnan(sol_val[y1_idx]) && isnan(ret_val[y1_idx]))) {
 			TC_ASSERT_LEQ("y1", fabs(sol_val[y1_idx] - ret_val[y1_idx]), FLT_EPSILON);
@@ -3088,12 +3089,12 @@ static void tc_libc_math_y1(void)
  */
 static void tc_libc_math_y1f(void)
 {
-	const float in_val[8] = { ZERO, VAL1, -VAL1, VAL2, -VAL2, INFINITY, -INFINITY, NAN };
-	const float sol_val[8] = { -INFINITY, -ZERO, NAN, -ZERO, NAN, ZERO, NAN, NAN };
-	float ret_val[8];
+	const float in_val[] = { ZERO, VAL1, -VAL1, VAL2, -VAL2, INFINITY, -INFINITY, NAN };
+	const float sol_val[] = { -INFINITY, -ZERO, NAN, -ZERO, NAN, ZERO, NAN, NAN };
+	float ret_val[SIZE(sol_val, float)];
 	int y1f_idx;
 
-	for (y1f_idx = 0; y1f_idx < 8; y1f_idx++) {
+	for (y1f_idx = 0; y1f_idx < SIZE(in_val, float); y1f_idx++) {
 		ret_val[y1f_idx] = y1f(in_val[y1f_idx]);
 		if (!(isnan(sol_val[y1f_idx]) && isnan(ret_val[y1f_idx]))) {
 			TC_ASSERT_LEQ("y1f", fabsf(sol_val[y1f_idx] - ret_val[y1f_idx]), FLT_EPSILON);
@@ -3114,13 +3115,13 @@ static void tc_libc_math_y1f(void)
  */
 static void tc_libc_math_yn(void)
 {
-	const double in_val[8] = { ZERO, VAL1, -VAL1, VAL2, -VAL2, INFINITY, -INFINITY, NAN };
-	const double sol_val[8] = { -INFINITY, ZERO, NAN, ZERO, NAN, ZERO, NAN, NAN };
-	double ret_val[8];
+	const double in_val[] = { ZERO, VAL1, -VAL1, VAL2, -VAL2, INFINITY, -INFINITY, NAN };
+	const double sol_val[] = { -INFINITY, ZERO, NAN, ZERO, NAN, ZERO, NAN, NAN };
+	double ret_val[SIZE(sol_val, double)];
 	int yn_idx;
 	int order = 3;
 
-	for (yn_idx = 0; yn_idx < 8; yn_idx++) {
+	for (yn_idx = 0; yn_idx < SIZE(in_val, double); yn_idx++) {
 		ret_val[yn_idx] = yn(order, in_val[yn_idx]);
 		if (!(isnan(sol_val[yn_idx]) && isnan(ret_val[yn_idx]))) {
 			TC_ASSERT_LEQ("yn", fabs(sol_val[yn_idx] - ret_val[yn_idx]), FLT_EPSILON);
@@ -3141,13 +3142,13 @@ static void tc_libc_math_yn(void)
  */
 static void tc_libc_math_ynf(void)
 {
-	const float in_val[8] = { ZERO, VAL1, -VAL1, VAL2, -VAL2, INFINITY, -INFINITY, NAN };
-	const float sol_val[8] = { -INFINITY, ZERO, NAN, ZERO, NAN, ZERO, NAN, NAN };
-	float ret_val[8];
+	const float in_val[] = { ZERO, VAL1, -VAL1, VAL2, -VAL2, INFINITY, -INFINITY, NAN };
+	const float sol_val[] = { -INFINITY, ZERO, NAN, ZERO, NAN, ZERO, NAN, NAN };
+	float ret_val[SIZE(in_val, float)];
 	int ynf_idx;
 	int order = 3;
 
-	for (ynf_idx = 0; ynf_idx < 8; ynf_idx++) {
+	for (ynf_idx = 0; ynf_idx < SIZE(in_val,float); ynf_idx++) {
 		ret_val[ynf_idx] = ynf(order, in_val[ynf_idx]);
 		if (!(isnan(sol_val[ynf_idx]) && isnan(ret_val[ynf_idx]))) {
 			TC_ASSERT_LEQ("ynf", fabsf(sol_val[ynf_idx] - ret_val[ynf_idx]), FLT_EPSILON);
@@ -3287,3 +3288,4 @@ int libc_math_main(void)
 #endif
 	return 0;
 }
+


### PR DESCRIPTION
Adds test cases for following libc/math API's,
cbrtf, cbrtl, exp2, expl, exp2f, exp2l, fabsf, fabsl, fdimf, fdimfl,
floorf, floorl, fmaxf, fmaxl, fminf, fminl, hypotf, hypotl, j0f, j1f, jnf,
nextafterf, nextafterl, nexttowardf, nexttowardl, remainderf, remainderl,
remquof, remquol, rint, rintf, rintl, round, roundf, roundl, scalbnf, scalbnl,
sqrt, sqrtf, sqrl, y0f, y1f, ynf.

Signed-off-by: Lokesh B V <lokesh.bv@partner.samsung.com>