### PR TITLE
Fix svace errors

### DIFF
--- a/framework/src/st_things/st_things_request_handler.c
+++ b/framework/src/st_things/st_things_request_handler.c
@@ -90,6 +90,7 @@ bool get_query_value_internal(const char *query, const char *key, char **value, 
 			if (NULL == *value) {
 				ST_LOG(ST_ERROR, "Failed to clone the query value.");
 				util_free(p_origin);
+				return false;
 			} else {
 				res = true;
 			}

--- a/framework/src/st_things/things_stack/src/common/cloud/cloud_connector.c
+++ b/framework/src/st_things/things_stack/src/common/cloud/cloud_connector.c
@@ -196,6 +196,8 @@ OCStackResult things_cloud_signup(const char *host, const char *device_id, const
 
 			create_time_out_process(g_req_handle, timeoutHandler, timeout);
 		}
+	} else {
+		OCRepPayloadDestroy(registerPayload);
 	}
 
 	return result;
@@ -280,6 +282,8 @@ OCStackResult things_cloud_session(const char *host, const char *uId, const char
 
 			create_time_out_process(g_req_handle, timeoutHandler, timeout);
 		}
+	} else {
+		OCRepPayloadDestroy(loginoutPayload);
 	}
 
 	if (IoTivityVer) {

--- a/framework/src/st_things/things_stack/src/common/easy-setup/easysetup_manager.c
+++ b/framework/src/st_things/things_stack/src/common/easy-setup/easysetup_manager.c
@@ -247,10 +247,14 @@ esm_result_e esm_init_easysetup(int restart_flag, things_server_builder_s *serve
 				}
 			}
 			pthread_join(gthread_id_cloud_refresh_check, NULL);
-			close(ci_token_expire_fds[0]);
-			close(ci_token_expire_fds[1]);
-			ci_token_expire_fds[0] = -1;
-			ci_token_expire_fds[1] = -1;
+			if (ci_token_expire_fds[0] != -1) {
+				close(ci_token_expire_fds[0]);
+				ci_token_expire_fds[0] = -1;
+			}
+			if (ci_token_expire_fds[1] != -1) {
+				close(ci_token_expire_fds[1]);
+				ci_token_expire_fds[1] = -1;
+			}
 #else
 			pthread_join(gthread_id_cloud_refresh_check, NULL);
 #endif
