### PR TITLE
Remove hardcoded directories in framework/Makefile

### DIFF
--- a/framework/Makefile
+++ b/framework/Makefile
@@ -26,36 +26,17 @@ ASRCS =
 CSRCS =
 VPATH = .
 
-CFLAGS += -I$(TOPDIR)/../framework/include/iotbus
-include src$(DELIM)iotbus$(DELIM)Make.defs
+# Framework Directories
 
-ifeq ($(CONFIG_DM), y)
-include src$(DELIM)dm$(DELIM)Make.defs
-endif
+# BUILDIRS is the list of top-level directories containing Make.defs files
 
-ifeq ($(CONFIG_ARASTORAGE), y)
-include src$(DELIM)arastorage$(DELIM)Make.defs
-endif
+BUILDIRS   := $(dir $(wildcard src/*/Make.defs))
 
-ifeq ($(CONFIG_NETUTILS_MQTT), y)
-include src$(DELIM)network$(DELIM)mqtt$(DELIM)Make.defs
-endif
+define Add_Framework
+  include $(1)Make.defs
+endef
 
-ifeq ($(CONFIG_WIFI_MANAGER), y)
-include src$(DELIM)wifi_manager$(DELIM)Make.defs
-endif
-
-ifeq ($(CONFIG_ST_THINGS), y)
-include src$(DELIM)st_things$(DELIM)Make.defs
-endif
-
-ifeq ($(CONFIG_AUDIO), y)
-include src$(DELIM)tinyalsa$(DELIM)Make.defs
-endif
-
-ifeq ($(CONFIG_MEDIA), y)
-include src$(DELIM)media$(DELIM)Make.defs
-endif
+$(foreach BDIR, $(BUILDIRS), $(eval $(call Add_Framework,$(BDIR))))
 
 AOBJS = $(ASRCS:.S=$(OBJEXT))
 COBJS = $(CSRCS:.c=$(OBJEXT))

--- a/framework/src/arastorage/Make.defs
+++ b/framework/src/arastorage/Make.defs
@@ -15,6 +15,8 @@
 # language governing permissions and limitations under the License.
 #
 ###########################################################################
+
+ifeq ($(CONFIG_ARASTORAGE), y)
 CSRCS += aql_adt.c aql_exec.c aql_lexer.c aql_parser.c
 CSRCS += arastorage.c cursor.c lvm.c relation.c result.c
 CSRCS += storage_abstraction.c storage_interface.c
@@ -23,3 +25,4 @@ CSRCS += list.c random.c memb.c rw_locks.c
 
 DEPPATH += --dep-path src/arastorage
 VPATH += :src/arastorage
+endif

--- a/framework/src/dm/Make.defs
+++ b/framework/src/dm/Make.defs
@@ -16,6 +16,7 @@
 #
 ###########################################################################
 
+ifeq ($(CONFIG_DM), y)
 ifeq ($(CONFIG_LWM2M_CLIENT_MODE),y)
 CSRCS += dm_lwm2m.c
 endif
@@ -40,4 +41,5 @@ VPATH += :src/dm
 ifeq ($(CONFIG_ARCH_CHIP_S5JT200),y)
 DEPPATH += --dep-path src/dm/arch/sidk_s5jt200
 VPATH += src/dm/arch/sidk_s5jt200
+endif
 endif

--- a/framework/src/iotbus/Make.defs
+++ b/framework/src/iotbus/Make.defs
@@ -15,6 +15,8 @@
 # language governing permissions and limitations under the License.
 #
 ###########################################################################
+
+CFLAGS += -I$(TOPDIR)/../framework/include/iotbus
 CSRCS += iotapi_evt_handler.c
 CSRCS += iotbus_gpio.c iotbus_i2c.c iotbus_spi.c iotbus_pwm.c iotbus_uart.c
 

--- a/framework/src/media/Make.defs
+++ b/framework/src/media/Make.defs
@@ -15,6 +15,8 @@
 # language governing permissions and limitations under the License.
 #
 ###########################################################################
+
+ifeq ($(CONFIG_MEDIA), y)
 ifeq ($(CONFIG_MEDIA_PLAYER), y)
 CSRCS += media_player.c
 endif
@@ -27,3 +29,4 @@ CSRCS += media_utils.c
 
 DEPPATH += --dep-path src/media
 VPATH += :src/media
+endif

--- a/framework/src/network/Make.defs
+++ b/framework/src/network/Make.defs
@@ -1,6 +1,6 @@
 ###########################################################################
 #
-# Copyright 2017 Samsung Electronics All Rights Reserved.
+# Copyright 2018 Samsung Electronics All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,15 +16,4 @@
 #
 ###########################################################################
 
-ifeq ($(CONFIG_WIFI_MANAGER), y)
-CSRCS += wifi_manager.c wifi_net.c
-CSRCS += wifi_profile.c
-
-ifeq ($(CONFIG_WPA_SUPPLICANT), y)
-CSRCS += wpa_wifi_utils.c
-endif
-
-DEPPATH += --dep-path src/wifi_manager
-VPATH += :src/wifi_manager
-endif
-
+include $(wildcard src/network/*/Make.defs)

--- a/framework/src/st_things/Make.defs
+++ b/framework/src/st_things/Make.defs
@@ -16,6 +16,7 @@
 #
 ###########################################################################
 
+ifeq ($(CONFIG_ST_THINGS), y)
 THINGS_LIB_DIR = $(TOPDIR)/../framework/src/st_things
 THINGS_STACK_DIR = $(TOPDIR)/../framework/src/st_things/things_stack
 IOTIVITY_RELEASE=${shell echo $(CONFIG_IOTIVITY_RELEASE_VERSION) | sed 's/"//g'}
@@ -94,3 +95,4 @@ endif
 
 DEPPATH += --dep-path src/st_things
 VPATH += :src/st_things
+endif

--- a/framework/src/tinyalsa/Make.defs
+++ b/framework/src/tinyalsa/Make.defs
@@ -15,9 +15,10 @@
  # language governing permissions and limitations under the License. 
  # 
  ########################################################################### 
+
+ifeq ($(CONFIG_AUDIO), y)
 CSRCS += tinyalsa.c 
- 
 
 DEPPATH += --dep-path src/tinyalsa 
 VPATH += :src/tinyalsa 
-
+endif


### PR DESCRIPTION
Using wildcard, all Make.defs are included