### PR TITLE
Fix Svace issues in webclient/webserver/websocket examples.

### DIFF
--- a/apps/examples/webserver/webserver_main.c
+++ b/apps/examples/webserver/webserver_main.c
@@ -395,25 +395,25 @@ pthread_addr_t httptest_cb(void *arg)
 	int auth_mode = MBEDTLS_SSL_VERIFY_REQUIRED;
 #endif
 	struct webserver_input *input = arg;
-	if (!strcmp(input->argv[1], "start")) {
+	if (!strncmp(input->argv[1], "start", 5)) {
 #ifdef CONFIG_NET_SECURITY_TLS
 		if (input->argc != 3) {
 			print_webserver_usage();
 			goto release;
 		}
-		if (strcmp(input->argv[2], "required") == 0) {
-			auth_mode = MBEDTLS_SSL_VERIFY_REQUIRED;
-		} else if (strcmp(input->argv[2], "optional") == 0) {
-			auth_mode = MBEDTLS_SSL_VERIFY_OPTIONAL;
-		} else if (strcmp(input->argv[2], "none") == 0) {
+		if (strncmp(input->argv[2], "none", 4) == 0) {
 			auth_mode = MBEDTLS_SSL_VERIFY_NONE;
+		} else if (strncmp(input->argv[2], "required", 8) == 0) {
+			auth_mode = MBEDTLS_SSL_VERIFY_REQUIRED;
+		} else if (strncmp(input->argv[2], "optional", 8) == 0) {
+			auth_mode = MBEDTLS_SSL_VERIFY_OPTIONAL;
 		} else {
 			print_webserver_usage();
 			goto release;
 		}
 #endif
 		goto start;
-	} else if (!strcmp(input->argv[1], "stop")) {
+	} else if (!strncmp(input->argv[1], "stop", 4)) {
 		if (input->argc != 2) {
 			print_webserver_usage();
 			goto release;
@@ -520,7 +520,7 @@ int webserver_main(int argc, char *argv[])
 			WEBSERVER_FREE_INPUT(input, i);
 			return -1;
 		}
-		strcpy(input->argv[i], argv[i]);
+		strncpy(input->argv[i], argv[i], strlen(argv[i]));
 	}
 	status = pthread_attr_init(&attr);
 	if (status != 0) {

--- a/apps/examples/websocket/websocket_main.c
+++ b/apps/examples/websocket/websocket_main.c
@@ -600,7 +600,7 @@ WEB_CLI_EXIT:
 
 	if (tls) {
 		websocket_tls_release(1, &conf, &cert, &pkey, &entropy, &ctr_drbg, &cache);
-		if (websocket_cli->tls_ssl) {
+		if (websocket_cli && websocket_cli->tls_ssl) {
 			mbedtls_ssl_free(websocket_cli->tls_ssl);
 			free(websocket_cli->tls_ssl);
 		}
@@ -723,7 +723,7 @@ int websocket_main(int argc, char *argv[])
 	int status;
 	pthread_attr_t attr;
 	pthread_t tid;
-	struct options_s *input;
+	struct options_s *input = NULL;
 	if (argc < 3) {
 		goto error_with_input;
 	}
@@ -747,9 +747,9 @@ int websocket_main(int argc, char *argv[])
 			goto error_with_input;
 		}
 
-		strncpy(input->server_ip, argv[2], 20);
-		strncpy(input->server_port, argv[3], 8);
-		strncpy(input->path, argv[4], 32);
+		strncpy(input->server_ip, argv[2], 19);
+		strncpy(input->server_port, argv[3], 7);
+		strncpy(input->path, argv[4], 31);
 		input->tls_mode = atoi(argv[5]);
 		input->size = atoi(argv[6]);
 		input->num = atoi(argv[7]);
@@ -759,7 +759,7 @@ int websocket_main(int argc, char *argv[])
 
 	if ((status = pthread_attr_init(&attr)) != 0) {
 		printf("fail to init thread\n");
-		return -1;
+		goto error_with_function_failure;
 	}
 
 	pthread_attr_setstacksize(&attr, WEBSOCKET_EXAMPLE_STACKSIZE);
@@ -768,24 +768,33 @@ int websocket_main(int argc, char *argv[])
 	if (memcmp(argv[1], "client", strlen("client")) == 0 && argc == 8) {
 		if ((status = pthread_create(&tid, &attr, (pthread_startroutine_t)websocket_client, (void *)input)) != 0) {
 			printf("fail to create thread\n");
-			return -1;
+			goto error_with_function_failure;
 		}
 		pthread_setname_np(tid, "websocket client");
 		pthread_detach(tid);
 	} else if (memcmp(argv[1], "server", strlen("server")) == 0 && argc == 3) {
 		if ((status = pthread_create(&tid, &attr, (pthread_startroutine_t)websocket_server, (void *)input)) != 0) {
 			printf("fail to create thread\n");
-			return -1;
+			goto error_with_function_failure;
 		}
 		pthread_setname_np(tid, "websocket server");
 		pthread_detach(tid);
 	} else {
 		printf("\nwrong input parameter !!!\n %s\n", WEBSOCKET_USAGE);
-		return -1;
+		goto error_with_function_failure;
 	}
+
+	if (input) {
+		free(input);
+	}
+
 	return 0;
 
 error_with_input:
 	printf("%s", WEBSOCKET_USAGE);
+error_with_function_failure:
+	if (input) {
+		free(input);
+	}
 	return -1;
 }


### PR DESCRIPTION
1. Use strncmp instead of strcmp
2. Delete duplicated usage print webclient example
3. Free malloced variables before a function returns