### PR TITLE
framework/st_things: Arrange unused or duplicated CFLAGS

### DIFF
--- a/framework/src/st_things/Make.defs
+++ b/framework/src/st_things/Make.defs
@@ -26,7 +26,6 @@ CSRCS += st_things.c st_things_util.c st_things_request_handler.c st_things_requ
 CFLAGS += -D__TIZENRT__
 CFLAGS += -D__TINYARA__
 CFLAGS += -D__ST_THINGS_RTOS__
-CFLAGS += -DUSE_LOG_NO_NEWLINE
 CFLAGS += -std=c99
 CFLAGS += -w
 
@@ -39,17 +38,13 @@ CFLAGS += -I$(THINGS_STACK_DIR)/src/common/easy-setup/inc
 CFLAGS += -I$(THINGS_STACK_DIR)/src/common/framework/inc
 CFLAGS += -I$(THINGS_STACK_DIR)/src/common/logging/inc
 CFLAGS += -I$(THINGS_STACK_DIR)/src/common/memory/inc
-CFLAGS += -I$(THINGS_STACK_DIR)/src/common/security/inc
 CFLAGS += -I$(THINGS_STACK_DIR)/src/common/utils/inc
-CFLAGS += -I$(THINGS_STACK_DIR)/src/common/stack
-CFLAGS += -I$(THINGS_STACK_DIR)/inc
 CFLAGS += -I$(THINGS_STACK_DIR)/src/common/security/ssCrypto/include
-CFLAGS += -I$(THINGS_STACK_DIR)/src/common/framework/inc
+CFLAGS += -I$(THINGS_STACK_DIR)/inc
 
-
-#
+####################################
 # THINGS STACK
-#
+####################################
 CFLAGS += -DWITH_POSIX -DIP_ADAPTER
 CFLAGS += -DWITH_BWT
 #CFLAGS += -D_EXCLUDE_TEST_KEY_
@@ -70,23 +65,16 @@ include $(THINGS_STACK_DIR)/src/common/memory/Make.defs
 CFLAGS += -I$(IOTIVITY_BASE_DIR)/resource/c_common
 CFLAGS += -I$(IOTIVITY_BASE_DIR)/resource/csdk/connectivity/api
 CFLAGS += -I$(IOTIVITY_BASE_DIR)/resource/csdk/connectivity/common/inc
-CFLAGS += -I$(IOTIVITY_BASE_DIR)/resource/csdk/logger/include
 CFLAGS += -I$(IOTIVITY_BASE_DIR)/resource/csdk/security/include
 CFLAGS += -I$(IOTIVITY_BASE_DIR)/resource/csdk/security/include/internal
 CFLAGS += -I$(IOTIVITY_BASE_DIR)/resource/csdk/stack/include
-CFLAGS += -I$(IOTIVITY_BASE_DIR)/extlibs/mbedtls/mbedtls/include
+CFLAGS += -I$(IOTIVITY_BASE_DIR)/resource/csdk/stack/include/internal
 CFLAGS += -I$(IOTIVITY_BASE_DIR)/resource/c_common/oic_malloc/include
 CFLAGS += -I$(IOTIVITY_BASE_DIR)/resource/c_common/oic_string/include
 CFLAGS += -I$(IOTIVITY_BASE_DIR)/resource/c_common/ocrandom/include
-CFLAGS += -I$(IOTIVITY_BASE_DIR)/resource/c_common/oic_time/include
-CFLAGS += -I$(IOTIVITY_BASE_DIR)/resource/csdk/connectivity/api
-CFLAGS += -I$(IOTIVITY_BASE_DIR)/service/notification/src/common/
-CFLAGS += -I$(IOTIVITY_BASE_DIR)/service/notification/include/
-CFLAGS += -I$(IOTIVITY_BASE_DIR)/service/notification/src/provider/
+CFLAGS += -I$(IOTIVITY_BASE_DIR)/service/notification/include
 CFLAGS += -I$(IOTIVITY_BASE_DIR)/resource/csdk/resource-directory/include/
 CFLAGS += -I$(IOTIVITY_BASE_DIR)/resource/csdk/connectivity/lib/libcoap-4.1.1/include/
-CFLAGS += -I$(IOTIVITY_BASE_DIR)/resource/csdk/stack/include/internal/
-
 
 ifeq ($(CONFIG_IOTIVITY_ROUTING),"EP")
 CFLAGS += -DROUTING_EP
@@ -96,7 +84,6 @@ endif
 
 ifeq ($(CONFIG_ENABLE_IOTIVITY_SECURED),y)
 CFLAGS += -D__WITH_DTLS__
-CFLAGS += -D__ST_THINGS_RTOS_LOCAL_SECURED__
 endif
 
 ifeq ($(CONFIG_ENABLE_IOTIVITY_CLOUD),y)
@@ -104,7 +91,6 @@ CFLAGS += -DWITH_CLOUD
 CFLAGS += -D__WITH_TLS__
 CFLAGS += -D__SECURED__
 CFLAGS += -DTCP_ADAPTER
-CFLAGS += -D__ST_THINGS_RTOS_CLOUD__
 endif
 
 DEPPATH += --dep-path src/st_things


### PR DESCRIPTION
To avoid errors that can occur while building, arranged CFLAGS.