### PR TITLE
sem: add a flag to show initialization and check it on sem APIs

### DIFF
--- a/lib/libc/semaphore/sem_getprotocol.c
+++ b/lib/libc/semaphore/sem_getprotocol.c
@@ -57,7 +57,7 @@
 #include <tinyara/config.h>
 
 #include <sys/types.h>
-#include <assert.h>
+#include <errno.h>
 
 #include <tinyara/semaphore.h>
 
@@ -85,7 +85,10 @@
 
 int sem_getprotocol(FAR sem_t *sem, FAR int *protocol)
 {
-	DEBUGASSERT(sem != NULL && protocol != NULL);
+	if ((sem == NULL) || (protocol == NULL) || ((sem->flags & FLAGS_INITIALIZED) == 0)) {
+		set_errno(EINVAL);
+		return ERROR;
+	}
 
 #ifdef CONFIG_PRIORITY_INHERITANCE
 	if ((sem->flags & PRIOINHERIT_FLAGS_DISABLE) != 0) {

--- a/lib/libc/semaphore/sem_getvalue.c
+++ b/lib/libc/semaphore/sem_getvalue.c
@@ -112,7 +112,7 @@
 
 int sem_getvalue(FAR sem_t *sem, FAR int *sval)
 {
-	if (sem && sval) {
+	if (sem && sval && ((sem->flags & FLAGS_INITIALIZED) != 0)) {
 		*sval = sem->semcount;
 		return OK;
 	} else {

--- a/lib/libc/semaphore/sem_init.c
+++ b/lib/libc/semaphore/sem_init.c
@@ -108,10 +108,12 @@ int sem_init(FAR sem_t *sem, int pshared, unsigned int value)
 		save_semaphore_history(sem, (void *)NULL, SEM_INIT);
 #endif
 
+		sem->flags = FLAGS_INITIALIZED;
+
 		/* Initialize to support priority inheritance */
 
 #ifdef CONFIG_PRIORITY_INHERITANCE
-		sem->flags = 0;
+		sem->flags &= ~(PRIOINHERIT_FLAGS_DISABLE);
 #if CONFIG_SEM_PREALLOCHOLDERS > 0
 		sem->hhead = NULL;
 #else

--- a/lib/libc/semaphore/sem_setprotocol.c
+++ b/lib/libc/semaphore/sem_setprotocol.c
@@ -56,7 +56,6 @@
 
 #include <tinyara/config.h>
 
-#include <assert.h>
 #include <errno.h>
 
 #include <tinyara/semaphore.h>
@@ -105,22 +104,22 @@
 
 int sem_setprotocol(FAR sem_t *sem, int protocol)
 {
-	int errcode;
+	int errcode = EINVAL;
 
-	DEBUGASSERT(sem != NULL);
+	if ((sem != NULL) && ((sem->flags & FLAGS_INITIALIZED) != 0)) {
+		switch (protocol) {
+		case SEM_PRIO_NONE:
+			return OK;
 
-	switch (protocol) {
-	case SEM_PRIO_NONE:
-		return OK;
+		case SEM_PRIO_INHERIT:
+		case SEM_PRIO_PROTECT:
+			errcode = ENOSYS;
+			break;
 
-	case SEM_PRIO_INHERIT:
-	case SEM_PRIO_PROTECT:
-		errcode = ENOSYS;
-		break;
-
-	default:
-		errcode = EINVAL;
-		break;
+		default:
+			errcode = EINVAL;
+			break;
+		}
 	}
 
 	set_errno(errcode);

--- a/os/include/semaphore.h
+++ b/os/include/semaphore.h
@@ -78,7 +78,7 @@
 
 #define PRIOINHERIT_FLAGS_DISABLE (1 << 0) /* Bit 0: Priority inheritance
 					    * is disabled for this semaphore */
-
+#define FLAGS_INITIALIZED         (1 << 1) /* Bit 1: This semaphore initialized */
 /****************************************************************************
  * Public Type Declarations
  ****************************************************************************/
@@ -117,8 +117,8 @@ struct sem_s {
 	 * tasks hold references to the semaphore.
 	 */
 
+	uint8_t flags;			/* See definitions for the struct sem_s flags */
 #ifdef CONFIG_PRIORITY_INHERITANCE
-	uint8_t flags;			/* See PRIOINHERIT_FLAGS_* definitions */
 #if CONFIG_SEM_PREALLOCHOLDERS > 0
 	FAR struct semholder_s *hhead;	/* List of holders of semaphore counts */
 #else

--- a/os/kernel/semaphore/sem_destroy.c
+++ b/os/kernel/semaphore/sem_destroy.c
@@ -119,6 +119,12 @@ int sem_destroy(FAR sem_t *sem)
 	/* Assure a valid semaphore is specified */
 
 	if (sem) {
+		/* Already destroyed? */
+
+		if ((sem->flags & FLAGS_INITIALIZED) == 0) {
+			return OK;
+		}
+
 		/* There is really no particular action that we need
 		 * take to destroy a semaphore.  We will just reset
 		 * the count to some reasonable value (1) and release
@@ -138,6 +144,8 @@ int sem_destroy(FAR sem_t *sem)
 		/* Release holders of the semaphore */
 
 		sem_destroyholder(sem);
+
+		sem->flags &= ~FLAGS_INITIALIZED;
 		return OK;
 	} else {
 		set_errno(EINVAL);

--- a/os/kernel/semaphore/sem_post.c
+++ b/os/kernel/semaphore/sem_post.c
@@ -131,7 +131,7 @@ int sem_post(FAR sem_t *sem)
 
 	/* Make sure we were supplied with a valid semaphore. */
 
-	if (sem) {
+	if (sem && ((sem->flags & FLAGS_INITIALIZED) != 0)) {
 		/* The following operations must be performed with interrupts
 		 * disabled because sem_post() may be called from an interrupt
 		 * handler.

--- a/os/kernel/semaphore/sem_reset.c
+++ b/os/kernel/semaphore/sem_reset.c
@@ -59,6 +59,7 @@
 #include <semaphore.h>
 #include <sched.h>
 #include <assert.h>
+#include <errno.h>
 
 #include <tinyara/irq.h>
 
@@ -80,7 +81,8 @@
  *   count - The requested semaphore count
  *
  * Return Value:
- *   0 (OK) or a negated errno value if unsuccessful
+ *   0 if successful.  Otherwise, -1 is returned and the errno value is set
+ *   appropriately.
  *
  ****************************************************************************/
 
@@ -88,7 +90,10 @@ int sem_reset(FAR sem_t *sem, int16_t count)
 {
 	irqstate_t flags;
 
-	DEBUGASSERT(sem != NULL && count >= 0);
+	if ((sem == NULL) || ((sem->flags & FLAGS_INITIALIZED) == 0) || (count < 0)) {
+		set_errno(EINVAL);
+		return ERROR;
+	}
 
 	/*
 	 * Don't allow any context switches that may result from the following

--- a/os/kernel/semaphore/sem_trywait.c
+++ b/os/kernel/semaphore/sem_trywait.c
@@ -125,7 +125,7 @@ int sem_trywait(FAR sem_t *sem)
 
 	DEBUGASSERT(sem != NULL && up_interrupt_context() == false);
 
-	if (sem != NULL) {
+	if ((sem != NULL) && ((sem->flags & FLAGS_INITIALIZED) != 0)) {
 		/* The following operations must be performed with interrupts disabled
 		 * because sem_post() may be called from an interrupt handler.
 		 */

--- a/os/kernel/semaphore/sem_wait.c
+++ b/os/kernel/semaphore/sem_wait.c
@@ -153,7 +153,7 @@ int sem_wait(FAR sem_t *sem)
 	}
 
 	/* Make sure we were supplied with a valid semaphore */
-	if (sem != NULL) {
+	if ((sem != NULL) && ((sem->flags & FLAGS_INITIALIZED) != 0)) {
 
 		/* Check if the lock is available */
 


### PR DESCRIPTION
1. POSIX standard describes return value as shown below:
Upon successful completion, a value of zero shall be returned.
Otherwise, a value of -1 shall be returned and errno set to indicate the error.
  But our sem APIs do not check sem initialization and do not return ERROR.
2. Without sem_init, almost sem APIs work. But it can cause abnormal
  operation.

The sem_s structure already has the flag element inside
and first bit is an inheritance flag. Let's use second bit as
initialization flag and check it at first operation of sem APIs.