### PR TITLE
fs: fix config name for smartfs exclusion from procfs

### DIFF
--- a/os/fs/smartfs/smartfs_procfs.c
+++ b/os/fs/smartfs/smartfs_procfs.c
@@ -82,7 +82,7 @@
 #include <arch/irq.h>
 #include "smartfs.h"
 
-#if defined(CONFIG_FS_PROCFS) && !defined(CONFIG_FS_EXCLUDE_SMARTFS)
+#if defined(CONFIG_FS_PROCFS) && !defined(CONFIG_FS_PROCFS_EXCLUDE_SMARTFS)
 
 /****************************************************************************
  * Pre-processor Definitions


### PR DESCRIPTION
Smartfs info can be excluded from procfs by enabling
FS_PROCFS_EXCLUDE_SMARTFS config, but in smartfs_procfs
there was syntax error with wrong config name.

Signed-off-by: Oleg Lyovin <o.lyovin@partner.samsung.com>