### PR TITLE
Remove call statement which is called when network interface down

### DIFF
--- a/external/iotivity/iotivity_1.2-rel/resource/csdk/connectivity/src/ip_adapter/tizenrt/caipnwmonitor.c
+++ b/external/iotivity/iotivity_1.2-rel/resource/csdk/connectivity/src/ip_adapter/tizenrt/caipnwmonitor.c
@@ -324,8 +324,6 @@ u_arraylist_t *CAFindInterfaceChange()
 
 	if(buf[0] == 'd' && buf[1] == 'e' && buf[2] == 'l') {
 		printf("Receive the event(IF is down)\n");
-		CARemoveNetworkMonitorList(0);
-		CAIPPassNetworkChangesToAdapter(CA_INTERFACE_DOWN);
 	}
 	else if(buf[0] == 'g' && buf[1] == 'e' && buf[2] == 'n') {
 		printf("Receive the event(IF is UP)\n");


### PR DESCRIPTION
- 'Interface down' is a burden process in iotivity for TizenRT
- We need to keep tcp setting while device is on.
