### PR TITLE
external:xmlrpc handle an exceptional case when invalid parameters ar…

### DIFF
--- a/external/xmlrpc/xmlparser.c
+++ b/external/xmlrpc/xmlparser.c
@@ -136,7 +136,11 @@ static int xmlrpc_getelement(struct parsebuf_s *pbuf, char *data, int dataSize)
 	int j = 0;
 	int ret = XMLRPC_NO_ERROR;
 
-	while (!isprint(pbuf->buf[pbuf->index])) {
+	if (!pbuf || pbuf->len <= pbuf->index) {
+		return XMLRPC_PARSE_ERROR;
+	}
+
+	while ((pbuf->index < pbuf->len) && !isprint(pbuf->buf[pbuf->index])) {
 		pbuf->index++;
 	}
 


### PR DESCRIPTION
…e inserted

<> description:
Properly crafted xml request, can cause a situation in which the value of
the len field in the parsebuf_s structure will be less than the index field.
In this situation, when calling the xmlrpc_getelement from the xmlrpc_parseparams
function, the while loop will read the content of memory outside the buffer causing segmentation fault.

<> solution:
While calling xmlrpc_getelement function, check if index value inside parsebuf_s structure is less than len value.