### PR TITLE
media: fix svace issues

### DIFF
--- a/apps/examples/mediaplayer/mediaplayer_main.cpp
+++ b/apps/examples/mediaplayer/mediaplayer_main.cpp
@@ -44,8 +44,14 @@ class MediaPlayerTest : public MediaPlayerObserverInterface, public enable_share
 
 	void start();
 
-	MediaPlayerTest() { cout << "App start" << endl; }
-	~MediaPlayerTest() { cout << "App terminate" << endl; }
+	MediaPlayerTest() : volume(0)
+	{
+		cout << "App start" << endl;
+	}
+	~MediaPlayerTest() 
+	{
+		cout << "App terminate" << endl;
+	}
 
   private:
 	void printMenu();

--- a/apps/examples/mediarecorder/mediarecorder_main.cpp
+++ b/apps/examples/mediarecorder/mediarecorder_main.cpp
@@ -119,13 +119,7 @@ public:
 		int num_read;
 		unsigned int size;
 
-		pcm_config.channels = 2;
-		pcm_config.rate = 16000;
-		pcm_config.format = PCM_FORMAT_S16_LE;
-		pcm_config.period_size = 1024;
-		pcm_config.period_count = 2;
-
-		p_out = pcm_open(0, 0, PCM_OUT, &pcm_config);
+		p_out = pcm_open(0, 0, PCM_OUT, &pcmConfig);
 
 		if (pcm_get_file_descriptor(p_out) < 0) {
 			printf("pcm open fail\n%s\n", pcm_get_error(p_out));
@@ -136,6 +130,15 @@ public:
 		buffer = (char *)malloc(size);
 
 		fd = open("/ramfs/record", O_RDONLY);
+
+		if (fd < 0) {
+			printf("file open fail : %d\n", fd);
+			free(buffer);
+			buffer = NULL;
+			pcm_close(p_out);
+			p_out = NULL;
+			return;
+		}
 
 		printf("fd = %d\n", fd);
 
@@ -199,15 +202,21 @@ public:
 		return input;
 	}
 
-	MediaRecorderTest() {}
+	MediaRecorderTest() : p_out(nullptr), appRunning(false) 
+	{
+		pcmConfig.channels = 2;
+		pcmConfig.rate = 16000;
+		pcmConfig.format = PCM_FORMAT_S16_LE;
+		pcmConfig.period_size = 1024;
+		pcmConfig.period_count = 2;
+	}
 	~MediaRecorderTest() {}
 
 private:
+	struct pcm_config pcmConfig;
 	struct pcm *p_out;
-	struct pcm_config pcm_config;
-
-	MediaRecorder mr;
 	bool appRunning;
+	MediaRecorder mr;
 };
 
 extern "C"

