### PR TITLE
apps/init: bind a conditional

### DIFF
--- a/apps/system/init/Make.defs
+++ b/apps/system/init/Make.defs
@@ -16,5 +16,6 @@
 #
 ###########################################################################
 
+ifeq ($(CONFIG_SYSTEM_PREAPP_INIT),y)
 CONFIGURED_APPS += system/init
-
+endif


### PR DESCRIPTION
When CONFIG_SYSTEM_PREAPP_INIT is disabled, init should not be compiled.
So, bind it at Make.defs of init folder