### PR TITLE
fs/smartfs/Kconfig: make SMARTFS_SECTOR_RECOVERY dependent on MTD_SMART

### DIFF
--- a/os/fs/smartfs/Kconfig
+++ b/os/fs/smartfs/Kconfig
@@ -111,6 +111,7 @@ endif
 
 config SMARTFS_SECTOR_RECOVERY
 	bool "Enable recovery of lost sectors in Filesystem"
+	depends on MTD_SMART
 	default n
 	---help---
 		Enables recovery of lost sectors after power failure. Lost


### PR DESCRIPTION
* Implementation of sector recovery functionality requires mtd/smart.c
  routines, which compilation controlled by MTD_SMART.

Signed-off-by: Oleg Lyovin <o.lyovin@partner.samsung.com>