### PR TITLE
 libc/spwan: modify checking logic of function arguments

### DIFF
--- a/lib/libc/spawn/lib_psa_getflags.c
+++ b/lib/libc/spawn/lib_psa_getflags.c
@@ -57,7 +57,7 @@
 #include <tinyara/config.h>
 
 #include <spawn.h>
-#include <assert.h>
+#include <errno.h>
 
 /****************************************************************************
  * Global Functions
@@ -82,7 +82,10 @@
 
 int posix_spawnattr_getflags(FAR const posix_spawnattr_t *attr, FAR short *flags)
 {
-	DEBUGASSERT(attr && flags);
+	if (!attr || !flags) {
+		return EINVAL;
+	}
+
 	*flags = (short)attr->flags;
 	return OK;
 }

--- a/lib/libc/spawn/lib_psa_getschedparam.c
+++ b/lib/libc/spawn/lib_psa_getschedparam.c
@@ -58,7 +58,7 @@
 
 #include <sched.h>
 #include <spawn.h>
-#include <assert.h>
+#include <errno.h>
 
 /****************************************************************************
  * Global Functions
@@ -84,7 +84,10 @@
 
 int posix_spawnattr_getschedparam(FAR const posix_spawnattr_t *attr, FAR struct sched_param *param)
 {
-	DEBUGASSERT(attr && param);
+	if (!attr || !param) {
+		return EINVAL;
+	}
+
 	param->sched_priority = attr->priority;
 	return OK;
 }

--- a/lib/libc/spawn/lib_psa_getschedpolicy.c
+++ b/lib/libc/spawn/lib_psa_getschedpolicy.c
@@ -57,7 +57,7 @@
 #include <tinyara/config.h>
 
 #include <spawn.h>
-#include <assert.h>
+#include <errno.h>
 
 /****************************************************************************
  * Global Functions
@@ -83,7 +83,10 @@
 
 int posix_spawnattr_getschedpolicy(FAR const posix_spawnattr_t *attr, FAR int *policy)
 {
-	DEBUGASSERT(attr && policy);
+	if (!attr || !policy) {
+		return EINVAL;
+	}
+
 	*policy = (int)attr->policy;
 	return OK;
 }

--- a/lib/libc/spawn/lib_psa_getsigmask.c
+++ b/lib/libc/spawn/lib_psa_getsigmask.c
@@ -56,11 +56,10 @@
 
 #include <tinyara/config.h>
 
+#ifndef CONFIG_DISABLE_SIGNALS
 #include <signal.h>
 #include <spawn.h>
-#include <assert.h>
-
-#ifndef CONFIG_DISABLE_SIGNALS
+#include <errno.h>
 
 /****************************************************************************
  * Global Functions
@@ -86,7 +85,10 @@
 
 int posix_spawnattr_getsigmask(FAR const posix_spawnattr_t *attr, FAR sigset_t *sigmask)
 {
-	DEBUGASSERT(attr && sigmask);
+	if (!attr || !sigmask) {
+		return EINVAL;
+	}
+
 	*sigmask = attr->sigmask;
 	return OK;
 }

--- a/lib/libc/spawn/lib_psa_getstacksize.c
+++ b/lib/libc/spawn/lib_psa_getstacksize.c
@@ -56,11 +56,10 @@
 
 #include <tinyara/config.h>
 
-#include <sched.h>
-#include <spawn.h>
-#include <assert.h>
-
 #ifndef CONFIG_BUILD_KERNEL
+#include <sys/types.h>
+#include <spawn.h>
+#include <errno.h>
 
 /****************************************************************************
  * Public Functions
@@ -86,7 +85,10 @@
 
 int task_spawnattr_getstacksize(FAR const posix_spawnattr_t *attr, size_t *stacksize)
 {
-	DEBUGASSERT(attr && stacksize);
+	if (!attr || !stacksize) {
+		return EINVAL;
+	}
+
 	*stacksize = attr->stacksize;
 	return OK;
 }

--- a/lib/libc/spawn/lib_psa_init.c
+++ b/lib/libc/spawn/lib_psa_init.c
@@ -58,7 +58,6 @@
 
 #include <sched.h>
 #include <spawn.h>
-#include <assert.h>
 #include <errno.h>
 
 /****************************************************************************
@@ -91,9 +90,7 @@ int posix_spawnattr_init(posix_spawnattr_t *attr)
 	struct sched_param param;
 	int ret;
 
-	DEBUGASSERT(attr);
-
-	if (attr == NULL) {
+	if (!attr) {
 		return EINVAL;
 	}
 

--- a/lib/libc/spawn/lib_psa_setflags.c
+++ b/lib/libc/spawn/lib_psa_setflags.c
@@ -57,7 +57,7 @@
 #include <tinyara/config.h>
 
 #include <spawn.h>
-#include <assert.h>
+#include <errno.h>
 
 /****************************************************************************
  * Global Functions
@@ -82,7 +82,10 @@
 
 int posix_spawnattr_setflags(FAR posix_spawnattr_t *attr, short flags)
 {
-	DEBUGASSERT(attr && (flags & ~0xff) == 0);
+	if (!attr || !(flags & POSIX_SPAWN_ALLFLAG)) {
+		return EINVAL;
+	}
+
 	attr->flags = (uint8_t)flags;
 	return OK;
 }

--- a/lib/libc/spawn/lib_psa_setschedparam.c
+++ b/lib/libc/spawn/lib_psa_setschedparam.c
@@ -56,9 +56,10 @@
 
 #include <tinyara/config.h>
 
+#include <sys/types.h>
 #include <sched.h>
 #include <spawn.h>
-#include <assert.h>
+#include <errno.h>
 
 /****************************************************************************
  * Global Functions
@@ -84,7 +85,10 @@
 
 int posix_spawnattr_setschedparam(FAR posix_spawnattr_t *attr, FAR const struct sched_param *param)
 {
-	DEBUGASSERT(attr && param && (unsigned)param->sched_priority <= 0xff);
+	if (!attr || !param || (unsigned)param->sched_priority > SCHED_PRIORITY_MAX) {
+		return EINVAL;
+	}
+
 	attr->priority = (uint8_t)param->sched_priority;
 	return OK;
 }

--- a/lib/libc/spawn/lib_psa_setschedpolicy.c
+++ b/lib/libc/spawn/lib_psa_setschedpolicy.c
@@ -57,7 +57,8 @@
 #include <tinyara/config.h>
 
 #include <spawn.h>
-#include <assert.h>
+#include <sched.h>
+#include <errno.h>
 
 /****************************************************************************
  * Global Functions
@@ -83,7 +84,10 @@
 
 int posix_spawnattr_setschedpolicy(FAR posix_spawnattr_t *attr, int policy)
 {
-	DEBUGASSERT(attr && (policy == SCHED_FIFO || policy == SCHED_RR));
+	if (!attr || (policy != SCHED_FIFO && policy != SCHED_RR)) {
+		return EINVAL;
+	}
+
 	attr->policy = (uint8_t)policy;
 	return OK;
 }

--- a/lib/libc/spawn/lib_psa_setsigmask.c
+++ b/lib/libc/spawn/lib_psa_setsigmask.c
@@ -56,11 +56,10 @@
 
 #include <tinyara/config.h>
 
+#ifndef CONFIG_DISABLE_SIGNALS
 #include <signal.h>
 #include <spawn.h>
-#include <assert.h>
-
-#ifndef CONFIG_DISABLE_SIGNALS
+#include <errno.h>
 
 /****************************************************************************
  * Global Functions
@@ -86,7 +85,10 @@
 
 int posix_spawnattr_setsigmask(FAR posix_spawnattr_t *attr, FAR const sigset_t *sigmask)
 {
-	DEBUGASSERT(attr && sigmask);
+	if (!attr || !sigmask) {
+		return EINVAL;
+	}
+
 	attr->sigmask = *sigmask;
 	return OK;
 }

--- a/lib/libc/spawn/lib_psa_setstacksize.c
+++ b/lib/libc/spawn/lib_psa_setstacksize.c
@@ -56,11 +56,10 @@
 
 #include <tinyara/config.h>
 
-#include <sched.h>
-#include <spawn.h>
-#include <assert.h>
-
 #ifndef CONFIG_BUILD_KERNEL
+#include <sys/types.h>
+#include <spawn.h>
+#include <errno.h>
 
 /****************************************************************************
  * Public Functions
@@ -86,7 +85,10 @@
 
 int task_spawnattr_setstacksize(FAR posix_spawnattr_t *attr, size_t stacksize)
 {
-	DEBUGASSERT(attr);
+	if (!attr) {
+		return EINVAL;
+	}
+
 	attr->stacksize = stacksize;
 	return OK;
 }

--- a/lib/libc/spawn/lib_psfa_addclose.c
+++ b/lib/libc/spawn/lib_psfa_addclose.c
@@ -58,7 +58,6 @@
 
 #include <stdlib.h>
 #include <spawn.h>
-#include <assert.h>
 #include <errno.h>
 
 #include <tinyara/spawn.h>
@@ -94,7 +93,12 @@ int posix_spawn_file_actions_addclose(FAR posix_spawn_file_actions_t *file_actio
 {
 	FAR struct spawn_close_file_action_s *entry;
 
-	DEBUGASSERT(file_actions && fd >= 0 && fd < CONFIG_NFILE_DESCRIPTORS);
+	if (!file_actions) {
+		return EINVAL;
+	}
+	if (fd < 0 || fd >= CONFIG_NFILE_DESCRIPTORS) {
+		return EBADF;
+	}
 
 	/* Allocate the action list entry */
 

