### PR TITLE
external/curl: Increase stack size to 8K

### DIFF
--- a/external/curl/curl_threads.h
+++ b/external/curl/curl_threads.h
@@ -28,10 +28,12 @@
 #  define curl_mutex_t           pthread_mutex_t
 #  define curl_thread_t          pthread_t *
 #  define curl_thread_t_null     (pthread_t *)0
+#  define curl_attr_t            pthread_attr_t
 #  define Curl_mutex_init(m)     pthread_mutex_init(m, NULL)
 #  define Curl_mutex_acquire(m)  pthread_mutex_lock(m)
 #  define Curl_mutex_release(m)  pthread_mutex_unlock(m)
 #  define Curl_mutex_destroy(m)  pthread_mutex_destroy(m)
+#  define CURL_STACKSIZE         8192
 #elif defined(USE_THREADS_WIN32)
 #  define CURL_STDCALL           __stdcall
 #  define curl_mutex_t           CRITICAL_SECTION


### PR DESCRIPTION
@juitem , @sunghan-chang, @pillip8282, @bhargava-cs
Please review Curl-assert fix patch

    Pthread created by curl for address resolution, needed a minimum stack
    size of 4000 bytes. But only 2000 bytes were allocated, leading to assert.
    Updated pthread stacksize to 4096 bytes in this commit.