### PR TITLE
tools: Ensure mkromfsimg.sh run from os dir

### DIFF
--- a/tools/fs/mkromfsimg.sh
+++ b/tools/fs/mkromfsimg.sh
@@ -52,11 +52,10 @@
 ############################################################################
 
 # Make sure we understand where we are
-
-if [ ! -f tools/mkromfsimg.sh ]; then
+if [ ! -f ../tools/fs/mkromfsimg.sh ]; then
   cd .. || { echo "ERROR: cd .. failed"; exit 1; }
-  if [ ! -f tools/mkromfsimg.sh ]; then
-    error "This script must be executed from the top-level apps/ directory"
+  if [ ! -f ../tools/fs/mkromfsimg.sh ]; then
+    error "This script must be executed from the top-level os/ directory"
     exit 1
   fi
 fi


### PR DESCRIPTION
This is a divergence from NuttX,
problem has been introduced when removed file:
os/tools/mkromfsimg.sh (dropped NSHInitVol support)

https://github.com/Samsung/TizenRT/pull/1204

While this tools/fs/mkromfsimg.sh script was testing that removed file,
this is not relevent, so we adapt to check if pwd is in os dir

Observed regression is:

  The "bl1 bl2 sssfw wlanfw os rom" partition(s) will be flashed
  ../tools/fs/mkromfsimg.sh: 59: ../tools/fs/mkromfsimg.sh: error: not found
  ROMFS image is not present
  make[1]: *** [download] Error 1

URL: https://github.com/Samsung/TizenRT/pull/1204
Change-Id: I830dd31d95ff2b2342c3f0301a8ba83e5e3b75bf
Signed-off-by: Philippe Coval <philippe.coval@osg.samsung.com>