### PR TITLE
fs: Fix wrong typo in fs_auto_mount

### DIFF
--- a/os/fs/fs_initialize.c
+++ b/os/fs/fs_initialize.c
@@ -91,7 +91,7 @@ void fs_auto_mount(void)
 		const char *fs_mountpoint;
 	} fs_automount[] = {
 #ifdef CONFIG_FS_AUTOMOUNT_PROCFS
-		{ "procfs", "/procfs" },
+		{ "procfs", "/proc" },
 #endif
 		{ NULL, NULL }
 	};


### PR DESCRIPTION
Fix wrong typo "/procfs", which should be "/proc" in fs_auto_mount().

Signed-off-by: Lokesh B V <lokesh.bv@partner.samsung.com>