### PR TITLE
framework/st_things : Removing hash based device managing Logic

### DIFF
--- a/framework/src/st_things/things_stack/cloud/cloud_connector.c
+++ b/framework/src/st_things/things_stack/cloud/cloud_connector.c
@@ -447,7 +447,6 @@ OCStackResult things_cloud_dev_profile_publish(char *host, OCClientResponseHandl
 {
 	THINGS_LOG_D(TAG, "Device-profile Publish Start.");
 
-	long devCnt = 0;
 	st_device_s *dev_info = NULL;
 	int cntArrayPayload = 0;
 	OCRepPayload **arrayPayload = NULL;
@@ -458,11 +457,6 @@ OCStackResult things_cloud_dev_profile_publish(char *host, OCClientResponseHandl
 	char targetUri[MAX_URI_LENGTH * 2] = { 0, };
 	char *coreVer = NULL;
 	char *IoTivityVer = NULL;
-
-	if ((devCnt = dm_get_num_of_dev_cnt()) < 1) {
-		THINGS_LOG_E(TAG, "Not exist device to publish profile-Info of Device.");
-		return OC_STACK_ERROR;
-	}
 
 	snprintf(targetUri, MAX_URI_LENGTH * 2, "%s%s", host, OC_RSRVD_ACCOUNT_DEVPROFILE_URI);
 
@@ -478,25 +472,24 @@ OCStackResult things_cloud_dev_profile_publish(char *host, OCClientResponseHandl
 		goto no_memory;
 	}
 
-	if ((arrayPayload = (OCRepPayload **) things_malloc(sizeof(OCRepPayload *) * devCnt)) == NULL) {
+	if ((arrayPayload = (OCRepPayload **) things_malloc(sizeof(OCRepPayload *))) == NULL) {
 		THINGS_LOG_E(TAG, "[Error] memory allocation is failed.(arrayPayload)");
 		goto no_memory;
 	}
-	// Add All-device-info
-	for (unsigned long i = 0; i < devCnt; i++) {
-		if ((dev_info = dm_get_info_of_dev(i)) == NULL) {
-			THINGS_LOG_E(TAG, "[Error] device info structure is NULL.(seq=%d)", i);
+
+	if ((dev_info = dm_get_info_of_dev(0)) == NULL) {
+		THINGS_LOG_E(TAG, "[Error] device info structure is NULL");
+		goto no_memory;
+	}
+
+	if (dev_info->is_physical == 1) {
+		if ((arrayPayload[cntArrayPayload] = make_dev_profile_payload(dev_info)) == NULL) {
+			THINGS_LOG_E(TAG, "It's failed making payload of Device-Info.(seq=%d)", cntArrayPayload);
 			goto no_memory;
 		}
-
-		if (dev_info->is_physical == 1) {
-			if ((arrayPayload[cntArrayPayload] = make_dev_profile_payload(dev_info)) == NULL) {
-				THINGS_LOG_E(TAG, "It's failed making payload of Device-Info.(seq=%d)", cntArrayPayload);
-				goto no_memory;
-			}
-			cntArrayPayload++;
-		}
+		cntArrayPayload++;
 	}
+
 
 	if (cntArrayPayload < 1) {
 		THINGS_LOG_E(TAG, "[Error] pysical device is not exist. So, Can not Sending request for Device-Profile.");

--- a/framework/src/st_things/things_stack/framework/things_data_manager.h
+++ b/framework/src/st_things/things_stack/framework/things_data_manager.h
@@ -113,9 +113,6 @@ const wifi_freq_e dm_get_wifi_property_freq();
 
 struct things_resource_s *dm_get_resource_instance(const char *uri, const int id);
 
-int dm_get_device_information(int *cnt, st_device_s ***list);
-
-long dm_get_num_of_dev_cnt(void);
 st_device_s *dm_get_info_of_dev(unsigned long number);
 bool dm_register_user_define_device_id(const int seq_thing_info, const char *dev_id);
 bool dm_register_device_id(void);

--- a/framework/src/st_things/things_stack/things_def.h
+++ b/framework/src/st_things/things_stack/things_def.h
@@ -51,4 +51,8 @@
 #define URI_DEVICE_COL                  "/device"
 #define URI_FIRMWARE                    "/firmware"
 
+#define DEVICE_OS_VERSION               "1.1"
+#define DEVICE_PLATFORM_VERSION         "1.1"
+#define DEVICE_HARDWARE_VERSION         "1.0"
+
 #endif							// _THINGS_DEF_


### PR DESCRIPTION
… a hash map

- Logic changes to support only a single device because there are currently no multiple device requirements
- Define internal resource (easysetup, fota, etc.) as const str and change it to include in existing logic: Improvement of development convenience / readability