### PR TITLE
testcase : add TC for media framework

### DIFF
--- a/apps/examples/testcase/Kconfig
+++ b/apps/examples/testcase/Kconfig
@@ -31,6 +31,7 @@ source "$APPSDIR/examples/testcase/ta_tc/wifi_manager/utc/Kconfig"
 source "$APPSDIR/examples/testcase/ta_tc/wifi_manager/itc/Kconfig"
 source "$APPSDIR/examples/testcase/ta_tc/mqtt/utc/Kconfig"
 source "$APPSDIR/examples/testcase/ta_tc/mqtt/itc/Kconfig"
+source "$APPSDIR/examples/testcase/ta_tc/media/utc/Kconfig"
 endif #EXAMPLES_TESTCASE
 
 config USER_ENTRYPOINT

--- a/apps/examples/testcase/Makefile
+++ b/apps/examples/testcase/Makefile
@@ -60,11 +60,13 @@ include $(APPDIR)/Make.defs
 APPNAME = tc
 FUNCNAME = $(APPNAME)_main
 THREADEXEC = TASH_EXECMD_ASYNC
+CXXEXT ?= .cpp
 
 # testcase example
 
 ASRCS =
 CSRCS =
+CXXSRCS =
 
 ifeq ($(CONFIG_EXAMPLES_TESTCASE),y)
 
@@ -93,9 +95,10 @@ endif
 
 AOBJS		= $(ASRCS:.S=$(OBJEXT))
 COBJS		= $(CSRCS:.c=$(OBJEXT))
+CXXOBJS		= $(CXXSRCS:$(CXXEXT)=$(OBJEXT))
 
-SRCS		= $(ASRCS) $(CSRCS)
-OBJS		= $(AOBJS) $(COBJS)
+SRCS		= $(ASRCS) $(CSRCS) $(CXXSRCS)
+OBJS		= $(AOBJS) $(COBJS) $(CXXOBJS)
 
 ifeq ($(CONFIG_WINDOWS_NATIVE),y)
   BIN		= ..\..\libapps$(LIBEXT)
@@ -119,6 +122,9 @@ $(AOBJS): %$(OBJEXT): %.S
 
 $(COBJS): %$(OBJEXT): %.c
 	$(call COMPILE, $<, $@)
+
+$(CXXOBJS): %$(OBJEXT): %$(CXXEXT)
+	$(call COMPILEXX, $<, $@)
 endif
 
 .built: $(OBJS)
@@ -141,10 +147,12 @@ context:
 endif
 
 .depend: Makefile $(SRCS)
-ifeq ($(CONFIG_EXAMPLES_TESTCASE),y)
-	$(Q) $(MKDEP) $(DEPPATH) "$(CC)" -- $(CFLAGS) -- $(SRCS) >Make.dep
-	$(Q) touch $@
+ifeq ($(filter %$(CXXEXT),$(SRCS)),)
+	@$(MKDEP) $(DEPPATH) "$(CC)" -- $(CFLAGS) -- $(SRCS) >Make.dep
+else
+	@$(MKDEP) $(DEPPATH) "$(CXX)" -- $(CXXFLAGS) -- $(SRCS) >Make.dep
 endif
+	@touch $@
 
 depend: .depend
 

--- a/apps/examples/testcase/ta_tc/media/utc/Kconfig
+++ b/apps/examples/testcase/ta_tc/media/utc/Kconfig
@@ -1,0 +1,11 @@
+#
+# For a description of the syntax of this configuration file,
+# see kconfig-language at https://www.kernel.org/doc/Documentation/kbuild/kconfig-language.txt
+#
+
+config EXAMPLES_TESTCASE_MEDIA_UTC
+	bool "Media UTC TestCase Example"
+	default n
+	depends on HAVE_CXXINITIALIZE && LIBCXX && MEDIA && GMOCK
+	---help---
+		Enable the Media F/W TestCase example

--- a/apps/examples/testcase/ta_tc/media/utc/Make.defs
+++ b/apps/examples/testcase/ta_tc/media/utc/Make.defs
@@ -1,0 +1,33 @@
+###########################################################################
+#
+# Copyright 2018 Samsung Electronics All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+#
+###########################################################################
+
+ifeq ($(CONFIG_EXAMPLES_TESTCASE_MEDIA_UTC),y)
+CXXSRCS += utc_media_main.cpp
+
+GMOCK_DIR = $(TOPDIR)/../external/gmock
+GTEST_DIR = $(TOPDIR)/../external/gmock/gtest
+
+CXXFLAGS += -D__TIZENRT__ -DHAVE_PTHREAD -g -Wall -Wno-sign-compare
+CXXFLAGS += -I $(GMOCK_DIR) -I $(GMOCK_DIR)/include -I $(GMOCK_DIR)/include/gmock/internal
+CXXFLAGS += -I $(GTEST_DIR) -I $(GTEST_DIR)/include -I $(GTEST_DIR)/include/gtest/internal
+
+# Include media build support
+
+DEPPATH += --dep-path ta_tc/media/utc
+VPATH += :ta_tc/media/utc
+endif

