### PR TITLE
Register the basic TASH commands first

### DIFF
--- a/apps/shell/tash_command.c
+++ b/apps/shell/tash_command.c
@@ -281,8 +281,12 @@ int tash_execute_cmd(char **args, int argc)
 int tash_cmd_install(const char *str, TASH_CMD_CALLBACK cb, int thread_exec)
 {
 	int cmd_idx;
+	static int fail_cmd_count = 0;
 
 	if (TASH_MAX_COMMANDS == tash_cmds_info.count) {
+		printf("Allowed Max tash cmds: %d and Current tash cmd count: %d\n",
+				TASH_MAX_COMMANDS, tash_cmds_info.count + ++fail_cmd_count);
+		printf("Couldn't install cmd: (%s), Refer CONFIG_TASH_MAX_COMMANDS\n", str);
 		return -1;				/* MAX cmd count reached */
 	}
 

--- a/apps/system/init/init.c
+++ b/apps/system/init/init.c
@@ -130,13 +130,13 @@ int preapp_start(int argc, char *argv[])
 #endif
 
 #ifdef CONFIG_TASH
-	tash_register_cmds();
-
 	pid = tash_start();
 	if (pid <= 0) {
 		printf("TASH is failed to start, error code is %d\n", pid);
 		goto error_out;
 	}
+
+	tash_register_cmds();
 #endif
 
 #if defined(CONFIG_LIB_USRWORK) || defined(CONFIG_TASH)


### PR DESCRIPTION
Since basic TASH commands are registered at the end, there is a
chance that help command would not get install itself in some
corner cases and thus it causes inconvenience to see all
the registered commands

This patch fixes this issue by always registering basic commands first
and then prints the error message. This will help developer to increase
the CONFIG_TASH_MAX_COMMANDS value

For ex:
1. cd os/tools
2. ./configure.sh artik053/iotivity
3. cd ..
4. make menuconfig
5. go to Application Configuration --> TASH
6. It shows MAX commands allowed as 132
7. Disable the tash option and save the config and exit
8. again run "make menuconfig" and enable the tash
9. It updates the default registered commands as 32 only.
10. Save the config and exit
11. build and download the binary
12. help command is not registered.

Signed-off-by: pradeep.ns <pradeep.ns@samsung.com>