### PR TITLE
remove the CONFIG_CANCELLATION_POINTS conditional at task_setcancelty…

### DIFF
--- a/os/kernel/task/task_cancelpt.c
+++ b/os/kernel/task/task_cancelpt.c
@@ -95,8 +95,6 @@
 #include "mqueue/mqueue.h"
 #include "task/task.h"
 
-#ifdef CONFIG_CANCELLATION_POINTS
-
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
@@ -323,4 +321,3 @@ void notify_cancellation(FAR struct tcb_s *tcb)
 	irqrestore(flags);
 }
 
-#endif /* CONFIG_CANCELLATION_POINTS */

--- a/os/kernel/task/task_setcanceltype.c
+++ b/os/kernel/task/task_setcanceltype.c
@@ -112,13 +112,11 @@ int task_setcanceltype(int type, FAR int *oldtype)
 
 		tcb->flags &= ~TCB_FLAG_CANCEL_DEFERRED;
 
-#ifdef CONFIG_CANCELLATION_POINTS
 		/* If we just switched from deferred to asynchronous type and if a
 		 * cancellation is pending, then exit now.
 		 */
 
-		if ((tcb->flags & TCB_FLAG_CANCEL_PENDING) != 0 &&
-		(tcb->flags & TCB_FLAG_NONCANCELABLE) == 0) {
+		if ((tcb->flags & TCB_FLAG_CANCEL_PENDING) != 0 && (tcb->flags & TCB_FLAG_NONCANCELABLE) == 0) {
 			tcb->flags &= ~TCB_FLAG_CANCEL_PENDING;
 
 			/* Exit according to the type of the thread */
@@ -132,16 +130,11 @@ int task_setcanceltype(int type, FAR int *oldtype)
 				exit(EXIT_FAILURE);
 			}
 		}
-#endif
-	}
-#ifdef CONFIG_CANCELLATION_POINTS
-	else if (type == TASK_CANCEL_DEFERRED) {
+	} else if (type == TASK_CANCEL_DEFERRED) {
 		/* Set the deferred cancellation type */
 
 		tcb->flags |= TCB_FLAG_CANCEL_DEFERRED;
-	}
-#endif
-	else {
+	} else {
 		ret = EINVAL;
 	}
 


### PR DESCRIPTION
…pe and task_cancelpt

Those two files are already under CONFIG_CANCELLATION_POINTS at make.defs.
Checking it in file is redundant.

ifeq ($(CONFIG_CANCELLATION_POINTS),y)
CSRCS += task_setcanceltype.c task_testcancel.c task_cancelpt.c
endif