### PR TITLE
pm/Kconfig: make power management settings dependent on SCHED_WORKQUEUE

### DIFF
--- a/os/pm/Kconfig
+++ b/os/pm/Kconfig
@@ -6,6 +6,7 @@
 menuconfig PM
 	bool "Power management (PM) driver interfaces"
 	default n
+	depends on SCHED_WORKQUEUE
 	---help---
 		Power management (PM) driver interfaces.  These interfaces are used
 		to manage power usage of a platform by monitoring driver activity


### PR DESCRIPTION
* The power managment system depends on workqueue support, which
  checks at compile time and cause build failure, if workqueues
  disabled. However, it seems necessary to make PM
  option dependent on SCHED_WORKQUEUE itself.

Signed-off-by: Oleg Lyovin <o.lyovin@partner.samsung.com>