### PR TITLE
set null for audio_utc

### DIFF
--- a/apps/examples/testcase/ta_tc/audio/utc/utc_audio_main.c
+++ b/apps/examples/testcase/ta_tc/audio/utc/utc_audio_main.c
@@ -71,6 +71,7 @@ static void clean_all_data(int fd)
 
 	if (g_pcm) {
 		pcm_close(g_pcm);
+		g_pcm = NULL;
 	}
 
 	if (g_record_buffer) {


### PR DESCRIPTION
After pcm_close, set the g_pcm variable to null

Signed-off-by: jaesick.shin <jaesick.shin@samsung.com>