### PR TITLE
apps/utils/Kconfig: make ENABLE_STACKMONITOR dependent on !DISABLE_SI…

### DIFF
--- a/apps/system/utils/Kconfig
+++ b/apps/system/utils/Kconfig
@@ -115,7 +115,8 @@ config ENABLE_PS
 config ENABLE_STACKMONITOR
 	bool "Stack monitor"
 	default n
-	depends on !BUILD_PROTECTED && !BUILD_KERNEL
+	depends on !BUILD_PROTECTED && !BUILD_KERNEL && !DISABLE_SIGNALS
+
 	select STACK_COLORATION
 	---help---
 		The stack monitor is a daemon that will periodically assess


### PR DESCRIPTION
…GNALS

* usleep() is not available if signals are disabled.

Signed-off-by: Oleg Lyovin <o.lyovin@partner.samsung.com>