### PR TITLE
Edit fix for CVE issues in wpa_supplicant

### DIFF
--- a/external/wpa_supplicant/Kconfig
+++ b/external/wpa_supplicant/Kconfig
@@ -73,9 +73,12 @@ config DRIVER_T20
 	default y
 	depends on SCSC_WLAN
 
-config DISABLE_EAP_FOR_SUPPLICANT
-	bool "Disable EAP for WPA supplicant"
-	default y
+config ENABLE_EAP_FOR_SUPPLICANT
+	bool
+	default n
+	---help---
+		Enable EAP support for the supplicant. This is disabled by default,
+		because of pending CVE issues in some affected files.
 endif
 
 endmenu # wpa_supplicant

--- a/external/wpa_supplicant/src/eap_peer/eap_pwd.c
+++ b/external/wpa_supplicant/src/eap_peer/eap_pwd.c
@@ -4,8 +4,16 @@
  *
  * This software may be distributed under the terms of the BSD license.
  * See README for more details.
+ *
+ * NOTE: This file has a potential CVE issue (CVE-2015-5315 and CVE-2015-5316)
+ * at lines 673 (eap_pwd_perform_confirm_exchange function), 790 and 813 (both under
+ * eap_pwd_process function). However, we have disabled this file for build, by
+ * setting a default value n for CONFIG_ENABLE_EAP_FOR_SUPPLICANT.
+ *
+ * If you choose to build this file, you are advised to set CONFIG_ENABLE_EAP_FOR_SUPPLICANT=y
+ * in your config, and also fix the CVE issues described above.
  */
-#ifndef CONFIG_DISABLE_EAP_FOR_SUPPLICANT
+#ifdef CONFIG_ENABLE_EAP_FOR_SUPPLICANT
 #include "includes.h"
 
 #include "common.h"

--- a/external/wpa_supplicant/src/eap_server/eap_server_pwd.c
+++ b/external/wpa_supplicant/src/eap_server/eap_server_pwd.c
@@ -4,8 +4,17 @@
  *
  * This software may be distributed under the terms of the BSD license.
  * See README for more details.
+ *
+ * NOTE: This file has a potential CVE issue (CVE-2015-5314)
+ * at lines 852 and 869 (eap_pwd_process function). However, we have
+ * disabled this file for build, by setting a
+ * default value n for CONFIG_ENABLE_EAP_FOR_SUPPLICANT.
+ *
+ * If you choose to build this file, you are advised to
+ * set CONFIG_ENABLE_EAP_FOR_SUPPLICANT=y in your config,
+ * and also fix the CVE issues described above.
  */
-#ifndef CONFIG_DISABLE_EAP_FOR_SUPPLICANT
+#ifdef CONFIG_ENABLE_EAP_FOR_SUPPLICANT
 #include "includes.h"
 
 #include "common.h"


### PR DESCRIPTION
Edit a fix for CVE issues (commit id: 23fa1c75c26aa0fb400c7e2df6345e63a4cc2825). In this pull request, we perform the following edits to the above fix.

1. Rename the Kconfig parameter, allowing a default value of n.
2. Fix correct usage of the parameter to disable build of the affected files.
3. Document the CVE issues at affected code, and suggest the developer to fix the CVE issues before using the code.