### PR TITLE
Fixed a build error when using netdb interface

### DIFF
--- a/apps/system/netdb/netdb_main.c
+++ b/apps/system/netdb/netdb_main.c
@@ -141,8 +141,9 @@ int netdb_main(int argc, char *argv[])
 	FAR struct hostent *host;
 	FAR const char *addrtype;
 	char buffer[48];
+#ifdef HAVE_GETHOSTBYADDR
 	int ret;
-
+#endif
 	/* Handle: netdb --help */
 
 	if (argc == 2 && strcmp(argv[1], "--help") == 0) {


### PR DESCRIPTION
Fixed a build error when using netdb interface

netdb_main.c:144:6: error: unused variable 'ret' [-Werror=unused-variable]
  int ret;
      ^
