### PR TITLE
net:wifimanager fix sending net events to iotivity from wifi manager

### DIFF
--- a/framework/src/wifi_manager/wifi_manager.c
+++ b/framework/src/wifi_manager/wifi_manager.c
@@ -78,6 +78,9 @@ static wifi_utils_result_e start_dhcp_client(void)
 	netlib_set_ipv4netmask(CTRL_IFNAME, &state.netmask);
 	netlib_set_dripv4addr(CTRL_IFNAME, &state.default_router);
 
+#ifdef CONFIG_ENABLE_IOTIVITY
+	__tizenrt_manual_linkset("gen");
+#endif
 	nvdbg("IP address : %s ----\n", inet_ntoa(state.ipaddr));
 
 	return WIFI_UTILS_SUCCESS;
@@ -108,7 +111,9 @@ static wifi_utils_result_e start_dhcp_server(void)
 		ndbg("DHCP Server - started fail\n");
 		return WIFI_UTILS_FAIL;
 	}
-
+#ifdef CONFIG_ENABLE_IOTIVITY
+	__tizenrt_manual_linkset("gen");
+#endif
 	nvdbg("DHCP Server - started success\n");
 	return WIFI_UTILS_SUCCESS;
 }
@@ -122,6 +127,9 @@ static wifi_utils_result_e stop_dhcp_server(void)
 
 	dhcpd_stop();
 
+#ifdef CONFIG_ENABLE_IOTIVITY
+	__tizenrt_manual_linkset("del");
+#endif
 	return WIFI_UTILS_SUCCESS;
 }
 
@@ -193,9 +201,7 @@ static void wifi_linkup_event_func(void)
 		 */
 	}
 
-#ifdef CONFIG_ENABLE_IOTIVITY
-	__tizenrt_manual_linkset("gen");
-#endif
+
 	/* TODO: Import files from source
 	 * sendStatusTrigger (TRIGGER_NETWORK_CHANGED, DAWIT_NW_CHANGED_UP);
 	 */
@@ -231,9 +237,7 @@ static void wifi_linkdown_event_func(void)
 		}
 	}
 
-#ifdef CONFIG_ENABLE_IOTIVITY
-	__tizenrt_manual_linkset("del");
-#endif
+
 
 	/* TODO: Import files from source
 	 * sendStatusTrigger(TRIGGER_NETWORK_CHANGED, DAWIT_NW_CHANGED_DOWN);
@@ -379,6 +383,12 @@ wifi_manager_result_e wifi_manager_disconnect_ap(void)
 	wifi_mutex_acquire(w_mutex, WIFI_UTILS_FOREVER);
 	result = wifi_utils_disconnect_ap();
 	wifi_mutex_release(w_mutex);
+
+#ifdef CONFIG_ENABLE_IOTIVITY
+	if (result == WIFI_UTILS_SUCCESS) {
+		__tizenrt_manual_linkset("del");
+	}
+#endif
 
 	return result;
 }


### PR DESCRIPTION
Send network events to Iotivity only when the IP address is changed on the device.
Wifi manager sends network event even though sta leaves on SoftAP mode.
In above case, The IP address on the device is still ok, so it doesn't need to send.