### PR TITLE
configs, tools: fix incorrect information on README

### DIFF
--- a/build/configs/artik053/README.md
+++ b/build/configs/artik053/README.md
@@ -175,7 +175,8 @@ Before executing below board-specific steps, execute [generic steps](../../../to
         ```bash
         Hardware Configuration -> Board Selection -> Automount partitions -> Automount romfs partiton to y
         ```
-4. Build TizenRT and flash a binary [using download script](#using-download-script)
+4. Build TizenRT and flash a binary.  
+    Refer [How to program a binary](#how-to-program-a-binary).
 
 ## How to use GDB
 1. Run OpenOCD daemon.

--- a/build/configs/artik053s/README.md
+++ b/build/configs/artik053s/README.md
@@ -173,7 +173,8 @@ Before executing below board-specific steps, execute [generic steps](../../../to
         ```bash
         Hardware Configuration -> Board Selection -> Automount partitions -> Automount romfs partiton to y
         ````
-4. Build TizenRT and flash a binary [using download script](#using-download-script)
+4. Build TizenRT and flash a binary.  
+    Refer [How to program a binary](#how-to-program-a-binary).
 
 ## How to use GDB
 1. Run OpenOCD daemon.

--- a/build/configs/artik055s/README.md
+++ b/build/configs/artik055s/README.md
@@ -179,7 +179,8 @@ Before executing below board-specific steps, execute [generic steps](../../../to
         ```bash
         Hardware Configuration -> Board Selection -> Automount partitions -> Automount romfs partiton to y
         ````
-4. Build TizenRT and flash a binary [using download script](#using-download-script)
+4. Build TizenRT and flash a binary.  
+    Refer [How to program a binary](#how-to-program-a-binary).
 
 ## How to use GDB
 1. Run OpenOCD daemon.

--- a/build/configs/sidk_s5jt200/README.md
+++ b/build/configs/sidk_s5jt200/README.md
@@ -134,8 +134,8 @@ Before executing below steps, execute [generic steps](../../../tools/fs/README_R
     ```bash
     Hardware Configuration -> Board Selection -> Automount partitions -> Automount ROM read only partition to y
     ```
-
-After above two steps, build TizenRT and program a TizenRT binary through above [method](#how-to-program-a-binary).
+5. Build TizenRT and flash a binary.  
+    Refer [How to program a binary](#how-to-program-a-binary).
 
 ## Using GDB
 1. Build TizenRT and program a TizenRT binary through above [method](#how-to-program-a-binary)

--- a/tools/fs/README_ROMFS.md
+++ b/tools/fs/README_ROMFS.md
@@ -8,9 +8,10 @@ sudo apt-get install genromfs
 ### Steps
 1. Enable ROMFS config through menuconfig at *os* folder.
 ```bash
-cd $TIZENRT_BASEDIR
+cd $TIZENRT_BASEDIR/os
 make menuconfig
 ```
+See [[Getting the sources]](https://github.com/Samsung/TizenRT#getting-the-sources) for how to set *TIZENRT_BASEDIR*.
 
 Select menu.
 ```bash


### PR DESCRIPTION
1. There is no [using download script] tab. It should be
[How to download a binary].
2. To run menuconfig, os folder is right, not on $TIZENRT_BASEDIR.

Signed-off-by: sunghan-chang <sh924.chang@samsung.com>