### PR TITLE
Fix documentation mistake about standalone problem

### DIFF
--- a/apps/examples/i2schar/i2schar.h
+++ b/apps/examples/i2schar/i2schar.h
@@ -65,7 +65,7 @@
  ****************************************************************************/
 /* Configuration ************************************************************/
 /* CONFIG_NSH_BUILTIN_APPS - Build the I2SCHAR test as an NSH built-in
- *   function. Default: Built as a standalone problem
+ *   function. Default: Built as a standalone program
  * CONFIG_EXAMPLES_I2SCHAR_DEVPATH - The default path to the I2S character
  *   device. Default: /dev/i2schar0
  */


### PR DESCRIPTION
I guess author meant "standalone program" not "standalone problem" ?

Change-Id: Ida45d512ba7aeacf864736468ff8ce7f2d3a4d45
Related: https://bitbucket.org/nuttx/apps/pull-requests/132
Signed-off-by: Philippe Coval <philippe.coval@osg.samsung.com>