### PR TITLE
arch/artik053: make a dependancy with ROMFS for ROMFS automount

### DIFF
--- a/os/arch/arm/src/artik053/Kconfig
+++ b/os/arch/arm/src/artik053/Kconfig
@@ -114,6 +114,7 @@ config ARTIK053_AUTOMOUNT_ROMFS
 	bool "Automount romfs partiton"
 	default y
 	depends on ARTIK053_AUTOMOUNT
+	depends on FS_ROMFS
 	---help---
 		If enabled, romfs partition will be mounted automatically
 		at boot.


### PR DESCRIPTION
Automount functionality of ROMFS for ARTIK053 should be executed
only when FS_ROMFS is enabled.