### PR TITLE
scripts: ota_img target paths fixed and scripts

### DIFF
--- a/build/configs/artik05x/artik05x_cmn.sh
+++ b/build/configs/artik05x/artik05x_cmn.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+###########################################################################
+#
+# Copyright 2018 Samsung Electronics All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+#
+###########################################################################
+#
+# File          : artik05x_cmn.sh
+# Description   : Common file for other *sh in directory
+
+set -e
+
+# Remember, make is invoked from "os" directory
+OS_DIR_PATH=${PWD}
+BUILD_DIR_PATH=${OS_DIR_PATH}/../build
+CONFIGS_DIR_PATH=${BUILD_DIR_PATH}/configs
+OUTPUT_BINARY_PATH=${BUILD_DIR_PATH}/output/bin
+ARTIK05X_DIR_PATH=${CONFIGS_DIR_PATH}/artik05x
+TIZENRT_BIN=$OUTPUT_BINARY_PATH/tinyara_head.bin
+CODESIGNER_TOOL=artik05x_AppCodesigner
+CODESIGNER_PATH=${ARTIK05X_DIR_PATH}/tools/codesigner
+CODESIGNER_DIR_PATH=${ARTIK05X_DIR_PATH}/tools/codesigner
+OPENOCD_DIR_PATH=${BUILD_DIR_PATH}/tools/openocd
+
+if [[ $CONFIG_HOST_OSX == 'y' ]]; then
+	OPENOCD_BIN_PATH=${OPENOCD_DIR_PATH}/macos
+	CODESIGNER_PATH=${CODESIGNER_DIR_PATH}/macos
+else
+	SYSTEM_TYPE=`getconf LONG_BIT`
+	if [ "$SYSTEM_TYPE" = "64" ]; then
+		OPENOCD_BIN_PATH=${OPENOCD_DIR_PATH}/linux64
+		CODESIGNER_PATH=${CODESIGNER_DIR_PATH}/linux64
+	else
+		OPENOCD_BIN_PATH=${OPENOCD_DIR_PATH}/linux32
+		CODESIGNER_PATH=${CODESIGNER_DIR_PATH}/linux32
+	fi
+fi
+OPENOCD=${OPENOCD_BIN_PATH}/openocd
+
+signing() {
+	if [ ! -f ${CODESIGNER_PATH}/${CODESIGNER_TOOL} ]; then
+		echo "${CODESIGNER_TOOL} should be in ${CODESIGNER_PATH} to use secure boards like ARTIK053S, ARTIK055S."
+		exit 1
+	fi
+
+	${CODESIGNER_PATH}/${CODESIGNER_TOOL} ${CODESIGNER_DIR_PATH}/rsa_private.key $TIZENRT_BIN
+	TIZENRT_BIN=${TIZENRT_BIN}-signed
+}
+
+

--- a/build/configs/artik05x/artik05x_download.sh
+++ b/build/configs/artik05x/artik05x_download.sh
@@ -20,36 +20,12 @@
 # File   : artik05x_download.sh
 # Description : Download script for ARTIK 05X
 
-# Remember, make is invoked from "os" directory
 source .config
-OS_DIR_PATH=${PWD}
-BUILD_DIR_PATH=${OS_DIR_PATH}/../build
-CONFIGS_DIR_PATH=${BUILD_DIR_PATH}/configs
-OUTPUT_BINARY_PATH=${BUILD_DIR_PATH}/output/bin
-OPENOCD_DIR_PATH=${BUILD_DIR_PATH}/tools/openocd
-ARTIK05X_DIR_PATH=${CONFIGS_DIR_PATH}/artik05x
+SCRIPT_DIR=$(dirname "${BASH_SOURCE[0]}")
+source $(dirname "${BASH_SOURCE[0]}")/artik05x_cmn.sh
 SCRIPTS_PATH=${ARTIK05X_DIR_PATH}/scripts
