### PR TITLE
README: Fix not working a link to "supported board and emulator"

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Please find project details like APIs reference at [docs](docs/) folder. Wiki wi
 ## Contents
 
 > [Quick Start](#quick-start)  
-> [Supported Board](#supported-board)  
+> [Supported Board / Emulator](#supported-board--emulator)  
 > [Configuration Sets](#configuration-sets)
 
 ## Quick Start


### PR DESCRIPTION
Sub-title was changed to "Supported Board / Emulator" but link is not.
Because of that, link is not working. Fix it to current name.