### PR TITLE
testcase/le_tc/network : add ITCs for network APIs

### DIFF
--- a/apps/examples/testcase/le_tc/network/Kconfig
+++ b/apps/examples/testcase/le_tc/network/Kconfig
@@ -38,6 +38,10 @@ config TC_NET_ALL
 	select TC_NET_ETHER
 	select TC_NET_NETDB
 	select TC_NET_DUP
+	select ITC_NET_CLOSE
+	select ITC_NET_DUP
+	select ITC_NET_FCNTL
+	select ITC_NET_LISTEN
 
 config TC_NET_SOCKET
 	bool "socket() api"
@@ -127,5 +131,20 @@ config TC_NET_DUP
 	bool "dup() api"
 	default n
 
+config ITC_NET_CLOSE
+	bool "ITC close() api"
+	default n
+
+config ITC_NET_DUP
+	bool "ITC dup() api"
+	default n
+
+config ITC_NET_FCNTL
+	bool "ITC fcntl() api"
+	default n
+
+config ITC_NET_LISTEN
+	bool "ITC listen() api"
+	default n
 
 endif #EXAMPLES_TESTCASE_NETWORK

--- a/apps/examples/testcase/le_tc/network/Make.defs
+++ b/apps/examples/testcase/le_tc/network/Make.defs
@@ -122,6 +122,18 @@ endif
 ifeq ($(CONFIG_TC_NET_DUP),y)
 CSRCS +=tc_net_dup.c
 endif
+ifeq ($(CONFIG_ITC_NET_CLOSE),y)
+CSRCS += itc_net_close.c
+endif
+ifeq ($(CONFIG_ITC_NET_DUP),y)
+CSRCS += itc_net_dup.c
+endif
+ifeq ($(CONFIG_ITC_NET_FCNTL),y)
+CSRCS += itc_net_fcntl.c
+endif
+ifeq ($(CONFIG_ITC_NET_LISTEN),y)
+CSRCS += itc_net_listen.c
+endif
 
 # Include network build support
 

--- a/apps/examples/testcase/le_tc/network/itc_net_close.c
+++ b/apps/examples/testcase/le_tc/network/itc_net_close.c
@@ -1,0 +1,86 @@
+/****************************************************************************
+ *
+ * Copyright 2017 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+///file itc_net_close.c
+///brief Test Case Example for close() API
+
+#include <sys/socket.h>
+#include "tc_internal.h"
+
+#define LOOP_COUNT 10
+
+/**
+* @testcase          :itc_net_close_p_multi_times
+* @brief             :close file descriptor
+* @scenario          :open socket and close file descriptor multiple times
+* @apicovered        :close()
+* @precondition      :open socket
+* @postcondition     :none
+*/
+static void itc_net_close_p_multi_times(void)
+{
+	int fd = -1;
+	int index = 0;
+	int ret;
+
+	for (index = 0; index < LOOP_COUNT; index++) {
+		fd = -1;
+		fd = socket(AF_INET, SOCK_STREAM, 0);
+		TC_ASSERT_GEQ("socket", fd, CONFIG_NFILE_DESCRIPTORS);//If ASSERT FAILS, no need to close(fd) as socket is not created
+
+		ret = close(fd);
+		TC_ASSERT_EQ("close", ret, 0);
+	}
+
+	TC_SUCCESS_RESULT();
+}
+
+/**
+* @testcase          :itc_net_close_n_reclose
+* @brief             :close file descriptor
+* @scenario          :open socket and close file descriptor and then reclose file descriptor
+* @apicovered        :close()
+* @precondition      :open socket
+* @postcondition     :none
+*/
+static void itc_net_close_n_reclose(void)
+{
+	int fd = -1;
+	fd = socket(AF_INET, SOCK_STREAM, 0);
+	TC_ASSERT_GEQ("socket", fd, CONFIG_NFILE_DESCRIPTORS);
+
+	int ret = close(fd);
+	TC_ASSERT_EQ("close", ret, 0);
+
+	ret = close(fd);
+	TC_ASSERT_LT("close", ret, 0);
+
+	TC_SUCCESS_RESULT();
+}
+
+/****************************************************************************
+ * Name: close()
+ ****************************************************************************/
+
+int itc_net_close_main(void)
+{
+	itc_net_close_p_multi_times();
+	itc_net_close_n_reclose();
+
+	return 0;
+}

