### PR TITLE
I2 c artik extensions

### DIFF
--- a/os/arch/arm/src/s5j/Kconfig
+++ b/os/arch/arm/src/s5j/Kconfig
@@ -196,6 +196,11 @@ config S5J_I2S_MAXINFLIGHT
 		determines the number certain queue data structures that will be
 		pre-allocated.
 
+config I2C_ARTIK_EXTENSIONS
+	bool "Support for incomplete I2C transactions for Artik (S5J) chips"
+	depends on S5J_I2C
+	default n
+
 config S5J_MCT
 	bool
 	default n

--- a/os/arch/arm/src/s5j/s5j_i2c.h
+++ b/os/arch/arm/src/s5j/s5j_i2c.h
@@ -189,6 +189,9 @@ struct s5j_i2c_priv_s {
 	unsigned int slave_addr;
 	unsigned int addrlen;
 	unsigned int timeout;
+#ifdef CONFIG_I2C_ARTIK_EXTENSIONS
+	unsigned int atomic;
+#endif
 	char name[16];
 
 	unsigned int initialized;
@@ -272,6 +275,7 @@ static int s5j_i2c_uninitialize(struct s5j_i2c_priv_s *priv);
  * Public Function Prototypes
  ****************************************************************************/
 unsigned int s5j_i2c_setclock(struct i2c_dev_s *dev, unsigned int frequency);
+int s5j_i2c_setatomic(struct i2c_dev_s *dev, int atomic);
 int s5j_i2c_setownaddress(FAR struct i2c_dev_s *dev, int addr, int nbits);
 int s5j_i2c_transfer(struct i2c_dev_s *dev, struct i2c_msg_s *msgv, int msgc);
 int s5j_i2c_read(FAR struct i2c_dev_s *dev, FAR uint8_t *buffer, int buflen);

--- a/os/drivers/i2c/Make.defs
+++ b/os/drivers/i2c/Make.defs
@@ -58,6 +58,10 @@ ifeq ($(CONFIG_I2C_TRANSFER),y)
   CSRCS += i2c_read.c i2c_write.c i2c_writeread.c
 endif
 
+ifeq ($(CONFIG_I2C_USERIO),y)
+  CSRCS += i2c_ioctrl.c
+endif
+
 ifneq ($(CONFIG_NFILE_DESCRIPTORS),0)
   ifeq ($(CONFIG_I2C_USERIO),y)
     CSRCS += i2c_uio.c

--- a/os/drivers/i2c/i2c_ioctrl.c
+++ b/os/drivers/i2c/i2c_ioctrl.c
@@ -1,0 +1,104 @@
+/****************************************************************************
+ * drivers/i2c/i2c_ioctrl.c
+ *
+ *   Copyright (C) 2016,2017 SAMSUNG ELECTRONICS CO., LTD. All rights reserved.
+ *   Author: ByoungTae Cho <bt.cho@samsung.com>
+ *   Author: Tomasz Wozniak <t.wozniak@samsung.com>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <tinyara/config.h>
+#include <assert.h>
+#include <errno.h>
+#include <debug.h>
+#include <tinyara/i2c.h>
+#include <tinyara/fs/ioctl.h>
+
+/****************************************************************************
+ * Name: i2c_ioctrl
+ *
+ * Description:
+ *   IO control on I2C device.
+ *
+ * TODO: validate pointers
+ ****************************************************************************/
+
+int i2c_ioctrl(FAR struct i2c_dev_s *dev, int cmd, unsigned long arg)
+{
+	int32_t ret;
+	int addr;
+	FAR struct i2c_rdwr_ioctl_data_s *rdwr;
+	int32_t freq;
+#ifdef CONFIG_I2C_ARTIK_EXTENSIONS
+	int atomic;
+#endif
+
+	switch (cmd) {
+	case I2C_SLAVE:
+	case I2C_SLAVE_FORCE:
+		addr = *((int *)arg);
+		ret = I2C_SETADDRESS(dev, addr, -1);
+		break;
+	case I2C_TENBIT:
+		/* 0 for 7 bit addrs, != 0 for 10 bit */
+		if (arg == 0) {
+			ret = I2C_SETADDRESS(dev, -1, 7);
+		} else {
+			ret = I2C_SETADDRESS(dev, -1, 10);
+		}
+		break;
+	case I2C_RDWR:
+		rdwr = (struct i2c_rdwr_ioctl_data_s *)(arg);
+		ret = I2C_TRANSFER(dev, rdwr->msgs, rdwr->nmsgs);
+		break;
+
+	case I2C_FREQUENCY:
+		freq = *((uint32_t *)arg);
+		ret = I2C_SETFREQUENCY(dev, freq);
+		break;
+#ifdef CONFIG_I2C_ARTIK_EXTENSIONS
+	case I2C_ATOMICITY:
+		atomic = *((uint32_t *)arg) & I2C_ATOMIC_FLAG;
+		ret = I2C_SETATOMIC(dev, atomic);
+		break;
+#endif
+
+	default:
+		dbg("Unknown cmd(%x)\n", cmd);
+		ret = -EINVAL;
+		break;
+	}
+
+	return ret;
+}

--- a/os/drivers/i2c/i2c_uio.c
+++ b/os/drivers/i2c/i2c_uio.c
@@ -222,44 +222,13 @@ static ssize_t i2c_uiowrite(FAR struct file *filep, FAR const char *buffer, size
 
 static int i2c_uioctrl(FAR struct file *filep, int cmd, unsigned long arg)
 {
-	int32_t ret;
-	int addr;
-	int32_t freq;
-	FAR struct inode *inode = filep->f_inode;
-	FAR struct i2c_dev_s *dev = inode->i_private;
-	FAR struct i2c_rdwr_ioctl_data_s *rdwr;
-
-	switch (cmd) {
-	case I2C_SLAVE:
-	case I2C_SLAVE_FORCE:
-		addr = *((int *)arg);
-		ret = I2C_SETADDRESS(dev, addr, -1);
-		break;
-	case I2C_TENBIT:
-		/* 0 for 7 bit addrs, != 0 for 10 bit */
-		if (arg == 0) {
-			ret = I2C_SETADDRESS(dev, -1, 7);
-		} else {
-			ret = I2C_SETADDRESS(dev, -1, 10);
-		}
-		break;
-	case I2C_RDWR:
-		rdwr = (struct i2c_rdwr_ioctl_data_s *)(arg);
-		ret = I2C_TRANSFER(dev, rdwr->msgs, rdwr->nmsgs);
-		break;
-
-	case I2C_FREQUENCY:
-		freq = *((uint32_t *)arg);
-		ret = I2C_SETFREQUENCY(dev, freq);
-		break;
-
-	default:
-		dbg("Unknown cmd(%x)\n", cmd);
-		ret = -EINVAL;
-		break;
+	FAR struct inode *inode = filep ? filep->f_inode  : NULL;
+	FAR struct i2c_dev_s *dev = inode ? inode->i_private : NULL;
+	if (dev) {
+		return i2c_ioctrl(dev, cmd, arg);
+	} else {
+		return -EINVAL;
 	}
-
-	return ret;
 }
 
 /****************************************************************************

--- a/os/include/tinyara/i2c.h
+++ b/os/include/tinyara/i2c.h
@@ -110,7 +110,13 @@
 #define I2C_TENBIT           0x0704	/* 0 for 7 bit addrs, != 0 for 10 bit */
 #define I2C_RDWR             0x0707	/* Combined R/W transfer (one STOP only) */
 
-#define I2C_FREQUENCY    0X801
+#define I2C_FREQUENCY        0X0801
+
+/* Transaction settings: standard mandated or TizenRT incompatible adoptions */
+#define I2C_ATOMICITY        0X0810
+
+#define I2C_ATOMIC_FLAG      0x0001
+
 
 #define I2C_M_IGNORE_NAK  0x1000	/* if I2C_FUNC_PROTOCOL_MANGLING */
 #define I2C_M_NOSTART   0x4000	/* if I2C_FUNC_NOSTART */
@@ -134,6 +140,10 @@
  ****************************************************************************/
 
 #define I2C_SETFREQUENCY(d, f) ((d)->ops->setfrequency(d, f))
+
+#ifdef CONFIG_I2C_ARTIK_EXTENSIONS
+#define I2C_SETATOMIC(d, f)    ((d)->ops->setatomic(d, f))
+#endif
 
 /****************************************************************************
  * Name: I2C_SETADDRESS
@@ -289,6 +299,9 @@ struct i2c_ops_s {
 	int (*setownaddress)(FAR struct i2c_dev_s *dev, int addr, int nbits);
 
 	int (*registercallback)(FAR struct i2c_dev_s *dev, int (*callback)(void));
+#endif
+#ifdef CONFIG_I2C_ARTIK_EXTENSIONS
+	int (*setatomic)(FAR struct i2c_dev_s *dev, int atomic);
 #endif
 };
 
@@ -469,6 +482,10 @@ int i2c_read(FAR struct i2c_dev_s *dev, FAR const struct i2c_config_s *config, F
 
 #ifdef CONFIG_I2C_USERIO
 int i2c_uioregister(FAR const char *path, FAR struct i2c_dev_s *dev);
+#endif
+
+#if defined(CONFIG_I2C_ARTIK_EXTENSIONS) || defined(CONFIG_I2C_USERIO)
+int i2c_ioctrl(FAR struct i2c_dev_s *dev, int cmd, unsigned long arg);
 #endif
 
 #undef EXTERN


### PR DESCRIPTION
Wrap split I2C transaction as a feature controlled by Kconfig option (I2C_ARTIK_EXTENSIONS).
If disabled, the I2C operations conform to the standard.
Once enabled, the i2c_read/i2c_write might not start/end i2c transaction, leaving i2c bus in undefined state (this is how TizenRT works now on Artik platform).

If the extensions are enabled, an ioctl is provided to control the I2C operation mode.
Enabled extensions allow transfers not being transactions (not conforming to start-transfer-stop schema).

Not yet tested, as I wanted if this approach is acceptable to I2C TizenRT maintainer[s].