### PR TITLE
framework/st_things : Fix memory leak.

### DIFF
--- a/framework/src/st_things/st_things_request_handler.c
+++ b/framework/src/st_things/st_things_request_handler.c
@@ -265,6 +265,7 @@ bool add_common_props(things_resource_s *rsrc, bool collection, OCRepPayload *re
 			return false;
 		}
 	}
+	util_free(res_types);
 
 	// Set interface types.
 	int if_count = 0;
@@ -282,6 +283,7 @@ bool add_common_props(things_resource_s *rsrc, bool collection, OCRepPayload *re
 			return false;
 		}
 	}
+	util_free(if_types);
 
 	// Set "links"(only for collection).
 	if (collection) {

--- a/framework/src/st_things/things_stack/framework/things_data_manager.h
+++ b/framework/src/st_things/things_stack/framework/things_data_manager.h
@@ -55,8 +55,9 @@ typedef struct st_resource_type_s {
 typedef struct col_resource_s {
 	char uri[MAX_URI_LENGTH_OCF];
 	char *interface_types[MAX_IT_CNT];
-	struct things_resource_info_s *links[MAX_DEVICE_CAPABILTY_CNT];
 	char *resource_types[MAX_RT_CNT];
+
+	struct things_resource_info_s **links;
 
 	int if_cnt;
 	int rt_cnt;


### PR DESCRIPTION
To generate the response of resource,
the function created double pointer and allocate some memories.
But these memory had not freed.