### PR TITLE
external/iotjs: get build options, target-arch and board from Kconfig

### DIFF
--- a/external/Makefile
+++ b/external/Makefile
@@ -180,8 +180,8 @@ endif
 
 iotjs_build:
 ifeq ($(CONFIG_ENABLE_IOTJS),y)
-	python $(IOTJS_ROOT_DIR)/tools/build.py --target-arch=arm --target-os=tizenrt \
-	--sysroot=../os --target-board=artik05x --jerry-heaplimit=$(CONFIG_IOTJS_JERRY_HEAP) \
+	python $(IOTJS_ROOT_DIR)/tools/build.py --target-arch=$(CONFIG_ARCH) --target-os=tizenrt \
+	--sysroot=$(TOPDIR) --target-board=$(CONFIG_ARCH_BOARD) --jerry-heaplimit=$(CONFIG_IOTJS_JERRY_HEAP) \
 	--buildtype=$(IOTJS_BUILDTYPE) --no-init-submodule $(IOTJS_BUILD_OPTION)
 endif
 


### PR DESCRIPTION
When we try to build IoTjs, we should set --target-arch and --target-board
options on Makefile. They are fixed to arm and artik05x but they cause
difficult to find and wrong operation on IoTjs.
When TizenRT is built, CONFIG_ARCH and CONFIG_ARCH_BOARD are set and
they shows the information of selected board. User doesn't need to
set them in iotjs again.
This commit makes iotjs using those configurations.