### PR TITLE
Qemu/readme : Update about using latest qemu sw 2.12.0-rc1

### DIFF
--- a/build/configs/qemu/README.md
+++ b/build/configs/qemu/README.md
@@ -18,11 +18,12 @@ This section covers board-specific environment set-up.
 Please set TizenRT common environment, [quick start](https://github.com/Samsung/TizenRT#quick-start), first before doing below.
 
 ### QEMU installation
+#Qemu version used 2.12.0-rc1
 
 ```
-wget http://download.qemu-project.org/qemu-2.10.0-rc2.tar.xz
-tar xvJf qemu-2.10.0-rc2.tar.xz
-cd qemu-2.10.0-rc2
+wget https://download.qemu.org/qemu-2.12.0-rc1.tar.xz
+tar xvJf qemu-2.12.0-rc1.tar.xz
+cd qemu-2.12.0-rc1
 /* If you want to use 1MB RAM, copy qemu-2.10.0-rc2_1m_ram_size.patch from TizenRT/build/configs/qemu */
 patch -p1 < qemu-2.10.0-rc2_1m_ram_size.patch
 /* If you want to use 16MB RAM, copy qemu-2.10.0-rc2_16m_ram_size.patch from TizenRT/build/configs/qemu */


### PR DESCRIPTION
Issue: Hardfault while running iperf application with huge TCP throughput [>20MB]
Fix: Use latest qemu sw : 2.12.0-rc1
Qemu sw has been recently updated with several enhancements to
cortex m profile emulation as well as to network component.
More details about change log is here: https://wiki.qemu.org/ChangeLog/2.12
procedure to download and build are updated in this readme

Signed-off-by: pradeep.ns <pradeep.ns@samsung.com>