### PR TITLE
apps:nettest modify multicast test in nettest

### DIFF
--- a/apps/examples/nettest/nettest.c
+++ b/apps/examples/nettest/nettest.c
@@ -141,49 +141,113 @@ char *g_app_target_addr = "192.168.2.6";
 int g_app_target_port = 5555;
 uint32_t total_data;
 
+#define NETTEST_SERVER_MODE 1
+#define NETTEST_CLIENT_MODE 2
+#define NETTEST_PROTO_TCP "tcp"
+#define NETTEST_PROTO_UDP "udp"
+#define NETTEST_PROTO_MULTICAST "mtc"
+
+typedef enum {
+	NT_NONE,
+	NT_TCP,
+	NT_UDP,
+	NT_MULTICAST,
+} nettest_proto_e;
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+static void show_usage(void)
+{
+	printf("Usage: \n\n");
+	printf("\tnettest MODE PROTOCOL ADDRESS PORT PACKETS [INTERVAL] [INTERFACE]\n");
+
+	printf("MODE:\n");
+	printf("\t1: server\n");
+	printf("\t2: client\n");
+
+	printf("PROTOCOL\n");
+	printf("\ttcp: TCP\n");
+	printf("\tudp: UDP\n");
+	printf("\tmtc: MULTICAST\n");
+
+	printf("ADDRESS\n");
+	printf("\tAddress to bind if mode is server\n");
+	printf("\t\t(If you want to choose the default interface then insert 0)\n");
+	printf("\tTarget address if mode is client\n");
+	printf("\tGroup address to join if mode is multicast\n");
+
+	printf("PORT\n");
+	printf("\tPort to bind if mode is server\n");
+	printf("\tPort to connect if mode is client\n");
+
+	printf("PACKET\n");
+	printf("\tThe number of packets to receive if the mode is server\n");
+	printf("\t\t(If you want to receive continousely then insert 0)\n");
+	printf("\tThe number of packets to send if the mode is client\n");
+	printf("\t\t(If you want to send continousely then insert 0)\n");
+
+	printf("INTERVAL\n");
+	printf("\tSet the interval of the sent packet if mode is client(default 0)\n");
+	printf("\t\t(Set 0 if you want send packet as many as possible)\n");
+	printf("\t\t(You can't insert the interval if mode is server)\n");
+
+	printf("INTERFACE\n");
+	printf("\tThe interface to bind if mode is multicast\n");
+
+	printf("Sample Command:\n");
+	printf("\tRun TCP Server\n");
+	printf("\t\tTASH>>nettest 1 tcp 0 9098 10\n");
+
+	printf("\tRun UDP Client\n");
+	printf("\t\tTASH>>nettest 2 udp 192.168.1.1 9098 10 3\n");
+
+	printf("\tRun Multicast Receiver\n");
+	printf("\t\tTASH>>nettest 1 mtc 224.1.1.1 5555 0 wl1\n");
+	printf("\n\n");
+}
+
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
 
