### PR TITLE
network/tc: Domain, type, and protocol matching for socket API

### DIFF
--- a/apps/examples/testcase/le_tc/network/network_tc_main.c
+++ b/apps/examples/testcase/le_tc/network/network_tc_main.c
@@ -133,7 +133,6 @@ int tc_network_main(int argc, char *argv[])
 #ifdef CONFIG_ITC_NET_CONNECT
 	itc_net_connect_main();
 #endif
-
 	(void)tc_handler(TC_END, "Network TC");
 
 	return 0;

--- a/apps/examples/testcase/le_tc/network/tc_net_bind.c
+++ b/apps/examples/testcase/le_tc/network/tc_net_bind.c
@@ -242,8 +242,5 @@ int net_bind_main(void)
 	tc_net_bind_udp_p();
 	tc_net_bind_broadcast_p();
 	tc_net_bind_size_n();
-#ifdef AF_UNIX
-	tc_net_bind_addrfamily_n();
-#endif
 	return 0;
 }

--- a/apps/examples/testcase/le_tc/network/tc_net_getpeername.c
+++ b/apps/examples/testcase/le_tc/network/tc_net_getpeername.c
@@ -309,8 +309,6 @@ int net_getpeername_main(void)
 
 	tc_net_getpeername_sock_n();
 	tc_net_getpeername_close_n();
-#ifdef AF_UNIX
-	tc_net_getpeername_unix_p();
-#endif
+
 	return 0;
 }

--- a/apps/examples/testcase/le_tc/network/tc_net_getsockname.c
+++ b/apps/examples/testcase/le_tc/network/tc_net_getsockname.c
@@ -212,8 +212,5 @@ int net_getsockname_main(void)
 	tc_net_getsockname_udp_p();
 	tc_net_getsockname_icmp_p();
 	tc_net_getsockname_close_n();
-#ifdef AF_UNIX
-	tc_net_getsockname_unix_p();
-#endif
 	return 0;
 }

--- a/apps/examples/testcase/le_tc/network/tc_net_socket.c
+++ b/apps/examples/testcase/le_tc/network/tc_net_socket.c
@@ -40,11 +40,11 @@
 * @precondition
 * @postcondition
 */
