### PR TITLE
media: Remove unused var in RecorderWorker

### DIFF
--- a/framework/src/media/RecorderWorker.cpp
+++ b/framework/src/media/RecorderWorker.cpp
@@ -19,7 +19,6 @@
 #include "RecorderWorker.h"
 
 namespace media {
-once_flag RecorderWorker::mOnceFlag;
 
 RecorderWorker::RecorderWorker() : mRefCnt(0)
 {

--- a/framework/src/media/RecorderWorker.h
+++ b/framework/src/media/RecorderWorker.h
@@ -58,7 +58,6 @@ private:
 	void decreaseRef();
 
 private:
-	static once_flag mOnceFlag;
 	int mRefCnt;
 	std::atomic<bool> mIsRunning;
 	std::thread mWorkerThread;


### PR DESCRIPTION
mOnceFlag is no longer used