### PR TITLE
arch/artik053: make ARTIK053_FLASH_PART dependent on !DISABLE_MOUNTPOINT

### DIFF
--- a/os/arch/arm/src/artik053/Kconfig
+++ b/os/arch/arm/src/artik053/Kconfig
@@ -41,7 +41,7 @@ config ARTIK053_FLASH_PART
 	default n
 	select MTD_PARTITION
 	select MTD_PROGMEM
-	depends on S5J_SFLASH
+	depends on S5J_SFLASH && !DISABLE_MOUNTPOINT
 	---help---
 		Enables creation of partitions on the FLASH
 


### PR DESCRIPTION
* Since ARTIK053_FLASH_PART selects MTD layer specific options, which
  are available only with mountpoints being enabled, ARTIK053_FLASH_PART
  option must be invisible for user when DISABLE_MOUNTPOINT is enabled.

Signed-off-by: Oleg Lyovin <o.lyovin@partner.samsung.com>