### PR TITLE
Fix filesystem testcase issues

### DIFF
--- a/apps/examples/testcase/le_tc/filesystem/fs_main.c
+++ b/apps/examples/testcase/le_tc/filesystem/fs_main.c
@@ -951,7 +951,7 @@ static void tc_fs_vfs_seekdir(void)
 	seekdir(dir, offset);
 	TC_ASSERT_NEQ_CLEANUP("seekdir", dir, NULL, closedir(dir));
 	dirent = readdir(dir);
-	TC_ASSERT_NEQ_CLEANUP("readdir", dirent, NULL, closedir(dir));
+	TC_ASSERT_EQ_CLEANUP("readdir", dirent, NULL, closedir(dir));
 
 	ret = closedir(dir);
 	TC_ASSERT_EQ("closedir", ret, OK);

--- a/apps/examples/testcase/le_tc/filesystem/fs_main.c
+++ b/apps/examples/testcase/le_tc/filesystem/fs_main.c
@@ -1328,6 +1328,7 @@ static void tc_fs_vfs_mkfifo(void)
 	TC_ASSERT_GEQ("unlink", ret, 0);
 
 	TC_SUCCESS_RESULT();
+	return;
 errout:
 	pthread_kill(tid, SIGUSR1);
 	close(fd);
@@ -1682,12 +1683,12 @@ static void tc_driver_mtd_ftl_ops(void)
 	ret = write(fd, buf, BUF_SIZE);
 	TC_ASSERT_EQ_CLEANUP("write", ret, BUF_SIZE, goto cleanup);
 #endif
-#ifdef FIXME	// This causes tc stuck. Temporarilly block.
 	free(buf);
-#endif
+	buf = NULL;
 	ret = close(fd);
 	TC_ASSERT_EQ("close", ret, OK);
 	TC_SUCCESS_RESULT();
+	return;
 cleanup:
 	free(buf);
 	close(fd);
@@ -3224,6 +3225,7 @@ static void tc_libc_stdio_tempnam(void)
 	umount(CONFIG_LIBC_TMPDIR);
 
 	TC_SUCCESS_RESULT();
+	return;
 
 errout2:
 	unlink(ret2);
@@ -3275,6 +3277,7 @@ static void tc_libc_stdio_tmpnam(void)
 	umount(CONFIG_LIBC_TMPDIR);
 
 	TC_SUCCESS_RESULT();
+	return;
 
 errout2:
 	unlink(ret2);

--- a/apps/examples/testcase/le_tc/filesystem/fs_main.c
+++ b/apps/examples/testcase/le_tc/filesystem/fs_main.c
@@ -1153,9 +1153,6 @@ static void tc_fs_vfs_stat(void)
 	ret = stat("", &st);
 	TC_ASSERT_EQ("stat", ret, ERROR);
 
-	ret = stat(PROCFS_PATH, &st);
-	TC_ASSERT_EQ("stat", ret, OK);
-
 	TC_SUCCESS_RESULT();
 }
 

--- a/apps/examples/testcase/le_tc/filesystem/fs_main.c
+++ b/apps/examples/testcase/le_tc/filesystem/fs_main.c
@@ -93,8 +93,6 @@
 
 #define VFS_FILE1_PATH MOUNT_DIR"file1.txt"
 
-#define PROCFS_PATH "/proc"
-
 #define DEV_ZERO_PATH "/dev/zero"
 
 #define DEV_CONSOLE_PATH "/dev/console"
@@ -126,8 +124,6 @@
 
 #define FIFO_DATA "FIFO DATA"
 #endif
-
-#define MTD_PROCFS_PATH "/proc/mtd"
 
 #ifndef STDIN_FILENO
 #define STDIN_FILENO 0
@@ -3306,33 +3302,7 @@ static void tc_libc_stdio_zeroinstream(void)
 
 	TC_SUCCESS_RESULT();
 }
