### PR TITLE
kernel/pthread : Assign correct return values

### DIFF
--- a/os/kernel/group/group_join.c
+++ b/os/kernel/group/group_join.c
@@ -189,6 +189,10 @@ int group_bind(FAR struct pthread_tcb_s *tcb)
 
 	DEBUGASSERT(ptcb && tcb && ptcb->group && !tcb->cmn.group);
 
+	if (!(ptcb && tcb && ptcb->group && !tcb->cmn.group)) {
+		return -EINVAL;
+	}
+
 	/* Copy the group reference from the parent to the child */
 
 	tcb->cmn.group = ptcb->group;

--- a/os/kernel/pthread/pthread_create.c
+++ b/os/kernel/pthread/pthread_create.c
@@ -277,7 +277,7 @@ int pthread_create(FAR pthread_t *thread, FAR const pthread_attr_t *attr, pthrea
 
 	ret = group_bind(ptcb);
 	if (ret < 0) {
-		errcode = ENOMEM;
+		errcode = -ret;
 		goto errout_with_tcb;
 	}
 #endif
@@ -305,7 +305,7 @@ int pthread_create(FAR pthread_t *thread, FAR const pthread_attr_t *attr, pthrea
 
 	ret = up_create_stack((FAR struct tcb_s *)ptcb, attr->stacksize, TCB_FLAG_TTYPE_PTHREAD);
 	if (ret != OK) {
-		errcode = ENOMEM;
+		errcode = -ret;
 		goto errout_with_join;
 	}
 #if defined(CONFIG_BUILD_PROTECTED)
@@ -370,7 +370,7 @@ int pthread_create(FAR pthread_t *thread, FAR const pthread_attr_t *attr, pthrea
 
 	ret = group_join(ptcb);
 	if (ret < 0) {
-		errcode = ENOMEM;
+		errcode = -ret;
 		goto errout_with_join;
 	}
 
@@ -384,8 +384,6 @@ int pthread_create(FAR pthread_t *thread, FAR const pthread_attr_t *attr, pthrea
 	/* Set the appropriate scheduling policy in the TCB */
 
 	switch (policy) {
-	default:
-		DEBUGPANIC();
 	case SCHED_FIFO:
 		ptcb->cmn.flags &= ~TCB_FLAG_ROUND_ROBIN;
 		break;
@@ -396,6 +394,8 @@ int pthread_create(FAR pthread_t *thread, FAR const pthread_attr_t *attr, pthrea
 		ptcb->cmn.timeslice = MSEC2TICK(CONFIG_RR_INTERVAL);
 		break;
 #endif
+	default:
+		DEBUGPANIC();
 	}
 
 #ifdef CONFIG_CANCELLATION_POINTS


### PR DESCRIPTION
Hard coded return values have been assigned instead of actual return value.
This patch address it by assigning the correct return values.

Signed-off-by: pradeep.ns <pradeep.ns@samsung.com>