### PR TITLE
arch/arm/common: add directives to compile up_schedyield logic

### DIFF
--- a/os/arch/arm/src/s5j/Make.defs
+++ b/os/arch/arm/src/s5j/Make.defs
@@ -102,6 +102,10 @@ ifeq ($(CONFIG_ARMV7M_MPU),y)
 CMN_CSRCS += arm_mpu.c
 endif
 
+ifeq ($(CONFIG_SCHED_YIELD_OPTIMIZATION),y)
+CMN_CSRCS += up_schedyield.c
+endif
+
 ifeq ($(CONFIG_BUILD_KERNEL),y)
 CMN_CSRCS += up_task_start.c up_pthread_start.c arm_signal_dispatch.c
 endif


### PR DESCRIPTION
* When option CONFIG_SCHED_YIELD_OPTIMIZATION is enabled, scheduler's
  code enable yield feature which requires up_schedyield to be
  implemented. But there was missing logic in arch Makefile for
  compiling up_schedyield.c file.

Signed-off-by: Oleg Lyovin <o.lyovin@partner.samsung.com>