--- a/framework/src/media/FileOutputDataSource.cpp
+++ b/framework/src/media/FileOutputDataSource.cpp
@@ -23,7 +23,7 @@
 namespace media {
 namespace stream {
 
-FileOutputDataSource::FileOutputDataSource(const std::string& dataPath) 
+FileOutputDataSource::FileOutputDataSource(const std::string& dataPath)
 	: OutputDataSource(), mDataPath(dataPath), mFp(nullptr)
 {	
 }
@@ -33,7 +33,8 @@ FileOutputDataSource::FileOutputDataSource(unsigned short channels, unsigned int
 {
 }
 
-FileOutputDataSource::FileOutputDataSource(const FileOutputDataSource& source) : OutputDataSource(source)
+FileOutputDataSource::FileOutputDataSource(const FileOutputDataSource& source) : 
+	OutputDataSource(source), mDataPath(source.mDataPath), mFp(source.mFp)
 {
 }
 

--- a/framework/src/media/InputDataSource.cpp
+++ b/framework/src/media/InputDataSource.cpp
@@ -23,12 +23,12 @@ namespace media {
 namespace stream {
 
 InputDataSource::InputDataSource()
-	: DataSource()
+	: DataSource(), mAudioType(utils::AUDIO_TYPE_INVALID)
 {
 }
 
 InputDataSource::InputDataSource(const InputDataSource& source)
-	: DataSource(source)
+	: DataSource(source), mAudioType(source.mAudioType)
 {
 
 }

--- a/framework/src/media/MediaPlayerImpl.cpp
+++ b/framework/src/media/MediaPlayerImpl.cpp
@@ -29,6 +29,7 @@ MediaPlayerImpl::MediaPlayerImpl()
 	mPlayerObserver = nullptr;
 	mCurState = PLAYER_STATE_NONE;
 	mBuffer = nullptr;
+	mBufSize = 0;
 	mInputDataSource = nullptr;
 
 	static int playerId = 1;
@@ -107,6 +108,11 @@ player_result_t MediaPlayerImpl::prepare()
 	}
 
 	mBufSize = get_output_frames_byte_size(get_output_frame_count());
+	if (mBufSize < 0) {
+		meddbg("MediaPlayer prepare fail : get_output_frames_byte_size fail\n");
+		return PLAYER_ERROR;
+	}
+
 	medvdbg("MediaPlayer mBuffer size : %d\n", mBufSize);
 
 	mBuffer = new unsigned char[mBufSize];

--- a/framework/src/media/MediaPlayerImpl.h
+++ b/framework/src/media/MediaPlayerImpl.h
@@ -79,7 +79,7 @@ public:
 public:
 	std::atomic<player_state_t> mCurState;
 	unsigned char* mBuffer;
-	unsigned int mBufSize;
+	int mBufSize;
 	std::mutex mCmdMtx;
 	std::condition_variable mSyncCv;
 	std::shared_ptr<MediaPlayerObserverInterface> mPlayerObserver;

--- a/framework/src/media/MediaRecorderImpl.cpp
+++ b/framework/src/media/MediaRecorderImpl.cpp
@@ -108,6 +108,14 @@ recorder_result_t MediaRecorderImpl::prepare()
 	}
 
 	mBuffSize = get_input_frames_byte_size(get_input_frame_count());
+
+	if (mBuffSize < 0) {
+		meddbg("MediaRecorderImpl::prepare() - get_input_frames_byte_size(get_input_frame_count()) failed\n");
+		return RECORDER_ERROR;
+	}
+
+	medvdbg("MediaRecorder mBuffer size : %d\n", mBufSize);
+
 	mBuffer = new unsigned char[mBuffSize];
 	if (!mBuffer) {
 		meddbg("MediaRecorderImpl::prepare() - mBuffer alloc failed\n");

--- a/framework/src/media/MediaRecorderImpl.h
+++ b/framework/src/media/MediaRecorderImpl.h
@@ -93,7 +93,7 @@ private:
 	std::shared_ptr<MediaRecorderObserverInterface> mRecorderObserver;
 
 	unsigned char* mBuffer;
-	unsigned int mBuffSize;
+	int mBuffSize;
 	mutex mCmdMtx; // command mutex
 	std::condition_variable mSyncCv;
 	int mId;

--- a/framework/src/media/PlayerObserverWorker.cpp
+++ b/framework/src/media/PlayerObserverWorker.cpp
@@ -21,7 +21,7 @@
 #include "PlayerObserverWorker.h"
 
 namespace media {
-PlayerObserverWorker::PlayerObserverWorker() : mRefCnt{0}
+PlayerObserverWorker::PlayerObserverWorker() : mRefCnt{0}, mIsRunning(false)
 {
 }
 

--- a/framework/src/media/PlayerWorker.cpp
+++ b/framework/src/media/PlayerWorker.cpp
@@ -26,7 +26,7 @@
 using namespace std;
 
 namespace media {
-PlayerWorker::PlayerWorker() : mRefCnt{0}
+PlayerWorker::PlayerWorker() : mRefCnt(0), mIsRunning(false)
 {
 }
 
@@ -47,7 +47,7 @@ int PlayerWorker::entry()
 			shared_ptr<Decoder> mDecoder = mCurPlayer->mInputDataSource->getDecoder();
 			if (mDecoder) {
 				size_t num_read = mCurPlayer->mInputDataSource->read(mCurPlayer->mBuffer,
-					(mCurPlayer->mBufSize < mDecoder->getAvailSpace()) ?
+					((size_t)mCurPlayer->mBufSize < mDecoder->getAvailSpace()) ?
 						mCurPlayer->mBufSize : mDecoder->getAvailSpace());
 				medvdbg("MediaPlayer Worker(has mDecoder) : num_read = %d\n", num_read);
 

--- a/framework/src/media/RecorderObserverWorker.cpp
+++ b/framework/src/media/RecorderObserverWorker.cpp
@@ -21,7 +21,7 @@
 namespace media {
 once_flag RecorderObserverWorker::mOnceFlag;
 
-RecorderObserverWorker::RecorderObserverWorker() : mRefCnt(0)
+RecorderObserverWorker::RecorderObserverWorker() : mRefCnt(0), mIsRunning(false)
 {
 }
 RecorderObserverWorker::~RecorderObserverWorker()

--- a/framework/src/media/RecorderWorker.cpp
+++ b/framework/src/media/RecorderWorker.cpp
@@ -20,7 +20,7 @@
 
 namespace media {
 
-RecorderWorker::RecorderWorker() : mRefCnt(0)
+RecorderWorker::RecorderWorker() : mRefCnt(0), mIsRunning(false)
 {
 	medvdbg("RecorderWorker::RecorderWorker()\n");
 }


### PR DESCRIPTION
fix svace issuse for media
fix WGID numbers
218000	do not initialize class member variables
217922	do not checking the file open status
217938	do not initialize class members
217932	different return type
217933	different return type
217939	do not initialize class member variables
218001	do not initialize class member variables
218002	do not initialize class member variables
218004	do not initialize class member variables
218005	do not initialize class member variables
218006	do not initialize class member variables
218007	do not initialize class member variables
218008	do not initialize class member variables
218009	do not initialize class member variables
218010	do not initialize class member variables


Signed-off-by: jaesick.shin <jaesick.shin@samsung.com>