### PR TITLE
framework/iotbus,tinyalsa,wifi_manager: fix wrong version of API

### DIFF
--- a/framework/include/iotbus/iotbus_gpio.h
+++ b/framework/include/iotbus/iotbus_gpio.h
@@ -241,7 +241,7 @@ int iotbus_gpio_get_drive_mode(iotbus_gpio_context_h dev, iotbus_gpio_drive_e *d
  * @param[in] dev handle of gpio_context
  * @param[in] edge gpio edge type
  * @return On success, 0 is returned. On failure, a negative value is returned.
- * @since TizenRT v2.0 PRE PRE
+ * @since TizenRT v2.0 PRE
  */
 #ifndef CONFIG_DISABLE_SIGNALS
 int iotbus_gpio_register_signal(iotbus_gpio_context_h dev, iotbus_gpio_edge_e edge);

--- a/framework/include/tinyalsa/tinyalsa.h
+++ b/framework/include/tinyalsa/tinyalsa.h
@@ -354,7 +354,7 @@ int pcm_readi(struct pcm *pcm, void *data, unsigned int frame_count);
 * @details @b #include <tinyalsa/tinyalsa.h>
 * @param[in] pcm A PCM handle.
 * @returns On success, zero; on failure, a negative number.
-* @since TizenRT v2.0 PRE PRE
+* @since TizenRT v2.0 PRE
 */
 int pcm_drop(struct pcm *pcm);
 
@@ -364,7 +364,7 @@ int pcm_drop(struct pcm *pcm);
 * @details @b #include <tinyalsa/tinyalsa.h>
 * @param[in] pcm A PCM handle.
 * @returns On success, zero; on failure, a negative number.
-* @since TizenRT v2.0 PRE PRE
+* @since TizenRT v2.0 PRE
 */
 int pcm_drain(struct pcm *pcm);
 
@@ -406,7 +406,7 @@ unsigned int pcm_get_subdevice(const struct pcm *pcm);
 * @param[in] data Pointer to the buffer containing data to be written
 * @param[in] count Size of the data in bytes
 * @returns On success, written number of frames returned. On failure, a negative number returned
-* @since TizenRT v2.0 PRE PRE
+* @since TizenRT v2.0 PRE
 */
 int pcm_mmap_write(struct pcm *pcm, const void *data, unsigned int count);
 
@@ -418,7 +418,7 @@ int pcm_mmap_write(struct pcm *pcm, const void *data, unsigned int count);
 * @param[in] data Pointer to the buffer to read into
 * @param[in] count Size of the buffer in bytes
 * @returns On success, read number of frames returned. On failure, a negative number returned
-* @since TizenRT v2.0 PRE PRE
+* @since TizenRT v2.0 PRE
 */
 int pcm_mmap_read(struct pcm *pcm, void *data, unsigned int count);
 
@@ -431,7 +431,7 @@ int pcm_mmap_read(struct pcm *pcm, void *data, unsigned int count);
 * @param[out] offset Returned mmap area offset in frames
 * @param[out] frames Mmap area portion size in frames
 * @returns On success, zero is returned. On failure, a negative number returned
-* @since TizenRT v2.0 PRE PRE
+* @since TizenRT v2.0 PRE
 */
 int pcm_mmap_begin(struct pcm *pcm, void **areas, unsigned int *offset, unsigned int *frames);
 
@@ -443,7 +443,7 @@ int pcm_mmap_begin(struct pcm *pcm, void **areas, unsigned int *offset, unsigned
 * @param[in] offset Area offset in frames. This must be same as the offset returned by pcm_mmap_begin
 * @param[in] frames Mmap area portion size in frames that application wishes to commit
 * @returns On success, zero is returned. On failure, a negative number returned
-* @since TizenRT v2.0 PRE PRE
+* @since TizenRT v2.0 PRE
 */
 int pcm_mmap_commit(struct pcm *pcm, unsigned int offset, unsigned int frames);
 
@@ -454,7 +454,7 @@ int pcm_mmap_commit(struct pcm *pcm, unsigned int offset, unsigned int frames);
 * @param[in] pcm A PCM handle
 * @param[in] timeout Maximum time in milliseconds to wait, a negative value means infinity
 * @returns On success, one is returned. On timeout, zero is returned. On failure, a negative number returned
-* @since TizenRT v2.0 PRE PRE
+* @since TizenRT v2.0 PRE
 */
 int pcm_wait(struct pcm *pcm, int timeout);
 
@@ -464,7 +464,7 @@ int pcm_wait(struct pcm *pcm, int timeout);
 * @details @b #include <tinyalsa/tinyalsa.h>
 * @param[in] pcm A PCM handle
 * @returns On success, positive number is returned. On failure, a negative number returned
-* @since TizenRT v2.0 PRE PRE
+* @since TizenRT v2.0 PRE
 */
 int pcm_avail_update(struct pcm *pcm);
 #if defined(__cplusplus)

--- a/framework/include/wifi_manager/wifi_manager.h
+++ b/framework/include/wifi_manager/wifi_manager.h
@@ -268,7 +268,7 @@ wifi_manager_result_e wifi_manager_scan_ap(void);
  * @details @b #include <wifi_manager/wifi_manager.h>
  * @param[in] config AP configuration infomation should be given including ssid, channel, and passphrase.
  * @return On success, WIFI_MANAGER_SUCCESS (i.e., 0) is returned. On failure, non-zero value is returned.
- * @since TizenRT v2.0 PRE PRE
+ * @since TizenRT v2.0 PRE
  */
 wifi_manager_result_e wifi_manager_save_config(wifi_manager_ap_config_s *config);
 
@@ -277,7 +277,7 @@ wifi_manager_result_e wifi_manager_save_config(wifi_manager_ap_config_s *config)
  * @details @b #include <wifi_manager/wifi_manager.h>
  * @param[in] config The pointer of AP configuration infomation which will be filled
  * @return On success, WIFI_MANAGER_SUCCESS (i.e., 0) is returned. On failure, non-zero value is returned.
- * @since TizenRT v2.0 PRE PRE
+ * @since TizenRT v2.0 PRE
  */
 
 wifi_manager_result_e wifi_manager_get_config(wifi_manager_ap_config_s *config);
@@ -286,7 +286,7 @@ wifi_manager_result_e wifi_manager_get_config(wifi_manager_ap_config_s *config);
  * @brief Remove the AP configuration which was saved
  * @details @b #include <wifi_manager/wifi_manager.h>
  * @return On success, WIFI_MANAGER_SUCCESS (i.e., 0) is returned. On failure, non-zero value is returned.
- * @since TizenRT v2.0 PRE PRE
+ * @since TizenRT v2.0 PRE
  */
 wifi_manager_result_e wifi_manager_remove_config(void);
 


### PR DESCRIPTION
Current TizenRT API version is "TizenRT v2.0 PRE", not "PRE PRE".
This commit fixs above wrong version.