### PR TITLE
Fix coding rule error

### DIFF
--- a/apps/examples/testcase/le_tc/kernel/tc_libc_math.c
+++ b/apps/examples/testcase/le_tc/kernel/tc_libc_math.c
@@ -1928,7 +1928,7 @@ static void tc_libc_math_jnf(void)
 {
 	const float in_val[] = { ZERO, VAL1, -VAL1, VAL2, -VAL2, INFINITY, -INFINITY, NAN, 0x1p-10, 0x1p-20 };
 	int order[] = { -1, 0, 1, 2, 9 };
-	const float sol_val[][SIZE(order, int)] = { { -ZERO, 1.0, ZERO, ZERO, ZERO }, { -ZERO, ZERO, ZERO, -ZERO, ZERO }, { ZERO, ZERO, -ZERO, -ZERO, -ZERO }, { -ZERO, ZERO, ZERO, -ZERO, ZERO }, { ZERO, ZERO, -ZERO, -ZERO, -ZERO }, { -ZERO, ZERO, ZERO, ZERO, ZERO }, { ZERO, ZERO, -ZERO, ZERO, -ZERO },{ NAN, NAN, NAN, NAN, NAN }, { -0.0004883, 0.9999998, 0.0004883, 0.0000001, ZERO }, { -0.0000005, 1.0, 0.0000005, ZERO, ZERO } };
+	const float sol_val[][SIZE(order, int)] = { { -ZERO, 1.0, ZERO, ZERO, ZERO }, { -ZERO, ZERO, ZERO, -ZERO, ZERO }, { ZERO, ZERO, -ZERO, -ZERO, -ZERO }, { -ZERO, ZERO, ZERO, -ZERO, ZERO }, { ZERO, ZERO, -ZERO, -ZERO, -ZERO }, { -ZERO, ZERO, ZERO, ZERO, ZERO }, { ZERO, ZERO, -ZERO, ZERO, -ZERO }, { NAN, NAN, NAN, NAN, NAN }, { -0.0004883, 0.9999998, 0.0004883, 0.0000001, ZERO }, { -0.0000005, 1.0, 0.0000005, ZERO, ZERO } };
 	float ret_val[SIZE(sol_val, float)][SIZE(order, int)];
 	int jnf_idx;
 	int order_idx;

--- a/os/arch/arm/src/s5j/s5j_boot.c
+++ b/os/arch/arm/src/s5j/s5j_boot.c
@@ -110,7 +110,7 @@ static inline void up_idlestack_color(void *pv, unsigned int nbytes)
 						 "2:\n" "\tmov  r14, #0\n"	/* LR = return address (none) */
 						 "\tb    os_start\n"	/* Branch to os_start */
 						 :		/* No Output */
-						 :"r"(r0), "r"(r1)
+						 : "r"(r0), "r"(r1)
 						);
 
 	__builtin_unreachable();

--- a/os/drivers/wireless/scsc/misc/utils_misc.h
+++ b/os/drivers/wireless/scsc/misc/utils_misc.h
@@ -252,7 +252,7 @@ static inline void prefetch(__attribute__((unused))
 
 #define container_of(ptr, type, member) ({				\
 		const typeof(((type*)0)->member) *__mptr = (ptr);	\
-		(type *)((char *)__mptr - offsetof(type, member));})
+		(type *)((char *)__mptr - offsetof(type, member)); })
 
 /**
  * dlist_entry - get the struct for this entry

--- a/os/fs/smartfs/smartfs_utils.c
+++ b/os/fs/smartfs/smartfs_utils.c
@@ -3426,11 +3426,11 @@ static int smartfs_verify_transaction(struct smartfs_mountpt_s *fs, uint16_t sec
 	return OK;
 
 
-error_with_dumpret :
+error_with_dumpret:
 	for (i = 0; i < entry->datalen + sizeof(struct smartfs_logging_entry_s); i++) {
 		fdbg("offset : %d write : 0x%x read : 0x%x\n", i, j_mgr->buffer[i], buff[i]);
 	}
-error_with_ret :
+error_with_ret:
 	free(buff);
 	return ERROR;
 }


### PR DESCRIPTION
./os/fs/smartfs/smartfs_utils.c:3429: ERROR: [SPC_M_OPR] space prohibited before that ':' (ctx:WxE)
./os/fs/smartfs/smartfs_utils.c:3433: ERROR: [SPC_M_OPR] space prohibited before that ':' (ctx:WxE)
./os/arch/arm/src/s5j/s5j_boot.c:113: ERROR: [SPC_M_OPR] spaces required around that ':' (ctx:ExV)
./apps/examples/testcase/le_tc/kernel/tc_libc_math.c:1931: ERROR: [SPC_M_OPR] space required after that ',' (ctx:VxV)
./os/drivers/wireless/scsc/misc/utils_misc.h:255: ERROR: [SPC_M_OPR] space required after that ';' (ctx:VxV)