### PR TITLE
Fix buffer overflow in FTP client

### DIFF
--- a/external/ftpc/ftpc_utils.c
+++ b/external/ftpc/ftpc_utils.c
@@ -173,7 +173,7 @@ void ftpc_stripcrlf(FAR char *str)
 		len = strlen(str);
 		if (len > 0) {
 			ptr = str + len - 1;
-			while (*ptr == '\r' || *ptr == '\n') {
+			while ((ptr >= str) && (*ptr == '\r' || *ptr == '\n')) {
 				*ptr = '\0';
 				ptr--;
 			}
@@ -237,6 +237,9 @@ FAR char *ftpc_dequote(FAR const char *str)
 				if (str[0] == '%') {
 					/* Extract the hex value */
 
+					if (!str[1] || !str[2]) {
+						break;
+					}
 					ms = ftpc_nibble(str[1]);
 					if (ms >= 0) {
 						ls = ftpc_nibble(str[2]);


### PR DESCRIPTION
Function ftpc_dequote that converts quoted hexadecimal constants to binary values goes outside input data buffer -str pointer is checked, while str[1] and str[2] are read.
while parsing the server response end of string should be checked