### PR TITLE
Fix build warnings in logm

### DIFF
--- a/os/logm/logm.c
+++ b/os/logm/logm.c
@@ -16,11 +16,15 @@
  *
  ****************************************************************************/
 
+#include <tinyara/config.h>
 #include <stdio.h>
 #include <stdarg.h>
 #include <unistd.h>
+#ifdef CONFIG_ARCH_LOWPUTC
+#include <sched.h>
+#endif
 #include <arch/irq.h>
-#include <tinyara/config.h>
+#include <tinyara/arch.h>
 #include <tinyara/logm.h>
 #include <tinyara/streams.h>
 #ifdef CONFIG_LOGM_TIMESTAMP

--- a/os/logm/logm.h
+++ b/os/logm/logm.h
@@ -80,7 +80,6 @@ EXTERN volatile int logm_print_interval;
  ************************************************************************************/
 int logm_task(int argc, char *argv[]);
 void logm_register_tashcmds(void);
-static int logm_tash(int argc, char **args);
 
 #undef EXTERN
 #if defined(__cplusplus)

--- a/os/logm/logm_tashcmds.c
+++ b/os/logm/logm_tashcmds.c
@@ -18,9 +18,12 @@
 #include <stdio.h>
 #include <unistd.h>
 #include <stdlib.h>
+#include <string.h>
 #include <apps/shell/tash.h>
 #include <tinyara/logm.h>
 #include "logm.h"
+
+static int logm_tash(int argc, char **args);
 
 const static tash_cmdlist_t logm_tashmds[] = {
 	{"logm", logm_tash, TASH_EXECMD_SYNC},


### PR DESCRIPTION
- Add missing include header
- Delete logm_tash definition from logm.h because it is used in a file only