### PR TITLE
media: Returns result of setObserver

### DIFF
--- a/framework/include/media/MediaPlayer.h
+++ b/framework/include/media/MediaPlayer.h
@@ -159,9 +159,10 @@ public:
 	 * @details @b #include <media/MediaPlayer.h>
 	 * This function is sync call apis
 	 * It sets the user's function
+	 * @return The result of the setObserver operation
 	 * @since TizenRT v2.0 PRE
 	 */
-	void setObserver(std::shared_ptr<MediaPlayerObserverInterface>);
+	player_result_t setObserver(std::shared_ptr<MediaPlayerObserverInterface>);
 	/**
 	 * @brief Gets the current state of MediaPlayer
 	 * @details @b #include <media/MediaPlayer.h>

--- a/framework/src/media/MediaPlayer.cpp
+++ b/framework/src/media/MediaPlayer.cpp
@@ -75,9 +75,9 @@ player_result_t MediaPlayer::setDataSource(std::unique_ptr<stream::InputDataSour
 	return mPMpImpl->setDataSource(std::move(source));
 }
 
-void MediaPlayer::setObserver(std::shared_ptr<MediaPlayerObserverInterface> observer)
+player_result_t MediaPlayer::setObserver(std::shared_ptr<MediaPlayerObserverInterface> observer)
 {
-	mPMpImpl->setObserver(observer);
+	return mPMpImpl->setObserver(observer);
 }
 
 player_result_t MediaPlayer::seekTo(int msec)

--- a/framework/src/media/MediaPlayerImpl.h
+++ b/framework/src/media/MediaPlayerImpl.h
@@ -66,7 +66,7 @@ public:
 	player_result_t setVolume(int);
 
 	player_result_t setDataSource(std::unique_ptr<stream::InputDataSource>);
-	void setObserver(std::shared_ptr<MediaPlayerObserverInterface>);
+	player_result_t setObserver(std::shared_ptr<MediaPlayerObserverInterface>);
 
 	player_state_t getState();
 	player_result_t seekTo(int);


### PR DESCRIPTION
If setObserver called before PlayerWorker creation, setObserver returns
PLAYER_ERROR