### PR TITLE
setjmp/longjmp tests

### DIFF
--- a/apps/examples/setjmp/Kconfig
+++ b/apps/examples/setjmp/Kconfig
@@ -1,0 +1,14 @@
+#
+# For a description of the syntax of this configuration file,
+# see kconfig-language at https://www.kernel.org/doc/Documentation/kbuild/kconfig-language.txt
+#
+
+config EXAMPLES_SETJMP_TEST
+	bool "setjmp/longjmp test"
+	default n
+	---help---
+        setjmp/longjmp pair of functions facilitate execution context management in plain C.
+        You can think of them as exception handling/coroutine facilitating mechanism.
+
+        This option enables test application of this feature. In order to have it
+         accessible out of the box, enable BUILTIN_APPS.

--- a/apps/examples/setjmp/Make.defs
+++ b/apps/examples/setjmp/Make.defs
@@ -1,0 +1,21 @@
+###########################################################################
+#
+# Copyright 2017 Samsung Electronics All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+#
+###########################################################################
+
+ifeq ($(CONFIG_EXAMPLES_SETJMP_TEST),y)
+CONFIGURED_APPS += examples/setjmp
+endif

--- a/apps/examples/setjmp/Makefile
+++ b/apps/examples/setjmp/Makefile
@@ -1,0 +1,159 @@
+############################################################################
+#
+# Copyright 2017 Samsung Electronics All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+#
+############################################################################
+############################################################################
+# apps/examples/setjmp/Makefile
+#
+#   Copyright (C) 2016 Gregory Nutt. All rights reserved.
+#   Author: Gregory Nutt <gnutt@nuttx.org>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in
+#    the documentation and/or other materials provided with the
+#    distribution.
+# 3. Neither the name NuttX nor the names of its contributors may be
+#    used to endorse or promote products derived from this software
+#    without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+# OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+# AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+############################################################################
+
+-include $(TOPDIR)/.config
+-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
+
+APPNAME = setjmp_test
+FUNCNAME = setjmp_test
+PRIORITY = SCHED_PRIORITY_DEFAULT
+STACKSIZE = 4096
+THREADEXEC = TASH_EXECMD_SYNC
+
+ASRCS =
+CSRCS =
+MAINSRC = setjmp_longjmp_test.c
+
+AOBJS = $(ASRCS:.S=$(OBJEXT))
+COBJS = $(CSRCS:.c=$(OBJEXT))
+MAINOBJ = $(MAINSRC:.c=$(OBJEXT))
+
+SRCS = $(ASRCS) $(CSRCS) $(MAINSRC)
+OBJS = $(AOBJS) $(COBJS)
+
+ifneq ($(CONFIG_BUILD_KERNEL),y)
+  OBJS += $(MAINOBJ)
+endif
+
+ifeq ($(CONFIG_WINDOWS_NATIVE),y)
+  BIN = ..\..\libapps$(LIBEXT)
+else
+ifeq ($(WINTOOL),y)
+  BIN = ..\\..\\libapps$(LIBEXT)
+else
+  BIN = ../../libapps$(LIBEXT)
+endif
+endif
+
+ifeq ($(WINTOOL),y)
+  INSTALL_DIR = "${shell cygpath -w $(BIN_DIR)}"
+else
+  INSTALL_DIR = $(BIN_DIR)
+endif
+
+#kps
+CONFIG_EXAMPLES_SETJMP_TEST_PROGNAME ?= $(APPNAME)$(EXEEXT)
+PROGNAME = $(CONFIG_EXAMPLES_SETJMP_TEST_PROGNAME)
+
+ROOTDEPPATH = --dep-path .
+
+
+# Common build
+
+VPATH =
+
+all: .built
+.PHONY: clean depend distclean preconfig
+
+$(AOBJS): %$(OBJEXT): %.S
+	$(call ASSEMBLE, $<, $@)
+
+$(COBJS) $(MAINOBJ): %$(OBJEXT): %.c
+	$(call COMPILE, $<, $@)
+
+.built: $(OBJS)
+	$(call ARCHIVE, $(BIN), $(OBJS))
+	@touch .built
+
+ifeq ($(CONFIG_BUILD_KERNEL),y)
+$(BIN_DIR)$(DELIM)$(PROGNAME): $(OBJS) $(MAINOBJ)
+	@echo "LD: $(PROGNAME)"
+	$(Q) $(LD) $(LDELFFLAGS) $(LDLIBPATH) -o $(INSTALL_DIR)$(DELIM)$(PROGNAME) $(ARCHCRT0OBJ) $(MAINOBJ) $(LDLIBS)
+	$(Q) $(NM) -u  $(INSTALL_DIR)$(DELIM)$(PROGNAME)
+
+install: $(BIN_DIR)$(DELIM)$(PROGNAME)
+
+else
+install:
+
+endif
+
+ifeq ($(CONFIG_BUILTIN_APPS)$(CONFIG_EXAMPLES_SETJMP_TEST),yy)
+$(BUILTIN_REGISTRY)$(DELIM)$(FUNCNAME).bdat: $(DEPCONFIG) Makefile
+	$(Q) $(call REGISTER,$(APPNAME),$(FUNCNAME),$(THREADEXEC),$(PRIORITY),$(STACKSIZE))
+
+context: $(BUILTIN_REGISTRY)$(DELIM)$(FUNCNAME).bdat
+
+else
+context:
+
+endif
+
+.depend: Makefile $(SRCS)
+	@$(MKDEP) $(ROOTDEPPATH) "$(CC)" -- $(CFLAGS) -- $(SRCS) >Make.dep
+	@touch $@
+
+depend: .depend
+
+clean:
+	$(call DELFILE, .built)
+	$(call CLEAN)
+
+distclean: clean
+	$(call DELFILE, Make.dep)
+	$(call DELFILE, .depend)
+
+-include Make.dep
+
+preconfig:
+

