### PR TITLE
le_tc/kernel: Add missing CONFIG_SCHED_TICKLESS wrapper

### DIFF
--- a/apps/examples/testcase/le_tc/kernel/tc_clock.c
+++ b/apps/examples/testcase/le_tc/kernel/tc_clock.c
@@ -155,6 +155,7 @@ static void tc_clock_clock_gettimeofday(void)
 	TC_SUCCESS_RESULT();
 }
 
+#ifndef CONFIG_SCHED_TICKLESS
 /**
 * @fn                   :tc_clock_clock_timer
 * @brief                :This function must be called once every time the real time clock interrupt occurs
@@ -175,6 +176,7 @@ static void tc_clock_clock_timer(void)
 
 	TC_SUCCESS_RESULT();
 }
+#endif
 
 /**
 * @fn                   :tc_clock_clock_systimer
@@ -252,7 +254,9 @@ static void tc_clock_clock_abstime2ticks(void)
 
 int clock_main(void)
 {
+#ifndef CONFIG_SCHED_TICKLESS
 	tc_clock_clock_timer();
+#endif
 	tc_clock_clock_systimer();
 	tc_clock_clock_systimer64();
 	tc_clock_clock_gettimeofday();


### PR DESCRIPTION
clock_timer() interface is available only when CONFIG_SCHED_TICKLESS is not defined.
So the test case used to test the clock_timer() should also be made available
only when CONFIG_SCHED_TICKLESS is not defined.

Otherwise when CONFIG_SCHED_TICKLESS is enabled, build error occurs.

Signed-off-by: Lokesh B V <lokesh.bv@partner.samsung.com>