### PR TITLE
media : add missing lock_guard for state

### DIFF
--- a/framework/src/media/MediaRecorderImpl.cpp
+++ b/framework/src/media/MediaRecorderImpl.cpp
@@ -231,12 +231,14 @@ recorder_result_t MediaRecorderImpl::setDataSource(std::unique_ptr<stream::Outpu
 
 recorder_state_t MediaRecorderImpl::getState()
 {
+	std::lock_guard<std::mutex> lock(mCmdMtx);
 	medvdbg("MediaRecorderImpl::getState()\n");
 	return mCurState;
 }
 
 void MediaRecorderImpl::setState(recorder_state_t state)
 {
+	std::lock_guard<std::mutex> lock(mCmdMtx);
 	medvdbg("MediaRecorderImpl::setState(recorder_state_t state)\n");
 	mCurState = state;
 }


### PR DESCRIPTION
On the user side, use mCurstate,
On the operator side, use getState and setState
so, synchronized using lock_guard for state

Signed-off-by: jaesick.shin <jaesick.shin@samsung.com>