### PR TITLE
framework/st_things: Fix implicit bug to create collection resource.

### DIFF
--- a/framework/src/st_things/things_stack/framework/things_server_builder.c
+++ b/framework/src/st_things/things_stack/framework/things_server_builder.c
@@ -175,8 +175,8 @@ struct things_resource_s *create_collection_resource(struct things_server_builde
 #endif							//#ifdef __SECURED__
 
 	OCStackResult ret = OCCreateResource(&hd,
-										 uri,
 										 type,
+										 interface,
 										 uri,
 										 builder->handler,
 										 NULL,


### PR DESCRIPTION
There can be showing a bug when using collection resource.
In previous version, It passes a uri instead of type.
This is an fault what is entering wrong parameters to create resource.