### PR TITLE
arch/s5jt200: make SIDK_S5JT200_FLASH_PART dependent on !DISABLE_MOUN…

### DIFF
--- a/os/arch/arm/src/sidk_s5jt200/Kconfig
+++ b/os/arch/arm/src/sidk_s5jt200/Kconfig
@@ -66,7 +66,10 @@ config SIDK_S5JT200_FLASH_MINOR
 config SIDK_S5JT200_FLASH_PART
 	bool "Enable partition support on FLASH"
 	default n
-	depends on S5J_SFLASH
+	select MTD
+	select MTD_PARTITION
+	select MTD_PROGMEM
+	depends on S5J_SFLASH && !DISABLE_MOUNTPOINT
 	---help---
 		Enables creation of partitions on the FLASH
 


### PR DESCRIPTION
…TPOINT

* Since SIDK_S5JT200_FLASH_PART selects MTD layer specific options, which
  are available only with mountpoints being enabled, SIDK_S5JT200_FLASH_PART
  option must be invisible for user when DISABLE_MOUNTPOINT is enabled.

Change-Id: I0fc8996864c0e71273d0976e2e7f0e3ce2331c6e
Signed-off-by: Oleg Lyovin <o.lyovin@partner.samsung.com>