### PR TITLE
example/wifi_maanger: fix an overflow issue of an input parameter

### DIFF
--- a/apps/examples/wifi_manager_sample/wm_test.c
+++ b/apps/examples/wifi_manager_sample/wm_test.c
@@ -575,6 +575,11 @@ void wm_softap_start(void *arg)
 	WM_TEST_LOG_START;
 	wifi_manager_result_e res = WIFI_MANAGER_SUCCESS;
 	struct options *ap_info = (struct options *)arg;
+	if (strlen(ap_info->ssid) >= 32 || strlen(ap_info->password) >= 64) {
+		printf("Param Error\n");
+		WM_TEST_LOG_END;
+		return;
+	}
 	wifi_manager_softap_config_s ap_config;
 	strcpy(ap_config.ssid, ap_info->ssid);
 	ap_config.ssid[strlen(ap_info->ssid)] = '\0';


### PR DESCRIPTION
it make crash when ssid or password is more than 32 or 64 at wm_softap_start()