### PR TITLE
external:xmlrpc fix xmlrpc refer invalid memory area

### DIFF
--- a/external/xmlrpc/xmlparser.c
+++ b/external/xmlrpc/xmlparser.c
@@ -140,6 +140,10 @@ static int xmlrpc_getelement(struct parsebuf_s *pbuf, char *data, int dataSize)
 		return XMLRPC_PARSE_ERROR;
 	}
 
+	if (pbuf->len < 0 || pbuf->index < 0) {
+		return XMLRPC_PARSE_ERROR;
+	}
+
 	while ((pbuf->index < pbuf->len) && !isprint(pbuf->buf[pbuf->index])) {
 		pbuf->index++;
 	}


### PR DESCRIPTION
if member in parsebuf_s has negative value then xmlrpc refers buf with index -1
so I add compare logic in xmlrpc_getelement()