### PR TITLE
apps/exaple/testcase/ : fix svace issue for network and arastorage ITC

### DIFF
--- a/apps/examples/testcase/le_tc/network/itc_net_connect.c
+++ b/apps/examples/testcase/le_tc/network/itc_net_connect.c
@@ -56,6 +56,10 @@ static void *server_connect(void *ptr_num_clients)
 	int *pret = malloc(sizeof(int));
 	int recv_len = 0;
 	int send_len = 0;
+	if (NULL == pret) {
+		printf("Memory allocation to pret is failed\n");
+		return NULL;
+	}
 	*pret = OK;
 
 	printf("Server thread started...\n");
@@ -64,7 +68,12 @@ static void *server_connect(void *ptr_num_clients)
 		*pret = ERROR;
 		pthread_exit(pret);
 	}
-	setsockopt(server_socket, SOL_SOCKET, SO_REUSEADDR | SO_REUSEPORT, &opt, sizeof(opt));
+	int nRet = setsockopt(server_socket, SOL_SOCKET, SO_REUSEADDR | SO_REUSEPORT, &opt, sizeof(opt));
+	if (nRet < 0) {
+		printf("setsockopt API failed \n");
+		*pret = ERROR;
+		pthread_exit(pret);
+	}
 	address.sin_family = AF_INET;
 	address.sin_addr.s_addr = INADDR_ANY;
 	address.sin_port = htons(g_port);
@@ -164,16 +173,20 @@ static void *client_connect(void *ptr_id)
 	char buffer[BUFF_LEN] = {0};
 	int total_recv;
 	int total_send;
-	int *pret = malloc(sizeof(int));
 	int recv_len = 0;
 	int send_len = 0;
+	int *pret = malloc(sizeof(int));
+	if (NULL == pret) {
+		printf("Memory allocation to pret is failed\n");
+		return NULL;
+	}
 	*pret = OK;
 	printf("Client thread started...\n");
 	sock = socket(AF_INET, SOCK_STREAM, 0);
 	if (sock < 0) {
 		pthread_exit(pret);
 	}
-	memset(&serv_addr, '0', sizeof(serv_addr));
+	memset(&serv_addr, 0, sizeof(serv_addr));
 	serv_addr.sin_family = AF_INET;
 	serv_addr.sin_addr.s_addr = inet_addr("127.0.0.1");
 	serv_addr.sin_port = htons(g_port);

--- a/apps/examples/testcase/le_tc/network/itc_net_setsockopt.c
+++ b/apps/examples/testcase/le_tc/network/itc_net_setsockopt.c
@@ -222,6 +222,10 @@ int itc_net_setsockopt_main(void)
 	int fd = -1;
 
 	fd = socket(AF_INET, SOCK_STREAM, 0);
+	if (fd < 0) {
+		printf("socket creation failed\n");
+		return 0;
+	}
 
 	itc_net_setsockopt_n_invalid_opt_name(fd);
 	itc_net_setsockopt_p_rcvbuf(fd);
@@ -232,8 +236,12 @@ int itc_net_setsockopt_main(void)
 	itc_net_setsockopt_p_ip_ttl(fd);
 
 	close(fd);
-
+	fd = -1;
 	fd = socket(AF_INET, SOCK_DGRAM, 0);
+	if (fd < 0) {
+		printf("socket creation failed\n");
+		return 0;
+	}
 
 	itc_net_setsockopt_p_no_check(fd);
 	itc_net_setsockopt_p_multicast_ttl_loop(fd);


### PR DESCRIPTION
Changes are as below:
itc_net_connect.c     -> 1. Memory allocation of *pret was not checked for proper memory allocation
			 2. return value of setsockopt() API not checked
 			 3. wrong parameter in memset API
itc_net_setsockopt.c  -> 1. return value of socket() API not checked
itc_arastorage_main.c  ->1. return value of db_exec() API not checked
		         2. used sprintf instead of snprintf
			 3. return value of cursor_get_count() API not checked

Signed-off-by: manoj <manoj.g2@samsung.com>