### PR TITLE
examples/media: Fix recording stop issue

### DIFF
--- a/apps/examples/media_test/server/server_example_linux.c
+++ b/apps/examples/media_test/server/server_example_linux.c
@@ -114,6 +114,10 @@ void *recv_thread(void *arg)
 			SEND_STATE_LOCK();
 			g_sc.send_state = SEND_STATE_STOP;
 			close(g_sc.client_sock);
+			if (fp) {
+				fclose(fp);
+				fp = NULL;
+			}
 			g_sc.recv_thread_running = false;
 			g_sc.send_thread_running = false;
 			g_sc.client_sock = -1;

--- a/framework/src/media/media_recorder.c
+++ b/framework/src/media/media_recorder.c
@@ -30,7 +30,7 @@
 #define ST_PROTO_RECORD			0x04
 #define ST_PROTO_RECORD_DATA	0x05
 #define ST_PROTO_RECORD_PAUSE	0x02
-#define ST_PROTO_RECORD_STOP	0x03
+#define ST_PROTO_RECORD_STOP	0x01
 
 enum record_state_e {
 	RECORD_ERROR,


### PR DESCRIPTION
When stop recording, server program would be caught in a infinite loop.
Reason: Sent wrong instruction number.