### PR TITLE
Add description for DM data structures

### DIFF
--- a/framework/include/dm/dm_connectivity.h
+++ b/framework/include/dm/dm_connectivity.h
@@ -35,7 +35,11 @@
 extern "C"
 {
 #endif
-
+/**
+ * @brief Specify the data structure to hold WiFi scanning information.
+ * @details The information comprises SSID and BSSID of nearby Access Points (APs),
+ * as well as RSSI (wireless received signal strength indicator).
+ */
 struct dm_scan_info_s {
 	char ssid[33];               // 802.11 spec defined unspecified or uint8
 	char bssid[18];                 // char string e.g. xx:xx:xx:xx:xx:xx

--- a/framework/include/dm/dm_lwm2m.h
+++ b/framework/include/dm/dm_lwm2m.h
@@ -55,18 +55,27 @@ typedef enum {
 } dm_lwm2m_client_state_e;
 
 /**
- * @brief Struct definition of DM context for a LWM2M session
+ * @brief Specify LWM2M server information such as ipaddress and port
  */
+struct server_info_s {
+	char ipAddress[IPADDRLEN_MAX];
+	char port[PORTLEN];
+	bool isBootstrap;
+};
 
+/**
+ * @brief Specify LWM2M client information such as session lifetime
+ */
+struct client_info_s {
+	int lifetime;
+};
+
+/**
+ * @brief Specify DM context structure for a LWM2M session.
+ */
 struct dm_lwm2m_context_s {
-	struct server_info_s {
-		char ipAddress[IPADDRLEN_MAX];
-		char port[PORTLEN];
-		bool isBootstrap;
-	} server_info;
-	struct client_info_s {
-		int lifetime;
-	} client_info;
+	struct server_info_s server_info;
+	struct client_info_s client_info;
 };
 
 /**


### PR DESCRIPTION
Add description in the DM LWM2M and connectivity header files, to describe data structures.