### PR TITLE
lib/libc/Kconfig: make FLOATINGPOINT dependent on LIBM support

### DIFF
--- a/lib/libc/Kconfig
+++ b/lib/libc/Kconfig
@@ -45,6 +45,7 @@ config NOPRINTF_FIELDWIDTH
 
 config LIBC_FLOATINGPOINT
 	bool "Enable floating point in printf"
+	depends on LIBM
 	default n
 	---help---
 		By default, floating point


### PR DESCRIPTION
* LIBC_FLOATINGPOINT option enables printing float point in printf,
  and the implementation of it depends on libm functions.

Signed-off-by: Oleg Lyovin <o.lyovin@partner.samsung.com>