### PR TITLE
kdbg/heapinfo : Implement to showing User Defined Group Heap Usage

### DIFF
--- a/apps/system/utils/Kconfig
+++ b/apps/system/utils/Kconfig
@@ -81,6 +81,21 @@ config ENABLE_HEAPINFO
 	---help---
 		Show information about memory status per thread
 
+if ENABLE_HEAPINFO
+config HEAPINFO_GROUP
+	bool "Enable User defined Group Memory Usage"
+	default n
+
+if HEAPINFO_GROUP
+config HEAPINFO_PER_GROUP
+	string "Thread Name List for measuring Alloc Size"
+	default ""
+	---help---
+		Task/Thread name is separated with ',' and Group is separated with '/'.
+		For example, "abc,def/ghi,jklmn/opqr".
+endif
+endif
+
 config ENABLE_IRQINFO
 	bool "irqinfo"
 	default n

--- a/apps/system/utils/README.md
+++ b/apps/system/utils/README.md
@@ -288,6 +288,8 @@ Options:
  -a           Show the all allocation details
  -p PID       Show the specific PID allocation details
  -f           Show the free list
+ -g           Show the User defined group allocation details
+              (for -g option, CONFIG_HEAPINFO_GROUP is needed)
 
 TASH>>heapinfo
 
@@ -332,6 +334,30 @@ Enable CONFIG_DEBUG_MM_HEAPINFO.
 ```
 Debug options -> Enable Debug Output Features to y
 ```
+
+### Heapinfo for User defined Group
+With specified task/thread name, heapinfo can show User defined group heap memory usage.
+
+Enable *CONFIG_HEAPINFO_GROUP* to use this option.
+```
+Application Configuration -> System Libraries and Add-Ons -> heapinfo -> Enable User defined Group Memory Usage -> set Thread Name List for measuring Alloc size
+```
+
+- Thread Name List for measuring Alloc size can be set like below:  
+  Task/Thread name is separated with ',' and Group is separated with '/'.  
+  For example, "abc,def/ghi,jklmn/opqr".
+
+```
+****************************************************************
+Heap Allocation Information per User defined Group
+****************************************************************
+ PEAK | HEAP_ON_PEAK | STACK_ON_PEAK | THREADS_IN_GROUP
+----------------------------------------------------------------
+ 4572 |         3568 |          1004 | jckim,jckim2
+ 5772 |         4768 |          1004 | jckim3
+ 2940 |          896 |          2044 | asdf
+```
+
 
 
 ## irqinfo

--- a/apps/system/utils/kdbg_heapinfo.c
+++ b/apps/system/utils/kdbg_heapinfo.c
@@ -22,6 +22,13 @@
 #include <tinyara/sched.h>
 #include <tinyara/config.h>
 #include <tinyara/mm/mm.h>
+#ifdef CONFIG_HEAPINFO_GROUP
+#include <stdbool.h>
+#include <tinyara/mm/heapinfo_internal.h>
+extern struct heapinfo_group_info_s group_info[HEAPINFO_THREAD_NUM];
+static char *ptr = CONFIG_HEAPINFO_PER_GROUP;
+const static char *end_list = CONFIG_HEAPINFO_PER_GROUP + sizeof(CONFIG_HEAPINFO_PER_GROUP);
+#endif
 
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
 static void kdbg_heapinfo_init(FAR struct tcb_s *tcb, FAR void *arg)
@@ -57,10 +64,27 @@ static void kdbg_heapinfo_task(FAR struct tcb_s *tcb, FAR void *arg)
 	printf(")\n");
 }
 #endif
+
+#ifdef CONFIG_HEAPINFO_GROUP
+static void kdbg_heapinfo_group_threadlist(void)
+{
+	while (*ptr != '/') {
+		printf("%c", *ptr++);
+		if (ptr == end_list) {
+			ptr = CONFIG_HEAPINFO_PER_GROUP - 1;
+			break;
+		}
+	}
+	printf("\n");
+	ptr++;
+}
+#endif
+
 int kdbg_heapinfo(int argc, char **args)
 {
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
 	int option;
+	bool show_group = false;
 	int mode = HEAPINFO_SIMPLE;
 	int pid = HEAPINFO_PID_NOTNEEDED;
 
@@ -69,7 +93,7 @@ int kdbg_heapinfo(int argc, char **args)
 	}
 
 	struct mm_heap_s *user_heap = mm_get_heap_info();
