### PR TITLE
Fix: Minor change in Libc FixedMath "ub16mulub16" function

### DIFF
--- a/lib/libc/fixedmath/lib_fixedmath.c
+++ b/lib/libc/fixedmath/lib_fixedmath.c
@@ -167,7 +167,7 @@ ub16_t ub16mulub16(ub16_t m1, ub16_t m2)
 	 */
 
 	uint32_t m1i = ((uint32_t)m1 >> 16);
-	uint32_t m2i = ((uint32_t)m1 >> 16);
+	uint32_t m2i = ((uint32_t)m2 >> 16);
 	uint32_t m1f = ((uint32_t)m1 & 0x0000ffff);
 	uint32_t m2f = ((uint32_t)m2 & 0x0000ffff);
 


### PR DESCRIPTION
Fix in **ub16mulub16()** of fixedmath,
It's "**uint32_t m2i = ((uint32_t)m1 >> 16)**"
where, It should be "**uint32_t m2i = ((uint32_t)m2 >> 16)**"

Signed-off-by: Lokesh B V <lokesh.bv@partner.samsung.com>