### PR TITLE
testcase/le_tc/network : add ITC for network

### DIFF
--- a/apps/examples/testcase/le_tc/network/Kconfig
+++ b/apps/examples/testcase/le_tc/network/Kconfig
@@ -42,6 +42,11 @@ config TC_NET_ALL
 	select ITC_NET_DUP
 	select ITC_NET_FCNTL
 	select ITC_NET_LISTEN
+	select ITC_NET_SETSOCKOPT
+	select ITC_NET_SEND
+	select ITC_NET_INET
+	select ITC_NET_NETDB
+	select ITC_NET_CONNECT
 
 config TC_NET_SOCKET
 	bool "socket() api"
@@ -145,6 +150,26 @@ config ITC_NET_FCNTL
 
 config ITC_NET_LISTEN
 	bool "ITC listen() api"
+	default n
+
+config ITC_NET_SETSOCKOPT
+	bool "ITC setsockopt() api"
+	default n
+
+config ITC_NET_SEND
+	bool "ITC send() api"
+	default n
+
+config ITC_NET_INET
+	bool "ITC inet() api"
+	default n
+
+config ITC_NET_NETDB
+	bool "ITC netdb() api"
+	default n
+
+config ITC_NET_CONNECT
+	bool "ITC connect() api"
 	default n
 
 endif #EXAMPLES_TESTCASE_NETWORK

--- a/apps/examples/testcase/le_tc/network/Make.defs
+++ b/apps/examples/testcase/le_tc/network/Make.defs
@@ -134,6 +134,21 @@ endif
 ifeq ($(CONFIG_ITC_NET_LISTEN),y)
 CSRCS += itc_net_listen.c
 endif
+ifeq ($(CONFIG_ITC_NET_SETSOCKOPT),y)
+CSRCS +=itc_net_setsockopt.c
+endif
+ifeq ($(CONFIG_ITC_NET_SEND),y)
+CSRCS +=itc_net_send.c
+endif
+ifeq ($(CONFIG_ITC_NET_INET),y)
+CSRCS +=itc_net_inet.c
+endif
+ifeq ($(CONFIG_ITC_NET_NETDB),y)
+CSRCS +=itc_net_netdb.c
+endif
+ifeq ($(CONFIG_ITC_NET_CONNECT),y)
+CSRCS += itc_net_connect.c
+endif
 
 # Include network build support
 

