### PR TITLE
external: Modify paths and conditionals on headers of include folder

### DIFF
--- a/external/include/codecs/base64.h
+++ b/external/include/codecs/base64.h
@@ -16,7 +16,7 @@
  *
  ****************************************************************************/
 /****************************************************************************
- * apps/include/netutils/base64.h
+ * external/include/codecs/base64.h
  *
  * This file is part of the NuttX RTOS:
  *
@@ -66,8 +66,8 @@
  *
  ****************************************************************************/
 
-#ifndef __APPS_INCLUDE_NETUTILS_BASE64_H
-#define __APPS_INCLUDE_NETUTILS_BASE64_H
+#ifndef __EXTERNAL_INCLUDE_CODECS_BASE64_H
+#define __EXTERNAL_INCLUDE_CODECS_BASE64_H
 
 /****************************************************************************
  * Included Files
@@ -98,4 +98,4 @@ unsigned char *base64w_decode(const unsigned char *src, size_t len, unsigned cha
 }
 #endif
 
-#endif							/* __APPS_INCLUDE_NETUTILS_BASE64_H */
+#endif							/* __EXTERNAL_INCLUDE_CODECS_BASE64_H */

--- a/external/include/codecs/md5.h
+++ b/external/include/codecs/md5.h
@@ -16,7 +16,7 @@
  *
  ****************************************************************************/
 /****************************************************************************
- * apps/include/netutils/md5.h
+ * external/include/codecs/md5.h
  *
  * This file is part of the NuttX RTOS:
  *
@@ -71,8 +71,8 @@
  *
  ****************************************************************************/
 
-#ifndef __APPS_INCLUDE_NETUTILS_MD5_H
-#define __APPS_INCLUDE_NETUTILS_MD5_H
+#ifndef __EXTERNAL_INCLUDE_CODECS_MD5_H
+#define __EXTERNAL_INCLUDE_CODECS_MD5_H
 
 /****************************************************************************
  * Included Files
@@ -118,4 +118,4 @@ char *md5_hash(const uint8_t *addr, const size_t len);
 }
 #endif
 #endif							/* CONFIG_CODECS_HASH_MD5 */
-#endif							/* __APPS_INCLUDE_NETUTILS_MD5_H */
+#endif							/* __EXTERNAL_INCLUDE_CODECS_MD5_H */

--- a/external/include/codecs/urldecode.h
+++ b/external/include/codecs/urldecode.h
@@ -16,7 +16,7 @@
  *
  ****************************************************************************/
 /****************************************************************************
- * apps/include/netutils/urldecode.h
+ * external/include/codecs/urldecode.h
  *
  * This file is part of the NuttX RTOS:
  *
@@ -50,8 +50,8 @@
  *
  ****************************************************************************/
 
-#ifndef __APPS_INCLUDE_NETUTILS_URLDECODE_H
-#define __APPS_INCLUDE_NETUTILS_URLDECODE_H
+#ifndef __EXTERNAL_INCLUDE_CODECS_URLDECODE_H
+#define __EXTERNAL_INCLUDE_CODECS_URLDECODE_H
 
 /****************************************************************************
  * Included Files
@@ -92,4 +92,4 @@ void urlrawencode(char *str, char *urlbuf);
 }
 #endif
 
-#endif							/* __APPS_INCLUDE_NETUTILS_URLDECODE_H */
+#endif							/* __EXTERNAL_INCLUDE_CODECS_URLDECODE_H */

--- a/external/include/json/cJSON.h
+++ b/external/include/json/cJSON.h
@@ -16,7 +16,7 @@
  *
  ****************************************************************************/
 /****************************************************************************
- * external/json/cJSON.c
+ * external/include/json/cJSON.h
  *
  * This file is a part of NuttX:
  *
@@ -47,8 +47,8 @@
  *
  ****************************************************************************/
 
-#ifndef __APPS_INCLUDE_NETUTILS_JSON_H
-#define __APPS_INCLUDE_NETUTILS_JSON_H
+#ifndef __EXTERNAL_INCLUDE_JSON_CJSON_H
+#define __EXTERNAL_INCLUDE_JSON_CJSON_H
 
 #ifdef __cplusplus
 // *INDENT-OFF*
@@ -297,4 +297,4 @@ CJSON_PUBLIC(void) cJSON_free(void *object);
 }
 // *INDENT-ON*
 #endif
