### PR TITLE
Fix Svace issues in wifi_test.c

### DIFF
--- a/apps/examples/wifi_test/wifi_test.c
+++ b/apps/examples/wifi_test/wifi_test.c
@@ -204,15 +204,16 @@ int wifi_test_proc(int argc, char *argv[])
 		memset(payload, 0, BUF_MAX_SIZE);
 
 		printScanResult(scan_info);
-		sprintf(payload, "/%s|", DEVICE_NAME);
+		snprintf(payload, BUF_MAX_SIZE, "/%s|", DEVICE_NAME);
 		for (i = 0; i < aps_cnt; i++) {
 			sprintf(buf, "%02d:%d/", g_aps[i].id, g_aps[i].rssi);
-			strcat(payload, buf);
+			strncat(payload, buf, strlen(buf));
 		}
 		printf("[WiFi] PAYLOAD : %s\n", payload);
 		if (sendto(fd, payload, strlen(payload), 0, (struct sockaddr *)&dest, sizeof(struct sockaddr_in)) == -1) {
 			printf("[WiFi] Failed to sendto UDP.\n");
 			ret = -1;
+			closesocket(fd);
 			goto error_out;
 		}
 		/* Type in code to free WiFi scan data. Do check and


### PR DESCRIPTION
1. use strncat instead of strcat.
2. use snprintf instead of sprintf
3. close socket fd when send() fails.