### PR TITLE
Fix SVACE defect in IoT.js (fs.scandir)

### DIFF
--- a/external/iotjs/deps/libtuv/src/unix/fs.c
+++ b/external/iotjs/deps/libtuv/src/unix/fs.c
@@ -407,6 +407,12 @@ static ssize_t uv__fs_scandir(uv_fs_t* req) {
       cnt++;
   }
 
+  if (cnt > 0 && dents == NULL) {
+      closedir(dir);
+      cnt = -1;
+      goto error;
+  }
+
   /* Allcoate memory for the directory entries. */
   dents = (uv__dirent_t**) malloc(sizeof (uv__dirent_t*) * cnt);
 


### PR DESCRIPTION
Issue close dir on fs.scandir