### PR TITLE
example/wifi_manager: Revision of wifi_manager stress test

### DIFF
--- a/apps/examples/wifi_manager_sample/Kconfig
+++ b/apps/examples/wifi_manager_sample/Kconfig
@@ -10,7 +10,6 @@ config EXAMPLES_WIFIMANAGER_TEST
 	---help---
 		Wi-Fi Manager sample program
 
-
 config USER_ENTRYPOINT
 	string
 	default "wm_test_main" if ENTRY_WIFIMANAGER_TEST
@@ -21,14 +20,18 @@ config EXAMPLES_WIFIMANAGER_STRESS_TEST
 	bool "Enable Sterss Test"
 	default n
 
-
 if EXAMPLES_WIFIMANAGER_STRESS_TEST
+config WIFIMANAGER_TEST_TRIAL
+	int "Number of test trial"
+	default 5
+	---help---
+		Number of test trial
+
 config WIFIMANAGER_TEST_AP_SSID
 	string "SSID of AP"
 	default "SSID"
 	---help---
 		Select SSID of AP which you want to connect to
-
 
 config WIFIMANAGER_TEST_AP_PASSPHRASE
 	string "Passphrase of AP"

--- a/apps/examples/wifi_manager_sample/rt_perf.c
+++ b/apps/examples/wifi_manager_sample/rt_perf.c
@@ -26,9 +26,8 @@ _calc_performance(rt_performance *p, rt_elapsed_time *duration)
 {
 	rt_performance_time *start = &duration->start;
 	rt_performance_time *end = &duration->end;
-
-	printf("start %d %d\n", start->second, start->micro);
-	printf("end %d %d\n", end->second, end->micro);
+	unsigned int start_time = start->second*1000000 + start->micro;
+	unsigned int end_time = end->second*1000000 + end->micro;
 	rt_performance_stat *stat = &p->stat;
 	if (stat->count == 0) {
 		stat->start.second = start->second;
@@ -37,15 +36,20 @@ _calc_performance(rt_performance *p, rt_elapsed_time *duration)
 	stat->count++;
 	stat->end.second = end->second;
 	stat->end.micro = end->micro;
-
 	unsigned int elapsed = (end->second - start->second) * 1000000 + (end->micro - start->micro);
-	printf("elapsed %d\n", elapsed);
+	printf("TEST#%d\tstart %d end %d, elapsed %d us\n", stat->count, start_time, end_time, elapsed);
+	
 	stat->sum += elapsed;
-	if (elapsed > stat->max) {
+	if (stat->count == 1) {
 		stat->max = elapsed;
-	}
-	if (elapsed < stat->min) {
 		stat->min = elapsed;
+	} else {
+		if (elapsed > stat->max) {
+			stat->max = elapsed;
+		}
+		if (elapsed < stat->min) {
+			stat->min = elapsed;
+		}
 	}
 	if (p->expect != 0 && p->expect < elapsed) {
 		printf("timeout\n");
@@ -87,6 +91,7 @@ _run_smoke(rt_smoke *smoke)
 	rt_tc_result ret;
 	int perf_result;
 	rt_func *unit = smoke->func;
+	printf("Repeat size: %d\n", smoke->repeat_size);
 	for (; cnt < smoke->repeat_size; cnt++) {
 		if (unit->setup) {
 			ret = unit->setup(NULL);
@@ -121,7 +126,7 @@ void
 _print_stability(rt_stability *stab)
 {
 	rt_stability_stat *s = &stab->stat;
-	printf("S:\t%d\t%d\t%d\t%d\t:%d\n", s->count, s->pass, s->fail, s->skip, s->result);
+	printf("             %-11d%-8d%-8d%-7d         :%-d\n", s->count, s->pass, s->fail, s->skip, s->result);
 }
 
 
@@ -129,14 +134,14 @@ void
 _print_performance(rt_performance *perf)
 {
 	rt_performance_stat *p = &perf->stat;
-	printf("P:\t%d\t%d\t%d\t%d\t%d\t:%d\t", p->count, p->max, p->min, p->sum, p->fail, p->result);
+	printf("             %-11d%-8d%-8d%-8d%-8d:%-d\n", p->count, p->max/1000, p->min/1000, p->sum/1000, p->fail, p->result);
 }
 
 
 void
 _print_smoke(rt_smoke *smoke)
 {
-	printf("TC: %s\n", smoke->func->tc_name);
+	printf("TESTCASE: %s\n", smoke->func->tc_name);
 	_print_performance(smoke->performance);
 	_print_stability(smoke->stability);
 	printf("----------------------------------------------------------------------------\n");
@@ -164,8 +169,8 @@ perf_print_result(rt_pack *pack) {
 	rt_smoke *smoke = pack->head;
 	printf(COLOR_RESULT);
 	printf("============================================================================\n");
-	printf("performance: count\tmax\tmin\tsum\tfail\tresult\t");
-	printf("stability: count\tpass\tfail\tskip\tresult\n");
+	printf("PERFORMANCE: count\tmax\tmin\tsum\tfail\tresult\n");
+	printf("STABILITY  : count\tpass\tfail\tskip\t        result\n");
 	printf("----------------------------------------------------------------------------\n");
 	for (; smoke != NULL; smoke = smoke->next) {
 		_print_smoke(smoke);

--- a/apps/examples/wifi_manager_sample/wm_test_stress.c
+++ b/apps/examples/wifi_manager_sample/wm_test_stress.c
@@ -29,7 +29,7 @@
 #define WM_AP_PASSWORD     CONFIG_WIFIMANAGER_TEST_AP_PASSPHRASE
 #define WM_AP_AUTH         CONFIG_WIFIMANAGER_TEST_AP_AUTHENTICATION
 #define WM_AP_CRYPTO       CONFIG_WIFIMANAGER_TEST_AP_CRYPTO
-
+#define WM_TEST_TRIAL	   CONFIG_WIFIMANAGER_TEST_TRIAL
 #define WM_SOFTAP_SSID     CONFIG_WIFIMANAGER_TEST_SOFTAP_SSID
 #define WM_SOFTAP_PASSWORD CONFIG_WIFIMANAGER_TEST_SOFTAP_PASSWORD
 #define WM_SOFTAP_CHANNEL  CONFIG_WIFIMANAGER_TEST_SOFTAP_CHANNEL
@@ -320,12 +320,12 @@ TEST_F(softap_stop)
 }
 
 
-RT_SET_SMOKE_TAIL(2, 3000, "station join", sta_join);
-RT_SET_SMOKE(2, 3000, "station leave", sta_leave, sta_join);
-RT_SET_SMOKE(2, 3000, "station scan", sta_scan, sta_leave);
-RT_SET_SMOKE(2, 3000, "softap start", softap_start, sta_scan);
-//RT_SET_SMOKE(2, 3000, "softap scan", softap_scan, softap_start);
-RT_SET_SMOKE(2, 3000, "softap stop", softap_stop, softap_start);
+RT_SET_SMOKE_TAIL(WM_TEST_TRIAL, 3000000, "station join", sta_join);
+RT_SET_SMOKE(WM_TEST_TRIAL, 100000, "station leave", sta_leave, sta_join);
+RT_SET_SMOKE(WM_TEST_TRIAL, 5000000, "station scan", sta_scan, sta_leave);
+RT_SET_SMOKE(WM_TEST_TRIAL, 1000000, "softap start", softap_start, sta_scan);
+//RT_SET_SMOKE(WM_TEST_TRIAL, 3000000, "softap scan", softap_scan, softap_start);
+RT_SET_SMOKE(WM_TEST_TRIAL, 2000000, "softap stop", softap_stop, softap_start);
 
 RT_SET_PACK(wifi, softap_stop);
 


### PR DESCRIPTION
- Add a configuration parameter of test trial number
- Modify output print messages
- Initialize min/max of execution time