### PR TITLE
media: Use focuslist instead of curPlayer

### DIFF
--- a/framework/src/media/MediaPlayerImpl.h
+++ b/framework/src/media/MediaPlayerImpl.h
@@ -73,6 +73,8 @@ public:
 	void notifySync();
 	void notifyObserver(player_observer_command_t cmd);
 
+	bool setAudioStream();
+	bool resetAudioStream();
 	void playback();
 
 private:

--- a/framework/src/media/PlayerWorker.h
+++ b/framework/src/media/PlayerWorker.h
@@ -19,6 +19,7 @@
 #ifndef __MEDIA_PLAYERWORKER_HPP
 #define __MEDIA_PLAYERWORKER_HPP
 
+#include <list>
 #include <memory>
 #include <media/MediaPlayer.h>
 #include "MediaWorker.h"
@@ -29,8 +30,8 @@ class PlayerWorker : public MediaWorker
 public:
 	static PlayerWorker &getWorker();
 
-	void setPlayer(std::shared_ptr<MediaPlayerImpl>);
-	std::shared_ptr<MediaPlayerImpl> getPlayer();
+	bool requestFocus(std::shared_ptr<MediaPlayerImpl>);
+	bool abandonFocus(std::shared_ptr<MediaPlayerImpl>);
 
 private:
 	PlayerWorker();
@@ -38,7 +39,7 @@ private:
 	bool processLoop() override;
 
 private:
-	std::shared_ptr<MediaPlayerImpl> mCurPlayer;
+	std::list<std::shared_ptr<MediaPlayerImpl>> mFocusList;
 };
 } // namespace media
 #endif


### PR DESCRIPTION
At start, player is added to list.
The front player of list is focused, and played.
At finish, stop, pause, and unprepare, player is removed from list