### PR TITLE
media: bug fix for media destroy api

### DIFF
--- a/framework/src/media/MediaPlayerImpl.cpp
+++ b/framework/src/media/MediaPlayerImpl.cpp
@@ -85,12 +85,15 @@ player_result_t MediaPlayerImpl::destroy()
 
 	mpw.getQueue().enQueue(&MediaPlayerImpl::destroyPlayer, shared_from_this(), std::ref(ret));
 	mSyncCv.wait(lock);
-	mpw.stopWorker();
+	
+	if (ret == PLAYER_OK) {
+		if (mPlayerObserver) {
+			PlayerObserverWorker& pow = PlayerObserverWorker::getWorker();
+			pow.stopWorker();
+			mPlayerObserver = nullptr;
+		}
 
-	if (mPlayerObserver) {
-		PlayerObserverWorker& pow = PlayerObserverWorker::getWorker();
-		pow.stopWorker();
-		mPlayerObserver = nullptr;
+		mpw.stopWorker();
 	}
 
 	return ret;

--- a/framework/src/media/MediaRecorderImpl.cpp
+++ b/framework/src/media/MediaRecorderImpl.cpp
@@ -77,13 +77,16 @@ recorder_result_t MediaRecorderImpl::destroy()
 	mrw.getQueue().enQueue(&MediaRecorderImpl::destroyRecorder, shared_from_this(), std::ref(ret));
 	mSyncCv.wait(lock);
 
-	if (mRecorderObserver) {
-		RecorderObserverWorker& row = RecorderObserverWorker::getWorker();
-		row.stopWorker();
-		mRecorderObserver = nullptr;
+	if (ret == RECORDER_OK) {
+		if (mRecorderObserver) {
+			RecorderObserverWorker& row = RecorderObserverWorker::getWorker();
+			row.stopWorker();
+			mRecorderObserver = nullptr;
+		}
+
+		mrw.stopWorker();
 	}
 
-	mrw.stopWorker();
 	return ret;
 }
 


### PR DESCRIPTION
Modified to call stopWorker according to
the result of destroyRecorder function.

Signed-off-by: jaesick.shin <jaesick.shin@samsung.com>