### PR TITLE
external: add header files that require iotivity

### DIFF
--- a/external/Kconfig
+++ b/external/Kconfig
@@ -73,6 +73,7 @@ config ENABLE_IOTIVITY
 	default n
 	select LIBC_NETDB
 	select TIME_EXTENDED
+	select ARCH_STDARG_H
 	---help---
 		select to enable the iotivity stack in tinyara
 


### PR DESCRIPTION
To handle variable arguments in iotivity, you need the stdarg.h file.
This patch allows you to include this file.

Change-Id: I3c6afee312542764c94ced931e9563ed70090875
Signed-off-by: Junhwan Park <junhwan.park@samsung.com>