### PR TITLE
framework/st_things : Change manufacturerID to MNID and venderID to VID

### DIFF
--- a/apps/examples/st_things/blink/contents/device_def.json
+++ b/apps/examples/st_things/blink/contents/device_def.json
@@ -9,7 +9,7 @@
                 "dataModelVersion": "res.1.1.0"
             },
             "platform": {
-                "manufacturerName": "Test",
+                "MNID": "Test",
                 "manufacturerUrl": "http://www.samsung.com/sec/",
                 "manufacturingDate": "2018-04-26",
                 "modelNumber": "NWSP-01",
@@ -17,7 +17,7 @@
                 "osVersion": "1.0",
                 "hardwareVersion": "1.0",
                 "firmwareVersion": "1.0",
-                "vendorId": "SWC-BLINK-2018"
+                "VID": "SWC-BLINK-2018"
             }
           }, 
           "resources": {

--- a/apps/examples/st_things/light/contents/device_def.json
+++ b/apps/examples/st_things/light/contents/device_def.json
@@ -9,7 +9,7 @@
           "dataModelVersion": "res.1.1.0"
         },
         "platform": {
-          "manufacturerName": "xxxx",
+          "MNID": "xxxx",
           "manufacturerUrl": "http://www.samsung.com/sec/",
           "manufacturingDate": "2017-08-31",
           "modelNumber": "NWSP-01",
@@ -17,7 +17,7 @@
           "osVersion": "1.0",
           "hardwareVersion": "1.0",
           "firmwareVersion": "1.0",
-          "vendorId": "xxxx"
+          "VID": "xxxx"
         }
       },
       "resources": {

--- a/framework/src/st_things/things_stack/cloud/cloud_connector.c
+++ b/framework/src/st_things/things_stack/cloud/cloud_connector.c
@@ -673,7 +673,7 @@ static OCRepPayload *make_dev_profile_payload(const st_device_s *dev_info)
 	OCRepPayloadSetPropString(payload, "mnos", dev_info->ver_os);
 	OCRepPayloadSetPropString(payload, "mnhw", dev_info->ver_hw);
 	OCRepPayloadSetPropString(payload, "mnfv", dev_info->ver_fw);
-	OCRepPayloadSetPropString(payload, "vid", dev_info->vender_id);
+	OCRepPayloadSetPropString(payload, "vid", dev_info->vid);
 
 	THINGS_LOG_D(TAG, "di   = %s", dev_info->device_id);
 	THINGS_LOG_D(TAG, "n    = %s", dev_info->name);
@@ -686,7 +686,7 @@ static OCRepPayload *make_dev_profile_payload(const st_device_s *dev_info)
 	THINGS_LOG_D(TAG, "mnos = %s", dev_info->ver_os);
 	THINGS_LOG_D(TAG, "mnhw = %s", dev_info->ver_hw);
 	THINGS_LOG_D(TAG, "mnfv = %s", dev_info->ver_fw);
-	THINGS_LOG_D(TAG, "vid  = %s", dev_info->vender_id);
+	THINGS_LOG_D(TAG, "vid  = %s", dev_info->vid);
 
 	res = true;
 

--- a/framework/src/st_things/things_stack/framework/things_data_manager.c
+++ b/framework/src/st_things/things_stack/framework/things_data_manager.c
@@ -162,9 +162,9 @@ static char *g_model_number;
 static char *g_setup_id;
 static bool is_artik;
 static char g_easysetup_softap_ssid[MAX_SOFTAP_SSID + 1];
-static char *g_easysetup_softap_passphrase = "1111122222";
-static char *g_easysetup_tag = "E1";
-static int g_easysetup_softap_channel = 1;
+static const char *g_easysetup_softap_passphrase = "1111122222";
+static const char *g_easysetup_tag = "E1";
+static const int g_easysetup_softap_channel = 1;
 
 static int g_wifi_interface;
 static wifi_freq_e g_wifi_freq;

--- a/framework/src/st_things/things_stack/framework/things_data_manager.h
+++ b/framework/src/st_things/things_stack/framework/things_data_manager.h
@@ -69,7 +69,7 @@ typedef struct st_device_s {
 	int no;
 	char *type;
 	char *name;
-	char *manufacturer_name;
+	char *mnid;
 	char *manufacturer_url;
 	char *manufacturing_date;
 	char *model_num;
@@ -78,7 +78,7 @@ typedef struct st_device_s {
 	char *ver_hw;	// mnhw
 	char *ver_fw;	// mnfv
 	char *device_id;	// mnfv
-	char *vender_id;	// mnfv
+	char *vid;	// mnfv
 #ifdef CONFIG_ST_THINGS_COLLECTION
 	col_resource_s *collection;
 #endif


### PR DESCRIPTION
- The current manufacturerName is used as the MNID of the Samsung Account
VenderID is used as a VID.
Dev.Workspace has inconsistencies with the terms used in development.
Therefore, the manufactureName is MNID and the VenderID is VID.