### PR TITLE
libxx : remove uClibc++ configurations

### DIFF
--- a/apps/examples/cxxtest/cxxtest_main.cxx
+++ b/apps/examples/cxxtest/cxxtest_main.cxx
@@ -89,11 +89,6 @@ using namespace std;
 #undef CXXTEST_ISTREAM
 #undef CXXTEST_EXCEPTION
 
-#ifdef CONFIG_UCLIBCXX_EXCEPTION
-#define CXXTEST_EXCEPTION
-#endif
-
-
 //***************************************************************************
 // Private Classes
 //***************************************************************************

--- a/build/configs/artik053/audio/Make.defs
+++ b/build/configs/artik053/audio/Make.defs
@@ -56,12 +56,6 @@ include ${TOPDIR}/arch/arm/src/armv7-r/Toolchain.defs
 
 LDSCRIPT = flash.ld
 
-ifeq ($(CONFIG_UCLIBCXX_HAVE_LIBSUPCXX),y)
-LIBSUPXX = ${shell $(CC) --print-file-name=libsupc++.a}
-EXTRA_LIBPATHS = -L "${shell dirname "$(LIBSUPXX)"}"
-EXTRA_LIBS = -lsupc++
-endif
-
 ifeq ($(WINTOOL),y)
   # Windows-native toolchains
   DIRLINK = $(TOPDIR)/tools/copydir.sh

--- a/build/configs/artik053/extra/Make.defs
+++ b/build/configs/artik053/extra/Make.defs
@@ -56,12 +56,6 @@ include ${TOPDIR}/arch/arm/src/armv7-r/Toolchain.defs
 
 LDSCRIPT = flash.ld
 
-ifeq ($(CONFIG_UCLIBCXX_HAVE_LIBSUPCXX),y)
-LIBSUPXX = ${shell $(CC) --print-file-name=libsupc++.a}
-EXTRA_LIBPATHS = -L "${shell dirname "$(LIBSUPXX)"}"
-EXTRA_LIBS = -lsupc++
-endif
-
 ifeq ($(WINTOOL),y)
   # Windows-native toolchains
   DIRLINK = $(TOPDIR)/tools/copydir.sh

--- a/build/configs/artik053/hello/Make.defs
+++ b/build/configs/artik053/hello/Make.defs
@@ -56,12 +56,6 @@ include ${TOPDIR}/arch/arm/src/armv7-r/Toolchain.defs
 
 LDSCRIPT = flash.ld
 
-ifeq ($(CONFIG_UCLIBCXX_HAVE_LIBSUPCXX),y)
-LIBSUPXX = ${shell $(CC) --print-file-name=libsupc++.a}
-EXTRA_LIBPATHS = -L "${shell dirname "$(LIBSUPXX)"}"
-EXTRA_LIBS = -lsupc++
-endif
-
 ifeq ($(WINTOOL),y)
   # Windows-native toolchains
   DIRLINK = $(TOPDIR)/tools/copydir.sh

--- a/build/configs/artik053/iotivity/Make.defs
+++ b/build/configs/artik053/iotivity/Make.defs
@@ -56,12 +56,6 @@ include ${TOPDIR}/arch/arm/src/armv7-r/Toolchain.defs
 
 LDSCRIPT = flash.ld
 
-ifeq ($(CONFIG_UCLIBCXX_HAVE_LIBSUPCXX),y)
-LIBSUPXX = ${shell $(CC) --print-file-name=libsupc++.a}
-EXTRA_LIBPATHS = -L "${shell dirname "$(LIBSUPXX)"}"
-EXTRA_LIBS = -lsupc++
-endif
-
 ifeq ($(WINTOOL),y)
   # Windows-native toolchains
   DIRLINK = $(TOPDIR)/tools/copydir.sh

--- a/build/configs/artik053/iotjs/Make.defs
+++ b/build/configs/artik053/iotjs/Make.defs
@@ -56,12 +56,6 @@ include ${TOPDIR}/arch/arm/src/armv7-r/Toolchain.defs
 
 LDSCRIPT = flash.ld
 
