### PR TITLE
Remove wrong conditional config in libc time

### DIFF
--- a/apps/examples/testcase/le_tc/kernel/tc_libc_timer.c
+++ b/apps/examples/testcase/le_tc/kernel/tc_libc_timer.c
@@ -416,6 +416,144 @@ static void tc_libc_timer_strftime(void)
 }
 
 /**
+* @fn             :tc_libc_timer_strptime
+* @brief          :strptime - Format string as time
+* @Scenario       :strptime - converts time string as the time described in timeptr
+*                  structure as per the format specifiers.
+* API's covered   :strptime
+* Preconditions   :none
+* Postconditions  :none
+* @return         :void
+*/
+static void tc_libc_timer_strptime(void)
+{
+	struct tm sp_tm;
+	struct tm sf_tm;
+	char *ret;
+
+	sf_tm.tm_sec  = 13;
+	sf_tm.tm_min  = 42;
+	sf_tm.tm_hour = 12;
+	sf_tm.tm_mday = 5;
+	sf_tm.tm_mon  = 5;
+	sf_tm.tm_year = 2018 - YEAR_BASE;
+
+	memset(&sp_tm, 0, sizeof(struct tm));
+
+	/* strptime() converts a string representation of time to a time tm structure,
+	 * using the specified format. descrtiption of example formats are as shown below,
+	 * %Y or %y - The year, including century (2018 = 2000(century) + 18(year)).
+	 * %m - The month number.
+	 * %d - The day of month (1-31).
+	 * %k - The hour on a 24-hour clock (0-23).
+	 * %M - The minute (0-59).
+	 * %S - The second (0-60).
+	 * %p - The locale's equivalent of AM or PM.
+	 */
+	ret = strptime("2018-06-05 12:42:13 PM", "%Y-%m-%Od %k:%M:%S %p", &sp_tm);
+	TC_ASSERT_NEQ("strptime", ret, NULL);
+	TC_ASSERT_EQ("strptime", sp_tm.tm_year, sf_tm.tm_year);
+	TC_ASSERT_EQ("strptime", sp_tm.tm_mon, sf_tm.tm_mon);
+	TC_ASSERT_EQ("strptime", sp_tm.tm_mday, sf_tm.tm_mday);
+	TC_ASSERT_EQ("strptime", sp_tm.tm_hour, sf_tm.tm_hour);
+	TC_ASSERT_EQ("strptime", sp_tm.tm_min, sf_tm.tm_min);
+	TC_ASSERT_EQ("strptime", sp_tm.tm_sec, sf_tm.tm_sec);
+
+	/* %U - The week number with Sunday the first day of the week (0-53).
+	 *      The first Sunday of January is the first day of week 1.
+	 * %b or %B or %h - The month name according to the current locale, in abbreviated form or the full name.
+	 * %l or %I - The hour on a 12-hour clock (1-12).
+	 */
+	memset(&sp_tm, 0, sizeof(struct tm));
+	ret = strptime("22 June 10 AM 18", "%U %B %l %p %Ey", &sp_tm);
+	TC_ASSERT_NEQ("strptime", ret, NULL);
+	TC_ASSERT_EQ("strptime", sp_tm.tm_year, sf_tm.tm_year);
+	TC_ASSERT_EQ("strptime", sp_tm.tm_mon, sf_tm.tm_mon);
+	TC_ASSERT_EQ("strptime", sp_tm.tm_hour, sf_tm.tm_hour - 2);
+
+	/* %C - The century number (0-99).
+	 * %C does not modify tm structure, so just validating the return value..
+	 */
+	ret = strptime("2018", "%C", &sp_tm);
+	TC_ASSERT_NEQ("strptime", ret, NULL);
+
+	/* %D - Equivalent  to %m/%d/%y(month/day/year).
+	 * %X - The time, using the locale's time format.
+	 */
+	memset(&sp_tm, 0, sizeof(struct tm));
+	ret = strptime("06/05/18 12:42:13", "%D %X", &sp_tm);
+	TC_ASSERT_NEQ("strptime", ret, NULL);
+	TC_ASSERT_EQ("strptime", sp_tm.tm_year, sf_tm.tm_year);
+	TC_ASSERT_EQ("strptime", sp_tm.tm_mon, sf_tm.tm_mon);
+	TC_ASSERT_EQ("strptime", sp_tm.tm_mday, sf_tm.tm_mday);
+	TC_ASSERT_EQ("strptime", sp_tm.tm_hour, sf_tm.tm_hour);
+	TC_ASSERT_EQ("strptime", sp_tm.tm_min, sf_tm.tm_min);
+	TC_ASSERT_EQ("strptime", sp_tm.tm_sec, sf_tm.tm_sec);
+
+	/* %x - The date, using the locale's date format.
+	 * %R - Equivalent to %H:%M (hour:minute).
+     */
+	memset(&sp_tm, 0, sizeof(struct tm));
+	ret = strptime("06/05/18 12:42", "%x %R", &sp_tm);
+	TC_ASSERT_NEQ("strptime", ret, NULL);
+	TC_ASSERT_EQ("strptime", sp_tm.tm_year, sf_tm.tm_year);
+	TC_ASSERT_EQ("strptime", sp_tm.tm_mon, sf_tm.tm_mon);
+	TC_ASSERT_EQ("strptime", sp_tm.tm_mday, sf_tm.tm_mday);
+	TC_ASSERT_EQ("strptime", sp_tm.tm_hour, sf_tm.tm_hour);
+	TC_ASSERT_EQ("strptime", sp_tm.tm_min, sf_tm.tm_min);
+
+	/* %T - Equivalent to %H:%M:%S (hour/minute/second). */
+	memset(&sp_tm, 0, sizeof(struct tm));
+	ret = strptime("12:42:13", "%T", &sp_tm);
+	TC_ASSERT_NEQ("strptime", ret, NULL);
+	TC_ASSERT_EQ("strptime", sp_tm.tm_hour, sf_tm.tm_hour);
+	TC_ASSERT_EQ("strptime", sp_tm.tm_min, sf_tm.tm_min);
+	TC_ASSERT_EQ("strptime", sp_tm.tm_sec, sf_tm.tm_sec);
+
+
+	/* %r - The 12-hour clock time (using the locale's AM or PM).
+	 * In the POSIX locale equivalent to %I:%M:%S %p.
+	 */
+	memset(&sp_tm, 0, sizeof(struct tm));
+	ret = strptime("12:42:13 PM", "%r", &sp_tm);
+	TC_ASSERT_NEQ("strptime", ret, NULL);
+	TC_ASSERT_EQ("strptime", sp_tm.tm_hour, sf_tm.tm_hour);
+	TC_ASSERT_EQ("strptime", sp_tm.tm_min, sf_tm.tm_min);
+	TC_ASSERT_EQ("strptime", sp_tm.tm_sec, sf_tm.tm_sec);
+
+#if defined(CONFIG_LIBC_LOCALTIME) || defined(CONFIG_TIME_EXTENDED)
+	/* Tuesday (0-6: day of the week, week starts on Sunday)*/
+	sf_tm.tm_wday = 2;
+	memset(&sp_tm, 0, sizeof(struct tm));
+	/* %a or %A - The weekday name according to the current locale,
+	 * in abbreviated form or the full name.
+	 * %j - The day number in the year (1-366).
+	 * %w - The weekday number (0-6) with Sunday = 0.
+	 */
+	ret = strptime("Tue/Tuesday 187 2", "%a/%A %j %w", &sp_tm);
+	TC_ASSERT_NEQ("strptime", ret, NULL);
+	TC_ASSERT_EQ("strptime", sp_tm.tm_wday, sf_tm.tm_wday);
+
+	/* %c - The date and time representation for the current locale. */
+	memset(&sp_tm, 0, sizeof(struct tm));
+	ret = strptime("Tue Jun 5 12:42:13 2018", "%c", &sp_tm);
+	TC_ASSERT_NEQ("strptime", ret, NULL);
+	TC_ASSERT_EQ("strptime", sp_tm.tm_year, sf_tm.tm_year);
+	TC_ASSERT_EQ("strptime", sp_tm.tm_mon, sf_tm.tm_mon);
+	TC_ASSERT_EQ("strptime", sp_tm.tm_mday, sf_tm.tm_mday);
+	TC_ASSERT_EQ("strptime", sp_tm.tm_hour, sf_tm.tm_hour);
+	TC_ASSERT_EQ("strptime", sp_tm.tm_min, sf_tm.tm_min);
+	TC_ASSERT_EQ("strptime", sp_tm.tm_sec, sf_tm.tm_sec);
+#endif
+
+	/* Check with invalid param. it will returns NULl. */
+	ret = strptime("", "%f", NULL);
+	TC_ASSERT_EQ("strptime", ret, NULL);
+
+	TC_SUCCESS_RESULT();
+}
+
+/**
 * @fn                   :tc_libc_timer_time
 * @brief                :Get the current calendar time as a value of type time_t.
 * @Scenario             :The function returns this value, and if the argument is not a null
@@ -552,6 +690,7 @@ int libc_timer_main(void)
 	tc_libc_timer_localtime_r();
 	tc_libc_timer_mktime();
 	tc_libc_timer_strftime();
+	tc_libc_timer_strptime();
 	tc_libc_timer_time();
 
 	return 0;

--- a/apps/examples/testcase/le_tc/kernel/tc_libc_timer.c
+++ b/apps/examples/testcase/le_tc/kernel/tc_libc_timer.c
@@ -505,23 +505,54 @@ static void tc_libc_timer_clock(void)
 	TC_SUCCESS_RESULT();
 }
 
+#ifdef CONFIG_LIBM
+static void tc_libc_timer_difftime(void)
+{
+	time_t t0;
+	time_t t1;
+#ifdef CONFIG_HAVE_DOUBLE
+	double ret;
+#else
+	float ret;
+#endif
+
+	t0 = time(NULL);
+	/* Time elapse of 1s */
+	sleep(1);
+	t1 = time(NULL);
+
+	ret = difftime(t1, t0);
+
+#ifdef CONFIG_HAVE_DOUBLE
+	TC_ASSERT_LEQ("difftime", fabs(1.0 - ret), DBL_EPSILON);
+#else
+	TC_ASSERT_LEQ("difftime", fabsf(1.0f - ret), DBL_EPSILON);
+#endif
+
+	TC_SUCCESS_RESULT();
+}
+#endif
+
 /****************************************************************************
  * Name: libc_timer
  ****************************************************************************/
 
 int libc_timer_main(void)
 {
+	tc_libc_timer_clock();
 	tc_libc_timer_clock_calendar2utc();
-	tc_libc_timer_gmtime_r();
-	tc_libc_timer_gmtime();
+	tc_libc_timer_clock_daysbeforemonth();
 	tc_libc_timer_clock_isleapyear();
+#ifdef CONFIG_LIBM
+	tc_libc_timer_difftime();
+#endif
+	tc_libc_timer_gmtime();
+	tc_libc_timer_gmtime_r();
 	tc_libc_timer_localtime();
 	tc_libc_timer_localtime_r();
 	tc_libc_timer_mktime();
 	tc_libc_timer_strftime();
 	tc_libc_timer_time();
-	tc_libc_timer_clock_daysbeforemonth();
-	tc_libc_timer_clock();
 
 	return 0;
 }

