### PR TITLE
fix coap parsing to process option boundary

### DIFF
--- a/external/wakaama/core/er-coap-13/er-coap-13.c
+++ b/external/wakaama/core/er-coap-13/er-coap-13.c
@@ -240,7 +240,7 @@ int coap_merge_multi_option(uint8_t **dst, size_t *dst_len, uint8_t *option, siz
 		*dst_len += option_len;
 	} else {
 		/* Option bytes exceeds boundary, cannot fit into destination */
-		if (option + option_len >= buffer_boundary) {
+		if (option + option_len > buffer_boundary) {
 			return -1;
 		}
 		/* dst is empty: set to option */
@@ -913,7 +913,7 @@ coap_status_t coap_parse_message(void *packet, coap_protocol_t protocol, uint8_t
 		PRINTF("OPTION %u (delta %u, len %u): ", option_number, option_delta, option_length);
 		SET_OPTION(coap_pkt, option_number);
 
-		if (current_option + option_length >= (uint8_t *)data + data_len) {
+		if (current_option + option_length > (uint8_t *)data + data_len) {
 			return NOT_ACCEPTABLE_4_06;
 		}
 		switch (option_number) {


### PR DESCRIPTION
er-coap parsing in wakaama does not handle option processing correctly, and generates false positives in parsing errors. This commit fixes the problem.