-ifeq ($(CONFIG_UCLIBCXX_HAVE_LIBSUPCXX),y)
-LIBSUPXX = ${shell $(CC) --print-file-name=libsupc++.a}
-EXTRA_LIBPATHS = -L "${shell dirname "$(LIBSUPXX)"}"
-EXTRA_LIBS = -lsupc++
-endif
-
 ifeq ($(WINTOOL),y)
   # Windows-native toolchains
   DIRLINK = $(TOPDIR)/tools/copydir.sh

--- a/build/configs/artik053/kernel_sample/Make.defs
+++ b/build/configs/artik053/kernel_sample/Make.defs
@@ -56,12 +56,6 @@ include ${TOPDIR}/arch/arm/src/armv7-r/Toolchain.defs
 
 LDSCRIPT = flash.ld
 
-ifeq ($(CONFIG_UCLIBCXX_HAVE_LIBSUPCXX),y)
-LIBSUPXX = ${shell $(CC) --print-file-name=libsupc++.a}
-EXTRA_LIBPATHS = -L "${shell dirname "$(LIBSUPXX)"}"
-EXTRA_LIBS = -lsupc++
-endif
-
 ifeq ($(WINTOOL),y)
   # Windows-native toolchains
   DIRLINK = $(TOPDIR)/tools/copydir.sh

--- a/build/configs/artik053/minimal/Make.defs
+++ b/build/configs/artik053/minimal/Make.defs
@@ -56,12 +56,6 @@ include ${TOPDIR}/arch/arm/src/armv7-r/Toolchain.defs
 
 LDSCRIPT = flash.ld
 
-ifeq ($(CONFIG_UCLIBCXX_HAVE_LIBSUPCXX),y)
-LIBSUPXX = ${shell $(CC) --print-file-name=libsupc++.a}
-EXTRA_LIBPATHS = -L "${shell dirname "$(LIBSUPXX)"}"
-EXTRA_LIBS = -lsupc++
-endif
-
 ifeq ($(WINTOOL),y)
   # Windows-native toolchains
   DIRLINK = $(TOPDIR)/tools/copydir.sh

--- a/build/configs/artik053/nettest/Make.defs
+++ b/build/configs/artik053/nettest/Make.defs
@@ -56,12 +56,6 @@ include ${TOPDIR}/arch/arm/src/armv7-r/Toolchain.defs
 
 LDSCRIPT = flash.ld
 
-ifeq ($(CONFIG_UCLIBCXX_HAVE_LIBSUPCXX),y)
-LIBSUPXX = ${shell $(CC) --print-file-name=libsupc++.a}
-EXTRA_LIBPATHS = -L "${shell dirname "$(LIBSUPXX)"}"
-EXTRA_LIBS = -lsupc++
-endif
-
 ifeq ($(WINTOOL),y)
   # Windows-native toolchains
   DIRLINK = $(TOPDIR)/tools/copydir.sh

--- a/build/configs/artik053/st_things/Make.defs
+++ b/build/configs/artik053/st_things/Make.defs
@@ -22,12 +22,6 @@ include ${TOPDIR}/arch/arm/src/armv7-r/Toolchain.defs
 
 LDSCRIPT = flash.ld
 
-ifeq ($(CONFIG_UCLIBCXX_HAVE_LIBSUPCXX),y)
-LIBSUPXX = ${shell $(CC) --print-file-name=libsupc++.a}
-EXTRA_LIBPATHS = -L "${shell dirname "$(LIBSUPXX)"}"
-EXTRA_LIBS = -lsupc++
-endif
-
 ifeq ($(WINTOOL),y)
   # Windows-native toolchains
   DIRLINK = $(TOPDIR)/tools/copydir.sh

--- a/build/configs/artik053/tc/Make.defs
+++ b/build/configs/artik053/tc/Make.defs
@@ -56,12 +56,6 @@ include ${TOPDIR}/arch/arm/src/armv7-r/Toolchain.defs
 
 LDSCRIPT = flash.ld
 
