### PR TITLE
media: Use enum value to represent pcm format

### DIFF
--- a/framework/include/media/DataSource.h
+++ b/framework/include/media/DataSource.h
@@ -20,6 +20,7 @@
 #define __MEDIA_DATASOURCE_H
 
 #include <iostream>
+#include <media/MediaUtils.h>
 
 namespace media {
 /**

--- a/framework/include/media/MediaUtils.h
+++ b/framework/include/media/MediaUtils.h
@@ -15,6 +15,72 @@
  * limitations under the License.
  *
  ******************************************************************/
+/****************************************************************************
+*
+* Developed by:
+*
+*   Copyright (C) 2013 Ken Pettit. All rights reserved.
+*   Author: Ken Pettit <pettitkd@gmail.com>
+*
+* With ongoing support:
+*
+*   Copyright (C) 2014 Gregory Nutt. All rights reserved.
+*   Author: Greory Nutt <gnutt@nuttx.org>
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions
+* are met:
+*
+* 1. Redistributions of source code must retain the above copyright
+*    notice, this list of conditions and the following disclaimer.
+* 2. Redistributions in binary form must reproduce the above copyright
+*    notice, this list of conditions and the following disclaimer in
+*    the documentation and/or other materials provided with the
+*    distribution.
+* 3. Neither the name NuttX nor the names of its contributors may be
+*    used to endorse or promote products derived from this software
+*    without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+* "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+* LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+* FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+* COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+* BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+* OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+* AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+* LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+* ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*
+****************************************************************************/
+/*
+** Copyright 2011, The Android Open Source Project
+**
+** Redistribution and use in source and binary forms, with or without
+** modification, are permitted provided that the following conditions are met:
+**     * Redistributions of source code must retain the above copyright
+**       notice, this list of conditions and the following disclaimer.
+**     * Redistributions in binary form must reproduce the above copyright
+**       notice, this list of conditions and the following disclaimer in the
+**       documentation and/or other materials provided with the distribution.
+**     * Neither the name of The Android Open Source Project nor the names of
+**       its contributors may be used to endorse or promote products derived
+**       from this software without specific prior written permission.
+**
+** THIS SOFTWARE IS PROVIDED BY The Android Open Source Project ``AS IS'' AND
+** ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+** IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+** ARE DISCLAIMED. IN NO EVENT SHALL The Android Open Source Project BE LIABLE
+** FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+** DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+** SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+** CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+** LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+** OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+** DAMAGE.
+*/
 
 #ifndef __MEDIA_UTILS_H
 #define __MEDIA_UTILS_H
@@ -43,6 +109,40 @@ typedef enum audio_type_e {
 	/** Audio type is PCM */
 	AUDIO_TYPE_FLAC = 5
 } audio_type_t;
+
+/**
+ * @brief Audio sample format of a PCM.
+ * @details The first letter specifiers whether the sample is signed or unsigned.
+ * The letter 'S' means signed. The letter 'U' means unsigned.
+ * The following number is the amount of bits that the sample occupies in memory.
+ * Following the underscore, specifiers whether the sample is big endian or little endian.
+ * The letters 'LE' mean little endian.
+ * The letters 'BE' mean big endian.
+ */
+typedef enum pcm_format_e {
+	/** Error Case */
+	PCM_FORMAT_NONE = -1,
+	/** Signed, 8-bit */
+	PCM_FORMAT_S8 = 1,
+	/** Signed 16-bit, little endian */
+	PCM_FORMAT_S16_LE = 0,
+	/** Signed, 16-bit, big endian */
+	PCM_FORMAT_S16_BE = 2,
+	/** Signed, 24-bit (32-bit in memory), little endian */
+	PCM_FORMAT_S24_LE,
+	/** Signed, 24-bit (32-bit in memory), big endian */
+	PCM_FORMAT_S24_BE,
+	/** Signed, 24-bit, little endian */
+	PCM_FORMAT_S24_3LE,
+	/** Signed, 24-bit, big endian */
+	PCM_FORMAT_S24_3BE,
+	/** Signed, 32-bit, little endian */
+	PCM_FORMAT_S32_LE,
+	/** Signed, 32-bit, big endian */
+	PCM_FORMAT_S32_BE,
+	/** Max of the enumeration list, not an actual format. */
+	PCM_FORMAT_MAX
+} pcm_format_t;
 
 /**
  * @brief Replace string with lowercase string.

--- a/framework/src/media/DataSource.cpp
+++ b/framework/src/media/DataSource.cpp
@@ -23,7 +23,7 @@ namespace media {
 DataSource::DataSource()
 	: mChannels(2)
 	, mSampleRate(16000)
-	, mPcmFormat(0)
+	, mPcmFormat(utils::PCM_FORMAT_S16_LE)
 {
 	medvdbg("DataSource::DataSource()\n");
 }


### PR DESCRIPTION
Instead of hardcoded 0, use utils::PCM_FORMAT_S16_LE