### PR TITLE
kernel, logm: modify dependancies of configs

### DIFF
--- a/os/Kconfig.debug
+++ b/os/Kconfig.debug
@@ -567,5 +567,7 @@ config FRAME_POINTER
 		reported during system crash is very limited.
 
 menu "Logger Module"
+	depends on !DISABLE_SIGNALS
+
 source logm/Kconfig
 endmenu

--- a/os/kernel/Kconfig
+++ b/os/kernel/Kconfig
@@ -833,10 +833,8 @@ endmenu # POSIX Message Queue Options
 menu "Work Queue Support"
 
 config SCHED_WORKQUEUE
-#	bool "Enable worker thread"
 	bool
 	default y
-	depends on !DISABLE_SIGNALS
 	---help---
 		Create dedicated "worker" threads to handle delayed or asynchronous
 		processing.
@@ -844,7 +842,7 @@ config SCHED_WORKQUEUE
 config SCHED_WORKQUEUE_SORTING
 	bool "Sort workers by delay"
 	default y
-	select SCHED_WORKQUEUE
+	depends on SCHED_WORKQUEUE
 	---help---
 		Sort workers by delay when worker is inserted
 
@@ -1032,12 +1030,14 @@ config MPU_STACKGAURD
 config PTHREAD_STACK_MIN
 	int "Minimum pthread stack size"
 	default 256
+	depends on !DISABLE_PTHREAD
 	---help---
 		Minimum pthread stack size
 
 config PTHREAD_STACK_DEFAULT
 	int "Default pthread stack size"
 	default 2048
+	depends on !DISABLE_PTHREAD
 	---help---
 		Default pthread stack size
 endmenu # Stack size information

--- a/os/logm/Kconfig
+++ b/os/logm/Kconfig
@@ -5,7 +5,6 @@
 
 config LOGM
 	bool "Logger Module"
-	depends on !DISABLE_SIGNALS
 	default n
 	---help---
 		Logger.


### PR DESCRIPTION
1. PTHREAD_STACK_MIN and PTHREAD_STACK_DEFAULT
  They should not be shown when DISABLE_PTHREAD is enabled.
  Let's make a dependancy as "depends on !DISABLE_PTHREAD".
2. SCHED_WORKQUEUE and SCHED_WORKQUEUE_SORTING
  SORTING config is meaningful when one of kernel workqueues is enabled.
  Let's make a dependancy as "depends on SCHED_WORKQUEUE"
  Remove unncessary comments and duplicated a dependancy, !DISABLE_SIGNAL.
3. LOGM
  When DISABLE_SIGNAL is enabled, we can't enable LOGM. But it shows only
  menu without config. Let's move a dependancy from config to menu.
  When DISABLE_SIGNAL is enabled, it will not show meanless title.