### PR TITLE
SVACE error fix (160314) - missing initial values on iotjs_main.c 

### DIFF
--- a/external/iotjs/src/platform/tizenrt/iotjs_main.c
+++ b/external/iotjs/src/platform/tizenrt/iotjs_main.c
@@ -132,7 +132,7 @@
    pthread_attr_t attr;
    int status;
    struct sched_param sparam;
-   pthread_t tid;
+   pthread_t tid = (pthread_t)0;
    struct iotjs_thread_arg arg;
 
    status = pthread_attr_init(&attr);


### PR DESCRIPTION
SVACE error fix (160314)

IoT.js-DCO-1.0-Signed-off-by: Haesik, Jun haesik.jun@samsung.com