### PR TITLE
framework/task_manager: Refactoring task_manager

### DIFF
--- a/framework/src/media/audio/resample/samplerate.h
+++ b/framework/src/media/audio/resample/samplerate.h
@@ -34,7 +34,6 @@
 
 #ifndef SAMPLERATE_H
 #define SAMPLERATE_H
-
 #ifdef __cplusplus
 extern "C" {
 #endif	/* __cplusplus */
@@ -90,13 +89,14 @@ struct src_data_s {
 	int channels_num;           // number of channels (1: mono, 2: stereo)
 	int origin_sample_rate;     // original sample rate
 	int origin_sample_width;    // original sample width (bits per sample), only support SAMPLE_WIDTH_16BITS now.
+	void *data_out;             // pointer to output sample buffer (user buffer)
+	int out_buf_length;         // length of data_out buffer (bytes)
 
 	/* input params - specify desired output */
 	int desired_sample_rate;    // target sample rate
 	int desired_sample_width;   // target sample width (bits per sample), only support SAMPLE_WIDTH_16BITS now.
 
 	/* output */
-	void *data_out;             // pointer to output sample buffer (internal buffer of resampler)
 	int output_frames_gen;      // number of output frames generated
 	int input_frames_used;      // number of frames used from input frames buffer
 	float src_ratio;            // desired_sample_rate/origin_sample_rate;

--- a/framework/src/task_manager/task_manager.c
+++ b/framework/src/task_manager/task_manager.c
@@ -92,7 +92,7 @@ static int tm_get_task_state(int handle)
 
 static int tm_check_permission(int handle, pid_t pid)
 {
-	int ret = ERROR;
+	int ret = TM_FAIL_NOT_PERMITTED;
 	int chk_idx;
 	int caller_gid = -1;
 
@@ -256,7 +256,7 @@ int task_manager(int argc, char *argv[])
 
 		sched_lock();
 
-		printf("Recevied Request msg : cmd = %d\n", request_msg.cmd);
+		tmdbg("Recevied Request msg : cmd = %d\n", request_msg.cmd);
 		switch (request_msg.cmd) {
 		case TASKMGT_REGISTER_TASK:
 			register_permission = request_msg.handle;
@@ -443,8 +443,6 @@ int task_manager(int argc, char *argv[])
 			ret = sigqueue(TASK_PID(request_msg.handle), SIGTM_UNICAST, msg);
 			if (ret != OK) {
 				tmdbg("Fail to send signal, errno : %d\n", errno);
-				TM_FREE(request_msg.data);
-				request_msg.data = NULL;
 				ret = TM_FAIL_SEND_MSG;
 			}
 			break;

--- a/os/include/signal.h
+++ b/os/include/signal.h
@@ -163,7 +163,7 @@
 #endif
 
 /* SIGTM is used in Task Manager */
-#ifndef CONFIG_SIG_SIGTM
+#ifndef CONFIG_SIG_SIGTM_UNICAST
 #define SIGTM_UNICAST       18			/* Taskmgt signal */
 #else
 #define SIGTM_UNICAST       CONFIG_SIG_SIGTM_UNICAST


### PR DESCRIPTION
1. set the default return value to TM_FAIL_NOT_PERMITTED in permission check
2. modify unnecessary printf to tmdbg
3. remove overlapped memory free logic