### PR TITLE
Fix Memory Issues and Optimizations in Code Usage 

### DIFF
--- a/apps/examples/fs_helper/ramfs_test.c
+++ b/apps/examples/fs_helper/ramfs_test.c
@@ -111,6 +111,7 @@ static int make_file(char *filename)
 
 	if (fwrite(in_string, BUFFER_SIZE, 1, fp) < 0) {
 		printf("Cannot write file %s\n", filename);
+		fclose(fp);
 		return -1;
 	}
 

--- a/os/logm/logm_process.c
+++ b/os/logm/logm_process.c
@@ -42,10 +42,12 @@ static int logm_change_bufsize(int buflen)
 	}
 
 	/* Realloc new buffer with new length */
-	g_logm_rsvbuf = (char *)realloc(g_logm_rsvbuf, buflen);
-	if (!g_logm_rsvbuf) {
+	char *new_g_logm_rsvbuf = (char *)realloc(g_logm_rsvbuf, buflen);
+	if (new_g_logm_rsvbuf == NULL) {
+		wdbg("Realloc Fail\n");
 		return ERROR;
 	}
+	g_logm_rsvbuf = new_g_logm_rsvbuf;
 	memset(g_logm_rsvbuf, 0, buflen);
 
 	/* Reinitialize all  */


### PR DESCRIPTION
In this scenario,  if realloc fails, then the original memory allocation exists, but is leaked as it is no longer referred. So you need to keep a handle on the original allocation until you have verified that the new allocation is valid.