### PR TITLE
 Added support for separate device registeration for play and capture.

### DIFF
--- a/os/arch/arm/src/artik053/src/artik053_alc5658.c
+++ b/os/arch/arm/src/artik053/src/artik053_alc5658.c
@@ -285,6 +285,9 @@ int s5j_alc5658_initialize(int minor)
 		/* Now we can use these I2C and I2S interfaces to initialize the
 		 * ALC5658 which will return an audio interface.
 		 */
+		/* Create a device name */
+#ifdef CONFIG_AUDIO_MULTI_CARD
+		snprintf(devname, 12, "pcmC%uD%u%c", minor, 0, 'c');
 
 		alc5658 = alc5658_initialize(i2c, i2s, &g_alc5658info.lower);
 		if (!alc5658) {
@@ -305,9 +308,38 @@ int s5j_alc5658_initialize(int minor)
 			goto errout_with_alc5658;
 		}
 
-		/* Create a device name */
+		ret = audio_register(devname, pcm);
+		if (ret < 0) {
+			auddbg("ERROR: Failed to register /dev/%s device: %d\n", devname, ret);
+			goto errout_with_pcm;
+		}
 
-		snprintf(devname, 12, "pcm%d", minor);
+		snprintf(devname, 12, "pcmC%uD%u%c", minor, 0, 'p');
+
+#else
+		snprintf(devname, 12, "pcmC%u", minor);
+#endif
+
+		alc5658 = alc5658_initialize(i2c, i2s, &g_alc5658info.lower);
+		if (!alc5658) {
+			auddbg("ERROR: Failed to initialize the ALC5658\n");
+			ret = -ENODEV;
+			goto errout_with_irq;
+		}
+
+		/* No we can embed the ALC5658/I2C/I2S conglomerate into a PCM decoder
+		 * instance so that we will have a PCM front end for the the ALC5658
+		 * driver.
+		 */
+
+		pcm = pcm_decode_initialize(alc5658);
+		if (!pcm) {
+			auddbg("ERROR: Failed create the PCM decoder\n");
+			ret = -ENODEV;
+			goto errout_with_alc5658;
+		}
+
+
 
 		/* Finally, we can register the PCM/ALC5658/I2C/I2S audio device.
 		 *

--- a/os/arch/arm/src/artik053/src/artik053_alc5658.c
+++ b/os/arch/arm/src/artik053/src/artik053_alc5658.c
@@ -287,8 +287,15 @@ int s5j_alc5658_initialize(int minor)
 		 */
 		/* Create a device name */
 #ifdef CONFIG_AUDIO_MULTI_CARD
+
+		/*Device name for capture interface of sound card */
 		snprintf(devname, 12, "pcmC%uD%u%c", minor, 0, 'c');
 
+
+		/* ALC5658 initiliased for capture device */
+		/* Now we can use these I2C and I2S interfaces to initialize the
+		 * ALC5658 which will return an audio interface.
+		 */
 		alc5658 = alc5658_initialize(i2c, i2s, &g_alc5658info.lower);
 		if (!alc5658) {
 			auddbg("ERROR: Failed to initialize the ALC5658\n");
@@ -314,11 +321,16 @@ int s5j_alc5658_initialize(int minor)
 			goto errout_with_pcm;
 		}
 
+		/*Device name for playback interface of sound card */
 		snprintf(devname, 12, "pcmC%uD%u%c", minor, 0, 'p');
 
 #else
+		/*Device name for both playback and capture interfaces of sound card */
 		snprintf(devname, 12, "pcmC%u", minor);
 #endif
+		/* Now we can use these I2C and I2S interfaces to initialize the
+		 * ALC5658 which will return an audio interface.
+		 */
 
 		alc5658 = alc5658_initialize(i2c, i2s, &g_alc5658info.lower);
 		if (!alc5658) {

--- a/os/audio/Kconfig
+++ b/os/audio/Kconfig
@@ -60,6 +60,11 @@ config AUDIO_DRIVER_SPECIFIC_BUFFERS
 
 endmenu # Audio Buffer Configuration
 
+config AUDIO_MULTI_CARD
+	bool "Registering audio device as different devices for capture and playback"
+	default n
+
+
 config DEBUG_AUDIO_ERROR
 	bool "Output AUDIO Error Debug Messages"
 	default n


### PR DESCRIPTION
alc5658 audio device can be registered as two seperate devices.
The device naming format is "/dev/audio/pcmC%dD%d%c",card,device,(playback or capture flag).

Changed the device opening format in tinyalsa to open the device registered as a single device for both playback and capture.