-ifeq ($(CONFIG_UCLIBCXX_HAVE_LIBSUPCXX),y)
-LIBSUPXX = ${shell $(CC) --print-file-name=libsupc++.a}
-EXTRA_LIBPATHS = -L "${shell dirname "$(LIBSUPXX)"}"
-EXTRA_LIBS = -lsupc++
-endif
-
 ifeq ($(WINTOOL),y)
   # Windows-native toolchains
   DIRLINK = $(TOPDIR)/tools/copydir.sh

--- a/build/configs/artik053s/nettest/Make.defs
+++ b/build/configs/artik053s/nettest/Make.defs
@@ -56,12 +56,6 @@ include ${TOPDIR}/arch/arm/src/armv7-r/Toolchain.defs
 
 LDSCRIPT = flash.ld
 
-ifeq ($(CONFIG_UCLIBCXX_HAVE_LIBSUPCXX),y)
-LIBSUPXX = ${shell $(CC) --print-file-name=libsupc++.a}
-EXTRA_LIBPATHS = -L "${shell dirname "$(LIBSUPXX)"}"
-EXTRA_LIBS = -lsupc++
-endif
-
 ifeq ($(WINTOOL),y)
   # Windows-native toolchains
   DIRLINK = $(TOPDIR)/tools/copydir.sh

--- a/build/configs/artik053s/st_things/Make.defs
+++ b/build/configs/artik053s/st_things/Make.defs
@@ -56,12 +56,6 @@ include ${TOPDIR}/arch/arm/src/armv7-r/Toolchain.defs
 
 LDSCRIPT = flash.ld
 
-ifeq ($(CONFIG_UCLIBCXX_HAVE_LIBSUPCXX),y)
-LIBSUPXX = ${shell $(CC) --print-file-name=libsupc++.a}
-EXTRA_LIBPATHS = -L "${shell dirname "$(LIBSUPXX)"}"
-EXTRA_LIBS = -lsupc++
-endif
-
 ifeq ($(WINTOOL),y)
   # Windows-native toolchains
   DIRLINK = $(TOPDIR)/tools/copydir.sh

--- a/build/configs/artik055s/audio/Make.defs
+++ b/build/configs/artik055s/audio/Make.defs
@@ -56,12 +56,6 @@ include ${TOPDIR}/arch/arm/src/armv7-r/Toolchain.defs
 
 LDSCRIPT = flash.ld
 
-ifeq ($(CONFIG_UCLIBCXX_HAVE_LIBSUPCXX),y)
-LIBSUPXX = ${shell $(CC) --print-file-name=libsupc++.a}
-EXTRA_LIBPATHS = -L "${shell dirname "$(LIBSUPXX)"}"
-EXTRA_LIBS = -lsupc++
-endif
-
 ifeq ($(WINTOOL),y)
   # Windows-native toolchains
   DIRLINK = $(TOPDIR)/tools/copydir.sh

--- a/build/configs/artik055s/minimal/Make.defs
+++ b/build/configs/artik055s/minimal/Make.defs
@@ -56,12 +56,6 @@ include ${TOPDIR}/arch/arm/src/armv7-r/Toolchain.defs
 
 LDSCRIPT = flash.ld
 
-ifeq ($(CONFIG_UCLIBCXX_HAVE_LIBSUPCXX),y)
-LIBSUPXX = ${shell $(CC) --print-file-name=libsupc++.a}
-EXTRA_LIBPATHS = -L "${shell dirname "$(LIBSUPXX)"}"
-EXTRA_LIBS = -lsupc++
-endif
-
 ifeq ($(WINTOOL),y)
   # Windows-native toolchains
   DIRLINK = $(TOPDIR)/tools/copydir.sh

--- a/build/configs/artik055s/nettest/Make.defs
+++ b/build/configs/artik055s/nettest/Make.defs
@@ -56,12 +56,6 @@ include ${TOPDIR}/arch/arm/src/armv7-r/Toolchain.defs
 
 LDSCRIPT = flash.ld
 
