### PR TITLE
arch/armv7-r, framework/st_things: use appropriate config

### DIFF
--- a/framework/src/st_things/Kconfig
+++ b/framework/src/st_things/Kconfig
@@ -25,7 +25,7 @@ comment "ST_Things Config Parameters"
 
 config ST_THINGS_ARTIK_HW_CERT_KEY
 	bool "Enable Artik H/W Certificate & Key"
-	depends on ARCH_BOARD_ARTIK053 || ARCH_BOARD_ARTIK053S || ARCH_BOARD_ARTIK055 || ARCH_BOARD_ARTIK055S
+	depends on ARCH_BOARD_ARTIK05X_FAMILY
 	select TLS_WITH_SSS
 	select SUPPORT_FULL_SECURITY
 	select HW_RNG

--- a/os/arch/arm/src/armv7-r/mpu.h
+++ b/os/arch/arm/src/armv7-r/mpu.h
@@ -491,7 +491,7 @@ static inline void mpu_control(bool enable)
  *
  ****************************************************************************/
 
-#if defined(CONFIG_ARMV7R_HAVE_ICACHE) || defined(CONFIG_ARMV7R_DCACHE)
+#if defined(CONFIG_ARMV7R_ICACHE) || defined(CONFIG_ARMV7R_DCACHE)
 static inline void mpu_priv_stronglyordered(uintptr_t base, size_t size)
 {
 	unsigned int region = mpu_allocregion();


### PR DESCRIPTION
1. arch/armv7-r: fix wrong config name, CONFIG_ARMV7R_HAVE_ICACHE 
2. framework/st_things: use presentative config for ARTIK board 