### PR TITLE
Tinyalsa : Fix readi and writei API's

### DIFF
--- a/framework/src/tinyalsa/tinyalsa.c
+++ b/framework/src/tinyalsa/tinyalsa.c
@@ -15,46 +15,46 @@
  * language governing permissions and limitations under the License.
  *
  ****************************************************************************/
- /****************************************************************************
- *
- * Developed by:
- *
- *   Copyright (C) 2013 Ken Pettit. All rights reserved.
- *   Author: Ken Pettit <pettitkd@gmail.com>
- *
- * With ongoing support:
- *
- *   Copyright (C) 2014 Gregory Nutt. All rights reserved.
- *   Author: Greory Nutt <gnutt@nuttx.org>
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
- *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX nor the names of its contributors may be
- *    used to endorse or promote products derived from this software
- *    without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- *
- ****************************************************************************/
+/****************************************************************************
+*
+* Developed by:
+*
+*   Copyright (C) 2013 Ken Pettit. All rights reserved.
+*   Author: Ken Pettit <pettitkd@gmail.com>
+*
+* With ongoing support:
+*
+*   Copyright (C) 2014 Gregory Nutt. All rights reserved.
+*   Author: Greory Nutt <gnutt@nuttx.org>
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions
+* are met:
+*
+* 1. Redistributions of source code must retain the above copyright
+*    notice, this list of conditions and the following disclaimer.
+* 2. Redistributions in binary form must reproduce the above copyright
+*    notice, this list of conditions and the following disclaimer in
+*    the documentation and/or other materials provided with the
+*    distribution.
+* 3. Neither the name NuttX nor the names of its contributors may be
+*    used to endorse or promote products derived from this software
+*    without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+* "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+* LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+* FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+* COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+* BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+* OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+* AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+* LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+* ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*
+****************************************************************************/
 /* tinyalsa.c
 **
 ** Copyright 2011, The Android Open Source Project
@@ -319,7 +319,6 @@ static int pcm_set_config(struct pcm *pcm, const struct pcm_config *config)
 		pcm->config = *config;
 	}
 
-
 #ifdef CONFIG_AUDIO_MULTI_SESSION
 	cap_desc.session = pcm->session;
 #endif
@@ -483,14 +482,13 @@ int pcm_get_htimestamp(struct pcm *pcm, unsigned int *avail, struct timespec *ts
  * @param pcm A PCM handle.
  * @param data The audio sample array
  * @param frame_count The number of frames occupied by the sample array.
- *  This value should not be greater than @ref TINYALSA_FRAMES_MAX
- *  or INT_MAX.
+ *  This value should not be greater than @ref INT_MAX.
  * @return On success, this function returns the number of frames written; otherwise, a negative number.
  * @ingroup libtinyalsa-pcm
  */
 int pcm_writei(struct pcm *pcm, const void *data, unsigned int frame_count)
 {
-	unsigned int nbytes;
+	unsigned int nbytes = 0, pending = 0, offset = 0;
 	struct audio_buf_desc_s bufdesc;
 	struct ap_buffer_s *apb;
 	struct audio_msg_s msg;
@@ -505,49 +503,56 @@ int pcm_writei(struct pcm *pcm, const void *data, unsigned int frame_count)
 		return -EINVAL;
 	}
 
