### PR TITLE
arch/board/*_tash: hide all user-fs configuration with mountpoints di…

### DIFF
--- a/os/arch/arm/src/artik053/src/artik053_tash.c
+++ b/os/arch/arm/src/artik053/src/artik053_tash.c
@@ -272,6 +272,7 @@ int board_app_initialize(void)
 	struct mtd_dev_s *mtd;
 #endif /* CONFIG_RAMMTD */
 
+#ifndef CONFIG_DISABLE_MOUNTPOINT
 	artik053_configure_partitions();
 
 #ifdef CONFIG_ARTIK053_AUTOMOUNT_USERFS_DEVNAME
@@ -318,6 +319,8 @@ int board_app_initialize(void)
 		}
 	}
 #endif /* CONFIG_RAMMTD */
+
+#endif /* CONFIG_DISABLE_MOUNTPOINT */
 
 #if defined(CONFIG_RTC_DRIVER)
 	{

--- a/os/arch/arm/src/sidk_s5jt200/src/s5jt200_tash.c
+++ b/os/arch/arm/src/sidk_s5jt200/src/s5jt200_tash.c
@@ -271,6 +271,7 @@ int board_app_initialize(void)
 	struct mtd_dev_s *mtd;
 #endif /* CONFIG_RAMMTD */
 
+#ifndef CONFIG_DISABLE_MOUNTPOINT
 	sidk_s5jt200_configure_partitions();
 
 #if defined(CONFIG_SIDK_S5JT200_AUTOMOUNT_ROMFS_DEVNAME)
@@ -348,6 +349,8 @@ int board_app_initialize(void)
 		}
 	}
 #endif /* CONFIG_RAMMTD */
+
+#endif /* CONFIG_DISABLE_MOUNTPOINT */
 
 #ifdef CONFIG_S5J_I2C
 	s5j_i2c_register(0);


### PR DESCRIPTION
…sabled

* Having mounpoints disabled system must not perform configuration of
  any non user (non-pseudo in NuttX terminology) filesystems.

Signed-off-by: Oleg Lyovin <o.lyovin@partner.samsung.com>