### PR TITLE
Introduce w_info_mutex to protect g_manager_info of wifi_manager whil…

### DIFF
--- a/apps/examples/testcase/ta_tc/wifi_manager/utc/utc_wifi_manager_main.c
+++ b/apps/examples/testcase/ta_tc/wifi_manager/utc/utc_wifi_manager_main.c
@@ -143,7 +143,7 @@ static void utc_wifi_manager_set_mode_n(void)
 
 	ret = wifi_manager_set_mode(SOFTAP_MODE, NULL);
 
-	TC_ASSERT_EQ("wifi_manager_set_mode_n", ret, WIFI_MANAGER_FAIL);
+	TC_ASSERT_EQ("wifi_manager_set_mode_n", ret, WIFI_MANAGER_INVALID_ARGS);
 
 	wifi_manager_softap_config_s ap_config;
 	strncpy(ap_config.ssid, CONFIG_EXAMPLES_TESTCASE_WIFI_MANAGER_UTC_SOFTAP_SSID, \
@@ -388,7 +388,7 @@ int wifi_manager_utc(int argc, FAR char *argv[])
 	utc_wifi_utils_disconnect_ap_p();
 
 	WIFITEST_WAIT;
-	
+
 	utc_wifi_utils_disconnect_ap_n();	//  Should be run after positive tc, that is, the second disconnect gets failed.
 
 	utc_wifi_manager_deinit_p();

--- a/framework/include/wifi_manager/wifi_manager.h
+++ b/framework/include/wifi_manager/wifi_manager.h
@@ -60,7 +60,11 @@ typedef enum {
 typedef enum {
 	WIFI_NONE = -1,
 	STA_MODE,
-	SOFTAP_MODE
+	SOFTAP_MODE,
+	WIFI_MODE_CHANGING,
+	WIFI_INITIALIZING,
+	WIFI_DEINITIALIZING,
+	WIFI_FAILURE
 } wifi_manager_mode_e;
 
 typedef enum {


### PR DESCRIPTION
…e limiting the role of w_mutex to serializing wifi_manager APIs

1. By using this w_info_mutex, deadlock between wifi_manager and slsi_wifi callback is resolved.
2. Introduce additional wifi_manager status: WIFI_MODE_CHAING, WIFI_INITIALIZING, WIFI_DEINITIALIZING, and WIFI_FAILURE.
   In case of WIFI_FAILURE, app developers are requested to deinit and init wifi_manager.
3. wifi_manager_set_mode() returns WIFI_MANAGER_INVALID_ARGS when mode is softap without config.