### PR TITLE
Bug fix: inode_stat mishandled the buffer, resulting in NULL dereference

### DIFF
--- a/os/fs/vfs/fs_stat.c
+++ b/os/fs/vfs/fs_stat.c
@@ -205,7 +205,7 @@ int inode_stat(FAR struct inode *inode, FAR struct stat *buf)
 {
 	DEBUGASSERT(inode != NULL && buf != NULL);
 
-	memset(&buf, 0, sizeof(*buf));
+	memset(buf, 0, sizeof(*buf));
 
 	if (INODE_IS_SPECIAL(inode)) {
 #if defined(CONFIG_FS_NAMED_SEMAPHORES)


### PR DESCRIPTION
Previous PR contains a bug - the buffer pointer is cleared (along some adjacent memory), and later on some value is written into location pointed by resulting NULL.
Reproduction:
> TASH>>ls /dev
Crashes

Tested on artik053.