### PR TITLE
arch/tiva: modify TIVA_ETHERNET dependancies

### DIFF
--- a/os/arch/arm/src/tiva/Kconfig
+++ b/os/arch/arm/src/tiva/Kconfig
@@ -532,7 +532,8 @@ config TIVA_TIMER7
 config TIVA_ETHERNET
 	bool "Ethernet"
 	default n
-	select NETDEVICES
+	depends on TIVA_HAVE_ETHERNET
+	select NETDEVICES if NET
 	---help---
 		This must be set (along with NET) to build the Stellaris Ethernet driver.
 


### PR DESCRIPTION
1. When we use menuconfig, we can meet a warning as shown below:
  warning: (TIVA_ETHERNET) selects NETDEVICES which has unmet direct dependencies (NET)

  NETDEVICES is under NET so that if we want to enable NETDEVICES,
  NET should be enabled first. To resolve this, let's add "if NET" at end of
  NETDEVICE selection.

2. TIVA_ETHERNET can be enabled when hw has that periperal.
  TIVA_HAVE_EHTERNET shows that so that TIVA_ETHERNET should have
  a dependancy with TIVA_HAVE_ETHERNET.