### PR TITLE
drivers/scsc/Make.defs: add scsc/misc directory to C include path

### DIFF
--- a/os/drivers/wireless/scsc/Make.defs
+++ b/os/drivers/wireless/scsc/Make.defs
@@ -64,5 +64,6 @@ CSRCS += \
 
 DEPPATH += --dep-path wireless$(DELIM)scsc
 VPATH += :wireless$(DELIM)scsc
-CFLAGS += ${shell $(INCDIR) $(INCDIROPT) "$(CC)" $(TOPDIR)$(DELIM)drivers$(DELIM)wireless$(DELIM)scsc}
+CFLAGS += ${shell $(INCDIR) $(INCDIROPT) "$(CC)" $(TOPDIR)$(DELIM)drivers$(DELIM)wireless$(DELIM)scsc \
+			$(TOPDIR)$(DELIM)drivers$(DELIM)wireless$(DELIM)scsc$(DELIM)misc}
 endif


### PR DESCRIPTION
* There are some files in the wireless/scsc directory, that include
  utils_misc.h header, which is not in the C include path. The solution
  is to add the required path into the C include path.

Signed-off-by: Oleg Lyovin <o.lyovin@partner.samsung.com>