### PR TITLE
Fix i2c return value when it fails to read

### DIFF
--- a/os/arch/arm/src/s5j/s5j_i2c.c
+++ b/os/arch/arm/src/s5j/s5j_i2c.c
@@ -765,7 +765,7 @@ int s5j_i2c_transfer(struct i2c_dev_s *dev, struct i2c_msg_s *msgv, int msgc)
 			ret = readbytes(priv, pmsg);
 			if (ret < pmsg->length) {
 				if (ret >= 0) {
-					return -EIO;
+					ret = -EIO;
 				}
 				goto fail;
 			}


### PR DESCRIPTION
Assign I/O error when i2c fails to read bytes, and jump to fail laber with -EIO return value.

Signed-off-by: Jihoon Park <jh6186.park@samsung.com>