### PR TITLE
apps/testcase/systemio : uart, gpio ITC refactor

### DIFF
--- a/apps/examples/testcase/ta_tc/systemio/itc/itc_gpio.c
+++ b/apps/examples/testcase/ta_tc/systemio/itc/itc_gpio.c
@@ -21,294 +21,322 @@
 /// @brief Test Case Example for gpio API
 
 #include <tinyara/config.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <errno.h>
-#include <tinyara/time.h>
-#include <sys/time.h>
 #include "itc_internal.h"
 #include <iotbus_gpio.h>
-#include <iotbus_error.h>
-#ifdef CONFIG_ARCH_CHIP_STM32
-#include "../../os/arch/arm/src/mikroequail/src/mikroequail_gpio.h"
-#endif
 
-iotbus_gpio_context_h g_gpio;
-iotbus_gpio_context_h g_gpio2;
+#define GPIO_PIN 41
+#define WAIT_SECONDS 2
 
-int gpio_flag_callback = 0;
+static iotbus_gpio_context_h g_gpio_h;
+static iotbus_gpio_context_h g_gpio_h2;
+
+static int gpio_flag_callback = 0;
+static int gpio_callback_data = -1;
 
 /**
 * @testcase         gpio_event_callback
-* @brief            callback called from itc_gpio_register_unregister_callback_p
+* @brief            callback called from itc_systemio_gpio_register_unregister_callback_p
 * @scenario         successfully invoke callback and iotbus_gpio_read
 * @apicovered       none
 * @precondition     none
 * @postcondition    nona
 */
-void gpio_event_callback(void *user_data)
+static void gpio_event_callback(void *user_data)
 {
 	SYSIO_ITC_PRINT("\n inside the function %s \n", __func__);
 	iotbus_gpio_context_h hnd = (iotbus_gpio_context_h) user_data;
-	int value = iotbus_gpio_read(hnd);
-	if (value < 0) {
-		gpio_flag_callback = 0;
-		return;
-	}
+	gpio_callback_data = iotbus_gpio_read(hnd);
 	gpio_flag_callback = 1;
-
-	return;
 }
 
 /**
-* @testcase         itc_gpio_open_close_p
+* @testcase         itc_systemio_gpio_open_close_p
 * @brief            gpio_open returns handle of gpio context and gpio_close closes the context
 * @scenario         initializes gpio_context based on gpio pin and then closes the gpio_context.
 * @apicovered       iotbus_gpio_open, iotbus_gpio_close
 * @precondition     none
 * @postcondition    none
 */
-void itc_gpio_open_close_p(void)
+static void itc_systemio_gpio_open_close_p(void)
 {
-	int gpiopin = 41;
 	int ret;
-	g_gpio = iotbus_gpio_open(gpiopin);
-	TC_ASSERT_NEQ("iotbus_gpio_open" , g_gpio, NULL);
+	g_gpio_h = NULL;
+	g_gpio_h = iotbus_gpio_open(GPIO_PIN);
+	TC_ASSERT_NEQ("iotbus_gpio_open", g_gpio_h, NULL);
 
-	gpiopin = 14;
-	g_gpio2 = iotbus_gpio_open(gpiopin);
-	TC_ASSERT_EQ_CLEANUP("iotbus_gpio_open", g_gpio2 , NULL , iotbus_gpio_close(g_gpio));
-
-	ret = iotbus_gpio_close(g_gpio);
-	TC_ASSERT_EQ_CLEANUP("iotbus_gpio_close", ret, 0, iotbus_gpio_close(g_gpio2));
-
-	ret = iotbus_gpio_close(g_gpio2);
-	TC_ASSERT_LT("iotbus_gpio_close", ret, 0);
+	ret = iotbus_gpio_close(g_gpio_h);
+	TC_ASSERT_EQ("iotbus_gpio_close", ret, 0);
 
 	TC_SUCCESS_RESULT();
 }
 
 /**
-* @testcase         itc_gpio_set_get_direction_p
+* @testcase         itc_systemio_gpio_set_get_direction_p
 * @brief            sets and gets gpio direction
 * @scenario         Sets gpio direction and then gets the same gpio direction
 * @apicovered       iotbus_gpio_set_direction, iotbus_gpio_get_direction
 * @precondition     open gpio context
 * @postcondition    close gpio context
 */