--- a/apps/examples/testcase/le_tc/network/itc_net_connect.c
+++ b/apps/examples/testcase/le_tc/network/itc_net_connect.c
@@ -1,0 +1,337 @@
+/****************************************************************************
+ *
+ * Copyright 2017 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+/// @file itc_net_connect.c
+/// @brief ITC Scenario Test Case for connect() API
+
+#include <sys/socket.h>
+#include <string.h>
+#include <unistd.h>
+#include <pthread.h>
+#include <sys/types.h>
+#include "tc_internal.h"
+
+#define SERVER_MSG "Hello from server"
+#define CLIENT_MSG "Hello from client 0 "
+#define BUFF_LEN 64
+#define SERVER_WAIT_TIME 3
+#define CLIENT_WAIT_TIME 7
+
+static int g_port;
+/**
+* @fn               :server_connect
+* @description      :starts server
+* @return           :void
+*/
+static void *server_connect(void *ptr_num_clients)
+{
+	int server_socket;
+	int client_socket;
+	int valrecv = 0;
+	int valsend = 0;
+	int opt = 1;
+	int ret;
+	struct sockaddr_in address;
+	int addrlen = sizeof(address);
+	int num_clients = *((int *)ptr_num_clients);
+	char buffer[BUFF_LEN] = {0};
+	char *ptr_msg = SERVER_MSG;
+	int total_recv;
+	int total_send;
+	int *pret = malloc(sizeof(int));
+	int recv_len = 0;
+	int send_len = 0;
+	*pret = OK;
+
+	printf("Server thread started...\n");
+	server_socket = socket(AF_INET, SOCK_STREAM, 0);
+	if (server_socket < 0) {
+		*pret = ERROR;
+		pthread_exit(pret);
+	}
+	setsockopt(server_socket, SOL_SOCKET, SO_REUSEADDR | SO_REUSEPORT, &opt, sizeof(opt));
+	address.sin_family = AF_INET;
+	address.sin_addr.s_addr = INADDR_ANY;
+	address.sin_port = htons(g_port);
+	ret = bind(server_socket, (struct sockaddr *)&address, sizeof(address));
+	if (ret != OK) {
+		close(server_socket);
+		*pret = ERROR;
+		pthread_exit(pret);
+	}
+	ret = listen(server_socket, 5);
+	if (ret != OK) {
+		close(server_socket);
+		*pret = ERROR;
+		pthread_exit(pret);
+	}
+	while (num_clients-- > 0) {
+		client_socket = accept(server_socket, (struct sockaddr *)&address, (socklen_t*)&addrlen);
+		if (client_socket < 0) {
+			close(server_socket);
+			*pret = ERROR;
+			pthread_exit(pret);
+		}
+		total_recv = strlen(CLIENT_MSG);
+		memset(buffer, 0, BUFF_LEN);
+		while (total_recv) {
+			valrecv = recv(client_socket, buffer + recv_len, BUFF_LEN - recv_len, MSG_WAITALL);
+			printf("server recv: %s\n", buffer);
+			if (valrecv == -1) {
+				close(client_socket);
+				close(server_socket);
+				pthread_exit(pret);
+			}
+			total_recv -= valrecv;
+			if (total_recv < 0) {
+				close(client_socket);
+				close(server_socket);
+				*pret = ERROR;
+				pthread_exit(pret);
+			}
+			recv_len += valrecv;
+		}
+		strncpy(buffer + recv_len, ptr_msg, sizeof(SERVER_MSG));
+		total_send = strlen(buffer);
+		while (total_send) {
+			valsend = send(client_socket, buffer + send_len, strlen(buffer) - send_len, 0);
+			printf("server send: %s\n", buffer);
+			if (valsend == -1) {
+				close(client_socket);
+				close(server_socket);
+				*pret = ERROR;
+				pthread_exit(pret);
+			}
+			total_send -= valsend;
+			if (total_send < 0) {
+				close(client_socket);
+				close(server_socket);
+				*pret = ERROR;
+				pthread_exit(pret);
+			}
+			send_len += valsend;
+		}
+		sleep(SERVER_WAIT_TIME);
+		ret = close(client_socket);
+		if (ret != OK) {
+			close(server_socket);
+			*pret = ERROR;
+			pthread_exit(pret);
+		}
+		printf("Server thread : finished with client\n");
+	}
+	ret = close(server_socket);
+	if (ret != OK) {
+		*pret = ERROR;
+		pthread_exit(pret);
+	}
+	printf("Server completed\n");
+	pthread_exit(pret);
+}
+
+/**
+* @fn               :client_connect
+* @description      :starts client
+* @return           :void
+*/
+static void *client_connect(void *ptr_id)
+{
+	int *id;
+	id = (int *)ptr_id;
+	int sock = 0;
+	int ret;
+	int valrecv = 0;
+	int valsend = 0;
+	struct sockaddr_in serv_addr;
+	char client_msg[BUFF_LEN];
+	char buffer[BUFF_LEN] = {0};
+	int total_recv;
+	int total_send;
+	int *pret = malloc(sizeof(int));
+	int recv_len = 0;
+	int send_len = 0;
+	*pret = OK;
+	printf("Client thread started...\n");
+	sock = socket(AF_INET, SOCK_STREAM, 0);
+	if (sock < 0) {
+		pthread_exit(pret);
+	}
+	memset(&serv_addr, '0', sizeof(serv_addr));
+	serv_addr.sin_family = AF_INET;
+	serv_addr.sin_addr.s_addr = inet_addr("127.0.0.1");
+	serv_addr.sin_port = htons(g_port);
+	ret = connect(sock, (struct sockaddr *)&serv_addr, sizeof(serv_addr));
+	if (ret != OK) {
+		close(sock);
+		pthread_exit(ret);
+	}
+	strncpy(client_msg, CLIENT_MSG, sizeof(CLIENT_MSG));
+	client_msg[strlen(client_msg) - 2] = '0' + (*id);
+	total_send = strlen(client_msg);
+	while (total_send) {
+		valsend = send(sock, client_msg + send_len, strlen(client_msg) - send_len, 0);
+		printf("client send: %s\n", client_msg);
+		if (valsend == -1) {
+			close(sock);
+			pthread_exit(pret);
+		}
+		total_send -= valsend;
+		if (total_send < 0) {
+			close(sock);
+			*pret = ERROR;
+			pthread_exit(pret);
+		}
+		send_len += valsend;
+	}
+	total_recv = strlen(client_msg) + strlen(SERVER_MSG);
+	memset(buffer, 0, BUFF_LEN);
+	while (total_recv) {
+		valrecv = recv(sock, buffer + recv_len, BUFF_LEN - recv_len, MSG_WAITALL);
+		printf("client recv: %s\n", buffer);
+		if (valrecv <= 0) {
+			close(sock);
+			*pret = ERROR;
+			pthread_exit(pret);
+		}
+		total_recv -= valrecv;
+		if (total_recv < 0) {
+			close(sock);
+			*pret = ERROR;
+			pthread_exit(pret);
+		}
+		recv_len += valrecv;
+	}
+	if (strncmp(buffer, client_msg, strlen(client_msg)) != 0) {
+		close(sock);
+		*pret = ERROR;
+		pthread_exit(pret);
+	}
+	if (strncmp(buffer + strlen(client_msg), SERVER_MSG, strlen(SERVER_MSG)) != 0) {
+		close(sock);
+		*pret = ERROR;
+		pthread_exit(pret);
+	}
+	sleep(CLIENT_WAIT_TIME);
+	ret = close(sock);
+	if (ret != OK) {
+		*pret = ERROR;
+		pthread_exit(pret);
+	}
+	printf("Client completed\n");
+	pthread_exit(pret);
+}
+
+/**
+* @testcase         :itc_net_connect_p
+* @brief            :connects the socket referred to by the file descriptor
+* @scenario         :start server and client thread, connect client to server
+* @apicovered       :connect()
+* @precondition     :none
+* @postcondition    :none
+*/
+static void itc_net_connect_p(void)
+{
+	pthread_t server_thread;
+	pthread_t client_thread;
+	int num_clients = 1;
+	int id = 1;
+	int ret;
+	int *ptr = &num_clients;
+	int *ptr_id = &id;
+	int *pret = OK;
+	g_port = 8880;
+
+	pthread_create(&server_thread, NULL, server_connect, ptr);
+	sleep(SERVER_WAIT_TIME);
+	pthread_create(&client_thread, NULL, client_connect, ptr_id);
+
+	sleep(CLIENT_WAIT_TIME);
+
+	ret = pthread_join(server_thread, (void *)&pret);
+	TC_ASSERT_EQ_CLEANUP("pthread_join", ret, OK, free(pret); pthread_join(client_thread, NULL));
+	TC_ASSERT_EQ_CLEANUP("pthread_join", *pret, OK, free(pret); pthread_join(client_thread, NULL));
+	ret = pthread_join(client_thread, (void *)&pret);
+	TC_ASSERT_EQ_CLEANUP("pthread_join", ret, OK, free(pret));
+	TC_ASSERT_EQ_CLEANUP("pthread_join", *pret, OK, free(pret));
+
+	free(pret);
+	TC_SUCCESS_RESULT();
+}
+
+/**
+* @testcase         :itc_net_connect_p_multiple_clients
+* @brief            :connects the socket referred to by the file descriptor
+* @scenario         :start server and 3 client thread, connect client thread to server one by one
+* @apicovered       :connect()
+* @precondition     :none
+* @postcondition    :none
+*/
+static void itc_net_connect_p_multiple_clients(void)
+{
+	pthread_t server_thread;
+	pthread_t client1_thread;
+	pthread_t client2_thread;
+	pthread_t client3_thread;
+	int num_clients = 3;
+	int id1 = 1;
+	int id2 = 2;
+	int id3 = 3;
+	int ret;
+	int *ptr_num_clients = &num_clients;
+	int *ptr_id1 = &id1;
+	int *ptr_id2 = &id2;
+	int *ptr_id3 = &id3;
+	int *pret = OK;
+
+	g_port = 8890;
+
+	pthread_create(&server_thread, NULL, server_connect, ptr_num_clients);
+	sleep(SERVER_WAIT_TIME);
+	pthread_create(&client1_thread, NULL, client_connect, ptr_id1);
+	sleep(SERVER_WAIT_TIME);
+	pthread_create(&client2_thread, NULL, client_connect, ptr_id2);
+	sleep(SERVER_WAIT_TIME);
+	pthread_create(&client3_thread, NULL, client_connect, ptr_id3);
+
+	sleep(CLIENT_WAIT_TIME);
+
+	ret = pthread_join(server_thread, (void *)&pret);
+	TC_ASSERT_EQ_CLEANUP("pthread_join", ret, OK, free(pret); pthread_join(client3_thread, NULL); pthread_join(client2_thread, NULL); pthread_join(client1_thread, NULL));
+	TC_ASSERT_EQ_CLEANUP("pthread_join", *pret, OK, free(pret); pthread_join(client3_thread, NULL); pthread_join(client2_thread, NULL); pthread_join(client1_thread, NULL));
+	ret = pthread_join(client3_thread, (void *)&pret);
+	TC_ASSERT_EQ_CLEANUP("pthread_join", ret, OK, free(pret); pthread_join(client2_thread, NULL); pthread_join(client1_thread, NULL));
+	TC_ASSERT_EQ_CLEANUP("pthread_join", *pret, OK, free(pret); pthread_join(client2_thread, NULL); pthread_join(client1_thread, NULL));
+
+	ret = pthread_join(client2_thread, (void *)&pret);
+	TC_ASSERT_EQ_CLEANUP("pthread_join", ret, OK, free(pret); pthread_join(client1_thread, NULL));
+	TC_ASSERT_EQ_CLEANUP("pthread_join", *pret, OK, free(pret); pthread_join(client1_thread, NULL));
+
+	ret = pthread_join(client1_thread, NULL);
+	TC_ASSERT_EQ_CLEANUP("pthread_join", ret, OK, free(pret));
+
+	free(pret);
+	TC_SUCCESS_RESULT();
+}
+
+int itc_net_connect_main(void)
+{
+	itc_net_connect_p();
+	itc_net_connect_p_multiple_clients();
+
+	return 0;
+}

