### PR TITLE
Fix compilation of arm-linux-gnueabi-gcc-

### DIFF
--- a/lib/libc/math/lib_j0.c
+++ b/lib/libc/math/lib_j0.c
@@ -102,6 +102,7 @@
 
 #include <tinyara/compiler.h>
 #include <math.h>
+#include <sys/types.h>
 
 #include "libm.h"
 

--- a/lib/libc/math/lib_j1.c
+++ b/lib/libc/math/lib_j1.c
@@ -102,6 +102,7 @@
 
 #include <tinyara/compiler.h>
 #include <math.h>
+#include <sys/types.h>
 
 #include "libm.h"
 


### PR DESCRIPTION
When compiling with Linux toolchain, there are build errors like:

```
   math/lib_j1.c: In function ‘pone’:
   math/lib_j1.c:363:2: error: unknown type name ‘double_t’; did you mean
   ‘double’?
     double_t z;
     ^~~~~~~~
```

This patch solves compilation using modern v7.2.0 toolchain.

This PR fixes issue:
https://github.com/Samsung/TizenRT/issues/463

Signed-off-by: Jaroslaw Pelczar <j.pelczar@samsung.com>