### PR TITLE
Fix wrong filenames

### DIFF
--- a/lib/libc/stdio/lib_rawinstream.c
+++ b/lib/libc/stdio/lib_rawinstream.c
@@ -16,9 +16,9 @@
  *
  ****************************************************************************/
 /****************************************************************************
- * libc/stdio/lib_rawsistream.c
+ * libc/stdio/lib_rawinstream.c
  *
- *   Copyright (C) 2014 Gregory Nutt. All rights reserved.
+ *   Copyright (C) 2007-2009, 2011-2012, 2014 Gregory Nutt. All rights reserved.
  *   Author: Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
@@ -65,12 +65,12 @@
  ****************************************************************************/
 
 /****************************************************************************
- * Name: rawsistream_getc
+ * Name: rawinstream_getc
  ****************************************************************************/
 
-static int rawsistream_getc(FAR struct lib_sistream_s *this)
+static int rawinstream_getc(FAR struct lib_instream_s *this)
 {
-	FAR struct lib_rawsistream_s *rthis = (FAR struct lib_rawsistream_s *)this;
+	FAR struct lib_rawinstream_s *rthis = (FAR struct lib_rawinstream_s *)this;
 	int nwritten;
 	char ch;
 
@@ -94,30 +94,18 @@ static int rawsistream_getc(FAR struct lib_sistream_s *this)
 }
 
 /****************************************************************************
- * Name: rawsistream_seek
- ****************************************************************************/
-
-static off_t rawsistream_seek(FAR struct lib_sistream_s *this, off_t offset, int whence)
-{
-	FAR struct lib_rawsistream_s *mthis = (FAR struct lib_rawsistream_s *)this;
-
-	DEBUGASSERT(this);
-	return lseek(mthis->fd, offset, whence);
-}
-
-/****************************************************************************
  * Public Functions
  ****************************************************************************/
 
 /****************************************************************************
- * Name: lib_rawsistream
+ * Name: lib_rawinstream
  *
  * Description:
  *   Initializes a stream for use with a file descriptor.
  *
  * Input parameters:
  *   instream - User allocated, uninitialized instance of struct
- *              lib_rawsistream_s to be initialized.
+ *              lib_rawinstream_s to be initialized.
  *   fd       - User provided file/socket descriptor (must have been opened
  *              for the correct access).
  *
@@ -126,10 +114,9 @@ static off_t rawsistream_seek(FAR struct lib_sistream_s *this, off_t offset, int
  *
  ****************************************************************************/
 
-void lib_rawsistream(FAR struct lib_rawsistream_s *instream, int fd)
+void lib_rawinstream(FAR struct lib_rawinstream_s *instream, int fd)
 {
-	instream->public.get = rawsistream_getc;
-	instream->public.seek = rawsistream_seek;
+	instream->public.get = rawinstream_getc;
 	instream->public.nget = 0;
 	instream->fd = fd;
 }

--- a/lib/libc/stdio/lib_rawsistream.c
+++ b/lib/libc/stdio/lib_rawsistream.c
@@ -16,9 +16,9 @@
  *
  ****************************************************************************/
 /****************************************************************************
- * libc/stdio/lib_rawinstream.c
+ * libc/stdio/lib_rawsistream.c
  *
- *   Copyright (C) 2007-2009, 2011-2012, 2014 Gregory Nutt. All rights reserved.
+ *   Copyright (C) 2014 Gregory Nutt. All rights reserved.
  *   Author: Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
@@ -65,12 +65,12 @@
  ****************************************************************************/
 
 /****************************************************************************
- * Name: rawinstream_getc
+ * Name: rawsistream_getc
  ****************************************************************************/
 
-static int rawinstream_getc(FAR struct lib_instream_s *this)
+static int rawsistream_getc(FAR struct lib_sistream_s *this)
 {
-	FAR struct lib_rawinstream_s *rthis = (FAR struct lib_rawinstream_s *)this;
+	FAR struct lib_rawsistream_s *rthis = (FAR struct lib_rawsistream_s *)this;
 	int nwritten;
 	char ch;
 
@@ -94,18 +94,30 @@ static int rawinstream_getc(FAR struct lib_instream_s *this)
 }
 
 /****************************************************************************
+ * Name: rawsistream_seek
+ ****************************************************************************/
+
+static off_t rawsistream_seek(FAR struct lib_sistream_s *this, off_t offset, int whence)
+{
+	FAR struct lib_rawsistream_s *mthis = (FAR struct lib_rawsistream_s *)this;
+
+	DEBUGASSERT(this);
+	return lseek(mthis->fd, offset, whence);
+}
+
+/****************************************************************************
  * Public Functions
  ****************************************************************************/
 
 /****************************************************************************
- * Name: lib_rawinstream
+ * Name: lib_rawsistream
  *
  * Description:
  *   Initializes a stream for use with a file descriptor.
  *
  * Input parameters:
  *   instream - User allocated, uninitialized instance of struct
- *              lib_rawinstream_s to be initialized.
+ *              lib_rawsistream_s to be initialized.
  *   fd       - User provided file/socket descriptor (must have been opened
  *              for the correct access).
  *
@@ -114,9 +126,10 @@ static int rawinstream_getc(FAR struct lib_instream_s *this)
  *
  ****************************************************************************/
 
-void lib_rawinstream(FAR struct lib_rawinstream_s *instream, int fd)
+void lib_rawsistream(FAR struct lib_rawsistream_s *instream, int fd)
 {
-	instream->public.get = rawinstream_getc;
+	instream->public.get = rawsistream_getc;
+	instream->public.seek = rawsistream_seek;
 	instream->public.nget = 0;
 	instream->fd = fd;
 }


### PR DESCRIPTION
This patch fixes wrong file names of the files:
lib_rawinstream.c
lib_rawoutstream.c
lib_rawsistream.c
lib_rawsostream.c

Signed-off-by: Vidisha Thapa <thapa.v@samsung.com>