### PR TITLE
Replace clock_systimer() with clock() API

### DIFF
--- a/apps/examples/kernel_sample/workqueue.c
+++ b/apps/examples/kernel_sample/workqueue.c
@@ -36,7 +36,7 @@
  * Private Data
  ****************************************************************************/
 
-static systime_t start_time;
+static clock_t start_time;
 
 /****************************************************************************
  * Private Functions
@@ -44,32 +44,32 @@ static systime_t start_time;
 
 static void wq_test1(FAR void *arg)
 {
-	systime_t cur_time = 0;
-	cur_time = clock_systimer();
+	clock_t cur_time = 0;
+	cur_time = clock();
 
 	printf("workqueue_test: test 1 requested delay is (%u) ticks, executed delay is (%llu) ticks.\n", (uint32_t)arg, (uint64_t)cur_time - (uint64_t)start_time);
 }
 
 static void wq_test2(FAR void *arg)
 {
-	systime_t cur_time = 0;
-	cur_time = clock_systimer();
+	clock_t cur_time = 0;
+	cur_time = clock();
 
 	printf("workqueue_test: test 2 requested delay is (%u) ticks, executed delay is (%llu) ticks.\n", (uint32_t)arg, (uint64_t)cur_time - (uint64_t)start_time);
 }
 
 static void wq_test3(FAR void *arg)
 {
-	systime_t cur_time = 0;
-	cur_time = clock_systimer();
+	clock_t cur_time = 0;
+	cur_time = clock();
 
 	printf("workqueue_test: test 3 requested delay is (%u) ticks, executed delay is (%llu) ticks.\n", (uint32_t)arg, (uint64_t)cur_time - (uint64_t)start_time);
 }
 
 static void wq_test4(FAR void *arg)
 {
-	systime_t cur_time = 0;
-	cur_time = clock_systimer();
+	clock_t cur_time = 0;
+	cur_time = clock();
 
 	printf("workqueue_test: test 4 requested delay is (%u) ticks, executed delay is (%llu) ticks.\n", (uint32_t)arg, (uint64_t)cur_time - (uint64_t)start_time);
 }
@@ -94,7 +94,7 @@ int workqueue_test(void)
 	test_wq3 = (struct work_s *)malloc(sizeof(struct work_s));
 	test_wq4 = (struct work_s *)malloc(sizeof(struct work_s));
 
-	start_time = clock_systimer();
+	start_time = clock();
 
 	printf("workqueue_test: test1 is queued and will excute it after 50 ticks\n");
 	work_queue(HPWORK, test_wq1, wq_test1, (void *)50, 50);

--- a/apps/examples/testcase/le_tc/kernel/tc_clock.c
+++ b/apps/examples/testcase/le_tc/kernel/tc_clock.c
@@ -179,25 +179,6 @@ static void tc_clock_clock_timer(void)
 #endif
 
 /**
-* @fn                   :tc_clock_clock_systimer
-* @brief                :Return the current value of the 32 bit system timer counter
-* @scenario             :Return the current value of the 32 bit system timer counter
-* API's covered         :clock_systimer
-* Preconditions         :none
-* Postconditions        :none
-* @return               :void
-*/
-
-static void tc_clock_clock_systimer(void)
-{
-	systime_t itime = ERROR;
-	itime = clock_systimer();
-	TC_ASSERT_GEQ("clock_systimer", itime, 0);
-
-	TC_SUCCESS_RESULT();
-}
-
-/**
 * @fn                   :tc_clock_clock_abstime2ticks
 * @brief                :Convert an absolute timespec to ticks
 * @scenario             :Compare two conversions to ticks with some calculation
@@ -239,7 +220,6 @@ int clock_main(void)
 #ifndef CONFIG_SCHED_TICKLESS
 	tc_clock_clock_timer();
 #endif
-	tc_clock_clock_systimer();
 	tc_clock_clock_gettimeofday();
 	tc_clock_clock_set_get_time();
 	tc_clock_clock_getres();

--- a/apps/examples/testcase/le_tc/kernel/tc_semaphore.c
+++ b/apps/examples/testcase/le_tc/kernel/tc_semaphore.c
@@ -422,7 +422,7 @@ static void tc_semaphore_sem_tickwait(void)
 	ret_chk = clock_gettime(CLOCK_REALTIME, &abstime);
 	TC_ASSERT_EQ("clock_gettime", ret_chk, OK);
 
-	ret_chk = sem_tickwait(&sem, clock_systimer(), SEC_2);
+	ret_chk = sem_tickwait(&sem, (systime_t)clock(), SEC_2);
 	TC_ASSERT_EQ("sem_tickwait", ret_chk, OK);
 
 	ret_chk = clock_gettime(CLOCK_REALTIME, &curtime);
@@ -442,13 +442,13 @@ static void tc_semaphore_sem_tickwait(void)
 
 	/* expired time test */
 
