### PR TITLE
MediaPlayerImpl: Remove duplicated function call

### DIFF
--- a/framework/src/media/MediaPlayerImpl.cpp
+++ b/framework/src/media/MediaPlayerImpl.cpp
@@ -92,8 +92,7 @@ player_result_t MediaPlayerImpl::prepare()
 		return PLAYER_ERROR;
 	}
 
-	mInputDataSource->open();
-	if (!mInputDataSource->isPrepare()) {
+	if (!mInputDataSource->open()) {
 		meddbg("MediaPlayer prepare fail : file open fail\n");
 		return PLAYER_ERROR;
 	}


### PR DESCRIPTION
InputDataSource.open() returns InputDataSource.isPrepare()
Remove unnecessary line