### PR TITLE
Revert "Fix build error in tls_client_main.c"

### DIFF
--- a/apps/examples/tls_client/tls_client_main.c
+++ b/apps/examples/tls_client/tls_client_main.c
@@ -462,7 +462,7 @@ int tls_client_cb(void *args)
 	int tail_len;
 	int i;
 	int written;
-	int frags = 0;
+	int frags;
 	int retry_left;
 	mbedtls_net_context server_fd;
 #if defined(MBEDTLS_KEY_EXCHANGE__SOME__PSK_ENABLED)

--- a/apps/examples/websocket/websocket_main.c
+++ b/apps/examples/websocket/websocket_main.c
@@ -795,6 +795,10 @@ int websocket_main(int argc, char *argv[])
 		goto error_with_function_failure;
 	}
 
+	if (input) {
+		free(input);
+	}
+
 	return 0;
 
 error_with_input:


### PR DESCRIPTION
Reverts Samsung/TizenRT#667

I think we should use join instread of detach and free 'input' in main() not in websocket_client() and websocket_server().