### PR TITLE
Fix I2C transaction support (single byte read and write).

### DIFF
--- a/os/arch/arm/src/s5j/s5j_i2c.c
+++ b/os/arch/arm/src/s5j/s5j_i2c.c
@@ -1129,6 +1129,7 @@ int s5j_i2c_transfer(struct i2c_dev_s *dev, struct i2c_msg_s *msgv, int msgc)
 	 * i2c_read is expected from writing with count '1',
 	 * no stop for next transfer
 	 */
+#if defined CONFIG_BROKEN_I2C_TRANSACTIONS
 	if (((msgv->flags & I2C_M_READ) != 1) && (msgv->length == 1) && (msgc == 1)) {
 		stop = 0;
 	}
@@ -1136,6 +1137,7 @@ int s5j_i2c_transfer(struct i2c_dev_s *dev, struct i2c_msg_s *msgv, int msgc)
 	if ((msgv->flags & I2C_M_READ) && (msgc == 1)) {
 		start = 0;
 	}
+#endif
 
 	priv->mcnt = 0;
 	priv->mptr = NULL;


### PR DESCRIPTION
The fix removes an interesting behaviour that prevents sending one-byte read/write transactions.
See https://github.com/Samsung/TizenRT/issues/322.
It somewhat fixes the I2C support: writes seem to work now.

Reads however don't, as master NACKed the response it requested. Why is that - what needs to be done so that Artik accepts I2C data it requested?
The scope diagrams:
![failed_read](https://user-images.githubusercontent.com/9527196/28690190-99d74570-7318-11e7-96d3-6f6b27c17964.jpg)
I2C transaction overview.

![aritk_request](https://user-images.githubusercontent.com/9527196/28690229-b87596bc-7318-11e7-86d4-ace2460971c9.jpg)
Starts with artik requesting read from slave 0x60.

![artik_nack_highlight](https://user-images.githubusercontent.com/9527196/28691162-34b48172-731c-11e7-9ec8-c7940d9a2a80.jpg)
The device responds with 0xc3; artik NACKs.