--- a/apps/examples/testcase/ta_tc/media/utc/utc_media_main.cpp
+++ b/apps/examples/testcase/ta_tc/media/utc/utc_media_main.cpp
@@ -1,0 +1,64 @@
+/****************************************************************************
+ *
+ * Copyright 2018 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+//***************************************************************************
+// Included Files
+//***************************************************************************
+
+#include <tinyara/config.h>
+#include <tinyara/init.h>
+#include <stdio.h>
+#include <apps/platform/cxxinitialize.h>
+#include <errno.h>
+#include <gtest/gtest.h>
+#include <iostream>
+#include "tc_common.h"
+
+TEST(SimpleTest, SubTest1)
+{
+	// will do implementation for media test case
+	ASSERT_TRUE(1 == 1);
+	EXPECT_EQ(1, 1);
+}
+
+int gtest_run(int *argc, char **argv)
+{
+	testing::InitGoogleTest(argc, argv);	
+	return RUN_ALL_TESTS();
+}
+
+extern "C" 
+{
+	#ifdef CONFIG_BUILD_KERNEL
+	int main(int argc, FAR char *argv[])
+	#else
+	int utc_media_main(int argc, char *argv[])
+	#endif
+	{
+		up_cxxinitialize();
+		
+		if (tc_handler(TC_START, "Media UTC") == -1) {
+			return -1;
+		}
+		
+		gtest_run(&argc, argv);
+
+		(void)tc_handler(TC_END, "Media UTC");
+
+		return 0;
+	}
+}

--- a/apps/examples/testcase/tc_common.h
+++ b/apps/examples/testcase/tc_common.h
@@ -149,6 +149,14 @@ extern int total_fail;
 	} \
 }
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 int tc_handler(tc_op_type_t type, const char *tc_name);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/apps/examples/testcase/tc_main.c
+++ b/apps/examples/testcase/tc_main.c
@@ -66,6 +66,9 @@
 #if defined(CONFIG_EXAMPLES_TESTCASE_AUDIO_UTC) || defined(CONFIG_EXAMPLES_TESTCASE_AUDIO_ITC)
 #define TC_AUDIO_STACK  2048
 #endif
+#if defined(CONFIG_EXAMPLES_TESTCASE_MEDIA_UTC) || defined(CONFIG_EXAMPLES_TESTCASE_MEDIA_ITC)
+#define TC_MEDIA_STACK  8192
+#endif
 #endif
 
 sem_t tc_sem;
@@ -93,6 +96,7 @@ extern int utc_mqtt_main(int argc, char *argv[]);
 extern int itc_mqtt_main(int argc, char *argv[]);
 extern int utc_audio_main(int argc, char *argv[]);
 extern int itc_audio_main(int argc, char *argv[]);
+extern int utc_media_main(int argc, char *argv[]);
 
 /* Not yet */
 extern int tc_mpu_main(int argc, char *argv[]);
@@ -153,10 +157,16 @@ static const tash_cmdlist_t tc_cmds[] = {
 #ifdef CONFIG_EXAMPLES_TESTCASE_AUDIO_ITC
 	{"audio_itc", itc_audio_main, TASH_EXECMD_ASYNC},
 #endif
+#ifdef CONFIG_EXAMPLES_TESTCASE_MEDIA_UTC
+	{"media_utc", utc_media_main, TASH_EXECMD_ASYNC},
+#endif
 	{NULL, NULL, 0}
 };
 #endif
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 int tc_handler(tc_op_type_t type, const char *tc_name)
 {
 	switch (type) {
@@ -317,9 +327,19 @@ int tc_main(int argc, char *argv[])
 		printf("Audio itc is not started, err = %d\n", pid);
 	}
 #endif
+#ifdef CONFIG_EXAMPLES_TESTCASE_MEDIA_UTC
+	pid = task_create("mediautc", SCHED_PRIORITY_DEFAULT, TC_MEDIA_STACK, utc_media_main, argv);
+	if (pid < 0) {
+		printf("Media utc is not started, err = %d\n", pid);
+	}
+#endif
 
 	printf("All Testcases finished\n");
 #endif
 
 	return 0;
 }
+
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
modified the environment files to use gtest,
and inserted the skeleton code for media utc development.

Signed-off-by: jaesick.shin <jaesick.shin@samsung.com>