### PR TITLE
network/socket_api: remove dependency between iotivity and socket apis

### DIFF
--- a/os/include/sys/sock_internal.h
+++ b/os/include/sys/sock_internal.h
@@ -60,8 +60,6 @@
 #include <tinyara/config.h>
 #include <sys/types.h>
 
-#if defined(CONFIG_ENABLE_IOTIVITY) || defined(CONFIG_GRPC)
-
 #include <uio.h>
 
 struct msghdr {
@@ -119,7 +117,6 @@ static inline struct cmsghdr *cmsg_nxthdr(struct msghdr *__msg, struct cmsghdr *
 ssize_t recvmsg(int sockfd, struct msghdr *msg, int flags);
 ssize_t sendmsg(int sockfd, struct msghdr *msg, int flags);
 
-#endif							/* CONFIG_ENABLE_IOTIVITY */
 
 /****************************************************************************
  * Definitions

--- a/os/net/socket/Make.defs
+++ b/os/net/socket/Make.defs
@@ -56,18 +56,8 @@
 ifeq ($(CONFIG_NET_SOCKET),y)
 SOCK_CSRCS += net_sockets.c net_close.c net_dupsd.c net_dupsd2.c
 SOCK_CSRCS += net_clone.c net_vfcntl.c bsd_socket_api.c
-
-endif
-
-# Iotivity Support
-ifeq ($(CONFIG_ENABLE_IOTIVITY),y)
-SOCK_CSRCS += recvmsg.c
-endif
-
-ifeq ($(CONFIG_GRPC),y)
 SOCK_CSRCS += recvmsg.c sendmsg.c
 endif
-
 
 # Support for network access using streams
 

--- a/os/net/socket/recvmsg.c
+++ b/os/net/socket/recvmsg.c
@@ -57,7 +57,6 @@
 
 #include <tinyara/config.h>
 #ifdef CONFIG_NET
-#if defined(CONFIG_ENABLE_IOTIVITY) || defined(CONFIG_GRPC)
 
 #include <sys/types.h>
 #include <sys/socket.h>
@@ -100,5 +99,4 @@ ssize_t recvmsg(int sockfd, struct msghdr *msg, int flags)
 
 	return recvfrom(sockfd, buf, len, flags, from, (socklen_t *) addrlen);
 }
-#endif							/* CONFIG_ENABLE_IOTIVITY || CONFIG_GRPC */
 #endif							/* CONFIG_NET */

--- a/os/net/socket/sendmsg.c
+++ b/os/net/socket/sendmsg.c
@@ -57,7 +57,6 @@
 
 #include <tinyara/config.h>
 #ifdef CONFIG_NET
-#if defined(CONFIG_ENABLE_IOTIVITY) || defined(CONFIG_GRPC)
 
 #include <sys/types.h>
 #include <sys/socket.h>
@@ -98,5 +97,4 @@ ssize_t sendmsg(int sockfd, struct msghdr *msg, int flags)
 
 	return sendto(sockfd, buf, len, flags, to, (socklen_t) *addrlen);
 }
-#endif							/* CONFIG_ENABLE_IOTIVITY || CONFIG_GRPC */
 #endif							/* CONFIG_NET */


### PR DESCRIPTION
socket apis(recvmsg, sendmsg) have a dependency to iotivity.
recvmsg and sendmsg will be built with other socket apis
but those apis are not fully supported. so it should be used carefully.