### PR TITLE
s5jt200 : add openocd configuration to attach gdb

### DIFF
--- a/build/configs/sidk_s5jt200/README.md
+++ b/build/configs/sidk_s5jt200/README.md
@@ -8,6 +8,7 @@ Samsung IoT Development Kit for S5JT200 chipset.
 > [Environment Set-up](#environment-set-up)  
 > [How to program a binary](#how-to-program-a-binary)  
 > [ROMFS](#romfs)  
+> [Using GDB](#using-gdb)  
 > [Configuration Sets](#configuration-sets)  
 > [Board Configuration](#board-configuration)
 
@@ -120,6 +121,28 @@ Before executing below steps, execute [generic steps](../../../external/contents
     ```
 
 After above two steps, build Tizen RT and program a Tizen RT binary through above [method](#how-to-program-a-binary).
+
+## Using GDB
+1. Build Tizen RT and program a Tizen RT binary through above [method](#how-to-program-a-binary)
+
+2. Run GDB server by running openocd with gdb cfg
+    ```bash
+    cd $TIZENRT_BASEDIR/build/configs/sidk_s5jt200/tools/openocd/
+    ./linux64/openocd -f s5jt200_attach_gdb.cfg
+    ```
+3. Run GDB client from another terminal
+    ```bash
+    cd $TIZENRT_BASEDIR/os/
+    arm-none-eabi-gdb -ex "target remote :3333" $TIZENRT_BASEDIR/build/output/bin/tinyara
+    ```
+    1. To run tinyara from beginning, set entrypoint to pc register in gdb.
+    ```bash
+    (gdb) set $pc = entry_addr
+    ```
+    2. entry_addr can be obtained by
+    ```bash
+    arm-none-eabi-readelf -h $TIZENRT_BASEDIR/build/output/bin/tinyara
+    ```
 
 ## Configuration Sets
 

--- a/build/configs/sidk_s5jt200/tools/openocd/s5jt200_attach_gdb.cfg
+++ b/build/configs/sidk_s5jt200/tools/openocd/s5jt200_attach_gdb.cfg
@@ -1,0 +1,66 @@
+###########################################################################
+#
+# Copyright 2017 Samsung Electronics All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+#
+###########################################################################
+
+# OpenOCD config used to attach gdb via FTDI
+# USB FT2232H (SIDK S5JT200 Board)
+
+#daemon configuration
+telnet_port 4444
+gdb_port 3333
+#gdb_memory_map enable
+
+#interface
+interface ftdi
+ftdi_vid_pid 0x0403 0x6010
+
+ftdi_layout_init 0x0008 0x000b
+ftdi_layout_signal nTRST -data 0x0200 -oe 0x0200
+ftdi_layout_signal nSRST -data 0x0080 -oe 0x0080
+
+reset_config trst_and_srst srst_push_pull trst_push_pull
+
+set _CHIPNAME s5jt200
+set _ENDIAN little
+set _CPUTAPID 0x4BA00477
+
+adapter_khz 2000
+
+# jtag scan chain
+set _ARM_CR4_JTAGID1 0x3ba00477
+set _ARM_CR4_JTAGID2 0x4ba00477
+set _ARM_CR4_JTAGID3 0x5ba00477
+
+jtag newtap $_CHIPNAME cpu -irlen 4 -ircapture 0x1 -irmask 0xf -expected-id $_CPUTAPID
+
+set _TARGETNAME $_CHIPNAME.cpu
+
+target create $_TARGETNAME cortex_r4 -endian $_ENDIAN -chain-position $_TARGETNAME -dbgbase 0x801E0000
+$_TARGETNAME configure -event gdb-attach { cortex_r4 dbginit }
+
+gdb_breakpoint_override hard
+
+proc jtag_init {} {
+	debug_level -1
+	global _TARGETNAME
+	jtag_reset 0 0
+	jtag arp_init
+	$_TARGETNAME arp_examine
+	reset halt
+	cortex_r4 maskisr on
+	gdb_breakpoint_override on
+}


### PR DESCRIPTION
This patch adds a openocd cfg which can be used to attach
gdb to s5jt200 chip.

Steps:
1. Build tinyara for sidk_s5j200 board (tested with hello_with_tash config)
2. make download ALL
3. cp build/output/bin/tinyara os/

4. [In Terminal 1] :
	- cd build/configs/sidk_s5jt200/tools/openocd/
	- ./linux64/openocd -f s5jt200_attach_gdb.cfg

5. [In Terminal 2] :
	- cd os/
	- arm-none-eabi-gdb -ex "target remote :3333" tinyara
	- To run tinyara from beginning, set entrypoint to pc register in gdb
	- Ex : (gdb) set $pc = entry_addr
	- entry_addr can be obtained by "arm-none-eabi-readelf -h tinyara"

Signed-off-by: Manohara HK <manohara.hk@samsung.com>