### PR TITLE
kernel/task: Move calling atexit and onexit for supporting them in ta…

### DIFF
--- a/os/kernel/task/task.h
+++ b/os/kernel/task/task.h
@@ -91,7 +91,17 @@ int task_argsetup(FAR struct task_tcb_s *tcb, FAR const char *name, FAR char *co
 int task_exit(void);
 int task_terminate(pid_t pid, bool nonblocking);
 void task_exithook(FAR struct tcb_s *tcb, int status, bool nonblocking);
-void task_recover(FAR struct tcb_s *tcb);
+void task_recover(FAR struct tcb_s *tcb, int status, bool nonblocking);
+#if defined(CONFIG_SCHED_ATEXIT) && !defined(CONFIG_SCHED_ONEXIT)
+void task_atexit(FAR struct tcb_s *tcb);
+#else
+#define task_atexit(tcb)
+#endif
+#ifdef CONFIG_SCHED_ONEXIT
+void task_onexit(FAR struct tcb_s *tcb, int status);
+#else
+#define task_onexit(tcb, status)
+#endif
 
 /* Misc. */
 

--- a/os/kernel/task/task_restart.c
+++ b/os/kernel/task/task_restart.c
@@ -58,6 +58,7 @@
 
 #include <sys/types.h>
 #include <sched.h>
+#include <stdlib.h>
 #include <errno.h>
 
 #include <tinyara/arch.h>
@@ -166,7 +167,7 @@ int task_restart(pid_t pid)
 
 		/* Try to recover from any bad states */
 
-		task_recover((FAR struct tcb_s *)tcb);
+		task_recover((FAR struct tcb_s *)tcb, EXIT_SUCCESS, false);
 
 		/* Kill any children of this thread */
 


### PR DESCRIPTION
…sk_restart

If moving them to task_recover, axexit and onexit can be called when restart the task.
Then, we can use atexit or onexit for resource deallocation callback when restart the task.