### PR TITLE
framework/task_manager: Fix dereferencing pointer

### DIFF
--- a/framework/include/task_manager/task_manager.h
+++ b/framework/include/task_manager/task_manager.h
@@ -75,6 +75,7 @@
 #define TM_FAIL_RESPONSE              (-11)
 #define TM_FAIL_UNREGISTER            (-12)
 #define TM_INVALID_PARAM              (-13)
+#define TM_OUT_OF_MEMORY              (-14)
 
 /**
  * @brief Task Info Structure


### PR DESCRIPTION
WID:5144327 After having been compared to NULL value at task_manager.c:412, pointer 'request_msg.data' is dereferenced at task_manager.c:264 by calling function 'strlen'.
WID:5144550 'return value of malloc(20)' may be null, and it is dereferenced at task_manager.c:279.