### PR TITLE
build/artik05x: support erasing ota partition through make command

### DIFF
--- a/build/configs/artik053/.flashSpec.xml
+++ b/build/configs/artik053/.flashSpec.xml
@@ -25,6 +25,7 @@
         <option desc="Flash Bootloader binaries">BL1 BL2</option>
         <option desc="Flash Firmware binaries">SSSFW WLANFW</option>
         <option desc="Flash ROMFS image">ROMFS</option>
+        <option desc="Erase OTA partition">ERASE_OTA</option>
         <option desc="Erase user file system">ERASE_USERFS</option>
         <option desc="Erase all of partitions">ERASE_ALL</option>
     </options>

--- a/build/configs/artik053s/.flashSpec.xml
+++ b/build/configs/artik053s/.flashSpec.xml
@@ -25,6 +25,7 @@
         <option desc="Flash Bootloader binaries">BL1 BL2</option>
         <option desc="Flash Firmware binaries">SSSFW WLANFW</option>
         <option desc="Flash ROMFS image">ROMFS</option>
+        <option desc="Erase OTA partition">ERASE_OTA</option>
         <option desc="Erase user file system">ERASE_USERFS</option>
         <option desc="Erase all of partitions">ERASE_ALL</option>
     </options>

--- a/build/configs/artik055s/.flashSpec.xml
+++ b/build/configs/artik055s/.flashSpec.xml
@@ -25,6 +25,7 @@
         <option desc="Flash Bootloader binaries">BL1 BL2</option>
         <option desc="Flash Firmware binaries">SSSFW WLANFW</option>
         <option desc="Flash ROMFS image">ROMFS</option>
+        <option desc="Erase OTA partition">ERASE_OTA</option>
         <option desc="Erase user file system">ERASE_USERFS</option>
         <option desc="Erase all of partitions">ERASE_ALL</option>
     </options>

--- a/build/configs/artik05x/artik05x_download.sh
+++ b/build/configs/artik05x/artik05x_download.sh
@@ -205,6 +205,9 @@ download()
 erase()
 {
 	case $optarg in
+		OTA|ota)
+			PART_NAME=ota
+			;;
 		USERFS|userfs)
 			PART_NAME=user
 			;;


### PR DESCRIPTION
Erasing ota partition is needed to support FOTA. This commit add
ERASE_OTA option on make command to do it.