### PR TITLE
Fixed stack based memory disclosure in FTP client

### DIFF
--- a/external/ftpc/ftpc_transfer.c
+++ b/external/ftpc/ftpc_transfer.c
@@ -143,7 +143,7 @@ static int ftp_pasvmode(struct ftpc_session_s *session, uint8_t addrport[6])
 	/* Skip over any leading stuff before address begins */
 
 	ptr = session->reply + 4;
-	while (!isdigit((int)*ptr)) {
+	while (*ptr && !isdigit((int)*ptr)) {
 		ptr++;
 	}
 


### PR DESCRIPTION
Function ftp_pasvmode that parses FTP server response to PASV command goes outside data buffer - ptr is increased and checked only using !isdigit function.
This can lead to memory disclosure / corruption but is not easily exploitable, so the risk is reduced. In FTP client code input from server is written correctly to staticaly allocated buffer and only reading after end of buffer is possible.