### PR TITLE
apps/builtin : Add omitted const identifier

### DIFF
--- a/apps/builtin/builtin_taskinfo.c
+++ b/apps/builtin/builtin_taskinfo.c
@@ -70,7 +70,7 @@
 /****************************************************************************
  * Public Data
  ****************************************************************************/
-tash_taskinfo_t tash_taskinfo_list[] = {
+const tash_taskinfo_t tash_taskinfo_list[] = {
 #include "builtin_taskinfo.h"
 	{ NULL, 0, 0 }
 };

--- a/apps/shell/tash_command.c
+++ b/apps/shell/tash_command.c
@@ -86,7 +86,7 @@ static int tash_exit(int argc, char **args);
 static int tash_reboot(int argc, char **argv);
 #endif
 
-extern tash_taskinfo_t tash_taskinfo_list[];
+extern const tash_taskinfo_t tash_taskinfo_list[];
 /****************************************************************************
  * Private Variables
  ****************************************************************************/

--- a/apps/system/utils/kdbg_stackopt.c
+++ b/apps/system/utils/kdbg_stackopt.c
@@ -49,7 +49,7 @@
  * Extern Data
  ****************************************************************************/
 extern struct stkmon_save_s stkmon_arr[CONFIG_MAX_TASKS * 2];
-extern tash_taskinfo_t tash_taskinfo_list[];
+extern const tash_taskinfo_t tash_taskinfo_list[];
 
 static bool find_app(TASH_CMD_CALLBACK *cb, char *name)
 {


### PR DESCRIPTION
tash_taskinfo_list[] is declared when build time, so it cannot be changed.
so set to const.