### PR TITLE
media: Add descriptions for naming audio drivers

### DIFF
--- a/docs/HowToUseAudio.md
+++ b/docs/HowToUseAudio.md
@@ -22,10 +22,12 @@ the lower half through POSIX like system APIs.
 ##  Tinyalsa  
 [framework/src/tinyalsa](../framework/src/tinyalsa) has the Tiny library to provide audio API similar to ALSA in Linux. Refer [HowToUseTinyAlsa](HowToUseTinyalsa.md) to find out how to develop audio applications using TinyAlsa
 
+
 ## Device Drivers  
 Most commonly, audio devices use I2S port for audio data path and 
 I2C, SPI etc for audio control path.  
 Depending on the board schematics, a control path (i2c, spi, etc) and a data path (i2s, etc) is to be configured. Please refer [HowToUsePeripheral](HowToUsePeripheral.md)
+
 
 ## Audio Codec Setup
 
@@ -53,9 +55,14 @@ After setting up audio codec, the codec's lowerhalf is wrapped around in an audi
 Psuedocode
 
 ```
-	/*Embed codec device witin audio device */
+	/*Embed codec device within audio device */
 	ret = audio_register(devname, codec_lowerhalf);
 ```
 
 Example: [os/arch/arm/src/artik05x/src/artik055_alc5658.c](../os/arch/arm/src/artik05x/src/artik055_alc5658.c)
 
+
+Driver registering policy (*devname* Naming)
+
+>Input: 	/dev/pcmC[card id]D[device id]c  
+>Output:	/dev/pcmC[card id]D[device id]p


### PR DESCRIPTION
- Naming rules for alc5658 chip are added to 'HowToUseAudio.md'.