### PR TITLE
Make user choose dump callstack with symbol feature

### DIFF
--- a/os/Makefile.unix
+++ b/os/Makefile.unix
@@ -507,6 +507,11 @@ ifeq ($(CONFIG_UBOOT_UIMAGE),y)
 		cp -f uImage /tftpboot/uImage; \
 	fi
 endif
+ifeq ($(CONFIG_DEBUG_DISPLAY_SYMBOL),y)
+	cp ${BIN_DIR}/System.map ${TOOLSDIR}/fs/contents/System.map
+else
+	$(call DELFILE, ${TOOLSDIR}/fs/contents/System.map)
+endif
 
 # $(BIN)
 #

--- a/os/arch/Kconfig.chip
+++ b/os/arch/Kconfig.chip
@@ -443,6 +443,13 @@ config ARCH_STACKDUMP
 	---help---
 		Enable to do stack dumps after assertions
 
+config DEBUG_DISPLAY_SYMBOL
+	bool "Display symbols on call stack dump"
+	default n
+	depends on DEBUG_SYMBOLS && FRAME_POINTER && FS_ROMFS
+	---help---
+		Enable to show symbol on call stack dump
+
 config ARCH_USBDUMP
 	bool "Dump USB trace data"
 	default n

--- a/os/arch/arm/src/armv7-r/arm_assert.c
+++ b/os/arch/arm/src/armv7-r/arm_assert.c
@@ -92,7 +92,7 @@
 #endif
 #include <stdbool.h>
 
-#if defined(CONFIG_FS_ROMFS) && defined(CONFIG_FRAME_POINTER)
+#ifdef CONFIG_DEBUG_DISPLAY_SYMBOL
 #include <stdio.h>
 bool abort_mode = false;
 #endif
@@ -204,7 +204,7 @@ static int is_text_address(unsigned long programCounter)
  * Name: get_symbol
  * Below API works if there is existance of System.map file in rom fs
  ****************************************************************************/
-#ifdef CONFIG_FS_ROMFS
+#ifdef CONFIG_DEBUG_DISPLAY_SYMBOL
 int get_symbol(unsigned long search_addr, char *buffer, size_t buflen)
 {
 	FILE *pFile;
@@ -301,7 +301,7 @@ int get_symbol(unsigned long search_addr, char *buffer, size_t buflen)
 
 	return 0;
 }
-#endif						/* End of CONFIG_FS_ROMFS */
+#endif
 
 /****************************************************************************
  * Name: unwind_frame_with_fp
@@ -386,7 +386,7 @@ static void unwind_backtrace_with_fp(arm_regs_t *regs, struct tcb_s *task)
 		uint32_t current_addr = stack_frame.programCounter;
 		if (unwind_frame_with_fp(&stack_frame, ustacksize) >= 0) {
 			/* Print the call stack address */
-#ifdef CONFIG_FS_ROMFS
+#ifdef CONFIG_DEBUG_DISPLAY_SYMBOL
 			char buffer[128];
 			if (get_symbol(current_addr, buffer, sizeof(buffer)) == 0) {
 				lldbg("[<0x%p>] %s\n", (void *)current_addr, buffer);
@@ -915,7 +915,7 @@ static void _up_assert(int errorcode)
 void up_assert(const uint8_t *filename, int lineno)
 {
 	board_autoled_on(LED_ASSERTION);
-#if defined(CONFIG_FS_ROMFS) && defined(CONFIG_FRAME_POINTER)
+#ifdef CONFIG_DEBUG_DISPLAY_SYMBOL
 	abort_mode = true;
 #endif
 

--- a/os/kernel/semaphore/sem_wait.c
+++ b/os/kernel/semaphore/sem_wait.c
@@ -77,7 +77,7 @@
 /****************************************************************************
  * Global Variables
  ****************************************************************************/
-#if defined(CONFIG_FS_ROMFS) && defined(CONFIG_FRAME_POINTER)
+#ifdef CONFIG_DEBUG_DISPLAY_SYMBOL
 extern bool abort_mode;
 #endif
 
@@ -121,7 +121,7 @@ int sem_wait(FAR sem_t *sem)
 	irqstate_t saved_state;
 	int ret = ERROR;
 	/* This API should not be called from interrupt handlers */
-#if defined(CONFIG_FS_ROMFS) && defined(CONFIG_FRAME_POINTER)
+#ifdef CONFIG_DEBUG_DISPLAY_SYMBOL
 	DEBUGASSERT((sem != NULL && up_interrupt_context() == false) || abort_mode);
 
 	if (abort_mode && up_interrupt_context() == true) {

--- a/tools/fs/mkromfsimg.sh
+++ b/tools/fs/mkromfsimg.sh
@@ -70,10 +70,6 @@ buildpath=${topdir}/../build
 contentsdir=${topdir}/../tools/fs/contents
 romfsimg=${buildpath}/output/bin/romfs.img
 
-system_map_srcpath=${buildpath}/output/bin/System.map
-system_map_destpath=${contentsdir}/System.map
-cp $system_map_srcpath $system_map_destpath
-
 # Sanity checks
 
 if [ ! -d "${contentsdir}" ]; then


### PR DESCRIPTION
callstack dump with symbol feature stores symbol data in romfs.
user should be able to turn this feature on and off.