### PR TITLE
doxygen : Add include path and missing param name in framework

### DIFF
--- a/framework/include/dm/dm_connectivity.h
+++ b/framework/include/dm/dm_connectivity.h
@@ -49,6 +49,7 @@ typedef void (*conn_cb)(void);
 /**
  * @brief get the rssi of network
  *
+ * @details @b #include <dm/dm_connectivity.h>
  * @param[out] rssi current rssi. (the rssi is a negative value)
  * @return On success, 0 is returned. On failure, a negative value is returned.
  * @since Tizen RT v1.0
@@ -58,6 +59,7 @@ int dm_conn_get_rssi(int *rssi);
 /**
  * @brief get the ip address of network
  *
+ * @details @b #include <dm/dm_connectivity.h>
  * @param[out] ipAddr current ip address. (the form is XXX.XXX.XXX.XXX)
  * @return On success, 0 is returned. On failure, a negative value is returned.
  * @since Tizen RT v1.0
@@ -67,6 +69,7 @@ int dm_conn_get_address(char *ipAddr);
 /**
  * @brief get the current interface of network
  *
+ * @details @b #include <dm/dm_connectivity.h>
  * @param[out] interface current interface of network. (the value is a string)
  * @return On success, 0 is returned. On failure, a negative value is returned.
  * @since Tizen RT v1.0
@@ -76,6 +79,7 @@ int dm_conn_get_interface(char *interface);
 /**
  * @brief get the channel of network
  *
+ * @details @b #include <dm/dm_connectivity.h>
  * @param[out] channel current channel of network.
  * @return On success, 0 is returned. On failure, a negative value is returned.
  * @since Tizen RT v1.0
@@ -85,6 +89,7 @@ int dm_conn_get_channel(int *channel);
 /**
  * @brief get the tx power of network
  *
+ * @details @b #include <dm/dm_connectivity.h>
  * @param[out] dbm current tx power of network. (the value is between 0 ~ 30 dbm)
  * @return On success, 0 is returned. On failure, a negative value is returned.
  * @since Tizen RT v1.0
@@ -94,6 +99,7 @@ int dm_conn_get_tx_power(int *dbm);
 /**
  * @brief set the tx power of network
  *
+ * @details @b #include <dm/dm_connectivity.h>
  * @param[in] dbm the power value to set up. (the value is between 0 ~ 30 dbm)
  * @return On success, 0 is returned. On failure, a negative value is returned.
  * @since Tizen RT v1.0
@@ -103,6 +109,7 @@ int dm_conn_set_tx_power(const int *dbm);
 /**
  * @brief register link up callback function for connectivity event.
  *
+ * @details @b #include <dm/dm_connectivity.h>
  * @param[in] cb A pointer to call when a network link up event occurs.
  * @return On success, 0 is returned. On failure, a negative value is returned.
  * @since Tizen RT v1.0
@@ -112,6 +119,7 @@ int dm_conn_register_linkup_cb(conn_cb cb);
 /**
  * @brief register link down callback function for connectivity event.
  *
+ * @details @b #include <dm/dm_connectivity.h>
  * @param[in] cb A pointer to call when a network link down event occurs.
  * @return On success, 0 is returned. On failure, a negative value is returned.
  * @since Tizen RT v1.0
@@ -121,6 +129,7 @@ int dm_conn_register_linkdown_cb(conn_cb cb);
 /**
  * @brief unregister link up callback function for connectivity event.
  *
+ * @details @b #include <dm/dm_connectivity.h>
  * @param[in] cb A pointer to call when a network link up event occurs.
  * @return On success, 0 is returned. On failure, a negative value is returned.
  * @since Tizen RT v1.0
@@ -130,6 +139,7 @@ int dm_conn_unregister_linkup_cb(conn_cb cb);
 /**
  * @brief unregister link down callback function for connectivity event.
  *
+ * @details @b #include <dm/dm_connectivity.h>
  * @param[in] cb A pointer to call when a network link down event occurs.
  * @return On success, 0 is returned. On failure, a negative value is returned.
  * @since Tizen RT v1.0
@@ -140,7 +150,7 @@ int dm_conn_unregister_linkdown_cb(conn_cb cb);
 /**
  * @brief Perform a WiFi scan over all channels
  *
- * @param[in] None.
+ * @details @b #include <dm/dm_connectivity.h>
  * @return On success, 0 is returned. On failure, a negative value is returned.
  * @internal
  */
@@ -149,7 +159,8 @@ int dm_conn_wifi_scan(void);
 /**
  * @brief Fetch WiFi scan result
  *
- * @param[out] pointer to WiFi scan structure to hold result.
+ * @details @b #include <dm/dm_connectivity.h>
+ * @param[out] result pointer to WiFi scan structure to hold result.
  * @return On success, 0 is returned. On failure, a negative value is returned.
  * @internal
  */
