### PR TITLE
fstat & fstatfs for ROMFS and SMARTFS backported from nuttx

### DIFF
--- a/os/fs/inode/inode.h
+++ b/os/fs/inode/inode.h
@@ -187,6 +187,30 @@ void inode_semgive(void);
 FAR struct inode *inode_search(FAR const char **path, FAR struct inode **peer, FAR struct inode **parent, FAR const char **relpath);
 
 /****************************************************************************
+ * Name: inode_stat
+ *
+ * Description:
+ *   The inode_stat() function will obtain information about an 'inode' in
+ *   the pseudo file system and will write it to the area pointed to by 'buf'.
+ *
+ *   The 'buf' argument is a pointer to a stat structure, as defined in
+ *   <sys/stat.h>, into which information is placed concerning the file.
+ *
+ * Input Parameters:
+ *   inode - The inode of interest
+ *   buf   - The caller provide location in which to return information about
+ *           the inode.
+ *
+ * Returned Value:
+ *   Zero (OK) returned on success.  Otherwise, a negated errno value is
+ *   returned to indicate the nature of the failure.
+ *
+ ****************************************************************************/
+
+struct stat;  /* Forward reference */
+int inode_stat(FAR struct inode *inode, FAR struct stat *buf);
+
+/****************************************************************************
  * Name: inode_free
  *
  * Description:

--- a/os/fs/procfs/fs_procfs.c
+++ b/os/fs/procfs/fs_procfs.c
@@ -209,6 +209,7 @@ const struct mountpt_operations procfs_operations = {
 
 	NULL,						/* sync */
 	procfs_dup,					/* dup */
+	NULL,						/* fstat */
 
 	procfs_opendir,				/* opendir */
 	procfs_closedir,			/* closedir */

--- a/os/fs/romfs/fs_romfs.h
+++ b/os/fs/romfs/fs_romfs.h
@@ -180,6 +180,7 @@ struct romfs_file_s {
 	uint32_t rf_size;			/* Size of the file in bytes */
 	uint32_t rf_cachesector;	/* Current sector in the rf_buffer */
 	uint8_t *rf_buffer;			/* File sector buffer, allocated if rm_xipbase==0 */
+	uint8_t rf_type;            /* File type (for fstat()) */
 };
 
 /* This structure is used internally for describing the result of

--- a/os/fs/vfs/Make.defs
+++ b/os/fs/vfs/Make.defs
@@ -78,9 +78,9 @@ else
 # Common file/socket descriptor support
 
 CSRCS += fs_close.c fs_dup.c fs_dup2.c fs_fcntl.c fs_dupfd.c fs_dupfd2.c
-CSRCS += fs_getfilep.c fs_ioctl.c fs_lseek.c fs_mkdir.c fs_open.c fs_poll.c 
-CSRCS += fs_read.c fs_rename.c fs_rmdir.c fs_stat.c fs_statfs.c fs_select.c
-CSRCS += fs_unlink.c fs_write.c
+CSRCS += fs_fstat.c fs_fstatfs.c fs_getfilep.c fs_ioctl.c fs_lseek.c
+CSRCS += fs_mkdir.c fs_open.c fs_poll.c fs_read.c fs_rename.c fs_rmdir.c
+CSRCS += fs_stat.c fs_statfs.c fs_select.c fs_unlink.c fs_write.c
 
 # Certain interfaces are not available if there is no mountpoint support
 

--- a/os/fs/vfs/fs_fstat.c
+++ b/os/fs/vfs/fs_fstat.c
@@ -1,0 +1,144 @@
+/****************************************************************************
+ *
+ * Copyright 2017 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+/****************************************************************************
+ * fs/vfs/fs_fstat.c
+ *
+ *   Copyright (C) 2017 Gregory Nutt. All rights reserved.
+ *   Author: Gregory Nutt <gnutt@nuttx.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <tinyara/config.h>
+
+#include <unistd.h>
+#include <sched.h>
+#include <errno.h>
+
+#include <tinyara/fs/fs.h>
+#include "inode/inode.h"
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: fstat
+ *
+ * Description:
+ *   The fstat() function will obtain information about an open file
+ *   associated with the file descriptor 'fd', and will write it to the area
+ *   pointed to by 'buf'.
+ *
+ *   The 'buf' argument is a pointer to a stat structure, as defined in
+ *   <sys/stat.h>, into which information is placed concerning the file.
+ *
+ * Input Parameters:
+ *   fd  - The file descriptor associated with the open file of interest
+ *   buf - The caller provide location in which to return information about
+ *         the open file.
+ *
+ * Returned Value:
+ *   Upon successful completion, 0 shall be returned. Otherwise, -1 shall be
+ *   returned and errno set to indicate the error.
+ *
+ ****************************************************************************/
+
+int fstat(int fd, FAR struct stat *buf)
+{
+	FAR struct file *filep;
+	FAR struct inode *inode;
+	int ret;
+
+	/* Did we get a valid file descriptor? */
+	if ((unsigned int)fd >= CONFIG_NFILE_DESCRIPTORS) {
+		/* No networking... it is a bad descriptor in any event */
+		set_errno(EBADF);
+		return ERROR;
+	}
+
+	/* The descriptor is in a valid range to file descriptor... do the
+	 * read.	First, get the file structure.	Note that on failure,
+	 * fs_getfilep() will set the errno variable. */
+	filep = fs_getfilep(fd);
+	if (filep == NULL) {
+		/* The errno value has already been set */
+		return ERROR;
+	}
+
+	/* Get the inode from the file structure */
+	inode = filep->f_inode;
+	DEBUGASSERT(inode != NULL);
+
+	/* The way we handle the stat depends on the type of inode that we
+	 * are dealing with. */
+#ifndef CONFIG_DISABLE_MOUNTPOINT
+	if (INODE_IS_MOUNTPT(inode)) {
+		/* The inode is a file system mointpoint. Verify that the mountpoint
+		 * supports the fstat() method */
+		ret = -ENOSYS;
+		if (inode->u.i_mops && inode->u.i_mops->fstat) {
+			/* Perform the fstat() operation */
+			ret = inode->u.i_mops->fstat(filep, buf);
+		}
+	} else
+#endif
+	{
+		/* The inode is part of the root pseudo file system. */
+		ret = inode_stat(inode, buf);
+	}
+
+	/* Check if the fstat operation was successful */
+	if (ret < 0) {
+		set_errno(-ret);
+		return ERROR;
+	}
+
+	/* Successfully fstat'ed the file */
+	return OK;
+}

