### PR TITLE
media: add API descriptions for audio manager

### DIFF
--- a/framework/src/media/audio/audio_manager.c
+++ b/framework/src/media/audio/audio_manager.c
@@ -372,7 +372,7 @@ uint32_t get_input_frame_count(void)
 
 uint32_t get_input_frames_byte_size(uint32_t frames)
 {
-	if (g_actual_audio_in_card_id < 0) {
+	if ((g_actual_audio_in_card_id < 0) || (frames == 0)) {
 		meddbg("No input audio card is active.\n");
 		return 0;
 	}
@@ -382,7 +382,7 @@ uint32_t get_input_frames_byte_size(uint32_t frames)
 
 uint32_t get_input_bytes_frame_count(uint32_t bytes)
 {
-	if (g_actual_audio_in_card_id < 0) {
+	if ((g_actual_audio_in_card_id < 0) || (bytes == 0)) {
 		meddbg("No input audio card is active.\n");
 		return 0;
 	}
@@ -402,7 +402,7 @@ uint32_t get_output_frame_count(void)
 
 uint32_t get_output_frames_byte_size(uint32_t frames)
 {
-	if (g_actual_audio_out_card_id < 0) {
+	if ((g_actual_audio_out_card_id < 0) || (frames == 0)) {
 		meddbg("No output audio card is active.\n");
 		return 0;
 	}
@@ -412,7 +412,7 @@ uint32_t get_output_frames_byte_size(uint32_t frames)
 
 uint32_t get_output_bytes_frame_count(uint32_t bytes)
 {
-	if (g_actual_audio_out_card_id < 0) {
+	if ((g_actual_audio_out_card_id < 0) || (bytes == 0)) {
 		meddbg("No output audio card is active.\n");
 		return 0;
 	}

--- a/framework/src/media/audio/audio_manager.h
+++ b/framework/src/media/audio/audio_manager.h
@@ -153,11 +153,70 @@ audio_manager_result_t set_audio_stream_in(uint8_t channels, uint32_t sample_rat
  ****************************************************************************/
 audio_manager_result_t set_audio_stream_out(uint8_t channels, uint32_t sample_rate, uint8_t format);
 
+/****************************************************************************
+ * Name: get_input_frame_count
+ *
+ * Description:
+ *   Get the frame size of the pcm buffer in the active input audio device.
+ *
+ * Returned Value:
+ *   On success, the size of the pcm buffer for input streams. Otherwise, 0.
+ ****************************************************************************/
 uint32_t get_input_frame_count(void);
+
+/****************************************************************************
+ * Name: get_input_frames_byte_size
+ *
+ * Description:
+ *   Get the byte size of the given frame value in input stream.
+ *
+ * Returned Value:
+ *   On success, the byte size of the frame in input stream. Otherwise, 0.
+ ****************************************************************************/
 uint32_t get_input_frames_byte_size(uint32_t frames);
+
+/****************************************************************************
+ * Name: get_input_bytes_frame_count
+ *
+ * Description:
+ *   Get the number of frames for the given byte size in input stream.
+ *
+ * Returned Value:
+ *   On success, the number of frames in input stream. Otherwise, 0.
+ ****************************************************************************/
 uint32_t get_input_bytes_frame_count(uint32_t bytes);
+
+/****************************************************************************
+ * Name: get_output_frame_count
+ *
+ * Description:
+ *   Get the frame size of the pcm buffer in the active output audio device.
+ *
+ * Returned Value:
+ *   On success, the size of the pcm buffer for output streams. Otherwise, 0.
+ ****************************************************************************/
 uint32_t get_output_frame_count(void);
+
+/****************************************************************************
+ * Name: get_output_frames_byte_size
+ *
+ * Description:
+ *   Get the byte size of the given frame value in output stream.
+ *
+ * Returned Value:
+ *   On success, the byte size of the frame in output stream. Otherwise, 0.
+ ****************************************************************************/
 uint32_t get_output_frames_byte_size(uint32_t frames);
+
+/****************************************************************************
+ * Name: get_output_bytes_frame_count
+ *
+ * Description:
+ *   Get the number of frames for the given byte size in output stream.
+ *
+ * Returned Value:
+ *   On success, the number of frames in output stream. Otherwise, 0.
+ ****************************************************************************/
 uint32_t get_output_bytes_frame_count(uint32_t bytes);
 
 /****************************************************************************


### PR DESCRIPTION
- The basic descriptions for get functions to calculate a byte size from a frame value and vice versa for both input and output streams are added.