### PR TITLE
Provide fine-grained control for artik053 flashing

### DIFF
--- a/build/configs/artik053/artik053_download.sh
+++ b/build/configs/artik053/artik053_download.sh
@@ -21,6 +21,14 @@
 # Description : Download script for ARTIK 053
 
 # Remember, make is invoked from "os" directory
+function warn() {
+	echo "WARNING: $@" >&2
+}
+
+function die() {
+	echo "FATAL: $@" >&2
+	exit 1
+}
 
 # Include the configuration file
 source .config
@@ -31,113 +39,133 @@ BOARD_DIR_PATH=${BUILD_DIR_PATH}/configs/artik053
 OPENOCD_DIR_PATH=${BOARD_DIR_PATH}/tools/openocd
 FW_DIR_PATH=${BOARD_DIR_PATH}/bin
 
-SYSTEM_TYPE=`getconf LONG_BIT`
-if [ "$SYSTEM_TYPE" = "64" ]; then
-	OPENOCD_BIN_PATH=${OPENOCD_DIR_PATH}/linux64
+CFG_FILE=artik053.cfg
+
+
+if ! which openocd >/dev/null; then
+	SYSTEM_TYPE=`getconf LONG_BIT`
+	if [ "$SYSTEM_TYPE" = "64" ]; then
+		OPENOCD_BIN_PATH=${OPENOCD_DIR_PATH}/linux64
+	else
+		OPENOCD_BIN_PATH=${OPENOCD_DIR_PATH}/linux32
+	fi
+	OPENOCD=${OPENOCD_BIN_PATH}/openocd
 else
-	OPENOCD_BIN_PATH=${OPENOCD_DIR_PATH}/linux32
+	OPENOCD=openocd
 fi
 
-prepare_download()
-{
-	# Prepare for ROMFS
-	if [ "${CONFIG_FS_ROMFS}" == "y" ]; then
-		OPENOCD_ROMFS="set romfs_partition_enable 1; echo \"romfs is enabled\""
-	else
-		OPENOCD_ROMFS="set romfs_partition_enable 0; echo \"romfs is disabled\""
-	fi
-}
-
-finish_download()
-{
-	exit $1
-}
-
-romfs()
-{
-	# Make romfs.img
-	if [ "${CONFIG_FS_ROMFS}" == "y" ]; then
-		pushd ${OS_DIR_PATH}
-		sh ../tools/fs/mkromfsimg.sh
-		if [ ! -f "../build/output/bin/romfs.img" ]; then
-			echo "ROMFS image is not present"
-			finish_download 1
-		fi
-		popd
-
-		pushd ${OPENOCD_DIR_PATH}
-		${OPENOCD_BIN_PATH}/openocd -c "${OPENOCD_ROMFS}" -f artik053.cfg -c ' 	\
-		flash_write rom ../../../../output/bin/romfs.img; \
-		exit' || finish_download 1
-		popd
-	fi
-}
-
-main()
-{
-	echo "openocd is picked from ${OPENOCD_BIN_PATH}"
-	echo "Binaries are picked from ${OUTPUT_BINARY_PATH}"
-	echo "Board path is ${BOARD_DIR_PATH}"
-
-	prepare_download
-
-	# Process arguments
-	for arg in $@
-	do
-		case ${arg} in
-		ALL|all)
-			echo "ALL :"
-
-			# check existence of os binary
-			if [ ! -f "${OUTPUT_BINARY_PATH}/tinyara_head.bin" ]; then
-				echo "TinyAra binary is not existed, build first"
-				finish_download 1
-			fi
-
-			# check existence of firmware binaries
-			if [ ! -f "${FW_DIR_PATH}/bl1.bin" ] ||\
-				[ ! -f "${FW_DIR_PATH}/bl2.bin" ] ||\
-				[ ! -f "${FW_DIR_PATH}/sssfw.bin" ] ||\
-				[ ! -f "${FW_DIR_PATH}/wlanfw.bin" ]; then
-				echo "Firmware binaries for ARTIK 053 are not existed"
-				finish_download 1
-			fi
-
-			# Download all binaries using openocd script
-			pushd ${OPENOCD_DIR_PATH}
-			${OPENOCD_BIN_PATH}/openocd -c "${OPENOCD_ROMFS}" -f artik053.cfg -c ' 	\
-			flash_write bl1 ../../bin/bl1.bin; 		\
-			flash_write bl2 ../../bin/bl2.bin; 		\
-			flash_write sssfw ../../bin/sssfw.bin; 		\
-			flash_write wlanfw ../../bin/wlanfw.bin;	\
-			flash_write os ../../../../output/bin/tinyara_head.bin;	\
-			exit' || finish_download 1
-			popd
-
-			# check romfs and download it
-			romfs
-			;;
-
-		ERASE_USERFS|erase_userfs)
-			echo "USERFS :"
-
-			pushd ${OPENOCD_DIR_PATH}
-			${OPENOCD_BIN_PATH}/openocd -c "${OPENOCD_ROMFS}" -f artik053.cfg -c ' 	\
-			flash_erase_part user;	\
-			exit' || finish_download 1
-			popd
-			;;
-
+# In - $@ (download parameters: [bl] [bl1] [bl2] [sssfw] [wlan] [os] [rom])
+function compute_fw_parts() {
+	bl1=0; bl2=2; sssfw=0; wlanfw=0; os=0; rom=0;
+	for arg in "$@"; do
+		case "${arg}" in
+		BL|bl)
+			bl1=1;bl2=1;;
+		bl1|BL1)
+			bl1=1;;
+		bl2|BL2)
+			bl2=1;;
+		sssfw|ssfw|sfw)
+			sssfw=1;;
+		wlan|wlanfw)
+			wlanfw=1;;
+		os|OS|tizenrt)
+			os=1;;
+		rom|romfs|ROM|ROMFS)
+			rom=1;;
+		ALL)
+			bl1=1; bl2=1; sssfw=1; wlanfw=1; os=1; rom=1;;
 		*)
