### PR TITLE
tools: Apply M16 rule at clang-format file

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -6,13 +6,13 @@ AccessModifierOffset: -4
 AllowShortFunctionsOnASingleLine: false
 BreakBeforeBraces: Custom
 BraceWrapping:
-  AfterEnum: true
-  AfterFunction: true
-  AfterStruct: true
-  AfterUnion: true
+  AfterEnum: false #[M16]
+  AfterFunction: true #[M14]
+  AfterStruct: false #[M16]
+  AfterUnion: false #[M16]
   AfterClass: true
   AfterNamespace: false
-  BeforeElse: false
+  BeforeElse: false #[M15]
 IndentCaseLabels: false #[M09]
 IndentWidth:     4 #[M08]
 SpaceBeforeAssignmentOperators: true #[M11]

--- a/framework/include/media/MediaPlayer.h
+++ b/framework/include/media/MediaPlayer.h
@@ -29,8 +29,7 @@ namespace media {
  * @details @b #include <media/MediaPlayer.h>
  * @since TizenRT v2.0 PRE
  */
-typedef enum player_state_e
-{
+typedef enum player_state_e {
 	/** MediaPlayer object was created */
 	PLAYER_STATE_NONE,
 	/** MediaPlayer worker object was created */
@@ -48,8 +47,7 @@ typedef enum player_state_e
  * @details @b #include <media/MediaPlayer.h>
  * @since TizenRT v2.0 PRE
  */
-typedef enum player_result_e
-{
+typedef enum player_result_e {
 	/** MediaPlayer Error case */
 	PLAYER_ERROR,
 	/** MediaPlayer Success case */

--- a/framework/include/media/MediaRecorder.h
+++ b/framework/include/media/MediaRecorder.h
@@ -29,8 +29,7 @@ namespace media {
  * @details @b #include <media/MediaRecorder.h>
  * @since TizenRT v2.0 PRE
  */
-typedef enum recorder_state_e
-{
+typedef enum recorder_state_e {
 	/** MediaRecorder object was created */
 	RECORDER_STATE_NONE,
 	/** MediaRecorder worker object was created */
@@ -48,8 +47,7 @@ typedef enum recorder_state_e
  * @details @b #include <media/MediaRecorder.h>
  * @since TizenRT v2.0 PRE
  */
-typedef enum recorder_result_e
-{
+typedef enum recorder_result_e {
 	/** MediaRecorder Error case */
 	RECORDER_ERROR,
 	/** MediaRecorder Success case */


### PR DESCRIPTION
[M16] Open braces for enum, union and struct go on the same line