-#endif							/* __APPS_INCLUDE_NETUTILS_JSON_H */
+#endif							/* __EXTERNAL_INCLUDE_JSON_CJSON_H */

--- a/external/include/netutils/ipmsfilter.h
+++ b/external/include/netutils/ipmsfilter.h
@@ -16,7 +16,7 @@
  *
  ****************************************************************************/
 /****************************************************************************
- * apps/include/netutils/ipmsfilter.h
+ * external/include/netutils/ipmsfilter.h
  * User interface to add/remove IP multicast address
  *
  *   Copyright (C) 2009, 2011 Gregory Nutt. All rights reserved.
@@ -51,8 +51,8 @@
  *
  ****************************************************************************/
 
-#ifndef __APPS_INCLUDE_NETUTILS_IPMSFILTER_H
-#define __APPS_INCLUDE_NETUTILS_IPMSFILTER_H
+#ifndef __EXTERNAL_INCLUDE_NETUTILS_IPMSFILTER_H
+#define __EXTERNAL_INCLUDE_NETUTILS_IPMSFILTER_H
 
 /****************************************************************************
  * Included Files
@@ -112,4 +112,4 @@ EXTERN int ipmsfilter(FAR const char *ifname, FAR const struct in_addr *multiadd
 #endif
 
 #endif							/* CONFIG_NET_IGMP */
-#endif							/* __APPS_INCLUDE_NETUTILS_IPMSFILTER_H */
+#endif							/* __EXTERNAL_INCLUDE_NETUTILS_IPMSFILTER_H */

--- a/external/include/netutils/netlib.h
+++ b/external/include/netutils/netlib.h
@@ -16,7 +16,7 @@
  *
  ****************************************************************************/
 /****************************************************************************
- *  apps/include/netutils/netlib.h
+ *  external/include/netutils/netlib.h
  * Various non-standard APIs to support netutils.  All non-standard and
  * intended only for internal use.
  *
@@ -57,8 +57,8 @@
  *
  ****************************************************************************/
 
-#ifndef __APPS_INCLUDE_NETUTILS_NETLIB_H
-#define __APPS_INCLUDE_NETUTILS_NETLIB_H
+#ifndef __EXTERNAL_INCLUDE_NETUTILS_NETLIB_H
+#define __EXTERNAL_INCLUDE_NETUTILS_NETLIB_H
 
 /****************************************************************************
  * Included Files
@@ -167,4 +167,4 @@ int netlib_ifdown(FAR const char *ifname);
 // *INDENT-ON*
 #endif
 
-#endif							/* __APPS_INCLUDE_NETUTILS_NETLIB_H */
+#endif							/* __EXTERNAL_INCLUDE_NETUTILS_NETLIB_H */

--- a/external/include/protocols/dhcpc.h
+++ b/external/include/protocols/dhcpc.h
@@ -16,7 +16,7 @@
  *
  ****************************************************************************/
 /****************************************************************************
- * apps/include/netutils/dhcpc.h
+ * external/include/protocols/dhcpc.h
  *
  *   Copyright (C) 2007, 2009-2011 Gregory Nutt. All rights reserved.
  *   Author: Gregory Nutt <gnutt@nuttx.org>
@@ -63,8 +63,8 @@
  * @brief APIs for DHCP client
  */
 
-#ifndef __APPS_INCLUDE_NETUTILS_DHCPC_H
-#define __APPS_INCLUDE_NETUTILS_DHCPC_H
+#ifndef __EXTERNAL_INCLUDE_PROTOCOLS_DHCPC_H
+#define __EXTERNAL_INCLUDE_PROTOCOLS_DHCPC_H
 
 /****************************************************************************
  * Included Files
@@ -136,5 +136,5 @@ void dhcpc_close(void *handle);
 }
 #endif
 
-#endif							/* __APPS_INCLUDE_NETUTILS_DHCPC_H */
+#endif							/* __EXTERNAL_INCLUDE_PROTOCOLS_DHCPC_H */
 /**@} */

--- a/external/include/protocols/dhcpd.h
+++ b/external/include/protocols/dhcpd.h
@@ -16,7 +16,7 @@
  *
  ****************************************************************************/
 /****************************************************************************
- * apps/include/netutils/dhcpd.h
+ * external/include/protocols/dhcpd.h
  *
  *   Copyright (C) 2007, 2009, 2011 Gregory Nutt. All rights reserved.
  *   Author: Gregory Nutt <gnutt@nuttx.org>
@@ -62,8 +62,8 @@
  * @brief netif API (to be used from lwIP TCPIP thread)
  */
 
