### PR TITLE
Fix: Remove duplicate entry in 'os/arch/arm/src/s5j/Make.defs'

### DIFF
--- a/os/arch/arm/src/s5j/Make.defs
+++ b/os/arch/arm/src/s5j/Make.defs
@@ -172,8 +172,6 @@ ifeq ($(CONFIG_S5J_PWR),y)
 CHIP_CSRCS += s5j_pwr.c
 endif
 
-CHIP_CSRCS += s5j_clock.c
-
 ifeq ($(CONFIG_S5J_PWM),y)
 CHIP_CSRCS += s5j_pwm.c
 endif


### PR DESCRIPTION
Fix "Makefile:174: target `s5j_clock.o' given more than once in the same rule"
Removed the duplicate entry 'CHIP_CSRCS += s5j_clock.c' in 'os/arch/arm/src/s5j/Make.defs'

Signed-off-by: Lokesh B V <lokesh.bv@partner.samsung.com>