### PR TITLE
kernel/sched: Change ordering of round-robin time slice check and processing of wdog timers

### DIFF
--- a/os/kernel/sched/sched_processtimer.c
+++ b/os/kernel/sched/sched_processtimer.c
@@ -18,7 +18,7 @@
 /************************************************************************
  * kernel/sched/sched_processtimer.c
  *
- *   Copyright (C) 2007, 2009, 2014 Gregory Nutt. All rights reserved.
+ *   Copyright (C) 2007, 2009, 2014-2018 Gregory Nutt. All rights reserved.
  *   Author: Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
@@ -214,13 +214,13 @@ void sched_process_timer(void)
 	}
 #endif
 
-	/* Process watchdogs */
-
-	wd_timer();
-
 	/* Check if the currently executing task has exceeded its
 	 * timeslice.
 	 */
 
 	sched_process_timeslice();
+
+	/* Process watchdogs */
+
+	wd_timer();
 }


### PR DESCRIPTION

wd_timer()'s callback function can change current running task and hence it must be called after the time slice check.

The time slice check will decrement the currently running task's time slice count.
When context switch occurs before decrementing the slice count, then the newly started task will lost one slice count before it even has a chance to run.

This is patch is back ported from Nuttx.

Signed-off-by: Lokesh B V <lokesh.bv@partner.samsung.com>