-	while ((option = getopt(argc, args, "iap:f")) != ERROR) {
+	while ((option = getopt(argc, args, "iap:fg")) != ERROR) {
 		switch (option) {
 		case 'i':
 			sched_foreach(kdbg_heapinfo_init, NULL);
@@ -86,6 +110,9 @@ int kdbg_heapinfo(int argc, char **args)
 		case 'f':
 			mode = HEAPINFO_DETAIL_FREE;
 			pid = HEAPINFO_PID_NOTNEEDED;
+			break;
+		case 'g':
+			show_group = true;
 			break;
 		case '?':
 		default:
@@ -110,6 +137,26 @@ int kdbg_heapinfo(int argc, char **args)
 	printf("\n** NOTED **\n");
 	printf("* Idle Task's stack is not allocated in heap region\n");
 	printf("* And another stack size is allocated stack size + alloc node size(task:32/pthread:20)\n\n");
+
+#ifdef CONFIG_HEAPINFO_GROUP
+	if (show_group == true) {
+		int group_idx;
+		printf("****************************************************************\n");
+		printf("Heap Allocation Information per User defined Group\n");
+		printf("****************************************************************\n");
+		printf(" PEAK | HEAP_ON_PEAK | STACK_ON_PEAK | THREADS_IN_GROUP \n");
+		printf("----------------------------------------------------------------\n");
+
+		for (group_idx = 0; group_idx <= user_heap->max_group; group_idx++) {
+			printf(" %4d | %12d | %13d | ", user_heap->group[group_idx].peak_size, user_heap->group[group_idx].heap_size, user_heap->group[group_idx].stack_size);
+			kdbg_heapinfo_group_threadlist();
+		}
+	}
+#else
+	if (show_group == true) {
+		printf("NOT supported!! Please enable CONFIG_HEAPINFO_GROUP\n");
+	}
+#endif
 	return OK;
 
 usage:
@@ -120,6 +167,9 @@ usage:
 	printf(" -a           Show the all allocation details\n");
 	printf(" -p PID       Show the specific PID allocation details \n");
 	printf(" -f           Show the free list \n");
+#ifdef CONFIG_HEAPINFO_GROUP
+	printf(" -g           Show the User defined group allocation details \n");
+#endif
 #endif
 	return ERROR;
 }

--- a/os/include/tinyara/mm/.gitignore
+++ b/os/include/tinyara/mm/.gitignore
@@ -1,0 +1,1 @@
+/heapinfo_internal.h

--- a/os/include/tinyara/mm/mm.h
+++ b/os/include/tinyara/mm/mm.h
@@ -61,6 +61,9 @@
 #include <sys/types.h>
 #include <stdbool.h>
 #include <semaphore.h>
+#ifdef CONFIG_HEAPINFO_GROUP
+#include <tinyara/mm/heapinfo_internal.h>
+#endif
 
 /****************************************************************************
  * Pre-Processor Definitions
@@ -200,6 +203,9 @@
 #define HEAPINFO_DETAIL_PID 3
 #define HEAPINFO_DETAIL_FREE 4
 #define HEAPINFO_PID_NOTNEEDED -1
+#define HEAPINFO_INIT_INFO 0
+#define HEAPINFO_ADD_INFO 1
+#define HEAPINFO_DEL_INFO 2
 
 /* Determines the size of the chunk size/offset type */
 
@@ -301,6 +307,20 @@ struct mm_freenode_s {
 #define CHECK_FREENODE_SIZE \
 	DEBUGASSERT(sizeof(struct mm_freenode_s) == SIZEOF_MM_FREENODE)
 
+#ifdef CONFIG_HEAPINFO_GROUP
+struct heapinfo_group_info_s {
+	int pid;
+	int group;
+	int stack_size;
+};
+
+struct heapinfo_group_s {
+	int curr_size;
+	int peak_size;
+	int stack_size;
+	int heap_size;
+};
+#endif
 /* This describes one heap (possibly with multiple regions) */
 
 struct mm_heap_s {
@@ -318,6 +338,10 @@ struct mm_heap_s {
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
 	size_t peak_alloc_size;
 	size_t total_alloc_size;
+#ifdef CONFIG_HEAPINFO_GROUP
+	int max_group;
+	struct heapinfo_group_s group[HEAPINFO_GROUP_NUM];
+#endif
 #endif
 
 	/* This is the first and last nodes of the heap */
@@ -607,8 +631,12 @@ void heapinfo_update_node(FAR struct mm_allocnode_s *node, mmaddress_t caller_re
 
 void heapinfo_add_size(pid_t pid, mmsize_t size);
 void heapinfo_subtract_size(pid_t pid, mmsize_t size);
-void heapinfo_update_total_size(struct mm_heap_s *heap, mmsize_t size);
+void heapinfo_update_total_size(struct mm_heap_s *heap, mmsize_t size, pid_t pid);
 void heapinfo_exclude_stacksize(void *stack_ptr);
+#ifdef CONFIG_HEAPINFO_GROUP
+void heapinfo_update_group_info(pid_t pid, int group, int type);
+void heapinfo_check_group_list(pid_t pid, char *name);
+#endif
 #endif
 
 #ifdef CONFIG_DEBUG_MM_HEAPINFO

--- a/os/kernel/sched/sched_releasetcb.c
+++ b/os/kernel/sched/sched_releasetcb.c
@@ -69,6 +69,9 @@
 #if defined(CONFIG_ENABLE_STACKMONITOR) && defined(CONFIG_DEBUG)
 #include <apps/system/utils.h>
 #endif
+#ifdef CONFIG_DEBUG_MM_HEAPINFO
+#include <tinyara/mm/mm.h>
+#endif
 
 /************************************************************************
  * Private Functions
@@ -138,6 +141,10 @@ int sched_releasetcb(FAR struct tcb_s *tcb, uint8_t ttype)
 	if (tcb) {
 #if defined(CONFIG_ENABLE_STACKMONITOR) && defined(CONFIG_DEBUG)
 		stkmon_logging(tcb);
+#endif
+
+#ifdef CONFIG_HEAPINFO_GROUP
+		heapinfo_update_group_info(tcb->pid, -1, HEAPINFO_DEL_INFO);
 #endif
 
 #ifndef CONFIG_DISABLE_POSIX_TIMERS

--- a/os/kernel/task/task_create.c
+++ b/os/kernel/task/task_create.c
@@ -67,6 +67,10 @@
 #include <tinyara/ttrace.h>
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
 #include <tinyara/mm/mm.h>
+#ifdef CONFIG_HEAPINFO_GROUP
+#include <tinyara/sched.h>
+#include <string.h>
+#endif
 #endif
 
 #include "sched/sched.h"
@@ -212,6 +216,10 @@ static int thread_create(FAR const char *name, uint8_t ttype, int priority, int 
 	/* Get the assigned pid before we start the task */
 
 	pid = (int)tcb->cmn.pid;
+
+#ifdef CONFIG_HEAPINFO_GROUP
+	heapinfo_check_group_list(pid, tcb->cmn.name);
+#endif
 
 	/* Activate the task */
 

--- a/os/kernel/task/task_prctl.c
+++ b/os/kernel/task/task_prctl.c
@@ -149,6 +149,9 @@ int prctl(int option, ...)
 
 			strncpy(tcb->name, name, CONFIG_TASK_NAME_SIZE);
 			tcb->name[CONFIG_TASK_NAME_SIZE] = '\0';
+#ifdef CONFIG_HEAPINFO_GROUP
+			heapinfo_check_group_list(tcb->pid, tcb->name);
+#endif
 		} else {
 			/* The returned value will be null-terminated, truncating if necessary */
 

--- a/os/mm/Makefile
+++ b/os/mm/Makefile
@@ -121,6 +121,13 @@ $(KBIN):
 	$(Q) $(MAKE) $(KBIN) BIN=$(KBIN) BINDIR=kbin TOPDIR=$(TOPDIR) EXTRADEFINES=$(EXTRADEFINES)
 endif
 
+ifeq ($(CONFIG_HEAPINFO_GROUP),y)
+  GROUP_DELIM_NUM = "${shell echo $(CONFIG_HEAPINFO_PER_GROUP) | grep -o '/' | wc -l}"
+  THREAD_DELIM_NUM = "${shell echo $(CONFIG_HEAPINFO_PER_GROUP) | grep -o ',' | wc -l}"
+
+  ${shell echo '#define HEAPINFO_GROUP_DELIM_NUM' "$(GROUP_DELIM_NUM)\n"'#define HEAPINFO_THREAD_DELIM_NUM' "$(THREAD_DELIM_NUM)\n"'#define HEAPINFO_GROUP_NUM (HEAPINFO_GROUP_DELIM_NUM + 1)\n#define HEAPINFO_THREAD_NUM (HEAPINFO_GROUP_NUM + HEAPINFO_THREAD_DELIM_NUM)' > $(TOPDIR)$(DELIM)include$(DELIM)tinyara$(DELIM)mm$(DELIM)heapinfo_internal.h}
+endif
+
 # Dependencies
 
 .depend: Makefile $(SRCS)
@@ -143,6 +150,9 @@ clean:
 	$(call DELFILE, $(BIN))
 	$(call DELFILE, $(UBIN))
 	$(call DELFILE, $(KBIN))
+ifeq ($(CONFIG_HEAPINFO_GROUP),y)
+	$(call DELFILE, $(TOPDIR)$(DELIM)include$(DELIM)tinyara$(DELIM)mm$(DELIM)heapinfo_internal.h)
+endif
 	$(call CLEAN)
 
 # Deep clean -- removes all traces of the configuration

--- a/os/mm/mm_heap/mm_free.c
+++ b/os/mm/mm_heap/mm_free.c
@@ -141,7 +141,7 @@ void mm_free(FAR struct mm_heap_s *heap, FAR void *mem)
 
 	if ((alloc_node->preceding & MM_ALLOC_BIT) != 0) {
 		heapinfo_subtract_size(alloc_node->pid, alloc_node->size);
-		heapinfo_update_total_size(heap, ((-1) * alloc_node->size));
+		heapinfo_update_total_size(heap, ((-1) * alloc_node->size), alloc_node->pid);
 	}
 #endif
 	node->preceding &= ~MM_ALLOC_BIT;

--- a/os/mm/mm_heap/mm_heapinfo.c
+++ b/os/mm/mm_heap/mm_heapinfo.c
@@ -59,6 +59,9 @@
 #include <unistd.h>
 #include <stdint.h>
 #include <stdio.h>
+#ifdef CONFIG_HEAPINFO_GROUP
+#include <tinyara/mm/heapinfo_internal.h>
+#endif
 
 /****************************************************************************
  * Pre-processor Definitions
@@ -66,6 +69,10 @@
 #define MM_PIDHASH(pid) ((pid) & (CONFIG_MAX_TASKS - 1))
 #define HEAPINFO_INT INT16_MAX
 #define HEAPINFO_NONSCHED (INT16_MAX - 1)
+
+#ifdef CONFIG_HEAPINFO_GROUP
+struct heapinfo_group_info_s group_info[HEAPINFO_THREAD_NUM];
+#endif
 
 /****************************************************************************
  * Public Functions
@@ -198,7 +205,40 @@ void heapinfo_parse(FAR struct mm_heap_s *heap, int mode, pid_t pid)
 
 	return;
 }
-
+/****************************************************************************
+ * Name: heapinfo_update_group
+ *
+ * Description:
+ * Update Peak heap size for Group
+ ****************************************************************************/
+#ifdef CONFIG_HEAPINFO_GROUP
+static void heapinfo_update_group(mmsize_t size, pid_t pid)
+{
+	int check_idx;
+	int group_num;
+	int stack_pid;
+	struct mm_heap_s *heap = mm_get_heap_info();
+	for (check_idx = 0; check_idx < HEAPINFO_THREAD_NUM; check_idx++) {
+		if (pid == group_info[check_idx].pid) {
+			group_num = group_info[check_idx].group;
+			heap->group[group_num].curr_size += size;
+			/* Update peak size */
+			if (heap->group[group_num].curr_size > heap->group[group_num].peak_size) {
+				heap->group[group_num].peak_size = heap->group[group_num].curr_size;
+				/* calculate the summation of stacks */
+				heap->group[group_num].stack_size = 0;
+				for (stack_pid = 0; stack_pid < HEAPINFO_THREAD_NUM; stack_pid++) {
+					if (group_info[stack_pid].pid != -1 && group_info[stack_pid].group == group_num) {
+						heap->group[group_num].stack_size += group_info[stack_pid].stack_size;
+					}
+				}
+				heap->group[group_num].heap_size = heap->group[group_num].peak_size - heap->group[group_num].stack_size;
+			}
+			break;
+		}
+	}
+}
+#endif
 /****************************************************************************
  * Name: heapinfo_add_size
  *
@@ -239,14 +279,16 @@ void heapinfo_subtract_size(pid_t pid, mmsize_t size)
  * Description:
  * Calculate the total allocated size and update the peak allocated size for heap
  ****************************************************************************/
-void heapinfo_update_total_size(struct mm_heap_s *heap, mmsize_t size)
+void heapinfo_update_total_size(struct mm_heap_s *heap, mmsize_t size, pid_t pid)
 {
 	heap->total_alloc_size += size;
 	if (heap->total_alloc_size > heap->peak_alloc_size) {
 		heap->peak_alloc_size = heap->total_alloc_size;
 	}
+#ifdef CONFIG_HEAPINFO_GROUP
+	heapinfo_update_group(size, pid);
+#endif
 }
-
 /****************************************************************************
  * Name: heapinfo_update_node
  *
@@ -282,5 +324,113 @@ void heapinfo_exclude_stacksize(void *stack_ptr)
 
 	ASSERT(rtcb);
 	rtcb->curr_alloc_size -= node->size;
+
+#ifdef CONFIG_HEAPINFO_GROUP
+	int check_idx;
+	int group_num;
+	struct mm_heap_s *heap = mm_get_heap_info();
+
+	for (check_idx = 0; check_idx <= heap->max_group; check_idx++) {
+		if (node->pid == group_info[check_idx].pid) {
+			group_num = group_info[check_idx].group;
+			heap->group[group_num].curr_size -= node->size;
+			break;
+		}
+	}
+#endif
 }
+
+#ifdef CONFIG_HEAPINFO_GROUP
+/****************************************************************************
+ * Name: heapinfo_update_group_info
+ *
+ * Description:
+ * when create or release task/thread, check that the task/thread is 
+ * in group list
+ ****************************************************************************/
+void heapinfo_update_group_info(pid_t pid, int group, int type)
+{
+	int info_idx;
+	struct tcb_s *tcb;
+	struct mm_heap_s *heap = mm_get_heap_info();
+	switch (type) {
+	case HEAPINFO_INIT_INFO:
+		for (info_idx = 0; info_idx < HEAPINFO_THREAD_NUM; info_idx++) {
+			group_info[info_idx].pid = pid;
+			group_info[info_idx].group = group;
+			group_info[info_idx].stack_size = 0;
+		}
+		break;
+	case HEAPINFO_ADD_INFO:
+		if (group > heap->max_group) {
+			heap->max_group = group;
+		}
+		for (info_idx = 0; info_idx < HEAPINFO_THREAD_NUM; info_idx++) {
+			if (group_info[info_idx].pid <= 0) {
+				group_info[info_idx].pid = pid;
+				group_info[info_idx].group = group;
+				tcb = sched_gettcb(pid);
+				group_info[info_idx].stack_size = tcb->adj_stack_size;
+				heapinfo_update_group(tcb->adj_stack_size, pid);
+				break;
+			}
+		}
+		break;
+	case HEAPINFO_DEL_INFO:
+		for (info_idx = 0; info_idx < HEAPINFO_THREAD_NUM; info_idx++) {
+			if (pid == group_info[info_idx].pid) {
+				heapinfo_update_group((-1) * group_info[info_idx].stack_size, pid);
+
+				group_info[info_idx].pid = -1;
+				group_info[info_idx].group = -1;
+				group_info[info_idx].stack_size = 0;
+				break;
+			}
+		}
+		break;
+	default:
+		break;
+	}
+}
+
+/****************************************************************************
+ * Name: heapinfo_check_group_list
+ *
+ * Description:
+ * check that task/thread is in group list
+ ****************************************************************************/
+void heapinfo_check_group_list(pid_t pid, char *name)
+{
+	char *thread_list = CONFIG_HEAPINFO_PER_GROUP;
+
+	int group_num = 0;
+
+	char *name_start;
+	char *name_end;
+	int name_length;
+	name_start = name_end = thread_list;
+
+	while (*name_start != '\0') {
+		if (*name_end == '/' || *name_end == ',' || *name_end == '\0') {
+			name_length = name_end - name_start;
+			if (name_length == strlen(name)) {
+				if (strncmp(name_start, name, name_end - name_start) == 0) {
+					heapinfo_update_group_info(pid, group_num, HEAPINFO_ADD_INFO);
+					break;
+				}
+			}
+			if (*name_end == '/') {
+				group_num++;
+			} else if (*name_end == '\0') {
+				name_start = name_end;
+				continue;
+			}
+			name_end++;
+			name_start = name_end;
+		} else {
+			name_end++;
+		}
+	}
+}
+#endif /* CONFIG_HEAPINFO_GROUP */
 #endif

--- a/os/mm/mm_heap/mm_initialize.c
+++ b/os/mm/mm_heap/mm_initialize.c
@@ -229,4 +229,7 @@ void mm_initialize(FAR struct mm_heap_s *heap, FAR void *heapstart, size_t heaps
 	/* Add the initial region of memory to the heap */
 
 	mm_addregion(heap, heapstart, heapsize);
+#ifdef CONFIG_HEAPINFO_GROUP
+	heapinfo_update_group_info(-1, -1, HEAPINFO_INIT_INFO);
+#endif
 }

--- a/os/mm/mm_heap/mm_malloc.c
+++ b/os/mm/mm_heap/mm_malloc.c
@@ -213,7 +213,7 @@ FAR void *mm_malloc(FAR struct mm_heap_s *heap, size_t size)
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
 		heapinfo_update_node((struct mm_allocnode_s *)node, caller_retaddr);
 		heapinfo_add_size(((struct mm_allocnode_s *)node)->pid, node->size);
-		heapinfo_update_total_size(heap, node->size);
+		heapinfo_update_total_size(heap, node->size, ((struct mm_allocnode_s *)node)->pid);
 #endif
 		ret = (void *)((char *)node + SIZEOF_MM_ALLOCNODE);
 	}

--- a/os/mm/mm_heap/mm_memalign.c
+++ b/os/mm/mm_heap/mm_memalign.c
@@ -149,7 +149,7 @@ FAR void *mm_memalign(FAR struct mm_heap_s *heap, size_t alignment, size_t size)
 
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
 		heapinfo_subtract_size(node->pid, node->size);
-		heapinfo_update_total_size(heap, ((-1) * (node->size)));
+		heapinfo_update_total_size(heap, ((-1) * (node->size)), node->pid);
 #endif
 	/* Find the aligned subregion */
 
@@ -237,7 +237,7 @@ FAR void *mm_memalign(FAR struct mm_heap_s *heap, size_t alignment, size_t size)
 	heapinfo_update_node(node, caller_retaddr);
 
 	heapinfo_add_size(node->pid, node->size);
-	heapinfo_update_total_size(heap, node->size);
+	heapinfo_update_total_size(heap, node->size, node->pid);
 #endif
 	mm_givesemaphore(heap);
 	return (FAR void *)alignedchunk;

--- a/os/mm/mm_heap/mm_realloc.c
+++ b/os/mm/mm_heap/mm_realloc.c
@@ -164,7 +164,7 @@ FAR void *mm_realloc(FAR struct mm_heap_s *heap, FAR void *oldmem, size_t size)
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
 			/* modify the current allocated size of old node */
 			heapinfo_subtract_size(oldnode->pid, oldsize);
-			heapinfo_update_total_size(heap, (-1) * oldsize);
+			heapinfo_update_total_size(heap, (-1) * oldsize, oldnode->pid);
 #endif
 
 			mm_shrinkchunk(heap, oldnode, newsize);
@@ -173,7 +173,7 @@ FAR void *mm_realloc(FAR struct mm_heap_s *heap, FAR void *oldmem, size_t size)
 			heapinfo_update_node(oldnode, caller_retaddr);
 
 			heapinfo_add_size(oldnode->pid, oldnode->size);
-			heapinfo_update_total_size(heap, oldnode->size);
+			heapinfo_update_total_size(heap, oldnode->size, oldnode->pid);
 #endif
 		}
 
@@ -208,7 +208,7 @@ FAR void *mm_realloc(FAR struct mm_heap_s *heap, FAR void *oldmem, size_t size)
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
 		/* modify the current allocated size of old node */
 		heapinfo_subtract_size(oldnode->pid, oldsize);
-		heapinfo_update_total_size(heap, (-1) * oldsize);
+		heapinfo_update_total_size(heap, (-1) * oldsize, oldnode->pid);
 #endif
 
 		/* Check if we can extend into the previous chunk and if the
@@ -359,7 +359,7 @@ FAR void *mm_realloc(FAR struct mm_heap_s *heap, FAR void *oldmem, size_t size)
 		heapinfo_update_node(oldnode, caller_retaddr);
 
 		heapinfo_add_size(oldnode->pid, oldnode->size);
-		heapinfo_update_total_size(heap, oldnode->size);
+		heapinfo_update_total_size(heap, oldnode->size, oldnode->pid);
 #endif
 
 		mm_givesemaphore(heap);


### PR DESCRIPTION
"heapinfo -g" shows the information about user defined group heap memory usage

example)
```
****************************************************************
Heap Allocation Information per User defined Group
****************************************************************
 PEAK | HEAP_ON_PEAK | STACK_ON_PEAK | THREADS_IN_GROUP
----------------------------------------------------------------
 4572 |         3568 |          1004 | jckim,jckim2
 5772 |         4768 |          1004 | jckim3
 2940 |          896 |          2044 | asdf

```