### PR TITLE
Remove unnessary tab in environ tc

### DIFF
--- a/apps/examples/testcase/le_tc/kernel/tc_environ.c
+++ b/apps/examples/testcase/le_tc/kernel/tc_environ.c
@@ -158,7 +158,7 @@ static void tc_environ_putenv(void)
 	TC_ASSERT_EQ("putenv", ret_chk, OK);
 
 	psz_getvalue = getenv("PATH");
-	TC_ASSERT_NEQ_CLEANUP("getenv", psz_getvalue, NULL, clearenv());	
+	TC_ASSERT_NEQ_CLEANUP("getenv", psz_getvalue, NULL, clearenv());
 	TC_ASSERT_EQ_CLEANUP("getenv", strcmp(psz_getvalue, "D:"), 0, clearenv());
 
 	ret_chk = putenv(NULL);


### PR DESCRIPTION
For TizenRT coding rule, trailing blank should not allowed