### PR TITLE
Support for symbol name display inside callStack

### DIFF
--- a/os/arch/arm/src/armv7-r/arm_assert.c
+++ b/os/arch/arm/src/armv7-r/arm_assert.c
@@ -91,6 +91,11 @@
 #include "mpu.h"
 #endif
 
+#if defined(CONFIG_FS_ROMFS) && defined(CONFIG_FRAME_POINTER)
+#include <stdio.h>
+bool abort_mode = false;
+#endif
+
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
@@ -163,6 +168,10 @@ struct stackframe {
 	uint32_t framePointer;		// R11
 };
 
+/****************************************************************************
+ * Name: is_text_address
+ ****************************************************************************/
+
 static int is_text_address(unsigned long programCounter)
 {
 
@@ -189,6 +198,101 @@ static int is_text_address(unsigned long programCounter)
 }
 
 #define MEM_READ(x) (*(uint32_t volatile*)(x))
+
+/****************************************************************************
+ * Name: get_symbol
+ * Below API works if there is existance of System.map file in rom fs
+ ****************************************************************************/
+#ifdef CONFIG_FS_ROMFS
+void get_symbol(unsigned long search_addr, char *buffer)
+{
+	FILE *pFile;
+	unsigned long sym_offset;
+	unsigned long total_size;
+	unsigned long addr;
+	unsigned long next_addr;
+	int first = 0;
+	int last = 0;
+	int mid;
+	char line[128];
+	char data[6][128];
+	char c;
+	int n;
+	int i;
+	int j;
+	int k;
+
+	pFile = fopen("/rom/System.map", "r");
+
+	/* Check if file exists */
+	if (pFile == NULL) {
+		lldbg("Could not open file: /rom/System.map\n");
+		return;
+	}
+	// obtain file size:
+	fseek(pFile, 0, SEEK_END);
+	last = ftell(pFile);
+
+	rewind(pFile);
+	mid = (first + last) / 2;
+	while (first <= last) {
+		fseek(pFile, mid, SEEK_SET);
+
+		// Extract characters from file and store in character c
+		for (c = getc(pFile); c != '\n'; c = getc(pFile)) {
+		}
+		n = 0;
+		// Read 2 lines and Split the string as words
+		for (k = 0; k < 2; k++) {
+			fgets(line, 128, pFile);
+			i = 0;
+			j = 0;
+			while (line[i] != '\0') {
+				if (line[i] != ' ') {
+					data[n][j++] = line[i];
+				} else {
+					data[n][j++] = '\0';//insert NULL
+					n++;
+					j = 0;
+				}
+				i++;
+				if (line[i] == '\0') {
+					data[n][j++] = '\0';//insert NULL
+					n++;
+					j = 0;
+				}
+			}
+		}
+		addr = strtoul(data[0], NULL, 16);
+		next_addr = strtoul(data[3], NULL, 16);
+		if (search_addr >= addr && search_addr < next_addr) {
+			sprintf(buffer, "%s", data[2]);
+			sym_offset = search_addr - addr;
+			total_size = next_addr - addr;
+			sprintf(buffer + strlen(buffer)-1, "+0x%lx/0x%lx", sym_offset, total_size);
+			//lldbg("Got it buffer is : %s\n", buffer);
+			break;
+		}
+		if (search_addr < addr) {
+			last = mid - 1;
+		} else {
+			first = mid + 1;
+		}
+
+		mid = (first + last ) / 2;
+	}
+	if (first > last) {
+		lldbg("symbol is not found in system map\n");
+		buffer = "";
+	}
+
+	fclose(pFile);
+}
+#endif						/* End of CONFIG_FS_ROMFS */
+
+/****************************************************************************
+ * Name: unwind_frame_with_fp
+ ****************************************************************************/
 
 static int unwind_frame_with_fp(struct stackframe *stack_frame, uint32_t stacksize)
 {
@@ -217,6 +321,10 @@ static int unwind_frame_with_fp(struct stackframe *stack_frame, uint32_t stacksi
 	return 0;
 }
 
+/****************************************************************************
+ * Name: unwind_backtrace_with_fp
+ ****************************************************************************/
+
 static void unwind_backtrace_with_fp(arm_regs_t *regs, struct tcb_s *task)
 {
 	uint32_t ustacksize;
@@ -224,7 +332,7 @@ static void unwind_backtrace_with_fp(arm_regs_t *regs, struct tcb_s *task)
 	struct tcb_s *current = this_task();
 
 #if CONFIG_TASK_NAME_SIZE > 0
-	lldbg("Task(pid): %s(%d), TaskAddr: [0x%p] and [Current : %s]\n", task ? task->name : "No Task", task->pid, task, current ? current->name : "No Task");
+	lldbg("Task: [%s], Pid: [%d], TaskAddr: [0x%p] and [Current : %s]\n", task ? task->name : "No Task", task->pid, task, current ? current->name : "No Task");
 #else
 	lldbg("pid: %d, TaskAddr: [0x%p] \n", task->pid, task);
 #endif
@@ -240,7 +348,7 @@ static void unwind_backtrace_with_fp(arm_regs_t *regs, struct tcb_s *task)
 		stack_frame.programCounter = (uint32_t)unwind_backtrace_with_fp;
 		stack_frame.stackPointer = up_getsp();
 		stack_frame.framePointer = (uint32_t)FRAME_POINTER_ADDR;
-	} else if (regs->reg[REG_R15] && regs->reg[REG_R14]) {
+	} else if (regs && regs->reg[REG_R15] && regs->reg[REG_R14] && task == current) {
 		lldbg("Registers are Valid, We may be either Interrupt context/exception context\n");
 		stack_frame.programCounter = regs->reg[REG_R15];	/* pc */
 		stack_frame.stackPointer = regs->reg[REG_R13];	/* sp */
@@ -265,16 +373,24 @@ static void unwind_backtrace_with_fp(arm_regs_t *regs, struct tcb_s *task)
 		uint32_t current_addr = stack_frame.programCounter;
 		if (unwind_frame_with_fp(&stack_frame, ustacksize) >= 0) {
 			/* Print the call stack address */
+#ifdef CONFIG_FS_ROMFS
+			char buffer[64];
+			get_symbol(current_addr, buffer);
+			lldbg("[<0x%p>] %s\n", (void *)current_addr, buffer);
+#else
 			lldbg("[<0x%p>]\n", (void *)current_addr);
+#endif
 		} else {
 			/* End of stack */
 			break;
 		}
 	}
 }
