### PR TITLE
example/wifi_manager: Revision of wifi_manager stress test

### DIFF
--- a/apps/examples/wifi_manager_sample/Kconfig
+++ b/apps/examples/wifi_manager_sample/Kconfig
@@ -10,7 +10,6 @@ config EXAMPLES_WIFIMANAGER_TEST
 	---help---
 		Wi-Fi Manager sample program
 
-
 config USER_ENTRYPOINT
 	string
 	default "wm_test_main" if ENTRY_WIFIMANAGER_TEST
@@ -21,14 +20,18 @@ config EXAMPLES_WIFIMANAGER_STRESS_TEST
 	bool "Enable Sterss Test"
 	default n
 
-
 if EXAMPLES_WIFIMANAGER_STRESS_TEST
+config WIFIMANAGER_TEST_TRIAL
+	string "Number of test trial"
+	default "2"
+	---help---
+		Number of test trial
+
 config WIFIMANAGER_TEST_AP_SSID
 	string "SSID of AP"
 	default "SSID"
 	---help---
 		Select SSID of AP which you want to connect to
-
 
 config WIFIMANAGER_TEST_AP_PASSPHRASE
 	string "Passphrase of AP"

--- a/apps/examples/wifi_manager_sample/wm_test_stress.c
+++ b/apps/examples/wifi_manager_sample/wm_test_stress.c
@@ -29,7 +29,7 @@
 #define WM_AP_PASSWORD     CONFIG_WIFIMANAGER_TEST_AP_PASSPHRASE
 #define WM_AP_AUTH         CONFIG_WIFIMANAGER_TEST_AP_AUTHENTICATION
 #define WM_AP_CRYPTO       CONFIG_WIFIMANAGER_TEST_AP_CRYPTO
-
+#define WM_TEST_TRIAL	   CONFIG_WIFIMANAGER_TEST_TRIAL
 #define WM_SOFTAP_SSID     CONFIG_WIFIMANAGER_TEST_SOFTAP_SSID
 #define WM_SOFTAP_PASSWORD CONFIG_WIFIMANAGER_TEST_SOFTAP_PASSWORD
 #define WM_SOFTAP_CHANNEL  CONFIG_WIFIMANAGER_TEST_SOFTAP_CHANNEL
@@ -320,12 +320,12 @@ TEST_F(softap_stop)
 }
 
 
-RT_SET_SMOKE_TAIL(2, 3000, "station join", sta_join);
-RT_SET_SMOKE(2, 3000, "station leave", sta_leave, sta_join);
-RT_SET_SMOKE(2, 3000, "station scan", sta_scan, sta_leave);
-RT_SET_SMOKE(2, 3000, "softap start", softap_start, sta_scan);
-//RT_SET_SMOKE(2, 3000, "softap scan", softap_scan, softap_start);
-RT_SET_SMOKE(2, 3000, "softap stop", softap_stop, softap_start);
+RT_SET_SMOKE_TAIL((int)WM_TEST_TRIAL, 3000000, "station join", sta_join);
+RT_SET_SMOKE((int)WM_TEST_TRIAL, 100000, "station leave", sta_leave, sta_join);
+RT_SET_SMOKE((int)WM_TEST_TRIAL, 5000000, "station scan", sta_scan, sta_leave);
+RT_SET_SMOKE((int)WM_TEST_TRIAL, 1000000, "softap start", softap_start, sta_scan);
+//RT_SET_SMOKE((int)WM_TEST_TRIAL, 3000000, "softap scan", softap_scan, softap_start);
+RT_SET_SMOKE((int)WM_TEST_TRIAL, 2000000, "softap stop", softap_stop, softap_start);
 
 RT_SET_PACK(wifi, softap_stop);
 


### PR DESCRIPTION
- Add a configuration parameter of test trial number
- Modify output print messages
- Initialize min/max of execution time