### PR TITLE
artik: Explain to erase OTA part for factory reset

### DIFF
--- a/build/configs/artik053/README.md
+++ b/build/configs/artik053/README.md
@@ -169,6 +169,7 @@ You can download it using OpenOCD. You compress the compiled firmware and downlo
 ```bash
 gzip -c tinyara_head.bin > factoryimage.gz
 openocd -f artik05x.cfg -s ../build/configs/artik05x/scripts -c ' \
+    flash_erase_part ota ;\
     flash_write factory    ../build/configs/artik053/bin/factoryimage.gz;      \
     exit'
 ```

--- a/build/configs/artik053s/README.md
+++ b/build/configs/artik053s/README.md
@@ -170,6 +170,7 @@ You can download it using OpenOCD. You compress the compiled firmware and downlo
 ```bash
 gzip -c tinyara_head.bin-signed > factoryimage.gz
 openocd -f artik05x.cfg -s ../build/configs/artik05x/scripts -c ' \
+    flash_erase_part ota ;\
     flash_write factory    ../build/configs/artik053/bin/factoryimage.gz;      \
     exit'
 ```

--- a/build/configs/artik055s/README.md
+++ b/build/configs/artik055s/README.md
@@ -176,6 +176,7 @@ You can download it using OpenOCD. You compress the compiled firmware and downlo
 ```bash
 gzip -c tinyara_head.bin-signed > factoryimage.gz
 openocd -f artik05x.cfg -s ../build/configs/artik05x/scripts -c ' \
+    flash erase_part ota ; \
     flash_write factory    ../build/configs/artik055s/bin/factoryimage.gz;      \
     exit'
 ```


### PR DESCRIPTION
For a safer factory reset, it's safer to erase OTA partition.

I came to the case, where there was junk in partition,
instead of actual "Over the Air" image
And do_checkupdate failed on crc32 which caused a reset of uboot.

So to reduce unexpected cases, the partition is just erased,
then comparaison test on ${otapart} header will be skipped (==0xffffffff).

For more insights check file:
artik-05x/include/configs/artik05x.h

URL: https://developer.artik.io/forums/t/solved-how-to-factory-reset-artik055s/5254
Change-Id: I19de266fdfe134fe3cc9574f5cc2482215d9877a
Signed-off-by: Philippe Coval <philippe.coval@osg.samsung.com>