### PR TITLE
docs: make a link to audio document on Porting guide

### DIFF
--- a/docs/Porting_Guide.md
+++ b/docs/Porting_Guide.md
@@ -39,7 +39,7 @@ Understanding the TizenRT code structure and adhering to the structure helps in 
 2. [How to port TizenRT on new WiFi chipset](HowToPortTizenRTOnWiFiChipset.md)
 
 ## Audio
-Will be updated
+[How to use audio](HowToUseAudio.md)
 
 ## Confirmation of Porting
 Will be updated


### PR DESCRIPTION
Audio is a part of porting so that link is necessary on porting guide.