### PR TITLE
New feature to detect the soft lockup in the system

### DIFF
--- a/apps/examples/softlockup_test/Kconfig
+++ b/apps/examples/softlockup_test/Kconfig
@@ -1,0 +1,13 @@
+#
+# For a description of the syntax of this configuration file,
+# see kconfig-language at https://www.kernel.org/doc/Documentation/kbuild/kconfig-language.txt
+#
+
+config EXAMPLES_SOFTLOCKUP_TEST
+	bool "Soft lockup Test example"
+	default n
+	depends on !DISABLE_PTHREAD
+	depends on !DISABLE_SIGNALS
+	select SOFT_LOCKUP_DETECT
+	---help---
+		Enable testcases to validate soft lockup detect feature.

--- a/apps/examples/softlockup_test/Make.defs
+++ b/apps/examples/softlockup_test/Make.defs
@@ -1,0 +1,21 @@
+###########################################################################
+#
+# Copyright 2017 Samsung Electronics All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+#
+###########################################################################
+
+ifeq ($(CONFIG_EXAMPLES_SOFTLOCKUP_TEST),y)
+CONFIGURED_APPS += examples/softlockup_test
+endif

--- a/apps/examples/softlockup_test/Makefile
+++ b/apps/examples/softlockup_test/Makefile
@@ -1,0 +1,124 @@
+###########################################################################
+#
+# Copyright 2017 Samsung Electronics All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+#
+###########################################################################
+
+-include $(TOPDIR)/.config
+-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
+
+# Lockup test
+
+APPNAME = softlockup_test
+THREADEXEC = TASH_EXECMD_ASYNC
+PRIORITY = SCHED_PRIORITY_DEFAULT
+STACKSIZE = 1024
+
+ASRCS =
+CSRCS =
+MAINSRC = softlockup_test.c
+
+AOBJS = $(ASRCS:.S=$(OBJEXT))
+COBJS = $(CSRCS:.c=$(OBJEXT))
+MAINOBJ = $(MAINSRC:.c=$(OBJEXT))
+
+SRCS = $(ASRCS) $(CSRCS) $(MAINSRC)
+OBJS = $(AOBJS) $(COBJS)
+
+ifneq ($(CONFIG_BUILD_KERNEL),y)
+  OBJS += $(MAINOBJ)
+endif
+
+ifeq ($(CONFIG_WINDOWS_NATIVE),y)
+  BIN = ..\..\libapps$(LIBEXT)
+else
+ifeq ($(WINTOOL),y)
+  BIN = ..\\..\\libapps$(LIBEXT)
+else
+  BIN = ../../libapps$(LIBEXT)
+endif
+endif
+
+ifeq ($(WINTOOL),y)
+  INSTALL_DIR = "${shell cygpath -w $(BIN_DIR)}"
+else
+  INSTALL_DIR = $(BIN_DIR)
+endif
+
+ROOTDEPPATH = --dep-path .
+
+# Common build
+
+VPATH =
+
+all: .built
+.PHONY: context depend clean distclean
+
+$(AOBJS): %$(OBJEXT): %.S
+	$(call ASSEMBLE, $<, $@)
+
+$(COBJS) $(MAINOBJ): %$(OBJEXT): %.c
+	$(call COMPILE, $<, $@)
+
+.built: $(OBJS)
+	$(call ARCHIVE, $(BIN), $(OBJS))
+	$(Q) touch .built
+
+ifeq ($(CONFIG_BUILD_KERNEL),y)
+$(BIN_DIR)$(DELIM)$(PROGNAME): $(OBJS) $(MAINOBJ)
+	@echo "LD: $(PROGNAME)"
+	$(Q) $(LD) $(LDELFFLAGS) $(LDLIBPATH) -o $(INSTALL_DIR)$(DELIM)$(PROGNAME) $(ARCHCRT0OBJ) $(MAINOBJ) $(LDLIBS)
+	$(Q) $(NM) -u  $(INSTALL_DIR)$(DELIM)$(PROGNAME)
+
+install: $(BIN_DIR)$(DELIM)$(PROGNAME)
+
+else
+install:
+
+endif
+
+# Register application
+
+ifeq ($(CONFIG_BUILTIN_APPS)$(CONFIG_EXAMPLES_SOFTLOCKUP_TEST),yy)
+$(BUILTIN_REGISTRY)$(DELIM)$(APPNAME)_main.bdat: $(DEPCONFIG) Makefile
+	$(call REGISTER,$(APPNAME),$(APPNAME)_main,$(THREADEXEC),$(PRIORITY),$(STACKSIZE))
+
+context: $(BUILTIN_REGISTRY)$(DELIM)$(APPNAME)_main.bdat
+
+else
+context:
+
+endif
+
+# Create dependencies
+
+.depend: Makefile $(SRCS)
+	$(Q) $(MKDEP) $(ROOTDEPPATH) "$(CC)" -- $(CFLAGS) -- $(SRCS) >Make.dep
+	$(Q) touch $@
+
+depend: .depend
+
+clean:
+	$(call DELFILE, .built)
+	$(call CLEAN)
+
+distclean: clean
+	$(call DELFILE, Make.dep)
+	$(call DELFILE, .depend)
+
+-include Make.dep
+.PHONY: preconfig
+preconfig:

--- a/apps/examples/softlockup_test/softlockup_test.c
+++ b/apps/examples/softlockup_test/softlockup_test.c
@@ -1,0 +1,191 @@
+/****************************************************************************
+ *
+ * Copyright 2017 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <stdio.h>
+#include <unistd.h>
+#include <tinyara/config.h>
+#include <pthread.h>
+#include <tinyara/wqueue.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define HOG_PTHREAD_PRIORITY     200
+#define NON_HOG_PTHREAD_PRIORITY HOG_PTHREAD_PRIORITY + 1
+
+/****************************************************************************
+ * Private Types
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+/****************************************************************************
+ * Name: hogging_function
+ *
+ * Description:
+ *   This functions starts the infinte loop to simulate the hogging scenario.
+ *
+ * Input parameters:
+ *   void
+ *
+ * Returned Value:
+ *   void
+ *
+ ****************************************************************************/
+
+static void *hogging_function(void *parameter)
+{
+	pthread_t tid = getpid();
+	pthread_setname_np(tid, "hog_thread");
+	for (;;) {
+		/* Do Nothing and Hog */
+	}
+	return NULL;
+}
+
+/****************************************************************************
+ * Name: thread_function
+ *
+ * Description:
+ *   This function terminates after a finite period say 15 seconds.
+ *
+ * Input parameters:
+ *   void
+ *
+ * Returned Value:
+ *   void
+ *
+ ****************************************************************************/
+
+static void *non_hogging_function(void *parameter)
+{
+	int i;
+	for (i = 0; i < 15; i++) {
+		/* Sleep for 1 sec */
+		sleep(1);
+	}
+	return NULL;
+}
+
+/****************************************************************************
+ * Name: test_low_prio_hog_thread
+ *
+ * Description:
+ *   This function creates two pthreads. One pthread is of high priority and
+ *   terminates after a finite period and second pthread runs in an infinite
+ *   loop.
+ *
+ * Input parameters:
+ *   void
+ *
+ * Returned Value:
+ *   void
+ *
+ ****************************************************************************/
+
+void test_low_prio_hog_thread(void)
+{
+	pthread_t thread1;
+	pthread_t thread2;
+	pthread_attr_t attr1;
+	pthread_attr_t attr2;
+	struct sched_param sparam;
+
+	(void)pthread_attr_init(&attr1);
+	sparam.sched_priority = NON_HOG_PTHREAD_PRIORITY;
+	(void)pthread_attr_setschedparam(&attr1, & sparam);
+	(void)pthread_create(&thread1, &attr1, non_hogging_function, NULL);
+
+	(void)pthread_attr_init(&attr2);
+	sparam.sched_priority = HOG_PTHREAD_PRIORITY;
+	(void)pthread_attr_setschedparam(&attr2, & sparam);
+	(void)pthread_create(&thread2, &attr2, hogging_function, NULL);
+
+	/* Detach the threads */
+	pthread_detach(thread1);
+	pthread_detach(thread2);
+}
+
+/****************************************************************************
+ * Name: test_normal_prio_hog_thread
+ *
+ * Description:
+ *   This function creates a single pthread which is runing in an infinite
+ *   loop.
+ *
+ * Input parameters:
+ *   void
+ *
+ * Returned Value:
+ *   void
+ *
+ ****************************************************************************/
+
+void test_normal_prio_hog_thread(void)
+{
+	pthread_t thread1;
+	pthread_attr_t attr;
+	struct sched_param sparam;
+
+	(void)pthread_attr_init(&attr);
+	sparam.sched_priority = HOG_PTHREAD_PRIORITY;
+	(void)pthread_attr_setschedparam(&attr, & sparam);
+	(void)pthread_create(&thread1, &attr, hogging_function, NULL);
+	pthread_detach(thread1);
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+#ifdef CONFIG_BUILD_KERNEL
+int main(int argc, FAR char *argv[])
+#else
+int softlockup_test_main(int argc, char **argv)
+#endif
+{
+	char ch;
+	printf("\nPress A - For Normal Priority Hogging Thread Testcase\n");
+	printf("Press B - For Low Priority Hogging Thread Testcase\n");
+
+	ch = getchar();
+	printf("%c", ch);
+	if (ch == 'A' || ch == 'a') {
+		printf("\nStarting normal priority hogging thread testcase\n");
+		sleep(1);
+		test_normal_prio_hog_thread();
+	} else if (ch == 'B' || ch == 'b') {
+		printf("\nStarting low priority hogging thread testcase along with high priority non hogging thread\n");
+		sleep(1);
+		test_low_prio_hog_thread();
+	} else {
+		printf("\nInvalid Option, Exiting!!\n");
+	}
+
+	return 0;
+}

--- a/os/arch/arm/src/armv7-m/up_blocktask.c
+++ b/os/arch/arm/src/armv7-m/up_blocktask.c
@@ -161,6 +161,9 @@ void up_block_task(struct tcb_s *tcb, tstate_t task_state)
 			 * ready to run list.
 			 */
 
+#ifdef CONFIG_SOFT_LOCKUP_DETECT
+			context_switch_counter++;
+#endif
 			struct tcb_s *nexttcb = this_task();
 			up_switchcontext(rtcb->xcp.regs, nexttcb->xcp.regs);
 

--- a/os/arch/arm/src/armv7-m/up_releasepending.c
+++ b/os/arch/arm/src/armv7-m/up_releasepending.c
@@ -129,6 +129,9 @@ void up_release_pending(void)
 			/* Switch context to the context of the task at the head of the
 			 * ready to run list.
 			 */
+#ifdef CONFIG_SOFT_LOCKUP_DETECT
+			context_switch_counter++;
+#endif
 
 			struct tcb_s *nexttcb = this_task();
 			up_switchcontext(rtcb->xcp.regs, nexttcb->xcp.regs);

--- a/os/arch/arm/src/armv7-m/up_reprioritizertr.c
+++ b/os/arch/arm/src/armv7-m/up_reprioritizertr.c
@@ -181,6 +181,9 @@ void up_reprioritize_rtr(struct tcb_s *tcb, uint8_t priority)
 				/* Switch context to the context of the task at the head of the
 				 * ready to run list.
 				 */
+#ifdef CONFIG_SOFT_LOCKUP_DETECT
+				context_switch_counter++;
+#endif
 
 				struct tcb_s *nexttcb = this_task();
 				up_switchcontext(rtcb->xcp.regs, nexttcb->xcp.regs);

--- a/os/arch/arm/src/armv7-m/up_unblocktask.c
+++ b/os/arch/arm/src/armv7-m/up_unblocktask.c
@@ -151,6 +151,9 @@ void up_unblock_task(struct tcb_s *tcb)
 			/* Switch context to the context of the task at the head of the
 			 * ready to run list.
 			 */
+#ifdef CONFIG_SOFT_LOCKUP_DETECT
+			context_switch_counter++;
+#endif
 
 			struct tcb_s *nexttcb = this_task();
 			up_switchcontext(rtcb->xcp.regs, nexttcb->xcp.regs);

--- a/os/arch/arm/src/armv7-r/arm_blocktask.c
+++ b/os/arch/arm/src/armv7-r/arm_blocktask.c
@@ -161,7 +161,9 @@ void up_block_task(struct tcb_s *tcb, tstate_t task_state)
 			/* Restore the exception context of the rtcb at the (new) head
 			 * of the g_readytorun task list.
 			 */
-
+#ifdef CONFIG_SOFT_LOCKUP_DETECT
+			context_switch_counter++;
+#endif
 			rtcb = this_task();
 
 #ifdef CONFIG_TASK_SCHED_HISTORY

--- a/os/arch/arm/src/armv7-r/arm_releasepending.c
+++ b/os/arch/arm/src/armv7-r/arm_releasepending.c
@@ -133,7 +133,9 @@ void up_release_pending(void)
 			/* Restore the exception context of the rtcb at the (new) head
 			 * of the g_readytorun task list.
 			 */
-
+#ifdef CONFIG_SOFT_LOCKUP_DETECT
+			context_switch_counter++;
+#endif
 			rtcb = this_task();
 
 #ifdef CONFIG_TASK_SCHED_HISTORY

--- a/os/arch/arm/src/armv7-r/arm_reprioritizertr.c
+++ b/os/arch/arm/src/armv7-r/arm_reprioritizertr.c
@@ -180,7 +180,9 @@ void up_reprioritize_rtr(struct tcb_s *tcb, uint8_t priority)
 				/* Restore the exception context of the rtcb at the (new) head
 				 * of the g_readytorun task list.
 				 */
-
+#ifdef CONFIG_SOFT_LOCKUP_DETECT
+				context_switch_counter++;
+#endif
 				rtcb = this_task();
 
 				/* Then switch contexts */

--- a/os/arch/arm/src/armv7-r/arm_unblocktask.c
+++ b/os/arch/arm/src/armv7-r/arm_unblocktask.c
@@ -164,7 +164,9 @@ void up_unblock_task(struct tcb_s *tcb)
 			 * run (probably tcb).  This is the new rtcb at the head of the
 			 * g_readytorun task list.
 			 */
-
+#ifdef CONFIG_SOFT_LOCKUP_DETECT
+			context_switch_counter++;
+#endif
 			rtcb = this_task();
 			trace_sched(NULL, rtcb);
 

--- a/os/include/tinyara/sched.h
+++ b/os/include/tinyara/sched.h
@@ -666,6 +666,9 @@ typedef void (*sched_foreach_t)(FAR struct tcb_s *tcb, FAR void *arg);
 /********************************************************************************
  * Public Data
  ********************************************************************************/
+#ifdef CONFIG_SOFT_LOCKUP_DETECT
+extern int context_switch_counter;
+#endif
 
 #ifndef __ASSEMBLY__
 #undef EXTERN

--- a/os/kernel/Kconfig
+++ b/os/kernel/Kconfig
@@ -1041,3 +1041,25 @@ config PTHREAD_STACK_DEFAULT
 		Default pthread stack size
 endmenu # Stack size information
 
+menu "Lockup detector"
+
+config SOFT_LOCKUP_DETECT
+	bool "Monitor the system for soft lockup"
+	default n
+	depends on !DISABLE_SIGNALS
+	---help---
+		This monitors the system in regular intervals and detects the task/thread
+		which causes system lockup
+
+if SOFT_LOCKUP_DETECT
+
+config SOFT_LOCK_MONITOR_PERIOD
+	int "Interval for soft lock up monitor"
+	default 10
+	---help---
+		This is the interval at which soft lockup monitor thread checks for hogging threads in
+		the system. By default it's set as 10 sec
+
+endif
+
+endmenu # Lockup detector


### PR DESCRIPTION
This feature detects if any thread or worker function hogging the cpu
and prints the pid and name of the hogging thread

Please find the detailed steps below to achieve the same

1) Creates a high priority[255] dedicated workqueue (work_softlockup_monitor_hpthread)
2) Job of the dedicated workqueue is to wakeup at regular interval and process any
   pending worker functions at an interval of [CONFIG_SLMWORKPERIOD/USEC_PER_TICK]