-	ret_chk = sem_tickwait(&sem, clock_systimer() - SEC_2, 0);
+	ret_chk = sem_tickwait(&sem, (systime_t)clock() - SEC_2, 0);
 	TC_ASSERT_EQ("sem_tickwait", ret_chk, ERROR);
 
-	ret_chk = sem_tickwait(&sem, clock_systimer() - SEC_2, 1);
+	ret_chk = sem_tickwait(&sem, (systime_t)clock() - SEC_2, 1);
 	TC_ASSERT_EQ("sem_tickwait", ret_chk, ERROR);
 
-	ret_chk = sem_tickwait(&sem, clock_systimer() - SEC_2, 3);
+	ret_chk = sem_tickwait(&sem, (systime_t)clock() - SEC_2, 3);
 	TC_ASSERT_EQ("sem_tickwait", ret_chk, ERROR);
 
 	ret_chk = sem_destroy(&sem);

--- a/apps/examples/testcase/le_tc/kernel/tc_wqueue.c
+++ b/apps/examples/testcase/le_tc/kernel/tc_wqueue.c
@@ -37,29 +37,29 @@
 * Private Variables
 **************************************************************************/
 
-static systime_t start_time;
+static clock_t start_time;
 
 /**************************************************************************
 * Private Functions
 **************************************************************************/
 static void wq_test1(void *arg)
 {
-	systime_t cur_time = 0;
-	cur_time = clock_systimer();
+	clock_t cur_time = 0;
+	cur_time = clock();
 	printf("workqueue_test 1 : test 1 requested delay is (%u) ticks, executed delay is (%llu) ticks.\n", (uint32_t)arg, (uint64_t)cur_time - (uint64_t)start_time);
 }
 
 static void wq_test2(void *arg)
 {
-	systime_t cur_time = 0;
-	cur_time = clock_systimer();
+	clock_t cur_time = 0;
+	cur_time = clock();
 	printf("workqueue_test 2 : test 2 requested delay is (%u) ticks, executed delay is (%llu) ticks.\n", (uint32_t)arg, (uint64_t)cur_time - (uint64_t)start_time);
 }
 
 static void wq_test3(void *arg)
 {
-	systime_t cur_time = 0;
-	cur_time = clock_systimer();
+	clock_t cur_time = 0;
+	cur_time = clock();
 	printf("workqueue_test 3 : test 3 requested delay is (%u) ticks, executed delay is (%llu) ticks.\n", (uint32_t)arg, (uint64_t)cur_time - (uint64_t)start_time);
 }
 /**************************************************************************
@@ -77,7 +77,7 @@ static void tc_wqueue_work_queue_cancel(void)
 	test_work2 = (struct work_s *)malloc(sizeof(struct work_s));
 	test_work3 = (struct work_s *)malloc(sizeof(struct work_s));
 
-	start_time = clock_systimer();
+	start_time = clock();
 
 	printf("workqueue_test: test1 is queued and will excute it after 50 ticks\n");
 	result = work_queue(HPWORK, test_work1, wq_test1, (void *)50, 50);

--- a/apps/system/utils/kdbg_stackmonitor.c
+++ b/apps/system/utils/kdbg_stackmonitor.c
@@ -116,9 +116,9 @@ static void stkmon_inactive_check(void)
 	for (inactive_idx = 0; inactive_idx < CONFIG_MAX_TASKS * 2; inactive_idx++) {
 		if (stkmon_arr[inactive_idx].timestamp != 0) {
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
-			printf("%5d | %8s | %8d | %10d | %10d | %7lld | ", stkmon_arr[inactive_idx].chk_pid, "INACTIVE", stkmon_arr[inactive_idx].chk_stksize, stkmon_arr[inactive_idx].chk_peaksize, stkmon_arr[inactive_idx].chk_peakheap, (uint64_t)((systime_t)stkmon_arr[inactive_idx].timestamp));
+			printf("%5d | %8s | %8d | %10d | %10d | %7lld | ", stkmon_arr[inactive_idx].chk_pid, "INACTIVE", stkmon_arr[inactive_idx].chk_stksize, stkmon_arr[inactive_idx].chk_peaksize, stkmon_arr[inactive_idx].chk_peakheap, (uint64_t)((clock_t)stkmon_arr[inactive_idx].timestamp));
 #else
-			printf("%5d | %8s | %8d | %10d | %10lld | ", stkmon_arr[inactive_idx].chk_pid, "INACTIVE", stkmon_arr[inactive_idx].chk_stksize, stkmon_arr[inactive_idx].chk_peaksize, (uint64_t)((systime_t)stkmon_arr[inactive_idx].timestamp));
+			printf("%5d | %8s | %8d | %10d | %10lld | ", stkmon_arr[inactive_idx].chk_pid, "INACTIVE", stkmon_arr[inactive_idx].chk_stksize, stkmon_arr[inactive_idx].chk_peaksize, (uint64_t)((clock_t)stkmon_arr[inactive_idx].timestamp));
 #endif
 #if (CONFIG_TASK_NAME_SIZE > 0)
 			printf("%s\n", stkmon_arr[inactive_idx].chk_name);
@@ -137,9 +137,9 @@ static void stkmon_active_check(struct tcb_s *tcb, void *arg)
 		tcb->stack_alloc_ptr = (void *)(g_idle_topstack - CONFIG_IDLETHREAD_STACKSIZE);
 	}
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
-	printf("%5d | %8s | %8d | %10d | %10d | %7lld | ", tcb->pid, "ACTIVE", tcb->adj_stack_size, up_check_tcbstack(tcb), tcb->peak_alloc_size, (uint64_t)((systime_t)clock_systimer()));
+	printf("%5d | %8s | %8d | %10d | %10d | %7lld | ", tcb->pid, "ACTIVE", tcb->adj_stack_size, up_check_tcbstack(tcb), tcb->peak_alloc_size, (uint64_t)((clock_t)clock()));
 #else
-	printf("%5d | %8s | %8d | %10d | %10lld | ", tcb->pid, "ACTIVE", tcb->adj_stack_size, up_check_tcbstack(tcb), (uint64_t)((systime_t)clock_systimer()));
+	printf("%5d | %8s | %8d | %10d | %10lld | ", tcb->pid, "ACTIVE", tcb->adj_stack_size, up_check_tcbstack(tcb), (uint64_t)((clock_t)clock()));
 #endif
 #if (CONFIG_TASK_NAME_SIZE > 0)
 	printf("%s\n", tcb->name);
@@ -203,7 +203,7 @@ void stkmon_logging(struct tcb_s *tcb)
 #if (CONFIG_TASK_NAME_SIZE > 0)
 	int name_idx;
 #endif
-	stkmon_arr[stkmon_chk_idx % (CONFIG_MAX_TASKS * 2)].timestamp = clock_systimer();
+	stkmon_arr[stkmon_chk_idx % (CONFIG_MAX_TASKS * 2)].timestamp = clock();
 	stkmon_arr[stkmon_chk_idx % (CONFIG_MAX_TASKS * 2)].chk_pid = tcb->pid;
 	stkmon_arr[stkmon_chk_idx % (CONFIG_MAX_TASKS * 2)].chk_stksize = tcb->adj_stack_size;
 	stkmon_arr[stkmon_chk_idx % (CONFIG_MAX_TASKS * 2)].chk_peaksize = up_check_tcbstack(tcb);

--- a/apps/system/utils/kdbg_uptime.c
+++ b/apps/system/utils/kdbg_uptime.c
@@ -23,7 +23,7 @@
 
 int kdbg_uptime(int argc, char **args)
 {
-	systime_t ticktime;
+	clock_t ticktime;
 #if defined(CONFIG_HAVE_DOUBLE) && defined(CONFIG_LIBC_FLOATINGPOINT)
 	double now;
 #else
@@ -35,7 +35,7 @@ int kdbg_uptime(int argc, char **args)
 	unsigned int csec;
 #endif
 
-	ticktime = clock_systimer();
+	ticktime = clock();
 
 #if defined(CONFIG_HAVE_DOUBLE) && defined(CONFIG_LIBC_FLOATINGPOINT)
 	now = (double)ticktime / (double)CLOCKS_PER_SEC;

--- a/apps/system/utils/kdbg_utils.h
+++ b/apps/system/utils/kdbg_utils.h
@@ -25,7 +25,7 @@
 #include <sys/types.h>
 
 struct stkmon_save_s {
-	systime_t timestamp;
+	clock_t timestamp;
 	pid_t chk_pid;
 	size_t chk_stksize;
 	size_t chk_peaksize;

--- a/lib/libc/wqueue/work_queue.c
+++ b/lib/libc/wqueue/work_queue.c
@@ -134,7 +134,7 @@ static int work_qqueue(FAR struct usr_wqueue_s *wqueue, FAR struct work_s *work,
 
 	/* Now, time-tag that entry and put it in the work queue. */
 
