### PR TITLE
testcase/kernel: remove unncessary clock dependancy

### DIFF
--- a/apps/examples/testcase/le_tc/kernel/Kconfig
+++ b/apps/examples/testcase/le_tc/kernel/Kconfig
@@ -61,7 +61,6 @@ config TC_KN_ALL
 config TC_KERNEL_CLOCK
 	bool "Clock"
 	default n
-	select SYSTEM_TIME64
 
 config TC_KERNEL_ENVIRON
 	bool "Environ"

--- a/apps/examples/testcase/le_tc/kernel/kernel_tc_main.c
+++ b/apps/examples/testcase/le_tc/kernel/kernel_tc_main.c
@@ -44,9 +44,6 @@ int tc_kernel_main(int argc, char *argv[])
 #endif
 
 #ifdef CONFIG_TC_KERNEL_CLOCK
-#if (!defined CONFIG_SYSTEM_TIME64)
-#error CONFIG_SYSTEM_TIME64 is needed for testing CLOCK TC
-#endif
 	clock_main();
 #endif
 


### PR DESCRIPTION
To run clock tc, CONFIG_SYSTEM_TIME64 is not mandatory.
This dependancy makes wrong selection on config and causes
compilation error when that config is disabled.

le_tc/kernel/kernel_tc_main.c: In function 'tc_kernel_main':
le_tc/kernel/kernel_tc_main.c:48:2: error: #error CONFIG_SYSTEM_TIME64 is needed for testing CLOCK TC
 #error CONFIG_SYSTEM_TIME64 is needed for testing CLOCK TC
  ^~~~~
Makefile:121: recipe for target 'kernel_tc_main.o' failed