### PR TITLE
modify CONFIG name for automount of artik053 user fs

### DIFF
--- a/os/arch/arm/src/artik053/src/artik053_tash.c
+++ b/os/arch/arm/src/artik053/src/artik053_tash.c
@@ -274,7 +274,7 @@ int board_app_initialize(void)
 
 	artik053_configure_partitions();
 
-#ifdef CONFIG_ARTIK053_AUTOMOUNT_USERFS_DEVNAME
+#ifdef CONFIG_ARTIK053_AUTOMOUNT_USERFS
 	/* Initialize and mount user partition (if we have) */
 	ret = mksmartfs(CONFIG_ARTIK053_AUTOMOUNT_USERFS_DEVNAME, false);
 	if (ret != OK) {
@@ -285,7 +285,7 @@ int board_app_initialize(void)
 			lldbg("ERROR: mounting '%s' failed\n", CONFIG_ARTIK053_AUTOMOUNT_USERFS_DEVNAME);
 		}
 	}
-#endif /* CONFIG_ARTIK053_AUTOMOUNT_USERFS_DEVNAME */
+#endif /* CONFIG_ARTIK053_AUTOMOUNT_USERFS */
 
 #ifdef CONFIG_FS_PROCFS
 	/* Mount the procfs file system */


### PR DESCRIPTION
ARTIK053_AUTOMOUNT_USERFS is a title of automount functionality
of artik053 usr fs. ARTIK053_AUTOMOUNT_USERFS_DEVNAME is one of
components for ARTIK053_AUTOMOUNT_USERFS.