### PR TITLE
kernel/group: Add sem_init for tg_exitsem

### DIFF
--- a/os/kernel/group/group_create.c
+++ b/os/kernel/group/group_create.c
@@ -254,7 +254,9 @@ int group_allocate(FAR struct task_tcb_s *tcb, uint8_t ttype)
 #ifndef CONFIG_DISABLE_PTHREAD
 	(void)sem_init(&group->tg_joinsem, 0, 1);
 #endif
-
+#if defined(CONFIG_SCHED_WAITPID) && !defined(CONFIG_SCHED_HAVE_PARENT)
+	(void)sem_init(&group->tg_exitsem, 0, 0);
+#endif
 	return OK;
 }
 


### PR DESCRIPTION
if defined CONFIG_SCHED_WAITPID and not defined CONFIG_SCHED_HAVE_PARENT,
tg_exitsem in task_group_s is used for waitpid, but not initialized when creating task.