### PR TITLE
doc: Install bison to support kconfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,9 +78,9 @@ Please keep in mind that we are actively working on board configurations, and wi
 ## APPENDIX
 ### Kconfig-frontends Installation
 
-1. The *byacc*, *flex*, *gperf* and *libncurses5-dev* packages should be installed.
+1. The *bison* (or byacc if supported), *flex*, *gperf* and *libncurses5-dev* packages should be installed:
 ```bash
-sudo apt-get install byacc flex gperf libncurses5-dev
+sudo apt-get install bison flex gperf libncurses5-dev
 ```
 
 2. Download and untar *kconfig-frontends* package.  


### PR DESCRIPTION
Current kconfig-frontends is not supporting byacc anymore.
Observed issue using byacc (20140715-1):

  kconfig-frontends/kconfig-frontends/libs/parser/yconf.y", syntax error
  %destructor {

Problem has been solved using bison-2:3.0.4.dfsg-1 instead.

Change-Id: I25d53f3d01c1f260b6fa9523ca9442b719862139
Signed-off-by: Philippe Coval <philippe.coval@osg.samsung.com>