### PR TITLE
arch: move and rename configs to support additional heap regions

### DIFF
--- a/docs/HowToUseMultiHeap.md
+++ b/docs/HowToUseMultiHeap.md
@@ -4,29 +4,27 @@ There are two cases to use multi-heap regions.
 1. continuous physical RAM but want to split regions  
 2. separated physical RAMs but want to use for heap  
 
-Modify *[Kconfig](#Kconfig)* and *[TizenRT configuration file](#tizenrt-configuration-file)*.  
+To use multi-heap regions, find below two steps.
 
-## Kconfig
+## Set number of Heap regions
 
-Add **select ARCH_HAVE_HEAPx** belong to config ARCH_ARM in os/arch/<ARCH_NAME>/src/<CHIP_NAME>/Kconfig.
+Set **CONFIG_MM_REGIONS** value which shows how many regions are.
 ```
-config ARCH_CHIP_<CHIP_NAME>
-	select ARCH_HAVE_HEAPx
+Memory Management -> Number of memory regions -> change a number over 2
 ```
-This will enable HEAPx_BASE and HEAPx_SIZE configs in os/mm/Kconfig.
+When CONFIG_MM_REGIONS has over 2, RAMx_START and RAMx_SIZE configs come out.
 
-## TizenRT configuration file
+## Set RAM start address and size
 
-Set base addresses and sizes for new heap regions through menuconfig.
+Set start addresses, **CONFIG_RAMx_START** with hexa values and sizes, **CONFIG_RAMx_SIZE** with decimal values of new heap regions.
 ```
-cd $TIZENRT_BASEDIR
-cd os
-make menuconfig
+Hardware Configuration -> Chip Selection -> List of start address for additional heap region -> set values
+Hardware Configuration -> Chip Selection -> List of size for additional heap region -> set values
 ```
-Set *CONFIG_HEAPx_BASE* and *CONFIG_HEAPx_SIZE* based on new heap region information.
+Each region is separated by ```','``` as shown below example:
 ```
-Memory Management -> Set List of start address for additional heap region
-Memory Management -> Set List of size for additional heap region
+0x02000000,0x4000000
+100,200
 ```
 
-TizenRT will add additional heap region automatically.
+Based on above configurations, *up_addregion* function sets new regions automatically.

--- a/os/arch/Kconfig.chip
+++ b/os/arch/Kconfig.chip
@@ -735,6 +735,31 @@ config RAM_SIZE
 		does not execute out of RAM but from FLASH, then you may designate
 		any block of RAM as "primary."
 
+config RAMx_START
+	string "List of start address for additional heap region"
+	default "0x00000000,"
+	depends on MM_REGIONS != 1
+	---help---
+		The start address list of the additional heap regions.
+		When you want to use separated heap region in a physical RAM or
+		two different physical RAMs, set MM_REGIONS first at memory
+		management, and then set hexa values at RAMx_START and RAMx_SIZE
+		to support several heap regions.
+		Each region is separated by ',' as shown in example.
+		i.e. "0x02000000,0x4000000"
+
+config RAMx_SIZE
+	string "List of size for additional heap region"
+	default "0,"
+	depends on MM_REGIONS != 1
+	---help---
+		The size list of additional heap region.
+		Refer RAMx_START content. One different thing is this has
+		decimal values (START has hexa values).
+		This should have same number of list element with RAMx_START's.
+		Each region is separated by ',' as shown in example.
+		i.e. "100,200"
+
 config DDR
 	bool "Use DDR memory"
 	default n

--- a/os/arch/arm/src/common/up_allocateheap.c
+++ b/os/arch/arm/src/common/up_allocateheap.c
@@ -216,8 +216,9 @@ void up_addregion(void)
 	char *mem_size = CONFIG_HEAPx_SIZE;
 
 	for (region_cnt = 0; region_cnt < CONFIG_MM_REGIONS - 1; region_cnt++) {
-		if (*mem_start || *mem_size) {
-			dbg("CONFIG_HEAPx_BASE and CONFIG_HEAPx_SIZE are not defined properly\n");
+		if (!*mem_start || !*mem_size) {
+			dbg("Fail to add %dth heap region\n", region_cnt + 1);
+			break;
 		}
 		kumm_addregion((void *)strtol(mem_start, &mem_start, 16), (size_t)strtol(mem_size, &mem_size, 0));
 

--- a/os/arch/arm/src/common/up_allocateheap.c
+++ b/os/arch/arm/src/common/up_allocateheap.c
@@ -212,8 +212,8 @@ void up_allocate_kheap(FAR void **heap_start, size_t *heap_size)
 void up_addregion(void)
 {
 	int region_cnt;
-	char *mem_start = CONFIG_HEAPx_BASE;
-	char *mem_size = CONFIG_HEAPx_SIZE;
+	char *mem_start = CONFIG_RAMx_START;
+	char *mem_size = CONFIG_RAMx_SIZE;
 
 	for (region_cnt = 0; region_cnt < CONFIG_MM_REGIONS - 1; region_cnt++) {
 		if (!*mem_start || !*mem_size) {

--- a/os/mm/Kconfig
+++ b/os/mm/Kconfig
@@ -68,26 +68,6 @@ config MM_REGIONS
 		that the memory manager must handle and enables the API
 		mm_addregion(heap, start, end);
 
-config ARCH_HAVE_HEAPx
-	bool
-	default n
-
-if ARCH_HAVE_HEAPx
-
-config HEAPx_BASE
-	string "List of start address for additional heap region"
-	default "0x00000000,"
-	---help---
-		The base address list of the additional heap region.
-
-config HEAPx_SIZE
-	string "List of size for additional heap region"
-	default "0,"
-	---help---
-		The size list of additional heap region.
-
-endif # ARCH_HAVE_HEAPx
-
 config GRAN
 	bool "Enable Granule Allocator"
 	default n


### PR DESCRIPTION
By user decision or hw limitation, heap regions can be separated.
As of now, HEAPx_BASE and HEAPx_SIZE supports that.
But, config of first heap region is RAM_START and RAM_SIZE.
Because they have different naming rules and are at different locations,
it is difficult to know.
Let's move additional heap configurations to arch and rename them.
Because usually architecture determines heap regions.