### PR TITLE
framework/dm: fix Kconfig warning

### DIFF
--- a/framework/src/dm/Kconfig
+++ b/framework/src/dm/Kconfig
@@ -7,6 +7,7 @@ config DM
 	bool "DM"
 	default n
 	depends on NET
+	select LIBC_NETDB
 	select LWM2M_WAKAAMA
 	---help---
 		enable the DM functionality


### PR DESCRIPTION
- Add dependency on LIBC_NETDB because LIBC_NETDB have to be on when LWM2M_WAKAAMA is selected.