### PR TITLE
driver/mtd: Fix wrong return value in mtdconfig_register

### DIFF
--- a/os/fs/driver/mtd/mtd_config.c
+++ b/os/fs/driver/mtd/mtd_config.c
@@ -1243,6 +1243,8 @@ int mtdconfig_register(FAR struct mtd_dev_s *mtd)
 		dev->nblocks = geo.neraseblocks * geo.erasesize / geo.blocksize;
 
 		(void)register_driver("/dev/config", &mtdconfig_fops, 0666, dev);
+	} else {
+		ret = -ENOMEM;
 	}
 
 errout:


### PR DESCRIPTION
When kmm_malloc() fails, it returns OK instead of -ENOMEM.

Signed-off-by: Lokesh B V <lokesh.bv@partner.samsung.com>