### PR TITLE
(net) lwip/src/core/netif.c: fix 'tcpip_input' undeclared error

### DIFF
--- a/os/net/lwip/src/core/netif.c
+++ b/os/net/lwip/src/core/netif.c
@@ -54,7 +54,7 @@
  */
 
 #include <net/lwip/opt.h>
-
+#include <net/lwip/tcpip.h>
 #include <net/lwip/def.h>
 #include <net/lwip/ipv4/ip_addr.h>
 #include <net/lwip/netif.h>


### PR DESCRIPTION
fix build break in lwip/src/core/netif.c

error : In  In function 'netif_register_with_initial_ip':  'tcpip_input' undeclared
fix:  include header - #include <net/lwip/tcpip.h>