### PR TITLE
kernel, tools: remove unused codes related CONFIG_INIT_FILEPATH

### DIFF
--- a/os/kernel/Kconfig
+++ b/os/kernel/Kconfig
@@ -240,46 +240,6 @@ config INIT_ENTRYPOINT
 
 endchoice # Initialization task
 
-if INIT_FILEPATH
-
-config USER_INITPATH
-	string "Application initialization path"
-	default "/bin/init"
-	---help---
-		The name of the entry point for user applications.  For the example
-		applications this is of the form 'app_main' where 'app' is the application
-		name. If not defined, USER_ENTRYPOINT defaults to "main".
-
-config INIT_SYMTAB
-	string "Symbol table"
-	default "NULL"
-	depends on !BUILD_PROTECTED && !BUILD_KERNEL
-	---help---
-		The name of othe global array that holds the exported symbol table.
-		The special string "NULL" may be provided if there is no symbol
-		table.  Quotation marks will be stripped when config.h is generated.
-
-		NOTE: This setting cannot be used in protected or kernel builds.
-		Any kernel mode symbols tables would not be usable for resolving
-		symbols in user mode executables.
-
-config INIT_NEXPORTS
-	string "Symbol table size"
-	default "0"
-	depends on !BUILD_PROTECTED && !BUILD_KERNEL
-	---help---
-		The size of the symbol table.  NOTE that is is logically a numeric
-		value but is represent by a string.  That allows you to put
-		sizeof(something) or a macro or a global variable name for the
-		symbol table size.  Quotation marks will be stripped when config.h
-		is generated.
-
-		NOTE: This setting cannot be used in protected or kernel builds.
-		Any kernel mode symbols tables would not be usable for resolving
-		symbols in user mode executables.
-
-endif # INIT_FILEPATH
-
 config RR_INTERVAL
 	int "Round robin timeslice (MSEC)"
 	default 0

--- a/os/tools/cfgdefine.c
+++ b/os/tools/cfgdefine.c
@@ -84,12 +84,6 @@ static const char *dequote_list[] = {
 	"CONFIG_PASS1_TARGET",		/* Pass1 build target */
 	"CONFIG_PASS1_OBJECT",		/* Pass1 build object */
 	"CONFIG_DEBUG_OPTLEVEL",	/* Custom debug level */
-	"CONFIG_INIT_SYMTAB",		/* Global symbol table */
-	"CONFIG_INIT_NEXPORTS",		/* Global symbol table size */
-
-	/* RGMP */
-
-	"CONFIG_RGMP_SUBARCH",		/* RGMP sub-architecture */
 
 	/* apps/ definitions */
 


### PR DESCRIPTION
CONFIG_INIT_FILEPATH, CONFIG_INIT_SYMTAB and CONFIG_INIT_NEXPORTS are not
needed anymore. They are not needed and
config already removed so that we can't enable them.