### PR TITLE
Add retry for dhcpc sendDiscover

### DIFF
--- a/external/dhcpc/dhcpc.c
+++ b/external/dhcpc/dhcpc.c
@@ -501,6 +501,9 @@ int dhcpc_request(void *handle, struct dhcpc_state *presult)
 		result = dhcpc_sendmsg(pdhcpc, g_pResult, DHCPDISCOVER);
 		usleep(100000);
 		if (result < 0) {
+			if (get_errno() == EAGAIN) {
+				continue;
+			}
 			ndbg("sendDiscover Error\n");
 			return -1;
 		}


### PR DESCRIPTION
dhcp client returns -1 when it fails to send Discover packet once. If the errno is EAGAIN, we should allow it to retry.