### PR TITLE
media : bug fix for MediaRecorder

### DIFF
--- a/framework/src/media/MediaRecorderImpl.cpp
+++ b/framework/src/media/MediaRecorderImpl.cpp
@@ -77,6 +77,7 @@ recorder_result_t MediaRecorderImpl::prepare()
 	unique_lock<mutex> lock(mCmdMtx);
 
 	medvdbg("MediaRecorderImpl::prepare()\n");
+
 	if (mCurState != RECORDER_STATE_IDLE || mOutputDataSource == nullptr) {
 		meddbg("MediaRecorderImpl::prepare() - mCurState != RECORDER_STATE_IDLE || mOutputDataSource == nullptr\n");
 		return RECORDER_ERROR;
@@ -114,6 +115,7 @@ recorder_result_t MediaRecorderImpl::unprepare()
 	unique_lock<mutex> lock(mCmdMtx);
 
 	medvdbg("MediaRecorderImpl::unprepare()\n");
+
 	if (mCurState == RECORDER_STATE_NONE || mCurState == RECORDER_STATE_IDLE) {
 		meddbg("MediaRecorderImpl::unprepare() - mCurState == RECORDER_STATE_NONE || mCurState == RECORDER_STATE_IDLE\n");
 		return RECORDER_ERROR;
@@ -134,7 +136,15 @@ recorder_result_t MediaRecorderImpl::unprepare()
 		mOutputDataSource->close();
 	}
 
-	reset_audio_stream_in();
+	if (reset_audio_stream_in() != AUDIO_MANAGER_SUCCESS) {
+		meddbg("reset_audio_stream_in() != AUDIO_MANAGER_SUCCESS\n");
+		return RECORDER_ERROR;
+	}
+
+	if (destroy_audio_stream_in() != AUDIO_MANAGER_SUCCESS) {
+		meddbg("destroy_audio_stream_in() != AUDIO_MANAGER_SUCCESS\n");
+		return RECORDER_ERROR;
+	}
 
 	mCurState = RECORDER_STATE_IDLE;
 	return RECORDER_OK;
@@ -207,6 +217,7 @@ void MediaRecorderImpl::setObserver(std::shared_ptr<MediaRecorderObserverInterfa
 {
 	unique_lock<mutex> lock(mCmdMtx);
 	medvdbg("MediaRecorderImpl::setObserver(std::shared_ptr<MediaRecorderObserverInterface> observer)\n");
+
 	RecorderObserverWorker& row = RecorderObserverWorker::getWorker();
 	row.startWorker();
 	mRecorderObserver = observer;

--- a/framework/src/media/RecorderObserverWorker.cpp
+++ b/framework/src/media/RecorderObserverWorker.cpp
@@ -32,6 +32,7 @@ RecorderObserverWorker::~RecorderObserverWorker()
 int RecorderObserverWorker::entry()
 {
 	medvdbg("RecorderObserverWorker::entry()\n");
+
 	while (mIsRunning) {
 		unique_lock<mutex> lock(mObserverQueue.getMutex());
 
@@ -91,6 +92,7 @@ void RecorderObserverWorker::increaseRef()
 
 void RecorderObserverWorker::decreaseRef()
 {
-	mRefCnt--;
+	if (mRefCnt > 0)
+		mRefCnt--;
 }
 } // namespace media

--- a/framework/src/media/RecorderWorker.cpp
+++ b/framework/src/media/RecorderWorker.cpp
@@ -96,8 +96,8 @@ void RecorderWorker::startRecorder(std::shared_ptr<MediaRecorderImpl> mr)
 	if (mr->getState() != RECORDER_STATE_READY) {
 
 		mr->notifyObserver(OBSERVER_COMMAND_ERROR);
-		meddbg("RecorderWorker::startRecorder(std::shared_ptr<MediaRecorderImpl> mr) \
-				- mr->getState() != RECORDER_STATE_READY\n");
+		meddbg("RecorderWorker::startRecorder(std::shared_ptr<MediaRecorderImpl> mr) \n "
+			"- mr->getState() != RECORDER_STATE_READY\n");
 		return;
 	}
 
@@ -107,6 +107,7 @@ void RecorderWorker::startRecorder(std::shared_ptr<MediaRecorderImpl> mr)
 	mCurRecorder = mr;
 
 	mr->setState(RECORDER_STATE_RECORDING);
+	mr->notifyObserver(OBSERVER_COMMAND_STARTED);
 }
 
 void RecorderWorker::stopRecorder(std::shared_ptr<MediaRecorderImpl> mr, bool completed)


### PR DESCRIPTION
1. fix wrong reference count for recorder observerworker
2. add missing function call for observer

Signed-off-by: jaesick.shin <jaesick.shin@samsung.com>