### PR TITLE
iotivity : remove unsupported strings.h for tizenrt

### DIFF
--- a/external/iotivity/iotivity_1.2-rel/resource/c_common/SConscript
+++ b/external/iotivity/iotivity_1.2-rel/resource/c_common/SConscript
@@ -93,6 +93,7 @@ if target_os in ['tizenrt']:
 	env.AppendUnique(CCFLAGS = ['-std=c99'])
 	env.AppendUnique(CCFLAGS = ['-w'])
 	cxx_headers.remove('sys/timeb.h')
+	cxx_headers.remove('strings.h')
 	config_h_body += "#include <tinyara/config.h>\n\n"
 
 if target_os == 'msys_nt':


### PR DESCRIPTION
strings.h is not supported, hence removing it.

Signed-off-by: Manohara HK <manohara.hk@samsung.com>