-#endif
 
-static uint32_t task_counter = 0;
+/****************************************************************************
+ * Name: print_callstack
+ ****************************************************************************/
+
 static void print_callstack(FAR struct tcb_s *tcb, FAR void *arg)
 {
 	uint32_t regs;
@@ -285,28 +401,32 @@ static void print_callstack(FAR struct tcb_s *tcb, FAR void *arg)
 			task_ctxt_regs.reg[regs] = current_regs[regs];
 		}
 	}
-#ifdef CONFIG_FRAME_POINTER
 	/* Unwind the task stack by using fp (R11) */
 	unwind_backtrace_with_fp(&task_ctxt_regs, tcb);
-	lldbg("Call stack displayed for %d of Tasks.\n", ++task_counter);
-#endif
+	lldbg("*******************************************************************************\n");
 
 }
 
+/****************************************************************************
+ * Name: dump_all_stack
+ ****************************************************************************/
+
 void dump_all_stack(void)
 {
-	/* Reset the counter which counts the callstack displyed */
-	task_counter = 0;
+	lldbg("*******************************************************************************\n");
+	lldbg("Printing the call stack of all the tasks in the system\n");
+	lldbg("*******************************************************************************\n");
 
 	/* Display Call stack for all available tasks in the system */
 	sched_foreach(print_callstack, NULL);
 }
 
