### PR TITLE
arch/artik053/Kconfig: selecting MTD_PARTITION without MTD is an error

### DIFF
--- a/os/arch/arm/src/artik053/Kconfig
+++ b/os/arch/arm/src/artik053/Kconfig
@@ -39,6 +39,7 @@ config ARTIK053_FLASH_PAGE_SIZE
 config ARTIK053_FLASH_PART
 	bool "Enable partition support on FLASH"
 	default n
+	select MTD
 	select MTD_PARTITION
 	select MTD_PROGMEM
 	depends on S5J_SFLASH


### PR DESCRIPTION
* MTD_PARTITION option is supported only when MTD support is enabled.

Signed-off-by: Oleg Lyovin <o.lyovin@partner.samsung.com>