--- a/apps/examples/testcase/le_tc/network/itc_net_inet.c
+++ b/apps/examples/testcase/le_tc/network/itc_net_inet.c
@@ -1,0 +1,237 @@
+/****************************************************************************
+*
+* Copyright 2017 Samsung Electronics All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+* either express or implied. See the License for the specific
+* language governing permissions and limitations under the License.
+*
+****************************************************************************/
+
+/// @file itc_net_inet.c
+/// @brief ITC Test Case Example for inet() API
+
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <tinyara/config.h>
+#include "tc_internal.h"
+
+/**
+* @testcase          :itc_net_inet_addr_n
+* @brief             :function converts the Internet host address cp from IPv4
+*                     numbers-and-dots notation into binary data in network byte order.
+* @scenario          :passing invalid address
+* @apicovered        :inet_addr()
+* @precondition      :None
+* @postcondition     :None
+*/
+static void itc_net_inet_addr_n(void)
+{
+	int ret;
+
+	ret = inet_addr("q");
+	TC_ASSERT_EQ("inet", ret, -1);
+	TC_SUCCESS_RESULT();
+}
+
+/**
+* @testcase          :itc_net_inet_aton_n
+* @brief             :converts the Internet host address cp from the IPv4
+*                     numbers-and-dots notation into binary form
+* @scenario          :Passing invalid args
+* @apicovered        :inet_aton()
+* @precondition      :None
+* @postcondition     :None
+*/
+static void itc_net_inet_aton_n(void)
+{
+	unsigned long ret;
+
+	ret = inet_aton(NULL, NULL);
+
+	TC_ASSERT_EQ("inet", ret, 0);
+	TC_SUCCESS_RESULT();
+}
+
+/**
+* @testcase          :itc_net_inet_ntop_p
+* @brief             :function  converts  the network address structure src 
+*                     in the af address family into a character string*
+* @scenario          :passing hex value in inet_ntop
+* @apicovered        :inet_ntop()
+* @precondition      :None
+* @postcondition     :None
+*/
+static void itc_net_inet_ntop_p(void)
+{
+	struct in_addr in_addr;
+	char dst[INET_ADDRSTRLEN];
+	const char *ret;
+
+	in_addr.s_addr = 0x17071994;
+
+#ifdef CONFIG_NET_IPv4
+	ret = inet_ntop(AF_INET, &in_addr, dst, INET_ADDRSTRLEN);
+	TC_ASSERT_NEQ("inet_ntop", ret, NULL);
+#endif
+
+#ifdef CONFIG_NET_IPv6
+	ret = inet_ntop(AF_INET6, &in_addr, dst, INET_ADDRSTRLEN);
+	TC_ASSERT_NEQ("inet_ntop", ret, NULL);
+#endif
+
+	TC_SUCCESS_RESULT();
+}
+
+/**
+* @testcase          :itc_net_inet_ntop_n
+* @brief             :function  converts  the network address structure src 
+*                     in the af address family into a character string*
+* @scenario          :passing invalid args to inet_ntop
+* @apicovered        :inet_ntop()
+* @precondition      :None
+* @postcondition     :None
+*/
+static void itc_net_inet_ntop_n(void)
+{
+	struct in_addr in_addr;
+	char dst[INET_ADDRSTRLEN];
+	const char *ret;
+
+	in_addr.s_addr = 0x17071994;
+
+#ifdef CONFIG_NET_IPv4
+	ret = inet_ntop(AF_INET, &in_addr, dst, 7);
+	TC_ASSERT_EQ("inet_ntop", ret, NULL);
+#endif
+#ifdef CONFIG_NET_IPv6
+	ret = inet_ntop(AF_INET6, &in_addr, dst, 7);
+	TC_ASSERT_EQ("inet_ntop", ret, NULL);
+#endif
+	ret = inet_ntop(33, &in_addr, dst, INET_ADDRSTRLEN);
+	TC_ASSERT_EQ("inet_ntop", ret, NULL);
+
+	TC_SUCCESS_RESULT();
+}
+
+/**
+* @testcase         :itc_net_inet_pton_p
+* @brief            :function converts the character string src into a 
+*                    network address structure in the af address family
+* @scenario         :passing IPv4 addr in dot format and IPv6 in colon format
+* @apicovered       :inet_pton()
+* @precondition     :None
+* @postcondition    :None
+*/
+static void itc_net_inet_pton_p(void)
+{
+	struct sockaddr_in addr_inet;
+	int ret;
+
+#ifdef CONFIG_NET_IPv4
+	ret = inet_pton(AF_INET, "107.108.218.83", &(addr_inet.sin_addr));
+	TC_ASSERT_EQ("inet_pton", ret, 1);
+#endif
+#ifdef CONFIG_NET_IPv6
+	ret = inet_pton(AF_INET6, "0:0:0:0:0:0:0:1", &(addr_inet.sin_addr));
+	TC_ASSERT_EQ("inet_pton", ret, 1);
+#endif
+	TC_SUCCESS_RESULT();
+}
+
+/**
+* @testcase         :itc_net_inet_pton_n
+* @brief            :function converts the character string src into a 
+*                    network address structure in the af address family
+* @scenario         :passing invalid args to inet_pton
+* @apicovered       :inet_pton()
+* @precondition     :None
+* @postcondition    :None
+*/
+static void itc_net_inet_pton_n(void)
+{
+	struct sockaddr_in addr_inet;
+	int ret;
+
+#ifdef CONFIG_NET_IPv4
+	ret = inet_pton(AF_INET, "30051995", &(addr_inet.sin_addr));
+	TC_ASSERT_EQ("inet_pton", ret, 0);
+#endif
+#ifdef CONFIG_NET_IPv6
+	ret = inet_pton(AF_INET6, "0:0:0:0:0:0:0:1", &(addr_inet.sin_addr));
+	TC_ASSERT_EQ("inet_pton", ret, 1);
+#endif
+	ret = inet_pton(33, "107.108.218.83", &(addr_inet.sin_addr));
+	TC_ASSERT_EQ("inet_pton", ret, -1);
+
+	TC_SUCCESS_RESULT();
+}
+
+/**
+* @testcase         :itc_net_ntohl_p
+* @brief            :function converts the unsigned integer
+*                    netlong from network byte order to host byte order
+* @scenario         :passing uint32_t hostlong and comparing value
+* @apicovered       :ntohl()
+* @precondition     :None
+* @postcondition    :None
+*/
+static void itc_net_ntohl_p(void)
+{
+	uint32_t var = 0xa000000;
+	uint32_t ret;
+	uint32_t ref;
+
+	ret = ntohl(var);
+	ref = 10;
+
+	TC_ASSERT_EQ("inet", ret, ref);
+	TC_SUCCESS_RESULT();
+}
+
+/**
+* @testcase         :itc_net_ntohs_P
+* @brief            :function converts the unsigned short integer
+*                    hostshort from host byte order to network byte order. 
+* @scenario         :passin guint16_t hostshort and reconvering to uint16_t netshort
+*                    comparing their values
+* @apicovered       :ntohs()
+* @precondition     :None
+* @postcondition    :None
+*/
+static void itc_net_ntohs_p(void)
+{
+	uint16_t var = 20;
+	uint16_t ret;
+
+	ret = ntohs(htons(var));
+	TC_ASSERT_EQ("inet", ret, var);
+	TC_SUCCESS_RESULT();
+}
+
+/****************************************************************************
+* Name: inet()
+****************************************************************************/
+
+int itc_net_inet_main(void)
+{
+	itc_net_inet_addr_n();
+	itc_net_inet_aton_n();
+	itc_net_inet_ntop_p();
+	itc_net_inet_ntop_n();
+	itc_net_inet_pton_p();
+	itc_net_inet_pton_n();
+	itc_net_ntohl_p();
+	itc_net_ntohs_p();
+
+	return 0;
+}

