### PR TITLE
external/webclient: Modify WGET return value

### DIFF
--- a/external/webclient/webclient.c
+++ b/external/webclient/webclient.c
@@ -1048,7 +1048,13 @@ retry:
 			goto errout;
 		} else if (len == 0) {
 			ndbg("Finish read\n");
-			goto errout;
+			if (mlen.message_len - mlen.sentence_start == mlen.content_len) {
+				ndbg("download completed successfully\n");
+				break;
+			} else {
+				ndbg("Error: Receive Fail\n");
+				goto errout;
+			}
 		}
 
 		usleep(1);
@@ -1198,7 +1204,13 @@ static pthread_addr_t wget_base(void *arg)
 			goto errout;
 		} else if (len == 0) {
 			ndbg("Finish read\n");
-			goto errout;
+			if (mlen.message_len - mlen.sentence_start == mlen.content_len) {
+				ndbg("download completed successfully\n");
+				break;
+			} else {
+				ndbg("Error: Receive Fail\n");
+				goto errout;
+			}
 		}
 
 		usleep(1);


### PR DESCRIPTION
There is an intermittent case where recv is called one more time after receiving all files.
In this case, returning 0 from the recv function is not an error.
If all data is received, the return value is changed to WGET_OK.