### PR TITLE
Logging task scheduling info for armv7-m based board

### DIFF
--- a/os/arch/arm/src/armv7-m/up_blocktask.c
+++ b/os/arch/arm/src/armv7-m/up_blocktask.c
@@ -65,6 +65,10 @@
 #include "sched/sched.h"
 #include "up_internal.h"
 
+#ifdef CONFIG_TASK_SCHED_HISTORY
+#include <tinyara/debug/sysdbg.h>
+#endif
+
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
@@ -149,6 +153,11 @@ void up_block_task(struct tcb_s *tcb, tstate_t task_state)
 
 			rtcb = this_task();
 
+#ifdef CONFIG_TASK_SCHED_HISTORY
+			/* Save the task name which will be scheduled */
+			save_task_scheduling_status(rtcb);
+#endif
+
 			/* Then switch contexts */
 
 			up_restorestate(rtcb->xcp.regs);
@@ -162,6 +171,10 @@ void up_block_task(struct tcb_s *tcb, tstate_t task_state)
 			 */
 
 			struct tcb_s *nexttcb = this_task();
+#ifdef CONFIG_TASK_SCHED_HISTORY
+			/* Save the task name which will be scheduled */
+			save_task_scheduling_status(nexttcb);
+#endif
 			up_switchcontext(rtcb->xcp.regs, nexttcb->xcp.regs);
 
 			/* up_switchcontext forces a context switch to the task at the

--- a/os/arch/arm/src/armv7-m/up_releasepending.c
+++ b/os/arch/arm/src/armv7-m/up_releasepending.c
@@ -63,6 +63,10 @@
 #include "sched/sched.h"
 #include "up_internal.h"
 
+#ifdef CONFIG_TASK_SCHED_HISTORY
+#include <tinyara/debug/sysdbg.h>
+#endif
+
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
@@ -118,6 +122,10 @@ void up_release_pending(void)
 			rtcb = this_task();
 			sllvdbg("New Active Task TCB=%p\n", rtcb);
 
+#ifdef CONFIG_TASK_SCHED_HISTORY
+			/* Save the task name which will be scheduled */
+			save_task_scheduling_status(rtcb);
+#endif
 			/* Then switch contexts */
 
 			up_restorestate(rtcb->xcp.regs);
@@ -131,6 +139,10 @@ void up_release_pending(void)
 			 */
 
 			struct tcb_s *nexttcb = this_task();
+#ifdef CONFIG_TASK_SCHED_HISTORY
+			/* Save the task name which will be scheduled */
+			save_task_scheduling_status(nexttcb);
+#endif
 			up_switchcontext(rtcb->xcp.regs, nexttcb->xcp.regs);
 
 			/* up_switchcontext forces a context switch to the task at the

--- a/os/arch/arm/src/armv7-m/up_reprioritizertr.c
+++ b/os/arch/arm/src/armv7-m/up_reprioritizertr.c
@@ -65,6 +65,10 @@
 #include "sched/sched.h"
 #include "up_internal.h"
 
+#ifdef CONFIG_TASK_SCHED_HISTORY
+#include <tinyara/debug/sysdbg.h>
+#endif
+
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
@@ -170,6 +174,10 @@ void up_reprioritize_rtr(struct tcb_s *tcb, uint8_t priority)
 				rtcb = this_task();
 				sllvdbg("New Active Task TCB=%p\n", rtcb);
 
+#ifdef CONFIG_TASK_SCHED_HISTORY
+				/* Save the task name which will be scheduled */
+				save_task_scheduling_status(rtcb);
+#endif
 				/* Then switch contexts */
 
 				up_restorestate(rtcb->xcp.regs);
@@ -183,6 +191,10 @@ void up_reprioritize_rtr(struct tcb_s *tcb, uint8_t priority)
 				 */
 
 				struct tcb_s *nexttcb = this_task();
+#ifdef CONFIG_TASK_SCHED_HISTORY
+				/* Save the task name which will be scheduled */
+				save_task_scheduling_status(nexttcb);
+#endif
 				up_switchcontext(rtcb->xcp.regs, nexttcb->xcp.regs);
 
 				/* up_switchcontext forces a context switch to the task at the

--- a/os/arch/arm/src/armv7-m/up_sigdeliver.c
+++ b/os/arch/arm/src/armv7-m/up_sigdeliver.c
@@ -68,6 +68,10 @@
 #include "up_internal.h"
 #include "up_arch.h"
 
+#ifdef CONFIG_TASK_SCHED_HISTORY
+#include <tinyara/debug/sysdbg.h>
+#endif
+
 #ifndef CONFIG_DISABLE_SIGNALS
 
 /****************************************************************************
@@ -162,6 +166,11 @@ void up_sigdeliver(void)
 	 */
 
 	board_led_off(LED_SIGNAL);
+
+#ifdef CONFIG_TASK_SCHED_HISTORY
+	/* Save the task name which will be scheduled */
+	save_task_scheduling_status(rtcb);
+#endif
 	up_fullcontextrestore(regs);
 }
 

--- a/os/arch/arm/src/armv7-m/up_unblocktask.c
+++ b/os/arch/arm/src/armv7-m/up_unblocktask.c
@@ -64,6 +64,10 @@
 #include "clock/clock.h"
 #include "up_internal.h"
 
+#ifdef CONFIG_TASK_SCHED_HISTORY
+#include <tinyara/debug/sysdbg.h>
+#endif
+
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
@@ -140,6 +144,11 @@ void up_unblock_task(struct tcb_s *tcb)
 
 			rtcb = this_task();
 
+#ifdef CONFIG_TASK_SCHED_HISTORY
+			/* Save the task name which will be scheduled */
+			save_task_scheduling_status(rtcb);
+#endif
+
 			/* Then switch contexts */
 
 			up_restorestate(rtcb->xcp.regs);
@@ -153,6 +162,10 @@ void up_unblock_task(struct tcb_s *tcb)
 			 */
 
 			struct tcb_s *nexttcb = this_task();
+#ifdef CONFIG_TASK_SCHED_HISTORY
+			/* Save the task name which will be scheduled */
+			save_task_scheduling_status(nexttcb);
+#endif
 			up_switchcontext(rtcb->xcp.regs, nexttcb->xcp.regs);
 
 			/* up_switchcontext forces a context switch to the task at the


### PR DESCRIPTION
Further enhancement of Reference PR#1141

This commits adds support for logging the task scheduling information
for armv7-m architecture and it's verified using qemu as it uses armv7-m

Signed-off-by: pradeep.ns <pradeep.ns@samsung.com>