### PR TITLE
external/wpa_supplicant/src/utils/os_tinyara.c: fix misplaced parentheses

### DIFF
--- a/external/wpa_supplicant/src/utils/os_tinyara.c
+++ b/external/wpa_supplicant/src/utils/os_tinyara.c
@@ -155,7 +155,7 @@ static int os_daemon(int nochdir, int noclose)
 		exit(EXIT_SUCCESS);
 	}
 
-	if (((nochdir == 0) && (chdir("/"))) < 0) {
+	if ((nochdir == 0) && (chdir("/") < 0)) {
 		exit(EXIT_FAILURE);
 	}
 


### PR DESCRIPTION
Comparison should be performed on return value of call to chdir.