### PR TITLE
Fix: sigtimedwait: Pending signal structure used after it has been released

### DIFF
--- a/os/kernel/signal/sig_timedwait.c
+++ b/os/kernel/signal/sig_timedwait.c
@@ -231,14 +231,14 @@ int sigtimedwait(FAR const sigset_t *set, FAR struct siginfo *info, FAR const st
 			memcpy(info, &sigpend->info, sizeof(struct siginfo));
 		}
 
+		/* The return value is the number of the signal that awakened us */
+
+		ret = sigpend->info.si_signo;
+
 		/* Then dispose of the pending signal structure properly */
 
 		sig_releasependingsignal(sigpend);
 		irqrestore(saved_state);
-
-		/* The return value is the number of the signal that awakened us */
-
-		ret = sigpend->info.si_signo;
 	}
 
 	/* We will have to wait for a signal to be posted to this task. */


### PR DESCRIPTION
Pending signal structure '**sigpend**' is used after it has been released by **sig_releasependingsignal**().

Signed-off-by: Lokesh B V <lokesh.bv@partner.samsung.com>