### PR TITLE
testcase/tc_sched: Redefine INVALID_PID to -2 and modify waitpid tc

### DIFF
--- a/apps/examples/testcase/le_tc/kernel/tc_sched.c
+++ b/apps/examples/testcase/le_tc/kernel/tc_sched.c
@@ -40,7 +40,7 @@
 #define VAL_3           3
 #define VAL_5           5
 #define TASK_STACKSIZE 2048
-#define PID_INVAL       -1
+#define INVALID_PID       -2
 #define PID_IDLE        0
 #define TASK_CANCEL_INVALID  -1
 
@@ -396,7 +396,7 @@ static void tc_sched_waitpid(void)
 	int status;
 
 	/* Check for The TCB corresponding to this PID is not our child. */
-	ret_chk = waitpid(-1, &status, 0);
+	ret_chk = waitpid(INVALID_PID, &status, 0);
 	TC_ASSERT_EQ("waitpid", ret_chk, ERROR);
 	TC_ASSERT_EQ("waitpid", errno, ECHILD);
 
@@ -429,7 +429,7 @@ static void tc_sched_sched_gettcb(void)
 {
 	struct tcb_s *tcb;
 
-	tcb = sched_gettcb(PID_INVAL);
+	tcb = sched_gettcb(INVALID_PID);
 	TC_ASSERT_EQ("sched_gettcb", tcb, NULL);
 
 	tcb = sched_gettcb(PID_IDLE);


### PR DESCRIPTION
If pid is equal to (pid_t)-1, status is requested for any child process in waitpid.
So -1 cannot be a invalid pid in waitpid