--- a/apps/examples/testcase/le_tc/network/itc_net_netdb.c
+++ b/apps/examples/testcase/le_tc/network/itc_net_netdb.c
@@ -1,0 +1,70 @@
+/****************************************************************************
+
+*
+* Copyright 2017 Samsung Electronics All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+* either express or implied. See the License for the specific
+* language governing permissions and limitations under the License.
+*
+****************************************************************************/
+
+/// @file itc_net_netdb.c
+/// @brief ITC Test Case Example for getaddrinfo() API
+
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <tinyara/config.h>
+#ifdef CONFIG_LIBC_NETDB
+#include <netdb.h>
+#endif
+
+#include "tc_internal.h"
+
+#ifdef CONFIG_LIBC_NETDB
+
+/**
+* @testcase          :itc_net_netdb_getaddrinfo_n
+* @brief             :getaddrinfo() returns one or more addrinfo structures
+* @scenario          :passing invalid node and service
+* @apicovered        :getaddrinfo()
+* @precondition      :None
+* @postcondition     :None
+*/
+static void itc_net_netdb_getaddrinfo_n(void)
+{
+
+	struct addrinfo hints;
+	struct addrinfo *res;
+	int ret;
+
+	memset(&hints, 0, sizeof hints);
+	hints.ai_family = AF_INET;
+	hints.ai_socktype = SOCK_DGRAM;
+
+	ret = getaddrinfo(NULL, NULL, &hints, &res);
+	TC_ASSERT_NEQ("getaddrinfo", ret, 0);
+	TC_SUCCESS_RESULT();
+}
+
+#endif
+
+/****************************************************************************
+* Name: getaddrinfo()
+****************************************************************************/
+
+int itc_net_netdb_main(void)
+{
+#ifdef CONFIG_LIBC_NETDB
+	itc_net_netdb_getaddrinfo_n();
+#endif
+	return 0;
+}

