### PR TITLE
external/curl: disable HAVE_SYS_PARAM_H definition

### DIFF
--- a/external/curl/curl_config.h
+++ b/external/curl/curl_config.h
@@ -594,8 +594,10 @@
 /* Define to 1 if you have the <sys/ioctl.h> header file. */
 #define HAVE_SYS_IOCTL_H 1
 
+#ifndef __TIZENRT__
 /* Define to 1 if you have the <sys/param.h> header file. */
 #define HAVE_SYS_PARAM_H 1
+#endif
 
 /* Define to 1 if you have the <sys/poll.h> header file. */
 #define HAVE_SYS_POLL_H 1


### PR DESCRIPTION
TizenRT does not have sys/param.h header so that we should
not define HAVE_SYS_PARAM_H.
This commit fixs compilation error.

CC:  http.c
In file included from /gcc-arm-none-eabi-6-2017-q1-update/arm-none-eabi/include/machine/endian.h:5:0,
                 from /gcc-arm-none-eabi-6-2017-q1-update/arm-none-eabi/include/sys/param.h:7,
                 from http.c:45:
/gcc-arm-none-eabi-6-2017-q1-update/arm-none-eabi/include/sys/_types.h:168:5: error: unknown type name 'wint_t'
     wint_t __wch;
     ^~~~~~
Makefile:64: recipe for target 'curl_http.o' failed