### PR TITLE
docs : add SPI device driver usage

### DIFF
--- a/docs/HowToUsePeripheral.md
+++ b/docs/HowToUsePeripheral.md
@@ -127,6 +127,121 @@ static struct up_dev_s g_uart0priv = {
 ```
 
 ## SPI
+All structures and function prototypes to be implemented by the low-level  
+SPI drivers are provided in the header file **[spi.h](../os/include/tinyara/spi/spi.h)**
+under *os/include/tinyara/spi* folder.
+
+### SPI device driver initialization
+Each SPI device driver must implement the definitions of below prototypes for  
+SPI device initialization
+```
+FAR struct spi_dev_s *up_spiinitialize(int port);
+```
+
+Example implementation is present in **[s5j_spi.c](../os/arch/arm/src/s5j/s5j_spi.c)**
+under *os/arch/arm/src/s5j* folder.
+```
+struct spi_dev_s *up_spiinitialize(int port)
+{
+	FAR struct s5j_spidev_s *priv = NULL;
+
+	if (port < 0 || port >= SPI_PORT_MAX) {
+		return NULL;
+	}
+
+	switch (port) {
+	case 0:
+		priv = &g_spi0dev;
+		break;
+
+	...
+
+	}
+
+	...
+
+	return (struct spi_dev_s *)priv;
+}
+```
+
+Low level(hardware-specific) SPI device driver must create an instace of  
+*struct spi_dev_s* and returned to higher level device driver as shown above.  
+Also the SPI driver must create an instance of *struct spi_ops_s* and  
+hook it to the *ops* member of *struct spi_dev_s* instance
+```
+struct spi_dev_s {
+	FAR const struct spi_ops_s *ops;
+};
+
+struct spi_ops_s {
+#ifndef CONFIG_SPI_OWNBUS
+	int (*lock)(FAR struct spi_dev_s *dev, bool lock);
+#endif
+	void (*select)(FAR struct spi_dev_s *dev, enum spi_dev_e devid, bool selected);
+	uint32_t (*setfrequency)(FAR struct spi_dev_s *dev, uint32_t frequency);
+	void (*setmode)(FAR struct spi_dev_s *dev, enum spi_mode_e mode);
+	void (*setbits)(FAR struct spi_dev_s *dev, int nbits);
+	uint8_t (*status)(FAR struct spi_dev_s *dev, enum spi_dev_e devid);
+#ifdef CONFIG_SPI_CMDDATA
+	int (*cmddata)(FAR struct spi_dev_s *dev, enum spi_dev_e devid, bool cmd);
+#endif
+	uint16_t (*send)(FAR struct spi_dev_s *dev, uint16_t wd);
+#ifdef CONFIG_SPI_EXCHANGE
+	void (*exchange)(FAR struct spi_dev_s *dev, FAR const void *txbuffer, FAR void *rxbuffer, size_t nwords);
+#else
+	void (*sndblock)(FAR struct spi_dev_s *dev, FAR const void *buffer, size_t nwords);
+	void (*recvblock)(FAR struct spi_dev_s *dev, FAR void *buffer, size_t nwords);
+#endif
+	int (*registercallback)(FAR struct spi_dev_s *dev, spi_mediachange_t callback, void *arg);
+};
+
+```
+
+The above structure *struct spi_ops_s* defines a list of function pointers to be  
+implemented by the low level SPI device driver.
+
+Example implementation is present in **[s5j_spi.c](../os/arch/arm/src/s5j/s5j_spi.c)**
+under *os/arch/arm/src/s5j* folder.
+```
+static const struct spi_ops_s g_spiops = {
+#ifndef CONFIG_SPI_OWNBUS
+	.lock = spi_lock,
+#endif
+	.select = spi_select,
+	.setfrequency = spi_setfrequency,
+	.setmode = (void *)spi_setmode,
+	.setbits = (void *)spi_setbits,
+	.status = 0,
+#ifdef CONFIG_SPI_CMDDATA
+	.cmddata = 0,
+#endif
+	.send = spi_send,
+#ifdef CONFIG_SPI_EXCHANGE
+	.exchange = spi_exchange,
+#else
+	.sndblock = spi_sndblock,
+	.recvblock = spi_recvblock,
+#endif
+	.registercallback = 0,
+};
+
+static int spi_lock(struct spi_dev_s *dev, bool lock)
+{
+	FAR struct s5j_spidev_s *priv = (FAR struct s5j_spidev_s *)dev;
+
+        ...
+
+	return OK;
+}
+
+static void spi_select(struct spi_dev_s *dev, enum spi_dev_e devid, bool selected)
+{
+	FAR struct s5j_spidev_s *priv = (FAR struct s5j_spidev_s *)dev;
+
+	...
+
+}
+```
 
 ## I2C
 


### PR DESCRIPTION
This patch updates SPI driver section in How to Use Peripheral
document.
It describes the low-level SPI device driver implementation
details with examples.

Signed-off-by: Manohara HK <manohara.hk@samsung.com>