### PR TITLE
lib/libc: fix 'unsuned variable' compilation error

### DIFF
--- a/lib/libc/stdio/lib_dtoa.c
+++ b/lib/libc/stdio/lib_dtoa.c
@@ -735,12 +735,10 @@ static const double tens[] = {
 
 #ifdef IEEE_Arith
 static const double bigtens[] = { 1e16, 1e32, 1e64, 1e128, 1e256 };
-static const double tinytens[] = { 1e-16, 1e-32, 1e-64, 1e-128, 1e-256 };
 
 #define n_bigtens 5
 #else
 static const double bigtens[] = { 1e16, 1e32 };
-static const double tinytens[] = { 1e-16, 1e-32 };
 
 #define n_bigtens 2
 #endif


### PR DESCRIPTION
Signed-off-by: Oleg Lyovin <o.lyovin@partner.samsung.com>