### PR TITLE
framework/st_things : updates post request handling logic without mandatory attribute of resource.

### DIFF
--- a/framework/src/st_things/st_things_request_handler.c
+++ b/framework/src/st_things/st_things_request_handler.c
@@ -971,9 +971,9 @@ bool handle_post_req_helper(const char *res_uri, const char *query, OCRepPayload
 			break;
 		}
 
-		if (properties[index]->mandatory) {
+		if (!IS_WRITABLE(properties[index]->rw)) {
 			if (OCRepPayloadIsNull(req_payload, properties[index]->key)) {
-				THINGS_LOG_E(TAG, "Mandatory property (%s) is not present in the request.", properties[index]->key);
+				THINGS_LOG_E(TAG, "(%s) is not present in the request.", properties[index]->key);
 				res = false;
 				break;
 			}


### PR DESCRIPTION
Post handler can not when value is NULL and not writable.