### PR TITLE
Fix a http header parsing function in webserver

### DIFF
--- a/external/webserver/http_string_util.c
+++ b/external/webserver/http_string_util.c
@@ -169,12 +169,11 @@ int http_separate_keyvalue(const char *src, char *key, char *value)
 	int value_position = 0;
 	int src_len = strlen(src);
 
-	if (src_len > HTTP_CONF_MAX_KEY_LENGTH) {
-		HTTP_LOGE("Error: src_len is over the key buffer size.\n");
-		return HTTP_ERROR;
-	}
-
 	for (i = 0; i < src_len; i++) {
+		if (i >= HTTP_CONF_MAX_KEY_LENGTH) {
+			HTTP_LOGE("Error: The key length is over the value buffer size.\n");
+			return HTTP_ERROR;
+		}
 		if (src[i] != ':') {
 			key[i] = src[i];
 		} else {
@@ -186,7 +185,7 @@ int http_separate_keyvalue(const char *src, char *key, char *value)
 
 	for (i = value_position; i < src_len; i++) {
 		if ((i - value_position) >= HTTP_CONF_MAX_VALUE_LENGTH) {
-			HTTP_LOGE("Error: The length is over the value buffer size.\n");
+			HTTP_LOGE("Error: The value length is over the value buffer size.\n");
 			return HTTP_ERROR;
 		}
 		value[i - value_position] = src[i];


### PR DESCRIPTION
- Remove the code for checking the length of the http header. The whole unseparated http header can be longer than the max key length.
- Re-fix of commit eda61d6f7b0b1ed4a17a62206ddf94d6fc8069d1