-void ipmcast_sender_thread(int num_packets, uint32_t sleep_time)
-{
 
-	/* ------------------------------------------------------------ */
-	/*                                                              */
-	/* Send Multicast Datagram code example.                        */
-	/*                                                              */
-	/* ------------------------------------------------------------ */
+/* ------------------------------------------------------------ */
+/*                                                              */
+/* Send Multicast Datagram code example.                        */
+/*                                                              */
+/* ------------------------------------------------------------ */
+void ipmcast_sender_thread(int num_packets, uint32_t sleep_time, const char *intf)
+{
 	int ret = 0;
 	int i = 0;
 	int datalen;
 	struct in_addr localInterface;
 	struct sockaddr_in groupSock;
 	int sd;
+	char loopch = 0;
 	char *databuf = "Test Data: IP Multicast from TinyAra Node to Linux";
 
 	socklen_t addrlen = sizeof(struct sockaddr_in);
-	printf("\n[MCASTCLIENT] start multicast sender\n");
+	printf("[MCASTCLIENT] start multicast sender\n");
 	/*
 	 * Create a datagram socket on which to send.
 	 */
 	sd = socket(AF_INET, SOCK_DGRAM, 0);
 	if (sd < 0) {
 		printf("[MCASTCLIENT] [ERR] opening datagram socket");
-		exit(1);
+		return;
 	}
-	printf("\n[MCASTCLIENT] created socket successfully\n");
+	printf("[MCASTCLIENT] created socket successfully\n");
 
 	/*
 	 * Disable loopback so you do not receive your own datagrams.
 	 */
-
-	char loopch = 0;
-
 	if (setsockopt(sd, IPPROTO_IP, IP_MULTICAST_LOOP, (char *)&loopch, sizeof(loopch)) < 0) {
-		printf("\n[MCASTCLIENT] [ERR] Failed setting IP_MULTICAST_LOOP:");
-		goto errout_with_socket;
+		printf("[MCASTCLIENT] [ERR] Failed setting IP_MULTICAST_LOOP:");
+		goto out_with_socket;
 	}
-	printf("\n[MCASTCLIENT] setsockopt MULTICAST_LOOP success\n");
+	printf("[MCASTCLIENT] setsockopt MULTICAST_LOOP success\n");
 
 	/*
 	 * Initialize the group sockaddr structure with a
@@ -199,64 +263,69 @@ void ipmcast_sender_thread(int num_packets, uint32_t sleep_time)
 	 * The IP address specified must be associated with a local,
 	 * multicast-capable interface.
 	 */
-	localInterface.s_addr = inet_addr(LOCAL_DEVICE);
-	if (setsockopt(sd, IPPROTO_IP, IP_MULTICAST_IF, (char *)&localInterface, sizeof(localInterface)) < 0) {
-		printf("\n[MCASTCLIENT] [ERR] Failed setting local interface");
-		goto errout_with_socket;
+	ret = netlib_get_ipv4addr(intf, &localInterface);
+	if (ret == -1) {
+		printf("[MCASTCLIENT] fail to get interface's ip address\n");
+		goto out_with_socket;
 	}
-	printf("\n[MCASTCLIENT] setsockopt IP_MULTICAST_IF success\n");
+	printf("[MCASTCLIENT] bind interface(%s)\n", intf);
+	printf("[MCASTCLIENT] group address(%s)\n", g_app_target_addr);
+	printf("[MCASTCLIENT] port(%d)\n", g_app_target_port);
+
+	if (setsockopt(sd, IPPROTO_IP, IP_MULTICAST_IF, (char *)&localInterface, sizeof(localInterface)) < 0) {
+		printf("[MCASTCLIENT] [ERR] Failed setting local interface");
+		goto out_with_socket;
+	}
+	printf("[MCASTCLIENT] setsockopt IP_MULTICAST_IF success\n");
 
 	/*
 	 * Send a message to the multicast group specified by the
 	 * groupSock sockaddr structure.
 	 */
-
 	datalen = strlen(databuf);
-	printf("\n[MCASTCLIENT] datalen = %d \n", datalen);
-
+	printf("[MCASTCLIENT] datalen = %d \n", datalen);
+	printf("[MCASTCLIENT] data (%s)\n", databuf);
+	printf("[MCASTCLIENT] interval(%d)\n", sleep_time);
 	for (i = 1; i <= num_packets; i++) {
-		printf("\n[MCASTCLIENT] sending mcast message (%s) length (%d) number (%d)\n", databuf, datalen, i);
+		printf("[MCASTCLIENT] sending mcast message length (%d) number (%d)\n", datalen, i);
 		ret = sendto(sd, databuf, datalen, 0, (struct sockaddr *)&groupSock, addrlen);
 		if (ret < 0) {
-			printf("\n[MCASTCLIENT] [ERR] sending datagram message");
+			printf("[MCASTCLIENT] [ERR] sending datagram message");
 		}
-		sleep(1);
+		if (sleep_time != 0) {
+			usleep(sleep_time);
+		}
 	}
-
-	printf("\n[MCASTCLIENT] Terminate multicast sender after sending sufficient messages (%d)\n", num_packets);
+	printf("[MCASTCLIENT] Terminate multicast sender after sending sufficient messages (%d)\n", num_packets);
+out_with_socket:
 	close(sd);
 	return;
-
-errout_with_socket:
-	close(sd);
-	exit(1);
 }
 
-void ipmcast_receiver_thread(int num_packets)
+/* ------------------------------------------------------------ */
+/*                                                              */
+/* Receive Multicast Datagram code example.                     */
+/*                                                              */
+/* ------------------------------------------------------------ */
+void ipmcast_receiver_thread(int num_packets, const char *intf)
 {
 	int ret = 0;
 	int count = 0;
-	int datalen;
+	int datalen = 0;
 	char databuf[256];
-	int sd;
+	int sd = -1;
 	struct sockaddr_in localSock;
 	struct ip_mreq group;
-	printf("\n[MCASTSERV] start multicast receiver\n");
-	/* ------------------------------------------------------------ */
-	/*                                                              */
-	/* Receive Multicast Datagram code example.                     */
-	/*                                                              */
-	/* ------------------------------------------------------------ */
-
+	printf("[MCASTSERV] start multicast receiver\n");
 	/*
 	 * Create a datagram socket on which to receive.
 	 */
 	sd = socket(AF_INET, SOCK_DGRAM, 0);
 	if (sd < 0) {
-		printf("\n[MCASTSERV] ERR : opening datagram socket\n");
-		exit(1);
+		printf("[MCASTSERV] ERR : opening datagram socket\n");
+		return;
 	}
-	printf("\n[MCASTSERV] create socket success\n");
+	printf("[MCASTSERV] create socket success\n");
 	/*
 	 * Enable SO_REUSEADDR to allow multiple instances of this
 	 * application to receive copies of the multicast datagrams.
@@ -265,10 +334,10 @@ void ipmcast_receiver_thread(int num_packets)
 	int reuse = 1;
 	ret = setsockopt(sd, SOL_SOCKET, SO_REUSEADDR, (char *)&reuse, sizeof(reuse));
 	if (ret < 0) {
-		printf("\n[MCASTSERV] ERR: setting SO_REUSEADDR\n");
-		goto errout_with_socket;
+		printf("[MCASTSERV] ERR: setting SO_REUSEADDR\n");
+		goto out_with_socket;
 	}
-	printf("\n[MCASTSERV] set reusable success\n");
+	printf("[MCASTSERV] set reusable success\n");
 
 	/*
 	 * Bind to the proper port number with the IP address
@@ -280,24 +349,35 @@ void ipmcast_receiver_thread(int num_packets)
 	localSock.sin_addr.s_addr = INADDR_ANY;
 
 	if (bind(sd, (struct sockaddr *)&localSock, sizeof(localSock))) {
-		printf("\n[MCASTSERV] ERR: binding datagram socket\n");
-		goto errout_with_socket;
+		printf("[MCASTSERV] ERR: binding datagram socket\n");
+		goto out_with_socket;
 	}
 
-	printf("\n[MCASTSERV] bind socket success\n");
+	printf("[MCASTSERV] bind socket success\n");
+
 	/*
 	 * Join the multicast group 225.1.1.1 on the local 192.168.2.10
 	 * interface.  Note that this IP_ADD_MEMBERSHIP option must be
 	 * called for each local interface over which the multicast
 	 * datagrams are to be received.
 	 */
-	group.imr_multiaddr.s_addr = inet_addr(g_app_target_addr);
-	group.imr_interface.s_addr = inet_addr(LOCAL_DEVICE);
-	if (setsockopt(sd, IPPROTO_IP, IP_ADD_MEMBERSHIP, (char *)&group, sizeof(group)) < 0) {
-		printf("\n[MCASTSERV] ERR: adding multicast group\n");
-		goto errout_with_socket;
+
+	ret = netlib_get_ipv4addr(intf, &group.imr_interface);
+	if (ret == -1) {
+		printf("[MCASTSERV] fail to get interface's ip address\n");
+		goto out_with_socket;
 	}
-	printf("\n[MCASTSERV] join multicast success sucess success success success success success success\n");
+	printf("[MCASTSERV] bind interface(%s)\n", intf);
+	printf("[MCASTSERV] group address(%s)\n", g_app_target_addr);
+	printf("[MCASTSERV] port(%d)\n", g_app_target_port);
+
+	group.imr_multiaddr.s_addr = inet_addr(g_app_target_addr);
+	if (setsockopt(sd, IPPROTO_IP, IP_ADD_MEMBERSHIP, (char *)&group, sizeof(group)) < 0) {
+		printf("[MCASTSERV] fail: adding multicast group %d\n", errno);
+		goto out_with_socket;
+	}
+
+	printf("[MCASTSERV] join multicast success\n");
 	/*
 	 * Read from the socket.
 	 */
@@ -307,24 +387,23 @@ void ipmcast_receiver_thread(int num_packets)
 		ret = read(sd, databuf, datalen);
 
 		if (ret < 0) {
-			printf("\n[MCASTSERV] ERR: reading datagram message\n");
-		} else {
-			databuf[ret] = '\0';
-			count++;
-			if (count > num_packets) {
-				printf("\n[MCASTSERV] - Received Msg # %d] read (%s) (%d) bytes, Terminating MCLIENT as received sufficient packets for testing\n", count, databuf, ret);
-				break;
-			} else {
-				printf("\n[MCASTSERV] - Received Msg # %d] read (%s) (%d) bytes\n", count, databuf, ret);
-			}
+			printf("[MCASTSERV] ERR: reading datagram message (%d)\n", errno);
+			break;
+		}
+
+		count++;
+		printf("[MCASTSERV] - Received Msg # %d] read (%d) bytes\n", count, ret);
+		if (num_packets == 0) {
+			continue;
+		}
+		if (count > num_packets) {
+			printf("[MCASTSERV] Terminating MCLIENT as received sufficient packets for testing\n");
+			break;
 		}
 	}
+out_with_socket:
 	close(sd);
 	return;
-
-errout_with_socket:
-	close(sd);
-	exit(1);
 }
 
 int udp_server_thread(int num_packets)
@@ -342,12 +421,12 @@ int udp_server_thread(int num_packets)
 
 	s = socket(PF_INET, SOCK_DGRAM, 0);
 	if (s < 0) {
-		perror("\n[UDPSERV]socket fail");
+		perror("[UDPSERV]socket fail");
 		return 0;
 	}
 
-	printf("\n[UDPSERV] socket created\n");
-	printf("\n[UDPSERV] debug %d %d\n", addrlen, sizeof(struct sockaddr));
+	printf("[UDPSERV] socket created\n");
+	printf("[UDPSERV] debug %d %d\n", addrlen, sizeof(struct sockaddr));
 	memset(&cliaddr, 0, addrlen);
 	memset(&servaddr, 0, addrlen);
 	servaddr.sin_family = AF_INET;
@@ -356,11 +435,11 @@ int udp_server_thread(int num_packets)
 
 	ret = bind(s, (struct sockaddr *)&servaddr, addrlen);
 	if (ret < 0) {
-		perror("\n[UDPSERV]bind fail\n");
-		goto errout_with_socket;
+		perror("[UDPSERV]bind fail\n");
+		goto out_with_socket;
 	}
-	printf("\n[UDPSERV] socket binded\n");
-	printf("\n[UDPSERV] waiting on port %d\n", g_app_target_port);
+	printf("[UDPSERV] socket binded\n");
+	printf("[UDPSERV] waiting on port %d\n", g_app_target_port);
 
 	FD_ZERO(&fds);
 	FD_SET(s, &fds);
@@ -368,12 +447,10 @@ int udp_server_thread(int num_packets)
 	int max_fd = s + 1;
 	while (1) {
 		rfds = fds;
-		printf("[UDPSERV] -->select\n");
 		int res = select(max_fd, &rfds, NULL, NULL, NULL);
-		printf("[UDPSERV] <--select(%d)\n", res);
 		if (res < 0) {
 			printf("[UDPSERV] select error(%d)\n", errno);
-			goto errout_with_socket;
+			goto out_with_socket;
 		}
 		if (res > 0) {
 			if (FD_ISSET(s, &rfds)) {
@@ -384,22 +461,24 @@ int udp_server_thread(int num_packets)
 				}
 				if (nbytes == 0) {
 					printf("[UDPSERV] socket closed from remote\n");
-					goto errout_with_socket;
+					goto out_with_socket;
 				}
 				count++;
+				printf("[UDPSERV] - Received Msg # %d] Received Msg (%s) data size (%d)\n",
+					count, buf, nbytes);
+				if (num_packets == 0) {
+					continue;
+				}
 				if (count >= num_packets) {
-					printf("[UDPSERV] - Received Msg # %d] Received Msg (%s) data size (%d), Exiting UDPSERV as received sufficient packets for testing\n", count, buf, nbytes);
+					printf("[UDPSERV] Exiting UDPSERV as received sufficient packets for testing\n");
 					break;
-				} else {
-					printf("[UDPSERV] - Received Msg # %d] Received Msg (%s) data size (%d)\n", count, buf, nbytes);
 				}
 			}
 		} else {
 			assert(0);
 		}
 	}
-
-errout_with_socket:
+out_with_socket:
 	close(s);
 	return 0;
 }
