### PR TITLE
init/os_bringup: Add return value check when creating app init task

### DIFF
--- a/os/kernel/init/os_bringup.c
+++ b/os/kernel/init/os_bringup.c
@@ -257,6 +257,9 @@ static inline void os_do_appstart(void)
 #else
 	pid = task_create("appinit", SCHED_PRIORITY_DEFAULT, CONFIG_SYSTEM_PREAPP_STACKSIZE, preapp_start, (FAR char *const *)NULL);
 #endif
+	if (pid < 0) {
+		svdbg("Failed to create application init thread\n");
+	}
 #endif
 
 #ifdef CONFIG_TASK_MANAGER


### PR DESCRIPTION
WID:5130364 Return value of a function 'task_create' called at os_bringup.c:255 is not checked, but it is usually checked for this function (6/7).