### PR TITLE
external: delete output of built, Make.dep at distclean

### DIFF
--- a/external/Makefile
+++ b/external/Makefile
@@ -132,6 +132,7 @@ clean: $(foreach SDIR, $(BUILDIRS), $(SDIR)_clean) iotivity_clean
 
 distclean: $(foreach SDIR, $(BUILDIRS), $(SDIR)_distclean)
 	$(call DELFILE, .depend)
+	$(call DELFILE, Make.dep)
 	$(call DELFILE, $(BIN))
 	$(call CLEAN)
 


### PR DESCRIPTION
The Make.dep is an output of built so that it should be clean when
we execute "make distclean".