### PR TITLE
examples/testcase: Fix wrong typo in kernel tc main

### DIFF
--- a/apps/examples/testcase/tc_main.c
+++ b/apps/examples/testcase/tc_main.c
@@ -27,7 +27,7 @@
 #include <semaphore.h>
 #include "tc_common.h"
 
-#if CONFIG_TASH
+#ifdef CONFIG_TASH
 #include <apps/shell/tash.h>
 #else
 #if defined(CONFIG_EXAMPLES_TESTCASE_ARASTORAGE_UTC) || defined(CONFIG_EXAMPLES_TESTCASE_ARASTORAGE_ITC)


### PR DESCRIPTION
Fixes wrong typo "#if CONFIG_TASH" introduced in the commit [fff960](https://github.com/Samsung/TizenRT/commit/fff960a48b956ae6f0e4775818455a0eddc55f23#diff-5a3373019e1c1e2913a474432bdc9943).
Due to which error occurs in kernel tc_main when CONFIG_TASH is disabled.
The correct typo is "#ifdef CONFIG_TASH".

Signed-off-by: Lokesh B V <lokesh.bv@partner.samsung.com>