--- a/apps/examples/setjmp/setjmp_longjmp_test.c
+++ b/apps/examples/setjmp/setjmp_longjmp_test.c
@@ -1,0 +1,162 @@
+/****************************************************************************
+ *
+ * Copyright 2017 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+#include <tinyara/config.h>
+
+#include <setjmp.h>
+#include <stdio.h>
+#include <unistd.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+#define VERIFY_OR_RETURN(value, msg, ...) \
+	do { \
+		int _v = (value); \
+		if (!_v) { \
+			fprintf(stderr, "[%s:%d] ERROR: " msg, \
+					__FUNCTION__, __LINE__, \
+					#value, ##__VA_ARGS__); \
+			fail = 1; \
+			return 1; \
+		} \
+	} while (0)
+
+#define MAX_DEPTH 8
+static int did_return[MAX_DEPTH];
+static int fail;
+
+typedef enum {
+	DIVE_RETURN,
+	DIVE_LONGJMP,
+	DIVE_EXCEPTION
+} dive_mode_t;
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+// This function does a recursive dive MAX_DEPTH times, each time saving local
+// state on stack with setjmp call (ensure stck is big enough to hold them).
+//
+// Depending on the |mode| it either:
+//   DIVE_RETURN - just returns (dive all to the bottom, then return
+//                 all the way up, one frame at a time).
+//   DIVE_LONGJMP - calls down (until it reaches the bottom), then "returns"
+//                 via longjmp to its immediate caller, all the way up.
+//   DIVE_EXCEPTION - calls down (until it reaches the bottom), then returns
+//                 to the top, skipping intermediate stack frames.
+static int dive(int depth, dive_mode_t mode, jmp_buf upper)
+{
+	printf("diving(%d, %c, %p)\n", depth, "RLE"[mode], (void *)upper);
+	jmp_buf env;
+
+	switch (mode) {
+	case DIVE_RETURN:
+		VERIFY_OR_RETURN(setjmp(env) == 0, "setjmp failed");
+		if (depth < MAX_DEPTH) {
+			dive(depth + 1, mode, env);
+		}
+		break;
+	case DIVE_LONGJMP:
+		if ((setjmp(env) == 0) && (depth < MAX_DEPTH)) {
+			dive(depth + 1, mode, env);
+			VERIFY_OR_RETURN(false, "Unreachable code");
+		}
+		fprintf(stderr, "ascending(%d, %c, %p)\n", depth, "RLE"[mode], (void *)upper);
+		did_return[depth - 1] = -1;
+		longjmp(upper, 1);
+		break;
+	case DIVE_EXCEPTION:
+		if ((setjmp(env) == 0) && (depth < MAX_DEPTH)) {
+			dive(depth + 1, mode, upper);
+		} else {
+			did_return[depth - 1] = -1;
+			printf("ascending(%d, %c, %p)\n", depth, "RLE"[mode], (void *)upper);
+			longjmp(upper, 1);
+		}
+	}
+	did_return[depth - 1] = 1;
+	printf("return(%d, %c, %p)\n", depth, "RLE"[mode], (void *)upper);
+	return 0;
+}
+
+static void clear_state(void)
+{
+	int i;
+	for (i = 0; i < MAX_DEPTH; ++i) {
+		did_return[i] = 0;
+	}
+	fail = 0;
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+#ifdef CONFIG_BUILD_KERNEL
+int main(int argc, FAR char *argv[])
+#else
+int setjmp_test(int argc, char *argv[])
+#endif
+{
+	jmp_buf hook;
+	int i;
+
+	// Every depth of dive has returned.
+	clear_state();
+	VERIFY_OR_RETURN(setjmp(hook) == 0, "setjmp returned non-zero");
+	VERIFY_OR_RETURN(dive(1, DIVE_RETURN, hook) == 0, "setjmp broken");
+	VERIFY_OR_RETURN(!fail, "setjmp breaks functions");
+	for (i = 0; i < MAX_DEPTH; ++i) {
+		VERIFY_OR_RETURN(did_return[i] == 1, "frame #%d didn't return", i);
+	}
+	printf("setjmp does not break function return\n");
+
+	// Every depth "returned" via longjmp.
+	clear_state();
+	if (setjmp(hook) == 0) {
+		dive(1, DIVE_LONGJMP, hook);
+		VERIFY_OR_RETURN(false, "Unreachable code");
+	}
+	VERIFY_OR_RETURN(!fail, "longjmp didn't work (?)");
+	for (i = 0; i < MAX_DEPTH; ++i) {
+		VERIFY_OR_RETURN(did_return[i] == -1, "frame #%d should have longjmp'ed out");
+	}
+	printf("setjmp skips a single stack frame\n");
+
+	// Nothing returned (emergency ascent from the deep).
+	clear_state();
+	if (setjmp(hook) == 0) {
+		dive(1, DIVE_EXCEPTION, hook);
+		VERIFY_OR_RETURN(false, "Unreachable code");
+	}
+	VERIFY_OR_RETURN(!fail, "setjmp/longjmp is broken (?)");
+	for (i = 0; i < MAX_DEPTH - 1; ++i) {
+		VERIFY_OR_RETURN(did_return[i] == 0, "frame #%d should have been skipped");
+	}
+	VERIFY_OR_RETURN(did_return[MAX_DEPTH - 1] == -1, "frame #%d should have longjmp'ed out");
+	printf("setjmp skips multiple frames\n");
+
+	return 0;
+}


### PR DESCRIPTION
setjmp/longjmp test example

These tests check for:
 - setjmp not destroying local stack,
 - setjmp/longjmp working as return replacement,
 - setjmp/longjmp working as an exception (skipping multiple stack frames)
They do pass.