### PR TITLE
utils/kdbg_irqinfo : Fix build error for qemu/tc_1m configuration

### DIFF
--- a/apps/system/utils/kdbg_irqinfo.c
+++ b/apps/system/utils/kdbg_irqinfo.c
@@ -16,7 +16,9 @@
  *
  ****************************************************************************/
 
+#include <tinyara/config.h>
 #include <tinyara/irq.h>
+#include <sys/types.h>
 
 
 int kdbg_irqinfo(int argc, char **args)


### PR DESCRIPTION
Build error happens when CONFIG_ENABLE_IRQINFO is enabled for
qemu/tc_1m configuration as OK and ERROR are undefined

Signed-off-by: pradeep.ns <pradeep.ns@samsung.com>