### PR TITLE
arch/artik053: tidy up on alc5658

### DIFF
--- a/os/arch/arm/src/artik053/include/artik053_alc5658_i2c.h
+++ b/os/arch/arm/src/artik053/include/artik053_alc5658_i2c.h
@@ -22,11 +22,13 @@ typedef int (*alc_write)(uint16_t addr, uint16_t data);
 typedef int (*alc_read)(uint16_t addr, uint16_t *data);
 typedef int (*alc_modify)(uint16_t addr, uint16_t set, uint16_t clear);
 
-typedef struct {
+struct alc_i2c_s {
 	alc_write write;
 	alc_read read;
 	alc_modify modify;
-} i2c_alc;
+};
 
-i2c_alc *alc5658_i2c_initialize(void);
+typedef struct alc_i2c_s alc_i2c_t;
+
+alc_i2c_t *alc5658_i2c_initialize(void);
 #endif /* __ARCH_ARM_SRC_ARTIK053_INCLUDE_ARTIK053_ALC5658_I2C_H */

--- a/os/arch/arm/src/artik053/include/artik053_alc5658_i2c.h
+++ b/os/arch/arm/src/artik053/include/artik053_alc5658_i2c.h
@@ -16,6 +16,8 @@
  *
  ****************************************************************************/
 
+#ifndef __ARCH_ARM_SRC_ARTIK053_INCLUDE_ARTIK053_ALC5658_I2C_H
+#define __ARCH_ARM_SRC_ARTIK053_INCLUDE_ARTIK053_ALC5658_I2C_H
 typedef int (*alc_write)(uint16_t addr, uint16_t data);
 typedef int (*alc_read)(uint16_t addr, uint16_t *data);
 typedef int (*alc_modify)(uint16_t addr, uint16_t set, uint16_t clear);
@@ -27,3 +29,4 @@ typedef struct {
 } i2c_alc;
 
 i2c_alc *alc5658_i2c_initialize(void);
+#endif /* __ARCH_ARM_SRC_ARTIK053_INCLUDE_ARTIK053_ALC5658_I2C_H */

--- a/os/arch/arm/src/artik053/src/artik053_alc5658_i2c.c
+++ b/os/arch/arm/src/artik053/src/artik053_alc5658_i2c.c
@@ -59,7 +59,7 @@ typedef struct {
 static struct i2c_dev_s *i2c_dev;
 static struct i2c_config_s configs;
 
-static i2c_alc i2c_alc5658 = {
+static alc_i2c_t alc5658_i2c = {
 	.write = alc5658_write,
 	.read = alc5658_read,
 	.modify = alc5658_modify,
@@ -208,13 +208,13 @@ static void delay(unsigned int mS)
  *  None
  *
  * Returned Value:
- *   pointer to i2c_alc operations structure, or NULL in case of errors
+ *   pointer to alc_i2c_t operations structure, or NULL in case of errors
  *
  ****************************************************************************/
 
-i2c_alc *alc5658_i2c_initialize(void)
+alc_i2c_t *alc5658_i2c_initialize(void)
 {
-	i2c_alc *i2c;
+	alc_i2c_t *i2c;
 	int i;
 	int ret;
 
@@ -228,7 +228,7 @@ i2c_alc *alc5658_i2c_initialize(void)
 	configs.address = ALC5658_ADDR;
 	configs.addrlen = CONFIG_ALC5658_I2C_ADDRLEN;
 
-	i2c = &i2c_alc5658;
+	i2c = &alc5658_i2c;
 
 	for (i = 0; i < sizeof(codec_init_script) / sizeof(t_codec_init_script_entry); i++) {
 		ret = i2c->modify(codec_init_script[i].addr, codec_init_script[i].val, 0xFFFF);


### PR DESCRIPTION
1. Add a conditional on alc5658 header
For every header file, checking a conditional is needed to prevent
duplicated including header file. That is missed in artik053_alc5658_i2c.h.

2. refactor alc5658 files
for coding rule and readability