### PR TITLE
Modify build warning options in artik053/grpc

### DIFF
--- a/build/configs/artik053/grpc/Make.defs
+++ b/build/configs/artik053/grpc/Make.defs
@@ -68,10 +68,10 @@ ARCHCFLAGS = -fno-builtin -mcpu=cortex-r4 -mfpu=vfpv3
 ARCHCXXFLAGS = -fno-builtin -mcpu=cortex-r4 -mfpu=vfpv3
 ifeq ($(QUICKBUILD),y)
 ARCHWARNINGS = -Wall -Werror -Wstrict-prototypes -Wshadow -Wundef -Wno-implicit-function-declaration -Wno-unused-function -Wno-unused-but-set-variable
-ARCHWARNINGSXX = -Wall -Wshadow -Wundef
+ARCHWARNINGSXX = -Wall -Wno-sign-compare
 else
 ARCHWARNINGS = -Wall -Werror -Wstrict-prototypes -Wshadow -Wundef -Wno-implicit-function-declaration -Wno-unused-function -Wno-unused-but-set-variable
-ARCHWARNINGSXX = -Wall -Wshadow -Wundef
+ARCHWARNINGSXX = -Wall -Wno-sign-compare
 # only version 4.9 supports color diagnostics
 ifeq "$(ARCHMAJOR)" "4"
 ifeq "$(ARCHMINOR)" "9"
@@ -90,7 +90,7 @@ CPICFLAGS = $(ARCHPICFLAGS) $(CFLAGS)
 CXXFLAGS  = $(ARCHCXXFLAGS) $(ARCHWARNINGSXX) $(ARCHOPTIMIZATION) $(ARCHCPUFLAGS) $(ARCHXXINCLUDES)
 CXXFLAGS += $(ARCHDEFINES) $(EXTRADEFINES) -pipe -std=c++11 -DCLOCK_MONOTONIC -D__TINYARA__
 CXXFLAGS += -fno-exceptions -fcheck-new -fno-rtti
-CXXFLAGS += -pedantic -D_DEBUG -D_LIBCPP_BUILD_STATIC -D_LIBCPP_NO_EXCEPTIONS -ffunction-sections -fdata-sections
+CXXFLAGS += -D_DEBUG -D_LIBCPP_BUILD_STATIC -D_LIBCPP_NO_EXCEPTIONS -ffunction-sections -fdata-sections
 CXXPICFLAGS = $(ARCHPICFLAGS) $(CXXFLAGS)
 CPPFLAGS = $(ARCHINCLUDES) $(ARCHDEFINES) $(EXTRADEFINES)
 AFLAGS = $(CFLAGS) -D__ASSEMBLY__


### PR DESCRIPTION
- Modify C++ warning options of grpc which issue a lot of build warnings as grpc doesn't check them strictly
 1. removed :  -Wshadow, -Wundef, -pedantic
 2. added : -Wno-sign-compare