### PR TITLE
sched_note: remove remained codes related to non-existent functions for monitoring system

### DIFF
--- a/os/include/sched.h
+++ b/os/include/sched.h
@@ -357,35 +357,6 @@ int sched_unlock(void);
  */
 int sched_lockcount(void);
 
-/* If instrumentation of the scheduler is enabled, then some outboard logic
- * must provide the following interfaces.
- */
-
-#ifdef CONFIG_SCHED_INSTRUMENTATION
-/**
- *@cond
- *@ internal
- */
-void sched_note_start(FAR struct tcb_s *tcb);
-/**
- *@internal
- */
-void sched_note_stop(FAR struct tcb_s *tcb);
-/**
- *@internal
- */
-void sched_note_switch(FAR struct tcb_s *pFromTcb, FAR struct tcb_s *pToTcb);
-
-/**
- *@endcond
- */
-
-#else
-#define sched_note_start(t)
-#define sched_note_stop(t)
-#define sched_note_switch(t1, t2)
-#endif							/* CONFIG_SCHED_INSTRUMENTATION */
-
 #undef EXTERN
 #if defined(__cplusplus)
 }

--- a/os/kernel/Kconfig
+++ b/os/kernel/Kconfig
@@ -529,18 +529,6 @@ config SCHED_CPULOAD_TIMECONSTANT
 
 endif # SCHED_CPULOAD
 
-config SCHED_INSTRUMENTATION
-	bool "System performance monitor hooks"
-	default n
-	---help---
-		Enables instrumentation in scheduler to monitor system performance.
-		If enabled, then the board-specific logic must provide the following
-		functions (see include/sched.h):
-
-		void sched_note_start(FAR struct tcb_s *tcb);
-		void sched_note_stop(FAR struct tcb_s *tcb);
-		void sched_note_switch(FAR struct tcb_s *pFromTcb, FAR struct tcb_s *pToTcb);
-
 endmenu # Performance Monitoring
 
 menu "Latency optimization"

--- a/os/kernel/sched/sched_addreadytorun.c
+++ b/os/kernel/sched/sched_addreadytorun.c
@@ -138,10 +138,6 @@ bool sched_addreadytorun(FAR struct tcb_s *btcb)
 	/* Otherwise, add the new task to the ready-to-run task list */
 
 	else if (sched_addprioritized(btcb, (FAR dq_queue_t *)&g_readytorun)) {
-		/* Inform the instrumentation logic that we are switching tasks */
-
-		sched_note_switch(rtcb, btcb);
-
 		/* The new btcb was added at the head of the ready-to-run list.  It
 		 * is now to new active task!
 		 */

--- a/os/kernel/sched/sched_mergepending.c
+++ b/os/kernel/sched/sched_mergepending.c
@@ -146,12 +146,8 @@ bool sched_mergepending(void)
 		rtrprev = rtrtcb->blink;
 		if (!rtrprev) {
 			/* Special case: Inserting pndtcb at the head of the list */
-			/* Inform the instrumentation layer that we are switching tasks */
-
-			sched_note_switch(rtrtcb, pndtcb);
 
 			/* Then insert at the head of the list */
-
 			pndtcb->flink = rtrtcb;
 			pndtcb->blink = NULL;
 			rtrtcb->blink = pndtcb;

--- a/os/kernel/sched/sched_removereadytorun.c
+++ b/os/kernel/sched/sched_removereadytorun.c
@@ -122,9 +122,6 @@ bool sched_removereadytorun(FAR struct tcb_s *rtcb)
 		ntcb = (FAR struct tcb_s *)rtcb->flink;
 		DEBUGASSERT(ntcb != NULL);
 
-		/* Inform the instrumentation layer that we are switching tasks */
-
-		sched_note_switch(rtcb, ntcb);
 		ntcb->task_state = TSTATE_TASK_RUNNING;
 		ret = true;
 	}

--- a/os/kernel/sched/sched_yield.c
+++ b/os/kernel/sched/sched_yield.c
@@ -126,7 +126,6 @@ int sched_yield(void)
 		saved_state = irqsave();
 
 		/* A context switch will occur. */
-		sched_note_switch(rtcb, ntcb);
 		ntcb->task_state = TSTATE_TASK_RUNNING;
 		switch_needed = true;
 

--- a/os/kernel/task/task_activate.c
+++ b/os/kernel/task/task_activate.c
@@ -108,25 +108,6 @@ int task_activate(FAR struct tcb_s *tcb)
 {
 	irqstate_t flags = irqsave();
 
-#ifdef CONFIG_SCHED_INSTRUMENTATION
-
-	/* Check if this is really a re-start */
-
-	if (tcb->task_state != TSTATE_TASK_INACTIVE) {
-		/* Inform the instrumentation layer that the task
-		 * has stopped
-		 */
-
-		sched_note_stop(tcb);
-	}
-
-	/* Inform the instrumentation layer that the task
-	 * has started
-	 */
-
-	sched_note_start(tcb);
-#endif
-
 	up_unblock_task(tcb);
 	irqrestore(flags);
 	return OK;

--- a/os/kernel/task/task_terminate.c
+++ b/os/kernel/task/task_terminate.c
@@ -194,12 +194,6 @@ int task_terminate(pid_t pid, bool nonblocking)
 
 	sched_unlock();
 
-	/* Since all tasks pass through this function as the final step in their
-	 * exit sequence, this is an appropriate place to inform any instrumentation
-	 * layer that the task no longer exists.
-	 */
-
-	sched_note_stop(dtcb);
 	trace_end(TTRACE_TAG_TASK);
 
 	/* Deallocate its TCB */


### PR DESCRIPTION
sched_note_XXX are functions for monitoring system performance.
Implementations of these functions don't exist and we don't need to use it because ttrace has similar functionality in TizenRT.
So remove all remained things related to these functions.