### PR TITLE
Audio ioctl causes crash in NON-DEBUG build.

### DIFF
--- a/os/audio/audio.c
+++ b/os/audio/audio.c
@@ -316,10 +316,18 @@ static int audio_start(FAR struct audio_upperhalf_s *upper, FAR void *session)
 static int audio_start(FAR struct audio_upperhalf_s *upper)
 #endif
 {
-	FAR struct audio_lowerhalf_s *lower = upper->dev;
-	int ret = OK;
 
-	DEBUGASSERT(upper != NULL && lower->ops->start != NULL);
+	if (!upper) {
+		return -EINVAL;
+	}
+
+	FAR struct audio_lowerhalf_s *lower = upper->dev;
+
+	if (lower->ops->start == NULL) {
+		return -ENOSYS;
+	}
+
+	int ret = OK;
 
 	/* Verify that the Audio is not already running */
 
@@ -383,40 +391,55 @@ static int audio_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
 	 */
 
 	case AUDIOIOC_GETCAPS: {
-		FAR struct audio_caps_s *caps = (FAR struct audio_caps_s *)((uintptr_t) arg);
-		DEBUGASSERT(lower->ops->getcaps != NULL);
 
-		audvdbg("AUDIOIOC_GETCAPS: Device=%d\n", caps->ac_type);
+		if (lower->ops->getcaps != NULL) {
 
-		/* Call the lower-half driver capabilities handler */
+			FAR struct audio_caps_s *caps = (FAR struct audio_caps_s *)((uintptr_t) arg);
 
-		ret = lower->ops->getcaps(lower, caps->ac_type, caps);
+			audvdbg("AUDIOIOC_GETCAPS: Device=%d\n", caps->ac_type);
+
+
+			/* Call the lower-half driver capabilities handler */
+
+			ret = lower->ops->getcaps(lower, caps->ac_type, caps);
+		} else {
+			ret = -ENOSYS;
+		}
 	}
 	break;
 
 	case AUDIOIOC_CONFIGURE: {
-		FAR const struct audio_caps_desc_s *caps = (FAR const struct audio_caps_desc_s *)((uintptr_t) arg);
-		DEBUGASSERT(lower->ops->configure != NULL);
 
-		audvdbg("AUDIOIOC_INITIALIZE: Device=%d\n", caps->caps.ac_type);
+		if (lower->ops->configure != NULL) {
 
-		/* Call the lower-half driver configure handler */
+			FAR const struct audio_caps_desc_s *caps = (FAR const struct audio_caps_desc_s *)((uintptr_t) arg);
+
+			audvdbg("AUDIOIOC_CONFIGURE: Device=%d\n", caps->caps.ac_type);
+
+			/* Call the lower-half driver configure handler */
 
 #ifdef CONFIG_AUDIO_MULTI_SESSION
-		ret = lower->ops->configure(lower, caps->session, &caps->caps);
+			ret = lower->ops->configure(lower, caps->session, &caps->caps);
 #else
-		ret = lower->ops->configure(lower, &caps->caps);
+			ret = lower->ops->configure(lower, &caps->caps);
 #endif
+		} else {
+			ret = -ENOSYS;
+		}
 	}
 	break;
 
 	case AUDIOIOC_SHUTDOWN: {
-		DEBUGASSERT(lower->ops->shutdown != NULL);
 
-		audvdbg("AUDIOIOC_SHUTDOWN\n");
+		if (lower->ops->shutdown != NULL) {
 
-		/* Call the lower-half driver initialize handler */
-		ret = lower->ops->shutdown(lower);
+			audvdbg("AUDIOIOC_SHUTDOWN\n");
+
+			/* Call the lower-half driver initialize handler */
+			ret = lower->ops->shutdown(lower);
+		} else {
+			ret = -ENOSYS;
+		}
 	}
 	break;
 
@@ -427,61 +450,73 @@ static int audio_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
 	 */
 
 	case AUDIOIOC_START: {
-		audvdbg("AUDIOIOC_START\n");
-		DEBUGASSERT(lower->ops->start != NULL);
 
-		/* Start the audio stream */
+		if (lower->ops->start != NULL) {
+			audvdbg("AUDIOIOC_START\n");
+
+			/* Start the audio stream */
 
 #ifdef CONFIG_AUDIO_MULTI_SESSION
-		session = (FAR void *)arg;
-		ret = audio_start(upper, session);
+			session = (FAR void *)arg;
+			ret = audio_start(upper, session);
 #else
-		ret = audio_start(upper);
+			ret = audio_start(upper);
 #endif
+		} else {
+			ret = -ENOSYS;
+		}
 	}
 	break;
 
-		/* AUDIOIOC_STOP - Stop the audio stream.
-		 *
-		 *   ioctl argument:  Audio session
-		 */
+	/* AUDIOIOC_STOP - Stop the audio stream.
+	 *
+	 *   ioctl argument:  Audio session
+	 */
 
 #ifndef CONFIG_AUDIO_EXCLUDE_STOP
 	case AUDIOIOC_STOP: {
-		audvdbg("AUDIOIOC_STOP\n");
-		DEBUGASSERT(lower->ops->stop != NULL);
 
-		if (upper->started) {
+		if (lower->ops->stop != NULL) {
+			audvdbg("AUDIOIOC_STOP\n");
+
+			if (upper->started) {
 #ifdef CONFIG_AUDIO_MULTI_SESSION
-			session = (FAR void *)arg;
-			ret = lower->ops->stop(lower, session);
+				session = (FAR void *)arg;
+				ret = lower->ops->stop(lower, session);
 #else
-			ret = lower->ops->stop(lower);
+				ret = lower->ops->stop(lower);
 #endif
-			upper->started = false;
+				upper->started = false;
+			}
+		} else {
+			ret = -ENOSYS;
 		}
 	}
 	break;
 #endif							/* CONFIG_AUDIO_EXCLUDE_STOP */
 
-		/* AUDIOIOC_PAUSE - Pause the audio stream.
-		 *
-		 *   ioctl argument:  Audio session
-		 */
+	/* AUDIOIOC_PAUSE - Pause the audio stream.
+	 *
+	 *   ioctl argument:  Audio session
+	 */
 
 #ifndef CONFIG_AUDIO_EXCLUDE_PAUSE_RESUME
 
 	case AUDIOIOC_PAUSE: {
-		audvdbg("AUDIOIOC_PAUSE\n");
-		DEBUGASSERT(lower->ops->pause != NULL);
+		if (lower->ops->pause != NULL) {
 
-		if (upper->started) {
+			audvdbg("AUDIOIOC_PAUSE\n");
+
+			if (upper->started) {
 #ifdef CONFIG_AUDIO_MULTI_SESSION
-			session = (FAR void *)arg;
-			ret = lower->ops->pause(lower, session);
+				session = (FAR void *)arg;
+				ret = lower->ops->pause(lower, session);
 #else
-			ret = lower->ops->pause(lower);
+				ret = lower->ops->pause(lower);
 #endif
+			}
+		} else {
+			ret = -ENOSYS;
 		}
 	}
 	break;
@@ -492,16 +527,20 @@ static int audio_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
 	 */
 
 	case AUDIOIOC_RESUME: {
-		audvdbg("AUDIOIOC_RESUME\n");
-		DEBUGASSERT(lower->ops->resume != NULL);
 
-		if (upper->started) {
+		if (lower->ops->resume != NULL) {
+			audvdbg("AUDIOIOC_RESUME\n");
+
+			if (upper->started) {
 #ifdef CONFIG_AUDIO_MULTI_SESSION
-			session = (FAR void *)arg;
-			ret = lower->ops->resume(lower, session);
+				session = (FAR void *)arg;
+				ret = lower->ops->resume(lower, session);
 #else
-			ret = lower->ops->resume(lower);
+				ret = lower->ops->resume(lower);
 #endif
+			}
+		} else {
+			ret = -ENOSYS;
 		}
 	}
 	break;
@@ -554,12 +593,14 @@ static int audio_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
 	 */
 
 	case AUDIOIOC_ENQUEUEBUFFER: {
-		audvdbg("AUDIOIOC_ENQUEUEBUFFER\n");
 
-		DEBUGASSERT(lower->ops->enqueuebuffer != NULL);
-
-		bufdesc = (FAR struct audio_buf_desc_s *)arg;
-		ret = lower->ops->enqueuebuffer(lower, bufdesc->u.pBuffer);
+		if (lower->ops->enqueuebuffer != NULL) {
+			audvdbg("AUDIOIOC_ENQUEUEBUFFER\n");
+			bufdesc = (FAR struct audio_buf_desc_s *)arg;
+			ret = lower->ops->enqueuebuffer(lower, bufdesc->u.pBuffer);
+		} else {
+			ret = -ENOSYS;
+		}
 	}
 	break;
 
@@ -596,16 +637,20 @@ static int audio_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
 	 */
 
 	case AUDIOIOC_RESERVE: {
-		audvdbg("AUDIOIOC_RESERVE\n");
-		DEBUGASSERT(lower->ops->reserve != NULL);
 
-		/* Call lower-half to perform the reservation */
+		if (lower->ops->reserve != NULL) {
+			audvdbg("AUDIOIOC_RESERVE\n");
+
+			/* Call lower-half to perform the reservation */
 
 #ifdef CONFIG_AUDIO_MULTI_SESSION
-		ret = lower->ops->reserve(lower, (FAR void **)arg);
+			ret = lower->ops->reserve(lower, (FAR void **)arg);
 #else
-		ret = lower->ops->reserve(lower);
+			ret = lower->ops->reserve(lower);
 #endif
+		} else {
+			ret = -ENOSYS;
+		}
 	}
 	break;
 
@@ -615,25 +660,31 @@ static int audio_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
 	 */
 
 	case AUDIOIOC_RELEASE: {
-		audvdbg("AUDIOIOC_RELEASE\n");
-		DEBUGASSERT(lower->ops->release != NULL);
+		if (lower->ops->release != NULL) {
+			audvdbg("AUDIOIOC_RELEASE\n");
 
-		/* Call lower-half to perform the release */
+			/* Call lower-half to perform the release */
 
 #ifdef CONFIG_AUDIO_MULTI_SESSION
-		ret = lower->ops->release(lower, (FAR void *)arg);
+			ret = lower->ops->release(lower, (FAR void *)arg);
 #else
-		ret = lower->ops->release(lower);
+			ret = lower->ops->release(lower);
 #endif
+		} else {
+			ret = -ENOSYS;
+		}
 	}
 	break;
 
 	/* Any unrecognized IOCTL commands might be platform-specific ioctl commands */
 
 	default: {
-		audvdbg("Forwarding unrecognized cmd: %d arg: %ld\n", cmd, arg);
-		DEBUGASSERT(lower->ops->ioctl != NULL);
-		ret = lower->ops->ioctl(lower, cmd, arg);
+		if (lower->ops->ioctl != NULL) {
+			audvdbg("Forwarding unrecognized cmd: %d arg: %ld\n", cmd, arg);
+			ret = lower->ops->ioctl(lower, cmd, arg);
+		} else {
+			ret = -ENOSYS;
+		}
 	}
 	break;
 	}


### PR DESCRIPTION
Audio ioctl function crashes if lower ops dont support any operation
listed.