### PR TITLE
Fix warning when CONFIG_IOTAPI_DEBUG is disabled

### DIFF
--- a/framework/src/iotbus/iotapi_evt_handler.c
+++ b/framework/src/iotbus/iotapi_evt_handler.c
@@ -107,9 +107,7 @@ void *iotapi_handler(void *data)
 		}
 
 		if (g_ia_evtlist[0].revents & POLLIN) {
-			int readed;
-			readed = read(g_ia_evtlist[0].fd, buf, 3);
-			IOTAPI_LOG("[iotcom] receive command(%d)\n", readed);
+			IOTAPI_LOG("[iotcom] receive command(%d)\n", read(g_ia_evtlist[0].fd, buf, 3));
 			if (buf[0] == 's' && buf[1] == 't')
 				break;
 


### PR DESCRIPTION
src/iotbus/iotapi_evt_handler.c:110:8: warning: variable 'readed' set but not used [-Wunused-but-set-variable]