--- a/apps/examples/testcase/le_tc/network/itc_net_send.c
+++ b/apps/examples/testcase/le_tc/network/itc_net_send.c
@@ -1,0 +1,186 @@
+/****************************************************************************
+*
+* Copyright 2017 Samsung Electronics All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+* either express or implied. See the License for the specific
+* language governing permissions and limitations under the License.
+*
+****************************************************************************/
+
+// @file itc_net_send.c
+// @brief ITC Test Case Example for send() API
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <pthread.h>
+
+#include "tc_internal.h"
+
+#define PORTNUM 1110
+
+static pthread_mutex_t g_lock = PTHREAD_MUTEX_INITIALIZER;
+static pthread_cond_t g_cond;
+
+/**
+* @testcase            :itc_net_send_n_fd
+* @brief               :used to transmit a message to another socket
+* @scenario            :sending invalid file descriptor
+* @apicovered          :send()
+* @precondition        :None
+* @postcondition       :None
+*/
+static void itc_net_send_n_fd(void)
+{
+	char *msg = "Hello World !\n";
+	int ret = send(-1, msg, strlen(msg), 0);
+
+	TC_ASSERT_EQ("send", ret, -1);
+	TC_SUCCESS_RESULT();
+}
+
+/**
+* @testcase            :itc_net_send_n_msg
+* @brief               :used to transmit a message to another socket
+* @scenario            :sending NULL msg
+* @apicovered          :send()
+* @precondition        :None
+* @postcondition       :None
+*/
+static void itc_net_send_n_msg(int client_socket)
+{
+	char *msg = NULL;
+	int ret = send(client_socket, msg, strlen(msg), 0);
+
+	TC_ASSERT_EQ("send", ret, -1);
+	TC_SUCCESS_RESULT();
+}
+
+/**
+* @fn                   :server
+* @brief                :For client server scenario creating thread function
+* @scenario             :None
+* API's covered         :socket,bind,listen,close
+* Preconditions         :None
+* Postconditions        :None
+*/
+static void *server(void *args)
+{
+	struct sockaddr_in sa, client;
+	int ret;
+	int client_socket;
+	int addr_len = sizeof(client);
+	int server_socket = socket(PF_INET, SOCK_STREAM, IPPROTO_TCP);
+	if (server_socket == -1) {
+		printf("[%s]Failed to create socket\n", __func__);
+		return NULL;
+	}
+
+	memset(&sa, 0, sizeof(sa));
+
+	sa.sin_family = PF_INET;
+	sa.sin_port = htons(PORTNUM);
+	sa.sin_addr.s_addr = inet_addr("127.0.0.1");
+
+	ret = bind(server_socket, (struct sockaddr *)&sa, sizeof(sa));
+	if (ret == -1) {
+		printf("[%s]Failed to bind socket\n", __func__);
+		goto end;
+	}
+
+	ret = listen(server_socket, 2);
+	if (ret == -1) {
+		printf("[%s]Failed to listen socket\n", __func__);
+		goto end;
+	}
+
+	pthread_mutex_lock(&g_lock);
+	pthread_cond_signal(&g_cond);
+	pthread_mutex_unlock(&g_lock);
+
+	client_socket = accept(server_socket, (struct sockaddr *)&client, (socklen_t *)&addr_len);
+	if (client_socket < 0) {
+		goto end;
+	}
+
+	itc_net_send_n_fd();
+	itc_net_send_n_msg(client_socket);
+
+	ret = close(client_socket);
+	if (ret == -1) {
+		printf("[%s]Failed to close socket\n", __func__);
+	}
+
+end:
+	ret = close(server_socket);
+	if (ret == -1) {
+		printf("[%s]Failed to close socket\n", __func__);
+	}
+	return 0;
+}
+
+/**
+* @fn                   :client
+* @brief                :For client server scenario creating thread function
+* @scenario             :None
+* API's covered         :socket,connect,recv,close
+* Preconditions         :None
+* Postconditions        :None
+*/
+static void *client(void *args)
+{
+	int client_socket;
+	int ret;
+	struct sockaddr_in dest;
+
+	client_socket = socket(PF_INET, SOCK_STREAM, IPPROTO_TCP);
+	if (client_socket == -1) {
+		printf("[%s]Failed to create socket\n", __func__);
+		return 0;
+	}
+
+	memset(&dest, 0, sizeof(dest));
+	dest.sin_family = PF_INET;
+	dest.sin_addr.s_addr = inet_addr("127.0.0.1");
+	dest.sin_port = htons(PORTNUM);
+
+	ret = connect(client_socket, (struct sockaddr *)&dest, sizeof(struct sockaddr));
+	if (ret == -1) {
+		printf("[%s]Failed to connect socket\n", __func__);
+		goto end;
+	}
+	pthread_cond_wait(&g_cond, &g_lock);
+
+end:
+	ret = close(client_socket);
+	if (ret == -1) {
+		printf("[%s]Failed to close socket\n", __func__);
+	}
+	return 0;
+}
+
+/****************************************************************************
+* Name: send()
+****************************************************************************/
+int itc_net_send_main(void)
+{
+	pthread_cond_init(&g_cond, NULL);
+	pthread_t Server, Client;
+
+	pthread_create(&Server, NULL, server, NULL);
+	pthread_create(&Client, NULL, client, NULL);
+
+	pthread_join(Client, NULL);
+	pthread_join(Server, NULL);
+
+	pthread_cond_destroy(&g_cond);
+
+	return 0;
+}

