### PR TITLE
media: add tc for media datasource

### DIFF
--- a/apps/examples/testcase/ta_tc/media/utc/utc_media_common.h
+++ b/apps/examples/testcase/ta_tc/media/utc/utc_media_common.h
@@ -1,0 +1,37 @@
+/****************************************************************************
+ *
+ * Copyright 2018 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __UTC_MEDIA_COMMON_H
+#define __UTC_MEDIA_COMMON_H
+
+#include <media/MediaRecorder.h>
+#include <media/MediaRecorderObserverInterface.h>
+#include <media/FileOutputDataSource.h>
+
+using namespace std;
+using namespace media;
+using namespace media::stream;
+
+using ::testing::_;
+
+unsigned char channels = 2;
+unsigned int sampleRate = 16000;
+int pcmFormat = 0;
+const char * filePath = "/ramfs/record";
+
+#endif

--- a/apps/examples/testcase/ta_tc/media/utc/utc_media_fileoutputdatasource.cpp
+++ b/apps/examples/testcase/ta_tc/media/utc/utc_media_fileoutputdatasource.cpp
@@ -1,0 +1,112 @@
+/****************************************************************************
+ *
+ * Copyright 2018 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+#include "utc_media_common.h"
+
+class FileOutputDataSourceTest : public testing::Test
+{
+protected:
+	virtual void SetUp() {
+		dataSource = new FileOutputDataSource(channels, sampleRate, pcmFormat, filePath);
+	}
+	virtual void TearDown() {
+		delete dataSource;
+		dataSource = nullptr;
+	}
+
+public:
+	FileOutputDataSource* dataSource;
+};
+
+TEST_F(FileOutputDataSourceTest, getMemberVariablePositive)
+{
+	unsigned short compare_channels = 2;
+	unsigned int compare_sampleRate = 16000;
+	int compare_pcmFormat = 0;
+
+	EXPECT_EQ(dataSource->getChannels(), compare_channels);
+	EXPECT_EQ(dataSource->getSampleRate(), compare_sampleRate);
+	EXPECT_EQ(dataSource->getPcmFormat(), compare_pcmFormat);
+}
+
+TEST_F(FileOutputDataSourceTest, setMemberVariablePositive)
+{
+	unsigned short compare_channels = 3;
+	unsigned int compare_sampleRate = 32000;
+	int compare_pcmFormat = 1;
+
+	dataSource->setChannels(compare_channels);
+	dataSource->setSampleRate(compare_sampleRate);
+	dataSource->setPcmFormat(compare_pcmFormat);
+
+	EXPECT_EQ(dataSource->getChannels(), compare_channels);
+	EXPECT_EQ(dataSource->getSampleRate(), compare_sampleRate);
+	EXPECT_EQ(dataSource->getPcmFormat(), compare_pcmFormat);
+}
+
+TEST_F(FileOutputDataSourceTest, FileOutputDataSourceFilePathConstructor)
+{
+	FileOutputDataSource dummy_value(filePath);
+
+	EXPECT_EQ(dataSource->getChannels(), dummy_value.getChannels());
+	EXPECT_EQ(dataSource->getSampleRate(), dummy_value.getSampleRate());
+	EXPECT_EQ(dataSource->getPcmFormat(), dummy_value.getPcmFormat());
+}
+
+TEST_F(FileOutputDataSourceTest, FileOutputDataSourceCopyConstructor)
+{
+	FileOutputDataSource dummy_value(*dataSource);
+
+	EXPECT_EQ(dataSource->getChannels(), dummy_value.getChannels());
+	EXPECT_EQ(dataSource->getSampleRate(), dummy_value.getSampleRate());
+	EXPECT_EQ(dataSource->getPcmFormat(), dummy_value.getPcmFormat());
+}
+
+TEST_F(FileOutputDataSourceTest, FileOutputDataSourceEqualOperator)
+{
+	FileOutputDataSource dummy_value = *dataSource;
+
+	EXPECT_EQ(dataSource->getChannels(), dummy_value.getChannels());
+	EXPECT_EQ(dataSource->getSampleRate(), dummy_value.getSampleRate());
+	EXPECT_EQ(dataSource->getPcmFormat(), dummy_value.getPcmFormat());
+}
+
+TEST_F(FileOutputDataSourceTest, OpenFilePositive)
+{
+	bool ret = dataSource->open();
+	dataSource->close();
+
+	EXPECT_EQ(ret, true);
+}
+
+TEST_F(FileOutputDataSourceTest, OpenFileNegative)
+{
+	dataSource->open();
+	bool ret = dataSource->open();
+	dataSource->close();
+
+	EXPECT_EQ(ret, false);
+}
+
+TEST_F(FileOutputDataSourceTest, CloseFilePositiveWithIsPrepare)
+{
+	dataSource->close();
+	bool ret = dataSource->isPrepare();
+
+	EXPECT_EQ(ret, false);
+}

--- a/apps/examples/testcase/ta_tc/media/utc/utc_media_main.cpp
+++ b/apps/examples/testcase/ta_tc/media/utc/utc_media_main.cpp
@@ -29,6 +29,7 @@
 #include <iostream>
 #include "tc_common.h"
 
+#include "utc_media_fileoutputdatasource.cpp"
 #include "utc_media_recorder.cpp"
 #include "utc_media_player.cpp"
 

--- a/apps/examples/testcase/ta_tc/media/utc/utc_media_recorder.cpp
+++ b/apps/examples/testcase/ta_tc/media/utc/utc_media_recorder.cpp
@@ -19,60 +19,7 @@
 // Included Files
 //***************************************************************************
 
-#include <media/MediaRecorder.h>
-#include <media/MediaRecorderObserverInterface.h>
-#include <media/FileOutputDataSource.h>
-
-using namespace std;
-using namespace media;
-using namespace media::stream;
-
-using ::testing::_;
-
-unsigned short channels = 2;
-unsigned int sampleRate = 16000;
-int pcmFormat = 0;
-const char * filePath = "/ramfs/record";
-
-class FileOutputDataTest : public testing::Test
-{
-protected:
-	virtual void SetUp() {
-		dataSource = new FileOutputDataSource(channels, sampleRate, pcmFormat, filePath);
-	}
-	virtual void TearDown() {
-		delete dataSource;
-		dataSource = nullptr;
-	}
-
-public:
-	FileOutputDataSource* dataSource;
-};
-
-TEST_F(FileOutputDataTest, OpenFilePositive)
-{
-	bool ret = dataSource->open();
-	dataSource->close();
-
-	EXPECT_EQ(ret, true);
-}
-
-TEST_F(FileOutputDataTest, OpenFileNegative)
-{
-	dataSource->open();
-	bool ret = dataSource->open();
-	dataSource->close();
-
-	EXPECT_EQ(ret, false);
-}
-
-TEST_F(FileOutputDataTest, CloseFilePositiveWithIsPrepare)
-{
-	dataSource->close();
-	bool ret = dataSource->isPrepare();
-
-	EXPECT_EQ(ret, false);
-}
+#include "utc_media_common.h"
 
 struct null_deleter
 {


### PR DESCRIPTION
1. add tc, which is a separate recorder and datasource
2. add tc for datasource constructor
3. add tc for get and set functions.

Signed-off-by: jaesick.shin <jaesick.shin@samsung.com>