### PR TITLE
apps/utils/kill(all): enable task termination with any configs

### DIFF
--- a/apps/system/utils/Kconfig
+++ b/apps/system/utils/Kconfig
@@ -89,7 +89,6 @@ config ENABLE_IRQINFO
 	---help---
 		List the registered interrupts, it's occurrence counts and corresponding isr.
 
-if !DISABLE_SIGNALS
 config ENABLE_KILL
 	bool "kill"
 	default y
@@ -103,7 +102,6 @@ config ENABLE_KILLALL
 	depends on !BUILD_PROTECTED
 	---help---
 		Send a signal to all processes running any of the specified commands
-endif #!DISABLE_SIGNALS
 
 config ENABLE_PS
 	bool "ps"

--- a/apps/system/utils/Makefile
+++ b/apps/system/utils/Makefile
@@ -124,12 +124,10 @@ ifeq ($(CONFIG_ENABLE_IRQINFO),y)
 CSRCS += kdbg_irqinfo.c
 endif
 
-ifneq ($(CONFIG_DISABLE_SIGNALS),y)
 ifeq ($(CONFIG_ENABLE_KILL),y)
 CSRCS += kdbg_kill.c
 else ifeq ($(CONFIG_ENABLE_KILLALL),y)
 CSRCS += kdbg_kill.c
-endif
 endif
 
 ifeq ($(CONFIG_ENABLE_PS),y)


### PR DESCRIPTION
The kill and killall functions can always run task termination, SIGKILL
even if signal and pthread are disabled.
So, remove a signal conditional on Kconfig and Makefile of kill and
make conditionals on source code for signal and pthread.
Kill and Killall is controled by only CONFIG_ENABLE_KILL(ALL).