### PR TITLE
apps/builtin: Use shell default values of priority and stacksize

### DIFF
--- a/apps/Make.defs
+++ b/apps/Make.defs
@@ -51,17 +51,22 @@
 #
 ############################################################################
 
+include $(TOPDIR)/.config
+
 # Builtin Registration
 
 BUILTIN_REGISTRY = $(APPDIR)$(DELIM)builtin$(DELIM)registry
 
 DEPCONFIG = $(TOPDIR)$(DELIM).config
 
+CONFIG_TASH_CMDTASK_PRIORITY ?= 100
+CONFIG_TASH_CMDTASK_STACKSIZE ?= 4096
+
 ifeq ($(CONFIG_WINDOWS_NATIVE),y)
 define REGISTER
 	$(Q) echo Register: $1
 	$(Q) if [ -z $5 ]; then \
-		$(Q) echo { "$1", $2, $3, 100, 1024 }, > "$(BUILTIN_REGISTRY)$(DELIM)$2.mdat"; \
+		$(Q) echo { "$1", $2, $3, ${CONFIG_TASH_CMDTASK_PRIORITY}, ${CONFIG_TASH_CMDTASK_STACKSIZE} }, > "$(BUILTIN_REGISTRY)$(DELIM)$2.mdat"; \
 	else \
 		$(Q) echo { "$1", $2, $3, $4, $5 }, > "$(BUILTIN_REGISTRY)$(DELIM)$2.mdat"; \
 	fi
@@ -72,7 +77,7 @@ else
 define REGISTER
 	$(Q) echo "Register: $1"
 	$(Q) if [ -z $5 ]; then \
-		echo { \"$1\", $2,  $3, 100, 1024 }, > "$(BUILTIN_REGISTRY)$(DELIM)$2.mdat"; \
+		echo { \"$1\", $2,  $3, ${CONFIG_TASH_CMDTASK_PRIORITY}, ${CONFIG_TASH_CMDTASK_STACKSIZE} }, > "$(BUILTIN_REGISTRY)$(DELIM)$2.mdat"; \
 	else \
 		echo { \"$1\", $2, $3, $4, $5 }, > "$(BUILTIN_REGISTRY)$(DELIM)$2.mdat"; \
 	fi


### PR DESCRIPTION
When builtin feature is enabled and priority and stacksize is not
configured in each application, let's use default values of
priority and stacksize which is defined in shell Kconfig instead
of hard-coded in apps/Make.defs.