### PR TITLE
network/itc_net_connect.c : fix build error

### DIFF
--- a/apps/examples/testcase/le_tc/network/itc_net_connect.c
+++ b/apps/examples/testcase/le_tc/network/itc_net_connect.c
@@ -178,7 +178,8 @@ static void *client_connect(void *ptr_id)
 	ret = connect(sock, (struct sockaddr *)&serv_addr, sizeof(serv_addr));
 	if (ret != OK) {
 		close(sock);
-		pthread_exit(ret);
+		*pret = ret;
+		pthread_exit(pret);
 	}
 	strncpy(client_msg, CLIENT_MSG, sizeof(CLIENT_MSG));
 	client_msg[strlen(client_msg) - 2] = '0' + (*id);


### PR DESCRIPTION
For artik053/tc coonfigurtion , when we run make menuconfig and save it
it results in build error as follows

le_tc/network/itc_net_connect.c:181:16: error: passing argument 1 of 'pthread_exit' makes pointer from integer without a cast [-Werror]
   pthread_exit(ret);

Signed-off-by: pradeep.ns <pradeep.ns@samsung.com>