### PR TITLE
Edit makefiles of framework and tc for the path inclusion of DM API header

### DIFF
--- a/apps/examples/testcase/ta_tc/device_management/itc/Make.defs
+++ b/apps/examples/testcase/ta_tc/device_management/itc/Make.defs
@@ -57,7 +57,6 @@ CSRCS += itc_dm_main.c itc_dm_lwm2m.c itc_dm_conn.c
 CFLAGS+=-I$(TOPDIR)/../external/wakaama/examples/shared
 CFLAGS+=-I$(TOPDIR)/../external/wakaama/examples/client
 CFLAGS+=-I$(TOPDIR)/../external/wakaama/core
-CFLAGS+=-I$(TOPDIR)/../framework/include/dm
 
 # Include kernel build support
 

--- a/apps/examples/testcase/ta_tc/device_management/itc/itc_dm_lwm2m.c
+++ b/apps/examples/testcase/ta_tc/device_management/itc/itc_dm_lwm2m.c
@@ -26,8 +26,8 @@
 #include <netutils/netlib.h>
 #include <sys/socket.h>
 #include "itc_internal.h"
-#include "dm_lwm2m.h"
-#include "dm_error.h"
+#include <dm/dm_lwm2m.h>
+#include <dm/dm_error.h>
 #include <tinyara/wqueue.h>
 
 #define ITC_DM_IPADDR_LEN 20

--- a/apps/examples/testcase/ta_tc/device_management/utc/Make.defs
+++ b/apps/examples/testcase/ta_tc/device_management/utc/Make.defs
@@ -57,7 +57,6 @@ CSRCS += utc_dm_main.c utc_dm_lwm2m.c utc_dm_conn.c
 CFLAGS+=-I$(TOPDIR)/../external/wakaama/examples/shared
 CFLAGS+=-I$(TOPDIR)/../external/wakaama/examples/client
 CFLAGS+=-I$(TOPDIR)/../external/wakaama/core
-CFLAGS+=-I$(TOPDIR)/../framework/include/dm
 
 # Include kernel build support
 

--- a/apps/examples/testcase/ta_tc/device_management/utc/utc_dm_lwm2m.c
+++ b/apps/examples/testcase/ta_tc/device_management/utc/utc_dm_lwm2m.c
@@ -27,8 +27,8 @@
 #include <sys/socket.h>
 
 #include "utc_internal.h"
-#include "dm_lwm2m.h"
-#include "dm_error.h"
+#include <dm/dm_lwm2m.h>
+#include <dm/dm_error.h>
 #include "tc_common.h"
 
 #define UTC_DM_IPADDR_LEN 20

--- a/framework/Makefile
+++ b/framework/Makefile
@@ -30,7 +30,6 @@ CFLAGS += -I$(TOPDIR)/../framework/include/iotbus
 include src$(DELIM)iotbus$(DELIM)Make.defs
 
 ifeq ($(CONFIG_DM), y)
-CFLAGS += -I$(TOPDIR)/../framework/include/dm
 include src$(DELIM)dm$(DELIM)Make.defs
 endif
 

--- a/framework/src/dm/dm_lwm2m.c
+++ b/framework/src/dm/dm_lwm2m.c
@@ -27,7 +27,6 @@
  * @brief device management APIs for DM
  */
 
-#include "dm_lwm2m.h"
 #include "lwm2mclient.h"
 #include "connectivity_interface.h"
 #include "internals.h"
@@ -35,8 +34,8 @@
 #include <sched.h>
 #include <sys/types.h>
 
-#include "dm_lwm2m.h"
-#include "dm_error.h"
+#include <dm/dm_lwm2m.h>
+#include <dm/dm_error.h>
 
 static pthread_t wakaama_thread;
 static pthread_attr_t wakaama_attr;


### PR DESCRIPTION
- Edit the compile option not to find the header file directory and use the original one as other framework modules do.