### PR TITLE
external/curl: Fix variadic function warning

### DIFF
--- a/external/curl/Makefile
+++ b/external/curl/Makefile
@@ -52,7 +52,6 @@ OBJS		= $(AOBJS) $(COBJS)
 BIN		= ../libexternal$(LIBEXT)
 
 CFLAGS+= -D__TIZENRT__
-CFLAGS+= -Wno-error
 
 all: .built
 .PHONY: .depend depend clean distclean

--- a/external/curl/formdata.c
+++ b/external/curl/formdata.c
@@ -303,7 +303,7 @@ CURLFORMcode FormAdd(struct curl_httppost **httppost,
     }
     else {
       /* This is not array-state, get next option */
-      option = va_arg(params, CURLformoption);
+      option = va_arg(params, int);
       if(CURLFORM_END == option)
         break;
     }


### PR DESCRIPTION
@juitem , @sunghan-chang, @pillip8282, @bhargava-cs
Please review patch to fix curl warning

external/curl: Fix variadic function warning

    Enums are promoted to 'int' when passed through '...'
    va_arg function does not take enums as arguments.
    Also this being the only warning, "CFLAGS += -Wno-error" has been
    removed from MakeFile, in this commit.

    Logs:
    formdata.c: In function 'FormAdd':
    formdata.c:306:31: warning: 'CURLformoption {aka enum <anonymous>}' is promoted to 'int' when passed through '...'
       option = va_arg(params, CURLformoption);
                               ^
    formdata.c:306:31: note: (so you should pass 'int' not 'CURLformoption {aka enum <anonymous>}' to 'va_arg')
    formdata.c:306:31: note: if this code is reached, the program will abort