### PR TITLE
parameterize the sta_connected user callback in wifi_manager

### DIFF
--- a/apps/examples/wifi_manager_sample/wm_test.c
+++ b/apps/examples/wifi_manager_sample/wm_test.c
@@ -70,7 +70,7 @@ int wm_signal_init(void);
 /*
  * callbacks
  */
-static void wm_sta_connected(void);
+static void wm_sta_connected(wifi_manager_result_e);
 static void wm_sta_disconnected(void);
 static void wm_softap_sta_join(void);
 static void wm_softap_sta_leave(void);
@@ -279,7 +279,7 @@ wm_signal_deinit(void)
 /*
  * Callback
  */
-void wm_sta_connected(void)
+void wm_sta_connected(wifi_manager_result_e res)
 {
 	printf(" T%d --> %s\n", getpid(), __FUNCTION__);
 	WM_TEST_SIGNAL;

--- a/framework/include/wifi_manager/wifi_manager.h
+++ b/framework/include/wifi_manager/wifi_manager.h
@@ -99,7 +99,7 @@ typedef struct wifi_manager_scan_info_s wifi_manager_scan_info_s;
  * @brief Include callback functions which are asynchronously called after Wi-Fi Manager APIs are called
  */
 typedef struct {
-	void (*sta_connected)(void);		// in station mode, connected to ap
+	void (*sta_connected)(wifi_manager_result_e);	// in station mode, connected to ap
 	void (*sta_disconnected)(void);		// in station mode, disconnected from ap
 	void (*softap_sta_joined)(void);	// in softap mode, a station joined
 	void (*softap_sta_left)(void);		// in softap mode, a station left

--- a/framework/src/wifi_manager/wifi_manager.c
+++ b/framework/src/wifi_manager/wifi_manager.c
@@ -827,11 +827,11 @@ void _handle_user_cb(_wifimgr_usr_cb_type_e evt, void *arg)
 	switch (evt) {
 	case CB_STA_CONNECTED:
 		nvdbg("call sta connect success event\n");
-		cbk->sta_connected();
+		cbk->sta_connected(WIFI_MANAGER_SUCCESS);
 		break;
 	case CB_STA_CONNECT_FAILED:
 		nvdbg("call sta connect fail event\n");
-		cbk->sta_connected();
+		cbk->sta_connected(WIFI_MANAGER_FAIL);
 		break;
 	case CB_STA_DISCONNECTED:
 		nvdbg("call sta disconnect event\n");


### PR DESCRIPTION
currently, sta_connected user callback in wifi_manager does not distinguish between success and fail event for station join. By parameterizing the callback, we make it possible to distinguish.