### PR TITLE
libc: optimize abs() function

### DIFF
--- a/framework/src/dm/dm_lwm2m.c
+++ b/framework/src/dm/dm_lwm2m.c
@@ -164,7 +164,7 @@ int dm_lwm2m_get_server_address(char *server_ipAddr)
 		fprintf(stderr, "%s: No data\n", __FUNCTION__);
 		return DM_ERROR_NO_DATA;
 	}
-	strncpy(server_ipAddr, g_dm_context.server_info.ipAddress, strlen(g_dm_context.server_info.ipAddress));
+	strncpy(server_ipAddr, g_dm_context.server_info.ipAddress, strlen(g_dm_context.server_info.ipAddress) + 1);
 	return DM_ERROR_NONE;
 }
 
@@ -191,7 +191,7 @@ int dm_lwm2m_get_server_port(char *server_port)
 		return DM_ERROR_NO_DATA;
 	}
 
-	strncpy(server_port, g_dm_context.server_info.port, strlen(g_dm_context.server_info.port));
+	strncpy(server_port, g_dm_context.server_info.port, strlen(g_dm_context.server_info.port) + 1);
 	return DM_ERROR_NONE;
 }
 

--- a/lib/libc/stdlib/lib_abs.c
+++ b/lib/libc/stdlib/lib_abs.c
@@ -63,8 +63,9 @@
 
 int abs(int j)
 {
-	if (j < 0) {
-		j = -j;
-	}
-	return j;
+	int mask;
+
+	mask = (j >> ((sizeof(j)*8) - 1));
+
+	return (j + mask) ^ mask;
 }


### PR DESCRIPTION
Current version uses branching, hence wring branch predictions could be possible for some inputs. So, proposing a version without branching!