### PR TITLE
examples/fs_helper: remove unnecessary menu in Kconfig

### DIFF
--- a/apps/examples/fs_helper/Kconfig
+++ b/apps/examples/fs_helper/Kconfig
@@ -3,8 +3,6 @@
 # see kconfig-language at https://www.kernel.org/doc/Documentation/kbuild/kconfig-language.txt
 #
 
-menu "filesystem helper application"
-
 config FILESYSTEM_HELPER_ENABLE
     bool "enable filesystem helper application"
     default n
@@ -49,4 +47,3 @@ config PROCFS_TEST
 
 endif #FILESYSTEM_HELPER_ENABLE
 
-endmenu


### PR DESCRIPTION
For fs helper example, we don't need to make a title.
It cause a wrong block for example.
```
  #
  # Examples
  #
  # CONFIG_EXAMPLES_ARTIK_DEMO is not set
  # CONFIG_EXAMPLES_AWS is not set
  # CONFIG_EXAMPLES_DNSCLIENT_TEST is not set
  # CONFIG_EXAMPLES_DTLS_CLIENT is not set
  # CONFIG_EXAMPLES_DTLS_SERVER is not set
  # CONFIG_EXAMPLES_EEPROM_TEST is not set
  # CONFIG_EXAMPLES_FOTA_SAMPLE is not set

  #
  # filesystem helper application
  #
```