### PR TITLE
external/gmock : Add macros indicating the current platform

### DIFF
--- a/external/gmock/gtest/include/gtest/internal/gtest-internal.h
+++ b/external/gmock/gtest/include/gtest/internal/gtest-internal.h
@@ -39,12 +39,12 @@
 
 #include "gtest/internal/gtest-port.h"
 
-#if GTEST_OS_LINUX
+#if (GTEST_OS_TIZENRT || GTEST_OS_LINUX)
 # include <stdlib.h>
 # include <sys/types.h>
 # include <sys/wait.h>
 # include <unistd.h>
-#endif  // GTEST_OS_LINUX
+#endif  // (GTEST_OS_TIZENRT || GTEST_OS_LINUX)
 
 #if GTEST_HAS_EXCEPTIONS
 # include <stdexcept>

--- a/external/gmock/gtest/include/gtest/internal/gtest-port.h
+++ b/external/gmock/gtest/include/gtest/internal/gtest-port.h
@@ -193,8 +193,11 @@
 //   Int32FromGTestEnv()  - parses an Int32 environment variable.
 //   StringFromGTestEnv() - parses a string environment variable.
 
-#if defined(__TIZENRT__) && defined(CONFIG_SERIAL_TERMIOS)
+#if defined(__TIZENRT__)
+#include <tinyara/config.h>
+#if defined(CONFIG_SERIAL_TERMIOS)
 #include <termios.h>
+#endif
 #endif
 #include <ctype.h>   // for isspace, etc
 #include <stddef.h>  // for ptrdiff_t
@@ -481,7 +484,7 @@
 //
 // To disable threading support in Google Test, add -DGTEST_HAS_PTHREAD=0
 // to your compiler flags.
-# define GTEST_HAS_PTHREAD (GTEST_OS_LINUX || GTEST_OS_MAC || GTEST_OS_HPUX \
+#define GTEST_HAS_PTHREAD (GTEST_OS_LINUX || GTEST_OS_MAC || GTEST_OS_HPUX \
     || GTEST_OS_QNX)
 #endif  // GTEST_HAS_PTHREAD
 
@@ -684,7 +687,7 @@ using ::std::tuple_size;
     (GTEST_OS_WINDOWS || GTEST_OS_CYGWIN || GTEST_OS_SYMBIAN || GTEST_OS_AIX)
 
 // Determines whether test results can be streamed to a socket.
-#if GTEST_OS_LINUX
+#if (GTEST_OS_TIZENRT || GTEST_OS_LINUX)
 # define GTEST_CAN_STREAM_RESULTS_ 1
 #endif
 

--- a/external/gmock/gtest/src/gtest.cc
+++ b/external/gmock/gtest/src/gtest.cc
@@ -50,7 +50,7 @@
 #include <sstream>
 #include <vector>
 
-#if GTEST_OS_LINUX
+#if (GTEST_OS_TIZENRT || GTEST_OS_LINUX)
 
 // TODO(kenton@google.com): Use autoconf to detect availability of
 // gettimeofday().
@@ -115,7 +115,7 @@
 # include <sys/time.h>  // NOLINT
 # include <unistd.h>  // NOLINT
 
-#endif  // GTEST_OS_LINUX
+#endif  // (GTEST_OS_TIZENRT || GTEST_OS_LINUX)
 
 #if GTEST_HAS_EXCEPTIONS
 # include <stdexcept>
@@ -3450,8 +3450,8 @@ void StreamingListener::SocketWriter::MakeConnection() {
   const int error_num = getaddrinfo(
       host_name_.c_str(), port_num_.c_str(), &hints, &servinfo);
   if (error_num != 0) {
-    GTEST_LOG_(WARNING) << "stream_result_to: getaddrinfo() failed: "
-                        << gai_strerror(error_num);
+      GTEST_LOG_(WARNING) << "stream_result_to: getaddrinfo() failed: ";
+    //                    << gai_strerror(error_num);
   }
 
   // Loop through all the results and connect to the first we can.

--- a/external/gmock/src/gmock-spec-builders.cc
+++ b/external/gmock/src/gmock-spec-builders.cc
@@ -44,7 +44,7 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
-#if GTEST_OS_CYGWIN || GTEST_OS_LINUX || GTEST_OS_MAC
+#if GTEST_OS_CYGWIN || GTEST_OS_TIZENRT || GTEST_OS_LINUX || GTEST_OS_MAC
 # include <unistd.h>  // NOLINT
 #endif
 


### PR DESCRIPTION
- Apply GTEST_OS_TIZENRT in gtest