### PR TITLE
add dependency between configurations about grpc and protobuf

### DIFF
--- a/apps/examples/grpc_greeter_client/Kconfig
+++ b/apps/examples/grpc_greeter_client/Kconfig
@@ -6,6 +6,7 @@
 config EXAMPLES_GREETER_CLIENT
 	bool "grpc client example"
 	default n
+	depends on GRPC
 	---help---
 		Enable the grpc client example
 

--- a/apps/examples/grpc_route_client/Kconfig
+++ b/apps/examples/grpc_route_client/Kconfig
@@ -6,6 +6,7 @@
 config EXAMPLES_ROUTE_CLIENT
 	bool "route client example"
 	default n
+	depends on GRPC
 	---help---
 		Enable the grpc client example
 

--- a/apps/examples/protobuf/Kconfig
+++ b/apps/examples/protobuf/Kconfig
@@ -6,6 +6,7 @@
 config EXAMPLES_PROTOBUF
 	bool "Protocol Buffers example"
 	default n
+	depends on PROTOBUF
 	---help---
 		Enable the Protocol Buffers example
 

--- a/external/grpc/Kconfig.protocol
+++ b/external/grpc/Kconfig.protocol
@@ -6,7 +6,7 @@
 config GRPC
 	bool "gRPC"
 	default n
-	depends on NET
-	depends on HAVE_CXX
+	select PROTOBUF
+	depends on NET && LIBCXX
 	---help---
 		Enable support for the gRPC.

--- a/external/protobuf/Kconfig
+++ b/external/protobuf/Kconfig
@@ -6,6 +6,7 @@
 config PROTOBUF
 	bool "protocol buffer"
 	default n
+	depends on LIBCXX
 	---help---
 		enable Protocol Buffer
 


### PR DESCRIPTION
These examples can be executed with enabling related modules.
And protobuf should be enabled for gRPC usage.
So these have some dependency on each module.