### PR TITLE
Fix the coding rule : libc/string/strncmp

### DIFF
--- a/lib/libc/string/lib_strncmp.c
+++ b/lib/libc/string/lib_strncmp.c
@@ -71,7 +71,7 @@ int strncmp(const char *cs, const char *ct, size_t nb)
 {
 	int result = 0;
 	for (; nb > 0; nb--) {
-		if ((result = (int) * cs - (int) * ct++) != 0 || !*cs++) {
+		if ((result = (int)*cs - (int)*ct++) != 0 || !*cs++) {
 			break;
 		}
 	}


### PR DESCRIPTION
that line is not operation, so space is not needed