### PR TITLE
tools: move a location of formatter, make a script of c++, add README

### DIFF
--- a/os/tools/README.txt
+++ b/os/tools/README.txt
@@ -384,13 +384,6 @@ kconfig.bat
      -   option env="APPSDIR"
      +   default "../apps"
 
-formatter.sh
----------
-
-  This script can be used to indent .c and .h files in a manner similar
-  to my coding TinyAra coding style.  It doesn't do a really good job,
-  however (see the comments at the top of the formatter.sh file).
-
 refresh.sh
 ----------
 

--- a/tools/HowToUseFormatter.md
+++ b/tools/HowToUseFormatter.md
@@ -1,0 +1,43 @@
+# How to use formatter
+Here are two formatter (or beautifier) for C and C++ languages, cformatter.sh and cxxformatter.sh.
+
+## Prerequisites
+```bash
+sudo apt-get install indent astyle
+sudo apt-get install clang-format
+```
+
+## formatter for C
+The **cformatter** script applies TizenRT C coding rule.  
+```--help``` option shows how to use it.
+```bash
+@ubuntu:~/TizenRT$ ./tools/cformatter.sh --help
+usage: ./tools/cformatter.sh TARGET
+     TARGET: folder path or target files
+Apply TizenRT C coding rule
+
+example:
+    ./tools/cformatter.sh ../kernel
+    ./tools/cformatter.sh ../../abc.c
+```
+Note: This sometimes makes incorrect changes.  
+Usually it adds a space between type casting and variable as shown below:
+```
+buf = (int *) malloc(8);
+size_a = (uint8_t) size_b;
+```
+
+## formatter for C++
+The **cxxformatter** script applies TizenRT C++ coding rule.  
+Type ```cxxformatter.sh --help``` to know the usage.
+```bash
+@ubuntu:~/TizenRT$ ./tools/cxxformatter.sh --help
+usage: ./tools/cxxformatter.sh TARGET
+     TARGET: folder path or target files
+Apply TizenRT C++ coding rule
+
+example:
+    ./tools/cxxformatter.sh kernel/
+    ./tools/cxxformatter.sh framework/src/media apps/system
+    ./tools/cxxformatter.sh ../../abc.c
+```

--- a/tools/cformatter.sh
+++ b/tools/cformatter.sh
@@ -18,10 +18,20 @@
 ###########################################################################
 TARGET=$1
 
+if ! which indent >/dev/null; then
+    echo "Need to install indent"
+    exit 1
+fi
+if ! which astyle >/dev/null; then
+    echo "Need to install astyle"
+    exit 1
+fi
+
 function USAGE()
 {
-    echo "usage: $0 <TARGET>"
-    echo "     <TARGET> : folder path or target files"
+    echo "usage: $0 TARGET"
+    echo "     TARGET: folder path or target files"
+    echo "Apply TizenRT C coding rule"
     echo ""
     echo "example:"
     echo "    $0 ../kernel"

--- a/tools/cxxformatter.sh
+++ b/tools/cxxformatter.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+###########################################################################
+#
+# Copyright 2018 Samsung Electronics All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+#
+###########################################################################
+
+CMD=clang-format
+OPTION="-i -style=file"
+
+if ! which ${CMD} >/dev/null; then
+	echo "Need to install clang-format"
+	exit 1
+fi
+
+function USAGE()
+{
+	echo "usage: $0 TARGET"
+	echo "     TARGET: folder path or target files"
+	echo "Apply TizenRT C++ coding rule"
+	echo ""
+	echo "example:"
+	echo "    $0 kernel/"
+	echo "    $0 framework/src/media apps/system"
+	echo "    $0 ../../abc.c"
+}
+
+if [ -z $1 ]; then
+	USAGE
+	exit 1
+fi
+if [ $1 == "--help" ]; then
+	USAGE
+	exit 1
+fi
+
+for target in "$@"; do
+	if [ -d "${target}" ]; then
+		find "${target}" -name *.cpp -o -name *.cxx -o -name *.cc -o -name *.h -exec ${CMD} ${OPTION} {} \;
+	else
+		${CMD} ${OPTION} ${target}
+	fi
+done
+


### PR DESCRIPTION
1. Move existing c formatter from os/tools to tools.
  Formatter is not only for os. Tools folder is approprietary location.
2. Add new script to run c++ formatter which use clang-format
  To give same usages with c, make a new script which has same usages.
3. Add new README to give information of formatter
4. Check existance of necessary package on ubuntu before excuting