### PR TITLE
fs/smartfs: add missing dependency on support for multiple root dir/mount points to mksmartfs

### DIFF
--- a/os/arch/arm/src/artik053/src/artik053_tash.c
+++ b/os/arch/arm/src/artik053/src/artik053_tash.c
@@ -284,7 +284,11 @@ int board_app_initialize(void)
 
 #ifdef CONFIG_ARTIK053_AUTOMOUNT_USERFS
 	/* Initialize and mount user partition (if we have) */
+#ifdef CONFIG_SMARTFS_MULTI_ROOT_DIRS
+	ret = mksmartfs(CONFIG_ARTIK053_AUTOMOUNT_USERFS_DEVNAME, 1, false);
+#else
 	ret = mksmartfs(CONFIG_ARTIK053_AUTOMOUNT_USERFS_DEVNAME, false);
+#endif
 	if (ret != OK) {
 		lldbg("ERROR: mksmartfs on %s failed\n", CONFIG_ARTIK053_AUTOMOUNT_USERFS_DEVNAME);
 	} else {
@@ -315,13 +319,20 @@ int board_app_initialize(void)
 			lldbg("ERROR: FAILED TO smart_initialize\n");
 			free(rambuf);
 		} else {
-			(void)mksmartfs(CONFIG_ARTIK053_RAMMTD_DEV_POINT, false);
-
-			ret = mount(CONFIG_ARTIK053_RAMMTD_DEV_POINT, CONFIG_ARTIK053_RAMMTD_MOUNT_POINT,
-						"smartfs", 0, NULL);
-			if (ret < 0) {
-				lldbg("ERROR: Failed to mount the SMART volume: %d\n", errno);
+#ifdef CONFIG_SMARTFS_MULTI_ROOT_DIRS
+			ret = mksmartfs(CONFIG_ARTIK053_RAMMTD_DEV_POINT, 1, false);
+#else
+			ret = mksmartfs(CONFIG_ARTIK053_RAMMTD_DEV_POINT, false);
+#endif
+			if (ret != OK) {
+				lldbg("ERROR: mksmartfs on %s failed\n", CONFIG_ARTIK053_RAMMTD_DEV_POINT);
 				free(rambuf);
+			} else {
+				ret = mount(CONFIG_ARTIK053_RAMMTD_DEV_POINT, CONFIG_ARTIK053_RAMMTD_MOUNT_POINT, "smartfs", 0, NULL);
+				if (ret < 0) {
+					lldbg("ERROR: Failed to mount the SMART volume: %d\n", errno);
+					free(rambuf);
+				}
 			}
 		}
 	}

--- a/os/arch/arm/src/sidk_s5jt200/src/s5jt200_tash.c
+++ b/os/arch/arm/src/sidk_s5jt200/src/s5jt200_tash.c
@@ -311,7 +311,11 @@ int board_app_initialize(void)
 
 #ifdef CONFIG_SIDK_S5JT200_AUTOMOUNT_USERFS
 	/* Initialize and mount user partition (if we have) */
+#ifdef CONFIG_SMARTFS_MULTI_ROOT_DIRS
+	ret = mksmartfs(CONFIG_SIDK_S5JT200_AUTOMOUNT_USERFS_DEVNAME, 1, false);
+#else
 	ret = mksmartfs(CONFIG_SIDK_S5JT200_AUTOMOUNT_USERFS_DEVNAME, false);
+#endif
 	if (ret != OK) {
 		lldbg("ERROR: mksmartfs on %s failed",
 				CONFIG_SIDK_S5JT200_AUTOMOUNT_USERFS_DEVNAME);
@@ -327,7 +331,11 @@ int board_app_initialize(void)
 
 #ifdef CONFIG_SIDK_S5JT200_AUTOMOUNT_SSSRW
 	/* Initialize and mount sssrw partition (if we have) */
+#ifdef CONFIG_SMARTFS_MULTI_ROOT_DIRS
+	ret = mksmartfs(CONFIG_SIDK_S5JT200_AUTOMOUNT_SSSRW_DEVNAME, 1, false);
+#else
 	ret = mksmartfs(CONFIG_SIDK_S5JT200_AUTOMOUNT_SSSRW_DEVNAME, false);
+#endif
 	if (ret != OK) {
 		lldbg("ERROR: mksmartfs on %s failed",
 				CONFIG_SIDK_S5JT200_AUTOMOUNT_SSSRW_DEVNAME);
@@ -362,13 +370,20 @@ int board_app_initialize(void)
 			lldbg("ERROR: FAILED TO smart_initialize\n");
 			free(rambuf);
 		} else {
-			(void)mksmartfs(CONFIG_SIDK_S5JT200_RAMMTD_DEV_POINT, false);
-
-			ret = mount(CONFIG_SIDK_S5JT200_RAMMTD_DEV_POINT, CONFIG_SIDK_S5JT200_RAMMTD_MOUNT_POINT,
-					"smartfs", 0, NULL);
-			if (ret < 0) {
-				lldbg("ERROR: Failed to mount the SMART volume: %d\n", errno);
+#ifdef CONFIG_SMARTFS_MULTI_ROOT_DIRS
+			ret = mksmartfs(CONFIG_SIDK_S5JT200_RAMMTD_DEV_POINT, 1, false);
+#else
+			ret = mksmartfs(CONFIG_SIDK_S5JT200_RAMMTD_DEV_POINT, false);
+#endif
+			if (ret != OK) {
+				lldbg("ERROR: mksmartfs on %s failed", CONFIG_SIDK_S5JT200_RAMMTD_DEV_POINT);
 				free(rambuf);
+			} else {
+				ret = mount(CONFIG_SIDK_S5JT200_RAMMTD_DEV_POINT, CONFIG_SIDK_S5JT200_RAMMTD_MOUNT_POINT, "smartfs", 0, NULL);
+				if (ret < 0) {
+					lldbg("ERROR: Failed to mount the SMART volume: %d\n", errno);
+					free(rambuf);
+				}
 			}
 		}
 	}


### PR DESCRIPTION
mksmartfs has 2 or 3 parameters depending on support for multiple root dir/mount points
If CONFIG_SMARTFS_MULTI_ROOT_DIRS is enabled, a nrootdirs parameter, the number of root dir entries is needed additionally.
And user can use mksmartfs TASH command with this value.