### PR TITLE
Fix conversion warnings in `os/arch/arm/include/armv7-r/irq.h`

### DIFF
--- a/os/arch/arm/include/armv7-r/irq.h
+++ b/os/arch/arm/include/armv7-r/irq.h
@@ -377,7 +377,7 @@ struct xcptcontext {
 
 static inline irqstate_t irqstate(void)
 {
-	unsigned int cpsr;
+	irqstate_t cpsr;
 
 	__asm__ __volatile__
 	(
@@ -394,7 +394,7 @@ static inline irqstate_t irqstate(void)
 
 static inline irqstate_t irqsave(void)
 {
-	unsigned int cpsr;
+	irqstate_t cpsr;
 
 	__asm__ __volatile__
 	(
@@ -415,7 +415,7 @@ static inline irqstate_t irqsave(void)
 
 static inline irqstate_t irqenable(void)
 {
-	unsigned int cpsr;
+	irqstate_t cpsr;
 
 	__asm__ __volatile__
 	(


### PR DESCRIPTION
I would like to build `IoT.js` on `artik053` with enabled `jerry-debugger`. The `CMakeLists.txt` of `JerryScript` (a dependency of IoT.js)  sets the conversion compile warning as an error with `-Werror=conversion` flag. This PR resolves the following issue:
`error: conversion to 'irqstate_t' from 'unsigned int' may alter its value [-Werror=conversion]`