### PR TITLE
arm : fix stack memory base alignment

### DIFF
--- a/os/arch/arm/src/common/up_createstack.c
+++ b/os/arch/arm/src/common/up_createstack.c
@@ -177,12 +177,12 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
 		/* Use the kernel allocator if this is a kernel thread */
 
 		if (ttype == TCB_FLAG_TTYPE_KERNEL) {
-			tcb->stack_alloc_ptr = (uint32_t *)kmm_memalign(stack_size, stack_size);
+			tcb->stack_alloc_ptr = (uint32_t *)kmm_malloc(stack_size);
 		} else
 #endif
 		{
 			/* Use the user-space allocator if this is a task or pthread */
-			tcb->stack_alloc_ptr = (uint32_t *)kumm_memalign(stack_size, stack_size);
+			tcb->stack_alloc_ptr = (uint32_t *)kumm_malloc(stack_size);
 		}
 
 #ifdef CONFIG_DEBUG


### PR DESCRIPTION
Currently stack base is aligned to the stack size requested which causes more
fragmentation.

stack base is not required to be aligned, only stack top needs to be
aligned to max 8 bytes in case of armv7 which is already done.

Hence this patch removes aligning stack base during stack allocation from heap

Signed-off-by: Manohara HK <manohara.hk@samsung.com>