@@ -424,7 +503,7 @@ void udp_client_thread(int num_packets, uint32_t sleep_time)
 	sockfd = socket(AF_INET, SOCK_DGRAM, 0);
 	if (sockfd < 0) {
 		printf("[UDPCLIENT]socket create error(%d)\n", errno);
-		exit(1);
+		return;
 	}
 	printf("[UDPCLIENT] socket create(%d)\n", sockfd);
 
@@ -439,10 +518,7 @@ void udp_client_thread(int num_packets, uint32_t sleep_time)
 	max_fd = sockfd + 1;
 	for (i = 1; i <= num_packets; i++) {
 		wfds = fds;
-		printf("[UDPCLIENT] -->select\n");
 		int res = select(max_fd, NULL, &wfds, NULL, 0);
-		printf("[UDPCLIENT] <--select(%d)\n", res);
-
 		if (res < 0) {
 			printf("[UDPCLIENT] select error(%d)\n", errno);
 			close(sockfd);
@@ -450,14 +526,16 @@ void udp_client_thread(int num_packets, uint32_t sleep_time)
 		}
 		if (res > 0) {
 			if (FD_ISSET(sockfd, &wfds)) {
-				printf("[UDPCLIENT] -->send msg # %d data (%s) nbytes (%d) \n", i, buf, strlen(buf));
 				if (sendto(sockfd, (void *)buf, strlen(buf), 0, (struct sockaddr *)&serveraddr, clilen) < 0) {
 					printf("[UDPCLIENT] sendto failed\n");
 				};
-				printf("[UDPCLIENT] <--sent msg\n");
+				printf("[UDPCLIENT] -->send msg # %d data (%s) nbytes (%d) \n", i, buf, strlen(buf));
 			} else {
 				assert(0);
 			}
+		}
+		if (sleep_time != 0) {
+			usleep(sleep_time);
 		}
 	}
 	printf("[UDPCLIENT] Terminating udpclient after sending sufficient messages (%d)\n", num_packets);
