### PR TITLE
framework/wifi_manager: Unify control interface name

### DIFF
--- a/apps/examples/mdns_test/mdns_main.c
+++ b/apps/examples/mdns_test/mdns_main.c
@@ -71,8 +71,8 @@
 /****************************************************************************
  * Definitions
  ****************************************************************************/
-#if defined(CONFIG_ARCH_BOARD_SIDK_S5JT200) || defined(CONFIG_ARCH_BOARD_ARTIK053)
-#define MDNS_NETIF_NAME         "wl1"
+#if defined(CONFIG_WIFI_MANAGER)
+#define MDNS_NETIF_NAME	CONFIG_WIFIMGR_STA_IFNAME
 #else
 #error "cannot set MDNS_NETIF_NAME"
 #endif

--- a/apps/examples/testcase/ta_tc/device_management/itc/itc_dm_main.c
+++ b/apps/examples/testcase/ta_tc/device_management/itc/itc_dm_main.c
@@ -31,7 +31,12 @@
 #include "tc_common.h"
 #include "itc_internal.h"
 
+#ifdef CONFIG_WIFI_MANAGER
+#define NET_DEVNAME	CONFIG_WIFIMGR_STA_IFNAME
+#else
 #define NET_DEVNAME "wl1"
+#endif
+
 
 static int isConnected = 0;
 

--- a/apps/examples/testcase/ta_tc/device_management/utc/utc_dm_main.c
+++ b/apps/examples/testcase/ta_tc/device_management/utc/utc_dm_main.c
@@ -31,7 +31,11 @@
 #include "tc_common.h"
 #include "utc_internal.h"
 
+#ifdef CONFIG_WIFI_MANAGER
+#define NET_DEVNAME	CONFIG_WIFIMGR_STA_IFNAME
+#else
 #define NET_DEVNAME "wl1"
+#endif
 
 static int isConnected = 0;
 

--- a/apps/examples/wakaama_client/wakaama_client.c
+++ b/apps/examples/wakaama_client/wakaama_client.c
@@ -29,8 +29,11 @@
 #include <protocols/dhcpc.h>
 #include <slsi_wifi/slsi_wifi_api.h>
 
-
+#ifdef CONFIG_WIFI_MANAGER
+#define NET_DEVNAME	CONFIG_WIFIMGR_STA_IFNAME
+#else
 #define NET_DEVNAME "wl1"
+#endif
 
 #define WAKAAMA_CHECK_ARG() \
 	do {\

--- a/external/include/slsi_wifi/slsi_wifi_api.h
+++ b/external/include/slsi_wifi/slsi_wifi_api.h
@@ -40,7 +40,13 @@ extern "C"
 #endif
 
 /* interface name to use */
+#ifdef CONFIG_WIFI_MANAGER
+#define CTRL_IFNAME	CONFIG_WIFIMGR_STA_IFNAME
+#else
 #define CTRL_IFNAME "wl1"
+#endif
+
+
 
 #ifndef BIT
 #define BIT(x) (1 << (x))

--- a/external/wakaama/examples/client/connectivity_interface.c
+++ b/external/wakaama/examples/client/connectivity_interface.c
@@ -39,14 +39,16 @@ char cm_iobuffer[PROC_BUFFER_LEN];
 
 void get_interface_name(char *mac)
 {
-#if defined(CONFIG_WICED)
+#if defined(CONFIG_WIFI_MANAGER)
+	strcpy(mac,CONFIG_WIFIMGR_STA_IFNAME);
+#elif defined(CONFIG_WICED)
     strcpy(mac,"en1");
 #elif defined(CONFIG_NET_ETHERNET)
     strcpy(mac,"eth0");
 #elif defined(CONFIG_NET_802154)
     strcpy(mac,"wlan0");
-#elif defined(CONFIG_ARCH_BOARD_SIDK_S5JT200)
-    strcpy(mac, "wl1");
+#else
+	strcpy(mac,"wl1");
 #endif
 }
 

--- a/framework/src/dm/arch/sidk_s5jt200/s5j_dm_connectivity.c
+++ b/framework/src/dm/arch/sidk_s5jt200/s5j_dm_connectivity.c
@@ -50,7 +50,11 @@
 
 #define DM_CALLBACK_BUFFER_SIZE 10
 #define DM_BSSID_LEN            18
-#define DM_NET_DEVNAME          "wl1"
+#ifdef CONFIG_WIFI_MANAGER
+#define DM_NET_DEVNAME	CONFIG_WIFIMGR_STA_IFNAME
+#else
+#define DM_NET_DEVNAME "wl1"
+#endif
 
 /* Static data structure to hold results of a WiFi scan.
  */


### PR DESCRIPTION
- Change the way to specify the interface name according to the configuration set by wifi manager, not forced to set 'wl1'