### PR TITLE
sidk build fix

### DIFF
--- a/os/arch/arm/src/sidk_s5jt200/src/s5jt200_led.c
+++ b/os/arch/arm/src/sidk_s5jt200/src/s5jt200_led.c
@@ -69,11 +69,12 @@ FAR struct pwm_lowerhalf_s    *ledr;
 FAR struct pwm_lowerhalf_s    *ledg;
 FAR struct pwm_lowerhalf_s    *ledb;
 
-int s5jt200_rgbled_state_task(void)
+int s5jt200_rgbled_state_task(int argc, char *argv[])
 {
 	char freq;
 	struct pwm_info_s info;
-
+	UNUSED(argv);
+	UNUSED(argc);
 	info.duty = 30;
 
 	while (1) {


### PR DESCRIPTION
the build target sidk_s5jt200 failed to build due to changes in kernel_thread() signature.
This patch corrects the build error.