### PR TITLE
tools/csvparser.c: Fix build error

### DIFF
--- a/os/tools/csvparser.c
+++ b/os/tools/csvparser.c
@@ -209,7 +209,7 @@ int parse_csvline(char *ptr)
 	 */
 
 	do {
-		if (nparams >= MAX_FIELDS) {
+		if (nparms >= MAX_FIELDS) {
 			fprintf(stderr, "%d: too many Parameters: \"%s\"\n", g_lineno, g_line);
 			exit(8);
 		}


### PR DESCRIPTION
Fix build error caused by wrong typo of variable `nparms` from the commit https://github.com/Samsung/TizenRT/commit/819fa0bdfb525199d7f587fade7f5af1311d2827