### PR TITLE
build/configs: support auto reset after download

### DIFF
--- a/build/configs/artik05x/artik05x_download.sh
+++ b/build/configs/artik05x/artik05x_download.sh
@@ -182,7 +182,7 @@ download()
 
 	# Download all binaries using openocd script
 	pushd ${OPENOCD_DIR_PATH} > /dev/null
-	${OPENOCD} -f ${CFG_FILE} -s ${SCRIPTS_PATH} -c "${commands} exit" || exit 1
+	${OPENOCD} -f ${CFG_FILE} -s ${SCRIPTS_PATH} -c "${commands}" -c "init; reset; exit" || exit 1
 	popd > /dev/null
 
 	echo "Flash DONE"

--- a/build/configs/sidk_s5jt200/sidk_s5jt200_download.sh
+++ b/build/configs/sidk_s5jt200/sidk_s5jt200_download.sh
@@ -99,7 +99,7 @@ main()
 
 			# download all binaries using openocd script
 			pushd ${OPENOCD_DIR_PATH}
-			${OPENOCD_BIN_PATH}/openocd -f s5jt200_silicon_evt0_fusing_flash_all.cfg || exit 1
+			${OPENOCD_BIN_PATH}/openocd -f s5jt200_silicon_evt0_fusing_flash_all.cfg -c "init; reset; exit" || exit 1
 			popd
 			;;
 


### PR DESCRIPTION
This patch supports auto reset after flashing all the built images on to the target.
It is better than pressing hardware reset button every time after flashing.

Signed-off-by: Lokesh B V <lokesh.bv@partner.samsung.com>