### PR TITLE
le_tc/sched: Modify wrong param for pid in waitpid

### DIFF
--- a/apps/examples/testcase/le_tc/kernel/tc_sched.c
+++ b/apps/examples/testcase/le_tc/kernel/tc_sched.c
@@ -396,8 +396,7 @@ static void tc_sched_waitpid(void)
 	int status;
 
 	/* Check for The TCB corresponding to this PID is not our child. */
-
-	ret_chk = waitpid(0, &status, 0);
+	ret_chk = waitpid(-1, &status, 0);
 	TC_ASSERT_EQ("waitpid", ret_chk, ERROR);
 	TC_ASSERT_EQ("waitpid", errno, ECHILD);
 


### PR DESCRIPTION
Line 399 in tc_sched.c is for checking wrong pid, so change to -1 which is not valid for pid