### PR TITLE
media : add logic for nullptr case in setObserver

### DIFF
--- a/framework/src/media/MediaPlayerImpl.cpp
+++ b/framework/src/media/MediaPlayerImpl.cpp
@@ -474,9 +474,16 @@ player_result_t MediaPlayerImpl::setObserver(std::shared_ptr<MediaPlayerObserver
 void MediaPlayerImpl::setPlayerObserver(std::shared_ptr<MediaPlayerObserverInterface> observer)
 {
 	PlayerObserverWorker& pow = PlayerObserverWorker::getWorker();
-	pow.startWorker();
-	mPlayerObserver = observer;
 
+	if (mPlayerObserver) {
+		pow.stopWorker();
+	}
+
+	if (observer) {
+		pow.startWorker();
+	}
+
+	mPlayerObserver = observer;
 	mSyncCv.notify_one();
 }
 

--- a/framework/src/media/MediaRecorderImpl.cpp
+++ b/framework/src/media/MediaRecorderImpl.cpp
@@ -442,9 +442,16 @@ void MediaRecorderImpl::setRecorderObserver(std::shared_ptr<MediaRecorderObserve
 	medvdbg("MediaRecorderImpl::notifySync()\n");
 
 	RecorderObserverWorker& row = RecorderObserverWorker::getWorker();
-	row.startWorker();
-	mRecorderObserver = observer;
 
+	if (mRecorderObserver) {
+		row.stopWorker();
+	}
+
+	if (observer) {
+		row.startWorker();
+	}
+
+	mRecorderObserver = observer;
 	notifySync();
 }
 


### PR DESCRIPTION
add missing logic for nullptr case in setObserver
1. first, mRecorderObserver is not null case
2. second, observer is not null case

Signed-off-by: jaesick.shin <jaesick.shin@samsung.com>