### PR TITLE
Disable MSG_NOSIGNAL in curl

### DIFF
--- a/external/curl/curl_config.h
+++ b/external/curl/curl_config.h
@@ -375,8 +375,10 @@
 /* Define to 1 if you have the memrchr function or macro. */
 /* #undef HAVE_MEMRCHR */
 
+#ifndef __TIZENRT__
 /* Define to 1 if you have the MSG_NOSIGNAL flag. */
 #define HAVE_MSG_NOSIGNAL 1
+#endif
 
 /* Define to 1 if you have the <netdb.h> header file. */
 #define HAVE_NETDB_H 1


### PR DESCRIPTION
@juitem , @sunghan-chang, @pillip8282 @bhargava-cs 
Please review the PR. This is to resolve following build error.

"In file included from curl_setup.h:638:0,
                 from sendf.c:23:
sendf.c: In function 'Curl_send_plain':
curl_setup_once.h:123:22: error: 'MSG_NOSIGNAL' undeclared (first use in this function)
 #define SEND_4TH_ARG MSG_NOSIGNAL
"