### PR TITLE
libc: add arch-dependent option for ARCH_ROMGETC visibility control

### DIFF
--- a/lib/libc/Kconfig
+++ b/lib/libc/Kconfig
@@ -235,9 +235,13 @@ config LIB_SENDFILE_BUFSIZE
 	---help---
 		Size of the I/O buffer to allocate in sendfile().  Default: 512b
 
+config ARCH_HAVE_ROMGETC
+	bool
+
 config ARCH_ROMGETC
 	bool "Support for ROM string access"
 	default n
+	depends on ARCH_HAVE_ROMGETC
 	---help---
 		In Harvard architectures, data accesses and instruction accesses
 		occur on different buses, perhaps concurrently.  All data accesses


### PR DESCRIPTION
Enabling ARCH_ROMGETC assumes that for the target architecture
there exists implementation of up_romgetc() function. But even when
implementation is missing ARCH_ROMGETC option is still visible
to the user, so the option being selected cause build failure.

The solution is to add upper-level option, which can be selected
in specific architecture configs and make option ARCH_ROMGETC visible.
Otherwise ARCH_ROMGETC will be unvisible to the user.

Signed-off-by: Oleg Lyovin <o.lyovin@partner.samsung.com>