### PR TITLE
testcase/ta_tc/SystemIO : add ITCs for SystemIO APIs

### DIFF
--- a/apps/examples/testcase/ta_tc/systemio/itc/itc_gpio.c
+++ b/apps/examples/testcase/ta_tc/systemio/itc/itc_gpio.c
@@ -23,9 +23,11 @@
 #include <tinyara/config.h>
 #include "itc_internal.h"
 #include <iotbus_gpio.h>
+#include <iotbus_error.h>
 
 #define GPIO_PIN 41
 #define WAIT_SECONDS 2
+#define LOOP_COUNT 10
 
 static iotbus_gpio_context_h g_gpio_h;
 static iotbus_gpio_context_h g_gpio_h2;
@@ -342,6 +344,793 @@ static void itc_systemio_gpio_register_unregister_callback_p(void)
 	TC_SUCCESS_RESULT();
 }
 
+/**
+* @testcase         itc_systemio_gpio_set_direction_read_write_p_all_directions
+* @brief            sets and gets gpio direction and read write
+* @scenario         Sets gpio direction and then gets the same gpio direction. reads and writes the gpio value
+* @apicovered       iotbus_gpio_set_direction, iotbus_gpio_get_direction, iotbus_gpio_read, iotbus_gpio_write
+* @precondition     open gpio context
+* @postcondition    close gpio context
+*/
+static void itc_systemio_gpio_set_direction_read_write_p_all_directions(void)
+{
+	int ret;
+	g_gpio_h = NULL;
+	int count_dir;
+	int i;
+
+	iotbus_gpio_direction_e get_direction;
+	iotbus_gpio_direction_e set_direction[] = { IOTBUS_GPIO_DIRECTION_NONE, IOTBUS_GPIO_DIRECTION_OUT, IOTBUS_GPIO_DIRECTION_IN };
+	char *ptr_dir[] = { "IOTBUS_GPIO_DIRECTION_NONE", "IOTBUS_GPIO_DIRECTION_OUT", "IOTBUS_GPIO_DIRECTION_IN" };
+
+	count_dir = sizeof(set_direction) / sizeof(set_direction[0]);
+	bool check = true;
+	g_gpio_h = iotbus_gpio_open(GPIO_PIN);
+	TC_ASSERT_NEQ("iotbus_gpio_open", g_gpio_h, NULL);
+
+	for (i = 0; i < count_dir; i++) {
+		ret = iotbus_gpio_set_direction(g_gpio_h, set_direction[i]);
+		if (ret != 0) {
+			SYSIO_ITC_PRINT("itc_systemio_gpio_all_direction_read_write_p: iotbus_gpio_set_direction FAIL for direction %s\n", ptr_dir[i]);
+			check = false;
+			continue;
+		}
+		ret = iotbus_gpio_get_direction(g_gpio_h, &get_direction);
+		if (ret != 0) {
+			SYSIO_ITC_PRINT("itc_systemio_gpio_all_direction_read_write_p: iotbus_gpio_get_direction FAIL for direction %s\n", ptr_dir[i]);
+			check = false;
+			continue;
+		}
+		if (get_direction != set_direction[i]) {
+			SYSIO_ITC_PRINT("itc_systemio_gpio_all_direction_read_write_p: FAIL, set and get values not same for direction %s\n", ptr_dir[i]);
+			check = false;
+		}
+
+		ret = iotbus_gpio_read(g_gpio_h);
+		TC_ASSERT_EQ_CLEANUP("iotbus_gpio_read", (ret < 0), false, iotbus_gpio_close(g_gpio_h));
+
+		ret = iotbus_gpio_write(g_gpio_h, 1);
+		TC_ASSERT_EQ_CLEANUP("iotbus_gpio_write", (ret < 0), false, iotbus_gpio_close(g_gpio_h));
+	}
+	TC_ASSERT_EQ_CLEANUP("itc_systemio_gpio_all_direction_read_write_p", check, true, iotbus_gpio_close(g_gpio_h));
+	iotbus_gpio_close(g_gpio_h);
+	TC_SUCCESS_RESULT();
+}
+
+/**
+* @testcase         itc_systemio_gpio_set_edge_read_write_p_all_edges
+* @brief            sets and gets gpio edge mode and gpio read and write
+* @scenario         Sets gpio edge mode and then gets the same gpio edge mode. reads and writes the gpio value
+* @apicovered       iotbus_gpio_set_edge_mode, iotbus_gpio_get_edge_mode, iotbus_gpio_read, iotbus_gpio_write
+* @precondition     open gpio context
+* @postcondition    close gpio context
+*/
+static void itc_systemio_gpio_set_edge_read_write_p_all_edges(void)
+{
+	int ret;
+	g_gpio_h = NULL;
+	int count_edge;
+	int i;
+
+	iotbus_gpio_edge_e get_edge;
+	iotbus_gpio_edge_e set_edge[] = { IOTBUS_GPIO_EDGE_NONE, IOTBUS_GPIO_EDGE_BOTH, IOTBUS_GPIO_EDGE_RISING, IOTBUS_GPIO_EDGE_FALLING };
+	char *ptr_edge[] = { "IOTBUS_GPIO_EDGE_NONE", "IOTBUS_GPIO_EDGE_BOTH", "IOTBUS_GPIO_EDGE_RISING", "IOTBUS_GPIO_EDGE_FALLING" };
+
+	count_edge = sizeof(set_edge) / sizeof(set_edge[0]);
+	bool check = true;
+	g_gpio_h = iotbus_gpio_open(GPIO_PIN);
+	TC_ASSERT_NEQ("iotbus_gpio_open", g_gpio_h, NULL);
+
+	for (i = 0; i < count_edge; i++) {
+		ret = iotbus_gpio_set_edge_mode(g_gpio_h, set_edge[i]);
+		if (ret != 0) {
+			SYSIO_ITC_PRINT("itc_systemio_gpio_all_edge_read_write_p: iotbus_gpio_set_edge_mode FAIL for edge %s\n", ptr_edge[i]);
+			check = false;
+			continue;
+		}
+		ret = iotbus_gpio_get_edge_mode(g_gpio_h, &get_edge);
+		if (ret != 0) {
+			SYSIO_ITC_PRINT("itc_systemio_gpio_all_edge_read_write_p: iotbus_gpio_get_edge_mode FAIL for edge %s\n", ptr_edge[i]);
+			check = false;
+			continue;
+		}
+		if (get_edge != set_edge[i]) {
+			SYSIO_ITC_PRINT("itc_systemio_gpio_all_edge_read_write_p: FAIL, set and get values not same for edge %s\n", ptr_edge[i]);
+			check = false;
+		}
+
+		ret = iotbus_gpio_read(g_gpio_h);
+		TC_ASSERT_EQ_CLEANUP("iotbus_gpio_read", (ret < 0), false, iotbus_gpio_close(g_gpio_h));
+
+		ret = iotbus_gpio_write(g_gpio_h, 1);
+		TC_ASSERT_EQ_CLEANUP("iotbus_gpio_write", (ret < 0), false, iotbus_gpio_close(g_gpio_h));
+	}
+	TC_ASSERT_EQ_CLEANUP("itc_systemio_gpio_all_edge_read_write_p", check, true, iotbus_gpio_close(g_gpio_h));
+	iotbus_gpio_close(g_gpio_h);
+	TC_SUCCESS_RESULT();
+}
+
+/**
+* @testcase         itc_systemio_gpio_set_drive_read_write_p_all_drive_mode
+* @brief            sets and gets gpio drive mode and gpio read and write
+* @scenario         Sets gpio drive mode and then gets the same gpio drive mode. reads and writes the gpio value
+* @apicovered       iotbus_gpio_set_drive_mode, iotbus_gpio_get_drive_mode, iotbus_gpio_read, iotbus_gpio_write
+* @precondition     open gpio context
+* @postcondition    close gpio context
+*/
+static void itc_systemio_gpio_set_drive_read_write_p_all_drive_mode(void)
+{
+	int ret;
+	g_gpio_h = NULL;
+	int count_drive;
+	int i;
+
+	iotbus_gpio_drive_e get_drive;
+	iotbus_gpio_drive_e set_drive[] = { IOTBUS_GPIO_DRIVE_PULLUP, IOTBUS_GPIO_DRIVE_PULLDOWN, IOTBUS_GPIO_DRIVE_FLOAT };
+	char *ptr_drive[] = { "IOTBUS_GPIO_DRIVE_PULLUP", "IOTBUS_GPIO_DRIVE_PULLDOWN", "IOTBUS_GPIO_DRIVE_FLOAT" };
+
+	count_drive = sizeof(set_drive) / sizeof(set_drive[0]);
+	bool check = true;
+	g_gpio_h = iotbus_gpio_open(GPIO_PIN);
+	TC_ASSERT_NEQ("iotbus_gpio_open", g_gpio_h, NULL);
+
+	for (i = 0; i < count_drive; i++) {
+		ret = iotbus_gpio_set_drive_mode(g_gpio_h, set_drive[i]);
+		if (ret != 0) {
+			SYSIO_ITC_PRINT("itc_systemio_gpio_all_drive_read_write_p: iotbus_gpio_set_drive_mode FAIL for drive : %s\n", ptr_drive[i]);
+			check = false;
+			continue;
+		}
+		ret = iotbus_gpio_get_drive_mode(g_gpio_h, &get_drive);
+		if (ret != 0) {
+			SYSIO_ITC_PRINT("itc_systemio_gpio_all_drive_read_write_p: iotbus_gpio_get_drive_mode FAIL for drive : %s\n", ptr_drive[i]);
+			check = false;
+			continue;
+		}
+		if (get_drive != set_drive[i]) {
+			SYSIO_ITC_PRINT("itc_systemio_gpio_all_drive_read_write_p: FAIL, set and get values not same for drive : %s\n", ptr_drive[i]);
+			check = false;
+		}
+
+		ret = iotbus_gpio_read(g_gpio_h);
+		TC_ASSERT_EQ_CLEANUP("iotbus_gpio_read", (ret < 0), false, iotbus_gpio_close(g_gpio_h));
+
+		ret = iotbus_gpio_write(g_gpio_h, 1);
+		TC_ASSERT_EQ_CLEANUP("iotbus_gpio_write", (ret < 0), false, iotbus_gpio_close(g_gpio_h));
+	}
+	TC_ASSERT_EQ_CLEANUP("itc_systemio_gpio_all_drive_read_write_p", check, true, iotbus_gpio_close(g_gpio_h));
+	iotbus_gpio_close(g_gpio_h);
+	TC_SUCCESS_RESULT();
+}
+
+/**
+* @testcase         itc_systemio_gpio_set_get_direction_edge_drive_mode_p
+* @brief            sets and gets gpio direction and edge mode
+* @scenario         Sets gpio direction, edge mode and drive mode and then gets the same gpio direction, edge mode and drive mode
+* @apicovered       iotbus_gpio_set_direction, iotbus_gpio_get_direction, iotbus_gpio_set_edge_mode, iotbus_gpio_get_edge_mode, iotbus_gpio_set_drive_mode, iotbus_gpio_get_drive_mode
+* @precondition     open gpio context
+* @postcondition    close gpio context
+*/
+static void itc_systemio_gpio_set_get_direction_edge_drive_mode_p(void)
+{
+	int ret;
+	g_gpio_h = NULL;
+	int count_dir;
+	int count_mode;
+	int count_drive;
+	int h;
+	int i;
+	int j;
+	int k;
+	iotbus_gpio_direction_e get_direction;
+	iotbus_gpio_edge_e get_edge;
+	iotbus_gpio_drive_e get_drive;
+	iotbus_gpio_direction_e set_direction[] = { IOTBUS_GPIO_DIRECTION_NONE, IOTBUS_GPIO_DIRECTION_OUT, IOTBUS_GPIO_DIRECTION_IN };
+	iotbus_gpio_edge_e set_edge[] = { IOTBUS_GPIO_EDGE_NONE, IOTBUS_GPIO_EDGE_BOTH, IOTBUS_GPIO_EDGE_RISING, IOTBUS_GPIO_EDGE_FALLING };
+	iotbus_gpio_drive_e set_drive[] = { IOTBUS_GPIO_DRIVE_PULLUP, IOTBUS_GPIO_DRIVE_PULLDOWN, IOTBUS_GPIO_DRIVE_FLOAT };
+	char *ptr_dir[] = { "IOTBUS_GPIO_DIRECTION_NONE", "IOTBUS_GPIO_DIRECTION_OUT", "IOTBUS_GPIO_DIRECTION_IN" };
+	char *ptr_edge[] = { "IOTBUS_GPIO_EDGE_NONE", "IOTBUS_GPIO_EDGE_BOTH", "IOTBUS_GPIO_EDGE_RISING", "IOTBUS_GPIO_EDGE_FALLING" };
+	char *ptr_drive[] = { "IOTBUS_GPIO_DRIVE_PULLUP", "IOTBUS_GPIO_DRIVE_PULLDOWN", "IOTBUS_GPIO_DRIVE_FLOAT" };
+
+	count_dir = sizeof(set_direction) / sizeof(set_direction[0]);
+	count_mode = sizeof(set_edge) / sizeof(set_edge[0]);
+	count_drive = sizeof(set_drive) / sizeof(set_drive[0]);
+	bool check = true;
+	g_gpio_h = iotbus_gpio_open(GPIO_PIN);
+	TC_ASSERT_NEQ("iotbus_gpio_open", g_gpio_h, NULL);
+
+	for (h = 0; h < LOOP_COUNT; h++) {
+		for (i = 0; i < count_dir; i++) {
+			for (j = 0; j < count_mode; j++) {
+				for (k = 0; k < count_drive; k++) {
+
+					ret = iotbus_gpio_set_direction(g_gpio_h, set_direction[i]);
+					if (ret != 0) {
+						SYSIO_ITC_PRINT("itc_systemio_gpio_set_get_direction_edge_drive_mode_p: iotbus_gpio_set_direction FAIL for direction %s\n", ptr_dir[i]);
+						check = false;
+						continue;
+					}
+					ret = iotbus_gpio_get_direction(g_gpio_h, &get_direction);
+					if (ret != 0) {
+						SYSIO_ITC_PRINT("itc_systemio_gpio_set_get_direction_edge_drive_mode_p: iotbus_gpio_get_direction FAIL for direction %s\n", ptr_dir[i]);
+						check = false;
+						continue;
+					}
+					if (get_direction != set_direction[i]) {
+						SYSIO_ITC_PRINT("itc_systemio_gpio_set_get_direction_edge_drive_mode_p: FAIL, set and get values not same for direction %s\n", ptr_dir[i]);
+						check = false;
+					}
+
+					ret = iotbus_gpio_set_edge_mode(g_gpio_h, set_edge[j]);
+					if (ret != 0) {
+						SYSIO_ITC_PRINT("itc_systemio_gpio_set_get_direction_edge_drive_mode_p: iotbus_gpio_set_edge_mode FAIL for edge mode : %s\n", ptr_edge[j]);
+						check = false;
+						continue;
+					}
+					ret = iotbus_gpio_get_edge_mode(g_gpio_h, &get_edge);
+					if (ret != 0) {
+						SYSIO_ITC_PRINT("itc_systemio_gpio_set_get_direction_edge_drive_mode_p: iotbus_gpio_get_edge_mode FAIL for edge mode : %s\n", ptr_edge[j]);
+						check = false;
+						continue;
+					}
+					if (get_edge != set_edge[j]) {
+						SYSIO_ITC_PRINT("itc_systemio_gpio_set_get_direction_edge_drive_mode_p: FAIL, set and get values not same for edge mode : %s\n", ptr_edge[j]);
+						check = false;
+					}
+
+					ret = iotbus_gpio_set_drive_mode(g_gpio_h, set_drive[k]);
+					if (ret != 0) {
+						SYSIO_ITC_PRINT("itc_systemio_gpio_set_get_direction_edge_drive_mode_p: iotbus_gpio_set_drive_mode FAIL for drive : %s\n", ptr_drive[k]);
+						check = false;
+						continue;
+					}
+					ret = iotbus_gpio_get_drive_mode(g_gpio_h, &get_drive);
+					if (ret != 0) {
+						SYSIO_ITC_PRINT("itc_systemio_gpio_set_get_direction_edge_drive_mode_p: iotbus_gpio_get_drive_mode FAIL for drive : %s\n", ptr_drive[k]);
+						check = false;
+						continue;
+					}
+					if (get_drive != set_drive[k]) {
+						SYSIO_ITC_PRINT("\nitc_systemio_gpio_set_get_drive_mode: FAIL, set and get values not same for drive : %s\n", ptr_drive[k]);
+						check = false;
+					}
+				}
+			}
+		}
+	}
+	TC_ASSERT_EQ_CLEANUP("itc_systemio_gpio_set_get_direction_edge_drive_mode_p", check, true, iotbus_gpio_close(g_gpio_h));
+	iotbus_gpio_close(g_gpio_h);
+	TC_SUCCESS_RESULT();
+}
+
+/**
+* @testcase         itc_systemio_gpio_open_close_p_different_pin
+* @brief            gpio_open returns handle of gpio context and gpio_close closes the context
+* @scenario         initializes gpio_context based on gpio pin and then closes the gpio_context for all the pins.
+* @apicovered       iotbus_gpio_open, iotbus_gpio_close
+* @precondition     none
+* @postcondition    none
+*/
+static void itc_systemio_gpio_open_close_p_different_pin(void)
+{
+	int gpio_pin[] = { 30, 31, 32, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 57, 58, 59 };
+	int ret;
+	int count;
+	int index;
+	count = sizeof(gpio_pin) / sizeof(gpio_pin[0]);
+	for (index = 0; index < count; index++) {
+		g_gpio_h = NULL;
+		g_gpio_h = iotbus_gpio_open(gpio_pin[index]);
+		TC_ASSERT_NEQ("iotbus_gpio_open", g_gpio_h, NULL);
+
+		ret = iotbus_gpio_close(g_gpio_h);
+		TC_ASSERT_EQ("iotbus_gpio_close", ret, 0);
+	}
+
+	TC_SUCCESS_RESULT();
+}
+
+/**
+* @testcase         itc_systemio_gpio_open_close_p_multi_handle
+* @brief            gpio_open returns handle of gpio context and gpio_close closes the context
+* @scenario         initializes gpio_context based on gpio pin and then reopens gpio with same pin and then closes the gpio_context.
+* @apicovered       iotbus_gpio_open, iotbus_gpio_close
+* @precondition     none
+* @postcondition    none
+*/
+static void itc_systemio_gpio_open_close_p_multi_handle(void)
+{
+	int ret;
+	g_gpio_h = NULL;
+	g_gpio_h2 = NULL;
+	g_gpio_h = iotbus_gpio_open(GPIO_PIN);
+	TC_ASSERT_NEQ("iotbus_gpio_open", g_gpio_h, NULL);
+
+	g_gpio_h2 = iotbus_gpio_open(GPIO_PIN);
+	TC_ASSERT_NEQ_CLEANUP("iotbus_gpio_open", g_gpio_h2, NULL, iotbus_gpio_close(g_gpio_h));
+
+	ret = iotbus_gpio_close(g_gpio_h);
+	TC_ASSERT_EQ_CLEANUP("iotbus_gpio_close", ret, 0, iotbus_gpio_close(g_gpio_h2));
+
+	ret = iotbus_gpio_close(g_gpio_h2);
+	TC_ASSERT_EQ("iotbus_gpio_close", ret, 0);
+
+	TC_SUCCESS_RESULT();
+}
+
+/**
+* @testcase         itc_systemio_gpio_open_close_p_reclose
+* @brief            gpio_open returns handle of gpio context and gpio_close closes the context
+* @scenario         initializes gpio_context based on gpio pin and then closes the gpio_context and then again recloses same gpio context.
+* @apicovered       iotbus_gpio_open, iotbus_gpio_close
+* @precondition     none
+* @postcondition    none
+*/
+static void itc_systemio_gpio_open_close_p_reclose(void)
+{
+	int ret;
+	g_gpio_h = NULL;
+
+	g_gpio_h = iotbus_gpio_open(GPIO_PIN);
+	TC_ASSERT_NEQ("iotbus_gpio_open", g_gpio_h, NULL);
+
+	ret = iotbus_gpio_close(g_gpio_h);
+	TC_ASSERT_EQ("iotbus_gpio_close", ret, 0);
+
+	ret = iotbus_gpio_close(g_gpio_h);
+	TC_ASSERT_LT("iotbus_gpio_close", ret, 0);
+
+	TC_SUCCESS_RESULT();
+}
+
+/**
+* @testcase         itc_systemio_gpio_open_n
+* @brief            gpio_open returns handle of gpio context
+* @scenario         initializes gpio_context based on invalid pin
+* @apicovered       iotbus_gpio_open
+* @precondition     none
+* @postcondition    none
+*/
+static void itc_systemio_gpio_open_n(void)
+{
+	g_gpio_h = NULL;
+	g_gpio_h = iotbus_gpio_open(1);
+	TC_ASSERT_EQ("iotbus_gpio_open", g_gpio_h, NULL);
+
+	TC_SUCCESS_RESULT();
+}
+
+/**
+* @testcase         itc_systemio_gpio_close_n
+* @brief            gpio_open returns handle of gpio context and gpio_close closes the context
+* @scenario         initializes gpio_context based on gpio pin and then closes the gpio_context and then again recloses same gpio context.
+* @apicovered       iotbus_gpio_close
+* @precondition     none
+* @postcondition    none
+*/
+static void itc_systemio_gpio_close_n(void)
+{
+	iotbus_gpio_context_h gpio_context = NULL;
+	int ret;
+
+	ret = iotbus_gpio_close(gpio_context);
+	TC_ASSERT_EQ("iotbus_gpio_close", ret, IOTBUS_ERROR_INVALID_PARAMETER);
+
+	TC_SUCCESS_RESULT();
+}
+
+/**
+* @testcase         itc_systemio_gpio_get_pin_n
+* @brief            gets a pin number of the gpio.
+* @scenario         gets a pin number of the gpio with invalid parameter.
+* @apicovered       iotbus_gpio_get_pin
+* @precondition     open gpio context
+* @postcondition    close gpio context
+*/
+static void itc_systemio_gpio_get_pin_n(void)
+{
+	int ret;
+	g_gpio_h = NULL;
+	ret = iotbus_gpio_get_pin(g_gpio_h);
+	TC_ASSERT_EQ("iotbus_gpio_get_pin", ret, IOTBUS_ERROR_INVALID_PARAMETER);
+	TC_SUCCESS_RESULT();
+}
+
+/**
+* @testcase         itc_systemio_gpio_get_pin_n_after_close
+* @brief            gpio_open returns handle of gpio context and gpio_close closes the context
+* @scenario         initializes gpio_context based on gpio pin and then closes the gpio_context, then get gpio pin
+* @apicovered       iotbus_gpio_get_pin
+* @precondition     none
+* @postcondition    none
+*/
+static void itc_systemio_gpio_get_pin_n_after_close(void)
+{
+	int ret;
+	g_gpio_h = NULL;
+	g_gpio_h = iotbus_gpio_open(GPIO_PIN);
+	TC_ASSERT_NEQ("iotbus_gpio_open", g_gpio_h, NULL);
+
+	ret = iotbus_gpio_close(g_gpio_h);
+	TC_ASSERT_EQ("iotbus_gpio_close", ret, 0);
+
+	ret = iotbus_gpio_get_pin(g_gpio_h);
+	TC_ASSERT_LT("iotbus_gpio_get_pin", ret, 0);
+
+	TC_SUCCESS_RESULT();
+}
+
+/**
+* @testcase         itc_systemio_gpio_get_pin_n_after_invalid_open
+* @brief            gpio_open returns handle of gpio context and gpio_close closes the context
+* @scenario         initializes gpio_context based on gpio pin and then closes the gpio_context, then get gpio pin
+* @apicovered       iotbus_gpio_get_pin
+* @precondition     none
+* @postcondition    none
+*/
+static void itc_systemio_gpio_get_pin_n_after_invalid_open(void)
+{
+	int ret;
+	int gpio_invalid_pin = 1;
+	g_gpio_h = NULL;
+	g_gpio_h = iotbus_gpio_open(gpio_invalid_pin);
+	TC_ASSERT_EQ("iotbus_gpio_open", g_gpio_h, NULL);
+
+	ret = iotbus_gpio_get_pin(g_gpio_h);
+	TC_ASSERT_EQ("iotbus_gpio_get_pin", ret, IOTBUS_ERROR_INVALID_PARAMETER);
+
+	TC_SUCCESS_RESULT();
+}
+
+/**
+* @testcase         itc_systemio_gpio_read_n_after_close
+* @brief            reads the gpio value
+* @scenario         reads the gpio value after gpio close
+* @apicovered       iotbus_gpio_read
+* @precondition     open gpio context
+* @postcondition    close gpio context
+*/
+static void itc_systemio_gpio_read_n_after_close(void)
+{
+	int ret;
+	g_gpio_h = NULL;
+	g_gpio_h = iotbus_gpio_open(GPIO_PIN);
+	TC_ASSERT_NEQ("iotbus_gpio_open", g_gpio_h, NULL);
+
+	ret = iotbus_gpio_close(g_gpio_h);
+	TC_ASSERT_EQ("iotbus_gpio_close", ret, 0);
+
+	ret = iotbus_gpio_read(g_gpio_h);
+	TC_ASSERT_LT("iotbus_gpio_read", ret, 0);
+
+	TC_SUCCESS_RESULT();
+}
+
+/**
+* @testcase         itc_systemio_gpio_write_n_after_close
+* @brief            writes the gpio value
+* @scenario         writes the gpio value after gpio close
+* @apicovered       iotbus_gpio_write
+* @precondition     open gpio context
+* @postcondition    close gpio context
+*/
+static void itc_systemio_gpio_write_n_after_close(void)
+{
+	int ret;
+	g_gpio_h = NULL;
+	g_gpio_h = iotbus_gpio_open(GPIO_PIN);
+	TC_ASSERT_NEQ("iotbus_gpio_open", g_gpio_h, NULL);
+
+	ret = iotbus_gpio_close(g_gpio_h);
+	TC_ASSERT_EQ("iotbus_gpio_close", ret, 0);
+
+	ret = iotbus_gpio_write(g_gpio_h, 1);
+	TC_ASSERT_LT("iotbus_gpio_write", ret, 0);
+
+	TC_SUCCESS_RESULT();
+}
+
+/**
+* @testcase         itc_systemio_gpio_set_direction_n
+* @brief            sets the gpio direction
+* @scenario         sets the gpio direction with invalid parameter
+* @apicovered       iotbus_gpio_set_direction
+* @precondition     open gpio context
+* @postcondition    close gpio context
+*/
+static void itc_systemio_gpio_set_direction_n(void)
+{
+	int ret;
+	g_gpio_h = NULL;
+	g_gpio_h = iotbus_gpio_open(GPIO_PIN);
+	TC_ASSERT_NEQ("iotbus_gpio_open", g_gpio_h, NULL);
+
+	ret = iotbus_gpio_set_direction(g_gpio_h, -1);
+	TC_ASSERT_LT_CLEANUP("iotbus_gpio_set_direction", ret, 0, iotbus_gpio_close(g_gpio_h));
+
+	ret = iotbus_gpio_close(g_gpio_h);
+	TC_ASSERT_EQ("iotbus_gpio_close", ret, 0);
+
+	TC_SUCCESS_RESULT();
+}
+
+/**
+* @testcase         itc_systemio_gpio_get_direction_n
+* @brief            gets the gpio direction
+* @scenario         gets the gpio direction with invalid parameter
+* @apicovered       iotbus_gpio_get_direction
+* @precondition     open gpio context
+* @postcondition    close gpio context
+*/
+static void itc_systemio_gpio_get_direction_n(void)
+{
+	int ret;
+	g_gpio_h = NULL;
+	iotbus_gpio_direction_e get_direction;
+
+	ret = iotbus_gpio_get_direction(g_gpio_h, &get_direction);
+	TC_ASSERT_EQ("iotbus_gpio_get_direction", ret, IOTBUS_ERROR_INVALID_PARAMETER);
+
+	TC_SUCCESS_RESULT();
+}
+
+/**
+* @testcase         itc_systemio_gpio_set_direction_n_after_close
+* @brief            sets the gpio direction
+* @scenario         sets the gpio direction after gpio context is closed
+* @apicovered       iotbus_gpio_set_direction
+* @precondition     open gpio context
+* @postcondition    close gpio context
+*/
+static void itc_systemio_gpio_set_direction_n_after_close(void)
+{
+	int ret;
+	g_gpio_h = NULL;
+	iotbus_gpio_direction_e set_direction = IOTBUS_GPIO_DIRECTION_NONE;
+	g_gpio_h = iotbus_gpio_open(GPIO_PIN);
+	TC_ASSERT_NEQ("iotbus_gpio_open", g_gpio_h, NULL);
+
+	ret = iotbus_gpio_close(g_gpio_h);
+	TC_ASSERT_EQ("iotbus_gpio_close", ret, 0);
+
+	ret = iotbus_gpio_set_direction(g_gpio_h, set_direction);
+	TC_ASSERT_LT("iotbus_gpio_set_direction", ret, 0);
+
+	TC_SUCCESS_RESULT();
+}
+
+/**
+* @testcase         itc_systemio_gpio_get_direction_n_after_close
+* @brief            gets the gpio direction
+* @scenario         gets the gpio direction after gpio context is closed
+* @apicovered       iotbus_gpio_get_direction
+* @precondition     open gpio context
+* @postcondition    close gpio context
+*/
+static void itc_systemio_gpio_get_direction_n_after_close(void)
+{
+	int ret;
+	g_gpio_h = NULL;
+	iotbus_gpio_direction_e set_direction = IOTBUS_GPIO_DIRECTION_NONE;
+	iotbus_gpio_direction_e get_direction;
+
+	g_gpio_h = iotbus_gpio_open(GPIO_PIN);
+	TC_ASSERT_NEQ("iotbus_gpio_open", g_gpio_h, NULL);
+
+	ret = iotbus_gpio_set_direction(g_gpio_h, set_direction);
+	TC_ASSERT_EQ_CLEANUP("iotbus_gpio_set_direction", ret, 0, iotbus_gpio_close(g_gpio_h));
+
+	ret = iotbus_gpio_close(g_gpio_h);
+	TC_ASSERT_EQ("iotbus_gpio_close", ret, 0);
+
+	ret = iotbus_gpio_get_direction(g_gpio_h, &get_direction);
+	TC_ASSERT_LT("iotbus_gpio_get_direction", ret, 0);
+
+	TC_SUCCESS_RESULT();
+}
+
+/**
+* @testcase         itc_systemio_gpio_set_edge_mode_n
+* @brief            sets the gpio edge mode
+* @scenario         sets the gpio edge mode with invalid parameter
+* @apicovered       iotbus_gpio_set_edge_mode
+* @precondition     open gpio context
+* @postcondition    close gpio context
+*/
+static void itc_systemio_gpio_set_edge_mode_n(void)
+{
+	int ret;
+	g_gpio_h = NULL;
+
+	g_gpio_h = iotbus_gpio_open(GPIO_PIN);
+	TC_ASSERT_NEQ("iotbus_gpio_open", g_gpio_h, NULL);
+
+	ret = iotbus_gpio_set_edge_mode(g_gpio_h, -1);
+	TC_ASSERT_LT_CLEANUP("iotbus_gpio_set_edge_mode", ret, 0, iotbus_gpio_close(g_gpio_h));
+
+	ret = iotbus_gpio_close(g_gpio_h);
+	TC_ASSERT_EQ("iotbus_gpio_close", ret, 0);
+
+	TC_SUCCESS_RESULT();
+}
+
+/**
+* @testcase         itc_systemio_gpio_get_edge_mode_n
+* @brief            gets the gpio edge mode
+* @scenario         gets the gpio edge mode with invalid parameter
+* @apicovered       iotbus_gpio_get_edge_mode
+* @precondition     open gpio context
+* @postcondition    close gpio context
+*/
+static void itc_systemio_gpio_get_edge_mode_n(void)
+{
+	int ret;
+	g_gpio_h = NULL;
+	iotbus_gpio_edge_e get_edge;
+
+	ret = iotbus_gpio_get_edge_mode(g_gpio_h, &get_edge);
+	TC_ASSERT_EQ("iotbus_gpio_get_edge_mode", ret, IOTBUS_ERROR_INVALID_PARAMETER);
+
+	TC_SUCCESS_RESULT();
+}
+
+/**
+* @testcase         itc_systemio_gpio_set_edge_mode_n_after_close
+* @brief            sets the gpio edge mode
+* @scenario         sets the gpio edge mode after gpio context is closed
+* @apicovered       iotbus_gpio_set_edge_mode
+* @precondition     open gpio context
+* @postcondition    close gpio context
+*/
+static void itc_systemio_gpio_set_edge_mode_n_after_close(void)
+{
+	int ret;
+	g_gpio_h = NULL;
+	iotbus_gpio_edge_e set_edge = IOTBUS_GPIO_EDGE_NONE;
+
+	g_gpio_h = iotbus_gpio_open(GPIO_PIN);
+	TC_ASSERT_NEQ("iotbus_gpio_open", g_gpio_h, NULL);
+
+	ret = iotbus_gpio_close(g_gpio_h);
+	TC_ASSERT_EQ("iotbus_gpio_close", ret, 0);
+
+	ret = iotbus_gpio_set_edge_mode(g_gpio_h, set_edge);
+	TC_ASSERT_LT("iotbus_gpio_set_edge_mode", ret, 0);
+
+	TC_SUCCESS_RESULT();
+}
+
+/**
+* @testcase         itc_systemio_gpio_get_edge_mode_n_after_close
+* @brief            gets the gpio edge mode
+* @scenario         gets the gpio edge mode after gpio context is closed
+* @apicovered       iotbus_gpio_get_edge_mode
+* @precondition     open gpio context
+* @postcondition    close gpio context
+*/
+static void itc_systemio_gpio_get_edge_mode_n_after_close(void)
+{
+	int ret;
+	g_gpio_h = NULL;
+	iotbus_gpio_edge_e set_edge = IOTBUS_GPIO_EDGE_NONE;
+	iotbus_gpio_edge_e get_edge;
+
+	g_gpio_h = iotbus_gpio_open(GPIO_PIN);
+	TC_ASSERT_NEQ("iotbus_gpio_open", g_gpio_h, NULL);
+
+	ret = iotbus_gpio_set_edge_mode(g_gpio_h, set_edge);
+	TC_ASSERT_EQ_CLEANUP("iotbus_gpio_set_edge_mode", ret, 0, iotbus_gpio_close(g_gpio_h));
+
+	ret = iotbus_gpio_close(g_gpio_h);
+	TC_ASSERT_EQ("iotbus_gpio_close", ret, 0);
+
+	ret = iotbus_gpio_get_edge_mode(g_gpio_h, &get_edge);
+	TC_ASSERT_LT("iotbus_gpio_get_edge_mode", ret, 0);
+
+	TC_SUCCESS_RESULT();
+}
+
+/**
+* @testcase         itc_systemio_gpio_set_drive_mode_n
+* @brief            sets the gpio drive mode
+* @scenario         sets the gpio drive mode with invalid parameter
+* @apicovered       iotbus_gpio_set_drive_mode
+* @precondition     open gpio context
+* @postcondition    close gpio context
+*/
+static void itc_systemio_gpio_set_drive_mode_n(void)
+{
+	int ret;
+	g_gpio_h = NULL;
+
+	g_gpio_h = iotbus_gpio_open(GPIO_PIN);
+	TC_ASSERT_NEQ("iotbus_gpio_open", g_gpio_h, NULL);
+
+	ret = iotbus_gpio_set_drive_mode(g_gpio_h, -1);
+	TC_ASSERT_LT_CLEANUP("iotbus_gpio_set_drive_mode", ret, 0, iotbus_gpio_close(g_gpio_h));
+
+	ret = iotbus_gpio_close(g_gpio_h);
+	TC_ASSERT_EQ("iotbus_gpio_close", ret, 0);
+
+	TC_SUCCESS_RESULT();
+}
+
+/**
+* @testcase         itc_systemio_gpio_get_drive_mode_n
+* @brief            gets the gpio drive mode
+* @scenario         gets the gpio drive mode with invalid parameter
+* @apicovered       iotbus_gpio_get_drive_mode
+* @precondition     open gpio context
+* @postcondition    close gpio context
+*/
+static void itc_systemio_gpio_get_drive_mode_n(void)
+{
+	int ret;
+	g_gpio_h = NULL;
+	iotbus_gpio_drive_e get_drive;
+
+	ret = iotbus_gpio_get_drive_mode(NULL, &get_drive);
+	TC_ASSERT_EQ("iotbus_gpio_get_drive_mode", ret, IOTBUS_ERROR_INVALID_PARAMETER);
+
+	TC_SUCCESS_RESULT();
+}
+
+/**
+* @testcase         itc_systemio_gpio_set_drive_mode_n_after_close
+* @brief            sets the gpio drive mode
+* @scenario         sets the gpio drive mode after gpio context close
+* @apicovered       iotbus_gpio_set_drive_mode
+* @precondition     open gpio context
+* @postcondition    close gpio context
+*/
+static void itc_systemio_gpio_set_drive_mode_n_after_close(void)
+{
+	int ret;
+	g_gpio_h = NULL;
+	iotbus_gpio_drive_e set_drive = IOTBUS_GPIO_DRIVE_PULLUP;
+
+	g_gpio_h = iotbus_gpio_open(GPIO_PIN);
+	TC_ASSERT_NEQ("iotbus_gpio_open", g_gpio_h, NULL);
+
+	ret = iotbus_gpio_close(g_gpio_h);
+	TC_ASSERT_EQ("iotbus_gpio_close", ret, 0);
+
+	ret = iotbus_gpio_set_drive_mode(g_gpio_h, set_drive);
+	TC_ASSERT_LT("iotbus_gpio_set_drive_mode", ret, 0);
+
+	TC_SUCCESS_RESULT();
+}
+
+/**
+* @testcase         itc_systemio_gpio_get_drive_mode_n_after_close
+* @brief            gets the gpio drive mode
+* @scenario         gets the gpio drive mode after gpio context close
+* @apicovered       iotbus_gpio_get_drive_mode
+* @precondition     open gpio context
+* @postcondition    close gpio context
+*/
+static void itc_systemio_gpio_get_drive_mode_n_after_close(void)
+{
+	int ret;
+	g_gpio_h = NULL;
+	iotbus_gpio_drive_e set_drive = IOTBUS_GPIO_DRIVE_PULLUP;
+	iotbus_gpio_drive_e get_drive;
+
+	g_gpio_h = iotbus_gpio_open(GPIO_PIN);
+	TC_ASSERT_NEQ("iotbus_gpio_open", g_gpio_h, NULL);
+
+	ret = iotbus_gpio_set_drive_mode(g_gpio_h, set_drive);
+	TC_ASSERT_EQ_CLEANUP("iotbus_gpio_set_drive_mode", ret, 0, iotbus_gpio_close(g_gpio_h));
+
+	ret = iotbus_gpio_close(g_gpio_h);
+	TC_ASSERT_EQ("iotbus_gpio_close", ret, 0);
+
+	ret = iotbus_gpio_get_drive_mode(g_gpio_h, &get_drive);
+	TC_ASSERT_LT("iotbus_gpio_get_drive_mode", ret, 0);
+
+	TC_SUCCESS_RESULT();
+}
+
 int itc_gpio_main(void)
 {
 	iotapi_initialize();
@@ -353,6 +1142,32 @@ int itc_gpio_main(void)
 	itc_systemio_gpio_set_get_drive_mode_p();
 	itc_systemio_gpio_read_write_p();
 	itc_systemio_gpio_register_unregister_callback_p();//TC FAIL, callback is not invoked
+	itc_systemio_gpio_set_direction_read_write_p_all_directions();
+	itc_systemio_gpio_set_edge_read_write_p_all_edges();
+	itc_systemio_gpio_set_drive_read_write_p_all_drive_mode();
+	itc_systemio_gpio_set_get_direction_edge_drive_mode_p();
+	itc_systemio_gpio_open_close_p_different_pin();
+	itc_systemio_gpio_open_close_p_multi_handle();
+	//itc_systemio_gpio_open_close_p_reclose();//TC FAIL, it should not return 0 on re-closing it. Also remaining TCs donot work after its execution
+	itc_systemio_gpio_open_n();
+	itc_systemio_gpio_close_n();
+	itc_systemio_gpio_get_pin_n();
+	itc_systemio_gpio_get_pin_n_after_close();//TC FAIL, it should not return opened pin after it has already been close
+	itc_systemio_gpio_get_pin_n_after_invalid_open();
+	itc_systemio_gpio_read_n_after_close();
+	itc_systemio_gpio_write_n_after_close();
+	itc_systemio_gpio_set_direction_n();
+	itc_systemio_gpio_get_direction_n();
+	itc_systemio_gpio_set_direction_n_after_close();
+	itc_systemio_gpio_get_direction_n_after_close();//TC FAIL, ret value should be less than 0
+	itc_systemio_gpio_set_edge_mode_n();
+	itc_systemio_gpio_get_edge_mode_n();
+	itc_systemio_gpio_set_edge_mode_n_after_close();
+	itc_systemio_gpio_get_edge_mode_n_after_close();//TC FAIL, ret value should be less than 0
+	itc_systemio_gpio_set_drive_mode_n();
+	itc_systemio_gpio_get_drive_mode_n();
+	itc_systemio_gpio_set_drive_mode_n_after_close();
+	itc_systemio_gpio_get_drive_mode_n_after_close();//TC FAIL, ret value should be less than 0
 
 	return 0;
 }

