### PR TITLE
code refactoring

### DIFF
--- a/apps/shell/Kconfig
+++ b/apps/shell/Kconfig
@@ -40,5 +40,13 @@ config TASH_CMDTASK_PRIORITY
 	default 100
 	---help---
 		The priority set for TASH command task
+
+config TASH_SCRIPT
+	bool "enable shell script"
+	default n
+	depends on !DISABLE_ENVIRON
+	---help---
+		This suppors parsing and executing shell script.
+		See "sh" on TASH help command.
 endif
 endmenu

--- a/apps/shell/Kconfig
+++ b/apps/shell/Kconfig
@@ -1,8 +1,13 @@
+#
+# For a description of the syntax of this configuration file,
+# see kconfig-language at https://www.kernel.org/doc/Documentation/kbuild/kconfig-language.txt
+#
 
 menu "Shell"
 config TASH
 	bool "Enable shell"
 	default y
+	depends on NFILE_DESCRIPTORS != 0
 
 if TASH
 config TASH_MAX_COMMANDS

--- a/apps/shell/Makefile
+++ b/apps/shell/Makefile
@@ -26,7 +26,7 @@ STACKSIZE = 2048
 
 ASRCS =
 CSRCS = tash_command.c tash_init.c
-ifneq ($(CONFIG_DISABLE_ENVIRON),y)
+ifeq ($(CONFIG_TASH_SCRIPT),y)
 CSRCS += tash_script.c
 endif
 ifneq ($(CONFIG_DISABLE_SIGNALS),y)

