### PR TITLE
mm_heap/mm_malloc : Add bad size checking logic which checks overflow

### DIFF
--- a/os/mm/mm_heap/mm_malloc.c
+++ b/os/mm/mm_heap/mm_malloc.c
@@ -118,6 +118,11 @@ FAR void *mm_malloc(FAR struct mm_heap_s *heap, size_t size)
 		return NULL;
 	}
 
+	if (size > MM_ALIGN_DOWN(MMSIZE_MAX) - SIZEOF_MM_ALLOCNODE) {
+		mvdbg("Because of mm_allocnode, %d cannot be allocated. The maximun allocable size is (MM_ALIGN_DOWN(MMSIZE_MAX) - SIZEOF_MM_ALLOCNODE) : %d\n.", size, (MM_ALIGN_DOWN(MMSIZE_MAX) - SIZEOF_MM_ALLOCNODE));
+		return NULL;
+	}
+
 	/* Adjust the size to account for (1) the size of the allocated node and
 	 * (2) to make sure that it is an even multiple of our granule size.
 	 */


### PR DESCRIPTION
if input size is greater than MM_ALIGN_DOWN(MMMAX_SIZE) - SIZEOF_MM_ALLOCNODE, it can be overflow by MM_ALIGN_UP.