### PR TITLE
init : call cxxinit initializers from idle thread

### DIFF
--- a/os/kernel/init/os_bringup.c
+++ b/os/kernel/init/os_bringup.c
@@ -250,9 +250,6 @@ static inline void os_do_appstart(void)
 
 	svdbg("Starting application init thread\n");
 
-#if !defined(CONFIG_BUILD_KERNEL) && defined(CONFIG_HAVE_CXXINITIALIZE)
-	up_cxxinitialize();
-#endif
 
 #ifdef CONFIG_SYSTEM_PREAPP_INIT
 #ifdef CONFIG_BUILD_PROTECTED
@@ -423,6 +420,10 @@ int os_bringup(void)
 
 #ifdef CONFIG_LOGM
 	logm_start();
+#endif
+
+#if !defined(CONFIG_BUILD_KERNEL) && defined(CONFIG_HAVE_CXXINITIALIZE)
+	up_cxxinitialize();
 #endif
 
 	/* Once the operating system has been initialized, the system must be


### PR DESCRIPTION
Previous commit which did cxxinitialize during os_do_appstart()
would cause crash in few scenarios.

If a task does cxxinitialize and creates a new c++ application task
and exits immediately then in newly created C++ task if iostream are used,
the task would crash.
It is because during cxxinitialize iostreams are initialized (ios_base::Init)
and during iostream initialization they refer console streams
(Ex: stdout, which are defined per task group: group->tg_streamlist)
and set those pointers in iostreams internal file pointers members.
Once the task which did cxxinitialize exits, it would destroy the streams as well
Hence if the newly created c++ task uses any iostreams(Ex: cout) would crash.

os_do_appstart can run as init kthread and would exit after application launch
and the above scenario would occur.

Hence this patch moves cxxinitialize to idle thread which never exits.

Signed-off-by: Manohara HK <manohara.hk@samsung.com>