### PR TITLE
media: bug fix for log in media recorder

### DIFF
--- a/framework/src/media/MediaRecorderImpl.cpp
+++ b/framework/src/media/MediaRecorderImpl.cpp
@@ -114,7 +114,7 @@ recorder_result_t MediaRecorderImpl::prepare()
 		return RECORDER_ERROR;
 	}
 
-	medvdbg("MediaRecorder mBuffer size : %d\n", mBufSize);
+	medvdbg("MediaRecorder mBuffer size : %d\n", mBuffSize);
 
 	mBuffer = new unsigned char[mBuffSize];
 	if (!mBuffer) {


### PR DESCRIPTION
used a variable with the wrong name

Signed-off-by: jaesick.shin <jaesick.shin@samsung.com>