### PR TITLE
use kernel_thread for kernel thread and refactor s5jt200 led

### DIFF
--- a/os/arch/arm/src/sidk_s5jt200/src/s5jt200_led.c
+++ b/os/arch/arm/src/sidk_s5jt200/src/s5jt200_led.c
@@ -60,6 +60,7 @@
 #include <errno.h>
 #include <sys/types.h>
 #include <tinyara/pwm.h>
+#include <tinyara/kthread.h>
 
 #include <tinyara/board.h>
 #include <arch/board/board.h>
@@ -174,7 +175,7 @@ int s5j_ledinitialize(void)
 	/* RGB LED controlled by S8300 LED DRIVER ID with PWM */
 	s5jt200_rgbled_setup();
 
-	g_rgbled_tid = task_create("s5jt200 rgbstate", 100, 1024,
+	g_rgbled_tid = kernel_thread("s5jt200 rgbstate", 100, 1024,
 					s5jt200_rgbled_state_task, NULL);
 	lldbg("Create rgbled task..\n");
 

--- a/os/arch/arm/src/sidk_s5jt200/src/s5jt200_led.c
+++ b/os/arch/arm/src/sidk_s5jt200/src/s5jt200_led.c
@@ -65,7 +65,6 @@
 #include <tinyara/board.h>
 #include <arch/board/board.h>
 
-pid_t g_rgbled_tid;
 FAR struct pwm_lowerhalf_s    *ledr;
 FAR struct pwm_lowerhalf_s    *ledg;
 FAR struct pwm_lowerhalf_s    *ledb;
@@ -172,14 +171,16 @@ int s5jt200_rgbled_setup(void)
 
 int s5j_ledinitialize(void)
 {
+	pid_t rgbled_tid;
+
 	/* RGB LED controlled by S8300 LED DRIVER ID with PWM */
 	s5jt200_rgbled_setup();
 
-	g_rgbled_tid = kernel_thread("s5jt200 rgbstate", 100, 1024,
+	lldbg("Creating rgbled task..\n");
+	rgbled_tid = kernel_thread("s5jt200 rgbstate", 100, 1024,
 					s5jt200_rgbled_state_task, NULL);
-	lldbg("Create rgbled task..\n");
 
-	if (!g_rgbled_tid) {
+	if (!rgbled_tid) {
 		lldbg("Failed to run rgbled task..\n");
 		return -ESRCH;
 	}

--- a/os/logm/logm_start.c
+++ b/os/logm/logm_start.c
@@ -15,14 +15,14 @@
  * language governing permissions and limitations under the License.
  *
  ****************************************************************************/
-#include <sched.h>
+#include <tinyara/kthread.h>
 #include "logm.h"
 
 void logm_start(void)
 {
 	int pid;
 
-	pid = task_create("logm", LOGM_TASK_PRORITY, LOGM_TASK_STACKSIZE, logm_task, NULL);
+	pid = kernel_thread("logm", LOGM_TASK_PRORITY, LOGM_TASK_STACKSIZE, logm_task, NULL);
 
 	if (pid < 0) {
 		return;

--- a/os/net/lwip/sys/arch/sys_arch.c
+++ b/os/net/lwip/sys/arch/sys_arch.c
@@ -654,7 +654,7 @@ sys_thread_t sys_thread_new(const char *name, lwip_thread_fn entry_function, voi
 
 	if (s_nextthread < SYS_THREAD_MAX) {
 		sys_thread_t new_thread;
-		new_thread = task_create(name, priority, stacksize, (main_t)entry_function, (char * const *)NULL);
+		new_thread = kernel_thread(name, priority, stacksize, (main_t)entry_function, (char * const *)NULL);
 		if (new_thread < 0) {
 			int errval = errno;
 			LWIP_DEBUGF(SYS_DEBUG, ("Failed to create new_thread: %d", errval));


### PR DESCRIPTION
1. use kernel_thread instead of task_create in kernel side, logm, arch and net
2. refactoring of s5jt200 led