+/****************************************************************************
+ * Name: dump_stack
+ ****************************************************************************/
+
 void dump_stack(void)
 {
-	/* Reset the counter which counts the callstack displyed */
-	task_counter = 0;
-
 	/* Disable the irqs */
 	irqstate_t flags = irqsave();
 
@@ -318,6 +438,7 @@ void dump_stack(void)
 	/* Restore the irqs */
 	irqrestore(flags);
 }
+#endif						/* End of CONFIG_FRAME_POINTER */
 
 /****************************************************************************
  * Name: up_taskdump
@@ -715,11 +836,24 @@ static void up_dumpstate(void)
 
 	up_registerdump();
 
+#ifdef CONFIG_FRAME_POINTER
+	/* Dump the stack */
+	lldbg("*******************************************\n");
+	lldbg("Call stack of aborted task:\n");
+	lldbg("*******************************************\n");
 	dump_stack();
-
+#endif
 	/* Dump the state of all tasks (if available) */
 
+	lldbg("*******************************************\n");
+	lldbg("List of all tasks in the system:\n");
+	lldbg("*******************************************\n");
 	up_showtasks();
+
+#ifdef CONFIG_FRAME_POINTER
+	/* Display the call stack of all tasks */
+	dump_all_stack();
+#endif
 
 #ifdef CONFIG_ARCH_USBDUMP
 	/* Dump USB trace data */
@@ -769,6 +903,9 @@ void up_assert(const uint8_t *filename, int lineno)
 	struct tcb_s *rtcb = this_task();
 #endif
 	board_autoled_on(LED_ASSERTION);
+#if defined(CONFIG_FS_ROMFS) && defined(CONFIG_FRAME_POINTER)
+	abort_mode = true;
+#endif
 
 #if CONFIG_TASK_NAME_SIZE > 0
 	lldbg("Assertion failed at file:%s line: %d task: %s\n", filename, lineno, rtcb->name);

--- a/os/include/assert.h
+++ b/os/include/assert.h
@@ -213,6 +213,17 @@ void up_assert(FAR const uint8_t *filename, int linenum) noreturn_function;
 void up_assert(void) noreturn_function;
 #endif
 
+#ifdef CONFIG_FRAME_POINTER
+/*****************************************************************************
+ * dump_stack : Dumps the call stack of the calling Task/Thread
+ *****************************************************************************/
+void dump_stack(void);
+
+/*****************************************************************************
+ * dump_all_stack : Dumps the call stack of all the tasks/threads in system
+ *****************************************************************************/
+void dump_all_stack(void);
+#endif
 /**
  * @}
  * @endcond

--- a/os/kernel/semaphore/sem_wait.c
+++ b/os/kernel/semaphore/sem_wait.c
@@ -77,6 +77,9 @@
 /****************************************************************************
  * Global Variables
  ****************************************************************************/
+#if defined(CONFIG_FS_ROMFS) && defined(CONFIG_FRAME_POINTER)
+extern bool abort_mode;
+#endif
 
 /****************************************************************************
  * Private Variables
@@ -117,10 +120,16 @@ int sem_wait(FAR sem_t *sem)
 	FAR struct tcb_s *rtcb = this_task();
 	irqstate_t saved_state;
 	int ret = ERROR;
-
 	/* This API should not be called from interrupt handlers */
+#if defined(CONFIG_FS_ROMFS) && defined(CONFIG_FRAME_POINTER)
+	DEBUGASSERT((sem != NULL && up_interrupt_context() == false) || abort_mode);
 
+	if (abort_mode && up_interrupt_context() == true) {
+		return OK;
+	}
+#else
 	DEBUGASSERT(sem != NULL && up_interrupt_context() == false);
