### PR TITLE
Fix : tash_start() prints incorrect error code

### DIFF
--- a/apps/shell/tash_main.c
+++ b/apps/shell/tash_main.c
@@ -220,10 +220,13 @@ static int tash_main(int argc, char *argv[])
 int tash_start(void)
 {
 	int pid;
+	int errcode;
 
 	pid = task_create("tash", TASH_TASK_PRIORITY, TASH_TASK_STACKSIZE, tash_main, (FAR char *const *)NULL);
 	if (pid < 0) {
-		printf("TASH is not started, error code = %d\n", pid);
+		errcode = errno;
+		DEBUGASSERT(errcode > 0);
+		return -errcode;
 	}
 
 	return pid;


### PR DESCRIPTION
tash_start() api prints pid as error code, tash_start calls task_create()
to start tash, Incase of task_create fails to start a task, it sets the
error code in "errno" and returns either valid pid or ERROR(-1)

Also, there is is no need to print the error message inside tash_start as it
causes duplication inside preapp_start() api of apps/system/init/init.c

This commit does following things
1. Sets the valid error code inside tash_start
2. Removes duplicated printf message inside tash_start as it's already
printed in preapp_start()

Signed-off-by: pradeep.ns <pradeep.ns@samsung.com>