### PR TITLE
media: Fix coding rule violation in media

### DIFF
--- a/framework/src/media/MediaRecorderImpl.h
+++ b/framework/src/media/MediaRecorderImpl.h
@@ -54,8 +54,7 @@ typedef enum recorder_state_e {
 	RECORDER_STATE_PAUSED
 } recorder_state_t;
 
-typedef enum observer_command_e
-{
+typedef enum observer_command_e {
 	OBSERVER_COMMAND_STARTED,
 	OBSERVER_COMMAND_FINISHIED,
 	OBSERVER_COMMAND_ERROR

--- a/framework/src/media/PlayerObserverWorker.h
+++ b/framework/src/media/PlayerObserverWorker.h
@@ -26,8 +26,7 @@
 #include "MediaQueue.h"
 
 namespace media {
-typedef enum player_observer_command_e
-{
+typedef enum player_observer_command_e {
 	PLAYER_OBSERVER_COMMAND_STARTED,
 	PLAYER_OBSERVER_COMMAND_FINISHIED,
 	PLAYER_OBSERVER_COMMAND_ERROR


### PR DESCRIPTION
Open braces for enum go on the same line