### PR TITLE
build/configs/artik05x: Correcting tizenrt image path in artik05x_download.sh 

### DIFF
--- a/build/configs/artik05x/artik05x_download.sh
+++ b/build/configs/artik05x/artik05x_download.sh
@@ -158,7 +158,7 @@ signing() {
         exit 1
     fi
 
-    ${CODESIGNER_PATH}/${CODESIGNER_TOOL} ${CODESIGNER_PATH}/rsa_private.key $TIZENRT_IMAGE
+    ${CODESIGNER_PATH}/${CODESIGNER_TOOL} ${CODESIGNER_PATH}/rsa_private.key $TIZENRT_BIN
     TIZENRT_BIN=${TIZENRT_BIN}-signed
 }
 


### PR DESCRIPTION
Correcting Tizenrt binary which is passed to codesigner signing script during flashing image to secure versions of artik05x series boards