### PR TITLE
framework/wifi_manager: Unification of SSID length 

### DIFF
--- a/apps/examples/wifi_manager_sample/wm_test.c
+++ b/apps/examples/wifi_manager_sample/wm_test.c
@@ -399,11 +399,13 @@ void wm_set_info(void *arg)
 	WM_TEST_LOG_START;
 	struct options *ap_info = (struct options *)arg;
 	wifi_manager_ap_config_s apconfig;
-	strncpy(apconfig.ssid, ap_info->ssid, 33);
+	strncpy(apconfig.ssid, ap_info->ssid, WIFIMGR_SSID_LEN-1);
 	apconfig.ssid_length = strlen(ap_info->ssid);
+	apconfig.ssid[WIFIMGR_SSID_LEN-1] = '\0';
 	apconfig.ap_auth_type = ap_info->auth_type;
 	if (apconfig.ap_auth_type != WIFI_MANAGER_AUTH_OPEN) {
-		strncpy(apconfig.passphrase, ap_info->password, 64);
+		strncpy(apconfig.passphrase, ap_info->password, WIFIMGR_PASSPHRASE_LEN-1);
+		apconfig.passphrase[WIFIMGR_PASSPHRASE_LEN-1] = '\0';
 		apconfig.passphrase_length = strlen(ap_info->password);
 		apconfig.ap_crypto_type = ap_info->crypto_type;
 	}
@@ -531,11 +533,13 @@ void wm_connect(void *arg)
 	WM_TEST_LOG_START;
 	struct options *ap_info = (struct options *)arg;
 	wifi_manager_ap_config_s apconfig;
-	strncpy(apconfig.ssid, ap_info->ssid, 33);
+	strncpy(apconfig.ssid, ap_info->ssid, WIFIMGR_SSID_LEN-1);
 	apconfig.ssid_length = strlen(ap_info->ssid);
+	apconfig.ssid[WIFIMGR_SSID_LEN-1] = '\0';
 	apconfig.ap_auth_type = ap_info->auth_type;
 	if (ap_info->auth_type != WIFI_MANAGER_AUTH_OPEN) {
-		strncpy(apconfig.passphrase, ap_info->password, 64);
+		strncpy(apconfig.passphrase, ap_info->password, WIFIMGR_PASSPHRASE_LEN-1);
+		apconfig.passphrase[WIFIMGR_PASSPHRASE_LEN-1] = '\0';
 		apconfig.passphrase_length = strlen(ap_info->password);
 		apconfig.ap_crypto_type = ap_info->crypto_type;
 	}
@@ -589,16 +593,16 @@ void wm_softap_start(void *arg)
 	WM_TEST_LOG_START;
 	wifi_manager_result_e res = WIFI_MANAGER_SUCCESS;
 	struct options *ap_info = (struct options *)arg;
-	if (strlen(ap_info->ssid) >= 32 || strlen(ap_info->password) >= 64) {
+	if (strlen(ap_info->ssid) > WIFIMGR_SSID_LEN || strlen(ap_info->password) > WIFIMGR_PASSPHRASE_LEN) {
 		printf("Param Error\n");
 		WM_TEST_LOG_END;
 		return;
 	}
 	wifi_manager_softap_config_s ap_config;
-	strcpy(ap_config.ssid, ap_info->ssid);
-	ap_config.ssid[strlen(ap_info->ssid)] = '\0';
-	strcpy(ap_config.passphrase, ap_info->password);
-	ap_config.passphrase[strlen(ap_info->password)] = '\0';
+	strncpy(ap_config.ssid, ap_info->ssid, WIFIMGR_SSID_LEN-1);
+	ap_config.ssid[WIFIMGR_SSID_LEN-1] = '\0';
+	strncpy(ap_config.passphrase, ap_info->password, WIFIMGR_PASSPHRASE_LEN-1);
+	ap_config.passphrase[WIFIMGR_PASSPHRASE_LEN-1] = '\0';
 	ap_config.channel = 1;
 
 	print_wifi_softap_profile(&ap_config, "AP INFO");
@@ -623,18 +627,20 @@ void wm_auto_test(void *arg)
 
 	/* Set SoftAP Configuration */
 	wifi_manager_softap_config_s softap_config;
-	strncpy(softap_config.ssid, info->softap_ssid, 33);
-	softap_config.ssid[strlen(info->ssid)] = '\0';
-	strncpy(softap_config.passphrase, info->softap_password, 64);
-	softap_config.passphrase[strlen(info->password)] = '\0';
+	strncpy(softap_config.ssid, info->softap_ssid, WIFIMGR_SSID_LEN-1);
+	softap_config.ssid[WIFIMGR_SSID_LEN-1] = '\0';
+	strncpy(softap_config.passphrase, info->softap_password, WIFIMGR_PASSPHRASE_LEN-1);
+	softap_config.passphrase[WIFIMGR_PASSPHRASE_LEN-1] = '\0';
 	softap_config.channel = 1;
 
 	/* Set AP Configuration */
 	wifi_manager_ap_config_s ap_config;
-	strncpy(ap_config.ssid, info->ssid, 33);
+	strncpy(ap_config.ssid, info->ssid, WIFIMGR_SSID_LEN-1);
 	ap_config.ssid_length = strlen(info->ssid);
-	strncpy(ap_config.passphrase, info->password, 64);
+	ap_config.ssid[WIFIMGR_SSID_LEN-1] = '\0';
+	strncpy(ap_config.passphrase, info->password, WIFIMGR_PASSPHRASE_LEN-1);
 	ap_config.passphrase_length = strlen(info->password);
+	ap_config.passphrase[WIFIMGR_PASSPHRASE_LEN-1] = '\0';
 	ap_config.ap_auth_type = info->auth_type;
 	ap_config.ap_crypto_type = info->crypto_type;
 
@@ -645,8 +651,11 @@ void wm_auto_test(void *arg)
 	wifi_manager_ap_config_s fake_config;
 	fake_config.ssid_length = strlen(fake_long_ssid);
 	fake_config.passphrase_length = strlen(fake_passphrase);
-	strncpy(fake_config.ssid, fake_long_ssid, fake_config.ssid_length + 1);
-	strncpy(fake_config.passphrase, fake_passphrase, fake_config.passphrase_length + 1);
+	//Long SSID passed to Wi-Fi Manager 
+	strncpy(fake_config.ssid, fake_long_ssid, fake_config.ssid_length);
+	fake_config.ssid[fake_config.ssid_length + 1] = '\0';
+	strncpy(fake_config.passphrase, fake_passphrase, fake_config.passphrase_length);
+	fake_config.passphrase[fake_config.passphrase_length + 1] = '\0';
 	fake_config.ap_auth_type = 2;
 	fake_config.ap_crypto_type = 3;
 	
@@ -686,7 +695,8 @@ void wm_auto_test(void *arg)
 			printf("AP connect failed due to bad configuration: long SSID\n");
 			res = WIFI_MANAGER_FAIL;
 			fake_config.ssid_length = strlen(fake_ssid);
-			strncpy(fake_config.ssid, fake_ssid, fake_config.ssid_length + 1);
+			strncpy(fake_config.ssid, fake_ssid, fake_config.ssid_length);
+			fake_config.ssid[fake_config.ssid_length + 1] = '\0';
 		}
 		printf("Connecting to fake AP (Auth/Crypto type 2/3)\n");
 		/* Connect to fake AP */

