### PR TITLE
Fix ALC5658 Kconfig: #1. ALC5658 buffers should be enabled only when …

### DIFF
--- a/os/drivers/audio/Kconfig
+++ b/os/drivers/audio/Kconfig
@@ -59,22 +59,21 @@ config ALC5658_INITVOLUME
 config ALC5658_INFLIGHT
 	int "ALC5658 maximum in-flight audio buffers"
 	default 2
-
-config ALC5658_MSG_PRIO
-	int "ALC5658 message priority"
-	default 1
+	depends on AUDIO_DRIVER_SPECIFIC_BUFFERS
 
 config ALC5658_BUFFER_SIZE
 	int "ALC5658 preferred buffer size"
 	default 8192
+	depends on AUDIO_DRIVER_SPECIFIC_BUFFERS
 
 config ALC5658_NUM_BUFFERS
 	int "ALC5658 preferred number of buffers"
 	default 4
+	depends on AUDIO_DRIVER_SPECIFIC_BUFFERS
 
-config ALC5658_WORKER_STACKSIZE
-	int "ALC5658 worker thread stack size"
-	default 768
+config ALC5658_MSG_PRIO
+	int "ALC5658 message priority"
+	default 1
 
 config ALC5658_REGDUMP
 	bool "ALC5658 register dump"


### PR DESCRIPTION
…driver specific buffer options are enabled in Audio, otherwise audio buffers should be used. #2. There is no worker thread in alc5658 driver.