### PR TITLE
Doxygen: Add iotjs description

### DIFF
--- a/external/iotjs/iotjs.h
+++ b/external/iotjs/iotjs.h
@@ -1,0 +1,14 @@
+/**
+ * @defgroup IOTJS IOTJS
+ * @ingroup IOTJS
+ * @{
+ */
+
+/**
+ * @file iotjs.h
+ * @brief IoT.js is Open Source software under the Apache 2.0 license. Complete license and copyright information can be found within the code.\n\n
+ * Official website : http://iotjs.net\n
+ * Online API Reference : https://github.com/Samsung/iotjs/blob/master/docs/api/IoT.js-API-reference.md\n
+ */
+
+/** @} */ // end of IOTJS group


### PR DESCRIPTION
doxygen Add a description of iotjs to display in the document.

It is also present in the latest version of doxygen pdf document.