### PR TITLE
Add LWIP error dependency to network testcase

### DIFF
--- a/apps/examples/testcase/le_tc/network/Kconfig
+++ b/apps/examples/testcase/le_tc/network/Kconfig
@@ -6,6 +6,7 @@
 menuconfig EXAMPLES_TESTCASE_NETWORK
 	bool "Network TestCase Example"
 	default n
+	select NET_LWIP_ERROR if NET_LWIP
 	---help---
 		Enable the Network TestCase Example
 


### PR DESCRIPTION
currently, network testcase does not have CONFIG_NET_LWIP_ERROR  automatically enabled, which causes problems in it's execution. The solution is to enforce a dependency of CONFIG_NET_LWIP_ERROR on the testcase example. This ensures that testcase can compile only if CONFIG_NET_LWIP_ERROR is enabled.