### PR TITLE
Fix iotivity bug in usage of mutex

### DIFF
--- a/external/iotivity/iotivity_1.2-rel/resource/csdk/connectivity/src/adapter_util/ca_adapter_net_ssl.c
+++ b/external/iotivity/iotivity_1.2-rel/resource/csdk/connectivity/src/adapter_util/ca_adapter_net_ssl.c
@@ -1163,10 +1163,7 @@ static SslEndPoint_t *GetSslPeerUsingUuid(const uint8_t *identity, size_t idLeng
 const CASecureEndpoint_t *GetCASecureEndpointData(const CAEndpoint_t* peer)
 {
     OIC_LOG_V(DEBUG, NET_SSL_TAG, "In %s", __func__);
-
-    // TODO: Added as workaround, need to debug
-    oc_mutex_unlock(g_sslContextMutex);
-
+    
     oc_mutex_lock(g_sslContextMutex);
     if (NULL == g_caSslContext)
     {
@@ -2656,10 +2653,7 @@ CAResult_t CAsslGenerateOwnerPsk(const CAEndpoint_t *endpoint,
     VERIFY_NON_NULL_RET(rsrcServerDeviceId, NET_SSL_TAG, "rsrcId is NULL", CA_STATUS_INVALID_PARAM);
     VERIFY_NON_NULL_RET(provServerDeviceId, NET_SSL_TAG, "provId is NULL", CA_STATUS_INVALID_PARAM);
     VERIFY_NON_NULL_RET(ownerPsk, NET_SSL_TAG, "ownerPSK is NULL", CA_STATUS_INVALID_PARAM);
-
-    // TODO: Added as workaround, need to debug
-    oc_mutex_unlock(g_sslContextMutex);
-
+    
     oc_mutex_lock(g_sslContextMutex);
     if (NULL == g_caSslContext)
     {


### PR DESCRIPTION
### Remove unlock statement with unlocked mutex

- 2619e21 : This commit changed 'pthread_mutex_unlock' process  when the mutex is already unlocked.
- In 'oc_mutex_unlock()', if we do unlock with unlocked mutex, 'pthread_mutex_unlock()' retruns FAIL.
- 'exit()' kill the essential thread which is running,  then every process is stopped.

```c
void oc_mutex_unlock(oc_mutex mutex)
{
    oc_mutex_internal *mutexInfo = (oc_mutex_internal*) mutex;
    if (mutexInfo)
    {
        int ret = pthread_mutex_unlock(&mutexInfo->mutex);
        if(ret != 0)
        {
            OIC_LOG_V(ERROR, TAG, "Pthread Mutex unlock failed: %d", ret);
            exit(ret);
        }
        (void)ret;
    }
    else
    {
        OIC_LOG_V(ERROR, TAG, "%s: Invalid mutex !", __func__);
    }
}
```
