### PR TITLE
media: Remove redundant method in MediaWorker

### DIFF
--- a/framework/src/media/MediaWorker.cpp
+++ b/framework/src/media/MediaWorker.cpp
@@ -34,7 +34,7 @@ MediaWorker::~MediaWorker()
 void MediaWorker::startWorker()
 {
 	std::unique_lock<std::mutex> lock(mRefMtx);
-	increaseRef();
+	++mRefCnt;
 	medvdbg("MediaWorker::startWorker() - increase RefCnt : %d\n", mRefCnt);
 	if (mRefCnt == 1) {
 		mIsRunning = true;
@@ -45,7 +45,9 @@ void MediaWorker::startWorker()
 void MediaWorker::stopWorker()
 {
 	std::unique_lock<std::mutex> lock(mRefMtx);
-	decreaseRef();
+	if (mRefCnt > 0) {
+		--mRefCnt;
+	}
 	medvdbg("MediaWorker::stopWorker() - decrease RefCnt : %d\n", mRefCnt);
 	if (mRefCnt <= 0) {
 		if (mWorkerThread.joinable()) {
@@ -83,18 +85,6 @@ int MediaWorker::mediaLooper()
 		}
 	}
 	return 0;
-}
-
-void MediaWorker::increaseRef()
-{
-	mRefCnt++;
-}
-
-void MediaWorker::decreaseRef()
-{
-	if (mRefCnt > 0) {
-		mRefCnt--;
-	}
 }
 
 bool MediaWorker::isAlive()

--- a/framework/src/media/MediaWorker.h
+++ b/framework/src/media/MediaWorker.h
@@ -46,9 +46,6 @@ protected:
 
 private:
 	int mediaLooper();
-	int getRefCnt();
-	void increaseRef();
-	void decreaseRef();
 
 	MediaQueue mWorkerQueue;
 	std::atomic<bool> mIsRunning;


### PR DESCRIPTION
increaseRefCnt, decreaseRefCnt can be replace with simple code.
And these methods are only used once.