### PR TITLE
include/libcxx : support ptrdifft_t, time*, remove functions

### DIFF
--- a/external/include/libcxx/cstddef
+++ b/external/include/libcxx/cstddef
@@ -79,6 +79,7 @@ namespace std
   using ::float64;
 #endif
   using ::mode_t;
+  using ::ptrdiff_t;
   using ::size_t;
   using ::ssize_t;
   using ::off_t;

--- a/external/include/libcxx/cstdio
+++ b/external/include/libcxx/cstdio
@@ -123,6 +123,7 @@ namespace std
   using ::statfs;
   using ::tmpnam;
   using ::tempnam;
+  using ::remove;
 }
 
 #endif // __INCLUDE_CXX_CSTDIO

--- a/external/include/libcxx/ctime
+++ b/external/include/libcxx/ctime
@@ -77,7 +77,12 @@ namespace std
   using ::clock_settime;
   using ::clock_gettime;
   using ::mktime;
+  using ::time;
+  using ::asctime;
+  using ::ctime;
+  using ::gmtime;
   using ::gmtime_r;
+  using ::localtime;
   using ::timer_create;
   using ::timer_delete;
   using ::timer_settime;


### PR DESCRIPTION
This patch updates C Standard Library headers(cstdio, etc ...) in libcxx
to add missing functions.

Signed-off-by: Manohara HK <manohara.hk@samsung.com>