### PR TITLE
artik05x/Makefile : Fix typo from artik053 to artik05x for ramdump

### DIFF
--- a/os/arch/arm/src/artik05x/src/Makefile
+++ b/os/arch/arm/src/artik05x/src/Makefile
@@ -73,7 +73,7 @@ CSRCS += artik055_alc5658char.c
 endif
 
 ifeq ($(CONFIG_BOARD_CRASHDUMP),y)
-CSRCS += artik053_crashdump.c
+CSRCS += artik05x_crashdump.c
 endif
 
 ifeq ($(CONFIG_MTD_PROGMEM),y)


### PR DESCRIPTION
File name was changed to artik05x_crashdump.c, but Makefile is not applied.