### PR TITLE
Fixed SVACE warnings for IotBus, Lwip and iperf_api

### DIFF
--- a/apps/system/iperf/iperf_api.c
+++ b/apps/system/iperf/iperf_api.c
@@ -1348,7 +1348,7 @@ static int get_parameters(struct iperf_test *test)
 			test->settings->bytes = j_p->valueint;
 		}
 		if ((j_p = cJSON_GetObjectItem(j, "blockcount")) != NULL) {
-			test->settings->blocks = j_p->valueint;
+			test->settings->blocks = (j_p->valueint > 0 ? j_p->valueint : 0);
 		}
 		if ((j_p = cJSON_GetObjectItem(j, "MSS")) != NULL) {
 			test->settings->mss = j_p->valueint;
@@ -3127,7 +3127,11 @@ int iprintf(struct iperf_test *test, const char *format, ...)
 		fprintf(test->outfile, "%s", linebuffer);
 
 		if (test->role == 's' && iperf_get_test_get_server_output(test)) {
-			struct iperf_textline *l = (struct iperf_textline *)malloc(sizeof(struct iperf_textline));
+			struct iperf_textline *l = NULL;
+			l = (struct iperf_textline *)malloc(sizeof(struct iperf_textline));
+			if (l == NULL) {
+				return -1;
+			}
 			l->line = strdup(linebuffer);
 			TAILQ_INSERT_TAIL(&(test->server_output_list), l, textlineentries);
 		}

--- a/framework/src/iotbus/iotbus_gpio.c
+++ b/framework/src/iotbus/iotbus_gpio.c
@@ -69,8 +69,13 @@ void gpio_async_handler(void *data)
  */
 iotbus_gpio_context_h iotbus_gpio_open(int gpiopin)
 {
-	struct _iotbus_gpio_s *dev = (struct _iotbus_gpio_s *)malloc(sizeof(struct _iotbus_gpio_s));
+	struct _iotbus_gpio_s *dev = NULL;
+	dev = (struct _iotbus_gpio_s *)malloc(sizeof(struct _iotbus_gpio_s));
 
+	if (dev == NULL) {
+		zdbg("malloc failed: %d\n", errno);
+		return NULL;
+	}
 	char gpio_dev[16] = { 0, };
 	snprintf(gpio_dev, 16, "/dev/gpio%d", gpiopin);
 

--- a/framework/src/iotbus/iotbus_i2c.c
+++ b/framework/src/iotbus/iotbus_i2c.c
@@ -51,7 +51,12 @@ iotbus_i2c_context_h iotbus_i2c_init(int bus)
 	if (fd < 0)
 		return NULL;
 
-	struct _iotbus_i2c_s *handle = (struct _iotbus_i2c_s *)malloc(sizeof(struct _iotbus_i2c_s));
+	struct _iotbus_i2c_s *handle = NULL;
+	handle = (struct _iotbus_i2c_s *)malloc(sizeof(struct _iotbus_i2c_s));
+	if (handle == NULL) {
+		close(fd);
+		return NULL;
+	}
 	handle->fd = fd;
 
 	return handle;

--- a/framework/src/iotbus/iotbus_spi.c
+++ b/framework/src/iotbus/iotbus_spi.c
@@ -73,15 +73,20 @@ iotbus_spi_context_h iotbus_spi_open(unsigned int bus, const struct iotbus_spi_c
 		return NULL;
 	}
 
-	struct spi_dev_s *dev = up_spiinitialize(bus);
-	if (!dev)
+	struct _iotbus_spi_s *handle = NULL;
+	handle = (struct _iotbus_spi_s *)malloc(sizeof(struct _iotbus_spi_s));
+	if (handle == NULL) {
 		return NULL;
-
-	struct _iotbus_spi_s *handle = (struct _iotbus_spi_s *)malloc(sizeof(struct _iotbus_spi_s));
+	}
 	handle->bpw = config->bits_per_word;
 	handle->freq = config->frequency;
 	handle->cs = config->chip_select;
 	handle->mode = config->mode;
+	struct spi_dev_s *dev = up_spiinitialize(bus);
+	if (!dev) {
+		free(handle);
+		return NULL;
+	}
 
 	handle->sdev = dev;
 

--- a/framework/src/iotbus/iotbus_uart.c
+++ b/framework/src/iotbus/iotbus_uart.c
@@ -77,6 +77,10 @@ iotbus_uart_context_h iotbus_uart_init(const char *path)
 		return handle;
 
 	handle = (struct _iotbus_uart_s *)malloc(sizeof(struct _iotbus_uart_s));
+	if (handle == NULL) {
+		close(fd);
+		return NULL;
+	}
 	handle->fd = fd;
 
 	return handle;

--- a/os/net/lwip/src/core/pbuf.c
+++ b/os/net/lwip/src/core/pbuf.c
@@ -832,6 +832,7 @@ err_t pbuf_copy(struct pbuf *p_to, struct pbuf *p_from)
 {
 	u16_t offset_to = 0, offset_from = 0, len;
 
+	LWIP_ASSERT("p_to != NULL", (p_to != NULL));
 	LWIP_DEBUGF(PBUF_DEBUG | LWIP_DBG_TRACE, ("pbuf_copy(%p, %p)\n", (void *)p_to, (void *)p_from));
 
 	/* is the target big enough to hold the source? */


### PR DESCRIPTION
1. Checked return value of malloc and exited function gracefully if malloc failed
2. used LWIP_ASSERT for null pointer check
3. check for negative values before copying to unsigned variable.
