### PR TITLE
docs: add a new documentation for how to install kconfig frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,7 @@ Please find project details like APIs reference at [docs](docs/) folder. Wiki wi
 
 > [Quick Start](#quick-start)  
 > [Supported Board](#supported-board)  
-> [Configuration Sets](#configuration-sets)  
-> [APPENDIX](#appendix)
+> [Configuration Sets](#configuration-sets)
 
 ## Quick Start
 ### Getting the toolchain
@@ -47,7 +46,7 @@ cd ..
 make menuconfig
 ```
 
-Refer kconfig-frontend installation to use *menuconfig* at [APPENDIX](README.md#kconfig-frontends-installation)
+Refer [kconfig-frontend installation](docs/HowtoInstallKconfigFrontend.md) to use *menuconfig*.
 
 Finally, initiate build by make from *$TIZENRT_BASEDIR/os*.
 ```bash
@@ -71,31 +70,4 @@ To customize your application with specific configuration settings, using the me
 ```bash
 make menuconfig
 ```
-Please keep in mind that we are actively working on board configurations, and will be posting our updates on the README files under each config
-
-## APPENDIX
-### Kconfig-frontends Installation
-
-1. The *bison* (or byacc if supported), *flex*, *gperf*, *libncurses5-dev*, *zlib1g-dev*, *gettext* and *g++* packages should be installed:
-```bash
-sudo apt-get install bison flex gperf libncurses5-dev zlib1g-dev gettext g++
-```
-
-2. Download and untar *kconfig-frontends* package.  
- One of site is [Yann Morin's Project](http://ymorin.is-a-geek.org/projects/kconfig-frontends)
-```bash
-tar -xvf kconfig-frontends-x.xx.x.x.tar.bz2
-```
-
-3. Go to *kconfig-frontends* folder
-```bash
-cd kconfig-frontends-x.xx.x.x
-```
-
-4. Configure and Build
-```bash
-./configure --enable-mconf --disable-gconf --disable-qconf
-make
-sudo make install
-```
-
+Please keep in mind that we are actively working on board configurations, and will be posting our updates on the README files under each config.

--- a/docs/HowtoInstallKconfigFrontend.md
+++ b/docs/HowtoInstallKconfigFrontend.md
@@ -1,0 +1,26 @@
+# Kconfig-frontends Installation
+
+## Prerequisites
+The *bison* (or byacc if supported), *flex*, *gperf*, *libncurses5-dev*, *zlib1g-dev*, *gettext* and *g++* packages should be installed:
+```bash
+sudo apt-get install bison flex gperf libncurses5-dev zlib1g-dev gettext g++
+```
+
+## Kconfig-frontend
+1. Download and untar *kconfig-frontends* package.  
+One of site is [Yann Morin's Project](http://ymorin.is-a-geek.org/projects/kconfig-frontends).
+```bash
+tar -xvf kconfig-frontends-x.xx.x.x.tar.bz2
+```
+
+2. Go to *kconfig-frontends* folder.
+```bash
+cd kconfig-frontends-x.xx.x.x
+```
+
+3. Configure and Build.
+```bash
+./configure --enable-mconf --disable-gconf --disable-qconf
+make
+sudo make install
+```


### PR DESCRIPTION
That is not a mandatory always. Someone who is not a developer will not
use menuconfig.