### PR TITLE
framework/task_manager: Add checking handler logic for unicast

### DIFF
--- a/framework/include/task_manager/task_manager.h
+++ b/framework/include/task_manager/task_manager.h
@@ -71,13 +71,14 @@
 #define TM_FAIL_START_NOT_CREATED     (-7)
 #define TM_FAIL_SEND_MSG              (-8)
 #define TM_FAIL_SET_HANDLER           (-9)
-#define TM_FAIL_PAUSE                 (-10)
-#define TM_FAIL_RESUME                (-11)
-#define TM_FAIL_REQ_TO_MGR            (-12)
-#define TM_FAIL_RESPONSE              (-13)
-#define TM_FAIL_UNREGISTER            (-14)
-#define TM_INVALID_PARAM              (-15)
-#define TM_OUT_OF_MEMORY              (-16)
+#define TM_FAIL_NO_HANDLER            (-10)
+#define TM_FAIL_PAUSE                 (-11)
+#define TM_FAIL_RESUME                (-12)
+#define TM_FAIL_REQ_TO_MGR            (-13)
+#define TM_FAIL_RESPONSE              (-14)
+#define TM_FAIL_UNREGISTER            (-15)
+#define TM_INVALID_PARAM              (-16)
+#define TM_OUT_OF_MEMORY              (-17)
 
 /**
  * @brief Task Info Structure

--- a/framework/src/task_manager/task_manager.c
+++ b/framework/src/task_manager/task_manager.c
@@ -431,6 +431,12 @@ int task_manager(int argc, char *argv[])
 				break;
 			}
 
+			ret = ioctl(fd, TMIOC_UNICAST, TASK_PID(request_msg.handle));
+			if (ret < 0) {
+				ret = TM_FAIL_NO_HANDLER;
+				break;
+			}
+
 			/* handle is in task_list */
 			union sigval msg;
 			msg.sival_ptr = request_msg.data;

--- a/os/drivers/task_manager/task_manager_drv.c
+++ b/os/drivers/task_manager/task_manager_drv.c
@@ -217,6 +217,18 @@ static int taskmgt_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
 		}
 		ret = OK;
 		break;
+	case TMIOC_UNICAST:
+		tcb = sched_gettcb((int)arg);
+		if (tcb == NULL) {
+			return ERROR;
+		}
+		ret = (int)sig_is_handler_registered(tcb, SIGTM_UNICAST);
+		if ((bool)ret != true) {
+			ret = ERROR;
+		} else {
+			ret = OK;
+		}
+		break;
 	case TMIOC_RESTART:
 		break;
 	case TMIOC_BROADCAST:

--- a/os/kernel/signal/Make.defs
+++ b/os/kernel/signal/Make.defs
@@ -59,7 +59,7 @@ CSRCS += sig_findaction.c sig_allocatependingsigaction.c
 CSRCS += sig_releasependingsigaction.c sig_unmaskpendingsignal.c
 CSRCS += sig_removependingsignal.c sig_releasependingsignal.c sig_lowest.c
 CSRCS += sig_mqnotempty.c sig_cleanup.c sig_dispatch.c sig_deliver.c
-CSRCS += sig_pause.c sig_nanosleep.c sig_sethandler.c
+CSRCS += sig_pause.c sig_nanosleep.c sig_sethandler.c sig_is_handler_registered.c
 
 # Include signal build support
 

--- a/os/kernel/signal/sig_is_handler_registered.c
+++ b/os/kernel/signal/sig_is_handler_registered.c
@@ -15,23 +15,20 @@
  * language governing permissions and limitations under the License.
  *
  ****************************************************************************/
-#ifndef ___INCLUDE_TINYARA_SIGNAL_H
-#define ___INCLUDE_TINYARA_SIGNAL_H
 
 /****************************************************************************
  * Included Files
  ****************************************************************************/
-
-#include <tinyara/config.h>
 #include <sched.h>
-#include <signal.h>
+#include <stdbool.h>
 
+#include "signal/signal.h"
 /****************************************************************************
- * Pre-processor Definitions
+ * Definitions
  ****************************************************************************/
 
 /****************************************************************************
- * Global Type Declarations
+ * Private Type Declarations
  ****************************************************************************/
 
 /****************************************************************************
@@ -39,29 +36,24 @@
  ****************************************************************************/
 
 /****************************************************************************
- * Global Function Prototypes
+ * Private Variables
  ****************************************************************************/
 
-#ifdef __cplusplus
-#define EXTERN extern "C"
-extern "C" {
-#else
-#define EXTERN extern
-#endif
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
 
-/**
- * @cond
- * @internal
- */
-int sig_sethandler(struct tcb_s *tcb, int signo, struct sigaction *act);
-bool sig_is_handler_registered(struct tcb_s *tcb, int signo);
-/**
- * @endcond
- */
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+bool sig_is_handler_registered(struct tcb_s *tcb, int signo)
+{
+	bool ret = false;
+	sigactq_t *sigact = NULL;
+	sigact = sig_findaction(tcb, signo);
+	if (sigact != NULL) {
+		ret = true;
+	}
 
-#undef EXTERN
-#ifdef __cplusplus
+	return ret;
 }
-#endif
-
-#endif							/* ___INCLUDE_TINYARA_SIGNAL_H */


### PR DESCRIPTION
If handler is not registered, unicast cannot work properly.