### PR TITLE
Add debug code to detect double freeing the pointer

### DIFF
--- a/os/Kconfig.debug
+++ b/os/Kconfig.debug
@@ -167,6 +167,16 @@ config DEBUG_MM_INFO
 	---help---
 		Enable memory management informational debug SYSLOG output.
 
+config DEBUG_DOUBLE_FREE
+	bool "Debug Double Free Attempt"
+	default n
+	---help---
+		This flag would help to debug following operations
+		Attempt to free Null pointer
+		Attempt to free an Unallocated pointer
+		Attempt to free an abruptly initialized pointer (Security exploitation)
+		Attempt to free an already released pointer ( double free detection )
+
 endif #DEBUG_MM
 
 config DEBUG_SHM


### PR DESCRIPTION
When CONFIG_DEBUG flag is enabled, This patch address to detect following 4
different bugs present in sw logic

1) Attempt to free a NULL pointer
2) Attempt to free an Unallocated pointer
3) Attempt to free an abruptly initialized pointer (Security exploitation)
without actually allocating it
4) Attempt to free an already released pointer ( double free detection )

Reference test code for each of the above case is as below
1)	int *ptr = NULL; free(ptr);
2)	int *ptr; free(ptr);
3)	int *ptr = (int*)0x20102020; free(ptr);
4)	int *ptr;
	ptr = malloc(100);
	free(ptr);
	/* Since ptr is not set to NULL after free, following code executes */
	if (ptr) {
		printf("Freeing the released pointer\n");
		free(ptr);
	}

Signed-off-by: pradeep.ns <pradeep.ns@samsung.com>