### PR TITLE
Modify strncmp 3rd param in kdbg

### DIFF
--- a/apps/system/utils/kdbg_date.c
+++ b/apps/system/utils/kdbg_date.c
@@ -304,9 +304,9 @@ int kdbg_date(int argc, char **args)
 	if (argc == 1) {
 		ret = date_showtime();
 #if !(defined(CONFIG_LIBC_LOCALTIME) || defined(CONFIG_TIME_EXTENDED))
-	} else if (!strncmp(args[1], "-s", strlen("-s")) && argc == 6) {
+	} else if (!strncmp(args[1], "-s", strlen("-s") + 1) && argc == 6) {
 #else
-	} else if (!strncmp(args[1], "-s", strlen("-s")) && (argc >= 7 && argc <= 9)) {
+	} else if (!strncmp(args[1], "-s", strlen("-s") + 1) && (argc >= 7 && argc <= 9)) {
 #endif
 		ret = date_settime(argc, args);
 	} else {

--- a/apps/system/utils/kdbg_env.c
+++ b/apps/system/utils/kdbg_env.c
@@ -31,7 +31,7 @@ int kdbg_env_set(int argc, char **args)
 {
 	int ret;
 
-	if ((argc != 3) || !strncmp(args[1], "--help", strlen("--help"))) {
+	if ((argc != 3) || !strncmp(args[1], "--help", strlen("--help") + 1)) {
 		printf("\nUsage : setenv NAME VALUE\n");
 		printf("Set each NAME to VALUE in the environment");
 		return ERROR;
@@ -53,7 +53,7 @@ int kdbg_env_unset(int argc, char **args)
 {
 	int ret;
 
-	if ((argc != 2) || !strncmp(args[1], "--help", strlen("--help"))) {
+	if ((argc != 2) || !strncmp(args[1], "--help", strlen("--help") + 1)) {
 		printf("\nUsage : unsetenv NAME\n");
 		printf("Remove the variable, NAME from the environment\n");
 		return ERROR;

--- a/apps/system/utils/kdbg_heapinfo.c
+++ b/apps/system/utils/kdbg_heapinfo.c
@@ -64,7 +64,7 @@ int kdbg_heapinfo(int argc, char **args)
 	int mode = HEAPINFO_SIMPLE;
 	int pid = HEAPINFO_PID_NOTNEEDED;
 
-	if (argc >= 2 && !strncmp(args[1], "--help", strlen("--help"))) {
+	if (argc >= 2 && !strncmp(args[1], "--help", strlen("--help") + 1)) {
 		goto usage;
 	}
 

--- a/apps/system/utils/kdbg_kill.c
+++ b/apps/system/utils/kdbg_kill.c
@@ -203,7 +203,7 @@ int kdbg_kill(int argc, char **args)
 		goto usage;
 	}
 
-	if (!strncmp(args[1], "--help", strlen("--help"))) {
+	if (!strncmp(args[1], "--help", strlen("--help") + 1)) {
 		goto usage;
 	}
 
@@ -211,7 +211,7 @@ int kdbg_kill(int argc, char **args)
 		/* For a case that no signal is specified or '-l' option */
 		/* 'kill PID' or 'kill -l' */
 		ptr = args[1];
-		if (!strncmp(ptr, "-l", strlen("-l"))) {
+		if (!strncmp(ptr, "-l", strlen("-l") + 1)) {
 			/* List signal numbers and it's name */
 			for (sigidx = 0; kdbg_sig[sigidx].signame != NULL; sigidx++) {
 				printf("%2d) %-15s\n", kdbg_sig[sigidx].signo, kdbg_sig[sigidx].signame);
@@ -285,7 +285,7 @@ int kdbg_killall(int argc, char **args)
 		goto usage;
 	}
 
-	if (!strncmp(args[1], "--help", strlen("--help"))) {
+	if (!strncmp(args[1], "--help", strlen("--help") + 1)) {
 		goto usage;
 	}
 
@@ -293,7 +293,7 @@ int kdbg_killall(int argc, char **args)
 		/* For a case that no signal is specified or '-l' option */
 		/* 'killall NAME' or 'killall -l' */
 		ptr = args[1];
-		if (!strncmp(ptr, "-l", strlen("-l"))) {
+		if (!strncmp(ptr, "-l", strlen("-l") + 1)) {
 			/* List signal numbers and it's name */
 			for (sigidx = 0; kdbg_sig[sigidx].signame != NULL; sigidx++) {
 				printf("%2d) %-15s\n", kdbg_sig[sigidx].signo, kdbg_sig[sigidx].signame);

--- a/apps/system/utils/kdbg_stackmonitor.c
+++ b/apps/system/utils/kdbg_stackmonitor.c
@@ -221,7 +221,7 @@ int kdbg_stackmonitor(int argc, char **args)
 	pthread_attr_t stkmon_attr;
 
 	if (argc > 1) {
-		if (!strncmp(args[1], "stop", strlen("stop"))) {
+		if (!strncmp(args[1], "stop", strlen("stop") + 1)) {
 			/* stop the stackmonitor */
 			stackmonitor_stop();
 			return OK;

--- a/apps/system/utils/kdbg_stackopt.c
+++ b/apps/system/utils/kdbg_stackopt.c
@@ -60,7 +60,7 @@ static bool find_app(TASH_CMD_CALLBACK *cb, char *name)
 	
 	for (cmd_idx = 0; cmd_idx < count; cmd_idx++) {
 		if (tash_get_cmdpair(str, cb, cmd_idx) == OK) {
-			if (!strncmp(name, str, strlen(name))) {
+			if (!strncmp(name, str, strlen(name) + 1)) {
 				flag = true;
 				break;
 			}
@@ -137,7 +137,7 @@ int kdbg_stackopt(int argc, char **args)
 		goto usage;
 	}
 	
-	if (!strncmp(args[1], "--help", strlen("--help"))) {
+	if (!strncmp(args[1], "--help", strlen("--help") + 1)) {
 		goto usage;
 	}
 	

--- a/apps/system/utils/kdbg_ttrace.c
+++ b/apps/system/utils/kdbg_ttrace.c
@@ -180,7 +180,7 @@ static int parse_args(int argc, char **args)
 static int check_args_validation(int argc, char **args)
 {
 	ttdbg("argc: %d, args[1]: %s\r\n", argc, args[1]);
-	if (argc == 1 || (strncmp(args[1], "--help", strlen("--help")) == 0)) {
+	if (argc == 1 || (strncmp(args[1], "--help", strlen("--help") + 1) == 0)) {
 		show_help();
 		return TTRACE_INVALID;
 	}


### PR DESCRIPTION
if only strlen, security issue can occur. so we should check strlen + 1 size.