### PR TITLE
Add NULL check in send_tcp function

### DIFF
--- a/os/net/lwip/src/api/api_msg.c
+++ b/os/net/lwip/src/api/api_msg.c
@@ -327,6 +327,10 @@ static err_t sent_tcp(void *arg, struct tcp_pcb *pcb, u16_t len)
 	LWIP_UNUSED_ARG(pcb);
 	LWIP_ASSERT("conn != NULL", (conn != NULL));
 
+	if (conn == NULL) {
+		return ERR_ARG;
+	}
+
 	if (conn->state == NETCONN_WRITE) {
 		do_writemore(conn);
 	} else if (conn->state == NETCONN_CLOSE) {


### PR DESCRIPTION
Pointer 'conn' which was dereferenced at api_msg.c:330 is compared to NULL value at api_msg.c:336.
If conn is NULL, ERR_ARG will be returned.