### PR TITLE
armv7-m/up_assert: wrap CONFIG_ARMV7M_MPU to 'mpu_show_regioninfo'

### DIFF
--- a/os/arch/arm/src/armv7-m/up_assert.c
+++ b/os/arch/arm/src/armv7-m/up_assert.c
@@ -305,7 +305,9 @@ static void up_dumpstate(void)
 	/* Then dump the registers (if available) */
 
 	up_registerdump();
+#ifdef CONFIG_ARMV7M_MPU
 	mpu_show_regioninfo();
+#endif
 #ifdef CONFIG_ARCH_USBDUMP
 	/* Dump USB trace data */
 


### PR DESCRIPTION
MPU regions info should be displayed in asserts only when `CONFIG_ARMV7M_MPU` is enabled.

Signed-off-by: Lokesh B V <lokesh.bv@partner.samsung.com>