### PR TITLE
Fix memory leak when CONFIG_SMARTFS_USE_SECTOR_BUFFER is enabled

### DIFF
--- a/os/fs/smartfs/smartfs_smart.c
+++ b/os/fs/smartfs/smartfs_smart.c
@@ -345,6 +345,12 @@ static int smartfs_open(FAR struct file *filep, const char *relpath, int oflags,
 	goto errout_with_semaphore;
 
 errout_with_buffer:
+#ifdef CONFIG_SMARTFS_USE_SECTOR_BUFFER
+	if (sf->buffer != NULL) {
+		kmm_free(sf->buffer);
+		sf->buffer = NULL;
+	}
+#endif
 	if (sf->entry.name != NULL) {
 		/* Free the space for the name too */
 


### PR DESCRIPTION
During error case in smartfs_open() , sf->buffer is not freed.

CONFIG_SMARTFS_USE_SECTOR_BUFFER is dependent on CONFIG_MTD_SMART_ENABLE_CRC
When CONFIG_MTD_SMART_ENABLE_CRC is enabled through make menuconfig,  *_SECTOR_BUFFER gets defined and thus , in below logic, there is a chance of potential memory leak incase of failure case in smartfs_open file.

#ifdef CONFIG_MTD_SMART_ENABLE_CRC
#define CONFIG_SMARTFS_USE_SECTOR_BUFFER
#endif

Signed-off-by: pradeep.ns <pradeep.ns@samsung.com>