### PR TITLE
arastorage : add missing filepath and description to doxygen for arastorage.h

### DIFF
--- a/framework/include/arastorage/arastorage.h
+++ b/framework/include/arastorage/arastorage.h
@@ -53,9 +53,14 @@
 
 /**
  * @defgroup ARASTORAGE ARASTORAGE
- * @brief Provides APIs for Lightweight Database
+ * @brief Provides APIs for Lightweight Database, Arastorage
  * @ingroup ARASTORAGE
  * @{
+ */
+
+/**
+ * @file arastorage/arastorage.h
+ * @brief APIs for Lightweight Database, Arastorage
  */
 
 #ifndef __ARASTORAGE_ARA_STORAGE_H


### PR DESCRIPTION
Add missing filepath and description in doxygen for arastorage.h to show this in File List of API page