### PR TITLE
kernel/task : Add ifndef condition for task_sigchild

### DIFF
--- a/os/kernel/task/task_exithook.c
+++ b/os/kernel/task/task_exithook.c
@@ -293,7 +293,7 @@ static inline void task_groupexit(FAR struct task_group_s *group)
  *
  ****************************************************************************/
 
-#ifdef CONFIG_SCHED_HAVE_PARENT
+#if defined(CONFIG_SCHED_HAVE_PARENT) && !defined(CONFIG_DISABLE_SIGNALS)
 #ifdef HAVE_GROUP_MEMBERS
 static inline void task_sigchild(gid_t pgid, FAR struct tcb_s *ctcb, int status)
 {
@@ -413,11 +413,11 @@ static inline void task_sigchild(FAR struct tcb_s *ptcb, FAR struct tcb_s *ctcb,
 }
 
 #endif							/* HAVE_GROUP_MEMBERS */
-#else							/* CONFIG_SCHED_HAVE_PARENT */
+#else							/* CONFIG_SCHED_HAVE_PARENT && !CONFIG_DISABLE_SIGNALS */
 
 #define task_sigchild(x, ctcb, status)
 
-#endif							/* CONFIG_SCHED_HAVE_PARENT */
+#endif							/* CONFIG_SCHED_HAVE_PARENT && !CONFIG_DISABLE_SIGNALS */
 
 /****************************************************************************
  * Name: task_signalparent


### PR DESCRIPTION
task_exithook.c fails to link if signals are disabled because was unconditionally trying to send the SIGCHLD signal to the parent in certain configurations.
commit from Nuttx - 3cd41b0