### PR TITLE
framework/st_things: Add canceling logic for trying reconnect the cloud.

### DIFF
--- a/framework/src/st_things/things_stack/things_stack.c
+++ b/framework/src/st_things/things_stack/things_stack.c
@@ -217,7 +217,7 @@ static void sync_time_from_ntp(int guarantee_secs)
 				} else if ((init_tp.tv_sec + guarantee_secs) < sync_tp.tv_sec) {
 					break;
 				}
-				usleep(100000);				
+				usleep(100000);
 			}
 			if (time_sync) {
 				THINGS_LOG(THINGS_INFO, TAG, "ntpc_time sync done");
@@ -264,6 +264,7 @@ void things_wifi_sta_connected(wifi_manager_result_e res)
 void things_wifi_sta_disconnected(void)
 {
 	THINGS_LOG_D(THINGS_INFO, TAG, "T%d --> %s", getpid(), __FUNCTION__);
+	things_wifi_changed_call_func(0, NULL, NULL);
 }
 
 void things_wifi_soft_ap_sta_joined(void)


### PR DESCRIPTION
The device had tried to connect when it is cut off from WiFi
and It occurred timed-out.

So Now, It doesn't try to connect to sign-up/in when disconnected the Network
and It will try to Sign-Up/In when WiFi are turned up.