### PR TITLE
Add WiFi open security mode in network manager.

### DIFF
--- a/apps/examples/wifi_manager_sample/wm_test.c
+++ b/apps/examples/wifi_manager_sample/wm_test.c
@@ -346,6 +346,10 @@ void wm_scan_done(wifi_manager_scan_info_s **scan_result, wifi_manager_scan_resu
 	/* Make sure you copy the scan results onto a local data structure.
 	 * It will be deleted soon eventually as you exit this function.
 	 */
+	if (scan_result == NULL) {
+		WM_TEST_SIGNAL;
+		return;
+	}
 	wifi_manager_scan_info_s *wifi_scan_iter = *scan_result;
 	while (wifi_scan_iter != NULL) {
 		printf("WiFi AP SSID: %-20s, WiFi AP BSSID: %-20s, WiFi Rssi: %d\n",

--- a/apps/examples/wifi_manager_sample/wm_test.c
+++ b/apps/examples/wifi_manager_sample/wm_test.c
@@ -529,6 +529,10 @@ wm_connect(void *arg)
 		strncpy(apconfig.passphrase, ap_info->password, 64);
 		apconfig.passphrase_length = strlen(ap_info->password);
 		apconfig.ap_crypto_type = ap_info->crypto_type;
+	} else {
+		apconfig.passphrase_length = 0;
+		memset(apconfig.passphrase, 0x0, 64);
+		apconfig.ap_crypto_type = WIFI_MANAGER_CRYPTO_NONE;
 	}
 
 	print_wifi_ap_profile(&apconfig, "Connecting AP Info");

--- a/framework/src/wifi_manager/wifi_manager.c
+++ b/framework/src/wifi_manager/wifi_manager.c
@@ -1192,18 +1192,24 @@ wifi_manager_result_e wifi_manager_get_info(wifi_manager_info_s *info)
 wifi_manager_result_e wifi_manager_connect_ap_config(wifi_manager_ap_config_s *config,
 													 wifi_manager_reconnect_config_s *conn_config)
 {
+
+	wifi_manager_result_e res = WIFI_MANAGER_SUCCESS;
+
 	if (!config || !conn_config) {
 		return WIFI_MANAGER_INVALID_ARGS;
 	}
 
-	if ((config->ssid_length > 31) || (config->passphrase_length > 63)) {
+
+	if ((config->ssid_length > 31)
+			|| ((config->ap_auth_type != WIFI_MANAGER_AUTH_OPEN)
+				&& (config->passphrase_length > 63))) {
 		ndbg("[WM] AP configuration fails: too long ssid or passphrase\n");
 		ndbg("[WM] Make sure that length of SSID < 32 and length of passphrase < 64\n");
 		return WIFI_MANAGER_INVALID_ARGS;
 	}
-	_wifimgr_conn_info_msg_s conninfo = {config, conn_config};
-	_wifimgr_msg_s msg = {EVT_CONNECT, &conninfo};
-	wifi_manager_result_e res = _handle_request(&msg);
+	_wifimgr_conn_info_msg_s conninfo = { config, conn_config };
+	_wifimgr_msg_s msg = { EVT_CONNECT, &conninfo };
+	res = _handle_request(&msg);
 	return res;
 }
 


### PR DESCRIPTION
    framework/src/wifi_manager : add WiFi open security code.
    WiFi open security mode connection code does not exist in network manager and wm_test function.
    so, add WiFi open security mode connection code.