### PR TITLE
Fix Svace issue : drivers, fs, libc_timer, pthread

### DIFF
--- a/apps/examples/testcase/le_tc/drivers/tc_loop.c
+++ b/apps/examples/testcase/le_tc/drivers/tc_loop.c
@@ -267,6 +267,8 @@ static void tc_driver_loop_losetup(void)
 
 	/* Positive test cases */
 	FILE *fp = fopen("/mnt/loopfile", "w");
+	TC_ASSERT_NEQ("fopen", fp, NULL);
+
 	int i;
 	for (i = 0; i < 1024; i++) {
 		fputc('a', fp);

--- a/apps/examples/testcase/le_tc/filesystem/fs_main.c
+++ b/apps/examples/testcase/le_tc/filesystem/fs_main.c
@@ -1204,7 +1204,7 @@ static void tc_fs_vfs_fstat(void)
 	TC_ASSERT_GEQ("open", fd, 0);
 
 	ret = fstat(fd, &st);
-	TC_ASSERT_EQ("fstat", ret, OK);
+	TC_ASSERT_EQ_CLEANUP("fstat", ret, OK, close(fd));
 
 	close(fd);
 	TC_SUCCESS_RESULT();
@@ -1670,17 +1670,21 @@ static void tc_driver_mtd_ftl_ops(void)
 	}
 
 	fd = open(MTD_FTL_PATH, O_RDWR);
-	TC_ASSERT_GEQ("open", fd, 0);
+	TC_ASSERT_GEQ_CLEANUP("open", fd, 0, free(buf));
 
 	ret = read(fd, buf, BUF_SIZE);
-	TC_ASSERT_EQ_CLEANUP("read", ret, BUF_SIZE, close(fd));
+	TC_ASSERT_EQ_CLEANUP("read", ret, BUF_SIZE, goto cleanup);
 #ifdef CONFIG_FS_WRITABLE
 	ret = write(fd, buf, BUF_SIZE);
-	TC_ASSERT_EQ_CLEANUP("write", ret, BUF_SIZE, close(fd));
+	TC_ASSERT_EQ_CLEANUP("write", ret, BUF_SIZE, goto cleanup);
 #endif
+	free(buf);
 	ret = close(fd);
 	TC_ASSERT_EQ("close", ret, OK);
 	TC_SUCCESS_RESULT();
+cleanup:
+	free(buf);
+	close(fd);
 }
 #endif
 /**
@@ -3333,21 +3337,17 @@ static void tc_libc_stdio_zeroinstream(void)
 #if !defined(CONFIG_FS_PROCFS_EXCLUDE_MTD)
 static void tc_driver_mtd_procfs_ops(void)
 {
-	int fd1;
-	int fd2;
+	int fd;
 	int ret;
 	struct stat st;
 
-	fd1 = open(MTD_PROCFS_PATH, O_RDONLY);
-	TC_ASSERT_GEQ("open", fd1, 0);
-
-	fd2 = dup(fd1);
-	TC_ASSERT_GEQ_CLEANUP("dup", fd2, 0, close(fd1));
+	fd = open(MTD_PROCFS_PATH, O_RDONLY);
+	TC_ASSERT_GEQ("open", fd, 0);
 
 	ret = stat(MTD_PROCFS_PATH, &st);
-	TC_ASSERT_EQ_CLEANUP("stat", ret, OK, close(fd1));
+	TC_ASSERT_EQ_CLEANUP("stat", ret, OK, close(fd));
 
-	ret = close(fd1);
+	ret = close(fd);
 	TC_ASSERT_EQ("close", ret, OK);
 
 	TC_SUCCESS_RESULT();

--- a/apps/examples/testcase/le_tc/filesystem/tc_fs_procfs.c
+++ b/apps/examples/testcase/le_tc/filesystem/tc_fs_procfs.c
@@ -122,7 +122,6 @@ static int procfs_uptime_ops(char *dirpath)
 	fd = open(PROC_UPTIME_PATH, O_RDONLY);
 	if (fd < 0) {
 		printf("Failed to open \n" );
-		close(fd);
 		return ERROR;
 	}
 
@@ -142,7 +141,6 @@ static int procfs_uptime_ops(char *dirpath)
 	ret = close(fd);
 	if (ret != OK) {
 		printf("failed to close \n");
-		close(fd);
 		return ERROR;
 	}
 
@@ -160,7 +158,6 @@ static int procfs_version_ops(char *dirpath)
 	fd = open(PROC_VERSION_PATH, O_RDONLY);
 	if (fd < 0) {
 		printf("Failed to open \n");
-		close(fd);
 		return ERROR;
 	}
 

--- a/apps/examples/testcase/le_tc/kernel/tc_libc_timer.c
+++ b/apps/examples/testcase/le_tc/kernel/tc_libc_timer.c
@@ -495,7 +495,7 @@ static void tc_libc_timer_clock(void)
 	clock_t ret_time = ERROR;
 
 	ret_time = clock();
-	TC_ASSERT_GEQ("clock", ret_time, 0);
+	TC_ASSERT_NEQ("clock", ret_time, 0);
 
 	TC_SUCCESS_RESULT();
 }

--- a/apps/examples/testcase/le_tc/kernel/tc_pthread.c
+++ b/apps/examples/testcase/le_tc/kernel/tc_pthread.c
@@ -945,7 +945,9 @@ static void tc_pthread_pthread_mutex_lock_unlock_trylock(void)
 {
 	int ret_chk;
 	pthread_mutexattr_t attr;
-	pthread_mutexattr_init(&attr);
+	
+	ret_chk = pthread_mutexattr_init(&attr);
+	TC_ASSERT_EQ("pthread_mutexattr_init", ret_chk, OK);
 	pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_RECURSIVE);
 
 	pthread_mutex_init(&g_mutex, NULL);


### PR DESCRIPTION
testcase/drivers : Add check logic for fd when open
testcase/fs : Remove unnecessary close() and  Add cleanup for fd, buf
testcase/libc_timer : Remove unnecessary return check logic
testcase/pthread : Add return check logic for pthread_mutexattr_init