--- a/os/fs/vfs/fs_fstatfs.c
+++ b/os/fs/vfs/fs_fstatfs.c
@@ -1,0 +1,142 @@
+/****************************************************************************
+ *
+ * Copyright 2017 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+/****************************************************************************
+ * fs/vfs/fs_fstatfs.c
+ *
+ *   Copyright (C) 2017 Gregory Nutt. All rights reserved.
+ *   Author: Gregory Nutt <gnutt@nuttx.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <tinyara/config.h>
+
+#include <sys/statfs.h>
+#include <string.h>
+#include <limits.h>
+#include <sched.h>
+#include <errno.h>
+
+#include "inode/inode.h"
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: fstatfs
+ *
+ * Return: Zero on success; -1 on failure with errno set:
+ *
+ *   EACCES  Search permission is denied for one of the directories in the
+ *           path prefix of path.
+ *   EFAULT  Bad address.
+ *   ENOENT  A component of the path path does not exist, or the path is an
+ *           empty string.
+ *   ENOMEM  Out of memory
+ *   ENOTDIR A component of the path is not a directory.
+ *   ENOSYS  The file system does not support this call.
+ *
+ ****************************************************************************/
+
+int fstatfs(int fd, FAR struct statfs *buf)
+{
+	FAR struct file *filep;
+	FAR struct inode *inode;
+	int ret;
+
+	DEBUGASSERT(buf != NULL);
+
+	/* First, get the file structure.
+     * Note that on failure, fs_getfilep() will set the errno variable.
+	 */
+	filep = fs_getfilep(fd);
+	if (filep == NULL) {
+		/* The errno value has already been set */
+		return ERROR;
+	}
+
+	/* Get the inode from the file structure */
+	inode = filep->f_inode;
+	DEBUGASSERT(inode != NULL);
+
+	/* Check if the file is open */
+	if (inode == NULL) {
+		/* The descriptor does not refer to an open file. */
+		ret = -EBADF;
+	} else
+#ifndef CONFIG_DISABLE_MOUNTPOINT
+	/* The way we handle the stat depends on the type of inode that we
+	 * are dealing with. */
+	if (INODE_IS_MOUNTPT(inode)) {
+		/* The node is a file system mointpoint. Verify that the mountpoint
+		 * supports the statfs() method */
+		ret = -ENOSYS;
+		if (inode->u.i_mops && inode->u.i_mops->statfs) {
+			/* Perform the statfs() operation */
+			ret = inode->u.i_mops->statfs(inode, buf);
+		}
+	} else
+#endif
+	{
+		/* The node is part of the root pseudo file system */
+		memset(buf, 0, sizeof(struct statfs));
+		buf->f_type = PROC_SUPER_MAGIC;
+		buf->f_namelen = NAME_MAX;
+		ret = OK;
+	}
+
+	/* Check if the fstat operation was successful */
+	if (ret < 0) {
+		set_errno(-ret);
+		return ERROR;
+	}
+
+	/* Successfully statfs'ed the file */
+	return OK;
+}

--- a/os/include/tinyara/fs/fs.h
+++ b/os/include/tinyara/fs/fs.h
@@ -189,6 +189,7 @@ struct mountpt_operations {
 
 	int (*sync)(FAR struct file *filep);
 	int (*dup)(FAR const struct file *oldp, FAR struct file *newp);
+	int (*fstat)(FAR const struct file *filep, FAR struct stat *buf);
 
 	/* Directory operations */
 


### PR DESCRIPTION
Somewhat tested on Artik053.

Note: only romfs and smartfs filesystems are covered.