### PR TITLE
fix SVACE issue on kernel side

### DIFF
--- a/apps/examples/testcase/le_tc/kernel/tc_pthread.c
+++ b/apps/examples/testcase/le_tc/kernel/tc_pthread.c
@@ -139,15 +139,19 @@ static void *do_nothing_thread(void *param)
 static void *setschedprio_test_thread(void *param)
 {
 	struct sched_param param_info;
+	int ret_chk;
 
 	/* sleep to guarantee running of pthread_setschedprio() */
 	sleep(1);
 
 	/* get current priority */
-	(void)sched_getparam(0, &param_info);
-
-	/* give getting value to global variable to compare it in another function */
-	check_prio = param_info.sched_priority;
+	ret_chk = sched_getparam(0, &param_info);
+	if (ret_chk == ERROR) {
+		check_prio = 0;	// Fail to get current priority
+	} else {
+		/* give getting value to global variable to compare it in another function */
+		check_prio = param_info.sched_priority;
+	}
 
 	return NULL;
 }

--- a/apps/examples/testcase/le_tc/kernel/tc_timer.c
+++ b/apps/examples/testcase/le_tc/kernel/tc_timer.c
@@ -257,6 +257,7 @@ static void tc_timer_timer_set_get_time(void)
 */
 static void tc_timer_timer_initialize(void)
 {
+	int ret_chk;
 	timer_t timer_id;
 	clockid_t clockid = CLOCK_REALTIME;
 	struct sigevent st_sigevent;
@@ -289,7 +290,9 @@ static void tc_timer_timer_initialize(void)
 	}
 
 	/* check the count for g_alloctimers and g_freetimers after create now they change */
-	timer_create(clockid, &st_sigevent, &timer_id);
+	ret_chk = timer_create(clockid, &st_sigevent, &timer_id);
+	TC_ASSERT_NEQ("timer_create", ret_chk, ERROR);
+	TC_ASSERT_NEQ("timer_create", timer_id, NULL);
 
 	for (timer = (FAR struct posix_timer_s *)g_alloctimers.head; timer; timer = next) {
 		next = timer->flink;

--- a/os/kernel/signal/sig_allocatependingsigaction.c
+++ b/os/kernel/signal/sig_allocatependingsigaction.c
@@ -130,9 +130,7 @@ FAR sigq_t *sig_allocatependingsigaction(void)
 		if (!sigq) {
 			/* No...Try the resource pool */
 
-			if (!sigq) {
-				sigq = (FAR sigq_t *)kmm_malloc((sizeof(sigq_t)));
-			}
+			sigq = (FAR sigq_t *)kmm_malloc((sizeof(sigq_t)));
 
 			/* Check if we got an allocated message */
 

--- a/os/kernel/signal/sig_dispatch.c
+++ b/os/kernel/signal/sig_dispatch.c
@@ -190,9 +190,7 @@ static FAR sigpendq_t *sig_allocatependingsignal(void)
 		if (!sigpend) {
 			/* No... Allocate the pending signal */
 
-			if (!sigpend) {
-				sigpend = (FAR sigpendq_t *)kmm_malloc((sizeof(sigpendq_t)));
-			}
+			sigpend = (FAR sigpendq_t *)kmm_malloc((sizeof(sigpendq_t)));
 
 			/* Check if we got an allocated message */
 

--- a/os/kernel/timer/timer_release.c
+++ b/os/kernel/timer/timer_release.c
@@ -114,10 +114,6 @@ static inline void timer_free(struct posix_timer_s *timer)
 		irqrestore(flags);
 		sched_kfree(timer);
 	}
-
-	/* Mark this timer is not in use */
-
-	timer->pt_flags &= ~PT_FLAGS_INUSE;
 }
 
 /********************************************************************************
@@ -166,6 +162,12 @@ int timer_release(FAR struct posix_timer_s *timer)
 	 */
 
 	(void)wd_delete(timer->pt_wdog);
+
+	/* Mark this timer is not in use before releasing the timer.
+	 * This prevents returning some value when timer API is called after release
+	 */
+
+	timer->pt_flags &= ~PT_FLAGS_INUSE;
 
 	/* Release the timer structure */
 

--- a/os/mm/mm_heap/mm_heapinfo.c
+++ b/os/mm/mm_heap/mm_heapinfo.c
@@ -371,8 +371,10 @@ void heapinfo_update_group_info(pid_t pid, int group, int type)
 				group_info[info_idx].pid = pid;
 				group_info[info_idx].group = group;
 				tcb = sched_gettcb(pid);
-				group_info[info_idx].stack_size = tcb->adj_stack_size;
-				heapinfo_update_group(tcb->adj_stack_size, pid);
+				if (tcb) {
+					group_info[info_idx].stack_size = tcb->adj_stack_size;
+					heapinfo_update_group(tcb->adj_stack_size, pid);
+				}
 				break;
 			}
 		}


### PR DESCRIPTION
1. kernel/timer: move a location of marking not in use
2. mm/mm_heap: check NULL dereferencing on sched_gettcb
3. kernel/signal: remove duplicated checking conditional
4. testcase/kernel/pthread: check return value of function
5. estcase/kernel/timer: check return value of function