### PR TITLE
framework/mqtt: add a missed description of doxygen in mqtt

### DIFF
--- a/framework/include/network/mqtt/mqtt_api.h
+++ b/framework/include/network/mqtt/mqtt_api.h
@@ -17,6 +17,7 @@
  ****************************************************************************/
 /**
  * @defgroup MQTT MQTT Client
+ * @brief Provides APIs for MQTT Client
  * @ingroup NETWORK
  * @{
  */


### PR DESCRIPTION
add a brief section in mqtt for doxygen.