### PR TITLE
net:netlib fix vulerability while parsing malicious URLs

### DIFF
--- a/external/netutils/netlib_parsehttpurl.c
+++ b/external/netutils/netlib_parsehttpurl.c
@@ -119,7 +119,7 @@ int netlib_parsehttpurl(const char *url, uint16_t *port, char *hostname, int hos
 			*dest++ = *src++;
 			bytesleft--;
 		} else {
-			ret = -E2BIG;
+			return -E2BIG;
 		}
 	}
 	*dest = '\0';
@@ -140,7 +140,7 @@ int netlib_parsehttpurl(const char *url, uint16_t *port, char *hostname, int hos
 	/* The rest of the line is the file name */
 
 	if (*src == '\0' || *src == ' ') {
-		ret = -ENOENT;
+		return -ENOENT;
 	}
 
 	/* Make sure the file name starts with exactly one '/' */


### PR DESCRIPTION
netlib_parsehttpurl() should be returned when error is detected