### PR TITLE
s5j/adc: change interrupt debug level

### DIFF
--- a/os/arch/arm/src/s5j/s5j_adc.c
+++ b/os/arch/arm/src/s5j/s5j_adc.c
@@ -336,7 +336,7 @@ static int adc_setup(FAR struct adc_dev_s *dev)
 	 * Enable the ADC interrupt, but it will not be generated until we
 	 * request to start the conversion.
 	 */
-	lldbg("Enable the ADC interrupt: irq=%d\n", IRQ_ADC);
+	llwdbg("Enable the ADC interrupt: irq=%d\n", IRQ_ADC);
 	up_enable_irq(IRQ_ADC);
 
 	return OK;


### PR DESCRIPTION
An unnecessary warning log was output. The debug level was modified to
prevent output by default.

Change-Id: If5a70358171450338699997de5a2b070c92566d5
Signed-off-by: Junhwan Park <junhwan.park@samsung.com>