### PR TITLE
docs: add the byacc package in bash command window

### DIFF
--- a/docs/HowtoInstallKconfigFrontend.md
+++ b/docs/HowtoInstallKconfigFrontend.md
@@ -1,9 +1,9 @@
 # Kconfig-frontends Installation
 
 ## Prerequisites
-The *bison* (or byacc if supported), *flex*, *gperf*, *libncurses5-dev*, *zlib1g-dev*, *gettext* and *g++* packages should be installed:
+The *bison* (or *byacc* if supported), *flex*, *gperf*, *libncurses5-dev*, *zlib1g-dev*, *gettext* and *g++* packages should be installed:
 ```bash
-sudo apt-get install bison flex gperf libncurses5-dev zlib1g-dev gettext g++
+sudo apt-get install bison byacc flex gperf libncurses5-dev zlib1g-dev gettext g++
 ```
 
 ## Kconfig-frontend


### PR DESCRIPTION
In some environment, byacc should be installed to use Kconfig-frontend.
We wrote that on description, "(or byacc if supported)".
But someone doesn't see it and just copy commands from bash window and execute.
To prevent an error, let's defaultly add that in bash window.