### PR TITLE
audiocodec/streaming/*: Clean code and add new interfaces

### DIFF
--- a/external/audiocodec/streaming/internal_defs.h
+++ b/external/audiocodec/streaming/internal_defs.h
@@ -16,47 +16,54 @@
  *
  ******************************************************************/
 
+#ifndef DEFS_H
+#define DEFS_H
+
 #include <stdio.h>
 #include <assert.h>
 #include "debug.h"
 
-#ifndef DEFS_H
-#define DEFS_H
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
 
 #define MY_ASSERT(condition) \
-	do {\
-		if (!(condition))\
+	do { \
+		if (!(condition)) \
 		{\
 			auddbg("[%s] line %d, ASSERT(%s) failed!\n", __FUNCTION__, __LINE__, #condition);\
-			assert(0);\
-		}\
+			assert(0); \
+		} \
 	} while (0)
 
 #define RETURN_IF_FAIL(condition) \
-	do {\
-		if (!(condition))\
-		{\
-			return;\
-		}\
+	do { \
+		if (!(condition)) \
+		{ \
+			return; \
+		} \
 	} while (0)
 
 #define RETURN_VAL_IF_FAIL(condition, val) \
-	do {\
-		if (!(condition))\
-		{\
-			return val;\
-		}\
+	do { \
+		if (!(condition)) \
+		{ \
+			return val; \
+		} \
 	} while (0)
 
 #define GOTO_IF_FAIL(condition, tag) \
-	do {\
-		if (!(condition))\
-		{\
-			goto tag;\
-		}\
+	do { \
+		if (!(condition)) \
+		{ \
+			goto tag; \
+		} \
 	} while (0)
 
 #define MINIMUM(x,y) (((x) < (y)) ? (x) : (y))
 
-#endif // DEFS_H
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
+#endif /* DEFS_H */
 

--- a/external/audiocodec/streaming/internal_defs.h
+++ b/external/audiocodec/streaming/internal_defs.h
@@ -19,10 +19,6 @@
 #ifndef DEFS_H
 #define DEFS_H
 
-#include <stdio.h>
-#include <assert.h>
-#include <debug.h>
-
 #ifdef __cplusplus
 extern "C" {
 #endif /* __cplusplus */
@@ -51,7 +47,20 @@ extern "C" {
 		} \
 	} while (0)
 
-#define MINIMUM(x,y) (((x) < (y)) ? (x) : (y))
+#ifndef MINIMUM
+#define MINIMUM(x, y) (((x) < (y)) ? (x) : (y))
+#endif
+
+// Size: 0, no data written or read
+#define SIZE_ZERO (0)
+
+#ifndef OK
+#define OK (0)
+#endif
+
+#ifndef ERROR
+#define ERROR (-1)
+#endif
 
 #ifdef __cplusplus
 }

--- a/external/audiocodec/streaming/internal_defs.h
+++ b/external/audiocodec/streaming/internal_defs.h
@@ -21,20 +21,11 @@
 
 #include <stdio.h>
 #include <assert.h>
-#include "debug.h"
+#include <debug.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif /* __cplusplus */
-
-#define MY_ASSERT(condition) \
-	do { \
-		if (!(condition)) \
-		{\
-			auddbg("[%s] line %d, ASSERT(%s) failed!\n", __FUNCTION__, __LINE__, #condition);\
-			assert(0); \
-		} \
-	} while (0)
 
 #define RETURN_IF_FAIL(condition) \
 	do { \

--- a/external/audiocodec/streaming/player.c
+++ b/external/audiocodec/streaming/player.c
@@ -17,173 +17,213 @@
  ******************************************************************/
 
 #include <sys/types.h>
-#include <sys/ioctl.h>
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
 #include <stdint.h>
-#include <unistd.h>
-#include <fcntl.h>
-#include <dirent.h>
-#include <math.h>
 #include <assert.h>
 #include <pthread.h>
-#include <sys/time.h>
 #include <debug.h>
 #include <audiocodec/streaming/player.h>
 #include "internal_defs.h"
 
-#define PV_SUCCESS  0
-#define PV_FAILURE  -1
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+#define PV_SUCCESS OK
+#define PV_FAILURE ERROR
 
+// Validation of audio type
+#define CHECK_AUDIO_TYPE(type) (AUDIO_TYPE_UNKNOWN < (type) && (type) < AUDIO_TYPE_MAX)
 
-//#define PERFORMANCE_TEST
+// MP3 tag frame header len
+#define MP3_HEAD_ID3_TAG_LEN 10
 
-#if defined(PERFORMANCE_TEST)
-static unsigned long timems_input = 0;
-static unsigned long timems_output = 0;
-static unsigned long timems_decode = 0;
-static unsigned long samples_output = 0;
-#endif
+// MP3 ID3v2 frame len, 6th~9th bytes in header
+#define MP3_HEAD_ID3_FRAME_GETSIZE(buf)  (((buf[6] & 0x7f) << 21) \
+										| ((buf[7] & 0x7f) << 14) \
+										| ((buf[8] & 0x7f) << 7) \
+										| ((buf[9] & 0x7f)))
+
+// Mask to verfiy the MP3 header, all bits should be '1' for all MP3 frames.
+#define MP3_FRAME_VERIFY_MASK 0xffe00000
 
 // Mask to extract the version, layer, sampling rate parts of the MP3 header,
 // which should be same for all MP3 frames.
 #define MP3_FRAME_HEADER_MASK 0xfffe0c00
+
+// AAC ADIF header sync data and len
+#define AAC_ADIF_SYNC_DATA "ADIF"
+#define AAC_ADIF_SYNC_LEN  4
+
+// AAC ADTS frame header len
+#define AAC_ADTS_FRAME_HEADER_LEN 9
+
+// AAC ADTS frame sync verify
+#define AAC_ADTS_SYNC_VERIFY(buf) ((buf[0] == 0xff) && ((buf[1] & 0xf6) == 0xf0))
+
+// AAC ADTS Frame size value stores in 13 bits started at the 31th bit from header
+#define AAC_ADTS_FRAME_GETSIZE(buf) ((buf[3] & 0x03) << 11 | buf[4] << 3 | buf[5] >> 5)
+
+// Read bytes each time from stream each time, while frame resyn.
+#define FRAME_RESYNC_READ_BYTES      (1024)
+// Max bytes could be read from stream in total, while frame resyn.
+#define FRAME_RESYNC_MAX_CHECK_BYTES (8 * 1024)
+
+// MPEG version
+#define MPEG_VERSION_1         3
+#define MPEG_VERSION_2         2
+#define MPEG_VERSION_UNDEFINED 1
+#define MPEG_VERSION_2_5       0
+#define MP3_FRAME_GET_MPEG_VERSION(header) (((header) >> 19) & 0x3)
+
+// MPEG layer
+#define MPEG_LAYER_1         3
+#define MPEG_LAYER_2         2
+#define MPEG_LAYER_3         1
+#define MPEG_LAYER_UNDEFINED 0
+#define MP3_FRAME_GET_MPEG_LAYER(header) (((header) >> 17) & 0x3)
+
+// Bitrate index
+#define BITRATE_IDX_FREE 0x0  // Variable Bit Rate
+#define BITRATE_IDX_BAD  0xf  // Not allow
+#define MP3_FRAME_GET_BITRATE_IDX(header) (((header) >> 12) & 0xf)
+
+// Sample Rate index
+#define SAMPLE_RATE_IDX_UNDEFINED 0x3
+#define MP3_FRAME_GET_SR_IDX(header) (((header) >> 10) & 0x3)
+
+// Padding flag
+#define MP3_FRAME_GET_PADDING(header) ((header >> 9) & 0x1)
+
+// Frame size = frame samples * (1 / sample rate) * bitrate / 8 + padding
+//            = frame samples * bitrate / 8 / sample rate + padding
+// Number of frame samples is constant value as below table:
+//        MPEG1  MPEG2(LSF)  MPEG2.5(LSF)
+// Layer1  384     384         384
+// Layer2  1152    1152        1152
+// Layer3  1152    576         576
+#define MPEG_LAYER1_FRAME_SIZE(sr, br, pad)  (384 * ((br) * 1000) / 8 / (sr) + ((pad) * 4))
+#define MPEG_LAYER2_FRAME_SIZE(sr, br, pad)  (1152 * ((br) * 1000) / 8 / (sr) + (pad))
+#define MPEG1_LAYER2_LAYER3_FRAME_SIZE(sr, br, pad) MPEG_LAYER2_FRAME_SIZE(sr, br, pad)
+#define MPEG2_LAYER3_FRAME_SIZE(sr, br, pad) (576 * ((br) * 1000) / 8 / (sr) + (pad))
+
+// Frame Resync, match more frame headers for confirming.
+#define FRAME_MATCH_REQUIRED 2
+
+#define U32_LEN_IN_BYTES (sizeof(uint32_t) / sizeof(uint8_t))
+
+/****************************************************************************
+ * Private Declarations
+ ****************************************************************************/
+
+/**
+ * @struct  priv_data_s
+ * @brief   Player private data structure define.
+ */
+struct priv_data_s {
+	ssize_t mCurrentPos;        /* read position when decoding */
+	uint32_t mFixedHeader;      /* mp3 frame header */
+};
+
+typedef struct priv_data_s priv_data_t;
+typedef struct priv_data_s *priv_data_p;
+
+// Sample Rate(in Hz) tables
+static const int kSamplingRateV1[] = {
+	44100, 48000, 32000
+};
+
+static const int kSamplingRateV2[] = {
+	22050, 24000, 16000
+};
+
+static const int kSamplingRateV2_5[] = {
+	11025, 12000, 8000
+};
+
+// Bit Rate (in kbps) tables
+// V1 - MPEG 1, V2 - MPEG 2 and MPEG 2.5
+// L1 - Layer 1, L2 - Layer 2, L3 - Layer 3
+static const int kBitrateV1L1[] = {
+	32, 64, 96, 128, 160, 192, 224, 256, 288, 320, 352, 384, 416, 448
+};
+
+static const int kBitrateV2L1[] = {
+	32, 48, 56, 64, 80, 96, 112, 128, 144, 160, 176, 192, 224, 256
+};
+
+static const int kBitrateV1L2[] = {
+	32, 48, 56, 64, 80, 96, 112, 128, 160, 192, 224, 256, 320, 384
+};
+
+static const int kBitrateV1L3[] = {
+	32, 40, 48, 56, 64, 80, 96, 112, 128, 160, 192, 224, 256, 320
+};
+
+static const int kBitrateV2L3[] = {
+	8, 16, 24, 32, 40, 48, 56, 64, 80, 96, 112, 128, 144, 160
+};
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
 
 static uint32_t _u32_at(const uint8_t *ptr)
 {
 	return ptr[0] << 24 | ptr[1] << 16 | ptr[2] << 8 | ptr[3];
 }
 
-static bool _parse_header(uint32_t header, size_t *frame_size, uint32_t *out_sampling_rate, uint32_t *out_channels, uint32_t *out_bitrate, uint32_t *out_num_samples)
+static bool _parse_header(uint32_t header, size_t *frame_size)
 {
 	*frame_size = 0;
 
-	if (out_sampling_rate) {
-		*out_sampling_rate = 0;
+	RETURN_VAL_IF_FAIL((header & MP3_FRAME_VERIFY_MASK) == MP3_FRAME_VERIFY_MASK, false);
+
+	unsigned version = MP3_FRAME_GET_MPEG_VERSION(header);
+	RETURN_VAL_IF_FAIL(version != MPEG_VERSION_UNDEFINED, false);
+
+	unsigned layer = MP3_FRAME_GET_MPEG_LAYER(header);
+	RETURN_VAL_IF_FAIL(layer != MPEG_LAYER_UNDEFINED, false);
+
+	unsigned bitrate_index = MP3_FRAME_GET_BITRATE_IDX(header);
+	RETURN_VAL_IF_FAIL((bitrate_index != BITRATE_IDX_FREE), false);
+	RETURN_VAL_IF_FAIL((bitrate_index != BITRATE_IDX_BAD), false);
+
+	unsigned sampling_rate_index = MP3_FRAME_GET_SR_IDX(header);
+	RETURN_VAL_IF_FAIL((sampling_rate_index != SAMPLE_RATE_IDX_UNDEFINED), false);
+
+	int sampling_rate;
+	if (version == MPEG_VERSION_1)
+		sampling_rate= kSamplingRateV1[sampling_rate_index];
+	else if (version == MPEG_VERSION_2) {
+		sampling_rate = kSamplingRateV2[sampling_rate_index];
+	} else { // MPEG_VERSION_2_5
+		sampling_rate = kSamplingRateV2_5[sampling_rate_index];
 	}
 
-	if (out_channels) {
-		*out_channels = 0;
-	}
+	unsigned padding = MP3_FRAME_GET_PADDING(header);
 
-	if (out_bitrate) {
-		*out_bitrate = 0;
-	}
-
-	if (out_num_samples) {
-		*out_num_samples = 1152;
-	}
-
-	RETURN_VAL_IF_FAIL((header & 0xffe00000) == 0xffe00000, false);
-
-	unsigned version = (header >> 19) & 3;
-	RETURN_VAL_IF_FAIL(version != 0x01, false);
-
-	unsigned layer = (header >> 17) & 3;
-
-	RETURN_VAL_IF_FAIL(layer != 0x00, false);
-
-	unsigned bitrate_index = (header >> 12) & 0x0f;
-
-	if (bitrate_index == 0 || bitrate_index == 0x0f) {
-		return false;           // Disallow "free" bitrate.
-	}
-
-	unsigned sampling_rate_index = (header >> 10) & 3;
-
-	RETURN_VAL_IF_FAIL((sampling_rate_index != 3), false);
-
-	static const int kSamplingRateV1[] = { 44100, 48000, 32000 };
-	int sampling_rate = kSamplingRateV1[sampling_rate_index];
-	if (version == 2 /* V2 */) {
-		sampling_rate /= 2;
-	} else if (version == 0 /* V2.5 */) {
-		sampling_rate /= 4;
-	}
-
-	unsigned padding = (header >> 9) & 1;
-
-	if (layer == 3) {
-		// layer I
-		static const int kBitrateV1[] = {
-			32, 64, 96, 128, 160, 192, 224, 256,
-			288, 320, 352, 384, 416, 448
-		};
-
-		static const int kBitrateV2[] = {
-			32, 48, 56, 64, 80, 96, 112, 128,
-			144, 160, 176, 192, 224, 256
-		};
-
-		int bitrate = (version == 3 /* V1 */)
-					  ? kBitrateV1[bitrate_index - 1]
-					  : kBitrateV2[bitrate_index - 1];
-
-		if (out_bitrate) {
-			*out_bitrate = bitrate;
-		}
-
-		*frame_size = (12000 * bitrate / sampling_rate + padding) * 4;
-
-		if (out_num_samples) {
-			*out_num_samples = 384;
-		}
+	if (layer == MPEG_LAYER_1) {
+		int bitrate = (version == MPEG_VERSION_1)
+					  ? kBitrateV1L1[bitrate_index - 1]
+					  : kBitrateV2L1[bitrate_index - 1];
+		*frame_size = MPEG_LAYER1_FRAME_SIZE(sampling_rate, bitrate, padding);
 	} else {
-		// layer II or III
-		static const int kBitrateV1L2[] = {
-			32, 48, 56, 64, 80, 96, 112, 128,
-			160, 192, 224, 256, 320, 384
-		};
-
-		static const int kBitrateV1L3[] = {
-			32, 40, 48, 56, 64, 80, 96, 112,
-			128, 160, 192, 224, 256, 320
-		};
-
-		static const int kBitrateV2[] = {
-			8, 16, 24, 32, 40, 48, 56, 64,
-			80, 96, 112, 128, 144, 160
-		};
-
 		int bitrate;
-		if (version == 3 /* V1 */) {
-			bitrate = (layer == 2 /* L2 */)
+		if (version == MPEG_VERSION_1) {
+			bitrate = (layer == MPEG_LAYER_2)
 					  ? kBitrateV1L2[bitrate_index - 1]
 					  : kBitrateV1L3[bitrate_index - 1];
-
-			if (out_num_samples) {
-				*out_num_samples = 1152;
-			}
+			*frame_size = MPEG1_LAYER2_LAYER3_FRAME_SIZE(sampling_rate, bitrate, padding);
 		} else {
-			// V2 (or 2.5)
-
-			bitrate = kBitrateV2[bitrate_index - 1];
-			if (out_num_samples) {
-				*out_num_samples = (layer == 1 /* L3 */) ? 576 : 1152;
+			bitrate = kBitrateV2L3[bitrate_index - 1];
+			if (layer == MPEG_LAYER_3) {
+				*frame_size = MPEG2_LAYER3_FRAME_SIZE(sampling_rate, bitrate, padding);
+			} else {
+				*frame_size = MPEG_LAYER2_FRAME_SIZE(sampling_rate, bitrate, padding);
 			}
 		}
-
-		if (out_bitrate) {
-			*out_bitrate = bitrate;
-		}
-
-		if (version == 3 /* V1 */) {
-			*frame_size = 144000 * bitrate / sampling_rate + padding;
-		} else {
-			// V2 or V2.5
-			size_t tmp = (layer == 1 /* L3 */) ? 72000 : 144000;
-			*frame_size = tmp * bitrate / sampling_rate + padding;
-		}
-	}
-
-	if (out_sampling_rate) {
-		*out_sampling_rate = sampling_rate;
-	}
-
-	if (out_channels) {
-		int channel_mode = (header >> 6) & 3;
-		*out_channels = (channel_mode == 3) ? 1 : 2;
 	}
 
 	return true;
@@ -192,7 +232,7 @@ static bool _parse_header(uint32_t header, size_t *frame_size, uint32_t *out_sam
 static ssize_t _source_read_at(rbstream_p fp, ssize_t offset, void *data, size_t size)
 {
 	int retVal = rbs_seek(fp, offset, SEEK_SET);
-	RETURN_VAL_IF_FAIL((retVal == 0), 0);
+	RETURN_VAL_IF_FAIL((retVal == OK), SIZE_ZERO);
 
 	return rbs_read(data, 1, size, fp);
 }
@@ -205,7 +245,7 @@ static bool mp3_resync(rbstream_p fp, uint32_t match_header, ssize_t *inout_pos,
 	if (*inout_pos == 0) {
 		// Skip an optional ID3 header if syncing at the very beginning of the datasource.
 		for (;;) {
-			uint8_t id3header[10];
+			uint8_t id3header[MP3_HEAD_ID3_TAG_LEN];
 			int retVal = _source_read_at(fp, *inout_pos, id3header, sizeof(id3header));
 			RETURN_VAL_IF_FAIL((retVal == (ssize_t) sizeof(id3header)), false);
 
@@ -213,42 +253,34 @@ static bool mp3_resync(rbstream_p fp, uint32_t match_header, ssize_t *inout_pos,
 				break;
 			}
 			// Skip the ID3v2 header.
-			size_t len = ((id3header[6] & 0x7f) << 21)
-						 | ((id3header[7] & 0x7f) << 14)
-						 | ((id3header[8] & 0x7f) << 7)
-						 | (id3header[9] & 0x7f);
-
-			len += 10;
-
+			size_t len = MP3_HEAD_ID3_FRAME_GETSIZE(id3header);
+			len += MP3_HEAD_ID3_TAG_LEN;
 			*inout_pos += len;
 		}
 	}
 
 	ssize_t pos = *inout_pos;
 	bool valid = false;
-
-	const int32_t kMaxReadBytes = 1024;
-	const int32_t kMaxBytesChecked = 8 * 1024;  //128 * 1024;
-	uint8_t buf[kMaxReadBytes];
-	ssize_t bytesToRead = kMaxReadBytes;
+	uint8_t buf[FRAME_RESYNC_READ_BYTES];
+	ssize_t bytesToRead = FRAME_RESYNC_READ_BYTES;
 	ssize_t totalBytesRead = 0;
 	ssize_t remainingBytes = 0;
 	bool reachEOS = false;
 	uint8_t *tmp = buf;
 
 	do {
-		if (pos >= *inout_pos + kMaxBytesChecked) {
-			medvdbg("[%s] Line %d, resync range < kMaxBytesChecked %d\n", __FUNCTION__, __LINE__, kMaxBytesChecked);
-			break;              // Don't scan forever.
+		if (pos >= *inout_pos + FRAME_RESYNC_MAX_CHECK_BYTES) {
+			medvdbg("[%s] resync range < %d\n", __FUNCTION__, FRAME_RESYNC_MAX_CHECK_BYTES);
+			break;
 		}
 
-		if (remainingBytes < 4) {
+		if (remainingBytes < U32_LEN_IN_BYTES) {
 			if (reachEOS) {
 				break;
 			}
 
 			memcpy(buf, tmp, remainingBytes);
-			bytesToRead = kMaxReadBytes - remainingBytes;
+			bytesToRead = FRAME_RESYNC_READ_BYTES - remainingBytes;
 
 			/*
 			 * The next read position should start from the end of
@@ -277,8 +309,7 @@ static bool mp3_resync(rbstream_p fp, uint32_t match_header, ssize_t *inout_pos,
 		}
 
 		size_t frame_size;
-		uint32_t sample_rate, num_channels, bitrate;
-		if (!_parse_header(header, &frame_size, &sample_rate, &num_channels, &bitrate, NULL)) {
+		if (!_parse_header(header, &frame_size)) {
 			++pos;
 			++tmp;
 			--remainingBytes;
@@ -287,12 +318,12 @@ static bool mp3_resync(rbstream_p fp, uint32_t match_header, ssize_t *inout_pos,
 
 		// We found what looks like a valid frame,
 		// now find its successors.
+		valid = true;
 		ssize_t test_pos = pos + frame_size;
 		medvdbg("[%s] Line %d, valid frame at pos %#x + framesize %#x = %#x\n", __FUNCTION__, __LINE__, pos, frame_size, test_pos);
-		valid = true;
-		const int FRAME_MATCH_REQUIRED = 2;
-		for (int j = 0; j < FRAME_MATCH_REQUIRED; ++j) {
-			uint8_t temp[4];
+		int j;
+		for (j = 0; j < FRAME_MATCH_REQUIRED; ++j) {
+			uint8_t temp[U32_LEN_IN_BYTES];
 			ssize_t retval = _source_read_at(fp, test_pos, temp, sizeof(temp));
 			if (retval < (ssize_t) sizeof(temp)) {
 				valid = false;
@@ -308,7 +339,7 @@ static bool mp3_resync(rbstream_p fp, uint32_t match_header, ssize_t *inout_pos,
 			}
 
 			size_t test_frame_size;
-			if (!_parse_header(test_header, &test_frame_size, NULL, NULL, NULL, NULL)) {
+			if (!_parse_header(test_header, &test_frame_size)) {
 				medvdbg("[%s] Line %d, invalid frame at pos2 %#x\n", __FUNCTION__, __LINE__, test_pos);
 				valid = false;
 				break;
@@ -337,7 +368,7 @@ static bool mp3_resync(rbstream_p fp, uint32_t match_header, ssize_t *inout_pos,
 }
 
 // Initialize the MP3 reader.
-bool mp3_init(rbstream_p mFp, ssize_t *offset, uint32_t *header, uint32_t *sample_rate, uint32_t *channles, uint32_t *bit_rate)
+bool mp3_init(rbstream_p mFp, ssize_t *offset, uint32_t *header)
 {
 	// Sync to the first valid frame.
 	bool success = mp3_resync(mFp, 0, offset, header);
@@ -347,24 +378,22 @@ bool mp3_init(rbstream_p mFp, ssize_t *offset, uint32_t *header, uint32_t *sampl
 	rbs_seek_ext(mFp, *offset, SEEK_SET);
 
 	size_t frame_size;
-	return _parse_header(*header, &frame_size, sample_rate, channles, bit_rate, NULL);
+	return _parse_header(*header, &frame_size);
 }
 
 // Get the next valid MP3 frame.
 bool mp3_get_frame(rbstream_p mFp, ssize_t *offset, uint32_t fixed_header, void *buffer, uint32_t *size)
 {
 	size_t frame_size;
-	uint32_t bitrate;
-	uint32_t num_samples;
-	uint32_t sample_rate;
+
 	for (;;) {
-		ssize_t n = _source_read_at(mFp, *offset, buffer, 4);
-		RETURN_VAL_IF_FAIL((n == 4), false);
+		ssize_t n = _source_read_at(mFp, *offset, buffer, U32_LEN_IN_BYTES);
+		RETURN_VAL_IF_FAIL((n == U32_LEN_IN_BYTES), false);
 
 		uint32_t header = _u32_at((const uint8_t *)buffer);
 
 		if ((header & MP3_FRAME_HEADER_MASK) == (fixed_header & MP3_FRAME_HEADER_MASK)
-			&& _parse_header(header, &frame_size, &sample_rate, NULL, &bitrate, &num_samples)) {
+			&& _parse_header(header, &frame_size)) {
 			break;
 		}
 
@@ -398,12 +427,12 @@ bool mp3_get_frame(rbstream_p mFp, ssize_t *offset, uint32_t fixed_header, void 
 bool mp3_check_type(rbstream_p rbsp)
 {
 	bool result = false;
-	uint8_t id3header[10];
+	uint8_t id3header[MP3_HEAD_ID3_TAG_LEN];
 
 	int retVal = _source_read_at(rbsp, 0, id3header, sizeof(id3header));
 	RETURN_VAL_IF_FAIL((retVal == (ssize_t) sizeof(id3header)), false);
 
-	if (0 == memcmp("ID3", id3header, 3)) {
+	if (memcmp("ID3", id3header, 3) == OK) {
 		return true;
 	}
 
@@ -421,28 +450,25 @@ static bool aac_resync(rbstream_p fp, ssize_t *inout_pos)
 	ssize_t pos = *inout_pos;
 	bool valid = false;
 
-	const int32_t kMaxReadBytes = 1024;
-	const int32_t kMaxBytesChecked = 4 * 1024;  //128 * 1024;
-	uint8_t buf[kMaxReadBytes];
-	ssize_t bytesToRead = kMaxReadBytes;
+	uint8_t buf[FRAME_RESYNC_READ_BYTES];
+	ssize_t bytesToRead = FRAME_RESYNC_READ_BYTES;
 	ssize_t totalBytesRead = 0;
 	ssize_t remainingBytes = 0;
 	bool reachEOS = false;
 	uint8_t *tmp = buf;
 
 	do {
-		if (pos >= *inout_pos + kMaxBytesChecked) {
-			break;              // Don't scan forever.
+		if (pos >= *inout_pos + FRAME_RESYNC_MAX_CHECK_BYTES) {
+			break;
 		}
 
-		if (remainingBytes < 6) {
-			// syncword... frame length, 6 bytes in total
+		if (remainingBytes < AAC_ADTS_FRAME_HEADER_LEN) {
 			if (reachEOS) {
 				break;
 			}
 
 			memcpy(buf, tmp, remainingBytes);
-			bytesToRead = kMaxReadBytes - remainingBytes;
+			bytesToRead = FRAME_RESYNC_READ_BYTES - remainingBytes;
 
 			/*
 			 * The next read position should start from the end of
@@ -450,7 +476,6 @@ static bool aac_resync(rbstream_p fp, ssize_t *inout_pos)
 			 * bytes in the buffer.
 			 */
 			totalBytesRead = _source_read_at(fp, pos + remainingBytes, buf + remainingBytes, bytesToRead);
-
 			if (totalBytesRead <= 0) {
 				break;
 			}
@@ -461,38 +486,33 @@ static bool aac_resync(rbstream_p fp, ssize_t *inout_pos)
 			continue;
 		}
 
-		if ((tmp[0] != 0xff) || ((tmp[1] & 0xf6) != 0xf0)) {
+		if (!AAC_ADTS_SYNC_VERIFY(tmp)) {
 			++pos;
 			++tmp;
 			--remainingBytes;
 			continue;
 		}
-		//int protectionAbsent = tmp[1] & 0x01;
-		int frame_size = (tmp[3] & 0x03) << 11 | tmp[4] << 3 | tmp[5] >> 5;
-		//int headerSize = protectionAbsent ? 7 : 9;
 
 		// We found what looks like a valid frame,
 		// now find its successors.
-
-		ssize_t test_pos = pos + frame_size;
-
 		valid = true;
-		const int FRAME_MATCH_REQUIRED = 3;
-		for (int j = 0; j < FRAME_MATCH_REQUIRED; ++j) {
-			uint8_t temp[6];
+		int frame_size = AAC_ADTS_FRAME_GETSIZE(tmp);
+		ssize_t test_pos = pos + frame_size;
+		int j;
+		for (j = 0; j < FRAME_MATCH_REQUIRED; ++j) {
+			uint8_t temp[AAC_ADTS_FRAME_HEADER_LEN];
 			ssize_t retval = _source_read_at(fp, test_pos, temp, sizeof(temp));
 			if (retval < (ssize_t) sizeof(temp)) {
 				valid = false;
 				break;
 			}
 
-			if ((temp[0] != 0xff) || ((temp[1] & 0xf6) != 0xf0)) {
+			if (!AAC_ADTS_SYNC_VERIFY(temp)) {
 				valid = false;
 				break;
 			}
 
-			int test_frame_size = (temp[3] & 0x03) << 11 | temp[4] << 3 | temp[5] >> 5;
-
+			int test_frame_size = AAC_ADTS_FRAME_GETSIZE(temp);
 			test_pos += test_frame_size;
 		}
 
@@ -527,15 +547,14 @@ bool aac_get_frame(rbstream_p mFp, ssize_t *offset, void *buffer, uint32_t *size
 	uint8_t *buf = (uint8_t *) buffer;
 
 	for (;;) {
-		ssize_t n = _source_read_at(mFp, *offset, buffer, 6);
-		RETURN_VAL_IF_FAIL((n == 6), false);
+		ssize_t n = _source_read_at(mFp, *offset, buffer, AAC_ADTS_FRAME_HEADER_LEN);
+		RETURN_VAL_IF_FAIL((n == AAC_ADTS_FRAME_HEADER_LEN), false);
 
-		if ((buf[0] == 0xff) && ((buf[1] & 0xf6) == 0xf0)) {
-			//int protectionAbsent = buffer[1] & 0x01;
-			frame_size = (buf[3] & 0x03) << 11 | buf[4] << 3 | buf[5] >> 5;
-			//int headerSize = protectionAbsent ? 7 : 9;
+		if (AAC_ADTS_SYNC_VERIFY(buf)) {
+			frame_size = AAC_ADTS_FRAME_GETSIZE(buf);
 			break;
 		}
+
 		// Lost sync.
 		ssize_t pos = *offset;
 		RETURN_VAL_IF_FAIL(aac_resync(mFp, &pos), false);
@@ -558,12 +577,13 @@ bool aac_get_frame(rbstream_p mFp, ssize_t *offset, void *buffer, uint32_t *size
 bool aac_check_type(rbstream_p rbsp)
 {
 	bool result = false;
-	uint8_t syncword[4];
+	uint8_t syncword[AAC_ADIF_SYNC_LEN];
 
 	ssize_t rlen = _source_read_at(rbsp, 0, syncword, sizeof(syncword));
 	RETURN_VAL_IF_FAIL((rlen == (ssize_t) sizeof(syncword)), false);
 
-	RETURN_VAL_IF_FAIL((0 != memcmp("ADIF", syncword, 4)), false);  // not support ADIF
+	// Don't support ADIF
+	RETURN_VAL_IF_FAIL((memcmp(AAC_ADIF_SYNC_DATA, syncword, AAC_ADIF_SYNC_LEN) != OK), false);
 
 	int value = rbs_ctrl(rbsp, OPTION_ALLOW_TO_DEQUEUE, 0);
 	ssize_t pos = 0;
@@ -576,33 +596,45 @@ bool aac_check_type(rbstream_p rbsp)
 int _get_audio_type(rbstream_p rbsp)
 {
 	if (mp3_check_type(rbsp)) {
-		return type_mp3;
+		return AUDIO_TYPE_MP3;
 	}
 
 	if (aac_check_type(rbsp)) {
-		return type_aac;
+		return AUDIO_TYPE_AAC;
 	}
 
-	return type_unknown;
+	return AUDIO_TYPE_UNKNOWN;
 }
 
 bool _get_frame(pv_player_p player)
 {
-	if (player->audio_type == type_mp3) {
+	priv_data_p priv = (priv_data_p) player->priv_data;
+	assert(priv != NULL);
+
+	switch (player->audio_type) {
+	case AUDIO_TYPE_MP3: {
 		tPVMP3DecoderExternal *mp3_ext = (tPVMP3DecoderExternal *) player->dec_ext;
-		return mp3_get_frame(player->rbsp, &player->mCurrentPos, player->mFixedHeader, (void *)mp3_ext->pInputBuffer, (uint32_t *)&mp3_ext->inputBufferCurrentLength);
-	} else if (player->audio_type == type_aac) {
-		tPVMP4AudioDecoderExternal *aac_ext = (tPVMP4AudioDecoderExternal *) player->dec_ext;
-		return aac_get_frame(player->rbsp, &player->mCurrentPos, (void *)aac_ext->pInputBuffer, (uint32_t *)&aac_ext->inputBufferCurrentLength);
+		return mp3_get_frame(player->rbsp, &priv->mCurrentPos, priv->mFixedHeader, (void *)mp3_ext->pInputBuffer, (uint32_t *)&mp3_ext->inputBufferCurrentLength);
 	}
 
-	medvdbg("[%s] unsupported audio type: %d\n", __FUNCTION__, player->audio_type);
-	return false;
+	case AUDIO_TYPE_AAC: {
+		tPVMP4AudioDecoderExternal *aac_ext = (tPVMP4AudioDecoderExternal *) player->dec_ext;
+		return aac_get_frame(player->rbsp, &priv->mCurrentPos, (void *)aac_ext->pInputBuffer, (uint32_t *)&aac_ext->inputBufferCurrentLength);
+	}
+
+	default:
+		medwdbg("[%s] unsupported audio type: %d\n", __FUNCTION__, player->audio_type);
+		return false;
+	}
 }
 
 int _init_decoder(pv_player_p player)
 {
-	if (player->audio_type == type_mp3) {
+	priv_data_p priv = (priv_data_p) player->priv_data;
+	assert(priv != NULL);
+
+	switch (player->audio_type) {
+	case AUDIO_TYPE_MP3: {
 		player->dec_ext = calloc(1, sizeof(tPVMP3DecoderExternal));
 		RETURN_VAL_IF_FAIL((player->dec_ext != NULL), PV_FAILURE);
 
@@ -611,12 +643,16 @@ int _init_decoder(pv_player_p player)
 
 		player->config_func(player->cb_data, player->audio_type, player->dec_ext);
 
+		pvmp3_resetDecoder(player->dec_mem);
 		pvmp3_InitDecoder(player->dec_ext, player->dec_mem);
 
-		player->mCurrentPos = 0;
-		bool ret = mp3_init(player->rbsp, &player->mCurrentPos, &player->mFixedHeader, &player->mSampleRate, &player->mNumChannels, &player->mBitrate);
+		priv->mCurrentPos = 0;
+		bool ret = mp3_init(player->rbsp, &priv->mCurrentPos, &priv->mFixedHeader);
 		RETURN_VAL_IF_FAIL((ret == true), PV_FAILURE);
-	} else if (player->audio_type == type_aac) {
+		break;
+	}
+
+	case AUDIO_TYPE_AAC: {
 		player->dec_ext = calloc(1, sizeof(tPVMP4AudioDecoderExternal));
 		RETURN_VAL_IF_FAIL((player->dec_ext != NULL), PV_FAILURE);
 
@@ -629,9 +665,15 @@ int _init_decoder(pv_player_p player)
 		Int err = PVMP4AudioDecoderInitLibrary(player->dec_ext, player->dec_mem);
 		RETURN_VAL_IF_FAIL((err == MP4AUDEC_SUCCESS), PV_FAILURE);
 
-		player->mCurrentPos = 0;
-		bool ret = aac_init(player->rbsp, &player->mCurrentPos);
+		priv->mCurrentPos = 0;
+		bool ret = aac_init(player->rbsp, &priv->mCurrentPos);
 		RETURN_VAL_IF_FAIL((ret == true), PV_FAILURE);
+		break;
+	}
+
+	default:
+		// Maybe do not need to init, return success.
+		return PV_SUCCESS;
 	}
 
 	return PV_SUCCESS;
@@ -639,37 +681,47 @@ int _init_decoder(pv_player_p player)
 
 int _frame_decoder(pv_player_p player, pcm_data_p pcm)
 {
-	if (player->audio_type == type_mp3) {
+	switch (player->audio_type) {
+	case AUDIO_TYPE_MP3: {
 		tPVMP3DecoderExternal tmp_ext = *((tPVMP3DecoderExternal *) player->dec_ext);
 		tPVMP3DecoderExternal *mp3_ext = &tmp_ext;
 
 		mp3_ext->inputBufferUsedLength = 0;
 
 		ERROR_CODE errorCode = pvmp3_framedecoder(mp3_ext, player->dec_mem);
+		medvdbg("[%s] Line %d, pvmp3_framedecoder, errorCode %d\n", __FUNCTION__, __LINE__, errorCode);
 		RETURN_VAL_IF_FAIL((errorCode == NO_DECODING_ERROR), PV_FAILURE);
 
 		pcm->length = mp3_ext->outputFrameSize;
 		pcm->samples = mp3_ext->pOutputBuffer;
-		pcm->channels = player->mNumChannels;
-		pcm->samplerate = player->mSampleRate;
-		return PV_SUCCESS;
-	} else if (player->audio_type == type_aac) {
+		pcm->channels = mp3_ext->num_channels;
+		pcm->samplerate = mp3_ext->samplingRate;
+		break;
+	}
+
+	case AUDIO_TYPE_AAC: {
 		tPVMP4AudioDecoderExternal *aac_ext = (tPVMP4AudioDecoderExternal *) player->dec_ext;
 
 		aac_ext->inputBufferUsedLength = 0;
 		aac_ext->remainderBits = 0;
 
 		Int decoderErr = PVMP4AudioDecodeFrame(aac_ext, player->dec_mem);
+		medvdbg("[%s] Line %d, PVMP4AudioDecodeFrame, decoderErr %d\n", __FUNCTION__, __LINE__, decoderErr);
 		RETURN_VAL_IF_FAIL((decoderErr == MP4AUDEC_SUCCESS), PV_FAILURE);
 
 		pcm->length = aac_ext->frameLength * aac_ext->desiredChannels;
 		pcm->samples = aac_ext->pOutputBuffer;
 		pcm->channels = aac_ext->desiredChannels;
 		pcm->samplerate = aac_ext->samplingRate;
-		return PV_SUCCESS;
+		break;
 	}
 
-	return PV_FAILURE;
+	default:
+		// No decoding, return failure.
+		return PV_FAILURE;
+	}
+
+	return PV_SUCCESS;
 }
 
 static size_t _input_callback(void *data, rbstream_p rbsp)
@@ -677,22 +729,16 @@ static size_t _input_callback(void *data, rbstream_p rbsp)
 	pv_player_p player = (pv_player_p) data;
 	assert(player != NULL);
 
-#if defined(PERFORMANCE_TEST)
-	struct timeval tv1, tv2;
-	gettimeofday(&tv1, NULL);
-#endif
-
 	size_t wlen = 0;
 	RETURN_VAL_IF_FAIL((player->input_func != NULL), wlen);
 	wlen = player->input_func(player->cb_data, player);
 
-#if defined(PERFORMANCE_TEST)
-	gettimeofday(&tv2, NULL);
-	timems_input += (tv2.tv_sec * 1000 + tv2.tv_usec / 1000) - (tv1.tv_sec * 1000 + tv1.tv_usec / 1000);
-#endif
-
 	return wlen;
 }
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
 
 size_t pv_player_pushdata(pv_player_p player, const void *data, size_t len)
 {
@@ -711,12 +757,14 @@ size_t pv_player_pushdata(pv_player_p player, const void *data, size_t len)
 size_t pv_player_dataspace(pv_player_p player)
 {
 	assert(player != NULL);
+
 	return rb_avail(&player->ringbuffer);
 }
 
 bool pv_player_dataspace_is_empty(pv_player_p player)
 {
 	assert(player != NULL);
+
 	return !rb_used(&player->ringbuffer);
 }
 
@@ -724,12 +772,14 @@ int pv_player_init(pv_player_p player, size_t rbuf_size, void *user_data, config
 {
 	assert(player != NULL);
 
-	player->mCurrentPos = 0;
-	player->mFixedHeader = 0;
-	player->mSampleRate = 0;
-	player->mNumChannels = 0;
-	player->mBitrate = 0;
+	priv_data_p priv = (priv_data_p) malloc(sizeof(priv_data_t));
+	RETURN_VAL_IF_FAIL((priv != NULL), PV_FAILURE);
 
+	// init private data
+	priv->mCurrentPos = 0;
+	priv->mFixedHeader = 0;
+
+	// init player data
 	player->cb_data = user_data;
 	player->config_func = config_func;
 	player->input_func = input_func;
@@ -737,6 +787,7 @@ int pv_player_init(pv_player_p player, size_t rbuf_size, void *user_data, config
 
 	player->dec_ext = NULL;
 	player->dec_mem = NULL;
+	player->priv_data = priv;
 
 	// init ring-buffer and open it as a stream
 	rb_init(&player->ringbuffer, rbuf_size);
@@ -759,17 +810,21 @@ int pv_player_finish(pv_player_p player)
 	rb_free(&player->ringbuffer);
 
 	// free decoder external buffer
-	//if (player->dec_ext != NULL)
-	{
+	if (player->dec_ext != NULL) {
 		free(player->dec_ext);
-		//player->dec_ext = NULL;
+		player->dec_ext = NULL;
 	}
 
 	// free decoder buffer
-	//if (player->dec_mem != NULL)
-	{
+	if (player->dec_mem != NULL) {
 		free(player->dec_mem);
-		//player->dec_mem = NULL;
+		player->dec_mem = NULL;
+	}
+
+	// free private data buffer
+	if (player->priv_data != NULL) {
+		free(player->priv_data);
+		player->priv_data = NULL;
 	}
 
 	return PV_SUCCESS;
@@ -778,51 +833,23 @@ int pv_player_finish(pv_player_p player)
 int pv_player_run(pv_player_p player)
 {
 	assert(player != NULL);
-	assert(player->input_func != NULL);
-	assert(player->output_func != NULL);
-	assert(player->config_func != NULL);
 
+	RETURN_VAL_IF_FAIL((player->input_func != NULL), PV_FAILURE);
+	RETURN_VAL_IF_FAIL((player->output_func != NULL), PV_FAILURE);
+	RETURN_VAL_IF_FAIL((player->config_func != NULL), PV_FAILURE);
 	RETURN_VAL_IF_FAIL((player->rbsp != NULL), PV_FAILURE);
 
 	player->audio_type = _get_audio_type(player->rbsp);
-	//RETURN_VAL_IF_FAIL((player->audio_type > 0), PV_FAILURE);
 
 	int ret = _init_decoder(player);
 	RETURN_VAL_IF_FAIL((ret == PV_SUCCESS), PV_FAILURE);
 
-#if defined(PERFORMANCE_TEST)
-	timems_input = 0;
-	timems_output = 0;
-	timems_decode = 0;
-	samples_output = 0;
-	struct timeval tv1, tv2, tv3;
-#endif
-
 	while (_get_frame(player)) {
-#if defined(PERFORMANCE_TEST)
-		gettimeofday(&tv1, NULL);
-#endif
-
 		pcm_data_t pcm;
-		if (0 == _frame_decoder(player, &pcm)) {
-#if defined(PERFORMANCE_TEST)
-			gettimeofday(&tv2, NULL);
-			timems_decode += (tv2.tv_sec * 1000 + tv2.tv_usec / 1000) - (tv1.tv_sec * 1000 + tv1.tv_usec / 1000);
-			samples_output += pcm.length;
-#endif
-
+		if (_frame_decoder(player, &pcm) == PV_SUCCESS) {
 			player->output_func(player->cb_data, player, &pcm);
-
-#if defined(PERFORMANCE_TEST)
-			gettimeofday(&tv3, NULL);
-			timems_output += (tv3.tv_sec * 1000 + tv3.tv_usec / 1000) - (tv2.tv_sec * 1000 + tv2.tv_usec / 1000);
-#endif
 		}
 	}
-
-#if defined(PERFORMANCE_TEST)
-	medvdbg("[%s] finished! time: input %lu / output %lu / decoding %lu ms, samples: 0x%x\n", __FUNCTION__, timems_input, timems_output, timems_decode, samples_output);
-#endif
 
 	return PV_SUCCESS;
 }

--- a/external/audiocodec/streaming/player.c
+++ b/external/audiocodec/streaming/player.c
@@ -33,12 +33,12 @@
 #include "debug.h"
 #include <audiocodec/streaming/player.h>
 
-#define PV_SUCCESS 	0
-#define PV_FAILURE 	-1
+#define PV_SUCCESS  0
+#define PV_FAILURE  -1
 
-#define PLAYER_DEBUG 	audvdbg
-#define PLAYER_ERROR 	auddbg
-#define PLAYER_ASSERT 	MY_ASSERT
+#define PLAYER_DEBUG    audvdbg
+#define PLAYER_ERROR    auddbg
+#define PLAYER_ASSERT   MY_ASSERT
 
 //#define PERFORMANCE_TEST
 
@@ -55,589 +55,557 @@ static unsigned long samples_output = 0;
 
 static uint32_t _u32_at(const uint8_t *ptr)
 {
-    return ptr[0] << 24 | ptr[1] << 16 | ptr[2] << 8 | ptr[3];
+	return ptr[0] << 24 | ptr[1] << 16 | ptr[2] << 8 | ptr[3];
 }
 
-static bool _parse_header(
-        uint32_t header, size_t *frame_size,
-        uint32_t *out_sampling_rate, uint32_t *out_channels ,
-        uint32_t *out_bitrate, uint32_t *out_num_samples)
+static bool _parse_header(uint32_t header, size_t *frame_size, uint32_t *out_sampling_rate, uint32_t *out_channels, uint32_t *out_bitrate, uint32_t *out_num_samples)
 {
-    *frame_size = 0;
+	*frame_size = 0;
 
-    if (out_sampling_rate)
-        *out_sampling_rate = 0;
+	if (out_sampling_rate) {
+		*out_sampling_rate = 0;
+	}
 
-    if (out_channels)
-        *out_channels = 0;
+	if (out_channels) {
+		*out_channels = 0;
+	}
 
-    if (out_bitrate)
-        *out_bitrate = 0;
+	if (out_bitrate) {
+		*out_bitrate = 0;
+	}
 
-    if (out_num_samples)
-        *out_num_samples = 1152;
+	if (out_num_samples) {
+		*out_num_samples = 1152;
+	}
 
-    RETURN_VAL_IF_FAIL((header & 0xffe00000) == 0xffe00000, false);
+	RETURN_VAL_IF_FAIL((header & 0xffe00000) == 0xffe00000, false);
 
-    unsigned version = (header >> 19) & 3;
-    RETURN_VAL_IF_FAIL(version != 0x01, false);
+	unsigned version = (header >> 19) & 3;
+	RETURN_VAL_IF_FAIL(version != 0x01, false);
 
-    unsigned layer = (header >> 17) & 3;
+	unsigned layer = (header >> 17) & 3;
 
-    RETURN_VAL_IF_FAIL(layer != 0x00, false);
+	RETURN_VAL_IF_FAIL(layer != 0x00, false);
 
-    unsigned bitrate_index = (header >> 12) & 0x0f;
+	unsigned bitrate_index = (header >> 12) & 0x0f;
 
-    if (bitrate_index == 0 || bitrate_index == 0x0f)
-        return false;	// Disallow "free" bitrate.
+	if (bitrate_index == 0 || bitrate_index == 0x0f) {
+		return false;           // Disallow "free" bitrate.
+	}
 
-    unsigned sampling_rate_index = (header >> 10) & 3;
+	unsigned sampling_rate_index = (header >> 10) & 3;
 
-    RETURN_VAL_IF_FAIL((sampling_rate_index != 3), false);
+	RETURN_VAL_IF_FAIL((sampling_rate_index != 3), false);
 
-    static const int kSamplingRateV1[] = { 44100, 48000, 32000 };
-    int sampling_rate = kSamplingRateV1[sampling_rate_index];
-    if (version == 2 /* V2 */)
-	{
-        sampling_rate /= 2;
-    }
-	else if (version == 0 /* V2.5 */)
-    {
-        sampling_rate /= 4;
-    }
+	static const int kSamplingRateV1[] = { 44100, 48000, 32000 };
+	int sampling_rate = kSamplingRateV1[sampling_rate_index];
+	if (version == 2 /* V2 */) {
+		sampling_rate /= 2;
+	} else if (version == 0 /* V2.5 */) {
+		sampling_rate /= 4;
+	}
 
-    unsigned padding = (header >> 9) & 1;
+	unsigned padding = (header >> 9) & 1;
 
-    if (layer == 3)
-	{
-        // layer I
-        static const int kBitrateV1[] = {
-            32, 64, 96, 128, 160, 192, 224, 256,
-            288, 320, 352, 384, 416, 448
-        };
+	if (layer == 3) {
+		// layer I
+		static const int kBitrateV1[] = {
+			32, 64, 96, 128, 160, 192, 224, 256,
+			288, 320, 352, 384, 416, 448
+		};
 
-        static const int kBitrateV2[] = {
-            32, 48, 56, 64, 80, 96, 112, 128,
-            144, 160, 176, 192, 224, 256
-        };
+		static const int kBitrateV2[] = {
+			32, 48, 56, 64, 80, 96, 112, 128,
+			144, 160, 176, 192, 224, 256
+		};
 
-        int bitrate =
-            (version == 3 /* V1 */)
-                ? kBitrateV1[bitrate_index - 1]
-                : kBitrateV2[bitrate_index - 1];
+		int bitrate = (version == 3 /* V1 */)
+					  ? kBitrateV1[bitrate_index - 1]
+					  : kBitrateV2[bitrate_index - 1];
 
-        if (out_bitrate)
-            *out_bitrate = bitrate;
+		if (out_bitrate) {
+			*out_bitrate = bitrate;
+		}
 
-        *frame_size = (12000 * bitrate / sampling_rate + padding) * 4;
+		*frame_size = (12000 * bitrate / sampling_rate + padding) * 4;
 
-        if (out_num_samples)
-            *out_num_samples = 384;
-    }
-	else
-	{
-        // layer II or III
-        static const int kBitrateV1L2[] = {
-            32, 48, 56, 64, 80, 96, 112, 128,
-            160, 192, 224, 256, 320, 384
-        };
+		if (out_num_samples) {
+			*out_num_samples = 384;
+		}
+	} else {
+		// layer II or III
+		static const int kBitrateV1L2[] = {
+			32, 48, 56, 64, 80, 96, 112, 128,
+			160, 192, 224, 256, 320, 384
+		};
 
-        static const int kBitrateV1L3[] = {
-            32, 40, 48, 56, 64, 80, 96, 112,
-            128, 160, 192, 224, 256, 320
-        };
+		static const int kBitrateV1L3[] = {
+			32, 40, 48, 56, 64, 80, 96, 112,
+			128, 160, 192, 224, 256, 320
+		};
 
-        static const int kBitrateV2[] = {
-            8, 16, 24, 32, 40, 48, 56, 64,
-            80, 96, 112, 128, 144, 160
-        };
+		static const int kBitrateV2[] = {
+			8, 16, 24, 32, 40, 48, 56, 64,
+			80, 96, 112, 128, 144, 160
+		};
 
-        int bitrate;
-        if (version == 3 /* V1 */) {
-            bitrate = (layer == 2 /* L2 */)
-                ? kBitrateV1L2[bitrate_index - 1]
-                : kBitrateV1L3[bitrate_index - 1];
+		int bitrate;
+		if (version == 3 /* V1 */) {
+			bitrate = (layer == 2 /* L2 */)
+					  ? kBitrateV1L2[bitrate_index - 1]
+					  : kBitrateV1L3[bitrate_index - 1];
 
-            if (out_num_samples) {
-                *out_num_samples = 1152;
-            }
-        }
-		else
-		{
-            // V2 (or 2.5)
+			if (out_num_samples) {
+				*out_num_samples = 1152;
+			}
+		} else {
+			// V2 (or 2.5)
 
-            bitrate = kBitrateV2[bitrate_index - 1];
-            if (out_num_samples)
-                *out_num_samples = (layer == 1 /* L3 */) ? 576 : 1152;
-        }
+			bitrate = kBitrateV2[bitrate_index - 1];
+			if (out_num_samples) {
+				*out_num_samples = (layer == 1 /* L3 */) ? 576 : 1152;
+			}
+		}
 
-        if (out_bitrate)
-            *out_bitrate = bitrate;
+		if (out_bitrate) {
+			*out_bitrate = bitrate;
+		}
 
-        if (version == 3 /* V1 */)
-		{
-            *frame_size = 144000 * bitrate / sampling_rate + padding;
-        }
-		else
-        {
-            // V2 or V2.5
-            size_t tmp = (layer == 1 /* L3 */) ? 72000 : 144000;
-            *frame_size = tmp * bitrate / sampling_rate + padding;
-        }
-    }
+		if (version == 3 /* V1 */) {
+			*frame_size = 144000 * bitrate / sampling_rate + padding;
+		} else {
+			// V2 or V2.5
+			size_t tmp = (layer == 1 /* L3 */) ? 72000 : 144000;
+			*frame_size = tmp * bitrate / sampling_rate + padding;
+		}
+	}
 
-    if (out_sampling_rate)
-        *out_sampling_rate = sampling_rate;
+	if (out_sampling_rate) {
+		*out_sampling_rate = sampling_rate;
+	}
 
-    if (out_channels)
-	{
-        int channel_mode = (header >> 6) & 3;
-        *out_channels = (channel_mode == 3) ? 1 : 2;
-    }
+	if (out_channels) {
+		int channel_mode = (header >> 6) & 3;
+		*out_channels = (channel_mode == 3) ? 1 : 2;
+	}
 
-    return true;
+	return true;
 }
 
 static ssize_t _source_read_at(rbstream_p fp, ssize_t offset, void *data, size_t size)
 {
-    int retVal = rbs_seek(fp, offset, SEEK_SET);
-    if (retVal != EXIT_SUCCESS)
-        return 0;
+	int retVal = rbs_seek(fp, offset, SEEK_SET);
+	RETURN_VAL_IF_FAIL((retVal == 0), 0);
 
-    return rbs_read(data, 1, size, fp);
+	return rbs_read(data, 1, size, fp);
 }
 
-
 // Resync to next valid MP3 frame in the file.
-static bool mp3_resync(
-        rbstream_p fp, uint32_t match_header,
-        ssize_t *inout_pos, uint32_t *out_header)
+static bool mp3_resync(rbstream_p fp, uint32_t match_header, ssize_t *inout_pos, uint32_t *out_header)
 {
 	PLAYER_DEBUG("[%s] Line %d, match_header %#x, *pos %d\n", __FUNCTION__, __LINE__, match_header, *inout_pos);
 
-    if (*inout_pos == 0)
-	{
-        // Skip an optional ID3 header if syncing at the very beginning of the datasource.
-        for (;;)
-		{
-            uint8_t id3header[10];
-            int retVal = _source_read_at(fp, *inout_pos, id3header, sizeof(id3header));
-            RETURN_VAL_IF_FAIL((retVal == (ssize_t)sizeof(id3header)), false);
+	if (*inout_pos == 0) {
+		// Skip an optional ID3 header if syncing at the very beginning of the datasource.
+		for (;;) {
+			uint8_t id3header[10];
+			int retVal = _source_read_at(fp, *inout_pos, id3header, sizeof(id3header));
+			RETURN_VAL_IF_FAIL((retVal == (ssize_t) sizeof(id3header)), false);
 
-            if (memcmp("ID3", id3header, 3))
-                break;
+			if (memcmp("ID3", id3header, 3)) {
+				break;
+			}
+			// Skip the ID3v2 header.
+			size_t len = ((id3header[6] & 0x7f) << 21)
+						 | ((id3header[7] & 0x7f) << 14)
+						 | ((id3header[8] & 0x7f) << 7)
+						 | (id3header[9] & 0x7f);
 
-            // Skip the ID3v2 header.
-            size_t len =
-                ((id3header[6] & 0x7f) << 21)
-                | ((id3header[7] & 0x7f) << 14)
-                | ((id3header[8] & 0x7f) << 7)
-                | (id3header[9] & 0x7f);
+			len += 10;
 
-            len += 10;
+			*inout_pos += len;
+		}
+	}
 
-            *inout_pos += len;
-        }
-    }
+	ssize_t pos = *inout_pos;
+	bool valid = false;
 
-    ssize_t pos = *inout_pos;
-    bool valid = false;
+	const int32_t kMaxReadBytes = 1024;
+	const int32_t kMaxBytesChecked = 8 * 1024;  //128 * 1024;
+	uint8_t buf[kMaxReadBytes];
+	ssize_t bytesToRead = kMaxReadBytes;
+	ssize_t totalBytesRead = 0;
+	ssize_t remainingBytes = 0;
+	bool reachEOS = false;
+	uint8_t *tmp = buf;
 
-    const int32_t kMaxReadBytes = 1024;
-    const int32_t kMaxBytesChecked = 8*1024;//128 * 1024;
-    uint8_t buf[kMaxReadBytes];
-    ssize_t bytesToRead = kMaxReadBytes;
-    ssize_t totalBytesRead = 0;
-    ssize_t remainingBytes = 0;
-    bool reachEOS = false;
-    uint8_t *tmp = buf;
+	do {
+		if (pos >= *inout_pos + kMaxBytesChecked) {
+			PLAYER_DEBUG("[%s] Line %d, resync range < kMaxBytesChecked %d\n", __FUNCTION__, __LINE__, kMaxBytesChecked);
+			break;              // Don't scan forever.
+		}
 
-    do {
-        if (pos >= *inout_pos + kMaxBytesChecked)
-            break;	// Don't scan forever.
+		if (remainingBytes < 4) {
+			if (reachEOS) {
+				break;
+			}
 
-        if (remainingBytes < 4)
-		{
-            if (reachEOS)
-                break;
+			memcpy(buf, tmp, remainingBytes);
+			bytesToRead = kMaxReadBytes - remainingBytes;
 
-            memcpy(buf, tmp, remainingBytes);
-            bytesToRead = kMaxReadBytes - remainingBytes;
+			/*
+			 * The next read position should start from the end of
+			 * the last buffer, and thus should include the remaining
+			 * bytes in the buffer.
+			 */
+			totalBytesRead = _source_read_at(fp, pos + remainingBytes, buf + remainingBytes, bytesToRead);
 
-            /*
-             * The next read position should start from the end of
-             * the last buffer, and thus should include the remaining
-             * bytes in the buffer.
-             */
-            totalBytesRead = _source_read_at(fp, pos + remainingBytes,
-                                         buf + remainingBytes, bytesToRead);
+			if (totalBytesRead <= 0) {
+				break;
+			}
 
-            if (totalBytesRead <= 0)
-                break;
+			reachEOS = (totalBytesRead != bytesToRead);
+			remainingBytes += totalBytesRead;
+			tmp = buf;
+			continue;
+		}
 
-            reachEOS = (totalBytesRead != bytesToRead);
-            remainingBytes += totalBytesRead;
-            tmp = buf;
-            continue;
-        }
+		uint32_t header = _u32_at(tmp);
 
-        uint32_t header = _u32_at(tmp);
+		if (match_header != 0 && (header & MP3_FRAME_HEADER_MASK) != (match_header & MP3_FRAME_HEADER_MASK)) {
+			++pos;
+			++tmp;
+			--remainingBytes;
+			continue;
+		}
 
-        if (match_header != 0 && (header & MP3_FRAME_HEADER_MASK) != (match_header & MP3_FRAME_HEADER_MASK))
-		{
-            ++pos;
-            ++tmp;
-            --remainingBytes;
-            continue;
-        }
+		size_t frame_size;
+		uint32_t sample_rate, num_channels, bitrate;
+		if (!_parse_header(header, &frame_size, &sample_rate, &num_channels, &bitrate, NULL)) {
+			++pos;
+			++tmp;
+			--remainingBytes;
+			continue;
+		}
 
-        size_t frame_size;
-        uint32_t sample_rate, num_channels, bitrate;
-        if (!_parse_header(header, &frame_size, &sample_rate, &num_channels, &bitrate, NULL))
-		{
-            ++pos;
-            ++tmp;
-            --remainingBytes;
-            continue;
-        }
+		// We found what looks like a valid frame,
+		// now find its successors.
+		ssize_t test_pos = pos + frame_size;
+		PLAYER_DEBUG("[%s] Line %d, valid frame at pos %#x + framesize %#x = %#x\n", __FUNCTION__, __LINE__, pos, frame_size, test_pos);
+		valid = true;
+		const int FRAME_MATCH_REQUIRED = 2;
+		for (int j = 0; j < FRAME_MATCH_REQUIRED; ++j) {
+			uint8_t temp[4];
+			ssize_t retval = _source_read_at(fp, test_pos, temp, sizeof(temp));
+			if (retval < (ssize_t) sizeof(temp)) {
+				valid = false;
+				break;
+			}
 
-        // We found what looks like a valid frame,
-        // now find its successors.
+			uint32_t test_header = _u32_at(temp);
 
-        ssize_t test_pos = pos + frame_size;
+			if ((test_header & MP3_FRAME_HEADER_MASK) != (header & MP3_FRAME_HEADER_MASK)) {
+				PLAYER_DEBUG("[%s] Line %d, invalid frame at pos1 %#x\n", __FUNCTION__, __LINE__, test_pos);
+				valid = false;
+				break;
+			}
 
-        valid = true;
-        const int FRAME_MATCH_REQUIRED = 2;
-        for (int j = 0; j < FRAME_MATCH_REQUIRED; ++j)
-		{
-            uint8_t temp[4];
-            ssize_t retval = _source_read_at(fp, test_pos, temp, sizeof(temp));
-            if (retval < (ssize_t)sizeof(temp))
-			{
-                valid = false;
-                break;
-            }
+			size_t test_frame_size;
+			if (!_parse_header(test_header, &test_frame_size, NULL, NULL, NULL, NULL)) {
+				PLAYER_DEBUG("[%s] Line %d, invalid frame at pos2 %#x\n", __FUNCTION__, __LINE__, test_pos);
+				valid = false;
+				break;
+			}
 
-            uint32_t test_header = _u32_at(temp);
+			PLAYER_DEBUG("[%s] Line %d, valid frame at pos %#x + framesize %#x = %#x\n", __FUNCTION__, __LINE__, test_pos, test_frame_size, test_pos + test_frame_size);
+			test_pos += test_frame_size;
+		}
 
-            if ((test_header & MP3_FRAME_HEADER_MASK) != (header & MP3_FRAME_HEADER_MASK))
-			{
-                valid = false;
-                break;
-            }
+		if (valid) {
+			*inout_pos = pos;
 
-            size_t test_frame_size;
-            if (!_parse_header(test_header, &test_frame_size, NULL, NULL, NULL, NULL))
-			{
-                valid = false;
-                break;
-            }
-
-            test_pos += test_frame_size;
-        }
-
-        if (valid)
-		{
-            *inout_pos = pos;
-
-            if (out_header != NULL)
-                *out_header = header;
+			if (out_header != NULL) {
+				*out_header = header;
+			}
 
 			PLAYER_DEBUG("[%s] Line %d, find header %#x at pos %d(%#x)\n", __FUNCTION__, __LINE__, header, pos, pos);
-        }
+		}
 
-        ++pos;
-        ++tmp;
-        --remainingBytes;
-    } while (!valid);
+		++pos;
+		++tmp;
+		--remainingBytes;
+	} while (!valid);
 
-    return valid;
+	return valid;
 }
 
 // Initialize the MP3 reader.
-bool mp3_init(rbstream_p mFp, ssize_t *offset, uint32_t *header,
-				uint32_t *sample_rate, uint32_t *channles, uint32_t *bit_rate)
+bool mp3_init(rbstream_p mFp, ssize_t *offset, uint32_t *header, uint32_t *sample_rate, uint32_t *channles, uint32_t *bit_rate)
 {
-    // Sync to the first valid frame.
-    bool success = mp3_resync(mFp, 0, offset, header);
-    RETURN_VAL_IF_FAIL((success == true), false);
+	// Sync to the first valid frame.
+	bool success = mp3_resync(mFp, 0, offset, header);
+	RETURN_VAL_IF_FAIL((success == true), false);
 
 	// Policy: Pop out data when *offset updated!
 	rbs_seek_ext(mFp, *offset, SEEK_SET);
 
-    size_t frame_size;
-    return _parse_header(*header, &frame_size, sample_rate, channles, bit_rate, NULL);
+	size_t frame_size;
+	return _parse_header(*header, &frame_size, sample_rate, channles, bit_rate, NULL);
 }
 
 // Get the next valid MP3 frame.
 bool mp3_get_frame(rbstream_p mFp, ssize_t *offset, uint32_t fixed_header, void *buffer, uint32_t *size)
 {
-    size_t frame_size;
-    uint32_t bitrate;
-    uint32_t num_samples;
-    uint32_t sample_rate;
-    for (;;)
-	{
-        ssize_t n = _source_read_at(mFp, *offset, buffer, 4);
-        RETURN_VAL_IF_FAIL((n == 4), false);
+	size_t frame_size;
+	uint32_t bitrate;
+	uint32_t num_samples;
+	uint32_t sample_rate;
+	for (;;) {
+		ssize_t n = _source_read_at(mFp, *offset, buffer, 4);
+		RETURN_VAL_IF_FAIL((n == 4), false);
 
-        uint32_t header = _u32_at((const uint8_t *)buffer);
+		uint32_t header = _u32_at((const uint8_t *)buffer);
 
-        if ((header & MP3_FRAME_HEADER_MASK) == (fixed_header & MP3_FRAME_HEADER_MASK)
-            && _parse_header(header, &frame_size, &sample_rate, NULL, &bitrate, &num_samples))
-        {
-            break;
-        }
+		if ((header & MP3_FRAME_HEADER_MASK) == (fixed_header & MP3_FRAME_HEADER_MASK)
+			&& _parse_header(header, &frame_size, &sample_rate, NULL, &bitrate, &num_samples)) {
+			break;
+		}
 
-        // Lost sync.
-        ssize_t pos = *offset;
-        if (!mp3_resync(mFp, fixed_header, &pos, NULL /*out_header*/))
-		{
-            // Unable to mp3_resync. Signalling end of stream.
-            return false;
-        }
+		// Lost sync.
+		ssize_t pos = *offset;
+		if (!mp3_resync(mFp, fixed_header, &pos, NULL /*out_header */)) {
+			// Unable to mp3_resync. Signalling end of stream.
+			return false;
+		}
 
-        *offset = pos;
+		*offset = pos;
 		// Policy: Pop out data when mCurrentPos updated!
 		rbs_seek_ext(mFp, *offset, SEEK_SET);
 
-        // Try again with the new position.
-    }
+		// Try again with the new position.
+	}
 
-    ssize_t n = _source_read_at(mFp, *offset, buffer, frame_size);
-    RETURN_VAL_IF_FAIL((n == (ssize_t)frame_size), false);
+	ssize_t n = _source_read_at(mFp, *offset, buffer, frame_size);
+	RETURN_VAL_IF_FAIL((n == (ssize_t) frame_size), false);
 
-    *size = frame_size;
-    *offset += frame_size;
+	PLAYER_DEBUG("[%s] Line %d, pos %#x, framesize %#x\n", __FUNCTION__, __LINE__, *offset, frame_size);
+
+	*size = frame_size;
+	*offset += frame_size;
 	// Policy: Pop out data when mCurrentPos updated!
 	rbs_seek_ext(mFp, *offset, SEEK_SET);
 
-    return true;
+	return true;
 }
-
 
 bool mp3_check_type(rbstream_p rbsp)
 {
 	bool result = false;
-    uint8_t id3header[10];
+	uint8_t id3header[10];
 
-	PLAYER_DEBUG("[%s] Line %d\n", __FUNCTION__, __LINE__);
+	int retVal = _source_read_at(rbsp, 0, id3header, sizeof(id3header));
+	RETURN_VAL_IF_FAIL((retVal == (ssize_t) sizeof(id3header)), false);
 
-    int retVal = _source_read_at(rbsp, 0, id3header, sizeof(id3header));
-    RETURN_VAL_IF_FAIL((retVal == (ssize_t)sizeof(id3header)), false);
+	if (0 == memcmp("ID3", id3header, 3)) {
+		return true;
+	}
 
-    if (0 == memcmp("ID3", id3header, 3)) {
-        return true;
-    }
-
-	int value = rbs_ctrl(rbsp, option_seek_with_pop, 0);
-    ssize_t pos = 0;
-    result = mp3_resync(rbsp, 0, &pos, NULL);
-	rbs_ctrl(rbsp, option_seek_with_pop, value);
+	int value = rbs_ctrl(rbsp, OPTION_ALLOW_TO_DEQUEUE, 0);
+	ssize_t pos = 0;
+	result = mp3_resync(rbsp, 0, &pos, NULL);
+	rbs_ctrl(rbsp, OPTION_ALLOW_TO_DEQUEUE, value);
 
 	return result;
 }
 
-
-
 // Resync to next valid MP3 frame in the file.
 static bool aac_resync(rbstream_p fp, ssize_t *inout_pos)
 {
-    ssize_t pos = *inout_pos;
-    bool valid = false;
+	ssize_t pos = *inout_pos;
+	bool valid = false;
 
-    const int32_t kMaxReadBytes = 1024;
-    const int32_t kMaxBytesChecked = 4*1024;//128 * 1024;
-    uint8_t buf[kMaxReadBytes];
-    ssize_t bytesToRead = kMaxReadBytes;
-    ssize_t totalBytesRead = 0;
-    ssize_t remainingBytes = 0;
-    bool reachEOS = false;
-    uint8_t *tmp = buf;
+	const int32_t kMaxReadBytes = 1024;
+	const int32_t kMaxBytesChecked = 4 * 1024;  //128 * 1024;
+	uint8_t buf[kMaxReadBytes];
+	ssize_t bytesToRead = kMaxReadBytes;
+	ssize_t totalBytesRead = 0;
+	ssize_t remainingBytes = 0;
+	bool reachEOS = false;
+	uint8_t *tmp = buf;
 
-    do {
-        if (pos >= *inout_pos + kMaxBytesChecked)
-            break;	// Don't scan forever.
+	do {
+		if (pos >= *inout_pos + kMaxBytesChecked) {
+			break;              // Don't scan forever.
+		}
 
-        if (remainingBytes < 6)
-		{  // syncword... frame length, 6 bytes in total
-            if (reachEOS)
-                break;
+		if (remainingBytes < 6) {
+			// syncword... frame length, 6 bytes in total
+			if (reachEOS) {
+				break;
+			}
 
-            memcpy(buf, tmp, remainingBytes);
-            bytesToRead = kMaxReadBytes - remainingBytes;
+			memcpy(buf, tmp, remainingBytes);
+			bytesToRead = kMaxReadBytes - remainingBytes;
 
-            /*
-             * The next read position should start from the end of
-             * the last buffer, and thus should include the remaining
-             * bytes in the buffer.
-             */
-            totalBytesRead = _source_read_at(fp, pos + remainingBytes, buf + remainingBytes, bytesToRead);
+			/*
+			 * The next read position should start from the end of
+			 * the last buffer, and thus should include the remaining
+			 * bytes in the buffer.
+			 */
+			totalBytesRead = _source_read_at(fp, pos + remainingBytes, buf + remainingBytes, bytesToRead);
 
-            if (totalBytesRead <= 0)
-                break;
+			if (totalBytesRead <= 0) {
+				break;
+			}
 
-            reachEOS = (totalBytesRead != bytesToRead);
-            remainingBytes += totalBytesRead;
-            tmp = buf;
-            continue;
-        }
+			reachEOS = (totalBytesRead != bytesToRead);
+			remainingBytes += totalBytesRead;
+			tmp = buf;
+			continue;
+		}
 
-        if((tmp[0] != 0xff) || ((tmp[1] & 0xf6) != 0xf0))
-		{
-            ++pos;
-            ++tmp;
-            --remainingBytes;
-            continue;
-        }
+		if ((tmp[0] != 0xff) || ((tmp[1] & 0xf6) != 0xf0)) {
+			++pos;
+			++tmp;
+			--remainingBytes;
+			continue;
+		}
+		//int protectionAbsent = tmp[1] & 0x01;
+		int frame_size = (tmp[3] & 0x03) << 11 | tmp[4] << 3 | tmp[5] >> 5;
+		//int headerSize = protectionAbsent ? 7 : 9;
 
-        //int protectionAbsent = tmp[1] & 0x01;
-        int frame_size = (tmp[3] & 0x03) << 11 | tmp[4] << 3 | tmp[5] >> 5;
-        //int headerSize = protectionAbsent ? 7 : 9;
+		// We found what looks like a valid frame,
+		// now find its successors.
 
-        // We found what looks like a valid frame,
-        // now find its successors.
+		ssize_t test_pos = pos + frame_size;
 
-        ssize_t test_pos = pos + frame_size;
+		valid = true;
+		const int FRAME_MATCH_REQUIRED = 3;
+		for (int j = 0; j < FRAME_MATCH_REQUIRED; ++j) {
+			uint8_t temp[6];
+			ssize_t retval = _source_read_at(fp, test_pos, temp, sizeof(temp));
+			if (retval < (ssize_t) sizeof(temp)) {
+				valid = false;
+				break;
+			}
 
-        valid = true;
-        const int FRAME_MATCH_REQUIRED = 3;
-        for (int j = 0; j < FRAME_MATCH_REQUIRED; ++j)
-		{
-            uint8_t temp[6];
-            ssize_t retval = _source_read_at(fp, test_pos, temp, sizeof(temp));
-            if (retval < (ssize_t)sizeof(temp))
-			{
-                valid = false;
-                break;
-            }
+			if ((temp[0] != 0xff) || ((temp[1] & 0xf6) != 0xf0)) {
+				valid = false;
+				break;
+			}
 
-	        if((temp[0] != 0xff) || ((temp[1] & 0xf6) != 0xf0))
-			{
-	            valid = false;
-	            break;
-	        }
+			int test_frame_size = (temp[3] & 0x03) << 11 | temp[4] << 3 | temp[5] >> 5;
 
-	        int test_frame_size = (temp[3] & 0x03) << 11 | temp[4] << 3 | temp[5] >> 5;
+			test_pos += test_frame_size;
+		}
 
-            test_pos += test_frame_size;
-        }
+		if (valid) {
+			*inout_pos = pos;
+		}
 
-        if (valid)
-            *inout_pos = pos;
+		++pos;
+		++tmp;
+		--remainingBytes;
+	} while (!valid);
 
-        ++pos;
-        ++tmp;
-        --remainingBytes;
-    } while (!valid);
-
-    return valid;
+	return valid;
 }
 
 // Initialize the aac reader.
 bool aac_init(rbstream_p mFp, ssize_t *offset)
 {
-    // Sync to the first valid frame.
-    bool success = aac_resync(mFp, offset);
-    RETURN_VAL_IF_FAIL((success == true), false);
+	// Sync to the first valid frame.
+	bool success = aac_resync(mFp, offset);
+	RETURN_VAL_IF_FAIL((success == true), false);
 
 	// Policy: Pop out data when *offset updated!
 	rbs_seek_ext(mFp, *offset, SEEK_SET);
-    return true;
+	return true;
 }
 
 // Get the next valid aac frame.
 bool aac_get_frame(rbstream_p mFp, ssize_t *offset, void *buffer, uint32_t *size)
 {
-    size_t frame_size = 0;
-	uint8_t *buf = (uint8_t *)buffer;
+	size_t frame_size = 0;
+	uint8_t *buf = (uint8_t *) buffer;
 
-    for (;;)
-	{
-        ssize_t n = _source_read_at(mFp, *offset, buffer, 6);
+	for (;;) {
+		ssize_t n = _source_read_at(mFp, *offset, buffer, 6);
 		RETURN_VAL_IF_FAIL((n == 6), false);
 
-        if((buf[0] == 0xff) && ((buf[1] & 0xf6) == 0xf0))
-		{
-	        //int protectionAbsent = buffer[1] & 0x01;
-	        frame_size = (buf[3] & 0x03) << 11 | buf[4] << 3 | buf[5] >> 5;
-	        //int headerSize = protectionAbsent ? 7 : 9;
-            break;
-        }
+		if ((buf[0] == 0xff) && ((buf[1] & 0xf6) == 0xf0)) {
+			//int protectionAbsent = buffer[1] & 0x01;
+			frame_size = (buf[3] & 0x03) << 11 | buf[4] << 3 | buf[5] >> 5;
+			//int headerSize = protectionAbsent ? 7 : 9;
+			break;
+		}
+		// Lost sync.
+		ssize_t pos = *offset;
+		RETURN_VAL_IF_FAIL(aac_resync(mFp, &pos), false);
 
-        // Lost sync.
-        ssize_t pos = *offset;
-        RETURN_VAL_IF_FAIL(aac_resync(mFp, &pos), false);
-
-        *offset = pos;
+		*offset = pos;
 		rbs_seek_ext(mFp, *offset, SEEK_SET);
-        // Try again with the new position.
-    }
+		// Try again with the new position.
+	}
 
-    ssize_t n = _source_read_at(mFp, *offset, buffer, frame_size);
-	RETURN_VAL_IF_FAIL((n == (ssize_t)frame_size), false);
+	ssize_t n = _source_read_at(mFp, *offset, buffer, frame_size);
+	RETURN_VAL_IF_FAIL((n == (ssize_t) frame_size), false);
 
-    *size = frame_size;
-    *offset += frame_size;
+	*size = frame_size;
+	*offset += frame_size;
 	rbs_seek_ext(mFp, *offset, SEEK_SET);
 
-    return true;
+	return true;
 }
 
 bool aac_check_type(rbstream_p rbsp)
 {
 	bool result = false;
-    uint8_t syncword[4];
+	uint8_t syncword[4];
 
-	PLAYER_DEBUG("[%s] Line %d\n", __FUNCTION__, __LINE__);
+	ssize_t rlen = _source_read_at(rbsp, 0, syncword, sizeof(syncword));
+	RETURN_VAL_IF_FAIL((rlen == (ssize_t) sizeof(syncword)), false);
 
-    ssize_t rlen = _source_read_at(rbsp, 0, syncword, sizeof(syncword));
-	RETURN_VAL_IF_FAIL((rlen == (ssize_t)sizeof(syncword)), false);
+	RETURN_VAL_IF_FAIL((0 != memcmp("ADIF", syncword, 4)), false);  // not support ADIF
 
-    RETURN_VAL_IF_FAIL((0 != memcmp("ADIF", syncword, 4)), false); // not support ADIF
-
-	int value = rbs_ctrl(rbsp, option_seek_with_pop, 0);
-    ssize_t pos = 0;
-    result = aac_resync(rbsp, &pos);
-	rbs_ctrl(rbsp, option_seek_with_pop, value);
+	int value = rbs_ctrl(rbsp, OPTION_ALLOW_TO_DEQUEUE, 0);
+	ssize_t pos = 0;
+	result = aac_resync(rbsp, &pos);
+	rbs_ctrl(rbsp, OPTION_ALLOW_TO_DEQUEUE, value);
 
 	return result;
 }
 
 int _get_audio_type(rbstream_p rbsp)
 {
-	if (mp3_check_type(rbsp))
+	if (mp3_check_type(rbsp)) {
 		return type_mp3;
+	}
 
-	if (aac_check_type(rbsp))
+	if (aac_check_type(rbsp)) {
 		return type_aac;
+	}
 
 	return type_unknown;
 }
 
 bool _get_frame(pv_player_p player)
 {
-	if (player->audio_type == type_mp3)
-	{
+	if (player->audio_type == type_mp3) {
 		tPVMP3DecoderExternal *mp3_ext = (tPVMP3DecoderExternal *) player->dec_ext;
-		return mp3_get_frame(player->rbsp, &player->mCurrentPos, player->mFixedHeader,
-							(void*) mp3_ext->pInputBuffer, (uint32_t*) &mp3_ext->inputBufferCurrentLength);
-	}
-	else if (player->audio_type == type_aac)
-	{
+		return mp3_get_frame(player->rbsp, &player->mCurrentPos, player->mFixedHeader, (void *)mp3_ext->pInputBuffer, (uint32_t *)&mp3_ext->inputBufferCurrentLength);
+	} else if (player->audio_type == type_aac) {
 		tPVMP4AudioDecoderExternal *aac_ext = (tPVMP4AudioDecoderExternal *) player->dec_ext;
-		return aac_get_frame(player->rbsp, &player->mCurrentPos,
-				(void*) aac_ext->pInputBuffer, (uint32_t*) &aac_ext->inputBufferCurrentLength);
+		return aac_get_frame(player->rbsp, &player->mCurrentPos, (void *)aac_ext->pInputBuffer, (uint32_t *)&aac_ext->inputBufferCurrentLength);
 	}
 
-	PLAYER_ERROR("[%s] unsupported audio type: %d\n", __FUNCTION__, player->audio_type);
+	PLAYER_DEBUG("[%s] unsupported audio type: %d\n", __FUNCTION__, player->audio_type);
 	return false;
 }
 
 int _init_decoder(pv_player_p player)
 {
-	if (player->audio_type == type_mp3)
-	{
+	if (player->audio_type == type_mp3) {
 		player->dec_ext = calloc(1, sizeof(tPVMP3DecoderExternal));
 		RETURN_VAL_IF_FAIL((player->dec_ext != NULL), PV_FAILURE);
 
@@ -651,9 +619,7 @@ int _init_decoder(pv_player_p player)
 		player->mCurrentPos = 0;
 		bool ret = mp3_init(player->rbsp, &player->mCurrentPos, &player->mFixedHeader, &player->mSampleRate, &player->mNumChannels, &player->mBitrate);
 		RETURN_VAL_IF_FAIL((ret == true), PV_FAILURE);
-	}
-	else if (player->audio_type == type_aac)
-	{
+	} else if (player->audio_type == type_aac) {
 		player->dec_ext = calloc(1, sizeof(tPVMP4AudioDecoderExternal));
 		RETURN_VAL_IF_FAIL((player->dec_ext != NULL), PV_FAILURE);
 
@@ -662,8 +628,9 @@ int _init_decoder(pv_player_p player)
 
 		player->config_func(player->cb_data, player->audio_type, player->dec_ext);
 
+		PVMP4AudioDecoderResetBuffer(player->dec_mem);
 		Int err = PVMP4AudioDecoderInitLibrary(player->dec_ext, player->dec_mem);
-	    RETURN_VAL_IF_FAIL((err == MP4AUDEC_SUCCESS), PV_FAILURE);
+		RETURN_VAL_IF_FAIL((err == MP4AUDEC_SUCCESS), PV_FAILURE);
 
 		player->mCurrentPos = 0;
 		bool ret = aac_init(player->rbsp, &player->mCurrentPos);
@@ -675,10 +642,9 @@ int _init_decoder(pv_player_p player)
 
 int _frame_decoder(pv_player_p player, pcm_data_p pcm)
 {
-	if (player->audio_type == type_mp3)
-	{
-		tPVMP3DecoderExternal   tmp_ext = *((tPVMP3DecoderExternal *) player->dec_ext);
-		tPVMP3DecoderExternal * mp3_ext = &tmp_ext;
+	if (player->audio_type == type_mp3) {
+		tPVMP3DecoderExternal tmp_ext = *((tPVMP3DecoderExternal *) player->dec_ext);
+		tPVMP3DecoderExternal *mp3_ext = &tmp_ext;
 
 		mp3_ext->inputBufferUsedLength = 0;
 
@@ -690,15 +656,13 @@ int _frame_decoder(pv_player_p player, pcm_data_p pcm)
 		pcm->channels = player->mNumChannels;
 		pcm->samplerate = player->mSampleRate;
 		return PV_SUCCESS;
-	}
-	else if (player->audio_type == type_aac)
-	{
-		tPVMP4AudioDecoderExternal * aac_ext = (tPVMP4AudioDecoderExternal *) player->dec_ext;
+	} else if (player->audio_type == type_aac) {
+		tPVMP4AudioDecoderExternal *aac_ext = (tPVMP4AudioDecoderExternal *) player->dec_ext;
 
 		aac_ext->inputBufferUsedLength = 0;
 		aac_ext->remainderBits = 0;
 
-        Int decoderErr = PVMP4AudioDecodeFrame(aac_ext, player->dec_mem);
+		Int decoderErr = PVMP4AudioDecodeFrame(aac_ext, player->dec_mem);
 		RETURN_VAL_IF_FAIL((decoderErr == MP4AUDEC_SUCCESS), PV_FAILURE);
 
 		pcm->length = aac_ext->frameLength * aac_ext->desiredChannels;
@@ -713,7 +677,7 @@ int _frame_decoder(pv_player_p player, pcm_data_p pcm)
 
 static size_t _input_callback(void *data, rbstream_p rbsp)
 {
-	pv_player_p player = (pv_player_p)data;
+	pv_player_p player = (pv_player_p) data;
 	PLAYER_ASSERT(player != NULL);
 
 #if defined(PERFORMANCE_TEST)
@@ -727,13 +691,13 @@ static size_t _input_callback(void *data, rbstream_p rbsp)
 
 #if defined(PERFORMANCE_TEST)
 	gettimeofday(&tv2, NULL);
-	timems_input += (tv2.tv_sec*1000+tv2.tv_usec/1000) - (tv1.tv_sec*1000 + tv1.tv_usec/1000);
+	timems_input += (tv2.tv_sec * 1000 + tv2.tv_usec / 1000) - (tv1.tv_sec * 1000 + tv1.tv_usec / 1000);
 #endif
 
 	return wlen;
 }
 
-size_t pv_player_pushdata(pv_player_p player, const void* data, size_t len)
+size_t pv_player_pushdata(pv_player_p player, const void *data, size_t len)
 {
 	PLAYER_ASSERT(player != NULL);
 	PLAYER_ASSERT(data != NULL);
@@ -747,7 +711,6 @@ size_t pv_player_pushdata(pv_player_p player, const void* data, size_t len)
 	return len;
 }
 
-
 size_t pv_player_dataspace(pv_player_p player)
 {
 	PLAYER_ASSERT(player != NULL);
@@ -755,19 +718,12 @@ size_t pv_player_dataspace(pv_player_p player)
 	return rb_avail(&player->ringbuffer);
 }
 
-
 bool pv_player_dataspace_is_empty(pv_player_p player)
 {
 	return !rb_used(&player->ringbuffer);
 }
 
-
-int pv_player_init(pv_player_p player,
-					size_t rbuf_size,
-					void *user_data,
-					config_func_f config_func,
-					input_func_f input_func,
-					output_func_f output_func)
+int pv_player_init(pv_player_p player, size_t rbuf_size, void *user_data, config_func_f config_func, input_func_f input_func, output_func_f output_func)
 {
 	PLAYER_ASSERT(player != NULL);
 
@@ -778,8 +734,8 @@ int pv_player_init(pv_player_p player,
 	player->mBitrate = 0;
 
 	player->cb_data = user_data;
-	player->config_func	= config_func;
-	player->input_func	= input_func;
+	player->config_func = config_func;
+	player->input_func = input_func;
 	player->output_func = output_func;
 
 	player->dec_ext = NULL;
@@ -787,10 +743,10 @@ int pv_player_init(pv_player_p player,
 
 	// init ring-buffer and open it as a stream
 	rb_init(&player->ringbuffer, rbuf_size);
-	player->rbsp = rbs_open(&player->ringbuffer, _input_callback, (void*)player);
+	player->rbsp = rbs_open(&player->ringbuffer, _input_callback, (void *)player);
 	RETURN_VAL_IF_FAIL((player->rbsp != NULL), PV_FAILURE);
 
-	rbs_ctrl(player->rbsp, option_seek_with_pop, 1);
+	rbs_ctrl(player->rbsp, OPTION_ALLOW_TO_DEQUEUE, 1);
 	return PV_SUCCESS;
 }
 
@@ -846,36 +802,32 @@ int pv_player_run(pv_player_p player)
 	struct timeval tv1, tv2, tv3;
 #endif
 
-	while(_get_frame(player))
-	{
-		#if defined(PERFORMANCE_TEST)
-			gettimeofday(&tv1, NULL);
-		#endif
+	while (_get_frame(player)) {
+#if defined(PERFORMANCE_TEST)
+		gettimeofday(&tv1, NULL);
+#endif
 
 		pcm_data_t pcm;
-		if (0 == _frame_decoder(player, &pcm))
-		{	// pcm output
-			#if defined(PERFORMANCE_TEST)
-				gettimeofday(&tv2, NULL);
-				timems_decode += (tv2.tv_sec*1000+tv2.tv_usec/1000) - (tv1.tv_sec*1000 + tv1.tv_usec/1000);
-				samples_output += pcm.length;
-			#endif
+		if (0 == _frame_decoder(player, &pcm)) {
+#if defined(PERFORMANCE_TEST)
+			gettimeofday(&tv2, NULL);
+			timems_decode += (tv2.tv_sec * 1000 + tv2.tv_usec / 1000) - (tv1.tv_sec * 1000 + tv1.tv_usec / 1000);
+			samples_output += pcm.length;
+#endif
 
 			player->output_func(player->cb_data, player, &pcm);
 
-			#if defined(PERFORMANCE_TEST)
-				gettimeofday(&tv3, NULL);
-				timems_output += (tv3.tv_sec*1000+tv3.tv_usec/1000) - (tv2.tv_sec*1000 + tv2.tv_usec/1000);
-			#endif
+#if defined(PERFORMANCE_TEST)
+			gettimeofday(&tv3, NULL);
+			timems_output += (tv3.tv_sec * 1000 + tv3.tv_usec / 1000) - (tv2.tv_sec * 1000 + tv2.tv_usec / 1000);
+#endif
 		}
 	}
 
 #if defined(PERFORMANCE_TEST)
-	printf("[%s] finished! time: input %lu / output %lu / decoding %lu ms, samples: 0x%x\n", __FUNCTION__,
-			timems_input, timems_output, timems_decode, samples_output);
+	printf("[%s] finished! time: input %lu / output %lu / decoding %lu ms, samples: 0x%x\n", __FUNCTION__, timems_input, timems_output, timems_decode, samples_output);
 #endif
 
 	return PV_SUCCESS;
 }
-
 

--- a/external/audiocodec/streaming/rb.c
+++ b/external/audiocodec/streaming/rb.c
@@ -38,57 +38,58 @@
  */
 static void _incr(rb_p rbp, volatile size_t *p_idx, size_t len);
 
-
 bool rb_init(rb_p rbp, size_t size)
 {
-    RETURN_VAL_IF_FAIL(rbp != NULL, false);
-    RETURN_VAL_IF_FAIL(size < MSB_MASK, false);
+	RETURN_VAL_IF_FAIL(rbp != NULL, false);
+	RETURN_VAL_IF_FAIL(size < MSB_MASK, false);
 
-    rbp->buf    = calloc(size, 1);
-    rbp->depth  = size;
-    rbp->rd_idx = 0;
-    rbp->wr_idx = 0;
+	rbp->buf = calloc(size, 1);
+	rbp->depth = size;
+	rbp->rd_idx = 0;
+	rbp->wr_idx = 0;
 
-    return (rbp->buf != NULL);
+	return (rbp->buf != NULL);
 }
 
 void rb_free(rb_p rbp)
 {
-    RETURN_IF_FAIL(rbp != NULL);
+	RETURN_IF_FAIL(rbp != NULL);
 
-    RETURN_IF_FAIL(rbp->buf != NULL);
-    free(rbp->buf);
-    rbp->buf = NULL;
+	RETURN_IF_FAIL(rbp->buf != NULL);
+	free(rbp->buf);
+	rbp->buf = NULL;
 }
 
 #if 0
 void rb_clear(rb_p rbp)
 {
-    RETURN_IF_FAIL(rbp != NULL);
-    rbp->rd_idx = 0;
-    rbp->wr_idx = 0;
+	RETURN_IF_FAIL(rbp != NULL);
+	rbp->rd_idx = 0;
+	rbp->wr_idx = 0;
 }
 #endif
 
 size_t rb_used(rb_p rbp)
 {
-    RETURN_VAL_IF_FAIL(rbp != NULL, 0);
+	RETURN_VAL_IF_FAIL(rbp != NULL, 0);
 
-    if (IS_EMPTY(rbp))
-        return 0;
+	if (IS_EMPTY(rbp)) {
+		return 0;
+	}
 
-    size_t wr_idx = (rbp->wr_idx & IDX_MASK);
-    size_t rd_idx = (rbp->rd_idx & IDX_MASK);
+	size_t wr_idx = (rbp->wr_idx & IDX_MASK);
+	size_t rd_idx = (rbp->rd_idx & IDX_MASK);
 
-	if (wr_idx > rd_idx)
+	if (wr_idx > rd_idx) {
 		return (wr_idx - rd_idx);
+	}
 
 	return (rbp->depth - (rd_idx - wr_idx));
 }
 
 size_t rb_avail(rb_p rbp)
 {
-    RETURN_VAL_IF_FAIL(rbp != NULL, 0);
+	RETURN_VAL_IF_FAIL(rbp != NULL, 0);
 	return (rbp->depth - rb_used(rbp));
 }
 
@@ -98,22 +99,20 @@ size_t rb_write(rb_p rbp, const void *ptr, size_t len)
 	RETURN_VAL_IF_FAIL(ptr != NULL, 0);
 
 	size_t avail = rb_avail(rbp);
-	if (len > avail)
-		len = avail;
+	len = MINIMUM(len, avail);
 
-    size_t wr_idx = (rbp->wr_idx & IDX_MASK);
+	size_t wr_idx = (rbp->wr_idx & IDX_MASK);
 	size_t len_contiguous = rbp->depth - wr_idx;
 
-	if (len > len_contiguous)
-	{
-		memcpy((void*)((uint8_t*)rbp->buf + wr_idx), ptr, len_contiguous);
-		memcpy(rbp->buf, (const void*)((const uint8_t*)ptr + len_contiguous), (len - len_contiguous));
+	if (len > len_contiguous) {
+		memcpy((void *)((uint8_t *) rbp->buf + wr_idx), ptr, len_contiguous);
+		memcpy(rbp->buf, (const void *)((const uint8_t *)ptr + len_contiguous), (len - len_contiguous));
+	} else {
+		memcpy((void *)((uint8_t *) rbp->buf + wr_idx), ptr, len);
 	}
-	else
-		memcpy((void*)((uint8_t*)rbp->buf + wr_idx), ptr, len);
 
-    _incr(rbp, &rbp->wr_idx, len);
-    return len;
+	_incr(rbp, &rbp->wr_idx, len);
+	return len;
 }
 
 size_t rb_read(rb_p rbp, void *ptr, size_t len)
@@ -122,7 +121,7 @@ size_t rb_read(rb_p rbp, void *ptr, size_t len)
 
 	len = rb_read_ext(rbp, ptr, len, 0);
 	_incr(rbp, &rbp->rd_idx, len);
-    return len;
+	return len;
 }
 
 size_t rb_read_ext(rb_p rbp, void *ptr, size_t len, size_t offset)
@@ -132,45 +131,40 @@ size_t rb_read_ext(rb_p rbp, void *ptr, size_t len, size_t offset)
 	size_t used = rb_used(rbp);
 	RETURN_VAL_IF_FAIL(offset < used, 0);
 
-	if (len > used - offset)
-		len = used - offset;
-	RETURN_VAL_IF_FAIL(len != 0, 0);
+	len = MINIMUM(len, (used - offset));
+	RETURN_VAL_IF_FAIL((len != 0), 0);
 
-	if (ptr != NULL)
-	{
+	if (ptr != NULL) {
 		// increase temp rd_idx
 		size_t rd_idx = rbp->rd_idx;
 		_incr(rbp, &rd_idx, offset);
 
 		// start to copy data
-	    rd_idx = (rd_idx & IDX_MASK);
+		rd_idx = (rd_idx & IDX_MASK);
 		size_t len_contiguous = rbp->depth - rd_idx;
 
-		if (len > len_contiguous)
-		{
-			memcpy(ptr, (void*)((uint8_t*)rbp->buf + rd_idx), len_contiguous);
-			memcpy((void*)((uint8_t*)ptr + len_contiguous), rbp->buf, (len - len_contiguous));
+		if (len > len_contiguous) {
+			memcpy(ptr, (void *)((uint8_t *) rbp->buf + rd_idx), len_contiguous);
+			memcpy((void *)((uint8_t *) ptr + len_contiguous), rbp->buf, (len - len_contiguous));
+		} else {
+			memcpy(ptr, (void *)((uint8_t *) rbp->buf + rd_idx), len);
 		}
-		else
-			memcpy(ptr, (void*)((uint8_t*)rbp->buf + rd_idx), len);
 	}
 
-    return len;
+	return len;
 }
 
 static void _incr(rb_p rbp, volatile size_t *p_idx, size_t len)
 {
-    size_t idx = *p_idx & IDX_MASK;
-    size_t msb = *p_idx & MSB_MASK;
+	size_t idx = *p_idx & IDX_MASK;
+	size_t msb = *p_idx & MSB_MASK;
 
 	idx += len;
-	if (idx >= rbp->depth)
-	{
-        msb ^= MSB_MASK;
-        idx -= rbp->depth;
+	if (idx >= rbp->depth) {
+		msb ^= MSB_MASK;
+		idx -= rbp->depth;
 	}
 
-    *p_idx = msb | idx;
+	*p_idx = msb | idx;
 }
-
 

--- a/external/audiocodec/streaming/rb.c
+++ b/external/audiocodec/streaming/rb.c
@@ -20,9 +20,8 @@
 #include <string.h>
 #include <assert.h>
 #include <stdio.h>
-#include "internal_defs.h"
-#include "debug.h"
 #include <audiocodec/streaming/rb.h>
+#include "internal_defs.h"
 
 #define IS_EMPTY(rbp) (rbp->rd_idx == rbp->wr_idx)
 #define IS_FULL(rbp) ((rbp->rd_idx & IDX_MASK) == (rbp->wr_idx & IDX_MASK) && (rbp->rd_idx & MSB_MASK) != (rbp->wr_idx & MSB_MASK))

--- a/external/audiocodec/streaming/rb.c
+++ b/external/audiocodec/streaming/rb.c
@@ -20,6 +20,7 @@
 #include <string.h>
 #include <assert.h>
 #include <stdio.h>
+#include <sys/types.h>
 #include <audiocodec/streaming/rb.h>
 #include "internal_defs.h"
 
@@ -42,7 +43,7 @@ bool rb_init(rb_p rbp, size_t size)
 	RETURN_VAL_IF_FAIL(rbp != NULL, false);
 	RETURN_VAL_IF_FAIL(size < MSB_MASK, false);
 
-	rbp->buf = calloc(size, 1);
+	rbp->buf = calloc(size, sizeof(uint8_t));
 	rbp->depth = size;
 	rbp->rd_idx = 0;
 	rbp->wr_idx = 0;
@@ -59,21 +60,12 @@ void rb_free(rb_p rbp)
 	rbp->buf = NULL;
 }
 
-#if 0
-void rb_clear(rb_p rbp)
-{
-	RETURN_IF_FAIL(rbp != NULL);
-	rbp->rd_idx = 0;
-	rbp->wr_idx = 0;
-}
-#endif
-
 size_t rb_used(rb_p rbp)
 {
-	RETURN_VAL_IF_FAIL(rbp != NULL, 0);
+	RETURN_VAL_IF_FAIL(rbp != NULL, SIZE_ZERO);
 
 	if (IS_EMPTY(rbp)) {
-		return 0;
+		return SIZE_ZERO;
 	}
 
 	size_t wr_idx = (rbp->wr_idx & IDX_MASK);
@@ -88,25 +80,28 @@ size_t rb_used(rb_p rbp)
 
 size_t rb_avail(rb_p rbp)
 {
-	RETURN_VAL_IF_FAIL(rbp != NULL, 0);
+	RETURN_VAL_IF_FAIL(rbp != NULL, SIZE_ZERO);
 	return (rbp->depth - rb_used(rbp));
 }
 
 size_t rb_write(rb_p rbp, const void *ptr, size_t len)
 {
-	RETURN_VAL_IF_FAIL(rbp != NULL, 0);
-	RETURN_VAL_IF_FAIL(ptr != NULL, 0);
+	RETURN_VAL_IF_FAIL(rbp != NULL, SIZE_ZERO);
+	RETURN_VAL_IF_FAIL(ptr != NULL, SIZE_ZERO);
 
 	size_t avail = rb_avail(rbp);
 	len = MINIMUM(len, avail);
 
 	size_t wr_idx = (rbp->wr_idx & IDX_MASK);
-	size_t len_contiguous = rbp->depth - wr_idx;
+	size_t len_part = rbp->depth - wr_idx;
 
-	if (len > len_contiguous) {
-		memcpy((void *)((uint8_t *) rbp->buf + wr_idx), ptr, len_contiguous);
-		memcpy(rbp->buf, (const void *)((const uint8_t *)ptr + len_contiguous), (len - len_contiguous));
+	if (len > len_part) {
+		// First, write part of data into empty space in ring buffer based on write index,
+		memcpy((void *)((uint8_t *) rbp->buf + wr_idx), ptr, len_part);
+		// and then write remained data at the start of ring buffer.
+		memcpy(rbp->buf, (const void *)((const uint8_t *)ptr + len_part), (len - len_part));
 	} else {
+		// If there is enough space just write all data based on write index.
 		memcpy((void *)((uint8_t *) rbp->buf + wr_idx), ptr, len);
 	}
 
@@ -116,8 +111,9 @@ size_t rb_write(rb_p rbp, const void *ptr, size_t len)
 
 size_t rb_read(rb_p rbp, void *ptr, size_t len)
 {
-	RETURN_VAL_IF_FAIL(rbp != NULL, 0);
+	RETURN_VAL_IF_FAIL(rbp != NULL, SIZE_ZERO);
 
+	// Reuse rb_read_ext() with offset: 0
 	len = rb_read_ext(rbp, ptr, len, 0);
 	_incr(rbp, &rbp->rd_idx, len);
 	return len;
@@ -125,31 +121,37 @@ size_t rb_read(rb_p rbp, void *ptr, size_t len)
 
 size_t rb_read_ext(rb_p rbp, void *ptr, size_t len, size_t offset)
 {
-	RETURN_VAL_IF_FAIL(rbp != NULL, 0);
+	RETURN_VAL_IF_FAIL(rbp != NULL, SIZE_ZERO);
 
 	size_t used = rb_used(rbp);
-	RETURN_VAL_IF_FAIL(offset < used, 0);
+	RETURN_VAL_IF_FAIL(offset < used, SIZE_ZERO);
 
 	len = MINIMUM(len, (used - offset));
-	RETURN_VAL_IF_FAIL((len != 0), 0);
+	RETURN_VAL_IF_FAIL((len != SIZE_ZERO), SIZE_ZERO);
 
 	if (ptr != NULL) {
-		// increase temp rd_idx
+		// Increase temp rd_idx, to read data at the given offset.
 		size_t rd_idx = rbp->rd_idx;
 		_incr(rbp, &rd_idx, offset);
 
-		// start to copy data
+		// Calculate part length can be read based on temp read index
 		rd_idx = (rd_idx & IDX_MASK);
-		size_t len_contiguous = rbp->depth - rd_idx;
+		size_t len_part = rbp->depth - rd_idx;
 
-		if (len > len_contiguous) {
-			memcpy(ptr, (void *)((uint8_t *) rbp->buf + rd_idx), len_contiguous);
-			memcpy((void *)((uint8_t *) ptr + len_contiguous), rbp->buf, (len - len_contiguous));
+		// Start to read(copy) data
+		if (len > len_part) {
+			// First, read part of data from ring buffer based on temp read index,
+			memcpy(ptr, (void *)((uint8_t *) rbp->buf + rd_idx), len_part);
+			// and then read remained data at the start of buffer.
+			memcpy((void *)((uint8_t *) ptr + len_part), rbp->buf, (len - len_part));
 		} else {
+			// If there is enough data just read all based on temp read index.
 			memcpy(ptr, (void *)((uint8_t *) rbp->buf + rd_idx), len);
 		}
 	}
 
+	// Even if ptr is NULL(that means user don't need to get data),
+	// always return len of data (can be) read.
 	return len;
 }
 

--- a/external/audiocodec/streaming/rbs.c
+++ b/external/audiocodec/streaming/rbs.c
@@ -31,10 +31,13 @@
 #include "debug.h"
 #include <audiocodec/streaming/rbs.h>
 
-#define RBS_DEBUG 	audvdbg
-#define RBS_ERROR 	auddbg
-#define RBS_ASSERT 	ASSERT
-#define MINIMUM(x,y) (((x) < (y)) ? (x) : (y))
+#define RBS_DEBUG   audvdbg
+#define RBS_ERROR   auddbg
+#define RBS_ASSERT  MY_ASSERT
+
+#define RBS_OPTION_SET(rbsp, option)    (((rbstream_p)(rbsp))->options |= (option))
+#define RBS_OPTION_CLR(rbsp, option)    (((rbstream_p)(rbsp))->options &= ~(option))
+#define RBS_OPTION_TEST(rbsp, option)   ((((rbstream_p)(rbsp))->options & (option)) != 0)
 
 /**
  * @brief  Pull/Request more data from user, because there's not enough data in ring-buffer.
@@ -47,7 +50,7 @@
  */
 static size_t _pull(size_t size, size_t least, rbstream_p rbsp);
 
-rbstream_p rbs_open(rb_p rbp, rbstream_input_f input_func, void* data)
+rbstream_p rbs_open(rb_p rbp, rbstream_input_f input_func, void *data)
 {
 	RBS_DEBUG("[%s] rbp %p, input_func %p, data %p\n", __FUNCTION__, rbp, input_func, data);
 	RETURN_VAL_IF_FAIL(rbp != NULL, NULL);
@@ -59,7 +62,7 @@ rbstream_p rbs_open(rb_p rbp, rbstream_input_f input_func, void* data)
 	rbsp->options = 0;
 	rbsp->cur_pos = 0;
 	rbsp->rd_size = 0;
-	rbsp->wr_size = rb_used(rbp); // Allow to preset data in ring-buffer.
+	rbsp->wr_size = rb_used(rbp);   // Allow to preset data in ring-buffer.
 
 	rbsp->data = data;
 	rbsp->input_func = input_func;
@@ -77,7 +80,6 @@ int rbs_close(rbstream_p rbsp)
 	return 0;
 }
 
-// limitation: support size 1 only
 size_t rbs_read(void *ptr, size_t size, size_t nmemb, rbstream_p rbsp)
 {
 	RBS_DEBUG("[%s] ptr %p nmemb %lu\n", __FUNCTION__, ptr, nmemb);
@@ -91,12 +93,11 @@ size_t rbs_read(void *ptr, size_t size, size_t nmemb, rbstream_p rbsp)
 	size_t len = size * nmemb;
 	size_t rlen = rb_read_ext(rbsp->rbp, ptr, len, offset);
 
-	if (rlen < len)
-	{
+	if (rlen < len) {
 		size_t least = len - rlen;
 		size_t avail = rb_avail(rbsp->rbp);
-		if (least > avail)
-		{	// need pop data
+		if (least > avail) {
+			// need pop data
 			size_t _len = offset;
 			size_t _least = least - avail;
 			_len = MINIMUM(_len, _least);
@@ -106,21 +107,10 @@ size_t rbs_read(void *ptr, size_t size, size_t nmemb, rbstream_p rbsp)
 			// update offset
 			offset = rbsp->cur_pos - rbsp->rd_size;
 		}
-
 		// pull stream data, then it's available to read more.
 		_pull(rb_avail(rbsp->rbp), least, rbsp);
 		// read again
 		rlen = rb_read_ext(rbsp->rbp, ptr, len, offset);
-#if 0
-		if (rlen < len)
-		{
-			if (0 == rb_avail(rbsp->rbp))
-			{	// ring-buffer is full, can not accept more data.
-				RBS_ERROR("[%s] WARNING!!! ring-buffer is FULL !!!\n", __FUNCTION__);
-			}
-			// else no more data, do nothing.
-		}
-#endif
 	}
 
 	RBS_DEBUG("[%s] done, rlen %lu\n", __FUNCTION__, rlen);
@@ -129,8 +119,6 @@ size_t rbs_read(void *ptr, size_t size, size_t nmemb, rbstream_p rbsp)
 	return rlen;
 }
 
-// always write to stream end, not cur_pos!
-// rename to rbs_append ?
 size_t rbs_write(const void *ptr, size_t size, size_t nmemb, rbstream_p rbsp)
 {
 	RBS_DEBUG("[%s] ptr %p nmemb %lu\n", __FUNCTION__, ptr, nmemb);
@@ -156,38 +144,33 @@ int rbs_seek(rbstream_p rbsp, ssize_t offset, int whence)
 	RBS_DEBUG("[%s] offset %ld, whence %d\n", __FUNCTION__, offset, whence);
 	RETURN_VAL_IF_FAIL(rbsp != NULL, -1);
 
-	switch (whence)
-	{
+	switch (whence) {
 	case SEEK_SET:
 		// checking underflow
-		RETURN_VAL_IF_FAIL(((size_t)offset >= rbsp->rd_size), -1);
+		RETURN_VAL_IF_FAIL(((size_t) offset >= rbsp->rd_size), -1);
 
-		while ((size_t)offset > rbsp->wr_size)
-		{
-			size_t least = (size_t)offset - rbsp->wr_size;
+		while ((size_t) offset > rbsp->wr_size) {
+			size_t least = (size_t) offset - rbsp->wr_size;
 			size_t wlen;
 
 			// pull stream data, then wr_size will be increased
 			wlen = _pull(rb_avail(rbsp->rbp), least, rbsp);
 
-			if ((size_t)offset > rbsp->wr_size)
-			{	// not enough
-				if (0 == rb_avail(rbsp->rbp))
-				{	// ring-buffer is full
-					RETURN_VAL_IF_FAIL((0 != (rbsp->options & option_seek_with_pop)), -1); // overflow
+			if ((size_t) offset > rbsp->wr_size) {
+				// not enough
+				if (0 == rb_avail(rbsp->rbp)) {
+					// ring-buffer is full
+					RETURN_VAL_IF_FAIL((RBS_OPTION_TEST(rbsp, OPTION_ALLOW_TO_DEQUEUE)), -1); // overflow
 
-					// pop out all data in buffer and continue to request
-					RBS_DEBUG("[%s] ring-buffer is full, pop out data...\n", __FUNCTION__);
+					// dequeue minimal data from ring-buffer
 					size_t len = rbsp->wr_size - rbsp->rd_size;
-					least = (size_t)offset - rbsp->wr_size;
-					len = MINIMUM(len, least);	// pop minimal data, not all.
+					least = (size_t) offset - rbsp->wr_size;
+					len = MINIMUM(len, least);
 					size_t rlen = rb_read(rbsp->rbp, NULL, len);
 					RBS_ASSERT(rlen == len);
 					rbsp->rd_size += rlen;
-				}
-				else
-				{
-					RETURN_VAL_IF_FAIL((wlen != 0), -1);	// EOS
+				} else {
+					RETURN_VAL_IF_FAIL((wlen != 0), -1);    // EOS
 				}
 
 				// request more data
@@ -197,48 +180,37 @@ int rbs_seek(rbstream_p rbsp, ssize_t offset, int whence)
 			break;
 		}
 
-		rbsp->cur_pos = (size_t)offset;
+		rbsp->cur_pos = (size_t) offset;
 		break;
 
 #if 0
 	case SEEK_CUR:
 		// checking underflow
-		RETURN_VAL_IF_FAIL(((ssize_t)rbsp->cur_pos + offset >= (ssize_t)rbsp->rd_size), -1);
+		RETURN_VAL_IF_FAIL(((ssize_t) rbsp->cur_pos + offset >= (ssize_t) rbsp->rd_size), -1);
 
-		while ((ssize_t)rbsp->cur_pos + offset > (ssize_t)rbsp->wr_size)
-		{
-			size_t least = (ssize_t)rbsp->cur_pos + offset - (ssize_t)rbsp->wr_size;
+		while ((ssize_t) rbsp->cur_pos + offset > (ssize_t) rbsp->wr_size) {
+			size_t least = (ssize_t) rbsp->cur_pos + offset - (ssize_t) rbsp->wr_size;
 			size_t wlen;
 
 			// pull stream data, then wr_size will be increased
 			wlen = _pull(rb_avail(rbsp->rbp), least, rbsp);
 
-			if ((ssize_t)rbsp->cur_pos + offset > (ssize_t)rbsp->wr_size)
-			{	// not enough
-				if (0 == rb_avail(rbsp->rbp))
-				{	// ring-buffer is full
-					if (0 != (rbsp->options & option_seek_with_pop))
-					{	// pop out all data in buffer and continue to request
-						RBS_DEBUG("[%s] ring-buffer is full, pop out data...\n", __FUNCTION__);
-						size_t len = rbsp->wr_size - rbsp->rd_size;
-						least = (ssize_t)rbsp->cur_pos + offset - (ssize_t)rbsp->wr_size;
-						len = MINIMUM(len, least);	// pop minimal data, not all.
-						size_t rlen = rb_read(rbsp->rbp, NULL, len);
-						RBS_ASSERT(rlen == len);
-						rbsp->rd_size += rlen;
-					}
-					else
-					{
-						RBS_ERROR("[%s] OVERFLOW, SEEK_CUR invalid offset[%ld] > wr[%lu] - cur[%lu]\n", __FUNCTION__, offset, rbsp->wr_size, rbsp->cur_pos);
-						return -1;
-					}
-				}
-				else if (wlen == 0)
-				{	// EOS
-					RBS_ERROR("[%s] EOS, SEEK_CUR invalid offset[%ld] > wr[%lu] - cur[%lu]\n", __FUNCTION__, offset, rbsp->wr_size, rbsp->cur_pos);
-					return -1;
-				}
+			if ((ssize_t) rbsp->cur_pos + offset > (ssize_t) rbsp->wr_size) {
+				// not enough
+				if (0 == rb_avail(rbsp->rbp)) {
+					// ring-buffer is full
+					RETURN_VAL_IF_FAIL((RBS_OPTION_TEST(rbsp, OPTION_ALLOW_TO_DEQUEUE)), -1);
 
+					// dequeue minimal data from ring-buffer
+					size_t len = rbsp->wr_size - rbsp->rd_size;
+					least = (ssize_t) rbsp->cur_pos + offset - (ssize_t) rbsp->wr_size;
+					len = MINIMUM(len, least);
+					size_t rlen = rb_read(rbsp->rbp, NULL, len);
+					RBS_ASSERT(rlen == len);
+					rbsp->rd_size += rlen;
+				} else {
+					RETURN_VAL_IF_FAIL((wlen != 0), -1);	// EOS
+				}
 				// request more data
 				continue;
 			}
@@ -246,11 +218,11 @@ int rbs_seek(rbstream_p rbsp, ssize_t offset, int whence)
 			break;
 		}
 
-		rbsp->cur_pos = (size_t)((ssize_t)rbsp->cur_pos + offset);
+		rbsp->cur_pos = (size_t)((ssize_t) rbsp->cur_pos + offset);
 		break;
 
 	case SEEK_END:
-		rbsp->cur_pos = rbsp->wr_size; // seek end of ring buffer, not end of stream, as we don't know the end of stream.
+		rbsp->cur_pos = rbsp->wr_size;  // seek end of ring buffer, not end of stream, as we don't know the end of stream.
 		break;
 
 	default:
@@ -261,19 +233,21 @@ int rbs_seek(rbstream_p rbsp, ssize_t offset, int whence)
 	return 0;
 }
 
-// seek and pop out data from ring buffer
+// seek and dequeue data from ring-buffer
 int rbs_seek_ext(rbstream_p rbsp, ssize_t offset, int whence)
 {
 	RBS_DEBUG("[%s] offset %ld, whence %d\n", __FUNCTION__, offset, whence);
+	RBS_ASSERT(RBS_OPTION_TEST(rbsp, OPTION_ALLOW_TO_DEQUEUE));
 
+	// seek
 	int ret = rbs_seek(rbsp, offset, whence);
 	RETURN_VAL_IF_FAIL(ret == 0, ret);
 
-	// pop out from ring buffer
+	// dequeue data from ring-buffer
 	size_t len = rbsp->cur_pos - rbsp->rd_size;
 	size_t rlen = rb_read(rbsp->rbp, NULL, len);
 
-	RBS_ASSERT(rlen == len); // rbs_seek returned success!
+	RBS_ASSERT(rlen == len);    // rbs_seek returned success!
 	rbsp->rd_size += rlen;
 
 	return ret;
@@ -300,14 +274,14 @@ int rbs_ctrl(rbstream_p rbsp, int option, int value)
 
 	int ret = 0;
 
-	switch (option)
-	{
-	case option_seek_with_pop:
-		ret = ((rbsp->options & option_seek_with_pop) != 0);
-		if (value == 0)
-			rbsp->options &= ~option_seek_with_pop;
-		else
-			rbsp->options |= option_seek_with_pop;
+	switch (option) {
+	case OPTION_ALLOW_TO_DEQUEUE:
+		ret = RBS_OPTION_TEST(rbsp, OPTION_ALLOW_TO_DEQUEUE);
+		if (value == 0) {
+			RBS_OPTION_CLR(rbsp, option);
+		} else {
+			RBS_OPTION_SET(rbsp, option);
+		}
 		break;
 	}
 
@@ -321,21 +295,19 @@ static size_t _pull(size_t size, size_t least, rbstream_p rbsp)
 
 	RBS_DEBUG("[%s] size %lu, least %lu\n", __FUNCTION__, size, least);
 
-	if (least > size)
-	{	// Large size ring-buffer is needed or you should pop out read-data from ring-buffer in time.
+	if (least > size) {
+		// Large size ring-buffer is needed or you should dequeue read-data from ring-buffer in time.
 		RBS_DEBUG("[%s] WARNING!!! least[%lu] > size[%lu]\n", __FUNCTION__, least, size);
 		least = size;
-		RETURN_VAL_IF_FAIL(least > 0, 0); // ring-buffer is full.
+		RETURN_VAL_IF_FAIL(least > 0, 0);   // ring-buffer is full.
 	}
 
 	size_t wlen = 0;
 	size_t len;
 	do {
 		len = (rbsp->input_func)(rbsp->data, rbsp);
-		if (len == 0)
-		{
-			RBS_DEBUG("[%s] WARNING!!! no more data, wlen[%lu], least[%lu], size[%lu]\n",
-					__FUNCTION__, wlen, least, size);
+		if (len == 0) {
+			RBS_DEBUG("[%s] WARNING!!! no more data, wlen[%lu], least[%lu], size[%lu]\n", __FUNCTION__, wlen, least, size);
 			break;
 		}
 

--- a/external/include/audiocodec/streaming/player.h
+++ b/external/include/audiocodec/streaming/player.h
@@ -27,13 +27,36 @@
 extern "C" {
 #endif
 
+/**
+ * @brief Audio type detected by player from audio stream.
+ */
+enum audio_type_e {
+	AUDIO_TYPE_INVALID = 0,
+	AUDIO_TYPE_UNKNOWN = AUDIO_TYPE_INVALID,
+	AUDIO_TYPE_MP3 = 1,
+	AUDIO_TYPE_AAC = 2,
+
+	// add new type above.
+	AUDIO_TYPE_MAX
+};
+
+typedef enum audio_type_e audio_type_t;
+
+/**
+ * Deprecated, to be removed.
+ */
 enum {
-	type_unknown = 0,
-	type_mp3 = 1,
-	type_aac = 2,
+	type_unknown = AUDIO_TYPE_UNKNOWN,
+	type_mp3 = AUDIO_TYPE_MP3,
+	type_aac = AUDIO_TYPE_AAC,
 	type_max,
 };
 
+/**
+ * @struct  pcm_data_s
+ * @brief   Define PCM data output structure, inludes sample rate, channel number,
+ *          and samples buffer and count.
+ */
 struct pcm_data_s {
 	unsigned int samplerate;    /* sampling frequency (Hz) */
 	unsigned short channels;    /* number of channels */
@@ -44,6 +67,7 @@ struct pcm_data_s {
 typedef struct pcm_data_s pcm_data_t;
 typedef struct pcm_data_s *pcm_data_p;
 
+struct pv_player_s;
 typedef struct pv_player_s pv_player_t;
 typedef struct pv_player_s *pv_player_p;
 
@@ -78,6 +102,12 @@ typedef size_t(*input_func_f)(void *user_data, pv_player_p player);
  */
 typedef size_t(*output_func_f)(void *user_data, pv_player_p player, pcm_data_p pcm_dat);
 
+/**
+ * @struct  pv_player_s
+ * @brief   Player structure, support decoding various types of audio stream, see enum audio_type_e.
+ *          User should define and mantain player object in stack or heap, and give object pointer
+ *          to pv_player_init(), and specify input/output/config callback routines at the same time.
+ */
 struct pv_player_s {
 	int audio_type;             /* indicates the format of current audio stream, mp3 or aac */
 
@@ -95,12 +125,8 @@ struct pv_player_s {
 	rb_t ringbuffer;            /* ring-buffer object */
 	rbstream_p rbsp;            /* ring-buffer stream handle, co-work with above ring-buffer */
 
-	// internal varialbes, the same below
-	ssize_t mCurrentPos;        /* read position when decoding */
-	uint32_t mFixedHeader;      /* mp3 frame header */
-	uint32_t mSampleRate;       /* mp3 sample rate */
-	uint32_t mNumChannels;      /* mp3 sound channel, 1:mono, 2:stereo */
-	uint32_t mBitrate;          /* mp3 bit rate */
+	// private data
+	void *priv_data;            /* pointer to private data */
 };
 
 /**
@@ -170,7 +196,7 @@ int _init_decoder(pv_player_p player);
 int _frame_decoder(pv_player_p player, pcm_data_p pcm);
 
 #ifdef __cplusplus
-}
+} /* extern "C" */
 #endif
-#endif
+#endif /* STREAMING_PLAYER_H */
 

--- a/external/include/audiocodec/streaming/player.h
+++ b/external/include/audiocodec/streaming/player.h
@@ -23,7 +23,6 @@
 #include <audiocodec/mp3dec/pvmp3decoder_api.h>
 #include <audiocodec/aacdec/pvmp4audiodecoder_api.h>
 
-
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -35,18 +34,18 @@ enum {
 	type_max,
 };
 
-struct pcm_data {
-	unsigned int samplerate;		/* sampling frequency (Hz) */
-	unsigned short channels;		/* number of channels */
-	unsigned short length;			/* Size of the output frame in 16-bit words */
-	signed short * samples;			/* PCM output 16-bit samples, include both L/R ch for stereo case */
+struct pcm_data_s {
+	unsigned int samplerate;    /* sampling frequency (Hz) */
+	unsigned short channels;    /* number of channels */
+	unsigned short length;      /* number of the output samples in 16-bit words */
+	signed short *samples;      /* PCM output 16-bit samples, include both L/R ch for stereo case */
 };
 
-typedef struct pcm_data		pcm_data_t;
-typedef struct pcm_data *	pcm_data_p;
+typedef struct pcm_data_s pcm_data_t;
+typedef struct pcm_data_s *pcm_data_p;
 
-typedef struct pv_player   	pv_player_t;
-typedef struct pv_player * 	pv_player_p;
+typedef struct pv_player_s pv_player_t;
+typedef struct pv_player_s *pv_player_p;
 
 /**
  * @brief  configure callback routine type.
@@ -57,7 +56,7 @@ typedef struct pv_player * 	pv_player_p;
  *         according to certain audio_type.
  * @return 0 on success, otherwise, return -1.
  */
-typedef int (*config_func_f)(void * user_data, int audio_type, void * dec_cfg);
+typedef int (*config_func_f)(void *user_data, int audio_type, void *dec_cfg);
 
 /**
  * @brief  input callback routine type.
@@ -67,41 +66,41 @@ typedef int (*config_func_f)(void * user_data, int audio_type, void * dec_cfg);
  * @return size of audio data pushed to player via pv_player_pushdata().
  *         in case of return 0, that means end of stream, then decoding will be terminated.
  */
-typedef size_t (*input_func_f)(void * user_data, pv_player_p player);
+typedef size_t(*input_func_f)(void *user_data, pv_player_p player);
 
 /**
  * @brief  output callback routine type.
  *
  * @param  user_data: Pointer to user callback data register via pv_player_init()
  * @param  player: Pointer to player object
- * @param  pcm_dat: Pointer to an object of pcm_data structure, includes pcm informations.
+ * @param  pcm_dat: Pointer to an object of structure pcm_data_s.
  * @return value not be used now.
  */
-typedef size_t (*output_func_f)(void * user_data, pv_player_p player, pcm_data_p pcm_dat);
+typedef size_t(*output_func_f)(void *user_data, pv_player_p player, pcm_data_p pcm_dat);
 
-struct pv_player {
-	int audio_type; 				/* indicates the format of current audio stream, mp3 or aac */
+struct pv_player_s {
+	int audio_type;             /* indicates the format of current audio stream, mp3 or aac */
 
 	// decoder buffer
-	void  *dec_ext;					/* decoder external struct, configured by user via config_func_f */
-	void  *dec_mem;					/* decoder required memory, used internally */
+	void *dec_ext;              /* decoder external struct, configured by user via config_func_f */
+	void *dec_mem;              /* decoder required memory, used internally */
 
 	// user callback func and data
-	void *cb_data;					/* data ptr user registered, be passed to callback function. */
-	config_func_f	config_func;
-	input_func_f	input_func;		/* input callback, be called when decoder request more data. */
-	output_func_f  	output_func;	/* output callback, be called when decoder output PCM data. */
+	void *cb_data;              /* data ptr user registered, be passed to callback function. */
+	config_func_f config_func;
+	input_func_f input_func;    /* input callback, be called when decoder request more data. */
+	output_func_f output_func;  /* output callback, be called when decoder output PCM data. */
 
 	// internal member used by decoder
-	rb_t ringbuffer;				/* ring-buffer object */
-	rbstream_p rbsp;				/* ring-buffer stream handle, co-work with above ring-buffer */
+	rb_t ringbuffer;            /* ring-buffer object */
+	rbstream_p rbsp;            /* ring-buffer stream handle, co-work with above ring-buffer */
 
-	/* internal varialbes, the same below */
-	ssize_t	 mCurrentPos;			/* read position when decoding */
-	uint32_t mFixedHeader;			/* mp3 frame header */
-	uint32_t mSampleRate;			/* mp3 sample rate */
-	uint32_t mNumChannels;			/* mp3 sound channel, 1:mono, 2:stereo */
-	uint32_t mBitrate;				/* mp3 bit rate */
+	// internal varialbes, the same below
+	ssize_t mCurrentPos;        /* read position when decoding */
+	uint32_t mFixedHeader;      /* mp3 frame header */
+	uint32_t mSampleRate;       /* mp3 sample rate */
+	uint32_t mNumChannels;      /* mp3 sound channel, 1:mono, 2:stereo */
+	uint32_t mBitrate;          /* mp3 bit rate */
 };
 
 /**
@@ -147,7 +146,7 @@ int pv_player_run(pv_player_p player);
  * @param  len: size in bytes of audio source data contained in buffer.
  * @return size in bytes of data actually accepted by player.
  */
-size_t pv_player_pushdata(pv_player_p player, const void* data, size_t len);
+size_t pv_player_pushdata(pv_player_p player, const void *data, size_t len);
 
 /**
  * @brief  get free data space in player, which means the maximum of data to push.
@@ -173,6 +172,5 @@ int _frame_decoder(pv_player_p player, pcm_data_p pcm);
 #ifdef __cplusplus
 }
 #endif
-
 #endif
 

--- a/external/include/audiocodec/streaming/player.h
+++ b/external/include/audiocodec/streaming/player.h
@@ -190,10 +190,50 @@ size_t pv_player_dataspace(pv_player_p player);
  */
 bool pv_player_dataspace_is_empty(pv_player_p player);
 
+/**
+ * @brief  get audio type from audio stream.
+ *
+ * @param  player : Pointer to player object
+ * @return audio type enum value.
+ * @see    enum audio_type_e
+ */
+int pv_player_get_audio_type(pv_player_p player);
+
+/**
+ * @brief  initilize decoder after get audio type.
+ *         frame data is stored in player structure.
+ * @param  player : Pointer to player object
+ * @param  audio_type : specify the audio type of the input audio stream
+ *         you can get the type via pv_player_get_audio_type().
+ * @return 0 on success, -1 on failure.
+ * @see pv_player_get_audio_type()
+ */
+int pv_player_init_decoder(pv_player_p player, int audio_type);
+
+/**
+ * @brief  get audio frame from audio stream.
+ *         frame data is stored in player structure.
+ * @param  player : Pointer to player object
+ * @return true on success, and false on failure.
+ */
+bool pv_player_get_frame(pv_player_p player);
+
+/**
+ * @brief  decode audio frame and then output raw PCM samples(16bits format).
+ *
+ * @param  player : Pointer to player object
+ * @param  pcm : Pointer to pcm_data_s structure, contains output raw PCM samples.
+ * @return 0 on success, -1 on failure.
+ */
+int pv_player_frame_decode(pv_player_p player, pcm_data_p pcm);
+
+
+//{{ Deprecated
 int _get_audio_type(rbstream_p rbsp);
 bool _get_frame(pv_player_p player);
 int _init_decoder(pv_player_p player);
 int _frame_decoder(pv_player_p player, pcm_data_p pcm);
+//}}
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/external/include/audiocodec/streaming/rb.h
+++ b/external/include/audiocodec/streaming/rb.h
@@ -28,40 +28,36 @@ extern "C" {
 #endif
 
 #define IDX_MASK (SIZE_MAX>>1)
-#define MSB_MASK (~IDX_MASK)	/* also the maximum value of the buffer depth */
+#define MSB_MASK (~IDX_MASK)    /* also the maximum value of the buffer depth */
 
 /* ring buffer structure */
-struct rb {
-    void * buf;					/* pointer to the buffer allocated   */
-    size_t depth;				/* maximum size of the ring buffer   */
-    volatile size_t rd_idx;    	/* MSB is used for the 'mirror' flag */
-    volatile size_t wr_idx;   	/* MSB is used for the 'mirror' flag */
+struct rb_s {
+	void *buf;                  /* pointer to the buffer allocated   */
+	size_t depth;               /* maximum size of the ring buffer   */
+	volatile size_t rd_idx;     /* MSB is used for the 'mirror' flag */
+	volatile size_t wr_idx;     /* MSB is used for the 'mirror' flag */
 };
 
-typedef struct rb  rb_t;
-typedef struct rb* rb_p;
+typedef struct rb_s  rb_t;
+typedef struct rb_s *rb_p;
 
 /**
  * @brief  Initialize the ring-buffer. Allocate necessary memory for the buffer.
- *
  * @param  rbp : Pointer to the ring-buffer object
  * @param  size: Maximum size in bytes of the buffer
- * @return true : Succeeded
- *         false: Failed
+ * @return true on success, false on failure.
  */
-bool rb_init (rb_p rbp, size_t size);
+bool rb_init(rb_p rbp, size_t size);
 
 /**
  * @brief  Release the ring-buffer object. Deallocate the buffer memory.
- *
  * @param  rbp: Pointer to the ring-buffer object
  */
-void rb_free (rb_p rbp);
+void rb_free(rb_p rbp);
 
 #if 0
 /**
  * @brief  Clear the ring-buffer object.
- *
  * @param  rbp: Pointer to the ring-buffer object
  */
 void rb_clear(rb_p rbp);
@@ -72,7 +68,7 @@ void rb_clear(rb_p rbp);
  * @param  rbp   : Pointer to the ring-buffer object
  * @return num of data in bytes
  */
-size_t rb_used (rb_p rbp);
+size_t rb_used(rb_p rbp);
 
 /**
  * @brief  Get free space in bytes in the ring-buffer
@@ -83,23 +79,19 @@ size_t rb_avail(rb_p rbp);
 
 /**
  * @brief  Write new data to the ring-buffer.
- *
  * @param  rbp: Pointer to the ring-buffer object
  * @param  ptr: Pointer of the new data to be written to the buffer
  * @param  len: length of the data to be written
- *
  * @return size of data be written, range[0, len]
  */
 size_t rb_write(rb_p rbp, const void *ptr, size_t len);
 
 /**
  * @brief  Read from the ring-buffer header
- *
  * @param  rbp: Pointer to the ring-buffer object
  * @param  ptr: Pointer to the bufer saving read data
  *              in case of ptr NULL, just increase rd_idx.
  * @param  len: length of the data to be read
- *
  * @return size of data be read(or rd_idx increased), range[0, len]
  */
 size_t rb_read(rb_p rbp, void *ptr, size_t len);
@@ -107,12 +99,10 @@ size_t rb_read(rb_p rbp, void *ptr, size_t len);
 /**
  * @brief  Read from the ring-buffer at an offset position,
  *         rd_idx will not be increased.
- *
  * @param  rbp: Pointer to the ring-buffer object
  * @param  ptr: Pointer to the bufer saving read data
  * @param  len: length of the data to be read
  * @param  offset: offset from rd_idx started to read.
- *
  * @return size of data actually be read, range[0, len]
  */
 size_t rb_read_ext(rb_p rbp, void *ptr, size_t len, size_t offset);
@@ -120,6 +110,5 @@ size_t rb_read_ext(rb_p rbp, void *ptr, size_t len, size_t offset);
 #ifdef __cplusplus
 }
 #endif
-
 #endif
 

--- a/external/include/audiocodec/streaming/rb.h
+++ b/external/include/audiocodec/streaming/rb.h
@@ -55,14 +55,6 @@ bool rb_init(rb_p rbp, size_t size);
  */
 void rb_free(rb_p rbp);
 
-#if 0
-/**
- * @brief  Clear the ring-buffer object.
- * @param  rbp: Pointer to the ring-buffer object
- */
-void rb_clear(rb_p rbp);
-#endif
-
 /**
  * @brief  Get data bytes in the ring-buffer
  * @param  rbp   : Pointer to the ring-buffer object
@@ -93,6 +85,7 @@ size_t rb_write(rb_p rbp, const void *ptr, size_t len);
  *              in case of ptr NULL, just increase rd_idx.
  * @param  len: length of the data to be read
  * @return size of data be read(or rd_idx increased), range[0, len]
+ *         size rd_idx increased, in case of 'ptr' is NULL.
  */
 size_t rb_read(rb_p rbp, void *ptr, size_t len);
 
@@ -101,9 +94,11 @@ size_t rb_read(rb_p rbp, void *ptr, size_t len);
  *         rd_idx will not be increased.
  * @param  rbp: Pointer to the ring-buffer object
  * @param  ptr: Pointer to the bufer saving read data
+ *              in case of ptr NULL, do not really read data
  * @param  len: length of the data to be read
  * @param  offset: offset from rd_idx started to read.
- * @return size of data actually be read, range[0, len]
+ * @return size of data actually be read, range[0, len].
+ *         size of avaialbe data can be read, in case of 'ptr' is NULL.
  */
 size_t rb_read_ext(rb_p rbp, void *ptr, size_t len, size_t offset);
 

--- a/external/include/audiocodec/streaming/rbs.h
+++ b/external/include/audiocodec/streaming/rbs.h
@@ -51,7 +51,6 @@ extern "C" {
  	             |...........#################.............|
                   ------------------------------------------
 
-
      ~~~~~~~~~~~~~~~~~~~~~~~~#################,,,,,,,,,,,,,,,,,,,,,,,
      |                       |       |        |                     |
 POS: 0                     rd_size cur_pos wr_size              end of stream
@@ -64,23 +63,23 @@ POS: 0                     rd_size cur_pos wr_size              end of stream
 */
 
 enum {
-	option_seek_with_pop = 0x0001,	/* for seek overflow case, data in ring-buffer may be popped out */
+	OPTION_ALLOW_TO_DEQUEUE = 0x0001,    /* Allow to dequeue data form ring-buffer */
+	OPTION_MAX,
 };
 
-typedef struct rbstream   rbstream_t;
-typedef struct rbstream * rbstream_p;
+typedef struct rbstream_s  rbstream_t;
+typedef struct rbstream_s *rbstream_p;
 
-typedef size_t (*rbstream_input_f)(void *data, rbstream_p stream);
+typedef size_t(*rbstream_input_f)(void *data, rbstream_p stream);
 
-struct rbstream
-{
-	rb_p   rbp;						/* pointer to the ring-buffer object */
-	volatile size_t wr_size;		/* total size written to ring-buffer */
-	volatile size_t rd_size;		/* total size read from ring-buffer  */
-	volatile size_t cur_pos;		/* current read position, range[rd_size,wr_size] */
-	void* data;						/* callback data for user */
-	rbstream_input_f input_func;	/* callback function to request more data */
-	int	options;					/*  */
+struct rbstream_s {
+	rb_p rbp;                       /* pointer to the ring-buffer object */
+	volatile size_t wr_size;        /* total size written to ring-buffer */
+	volatile size_t rd_size;        /* total size read from ring-buffer  */
+	volatile size_t cur_pos;        /* current read position, range[rd_size,wr_size] */
+	void *data;                     /* callback data for user */
+	rbstream_input_f input_func;    /* callback function to request more data */
+	int options;                    /*  */
 };
 
 /**
@@ -91,7 +90,7 @@ struct rbstream
  * @param  data: ponter to user callback data
  * @return ring-buffer stream handle, NULL is returned when failed.
  */
-rbstream_p rbs_open(rb_p rbp, rbstream_input_f input_func, void* data);
+rbstream_p rbs_open(rb_p rbp, rbstream_input_f input_func, void *data);
 
 /**
  * @brief  Close ring-buffer stream returned by rbs_open().
@@ -181,6 +180,5 @@ int rbs_ctrl(rbstream_p stream, int option, int value);
 #ifdef __cplusplus
 }
 #endif
-
 #endif
 

--- a/external/include/audiocodec/streaming/rbs.h
+++ b/external/include/audiocodec/streaming/rbs.h
@@ -149,24 +149,6 @@ int rbs_seek(rbstream_p stream, ssize_t offset, int whence);
  */
 int rbs_seek_ext(rbstream_p stream, ssize_t offset, int whence);
 
-#if 0
-/**
- * @brief  Obtains the current read position indicator for the stream.
- *
- * @param  stream : Pointer to the ring-buffer stream
- * @return the current offset (cur_pos).
- */
-size_t rbs_tell(rbstream_p stream);
-
-/**
- * @brief  Obtains the head position of ring-buffer for the stream.
- *
- * @param  stream : Pointer to the ring-buffer stream
- * @return the head position(rd_size).
- */
-size_t rbs_tell_ext(rbstream_p stream);
-#endif
-
 /**
  * @brief  Set options
  *


### PR DESCRIPTION
@Taejun-Kwon @sunghan-chang 

1. Correct codeing rule, and clean code.
format code with os/tools/formatter.sh,
remove unused code,
define macros to replace constant values,
delete unnecessary fucntion params,
update descriptions of structure and interfaces.
2. Use media framework debug methods to print log.
3. Add below new interfaces of audiocodec/streaming/player:
// new added ...
int pv_player_get_audio_type(pv_player_p player);
int pv_player_init_decoder(pv_player_p player, int audio_type);
bool pv_player_get_frame(pv_player_p player);
int pv_player_frame_decode(pv_player_p player, pcm_data_p pcm);
// to replace ...
int _get_audio_type(rbstream_p rbsp);
bool _get_frame(pv_player_p player);
int _init_decoder(pv_player_p player);
int _frame_decoder(pv_player_p player, pcm_data_p pcm);