-ifeq ($(CONFIG_UCLIBCXX_HAVE_LIBSUPCXX),y)
-LIBSUPXX = ${shell $(CC) --print-file-name=libsupc++.a}
-EXTRA_LIBPATHS = -L "${shell dirname "$(LIBSUPXX)"}"
-EXTRA_LIBS = -lsupc++
-endif
-
 ifeq ($(WINTOOL),y)
   # Windows-native toolchains
   DIRLINK = $(TOPDIR)/tools/copydir.sh

--- a/build/configs/artik055s/st_things/Make.defs
+++ b/build/configs/artik055s/st_things/Make.defs
@@ -56,12 +56,6 @@ include ${TOPDIR}/arch/arm/src/armv7-r/Toolchain.defs
 
 LDSCRIPT = flash.ld
 
-ifeq ($(CONFIG_UCLIBCXX_HAVE_LIBSUPCXX),y)
-LIBSUPXX = ${shell $(CC) --print-file-name=libsupc++.a}
-EXTRA_LIBPATHS = -L "${shell dirname "$(LIBSUPXX)"}"
-EXTRA_LIBS = -lsupc++
-endif
-
 ifeq ($(WINTOOL),y)
   # Windows-native toolchains
   DIRLINK = $(TOPDIR)/tools/copydir.sh

--- a/build/configs/sidk_s5jt200/hello/Make.defs
+++ b/build/configs/sidk_s5jt200/hello/Make.defs
@@ -55,11 +55,6 @@ include ${TOPDIR}/tools/Config.mk
 include ${TOPDIR}/arch/arm/src/armv7-r/Toolchain.defs
 
 LDSCRIPT = ld_s5jt200_flash.script
-ifeq ($(CONFIG_UCLIBCXX_HAVE_LIBSUPCXX),y)
-LIBSUPXX = ${shell $(CC) --print-file-name=libsupc++.a}
-EXTRA_LIBPATHS = -L "${shell dirname "$(LIBSUPXX)"}"
-EXTRA_LIBS = -lsupc++
-endif
 
 ifeq ($(WINTOOL),y)
   # Windows-native toolchains

--- a/build/configs/sidk_s5jt200/hello_with_tash/Make.defs
+++ b/build/configs/sidk_s5jt200/hello_with_tash/Make.defs
@@ -55,11 +55,6 @@ include ${TOPDIR}/tools/Config.mk
 include ${TOPDIR}/arch/arm/src/armv7-r/Toolchain.defs
 
 LDSCRIPT = ld_s5jt200_flash.script
-ifeq ($(CONFIG_UCLIBCXX_HAVE_LIBSUPCXX),y)
-LIBSUPXX = ${shell $(CC) --print-file-name=libsupc++.a}
-EXTRA_LIBPATHS = -L "${shell dirname "$(LIBSUPXX)"}"
-EXTRA_LIBS = -lsupc++
-endif
 
 ifeq ($(WINTOOL),y)
   # Windows-native toolchains

--- a/build/configs/sidk_s5jt200/kernel_sample/Make.defs
+++ b/build/configs/sidk_s5jt200/kernel_sample/Make.defs
@@ -55,11 +55,6 @@ include ${TOPDIR}/tools/Config.mk
 include ${TOPDIR}/arch/arm/src/armv7-r/Toolchain.defs
 
 LDSCRIPT = ld_s5jt200_flash.script
-ifeq ($(CONFIG_UCLIBCXX_HAVE_LIBSUPCXX),y)
-LIBSUPXX = ${shell $(CC) --print-file-name=libsupc++.a}
-EXTRA_LIBPATHS = -L "${shell dirname "$(LIBSUPXX)"}"
-EXTRA_LIBS = -lsupc++
-endif
 
 ifeq ($(WINTOOL),y)
   # Windows-native toolchains

--- a/build/configs/sidk_s5jt200/sidk_tash_aws/Make.defs
+++ b/build/configs/sidk_s5jt200/sidk_tash_aws/Make.defs
@@ -56,12 +56,6 @@ include ${TOPDIR}/arch/arm/src/armv7-r/Toolchain.defs
 
 LDSCRIPT = ld_s5jt200_flash.script
 
