### PR TITLE
libc/mutex: Modify the initialization for mutex attr robust

### DIFF
--- a/lib/libc/pthread/pthread_mutexattrinit.c
+++ b/lib/libc/pthread/pthread_mutexattrinit.c
@@ -119,7 +119,7 @@ int pthread_mutexattr_init(FAR pthread_mutexattr_t *attr)
 		attr->type = PTHREAD_MUTEX_DEFAULT;
 #endif
 
-#ifdef CONFIG_PTHREAD_MUTEX_BOTH
+#ifndef CONFIG_PTHREAD_MUTEX_UNSAFE
 #ifdef CONFIG_PTHREAD_MUTEX_DEFAULT_UNSAFE
 		attr->robust  = PTHREAD_MUTEX_STALLED;
 #else


### PR DESCRIPTION
if CONFIG_PTHREAD_MUTEX_UNSAFE is not enabled, pthread_mutexattrinit doesn't initialize the robust member.
So make initialization for robust to PTHREAD_MUTEX_ROBUST