### PR TITLE
os/pthread: Add DEBUGASSERT for checking tcb type

### DIFF
--- a/os/kernel/pthread/pthread_keycreate.c
+++ b/os/kernel/pthread/pthread_keycreate.c
@@ -131,7 +131,7 @@ int pthread_key_create(FAR pthread_key_t *key, pthread_destructor_t destructor)
 	struct task_group_s *group = rtcb->cmn.group;
 	int key_index = 0;
 
-	DEBUGASSERT(group);
+	DEBUGASSERT(group && (rtcb->cmn.flags & TCB_FLAG_TTYPE_MASK) == TCB_FLAG_TTYPE_PTHREAD);
 
 	if (!key) {
 		return EINVAL;

--- a/os/kernel/pthread/pthread_keydelete.c
+++ b/os/kernel/pthread/pthread_keydelete.c
@@ -113,7 +113,7 @@ int pthread_key_delete(pthread_key_t key)
 	struct pthread_tcb_s *rtcb = (FAR struct pthread_tcb_s *)this_task();
 	struct task_group_s *group = rtcb->cmn.group;
 
-	DEBUGASSERT(group);
+	DEBUGASSERT(group && (rtcb->cmn.flags & TCB_FLAG_TTYPE_MASK) == TCB_FLAG_TTYPE_PTHREAD);
 
 	if (key < PTHREAD_KEYS_MAX && group->tg_keys[key] == IN_USE) {
 		rtcb->pthread_data[key].data = NULL;


### PR DESCRIPTION
pthread_key_create and delete APIs are only for pthread type tcb