### PR TITLE
Codecoverage: add corner cases for semaphore TC's

### DIFF
--- a/apps/examples/testcase/le_tc/kernel/tc_libc_semaphore.c
+++ b/apps/examples/testcase/le_tc/kernel/tc_libc_semaphore.c
@@ -30,8 +30,8 @@
 #include "tc_internal.h"
 
 #define SEM_VALUE SEM_VALUE_MAX
-#define PSHARED 0
-
+#define PSHARED			0
+#define SEM_PRIO_DEFAULT	3
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
@@ -140,6 +140,49 @@ static void tc_libc_semaphore_sem_getprotocol(void)
 	return;
 }
 
+#ifndef CONFIG_PRIORITY_INHERITANCE
+/**
+ * @fn                   :tc_libc_semaphore_sem_setprotocol
+ * @brief                :this tc test sem_setprotocol function
+ * @Scenario             :Set the value of the semaphore protocol attribute.
+ * API's covered         :sem_init, sem_setprotocol
+ * Preconditions         :NA
+ * Postconditions        :NA
+ * @return               :total_pass on success.
+ */
+static void tc_libc_semaphore_sem_setprotocol(void)
+{
+	sem_t sem;
+	unsigned int value = SEM_VALUE;
+	int protocol;
+	int ret_chk;
+
+	ret_chk = sem_init(&sem, PSHARED, value);
+	TC_ASSERT_EQ("sem_init", ret_chk, OK);
+
+	protocol = SEM_PRIO_NONE;
+	ret_chk = sem_setprotocol(&sem, protocol);
+	TC_ASSERT_EQ("sem_setprotocol", ret_chk, OK);
+
+	protocol = SEM_PRIO_INHERIT;
+	ret_chk = sem_setprotocol(&sem, protocol);
+	TC_ASSERT_EQ("sem_setprotocol", ret_chk, ERROR);
+	TC_ASSERT_EQ("sem_setprotocol", errno, ENOSYS);
+
+	protocol = SEM_PRIO_DEFAULT;
+	ret_chk = sem_setprotocol(&sem, protocol);
+	TC_ASSERT_EQ("sem_setprotocol", ret_chk, ERROR);
+	TC_ASSERT_EQ("sem_setprotocol", errno, EINVAL);
+
+	ret_chk = sem_destroy(&sem);
+	TC_ASSERT_EQ("sem_destroy", ret_chk, OK);
+
+	TC_SUCCESS_RESULT();
+
+	return;
+}
+#endif
+
 /****************************************************************************
  * Name: libc_semaphore
  ****************************************************************************/
@@ -149,6 +192,9 @@ int libc_semaphore_main(void)
 	tc_libc_semaphore_sem_getvalue();
 	tc_libc_semaphore_sem_getprotocol();
 	tc_libc_semaphore_sem_init();
+#ifndef CONFIG_PRIORITY_INHERITANCE
+	tc_libc_semaphore_sem_setprotocol();
+#endif
 
 	return 0;
 }

--- a/apps/examples/testcase/le_tc/kernel/tc_semaphore.c
+++ b/apps/examples/testcase/le_tc/kernel/tc_semaphore.c
@@ -25,9 +25,10 @@
 #include <sys/types.h>
 #include "tc_internal.h"
 
-#define PSHARED     0
-#define SEC_2       2
-#define LOOP_CNT    5
+#define PSHARED			0
+#define SEC_2			2
+#define LOOP_CNT		5
+#define SEM_PRIO_DEFAULT	3
 
 static sem_t g_empty;
 static sem_t g_full;
@@ -352,6 +353,101 @@ static void tc_semaphore_sem_destroy(void)
 	TC_SUCCESS_RESULT();
 }
 
