### PR TITLE
kernel/task_atexit: Remove undefined and unnecessary variable and fix…

### DIFF
--- a/os/kernel/task/task_atexit.c
+++ b/os/kernel/task/task_atexit.c
@@ -117,7 +117,7 @@
  *      3. If both SCHED_ONEXIT and SCHED_ATEXIT are selected, then atexit()
  *         is built on top of the on_exit() implementation.  In that case,
  *         CONFIG_SCHED_ONEXIT_MAX determines the size of the combined
- *         number of atexit(0) and on_exit calls and SCHED_ATEXIT_MAX is
+ *         number of atexit() and on_exit() calls and SCHED_ATEXIT_MAX is
  *         not used.
  *
  * Input Parameters:
@@ -132,7 +132,7 @@ int atexit(void (*func)(void))
 {
 #if defined(CONFIG_SCHED_ONEXIT)
 	/* atexit is equivalent to on_exit() with no argument (Assuming that the ABI
-	 * can handle a callback function that recieves more parameters than it expects).
+	 * can handle a callback function that receives more parameters than it expects).
 	 */
 
 	return on_exit((onexitfunc_t)func, NULL);
@@ -151,12 +151,11 @@ int atexit(void (*func)(void))
 		sched_lock();
 
 		/* Search for the first available slot.  atexit() functions are registered
-		 * from lower to higher arry indices; they must be called in the reverse
+		 * from lower to higher array indices; they must be called in the reverse
 		 * order of registration when task exists, i.e., from higher to lower
 		 * indices.
 		 */
 
-		available = -1;
 		for (index = 0; index < CONFIG_SCHED_ATEXIT_MAX; index++) {
 			if (!group->tg_atexitfunc[index]) {
 				group->tg_atexitfunc[index] = func;


### PR DESCRIPTION
… comment typo

'available' is not defined and not used.