### PR TITLE
Fix iotivity init bug in psk setup

### DIFF
--- a/external/iotivity/iotivity_1.2-rel/resource/csdk/connectivity/src/adapter_util/ca_adapter_net_ssl.c
+++ b/external/iotivity/iotivity_1.2-rel/resource/csdk/connectivity/src/adapter_util/ca_adapter_net_ssl.c
@@ -1504,7 +1504,7 @@ static int InitPskIdentity(mbedtls_ssl_config * config)
         OIC_LOG_V(DEBUG, NET_SSL_TAG, "Out %s", __func__);
         return -1;
     }
-    if (0 != mbedtls_ssl_conf_psk(config, idBuf, 0, idBuf, UUID_LENGTH))
+    if (0 != mbedtls_ssl_conf_psk(config, idBuf, 1, idBuf, UUID_LENGTH))
     {
         OIC_LOG(ERROR, NET_SSL_TAG, "Identity initialization failed!");
         OIC_LOG_V(DEBUG, NET_SSL_TAG, "Out %s", __func__);


### PR DESCRIPTION
- In Ubuntu, malloc with zero-size returns a specified address, so the process will be continued.
- But in TizenRT, malloc with zero-size returns NULL.
- The mbedtls_ssl_conf_psk() should be done for initialize, but it always return error code because of NULL.
- Actually, in this step, <const unsigned char *psk, size_t psk_len> are not important at all.
- So to complete mbedtls_ssl_conf_psk(), mbedtls_ssl_conf_psk() should be called with at least 1byte.
