### PR TITLE
remove lib type (*.a) in .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@
 Make.dep
 .built
 *.o
-*.a
 *.d
 *.i
 *~


### PR DESCRIPTION
To add library type binary, *.a line is removed.