### PR TITLE
include/stdio: removed duplicate prototype of statfs

### DIFF
--- a/os/include/stdio.h
+++ b/os/include/stdio.h
@@ -447,10 +447,6 @@ int vdprintf(int fd, FAR const char *fmt, va_list ap);
 /**
  * @internal
  */
-int statfs(FAR const char *path, FAR struct statfs *buf);
-/**
- * @internal
- */
 FAR char *tmpnam(FAR char *s);
 /**
  * @internal


### PR DESCRIPTION
Declaration of statfs should belong to sys/statfs.h

Signed-off-by: Oleg Lyovin <o.lyovin@partner.samsung.com>