### PR TITLE
Fix wrong condition for checking invalid mode in freopen function.

### DIFF
--- a/lib/libc/stdio/lib_freopen.c
+++ b/lib/libc/stdio/lib_freopen.c
@@ -124,7 +124,7 @@ FAR FILE *freopen(FAR const char *path, FAR const char *mode, FAR FILE *stream)
 		/* Convert the mode string into standard file open mode flags. */
 
 		oflags = lib_mode2oflags(mode);
-		if (oflags == 0) {
+		if (oflags < 0) {
 			return NULL;
 		}
 


### PR DESCRIPTION
freopen should return NULL when oflags is less than 0, not equal to 0.
Because negative value is returned on failure of lib_mode2offlags which converts the mode string into file open mode flag.