### PR TITLE
setjmp/longjmp thumb build fix

### DIFF
--- a/os/arch/arm/src/common/setjmp.S
+++ b/os/arch/arm/src/common/setjmp.S
@@ -151,12 +151,19 @@ longjmp:
 	ldr	r14, [r0, #((_JB_REG_R14 - _JB_REG_R4) * 4)]
 #endif
 
+#ifndef __thumb__
 	/* Validate sp and r14 */
 	teq	sp, #0
 	it	ne
 	teqne	r14, #0
 	it	eq
 	beq	botch
+#else
+	cmp sp, #0
+	beq botch
+	cmp lr, #0
+	beq botch
+#endif
 
 	/* Set return value */
 	movs	r0, r1


### PR DESCRIPTION
Fix setjmp/longjmp implementation for thumb mode (i.e.: tiva, which is Cortex M3, based on armv7-m architecture).
Compiles for armv7-a/r in both arm and thumb modes and for armv7-m.

Please note the code is not tested. How do I run thumb-enabled build?