### PR TITLE
Wi-Fi Manager: add a checkpoint, to check if Wi-Fi Manager is initial…

### DIFF
--- a/framework/src/wifi_manager/wifi_manager.c
+++ b/framework/src/wifi_manager/wifi_manager.c
@@ -57,6 +57,22 @@ static wifi_manager_cb_s *g_manager_callback = NULL;
 static wifi_mutex *w_mutex = NULL;
 static wifi_mutex *w_info_mutex = NULL;
 
+#define CHECK_WITHOUT_RETURN(msg)			\
+do {										\
+	if (w_info_mutex == NULL || w_mutex == NULL) {	\
+		ndbg("%s: Wi-Fi Manager is not initialized.\n", msg);	\
+		return;	\
+	}	\
+} while (0)
+
+#define CHECK_WITH_RETURN(msg)			\
+	do {										\
+		if (w_info_mutex == NULL || w_mutex == NULL) {	\
+			ndbg("%s: Wi-Fi Manager is not initialized.\n", msg);	\
+			return WIFI_MANAGER_DEINITIALIZED;	\
+		}	\
+	} while (0)
+
 static wifi_utils_result_e start_dhcp_client(void)
 {
 	struct dhcpc_state state;
@@ -147,6 +163,8 @@ static void wifi_status_set(connect_status_e status)
 
 static void wifi_linkup_event_func(void)
 {
+	CHECK_WITHOUT_RETURN("linkup");
+
 	wifi_manager_cb_s *wifi_cb = g_manager_callback;
 	wifi_utils_info info;
 
@@ -208,9 +226,11 @@ static void wifi_linkdown_event_func(void)
 {
 // here, send a message to callback handler and rest of this function should be done by the callback handler.
 // wifi_manager_init() creates the callback handler and deinit() joins the callback handler.
-	wifi_manager_cb_s *wifi_cb = g_manager_callback;
-	wifi_mutex_acquire(w_info_mutex, WIFI_UTILS_FOREVER);
+	CHECK_WITHOUT_RETURN("linkdown");
 
+	wifi_manager_cb_s *wifi_cb = g_manager_callback;
+
+	wifi_mutex_acquire(w_info_mutex, WIFI_UTILS_FOREVER);
 	if (g_manager_info.mode == STA_MODE || (g_manager_info.mode == WIFI_MODE_CHANGING && g_manager_info.pre_mode == STA_MODE) || \
 			(g_manager_info.mode == WIFI_DEINITIALIZING && g_manager_info.pre_mode == STA_MODE)) {
 		nvdbg("WIFI DISCONNECTED AP - STA MODE");
@@ -310,8 +330,11 @@ static wifi_manager_result_e wifi_fetch_scan_results(slsi_scan_info_t **wifi_sca
 
 static wifi_manager_result_e wifi_scan_result_callback(slsi_reason_t *reason)
 {
+	CHECK_WITH_RETURN("scan_result_callback");
+
 	wifi_manager_scan_info_s *wifi_manager_scan_info = 0;
 	wifi_manager_cb_s *wifi_cb = g_manager_callback;
+
 	if (reason->reason_code == 0) {
 		slsi_scan_info_t *wifi_scan_result;
 		WiFiGetScanResults(&wifi_scan_result);
@@ -334,6 +357,8 @@ static wifi_manager_result_e wifi_scan_result_callback(slsi_reason_t *reason)
 
 wifi_manager_result_e wifi_manager_connect_ap(wifi_manager_ap_config_s *config)
 {
+	CHECK_WITH_RETURN("connect_ap");
+
 	if (config == NULL) {
 		return WIFI_MANAGER_INVALID_ARGS;
 	}
@@ -384,6 +409,8 @@ wifi_manager_result_e wifi_manager_connect_ap(wifi_manager_ap_config_s *config)
 
 wifi_manager_result_e wifi_manager_disconnect_ap(void)
 {
+	CHECK_WITH_RETURN("disconnect_ap");
+
 	wifi_utils_result_e result = WIFI_UTILS_SUCCESS;
 
 	wifi_mutex_acquire(w_mutex, WIFI_UTILS_FOREVER);
@@ -520,13 +547,10 @@ error_without_mutex_release:
 
 wifi_manager_result_e wifi_manager_deinit()
 {
+	CHECK_WITH_RETURN("deinit");
+
 	wifi_utils_result_e result = WIFI_UTILS_SUCCESS;
 	wifi_manager_result_e ret = WIFI_MANAGER_SUCCESS;
-
-	if ((g_manager_info.mode == WIFI_NONE) || (w_mutex == NULL)) {
-		ndbg("WI-FI is already deinitialized.\n");
-		return WIFI_MANAGER_DEINITIALIZED;
-	}
 
 	wifi_mutex_acquire(w_info_mutex, WIFI_UTILS_FOREVER);
 	/* wifi_manager mode is switched to wifi_deinitializing */
@@ -589,6 +613,8 @@ wifi_manager_result_e wifi_manager_deinit()
 
 wifi_manager_result_e wifi_manager_set_mode(wifi_manager_mode_e mode, wifi_manager_softap_config_s *config)
 {
+	CHECK_WITH_RETURN("set_mode");
+
 	wifi_utils_result_e result = WIFI_UTILS_SUCCESS;
 
 	if (mode != STA_MODE && mode != SOFTAP_MODE) {
@@ -697,6 +723,8 @@ error_with_failure:
 
 wifi_manager_result_e wifi_manager_get_info(wifi_manager_info_s *info)
 {
+	CHECK_WITH_RETURN("get_info");
+
 	if (info == NULL) {
 		ndbg("info is null.");
 		return WIFI_MANAGER_FAIL;
@@ -711,6 +739,8 @@ wifi_manager_result_e wifi_manager_get_info(wifi_manager_info_s *info)
 
 wifi_manager_result_e wifi_manager_scan_ap(void)
 {
+	CHECK_WITH_RETURN("scan_ap");
+
 	wifi_manager_result_e ret = WIFI_MANAGER_FAIL;
 
 	if (g_manager_callback->scan_ap_done == NULL) {


### PR DESCRIPTION
…ized, in APIs and callback handlers

To make Wi-Fi Manager thread-safe, it is necessary to check if Wi-Fi Manager is initialized.
For simplicity, we just do null-comparison of w_mutex and w_info_mutex at the very beginning of each API and each callback handler.