### PR TITLE
arastorage : Add ommited condition for removing inexistent relation as success

### DIFF
--- a/framework/src/arastorage/aql_exec.c
+++ b/framework/src/arastorage/aql_exec.c
@@ -170,7 +170,7 @@ db_result_t db_exec(char *format)
 	optype = AQL_GET_EXEC_TYPE(AQL_GET_TYPE(&adt));
 	if (optype != AQL_TYPE_CREATE_RELATION) {
 		rel = aql_get_relation(&adt);
-		if (rel == NULL) {
+		if (rel == NULL && optype != AQL_TYPE_REMOVE_RELATION) {
 			DB_LOG_E("DB : get relation Failed\n");
 			return DB_RELATIONAL_ERROR;
 		}


### PR DESCRIPTION
arastorage regards a request which tries to remove inexistent relation as success in relation_remove.
but when doing it by query, it is considered as error.
because aql_get_relation returns NULL and db_exec return ERROR finally.
So we need to exclude a case that optype is a type for remove relation.