### PR TITLE
Merge security-related fixes from eclipse wakaama Github to TizenRT

### DIFF
--- a/external/wakaama/core/internals.h
+++ b/external/wakaama/core/internals.h
@@ -276,6 +276,7 @@ coap_status_t observe_handleRequest(lwm2m_context_t * contextP, lwm2m_uri_t * ur
 void observe_cancel(lwm2m_context_t * contextP, uint16_t mid, void * fromSessionH);
 coap_status_t observe_setParameters(lwm2m_context_t * contextP, lwm2m_uri_t * uriP, lwm2m_server_t * serverP, lwm2m_attributes_t * attrP);
 void observe_step(lwm2m_context_t * contextP, time_t currentTime, time_t * timeoutP);
+void observe_clear(lwm2m_context_t *contextP, lwm2m_uri_t *uriP);
 bool observe_handleNotify(lwm2m_context_t * contextP, void * fromSessionH, coap_packet_t * message, coap_packet_t * response);
 void observe_remove(lwm2m_observation_t * observationP);
 lwm2m_observed_t * observe_findByUri(lwm2m_context_t * contextP, lwm2m_uri_t * uriP);
@@ -339,6 +340,7 @@ size_t utils_encodeFloat(double data, uint8_t data_buffer[_PRV_64BIT_BUFFER_SIZE
 size_t utils_base64ToOpaque(uint8_t * dataP, size_t dataLen, uint8_t ** bufferP);
 size_t utils_opaqueToBase64(uint8_t * dataP, size_t dataLen, uint8_t ** bufferP);
 size_t utils_base64Encode(uint8_t * dataP, size_t dataLen, uint8_t * bufferP, size_t bufferLen);
+size_t utils_base64GetSize(size_t dataLen);
 #ifdef LWM2M_CLIENT_MODE
 lwm2m_server_t * utils_findServer(lwm2m_context_t * contextP, void * fromSessionH);
 lwm2m_server_t * utils_findBootstrapServer(lwm2m_context_t * contextP, void * fromSessionH);

--- a/external/wakaama/core/liblwm2m.c
+++ b/external/wakaama/core/liblwm2m.c
@@ -105,9 +105,13 @@ void lwm2m_deregister(lwm2m_context_t * context)
     }
 }
 
-static void prv_deleteServer(lwm2m_server_t * serverP)
+static void prv_deleteServer(lwm2m_server_t * serverP, void *userData)
 {
     // TODO parse transaction and observation to remove the ones related to this server
+    if (serverP->sessionH != NULL)
+    {
+        lwm2m_close_connection(serverP->sessionH, userData);
+    }
     if (NULL != serverP->location)
     {
         lwm2m_free(serverP->location);
@@ -123,14 +127,18 @@ static void prv_deleteServerList(lwm2m_context_t * context)
         lwm2m_server_t * server;
         server = context->serverList;
         context->serverList = server->next;
-        prv_deleteServer(server);
+        prv_deleteServer(server, context->userData);
     }
 }
 
-static void prv_deleteBootstrapServer(lwm2m_server_t * serverP)
+static void prv_deleteBootstrapServer(lwm2m_server_t * serverP, void *userData)
 {
     // TODO should we free location as in prv_deleteServer ?
     // TODO should we parse transaction and observation to remove the ones related to this server ?
+    if (serverP->sessionH != NULL)
+    {
+        lwm2m_close_connection(serverP->sessionH, userData);
+    }
     free_block1_buffer(serverP->block1Data);
     lwm2m_free(serverP);
 }
@@ -142,7 +150,7 @@ static void prv_deleteBootstrapServerList(lwm2m_context_t * context)
         lwm2m_server_t * server;
         server = context->bootstrapServerList;
         context->bootstrapServerList = server->next;
-        prv_deleteBootstrapServer(server);
+        prv_deleteBootstrapServer(server, context->userData);
     }
 }
 
@@ -236,7 +244,7 @@ static int prv_refreshServerList(lwm2m_context_t * contextP)
         }
         else
         {
-            prv_deleteServer(targetP);
+            prv_deleteServer(targetP, contextP->userData);
         }
         targetP = nextP;
     }
@@ -253,7 +261,7 @@ static int prv_refreshServerList(lwm2m_context_t * contextP)
         }
         else
         {
-            prv_deleteServer(targetP);
+            prv_deleteServer(targetP, contextP->userData);
         }
         targetP = nextP;
     }

--- a/external/wakaama/core/objects.c
+++ b/external/wakaama/core/objects.c
@@ -366,6 +366,10 @@ coap_status_t object_delete(lwm2m_context_t * contextP,
     if (LWM2M_URI_IS_SET_INSTANCE(uriP))
     {
         result = objectP->deleteFunc(uriP->instanceId, objectP);
+        if (result == COAP_202_DELETED)
+        {
+             observe_clear(contextP, uriP);
+        }
     }
     else
     {
@@ -377,6 +381,13 @@ coap_status_t object_delete(lwm2m_context_t * contextP,
             && result == COAP_202_DELETED)
         {
             result = objectP->deleteFunc(instanceP->id, objectP);
+            if (result == COAP_202_DELETED)
+            {
+                uriP->flag |= LWM2M_URI_FLAG_INSTANCE_ID;
+                uriP->instanceId = instanceP->id;
+                observe_clear(contextP, uriP);
+                uriP->flag &= ~LWM2M_URI_FLAG_INSTANCE_ID;
+            }
             instanceP = objectP->instanceList;
         }
     }

--- a/external/wakaama/core/utils.c
+++ b/external/wakaama/core/utils.c
@@ -745,7 +745,7 @@ static void prv_decodeBlock(uint8_t input[4],
     output[2] = (tmp[2] << 6) | tmp[3];
 }
 
-static size_t prv_getBase64Size(size_t dataLen)
+size_t utils_base64GetSize(size_t dataLen)
 {
     size_t result_len;
 
@@ -764,7 +764,7 @@ size_t utils_base64Encode(uint8_t * dataP,
     unsigned int result_index;
     size_t result_len;
 
-    result_len = prv_getBase64Size(dataLen);
+    result_len = utils_base64GetSize(dataLen);
 
     if (result_len > bufferLen) return 0;
 
@@ -807,7 +807,7 @@ size_t utils_opaqueToBase64(uint8_t * dataP,
     size_t buffer_len;
     size_t result_len;
 
-    buffer_len = prv_getBase64Size(dataLen);
+    buffer_len = utils_base64GetSize(dataLen);
 
     *bufferP = (uint8_t *)lwm2m_malloc(buffer_len);
     if (!*bufferP) return 0;

--- a/external/wakaama/examples/server/lwm2mserver.c
+++ b/external/wakaama/examples/server/lwm2mserver.c
@@ -592,7 +592,7 @@ static void prv_create_client(char * buffer,
     {
         lwm2m_data_t * dataP;
 
-        if (1 != sscanf(buffer, "%d", &value))
+        if (1 != sscanf(buffer, "%"PRId64, &value))
         {
             fprintf(stdout, "Invalid value !");
             return;


### PR DESCRIPTION
Wakaama in the version currently used by TizenRT (seems to be from around March/April) is vulnerable to several security issues, which were since fixed in the upstream version at https://github.com/eclipse/wakaama.

Reference to the original fixes are given below:

1. eclipse/wakaama#319 (fix unknown, but likely eclipse/wakaama@8037174)
2. eclipse/wakaama#320
3. eclipse/wakaama#268
4. eclipse/wakaama#301