### PR TITLE
kernel/init: call fs_initialize before clock_initialize to initialize semaphore for inode

### DIFF
--- a/os/kernel/init/os_start.c
+++ b/os/kernel/init/os_start.c
@@ -434,6 +434,12 @@ void os_start(void)
 		wd_initialize();
 	}
 
+#if CONFIG_NFILE_DESCRIPTORS > 0
+	/* Initialize the file system (needed to support device drivers) */
+
+	fs_initialize();
+#endif
+
 	/* Initialize the POSIX timer facility (if included in the link) */
 
 #ifdef CONFIG_HAVE_WEAKFUNCTIONS
@@ -482,12 +488,6 @@ void os_start(void)
 	{
 		pthread_initialize();
 	}
-#endif
-
-#if CONFIG_NFILE_DESCRIPTORS > 0
-	/* Initialize the file system (needed to support device drivers) */
-
-	fs_initialize();
 #endif
 
 #ifdef CONFIG_NET


### PR DESCRIPTION
clock_initialize uses the semahpore for inode, g_inode_sem before initialization.
A semaphore shouldn't be used without initialization.
So we need to call fs_initilize function which initializes inode semaphore before that.