### PR TITLE
external/mbedtls : enable debugging function call in mbedtls

### DIFF
--- a/external/mbedtls/debug.c
+++ b/external/mbedtls/debug.c
@@ -81,16 +81,12 @@ static inline void debug_send_line(const mbedtls_ssl_context *ssl, int level, co
 	 * Since there is no portable way to get one, use the address of the ssl
 	 * context instead, as it shouldn't be shared between threads.
 	 */
-#if 0							/* For TinyAra */
 #if defined(MBEDTLS_THREADING_C)
 	char idstr[20 + DEBUG_BUF_SIZE];	/* 0x + 16 nibbles + ': ' */
 	mbedtls_snprintf(idstr, sizeof(idstr), "%p: %s", ssl, str);
 	ssl->conf->f_dbg(ssl->conf->p_dbg, level, file, line, idstr);
 #else
 	ssl->conf->f_dbg(ssl->conf->p_dbg, level, file, line, str);
-#endif
-#else
-	printf("%s(%d) : %s", file, line, str);
 #endif
 }
 


### PR DESCRIPTION
- Remove '#if' statement for general debugging function