### PR TITLE
Integrate iovec structure between uv-tizenrt.h and uio.h

### DIFF
--- a/external/iotjs/deps/libtuv/include/uv-tizenrt.h
+++ b/external/iotjs/deps/libtuv/include/uv-tizenrt.h
@@ -44,12 +44,7 @@
 
 #include <netdb.h>
 
-/* FIXME: This is workaround for strange TizenRT headers... */
-struct iovec
-{
-  void *iov_base;
-  size_t    iov_len;
-};
+#include <uio.h>
 
 #ifndef TUV_POLL_EVENTS_SIZE
 #define TUV_POLL_EVENTS_SIZE  32

--- a/os/include/uio.h
+++ b/os/include/uio.h
@@ -52,14 +52,11 @@
 #ifndef __OS_INCLUDE_UIO_H
 #define __OS_INCLUDE_UIO_H
 
-#ifdef CONFIG_ENABLE_IOTIVITY
 #include <sys/types.h>
 
 struct iovec {
 	void *iov_base;
 	__kernel_size_t iov_len;
 };
-
-#endif
 
 #endif							/* __OS_INCLUDE_UIO_H */


### PR DESCRIPTION
There are same structure definition, so integrated.