### PR TITLE
testcase/filesystem: not free allocated memory on tc_driver_mtd_ftl_ops

### DIFF
--- a/apps/examples/testcase/le_tc/filesystem/fs_main.c
+++ b/apps/examples/testcase/le_tc/filesystem/fs_main.c
@@ -1678,7 +1678,9 @@ static void tc_driver_mtd_ftl_ops(void)
 	ret = write(fd, buf, BUF_SIZE);
 	TC_ASSERT_EQ_CLEANUP("write", ret, BUF_SIZE, goto cleanup);
 #endif
+#ifdef FIXME	// This causes tc stuck. Temporarilly block.
 	free(buf);
+#endif
 	ret = close(fd);
 	TC_ASSERT_EQ("close", ret, OK);
 	TC_SUCCESS_RESULT();


### PR DESCRIPTION
free(buf) caues filesystem testcase stuck after printing
"[tc_libc_stdio_stdsostream] PASS" always.
But missing free causes memory leak, we should fix it later.