### PR TITLE
Correct the Kconfig help description

### DIFF
--- a/os/Kconfig
+++ b/os/Kconfig
@@ -175,7 +175,9 @@ config BUILD_PROTECTED
 	select LIB_SYSCALL
 	select BUILD_2PASS
 	---help---
-		Builds TinyAra and selected applications as two "blobs":  A protected, privileged kernel blob and a separate unprivileged, user blob.  This require sue of the two pass build with each blob being build on each pass.
+		Builds TinyAra and selected applications as two "blobs":  A protected,
+		privileged kernel blob and a separate unprivileged, user blob. This
+		require sue of the two pass build with each blob being build on each pass.
 
 		NOTE:  This build configuration requires that the platform support
 		a memory protection unit (MPU).  Support, however, may not be
@@ -191,7 +193,7 @@ config BUILD_KERNEL
 		they can be loaded into memory for execution.
 
 		NOTE:  This build configuration requires that the platform support
-		a memory management unit (MPU) and address environments.  Support,
+		a memory management unit (MMU) and address environments.  Support,
 		however, may not be implemented on all platforms.
 
 endchoice # Build configuration

--- a/os/arch/Kconfig
+++ b/os/arch/Kconfig
@@ -90,9 +90,9 @@ config ARCH_USE_MMU
 	default n
 	depends on ARCH_HAVE_MMU
 	---help---
-		The architecture supports supports an MMU.  Enable this option in
-		order to enable use of the MMU.  For most architectures, this is
-		not really an option:  It is required to use the MMU.  In those
+		The architecture supports MMU. Enable this option in order to
+		enable use of the MMU. For most architectures, this is not
+		really an option: It is required to use the MMU. In those
 		cases, this selection will always be forced.
 
 config ARCH_USE_MPU
@@ -100,9 +100,9 @@ config ARCH_USE_MPU
 	default n
 	depends on ARCH_HAVE_MPU
 	---help---
-		The architecture supports supports an MPU.  Enable this option in
-		order to enable use of the MPU.  For most architectures, this option
-		is enabled by other, platform-specific logic.  In those cases, this
+		The architecture supports MPU. Enable this option in order to
+		enable use of the MPU. For most architectures, this option is
+		enabled by other, platform-specific logic. In those cases, this
 		selection will always be forced.
 
 menuconfig ARCH_ADDRENV


### PR DESCRIPTION
Corrected the Kconfig help description as follows
BUILD_PROTECTED => Adjusted the length of the description to readable format
BUILD_KERNEL => Changed from MPU -> MMU
ARCH_USE_MMU => removed duplicate word
ARCH_USE_MPU => removed duplicate word

Signed-off-by: pradeep.ns <pradeep.ns@samsung.com>