@@ -158,7 +169,8 @@ int dm_conn_get_scan_result(dm_scan_info_t **result);
 /**
  * @brief Free WiFi scan result
  *
- * @param[out] pointer to WiFi scan structure that holds result.
+ * @details @b #include <dm/dm_connectivity.h>
+ * @param[out] result pointer to WiFi scan structure that holds result.
  * @return On completion, 0 is returned.
  * @internal
  */
@@ -167,7 +179,9 @@ int dm_conn_free_scan_result(dm_scan_info_t **result);
 /**
  * @brief Start device as WiFi station and connect to designated Access Point
  *
- * @param[in] callback functions to handle WiFi link being up and down.
+ * @details @b #include <dm/dm_connectivity.h>
+ * @param[in] linkUpEvent callback functions to handle WiFi link being up.
+ * @param[in] linkDownEvent callback functions to handle WiFi link being down.
  * @return On completion, 0 is returned. On failure, a negative value is returned.
  * @internal
  */
@@ -176,7 +190,7 @@ int dm_conn_wifi_connect(conn_cb linkUpEvent, conn_cb linkDownEvent);
 /**
  * @brief Perform DHCP client routine to obtain IP address for WiFi interface
  *
- * @param None
+ * @details @b #include <dm/dm_connectivity.h>
  * @return On completion, 0 is returned. On failure, a negative value is returned.
  * @internal
  */
@@ -185,7 +199,7 @@ int dm_conn_dhcp_init(void);
 /**
  * @brief Mark WiFi state as disconnected
  *
- * @param None
+ * @details @b #include <dm/dm_connectivity.h>
  * @return On completion, 0 is returned. On failure, a negative value is returned.
  * @internal
  */