-ifeq ($(CONFIG_UCLIBCXX_HAVE_LIBSUPCXX),y)
-LIBSUPXX = ${shell $(CC) --print-file-name=libsupc++.a}
-EXTRA_LIBPATHS = -L "${shell dirname "$(LIBSUPXX)"}"
-EXTRA_LIBS = -lsupc++
-endif
-
 ifeq ($(WINTOOL),y)
   # Windows-native toolchains
   DIRLINK = $(TOPDIR)/tools/copydir.sh

--- a/build/configs/sidk_s5jt200/sidk_tash_wlan/Make.defs
+++ b/build/configs/sidk_s5jt200/sidk_tash_wlan/Make.defs
@@ -56,12 +56,6 @@ include ${TOPDIR}/arch/arm/src/armv7-r/Toolchain.defs
 
 LDSCRIPT = ld_s5jt200_flash.script
 
-ifeq ($(CONFIG_UCLIBCXX_HAVE_LIBSUPCXX),y)
-LIBSUPXX = ${shell $(CC) --print-file-name=libsupc++.a}
-EXTRA_LIBPATHS = -L "${shell dirname "$(LIBSUPXX)"}"
-EXTRA_LIBS = -lsupc++
-endif
-
 ifeq ($(WINTOOL),y)
   # Windows-native toolchains
   DIRLINK = $(TOPDIR)/tools/copydir.sh

--- a/build/configs/sidk_s5jt200/tc/Make.defs
+++ b/build/configs/sidk_s5jt200/tc/Make.defs
@@ -55,11 +55,6 @@ include ${TOPDIR}/tools/Config.mk
 include ${TOPDIR}/arch/arm/src/armv7-r/Toolchain.defs
 
 LDSCRIPT = ld_s5jt200_flash.script
-ifeq ($(CONFIG_UCLIBCXX_HAVE_LIBSUPCXX),y)
-LIBSUPXX = ${shell $(CC) --print-file-name=libsupc++.a}
-EXTRA_LIBPATHS = -L "${shell dirname "$(LIBSUPXX)"}"
-EXTRA_LIBS = -lsupc++
-endif
 
 ifeq ($(WINTOOL),y)
   # Windows-native toolchains

--- a/external/iotjs/config/tizenrt/artik05x/configs/Make.defs
+++ b/external/iotjs/config/tizenrt/artik05x/configs/Make.defs
@@ -56,12 +56,6 @@ include ${TOPDIR}/arch/arm/src/armv7-r/Toolchain.defs
 
 LDSCRIPT = flash.ld
 
-ifeq ($(CONFIG_UCLIBCXX_HAVE_LIBSUPCXX),y)
-LIBSUPXX = ${shell $(CC) --print-file-name=libsupc++.a}
-EXTRA_LIBPATHS = -L "${shell dirname "$(LIBSUPXX)"}"
-EXTRA_LIBS = -lsupc++
-endif
-
 EXTRA_LIBS += -lhttpparser -liotjs -ljerry-core -ltuv -ljerry-libm
 
 ifeq ($(WINTOOL),y)

--- a/external/iotjs/deps/jerry/targets/tizenrt-artik053/configs/jerryscript/Make.defs
+++ b/external/iotjs/deps/jerry/targets/tizenrt-artik053/configs/jerryscript/Make.defs
@@ -73,12 +73,6 @@ include ${TOPDIR}/arch/arm/src/armv7-r/Toolchain.defs
 
 LDSCRIPT = flash.ld
 
-ifeq ($(CONFIG_UCLIBCXX_HAVE_LIBSUPCXX),y)
-LIBSUPXX = ${shell $(CC) --print-file-name=libsupc++.a}
-EXTRA_LIBPATHS = -L "${shell dirname "$(LIBSUPXX)"}"
-EXTRA_LIBS = -lsupc++
-endif
-
 EXTRA_LIBS += -ljerry-core -ljerry-libm -ljerry-ext
 
 ifeq ($(WINTOOL),y)

