### PR TITLE
ta_tc/audio/{utc,itc} : Removing assert failure in audio TCs

### DIFF
--- a/apps/examples/testcase/ta_tc/audio/itc/itc_audio_main.c
+++ b/apps/examples/testcase/ta_tc/audio/itc/itc_audio_main.c
@@ -434,6 +434,9 @@ static void itc_audio_pcm_readi_tc_p(void)
 
 	while (remain > 0) {
 		frames_read = pcm_readi(g_pcm, buffer, remain);
+		if (frames_read < 0) {
+			break;
+		}
 		remain -= frames_read;
 		ret = write(fd, buffer, bytes_per_frame * frames_read);
 		TC_ASSERT_EQ_CLEANUP("pcm_readi", ret, (bytes_per_frame * frames_read), clean_all_data(fd, buffer));

--- a/apps/examples/testcase/ta_tc/audio/utc/utc_audio_main.c
+++ b/apps/examples/testcase/ta_tc/audio/utc/utc_audio_main.c
@@ -670,6 +670,9 @@ static void utc_audio_pcm_readi_p(void)
 
 	while (remain > 0) {
 		frames_read = pcm_readi(g_pcm, buffer, remain);
+		if (frames_read < 0) {
+			break;
+		}
 		remain -= frames_read;
 		ret = write(fd, buffer, bytes_per_frame * frames_read);
 		TC_ASSERT_EQ_CLEANUP("pcm_readi", ret, (bytes_per_frame * frames_read), clean_all_data(fd, buffer));


### PR DESCRIPTION
In audio utc/itc, readi positive tc gave an assert failure. The failure was due to the last pcm_readi call returning a negative value. The negative value was passed to write function which led to assert failure.

Now an if block has been added which checks the return value of pcm_readi before passing it to the write function.