-#ifndef __APPS_INCLUDE_NETUTILS_DHCPD_H
-#define __APPS_INCLUDE_NETUTILS_DHCPD_H
+#ifndef __EXTERNAL_INCLUDE_PROTOCOLS_DHCPD_H
+#define __EXTERNAL_INCLUDE_PROTOCOLS_DHCPD_H
 
 /****************************************************************************
  * Included Files
@@ -111,5 +111,5 @@ int dhcpd_start(char *intf, dhcp_sta_joined dhcp_join_cb);
 }
 #endif
 
-#endif							/* __APPS_INCLUDE_NETUTILS_DHCPD_H */
+#endif							/* __EXTERNAL_INCLUDE_PROTOCOLS_DHCPD_H */
 /** @} */

--- a/external/include/protocols/discover.h
+++ b/external/include/protocols/discover.h
@@ -16,7 +16,7 @@
  *
  ****************************************************************************/
 /****************************************************************************
- * apps/include/netutils/discover.h
+ * external/include/protocols/discover.h
  *
  *   Copyright (C) 2012 Max Holtzberg. All rights reserved.
  *   Author: Max Holtzberg <mh@uvc.de>
@@ -50,8 +50,8 @@
  *
  ****************************************************************************/
 
-#ifndef __APPS_INCLUDE_NETUTILS_DISCOVER_H
-#define __APPS_INCLUDE_NETUTILS_DISCOVER_H
+#ifndef __EXTERNAL_INCLUDE_PROTOCOLS_DISCOVER_H
+#define __EXTERNAL_INCLUDE_PROTOCOLS_DISCOVER_H
 
 #include <stdint.h>
 
@@ -96,4 +96,4 @@ int discover_start(struct discover_info_s *info);
 }
 #endif
 
-#endif							/* __APPS_INCLUDE_NETUTILS_DISCOVER_H */
+#endif							/* __EXTERNAL_INCLUDE_PROTOCOLS_DISCOVER_H */

--- a/external/include/protocols/ftpc.h
+++ b/external/include/protocols/ftpc.h
@@ -16,7 +16,7 @@
  *
  ****************************************************************************/
 /****************************************************************************
- * apps/include/ftpc.h
+ * external/include/protocols/ftpc.h
  *
  *   Copyright (C) 2011 Gregory Nutt. All rights reserved.
  *   Author: Gregory Nutt <gnutt@nuttx.org>
@@ -50,8 +50,8 @@
  *
  ****************************************************************************/
 
-#ifndef __APPS_INCLUDE_FTPC_H
-#define __APPS_INCLUDE_FTPC_H
+#ifndef __EXTERNAL_INCLUDE_PROTOCOLS_FTPC_H
+#define __EXTERNAL_INCLUDE_PROTOCOLS_FTPC_H
 
 /****************************************************************************
  * Included Files
@@ -237,4 +237,4 @@ EXTERN FAR char *ftpc_response(SESSION handle);
 // *INDENT-ON*
 #endif
 
-#endif							/* __APPS_INCLUDE_FTPC_H */
+#endif							/* __EXTERNAL_INCLUDE_PROTOCOLS_FTPC_H */

--- a/external/include/protocols/ftpd.h
+++ b/external/include/protocols/ftpd.h
@@ -16,7 +16,7 @@
  *
  ****************************************************************************/
 /****************************************************************************
- * apps/include/netutils/ftpd.h
+ * external/include/protocols/ftpd.h
  *
  *   Copyright (C) 2012 Gregory Nutt. All rights reserved.
  *   Author: Gregory Nutt <gnutt@nuttx.org>
@@ -50,8 +50,8 @@
  *
  ****************************************************************************/
 
-#ifndef __APPS_INCLUDE_NETUTILS_FTPD_H
-#define __APPS_INCLUDE_NETUTILS_FTPD_H
+#ifndef __EXTERNAL_INCLUDE_PROTOCOLS_FTPD_H
+#define __EXTERNAL_INCLUDE_PROTOCOLS_FTPD_H
 
 /****************************************************************************
  * Included Files
@@ -229,4 +229,4 @@ EXTERN void ftpd_close(FTPD_SESSION handle);
 #ifdef __cplusplus
 }
 #endif
-#endif							/* __APPS_INCLUDE_NETUTILS_FTPD_H */
+#endif							/* __EXTERNAL_INCLUDE_PROTOCOLS_FTPD_H */

