### PR TITLE
pm: add pm_unregister

### DIFF
--- a/os/include/tinyara/pm/pm.h
+++ b/os/include/tinyara/pm/pm.h
@@ -401,11 +401,29 @@ void pm_initialize(void);
  *               callback functions.
  *
  * Returned value:
- *    Zero (OK) on success; otherwise a negater errno value is returned.
+ *    Zero (OK) on success; otherwise a negated errno value is returned.
  *
  ****************************************************************************/
 
 int pm_register(int domain, FAR struct pm_callback_s *callbacks);
+
+/****************************************************************************
+ * Name: pm_unregister
+ *
+ * Description:
+ *   This function is called by a device driver in order to unregister
+ *   previously registered power management event callbacks.
+ *
+ * Input parameters:
+ *   callbacks - An instance of struct pm_callback_s providing the driver
+ *               callback functions.
+ *
+ * Returned value:
+ *    Zero (OK) on success; otherwise a negated errno value is returned.
+ *
+ ****************************************************************************/
+
+int pm_unregister(int domain, FAR struct pm_callback_s *callbacks);
 
 /****************************************************************************
  * Name: pm_activity
@@ -518,6 +536,7 @@ int pm_changestate(int domain, enum pm_state_e newstate);
 
 #define pm_initialize()
 #define pm_register(cb)             (0)
+#define pm_unregister(domain, cb)   (0)
 #define pm_activity(domain, prio)
 #define pm_checkstate(domain)       (0)
 #define pm_changestate(domain, state)

--- a/os/pm/Makefile
+++ b/os/pm/Makefile
@@ -21,7 +21,7 @@
 ASRCS =
 
 CSRCS += pm_activity.c pm_changestate.c pm_checkstate.c pm_initialize.c
-CSRCS += pm_register.c pm_update.c pm_procfs.c
+CSRCS += pm_register.c pm_unregister.c pm_update.c pm_procfs.c
 
 ifeq ($(CONFIG_PM_METRICS),y)
 CSRCS += pm_metrics.c

--- a/os/pm/pm.h
+++ b/os/pm/pm.h
@@ -18,7 +18,7 @@
 /****************************************************************************
  * pm/pm.h
  *
- *   Copyright (C) 2011-2012, 2016 Gregory Nutt. All rights reserved.
+ *   Copyright (C) 2011-2012, 2016, 2018 Gregory Nutt. All rights reserved.
  *   Author: Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without

--- a/os/pm/pm_test.c
+++ b/os/pm/pm_test.c
@@ -79,8 +79,12 @@ static int pmtest_kthread(int argc, char *argv[])
 
 void pmtest_launch_kthread(void)
 {
+	int i = 0;
 	if (kernel_thread("pmtest", PMTEST_THREAD_PRIORITY, PMTEST_THREAD_STACKSIZE, pmtest_kthread, (char *const *)NULL) < 0) {
 		pmvdbg("pmtest kthread launch failed\n");
+		for (i = 0; i < PMTEST_DEVICES; i++) {
+			pm_unregister(0, &pmtest_cbarray[i]);
+		}
 	}
 }
 

--- a/os/pm/pm_unregister.c
+++ b/os/pm/pm_unregister.c
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- * Copyright 2016 Samsung Electronics All Rights Reserved.
+ * Copyright 2018 Samsung Electronics All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,10 +16,10 @@
  *
  ****************************************************************************/
 /****************************************************************************
- * pm/pm_register.c
+ * pm/pm_unregister.c
  *
- *   Copyright (C) 2011-2012 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ *   Copyright (C) 2018 Gregory Nutt. All rights reserved.
+ *   Author: Juha Niskanen <juha.niskanen@haltian.com>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -68,11 +68,11 @@
  ****************************************************************************/
 
 /****************************************************************************
- * Name: pm_register
+ * Name: pm_unregister
  *
  * Description:
- *   This function is called by a device driver in order to register to
- *   receive power management event callbacks.
+ *   This function is called by a device driver in order to unregister
+ *   previously registered power management event callbacks.
  *
  * Input parameters:
  *   callbacks - An instance of struct pm_callback_s providing the driver
@@ -83,19 +83,20 @@
  *
  ****************************************************************************/
 
-int pm_register(int domain_indx, FAR struct pm_callback_s *callbacks)
+int pm_unregister(int domain_indx, FAR struct pm_callback_s *callbacks)
 {
 	int ret;
 
 	DEBUGASSERT(callbacks);
 
-	/* Add the new entry to the end of the list of registered callbacks */
+	/* Remove entry from the list of registered callbacks. */
 
 	ret = pm_lock(domain_indx);
 	if (ret == OK) {
-		sq_addlast(&callbacks->entry, &g_pmglobals.domain[domain_indx].registry);
+		sq_rem(&callbacks->entry, &g_pmglobals.domain[domain_indx].registry);
+		pm_unlock(domain_indx);
 	}
-	pm_unlock(domain_indx);
+
 	return ret;
 }
 


### PR DESCRIPTION
add pm_unregister support for pm framework (Backport from Nuttx).
This function is called by a device driver in order to unregister
previously registered power management event callbacks.

Signed-off-by: Shadakshari KP <shari.kps@samsung.com>