### PR TITLE
Modify variable types on memory management

### DIFF
--- a/os/include/sys/types.h
+++ b/os/include/sys/types.h
@@ -187,10 +187,14 @@ typedef int16_t ssize_t;
 typedef uint16_t rsize_t;
 
 #else							/* CONFIG_SMALL_MEMORY */
+/* As a general rule, the size of size_t should be the same as the size of
+ * uintptr_t: 32-bits on a machine with 32-bit addressing but 64-bits on a
+ * machine with 64-bit addressing.
+ */
 
-typedef uint32_t size_t;
-typedef int32_t ssize_t;
-typedef uint32_t rsize_t;
+typedef uintptr_t size_t;
+typedef intptr_t ssize_t;
+typedef uintptr_t rsize_t;
 
 #endif							/* CONFIG_SMALL_MEMORY */
 

--- a/os/include/tinyara/mm/mm.h
+++ b/os/include/tinyara/mm/mm.h
@@ -203,13 +203,8 @@
 
 /* Determines the size of the chunk size/offset type */
 
-#ifdef CONFIG_MM_SMALL
-typedef uint16_t mmsize_t;
-#define MMSIZE_MAX 0xffff
-#else
-typedef uint32_t mmsize_t;
+typedef size_t mmsize_t;
 #define MMSIZE_MAX SIZE_MAX
-#endif
 
 /* typedef is used for defining size of address space */
 

--- a/os/include/tinyara/mm/mm.h
+++ b/os/include/tinyara/mm/mm.h
@@ -207,7 +207,7 @@
 typedef uint16_t mmsize_t;
 #define MMSIZE_MAX 0xffff
 #else
-typedef size_t mmsize_t;
+typedef uint32_t mmsize_t;
 #define MMSIZE_MAX SIZE_MAX
 #endif
 


### PR DESCRIPTION
1. Change types for size_t. size_t should be 64-bits on a 64-bit machine. Back ported from Nuttx
2. Change a type of mmsize_t and remove unnecessary conditional on mm.