### PR TITLE
Add s5j platform support for Tickless Kernel

### DIFF
--- a/apps/examples/tickless_test/Kconfig
+++ b/apps/examples/tickless_test/Kconfig
@@ -1,0 +1,14 @@
+#
+# For a description of the syntax of this configuration file,
+# see kconfig-language at https://www.kernel.org/doc/Documentation/kbuild/kconfig-language.txt
+#
+
+config EXAMPLES_TICKLESS_TEST
+	bool "Tickless Kernel test application"
+	default n
+	---help---
+		Enable the Tickless Kernel test application
+
+config USER_ENTRYPOINT
+	string
+	default "tickless_test_main" if ENTRY_TICKLESS_TEST

--- a/apps/examples/tickless_test/Kconfig_ENTRY
+++ b/apps/examples/tickless_test/Kconfig_ENTRY
@@ -1,0 +1,3 @@
+config ENTRY_TICKLESS_TEST
+	bool "Tickless Kernel test application"
+	depends on EXAMPLES_TICKLESS_TEST

--- a/apps/examples/tickless_test/Make.defs
+++ b/apps/examples/tickless_test/Make.defs
@@ -1,0 +1,21 @@
+###########################################################################
+#
+# Copyright 2018 Samsung Electronics All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+#
+###########################################################################
+
+ifeq ($(CONFIG_EXAMPLES_TICKLESS_TEST),y)
+CONFIGURED_APPS += examples/tickless_test
+endif

--- a/apps/examples/tickless_test/Makefile
+++ b/apps/examples/tickless_test/Makefile
@@ -1,0 +1,124 @@
+###########################################################################
+#
+# Copyright 2018 Samsung Electronics All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+#
+###########################################################################
+
+-include $(TOPDIR)/.config
+-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
+
+# Tickless kernel test application info
+
+APPNAME = tickless_test
+FUNCNAME = $(APPNAME)_main
+THREADEXEC = TASH_EXECMD_ASYNC
+
+# Tickless kernel test application
+
+ASRCS =
+CSRCS =
+MAINSRC = tickless_test_main.c
+
+AOBJS = $(ASRCS:.S=$(OBJEXT))
+COBJS = $(CSRCS:.c=$(OBJEXT))
+MAINOBJ = $(MAINSRC:.c=$(OBJEXT))
+
+SRCS = $(ASRCS) $(CSRCS) $(MAINSRC)
+OBJS = $(AOBJS) $(COBJS)
+
+ifneq ($(CONFIG_BUILD_KERNEL),y)
+  OBJS += $(MAINOBJ)
+endif
+
+ifeq ($(CONFIG_WINDOWS_NATIVE),y)
+  BIN = ..\..\libapps$(LIBEXT)
+else
+ifeq ($(WINTOOL),y)
+  BIN = ..\\..\\libapps$(LIBEXT)
+else
+  BIN = ../../libapps$(LIBEXT)
+endif
+endif
+
+ifeq ($(WINTOOL),y)
+  INSTALL_DIR = "${shell cygpath -w $(BIN_DIR)}"
+else
+  INSTALL_DIR = $(BIN_DIR)
+endif
+
+CONFIG_EXAMPLES_TICKLESS_TEST_PROGNAME ?= tickless_test$(EXEEXT)
+PROGNAME = $(CONFIG_EXAMPLES_TICKLESS_TEST_PROGNAME)
+
+ROOTDEPPATH = --dep-path .
+
+# Common build
+
+VPATH =
+
+all: .built
+.PHONY: clean depend distclean
+
+$(AOBJS): %$(OBJEXT): %.S
+	$(call ASSEMBLE, $<, $@)
+
+$(COBJS) $(MAINOBJ): %$(OBJEXT): %.c
+	$(call COMPILE, $<, $@)
+
+.built: $(OBJS)
+	$(call ARCHIVE, $(BIN), $(OBJS))
+	@touch .built
+
+ifeq ($(CONFIG_BUILD_KERNEL),y)
+$(BIN_DIR)$(DELIM)$(PROGNAME): $(OBJS) $(MAINOBJ)
+	@echo "LD: $(PROGNAME)"
+	$(Q) $(LD) $(LDELFFLAGS) $(LDLIBPATH) -o $(INSTALL_DIR)$(DELIM)$(PROGNAME) $(ARCHCRT0OBJ) $(MAINOBJ) $(LDLIBS)
+	$(Q) $(NM) -u  $(INSTALL_DIR)$(DELIM)$(PROGNAME)
+
+install: $(BIN_DIR)$(DELIM)$(PROGNAME)
+
+else
+install:
+
+endif
+
+ifeq ($(CONFIG_BUILTIN_APPS)$(CONFIG_EXAMPLES_TICKLESS_TEST),yy)
+$(BUILTIN_REGISTRY)$(DELIM)$(FUNCNAME).bdat: $(DEPCONFIG) Makefile
+	$(Q) $(call REGISTER,$(APPNAME),$(FUNCNAME),$(THREADEXEC),$(PRIORITY),$(STACKSIZE))
+
+context: $(BUILTIN_REGISTRY)$(DELIM)$(FUNCNAME).bdat
+
+else
+context:
+
+endif
+
+.depend: Makefile $(SRCS)
+	@$(MKDEP) $(ROOTDEPPATH) "$(CC)" -- $(CFLAGS) -- $(SRCS) >Make.dep
+	@touch $@
+
+depend: .depend
+
+clean:
+	$(call DELFILE, .built)
+	$(call CLEAN)
+
+distclean: clean
+	$(call DELFILE, Make.dep)
+	$(call DELFILE, .depend)
+
+-include Make.dep
+.PHONY: preconfig
+preconfig:

--- a/apps/examples/tickless_test/README.txt
+++ b/apps/examples/tickless_test/README.txt
@@ -1,0 +1,8 @@
+examples/tickless_test
+^^^^^^^^^^^^^^^^^^^^^^
+
+  This is an application to test tickless kernel feature.
+
+  Configs (see the details on Kconfig):
+  * CONFIG_EXAMPLES_TICKLESS_TEST
+

--- a/apps/examples/tickless_test/tickless_test_main.c
+++ b/apps/examples/tickless_test/tickless_test_main.c
@@ -1,0 +1,103 @@
+/****************************************************************************
+ *
+ * Copyright 2018 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define NTHREADS	5
+#define LOOP		3
+
+#define MSEC_PER_SEC	1000 /* 1s = 1000ms */
+
+#define MSEC_PER_NSEC	(1 / 1000000) /* 1ns = (1/1000000)ms */
+
+#define USEC_PER_MSEC	1000 /* 1ms = 1000us */
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <tinyara/config.h>
+#include <stdio.h>
+#include <time.h>
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+static void *thread_func(void *arg)
+{
+	unsigned int duration = (unsigned int)arg;
+	pid_t cur_thread = getpid();
+
+	systime_t t1 = clock_systimer();
+	t1 = (1000 * (t1 % CLOCKS_PER_SEC) + (CLOCKS_PER_SEC / 2)) / CLOCKS_PER_SEC;
+
+	printf("thread with pid=%d sleeping for %ums\n", cur_thread, duration);
+
+	/* sleep for 'duration' micro seconds */
+	usleep(duration * USEC_PER_MSEC);
+
+	systime_t t2 = clock_systimer();
+	t2 = (1000 * (t2 % CLOCKS_PER_SEC) + (CLOCKS_PER_SEC / 2)) / CLOCKS_PER_SEC;
+
+	printf("thread with pid=%d woke up after %ums\n", cur_thread, (t2 - t1));
+
+	return NULL;
+}
+
+static void tickless_test_helper(void)
+{
+	pthread_t thread_id[NTHREADS];
+	unsigned int thread;
+	unsigned int sleep_time[NTHREADS] = {1, 33, 89, 67, 17}; /* in milli seconds */
+
+	for (thread = 0; thread < NTHREADS; thread++) {
+		pthread_create(&thread_id[thread], NULL, (pthread_addr_t)thread_func, (pthread_addr_t *)(sleep_time[thread]));
+	}
+
+	for (thread = 0; thread < NTHREADS; thread++) {
+		pthread_join(thread_id[thread], NULL);
+	}
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/* sleep test for tickless feature */
+
+#ifdef CONFIG_BUILD_KERNEL
+int main(int argc, FAR char *argv[])
+#else
+int tickless_test_main(int argc, char *argv[])
+#endif
+{
+	unsigned int i = 0;
+	printf("\n%s: 'Begin' Test\n\n", __func__);
+
+	for (i = 0; i < LOOP; i++) {
+		printf("Loop %d Begin\n\n", i + 1);
+		tickless_test_helper();
+		printf("\nLoop %d End\n", i + 1);
+	}
+
+	printf("\n%s: 'End' Test\n", __func__);
+	return 0;
+}

--- a/os/arch/arm/src/s5j/Kconfig
+++ b/os/arch/arm/src/s5j/Kconfig
@@ -202,15 +202,19 @@ config S5J_MCT
 		The local timers are 32-bit free running down-counters and
 		generate an interrupt when the counter expires.
 
+if SCHED_TICKLESS
+
 config S5J_GTIMER
 	bool "MCT Global TIMER"
-	default n
+	default y
 	depends on S5J_HAVE_MCT
 	select S5J_MCT
 	---help---
 		This is a free-running timer which the capability to generate
 		a compare interrupt when the timer matches a comparison value.
 		So this timer is used to support tickless OS.
+
+endif # SCHED_TICKLESS
 
 config S5J_TIMER0
 	bool "TIMER0"

--- a/os/arch/arm/src/s5j/Kconfig
+++ b/os/arch/arm/src/s5j/Kconfig
@@ -194,6 +194,23 @@ config S5J_I2S_MAXINFLIGHT
 config S5J_MCT
 	bool
 	default n
+	depends on S5J_HAVE_MCT
+	---help---
+		Multi Core Timer (MCT). It has 1 global timer and 4 local timers.
+		The global timer is a 64-bit free running up-counter and can generate
+		4 interrupts when the counter reaches one of the four preset counter values.
+		The local timers are 32-bit free running down-counters and
+		generate an interrupt when the counter expires.
+
+config S5J_GTIMER
+	bool "MCT Global TIMER"
+	default n
+	depends on S5J_HAVE_MCT
+	select S5J_MCT
+	---help---
+		This is a free-running timer which the capability to generate
+		a compare interrupt when the timer matches a comparison value.
+		So this timer is used to support tickless OS.
 
 config S5J_TIMER0
 	bool "TIMER0"

--- a/os/arch/arm/src/s5j/Make.defs
+++ b/os/arch/arm/src/s5j/Make.defs
@@ -113,6 +113,10 @@ ifneq ($(CONFIG_SCHED_TICKLESS),y)
 CHIP_CSRCS += s5j_timerisr.c
 endif
 
+ifeq ($(CONFIG_SCHED_TICKLESS),y)
+CHIP_CSRCS += s5j_tickless.c
+endif
+
 CHIP_CSRCS += s5j_idle.c
 CHIP_CSRCS += s5j_boot.c s5j_irq.c
 CHIP_CSRCS += s5j_serial.c

--- a/os/arch/arm/src/s5j/chip/s5jt200_mct.h
+++ b/os/arch/arm/src/s5j/chip/s5jt200_mct.h
@@ -59,23 +59,23 @@
 /* Register Address *********************************************************/
 #define S5J_MCT_CFG					S5J_MCT_BASE
 
-#define S5J_MCT_TCNTB_OFFSET		0x0000
-#define S5J_MCT_TCNTO_OFFSET		0x0004
-#define S5J_MCT_ICNTB_OFFSET		0x0008
-#define S5J_MCT_ICNTO_OFFSET		0x000C
-#define S5J_MCT_FRCNTB_OFFSET		0x0010
-#define S5J_MCT_FRCNTO_OFFSET		0x0014
-#define S5J_MCT_TCON_OFFSET			0x0020
-#define S5J_MCT_INT_CSTAT_OFFSET	0x0030
-#define S5J_MCT_INT_ENB_OFFSET		0x0034
-#define S5J_MCT_WSTAT_OFFSET		0x0040
+#define S5J_MCT_L_TCNTB_OFFSET		0x0000
+#define S5J_MCT_L_TCNTO_OFFSET		0x0004
+#define S5J_MCT_L_ICNTB_OFFSET		0x0008
+#define S5J_MCT_L_ICNTO_OFFSET		0x000C
+#define S5J_MCT_L_FRCNTB_OFFSET	0x0010
+#define S5J_MCT_L_FRCNTO_OFFSET	0x0014
+#define S5J_MCT_L_TCON_OFFSET		0x0020
+#define S5J_MCT_L_INT_CSTAT_OFFSET	0x0030
+#define S5J_MCT_L_INT_ENB_OFFSET	0x0034
+#define S5J_MCT_L_WSTAT_OFFSET		0x0040
 
 /* Register Bitfield Definitions ********************************************/
 /* MCT TCON register */
-#define S5J_MCT_TCON_FRC_START		(1 << 3)
-#define S5J_MCT_TCON_INTERVAL_MODE	(1 << 2)
-#define S5J_MCT_TCON_INT_START		(1 << 1)
-#define S5J_MCT_TCON_TIMER_START	(1 << 0)
+#define S5J_MCT_L_TCON_FRC_START		(1 << 3)
+#define S5J_MCT_L_TCON_INTERVAL_MODE		(1 << 2)
+#define S5J_MCT_L_TCON_INT_START		(1 << 1)
+#define S5J_MCT_L_TCON_TIMER_START		(1 << 0)
 
 /* MCT INTR register */
 #define S5J_MCT_INTR_FRC			(1 << 1)
@@ -94,5 +94,32 @@
 /* MCT INT register */
 #define S5J_MCT_INT_ENB_FRC_MASK	(1 << 1)
 #define S5J_MCT_INT_ENB_ICNT_MASK	(1 << 0)
+
+/* Global MCT */
+
+#define S5J_MCT_G_CNT_L			(0x100)
+#define S5J_MCT_G_CNT_U			(0x104)
+#define S5J_MCT_G_CNT_WSTAT			(0x110)
+#define S5J_MCT_G_COMP_L(x)			(0x200 + (0x10 * x))
+#define S5J_MCT_G_COMP_U(x)			(0x204 + (0x10 * x))
+#define S5J_MCT_G_COMP_ADD_INCR(x)		(0x208 + (0x10 * x))
+#define S5J_MCT_G_TCON				(0x240)
+#define S5J_MCT_G_INT_CSTAT			(0x244)
+#define S5J_MCT_G_INT_ENB			(0x248)
+#define S5J_MCT_G_WSTAT				(0x24C)
+
+#define G_TCON_START_FRC			(1 << 8)
+
+#define G_TCON_AUTO_INCR_ENABLE(x)		(1 << ((2 * x) + 1))
+#define G_TCON_COMP_ENABLE(x)			(1 << ((2 * x) + 0))
+
+#define WSTAT_G_CNT_U				(1 << 1)
+#define WSTAT_G_CNT_L				(1 << 0)
+
+#define WSTAT_G_COMP_ADD_INCR(x)		(1 << ((x * 4) + 2))
+#define WSTAT_G_COMP_U(x)			(1 << ((x * 4) + 1))
+#define WSTAT_G_COMP_L(x)			(1 << ((x * 4) + 0))
+
+#define WSTAT_G_TCON				(1 << 16)
 
 #endif /* __ARCH_ARM_SRC_S5J_CHIP_S5JT200_MCT_H */

--- a/os/arch/arm/src/s5j/s5j_mct.c
+++ b/os/arch/arm/src/s5j/s5j_mct.c
@@ -81,15 +81,6 @@
  ****************************************************************************/
 
 /****************************************************************************
- * Private Types
- ****************************************************************************/
-struct s5j_mct_priv_s {
-	/* mct base address */
-	uint32_t	base_addr;
-	int			irq_id;
-};
-
-/****************************************************************************
  * Private Functions
  ****************************************************************************/
 static uint32_t mct_getreg32(FAR struct s5j_mct_priv_s *priv, uint32_t offset)
@@ -121,7 +112,18 @@ static int s5j_mct_setclock(uint32_t freq)
 
 static void s5j_mct_wait_wstat(uint32_t base, uint32_t bitmask)
 {
-	uint32_t reg = base + S5J_MCT_WSTAT_OFFSET;
+	uint32_t reg = base + S5J_MCT_L_WSTAT_OFFSET;
+
+	while ((getreg32(reg) & bitmask) == 0) {
+		/* poll */
+	}
+
+	putreg32(bitmask, reg);
+}
+
+static void s5j_mct_global_wait_wstat(uint32_t base, uint32_t wstat, uint32_t bitmask)
+{
+	uint32_t reg = base + wstat;
 
 	while ((getreg32(reg) & bitmask) == 0) {
 		/* poll */
@@ -131,8 +133,55 @@ static void s5j_mct_wait_wstat(uint32_t base, uint32_t bitmask)
 }
 
 /****************************************************************************
+ * Name: s5j_mct_global_get_comp_cnt
+ *
+ * Description:
+ *   Return current counter value of comparator
+ *
+ ****************************************************************************/
+
+static u64 s5j_mct_global_get_comp_cnt(FAR struct s5j_mct_priv_s *priv, int mct_id, uint32_t gmct_offset)
+{
+	u32 low;
+	u32 high;
+
+	DEBUGASSERT(mct_id == S5J_MCT_GLOBAL);
+
+	low = getreg32(priv->base_addr + S5J_MCT_G_COMP_L(gmct_offset));
+	high = getreg32(priv->base_addr + S5J_MCT_G_COMP_U(gmct_offset));
+
+	return (u64)(((u64)high << 32) | low);
+}
+
+/****************************************************************************
+ * Name: s5j_mct_global_disable_int
+ *
+ * Description:
+ *	Disable Global MCT interrupt.
+ *
+ ****************************************************************************/
+
+static void s5j_mct_global_disable_int(FAR struct s5j_mct_priv_s *priv, uint32_t gmct_int)
+{
+	unsigned int reg;
+
+	DEBUGASSERT(gmct_int >= MCT_G0 && gmct_int <= MCT_G3);
+
+	reg = getreg32(priv->base_addr + S5J_MCT_G_INT_ENB);
+	reg &= ~(1 << gmct_int);
+	putreg32(reg, priv->base_addr + S5J_MCT_G_INT_ENB);
+}
+
+/****************************************************************************
  * Private Data
  ****************************************************************************/
+#ifdef CONFIG_S5J_GTIMER
+static FAR struct s5j_mct_priv_s s5j_gmct_priv = {
+	.base_addr = S5J_MCT_BASE,
+	.irq_id    = IRQ_MCT_G0,
+};
+#endif
+
 #ifdef CONFIG_S5J_TIMER0
 static FAR struct s5j_mct_priv_s s5j_mct0_priv = {
 	.base_addr = (S5J_MCT_BASE + 0x300),
@@ -166,21 +215,259 @@ static bool g_mct_initialized;
 /****************************************************************************
  * Pubic Functions
  ****************************************************************************/
+/****************************************************************************
+ * Name: s5j_mct_global_get_frc_cnt
+ *
+ * Description:
+ *	Read all 64-bits of global free running counter.
+ *	Returns the number of cycles in the global counter.
+ *
+ *	Input Parameters:
+ *		priv - mct device structure
+ *
+ *	Returned Value:
+ *		64-bit Global FRC value.
+ *
+ ****************************************************************************/
+
+u64 s5j_mct_global_get_frc_cnt(FAR struct s5j_mct_priv_s *priv)
+{
+	u32 low;
+	u32 high;
+	u32 high1 = getreg32(priv->base_addr + S5J_MCT_G_CNT_U);
+
+	do {
+		high = high1;
+		low = getreg32(priv->base_addr + S5J_MCT_G_CNT_L);
+		high1 = getreg32(priv->base_addr + S5J_MCT_G_CNT_U);
+	} while (high != high1);
+
+	return sizeof(u64) > sizeof(u32) ? ((u64)high << 32) | low : (u64)low;
+}
+
+/****************************************************************************
+ * Name: s5j_mct_global_set_frc_cnt
+ *
+ * Description:
+ *	Set FRC counter value
+ *
+ *	Input Parameters:
+ *		priv - mct device structure
+ *		count - 64-bit count value
+ *
+ *	Return:
+ *		None
+ *
+ ****************************************************************************/
+
+void s5j_mct_global_set_frc_cnt(FAR struct s5j_mct_priv_s *priv, u64 count)
+{
+	u32 low;
+	u32 high;
+
+	if (count == s5j_mct_global_get_frc_cnt(priv)) {
+		return;
+	}
+
+	high = (u32)((count >> 32) & 0xFFFFFFFF);
+	low = (u32)(count & 0xFFFFFFFF);
+
+	putreg32(high, priv->base_addr + S5J_MCT_G_CNT_U);
+	s5j_mct_global_wait_wstat(priv->base_addr, S5J_MCT_G_CNT_WSTAT, WSTAT_G_CNT_U);
+
+	putreg32(low, priv->base_addr + S5J_MCT_G_CNT_L);
+	s5j_mct_global_wait_wstat(priv->base_addr, S5J_MCT_G_CNT_WSTAT, WSTAT_G_CNT_L);
+}
+
+/****************************************************************************
+ * Name: s5j_mct_global_start_frc
+ *
+ * Description:
+ *	Start Global Free-Running Counter
+ *
+ *	Input Parameters:
+ *		priv - mct device structure
+ *
+ *	Return:
+ *		None
+ *
+ ****************************************************************************/
+
+void s5j_mct_global_start_frc(FAR struct s5j_mct_priv_s *priv)
+{
+	unsigned int reg;
+
+	reg = getreg32(priv->base_addr + S5J_MCT_G_TCON);
+	reg |= G_TCON_START_FRC;
+	putreg32(reg, priv->base_addr + S5J_MCT_G_TCON);
+	s5j_mct_global_wait_wstat(priv->base_addr, S5J_MCT_G_WSTAT, WSTAT_G_TCON);
+}
+
+/****************************************************************************
+ * Name: s5j_mct_global_set_comp_cnt
+ *
+ * Description:
+ *	Set global timer comparation value.
+ *	MCT will set interrupt if reach to timer count.
+ *	FRC in global timer is an up-counter.
+ *	After it starts, it increments until 64'hffff_ffff_ffff_ffff and returns to 0.
+ *
+ *	Input Parameters:
+ *		priv - mct device structure
+ *		mct_id - global mct device id (S5J_MCT_GLOBAL)
+ *		gmct_offset - offset to comparator counter register from the mct base address
+ *		count - 64-bit count value
+ *
+ *	Return:
+ *		None
+ *
+ ****************************************************************************/
+
+void s5j_mct_global_set_comp_cnt(FAR struct s5j_mct_priv_s *priv, int mct_id, uint32_t gmct_offset, u64 count)
+{
+	u32 low;
+	u32 high;
+
+	DEBUGASSERT(mct_id == S5J_MCT_GLOBAL);
+
+	if (count == s5j_mct_global_get_comp_cnt(priv, mct_id, gmct_offset)) {
+		return;
+	}
+
+	low = (u32)(count & 0xFFFFFFFF);
+	high = (u32)((count >> 32) & 0xFFFFFFFF);
+
+	putreg32(low, priv->base_addr + S5J_MCT_G_COMP_L(gmct_offset));
+	s5j_mct_global_wait_wstat(priv->base_addr, S5J_MCT_G_WSTAT,  WSTAT_G_COMP_L(gmct_offset));
+
+	putreg32(high, priv->base_addr + S5J_MCT_G_COMP_U(gmct_offset));
+	s5j_mct_global_wait_wstat(priv->base_addr, S5J_MCT_G_WSTAT, WSTAT_G_COMP_U(gmct_offset));
+}
+
+/****************************************************************************
+ * Name: s5j_mct_global_disable_comp
+ *
+ * Description:
+ *	Disable the comparison between the global FRC and the 64-bit comparaton in MCT channel.
+ *
+ *	Input Parameters:
+ *		priv - mct device structure
+ *		mct_id - global mct device id (S5J_MCT_GLOBAL)
+ *		gmct_offset - offset to comparator enable field in control register
+ *
+ *	Return:
+ *		None
+ *
+ ****************************************************************************/
+
+void s5j_mct_global_disable_comp(FAR struct s5j_mct_priv_s *priv, int mct_id, uint32_t gmct_offset)
+{
+	unsigned int reg;
+
+	DEBUGASSERT(mct_id == S5J_MCT_GLOBAL);
+
+	reg = getreg32(priv->base_addr + S5J_MCT_G_TCON);
+	if (reg & G_TCON_COMP_ENABLE(gmct_offset)) {
+		reg &= ~(1 << (gmct_offset * 2));
+		putreg32(reg, priv->base_addr + S5J_MCT_G_TCON);
+		s5j_mct_global_wait_wstat(priv->base_addr, S5J_MCT_G_WSTAT, WSTAT_G_TCON);
+	}
+}
+
+/****************************************************************************
+ * Name: s5j_mct_global_enable_comp
+ *
+ * Description:
+ *	Enable the comparison between the global FRC and the 64-bit comparaton in MCT channel.
+ *
+ *	Input Parameters:
+ *		priv - mct device structure
+ *		mct_id - global mct device id (S5J_MCT_GLOBAL)
+ *		gmct_offset - offset to comparator enable field in control register
+ *
+ *	Return:
+ *		None
+ *
+ ****************************************************************************/
+
+void s5j_mct_global_enable_comp(FAR struct s5j_mct_priv_s *priv, int mct_id, uint32_t gmct_offset)
+{
+	unsigned int reg;
+
+	DEBUGASSERT(mct_id == S5J_MCT_GLOBAL);
+
+	reg = getreg32(priv->base_addr + S5J_MCT_G_TCON);
+	if (!(reg & G_TCON_COMP_ENABLE(gmct_offset))) {
+		reg |= G_TCON_COMP_ENABLE(gmct_offset);
+		putreg32(reg, priv->base_addr + S5J_MCT_G_TCON);
+		s5j_mct_global_wait_wstat(priv->base_addr, S5J_MCT_G_WSTAT, WSTAT_G_TCON);
+	}
+}
+
+/****************************************************************************
+ * Name: s5j_mct_clear_pending
+ *
+ * Description:
+ *	Clear interupt pending register in MCT.
+ *
+ *	Input Parameters:
+ *		priv - mct device structure
+ *		mct_id - global mct device id (S5J_MCT_GLOBAL)
+ *		gmct_offset - offset to interrupt status
+ *
+ *	Return:
+ *		None
+ *
+ ****************************************************************************/
+
+void s5j_mct_clear_pending(FAR struct s5j_mct_priv_s *priv, int mct_id, uint32_t gmct_offset)
+{
+	if (mct_id == S5J_MCT_GLOBAL) {
+		putreg32(1 << gmct_offset, priv->base_addr + S5J_MCT_G_INT_CSTAT);
+	}
+}
+
+/****************************************************************************
+ * Name: s5j_mct_global_enable_int
+ *
+ * Description:
+ *	Enable Global MCT interrupt.
+ *
+ *	Input Parameters:
+ *		priv - mct device structure
+ *		mct_id - global mct interrupt number
+ *
+ *	Return:
+ *		None
+ *
+ ****************************************************************************/
+
+void s5j_mct_global_enable_int(FAR struct s5j_mct_priv_s *priv, uint32_t gmct_int)
+{
+	unsigned int reg;
+
+	DEBUGASSERT(gmct_int >= 0 && gmct_int < 4);
+
+	reg = getreg32(priv->base_addr + S5J_MCT_G_INT_ENB);
+	reg |= 1 << gmct_int;
+	putreg32(reg, priv->base_addr + S5J_MCT_G_INT_ENB);
+}
+
 void s5j_mct_ack_irq(FAR struct s5j_mct_priv_s *priv)
 {
 	unsigned int cstat = S5J_MCT_INT_CSTAT_FRC | S5J_MCT_INT_CSTAT_ICNT;
 
-	mct_putreg32(priv, S5J_MCT_INT_CSTAT_OFFSET, cstat);
+	mct_putreg32(priv, S5J_MCT_L_INT_CSTAT_OFFSET, cstat);
 }
 
 void s5j_mct_setmode(FAR struct s5j_mct_priv_s *priv, bool oneshot)
 {
-	unsigned int value = mct_getreg32(priv, S5J_MCT_TCON_OFFSET);
+	unsigned int value = mct_getreg32(priv, S5J_MCT_L_TCON_OFFSET);
 
 	if (oneshot) {
-		mct_putreg32(priv, S5J_MCT_TCON_OFFSET, value & ~S5J_MCT_TCON_INTERVAL_MODE);
+		mct_putreg32(priv, S5J_MCT_L_TCON_OFFSET, value & ~S5J_MCT_L_TCON_INTERVAL_MODE);
 	} else {
-		mct_putreg32(priv, S5J_MCT_TCON_OFFSET, value | S5J_MCT_TCON_INTERVAL_MODE);
+		mct_putreg32(priv, S5J_MCT_L_TCON_OFFSET, value | S5J_MCT_L_TCON_INTERVAL_MODE);
 	}
 
 	s5j_mct_wait_wstat(priv->base_addr, S5J_MCT_WSTAT_TCON);
@@ -191,9 +478,9 @@ void s5j_mct_enable(FAR struct s5j_mct_priv_s *priv)
 	unsigned int value;
 
 	/* Start timer and enable interrupt */
-	value = mct_getreg32(priv, S5J_MCT_TCON_OFFSET);
-	value |= S5J_MCT_TCON_INT_START | S5J_MCT_TCON_TIMER_START;
-	mct_putreg32(priv, S5J_MCT_TCON_OFFSET, value);
+	value = mct_getreg32(priv,  S5J_MCT_L_TCON_OFFSET);
+	value |=  S5J_MCT_L_TCON_INT_START |  S5J_MCT_L_TCON_TIMER_START;
+	mct_putreg32(priv,  S5J_MCT_L_TCON_OFFSET, value);
 	s5j_mct_wait_wstat(priv->base_addr, S5J_MCT_WSTAT_TCON);
 }
 
@@ -202,9 +489,9 @@ void s5j_mct_disable(FAR struct s5j_mct_priv_s *priv)
 	unsigned int value;
 
 	/* Stop timer and disable interrupt */
-	value = mct_getreg32(priv, S5J_MCT_TCON_OFFSET);
-	value &= ~(S5J_MCT_TCON_TIMER_START | S5J_MCT_TCON_INT_START);
-	mct_putreg32(priv, S5J_MCT_TCON_OFFSET, value);
+	value = mct_getreg32(priv,  S5J_MCT_L_TCON_OFFSET);
+	value &= ~(S5J_MCT_L_TCON_TIMER_START | S5J_MCT_L_TCON_INT_START);
+	mct_putreg32(priv,  S5J_MCT_L_TCON_OFFSET, value);
 	s5j_mct_wait_wstat(priv->base_addr, S5J_MCT_WSTAT_TCON);
 }
 
@@ -221,25 +508,25 @@ int s5j_mct_setisr(FAR struct s5j_mct_priv_s *priv, xcpt_t handler, void *arg)
 void s5j_mct_setperiod(FAR struct s5j_mct_priv_s *priv, uint32_t period)
 {
 	/* Write the appropriate values to TCNTB SFR to set the tick counter. */
-	mct_putreg32(priv, S5J_MCT_TCNTB_OFFSET, period);
+	mct_putreg32(priv,  S5J_MCT_L_TCNTB_OFFSET, period);
 	s5j_mct_wait_wstat(priv->base_addr, S5J_MCT_WSTAT_TCNTB);
 
 	/*
 	 * Write ICNTB SFR with ICNTB[31] = 1 to
 	 * update the 31-bit internal interrupt counter.
 	 */
-	mct_putreg32(priv, S5J_MCT_ICNTB_OFFSET, 1 << 31);
+	mct_putreg32(priv,  S5J_MCT_L_ICNTB_OFFSET, 1 << 31);
 	s5j_mct_wait_wstat(priv->base_addr, S5J_MCT_WSTAT_ICNTB);
 }
 
 void s5j_mct_enableint(FAR struct s5j_mct_priv_s *priv)
 {
-	mct_putreg32(priv, S5J_MCT_INT_ENB_OFFSET, S5J_MCT_INTR_ICNT);
+	mct_putreg32(priv,  S5J_MCT_L_INT_ENB_OFFSET, S5J_MCT_INTR_ICNT);
 }
 
 void s5j_mct_disableint(FAR struct s5j_mct_priv_s *priv)
 {
-	mct_putreg32(priv, S5J_MCT_INT_ENB_OFFSET, 0);
+	mct_putreg32(priv,  S5J_MCT_L_INT_ENB_OFFSET, 0);
 }
 
 FAR struct s5j_mct_priv_s *s5j_mct_init(int timer)
@@ -249,6 +536,14 @@ FAR struct s5j_mct_priv_s *s5j_mct_init(int timer)
 	DEBUGASSERT(timer < CONFIG_S5J_MCT_NUM);
 
 	switch (timer) {
+	/* Global Timer */
+#ifdef CONFIG_S5J_GTIMER
+	case S5J_MCT_GLOBAL:
+		priv = &s5j_gmct_priv;
+		break;
+#endif
+
+	/* Local Timers */
 #ifdef CONFIG_S5J_TIMER0
 	case S5J_MCT_CHANNEL0:
 		priv = &s5j_mct0_priv;
@@ -277,6 +572,7 @@ FAR struct s5j_mct_priv_s *s5j_mct_init(int timer)
 	if (!g_mct_initialized && priv) {
 		s5j_mct_setclock(USEC_PER_SEC);
 		g_mct_initialized = true;
+		lldbg("MCT Initilaized\n");
 	}
 
 	return priv;

--- a/os/arch/arm/src/s5j/s5j_mct.h
+++ b/os/arch/arm/src/s5j/s5j_mct.h
@@ -68,10 +68,19 @@
  ****************************************************************************/
 /* Helpers ******************************************************************/
 #ifdef CONFIG_S5J_MCT
-#  define CONFIG_S5J_MCT_NUM    4
+#  define CONFIG_S5J_MCT_NUM    5 /* 1 (Global) + 4 (Local) Timers */
 #else
 #  define CONFIG_S5J_MCT_NUM    0
 #endif
+
+/****************************************************************************
+ * Private Types
+ ****************************************************************************/
+struct s5j_mct_priv_s {
+	/* mct base address */
+	uint32_t base_addr;
+	int	irq_id;
+};
 
 /****************************************************************************
  * Public Types
@@ -87,11 +96,21 @@ extern "C"
 #define EXTERN extern
 #endif
 
+/* MCT Timers */
 enum s5j_mct_channel_e {
+	S5J_MCT_GLOBAL,
 	S5J_MCT_CHANNEL0,
 	S5J_MCT_CHANNEL1,
 	S5J_MCT_CHANNEL2,
 	S5J_MCT_CHANNEL3,
+};
+
+/* Global MCT Timer supports 4 match interrupts */
+enum {
+	MCT_G0,
+	MCT_G1,
+	MCT_G2,
+	MCT_G3,
 };
 
 /****************************************************************************
@@ -110,6 +129,17 @@ void s5j_mct_disableint(FAR struct s5j_mct_priv_s *priv);
 
 /* Power-up timer and get its structure */
 FAR struct s5j_mct_priv_s *s5j_mct_init(int timer);
+
+u64 s5j_mct_global_get_frc_cnt(FAR struct s5j_mct_priv_s *priv);
+void s5j_mct_global_set_frc_cnt(FAR struct s5j_mct_priv_s *priv, u64 count);
+void s5j_mct_global_start_frc(FAR struct s5j_mct_priv_s *priv);
+void s5j_mct_global_stop_frc(FAR struct s5j_mct_priv_s *priv);
+void s5j_mct_global_set_comp_cnt(FAR struct s5j_mct_priv_s *priv, int mct_id, uint32_t gmct_offset, u64 count);
+void s5j_mct_global_disable_comp(FAR struct s5j_mct_priv_s *priv, int mct_id, uint32_t gmct_offset);
+void s5j_mct_global_enable_comp(FAR struct s5j_mct_priv_s *priv, int mct_id, uint32_t gmct_offset);
+void s5j_mct_global_enable_int(FAR struct s5j_mct_priv_s *priv, uint32_t gmct_int);
+static void s5j_mct_global_disable_int(FAR struct s5j_mct_priv_s *priv, uint32_t gmct_int);
+void s5j_mct_clear_pending(FAR struct s5j_mct_priv_s *priv, int mct_id, uint32_t gmct_offset);
 
 /****************************************************************************
  * Name: s5j_timer_initialize

--- a/os/arch/arm/src/s5j/s5j_tickless.c
+++ b/os/arch/arm/src/s5j/s5j_tickless.c
@@ -1,0 +1,248 @@
+/****************************************************************************
+ *
+ * Copyright 2018 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+/****************************************************************************
+ * arch/arm/src/s5j/s5j_tickless.c
+ *
+ *   Copyright (C) 2009, 2014 Gregory Nutt. All rights reserved.
+ *   Author: Gregory Nutt <gnutt@nuttx.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+/****************************************************************************
+ * Tickless OS Support.
+ *
+ * When CONFIG_SCHED_TICKLESS is enabled, all support for timer interrupts
+ * is suppressed and the platform specific code is expected to provide the
+ * following custom functions.
+ *
+ *   void up_timer_initialize(void): Initializes the timer facilities.  Called
+ *     early in the intialization sequence (by up_intialize()).
+ *   int up_timer_gettime(FAR struct timespec *ts):  Returns the current
+ *     time from the platform specific time source.
+ *   int up_alarm_cancel(void):  Cancels the interval timer.
+ *   int up_alarm_start(FAR const struct timespec *ts): Start (or re-starts)
+ *     the interval timer.
+ *
+ * The RTOS will provide the following interfaces for use by the platform-
+ * specific interval timer implementation:
+ *
+ *   void sched_timer_expiration(void):  Called by the platform-specific
+ *     logic when the interval timer expires.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <tinyara/config.h>
+
+#include <stdint.h>
+#include <time.h>
+#include <debug.h>
+#include <tinyara/arch.h>
+
+#include "s5j_mct.h"
+#include "s5j_clock.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Types
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+static struct s5j_mct_priv_s *g_mct;
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: s5j_convert_systimr
+ *
+ * Description:
+ *   Convert the 64-bit system timer value to a standard struct ts
+ *
+ * Input Parameters:
+ *   ts = Location to return the converted system timer value
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+static void s5j_convert_systimr(u64 usec, FAR struct timespec *ts)
+{
+	u32 sec;
+
+	sec         = (u32)(usec / USEC_PER_SEC);
+	ts->tv_sec  = sec;
+	ts->tv_nsec = (usec - (sec * USEC_PER_SEC)) * NSEC_PER_USEC;
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Function:  up_timerisr
+ *
+ * Description:
+ *   The timer ISR will perform a variety of services for various portions
+ *   of the systems.
+ *
+ ****************************************************************************/
+int up_timerisr(int irq, uint32_t *regs)
+{
+	struct timespec ts;
+	u64 cnt_val;
+
+	s5j_mct_clear_pending(g_mct, S5J_MCT_GLOBAL, MCT_G0);
+
+	cnt_val = s5j_mct_global_get_frc_cnt(g_mct);
+
+	s5j_convert_systimr(cnt_val, &ts);
+
+	/* Process timer interrupt */
+	sched_alarm_expiration(&ts);
+
+	return 0;
+}
+
+/****************************************************************************
+ * Function:  up_timer_initialize
+ *
+ * Description:
+ *   This function is called during start-up to initialize
+ *   the timer interrupt.
+ *
+ ****************************************************************************/
+void up_timer_initialize(void)
+{
+	/* Initialize MCT */
+	g_mct = s5j_mct_init(S5J_MCT_GLOBAL);
+
+	DEBUGASSERT(g_mct);
+
+	s5j_mct_global_set_frc_cnt(g_mct, 0);
+
+	s5j_mct_global_start_frc(g_mct);
+
+	(void)irq_attach(IRQ_MCT_G0, (xcpt_t)up_timerisr, NULL);
+
+	/* Enable SysTick interrupts */
+	s5j_mct_global_enable_int(g_mct, MCT_G0);
+
+
+	/* And enable the timer interrupt */
+	up_enable_irq(IRQ_MCT_G0);
+}
+
+int up_timer_gettime(FAR struct timespec *ts)
+{
+	u64 cnt_val;
+	irqstate_t flags;
+
+	DEBUGASSERT(g_mct && ts != NULL);
+
+	/* Read the 64-bit frc */
+
+	flags = irqsave();
+	cnt_val = s5j_mct_global_get_frc_cnt(g_mct);
+	irqrestore(flags);
+
+	s5j_convert_systimr(cnt_val, ts);
+
+	return OK;
+}
+
+int up_alarm_cancel(FAR struct timespec *ts)
+{
+	u64 cnt_val;
+	irqstate_t flags;
+
+	DEBUGASSERT(g_mct && ts != NULL);
+
+	flags = irqsave();
+	up_disable_irq(IRQ_MCT_G0);
+
+	s5j_mct_global_disable_comp(g_mct, S5J_MCT_GLOBAL, MCT_G0);
+
+	cnt_val = s5j_mct_global_get_frc_cnt(g_mct);
+
+	up_enable_irq(IRQ_MCT_G0);
+	irqrestore(flags);
+
+	s5j_convert_systimr(cnt_val, ts);
+
+	return OK;
+}
+
+int up_alarm_start(FAR const struct timespec *ts)
+{
+	u64 cnt_val;
+	irqstate_t flags;
+
+	DEBUGASSERT(g_mct && ts != NULL);
+
+	cnt_val = (u64)ts->tv_sec * USEC_PER_SEC;
+	cnt_val += (u64)ts->tv_nsec / NSEC_PER_USEC;
+
+	flags = irqsave();
+	up_disable_irq(IRQ_MCT_G0);
+
+	s5j_mct_global_set_comp_cnt(g_mct, S5J_MCT_GLOBAL, MCT_G0, cnt_val);
+
+	s5j_mct_global_enable_comp(g_mct, S5J_MCT_GLOBAL, MCT_G0);
+
+	up_enable_irq(IRQ_MCT_G0);
+	irqrestore(flags);
+
+	return OK;
+}

--- a/os/kernel/init/os_start.c
+++ b/os/kernel/init/os_start.c
@@ -490,6 +490,14 @@ void os_start(void)
 	}
 #endif
 
+	/* The processor specific details of running the operating system
+	 * will be handled here.  Such things as setting up interrupt
+	 * service routines and starting the clock are some of the things
+	 * that are different for each  processor and hardware platform.
+	 */
+
+	up_initialize();
+
 #ifdef CONFIG_NET
 	/* Initialize the networking system.  Network initialization is
 	 * performed in two steps:  (1) net_setup() initializes static
@@ -502,14 +510,6 @@ void os_start(void)
 	net_setup();
 
 #endif							/* CONFIG_NET */
-
-	/* The processor specific details of running the operating system
-	 * will be handled here.  Such things as setting up interrupt
-	 * service routines and starting the clock are some of the things
-	 * that are different for each  processor and hardware platform.
-	 */
-
-	up_initialize();
 
 #ifdef CONFIG_KERNEL_TEST_DRV
 	test_drv_register();


### PR DESCRIPTION
1. s5j arch support for Tickless kernel feature.

Tickless feature can be enabled by enabling below configs through menuconfig,

> Hardware Configuration > Chip Selection > S5J Peripheral Support > [*] MCT Global TIMER
CONFIG_S5J_G_TIMER=y
CONFIG_S5J_MCT=y

> Kernel Features > Clocks and Timers > [*] Support tick-less OS
CONFIG_SCHED_TICKLESS=y

> Kernel Features > Clocks and Timers > [*]   Tickless alarm
CONFIG_SCHED_TICKLESS_ALARM=y

> Kernel Features > Clocks and Timers > (100) System timer tick period (microseconds)
CONFIG_USEC_PER_TICK=100

2. adds device driver support for mct global timer.