### PR TITLE
.clang-format: Modify pointer alignment

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -19,6 +19,6 @@ SpaceBeforeAssignmentOperators: true #[M11]
 SpaceBeforeParens: ControlStatements
 TabWidth:        4 #[M08]
 UseTab:          Always #[M08]
-PointerAlignment: Left #[M13]
+PointerAlignment: Right
 SortIncludes: false
 ...


### PR DESCRIPTION
The asterisk can be placed adjacent to either the variable name