### PR TITLE
external/iotivity: fix build configurations

### DIFF
--- a/external/iotivity/iotivity_1.2-rel/build_common/tizenrt/SConscript
+++ b/external/iotivity/iotivity_1.2-rel/build_common/tizenrt/SConscript
@@ -77,13 +77,12 @@ if env.get('LOGGING'):
 # Determine dependency for tizenrt_os_dir
 
 dep_src_dir1 =  os.path.join(tizenrt_os_dir, 'include')
-dep_src_dir2 =  os.path.join(tizenrt_os_dir, 'include/tinyara')
-dep_src_dir3 =  os.path.join(tizenrt_os_dir, '../external/include')
-dep_lib_dir =  '/usr/lib/arm-none-eabi/include'
+dep_src_dir2 =  os.path.join(tizenrt_os_dir, '../external/include')
+dep_lib_dir =  default_os_dir + 'include'
 
 
 # Add directories to search for header files and external libraries
-env.AppendUnique(CPPPATH = [ dep_src_dir1, dep_src_dir2, dep_src_dir3 ])
+env.AppendUnique(CPPPATH = [ dep_src_dir1, dep_src_dir2 ])
 env.AppendUnique(LIBPATH = [ dep_lib_dir ])
 
 print env.get('CPPPATH')

--- a/external/iotivity/iotivity_1.2-rel/resource/c_common/SConscript
+++ b/external/iotivity/iotivity_1.2-rel/resource/c_common/SConscript
@@ -94,6 +94,8 @@ if target_os in ['tizenrt']:
 	env.AppendUnique(CCFLAGS = ['-w'])
 	cxx_headers.remove('sys/timeb.h')
 	cxx_headers.remove('strings.h')
+        cxx_headers.remove('grp.h')
+        cxx_headers.remove('pwd.h')
 	config_h_body += "#include <tinyara/config.h>\n\n"
 
 if target_os == 'msys_nt':


### PR DESCRIPTION
fix that iotivity refers /usr/lib/include/
Iotivity on TizenRT should not refer compiler's header files
And iotivity refered header files that TizenRT doesn't support.
because thoes are in system include path.