### PR TITLE
examples/cy4390x_demo: add a dependancy with ARCH_BOARD_CY4390x

### DIFF
--- a/apps/examples/cy4390x_demo/Kconfig
+++ b/apps/examples/cy4390x_demo/Kconfig
@@ -6,5 +6,6 @@
 config EXAMPLES_CY4390x_DEMO
 	bool "cy4390x demo example"
 	default n
+	depends on ARCH_BOARD_CY4390x
 	---help---
 		Enable the cy4390x demo example


### PR DESCRIPTION
cy4390x_demo app is valid when cy4390x board is selected.
Let's make a dependancy between EXAMPLES_CY4390x_DEMO and ARCH_BOARD_CY4390x.
It prevents compilation error and removes unnecessary menu on menuconfig.