### PR TITLE
framework/task_manager: Add default timeout to TM_NO_RESPONSE in broa…

### DIFF
--- a/framework/src/task_manager/task_manager_broadcast.c
+++ b/framework/src/task_manager/task_manager_broadcast.c
@@ -45,6 +45,7 @@ int task_manager_broadcast(int msg)
 
 	/* Set the request msg */
 	request_msg.cmd = TASKMGT_BROADCAST;
+	request_msg.timeout = TM_NO_RESPONSE;
 
 	status = taskmgr_send_request(&request_msg);
 	if (status < 0) {


### PR DESCRIPTION
…dcast

Broadcast functionailty needs not to get response. If default timeout is not setting,
unnecessary private queue will be opened.