### PR TITLE
code coverage: add utc to network tc and change make.defs not to build unused network files now.

### DIFF
--- a/apps/examples/testcase/le_tc/network/Kconfig
+++ b/apps/examples/testcase/le_tc/network/Kconfig
@@ -36,6 +36,7 @@ config TC_NET_ALL
 	select TC_NET_INET
 	select TC_NET_ETHER
 	select TC_NET_NETDB
+	select TC_NET_DUP
 
 config TC_NET_SOCKET
 	bool "socket() api"
@@ -121,6 +122,9 @@ config TC_NET_NETDB
 	bool "netdb() api"
 	default n
 
+config TC_NET_DUP
+	bool "dup() api"
+	default n
 
 
 endif #EXAMPLES_TESTCASE_NETWORK

--- a/apps/examples/testcase/le_tc/network/Make.defs
+++ b/apps/examples/testcase/le_tc/network/Make.defs
@@ -119,6 +119,9 @@ endif
 ifeq ($(CONFIG_TC_NET_NETDB),y)
 CSRCS +=tc_net_netdb.c
 endif
+ifeq ($(CONFIG_TC_NET_DUP),y)
+CSRCS +=tc_net_dup.c
+endif
 
 # Include network build support
 

--- a/apps/examples/testcase/le_tc/network/network_tc_main.c
+++ b/apps/examples/testcase/le_tc/network/network_tc_main.c
@@ -110,6 +110,9 @@ int network_tc_main(int argc, char *argv[])
 #ifdef CONFIG_TC_NET_NETDB
 	net_netdb_main();
 #endif
+#ifdef CONFIG_TC_NET_DUP
+	net_dup_main();
+#endif
 
 	printf("\n=== TINYARA Network TC COMPLETE ===\n");
 	printf("\t\tTotal pass : %d\n\t\tTotal fail : %d\n", total_pass, total_fail);

--- a/os/net/netdev/Make.defs
+++ b/os/net/netdev/Make.defs
@@ -53,9 +53,10 @@
 
 # Support for operations on network devices
 NETDEV_CSRCS += netdev_ioctl.c
-NETDEV_CSRCS += netdev_findbyname.c netdev_count.c
-NETDEV_CSRCS += netdev_foreach.c netdev_sem.c
-NETDEV_CSRCS += netdev_carrier.c netdev_default.c
+NETDEV_CSRCS += netdev_findbyname.c
+NETDEV_CSRCS += netdev_count.c
+NETDEV_CSRCS += netdev_foreach.c
+NETDEV_CSRCS += netdev_sem.c
 
 # Include netdev build support
 

--- a/os/net/utils/Make.defs
+++ b/os/net/utils/Make.defs
@@ -53,7 +53,6 @@
 
 # Common utilities
 
-NET_CSRCS += net_dsec2tick.c net_dsec2timeval.c net_timeval2dsec.c
 NET_CSRCS += net_lock.c
 
 # Include utility build support


### PR DESCRIPTION
This commit is for increasing code coverage.
1) add UTC to test dup() which duplicate a socket descriptor
2) modify make.defs because netdev_* files are not currently used.