--- a/apps/examples/testcase/le_tc/network/itc_net_setsockopt.c
+++ b/apps/examples/testcase/le_tc/network/itc_net_setsockopt.c
@@ -1,0 +1,237 @@
+/****************************************************************************
+*
+* Copyright 2017 Samsung Electronics All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+* either express or implied. See the License for the specific
+* language governing permissions and limitations under the License.
+*
+****************************************************************************/
+
+/// @file itc_net_setsockopt.c
+/// @brief ITC Test Case Example for setsockopt() API
+
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <time.h>
+#include "tc_internal.h"
+
+/**
+* @fn                   :itc_net_setsockopt_n_invalid_opt_name
+* @brief                :setsockopt accept opt name
+* @Scenario             :sending invalid opt name
+* @API's covered        :setsockopt()
+* Preconditions         :socket file descriptor
+* Postconditions        :None
+*/
+static void itc_net_setsockopt_n_invalid_opt_name(int s)
+{
+	int ret = -1;
+	int optname = 16; //invalid opt name
+	void *optval = NULL;
+	socklen_t optlen = 0;
+
+	ret = setsockopt(s, SOL_SOCKET, optname, optval, optlen);
+	TC_ASSERT_EQ("setsockopt", ret, -1);
+	TC_SUCCESS_RESULT();
+}
+
+/**
+* @fn                   :itc_net_setsockopt_p_rcvbuf
+* @brief                :setsockopt setting flag SO_RCVBUF
+* @Scenario             :setsockopt setting flag SO_RCVBUF
+* @API's covered        :setsockopt()
+* Preconditions         :socket file descriptor
+* Postconditions        :None
+*/
+static void itc_net_setsockopt_p_rcvbuf(int s)
+{
+	int ret = -1;
+	int size = 1000;
+
+	ret = setsockopt(s, SOL_SOCKET, SO_RCVBUF, &size, size);
+	TC_ASSERT_EQ("setsockopt", ret, 0);
+	TC_SUCCESS_RESULT();
+}
+
+/**
+* @testcase             :itc_net_setsockopt_p_reuseport
+* @brief                :setsockopt setting flag SO_REUSEPORT
+* @scenario             :setsockopt setting flag SO_REUSEPORT
+* @apicovered           :setsockopt()
+* @precondition         :socket file descriptor
+* @postcondition        :None
+*/
+static void itc_net_setsockopt_p_reuseport(int s)
+{
+	int ret = -1;
+	int option = 1;
+
+	ret = setsockopt(s, SOL_SOCKET, SO_REUSEPORT, (char *)&option, sizeof option);
+	TC_ASSERT_EQ("setsockopt", ret, 0);
+	TC_SUCCESS_RESULT();
+}
+
+/**
+* @testcase             :itc_net_setsockopt_p_reuseaddr
+* @brief                :setsockopt setting flag SO_REUSEADDR
+* @scenario             :setsockopt setting flag SO_REUSEADDR
+* @apicovered           :setsockopt()
+* @precondition         :socket file descriptor
+* @postcondition        :None
+*/
+static void itc_net_setsockopt_p_reuseaddr(int s)
+{
+	int ret = -1;
+	int option = 1;
+
+	ret = setsockopt(s, SOL_SOCKET, SO_REUSEADDR, (char *)&option, sizeof(option));
+	TC_ASSERT_EQ("setsockopt", ret, 0);
+	TC_SUCCESS_RESULT();
+}
+
+/**
+* @testcase             :itc_net_setsockopt_p_rcvtimo
+* @brief                :setsockopt setting flag SO_RCVTIMEO
+* @scenario             :setsockopt setting flag SO_RCVTIMEO
+* @apicovered           :setsockopt()
+* @precondition         :socket file descriptor
+* @postcondition        :None
+*/
+static void itc_net_setsockopt_p_rcvtimo(int s)
+{
+	int ret = -1;
+	struct timeval tv;
+	tv.tv_sec = 1;
+	tv.tv_usec = 0;
+
+	ret = setsockopt(s, SOL_SOCKET, SO_RCVTIMEO, (struct timeval *)&tv, sizeof(struct timeval));
+
+	TC_ASSERT_EQ("setsockopt", ret, 0);
+	TC_SUCCESS_RESULT();
+}
+
+/**
+* @fn                   :itc_net_setsockopt_p_sndtimo
+* @brief                :setsockopt setting flag SO_SNDTIMEO
+* @Scenario             :setsockopt setting flag SO_SNDTIMEO
+* @API's covered        :setsockopt()
+* Preconditions         :socket file descriptor
+* Postconditions        :None
+*/
+static void itc_net_setsockopt_p_sndtimo(int s)
+{
+	int ret = -1;
+	struct timeval timeout;
+	timeout.tv_sec = 10;
+	timeout.tv_usec = 0;
+
+	ret = setsockopt(s, SOL_SOCKET, SO_SNDTIMEO, (char *)&timeout, sizeof(timeout));
+	TC_ASSERT_EQ("setsockopt", ret, 0);
+	TC_SUCCESS_RESULT();
+}
+
+/**
+* @fn                   :itc_net_setsockopt_p_no_check
+* @brief                :setsockopt setting flag SO_NO_CHECK
+* @Scenario             :setsockopt setting flag SO_NO_CHECK
+* @API's covered        :setsockopt()
+* Preconditions         :socket file descriptor
+* Postconditions        :None
+*/
+static void itc_net_setsockopt_p_no_check(int s)
+{
+	int ret = -1;
+	int optval = 1;
+
+	ret = setsockopt(s, SOL_SOCKET, SO_NO_CHECK, &optval, sizeof(optval));
+	TC_ASSERT_EQ("setsockopt", ret, 0);
+	TC_SUCCESS_RESULT();
+}
+
+/**
+* @fn                   :itc_net_setsockopt_p_ip_ttl
+* @brief                :setsockopt setting flag IP_TTL
+* @Scenario             :setsockopt setting flag IP_TTL
+* @API's covered        :setsockopt()
+* Preconditions         :socket file descriptor
+* Postconditions        :None
+*/
+static void itc_net_setsockopt_p_ip_ttl(int s)
+{
+	int ret = -1;
+	int optval = 1;
+
+	ret = setsockopt(s, IPPROTO_IP, IP_TTL, &optval, sizeof(optval));
+	TC_ASSERT_EQ("setsockopt", ret, 0);
+	TC_SUCCESS_RESULT();
+}
+
+/**
+* @fn                   :itc_net_setsockopt_p_multicast_ttl_loop
+* @brief                :setsockopt setting flag IP_MULTICAST_LOOP
+* @Scenario             :setsockopt setting flag IP_MULTICAST_LOOP
+* @API's covered        :setsockopt()
+* Preconditions         :socket file descriptor
+* Postconditions        :None
+*/
+
+static void itc_net_setsockopt_p_multicast_ttl_loop(int s)
+{
+	int ret = -1;
+	int loop = 250;
+	ret = setsockopt(s, IPPROTO_IP, IP_MULTICAST_LOOP, &loop, sizeof(loop));
+	TC_ASSERT_EQ("setsockopt", ret, 0);
+	TC_SUCCESS_RESULT();
+}
+
+/**
+* @fn                   :itc_net_setsockopt_p_multicast_ttl_loop_own
+* @brief                :setsockopt setting flag IP_MULTICAST_LOOP
+* @Scenario             :setsockopt setting flag IP_MULTICAST_LOOP
+* @API's covered        :setsockopt()
+* Preconditions         :socket file descriptor
+* Postconditions        :None
+*/
+
+static void itc_net_setsockopt_p_multicast_ttl_loop_own(int s)
+{
+	int ret = -1;
+	int loop = 1;
+	ret = setsockopt(s, IPPROTO_IP, IP_MULTICAST_LOOP, &loop, sizeof(loop));
+	TC_ASSERT_EQ("setsockopt", ret, 0);
+	TC_SUCCESS_RESULT();
+}
+
+/****************************************************************************
+* Name: setsockopt()
+****************************************************************************/
+
+int itc_net_setsockopt_main(void)
+{
+	int fd = -1;
+
+	fd = socket(AF_INET, SOCK_STREAM, 0);
+
+	itc_net_setsockopt_n_invalid_opt_name(fd);
+	itc_net_setsockopt_p_rcvbuf(fd);
+	itc_net_setsockopt_p_reuseport(fd);
+	itc_net_setsockopt_p_reuseaddr(fd);
+	itc_net_setsockopt_p_rcvtimo(fd);
+	itc_net_setsockopt_p_sndtimo(fd);
+	itc_net_setsockopt_p_no_check(fd);
+	itc_net_setsockopt_p_ip_ttl(fd);
+	itc_net_setsockopt_p_multicast_ttl_loop(fd);
+	itc_net_setsockopt_p_multicast_ttl_loop_own(fd);
+
+	close(fd);
+	return 0;
+}

