### PR TITLE
apps/example/testcase/ : removed unsupported Macro SO_REUSEPORT

### DIFF
--- a/apps/examples/testcase/le_tc/network/itc_net_connect.c
+++ b/apps/examples/testcase/le_tc/network/itc_net_connect.c
@@ -68,7 +68,7 @@ static void *server_connect(void *ptr_num_clients)
 		*pret = ERROR;
 		pthread_exit(pret);
 	}
-	int nRet = setsockopt(server_socket, SOL_SOCKET, SO_REUSEADDR | SO_REUSEPORT, &opt, sizeof(opt));
+	int nRet = setsockopt(server_socket, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt));
 	if (nRet < 0) {
 		printf("setsockopt API failed \n");
 		*pret = ERROR;


### PR DESCRIPTION
Changes are as below:
itc_net_connect.c     -> 1. removed unsupported macro "SO_REUSEPORT"for setcockopt API

Signed-off-by: manoj <manoj.g2@samsung.com>