### PR TITLE
Add an error handling code and an initialization function in webserver&client

### DIFF
--- a/external/webclient/webclient.c
+++ b/external/webclient/webclient.c
@@ -89,6 +89,7 @@
 
 #include "../webserver/http_string_util.h"
 #include "../webserver/http_client.h"
+#include <protocols/webserver/http_err.h>
 #include <protocols/webclient.h>
 #if defined(CONFIG_NETUTILS_CODECS)
 #  if defined(CONFIG_CODECS_URLCODE)
@@ -1059,6 +1060,11 @@ retry:
 						 &encoding, &state, &mlen,
 						 param->response->headers,
 						 NULL, param->response, NULL);
+
+		if (read_finish == HTTP_ERROR) {
+			ndbg("Error: Parse message Fail\n");
+			goto errout;
+		}
 	}
 
 	param->response->method = param->method;
@@ -1203,6 +1209,11 @@ static pthread_addr_t wget_base(void *arg)
 						 &encoding, &state, &mlen,
 						 param->response->headers,
 						 NULL, param->response, NULL);
+
+		if (read_finish == HTTP_ERROR) {
+			ndbg("Error: Parse message Fail\n");
+			goto errout;
+		}
 	}
 
 	param->response->method = param->method;


### PR DESCRIPTION
- http_parse_message function doesn't check an returned value of an error, it can causes proceed with unproper values.
- Initialization of buffers is needed for every loop not to be filled with the previous data.