### PR TITLE
Fix assert during things reset

### DIFF
--- a/framework/src/st_things/things_stack/src/common/utils/things_network.c
+++ b/framework/src/st_things/things_stack/src/common/utils/things_network.c
@@ -40,6 +40,7 @@ static int app_state = -1;
 static char *app_ap_name = NULL;
 static char *app_ip_addr = NULL;
 volatile static bool is_connected_target_ap = false;
+extern bool b_reset_continue_flag;
 
 #define IP_NULL_VAL     "0.0.0.0"
 
@@ -194,6 +195,10 @@ void things_adapter_state_cb(CATransportAdapter_t adapter, bool enabled)
 void things_tcp_session_state_cb(const CAEndpoint_t *info, bool connected)
 {
 	THINGS_LOG_D(THINGS_DEBUG, TAG, "Enter.");
+
+	if (b_reset_continue_flag == true) {
+		return;
+	}
 
 	if (info == NULL) {
 		THINGS_LOG_V_ERROR(THINGS_ERROR, TAG, "[IoTivity Error] invalid call-back parameter.(info is null.)");

--- a/framework/src/st_things/things_stack/src/common/utils/things_ping.c
+++ b/framework/src/st_things/things_stack/src/common/utils/things_ping.c
@@ -1063,7 +1063,6 @@ GOTO_OUT:
 static bool things_ping_destroy_thread(things_ping_s *ping)
 {
 	THINGS_LOG(THINGS_DEBUG, TAG, "Enter.");
-
 	bool res = false;
 
 	if (ping == NULL || ping->addr == NULL) {
@@ -1076,14 +1075,13 @@ static bool things_ping_destroy_thread(things_ping_s *ping)
 #ifdef __ST_THINGS_RTOS__
 		ping->continue_thread = false;
 		sleep(2);				/* wait till thread exit */
-		pthread_detach(ping->handle_thread);
+		pthread_join(ping->handle_thread, NULL);
 #else							/* there is problem in artik during thread_cancel hence avoiding it */
 		pthread_cancel(ping->handle_thread);
 		pthread_detach(ping->handle_thread);
 #endif
 		ping->handle_thread = 0;
 		ping->continue_thread = false;
-		set_def_interval(ping);
 
 		unset_mask(ping, PING_ST_STARTTHREAD | PING_ST_DISCOVERY | PING_ST_REQUEST | PING_ST_INTUPDATE | PING_ST_TIMEOUT);
 		res = true;

--- a/framework/src/st_things/things_stack/src/stack/things_stack.c
+++ b/framework/src/st_things/things_stack/src/stack/things_stack.c
@@ -101,7 +101,7 @@ do {										\
 	pthread_mutex_unlock(&g_wifi_mutex);			\
 } while (0)
 
-static bool b_reset_continue_flag = false;
+bool b_reset_continue_flag = false;
 static bool b_thread_things_reset = false;
 static pthread_t h_thread_things_reset = NULL;
 static pthread_t h_thread_things_wifi_join = NULL;


### PR DESCRIPTION
- Assert often occur during the reset process as the TCP receive thread is trying to use resources of the ping thread already terminated.
- The TCP receive thread does not need to call the session state callback to terminate the ping thread during reset because the reset loop thread will unregister that callback.