### PR TITLE
Fix svace error.

### DIFF
--- a/framework/src/st_things/st_things_request_handler.c
+++ b/framework/src/st_things/st_things_request_handler.c
@@ -349,7 +349,7 @@ static bool get_supported_properties(const char *res_type, const char *res_uri, 
 			return false;
 		}
 		prop_count = (int *)util_calloc(type_count, sizeof(int));
-		if (NULL == props) {
+		if (NULL == prop_count) {
 			ST_LOG(ST_ERROR, "Failed to allocate memory for resource properties.");
 			util_free(props);
 			return false;

--- a/framework/src/st_things/things_stack/src/common/easy-setup/easysetup_manager.c
+++ b/framework/src/st_things/things_stack/src/common/easy-setup/easysetup_manager.c
@@ -168,7 +168,7 @@ int esm_set_device_property_by_app(char *name, const wifi_mode_e *mode, int ea_m
 
 	int i = 0;
 
-	if (mode == NULL || ea_mode < 1 || WiFi_24G > freq || freq >= WiFi_FREQ_EOF) {
+	if (mode == NULL || ea_mode < 1 || freq >= WiFi_FREQ_EOF) {
 		THINGS_LOG_V_ERROR(THINGS_ERROR, TAG, "Invalid Input Arguments.(mode=0x%X, ea_mode=%d, freq=%d)", mode, ea_mode, freq);
 		return 0;
 	}
@@ -381,10 +381,14 @@ esm_result_e esm_terminate_easysetup()
 			}
 		}
 		pthread_join(gthread_id_cloud_refresh_check, NULL);
-		close(ci_token_expire_fds[0]);
-		close(ci_token_expire_fds[1]);
-		ci_token_expire_fds[0] = -1;
-		ci_token_expire_fds[1] = -1;
+		if (ci_token_expire_fds[0] != -1) {
+			close(ci_token_expire_fds[0]);
+			ci_token_expire_fds[0] = -1;
+		}
+		if (ci_token_expire_fds[1] != -1) {
+			close(ci_token_expire_fds[1]);
+			ci_token_expire_fds[1] = -1;
+		}
 #else
 		pthread_join(gthread_id_cloud_refresh_check, NULL);
 #endif

--- a/framework/src/st_things/things_stack/src/common/framework/things_security_manager.c
+++ b/framework/src/st_things/things_stack/src/common/framework/things_security_manager.c
@@ -239,9 +239,9 @@ static OCStackResult seckey_setup(const char *filename, OicSecKey_t *key, OicEnc
 		fread(key->data, 1, size, fp);
 		key->len = size;
 		key->encoding = encoding;
-		fclose(fp);
 	}
-
+	
+	fclose(fp);
 	THINGS_LOG_D(THINGS_DEBUG, TAG, "OUT: %s", __func__);
 	return OC_STACK_OK;
 }


### PR DESCRIPTION
st_things_request_handler.c
- fix misspell in null check

easysetup_manager.c
- remove unreachable expression
- check negative value before close fd

things_security_manager.c
- move 'fclose(fp)' to general location