### PR TITLE
testcase/ttrace: add select condition for using ttrace in Kconfig

### DIFF
--- a/apps/examples/testcase/le_tc/ttrace/Kconfig
+++ b/apps/examples/testcase/le_tc/ttrace/Kconfig
@@ -6,6 +6,7 @@
 config EXAMPLES_TESTCASE_TTRACE
 	bool "T-trace TestCase Example"
 	default n
+	select TTRACE
 	---help---
 		Enable the T-trace TestCase example
 


### PR DESCRIPTION
Add select config in Kconfig for testcase of T-trace.
Enable CONFIG_TTRACE when CONFIG_EXAMPLES_TESTCASE_TTRACE is turned on.