### PR TITLE
drivers/scsc/Kconfig: make SCSC_WLAN dependent on WPA_SUPPLICANT and …

### DIFF
--- a/os/drivers/wireless/scsc/Kconfig
+++ b/os/drivers/wireless/scsc/Kconfig
@@ -1,6 +1,7 @@
 menuconfig SCSC_WLAN
 	bool "SCSC Wireless Module support"
 	default n
+	depends on LIBM && SCHED_WORKQUEUE && !DISABLE_PTHREAD && WPA_SUPPLICANT
 	select SPI
 
 if SCSC_WLAN


### PR DESCRIPTION
…PTHREAD

* SCSC drivers implementation uses wpa_supplicant routines, so
  need to be dependent on WPA_SUPPLICANT

* SCSC driver implementation uses pthreads API, so their support
  must be provided, otherwise we are not able to compile driver.

Signed-off-by: Oleg Lyovin <o.lyovin@partner.samsung.com>