### PR TITLE
framework/tinyalsa : Removing pcm_set_config as public API

### DIFF
--- a/apps/examples/testcase/ta_tc/audio/itc/itc_audio_main.c
+++ b/apps/examples/testcase/ta_tc/audio/itc/itc_audio_main.c
@@ -296,30 +296,6 @@ static void itc_audio_pcm_get_subdevice_tc_p(void)
 }
 
 /**
-* @testcase         audio_pcm_set_config_p
-* @brief            set config values of pcm
-* @scenario         set config values with pcm_config
-* @apicovered       pcm_set_config
-* @precondition     pcm should be opened before.
-* @postcondition    NA
-*/
-static void itc_audio_pcm_set_config_tc_p(void)
-{
-	struct pcm_config config;
-	config.channels = 1;
-	config.rate = CONFIG_RATE;
-	config.format = PCM_FORMAT_S8;
-	g_pcm = pcm_open(0, 0, PCM_IN, NULL);
-	TC_ASSERT_GT("pcm_open", pcm_get_file_descriptor(g_pcm), 0);
-	pcm_set_config(g_pcm, &config);
-	TC_ASSERT_EQ_CLEANUP("pcm_set_config", pcm_get_channels(g_pcm), 1, pcm_close(g_pcm));
-	TC_ASSERT_EQ_CLEANUP("pcm_set_config", pcm_get_rate(g_pcm), CONFIG_RATE, pcm_close(g_pcm));
-	TC_ASSERT_EQ_CLEANUP("pcm_set_config", pcm_get_format(g_pcm), PCM_FORMAT_S8, pcm_close(g_pcm));
-	TC_ASSERT_EQ("pcm_close", pcm_close(g_pcm), 0);
-	TC_SUCCESS_RESULT();
-}
-
-/**
 * @testcase         audio_pcm_frame_to_bytes_p
 * @brief            convert frames to bytes
 * @scenario         get configuration value of pcm and calculate frame to byte
@@ -337,7 +313,6 @@ static void itc_audio_pcm_frames_to_bytes_tc_p(void)
 	TC_ASSERT_GT("pcm_open", pcm_get_file_descriptor(g_pcm), 0);
 
 	/* set basic configuration values for next test */
-	pcm_set_config(g_pcm, NULL);
 	size = pcm_get_buffer_size(g_pcm);
 	TC_ASSERT_GT_CLEANUP("pcm_get_buffer_size", size, 0, pcm_close(g_pcm));
 
@@ -366,7 +341,6 @@ static void itc_audio_pcm_bytes_to_frames_tc_p(void)
 	g_pcm = pcm_open(0, 0, PCM_IN, NULL);
 	TC_ASSERT_GT("pcm_open", pcm_get_file_descriptor(g_pcm), 0);
 
-	pcm_set_config(g_pcm, NULL);
 	size = pcm_get_buffer_size(g_pcm);
 	TC_ASSERT_GT_CLEANUP("pcm_get_buffer_size", size, 0, pcm_close(g_pcm));
 
@@ -513,7 +487,6 @@ static int audio_tc_launcher(int argc, char **args)
 	itc_audio_pcm_get_error_tc_p();
 	itc_audio_pcm_get_buffer_size_tc_p();
 	itc_audio_pcm_get_subdevice_tc_p();
-	itc_audio_pcm_set_config_tc_p();
 	itc_audio_pcm_frames_to_bytes_tc_p();
 	itc_audio_pcm_bytes_to_frames_tc_p();
 	itc_audio_pcm_format_to_bits_tc_p();

