### PR TITLE
artik053/Kconfig: made ARTIK053_AUTOMOUNT_USERFS dependent on FS_SMARTFS

### DIFF
--- a/os/arch/arm/src/artik053/Kconfig
+++ b/os/arch/arm/src/artik053/Kconfig
@@ -87,6 +87,7 @@ config ARTIK053_AUTOMOUNT_USERFS
 	bool "Automount user r/w partiton"
 	default n
 	depends on ARTIK053_AUTOMOUNT
+	depends on FS_SMARTFS
 	---help---
 		If enabled, user r/w partition will be mounted automatically
 		at boot.


### PR DESCRIPTION
Implementation of userfs partition automount ('artik053_tash.c',
'board_app_initialize()') requires smartfs filesystem support.

Signed-off-by: Oleg Lyovin <o.lyovin@partner.samsung.com>