### PR TITLE
Initialize usermq only when first audio_open

### DIFF
--- a/os/audio/audio.c
+++ b/os/audio/audio.c
@@ -185,7 +185,13 @@ static int audio_open(FAR struct file *filep)
 	/* Save the new open count on success */
 
 	upper->crefs = tmp;
-	upper->usermq = NULL;
+
+	/* Initialize usermq only when it is the first open */
+
+	if (upper->crefs == 1) {
+		upper->usermq = NULL;
+	}
+
 	ret = OK;
 
 errout_with_sem:


### PR DESCRIPTION
usermq should not be initialize after first audio_open,
because previous thread may using that usermq