### PR TITLE
armv7: Move log header of up_showtasks inside it's function definition

### DIFF
--- a/os/arch/arm/src/armv7-m/up_assert.c
+++ b/os/arch/arm/src/armv7-m/up_assert.c
@@ -206,6 +206,10 @@ static void up_taskdump(FAR struct tcb_s *tcb, FAR void *arg)
 #ifdef CONFIG_STACK_COLORATION
 static inline void up_showtasks(void)
 {
+	lldbg("*******************************************\n");
+	lldbg("List of all tasks in the system:\n");
+	lldbg("*******************************************\n");
+
 	/* Dump interesting properties of each task in the crash environment */
 
 	sched_foreach(up_taskdump, NULL);
@@ -345,9 +349,6 @@ static void up_dumpstate(void)
 
 	/* Dump the state of all tasks (if available) */
 
-	lldbg("*******************************************\n");
-	lldbg("List of all tasks in the system:\n");
-	lldbg("*******************************************\n");
 	up_showtasks();
 
 	/* Dump MPU regions info */

--- a/os/arch/arm/src/armv7-r/arm_assert.c
+++ b/os/arch/arm/src/armv7-r/arm_assert.c
@@ -490,6 +490,10 @@ static void up_taskdump(FAR struct tcb_s *tcb, FAR void *arg)
 #ifdef CONFIG_STACK_COLORATION
 static inline void up_showtasks(void)
 {
+	lldbg("*******************************************\n");
+	lldbg("List of all tasks in the system:\n");
+	lldbg("*******************************************\n");
+
 	/* Dump interesting properties of each task in the crash environment */
 
 	sched_foreach(up_taskdump, NULL);
@@ -869,11 +873,9 @@ static void up_dumpstate(void)
 	lldbg("*******************************************\n");
 	dump_stack();
 #endif
+
 	/* Dump the state of all tasks (if available) */
 
-	lldbg("*******************************************\n");
-	lldbg("List of all tasks in the system:\n");
-	lldbg("*******************************************\n");
 	up_showtasks();
 
 #ifdef CONFIG_FRAME_POINTER


### PR DESCRIPTION
It is not relavant to print log header without actual log content.
So it is better to move log header of up_showtasks inside it's function definition.

Signed-off-by: Lokesh B V <lokesh.bv@partner.samsung.com>