### PR TITLE
mm/mm_heap : simplify the overflow checking login in mm_malloc

### DIFF
--- a/os/mm/mm_heap/mm_malloc.c
+++ b/os/mm/mm_heap/mm_malloc.c
@@ -118,16 +118,16 @@ FAR void *mm_malloc(FAR struct mm_heap_s *heap, size_t size)
 		return NULL;
 	}
 
-	if (size > MM_ALIGN_DOWN(MMSIZE_MAX) - SIZEOF_MM_ALLOCNODE) {
-		mvdbg("Because of mm_allocnode, %u cannot be allocated. The maximun allocable size is (MM_ALIGN_DOWN(MMSIZE_MAX) - SIZEOF_MM_ALLOCNODE) : %u\n.", size, (MM_ALIGN_DOWN(MMSIZE_MAX) - SIZEOF_MM_ALLOCNODE));
-		return NULL;
-	}
-
 	/* Adjust the size to account for (1) the size of the allocated node and
 	 * (2) to make sure that it is an even multiple of our granule size.
 	 */
 
-	size = MM_ALIGN_UP(size + SIZEOF_MM_ALLOCNODE);
+	if (size <= MM_ALIGN_UP(size + SIZEOF_MM_ALLOCNODE)) {
+		size = MM_ALIGN_UP(size + SIZEOF_MM_ALLOCNODE);
+	} else {
+		mvdbg("Because of mm_allocnode, %u cannot be allocated. The maximun allocable size is (MM_ALIGN_DOWN(MMSIZE_MAX) - SIZEOF_MM_ALLOCNODE) : %u\n.", size, (MM_ALIGN_DOWN(MMSIZE_MAX) - SIZEOF_MM_ALLOCNODE));
+		return NULL;
+	}
 
 	/* We need to hold the MM semaphore while we muck with the nodelist. */
 


### PR DESCRIPTION
if aligned size is smaller than the original size, then it is overflowed.