### PR TITLE
fs/Kconfig: make invisible user-fs options when mountpoints are disabled

### DIFF
--- a/os/fs/Kconfig
+++ b/os/fs/Kconfig
@@ -28,6 +28,7 @@ config FS_WRITABLE
 	bool
 	default y
 
+if !DISABLE_MOUNTPOINT
 source fs/aio/Kconfig
 source fs/semaphore/Kconfig
 source fs/mqueue/Kconfig
@@ -36,6 +37,7 @@ source fs/procfs/Kconfig
 source fs/romfs/Kconfig
 source fs/driver/block/Kconfig
 source fs/driver/mtd/Kconfig
+endif
 
 comment "System Logging"
 


### PR DESCRIPTION
* With mountpoints disabled it is meaningless to configurate options
  for filesystems, which are required to be mounted.

Signed-off-by: Oleg Lyovin <o.lyovin@partner.samsung.com>