### PR TITLE
kernel/task: Add calling atexit and onexit in task_restart

### DIFF
--- a/os/kernel/task/task.h
+++ b/os/kernel/task/task.h
@@ -92,7 +92,16 @@ int task_exit(void);
 int task_terminate(pid_t pid, bool nonblocking);
 void task_exithook(FAR struct tcb_s *tcb, int status, bool nonblocking);
 void task_recover(FAR struct tcb_s *tcb);
-
+#if defined(CONFIG_SCHED_ATEXIT) && !defined(CONFIG_SCHED_ONEXIT)
+void task_atexit(FAR struct tcb_s *tcb);
+#else
+#define task_atexit(tcb)
+#endif
+#ifdef CONFIG_SCHED_ONEXIT
+void task_onexit(FAR struct tcb_s *tcb, int status);
+#else
+#define task_onexit(tcb, status)
+#endif
 /* Misc. */
 
 bool sched_addreadytorun(FAR struct tcb_s *rtrtcb);

--- a/os/kernel/task/task_exithook.c
+++ b/os/kernel/task/task_exithook.c
@@ -103,7 +103,7 @@
  ****************************************************************************/
 
 #if defined(CONFIG_SCHED_ATEXIT) && !defined(CONFIG_SCHED_ONEXIT)
-static inline void task_atexit(FAR struct tcb_s *tcb)
+inline void task_atexit(FAR struct tcb_s *tcb)
 {
 	FAR struct task_group_s *group = tcb->group;
 
@@ -159,7 +159,7 @@ static inline void task_atexit(FAR struct tcb_s *tcb)
  ****************************************************************************/
 
 #ifdef CONFIG_SCHED_ONEXIT
-static inline void task_onexit(FAR struct tcb_s *tcb, int status)
+inline void task_onexit(FAR struct tcb_s *tcb, int status)
 {
 	FAR struct task_group_s *group = tcb->group;
 


### PR DESCRIPTION
If atexit and onexit are in task restart, we can hook function when restart the task, such as resource deallocation callback