### PR TITLE
s5j/clk: modify SPI clk rate

### DIFF
--- a/os/arch/arm/src/s5j/s5j_clock.c
+++ b/os/arch/arm/src/s5j/s5j_clock.c
@@ -226,6 +226,12 @@ void s5j_clk_set_rate(unsigned int id, unsigned long rate)
 	case CLK_SPL_SPI1:
 	case CLK_SPL_SPI2:
 	case CLK_SPL_SPI3:
+		/* Exynos T200 provides an SPI with various kinds of clock sources.
+		 * SPI uses the SCLK_SPI clock from an external Clock Controller Module (CMU).
+		 * You can also select an SCLK_SPI from various clock sources.
+		 * An SPI contains an internal 1/2 clock divider.
+		 * Configure the SCLK_SPI value to the double of an SPI operating clock frequency.
+		 */
 		clk_spi_set_rate(id, rate * 2);
 		break;
 

--- a/os/arch/arm/src/s5j/s5j_clock.c
+++ b/os/arch/arm/src/s5j/s5j_clock.c
@@ -226,7 +226,7 @@ void s5j_clk_set_rate(unsigned int id, unsigned long rate)
 	case CLK_SPL_SPI1:
 	case CLK_SPL_SPI2:
 	case CLK_SPL_SPI3:
-		/* Exynos T200 provides an SPI with various kinds of clock sources.
+		/* S5J provides an SPI with various kinds of clock sources.
 		 * SPI uses the SCLK_SPI clock from an external Clock Controller Module (CMU).
 		 * You can also select an SCLK_SPI from various clock sources.
 		 * An SPI contains an internal 1/2 clock divider.

--- a/os/arch/arm/src/s5j/s5j_clock.c
+++ b/os/arch/arm/src/s5j/s5j_clock.c
@@ -226,7 +226,7 @@ void s5j_clk_set_rate(unsigned int id, unsigned long rate)
 	case CLK_SPL_SPI1:
 	case CLK_SPL_SPI2:
 	case CLK_SPL_SPI3:
-		clk_spi_set_rate(id, rate);
+		clk_spi_set_rate(id, rate * 2);
 		break;
 
 	default:


### PR DESCRIPTION
An SPI contains an internal 1/2 clock divider. Configure the SCLK_SPI
value to the double of an SPI operating clock frequency.

Change-Id: I8efd88dec2166ae5241f13a08d2c18438d26bb9b
Signed-off-by: Junhwan Park <junhwan.park@samsung.com>