### PR TITLE
fix deadlock for media_framework.

### DIFF
--- a/framework/src/media/media_player.c
+++ b/framework/src/media/media_player.c
@@ -150,9 +150,12 @@ play_result_t media_stop_play(void)
 	}
 
 	g_pc.state = PLAY_STOPPING;
-	pthread_join(g_pc.pth, NULL);
-	g_pc.pth = -1;
+	PLAY_UNLOCK();
 
+	pthread_join(g_pc.pth, NULL);
+	
+	PLAY_LOCK();
+	g_pc.pth = -1;
 	PLAY_UNLOCK();
 
 	return MEDIA_OK;
@@ -242,6 +245,7 @@ int read_data_pcm_write(char *buffer)
 		} else {
 			ret = read(g_pc.fd, buffer + readed, g_pc.buffer_size - readed);
 		}
+		printf("ret = %d\n", ret);
 		readed += ret;
 		if (ret == 0) {
 			break;

--- a/framework/src/media/media_recorder.c
+++ b/framework/src/media/media_recorder.c
@@ -193,8 +193,9 @@ record_result_t media_stop_record(void)
 	}
 
 	g_rc.state = RECORD_STOPPING;
-	pthread_join(g_rc.pth, NULL);
 	RECORD_UNLOCK();
+
+	pthread_join(g_rc.pth, NULL);	
 
 	return RECORD_OK;
 }


### PR DESCRIPTION
a problem by unlocking the lock after pthread_join,
and I fixed that part.

Signed-off-by: jaesick.shin <jaesick.shin@samsung.com>