### PR TITLE
media: Move decoder variable to heap from stack, Fix build error

### DIFF
--- a/framework/src/media/Decoder.h
+++ b/framework/src/media/Decoder.h
@@ -22,7 +22,7 @@ public:
 private:
 #ifdef CONFIG_AUDIO_CODEC
 	static int _configFunc(void* user_data, int audio_type, void* dec_ext);
-	pv_player_t mPlayer;
+	pv_player_p mPlayer;
 #endif
 };
 } // namespace media

--- a/framework/src/media/FileOutputDataSource.cpp
+++ b/framework/src/media/FileOutputDataSource.cpp
@@ -16,6 +16,8 @@
  *
  ******************************************************************/
 
+#include <debug.h>
+
 #include <media/FileOutputDataSource.h>
 
 namespace media {


### PR DESCRIPTION
pv_player_t mPlayer is changed to pv_player_t *mPlayer for moving to the heap.
Add include debug.h into FileOutputDataSource.cpp to prevent build error.