### PR TITLE
apps/testcase/DM : DM ITC rename

### DIFF
--- a/apps/examples/testcase/ta_tc/device_management/itc/itc_dm_conn.c
+++ b/apps/examples/testcase/ta_tc/device_management/itc/itc_dm_conn.c
@@ -190,14 +190,14 @@ static void itc_dm_conn_set_get_tx_power_p(void)
 }
 
 /**
-* @testcase         itc_dm_conn_get_adress_channel_after_set_tx_power_p
+* @testcase         itc_dm_conn_get_adress_channel_p_after_set_tx_power
 * @brief            Set wifi tx power and get address and channel value
 * @scenario         Set wifi tx power and get address and channel value
 * @apicovered       dm_conn_set_tx_power, dm_conn_get_tx_power, dm_conn_get_address, dm_conn_get_channel
 * @precondition     WiFi connected
 * @postcondition    NA
 */
-static void itc_dm_conn_get_adress_channel_after_set_tx_power_p(void)
+static void itc_dm_conn_get_adress_channel_p_after_set_tx_power(void)
 {
 	int ret;
 	int set_val = 20;
@@ -229,14 +229,14 @@ static void itc_dm_conn_get_adress_channel_after_set_tx_power_p(void)
 }
 
 /**
-* @testcase         itc_dm_conn_get_interface_rssi_after_set_tx_power_p
+* @testcase         itc_dm_conn_get_interface_rssi_p_after_set_tx_power
 * @brief            Set wifi tx power and get interface and rssi value
 * @scenario         Set wifi tx power and get interface and rssi value
 * @apicovered       dm_conn_set_tx_power, dm_conn_get_tx_power, dm_conn_get_interface, dm_conn_get_rssi
 * @precondition     WiFi connected
 * @postcondition    NA
 */
-static void itc_dm_conn_get_interface_rssi_after_set_tx_power_p(void)
+static void itc_dm_conn_get_interface_rssi_p_after_set_tx_power(void)
 {
 	int ret;
 	int set_val = 20;
@@ -355,14 +355,14 @@ static void itc_dm_conn_re_register_linkup_p(void)
 }
 
 /**
-* @testcase         itc_dm_conn_get_address_channel_after_register_linkup_p
+* @testcase         itc_dm_conn_get_address_channel_p_after_register_linkup
 * @brief            Register linkup callback and get address and channel value
 * @scenario         Register linkup callback and get address and channel value
 * @apicovered       dm_conn_get_address, dm_conn_get_channel, dm_conn_register_linkup_cb, dm_conn_unregister_linkup_cb
 * @precondition     WiFi connected
 * @postcondition    NA
 */
-static void itc_dm_conn_get_address_channel_after_register_linkup_p(void)
+static void itc_dm_conn_get_address_channel_p_after_register_linkup(void)
 {
 	int ret;
 	int val = -1;
@@ -386,14 +386,14 @@ static void itc_dm_conn_get_address_channel_after_register_linkup_p(void)
 }
 
 /**
-* @testcase         itc_dm_conn_get_interface_rssi_after_register_linkup_p
+* @testcase         itc_dm_conn_get_interface_rssi_p_after_register_linkup
 * @brief            Register linkup callback and get address and channel value
 * @scenario         Register linkup callback and get address and channel value
 * @apicovered       dm_conn_get_address, dm_conn_get_channel, dm_conn_register_linkup_cb, dm_conn_unregister_linkup_cb
 * @precondition     WiFi connected
 * @postcondition    NA
 */