-static void tc_net_socket_pf_inet_sock_raw_p(void)
+static void tc_net_socket_pf_inet_sock_raw_n(void)
 {
 	int fd = -1;
 	fd = socket(PF_INET, SOCK_RAW, 0);
-	TC_ASSERT_GEQ("socket", fd, 0)
+	TC_ASSERT_EQ_CLEANUP("socket", fd, -1, close(fd))
 	TC_SUCCESS_RESULT()
 
 	close(fd);
@@ -149,19 +149,19 @@ static void tc_net_socket_af_inet_sock_dgram_udp_p(void)
 * @precondition
 * @postcondition
 */
-static void tc_net_socket_af_inet_soc_dgram_icmp_p(void)
+static void tc_net_socket_af_inet_sock_dgram_icmp_n(void)
 {
 
 	int fd = -1;
 	fd = socket(AF_INET, SOCK_DGRAM, IPPROTO_ICMP);
-	TC_ASSERT_GEQ("socket", fd, 0)
+	TC_ASSERT_EQ_CLEANUP("socket", fd, -1, close(fd))
 	TC_SUCCESS_RESULT()
 
 	close(fd);
 
 }
 
-#ifdef IPPROTO_IGMP
+#ifdef CONFIG_NET_LWIP_IGMP
 /**
 * @testcase		tc_net_socket_af_inet_sock_dgram_igmp_p
 * @brief
@@ -170,12 +170,12 @@ static void tc_net_socket_af_inet_soc_dgram_icmp_p(void)
 * @precondition
 * @postcondition
 */
-static void tc_net_socket_af_inet_sock_dgram_igmp_p(void)
+static void tc_net_socket_af_inet_sock_dgram_igmp_n(void)
 {
 
 	int fd = -1;
 	fd = socket(AF_INET, SOCK_DGRAM, IPPROTO_IGMP);
-	TC_ASSERT_GEQ("socket", fd, 0)
+	TC_ASSERT_EQ_CLEANUP("socket", fd, -1, close(fd))
 	TC_SUCCESS_RESULT()
 
 	close(fd);
@@ -199,48 +199,6 @@ static void tc_net_socket_af_inet_sock_dgram_ipv6_n(void)
 	TC_ASSERT_EQ_CLEANUP("socket", fd, -1, close(fd))
 	TC_SUCCESS_RESULT()
 }
-
-#ifdef IPPROTO_ROUTING
-/**
-* @testcase		tc_net_socket_af_inet_sock_dgram_routing_p
-* @brief
-* @scenario
-* @apicovered		socket()
-* @precondition
-* @postcondition
-*/
-static void tc_net_socket_af_inet_sock_dgram_routing_p(void)
-{
-
-	int fd = -1;
-	fd = socket(AF_INET, SOCK_DGRAM, IPPROTO_ROUTING);
-	TC_ASSERT_GEQ("socket", fd, 0)
-	TC_SUCCESS_RESULT()
-
-	close(fd);
-}
-#endif
-
-#ifdef IPPROTO_FRAGMENT
-/**
-* @testcase		tc_net_socket_af_inet_sock_dgram_fragment_p
-* @brief
-* @scenario
-* @apicovered		socket()
-* @precondition
-* @postcondition
-*/
-static void tc_net_socket_af_inet_sock_dgram_fragment_p(void)
-{
-
-	int fd = -1;
-	fd = socket(AF_INET, SOCK_DGRAM, IPPROTO_FRAGMENT);
-	TC_ASSERT_GEQ("socket", fd, 0)
-	TC_SUCCESS_RESULT()
-
-	close(fd);
-}
-#endif
 
 /**
 * @testcase		tc_net_socket_af_inet_sock_dgram_icmpv6_n
@@ -313,7 +271,7 @@ static void tc_net_socket_af_unix_sock_dgram_icmp_n(void)
 	TC_SUCCESS_RESULT()
 }
 
-#ifdef IPPROTO_IGMP
+#ifdef CONFIG_NET_LWIP_IGMP
 /**
 * @testcase		tc_net_socket_af_unix_sock_dgram_igmp_n
 * @brief
@@ -456,7 +414,7 @@ static void tc_net_socket_af_unix_sock_stream_icmp_n(void)
 	TC_SUCCESS_RESULT()
 }
 
-#ifdef IPPROTO_IGMP
+#ifdef CONFIG_NET_LWIP_IGMP
 /**
 * @testcase		tc_net_socket_af_unix_sock_stream_igmp_n
 * @brief
@@ -491,25 +449,6 @@ static void tc_net_socket_af_unix_sock_stream_ipv6_n(void)
 	TC_ASSERT_EQ_CLEANUP("socket", fd, -1, close(fd))
 	TC_SUCCESS_RESULT()
 }
-
-#ifdef IPPROTO_ROUTING
-/**
-* @testcase		tc_net_socket_af_unixsock_stream_routing_n
-* @brief
-* @scenario
-* @apicovered		socket()
-* @precondition
-* @postcondition
-*/
-static void tc_net_socket_af_unixsock_stream_routing_n(void)
-{
-
-	int fd = -1;
-	fd = socket(AF_UNIX, SOCK_STREAM, IPPROTO_ROUTING);
-	TC_ASSERT_EQ_CLEANUP("socket", fd, -1, close(fd))
-	TC_SUCCESS_RESULT()
-}
-#endif
 
 /**
 * @testcase		tc_net_socket_af_unix_sock_stream_icmpv6_n
@@ -688,17 +627,17 @@ static void tc_net_socket_af_inet_sock_stream_udp_n(void)
 * @precondition
 * @postcondition
 */
-static void tc_net_socket_af_inet_sock_stream_icmp_p(void)
+static void tc_net_socket_af_inet_sock_stream_icmp_n(void)
 {
 	int fd = -1;
 	fd = socket(AF_INET, SOCK_STREAM, IPPROTO_ICMP);
-	TC_ASSERT_GEQ("socket", fd, 0)
+	TC_ASSERT_EQ_CLEANUP("socket", fd, -1, close(fd))
 	TC_SUCCESS_RESULT()
 
 	close(fd);
 }
 
-#ifdef IPPROTO_IGMP
+#ifdef CONFIG_NET_LWIP_IGMP
 /**
 * @testcase		tc_net_socket_af_inet_sock_stream_igmp_p
 * @brief
@@ -707,11 +646,11 @@ static void tc_net_socket_af_inet_sock_stream_icmp_p(void)
 * @precondition
 * @postcondition
 */
-static void tc_net_socket_af_inet_sock_stream_igmp_p(void)
+static void tc_net_socket_af_inet_sock_stream_igmp_n(void)
 {
 	int fd = -1;
 	fd = socket(AF_INET, SOCK_STREAM, IPPROTO_IGMP);
-	TC_ASSERT_GEQ("socket", fd, 0)
+	TC_ASSERT_EQ_CLEANUP("socket", fd, -1, close(fd))
 	TC_SUCCESS_RESULT()
 
 	close(fd);
@@ -734,46 +673,6 @@ static void tc_net_socket_af_inet_sock_stream_protoipv6_n(void)
 	TC_ASSERT_EQ_CLEANUP("socket", fd, -1, close(fd))
 	TC_SUCCESS_RESULT()
 }
-
-#ifdef IPPROTO_ROUTING
-/**
-* @testcase		tc_net_socket_af_inet_sock_stream_routing_p
-* @brief
-* @scenario
-* @apicovered		socket()
-* @precondition
-* @postcondition
-*/
-static void tc_net_socket_af_inet_sock_stream_routing_p(void)
-{
-	int fd = -1;
-	fd = socket(AF_INET, SOCK_STREAM, IPPROTO_ROUTING);
-	TC_ASSERT_GEQ("socket", fd, 0)
-	TC_SUCCESS_RESULT()
-
-	close(fd);
-}
-#endif
-
-#ifdef IPPROTO_FRAGMENT
-/**
-* @testcase		tc_net_socket_af_inet_sock_stream_fragment_p
-* @brief
-* @scenario
-* @apicovered		socket()
-* @precondition
-* @postcondition
-*/
-static void tc_net_socket_af_inet_sock_stream_fragment_p(void)
-{
-	int fd = -1;
-	fd = socket(AF_INET, SOCK_STREAM, IPPROTO_FRAGMENT);
-	TC_ASSERT_GEQ("socket", fd, 0)
-	TC_SUCCESS_RESULT()
-
-	close(fd);
-}
-#endif
 
 /**
 * @testcase		tc_net_socket_af_inet_sock_stream_icmpv6_n
@@ -924,44 +823,6 @@ static void tc_net_socket_af_unix_sock_dgram_ipv6_n(void)
 	TC_ASSERT_EQ_CLEANUP("socket", fd, -1, close(fd))
 	TC_SUCCESS_RESULT()
 }
-
-#ifdef IPPROTO_ROUTING
-/**
-* @testcase		tc_net_socket_af_unix_sock_dgram_routing_n
-* @brief
-* @scenario
-* @apicovered		socket()
-* @precondition
-* @postcondition
-*/
-static void tc_net_socket_af_unix_sock_dgram_routing_n(void)
-{
-	int fd = -1;
-	fd = socket(AF_UNIX, SOCK_DGRAM, IPPROTO_ROUTING);
-	TC_ASSERT_EQ_CLEANUP("socket", fd, -1, close(fd))
-	TC_SUCCESS_RESULT()
-}
-#endif
-#ifdef IPPROTO_FRAGMENT
-/**
-* @testcase		tc_net_socket_af_unix_sock_dgram_fragment_p
-* @brief
-* @scenario
-* @apicovered		socket()
-* @precondition
-* @postcondition
-*/
-static void tc_net_socket_af_unix_sock_dgram_fragment_p(void)
-{
-	int fd = -1;
-	fd = socket(AF_UNIX, SOCK_DGRAM, IPPROTO_FRAGMENT);
-	TC_ASSERT_GEQ("socket", fd, 0)
-	TC_SUCCESS_RESULT()
-
-	close(fd);
-}
-#endif
-
 /**
 * @testcase		tc_net_socket_af_unix_sock_dgram_icmpv6_n
 * @brief
@@ -1100,11 +961,11 @@ static void tc_net_socket_af_packet_sock_dgram_p(void)
 * @precondition
 * @postcondition
 */
-static void tc_net_socket_af_inet_sock_raw_p(void)
+static void tc_net_socket_af_inet_sock_raw_n(void)
 {
 	int fd = -1;
 	fd = socket(AF_INET, SOCK_RAW, 0);
-	TC_ASSERT_GEQ("socket", fd, 0)
+	TC_ASSERT_EQ_CLEANUP("socket", fd, -1, close(fd))
 	TC_SUCCESS_RESULT()
 
 	close(fd);
@@ -1118,11 +979,11 @@ static void tc_net_socket_af_inet_sock_raw_p(void)
 * @precondition
 * @postcondition
 */
-static void tc_net_socket_af_inet_sock_raw_tcp_p(void)
+static void tc_net_socket_af_inet_sock_raw_tcp_n(void)
 {
 	int fd = -1;
 	fd = socket(AF_INET, SOCK_RAW, IPPROTO_TCP);
-	TC_ASSERT_GEQ("socket", fd, 0)
+	TC_ASSERT_EQ_CLEANUP("socket", fd, -1, close(fd))
 	TC_SUCCESS_RESULT()
 
 	close(fd);
@@ -1136,11 +997,11 @@ static void tc_net_socket_af_inet_sock_raw_tcp_p(void)
 * @precondition
 * @postcondition
 */
-static void tc_net_socket_af_inet_sock_raw_udp_p(void)
+static void tc_net_socket_af_inet_sock_raw_udp_n(void)
 {
 	int fd = -1;
 	fd = socket(AF_INET, SOCK_RAW, IPPROTO_UDP);
-	TC_ASSERT_GEQ("socket", fd, 0)
+	TC_ASSERT_EQ_CLEANUP("socket", fd, -1, close(fd))
 	TC_SUCCESS_RESULT()
 
 	close(fd);
@@ -1164,7 +1025,7 @@ static void tc_net_socket_af_inet_sock_raw_icmp_p(void)
 	close(fd);
 }
 
-#ifdef IPPROTO_IGMP
+#ifdef CONFIG_NET_LWIP_IGMP
 /**
 * @testcase		tc_net_socket_af_inet_sock_raw_igmp_p
 * @brief
@@ -1179,7 +1040,6 @@ static void tc_net_socket_af_inet_sock_raw_igmp_p(void)
 	fd = socket(AF_INET, SOCK_RAW, IPPROTO_IGMP);
 	TC_ASSERT_GEQ("socket", fd, 0)
 	TC_SUCCESS_RESULT()
-
 	close(fd);
 }
 #endif
@@ -1201,46 +1061,6 @@ static void tc_net_socket_af_inet_sock_raw_ipv6_n(void)
 	TC_ASSERT_EQ_CLEANUP("socket", fd, -1, close(fd))
 	TC_SUCCESS_RESULT()
 }
-#ifdef IPPROTO_ROUTING
-/**
-* @testcase		tc_net_socket_af_inet_sock_raw_routing_p
-* @brief
-* @scenario
-* @apicovered		socket()
-* @precondition
-* @postcondition
-*/
-static void tc_net_socket_af_inet_sock_raw_routing_p(void)
-{
-
-	int fd = -1;
-	fd = socket(AF_INET, SOCK_RAW, IPPROTO_ROUTING);
-	TC_ASSERT_GEQ("socket", fd, 0)
-	TC_SUCCESS_RESULT()
-
-	close(fd);
-}
-#endif
-#ifdef IPPROTO_FRAGMENT
-/**
-* @testcase		tc_net_socket_af_inet_sock_raw_fragment_p
-* @brief
-* @scenario
-* @apicovered		socket()
-* @precondition
-* @postcondition
-*/
-static void tc_net_socket_af_inet_sock_raw_fragment_p(void)
-{
-
-	int fd = -1;
-	fd = socket(AF_INET, SOCK_RAW, IPPROTO_FRAGMENT);
-	TC_ASSERT_GEQ("socket", fd, 0)
-	TC_SUCCESS_RESULT()
-
-	close(fd);
-}
-#endif
 /**
 * @testcase		tc_net_socket_af_inet_sock_raw_icmpv6_n
 * @brief
@@ -1249,12 +1069,12 @@ static void tc_net_socket_af_inet_sock_raw_fragment_p(void)
 * @precondition
 * @postcondition
 */
-static void tc_net_socket_af_inet_sock_raw_icmpv6_n(void)
+static void tc_net_socket_af_inet_sock_raw_icmpv6_p(void)
 {
 
 	int fd = -1;
 	fd = socket(AF_INET, SOCK_RAW, IPPROTO_ICMPV6);
-	TC_ASSERT_EQ_CLEANUP("socket", fd, -1, close(fd))
+	TC_ASSERT_GEQ("socket", fd, 0)
 	TC_SUCCESS_RESULT()
 }
 #endif
@@ -1328,7 +1148,7 @@ static void tc_net_socket_af_unix_sock_raw_icmp_n(void)
 	TC_SUCCESS_RESULT()
 }
 
-#ifdef IPPROTO_IGMP
+#ifdef CONFIG_NET_LWIP_IGMP
 /**
 * @testcase		tc_net_socket_af_unix_sock_raw_igmp_n
 * @brief
@@ -1365,44 +1185,6 @@ static void tc_net_socket_af_unix_sock_raw_ipv6_n(void)
 	TC_SUCCESS_RESULT()
 }
 
-#ifdef IPPROTO_ROUTING
-/**
-* @testcase		tc_net_socket_af_unix_sock_raw_routing_n
-* @brief
-* @scenario
-* @apicovered		socket()
-* @precondition
-* @postcondition
-*/
-static void tc_net_socket_af_unix_sock_raw_routing_n(void)
-{
-
-	int fd = -1;
-	fd = socket(AF_UNIX, SOCK_RAW, IPPROTO_ROUTING);
-	TC_ASSERT_EQ_CLEANUP("socket", fd, -1, close(fd))
-	TC_SUCCESS_RESULT()
-}
-#endif
-
-#ifdef IPPROTO_FRAGMENT
-/**
-* @testcase		tc_net_socket_af_unix_sock_raw_fragment_n
-* @brief
-* @scenario
-* @apicovered		socket()
-* @precondition
-* @postcondition
-*/
-static void tc_net_socket_af_unix_sock_raw_fragment_n(void)
-{
-
-	int fd = -1;
-	fd = socket(AF_UNIX, SOCK_RAW, IPPROTO_FRAGMENT);
-	TC_ASSERT_EQ_CLEANUP("socket", fd, -1, close(fd))
-	TC_SUCCESS_RESULT()
-}
-#endif
-
 /**
 * @testcase		tc_net_socket_af_unix_sock_raw_icmpv6_n
 * @brief
@@ -1431,65 +1213,19 @@ int net_socket_main(void)
 	tc_net_socket_pf_inet_sock_stream_p();
 	tc_net_socket_af_inet_sock_dgram_p();
 	tc_net_socket_pf_inet_sock_dgram_p();
-	tc_net_socket_pf_inet_sock_raw_p();
+	tc_net_socket_pf_inet_sock_raw_n();
 	tc_net_socket_af_inet_sock_dgram_tcp_n();
 	tc_net_socket_af_inet_sock_dgram_udp_p();
-	tc_net_socket_af_inet_soc_dgram_icmp_p();
-#ifdef IPPROTO_IGMP
-	tc_net_socket_af_inet_sock_dgram_igmp_p();
+	tc_net_socket_af_inet_sock_dgram_icmp_n();
+#ifdef CONFIG_NET_LWIP_IGMP
+	tc_net_socket_af_inet_sock_dgram_igmp_n();
 #endif
 #ifdef CONFIG_NET_IPv6
 	tc_net_socket_af_inet_sock_dgram_ipv6_n();
-#ifdef IPPROTO_ROUTING
-	tc_net_socket_af_inet_sock_dgram_routing_p();
-#endif
-#ifdef IPPROTO_FRAGMENT
-	tc_net_socket_af_inet_sock_dgram_fragment_p();
-#endif
-#endif
 	tc_net_socket_invalid_domain_sock_stream_n();
-#ifdef CONFIG_NET_IPv6
 	tc_net_socket_af_inet_sock_dgram_icmpv6_n();
 #endif
-#ifdef AF_UNIX
-	tc_net_socket_af_unix_sock_dgram_tcp_n();
-	tc_net_socket_af_unix_sock_dgram_udp_p();
-	tc_net_socket_af_unix_sock_dgram_icmp_n();
-#ifdef IPPROTO_IGMP
-	tc_net_socket_af_unix_sock_dgram_igmp_n();
-#endif
-#endif
-#ifdef AF_X25
-	tc_net_socket_af_x25_sock_stream_n();
-#endif
-#ifdef AF_AX25
-	tc_net_socket_af_ax25_sock_stream_n();
-#endif
-#ifdef AF_PACKET
-	tc_net_socket_af_packet_sock_stream_n();
-#endif
-#ifdef AF_UNIX
-	tc_net_socket_af_unix_sock_stream_p();
-	tc_net_socket_af_unix_sock_stream_udp_n();
-	tc_net_socket_af_unix_sock_stream_icmp_n();
-#ifdef IPPROTO_IGMP
-	tc_net_socket_af_unix_sock_stream_igmp_n();
-#endif
-#ifdef CONFIG_NET_IPv6
-	tc_net_socket_af_unix_sock_stream_ipv6_n();
-#ifdef IPPROTO_ROUTING
-	tc_net_socket_af_unixsock_stream_routing_n();
-#endif
-	tc_net_socket_af_unix_sock_stream_icmpv6_n();
-#endif
-#endif
-#ifdef AF_NETLINK
-	tc_net_socket_af_netlink_sock_stream_n();
-#endif
 	tc_net_socket_af_unspec_sock_stream_p();
-#ifdef AF_UNIX
-	tc_net_socket_af_unix_sock_stream_tcp_p();
-#endif
 	tc_net_socket_af_inet_sock_stream_protocol_n();
 	tc_net_socket_domain_sock_stream_protocol_n();
 	tc_net_socket_af_inet_sock_stream_tcp_p();
@@ -1497,18 +1233,12 @@ int net_socket_main(void)
 	tc_net_socket_domain_type_protocol_n();
 	tc_net_socket_domain_sock_stream_tcp_n();
 	tc_net_socket_af_inet_sock_stream_udp_n();
-	tc_net_socket_af_inet_sock_stream_icmp_p();
-#ifdef IPPROTO_IGMP
-	tc_net_socket_af_inet_sock_stream_igmp_p();
+	tc_net_socket_af_inet_sock_stream_icmp_n();
+#ifdef CONFIG_NET_LWIP_IGMP
+	tc_net_socket_af_inet_sock_stream_igmp_n();
 #endif
 #ifdef CONFIG_NET_IPv6
 	tc_net_socket_af_inet_sock_stream_protoipv6_n();
-#ifdef IPPROTO_ROUTING
-	tc_net_socket_af_inet_sock_stream_routing_p();
-#endif
-#ifdef IPPROTO_FRAGMENT
-	tc_net_socket_af_inet_sock_stream_fragment_p();
-#endif
 	tc_net_socket_af_inet_sock_stream_icmpv6_n();
 #endif
 	tc_net_socket_af_inet6_sock_stream_p();
@@ -1516,69 +1246,17 @@ int net_socket_main(void)
 	tc_net_socket_af_inet_sock_stream_domain_n();
 	tc_net_socket_af_inet_sock_stream_domain_protocol_n();
 	tc_net_socket_af_inet_sock_stream_type_protocol_n();
-#ifdef AF_UNIX
-#ifdef CONFIG_NET_IPv6
-	tc_net_socket_af_unix_sock_dgram_ipv6_n();
-#ifdef IPPROTO_ROUTING
-	tc_net_socket_af_unix_sock_dgram_routing_n();
-#endif
-#ifdef IPPROTO_FRAGMENT
-	tc_net_socket_af_unix_sock_dgram_fragment_p();
-#endif
-	tc_net_socket_af_unix_sock_dgram_icmpv6_n();
-#endif
-#endif
-#ifdef AF_NETLINK
-	tc_net_socket_af_netlink_sock_dgram_p();
-#endif
 	tc_net_socket_af_unspec_sock_dgram_p();
-#ifdef AF_LOCAL
-	tc_net_socket_af_local_sock_dgram_p();
-#endif
-#ifdef AF_X25
-	tc_net_socket_af_x25_sock_dgram_n();
-#endif
-#ifdef AF_AX25
-	tc_net_socket_af_ax25_sock_dgram_n();
-#endif
-#ifdef AF_PACKET
-	tc_net_socket_af_packet_sock_dgram_p();
-#endif
-	tc_net_socket_af_inet_sock_raw_p();
-	tc_net_socket_af_inet_sock_raw_tcp_p();
-	tc_net_socket_af_inet_sock_raw_udp_p();
+	tc_net_socket_af_inet_sock_raw_n();
+	tc_net_socket_af_inet_sock_raw_tcp_n();
+	tc_net_socket_af_inet_sock_raw_udp_n();
 	tc_net_socket_af_inet_sock_raw_icmp_p();
-#ifdef IPPROTO_IGMP
+#ifdef CONFIG_NET_LWIP_IGMP
 	tc_net_socket_af_inet_sock_raw_igmp_p();
 #endif
 #ifdef CONFIG_NET_IPv6
 	tc_net_socket_af_inet_sock_raw_ipv6_n();
-#ifdef IPPROTO_ROUTING
-	tc_net_socket_af_inet_sock_raw_routing_p();
-#endif
-#ifdef IPPROTO_FRAGMENT
-	tc_net_socket_af_inet_sock_raw_fragment_p();
-#endif
-	tc_net_socket_af_inet_sock_raw_icmpv6_n();
-#endif
-#ifdef AF_UNIX
-	tc_net_socket_af_unix_sock_raw_n();
-	tc_net_socket_af_unix_sock_raw_tcp_n();
-	tc_net_socket_af_unix_sock_raw_udp_n();
-	tc_net_socket_af_unix_sock_raw_icmp_n();
-#ifdef IPPROTO_IGMP
-	tc_net_socket_af_unix_sock_raw_igmp_n();
-#endif
-#ifdef CONFIG_NET_IPv6
-	tc_net_socket_af_unix_sock_raw_ipv6_n();
-#ifdef IPPROTO_ROUTING
-	tc_net_socket_af_unix_sock_raw_routing_n();
-#endif
-#ifdef IPPROTO_FRAGMENT
-	tc_net_socket_af_unix_sock_raw_fragment_n();
-#endif
-	tc_net_socket_af_unix_sock_raw_icmpv6_n();
-#endif
+	tc_net_socket_af_inet_sock_raw_icmpv6_p();
 #endif
 	return 0;
 }

--- a/os/include/net/lwip/sockets.h
+++ b/os/include/net/lwip/sockets.h
@@ -292,7 +292,9 @@ struct linger {
 
 #define IPPROTO_IP      0
 #define IPPROTO_ICMP    1
+#define IPPROTO_IGMP    2
 #define IPPROTO_TCP     6
+
 #define IPPROTO_UDP     17
 #define IPPROTO_IPV6    41
 #define IPPROTO_ICMPV6  58

--- a/os/net/socket/bsd_socket_api.c
+++ b/os/net/socket/bsd_socket_api.c
@@ -173,35 +173,34 @@ static int socket_argument_validation(int domain, int type, int protocol)
 	if (domain != AF_INET && domain != AF_INET6 && domain != AF_UNSPEC) {
 		return -1;
 	}
-
-	switch (type) {
-	case SOCK_STREAM:
-		if (protocol == IPPROTO_UDP) {
-			return -1;
-		}
-		break;
-	case SOCK_DGRAM:
-		if (protocol == IPPROTO_TCP) {
-			return -1;
-		}
-		break;
-	case SOCK_RAW:
-		break;
-	default:
-		return -1;
-	}
-
 	switch (protocol) {
-	case IPPROTO_IP:
-	case IPPROTO_ICMP:
-	case IPPROTO_TCP:
-	case IPPROTO_UDP:
-	case IPPROTO_UDPLITE:
-		break;
-	default:
-		return -1;
+		case IPPROTO_UDP:
+		case IPPROTO_UDPLITE:
+			if (type != SOCK_DGRAM) {
+				return -1;
+			}
+			break;
+		case IPPROTO_TCP:
+			if (type != SOCK_STREAM) {
+				return -1;
+			}
+			break;
+		case IPPROTO_ICMP:
+		case IPPROTO_IGMP:
+		case IPPROTO_ICMPV6:
+			if (type != SOCK_RAW) {
+				return -1;
+			}
+			break;
+		case IPPROTO_IP:
+			if (type == SOCK_RAW) {
+				return -1;
+			}
+			break;
+		default:
+			return -1;
+			break;
 	}
-
 	return 0;
 }
 


### PR DESCRIPTION
- Remove socket protocols (and tc) not supported by lwip
- Provide a proper socket_argument_validation function to match
  domain, type, and protocol correctly
- Modify tc contents (positive/negative) according to the socket protocol