### PR TITLE
testcase: fix some defects in testcase for network, gpio

### DIFF
--- a/apps/examples/testcase/le_tc/network/tc_net_getsockname.c
+++ b/apps/examples/testcase/le_tc/network/tc_net_getsockname.c
@@ -48,13 +48,10 @@ static void tc_net_getsockname_p(void)
 	struct sockaddr foo;
 
 	sock = socket(AF_INET, SOCK_STREAM, 0);
-
 	int ret = getsockname(sock, &foo, (socklen_t *)&len);
-
+	close(sock);
 	TC_ASSERT_NEQ("getsockname", ret, -1);
 	TC_SUCCESS_RESULT();
-
-	close(sock);
 }
 
 /**
@@ -73,11 +70,9 @@ static void tc_net_getsockname_unix_p(void)
 
 	sock = socket(AF_UNIX, SOCK_STREAM, 0);
 	int ret = getsockname(sock, &foo, (socklen_t *)&len);
-
+	close(sock);
 	TC_ASSERT_NEQ("getsockname", ret, -1);
 	TC_SUCCESS_RESULT();
-
-	close(sock);
 }
 
 /**
@@ -123,7 +118,6 @@ static void tc_net_getsockname_close_n(void)
 
 	TC_ASSERT_NEQ("getsockname", ret, 0);
 	TC_SUCCESS_RESULT();
-
 }
 
 /**
@@ -142,11 +136,9 @@ static void tc_net_getsockname_udp_p(void)
 
 	sock = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
 	int ret = getsockname(sock, &foo, (socklen_t *)&len);
-
+	close(sock);
 	TC_ASSERT_NEQ("getsockname", ret, -1);
 	TC_SUCCESS_RESULT();
-
-	close(sock);
 }
 
 /**
@@ -165,11 +157,9 @@ static void tc_net_getsockname_icmp_p(void)
 
 	sock = socket(AF_INET, SOCK_DGRAM, IPPROTO_ICMP);
 	int ret = getsockname(sock, &foo, (socklen_t *)&len);
-
+	close(sock);
 	TC_ASSERT_NEQ("getsockname", ret, -1);
 	TC_SUCCESS_RESULT();
-
-	close(sock);
 }
 
 /**

--- a/apps/examples/testcase/le_tc/network/tc_net_listen.c
+++ b/apps/examples/testcase/le_tc/network/tc_net_listen.c
@@ -81,11 +81,9 @@ static void tc_net_listen_fd_n(void)
 
 	bind(fd, (struct sockaddr *)&sa, sizeof(sa));
 	int ret = (listen(-1, 10));
-
+	close(fd);
 	TC_ASSERT_NEQ("listen", ret, 0);
 	TC_SUCCESS_RESULT();
-	close(fd);
-
 }
 
 /**
@@ -137,11 +135,9 @@ static void tc_net_listen_fd_backlog_n(void)
 
 	bind(SocketFD, (struct sockaddr *)&sa, sizeof(sa));
 	int ret = (listen(-1, -1));
-
+	close(SocketFD);
 	TC_ASSERT_NEQ("listen", ret, 0);
 	TC_SUCCESS_RESULT();
-
-	close(SocketFD);
 }
 
 /****************************************************************************

--- a/apps/examples/testcase/le_tc/network/tc_net_netdb.c
+++ b/apps/examples/testcase/le_tc/network/tc_net_netdb.c
@@ -57,12 +57,11 @@ static void tc_net_netdb_p(void)
 	hints.ai_socktype = SOCK_DGRAM;
 
 	ret = getaddrinfo(NULL, port, &hints, &res);
-	TC_ASSERT_EQ("getaddrinfo", ret, 0)
-
 	/*
 	* This API has no way to check errors.
 	*/
 	freeaddrinfo(res);
+	TC_ASSERT_EQ("getaddrinfo", ret, 0);
 	TC_SUCCESS_RESULT()
 }
 #endif

--- a/apps/examples/testcase/ta_tc/systemio/utc/utc_gpio.c
+++ b/apps/examples/testcase/ta_tc/systemio/utc/utc_gpio.c
@@ -64,7 +64,8 @@ static void utc_systemio_gpio_open_p(void)
 
 static void utc_systemio_gpio_open_n(void)
 {
-	TC_ASSERT_EQ("iotbus_gpio_open", iotbus_gpio_open(-1), NULL);
+	iotbus_gpio_context_h m_gpio = iotbus_gpio_open(-1);
+	TC_ASSERT_EQ_CLEANUP("iotbus_gpio_open", m_gpio, NULL, iotbus_gpio_close(&m_gpio));
 	TC_SUCCESS_RESULT();
 }
 


### PR DESCRIPTION
fixed to close handle or free allocated resource before exit

tc_net_getsockname.c:
- The handle 'sock' was created at tc_net_getsockname.c:50 by calling function 'socket' and lost at tc_net_getsockname.c:54.
- The handle 'sock' was created at tc_net_getsockname.c:74 by calling function 'socket' and lost at tc_net_getsockname.c:77.
- The handle 'sock' was created at tc_net_getsockname.c:143 by calling function 'socket' and lost at tc_net_getsockname.c:146.
- The handle 'sock' was created at tc_net_getsockname.c:166 by calling function 'socket' and lost at tc_net_getsockname.c:169.

tc_net_listen.c:
- The handle 'SocketFD' was created at tc_net_listen.c:130 by calling function 'socket' and lost at tc_net_listen.c:141.

tc_net_netdb.c:
- The handle 'res' was created at tc_net_netdb.c:59 by calling function 'getaddrinfo' and lost at tc_net_netdb.c:60.

utc_gpio.c:
- Dynamic memory referenced by 'return value of iotbus_gpio_open(-1)' was allocated at iotbus_gpio.c:73 by calling function 'iotbus_gpio_open' at utc_gpio.c:67 and lost at utc_gpio.c:67.