### PR TITLE
framework/st_things : separates object attribute handling logic as collection feature.

### DIFF
--- a/framework/include/st_things/st_things_types.h
+++ b/framework/include/st_things/st_things_types.h
@@ -265,6 +265,7 @@ typedef struct _st_things_representation {
 	*/
 	bool (*get_double_array_value)(struct _st_things_representation *rep, const char *key, double **array, size_t *length);
 
+#ifdef CONFIG_ST_THINGS_COLLECTION
 	/**
 	* @brief API for getting the value of object array type property with a key.
 	*
@@ -279,6 +280,7 @@ typedef struct _st_things_representation {
 	* @since TizenRT v1.1
 	*/
 	bool (*get_object_array_value)(struct _st_things_representation *rep, const char *key, struct _st_things_representation ***array, size_t *length);
+#endif
 
 	/**
 	* @brief API for setting the value of string array type property with a key.
@@ -322,6 +324,7 @@ typedef struct _st_things_representation {
 	*/
 	bool (*set_double_array_value)(struct _st_things_representation *rep, const char *key, const double *array, size_t length);
 
+#ifdef CONFIG_ST_THINGS_COLLECTION
 	/**
 	* @brief API for setting the value of object array type property with a key.
 	*
@@ -335,6 +338,7 @@ typedef struct _st_things_representation {
 	* @since TizenRT v1.1
 	*/
 	bool (*set_object_array_value)(struct _st_things_representation *rep, const char *key, const struct _st_things_representation **array, size_t length);
+#endif
 
 } st_things_representation_s;
 

--- a/framework/src/st_things/st_things_representation.c
+++ b/framework/src/st_things/st_things_representation.c
@@ -214,6 +214,7 @@ bool get_double_array_value(struct _st_things_representation *rep, const char *k
 	return ret;
 }
 
+#ifdef CONFIG_ST_THINGS_COLLECTION
 bool get_object_array_value(struct _st_things_representation *rep, const char *key, struct _st_things_representation ***array, size_t *length)
 {
 	RET_FALSE_IF_PARAM_IS_NULL(TAG, rep);
@@ -269,6 +270,7 @@ bool get_object_array_value(struct _st_things_representation *rep, const char *k
 	things_free(children);
 	return true;
 }
+#endif
 
 bool set_str_array_value(struct _st_things_representation *rep, const char *key, const char **array, size_t length)
 {
@@ -306,6 +308,7 @@ bool set_double_array_value(struct _st_things_representation *rep, const char *k
 	return OCRepPayloadSetDoubleArray(rep->payload, key, array, dimensions);
 }
 
+#ifdef CONFIG_ST_THINGS_COLLECTION
 bool set_object_array_value(struct _st_things_representation *rep, const char *key, const struct _st_things_representation **array, size_t length)
 {
 	RET_FALSE_IF_PARAM_IS_NULL(TAG, rep);
@@ -341,6 +344,7 @@ bool set_object_array_value(struct _st_things_representation *rep, const char *k
 
 	return res;
 }
+#endif
 
 st_things_representation_s *create_representation_inst_internal(OCRepPayload *payload)
 {
@@ -364,12 +368,16 @@ st_things_representation_s *create_representation_inst_internal(OCRepPayload *pa
 	rep->get_str_array_value = &get_str_array_value;
 	rep->get_int_array_value = &get_int_array_value;
 	rep->get_double_array_value = &get_double_array_value;
+#ifdef CONFIG_ST_THINGS_COLLECTION
 	rep->get_object_array_value = &get_object_array_value;
+#endif
 
 	rep->set_str_array_value = &set_str_array_value;
 	rep->set_int_array_value = &set_int_array_value;
 	rep->set_double_array_value = &set_double_array_value;
+#ifdef CONFIG_ST_THINGS_COLLECTION
 	rep->set_object_array_value = &set_object_array_value;
+#endif
 
 	if (NULL != payload) {
 		THINGS_LOG_D(TAG, "Setting the given payload in the representation.");


### PR DESCRIPTION
Regarding smart things resource model, there is no resource which it has object array attribute.
So, the object array attribute logic never used. Now.
But these codes will be able to use when collection resource feature is activated.
In this case, object array's elements will representated a child resource.