### PR TITLE
Remove unnessary CONFIG_PRINT_TASKNAME

### DIFF
--- a/os/arch/arm/src/armv7-m/up_assert.c
+++ b/os/arch/arm/src/armv7-m/up_assert.c
@@ -96,19 +96,6 @@
 #undef CONFIG_ARCH_USBDUMP
 #endif
 
-/* The following is just intended to keep some ugliness out of the mainline
- * code.  We are going to print the task name if:
- *
- *  CONFIG_TASK_NAME_SIZE > 0 &&    <-- The task has a name
- *  (defined(CONFIG_DEBUG)    ||    <-- And the debug is enabled (lldbg used)
- *   defined(CONFIG_ARCH_STACKDUMP) <-- Or lowsyslog() is used
- */
-
-#undef CONFIG_PRINT_TASKNAME
-#if CONFIG_TASK_NAME_SIZE > 0 && (defined(CONFIG_DEBUG) || defined(CONFIG_ARCH_STACKDUMP))
-#define CONFIG_PRINT_TASKNAME 1
-#endif
-
 /****************************************************************************
  * Private Data
  ****************************************************************************/
@@ -381,13 +368,13 @@ void dump_all_stack(void)
 
 void up_assert(const uint8_t *filename, int lineno)
 {
-#ifdef CONFIG_PRINT_TASKNAME
+#if CONFIG_TASK_NAME_SIZE > 0
 	struct tcb_s *rtcb = this_task();
 #endif
 
 	board_led_on(LED_ASSERTION);
 
-#ifdef CONFIG_PRINT_TASKNAME
+#if CONFIG_TASK_NAME_SIZE > 0
 	lldbg("Assertion failed at file:%s line: %d task: %s\n", filename, lineno, rtcb->name);
 #else
 	lldbg("Assertion failed at file:%s line: %d\n", filename, lineno);

--- a/os/arch/arm/src/armv7-r/arm_assert.c
+++ b/os/arch/arm/src/armv7-r/arm_assert.c
@@ -100,19 +100,6 @@
 #undef CONFIG_ARCH_USBDUMP
 #endif
 
-/* The following is just intended to keep some ugliness out of the mainline
- * code.  We are going to print the task name if:
- *
- *  CONFIG_TASK_NAME_SIZE > 0 &&    <-- The task has a name
- *  (defined(CONFIG_DEBUG)    ||    <-- And the debug is enabled (lldbg used)
- *   defined(CONFIG_ARCH_STACKDUMP) <-- Or lowsyslog() is used
- */
-
-#undef CONFIG_PRINT_TASKNAME
-#if CONFIG_TASK_NAME_SIZE > 0 && (defined(CONFIG_DEBUG) || defined(CONFIG_ARCH_STACKDUMP))
-#define CONFIG_PRINT_TASKNAME 1
-#endif
-
 #define FRAME_POINTER_ADDR __builtin_frame_address(0)
 
 /* Flag used to detect the whether upassert called or not */
@@ -341,7 +328,7 @@ static void up_taskdump(FAR struct tcb_s *tcb, FAR void *arg)
 {
 	/* Dump interesting properties of this task */
 
-#ifdef CONFIG_PRINT_TASKNAME
+#if CONFIG_TASK_NAME_SIZE > 0
 	lldbg("%s: PID=%d Stack Used=%lu of %lu\n", tcb->name, tcb->pid, (unsigned long)up_check_tcbstack(tcb), (unsigned long)tcb->adj_stack_size);
 #else
 	lldbg("PID: %d Stack Used=%lu of %lu\n", tcb->pid, (unsigned long)up_check_tcbstack(tcb), (unsigned long)tcb->adj_stack_size);
@@ -778,12 +765,12 @@ static void _up_assert(int errorcode)
 
 void up_assert(const uint8_t *filename, int lineno)
 {
-#ifdef CONFIG_PRINT_TASKNAME
+#if CONFIG_TASK_NAME_SIZE > 0
 	struct tcb_s *rtcb = this_task();
 #endif
 	board_autoled_on(LED_ASSERTION);
 
-#ifdef CONFIG_PRINT_TASKNAME
+#if CONFIG_TASK_NAME_SIZE > 0
 	lldbg("Assertion failed at file:%s line: %d task: %s\n", filename, lineno, rtcb->name);
 #else
 	lldbg("Assertion failed at file:%s line: %d\n", filename, lineno);


### PR DESCRIPTION
If CONFIG_ARCH_STACKDUMP is defined, CONFIG_DEBUG will be defined.
So " || defined(CONFIG_ARCH_STACKDUMP)" is not needed.
And if CONFIG_DEBUG is off, lldbg will be replaced with an empty line.
In conclusion, CONFIG_TASK_NAME_SIZE > 0 is enough.