### PR TITLE
Remove failsafe error setting in pthread_setschedparam.c

### DIFF
--- a/os/kernel/pthread/pthread_setschedparam.c
+++ b/os/kernel/pthread/pthread_setschedparam.c
@@ -141,10 +141,6 @@ int pthread_setschedparam(pthread_t thread, int policy, FAR const struct sched_p
 
 	svdbg("thread ID=%d policy=%d param=0x%p\n", thread, policy, param);
 
-	/* Set the errno to some non-zero value (failsafe) */
-
-	set_errno(EINVAL);
-
 	/* Let sched_setscheduler do all of the work */
 
 	ret = sched_setscheduler((pid_t)thread, policy, param);


### PR DESCRIPTION
Setting the error no at the beginning of logic is not a good practice as it causes
confusion during successful execution of the API.

When API executes successfully, it does not revert the wrong error code set during
beginning of the logic. Thus we should always make a practice to set the error no
only when logic enters the error case.

Signed-off-by: pradeep.ns <pradeep.ns@samsung.com>