### PR TITLE
framework/task_manager: Modify unicast callback API prototype and callback func type

### DIFF
--- a/apps/examples/task_manager_sample/action_manager.c
+++ b/apps/examples/task_manager_sample/action_manager.c
@@ -33,12 +33,12 @@
 static int exit_flag;
 static int handle_alarm;
 
-static void action(int signo, tm_msg_t *info)
+static void action(void *info)
 {
 	int ret;
 
-	char *rec = (char *)malloc(strlen((char *)info->si_value.sival_ptr) + 1);
-	strncpy(rec, info->si_value.sival_ptr, strlen((char *)info->si_value.sival_ptr) + 1);
+	char *rec = (char *)malloc(strlen((char *)info) + 1);
+	strncpy(rec, info, strlen((char *)info) + 1);
 
 	if (strncmp(rec, "alarm_on", strlen("alarm_on") + 1) == 0) {
 		printf("\nAction Manager receives Alarm On request\n");
@@ -165,7 +165,7 @@ int action_manager_main(int argc, char *argv[])
 		printf("LED Off Action is successfully started\n");
 	}
 
-	task_manager_set_handler(action);
+	task_manager_set_unicast_cb(action);
 	task_manager_set_broadcast_handler((TM_BROADCAST_WIFI_ON | TM_BROADCAST_WIFI_OFF), action_broad);
 	sem_post(&tm_sem);
 

--- a/apps/examples/testcase/ta_tc/task_manager/utc/utc_task_manager_main.c
+++ b/apps/examples/testcase/ta_tc/task_manager/utc/utc_task_manager_main.c
@@ -43,9 +43,9 @@ static task_info_list_t *sample_list_info;
 static int *addr;
 static int *addr2;
 
-static void test_handler(int sig, tm_msg_t *info)
+static void test_handler(void *info)
 {
-	flag = !strncmp(info->si_value.sival_ptr, TM_SAMPLE_MSG, strlen(TM_SAMPLE_MSG));
+	flag = !strncmp(info, TM_SAMPLE_MSG, strlen(TM_SAMPLE_MSG));
 }
 
 void free_handler(void)
@@ -60,10 +60,11 @@ int tm_sample_main(int argc, char *argv[])
 
 	tm_noperm_handle = task_manager_register(TM_NOPERM_NAME, TM_TASK_PERMISSION_DEDICATE, 100);
 
-	ret = task_manager_set_handler(test_handler);
+	ret = task_manager_set_unicast_cb(test_handler);
 	if (ret != OK) {
 		printf("ERROR : fail to set handler\n");
 	}
+
 	while (1) {
 		usleep(1);
 	}	// This will be dead at utc_task_manager_terminate_p
@@ -123,20 +124,20 @@ static void utc_task_manager_start_p(void)
 	TC_SUCCESS_RESULT();
 }
 
-static void utc_task_manager_set_handler_n(void)
+static void utc_task_manager_set_unicast_cb_n(void)
 {
 	int ret;
-	ret = task_manager_set_handler(NULL);
-	TC_ASSERT_EQ("task_manager_set_handler", ret, TM_INVALID_PARAM);
+	ret = task_manager_set_unicast_cb(NULL);
+	TC_ASSERT_EQ("task_manager_set_unicast_cb", ret, TM_INVALID_PARAM);
 
 	TC_SUCCESS_RESULT();
 }
 
-static void utc_task_manager_set_handler_p(void)
+static void utc_task_manager_set_unicast_cb_p(void)
 {
 	int ret;
-	ret = task_manager_set_handler(test_handler);
-	TC_ASSERT_EQ("task_manager_set_handler", ret, OK);
+	ret = task_manager_set_unicast_cb(test_handler);
+	TC_ASSERT_EQ("task_manager_set_unicast_cb", ret, OK);
 
 	TC_SUCCESS_RESULT();
 }
@@ -418,14 +419,13 @@ int utc_task_manager_main(int argc, char *argv[])
 	}
 
 	utc_task_manager_register_n();
-
 	utc_task_manager_register_p();
 
 	utc_task_manager_start_n();
 	utc_task_manager_start_p();
 
-	utc_task_manager_set_handler_n();
-	utc_task_manager_set_handler_p();
+	utc_task_manager_set_unicast_cb_n();
+	utc_task_manager_set_unicast_cb_p();
 
 	utc_task_manager_set_termination_cb_n();
 	utc_task_manager_set_termination_cb_p();

--- a/framework/include/task_manager/task_manager.h
+++ b/framework/include/task_manager/task_manager.h
@@ -226,14 +226,13 @@ int task_manager_unicast(int handle, void *msg, int msg_size, int timeout);
  */
 int task_manager_broadcast(int msg);
 /**
- * @brief Set handler function API
+ * @brief Set unicast callback function API
  * @details @b #include <task_manager/task_manager.h>
- * @param[in] func the handler function which handle the msg\n
- * In handler function, tm_msg_t is for containing data. It is originally siginfo_t type.\n
+ * @param[in] func the callback function which handle the msg\n
  * @return On success, OK is returned. On failure, defined negative value is returned.
  * @since TizenRT v2.0 PRE
  */
