### PR TITLE
includes : Fix spi header guard

### DIFF
--- a/os/include/tinyara/spi/spi.h
+++ b/os/include/tinyara/spi/spi.h
@@ -49,8 +49,8 @@
  *
  ****************************************************************************/
 
-#ifndef __INCLUDE_SPI_SPI_H
-#define __INCLUDE_SPI_SPI_H
+#ifndef __INCLUDE_TINYARA_SPI_SPI_H
+#define __INCLUDE_TINYARA_SPI_SPI_H
 
 /****************************************************************************
  * Included Files
@@ -475,4 +475,4 @@ FAR struct spi_dev_s *up_spiinitialize(int port);
 #if defined(__cplusplus)
 }
 #endif
-#endif							/* __INCLUDE_SPI_SPI_H */
+#endif					/* __INCLUDE_TINYARA_SPI_SPI_H */

--- a/os/include/tinyara/spi/spi_bitbang.h
+++ b/os/include/tinyara/spi/spi_bitbang.h
@@ -49,8 +49,8 @@
  *
  ****************************************************************************/
 
-#ifndef __INCLUDE_SPI_SPI_BITBANG_H
-#define __INCLUDE_SPI_SPI_BITBANG_H
+#ifndef __INCLUDE_TINYARA_SPI_SPI_BITBANG_H
+#define __INCLUDE_TINYARA_SPI_SPI_BITBANG_H
 
 /****************************************************************************
  * Included Files
@@ -185,4 +185,4 @@ FAR struct spi_dev_s *spi_create_bitbang(FAR const struct spi_bitbang_ops_s *low
 
 #endif							/* __ASSEMBLY__ */
 #endif							/* CONFIG_SPI_BITBANG */
-#endif							/* __INCLUDE_SPI_SPI_BITBANG_H */
+#endif				/* __INCLUDE_TINYARA_SPI_SPI_BITBANG_H */


### PR DESCRIPTION
This patch fix's the header guard in spi header files.

Signed-off-by: Manohara HK <manohara.hk@samsung.com>