### PR TITLE
Should deinitialize database after removing relations (db_cleanup).

### DIFF
--- a/apps/examples/testcase/ta_tc/arastorage/itc/itc_arastorage_main.c
+++ b/apps/examples/testcase/ta_tc/arastorage/itc/itc_arastorage_main.c
@@ -1780,8 +1780,8 @@ int itc_arastorage_launcher(int argc, FAR char *argv[])
 	itc_arastorage_db_cursor_free_p();
 	itc_arastorage_db_cursor_free_n();
 
-	deinit_db();
 	db_cleanup(RELATION_NAME1);
+	deinit_db();
 
 	//Scenario ITCs called after db_deinit
 	itc_arastorage_db_init_deinit_p();


### PR DESCRIPTION
Original code tries to remove the relation after deinitializing database. I observed kernel panic due to illegal memory access occasionally during the execution of `arastorage_itc` tests on ARTIK053 board. After this fix, I did not observe the kernel panic.