--- a/external/include/protocols/ntpclient.h
+++ b/external/include/protocols/ntpclient.h
@@ -16,7 +16,7 @@
  *
  ****************************************************************************/
 /****************************************************************************
- * apps/include/netutils/ntpclient.h
+ * external/include/protocols/ntpclient.h
  *
  *   Copyright (C) 2014 Gregory Nutt. All rights reserved.
  *   Author: Gregory Nutt <gnutt@nuttx.org>
@@ -59,8 +59,8 @@
 /// @file protocols/ntpclient.h
 /// @brief APIs for NTP Client
 
-#ifndef __APPS_INCLUDE_NETUTILS_NTPCLIENT_H
-#define __APPS_INCLUDE_NETUTILS_NTPCLIENT_H 1
+#ifndef __EXTERNAL_INCLUDE_PROTOCOLS_NTPCLIENT_H
+#define __EXTERNAL_INCLUDE_PROTOCOLS_NTPCLIENT_H
 
 /****************************************************************************
  * Included Files
@@ -187,6 +187,6 @@ int ntpc_get_link_status(void);
 }
 #endif
 
-#endif							/* __APPS_INCLUDE_NETUTILS_NTPCLIENT_H */
+#endif							/* __EXTERNAL_INCLUDE_PROTOCOLS_NTPCLIENT_H */
 
 /** @} */// end of NTPC group

--- a/external/include/protocols/smtp.h
+++ b/external/include/protocols/smtp.h
@@ -16,7 +16,7 @@
  *
  ****************************************************************************/
 /****************************************************************************
- * apps/include/netutils/smtp.h
+ * external/include/protocols/smtp.h
  * SMTP header file
  *
  *   Copyright (C) 2007, 2009, 2011, 2015 Gregory Nutt. All rights reserved.
@@ -54,8 +54,8 @@
  *
  ****************************************************************************/
 
-#ifndef __APPS_INCLUDE_NETUTILS_SMTP_H
-#define __APPS_INCLUDE_NETUTILS_SMTP_H
+#ifndef __EXTERNAL_INCLUDE_PROTOCOLS_SMTP_H
+#define __EXTERNAL_INCLUDE_PROTOCOLS_SMTP_H
 
 /****************************************************************************
  * Included Files
@@ -92,4 +92,4 @@ void smtp_close(FAR void *handle);
 }
 #endif
 
-#endif							/* __APPS_INCLUDE_NETUTILS_SMTP_H */
+#endif							/* __EXTERNAL_INCLUDE_PROTOCOLS_SMTP_H */

--- a/external/include/protocols/telnetd.h
+++ b/external/include/protocols/telnetd.h
@@ -16,7 +16,7 @@
  *
  ****************************************************************************/
 /****************************************************************************
- *  apps/include/netutils/telnetd.h
+ *  external/include/protocols/telnetd.h
  *
  *   Copyright (C) 2007, 2011-2012 Gregory Nutt. All rights reserved.
  *   Author: Gregory Nutt <gnutt@nuttx.org>
@@ -50,8 +50,8 @@
  *
  ****************************************************************************/
 
-#ifndef __APPS_INCLUDE_NETUTILS_TELNETD_H
-#define __APPS_INCLUDE_NETUTILS_TELNETD_H
+#ifndef __EXTERNAL_INCLUDE_PROTOCOLS_TELNETD_H
+#define __EXTERNAL_INCLUDE_PROTOCOLS_TELNETD_H
 
 /****************************************************************************
  * Included Files
@@ -140,4 +140,4 @@ EXTERN int telnetd_start(FAR struct telnetd_config_s *config);
 #ifdef __cplusplus
 }
 #endif
-#endif							/* __APPS_INCLUDE_NETUTILS_TELNETD_H */
+#endif							/* __EXTERNAL_INCLUDE_PROTOCOLS_TELNETD_H */

