### PR TITLE
include/netdev: include missing header

### DIFF
--- a/os/include/tinyara/net/netdev.h
+++ b/os/include/tinyara/net/netdev.h
@@ -77,6 +77,10 @@
 
 #include <tinyara/net/ip.h>
 
+#ifndef CONFIG_NET_MULTIBUFFER
+#include <net/lwip/netif.h>
+#endif
+
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/


### PR DESCRIPTION
* If CONFIG_NET_MULTIBUFFER is not defined, then static buffer
  for holding packets allocated and it's size depends on MAX_NET_DEV_MTU
  constant. Included header with it's definition.

Signed-off-by: Oleg Lyovin <o.lyovin@partner.samsung.com>