### PR TITLE
iotbus/uart: add missing break

### DIFF
--- a/framework/src/iotbus/iotbus_uart.c
+++ b/framework/src/iotbus/iotbus_uart.c
@@ -194,6 +194,7 @@ int iotbus_uart_set_mode(iotbus_uart_context_h hnd, int bytesize, iotbus_uart_pa
 		break;
 	case 2:
 		tio.c_cflag |= CSTOPB;
+		break;
 	default:
 		return IOTBUS_ERROR_INVALID_PARAMETER;
 	}


### PR DESCRIPTION
A break statement was missing inside switch case. no break statement,
hence stopbits 2 always failed.

Change-Id: Ib2b53ef73e752821f1b077700606fcb45d403597
Signed-off-by: Junhwan Park <junhwan.park@samsung.com>