### PR TITLE
framework/iotbus/gpio: set a dev to NULL on close

### DIFF
--- a/framework/src/iotbus/iotbus_gpio.c
+++ b/framework/src/iotbus/iotbus_gpio.c
@@ -111,6 +111,7 @@ int iotbus_gpio_close(iotbus_gpio_context_h dev)
 
 	close(dev->fd);
 	free(dev);
+	dev = NULL;
 	return IOTBUS_ERROR_NONE;
 }
 


### PR DESCRIPTION
When gpio is closed, even though dev resource is freed, dev value
is not set to NULL. It causes getting wrong response from gpio function
after calling close function.