### PR TITLE
media: rearrange API orders

### DIFF
--- a/framework/src/media/audio/audio_manager.c
+++ b/framework/src/media/audio/audio_manager.c
@@ -66,7 +66,7 @@
 #define INVALID_ID -1
 
 /****************************************************************************
- * Private Declarations
+ * Private Types
  ****************************************************************************/
 enum audio_card_status_e {
 	AUDIO_CARD_IDLE = 0,
@@ -129,17 +129,6 @@ audio_card_info_t g_audio_out_cards[CONFIG_AUDIO_MAX_OUTPUT_CARD_NUM];
 static int g_actual_audio_in_card_id = INVALID_ID;
 static int g_actual_audio_out_card_id = INVALID_ID;
 
-static void get_hardware_params(audio_card_info_t *card, audio_card_type_t card_type);
-static int get_actual_audio_in_card_id(void);
-static int get_actual_audio_out_card_id(void);
-static audio_manager_result_t get_active_audio_device_pcm(struct pcm **pcm, audio_card_type_t type);
-static audio_manager_result_t get_audio_volume(int fd, audio_config_t *config, audio_card_type_t card_type);
-static audio_manager_result_t set_audio_volume(audio_card_type_t type, uint8_t volume);
-static audio_manager_result_t get_supported_sample_rate(int fd, uint32_t *sample_type, audio_card_type_t type);
-static uint32_t get_closest_samprate(uint32_t origin_samprate, audio_card_type_t type);
-static int resample_stream_in(audio_card_info_t *cur_card, void *data, uint32_t frames);
-static int resample_stream_out(audio_card_info_t *cur_card, void *data, uint32_t frames);
-
 static const struct audio_samprate_map_entry_s g_audio_samprate_entry[] = {
 	{AUDIO_SAMP_RATE_TYPE_8K, AUDIO_SAMP_RATE_8K},
 	{AUDIO_SAMP_RATE_TYPE_11K, AUDIO_SAMP_RATE_11K},
@@ -152,8 +141,39 @@ static const struct audio_samprate_map_entry_s g_audio_samprate_entry[] = {
 };
 
 /****************************************************************************
- * Public Functions
+ * Private Function Prototypes
  ****************************************************************************/
+static audio_manager_result_t find_audio_card_if_empty(audio_card_type_t card_type);
+static audio_manager_result_t find_audio_card(audio_card_type_t card_type);
+static int get_actual_audio_in_card_id(void);
+static int get_actual_audio_out_card_id(void);
+static void get_hardware_params(audio_card_info_t *card, audio_card_type_t card_type);
+static audio_manager_result_t get_supported_sample_rate(int fd, uint32_t *sample_type, audio_card_type_t type);
+static uint32_t get_closest_samprate(uint32_t origin_samprate, audio_card_type_t type);
+static audio_manager_result_t get_active_audio_device_pcm(struct pcm **pcm, audio_card_type_t type);
+static int resample_stream_in(audio_card_info_t *cur_card, void *data, uint32_t frames);
+static int resample_stream_out(audio_card_info_t *cur_card, void *data, uint32_t frames);
+static audio_manager_result_t get_audio_volume(int fd, audio_config_t *config, audio_card_type_t card_type);
+static audio_manager_result_t set_audio_volume(audio_card_type_t type, uint8_t volume);
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+static audio_manager_result_t find_audio_card_if_empty(audio_card_type_t card_type)
+{
+	int id = g_actual_audio_out_card_id;
+
+	if (card_type == INPUT) {
+		id = g_actual_audio_in_card_id;
+	}
+
+	if ((id == INVALID_ID) && (find_audio_card(card_type) != AUDIO_MANAGER_SUCCESS)) {
+		meddbg("Found no active audio card type : %d\n", card_type);
+		return AUDIO_MANAGER_CARD_NOT_FOUND;
+	}
+	return AUDIO_MANAGER_SUCCESS;
+}
+
 static audio_manager_result_t find_audio_card(audio_card_type_t card_type)
 {
 	audio_manager_result_t ret = AUDIO_MANAGER_SUCCESS;
@@ -219,18 +239,253 @@ error_out:
 	return ret;
 }
 
-static audio_manager_result_t find_audio_card_if_empty(audio_card_type_t card_type)
+/* TODO this function should consider priority of each function in future */
+static int get_actual_audio_in_card_id()
 {
-	int id = g_actual_audio_out_card_id;
+	int i;
+	for (i = 0; i < CONFIG_AUDIO_MAX_INPUT_CARD_NUM; i++) {
+		if (g_audio_in_cards[i].status != AUDIO_CARD_IDLE) {
+			return i;
+		}
+	}
+
+	/* Now all cards are IDLE state, we select card which has highest priority */
+	g_audio_in_cards[0].status = AUDIO_CARD_READY;
+	return 0;
+}
+
+static int get_actual_audio_out_card_id()
+{
+	int i;
+	for (i = 0; i < CONFIG_AUDIO_MAX_OUTPUT_CARD_NUM; i++) {
+		if (g_audio_out_cards[i].status != AUDIO_CARD_IDLE) {
+			return i;
+		}
+	}
+	/* Now all cards are IDLE state, we select card which has highest priority */
+	g_audio_out_cards[0].status = AUDIO_CARD_READY;
+	return 0;
+}
+
+static void get_hardware_params(audio_card_info_t *card, audio_card_type_t card_type)
+{
+	int fd;
+	int ret;
+	audio_config_t *config;
+
+	fd = open(card->card_path, O_RDONLY);
+	if (fd < 0) {
+		meddbg("Failed to open audio driver, path : %s errno : %d\n", card->card_path, errno);
+		return;
+	}
+
+	config = &card->config;
+#ifndef CONFIG_AUDIO_EXCLUDE_VOLUME
+	/* get volume of current card first */
+	ret = get_audio_volume(fd, config, card_type);
+
+	/* If it is failed, it doesn't return because we should get next h/w params */
+	if (ret != AUDIO_MANAGER_SUCCESS) {
+		meddbg("Get volume failed card path : %s card_type : %d ret : %d\n", card->card_path, card_type, ret);
+	}
+
+	medvdbg("Max volume: %d, Current Volume : %d card path : %s\n", card->config.max_volume, card->config.volume, card->card_path);
+#endif
+	/* get supported sample rate type */
+	ret = get_supported_sample_rate(fd, &card->resample.samprate_types, card_type);
+	if (ret != AUDIO_MANAGER_SUCCESS) {
+		meddbg("Get supported sample rate failed card path : %s card_type : %d ret : %d\n", card->card_path, card_type, ret);
+	}
+	medvdbg("card path : %s Supported sample rate: %x\n", card->card_path, card->resample.samprate_types);
+	close(fd);
+}
+
+static audio_manager_result_t get_supported_sample_rate(int fd, uint32_t *sample_type, audio_card_type_t card_type)
+{
+	struct audio_caps_desc_s caps_desc;
+
+	caps_desc.caps.ac_len = sizeof(struct audio_caps_s);
+	caps_desc.caps.ac_type = AUDIO_TYPE_OUTPUT;
+	if (card_type == INPUT) {
+		caps_desc.caps.ac_type = AUDIO_TYPE_INPUT;
+	}
+	caps_desc.caps.ac_subtype = AUDIO_TYPE_QUERY;
+
+	if (ioctl(fd, AUDIOIOC_GETCAPS, (unsigned long *)&caps_desc.caps) < 0) {
+		meddbg("Fail to ioctl AUDIOIOC_GETCAPS\n");
+		return AUDIO_MANAGER_DEVICE_FAIL;
+	}
+
+	*sample_type = caps_desc.caps.ac_controls.b[0];
+
+	return AUDIO_MANAGER_SUCCESS;
+}
+
+static uint32_t get_closest_samprate(uint32_t origin_samprate, audio_card_type_t type)
+{
+	int i;
+	uint32_t result;
+	uint32_t samprate_types;
+	int count = sizeof(g_audio_samprate_entry) / sizeof(struct audio_samprate_map_entry_s);
+
+	ASSERT(count > 0);
+
+	if (type == INPUT) {
+		ASSERT(g_actual_audio_in_card_id >= 0);
+		samprate_types = g_audio_in_cards[g_actual_audio_in_card_id].resample.samprate_types;
+	} else {
+		ASSERT(g_actual_audio_out_card_id >= 0);
+		samprate_types = g_audio_out_cards[g_actual_audio_out_card_id].resample.samprate_types;
+	}
+
+	result = g_audio_samprate_entry[count - 1].samprate;
+
+	for (i = count - 1; i >= 0; i--) {
+		if (g_audio_samprate_entry[i].samprate_types & samprate_types) {
+			if (g_audio_samprate_entry[i].samprate >= origin_samprate) {
+				result = g_audio_samprate_entry[i].samprate;
+			}
+		}
+	}
+
+	return result;
+}
+
+static audio_manager_result_t get_active_audio_device_pcm(struct pcm **pcm, audio_card_type_t type)
+{
+	if (type == INPUT) {
+		if (g_actual_audio_in_card_id < 0) {
+			meddbg("Found no active input audio card\n");
+			return AUDIO_MANAGER_NO_AVAIL_CARD;
+		}
+
+		*pcm = g_audio_in_cards[g_actual_audio_in_card_id].pcm;
+	} else {
+		if (g_actual_audio_out_card_id < 0) {
+			meddbg("Found no active output audio card\n");
+			return AUDIO_MANAGER_NO_AVAIL_CARD;
+		}
+
+		*pcm = g_audio_out_cards[g_actual_audio_out_card_id].pcm;
+	}
+
+	if (!pcm_is_ready(*pcm)) {
+		pcm_close(*pcm);
+		meddbg("Found a null pcm\n");
+		return AUDIO_MANAGER_CARD_NOT_READY;
+	}
+
+	return AUDIO_MANAGER_SUCCESS;
+}
+
+static int resample_stream_in(audio_card_info_t *cur_card, void *data, uint32_t frames)
+{
+	int used_frames = 0;
+	int resampled_frames = 0;
+	src_data_t srcData = { 0, };
+
+	srcData.channels_num = 2;
+	srcData.origin_sample_rate = cur_card->resample.from;
+	srcData.origin_sample_width = SAMPLE_WIDTH_16BITS;
+	srcData.desired_sample_rate = cur_card->resample.to;
+	srcData.desired_sample_width = SAMPLE_WIDTH_16BITS;
+	srcData.input_frames_used = 0;
+	srcData.data_out = data;
+	srcData.out_buf_length = cur_card->resample.buffer_size;
+
+	while (frames > used_frames) {
+		srcData.data_in = cur_card->resample.buffer + get_input_frames_byte_size(used_frames);
+		srcData.input_frames = frames - used_frames;
+		srcData.data_out = data + get_input_frames_byte_size(resampled_frames);
+		medvdbg("data_in addr = 0x%x + %d\t", srcData.data_in, get_input_frames_byte_size(used_frames));
+		if (src_simple(cur_card->resample.handle, &srcData) != SRC_ERR_NO_ERROR) {
+			meddbg("Fail to resample in:%d/%d, out:%d, to %u from %u\n", used_frames, frames, srcData.desired_sample_rate, srcData.origin_sample_rate);
+			return AUDIO_MANAGER_RESAMPLE_FAIL;
+		}
+
+		if (srcData.output_frames_gen > 0) {
+			resampled_frames += srcData.output_frames_gen;
+			used_frames += srcData.input_frames_used;
+			medvdbg("Record resampled in:%d/%d, out:%d\n", used_frames, frames, resampled_frames);
+		} else {
+			meddbg("Wrong output_frames_gen : %d\n", srcData.output_frames_gen);
+			return AUDIO_MANAGER_RESAMPLE_FAIL;
+		}
+	}
+
+	return resampled_frames;
+}
+
+static int resample_stream_out(audio_card_info_t *cur_card, void *data, uint32_t frames)
+{
+	int used_frames = 0;
+	int resampled_frames = 0;
+	src_data_t srcData = { 0, };
+
+	srcData.channels_num = 2;
+	srcData.origin_sample_rate = cur_card->resample.from;
+	srcData.origin_sample_width = SAMPLE_WIDTH_16BITS;
+	srcData.desired_sample_rate = cur_card->resample.to;
+	srcData.desired_sample_width = SAMPLE_WIDTH_16BITS;
+	srcData.input_frames_used = 0;
+	srcData.data_out = cur_card->resample.buffer;
+	srcData.out_buf_length = cur_card->resample.buffer_size;
+	medvdbg("resampler buffer_size = %d, buffer_addr = 0x%x\n", cur_card->resample.buffer_size, cur_card->resample.buffer);
+
+	while (frames > used_frames) {
+		srcData.data_in = data + get_output_frames_byte_size(used_frames);
+		srcData.input_frames = frames - used_frames;
+		srcData.data_out = cur_card->resample.buffer + get_output_frames_byte_size(resampled_frames);
+		medvdbg("buffer addr = 0x%x   data_out addr = 0x%x   ", cur_card->resample.buffer, srcData.data_out);
+		if (src_simple(cur_card->resample.handle, &srcData) != SRC_ERR_NO_ERROR) {
+			meddbg("Fail to resample in:%d/%d, out:%d, to %u from %u\n", used_frames, frames, srcData.desired_sample_rate, srcData.origin_sample_rate);
+			return AUDIO_MANAGER_RESAMPLE_FAIL;
+		}
+
+		if (srcData.output_frames_gen > 0) {
+			resampled_frames += srcData.output_frames_gen;
+			used_frames += srcData.input_frames_used;
+		} else {
+			meddbg("Wrong output_frames_gen : %d\n", srcData.output_frames_gen);
+			return AUDIO_MANAGER_RESAMPLE_FAIL;
+		}
+		medvdbg("%d resampled from (%d/%d) @ 0x%x\t", resampled_frames, used_frames, frames, srcData.data_out);
+	}
+	medvdbg("Resample finished\n");
+
+	return resampled_frames;
+}
+
+static audio_manager_result_t get_audio_volume(int fd, audio_config_t *config, audio_card_type_t card_type)
+{
+	struct audio_caps_desc_s caps_desc;
+	int ret;
+	int max_volume;
+	int cur_volume;
+
+	caps_desc.caps.ac_len = sizeof(struct audio_caps_s);
+	caps_desc.caps.ac_type = AUDIO_TYPE_FEATURE;
+	caps_desc.caps.ac_format.hw = AUDIO_FU_VOLUME;
 
 	if (card_type == INPUT) {
-		id = g_actual_audio_in_card_id;
+		caps_desc.caps.ac_format.hw = AUDIO_FU_INP_GAIN;
 	}
 
-	if ((id == INVALID_ID) && (find_audio_card(card_type) != AUDIO_MANAGER_SUCCESS)) {
-		meddbg("Found no active audio card type : %d\n", card_type);
-		return AUDIO_MANAGER_CARD_NOT_FOUND;
+	ret = ioctl(fd, AUDIOIOC_GETCAPS, (unsigned long *)&caps_desc.caps);
+	if (ret < 0) {
+		meddbg("Fail to ioctl AUDIOIOC_GETCAPS\n");
+		return AUDIO_MANAGER_DEVICE_FAIL;
 	}
+
+	max_volume = caps_desc.caps.ac_controls.b[0];
+	cur_volume = caps_desc.caps.ac_controls.b[1];
+
+	/* scale here */
+	cur_volume = cur_volume * AUDIO_DEVICE_MAX_VOLUME / (max_volume - (max_volume % AUDIO_DEVICE_MAX_VOLUME));
+
+	config->max_volume = max_volume;
+	config->volume = cur_volume;
+
 	return AUDIO_MANAGER_SUCCESS;
 }
 
@@ -285,384 +540,9 @@ errout:
 	return ret;
 }
 
-audio_manager_result_t set_input_audio_volume(uint8_t volume)
-{
-#ifndef CONFIG_AUDIO_EXCLUDE_VOLUME
-	if (g_audio_in_cards[g_actual_audio_in_card_id].config.volume == volume) {
-		return AUDIO_MANAGER_SUCCESS;
-	}
-
-	return set_audio_volume(INPUT, volume);
-#endif
-	return AUDIO_MANAGER_SUCCESS;
-}
-
-audio_manager_result_t set_output_audio_volume(uint8_t volume)
-{
-#ifndef CONFIG_AUDIO_EXCLUDE_VOLUME
-	if (g_audio_out_cards[g_actual_audio_out_card_id].config.volume == volume) {
-		return AUDIO_MANAGER_SUCCESS;
-	}
-
-	return set_audio_volume(OUTPUT, volume);
-#endif
-	return AUDIO_MANAGER_SUCCESS;
-}
-
-int get_input_audio_volume(void)
-{
-#ifndef CONFIG_AUDIO_EXCLUDE_VOLUME	//TODO consider about config for gain.
-	int ret;
-	
-	/* check actual card and try to find all card if there is no actual card */
-	ret = find_audio_card_if_empty(INPUT);
-	if (ret != AUDIO_MANAGER_SUCCESS) {
-		return ret;
-	}
-	return g_audio_in_cards[g_actual_audio_in_card_id].config.volume;
-#endif
-	return 0;
-}
-
-int get_output_audio_volume(void)
-{
-#ifndef CONFIG_AUDIO_EXCLUDE_VOLUME
-	int ret;
-
-	/* check actual card and try to find all card if there is no actual card */
-	ret = find_audio_card_if_empty(OUTPUT);
-	if (ret != AUDIO_MANAGER_SUCCESS) {
-		return ret;
-	}
-	return g_audio_out_cards[g_actual_audio_out_card_id].config.volume;
-#endif
-	return 0;
-}
-
-uint16_t get_max_audio_volume(void)
-{
-	return AUDIO_DEVICE_MAX_VOLUME;
-}
-
-uint32_t get_input_frame_count(void)
-{
-	if (g_actual_audio_in_card_id < 0) {
-		meddbg("No input audio card is active.\n");
-		return 0;
-	}
-
-	return pcm_get_buffer_size(g_audio_in_cards[g_actual_audio_in_card_id].pcm);
-}
-
-uint32_t get_input_frames_byte_size(uint32_t frames)
-{
-	if ((g_actual_audio_in_card_id < 0) || (frames == 0)) {
-		meddbg("No input audio card is active.\n");
-		return 0;
-	}
-
-	return pcm_frames_to_bytes(g_audio_in_cards[g_actual_audio_in_card_id].pcm, frames);
-}
-
-uint32_t get_input_bytes_frame_count(uint32_t bytes)
-{
-	if ((g_actual_audio_in_card_id < 0) || (bytes == 0)) {
-		meddbg("No input audio card is active.\n");
-		return 0;
-	}
-
-	return pcm_bytes_to_frames(g_audio_in_cards[g_actual_audio_in_card_id].pcm, bytes);
-}
-
-uint32_t get_output_frame_count(void)
-{
-	if (g_actual_audio_out_card_id < 0) {
-		meddbg("No output audio card is active.\n");
-		return 0;
-	}
-
-	return pcm_get_buffer_size(g_audio_out_cards[g_actual_audio_out_card_id].pcm);
-}
-
-uint32_t get_output_frames_byte_size(uint32_t frames)
-{
-	if ((g_actual_audio_out_card_id < 0) || (frames == 0)) {
-		meddbg("No output audio card is active.\n");
-		return 0;
-	}
-
-	return pcm_frames_to_bytes(g_audio_out_cards[g_actual_audio_out_card_id].pcm, frames);
-}
-
-uint32_t get_output_bytes_frame_count(uint32_t bytes)
-{
-	if ((g_actual_audio_out_card_id < 0) || (bytes == 0)) {
-		meddbg("No output audio card is active.\n");
-		return 0;
-	}
-
-	return pcm_bytes_to_frames(g_audio_out_cards[g_actual_audio_out_card_id].pcm, bytes);
-}
-
-static audio_manager_result_t get_active_audio_device_pcm(struct pcm **pcm, audio_card_type_t type)
-{
-	if (type == INPUT) {
-		if (g_actual_audio_in_card_id < 0) {
-			meddbg("Found no active input audio card\n");
-			return AUDIO_MANAGER_NO_AVAIL_CARD;
-		}
-
-		*pcm = g_audio_in_cards[g_actual_audio_in_card_id].pcm;
-	} else {
-		if (g_actual_audio_out_card_id < 0) {
-			meddbg("Found no active output audio card\n");
-			return AUDIO_MANAGER_NO_AVAIL_CARD;
-		}
-
-		*pcm = g_audio_out_cards[g_actual_audio_out_card_id].pcm;
-	}
-
-	if (!pcm_is_ready(*pcm)) {
-		pcm_close(*pcm);
-		meddbg("Found a null pcm\n");
-		return AUDIO_MANAGER_CARD_NOT_READY;
-	}
-
-	return AUDIO_MANAGER_SUCCESS;
-}
-
-/* TODO this function should consider priority of each function in future */
-static int get_actual_audio_in_card_id()
-{
-	int i;
-	for (i = 0; i < CONFIG_AUDIO_MAX_INPUT_CARD_NUM; i++) {
-		if (g_audio_in_cards[i].status != AUDIO_CARD_IDLE) {
-			return i;
-		}
-	}
-
-	/* Now all cards are IDLE state, we select card which has highest priority */
-	g_audio_in_cards[0].status = AUDIO_CARD_READY;
-	return 0;
-}
-
-static int get_actual_audio_out_card_id()
-{
-	int i;
-	for (i = 0; i < CONFIG_AUDIO_MAX_OUTPUT_CARD_NUM; i++) {
-		if (g_audio_out_cards[i].status != AUDIO_CARD_IDLE) {
-			return i;
-		}
-	}
-	/* Now all cards are IDLE state, we select card which has highest priority */
-	g_audio_out_cards[0].status = AUDIO_CARD_READY;
-	return 0;
-}
-
-static int resample_stream_in(audio_card_info_t *cur_card, void *data, uint32_t frames)
-{
-	int used_frames = 0;
-	int resampled_frames = 0;
-	src_data_t srcData = { 0, };
-
-	srcData.channels_num = 2;
-	srcData.origin_sample_rate = cur_card->resample.from;
-	srcData.origin_sample_width = SAMPLE_WIDTH_16BITS;
-	srcData.desired_sample_rate = cur_card->resample.to;
-	srcData.desired_sample_width = SAMPLE_WIDTH_16BITS;
-	srcData.input_frames_used = 0;
-	srcData.data_out = data;
-	srcData.out_buf_length = cur_card->resample.buffer_size;
-
-	while (frames > used_frames) {
-		srcData.data_in = cur_card->resample.buffer + get_input_frames_byte_size(used_frames);
-		srcData.input_frames = frames - used_frames;
-		srcData.data_out = data + get_input_frames_byte_size(resampled_frames);
-		medvdbg("data_in addr = 0x%x + %d\t", srcData.data_in, get_input_frames_byte_size(used_frames));
-		if (src_simple(cur_card->resample.handle, &srcData) != SRC_ERR_NO_ERROR) {
-			meddbg("Fail to resample in:%d/%d, out:%d, to %u from %u\n", used_frames, frames, srcData.desired_sample_rate, srcData.origin_sample_rate);
-			return AUDIO_MANAGER_RESAMPLE_FAIL;
-		}
-
-		if (srcData.output_frames_gen > 0) {
-			resampled_frames += srcData.output_frames_gen;
-			used_frames += srcData.input_frames_used;
-			medvdbg("Record resampled in:%d/%d, out:%d\n", used_frames, frames, resampled_frames);
-		} else {
-			meddbg("Wrong output_frames_gen : %d\n", srcData.output_frames_gen);
-			return AUDIO_MANAGER_RESAMPLE_FAIL;
-		}
-	}
-
-	return resampled_frames;
-}
-
-int start_audio_stream_in(void *data, uint32_t frames)
-{
-	int ret;
-	int prepare_retry = AUDIO_STREAM_RETRY_COUNT;
-	struct pcm *pcm;
-	audio_card_info_t *cur_card;
-
-	if ((ret = get_active_audio_device_pcm(&pcm, INPUT)) != AUDIO_MANAGER_SUCCESS) {
-		return ret;
-	}
-
-	cur_card = &g_audio_in_cards[g_actual_audio_in_card_id];
-	if (cur_card->status == AUDIO_CARD_PAUSE) {
-		ret = ioctl(pcm_get_file_descriptor(pcm), AUDIOIOC_RESUME, NULL);
-		if (ret < 0) {
-			meddbg("Fail to ioctl AUDIOIOC_RESUME, ret = %d\n", ret);
-			return AUDIO_MANAGER_DEVICE_FAIL;
-		}
-
-		cur_card->status = AUDIO_CARD_RUNNING;
-		medvdbg("Resume the input audio card!!\n");
-	}
-
-	do {
-		// Todo: Logic needs to be changed.
-		//       From: 1 pcm_readi - 1 resampling
-		//       To  : * pcm_readi - 1 resampling
-		if (cur_card->resample.necessary) {
-			unsigned int frames_to_read = (unsigned int)((float)frames / cur_card->resample.ratio);
-			if (frames_to_read > (get_input_frame_count() / cur_card->resample.ratio)) {
-				frames_to_read = (get_input_frame_count() / cur_card->resample.ratio);
-			}
-
-			cur_card->resample.buffer_size = get_input_frames_byte_size(frames);
-
-			ret = pcm_readi(pcm, cur_card->resample.buffer, frames_to_read);
-			medvdbg("Read frames (%d/%u) for resample to %u\n", ret, frames_to_read, frames);
-		} else {
-			ret = pcm_readi(pcm, data, frames);
-			medvdbg("Read %d frames\n", ret);
-		}
-
-		if (ret == -EPIPE) {
-			ret = pcm_prepare(pcm);
-			meddbg("PCM is reprepared\n");
-			if (ret != OK) {
-				meddbg("Fail to pcm_prepare()\n");
-				return AUDIO_MANAGER_XRUN_STATE;
-			}
-		} else if (ret == -EINVAL) {
-			return AUDIO_MANAGER_INVALID_PARAM;
-		} else {
-			break;
-		}
-	} while ((ret == OK) && (prepare_retry--));
-
-	if (cur_card->resample.necessary) {
-		ret = resample_stream_in(cur_card, data, ret);
-		medvdbg("Resampled frames = %d\n", ret);
-	}
-
-	return ret;
-}
-
-static int resample_stream_out(audio_card_info_t *cur_card, void *data, uint32_t frames)
-{
-	int used_frames = 0;
-	int resampled_frames = 0;
-	src_data_t srcData = { 0, };
-
-	srcData.channels_num = 2;
-	srcData.origin_sample_rate = cur_card->resample.from;
-	srcData.origin_sample_width = SAMPLE_WIDTH_16BITS;
-	srcData.desired_sample_rate = cur_card->resample.to;
-	srcData.desired_sample_width = SAMPLE_WIDTH_16BITS;
-	srcData.input_frames_used = 0;
-	srcData.data_out = cur_card->resample.buffer;
-	srcData.out_buf_length = cur_card->resample.buffer_size;
-	medvdbg("resampler buffer_size = %d, buffer_addr = 0x%x\n", cur_card->resample.buffer_size, cur_card->resample.buffer);
-
-	while (frames > used_frames) {
-		srcData.data_in = data + get_output_frames_byte_size(used_frames);
-		srcData.input_frames = frames - used_frames;
-		srcData.data_out = cur_card->resample.buffer + get_output_frames_byte_size(resampled_frames);
-		medvdbg("buffer addr = 0x%x   data_out addr = 0x%x   ", cur_card->resample.buffer, srcData.data_out);
-		if (src_simple(cur_card->resample.handle, &srcData) != SRC_ERR_NO_ERROR) {
-			meddbg("Fail to resample in:%d/%d, out:%d, to %u from %u\n", used_frames, frames, srcData.desired_sample_rate, srcData.origin_sample_rate);
-			return AUDIO_MANAGER_RESAMPLE_FAIL;
-		}
-
-		if (srcData.output_frames_gen > 0) {
-			resampled_frames += srcData.output_frames_gen;
-			used_frames += srcData.input_frames_used;
-		} else {
-			meddbg("Wrong output_frames_gen : %d\n", srcData.output_frames_gen);
-			return AUDIO_MANAGER_RESAMPLE_FAIL;
-		}
-		medvdbg("%d resampled from (%d/%d) @ 0x%x\t", resampled_frames, used_frames, frames, srcData.data_out);
-	}
-	medvdbg("Resample finished\n");
-
-	return resampled_frames;
-}
-
-int start_audio_stream_out(void *data, uint32_t frames)
-{
-	int ret;
-	int resampled_frames = 0;
-	int prepare_retry = AUDIO_STREAM_RETRY_COUNT;
-	struct pcm *pcm;
-	audio_card_info_t *cur_card;
-	medvdbg("start_audio_stream_out(%u)\n", frames);
-
-	if ((ret = get_active_audio_device_pcm(&pcm, OUTPUT)) != AUDIO_MANAGER_SUCCESS) {
-		return ret;
-	}
-	cur_card = &g_audio_out_cards[g_actual_audio_out_card_id];
-
-	if (cur_card->status == AUDIO_CARD_PAUSE) {
-		ret = ioctl(pcm_get_file_descriptor(pcm), AUDIOIOC_RESUME, NULL);
-		if (ret < 0) {
-			meddbg("Fail to ioctl AUDIOIOC_RESUME, ret = %d\n", ret);
-			return AUDIO_MANAGER_DEVICE_FAIL;
-		}
-
-		cur_card->status = AUDIO_CARD_RUNNING;
-		medvdbg("Resume the output audio card!!\n");
-	}
-
-	if (cur_card->resample.necessary) {
-		resampled_frames = resample_stream_out(cur_card, data, frames);
-	}
-
-	do {
-		medvdbg("Start Playing!! Resample : %d\t", cur_card->resample.necessary);
-		if (cur_card->resample.necessary) {
-			ret = pcm_writei(pcm, cur_card->resample.buffer, resampled_frames);
-		} else {
-			ret = pcm_writei(pcm, data, frames);
-		}
-
-		if (ret < 0) {
-			if (ret == -EPIPE) {
-				if (prepare_retry > 0) {
-					ret = pcm_prepare(pcm);
-					if (ret != OK) {
-						meddbg("Fail to pcm_prepare()\n");
-						return AUDIO_MANAGER_XRUN_STATE;
-					}
-					prepare_retry--;
-				} else {
-					meddbg("prepare_retry = 0\n");
-					return AUDIO_MANAGER_XRUN_STATE;
-				}
-			} else if (ret == -EINVAL) {
-				meddbg("pcm_writei = -EINVAL\n");
-				return AUDIO_MANAGER_INVALID_PARAM;
-			} else {
-				return AUDIO_MANAGER_FAIL;
-			}
-		}
-	} while (ret == OK);
-
-	return ret;
-}
-
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
 audio_manager_result_t set_audio_stream_in(uint8_t channels, uint32_t sample_rate, uint8_t format)
 {
 	struct pcm_config config;
@@ -782,6 +662,132 @@ audio_manager_result_t set_audio_stream_out(uint8_t channels, uint32_t sample_ra
 	return AUDIO_MANAGER_SUCCESS;
 }
 
+int start_audio_stream_in(void *data, uint32_t frames)
+{
+	int ret;
+	int prepare_retry = AUDIO_STREAM_RETRY_COUNT;
+	struct pcm *pcm;
+	audio_card_info_t *cur_card;
+
+	if ((ret = get_active_audio_device_pcm(&pcm, INPUT)) != AUDIO_MANAGER_SUCCESS) {
+		return ret;
+	}
+
+	cur_card = &g_audio_in_cards[g_actual_audio_in_card_id];
+	if (cur_card->status == AUDIO_CARD_PAUSE) {
+		ret = ioctl(pcm_get_file_descriptor(pcm), AUDIOIOC_RESUME, NULL);
+		if (ret < 0) {
+			meddbg("Fail to ioctl AUDIOIOC_RESUME, ret = %d\n", ret);
+			return AUDIO_MANAGER_DEVICE_FAIL;
+		}
+
+		cur_card->status = AUDIO_CARD_RUNNING;
+		medvdbg("Resume the input audio card!!\n");
+	}
+
+	do {
+		// Todo: Logic needs to be changed.
+		//       From: 1 pcm_readi - 1 resampling
+		//       To  : * pcm_readi - 1 resampling
+		if (cur_card->resample.necessary) {
+			unsigned int frames_to_read = (unsigned int)((float)frames / cur_card->resample.ratio);
+			if (frames_to_read > (get_input_frame_count() / cur_card->resample.ratio)) {
+				frames_to_read = (get_input_frame_count() / cur_card->resample.ratio);
+			}
+
+			cur_card->resample.buffer_size = get_input_frames_byte_size(frames);
+
+			ret = pcm_readi(pcm, cur_card->resample.buffer, frames_to_read);
+			medvdbg("Read frames (%d/%u) for resample to %u\n", ret, frames_to_read, frames);
+		} else {
+			ret = pcm_readi(pcm, data, frames);
+			medvdbg("Read %d frames\n", ret);
+		}
+
+		if (ret == -EPIPE) {
+			ret = pcm_prepare(pcm);
+			meddbg("PCM is reprepared\n");
+			if (ret != OK) {
+				meddbg("Fail to pcm_prepare()\n");
+				return AUDIO_MANAGER_XRUN_STATE;
+			}
+		} else if (ret == -EINVAL) {
+			return AUDIO_MANAGER_INVALID_PARAM;
+		} else {
+			break;
+		}
+	} while ((ret == OK) && (prepare_retry--));
+
+	if (cur_card->resample.necessary) {
+		ret = resample_stream_in(cur_card, data, ret);
+		medvdbg("Resampled frames = %d\n", ret);
+	}
+
+	return ret;
+}
+
+int start_audio_stream_out(void *data, uint32_t frames)
+{
+	int ret;
+	int resampled_frames = 0;
+	int prepare_retry = AUDIO_STREAM_RETRY_COUNT;
+	struct pcm *pcm;
+	audio_card_info_t *cur_card;
+	medvdbg("start_audio_stream_out(%u)\n", frames);
+
+	if ((ret = get_active_audio_device_pcm(&pcm, OUTPUT)) != AUDIO_MANAGER_SUCCESS) {
+		return ret;
+	}
+	cur_card = &g_audio_out_cards[g_actual_audio_out_card_id];
+
+	if (cur_card->status == AUDIO_CARD_PAUSE) {
+		ret = ioctl(pcm_get_file_descriptor(pcm), AUDIOIOC_RESUME, NULL);
+		if (ret < 0) {
+			meddbg("Fail to ioctl AUDIOIOC_RESUME, ret = %d\n", ret);
+			return AUDIO_MANAGER_DEVICE_FAIL;
+		}
+
+		cur_card->status = AUDIO_CARD_RUNNING;
+		medvdbg("Resume the output audio card!!\n");
+	}
+
+	if (cur_card->resample.necessary) {
+		resampled_frames = resample_stream_out(cur_card, data, frames);
+	}
+
+	do {
+		medvdbg("Start Playing!! Resample : %d\t", cur_card->resample.necessary);
+		if (cur_card->resample.necessary) {
+			ret = pcm_writei(pcm, cur_card->resample.buffer, resampled_frames);
+		} else {
+			ret = pcm_writei(pcm, data, frames);
+		}
+
+		if (ret < 0) {
+			if (ret == -EPIPE) {
+				if (prepare_retry > 0) {
+					ret = pcm_prepare(pcm);
+					if (ret != OK) {
+						meddbg("Fail to pcm_prepare()\n");
+						return AUDIO_MANAGER_XRUN_STATE;
+					}
+					prepare_retry--;
+				} else {
+					meddbg("prepare_retry = 0\n");
+					return AUDIO_MANAGER_XRUN_STATE;
+				}
+			} else if (ret == -EINVAL) {
+				meddbg("pcm_writei = -EINVAL\n");
+				return AUDIO_MANAGER_INVALID_PARAM;
+			} else {
+				return AUDIO_MANAGER_FAIL;
+			}
+		}
+	} while (ret == OK);
+
+	return ret;
+}
+
 audio_manager_result_t pause_audio_stream_in(void)
 {
 	int ret;
@@ -818,46 +824,6 @@ audio_manager_result_t pause_audio_stream_out(void)
 	}
 
 	g_audio_out_cards[g_actual_audio_out_card_id].status = AUDIO_CARD_PAUSE;
-
-	return AUDIO_MANAGER_SUCCESS;
-}
-
-audio_manager_result_t stop_audio_stream_in(void)
-{
-	int ret;
-	struct pcm *pcm;
-
-	if ((ret = get_active_audio_device_pcm(&pcm, INPUT)) != AUDIO_MANAGER_SUCCESS) {
-		return ret;
-	}
-	ret = pcm_drop(pcm);
-
-	if (ret < 0) {
-		meddbg("pcm_drop Failed, ret = %d\n", ret);
-		return AUDIO_MANAGER_DEVICE_FAIL;
-	}
-
-	g_audio_in_cards[g_actual_audio_in_card_id].status = AUDIO_CARD_READY;
-
-	return AUDIO_MANAGER_SUCCESS;
-}
-
-audio_manager_result_t stop_audio_stream_out(void)
-{
-	int ret;
-	struct pcm *pcm;
-
-	if ((ret = get_active_audio_device_pcm(&pcm, OUTPUT)) != AUDIO_MANAGER_SUCCESS) {
-		return ret;
-	}
-
-	ret = pcm_drain(pcm);
-	if (ret < 0) {
-		meddbg("pcm_drain failed ret = %d\n", ret);
-		return AUDIO_MANAGER_DEVICE_FAIL;
-	}
-
-	g_audio_out_cards[g_actual_audio_out_card_id].status = AUDIO_CARD_READY;
 
 	return AUDIO_MANAGER_SUCCESS;
 }
@@ -910,119 +876,161 @@ audio_manager_result_t reset_audio_stream_out(void)
 	return AUDIO_MANAGER_SUCCESS;
 }
 
-static uint32_t get_closest_samprate(uint32_t origin_samprate, audio_card_type_t type)
+audio_manager_result_t stop_audio_stream_in(void)
 {
-	int i;
-	uint32_t result;
-	uint32_t samprate_types;
-	int count = sizeof(g_audio_samprate_entry) / sizeof(struct audio_samprate_map_entry_s);
-
-	ASSERT(count > 0);
-
-	if (type == INPUT) {
-		ASSERT(g_actual_audio_in_card_id >= 0);
-		samprate_types = g_audio_in_cards[g_actual_audio_in_card_id].resample.samprate_types;
-	} else {
-		ASSERT(g_actual_audio_out_card_id >= 0);
-		samprate_types = g_audio_out_cards[g_actual_audio_out_card_id].resample.samprate_types;
-	}
-
-	result = g_audio_samprate_entry[count - 1].samprate;
-
-	for (i = count - 1; i >= 0; i--) {
-		if (g_audio_samprate_entry[i].samprate_types & samprate_types) {
-			if (g_audio_samprate_entry[i].samprate >= origin_samprate) {
-				result = g_audio_samprate_entry[i].samprate;
-			}
-		}
-	}
-
-	return result;
-}
-
-static audio_manager_result_t get_supported_sample_rate(int fd, uint32_t *sample_type, audio_card_type_t card_type)
-{
-	struct audio_caps_desc_s caps_desc;
-
-	caps_desc.caps.ac_len = sizeof(struct audio_caps_s);
-	caps_desc.caps.ac_type = AUDIO_TYPE_OUTPUT;
-	if (card_type == INPUT) {
-		caps_desc.caps.ac_type = AUDIO_TYPE_INPUT;
-	}
-	caps_desc.caps.ac_subtype = AUDIO_TYPE_QUERY;
-
-	if (ioctl(fd, AUDIOIOC_GETCAPS, (unsigned long *)&caps_desc.caps) < 0) {
-		meddbg("Fail to ioctl AUDIOIOC_GETCAPS\n");
-		return AUDIO_MANAGER_DEVICE_FAIL;
-	}
-
-	*sample_type = caps_desc.caps.ac_controls.b[0];
-
-	return AUDIO_MANAGER_SUCCESS;
-}
-
-static audio_manager_result_t get_audio_volume(int fd, audio_config_t *config, audio_card_type_t card_type)
-{
-	struct audio_caps_desc_s caps_desc;
 	int ret;
-	int max_volume;
-	int cur_volume;
+	struct pcm *pcm;
 
-	caps_desc.caps.ac_len = sizeof(struct audio_caps_s);
-	caps_desc.caps.ac_type = AUDIO_TYPE_FEATURE;
-	caps_desc.caps.ac_format.hw = AUDIO_FU_VOLUME;
-
-	if (card_type == INPUT) {
-		caps_desc.caps.ac_format.hw = AUDIO_FU_INP_GAIN;
+	if ((ret = get_active_audio_device_pcm(&pcm, INPUT)) != AUDIO_MANAGER_SUCCESS) {
+		return ret;
 	}
+	ret = pcm_drop(pcm);
 
-	ret = ioctl(fd, AUDIOIOC_GETCAPS, (unsigned long *)&caps_desc.caps);
 	if (ret < 0) {
-		meddbg("Fail to ioctl AUDIOIOC_GETCAPS\n");
+		meddbg("pcm_drop Failed, ret = %d\n", ret);
 		return AUDIO_MANAGER_DEVICE_FAIL;
 	}
 
-	max_volume = caps_desc.caps.ac_controls.b[0];
-	cur_volume = caps_desc.caps.ac_controls.b[1];
-
-	/* scale here */
-	cur_volume = cur_volume * AUDIO_DEVICE_MAX_VOLUME / (max_volume - (max_volume % AUDIO_DEVICE_MAX_VOLUME));
-
-	config->max_volume = max_volume;
-	config->volume = cur_volume;
+	g_audio_in_cards[g_actual_audio_in_card_id].status = AUDIO_CARD_READY;
 
 	return AUDIO_MANAGER_SUCCESS;
 }
 
-static void get_hardware_params(audio_card_info_t *card, audio_card_type_t card_type)
+audio_manager_result_t stop_audio_stream_out(void)
 {
-	int fd;
 	int ret;
-	audio_config_t *config;
+	struct pcm *pcm;
 
-	fd = open(card->card_path, O_RDONLY);
-	if (fd < 0) {
-		meddbg("Failed to open audio driver, path : %s errno : %d\n", card->card_path, errno);
-		return;
+	if ((ret = get_active_audio_device_pcm(&pcm, OUTPUT)) != AUDIO_MANAGER_SUCCESS) {
+		return ret;
 	}
 
-	config = &card->config;
-#ifndef CONFIG_AUDIO_EXCLUDE_VOLUME
-	/* get volume of current card first */
-	ret = get_audio_volume(fd, config, card_type);
+	ret = pcm_drain(pcm);
+	if (ret < 0) {
+		meddbg("pcm_drain failed ret = %d\n", ret);
+		return AUDIO_MANAGER_DEVICE_FAIL;
+	}
 
-	/* If it is failed, it doesn't return because we should get next h/w params */
+	g_audio_out_cards[g_actual_audio_out_card_id].status = AUDIO_CARD_READY;
+
+	return AUDIO_MANAGER_SUCCESS;
+}
+
+uint32_t get_input_frame_count(void)
+{
+	if (g_actual_audio_in_card_id < 0) {
+		meddbg("No input audio card is active.\n");
+		return 0;
+	}
+
+	return pcm_get_buffer_size(g_audio_in_cards[g_actual_audio_in_card_id].pcm);
+}
+
+uint32_t get_input_frames_byte_size(uint32_t frames)
+{
+	if ((g_actual_audio_in_card_id < 0) || (frames == 0)) {
+		meddbg("No input audio card is active.\n");
+		return 0;
+	}
+
+	return pcm_frames_to_bytes(g_audio_in_cards[g_actual_audio_in_card_id].pcm, frames);
+}
+
+uint32_t get_input_bytes_frame_count(uint32_t bytes)
+{
+	if ((g_actual_audio_in_card_id < 0) || (bytes == 0)) {
+		meddbg("No input audio card is active.\n");
+		return 0;
+	}
+
+	return pcm_bytes_to_frames(g_audio_in_cards[g_actual_audio_in_card_id].pcm, bytes);
+}
+
+uint32_t get_output_frame_count(void)
+{
+	if (g_actual_audio_out_card_id < 0) {
+		meddbg("No output audio card is active.\n");
+		return 0;
+	}
+
+	return pcm_get_buffer_size(g_audio_out_cards[g_actual_audio_out_card_id].pcm);
+}
+
+uint32_t get_output_frames_byte_size(uint32_t frames)
+{
+	if ((g_actual_audio_out_card_id < 0) || (frames == 0)) {
+		meddbg("No output audio card is active.\n");
+		return 0;
+	}
+
+	return pcm_frames_to_bytes(g_audio_out_cards[g_actual_audio_out_card_id].pcm, frames);
+}
+
+uint32_t get_output_bytes_frame_count(uint32_t bytes)
+{
+	if ((g_actual_audio_out_card_id < 0) || (bytes == 0)) {
+		meddbg("No output audio card is active.\n");
+		return 0;
+	}
+
+	return pcm_bytes_to_frames(g_audio_out_cards[g_actual_audio_out_card_id].pcm, bytes);
+}
+
+uint16_t get_max_audio_volume(void)
+{
+	return AUDIO_DEVICE_MAX_VOLUME;
+}
+
+int get_input_audio_volume(void)
+{
+#ifndef CONFIG_AUDIO_EXCLUDE_VOLUME	//TODO consider about config for gain.
+	int ret;
+
+	/* check actual card and try to find all card if there is no actual card */
+	ret = find_audio_card_if_empty(INPUT);
 	if (ret != AUDIO_MANAGER_SUCCESS) {
-		meddbg("Get volume failed card path : %s card_type : %d ret : %d\n", card->card_path, card_type, ret);
+		return ret;
 	}
-
-	medvdbg("Max volume: %d, Current Volume : %d card path : %s\n", card->config.max_volume, card->config.volume, card->card_path);
+	return g_audio_in_cards[g_actual_audio_in_card_id].config.volume;
 #endif
-	/* get supported sample rate type */
-	ret = get_supported_sample_rate(fd, &card->resample.samprate_types, card_type);
+	return 0;
+}
+
+int get_output_audio_volume(void)
+{
+#ifndef CONFIG_AUDIO_EXCLUDE_VOLUME
+	int ret;
+
+	/* check actual card and try to find all card if there is no actual card */
+	ret = find_audio_card_if_empty(OUTPUT);
 	if (ret != AUDIO_MANAGER_SUCCESS) {
-		meddbg("Get supported sample rate failed card path : %s card_type : %d ret : %d\n", card->card_path, card_type, ret);
+		return ret;
 	}
-	medvdbg("card path : %s Supported sample rate: %x\n", card->card_path, card->resample.samprate_types);
-	close(fd);
+	return g_audio_out_cards[g_actual_audio_out_card_id].config.volume;
+#endif
+	return 0;
+}
+
+audio_manager_result_t set_input_audio_volume(uint8_t volume)
+{
+#ifndef CONFIG_AUDIO_EXCLUDE_VOLUME
+	if (g_audio_in_cards[g_actual_audio_in_card_id].config.volume == volume) {
+		return AUDIO_MANAGER_SUCCESS;
+	}
+
+	return set_audio_volume(INPUT, volume);
+#endif
+	return AUDIO_MANAGER_SUCCESS;
+}
+
+audio_manager_result_t set_output_audio_volume(uint8_t volume)
+{
+#ifndef CONFIG_AUDIO_EXCLUDE_VOLUME
+	if (g_audio_out_cards[g_actual_audio_out_card_id].config.volume == volume) {
+		return AUDIO_MANAGER_SUCCESS;
+	}
+
+	return set_audio_volume(OUTPUT, volume);
+#endif
+	return AUDIO_MANAGER_SUCCESS;
 }

--- a/framework/src/media/audio/audio_manager.h
+++ b/framework/src/media/audio/audio_manager.h
@@ -58,66 +58,6 @@ typedef enum audio_manager_result_e audio_manager_result_t;
  ****************************************************************************/
 
 /****************************************************************************
- * Name: set_input_audio_volume
- *
- * Description:
- *   Adjust the volume level of the active input audio device.
- *
- * Input parameters:
- *   volume:   Volume level, 0(Min) ~ 10(Max)
- *
- * Returned Value:
- *   On success, AUDIO_MANAGER_SUCCESS. Otherwise, a negative value.
- ****************************************************************************/
-audio_manager_result_t set_input_audio_volume(uint8_t volume);
-
-/****************************************************************************
- * Name: set_output_audio_volume
- *
- * Description:
- *   Adjust the volume level of the active output audio device.
- *
- * Input parameters:
- *   volume:   Volume level, 0(Min) ~ 10(Max)
- *
- * Returned Value:
- *   On success, AUDIO_MANAGER_SUCCESS. Otherwise, a negative value.
- ****************************************************************************/
-audio_manager_result_t set_output_audio_volume(uint8_t volume);
-
-/****************************************************************************
- * Name: get_input_audio_volume
- *
- * Description:
- *   Get the current volume level of the active input audio device.
- *
- * Returned Value:
- *   On success, the current input volume level. Otherwise, a negative value.
- ****************************************************************************/
-int get_input_audio_volume(void);
-
-/****************************************************************************
- * Name: get_output_audio_volume
- *
- * Description:
- *   Get the current volume level of the active output audio device.
- *
- * Returned Value:
- *   On success, the current output volume level. Otherwise, a negative value.
- ****************************************************************************/
-int get_output_audio_volume(void);
-
-/****************************************************************************
- * Name: get_audio_volume
- *
- * Description:
- *   Get the maximum volume level of an audio device.
- *
- * Returned Value: The maximum volume level.
- ****************************************************************************/
-uint16_t get_max_audio_volume(void);
-
-/****************************************************************************
  * Name: set_audio_stream_in
  *
  * Description:
@@ -152,6 +92,118 @@ audio_manager_result_t set_audio_stream_in(uint8_t channels, uint32_t sample_rat
  *   On success, AUDIO_MANAGER_SUCCESS. Otherwise, a negative value.
  ****************************************************************************/
 audio_manager_result_t set_audio_stream_out(uint8_t channels, uint32_t sample_rate, uint8_t format);
+
+/****************************************************************************
+ * Name: start_audio_stream_in
+ *
+ * Description:
+ *   Read the specified number of frames from the input stream.
+ *   If the input audio device have been paused, resume and proceed the reading.
+ *
+ * Input parameters:
+ *   data: buffer to get the frame data
+ *   frames: number of frames to be read
+ *
+ * Returned Value:
+ *   On success, the number of frames read. Otherwise, a negative value.
+ ****************************************************************************/
+int start_audio_stream_in(void *data, uint32_t frames);
+
+/****************************************************************************
+ * Name: start_audio_stream_out
+ *
+ * Description:
+ *   Write the specified frame data to the output stream.
+ *   If the output audio device have been paused, resume and proceed the writing.
+ *
+ * Input parameters:
+ *   data: buffer to transfer the frame data
+ *   frames: number of frames to be written
+ *
+ * Returned Value:
+ *   On success, the number of frames written. Otherwise, a negative value.
+ ****************************************************************************/
+int start_audio_stream_out(void *data, uint32_t frames);
+
+/****************************************************************************
+ * Name: pause_audio_stream_in
+ *
+ * Description:
+ *   Pause the active input audio device.
+ *   Note that only the active audio device currently running can be paused.
+ *   If the device is resumed, the paused stream is continued.
+ *
+ * Returned Value:
+ *   On success, AUDIO_MANAGER_SUCCESS. Otherwise, a negative value.
+ ****************************************************************************/
+audio_manager_result_t pause_audio_stream_in(void);
+
+/****************************************************************************
+ * Name: pause_audio_stream_out
+ *
+ * Description:
+ *   Pause the active output audio device.
+ *	 Note that only the active audio device currently running can be paused.
+ *	 If the device is resumed, the paused stream is continued.
+ *
+ * Returned Value:
+ *   On success, AUDIO_MANAGER_SUCCESS. Otherwise, a negative value.
+ ****************************************************************************/
+audio_manager_result_t pause_audio_stream_out(void);
+
+/****************************************************************************
+ * Name: reset_audio_stream_in
+ *
+ * Description:
+ *   Close the active input audio stream.
+ *   After the reset, the stream should be restarted from the beginning with
+ *   calling set_audio_stream_in().
+ *
+ * Returned Value:
+ *   On success, AUDIO_MANAGER_SUCCESS. Otherwise, a negative value.
+ ****************************************************************************/
+audio_manager_result_t reset_audio_stream_in(void);
+
+/****************************************************************************
+ * Name: reset_audio_stream_out
+ *
+ * Description:
+ *   Close the active output audio stream.
+ *   After the reset, the stream should be restarted from the beginning with
+ *   calling set_audio_stream_out().
+ *
+ * Returned Value:
+ *   On success, AUDIO_MANAGER_SUCCESS. Otherwise, a negative value.
+ ****************************************************************************/
+audio_manager_result_t reset_audio_stream_out(void);
+
+/****************************************************************************
+ * Name: stop_audio_stream_in
+ *
+ * Description:
+ *   Stop the active input audio device.
+ *   Note that only the active audio device currently running can be stopped.
+ *	 Once the device is stopped, the stream should be restarted from the beginning
+ *	 with calling set_audio_stream_in().
+ *
+ * Returned Value:
+ *   On success, AUDIO_MANAGER_SUCCESS. Otherwise, a negative value.
+ ****************************************************************************/
+audio_manager_result_t stop_audio_stream_in(void);
+
+/****************************************************************************
+ * Name: stop_audio_stream_out
+ *
+ * Description:
+ *   Stop the active output audio device.
+ *   Note that only the active audio device currently running can be stopped.
+ *	 Once the device is stopped, the stream should be restarted from the beginning
+ *	 with calling set_audio_stream_out().
+ *
+ * Returned Value:
+ *   On success, AUDIO_MANAGER_SUCCESS. Otherwise, a negative value.
+ ****************************************************************************/
+audio_manager_result_t stop_audio_stream_out(void);
 
 /****************************************************************************
  * Name: get_input_frame_count
@@ -220,116 +272,64 @@ uint32_t get_output_frames_byte_size(uint32_t frames);
 uint32_t get_output_bytes_frame_count(uint32_t bytes);
 
 /****************************************************************************
- * Name: start_audio_stream_in
+ * Name: get_audio_volume
  *
  * Description:
- *   Read the specified number of frames from the input stream.
- *   If the input audio device have been paused, resume and proceed the reading.
+ *   Get the maximum volume level of an audio device.
+ *
+ * Returned Value: The maximum volume level.
+ ****************************************************************************/
+uint16_t get_max_audio_volume(void);
+
+/****************************************************************************
+ * Name: get_input_audio_volume
+ *
+ * Description:
+ *   Get the current volume level of the active input audio device.
+ *
+ * Returned Value:
+ *   On success, the current input volume level. Otherwise, a negative value.
+ ****************************************************************************/
+int get_input_audio_volume(void);
+
+/****************************************************************************
+ * Name: get_output_audio_volume
+ *
+ * Description:
+ *   Get the current volume level of the active output audio device.
+ *
+ * Returned Value:
+ *   On success, the current output volume level. Otherwise, a negative value.
+ ****************************************************************************/
+int get_output_audio_volume(void);
+
+/****************************************************************************
+ * Name: set_input_audio_volume
+ *
+ * Description:
+ *   Adjust the volume level of the active input audio device.
  *
  * Input parameters:
- *   data: buffer to get the frame data
- *   frames: number of frames to be read
+ *   volume:   Volume level, 0(Min) ~ 10(Max)
  *
  * Returned Value:
- *   On success, the number of frames read. Otherwise, a negative value.
+ *   On success, AUDIO_MANAGER_SUCCESS. Otherwise, a negative value.
  ****************************************************************************/
-int start_audio_stream_in(void *data, uint32_t frames);
+audio_manager_result_t set_input_audio_volume(uint8_t volume);
 
 /****************************************************************************
- * Name: start_audio_stream_out
+ * Name: set_output_audio_volume
  *
  * Description:
- *   Write the specified frame data to the output stream.
- *   If the output audio device have been paused, resume and proceed the writing.
+ *   Adjust the volume level of the active output audio device.
  *
  * Input parameters:
- *   data: buffer to transfer the frame data
- *   frames: number of frames to be written
- *
- * Returned Value:
- *   On success, the number of frames written. Otherwise, a negative value.
- ****************************************************************************/
-int start_audio_stream_out(void *data, uint32_t frames);
-
-/****************************************************************************
- * Name: pause_audio_stream_in
- *
- * Description:
- *   Pause the active input audio device.
- *   Note that only the active audio device currently running can be paused.
- *   If the device is resumed, the paused stream is continued.
+ *   volume:   Volume level, 0(Min) ~ 10(Max)
  *
  * Returned Value:
  *   On success, AUDIO_MANAGER_SUCCESS. Otherwise, a negative value.
  ****************************************************************************/
-audio_manager_result_t pause_audio_stream_in(void);
-
-/****************************************************************************
- * Name: pause_audio_stream_out
- *
- * Description:
- *   Pause the active output audio device.
- *	 Note that only the active audio device currently running can be paused.
- *	 If the device is resumed, the paused stream is continued.
- *
- * Returned Value:
- *   On success, AUDIO_MANAGER_SUCCESS. Otherwise, a negative value.
- ****************************************************************************/
-audio_manager_result_t pause_audio_stream_out(void);
-
-/****************************************************************************
- * Name: stop_audio_stream_in
- *
- * Description:
- *   Stop the active input audio device.
- *   Note that only the active audio device currently running can be stopped.
- *	 Once the device is stopped, the stream should be restarted from the beginning
- *	 with calling set_audio_stream_in().
- *
- * Returned Value:
- *   On success, AUDIO_MANAGER_SUCCESS. Otherwise, a negative value.
- ****************************************************************************/
-audio_manager_result_t stop_audio_stream_in(void);
-
-/****************************************************************************
- * Name: stop_audio_stream_out
- *
- * Description:
- *   Stop the active output audio device.
- *   Note that only the active audio device currently running can be stopped.
- *	 Once the device is stopped, the stream should be restarted from the beginning
- *	 with calling set_audio_stream_out().
- *
- * Returned Value:
- *   On success, AUDIO_MANAGER_SUCCESS. Otherwise, a negative value.
- ****************************************************************************/
-audio_manager_result_t stop_audio_stream_out(void);
-
-/****************************************************************************
- * Name: reset_audio_stream_in
- *
- * Description:
- *   Close the active input audio stream.
- *   After the reset, the stream should be restarted from the beginning with
- *   calling set_audio_stream_in().
- *
- * Returned Value:
- *   On success, AUDIO_MANAGER_SUCCESS. Otherwise, a negative value.
- ****************************************************************************/
-audio_manager_result_t reset_audio_stream_in(void);
-
-/****************************************************************************
- * Name: reset_audio_stream_out
- *
- * Description:
- *   Close the active output audio stream.
- *   After the reset, the stream should be restarted from the beginning with
- *   calling set_audio_stream_out().
- *
- * Returned Value:
- *   On success, AUDIO_MANAGER_SUCCESS. Otherwise, a negative value.
- ****************************************************************************/
-audio_manager_result_t reset_audio_stream_out(void);
+audio_manager_result_t set_output_audio_volume(uint8_t volume);
 
 #if defined(__cplusplus)
 }								/* extern "C" */


### PR DESCRIPTION
- Static functions are grouped and moved to the upper position of public functions.
- Public functions are reordered following actual execution orders for readability.