--- a/framework/include/dm/dm_lwm2m.h
+++ b/framework/include/dm/dm_lwm2m.h
@@ -72,6 +72,7 @@ struct dm_lwm2m_context_s {
 /**
  * @brief Start a DM client
  *
+ * @details @b #include <dm/dm_lwm2m.h>
  * @param[in] dm_context pointer to DM context
  * @return On success, 0 is returned.
  *         On failure, a negative value is returned.
@@ -83,7 +84,7 @@ int dm_lwm2m_start_client(struct dm_lwm2m_context_s *dm_context);
 /**
  * @brief Close a DM client
  *
- * @param  None
+ * @details @b #include <dm/dm_lwm2m.h>
  * @return On success, 0 is returned.
  *         On failure, a negative value is returned.
  *         If client is already stopped, return DM_ERROR_ALREADY_STOPPED.
@@ -94,7 +95,8 @@ int dm_lwm2m_stop_client(void);
 /**
  * @brief Get server IP address
  *
- * @param[out] IP address pointer to memory to store server IP address
+ * @details @b #include <dm/dm_lwm2m.h>
+ * @param[out] server_ipAddr pointer to memory to store server IP address
  * @return     On success, 0 is returned.
  *             On failure, a negative value is returned.
  * @since Tizen RT v1.0
@@ -104,7 +106,8 @@ int dm_lwm2m_get_server_address(char *server_ipAddr);
 /**
  * @brief Get server port number
  *
- * @param[out] port pointer to memory to store server port
+ * @details @b #include <dm/dm_lwm2m.h>
+ * @param[out] server_port pointer to memory to store server port
  * @return     On success, 0 is returned.
  *             On failure, a negative value is returned.
  * @since Tizen RT v1.0
@@ -114,6 +117,7 @@ int dm_lwm2m_get_server_port(char *server_port);
 /**
  * @brief Get lifetime for a client
  *
+ * @details @b #include <dm/dm_lwm2m.h>
  * @param[out] lifetime pointer to memory to store client lifetime
  * @return     On success, 0 is returned.
  *             On failure, a negative value is returned.
@@ -124,7 +128,8 @@ int dm_lwm2m_get_client_lifetime(int *lifetime);
 /**
  * @brief Get state of client
  *
- * @param[out] lifetime pointer to memory to store client state
+ * @details @b #include <dm/dm_lwm2m.h>
+ * @param[out] state pointer to memory to store client state
  * @return     On success, 0 is returned.
  *             On failure, a negative value is returned.
  * @since Tizen RT v1.0
@@ -134,6 +139,7 @@ int dm_lwm2m_get_client_state(dm_lwm2m_client_state_e *state);
 /**
  * @brief Get client resource value
  *
+ * @details @b #include <dm/dm_lwm2m.h>
  * @param[in] buffer pointer to resource URI
  *
  * @return     On success, 0 is returned.

--- a/framework/include/network/mqtt/mqtt_api.h
+++ b/framework/include/network/mqtt/mqtt_api.h
@@ -145,6 +145,7 @@ typedef struct _mqtt_client_t {
 /**
  * @brief mqtt_init_client() initializes MQTT client
  *
+ * @details @b #include <network/mqtt/mqtt_api.h>
  * @param[in] config the information of MQTT client object configuration
  * @return On success, the handle of MQTT client object is returned. On failure, NULL is returned.
  * @since Tizen RT v1.1
@@ -154,7 +155,8 @@ mqtt_client_t *mqtt_init_client(mqtt_client_config_t *config);
 /**
  * @brief mqtt_deinit_client() de-initializes MQTT client
  *
- * @param[in] handle  the handle of MQTT client object
+ * @details @b #include <network/mqtt/mqtt_api.h>
+ * @param[in] handle the handle of MQTT client object
  * @return On success, 0 is returned. On failure, a negative value is returned.
  * @since Tizen RT v1.1
  */
@@ -163,10 +165,11 @@ int mqtt_deinit_client(mqtt_client_t *handle);
 /**
  * @brief mqtt_connect() connects to a MQTT broker
  *
- * @param[in] handle  the handle of MQTT client object
- * @param[in] addr  MQTT broker address
- * @param[in] port  MQTT broker port
- * @param[in] keep_alive  MQTT keep-alive time in second
+ * @details @b #include <network/mqtt/mqtt_api.h>
+ * @param[in] handle the handle of MQTT client object
+ * @param[in] addr MQTT broker address
+ * @param[in] port MQTT broker port
+ * @param[in] keep_alive MQTT keep-alive time in second
  * @return On success, 0 is returned. On failure, a negative value is returned.
  * @since Tizen RT v1.1
  */
@@ -175,7 +178,8 @@ int mqtt_connect(mqtt_client_t *handle, char *addr, int port, int keep_alive);
 /**
  * @brief mqtt_disconnect() disconnects from a MQTT broker
  *
- * @param[in] handle  the handle of MQTT client object
+ * @details @b #include <network/mqtt/mqtt_api.h>
+ * @param[in] handle the handle of MQTT client object
  * @return On success, 0 is returned. On failure, a negative value is returned.
  * @since Tizen RT v1.1
  */
@@ -184,12 +188,13 @@ int mqtt_disconnect(mqtt_client_t *handle);
 /**
  * @brief mqtt_publish() pusblishes message to a MQTT broker on the given topic
  *
- * @param[in] handle  the handle of MQTT client object
- * @param[in] topic  the topic on which the message to be published
- * @param[in] data  the message to publish
- * @param[in] data_len  the length of message
- * @param[in] qos  the Quality of Service to be used for the message. QoS value should be 0,1 or 2.
- * @param[in] retain  the flag to make the message retained.
+ * @details @b #include <network/mqtt/mqtt_api.h>
+ * @param[in] handle the handle of MQTT client object
+ * @param[in] topic the topic on which the message to be published
+ * @param[in] data the message to publish
+ * @param[in] data_len the length of message
+ * @param[in] qos the Quality of Service to be used for the message. QoS value should be 0,1 or 2.
+ * @param[in] retain the flag to make the message retained.
  * @return On success, 0 is returned. On failure, a negative value is returned.
  * @since Tizen RT v1.1
  */
@@ -198,9 +203,10 @@ int mqtt_publish(mqtt_client_t *handle, char *topic, char *data, uint32_t data_l
 /**
  * @brief mqtt_subscribe() subscribes for the specified topic with MQTT broker
  *
- * @param[in] handle  the handle of MQTT client object
- * @param[in] topic  the topic on which the message to be unsubscribed
- * @param[in] qos  the Quality of Service for the subscription.  QoS value should be 0,1 or 2.
+ * @details @b #include <network/mqtt/mqtt_api.h>
+ * @param[in] handle the handle of MQTT client object
+ * @param[in] topic the topic on which the message to be unsubscribed
+ * @param[in] qos the Quality of Service for the subscription.  QoS value should be 0,1 or 2.
  * @return On success, 0 is returned. On failure, a negative value is returned.
  * @since Tizen RT v1.1
  */
@@ -209,8 +215,9 @@ int mqtt_subscribe(mqtt_client_t *handle, char *topic, uint8_t qos);
 /**
  * @brief mqtt_unsubscribe() unsubscribes from the specified topic
  *
- * @param[in] handle  the handle of MQTT client object
- * @param[in] topic  the topic on which the message to be unsubscribed
+ * @details @b #include <network/mqtt/mqtt_api.h>
+ * @param[in] handle the handle of MQTT client object
+ * @param[in] topic the topic on which the message to be unsubscribed
  * @return On success, 0 is returned. On failure, a negative value is returned.
  * @since Tizen RT v1.1
  */


### PR DESCRIPTION
1. Add include path for each api 
- if not, we cannot know which header we should include for using that api
2. Add missing param name for each api 
- argument name is needed after param[in] or param[out]
