### PR TITLE
media: Remove no effect macro

### DIFF
--- a/apps/examples/testcase/ta_tc/audio/utc/utc_audio_main.c
+++ b/apps/examples/testcase/ta_tc/audio/utc/utc_audio_main.c
@@ -1182,7 +1182,6 @@ static void utc_audio_pcm_begin_p(void)
 	ret = pcm_mmap_begin(g_pcm, (void **)&areas, &offset, &frames);
 	TC_ASSERT_EQ_CLEANUP("pcm_mmap_begin", ret, 0, pcm_close(g_pcm));
 	TC_ASSERT_NEQ_CLEANUP("pcm_mmap_begin", areas, NULL, pcm_close(g_pcm));
-	TC_ASSERT_GEQ_CLEANUP("pcm_mmap_begin", offset, 0, pcm_close(g_pcm));
 	TC_ASSERT_GT_CLEANUP("pcm_mmap_begin", frames, 0, pcm_close(g_pcm));
 	pcm_close(g_pcm);
 
@@ -1192,7 +1191,6 @@ static void utc_audio_pcm_begin_p(void)
 	ret = pcm_mmap_begin(g_pcm, (void **)&areas, &offset, &frames);
 	TC_ASSERT_EQ_CLEANUP("pcm_mmap_begin", ret, 0, pcm_close(g_pcm));
 	TC_ASSERT_NEQ_CLEANUP("pcm_mmap_begin", areas, NULL, pcm_close(g_pcm));
-	TC_ASSERT_GEQ_CLEANUP("pcm_mmap_begin", offset, 0, pcm_close(g_pcm));
 	TC_ASSERT_GT_CLEANUP("pcm_mmap_begin", frames, 0, pcm_close(g_pcm));
 	pcm_close(g_pcm);
 
@@ -1255,7 +1253,6 @@ static void utc_audio_pcm_commit_p(void)
 	ret = pcm_mmap_begin(g_pcm, (void **)&areas, &offset, &frames);
 	TC_ASSERT_EQ_CLEANUP("pcm_mmap_commit", ret, 0, pcm_close(g_pcm));
 	TC_ASSERT_NEQ_CLEANUP("pcm_mmap_commit", areas, NULL, pcm_close(g_pcm));
-	TC_ASSERT_GEQ_CLEANUP("pcm_mmap_commit", offset, 0, pcm_close(g_pcm));
 	TC_ASSERT_GT_CLEANUP("pcm_mmap_commit", frames, 0, pcm_close(g_pcm));
 
 	ret = pcm_mmap_commit(g_pcm, offset, 10);
@@ -1264,7 +1261,6 @@ static void utc_audio_pcm_commit_p(void)
 	ret = pcm_mmap_begin(g_pcm, (void **)&areas, &offset, &frames);
 	TC_ASSERT_EQ_CLEANUP("pcm_mmap_commit", ret, 0, pcm_close(g_pcm));
 	TC_ASSERT_NEQ_CLEANUP("pcm_mmap_commit", areas, NULL, pcm_close(g_pcm));
-	TC_ASSERT_GEQ_CLEANUP("pcm_mmap_commit", offset, 0, pcm_close(g_pcm));
 	TC_ASSERT_GT_CLEANUP("pcm_mmap_commit", frames, 0, pcm_close(g_pcm));
 	ret = pcm_mmap_commit(g_pcm, offset, frames);
 	TC_ASSERT_EQ_CLEANUP("pcm_mmap_commit", ret, 0, pcm_close(g_pcm));
@@ -1277,7 +1273,6 @@ static void utc_audio_pcm_commit_p(void)
 	ret = pcm_mmap_begin(g_pcm, (void **)&areas, &offset, &frames);
 	TC_ASSERT_EQ_CLEANUP("pcm_mmap_commit", ret, 0, pcm_close(g_pcm));
 	TC_ASSERT_NEQ_CLEANUP("pcm_mmap_commit", areas, NULL, pcm_close(g_pcm));
-	TC_ASSERT_GEQ_CLEANUP("pcm_mmap_commit", offset, 0, pcm_close(g_pcm));
 	TC_ASSERT_GT_CLEANUP("pcm_mmap_commit", frames, 0, pcm_close(g_pcm));
 	ret = pcm_mmap_commit(g_pcm, offset, frames);
 	TC_ASSERT_EQ_CLEANUP("pcm_mmap_commit", ret, 0, pcm_close(g_pcm));


### PR DESCRIPTION
Fix Svace issue: 218040, 218041
'offset' is unsigned int. So, always equal or greater than zero.