### PR TITLE
drivers/scsc: make scsc driver dependent on libm and workqueue support

### DIFF
--- a/os/drivers/wireless/scsc/Kconfig
+++ b/os/drivers/wireless/scsc/Kconfig
@@ -1,6 +1,7 @@
 menuconfig SCSC_WLAN
 	bool "SCSC Wireless Module support"
 	default n
+	depends on LIBM && SCHED_WORKQUEUE
 	select SPI
 
 if SCSC_WLAN


### PR DESCRIPTION
* Implementation of wireless scsc driver requires math library
  (according to "utils_misc.h") to be enabled and workqueues to be supported
  (as it uses work_s structures in the implementation).

Signed-off-by: Oleg Lyovin <o.lyovin@partner.samsung.com>