@@ -465,25 +543,23 @@ void udp_client_thread(int num_packets, uint32_t sleep_time)
 	return;
 }
 
-void tcp_server_thread(int num_packets, int infpkt)
+void tcp_server_thread(int num_packets)
 {
 	struct sockaddr_in servaddr;
 	struct sockaddr_in cliaddr;
+	int count = 0;
 	int listenfd = -1;
 	int connfd = -1;
 	socklen_t clilen;
-
 	int ret = 0;
 	int recv_len = 0;
 	int nbytes = 0;
-	int count = 0;
-
 	char msg[BUF_SIZE];
 
 	listenfd = socket(PF_INET, SOCK_STREAM, 0);
 	if (listenfd < 0) {
-		printf("\n[TCPSERV] TCP socket failure %d\n", errno);
-		exit(1);
+		printf("[TCPSERV] TCP socket failure %d\n", errno);
+		return;
 	}
 
 	/*
@@ -494,10 +570,10 @@ void tcp_server_thread(int num_packets, int infpkt)
 	int reuse = 1;
 	ret = setsockopt(listenfd, SOL_SOCKET, SO_REUSEADDR, (char *)&reuse, sizeof(reuse));
 	if (ret < 0) {
-		printf("\n[TCPSERV] ERR: setting SO_REUSEADDR\n");
-		goto errout_with_socket;
+		printf("[TCPSERV] ERR: setting SO_REUSEADDR\n");
+		goto out_with_socket;
 	}
-	printf("\n[TCPSERV] set reusable success\n");
+	printf("[TCPSERV] set reusable success\n");
 
 	/* Connect the socket to the server */
 	memset(&servaddr, 0, sizeof(servaddr));
@@ -507,63 +583,54 @@ void tcp_server_thread(int num_packets, int infpkt)
 
 	ret = bind(listenfd, (struct sockaddr *)&servaddr, sizeof(servaddr));
 	if (ret < 0) {
-		perror("\n[TCPSERV] bind fail\n");
-		goto errout_with_socket;
+		perror("[TCPSERV] bind fail\n");
+		goto out_with_socket;
 	}
 
-	printf("\n[TCPSERV] Listening... port %d\n", g_app_target_port);
+	printf("[TCPSERV] Listening... port %d\n", g_app_target_port);
 
 	ret = listen(listenfd, 1024);
 	if (ret < 0) {
-		perror("\n[TCPSERV] listen fail\n");
-		goto errout_with_socket;
+		perror("[TCPSERV] listen fail\n");
+		goto out_with_socket;
 	}
 
 	clilen = sizeof(cliaddr);
 
 	connfd = accept(listenfd, (struct sockaddr *)&cliaddr, &clilen);
 	if (connfd < 0) {
-		perror("\n[TCPSERV] accept fail\n");
-		goto errout_with_socket;
+		perror("[TCPSERV] accept fail\n");
+		goto out_with_socket;
 	}
-	printf("\n[TCPSERV] Accepted\n");
+	printf("[TCPSERV] Accepted\n");
 
 	recv_len = sizeof(msg);
 	while (1) {
 		nbytes = recv(connfd, msg, recv_len, 0);
 		if (nbytes <= 0) {
 			/* connection closed */
-			printf("\n[TCPSERV] selectserver: socket hung up err\n");
+			printf("[TCPSERV] selectserver: socket hung up err\n");
 			break;
 		}
 		count++;
-		if (infpkt == 0) {
-			if (count > num_packets) {
-				printf("\n[TCPSERV] - Received Msg # %d] Received Msg (%s) data size (%d)\n Exiting tcp_server as received sufficient packets for testing\n", count, msg, nbytes);
-				break;
-			} else {
-				printf("[TCPSERV] - Received Msg # %d] Received Msg (%s) data size (%d)\n", count, msg, nbytes);
-			}
-		} else if (infpkt == 1) {
-			if (count >= num_packets) {
-				printf("Count %d\n", count);
-				num_packets += num_packets;
-			} else {
-				printf("[TCPSERV] - Received Msg # %d] Received Msg (%s) data size (%d)\n", count, msg, nbytes);
-			}
+		printf("[TCPSERV] - Received Msg # %d] Received Msg (%s) data size (%d)\n",
+					count, msg, nbytes);
+		if (num_packets == 0) {
+			continue;
+		}
+		if (count > num_packets) {
+			printf("Exiting tcp_server as received sufficient packets for testing\n");
+			break;
 		}
 	}
 	if (connfd > 0) {
 		close(connfd);
-		printf("\n[TCPSERV] Closed connfd successfully \n");
+		printf("[TCPSERV] Closed connfd successfully \n");
 	}
+	printf("[TCPSERV] Closed listenfd successfully \n");
+out_with_socket:
 	close(listenfd);
-	printf("\n[TCPSERV] Closed listenfd successfully \n");
 	return;
-
-errout_with_socket:
-	close(listenfd);
-	exit(1);
 }
 
 void tcp_client_thread(int num_packets, uint32_t sleep_time)
@@ -579,8 +646,8 @@ void tcp_client_thread(int num_packets, uint32_t sleep_time)
 
 	sockfd = socket(PF_INET, SOCK_STREAM, 0);
 	if (sockfd < 0) {
-		printf("\n[TCPCLIENT] TCP socket failure %d\n", errno);
-		exit(1);
+		printf("[TCPCLIENT] TCP socket failure %d\n", errno);
+		return;
 	}
 
 	/* Connect the socket to the server */
@@ -590,12 +657,12 @@ void tcp_client_thread(int num_packets, uint32_t sleep_time)
 
 	addrlen = sizeof(struct sockaddr_in);
 
-	printf("\n[TCPCLIENT] Connecting...\n");
+	printf("[TCPCLIENT] Connecting...\n");
 	if (connect(sockfd, (struct sockaddr *)&myaddr, addrlen) < 0) {
-		printf("\n[TCPCLIENT] connect fail: %d\n", errno);
-		goto errout_with_socket;
+		printf("[TCPCLIENT] connect fail: %d\n", errno);
+		goto out_with_socket;
 	}
-	printf("\n[TCPCLIENT] Connected\n");
+	printf("[TCPCLIENT] Connected\n");
 
 	/* Then send num_packets number of messages */
 
@@ -603,44 +670,41 @@ void tcp_client_thread(int num_packets, uint32_t sleep_time)
 
 	for (i = 1; i <= num_packets; i++) {
 		sbuf_size = strlen(buf);
-		printf("\n\n\n[TCPCLIENT] -->send msg # %d data (%s) nbytes (%d) \n", i, buf, strlen(buf));
+		printf("\n\n[TCPCLIENT] -->send msg # %d data (%s) nbytes (%d) \n", i, buf, strlen(buf));
 
 		ret = send(sockfd, buf, sbuf_size, 0);
 
 		if (ret <= 0) {
 
 			if (ret == 0) {
-				printf("\n[TCPCLIENT] connection closed\n");
+				printf("[TCPCLIENT] connection closed\n");
 				break;
 			}
 
 			if (errno == EWOULDBLOCK) {
 				if (send_try++ > 100) {
-					printf("\n[TCPCLIENT] Sending try is more than LIMIT(%d)\n", 100);
+					printf("[TCPCLIENT] Sending try is more than LIMIT(%d)\n", 100);
 					break;
 				}
-				printf("\n[TCPCLIENT] wouldblock, retry delay 200ms!!\n");
+				/* we don't take care this sleep time in interval */
+				printf("[TCPCLIENT] wouldblock, retry delay 200ms!!\n");
 				usleep(200000);
 				continue;
 			}
 
-			printf("\n[TCPCLIENT] socket error ret(%d) err(%d) EAGAIN(%d)\n", ret, errno, EWOULDBLOCK);
+			printf("[TCPCLIENT] socket error ret(%d) err(%d) EAGAIN(%d)\n", ret, errno, EWOULDBLOCK);
 			break;
 		}
 		send_try = 0;
-		printf("\n[TCPCLIENT] <--send\t%d bytes\n\n", ret);
-		sleep(1);
-
+		printf("[TCPCLIENT] <--send\t%d bytes\n\n", ret);
+		if (sleep_time != 0) {
+			usleep(sleep_time);
+		}
 	}
-
-	printf("\n[TCPCLIENT] Terminating tcpclient after sending sufficient messages (%d)\n", num_packets);
-
+	printf("[TCPCLIENT] Terminating tcpclient after sending sufficient messages (%d)\n", num_packets);
+out_with_socket:
 	close(sockfd);
 	return;
-
-errout_with_socket:
-	close(sockfd);
-	exit(1);
 }
 
 /* Sample App to test Transport Layer (TCP / UDP) / IP Multicast Functionality */
