### PR TITLE
Move typedef unsigned long __kernel_size_t out of ifdef condition

### DIFF
--- a/os/include/sys/types.h
+++ b/os/include/sys/types.h
@@ -125,10 +125,11 @@
 
 #ifndef __ASSEMBLY__
 
+typedef unsigned long __kernel_size_t;
+
 #ifdef CONFIG_ENABLE_IOTIVITY
 
 typedef int wint_t;
-typedef unsigned long __kernel_size_t;
 typedef unsigned short __kernel_sa_family_t;
 typedef unsigned short __u16;
 


### PR DESCRIPTION
IoT.js uses this type, so remove iotivity ifdef condition