+#endif
 
 	/* The following operations must be performed with interrupts
 	 * disabled because sem_post() may be called from an interrupt

--- a/tools/fs/mkromfsimg.sh
+++ b/tools/fs/mkromfsimg.sh
@@ -70,6 +70,10 @@ buildpath=${topdir}/../build
 contentsdir=${topdir}/../tools/fs/contents
 romfsimg=${buildpath}/output/bin/romfs.img
 
+system_map_srcpath=${buildpath}/output/bin/System.map
+system_map_destpath=${contentsdir}/System.map
+cp $system_map_srcpath $system_map_destpath
+
 # Sanity checks
 
 if [ ! -d "${contentsdir}" ]; then


### PR DESCRIPTION
This feature is dependent on CONFIG_FS_ROMFS and CONFIG_FRAME_POINTER
It Copies the System.map file from output/bin/System.map to tools/fs/contents/System.map
It Parses the System.map file and searches for the symbol name corresponding to address
It displays the callStack along with symbol name

Advantage of this feature:
1. One can use these utilities [ dump_stack and dump_all_stack ] to display the callStack
anywhere in the source code for the src code browsing and learning
2. During System crash, along with stackdump, it helps to print the call stack with
symbol names. which will help the developer to debug the issue

Foreseen issue for point 2:
Since the file operations (fopen, fseek, rewind) are done when system is crashed,
there can be a recursive crash if there is a abort inside file sytem

Sample o/p during crash inside apps/system/utils/kdbg_ps.c [ int *p = NULL; *p = 5; ]

Data abort. PC: 040d9efc DFAR: 00000000 DFSR: 0000080d
up_assert: Assertion failed at file:armv7-r/arm_dataabort.c line: 111 task: tash
up_dumpstate: Current sp: 02063df8
up_dumpstate: User stack:
up_dumpstate:   base: 02063fe8
up_dumpstate:   size: 00000fec
up_dumpstate:   used: 00000394
up_dumpstate: User Stack
up_stackdump: 02063de0: 02063df8 040c9e30 040d3218 041acc6a 041ac94c 02063df8 02063df8 040c9e30
up_stackdump: 02063e00: 040d3218 041acc6a 041ac94c 02063df8 02063df8 040c9e30 02063e30 02023c7c
up_stackdump: 02063e20: 02063e44 02063e30 040ca0b4 040c9c68 00000000 0000080d 00000000 02063e48
up_stackdump: 02063e40: 040c827c 040ca080 041af68d 00000000 020258f0 020258fc 00000000 00000090
up_stackdump: 02063e60: 02063ed8 02023c7c 02023c7c 00000001 00000006 00000000 02063e9c 02063dc0
up_stackdump: 02063e80: 02063e90 040ce7c8 040d9efc 60000053 02063ed4 02063ea0 040dcf58 040d9ed4
up_stackdump: 02063ea0: 80402000 0000005a 02063ecc 00000000 0205f942 00000001 00000000 00000001
up_stackdump: 02063ec0: 00000003 00000003 02063f7c 02063ed8 040dd41c 040dcedc 0205f940 00000000
up_stackdump: 02063ee0: 020259b0 00000000 020239f0 20000053 00000001 020239f0 00000001 00000000
up_stackdump: 02063f00: 02063f34 02063ef8 02063f18 040ce7c8 040cd0b4 20000053 0000000a 020239c4
up_stackdump: 02063f20: 0205f943 00000001 02063f64 02063f38 040cb03c 040cd010 040caeb4 00000002
up_stackdump: 02063f40: 00000003 0205f940 00000008 00000000 00000003 00000003 02063f7c 00000003
up_stackdump: 02063f60: 00000003 0205f940 00000008 00000001 02063fd4 02063f80 040dd7bc 040dd3c8
up_stackdump: 02063f80: 02063fa0 deadbeef 02025e80 00000001 00000008 00000000 deadbeef 00000008
up_stackdump: 02063fa0: 00000006 00000000 deadbeef 00000000 00000000 00000000 00000000 00000000
up_stackdump: 02063fc0: 00000000 00000000 02063fe4 02063fd8 040cce14 040dd590 00000000 02063fe8
up_stackdump: 02063fe0: 00000000 040ccdbc deadbeef 02063ff4 00000000 68736174 deadbe00 42c00030
up_registerdump: R0: 00000000 020258f0 020258fc 00000000 00000090 02063ed8 02023c7c 02023c7c
up_registerdump: R8: 00000001 00000006 00000000 02063e9c 02063dc0 02063e90 040ce7c8 040d9efc
up_registerdump: CPSR: 60000053
up_dumpstate: *******************************************
up_dumpstate: Call stack of aborted task:
up_dumpstate: *******************************************
unwind_backtrace_with_fp: Task: [tash], Pid: [5], TaskAddr: [0x2061060] and [Current : tash]
unwind_backtrace_with_fp: stack size 0xfec
unwind_backtrace_with_fp: Registers are Valid, We may be either Interrupt context/exception context
unwind_backtrace_with_fp: fp:0x2063e9c , sp:0x2063e90 , pc:0x40d9efc
unwind_backtrace_with_fp: Call Stack:
unwind_backtrace_with_fp: [<0x40d9efc>] kdbg_ps+0x34/0x4c
unwind_backtrace_with_fp: [<0x40dcf58>] tash_execute_cmd+0x88/0x158
unwind_backtrace_with_fp: [<0x40dd41c>] tash_execute_cmdline+0x60/0x1c8
unwind_backtrace_with_fp: [<0x40dd7bc>] tash_main+0x238/0x278
unwind_backtrace_with_fp: [<0x40cce14>] task_start+0x64/0x70
unwind_frame_with_fp: End of Callstack
print_callstack: *******************************************************************************
up_dumpstate: *******************************************
up_dumpstate: List of all tasks in the system:
up_dumpstate: *******************************************
up_taskdump: Idle Task: PID=0 Stack Used=0 of 0
up_taskdump: hpwork: PID=1 Stack Used=388 of 2028
up_taskdump: lpwork: PID=2 Stack Used=260 of 2028
up_taskdump: LWIP_TCP/IP: PID=3 Stack Used=332 of 4068
up_taskdump: tash: PID=5 Stack Used=1980 of 4076
dump_all_stack: *******************************************************************************
dump_all_stack: Printing the call stack of all the tasks in the system
dump_all_stack: *******************************************************************************
unwind_backtrace_with_fp: Task: [Idle Task], Pid: [0], TaskAddr: [0x20257e4] and [Current : tash]
unwind_backtrace_with_fp: stack size 0x400
unwind_backtrace_with_fp: Task would be blocked in context switch : up_saveusercontext
unwind_backtrace_with_fp: fp:0x204fcdc , sp:0x204fcc0 , pc:0x40d4e60
unwind_backtrace_with_fp: Call Stack:
unwind_backtrace_with_fp: [<0x40d4e60>] up_idle+0x88/0x90
unwind_backtrace_with_fp: [<0x40cc548>] os_start+0x234/0x294
get_symbol: symbol is not found in system map
unwind_backtrace_with_fp: [<0x0>] os_start+0x234/0x294
unwind_frame_with_fp: End of Callstack
print_callstack: *******************************************************************************
unwind_backtrace_with_fp: Task: [hpwork], Pid: [1], TaskAddr: [0x2052990] and [Current : tash]
unwind_backtrace_with_fp: stack size 0x7ec
unwind_backtrace_with_fp: Task would be blocked in context switch : up_saveusercontext
unwind_backtrace_with_fp: fp:0x2053f3c , sp:0x2053f18 , pc:0x40d6a90
unwind_backtrace_with_fp: Call Stack:
unwind_backtrace_with_fp: [<0x40d6a90>] up_block_task+0xa4/0xc8
unwind_backtrace_with_fp: [<0x40cf790>] sigtimedwait+0x174/0x20c
unwind_backtrace_with_fp: [<0x40cf17c>] work_process+0x11c/0x164
unwind_backtrace_with_fp: [<0x40ce140>] work_hpthread+0x1c/0x24
unwind_backtrace_with_fp: [<0x40cce14>] task_start+0x64/0x70
unwind_frame_with_fp: End of Callstack
print_callstack: *******************************************************************************
unwind_backtrace_with_fp: Task: [lpwork], Pid: [2], TaskAddr: [0x2053080] and [Current : tash]
unwind_backtrace_with_fp: stack size 0x7ec
unwind_backtrace_with_fp: Task would be blocked in context switch : up_saveusercontext
unwind_backtrace_with_fp: fp:0x2054f34 , sp:0x2054f10 , pc:0x40d6a90
unwind_backtrace_with_fp: Call Stack:
unwind_backtrace_with_fp: [<0x40d6a90>] up_block_task+0xa4/0xc8
unwind_backtrace_with_fp: [<0x40cf790>] sigtimedwait+0x174/0x20c
unwind_backtrace_with_fp: [<0x40cf17c>] work_process+0x11c/0x164
unwind_backtrace_with_fp: [<0x40ce1f8>] work_lpthread+0x38/0x50
unwind_backtrace_with_fp: [<0x40cce14>] task_start+0x64/0x70
unwind_frame_with_fp: End of Callstack
print_callstack: *******************************************************************************
unwind_backtrace_with_fp: Task: [LWIP_TCP/IP], Pid: [3], TaskAddr: [0x205f250] and [Current : tash]
unwind_backtrace_with_fp: stack size 0xfe4
unwind_backtrace_with_fp: Task would be blocked in context switch : up_saveusercontext
unwind_backtrace_with_fp: fp:0x2060ee4 , sp:0x2060ec0 , pc:0x40d6a90
unwind_backtrace_with_fp: Call Stack:
unwind_backtrace_with_fp: [<0x40d6a90>] up_block_task+0xa4/0xc8
unwind_backtrace_with_fp: [<0x40ccfac>] sem_wait+0xe4/0x13c
unwind_backtrace_with_fp: [<0x41a38dc>] sem_tickwait+0xec/0x144
unwind_backtrace_with_fp: [<0x4142280>] sys_arch_sem_wait+0xc8/0x108
unwind_backtrace_with_fp: [<0x41424a8>] sys_arch_mbox_fetch+0x98/0x104
unwind_backtrace_with_fp: [<0x413ce0c>] sys_timeouts_mbox_fetch+0x7c/0xa4
unwind_backtrace_with_fp: [<0x413f294>] tcpip_thread+0x40/0x100
unwind_backtrace_with_fp: [<0x40cce14>] task_start+0x64/0x70
unwind_frame_with_fp: End of Callstack
print_callstack: *******************************************************************************
unwind_backtrace_with_fp: Task: [tash], Pid: [5], TaskAddr: [0x2061060] and [Current : tash]
unwind_backtrace_with_fp: stack size 0xfec
unwind_backtrace_with_fp: Registers are Valid, We may be either Interrupt context/exception context
unwind_backtrace_with_fp: fp:0x2063e9c , sp:0x2063e90 , pc:0x40d9efc
unwind_backtrace_with_fp: Call Stack:
unwind_backtrace_with_fp: [<0x40d9efc>] kdbg_ps+0x34/0x4c
unwind_backtrace_with_fp: [<0x40dcf58>] tash_execute_cmd+0x88/0x158
unwind_backtrace_with_fp: [<0x40dd41c>] tash_execute_cmdline+0x60/0x1c8
unwind_backtrace_with_fp: [<0x40dd7bc>] tash_main+0x238/0x278
unwind_backtrace_with_fp: [<0x40cce14>] task_start+0x64/0x70
unwind_frame_with_fp: End of Callstack
print_callstack: *******************************************************************************
dump_all_stack: *******************************************************************************

Signed-off-by: pradeep.ns <pradeep.ns@samsung.com>