@@ -337,10 +341,14 @@ esm_result_e esm_init_easysetup(int restart_flag, things_server_builder_s *serve
 	if (gthread_id_cloud_refresh_check == 0) {
 		int ret = pipe(ci_token_expire_fds);
 		if (-1 == ret) {
-			close(ci_token_expire_fds[0]);
-			close(ci_token_expire_fds[1]);
-			ci_token_expire_fds[0] = -1;
-			ci_token_expire_fds[1] = -1;
+			if (ci_token_expire_fds[0] != -1)  {
+				close(ci_token_expire_fds[0]);
+				ci_token_expire_fds[0] = -1;
+			}
+			if (ci_token_expire_fds[1] != -1)  {
+				close(ci_token_expire_fds[1]);
+				ci_token_expire_fds[1] = -1;
+			}
 			THINGS_LOG_D_ERROR(THINGS_ERROR, TAG, "pipe failed: %s", strerror(errno));
 			return ESM_ERROR;
 		}

--- a/framework/src/st_things/things_stack/src/common/easy-setup/resource_handler.c
+++ b/framework/src/st_things/things_stack/src/common/easy-setup/resource_handler.c
@@ -1032,7 +1032,7 @@ OCRepPayload *construct_response_of_prov(OCEntityHandlerRequest *eh_request)
 		return NULL;
 	}
 	// Requested interface is Link list interface
-	if (!eh_request->query || (eh_request->query && !strncmp(eh_request->query, "", strlen(eh_request->query))) || (eh_request->query && compare_resource_interface(eh_request->query, OC_RSRVD_INTERFACE_LL)) || (eh_request->query && compare_resource_interface(eh_request->query, OC_RSRVD_INTERFACE_DEFAULT))) {
+	if (!eh_request->query || (eh_request->query && (strlen(eh_request->query) > 0)) || (eh_request->query && compare_resource_interface(eh_request->query, OC_RSRVD_INTERFACE_LL)) || (eh_request->query && compare_resource_interface(eh_request->query, OC_RSRVD_INTERFACE_DEFAULT))) {
 		if ((arrayPayload[childResCnt] = make_rep_payload(g_wifi_resource.handle, &eh_request->devAddr)) == NULL) {
 			THINGS_LOG_ERROR(THINGS_ERROR, ES_RH_TAG, "It's failed making payload of wifi_resource_s-Representation");
 			goto GOTO_FAILED;

--- a/framework/src/st_things/things_stack/src/common/framework/things_req_handler.c
+++ b/framework/src/st_things/things_stack/src/common/framework/things_req_handler.c
@@ -80,6 +80,7 @@ OCEntityHandlerResult things_abort(pthread_t *h_thread_abort, things_es_enrollee
 static int verify_request(OCEntityHandlerRequest *eh_request, const char *uri, int req_type)
 {
 	int result = 0;
+	things_resource_s *pst_temp_resource = NULL;
 
 	if (g_builder == NULL) {
 		THINGS_LOG_ERROR(THINGS_ERROR, TAG, "Server Builder is not registered..");
@@ -93,7 +94,7 @@ static int verify_request(OCEntityHandlerRequest *eh_request, const char *uri, i
 	things_resource_s *child = NULL;
 	/*! Added by st_things for memory Leak fix
 	 */
-	things_resource_s *pst_temp_resource = resource;
+	pst_temp_resource = resource;
 	if (resource == NULL) {
 		THINGS_LOG_V_ERROR(THINGS_ERROR, TAG, "Resource Not found : %s ", uri);
 		goto EXIT_VALIDATION;

--- a/framework/src/st_things/things_stack/src/common/framework/things_security_manager.c
+++ b/framework/src/st_things/things_stack/src/common/framework/things_security_manager.c
@@ -233,11 +233,13 @@ static OCStackResult seckey_setup(const char *filename, OicSecKey_t *key, OicEnc
 		if (key->data == NULL) {
 			THINGS_LOG_D(THINGS_ERROR, TAG, "Memory Full");
 			THINGS_LOG_D(THINGS_DEBUG, TAG, "OUT[FAIL]: %s", __func__);
+			fclose(fp);
 			return OC_STACK_NO_MEMORY;
 		}
 		fread(key->data, 1, size, fp);
 		key->len = size;
 		key->encoding = encoding;
+		fclose(fp);
 	}
 
 	THINGS_LOG_D(THINGS_DEBUG, TAG, "OUT: %s", __func__);

--- a/framework/src/st_things/things_stack/src/common/utils/things_string_util.c
+++ b/framework/src/st_things/things_stack/src/common/utils/things_string_util.c
@@ -74,7 +74,7 @@ void concat_string(char **target, char *attach)
 		*target = NULL;
 	}
 
-	if (MAX_BUF_LEN >= (strlen(buf) + strlen(attach))) {
+	if (MAX_BUF_LEN >= (strlen(buf) + strlen(attach) + 1)) {
 		strncat(buf, attach, MAX_BUF_LEN);
 	} else {
 		THINGS_LOG_ERROR(THINGS_ERROR, TAG, "Something went wrong");


### PR DESCRIPTION
st_things_request_handler.c
- In error statement, make the func to return false

cloud_connector.c
- 'registerPayload' & 'loginoutPayload' are released in 'OCDoResource'
- So, add 'OCRepPayloadDestroy' to release in error state.

easysetup_manager.c
- Add check statement before close file descriptor

resource_handler.c
- change 'strncmp' which is using just for empty checking to 'strlen'

things_req_handler.c
- initialize variable before using

things_security_manager.c
- Add fclose after usage of fds.

things_string_utils.c
- Add '+1' when check string length for null character.