-			echo "${arg} is not suppported in artik053"
-			echo "Usage : make download [ ALL | ERASE_USERFS ]"
-			finish_download 1
-			;;
+			warn "Unknown fw part ${arg}";;
 		esac
 	done
 
-	finish_download
+	parts=
+	for var in bl1 bl2 sssfw wlanfw os rom; do
+		eval value='${'${var}:-}
+		if [ "x${value:-}" == x1 ]; then
+			parts+=" ${var}"
+		fi
+	done
+	[ -z "${parts}" ] || echo ${parts}
 }
 
-main $*
+# Exit if the file is not there
+function ensure_file() {
+	[ -f "${1:?}" ] || die "missing file $1"
+}
 
+# $@ - bl1 bl2 sssfw wlanfw os rom
+function compute_ocd_commands() {
+	commands=
+	for part in "$@"; do
+		case "${part}" in
+		bl1|bl2|sssfw|wlanfw)
+			ensure_file ${FW_DIR_PATH}/${part}.bin
+			commands+="flash_write ${part} ${FW_DIR_PATH}/${part}.bin; ";;
+		os)
+			ensure_file ${OUTPUT_BINARY_PATH}/tinyara_head.bin
+			commands+="flash_write ${part} ${OUTPUT_BINARY_PATH}/tinyara_head.bin; ";;
+		rom)
+			ensure_file ${OUTPUT_BINARY_PATH}/romfs.img
+			commands+="flash_write ${part} ${OUTPUT_BINARY_PATH}/romfs.img; ";;
+		*)
+			warn "Unrecognized firmware part ${part}";;
+		esac
+	done
+	echo ${commands}
+}
+
+function setup_romfs_variable() {
+	# Prepare for ROMFS
+	if [ "${CONFIG_FS_ROMFS}" == "y" ]; then
+		OPENOCD_ROMFS_SETUP="set romfs_partition_enable 1; echo \"romfs is enabled\""
+	else
+		OPENOCD_ROMFS_SETUP="set romfs_partition_enable 0; echo \"romfs is disabled\""
+	fi
+}
+
+# $@ - bl1 bl2 sssfw wlanfw os rom
+function upload_components() {
+	commands=$(compute_ocd_commands "$@")
+
+	setup_romfs_variable
+
+	pushd ${OPENOCD_DIR_PATH}
+	"${OPENOCD}" -c "${OPENOCD_ROMFS_SETUP}" -f "${CFG_FILE}" -c "${commands} exit"
+	popd >/dev/null
+}
+
+function erase_userfs_maybe() {
+	while [ $# -gt 0 ]; do
+		case "${1}" in
+		ERASE_USERFS|erase_userfs)
+			echo "USERFS :"
+			pushd ${OPENOCD_DIR_PATH}
+			${OPENOCD} -f "${CFG_FILE}" -c 'flash_erase_part user;	exit'
+			popd > /dev/null;;
+		*)
+			:;;
+		esac
+		shift
+	done
+}
+
+main() {
+	echo "Parameters are: $@"
+	echo "openocd is ${OPENOCD}"
+	echo "Binaries are picked from ${OUTPUT_BINARY_PATH}"
+	echo "Board path is ${BOARD_DIR_PATH}"
+
+	erase_userfs_maybe "$@"
+
+	parts=$(compute_fw_parts "$@")
+	if [ -n "${parts:-}" ]; then
+		echo "Flashing parts ${parts}"
+		upload_components ${parts}
+	else
+		warn "Flashing no parts"
+	fi
+}
+
+main "$@"