--- a/external/include/protocols/tftp.h
+++ b/external/include/protocols/tftp.h
@@ -16,7 +16,7 @@
  *
  ****************************************************************************/
 /****************************************************************************
- *  apps/include/netutils/tftp.h
+ *  external/include/protocols/tftp.h
  *
  *   Copyright (C) 2008-2009, 2011 Gregory Nutt. All rights reserved.
  *   Author: Gregory Nutt <gnutt@nuttx.org>
@@ -50,8 +50,8 @@
  *
  ****************************************************************************/
 
-#ifndef __APPS_INCLUDE_NETUTILS_TFTP_H
-#define __APPS_INCLUDE_NETUTILS_TFTP_H
+#ifndef __EXTERNAL_INCLUDE_PROTOCOLS_TFTP_H
+#define __EXTERNAL_INCLUDE_PROTOCOLS_TFTP_H
 
 /****************************************************************************
  * Included Files
@@ -87,4 +87,4 @@ int tftpput(const char *local, const char *remote, in_addr_t addr, bool binary);
 }
 #endif
 
-#endif							/* __APPS_INCLUDE_NETUTILS_TFTP_H */
+#endif							/* __EXTERNAL_INCLUDE_PROTOCOLS_TFTP_H */

--- a/external/include/protocols/webclient.h
+++ b/external/include/protocols/webclient.h
@@ -30,8 +30,8 @@
  * @brief APIs for HTTP Client.
  */
 
-#ifndef __APPS_INCLUDE_NETUTILS_WEBCLIENT_H
-#define __APPS_INCLUDE_NETUTILS_WEBCLIENT_H
+#ifndef __EXTERNAL_INCLUDE_PROTOCOLS_WEBCLIENT_H
+#define __EXTERNAL_INCLUDE_PROTOCOLS_WEBCLIENT_H
 
 /****************************************************************************
  * Included Files
@@ -215,5 +215,5 @@ void http_client_response_release(struct http_client_response_t *response);
 }
 #endif
 
-#endif /* __APPS_INCLUDE_NETUTILS_WEBCLIENT_H */
+#endif /* __EXTERNAL_INCLUDE_PROTOCOLS_WEBCLIENT_H */
 /**@} */

--- a/external/include/protocols/websocket.h
+++ b/external/include/protocols/websocket.h
@@ -28,8 +28,8 @@
  * @brief websocket header to support WS/WSS server and client.
  */
 
-#ifndef __APPS_INCLUDE_NETUTILS_WEBSOCKET_H
-#define __APPS_INCLUDE_NETUTILS_WEBSOCKET_H
+#ifndef __EXTERNAL_INCLUDE_PROTOCOLS_WEBSOCKET_H
+#define __EXTERNAL_INCLUDE_PROTOCOLS_WEBSOCKET_H
 
 /****************************************************************************
  * Included Files
@@ -558,4 +558,4 @@ websocket_return_t websocket_set_error(websocket_t *websocket, int val);
 
 /** @} */// end of Websocket group
 
-#endif							/* __APPS_INCLUDE_NETUTILS_WEBSOCKET_H */
+#endif							/* __EXTERNAL_INCLUDE_PROTOCOLS_WEBSOCKET_H */

--- a/external/include/protocols/xmlrpc.h
+++ b/external/include/protocols/xmlrpc.h
@@ -16,7 +16,7 @@
  *
  ****************************************************************************/
 /****************************************************************************
- * apps/include/netutils/xmlrpc.h
+ * external/include/protocols/xmlrpc.h
  *
  *   Copyright (C) 2012 Max Holtzberg. All rights reserved.
  *   Author: Max Holtzberg <mh@uvc.de>
@@ -64,8 +64,8 @@
  *
  */
 
-#ifndef __APPS_INCLUDE_NETUTILS_XMLRPC_H
-#define __APPS_INCLUDE_NETUTILS_XMLRPC_H
+#ifndef __EXTERNAL_INCLUDE_PROTOCOLS_XMLRPC_H
+#define __EXTERNAL_INCLUDE_PROTOCOLS_XMLRPC_H
 
 /****************************************************************************
  * Included Files
@@ -145,4 +145,4 @@ int xmlrpc_buildresponse(struct xmlrpc_s *, char *, ...);
 }
 #endif
 
-#endif							/* __APPS_INCLUDE_NETUTILS_XMLRPC_H */
+#endif							/* __EXTERNAL_INCLUDE_PROTOCOLS_XMLRPC_H */


### PR DESCRIPTION
Those were moved from apps but they have previous path and conditionals.
Let's modify them with right path information.