### PR TITLE
Set default partition info in partition_gen.sh

### DIFF
--- a/build/configs/artik053/tools/openocd/partition_gen.sh
+++ b/build/configs/artik053/tools/openocd/partition_gen.sh
@@ -31,13 +31,16 @@ OS_DIR_PATH=${PWD}
 BUILD_DIR_PATH=${OS_DIR_PATH}/../build
 BOARD_DIR_PATH=${BUILD_DIR_PATH}/configs/${BOARD_NAME}
 OPENOCD_DIR_PATH=${BOARD_DIR_PATH}/tools/openocd
+BOARD_KCONFIG=${OS_DIR_PATH}/arch/arm/src/${BOARD_NAME}/Kconfig
 
 # FLASH BASE ADDRESS (Can it be made to read dynamically from .config?)
 FLASH_BASE=0x04000000
 
 # Partition information
-partsize_list=${CONFIG_ARTIK053_FLASH_PART_LIST}
-partname_list=${CONFIG_ARTIK053_FLASH_PART_NAME}
+partsize_list_default=`grep -A 2 'config ARTIK053_FLASH_PART_LIST' ${BOARD_KCONFIG} | sed -n 's/\tdefault "\(.*\)".*/\1/p'`
+partsize_list=${CONFIG_ARTIK053_FLASH_PART_LIST:=${partsize_list_default}}
+partname_list_default=`grep -A 2 'config ARTIK053_FLASH_PART_NAME' ${BOARD_KCONFIG} | sed -n 's/\tdefault "\(.*\)".*/\1/p'`
+partname_list=${CONFIG_ARTIK053_FLASH_PART_NAME:=${partname_list_default}}
 
 # OpenOCD cfg file to be created for flashing
 PARTITION_MAP_CFG=${OPENOCD_DIR_PATH}/partition_map.cfg


### PR DESCRIPTION
If CONFIG_ARTIK053_FLASH_PART_LIST or CONFIG_ARTIK053_FLASH_PART_NAME are unset, they will be set as default value