### PR TITLE
apps/testcase/spi : spi ITC refactor

### DIFF
--- a/apps/examples/testcase/ta_tc/systemio/itc/itc_spi.c
+++ b/apps/examples/testcase/ta_tc/systemio/itc/itc_spi.c
@@ -16,25 +16,17 @@
  *
  ****************************************************************************/
 
-/// @file iotbus_spi.h
+/// @file itc_spi.c
 
 /// @brief Test Case Iotbus APIs for SPI
 
-#include <tinyara/config.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <errno.h>
-#include <tinyara/time.h>
-#include <sys/time.h>
 #include "itc_internal.h"
 #include <iotbus_spi.h>
 #include <iotbus_error.h>
 
-iotbus_spi_context_h spi;
+static unsigned int gBus = 0;
 
-unsigned int gBus = 0;
-
-struct iotbus_spi_config_s _g_st_config = {
+static struct iotbus_spi_config_s _g_st_config = {
 	(char)8,
 	0,
 	12000000,
@@ -42,14 +34,14 @@ struct iotbus_spi_config_s _g_st_config = {
 };
 
 /**
-* @testcase         itc_iotbus_spi_open_close_p
+* @testcase         itc_systemio_spi_open_close_p
 * @brief            initializes and closes the spi_context
 * @scenario         initializes and closes the spi_context
 * @apicovered       iotbus_spi_open, iotbus_spi_close
 * @precondition     none
 * @postcondition    none
 */
-void itc_iotbus_spi_open_close_p(void)
+void itc_systemio_spi_open_close_p(void)
 {
 	int ret = IOTBUS_ERROR_NONE;
 	iotbus_spi_context_h h_spi = iotbus_spi_open(gBus, &_g_st_config);
@@ -62,14 +54,14 @@ void itc_iotbus_spi_open_close_p(void)
 }
 
 /**
-* @testcase         itc_iotbus_spi_write_recv_trasfer_p
+* @testcase         itc_systemio_spi_write_recv_trasfer_p
 * @brief            reads and writes data over spi bus, and transfers rx and tx data over spi bus
 * @scenario         writes data over spi bus, reads data over spi bus and transfers rx and tx data over spi bus
 * @apicovered       iotbus_spi_write, iotbus_spi_recv, iotbus_spi_transfer_buf
 * @precondition     none
 * @postcondition    none
 */
-void itc_iotbus_spi_write_recv_trasfer_p(void)
+void itc_systemio_spi_write_recv_trasfer_p(void)
 {
 	unsigned char sz_txbuf[64] = { 0, };
 	unsigned char sz_rxbuf[64] = { 0, };
@@ -98,7 +90,7 @@ void itc_iotbus_spi_write_recv_trasfer_p(void)
 
 int itc_spi_main(void)
 {
-	itc_iotbus_spi_open_close_p();
-	itc_iotbus_spi_write_recv_trasfer_p();
+	itc_systemio_spi_open_close_p();
+	itc_systemio_spi_write_recv_trasfer_p();
 	return 0;
 }


### PR DESCRIPTION
Refactor of ITCs of SystemIO spi
add static keyword for local function and variable.
TC Naming rule is <TC_Category>_<Module>_<SubModule>_<FunctionName>_<Positive/Negative>_<AdditionalInformation>
Current TC names do not have above naming convention
Remove not required header files and correct file name comment

Signed-off-by: Arvin Mittal <arvin.mittal@samsung.com>