+#ifdef CONFIG_PRIORITY_INHERITANCE
+/**
+* @fn                   :tc_semaphore_sem_setprotocol
+* @brief                :Set semaphore protocol attribute
+* @scenario             :if sem protocol is SEM_PRIO_NONE/SEM_PRIO_INHERIT, it returns OK else it returns ERROR
+* API's covered         :sem_setprotocol
+* Preconditions         :none
+* Postconditions        :none
+* @return               :void
+*/
+static void tc_semaphore_sem_setprotocol(void)
+{
+	sem_t sem;
+	int ret_chk;
+
+	ret_chk = sem_init(&sem, PSHARED, 1);
+	TC_ASSERT_EQ("sem_init", ret_chk, OK);
+
+	ret_chk = sem_setprotocol(&sem, SEM_PRIO_PROTECT);
+	TC_ASSERT_EQ("sem_setprotocol", ret_chk, ERROR);
+	TC_ASSERT_EQ("sem_setprotocol", errno, ENOSYS);
+
+	ret_chk = sem_setprotocol(&sem, SEM_PRIO_DEFAULT);
+	TC_ASSERT_EQ("sem_setprotocol", ret_chk, ERROR);
+	TC_ASSERT_EQ("sem_setprotocol", errno, EINVAL);
+
+	ret_chk = sem_destroy(&sem);
+	TC_ASSERT_EQ("sem_destroy", ret_chk, OK);
+	TC_ASSERT_EQ("sem_destroy", sem.semcount, 1);
+
+	TC_SUCCESS_RESULT();
+}
+#endif
+
+/**
+* @fn                   :tc_semaphore_sem_tickwait
+* @brief                :lighter weight version of sem_timedwait() - will lock the semaphore referenced by sem as in the sem_wait() function
+* @scenario             :if parameters are invalid, sem_timedwait returns ERROR
+*                        else, it returns OK
+* API's covered         :sem_tickwait
+* Preconditions         :none
+* Postconditions        :none
+* @return               :void
+*/
+static void tc_semaphore_sem_tickwait(void)
+{
+	struct timespec abstime;
+	struct timespec curtime;
+	sem_t sem;
+	int ret_chk;
+
+	/* init sem count to 1 */
+
+	ret_chk = sem_init(&sem, PSHARED, 1);
+	TC_ASSERT_EQ("sem_init", ret_chk, OK);
+
+	/* success to get sem case test */
+
+	ret_chk = clock_gettime(CLOCK_REALTIME, &abstime);
+	TC_ASSERT_EQ("clock_gettime", ret_chk, OK);
+
+	abstime.tv_sec = abstime.tv_sec + SEC_2;
+	abstime.tv_nsec = 0;
+
+	ret_chk = sem_tickwait(&sem, &abstime, 0);
+	TC_ASSERT_EQ("sem_tickwait", ret_chk, OK);
+
+	ret_chk = clock_gettime(CLOCK_REALTIME, &curtime);
+	TC_ASSERT_EQ("clock_gettime", ret_chk, OK);
+	TC_ASSERT_NEQ("sem_tickwait", abstime.tv_sec, curtime.tv_sec);
+
+	ret_chk = sem_post(&sem);
+	TC_ASSERT_EQ("sem_post", ret_chk, OK);
+
+	ret_chk = sem_destroy(&sem);
+	TC_ASSERT_EQ("sem_destroy", ret_chk, OK);
+
+	/* init sem count to 0 */
+
+	ret_chk = sem_init(&sem, PSHARED, 0);
+	TC_ASSERT_EQ("sem_init", ret_chk, OK);
+
+	/* expired time test */
+
+	ret_chk = clock_gettime(CLOCK_REALTIME, &abstime);
+	TC_ASSERT_EQ("clock_gettime", ret_chk, OK);
+
+	ret_chk = sem_tickwait(&sem, &abstime, 0);
+	TC_ASSERT_EQ("sem_tickwait", ret_chk, ERROR);
+
+	ret_chk = sem_destroy(&sem);
+	TC_ASSERT_EQ("sem_destroy", ret_chk, OK);
+
+	TC_SUCCESS_RESULT();
+}
 /****************************************************************************
  * Name: semaphore
  ****************************************************************************/
@@ -360,6 +456,10 @@ int semaphore_main(void)
 {
 	tc_semaphore_sem_destroy();
 	tc_semaphore_sem_post_wait();
+#ifdef CONFIG_PRIORITY_INHERITANCE
+	tc_semaphore_sem_setprotocol();
+#endif
+	tc_semaphore_sem_tickwait();
 	tc_semaphore_sem_trywait();
 	tc_semaphore_sem_timedwait();
 


### PR DESCRIPTION
This patch adds left over cases for API's:

kernel/semaphore:
sem_setprotocol()
sem_tickwait()

libc/semaphore:
sem_setprotocol()