### PR TITLE
framework/task_manager: Add resource collection logic

### DIFF
--- a/framework/include/task_manager/task_manager.h
+++ b/framework/include/task_manager/task_manager.h
@@ -77,8 +77,9 @@
 #define TM_FAIL_REQ_TO_MGR            (-13)
 #define TM_FAIL_RESPONSE              (-14)
 #define TM_FAIL_UNREGISTER            (-15)
-#define TM_INVALID_PARAM              (-16)
-#define TM_OUT_OF_MEMORY              (-17)
+#define TM_FAIL_SET_TERMINATION_CB    (-16)
+#define TM_INVALID_PARAM              (-17)
+#define TM_OUT_OF_MEMORY              (-18)
 
 /**
  * @brief Task Info Structure
@@ -205,6 +206,14 @@ int task_manager_unicast(int handle, void *msg, int msg_size, int timeout);
  * @since TizenRT v2.0 PRE
  */
 int task_manager_set_handler(void (*func)(int signo, tm_msg_t *data));
+/**
+ * @brief Set callback function for resource deallocation API. If you set the callback, it will works when task is terminated.
+ * @details @b #include <task_manager/task_manager.h>
+ * @param[in] func the callback function which deallocate resources\n
+ * @return On success, OK is returned. On failure, defined negative value is returned.
+ * @since TizenRT v2.0 PRE
+ */
+int task_manager_set_termination_cb(void (*func)(void));
 /**
  * @brief Get task information list through task name
  * @details @b #include <task_manager/task_manager.h>

--- a/framework/src/task_manager/Kconfig
+++ b/framework/src/task_manager/Kconfig
@@ -7,6 +7,7 @@ config TASK_MANAGER
 	bool "Task Manager"
 	default n
 	select BUILTIN_APPS
+	select SCHED_ATEXIT
 	depends on !DISABLE_SIGNALS && !DISABLE_MQUEUE
 	---help---
 		Enables Task Manager.

--- a/framework/src/task_manager/taskmgr_interface.c
+++ b/framework/src/task_manager/taskmgr_interface.c
@@ -451,6 +451,18 @@ int task_manager_set_handler(void (*func)(int signo, tm_msg_t *data))
 	return OK;
 }
 
+int task_manager_set_termination_cb(void (*func)(void))
+{
+	if (func == NULL) {
+		return TM_INVALID_PARAM;
+	}
+
+	if (atexit((void *)func) != OK) {
+		return TM_FAIL_SET_TERMINATION_CB;
+	}
+	return OK;
+}
+
 task_info_list_t *task_manager_getinfo_with_name(char *name, int timeout)
 {
 	int status;


### PR DESCRIPTION
When request to terminate or restart, resource collection is needed.
So if user registered the resource collection handler, task_manager will call that handler.