### PR TITLE
kernel/pthread: modify operation of pthread key

### DIFF
--- a/os/include/pthread.h
+++ b/os/include/pthread.h
@@ -244,7 +244,7 @@ extern "C" {
 
 /* pthread-specific types */
 
-typedef int pthread_key_t;
+typedef unsigned int pthread_key_t;
 typedef FAR void *pthread_addr_t;
 
 typedef pthread_addr_t(*pthread_startroutine_t)(pthread_addr_t);

--- a/os/include/tinyara/sched.h
+++ b/os/include/tinyara/sched.h
@@ -252,6 +252,10 @@ typedef CODE void (*atexitfunc_t)(void);
 typedef CODE void (*onexitfunc_t)(int exitcode, FAR void *arg);
 #endif
 
+#if CONFIG_NPTHREAD_KEYS > 0
+typedef CODE void (*pthread_destructor_t)(void *arg);
+#endif
+
 /* struct child_status_s *********************************************************/
 /** @brief This structure is used to maintin information about child tasks.
  * pthreads work differently, they have join information.  This is
@@ -299,6 +303,14 @@ struct dspace_s {
 	 */
 
 	FAR uint8_t *region;
+};
+#endif
+
+/* struct pthread_key_s **********************************************************/
+#if CONFIG_NPTHREAD_KEYS > 0
+struct pthread_key_s {
+	void *data;
+	pthread_destructor_t destructor;
 };
 #endif
 
