### PR TITLE
Add artk053 TizenRT & romfs download mode

### DIFF
--- a/build/configs/artik053/.flashSpec.xml
+++ b/build/configs/artik053/.flashSpec.xml
@@ -21,6 +21,7 @@
     </executors>
     <options>
         <option>ALL</option>
+        <option>OS</option>
         <option>ERASE_USERFS</option>
     </options>
 </flash>

--- a/build/configs/artik053/artik053_download.sh
+++ b/build/configs/artik053/artik053_download.sh
@@ -120,7 +120,7 @@ main()
 			;;
 
 		OS|os)
-			echo "OS only :"
+			echo "OS :"
 
 			# check existence of os binary
 			if [ ! -f "${OUTPUT_BINARY_PATH}/tinyara_head.bin" ]; then

--- a/build/configs/artik053/artik053_download.sh
+++ b/build/configs/artik053/artik053_download.sh
@@ -119,6 +119,26 @@ main()
 			romfs
 			;;
 
+		OS|os)
+			echo "OS only :"
+
+			# check existence of os binary
+			if [ ! -f "${OUTPUT_BINARY_PATH}/tinyara_head.bin" ]; then
+				echo "TinyAra binary is not existed, build first"
+				finish_download 1
+			fi
+
+			# Download all binaries using openocd script
+			pushd ${OPENOCD_DIR_PATH}
+			${OPENOCD_BIN_PATH}/openocd -f artik053.cfg -c ' 	\
+			flash_write os ../../../../output/bin/tinyara_head.bin;	\
+			exit'
+			popd
+
+			# check romfs and download it
+			romfs
+			;;
+
 		ERASE_USERFS|erase_userfs)
 			echo "USERFS :"
 
@@ -131,7 +151,7 @@ main()
 
 		*)
 			echo "${arg} is not suppported in artik053"
-			echo "Usage : make download [ ALL | ERASE_USERFS ]"
+			echo "Usage : make download [ ALL | OS | ERASE_USERFS ]"
 			finish_download 1
 			;;
 		esac


### PR DESCRIPTION
I think we don't need to download every bin file(bl1, bl2, sssfw, wlanfw, os).
To improve development environment, adding os only download mode would be good.