### PR TITLE
Set idle stack size value to idle tcb

### DIFF
--- a/apps/system/utils/kdbg_stackmonitor.c
+++ b/apps/system/utils/kdbg_stackmonitor.c
@@ -81,7 +81,7 @@
 #ifndef CONFIG_STACKMONITOR_INTERVAL
 #define CONFIG_STACKMONITOR_INTERVAL 5
 #endif
-extern const uint32_t g_idle_topstack;
+
 /****************************************************************************
  * Private Types
  ****************************************************************************/
@@ -132,10 +132,6 @@ static void stkmon_inactive_check(void)
 
 static void stkmon_active_check(struct tcb_s *tcb, void *arg)
 {
-	if (tcb->pid == 0) {
-		tcb->adj_stack_size = CONFIG_IDLETHREAD_STACKSIZE;
-		tcb->stack_alloc_ptr = (void *)(g_idle_topstack - CONFIG_IDLETHREAD_STACKSIZE);
-	}
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
 	printf("%5d | %8s | %8d | %10d | %10d | %7lld | ", tcb->pid, "ACTIVE", tcb->adj_stack_size, up_check_tcbstack(tcb), tcb->peak_alloc_size, (uint64_t)((systime_t)clock_systimer()));
 #else

--- a/os/kernel/init/os_start.c
+++ b/os/kernel/init/os_start.c
@@ -101,6 +101,8 @@
  * Global Variables
  ****************************************************************************/
 
+extern const uint32_t g_idle_topstack;
+
 /* Task Lists ***************************************************************/
 /* The state of a task is indicated both by the task_state field of the TCB
  * and by a series of task lists.  All of these tasks lists are declared
@@ -326,6 +328,8 @@ void os_start(void)
 	g_idletcb.cmn.task_state = TSTATE_TASK_RUNNING;
 	g_idletcb.cmn.entry.main = (main_t)os_start;
 	g_idletcb.cmn.flags = TCB_FLAG_TTYPE_KERNEL;
+	g_idletcb.cmn.stack_alloc_ptr = (void *)(g_idle_topstack - CONFIG_IDLETHREAD_STACKSIZE);
+	g_idletcb.cmn.adj_stack_size = CONFIG_IDLETHREAD_STACKSIZE;
 
 	/* Set the IDLE task name */
 


### PR DESCRIPTION
This prevents users from considering the idle task when using stack size