### PR TITLE
mm/heapinfo : Add omitted header include

### DIFF
--- a/os/mm/mm_heap/mm_heapinfo.c
+++ b/os/mm/mm_heap/mm_heapinfo.c
@@ -60,6 +60,7 @@
 #include <stdint.h>
 #include <stdio.h>
 #ifdef CONFIG_HEAPINFO_GROUP
+#include <string.h>
 #include <tinyara/mm/heapinfo_internal.h>
 #endif
 


### PR DESCRIPTION
for strncmp() and strlen, #include <string.h> is needed, but omitted