### PR TITLE
Audio: Fix I2S issue during pcm_stop

### DIFF
--- a/os/arch/arm/src/s5j/s5j_i2s.c
+++ b/os/arch/arm/src/s5j/s5j_i2s.c
@@ -171,11 +171,11 @@
 struct s5j_buffer_s {
 	struct s5j_buffer_s *flink;	/* Supports a singly linked list */
 	i2s_callback_t callback;	/* Function to call when the transfer completes */
-	dma_task *dmatask;		/* DMA transfer task structure */
-	uint32_t timeout;		/* The timeout value to use with DMA transfers */
-	void *arg;			/* The argument to be returned with the callback */
+	dma_task *dmatask;			/* DMA transfer task structure */
+	uint32_t timeout;			/* The timeout value to use with DMA transfers */
+	void *arg;					/* The argument to be returned with the callback */
 	struct ap_buffer_s *apb;	/* The audio buffer */
-	int result;			/* The result of the transfer */
+	int result;					/* The result of the transfer */
 };
 
 /* This structure describes the state of one receiver or transmitter transport */
@@ -192,7 +192,7 @@ struct s5j_transport_s {
 /* The state of the one I2S peripheral */
 
 struct s5j_i2s_s {
-	struct i2s_dev_s dev;			/* Externally visible I2S interface */
+	struct i2s_dev_s dev;		/* Externally visible I2S interface */
 	uintptr_t base;				/* I2S controller register base address */
 	int isr_num;				/* isr number */
 	xcpt_t isr_handler;			/* irs handler */
@@ -200,23 +200,23 @@ struct s5j_i2s_s {
 	sem_t exclsem;				/* Assures mutually exclusive acess to I2S */
 	uint8_t datalen;			/* Data width (8, 16, or 32) */
 	uint8_t rx_datalen;			/* Data width (8, 16, or 32) */
-	uint8_t txp_datalen;			/* Data width (8, 16, or 32) */
-	uint8_t txs_datalen;			/* Data width (8, 16, or 32) */
+	uint8_t txp_datalen;		/* Data width (8, 16, or 32) */
+	uint8_t txs_datalen;		/* Data width (8, 16, or 32) */
 
-	uint8_t rxenab:1;			/* True: RX transfers enabled */
-	uint8_t txpenab:1;			/* True: TX primary transfers enabled */
-	uint8_t txsenab:1;			/* True: TX secondary transfers enabled */
+	uint8_t rxenab: 1;			/* True: RX transfers enabled */
+	uint8_t txpenab: 1;			/* True: TX primary transfers enabled */
+	uint8_t txsenab: 1;			/* True: TX secondary transfers enabled */
 
-	uint32_t samplerate;			/* Not actually needed in slave mode */
+	uint32_t samplerate;		/* Not actually needed in slave mode */
 
 #ifdef I2S_HAVE_RX
-	struct s5j_transport_s rx;		/* RX transport state */
+	struct s5j_transport_s rx;	/* RX transport state */
 #endif
 #ifdef I2S_HAVE_TX_P
-	struct s5j_transport_s txp;		/* TX primary transport state */
+	struct s5j_transport_s txp;	/* TX primary transport state */
 #endif
 #ifdef I2S_HAVE_TX_S
-	struct s5j_transport_s txs;		/* TX secodary transport state */
+	struct s5j_transport_s txs;	/* TX secodary transport state */
 #endif
 
 	/* Pre-allocated pool of buffer containers */
@@ -293,6 +293,8 @@ static uint32_t i2s_samplerate(struct i2s_dev_s *dev, uint32_t rate);
 static uint32_t i2s_txdatawidth(struct i2s_dev_s *dev, int bits);
 static int i2s_send(struct i2s_dev_s *dev, struct ap_buffer_s *apb, i2s_callback_t callback, void *arg, uint32_t timeout);
 
+static int i2s_stop(struct i2s_dev_s *dev);
+
 /* Initialization */
 
 #ifdef I2S_HAVE_RX
@@ -324,6 +326,9 @@ static const struct i2s_ops_s g_i2sops = {
 	.i2s_txsamplerate = i2s_samplerate,
 	.i2s_txdatawidth = i2s_txdatawidth,
 	.i2s_send = i2s_send,
+
+	/* Generic stio method */
+	.i2s_stop = i2s_stop,
 };
 
 static struct s5j_i2s_s *g_i2sdevice[S5J_I2S_MAXPORTS];
@@ -1575,6 +1580,74 @@ static uint32_t i2s_txdatawidth(struct i2s_dev_s *dev, int bits)
 
 	return 0;
 }
+
+static int i2s_stop(struct i2s_dev_s *dev)
+{
+	struct s5j_i2s_s *priv = (struct s5j_i2s_s *)dev;
+	irqstate_t flags;
+	struct s5j_buffer_s *bfcontainer;
+
+	DEBUGASSERT(priv);
+
+#ifdef I2S_HAVE_TX_P
+	while (sq_peek(&priv->txp.pend) != NULL) {
+		flags = irqsave();
+		bfcontainer = (struct s5j_buffer_s *)sq_remfirst(&priv->txp.pend);
+		irqrestore(flags);
+		apb_free(bfcontainer->apb);
+		i2s_buf_tx_free(priv, bfcontainer);
+	}
+
+	s5j_dmastop(priv->txp.dma);
+
+        while (sq_peek(&priv->txp.act) != NULL) {
+                flags = irqsave();
+                bfcontainer = (struct s5j_buffer_s *)sq_remfirst(&priv->txp.act);
+                irqrestore(flags);
+                apb_free(bfcontainer->apb);
+                i2s_buf_tx_free(priv, bfcontainer);
+        }
+
+        while (sq_peek(&priv->txp.done) != NULL) {
+                flags = irqsave();
+                bfcontainer = (struct s5j_buffer_s *)sq_remfirst(&priv->txp.done);
+                irqrestore(flags);
+                apb_free(bfcontainer->apb);
+                i2s_buf_tx_free(priv, bfcontainer);
+        }
+#endif
+
+#ifdef I2S_HAVE_RX
+	while (sq_peek(&priv->rx.pend) != NULL) {
+		flags = irqsave();
+		bfcontainer = (struct s5j_buffer_s *)sq_remfirst(&priv->rx.pend);
+		irqrestore(flags);
+		apb_free(bfcontainer->apb);
+		i2s_buf_rx_free(priv, bfcontainer);
+	}
+
+	s5j_dmastop(priv->rx.dma);
+
+        while (sq_peek(&priv->rx.act) != NULL) {
+                flags = irqsave();
+                bfcontainer = (struct s5j_buffer_s *)sq_remfirst(&priv->rx.act);
+                irqrestore(flags);
+                apb_free(bfcontainer->apb);
+                i2s_buf_rx_free(priv, bfcontainer);
+        }
+
+        while (sq_peek(&priv->rx.done) != NULL) {
+                flags = irqsave();
+                bfcontainer = (struct s5j_buffer_s *)sq_remfirst(&priv->rx.done);
+                irqrestore(flags);
+                apb_free(bfcontainer->apb);
+                i2s_buf_rx_free(priv, bfcontainer);
+        }
+#endif
+
+	return 0;
+}
+
 
 /****************************************************************************
  * Name: i2s_send

--- a/os/drivers/audio/alc5658.c
+++ b/os/drivers/audio/alc5658.c
@@ -777,6 +777,15 @@ static int alc5658_stop(FAR struct audio_lowerhalf_s *dev)
 	/* Need to run the stop script here */
 	alc5658_exec_i2c_script(priv, codec_stop_script, sizeof(codec_stop_script) / sizeof(t_codec_init_script_entry));
 
+
+	I2S_STOP(priv->i2s);
+
+	dq_entry_t *tmp;
+        for (tmp = (dq_entry_t *)dq_peek(&priv->pendq); tmp; tmp = dq_next(tmp)) {
+		dq_rem(tmp, &priv->pendq);
+		apb_free((struct ap_buffer_s *)tmp);
+        }
+
 	alc5658_takesem(&priv->devsem);
 	priv->running = false;
 	alc5658_givesem(&priv->devsem);

--- a/os/include/tinyara/audio/i2s.h
+++ b/os/include/tinyara/audio/i2s.h
@@ -213,6 +213,8 @@
 
 #define I2S_SEND(d, b, c, a, t) ((d)->ops->i2s_send(d, b, c, a, t))
 
+#define I2S_STOP(d)		((d)->ops->i2s_stop(d))
+
 /****************************************************************************
  * Public Types
  ****************************************************************************/
@@ -235,6 +237,9 @@ struct i2s_ops_s {
 	CODE uint32_t(*i2s_txsamplerate)(FAR struct i2s_dev_s *dev, uint32_t rate);
 	CODE uint32_t(*i2s_txdatawidth)(FAR struct i2s_dev_s *dev, int bits);
 	CODE int (*i2s_send)(FAR struct i2s_dev_s *dev, FAR struct ap_buffer_s *apb, i2s_callback_t callback, FAR void *arg, uint32_t timeout);
+
+	/* Generic stop method */
+	CODE int (*i2s_stop)(FAR struct i2s_dev_s *dev);
 };
 
 /* I2S private data.  This structure only defines the initial fields of the


### PR DESCRIPTION
When the codec driver stop API is called, any I2S transfers in progress
will be stopped and the I2S queues will be cleared. The codec buffer queues
are also cleared and all references to the apb are freed.