### PR TITLE
logm/Kconfig: make LOGM dependent on !DISABLE_SIGNALS

### DIFF
--- a/os/logm/Kconfig
+++ b/os/logm/Kconfig
@@ -5,6 +5,7 @@
 
 config LOGM
 	bool "Logger Module"
+	depends on !DISABLE_SIGNALS
 	default n
 	---help---
 		Logger.


### PR DESCRIPTION
* logm_task uses usleep() call, which implementation
  relies on signals. So when they are disabled, usleep()
  routine is not compiled.

Signed-off-by: Oleg Lyovin <o.lyovin@partner.samsung.com>