--- a/apps/examples/testcase/le_tc/network/network_tc_main.c
+++ b/apps/examples/testcase/le_tc/network/network_tc_main.c
@@ -118,6 +118,21 @@ int tc_network_main(int argc, char *argv[])
 #ifdef CONFIG_ITC_NET_LISTEN
 	itc_net_listen_main();
 #endif
+#ifdef CONFIG_ITC_NET_SETSOCKOPT
+	itc_net_setsockopt_main();
+#endif
+#ifdef CONFIG_ITC_NET_SEND
+	itc_net_send_main();
+#endif
+#ifdef CONFIG_ITC_NET_INET
+	itc_net_inet_main();
+#endif
+#ifdef CONFIG_ITC_NET_NETDB
+	itc_net_netdb_main();
+#endif
+#ifdef CONFIG_ITC_NET_CONNECT
+	itc_net_connect_main();
+#endif
 
 	(void)tc_handler(TC_END, "Network TC");
 

--- a/apps/examples/testcase/le_tc/network/tc_internal.h
+++ b/apps/examples/testcase/le_tc/network/tc_internal.h
@@ -109,4 +109,20 @@ int itc_net_fcntl_main(void);
 #ifdef CONFIG_ITC_NET_LISTEN
 int itc_net_listen_main(void);
 #endif
