### PR TITLE
Move machine header files to external folder and add ommited licenses

### DIFF
--- a/external/grpc/third_party/nanopb/LICENSE.txt
+++ b/external/grpc/third_party/nanopb/LICENSE.txt
@@ -1,0 +1,20 @@
+Copyright (c) 2011 Petteri Aimonen <jpa at nanopb.mail.kapsi.fi>
+
+This software is provided 'as-is', without any express or 
+implied warranty. In no event will the authors be held liable 
+for any damages arising from the use of this software.
+
+Permission is granted to anyone to use this software for any 
+purpose, including commercial applications, and to alter it and 
+redistribute it freely, subject to the following restrictions:
+
+1. The origin of this software must not be misrepresented; you 
+   must not claim that you wrote the original software. If you use 
+   this software in a product, an acknowledgment in the product 
+   documentation would be appreciated but is not required.
+
+2. Altered source versions must be plainly marked as such, and 
+   must not be misrepresented as being the original software.
+
+3. This notice may not be removed or altered from any source 
+   distribution.

--- a/external/include/libcxx/machine/_default_types.h
+++ b/external/include/libcxx/machine/_default_types.h
@@ -16,6 +16,10 @@
  *
  ****************************************************************************/
 /*
+ * This file is dual licensed under the MIT and the University of Illinois Open
+ * Source Licenses. See LICENSE.TXT for details.
+ */
+/*
  *  $Id$
  */
 

--- a/external/include/libcxx/machine/_types.h
+++ b/external/include/libcxx/machine/_types.h
@@ -16,6 +16,10 @@
  *
  ****************************************************************************/
 /*
+ * This file is dual licensed under the MIT and the University of Illinois Open
+ * Source Licenses. See LICENSE.TXT for details.
+ */
+/*
  *  $Id$
  */
 

--- a/external/include/libcxx/machine/endian.h
+++ b/external/include/libcxx/machine/endian.h
@@ -15,6 +15,10 @@
  * language governing permissions and limitations under the License.
  *
  ****************************************************************************/
+/*
+ * This file is dual licensed under the MIT and the University of Illinois Open
+ * Source Licenses. See LICENSE.TXT for details.
+ */
 #ifndef __MACHINE_ENDIAN_H__
 
 #ifndef __TINYARA__

--- a/external/include/libcxx/machine/ieeefp.h
+++ b/external/include/libcxx/machine/ieeefp.h
@@ -15,6 +15,10 @@
  * language governing permissions and limitations under the License.
  *
  ****************************************************************************/
+/*
+ * This file is dual licensed under the MIT and the University of Illinois Open
+ * Source Licenses. See LICENSE.TXT for details.
+ */
 #ifndef __IEEE_BIG_ENDIAN
 #ifndef __IEEE_LITTLE_ENDIAN
 


### PR DESCRIPTION
- libcxx/machine : move a folder from os/include to external/include/libcxx
- Add ommited licenses for nanopb and header files in libcxx/machine