### PR TITLE
Qemu: Fix SUPPORT_SDRAM flag usage error

### DIFF
--- a/build/configs/qemu/qemu-2.12.0-rc1_16m_ram_size.patch
+++ b/build/configs/qemu/qemu-2.12.0-rc1_16m_ram_size.patch
@@ -1,23 +1,23 @@
-From 23caf033c718dd932efd225a01d00587b88b081a Mon Sep 17 00:00:00 2001
-From: Manohara HK <manohara.hk@samsung.com>
-Date: Mon, 20 Mar 2017 19:13:02 +0530
-Subject: [PATCH] arm : stellaris : Increase sram and flash size and support
- sdram
+From 56d2f3a419cd7304ec7a14c2031f233645229e3b Mon Sep 17 00:00:00 2001
+From: "pradeep.ns" <pradeep.ns@samsung.com>
+Date: Mon, 2 Apr 2018 21:57:32 +0530
+Subject: [PATCH] qemu/hw/arm: stellaris: Increase sram and flash size and
+ support sdram
 
-This patch increase's the sram and flash size of stellaris lm3s6965 board.
+This patch increases the sram and flash size of stellaris lm3s6965 board.
 It also adds a sdram of 512MB to the board.
 
-Signed-off-by: Manohara HK <manohara.hk@samsung.com>
 Signed-off-by: pradeep.ns <pradeep.ns@samsung.com>
+Signed-off-by: manohara.hk <manohara.hk@samsung.com>
 ---
- hw/arm/stellaris.c | 35 +++++++++++++++++++++++++++++++++--
- 1 file changed, 33 insertions(+), 2 deletions(-)
+ hw/arm/stellaris.c | 32 ++++++++++++++++++++++++++++++++
+ 1 file changed, 32 insertions(+)
 
 diff --git a/hw/arm/stellaris.c b/hw/arm/stellaris.c
-index 408c1a1..171fe0c 100644
+index de7c0fc..3a0f928 100644
 --- a/hw/arm/stellaris.c
 +++ b/hw/arm/stellaris.c
