### PR TITLE
net:lwip modify Make.defs not to build stats.c if the stats feature i…

### DIFF
--- a/os/include/net/lwip/opt.h
+++ b/os/include/net/lwip/opt.h
@@ -1485,7 +1485,7 @@
  * LWIP_STATS==1: Enable statistics collection in lwip_stats.
  */
 #ifndef LWIP_STATS
-#define LWIP_STATS                      1
+#define LWIP_STATS                      0
 #endif
 
 #if LWIP_STATS

--- a/os/net/lwip/src/core/Make.defs
+++ b/os/net/lwip/src/core/Make.defs
@@ -23,8 +23,11 @@
 
 
 LWIP_CSRCS += def.c dhcp.c init.c mem.c memp.c netif.c
-LWIP_CSRCS += pbuf.c raw.c stats.c sys.c tcp.c tcp_in.c tcp_out.c timers.c udp.c
+LWIP_CSRCS += pbuf.c raw.c sys.c tcp.c tcp_in.c tcp_out.c timers.c udp.c
 LWIP_CSRCS += dhcps.c
+ifeq ($(CONFIG_NET_STATS),y)
+LWIP_CSRCS += stats.c
+endif
 
 # Include core build support
 

--- a/os/net/lwip/src/core/init.c
+++ b/os/net/lwip/src/core/init.c
@@ -297,7 +297,9 @@
 void lwip_init(void)
 {
 	/* Modules initialization */
+#if LWIP_STATS
 	stats_init();
+#endif
 #if !NO_SYS
 	sys_init();
 #endif							/* !NO_SYS */

--- a/os/net/lwip/sys/arch/sys_arch.c
+++ b/os/net/lwip/sys/arch/sys_arch.c
@@ -50,7 +50,7 @@
 #define SYS_THREAD_MAX 6
 
 static u16_t s_nextthread = 0;
-
+static u32_t g_mbox_id = 0;
 /*---------------------------------------------------------------------------*
  * Routine:  sys_mbox_new
  *---------------------------------------------------------------------------*
@@ -64,10 +64,9 @@ static u16_t s_nextthread = 0;
  *---------------------------------------------------------------------------*/
 err_t sys_mbox_new(sys_mbox_t *mbox, int queue_sz)
 {
-
 	err_t err = ERR_OK;
 	mbox->is_valid = 1;
-	mbox->id = lwip_stats.sys.mbox.used + 1;
+	mbox->id = g_mbox_id++;
 	mbox->queue_size = queue_sz;
 	mbox->wait_send = 0;
 	mbox->wait_fetch = 0;


### PR DESCRIPTION
…s disable
Statistics files in lwip is built even though it is not enabled in menuconfig.
And sys arch.c has depency to the statistics feature.
The commit won't build statistics files if it is disabled and will break the relationship between sys arch and statistics.