### PR TITLE
iotbus: bug fix in pwm

### DIFF
--- a/framework/src/iotbus/iotbus_pwm.c
+++ b/framework/src/iotbus/iotbus_pwm.c
@@ -117,7 +117,7 @@ int iotbus_pwm_set_duty_cycle(iotbus_pwm_context_h pwm, percent_t duty_cycle)
 		return IOTBUS_ERROR_UNKNOWN;
 	}
 
-	info->duty = ((duty_cycle * IOTBUS_PWM_MAX_RESOLUTION) / 100) + 0.5;
+	info->duty = ((duty_cycle * IOTBUS_PWM_MAX_RESOLUTION) / 100.0) + 0.5;
 	ret = ioctl(fd, PWMIOC_SETCHARACTERISTICS, (unsigned long)((uintptr_t)info));
 	if (ret < 0) {
 		zdbg("ioctl(PWMIOC_SETCHARACTERISTICS) failed: %d\n", errno);


### PR DESCRIPTION
- change type of divisor to get the result as float value.