### PR TITLE
fs/procfs: make FS_PROCFS option visible only with mountpoints enabled

### DIFF
--- a/os/fs/procfs/Kconfig
+++ b/os/fs/procfs/Kconfig
@@ -6,6 +6,7 @@
 config FS_PROCFS
 	bool "PROCFS File System"
 	default n
+	depends on !DISABLE_MOUNTPOINT
 	select FS_READABLE
 	---help---
 		The PROCFS file system provides access to task status and other driver


### PR DESCRIPTION
Signed-off-by: Oleg Lyovin <o.lyovin@partner.samsung.com>