--- a/lib/libc/spawn/lib_psfa_adddup2.c
+++ b/lib/libc/spawn/lib_psfa_adddup2.c
@@ -58,7 +58,6 @@
 
 #include <stdlib.h>
 #include <spawn.h>
-#include <assert.h>
 #include <errno.h>
 
 #include <tinyara/spawn.h>
@@ -95,7 +94,12 @@ int posix_spawn_file_actions_adddup2(FAR posix_spawn_file_actions_t *file_action
 {
 	FAR struct spawn_dup2_file_action_s *entry;
 
-	DEBUGASSERT(file_actions && fd1 >= 0 && fd1 < CONFIG_NFILE_DESCRIPTORS && fd2 >= 0 && fd2 < CONFIG_NFILE_DESCRIPTORS);
+	if (!file_actions) {
+		return EINVAL;
+	}
+	if (fd1 < 0 || fd1 >= CONFIG_NFILE_DESCRIPTORS || fd2 < 0 || fd2 >= CONFIG_NFILE_DESCRIPTORS) {
+		return EBADF;
+	}
 
 	/* Allocate the action list entry */
 

--- a/lib/libc/spawn/lib_psfa_addopen.c
+++ b/lib/libc/spawn/lib_psfa_addopen.c
@@ -59,7 +59,6 @@
 #include <stdlib.h>
 #include <string.h>
 #include <spawn.h>
-#include <assert.h>
 #include <errno.h>
 
 #include <tinyara/spawn.h>
@@ -102,7 +101,12 @@ int posix_spawn_file_actions_addopen(FAR posix_spawn_file_actions_t *file_action
 	size_t len;
 	size_t alloc;
 
-	DEBUGASSERT(file_actions && path && fd >= 0 && fd < CONFIG_NFILE_DESCRIPTORS);
+	if (!file_actions || !path) {
+		return EINVAL;
+	}
+	if (fd < 0 || fd >= CONFIG_NFILE_DESCRIPTORS) {
+		return EBADF;
+	}
 
 	/* Get the size of the action including storage for the path plus its NUL
 	 * terminating character.

--- a/lib/libc/spawn/lib_psfa_destroy.c
+++ b/lib/libc/spawn/lib_psfa_destroy.c
@@ -58,7 +58,7 @@
 
 #include <stdlib.h>
 #include <spawn.h>
-#include <assert.h>
+#include <errno.h>
 
 #include <tinyara/spawn.h>
 
@@ -94,7 +94,9 @@ int posix_spawn_file_actions_destroy(FAR posix_spawn_file_actions_t *file_action
 	FAR struct spawn_general_file_action_s *curr;
 	FAR struct spawn_general_file_action_s *next;
 
-	DEBUGASSERT(file_actions);
+	if (!file_actions) {
+		return EINVAL;
+	}
 
 	/* Destroy each file action, one at a time */
 

--- a/os/include/spawn.h
+++ b/os/include/spawn.h
@@ -94,6 +94,7 @@
 #define POSIX_SPAWN_SETSCHEDULER  (1 << 3)	/* 1: Set task's scheduler policy */
 #define POSIX_SPAWN_SETSIGDEF     (1 << 4)	/* 1: Set default signal actions */
 #define POSIX_SPAWN_SETSIGMASK    (1 << 5)	/* 1: Set sigmask */
+#define POSIX_SPAWN_ALLFLAG       (POSIX_SPAWN_RESETIDS | POSIX_SPAWN_SETPGROUP | POSIX_SPAWN_SETSCHEDPARAM | POSIX_SPAWN_SETSCHEDULER | POSIX_SPAWN_SETSIGDEF | POSIX_SPAWN_SETSIGMASK)
 
 /****************************************************************************
  * Type Definitions


### PR DESCRIPTION
Nuttx checks them with DEBUGASSERT. But that is different with POSIX
standard and we don't want to make a crash even if it has invalid arguments.
This commit changes them returning errno values without crash.