### PR TITLE
Changing rxdma_setup code to not overwrite the wav header

### DIFF
--- a/os/arch/arm/src/s5j/s5j_i2s.c
+++ b/os/arch/arm/src/s5j/s5j_i2s.c
@@ -665,12 +665,10 @@ static int i2s_rxdma_setup(struct s5j_i2s_s *priv)
 	dmatask = bfcontainer->dmatask;
 	/* No data received yet */
 
-	apb->nbytes = 0;
-	apb->curbyte = 0;
 
-	dmatask->dst = (void *)apb->samp;
+	dmatask->dst = (void *)((uintptr_t)apb->samp + apb->curbyte);
 	dmatask->src = (void *)(priv->base + S5J_I2S_RXD);
-	dmatask->size = apb->nmaxbytes;
+	dmatask->size = apb->nmaxbytes - apb->curbyte;
 	dmatask->callback = i2s_rxdma_callback;
 	dmatask->arg = priv;
 

--- a/os/audio/pcm_decode.c
+++ b/os/audio/pcm_decode.c
@@ -980,7 +980,6 @@ static int pcm_enqueuebuffer(FAR struct audio_lowerhalf_s *dev, FAR struct ap_bu
 	DEBUGASSERT(lower && lower->ops->enqueuebuffer && lower->ops->configure);
 
 	/* Are we streaming yet? */
-	priv->streaming = 1;	/* TODO add wav header to the first buffer being passed */
 
 	if (priv->streaming) {
 		/* Yes, we are streaming */


### PR DESCRIPTION
Now the rxdma would start writing from an offset of apb->curbyte and would write at max nmaxbytes - curbytes