### PR TITLE
Fix svace issue in st_things

### DIFF
--- a/framework/src/st_things/things_stack/src/common/cloud/cloud_manager.c
+++ b/framework/src/st_things/things_stack/src/common/cloud/cloud_manager.c
@@ -2058,7 +2058,7 @@ GOTO_OUT:
 bool es_cloud_session_stop_trigger(things_es_enrollee_state_e es_state)
 {
 	if (g_qis_cloud_thread_running != CISESS_APDISCON) {
-		if ((g_qis_cloud_thread_running == CISESS_STOP_TRIGGER || (ES_STATE_INIT <= es_state && es_state <= ES_STATE_CONNECTED_TO_ENROLLER))
+		if ((g_qis_cloud_thread_running == CISESS_STOP_TRIGGER || es_state <= ES_STATE_CONNECTED_TO_ENROLLER)
 			&& g_qis_cloud_thread_running != CISESS_SIGNOUT && es_get_cloud_login_state() == true) {
 			THINGS_LOG_D(THINGS_DEBUG, TAG, "Sign-Out Start.");
 			log_in_out_to_cloud(false, NULL);

--- a/framework/src/st_things/things_stack/src/common/framework/things_data_manager.c
+++ b/framework/src/st_things/things_stack/src/common/framework/things_data_manager.c
@@ -988,8 +988,12 @@ static int parse_things_info_json(const char *filename)
 										return 0;
 									}
 									cJSON *policy = cJSON_GetObjectItem(link, KEY_DEVICE_RESOURCE_POLICY);
-									link_resource->policy = policy->valueint;
-									node->collection[iter].links[linkiter] = link_resource;
+									if (policy) {
+										link_resource->policy = policy->valueint;
+										node->collection[iter].links[linkiter] = link_resource;
+									} else {
+										return 0;
+									}
 								}
 							} else {
 								return 0;


### PR DESCRIPTION
- cloud_manager.c
 . Expression 'ES_STATE_INIT <= es_state' is always true , which may be caused by a logical error

- things_data_manager.c
 . Return value of a function 'cJSON_GetObjectItem' is dereferenced at things_data_manager.c:991 without checking, but it is usually checked for this function (79/83).