### PR TITLE
Fix: Use correct type of 'fabs' API

### DIFF
--- a/lib/libc/math/lib_logf.c
+++ b/lib/libc/math/lib_logf.c
@@ -74,7 +74,7 @@ float logf(float x)
 			y = -700.0;
 		}
 
-		epsilon = (fabs(y) > 1.0) ? fabs(y) * FLT_EPSILON : FLT_EPSILON;
+		epsilon = (fabsf(y) > 1.0) ? fabsf(y) * FLT_EPSILON : FLT_EPSILON;
 	}
 
 	if (y == 700.0) {

--- a/lib/libc/math/lib_modff.c
+++ b/lib/libc/math/lib_modff.c
@@ -57,7 +57,7 @@ float modff(float x, float *iptr)
 	if (fabsf(x) >= 8388608.0) {
 		*iptr = x;
 		return 0.0;
-	} else if (fabs(x) < 1.0) {
+	} else if (fabsf(x) < 1.0) {
 		*iptr = (x * 0.0);
 		return x;
 	} else {

--- a/lib/libc/math/lib_modfl.c
+++ b/lib/libc/math/lib_modfl.c
@@ -58,10 +58,10 @@
 #ifdef CONFIG_HAVE_LONG_DOUBLE
 long double modfl(long double x, long double *iptr)
 {
-	if (fabs(x) >= 4503599627370496.0) {
+	if (fabsl(x) >= 4503599627370496.0) {
 		*iptr = x;
 		return 0.0;
-	} else if (fabs(x) < 1.0) {
+	} else if (fabsl(x) < 1.0) {
 		*iptr = (x * 0.0);
 		return x;
 	} else {


### PR DESCRIPTION
Use correct type of 'fabs' API in modff, modfl and logf implementations.

Signed-off-by: Lokesh B V <lokesh.bv@partner.samsung.com>