### PR TITLE
Fix the WiFi linkdown hang up issue

### DIFF
--- a/framework/include/wifi_manager/wifi_manager.h
+++ b/framework/include/wifi_manager/wifi_manager.h
@@ -98,6 +98,8 @@ typedef struct {
 	int rssi;
 	connect_status_e status;
 	wifi_manager_mode_e mode;
+	wifi_manager_mode_e pre_mode;
+	wifi_manager_mode_e next_mode;
 } wifi_manager_info_s;
 
 typedef struct {


### PR DESCRIPTION
- Hung up during linkdown because the linkdown handler did not consider WIFI_MODE_CHANGING state.
- Add wifi manager modes for linkup&down handlers to know previous and next modes.
- Edit functions of wifi init, deinit and set mode which trigger linkup&down handlers.
- Re-fix for the previous quick fix(commit 111d0b10430601ea4653b2be3530b94dc9848ffd)