### PR TITLE
Remove unnecessary logic while handling return of task_activate

### DIFF
--- a/os/kernel/task/task_create.c
+++ b/os/kernel/task/task_create.c
@@ -205,15 +205,8 @@ static int thread_create(FAR const char *name, uint8_t ttype, int priority, int 
 
 	/* Activate the task */
 
-	ret = task_activate((FAR struct tcb_s *)tcb);
-	if (ret < OK) {
-		errcode = get_errno();
+	(void)task_activate((FAR struct tcb_s *)tcb);
 
-		/* The TCB was added to the active task list by task_schedsetup() */
-
-		dq_rem((FAR dq_entry_t *)tcb, (dq_queue_t *)&g_inactivetasks);
-		goto errout_with_tcb;
-	}
 	trace_end(TTRACE_TAG_TASK);
 	return pid;
 

--- a/os/kernel/task/task_restart.c
+++ b/os/kernel/task/task_restart.c
@@ -123,7 +123,6 @@ int task_restart(pid_t pid)
 	FAR struct tcb_s *rtcb;
 	FAR struct task_tcb_s *tcb;
 	irqstate_t state;
-	int status;
 
 	trace_begin(TTRACE_TAG_TASK, "task_restart");
 
@@ -214,13 +213,7 @@ int task_restart(pid_t pid)
 
 		/* Activate the task */
 
-		status = task_activate((FAR struct tcb_s *)tcb);
-		if (status != OK) {
-			(void)task_terminate(pid, true);
-			set_errno(-status);
-			trace_end(TTRACE_TAG_TASK);
-			return ERROR;
-		}
+		(void)task_activate((FAR struct tcb_s *)tcb);
 	}
 
 	sched_unlock();

--- a/os/kernel/task/task_vfork.c
+++ b/os/kernel/task/task_vfork.c
@@ -401,11 +401,7 @@ pid_t task_vforkstart(FAR struct task_tcb_s *child)
 
 	/* Activate the task */
 
-	ret = task_activate((FAR struct tcb_s *)child);
-	if (ret < OK) {
-		task_vforkabort(child, -ret);
-		return ERROR;
-	}
+	(void)task_activate((FAR struct tcb_s *)child);
 
 	/* Since the child task has the same priority as the parent task, it is
 	 * now ready to run, but has not yet ran.  It is a requirement that


### PR DESCRIPTION
By design, task_activate API always returns OK.
There is no need to check error condition and
add the un-necessary code. Keep the code clean

Signed-off-by: pradeep.ns <pradeep.ns@samsung.com>