### PR TITLE
add .gitignore to block adding built file for specific configs

### DIFF
--- a/build/configs/sidk_s5jt200/tools/openocd/.gitignore
+++ b/build/configs/sidk_s5jt200/tools/openocd/.gitignore
@@ -1,0 +1,1 @@
+/partition_map.cfg


### PR DESCRIPTION
The partition_map.cfg is built for specific configs, we don't need to add
that at repository.