### PR TITLE
init : do up_cxxinitialize during application init

### DIFF
--- a/apps/platform/gnu/gnu_cxxinitialize.c
+++ b/apps/platform/gnu/gnu_cxxinitialize.c
@@ -123,6 +123,14 @@ extern uint32_t _etext;
 void up_cxxinitialize(void)
 {
 	initializer_t *initp;
+#if !defined(CONFIG_BUILD_KERNEL)
+	static bool cxxinitialized = false;
+
+	if (cxxinitialized)
+		return;
+
+	cxxinitialized = true;
+#endif
 
 	cxxinfo("_sinit: %p _einit: %p _stext: %p _etext: %p\n", &_sinit, &_einit, &_stext, &_etext);
 

--- a/os/kernel/init/os_bringup.c
+++ b/os/kernel/init/os_bringup.c
@@ -250,6 +250,10 @@ static inline void os_do_appstart(void)
 
 	svdbg("Starting application init thread\n");
 
+#if !defined(CONFIG_BUILD_KERNEL) && defined(CONFIG_HAVE_CXXINITIALIZE)
+	up_cxxinitialize();
+#endif
+
 #ifdef CONFIG_SYSTEM_PREAPP_INIT
 #ifdef CONFIG_BUILD_PROTECTED
 	DEBUGASSERT(USERSPACE->preapp_start != NULL);


### PR DESCRIPTION
up_cxxinitialize is to perform initialization of the
static C++ class instances. All the static initializers
are put in init section(sinit <--> _einit) during build time
and before application start all these initializers must be
invoked by parsing init section.

But in case of Flat address space, all application's initializers are
put into init section of a single blob.

Hence up_cxxinitialize need not to be performed in each application start,
instead it can invoked during application init in os bringup.

This patch makes up_cxxinitialize to perfrom initialization only once and
any subsequent invokations, are ingored.

Signed-off-by: Manohara HK <manohara.hk@samsung.com>