### PR TITLE
Allow logm to operate synchronously to avoid dropping logs.

### DIFF
--- a/os/logm/Kconfig
+++ b/os/logm/Kconfig
@@ -24,6 +24,23 @@ config LOGM_TIMESTAMP
 	bool "Prepend timestamp to message"
 	default n
 
+config LOGM_SYNCHRONOUS
+	bool "Stall logging thread instead of dropping log messages"
+	default n
+	---help---
+		When LOGM_SYNCHRONOUS is enabled, logm would wait for space in log
+		buffer before discarding an overflowing log message.
+
+config LOGM_TIMEOUT_MS
+	int "Max delay logging thread would wait before dropping a message"
+	default -1
+	depends on LOGM_SYNCHRONOUS
+	---help---
+		When LOGM_SYNCHRONOUS is enabled, this option defines how
+		long (in ms) a thread would wait for space in logging buffer.
+		0 is equivalent to no wait, <0 waits (almost) indefinitely.
+		See also LOGM_PRINT_INTERVAL.
+
 config LOGM_BUFFER_SIZE
 	int "Logm Buffer size"
 	default 10240

--- a/os/logm/logm.c
+++ b/os/logm/logm.c
@@ -88,6 +88,18 @@ int logm_internal(int flag, int indx, int priority, const char *fmt, va_list ap)
 		&& flag == LOGM_NORMAL && !up_interrupt_context()) {
 
 		flags = irqsave();
+#if defined(CONFIG_LOGM_SYNCHRONOUS) && (CONFIG_LOGM_TIMEOUT_MS != 0)
+#if CONFIG_LOGM_TIMEOUT_MS > 0
+		int count = (CONFIG_LOGM_TIMEOUT_MS + 9) / 10;
+#else
+		int count = -1;
+#endif
+		while (LOGM_STATUS(LOGM_BUFFER_OVERFLOW) && count--) {
+			irqrestore(flags);
+			usleep(10000);
+			flags = irqsave();
+		}
+#endif /* CONFIG_LOGM_SYNCHRONOUS */
 
 		if (LOGM_STATUS(LOGM_BUFFER_OVERFLOW)) {
 			g_logm_dropmsg_count++;


### PR DESCRIPTION
Add configuration option for logm, so that in case of overflowing log messages, logging thread waits for buffer space instead of discarding the logs.

This has the side effect of stopping the calling thread until the buffer space is available, or timeout occurs.

The motivation of this was debugging network stack (lwIP) that spew logs and quickly fills the log buffer (even at >100kB). In that case it is better to wait a little (think: at most single-digit seconds) than to lose log traces.