### PR TITLE
doxygen : Add include path, brief desc and missing param name and fix…

### DIFF
--- a/os/include/assert.h
+++ b/os/include/assert.h
@@ -117,7 +117,8 @@
 /**
  * @brief Assert if the condition is not true
  *
- * @param[in] assertion condition which shall have a scalar type
+ * @details @b #include <assert.h>
+ * @param[in] f assertion condition which shall have a scalar type
  * @return none
  * @since Tizen RT v1.0
  */
@@ -125,7 +126,8 @@
 /**
  * @brief Assert if a function returns a negative value
  *
- * @param[in] assertion condition which shall have a scalar type
+ * @details @b #include <assert.h>
+ * @param[in] f assertion condition which shall have a scalar type
  * @return none
  * @since Tizen RT v1.0
  */
@@ -133,6 +135,7 @@
 /**
  * @brief Unconditional abort
  *
+ * @details @b #include <assert.h>
  * @return none
  * @since Tizen RT v1.0
  */
@@ -143,7 +146,8 @@
 /**
  * @brief Like ASSERT, but only if CONFIG_DEBUG is defined
  *
- * @param[in] assertion condition which shall have a scalar type
+ * @details @b #include <assert.h>
+ * @param[in] f assertion condition which shall have a scalar type
  * @return none
  * @since Tizen RT v1.0
  */
@@ -151,7 +155,8 @@
 /**
  * @brief Like VERIFY, but only if CONFIG_DEBUG is defined
  *
- * @param[in] assertion condition which shall have a scalar type
+ * @details @b #include <assert.h>
+ * @param[in] f assertion condition which shall have a scalar type
  * @return none
  * @since Tizen RT v1.0
  */
@@ -159,6 +164,7 @@
 /**
  * @brief Like PANIC, but only if CONFIG_DEBUG is defined
  *
+ * @details @b #include <assert.h>
  * @return none
  * @since Tizen RT v1.0
  */

