### PR TITLE
testcase/dm/itc: remove duplicated configs for wifi

### DIFF
--- a/apps/examples/testcase/ta_tc/device_management/itc/Kconfig
+++ b/apps/examples/testcase/ta_tc/device_management/itc/Kconfig
@@ -12,29 +12,6 @@ menuconfig EXAMPLES_TESTCASE_DM_ITC
 
 if EXAMPLES_TESTCASE_DM_ITC
 
-menuconfig EXAMPLES_TESTCASE_DM_WIFI
-  bool "Set Up Wifi Info For DM Demo"
-  default n
-  ---help---
-    Enable the artik demo example
-
-if EXAMPLES_TESTCASE_DM_WIFI
-
-config DM_AP_SSID
-  string "wifi ap ssid"
-  default "SSID"
-
-config DM_AP_PASS
-  string "wifi ap password"
-  default "PASSWORD"
-
-config DM_AP_SECURITY
-  string "wifi join security"
-  default "wpa2_aes"
-
-endif #EXAMPLES_TESTCASE_DM_WIFI
-
-
 config ITC_DM_START
   bool "Start API"
   default n


### PR DESCRIPTION
DM_WIFI, DM_AP_SSID, DM_AP_PASS and DM_AP_SECURITY should be set
in DM of framework, not testcase. Due to this, these are listed in
in-correct locations.
```
 # CONFIG_EXAMPLES_TESTCASE is not set
 CONFIG_DM_AP_SSID="TizenRT1"
 CONFIG_DM_AP_PASS="tizenrt_tdc2017"
 CONFIG_DM_AP_SECURITY="wpa2_aes"

 #
 # Device Management
 #
 CONFIG_DM=y
 CONFIG_DM_WIFI=y
```