### PR TITLE
lwip: removed unused netif flag for point to point connections

### DIFF
--- a/os/net/lwip/src/netif/ppp/ppp.c
+++ b/os/net/lwip/src/netif/ppp/ppp.c
@@ -1269,7 +1269,7 @@ static err_t pppifNetifInit(struct netif *netif)
 	netif->name[1] = 'p';
 	netif->output = pppifOutput;
 	netif->mtu = pppMTU((int)(size_t) netif->state);
-	netif->flags = NETIF_FLAG_POINTTOPOINT | NETIF_FLAG_LINK_UP;
+	netif->flags = NETIF_FLAG_LINK_UP;
 #if LWIP_NETIF_HOSTNAME
 	/* @todo: Initialize interface hostname */
 	/* netif_set_hostname(netif, "lwip"); */

--- a/os/net/lwip/src/netif/slipif.c
+++ b/os/net/lwip/src/netif/slipif.c
@@ -346,7 +346,6 @@ err_t slipif_init(struct netif *netif)
 
 	netif->output = slipif_output;
 	netif->mtu = SLIP_MAX_SIZE;
-	netif->flags |= NETIF_FLAG_POINTTOPOINT;
 
 	/* netif->state or netif->num contain the port number */
 	if (netif->state != NULL) {


### PR DESCRIPTION
NETIF_FLAG_POINTTOPOINT is deprecated from lwip 2.0.0 so removed it.
 - It can cause compilation error during build so, fix it.