### PR TITLE
ttrace: make a dependancy between DEBUG_TTRACE and TTRACE

### DIFF
--- a/os/Kconfig.debug
+++ b/os/Kconfig.debug
@@ -525,6 +525,7 @@ config DEBUG_WATCHDOG
 config DEBUG_TTRACE
 	bool "T-trace Debug Output"
 	default n
+	depends on TTRACE
 	---help---
 		Enable T-trace debug SYSLOG output (disabled by default)
 


### PR DESCRIPTION
DEBUG_TTRACE is valid when TTRACE is enabled.