### PR TITLE
Fixed resource leak in examples/sensorbd_demo

### DIFF
--- a/apps/examples/sensorbd_demo/examples/gpio_ledonoff.c
+++ b/apps/examples/sensorbd_demo/examples/gpio_ledonoff.c
@@ -67,7 +67,6 @@ static void gpio_write(int port, int value)
 	ioctl(fd, GPIOIOC_SET_DIRECTION, GPIO_DIRECTION_OUT);
 	if (write(fd, str, snprintf(str, 4, "%d", value != 0) + 1) < 0) {
 		printf("write error\n");
-		return;
 	}
 
 	close(fd);

--- a/apps/examples/sensorbd_demo/examples/gpio_loopback.c
+++ b/apps/examples/sensorbd_demo/examples/gpio_loopback.c
@@ -74,6 +74,7 @@ static int gpio_read(int port)
 
 	if (read(fd, buf, sizeof(buf)) < 0) {
 		printf("read error\n");
+		close(fd);
 		return -1;
 	}
 	close(fd);
@@ -95,7 +96,6 @@ static void gpio_write(int port, int value)
 	ioctl(fd, GPIOIOC_SET_DIRECTION, GPIO_DIRECTION_OUT);
 	if (write(fd, buf, snprintf(buf, sizeof(buf), "%d", !!value)) < 0) {
 		printf("write error\n");
-		return;
 	}
 	close(fd);
 }

--- a/apps/examples/sensorbd_demo/examples/gpio_starterled.c
+++ b/apps/examples/sensorbd_demo/examples/gpio_starterled.c
@@ -59,10 +59,15 @@ static int gpio_read(int port)
 	char devpath[16];
 	snprintf(devpath, 16, "/dev/gpio%d", port);
 	int fd = open(devpath, O_RDWR);
+	if (fd < 0) {
+		printf("fd open fail\n");
+		return -1;
+	}
 
 	ioctl(fd, GPIOIOC_SET_DIRECTION, GPIO_DIRECTION_IN);
 	if (read(fd, buf, sizeof(buf)) < 0) {
 		printf("read error\n");
+		close(fd);
 		return -1;
 	}
 	close(fd);
@@ -76,11 +81,14 @@ static void gpio_write(int port, int value)
 	char devpath[16];
 	snprintf(devpath, 16, "/dev/gpio%d", port);
 	int fd = open(devpath, O_RDWR);
+	if (fd < 0) {
+		printf("fd open fail\n");
+		return;
+	}
 
 	ioctl(fd, GPIOIOC_SET_DIRECTION, GPIO_DIRECTION_OUT);
 	if (write(fd, buf, snprintf(buf, sizeof(buf), "%d", !!value)) < 0) {
 		printf("write error\n");
-		return;
 	}
 	close(fd);
 }

--- a/apps/examples/sensorbd_demo/examples/pwm_led.c
+++ b/apps/examples/sensorbd_demo/examples/pwm_led.c
@@ -70,16 +70,22 @@ void ledpwm_main(int argc, char *argv[])
 	fd2 = open("/dev/pwm3", O_RDWR);
 	if (fd2 < 0) {
 		printf("fd open fail\n");
+		close(fd1);
 		return;
 	}
 	fd3 = open("/dev/pwm4", O_RDWR);
 	if (fd3 < 0) {
 		printf("fd open fail\n");
+		close(fd1);
+		close(fd2);
 		return;
 	}
 	fd4 = open("/dev/pwm5", O_RDWR);
 	if (fd4 < 0) {
 		printf("fd open fail\n");
+		close(fd1);
+		close(fd2);
+		close(fd3);
 		return;
 	}
 	pwm_info.frequency = 1000;


### PR DESCRIPTION
examples/gpio_starterled.c:66: (error) Resource leak: fd
examples/gpio_starterled.c:83: (error) Resource leak: fd
examples/gpio_loopback.c:77: (error) Resource leak: fd
examples/gpio_loopback.c:98: (error) Resource leak: fd
examples/pwm_led.c:73: (error) Resource leak: fd1
examples/pwm_led.c:78: (error) Resource leak: fd2
examples/pwm_led.c:83: (error) Resource leak: fd3
examples/gpio_ledonoff.c:70: (error) Resource leak: fd