### PR TITLE
arch/arm/sss: define SSS_OVER_MTDFTL only if MTD_FTL is enabled

### DIFF
--- a/os/arch/arm/src/s5j/sss/sss_driver_io.h
+++ b/os/arch/arm/src/s5j/sss/sss_driver_io.h
@@ -19,8 +19,12 @@
 #ifndef DRIVER_IO_H_
 #define DRIVER_IO_H_
 
+#include <tinyara/config.h>
+
+#ifdef CONFIG_MTD_FTL
 #ifndef SSS_OVER_MTDFTL
 #define SSS_OVER_MTDFTL
+#endif
 #endif
 
 char *sss_get_flash_device_name(void);


### PR DESCRIPTION
* It is possible to disable MTD FTL layer support through user configs,
  so the MTD FTL interface used by SSS driver will be undefined and compilation
  error will occurs.

Signed-off-by: Oleg Lyovin <o.lyovin@partner.samsung.com>