### PR TITLE
Fix svace issue : kdbg_stackopt array index error

### DIFF
--- a/apps/system/utils/kdbg_stackopt.c
+++ b/apps/system/utils/kdbg_stackopt.c
@@ -113,17 +113,17 @@ static void print_measure_result(pid_t pid, int argc, char **args)
 	int stkmon_idx;
 	for (stkmon_idx = 0; stkmon_idx < CONFIG_MAX_TASKS * 2; stkmon_idx++) {
 		if (stkmon_arr[stkmon_idx].chk_pid == pid) {
-			break;
+			printf("---------------------------------------------------------------\n");
+			printf(">> Stack Size Measure Finish\n");
+			printf("APP Name : %s\n", stkmon_arr[stkmon_idx].chk_name);
+			printf("Allocate %d stack size for measure\n",  stkmon_arr[stkmon_idx].chk_stksize);
+			printf("Optimal Stack Size is %d\n", stkmon_arr[stkmon_idx].chk_peaksize + get_frame_size(argc, args));
+			printf("If the arguments are changed, optimal stack size can be changed\n");
+			printf("---------------------------------------------------------------\n");
+			return;
 		}
 	}
-
-	printf("---------------------------------------------------------------\n");
-	printf(">> Stack Size Measure Finish\n");
-	printf("APP Name : %s\n", stkmon_arr[stkmon_idx].chk_name);
-	printf("Allocate %d stack size for measure\n",  stkmon_arr[stkmon_idx].chk_stksize);
-	printf("Optimal Stack Size is %d\n", stkmon_arr[stkmon_idx].chk_peaksize + get_frame_size(argc, args));
-	printf("If the arguments are changed, optimal stack size can be changed\n");
-	printf("---------------------------------------------------------------\n");
+	printf("[ERROR] Cannot find the app\n");
 	return;
 }
 


### PR DESCRIPTION
Buffer '&stkmon_arr' of size 64 accessed at kdbg_stackopt.c:124 can overflow, since its index 'stkmon_idx' can have value 64
 that is out of range, as indicated by preceding conditional expression at kdbg_stackopt.c:114.