### PR TITLE
libc/stdio: Add support for floating point precision in printf

### DIFF
--- a/lib/libc/Kconfig
+++ b/lib/libc/Kconfig
@@ -51,6 +51,13 @@ config LIBC_FLOATINGPOINT
 		By default, floating point
 		support in printf, sscanf, etc. is disabled.
 
+config LIBC_FLOATPRECISION
+	int "Default floating point Precision value"
+	depends on LIBC_FLOATINGPOINT
+	default 6
+	---help---
+		Precision point support for floating point values.
+
 config LIBC_SCANSET
         bool "Scanset support"
         default y 

--- a/lib/libc/stdio/lib_libvsprintf.c
+++ b/lib/libc/stdio/lib_libvsprintf.c
@@ -78,6 +78,10 @@
 #define CONFIG_LIBC_FIXEDPRECISION 3
 #endif
 
+#if defined(CONFIG_LIBC_FLOATINGPOINT) && !defined(CONFIG_LIBC_FLOATPRECISION)
+#define CONFIG_LIBC_FLOATPRECISION 6
+#endif
+
 #define FLAG_SHOWPLUS            0x01
 #define FLAG_ALTFORM             0x02
 #define FLAG_HASDOT              0x04
@@ -1133,7 +1137,7 @@ int lib_vsprintf(FAR struct lib_outstream_s *obj, FAR const char *src, va_list a
 		fmt = FMT_RJUST;
 		width = 0;
 #ifdef CONFIG_LIBC_FLOATINGPOINT
-		trunc = 0;
+		trunc = CONFIG_LIBC_FLOATPRECISION;
 #endif
 #endif
 


### PR DESCRIPTION
As per standard, if precsion is not provided in printf, it should print
float values with default precision. This patch adds support for default
floating point precsion in printf

Signed-off-by: Lokesh B V <lokesh.bv@partner.samsung.com>