### PR TITLE
framework/media: Refine decoder buffer usage

### DIFF
--- a/framework/include/media/FileInputDataSource.h
+++ b/framework/include/media/FileInputDataSource.h
@@ -101,10 +101,11 @@ public:
 	 * @details @b #include <media/FileInputDataSource.h>
 	 * @param[out] buf The buf that read the data and fill it into the buffer
 	 * @param[in] size The size that the size of the buffer
-	 * @return if there is nothing to read, it returns 0, else readead size returns
+	 * @return if there is nothing to read, it returns 0
+	 *         if error occurred, it returns -1, else readead size returns
 	 * @since TizenRT v2.0 PRE
 	 */
-	size_t read(unsigned char* buf, size_t size) override;
+	ssize_t read(unsigned char* buf, size_t size) override;
 
 	/**
 	 * @brief Gets the file data

--- a/framework/include/media/FileOutputDataSource.h
+++ b/framework/include/media/FileOutputDataSource.h
@@ -106,16 +106,17 @@ public:
 	 * @since TizenRT v2.0 PRE
 	 */
 	bool close() override;
-	
+
 	/**
 	 * @brief Puts the file data
 	 * @details @b #include <media/FileOutputDataSource.h>
 	 * @param[in] buf The buf that buffer to be written to the file
 	 * @param[in] size The size that the size of the buffer
-	 * @return if there is nothing to write, it returns 0, else written size returns
+	 * @return if there is nothing to write, it returns 0
+	 *         if error occurred, it returns -1, else written size returns
 	 * @since TizenRT v2.0 PRE
 	 */
-	size_t write(unsigned char* buf, size_t size) override;
+	ssize_t write(unsigned char* buf, size_t size) override;
 
 private:
 	std::string mDataPath;

--- a/framework/include/media/InputDataSource.h
+++ b/framework/include/media/InputDataSource.h
@@ -69,13 +69,13 @@ public:
 	 * @since TizenRT v2.0 PRE
 	 */
 	virtual ~InputDataSource();
-  
+
   	/**
 	 * @brief Gets the stream data
 	 * @details @b #include <media/InputDataSource.h>
 	 * @since TizenRT v2.0 PRE
 	 */
-	virtual size_t read(unsigned char* buf, size_t size) = 0;
+	virtual ssize_t read(unsigned char* buf, size_t size) = 0;
 
   	/**
 	 * @brief Gets the stream data from offset

--- a/framework/include/media/OutputDataSource.h
+++ b/framework/include/media/OutputDataSource.h
@@ -53,11 +53,11 @@ public:
 	 * @details @b #include <media/OutputDataSource.h>
 	 * param[in] channels   The channels that the channels of audio
 	 * param[in] sampleRate The sampleRate that the sample rate of audio
-	 * param[in] pcmFormat  The pcmFormat that the pcm format of audio	
+	 * param[in] pcmFormat  The pcmFormat that the pcm format of audio
 	 * @since TizenRT v2.0 PRE
 	 */
 	OutputDataSource(unsigned short channels, unsigned int sampleRate, int pcmFormat);
-	
+
 	/**
 	 * @brief Copy constructs for OutputDataSource.
 	 * @details @b #include <media/OutputDataSource.h>
@@ -83,7 +83,7 @@ public:
 	 * @details @b #include <media/OutputDataSource.h>
 	 * @since TizenRT v2.0 PRE
 	 */
-	virtual size_t write(unsigned char* buf, size_t size) = 0;
+	virtual ssize_t write(unsigned char* buf, size_t size) = 0;
 };
 } // namespace stream
 } // namespace media

--- a/framework/include/media/SocketOutputDataSource.h
+++ b/framework/include/media/SocketOutputDataSource.h
@@ -112,16 +112,17 @@ public:
 	 * @since TizenRT v2.0 PRE
 	 */
 	bool close() override;
-	
+
 	/**
 	 * @brief Puts the file data
 	 * @details @b #include <media/SocketOutputDataSource.h>
 	 * @param[in] buf The buf that buffer to be written to the file
 	 * @param[in] size The size that the size of the buffer
-	 * @return if there is nothing to write, it returns 0, else written size returns
+	 * @return if there is nothing to write, it returns 0
+	 *         if error occurred, it returns -1, else written size returns
 	 * @since TizenRT v2.0 PRE
 	 */
-	size_t write(unsigned char* buf, size_t size) override;
+	ssize_t write(unsigned char* buf, size_t size) override;
 
 private:
 	std::string mIpAddr;