--- a/apps/examples/testcase/le_tc/network/itc_net_dup.c
+++ b/apps/examples/testcase/le_tc/network/itc_net_dup.c
@@ -1,0 +1,106 @@
+/****************************************************************************
+*
+* Copyright 2017 Samsung Electronics All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+* either express or implied. See the License for the specific
+* language governing permissions and limitations under the License.
+*
+****************************************************************************/
+
+///@file itc_net_dup.c
+///@brief Test Case Example for dup() API
+
+#include <sys/socket.h>
+#include "tc_internal.h"
+
+#define LOOP_COUNT 10
+
+/**
+* @testcase         :itc_net_dup_p_multiple_time
+* @brief            :clone a file descriptor to arbitrary descriptor
+* @scenario         :open socket and clone a file descriptor to arbitrary descriptor multiple times
+* @apicovered       :dup()
+* @precondition     :open socket()
+* @postcondition    :close socket descriptor
+*/
+static void itc_net_dup_p_multiple_time(void)
+{
+	int index;
+	int sock;
+	int ret;
+	int fd;
+
+	for (index = 0; index < LOOP_COUNT; index++) {
+		sock = socket(AF_INET, SOCK_STREAM, 0);
+		TC_ASSERT_GEQ("socket", sock, CONFIG_NFILE_DESCRIPTORS);//If ASSERT FAILS, no need to close(sock) as socket is not created
+
+		fd = dup(sock);
+		TC_ASSERT_GT_CLEANUP("dup", fd, CONFIG_NFILE_DESCRIPTORS, close(sock));
+
+		ret = close(sock);
+		TC_ASSERT_EQ_CLEANUP("close", ret, 0, close(fd));
+
+		ret = close(fd);
+		TC_ASSERT_EQ("close", ret, 0);
+	}
+
+	TC_SUCCESS_RESULT();
+}
+
+/**
+* @testcase         :itc_net_dup2_p_multiple_time
+* @brief            :clone a file descriptor to specific descriptor
+* @scenario         :open socket twice to get 2 socket descriptor and clone a file descriptor to specific descriptor
+* @apicovered       :dup2()
+* @precondition     :open socket()
+* @postcondition    :close socket descriptors
+*/
+static void itc_net_dup2_p_multiple_time(void)
+{
+	int index;
+	int sock_old;
+	int sock_new;
+	int ret;
+
+	for (index = 0; index < LOOP_COUNT; index++) {
+		sock_old = -1;
+		sock_old = socket(AF_INET, SOCK_STREAM, 0);
+		TC_ASSERT_GEQ("socket", sock_old, CONFIG_NFILE_DESCRIPTORS);
+
+		sock_new = -1;
+		sock_new = socket(AF_INET, SOCK_DGRAM, 0);
+		TC_ASSERT_GEQ_CLEANUP("socket", sock_new, CONFIG_NFILE_DESCRIPTORS, close(sock_old));
+
+		ret = dup2(sock_old, sock_new);
+		TC_ASSERT_EQ_CLEANUP("dup2", ret, 0, close(sock_old); close(sock_new));
+
+		ret = close(sock_old);
+		TC_ASSERT_EQ_CLEANUP("close", ret, 0, close(sock_new));
+
+		ret = close(sock_new);
+		TC_ASSERT_EQ("close", ret, 0);
+	}
+
+	TC_SUCCESS_RESULT();
+}
+
+/****************************************************************************
+* Name: dup()
+****************************************************************************/
+
+int itc_net_dup_main(void)
+{
+	itc_net_dup_p_multiple_time();
+	itc_net_dup2_p_multiple_time();
+
+	return 0;
+}

