### PR TITLE
Remove setjmp.S in tiva/Make.defs

### DIFF
--- a/os/arch/arm/src/tiva/Make.defs
+++ b/os/arch/arm/src/tiva/Make.defs
@@ -53,7 +53,7 @@
 HEAD_ASRC  = tiva_vectors.S
 
 CMN_ASRCS  = up_saveusercontext.S up_fullcontextrestore.S up_switchcontext.S
-CMN_ASRCS += vfork.S setjmp.S
+CMN_ASRCS += vfork.S
 
 CMN_CSRCS  = up_assert.c up_blocktask.c up_copyfullstate.c up_createstack.c
 CMN_CSRCS += up_mdelay.c up_udelay.c up_exit.c up_idle.c up_initialize.c


### PR DESCRIPTION
It makes build error.
Assembler messages: common/setjmp.S:155: Error: r13 not allowed here