3) In os_bringup.c, A softlockup monitor worker function is queued to above workqueue
   with a time interval delay of 10 sec [CONFIG_SOFT_LOCK_MONITOR_PERIOD]
4) Job of softlockup_monitor_work is to find out any lockup happened in the system
   by having below checks
	a) It will check the number of context switch operations occured since
           it was called the last time
	b) Whether is there any other thread running except idle thread
5) context_switch_counter will be incremented for every context switch between tasks
6) Above conunter is not incremented for context switch between tasks and interrupts
7) Above counter will be reset back to 0 inside softlockup_monitor_work at step 4, if
   there is no lockup detected. Also it will re-queue the worker function
8) If there is a lockup detected at step 4, it will print the hogging thread name, pid
   and calls PANIC

Assumptions:

1) Time interval of 10 sec is set for softlocup_monitor work by assuming single thread
   may not run continuously for 10 sec without any context switching !!

Limitations:

1) This feature is dependent on SCHED_WORKQUEUE and !DISABLE_SIGNALS
2) If any other task with highest priority [255] hogs the cpu, it can't be detected
3) If a low priority thread is hogging the cpu and high priority thread is working fine, then
   we can find out the hogging low priority thread, only after high priority thread ends

Signed-off-by: pradeep.ns <pradeep.ns@samsung.com>
Signed-off-by: Shashwat KN <shashwat.2017@partner.samsung.com>