### PR TITLE
build: add starter kit pinout figure

### DIFF
--- a/build/configs/artik053/README.md
+++ b/build/configs/artik053/README.md
@@ -17,7 +17,7 @@ Aimed especially at power-sensitive devices needing Wi-Fi®, the ARTIK 053 Modul
 
 Here is a [memory map](scripts/README.md).
 
-## ARTIK053 Starter Kit PinOut
+### ARTIK053 Starter Kit PinOut
 #### CON710 CON711 CON708 CON709
 ```
                  XGPIO13(gpio42) <- SW702 | SW703 -> XGPIO15(gpio44)

--- a/build/configs/artik053/README.md
+++ b/build/configs/artik053/README.md
@@ -17,6 +17,70 @@ Aimed especially at power-sensitive devices needing Wi-Fi®, the ARTIK 053 Modul
 
 Here is a [memory map](scripts/README.md).
 
+## ARTIK053 Starter Kit PinOut
+#### CON710 CON711 CON708 CON709
+```
+                 XGPIO13(gpio42) <- SW702 | SW703 -> XGPIO15(gpio44)
+                XGPIO16(gpio45) <- LED703 | LED702 -> XGPIO20(gpio49)
+                                             [CON708]
+                           |           |     * -> XI2C0_SCL
+                           |           |     * -> XI2C0_SDA
+                           |           |     * -> AREF
+              [CON710]     |           |     * -> GND
+               NC <- *     |           |    13 -> XSPI1_CLK
+               NC <- *     |           |    12 -> XSPI1_MISO
+            RESET <- *     |           |    11 -> XSPI1_MOSI
+             3.3V <- *     | ARTIK053  |    10 -> XSPI1_CSN
+               NC <- *     |           |     9 -> XPWMTOUT_4
+              GND <- *     |           |     8 -> XGPIO21(gpio50)
+              GND <- *     |           |     [CON709]
+              Vin <- *     |           |     7 -> XGPIO19(gpio48)
+              [CON711]     |           |     6 -> XPWMTOUT_2
+            XADC0 <- A0    +-----------+     5 -> XPWMTOUT_1
+            XADC1 <- A1                      4 -> XGPIO18(gpio47)
+            XADC2 <- A2                      3 -> XPWMTOUT_0
+            XADC3 <- A3                      2 -> XGPIO17(gpio46)
+            XADC4 <- A4                      1 -> XUART0_TX
+            XADC5 <- A5                      0 -> XUART0_RX
+
+                   [CON703]
+                   2 4 6 8 10 12 14 16 18 20 22 24
+                   1 3 5 7  9 11 13 15 17 19 21 23
+                   [CON704]
+                   2 4 6 8 10 12 14 16 18 20 22 24
+                   1 3 5 7  9 11 13 15 17 19 21 23
+```
+#### CON703
+```
+                 XPWMTOUT_1 <-  1 |  2 -> VCC_EXT3P3
+                 XPWMTOUT_2 <-  3 |  4 -> XADC6
+                 XPWMTOUT_3 <-  5 |  6 -> XADC7
+                 XPWMTOUT_0 <-  7 |  8 -> XI2C1_SCL
+                 XUART1_RXD <-  9 | 10 -> XI2C1_SDA
+                 XUART1_TXD <- 11 | 12 -> GND
+            XGPIO26(gpio55) <- 13 | 14 -> VCC_EXT3P3
+            XGPIO25(gpio54) <- 15 | 16 -> XSPI0_CLK
+            XGPIO24(gpio53) <- 17 | 18 -> XSPI0_CSN
+            XGPIO23(gpio52) <- 19 | 20 -> XSPI0_MISO
+            XGPIO22(gpio51) <- 21 | 22 -> XSPI0_MOSI
+             XEINT0(gpio57) <- 23 | 24 -> GND
+```
+#### CON704
+```
+                 XPWMTOUT_4 <-  1 |  2 -> VCC_EXT3P3
+                 XPWMTOUT_5 <-  3 |  4 -> XUART2_RXD
+             XEINT2(gpio59) <-  5 |  6 -> XUART2_TXD
+             XEINT1(gpio58) <-  7 |  8 -> XUART3_RXD
+            XGPIO12(gpio41) <-  9 | 10 -> XUART3_TXD
+            XGPIO10(gpio39) <- 11 | 12 -> GND
+             XGPIO9(gpio38) <- 13 | 14 -> VCC_EXT3P3
+            XGPIO11(gpio40) <- 15 | 16 -> XGPIO4(gpio33)/XSPI2_CLK
+             XGPIO8(gpio37) <- 17 | 18 -> XGPIO5(gpio34)/XSPI2_CSN
+             XGPIO2(gpio31) <- 19 | 20 -> XGPIO6(gpio35)/XSPI2_MISO
+             XGPIO1(gpio30) <- 21 | 22 -> XGPIO7(gpio36)/XSPI2_MOSI
+             XGPIO3(gpio32) <- 23 | 24 -> GND
+```
+
 ## Environment Set-up
 ### On Chip Debugger installation
 


### PR DESCRIPTION
If you have an ARTIK 0 Starter Kit board, you can refer to PinOut with
this document.

Change-Id: Iaee1b9ebfab25c8def33e215285847d2716bfa62
Signed-off-by: Junhwan Park <junhwan.park@samsung.com>