### PR TITLE
examples/task_manager_sample: Add calling clean_infolist after getinfo

### DIFF
--- a/apps/examples/task_manager_sample/user.c
+++ b/apps/examples/task_manager_sample/user.c
@@ -57,7 +57,8 @@ int user_main(int argc, char *argv[])
 	if (action_manager_info != NULL) {
 		handle_actionmanager = action_manager_info->task.handle;
 	}
-
+	task_manager_clean_infolist(&action_manager_info);
+	
 	printf("\nUser App sends Alarm On message to Action Manager\n");
 	ret = task_manager_unicast(handle_actionmanager, msg1, strlen(msg1) + 1, TM_RESPONSE_WAIT_INF);
 	if (ret != OK) {


### PR DESCRIPTION
In order to solve memory leakage problem, memory free procedure is added to the task manager sample.
(When task_manager_getinfo_with_name() API is used, use task_manager_clean_infolist() API to free allocated memory to solve memory leakage problem)