### PR TITLE
libc++: allocate thread_specific_ptr per task

### DIFF
--- a/external/include/libcxx/__threading_support
+++ b/external/include/libcxx/__threading_support
@@ -117,7 +117,7 @@ int __libcpp_tls_create(__libcpp_tls_key* __key, void (*__at_exit)(void*));
 _LIBCPP_THREAD_ABI_VISIBILITY
 void* __libcpp_tls_get(__libcpp_tls_key __key);
 _LIBCPP_THREAD_ABI_VISIBILITY
-void __libcpp_tls_set(__libcpp_tls_key __key, void* __p);
+int __libcpp_tls_set(__libcpp_tls_key __key, void* __p);
 
 #if defined(_LIBCPP_HAS_THREAD_API_PTHREAD) || defined(_LIBCPP_BUILDING_EXTERNAL_THREADS)
 
@@ -247,9 +247,9 @@ void* __libcpp_tls_get(__libcpp_tls_key __key)
     return pthread_getspecific(__key);
 }
 
-void __libcpp_tls_set(__libcpp_tls_key __key, void* __p)
+int __libcpp_tls_set(__libcpp_tls_key __key, void* __p)
 {
-    pthread_setspecific(__key, __p);
+    return pthread_setspecific(__key, __p);
 }
 
 #endif // _LIBCPP_HAS_THREAD_API_PTHREAD || _LIBCPP_BUILDING_EXTERNAL_THREADS

--- a/external/include/libcxx/thread
+++ b/external/include/libcxx/thread
@@ -159,7 +159,6 @@ class __thread_specific_ptr
      // Only __thread_local_data() may construct a __thread_specific_ptr
      // and only with _Tp == __thread_struct.
     static_assert((is_same<_Tp, __thread_struct>::value), "");
-    __thread_specific_ptr();
     friend _LIBCPP_FUNC_VIS __thread_specific_ptr<__thread_struct>& __thread_local_data();
 
     __thread_specific_ptr(const __thread_specific_ptr&);
@@ -169,6 +168,7 @@ class __thread_specific_ptr
 public:
     typedef _Tp* pointer;
 
+    __thread_specific_ptr();
     ~__thread_specific_ptr();
 
     _LIBCPP_INLINE_VISIBILITY
@@ -213,7 +213,10 @@ __thread_specific_ptr<_Tp>::set_pointer(pointer __p)
 {
     _LIBCPP_ASSERT(get() == nullptr,
                    "Attempting to overwrite thread local data");
-    __libcpp_tls_set(__key_, __p);
+    if (__libcpp_tls_set(__key_, __p) != 0)
+    {
+        delete static_cast<pointer>(__p);
+    }
 }
 
 class _LIBCPP_TYPE_VIS thread;
@@ -354,10 +357,21 @@ __thread_execute(tuple<_TSp, _Fp, _Args...>& __t, __tuple_indices<_Indices...>)
     __invoke(_VSTD::move(_VSTD::get<1>(__t)), _VSTD::move(_VSTD::get<_Indices>(__t))...);
 }
 