-static void itc_dm_conn_get_interface_rssi_after_register_linkup_p(void)
+static void itc_dm_conn_get_interface_rssi_p_after_register_linkup(void)
 {
 	int ret;
 	char interface[BUF_SIZE] = { 0, };
@@ -417,14 +417,14 @@ static void itc_dm_conn_get_interface_rssi_after_register_linkup_p(void)
 }
 
 /**
-* @testcase         itc_dm_conn_setget_tx_power_after_register_linkup_p
+* @testcase         itc_dm_conn_setget_tx_power_p_after_register_linkup
 * @brief            Set and unset link up callback function with set and get tx power
 * @scenario         Set link up callback and then set and get tx power and then unset link up callback
 * @apicovered       dm_conn_register_linkup_cb, dm_conn_unregister_linkup_cb, dm_conn_set_tx_power, dm_conn_get_tx_power
 * @precondition     NA
 * @postcondition    NA
 */
-static void itc_dm_conn_setget_tx_power_after_register_linkup_p(void)
+static void itc_dm_conn_setget_tx_power_p_after_register_linkup(void)
 {
 	int ret;
 	int set_val = 20;
@@ -496,14 +496,14 @@ static void itc_dm_conn_register_unregister_linkdown_p(void)
 }
 
 /**
-* @testcase         itc_dm_conn_re_register_linkdown_p
+* @testcase         itc_dm_conn_register_linkdown_p_reregister
 * @brief            Re-register link down callback function
 * @scenario         Set link down callback function successfully and then re-register link down callback function
 * @apicovered       dm_conn_register_linkup_cb
 * @precondition     NA
 * @postcondition    NA
 */
-static void itc_dm_conn_re_register_linkdown_p(void)
+static void itc_dm_conn_register_linkdown_p_reregister(void)
 {
 	int ret;
 	ret = dm_conn_register_linkdown_cb(link_event);
@@ -519,14 +519,14 @@ static void itc_dm_conn_re_register_linkdown_p(void)
 }
 
 /**
-* @testcase         itc_dm_conn_get_address_channel_after_register_linkdown_p
+* @testcase         itc_dm_conn_get_address_channel_p_after_register_linkdown
 * @brief            Register linkdown callback and get address and channel value
 * @scenario         Register linkdown callback and get address and channel value and unregister callback
 * @apicovered       dm_conn_get_address, dm_conn_get_channel, dm_conn_register_linkdown_cb, dm_conn_unregister_linkdown_cb
 * @precondition     WiFi connected
 * @postcondition    NA
 */
-static void itc_dm_conn_get_address_channel_after_register_linkdown_p(void)
+static void itc_dm_conn_get_address_channel_p_after_register_linkdown(void)
 {
 	int ret;
 	int val = -1;
@@ -550,14 +550,14 @@ static void itc_dm_conn_get_address_channel_after_register_linkdown_p(void)
 }
 
 /**
-* @testcase         itc_dm_conn_get_interface_rssi_after_register_linkdown_p
+* @testcase         itc_dm_conn_get_interface_rssi_p_after_register_linkdown
 * @brief            Register linkdown callback and get interface and rssi value
 * @scenario         Register linkdown callback and get interface and rssi value and unregister callback
 * @apicovered       dm_conn_get_interface, dm_conn_get_rssi, dm_conn_register_linkdown_cb, dm_conn_unregister_linkdown_cb
 * @precondition     WiFi connected
 * @postcondition    NA
 */
-static void itc_dm_conn_get_interface_rssi_after_register_linkdown_p(void)
+static void itc_dm_conn_get_interface_rssi_p_after_register_linkdown(void)
 {
 	int ret;
 	char interface[BUF_SIZE] = { 0, };
@@ -581,14 +581,14 @@ static void itc_dm_conn_get_interface_rssi_after_register_linkdown_p(void)
 }
 
 /**
-* @testcase         itc_dm_conn_setget_tx_power_after_register_linkdown_p
+* @testcase         itc_dm_conn_setget_tx_power_p_after_register_linkdown
 * @brief            Set and unset link up callback function with set and get tx power
 * @scenario         Set link up callback and then set and get tx power and then unset link up callback
 * @apicovered       dm_conn_register_linkdown_cb, dm_conn_unregister_linkdown_cb, dm_conn_set_tx_power, dm_conn_get_tx_power
 * @precondition     NA
 * @postcondition    NA
 */
