### PR TITLE
fix memory leak in things_abort()

### DIFF
--- a/framework/src/st_things/things_stack/src/common/framework/things_req_handler.c
+++ b/framework/src/st_things/things_stack/src/common/framework/things_req_handler.c
@@ -485,7 +485,6 @@ static OCEntityHandlerResult trigger_abort_request(things_resource_s *target_res
 {
 	OCEntityHandlerResult eh_result = OC_EH_ERROR;
 	static pthread_t h_thread_abort = NULL;
-//    static pthread_t h_thread_abort[4] = {NULL, };
 
 	THINGS_LOG_V(THINGS_DEBUG, TAG, "==> ABORT Easy Setup : %d", abort_es);
 
@@ -495,7 +494,6 @@ static OCEntityHandlerResult trigger_abort_request(things_resource_s *target_res
 	case ABORT_BEFORE_DATA_PROVISIONING:	// After Security Confirm
 		THINGS_LOG_V(THINGS_DEBUG, TAG, "Forwarding abort-level to st_things App.(Level: %d)", abort_es);
 		eh_result = things_abort(&h_thread_abort, abort_es);
-//        eh_result = things_abort(&h_thread_abort[abort_es], abort_es);
 		break;
 	default:
 		THINGS_LOG_D(THINGS_DEBUG, TAG, "abort_es = %d, So, Don't need any-process", abort_es);

--- a/framework/src/st_things/things_stack/src/stack/things_stack.c
+++ b/framework/src/st_things/things_stack/src/stack/things_stack.c
@@ -605,7 +605,6 @@ int things_reset(void *remote_owner, things_es_enrollee_reset_e resetType)
 			THINGS_LOG_V_ERROR(THINGS_ERROR, TAG, "Failed to create thread");
 			h_thread_things_reset = 0;
 			things_free(args);
-			args = NULL;
 			b_thread_things_reset = false;
 			res = -1;
 			goto GOTO_OUT;
@@ -1002,6 +1001,8 @@ OCEntityHandlerResult things_abort(pthread_t *h_thread_abort, things_es_enrollee
 		{
 			THINGS_LOG_V_ERROR(THINGS_ERROR, TAG, "Create thread is failed.(for abort Thread)");
 			*h_thread_abort = 0;
+			things_free(ARGs);
+			pthread_detach(h_thread_abort);
 			eh_result = OC_EH_ERROR;
 		}
 	} else {
@@ -1009,7 +1010,6 @@ OCEntityHandlerResult things_abort(pthread_t *h_thread_abort, things_es_enrollee
 		eh_result = OC_EH_NOT_ACCEPTABLE;
 	}
 
-	pthread_detach(h_thread_abort);
 	return eh_result;
 }
 


### PR DESCRIPTION
- Add things_free() of thread arguments to things_abort() to avoid memory leak
- Delete useless comments in trigger_abort_request()