### PR TITLE
[Arastorage] Svace warning fix

### DIFF
--- a/framework/src/arastorage/index_manager.c
+++ b/framework/src/arastorage/index_manager.c
@@ -477,7 +477,7 @@ db_result_t db_indexing(relation_t *rel)
 	cardinality = relation_cardinality(rel);
 
 	for (tuple_id = 0; tuple_id < cardinality; tuple_id++) {
-		memset(row, 0, sizeof(storage_row_t));
+		memset(row, 0, sizeof(char) * rel->row_length + 1);
 		DB_LOG_V("DB: Indexing Tuple id %d\n", tuple_id);
 		result = storage_get_row(rel, &tuple_id, row);
 		if (DB_ERROR(result)) {


### PR DESCRIPTION
Corrected num of bytes being passed to memset in index_manager.c at line 480
Earlier size of pointer struct was being passed, now the value to which row is malloc'd is sent to memset.
