### PR TITLE
Fix svace error (160318) - use of vulnerable function

### DIFF
--- a/external/iotjs/src/modules/iotjs_module_dns.c
+++ b/external/iotjs/src/modules/iotjs_module_dns.c
@@ -196,7 +196,7 @@ JHANDLER_FUNCTION(GetAddrInfo) {
   const char* hostname_data = iotjs_string_data(&hostname);
 
   if (strcmp(hostname_data, "localhost") == 0) {
-    strcpy(ip, "127.0.0.1");
+    strncpy(ip, "127.0.0.1", sizeof("127.0.0.1")+1);
   } else {
     struct sockaddr_in addr;
 


### PR DESCRIPTION
Use of vulnerable function 'strcpy' at iotjs_module_dns.c
It's changed to 'strncpy'

IoT.js-DCO-1.0-Signed-off-by: Haesik, Jun haesik.jun@samsung.com