### PR TITLE
Adjust the allocated size 1~ALLOC_MAX_SIZE in tc_umm_heap_random_malloc

### DIFF
--- a/apps/examples/testcase/le_tc/kernel/tc_umm_heap.c
+++ b/apps/examples/testcase/le_tc/kernel/tc_umm_heap.c
@@ -180,6 +180,7 @@ static void tc_umm_heap_memalign(struct tcb_s *st_tcb)
 */
 static void tc_umm_heap_random_malloc(struct tcb_s *st_tcb)
 {
+	struct mallinfo info;
 	int *mem_ptr[ALLOC_FREE_TIMES] = { NULL };
 	int allocated[ALLOC_FREE_TIMES] = { 0 };
 	int alloc_cnt;
@@ -191,15 +192,23 @@ static void tc_umm_heap_random_malloc(struct tcb_s *st_tcb)
 	for (alloc_tc_cnt = 0; alloc_tc_cnt < TEST_TIMES; alloc_tc_cnt++) {
 		allocated_size = 0;
 		for (alloc_cnt = 0; alloc_cnt < ALLOC_FREE_TIMES; alloc_cnt++) {
-			allocated[alloc_cnt] = rand();
+			allocated[alloc_cnt] = rand() + 1;
+			info = mallinfo();
 			mem_ptr[alloc_cnt] = (int *)malloc(allocated[alloc_cnt]);
-			TC_ASSERT_NOT_NULL("malloc", mem_ptr[alloc_cnt]);
+			if (info.mxordblk > allocated[alloc_cnt]) {
+				TC_ASSERT_NOT_NULL("malloc", mem_ptr[alloc_cnt]);
+			} else {
+				TC_ASSERT_EQ("malloc", mem_ptr[alloc_cnt], NULL);
+				allocated[alloc_cnt] = 0;
+			}
 		}
 		for (alloc_cnt = 0; alloc_cnt < ALLOC_FREE_TIMES; alloc_cnt++) {
 			/* do alloc 'allocated[alloc_cnt]',
 			   but allocated MM_ALIGN_UP'(allocated[alloc_cnt] + SIZEOF_MM_ALLOCNODE)',
 			   because of the chunk size */
-			allocated_size += MM_ALIGN_UP(allocated[alloc_cnt] + SIZEOF_MM_ALLOCNODE);
+			if (allocated[alloc_cnt] > 0) {
+				allocated_size += MM_ALIGN_UP(allocated[alloc_cnt] + SIZEOF_MM_ALLOCNODE);
+			}
 		}
 		TC_ASSERT_EQ_ERROR_CLEANUP("malloc", st_tcb->curr_alloc_size, allocated_size, get_errno(), mem_deallocate_func(mem_ptr, ALLOC_FREE_TIMES));
 		mem_deallocate_func(mem_ptr, ALLOC_FREE_TIMES);


### PR DESCRIPTION
tc_umm_heap_random_malloc fails if rand() generates 0.
And depends on board memory size,
too much big size memory allocation causes tc failure.