### PR TITLE
Add new methods, pause and resume, in I2S driver

### DIFF
--- a/os/include/tinyara/audio/i2s.h
+++ b/os/include/tinyara/audio/i2s.h
@@ -236,6 +236,8 @@
 
 /***********************************************************/
 #define I2S_STOP(d)		((d)->ops->i2s_stop(d))
+#define I2S_PAUSE(d)		((d)->ops->i2s_pause(d))
+#define I2S_RESUME(d)		((d)->ops->i2s_resume(d))
 /************************************************************/
 
 /****************************************************************************
@@ -268,8 +270,10 @@ struct i2s_ops_s {
 
 	CODE int (*i2s_err_cb_register)(FAR struct i2s_dev_s *dev, i2s_err_cb_t cb, FAR void *arg);
 
-	/* Generic stop method */
+	/* Generic methods */
 	CODE int (*i2s_stop)(FAR struct i2s_dev_s *dev);
+	CODE int (*i2s_pause)(FAR struct i2s_dev_s *dev);
+	CODE int (*i2s_resume)(FAR struct i2s_dev_s *dev);
 };
 
 /* I2S private data.  This structure only defines the initial fields of the


### PR DESCRIPTION
Add i2s_pause and i2s_resume methods for s5j_i2s driver.
These methods will be used to pause and resume i2s transfer
while trying to recover from xrun error during audio play / record.