-int task_manager_set_handler(void (*func)(int signo, tm_msg_t *data));
+int task_manager_set_unicast_cb(void (*func)(void *data));
 /**
  * @brief Register callback function which will be used for processing received broadcast messages
  * @details @b #include <task_manager/task_manager.h>

--- a/framework/src/task_manager/Make.defs
+++ b/framework/src/task_manager/Make.defs
@@ -17,8 +17,9 @@
 ###########################################################################
 
 ifeq ($(CONFIG_TASK_MANAGER),y)
+
 CSRCS += task_manager_register.c task_manager_unregister.c task_manager_start.c task_manager_terminate.c task_manager_restart.c task_manager_pause.c task_manager_resume.c
-CSRCS += task_manager_getinfo.c task_manager_unicast.c task_manager_cleaninfo.c task_manager_sethandler.c task_manager_state.c task_manager_permission.c
+CSRCS += task_manager_getinfo.c task_manager_unicast.c task_manager_cleaninfo.c task_manager_set_unicast_cb.c task_manager_state.c task_manager_permission.c
 CSRCS += task_manager_core.c task_manager_interface.c task_manager_broadcast.c task_manager_set_broadcast_handler.c
 
 DEPPATH += --dep-path src/task_manager

--- a/framework/src/task_manager/task_manager_internal.h
+++ b/framework/src/task_manager/task_manager_internal.h
@@ -33,11 +33,12 @@
 #define TASKMGT_SCAN                    7
 #define TASKMGT_UNICAST                 8
 #define TASKMGT_BROADCAST               9
-#define TASKMGT_SCAN_NAME               10
-#define TASKMGT_SCAN_HANDLE             11
-#define TASKMGT_SCAN_GROUP              12
-#define TASKMGT_UNREGISTER_TASK         13
-#define TASKMGT_SET_BROADCAST_HANDLER   14
+#define TASKMGT_SET_UNICAST_CB          10
+#define TASKMGT_SCAN_NAME               11
+#define TASKMGT_SCAN_HANDLE             12
+#define TASKMGT_SCAN_GROUP              13
+#define TASKMGT_UNREGISTER_TASK         14
+#define TASKMGT_SET_BROADCAST_HANDLER   15
 
 /* Message Queue Values */
 #define TM_MQ_PRIO   50
@@ -47,6 +48,8 @@
 /* Wrapper of allocation APIs */
 #define TM_ALLOC(a)  malloc(a)
 #define TM_FREE(a)   free(a)