-static void itc_dm_conn_setget_tx_power_after_register_linkdown_p(void)
+static void itc_dm_conn_setget_tx_power_p_after_register_linkdown(void)
 {
 	int ret;
 	int set_val = 20;
@@ -691,8 +691,8 @@ int itc_dm_conn_get_rssi_main(void)
 int itc_dm_conn_set_get_tx_power_main(void)
 {
 	itc_dm_conn_set_get_tx_power_p();
-	itc_dm_conn_get_adress_channel_after_set_tx_power_p();
-	itc_dm_conn_get_interface_rssi_after_set_tx_power_p();
+	itc_dm_conn_get_adress_channel_p_after_set_tx_power();
+	itc_dm_conn_get_interface_rssi_p_after_set_tx_power();
 	itc_dm_conn_set_tx_power_n();
 	itc_dm_conn_get_tx_power_n();
 	return 0;
@@ -706,9 +706,9 @@ int itc_dm_conn_regi_unreg_linkup_main(void)
 {
 	itc_dm_conn_register_unregister_linkup_p();
 	itc_dm_conn_re_register_linkup_p();
-	itc_dm_conn_get_address_channel_after_register_linkup_p();
-	itc_dm_conn_get_interface_rssi_after_register_linkup_p();
-	itc_dm_conn_setget_tx_power_after_register_linkup_p();
+	itc_dm_conn_get_address_channel_p_after_register_linkup();
+	itc_dm_conn_get_interface_rssi_p_after_register_linkup();
+	itc_dm_conn_setget_tx_power_p_after_register_linkup();
 	itc_dm_conn_register_linkup_n();
 	itc_dm_conn_unregister_linkup_n();
 	return 0;
@@ -721,10 +721,10 @@ int itc_dm_conn_regi_unreg_linkup_main(void)
 int itc_dm_conn_regi_unreg_linkdown_main(void)
 {
 	itc_dm_conn_register_unregister_linkdown_p();
-	itc_dm_conn_re_register_linkdown_p();
-	itc_dm_conn_get_address_channel_after_register_linkdown_p();
-	itc_dm_conn_get_interface_rssi_after_register_linkdown_p();//TC FAIL when run along with all other DM TCs, individual TC is PASS, return value is 0xffffffc3 not equal to 0x0
-	itc_dm_conn_setget_tx_power_after_register_linkdown_p();
+	itc_dm_conn_register_linkdown_p_reregister();
+	itc_dm_conn_get_address_channel_p_after_register_linkdown();
+	itc_dm_conn_get_interface_rssi_p_after_register_linkdown();//TC FAIL when run along with all other DM TCs, individual TC is PASS, return value is 0xffffffc3 not equal to 0x0
+	itc_dm_conn_setget_tx_power_p_after_register_linkdown();
 	itc_dm_conn_register_linkdown_n();
 	itc_dm_conn_unregister_linkdown_n();
 	return 0;

--- a/apps/examples/testcase/ta_tc/device_management/itc/itc_dm_lwm2m.c
+++ b/apps/examples/testcase/ta_tc/device_management/itc/itc_dm_lwm2m.c
@@ -183,14 +183,14 @@ static void itc_dm_lwm2m_display_client_resource_p(void)
 }
 
 /**
-* @testcase             itc_dm_lwm2m_restart_client_p
+* @testcase             itc_dm_lwm2m_start_client_p_restart_client
 * @brief                Start and restart DM LWM2M client session
 * @scenario             Pass valid DM_ERROR_ALREADY_STARTED
 * @apicovered           dm_lwm2m_start_client
 * @precondition         WiFi connected, DM LWM2M client is not started yet
 * @postcondition        NA
 */
-static void itc_dm_lwm2m_restart_client_p(void)
+static void itc_dm_lwm2m_start_client_p_restart_client(void)
 {
 	int ret;
 	ret = dm_lwm2m_start_client(&test_data_itc);
@@ -206,14 +206,14 @@ static void itc_dm_lwm2m_restart_client_p(void)
 }
 
 /**
-* @testcase             itc_dm_lwm2m_restop_client_p
+* @testcase             itc_dm_lwm2m_stop_client_p_restop_client
 * @brief                Stop and restop DM LWM2M client session
 * @scenario             Pass valid DM_ERROR_ALREADY_STOPPED
 * @apicovered           dm_lwm2m_stop_client
 * @precondition         WiFi connected, DM LWM2M client is started
 * @postcondition        NA
 */
-static void itc_dm_lwm2m_restop_client_p(void)
+static void itc_dm_lwm2m_stop_client_p_restop_client(void)
 {
 	int ret;
 	ret = dm_lwm2m_start_client(&test_data_itc);
@@ -229,14 +229,14 @@ static void itc_dm_lwm2m_restop_client_p(void)
 }
 
 /**
-* @testcase             itc_dm_lwm2m_get_client_lifetime_before_start_n
+* @testcase             itc_dm_lwm2m_get_client_lifetime_n_before_start
 * @brief                Get LWM2M client lifetime
 * @scenario             Pass with return vlaue of less than DM_ERROR_NONE
 * @apicovered           dm_lwm2m_get_client_lifetime
 * @precondition         NA
 * @postcondition        NA
 */
-static void itc_dm_lwm2m_get_client_lifetime_before_start_n(void)
+static void itc_dm_lwm2m_get_client_lifetime_n_before_start(void)
 {
 	int life = -1;
 	int ret = -1;
@@ -248,14 +248,14 @@ static void itc_dm_lwm2m_get_client_lifetime_before_start_n(void)
 }
 
 /**
-* @testcase             itc_dm_lwm2m_get_client_lifetime_after_close_n
+* @testcase             itc_dm_lwm2m_get_client_lifetime_n_after_close
 * @brief                Get LWM2M client lifetime
 * @scenario             Pass with return vlaue of less than DM_ERROR_NONE
 * @apicovered           dm_lwm2m_get_client_lifetime
 * @precondition         DM LWM2M client has been started and stopped
 * @postcondition        NA
 */
-static void itc_dm_lwm2m_get_client_lifetime_after_close_n(void)
+static void itc_dm_lwm2m_get_client_lifetime_n_after_close(void)
 {
 	int life = -1;
 	int ret = -1;
@@ -272,14 +272,14 @@ static void itc_dm_lwm2m_get_client_lifetime_after_close_n(void)
 }
 
 /**
-* @testcase             itc_dm_lwm2m_get_server_address_before_start_n
+* @testcase             itc_dm_lwm2m_get_server_address_n_before_start
 * @brief                Get LWM2M Server IP addr
 * @scenario             Pass with return vlaue of less than DM_ERROR_NONE
 * @apicovered           dm_lwm2m_get_server_address
 * @precondition         NA
 * @postcondition        NA
 */
-static void itc_dm_lwm2m_get_server_address_before_start_n(void)
+static void itc_dm_lwm2m_get_server_address_n_before_start(void)
 {
 	char ip_addr[ITC_DM_IPADDR_LEN];
 	int ret = dm_lwm2m_get_server_address(ip_addr);
@@ -289,14 +289,14 @@ static void itc_dm_lwm2m_get_server_address_before_start_n(void)
 }
 
 /**
-* @testcase             itc_dm_lwm2m_get_server_address_after_close_n
+* @testcase             itc_dm_lwm2m_get_server_address_n_after_close
 * @brief                Get LWM2M Server IP addr
 * @scenario             Pass with return vlaue of less than DM_ERROR_NONE
 * @apicovered           dm_lwm2m_get_server_address
 * @precondition         DM LWM2M client has been started and stop
 * @postcondition        NA
 */
-static void itc_dm_lwm2m_get_server_address_after_close_n(void)
+static void itc_dm_lwm2m_get_server_address_n_after_close(void)
 {
 	int ret = dm_lwm2m_start_client(&test_data_itc);
 	TC_ASSERT_EQ("dm_lwm2m_start_client", ret, DM_ERROR_NONE);
@@ -312,14 +312,14 @@ static void itc_dm_lwm2m_get_server_address_after_close_n(void)
 }
 
 /**
-* @testcase             itc_dm_lwm2m_get_server_port_before_start_n
+* @testcase             itc_dm_lwm2m_get_server_port_n_before_start
 * @brief                Get LWM2M Server IP port
 * @scenario             Pass with return vlaue of less than DM_ERROR_NONE
 * @apicovered           dm_lwm2m_get_server_port
 * @precondition         NA
 * @postcondition        NA
 */
-static void itc_dm_lwm2m_get_server_port_before_start_n(void)
+static void itc_dm_lwm2m_get_server_port_n_before_start(void)
 {
 	char port[ITC_DM_SERVER_PORT];
 
@@ -330,14 +330,14 @@ static void itc_dm_lwm2m_get_server_port_before_start_n(void)
 }
 
 /**
-* @testcase             itc_dm_lwm2m_get_server_port_after_close_n
+* @testcase             itc_dm_lwm2m_get_server_port_n_after_close
 * @brief                Get LWM2M Server IP port
 * @scenario             Pass with return vlaue of less than DM_ERROR_NONE
 * @apicovered           dm_lwm2m_get_server_port
 * @precondition         DM LWM2M client has been started and stopped
 * @postcondition        NA
 */
-static void itc_dm_lwm2m_get_server_port_after_close_n(void)
+static void itc_dm_lwm2m_get_server_port_n_after_close(void)
 {
 	char port[ITC_DM_SERVER_PORT];
 	int ret = dm_lwm2m_start_client(&test_data_itc);
@@ -353,14 +353,14 @@ static void itc_dm_lwm2m_get_server_port_after_close_n(void)
 }
 
 /**
-* @testcase             itc_dm_lwm2m_get_client_state_before_start_n
+* @testcase             itc_dm_lwm2m_get_client_state_n_before_start
 * @brief                Get LWM2M Client state
 * @scenario             Pass with return vlaue of less than DM_ERROR_NONE
 * @apicovered           dm_lwm2m_get_client_state
 * @precondition         NA
 * @postcondition        NA
 */
-static void itc_dm_lwm2m_get_client_state_before_start_n(void)
+static void itc_dm_lwm2m_get_client_state_n_before_start(void)
 {
 	dm_lwm2m_client_state_e state;
 
@@ -372,14 +372,14 @@ static void itc_dm_lwm2m_get_client_state_before_start_n(void)
 }
 
 /**
-* @testcase             itc_dm_lwm2m_get_client_state_after_close_n
+* @testcase             itc_dm_lwm2m_get_client_state_n_after_close
 * @brief                Get LWM2M Client state
 * @scenario             Pass with return vlaue of less than DM_ERROR_NONE
 * @apicovered           dm_lwm2m_get_client_state
 * @precondition         DM LWM2M client has been started and stopped
 * @postcondition        NA
 */
-static void itc_dm_lwm2m_get_client_state_after_close_n(void)
+static void itc_dm_lwm2m_get_client_state_n_after_close(void)
 {
 	dm_lwm2m_client_state_e state;
 	int ret = dm_lwm2m_start_client(&test_data_itc);
@@ -396,14 +396,14 @@ static void itc_dm_lwm2m_get_client_state_after_close_n(void)
 }
 
 /**
-* @testcase             itc_dm_lwm2m_display_client_resource_with_no_data_p
+* @testcase             itc_dm_lwm2m_display_client_resource_p_with_no_data
 * @brief                Display LWM2M Client resource
 * @scenario             Pass valid argument to API
 * @apicovered           dm_lwm2m_display_client_resource
 * @precondition         NA
 * @postcondition        NA
 */
-static void itc_dm_lwm2m_display_client_resource_with_no_data_p(void)
+static void itc_dm_lwm2m_display_client_resource_p_with_no_data(void)
 {
 	int ret;
 	char arg_buffer[10];
@@ -442,46 +442,46 @@ int itc_dm_lwm2m_testcase_main(void)
 
 	itc_dm_lwm2m_start_stop_client_p();
 	sleep(SEC_1);
-	itc_dm_lwm2m_restart_client_p();
+	itc_dm_lwm2m_start_client_p_restart_client();
 	sleep(SEC_1);
-	itc_dm_lwm2m_restop_client_p();
+	itc_dm_lwm2m_stop_client_p_restop_client();
 	sleep(SEC_1);
 #ifdef CONFIG_ITC_DM_GET_CLIENT_LIFETIME
 	itc_dm_lwm2m_get_client_lifetime_p();
 	sleep(SEC_1);
-	itc_dm_lwm2m_get_client_lifetime_before_start_n();
+	itc_dm_lwm2m_get_client_lifetime_n_before_start();
 	sleep(SEC_1);
-	itc_dm_lwm2m_get_client_lifetime_after_close_n();
+	itc_dm_lwm2m_get_client_lifetime_n_after_close();
 	sleep(SEC_1);
 #endif
 #ifdef CONFIG_ITC_DM_GET_SERVER_ADDR
 	itc_dm_lwm2m_get_server_address_p();
 	sleep(SEC_1);
-	itc_dm_lwm2m_get_server_address_before_start_n();
+	itc_dm_lwm2m_get_server_address_n_before_start();
 	sleep(SEC_1);
-	itc_dm_lwm2m_get_server_address_after_close_n();
+	itc_dm_lwm2m_get_server_address_n_after_close();
 	sleep(SEC_1);
 #endif
 #ifdef CONFIG_ITC_DM_GET_SERVER_PORT
 	itc_dm_lwm2m_get_server_port_p();
 	sleep(SEC_1);
-	itc_dm_lwm2m_get_server_port_before_start_n();
+	itc_dm_lwm2m_get_server_port_n_before_start();
 	sleep(SEC_1);
-	itc_dm_lwm2m_get_server_port_after_close_n();
+	itc_dm_lwm2m_get_server_port_n_after_close();
 	sleep(SEC_1);
 #endif
 #ifdef CONFIG_ITC_DM_GET_CLIENT_STATE
 	itc_dm_lwm2m_get_client_state_p();
 	sleep(SEC_1);
-	itc_dm_lwm2m_get_client_state_before_start_n();
+	itc_dm_lwm2m_get_client_state_n_before_start();
 	sleep(SEC_1);
-	itc_dm_lwm2m_get_client_state_after_close_n();
+	itc_dm_lwm2m_get_client_state_n_after_close();
 	sleep(SEC_1);
 #endif
 #ifdef CONFIG_ITC_DM_DISPLAY_CLIENT_RESOURCE
 	itc_dm_lwm2m_display_client_resource_p();
 	sleep(SEC_1);
-	itc_dm_lwm2m_display_client_resource_with_no_data_p();//TC FAIL, Line no. 407, Should return DM_ERROR_NO_DATA, but it returning DM_ERROR_NONE
+	itc_dm_lwm2m_display_client_resource_p_with_no_data();//TC FAIL, Line no. 407, Should return DM_ERROR_NO_DATA, but it returning DM_ERROR_NONE
 	sleep(SEC_1);
 	itc_dm_lwm2m_display_client_resource_n();
 	sleep(SEC_1);


### PR DESCRIPTION
apps/examples/testcase/ta_tc/device_management/itc : DM ITC rename

Rename of scenario ITCs of DM
TC Naming rule is <TC_Category>_<Module>_<FunctionName>_<Positive/Negative>_<AdditionalInformation>
Current TC name do not have above naming convention



Signed-off-by: Arvin Mittal <arvin.mittal@samsung.com>