### PR TITLE
os/Kconfig.debug: make a dependancy between DEBUG and core module

### DIFF
--- a/os/Kconfig.debug
+++ b/os/Kconfig.debug
@@ -48,6 +48,7 @@ comment "Subsystem Debug Options"
 config DEBUG_ST_THINGS
 	bool "ST Things Debug Output"
 	default y
+	depends on ST_THINGS
 	---help---
 		Enable st things debug SYSLOG output (enabled by default)
 

--- a/os/Kconfig.debug
+++ b/os/Kconfig.debug
@@ -118,6 +118,7 @@ endif #DEBUG_FS
 config DEBUG_AUDIO
 	bool "Audio Debug Output"
 	default n
+	depends on AUDIO
 	---help---
 		Enable Audio debug SYSLOG output (disabled by default)
 


### PR DESCRIPTION
DEBUG output message is valid only when core module is enabled.
As of now, it shows debug always even though core is disabled.