### PR TITLE
testcase/wifi-manager: fix callback function definition

### DIFF
--- a/apps/examples/testcase/ta_tc/wifi_manager/utc/utc_wifi_manager_main.c
+++ b/apps/examples/testcase/ta_tc/wifi_manager/utc/utc_wifi_manager_main.c
@@ -40,7 +40,7 @@ do {										\
 	pthread_cond_wait(&g_wifi_manager_test_cond, &g_wifi_manager_test_mutex);	\
 	pthread_mutex_unlock(&g_wifi_manager_test_mutex);			\
 } while (0)
-void wifi_sta_connected(void);		// in station mode, connected to ap
+void wifi_sta_connected(wifi_manager_result_e result);		// in station mode, connected to ap
 void wifi_sta_disconnected(void);	// in station mode, disconnected from ap
 void wifi_softap_sta_joined(void);	// in softap mode, a station joined
 void wifi_softap_sta_left(void);		// in softap mode, a station left
@@ -62,9 +62,9 @@ static wifi_manager_cb_s wifi_null_callbacks = {
 	NULL,	// in station mode, this callback function is called when scanning ap is done.
 };
 
-void wifi_sta_connected(void)
+void wifi_sta_connected(wifi_manager_result_e result)
 {
-	printf("wifi_sta_connected: send signal!!! \n");
+	printf("wifi_sta_connected: send signal!!!(%d) \n", result);
 	WIFITEST_SIGNAL;
 }
 

--- a/framework/src/wifi_manager/wifi_manager.c
+++ b/framework/src/wifi_manager/wifi_manager.c
@@ -980,6 +980,7 @@ wifi_manager_result_e _handler_on_reconnect_state(_wifimgr_msg_s *msg)
 		nvdbg("[WM] reconnect\n");
 	} else if (msg->event == EVT_STA_CONNECTED) {
 		nvdbg("[WM] connected\n");
+		_handle_user_cb(CB_STA_CONNECTED, NULL);
 		WIFIMGR_SET_STATE(WIFIMGR_STA_CONNECTED);
 	}
 #endif /* WIFIDRIVER_SUPPORT_AUTOCONNECT*/


### PR DESCRIPTION
As definition of wifi-manager's callback is changed, utc need to be changed in UTC.