### PR TITLE
os/pthread: add doxygen comment on pthread_key_delete

### DIFF
--- a/os/include/pthread.h
+++ b/os/include/pthread.h
@@ -604,13 +604,14 @@ int pthread_setspecific(pthread_key_t key, FAR const void *value);
  */
 FAR void *pthread_getspecific(pthread_key_t key);
 /**
- * @cond
- * @internal
+ * @ingroup PTHREAD_KERNEL
+ * @brief thread-specific data key deletion
+ * @details @b #include <pthread.h> \n
+ * SYSTEM CALL API \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @since TizenRT v2.0
  */
 int pthread_key_delete(pthread_key_t key);
-/**
- * @endcond
- */
 
 /* The following routines create, delete, lock and unlock mutexes. */
 


### PR DESCRIPTION
Recently that was implemented and has testcase so that
we announce it is tested and is a public API.