### PR TITLE
apps/st_things : rename GPIO config from iotbus to st_things

### DIFF
--- a/apps/examples/st_things/Kconfig
+++ b/apps/examples/st_things/Kconfig
@@ -50,10 +50,11 @@ config EXAMPLES_ST_THINGS_MSG_HANDLING
 	---help---
 		This is a Message handling Sample.
 
-config EXAMPLES_IOTBUS_TEST_RED_LED_GPIO_NUM
+config EXAMPLES_ST_THINGS_RED_LED_GPIO_NUM
 	int "GPIO number of RED LED"
 	default 45
-	depends on EXAMPLES_ST_THINGS_BLINK
+	---help---
+		This is a red led gpio num.
 endchoice
 endif
 

--- a/apps/examples/st_things/Kconfig
+++ b/apps/examples/st_things/Kconfig
@@ -23,6 +23,20 @@ config EXAMPLES_ST_THINGS_LIGHT
 	---help---
 		This is a Light Sample.
 
+config EXAMPLES_ST_THINGS_BLINK
+	bool "BLINK"
+	select IOTBUS_GPIO
+	---help---
+		This is a Blink Sample.
+
+config EXAMPLES_ST_THINGS_MSG_HANDLING
+	bool "Message Handling Example"
+	select IOTBUS_GPIO
+	---help---
+		This is a Message handling Sample.
+
+endchoice
+
 config RESET_BUTTON
 	bool "Reset_Button"
 	default y
@@ -38,24 +52,14 @@ config RESET_BUTTON_PIN_NUMBER
 		The default is the reset button pin number 44 for the ARTIK 053.
 		If you use another board, you can set the pin number for the board.
 
-config EXAMPLES_ST_THINGS_BLINK
-	bool "BLINK"
-	select IOTBUS_GPIO
-	---help---
-		This is a Blink Sample.
-
-config EXAMPLES_ST_THINGS_MSG_HANDLING
-	bool "Message Handling Example"
-	select IOTBUS_GPIO
-	---help---
-		This is a Message handling Sample.
 
 config EXAMPLES_ST_THINGS_RED_LED_GPIO_NUM
 	int "GPIO number of RED LED"
 	default 45
+	depends on EXAMPLES_ST_THINGS_BLINK
 	---help---
 		This is a red led gpio num.
-endchoice
+
 endif
 
 config USER_ENTRYPOINT

--- a/apps/examples/st_things/blink/blink.h
+++ b/apps/examples/st_things/blink/blink.h
@@ -21,11 +21,11 @@
 #include <tinyara/gpio.h>
 #include <iotbus/iotbus_gpio.h>
 
-#if !defined(CONFIG_EXAMPLES_IOTBUS_TEST_RED_LED_GPIO_NUM)
+#if !defined(CONFIG_EXAMPLES_ST_THINGS_RED_LED_GPIO_NUM)
 #error To run this sample, input GPIO numbers on menuconfig.
 #endif
 
-#define LED_POWER_PORT CONFIG_EXAMPLES_IOTBUS_TEST_RED_LED_GPIO_NUM
+#define LED_POWER_PORT CONFIG_EXAMPLES_ST_THINGS_RED_LED_GPIO_NUM
 
 const char *get_led_power(void);
 int set_led_power(char *value);


### PR DESCRIPTION
…nd EXAMPLES_IOTBUS_TEST.

Both features depends on EXAMPLES_IOTBUS_TEST_RED_LED_GPIO_NUM.
To solve this, EXAMPLES_IOTBUS_TEST_RED_LED_GPIO_NUM is changed to EXAMPLES_ST_THINGS_RED_LED_GPIO_NUM.