### PR TITLE
S5J I2C: fix bus initialization.

### DIFF
--- a/os/arch/arm/src/s5j/s5j_i2c.c
+++ b/os/arch/arm/src/s5j/s5j_i2c.c
@@ -1270,7 +1270,9 @@ struct i2c_dev_s *up_i2cinitialize(int port)
 
 	/* Get I2C private structure */
 	if (g_s5j_i2c_priv[port] != NULL) {
-		return (FAR struct i2c_dev_s *)g_s5j_i2c_priv[port];
+		priv = g_s5j_i2c_priv[port];
+		priv->refs++;
+		return (FAR struct i2c_dev_s *)priv;
 	}
 
 	switch (port) {


### PR DESCRIPTION
Before the bus could only be taken once, otherwise it didn't work.
Even worse, second uninit triggered a DEBUGASSERT failure.

Fixes https://github.com/Samsung/TizenRT/issues/476
Tested (in relevant regard) on Artik053