### PR TITLE
s5j/s5j_pwm.c: Fix NULL pointer dereference

### DIFF
--- a/os/arch/arm/src/s5j/s5j_pwm.c
+++ b/os/arch/arm/src/s5j/s5j_pwm.c
@@ -430,6 +430,7 @@ FAR struct pwm_lowerhalf_s *s5j_pwminitialize(int timer)
 #endif
 	{
 		lldbg("ERROR: invalid PWM is requested\n");
+		return NULL;
 	}
 
 	s5j_pwm_reset(lower, timer);


### PR DESCRIPTION
In 's5j_pwminitialize' function, if timer value is invalid or pwm value is NULL,
then it calls 's5j_pwm_reset' with NULL as a pwm dev parameter.
This case leads to NULL pointer dereference in 's5j_pwm_reset' function.

So NULL check is added in 's5j_pwminitialize' before calling 's5j_pwm_reset'.

Signed-off-by: Lokesh B V <lokesh.bv@partner.samsung.com>