### PR TITLE
doxygen: modify @file option to show path for including

### DIFF
--- a/external/include/mbedtls/see_api.h
+++ b/external/include/mbedtls/see_api.h
@@ -15,7 +15,7 @@
  * language governing permissions and limitations under the License.
  *
  ****************************************************************************/
-/// @file see/see_api.h
+/// @file mbedtls/see_api.h
 /// @brief SEE api is supporting security api for using secure storage.
 
 #ifndef __SEE_API_H

--- a/external/include/mbedtls/see_internal.h
+++ b/external/include/mbedtls/see_internal.h
@@ -16,7 +16,7 @@
  *
  ****************************************************************************/
 
-/// @file see/see_internal.h
+/// @file mbedtls/see_internal.h
 /// @brief SEE api for using in TLS internal.
 
 #ifndef __SEE_INTERNAL_H

--- a/external/include/protocols/dhcpc.h
+++ b/external/include/protocols/dhcpc.h
@@ -59,7 +59,7 @@
  * @{
  */
 /**
- * @file dhcpc.h
+ * @file protocols/dhcpc.h
  * @brief APIs for DHCP client
  */
 

--- a/external/include/protocols/dhcpd.h
+++ b/external/include/protocols/dhcpd.h
@@ -58,7 +58,7 @@
   */
 
 /**
- * @file netif.h
+ * @file protocols/dhcpd.h
  * @brief netif API (to be used from lwIP TCPIP thread)
  */
 

--- a/external/include/protocols/libcoap/address.h
+++ b/external/include/protocols/libcoap/address.h
@@ -24,7 +24,7 @@
  */
 
 /**
- * @file address.h
+ * @file protocols/libcoap/address.h
  * @brief representation of network addresses
  */
 

--- a/external/include/protocols/libcoap/async.h
+++ b/external/include/protocols/libcoap/async.h
@@ -24,7 +24,7 @@
  */
 
 /**
- * @file async.h
+ * @file protocols/libcoap/async.h
  * @brief state management for asynchronous messages
  */
 

--- a/external/include/protocols/libcoap/bits.h
+++ b/external/include/protocols/libcoap/bits.h
@@ -25,7 +25,7 @@
  */
 
 /**
- * @file bits.h
+ * @file protocols/libcoap/bits.h
  * @brief bit vector manipulation
  */
 

--- a/external/include/protocols/libcoap/coap_time.h
+++ b/external/include/protocols/libcoap/coap_time.h
@@ -24,7 +24,7 @@
  */
 
 /**
- * @file coap_time.h
+ * @file protocols/libcoap/coap_time.h
  * @brief Clock Handling
  */
 

--- a/external/include/protocols/libcoap/hashkey.h
+++ b/external/include/protocols/libcoap/hashkey.h
@@ -24,7 +24,7 @@
  */
 
 /**
- * @file hashkey.h
+ * @file protocols/libcoap/hashkey.h
  * @brief definition of hash key type and helper functions
  */
 

--- a/external/include/protocols/libcoap/prng.h
+++ b/external/include/protocols/libcoap/prng.h
@@ -24,7 +24,7 @@
  */
 
 /**
- * @file prng.h
+ * @file protocols/libcoap/prng.h
  * @brief Pseudo Random Numbers
  */
 

--- a/external/include/protocols/libcoap/resource.h
+++ b/external/include/protocols/libcoap/resource.h
@@ -24,7 +24,7 @@
  */
 
 /**
- * @file resource.h
+ * @file protocols/libcoap/resource.h
  * @brief generic resource handling
  */
 

--- a/external/include/protocols/libcoap/t_list.h
+++ b/external/include/protocols/libcoap/t_list.h
@@ -41,7 +41,7 @@
  */
 
 /**
- * @file t_list.h
+ * @file protocols/libcoap/t_list.h
  * @brief Wrappers for list structures and functions
  */
 

--- a/external/include/protocols/mdnsd.h
+++ b/external/include/protocols/mdnsd.h
@@ -49,7 +49,7 @@
  * @{
  */
 /**
- * @file mdnsd.h
+ * @file protocols/mdnsd.h
  * @brief APIs for Multicast DNS
  */
 

--- a/external/include/protocols/ntpclient.h
+++ b/external/include/protocols/ntpclient.h
@@ -56,7 +56,7 @@
  * @{
  */
 
-/// @file ntpclient.h
+/// @file protocols/ntpclient.h
 /// @brief APIs for NTP Client
 
 #ifndef __APPS_INCLUDE_NETUTILS_NTPCLIENT_H

--- a/external/include/protocols/webclient.h
+++ b/external/include/protocols/webclient.h
@@ -26,7 +26,7 @@
  */
 
 /**
- * @file webclient.h
+ * @file protocols/webclient.h
  * @brief APIs for HTTP Client.
  */
 

--- a/external/include/protocols/webserver/http_keyvalue_list.h
+++ b/external/include/protocols/webserver/http_keyvalue_list.h
@@ -21,7 +21,7 @@
  */
 
 /**
- * @file http_keyvalue_list.h
+ * @file protocols/webserver/http_keyvalue_list.h
  * @brief APIs for key/value in HTTP Server.
  */
 

--- a/external/include/protocols/webserver/http_server.h
+++ b/external/include/protocols/webserver/http_server.h
@@ -29,7 +29,7 @@
  */
 
 /**
- * @file http_server.h
+ * @file protocols/webserver/http_server.h
  * @brief APIs for HTTP Server.
  */
 

--- a/external/include/protocols/websocket.h
+++ b/external/include/protocols/websocket.h
@@ -16,10 +16,6 @@
  *
  ****************************************************************************/
 /**
- * @file websocket.h
- * @brief websocket header to support WS/WSS server and client.
- */
-/**
  * @defgroup Websocket Websocket
  * @brief Provides APIs for Websocket
  * @ingroup NETWORK
@@ -27,8 +23,10 @@
  * @{
  */
 
-/// @file app/include/netutils/websocket.h
-/// @brief websocket api header.
+/**
+ * @file protocols/websocket.h
+ * @brief websocket header to support WS/WSS server and client.
+ */
 
 #ifndef __APPS_INCLUDE_NETUTILS_WEBSOCKET_H
 #define __APPS_INCLUDE_NETUTILS_WEBSOCKET_H

--- a/framework/include/dm/dm_connectivity.h
+++ b/framework/include/dm/dm_connectivity.h
@@ -24,7 +24,7 @@
  */
 
 /**
- * @file dm_connectivity.h
+ * @file dm/dm_connectivity.h
  * @brief DM Connectivity APIs
  */
 

--- a/framework/include/dm/dm_error.h
+++ b/framework/include/dm/dm_error.h
@@ -23,7 +23,7 @@
  */
 
 /**
- * @file dm_error.h
+ * @file dm/dm_error.h
  * @brief Definition of dm_error
  */
 

--- a/framework/include/dm/dm_lwm2m.h
+++ b/framework/include/dm/dm_lwm2m.h
@@ -24,7 +24,7 @@
  */
 
 /**
- * @file dm_lwm2m.h
+ * @file dm/dm_lwm2m.h
  * @brief device management APIs for DM
  */
 

--- a/framework/include/iotbus/iotbus_error.h
+++ b/framework/include/iotbus/iotbus_error.h
@@ -23,7 +23,7 @@
  */
 
 /**
- * @file iotbus_error.h
+ * @file iotbus/iotbus_error.h
  * @brief Definition of iotbus_error
  */
 

--- a/framework/include/iotbus/iotbus_gpio.h
+++ b/framework/include/iotbus/iotbus_gpio.h
@@ -24,7 +24,7 @@
  */
 
 /**
- * @file iotbus_gpio.h
+ * @file iotbus/iotbus_gpio.h
  * @brief Iotbus APIs for GPIO
  */
 

--- a/framework/include/iotbus/iotbus_i2c.h
+++ b/framework/include/iotbus/iotbus_i2c.h
@@ -24,7 +24,7 @@
  */
 
 /**
- * @file iotbus_i2c.h
+ * @file iotbus/iotbus_i2c.h
  * @brief Iotbus APIs for I2C
  */
 

--- a/framework/include/iotbus/iotbus_pwm.h
+++ b/framework/include/iotbus/iotbus_pwm.h
@@ -24,7 +24,7 @@
  */
 
 /**
- * @file iotbus_pwm.h
+ * @file iotbus/iotbus_pwm.h
  * @brief Iotbus APIs for PWM
  */
 

--- a/framework/include/iotbus/iotbus_spi.h
+++ b/framework/include/iotbus/iotbus_spi.h
@@ -24,7 +24,7 @@
  */
 
 /**
- * @file iotbus_spi.h
+ * @file iotbus/iotbus_spi.h
  * @brief Iotbus APIs for SPI
  */
 

--- a/framework/include/iotbus/iotbus_uart.h
+++ b/framework/include/iotbus/iotbus_uart.h
@@ -24,7 +24,7 @@
  */
 
 /**
- * @file iotbus_uart.h
+ * @file iotbus/iotbus_uart.h
  * @brief Iotbus APIs for UART
  */
 

--- a/framework/include/st_things/st_things.h
+++ b/framework/include/st_things/st_things.h
@@ -23,7 +23,7 @@
  */
 
 /**
- * @file st_things.h
+ * @file st_things/st_things.h
  * @brief Provides APIs for SmartThings Things SDK
  */
 

--- a/framework/include/st_things/st_things_types.h
+++ b/framework/include/st_things/st_things_types.h
@@ -21,7 +21,7 @@
  */
 
 /**
- * @file st_things_types.h
+ * @file st_things/st_things_types.h
  * @brief Provides structure definition for SmartThings Things SDK
  */
 

--- a/framework/include/wifi_manager/wifi_manager.h
+++ b/framework/include/wifi_manager/wifi_manager.h
@@ -24,7 +24,7 @@
  */
 
 /**
- * @file wifi_manager.h
+ * @file wifi_manager/wifi_manager.h
  * @brief Provides APIs for Wi-Fi Manager
  */
 

--- a/os/include/arpa/inet.h
+++ b/os/include/arpa/inet.h
@@ -57,7 +57,7 @@
   */
 
 /**
- * @file inet.h
+ * @file arpa/inet.h
  * @brief inet API
  */
 

--- a/os/include/net/lwip/dhcp.h
+++ b/os/include/net/lwip/dhcp.h
@@ -22,7 +22,7 @@
  */
 
 /**
- * @file dhcp.h
+ * @file net/dhcp.h
  * @brief APIs for DHCP client
  */
 #ifndef __LWIP_DHCP_H__

--- a/os/include/net/lwip/netif.h
+++ b/os/include/net/lwip/netif.h
@@ -54,7 +54,7 @@
  */
 
 /**
- * @file netif.h
+ * @file net/lwip/netif.h
  * @brief netif API (to be used from lwIP TCPIP thread)
  */
 

--- a/os/include/sys/ioctl.h
+++ b/os/include/sys/ioctl.h
@@ -57,7 +57,7 @@
  * @{
  */
 
-/// @file ioctl.h
+/// @file sys/ioctl.h
 /// @brief I/O control APIs
 
 #ifndef __INCLUDE_SYS_IOCTL_H

--- a/os/include/sys/mount.h
+++ b/os/include/sys/mount.h
@@ -57,7 +57,7 @@
  * @{
  */
 
-/// @file mount.h
+/// @file sys/mount.h
 /// @brief mount APIs
 
 #ifndef __INCLUDE_SYS_MOUNT_H

--- a/os/include/sys/select.h
+++ b/os/include/sys/select.h
@@ -57,7 +57,7 @@
  * @{
  */
 
-/// @file select.h
+/// @file sys/select.h
 /// @brief synchronous I/O multiplexing APIs
 
 #ifndef __INCLUDE_SYS_SELECT_H

--- a/os/include/sys/socket.h
+++ b/os/include/sys/socket.h
@@ -58,7 +58,7 @@
  * @{
  */
 
-/// @file socket.h
+/// @file sys/socket.h
 /// @brief Socket APIs
 #ifndef __INCLUDE_SYS_SOCKET_H
 #define __INCLUDE_SYS_SOCKET_H

--- a/os/include/sys/stat.h
+++ b/os/include/sys/stat.h
@@ -58,7 +58,7 @@
  * @{
  */
 
-/// @file stat.h
+/// @file sys/stat.h
 /// @brief Status APIs
 
 #ifndef __INCLUDE_SYS_STAT_H

--- a/os/include/tinyara/net/dns.h
+++ b/os/include/tinyara/net/dns.h
@@ -59,7 +59,7 @@
  */
 
 /**
- * @file dns.h
+ * @file tinyara/net/dns.h
  * @brief DNS client API
  */
 

--- a/os/include/tinyara/ringbuf.h
+++ b/os/include/tinyara/ringbuf.h
@@ -22,7 +22,7 @@
  * @{
  */
 
-///@file ringbuf.h
+///@file tinyara/ringbuf.h
 ///@brief ttrace ringbuffer APIs
 
 #ifndef __INCLUDE_TINYARA_TTRACE_RINGBUF_H

--- a/os/include/tinyara/ttrace.h
+++ b/os/include/tinyara/ttrace.h
@@ -22,7 +22,7 @@
  * @{
  */
 
-///@file ttrace.h
+///@file tinyara/ttrace.h
 ///@brief ttrace APIs
 
 #ifndef __INCLUDE_TINYARA_TTRACE_H


### PR DESCRIPTION
In doxygen output, file shows only a header file name.
But with that, developer can't include a header to use specific APIs.
Adding a path in @file option helps to include it.
For example,
 @file aa/bb.h
then, we can include it like belows.
 #include <aa/bb.h>