### PR TITLE
fix coap_show_pdu2 signature in libcoap

### DIFF
--- a/external/include/protocols/libcoap/debug.h
+++ b/external/include/protocols/libcoap/debug.h
@@ -86,7 +86,7 @@ size_t coap_print_addr(const struct coap_address_t *, unsigned char *, size_t);
 #define warn(...)
 
 #define coap_show_pdu(x)
-#define coap_show_pdu2(x)
+#define coap_show_pdu2(...)
 #define coap_print_addr(...)
 
 #endif


### PR DESCRIPTION
fix coap_show_pdu2 signature in libcoap. Currently when CONFIG_NETUTILS_LIBCOAP_DEBUG is disabled, coap_show_pdu2 shows wrong signature. This commit fixes the problem.