### PR TITLE
apps : include platform/gnu Kconfig

### DIFF
--- a/apps/platform/Kconfig
+++ b/apps/platform/Kconfig
@@ -14,4 +14,7 @@ config PLATFORM_CONFIGDATA
 		storage mechanism is not visible to applications so underlying non-
 		volatile storage can be used:  A file, EEPROM, hardcoded values in
 		FLASH, etc.
+
+source "$APPSDIR/platform/gnu/Kconfig"
+
 endmenu


### PR DESCRIPTION
This patch adds support to source missing gnu/Kconfig
It is required to include CONFIG_HAVE_CXXINITIALIZE in the
build configuration

Signed-off-by: Manohara HK <manohara.hk@samsung.com>