### PR TITLE
Fix miswritten address of author in pcm_decode.c

### DIFF
--- a/os/audio/pcm_decode.c
+++ b/os/audio/pcm_decode.c
@@ -19,7 +19,7 @@
  * audio/pcm_decode.c
  *
  *   Copyright (C) 2014 Gregory Nutt. All rights reserved.
- *   Author:  Gregory Nutt <gnutt@tinyara.org>
+ *   Author:  Gregory Nutt <gnutt@nuttx.org>
  *
  * Based on the original audio framework from:
  *


### PR DESCRIPTION
This line is misreplaced