### PR TITLE
framework/st_things : Changes OCRepSet/Add*AsOwner to OCRep*.

### DIFF
--- a/framework/src/st_things/st_things_request_handler.c
+++ b/framework/src/st_things/st_things_request_handler.c
@@ -261,7 +261,7 @@ bool add_common_props(things_resource_s *rsrc, bool collection, OCRepPayload *re
 	}
 
 	for (int i = 0; i < rt_count; i++) {
-		if (!OCRepPayloadAddResourceTypeAsOwner(resp_payload, res_types[i])) {
+		if (!OCRepPayloadAddResourceType(resp_payload, res_types[i])) {
 			THINGS_LOG(THINGS_ERROR, TAG, "Failed to add the resource type in the response payload.");
 			// Release memory allocated for resource types.
 			things_free_str_array(res_types, rt_count);
@@ -278,7 +278,7 @@ bool add_common_props(things_resource_s *rsrc, bool collection, OCRepPayload *re
 	}
 
 	for (int i = 0; i < if_count; i++) {
-		if (!OCRepPayloadAddInterfaceAsOwner(resp_payload, if_types[i])) {
+		if (!OCRepPayloadAddInterface(resp_payload, if_types[i])) {
 			THINGS_LOG(THINGS_ERROR, TAG, "Failed to add the interface type in the response payload.");
 			// Release memory allocated for interface types.
 			things_free_str_array(if_types, if_count);
@@ -297,7 +297,7 @@ bool add_common_props(things_resource_s *rsrc, bool collection, OCRepPayload *re
 
 		THINGS_LOG(THINGS_DEBUG, TAG, "Formed links for collection.");
 		size_t dimensions[MAX_REP_ARRAY_DEPTH] = { count, 0, 0 };
-		bool result = OCRepPayloadSetPropObjectArrayAsOwner(resp_payload, OC_RSRVD_LINKS, links, dimensions);
+		bool result = OCRepPayloadSetPropObjectArray(resp_payload, OC_RSRVD_LINKS, links, dimensions);
 		if (!result) {
 			THINGS_LOG(THINGS_ERROR, TAG, "Failed to add the links in the response payload.");
 			for (size_t i = 0; i < count && NULL != links[i]; i++) {
@@ -522,7 +522,7 @@ static bool add_property_in_post_req_msg(st_things_set_request_message_s *req_ms
 	case STRING_ID: {
 		char *value = NULL;
 		if (OCRepPayloadGetPropString(req_payload, prop->key, &value)) {
-			result = OCRepPayloadSetPropStringAsOwner(resp_payload, prop->key, value);
+			result = OCRepPayloadSetPropString(resp_payload, prop->key, value);
 			if (!result) {
 				THINGS_LOG_V(THINGS_ERROR, TAG, "Failed to set the string value of '%s' in request message", prop->key);
 				things_free(value);
@@ -535,7 +535,7 @@ static bool add_property_in_post_req_msg(st_things_set_request_message_s *req_ms
 	case OBJECT_ID: {
 		OCRepPayload *value = NULL;
 		if (OCRepPayloadGetPropObject(req_payload, prop->key, &value)) {
-			result = OCRepPayloadSetPropObjectAsOwner(resp_payload, prop->key, value);
+			result = OCRepPayloadSetPropObject(resp_payload, prop->key, value);
 			if (!result) {
 				THINGS_LOG_V(THINGS_ERROR, TAG, "Failed to set the object value of '%s' in request message", prop->key);
 				OCRepPayloadDestroy(value);
@@ -546,24 +546,15 @@ static bool add_property_in_post_req_msg(st_things_set_request_message_s *req_ms
 	}
 	break;
 	case BYTE_ID: {
-		OCByteString *byte_value = (OCByteString *)things_calloc(1, sizeof(OCByteString));
-		if (NULL == byte_value) {
-			THINGS_LOG_V(THINGS_ERROR, TAG, "Failed to allocate memory for byte string value of '%s' in request message", prop->key);
-			break;
-		}
-
-		if (OCRepPayloadGetPropByteString(req_payload, prop->key, byte_value)) {
-			result = OCRepPayloadSetPropByteStringAsOwner(resp_payload, prop->key, byte_value);
+		OCByteString byte_value;
+		if (OCRepPayloadGetPropByteString(req_payload, prop->key, &byte_value)) {
+			result = OCRepPayloadSetPropByteString(resp_payload, prop->key, byte_value);
 			if (!result) {
 				THINGS_LOG_V(THINGS_ERROR, TAG, "Failed to set the byte string value of '%s' in request message", prop->key);
-				things_free(byte_value->bytes);
+				things_free(byte_value.bytes);
 			}
 		} else {
 			THINGS_LOG_V(THINGS_ERROR, TAG, "Failed to get the byte string value of '%s' for request message", prop->key);
-		}
-
-		if (!result) {
-			things_free(byte_value);
 		}
 	}
 	break;
@@ -571,7 +562,7 @@ static bool add_property_in_post_req_msg(st_things_set_request_message_s *req_ms
 		int64_t *value = NULL;
 		size_t dimensions[MAX_REP_ARRAY_DEPTH] = { 0 };
 		if (OCRepPayloadGetIntArray(req_payload, prop->key, &value, dimensions)) {
-			result = OCRepPayloadSetIntArrayAsOwner(resp_payload, prop->key, value, dimensions);
+			result = OCRepPayloadSetIntArray(resp_payload, prop->key, value, dimensions);
 			if (!result) {
 				THINGS_LOG_V(THINGS_ERROR, TAG, "Failed to set the integer array value of '%s' in request message", prop->key);
 				things_free(value);
@@ -585,7 +576,7 @@ static bool add_property_in_post_req_msg(st_things_set_request_message_s *req_ms
 		double *value = NULL;
 		size_t dimensions[MAX_REP_ARRAY_DEPTH] = { 0 };
 		if (OCRepPayloadGetDoubleArray(req_payload, prop->key, &value, dimensions)) {
-			result = OCRepPayloadSetDoubleArrayAsOwner(resp_payload, prop->key, value, dimensions);
+			result = OCRepPayloadSetDoubleArray(resp_payload, prop->key, value, dimensions);
 			if (!result) {
 				THINGS_LOG_V(THINGS_ERROR, TAG, "Failed to set the double array value of '%s' in request message", prop->key);
 				things_free(value);
@@ -599,7 +590,7 @@ static bool add_property_in_post_req_msg(st_things_set_request_message_s *req_ms
 		char **value = NULL;
 		size_t dimensions[MAX_REP_ARRAY_DEPTH] = { 0 };
 		if (OCRepPayloadGetStringArray(req_payload, prop->key, &value, dimensions)) {
-			result = OCRepPayloadSetStringArrayAsOwner(resp_payload, prop->key, value, dimensions);
+			result = OCRepPayloadSetStringArray(resp_payload, prop->key, value, dimensions);
 			if (!result) {
 				THINGS_LOG_V(THINGS_ERROR, TAG, "Failed to set the string array value of '%s' in request message", prop->key);
 				size_t len = calcDimTotal(dimensions);
@@ -614,7 +605,7 @@ static bool add_property_in_post_req_msg(st_things_set_request_message_s *req_ms
 		OCRepPayload **value = NULL;
 		size_t dimensions[MAX_REP_ARRAY_DEPTH] = { 0 };
 		if (OCRepPayloadGetPropObjectArray(req_payload, prop->key, &value, dimensions)) {
-			result = OCRepPayloadSetPropObjectArrayAsOwner(resp_payload, prop->key, value, dimensions);
+			result = OCRepPayloadSetPropObjectArray(resp_payload, prop->key, value, dimensions);
 			if (!result) {
 				THINGS_LOG_V(THINGS_ERROR, TAG, "Failed to set the object array value of '%s' in request message", prop->key);
 				size_t len = calcDimTotal(dimensions);

--- a/framework/src/st_things/st_things_request_handler_collection.c
+++ b/framework/src/st_things/st_things_request_handler_collection.c
@@ -186,7 +186,7 @@ bool form_collection_links(things_resource_s *collection_rsrc, OCRepPayload ***l
 			break;
 		}
 		dimensions[0] = rt_count;
-		result = OCRepPayloadSetStringArrayAsOwner(link_arr[index], OC_RSRVD_RESOURCE_TYPE, res_types, dimensions);
+		result = OCRepPayloadSetStringArray(link_arr[index], OC_RSRVD_RESOURCE_TYPE, res_types, dimensions);
 		if (!result) {
 			THINGS_LOG_V(THINGS_ERROR, TAG, "Failed to set the resource types of child(%s) for links in collection.", children[index]->uri);
 			result = false;
@@ -203,7 +203,7 @@ bool form_collection_links(things_resource_s *collection_rsrc, OCRepPayload ***l
 			break;
 		}
 		dimensions[0] = if_count;
-		result = OCRepPayloadSetStringArrayAsOwner(link_arr[index], OC_RSRVD_INTERFACE, if_types, dimensions);
+		result = OCRepPayloadSetStringArray(link_arr[index], OC_RSRVD_INTERFACE, if_types, dimensions);
 		if (!result) {
 			THINGS_LOG_V(THINGS_ERROR, TAG, "Failed to set the interface types of child(%s) for links in collection.", children[index]->uri);
 			result = false;
@@ -282,7 +282,7 @@ static bool handle_get_req_on_collection_linkslist(things_resource_s *collection
 	bool result = false;
 	if (form_collection_links(collection_rsrc, &links, &count)) {
 		size_t dimensions[MAX_REP_ARRAY_DEPTH] = { count, 0, 0 };
-		result = OCRepPayloadSetPropObjectArrayAsOwner(payload, OC_RSRVD_LINKS, links, dimensions);
+		result = OCRepPayloadSetPropObjectArray(payload, OC_RSRVD_LINKS, links, dimensions);
 		if (!result) {
 			THINGS_LOG(THINGS_ERROR, TAG, "Failed to add the links in the response payload.");
 			for (size_t i = 0; i < count && NULL != links[i]; i++) {
@@ -459,7 +459,7 @@ static bool handle_get_req_on_collection_batch(things_resource_s *collection_rsr
 		THINGS_LOG(THINGS_DEBUG, TAG, "Corresponding payload in response will be empty.");
 	}
 
-	result = OCRepPayloadSetPropObjectAsOwner(payload_head, OC_RSRVD_REPRESENTATION, rep_payload);
+	result = OCRepPayloadSetPropObject(payload_head, OC_RSRVD_REPRESENTATION, rep_payload);
 	if (!result) {
 		THINGS_LOG(THINGS_ERROR, TAG, "Failed to set 'rep' for collection in response payload.");
 		OCRepPayloadDestroy(rep_payload);
@@ -527,7 +527,7 @@ static bool handle_get_req_on_collection_batch(things_resource_s *collection_rsr
 			break;
 		}
 		dimensions[0] = rt_count;
-		if (!OCRepPayloadSetStringArrayAsOwner(rep_payload, OC_RSRVD_RESOURCE_TYPE, res_types, dimensions)) {
+		if (!OCRepPayloadSetStringArray(rep_payload, OC_RSRVD_RESOURCE_TYPE, res_types, dimensions)) {
 			THINGS_LOG(THINGS_ERROR, TAG, "Failed to set the resource types of child in response representation.");
 			result = false;
 			break;
@@ -541,7 +541,7 @@ static bool handle_get_req_on_collection_batch(things_resource_s *collection_rsr
 			break;
 		}
 		dimensions[0] = if_count;
-		if (!OCRepPayloadSetStringArrayAsOwner(rep_payload, OC_RSRVD_INTERFACE, if_types, dimensions)) {
+		if (!OCRepPayloadSetStringArray(rep_payload, OC_RSRVD_INTERFACE, if_types, dimensions)) {
 			THINGS_LOG(THINGS_ERROR, TAG, "Failed to set the inteface types of child in response representation.");
 			result = false;
 			break;
@@ -580,8 +580,7 @@ static bool handle_get_req_on_collection_batch(things_resource_s *collection_rsr
 			THINGS_LOG_V(THINGS_DEBUG, TAG, "Failed to get the child resource(%s) properties from application.", children[index]->uri);
 			THINGS_LOG(THINGS_DEBUG, TAG, "Corresponding payload in response will be empty.");
 		}
-
-		if (!OCRepPayloadSetPropObjectAsOwner(child_payload, OC_RSRVD_REPRESENTATION, rep_payload)) {
+		if (!OCRepPayloadSetPropObject(child_payload, OC_RSRVD_REPRESENTATION, rep_payload)) {
 			THINGS_LOG(THINGS_ERROR, TAG, "Failed to set the child representation in response representation.");
 			things_free(query);
 			result = false;
@@ -813,7 +812,7 @@ static bool handle_post_req_on_collection_batch(things_resource_s *collection_rs
 		THINGS_LOG(THINGS_DEBUG, TAG, "Corresponding payload in response will be empty.");
 	}
 
-	result = OCRepPayloadSetPropObjectAsOwner(payload_head, OC_RSRVD_REPRESENTATION, rep_payload);
+	result = OCRepPayloadSetPropObject(payload_head, OC_RSRVD_REPRESENTATION, rep_payload);
 	if (!result) {
 		THINGS_LOG(THINGS_ERROR, TAG, "Failed to set the representation for collection in response payload.");
 		OCRepPayloadDestroy(rep_payload);
@@ -882,7 +881,7 @@ static bool handle_post_req_on_collection_batch(things_resource_s *collection_rs
 			break;
 		}
 		dimensions[0] = rt_count;
-		if (!OCRepPayloadSetStringArrayAsOwner(rep_payload, OC_RSRVD_RESOURCE_TYPE, res_types, dimensions)) {
+		if (!OCRepPayloadSetStringArray(rep_payload, OC_RSRVD_RESOURCE_TYPE, res_types, dimensions)) {
 			THINGS_LOG(THINGS_ERROR, TAG, "Failed to set the resource types of child in response representation.");
 			result = false;
 			break;
@@ -896,7 +895,7 @@ static bool handle_post_req_on_collection_batch(things_resource_s *collection_rs
 			break;
 		}
 		dimensions[0] = if_count;
-		if (!OCRepPayloadSetStringArrayAsOwner(rep_payload, OC_RSRVD_INTERFACE, if_types, dimensions)) {
+		if (!OCRepPayloadSetStringArray(rep_payload, OC_RSRVD_INTERFACE, if_types, dimensions)) {
 			THINGS_LOG(THINGS_ERROR, TAG, "Failed to set the inteface types of child in response representation.");
 			result = false;
 			break;
@@ -936,7 +935,7 @@ static bool handle_post_req_on_collection_batch(things_resource_s *collection_rs
 			THINGS_LOG(THINGS_DEBUG, TAG, "Corresponding payload in response will be empty.");
 		}
 
-		if (!OCRepPayloadSetPropObjectAsOwner(payload, OC_RSRVD_REPRESENTATION, rep_payload)) {
+		if (!OCRepPayloadSetPropObject(payload, OC_RSRVD_REPRESENTATION, rep_payload)) {
 			THINGS_LOG(THINGS_ERROR, TAG, "Failed to set the child representation in response representation.");
 			result = false;
 			break;


### PR DESCRIPTION
OCRepSet/Add*AsOwner function doesn't allocated memory when build the response payload.
So, user should allocate the memory for payload but user can't free.

In order to ignore this issue , We can use OCRep* instead of OCRepSet/Add*AsOwner. Therefore we should care of the pointers to avoid memory leak.