### PR TITLE
logm: Fix overflow detection logic.

### DIFF
--- a/os/logm/logm_process.c
+++ b/os/logm/logm_process.c
@@ -81,7 +81,7 @@ int logm_task(int argc, char *argv[])
 			if (LOGM_STATUS(LOGM_BUFFER_OVERFLOW)) {
 				LOGM_STATUS_CLEAR(LOGM_BUFFER_OVERFLOW);
 			}
-			if (g_logm_overflow_offset >= 0 && g_logm_overflow_offset == g_logm_head) {
+			if (g_logm_overflow_offset >= 0 && g_logm_overflow_offset == g_logm_head && g_logm_dropmsg_count > 0) {
 				fprintf(stdout, "\n[LOGM BUFFER OVERFLOW] %d messages are dropped\n", g_logm_dropmsg_count);
 				g_logm_overflow_offset = -1;
 			}


### PR DESCRIPTION
Currently logm decides overflow happens even if g_logm_dropmsg_count is
zero. This is not correct. This patch add condition to overflow detection
logic to check g_logm_dropmsg_count is greater than zero.

Change-Id: Id792f044def1a68cd89ae01201dda88edc1131e9
Signed-off-by: EunBong Song <eunb.song@samsung.com>