### PR TITLE
Add NULL check in Balloc

### DIFF
--- a/lib/libc/stdio/lib_dtoa.c
+++ b/lib/libc/stdio/lib_dtoa.c
@@ -160,6 +160,9 @@ static Bigint *Balloc(int k)
 	} else {
 		x = 1 << k;
 		rv = (Bigint *)lib_malloc(sizeof(Bigint) + (x - 1) * sizeof(long));
+		if (rv == NULL) {
+			return NULL;
+		}
 		rv->k = k;
 		rv->maxwds = x;
 	}


### PR DESCRIPTION
Pointer 'rv' returned from function 'malloc' at lib_dtoa.c:162 may be null,
and it is dereferenced at lib_dtoa.c:163.