### PR TITLE
Mediaplayer : Check parameter of setDataSource

### DIFF
--- a/framework/include/media/MediaPlayer.h
+++ b/framework/include/media/MediaPlayer.h
@@ -159,9 +159,10 @@ public:
 	 * @details @b #include <media/MediaPlayer.h>
 	 * This function is sync call apis
 	 * @param[in] dataSource The dataSource that the config of input data
+	 * @return The result of the setDataSource operation
 	 * @since TizenRT v2.0 PRE
 	 */
-	void setDataSource(std::unique_ptr<stream::InputDataSource>);
+	player_result_t setDataSource(std::unique_ptr<stream::InputDataSource>);
 	/**
 	 * @brief Sets the observer of MediaPlayer
 	 * @details @b #include <media/MediaPlayer.h>

--- a/framework/src/media/MediaPlayer.cpp
+++ b/framework/src/media/MediaPlayer.cpp
@@ -70,9 +70,9 @@ player_result_t MediaPlayer::setVolume(int vol)
 	return mPMpImpl->setVolume(vol);
 }
 
-void MediaPlayer::setDataSource(std::unique_ptr<stream::InputDataSource> source)
+player_result_t MediaPlayer::setDataSource(std::unique_ptr<stream::InputDataSource> source)
 {
-	mPMpImpl->setDataSource(std::move(source));
+	return mPMpImpl->setDataSource(std::move(source));
 }
 
 void MediaPlayer::setObserver(std::shared_ptr<MediaPlayerObserverInterface> observer)

--- a/framework/src/media/MediaPlayerImpl.cpp
+++ b/framework/src/media/MediaPlayerImpl.cpp
@@ -215,11 +215,17 @@ player_result_t MediaPlayerImpl::setVolume(int vol)
 	}
 }
 
-void MediaPlayerImpl::setDataSource(std::unique_ptr<stream::InputDataSource> source)
+player_result_t MediaPlayerImpl::setDataSource(std::unique_ptr<stream::InputDataSource> source)
 {
 	std::lock_guard<std::mutex> lock(mCmdMtx);
 	medvdbg("MediaPlayer setDataSource\n");
+	if (!source) {
+		meddbg("MediaPlayer setDataSource fail : invalid argument. DataSource should not be nullptr\n");
+		return PLAYER_ERROR;
+	}
+
 	mInputDataSource = std::move(source);
+	return PLAYER_OK;
 }
 
 void MediaPlayerImpl::setObserver(std::shared_ptr<MediaPlayerObserverInterface> observer)

--- a/framework/src/media/MediaPlayerImpl.h
+++ b/framework/src/media/MediaPlayerImpl.h
@@ -29,7 +29,7 @@ public:
 	int getVolume();
 	player_result_t setVolume(int);
 
-	void setDataSource(std::unique_ptr<stream::InputDataSource>);
+	player_result_t setDataSource(std::unique_ptr<stream::InputDataSource>);
 	void setObserver(std::shared_ptr<MediaPlayerObserverInterface>);
 
 	player_state_t getState();


### PR DESCRIPTION
If source is nullptr, setDataSource returns PLAYER_ERROR.
Else it returns PLAYER_OK.