### PR TITLE
testcase/filesystem : fix coding rule error - remove unnecessary space

### DIFF
--- a/apps/examples/testcase/le_tc/filesystem/fs_main.c
+++ b/apps/examples/testcase/le_tc/filesystem/fs_main.c
@@ -53,7 +53,7 @@
 /****************************************************************************
  * Definitions
  ****************************************************************************/
-#define STDIO_BUFLEN 		64
+#define STDIO_BUFLEN		64
 #define VFS_CONTENTS_LEN	20
 
 #define MOUNT_DIR CONFIG_MOUNT_POINT


### PR DESCRIPTION
[IDT_M_TAB] please, no space before tabs