+#ifdef CONFIG_ITC_NET_SETSOCKOPT
+int itc_net_setsockopt_main(void);
+#endif
+#ifdef CONFIG_ITC_NET_SEND
+int itc_net_send_main(void);
+#endif
+#ifdef CONFIG_ITC_NET_INET
+int itc_net_inet_main(void);
+#endif
+#ifdef CONFIG_ITC_NET_NETDB
+int itc_net_netdb_main(void);
+#endif
+#ifdef CONFIG_ITC_NET_CONNECT
+int itc_net_connect_main(void);
+#endif
+
 #endif /* __EXAMPLES_TESTCASE_NETWORK_TC_INTERNAL_H */


### PR DESCRIPTION
Scenarios ITCs perform below tests:
itc_net_inet_addr_n : passing invalid address
itc_net_inet_aton_n : passing invalid args
itc_net_inet_ntop_p : passing hex value in inet_ntop
itc_net_inet_ntop_n : passing invalid args to inet_ntop
itc_net_inet_pton_p : passing IPv4 addr in dot format and IPv6 in colon
format
itc_net_inet_pton_n : passing invalid args to inet_pton
itc_net_ntohl_p : passing uint32_t hostlong and comparing value
itc_net_ntohs_p : passing uint16_t hostshort and reconvering to uint16_t
netshort comparing their values
itc_net_netdb_getaddrinfo_n : passing invalid node and service
itc_net_send_n_fd : sending invalid file descriptor
itc_net_send_n_msg : sending NULL msg
itc_net_setsockopt_p_invalid_opt_name : sending invalid opt name
itc_net_setsockopt_p_rcvbuf : setsockopt setting flag SO_RCVBUF
itc_net_setsockopt_p_reuseport : setsockopt setting flag SO_REUSEPORT
itc_net_setsockopt_p_reuseaddr : setsockopt setting flag SO_REUSEADDR
itc_net_setsockopt_p_rcvtimo : setsockopt setting flag SO_RCVTIMEO
itc_net_setsockopt_p_sndtimo : setsockopt setting flag SO_SNDTIMEO
itc_net_setsockopt_p_no_check : setsockopt setting flag SO_NO_CHECK
itc_net_setsockopt_p_ip_ttl : setsockopt setting flag IP_TTL
itc_net_setsockopt_p_multicast_ttl_loop : setsockopt setting flag
IP_MULTICAST_LOOP
itc_net_setsockopt_p_multicast_ttl_loop_own : setsockopt setting flag
IP_MULTICAST_LOOP
itc_net_connect_p : start server and client thread, connect client to
server
itc_net_connect_p_multiple_clients : start server and 3 client thread,
connect client thread to server one by one