### PR TITLE
Fix build errors

### DIFF
--- a/apps/examples/testcase/le_tc/filesystem/fs_main.c
+++ b/apps/examples/testcase/le_tc/filesystem/fs_main.c
@@ -37,6 +37,8 @@
 #include <poll.h>
 #endif
 #include <errno.h>
+#include <sys/ioctl.h>
+#include <sys/mount.h>
 #include <sys/stat.h>
 #include <sys/sendfile.h>
 #include <sys/statfs.h>
@@ -1592,19 +1594,19 @@ static void tc_fs_vfs_ioctl(void)
 
 	fd1 = open(DEV_CONSOLE_PATH, O_RDWR);
 	TC_ASSERT_GEQ("open", fd1, 0);
-	ret = ioctl(fd1, FIONREAD, &size);
+	ret = ioctl(fd1, FIONREAD, (unsigned long)&size);
 	close(fd1);
 	TC_ASSERT_EQ("ioctl", ret, OK);
 
 	/*Negative case where invalid fd */
-	ret = ioctl(INV_FD, FIONREAD, &size);
+	ret = ioctl(INV_FD, FIONREAD, (unsigned long)&size);
 	TC_ASSERT_EQ("ioctl", ret, ERROR);
 
 	/*Negative cae where invalid cmd */
 	fd2 = open(DEV_CONSOLE_PATH, O_RDWR);
 	TC_ASSERT_GEQ("open", fd2, 0);
 
-	ret = ioctl(fd2, FIONREAD, &size);
+	ret = ioctl(fd2, FIONREAD, (unsigned long)&size);
 	close(fd2);
 	TC_ASSERT_LEQ("ioctl", ret, 0);
 

--- a/apps/examples/testcase/le_tc/filesystem/fs_main.c
+++ b/apps/examples/testcase/le_tc/filesystem/fs_main.c
@@ -2339,32 +2339,6 @@ static void tc_libc_stdio_fileno(void)
 	TC_SUCCESS_RESULT();
 }
 
-#if CONFIG_STDIO_BUFFER_SIZE > 0
-/**
-* @testcase         tc_libc_stdio_lib_rdflush
-* @brief            Flush read data from the I/O buffer and adjust the file pointer to account for the unread data.
-* @scenario         Flush read data from the I/O buffer and adjust the file pointer to account for the unread data.
-* @apicovered       lib_rdflush
-* @precondition     NA
-* @postcondition    NA
-*/
-static void tc_libc_stdio_lib_rdflush(void)
-{
-	char *filename = VFS_FILE_PATH;
-	FILE *stream;
-	int ret;
-
-	stream = fopen(filename, "r");
-	TC_ASSERT_NEQ("fopen", stream, NULL);
-
-	ret = lib_rdflush(stream);
-	fclose(stream);
-	TC_ASSERT_EQ("lib_rdflush", ret, OK);
-
-	TC_SUCCESS_RESULT();
-}
-#endif
-
 #ifdef CONFIG_STDIO_LINEBUFFER
 /**
 * @testcase         tc_libc_stdio_lib_snoflush
@@ -3596,9 +3570,6 @@ int tc_filesystem_main(int argc, char *argv[])
 	tc_libc_stdio_gets_s();
 #endif
 	tc_libc_stdio_fileno();
-#if CONFIG_STDIO_BUFFER_SIZE > 0
-	tc_libc_stdio_lib_rdflush();
-#endif
 #ifdef CONFIG_STDIO_LINEBUFFER
 	tc_libc_stdio_lib_snoflush();
 #endif

--- a/os/fs/vfs/fs_mkdir.c
+++ b/os/fs/vfs/fs_mkdir.c
@@ -55,6 +55,7 @@
  ****************************************************************************/
 
 #include <tinyara/config.h>
+#include <string.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <errno.h>


### PR DESCRIPTION
When configured with `qemu/tc_64k` defconfig, following build errors occur,

```
vfs/fs_mkdir.c: In function 'mkdir':
vfs/fs_mkdir.c:164:4: error: implicit declaration of function 'memset'; did you mean 'sigset'? [-Werror=implicit-function-declaration]
vfs/fs_mkdir.c:165:4: error: implicit declaration of function 'strncpy' [-Werror=implicit-function-declaration]

le_tc/filesystem/fs_main.c: In function 'tc_fs_vfs_ioctl':
le_tc/filesystem/fs_main.c:1598:29: error: passing argument 3 of 'ioctl' makes integer from pointer without a cast [-Werror=int-conversion]

le_tc/filesystem/fs_main.c: In function 'tc_fs_vfs_ioctl':
le_tc/filesystem/fs_main.c:1596:8: error: implicit declaration of function 'ioctl'; did you mean 'prctl'? [-Werror=implicit-function-declaration]

le_tc/filesystem/fs_main.c: In function 'tc_libc_stdio_lib_rdflush':
le_tc/filesystem/fs_main.c:2359:8: error: implicit declaration of function 'lib_rdflush'; did you mean 'lib_noflush'? [-Werror=implicit-function-declaration]

le_tc/filesystem/fs_main.c:284:8: error: implicit declaration of function 'mount' [-Werror=implicit-function-declaration]

le_tc/filesystem/fs_main.c: In function 'tc_fs_vfs_umount':
le_tc/filesystem/fs_main.c:306:8: error: implicit declaration of function 'umount' [-Werror=implicit-function-declaration]
```