### PR TITLE
sidk_s5t200 : create rom device using ftl mtd

### DIFF
--- a/build/configs/sidk_s5jt200/README.md
+++ b/build/configs/sidk_s5jt200/README.md
@@ -115,16 +115,16 @@ Before executing below steps, execute [generic steps](../../../tools/fs/README_R
 
 3. Modify partition configs.  
     Below steps creates ROMFS partition with size 256KB at the end,  
-    where romfs device is a smart device and romfs filesystem will be mounted on smartdevice "/dev/smart0p15"  
+    where romfs device is a ftl mtd block device and romfs filesystem will be mounted on ftl mtd device "/dev/mtdblockX"
     1. Split last partition size to (256, 256) in SIDK_S5JT200_FLASH_PART_LIST
         ```bash
         Board Selection -> change values at Flash partition size list (in KBytes)
         ```
-    2. Append "smartfs," at end to SIDK_S5JT200_FLASH_PART_TYPE
+    2. Append "romfs," at end to SIDK_S5JT200_FLASH_PART_TYPE
         ```bash
         Board Selection -> append string at Flash partition type list
         ```
-    3. Append "romfs," at end to SIDK_S5JT200_FLASH_PART_NAME
+    3. Append "rom," at end to SIDK_S5JT200_FLASH_PART_NAME
         ```bash
         Board Selection -> append string at FLash partition name list
         ```

--- a/build/configs/sidk_s5jt200/tools/openocd/partition_gen.sh
+++ b/build/configs/sidk_s5jt200/tools/openocd/partition_gen.sh
@@ -78,7 +78,7 @@ echo "# Partition Map (Auto generated)" > ${PARTITION_MAP_CFG}
 echo "set FLASH_START $FLASH_BASE" >> ${PARTITION_MAP_CFG}
 for pname in $partname_list
 do
-	if [ "$pname" == "romfs" ]; then
+	if [ "$pname" == "rom" ]; then
 		romfs_part_exist=1
 	fi
 

--- a/build/configs/sidk_s5jt200/tools/openocd/s5jt200_silicon_evt0_fusing_flash_all.cfg
+++ b/build/configs/sidk_s5jt200/tools/openocd/s5jt200_silicon_evt0_fusing_flash_all.cfg
@@ -316,8 +316,8 @@ proc fusing_image_romfs {} {
 		echo "Fusing ROMFS Image.."
 		echo "----------------------------------------------------------------------"
 		set ROMFS_IMG_PATH "../../../../../build/output/bin/romfs.img"
-		global romfs_part_start
-		load_image $ROMFS_IMG_PATH $romfs_part_start
+		global rom_part_start
+		load_image $ROMFS_IMG_PATH $rom_part_start
 		echo "Done"
 	}
 }

--- a/os/arch/arm/src/sidk_s5jt200/Kconfig
+++ b/os/arch/arm/src/sidk_s5jt200/Kconfig
@@ -112,14 +112,6 @@ config SIDK_S5JT200_AUTOMOUNT_ROMFS
 		If enabled, rom readonly partition will be mounted automatically
 		at boot.
 
-config SIDK_S5JT200_AUTOMOUNT_ROMFS_DEVNAME
-	string "Device name of the partition for rom readonly file system"
-	default "/dev/smart0p15"
-	depends on SIDK_S5JT200_AUTOMOUNT_ROMFS
-	---help---
-		Specifies the device name (/dev/smart0pX) of the partition
-		for rom readonly file system.
-
 config SIDK_S5JT200_AUTOMOUNT_ROMFS_MOUNTPOINT
 	string "Mountpoint of the partition for rom read only file system"
 	default "/rom"

--- a/os/arch/arm/src/sidk_s5jt200/src/s5jt200_tash.c
+++ b/os/arch/arm/src/sidk_s5jt200/src/s5jt200_tash.c
@@ -81,6 +81,14 @@
  ****************************************************************************/
 
 /****************************************************************************
+ * Private Variables
+ ****************************************************************************/
+#if defined(CONFIG_FS_ROMFS)
+static uint16_t	rommtd_partno;
+static bool	rommtd_device_exist = false;
+#endif
+
+/****************************************************************************
  * Public Functions
  ****************************************************************************/
 extern void s5j_i2c_register(int bus);
@@ -191,6 +199,16 @@ static void sidk_s5jt200_configure_partitions(void)
 					mtd_part, partref);
 		} else
 #endif
+#if defined(CONFIG_MTD_FTL) && defined(CONFIG_FS_ROMFS)
+		if (!strncmp(types, "romfs,", 6)) {
+			if (ftl_initialize(partno, mtd_part)) {
+				lldbg("ERROR: failed to initialise mtd ftl errno :%d\n", errno);
+			} else {
+				rommtd_partno = partno;
+				rommtd_device_exist = true;
+			}
+		} else
+#endif
 		{
 		}
 
@@ -270,17 +288,24 @@ int board_app_initialize(void)
 	static uint8_t *rambuf;
 	struct mtd_dev_s *mtd;
 #endif /* CONFIG_RAMMTD */
+#if defined(CONFIG_FS_ROMFS)
+	char rommtd_devname[16];
+#endif
 
 	sidk_s5jt200_configure_partitions();
 
 #if defined(CONFIG_SIDK_S5JT200_AUTOMOUNT_ROMFS)
-	ret = mount(CONFIG_SIDK_S5JT200_AUTOMOUNT_ROMFS_DEVNAME,
-			CONFIG_SIDK_S5JT200_AUTOMOUNT_ROMFS_MOUNTPOINT,
-			"romfs", 0, NULL);
+	if (rommtd_device_exist) {
+		snprintf(rommtd_devname, 16, "/dev/mtdblock%d", rommtd_partno);
 
-	if (ret != OK) {
-		lldbg("ERROR: mounting '%s'(ROMFS) failed\n",
-			CONFIG_SIDK_S5JT200_AUTOMOUNT_ROMFS_DEVNAME);
+		ret = mount(rommtd_devname,
+				CONFIG_SIDK_S5JT200_AUTOMOUNT_ROMFS_MOUNTPOINT,
+				"romfs", 0, NULL);
+
+		if (ret != OK) {
+			lldbg("ERROR: mounting '%s'(ROMFS) failed\n",
+				rommtd_devname);
+		}
 	}
 #endif /* CONFIG_SIDK_S5JT200_AUTOMOUNT_ROMFS */
 


### PR DESCRIPTION
Changes:
1. Create rom device using ftl mtd instead of smart mtd
2. Removed SIDK_S5JT200_AUTOMOUNT_ROMFS_DEVNAME config,
   and devname is dynamically composed.
3. Modified partition and openocd script accordingly

Signed-off-by: Manohara HK <manohara.hk@samsung.com>