### PR TITLE
kdbg_date.c: Fix compilation error on GCC 7

### DIFF
--- a/apps/system/utils/kdbg_date.c
+++ b/apps/system/utils/kdbg_date.c
@@ -73,9 +73,11 @@ static FAR const char *const g_datemontab[] = {
 	"Jul", "Aug", "Sep", "Oct", "Nov", "Dec"
 };
 
+#if defined(CONFIG_LIBC_LOCALTIME) || defined(CONFIG_TIME_EXTENDED)
 static FAR const char *const g_dayofweek[] = {
 	"Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"
 };
+#endif
 
 /****************************************************************************
  * Private Functions


### PR DESCRIPTION
This symbol is used only in day_of_week() function

Fixes following error:

kdbg_date.c:76:30: error: ‘g_dayofweek’ defined but not used
[-Werror=unused-const-variable=]
static FAR const char *const g_dayofweek[] = {

Signed-off-by: Jaroslaw Pelczar <j.pelczar@samsung.com>