+#if defined(__TINYARA__)
+extern "C" void* __libcpp_get_tls_pointer();
+extern "C" void  __libcpp_set_tls_pointer(void *);
+extern "C" int on_exit(void (*func)(int, void *), void *arg);
+
+void thread_specific_ptr_init(void);
+#endif
+
 template <class _Fp>
 void* __thread_proxy(void* __vp)
 {
     // _Fp = std::tuple< unique_ptr<__thread_struct>, Functor, Args...>
+#if defined(__TINYARA__)
+    thread_specific_ptr_init();
+#endif
     std::unique_ptr<_Fp> __p(static_cast<_Fp*>(__vp));
     __thread_local_data().set_pointer(_VSTD::get<0>(*__p).release());
     typedef typename __make_tuple_indices<tuple_size<_Fp>::value, 2>::type _Index;
@@ -400,6 +414,9 @@ template <class _Fp>
 void* __thread_proxy_cxx03(void* __vp)
 {
     std::unique_ptr<_Fp> __p(static_cast<_Fp*>(__vp));
+#if defined(__TINYARA__)
+    thread_specific_ptr_init();
+#endif
     __thread_local_data().set_pointer(__p->__tsp_.release());
     (__p->__fn_)();
     return nullptr;

--- a/lib/libxx/Makefile
+++ b/lib/libxx/Makefile
@@ -75,6 +75,11 @@ ifeq ($(CONFIG_LIBCXX_HAVE_LIBSUPCXX),y)
 CSRCS += libxx_newlib_impure.c
 endif
 
+# custom task specific tls data pointer implementation
+ifeq ($(CONFIG_LIBCXX),y)
+CSRCS += libcpp_tls_pointer.c
+endif
+
 # Paths
 
 DEPPATH = --dep-path .

--- a/lib/libxx/libcpp_tls_pointer.c
+++ b/lib/libxx/libcpp_tls_pointer.c
@@ -1,0 +1,97 @@
+/****************************************************************************
+ *
+ * Copyright 2018 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <tinyara/config.h>
+
+#include <sched.h>
+#include <errno.h>
+#include <assert.h>
+#include <debug.h>
+
+/* Its workaround implementation to provide to per task tls data.
+ * current libc++ uses static storage which resides in global space
+ * and it failes because of globals symbols cannot be reset upon task exit
+ * and even though we tried to reset only seleted symbols during exit,
+ * concurrent c++ taks using the same global symbols would crash.
+ * Hence we store the tls data pointer in the task group on per task basis
+ * Note : It will work for flat memory model. For protected & kernel
+ * mode it will break the ABI(application interface)
+ */
+#if !defined(CONFIG_BUILD_PROTECTED) || !defined(CONFIG_BUILD_KERNEL)
+/****************************************************************************
+ * Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Type Declarations
+ ****************************************************************************/
+
+/****************************************************************************
+ * Global Variables
+ ****************************************************************************/
+/* Fix ME: */
+extern volatile dq_queue_t g_readytorun;
+/****************************************************************************
+ * Private Variables
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: __libcpp_get_tls_pointer
+ *
+ * Description:
+ *    Returns tls data pointer
+ ****************************************************************************/
+
+void *__libcpp_get_tls_pointer(void)
+{
+	struct pthread_tcb_s *rtcb = (struct pthread_tcb_s *)((FAR struct tcb_s *)g_readytorun.head);
+	struct task_group_s *group = rtcb->cmn.group;
+
+	DEBUGASSERT(group && (rtcb->cmn.flags & TCB_FLAG_TTYPE_MASK) == TCB_FLAG_TTYPE_PTHREAD);
+
+	return group->__libcpp_tls_pointer;
+}
+
+/****************************************************************************
+ * Name: __libcpp_set_tls_pointer
+ *
+ * Description:
+ *    set tls data pointer
+ ****************************************************************************/
+void __libcpp_set_tls_pointer(void *__p)
+{
+	struct pthread_tcb_s *rtcb = (struct pthread_tcb_s *)((FAR struct tcb_s *)g_readytorun.head);
+	struct task_group_s *group = rtcb->cmn.group;
+
+	DEBUGASSERT(group && (rtcb->cmn.flags & TCB_FLAG_TTYPE_MASK) == TCB_FLAG_TTYPE_PTHREAD);
+
+	group->__libcpp_tls_pointer = __p;
+}
+#endif	/* !defined(CONFIG_BUILD_PROTECTED) || !defined(CONFIG_BUILD_KERNEL) */

--- a/os/include/tinyara/sched.h
+++ b/os/include/tinyara/sched.h
@@ -410,6 +410,10 @@ struct task_group_s {
 #endif
 #endif
 
+#if defined(CONFIG_LIBCXX)
+	void *__libcpp_tls_pointer;
+#endif
+
 #ifndef CONFIG_DISABLE_SIGNALS
 	/* POSIX Signal Control Fields *********************************************** */
 


### PR DESCRIPTION
There is problem due to static constructor.  current libc++ uses pthread key for thread local storage which is constructed on static storage space which resides in global space.

It works on Linux, because each process will get a separate global symbols, where as in tizenrt global symbols are shared across all application/task(due to flat memory model) and global symbols wont reset even after task exit.              
                                                                                 
Hence in tizenrt case, it fails because of global symbols cannot be reset upon task exit  and even though we tried to reset only selected symbols during exit, concurrent c++ tasks using the same global symbols(tls) would crash.

To avoid this, as a workaround for tizenrt, We have stored the TLS object(key) pointer in the task group on per task basis instead of static object. So each  task would create a separate key and all its 
threads use the same keys.

Also there is one more patch to avoid registration of lot of static destructors which are not useful incase of tizenrt