-CODESIGNER_DIR_PATH=${ARTIK05X_DIR_PATH}/tools/codesigner
-
-if [[ $CONFIG_HOST_OSX == 'y' ]]; then
-	OPENOCD_BIN_PATH=${OPENOCD_DIR_PATH}/macos
-	CODESIGNER_PATH=${CODESIGNER_DIR_PATH}/macos
-else
-	SYSTEM_TYPE=`getconf LONG_BIT`
-	if [ "$SYSTEM_TYPE" = "64" ]; then
-		OPENOCD_BIN_PATH=${OPENOCD_DIR_PATH}/linux64
-		CODESIGNER_PATH=${CODESIGNER_DIR_PATH}/linux64
-	else
-		OPENOCD_BIN_PATH=${OPENOCD_DIR_PATH}/linux32
-		CODESIGNER_PATH=${CODESIGNER_DIR_PATH}/linux32
-	fi
-fi
-OPENOCD=${OPENOCD_BIN_PATH}/openocd
 
 CFG_FILE=artik05x.cfg
-
-TIZENRT_BIN=$OUTPUT_BINARY_PATH/tinyara_head.bin
-CODESIGNER_TOOL=artik05x_AppCodesigner
 
 usage() {
 	cat <<EOF
@@ -230,16 +206,6 @@ erase()
 	pushd ${OPENOCD_DIR_PATH} > /dev/null
 	${OPENOCD} -f ${CFG_FILE} -s ${SCRIPTS_PATH} -c "flash_erase_part ${PART_NAME};	exit" || exit 1
 	popd > /dev/null
-}
-
-signing() {
-	if [ ! -f ${CODESIGNER_PATH}/${CODESIGNER_TOOL} ]; then
-		echo "${CODESIGNER_TOOL} should be in ${CODESIGNER_PATH} to use secure boards like ARTIK053S, ARTIK055S."
-		exit 1
-	fi
-
-	${CODESIGNER_PATH}/${CODESIGNER_TOOL} ${CODESIGNER_DIR_PATH}/rsa_private.key $TIZENRT_BIN
-	TIZENRT_BIN=${TIZENRT_BIN}-signed
 }
 
 if test $# -eq 0; then

--- a/build/configs/artik05x/artik05x_ota.sh
+++ b/build/configs/artik05x/artik05x_ota.sh
@@ -20,28 +20,10 @@
 # File   : artik05x_ota.sh
 # Description : Attach CRC and Signing in TizenRT Binary
 
-# Remember, make is invoked from "os" directory
-OS_DIR_PATH=${PWD}
-BUILD_DIR_PATH=${OS_DIR_PATH}/../build
-CONFIGS_DIR_PATH=${BUILD_DIR_PATH}/configs
-OUTPUT_BINARY_PATH=${BUILD_DIR_PATH}/output/bin
-ARTIK05X_DIR_PATH=${CONFIGS_DIR_PATH}/artik05x
-CODESIGNER_PATH=${ARTIK05X_DIR_PATH}/tools/codesigner
+SCRIPT_DIR=$(dirname "${BASH_SOURCE[0]}")
+source ../build/configs/artik05x/artik05x_cmn.sh
 TARGET_NAME=ota
 OUTPUT_BIN=$OUTPUT_BINARY_PATH/${TARGET_NAME}.bin
-
-TIZENRT_BIN=$OUTPUT_BINARY_PATH/tinyara_head.bin
-CODESIGNER_TOOL=artik05x_AppCodesigner
-
-signing() {
-    if [ ! -f ${CODESIGNER_PATH}/${CODESIGNER_TOOL} ]; then
-        echo "${CODESIGNER_TOOL} should be in ${CODESIGNER_PATH} to use secure boards like ARTIK053S, ARTIK055S."
-        exit 1
-    fi
-
-    ${CODESIGNER_PATH}/${CODESIGNER_TOOL} ${CODESIGNER_PATH}/rsa_private.key $TIZENRT_BIN
-    TIZENRT_BIN=${TIZENRT_BIN}-signed
-}
 
 make-target-bin() {
     local bin=


### PR DESCRIPTION
After fixing artik05x_download.sh directory pathing artik05x_ota.sh was
neglected, therefore common variables were unified and '-x' was added to
abort scripts on first error.