### PR TITLE
Typo Fix in Libc Kconfig and Add Missing TC_SUCCESS_RESULT Macro in libc termios.

### DIFF
--- a/apps/examples/testcase/le_tc/kernel/tc_termios.c
+++ b/apps/examples/testcase/le_tc/kernel/tc_termios.c
@@ -81,6 +81,8 @@ static void tc_termios_tcsetattr_tcgetattr(void)
 	printf("\n");
 	printf("<< Enable (NL) to (CR-NL) >>\n");
 	printf("-> This line is adapted to Carriage-return\n");
+
+	TC_SUCCESS_RESULT();
 }
 
 /****************************************************************************

--- a/lib/libc/Kconfig
+++ b/lib/libc/Kconfig
@@ -337,8 +337,8 @@ config MEMSET_OPTSPEED
 	default n
 	depends on !ARCH_MEMSET
 	---help---
-		Select this option to use a version of memcpy() optimized for speed.
-		Default: memcpy() is optimized for size.
+		Select this option to use a version of memset() optimized for speed.
+		Default: memset() is optimized for size.
 
 config MEMSET_64BIT
 	bool "64-bit memset()"


### PR DESCRIPTION
1) Changes wrong typo '_memcpy_' to '_memset_' in `config MEMSET_OPTSPEED `"`--help--`" section. 
2) Add Missing TC_SUCCESS_RESULT Macro in libc termios.