### PR TITLE
Fix oops parameter in tinyalsa.c

### DIFF
--- a/framework/src/tinyalsa/tinyalsa.c
+++ b/framework/src/tinyalsa/tinyalsa.c
@@ -442,7 +442,7 @@ static int pcm_mmap_transfer_areas(struct pcm *pcm, char *buf, unsigned int offs
 		pcm_areas_copy(pcm, pcm_offset, buf, offset, frames);
 		commit = pcm_mmap_commit(pcm, pcm_offset, frames);
 		if (commit < 0) {
-			return oops(pcm, commit, "failed to commit %d frames\n", frames);
+			return oops(pcm, -commit, "failed to commit %d frames\n", frames);
 		}
 
 		offset += commit;


### PR DESCRIPTION
Argument e of oops(struct pcm *pcm, int e, const char *fmt, ...)
must be >= 0