--- a/apps/examples/testcase/ta_tc/systemio/itc/itc_spi.c
+++ b/apps/examples/testcase/ta_tc/systemio/itc/itc_spi.c
@@ -20,13 +20,14 @@
 
 /// @brief Test Case Iotbus APIs for SPI
 
+#include <tinyara/config.h>
 #include "itc_internal.h"
 #include <iotbus_spi.h>
 #include <iotbus_error.h>
 
-static unsigned int gBus = 0;
+static unsigned int g_bus = 0;
 
-static struct iotbus_spi_config_s _g_st_config = {
+static struct iotbus_spi_config_s g_st_config = {
 	(char)8,
 	0,
 	12000000,
@@ -44,11 +45,164 @@ static struct iotbus_spi_config_s _g_st_config = {
 void itc_systemio_spi_open_close_p(void)
 {
 	int ret = IOTBUS_ERROR_NONE;
-	iotbus_spi_context_h h_spi = iotbus_spi_open(gBus, &_g_st_config);
+	iotbus_spi_context_h h_spi = iotbus_spi_open(g_bus, &g_st_config);
 	TC_ASSERT_NEQ("iotbus_spi_open", h_spi, NULL);
 
 	ret = iotbus_spi_close(h_spi);
 	TC_ASSERT_EQ("iotbus_spi_close", ret, IOTBUS_ERROR_NONE);
+
+	TC_SUCCESS_RESULT();
+}
+
+/**
+* @testcase         itc_systemio_spi_open_close_p_multi_handler
+* @brief            initializes and closes the spi_context with multi handler
+* @scenario         initializes and closes the spi_context with multi handler
+* @apicovered       iotbus_spi_open, iotbus_spi_close
+* @precondition     none
+* @postcondition    none
+*/
+static void itc_systemio_spi_open_close_p_multi_handler(void)
+{
+	int ret = IOTBUS_ERROR_NONE;
+	iotbus_spi_context_h h_spi_1 = iotbus_spi_open(g_bus, &g_st_config);
+	TC_ASSERT_NEQ("iotbus_spi_open", h_spi_1, NULL);
+
+	iotbus_spi_context_h h_spi_2 = iotbus_spi_open(g_bus, &g_st_config);
+	TC_ASSERT_NEQ_CLEANUP("iotbus_spi_open", h_spi_2, NULL, iotbus_spi_close(h_spi_1));
+
+	ret = iotbus_spi_close(h_spi_2);
+	TC_ASSERT_EQ_CLEANUP("iotbus_spi_close", ret, IOTBUS_ERROR_NONE, iotbus_spi_close(h_spi_1));
+
+	ret = iotbus_spi_close(h_spi_1);
+	TC_ASSERT_EQ("iotbus_spi_close", ret, IOTBUS_ERROR_NONE);
+
+	TC_SUCCESS_RESULT();
+}
+
+/**
+* @testcase         itc_systemio_spi_open_close_p_modes
+* @brief            initializes and closes the spi_context for modes
+* @scenario         initializes and closes the spi_context for modes
+* @apicovered       iotbus_spi_open, iotbus_spi_close
+* @precondition     none
+* @postcondition    none
+*/
+static void itc_systemio_spi_open_close_p_modes(void)
+{
+	int ret = IOTBUS_ERROR_NONE;
+	int max_index = 4;
+	int check_open = 0;
+	int check_close = 0;
+	int index = 0;
+	struct iotbus_spi_config_s st_config = {
+		(char)8,
+		0,
+		12000000,
+		IOTBUS_SPI_MODE0,
+	};
+
+	int modes[4] = { IOTBUS_SPI_MODE0, IOTBUS_SPI_MODE1, IOTBUS_SPI_MODE2, IOTBUS_SPI_MODE2 };
+	char *str_modes[4] = { "IOTBUS_SPI_MODE0", "IOTBUS_SPI_MODE1", "IOTBUS_SPI_MODE2", "IOTBUS_SPI_MODE3" };
+
+	for (index = 0; index < max_index; ++index) {
+		st_config.mode = modes[index];
+
+		iotbus_spi_context_h h_spi = iotbus_spi_open(g_bus, &st_config);
+		if (h_spi == NULL) {
+			SYSIO_ITC_PRINT("iotbus_spi_open failed, mode :: %s \n", str_modes[index]);
+			check_open++;
+			continue;
+		}
+
+		ret = iotbus_spi_close(h_spi);
+		if (h_spi == NULL) {
+			SYSIO_ITC_PRINT("iotbus_spi_close failed, mode :: %s \n", str_modes[index]);
+			check_close++;
+			continue;
+		}
+
+		SYSIO_ITC_PRINT("spi open/close  :: %s \n", str_modes[index]);
+	}
+
+	TC_ASSERT_EQ("iotbus_spi_open failed", check_open, 0);
+	TC_ASSERT_EQ("iotbus_spi_close failed", check_close, 0);
+	TC_SUCCESS_RESULT();
+}
+
+/**
+* @testcase         itc_systemio_spi_open_close_n_invalid_bus
+* @brief            initializes and closes the spi_context
+* @scenario         initializes and closes the spi_context
+* @apicovered       iotbus_spi_open, iotbus_spi_close
+* @precondition     none
+* @postcondition    none
+*/
+static void itc_systemio_spi_open_close_n_invalid_bus(void)
+{
+	int ret = IOTBUS_ERROR_NONE;
+	int invalid_bus = -1;
+	iotbus_spi_context_h h_spi = iotbus_spi_open(invalid_bus, &g_st_config);
+	TC_ASSERT_EQ("iotbus_spi_open", h_spi, NULL);
+
+	ret = iotbus_spi_close(h_spi);
+	TC_ASSERT_EQ("iotbus_spi_close", ret, IOTBUS_ERROR_INVALID_PARAMETER);
+
+	TC_SUCCESS_RESULT();
+}
+
+/**
+* @testcase         itc_systemio_spi_open_close_n_invalid_bpw
+* @brief            initializes and closes the spi_context
+* @scenario         initializes and closes the spi_context
+* @apicovered       iotbus_spi_open, iotbus_spi_close
+* @precondition     none
+* @postcondition    none
+*/
+static void itc_systemio_spi_open_close_n_invalid_bpw(void)
+{
+	int ret = IOTBUS_ERROR_NONE;
+
+	struct iotbus_spi_config_s st_config = {
+		(char)1,
+		0,
+		12000000,
+		IOTBUS_SPI_MODE0,
+	};
+
+	iotbus_spi_context_h h_spi = iotbus_spi_open(g_bus, &st_config);
+	TC_ASSERT_EQ("iotbus_spi_open", h_spi, NULL);
+
+	ret = iotbus_spi_close(h_spi);
+	TC_ASSERT_EQ("iotbus_spi_close", ret, IOTBUS_ERROR_INVALID_PARAMETER);
+
+	TC_SUCCESS_RESULT();
+}
+
+/**
+* @testcase         itc_systemio_spi_open_close_n_invalid_frequecy
+* @brief            initializes and closes the spi_context
+* @scenario         initializes and closes the spi_context
+* @apicovered       iotbus_spi_open, iotbus_spi_close
+* @precondition     none
+* @postcondition    none
+*/
+static void itc_systemio_spi_open_close_n_invalid_frequecy(void)
+{
+	int ret = IOTBUS_ERROR_NONE;
+
+	struct iotbus_spi_config_s st_config = {
+		(char)8,
+		0,
+		13000000, //13Mhz Invalid frequency
+		IOTBUS_SPI_MODE0,
+	};
+
+	iotbus_spi_context_h h_spi = iotbus_spi_open(g_bus, &st_config);
+	TC_ASSERT_EQ("iotbus_spi_open", h_spi, NULL);
+
+	ret = iotbus_spi_close(h_spi);
+	TC_ASSERT_EQ("iotbus_spi_close", ret, IOTBUS_ERROR_INVALID_PARAMETER);
 
 	TC_SUCCESS_RESULT();
 }
@@ -66,7 +220,7 @@ void itc_systemio_spi_write_recv_trasfer_p(void)
 	unsigned char sz_txbuf[64] = { 0, };
 	unsigned char sz_rxbuf[64] = { 0, };
 	int ret = IOTBUS_ERROR_NONE;
-	iotbus_spi_context_h h_spi = iotbus_spi_open(gBus, &_g_st_config);
+	iotbus_spi_context_h h_spi = iotbus_spi_open(g_bus, &g_st_config);
 	TC_ASSERT_NEQ("iotbus_spi_open", h_spi, NULL);
 
 	ret = iotbus_spi_write(h_spi, sz_txbuf, 8);
@@ -91,6 +245,11 @@ void itc_systemio_spi_write_recv_trasfer_p(void)
 int itc_spi_main(void)
 {
 	itc_systemio_spi_open_close_p();
+	itc_systemio_spi_open_close_p_multi_handler();
+	itc_systemio_spi_open_close_p_modes();
+	itc_systemio_spi_open_close_n_invalid_bus();
+	itc_systemio_spi_open_close_n_invalid_bpw();
+	itc_systemio_spi_open_close_n_invalid_frequecy();
 	itc_systemio_spi_write_recv_trasfer_p();
 	return 0;
 }

--- a/apps/examples/testcase/ta_tc/systemio/itc/itc_uart.c
+++ b/apps/examples/testcase/ta_tc/systemio/itc/itc_uart.c
@@ -29,6 +29,7 @@
 #include "iotbus_error.h"
 
 #define MICROSECOND 1000000
+#define BUF_LEN 32
 #ifdef CONFIG_ARCH_CHIP_STM32
 #define DEVPATH "/dev/ttyS1"
 #else                            // artik
@@ -51,6 +52,39 @@ void itc_systemio_iotbus_uart_init_stop_p(void)
 
 	ret = iotbus_uart_stop(h_uart);
 	TC_ASSERT_EQ("iotbus_uart_stop", ret, IOTBUS_ERROR_NONE);
+
+	TC_SUCCESS_RESULT();
+}
+
+/**
+* @testcase         itc_systemio_iotbus_uart_init_stop_p_multi_handle
+* @brief            initializes and closes uart_context
+* @scenario         initializes and closes uart_context
+* @apicovered       iotbus_uart_init, iotbus_uart_stop
+* @precondition     none
+* @postcondition    none
+*/
+static void itc_systemio_iotbus_uart_init_stop_p_multi_handle(void)
+{
+	int ret = IOTBUS_ERROR_NONE;
+
+	iotbus_uart_context_h h_uart1 = iotbus_uart_init(DEVPATH);
+	TC_ASSERT_NEQ("iotbus_uart_init1", h_uart1, NULL);
+
+	iotbus_uart_context_h h_uart2 = iotbus_uart_init(DEVPATH);
+	TC_ASSERT_NEQ_CLEANUP("iotbus_uart_init2", h_uart2, NULL, iotbus_uart_stop(h_uart1));
+
+	iotbus_uart_context_h h_uart3 = iotbus_uart_init(DEVPATH);
+	TC_ASSERT_NEQ_CLEANUP("iotbus_uart_init3", h_uart3, NULL, iotbus_uart_stop(h_uart2); iotbus_uart_stop(h_uart1));
+
+	ret = iotbus_uart_stop(h_uart3);
+	TC_ASSERT_EQ_CLEANUP("iotbus_uart_stop3", ret, IOTBUS_ERROR_NONE, iotbus_uart_stop(h_uart2); iotbus_uart_stop(h_uart1));
+
+	ret = iotbus_uart_stop(h_uart2);
+	TC_ASSERT_EQ_CLEANUP("iotbus_uart_stop2", ret, IOTBUS_ERROR_NONE, iotbus_uart_stop(h_uart1));
+
+	ret = iotbus_uart_stop(h_uart1);
+	TC_ASSERT_EQ("iotbus_uart_stop1", ret, IOTBUS_ERROR_NONE);
 
 	TC_SUCCESS_RESULT();
 }
@@ -80,6 +114,31 @@ void itc_systemio_iotbus_uart_set_baudrate_p(void)
 }
 
 /**
+* @testcase         itc_systemio_iotbus_uart_set_baudrate_n
+* @brief            sets uart baud rate
+* @scenario         sets uart baud rate
+* @apicovered       iotbus_uart_set_baudrate
+* @precondition     initializes uart_context
+* @postcondition    closes uart_context
+*/
+static void itc_systemio_iotbus_uart_set_baudrate_n(void)
+{
+	int i_baudrate = -115200; // invalid baudrate
+	int ret = IOTBUS_ERROR_NONE;
+
+	iotbus_uart_context_h h_uart = iotbus_uart_init(DEVPATH);
+	TC_ASSERT_NEQ("iotbus_uart_init", h_uart, NULL);
+
+	ret = iotbus_uart_set_baudrate(h_uart, i_baudrate);
+	TC_ASSERT_EQ_CLEANUP("iotbus_uart_set_baudrate", ret, IOTBUS_ERROR_INVALID_PARAMETER, iotbus_uart_stop(h_uart));
+
+	ret = iotbus_uart_stop(h_uart);
+	TC_ASSERT_EQ("iotbus_uart_stop", ret, IOTBUS_ERROR_NONE);
+
+	TC_SUCCESS_RESULT();
+}
+
+/**
 * @testcase         itc_systemio_iotbus_uart_set_mode_p
 * @brief            sets byte size, parity bit and stop bits
 * @scenario         sets byte size, parity bit and stop bits
@@ -102,6 +161,68 @@ void itc_systemio_iotbus_uart_set_mode_p(void)
 		ret = iotbus_uart_set_mode(h_uart, i_bytesize, mode[index], i_stop_bits);
 		TC_ASSERT_EQ_CLEANUP("iotbus_uart_set_mode", ret, IOTBUS_ERROR_NONE, iotbus_uart_stop(h_uart));
 	}
+
+	ret = iotbus_uart_stop(h_uart);
+	TC_ASSERT_EQ("iotbus_uart_stop", ret, IOTBUS_ERROR_NONE);
+
+	TC_SUCCESS_RESULT();
+}
+
+/**
+* @testcase         itc_systemio_iotbus_uart_set_mode_p_all
+* @brief            sets byte size, parity bit and stop bits (all combinations)
+* @scenario         sets byte size, parity bit and stop bits (all combinations)
+* @apicovered       iotbus_uart_set_mode
+* @precondition     initializes uart_context
+* @postcondition    closes uart_context
+*/
+static void itc_systemio_iotbus_uart_set_mode_p_all(void)
+{
+	int i_bytesize = 0;
+	int i_max_bytesize = 10;
+	int i_stop_bits = 0;
+	int i_max_stop_bits = 4;
+	int ret = IOTBUS_ERROR_NONE;
+	int mode[] = { IOTBUS_UART_PARITY_NONE, IOTBUS_UART_PARITY_EVEN, IOTBUS_UART_PARITY_ODD };
+	char mode_str[3][BUF_LEN] = { "IOTBUS_UART_PARITY_NONE", "IOTBUS_UART_PARITY_EVEN", "IOTBUS_UART_PARITY_ODD" };
+	int i_modes = sizeof(mode) / sizeof(int);
+	int index = 0;
+	int count_bytesize_fail = 0;
+	int count_stopbit_fail = 0;
+	int count_fail = 0;
+
+	iotbus_uart_context_h h_uart = iotbus_uart_init(DEVPATH);
+	TC_ASSERT_NEQ("iotbus_uart_init", h_uart, NULL);
+
+	for (i_bytesize = 0; i_bytesize < i_max_bytesize; ++i_bytesize) {
+		for (i_stop_bits = 0; i_stop_bits < i_max_stop_bits; ++i_stop_bits) {
+			for (index = 0; index < i_modes; index++) {
+				ret = iotbus_uart_set_mode(h_uart, i_bytesize, mode[index], i_stop_bits);
+				if (i_stop_bits < 1 || i_stop_bits > 2) {
+					//checking for invalid parameters (stopbits)
+					if (ret != IOTBUS_ERROR_INVALID_PARAMETER) {
+						SYSIO_ITC_PRINT("iotbus_uart_set_mode failed for stopbits ::%d\n", i_stop_bits);
+						count_stopbit_fail++;
+					}
+				} else if (i_bytesize < 5 || i_bytesize > 8) {
+					//checking with invalid parameters (bytessize)
+					if (ret != IOTBUS_ERROR_INVALID_PARAMETER) {
+						SYSIO_ITC_PRINT("iotbus_uart_set_mode failed for bytesize ::%d\n", i_bytesize);
+						count_bytesize_fail++;
+					}
+				} else {
+					//checking with valid parameters
+					if (ret != IOTBUS_ERROR_NONE) {
+						SYSIO_ITC_PRINT("iotbus_uart_set_mode failed UART_PARITY::%s, bytesize::%d, stopbits::%d \n", mode_str[index], i_bytesize, i_stop_bits);
+						count_fail++;
+					}
+				}
+			}
+		}
+	}
+	TC_ASSERT_EQ_CLEANUP("iotbus_uart_set_mode fail_count with bytesize", count_bytesize_fail, 0, iotbus_uart_stop(h_uart));
+	TC_ASSERT_EQ_CLEANUP("iotbus_uart_set_mode fail_count with stopbit", count_stopbit_fail, 0, iotbus_uart_stop(h_uart));
+	TC_ASSERT_EQ_CLEANUP("iotbus_uart_set_mode fail_count", count_fail, 0, iotbus_uart_stop(h_uart));
 
 	ret = iotbus_uart_stop(h_uart);
 	TC_ASSERT_EQ("iotbus_uart_stop", ret, IOTBUS_ERROR_NONE);
@@ -148,20 +269,20 @@ void itc_systemio_iotbus_uart_set_flowcontrol_p(void)
 void itc_systemio_iotbus_uart_write_read_p(void)
 {
 	int ret = IOTBUS_ERROR_NONE;
-	char szInputText[32] = "UART READ/WRITE ITC TESTING!";
-	char szOutputText[32];
+	char sz_input_text[BUF_LEN] = "UART READ/WRITE ITC TESTING!";
+	char sz_output_text[BUF_LEN];
 	iotbus_uart_context_h h_uart = iotbus_uart_init(DEVPATH);
 	TC_ASSERT_NEQ("iotbus_uart_init", h_uart, NULL);
 
-	ret = iotbus_uart_write(h_uart, szInputText, sizeof(szInputText));
+	ret = iotbus_uart_write(h_uart, sz_input_text, sizeof(sz_input_text));
 	TC_ASSERT_EQ_CLEANUP("iotbus_uart_write", ret < 0, false, iotbus_uart_stop(h_uart));
 
 	usleep(MICROSECOND);
 
-	ret = iotbus_uart_read(h_uart, szOutputText, sizeof(szOutputText));
+	ret = iotbus_uart_read(h_uart, sz_output_text, sizeof(sz_output_text));
 	TC_ASSERT_EQ_CLEANUP("iotbus_uart_read", ret < 0, false, iotbus_uart_stop(h_uart));
 
-	TC_ASSERT_EQ_CLEANUP("iotbus_uart_read", strcmp(szInputText, szOutputText), 0, iotbus_uart_stop(h_uart));
+	TC_ASSERT_EQ_CLEANUP("iotbus_uart_read", strcmp(sz_input_text, sz_output_text), 0, iotbus_uart_stop(h_uart));
 
 	ret = iotbus_uart_stop(h_uart);
 	TC_ASSERT_EQ("iotbus_uart_stop", ret, IOTBUS_ERROR_NONE);
@@ -192,6 +313,464 @@ void itc_systemio_iotbus_uart_flush_p(void)
 	TC_SUCCESS_RESULT();
 }
 
+/**
+* @testcase         itc_systemio_iotbus_uart_write_read_flush_p
+* @brief            write, read, flush data over uart bus
+* @scenario         write, read, flush data over uart bus
+* @apicovered       iotbus_uart_write, iotbus_uart_read, iotbus_uart_flush
+* @precondition     initializes uart_context
+* @postcondition    closes uart_context
+*/
+static void itc_systemio_iotbus_uart_write_read_flush_p(void)
+{
+	int ret = IOTBUS_ERROR_NONE;
+	char sz_input_text[BUF_LEN] = "UART READ/WRITE ITC TESTING!";
+	char sz_output_text[BUF_LEN];
+
+	iotbus_uart_context_h h_uart = iotbus_uart_init(DEVPATH);
+	TC_ASSERT_NEQ("iotbus_uart_init", h_uart, NULL);
+
+	ret = iotbus_uart_write(h_uart, sz_input_text, sizeof(sz_input_text));
+	TC_ASSERT_EQ_CLEANUP("iotbus_uart_write", ret < 0, false, iotbus_uart_stop(h_uart));
+
+	usleep(MICROSECOND);
+
+	ret = iotbus_uart_read(h_uart, sz_output_text, sizeof(sz_output_text));
+	TC_ASSERT_EQ_CLEANUP("iotbus_uart_read", ret < 0, false, iotbus_uart_stop(h_uart));
+	TC_ASSERT_EQ_CLEANUP("iotbus_uart_read", strcmp(sz_input_text, sz_output_text), 0, iotbus_uart_stop(h_uart));
+
+	ret = iotbus_uart_flush(h_uart);
+	TC_ASSERT_EQ_CLEANUP("iotbus_uart_flush", ret, IOTBUS_ERROR_NONE, iotbus_uart_stop(h_uart));
+
+	ret = iotbus_uart_stop(h_uart);
+	TC_ASSERT_EQ("iotbus_uart_stop", ret, IOTBUS_ERROR_NONE);
+
+	TC_SUCCESS_RESULT();
+}
+
+/**
+* @testcase         itc_systemio_iotbus_uart_write_read_flush_multi_p_multi_handle
+* @brief            write, read, flush data over uart bus with multi handler
+* @scenario         write, read, flush data over uart bus with multi handler
+* @apicovered       iotbus_uart_write, iotbus_uart_read, iotbus_uart_flush
+* @precondition     initializes uart_context
+* @postcondition    closes uart_context
+*/
+static void itc_systemio_iotbus_uart_write_read_flush_p_multi_handle(void)
+{
+	int ret = IOTBUS_ERROR_NONE;
+	char sz_input_text1[BUF_LEN] = "UART READ/WRITE ITC TESTING!";
+	char sz_input_text2[BUF_LEN] = "UART READ/WRITE ITC TESTING1!";
+	char sz_output_text[BUF_LEN];
+
+	iotbus_uart_context_h h_uart1 = iotbus_uart_init(DEVPATH);
+	TC_ASSERT_NEQ("iotbus_uart_init", h_uart1, NULL);
+
+	iotbus_uart_context_h h_uart2 = iotbus_uart_init(DEVPATH);
+	TC_ASSERT_NEQ_CLEANUP("iotbus_uart_init", h_uart2, NULL, iotbus_uart_stop(h_uart1));
+
+	ret = iotbus_uart_write(h_uart1, sz_input_text1, sizeof(sz_input_text1));
+	TC_ASSERT_EQ_CLEANUP("iotbus_uart_write", ret < 0, false, iotbus_uart_stop(h_uart1); iotbus_uart_stop(h_uart2));
+
+	ret = iotbus_uart_write(h_uart2, sz_input_text2, sizeof(sz_input_text2));
+	TC_ASSERT_EQ_CLEANUP("iotbus_uart_write", ret < 0, false, iotbus_uart_stop(h_uart1); iotbus_uart_stop(h_uart2));
+
+	usleep(MICROSECOND);
+
+	ret = iotbus_uart_read(h_uart1, sz_output_text, sizeof(sz_output_text));
+	TC_ASSERT_EQ_CLEANUP("iotbus_uart_read", ret < 0, false, iotbus_uart_stop(h_uart1); iotbus_uart_stop(h_uart2));
+	TC_ASSERT_EQ_CLEANUP("iotbus_uart_read", strcmp(sz_input_text1, sz_output_text), 0, iotbus_uart_stop(h_uart1); iotbus_uart_stop(h_uart2));
+
+	ret = iotbus_uart_read(h_uart2, sz_output_text, sizeof(sz_output_text));
+	TC_ASSERT_EQ_CLEANUP("iotbus_uart_read", ret < 0, false, iotbus_uart_stop(h_uart1); iotbus_uart_stop(h_uart2));
+	TC_ASSERT_EQ_CLEANUP("iotbus_uart_read", strcmp(sz_input_text2, sz_output_text), 0, iotbus_uart_stop(h_uart1); iotbus_uart_stop(h_uart2));
+
+	ret = iotbus_uart_flush(h_uart1);
+	TC_ASSERT_EQ_CLEANUP("iotbus_uart_flush", ret, IOTBUS_ERROR_NONE, iotbus_uart_stop(h_uart1); iotbus_uart_stop(h_uart2));
+
+	ret = iotbus_uart_flush(h_uart2);
+	TC_ASSERT_EQ_CLEANUP("iotbus_uart_flush", ret, IOTBUS_ERROR_NONE, iotbus_uart_stop(h_uart1); iotbus_uart_stop(h_uart2));
+
+	ret = iotbus_uart_stop(h_uart2);
+	TC_ASSERT_EQ_CLEANUP("iotbus_uart_stop", ret, IOTBUS_ERROR_NONE, iotbus_uart_stop(h_uart1));
+
+	ret = iotbus_uart_stop(h_uart1);
+	TC_ASSERT_EQ("iotbus_uart_stop", ret, IOTBUS_ERROR_NONE);
+
+	TC_SUCCESS_RESULT();
+}
+
+/**
+* @testcase         itc_systemio_iotbus_uart_write_read_flush_read_p
+* @brief            perform write, read, flush, and read data operations over uart bus
+* @scenario         perform write, read, flush, and read data operations over uart bus
+* @apicovered       iotbus_uart_write, iotbus_uart_read, iotbus_uart_flush
+* @precondition     initializes uart_context
+* @postcondition    closes uart_context
+*/
+static void itc_systemio_iotbus_uart_write_read_flush_read_p(void)
+{
+	int ret = IOTBUS_ERROR_NONE;
+	char sz_input_text[BUF_LEN] = "UART READ/WRITE ITC TESTING!";
+	char sz_output_text[BUF_LEN];
+
+	iotbus_uart_context_h h_uart = iotbus_uart_init(DEVPATH);
+	TC_ASSERT_NEQ("iotbus_uart_init", h_uart, NULL);
+
+	ret = iotbus_uart_write(h_uart, sz_input_text, sizeof(sz_input_text));
+	TC_ASSERT_EQ_CLEANUP("iotbus_uart_write", ret < 0, false, iotbus_uart_stop(h_uart));
+
+	usleep(MICROSECOND);
+
+	ret = iotbus_uart_read(h_uart, sz_output_text, sizeof(sz_output_text));
+	TC_ASSERT_EQ_CLEANUP("iotbus_uart_read", ret < 0, false, iotbus_uart_stop(h_uart));
+	TC_ASSERT_EQ_CLEANUP("iotbus_uart_read", strcmp(sz_input_text, sz_output_text), 0, iotbus_uart_stop(h_uart));
+
+	ret = iotbus_uart_flush(h_uart);
+	TC_ASSERT_EQ_CLEANUP("iotbus_uart_flush", ret, IOTBUS_ERROR_NONE, iotbus_uart_stop(h_uart));
+
+	ret = iotbus_uart_read(h_uart, sz_output_text, sizeof(sz_output_text));
+	TC_ASSERT_EQ_CLEANUP("iotbus_uart_read", ret == 0, true, iotbus_uart_stop(h_uart));
+
+	ret = iotbus_uart_stop(h_uart);
+	TC_ASSERT_EQ("iotbus_uart_stop", ret, IOTBUS_ERROR_NONE);
+
+	TC_SUCCESS_RESULT();
+}
+
+/**
+* @testcase         itc_systemio_iotbus_uart_set_flow_write_read_p
+* @brief            write and read data over uart bus with set flow
+* @scenario         write and read data over uart bus with set flow
+* @apicovered       iotbus_uart_write, iotbus_uart_read, iotbus_uart_set_flowcontrol
+* @precondition     initializes uart_context
+* @postcondition    closes uart_context
+*/
+static void itc_systemio_iotbus_uart_set_flow_write_read_p(void)
+{
+	int i_size = 4;
+	int ret = IOTBUS_ERROR_NONE;
+	char sz_input_text[BUF_LEN] = "UART READ/WRITE ITC TESTING!";
+	char sz_output_text[BUF_LEN];
+	int rtscts[4][2] = { {1, 0}, {0, 1}, {1, 1}, {0, 0} };
+	int index = 0;
+	int count_fail_flowcontrol = 0;
+	int count_fail_write = 0;
+	int count_fail_read = 0;
+
+	iotbus_uart_context_h h_uart = iotbus_uart_init(DEVPATH);
+	TC_ASSERT_NEQ("iotbus_uart_init", h_uart, NULL);
+
+	for (index = 0; index < i_size; index++) {
+		ret = iotbus_uart_set_flowcontrol(h_uart, rtscts[index][0], rtscts[index][1]);
+		if (ret != IOTBUS_ERROR_NONE) {
+			SYSIO_ITC_PRINT("iotbus_uart_set_flowcontrol failed with xonxoff ::%d, rtscts::%d\n", rtscts[index][0], rtscts[index][1]);
+			count_fail_flowcontrol++;
+			continue;
+		}
+
+		ret = iotbus_uart_write(h_uart, sz_input_text, sizeof(sz_input_text));
+		if (ret < 0) {
+			SYSIO_ITC_PRINT("iotbus_uart_write failed with xonxoff ::%d, rtscts::%d\n", rtscts[index][0], rtscts[index][1]);
+			count_fail_write++;
+			continue;
+		}
+
+		usleep(MICROSECOND);
+
+		ret = iotbus_uart_read(h_uart, sz_output_text, sizeof(sz_output_text));
+		if ((ret < 0) || (strcmp(sz_input_text, sz_output_text) != 0)) {
+			SYSIO_ITC_PRINT("iotbus_uart_read failed with xonxoff ::%d, rtscts::%d\n", rtscts[index][0], rtscts[index][1]);
+			count_fail_read++;
+		}
+	}
+	TC_ASSERT_EQ_CLEANUP("iotbus_uart_write failed count", count_fail_write, 0, iotbus_uart_stop(h_uart));
+	TC_ASSERT_EQ_CLEANUP("iotbus_uart_read failed count", count_fail_read, 0, iotbus_uart_stop(h_uart));
+	TC_ASSERT_EQ_CLEANUP("iotbus_uart_set_flowcontrol failed count", count_fail_flowcontrol, 0, iotbus_uart_stop(h_uart));
+
+	ret = iotbus_uart_stop(h_uart);
+	TC_ASSERT_EQ("iotbus_uart_stop", ret, IOTBUS_ERROR_NONE);
+
+	TC_SUCCESS_RESULT();
+}
+
+/**
+* @testcase         itc_systemio_iotbus_uart_set_flow_write_flush_read_p
+* @brief            flush, write, and read data over uart bus with set flow
+* @scenario         flush, write, and read data over uart bus with set flow
+* @apicovered       iotbus_uart_write, iotbus_uart_read, iotbus_uart_set_flowcontrol, iotbus_uart_flush
+* @precondition     initializes uart_context
+* @postcondition    closes uart_context
+*/
+static void itc_systemio_iotbus_uart_set_flow_flush_write_read_p(void)
+{
+	int i_size = 4;
+	int ret = IOTBUS_ERROR_NONE;
+	char sz_input_text[BUF_LEN] = "UART READ/WRITE ITC TESTING!";
+	char sz_output_text[BUF_LEN];
+	int rtscts[4][2] = { {1, 0}, {0, 1}, {1, 1}, {0, 0} };
+	int index = 0;
+	int count_fail_flowcontrol = 0;
+	int count_fail_write = 0;
+	int count_fail_read = 0;
+	int count_fail_flush = 0;
+
+	iotbus_uart_context_h h_uart = iotbus_uart_init(DEVPATH);
+	TC_ASSERT_NEQ("iotbus_uart_init", h_uart, NULL);
+
+	for (index = 0; index < i_size; index++) {
+		ret = iotbus_uart_set_flowcontrol(h_uart, rtscts[index][0], rtscts[index][1]);
+		if (ret != IOTBUS_ERROR_NONE) {
+			SYSIO_ITC_PRINT("iotbus_uart_set_flowcontrol failed with xonxoff ::%d, rtscts::%d\n", rtscts[index][0], rtscts[index][1]);
+			count_fail_flowcontrol++;
+			continue;
+		}
+
+		ret = iotbus_uart_flush(h_uart);
+		if (ret != IOTBUS_ERROR_NONE) {
+			SYSIO_ITC_PRINT("iotbus_uart_flush failed with xonxoff ::%d, rtscts::%d\n", rtscts[index][0], rtscts[index][1]);
+			count_fail_flush++;
+			continue;
+		}
+
+		ret = iotbus_uart_write(h_uart, sz_input_text, sizeof(sz_input_text));
+		if (ret < 0) {
+			SYSIO_ITC_PRINT("iotbus_uart_write failed with xonxoff ::%d, rtscts::%d\n", rtscts[index][0], rtscts[index][1]);
+			count_fail_write++;
+			continue;
+		}
+
+		usleep(MICROSECOND);
+
+		ret = iotbus_uart_read(h_uart, sz_output_text, sizeof(sz_output_text));
+		if ((ret < 0) || (strcmp(sz_input_text, sz_output_text) != 0)) {
+			SYSIO_ITC_PRINT("iotbus_uart_read failed with xonxoff ::%d, rtscts::%d\n", rtscts[index][0], rtscts[index][1]);
+			count_fail_read++;
+		}
+	}
+
+	TC_ASSERT_EQ_CLEANUP("iotbus_uart_flush failed count", count_fail_flush, 0, iotbus_uart_stop(h_uart));
+	TC_ASSERT_EQ_CLEANUP("iotbus_uart_write failed count", count_fail_write, 0, iotbus_uart_stop(h_uart));
+	TC_ASSERT_EQ_CLEANUP("iotbus_uart_read failed count", count_fail_read, 0, iotbus_uart_stop(h_uart));
+	TC_ASSERT_EQ_CLEANUP("iotbus_uart_set_flowcontrol failed count", count_fail_flowcontrol, 0, iotbus_uart_stop(h_uart));
+
+	ret = iotbus_uart_stop(h_uart);
+	TC_ASSERT_EQ("iotbus_uart_stop", ret, IOTBUS_ERROR_NONE);
+
+	TC_SUCCESS_RESULT();
+}
+
+/**
+* @testcase         itc_systemio_iotbus_uart_set_mode_write_read_p
+* @brief            To check write/read operation with different parity
+* @scenario         uart write/read operation with different parity
+* @apicovered       iotbus_uart_set_mode, iotbus_uart_write, iotbus_uart_read
+* @precondition     initializes uart_context
+* @postcondition    closes uart_context
+*/
+static void itc_systemio_iotbus_uart_set_mode_write_read_p(void)
+{
+	int i_bytesize = 8;
+	int i_stop_bits = 1;
+	int ret = IOTBUS_ERROR_NONE;
+	char sz_input_text[BUF_LEN] = "UART READ/WRITE ITC TESTING!";
+	char sz_output_text[BUF_LEN];
+	int mode[] = { IOTBUS_UART_PARITY_NONE, IOTBUS_UART_PARITY_EVEN, IOTBUS_UART_PARITY_ODD };
+	char *mode_str[3] = { "IOTBUS_UART_PARITY_NONE", "IOTBUS_UART_PARITY_EVEN", "IOTBUS_UART_PARITY_ODD" };
+	int i_modes = sizeof(mode) / sizeof(int);
+	int index = 0;
+	int count_fail_mode = 0;
+	int count_fail_write = 0;
+	int count_fail_read = 0;
+
+	iotbus_uart_context_h h_uart = iotbus_uart_init(DEVPATH);
+	TC_ASSERT_NEQ("iotbus_uart_init", h_uart, NULL);
+
+	for (index = 0; index < i_modes; index++) {
+		ret = iotbus_uart_set_mode(h_uart, i_bytesize, mode[index], i_stop_bits);
+		if ((ret != IOTBUS_ERROR_NONE)) {
+			SYSIO_ITC_PRINT("iotbus_uart_set_mode failed with PARITY ::%s, stop_bits::%d\n", mode_str[index], i_stop_bits);
+			count_fail_mode++;
+			continue;
+		}
+
+		ret = iotbus_uart_write(h_uart, sz_input_text, sizeof(sz_input_text));
+		if ((ret < 0)) {
+			SYSIO_ITC_PRINT("iotbus_uart_write failed with PARITY ::%s, stop_bits::%d\n", mode_str[index], i_stop_bits);
+			count_fail_write++;
+			continue;
+		}
+
+		usleep(MICROSECOND);
+
+		ret = iotbus_uart_read(h_uart, sz_output_text, sizeof(sz_output_text));
+		if ((ret < 0) || (strcmp(sz_input_text, sz_output_text) != 0)) {
+			SYSIO_ITC_PRINT("iotbus_uart_read failed with PARITY ::%s, stop_bits::%d\n", mode_str[index], i_stop_bits);
+			count_fail_read++;
+		}
+	}
+
+	TC_ASSERT_EQ_CLEANUP("iotbus_uart_set_mode failed count", count_fail_mode, 0, iotbus_uart_stop(h_uart));
+	TC_ASSERT_EQ_CLEANUP("iotbus_uart_write failed count", count_fail_write, 0, iotbus_uart_stop(h_uart));
+	TC_ASSERT_EQ_CLEANUP("iotbus_uart_read failed count", count_fail_read, 0, iotbus_uart_stop(h_uart));
+
+	ret = iotbus_uart_stop(h_uart);
+	TC_ASSERT_EQ("iotbus_uart_stop", ret, IOTBUS_ERROR_NONE);
+
+	TC_SUCCESS_RESULT();
+}
+
+/**
+* @testcase         itc_systemio_iotbus_uart_set_mode_flush_write_read_p
+* @brief            To check flush/write/read operation with different parity
+* @scenario         uart flush/write/read operation with different parity
+* @apicovered       iotbus_uart_set_mode, iotbus_uart_write, iotbus_uart_read, iotbus_uart_flush
+* @precondition     initializes uart_context
+* @postcondition    closes uart_context
+*/
+static void itc_systemio_iotbus_uart_set_mode_flush_write_read_p(void)
+{
+	int i_bytesize = 8;
+	int i_stop_bits = 1;
+	int ret = IOTBUS_ERROR_NONE;
+	char sz_input_text[BUF_LEN] = "UART READ/WRITE ITC TESTING!";
+	char sz_output_text[BUF_LEN];
+	int mode[] = { IOTBUS_UART_PARITY_NONE, IOTBUS_UART_PARITY_EVEN, IOTBUS_UART_PARITY_ODD };
+	char *mode_str[3] = { "IOTBUS_UART_PARITY_NONE", "IOTBUS_UART_PARITY_EVEN", "IOTBUS_UART_PARITY_ODD" };
+	int i_modes = sizeof(mode) / sizeof(int);
+	int index = 0;
+	int count_fail_mode = 0;
+	int count_fail_write = 0;
+	int count_fail_read = 0;
+	int count_fail_flush = 0;
+
+	iotbus_uart_context_h h_uart = iotbus_uart_init(DEVPATH);
+	TC_ASSERT_NEQ("iotbus_uart_init", h_uart, NULL);
+
+	for (index = 0; index < i_modes; index++) {
+		ret = iotbus_uart_set_mode(h_uart, i_bytesize, mode[index], i_stop_bits);
+		if ((ret != IOTBUS_ERROR_NONE)) {
+			SYSIO_ITC_PRINT("iotbus_uart_set_mode failed with PARITY ::%s, stop_bits::%d\n", mode_str[index], i_stop_bits);
+			count_fail_mode++;
+			continue;
+		}
+
+		ret = iotbus_uart_flush(h_uart);
+		if ((ret != IOTBUS_ERROR_NONE)) {
+			SYSIO_ITC_PRINT("iotbus_uart_flush failed with PARITY ::%s, stop_bits::%d\n", mode_str[index], i_stop_bits);
+			count_fail_flush++;
+			continue;
+		}
+
+		ret = iotbus_uart_write(h_uart, sz_input_text, sizeof(sz_input_text));
+		if ((ret < 0)) {
+			SYSIO_ITC_PRINT("iotbus_uart_write failed with PARITY ::%s, stop_bits::%d\n", mode_str[index], i_stop_bits);
+			count_fail_write++;
+			continue;
+		}
+
+		usleep(MICROSECOND);
+
+		ret = iotbus_uart_read(h_uart, sz_output_text, sizeof(sz_output_text));
+		if ((ret < 0) || (strcmp(sz_input_text, sz_output_text) != 0)) {
+			SYSIO_ITC_PRINT("iotbus_uart_read failed with PARITY ::%s, stop_bits::%d\n", mode_str[index], i_stop_bits);
+			count_fail_read++;
+		}
+	}
+
+	TC_ASSERT_EQ_CLEANUP("iotbus_uart_set_mode failed count", count_fail_mode, 0, iotbus_uart_stop(h_uart));
+	TC_ASSERT_EQ_CLEANUP("iotbus_uart_flush failed count", count_fail_flush, 0, iotbus_uart_stop(h_uart));
+	TC_ASSERT_EQ_CLEANUP("iotbus_uart_write failed count", count_fail_write, 0, iotbus_uart_stop(h_uart));
+	TC_ASSERT_EQ_CLEANUP("iotbus_uart_read failed count", count_fail_read, 0, iotbus_uart_stop(h_uart));
+
+	ret = iotbus_uart_stop(h_uart);
+	TC_ASSERT_EQ("iotbus_uart_stop", ret, IOTBUS_ERROR_NONE);
+
+	TC_SUCCESS_RESULT();
+}
+
+/**
+* @testcase         itc_systemio_iotbus_uart_set_flow_mode_flush_write_read_p
+* @brief            To check flush/write/read operation with all combination of parity and flow
+* @scenario         uart flush/write/read operation with all combination of parity and flow
+* @apicovered       iotbus_uart_set_flowcontrol, iotbus_uart_set_mode, iotbus_uart_write, iotbus_uart_read, iotbus_uart_flush
+* @precondition     initializes uart_context
+* @postcondition    closes uart_context
+*/
+static void itc_systemio_iotbus_uart_set_flow_mode_flush_write_read_p(void)
+{
+	int i_bytesize = 8;
+	int i_flow_size = 4;
+	int i_stop_bits = 1;
+	int ret = IOTBUS_ERROR_NONE;
+	char sz_input_text[BUF_LEN] = "UART READ/WRITE ITC TESTING!";
+	char sz_output_text[BUF_LEN];
+	int mode[] = { IOTBUS_UART_PARITY_NONE, IOTBUS_UART_PARITY_EVEN, IOTBUS_UART_PARITY_ODD };
+	char *mode_str[3] = { "IOTBUS_UART_PARITY_NONE", "IOTBUS_UART_PARITY_EVEN", "IOTBUS_UART_PARITY_ODD" };
+	int rtscts[4][2] = { {1, 0}, {0, 1}, {1, 1}, {0, 0} };
+	int i_modes = sizeof(mode) / sizeof(int);
+	int index = 0;
+	int flow_index = 0;
+	int count_fail_mode = 0;
+	int count_fail_write = 0;
+	int count_fail_read = 0;
+	int count_fail_flush = 0;
+	int count_fail_flowcontrol = 0;
+
+	iotbus_uart_context_h h_uart = iotbus_uart_init(DEVPATH);
+	TC_ASSERT_NEQ("iotbus_uart_init", h_uart, NULL);
+
+	for (flow_index = 0; flow_index < i_flow_size; flow_index++) {
+		ret = iotbus_uart_set_flowcontrol(h_uart, rtscts[flow_index][0], rtscts[flow_index][1]);
+		if (ret != IOTBUS_ERROR_NONE) {
+			SYSIO_ITC_PRINT("iotbus_uart_set_flowcontrol failed with xonxoff ::%d, rtscts::%d\n", rtscts[flow_index][0], rtscts[flow_index][1]);
+			count_fail_flowcontrol++;
+			continue;
+		}
+
+		for (index = 0; index < i_modes; index++) {
+			ret = iotbus_uart_set_mode(h_uart, i_bytesize, mode[index], i_stop_bits);
+			if ((ret != IOTBUS_ERROR_NONE)) {
+				SYSIO_ITC_PRINT("iotbus_uart_set_mode failed with PARITY ::%s, stop_bits::%d, xonxoff::%d, rtscts::%d\n", mode_str[index], i_stop_bits, rtscts[flow_index][0], rtscts[flow_index][1]);
+				count_fail_mode++;
+				continue;
+			}
+
+			ret = iotbus_uart_flush(h_uart);
+			if ((ret != IOTBUS_ERROR_NONE)) {
+				SYSIO_ITC_PRINT("iotbus_uart_flush failed with PARITY ::%s, stop_bits::%d, xonxoff::%d, rtscts::%d\n", mode_str[index], i_stop_bits, rtscts[flow_index][0], rtscts[flow_index][1]);
+				count_fail_flush++;
+				continue;
+			};
+
+			ret = iotbus_uart_write(h_uart, sz_input_text, sizeof(sz_input_text));
+			if ((ret < 0)) {
+				SYSIO_ITC_PRINT("iotbus_uart_write failed with PARITY ::%s, stop_bits::%d, xonxoff::%d, rtscts::%d\n", mode_str[index], i_stop_bits, rtscts[flow_index][0], rtscts[flow_index][1]);
+				count_fail_write++;
+				continue;
+			}
+
+			usleep(MICROSECOND);
+
+			ret = iotbus_uart_read(h_uart, sz_output_text, sizeof(sz_output_text));
+			if ((ret < 0) || (strcmp(sz_input_text, sz_output_text) != 0)) {
+				SYSIO_ITC_PRINT("iotbus_uart_read failed with PARITY ::%s, stop_bits::%d, xonxoff::%d, rtscts::%d\n", mode_str[index], i_stop_bits, rtscts[flow_index][0], rtscts[flow_index][1]);
+				count_fail_read++;
+			}
+		}
+	}
+	TC_ASSERT_EQ_CLEANUP("iotbus_uart_set_flowcontrol failed count", count_fail_flowcontrol, 0, iotbus_uart_stop(h_uart));
+	TC_ASSERT_EQ_CLEANUP("iotbus_uart_set_mode failed count", count_fail_mode, 0, iotbus_uart_stop(h_uart));
+	TC_ASSERT_EQ_CLEANUP("iotbus_uart_flush failed count", count_fail_flush, 0, iotbus_uart_stop(h_uart));
+	TC_ASSERT_EQ_CLEANUP("iotbus_uart_write failed count", count_fail_write, 0, iotbus_uart_stop(h_uart));
+	TC_ASSERT_EQ_CLEANUP("iotbus_uart_read failed count", count_fail_read, 0, iotbus_uart_stop(h_uart));
+
+	ret = iotbus_uart_stop(h_uart);
+	TC_ASSERT_EQ("iotbus_uart_stop", ret, IOTBUS_ERROR_NONE);
+
+	TC_SUCCESS_RESULT();
+}
+
 /****************************************************************************
  * Name: environ
  ****************************************************************************/
@@ -202,11 +781,22 @@ int itc_uart_main(void)
 	SYSIO_ITC_UART_PRINT("IOTBUS Not Supported\n");
 #else
 	itc_systemio_iotbus_uart_init_stop_p();
+	itc_systemio_iotbus_uart_init_stop_p_multi_handle();
 	itc_systemio_iotbus_uart_set_baudrate_p();
+	itc_systemio_iotbus_uart_set_baudrate_n();
 	itc_systemio_iotbus_uart_set_mode_p();
+	itc_systemio_iotbus_uart_set_mode_p_all();
 	itc_systemio_iotbus_uart_set_flowcontrol_p();
 	itc_systemio_iotbus_uart_write_read_p();
+	itc_systemio_iotbus_uart_write_read_flush_p_multi_handle();
 	itc_systemio_iotbus_uart_flush_p();
+	itc_systemio_iotbus_uart_write_read_flush_p();
+	//itc_systemio_iotbus_uart_write_read_flush_read_p();// TASH being hanged on execution of the testcase
+	itc_systemio_iotbus_uart_set_flow_write_read_p();
+	itc_systemio_iotbus_uart_set_flow_flush_write_read_p();
+	itc_systemio_iotbus_uart_set_mode_write_read_p();
+	itc_systemio_iotbus_uart_set_mode_flush_write_read_p();
+	itc_systemio_iotbus_uart_set_flow_mode_flush_write_read_p();
 #endif
 
 	return 0;


### PR DESCRIPTION
Scenarios ITCs of gpio, spi and uart modules of systemio perform below tests:
itc_systemio_gpio_set_direction_read_write_p_all_directions : gpio read wirte for all direction
itc_systemio_gpio_set_edge_read_write_p_all_edges : gpio read wirte for all edges
itc_systemio_gpio_set_drive_read_write_p_all_drive_mode : gpio read wirte for all drive modes
itc_systemio_gpio_set_get_direction_edge_drive_mode_p : gpio set get direction edge and drive mode combined
itc_systemio_gpio_open_close_p_different_pin : gpio open close different pins
itc_systemio_gpio_open_close_p_multi_handle : gpio open close formultiple handle
itc_systemio_gpio_open_close_p_reclose : gpio reclose after gpio close
itc_systemio_gpio_open_n : gpio open with invalid argument
itc_systemio_gpio_close_n : gpio close with invalid argument
itc_systemio_gpio_get_pin_n : gets a pin number of the gpio with invalid parameter
itc_systemio_gpio_get_pin_n_after_close : initializes gpio_context based on gpio pin and then closes the gpio_context, then get gpio pin
itc_systemio_gpio_get_pin_n_after_invalid_open : initializes gpio_context based on gpio pin and then closes the gpio_context, then get gpio pin
itc_systemio_gpio_read_n_after_close : reads the gpio value after gpio close
itc_systemio_gpio_write_n_after_close : writes the gpio value after gpio close
itc_systemio_gpio_set_direction_n : sets the gpio direction with invalid parameter
itc_systemio_gpio_get_direction_n : gets the gpio direction with invalid parameter
itc_systemio_gpio_set_direction_n_after_close : sets the gpio direction after gpio context is closed
itc_systemio_gpio_get_direction_n_after_close : gets the gpio direction after gpio context is closed
itc_systemio_gpio_set_edge_mode_n : sets the gpio edge mode with invalid parameter
itc_systemio_gpio_get_edge_mode_n : gets the gpio edge mode with invalid parameter
itc_systemio_gpio_set_edge_mode_n_after_close : sets the gpio edge mode after gpio context is closed
itc_systemio_gpio_get_edge_mode_n_after_close : gets the gpio edge mode after gpio context is closed
itc_systemio_gpio_set_drive_mode_n : sets the gpio drive mode with invalid parameter
itc_systemio_gpio_get_drive_mode_n : gets the gpio drive mode with invalid parameter
itc_systemio_gpio_set_drive_mode_n_after_close : sets the gpio drive mode after gpio context close
itc_systemio_gpio_get_drive_mode_n_after_close : gets the gpio drive mode after gpio context close
itc_systemio_spi_open_close_p_multi_handler : initializes and closes the spi_context with multi handler
itc_systemio_spi_open_close_p_modes : initializes and closes the spi_context for modes
itc_systemio_spi_open_close_n_invalid_bus : initializes and closes the spi_context with invalid bus
itc_systemio_spi_open_close_n_invalid_bpw : initializes and closes the spi_context with invalid bpw
itc_systemio_spi_open_close_n_invalid_frequecy : initializes and closes the spi_context with invalid frequency
itc_systemio_iotbus_uart_init_stop_p_multi_handle : initializes and closes uart_context with multi handle
itc_systemio_iotbus_uart_set_baudrate_n : sets uart baud rate with invalid rate
itc_systemio_iotbus_uart_set_mode_p_all : sets byte size, parity bit and stop bits (all combinations)
itc_systemio_iotbus_uart_write_read_flush_p_multi_handle : write, read, flush data over uart bus with multi handler
itc_systemio_iotbus_uart_write_read_flush_p : write, read, flush data over uart bus
itc_systemio_iotbus_uart_write_read_flush_read_p : perform write, read, flush, and read data operations over uart bus
itc_systemio_iotbus_uart_set_flow_write_read_p : write and read data over uart bus with set flow
itc_systemio_iotbus_uart_set_flow_flush_write_read_p : flush, write, and read data over uart bus with set flow
itc_systemio_iotbus_uart_set_mode_write_read_p : uart write/read operation with different parity
itc_systemio_iotbus_uart_set_mode_flush_write_read_p : uart flush/write/read operation with different parity
itc_systemio_iotbus_uart_set_flow_mode_flush_write_read_p : uart flush/write/read operation with all combination of parity and flow

Signed-off-by: Arvin Mittal <arvin.mittal@samsung.com>