### PR TITLE
fs/stdio : change return value as same as close if flush returns -ENOSPC

### DIFF
--- a/lib/libc/stdio/lib_fclose.c
+++ b/lib/libc/stdio/lib_fclose.c
@@ -112,9 +112,10 @@ int fclose(FAR FILE *stream)
 
 			/* If close() returns an error but flush() did not then make sure
 			 * that we return the close() error condition.
+			 * Also If flush returns error but storage is full, we return close status.
 			 */
 
-			if (ret == OK) {
+			if (ret == OK || ret == -ENOSPC) {
 				ret = status;
 				err = errno;
 			}


### PR DESCRIPTION
If flush failed during fclose, it doesn't return close's result.
But if disk is full, there's no way write contents anymore, so
File should be closed