-	if (frame_count > pcm->config.period_size) {
-		frame_count = pcm->config.period_size;
+	if (frame_count > INT_MAX) {
+		return -EINVAL;
 	}
 
-	nbytes = pcm_frames_to_bytes(pcm, frame_count);
+	pending = pcm_frames_to_bytes(pcm, frame_count);
 
-	if (pcm->buf_ptr < pcm->config.period_count) {
-		/* If we have empty buffers, fill them first */
-		memcpy(pcm->pBuffers[pcm->buf_ptr]->samp, data, nbytes);
-		apb = pcm->pBuffers[pcm->buf_ptr];
-		pcm->buf_ptr++;
-	} else {
-		/* We dont have any empty buffers. wait for deque message from kernel */
-		size = mq_receive(pcm->mq, (FAR char *)&msg, sizeof(msg), &prio);
-		if (size != sizeof(msg)) {
-			/* Interrupted by a signal? What to do? */
-			return oops(pcm, EINTR, "Interrupted while waiting for deque message from kernel");
-		}
-		if (msg.msgId == AUDIO_MSG_DEQUEUE) {
-			apb = (struct ap_buffer_s *)msg.u.pPtr;
-			memcpy(apb->samp, data, nbytes);
+	while (pending > 0) {
+		nbytes = pending > pcm->config.period_size ? pcm->config.period_size : pending;
+
+		if (pcm->buf_ptr < pcm->config.period_count) {
+			/* If we have empty buffers, fill them first */
+			memcpy(pcm->pBuffers[pcm->buf_ptr]->samp, (char*)data + offset, nbytes);
+			apb = pcm->pBuffers[pcm->buf_ptr];
+			pcm->buf_ptr++;
 		} else {
-			return oops(pcm, EINTR, "Recieved unexpected msg (id = %d) while waiting for deque message from kernel", msg.msgId);
+			/* We dont have any empty buffers. wait for deque message from kernel */
+			size = mq_receive(pcm->mq, (FAR char *)&msg, sizeof(msg), &prio);
+			if (size != sizeof(msg)) {
+				/* Interrupted by a signal? What to do? */
+				return oops(pcm, EINTR, "Interrupted while waiting for deque message from kernel");
+			}
+			if (msg.msgId == AUDIO_MSG_DEQUEUE) {
+				apb = (struct ap_buffer_s *)msg.u.pPtr;
+				memcpy(apb->samp, (char*)data + offset, nbytes);
+			} else {
+				return oops(pcm, EINTR, "Recieved unexpected msg (id = %d) while waiting for deque message from kernel", msg.msgId);
+			}
 		}
-	}
 
-	/* Buffer is ready. Enque it */
+		/* Buffer is ready. Enque it */
 #ifdef CONFIG_AUDIO_MULTI_SESSION
-	bufdesc.session = pcm->session;
+		bufdesc.session = pcm->session;
 #endif
-	apb->nbytes = nbytes;
-	apb->curbyte = 0;
-	apb->flags = 0;
-	bufdesc.numbytes = apb->nbytes;
-	bufdesc.u.pBuffer = apb;
-	if (ioctl(pcm->fd, AUDIOIOC_ENQUEUEBUFFER, (unsigned long)&bufdesc) < 0) {
-		return oops(pcm, errno, "AUDIOIOC_ENQUEUEBUFFER ioctl failed");
-	}
-	/* If playback is not already started, start now! */
-	if ((!pcm->running) && (pcm_start(pcm) < 0)) {
-		return -errno;
-	} else {
-		pcm->running = 1;
+		apb->nbytes = nbytes;
+		apb->curbyte = 0;
+		apb->flags = 0;
+		bufdesc.numbytes = apb->nbytes;
+		bufdesc.u.pBuffer = apb;
+		if (ioctl(pcm->fd, AUDIOIOC_ENQUEUEBUFFER, (unsigned long)&bufdesc) < 0) {
+			return oops(pcm, errno, "AUDIOIOC_ENQUEUEBUFFER ioctl failed");
+		}
+		/* If playback is not already started, start now! */
+		if ((!pcm->running) && (pcm_start(pcm) < 0)) {
+			return -errno;
+		} else {
+			pcm->running = 1;
+		}
+
+		offset += nbytes;
+		pending -= nbytes;
 	}
 
 	return pcm_bytes_to_frames(pcm, nbytes);
@@ -560,14 +565,13 @@ int pcm_writei(struct pcm *pcm, const void *data, unsigned int frame_count)
  * @param pcm A PCM handle.
  * @param data The audio sample array
  * @param frame_count The number of frames occupied by the sample array.
- *  This value should not be greater than @ref TINYALSA_FRAMES_MAX
- *  or INT_MAX.
+ *  This value should not be greater than @ref INT_MAX.
  * @return On success, this function returns the number of frames written; otherwise, a negative number.
  * @ingroup libtinyalsa-pcm
  */
 int pcm_readi(struct pcm *pcm, void *data, unsigned int frame_count)
 {
-	int nbytes;
+	int nbytes = 0, pending = 0, offset = 0;
 	struct audio_buf_desc_s bufdesc;
 	struct ap_buffer_s *apb;
 	struct audio_msg_s msg;
@@ -583,7 +587,11 @@ int pcm_readi(struct pcm *pcm, void *data, unsigned int frame_count)
 		return -EINVAL;
 	}
 
-	nbytes = pcm_frames_to_bytes(pcm, frame_count);
+	if (frame_count > INT_MAX) {
+		return -EINVAL;
+	}
+
+	pending = pcm_frames_to_bytes(pcm, frame_count);
 
 	bufdesc.numbytes = pcm_frames_to_bytes(pcm, (pcm->buffer_size));
 
@@ -596,80 +604,30 @@ int pcm_readi(struct pcm *pcm, void *data, unsigned int frame_count)
 		return -errno;
 	}
 
-	/* Read data */
-	if (pcm->next_buf != NULL) {
-		/* We have a pending buffer with some data in it. */
-		apb = pcm->next_buf;
+	while (pending > 0) {
 
-		if (nbytes < pcm->next_size) {
-			/* User wants less data than we have in buffer.
-			   Copy the requested amount of data to user buffer and return */
-			memcpy(data, apb->samp + pcm->next_offset, nbytes);
-			pcm->next_size -= nbytes;
-			pcm->next_offset += nbytes;
-		} else {
-			/* User wants more data than we have in buffer.
-			   Copy available data to user buffer, enqueue buffer and return */
-			memcpy(data, apb->samp + pcm->next_offset, pcm->next_size);
+		/* Read data */
+		if (pcm->next_buf != NULL) {
+			/* We have a pending buffer with some data in it. */
+			apb = pcm->next_buf;
 
-			nbytes = pcm->next_size;
-			pcm->next_size = 0;
-			pcm->next_offset = 0;
-			pcm->next_buf = NULL;
-
-			apb->nbytes = 0;
-			apb->curbyte = 0;
-			apb->flags = 0;
-			bufdesc.u.pBuffer = apb;
-			if (ioctl(pcm->fd, AUDIOIOC_ENQUEUEBUFFER, (unsigned long)&bufdesc) < 0) {
-				return oops(pcm, errno, "failed to enque buffer after read");
-			}
-		}
-
-	} else {
-		/* We got here because we dont have any pending buffers */
-		/* Wait for deque message from kernel */
-		if (pcm->draining) {
-			/* When we are in draining state, we will check for buffers already in the msg queue
-			   If there is no buffer on the queue, we return immediately */
-			clock_gettime(CLOCK_REALTIME, &st_time);
-			size = mq_timedreceive(pcm->mq, (FAR char *)&msg, sizeof(msg), &prio, &st_time);
-			if (size != sizeof(msg)) {
-				pcm->draining = 0;
-				pcm->next_size = 0;
-				pcm->next_offset = 0;
-				pcm->next_buf = NULL;
-				return oops(pcm, ENODATA, "no data available");
-			}
-		} else {
-			size = mq_receive(pcm->mq, (FAR char *)&msg, sizeof(msg), &prio);
-			if (size != sizeof(msg)) {
-				/* Interrupted by a signal? What to do? */
-				return oops(pcm, EINTR, "Interrupted while waiting for deque message from kernel");
-			}
-		}
-		if (msg.msgId == AUDIO_MSG_DEQUEUE) {
-			apb = (struct ap_buffer_s *)msg.u.pPtr;
-
-			if (nbytes < apb->nbytes) {
+			if (pending <= pcm->next_size) {
 				/* User wants less data than we have in buffer.
-				   Copy the requested amount of data and keep the buffer as pending buffer */
-				memcpy(data, apb->samp, nbytes);
+				   Copy the requested amount of data to user buffer and return */
+				memcpy((char*)data + offset, apb->samp + pcm->next_offset, pending);
+				pcm->next_size -= pending;
+				pcm->next_offset += pending;
 
-				pcm->next_buf = apb;
-				pcm->next_offset = nbytes;
-				pcm->next_size = apb->nbytes - nbytes;
+				nbytes = pending;
 			} else {
 				/* User wants more data than we have in buffer.
 				   Copy available data to user buffer, enqueue buffer and return */
-				memcpy(data, apb->samp, apb->nbytes);
-				nbytes = apb->nbytes;
+				memcpy((char*)data + offset, apb->samp + pcm->next_offset, pcm->next_size);
 
-				if (pcm->draining) {
-					/* Dont enque the buffer since we are draining and
-						the pcm has already been stopped */
-					return pcm_bytes_to_frames(pcm, nbytes);
-				}
+				nbytes = pcm->next_size;
+				pcm->next_size = 0;
+				pcm->next_offset = 0;
+				pcm->next_buf = NULL;
 
 				apb->nbytes = 0;
 				apb->curbyte = 0;
@@ -681,11 +639,69 @@ int pcm_readi(struct pcm *pcm, void *data, unsigned int frame_count)
 			}
 
 		} else {
-			return oops(pcm, EINTR, "Recieved unexpected msg (id = %d) while waiting for deque message from kernel", msg.msgId);
+			/* We got here because we dont have any pending buffers */
+			/* Wait for deque message from kernel */
+			if (pcm->draining) {
+				/* When we are in draining state, we will check for buffers already in the msg queue
+				   If there is no buffer on the queue, we return immediately */
+				clock_gettime(CLOCK_REALTIME, &st_time);
+				size = mq_timedreceive(pcm->mq, (FAR char *)&msg, sizeof(msg), &prio, &st_time);
+				if (size != sizeof(msg)) {
+					pcm->draining = 0;
+					pcm->next_size = 0;
+					pcm->next_offset = 0;
+					pcm->next_buf = NULL;
+					return pcm_frames_to_bytes(pcm, frame_count) - pending;
+				}
+			} else {
+				size = mq_receive(pcm->mq, (FAR char *)&msg, sizeof(msg), &prio);
+				if (size != sizeof(msg)) {
+					/* Interrupted by a signal? What to do? */
+					return oops(pcm, EINTR, "Interrupted while waiting for deque message from kernel");
+				}
+			}
+			if (msg.msgId == AUDIO_MSG_DEQUEUE) {
+				apb = (struct ap_buffer_s *)msg.u.pPtr;
+
+				if (pending <= apb->nbytes) {
+					/* User wants less data than we have in buffer.
+					   Copy the requested amount of data and keep the buffer as pending buffer */
+					memcpy((char*)data + offset, apb->samp, pending);
+
+					pcm->next_buf = apb;
+					pcm->next_offset = pending;
+					pcm->next_size = apb->nbytes - pending;
+
+					nbytes = pending;
+				} else {
+					/* User wants more data than we have in buffer.
+					   Copy available data to user buffer, enqueue buffer and return */
+					memcpy((char*)data + offset, apb->samp, apb->nbytes);
+					nbytes = apb->nbytes;
+
+					if (!pcm->draining) {
+						/* Dont enque the buffer since we are draining and
+						   the pcm has already been stopped */
+						apb->nbytes = 0;
+						apb->curbyte = 0;
+						apb->flags = 0;
+						bufdesc.u.pBuffer = apb;
+						if (ioctl(pcm->fd, AUDIOIOC_ENQUEUEBUFFER, (unsigned long)&bufdesc) < 0) {
+							return oops(pcm, errno, "failed to enque buffer after read");
+						}
+					}
+				}
+
+			} else {
+				return oops(pcm, EINTR, "Recieved unexpected msg (id = %d) while waiting for deque message from kernel", msg.msgId);
+			}
 		}
+
+		offset += nbytes;
+		pending -= nbytes;
 	}
 
-	return pcm_bytes_to_frames(pcm, nbytes);
+	return pcm_bytes_to_frames(pcm, pcm_frames_to_bytes(pcm, frame_count) - pending);
 }
 
 /** Writes audio samples to PCM.
@@ -1194,7 +1210,6 @@ int pcm_stop(struct pcm *pcm)
 	if (!pcm->running) {
 		return oops(pcm, EINVAL, "PCM already in stop state");
 	}
-
 #ifdef CONFIG_AUDIO_MULTI_SESSION
 	if (ioctl(pcm->fd, AUDIOIOC_STOP, (unsigned long)pcm->session) < 0)
 #else


### PR DESCRIPTION
Modify the readi and writei API to run in a loop and transfer "frame_count"
size of data as requested by user. This will remove the limitation of the API
to transfer only period_size bytes of data at a time. However, this change will
make both the API's block for a long time, depending on the size of data transfer
requested by the user.