### PR TITLE
Revert "net:tc add dup testcases"

### DIFF
--- a/apps/examples/testcase/le_tc/network/Kconfig
+++ b/apps/examples/testcase/le_tc/network/Kconfig
@@ -36,7 +36,6 @@ config TC_NET_ALL
 	select TC_NET_INET
 	select TC_NET_ETHER
 	select TC_NET_NETDB
-	select TC_NET_DUP
 
 config TC_NET_SOCKET
 	bool "socket() api"
@@ -122,9 +121,6 @@ config TC_NET_NETDB
 	bool "netdb() api"
 	default n
 
-config TC_NET_DUP
-	bool "dup() api"
-	default n
 
 
 endif #EXAMPLES_TESTCASE_NETWORK

--- a/apps/examples/testcase/le_tc/network/Make.defs
+++ b/apps/examples/testcase/le_tc/network/Make.defs
@@ -119,9 +119,6 @@ endif
 ifeq ($(CONFIG_TC_NET_NETDB),y)
 CSRCS +=tc_net_netdb.c
 endif
-ifeq ($(CONFIG_TC_NET_DUP),y)
-CSRCS +=tc_net_dup.c
-endif
 
 # Include network build support
 

--- a/apps/examples/testcase/le_tc/network/network_tc_main.c
+++ b/apps/examples/testcase/le_tc/network/network_tc_main.c
@@ -110,9 +110,6 @@ int network_tc_main(int argc, char *argv[])
 #ifdef CONFIG_TC_NET_NETDB
 	net_netdb_main();
 #endif
-#ifdef CONFIG_TC_NET_DUP
-	net_dup_main();
-#endif
 
 	printf("\n=== TINYARA Network TC COMPLETE ===\n");
 	printf("\t\tTotal pass : %d\n\t\tTotal fail : %d\n", total_pass, total_fail);


### PR DESCRIPTION
This reverts commit 43f0771693275fe3ea141a5c0869c6da111e21a2.

Missed a main file for this commit. This will be merged including that file later.