### PR TITLE
s5j: Add Tick Suppression feature support

### DIFF
--- a/os/arch/arm/Kconfig
+++ b/os/arch/arm/Kconfig
@@ -21,6 +21,7 @@ config ARCH_CHIP_S5J
 	select ARCH_CORTEXR4
 	select ARCH_HAVE_MPU
 	select ARCH_HAVE_TICKLESS
+	select ARCH_HAVE_TICKSUPPRESS
 	select ARM_HAVE_MPU_UNIFIED
 	select ARMV7R_MEMINIT
 	---help---

--- a/os/arch/arm/src/armv7-m/up_unblocktask.c
+++ b/os/arch/arm/src/armv7-m/up_unblocktask.c
@@ -132,6 +132,11 @@ void up_unblock_task(struct tcb_s *tcb)
 		 */
 
 		if (current_regs) {
+#ifdef CONFIG_SCHED_TICKSUPPRESS
+			/* Disable tick suppression */
+			up_stop_ticksuppress();
+#endif
+
 			/* Yes, then we have to do things differently.
 			 * Just copy the current_regs into the OLD rtcb.
 			 */

--- a/os/arch/arm/src/armv7-r/arm_unblocktask.c
+++ b/os/arch/arm/src/armv7-r/arm_unblocktask.c
@@ -127,6 +127,11 @@ void up_unblock_task(struct tcb_s *tcb)
 		/* Are we in an interrupt handler? */
 
 		if (current_regs) {
+#ifdef CONFIG_SCHED_TICKSUPPRESS
+			/* Disable tick suppression */
+			up_stop_ticksuppress();
+#endif
+
 			/* Yes, then we have to do things differently.
 			 * Just copy the current_regs into the OLD rtcb.
 			 */

--- a/os/arch/arm/src/s5j/Make.defs
+++ b/os/arch/arm/src/s5j/Make.defs
@@ -110,7 +110,13 @@ CMN_CSRCS += up_task_start.c up_pthread_start.c arm_signal_dispatch.c
 endif
 
 ifneq ($(CONFIG_SCHED_TICKLESS),y)
+ifneq ($(CONFIG_SCHED_TICKSUPPRESS),y)
 CHIP_CSRCS += s5j_timerisr.c
+endif
+endif
+
+ifeq ($(CONFIG_SCHED_TICKSUPPRESS),y)
+CHIP_CSRCS += s5j_ticksuppress.c
 endif
 
 CHIP_CSRCS += s5j_idle.c

--- a/os/arch/arm/src/s5j/s5j_idle.c
+++ b/os/arch/arm/src/s5j/s5j_idle.c
@@ -119,6 +119,10 @@ static void up_idlepm(void)
 			break;
 
 		case PM_SLEEP:
+#ifdef CONFIG_SCHED_TICKSUPPRESS
+			/* Enable tick suppression */
+			up_start_ticksuppress();
+#endif
 			s5j_pmstandby();
 			break;
 
@@ -160,6 +164,11 @@ void up_idle(void)
 #else
 	/* Perform IDLE mode power management */
 	up_idlepm();
+
+#if !defined CONFIG_PM && defined CONFIG_SCHED_TICKSUPPRESS
+	/* Enable tick suppression */
+	up_start_ticksuppress();
+#endif
 
 	/* Sleep until an interrupt occurs to save power. */
 	asm("WFI");

--- a/os/arch/arm/src/s5j/s5j_ticksuppress.c
+++ b/os/arch/arm/src/s5j/s5j_ticksuppress.c
@@ -1,0 +1,273 @@
+/****************************************************************************
+ *
+ * Copyright 2018 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+#include <tinyara/config.h>
+
+#include <debug.h>
+#include <queue.h>
+#include <tinyara/wdog.h>
+#include <tinyara/clock.h>
+#include <tinyara/time.h>
+#include <tinyara/wdog.h>
+#include <arch/board/board.h>
+
+#include "up_arch.h"
+#include "chip/s5jt200_rtc.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+/*
+ * The desired timer interrupt frequency is provided by the definition
+ * CLK_TCK (see include/time.h).  CLK_TCK defines the desired number of
+ * system clock ticks per second.  That value is a user configurable setting
+ * that defaults to 100 (100 ticks per second = 10 MS interval).
+ *
+ * The timer counts at the rate SYSCLK_FREQUENCY as defined in the board.h
+ * header file.
+ */
+#define SYSTICK_RELOAD ((SYSCLK_FREQUENCY / CLK_TCK) - 1)
+
+#define MAX_TCNT UINT32_MAX	/* Max 32-bit timer-tick value */
+
+/****************************************************************************
+ * Type Definitions
+ ****************************************************************************/
+enum {
+	TICKSUPPRESS_DISABLE,
+	TICKSUPPRESS_ENABLE
+} timertick_mode;
+
+enum {
+	START,
+	READ,
+	WRITE,
+	STOP
+} timer_states;
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+static uint8_t g_tick_mode;	/* timer-tick mode  */
+
+static uint32_t last_event = 0;
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+static uint32_t s5j_get_next_event(void)
+{
+	return (uint32_t)wd_getdelay();
+}
+
+static uint32_t s5j_timer_setup(int state, uint32_t value)
+{
+	switch (state) {
+		case START:
+			modifyreg32(S5J_RTC_RTCCON, RTC_RTCCON_TICCKSEL0_MASK, RTC_RTCCON_TICKEN0_ENABLE | RTC_RTCCON_TICCKSEL0_32768HZ);
+			break;
+		case READ:
+			return getreg32(S5J_RTC_CURTICCNT0);
+		case WRITE:
+			putreg32(SYSTICK_RELOAD * value, S5J_RTC_TICCNT0);
+			break;
+		case STOP:
+			/* Clear interrupt pending */
+
+			putreg32(RTC_INTP_TIMETIC0, S5J_RTC_INTP);
+
+			/* Disable timertick */
+
+			modifyreg32(S5J_RTC_RTCCON, RTC_RTCCON_TICKEN0_ENABLE, 0);
+			break;
+		default:
+			/* Shouldn't reach here */
+			DEBUGPANIC();
+			break;
+	}
+
+	return 0;
+}
+
+static void s5j_set_next_event(uint32_t next_event)
+{
+	/* Disable timer tick */
+
+	s5j_timer_setup(STOP, 0);
+
+	/* Configure the RTC timetick to generate interrupt on next event */
+
+	s5j_timer_setup(WRITE, next_event);
+
+	/* Enable timer tick */
+
+	s5j_timer_setup(START, 0);
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Function:  up_stop_ticksuppress
+ *
+ * Description:
+ *   Disables tick suppression (re-enables periodic ticks) when,
+ *   1. Scheduled event expires
+ *   2. Context switch takes place on an external event (interrupt)
+ *
+ ****************************************************************************/
+
+void up_stop_ticksuppress(void)
+{
+	/* If tick suppression is disabled, do nothing! */
+
+	if (g_tick_mode == TICKSUPPRESS_DISABLE) {
+		return;
+	}
+
+	/* If this function called from interrupt context,
+	 * read current value of the counter and update last event value
+	 */
+
+	if (up_interrupt_context()) {
+		last_event = ((uint32_t)s5j_timer_setup(READ, 0) / SYSTICK_RELOAD);
+	}
+
+	/* This function will be called when last scheduled event expires.
+	 * so update the global system timer using expired last event value.
+	 */
+
+	if (last_event) {
+		/* Update global system timer */
+
+		g_system_timer += last_event;
+
+		/* Update wdog delay */
+
+		wd_updatedelay(last_event);
+
+		/* Reset last event */
+
+		last_event = 0;
+	}
+
+	/* Change timer tick state as periodic */
+
+	g_tick_mode = TICKSUPPRESS_DISABLE;
+
+	/* Re-enable periodic timer ticks */
+
+	s5j_set_next_event(0x1);
+}
+
+/*****************************************************************************
+ * Function:  up_start_ticksuppress
+ *
+ * Description:
+ *   Enables tick suppression (disables periodic ticks), when system goes idle
+ *
+ *****************************************************************************/
+
+void up_start_ticksuppress(void)
+{
+	uint32_t next_event = 0;
+
+	/* Check whether the threshold value is reached or not
+	 * If threshold value is crossed, ticks are suppressed and
+	 * next expected event is scheduled.
+	 */
+
+	s5j_timer_setup(STOP, 0);
+
+	next_event = s5j_get_next_event();
+	if (!next_event) {
+		next_event = MAX_TCNT;
+	}
+	last_event = next_event;
+
+	g_tick_mode = TICKSUPPRESS_ENABLE;
+
+	/* Schedule next expected event */
+
+	s5j_set_next_event(next_event);
+}
+
+/****************************************************************************
+ * Function:  up_timerisr
+ *
+ * Description:
+ *   The timer ISR will perform a variety of services for various portions
+ *   of the systems.
+ *
+ ****************************************************************************/
+
+int up_timerisr(int irq, FAR void *context, FAR void *arg)
+{
+	if (g_tick_mode == TICKSUPPRESS_ENABLE) {
+
+		/* Disable tick suppression */
+
+		up_stop_ticksuppress();
+	}
+
+	/* Clear interrupt pending */
+
+	putreg32(RTC_INTP_TIMETIC0, S5J_RTC_INTP);
+
+	/* Process timer interrupt */
+
+	sched_process_timer();
+
+	return 0;
+}
+
+/****************************************************************************
+ * Function:  up_timer_initialize
+ *
+ * Description:
+ *   This function is called during start-up to initialize
+ *   the timer interrupt.
+ *
+ ****************************************************************************/
+
+void up_timer_initialize(void)
+{
+	/* OSC_CON[16] should be set to 1, so that RTC uses XRTCXTO as srcclk */
+
+	modifyreg32(0x800A0554, 0x0, 1 << 16);
+
+	g_tick_mode = TICKSUPPRESS_DISABLE;
+
+	/* Configure the RTC timetick to generate periodic interrupts */
+
+	modifyreg32(S5J_RTC_RTCCON, RTC_RTCCON_TICKEN0_ENABLE, 0);
+	putreg32(SYSTICK_RELOAD, S5J_RTC_TICCNT0);
+	modifyreg32(S5J_RTC_RTCCON, RTC_RTCCON_TICCKSEL0_MASK, RTC_RTCCON_TICKEN0_ENABLE | RTC_RTCCON_TICCKSEL0_32768HZ);
+
+	/* Attach the timer interrupt vector */
+
+	irq_attach(IRQ_TOP_RTC_TIC, up_timerisr, NULL);
+
+	/* Enable the timer interrupt */
+
+	up_enable_irq(IRQ_TOP_RTC_TIC);
+}

--- a/os/include/tinyara/arch.h
+++ b/os/include/tinyara/arch.h
@@ -1604,6 +1604,62 @@ int up_timer_start(FAR const struct timespec *ts);
 #endif
 
 /****************************************************************************
+ * Name: up_start_ticksuppress
+ *
+ * Description:
+ *	Periodic timer tick interrupts are suppressed and reschedules timer tick
+ *  interrupt to a much later time (either when the next known tasks are
+ *  scheduled to run or to a maximum possible tick timer value).
+ *	This function is called from platform specific idle interface
+ *	up_idle() or up_idlepm().
+
+ *	Provided by platform-specific code and called from the architecture-
+ *	specific logic.
+ *
+ * Input Parameters:
+ *   None
+ *
+ * Returned Value:
+ *   None
+ *
+ * Assumptions:
+ *	Called from interrupt context, interrupts may need to be disabled
+ *	internally to assure non-reentrancy.
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_SCHED_TICKSUPPRESS
+void up_start_ticksuppress(void);
+#endif
+
+/****************************************************************************
+ * Name: up_stop_ticksuppress
+ *
+ * Description:
+ *  Periodic timer tick interrupts are re-enabled.
+ *  This function is called from platform timer isr, up_timerisr() or
+ *	from context switch logic in interrupt context.
+ *
+ *  Provided by platform-specific code and called from the architecture-
+ *  specific logic.
+ *
+ * Input Parameters:
+ *   None
+ *
+ * Returned Value:
+ *   None
+ *
+ * Assumptions:
+ *  Called from interrupt context, interrupts may need to be disabled
+ *  internally to assure non-reentrancy.
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_SCHED_TICKSUPPRESS
+void up_stop_ticksuppress(void);
+#endif
+
+/****************************************************************************
  * Name: up_romgetc
  *
  * Description:

--- a/os/include/tinyara/wdog.h
+++ b/os/include/tinyara/wdog.h
@@ -180,6 +180,11 @@ int wd_start(WDOG_ID wdog, int delay, wdentry_t wdentry, int argc, ...);
 int wd_cancel(WDOG_ID wdog);
 int wd_gettime(WDOG_ID wdog);
 
+#ifdef CONFIG_SCHED_TICKSUPPRESS
+int wd_getdelay(void);
+void wd_updatedelay(int elapsed);
+#endif
+
 #undef EXTERN
 #ifdef __cplusplus
 }

--- a/os/kernel/Kconfig
+++ b/os/kernel/Kconfig
@@ -94,6 +94,25 @@ config SCHED_TICKLESS_LIMIT_MAX_SLEEP
 
 endif
 
+config ARCH_HAVE_TICKSUPPRESS
+	bool
+	default n
+
+config SCHED_TICKSUPPRESS
+	bool "Support Tick Suppression"
+	default n
+	depends on ARCH_HAVE_TICKSUPPRESS
+	---help---
+		The OS task scheduler has a periodic timer tick interrupt
+		occurring at a fixed interval in order to perform task scheduling,
+		even when the CPU is in idle. Due to which effective power save
+		by Idle PM reduces. This can be avoided by enabling tick suppression feature.
+		Tick suppression allows CPU to stay idle for a much longer time.
+		Longer the CPU is in idle, more the power save by Idle PM.
+		If the tick suppression is selected, then there are additional
+		platform specific interfaces that must be provided as
+		defined in include/tinyara/arch.h
+
 config USEC_PER_TICK
 	int "System timer tick period (microseconds)"
 	default 10000 if !SCHED_TICKLESS

--- a/os/kernel/wdog/wd_gettime.c
+++ b/os/kernel/wdog/wd_gettime.c
@@ -129,3 +129,53 @@ int wd_gettime(WDOG_ID wdog)
 	irqrestore(flags);
 	return 0;
 }
+
+#ifdef CONFIG_SCHED_TICKSUPPRESS
+/********************************************************************************
+ * Name: wd_getdelay
+ *
+ * Description:
+ *  This function returns delay (in system ticks) from head of wdog active list.
+ *  This function is provided by RTOS and called from platform-specific code.
+ *
+ * Parameters:
+ *	None
+ *
+ * Return Value:
+ *  wdog delay in system ticks
+ *
+ * Assumptions:
+ *
+ ********************************************************************************/
+
+int wd_getdelay(void)
+{
+	return (g_wdactivelist.head) ? ((FAR struct wdog_s *)g_wdactivelist.head)->lag : 0;
+}
+
+/********************************************************************************
+ * Name: wd_updatedelay
+ *
+ * Description:
+ *	This function updates delay in head of wdog active list
+ *	using elapsed time in system ticks.
+ *	This function is provided by RTOS and called from platform-specific code.
+ *
+ * Parameters:
+ *   elapsed = elapsed time in system ticks
+ *
+ * Return Value:
+ *	None
+ *
+ * Assumptions:
+ *
+ ********************************************************************************/
+
+void wd_updatedelay(int elapsed)
+{
+	if (g_wdactivelist.head) {
+		/* Update  wdog lag (delay) */
+		((FAR struct wdog_s *)g_wdactivelist.head)->lag -= elapsed;
+	}
+}
+#endif


### PR DESCRIPTION
Adds Tick Suppression feature support for s5j platform.

> Tick suppression can generally be enabled and left enabled without any drawbacks.

> The way tick suppression works is that whenever the scheduler sees an expected idle time
 (no tasks to be scheduled) longer than the time remaining to the next scheduled timer interrupt, it reschedules the next tick/interval timer interrupt to a much later time (either when the next known tasks are scheduled to run or to a maximum possible tick timer value).

> Upon coming out of the idle state, whether the exit was caused by the scheduled interval timer interrupt or an asynchronous external interrupt, the system time and other state information is properly adjusted so that any running tasks are not affected – they see “the world” the same regardless if tick suppression happened or not.

This feature can be enabled through menuconfig as follows,

> Kernel Features > Clocks and Timers > [*] Support Tick Suppression
CONFIG_SCHED_TICKSUPPRESS=y

Signed-off-by: Lokesh B V <lokesh.bv@partner.samsung.com>