### PR TITLE
remove unused definitions for pm

### DIFF
--- a/os/pm/pm_metrics.h
+++ b/os/pm/pm_metrics.h
@@ -41,10 +41,6 @@ extern struct pm_global_s g_pmglobals;
 
 void pm_get_domainmetrics(int indx, struct pm_time_in_each_s *mtrics);
 void pm_prune_history(sq_queue_t *q);
-
-#else
-#define pm_get_domainmetrics(indx, mtrics)
-#define pm_prune_history(q)
 #endif
 
 #endif


### PR DESCRIPTION
The pm_get_domainmetrics and pm_prune_history functions are called
only when CONFIG_PM_METRICS is enabled. So definitions for them is
not needed when config is disabled.