--- a/lib/libc/time/Make.defs
+++ b/lib/libc/time/Make.defs
@@ -52,12 +52,8 @@
 
 # Add the time C files to the build
 
-CSRCS += lib_strftime.c lib_calendar2utc.c lib_daysbeforemonth.c
+CSRCS += lib_strftime.c lib_strptime.c lib_calendar2utc.c lib_daysbeforemonth.c
 CSRCS += lib_isleapyear.c lib_time.c lib_difftime.c lib_clock.c
-
-ifdef CONFIG_ENABLE_IOTIVITY
-CSRCS +=lib_strptime.c
-endif
 
 ifdef CONFIG_LIBC_LOCALTIME
 CSRCS +=lib_asctime.c lib_asctimer.c lib_ctime.c lib_ctimer.c

--- a/lib/libc/time/lib_strptime.c
+++ b/lib/libc/time/lib_strptime.c
@@ -230,6 +230,7 @@ literal:
 		/*
 		 * "Elementary" conversion rules.
 		 */
+#if defined(CONFIG_LIBC_LOCALTIME) || defined(CONFIG_TIME_EXTENDED)
 		case 'A':				/* The day of week, using the locale's form. */
 		case 'a':
 			_LEGAL_ALT(0);
@@ -252,6 +253,7 @@ literal:
 			tm->tm_wday = i;
 			bp += len;
 			break;
