### PR TITLE
Add Feature dependency before copying System.map file

### DIFF
--- a/build/configs/sidk_s5jt200/sidk_s5jt200_download.sh
+++ b/build/configs/sidk_s5jt200/sidk_s5jt200_download.sh
@@ -48,6 +48,17 @@ prepare_resource()
 {
 	if [ -d "${RESOURCE_DIR_PATH}" ]; then
 		echo "Packing resources into romfs.img ..."
+		# When CONGIG_FRAME_POINTER flag is enabled, copy the build/output/bin/System.map
+		# file to tools/fs/contents directory so that symbol names can be displayed using
+		# dump_stack
+		if [ "${CONFIG_FRAME_POINTER}" == "y" ]; then
+			echo "Copying System.map file from ${OUTPUT_BIN_PATH} to ${RESOURCE_DIR_PATH}"
+			cp ${OUTPUT_BIN_PATH}/System.map ${RESOURCE_DIR_PATH}/System.map
+			if [ ! -f "${RESOURCE_DIR_PATH}/System.map" ]; then
+				echo "Failed to copy System.map file"
+				exit 1
+			fi
+		fi
 
 		# create romfs.img
 		sh ${FSTOOLS_DIR_PATH}/mkromfsimg.sh

--- a/os/arch/arm/src/armv7-r/arm_assert.c
+++ b/os/arch/arm/src/armv7-r/arm_assert.c
@@ -90,6 +90,7 @@
 #ifdef CONFIG_ARMV7M_MPU
 #include "mpu.h"
 #endif
+#include <stdbool.h>
 
 #if defined(CONFIG_FS_ROMFS) && defined(CONFIG_FRAME_POINTER)
 #include <stdio.h>
@@ -204,7 +205,7 @@ static int is_text_address(unsigned long programCounter)
  * Below API works if there is existance of System.map file in rom fs
  ****************************************************************************/
 #ifdef CONFIG_FS_ROMFS
-void get_symbol(unsigned long search_addr, char *buffer)
+int get_symbol(unsigned long search_addr, char *buffer)
 {
 	FILE *pFile;
 	unsigned long sym_offset;
@@ -214,8 +215,8 @@ void get_symbol(unsigned long search_addr, char *buffer)
 	int first = 0;
 	int last = 0;
 	int mid;
-	char line[128];
-	char data[6][128];
+	char line[128] = { '\0' };
+	char data[6][128] = { {'\0', '\0'} };
 	char c;
 	int n;
 	int i;
@@ -227,7 +228,7 @@ void get_symbol(unsigned long search_addr, char *buffer)
 	/* Check if file exists */
 	if (pFile == NULL) {
 		lldbg("Could not open file: /rom/System.map\n");
-		return;
+		return -1;
 	}
 	// obtain file size:
 	fseek(pFile, 0, SEEK_END);
@@ -238,9 +239,17 @@ void get_symbol(unsigned long search_addr, char *buffer)
 	while (first <= last) {
 		fseek(pFile, mid, SEEK_SET);
 
-		// Extract characters from file and store in character c
+		/* If the file pointer is in the mid of the line, make sure
+		 * it's been properly moved to start of next line
+		 */
 		for (c = getc(pFile); c != '\n'; c = getc(pFile)) {
+			if (c == EOF) {
+				lldbg("Reached end of file and couldn't find symbol\n");
+				fclose(pFile);
+				return -1;
+			}
 		}
+
 		n = 0;
 		// Read 2 lines and Split the string as words
 		for (k = 0; k < 2; k++) {
@@ -251,18 +260,19 @@ void get_symbol(unsigned long search_addr, char *buffer)
 				if (line[i] != ' ') {
 					data[n][j++] = line[i];
 				} else {
-					data[n][j++] = '\0';//insert NULL
+					data[n][j++] = '\0';
 					n++;
 					j = 0;
 				}
 				i++;
 				if (line[i] == '\0') {
-					data[n][j++] = '\0';//insert NULL
+					data[n][j++] = '\0';
 					n++;
 					j = 0;
 				}
 			}
 		}
+		/* Convert the string data to hexadecimal */
 		addr = strtoul(data[0], NULL, 16);
 		next_addr = strtoul(data[3], NULL, 16);
 		if (search_addr >= addr && search_addr < next_addr) {
@@ -270,7 +280,6 @@ void get_symbol(unsigned long search_addr, char *buffer)
 			sym_offset = search_addr - addr;
 			total_size = next_addr - addr;
 			sprintf(buffer + strlen(buffer)-1, "+0x%lx/0x%lx", sym_offset, total_size);
-			//lldbg("Got it buffer is : %s\n", buffer);
 			break;
 		}
 		if (search_addr < addr) {
@@ -279,14 +288,17 @@ void get_symbol(unsigned long search_addr, char *buffer)
 			first = mid + 1;
 		}
 
-		mid = (first + last ) / 2;
+		mid = (first + last) / 2;
 	}
 	if (first > last) {
 		lldbg("symbol is not found in system map\n");
 		buffer = "";
 	}
 
+	/* Close the file */
 	fclose(pFile);
+
+	return 0;
 }
 #endif						/* End of CONFIG_FS_ROMFS */
 
@@ -374,12 +386,14 @@ static void unwind_backtrace_with_fp(arm_regs_t *regs, struct tcb_s *task)
 		if (unwind_frame_with_fp(&stack_frame, ustacksize) >= 0) {
 			/* Print the call stack address */
 #ifdef CONFIG_FS_ROMFS
-			char buffer[64];
-			get_symbol(current_addr, buffer);
-			lldbg("[<0x%p>] %s\n", (void *)current_addr, buffer);
-#else
-			lldbg("[<0x%p>]\n", (void *)current_addr);
+			char buffer[64] = { '\0' };
+			if (get_symbol(current_addr, buffer) == 0) {
+				lldbg("[<0x%p>] %s\n", (void *)current_addr, buffer);
+			} else
 #endif
+			{
+				lldbg("[<0x%p>]\n", (void *)current_addr);
+			}
 		} else {
 			/* End of stack */
 			break;

--- a/tools/fs/mkromfsimg.sh
+++ b/tools/fs/mkromfsimg.sh
@@ -70,10 +70,6 @@ buildpath=${topdir}/../build
 contentsdir=${topdir}/../tools/fs/contents
 romfsimg=${buildpath}/output/bin/romfs.img
 
-system_map_srcpath=${buildpath}/output/bin/System.map
-system_map_destpath=${contentsdir}/System.map
-cp $system_map_srcpath $system_map_destpath
-
 # Sanity checks
 
 if [ ! -d "${contentsdir}" ]; then


### PR DESCRIPTION
system.map file needs to be copied to tools/fs/contents folder only
when CONFIG_FRAME_POINTER flag is enabled.

Also fix coding rule violation

Signed-off-by: pradeep.ns <pradeep.ns@samsung.com>