--- a/apps/examples/testcase/le_tc/network/itc_net_fcntl.c
+++ b/apps/examples/testcase/le_tc/network/itc_net_fcntl.c
@@ -1,0 +1,89 @@
+/****************************************************************************
+ *
+ * Copyright 2017 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+///@file itc_net_fcntl.c
+///@brief Test Case Example for fcntl() API
+
+#include <sys/socket.h>
+#include "tc_internal.h"
+
+/**
+* @testcase          :itc_net_fcntl_p_dupfd
+* @brief             :manipulate file descriptor
+* @scenario          :open socket and call fcntl with flag F_DUPFD which duplicates the file descriptor
+* @apicovered        :fcntl()
+* @precondition      :open socket
+* @postcondition     :close socket
+*/
+static void itc_net_fcntl_p_dupfd(void)
+{
+	int ret;
+	int fd = -1;
+	fd = socket(AF_INET, SOCK_STREAM, 0);//If ASSERT FAILS, no need to close(fd) as socket is not created
+	TC_ASSERT_GEQ("socket", fd, CONFIG_NFILE_DESCRIPTORS);
+
+	int nfd = fcntl(fd, F_DUPFD, 0);
+	TC_ASSERT_GEQ_CLEANUP("fcntl", nfd, CONFIG_NFILE_DESCRIPTORS, close(fd));
+
+	ret = close(fd);
+	TC_ASSERT_EQ_CLEANUP("close", ret, 0, close(nfd));
+
+	ret = close(nfd);
+	TC_ASSERT_EQ("close", ret, 0);
+
+	TC_SUCCESS_RESULT();
+}
+
+/**
+* @testcase          :itc_net_fcntl_p_dupfd_nonblock
+* @brief             :manipulate file descriptor
+* @scenario          :open socket and call fcntl with flag O_NONBLOCK and F_DUPFD which duplicates the file descriptor
+* @apicovered        :fcntl()
+* @precondition      :socket open
+* @postcondition     :socket close
+*/
+static void itc_net_fcntl_p_dupfd_nonblock(void)
+{
+	int ret;
+	int fd = -1;
+	fd = socket(AF_INET, SOCK_STREAM, 0);
+	TC_ASSERT_GEQ("socket", fd, CONFIG_NFILE_DESCRIPTORS);
+
+	int nfd = fcntl(fd, F_DUPFD, O_NONBLOCK);
+	TC_ASSERT_GEQ_CLEANUP("fcntl", nfd, CONFIG_NFILE_DESCRIPTORS, close(fd));
+
+	ret = close(fd);
+	TC_ASSERT_EQ_CLEANUP("close", ret, 0, close(nfd));
+
+	ret = close(nfd);
+	TC_ASSERT_EQ("close", ret, 0);
+
+	TC_SUCCESS_RESULT();
+}
+
+/****************************************************************************
+ * Name: fcntl()
+ ****************************************************************************/
+
+int itc_net_fcntl_main(void)
+{
+	itc_net_fcntl_p_dupfd();
+	itc_net_fcntl_p_dupfd_nonblock();
+
+	return 0;
+}

