### PR TITLE
Fix doxygen comment for arastorage in framework/include/arastorage/arastorage.h

### DIFF
--- a/framework/include/arastorage/arastorage.h
+++ b/framework/include/arastorage/arastorage.h
@@ -52,9 +52,9 @@
  */
 
 /**
- * @ingroup AraStorage
- * @defgroup AraStorage AraStorage
+ * @defgroup ARASTORAGE ARASTORAGE
  * @brief Provides APIs for Lightweight Database
+ * @ingroup ARASTORAGE
  * @{
  */
 


### PR DESCRIPTION
The group name, ARASTORAGE is used in ingroup before being defined by defgroup.
Defgroup which means definition of group should be in front of ingroup.