### PR TITLE
kernel/pthread: Modify comment for pthread_key create and delete APIs

### DIFF
--- a/os/kernel/pthread/pthread_keycreate.c
+++ b/os/kernel/pthread/pthread_keycreate.c
@@ -105,8 +105,7 @@
  * Parameters:
  *   key = A pointer to the key to create.
  *   destructor = An optional destructor() function that may be associated
- *      with each key that is invoked when a thread exits.  However, this
- *      argument is ignored in the current implementation.
+ *      with each key that is invoked when a thread exits.
  *
  * Return Value:
  *   If successful, the pthread_key_create() function will store the newly
@@ -121,7 +120,6 @@
  * Assumptions:
  *
  * POSIX Compatibility:
- *   - The present implementation ignores the destructor argument.
  *
  ****************************************************************************/
 

--- a/os/kernel/pthread/pthread_keydelete.c
+++ b/os/kernel/pthread/pthread_keydelete.c
@@ -93,8 +93,7 @@
  *
  * Description:
  *   This POSIX function should delete a thread-specific data key
- *   previously returned by pthread_key_create().  However, this function
- *   does nothing in the present implementation.
+ *   previously returned by pthread_key_create().
  *
  * Parameters:
  *   key = the key to delete


### PR DESCRIPTION
In present implementation, pthread_key_delete and destructor for key deletion are supported.