### PR TITLE
Fix filesystem issues

### DIFF
--- a/apps/examples/testcase/le_tc/filesystem/fs_main.c
+++ b/apps/examples/testcase/le_tc/filesystem/fs_main.c
@@ -638,6 +638,7 @@ static void tc_fs_vfs_lseek(void)
 
 	ret = lseek(fd, 10, SEEK_SET);
 	TC_ASSERT_NEQ_CLEANUP("lseek", ret, 10, close(fd));
+	close(fd);
 #if defined(CONFIG_PIPES) && (CONFIG_DEV_PIPE_SIZE > 11)
 	ret = mkfifo(FIFO_FILE_PATH, 0666);
 	if (ret < 0) {
@@ -659,8 +660,8 @@ static void tc_fs_vfs_lseek(void)
 	TC_ASSERT_NEQ_CLEANUP("lseek", ret, 10, close(fd));
 
 	close(fd);
-
 #endif
+
 	TC_SUCCESS_RESULT();
 }
 
@@ -739,6 +740,7 @@ static void tc_fs_vfs_mkdir(void)
 	size_t len;
 
 	len = strlen(VFS_FOLDER_PATH) + 3;
+
 	/** make parent folder first **/
 	ret = mkdir(VFS_FOLDER_PATH, 0777);
 	TC_ASSERT_EQ("mkdir", ret, OK);
@@ -926,11 +928,11 @@ static void tc_fs_vfs_seekdir(void)
 	TC_ASSERT_NEQ_CLEANUP("readdir", dirent, NULL, closedir(dir));
 	TC_ASSERT_EQ_CLEANUP("readdir", dirent->d_type, DTYPE_DIRECTORY, closedir(dir));
 
+	itoa((int)offset, filename, 10);
+	TC_ASSERT_EQ_CLEANUP("readdir", strncmp(dirent->d_name, filename, 1), 0, closedir(dir));
+
 	ret = closedir(dir);
 	TC_ASSERT_EQ("closedir", ret, OK);
-
-	itoa((int)offset, filename, 10);
-	TC_ASSERT_EQ("readdir", strncmp(dirent->d_name, filename, 1), 0);
 
 	/* For Negative offset in seekmountdir operations */
 	dir = opendir(VFS_FOLDER_PATH);

--- a/lib/libc/stdio/lib_fopen.c
+++ b/lib/libc/stdio/lib_fopen.c
@@ -106,6 +106,10 @@ int lib_mode2oflags(FAR const char *mode)
 
 	DEBUGASSERT(mode);
 
+	if (!mode || !*mode) {
+		goto errout;
+	}
+
 	/* Parse the mode string to determine the corresponding open flags */
 
 	state = MODE_NONE;

--- a/os/fs/dirent/fs_closedir.c
+++ b/os/fs/dirent/fs_closedir.c
@@ -58,6 +58,7 @@
 
 #include <dirent.h>
 #include <errno.h>
+#include <string.h>
 
 #include <tinyara/kmalloc.h>
 #include <tinyara/fs/fs.h>
@@ -156,6 +157,7 @@ int closedir(FAR DIR *dirp)
 
 	/* Then release the container */
 
+	memset(idir, 0, sizeof(struct fs_dirent_s));
 	kumm_free(idir);
 	return OK;
 

--- a/os/fs/smartfs/smartfs_smart.c
+++ b/os/fs/smartfs/smartfs_smart.c
@@ -1063,7 +1063,6 @@ static off_t smartfs_seek_internal(struct smartfs_mountpt_s *fs, struct smartfs_
 
 	switch (whence) {
 	case SEEK_SET:
-	default:
 		newpos = offset;
 		break;
 
@@ -1074,6 +1073,8 @@ static off_t smartfs_seek_internal(struct smartfs_mountpt_s *fs, struct smartfs_
 	case SEEK_END:
 		newpos = sf->entry.datlen + offset;
 		break;
+	default:
+		return -EINVAL;
 	}
 
 	/* Ensure newpos is in range */

--- a/os/fs/vfs/fs_lseek.c
+++ b/os/fs/vfs/fs_lseek.c
@@ -97,9 +97,16 @@ off_t file_seek(FAR struct file *filep, off_t offset, int whence)
 	DEBUGASSERT(filep);
 	inode = filep->f_inode;
 
+	/* File is not open */
+
+	if (!inode) {
+		err = -EBADF;
+		goto errout;
+	}
+
 	/* Invoke the file seek method if available */
 
-	if (inode && inode->u.i_ops && inode->u.i_ops->seek) {
+	if (inode->u.i_ops && inode->u.i_ops->seek) {
 		ret = (int)inode->u.i_ops->seek(filep, offset, whence);
 		if (ret < 0) {
 			err = -ret;


### PR DESCRIPTION
fs_main.c
1. tc_fs_vfs_lseek
   - fd is not closed when open is called below.

2. tc_fs_vfs_mkdir
   - readdir returns a pointer to a direct structre and closedir release it.
	so returned dirent is not valid after calling closedir.

lib_fopen.c
 - If mode value is an empty string, it should return ERROR with errno, EINVAL.

fs_closedir.c
 - Before free memories, initialzation is needed because free function doesn't delete somethings in that region.

fs_opendir.c
 - If name is an empty string, it should return ERROR with errno, ENOENT.
 - Refer to Posix API in http://pubs.opengroup.org/onlinepubs/9699919799/

smartfs_smart.c
 1. smartfs_seek_internal
    - If whence is not one of SEEK_SET, SEEK_CUR, SEEK_END, it should return ERROR with errno, EINVAL.
    - Refer to Posix API in http://pubs.opengroup.org/onlinepubs/9699919799/

 2. smartfs_opendir
    - A file can't be opened by opendir.

 3. smartfs_mkdir
    - If the parent doesn't have a permission for write, mkdir operation should be denied.