-/**
-* @testcase         tc_fs_driver_mtd_procfs_ops
-* @brief            mtd procfs ops
-* @scenario         opens /proc/mtd and performs operations
-* @apicovered       mtdprocfs_operations (mtd_open, mtd_dup, mtd_stat, mtd_close)
-* @precondition     NA
-* @postcondition    NA
-*/
-#if !defined(CONFIG_FS_PROCFS_EXCLUDE_MTD)
-static void tc_driver_mtd_procfs_ops(void)
-{
-	int fd;
-	int ret;
-	struct stat st;
 
-	fd = open(MTD_PROCFS_PATH, O_RDONLY);
-	TC_ASSERT_GEQ("open", fd, 0);
-
-	ret = stat(MTD_PROCFS_PATH, &st);
-	TC_ASSERT_EQ_CLEANUP("stat", ret, OK, close(fd));
-
-	ret = close(fd);
-	TC_ASSERT_EQ("close", ret, OK);
-
-	TC_SUCCESS_RESULT();
-}
-#endif
 /**
 * @testcase         tc_fs_mqueue_ops
 * @brief            mqueue creation
@@ -3535,9 +3505,6 @@ int tc_filesystem_main(int argc, char *argv[])
 #ifdef CONFIG_TC_FS_PROCFS
 	tc_fs_procfs_main();
 #endif
-#if defined(CONFIG_TC_FS_PROCFS) && !defined(CONFIG_FS_PROCFS_EXCLUDE_SMARTFS)
-	tc_fs_smartfs_procfs_main();
-#endif
 #if defined(CONFIG_MTD_CONFIG)
 	tc_driver_mtd_config_ops();
 #endif
@@ -3578,9 +3545,6 @@ int tc_filesystem_main(int argc, char *argv[])
 #if CONFIG_STDIO_BUFFER_SIZE > 0
 	tc_libc_stdio_setbuf();
 	tc_libc_stdio_setvbuf();
-#endif
-#if !defined(CONFIG_FS_PROCFS_EXCLUDE_MTD)
-	tc_driver_mtd_procfs_ops();
 #endif
 	tc_fs_mqueue_ops();
 #ifdef CONFIG_BCH

--- a/apps/examples/testcase/le_tc/filesystem/tc_fs_procfs.c
+++ b/apps/examples/testcase/le_tc/filesystem/tc_fs_procfs.c
@@ -262,6 +262,34 @@ void tc_fs_smartfs_procfs_main(void)
 }
 #endif
 
+/**
+* @testcase         tc_fs_driver_mtd_procfs_ops
+* @brief            mtd procfs ops
+* @scenario         opens /proc/mtd and performs operations
+* @apicovered       mtdprocfs_operations (mtd_open, mtd_dup, mtd_stat, mtd_close)
+* @precondition     NA
+* @postcondition    NA
+*/
+#ifndef CONFIG_FS_PROCFS_EXCLUDE_MTD
+static void tc_driver_mtd_procfs_ops(void)
+{
+	int fd;
+	int ret;
+	struct stat st;
+
+	fd = open(MTD_PROCFS_PATH, O_RDONLY);
+	TC_ASSERT_GEQ("open", fd, 0);
+
+	ret = stat(MTD_PROCFS_PATH, &st);
+	TC_ASSERT_EQ_CLEANUP("stat", ret, OK, close(fd));
+
+	ret = close(fd);
+	TC_ASSERT_EQ("close", ret, OK);
+
+	TC_SUCCESS_RESULT();
+}
+#endif
+
 void tc_fs_procfs_main(void)
 {
 	int ret;
@@ -299,6 +327,11 @@ void tc_fs_procfs_main(void)
 #if defined(CONFIG_FS_PROCFS)
 	ret = procfs_version_ops(PROC_UPTIME_PATH);
 	TC_ASSERT_EQ("procfs_version_ops", ret, OK);
+#ifndef CONFIG_FS_PROCFS_EXCLUDE_SMARTFS
+	tc_fs_smartfs_procfs_main();
+#endif
+#ifndef CONFIG_FS_PROCFS_EXCLUDE_MTD
+	tc_driver_mtd_procfs_ops();
 #endif
 
 	TC_SUCCESS_RESULT();

--- a/apps/examples/testcase/le_tc/filesystem/tc_fs_procfs.c
+++ b/apps/examples/testcase/le_tc/filesystem/tc_fs_procfs.c
@@ -55,6 +55,7 @@
 
 #define PROC_SMARTFS_PATH "/proc/fs/smartfs"
 #define PROC_SMARTFS_FILE_PATH "/proc/fs/smartfs/file.txt"
+
 /* Read all files in the directory */
 static int read_dir_entries(const char *dirpath)
 {
@@ -112,7 +113,7 @@ error:
 
 	return ERROR;
 }
-#if defined(CONFIG_FS_PROCFS) && !defined (CONFIG_FS_PROCFS_EXCLUDE_UPTIME)
+#ifndef CONFIG_FS_PROCFS_EXCLUDE_UPTIME
 static int procfs_uptime_ops(char *dirpath)
 {
 	int ret;
@@ -148,7 +149,6 @@ static int procfs_uptime_ops(char *dirpath)
 }
 #endif
 
-#if defined(CONFIG_FS_PROCFS)
 static int procfs_version_ops(char *dirpath)
 {
 	int ret;
@@ -182,7 +182,7 @@ static int procfs_version_ops(char *dirpath)
 
 		return OK;
 }
-#endif
+
 static int procfs_rewind_tc(const char *dirpath)
 {
 	int count;
@@ -313,7 +313,7 @@ void tc_fs_procfs_main(void)
 	ret = procfs_rewind_tc(PROC_MOUNTPOINT);
 	TC_ASSERT_EQ("procfs_rewind_tc", ret, OK);
 
-#if defined(CONFIG_FS_PROCFS) && !defined (CONFIG_FS_PROCFS_EXCLUDE_UPTIME)
+#ifndef CONFIG_FS_PROCFS_EXCLUDE_UPTIME
 	ret = procfs_uptime_ops(PROC_UPTIME_PATH);
 	TC_ASSERT_EQ("procfs_uptime_ops", ret, OK);
 #endif
@@ -324,7 +324,6 @@ void tc_fs_procfs_main(void)
 	ret = stat(PROC_INVALID_PATH, &st);
 	TC_ASSERT_EQ("stat", ret, ERROR);
 
-#if defined(CONFIG_FS_PROCFS)
 	ret = procfs_version_ops(PROC_UPTIME_PATH);
 	TC_ASSERT_EQ("procfs_version_ops", ret, OK);
 #ifndef CONFIG_FS_PROCFS_EXCLUDE_SMARTFS

--- a/apps/examples/testcase/le_tc/filesystem/tc_fs_procfs.c
+++ b/apps/examples/testcase/le_tc/filesystem/tc_fs_procfs.c
@@ -274,7 +274,7 @@ void tc_fs_procfs_main(void)
 
 		ret = mount(NULL, PROC_MOUNTPOINT, "procfs", 0, NULL);
 	}
-	
+
 	if (ret < 0) {
 		TC_ASSERT_EQ("mount", errno, EEXIST);
 	}
@@ -288,11 +288,13 @@ void tc_fs_procfs_main(void)
 #if defined(CONFIG_FS_PROCFS) && !defined (CONFIG_FS_PROCFS_EXCLUDE_UPTIME)
 	ret = procfs_uptime_ops(PROC_UPTIME_PATH);
 	TC_ASSERT_EQ("procfs_uptime_ops", ret, OK);
+#endif
+
+	ret = stat(PROC_MOUNTPOINT, &st);
+	TC_ASSERT_EQ("stat", ret, OK);
 
 	ret = stat(PROC_INVALID_PATH, &st);
 	TC_ASSERT_EQ("stat", ret, ERROR);
-
-#endif
 
 #if defined(CONFIG_FS_PROCFS)
 	ret = procfs_version_ops(PROC_UPTIME_PATH);

--- a/apps/examples/testcase/le_tc/filesystem/tc_fs_procfs.c
+++ b/apps/examples/testcase/le_tc/filesystem/tc_fs_procfs.c
@@ -33,16 +33,18 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include "tc_common.h"
+#include <stdbool.h>
 
-#define PROC_MOUNTPOINT "/proc"
+#define PROCFS_TEST_MOUNTPOINT "/proc_test"
+#define MTD_PROCFS_PATH PROCFS_TEST_MOUNTPOINT"/mtd"
 #define PROC_BUFFER_LEN 128
 #define PROC_FILEPATH_LEN CONFIG_PATH_MAX
 
 #define LOOP_COUNT 5
-#define PROC_UPTIME_PATH "/proc/uptime"
-#define PROC_VERSION_PATH "/proc/version"
-#define PROC_INVALID_PATH "/proc/nofile"
-#define INVALID_PATH "/proc/fs/invalid"
+#define PROC_UPTIME_PATH PROCFS_TEST_MOUNTPOINT"/uptime"
+#define PROC_VERSION_PATH PROCFS_TEST_MOUNTPOINT"/version"
+#define PROC_INVALID_PATH PROCFS_TEST_MOUNTPOINT"/nofile"
+#define INVALID_PATH PROCFS_TEST_MOUNTPOINT"/fs/invalid"
 #if defined(CONFIG_SIDK_S5JT200_AUTOMOUNT_USERFS)
 #define SMARTFS_DEV_PATH CONFIG_SIDK_S5JT200_AUTOMOUNT_USERFS_DEVNAME
 
@@ -53,8 +55,8 @@
 #define SMARTFS_DEV_PATH "/dev/smart1"
 #endif
 
-#define PROC_SMARTFS_PATH "/proc/fs/smartfs"
-#define PROC_SMARTFS_FILE_PATH "/proc/fs/smartfs/file.txt"
+#define PROC_SMARTFS_PATH PROCFS_TEST_MOUNTPOINT"/fs/smartfs"
+#define PROC_SMARTFS_FILE_PATH PROCFS_TEST_MOUNTPOINT"/fs/smartfs/file.txt"
 
 /* Read all files in the directory */
 static int read_dir_entries(const char *dirpath)
@@ -265,7 +267,7 @@ void tc_fs_smartfs_procfs_main(void)
 /**
 * @testcase         tc_fs_driver_mtd_procfs_ops
 * @brief            mtd procfs ops
-* @scenario         opens /proc/mtd and performs operations
+* @scenario         opens /test_proc/mtd and performs operations
 * @apicovered       mtdprocfs_operations (mtd_open, mtd_dup, mtd_stat, mtd_close)
 * @precondition     NA
 * @postcondition    NA
@@ -294,23 +296,18 @@ void tc_fs_procfs_main(void)
 {
 	int ret;
 	struct stat st;
+	bool procfs_mount_exist = false;
 
-	ret = mount(NULL, PROC_MOUNTPOINT, "procfs", 0, NULL);
-	if (ret == EEXIST) {
-		ret = umount(PROC_MOUNTPOINT);
-		TC_ASSERT_EQ("umount", ret, OK);
-
-		ret = mount(NULL, PROC_MOUNTPOINT, "procfs", 0, NULL);
-	}
-
+	ret = mount(NULL, PROCFS_TEST_MOUNTPOINT, "procfs", 0, NULL);
 	if (ret < 0) {
 		TC_ASSERT_EQ("mount", errno, EEXIST);
+		procfs_mount_exist = true;
 	}
 
-	ret = read_dir_entries(PROC_MOUNTPOINT);
+	ret = read_dir_entries(PROCFS_TEST_MOUNTPOINT);
 	TC_ASSERT_EQ("read_dir_entries", ret, OK);
 
-	ret = procfs_rewind_tc(PROC_MOUNTPOINT);
+	ret = procfs_rewind_tc(PROCFS_TEST_MOUNTPOINT);
 	TC_ASSERT_EQ("procfs_rewind_tc", ret, OK);
 
 #ifndef CONFIG_FS_PROCFS_EXCLUDE_UPTIME
@@ -318,7 +315,7 @@ void tc_fs_procfs_main(void)
 	TC_ASSERT_EQ("procfs_uptime_ops", ret, OK);
 #endif
 
-	ret = stat(PROC_MOUNTPOINT, &st);
+	ret = stat(PROCFS_TEST_MOUNTPOINT, &st);
 	TC_ASSERT_EQ("stat", ret, OK);
 
 	ret = stat(PROC_INVALID_PATH, &st);
@@ -332,6 +329,11 @@ void tc_fs_procfs_main(void)
 #ifndef CONFIG_FS_PROCFS_EXCLUDE_MTD
 	tc_driver_mtd_procfs_ops();
 #endif
+
+	if (false == procfs_mount_exist) {
+		ret = umount(PROCFS_TEST_MOUNTPOINT);
+		TC_ASSERT_EQ("umount", ret, OK);
+	}
 
 	TC_SUCCESS_RESULT();
 }


### PR DESCRIPTION
- Fix blocking of fs testcase
- Fix failure of tc_fs_vfs_stat()
- Move procfs tc's from fs_main to tc_procfs_main
- Fix wrong usage of configs wrapper
- Modify mounting un-mounting of procfs
- Fix fs readdir() tc failure