--- a/framework/include/wifi_manager/wifi_manager.h
+++ b/framework/include/wifi_manager/wifi_manager.h
@@ -31,6 +31,12 @@
 #ifndef WIFI_MANAGER_H
 #define WIFI_MANAGER_H
 
+/* Length defines */
+#define WIFIMGR_MACADDR_LEN        6
+#define WIFIMGR_MACADDR_STR_LEN    18
+#define WIFIMGR_SSID_LEN           32
+#define WIFIMGR_PASSPHRASE_LEN     64
+
 /**
  * @brief Status of Wi-Fi interface such as connected or disconnected
  */
@@ -95,8 +101,8 @@ typedef enum {
  * @brief Keep information of nearby access points as scan results
  */
 struct wifi_manager_scan_info_s {
-	char ssid[33];	// 802.11 spec defined unspecified or uint8
-	char bssid[18];	// char string e.g. xx:xx:xx:xx:xx:xx
+	char ssid[WIFIMGR_SSID_LEN];	// 802.11 spec defined unspecified or uint8
+	char bssid[WIFIMGR_MACADDR_STR_LEN];	// char string e.g. xx:xx:xx:xx:xx:xx
 	int8_t rssi;		// received signal strength indication
 	uint8_t channel;	// channel/frequency
 	uint8_t phy_mode;	// 0:legacy 1: 11N HT
@@ -120,9 +126,9 @@ typedef struct {
  * @brief Keep Wi-Fi Manager information including ip/mac address, ssid, rssi, etc.
  */
 typedef struct {
-	char ip4_address[18];
-	char ssid[32];
-	char mac_address[6];	   /**<  MAC address of wifi interface             */
+	char ip4_address[WIFIMGR_MACADDR_STR_LEN];
+	char ssid[WIFIMGR_SSID_LEN];
+	char mac_address[WIFIMGR_MACADDR_LEN];	   /**<  MAC address of wifi interface             */
 	int rssi;
 	connect_status_e status;
 	wifi_manager_mode_e mode;
@@ -132,7 +138,7 @@ typedef struct {
  * @brief Specify information of soft access point (softAP) such as ssid and channel number
  */
 typedef struct {
-	char ssid[32];
+	char ssid[WIFIMGR_SSID_LEN];
 	char passphrase[64];
 	uint16_t channel;
 } wifi_manager_softap_config_s;
@@ -179,9 +185,9 @@ typedef enum {
  * @brief Specify which access point (AP) a client connects to
  */
 typedef struct {
-	char ssid[32];							 /**<  Service Set Identification         */
+	char ssid[WIFIMGR_SSID_LEN];							 /**<  Service Set Identification         */
 	unsigned int ssid_length;				 /**<  Service Set Identification Length  */
-	char passphrase[64];					 /**<  ap passphrase(password)            */
+	char passphrase[WIFIMGR_PASSPHRASE_LEN];					 /**<  ap passphrase(password)            */
 	unsigned int passphrase_length;			 /**<  ap passphrase length               */
 	wifi_manager_ap_auth_type_e ap_auth_type;	  /**<  @ref wifi_utils_ap_auth_type   */
 	wifi_manager_ap_crypto_type_e ap_crypto_type;  /**<  @ref wifi_utils_ap_crypto_type */


### PR DESCRIPTION
- Add WIFIMGR's string length definition.
- AP configuration structure should have a SSID with a length of WIFIMGR_SSID_LEN.
Some of them have a length of 33, which causes SVACE criticals.