### PR TITLE
examples/testcase/audio: Apply manual flag for testcase of audio

### DIFF
--- a/apps/examples/testcase/ta_tc/audio/itc/itc_audio_main.c
+++ b/apps/examples/testcase/ta_tc/audio/itc/itc_audio_main.c
@@ -1153,10 +1153,12 @@ int itc_audio_main(int argc, char *argv[])
 	itc_audio_pcm_bytes_to_frames_n();
 	itc_audio_pcm_format_to_bits_p();
 	itc_audio_pcm_format_to_bits_n();
+#ifndef CONFIG_DISABLE_MANUAL_TESTCASE
 	itc_audio_pcm_readi_p();
 	itc_audio_pcm_readi_n();
 	itc_audio_pcm_writei_p();
 	itc_audio_pcm_writei_n();
+#endif
 	/* after test, unlink the file */
 	unlink(AUDIO_TEST_FILE);
 

--- a/apps/examples/testcase/ta_tc/audio/utc/utc_audio_main.c
+++ b/apps/examples/testcase/ta_tc/audio/utc/utc_audio_main.c
@@ -1505,6 +1505,7 @@ int utc_audio_main(int argc, char *argv[])
 	utc_audio_pcm_bytes_to_frames_n();
 	utc_audio_pcm_format_to_bits_p();
 	utc_audio_pcm_format_to_bits_n();
+#ifndef CONFIG_DISABLE_MANUAL_TESTCASE
 	utc_audio_pcm_readi_p();
 	utc_audio_pcm_readi_n();
 
@@ -1513,7 +1514,6 @@ int utc_audio_main(int argc, char *argv[])
 	*/
 	utc_audio_pcm_writei_p();
 	utc_audio_pcm_drain_p();
-
 	utc_audio_pcm_writei_n();
 	utc_audio_pcm_drain_n();
 	utc_audio_pcm_drop_p();
@@ -1532,6 +1532,7 @@ int utc_audio_main(int argc, char *argv[])
 	utc_audio_pcm_commit_p();
 	utc_audio_pcm_mmap_read_p();
 	utc_audio_pcm_mmap_write_p();
+#endif
 
 	/* after test, unlink the file */
 	unlink(AUDIO_TEST_FILE);


### PR DESCRIPTION
Apply manual flag for manual testcase of audio framework 

List of Manual Testcase :
itc_audio_pcm_readi_p
itc_audio_pcm_readi_n
itc_audio_pcm_writei_p
itc_audio_pcm_writei_n
utc_audio_pcm_readi_p
utc_audio_pcm_readi_n
utc_audio_pcm_writei_p
utc_audio_pcm_drain_p
utc_audio_pcm_writei_n
utc_audio_pcm_drain_n
utc_audio_pcm_drop_p
utc_audio_pcm_drop_n
utc_audio_pcm_avail_update_n
utc_audio_pcm_wait_n
utc_audio_pcm_begin_n
utc_audio_pcm_commit_n
utc_audio_pcm_mmap_read_n
utc_audio_pcm_mmap_write_n
utc_audio_pcm_avail_update_p
utc_audio_pcm_wait_p
utc_audio_pcm_begin_p
utc_audio_pcm_commit_p
utc_audio_pcm_mmap_read_p
utc_audio_pcm_mmap_write_p

Signed-off-by: sri <sri@s.sa.corp.samsungelectronics.net>