+#endif
 		case 'B':				/* The month, using the locale's form. */
 		case 'b':
 		case 'h':
@@ -307,6 +309,7 @@ literal:
 				return (NULL);
 			}
 			break;
+#if defined(CONFIG_LIBC_LOCALTIME) || defined(CONFIG_TIME_EXTENDED)
 		case 'j':				/* The day of year. */
 			_LEGAL_ALT(0);
 			if (!(_conv_num(&bp, &tm->tm_yday, 1, 366))) {
@@ -314,6 +317,7 @@ literal:
 			}
 			tm->tm_yday--;
 			break;
+#endif
 		case 'M':				/* The minute. */
 			_LEGAL_ALT(_ALT_O);
 			if (!(_conv_num(&bp, &tm->tm_min, 0, 59))) {
@@ -372,12 +376,14 @@ literal:
 				return (NULL);
 			}
 			break;
+#if defined(CONFIG_LIBC_LOCALTIME) || defined(CONFIG_TIME_EXTENDED)
 		case 'w':				/* The day of week, beginning on sunday. */
 			_LEGAL_ALT(_ALT_O);
 			if (!(_conv_num(&bp, &tm->tm_wday, 0, 6))) {
 				return (NULL);
 			}
 			break;
+#endif
 		case 'Y':				/* The year. */
 			_LEGAL_ALT(_ALT_E);
 			if (!(_conv_num(&bp, &i, 0, 9999))) {

--- a/os/include/time.h
+++ b/os/include/time.h
@@ -334,23 +334,26 @@ FAR char *ctime_r(FAR const time_t *timep, FAR char *buf);
  * @endcond
  */
 
-#ifdef CONFIG_ENABLE_IOTIVITY
 /**
- * @cond
- * @internal
+ * @ingroup TIME_KERNEL
+ * @brief convert a time string to a time tm structure
+ * @details @b #include <time.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @since TizenRT v2.0 PRE
  */
 char *strptime(const char *buf, const char *fmt, struct tm *tm);
+
 /**
- * @internal
+ * @ingroup TIME_KERNEL
+ * @brief calculate time difference
+ * @details @b #include <time.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @since TizenRT v2.0 PRE
  */
 #ifdef CONFIG_HAVE_DOUBLE
 double difftime(time_t time1, time_t time0);
 #else
 float difftime(time_t time1, time_t time0);
-#endif
-/**
- * @endcond
- */
 #endif
 
 /**


### PR DESCRIPTION
- Prototypes of strptime() and difftime() are wrapped with CONFIG_ENABLE_IOTIVITY conditional. This conditional is removed as there is no such dependency exists.
- libc/time: Fix compilation error in strptime
- testcase/kernel: Add test case for difftime()
- testcase/kernel: Add test case for strptime() 
libc time tc result:
![tc_libc_time-result](https://user-images.githubusercontent.com/26534978/41283723-f70c68a0-6e54-11e8-92a9-0a730c94be34.PNG)