### PR TITLE
testcase/mqtt_itc : fix coding rule error - space is needed before '='

### DIFF
--- a/apps/examples/testcase/ta_tc/mqtt/itc/itc_mqtt_main.c
+++ b/apps/examples/testcase/ta_tc/mqtt/itc/itc_mqtt_main.c
@@ -151,7 +151,7 @@ static void on_unsubscribe(void *client, int msg_id)
  * pre-initialization functions
  ****************************************************************************************/
 
-static mqtt_client_config_t g_mqtt_client_config= {
+static mqtt_client_config_t g_mqtt_client_config = {
 	ITC_SUB_PUB_ID,
 	"", "", 1, 3, 0, 0,
 	on_connect,


### PR DESCRIPTION
[SPC_M_OPR] spaces required around that '=' (ctx:VxW)