+
+typedef void (*_tm_callback_t)(void *);
 
 struct task_list_s {
 	int pid;
@@ -61,6 +64,7 @@ struct task_list_data_s {
 	int status;
 	int permission;
 	int msg_mask;
+	_tm_callback_t unicast_cb;
 };
 typedef struct task_list_data_s task_list_data_t;
 
@@ -82,13 +86,14 @@ typedef struct tm_response_s tm_response_t;
 
 #define IS_INVALID_HANDLE(i) (i < 0 || i >= CONFIG_TASK_MANAGER_MAX_TASKS)
 
-#define TASK_LIST_ADDR(handle)   ((task_list_data_t *)tm_task_list[handle].addr)
-#define TASK_PID(handle)         tm_task_list[handle].pid
-#define TASK_BUILTIN_IDX(handle) TASK_LIST_ADDR(handle)->builtin_idx
-#define TASK_TM_GID(handle)      TASK_LIST_ADDR(handle)->tm_gid
-#define TASK_STATUS(handle)      TASK_LIST_ADDR(handle)->status
-#define TASK_PERMISSION(handle)  TASK_LIST_ADDR(handle)->permission
-#define TASK_MSG_MASK(handle)    TASK_LIST_ADDR(handle)->msg_mask
+#define TASK_LIST_ADDR(handle)       ((task_list_data_t *)tm_task_list[handle].addr)
+#define TASK_PID(handle)             tm_task_list[handle].pid
+#define TASK_BUILTIN_IDX(handle)     TASK_LIST_ADDR(handle)->builtin_idx
+#define TASK_TM_GID(handle)          TASK_LIST_ADDR(handle)->tm_gid
+#define TASK_STATUS(handle)          TASK_LIST_ADDR(handle)->status
+#define TASK_PERMISSION(handle)      TASK_LIST_ADDR(handle)->permission
+#define TASK_MSG_MASK(handle)        TASK_LIST_ADDR(handle)->msg_mask
+#define TASK_UNICAST_CB(handle)      TASK_LIST_ADDR(handle)->unicast_cb
 
 extern task_list_t tm_task_list[CONFIG_TASK_MANAGER_MAX_TASKS];
 
@@ -99,5 +104,6 @@ int taskmgr_receive_response(char *q_name, tm_response_t *response_msg, int time
 bool taskmgr_is_permitted(int handle, pid_t pid);
 int taskmgr_get_task_state(int handle);
 int taskmgr_get_drvfd(void);
+int taskmgr_get_handle_by_pid(int pid);
 
 #endif

--- a/framework/src/task_manager/task_manager_set_unicast_cb.c
+++ b/framework/src/task_manager/task_manager_set_unicast_cb.c
@@ -21,23 +21,36 @@
 #include <stdio.h>
 #include <signal.h>
 #include <stdlib.h>
+#include <unistd.h>
 #include <sys/types.h>
 #include <task_manager/task_manager.h>
 #include "task_manager_internal.h"
 
+void taskmgr_unicast_cb(int signo, tm_msg_t *data)
+{
+	int handle;
+	handle = taskmgr_get_handle_by_pid(getpid());
+	if (handle == TM_FAIL_UNREGISTERED_TASK) {
+		tmdbg("Fail to start the unicast callback\n");
+		return;
+	}
+	(*TASK_UNICAST_CB(handle))((void *)data->si_value.sival_ptr);
+}
+
 /****************************************************************************
- * task_manager_set_handler
+ * task_manager_set_unicast_cb
  ****************************************************************************/
-int task_manager_set_handler(void (*func)(int signo, tm_msg_t *data))
+int task_manager_set_unicast_cb(void (*func)(void *data))
 {
 	int ret = OK;
 	struct sigaction act;
+	tm_request_t request_msg;
 
 	if (func == NULL) {
 		return TM_INVALID_PARAM;
 	}
 
-	act.sa_sigaction = (_sa_sigaction_t)func;
+	act.sa_sigaction = (_sa_sigaction_t)taskmgr_unicast_cb;
 	act.sa_flags = 0;
 	(void)sigemptyset(&act.sa_mask);
 
@@ -48,7 +61,21 @@ int task_manager_set_handler(void (*func)(int signo, tm_msg_t *data))
 
 	ret = sigaction(SIGTM_UNICAST, &act, NULL);
 	if (ret == (int)SIG_ERR) {
-		ret = TM_FAIL_SET_HANDLER;
+		return TM_FAIL_SET_HANDLER;
+	}
+
+	/* send user defined callback function to task manager */
+
+	memset(&request_msg, 0, sizeof(tm_request_t));
+	/* Set the request msg */
+	request_msg.cmd = TASKMGT_SET_UNICAST_CB;
+	request_msg.caller_pid = getpid();
+	request_msg.data = (void *)func;
+
+
+	ret = taskmgr_send_request(&request_msg);
+	if (ret < 0) {
+		return TM_FAIL_REQ_TO_MGR;
 	}
 
 	return ret;

--- a/framework/src/task_manager/task_manager_start.c
+++ b/framework/src/task_manager/task_manager_start.c
@@ -44,6 +44,7 @@ int task_manager_start(int handle, int timeout)
 	request_msg.handle = handle;
 	request_msg.caller_pid = getpid();
 	request_msg.timeout = timeout;
+	request_msg.data = NULL;
 
 	if (timeout != TM_NO_RESPONSE) {
 		asprintf(&request_msg.q_name, "%s%d", TM_PRIVATE_MQ, request_msg.caller_pid);

--- a/framework/src/task_manager/task_manager_terminate.c
+++ b/framework/src/task_manager/task_manager_terminate.c
@@ -44,6 +44,7 @@ int task_manager_terminate(int handle, int timeout)
 	request_msg.handle = handle;
 	request_msg.caller_pid = getpid();
 	request_msg.timeout = timeout;
+	request_msg.data = NULL;
 
 	if (timeout != TM_NO_RESPONSE) {
 		asprintf(&request_msg.q_name, "%s%d", TM_PRIVATE_MQ, request_msg.caller_pid);

--- a/framework/src/task_manager/task_manager_unregister.c
+++ b/framework/src/task_manager/task_manager_unregister.c
@@ -43,6 +43,7 @@ int task_manager_unregister(int handle, int timeout)
 	request_msg.handle = handle;
 	request_msg.caller_pid = getpid();
 	request_msg.timeout = timeout;
+	request_msg.data = NULL;
 
 	if (timeout != TM_NO_RESPONSE) {
 		asprintf(&request_msg.q_name, "%s%d", TM_PRIVATE_MQ, request_msg.caller_pid);


### PR DESCRIPTION
    1. modify task_manager_set_handler to task_manager_set_unicast_cb
    2. modify unicast cb prototype to "void func(void *)"
    3. apply api and cb prototype in tc and sample