### PR TITLE
apps/builtin: Modify Makefile to delete tdat file

### DIFF
--- a/apps/builtin/registry/Makefile
+++ b/apps/builtin/registry/Makefile
@@ -61,6 +61,7 @@ all:
 .updated: $(DEPCONFIG)
 	$(call DELFILE, *.bdat)
 	$(call DELFILE, *.pdat)
+	$(call DELFILE, *.tdat)
 	$(Q) touch .updated
 
 # This must run before any other context target
@@ -77,4 +78,5 @@ clean:
 distclean: clean
 	$(call DELFILE, *.bdat)
 	$(call DELFILE, *.pdat)
+	$(call DELFILE, *.tdat)
 	$(call DELFILE, .updated)


### PR DESCRIPTION
Builtin makes tdat file to save TASH task informations, priority and stacksize.
But it doesn't delete them after using by missing codes in Makefile.
When user calls update or clean, they will be deleted.