### PR TITLE
refactoring create_appspec

### DIFF
--- a/apps/Makefile
+++ b/apps/Makefile
@@ -60,12 +60,10 @@ TOPDIR ?= $(APPDIR)/import
 
 # Application Directories
 
-# KCONFDIRS is the list of examples level directories containing Kconfig.
 # BUILDIRS is the list of top-level directories containing Make.defs files
 # CLEANDIRS is the list of all top-level directories containing Makefiles.
 #   It is used only for cleaning.
 
-KCONFDIRS  := $(dir $(wildcard examples/*/Kconfig))
 BUILDIRS   := $(dir $(filter-out import/Make.defs,$(wildcard */Make.defs)))
 CLEANDIRS  := $(dir $(wildcard */Makefile))
 
@@ -155,7 +153,8 @@ clean: $(foreach SDIR, $(CLEANDIRS), $(SDIR)_clean)
 	$(call CLEAN)
 
 applist:
-	$(foreach DIR, $(KCONFDIRS), ./tools/create_appspec.sh $(DIR))
+	$(Q) ./tools/create_appspec.sh
+
 appupdate:
 	$(Q) ./tools/update_config.sh -sw
 	$(Q) rm ../os/.appSpec


### PR DESCRIPTION
1. modify calling method on Makefile
  The applist should be called at everywhere of apps, not only example
2. add removing an old appspec meta file before making a new meta
3. modify a variable name from EXAMPLEDIR to TARGET_DIR_LIST
4. modify a method to get whether configuration is enabled or not
  If some config is not in defconfig (It means config is not enabled),
  this script recognize config is enabled. This is wrong.
  Let's get "CONFIG_XX=y" instead of "# CONFIG_XX is not set"
5. add output sentence to notice finishing