### PR TITLE
protocol:libcoap Fix build error

### DIFF
--- a/external/libcoap/Makefile
+++ b/external/libcoap/Makefile
@@ -73,7 +73,7 @@ CSRCS += subscribe.c
 CSRCS += uri.c
 
 AOBJS = $(ASRCS:.S=$(OBJEXT))
-COBJS = $(CSRCS:.c=$(OBJEXT))
+COBJS = $(patsubst %.c, libcoap_%$(OBJEXT), $(CSRCS))
 
 SRCS = $(ASRCS) $(CSRCS)
 OBJS = $(AOBJS) $(COBJS)
@@ -100,7 +100,7 @@ all: .built
 $(AOBJS): %$(OBJEXT): %.S
 	$(call ASSEMBLE, $<, $@)
 
-$(COBJS): %$(OBJEXT): %.c
+$(COBJS): libcoap_%$(OBJEXT): %.c
 	$(call COMPILE, $<, $@)
 
 .built: $(OBJS)


### PR DESCRIPTION
mbedtls and libcoap cause a conflict because there are object files which are same name
To fix it I added prefix at object files