### PR TITLE
kernel/task: Remove unnecessary DEBUGASSERT for group_findchild in ta…

### DIFF
--- a/os/kernel/task/task_exithook.c
+++ b/os/kernel/task/task_exithook.c
@@ -227,7 +227,6 @@ static inline void task_exitstatus(FAR struct task_group_s *group, int status)
 		/* No.. Find the exit status entry for this task in the parent TCB */
 
 		child = group_findchild(group, getpid());
-		DEBUGASSERT(child);
 		if (child) {
 #ifndef HAVE_GROUP_MEMBERS
 			/* No group members? Save the exit status */
@@ -270,7 +269,6 @@ static inline void task_groupexit(FAR struct task_group_s *group)
 		/* No.. Find the exit status entry for this task in the parent TCB */
 
 		child = group_findchild(group, getpid());
-		DEBUGASSERT(child);
 		if (child) {
 			/* Mark that all members of the child task group has exited */
 


### PR DESCRIPTION
…sk_exithook.c

For all cases, the return value of group_findchild is checked in the below.