### PR TITLE
Fix: libc tc issues

### DIFF
--- a/apps/examples/testcase/le_tc/kernel/kernel_tc_main.c
+++ b/apps/examples/testcase/le_tc/kernel/kernel_tc_main.c
@@ -99,9 +99,6 @@ int kernel_tc_main(int argc, char *argv[])
 #endif
 
 #ifdef CONFIG_TC_KERNEL_LIBC_PTHREAD
-#if (!defined CONFIG_PTHREAD_MUTEX_TYPES)
-#error CONFIG_PTHREAD_MUTEX_TYPES is needed for testing LIBC_PTHREAD TC
-#endif
 	libc_pthread_main();
 #endif
 
@@ -160,9 +157,6 @@ int kernel_tc_main(int argc, char *argv[])
 #endif
 
 #ifdef CONFIG_TC_KERNEL_PTHREAD
-#if (!defined CONFIG_PTHREAD_MUTEX_TYPES)
-#error CONFIG_PTHREAD_MUTEX_TYPES is needed for testing PTHREAD TC
-#endif
 	pthread_main();
 #endif
 

--- a/apps/examples/testcase/le_tc/kernel/tc_libc_unistd.c
+++ b/apps/examples/testcase/le_tc/kernel/tc_libc_unistd.c
@@ -50,6 +50,7 @@ static void *pipe_tx_func(void *arg)
 	for (tx_iter = 0; tx_iter < 10; tx_iter++) {
 		write(pipe_fd[1], msg, MSG_SIZE);
 	}
+	sem_post(&pipe_sem);
 
 	return NULL;
 }
@@ -58,6 +59,7 @@ static void *pipe_rx_func(void *arg)
 {
 	int rx_iter;
 
+	sem_wait(&pipe_sem);
 	for (rx_iter = 0; rx_iter < 10; rx_iter++) {
 		read(pipe_fd[0], pipe_buf, MSG_SIZE);
 		if (strcmp(pipe_buf, msg) != 0) {

--- a/apps/examples/testcase/le_tc/kernel/tc_pthread.c
+++ b/apps/examples/testcase/le_tc/kernel/tc_pthread.c
@@ -1028,6 +1028,7 @@ static void tc_pthread_pthread_mutex_lock_unlock_trylock(void)
 
 	sleep(SEC_2);
 
+#ifdef CONFIG_PTHREAD_MUTEX_TYPES
 	/* initalize mutex with PTHREAD_MUTEX_RECURSIVE attribute */
 	pthread_mutex_init(&g_mutex, &attr);
 
@@ -1042,6 +1043,7 @@ static void tc_pthread_pthread_mutex_lock_unlock_trylock(void)
 
 	ret_chk = pthread_mutex_unlock(&g_mutex);
 	TC_ASSERT_EQ("pthread_mutex_unlock", ret_chk, OK);
+#endif
 
 	/* mutex_lock mutex_unlock check through multi threads */
 	g_mutex_cnt = 0;

--- a/os/include/pthread.h
+++ b/os/include/pthread.h
@@ -296,7 +296,7 @@ struct pthread_mutexattr_s {
 #ifdef CONFIG_PTHREAD_MUTEX_TYPES
 	uint8_t type    : 2; /* Type of the mutex.  See PTHREAD_MUTEX_* definitions */
 #endif
-#ifdef CONFIG_PTHREAD_MUTEX_BOTH
+#if defined(CONFIG_PTHREAD_MUTEX_BOTH) || defined(CONFIG_PTHREAD_MUTEX_ROBUST)
 	uint8_t robust  : 1; /* PTHREAD_MUTEX_STALLED or PTHREAD_MUTEX_ROBUST */
 #endif
 };


### PR DESCRIPTION
1) Fix for tc libc sleep fail.
2) Fix for tc build error when CONFIG_PTHREAD_MUTEX_TYPES disabled.