-void itc_gpio_set_get_direction_p(void)
+static void itc_systemio_gpio_set_get_direction_p(void)
 {
-	int ret, index, ncount, gpiopin;
-	iotbus_gpio_direction_e getDirection;
-	iotbus_gpio_direction_e setDirection[] = { IOTBUS_GPIO_DIRECTION_NONE, IOTBUS_GPIO_DIRECTION_OUT, IOTBUS_GPIO_DIRECTION_IN };
-	ncount = sizeof(setDirection) / sizeof(setDirection[0]);
+	int ret;
+	g_gpio_h = NULL;
+	int index;
+	int ncount;
+	iotbus_gpio_direction_e get_direction;
+	iotbus_gpio_direction_e set_direction[] = { IOTBUS_GPIO_DIRECTION_NONE, IOTBUS_GPIO_DIRECTION_OUT, IOTBUS_GPIO_DIRECTION_IN };
+	char *ptr_dir[] = { "IOTBUS_GPIO_DIRECTION_NONE", "IOTBUS_GPIO_DIRECTION_OUT", "IOTBUS_GPIO_DIRECTION_IN" };
+	ncount = sizeof(set_direction) / sizeof(set_direction[0]);
 	bool check = true;
-	gpiopin = 41;
-	g_gpio = iotbus_gpio_open(gpiopin);
-	TC_ASSERT_NEQ("iotbus_gpio_open" , g_gpio, NULL);
+	g_gpio_h = iotbus_gpio_open(GPIO_PIN);
+	TC_ASSERT_NEQ("iotbus_gpio_open", g_gpio_h, NULL);
 
 	for (index = 0; index < ncount; index++) {
-		ret = iotbus_gpio_set_direction(g_gpio, setDirection[index]);
+		ret = iotbus_gpio_set_direction(g_gpio_h, set_direction[index]);
 
 		if (ret != 0) {
-			SYSIO_ITC_PRINT("\nitc_gpio_set_get_direction: iotbus_gpio_set_direction FAIL for array index : %d\n", index);
+			SYSIO_ITC_PRINT("\nitc_systemio_gpio_set_get_direction: iotbus_gpio_set_direction FAIL for direction : %s\n", ptr_dir[index]);
 			check = false;
 			continue;
 		}
 
-		ret = iotbus_gpio_get_direction(g_gpio, &getDirection);
+		ret = iotbus_gpio_get_direction(g_gpio_h, &get_direction);
 		if (ret != 0) {
-			SYSIO_ITC_PRINT("\nitc_gpio_set_get_direction: iotbus_gpio_get_direction FAIL for array index : %d\n", index);
+			SYSIO_ITC_PRINT("\nitc_systemio_gpio_set_get_direction: iotbus_gpio_get_direction FAIL for direction : %s\n", ptr_dir[index]);
 			check = false;
 			continue;
 		}
 
-		if (getDirection != setDirection[index]) {
-			SYSIO_ITC_PRINT("\nitc_gpio_set_get_direction: FAIL, set and get values not same for array index : %d\n", index);
+		if (get_direction != set_direction[index]) {
+			SYSIO_ITC_PRINT("\nitc_systemio_gpio_set_get_direction: FAIL, set and get values not same for direction : %s\n", ptr_dir[index]);
 			check = false;
 		}
 	}
 
-	TC_ASSERT_EQ_CLEANUP("iotbus_gpio_set_get_direction", check , true , iotbus_gpio_close(g_gpio));
-	iotbus_gpio_close(g_gpio);
+	TC_ASSERT_EQ_CLEANUP("iotbus_gpio_set_get_direction", check, true, iotbus_gpio_close(g_gpio_h));
+	ret = iotbus_gpio_close(g_gpio_h);
+	TC_ASSERT_EQ("iotbus_gpio_close", ret, 0);
+
 	TC_SUCCESS_RESULT();
 }
 
 /**
-* @testcase         itc_gpio_set_get_edge_mode_p
+* @testcase         itc_systemio_gpio_set_get_edge_mode_p
 * @brief            sets and gets gpio edge mode
 * @scenario         Sets gpio edge mode and then gets the same gpio edge mode
 * @apicovered       iotbus_gpio_set_edge_mode, iotbus_gpio_get_edge_mode
 * @precondition     open gpio context
 * @postcondition    close gpio context
 */
-void itc_gpio_set_get_edge_mode_p(void)
+static void itc_systemio_gpio_set_get_edge_mode_p(void)
 {
-	int ret, index, ncount, gpiopin;
-	iotbus_gpio_edge_e getEdge;
-	iotbus_gpio_edge_e setEdge[] = { IOTBUS_GPIO_EDGE_NONE, IOTBUS_GPIO_EDGE_BOTH, IOTBUS_GPIO_EDGE_RISING, IOTBUS_GPIO_EDGE_FALLING };
-	ncount = sizeof(setEdge) / sizeof(setEdge[0]);
+	int ret;
+	g_gpio_h = NULL;
+	int index;
+	int ncount;
+	iotbus_gpio_edge_e get_edge;
+	iotbus_gpio_edge_e set_edge[] = { IOTBUS_GPIO_EDGE_NONE, IOTBUS_GPIO_EDGE_BOTH, IOTBUS_GPIO_EDGE_RISING, IOTBUS_GPIO_EDGE_FALLING };
+	char *ptr_edge[] = { "IOTBUS_GPIO_EDGE_NONE", "IOTBUS_GPIO_EDGE_BOTH", "IOTBUS_GPIO_EDGE_RISING", "IOTBUS_GPIO_EDGE_FALLING" };
+	ncount = sizeof(set_edge) / sizeof(set_edge[0]);
 	bool check = true;
-	gpiopin = 41;
-	g_gpio = iotbus_gpio_open(gpiopin);
-	TC_ASSERT_NEQ("iotbus_gpio_open" , g_gpio, NULL);
+	g_gpio_h = iotbus_gpio_open(GPIO_PIN);
+	TC_ASSERT_NEQ("iotbus_gpio_open", g_gpio_h, NULL);
 
 	for (index = 0; index < ncount; index++) {
-		ret = iotbus_gpio_set_edge_mode(g_gpio, setEdge[index]);
+		ret = iotbus_gpio_set_edge_mode(g_gpio_h, set_edge[index]);
 		if (ret != 0) {
-			SYSIO_ITC_PRINT("\nitc_gpio_set_get_edge_mode: iotbus_gpio_set_edge_mode FAIL for array index : %d\n", index);
+			SYSIO_ITC_PRINT("\nitc_systemio_gpio_set_get_edge_mode: iotbus_gpio_set_edge_mode FAIL for edge mode : %s\n", ptr_edge[index]);
 			check = false;
 			continue;
 		}
-		ret = iotbus_gpio_get_edge_mode(g_gpio, &getEdge);
+		ret = iotbus_gpio_get_edge_mode(g_gpio_h, &get_edge);
 		if (ret != 0) {
-			SYSIO_ITC_PRINT("\nitc_gpio_set_get_edge_mode: iotbus_gpio_get_edge_mode FAIL for array index : %d\n", index);
+			SYSIO_ITC_PRINT("\nitc_systemio_gpio_set_get_edge_mode: iotbus_gpio_get_edge_mode FAIL for edge mode : %s\n", ptr_edge[index]);
 			check = false;
 			continue;
 		}
-		if (getEdge != setEdge[index]) {
-			SYSIO_ITC_PRINT("\nitc_gpio_set_get_edge_mode: FAIL, set and get values not same for array index : %d\n", index);
+		if (get_edge != set_edge[index]) {
+			SYSIO_ITC_PRINT("\nitc_systemio_gpio_set_get_edge_mode: FAIL, set and get values not same for edge mode : %s\n", ptr_edge[index]);
 			check = false;
 		}
 	}
 
-	TC_ASSERT_EQ_CLEANUP("iotbus_gpio_set_get_edge", check , true , iotbus_gpio_close(g_gpio));
-	iotbus_gpio_close(g_gpio);
+	TC_ASSERT_EQ_CLEANUP("iotbus_gpio_set_get_edge", check, true, iotbus_gpio_close(g_gpio_h));
+	ret = iotbus_gpio_close(g_gpio_h);
+	TC_ASSERT_EQ("iotbus_gpio_close", ret, 0);
+
 	TC_SUCCESS_RESULT();
 }
 
 /**
-* @testcase         itc_gpio_set_get_drive_mode_p
+* @testcase         itc_systemio_gpio_set_get_drive_mode_p
 * @brief            sets and gets gpio drive mode
 * @scenario         Sets gpio drive mode and then gets the same gpio drive mode
 * @apicovered       iotbus_gpio_set_drive_mode, iotbus_gpio_get_drive_mode
 * @precondition     open gpio context
 * @postcondition    close gpio context
 */
-void itc_gpio_set_get_drive_mode_p(void)
+static void itc_systemio_gpio_set_get_drive_mode_p(void)
 {
-	int gpiopin = 41;
-	int ret, index, ncount;
-	iotbus_gpio_drive_e getDrive;
-	iotbus_gpio_drive_e setDrive[] = { IOTBUS_GPIO_DRIVE_PULLUP, IOTBUS_GPIO_DRIVE_PULLDOWN, IOTBUS_GPIO_DRIVE_FLOAT };
-	ncount = sizeof(setDrive) / sizeof(setDrive[0]);
+	int ret;
+	g_gpio_h = NULL;
+	int index;
+	int ncount;
+	iotbus_gpio_drive_e get_drive;
+	iotbus_gpio_drive_e set_drive[] = { IOTBUS_GPIO_DRIVE_PULLUP, IOTBUS_GPIO_DRIVE_PULLDOWN, IOTBUS_GPIO_DRIVE_FLOAT };
+	char *ptr_drive[] = { "IOTBUS_GPIO_DRIVE_PULLUP", "IOTBUS_GPIO_DRIVE_PULLDOWN", "IOTBUS_GPIO_DRIVE_FLOAT" };
+	ncount = sizeof(set_drive) / sizeof(set_drive[0]);
 	bool check = true;
 
-	g_gpio = iotbus_gpio_open(gpiopin);
-	TC_ASSERT_NEQ("iotbus_gpio_open" , g_gpio, NULL);
+	g_gpio_h = iotbus_gpio_open(GPIO_PIN);
+	TC_ASSERT_NEQ("iotbus_gpio_open", g_gpio_h, NULL);
 
 	for (index = 0; index < ncount; index++) {
-		ret = iotbus_gpio_set_drive_mode(g_gpio, setDrive[index]);
+		ret = iotbus_gpio_set_drive_mode(g_gpio_h, set_drive[index]);
 		if (ret != 0) {
-			SYSIO_ITC_PRINT("\nitc_gpio_set_get_drive_mode: iotbus_gpio_set_drive_mode FAIL for array index : %d\n", index);
+			check = false;
+			SYSIO_ITC_PRINT("\nitc_systemio_gpio_set_get_drive_mode: iotbus_gpio_set_drive_mode FAIL for drive : %s\n", ptr_drive[index]);
+			continue;
+		}
+		ret = iotbus_gpio_get_drive_mode(g_gpio_h, &get_drive);
+		if (ret != 0) {
+			SYSIO_ITC_PRINT("\nitc_systemio_gpio_set_get_drive_mode: iotbus_gpio_get_drive_mode FAIL for drive : %s\n", ptr_drive[index]);
 			check = false;
 			continue;
 		}
-		ret = iotbus_gpio_get_drive_mode(g_gpio, &getDrive);
-		if (ret != 0) {
-			SYSIO_ITC_PRINT("\nitc_gpio_set_get_drive_mode: iotbus_gpio_get_drive_mode FAIL for array index : %d\n", index);
-			check = false;
-			continue;
-		}
-		if (getDrive != setDrive[index]) {
-			SYSIO_ITC_PRINT("\nitc_gpio_set_get_drive_mode: FAIL, set and get values not same for array index : %d\n", index);
+		if (get_drive != set_drive[index]) {
+			SYSIO_ITC_PRINT("\nitc_systemio_gpio_set_get_drive_mode: FAIL, set and get values not same for drive : %s\n", ptr_drive[index]);
 			check = false;
 		}
 	}
 
-	TC_ASSERT_EQ_CLEANUP("iotbus_gpio_set_get_drive_mode", check , true , iotbus_gpio_close(g_gpio));
-	iotbus_gpio_close(g_gpio);
+	TC_ASSERT_EQ_CLEANUP("iotbus_gpio_set_get_drive_mode", check, true, iotbus_gpio_close(g_gpio_h));
+	ret = iotbus_gpio_close(g_gpio_h);
+	TC_ASSERT_EQ("iotbus_gpio_close", ret, 0);
+
 	TC_SUCCESS_RESULT();
 }
 
 /**
-* @testcase         itc_gpio_get_pin_p
+* @testcase         itc_systemio_gpio_get_pin_p
 * @brief            gets a pin number of the gpio.
 * @scenario         gets a pin number of the gpio.
 * @apicovered       iotbus_gpio_get_pin
 * @precondition     open gpio context
 * @postcondition    close gpio context
 */
-void itc_gpio_get_pin_p(void)
+static void itc_systemio_gpio_get_pin_p(void)
 {
-	int gpioSetpin = 41;
-	int gpioGetpin;
-	iotbus_gpio_context_h m_gpio = iotbus_gpio_open(gpioSetpin);
-	TC_ASSERT_NEQ("iotbus_gpio_open" , m_gpio, NULL);
+	int ret;
+	int gpio_set_pin = GPIO_PIN;
+	int gpio_get_pin;
+	iotbus_gpio_context_h m_gpio = iotbus_gpio_open(gpio_set_pin);
+	TC_ASSERT_NEQ("iotbus_gpio_open", m_gpio, NULL);
 
-	gpioGetpin = iotbus_gpio_get_pin(m_gpio);
-	TC_ASSERT_EQ_CLEANUP("iotbus_gpio_get_pin", gpioGetpin, gpioSetpin, iotbus_gpio_close(m_gpio));
+	gpio_get_pin = iotbus_gpio_get_pin(m_gpio);
+	TC_ASSERT_EQ_CLEANUP("iotbus_gpio_get_pin", gpio_get_pin, gpio_set_pin, iotbus_gpio_close(m_gpio));
 
-	iotbus_gpio_close(m_gpio);
+	ret = iotbus_gpio_close(m_gpio);
+	TC_ASSERT_EQ("iotbus_gpio_close", ret, 0);
+
 	TC_SUCCESS_RESULT();
 }
 
 /**
-* @testcase         itc_gpio_read_write_p
+* @testcase         itc_systemio_gpio_read_write_p
 * @brief            reads and writes the gpio value
 * @scenario         reads and writes the gpio value
 * @apicovered       iotbus_gpio_read, iotbus_gpio_write
 * @precondition     open gpio context
 * @postcondition    close gpio context
 */
-void itc_gpio_read_write_p(void)
+static void itc_systemio_gpio_read_write_p(void)
 {
-	int ret, gpiopin = 41;
-	g_gpio = iotbus_gpio_open(gpiopin);
-	TC_ASSERT_NEQ("iotbus_gpio_open" , g_gpio, NULL);
+	int ret;
+	g_gpio_h = NULL;
+	g_gpio_h = iotbus_gpio_open(GPIO_PIN);
+	TC_ASSERT_NEQ("iotbus_gpio_open", g_gpio_h, NULL);
 
-	ret = iotbus_gpio_read(g_gpio);
-	TC_ASSERT_EQ_CLEANUP("iotbus_gpio_read", (ret < 0), false, iotbus_gpio_close(g_gpio));
+	ret = iotbus_gpio_read(g_gpio_h);
+	TC_ASSERT_EQ_CLEANUP("iotbus_gpio_read", (ret < 0), false, iotbus_gpio_close(g_gpio_h));
 
-	ret = iotbus_gpio_write(g_gpio, 1);
-	TC_ASSERT_EQ_CLEANUP("iotbus_gpio_write", (ret < 0), false, iotbus_gpio_close(g_gpio));
+	ret = iotbus_gpio_write(g_gpio_h, 1);
+	TC_ASSERT_EQ_CLEANUP("iotbus_gpio_write", (ret < 0), false, iotbus_gpio_close(g_gpio_h));
 
-	iotbus_gpio_close(g_gpio);
+	ret = iotbus_gpio_close(g_gpio_h);
+	TC_ASSERT_EQ("iotbus_gpio_close", ret, 0);
+
 	TC_SUCCESS_RESULT();
 }
 
 /**
-* @testcase         itc_gpio_register_unregister_callback_p
+* @testcase         itc_systemio_gpio_register_unregister_callback_p
 * @brief            register and unregister event handler callback for interrupt
 * @scenario         register and unregister event handler callback for interrupt
 * @apicovered       iotbus_gpio_register_cb, iotbus_gpio_unregister_cb
 * @precondition     open gpio context
 * @postcondition    close gpio context
 */
-void itc_gpio_register_unregister_callback_p(void)
+static void itc_systemio_gpio_register_unregister_callback_p(void)
 {
 	gpio_flag_callback = 0;
 	int ret;
-	int data = 0, gpio_pin2 = 57, gpio_pin1 = 41;
+	g_gpio_h = NULL;
+	g_gpio_h2 = NULL;
+	int data = 0;
+	int gpio_pin2 = 57;
+	int gpio_pin1 = GPIO_PIN;
 
-	g_gpio = iotbus_gpio_open(gpio_pin1);
-	TC_ASSERT_NEQ("iotbus_gpio_open" , g_gpio, NULL);
+	g_gpio_h = iotbus_gpio_open(gpio_pin1);
+	TC_ASSERT_NEQ("iotbus_gpio_open", g_gpio_h, NULL);
 
-	g_gpio2 = iotbus_gpio_open(gpio_pin2);
-	TC_ASSERT_NEQ_CLEANUP("iotbus_gpio_open", g_gpio2 , NULL , iotbus_gpio_close(g_gpio));
+	g_gpio_h2 = iotbus_gpio_open(gpio_pin2);
+	TC_ASSERT_NEQ_CLEANUP("iotbus_gpio_open", g_gpio_h2, NULL, iotbus_gpio_close(g_gpio_h));
 
-	iotbus_gpio_set_direction(g_gpio, IOTBUS_GPIO_DIRECTION_OUT);
-	iotbus_gpio_set_direction(g_gpio2, IOTBUS_GPIO_DIRECTION_IN);
+	ret = iotbus_gpio_set_direction(g_gpio_h, IOTBUS_GPIO_DIRECTION_OUT);
+	TC_ASSERT_EQ_CLEANUP("iotbus_gpio_set_direction", ret, 0, iotbus_gpio_close(g_gpio_h2); iotbus_gpio_close(g_gpio_h));
 
-	ret = iotbus_gpio_register_cb(g_gpio2, IOTBUS_GPIO_EDGE_RISING, gpio_event_callback, (void *)g_gpio2);
-	TC_ASSERT_EQ_CLEANUP("iotbus_gpio_register_cb", ret , 0, iotbus_gpio_close(g_gpio2); iotbus_gpio_close(g_gpio));
+	ret = iotbus_gpio_set_direction(g_gpio_h2, IOTBUS_GPIO_DIRECTION_IN);
+	TC_ASSERT_EQ_CLEANUP("iotbus_gpio_set_direction", ret, 0, iotbus_gpio_close(g_gpio_h2); iotbus_gpio_close(g_gpio_h));
+
+	ret = iotbus_gpio_register_cb(g_gpio_h2, IOTBUS_GPIO_EDGE_BOTH, gpio_event_callback, (void *)g_gpio_h2);
+	TC_ASSERT_EQ_CLEANUP("iotbus_gpio_register_cb", ret, 0, iotbus_gpio_close(g_gpio_h2); iotbus_gpio_close(g_gpio_h));
 
 	// To trigger event for callback
-	iotbus_gpio_write(g_gpio, data);
-	sleep(1);
+	ret = iotbus_gpio_write(g_gpio_h, data);
+	TC_ASSERT_EQ_CLEANUP("iotbus_gpio_write", ret, 0, iotbus_gpio_close(g_gpio_h2); iotbus_gpio_close(g_gpio_h));
+	sleep(WAIT_SECONDS);
+
+	TC_ASSERT_EQ_CLEANUP("iotbus_gpio_register_cb not triggered", gpio_flag_callback, 1, iotbus_gpio_unregister_cb(g_gpio_h2); iotbus_gpio_close(g_gpio_h2); iotbus_gpio_close(g_gpio_h));
+	TC_ASSERT_EQ_CLEANUP("iotbus_gpio_register_cb response", gpio_callback_data, data, iotbus_gpio_unregister_cb(g_gpio_h2); iotbus_gpio_close(g_gpio_h2); iotbus_gpio_close(g_gpio_h));
+
+	gpio_flag_callback = 0;
 	data = 1;
-	iotbus_gpio_write(g_gpio, data);
-	sleep(2);
 
-	TC_ASSERT_EQ_CLEANUP("iotbus_gpio_register_cb", gpio_flag_callback, 1, iotbus_gpio_unregister_cb(g_gpio); iotbus_gpio_close(g_gpio2); iotbus_gpio_close(g_gpio));
+	ret = iotbus_gpio_write(g_gpio_h, data);
+	TC_ASSERT_EQ_CLEANUP("iotbus_gpio_register_cb", ret, 0, iotbus_gpio_unregister_cb(g_gpio_h2); iotbus_gpio_close(g_gpio_h2); iotbus_gpio_close(g_gpio_h));
+	sleep(WAIT_SECONDS);
 
-	ret = iotbus_gpio_unregister_cb(g_gpio);
-	TC_ASSERT_EQ_CLEANUP("iotbus_gpio_unregister_cb", ret, 0, iotbus_gpio_close(g_gpio2); iotbus_gpio_close(g_gpio));
+	TC_ASSERT_EQ_CLEANUP("iotbus_gpio_register_cb triggered", gpio_flag_callback, 1, iotbus_gpio_unregister_cb(g_gpio_h2); iotbus_gpio_close(g_gpio_h2); iotbus_gpio_close(g_gpio_h));
+	TC_ASSERT_EQ_CLEANUP("iotbus_gpio_register_cb response", gpio_callback_data, data, iotbus_gpio_unregister_cb(g_gpio_h2); iotbus_gpio_close(g_gpio_h2); iotbus_gpio_close(g_gpio_h));
 
-	ret = iotbus_gpio_close(g_gpio2);
-	TC_ASSERT_EQ_CLEANUP("iotbus_gpio_close", ret, 0 , iotbus_gpio_close(g_gpio));
+	ret = iotbus_gpio_unregister_cb(g_gpio_h2);
+	TC_ASSERT_EQ_CLEANUP("iotbus_gpio_unregister_cb", ret, 0, iotbus_gpio_close(g_gpio_h2); iotbus_gpio_close(g_gpio_h));
 
-	ret = iotbus_gpio_close(g_gpio);
+	gpio_flag_callback = 0;
+	data = 1;
+
+	ret = iotbus_gpio_write(g_gpio_h, data);
+	TC_ASSERT_EQ_CLEANUP("iotbus_gpio_register_cb", ret, 0, iotbus_gpio_unregister_cb(g_gpio_h2); iotbus_gpio_close(g_gpio_h2); iotbus_gpio_close(g_gpio_h));
+	sleep(WAIT_SECONDS);
+
+	TC_ASSERT_EQ_CLEANUP("iotbus_gpio_register_cb triggered", gpio_flag_callback, 0, iotbus_gpio_unregister_cb(g_gpio_h2); iotbus_gpio_close(g_gpio_h2); iotbus_gpio_close(g_gpio_h));
+
+	ret = iotbus_gpio_close(g_gpio_h2);
+	TC_ASSERT_EQ_CLEANUP("iotbus_gpio_close", ret, 0, iotbus_gpio_close(g_gpio_h));
+
+	ret = iotbus_gpio_close(g_gpio_h);
 	TC_ASSERT_EQ(iotbus_gpio_close, ret, 0)
 
 	TC_SUCCESS_RESULT();
@@ -318,13 +346,13 @@ int itc_gpio_main(void)
 {
 	iotapi_initialize();
 
-	itc_gpio_open_close_p();
-	itc_gpio_get_pin_p();
-	itc_gpio_set_get_direction_p();
-	itc_gpio_set_get_edge_mode_p();
-	itc_gpio_set_get_drive_mode_p();
-	itc_gpio_read_write_p();
-	itc_gpio_register_unregister_callback_p();
+	itc_systemio_gpio_open_close_p();
+	itc_systemio_gpio_get_pin_p();
+	itc_systemio_gpio_set_get_direction_p();
+	itc_systemio_gpio_set_get_edge_mode_p();
+	itc_systemio_gpio_set_get_drive_mode_p();
+	itc_systemio_gpio_read_write_p();
+	itc_systemio_gpio_register_unregister_callback_p();//TC FAIL, callback is not invoked
 
 	return 0;
 }

--- a/apps/examples/testcase/ta_tc/systemio/itc/itc_uart.c
+++ b/apps/examples/testcase/ta_tc/systemio/itc/itc_uart.c
@@ -16,7 +16,7 @@
  *
  ****************************************************************************/
 
-/// @file iotbus_uart.h
+/// @file itc_uart.c
 
 /// @brief Test Case Iotbus APIs for UART
 
@@ -24,12 +24,6 @@
  * Included Files
  ****************************************************************************/
 #include <tinyara/config.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include <errno.h>
-#include <termios.h>
-
 #include <iotbus_uart.h>
 #include "itc_internal.h"
 #include "iotbus_error.h"
@@ -42,14 +36,14 @@
 #endif
 
 /**
-* @testcase         itc_iotbus_uart_init_stop_p
+* @testcase         itc_systemio_iotbus_uart_init_stop_p
 * @brief            initializes and closes uart_context
 * @scenario         initializes and closes uart_context
 * @apicovered       iotbus_uart_init, iotbus_uart_stop
 * @precondition     none
 * @postcondition    none
 */
-void itc_iotbus_uart_init_stop_p(void)
+void itc_systemio_iotbus_uart_init_stop_p(void)
 {
 	int ret = IOTBUS_ERROR_NONE;
 	iotbus_uart_context_h h_uart = iotbus_uart_init(DEVPATH);
@@ -62,14 +56,14 @@ void itc_iotbus_uart_init_stop_p(void)
 }
 
 /**
-* @testcase         itc_iotbus_uart_set_baudrate_p
+* @testcase         itc_systemio_iotbus_uart_set_baudrate_p
 * @brief            sets uart baud rate
 * @scenario         sets uart baud rate
 * @apicovered       iotbus_uart_set_baudrate
 * @precondition     initializes uart_context
 * @postcondition    closes uart_context
 */
-void itc_iotbus_uart_set_baudrate_p(void)
+void itc_systemio_iotbus_uart_set_baudrate_p(void)
 {
 	int i_baudrate = 115200;
 	int ret = IOTBUS_ERROR_NONE;
@@ -86,14 +80,14 @@ void itc_iotbus_uart_set_baudrate_p(void)
 }
 
 /**
-* @testcase         itc_iotbus_uart_set_mode_p
+* @testcase         itc_systemio_iotbus_uart_set_mode_p
 * @brief            sets byte size, parity bit and stop bits
 * @scenario         sets byte size, parity bit and stop bits
 * @apicovered       iotbus_uart_set_mode
 * @precondition     initializes uart_context
 * @postcondition    closes uart_context
 */
-void itc_iotbus_uart_set_mode_p(void)
+void itc_systemio_iotbus_uart_set_mode_p(void)
 {
 	int i_bytesize = 8;
 	int i_stop_bits = 1;
@@ -116,14 +110,14 @@ void itc_iotbus_uart_set_mode_p(void)
 }
 
 /**
-* @testcase         itc_iotbus_uart_set_flowcontrol_p
+* @testcase         itc_systemio_iotbus_uart_set_flowcontrol_p
 * @brief            set flow control settings
 * @scenario         set flow control settings
 * @apicovered       iotbus_uart_set_flowcontrol
 * @precondition     initializes uart_context
 * @postcondition    closes uart_context
 */
-void itc_iotbus_uart_set_flowcontrol_p(void)
+void itc_systemio_iotbus_uart_set_flowcontrol_p(void)
 {
 	int i_size = 4;
 	int ret = IOTBUS_ERROR_NONE;
@@ -144,14 +138,14 @@ void itc_iotbus_uart_set_flowcontrol_p(void)
 }
 
 /**
-* @testcase         itc_iotbus_uart_write_read_p
+* @testcase         itc_systemio_iotbus_uart_write_read_p
 * @brief            write and read data over uart bus
 * @scenario         write and read data over uart bus
 * @apicovered       iotbus_uart_write, iotbus_uart_read
 * @precondition     initializes uart_context
 * @postcondition    closes uart_context
 */
-void itc_iotbus_uart_write_read_p(void)
+void itc_systemio_iotbus_uart_write_read_p(void)
 {
 	int ret = IOTBUS_ERROR_NONE;
 	char szInputText[32] = "UART READ/WRITE ITC TESTING!";
@@ -176,14 +170,14 @@ void itc_iotbus_uart_write_read_p(void)
 }
 
 /**
-* @testcase         itc_iotbus_uart_flush_p
+* @testcase         itc_systemio_iotbus_uart_flush_p
 * @brief            flushes uart buffer
 * @scenario         flushes uart buffer
 * @apicovered       iotbus_uart_flush
 * @precondition     initializes uart_context
 * @postcondition    closes uart_context
 */
-void itc_iotbus_uart_flush_p(void)
+void itc_systemio_iotbus_uart_flush_p(void)
 {
 	int ret = IOTBUS_ERROR_NONE;
 	iotbus_uart_context_h h_uart = iotbus_uart_init(DEVPATH);
@@ -207,12 +201,12 @@ int itc_uart_main(void)
 #ifndef CONFIG_SERIAL_TERMIOS
 	SYSIO_ITC_UART_PRINT("IOTBUS Not Supported\n");
 #else
-	itc_iotbus_uart_init_stop_p();
-	itc_iotbus_uart_set_baudrate_p();
-	itc_iotbus_uart_set_mode_p();
-	itc_iotbus_uart_set_flowcontrol_p();
-	itc_iotbus_uart_write_read_p();
-	itc_iotbus_uart_flush_p();
+	itc_systemio_iotbus_uart_init_stop_p();
+	itc_systemio_iotbus_uart_set_baudrate_p();
+	itc_systemio_iotbus_uart_set_mode_p();
+	itc_systemio_iotbus_uart_set_flowcontrol_p();
+	itc_systemio_iotbus_uart_write_read_p();
+	itc_systemio_iotbus_uart_flush_p();
 #endif
 
 	return 0;


### PR DESCRIPTION
Refactor of ITCs of SystemIO : uart and gpio
TC Naming rule is <TC_Category>_<Module>_<SubModule>_<FunctionName>_<Positive/Negative>_<AdditionalInformation>
Current TC names do not have above naming convention
Remove not required header files and correct file name comment
Restructure TCs and declare variable in seperate line.
Current TC do not have this conventtion

Signed-off-by: Arvin Mittal <arvin.mittal@samsung.com>