### PR TITLE
network/dhcpd: dhcpd bug fix 

### DIFF
--- a/external/dhcpd/dhcpd.c
+++ b/external/dhcpd/dhcpd.c
@@ -1491,7 +1491,6 @@ void dhcpd_stop(void)
 		pthread_mutex_unlock(&g_dhcpd_lock);
 		return;
 	}
-	pthread_mutex_unlock(&g_dhcpd_lock);
 
 	g_dhcpd_quit = 1;
 	while (ret != OK) {
@@ -1502,17 +1501,21 @@ void dhcpd_stop(void)
 				ndbg("ERR: EINTR for sem_wait in dhcpd\n");
 				continue;
 			}
+			pthread_mutex_unlock(&g_dhcpd_lock);			
 			return;
 		}
 	}
+	g_dhcpd_running = 0;
 	ret = sem_destroy(&g_dhcpd_sem);
 	if (ret != OK) {
 		ndbg("ERR: sem_destroy for dhcpd failed\n");
+		pthread_mutex_unlock(&g_dhcpd_lock);
 		return;
 	}
 #if DHCPD_SELECT
 	ndbg("WARN : dhcpd will be stopped after %d seconds\n", g_select_timeout.tv_sec);
 #endif
+	pthread_mutex_unlock(&g_dhcpd_lock);
 }
 
 /****************************************************************************

--- a/external/dhcpd/dhcpd.c
+++ b/external/dhcpd/dhcpd.c
@@ -1675,8 +1675,6 @@ int dhcpd_start(char *intf, dhcp_sta_joined dhcp_join_cb)
 		pthread_mutex_unlock(&g_dhcpd_lock);
 		return -1;
 	}
-	g_dhcpd_running = 1;
-	pthread_mutex_unlock(&g_dhcpd_lock);
 
 	pthread_attr_t attr;
 	int status;
@@ -1735,9 +1733,11 @@ int dhcpd_start(char *intf, dhcp_sta_joined dhcp_join_cb)
 	pthread_setname_np(g_tid, "dhcpd");
 	pthread_detach(g_tid);
 
+	g_dhcpd_running = 1;
+	pthread_mutex_unlock(&g_dhcpd_lock);
+
 	return 0;
 err_exit:
-	pthread_mutex_lock(&g_dhcpd_lock);
 	g_dhcpd_running = 0;
 	pthread_mutex_unlock(&g_dhcpd_lock);
 


### PR DESCRIPTION
dhcpd_stop & dhcpd_start bug fix
- reset g_dhcpd_running variable when dhcp server is destroyed
- set g_dhcpd_running variable after dhcp server is actually running
- change blocking range of dhcpd_stop & dhcpd_start