--- a/lib/libxx/.gitignore
+++ b/lib/libxx/.gitignore
@@ -1,6 +1,5 @@
 /Make.dep
 /.depend
-/uClibc++
 /*.asm
 /*.obj
 /*.rel

--- a/lib/libxx/Kconfig
+++ b/lib/libxx/Kconfig
@@ -58,31 +58,4 @@ config LIBCXX_HAVE_LIBSUPCXX
 
 endif
 
-comment "uClibc++ Standard C++ Library"
-
-config UCLIBCXX
-	bool "Build uClibc++ (must be installed)"
-	default n
-	---help---
-		If you have installed uClibc++ into the TinyAra source try, then it can
-		be built by selecting this option.
-
-if UCLIBCXX
-
-config UCLIBCXX_EXCEPTION
-	bool "Enable Exception Suppport"
-	default y
-
-config UCLIBCXX_IOSTREAM_BUFSIZE
-	int "IO Stream Buffer Size"
-	default 32
-
-config UCLIBCXX_HAVE_LIBSUPCXX
-	bool "Have libsupc++ (required)"
-	default y
-	---help---
-		Select if your toolchain provides libsupc++.  This option is required
-		at present because the built-in libsupc++ support is incomplete.
-
-endif
 endif

--- a/lib/libxx/Makefile
+++ b/lib/libxx/Makefile
@@ -59,19 +59,14 @@ CSRCS =
 
 CXXSRCS  = libxx_cxapurevirtual.cxx libxx_eabi_atexit.cxx  libxx_cxa_atexit.cxx
 
-ifeq (,$(findstring y,$(CONFIG_UCLIBCXX) $(CONFIG_LIBCXX)))
+ifneq ($(CONFIG_LIBCXX),y)
 CXXSRCS += libxx_delete.cxx libxx_delete_sized.cxx libxx_deletea.cxx
 CXXSRCS += libxx_deletea_sized.cxx libxx_new.cxx libxx_newa.cxx
-CXXSRCS += libxx_stdthrow.cxx
+CXXSRCS += libxx_stdthrow.cxx libxx_cxa_guard.cxx
 else
-ifeq (,$(findstring y,$(CONFIG_UCLIBCXX_EXCEPTION) $(CONFIG_LIBCXX_EXCEPTION)))
+ifneq ($(CONFIG_LIBCXX_EXCEPTION),y)
 CXXSRCS += libxx_stdthrow.cxx
 endif
-endif
-
-# uClibc++ doesn't need this file
-
-ifneq ($(CONFIG_UCLIBCXX),y)
 CXXSRCS += libxx_cxa_guard.cxx
 endif
 
@@ -80,20 +75,7 @@ endif
 DEPPATH = --dep-path .
 VPATH = .
 
-# Include the uClibc++ Make.defs file if selected.  If it is included,
-# the uClibc++/Make.defs file will add its files to the source file list,
-# add its DEPPATH info, and will add the appropriate paths to the VPATH
-# variable
-#
-# Note that an error will occur if you select CONFIG_LIBXX_UCLIBCXX
-# without installing the uClibc++ package.  This is intentional to let
-# you know about the configuration problem.  Refer to misc/uClibc++/README.txt
-# for more information
-
-ifeq ($(CONFIG_UCLIBCXX),y)
-include uClibc++/Make.defs
-endif
-
+# Include the llvm libcxx Make.defs file if selected.
 ifeq ($(CONFIG_LIBCXX),y)
 include libcxx/Make.defs
 endif

--- a/os/include/.gitignore
+++ b/os/include/.gitignore
@@ -5,4 +5,3 @@
 /float.h
 /stdarg.h
 /features.h
-/uClibc++


### PR DESCRIPTION
uClibc++ configurations no longer required.
This patch removes these configurations from Kconfig
and Makefiles

This also updates all Make.defs to remove definitions/code under
uClibc++ configs.

Signed-off-by: Manohara HK <manohara.hk@samsung.com>