### PR TITLE
fs/smartfs: assign stat values for root in smartfs_stat_common

### DIFF
--- a/os/fs/smartfs/smartfs_smart.c
+++ b/os/fs/smartfs/smartfs_smart.c
@@ -2188,11 +2188,12 @@ static void smartfs_stat_common(FAR struct smartfs_mountpt_s *fs,
 		} else {
 			buf->st_mode |= S_IFREG;
 		}
-
-		buf->st_size = entry->datlen;
-		buf->st_blksize = fs->fs_llformat.availbytes;
-		buf->st_blocks = (buf->st_size + buf->st_blksize - 1) / buf->st_blksize;
 	}
+	buf->st_size = entry->datlen;
+	buf->st_blksize = fs->fs_llformat.availbytes;
+	buf->st_blocks = (buf->st_size + buf->st_blksize - 1) / buf->st_blksize;
+	buf->st_atime = 0;
+	buf->st_ctime = 0;
 }
 
 /****************************************************************************


### PR DESCRIPTION
These values also should be assigned when entry is root.