### PR TITLE
Fix problem with offset in wpa_receive_from not being updated correctly

### DIFF
--- a/external/wpa_supplicant/src/common/wpa_ctrl.c
+++ b/external/wpa_supplicant/src/common/wpa_ctrl.c
@@ -564,7 +564,7 @@ int wpa_ctrl_recvfrom(int sock, char *buf, size_t len
 	ssize_t amount = 0;
 	size_t recv_len;
 	char *pos;
-	int res;
+	int res = -1;
 #ifdef CONFIG_CTRL_IFACE_UDP
 	UNUSED(flags);
 #endif

--- a/external/wpa_supplicant/src/common/wpa_ctrl.c
+++ b/external/wpa_supplicant/src/common/wpa_ctrl.c
@@ -568,7 +568,7 @@ int wpa_ctrl_recvfrom(int sock, char *buf, size_t len
 #ifdef CONFIG_CTRL_IFACE_UDP
 	UNUSED(flags);
 #endif
-	while ((offset += amount) < CTRL_HEADER_SIZE)) {
+	while ((offset += amount) < CTRL_HEADER_SIZE) {
 #ifdef CONFIG_CTRL_IFACE_UDP
 		amount = recvfrom(sock, buf + offset, CTRL_HEADER_SIZE - offset, 0, from, fromlen);
 #else
@@ -583,7 +583,7 @@ int wpa_ctrl_recvfrom(int sock, char *buf, size_t len
 	buf[CTRL_HEADER_SIZE] = '\0';
 	wpa_printf(MSG_EXCESSIVE, "received message size: %d ('%s')", msg_size, buf);
 	
-	while ((offset += amount) < msg_size)) {
+	while ((offset += amount) < msg_size) {
 		if (msg_size > len) {	// This is BAD!!! read out the message to keep alignment.
 			pos = buf;
 		} else {

--- a/external/wpa_supplicant/src/common/wpa_ctrl.c
+++ b/external/wpa_supplicant/src/common/wpa_ctrl.c
@@ -568,23 +568,22 @@ int wpa_ctrl_recvfrom(int sock, char *buf, size_t len
 #ifdef CONFIG_CTRL_IFACE_UDP
 	UNUSED(flags);
 #endif
-	while ((amount >= 0) && ((amount + offset) < CTRL_HEADER_SIZE)) {
+	while ((offset += amount) < CTRL_HEADER_SIZE)) {
 #ifdef CONFIG_CTRL_IFACE_UDP
 		amount = recvfrom(sock, buf + offset, CTRL_HEADER_SIZE - offset, 0, from, fromlen);
 #else
 		amount = read(sock, buf + offset, CTRL_HEADER_SIZE - offset);
 #endif
-	}
 	if (amount < 0) {
 		return amount;
-	} else {
-		msg_size = wpa_ctrl_get_header(buf);
-		offset = 0;
-		amount = 0;
-		buf[CTRL_HEADER_SIZE] = '\0';
-		wpa_printf(MSG_EXCESSIVE, "received message size: %d ('%s')", msg_size, buf);
 	}
-	while ((amount >= 0) && ((amount + offset) < msg_size)) {
+	msg_size = wpa_ctrl_get_header(buf);
+	offset = 0;
+	amount = 0;
+	buf[CTRL_HEADER_SIZE] = '\0';
+	wpa_printf(MSG_EXCESSIVE, "received message size: %d ('%s')", msg_size, buf);
+	
+	while ((offset += amount) < msg_size)) {
 		if (msg_size > len) {	// This is BAD!!! read out the message to keep alignment.
 			pos = buf;
 		} else {
@@ -594,16 +593,14 @@ int wpa_ctrl_recvfrom(int sock, char *buf, size_t len
 #ifdef CONFIG_CTRL_IFACE_UDP
 		amount = recvfrom(sock, pos, recv_len, 0, from, fromlen);
 #else
-		amount += read(sock, pos, recv_len);
+		amount = read(sock, pos, recv_len);
 #endif
+		if (amount < 0) {
+			res = amount;
+		}
 	}
 	if (msg_size > len) {
 		return -1;				// Buffer too small for the message, return error
-	}
-	if (amount >= 0) {
-		res = amount + offset;
-	} else {
-		res = amount;
 	}
 	return res;
 }

--- a/external/wpa_supplicant/src/common/wpa_ctrl.c
+++ b/external/wpa_supplicant/src/common/wpa_ctrl.c
@@ -574,9 +574,11 @@ int wpa_ctrl_recvfrom(int sock, char *buf, size_t len
 #else
 		amount = read(sock, buf + offset, CTRL_HEADER_SIZE - offset);
 #endif
-	if (amount < 0) {
-		return amount;
+		if (amount < 0) {
+			return amount;
+		}
 	}
+	
 	msg_size = wpa_ctrl_get_header(buf);
 	offset = 0;
 	amount = 0;

--- a/external/wpa_supplicant/src/common/wpa_ctrl.c
+++ b/external/wpa_supplicant/src/common/wpa_ctrl.c
@@ -564,7 +564,7 @@ int wpa_ctrl_recvfrom(int sock, char *buf, size_t len
 	ssize_t amount = 0;
 	size_t recv_len;
 	char *pos;
-	int res = -1;
+
 #ifdef CONFIG_CTRL_IFACE_UDP
 	UNUSED(flags);
 #endif
@@ -598,13 +598,13 @@ int wpa_ctrl_recvfrom(int sock, char *buf, size_t len
 		amount = read(sock, pos, recv_len);
 #endif
 		if (amount < 0) {
-			res = amount;
+			return amount;
 		}
 	}
 	if (msg_size > len) {
 		return -1;				// Buffer too small for the message, return error
 	}
-	return res;
+	return msg_size;
 }
 
 static int _wpa_ctrl_sendto(int sock, const char *buf, size_t len


### PR DESCRIPTION
In cases where a large amount of data is to be transferred over a non-UDP socket, the offset would not be updated correctly.
This patch makes sure that the offset is always updated according to the amount read.