### PR TITLE
mm : Modify memory size type to size_t and dbg msg format to %u

### DIFF
--- a/os/include/tinyara/mm/mm.h
+++ b/os/include/tinyara/mm/mm.h
@@ -316,8 +316,8 @@ struct mm_heap_s {
 
 	size_t mm_heapsize;
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
-	int peak_alloc_size;
-	int total_alloc_size;
+	size_t peak_alloc_size;
+	size_t total_alloc_size;
 #endif
 
 	/* This is the first and last nodes of the heap */

--- a/os/mm/mm_heap/mm_heapinfo.c
+++ b/os/mm/mm_heap/mm_heapinfo.c
@@ -84,13 +84,13 @@ void heapinfo_parse(FAR struct mm_heap_s *heap, int mode, pid_t pid)
 	size_t mxordblk = 0;
 	int    ordblks  = 0;		/* Number of non-inuse chunks */
 	size_t fordblks = 0;		/* Total non-inuse space */
-	int stack_resource;
-	int nonsched_resource;
+	size_t stack_resource;
+	size_t nonsched_resource;
 	int nonsched_idx;
 
 	/* This nonsched can be 3 types : group resources, freed when child task finished, leak */
 	pid_t nonsched_list[CONFIG_MAX_TASKS];
-	int nonsched_size[CONFIG_MAX_TASKS];
+	size_t nonsched_size[CONFIG_MAX_TASKS];
 
 #if CONFIG_MM_REGIONS > 1
 	int region;


### PR DESCRIPTION
1. Modify memory size type to size_t instead of int
2. All memory size is unsigned value, so dbg msg format should be %u instead of %d