### PR TITLE
Initialize g_logm_overflow_offset value as -1 in logm.c

### DIFF
--- a/os/logm/logm.c
+++ b/os/logm/logm.c
@@ -35,7 +35,7 @@
 int g_logm_head;
 int g_logm_tail;
 int g_logm_dropmsg_count;
-int g_logm_overflow_offset;
+int g_logm_overflow_offset = -1;
 
 static void logm_putc(FAR struct lib_outstream_s *this, int ch)
 {


### PR DESCRIPTION
g_logm_overflow_offset is a variable for saving buffer offset where overflow happened.
So when overflow happens only, It has a value of which the range is from 0 to (buffer size-1).
If not, it should be invalid value like -1.
Initially, logm buffer is empty but logm can decide that overflow happened because this value is 0.
So It is needed to be initialized as invalid value.