### PR TITLE
os/sem: fix missing value of SEM_INITIALIZER on commit 9d4e238

### DIFF
--- a/os/include/semaphore.h
+++ b/os/include/semaphore.h
@@ -141,7 +141,7 @@ typedef struct sem_s sem_t;
 #define SEM_INITIALIZER(c) {(c), FLAGS_INITIALIZED, SEMHOLDER_INITIALIZER} /* semcount, flags, holder */
 #endif
 #else
-#define SEM_INITIALIZER(c) {(c)}	/* semcount */
+#define SEM_INITIALIZER(c) {(c), FLAGS_INITIALIZED}	/* semcount, flags */
 #endif
 
 /****************************************************************************


### PR DESCRIPTION
The sem_s structure has the flags element always by commit 9d4e238.
But SEM_INITIALIZER misses adding that element.
This commit fixs commit 9d4e238 and 3b7eaca.