### PR TITLE
le_tc/filesystem: Fix build error when CONFIG_FS_SMARTFS is disabled

### DIFF
--- a/apps/examples/testcase/le_tc/filesystem/fs_main.c
+++ b/apps/examples/testcase/le_tc/filesystem/fs_main.c
@@ -3635,7 +3635,7 @@ int tc_filesystem_main(int argc, char *argv[])
 #ifdef CONFIG_ITC_FS
 	itc_fs_main();
 #endif
-#if defined(CONFIG_TC_FS_PROCFS) && !defined(CONFIG_SMARTFS_MULTI_ROOT_DIRS)
+#if defined(CONFIG_TC_FS_PROCFS) && defined(CONFIG_FS_SMARTFS) && !defined(CONFIG_SMARTFS_MULTI_ROOT_DIRS)
 	tc_fs_smartfs_mksmartfs();
 #endif
 	(void)tc_handler(TC_END, "FileSystem TC");

--- a/apps/examples/testcase/le_tc/filesystem/tc_fs_procfs.c
+++ b/apps/examples/testcase/le_tc/filesystem/tc_fs_procfs.c
@@ -216,7 +216,7 @@ static int procfs_rewind_tc(const char *dirpath)
 
 	return OK;
 }
-#ifndef CONFIG_SMARTFS_MULTI_ROOT_DIRS
+#if defined(CONFIG_FS_SMARTFS) && !defined(CONFIG_SMARTFS_MULTI_ROOT_DIRS)
 void tc_fs_smartfs_mksmartfs(void)
 {
 	int ret;


### PR DESCRIPTION
When CONFIG_FS_SMARTFS is not enabled, it gives build error
This patch fix it by adding the conditional flag

Signed-off-by: pradeep.ns <pradeep.ns@samsung.com>