### PR TITLE
s5j: exclude s5j_watchdog_disable from CONFIG_S5J_WATCHDOG

### DIFF
--- a/os/arch/arm/src/s5j/Make.defs
+++ b/os/arch/arm/src/s5j/Make.defs
@@ -119,8 +119,8 @@ CHIP_CSRCS += s5j_serial.c
 CHIP_CSRCS += s5j_mac.c
 CHIP_CSRCS += s5j_systemreset.c
 
-ifeq ($(CONFIG_S5J_WATCHDOG),y)
 CHIP_CSRCS += s5j_watchdog.c
+ifeq ($(CONFIG_S5J_WATCHDOG),y)
 ifeq ($(CONFIG_WATCHDOG),y)
 CHIP_CSRCS += s5j_watchdog_lowerhalf.c
 endif

--- a/os/arch/arm/src/s5j/s5j_boot.c
+++ b/os/arch/arm/src/s5j/s5j_boot.c
@@ -180,9 +180,7 @@ void arm_boot(void)
 	up_copyvectorblock();
 
 	/* Disable the watchdog timer */
-#ifdef CONFIG_S5J_WATCHDOG
 	s5j_watchdog_disable();
-#endif
 
 #ifdef CONFIG_ARMV7R_MEMINIT
 	/* Initialize the .bss and .data sections as well as RAM functions

--- a/os/arch/arm/src/s5j/s5j_watchdog.c
+++ b/os/arch/arm/src/s5j/s5j_watchdog.c
@@ -101,6 +101,7 @@ void s5j_watchdog_disable(void)
 	putreg32(wtcon, S5J_WDT_WTCON);
 }
 
+#ifdef CONFIG_S5J_WATCHDOG
 /****************************************************************************
  * Name: s5j_watchdog_enable
  *
@@ -249,3 +250,4 @@ void s5j_watchdog_clear_int(void)
 {
 	putreg32(0xffffffff, S5J_WDT_WTCLRINT);
 }
+#endif


### PR DESCRIPTION
As soon as tizenrt boots on s5j chip, it might reset because of
watchdog timeout set by the previous bootloader.

Inorder to continue tizenrt boot on s5j chip by avoiding watchdog reset,
watchdog must be disabled during boot. The code which does this part
is s5j_watchdog_disable() and it is under CONFIG_S5J_WATCHDOG.

The simple way is to keep this function always enabled for s5j chip.

Hence this patch excludes s5j_watchdog_disable() from CONFIG_S5J_WATCHDOG.

Signed-off-by: Manohara HK <manohara.hk@samsung.com>