--- a/apps/examples/testcase/ta_tc/audio/utc/utc_audio_main.c
+++ b/apps/examples/testcase/ta_tc/audio/utc/utc_audio_main.c
@@ -488,41 +488,6 @@ static void utc_audio_pcm_get_subdevice_tc_n(void)
 }
 
 /**
-* @testcase         audio_pcm_set_config_p
-* @brief            set config values of pcm
-* @scenario         set config values with pcm_config
-* @apicovered       pcm_set_config
-* @precondition     pcm should be opened before.
-* @postcondition    NA
-*/
-static void utc_audio_pcm_set_config_tc_p(void)
-{
-	struct pcm_config config;
-	config.channels = 1;
-	config.rate = 4000;
-	config.format = PCM_FORMAT_S8;
-	pcm_set_config(g_pcm, &config);
-	TC_ASSERT_EQ("pcm_set_config", pcm_get_channels(g_pcm), 1);
-	TC_ASSERT_EQ("pcm_set_config", pcm_get_rate(g_pcm), 4000);
-	TC_ASSERT_EQ("pcm_set_config", pcm_get_format(g_pcm), PCM_FORMAT_S8);
-	TC_SUCCESS_RESULT();
-}
-
-/**
-* @testcase         audio_pcm_set_config_n
-* @brief            set config values of pcm
-* @scenario         set config values with NULL pcm
-* @apicovered       pcm_set_config
-* @precondition     NA
-* @postcondition    NA
-*/
-static void utc_audio_pcm_set_config_tc_n(void)
-{
-	TC_ASSERT_LT("pcm_set_config", pcm_set_config(NULL, NULL), 0);
-	TC_SUCCESS_RESULT();
-}
-
-/**
 * @testcase         audio_pcm_frame_to_bytes_p
 * @brief            convert frames to bytes
 * @scenario         get configuration value of pcm and calculate frame to byte
@@ -537,7 +502,6 @@ static void utc_audio_pcm_frames_to_bytes_p(void)
 	unsigned int frame_size;
 
 	/* set basic configuration values for next test */
-	pcm_set_config(g_pcm, NULL);
 	size = pcm_get_buffer_size(g_pcm);
 	TC_ASSERT_GT("pcm_get_buffer_size", size, 0);
 
@@ -578,7 +542,6 @@ static void utc_audio_pcm_bytes_to_frames_p(void)
 	ssize_t size;
 	unsigned int frame_size;
 
-	pcm_set_config(g_pcm, NULL);
 	size = pcm_get_buffer_size(g_pcm);
 	TC_ASSERT_GT("pcm_get_buffer_size", size, 0);
 
@@ -831,8 +794,6 @@ static int audio_tc_launcher(int argc, char **args)
 	utc_audio_pcm_get_buffer_size_tc_n();
 	utc_audio_pcm_get_subdevice_tc_p();
 	utc_audio_pcm_get_subdevice_tc_n();
-	utc_audio_pcm_set_config_tc_p();
-	utc_audio_pcm_set_config_tc_n();
 	utc_audio_pcm_frames_to_bytes_p();
 	utc_audio_pcm_frames_to_bytes_n();
 	utc_audio_pcm_bytes_to_frames_p();

--- a/framework/include/tinyalsa/tinyalsa.h
+++ b/framework/include/tinyalsa/tinyalsa.h
@@ -339,16 +339,6 @@ int pcm_get_file_descriptor(const struct pcm *pcm);
 const char *pcm_get_error(const struct pcm *pcm);
 
 /**
-* @brief Sets the PCM configuration parameters
-*
-* @param[out] A PCM handle.
-* @param[in] The configuration to use for the PCM
-* @returns On success, 0 returned. On failure, a negative errno value returned
-* @since Tizen RT v1.1
-*/
-int pcm_set_config(struct pcm *pcm, const struct pcm_config *config);
-
-/**
 * @brief Gets the buffer size of the PCM.
 *
 * @param[in] A PCM handle.

--- a/framework/src/tinyalsa/tinyalsa.c
+++ b/framework/src/tinyalsa/tinyalsa.c
@@ -292,7 +292,7 @@ const char *pcm_get_error(const struct pcm *pcm)
  *  on failure.
  * @ingroup libtinyalsa-pcm
  * */
-int pcm_set_config(struct pcm *pcm, const struct pcm_config *config)
+static int pcm_set_config(struct pcm *pcm, const struct pcm_config *config)
 {
 	struct audio_caps_desc_s cap_desc;
 	int ret;


### PR DESCRIPTION
pcm_set_config has been removed from tinyalsa include file. The tcs in utc and itc which tested pcm_set_config have been removed. Calls to pcm_set_config outside of tinyalsa have also been removed .pcm_set_config has been made a static function so that it can it is called only from tinyalsa.c file.