### PR TITLE
system/readline: add preprocessor for global variable

### DIFF
--- a/apps/system/readline/readline_common.c
+++ b/apps/system/readline/readline_common.c
@@ -89,9 +89,9 @@
  * Private Data
  ****************************************************************************/
 /* <esc>[K is the VT100 command erases to the end of the line. */
-
+#ifdef CONFIG_READLINE_ECHO
 static const char g_erasetoeol[] = VT100_CLEAREOL;
-
+#endif
 /****************************************************************************
  * Private Functions
  ****************************************************************************/


### PR DESCRIPTION
This patch modifies the g_erasetoeol global variable to be included only
when CONFIG_READLINE_ECHO is enabled.
`
Signed-off-by: Heuisam Kwag <heuisam@samsung.com>`
(cherry picked from commit 8135f20f0d684a05a6de60dc294dfc27d00baf30)