### PR TITLE
Framework/task_manager: Fix buid error when CONFIG_SCHED_HAVE_PARENT …

### DIFF
--- a/framework/src/task_manager/task_manager.c
+++ b/framework/src/task_manager/task_manager.c
@@ -225,8 +225,9 @@ int task_manager(int argc, char *argv[])
 	int chk_idx;
 	int register_permission;
 	struct mq_attr attr;
-
+#ifdef CONFIG_SCHED_HAVE_PARENT
 	sigignore(SIGCHLD);
+#endif
 	attr.mq_maxmsg = CONFIG_TASK_MANAGER_MAX_MSG;
 	attr.mq_msgsize = sizeof(tm_request_t);
 	attr.mq_flags = 0;


### PR DESCRIPTION
…is disabled

selecting CONFIG_TASK_MANAGER leads to build error When CONFIG_SCHED_HAVE_PARENT
is not enabled

build error:
framework/src/task_manager/task_manager.c: In function 'task_manager':
framework/src/task_manager/task_manager.c:229:12: error: 'SIGCHLD' undeclared (first use in this function)

Signed-off-by: pradeep.ns <pradeep.ns@samsung.com>