-	work->qtime = clock_systimer();	/* Time work queued */
+	work->qtime = (systime_t)clock();	/* Time work queued */
 
 	dq_addlast((FAR dq_entry_t *)work, &wqueue->q);
 	kill(wqueue->pid, SIGWORK);	/* Wake up the worker thread */

--- a/lib/libc/wqueue/work_usrthread.c
+++ b/lib/libc/wqueue/work_usrthread.c
@@ -139,10 +139,10 @@ void work_process(FAR struct usr_wqueue_s *wqueue)
 	volatile FAR struct work_s *work;
 	worker_t worker;
 	FAR void *arg;
-	systime_t elapsed;
+	clock_t elapsed;
 	uint32_t remaining;
-	systime_t stick;
-	systime_t ctick;
+	clock_t stick;
+	clock_t ctick;
 	uint32_t next;
 	int ret;
 
@@ -160,7 +160,7 @@ void work_process(FAR struct usr_wqueue_s *wqueue)
 
 	/* Get the time that we started this polling cycle in clock ticks. */
 
-	stick = clock_systimer();
+	stick = clock();
 
 	/* And check each entry in the work queue.  Since we have locked the
 	 * work queue we know:  (1) we will not be suspended unless we do
@@ -175,7 +175,7 @@ void work_process(FAR struct usr_wqueue_s *wqueue)
 		 * zero.  Therefore a delay of zero will always execute immediately.
 		 */
 
-		ctick = clock_systimer();
+		ctick = clock();
 		elapsed = ctick - work->qtime;
 		if (elapsed >= work->delay) {
 			/* Remove the ready-to-execute work from the list */
@@ -261,7 +261,7 @@ void work_process(FAR struct usr_wqueue_s *wqueue)
 
 	/* Get the delay (in clock ticks) since we started the sampling */
 
-	elapsed = clock_systimer() - stick;
+	elapsed = clock() - stick;
 	if (elapsed < wqueue->delay && next > 0) {
 		/* How must time would we need to delay to get to the end of the
 		 * sampling period?  The amount of time we delay should be the smaller


### PR DESCRIPTION
As clock_systimer() is removed from syscall, all apps and lib's should use clock() API.
So clock_systimer() is replaced with clock() And tc for clock_systimer() is removed.

Signed-off-by: Lokesh B V <lokesh.bv@partner.samsung.com>