### PR TITLE
media: Modify samplerate value for resampler code coverage

### DIFF
--- a/apps/examples/testcase/ta_tc/media/utc/utc_media_player.cpp
+++ b/apps/examples/testcase/ta_tc/media/utc/utc_media_player.cpp
@@ -64,7 +64,7 @@ protected:
 		fclose(fp);
 		source = std::move(std::unique_ptr<media::stream::FileInputDataSource>(
 			new media::stream::FileInputDataSource(MEDIAPLAYER_TEST_FILE)));
-		source->setSampleRate(16000);
+		source->setSampleRate(20000);
 		source->setChannels(2);
 		mp = new media::MediaPlayer();
 	}


### PR DESCRIPTION
Most audio card doesn't support 20000hz. So if we deliver the sample rate as 20000hz,
device would open as 22050hz, and resampling logic is working to convert to 22050 from 20000.