### PR TITLE
wpa_supplicant : security vulnerability patch (http://w1.fi/security/2016-1/)

### DIFF
--- a/external/wpa_supplicant/src/utils/common.c
+++ b/external/wpa_supplicant/src/utils/common.c
@@ -714,6 +714,16 @@ int has_ctrl_char(const u8 *data, size_t len)
 	return 0;
 }
 
+int has_newline(const char *str)
+{
+	while (*str) {
+		if (*str == '\n' || *str == '\r')
+			return 1;
+		str++;
+	}
+	return 0;
+}
+
 size_t merge_byte_arrays(u8 *res, size_t res_len, const u8 *src1, size_t src1_len, const u8 *src2, size_t src2_len)
 {
 	size_t len = 0;

--- a/external/wpa_supplicant/src/utils/common.c
+++ b/external/wpa_supplicant/src/utils/common.c
@@ -703,6 +703,17 @@ int is_hex(const u8 *data, size_t len)
 	return 0;
 }
 
+int has_ctrl_char(const u8 *data, size_t len)
+{
+	size_t i;
+
+	for (i = 0; i < len; i++) {
+		if (data[i] < 32 || data[i] == 127)
+			return 1;
+	}
+	return 0;
+}
+
 size_t merge_byte_arrays(u8 *res, size_t res_len, const u8 *src1, size_t src1_len, const u8 *src2, size_t src2_len)
 {
 	size_t len = 0;

--- a/external/wpa_supplicant/src/utils/common.h
+++ b/external/wpa_supplicant/src/utils/common.h
@@ -514,6 +514,7 @@ const char *wpa_ssid_txt(const u8 *ssid, size_t ssid_len);
 
 char *wpa_config_parse_string(const char *value, size_t *len);
 int is_hex(const u8 *data, size_t len);
+int has_ctrl_char(const u8 *data, size_t len);
 size_t merge_byte_arrays(u8 *res, size_t res_len, const u8 *src1, size_t src1_len, const u8 *src2, size_t src2_len);
 char *dup_binstr(const void *src, size_t len);
 

--- a/external/wpa_supplicant/src/utils/common.h
+++ b/external/wpa_supplicant/src/utils/common.h
@@ -515,6 +515,7 @@ const char *wpa_ssid_txt(const u8 *ssid, size_t ssid_len);
 char *wpa_config_parse_string(const char *value, size_t *len);
 int is_hex(const u8 *data, size_t len);
 int has_ctrl_char(const u8 *data, size_t len);
+int has_newline(const char *str);
 size_t merge_byte_arrays(u8 *res, size_t res_len, const u8 *src1, size_t src1_len, const u8 *src2, size_t src2_len);
 char *dup_binstr(const void *src, size_t len);
 

--- a/external/wpa_supplicant/src/wps/wps_attr_process.c
+++ b/external/wpa_supplicant/src/wps/wps_attr_process.c
@@ -194,6 +194,15 @@ static int wps_workaround_cred_key(struct wps_credential *cred)
 		cred->key_len--;
 #endif							/* CONFIG_WPS_STRICT */
 	}
+
+	if (cred->auth_type & (WPS_AUTH_WPAPSK | WPS_AUTH_WPA2PSK) &&
+		(cred->key_len < 8 || has_ctrl_char(cred->key, cred->key_len))) {
+		wpa_printf(MSG_INFO, "WPS: Reject credential with invalid WPA/WPA2-Personal passphrase");
+		wpa_hexdump_ascii_key(MSG_INFO, "WPS: Network Key",
+				cred->key, cred->key_len);
+		return -1;
+	}
+
 	return 0;
 }
 

--- a/external/wpa_supplicant/wpa_supplicant/config.c
+++ b/external/wpa_supplicant/wpa_supplicant/config.c
@@ -2623,6 +2623,8 @@ int wpa_config_set_cred(struct wpa_cred *cred, const char *var, const char *valu
 	}
 
 	if (os_strcmp(var, "password") == 0 && os_strncmp(value, "ext:", 4) == 0) {
+		if (has_newline(value))
+			return -1;
 		str_clear_free(cred->password);
 		cred->password = os_strdup(value);
 		cred->ext_password = 1;
@@ -2674,8 +2676,13 @@ int wpa_config_set_cred(struct wpa_cred *cred, const char *var, const char *valu
 	}
 
 	val = wpa_config_parse_string(value, &len);
-	if (val == NULL) {
+	if (val == NULL ||
+		(os_strcmp(var, "excluded_ssid") != 0 &&
+		os_strcmp(var, "roaming_consortium") != 0 &&
+		os_strcmp(var, "required_roaming_consortium") != 0 &&
+		has_newline(val))) {
 		wpa_printf(MSG_ERROR, "Line %d: invalid field '%s' string " "value '%s'.", line, var, value);
+		os_free(val);
 		return -1;
 	}
 

--- a/external/wpa_supplicant/wpa_supplicant/config.c
+++ b/external/wpa_supplicant/wpa_supplicant/config.c
@@ -2435,7 +2435,16 @@ char *wpa_config_get(struct wpa_ssid *ssid, const char *var)
 	for (i = 0; i < NUM_SSID_FIELDS; i++) {
 		const struct parse_data *field = &ssid_fields[i];
 		if (os_strcmp(var, field->name) == 0) {
-			return field->writer(field, ssid);
+			char *ret = field->writer(field, ssid);
+
+			if (ret && has_newline(ret)) {
+				wpa_printf(MSG_ERROR,
+					"Found newline in value for %s; not returning it", var);
+				os_free(ret);
+				ret = NULL;
+			}
+
+			return ret;
 		}
 	}
 

--- a/external/wpa_supplicant/wpa_supplicant/config.c
+++ b/external/wpa_supplicant/wpa_supplicant/config.c
@@ -3476,6 +3476,11 @@ static int wpa_global_config_parse_str(const struct global_parse_data *data, str
 		return -1;
 	}
 
+	if (has_newline(pos)) {
+		wpa_printf(MSG_ERROR, "Line %d: invalid %s value with newline", line, data->name);
+		return -1;
+	}
+
 	tmp = os_strdup(pos);
 	if (tmp == NULL) {
 		return -1;

--- a/external/wpa_supplicant/wpa_supplicant/config.c
+++ b/external/wpa_supplicant/wpa_supplicant/config.c
@@ -395,6 +395,10 @@ static int wpa_config_parse_psk(const struct parse_data *data, struct wpa_ssid *
 			return -1;
 		}
 		wpa_hexdump_ascii_key(MSG_MSGDUMP, "PSK (ASCII passphrase)", (u8 *)value, len);
+		if (has_ctrl_char((u8 *) value, len)) {
+			wpa_printf(MSG_ERROR, "Line %d: Invalid passphrase character", line);
+			return -1;
+		}
 		if (ssid->passphrase && os_strlen(ssid->passphrase) == len && os_memcmp(ssid->passphrase, value, len) == 0) {
 			return 0;
 		}


### PR DESCRIPTION
Title : psk configuration parameter update allowing arbitrary data to be written

To prevent written arbitrary data on wpa_supplicant configuration file, requesting review.

Test Results
 - Hardware : ARTIK-053
 - Access Point : iptime  

1) Wi-Fi Join Test : OK
  - wpa-tkip, wpa-aes, wpa-mixed, wpa2-tkip, wpa2-aes, wpa2-mixed, wep, open
2) Wi-Fi Join / leave test : OK
 