--- a/apps/examples/testcase/le_tc/network/itc_net_listen.c
+++ b/apps/examples/testcase/le_tc/network/itc_net_listen.c
@@ -1,0 +1,161 @@
+/****************************************************************************
+ *
+ * Copyright 2017 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+/// @file itc_net_listen.c
+/// @brief Test Case Example for listen() API
+
+#include <sys/socket.h>
+#include "tc_internal.h"
+
+#define ADDR_PORT 1100
+#define SOCK_PORT 1101
+#define LOOP_COUNT 10
+#define BACK_LOG 10
+
+/**
+* @testcase        :itc_net_listen_p_multiple_time
+* @brief           :listen for socket connections and limit the queue of incoming connections
+* @scenario        :create socket, bind it and then listen and repeat multiple times
+* @apicovered      :listen()
+* @precondition    :open socket
+* @postcondition   :close socket
+*/
+static void itc_net_listen_p_multiple_time(void)
+{
+	int index;
+	int socket_fd;
+	int ret;
+	struct sockaddr_in sa;
+
+	for (index = 0; index < LOOP_COUNT; index++) {
+		socket_fd = socket(PF_INET, SOCK_STREAM, IPPROTO_TCP);
+		TC_ASSERT_GEQ("socket", socket_fd, CONFIG_NFILE_DESCRIPTORS);//If ASSERT FAILS, no need to close(socket_fd) as socket is not created
+
+		memset(&sa, 0, sizeof sa);
+
+		sa.sin_family = AF_INET;
+		sa.sin_port = htons(ADDR_PORT);
+		sa.sin_addr.s_addr = htonl(INADDR_ANY);
+
+		ret = bind(socket_fd, (struct sockaddr *)&sa, sizeof(sa));
+		TC_ASSERT_EQ_CLEANUP("bind", ret, 0, close(socket_fd));
+
+		ret = listen(socket_fd, BACK_LOG);
+		TC_ASSERT_EQ_CLEANUP("listen", ret, 0, close(socket_fd));
+
+		ret = close(socket_fd);
+		TC_ASSERT_EQ("close", ret, 0);
+	}
+
+	TC_SUCCESS_RESULT();
+}
+
+/**
+* @testcase        :itc_net_listen_p_different_socket
+* @brief           :listen for socket connections and limit the queue of incoming connections
+* @scenario        :create socket, bind it and then listen
+* @apicovered      :listen()
+* @precondition    :open socket
+* @postcondition   :close socket
+*/
+static void itc_net_listen_p_different_socket(void)
+{
+	struct sockaddr_in sa;
+	struct sockaddr_in saddr;
+	int socket_fd = socket(PF_INET, SOCK_STREAM, IPPROTO_TCP);
+	TC_ASSERT_GEQ("socket", socket_fd, CONFIG_NFILE_DESCRIPTORS);
+
+	int fd = socket(PF_INET, SOCK_STREAM, IPPROTO_TCP);
+	TC_ASSERT_GEQ("socket", fd, CONFIG_NFILE_DESCRIPTORS);
+
+	memset(&sa, 0, sizeof sa);
+	memset(&saddr, 0, sizeof saddr);
+
+	sa.sin_family = AF_INET;
+	sa.sin_port = htons(ADDR_PORT);
+	sa.sin_addr.s_addr = htonl(INADDR_ANY);
+
+	saddr.sin_family = AF_INET;
+	saddr.sin_port = htons(SOCK_PORT);
+	saddr.sin_addr.s_addr = htonl(INADDR_ANY);
+
+	int ret = bind(socket_fd, (struct sockaddr *)&sa, sizeof(sa));
+	TC_ASSERT_EQ_CLEANUP("bind", ret, 0, close(socket_fd); close(fd));
+
+	ret = bind(fd, (struct sockaddr *)&saddr, sizeof(saddr));
+	TC_ASSERT_EQ_CLEANUP("bind", ret, 0, close(socket_fd); close(fd));
+
+	ret = listen(socket_fd, BACK_LOG);
+	TC_ASSERT_EQ_CLEANUP("listen", ret, 0, close(socket_fd); close(fd));
+
+	ret = listen(fd, BACK_LOG);
+	TC_ASSERT_EQ_CLEANUP("listen", ret, 0, close(socket_fd); close(fd));
+
+	ret = close(socket_fd);
+	TC_ASSERT_EQ_CLEANUP("close", ret, 0, close(fd));
+
+	ret = close(fd);
+	TC_ASSERT_EQ("close", ret, 0);
+
+	TC_SUCCESS_RESULT();
+}
+
+/**
+* @testcase        :itc_net_listen_n_after_socket_close
+* @brief           :listen for socket connections and limit the queue of incoming connections
+* @scenario        :create socket, bind, close socket and then listen
+* @apicovered      :listen()
+* @precondition    :open socket, close socket
+* @postcondition   :none
+*/
+static void itc_net_listen_n_after_socket_close(void)
+{
+	struct sockaddr_in sa;
+	int socket_fd = socket(PF_INET, SOCK_STREAM, IPPROTO_TCP);
+	TC_ASSERT_GEQ("socket", socket_fd, CONFIG_NFILE_DESCRIPTORS);
+
+	memset(&sa, 0, sizeof sa);
+
+	sa.sin_family = AF_INET;
+	sa.sin_port = htons(ADDR_PORT);
+	sa.sin_addr.s_addr = htonl(INADDR_ANY);
+
+	int ret = bind(socket_fd, (struct sockaddr *)&sa, sizeof(sa));
+	TC_ASSERT_EQ_CLEANUP("bind", ret, 0, close(socket_fd));
+
+	ret = close(socket_fd);
+	TC_ASSERT_EQ("close", ret, 0);
+
+	ret = listen(socket_fd, BACK_LOG);
+	TC_ASSERT_NEQ("listen", ret, 0);
+
+	TC_SUCCESS_RESULT();
+}
+
+/****************************************************************************
+ * Name: listen()
+ ****************************************************************************/
+
+int itc_net_listen_main(void)
+{
+	itc_net_listen_p_multiple_time();
+	itc_net_listen_p_different_socket();
+	itc_net_listen_n_after_socket_close();
+
+	return 0;
+}