--- a/os/include/crc16.h
+++ b/os/include/crc16.h
@@ -80,9 +80,10 @@ extern "C" {
 /**
  * @brief  Continue CRC calculation on a part of the buffer.
  *
- * @param[in] source number for crc16
- * @param[in] length for calculation
- * @param[in] value for calculation
+ * @details @b #include <crc16.h>
+ * @param[in] src source number for crc16
+ * @param[in] len length for calculation
+ * @param[in] crc16val value for calculation
  * @return On success, calculated 16-bit CRC is returned.
  * @since Tizen RT v1.0
  */
@@ -92,8 +93,9 @@ uint16_t crc16part(FAR const uint8_t *src, size_t len, uint16_t crc16val);
 /**
  * @brief  Return a 16-bit CRC of the contents of the 'src' buffer, length 'len'
  *
- * @param[in] source number for crc16
- * @param[in] length for calculation
+ * @details @b #include <crc16.h>
+ * @param[in] src source number for crc16
+ * @param[in] len length for calculation
  * @return On success, calculated 16-bit CRC is returned.
  * @since Tizen RT v1.0
  */

--- a/os/include/crc32.h
+++ b/os/include/crc32.h
@@ -80,9 +80,10 @@ extern "C" {
 /**
  * @brief  Continue CRC calculation on a part of the buffer.
  *
- * @param[in] source number for crc32
- * @param[in] length for calculation
- * @param[in] value for calculation
+ * @details @b #include <crc32.h>
+ * @param[in] src source number for crc32
+ * @param[in] len length for calculation
+ * @param[in] crc32val value for calculation
  * @return On success, calculated 32-bit CRC is returned.
  * @since Tizen RT v1.0
  */
@@ -92,8 +93,9 @@ uint32_t crc32part(FAR const uint8_t *src, size_t len, uint32_t crc32val);
 /**
  * @brief  Return a 32-bit CRC of the contents of the 'src' buffer, length 'len'
  *
- * @param[in] source number for crc32
- * @param[in] length for calculation
+ * @details @b #include <crc32.h>
+ * @param[in] src source number for crc32
+ * @param[in] len length for calculation
  * @return On success, calculated 16-bit CRC is returned.
  * @since Tizen RT v1.0
  */

--- a/os/include/crc8.h
+++ b/os/include/crc8.h
@@ -84,9 +84,10 @@ extern "C" {
 /**
  * @brief  Continue CRC calculation on a part of the buffer.
  *
- * @param[in] source number for crc8
- * @param[in] length for calculation
- * @param[in] value for calculation
+ * @details @b #include <crc8.h>
+ * @param[in] src source number for crc8
+ * @param[in] len length for calculation
+ * @param[in] crc8val value for calculation
  * @return On success, calculated 8-bit CRC is returned.
  * @since Tizen RT v1.0
  */
@@ -96,8 +97,9 @@ uint8_t crc8part(FAR const uint8_t *src, size_t len, uint8_t crc8val);
  * @brief  Return an 8-bit CRC of the contents of the 'src' buffer, length 'len'
  *   using the polynomial x^8+x^6+x^3+x^2+1 (Koopman, et al. "0xA6" poly).
  *
- * @param[in] source number for crc8
- * @param[in] length for calculation
+ * @details @b #include <crc8.h>
+ * @param[in] src source number for crc8
+ * @param[in] len length for calculation
  * @return On success, calculated 8-bit CRC is returned.
  * @since Tizen RT v1.0
  */

--- a/os/include/debug.h
+++ b/os/include/debug.h
@@ -150,6 +150,7 @@ Once LOGM is approved, each module should have its own index
 #else
 /**
  * @brief  Error debug
+ * @details @b #include <debug.h>
  * @since Tizen RT v1.0
  */
 #define dbg(format, ...) \
@@ -160,6 +161,7 @@ Once LOGM is approved, each module should have its own index
 #ifdef CONFIG_ARCH_LOWPUTC
 /**
  * @brief  Error debug for low-level
+ * @details @b #include <debug.h>
  * @since Tizen RT v1.0
  */
 #define lldbg(format, ...) \
@@ -185,6 +187,7 @@ Once LOGM is approved, each module should have its own index
 #else
 /**
  * @brief  Warning debug
+ * @details @b #include <debug.h>
  * @since Tizen RT v1.0
  */
 #define wdbg(format, ...) \
@@ -193,6 +196,7 @@ Once LOGM is approved, each module should have its own index
 #ifdef CONFIG_ARCH_LOWPUTC
 /**
  * @brief  Warning debug for low-level
+ * @details @b #include <debug.h>
  * @since Tizen RT v1.0
  */
 #define llwdbg(format, ...) \
@@ -218,6 +222,7 @@ Once LOGM is approved, each module should have its own index
 #else
 /**
  * @brief  Informational(Verbose) debug
+ * @details @b #include <debug.h>
  * @since Tizen RT v1.0
  */
 #define vdbg(format, ...) \
@@ -226,6 +231,7 @@ Once LOGM is approved, each module should have its own index
 #ifdef CONFIG_ARCH_LOWPUTC
 /**
  * @brief  Informational(Verbose) debug for low-level
+ * @details @b #include <debug.h>
  * @since Tizen RT v1.0
  */
 #define llvdbg(format, ...) \
@@ -1133,9 +1139,10 @@ extern "C" {
  * @ingroup DEBUG_KERNEL
  * @brief  Dump a buffer of data
  *
- * @param[in] message for buffer dump
- * @param[in] buffer
- * @param[in] length for buffer
+ * @details @b #include <debug.h>
+ * @param[in] msg message for buffer dump
+ * @param[in] buffer buffer
+ * @param[in] buflen length for buffer
  * @return void
  * @since Tizen RT v1.1
  */

--- a/os/include/dirent.h
+++ b/os/include/dirent.h
@@ -128,50 +128,62 @@ extern "C" {
 
 /**
  * @ingroup DIRENT_KERNEL
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
- * @details SYSTEM CALL API
+ * @brief close a directory stream
+ * @details @b #include <dirent.h> \n
+ * SYSTEM CALL API \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int closedir(FAR DIR *dirp);
 /**
  * @ingroup DIRENT_KERNEL
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
- * @details SYSTEM CALL API
+ * @brief open directory associated with file descriptor
+ * @details @b #include <dirent.h> \n
+ * SYSTEM CALL API \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 FAR DIR *opendir(FAR const char *path);
 /**
  * @ingroup DIRENT_KERNEL
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
- * @details SYSTEM CALL API
+ * @brief read a directory
+ * @details @b #include <dirent.h> \n
+ * SYSTEM CALL API \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 FAR struct dirent *readdir(FAR DIR *dirp);
 /**
  * @ingroup DIRENT_KERNEL
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief read a directory
+ * @details @b #include <dirent.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int readdir_r(FAR DIR *dirp, FAR struct dirent *entry, FAR struct dirent **result);
 /**
  * @ingroup DIRENT_KERNEL
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
- * @details SYSTEM CALL API
+ * @brief reset the position of a directory stream to the beginning of a directory
+ * @details @b #include <dirent.h> \n
+ * SYSTEM CALL API \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 void rewinddir(FAR DIR *dirp);
 /**
  * @ingroup DIRENT_KERNEL
  * @brief sets the location in the directory stream from which the next readdir() call will start.
- * @param[in] An instance of type DIR.
- * @param[in] offset to seek.
+ * @details @b #include <dirent.h>
+ * @param[in] dirp An instance of type DIR.
+ * @param[in] loc offset to seek.
  * @since Tizen RT v1.0
  */
 void seekdir(FAR DIR *dirp, off_t loc);
 /**
  * @ingroup DIRENT_KERNEL
  * @brief gets the current location associated with the directory stream
- * @param[in] An instance of type DIR
+ * @details @b #include <dirent.h>
+ * @param[in] dirp An instance of type DIR
  * @return On success, the current location in the directory stream is returned. On failure, -1 is returned and errno is set appropriately.
  * @since Tizen RT v1.0
  */

--- a/os/include/errno.h
+++ b/os/include/errno.h
@@ -435,6 +435,7 @@ extern "C" {
 
 /**
  * @brief Return a pointer to the thread specific errno.
+ * @details @b #include <errno.h>
  * @return A pointer to the per-thread errno variable is returned.
  * @since Tizen RT v1.0
  */
@@ -443,7 +444,8 @@ FAR int *get_errno_ptr(void);
 #ifndef __DIRECT_ERRNO_ACCESS
 /**
  * @brief Set the value of the thread specific errno.
- * @details SYSTEM CALL API
+ * @details @b #include <errno.h> \n
+ * SYSTEM CALL API
  * @param[in] errcode The thread specific errno will be set to this error code value.
  * @return none
  * @since Tizen RT v1.0
@@ -452,7 +454,8 @@ void set_errno(int errcode);
 
 /**
  * @brief Return the value of the thread specific errno.
- * @details SYSTEM CALL API
+ * @details @b #include <errno.h> \n
+ * SYSTEM CALL API
  * @return The current value of the thread specific errno is returned.
  * @since Tizen RT v1.0
  */

--- a/os/include/fcntl.h
+++ b/os/include/fcntl.h
@@ -195,15 +195,19 @@ extern "C" {
 /* POSIX-like File System Interfaces */
 /**
  * @ingroup FCNTL_KERNEL
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
- * @details SYSTEM CALL API
+ * @brief open file
+ * @details @b #include <fcntl.h> \n
+ * SYSTEM CALL API \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int open(const char *path, int oflag, ...);
 /**
  * @ingroup FCNTL_KERNEL
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
- * @details SYSTEM CALL API
+ * @brief file control
+ * @details @b #include <fcntl.h> \n
+ * SYSTEM CALL API \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int fcntl(int fd, int cmd, ...);

--- a/os/include/fixedmath.h
+++ b/os/include/fixedmath.h
@@ -241,18 +241,18 @@ extern "C" {
 /* Multiplication operators */
 /**
  * @brief multiply two b16 numbers
- * @todo
- * @param[in] first operand
- * @param[in] second operand
+ * @details @b #include <fixedmath.h>
+ * @param[in] m1 first operand
+ * @param[in] m2 second operand
  * @return the result of two multiplication
  * @since Tizen RT v1.1
  */
 b16_t b16mulb16(b16_t m1, b16_t m2);
 /**
  * @brief multiply two unsigned b16 numbers
- * @todo
- * @param[in] first operand
- * @param[in] second operand
+ * @details @b #include <fixedmath.h>
+ * @param[in] m1 first operand
+ * @param[in] m2 second operand
  * @return the result of two multiplication
  * @since Tizen RT v1.1
  */
@@ -261,16 +261,16 @@ ub16_t ub16mulub16(ub16_t m1, ub16_t m2);
 /* Square operators */
 /**
  * @brief square b16 number
- * @todo
- * @param[in] first operand
+ * @details @b #include <fixedmath.h>
+ * @param[in] a first operand
  * @return the result of square
  * @since Tizen RT v1.1
  */
 b16_t b16sqr(b16_t a);
 /**
  * @brief square unsigned b16 number
- * @todo
- * @param[in] first operand
+ * @details @b #include <fixedmath.h>
+ * @param[in] a first operand
  * @return the result of square
  * @since Tizen RT v1.1
  */
@@ -279,18 +279,18 @@ ub16_t ub16sqr(ub16_t a);
 /* Division operators */
 /**
  * @brief divide operation
- * @todo
- * @param[in] a dividend
- * @param[in] a divisor
+ * @details @b #include <fixedmath.h>
+ * @param[in] num a dividend
+ * @param[in] denom a divisor
  * @return the result of divide
  * @since Tizen RT v1.1
  */
 b16_t b16divb16(b16_t num, b16_t denom);
 /**
  * @brief divide operation
- * @todo
- * @param[in] a dividend
- * @param[in] a divisor
+ * @details @b #include <fixedmath.h>
+ * @param[in] num a dividend
+ * @param[in] denom a divisor
  * @return the result of divide
  * @since Tizen RT v1.1
  */
@@ -300,26 +300,26 @@ ub16_t ub16divub16(ub16_t num, ub16_t denom);
 /* Trigonometric Functions */
 /**
  * @brief Trigonometric sine operation
- * @todo
- * @param[in] a radian value
+ * @details @b #include <fixedmath.h>
+ * @param[in] rad a radian value
  * @return the result of sine operation
  * @since Tizen RT v1.1
  */
 b16_t b16sin(b16_t rad);
 /**
  * @brief Trigonometric cosine operation
- * @todo
- * @param[in] a radian value
+ * @details @b #include <fixedmath.h>
+ * @param[in] rad a radian value
  * @return the result of cosine operation
  * @since Tizen RT v1.1
  */
 b16_t b16cos(b16_t rad);
 /**
  * @brief Trigonometric tangent operation
- * @details calculates the arctangent of y/x
- * @todo
- * @param[in] a radian y value
- * @param[in] a radian x value
+ * @details @b #include <fixedmath.h> \n
+ * calculates the arctangent of y/x
+ * @param[in] y a radian y value
+ * @param[in] x a radian x value
  * @return the result of tangent operation
  * @since Tizen RT v1.1
  */

--- a/os/include/inttypes.h
+++ b/os/include/inttypes.h
@@ -201,7 +201,9 @@ extern "C" {
  */
 
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief return absolute value
+ * @details @b #include <inttypes.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 intmax_t imaxabs(intmax_t);

--- a/os/include/libgen.h
+++ b/os/include/libgen.h
@@ -82,12 +82,16 @@ extern "C" {
 #define EXTERN extern
 #endif
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief return the last component of a pathname
+ * @details @b #include <libgen.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 FAR char *basename(FAR char *path);
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief return the directory portion of a pathname
+ * @details @b #include <libgen.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 FAR char *dirname(FAR char *path);

--- a/os/include/mqueue.h
+++ b/os/include/mqueue.h
@@ -110,61 +110,81 @@ extern "C" {
  * Public Function Prototypes
  ********************************************************************************/
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
- * @details SYSTEM CALL API
+ * @brief open a message queue
+ * @details @b #include <mqueue.h> \n
+ * SYSTEM CALL API \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 mqd_t mq_open(FAR const char *mq_name, int oflags, ...);
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
- * @details SYSTEM CALL API
+ * @brief close a message queue
+ * @details @b #include <mqueue.h> \n
+ * SYSTEM CALL API \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int mq_close(mqd_t mqdes);
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
- * @details SYSTEM CALL API
+ * @brief remove a message queue
+ * @details @b #include <mqueue.h> \n
+ * SYSTEM CALL API \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int mq_unlink(FAR const char *mq_name);
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
- * @details SYSTEM CALL API
+ * @brief send a message to a message queue
+ * @details @b #include <mqueue.h> \n
+ * SYSTEM CALL API \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int mq_send(mqd_t mqdes, FAR const char *msg, size_t msglen, int prio);
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
- * @details SYSTEM CALL API
+ * @brief send a message to a message queue
+ * @details @b #include <mqueue.h> \n
+ * SYSTEM CALL API \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int mq_timedsend(mqd_t mqdes, FAR const char *msg, size_t msglen, int prio, FAR const struct timespec *abstime);
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
- * @details SYSTEM CALL API
+ * @brief receive a message from a message queue
+ * @details @b #include <mqueue.h> \n
+ * SYSTEM CALL API \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 ssize_t mq_receive(mqd_t mqdes, FAR char *msg, size_t msglen, FAR int *prio);
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
- * @details SYSTEM CALL API
+ * @brief receive a message from a message queue
+ * @details @b #include <mqueue.h> \n
+ * SYSTEM CALL API \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 ssize_t mq_timedreceive(mqd_t mqdes, FAR char *msg, size_t msglen, FAR int *prio, FAR const struct timespec *abstime);
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
- * @details SYSTEM CALL API
+ * @brief notify process that a message is available
+ * @details @b #include <mqueue.h> \n
+ * SYSTEM CALL API \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int mq_notify(mqd_t mqdes, const struct sigevent *notification);
 
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief set message queue attributes
+ * @details @b #include <mqueue.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int mq_setattr(mqd_t mqdes, FAR const struct mq_attr *mq_stat, FAR struct mq_attr *oldstat);
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief get message queue attributes
+ * @details @b #include <mqueue.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int mq_getattr(mqd_t mqdes, FAR struct mq_attr *mq_stat);

--- a/os/include/pthread.h
+++ b/os/include/pthread.h
@@ -213,8 +213,9 @@
 /**
  * @ingroup PTHREAD_KERNEL
  * @brief sets the name of pthread
- * @param[in] pid of pthread
- * @param[in] name for setting
+ * @details @b #include <pthread.h>
+ * @param[in] thread pid of pthread
+ * @param[in] name name for setting
  * @return On success, OK is returned. On failure, ERROR is returned and errno is set appropriately.
  * @since Tizen RT v1.0
  */
@@ -224,8 +225,9 @@
 /**
  * @ingroup PTHREAD_KERNEL
  * @brief gets the name of pthread
- * @param[in] pid of pthread
- * @param[in] space for saving pthread name
+ * @details @b #include <pthread.h>
+ * @param[in] thread pid of pthread
+ * @param[in] name space for saving pthread name
  * @return On success, OK is returned. On failure, ERROR is returned and errno is set appropriately.
  * @since Tizen RT v1.0
  */
@@ -423,8 +425,10 @@ struct sched_param;			/* Defined in sched.h */
 
 /**
  * @ingroup PTHREAD_KERNEL
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
- * @details SYSTEM CALL API
+ * @brief thread creation
+ * @details @b #include <pthread.h> \n
+ * SYSTEM CALL API \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int pthread_create(FAR pthread_t *thread, FAR const pthread_attr_t *attr, pthread_startroutine_t startroutine, pthread_addr_t arg);
@@ -434,8 +438,10 @@ int pthread_create(FAR pthread_t *thread, FAR const pthread_attr_t *attr, pthrea
  */
 /**
  * @ingroup PTHREAD_KERNEL
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
- * @details SYSTEM CALL API
+ * @brief detach a thread
+ * @details @b #include <pthread.h> \n
+ * SYSTEM CALL API \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int pthread_detach(pthread_t thread);
@@ -445,35 +451,45 @@ int pthread_detach(pthread_t thread);
  */
 /**
  * @ingroup PTHREAD_KERNEL
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
- * @details SYSTEM CALL API
+ * @brief thread termination
+ * @details @b #include <pthread.h> \n
+ * SYSTEM CALL API \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 void pthread_exit(pthread_addr_t value) noreturn_function;
 /**
  * @ingroup PTHREAD_KERNEL
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
- * @details SYSTEM CALL API
+ * @brief cancel execution of a thread
+ * @details @b #include <pthread.h> \n
+ * SYSTEM CALL API \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int pthread_cancel(pthread_t thread);
 /**
  * @ingroup PTHREAD_KERNEL
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
- * @details SYSTEM CALL API
+ * @brief set cancelability state
+ * @details @b #include <pthread.h> \n
+ * SYSTEM CALL API \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int pthread_setcancelstate(int state, FAR int *oldstate);
 /**
  * @ingroup PTHREAD_KERNEL
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief set cancelability state
+ * @details @b #include <pthread.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 int pthread_setcanceltype(int type, FAR int *oldtype);
 
 /**
  * @ingroup PTHREAD_KERNEL
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief set cancelability state
+ * @details @b #include <pthread.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 void pthread_testcancel(void);
@@ -490,8 +506,10 @@ void pthread_cleanup_push(pthread_cleanup_t routine, FAR void *arg);
 
 /**
  * @ingroup PTHREAD_KERNEL
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
- * @details SYSTEM CALL API
+ * @brief wait for thread termination
+ * @details @b #include <pthread.h> \n
+ * SYSTEM CALL API \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int pthread_join(pthread_t thread, FAR pthread_addr_t *value);
@@ -499,8 +517,10 @@ int pthread_join(pthread_t thread, FAR pthread_addr_t *value);
 /* A thread may tell the scheduler that its processor can be made available. */
 /**
  * @ingroup PTHREAD_KERNEL
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
- * @details SYSTEM CALL API
+ * @brief yield the processor
+ * @details @b #include <pthread.h> \n
+ * SYSTEM CALL API \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 void pthread_yield(void);
@@ -508,8 +528,10 @@ void pthread_yield(void);
 /* A thread may obtain a copy of its own thread handle. */
 /**
  * @ingroup PTHREAD_KERNEL
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
- * @details SYSTEM CALL API
+ * @brief get the calling thread ID
+ * @details @b #include <pthread.h> \n
+ * SYSTEM CALL API \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 #define pthread_self() ((pthread_t)getpid())
@@ -517,8 +539,10 @@ void pthread_yield(void);
 /* Compare two thread IDs. */
 /**
  * @ingroup PTHREAD_KERNEL
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
- * @details SYSTEM CALL API
+ * @brief compare thread IDs
+ * @details @b #include <pthread.h> \n
+ * SYSTEM CALL API \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 #define pthread_equal(t1, t2) ((t1) == (t2))
@@ -526,21 +550,27 @@ void pthread_yield(void);
 /* Thread scheduling parameters */
 /**
  * @ingroup PTHREAD_KERNEL
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
- * @details SYSTEM CALL API
+ * @brief dynamic thread scheduling parameters access
+ * @details @b #include <pthread.h> \n
+ * SYSTEM CALL API \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int pthread_getschedparam(pthread_t thread, FAR int *policy, FAR struct sched_param *param);
 /**
  * @ingroup PTHREAD_KERNEL
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
- * @details SYSTEM CALL API
+ * @brief dynamic thread scheduling parameters access
+ * @details @b #include <pthread.h> \n
+ * SYSTEM CALL API \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int pthread_setschedparam(pthread_t thread, int policy, FAR const struct sched_param *param);
 /**
  * @ingroup PTHREAD_KERNEL
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief dynamic thread scheduling parameters access
+ * @details @b #include <pthread.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int pthread_setschedprio(pthread_t thread, int prio);
@@ -548,22 +578,28 @@ int pthread_setschedprio(pthread_t thread, int prio);
 /* Thread-specific Data Interfaces */
 /**
  * @ingroup PTHREAD_KERNEL
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
- * @details SYSTEM CALL API
+ * @brief thread-specific data key creation
+ * @details @b #include <pthread.h> \n
+ * SYSTEM CALL API \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int pthread_key_create(FAR pthread_key_t *key, CODE void (*destructor)(FAR void *));
 /**
  * @ingroup PTHREAD_KERNEL
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
- * @details SYSTEM CALL API
+ * @brief thread-specific data management
+ * @details @b #include <pthread.h> \n
+ * SYSTEM CALL API \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int pthread_setspecific(pthread_key_t key, FAR const void *value);
 /**
  * @ingroup PTHREAD_KERNEL
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
- * @details SYSTEM CALL API
+ * @brief thread-specific data management
+ * @details @b #include <pthread.h> \n
+ * SYSTEM CALL API \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 FAR void *pthread_getspecific(pthread_key_t key);
@@ -580,36 +616,46 @@ int pthread_key_delete(pthread_key_t key);
 
 /**
  * @ingroup PTHREAD_KERNEL
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
- * @details SYSTEM CALL API
+ * @brief initialize a mutex
+ * @details @b #include <pthread.h> \n
+ * SYSTEM CALL API \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int pthread_mutex_init(FAR pthread_mutex_t *mutex, FAR const pthread_mutexattr_t *attr);
 /**
  * @ingroup PTHREAD_KERNEL
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
- * @details SYSTEM CALL API
+ * @brief destroy a mutex
+ * @details @b #include <pthread.h> \n
+ * SYSTEM CALL API \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int pthread_mutex_destroy(FAR pthread_mutex_t *mutex);
 /**
  * @ingroup PTHREAD_KERNEL
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
- * @details SYSTEM CALL API
+ * @brief lock a mutex
+ * @details @b #include <pthread.h> \n
+ * SYSTEM CALL API \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int pthread_mutex_lock(FAR pthread_mutex_t *mutex);
 /**
  * @ingroup PTHREAD_KERNEL
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
- * @details SYSTEM CALL API
+ * @brief try to lock a mutex
+ * @details @b #include <pthread.h> \n
+ * SYSTEM CALL API \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int pthread_mutex_trylock(FAR pthread_mutex_t *mutex);
 /**
  * @ingroup PTHREAD_KERNEL
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
- * @details SYSTEM CALL API
+ * @brief unlock a mutex
+ * @details @b #include <pthread.h> \n
+ * SYSTEM CALL API \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int pthread_mutex_unlock(FAR pthread_mutex_t *mutex);
@@ -617,15 +663,19 @@ int pthread_mutex_unlock(FAR pthread_mutex_t *mutex);
 /* A thread can create and delete condition variables. */
 /**
  * @ingroup PTHREAD_KERNEL
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
- * @details SYSTEM CALL API
+ * @brief initialize condition variables
+ * @details @b #include <pthread.h> \n
+ * SYSTEM CALL API \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int pthread_cond_init(FAR pthread_cond_t *cond, FAR const pthread_condattr_t *attr);
 /**
  * @ingroup PTHREAD_KERNEL
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
- * @details SYSTEM CALL API
+ * @brief destroy condition variables
+ * @details @b #include <pthread.h> \n
+ * SYSTEM CALL API \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int pthread_cond_destroy(FAR pthread_cond_t *cond);
@@ -633,15 +683,19 @@ int pthread_cond_destroy(FAR pthread_cond_t *cond);
 /* A thread can signal to and broadcast on a condition variable. */
 /**
  * @ingroup PTHREAD_KERNEL
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
- * @details SYSTEM CALL API
+ * @brief broadcast a condition
+ * @details @b #include <pthread.h> \n
+ * SYSTEM CALL API \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int pthread_cond_broadcast(FAR pthread_cond_t *cond);
 /**
  * @ingroup PTHREAD_KERNEL
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
- * @details SYSTEM CALL API
+ * @brief signal a condition
+ * @details @b #include <pthread.h> \n
+ * SYSTEM CALL API \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int pthread_cond_signal(FAR pthread_cond_t *cond);
@@ -649,8 +703,10 @@ int pthread_cond_signal(FAR pthread_cond_t *cond);
 /* A thread can wait for a condition variable to be signalled or broadcast. */
 /**
  * @ingroup PTHREAD_KERNEL
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
- * @details SYSTEM CALL API
+ * @brief wait on a condition
+ * @details @b #include <pthread.h> \n
+ * SYSTEM CALL API \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int pthread_cond_wait(FAR pthread_cond_t *cond, FAR pthread_mutex_t *mutex);
@@ -658,8 +714,10 @@ int pthread_cond_wait(FAR pthread_cond_t *cond, FAR pthread_mutex_t *mutex);
 /* A thread can perform a timed wait on a condition variable. */
 /**
  * @ingroup PTHREAD_KERNEL
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
- * @details SYSTEM CALL API
+ * @brief wait on a condition
+ * @details @b #include <pthread.h> \n
+ * SYSTEM CALL API \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int pthread_cond_timedwait(FAR pthread_cond_t *cond, FAR pthread_mutex_t *mutex, FAR const struct timespec *abstime);
@@ -667,22 +725,28 @@ int pthread_cond_timedwait(FAR pthread_cond_t *cond, FAR pthread_mutex_t *mutex,
 /* Barriers */
 /**
  * @ingroup PTHREAD_KERNEL
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
- * @details SYSTEM CALL API
+ * @brief destroy a barrier object
+ * @details @b #include <pthread.h> \n
+ * SYSTEM CALL API \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int pthread_barrier_destroy(FAR pthread_barrier_t *barrier);
 /**
  * @ingroup PTHREAD_KERNEL
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
- * @details SYSTEM CALL API
+ * @brief initialize a barrier object
+ * @details @b #include <pthread.h> \n
+ * SYSTEM CALL API \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int pthread_barrier_init(FAR pthread_barrier_t *barrier, FAR const pthread_barrierattr_t *attr, unsigned int count);
 /**
  * @ingroup PTHREAD_KERNEL
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
- * @details SYSTEM CALL API
+ * @brief synchronize at a barrier
+ * @details @b #include <pthread.h> \n
+ * SYSTEM CALL API \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int pthread_barrier_wait(FAR pthread_barrier_t *barrier);
@@ -690,8 +754,10 @@ int pthread_barrier_wait(FAR pthread_barrier_t *barrier);
 /* Pthread initialization */
 /**
  * @ingroup PTHREAD_KERNEL
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
- * @details SYSTEM CALL API
+ * @brief dynamic package initialization
+ * @details @b #include <pthread.h> \n
+ * SYSTEM CALL API \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int pthread_once(FAR pthread_once_t *once_control, CODE void (*init_routine)(void));
@@ -699,15 +765,19 @@ int pthread_once(FAR pthread_once_t *once_control, CODE void (*init_routine)(voi
 /* Pthread signal management APIs */
 /**
  * @ingroup PTHREAD_KERNEL
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
- * @details SYSTEM CALL API
+ * @brief send a signal to a thread
+ * @details @b #include <pthread.h> \n
+ * SYSTEM CALL API \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int pthread_kill(pthread_t thread, int sig);
 /**
  * @ingroup PTHREAD_KERNEL
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
- * @details SYSTEM CALL API
+ * @brief examine and change blocked signals
+ * @details @b #include <pthread.h> \n
+ * SYSTEM CALL API \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int pthread_sigmask(int how, FAR const sigset_t *set, FAR sigset_t *oset);
@@ -717,7 +787,9 @@ int pthread_sigmask(int how, FAR const sigset_t *set, FAR sigset_t *oset);
  * @{
  */
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief initialize the thread attributes object
+ * @details @b #include <pthread.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int pthread_attr_init(FAR pthread_attr_t *attr);
@@ -725,7 +797,9 @@ int pthread_attr_init(FAR pthread_attr_t *attr);
 /* An attributes object can be deleted when it is no longer needed. */
 
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief destroy the thread attributes object
+ * @details @b #include <pthread.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int pthread_attr_destroy(pthread_attr_t *attr);
@@ -733,100 +807,136 @@ int pthread_attr_destroy(pthread_attr_t *attr);
 /* Set or obtain the default scheduling algorithm */
 
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief set the schedpolicy attribute
+ * @details @b #include <pthread.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int pthread_attr_setschedpolicy(FAR pthread_attr_t *attr, int policy);
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief get the schedpolicy attribute
+ * @details @b #include <pthread.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int pthread_attr_getschedpolicy(FAR const pthread_attr_t *attr, int *policy);
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief set the schedparam attribute
+ * @details @b #include <pthread.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int pthread_attr_setschedparam(FAR pthread_attr_t *attr, FAR const struct sched_param *param);
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief get the schedparam attribute
+ * @details @b #include <pthread.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int pthread_attr_getschedparam(FAR const pthread_attr_t *attr, FAR struct sched_param *param);
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief set the inheritsched attribute
+ * @details @b #include <pthread.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int pthread_attr_setinheritsched(FAR pthread_attr_t *attr, int inheritsched);
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief get the inheritsched attribute
+ * @details @b #include <pthread.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int pthread_attr_getinheritsched(FAR const pthread_attr_t *attr, FAR int *inheritsched);
 
 /* Set or obtain the default stack size */
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief set the stacksize attribute
+ * @details @b #include <pthread.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int pthread_attr_setstacksize(FAR pthread_attr_t *attr, long stacksize);
 
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief get the stacksize attribute
+ * @details @b #include <pthread.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int pthread_attr_getstacksize(FAR const pthread_attr_t *attr, long *stackaddr);
 
 /* Create, operate on, and destroy mutex attributes. */
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief initialize the mutex attributes object
+ * @details @b #include <pthread.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int pthread_mutexattr_init(FAR pthread_mutexattr_t *attr);
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief destroy the mutex attributes object
+ * @details @b #include <pthread.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int pthread_mutexattr_destroy(FAR pthread_mutexattr_t *attr);
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief get the process-shared attribute
+ * @details @b #include <pthread.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int pthread_mutexattr_getpshared(FAR const pthread_mutexattr_t *attr, FAR int *pshared);
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief set the process-shared attribute
+ * @details @b #include <pthread.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int pthread_mutexattr_setpshared(FAR pthread_mutexattr_t *attr, int pshared);
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief get the mutex type attribute
+ * @details @b #include <pthread.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int pthread_mutexattr_gettype(const pthread_mutexattr_t *attr, int *type);
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief set the mutex type attribute
+ * @details @b #include <pthread.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int pthread_mutexattr_settype(pthread_mutexattr_t *attr, int type);
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief get the protocol attribute of the mutex attributes object
+ * @details @b #include <pthread.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 int pthread_mutexattr_getprotocol(FAR const pthread_mutexattr_t *attr,
 				  FAR int *protocol);
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief set the protocol attribute of the mutex attributes object
+ * @details @b #include <pthread.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 int pthread_mutexattr_setprotocol(FAR pthread_mutexattr_t *attr,
 				  int protocol);
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief get the mutex robust attribute
+ * @details @b #include <pthread.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 int pthread_mutexattr_getrobust(FAR const pthread_mutexattr_t *attr,
 				FAR int *robust);
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief set the mutex robust attribute
+ * @details @b #include <pthread.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 int pthread_mutexattr_setrobust(FAR pthread_mutexattr_t *attr,
@@ -834,34 +944,46 @@ int pthread_mutexattr_setrobust(FAR pthread_mutexattr_t *attr,
 
 /* Operations on condition variables */
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief initialize the condition variable attributes object
+ * @details @b #include <pthread.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int pthread_condattr_init(FAR pthread_condattr_t *attr);
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief destroy the condition variable attributes object
+ * @details @b #include <pthread.h>
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int pthread_condattr_destroy(FAR pthread_condattr_t *attr);
 
 /* Barrier attributes */
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief destroy the barrier attributes object
+ * @details @b #include <pthread.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int pthread_barrierattr_destroy(FAR pthread_barrierattr_t *attr);
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief initialize the barrier attributes object
+ * @details @b #include <pthread.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int pthread_barrierattr_init(FAR pthread_barrierattr_t *attr);
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief get the process-shared attribute of the barrier attributes object
+ * @details @b #include <pthread.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int pthread_barrierattr_getpshared(FAR const pthread_barrierattr_t *attr, FAR int *pshared);
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief set the process-shared attribute of the barrier attributes object
+ * @details @b #include <pthread.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int pthread_barrierattr_setpshared(FAR pthread_barrierattr_t *attr, int pshared);
@@ -869,47 +991,65 @@ int pthread_barrierattr_setpshared(FAR pthread_barrierattr_t *attr, int pshared)
 /* Pthread rwlock */
 
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief destroy a read-write lock object
+ * @details @b #include <pthread.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 int pthread_rwlock_destroy(FAR pthread_rwlock_t *rw_lock);
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief initialize a read-write lock object
+ * @details @b #include <pthread.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 int pthread_rwlock_init(FAR pthread_rwlock_t *rw_lock, FAR const pthread_rwlockattr_t *attr);
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief lock a read-write lock object for reading
+ * @details @b #include <pthread.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 int pthread_rwlock_rdlock(pthread_rwlock_t *lock);
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief lock a read-write lock for reading
+ * @details @b #include <pthread.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 int pthread_rwlock_timedrdlock(FAR pthread_rwlock_t *lock, FAR const struct timespec *abstime);
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief lock a read-write lock for writing
+ * @details @b #include <pthread.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 int pthread_rwlock_timedwrlock(FAR pthread_rwlock_t *lock, FAR const struct timespec *abstime);
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief lock a read-write lock object for reading
+ * @details @b #include <pthread.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 int pthread_rwlock_tryrdlock(FAR pthread_rwlock_t *lock);
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief lock a read-write lock object for reading
+ * @details @b #include <pthread.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 int pthread_rwlock_trywrlock(FAR pthread_rwlock_t *lock);
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief unlock a read-write lock object
+ * @details @b #include <pthread.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 int pthread_rwlock_unlock(FAR pthread_rwlock_t *lock);
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief lock a read-write lock object for writing
+ * @details @b #include <pthread.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 int pthread_rwlock_wrlock(FAR pthread_rwlock_t *lock);

--- a/os/include/queue.h
+++ b/os/include/queue.h
@@ -138,58 +138,65 @@ extern "C" {
 
 /**
  * @brief places the 'node' at the head of the 'queue'
- * @param[in] node to be added
- * @param[in] queue
+ * @details @b #include <queue.h>
+ * @param[in] node node to be added
+ * @param[in] queue queue
  * @return none
  * @since Tizen RT v1.0
  */
 void sq_addfirst(FAR sq_entry_t *node, FAR sq_queue_t *queue);
 /**
  * @brief adds 'node' at the beginning of 'queue'
- * @param[in] node to be added
- * @param[in] queue
+ * @details @b #include <queue.h>
+ * @param[in] node node to be added
+ * @param[in] queue queue
  * @return none
  * @since Tizen RT v1.0
  */
 void dq_addfirst(FAR dq_entry_t *node, FAR dq_queue_t *queue);
 /**
  * @brief places the 'node' at the tail of the 'queue'
- * @param[in] node to be added
- * @param[in] queue
+ * @details @b #include <queue.h>
+ * @param[in] node node to be added
+ * @param[in] queue queue
  * @return none
  * @since Tizen RT v1.0
  */
 void sq_addlast(FAR sq_entry_t *node, FAR sq_queue_t *queue);
 /**
  * @brief adds 'node' to the end of 'queue'
- * @param[in] node to be added
- * @param[in] queue
+ * @details @b #include <queue.h>
+ * @param[in] node node to be added
+ * @param[in] queue queue
  * @return none
  * @since Tizen RT v1.0
  */
 void dq_addlast(FAR dq_entry_t *node, FAR dq_queue_t *queue);
 /**
- * @brief adds 'node' after 'prev' in the 'queue.'
- * @param[in] node to be added
- * @param[in] queue
+ * @brief adds 'node' fter 'prev' in the 'queue.'
+ * @details @b #include <queue.h>
+ * @param[in] node node to be added
+ * @param[in] queue queue
  * @return none
  * @since Tizen RT v1.0
  */
 void sq_addafter(FAR sq_entry_t *prev, FAR sq_entry_t *node, FAR sq_queue_t *queue);
 /**
  * @brief adds 'node' after 'prev' in the 'queue.'
- * @param[in] node to be added
- * @param[in] prev node
- * @param[in] queue
+ * @details @b #include <queue.h>
+ * @param[in] prev prev node
+ * @param[in] node node to be added
+ * @param[in] queue queue
  * @return none
  * @since Tizen RT v1.0
  */
 void dq_addafter(FAR dq_entry_t *prev, FAR dq_entry_t *node, FAR dq_queue_t *queue);
 /**
  * @brief adds 'node' before 'next' in 'queue'
- * @param[in] next node
- * @param[in] node to be added
- * @param[in] queue
+ * @details @b #include <queue.h>
+ * @param[in] next next node
+ * @param[in] node node to be added
+ * @param[in] queue queue
  * @return none
  * @since Tizen RT v1.0
  */
@@ -197,52 +204,59 @@ void dq_addbefore(FAR dq_entry_t *next, FAR dq_entry_t *node, FAR dq_queue_t *qu
 
 /**
  * @brief  removes the entry following 'node
- * @param[in] node to be removed
- * @param[in] queue
+ * @details @b #include <queue.h>
+ * @param[in] node node to be removed
+ * @param[in] queue queue
  * @return a reference to the removed entry
  * @since Tizen RT v1.0
  */
 FAR sq_entry_t *sq_remafter(FAR sq_entry_t *node, FAR sq_queue_t *queue);
 /**
  * @brief  removes a 'node' for 'queue.'
- * @param[in] node to be removed
- * @param[in] queue
+ * @details @b #include <queue.h>
+ * @param[in] node node to be removed
+ * @param[in] queue queue
  * @return void
  * @since Tizen RT v1.0
  */
 void sq_rem(FAR sq_entry_t *node, FAR sq_queue_t *queue);
 /**
  * @brief  removes 'node' from 'queue'
- * @param[in] node to be removed
- * @param[in] queue
+ * @details @b #include <queue.h>
+ * @param[in] node node to be removed
+ * @param[in] queue queue
  * @return void
  * @since Tizen RT v1.0
  */
 void dq_rem(FAR dq_entry_t *node, FAR dq_queue_t *queue);
 /**
  * @brief  Removes the last entry in a singly-linked queue.
- * @param[in] singly-linked queue
+ * @details @b #include <queue.h>
+ * @param[in] queue singly-linked queue
  * @return node to be removed
  * @since Tizen RT v1.0
  */
 FAR sq_entry_t *sq_remlast(FAR sq_queue_t *queue);
 /**
  * @brief  removes the last entry from 'queue'
- * @param[in] singly-linked queue
+ * @details @b #include <queue.h>
+ * @param[in] queue singly-linked queue
  * @return node to be removed
  * @since Tizen RT v1.0
  */
 FAR dq_entry_t *dq_remlast(FAR dq_queue_t *queue);
 /**
  * @brief  removes the first entry from 'queue'
- * @param[in] singly-linked queue
+ * @details @b #include <queue.h>
+ * @param[in] queue singly-linked queue
  * @return node to be removed
  * @since Tizen RT v1.0
  */
 FAR sq_entry_t *sq_remfirst(FAR sq_queue_t *queue);
 /**
  * @brief  removes 'node' from the head of 'queue'
- * @param[in] singly-linked queue
+ * @details @b #include <queue.h>
+ * @param[in] queue singly-linked queue
  * @return node to be removed
  * @since Tizen RT v1.0
  */

--- a/os/include/sched.h
+++ b/os/include/sched.h
@@ -153,18 +153,19 @@ int task_activate(FAR struct tcb_s *tcb);
  * @ingroup SCHED_KERNEL
  * @brief  creates and activates a new task with a specified
  *   priority and returns its system-assigned ID.
- * @details SYSTEM CALL API
+ * @details @b #include <sched.h> \n
+ * SYSTEM CALL API
  *       The entry address entry is the address of the "main" function of the
  *   task.  This function will be called once the C environment has been
  *   set up.  The specified function will be called with four arguments.
  *   Should the specified routine return, a call to exit() will
  *   automatically be made.
  *
- * @param[in] Name of the new task
- * @param[in] Priority of the new task
- * @param[in] size (in bytes) of the stack needed
- * @param[in] Entry point of a new task
- * @param[in]  A pointer to an array of input parameters. Up to
+ * @param[in] name Name of the new task
+ * @param[in] priority Priority of the new task
+ * @param[in] stack_size size (in bytes) of the stack needed
+ * @param[in] entry Entry point of a new task
+ * @param[in] argv[] A pointer to an array of input parameters. Up to
  *                CONFIG_MAX_TASK_ARG parameters may be provided.  If fewer
  *                than CONFIG_MAX_TASK_ARG parameters are passed, the list
  *                should be terminated with a NULL argv[] value. If no
@@ -179,7 +180,8 @@ int task_create(FAR const char *name, int priority, int stack_size, main_t entry
 /**
  * @ingroup SCHED_KERNEL
  * @brief  causes a specified task to cease to exist.
- * @details SYSTEM CALL API
+ * @details @b #include <sched.h> \n
+ * SYSTEM CALL API
  *      Its  stack and TCB will be deallocated.  This function is
  *   the companion to task_create().
  *   This is the version of the function exposed to the user; it is simply
@@ -201,7 +203,7 @@ int task_create(FAR const char *name, int priority, int stack_size, main_t entry
  *   Other exit paths (exit(), _eixt(), and pthread_exit()) will go through
  *   task_terminate()
  *
- * @param[in] The task ID of the task to delete.  A pid of zero
+ * @param[in] pid The task ID of the task to delete.  A pid of zero
  *         signifies the calling task.
  * @return OK on success; or ERROR on failure
  * @since Tizen RT v1.0
@@ -211,7 +213,8 @@ int task_delete(pid_t pid);
 /**
  * @ingroup SCHED_KERNEL
  * @brief  restart a task.
- * @details SYSTEM CALL API
+ * @details @b #include <sched.h> \n
+ * SYSTEM CALL API
  *     The task is first terminated and then
  *   reinitialized with same ID, priority, original entry point, stack size,
  *   and parameters it had when it was first started.
@@ -221,7 +224,7 @@ int task_delete(pid_t pid);
  *      (functionality not implemented)
  *   (2) The pid is not associated with any task known to the system.
  *
- * @param[in] The task ID of the task to delete.  An ID of zero signifies the
+ * @param[in] pid The task ID of the task to delete.  An ID of zero signifies the
  *         calling task.
  * @return OK on success; or ERROR on failure
  * @since Tizen RT v1.0
@@ -235,62 +238,80 @@ void   task_testcancel(void);
 /* Task Scheduling Interfaces (based on POSIX APIs) */
 /**
  * @ingroup SCHED_KERNEL
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
- * @details SYSTEM CALL API
+ * @brief set scheduling parameters
+ * @details @b #include <sched.h> \n
+ * SYSTEM CALL API \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int sched_setparam(pid_t pid, const struct sched_param *param);
 /**
  * @ingroup SCHED_KERNEL
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
- * @details SYSTEM CALL API
+ * @brief get scheduling parameters
+ * @details @b #include <sched.h> \n
+ * SYSTEM CALL API \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int sched_getparam(pid_t pid, struct sched_param *param);
 /**
  * @ingroup SCHED_KERNEL
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
- * @details SYSTEM CALL API
+ * @brief set scheduling policy and parameters
+ * @details @b #include <sched.h> \n
+ * SYSTEM CALL API \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int sched_setscheduler(pid_t pid, int policy, FAR const struct sched_param *param);
 /**
  * @ingroup SCHED_KERNEL
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
- * @details SYSTEM CALL API
+ * @brief get scheduling policy and parameters
+ * @details @b #include <sched.h> \n
+ * SYSTEM CALL API \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int sched_getscheduler(pid_t pid);
 /**
  * @ingroup SCHED_KERNEL
- * @details SYSTEM CALL API
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief yield the processor
+ * @details @b #include <sched.h> \n
+ * SYSTEM CALL API \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int sched_yield(void);
 /**
-		  * @} *///end for SCHED_KERNEL
+ * @}
+ *///end for SCHED_KERNEL
 
 /**
  * @addtogroup SCHED_KERNEL
  * @{
  */
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief get priority limits
+ * @details @b #include <sched.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int sched_get_priority_max(int policy);
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief get priority limits
+ * @details @b #include <sched.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int sched_get_priority_min(int policy);
 /**
-* @} */
+ * @}
+ */
 /**
  * @ingroup SCHED_KERNEL
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
- * @details SYSTEM CALL API
+ * @brief get execution time limits
+ * @details @b #include <sched.h> \n
+ * SYSTEM CALL API \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int sched_rr_get_interval(pid_t pid, FAR struct timespec *interval);
@@ -299,7 +320,8 @@ int sched_rr_get_interval(pid_t pid, FAR struct timespec *interval);
 /**
  * @ingroup SCHED_KERNEL
  * @brief disable context switching
- * @details SYSTEM CALL API
+ * @details @b #include <sched.h> \n
+ * SYSTEM CALL API
  * @return On success, OK is returned. On failure, ERROR is returned.
  * @since Tizen RT v1.0
  */
@@ -307,7 +329,8 @@ int sched_lock(void);
 /**
  * @ingroup SCHED_KERNEL
  * @brief re-enable the context switching which blocked from sched_lock()
- * @details SYSTEM CALL API
+ * @details @b #include <sched.h> \n
+ * SYSTEM CALL API
  *     This function decrements the preemption lock count.  Typically this
  *   is paired with sched_lock() and concludes a critical section of
  *   code.  Preemption will not be unlocked until sched_unlock() has
@@ -321,7 +344,8 @@ int sched_unlock(void);
 /**
  * @ingroup SCHED_KERNEL
  * @brief returns the current value of the lockcount
- * @details SYSTEM CALL API
+ * @details @b #include <sched.h> \n
+ * SYSTEM CALL API
  *      This function returns the current value of the lockcount. If zero,
  *   pre-emption is enabled; if non-zero, this value indicates the number
  *   of times that sched_lock() has been called on this thread of
@@ -344,11 +368,11 @@ int sched_lockcount(void);
  */
 void sched_note_start(FAR struct tcb_s *tcb);
 /**
- *@ internal
+ *@internal
  */
 void sched_note_stop(FAR struct tcb_s *tcb);
 /**
- *@ internal
+ *@internal
  */
 void sched_note_switch(FAR struct tcb_s *pFromTcb, FAR struct tcb_s *pToTcb);
 

--- a/os/include/semaphore.h
+++ b/os/include/semaphore.h
@@ -166,49 +166,63 @@ struct timespec;				/* Defined in time.h */
 /* Counting Semaphore Interfaces (based on POSIX APIs) */
 /**
  * @ingroup SEMAPHORE_KERNEL
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief initialize an unnamed semaphore
+ * @details @b #include <semaphore.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int sem_init(FAR sem_t *sem, int pshared, unsigned int value);
 
 /**
  * @ingroup SEMAPHORE_KERNEL
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
- * @details SYSTEM CALL API
+ * @brief destroy an unnamed semaphore
+ * @details @b #include <semaphore.h> \n
+ * SYSTEM CALL API \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int sem_destroy(FAR sem_t *sem);
 /**
  * @ingroup SEMAPHORE_KERNEL
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
- * @details SYSTEM CALL API
+ * @brief lock a semaphore
+ * @details @b #include <semaphore.h> \n
+ * SYSTEM CALL API \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int sem_wait(FAR sem_t *sem);
 /**
  * @ingroup SEMAPHORE_KERNEL
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
- * @details SYSTEM CALL API
+ * @brief lock a semaphore
+ * @details @b #include <semaphore.h> \n
+ * SYSTEM CALL API \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int sem_timedwait(FAR sem_t *sem, FAR const struct timespec *abstime);
 /**
  * @ingroup SEMAPHORE_KERNEL
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
- * @details SYSTEM CALL API
+ * @brief lock a semaphore
+ * @details @b #include <semaphore.h> \n
+ * SYSTEM CALL API \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int sem_trywait(FAR sem_t *sem);
 /**
  * @ingroup SEMAPHORE_KERNEL
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
- * @details SYSTEM CALL API
+ * @brief unlock a semaphore
+ * @details @b #include <semaphore.h> \n
+ * SYSTEM CALL API \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int sem_post(FAR sem_t *sem);
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @ingroup SEMAPHORE_KERNEL
+ * @brief get the value of a semaphore
+ * @details @b #include <semaphore.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int sem_getvalue(FAR sem_t *sem, FAR int *sval);

--- a/os/include/signal.h
+++ b/os/include/signal.h
@@ -294,8 +294,10 @@ extern "C" {
 #endif
 /**
  * @ingroup SIGNAL_KERNEL
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
- * @details SYSTEM CALL API
+ * @brief send a signal to a process or a group of processes
+ * @details @b #include <signal.h> \n
+ * SYSTEM CALL API \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int kill(pid_t pid, int sig);
@@ -305,62 +307,86 @@ int kill(pid_t pid, int sig);
  * @{
  */
 /**
- * @brief  POSIX APIs (refer to : http://pubs.pengroup.org/onlinepubs/9699919799/)
+ * @brief initialize and empty a signal set
+ * @details @b #include <signal.h> \n
+ * POSIX APIs (refer to : http://pubs.pengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int sigemptyset(FAR sigset_t *set);
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief initialize and fill a signal set
+ * @details @b #include <signal.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int sigfillset(FAR sigset_t *set);
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief add a signal to a signal set
+ * @details @b #include <signal.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int sigaddset(FAR sigset_t *set, int signo);
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief delete a signal from a signal set
+ * @details @b #include <signal.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int sigdelset(FAR sigset_t *set, int signo);
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief test for a signal in a signal set
+ * @details @b #include <signal.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int sigismember(FAR const sigset_t *set, int signo);
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief signal management
+ * @details @b #include <signal.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int sighold(int sig);
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief signal management
+ * @details @b #include <signal.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 int sigignore(int sig);
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief signal management
+ * @details @b #include <signal.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 int sigpause(int sig);
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief send a signal to the executing process
+ * @details @b #include <signal.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 int raise(int sig);
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief signal management
+ * @details @b #include <signal.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int sigrelse(int sig);
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief signal management
+ * @details @b #include <signal.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 CODE void (*sigset(int sig, CODE void (*func)(int sig)))(int sig);
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief signal management
+ * @details @b #include <signal.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 CODE void (*signal(int sig, CODE void (*func)(int sig)))(int sig);
@@ -370,50 +396,64 @@ CODE void (*signal(int sig, CODE void (*func)(int sig)))(int sig);
 
 /**
  * @ingroup SIGNAL_KERNEL
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
- * @details SYSTEM CALL API
+ * @brief examine and change a signal action
+ * @details @b #include <signal.h> \n
+ * SYSTEM CALL API \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int sigaction(int sig, FAR const struct sigaction *act, FAR struct sigaction *oact);
 /**
  * @ingroup SIGNAL_KERNEL
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
- * @details SYSTEM CALL API
+ * @brief examine and change blocked signals
+ * @details @b #include <signal.h> \n
+ * SYSTEM CALL API \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int sigprocmask(int how, FAR const sigset_t *set, FAR sigset_t *oset);
 /**
  * @ingroup SIGNAL_KERNEL
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
- * @details SYSTEM CALL API
+ * @brief examine pending signals
+ * @details @b #include <signal.h> \n
+ * SYSTEM CALL API \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int sigpending(FAR sigset_t *set);
 /**
  * @ingroup SIGNAL_KERNEL
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
- * @details SYSTEM CALL API
+ * @brief wait for a signal
+ * @details @b #include <signal.h> \n
+ * SYSTEM CALL API \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int sigsuspend(FAR const sigset_t *sigmask);
 /**
  * @ingroup SIGNAL_KERNEL
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
- * @details SYSTEM CALL API
+ * @brief wait for queued signals
+ * @details @b #include <signal.h> \n
+ * SYSTEM CALL API \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int sigwaitinfo(FAR const sigset_t *set, FAR struct siginfo *value);
 /**
  * @ingroup SIGNAL_KERNEL
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
- * @details SYSTEM CALL API
+ * @brief wait for queued signals
+ * @details @b #include <signal.h> \n
+ * SYSTEM CALL API \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int sigtimedwait(FAR const sigset_t *set, FAR struct siginfo *value, FAR const struct timespec *timeout);
 /**
  * @ingroup SIGNAL_KERNEL
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
- * @details SYSTEM CALL API
+ * @brief queue a signal to a process
+ * @details @b #include <signal.h> \n
+ * SYSTEM CALL API \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 #ifdef CONFIG_CAN_PASS_STRUCTS

--- a/os/include/spawn.h
+++ b/os/include/spawn.h
@@ -180,29 +180,39 @@ int task_spawn(FAR pid_t *pid, FAR const char *name, main_t entry, FAR const pos
 /* File action interfaces ***************************************************/
 /* File action initialization and destruction */
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief initialize spawn file actions object
+ * @details @b #include <spawn.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int posix_spawn_file_actions_init(FAR posix_spawn_file_actions_t *file_actions);
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief destroy spawn file actions object
+ * @details @b #include <spawn.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int posix_spawn_file_actions_destroy(FAR posix_spawn_file_actions_t *file_actions);
 
 /* Add file action interfaces */
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief add close or open action to spawn file actions object
+ * @details @b #include <spawn.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int posix_spawn_file_actions_addclose(FAR posix_spawn_file_actions_t *file_actions, int fd);
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief add dup2 action to spawn file actions object
+ * @details @b #include <spawn.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 int posix_spawn_file_actions_adddup2(FAR posix_spawn_file_actions_t *file_actions, int fd1, int fd2);
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief add close or open action to spawn file actions object
+ * @details @b #include <spawn.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int posix_spawn_file_actions_addopen(FAR posix_spawn_file_actions_t *file_actions, int fd, FAR const char *path, int oflags, mode_t mode);
@@ -210,7 +220,9 @@ int posix_spawn_file_actions_addopen(FAR posix_spawn_file_actions_t *file_action
 /* Spawn attributes interfaces **********************************************/
 /* Spawn attributes initialization and destruction */
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief initialize spawn attributes object
+ * @details @b #include <spawn.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int posix_spawnattr_init(FAR posix_spawnattr_t *attr);
@@ -224,25 +236,33 @@ int posix_spawnattr_init(FAR posix_spawnattr_t *attr);
 
 /* Get spawn attributes interfaces */
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief get and set the spawn-flags attribute of a spawn attributes object
+ * @details @b #include <spawn.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int posix_spawnattr_getflags(FAR const posix_spawnattr_t *attr, FAR short *flags);
 #define posix_spawnattr_getpgroup(attr, group) (ENOSYS)
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief get the spawn-schedparam attribute of a spawn attributes object
+ * @details @b #include <spawn.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int posix_spawnattr_getschedparam(FAR const posix_spawnattr_t *attr, FAR struct sched_param *param);
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief get the spawn-schedpolicy attribute of a spawn attributes object
+ * @details @b #include <spawn.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int posix_spawnattr_getschedpolicy(FAR const posix_spawnattr_t *attr, FAR int *policy);
 #define posix_spawnattr_getsigdefault(attr, sigdefault) (ENOSYS)
 #ifndef CONFIG_DISABLE_SIGNALS
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief get the spawn-sigmask attribute of a spawn attributes object
+ * @details @b #include <spawn.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int posix_spawnattr_getsigmask(FAR const posix_spawnattr_t *attr, FAR sigset_t *sigmask);
@@ -252,25 +272,33 @@ int posix_spawnattr_getsigmask(FAR const posix_spawnattr_t *attr, FAR sigset_t *
 
 /* Set spawn attributes interfaces */
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief set the spawn-flags attribute of a spawn attributes object
+ * @details @b #include <spawn.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int posix_spawnattr_setflags(FAR posix_spawnattr_t *attr, short flags);
 #define posix_spawnattr_setpgroup(attr, group) (ENOSYS)
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief set the spawn-schedparam attribute of a spawn attributes object
+ * @details @b #include <spawn.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int posix_spawnattr_setschedparam(FAR posix_spawnattr_t *attr, FAR const struct sched_param *param);
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief set the spawn-schedpolicy attribute of a spawn attributes object
+ * @details @b #include <spawn.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int posix_spawnattr_setschedpolicy(FAR posix_spawnattr_t *attr, int policy);
 #define posix_spawnattr_setsigdefault(attr, sigdefault) (ENOSYS)
 #ifndef CONFIG_DISABLE_SIGNALS
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief set the spawn-sigmask attribute of a spawn attributes object
+ * @details @b #include <spawn.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int posix_spawnattr_setsigmask(FAR posix_spawnattr_t *attr, FAR const sigset_t *sigmask);
@@ -286,8 +314,9 @@ int posix_spawnattr_setsigmask(FAR posix_spawnattr_t *attr, FAR const sigset_t *
  *   the spawn-stacksize attribute from the attributes object referenced
  *   by attr.
  *
- * @param[in] The address spawn attributes to be queried.
- * @param[in] The location to return the spawn-stacksize value.
+ * @details @b #include <spawn.h>
+ * @param[in] attr The address spawn attributes to be queried.
+ * @param[in] stacksize The location to return the spawn-stacksize value.
  * @return On success, these functions return 0; on failure they return an errno
  * @since Tizen RT v1.0
  */
@@ -297,8 +326,9 @@ int task_spawnattr_getstacksize(FAR const posix_spawnattr_t *attr, size_t *stack
  *   stacksize attribute in an initialized attributes object referenced
  *   by attr.
  *
- * @param[in] The address spawn attributes to be used.
- * @param[in] The new stacksize to set.
+ * @details @b #include <spawn.h>
+ * @param[in] attr The address spawn attributes to be used.
+ * @param[in] stacksize The new stacksize to set.
  * @return On success, these functions return 0; on failure they return an errno
  * @since Tizen RT v1.0
  */
@@ -308,12 +338,16 @@ int task_spawnattr_setstacksize(FAR posix_spawnattr_t *attr, size_t stacksize);
 
 #ifdef CONFIG_DEBUG
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief Show the entryent file actions.
+ * @details @b #include <spawn.h> \n
+ * @param[in] file_actions The address of the file_actions to be dumped.
  * @since Tizen RT v1.0
  */
 void posix_spawn_file_actions_dump(FAR posix_spawn_file_actions_t *file_actions);
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief Show the current attributes
+ * @details @b #include <spawn.h> \n
+ * @param[in] attr The address of the spawn attributes to be dumped.
  * @since Tizen RT v1.0
  */
 void posix_spawnattr_dump(FAR posix_spawnattr_t *attr);

--- a/os/include/stdio.h
+++ b/os/include/stdio.h
@@ -118,22 +118,30 @@
  */
 
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief put a byte on a stream
+ * @details @b #include <stdio.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 #define putc(c, s) fputc((c), (s))
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief put a byte on a stdout stream
+ * @details @b #include <stdio.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 #define putchar(c) fputc(c, stdout)
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief get a byte from a stream
+ * @details @b #include <stdio.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 #define getc(s)    fgetc(s)
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief get a byte from a stdin stream
+ * @details @b #include <stdio.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 #define getchar()  fgetc(stdin)
@@ -202,113 +210,156 @@ void clearerr(register FILE *stream);
  * @endcond
  */
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief close a stream
+ * @details @b #include <stdio.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int fclose(FAR FILE *stream);
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief flush a stream
+ * @details @b #include <stdio.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int fflush(FAR FILE *stream);
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief test end-of-file indicator on a stream
+ * @details @b #include <stdio.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int feof(FAR FILE *stream);
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief test error indicator on a stream
+ * @details @b #include <stdio.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int ferror(FAR FILE *stream);
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief map a stream pointer to a file descriptor
+ * @details @b #include <stdio.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int fileno(FAR FILE *stream);
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief get a byte from a stream
+ * @details @b #include <stdio.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int fgetc(FAR FILE *stream);
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief get current file position information
+ * @details @b #include <stdio.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int fgetpos(FAR FILE *stream, FAR fpos_t *pos);
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief get a string from a stream
+ * @details @b #include <stdio.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 char *fgets(FAR char *s, int n, FAR FILE *stream);
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief open a stream
+ * @details @b #include <stdio.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 FAR FILE *fopen(FAR const char *path, FAR const char *type);
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief open a stream
+ * @details @b #include <stdio.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 FAR FILE *freopen(FAR const char *path, FAR const char *mode, FAR FILE *stream);
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief assign buffering to a stream
+ * @details @b #include <stdio.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 void   setbuf(FAR FILE *stream, FAR char *buf);
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief assign buffering to a stream
+ * @details @b #include <stdio.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 int    setvbuf(FAR FILE *stream, FAR char *buffer, int mode, size_t size);
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief print formatted output
+ * @details @b #include <stdio.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int fprintf(FAR FILE *stream, FAR const char *format, ...);
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief put a byte on a stream
+ * @details @b #include <stdio.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int fputc(int c, FAR FILE *stream);
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief put a string on a stream
+ * @details @b #include <stdio.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int fputs(FAR const char *s, FAR FILE *stream);
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief binary input
+ * @details @b #include <stdio.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 size_t fread(FAR void *ptr, size_t size, size_t n_items, FAR FILE *stream);
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief reposition a file-position indicator in a stream
+ * @details @b #include <stdio.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int fseek(FAR FILE *stream, long int offset, int whence);
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief set current file position
+ * @details @b #include <stdio.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int fsetpos(FAR FILE *stream, FAR fpos_t *pos);
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief return a file offset in a stream
+ * @details @b #include <stdio.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 long ftell(FAR FILE *stream);
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief binary output
+ * @details @b #include <stdio.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 size_t fwrite(FAR const void *ptr, size_t size, size_t n_items, FAR FILE *stream);
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief get a string from a stdin stream
+ * @details @b #include <stdio.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 FAR char *gets(FAR char *s);
 /**
  * @brief reads a line from stdin into the buffer
- * @details  gets() reads a line from stdin into the buffer pointed to by s until
+ * @details @b #include <stdio.h> \n
+ *   gets() reads a line from stdin into the buffer pointed to by s until
  *   either a terminating newline or EOF, which it replaces with '\0'.  Reads
  *   at most n-1 characters from stdin into the array pointed to by str until
  *   new-line character, end-of-file condition, or read error.   The newline
@@ -332,7 +383,9 @@ FAR char *gets(FAR char *s);
  */
 FAR char *gets_s(FAR char *s, rsize_t n);
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief push byte back into input stream
+ * @details @b #include <stdio.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int ungetc(int c, FAR FILE *stream);
@@ -340,12 +393,15 @@ int ungetc(int c, FAR FILE *stream);
 /* Operations on the stdout stream, buffers, paths, and the whole printf-family */
 
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief print formatted output
+ * @details @b #include <stdio.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int printf(FAR const char *format, ...);
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief put a string on standard output
+ * @details POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int puts(FAR const char *s);
@@ -358,43 +414,67 @@ int rename(FAR const char *oldpath, FAR const char *newpath);
  * @endcond
  */
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief print formatted output
+ * @details @b #include <stdio.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int sprintf(FAR char *buf, FAR const char *format, ...);
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief print formatted output
+ * @details @b #include <stdio.h> \n
+ * This function is similar to sprintf, except that it dynamically
+ * allocates a string (as with malloc) to hold the output, instead of
+ * putting the output in a buffer you allocate in advance.  The ptr
+ * argument should be the address of a char * object, and a successful
+ * call to asprintf stores a pointer to the newly allocated string at that
+ * location.
+ * @return The returned value is the number of characters allocated for the buffer,
+ * or less than zero if an error occurred. Usually this means that the buffer
+ * could not be allocated.
  * @since Tizen RT v1.0
  */
 int asprintf(FAR char **ptr, FAR const char *fmt, ...);
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief print formatted output
+ * @details @b #include <stdio.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int snprintf(FAR char *buf, size_t size, FAR const char *format, ...);
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief convert formatted input
+ * @details @b #include <stdio.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int sscanf(FAR const char *buf, FAR const char *fmt, ...);
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief write error messages to standard error
+ * @details @b #include <stdio.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 void perror(FAR const char *s);
 
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief format output of a stdarg argument list
+ * @details @b #include <stdio.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int vprintf(FAR const char *format, va_list ap);
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief format output of a stdarg argument list
+ * @details @b #include <stdio.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int vfprintf(FAR FILE *stream, const char *format, va_list ap);
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief format output of a stdarg argument list
+ * @details @b #include <stdio.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int vsprintf(FAR char *buf, const char *format, va_list ap);
@@ -407,12 +487,16 @@ int avsprintf(FAR char **ptr, const char *fmt, va_list ap);
  * @endcond
  */
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief format output of a stdarg argument list
+ * @details @b #include <stdio.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int vsnprintf(FAR char *buf, size_t size, const char *format, va_list ap);
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief format input of a stdarg argument list
+ * @details @b #include <stdio.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int vsscanf(FAR const char *buf, FAR const char *s, va_list ap);
@@ -424,7 +508,9 @@ int vsscanf(FAR const char *buf, FAR const char *s, va_list ap);
  *   Part 1 (dprintf and vdprintf)
  */
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief associate a stream with a file descriptor
+ * @details @b #include <stdio.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 FAR FILE *fdopen(int fd, FAR const char *type);
@@ -448,7 +534,9 @@ FAR char *tmpnam(FAR char *s);
  */
 FAR char *tempnam(FAR const char *dir, FAR const char *pfx);
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief remove a file
+ * @details @b #include <stdio.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 int remove(FAR const char *path);

--- a/os/include/stdlib.h
+++ b/os/include/stdlib.h
@@ -172,6 +172,7 @@ extern "C" {
  * @ingroup STDLIB_LIBC
  * @brief initialize random number generator
  *
+ * @details @b #include <stdlib.h>
  * @param[in] seed An integer value to be used as seed
  * @return none
  * @since Tizen RT v1.0
@@ -179,7 +180,9 @@ extern "C" {
 void srand(unsigned int seed);
 /**
  * @ingroup STDLIB_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief pseudo-random number generator
+ * @details @b #include <stdlib.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int rand(void);
@@ -190,24 +193,29 @@ int rand(void);
 /**
  * @ingroup STDLIB_LIBC
  * @brief Return a pointer to the thread specific environ variable
- * @details This API is not a standard API. But another APIs which are related to ENV are in Stdlib,
+ * @details @b #include <stdlib.h> \n
+ * This API is not a standard API. But another APIs which are related to ENV are in Stdlib,
  *         so this API is in Stdlib for ease.
- * @param[in] A pointer to notify a size of environ variable
+ * @param[in] envsize A pointer to notify a size of environ variable
  * @return A pointer to the current thread environ variable
  * @since Tizen RT v1.0
  */
 FAR char *get_environ_ptr(size_t *envsize);
 /**
  * @ingroup STDLIB_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
- * @details SYSTEM CALL API
+ * @brief get value of an environment variable
+ * @details @b #include <stdlib.h> \n
+ * SYSTEM CALL API \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 FAR char *getenv(FAR const char *name);
 /**
  * @ingroup STDLIB_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
- * @details SYSTEM CALL API
+ * @brief change or add a value to an environment
+ * @details @b #include <stdlib.h> \n
+ * SYSTEM CALL API \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int putenv(FAR const char *string);
@@ -215,21 +223,26 @@ int putenv(FAR const char *string);
  * @ingroup STDLIB_LIBC
  * @brief clears the environment of all name-value pairs
  *        and sets the value of the external variable environ to NULL
- * @details SYSTEM CALL API
+ * @details @b #include <stdlib.h> \n
+ * SYSTEM CALL API
  * @since Tizen RT v1.0
  */
 int clearenv(void);
 /**
  * @ingroup STDLIB_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
- * @details SYSTEM CALL API
+ * @brief add or change environment variable
+ * @details @b #include <stdlib.h> \n
+ * SYSTEM CALL API \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int setenv(const char *name, const char *value, int overwrite);
 /**
  * @ingroup STDLIB_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
- * @details SYSTEM CALL API
+ * @brief remove an environment variable
+ * @details @b #include <stdlib.h> \n
+ * SYSTEM CALL API \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int unsetenv(const char *name);
@@ -238,22 +251,28 @@ int unsetenv(const char *name);
 /* Process exit functions */
 /**
  * @ingroup STDLIB_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
- * @details SYSTEM CALL API
+ * @brief terminate a process
+ * @details @b #include <stdlib.h> \n
+ * SYSTEM CALL API \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 void exit(int status) noreturn_function;
 /**
  * @ingroup STDLIB_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief generate an abnormal process abort
+ * @details @b #include <stdlib.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 void abort(void) noreturn_function;
 #ifdef CONFIG_SCHED_ATEXIT
 /**
  * @ingroup STDLIB_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
- * @details SYSTEM CALL API
+ * @brief register a function to run at process termination
+ * @details @b #include <stdlib.h> \n
+ * SYSTEM CALL API \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int atexit(CODE void (*func)(void));
@@ -262,7 +281,8 @@ int atexit(CODE void (*func)(void));
 /**
  * @ingroup STDLIB_LIBC
  * @brief register a function to be called at program exit
- * @details SYSTEM CALL API
+ * @details @b #include <stdlib.h> \n
+ * SYSTEM CALL API
  *
  * @param[in] func A pointer to the function to be called when the task exits.
  * @param[in] arg An argument that will be provided to the on_exit() function when
@@ -287,60 +307,78 @@ void _exit(int status);			/* See unistd.h */
 /* String to binary conversions */
 /**
  * @ingroup STDLIB_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief convert a string to a long integer
+ * @details @b #include <stdlib.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 long strtol(const char *, char **, int);
 /**
  * @ingroup STDLIB_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief convert a string to an unsigned long
+ * @details @b #include <stdlib.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 unsigned long strtoul(const char *, char **, int);
 #ifdef CONFIG_HAVE_LONG_LONG
 /**
  * @ingroup STDLIB_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief convert a string to a long integer
+ * @details @b #include <stdlib.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 long long strtoll(const char *, char **, int);
 /**
  * @ingroup STDLIB_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief convert a string to an unsigned long
+ * @details @b #include <stdlib.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 unsigned long long strtoull(const char *, char **, int);
 #endif
 /**
  * @ingroup STDLIB_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief convert a string to a double-precision number
+ * @details @b #include <stdlib.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 double_t strtod(const char *, char **);
 
 /**
  * @ingroup STDLIB_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief convert a string to an integer
+ * @details @b #include <stdlib.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 #define atoi(nptr)  strtol((nptr), NULL, 10)
 /**
  * @ingroup STDLIB_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief convert a string to a long integer
+ * @details @b #include <stdlib.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 #define atol(nptr)  strtol((nptr), NULL, 10)
 #ifdef CONFIG_HAVE_LONG_LONG
 /**
  * @ingroup STDLIB_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief convert a string to a long integer
+ * @details @b #include <stdlib.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 #define atoll(nptr) strtoll((nptr), NULL, 10)
 #endif
 /**
  * @ingroup STDLIB_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief convert a string to a double-precision number
+ * @details @b #include <stdlib.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 #define atof(nptr)  strtod((nptr), NULL)
@@ -350,6 +388,7 @@ double_t strtod(const char *, char **);
  * @ingroup STDLIB_LIBC
  * @brief convert integer to string
  *
+ * @details @b #include <stdlib.h>
  * @param[in] value Integer value
  * @param[out] str String where store the result
  * @param[in] base Numerical base
@@ -361,19 +400,25 @@ char *itoa(int value, char *str, int base);
 /* Memory Management */
 /**
  * @ingroup STDLIB_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief a memory allocator
+ * @details @b #include <stdlib.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 FAR void *malloc(size_t);
 /**
  * @ingroup STDLIB_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief free allocated memory
+ * @details @b #include <stdlib.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 void free(FAR void *);
 /**
  * @ingroup STDLIB_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief memory reallocator
+ * @details @b #include <stdlib.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 FAR void *realloc(FAR void *, size_t);
@@ -381,6 +426,7 @@ FAR void *realloc(FAR void *, size_t);
  * @ingroup STDLIB_LIBC
  * @brief allocates size bytes and returns a pointer to the allocated memory
  *
+ * @details @b #include <stdlib.h>
  * @param[in] alignment A power of two
  * @param[in] size Allocated memory size
  * @return On success, A pointer to the allocated memory is returned. On failure, NULL is returned.
@@ -391,6 +437,7 @@ FAR void *memalign(size_t, size_t);
  * @ingroup STDLIB_LIBC
  * @brief Allocate and zero memory from the user heap.
  *
+ * @details @b #include <stdlib.h>
  * @param[in] size Size (in bytes) of the memory region to be allocated.
  * @return On success, A pointer to the allocated memory is returned. On failure, NULL is returned.
  * @since Tizen RT v1.0
@@ -398,7 +445,9 @@ FAR void *memalign(size_t, size_t);
 FAR void *zalloc(size_t);
 /**
  * @ingroup STDLIB_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief a memory allocator
+ * @details @b #include <stdlib.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 FAR void *calloc(size_t, size_t);
@@ -406,20 +455,26 @@ FAR void *calloc(size_t, size_t);
 /* Misc */
 /**
  * @ingroup STDLIB_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief return an integer absolute value
+ * @details @b #include <stdlib.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int abs(int j);
 /**
  * @ingroup STDLIB_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief return a long integer absolute value
+ * @details @b #include <stdlib.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 long int labs(long int j);
 #ifdef CONFIG_HAVE_LONG_LONG
 /**
  * @ingroup STDLIB_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief return a long integer absolute value
+ * @details @b #include <stdlib.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 long long int llabs(long long int j);
@@ -428,7 +483,9 @@ long long int llabs(long long int j);
 #ifdef CONFIG_CAN_PASS_STRUCTS
 /**
  * @ingroup STDLIB_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief compute the quotient and remainder of an integer division
+ * @details @b #include <stdlib.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 div_t div(int numer, int denom);
@@ -464,7 +521,9 @@ int mkstemp(FAR char *path_template);
 /* Sorting */
 /**
  * @ingroup STDLIB_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief sort a table of data
+ * @details @b #include <stdlib.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 void qsort(void *base, size_t nmemb, size_t size, int (*compar)(const void *, const void *));
@@ -472,7 +531,9 @@ void qsort(void *base, size_t nmemb, size_t size, int (*compar)(const void *, co
 /* Binary search */
 /**
  * @ingroup STDLIB_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief binary search a sorted table
+ * @details @b #include <stdlib.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 FAR void *bsearch(FAR const void *key, FAR const void *base, size_t nel, size_t width, CODE int (*compar)(FAR const void *, FAR const void *));
@@ -481,6 +542,7 @@ FAR void *bsearch(FAR const void *key, FAR const void *base, size_t nel, size_t 
 /**
  * @ingroup STDLIB_LIBC
  * @brief returns a copy of updated current heap information for the user heap
+ * @details @b #include <stdlib.h>
  * @return Current mallinfo structure returned.
  * @since Tizen RT v1.0
  */
@@ -489,6 +551,7 @@ struct mallinfo mallinfo(void);
 /**
  * @ingroup STDLIB_LIBC
  * @brief returns a copy of updated current heap information for the user heap
+ * @details @b #include <stdlib.h>
  * @param[out] info mallinfo structure to be updated
  * @return OK returned.
  * @since Tizen RT v1.0

--- a/os/include/string.h
+++ b/os/include/string.h
@@ -95,157 +95,217 @@ extern "C" {
 #endif
 
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief duplicate a specific number of bytes from a string
+ * @details @b #include <string.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 FAR char *strdup(FAR const char *s);
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief duplicate a specific number of bytes from a string
+ * @details @b #include <string.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 FAR char *strndup(FAR const char *s, size_t size);
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief get error message string
+ * @details @b #include <string.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 FAR const char *strerror(int);
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief get length of fixed size string
+ * @details @b #include <string.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 size_t strlen(FAR const char *);
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief get length of fixed size string
+ * @details @b #include <string.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 size_t strnlen(FAR const char *, size_t);
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief concatenate two strings
+ * @details @b #include <string.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 FAR char *strcat(FAR char *, FAR const char *);
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief concatenate a string with part of another
+ * @details @b #include <string.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 FAR char *strncat(FAR char *, FAR const char *, size_t);
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief compare two strings
+ * @details @b #include <string.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int strcmp(FAR const char *, FAR const char *);
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief compare part of two strings
+ * @details @b #include <string.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int strncmp(FAR const char *, FAR const char *, size_t);
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief case-insensitive string comparisons
+ * @details @b #include <string.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int strcasecmp(FAR const char *, FAR const char *);
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief case-insensitive string comparisons
+ * @details @b #include <string.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int strncasecmp(FAR const char *, FAR const char *, size_t);
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief copy a string and return a pointer to the end of the result
+ * @details @b #include <string.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 FAR char *strcpy(char *dest, FAR const char *src);
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief copy a string and return a pointer to the end of the result
+ * @details @b #include <string.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 FAR char *stpcpy(char *dest, FAR const char *src);
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief copy fixed length string, returning a pointer to the array end
+ * @details @b #include <string.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 FAR char *strncpy(char *, FAR const char *, size_t);
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief scan a string for a byte
+ * @details @b #include <string.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 FAR char *strpbrk(FAR const char *, FAR const char *);
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief string scanning operation
+ * @details @b #include <string.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 FAR char *strchr(FAR const char *s, int c);
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief string scanning operation
+ * @details @b #include <string.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 FAR char *strrchr(FAR const char *s, int c);
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief get length of a substring
+ * @details @b #include <string.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 size_t strspn(FAR const char *, FAR const char *);
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief get the length of a complementary substring
+ * @details @b #include <string.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 size_t strcspn(FAR const char *, FAR const char *);
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief find a substring
+ * @details @b #include <string.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 FAR char *strstr(FAR const char *, FAR const char *);
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief locate a substring
+ * @details @b #include <string.h> \n
+ * @param[in] str src string
+ * @param[in] substr substring
  * @since Tizen RT v1.0
  */
 FAR char *strcasestr(FAR const char *, FAR const char *);
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief split string into tokens
+ * @details @b #include <string.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 FAR char *strtok(FAR char *, FAR const char *);
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief split string into tokens
+ * @details @b #include <string.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 FAR char *strtok_r(FAR char *, FAR const char *, FAR char **);
 
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief find byte in memory
+ * @details @b #include <string.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 FAR void *memchr(FAR const void *s, int c, size_t n);
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief copy bytes in memory
+ * @details @b #include <string.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 FAR void *memccpy(FAR void *s1, FAR const void *s2, int c, size_t n);
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief compare bytes in memory
+ * @details @b #include <string.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int memcmp(FAR const void *s1, FAR const void *s2, size_t n);
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief copy bytes in memory
+ * @details @b #include <string.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 FAR void *memcpy(FAR void *dest, FAR const void *src, size_t n);
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief copy bytes in memory with overlapping areas
+ * @details @b #include <string.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 FAR void *memmove(FAR void *dest, FAR const void *src, size_t count);
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief set bytes in memory
+ * @details @b #include <string.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 FAR void *memset(FAR void *s, int c, size_t n);
 
 /**
  * @brief Copies up to size - 1 characters from the NUL-terminated string src to dst, NUL-terminating the result.
- * @param[in] A pointer to the destination string.
- * @param[in] A pointer to the source string.
- * @param[in] The size of the destination buffer.
+ * @details @b #include <string.h>
+ * @param[in] dest A pointer to the destination string.
+ * @param[in] src A pointer to the source string.
+ * @param[in] size The size of the destination buffer.
  * @return Total length of the string they tried to create.
  * @since Tizen RT v1.0
  */

--- a/os/include/sys/ioctl.h
+++ b/os/include/sys/ioctl.h
@@ -128,8 +128,10 @@ extern "C" {
 
 /**
  * @ingroup IOCTL_KERNEL
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
- * @details SYSTEM CALL API
+ * @brief control a STREAMS device
+ * @details @b #include <sys/ioctl.h> \n
+ * SYSTEM CALL API \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 #ifdef CONFIG_LIBC_IOCTL_VARIADIC

--- a/os/include/sys/prctl.h
+++ b/os/include/sys/prctl.h
@@ -113,8 +113,9 @@ extern "C" {
  *   values PR_* defined above) and with additional arguments depending on
  *   the specific command.
  *
- * param[in] options for what to do
- * return The returned value may depend on the specific commnand.  For PR_SET_NAME
+ * @details @b #include <sys/prctl.h>
+ * @param[in] option options for what to do
+ * @return The returned value may depend on the specific commnand.  For PR_SET_NAME
  *   and PR_GET_NAME, the returned value of 0 indicates successful operation.
  *   On any failure, -1 is retruend and the errno value is set appropriately.
  *

--- a/os/include/sys/stat.h
+++ b/os/include/sys/stat.h
@@ -157,21 +157,24 @@ extern "C" {
 /**
  * @ingroup STAT_KERNEL
  * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
- * @details SYSTEM CALL API
+ * @details @b #include <sys/stat.h> \n
+ * SYSTEM CALL API
  * @since Tizen RT v1.0
  */
 int mkdir(FAR const char *pathname, mode_t mode);
 /**
  * @ingroup STAT_KERNEL
  * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
- * @details SYSTEM CALL API
+ * @details @b #include <sys/stat.h> \n
+ * SYSTEM CALL API
  * @since Tizen RT v1.0
  */
 int mkfifo(FAR const char *pathname, mode_t mode);
 /**
  * @ingroup STAT_KERNEL
  * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
- * @details SYSTEM CALL API
+ * @details @b #include <sys/stat.h> \n
+ * SYSTEM CALL API
  * @since Tizen RT v1.0
  */
 int stat(const char *path, FAR struct stat *buf);
@@ -190,4 +193,5 @@ int fstat(int fd, FAR struct stat *buf);
 
 #endif							/* __INCLUDE_SYS_STAT_H */
 /**
- * @} */
+ * @}
+ */

--- a/os/include/sys/time.h
+++ b/os/include/sys/time.h
@@ -86,7 +86,9 @@ extern "C" {
 #define EXTERN extern
 #endif
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief get the date and time
+ * @details @b #include <sys/time.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 EXTERN int gettimeofday(struct timeval *tv, FAR struct timezone *tz);

--- a/os/include/sys/wait.h
+++ b/os/include/sys/wait.h
@@ -124,7 +124,8 @@ extern "C" {
 /**
  * @ingroup SCHED_KERNEL
  * @brief suspend execution of the calling thread
- * @details SYSTEM CALL API
+ * @details @b #include <sys/wait.h> \n
+ * SYSTEM CALL API \n
  *      suspend execution of the calling thread until
  *   status information for one of its terminated child processes is
  *   available, or until delivery of a signal whose action is either to
@@ -146,7 +147,8 @@ EXTERN pid_t wait(FAR int *stat_loc);
 /**
  * @ingroup SCHED_KERNEL
  * @brief suspend execution of the calling thread
- * @details SYSTEM CALL API
+ * @details @b #include <sys/wait.h> \n
+ * SYSTEM CALL API \n
  *      The waitid() function suspends the calling thread until one child of
  *   the process containing the calling thread changes state. It records the
  *   current state of a child in the structure pointed to by 'info'. If a
@@ -209,7 +211,8 @@ EXTERN int waitid(idtype_t idtype, id_t id, FAR siginfo_t *info, int options);
 /**
  * @ingroup SCHED_KERNEL
  * @brief suspend execution of the calling thread
- * @details SYSTEM CALL API
+ * @details @b #include <sys/wait.h> \n
+ * SYSTEM CALL API \n
  *     obtain status information pertaining to one
  *   of the caller's child processes. The waitpid() function will suspend
  *   execution of the calling thread until status information for one of the

--- a/os/include/syslog.h
+++ b/os/include/syslog.h
@@ -193,7 +193,9 @@ void closelog(void);
  *
  ****************************************************************************/
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief control system log
+ * @details @b #include <syslog.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int syslog(int priority, FAR const char *format, ...);
@@ -201,8 +203,9 @@ int syslog(int priority, FAR const char *format, ...);
  * @brief performs the same task as syslog() with
  *        the difference that it takes a set of arguments which have been
  *        obtained using the stdarg variable argument list macros
+ * @details @b #include <syslog.h>
  * @param[in] priority priority of vsyslog
- * @param[in] format output format
+ * @param[in] src output format
  * @param[in] ap stdarg variable argument list macros
  * @return On success, number of characters written is returned. On failure, ERROR is returned.
  * @since Tizen RT v1.0
@@ -239,6 +242,7 @@ int vsyslog(int priority, FAR const char *src, va_list ap);
 /**
  * @brief a non-standard, low-level system logging interface.
  *
+ * @details @b #include <syslog.h>
  * @param[in] priority priority of lowsyslog
  * @param[in] format output format
  * @return On success, number of characters written is returned. On failure, ERROR is returned.
@@ -249,6 +253,7 @@ int lowsyslog(int priority, FAR const char *format, ...);
  * @brief performs the same task as lowsyslog() with
  *        the difference that it takes a set of arguments which have been
  *        obtained using the stdarg variable argument list macros
+ * @details @b #include <syslog.h>
  * @param[in] priority priority of lowvsyslog
  * @param[in] format output format
  * @param[in] ap stdarg variable argument list macros
@@ -294,7 +299,9 @@ int lowvsyslog(int priority, FAR const char *format, va_list ap);
  *
  ****************************************************************************/
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief set the log priority mask
+ * @details @b #include <syslog.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int setlogmask(int mask);

--- a/os/include/termios.h
+++ b/os/include/termios.h
@@ -325,7 +325,9 @@ int tcflush(int fd, int cmd);
 /* Get the parameters associated with the terminal */
 /**
  * @ingroup TERMIOS_KERNEL
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief get the parameters associated with the terminal
+ * @details @b #include <termios.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int tcgetattr(int fd, FAR struct termios *termiosp);
@@ -349,7 +351,9 @@ int tcsendbreak(int fd, int duration);
 /* Set the parameters associated with the terminal */
 /**
  * @ingroup TERMIOS_KERNEL
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief set the parameters associated with the terminal
+ * @details @b #include <termios.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int tcsetattr(int fd, int options, FAR const struct termios *termiosp);

--- a/os/include/time.h
+++ b/os/include/time.h
@@ -219,41 +219,53 @@ extern "C" {
 
 /**
  * @ingroup TIME_KERNEL
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
- * @details SYSTEM CALL API
+ * @brief clock and timer functions
+ * @details @b #include <time.h> \n
+ * SYSTEM CALL API \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int clock_settime(clockid_t clockid, FAR const struct timespec *tp);
 /**
  * @ingroup TIME_KERNEL
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
- * @details SYSTEM CALL API
+ * @brief clock and timer functions
+ * @details @b #include <time.h> \n
+ * SYSTEM CALL API \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int clock_gettime(clockid_t clockid, FAR struct timespec *tp);
 /**
  * @ingroup TIME_KERNEL
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
- * @details SYSTEM CALL API
+ * @brief clock and timer functions
+ * @details @b #include <time.h> \n
+ * SYSTEM CALL API \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int clock_getres(clockid_t clockid, FAR struct timespec *res);
 
 /**
  * @ingroup TIME_KERNEL
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief convert broken-down time into time since the Epoch
+ * @details @b #include <time.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 time_t mktime(FAR struct tm *tp);
 /**
  * @ingroup TIME_KERNEL
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief convert a time value to a broken-down UTC time
+ * @details @b #include <time.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 FAR struct tm *gmtime(FAR const time_t *timer);
 /**
  * @ingroup TIME_KERNEL
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief convert a time value to a broken-down UTC time
+ * @details @b #include <time.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 FAR struct tm *gmtime_r(FAR const time_t *timer, FAR struct tm *result);
@@ -261,13 +273,17 @@ FAR struct tm *gmtime_r(FAR const time_t *timer, FAR struct tm *result);
 #ifdef CONFIG_LIBC_LOCALTIME
 /**
  * @ingroup TIME_KERNEL
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief convert a time value to a broken-down local time
+ * @details @b #include <time.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 FAR struct tm *localtime(FAR const time_t *timer);
 /**
  * @ingroup TIME_KERNEL
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief convert a time value to a broken-down local time
+ * @details @b #include <time.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 FAR struct tm *localtime_r(FAR const time_t *timer, FAR struct tm *result);
@@ -275,7 +291,9 @@ FAR struct tm *localtime_r(FAR const time_t *timer, FAR struct tm *result);
 #endif
 /**
  * @ingroup TIME_KERNEL
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief convert date and time to a string
+ * @details @b #include <time.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 size_t strftime(char *s, size_t max, FAR const char *format, FAR const struct tm *tm);
@@ -327,36 +345,46 @@ float difftime(time_t time1, time_t time0);
 
 /**
  * @ingroup TIME_KERNEL
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief get time
+ * @details @b #include <time.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 time_t time(FAR time_t *tloc);
 
 /**
  * @ingroup TIME_KERNEL
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
- * @details SYSTEM CALL API
+ * @brief create a per-process timer
+ * @details @b #include <time.h> \n
+ * SYSTEM CALL API \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int timer_create(clockid_t clockid, FAR struct sigevent *evp, FAR timer_t *timerid);
 /**
  * @ingroup TIME_KERNEL
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
- * @details SYSTEM CALL API
+ * @brief delete a per-process timer
+ * @details @b #include <time.h> \n
+ * SYSTEM CALL API \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int timer_delete(timer_t timerid);
 /**
  * @ingroup TIME_KERNEL
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
- * @details SYSTEM CALL API
+ * @brief per-process timers
+ * @details @b #include <time.h> \n
+ * SYSTEM CALL API \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int timer_settime(timer_t timerid, int flags, FAR const struct itimerspec *value, FAR struct itimerspec *ovalue);
 /**
  * @ingroup TIME_KERNEL
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
- * @details SYSTEM CALL API
+ * @brief per-process timers
+ * @details @b #include <time.h> \n
+ * SYSTEM CALL API \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int timer_gettime(timer_t timerid, FAR struct itimerspec *value);
@@ -372,7 +400,8 @@ int timer_getoverrun(timer_t timerid);
 /**
  * @ingroup TIME_KERNEL
  * @brief high-resolution sleep
- * @details SYSTEM CALL API
+ * @details @b #include <time.h> \n
+ * SYSTEM CALL API
  *
  * @param[in] rqtp The amount of time to be suspended from execution.
  * @param[in] rmtp If the rmtp argument is non-NULL, the timespec structure

--- a/os/include/tinyara/clock.h
+++ b/os/include/tinyara/clock.h
@@ -306,7 +306,8 @@ void clock_synchronize(void);
 /**
  * @ingroup CLOCK_KERNEL
  * @brief Return the current value of the 32/64-bit system timer counter
- * @details SYSTEM CALL API
+ * @details @b #include <tinyara/clock.h> \n
+ * SYSTEM CALL API
  *
  * @return The current value of the system timer counter is returned.
  * @since Tizen RT v1.0

--- a/os/include/tinyara/math.h
+++ b/os/include/tinyara/math.h
@@ -178,14 +178,18 @@ extern "C" {
 /* General Functions ******************************************************* */
 /**
  * @ingroup MATH_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief ceiling value function
+ * @details @b #include <tinyara/math.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 float ceilf(float x);
 #ifdef CONFIG_HAVE_DOUBLE
 /**
  * @ingroup MATH_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief ceiling value function
+ * @details @b #include <tinyara/math.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 double ceil(double x);
@@ -193,21 +197,27 @@ double ceil(double x);
 #ifdef CONFIG_HAVE_LONG_DOUBLE
 /**
  * @ingroup MATH_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief ceiling value function
+ * @details @b #include <tinyara/math.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 long double ceill(long double x);
 #endif
 /**
  * @ingroup MATH_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief floor function
+ * @details @b #include <tinyara/math.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 float floorf(float x);
 #ifdef CONFIG_HAVE_DOUBLE
 /**
  * @ingroup MATH_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief floor function
+ * @details @b #include <tinyara/math.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 double floor(double x);
@@ -215,21 +225,27 @@ double floor(double x);
 #ifdef CONFIG_HAVE_LONG_DOUBLE
 /**
  * @ingroup MATH_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief floor function
+ * @details @b #include <tinyara/math.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 long double floorl(long double x);
 #endif
 /**
  * @ingroup MATH_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief round to the nearest integer value in a floating-point format
+ * @details @b #include <tinyara/math.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 float roundf(float x);
 #ifdef CONFIG_HAVE_DOUBLE
 /**
  * @ingroup MATH_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief round to the nearest integer value in a floating-point format
+ * @details @b #include <tinyara/math.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 double round(double x);
@@ -237,21 +253,27 @@ double round(double x);
 #ifdef CONFIG_HAVE_LONG_DOUBLE
 /**
  * @ingroup MATH_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief round to the nearest integer value in a floating-point format
+ * @details @b #include <tinyara/math.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 long double roundl(long double x);
 #endif
 /**
  * @ingroup MATH_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief round-to-nearest integral value
+ * @details @b #include <tinyara/math.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 float rintf(float x);		/* Not implemented */
 #ifdef CONFIG_HAVE_DOUBLE
 /**
  * @ingroup MATH_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief round-to-nearest integral value
+ * @details @b #include <tinyara/math.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 double rint(double x);
@@ -259,21 +281,27 @@ double rint(double x);
 #ifdef CONFIG_HAVE_LONG_DOUBLE
 /**
  * @ingroup MATH_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief round-to-nearest integral value
+ * @details @b #include <tinyara/math.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 long double rintl(long double x);	/* Not implemented */
 #endif
 /**
  * @ingroup MATH_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief absolute value function
+ * @details @b #include <tinyara/math.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 float fabsf(float x);
 #ifdef CONFIG_HAVE_DOUBLE
 /**
  * @ingroup MATH_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief absolute value function
+ * @details @b #include <tinyara/math.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 double fabs(double x);
@@ -281,7 +309,9 @@ double fabs(double x);
 #ifdef CONFIG_HAVE_LONG_DOUBLE
 /**
  * @ingroup MATH_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief absolute value function
+ * @details @b #include <tinyara/math.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 long double fabsl(long double x);
@@ -330,7 +360,9 @@ float powf(float b, float e);
 #ifdef CONFIG_HAVE_DOUBLE
 /**
  * @ingroup MATH_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief power function
+ * @details @b #include <tinyara/math.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 double pow(double b, double e);
@@ -347,20 +379,26 @@ long double powl(long double b, long double e);
  */
 /**
  * @ingroup MATH_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief exponential function
+ * @details @b #include <tinyara/math.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 float expf(float x);
 /**
  * @ingroup MATH_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief exponential function
+ * @details @b #include <tinyara/math.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 #define expm1f(x) (expf(x) - 1.0)
 #ifdef CONFIG_HAVE_DOUBLE
 /**
  * @ingroup MATH_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief exponential function
+ * @details @b #include <tinyara/math.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 double exp(double x);
@@ -369,7 +407,9 @@ double exp(double x);
 #ifdef CONFIG_HAVE_LONG_DOUBLE
 /**
  * @ingroup MATH_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief exponential function
+ * @details @b #include <tinyara/math.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 long double expl(long double x);
@@ -377,14 +417,18 @@ long double expl(long double x);
 #endif
 /**
  * @ingroup MATH_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief exponential base 2 functions
+ * @details @b #include <tinyara/math.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 float exp2f(float x);
 #ifdef CONFIG_HAVE_DOUBLE
 /**
  * @ingroup MATH_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief exponential base 2 functions
+ * @details @b #include <tinyara/math.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 double exp2(double x);
@@ -392,7 +436,9 @@ double exp2(double x);
 #ifdef CONFIG_HAVE_LONG_DOUBLE
 /**
  * @ingroup MATH_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief exponential base 2 functions
+ * @details @b #include <tinyara/math.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 long double exp2l(long double x);
@@ -435,14 +481,18 @@ long double log10l(long double x);
  */
 /**
  * @ingroup MATH_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief compute base 2 logarithm functions
+ * @details @b #include <tinyara/math.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 float log2f(float x);
 #ifdef CONFIG_HAVE_DOUBLE
 /**
  * @ingroup MATH_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief compute base 2 logarithm functions
+ * @details @b #include <tinyara/math.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 double log2(double x);
@@ -450,21 +500,27 @@ double log2(double x);
 #ifdef CONFIG_HAVE_LONG_DOUBLE
 /**
  * @ingroup MATH_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief compute base 2 logarithm functions
+ * @details @b #include <tinyara/math.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 long double log2l(long double x);
 #endif
 /**
  * @ingroup MATH_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief cube root functions
+ * @details @b #include <tinyara/math.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 float cbrtf(float x);
 #ifdef CONFIG_HAVE_DOUBLE
 /**
  * @ingroup MATH_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief cube root functions
+ * @details @b #include <tinyara/math.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 double cbrt(double x);
@@ -472,21 +528,27 @@ double cbrt(double x);
 #ifdef CONFIG_HAVE_LONG_DOUBLE
 /**
  * @ingroup MATH_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief cube root functions
+ * @details @b #include <tinyara/math.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 long double cbrtl(long double x);
 #endif
 /**
  * @ingroup MATH_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief square root function
+ * @details @b #include <tinyara/math.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 float sqrtf(float x);
 #ifdef CONFIG_HAVE_DOUBLE
 /**
  * @ingroup MATH_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief square root function
+ * @details @b #include <tinyara/math.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 double sqrt(double x);
@@ -494,21 +556,27 @@ double sqrt(double x);
 #ifdef CONFIG_HAVE_LONG_DOUBLE
 /**
  * @ingroup MATH_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief square root function
+ * @details @b #include <tinyara/math.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 long double sqrtl(long double x);
 #endif
 /**
  * @ingroup MATH_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief load exponent of a floating-point number
+ * @details @b #include <tinyara/math.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 float ldexpf(float x, int n);
 #ifdef CONFIG_HAVE_DOUBLE
 /**
  * @ingroup MATH_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief load exponent of a floating-point number
+ * @details @b #include <tinyara/math.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 double ldexp(double x, int n);
@@ -516,21 +584,27 @@ double ldexp(double x, int n);
 #ifdef CONFIG_HAVE_LONG_DOUBLE
 /**
  * @ingroup MATH_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief load exponent of a floating-point number
+ * @details @b #include <tinyara/math.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 long double ldexpl(long double x, int n);
 #endif
 /**
  * @ingroup MATH_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief extract mantissa and exponent from a double precision number
+ * @details @b #include <tinyara/math.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 float frexpf(float x, int *exp);
 #ifdef CONFIG_HAVE_DOUBLE
 /**
  * @ingroup MATH_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief extract mantissa and exponent from a double precision number
+ * @details @b #include <tinyara/math.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 double frexp(double x, int *exp);
@@ -538,7 +612,9 @@ double frexp(double x, int *exp);
 #ifdef CONFIG_HAVE_LONG_DOUBLE
 /**
  * @ingroup MATH_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief extract mantissa and exponent from a double precision number
+ * @details @b #include <tinyara/math.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 long double frexpl(long double x, int *exp);
@@ -547,14 +623,18 @@ long double frexpl(long double x, int *exp);
 /* Trigonometric Functions ************************************************* */
 /**
  * @ingroup MATH_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief sine function
+ * @details @b #include <tinyara/math.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 float sinf(float x);
 #ifdef CONFIG_HAVE_DOUBLE
 /**
  * @ingroup MATH_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief sine function
+ * @details @b #include <tinyara/math.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 double sin(double x);
@@ -562,21 +642,27 @@ double sin(double x);
 #ifdef CONFIG_HAVE_LONG_DOUBLE
 /**
  * @ingroup MATH_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief sine function
+ * @details @b #include <tinyara/math.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 long double sinl(long double x);
 #endif
 /**
  * @ingroup MATH_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief cosine function
+ * @details @b #include <tinyara/math.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 float cosf(float x);
 #ifdef CONFIG_HAVE_DOUBLE
 /**
  * @ingroup MATH_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief cosine function
+ * @details @b #include <tinyara/math.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 double cos(double x);
@@ -584,21 +670,27 @@ double cos(double x);
 #ifdef CONFIG_HAVE_LONG_DOUBLE
 /**
  * @ingroup MATH_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief cosine function
+ * @details @b #include <tinyara/math.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 long double cosl(long double x);
 #endif
 /**
  * @ingroup MATH_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief tangent function
+ * @details @b #include <tinyara/math.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 float tanf(float x);
 #if CONFIG_HAVE_DOUBLE
 /**
  * @ingroup MATH_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief tangent function
+ * @details @b #include <tinyara/math.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 double tan(double x);
@@ -606,21 +698,27 @@ double tan(double x);
 #ifdef CONFIG_HAVE_LONG_DOUBLE
 /**
  * @ingroup MATH_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief tangent function
+ * @details @b #include <tinyara/math.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 long double tanl(long double x);
 #endif
 /**
  * @ingroup MATH_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief arc sine function
+ * @details @b #include <tinyara/math.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 float asinf(float x);
 #ifdef CONFIG_HAVE_DOUBLE
 /**
  * @ingroup MATH_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief arc sine function
+ * @details @b #include <tinyara/math.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 double asin(double x);
@@ -628,21 +726,27 @@ double asin(double x);
 #ifdef CONFIG_HAVE_LONG_DOUBLE
 /**
  * @ingroup MATH_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief arc sine function
+ * @details @b #include <tinyara/math.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 long double asinl(long double x);
 #endif
 /**
  * @ingroup MATH_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief 
+ * @details @b #include <tinyara/math.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 float acosf(float x);
 #if CONFIG_HAVE_DOUBLE
 /**
  * @ingroup MATH_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief arc cosine functions
+ * @details @b #include <tinyara/math.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 double acos(double x);
@@ -650,21 +754,27 @@ double acos(double x);
 #ifdef CONFIG_HAVE_LONG_DOUBLE
 /**
  * @ingroup MATH_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief arc cosine functions
+ * @details @b #include <tinyara/math.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 long double acosl(long double x);
 #endif
 /**
  * @ingroup MATH_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief arc cosine functions
+ * @details @b #include <tinyara/math.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 float atanf(float x);
 #ifdef CONFIG_HAVE_DOUBLE
 /**
  * @ingroup MATH_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief arc tangent function
+ * @details @b #include <tinyara/math.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 double atan(double x);
@@ -672,21 +782,27 @@ double atan(double x);
 #ifdef CONFIG_HAVE_LONG_DOUBLE
 /**
  * @ingroup MATH_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief arc tangent function
+ * @details @b #include <tinyara/math.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 long double atanl(long double x);
 #endif
 /**
  * @ingroup MATH_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief arc tangent function
+ * @details @b #include <tinyara/math.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 float atan2f(float y, float x);
 #ifdef CONFIG_HAVE_DOUBLE
 /**
  * @ingroup MATH_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief arc tangent function
+ * @details @b #include <tinyara/math.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 double atan2(double y, double x);
@@ -694,21 +810,27 @@ double atan2(double y, double x);
 #ifdef CONFIG_HAVE_LONG_DOUBLE
 /**
  * @ingroup MATH_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief arc tangent function
+ * @details @b #include <tinyara/math.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 long double atan2l(long double y, long double x);
 #endif
 /**
  * @ingroup MATH_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief hyperbolic sine functions
+ * @details @b #include <tinyara/math.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 float sinhf(float x);
 #ifdef CONFIG_HAVE_DOUBLE
 /**
  * @ingroup MATH_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief hyperbolic sine functions
+ * @details @b #include <tinyara/math.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 double sinh(double x);
@@ -716,21 +838,27 @@ double sinh(double x);
 #ifdef CONFIG_HAVE_LONG_DOUBLE
 /**
  * @ingroup MATH_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief hyperbolic sine functions
+ * @details @b #include <tinyara/math.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 long double sinhl(long double x);
 #endif
 /**
  * @ingroup MATH_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief hyperbolic cosine functions
+ * @details @b #include <tinyara/math.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 float coshf(float x);
 #ifdef CONFIG_HAVE_DOUBLE
 /**
  * @ingroup MATH_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief hyperbolic cosine functions
+ * @details @b #include <tinyara/math.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 double cosh(double x);
@@ -738,21 +866,27 @@ double cosh(double x);
 #ifdef CONFIG_HAVE_LONG_DOUBLE
 /**
  * @ingroup MATH_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief hyperbolic cosine functions
+ * @details @b #include <tinyara/math.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 long double coshl(long double x);
 #endif
 /**
  * @ingroup MATH_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief hyperbolic tangent functions
+ * @details @b #include <tinyara/math.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 float tanhf(float x);
 #ifdef CONFIG_HAVE_DOUBLE
 /**
  * @ingroup MATH_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief hyperbolic tangent functions
+ * @details @b #include <tinyara/math.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 double tanh(double x);
@@ -760,21 +894,27 @@ double tanh(double x);
 #ifdef CONFIG_HAVE_LONG_DOUBLE
 /**
  * @ingroup MATH_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief hyperbolic tangent functions
+ * @details @b #include <tinyara/math.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 long double tanhl(long double x);
 #endif
 /**
  * @ingroup MATH_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief inverse hyperbolic sine functions
+ * @details @b #include <tinyara/math.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 float asinhf(float x);
 #ifdef CONFIG_HAVE_DOUBLE
 /**
  * @ingroup MATH_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief inverse hyperbolic sine functions
+ * @details @b #include <tinyara/math.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 double asinh(double x);
@@ -782,21 +922,27 @@ double asinh(double x);
 #ifdef CONFIG_HAVE_LONG_DOUBLE
 /**
  * @ingroup MATH_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief inverse hyperbolic sine functions
+ * @details @b #include <tinyara/math.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 long double asinhl(long double x);
 #endif
 /**
  * @ingroup MATH_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief inverse hyperbolic cosine functions
+ * @details @b #include <tinyara/math.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 float acoshf(float x);
 #ifdef CONFIG_HAVE_DOUBLE
 /**
  * @ingroup MATH_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief inverse hyperbolic cosine functions
+ * @details @b #include <tinyara/math.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 double acosh(double x);
@@ -804,21 +950,27 @@ double acosh(double x);
 #ifdef CONFIG_HAVE_LONG_DOUBLE
 /**
  * @ingroup MATH_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief inverse hyperbolic cosine functions
+ * @details @b #include <tinyara/math.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 long double acoshl(long double x);
 #endif
 /**
  * @ingroup MATH_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief inverse hyperbolic tangent functions
+ * @details @b #include <tinyara/math.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 float atanhf(float x);
 #ifdef CONFIG_HAVE_DOUBLE
 /**
  * @ingroup MATH_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief inverse hyperbolic tangent functions
+ * @details @b #include <tinyara/math.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 double atanh(double x);
@@ -826,14 +978,18 @@ double atanh(double x);
 #ifdef CONFIG_HAVE_LONG_DOUBLE
 /**
  * @ingroup MATH_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief inverse hyperbolic tangent functions
+ * @details @b #include <tinyara/math.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 long double atanhl(long double x);
 #endif
 /**
  * @ingroup MATH_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief error functions
+ * @details @b #include <tinyara/math.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 float erff(float x);
@@ -848,7 +1004,9 @@ float erff(float x);
  */
 /**
  * @ingroup MATH_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief error functions
+ * @details @b #include <tinyara/math.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 double erf(double x);
@@ -857,7 +1015,9 @@ double erf(double x);
 #ifdef CONFIG_HAVE_LONG_DOUBLE
 /**
  * @ingroup MATH_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief error functions
+ * @details @b #include <tinyara/math.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 long double erfl(long double x);
@@ -865,14 +1025,18 @@ long double erfl(long double x);
 #endif
 /**
  * @ingroup MATH_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief number manipulation function
+ * @details @b #include <tinyara/math.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 float copysignf(float x, float y);
 #ifdef CONFIG_HAVE_DOUBLE
 /**
  * @ingroup MATH_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief number manipulation function
+ * @details @b #include <tinyara/math.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 double copysign(double x, double y);
@@ -880,21 +1044,27 @@ double copysign(double x, double y);
 #ifdef CONFIG_HAVE_LONG_DOUBLE
 /**
  * @ingroup MATH_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief number manipulation function
+ * @details @b #include <tinyara/math.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 long double copysignl(long double x, long double y);
 #endif
 /**
  * @ingroup MATH_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief round to truncated integer value
+ * @details @b #include <tinyara/math.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 float truncf(float x);
 #ifdef CONFIG_HAVE_DOUBLE
 /**
  * @ingroup MATH_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief round to truncated integer value
+ * @details @b #include <tinyara/math.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 double trunc(double x);
@@ -902,21 +1072,27 @@ double trunc(double x);
 #ifdef CONFIG_HAVE_LONG_DOUBLE
 /**
  * @ingroup MATH_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief round to truncated integer value
+ * @details @b #include <tinyara/math.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 long double truncl(long double x);
 #endif
 /**
  * @ingroup MATH_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief compute positive difference between two floating-point numbers
+ * @details @b #include <tinyara/math.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 float fdimf(float x, float y);
 #ifdef CONFIG_HAVE_DOUBLE
 /**
  * @ingroup MATH_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief compute positive difference between two floating-point numbers
+ * @details @b #include <tinyara/math.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 double fdim(double x, double y);
@@ -924,21 +1100,27 @@ double fdim(double x, double y);
 #ifdef CONFIG_HAVE_LONG_DOUBLE
 /**
  * @ingroup MATH_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief compute positive difference between two floating-point numbers
+ * @details @b #include <tinyara/math.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 long double fdiml(long double x, long double y);
 #endif
 /**
  * @ingroup MATH_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief 
+ * @details @b #include <tinyara/math.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 float fmaxf(float x, float y);
 #ifdef CONFIG_HAVE_DOUBLE
 /**
  * @ingroup MATH_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief determine maximum numeric value of two floating-point numbers
+ * @details @b #include <tinyara/math.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 double fmax(double x, double y);
@@ -946,21 +1128,27 @@ double fmax(double x, double y);
 #ifdef CONFIG_HAVE_LONG_DOUBLE
 /**
  * @ingroup MATH_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief determine maximum numeric value of two floating-point numbers
+ * @details @b #include <tinyara/math.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 long double fmaxl(long double x, long double y);
 #endif
 /**
  * @ingroup MATH_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief determine minimum numeric value of two floating-point numbers
+ * @details @b #include <tinyara/math.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 float fminf(float x, float y);
 #ifdef CONFIG_HAVE_DOUBLE
 /**
  * @ingroup MATH_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief determine minimum numeric value of two floating-point numbers
+ * @details @b #include <tinyara/math.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 double fmin(double x, double y);
@@ -968,21 +1156,27 @@ double fmin(double x, double y);
 #ifdef CONFIG_HAVE_LONG_DOUBLE
 /**
  * @ingroup MATH_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief determine minimum numeric value of two floating-point numbers
+ * @details @b #include <tinyara/math.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 long double fminl(long double x, long double y);
 #endif
 /**
  * @ingroup MATH_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief Euclidean distance function
+ * @details @b #include <tinyara/math.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 float hypotf(float x, float y);
 #ifdef CONFIG_HAVE_DOUBLE
 /**
  * @ingroup MATH_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief Euclidean distance function
+ * @details @b #include <tinyara/math.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 double hypot(double x, double y);
@@ -990,21 +1184,27 @@ double hypot(double x, double y);
 #ifdef CONFIG_HAVE_LONG_DOUBLE
 /**
  * @ingroup MATH_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief Euclidean distance function
+ * @details @b #include <tinyara/math.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 long double hypotl(long double x, long double y);
 #endif
 /**
  * @ingroup MATH_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief compute exponent using FLT_RADIX
+ * @details @b #include <tinyara/math.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 float scalbnf(float x, int exp);
 #ifdef CONFIG_HAVE_DOUBLE
 /**
  * @ingroup MATH_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief compute exponent using FLT_RADIX
+ * @details @b #include <tinyara/math.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 double scalbn(double x, int exp);
@@ -1012,7 +1212,9 @@ double scalbn(double x, int exp);
 #ifdef CONFIG_HAVE_LONG_DOUBLE
 /**
  * @ingroup MATH_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief compute exponent using FLT_RADIX
+ * @details @b #include <tinyara/math.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 long double scalbnl(long double x, int exp);
@@ -1020,7 +1222,8 @@ long double scalbnl(long double x, int exp);
 /**
  * @ingroup MATH_LIBC
  * @brief returns Bessel functions of x of the first kind of orders 0
- * @param[in] float type value which wants to calc j0
+ * @details @b #include <tinyara/math.h>
+ * @param[in] x float type value which wants to calc j0
  * @return If x is a NaN, a NaN is returned. If x is too large in magnitude, or the result underflows,
  *  a range error occurs, and the return value is 0.
  * @since Tizen RT v1.1
@@ -1029,7 +1232,8 @@ float j0f(float x);
 /**
  * @ingroup MATH_LIBC
  * @brief returns Bessel functions of x of the first kind of orders 1
- * @param[in] float type value which wants to calc j1
+ * @details @b #include <tinyara/math.h>
+ * @param[in] x float type value which wants to calc j1
  * @return If x is a NaN, a NaN is returned. If x is too large in magnitude, or the result underflows,
  *  a range error occurs, and the return value is 0.
  * @since Tizen RT v1.1
@@ -1038,8 +1242,9 @@ float j1f(float x);
 /**
  * @ingroup MATH_LIBC
  * @brief returns Bessel functions of x of the first kind of orders n
- * @param[in] the number which want to calc the first kind of orders
- * @param[in] float type value which wants to calc jn
+ * @details @b #include <tinyara/math.h>
+ * @param[in] n the number which want to calc the first kind of orders
+ * @param[in] x float type value which wants to calc jn
  * @return If x is a NaN, a NaN is returned. If x is too large in magnitude, or the result underflows,
  *  a range error occurs, and the return value is 0.
  * @since Tizen RT v1.1
@@ -1048,19 +1253,25 @@ float jnf(int n, float x);
 #ifdef CONFIG_HAVE_DOUBLE
 /**
  * @ingroup MATH_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief Bessel functions of the first kind
+ * @details @b #include <tinyara/math.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 double j0(double x);
 /**
  * @ingroup MATH_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief Bessel functions of the first kind
+ * @details @b #include <tinyara/math.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 double j1(double x);
 /**
  * @ingroup MATH_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief Bessel functions of the first kind
+ * @details @b #include <tinyara/math.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 double jn(int n, double x);
@@ -1068,7 +1279,8 @@ double jn(int n, double x);
 /**
  * @ingroup MATH_LIBC
  * @brief returns Bessel functions of x of the second kind of orders 0
- * @param[in] float type value which wants to calc j0, it should be positive
+ * @details @b #include <tinyara/math.h>
+ * @param[in] x float type value which wants to calc j0, it should be positive
  * @return If x is a NaN, a NaN is returned. If x is negative, it returns -HUGE_VALF.
  *  If x is 0.0, it returns -HUGE_VALF. If the result underflows, it returns 0.0.
  *  If the result overflows, it returns -HUGE_VALF.
@@ -1078,7 +1290,8 @@ float y0f(float x);
 /**
  * @ingroup MATH_LIBC
  * @brief returns Bessel functions of x of the second kind of orders 1
- * @param[in] float type value which wants to calc j1, it should be positive
+ * @details @b #include <tinyara/math.h>
+ * @param[in] x float type value which wants to calc j1, it should be positive
  * @return If x is a NaN, a NaN is returned. If x is negative, it returns -HUGE_VALF.
  *  If x is 0.0, it returns -HUGE_VALF. If the result underflows, it returns 0.0.
  *  If the result overflows, it returns -HUGE_VALF.
@@ -1088,8 +1301,9 @@ float y1f(float x);
 /**
  * @ingroup MATH_LIBC
  * @brief returns Bessel functions of x of the second kind of orders n
- * @param[in] the number which want to calc the second kind of orders
- * @param[in] float type value which wants to calc jn, it should be positive
+ * @details @b #include <tinyara/math.h>
+ * @param[in] n the number which want to calc the second kind of orders
+ * @param[in] x float type value which wants to calc jn, it should be positive
  * @return If x is a NaN, a NaN is returned. If x is negative, it returns -HUGE_VALF.
  *  If x is 0.0, it returns -HUGE_VALF. If the result underflows, it returns 0.0.
  *  If the result overflows, it returns -HUGE_VALF.
@@ -1099,19 +1313,25 @@ float ynf(int n, float x);
 #ifdef CONFIG_HAVE_DOUBLE
 /**
  * @ingroup MATH_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief Bessel functions of the second kind
+ * @details @b #include <tinyara/math.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 double y0(double x);
 /**
  * @ingroup MATH_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief Bessel functions of the second kind
+ * @details @b #include <tinyara/math.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 double y1(double x);
 /**
  * @ingroup MATH_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief Bessel functions of the second kind
+ * @details @b #include <tinyara/math.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 double yn(int n, double x);
@@ -1119,21 +1339,27 @@ double yn(int n, double x);
 #ifdef CONFIG_HAVE_DOUBLE
 /**
  * @ingroup MATH_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief next representable floating-point number
+ * @details @b #include <tinyara/math.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 double nextafter(double x, double y);
 #endif
 /**
  * @ingroup MATH_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief next representable floating-point number
+ * @details @b #include <tinyara/math.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 float nextafterf(float x, float y);
 #ifdef CONFIG_HAVE_LONG_DOUBLE
 /**
  * @ingroup MATH_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief next representable floating-point number
+ * @details @b #include <tinyara/math.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 long double nextafterl(long double x, long double y);
@@ -1141,21 +1367,27 @@ long double nextafterl(long double x, long double y);
 #ifdef CONFIG_HAVE_DOUBLE
 /**
  * @ingroup MATH_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief next representable floating-point number
+ * @details @b #include <tinyara/math.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 double nexttoward(double x, long double y);
 #endif
 /**
  * @ingroup MATH_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief next representable floating-point number
+ * @details @b #include <tinyara/math.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 float nexttowardf(float x, long double y);
 #ifdef CONFIG_HAVE_LONG_DOUBLE
 /**
  * @ingroup MATH_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief next representable floating-point number
+ * @details @b #include <tinyara/math.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 long double nexttowardl(long double x, long double y);
@@ -1163,21 +1395,27 @@ long double nexttowardl(long double x, long double y);
 #ifdef CONFIG_HAVE_DOUBLE
 /**
  * @ingroup MATH_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief remainder function
+ * @details @b #include <tinyara/math.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 double remainder(double x, double y);
 #endif
 /**
  * @ingroup MATH_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief remainder function
+ * @details @b #include <tinyara/math.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 float remainderf(float x, float y);
 #ifdef CONFIG_HAVE_LONG_DOUBLE
 /**
  * @ingroup MATH_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief remainder function
+ * @details @b #include <tinyara/math.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 long double remainderl(long double x, long double y);
@@ -1185,21 +1423,27 @@ long double remainderl(long double x, long double y);
 #ifdef CONFIG_HAVE_DOUBLE
 /**
  * @ingroup MATH_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief remainder functions
+ * @details @b #include <tinyara/math.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 double remquo(double x, double y, int *quo);
 #endif
 /**
  * @ingroup MATH_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief remainder functions
+ * @details @b #include <tinyara/math.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 float remquof(float x, float y, int *quo);
 #ifdef CONFIG_HAVE_LONG_DOUBLE
 /**
  * @ingroup MATH_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief remainder functions
+ * @details @b #include <tinyara/math.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 long double remquol(long double x, long double y, int *quo);

--- a/os/include/tinyara/regex.h
+++ b/os/include/tinyara/regex.h
@@ -85,6 +85,7 @@ extern "C" {
 /**
  * @ingroup REGEX_KERNEL
  * @brief  Simple shell-style filename pattern matcher
+ * @details @b #include <tinyara/regex.h>
  * @param[in] pattern, only '?', '*' and '**', and multiple patterns separated by '|'.
  * @param[in] string to match pattern
  * @return Returns 1 (match) or 0 (no-match)

--- a/os/include/tinyara/sched.h
+++ b/os/include/tinyara/sched.h
@@ -686,7 +686,8 @@ extern "C" {
  * @ingroup SCHED_KERNEL
  * @brief returns the TCB of the currently running task (i.e., the
  * caller)
- * @details  Basically, this function just wraps the
+ * @details @b #include <tinyara/sched.h> \n
+ *  Basically, this function just wraps the
  *   head of the ready-to-run list and manages access to the TCB from outside
  *   of the sched/ sub-directory.
  * @return TCB structure
@@ -702,8 +703,9 @@ FAR struct tcb_s *sched_self(void);
  * or thread to a callback function.  Interrupts will be disabled throughout
  * this enumeration!
  *
- * @param[in] The function to be called with the TCB of each task
- * @param[in] param
+ * @details @b #include <tinyara/sched.h>
+ * @param[in] handler The function to be called with the TCB of each task
+ * @param[in] arg param
  * @return none
  * @since Tizen RT v1.0
  */
@@ -712,10 +714,11 @@ void sched_foreach(sched_foreach_t handler, FAR void *arg);
 /**
  * @ingroup SCHED_KERNEL
  * @brief Give a task ID, look up the corresponding TCB
- * @details  Given a task ID, this function will return
+ * @details @b #include <tinyara/sched.h> \n
+ *   Given a task ID, this function will return
  *   the a pointer to the corresponding TCB (or NULL if there
  *   is no such task ID).
- * @param[in] Pid for tcb
+ * @param[in] pid Pid for tcb
  * @return TCB structure about pid
  * @since Tizen RT v1.0
  */
@@ -739,6 +742,7 @@ FAR struct filelist *sched_getfiles(void);
 /**
  * @ingroup SCEHD_KERNEL
  * @brief Return a pointer to the streams list for this thread
+ * @details @b #include <tinyara/sched.h>
  * @return A pointer to the errno
  * @since Tizen RT v1.0
  */

--- a/os/include/tinyara/spawn.h
+++ b/os/include/tinyara/spawn.h
@@ -149,8 +149,9 @@ extern "C" {
  * @ingroup SPAWN_LIBC
  * @brief Add the file action to the end for the file action list.
  *
- * @param[in] The head of the file action list.
- * @param[in] The file action to be added
+ * @details @b #include <tinyara/spawn.h>
+ * @param[in] file_action The head of the file action list.
+ * @param[in] entry The file action to be added
  * @return none
  * @since Tizen RT v1.0
  */

--- a/os/include/tinyara/streams.h
+++ b/os/include/tinyara/streams.h
@@ -301,9 +301,10 @@ extern "C" {
 /**
  * @ingroup STREAMS_LIBC
  * @brief Initializes a stream for use with a fixed-size memory buffer
- * @param[in] User allocated, uninitialized instance of struct lib_meminstream_s
- * @param[in] Address of the beginning of the fixed-size memory buffer
- * @param[in] Size of the fixed-sized memory buffer in bytes
+ * @details @b #include <tinyara/streams.h>
+ * @param[in] instream User allocated, uninitialized instance of struct lib_meminstream_s
+ * @param[in] bufstart Address of the beginning of the fixed-size memory buffer
+ * @param[in] buflen Size of the fixed-sized memory buffer in bytes
  * @return None
  * @since Tizen RT v1.1
  */
@@ -311,9 +312,10 @@ void lib_meminstream(FAR struct lib_meminstream_s *instream, FAR const char *buf
 /**
  * @ingroup STREAMS_LIBC
  * @brief Initializes a stream for use with a fixed-size memory buffer
- * @param[in] User allocated, uninitialized instance of struct lib_memoutstream_s
- * @param[in] Address of the beginning of the fixed-size memory buffer
- * @param[in] Size of the fixed-sized memory buffer in bytes
+ * @details @b #include <tinyara/streams.h>
+ * @param[in] outstream User allocated, uninitialized instance of struct lib_memoutstream_s
+ * @param[in] bufstart Address of the beginning of the fixed-size memory buffer
+ * @param[in] buflen Size of the fixed-sized memory buffer in bytes
  * @return None
  * @since Tizen RT v1.1
  */
@@ -321,9 +323,10 @@ void lib_memoutstream(FAR struct lib_memoutstream_s *outstream, FAR char *bufsta
 /**
  * @ingroup STREAMS_LIBC
  * @brief Initializes a stream for use with a fixed-size memory buffer
- * @param[in] User allocated, uninitialized instance of struct lib_memsistream_s
- * @param[in] Address of the beginning of the fixed-size memory buffer
- * @param[in] Size of the fixed-sized memory buffer in bytes
+ * @details @b #include <tinyara/streams.h>
+ * @param[in] instream User allocated, uninitialized instance of struct lib_memsistream_s
+ * @param[in] bufstart Address of the beginning of the fixed-size memory buffer
+ * @param[in] buflen Size of the fixed-sized memory buffer in bytes
  * @return None
  * @since Tizen RT v1.1
  */
@@ -331,9 +334,10 @@ void lib_memsistream(FAR struct lib_memsistream_s *instream, FAR const char *buf
 /**
  * @ingroup STREAMS_LIBC
  * @brief Initializes a stream for use with a fixed-size memory buffer
- * @param[in] User allocated, uninitialized instance of struct lib_memsostream_s
- * @param[in] Address of the beginning of the fixed-size memory buffer
- * @param[in] Size of the fixed-sized memory buffer in bytes
+ * @details @b #include <tinyara/streams.h>
+ * @param[in] outstream User allocated, uninitialized instance of struct lib_memsostream_s
+ * @param[in] bufstart Address of the beginning of the fixed-size memory buffer
+ * @param[in] buflen Size of the fixed-sized memory buffer in bytes
  * @return None
  * @since Tizen RT v1.1
  */
@@ -362,8 +366,9 @@ void lib_memsostream(FAR struct lib_memsostream_s *outstream, FAR char *bufstart
 /**
  * @ingroup STREAMS_LIBC
  * @brief Initializes a stream for use with a FILE instance
- * @param[in] User allocated, uninitialized instance of struct lib_stdinstream_s
- * @param[in] Stream provided by user
+ * @details @b #include <tinyara/streams.h>
+ * @param[in] instream User allocated, uninitialized instance of struct lib_stdinstream_s
+ * @param[in] stream Stream provided by user
  * @return None
  * @since Tizen RT v1.1
  */
@@ -371,8 +376,9 @@ void lib_stdinstream(FAR struct lib_stdinstream_s *instream, FAR FILE *stream);
 /**
  * @ingroup STREAMS_LIBC
  * @brief Initializes a stream for use with a FILE instance
- * @param[in] User allocated, uninitialized instance of struct lib_stdoutstream_s
- * @param[in] Stream provided by user
+ * @details @b #include <tinyara/streams.h>
+ * @param[in] outstream User allocated, uninitialized instance of struct lib_stdoutstream_s
+ * @param[in] stream Stream provided by user
  * @return None
  * @since Tizen RT v1.1
  */
@@ -380,8 +386,9 @@ void lib_stdoutstream(FAR struct lib_stdoutstream_s *outstream, FAR FILE *stream
 /**
  * @ingroup STREAMS_LIBC
  * @brief Initializes a stream for use with a FILE instance
- * @param[in] User allocated, uninitialized instance of struct lib_stdsistream_s
- * @param[in] Stream provided by user
+ * @details @b #include <tinyara/streams.h>
+ * @param[in] instream User allocated, uninitialized instance of struct lib_stdsistream_s
+ * @param[in] stream Stream provided by user
  * @return None
  * @since Tizen RT v1.1
  */
@@ -389,8 +396,9 @@ void lib_stdsistream(FAR struct lib_stdsistream_s *instream, FAR FILE *stream);
 /**
  * @ingroup STREAMS_LIBC
  * @brief Initializes a stream for use with a FILE instance
- * @param[in] User allocated, uninitialized instance of struct lib_stdsostream_s
- * @param[in] Stream provided by user
+ * @details @b #include <tinyara/streams.h>
+ * @param[in] outstream User allocated, uninitialized instance of struct lib_stdsostream_s
+ * @param[in] stream Stream provided by user
  * @return None
  * @since Tizen RT v1.1
  */
@@ -421,8 +429,9 @@ void lib_stdsostream(FAR struct lib_stdsostream_s *outstream, FAR FILE *stream);
 /**
  * @ingroup STREAMS_LIBC
  * @brief Initializes a stream for use with a file descriptor
- * @param[in] User allocated, uninitialized instance of struct lib_rawinstream_s
- * @param[in] file/socket descriptor provided by user
+ * @details @b #include <tinyara/streams.h>
+ * @param[in] instream User allocated, uninitialized instance of struct lib_rawinstream_s
+ * @param[in] fd file/socket descriptor provided by user
  * @return None
  * @since Tizen RT v1.1
  */
@@ -430,8 +439,9 @@ void lib_rawinstream(FAR struct lib_rawinstream_s *instream, int fd);
 /**
  * @ingroup STREAMS_LIBC
  * @brief Initializes a stream for use with a file descriptor
- * @param[in] User allocated, uninitialized instance of struct lib_rawoutstream_s
- * @param[in] file/socket descriptor provided by user
+ * @details @b #include <tinyara/streams.h>
+ * @param[in] outstream User allocated, uninitialized instance of struct lib_rawoutstream_s
+ * @param[in] fd file/socket descriptor provided by user
  * @return None
  * @since Tizen RT v1.1
  */
@@ -439,8 +449,9 @@ void lib_rawoutstream(FAR struct lib_rawoutstream_s *outstream, int fd);
 /**
  * @ingroup STREAMS_LIBC
  * @brief Initializes a stream for use with a file descriptor
- * @param[in] User allocated, uninitialized instance of struct lib_rawsistream_s
- * @param[in] file/socket descriptor provided by user
+ * @details @b #include <tinyara/streams.h>
+ * @param[in] instream User allocated, uninitialized instance of struct lib_rawsistream_s
+ * @param[in] fd file/socket descriptor provided by user
  * @return None
  * @since Tizen RT v1.1
  */
@@ -448,8 +459,9 @@ void lib_rawsistream(FAR struct lib_rawsistream_s *instream, int fd);
 /**
  * @ingroup STREAMS_LIBC
  * @brief Initializes a stream for use with a file descriptor
- * @param[in] User allocated, uninitialized instance of struct lib_rawsostream_s
- * @param[in] file/socket descriptor provided by user
+ * @details @b #include <tinyara/streams.h>
+ * @param[in] outstream User allocated, uninitialized instance of struct lib_rawsostream_s
+ * @param[in] fd file/socket descriptor provided by user
  * @return None
  * @since Tizen RT v1.1
  */
@@ -477,7 +489,8 @@ void lib_rawsostream(FAR struct lib_rawsostream_s *outstream, int fd);
 /**
  * @ingroup STREAMS_LIBC
  * @brief Initializes a stream for use with low-level, architecture-specific I/O
- * @param[in] User allocated, uninitialized instance of struct lib_lowinstream_s
+ * @details @b #include <tinyara/streams.h>
+ * @param[in] lowinstream User allocated, uninitialized instance of struct lib_lowinstream_s
  * @return None
  * @since Tizen RT v1.1
  */
@@ -487,7 +500,8 @@ void lib_lowinstream(FAR struct lib_instream_s *lowinstream);
 /**
  * @ingroup STREAMS_LIBC
  * @brief Initializes a stream for use with low-level, architecture-specific I/O
- * @param[in] User allocated, uninitialized instance of struct lib_lowoutstream_s
+ * @details @b #include <tinyara/streams.h>
+ * @param[in] lowoutstream User allocated, uninitialized instance of struct lib_lowoutstream_s
  * @return None
  * @since Tizen RT v1.1
  */
@@ -522,7 +536,8 @@ void lib_lowoutstream(FAR struct lib_outstream_s *lowoutstream);
 /**
  * @ingroup STREAMS_LIBC
  * @brief Initializes NULL stream
- * @param[in] User allocated, uninitialized instance of struct lib_instream_s
+ * @details @b #include <tinyara/streams.h>
+ * @param[in] zeroinstream User allocated, uninitialized instance of struct lib_instream_s
  * @return None
  * @since Tizen RT v1.1
  */
@@ -530,7 +545,8 @@ void lib_zeroinstream(FAR struct lib_instream_s *zeroinstream);
 /**
  * @ingroup STREAMS_LIBC
  * @brief Initializes NULL stream
- * @param[in] User allocated, uninitialized instance of struct lib_instream_s
+ * @details @b #include <tinyara/streams.h>
+ * @param[in] nullinstream User allocated, uninitialized instance of struct lib_instream_s
  * @return None
  * @since Tizen RT v1.1
  */
@@ -538,7 +554,8 @@ void lib_nullinstream(FAR struct lib_instream_s *nullinstream);
 /**
  * @ingroup STREAMS_LIBC
  * @brief Initializes NULL stream
- * @param[in] User allocated, uninitialized instance of struct lib_outstream_s
+ * @details @b #include <tinyara/streams.h>
+ * @param[in] nulloutstream User allocated, uninitialized instance of struct lib_outstream_s
  * @return None
  * @since Tizen RT v1.1
  */

--- a/os/include/tinyara/time.h
+++ b/os/include/tinyara/time.h
@@ -100,7 +100,8 @@ extern "C" {
 /**
  * @ingroup TIME_KERNEL
  * @brief Return true if the specified year is a leap year
- * @param[in] year to check whether a leap year or not
+ * @details @b #include <tinyara/time.h>
+ * @param[in] year year to check whether a leap year or not
  * @return if leap year, TRUE or FALSE
  * @since Tizen RT v1.0
  */
@@ -109,8 +110,9 @@ EXTERN int clock_isleapyear(int year);
 /**
  * @ingroup TIME_KERNEL
  * @brief Get the number of days that occurred before the beginning of the month.
- * @param[in] the beginning of the month
- * @param[in] leap year
+ * @details @b #include <tinyara/time.h>
+ * @param[in] month the beginning of the month
+ * @param[in] leapyear leap year
  * @return the number of days
  * @since Tizen RT v1.0
  */
@@ -122,11 +124,11 @@ EXTERN int clock_daysbeforemonth(int month, bool leapyear);
  */
 /**
  * @ingroup TIME_KERNEL
- * @todo
  * @brief Get the day of the week
- * @param[in] The day of the month 1 - 31
- * @param[in] The month of the year 1 - 12
- * @param[in] the year including the 1900
+ * @details @b #include <tinyara/time.h>
+ * @param[in] mday The day of the month 1 - 31
+ * @param[in] month The month of the year 1 - 12
+ * @param[in] year the year including the 1900
  * @return Zero based day of the week 0-6, 0 = Sunday, 1 = Monday... 6 = Saturday
  * @since Tizen RT v1.0
  */
@@ -140,13 +142,14 @@ int clock_dayoftheweek(int mday, int month, int year);
 /**
  * @ingroup TIME_KERNEL
  * @brief Conversion Calendar/UTC
- * @details based on algorithms from p. 604
+ * @details @b #include <tinyara/time.h> \n
+ *    based on algorithms from p. 604
  *    of Seidelman, P. K. 1992.  Explanatory Supplement to
  *    the Astronomical Almanac.  University Science Books,
  *    Mill Valley.
- * @param[in] year to change
- * @param[in] month to change
- * @param[in] day to change
+ * @param[in] year year to change
+ * @param[in] month month to change
+ * @param[in] day day to change
  * @return the specific time
  * @since Tizen RT v1.0
  */

--- a/os/include/tinyara/ttrace.h
+++ b/os/include/tinyara/ttrace.h
@@ -113,8 +113,9 @@ extern "C" {
 /**
  * @ingroup TTRACE_LIBC
  * @brief writes a trace log with string to indicate that a event has begun
- * @param[in] number for tag
- * @param[in] unique strings like function name for distinguishing events
+ * @details @b #include <tinyara/ttrace.h>
+ * @param[in] tag number for tag
+ * @param[in] str unique strings like function name for distinguishing events
  * @return On success, TTRACE_VALID is returned. On failure, ERROR is returned and errno is set appropriately.
  * @since Tizen RT v1.1
  */
@@ -123,8 +124,9 @@ int trace_begin(int tag, char *str, ...);
 /**
  * @ingroup TTRACE_LIBC
  * @brief writes a trace log with unique id to indicate that a event has begun
- * @param[in] number for tag
- * @param[in] unique id for distinguishing events
+ * @details @b #include <tinyara/ttrace.h>
+ * @param[in] tag number for tag
+ * @param[in] uniqueid unique id for distinguishing events
  * @return On success, TTRACE_VALID is returned. On failure, TTRACE_INVALID is returned and errno is set appropriately.
  * @since Tizen RT v1.1
  */
@@ -133,7 +135,8 @@ int trace_begin_uid(int tag, int8_t uniqueid);
 /**
  * @ingroup TTRACE_LIBC
  * @brief writes a trace log to indicate that the event has ended
- * @param[in] number for tag
+ * @details @b #include <tinyara/ttrace.h>
+ * @param[in] tag number for tag
  * @return On success, TTRACE_VALID is returned. On failure, TTRACE_INVALID is returned and errno is set appropriately.
  * @since Tizen RT v1.1
  */
@@ -142,7 +145,8 @@ int trace_end(int tag);
 /**
  * @ingroup TTRACE_LIBC
  * @brief writes a trace log to indicate that a event has ended
- * @param[in] number for tag
+ * @details @b #include <tinyara/ttrace.h>
+ * @param[in] tag number for tag
  * @return On success, TTRACE_VALID is returned. On failure, TTRACE_INVALID is returned and errno is set appropriately.
  * @since Tizen RT v1.1
  */
@@ -151,8 +155,9 @@ int trace_end_uid(int tag);
 /**
  * @ingroup TTRACE_LIBC
  * @brief writes a trace log for scheduler events
- * @param[in] tcb of current task
- * @param[in] tcb of next task which will be switched
+ * @details @b #include <tinyara/ttrace.h>
+ * @param[in] prev tcb of current task
+ * @param[in] next tcb of next task which will be switched
  * @return On success, TTRACE_VALID is returned. On failure, TTRACE_INVALID is returned and errno is set appropriately.
  * @since Tizen RT v1.1
  */

--- a/os/include/unistd.h
+++ b/os/include/unistd.h
@@ -164,7 +164,8 @@ EXTERN int optopt;				/* unrecognized option character */
  *   from the function in which vfork() was called, or calls any other function before
  *   successfully calling _exit() or one of the exec family of functions.
  *
- * @details This thin layer implements vfork by simply calling up_vfork() with the vfork()
+ * @details @b #include <unistd.h> \n
+ * This thin layer implements vfork by simply calling up_vfork() with the vfork()
  *   context as an argument.  The overall sequence is:
  *
  *   1) User code calls vfork().  vfork() collects context information and
@@ -193,7 +194,9 @@ EXTERN int optopt;				/* unrecognized option character */
 pid_t vfork(void);
 /**
  * @ingroup UNISTD_KERNEL
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief get the process ID
+ * @details @b #include <unistd.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 pid_t getpid(void);
@@ -207,19 +210,29 @@ void _exit(int status) noreturn_function;
  */
 /**
  * @ingroup UNISTD_KERNEL
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief suspend execution for an interval of time
+ * @details @b #include <unistd.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 unsigned int sleep(unsigned int seconds);
 /**
  * @ingroup UNISTD_KERNEL
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief suspend execution for microsecond intervals
+ * @details @b #include <unistd.h> \n
+ * The usleep() function suspends execution of the calling thread for
+ * (at least) usec microseconds.  The sleep may be lengthened slightly
+ * by any system activity or by the time spent processing the call or by
+ * the granularity of system timers.
+ * @param[in] usec microsecond intervals
  * @since Tizen RT v1.0
  */
 int usleep(useconds_t usec);
 /**
  * @ingroup UNISTD_KERNEL
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief suspend the thread until a signal is received
+ * @details @b #include <unistd.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int pause(void);
@@ -231,56 +244,74 @@ int pause(void);
  * @{
  */
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
- * @details SYSTEM CALL API
+ * @brief close a file descriptor
+ * @details @b #include <unistd.h> \n
+ * SYSTEM CALL API \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int close(int fd);
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
- * @details SYSTEM CALL API
+ * @brief duplicate an open file descriptor
+ * @details @b #include <unistd.h> \n
+ * SYSTEM CALL API \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int dup(int fd);
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
- * @details SYSTEM CALL API
+ * @brief duplicate an open file descriptor
+ * @details @b #include <unistd.h> \n
+ * SYSTEM CALL API \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int dup2(int fd1, int fd2);
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
- * @details SYSTEM CALL API
+ * @brief synchronize changes to a file
+ * @details @b #include <unistd.h> \n
+ * SYSTEM CALL API \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int fsync(int fd);
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
- * @details SYSTEM CALL API
+ * @brief move the read/write file offset
+ * @details @b #include <unistd.h> \n
+ * SYSTEM CALL API \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 off_t lseek(int fd, off_t offset, int whence);
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
- * @details SYSTEM CALL API
+ * @brief read from a file
+ * @details @b #include <unistd.h> \n
+ * SYSTEM CALL API \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 ssize_t read(int fd, FAR void *buf, size_t nbytes);
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
- * @details SYSTEM CALL API
+ * @brief write to another user
+ * @details @b #include <unistd.h> \n
+ * SYSTEM CALL API \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 ssize_t write(int fd, FAR const void *buf, size_t nbytes);
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
- * @details SYSTEM CALL API
+ * @brief read from a file
+ * @details @b #include <unistd.h> \n
+ * SYSTEM CALL API \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 ssize_t pread(int fd, FAR void *buf, size_t nbytes, off_t offset);
 /**
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
- * @details SYSTEM CALL API
+ * @brief write on a file
+ * @details @b #include <unistd.h> \n
+ * SYSTEM CALL API \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 ssize_t pwrite(int fd, FAR const void *buf, size_t nbytes, off_t offset);
@@ -306,8 +337,10 @@ FAR void *sbrk(intptr_t incr);
 
 /**
  * @ingroup UNISTD_KERNEL
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
- * @details SYSTEM CALL API
+ * @brief create an interprocess channel
+ * @details @b #include <unistd.h> \n
+ * SYSTEM CALL API \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int pipe(int fd[2]);
@@ -316,13 +349,17 @@ int pipe(int fd[2]);
 
 /**
  * @ingroup UNISTD_KERNEL
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief change working directory
+ * @details @b #include <unistd.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int chdir(FAR const char *path);
 /**
  * @ingroup UNISTD_KERNEL
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief get the pathname of the current working directory
+ * @details @b #include <unistd.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 FAR char *getcwd(FAR char *buf, size_t size);
@@ -330,21 +367,27 @@ FAR char *getcwd(FAR char *buf, size_t size);
 /* File path operations */
 /**
  * @ingroup STDLIB_LIBC
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief determine accessibility of a file descriptor
+ * @details @b #include <unistd.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.1
  */
 int access(FAR const char *path, int amode);
 /**
  * @ingroup UNISTD_KERNEL
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
- * @details SYSTEM CALL API
+ * @brief remove a directory
+ * @details @b #include <unistd.h> \n
+ * SYSTEM CALL API \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int rmdir(FAR const char *pathname);
 /**
  * @ingroup UNISTD_KERNEL
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
- * @details SYSTEM CALL API
+ * @brief call the unlink function
+ * @details @b #include <unistd.h> \n
+ * SYSTEM CALL API \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int unlink(FAR const char *pathname);
@@ -367,7 +410,9 @@ int execv(FAR const char *path, FAR char *const argv[]);
 /* Other */
 /**
  * @ingroup UNISTD_KERNEL
- * @brief  POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @brief command option parsing
+ * @details @b #include <unistd.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since Tizen RT v1.0
  */
 int getopt(int argc, FAR char *const argv[], FAR const char *optstring);


### PR DESCRIPTION
… wrong desc in os/include

1. Add include path for each apis
  - if not, we cannot know which header we should include for using that api
2. Add missing param name for each apis
  - argument name is needed after param[in] or param[out]
3. Add brief description for POSIX APIs
4. Fix wrong desc
  - some apis are not POSIX apis, but marked POSIX. so fix.

assert.h, crc16.h, crc32.h, crc8.h, debug.h, dirent.h, errno.h, fcntl.h, fixedmath.h, inttypes.h,
libgen.h, mqueue.h, pthread.h, queue.h, sched.h, semaphore.h, signal.h, spawn.h, stdio.h, stdlib.h,
string.h, syslog.h, termios.h, time.h, unistd.h
sys/prctl.h, sys/stat.h, sys/time.h, sys/wait.h, sys/ioctl.h
tinyara/clock.h, tinyara/math.h, tinyara/regex.h, tinyara/sched.h, tinyara/spawn.h, tinyara/streams.h,
tinyara/time.h, tinyara/ttrace.h