### PR TITLE
Fix typo and remove unused variable in tiva

### DIFF
--- a/os/arch/arm/src/tiva/chip/lm3s_memorymap.h
+++ b/os/arch/arm/src/tiva/chip/lm3s_memorymap.h
@@ -146,7 +146,7 @@
 #define TIVA_TIMER2_BASE    (TIVA_PERIPH_BASE + 0x32000)	/* -0x32fff: Timer 2 */
 #define TIVA_TIMER3_BASE    (TIVA_PERIPH_BASE + 0x33000)	/* -0x33fff: Timer 3 */
 /* -0x37fff: Reserved */
-#define TIVA_ADC_BASE       (TIVA_PERIPH_BASE + 0x38000)	/* -0x38fff: ADC */
+#define TIVA_ADC0_BASE      (TIVA_PERIPH_BASE + 0x38000)	/* -0x38fff: ADC */
 /* -0x3bfff: Reserved */
 #define TIVA_CMP_BASE       (TIVA_PERIPH_BASE + 0x3c000)	/* -0x3cfff: Analog Comparators */
 /* -0x47fff: Reserved */
@@ -184,7 +184,7 @@
 #define TIVA_TIMER1_BASE    (TIVA_PERIPH_BASE + 0x31000)	/* -0x31fff: Timer 1 */
 #define TIVA_TIMER2_BASE    (TIVA_PERIPH_BASE + 0x32000)	/* -0x32fff: Timer 2 */
 /* -0x37fff: Reserved */
-#define TIVA_ADC_BASE       (TIVA_PERIPH_BASE + 0x38000)	/* -0x38fff: ADC */
+#define TIVA_ADC0_BASE      (TIVA_PERIPH_BASE + 0x38000)	/* -0x38fff: ADC */
 /* -0x3bfff: Reserved */
 #define TIVA_CMP_BASE       (TIVA_PERIPH_BASE + 0x3c000)	/* -0x3cfff: Analog Comparators */
 /* -0x47fff: Reserved */
@@ -229,7 +229,7 @@
 #define TIVA_TIMER2_BASE    (TIVA_PERIPH_BASE + 0x32000)	/* -0x32fff: Timer 2 */
 #define TIVA_TIMER3_BASE    (TIVA_PERIPH_BASE + 0x33000)	/* -0x33fff: Timer 3 */
 /* -0x37fff: Reserved */
-#define TIVA_ADC_BASE       (TIVA_PERIPH_BASE + 0x38000)	/* -0x38fff: ADC */
+#define TIVA_ADC0_BASE      (TIVA_PERIPH_BASE + 0x38000)	/* -0x38fff: ADC */
 /* -0x3bfff: Reserved */
 #define TIVA_CMP_BASE       (TIVA_PERIPH_BASE + 0x3c000)	/* -0x3cfff: Analog Comparators */
 /* -0x47fff: Reserved */
@@ -271,7 +271,7 @@
 #define TIVA_TIMER2_BASE    (TIVA_PERIPH_BASE + 0x32000)	/* -0x32fff: Timer 2 */
 #define TIVA_TIMER3_BASE    (TIVA_PERIPH_BASE + 0x33000)	/* -0x33fff: Timer 3 */
 /* -0x37fff: Reserved */
-#define TIVA_ADC_BASE       (TIVA_PERIPH_BASE + 0x38000)	/* -0x38fff: ADC */
+#define TIVA_ADC0_BASE      (TIVA_PERIPH_BASE + 0x38000)	/* -0x38fff: ADC */
 /* -0x3bfff: Reserved */
 #define TIVA_CMP_BASE       (TIVA_PERIPH_BASE + 0x3c000)	/* -0x3cfff: Analog Comparators */
 /* -0x3fffff: Reserved */

--- a/os/arch/arm/src/tiva/tiva_gpioirq.c
+++ b/os/arch/arm/src/tiva/tiva_gpioirq.c
@@ -675,7 +675,6 @@ int tiva_gpioirqattach(uint32_t pinset, xcpt_t isr, void *arg)
 	uint8_t port = (pinset & GPIO_PORT_MASK) >> GPIO_PORT_SHIFT;
 	uint8_t pinno = (pinset & GPIO_PIN_MASK);
 	uint8_t pin = 1 << pinno;
-	int index;
 
 	/* Assign per-pin interrupt handlers */
 


### PR DESCRIPTION
Replace TIVA_ADC_BASE with TIVA_ADC0_BASE
Remove unused variable 'index'