--- a/apps/examples/testcase/le_tc/network/network_tc_main.c
+++ b/apps/examples/testcase/le_tc/network/network_tc_main.c
@@ -30,7 +30,6 @@ extern int working_tc;
 /****************************************************************************
  * Name: network_tc_main
  ****************************************************************************/
-
 #ifdef CONFIG_BUILD_KERNEL
 int main(int argc, FAR char *argv[])
 #else
@@ -113,6 +112,18 @@ int tc_network_main(int argc, char *argv[])
 #endif
 #ifdef CONFIG_TC_NET_DUP
 	net_dup_main();
+#endif
+#ifdef CONFIG_ITC_NET_CLOSE
+	itc_net_close_main();
+#endif
+#ifdef CONFIG_ITC_NET_DUP
+	itc_net_dup_main();
+#endif
+#ifdef CONFIG_ITC_NET_FCNTL
+	itc_net_fcntl_main();
+#endif
+#ifdef CONFIG_ITC_NET_LISTEN
+	itc_net_listen_main();
 #endif
 
 	printf("\n########## Network TC End [PASS : %d, FAIL : %d] ##########\n", total_pass, total_fail);

--- a/apps/examples/testcase/le_tc/network/tc_internal.h
+++ b/apps/examples/testcase/le_tc/network/tc_internal.h
@@ -100,4 +100,16 @@ int net_netdb_main(void);
 #ifdef CONFIG_TC_NET_DUP
 int net_dup_main(void);
 #endif
+#ifdef CONFIG_ITC_NET_CLOSE
+int itc_net_close_main(void);
+#endif
+#ifdef CONFIG_ITC_NET_DUP
+int itc_net_dup_main(void);
+#endif
+#ifdef CONFIG_ITC_NET_FCNTL
+int itc_net_fcntl_main(void);
+#endif
+#ifdef CONFIG_ITC_NET_LISTEN
+int itc_net_listen_main(void);
+#endif
 #endif /* __EXAMPLES_TESTCASE_NETWORK_TC_INTERNAL_H */


### PR DESCRIPTION
Scenarios ITCs perform below tests:
open and close socket file descriptor multiple times,
reclose close file descriptor
clone a file descriptor multiple times
clone a file descriptor to specific descriptor multiple times
call fcntl with flag F_DUPFD
call fcntl with flag O_NONBLOCK and F_DUPFD
bind socket and then listen and repeat multiple times
bind different socket and then listen
listen afetr close socket

Signed-off-by: Arvin Mittal <arvin.mittal@samsung.com>