### PR TITLE
Move unreachable code properly in drivers/wireless

### DIFF
--- a/os/drivers/wireless/scsc/misc/mx_mmap.c
+++ b/os/drivers/wireless/scsc/misc/mx_mmap.c
@@ -556,12 +556,9 @@ int mx_gdb_close(struct file *filp)
 	}
 
 	sem_post(&mx_dev->data_wait);
-	return OK;
-
 	filp->f_priv = NULL;
 	mx_dev->filp = NULL;
-
-	return 0;
+	return OK;
 }
 
 static const struct file_operations mx_gdb_fops = {

--- a/os/drivers/wireless/scsc/t20_ops.c
+++ b/os/drivers/wireless/scsc/t20_ops.c
@@ -1256,7 +1256,7 @@ int slsi_get_signal_poll(void *priv, struct wpa_signal_info *si)
 	SLSI_MUTEX_LOCK(ndev_vif->vif_mutex);
 	if (!ndev_vif->activated) {
 		SLSI_ERR_NODEV("STA Not Connected\n");
-		return -EINVAL;
+		res = -EINVAL;
 		goto exit;
 	}
 	memset(si, 0, sizeof(*si));


### PR DESCRIPTION
Deleted code is never executed.