### PR TITLE
kernel/timer: add a logic to check timer is valid or not

### DIFF
--- a/os/kernel/timer/timer.h
+++ b/os/kernel/timer/timer.h
@@ -69,7 +69,12 @@
  * Definitions
  ********************************************************************************/
 
-#define PT_FLAGS_PREALLOCATED 0x01	/* Timer comes from a pool of preallocated timers */
+/* PT_FLAGS_* definitions */
+#define PT_FLAGS_ALLOC_MASK   (0)
+#define PT_FLAGS_USE_MASK     (1)
+
+#define PT_FLAGS_PREALLOCATED (1 << PT_FLAGS_ALLOC_MASK)    /* Timer comes from a pool of preallocated timers */
+#define PT_FLAGS_INUSE        (1 << PT_FLAGS_USE_MASK)      /* Timer is in use */
 
 /********************************************************************************
  * Public Types
@@ -89,6 +94,8 @@ struct posix_timer_s {
 	WDOG_ID pt_wdog;			/* The watchdog that provides the timing */
 	union sigval pt_value;		/* Data passed with notification */
 };
+
+#define PT_ISVALID(x)         (((x) != NULL) && (((struct posix_timer_s *)(x))->pt_flags & PT_FLAGS_INUSE))
 
 /********************************************************************************
  * Public Data

--- a/os/kernel/timer/timer_create.c
+++ b/os/kernel/timer/timer_create.c
@@ -122,6 +122,10 @@ static struct posix_timer_s *timer_allocate(void)
 	/* If we have a timer, then put it into the allocated timer list */
 
 	if (ret) {
+		/* Mark this timer is in use */
+
+		pt_flags |= PT_FLAGS_INUSE;
+
 		/* Initialize the timer structure */
 
 		memset(ret, 0, sizeof(struct posix_timer_s));

--- a/os/kernel/timer/timer_gettime.c
+++ b/os/kernel/timer/timer_gettime.c
@@ -120,7 +120,12 @@ int timer_gettime(timer_t timerid, FAR struct itimerspec *value)
 	FAR struct posix_timer_s *timer = (FAR struct posix_timer_s *)timerid;
 	int ticks;
 
-	if (!timer || !value) {
+	if (!PT_ISVALID(timerid)) {
+		set_errno(EINVAL);
+		return ERROR;
+	}
+
+	if (!value) {
 		set_errno(EINVAL);
 		return ERROR;
 	}

--- a/os/kernel/timer/timer_release.c
+++ b/os/kernel/timer/timer_release.c
@@ -114,6 +114,10 @@ static inline void timer_free(struct posix_timer_s *timer)
 		irqrestore(flags);
 		sched_kfree(timer);
 	}
+
+	/* Mark this timer is not in use */
+
+	timer->pt_flags &= ~PT_FLAGS_INUSE;
 }
 
 /********************************************************************************

--- a/os/kernel/timer/timer_settime.c
+++ b/os/kernel/timer/timer_settime.c
@@ -313,7 +313,12 @@ int timer_settime(timer_t timerid, int flags, FAR const struct itimerspec *value
 
 	/* Some sanity checks */
 
-	if (!timer || !value) {
+	if (!PT_ISVALID(timerid)) {
+		set_errno(EINVAL);
+		return ERROR;
+	}
+
+	if (!value) {
 		set_errno(EINVAL);
 		return ERROR;
 	}


### PR DESCRIPTION
When timer is created or released, they update pt_flags
inside posix_timer_s struct. And set and get timer functions check
that flag and return appropriatary value.