### PR TITLE
pthread, time: change sdbg to svdbg

### DIFF
--- a/lib/libc/pthread/pthread_attrdestroy.c
+++ b/lib/libc/pthread/pthread_attrdestroy.c
@@ -105,7 +105,7 @@ int pthread_attr_destroy(FAR pthread_attr_t *attr)
 {
 	int ret;
 
-	sdbg("attr=0x%p\n", attr);
+	svdbg("attr=0x%p\n", attr);
 
 	if (!attr) {
 		ret = EINVAL;
@@ -114,6 +114,6 @@ int pthread_attr_destroy(FAR pthread_attr_t *attr)
 		ret = OK;
 	}
 
-	sdbg("Returning %d\n", ret);
+	svdbg("Returning %d\n", ret);
 	return ret;
 }

--- a/lib/libc/pthread/pthread_attrgetinheritsched.c
+++ b/lib/libc/pthread/pthread_attrgetinheritsched.c
@@ -108,7 +108,7 @@ int pthread_attr_getinheritsched(FAR const pthread_attr_t *attr, FAR int *inheri
 {
 	int ret;
 
-	sdbg("attr=0x%p inheritsched=0x%p\n", attr, inheritsched);
+	svdbg("attr=0x%p inheritsched=0x%p\n", attr, inheritsched);
 
 	if (!attr || !inheritsched) {
 		ret = EINVAL;
@@ -117,6 +117,6 @@ int pthread_attr_getinheritsched(FAR const pthread_attr_t *attr, FAR int *inheri
 		ret = OK;
 	}
 
-	sdbg("Returning %d\n", ret);
+	svdbg("Returning %d\n", ret);
 	return ret;
 }

--- a/lib/libc/pthread/pthread_attrgetschedparam.c
+++ b/lib/libc/pthread/pthread_attrgetschedparam.c
@@ -106,7 +106,7 @@ int pthread_attr_getschedparam(FAR const pthread_attr_t *attr, FAR struct sched_
 {
 	int ret;
 
-	sdbg("attr=0x%p param=0x%p\n", attr, param);
+	svdbg("attr=0x%p param=0x%p\n", attr, param);
 
 	if (!attr || !param) {
 		ret = EINVAL;
@@ -115,6 +115,6 @@ int pthread_attr_getschedparam(FAR const pthread_attr_t *attr, FAR struct sched_
 		ret = OK;
 	}
 
-	sdbg("Returning %d\n", ret);
+	svdbg("Returning %d\n", ret);
 	return ret;
 }

--- a/lib/libc/pthread/pthread_attrgetschedpolicy.c
+++ b/lib/libc/pthread/pthread_attrgetschedpolicy.c
@@ -105,7 +105,7 @@ int pthread_attr_getschedpolicy(FAR const pthread_attr_t *attr, int *policy)
 {
 	int ret;
 
-	sdbg("attr=0x%p policy=0x%p\n", attr, policy);
+	svdbg("attr=0x%p policy=0x%p\n", attr, policy);
 
 	if (!attr || !policy) {
 		ret = EINVAL;
@@ -114,6 +114,6 @@ int pthread_attr_getschedpolicy(FAR const pthread_attr_t *attr, int *policy)
 		ret = OK;
 	}
 
-	sdbg("Returning %d\n", ret);
+	svdbg("Returning %d\n", ret);
 	return ret;
 }

--- a/lib/libc/pthread/pthread_attrgetstacksize.c
+++ b/lib/libc/pthread/pthread_attrgetstacksize.c
@@ -104,7 +104,7 @@ int pthread_attr_getstacksize(FAR const pthread_attr_t *attr, FAR long *stacksiz
 {
 	int ret;
 
-	sdbg("attr=0x%p stacksize=0x%p\n", attr, stacksize);
+	svdbg("attr=0x%p stacksize=0x%p\n", attr, stacksize);
 
 	if (!attr || !stacksize) {
 		ret = EINVAL;
@@ -113,6 +113,6 @@ int pthread_attr_getstacksize(FAR const pthread_attr_t *attr, FAR long *stacksiz
 		ret = OK;
 	}
 
-	sdbg("Returning %d\n", ret);
+	svdbg("Returning %d\n", ret);
 	return ret;
 }

--- a/lib/libc/pthread/pthread_attrinit.c
+++ b/lib/libc/pthread/pthread_attrinit.c
@@ -120,7 +120,7 @@ int pthread_attr_init(FAR pthread_attr_t *attr)
 {
 	int ret = OK;
 
-	sdbg("attr=0x%p\n", attr);
+	svdbg("attr=0x%p\n", attr);
 	if (!attr) {
 		ret = ENOMEM;
 	} else {
@@ -132,6 +132,6 @@ int pthread_attr_init(FAR pthread_attr_t *attr)
 		memcpy(attr, &g_default_pthread_attr, sizeof(pthread_attr_t));
 	}
 
-	sdbg("Returning %d\n", ret);
+	svdbg("Returning %d\n", ret);
 	return ret;
 }

--- a/lib/libc/pthread/pthread_attrsetinheritsched.c
+++ b/lib/libc/pthread/pthread_attrsetinheritsched.c
@@ -109,7 +109,7 @@ int pthread_attr_setinheritsched(FAR pthread_attr_t *attr, int inheritsched)
 {
 	int ret;
 
-	sdbg("inheritsched=%d\n", inheritsched);
+	svdbg("inheritsched=%d\n", inheritsched);
 
 	if (!attr || (inheritsched != PTHREAD_INHERIT_SCHED && inheritsched != PTHREAD_EXPLICIT_SCHED)) {
 		ret = EINVAL;
@@ -118,6 +118,6 @@ int pthread_attr_setinheritsched(FAR pthread_attr_t *attr, int inheritsched)
 		ret = OK;
 	}
 
-	sdbg("Returning %d\n", ret);
+	svdbg("Returning %d\n", ret);
 	return ret;
 }

--- a/lib/libc/pthread/pthread_attrsetschedparam.c
+++ b/lib/libc/pthread/pthread_attrsetschedparam.c
@@ -106,7 +106,7 @@ int pthread_attr_setschedparam(FAR pthread_attr_t *attr, FAR const struct sched_
 {
 	int ret;
 
-	sdbg("attr=0x%p param=0x%p\n", attr, param);
+	svdbg("attr=0x%p param=0x%p\n", attr, param);
 
 	if (!attr || !param) {
 		ret = EINVAL;
@@ -114,6 +114,6 @@ int pthread_attr_setschedparam(FAR pthread_attr_t *attr, FAR const struct sched_
 		attr->priority = (short)param->sched_priority;
 		ret = OK;
 	}
-	sdbg("Returning %d\n", ret);
+	svdbg("Returning %d\n", ret);
 	return ret;
 }

--- a/lib/libc/pthread/pthread_attrsetschedpolicy.c
+++ b/lib/libc/pthread/pthread_attrsetschedpolicy.c
@@ -107,7 +107,7 @@ int pthread_attr_setschedpolicy(FAR pthread_attr_t *attr, int policy)
 {
 	int ret;
 
-	sdbg("attr=0x%p policy=%d\n", attr, policy);
+	svdbg("attr=0x%p policy=%d\n", attr, policy);
 
 #if CONFIG_RR_INTERVAL > 0
 	if (!attr || (policy != SCHED_FIFO && policy != SCHED_RR))
@@ -121,6 +121,6 @@ int pthread_attr_setschedpolicy(FAR pthread_attr_t *attr, int policy)
 		ret = OK;
 	}
 
-	sdbg("Returning %d\n", ret);
+	svdbg("Returning %d\n", ret);
 	return ret;
 }

--- a/lib/libc/pthread/pthread_attrsetstacksize.c
+++ b/lib/libc/pthread/pthread_attrsetstacksize.c
@@ -105,7 +105,7 @@ int pthread_attr_setstacksize(FAR pthread_attr_t *attr, long stacksize)
 {
 	int ret;
 
-	sdbg("attr=0x%p stacksize=%ld\n", attr, stacksize);
+	svdbg("attr=0x%p stacksize=%ld\n", attr, stacksize);
 
 	if (!attr || stacksize < PTHREAD_STACK_MIN) {
 		ret = EINVAL;
@@ -114,6 +114,6 @@ int pthread_attr_setstacksize(FAR pthread_attr_t *attr, long stacksize)
 		ret = OK;
 	}
 
-	sdbg("Returning %d\n", ret);
+	svdbg("Returning %d\n", ret);
 	return ret;
 }

--- a/lib/libc/pthread/pthread_condattrdestroy.c
+++ b/lib/libc/pthread/pthread_condattrdestroy.c
@@ -84,12 +84,12 @@ int pthread_condattr_destroy(FAR pthread_condattr_t *attr)
 {
 	int ret = OK;
 
-	sdbg("attr=0x%p\n", attr);
+	svdbg("attr=0x%p\n", attr);
 
 	if (!attr) {
 		ret = EINVAL;
 	}
 
-	sdbg("Returning %d\n", ret);
+	svdbg("Returning %d\n", ret);
 	return ret;
 }

--- a/lib/libc/pthread/pthread_condattrinit.c
+++ b/lib/libc/pthread/pthread_condattrinit.c
@@ -84,7 +84,7 @@ int pthread_condattr_init(FAR pthread_condattr_t *attr)
 {
 	int ret = OK;
 
-	sdbg("attr=0x%p\n", attr);
+	svdbg("attr=0x%p\n", attr);
 
 	if (!attr) {
 		ret = EINVAL;
@@ -92,6 +92,6 @@ int pthread_condattr_init(FAR pthread_condattr_t *attr)
 		*attr = 0;
 	}
 
-	sdbg("Returning %d\n", ret);
+	svdbg("Returning %d\n", ret);
 	return ret;
 }

--- a/lib/libc/pthread/pthread_mutexattrdestroy.c
+++ b/lib/libc/pthread/pthread_mutexattrdestroy.c
@@ -104,7 +104,7 @@ int pthread_mutexattr_destroy(FAR pthread_mutexattr_t *attr)
 {
 	int ret = OK;
 
-	sdbg("attr=0x%p\n", attr);
+	svdbg("attr=0x%p\n", attr);
 
 	if (!attr) {
 		ret = EINVAL;
@@ -112,6 +112,6 @@ int pthread_mutexattr_destroy(FAR pthread_mutexattr_t *attr)
 		attr->pshared = 0;
 	}
 
-	sdbg("Returning %d\n", ret);
+	svdbg("Returning %d\n", ret);
 	return ret;
 }

--- a/lib/libc/pthread/pthread_mutexattrgetpshared.c
+++ b/lib/libc/pthread/pthread_mutexattrgetpshared.c
@@ -105,7 +105,7 @@ int pthread_mutexattr_getpshared(FAR const pthread_mutexattr_t *attr, FAR int *p
 {
 	int ret = OK;
 
-	sdbg("attr=0x%p pshared=0x%p\n", attr, pshared);
+	svdbg("attr=0x%p pshared=0x%p\n", attr, pshared);
 
 	if (!attr || !pshared) {
 		ret = EINVAL;
@@ -113,6 +113,6 @@ int pthread_mutexattr_getpshared(FAR const pthread_mutexattr_t *attr, FAR int *p
 		*pshared = attr->pshared;
 	}
 
-	sdbg("Returning %d\n", ret);
+	svdbg("Returning %d\n", ret);
 	return ret;
 }

--- a/lib/libc/pthread/pthread_mutexattrinit.c
+++ b/lib/libc/pthread/pthread_mutexattrinit.c
@@ -104,7 +104,7 @@ int pthread_mutexattr_init(FAR pthread_mutexattr_t *attr)
 {
 	int ret = OK;
 
-	sdbg("attr=0x%p\n", attr);
+	svdbg("attr=0x%p\n", attr);
 
 	if (!attr) {
 		ret = EINVAL;
@@ -128,6 +128,6 @@ int pthread_mutexattr_init(FAR pthread_mutexattr_t *attr)
 #endif
 	}
 
-	sdbg("Returning %d\n", ret);
+	svdbg("Returning %d\n", ret);
 	return ret;
 }

--- a/lib/libc/pthread/pthread_mutexattrsetpshared.c
+++ b/lib/libc/pthread/pthread_mutexattrsetpshared.c
@@ -105,7 +105,7 @@ int pthread_mutexattr_setpshared(FAR pthread_mutexattr_t *attr, int pshared)
 {
 	int ret = OK;
 
-	sdbg("attr=0x%p pshared=%d\n", attr, pshared);
+	svdbg("attr=0x%p pshared=%d\n", attr, pshared);
 
 	if (!attr || (pshared != 0 && pshared != 1)) {
 		ret = EINVAL;
@@ -113,6 +113,6 @@ int pthread_mutexattr_setpshared(FAR pthread_mutexattr_t *attr, int pshared)
 		attr->pshared = pshared;
 	}
 
-	sdbg("Returning %d\n", ret);
+	svdbg("Returning %d\n", ret);
 	return ret;
 }

--- a/lib/libc/time/lib_gmtimer.c
+++ b/lib/libc/time/lib_gmtimer.c
@@ -331,7 +331,7 @@ FAR struct tm *gmtime_r(FAR const time_t *timer, FAR struct tm *result)
 	/* Get the seconds since the EPOCH */
 
 	epoch = *timer;
-	sdbg("timer=%d\n", (int)epoch);
+	svdbg("timer=%d\n", (int)epoch);
 
 	/* Convert to days, hours, minutes, and seconds since the EPOCH */
 
@@ -346,13 +346,13 @@ FAR struct tm *gmtime_r(FAR const time_t *timer, FAR struct tm *result)
 
 	sec = epoch;
 
-	sdbg("hour=%d min=%d sec=%d\n", (int)hour, (int)min, (int)sec);
+	svdbg("hour=%d min=%d sec=%d\n", (int)hour, (int)min, (int)sec);
 
 	/* Convert the days since the EPOCH to calendar day */
 
 	clock_utc2calendar(jdn, &year, &month, &day);
 
-	sdbg("jdn=%d year=%d month=%d day=%d\n", (int)jdn, (int)year, (int)month, (int)day);
+	svdbg("jdn=%d year=%d month=%d day=%d\n", (int)jdn, (int)year, (int)month, (int)day);
 
 	/* Then return the struct tm contents */
 

--- a/lib/libc/time/lib_mktime.c
+++ b/lib/libc/time/lib_mktime.c
@@ -112,12 +112,12 @@ time_t mktime(FAR struct tm *tp)
 	 */
 
 	jdn = clock_calendar2utc(tp->tm_year + 1900, tp->tm_mon + 1, tp->tm_mday);
-	sdbg("jdn=%d tm_year=%d tm_mon=%d tm_mday=%d\n", (int)jdn, tp->tm_year, tp->tm_mon, tp->tm_mday);
+	svdbg("jdn=%d tm_year=%d tm_mon=%d tm_mday=%d\n", (int)jdn, tp->tm_year, tp->tm_mon, tp->tm_mday);
 
 	/* Return the seconds into the julian day. */
 
 	ret = ((jdn * 24 + tp->tm_hour) * 60 + tp->tm_min) * 60 + tp->tm_sec;
-	sdbg("ret=%d tm_hour=%d tm_min=%d tm_sec=%d\n", (int)ret, tp->tm_hour, tp->tm_min, tp->tm_sec);
+	svdbg("ret=%d tm_hour=%d tm_min=%d tm_sec=%d\n", (int)ret, tp->tm_hour, tp->tm_min, tp->tm_sec);
 
 	return ret;
 }

--- a/os/kernel/pthread/pthread_join.c
+++ b/os/kernel/pthread/pthread_join.c
@@ -204,7 +204,7 @@ int pthread_join(pthread_t thread, FAR pthread_addr_t *pexit_value)
 			/* Get the thread exit value from the terminated thread. */
 
 			if (pexit_value) {
-				sdbg("exit_value=0x%p\n", pjoin->exit_value);
+				svdbg("exit_value=0x%p\n", pjoin->exit_value);
 				*pexit_value = pjoin->exit_value;
 			}
 		} else {


### PR DESCRIPTION
Some sdbg has just information message, not error message so that
debug message level is changed to verbose instead of error.