### PR TITLE
framework/st_things: Fix get filepath logic

### DIFF
--- a/apps/examples/st_things/contents/sampleDevice.json
+++ b/apps/examples/st_things/contents/sampleDevice.json
@@ -109,10 +109,10 @@
             "frequency": 1
         },
         "filePath":{
-            "svrdb": "/mnt/artikserversecured.dat",
-            "provisioning": "/mnt/provisioning.dat",
-            "certificate": "/rom/certificate",
-            "privateKey": "/rom/privatekey"
+            "svrdb": "artikserversecured.dat",
+            "provisioning": "provisioning.dat",
+            "certificate": "certificate",
+            "privateKey": "privatekey"
         }
     }
 }

--- a/framework/src/st_things/things_stack/src/common/framework/things_data_manager.c
+++ b/framework/src/st_things/things_stack/src/common/framework/things_data_manager.c
@@ -1268,9 +1268,9 @@ static int parse_things_info_json(const char *filename)
 					return 0;
 				}
 
-				memset(g_svrdb_file_path, 0, (size_t) MAX_FILE_PATH_LENGTH + 1);
-				memset(g_certificate_file_path, 0, (size_t) MAX_FILE_PATH_LENGTH + 1);
-				memset(g_private_key_file_path, 0, (size_t) MAX_FILE_PATH_LENGTH + 1);
+				memset(g_svrdb_file_path, 0, (size_t)MAX_FILE_PATH_LENGTH + 1);
+				memset(g_certificate_file_path, 0, (size_t)MAX_FILE_PATH_LENGTH + 1);
+				memset(g_private_key_file_path, 0, (size_t)MAX_FILE_PATH_LENGTH + 1);
 
 				if (strncmp(svrdb->valuestring, PATH_MNT, sizeof(PATH_MNT)) == 0) {
 					if (strlen(svrdb->valuestring) > (size_t)MAX_FILE_PATH_LENGTH) {


### PR DESCRIPTION
1. Fix get filepath logic
Flexible logic to get file path for user authentication from json in Data Manager
The path to the file for user authentication may change during development, so change it flexibly to work even if it changes.

2. Fix coding rule
Modification of coding rule violation

3. Modify Json file
Modify the json file by agreement