### PR TITLE
drivers/rwbuffer/Kconfig: hide "Buffering" menu with SCHED_WORKQUEUE …

### DIFF
--- a/os/drivers/Kconfig
+++ b/os/drivers/Kconfig
@@ -19,6 +19,7 @@ menu "Buffering"
 
 config DRVR_WRITEBUFFER
 	bool "Enable write buffer support"
+	depends on SCHED_WORKQUEUE
 	default n
 	---help---
 		Enable generic write buffering support that can be used by a variety


### PR DESCRIPTION
…disabled

* The rwbuffer driver depends on workqueue support, which
  checks at compile time and cause build failure, if workqueues
  disabled. However, it seems necessary to make "Buffering"
  menu dependent on SCHED_WORKQUEUE itself.

Signed-off-by: Oleg Lyovin <o.lyovin@partner.samsung.com>