### PR TITLE
modify a dependancy of flash configuration on artik053 and sidk_s5jt200

### DIFF
--- a/os/arch/arm/src/artik053/Kconfig
+++ b/os/arch/arm/src/artik053/Kconfig
@@ -42,7 +42,7 @@ config ARTIK053_FLASH_PART
 	select MTD
 	select MTD_PARTITION
 	select MTD_PROGMEM
-	depends on S5J_SFLASH && !DISABLE_MOUNTPOINT
+	depends on S5J_SFLASH
 	---help---
 		Enables creation of partitions on the FLASH
 
@@ -81,6 +81,7 @@ config ARTIK053_AUTOMOUNT
        bool "Automount partitions"
        default n
        depends on ARTIK053_FLASH_PART
+	depends on !DISABLE_MOUNTPOINT
        ---help---
 		If enabled, mount userrw and sssrw partitions at boot.
 

--- a/os/arch/arm/src/artik053/Kconfig
+++ b/os/arch/arm/src/artik053/Kconfig
@@ -78,11 +78,11 @@ config ARTIK053_FLASH_PART_NAME
 		Comma separated list of partition names.
 
 config ARTIK053_AUTOMOUNT
-       bool "Automount partitions"
-       default n
-       depends on ARTIK053_FLASH_PART
+	bool "Automount partitions"
+	default n
+	depends on ARTIK053_FLASH_PART
 	depends on !DISABLE_MOUNTPOINT
-       ---help---
+	---help---
 		If enabled, mount userrw and sssrw partitions at boot.
 
 config ARTIK053_AUTOMOUNT_USERFS
@@ -112,22 +112,22 @@ config ARTIK053_AUTOMOUNT_USERFS_MOUNTPOINT
 
 if RAMMTD
 config ARTIK053_RAMMTD_NEBLOCKS
-		int "RAM MTD erase block count"
-		default 64
-		---help---
-				Ramfs size will be RAMMTD_ERASESIZE * SIDK_ARTIK053_RAMMTD_NEBLOCKS.
-				You have to consider total ramsize to alloc ramfs size.
+	int "RAM MTD erase block count"
+	default 64
+	---help---
+		Ramfs size will be RAMMTD_ERASESIZE * SIDK_ARTIK053_RAMMTD_NEBLOCKS.
+		You have to consider total ramsize to alloc ramfs size.
 
 config ARTIK053_RAMMTD_DEV_NUMBER
-		int "device number for mtd of smartfs"
-		default 3
+	int "device number for mtd of smartfs"
+	default 3
 
 config ARTIK053_RAMMTD_DEV_POINT
-		string "Device name of the partition for ramfs r/w file system"
-		default "/dev/smart3"
+	string "Device name of the partition for ramfs r/w file system"
+	default "/dev/smart3"
 
 config ARTIK053_RAMMTD_MOUNT_POINT
-		string "Mountpoint of the partition for ramfs r/w file system"
-		default "/ramfs"
+	string "Mountpoint of the partition for ramfs r/w file system"
+	default "/ramfs"
 endif
 endif

--- a/os/arch/arm/src/sidk_s5jt200/Kconfig
+++ b/os/arch/arm/src/sidk_s5jt200/Kconfig
@@ -66,6 +66,9 @@ config SIDK_S5JT200_FLASH_MINOR
 config SIDK_S5JT200_FLASH_PART
 	bool "Enable partition support on FLASH"
 	default n
+	select MTD
+	select MTD_PARTITION
+	select MTD_PROGMEM
 	depends on S5J_SFLASH
 	---help---
 		Enables creation of partitions on the FLASH
@@ -96,6 +99,7 @@ config SIDK_S5JT200_AUTOMOUNT
 	bool "Automount partitions"
 	default n
 	depends on SIDK_S5JT200_FLASH_PART
+	depends on !DISABLE_MOUNTPOINT
 	---help---
 		If enabled, mount userrw and sssrw partitions at boot.
 


### PR DESCRIPTION
For flash_part config, mtd should be enabled but disable_mountpoint
is not needed. But for automount config, disable_mountpoint should
be checked.