--- a/apps/shell/tash_command.c
+++ b/apps/shell/tash_command.c
@@ -97,7 +97,7 @@ static struct tash_cmd_info_s tash_cmds_info = {PTHREAD_MUTEX_INITIALIZER};
 const static tash_cmdlist_t tash_basic_cmds[] = {
 	{"exit",  tash_exit,   TASH_EXECMD_SYNC},
 	{"help",  tash_help,   TASH_EXECMD_SYNC},
-#ifndef CONFIG_DISABLE_ENVIRON
+#ifdef CONFIG_TASH_SCRIPT
 	{"sh",    tash_script, TASH_EXECMD_SYNC},
 #endif
 #ifndef CONFIG_DISABLE_SIGNALS

--- a/apps/shell/tash_internal.h
+++ b/apps/shell/tash_internal.h
@@ -57,7 +57,7 @@ extern void tash_register_basic_cmds(void);
 extern int tash_execute_cmdline(char *buff);
 extern int tash_execute_cmd(char **args, int argc);
 extern int tash_init(void);
-#ifndef CONFIG_DISABLE_ENVIRON
+#ifdef CONFIG_TASH_SCRIPT
 extern int tash_script(int argc, char **args);
 #endif
 #ifndef CONFIG_DISABLE_SIGNALS

--- a/apps/system/cle/Kconfig
+++ b/apps/system/cle/Kconfig
@@ -4,7 +4,7 @@
 #
 
 config SYSTEM_CLE
-	bool "Tiny VI work-alike command line editor"
+	bool "EMACS-like Command Line Editor"
 	default n
 	---help---
 		Enable support for TinyAra tiny EMACS-like command line editor.

--- a/apps/system/cle/Kconfig
+++ b/apps/system/cle/Kconfig
@@ -6,6 +6,7 @@
 config SYSTEM_CLE
 	bool "EMACS-like Command Line Editor"
 	default n
+	depends on NFILE_STREAMS != 0
 	---help---
 		Enable support for TinyAra tiny EMACS-like command line editor.
 

--- a/apps/system/poweroff/Kconfig
+++ b/apps/system/poweroff/Kconfig
@@ -6,6 +6,7 @@
 config SYSTEM_POWEROFF
 	bool "Power-Off command"
 	default n
+	depends on BOARDCTL_POWEROFF
 	---help---
 		Enable support for the TASH poweroff command.  NOTE: This option
 		provides the TASH power-off command only.  It requires board-specific

--- a/apps/system/utils/Kconfig
+++ b/apps/system/utils/Kconfig
@@ -12,7 +12,7 @@ config KERNEL_CMDS
 config FS_CMDS
 	bool "FS shell commands"
 	default y
-	depends on TASH
+	depends on TASH && (NFILE_DESCRIPTORS != 0)
 	---help---
 		Disable File System command in TASH.
 		Command including ls, cd, cat, mount, and so on.

--- a/apps/system/vi/Kconfig
+++ b/apps/system/vi/Kconfig
@@ -6,6 +6,7 @@
 config SYSTEM_VI
 	bool "Tiny VI work-alike text editor"
 	default n
+	depends on (NFILE_DESCRIPTORS != 0) && (NFILE_STREAMS != 0)
 	---help---
 		Enable support for TinyAra tiny VI work-alike editor.
 

--- a/framework/src/dm/Make.defs
+++ b/framework/src/dm/Make.defs
@@ -21,7 +21,7 @@ ifeq ($(CONFIG_LWM2M_CLIENT_MODE),y)
 CSRCS += dm_lwm2m.c
 endif
 CSRCS += dm_common_interface.c
-ifeq ($(CONFIG_ARCH_CHIP_S5JT200),y)
+ifeq ($(CONFIG_NETUTILS_WIFI),y)
 CSRCS += s5j_dm_connectivity.c
 else
 CSRCS += dm_connectivity.c

--- a/framework/src/dm/arch/sidk_s5jt200/s5j_dm_connectivity.c
+++ b/framework/src/dm/arch/sidk_s5jt200/s5j_dm_connectivity.c
@@ -200,7 +200,7 @@ int dm_conn_get_address(char *ipAddr)
 	ifcfg.ifc_buf = NULL;
 	ifcfg.ifc_len = sizeof(struct ifreq) * numreqs;
 	ifcfg.ifc_buf = malloc(ifcfg.ifc_len);
-	if (ioctl(fd, SIOCGIFCONF, (void *)&ifcfg) < 0) {
+	if (ioctl(fd, SIOCGIFCONF, (unsigned long)&ifcfg) < 0) {
 		perror("SIOCGIFCONF ");
 		goto DONE;
 	}
@@ -243,7 +243,7 @@ int dm_conn_get_interface(char *interface)
 	ifcfg.ifc_buf = NULL;
 	ifcfg.ifc_len = sizeof(struct ifreq) * numreqs;
 	ifcfg.ifc_buf = malloc(ifcfg.ifc_len);
-	if (ioctl(fd, SIOCGIFCONF, (void *)&ifcfg) < 0) {
+	if (ioctl(fd, SIOCGIFCONF, (unsigned long)&ifcfg) < 0) {
 		perror("SIOCGIFCONF ");
 		goto DONE;
 	}

--- a/os/arch/arm/src/artik05x/Kconfig
+++ b/os/arch/arm/src/artik05x/Kconfig
@@ -46,6 +46,7 @@ config ARTIK05X_FLASH_PART
 	select MTD_PARTITION
 	select MTD_PROGMEM
 	depends on S5J_SFLASH
+	depends on NFILE_DESCRIPTORS != 0
 	---help---
 		Enables creation of partitions on the FLASH
 

--- a/os/arch/arm/src/artik05x/src/artik05x_tash.c
+++ b/os/arch/arm/src/artik05x/src/artik05x_tash.c
@@ -266,7 +266,7 @@ static void scsc_wpa_ctrl_iface_init(void)
 int board_app_initialize(void)
 {
 	int ret;
-#if defined(CONFIG_RAMMTD) && defined(CONFIG_FS_SMARTFS)
+#if defined(CONFIG_ARTIK05X_AUTOMOUNT) && defined(CONFIG_RAMMTD) && defined(CONFIG_FS_SMARTFS)
 	int bufsize = CONFIG_RAMMTD_ERASESIZE * CONFIG_ARTIK05X_RAMMTD_NEBLOCKS;
 	static uint8_t *rambuf;
 	struct mtd_dev_s *mtd;
@@ -274,6 +274,7 @@ int board_app_initialize(void)
 
 	artik05x_configure_partitions();
 
+#ifdef CONFIG_ARTIK05X_AUTOMOUNT
 #ifdef CONFIG_ARTIK05X_AUTOMOUNT_USERFS
 	/* Initialize and mount user partition (if we have) */
 #ifdef CONFIG_SMARTFS_MULTI_ROOT_DIRS
@@ -368,6 +369,7 @@ int board_app_initialize(void)
 		}
 	}
 #endif /* CONFIG_RAMMTD */
+#endif /* CONFIG_ARTIK05X_AUTOMOUNT */
 
 #if defined(CONFIG_RTC_DRIVER)
 	{

--- a/os/arch/arm/src/sidk_s5jt200/Kconfig
+++ b/os/arch/arm/src/sidk_s5jt200/Kconfig
@@ -70,6 +70,7 @@ config SIDK_S5JT200_FLASH_PART
 	select MTD_PARTITION
 	select MTD_PROGMEM
 	depends on S5J_SFLASH
+	depends on NFILE_DESCRIPTORS != 0
 	---help---
 		Enables creation of partitions on the FLASH
 

--- a/os/arch/arm/src/sidk_s5jt200/src/s5jt200_tash.c
+++ b/os/arch/arm/src/sidk_s5jt200/src/s5jt200_tash.c
@@ -283,6 +283,7 @@ int ee_test_main(int argc, char **args);
 int board_app_initialize(void)
 {
 	int ret;
+#ifdef CONFIG_SIDK_S5JT200_AUTOMOUNT
 #if defined(CONFIG_RAMMTD) && defined(CONFIG_FS_SMARTFS)
 	int bufsize = CONFIG_RAMMTD_ERASESIZE * CONFIG_SIDK_S5JT200_RAMMTD_NEBLOCKS;
 	static uint8_t *rambuf;
@@ -291,9 +292,11 @@ int board_app_initialize(void)
 #if defined(CONFIG_FS_ROMFS)
 	char rommtd_devname[16];
 #endif
+#endif /* CONFIG_SIDK_S5JT200_AUTOMOUNT */
 
 	sidk_s5jt200_configure_partitions();
 
+#ifdef CONFIG_SIDK_S5JT200_AUTOMOUNT
 #if defined(CONFIG_SIDK_S5JT200_AUTOMOUNT_ROMFS)
 	if (rommtd_device_exist) {
 		snprintf(rommtd_devname, 16, "/dev/mtdblock%d", rommtd_partno);
@@ -388,6 +391,7 @@ int board_app_initialize(void)
 		}
 	}
 #endif /* CONFIG_RAMMTD */
+#endif /* CONFIG_SIDK_S5JT200_AUTOMOUNT */
 
 #ifdef CONFIG_S5J_I2C
 	s5j_i2c_register(0);

--- a/os/drivers/Kconfig
+++ b/os/drivers/Kconfig
@@ -223,6 +223,7 @@ menuconfig BCH
 menuconfig RTC
 	bool "RTC Driver Support"
 	default n
+	depends on NFILE_DESCRIPTORS != 0
 	---help---
 		This selection enables configuration of a real time clock (RTCdriver.
 		See include/tinyara/rtc.h for further watchdog timer driver information.

--- a/os/include/stdio.h
+++ b/os/include/stdio.h
@@ -108,10 +108,15 @@
 #define EOF        (-1)
 
 /* The first three _iob entries are reserved for standard I/O */
-
+#if CONFIG_NFILE_DESCRIPTORS > 0 && CONFIG_NFILE_STREAMS > 0
 #define stdin  (&sched_getstreams()->sl_streams[0])
 #define stdout (&sched_getstreams()->sl_streams[1])
 #define stderr (&sched_getstreams()->sl_streams[2])
+#else
+#define stdin  (NULL)
+#define stdout (NULL)
+#define stderr (NULL)
+#endif
 
 /* These APIs are not implemented and/or can be synthesized from
  * supported APIs.


### PR DESCRIPTION
1. Some module which uses file operation APIs like open, read, write and so on make a dependancy with NFILE_DESCRIPTORS to prevent compilation and linking errors.
2. TASH adds new config, TASH_SCRIPT to disable script functionality.