-@@ -55,6 +55,16 @@ typedef const struct {
+@@ -56,6 +56,16 @@ typedef const struct {
  #define STELLARIS_GPTM(obj) \
      OBJECT_CHECK(gptm_state, (obj), TYPE_STELLARIS_GPTM)
  
@@ -26,7 +26,7 @@ index 408c1a1..171fe0c 100644
 +#define SUPPORT_SDARAM		1 /*Add a sdram @cortexm3 default extranal RAM map */
 +
 +
-+#if defined(SUPPORT_SDARAM)
++#if SUPPORT_SDARAM
 +#define CORTEXM3_SDRAM_SIZE	(512 * 1024 * 1024)
 +#define CORTEXM3_SDRAM_ADDR	(0x60000000)
 +#endif
@@ -34,7 +34,7 @@ index 408c1a1..171fe0c 100644
  typedef struct gptm_state {
      SysBusDevice parent_obj;
  
-@@ -1216,7 +1226,13 @@ static stellaris_board_info stellaris_boards[] = {
+@@ -1217,7 +1227,13 @@ static stellaris_board_info stellaris_boards[] = {
    { "LM3S6965EVB",
      0x10010002,
      0x1073402e,
@@ -48,30 +48,21 @@ index 408c1a1..171fe0c 100644
      0x001133ff,
      0x030f5317,
      0x0f0f87ff,
-@@ -1282,21 +1298,36 @@ static void stellaris_init(const char *kernel_filename, const char *cpu_model,
+@@ -1282,6 +1298,9 @@ static void stellaris_init(MachineState *ms, stellaris_board_info *board)
  
      MemoryRegion *sram = g_new(MemoryRegion, 1);
      MemoryRegion *flash = g_new(MemoryRegion, 1);
-+#if defined(SUPPORT_SDARAM)
++#if SUPPORT_SDARAM
 +    MemoryRegion *sdram = g_new(MemoryRegion, 1);
 +#endif
      MemoryRegion *system_memory = get_system_memory();
  
      flash_size = (((board->dc0 & 0xffff) + 1) << 1) * 1024;
-     sram_size = ((board->dc0 >> 18) + 1) * 1024;
- 
--    /* Flash programming is done via the SCU, so pretend it is ROM.  */
-+    /* Flash is read/writable */
-     memory_region_init_ram(flash, NULL, "stellaris.flash", flash_size,
-                            &error_fatal);
--    memory_region_set_readonly(flash, true);
-     memory_region_add_subregion(system_memory, 0, flash);
- 
-     memory_region_init_ram(sram, NULL, "stellaris.sram", sram_size,
+@@ -1297,6 +1316,19 @@ static void stellaris_init(MachineState *ms, stellaris_board_info *board)
                             &error_fatal);
      memory_region_add_subregion(system_memory, 0x20000000, sram);
  
-+#if defined(SUPPORT_SDARAM)
++#if SUPPORT_SDARAM
 +    // Extranal RAM(SDRAM) of max CORTEXM3_SDRAM_SIZE @ CORTEXM3_SDRAM_ADDR
 +    memory_region_init_ram(sdram, NULL, "stellaris.sdram", CORTEXM3_SDRAM_SIZE,
 +				&error_fatal);
@@ -85,7 +76,7 @@ index 408c1a1..171fe0c 100644
 +#endif
 +
      nvic = armv7m_init(system_memory, flash_size, NUM_IRQ_LINES,
-                       kernel_filename, cpu_model);
+                        ms->kernel_filename, ms->cpu_type);
  
 -- 
 1.9.1

--- a/build/configs/qemu/qemu-2.12.0-rc1_1m_ram_size.patch
+++ b/build/configs/qemu/qemu-2.12.0-rc1_1m_ram_size.patch
@@ -1,23 +1,23 @@
-From a9f770243ccb354e99b9ff33ecfecbeca73b1b03 Mon Sep 17 00:00:00 2001
-From: Manohara HK <manohara.hk@samsung.com>
-Date: Mon, 20 Mar 2017 19:13:02 +0530
-Subject: [PATCH v2] arm : stellaris : Increase sram and flash size and support
- sdram
+From 56d2f3a419cd7304ec7a14c2031f233645229e3b Mon Sep 17 00:00:00 2001
+From: "pradeep.ns" <pradeep.ns@samsung.com>
+Date: Mon, 2 Apr 2018 21:57:32 +0530
+Subject: [PATCH] qemu/hw/arm: stellaris: Increase sram and flash size and
+ support sdram
 
-This patch increase's the sram and flash size of stellaris lm3s6965 board.
+This patch increases the sram and flash size of stellaris lm3s6965 board.
 It also adds a sdram of 512MB to the board.
 
-Signed-off-by: Manohara HK <manohara.hk@samsung.com>
 Signed-off-by: pradeep.ns <pradeep.ns@samsung.com>
+Signed-off-by: manohara.hk <manohara.hk@samsung.com>
 ---
- hw/arm/stellaris.c | 29 +++++++++++++++++++++++++++++
- 1 file changed, 29 insertions(+)
+ hw/arm/stellaris.c | 32 ++++++++++++++++++++++++++++++++
+ 1 file changed, 32 insertions(+)
 
 diff --git a/hw/arm/stellaris.c b/hw/arm/stellaris.c
-index 408c1a1..d9ebac8 100644
+index de7c0fc..3a0f928 100644
 --- a/hw/arm/stellaris.c
 +++ b/hw/arm/stellaris.c
-@@ -55,6 +55,16 @@ typedef const struct {
+@@ -56,6 +56,16 @@ typedef const struct {
  #define STELLARIS_GPTM(obj) \
      OBJECT_CHECK(gptm_state, (obj), TYPE_STELLARIS_GPTM)
  
@@ -26,7 +26,7 @@ index 408c1a1..d9ebac8 100644
 +#define SUPPORT_SDARAM		1 /*Add a sdram @cortexm3 default extranal RAM map */
 +
 +
-+#if defined(SUPPORT_SDARAM)
++#if SUPPORT_SDARAM
 +#define CORTEXM3_SDRAM_SIZE	(512 * 1024 * 1024)
 +#define CORTEXM3_SDRAM_ADDR	(0x60000000)
 +#endif
@@ -34,7 +34,7 @@ index 408c1a1..d9ebac8 100644
  typedef struct gptm_state {
      SysBusDevice parent_obj;
  
-@@ -1216,7 +1226,13 @@ static stellaris_board_info stellaris_boards[] = {
+@@ -1217,7 +1227,13 @@ static stellaris_board_info stellaris_boards[] = {
    { "LM3S6965EVB",
      0x10010002,
      0x1073402e,
@@ -48,21 +48,21 @@ index 408c1a1..d9ebac8 100644
      0x001133ff,
      0x030f5317,
      0x0f0f87ff,
-@@ -1282,6 +1298,9 @@ static void stellaris_init(const char *kernel_filename, const char *cpu_model,
+@@ -1282,6 +1298,9 @@ static void stellaris_init(MachineState *ms, stellaris_board_info *board)
  
      MemoryRegion *sram = g_new(MemoryRegion, 1);
      MemoryRegion *flash = g_new(MemoryRegion, 1);
-+#if defined(SUPPORT_SDARAM)
++#if SUPPORT_SDARAM
 +    MemoryRegion *sdram = g_new(MemoryRegion, 1);
 +#endif
      MemoryRegion *system_memory = get_system_memory();
  
      flash_size = (((board->dc0 & 0xffff) + 1) << 1) * 1024;
-@@ -1297,6 +1316,19 @@ static void stellaris_init(const char *kernel_filename, const char *cpu_model,
+@@ -1297,6 +1316,19 @@ static void stellaris_init(MachineState *ms, stellaris_board_info *board)
                             &error_fatal);
      memory_region_add_subregion(system_memory, 0x20000000, sram);
  
-+#if defined(SUPPORT_SDARAM)
++#if SUPPORT_SDARAM
 +    // Extranal RAM(SDRAM) of max CORTEXM3_SDRAM_SIZE @ CORTEXM3_SDRAM_ADDR
 +    memory_region_init_ram(sdram, NULL, "stellaris.sdram", CORTEXM3_SDRAM_SIZE,
 +				&error_fatal);
@@ -76,7 +76,7 @@ index 408c1a1..d9ebac8 100644
 +#endif
 +
      nvic = armv7m_init(system_memory, flash_size, NUM_IRQ_LINES,
-                       kernel_filename, cpu_model);
+                        ms->kernel_filename, ms->cpu_type);
  
 -- 
 1.9.1


### PR DESCRIPTION
1) Check for SUPPORT_SDRAM flag was not done properly.
Same has been fixed and publishing the correct patches.

2) Prepared the patch with latest qemu [ 2.12.0-rc1 ] source code clone

Signed-off-by: pradeep.ns <pradeep.ns@samsung.com>