### PR TITLE
pwm: fix issues on range and decimal point

### DIFF
--- a/framework/src/iotbus/iotbus_pwm.c
+++ b/framework/src/iotbus/iotbus_pwm.c
@@ -39,7 +39,7 @@
  */
 #define DEFAULT_PWM_DEVICE_NUM 0
 #define IOTBUS_PWM_MAX_PERIOD 1000000 // 1s
-#define IOTBUS_PWM_MAX_RESOLUTION 65536 // b16ONE
+#define IOTBUS_PWM_MAX_RESOLUTION 65535 // (b16ONE - 1)
 
 struct _iotbus_pwm_s {
 	int fd;
@@ -117,7 +117,7 @@ int iotbus_pwm_set_duty_cycle(iotbus_pwm_context_h pwm, percent_t duty_cycle)
 		return IOTBUS_ERROR_UNKNOWN;
 	}
 
-	info->duty = (duty_cycle * IOTBUS_PWM_MAX_RESOLUTION) / 100;
+	info->duty = ((duty_cycle * IOTBUS_PWM_MAX_RESOLUTION) / 100) + 0.5;
 	ret = ioctl(fd, PWMIOC_SETCHARACTERISTICS, (unsigned long)((uintptr_t)info));
 	if (ret < 0) {
 		zdbg("ioctl(PWMIOC_SETCHARACTERISTICS) failed: %d\n", errno);

--- a/os/include/tinyara/pwm.h
+++ b/os/include/tinyara/pwm.h
@@ -162,7 +162,7 @@ struct pwm_info_s {
 
 #else
 	ub16_t duty;				/* Duty of the pulse train, "1"-to-"0" duration.
-								 * Maximum value is b16ONE. (PWM makes always high)
+								 * Maximum value is (b16ONE - 1). (PWM makes always high)
 								 * Minimum value is 0. (PWM makes always low)
 								 * pulse width (duty cycle) 50% is b16HALF. (PWM repeats half high, half low) */
 #ifdef CONFIG_PWM_PULSECOUNT


### PR DESCRIPTION
- the range of pulse width should be 0 - 65535
- The max value should be b16ONE - 1 and the half value should be b16HALF.
- The rounding conversion satisfies above 2 condtions.