### PR TITLE
apps/kernel_sample: fix async io test

### DIFF
--- a/apps/examples/kernel_sample/kernel_sample_main.c
+++ b/apps/examples/kernel_sample/kernel_sample_main.c
@@ -323,7 +323,7 @@ static int user_main(int argc, char *argv[])
 		check_test_memory_usage();
 #endif
 
-#ifdef CONFIG_FS_AIO
+#if defined(CONFIG_FS_AIO) && defined(CONFIG_EXAMPLES_KERNEL_SAMPLE_AIO)
 		/* Check asynchronous I/O */
 
 		printf("\nuser_main: AIO test\n");


### PR DESCRIPTION
aio.c compiles only when CONFIG_EXAMPLES_KERNEL_SAMPLE_AIO is enable,
so in order to use it's functions we need to check whether
CONFIG_EXAMPLES_KERNEL_SAMPLE_AIO is enabled.

Signed-off-by: Oleg Lyovin <o.lyovin@partner.samsung.com>