--- a/framework/src/media/FileOutputDataSource.cpp
+++ b/framework/src/media/FileOutputDataSource.cpp
@@ -25,7 +25,7 @@ namespace stream {
 
 FileOutputDataSource::FileOutputDataSource(const std::string& dataPath)
 	: OutputDataSource(), mDataPath(dataPath), mFp(nullptr)
-{	
+{
 }
 
 FileOutputDataSource::FileOutputDataSource(unsigned short channels, unsigned int sampleRate, int pcmFormat, const std::string& dataPath)
@@ -33,7 +33,7 @@ FileOutputDataSource::FileOutputDataSource(unsigned short channels, unsigned int
 {
 }
 
-FileOutputDataSource::FileOutputDataSource(const FileOutputDataSource& source) : 
+FileOutputDataSource::FileOutputDataSource(const FileOutputDataSource& source) :
 	OutputDataSource(source), mDataPath(source.mDataPath), mFp(source.mFp)
 {
 }
@@ -76,7 +76,7 @@ bool FileOutputDataSource::isPrepare()
 	return (mFp != nullptr);
 }
 
-size_t FileOutputDataSource::write(unsigned char* buf, size_t size)
+ssize_t FileOutputDataSource::write(unsigned char* buf, size_t size)
 {
 	if (!buf) {
 		return (size_t)0;

--- a/framework/src/media/MediaPlayerImpl.cpp
+++ b/framework/src/media/MediaPlayerImpl.cpp
@@ -87,7 +87,7 @@ player_result_t MediaPlayerImpl::destroy()
 
 	mpw.enQueue(&MediaPlayerImpl::destroyPlayer, shared_from_this(), std::ref(ret));
 	mSyncCv.wait(lock);
-	
+
 	if (ret == PLAYER_OK) {
 		if (mPlayerObserver) {
 			PlayerObserverWorker& pow = PlayerObserverWorker::getWorker();
@@ -133,7 +133,7 @@ player_result_t MediaPlayerImpl::prepare()
 	mpw.enQueue(&MediaPlayerImpl::preparePlayer, shared_from_this(), std::ref(ret));
 	mSyncCv.wait(lock);
 
-	return ret;	
+	return ret;
 }
 
 void MediaPlayerImpl::preparePlayer(player_result_t &ret)
@@ -408,7 +408,7 @@ void MediaPlayerImpl::setVolumePlayer(int vol, player_result_t &ret)
 		meddbg("MediaPlayer setVolume fail : audio manager failed\n");
 		goto errout;
 	}
-	
+
 	medvdbg("MediaPlayer setVolume success\n");
 	ret = PLAYER_OK;
 	mSyncCv.notify_one();
@@ -531,7 +531,7 @@ void MediaPlayerImpl::notifyObserver(player_observer_command_t cmd)
 
 void MediaPlayerImpl::playback()
 {
-	size_t num_read = mInputDataSource->read(mBuffer,(int)mBufSize);
+	ssize_t num_read = mInputDataSource->read(mBuffer,(int)mBufSize);
 	meddbg("num_read : %d\n", num_read);
 	if (num_read > 0) {
 		start_audio_stream_out(mBuffer, get_output_bytes_frame_count(num_read));

--- a/framework/src/media/SocketOutputDataSource.cpp
+++ b/framework/src/media/SocketOutputDataSource.cpp
@@ -31,7 +31,7 @@ namespace stream {
 
 SocketOutputDataSource::SocketOutputDataSource(const std::string& ipAddr, const uint16_t port)
 	: OutputDataSource(), mIpAddr(ipAddr), mPort(port), mSockFd(INVALID_SOCKET)
-{	
+{
 }
 
 SocketOutputDataSource::SocketOutputDataSource(unsigned short channels, unsigned int sampleRate, int pcmFormat, const std::string& ipAddr, const uint16_t port)
@@ -39,7 +39,7 @@ SocketOutputDataSource::SocketOutputDataSource(unsigned short channels, unsigned
 {
 }
 
-SocketOutputDataSource::SocketOutputDataSource(const SocketOutputDataSource& source) : 
+SocketOutputDataSource::SocketOutputDataSource(const SocketOutputDataSource& source) :
 	OutputDataSource(source), mIpAddr(source.mIpAddr), mPort(source.mPort), mSockFd(source.mSockFd)
 {
 }
@@ -97,7 +97,7 @@ bool SocketOutputDataSource::isPrepare()
 	return (mSockFd != INVALID_SOCKET);
 }
 
-size_t SocketOutputDataSource::write(unsigned char* buf, size_t size)
+ssize_t SocketOutputDataSource::write(unsigned char* buf, size_t size)
 {
 	if (!buf) {
 		return (size_t)0;

--- a/framework/src/media/streaming/player.h
+++ b/framework/src/media/streaming/player.h
@@ -228,6 +228,18 @@ bool pv_player_get_frame(pv_player_p player);
  */
 int pv_player_frame_decode(pv_player_p player, pcm_data_p pcm);
 
+/**
+ * @brief  Get sample frames in 16bit-PCM format.
+ *
+ * @param  player : Pointer to player object
+ * @param  buf : Pointer to output buffer, which store outputed PCM data
+ * @param  max : Max bytes of output buffer, it should be 16bit-PCM frame aligned.
+ * @param  sr : Sample rate (Hz) of the output PCM data
+ * @param  ch : Number of channels of the output PCM data
+ * @return bytes of PCM data saved in 'buf', usually it's same as 'max'.
+ *         it may be less than 'max' when there's no more data to decode.
+ */
+size_t pv_player_get_frames(pv_player_p player, unsigned char *buf, size_t max, unsigned int *sr, unsigned short *ch);
 
 //{{ Deprecated
 int _get_audio_type(rbstream_p rbsp);


### PR DESCRIPTION
@Taejun-Kwon @jarvisjang 
Decode multiple audio frames to fill read buffer fully.
Previously, Decoder just decode one frame once, and more than half of the audio buffer is free. 
If apply this modification, decoder will return data of required size.
In addition,  we change to use latest pv_player APIs from deprecated ones.
Add a new pv_player API: *size_t pv_player_get_frames(...)*