### PR TITLE
fix CVE issues in wpa_supplicant

### DIFF
--- a/external/wpa_supplicant/Kconfig
+++ b/external/wpa_supplicant/Kconfig
@@ -81,6 +81,9 @@ config DRIVER_T20
 	default y
 	depends on SCSC_WLAN
 
+config DISABLE_EAP_FOR_SUPPLICANT
+	bool "Disable EAP for WPA supplicant"
+	default y
 endif
 
 endmenu # wpa_supplicant

--- a/external/wpa_supplicant/src/eap_peer/eap_pwd.c
+++ b/external/wpa_supplicant/src/eap_peer/eap_pwd.c
@@ -5,7 +5,7 @@
  * This software may be distributed under the terms of the BSD license.
  * See README for more details.
  */
-
+#ifndef CONFIG_DISABLE_EAP_FOR_SUPPLICANT
 #include "includes.h"
 
 #include "common.h"
@@ -941,3 +941,4 @@ int eap_peer_pwd_register(void)
 	}
 	return ret;
 }
+#endif /* #ifndef CONFIG_DISABLE_EAP_FOR_SUPPLICANT */

--- a/external/wpa_supplicant/src/eap_server/eap_server_pwd.c
+++ b/external/wpa_supplicant/src/eap_server/eap_server_pwd.c
@@ -5,7 +5,7 @@
  * This software may be distributed under the terms of the BSD license.
  * See README for more details.
  */
-
+#ifndef CONFIG_DISABLE_EAP_FOR_SUPPLICANT
 #include "includes.h"
 
 #include "common.h"
@@ -1000,3 +1000,4 @@ int eap_server_pwd_register(void)
 	}
 	return ret;
 }
+#endif /* #ifndef CONFIG_DISABLE_EAP_FOR_SUPPLICANT */


### PR DESCRIPTION
Fix CVE issues in wpa_supplicant (ref: issue #942). 

1. The fix disables building of the affected files eap_server_pwd.c and eap_pwd.c, by using a CONFIG_DISABLE_EAP_SUPPLICANT
2. CONFIG_DISABLE_EAP_SUPPLICANT is defined in the Kconfig for supplicant, and is set to true by default.