### PR TITLE
Fixed errors when building for both DM utc and itc

### DIFF
--- a/apps/examples/testcase/ta_tc/device_management/itc/itc_dm_main.c
+++ b/apps/examples/testcase/ta_tc/device_management/itc/itc_dm_main.c
@@ -67,7 +67,7 @@ static int app_dhcp_main(void)
 	return 1;
 }
 
-void linkUpEvent(void)
+static void linkUpEvent(void)
 {
 	isConnected = 1;
 }

--- a/apps/examples/testcase/ta_tc/device_management/utc/utc_dm_main.c
+++ b/apps/examples/testcase/ta_tc/device_management/utc/utc_dm_main.c
@@ -72,7 +72,7 @@ static int app_dhcp_main(void)
 	return 1;
 }
 
-void linkUpEvent(void)
+static void linkUpEvent(void)
 {
 	isConnected = 1;
 }


### PR DESCRIPTION
Callback functions for linkupEvent had multiple definitions for utc and itc.
These functions were renamed.