### PR TITLE
net:lwip fix snmp issues

### DIFF
--- a/os/net/lwip/src/core/snmp/mib_structs.c
+++ b/os/net/lwip/src/core/snmp/mib_structs.c
@@ -50,6 +50,7 @@
  */
 
 #include <net/lwip/opt.h>
+#include <net/lwip/debug.h>
 
 #if LWIP_SNMP					/* don't build if not configured for use in lwipopts.h */
 


### PR DESCRIPTION
1) build error fix 
    - Add <net/lwip/debug.h> in snmp to prevent a build error
2) assert due to config
    - fix SNMP assert when config value is not match to the received.
