### PR TITLE
fs/vfs: Fix negative errno set

### DIFF
--- a/os/fs/vfs/fs_open.c
+++ b/os/fs/vfs/fs_open.c
@@ -164,7 +164,7 @@ int open(const char *path, int oflags, ...)
 		/* Get the file descriptor of the opened character driver proxy */
 		fd = block_proxy(path, oflags);
 		if (fd < 0) {
-			ret = fd;
+			ret = -fd;
 			goto errout;
 		}
 


### PR DESCRIPTION
Fixes setting of negative errno in fs_open.

This patch is back ported from Nuttx.

Signed-off-by: Lokesh B V <lokesh.bv@partner.samsung.com>