### PR TITLE
apps/readline: check whether CONFIG_EOL_IS_EITHER_CRLF is defined

### DIFF
--- a/apps/system/readline/readline_common.c
+++ b/apps/system/readline/readline_common.c
@@ -247,7 +247,7 @@ ssize_t readline_common(FAR struct rl_common_s *vtbl, FAR char *buf, int buflen)
 		else if (ch == '\n')
 #elif defined(CONFIG_EOL_IS_CR)
 		else if (ch == '\r')
-#elif CONFIG_EOL_IS_EITHER_CRLF
+#elif defined(CONFIG_EOL_IS_EITHER_CRLF)
 		else if (ch == '\n' || ch == '\r')
 #endif
 		{


### PR DESCRIPTION
* We should check whether CONFIG_EOL_IS_EITHER_CRLF is defined,
  instead of checking it's value.

Signed-off-by: Oleg Lyovin <o.lyovin@partner.samsung.com>