### PR TITLE
iotjs: Select SPI in KConfig

### DIFF
--- a/external/iotjs/Kconfig.runtime
+++ b/external/iotjs/Kconfig.runtime
@@ -6,6 +6,7 @@
 config ENABLE_IOTJS
 	bool "IoT.js"
 	default n
+	select SPI_EXCHANGE
 	---help---
 		Enable IoT.js framework
 


### PR DESCRIPTION
Observed issue was:

  iotjs_module_spi-tizenrt.c:23:2: \
  error: #error "\n\nTizenRT CONFIG_SPI_EXCHANGE flag required for SPI module\n\n"

Change-Id: I8ec289c680973f7949d48b64a459524dab2083e0
Signed-off-by: Philippe Coval <philippe.coval@osg.samsung.com>