### PR TITLE
network/lwip: fix the build error in lwip configuration.

### DIFF
--- a/os/include/net/lwip/mem.h
+++ b/os/include/net/lwip/mem.h
@@ -58,6 +58,7 @@ extern "C" {
 #if MEM_LIBC_MALLOC
 
 #include <stddef.h>				/* for size_t */
+#include <stdlib.h>             /* for free() */
 
 typedef size_t mem_size_t;
 #define MEM_SIZE_F SZT_F


### PR DESCRIPTION
If lwip is set to use system malloc() then it doesn't succeed,
because it fails to find free() definition.
It will find free definition by including stdlib.h