### PR TITLE
libc: Enable LIBC_SCANSET by default in Kconfig

### DIFF
--- a/lib/libc/Kconfig
+++ b/lib/libc/Kconfig
@@ -53,7 +53,7 @@ config LIBC_FLOATINGPOINT
 
 config LIBC_SCANSET
         bool "Scanset support"
-        default n 
+        default y 
         ---help---
                 Add scanset support to sscanf().
 


### PR DESCRIPTION
Turn this feature on by default.
Instead, it will be enabled only in limited configurations