### PR TITLE
testcase/arastorage: delete checking result value in cleanup function.

### DIFF
--- a/apps/examples/testcase/ta_tc/arastorage/utc/utc_arastorage_main.c
+++ b/apps/examples/testcase/ta_tc/arastorage/utc/utc_arastorage_main.c
@@ -98,17 +98,14 @@ static void check_query_result(char * query)
 static void cleanup(void)
 {
 	char query[QUERY_LENGTH];
-	db_result_t res;
 
 	memset(query, 0, QUERY_LENGTH);
 	snprintf(query, QUERY_LENGTH, "REMOVE RELATION %s;", RELATION_NAME1);
-	res = db_exec(query);
-	TC_ASSERT_EQ("db_exec", DB_SUCCESS(res), true);
+	db_exec(query);
 
 	memset(query, 0, QUERY_LENGTH);
 	snprintf(query, QUERY_LENGTH, "REMOVE RELATION %s;", RELATION_NAME2);
-	res = db_exec(query);
-	TC_ASSERT_EQ("db_exec", DB_SUCCESS(res), true);
+	db_exec(query);
 }
 
 /**


### PR DESCRIPTION
cleanup function is called before and after arastorage TCs run to verify cleaning related resources
We don't need to check whether result value of function used here is valid or not.
Because this function is not tc and is used internally.