### PR TITLE
kernel/debug: Fix build error in sysdbg module

### DIFF
--- a/os/kernel/debug/sysdbg.c
+++ b/os/kernel/debug/sysdbg.c
@@ -889,21 +889,29 @@ static void sysdbg_monitor_enable(void)
 		irqrestore(saved_state);
 		return;
 	}
+
+#ifdef CONFIG_SEMAPHORE_HISTORY
 fail3:
+#endif
 #ifdef CONFIG_IRQ_SCHED_HISTORY
 	kmm_free(sysdbg_struct->irq);
 	sysdbg_struct->irq = NULL;
 #endif
 
+#ifdef CONFIG_IRQ_SCHED_HISTORY
 fail2:
+#endif
 #ifdef CONFIG_TASK_SCHED_HISTORY
 	kmm_free(sysdbg_struct->sched);
 	sysdbg_struct->sched = NULL;
 #endif
 
+#ifdef CONFIG_TASK_SCHED_HISTORY
 fail1:
+#endif
 	kmm_free(sysdbg_struct);
 	sysdbg_struct = NULL;
+
 fail:
 	lldbg("Disabling sysdbg monitoring feature, kindly use less count\n");
 	sysdbg_monitor = false;


### PR DESCRIPTION
This patch fixes build error, which occurs
when any one or two of below three configs are disabled
1. CONFIG_TASK_SCHED_HISTORY
2. CONFIG_IRQ_SCHED_HISTORY
3. CONFIG_SEMAPHORE_HISTORY

Signed-off-by: Lokesh B V <lokesh.bv@partner.samsung.com>