--- a/os/Makefile.unix
+++ b/os/Makefile.unix
@@ -73,6 +73,10 @@ endif
 
 # Default tools
 
+ifeq ($(PYTHON),)
+PYTHON := python2
+endif
+
 ifeq ($(DIRLINK),)
 DIRLINK = $(TOPDIR)/tools/link.sh
 DIRUNLINK = $(TOPDIR)/tools/unlink.sh
@@ -518,6 +522,17 @@ endif
 
 $(BIN): pass1deps pass2deps pass1 pass2
 
+# ROMFS
+# Optional arguments are platform-specific
+rom:
+ifeq ($(MAKEROMFS),)
+	@echo "ERROR: MAKEROMFS not defined (should be in ${TOPDIR}/Make.defs)"
+	@false
+else
+	$(call MAKEROMFS, $(wordlist 2,$(words $(MAKECMDGOALS)),$(MAKECMDGOALS)))
+endif
+	@:
+
 # download
 #
 # This is a helper target that will rebuild TinyAra and download it to the target
@@ -626,8 +641,8 @@ subdir_distclean:
 
 memstat:
 ifneq ($(MEMSTATS),)
-	$(Q) python ./tools/memstats_$(MEMSTATS).py -l -f ../build/output/bin/tinyara.map
-	$(Q) python ./tools/memstats_$(MEMSTATS).py -a -f ../build/output/bin/tinyara.map -o ../build/output/bin/tinyara_memstats.txt
+	$(Q) $(PYTHON) ./tools/memstats_$(MEMSTATS).py -l -f ../build/output/bin/tinyara.map
+	$(Q) $(PYTHON) ./tools/memstats_$(MEMSTATS).py -a -f ../build/output/bin/tinyara.map -o ../build/output/bin/tinyara_memstats.txt
 endif
 
 distclean: clean subdir_distclean clean_context

--- a/os/arch/Kconfig.board
+++ b/os/arch/Kconfig.board
@@ -162,6 +162,11 @@ config BOARD_RAMDUMP_UART
 	---help---
 		If selected it will send the RAM dump via UART.
 
+config ROMFS_SOURCE_DIR
+    string "Source directory for ROMFS filesystem image"
+	---help---
+        ROMFS image would be built off this directory.
+        Useful together wit FS_ROMFS and *_AUTOMOUNT_ROMFS options.
 
 comment "Board-Specific Options"
 

--- a/tools/fs/mkromfsimg.sh
+++ b/tools/fs/mkromfsimg.sh
@@ -61,7 +61,6 @@ if [ ! -f tools/mkromfsimg.sh ]; then
   fi
 fi
 
-echo "Making romfs.img..."
 
 # Environmental stuff
 
@@ -70,10 +69,13 @@ buildpath=${topdir}/../build
 contentsdir=${topdir}/../tools/fs/contents
 romfsimg=${buildpath}/output/bin/romfs.img
 
-# Sanity checks
+if [ $# -gt 0 ]; then
+  contentsdir=${1}; shift
+fi
 
+# Sanity checks
 if [ ! -d "${contentsdir}" ]; then
-  echo "ERROR: Directory ${contentsdir} does not exist"
+  echo "$0 ERROR: Directory ${contentsdir} does not exist"
   exit 1
 fi
 


### PR DESCRIPTION
 - parts can be flashed independently,
 - some messages added
 - removed creation of romfs image, which does not belong here (this is the download script)

I plan on adding the romfs image creation into makefile.
At the end it should look like this:
$ make R=0 && make romfs && make download os rom
make download ALL still flashes everything (bl1 bl2 sssfw wlanfw os rom)