### PR TITLE
Memory corruption security issue fixed for FTP client

### DIFF
--- a/external/ftpc/ftpc_utils.c
+++ b/external/ftpc/ftpc_utils.c
@@ -173,7 +173,7 @@ void ftpc_stripcrlf(FAR char *str)
 		len = strlen(str);
 		if (len > 0) {
 			ptr = str + len - 1;
-			while (*ptr == '\r' || *ptr == '\n') {
+			while ((ptr >= str) && (*ptr == '\r' || *ptr == '\n')) {
 				*ptr = '\0';
 				ptr--;
 			}


### PR DESCRIPTION
Function ftpc_stripcrlf removes newline characters from string can go before data buffer if the buffer is completely filled with newline characters(\r or \n).
This can lead to memory corruption but is not easily exploitable, so the risk is reduced.