### PR TITLE
alc5658: modify alc5658 codec register

### DIFF
--- a/os/drivers/audio/alc5658.c
+++ b/os/drivers/audio/alc5658.c
@@ -237,18 +237,18 @@ static uint16_t alc5658_modifyreg(FAR struct alc5658_dev_s *priv, uint16_t regad
 
 static void alc5658_setregs(struct alc5658_dev_s *priv)
 {
-	alc5658_writereg(priv, ALC5658_IN1_CTRL, (0 + 16) << 8);
-	alc5658_writereg(priv, ALC5658_HPOUT_MUTE, 0);
-	alc5658_writereg(priv, ALC5658_HPOUT_VLML, 0xd00);
-	alc5658_writereg(priv, ALC5658_HPOUT_VLMR, 0x700);
+	alc5658_writereg(priv, ALC5658_IN1, (0 + 16) << 8);
+	alc5658_writereg(priv, ALC5658_HPOUT, 0);
+	alc5658_writereg(priv, ALC5658_HPOUT_L, 0xd00);
+	alc5658_writereg(priv, ALC5658_HPOUT_R, 0x700);
 }
 
 static void alc5658_getregs(struct alc5658_dev_s *priv)
 {
-	audvdbg("MIC GAIN 0x%x\n", (uint32_t)alc5658_readreg(priv, ALC5658_IN1_CTRL));
-	audvdbg("MUTE HPOUT MUTE %x\n", (uint32_t)alc5658_readreg(priv, ALC5658_HPOUT_MUTE));
-	audvdbg("VOLL 0x%x\n", (uint32_t)alc5658_readreg(priv, ALC5658_HPOUT_VLML));
-	audvdbg("VOLR 0x%x\n", (uint32_t)alc5658_readreg(priv, ALC5658_HPOUT_VLMR));
+	audvdbg("MIC GAIN 0x%x\n", (uint32_t)alc5658_readreg(priv, ALC5658_IN1));
+	audvdbg("MUTE HPOUT MUTE %x\n", (uint32_t)alc5658_readreg(priv, ALC5658_HPOUT));
+	audvdbg("VOLL 0x%x\n", (uint32_t)alc5658_readreg(priv, ALC5658_HPOUT_L));
+	audvdbg("VOLR 0x%x\n", (uint32_t)alc5658_readreg(priv, ALC5658_HPOUT_R));
 }
 
 /************************************************************************************
@@ -1225,8 +1225,8 @@ static void alc5658_hw_reset(FAR struct alc5658_dev_s *priv)
 
 	alc5658_exec_i2c_script(priv, codec_reset_script, sizeof(codec_reset_script) / sizeof(t_codec_init_script_entry));
 
-	alc5658_writereg(priv, ALC5658_IN1_CTRL, (10 + 16) << 8);
-	audvdbg("MIC GAIN 0x%x\n", (uint32_t)alc5658_readreg(priv, ALC5658_IN1_CTRL));
+	alc5658_writereg(priv, ALC5658_IN1, (10 + 16) << 8);
+	audvdbg("MIC GAIN 0x%x\n", (uint32_t)alc5658_readreg(priv, ALC5658_IN1));
 
 	/* Dump some information and return the device instance */
 
@@ -1282,12 +1282,12 @@ FAR struct audio_lowerhalf_s *alc5658_initialize(FAR struct i2c_dev_s *i2c, FAR 
 		 * default state.
 		 */
 
-		alc5658_writereg(priv, ALC5658_RESET, 0);
+		alc5658_writereg(priv, ALC5658_SW_RESET, 0);
 		alc5658_dump_registers(&priv->dev, "After reset");
 
 		/* Verify that ALC5658 is present and available on this I2C */
 
-		regval = alc5658_readreg(priv, ALC5658_RESET);
+		regval = alc5658_readreg(priv, ALC5658_SW_RESET);
 		if (regval != 0) {
 			auddbg("ERROR: ALC5658 not found: ID=%04x\n", regval);
 			goto errout_with_dev;

--- a/os/drivers/audio/alc5658reg.h
+++ b/os/drivers/audio/alc5658reg.h
@@ -32,97 +32,180 @@
  ****************************************************************************/
 
 /* Registers Addresses ******************************************************/
-typedef enum {
-	ALC5658_RESET = 0x0000,
-	ALC5658_SPO_VOL = 0x0001,
-	ALC5658_HPOUT_MUTE = 0x0002,
-	ALC5658_LOUT_CTRL1 = 0x0003,
-	ALC5658_LOUT_CTRL2 = 0x0004,
-	ALC5658_HPOUT_VLML = 0x0005,
-	ALC5658_HPOUT_VLMR = 0x0006,
-	ALC5658_SPDIF_CTRL1 = 0x0008,
-	ALC5658_SPDIF_CTRL2 = 0x0009,
-	ALC5658_SPDIF_CTRL3 = 0x0036,
-	ALC5658_IN1_CTRL = 0x000C,
-	ALC5658_INL_VLM = 0x000F,
-	ALC5658_SIDETONE = 0x0018,
-	/* DIGITAL Volume */
-	ALC5658_DAC_L1R1_VLM = 0x0019,
-	ALC5658_DAC_L2R2_VLM = 0x001A,
-	ALC5658_DAC_L2R2_MUTE = 0x001B,
-	/* DIGITAL Mixers */
-	ALC5658_ADC_STR1_MXR = 0x0026,
-	ALC5658_ADC_MONO_MXR = 0x0027,
-	ALC5658_ADC_2_DAC_MXR = 0x0029,
-	ALC5658_DAC_STR_MXR = 0x002A,
-	ALC5658_DAC_MONO_MXR = 0x002B,
-	ALC5658_DAC_LB_SDTONE = 0x002C,
-	ALC5658_COPY_MODE = 0x002F,
-	/* Analog DAC Source */
-	ALC5658_DAC_SRC = 0x002D,
-	ALC5658_RECMIX1L_CTRL_1 = 0x003B,
-	ALC5658_RECMIX1L_CTRL_2 = 0x003C,
-	ALC5658_RECMIX1R_CTRL_1 = 0x003D,
-	ALC5658_RECMIX1R_CTRL_2 = 0x003E,
-	/* ANALOG Mixers */
-	ALC5658_SPKMIXL = 0x0046,
-	ALC5658_SPKMIXR = 0x0047,
-	ALC5658_SPOMIX = 0x0048,
-	ALC5658_OUTMIXL1 = 0x004D,
-	ALC5658_OUTMIXL2 = 0x004E,
-	ALC5658_OUTMIXR1 = 0x004F,
-	ALC5658_OUTMIXR2 = 0x0050,
-	ALC5658_LOUTMIX = 0x0052,
-	/* Power management */
-	ALC5658_PWR_MNG1 = 0x0061,
-	ALC5658_PWR_MNG2 = 0x0062,
-	ALC5658_PWR_MNG3 = 0x0063,
-	ALC5658_PWR_MNG4 = 0x0064,
-	ALC5658_PWR_MNG5 = 0x0065,
-	ALC5658_PWR_MNG6 = 0x0066,
-	ALC5658_PWR_MNG7 = 0x0067,
-	/* DIGITAL ports control */
-	ALC5658_IF_DTCT = 0x006B,
-	ALC5658_006E = 0x006E,
-	ALC5658_006F = 0x006F,
-	ALC5658_I2S1_CTRL = 0x0070,
-	ALC5658_I2S2_CTRL = 0x0071,
-	ALC5658_ADDA_CLK = 0x0073,
-	ALC5658_ADDA_HPF = 0x0074,
-	ALC5658_007B = 0x007B,
-	/* TDM */
-	ALC5658_TDM_CTRL1 = 0x0077,
-	ALC5658_TDM_CTRL2 = 0x0078,
-	ALC5658_TDM_CTRL3 = 0x0079,
-	ALC5658_TDM_CTRL4 = 0x007A,
-	/* Global Clock */
-	ALC5658_GLBL_CLK = 0x0080,
-	ALC5658_GLBL_PLL1 = 0x0081,
-	ALC5658_GLBL_PLL2 = 0x0082,
-	ALC5658_GLBL_ASRC1 = 0x0083,
-	ALC5658_GLBL_ASRC2 = 0x0084,
-	ALC5658_GLBL_ASRC3 = 0x0085,
-	ALC5658_GLBL_ASRC4 = 0x008A,
-	/* Amplifiers */
-	ALC5658_HP_AMP = 0x008E,
-	ALC5658_SPK_AMP = 0x00A0,
-	ALC5658_0091 = 0x0091,
-	ALC5658_INTCLK_CTRL = 0x0094,
-	ALC5658_GNRL_CTRL = 0x00FA,
-	ALC5658_GNRL_CTRL2 = 0x00FB,
-	ALC5658_0111 = 0x0111,
-	ALC5658_0125 = 0x0125,
-	ALC5658_ADDA_RST1 = 0x013A,
-	ALC5658_ADDA_RST2 = 0x013B,
-	ALC5658_0x013C = 0x013C,
-	ALC5658_NOISE_G_M1_CTRL1 = 0x0015,
-	ALC5658_NOISE_G_M2_CTRL = 0x0160,
-	ALC5658_0x01DE = 0x01DE,
-	ALC5658_0x01DF = 0x01DF,
-	ALC5658_0x01E4 = 0x01E4,
-	ALC5658_0040 = 0x0040,
-	ALC5658_0010 = 0x0010,
-} ALC5658_REG;
+
+#define ALC5658_SW_RESET			0x0000	/* S/W Reset & Device ID */
+#define ALC5658_SPKOUT				0x0001	/* Speaker Output Volume & Mute/Un-Mute */
+#define ALC5658_HPOUT				0x0002	/* Headphone Mute/Un-Mute */
+#define ALC5658_LOUT1				0x0003	/* Line Output Volume & Mute/Un-Mute */
+#define ALC5658_LOUT2				0x0004	/* Line Output Control */
+#define ALC5658_HPOUT_L				0x0005	/* Headphone L Channel Gain Control */
+#define ALC5658_HPOUT_R				0x0006	/* Headphone R Channel Gain Control */
+#define ALC5658_SPDIF_CTRL1			0x0008	/* S/PDIF Out Control */
+#define ALC5658_SPDIF_CTRL2			0x0009	/* S/PDIF Out Control */
+#define ALC5658_SPDIF_CTRL3			0x0036	/* S/PDIF Out Control */
+#define ALC5658_IN1					0x000C	/* IN1 Port Control */
+#define ALC5658_INL					0x000F	/* INLVolume Control */
+#define ALC5658_0010				0x0010
+#define ALC5658_JD					0x0011	/* Jack and Mic Detection Control 1 */
+#define ALC5658_SIDETONE			0x0018	/* Sidetone Control */
+#define ALC5658_NOISE_GATE1			0x0015	/* Noise Gate Mode1 Conrol 1 */
+#define ALC5658_NOISE_GATE2			0x0016	/* Noise Gate Mode1 Conrol 2 */
+#define ALC5658_DACL1R1				0x0019	/* DACL1/R1 Digital Volume Control */
+#define ALC5658_DACL2R2				0x001A	/* DACL2/R2 Digital Volume Control */
+#define ALC5658_DACL2R2_MUTE		0x001B	/* DACL2/R2 Digital Mute/Un-Mute Control */
+#define ALC5658_ADC_ST1_VOL			0x001C	/* Stereo1 ADCL/R Digital Volume & Mute/Un-Mute Control */
+#define ALC5658_ADC_MO_VOL			0x001D	/* Mono ADCL/R Digital Path Volume Control */
+#define ALC5658_ADC_ST1_GAIN		0x001F	/* Stereo1 ADC Filter Boost Gain for DMIC */
+#define ALC5658_ADC_MO_GAIN			0x0020	/* Mono ADC Filter Boost Gain for DMIC */
+#define ALC5658_ADC_ST1_MXR			0x0026	/* Stereo1 ADC Digital Mixer Control */
+#define ALC5658_ADC_MO_MXR			0x0027	/* Mono ADC Digital Mixer Control */
+#define ALC5658_ADC_2_MXR			0x0029	/* ADC to DAC Digital Mixer Control */
+#define ALC5658_DAC_ST_MXR			0x002A	/* DAC Stereo Digital Mixer Control */
+#define ALC5658_DAC_MO_MXR			0x002B	/* DAC Mono Digital Mixer Control */
+#define ALC5658_DAC_LOOPBACK		0x002C	/* Digital Loop Back and Sidetone Control Control */
+#define ALC5658_COPY_MODE			0x002F	/* ADC/DAC Data Copy Mode Control */
+#define ALC5658_DAC_SRC				0x002D	/* Analog DACL1/R1 and DACL2/R2 Input Source Control */
+#define ALC5658_PDM					0x0031	/* PDM Interface Control */
+#define ALC5658_RECMIX1L			0x003B	/* RECMIX1L Gain Control */
+#define ALC5658_RECMIX1L_SEL		0x003C	/* RECMIX1L Gain & Selection Control */
+#define ALC5658_RECMIX1R			0x003D	/* RECMIX1R Gain Control */
+#define ALC5658_RECMIX1R_SEL		0x003E	/* RECMIX1R Gain & Selection Control */
+#define ALC5658_RECMIX2L			0x009B	/* RECMIX2L Gain Control */
+#define ALC5658_RECMIX2L_SEL		0x009C	/* RECMIX2L Gain & Selection Control */
+#define ALC5658_RECMIX2R			0x009D	/* RECMIX2R Gain Control */
+#define ALC5658_RECMIX2R_SEL		0x009E	/* RECMIX2R Gain & Selection Control */
+#define ALC5658_0040				0x0040
+#define ALC5658_SPKMIXL				0x0046	/* SPKMIXL Gain & Selection Control */
+#define ALC5658_SPKMIXR				0x0047	/* SPKMIXR Gain & Selection Control */
+#define ALC5658_SPOMIX				0x0048	/* Speaker Amp Source Selection Control */
+#define ALC5658_OUTMIXL1			0x004D	/* OUTMIXL Gain & Selection Control */
+#define ALC5658_OUTMIXL2			0x004E	/* OUTMIXL Gain & Selection Control */
+#define ALC5658_OUTMIXR1			0x004F	/* OUTMIXR Gain & Selection Control */
+#define ALC5658_OUTMIXR2			0x0050	/* OUTMIXR Gain & Selection Control */
+#define ALC5658_LOUTMIX				0x0052	/* LOUTMIX Gain & Selection Control */
+#define ALC5658_GAPTIC_CTLRL01		0x0053	/* Gaptic Generator Control */
+#define ALC5658_GAPTIC_CTLRL02		0x0054	/* Gaptic Generator Control */
+#define ALC5658_GAPTIC_CTLRL03		0x0055	/* Gaptic Generator Control */
+#define ALC5658_GAPTIC_CTLRL04		0x0056	/* Gaptic Generator Control */
+#define ALC5658_GAPTIC_CTLRL05		0x0057	/* Gaptic Generator Control */
+#define ALC5658_GAPTIC_CTLRL06		0x0058	/* Gaptic Generator Control */
+#define ALC5658_GAPTIC_CTLRL07		0x0059	/* Gaptic Generator Control */
+#define ALC5658_GAPTIC_CTLRL08		0x005A	/* Gaptic Generator Control */
+#define ALC5658_GAPTIC_CTLRL09		0x005B	/* Gaptic Generator Control */
+#define ALC5658_GAPTIC_CTLRL10		0x005C	/* Gaptic Generator Control */
+#define ALC5658_GAPTIC_CTLRL11		0x005D	/* Gaptic Generator Control */
+#define ALC5658_GAPTIC_CTLRL12		0x005E	/* Gaptic Generator Control */
+#define ALC5658_MANAGEMENT1			0x0061	/* I2S & DAC & ADC & Class-D Power Control */
+#define ALC5658_MANAGEMENT2			0x0062	/* Digital Filter & PDM Power Control */
+#define ALC5658_MANAGEMENT3			0x0063	/* VREF & MBias & LOUTMIX & HP Power Control */
+#define ALC5658_MANAGEMENT4			0x0064	/* MICBST & MICBIAS & JD Power Control */
+#define ALC5658_MANAGEMENT5			0x0065	/* PLL & LDO Power Control */
+#define ALC5658_MANAGEMENT6			0x0066	/* OUTMIX & SPKMIX & RECMIX Power Control */
+#define ALC5658_MANAGEMENT7			0x0067	/* SPOVOL & OUTVOL & INVOL & MIC_IN_DET Power Control */
+#define ALC5658_IF_DETECTION		0x006B	/* Interface and System Clock Detection Control */
+#define ALC5658_006E				0x006E
+#define ALC5658_006F				0x006F
+#define ALC5658_I2S1_PORT_CTRL		0x0070	/* I2S-1 Interface Control */
+#define ALC5658_I2S2_PORT_CTRL		0x0071	/* I2S-2 Interface Control */
+#define ALC5658_ADCDAC_CLOCK		0x0073	/* ADC/DAC Clock Control */
+#define ALC5658_ADCDAC_HPF			0x0074	/* ADC/DAC HPF Control */
+#define ALC5658_MIC_CTRL1			0x0075	/* Digital Microphone Control */
+#define ALC5658_MIC_CTRL2			0x0076	/* Digital Microphone Control */
+#define ALC5658_TDM1				0x0077	/* TDM Interface Control */
+#define ALC5658_TDM2				0x0078	/* TDM Interface Control */
+#define ALC5658_TDM3				0x0079	/* TDM Interface Control */
+#define ALC5658_TDM4				0x007A	/* TDM Interface Control */
+#define ALC5658_007B				0x007B
+#define ALC5658_CLOCK				0x0080	/* Global Clock Control */
+#define ALC5658_PLL1				0x0081	/* PLL Control 1 */
+#define ALC5658_PLL2				0x0082	/* PLL Control 2 */
+#define ALC5658_ASRC1				0x0083	/* ASRC Control 1 */
+#define ALC5658_ASRC2				0x0084	/* ASRC Control 2 */
+#define ALC5658_ASRC3				0x0085	/* ASRC Control 3 */
+#define ALC5658_ASRC4				0x008A	/* ASRC Control 4 */
+#define ALC5658_HP					0x008E	/* HP Output Control 1 */
+#define ALC5658_0091				0x0091
+#define ALC5658_MICBIAS1			0x0093	/* MICBIAS Control */
+#define ALC5658_MICBIAS2			0x0094	/* MICBIAS Control */
+#define ALC5658_SPK_AMP				0x00A0	/* Class-D Amp Control */
+#define ALC5658_ADC_EQ1				0x00AE	/* ADC EQ Control 1 */
+#define ALC5658_ADC_EQ2				0x00AF	/* ADC EQ Control 2 */
+#define ALC5658_DAC_EQ1				0x00B0	/* DAC EQ Control 1 */
+#define ALC5658_DAC_EQ2				0x00B1	/* DAC EQ Control 2 */
+#define ALC5658_DAC_EQ3				0x00B2	/* DAC EQ Control 3 */
+#define ALC5658_IRQ1				0x00B8	/* IRQ Control 1 */
+#define ALC5658_IRQ2				0x00BA	/* IRQ Control 2 */
+#define ALC5658_IRQ3				0x00BB	/* IRQ Control 3 */
+#define ALC5658_INTERNAL_STATUS1	0x00BE	/* Internal Status 1 */
+#define ALC5658_INTERNAL_STATUS2	0x00BF	/* Internal Status 2 */
+#define ALC5658_GPIO1				0x00C0	/* GPIO Control 1 */
+#define ALC5658_GPIO2				0x00C1	/* GPIO Control 2 */
+#define ALC5658_GPIO3				0x00C2	/* GPIO Control 3 */
+#define ALC5658_SVOL1				0x00D9	/* Soft Volume and ZCD Control 1 */
+#define ALC5658_SVOL2				0x00DA	/* Soft Volume and ZCD Control 2 */
+#define ALC5658_3BTN1				0x00DB	/* 3 Buttons Inline Command Control 1 */
+#define ALC5658_3BTN2				0x00DC	/* 3 Buttons Inline Command Control 2 */
+#define ALC5658_3BTN3				0x00DD	/* 3 Buttons Inline Command Control 3 */
+#define ALC5658_3BTN4				0x00DE	/* 3 Buttons Inline Command Control 4 */
+#define ALC5658_4BTN1				0x00DF	/* 4 Buttons Inline Command Control 1 */
+#define ALC5658_4BTN2				0x00E0	/* 4 Buttons Inline Command Control 2 */
+#define ALC5658_4BTN3				0x00E1	/* 4 Buttons Inline Command Control 3 */
+#define ALC5658_PWR_SAVE1			0x00E4	/* Power Saving Inline Control 1 */
+#define ALC5658_PWR_SAVE2			0x00E5	/* Power Saving Inline Control 2 */
+#define ALC5658_STEREO1				0x00EA	/* Stereo1 ADC Wind Filter Control 1 */
+#define ALC5658_STEREO2				0x00EB	/* Stereo1 ADC Wind Filter Control 2 */
+#define ALC5658_MONO1				0x00EC	/* Mono ADC Wind Filter Control 1 */
+#define ALC5658_MONO2				0x00ED	/* Mono ADC Wind Filter Control 2 */
+#define ALC5658_GPIO_JD				0x00F6	/* GPIO Jack Detection Control 1 */
+#define ALC5658_GENERAL_CONTROL_1	0x00FA	/* General Control 1 */
+#define ALC5658_GENERAL_CONTROL_2	0x00FB	/* General Control 2 */
+#define ALC5658_0111				0x0110
+#define ALC5658_0125				0x0125
+#define ALC5658_RESET1				0x013A	/* ADC/DAC RESET Control 1 */
+#define ALC5658_RESET2				0x013B	/* ADC/DAC RESET Control 2 */
+#define ALC5658_013C				0x013C
+#define ALC5658_BASSBACK			0x0150	/* BassBack Control */
+#define ALC5658_TRUTREBLE1			0x0151	/* TruTreble Control 1 */
+#define ALC5658_TRUTREBLE2			0x0152	/* TruTreble Control 2 */
+#define ALC5658_OMNI_SOUND			0x0157	/* Omni Sound Control */
+#define ALC5658_NOISE_GATE			0x0160	/* Noise Gate Mode2 Conrol 1 */
+#define ALC5658_LDO					0x0192	/* LDO Control */
+#define ALC5658_SENSING_CTRL1		0x01C0	/* HP Impedance Sensing Control 1 */
+#define ALC5658_SENSING_CTRL2		0x01C2	/* HP Impedance Sensing Control 2 */
+#define ALC5658_SENSING_CTRL4		0x01DA	/* HP Impedance Sensing Control 4 */
+#define ALC5658_01DE				0x01DE
+#define ALC5658_01DF				0x01DF
+#define ALC5658_01E4				0x01E4
+#define ALC5658_PWR_LIMIT1			0x0200	/* Speaker Power Limiter Control 1 */
+#define ALC5658_PWR_LIMIT2			0x0201	/* Speaker Power Limiter Control 2 */
+#define ALC5658_PWR_LIMIT3			0x0202	/* Speaker Power Limiter Control 3 */
+#define ALC5658_PWR_LIMIT4			0x0204	/* Speaker Power Limiter Control 4 */
+#define ALC5658_PWR_LIMIT5			0x0205	/* Speaker Power Limiter Control 5 */
+#define ALC5658_SPKVDD				0x0281	/* SPKVDD Voltage Detection Control */
+#define ALC5658_SPK_DC_LV_DETECT1	0x0282	/* Speaker DC Level Detection Control 1 */
+#define ALC5658_SPK_DC_LV_DETECT2	0x0283	/* Speaker DC Level Detection Control 2 */
+#define ALC5658_SPK_DC_LV_DETECT3	0x0284	/* Speaker DC Level Detection Control 3 */
+#define ALC5658_SPK_DC_DETECT1		0x0290	/* Speaker DC Detection Control 1 */
+#define ALC5658_SPK_DC_DETECT2		0x0291	/* Speaker DC Detection Control 2 */
+#define ALC5658_DRCAGC1				0x0300	/* DRC/AGC Control 1 */
+#define ALC5658_DRCAGC2				0x0301	/* DRC/AGC Control 2 */
+#define ALC5658_DRCAGC3				0x0302	/* DRC/AGC Control 3 */
+#define ALC5658_DRCAGC4				0x0303	/* DRC/AGC Control 4 */
+#define ALC5658_DRCAGC5				0x0304	/* DRC/AGC Control 5 */
+#define ALC5658_DRCAGC_BASS1		0x0308	/* DRC/AGC Bass Control 1 */
+#define ALC5658_DRCAGC_BASS2		0x0309	/* DRC/AGC Bass Control 2 */
+#define ALC5658_DRCAGC_BASS3		0x030A	/* DRC/AGC Bass Control 3 */
+#define ALC5658_DRCAGC_BASS4		0x030B	/* DRC/AGC Bass Control 4 */
+#define ALC5658_DRCAGC_BASS5		0x030C	/* DRC/AGC Bass Control 5 */
+#define ALC5658_MULTI_DRC			0x0320	/* Multi-Band DRC Control */
+#define ALC5658_ALC_PGA1			0x0330	/* ALC PGA Control 1 */
+#define ALC5658_ALC_PGA2			0x0331	/* ALC PGA Control 2 */
+#define ALC5658_ALC_PGA3			0x0332	/* ALC PGA Control 3 */
+#define ALC5658_ALC_PGA4			0x0333	/* ALC PGA Control 4 */
+#define ALC5658_ALC_PGA5			0x0334	/* ALC PGA Control 5 */
+#define ALC5658_ALC_PGA6			0x0335	/* ALC PGA Control 6 */
+#define ALC5658_ALC_PGA7			0x0336	/* ALC PGA Control 7 */
+#define ALC5658_ALC_PGA8			0x0337	/* ALC PGA Control 8 */
 
 #endif							/* CONFIG_AUDIO_ALC5658 */
 #endif							/* __DRIVERS_AUDIO_ALC5658REG_H */

--- a/os/drivers/audio/alc5658scripts.h
+++ b/os/drivers/audio/alc5658scripts.h
@@ -29,370 +29,281 @@
 
 /* TYPEDEFS */
 typedef struct {
-	ALC5658_REG addr;
+	uint16_t addr;
 	uint16_t val;
 	unsigned int delay;
 } t_codec_init_script_entry;
 
-typedef struct {
-	ALC5658_REG addr;
-	char *name;
-} t_codec_dump_entry;
-
 t_codec_init_script_entry codec_reset_script[] = {
-	{ALC5658_RESET, 0x0000, 0},	/* Reset */
+	{ALC5658_SW_RESET, 0x0000, 0},	/* Reset */
 };
 
 t_codec_init_script_entry codec_stop_script[] = {
-	{ALC5658_RESET, 0x0000, 0},	/* Reset */
-	{ALC5658_I2S1_CTRL, 0x8000, 0},	/* Switch into slave to stop data transfer */
+	{ALC5658_SW_RESET, 0x0000, 0},	/* Reset */
+	{ALC5658_I2S1_PORT_CTRL, 0x8000, 0},	/* Switch into slave to stop data transfer */
 };
 
 t_codec_init_script_entry codec_init_script[] = {
-	{ALC5658_RESET, 0x0000, 0},	/* Reset */
+	{ALC5658_SW_RESET, 0x0000, 0},	/* Reset */
 	{ALC5658_006E, 0xFFFF, 0},	/* NO INFO IN DOCUMENTATION!!! */
 	{ALC5658_006F, 0xFFFF, 0},	/* NO INFO IN DOCUMENTATION!!! */
-	{ALC5658_GLBL_CLK, 0x8000, 0},	/* RC CLK, No dividers */
-	{ALC5658_INTCLK_CTRL, 0x0280, 0},	/* ??? Enable ALL int CLK, even more than in documentation */
+	{ALC5658_CLOCK, 0x8000, 0},	/* RC CLK, No dividers */
+	{ALC5658_MICBIAS2, 0x0280, 0},	/* Enable ALL int CLK, even more than in documentation */
 	{ALC5658_0111, 0xA502, 0},	/* NO INFO IN DOCUMENTATION!!! */
 	{ALC5658_0125, 0x0430, 0},	/* NO INFO IN DOCUMENTATION!!! */
-	{ALC5658_ADDA_RST1, 0x3020, 0},	/* ??? DAC1, DAC2 + alpha clock enable */
-	{ALC5658_ADDA_CLK, 0x1770, 0},	/* I2Sprediv1 = 2, bclk_ms2 = 16bits(32FS), I2Sprediv2 = 7, something reserved, dac/adc 128Fs */
-	{ALC5658_I2S1_CTRL, 0x0000, 0},	/* Master, off/normal/I2S...  16bit */
+	{ALC5658_RESET1, 0x3020, 0},	/* DAC1, DAC2 + alpha clock enable */
+	{ALC5658_ADCDAC_CLOCK, 0x1770, 0},	/* I2Sprediv1 = 2, bclk_ms2 = 16bits(32FS), I2Sprediv2 = 7, something reserved, dac/adc 128Fs */
+	{ALC5658_I2S1_PORT_CTRL, 0x0000, 0},	/* Master, off/normal/I2S...  16bit */
 	{ALC5658_007B, 0x0003, 0},	/* Select 64*FS for BCLK in master mode, No Info in documentation  */
-	{ALC5658_GNRL_CTRL, 0x0001, 0},	/* Enable Gate mode, Use(pass) Noise Gain Mode2 CTRL */
+	{ALC5658_GENERAL_CONTROL_1, 0x0001, 0},	/* Enable Gate mode, Use(pass) Noise Gain Mode2 CTRL */
 	{ALC5658_0091, 0x0C16, 0},	/* NO INFO IN DOCUMENTATION!!! */
-	{ALC5658_PWR_MNG3, 0xA23E, 60},	/* VREF1 on, fast VREF1, VREF2 on, fast VREF2, MBIAS on, LOUT off, MBIAS bandgap off, HP L/R ON, HPamp x5, LDO1 out 1.2V */
-	{ALC5658_PWR_MNG3, 0xF23E, 50},	/* VREF1 on, SLOW VREF1, VREF2 on, SLOW VREF2, MBIAS on, LOUT off, MBIAS bandgap off, HP L/R ON, HPamp x5, LDO1 out 1.2V */
-	{ALC5658_PWR_MNG2, 0x0400, 50},	/* pow_dac_stereo1_filter ON */
-	{ALC5658_PWR_MNG1, 0x8080, 10},	/* en_i2s1, Pow_ldo_dacref ON */
-	{ALC5658_ADC_2_DAC_MXR, 0x8080, 0},	/* Mu_stereo1_adc_mixer_l/r MUTE */
-	{ALC5658_DAC_STR_MXR, 0xAAAA, 0},	/* Default, mute all */
+	{ALC5658_MANAGEMENT3, 0xA23E, 60},	/* VREF1 on, fast VREF1, VREF2 on, fast VREF2, MBIAS on, LOUT off, MBIAS bandgap off, HP L/R ON, HPamp x5, LDO1 out 1.2V */
+	{ALC5658_MANAGEMENT3, 0xF23E, 50},	/* VREF1 on, SLOW VREF1, VREF2 on, SLOW VREF2, MBIAS on, LOUT off, MBIAS bandgap off, HP L/R ON, HPamp x5, LDO1 out 1.2V */
+	{ALC5658_MANAGEMENT2, 0x0400, 50},	/* pow_dac_stereo1_filter ON */
+	{ALC5658_MANAGEMENT1, 0x8080, 10},	/* en_i2s1, Pow_ldo_dacref ON */
+	{ALC5658_ADC_2_MXR, 0x8080, 0},	/* Mu_stereo1_adc_mixer_l/r MUTE */
+	{ALC5658_DAC_ST_MXR, 0xAAAA, 0},	/* Default, mute all */
 	{ALC5658_DAC_SRC, 0x0000, 0},	/* Default, no mixers (direct) */
-	{ALC5658_HP_AMP, 0x0009, 50},	/* en_out_hp - OFF, pow_pump_hp - ON, pow_capless - ON */
-	{ALC5658_PWR_MNG1, 0x8C80, 50},	/* en_i2s1, pow_dac1_l/r, Pow_ldo_dacref - ON */
+	{ALC5658_HP, 0x0009, 50},	/* en_out_hp - OFF, pow_pump_hp - ON, pow_capless - ON */
+	{ALC5658_MANAGEMENT1, 0x8C80, 50},	/* en_i2s1, pow_dac1_l/r, Pow_ldo_dacref - ON */
 	{ALC5658_0091, 0x0E16, 50},	/* NO INFO IN DOCUMENTATION!!! */
 	{ALC5658_0040, 0x0505, 0},	/* NO INFO IN DOCUMENTATION!!! */
-	{ALC5658_PWR_MNG5, 0x0180, 0},	/* Does not match with documentation */
-	{ALC5658_0x013C, 0x3C05, 0},	/* NO INFO IN DOCUMENTATION!!! */
-	{ALC5658_0x01DF, 0x02C1, 0},	/* NO INFO IN DOCUMENTATION!!! */
-	{ALC5658_0x01DF, 0x2CC1, 0},	/* NO INFO IN DOCUMENTATION!!! */
-	{ALC5658_0x01DE, 0x5100, 0},	/* NO INFO IN DOCUMENTATION!!! */
-	{ALC5658_0x01E4, 0x0014, 0},	/* NO INFO IN DOCUMENTATION!!! */
-	{ALC5658_0x01DE, 0xD100, 30},	/* NO INFO IN DOCUMENTATION!!! */
-	{ALC5658_0x01DF, 0x2CC1, 0},	/* NO INFO IN DOCUMENTATION!!! */
-	{ALC5658_0x01DE, 0x4900, 0},	/* NO INFO IN DOCUMENTATION!!! */
-	{ALC5658_0x01E4, 0x0016, 0},	/* NO INFO IN DOCUMENTATION!!! */
-	{ALC5658_0x01DE, 0xC900, 250},	/* NO INFO IN DOCUMENTATION!!! */
-	{ALC5658_0x01DF, 0x2CC1, 0},	/* NO INFO IN DOCUMENTATION!!! */
-	{ALC5658_HPOUT_MUTE, 0x0000, 0},	/* UNMUTE HP Output */
-	{ALC5658_0x01DE, 0x4500, 0},	/* NO INFO IN DOCUMENTATION!!! */
-	{ALC5658_0x01E4, 0x001F, 0},	/* NO INFO IN DOCUMENTATION!!! */
-	{ALC5658_0x01DE, 0xC500, 800},	/* NO INFO IN DOCUMENTATION!!! */
+	{ALC5658_MANAGEMENT5, 0x0180, 0},	/* Does not match with documentation */
+	{ALC5658_013C, 0x3C05, 0},	/* NO INFO IN DOCUMENTATION!!! */
+	{ALC5658_01DF, 0x02C1, 0},	/* NO INFO IN DOCUMENTATION!!! */
+	{ALC5658_01DF, 0x2CC1, 0},	/* NO INFO IN DOCUMENTATION!!! */
+	{ALC5658_01DE, 0x5100, 0},	/* NO INFO IN DOCUMENTATION!!! */
+	{ALC5658_01E4, 0x0014, 0},	/* NO INFO IN DOCUMENTATION!!! */
+	{ALC5658_01DE, 0xD100, 30},	/* NO INFO IN DOCUMENTATION!!! */
+	{ALC5658_01DF, 0x2CC1, 0},	/* NO INFO IN DOCUMENTATION!!! */
+	{ALC5658_01DE, 0x4900, 0},	/* NO INFO IN DOCUMENTATION!!! */
+	{ALC5658_01E4, 0x0016, 0},	/* NO INFO IN DOCUMENTATION!!! */
+	{ALC5658_01DE, 0xC900, 250},	/* NO INFO IN DOCUMENTATION!!! */
+	{ALC5658_01DF, 0x2CC1, 0},	/* NO INFO IN DOCUMENTATION!!! */
+	{ALC5658_HPOUT, 0x0000, 0},	/* UNMUTE HP Output */
+	{ALC5658_01DE, 0x4500, 0},	/* NO INFO IN DOCUMENTATION!!! */
+	{ALC5658_01E4, 0x001F, 0},	/* NO INFO IN DOCUMENTATION!!! */
+	{ALC5658_01DE, 0xC500, 800},	/* NO INFO IN DOCUMENTATION!!! */
 	{ALC5658_0040, 0x0808, 0},	/* NO INFO IN DOCUMENTATION!!! */
-	{ALC5658_PWR_MNG5, 0x0000, 0},	/* Default, PLL, LDO2, Speaker VDD off */
-	{ALC5658_0x013C, 0x2005, 0},	/* NO INFO IN DOCUMENTATION!!! */
-	{ALC5658_0x01E4, 0x0000, 0},	/* NO INFO IN DOCUMENTATION!!! */
-	{ALC5658_0x01DF, 0x20C0, 0},	/* NO INFO IN DOCUMENTATION!!! */
-	{ALC5658_ADDA_CLK, 0x0770, 0},	/* I2Sprediv1 = 2, bclk_ms2 = 16bits(32FS), I2Sprediv2 = 7, something reserved, dac/adc 128Fs */
-	{ALC5658_GLBL_CLK, 0x0000, 0},	/* MCLK, No dividers */
-	{ALC5658_NOISE_G_M2_CTRL, 0x8EC0, 0},	/* Stereo_noise_gate_mode2_en - ENABLE */
-	{ALC5658_HP_AMP, 0x0019, 0},	/* en_out_hp - ON, pow_pump_hp - ON, pow_capless - ON  */
-	{ALC5658_NOISE_G_M1_CTRL1, 0xC0F0, 0},	/* Noise_gate_mode1_en, Noise_gate_mode1_auto_en - EN, Noise_gate_mode1_threshold -78dB, DOES NOT MATCH WITH DOCUMENTATION !!! */
-	{ALC5658_NOISE_G_M1_CTRL1, 0x87F9, 0},	/* Blah blah blah, eventually enable Noise gate function >:( */
-	{ALC5658_INTCLK_CTRL, 0x0180, 0},	/* Probably enable Pow_int_clk1/2, does not match with DOC !!! */
-	{ALC5658_GNRL_CTRL2, 0x3000, 0},	/* Noise_gate_mode1/2_hp enable, DOES NOT MATCH WITH DOCUMENTATION */
+	{ALC5658_MANAGEMENT5, 0x0000, 0},	/* Default, PLL, LDO2, Speaker VDD off */
+	{ALC5658_013C, 0x2005, 0},	/* NO INFO IN DOCUMENTATION!!! */
+	{ALC5658_01E4, 0x0000, 0},	/* NO INFO IN DOCUMENTATION!!! */
+	{ALC5658_01DF, 0x20C0, 0},	/* NO INFO IN DOCUMENTATION!!! */
+	{ALC5658_ADCDAC_CLOCK, 0x0770, 0},	/* I2Sprediv1 = 2, bclk_ms2 = 16bits(32FS), I2Sprediv2 = 7, something reserved, dac/adc 128Fs */
+	{ALC5658_CLOCK, 0x0000, 0},	/* MCLK, No dividers */
+	{ALC5658_NOISE_GATE, 0x8EC0, 0},	/* Stereo_noise_gate_mode2_en - ENABLE */
+	{ALC5658_HP, 0x0019, 0},	/* en_out_hp - ON, pow_pump_hp - ON, pow_capless - ON  */
+	{ALC5658_NOISE_GATE1, 0xC0F0, 0},	/* Noise_gate_mode1_en, Noise_gate_mode1_auto_en - EN, Noise_gate_mode1_threshold -78dB, DOES NOT MATCH WITH DOCUMENTATION !!! */
+	{ALC5658_NOISE_GATE1, 0x87F9, 0},	/* Blah blah blah, eventually enable Noise gate function >:( */
+	{ALC5658_MICBIAS2, 0x0180, 0},	/* Probably enable Pow_int_clk1/2, does not match with DOC !!! */
+	{ALC5658_GENERAL_CONTROL_2, 0x3000, 0},	/* Noise_gate_mode1/2_hp enable, DOES NOT MATCH WITH DOCUMENTATION */
 };
 
 t_codec_init_script_entry codec_initial_script[] = {
-	{ALC5658_RESET, 0x0000, 0},
+	{ALC5658_SW_RESET, 0x0000, 0},
 	{ALC5658_0111, 0xA502, 0},
-	{ALC5658_ADDA_RST1, 0x3030, 0},	/* ??? DAC1, DAC2 + alpha clock enable */
+	{ALC5658_RESET1, 0x3030, 0},	/* DAC1, DAC2 + alpha clock enable */
 	{ALC5658_006E, 0xEF00, 0},
 	{ALC5658_006F, 0xEFFC, 0},
-	{ALC5658_INTCLK_CTRL, 0x0280, 0},	/* ??? Enable ALL int CLK, even more than in documentation */
-	{ALC5658_GLBL_CLK, 0x8000, 0},	/* RC CLK, No dividers */
-	{ALC5658_I2S1_CTRL, 0x0000, 0},	/* Master, off/normal/I2S...  16bit */
-	{ALC5658_ADDA_CLK, 0x1770, 0},	/* I2Sprediv1 = 2, bclk_ms2 = 16bits(32FS), I2Sprediv2 = 7, something reserved, dac/adc 128Fs */
+	{ALC5658_MICBIAS2, 0x0280, 0},	/* Enable ALL int CLK, even more than in documentation */
+	{ALC5658_CLOCK, 0x8000, 0},	/* RC CLK, No dividers */
+	{ALC5658_I2S1_PORT_CTRL, 0x0000, 0},	/* Master, off/normal/I2S...  16bit */
+	{ALC5658_ADCDAC_CLOCK, 0x1770, 0},	/* I2Sprediv1 = 2, bclk_ms2 = 16bits(32FS), I2Sprediv2 = 7, something reserved, dac/adc 128Fs */
 	{ALC5658_0091, 0x0C16, 0},
-	{ALC5658_PWR_MNG3, 0xAA7E, 60},	/* VREF1 on, fast VREF1, VREF2 on, fast VREF2, MBIAS on, LOUT off, MBIAS bandgap off, HP L/R ON, HPamp x5, LDO1 out 1.2V */
-	{ALC5658_PWR_MNG3, 0xFE7E, 50},	/* VREF1 on, SLOW VREF1, VREF2 on, SLOW VREF2, MBIAS on, LOUT off, MBIAS bandgap off, HP L/R ON, HPamp x5, LDO1 out 1.2V */
-	{ALC5658_PWR_MNG5, 0x0004, 0},	/* LDO2 ON */
-	{ALC5658_PWR_MNG2, 0x0400, 50},	/* pow_dac_stereo1_filter ON */
-	{ALC5658_PWR_MNG1, 0x0080, 10},	/* Pow_ldo_dacref ON */
-	{ALC5658_ADC_2_DAC_MXR, 0x8080, 0},	/* Mu_stereo1_adc_mixer_l/r MUTE */
-	{ALC5658_DAC_STR_MXR, 0xAAAA, 0},	/* Default, mute all */
+	{ALC5658_MANAGEMENT3, 0xAA7E, 60},	/* VREF1 on, fast VREF1, VREF2 on, fast VREF2, MBIAS on, LOUT off, MBIAS bandgap off, HP L/R ON, HPamp x5, LDO1 out 1.2V */
+	{ALC5658_MANAGEMENT3, 0xFE7E, 50},	/* VREF1 on, SLOW VREF1, VREF2 on, SLOW VREF2, MBIAS on, LOUT off, MBIAS bandgap off, HP L/R ON, HPamp x5, LDO1 out 1.2V */
+	{ALC5658_MANAGEMENT5, 0x0004, 0},	/* LDO2 ON */
+	{ALC5658_MANAGEMENT2, 0x0400, 50},	/* pow_dac_stereo1_filter ON */
+	{ALC5658_MANAGEMENT1, 0x0080, 10},	/* Pow_ldo_dacref ON */
+	{ALC5658_ADC_2_MXR, 0x8080, 0},	/* Mu_stereo1_adc_mixer_l/r MUTE */
+	{ALC5658_DAC_ST_MXR, 0xAAAA, 0},	/* Default, mute all */
 	{ALC5658_DAC_SRC, 0x0000, 0},	/* Default, no mixers (direct) */
-	{ALC5658_HP_AMP, 0x0009, 50},	/* en_out_hp - OFF, pow_pump_hp - ON, pow_capless - ON */
-	{ALC5658_PWR_MNG1, 0x0F80, 50},	/* pow_dac1_l/r, pow_dac2_l/r, Pow_ldo_dacref - ON */
+	{ALC5658_HP, 0x0009, 50},	/* en_out_hp - OFF, pow_pump_hp - ON, pow_capless - ON */
+	{ALC5658_MANAGEMENT1, 0x0F80, 50},	/* pow_dac1_l/r, pow_dac2_l/r, Pow_ldo_dacref - ON */
 	{ALC5658_0091, 0x0E16, 50},
 	{ALC5658_0040, 0x0505, 0},
-	{ALC5658_PWR_MNG5, 0x0184, 0},	/* ???NonDescribed,  LDO2 ON */
-	{ALC5658_0x013C, 0x3C05, 0},
-	{ALC5658_0x01DF, 0x2cc1, 6},
-	{ALC5658_0x01DE, 0x5100, 6},
-	{ALC5658_0x01E4, 0x0014, 6},
-	{ALC5658_0x01DE, 0xd100, 30},
-	{ALC5658_0x01DF, 0x20C1, 0},
-	{ALC5658_0x01DF, 0x2CC1, 0},
-	{ALC5658_0x01DE, 0x4900, 0},
-	{ALC5658_0x01E4, 0x0016, 0},
-	{ALC5658_0x01DE, 0xC900, 250},
-	{ALC5658_0x01DF, 0x2CC1, 0},
-	{ALC5658_HPOUT_MUTE, 0x0000, 0},	/* UNMUTE HP Output */
-	{ALC5658_0x01DE, 0x4500, 0},
-	{ALC5658_0x01E4, 0x001F, 0},
-	{ALC5658_0x01DE, 0xC500, 600},
-	{ALC5658_0x01E4, 0x0000, 0},
-	{ALC5658_0x01DF, 0x20C0, 0},
+	{ALC5658_MANAGEMENT5, 0x0184, 0},	/* NonDescribed,  LDO2 ON */
+	{ALC5658_013C, 0x3C05, 0},
+	{ALC5658_01DF, 0x2cc1, 6},
+	{ALC5658_01DE, 0x5100, 6},
+	{ALC5658_01E4, 0x0014, 6},
+	{ALC5658_01DE, 0xd100, 30},
+	{ALC5658_01DF, 0x20C1, 0},
+	{ALC5658_01DF, 0x2CC1, 0},
+	{ALC5658_01DE, 0x4900, 0},
+	{ALC5658_01E4, 0x0016, 0},
+	{ALC5658_01DE, 0xC900, 250},
+	{ALC5658_01DF, 0x2CC1, 0},
+	{ALC5658_HPOUT, 0x0000, 0},	/* UNMUTE HP Output */
+	{ALC5658_01DE, 0x4500, 0},
+	{ALC5658_01E4, 0x001F, 0},
+	{ALC5658_01DE, 0xC500, 600},
+	{ALC5658_01E4, 0x0000, 0},
+	{ALC5658_01DF, 0x20C0, 0},
 	{ALC5658_0040, 0x0808, 0},
-	{ALC5658_PWR_MNG5, 0x0000, 0},	/* LDO2 OFF */
-	{ALC5658_0x013C, 0x2005, 0},
-	{ALC5658_PWR_MNG6, 0x0000, 0},	/* MIXERs OFF */
-	{ALC5658_PWR_MNG7, 0x0000, 0},	/* VOL Out/In ctrl, MIC in det OFF */
-	{ALC5658_PWR_MNG1, 0x0000, 0},	/* I2S, DAC, ADC, SPDIFF, CLASS D OFF */
-	{ALC5658_PWR_MNG2, 0x0000, 0},	/* Filters, PDM I/F  OFF */
-	{ALC5658_PWR_MNG3, 0x003C, 0},	/* HP L/R ON, HPamp x5, LDO1 out 0.9V */
-	{ALC5658_GLBL_CLK, 0x0000, 0},	/* MCLK, No dividers */
-	{ALC5658_ADDA_CLK, 0x0770, 0},	/* I2Sprediv1 = 2, bclk_ms2 = 16bits(32FS), I2Sprediv2 = 7, something reserved, dac/adc 128Fs */
-	{ALC5658_INTCLK_CTRL, 0x0080, 0},	/* Probably enable Pow_int_clk1/2, does not match with DOC !!! */
+	{ALC5658_MANAGEMENT5, 0x0000, 0},	/* LDO2 OFF */
+	{ALC5658_013C, 0x2005, 0},
+	{ALC5658_MANAGEMENT6, 0x0000, 0},	/* MIXERs OFF */
+	{ALC5658_MANAGEMENT7, 0x0000, 0},	/* VOL Out/In ctrl, MIC in det OFF */
+	{ALC5658_MANAGEMENT1, 0x0000, 0},	/* I2S, DAC, ADC, SPDIFF, CLASS D OFF */
+	{ALC5658_MANAGEMENT2, 0x0000, 0},	/* Filters, PDM I/F  OFF */
+	{ALC5658_MANAGEMENT3, 0x003C, 0},	/* HP L/R ON, HPamp x5, LDO1 out 0.9V */
+	{ALC5658_CLOCK, 0x0000, 0},	/* MCLK, No dividers */
+	{ALC5658_ADCDAC_CLOCK, 0x0770, 0},	/* I2Sprediv1 = 2, bclk_ms2 = 16bits(32FS), I2Sprediv2 = 7, something reserved, dac/adc 128Fs */
+	{ALC5658_MICBIAS2, 0x0080, 0},	/* Probably enable Pow_int_clk1/2, does not match with DOC !!! */
 };
 
 t_codec_init_script_entry codec_init_out_script[] = {
-	{ALC5658_RESET, 0x0000, 0},
+	{ALC5658_SW_RESET, 0x0000, 0},
 	{ALC5658_006E, 0xFFFF, 0},
 	{ALC5658_006F, 0xFFFF, 0},
-	{ALC5658_GNRL_CTRL, 0x8001, 0},	/* Bypass_noise_gate_mode2 BYPASS, digital_gate_ctrl ENABLE */
-	{ALC5658_ADDA_RST1, 0x3030, 0},	/* ??? DAC1, DAC2 + alpha clock enable */
-	{ALC5658_GLBL_PLL1, 0x0302, 0},	/* k = 2, n = 8 */
-	{ALC5658_GLBL_PLL2, 0x0800, 0},	/* m - bypass */
-	{ALC5658_ADDA_CLK, 0x1110, 0},	/* I2Sprediv1 = 2, bclk_ms2 = 16bits(32FS), I2Sprediv2 = 2, something reserved, dac/adc 128Fs */
+	{ALC5658_GENERAL_CONTROL_1, 0x8001, 0},	/* Bypass_noise_gate_mode2 BYPASS, digital_gate_ctrl ENABLE */
+	{ALC5658_RESET1, 0x3030, 0},	/* DAC1, DAC2 + alpha clock enable */
+	{ALC5658_PLL1, 0x0302, 0},	/* k = 2, n = 8 */
+	{ALC5658_PLL2, 0x0800, 0},	/* m - bypass */
+	{ALC5658_ADCDAC_CLOCK, 0x1110, 0},	/* I2Sprediv1 = 2, bclk_ms2 = 16bits(32FS), I2Sprediv2 = 2, something reserved, dac/adc 128Fs */
 	{ALC5658_0091, 0x0C16, 0},
-	{ALC5658_PWR_MNG3, 0xA23E, 20},	/* VREF1 on, fast VREF1, VREF2 on, fast VREF2, MBIAS on, LOUT off, MBIAS bandgap off, HP L/R ON, HPamp x5, LDO1 out 1.2V */
-	{ALC5658_PWR_MNG3, 0xF23E, 0},	/* VREF1 on, SLOW VREF1, VREF2 on, SLOW VREF2, MBIAS on, LOUT off, MBIAS bandgap off, HP L/R ON, HPamp x5, LDO1 out 1.2V */
-	{ALC5658_PWR_MNG5, 0x0040, 0},	/* LDO2 ON */
-	{ALC5658_GLBL_CLK, 0x4000, 0},	/* PLL1, No dividers */
-	{ALC5658_GLBL_ASRC4, 0x0100, 0},	/* sel_i2s2_asrc = ASRC2 */
-	{ALC5658_GLBL_ASRC1, 0x1300, 0},	/* En_i2s2_asrc - EN, Sel_mono_dac_l/r_mode EN */
-	{ALC5658_GLBL_ASRC2, 0x0220, 0},	/* sel_da_filter_monol_track = clk_i2s2_track, sel_da_filter_monor_track = clk_i2s2_track */
-	{ALC5658_PWR_MNG1, 0xC080, 0},	/* en_i2s1/en_i2s2, Pow_ldo_dacref ON */
-	{ALC5658_HP_AMP, 0x0009, 0},	/* en_out_hp - OFF, pow_pump_hp - ON, pow_capless - ON */
-	{ALC5658_PWR_MNG1, 0xCC80, 0},	/* en_i2s1/en_i2s2, pow_dac1_l/r, Pow_ldo_dacref ON */
+	{ALC5658_MANAGEMENT3, 0xA23E, 20},	/* VREF1 on, fast VREF1, VREF2 on, fast VREF2, MBIAS on, LOUT off, MBIAS bandgap off, HP L/R ON, HPamp x5, LDO1 out 1.2V */
+	{ALC5658_MANAGEMENT3, 0xF23E, 0},	/* VREF1 on, SLOW VREF1, VREF2 on, SLOW VREF2, MBIAS on, LOUT off, MBIAS bandgap off, HP L/R ON, HPamp x5, LDO1 out 1.2V */
+	{ALC5658_MANAGEMENT5, 0x0040, 0},	/* LDO2 ON */
+	{ALC5658_CLOCK, 0x4000, 0},	/* PLL1, No dividers */
+	{ALC5658_ASRC4, 0x0100, 0},	/* sel_i2s2_asrc = ASRC2 */
+	{ALC5658_ASRC1, 0x1300, 0},	/* En_i2s2_asrc - EN, Sel_mono_dac_l/r_mode EN */
+	{ALC5658_ASRC2, 0x0220, 0},	/* sel_da_filter_monol_track = clk_i2s2_track, sel_da_filter_monor_track = clk_i2s2_track */
+	{ALC5658_MANAGEMENT1, 0xC080, 0},	/* en_i2s1/en_i2s2, Pow_ldo_dacref ON */
+	{ALC5658_HP, 0x0009, 0},	/* en_out_hp - OFF, pow_pump_hp - ON, pow_capless - ON */
+	{ALC5658_MANAGEMENT1, 0xCC80, 0},	/* en_i2s1/en_i2s2, pow_dac1_l/r, Pow_ldo_dacref ON */
 	{ALC5658_0091, 0x0E16, 0},
-	{ALC5658_PWR_MNG2, 0x0700, 0},	/* pow_dac_stereo1_filter, pow_dac_monol/r_filter ON  */
-	{ALC5658_HPOUT_MUTE, 0x0000, 0},	/* OFF */
+	{ALC5658_MANAGEMENT2, 0x0700, 0},	/* pow_dac_stereo1_filter, pow_dac_monol/r_filter ON  */
+	{ALC5658_HPOUT, 0x0000, 0},	/* OFF */
 	{ALC5658_0091, 0x0E1E, 0},
 	{ALC5658_006E, 0xFFFF, 0},
 	{ALC5658_006F, 0xFFFF, 0},
-	{ALC5658_I2S1_CTRL, 0x0000, 0},	//MASTER 32FS
-	{ALC5658_DAC_STR_MXR, 0x2A8A, 0},	/* mu_stereo_dacl1_mixl, mu_stereo_dacr1_mixr unmute */
+	{ALC5658_I2S1_PORT_CTRL, 0x0000, 0},	//MASTER 32FS
+	{ALC5658_DAC_ST_MXR, 0x2A8A, 0},	/* mu_stereo_dacl1_mixl, mu_stereo_dacr1_mixr unmute */
 	{ALC5658_DAC_SRC, 0x000F, 0},	/* DAC1 stereo, DAC2 mono */
-	{ALC5658_HP_AMP, 0x0019, 0},	/* en_out_hp - ON, pow_pump_hp - ON, pow_capless - ON  */
-	{ALC5658_TDM_CTRL2, 0x000C, 0},	//loopback
+	{ALC5658_HP, 0x0019, 0},	/* en_out_hp - ON, pow_pump_hp - ON, pow_capless - ON  */
+	{ALC5658_TDM2, 0x000C, 0},	//loopback
 };
 
 t_codec_init_script_entry codec_init_in_script[] = {
-	{ALC5658_RESET, 0x0000, 0},
-	{ALC5658_ADDA_RST1, 0x3030, 0},	/* ??? DAC1, DAC2 + alpha clock enable */
-	{ALC5658_ADDA_RST2, 0x3030, 0},	/* ??? ADC1, ADC2 + alpha clock enable */
+	{ALC5658_SW_RESET, 0x0000, 0},
+	{ALC5658_RESET1, 0x3030, 0},	/* DAC1, DAC2 + alpha clock enable */
+	{ALC5658_RESET2, 0x3030, 0},	/* ADC1, ADC2 + alpha clock enable */
 	{ALC5658_006E, 0xEF00, 0},
 	{ALC5658_006F, 0xEFFC, 0},
-	{ALC5658_I2S1_CTRL, 0x0000, 0},	/* Master, off/normal/I2S...  16bit */
-	{ALC5658_GNRL_CTRL, 0x8001, 0},	/* Bypass_noise_gate_mode2 BYPASS, digital_gate_ctrl ENABLE */
-	{ALC5658_ADDA_CLK, 0x0000, 0},	/* I2Sprediv1 = 1, bclk_ms2 = 16bits(32FS), I2Sprediv2 = 1, something reserved, dac/adc 128Fs */
-	{ALC5658_PWR_MNG3, 0xA2BE, 50},	/* VREF1 on, fast VREF1, VREF2 on, fast VREF2, MBIAS on, LOUT off, MBIAS bandgap ON, HP L/R ON, HPamp x5, LDO1 out 1.2V */
-	{ALC5658_PWR_MNG3, 0xF2BE, 0},	/* VREF1 on, slow VREF1, VREF2 on, slow VREF2, MBIAS on, LOUT off, MBIAS bandgap ON, HP L/R ON, HPamp x5, LDO1 out 1.2V */
-	{ALC5658_PWR_MNG1, 0x8098, 0},	/* en_i2s1, Pow_ldo_dacref, pow_adc1_l/r ON */
-	{ALC5658_PWR_MNG1, 0x8C80, 0},	/* en_i2s1, pow_dac1_l/r Pow_ldo_dacref, pow_adc1_l/r ON */
+	{ALC5658_I2S1_PORT_CTRL, 0x0000, 0},	/* Master, off/normal/I2S...  16bit */
+	{ALC5658_GENERAL_CONTROL_1, 0x8001, 0},	/* Bypass_noise_gate_mode2 BYPASS, digital_gate_ctrl ENABLE */
+	{ALC5658_ADCDAC_CLOCK, 0x0000, 0},	/* I2Sprediv1 = 1, bclk_ms2 = 16bits(32FS), I2Sprediv2 = 1, something reserved, dac/adc 128Fs */
+	{ALC5658_MANAGEMENT3, 0xA2BE, 50},	/* VREF1 on, fast VREF1, VREF2 on, fast VREF2, MBIAS on, LOUT off, MBIAS bandgap ON, HP L/R ON, HPamp x5, LDO1 out 1.2V */
+	{ALC5658_MANAGEMENT3, 0xF2BE, 0},	/* VREF1 on, slow VREF1, VREF2 on, slow VREF2, MBIAS on, LOUT off, MBIAS bandgap ON, HP L/R ON, HPamp x5, LDO1 out 1.2V */
+	{ALC5658_MANAGEMENT1, 0x8098, 0},	/* en_i2s1, Pow_ldo_dacref, pow_adc1_l/r ON */
+	{ALC5658_MANAGEMENT1, 0x8C80, 0},	/* en_i2s1, pow_dac1_l/r Pow_ldo_dacref, pow_adc1_l/r ON */
 	{ALC5658_0091, 0x0E16, 0},
-	{ALC5658_PWR_MNG2, 0xB400, 0},	/* pow_adc_stereo1_filter, pow_adc_monol/r_filter,  pow_dac_stereo1_filter ON */
+	{ALC5658_MANAGEMENT2, 0xB400, 0},	/* pow_adc_stereo1_filter, pow_adc_monol/r_filter,  pow_dac_stereo1_filter ON */
 	{ALC5658_0010, 0x3040, 0},	//CRT Mbias1 path
-	{ALC5658_PWR_MNG4, 0xC860, 0},	//enable mbias1 /* pow_bst1, pow_bst2, pow_micbias1_digital, pow_bst1-2, pow_bst2-2 ON   */
-	{ALC5658_PWR_MNG1, 0x8C98, 0},	/* en_i2s1, pow_dac1_l/r, Pow_ldo_dacref, pow_adc1_l/r ON */
-	{ALC5658_PWR_MNG6, 0x0C00, 0},	/* pow_recmix1l/r ON */
-	{ALC5658_PWR_MNG7, 0x0300, 0},	/* ?extra bits set? pow_inl_vol ON */
-	{ALC5658_IN1_CTRL, 0x3000, 0},	/* Gain -12dB + 0.75dB*0x30  */
-	{ALC5658_RECMIX1L_CTRL_2, 0x005F, 0},	/* Default, all mute */
-	{ALC5658_RECMIX1R_CTRL_2, 0x005F, 0},	/* Default, all mute */
-	{ALC5658_ADC_STR1_MXR, 0x6020, 0},	/* mu_stereo1_adcl1 unmute, sel_stereo1_adc1 Sel, mu_stereo1_adcr1 unmute */
-	{ALC5658_ADC_2_DAC_MXR, 0x0000, 100},	/* Mu_stereo1_adc_mixer_l/r unmute */
-	{ALC5658_DAC_MONO_MXR, 0x2A8A, 0},	/* mu_mono_dacl1_mixl/r unmute */
-	{ALC5658_ADC_MONO_MXR, 0x4040, 0},	/* mu_mono_adcl1 UM, sel_mono_adcl1/2 - Mono_DAC_Mixer_L, mu_mono_adcr1 UM, Sel_mono_adcr1/2 - Mono_DAC_Mixer_R, sel_mono_adcr - ADC1_L, Sel_mono_dmic_r - DMIC1_R */
+	{ALC5658_MANAGEMENT4, 0xC860, 0},	//enable mbias1 /* pow_bst1, pow_bst2, pow_micbias1_digital, pow_bst1-2, pow_bst2-2 ON   */
+	{ALC5658_MANAGEMENT1, 0x8C98, 0},	/* en_i2s1, pow_dac1_l/r, Pow_ldo_dacref, pow_adc1_l/r ON */
+	{ALC5658_MANAGEMENT6, 0x0C00, 0},	/* pow_recmix1l/r ON */
+	{ALC5658_MANAGEMENT7, 0x0300, 0},	/* ?extra bits set? pow_inl_vol ON */
+	{ALC5658_IN1, 0x3000, 0},	/* Gain -12dB + 0.75dB*0x30  */
+	{ALC5658_RECMIX1L_SEL, 0x005F, 0},	/* Default, all mute */
+	{ALC5658_RECMIX1R_SEL, 0x005F, 0},	/* Default, all mute */
+	{ALC5658_ADC_ST1_MXR, 0x6020, 0},	/* mu_stereo1_adcl1 unmute, sel_stereo1_adc1 Sel, mu_stereo1_adcr1 unmute */
+	{ALC5658_ADC_2_MXR, 0x0000, 100},	/* Mu_stereo1_adc_mixer_l/r unmute */
+	{ALC5658_DAC_MO_MXR, 0x2A8A, 0},	/* mu_mono_dacl1_mixl/r unmute */
+	{ALC5658_ADC_MO_MXR, 0x4040, 0},	/* mu_mono_adcl1 UM, sel_mono_adcl1/2 - Mono_DAC_Mixer_L, mu_mono_adcr1 UM, Sel_mono_adcr1/2 - Mono_DAC_Mixer_R, sel_mono_adcr - ADC1_L, Sel_mono_dmic_r - DMIC1_R */
 	{ALC5658_DAC_SRC, 0x000F, 0},	/* DAC1 stereo, DAC2 mono */
-	{ALC5658_TDM_CTRL1, 0x00F0, 0},	/* TDM IN/OUT 32bit LEN Applicable in master mode ??? */
-	{ALC5658_TDM_CTRL2, 0x0000, 0},	/* rx_adc_data_sel - IF_ADC1 / IF_ADC2 / DAC_REF / Null */
+	{ALC5658_TDM1, 0x00F0, 0},	/* TDM IN/OUT 32bit LEN Applicable in master mode */
+	{ALC5658_TDM2, 0x0000, 0},	/* rx_adc_data_sel - IF_ADC1 / IF_ADC2 / DAC_REF / Null */
 };
 
 t_codec_init_script_entry codec_init_inout_script1[] = {
-	{ALC5658_RESET, 0x0000, 0},
+	{ALC5658_SW_RESET, 0x0000, 0},
 	{ALC5658_006E, 0xEF00, 0},
 	{ALC5658_006F, 0xEFFC, 0},
-	{ALC5658_GNRL_CTRL, 0x8001, 0},
-	{ALC5658_ADDA_RST1, 0x3030, 0},
-	{ALC5658_ADDA_RST2, 0x3030, 0},
+	{ALC5658_GENERAL_CONTROL_1, 0x8001, 0},
+	{ALC5658_RESET1, 0x3030, 0},
+	{ALC5658_RESET2, 0x3030, 0},
 };
 
 t_codec_init_script_entry codec_init_pll_8K[] = {
-	{ALC5658_GLBL_PLL1, 0x0302, 0},
-	{ALC5658_GLBL_PLL2, 0x0800, 0},
-	{ALC5658_ADDA_CLK, 0x6110, 0},
+	{ALC5658_PLL1, 0x0302, 0},
+	{ALC5658_PLL2, 0x0800, 0},
+	{ALC5658_ADCDAC_CLOCK, 0x6110, 0},
 };
 
 t_codec_init_script_entry codec_init_pll_11K[] = {
-	{ALC5658_GLBL_PLL1, 0x4883, 0},
-	{ALC5658_GLBL_PLL2, 0xE000, 0},
-	{ALC5658_ADDA_CLK, 0x5110, 0},
+	{ALC5658_PLL1, 0x4883, 0},
+	{ALC5658_PLL2, 0xE000, 0},
+	{ALC5658_ADCDAC_CLOCK, 0x5110, 0},
 };
 
 t_codec_init_script_entry codec_init_pll_16K[] = {
-	{ALC5658_GLBL_PLL1, 0x0302, 0},
-	{ALC5658_GLBL_PLL2, 0x0800, 0},
-	{ALC5658_ADDA_CLK, 0x4110, 0},
+	{ALC5658_PLL1, 0x0302, 0},
+	{ALC5658_PLL2, 0x0800, 0},
+	{ALC5658_ADCDAC_CLOCK, 0x4110, 0},
 };
 
 t_codec_init_script_entry codec_init_pll_22K[] = {
-	{ALC5658_GLBL_PLL1, 0x4883, 0},
-	{ALC5658_GLBL_PLL2, 0xE000, 0},
-	{ALC5658_ADDA_CLK, 0x3110, 0},
+	{ALC5658_PLL1, 0x4883, 0},
+	{ALC5658_PLL2, 0xE000, 0},
+	{ALC5658_ADCDAC_CLOCK, 0x3110, 0},
 };
 
 t_codec_init_script_entry codec_init_pll_32K[] = {
-	{ALC5658_GLBL_PLL1, 0x0302, 0},
-	{ALC5658_GLBL_PLL2, 0x0800, 0},
-	{ALC5658_ADDA_CLK, 0x2110, 0},
+	{ALC5658_PLL1, 0x0302, 0},
+	{ALC5658_PLL2, 0x0800, 0},
+	{ALC5658_ADCDAC_CLOCK, 0x2110, 0},
 };
 
 t_codec_init_script_entry codec_init_pll_44K[] = {
-	{ALC5658_GLBL_PLL1, 0x4883, 0},
-	{ALC5658_GLBL_PLL2, 0xE000, 0},
-	{ALC5658_ADDA_CLK, 0x1110, 0},
+	{ALC5658_PLL1, 0x4883, 0},
+	{ALC5658_PLL2, 0xE000, 0},
+	{ALC5658_ADCDAC_CLOCK, 0x1110, 0},
 };
 
 t_codec_init_script_entry codec_init_pll_48K[] = {
-	{ALC5658_GLBL_PLL1, 0x0302, 0},
-	{ALC5658_GLBL_PLL2, 0x0800, 0},
-	{ALC5658_ADDA_CLK, 0x1110, 0},
+	{ALC5658_PLL1, 0x0302, 0},
+	{ALC5658_PLL2, 0x0800, 0},
+	{ALC5658_ADCDAC_CLOCK, 0x1110, 0},
 };
 
 t_codec_init_script_entry codec_init_inout_script2[] = {
 	{ALC5658_0091, 0x0C16, 0},
-	{ALC5658_PWR_MNG3, 0xA2BE, 20},
-	{ALC5658_PWR_MNG3, 0xF2BE, 0},
-	{ALC5658_PWR_MNG5, 0x0040, 0},
-	{ALC5658_GLBL_CLK, 0x4000, 0},
-	{ALC5658_GLBL_ASRC4, 0x0100, 0},
-	{ALC5658_GLBL_ASRC1, 0x1300, 0},
-	{ALC5658_GLBL_ASRC2, 0x0220, 0},
-	{ALC5658_PWR_MNG1, 0xC080, 0},
-	{ALC5658_HP_AMP, 0x0009, 0},
-	{ALC5658_PWR_MNG1, 0xCC80, 0},
-	{ALC5658_PWR_MNG1, 0xCC98, 0},
+	{ALC5658_MANAGEMENT3, 0xA2BE, 20},
+	{ALC5658_MANAGEMENT3, 0xF2BE, 0},
+	{ALC5658_MANAGEMENT5, 0x0040, 0},
+	{ALC5658_CLOCK, 0x4000, 0},
+	{ALC5658_ASRC4, 0x0100, 0},
+	{ALC5658_ASRC1, 0x1300, 0},
+	{ALC5658_ASRC2, 0x0220, 0},
+	{ALC5658_MANAGEMENT1, 0xC080, 0},
+	{ALC5658_HP, 0x0009, 0},
+	{ALC5658_MANAGEMENT1, 0xCC80, 0},
+	{ALC5658_MANAGEMENT1, 0xCC98, 0},
 	{ALC5658_0091, 0x0E16, 0},
-	{ALC5658_PWR_MNG2, 0xB700, 0},
-	{ALC5658_PWR_MNG4, 0xC860, 0},	//enable mbias1
-	{ALC5658_PWR_MNG6, 0x0C00, 0},
-	{ALC5658_PWR_MNG7, 0x0300, 0},
-	{ALC5658_HPOUT_MUTE, 0x8080, 0},	// MUTE OUTPUT
+	{ALC5658_MANAGEMENT2, 0xB700, 0},
+	{ALC5658_MANAGEMENT4, 0xC860, 0},	//enable mbias1
+	{ALC5658_MANAGEMENT6, 0x0C00, 0},
+	{ALC5658_MANAGEMENT7, 0x0300, 0},
+	{ALC5658_HPOUT, 0x8080, 0},	// MUTE OUTPUT
 	{ALC5658_0091, 0x0E1E, 0},
-	{ALC5658_I2S1_CTRL, 0x0000, 0},
-	{ALC5658_DAC_STR_MXR, 0x2A8A, 0},
+	{ALC5658_I2S1_PORT_CTRL, 0x0000, 0},
+	{ALC5658_DAC_ST_MXR, 0x2A8A, 0},
 	{ALC5658_DAC_SRC, 0x000F, 0},
-	{ALC5658_HP_AMP, 0x0019, 0},
+	{ALC5658_HP, 0x0019, 0},
 	{ALC5658_0010, 0x3040, 0},	//CRT Mbias1 path
-	{ALC5658_IN1_CTRL, 0x0000, 0},	//BST1 gain (minimal)
-	{ALC5658_RECMIX1L_CTRL_2, 0x005F, 0},	//BST1
-	{ALC5658_RECMIX1R_CTRL_2, 0x005F, 0},	//BST1
-	{ALC5658_ADC_STR1_MXR, 0x6020, 0},
-	{ALC5658_ADC_2_DAC_MXR, 0x8080, 100},
-	{ALC5658_DAC_MONO_MXR, 0x2A8A, 0},
-	{ALC5658_ADC_MONO_MXR, 0x4040, 0},
+	{ALC5658_IN1, 0x0000, 0},	//BST1 gain (minimal)
+	{ALC5658_RECMIX1L_SEL, 0x005F, 0},	//BST1
+	{ALC5658_RECMIX1R_SEL, 0x005F, 0},	//BST1
+	{ALC5658_ADC_ST1_MXR, 0x6020, 0},
+	{ALC5658_ADC_2_MXR, 0x8080, 100},
+	{ALC5658_DAC_MO_MXR, 0x2A8A, 0},
+	{ALC5658_ADC_MO_MXR, 0x4040, 0},
 	{ALC5658_DAC_SRC, 0x000F, 0},
-	{ALC5658_TDM_CTRL1, 0x00F0, 0},
-	{ALC5658_TDM_CTRL2, 0x0000, 0},
-
-};
-
-t_codec_dump_entry codec_dump_script[] = {
-	{ALC5658_RESET, "ALC5658_RESET"},
-	{ALC5658_SPO_VOL, "ALC5658_SPO_VOL"},
-	{ALC5658_HPOUT_MUTE, "ALC5658_HPOUT_MUTE"},
-	{ALC5658_LOUT_CTRL1, "ALC5658_LOUT_CTRL1"},
-	{ALC5658_LOUT_CTRL2, "ALC5658_LOUT_CTRL2"},
-	{ALC5658_HPOUT_VLML, "ALC5658_HPOUT_VLML"},
-	{ALC5658_HPOUT_VLMR, "ALC5658_HPOUT_VLMR"},
-	{ALC5658_SPDIF_CTRL1, "ALC5658_SPDIF_CTRL1"},
-	{ALC5658_SPDIF_CTRL2, "ALC5658_SPDIF_CTRL2"},
-	{ALC5658_SPDIF_CTRL3, "ALC5658_SPDIF_CTRL3"},
-	{ALC5658_IN1_CTRL, "ALC5658_IN1_CTRL"},
-	{ALC5658_INL_VLM, "ALC5658_INL_VLM"},
-	{ALC5658_SIDETONE, "ALC5658_SIDETONE"},
-	{ALC5658_DAC_L1R1_VLM, "ALC5658_DAC_L1R1_VLM"},
-	{ALC5658_DAC_L2R2_VLM, "ALC5658_DAC_L2R2_VLM"},
-	{ALC5658_DAC_L2R2_MUTE, "ALC5658_DAC_L2R2_MUTE"},
-	{ALC5658_ADC_STR1_MXR, "ALC5658_ADC_STR1_MXR"},
-	{ALC5658_ADC_MONO_MXR, "ALC5658_ADC_MONO_MXR"},
-	{ALC5658_ADC_2_DAC_MXR, "ALC5658_ADC_2_DAC_MXR"},
-	{ALC5658_DAC_STR_MXR, "ALC5658_DAC_STR_MXR"},
-	{ALC5658_DAC_MONO_MXR, "ALC5658_DAC_MONO_MXR"},
-	{ALC5658_DAC_LB_SDTONE, "ALC5658_DAC_LB_SDTONE"},
-	{ALC5658_COPY_MODE, "ALC5658_COPY_MODE"},
-	{ALC5658_DAC_SRC, "ALC5658_DAC_SRC"},
-	{ALC5658_RECMIX1L_CTRL_1, "ALC5658_RECMIX1L_CTRL_1"},
-	{ALC5658_RECMIX1L_CTRL_2, "ALC5658_RECMIX1L_CTRL_2"},
-	{ALC5658_RECMIX1R_CTRL_1, "ALC5658_RECMIX1R_CTRL_1"},
-	{ALC5658_RECMIX1R_CTRL_2, "ALC5658_RECMIX1R_CTRL_2"},
-	{ALC5658_SPKMIXL, "ALC5658_SPKMIXL"},
-	{ALC5658_SPKMIXR, "ALC5658_SPKMIXR"},
-	{ALC5658_SPOMIX, "ALC5658_SPOMIX"},
-	{ALC5658_OUTMIXL1, "ALC5658_OUTMIXL1"},
-	{ALC5658_OUTMIXL2, "ALC5658_OUTMIXL2"},
-	{ALC5658_OUTMIXR1, "ALC5658_OUTMIXR1"},
-	{ALC5658_OUTMIXR2, "ALC5658_OUTMIXR2"},
-	{ALC5658_LOUTMIX, "ALC5658_LOUTMIX"},
-	{ALC5658_PWR_MNG1, "ALC5658_PWR_MNG1"},
-	{ALC5658_PWR_MNG2, "ALC5658_PWR_MNG2"},
-	{ALC5658_PWR_MNG3, "ALC5658_PWR_MNG3"},
-	{ALC5658_PWR_MNG4, "ALC5658_PWR_MNG4"},
-	{ALC5658_PWR_MNG5, "ALC5658_PWR_MNG5"},
-	{ALC5658_PWR_MNG6, "ALC5658_PWR_MNG6"},
-	{ALC5658_PWR_MNG7, "ALC5658_PWR_MNG7"},
-	{ALC5658_IF_DTCT, "ALC5658_IF_DTCT"},
-	{ALC5658_006E, "ALC5658_006E"},
-	{ALC5658_006F, "ALC5658_006F"},
-	{ALC5658_I2S1_CTRL, "ALC5658_I2S1_CTRL"},
-	{ALC5658_I2S2_CTRL, "ALC5658_I2S2_CTRL"},
-	{ALC5658_ADDA_CLK, "ALC5658_ADDA_CLK"},
-	{ALC5658_ADDA_HPF, "ALC5658_ADDA_HPF"},
-	{ALC5658_007B, "ALC5658_007B"},
-	{ALC5658_TDM_CTRL1, "ALC5658_TDM_CTRL1"},
-	{ALC5658_TDM_CTRL2, "ALC5658_TDM_CTRL2"},
-	{ALC5658_TDM_CTRL3, "ALC5658_TDM_CTRL3"},
-	{ALC5658_TDM_CTRL4, "ALC5658_TDM_CTRL4"},
-	{ALC5658_GLBL_CLK, "ALC5658_GLBL_CLK"},
-	{ALC5658_GLBL_PLL1, "ALC5658_GLBL_PLL1"},
-	{ALC5658_GLBL_PLL2, "ALC5658_GLBL_PLL2"},
-	{ALC5658_GLBL_ASRC1, "ALC5658_GLBL_ASRC1"},
-	{ALC5658_GLBL_ASRC2, "ALC5658_GLBL_ASRC2"},
-	{ALC5658_GLBL_ASRC3, "ALC5658_GLBL_ASRC3"},
-	{ALC5658_GLBL_ASRC4, "ALC5658_GLBL_ASRC4"},
-	{ALC5658_HP_AMP, "ALC5658_HP_AMP"},
-	{ALC5658_SPK_AMP, "ALC5658_SPK_AMP"},
-	{ALC5658_0091, "ALC5658_0091"},
-	{ALC5658_INTCLK_CTRL, "ALC5658_INTCLK_CTRL"},
-	{ALC5658_GNRL_CTRL, "ALC5658_GNRL_CTRL"},
-	{ALC5658_GNRL_CTRL2, "ALC5658_GNRL_CTRL2"},
-	{ALC5658_0111, "ALC5658_0111"},
-	{ALC5658_0125, "ALC5658_0125"},
-	{ALC5658_ADDA_RST1, "ALC5658_ADDA_RST1"},
-	{ALC5658_ADDA_RST2, "ALC5658_ADDA_RST2"},
-	{ALC5658_0x013C, "ALC5658_0x013C"},
-	{ALC5658_NOISE_G_M1_CTRL1, "ALC5658_NOISE_G_M1_CTRL1"},
-	{ALC5658_NOISE_G_M2_CTRL, "ALC5658_NOISE_G_M2_CTRL"},
-	{ALC5658_0x01DE, "ALC5658_0x01DE"},
-	{ALC5658_0x01DF, "ALC5658_0x01DF"},
-	{ALC5658_0x01E4, "ALC5658_0x01E4"},
-	{ALC5658_0040, "ALC5658_0040"},
-	{ALC5658_0010, "ALC5658_0010"},
+	{ALC5658_TDM1, 0x00F0, 0},
+	{ALC5658_TDM2, 0x0000, 0},
 };
 
 #endif							/* CONFIG_AUDIO_ALC5658 */


### PR DESCRIPTION
This is a patch that adds the information in the ALC5658 codec register.
And I reset the naming with the keywords presented in the datasheet.
Similar to other driver register settings, I changed from 'enum' to
'define'.

Signed-off-by: Junhwan Park <junhwan.park@samsung.com>