### PR TITLE
Fix build warning at up_assert

### DIFF
--- a/os/arch/arm/src/armv7-m/up_assert.c
+++ b/os/arch/arm/src/armv7-m/up_assert.c
@@ -368,14 +368,10 @@ void dump_all_stack(void)
 
 void up_assert(const uint8_t *filename, int lineno)
 {
-#if CONFIG_TASK_NAME_SIZE > 0
-	struct tcb_s *rtcb = this_task();
-#endif
-
 	board_led_on(LED_ASSERTION);
 
 #if CONFIG_TASK_NAME_SIZE > 0
-	lldbg("Assertion failed at file:%s line: %d task: %s\n", filename, lineno, rtcb->name);
+	lldbg("Assertion failed at file:%s line: %d task: %s\n", filename, lineno, this_task()->name);
 #else
 	lldbg("Assertion failed at file:%s line: %d\n", filename, lineno);
 #endif

--- a/os/arch/arm/src/armv7-r/arm_assert.c
+++ b/os/arch/arm/src/armv7-r/arm_assert.c
@@ -765,13 +765,10 @@ static void _up_assert(int errorcode)
 
 void up_assert(const uint8_t *filename, int lineno)
 {
-#if CONFIG_TASK_NAME_SIZE > 0
-	struct tcb_s *rtcb = this_task();
-#endif
 	board_autoled_on(LED_ASSERTION);
 
 #if CONFIG_TASK_NAME_SIZE > 0
-	lldbg("Assertion failed at file:%s line: %d task: %s\n", filename, lineno, rtcb->name);
+	lldbg("Assertion failed at file:%s line: %d task: %s\n", filename, lineno, this_task()->name);
 #else
 	lldbg("Assertion failed at file:%s line: %d\n", filename, lineno);
 #endif


### PR DESCRIPTION
While removing CONFIG_PRINT_TASKNAME, some conditional statement is missed.
This commit takes into account the situation where CONFIG_TASK_NAME > 0 and CONFIG_DEBUG_ERROR is not defined

Please refer this commit : 907e0ca60d78503611e2fb063a16f9f4b8e2215f