### PR TITLE
Fix logical errors

### DIFF
--- a/apps/system/iperf/iperf_api.c
+++ b/apps/system/iperf/iperf_api.c
@@ -1348,7 +1348,7 @@ static int get_parameters(struct iperf_test *test)
 			test->settings->bytes = j_p->valueint;
 		}
 		if ((j_p = cJSON_GetObjectItem(j, "blockcount")) != NULL) {
-			test->settings->blocks = (j_p->valueint > 0 ? j_p->valueint : 0);
+			test->settings->blocks = (j_p->valueint > 0 ? (iperf_size_t)j_p->valueint : 0);
 		}
 		if ((j_p = cJSON_GetObjectItem(j, "MSS")) != NULL) {
 			test->settings->mss = j_p->valueint;

--- a/external/netutils/netlib_getipv4addr.c
+++ b/external/netutils/netlib_getipv4addr.c
@@ -100,7 +100,11 @@ int netlib_get_ipv4addr(FAR const char *ifname, FAR struct in_addr *addr)
 		int sockfd = socket(PF_INET, NETLIB_SOCK_IOCTL, 0);
 		if (sockfd >= 0) {
 			struct ifreq req;
+			if (strlen(ifname) >= IFNAMSIZ) {
+				return ret;
+			}
 			strncpy(req.ifr_name, ifname, IFNAMSIZ);
+			req.ifr_name[IFNAMSIZ - 1] = '\0';
 			ret = ioctl(sockfd, SIOCGIFADDR, (unsigned long)&req);
 			if (!ret) {
 				FAR struct sockaddr_in *req_addr;

--- a/framework/src/st_things/things_stack/framework/things_data_manager.c
+++ b/framework/src/st_things/things_stack/framework/things_data_manager.c
@@ -960,6 +960,10 @@ static int parse_things_info_json(const char *filename)
 							}
 
 							cJSON *policy = cJSON_GetObjectItem(res, KEY_DEVICE_RESOURCE_POLICY);
+							if (policy == NULL) {
+								THINGS_LOG_D(THINGS_ERROR, TAG, "[COLLECTION] Fail to get collection[iter].policy");
+								return -1;
+							}
 							node->collection[iter].policy = policy->valueint;
 							THINGS_LOG_D(THINGS_INFO, TAG, "[COLLECTION] collection[iter].policy : %d", (node->collection[iter].policy));
 

--- a/os/drivers/wireless/scsc/mib_text_convert.c
+++ b/os/drivers/wireless/scsc/mib_text_convert.c
@@ -176,6 +176,9 @@ static bool CsrWifiMibConvertTextParseLine(const char *linestr, struct slsi_mib_
 	size_t dot2 = 0;
 	size_t trimmedIndex = 0;
 	char *trimmed = kmm_malloc(strlen(linestr) + 1);
+	if (trimmed == NULL) {
+		return false;
+	}
 	const char *current_char = linestr;
 	bool processingStr = false;
 
@@ -266,6 +269,10 @@ static bool CsrWifiMibConvertTextParseLine(const char *linestr, struct slsi_mib_
 				entry.value.type = SLSI_MIB_TYPE_OCTET;
 				entry.value.u.octetValue.dataLength = octetLen;
 				entry.value.u.octetValue.data = kmm_malloc(entry.value.u.octetValue.dataLength + 1);
+				if (entry.value.u.octetValue.data == NULL) {
+					kmm_free(trimmed);
+					return false;
+				}
 				for (i = 0; i < octetLen; i++)
 					if (!CsrHexStrToUint8(&data[1 + (i * 2)], &entry.value.u.octetValue.data[i])) {
 						SLSI_ERR_NODEV("CsrWifiMibConvertTextParseLine('%s') Convert Hex Bytes <data> failed", trimmed);


### PR DESCRIPTION
- NULL check after memory allocation
- Add '\0' at the end of string
- Add type casting when change to bigger type