### PR TITLE
Fix a build error in webclient

### DIFF
--- a/external/webclient/webclient.c
+++ b/external/webclient/webclient.c
@@ -935,7 +935,7 @@ static pthread_addr_t wget_base(void *arg)
 	struct wget_s ws;
 	struct http_client_request_t *param = (struct http_client_request_t *)arg;
 	struct http_client_response_t response = {0, };
-	bool read_finish = false;
+	int read_finish = false;
 
 	struct http_client_tls_t *client_tls = (struct http_client_tls_t *)malloc(sizeof(
 			struct http_client_tls_t));
@@ -1125,7 +1125,7 @@ static pthread_addr_t wget_base(void *arg)
 	struct wget_s ws;
 	struct http_client_request_t *param = (struct http_client_request_t *)arg;
 	struct http_client_response_t response;
-	bool read_finish = false;
+	int read_finish = false;
 
 	/* Initialize the state structure */
 	memset(&ws, 0, sizeof(struct wget_s));


### PR DESCRIPTION
- webclient.c:1064:19: error: comparison of constant '-1' with boolean expression is always false [-Werror=bool-compare]
   if (read_finish == HTTP_ERROR) {
                   ^~
cc1: all warnings being treated as errors

- This patch is to change the data type of 'read_finish' as conditions compare boolean and '-1'
