### PR TITLE
Fix build error on sysdbg for qemu/tc_64k

### DIFF
--- a/apps/system/sysdbg/sysdbgapp_init.c
+++ b/apps/system/sysdbg/sysdbgapp_init.c
@@ -22,6 +22,8 @@
 
 #include <fcntl.h>
 #include <errno.h>
+#include <stdio.h>
+#include <string.h>
 #include <apps/system/sysdbgapp_init.h>
 #include <apps/shell/tash.h>
 

--- a/os/kernel/debug/sysdbg.c
+++ b/os/kernel/debug/sysdbg.c
@@ -21,6 +21,8 @@
  ****************************************************************************/
 
 #include <errno.h>
+#include <stdio.h>
+#include <string.h>
 #include <tinyara/config.h>
 #include <tinyara/arch.h>
 #include <tinyara/kmalloc.h>


### PR DESCRIPTION
Reference PR#1141

When CONFIG_DEBUG_SYSTEM & CONFIG_DEBUG_SYSTEM_APP is enabled,
in qemu/tc_64k or qemu/tc_1m configuration, build error occurs due to implicit
declaration of strlen, strncmp, sscanf and printf

This commit includes missing header files for below operations
Strlen => string.h (sysdbgapp_init.c)
printf => stdio.h  (sysdbgapp_init.c)

strncmp => string.h (sysdbg.c)
sscanf => stdio.h (sysdbg.c)

Signed-off-by: pradeep.ns <pradeep.ns@samsung.com>