@@ -650,67 +714,79 @@ int main(int argc, FAR char *argv[])
 int nettest_main(int argc, char *argv[])
 #endif
 {
-	nlldbg("Running nettest_main \n");
-	int proto = 0;
-	int num_packets_to_process = NUM_PACKETS;
-	uint32_t sleep_time = 0;
+	int mode = 0;
+	nettest_proto_e proto = NT_NONE;
+	int num_packets_to_process = 0;
+	uint32_t interval = 0;
 	/* pps - packet per second, default value 1 */
 	uint32_t pps = 1;
-	if (argc < 4) {
-		printf("\n\nUsage1: nettest target_addr target_port [0(tcpserv -infinite pkt receive), 1(tcpserv), 2(udpserv), 3(ipmulticastreceiver)]\n\n");
-		printf("\n\nSample Command1 (for ipmulticastreceiver): nettest 225.1.1.1 5555 3\n\n");
-		printf("\n\n");
-		printf("\n\nUsage2: nettest target_addr target_port [4(tcpclient), 5(udpclient), 6(ipmulticastsender)] pps(optional, number of packets transmitted per second - default value 1)\n\n");
-		printf("\n\nSample Command2 (for udpclient): nettest 192.168.2.5 5555 5 4\n\n");
-		printf("\n\n");
-		return 0;
+
+	if (argc < 6) {
+		goto err_with_input;
 	}
 
-	g_app_target_addr = argv[1];
-	g_app_target_port = atoi(argv[2]);
-	proto = atoi(argv[3]);
-
-	if (argc == 5) {
-		pps = atoi(argv[4]);
+	mode = atoi(argv[1]);
+	if (mode != NETTEST_SERVER_MODE && mode != NETTEST_CLIENT_MODE) {
+		goto err_with_input;
 	}
 
-	sleep_time = 1000000ul / pps;
-
-	printf("\n[NETTEST APP]Target addr : %s Target port %d protocol_under_test(%d) pps(%d)\n", g_app_target_addr, g_app_target_port, proto, pps);
-
-	switch (proto) {
-	case 0:
-		/* TCP Receive infinite pkts */
-		tcp_server_thread(num_packets_to_process, 1);
-		break;
-	case 1:
-		/* TCP receive test */
-		tcp_server_thread(num_packets_to_process, 0);
-		break;
-	case 2:
-		/* UDP receive test */
-		udp_server_thread(num_packets_to_process);
-		break;
-	case 3:
-		/* ipmulticast_receiver */
-		ipmcast_receiver_thread(num_packets_to_process);
-		break;
-	case 4:
-		/* TCP send test */
-		tcp_client_thread(num_packets_to_process, sleep_time);
-		break;
-	case 5:
-		/* UDP send test */
-		udp_client_thread(num_packets_to_process, sleep_time);
-		break;
-	case 6:
-		/* ipmulticast_sender */
-		ipmcast_sender_thread(num_packets_to_process, sleep_time);
-		break;
-	default:
-		printf("[NETTEST APP] Invalid proto type\n");
-		break;
+	if (strlen(argv[2]) != strlen(NETTEST_PROTO_TCP)) {
+		goto err_with_input;
 	}
-	printf("\nExiting nettest_main thread, job finished\n");
+	if (!strncmp(argv[2], NETTEST_PROTO_TCP, strlen(NETTEST_PROTO_TCP) + 1)) {
+		proto = NT_TCP;
+	} else if (!strncmp(argv[2], NETTEST_PROTO_UDP, strlen(NETTEST_PROTO_UDP) + 1)) {
+		proto = NT_UDP;
+	} else if (!strncmp(argv[2], NETTEST_PROTO_MULTICAST, strlen(NETTEST_PROTO_MULTICAST) + 1)) {
+		proto = NT_MULTICAST;
+	} else {
+		goto err_with_input;
+	}
+
+	g_app_target_addr = argv[3];
+	g_app_target_port = atoi(argv[4]);
+	num_packets_to_process = atoi(argv[5]);
+	if (num_packets_to_process < 0) {
+		goto err_with_input;
+	}
+
+	if (mode == NETTEST_SERVER_MODE) {
+		if (proto == NT_TCP) {
+			tcp_server_thread(num_packets_to_process);
+		} else if (proto == NT_UDP) {
+			udp_server_thread(num_packets_to_process);
+		} else if (proto == NT_MULTICAST) {
+			if (argc != 7) {
+				goto err_with_input;
+			}
+			ipmcast_receiver_thread(num_packets_to_process, argv[6]);
+		}
+	} else if (mode == NETTEST_CLIENT_MODE) {
+		if (argc < 7) {
+			goto err_with_input;
+		}
+		/* get interval */
+		pps = atoi(argv[6]);
+		if (pps < 0) {
+			goto err_with_input;
+		}
+		interval = 1000000ul / pps; /* sleep interval */
+
+		if (proto == NT_TCP) {
+			tcp_client_thread(num_packets_to_process, interval);
+		} else if (proto == NT_UDP) {
+			udp_client_thread(num_packets_to_process, interval);
+		} else if (proto == NT_MULTICAST) {
+			if (argc != 8) {
+				goto err_with_input;
+			}
+			ipmcast_sender_thread(num_packets_to_process, interval, argv[7]);
+		}
+	}
+	printf("Exiting nettest_main thread, job finished\n");
 	return 0;
+
+err_with_input:
+	show_usage();
+	return -1;
 }

--- a/external/netutils/netlib_getipv4addr.c
+++ b/external/netutils/netlib_getipv4addr.c
@@ -99,9 +99,6 @@ int netlib_get_ipv4addr(FAR const char *ifname, FAR struct in_addr *addr)
 	if (ifname && addr) {
 		int sockfd = socket(PF_INET, NETLIB_SOCK_IOCTL, 0);
 		if (sockfd >= 0) {
-#ifdef CONFIG_NET_LWIP
-			lwip_ioctl(sockfd, SIOCGIFADDR, addr);
-#else
 			struct ifreq req;
 			strncpy(req.ifr_name, ifname, IFNAMSIZ);
 			ret = ioctl(sockfd, SIOCGIFADDR, (unsigned long)&req);
@@ -111,7 +108,6 @@ int netlib_get_ipv4addr(FAR const char *ifname, FAR struct in_addr *addr)
 				req_addr = (FAR struct sockaddr_in *)&req.ifr_addr;
 				memcpy(addr, &req_addr->sin_addr, sizeof(struct in_addr));
 			}
-#endif
 			close(sockfd);
 		}
 	}


### PR DESCRIPTION
1) Add an interface name in command line to get an allocated ip address from system
2) Modify an usage because old version is difficult to understand
3) Bug fix in netlib_getipv4addr: NET_LWIP should not be used in netlib