### PR TITLE
media: Change unsafe string functions

### DIFF
--- a/os/audio/audio.c
+++ b/os/audio/audio.c
@@ -993,8 +993,8 @@ int audio_register(FAR const char *name, FAR struct audio_lowerhalf_s *dev)
 	/* Register the Audio device */
 
 	memset(path, 0, AUDIO_MAX_DEVICE_PATH);
-	strcpy(path, devname);
-	strcat(path, "/");
+	strncpy(path, devname, sizeof(path));
+	strncat(path, "/", strlen("/"));
 	strncat(path, name, AUDIO_MAX_DEVICE_PATH - 11);
 #endif
 


### PR DESCRIPTION
- strcpy and strcat are changed into strncpy and strncat, respectively.
- Major svace issues (WGID 217990, 217991) are fixed.