@@ -395,7 +407,9 @@ struct task_group_s {
 	sem_t tg_joinsem;			/*   Mutually exclusive access to join data */
 	FAR struct join_s *tg_joinhead;	/*   Head of a list of join data            */
 	FAR struct join_s *tg_jointail;	/*   Tail of a list of join data            */
-	uint8_t tg_nkeys;			/* Number pthread keys allocated            */
+#if CONFIG_NPTHREAD_KEYS > 0
+	uint8_t tg_keys[CONFIG_NPTHREAD_KEYS];	/* Information of pthread keys allocated */
+#endif
 #endif
 
 #ifndef CONFIG_DISABLE_SIGNALS
@@ -649,7 +663,7 @@ struct pthread_tcb_s {
 	/* POSIX Thread Specific Data ************************************************ */
 
 #if CONFIG_NPTHREAD_KEYS > 0
-	FAR void *pthread_data[CONFIG_NPTHREAD_KEYS];
+	struct pthread_key_s pthread_data[CONFIG_NPTHREAD_KEYS];
 #endif
 #if defined(CONFIG_BUILD_PROTECTED)
 	struct pthread_region_s *region;

--- a/os/kernel/Kconfig
+++ b/os/kernel/Kconfig
@@ -432,6 +432,14 @@ config NPTHREAD_KEYS
 		The number of items of thread-
 		specific data that can be retained
 
+config NPTHREAD_DESTRUCTOR_ITERATIONS
+	int "Maximum number of calling pthread destructor"
+	default 4
+	depends on NPTHREAD_KEYS != 0
+	---help---
+		The number of destructor of thread-
+		specific data that can be called
+
 config PTHREAD_CLEANUP
 	bool "pthread cleanup stack"
 	default n

--- a/os/kernel/pthread/Make.defs
+++ b/os/kernel/pthread/Make.defs
@@ -58,7 +58,9 @@ CSRCS += pthread_mutexinit.c pthread_mutexdestroy.c
 CSRCS += pthread_mutexlock.c pthread_mutextrylock.c pthread_mutexunlock.c
 CSRCS += pthread_condwait.c pthread_condsignal.c pthread_condbroadcast.c
 CSRCS += pthread_cancel.c
+ifneq ($(CONFIG_NPTHREAD_KEYS),0)
 CSRCS += pthread_keycreate.c pthread_setspecific.c pthread_getspecific.c pthread_keydelete.c
+endif
 CSRCS += pthread_initialize.c pthread_completejoin.c pthread_findjoininfo.c
 CSRCS += pthread_release.c pthread_setschedprio.c
 

--- a/os/kernel/pthread/pthread.h
+++ b/os/kernel/pthread/pthread.h
@@ -70,6 +70,14 @@
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
+#define NOT_IN_USE                     0  /* Pthread key is not in-use */
+#define IN_USE                         1  /* Pthread key is in-use     */
+/* Max Number of calling destructor */
+#ifdef CONFIG_NPTHREAD_DESTRUCTOR_ITERATIONS
+#define PTHREAD_DESTRUCTOR_ITERATIONS  CONFIG_NPTHREAD_DESTRUCTOR_ITERATIONS
+#else
+#define PTHREAD_DESTRUCTOR_ITERATIONS  2
+#endif
 
 /****************************************************************************
  * Public Type Declarations

--- a/os/kernel/pthread/pthread_getspecific.c
+++ b/os/kernel/pthread/pthread_getspecific.c
@@ -107,8 +107,6 @@
  *   associated with the given key.  If no thread specific data is
  *   associated with the key, then the value NULL is returned.
  *
- *      EINVAL - The key value is invalid.
- *
  * Assumptions:
  *
  * POSIX Compatibility:
@@ -120,7 +118,6 @@
 
 FAR void *pthread_getspecific(pthread_key_t key)
 {
-#if CONFIG_NPTHREAD_KEYS > 0
 	FAR struct pthread_tcb_s *rtcb = (FAR struct pthread_tcb_s *)this_task();
 	FAR struct task_group_s *group = rtcb->cmn.group;
 	FAR void *ret = NULL;
@@ -129,14 +126,11 @@ FAR void *pthread_getspecific(pthread_key_t key)
 
 	/* Check if the key is valid. */
 
-	if (key < group->tg_nkeys) {
+	if (key < PTHREAD_KEYS_MAX && group->tg_keys[key] == IN_USE) {
 		/* Return the stored value. */
 
-		ret = rtcb->pthread_data[key];
+		ret = rtcb->pthread_data[key].data;
 	}
 
 	return ret;
-#else
-	return NULL;
-#endif
 }

--- a/os/kernel/pthread/pthread_setspecific.c
+++ b/os/kernel/pthread/pthread_setspecific.c
@@ -131,27 +131,22 @@
 
 int pthread_setspecific(pthread_key_t key, FAR const void *value)
 {
-#if CONFIG_NPTHREAD_KEYS > 0
 	FAR struct pthread_tcb_s *rtcb = (FAR struct pthread_tcb_s *)this_task();
 	FAR struct task_group_s *group = rtcb->cmn.group;
-	int ret = EINVAL;
 
 	DEBUGASSERT(group && (rtcb->cmn.flags & TCB_FLAG_TTYPE_MASK) == TCB_FLAG_TTYPE_PTHREAD);
 
 	/* Check if the key is valid. */
 
-	if (key < group->tg_nkeys) {
+	if (key < PTHREAD_KEYS_MAX && group->tg_keys[key] == IN_USE) {
 		/* Store the data in the TCB. */
 
-		rtcb->pthread_data[key] = (FAR void *)value;
+		rtcb->pthread_data[key].data = (FAR void *)value;
 
 		/* Return success. */
 
-		ret = OK;
+		return OK;
 	}
 
-	return ret;
-#else
-	return ENOSYS;
-#endif
+	return EINVAL;
 }


### PR DESCRIPTION
kernel/pthread: modify operation of pthread key

Currently pthread key supports only create, not delete.
It causes limitation of pthread key usages, only first CONFIG_NPTHREAD_KEYS
number keys are working.
This commit supports deleting key so that this fixs above issue.

Here is results of simple exmaple using pthread key on this commit:
key1 create!! ret = 0, key = 0
key2 create!! ret = 0, key = 1
key3 create!! ret = 0, key = 2
key4 create!! ret = 0, key = 3
key5 create!! ret = 11, key = 33945344
key2 set!! ret = 0
key1 get!! ret = -369098745
key2 get!! ret = 123
key3 get!! ret = -369098745
key2 delete!! ret = 0
key2 get!! ret = -369098745
key6 create!! ret = 0, key = 1
key6 get!! ret = -369098745
key6 set!! ret = 0
key6 get!! ret = 123
