### PR TITLE
warning: fix variadic-macros warnings

### DIFF
--- a/apps/examples/helloxx/helloxx_main.cxx
+++ b/apps/examples/helloxx/helloxx_main.cxx
@@ -87,14 +87,14 @@
 #    define cxxvdbg           vdbg
 #    define cxxllvdbg         llvdbg
 #  else
-#    define cxxvdbg(x...)
-#    define cxxllvdbg(x...)
+#    define cxxvdbg(...)
+#    define cxxllvdbg(...)
 #  endif
 #else
-#  define cxxdbg(x...)
-#  define cxxlldbg(x...)
-#  define cxxvdbg(x...)
-#  define cxxllvdbg(x...)
+#  define cxxdbg(...)
+#  define cxxlldbg(...)
+#  define cxxvdbg(...)
+#  define cxxllvdbg(...)
 #endif
 
 //***************************************************************************

--- a/apps/examples/protobuf/addressbook_main.cc
+++ b/apps/examples/protobuf/addressbook_main.cc
@@ -66,14 +66,14 @@ using google::protobuf::util::TimeUtil;
 #define cxxvdbg vdbg
 #define cxxllvdbg llvdbg
 #else
-#define cxxvdbg(x...)
-#define cxxllvdbg(x...)
+#define cxxvdbg(...)
+#define cxxllvdbg(...)
 #endif
 #else
-#define cxxdbg(x...)
-#define cxxlldbg(x...)
-#define cxxvdbg(x...)
-#define cxxllvdbg(x...)
+#define cxxdbg(...)
+#define cxxlldbg(...)
+#define cxxvdbg(...)
+#define cxxllvdbg(...)
 #endif
 
 //***************************************************************************

--- a/apps/examples/testcase/le_tc/kernel/tc_internal.h
+++ b/apps/examples/testcase/le_tc/kernel/tc_internal.h
@@ -32,10 +32,10 @@
 # define tcknvdbg(format, ...)   vdbg(format, ##__VA_ARGS__)
 # define tcknllvdbg(format, ...) llvdbg(format, ##__VA_ARGS__)
 #else
-# define tckndbg(x...)
-# define tcknlldbg(x...)
-# define tcknvdbg(x...)
-# define tcknllvdbg(x...)
+# define tckndbg(...)
+# define tcknlldbg(...)
+# define tcknvdbg(...)
+# define tcknllvdbg(...)
 #endif
 
 #else /* ! CONFIG_CPP_HAVE_VARARGS */

--- a/apps/include/hex2bin.h
+++ b/apps/include/hex2bin.h
@@ -114,7 +114,7 @@
 #ifdef CONFIG_SYSTEM_HEX2BIN_DEBUG
 #define hex2bin_debug(format, ...) fprintf(stderr, format, ##__VA_ARGS__)
 #else
-#define hex2bin_debug(x...)
+#define hex2bin_debug(...)
 #endif
 #else
 #ifdef CONFIG_SYSTEM_HEX2BIN_DEBUG

--- a/apps/platform/gnu/gnu_cxxinitialize.c
+++ b/apps/platform/gnu/gnu_cxxinitialize.c
@@ -73,7 +73,7 @@
 #ifdef CONFIG_DEBUG_CXX
 #define cxxinfo        dbg
 #else
-#define cxxinfo(x...)
+#define cxxinfo(...)
 #endif
 
 /****************************************************************************

--- a/apps/shell/tash_internal.h
+++ b/apps/shell/tash_internal.h
@@ -36,8 +36,8 @@
 #define shvdbg(format, ...)       vdbg(format, ##__VA_ARGS__)
 #endif
 #else  /* !CONFIG_DEBUG_TASH */
-#define shdbg(x...)
-#define shvdbg(x...)
+#define shdbg(...)
+#define shvdbg(...)
 #endif /* CONFIG_DEBUG_TASH */
 #else  /* !CONFIG_CPP_HAVE_VARARGS */
 #ifdef CONFIG_DEBUG_TASH

--- a/apps/system/cle/cle.c
+++ b/apps/system/cle/cle.c
@@ -127,13 +127,13 @@
 #if CONFIG_SYSTEM_CLE_DEBUGLEVEL > 0
 #define cledbg(format, ...) syslog(LOG_DEBUG, EXTRA_FMT format EXTRA_ARG, ##__VA_ARGS__)
 #else
-#define cledbg(x...)
+#define cledbg(...)
 #endif
 
 #if CONFIG_SYSTEM_CLE_DEBUGLEVEL > 1
 #define clevdbg(format, ...) syslog(LOG_DEBUG, EXTRA_FMT format EXTRA_ARG, ##__VA_ARGS__)
 #else
-#define clevdbg(x...)
+#define clevdbg(...)
 #endif
 #else
 #if CONFIG_SYSTEM_CLE_DEBUGLEVEL > 0

--- a/apps/system/inifile/inifile.c
+++ b/apps/system/inifile/inifile.c
@@ -81,13 +81,13 @@
 #if CONFIG_SYSTEM_INIFILE_DEBUGLEVEL > 0
 #define inidbg(format, ...) printf(EXTRA_FMT format EXTRA_ARG, ##__VA_ARGS__)
 #else
-#define inidbg(x...)
+#define inidbg(...)
 #endif
 
 #if CONFIG_SYSTEM_INIFILE_DEBUGLEVEL > 1
 #define inivdbg(format, ...) printf(EXTRA_FMT format EXTRA_ARG, ##__VA_ARGS__)
 #else
-#define inivdbg(x...)
+#define inivdbg(...)
 #endif
 #else
 #if CONFIG_SYSTEM_INIFILE_DEBUGLEVEL > 0

--- a/apps/system/vi/vi.c
+++ b/apps/system/vi/vi.c
@@ -170,14 +170,14 @@
 #define vidbg(format, ...) syslog(LOG_DEBUG, EXTRA_FMT format EXTRA_ARG, ##__VA_ARGS__)
 #define vvidbg(format, ap) vsyslog(LOG_DEBUG, format, ap)
 #else
-#define vidbg(x...)
-#define vvidbg(x...)
+#define vidbg(...)
+#define vvidbg(...)
 #endif
 
 #if CONFIG_SYSTEM_VI_DEBUGLEVEL > 1
 #define vivdbg(format, ...) syslog(LOG_DEBUG, EXTRA_FMT format EXTRA_ARG, ##__VA_ARGS__)
 #else
-#define vivdbg(x...)
+#define vivdbg(...)
 #endif
 #else
 #if CONFIG_SYSTEM_VI_DEBUGLEVEL > 0

--- a/framework/src/iotbus/iotapi_evt_handler.c
+++ b/framework/src/iotbus/iotapi_evt_handler.c
@@ -29,7 +29,7 @@
 #ifdef CONFIG_IOTAPI_DEBUG
 #define IOTAPI_LOG(format, ...)	printf(format, ##__VA_ARGS__)
 #else
-#define IOTAPI_LOG(x...)
+#define IOTAPI_LOG(...)
 #endif
 
 #define IOTAPI_MESSAGE_QUEUE_EMPTY	0

--- a/framework/src/iotbus/iotbus_internal.h
+++ b/framework/src/iotbus/iotbus_internal.h
@@ -23,7 +23,7 @@
 #ifdef CONFIG_DEBUG_IOTBUS
 #define ibdbg(format, ...)        dbg(format, ##__VA_ARGS__)
 #else
-#define ibdbg(x...)
+#define ibdbg(...)
 #endif
 #else /* !CONFIG_CPP_HAVE_VARARGS */
 #ifdef CONFIG_DEBUG_IOTBUS

--- a/os/arch/arm/src/armv7-m/up_hardfault.c
+++ b/os/arch/arm/src/armv7-m/up_hardfault.c
@@ -79,7 +79,7 @@
 #ifdef CONFIG_DEBUG_HARDFAULT
 #define hfdbg(format, ...) lldbg(format, ##__VA_ARGS__)
 #else
-#define hfdbg(x...)
+#define hfdbg(...)
 #endif
 
 #define INSN_SVC0        0xdf00	/* insn: svc 0 */

--- a/os/arch/arm/src/armv7-m/up_memfault.c
+++ b/os/arch/arm/src/armv7-m/up_memfault.c
@@ -74,7 +74,7 @@
 #ifdef DEBUG_MEMFAULTS
 #define mfdbg(format, ...) lldbg(format, ##__VA_ARGS__)
 #else
-#define mfdbg(x...)
+#define mfdbg(...)
 #endif
 
 /****************************************************************************

--- a/os/arch/arm/src/armv7-m/up_ramvec_attach.c
+++ b/os/arch/arm/src/armv7-m/up_ramvec_attach.c
@@ -79,8 +79,8 @@
 #define intdbg    lldbg
 #define intvdbg   llvdbg
 #else
-#define intdbg(x...)
-#define intvdbg(x...)
+#define intdbg(...)
+#define intvdbg(...)
 #endif
 
 /****************************************************************************

--- a/os/arch/arm/src/armv7-m/up_ramvec_initialize.c
+++ b/os/arch/arm/src/armv7-m/up_ramvec_initialize.c
@@ -83,8 +83,8 @@
 #define intdbg    lldbg
 #define intvdbg   llvdbg
 #else
-#define intdbg(x...)
-#define intvdbg(x...)
+#define intdbg(...)
+#define intvdbg(...)
 #endif
 
 /****************************************************************************

--- a/os/arch/arm/src/armv7-m/up_svcall.c
+++ b/os/arch/arm/src/armv7-m/up_svcall.c
@@ -89,7 +89,7 @@
 #if defined(CONFIG_DEBUG_SYSCALL) || defined(CONFIG_DEBUG_SVCALL)
 #define svcdbg(format, ...) lldbg(format, ##__VA_ARGS__)
 #else
-#define svcdbg(x...)
+#define svcdbg(...)
 #endif
 
 /****************************************************************************

--- a/os/arch/arm/src/armv7-r/arm_syscall.c
+++ b/os/arch/arm/src/armv7-r/arm_syscall.c
@@ -95,7 +95,7 @@
 #if defined(CONFIG_DEBUG_SYSCALL)
 #define svcdbg(format, ...) lldbg(format, ##__VA_ARGS__)
 #else
-#define svcdbg(x...)
+#define svcdbg(...)
 #endif
 
 /****************************************************************************

--- a/os/arch/arm/src/lm3s6965-ek/src/up_leds.c
+++ b/os/arch/arm/src/lm3s6965-ek/src/up_leds.c
@@ -80,8 +80,8 @@
 #define leddbg  lldbg
 #define ledvdbg llvdbg
 #else
-#define leddbg(x...)
-#define ledvdbg(x...)
+#define leddbg(...)
+#define ledvdbg(...)
 #endif
 
 /* Dump GPIO registers */

--- a/os/arch/arm/src/lm3s6965-ek/src/up_ssi.c
+++ b/os/arch/arm/src/lm3s6965-ek/src/up_ssi.c
@@ -87,12 +87,12 @@
 #ifdef SSI_VERBOSE
 #define ssivdbg lldbg
 #else
-#define ssivdbg(x...)
+#define ssivdbg(...)
 #endif
 #else
 #undef SSI_VERBOSE
-#define ssidbg(x...)
-#define ssivdbg(x...)
+#define ssidbg(...)
+#define ssivdbg(...)
 #endif
 
 /* Dump GPIO registers */

--- a/os/arch/arm/src/tiva/tiva_i2c.c
+++ b/os/arch/arm/src/tiva/tiva_i2c.c
@@ -143,8 +143,8 @@
 #define i2cdbg dbg
 #define i2cvdbg vdbg
 #else
-#define i2cdbg(x...)
-#define i2cvdbg(x...)
+#define i2cdbg(...)
+#define i2cvdbg(...)
 #endif
 
 #ifndef CONFIG_DEBUG

--- a/os/arch/arm/src/tiva/tiva_ssi.c
+++ b/os/arch/arm/src/tiva/tiva_ssi.c
@@ -93,8 +93,8 @@
 #define ssidbg  lldbg
 #define ssivdbg llvdbg
 #else
-#define ssidbg(x...)
-#define ssivdbg(x...)
+#define ssidbg(...)
+#define ssivdbg(...)
 #endif
 
 /* How many SSI modules does this chip support? The LM3S6918 supports 2 SSI

--- a/os/arch/arm/src/tiva/tiva_timer.h
+++ b/os/arch/arm/src/tiva/tiva_timer.h
@@ -154,8 +154,8 @@
 #define timdbg  lldbg
 #define timvdbg llvdbg
 #else
-#define timdbg(x...)
-#define timvdbg(x...)
+#define timdbg(...)
+#define timvdbg(...)
 #endif
 
 /****************************************************************************

--- a/os/drivers/can.c
+++ b/os/drivers/can.c
@@ -88,10 +88,10 @@
 #define canlldbg  lldbg
 #define canllvdbg llvdbg
 #else
-#define candbg(x...)
-#define canvdbg(x...)
-#define canlldbg(x...)
-#define canllvdbg(x...)
+#define candbg(...)
+#define canvdbg(...)
+#define canlldbg(...)
+#define canllvdbg(...)
 #endif
 
 /* Timing Definitions *******************************************************/

--- a/os/drivers/net/phy_notify.c
+++ b/os/drivers/net/phy_notify.c
@@ -102,8 +102,8 @@
 #define phydbg    dbg
 #define phylldbg  lldbg
 #else
-#define phydbg(x...)
-#define phylldbg(x...)
+#define phydbg(...)
+#define phylldbg(...)
 #endif
 
 /****************************************************************************

--- a/os/drivers/pwm.c
+++ b/os/drivers/pwm.c
@@ -96,10 +96,10 @@
 #define pwmlldbg  lldbg
 #define pwmllvdbg llvdbg
 #else
-#define pwmdbg(x...)
-#define pwmvdbg(x...)
-#define pwmlldbg(x...)
-#define pwmllvdbg(x...)
+#define pwmdbg(...)
+#define pwmvdbg(...)
+#define pwmlldbg(...)
+#define pwmllvdbg(...)
 #endif
 
 /****************************************************************************

--- a/os/drivers/spi/spi_bitbang.c
+++ b/os/drivers/spi/spi_bitbang.c
@@ -110,11 +110,11 @@
 #ifdef CONFIG_DEBUG_VERBOSE
 #define spivdbg lldbg
 #else
-#define spivdbg(x...)
+#define spivdbg(...)
 #endif
 #else
-#define spidbg(x...)
-#define spivdbg(x...)
+#define spidbg(...)
+#define spivdbg(...)
 #endif
 
 /****************************************************************************

--- a/os/drivers/timer.c
+++ b/os/drivers/timer.c
@@ -87,10 +87,10 @@
 #define tmrlldbg  lldbg
 #define tmrllvdbg llvdbg
 #else
-#define tmrdbg(x...)
-#define tmrvdbg(x...)
-#define tmrlldbg(x...)
-#define tmrllvdbg(x...)
+#define tmrdbg(...)
+#define tmrvdbg(...)
+#define tmrlldbg(...)
+#define tmrllvdbg(...)
 #endif
 
 /****************************************************************************

--- a/os/drivers/watchdog.c
+++ b/os/drivers/watchdog.c
@@ -85,10 +85,10 @@
 #define wdlldbg  lldbg
 #define wdllvdbg llvdbg
 #else
-#define wddbg(x...)
-#define wdvdbg(x...)
-#define wdlldbg(x...)
-#define wdllvdbg(x...)
+#define wddbg(...)
+#define wdvdbg(...)
+#define wdlldbg(...)
+#define wdllvdbg(...)
 #endif
 
 /****************************************************************************

--- a/os/include/debug.h
+++ b/os/include/debug.h
@@ -167,13 +167,13 @@ Once LOGM is approved, each module should have its own index
 #define lldbg(format, ...) \
 	lowsyslog(LOG_ERR, EXTRA_FMT format EXTRA_ARG, ##__VA_ARGS__)
 #else
-#define lldbg(x...)
+#define lldbg(...)
 #endif
 #endif
 
 #else
-#define dbg(x...)
-#define lldbg(x...)
+#define dbg(...)
+#define lldbg(...)
 #endif
 
 #ifdef CONFIG_DEBUG_WARN
@@ -202,13 +202,13 @@ Once LOGM is approved, each module should have its own index
 #define llwdbg(format, ...) \
 	lowsyslog(LOG_WARNING, EXTRA_FMT format EXTRA_ARG, ##__VA_ARGS__)
 #else
-#define llwdbg(x...)
+#define llwdbg(...)
 #endif
 #endif
 
 #else
-#define wdbg(x...)
-#define llwdbg(x...)
+#define wdbg(...)
+#define llwdbg(...)
 #endif
 
 #ifdef CONFIG_DEBUG_VERBOSE
@@ -238,23 +238,23 @@ Once LOGM is approved, each module should have its own index
 	lowsyslog(LOG_INFO, EXTRA_FMT format EXTRA_ARG, ##__VA_ARGS__)
 
 #else
-#define llvdbg(x...)
+#define llvdbg(...)
 #endif
 #endif
 
 #else
-#define vdbg(x...)
-#define llvdbg(x...)
+#define vdbg(...)
+#define llvdbg(...)
 #endif
 
 #else							/* CONFIG_DEBUG */
 
-#define dbg(x...)
-#define lldbg(x...)
-#define wdbg(x...)
-#define llwdbg(x...)
-#define vdbg(x...)
-#define llvdbg(x...)
+#define dbg(...)
+#define lldbg(...)
+#define wdbg(...)
+#define llwdbg(...)
+#define vdbg(...)
+#define llvdbg(...)
 
 #endif							/* CONFIG_DEBUG */
 
@@ -264,184 +264,184 @@ Once LOGM is approved, each module should have its own index
 #define mdbg(format, ...)    dbg(format, ##__VA_ARGS__)
 #define mlldbg(format, ...)  lldbg(format, ##__VA_ARGS__)
 #else
-#define mdbg(x...)
-#define mlldbg(x...)
+#define mdbg(...)
+#define mlldbg(...)
 #endif
 
 #ifdef CONFIG_DEBUG_MM_WARN
 #define mwdbg(format, ...)    wdbg(format, ##__VA_ARGS__)
 #define mllwdbg(format, ...)  llwdbg(format, ##__VA_ARGS__)
 #else
-#define mwdbg(x...)
-#define mllwdbg(x...)
+#define mwdbg(...)
+#define mllwdbg(...)
 #endif
 
 #ifdef CONFIG_DEBUG_MM_INFO
 #define mvdbg(format, ...)   vdbg(format, ##__VA_ARGS__)
 #define mllvdbg(format, ...) llvdbg(format, ##__VA_ARGS__)
 #else
-#define mvdbg(x...)
-#define mllvdbg(x...)
+#define mvdbg(...)
+#define mllvdbg(...)
 #endif
 
 #ifdef CONFIG_DEBUG_SCHED_ERROR
 #define sdbg(format, ...)    dbg(format, ##__VA_ARGS__)
 #define slldbg(format, ...)  lldbg(format, ##__VA_ARGS__)
 #else
-#define sdbg(x...)
-#define slldbg(x...)
+#define sdbg(...)
+#define slldbg(...)
 #endif
 
 #ifdef CONFIG_DEBUG_SCHED_WARN
 #define swdbg(format, ...)    wdbg(format, ##__VA_ARGS__)
 #define sllwdbg(format, ...)  llwdbg(format, ##__VA_ARGS__)
 #else
-#define swdbg(x...)
-#define sllwdbg(x...)
+#define swdbg(...)
+#define sllwdbg(...)
 #endif
 
 #ifdef CONFIG_DEBUG_SCHED_INFO
 #define svdbg(format, ...)   vdbg(format, ##__VA_ARGS__)
 #define sllvdbg(format, ...) llvdbg(format, ##__VA_ARGS__)
 #else
-#define svdbg(x...)
-#define sllvdbg(x...)
+#define svdbg(...)
+#define sllvdbg(...)
 #endif
 
 #ifdef CONFIG_DEBUG_PM_ERROR
 #define pmdbg(format, ...)    dbg(format, ##__VA_ARGS__)
 #define pmlldbg(format, ...)  lldbg(format, ##__VA_ARGS__)
 #else
-#define pmdbg(x...)
-#define pmlldbg(x...)
+#define pmdbg(...)
+#define pmlldbg(...)
 #endif
 
 #ifdef CONFIG_DEBUG_PM_WARN
 #define pmwdbg(format, ...)    wdbg(format, ##__VA_ARGS__)
 #define pmllwdbg(format, ...)  llwdbg(format, ##__VA_ARGS__)
 #else
-#define pmwdbg(x...)
-#define pmllwdbg(x...)
+#define pmwdbg(...)
+#define pmllwdbg(...)
 #endif
 
 #ifdef CONFIG_DEBUG_PM_INFO
 #define pmvdbg(format, ...)   vdbg(format, ##__VA_ARGS__)
 #define pmllvdbg(format, ...) llvdbg(format, ##__VA_ARGS__)
 #else
-#define pmvdbg(x...)
-#define pmllvdbg(x...)
+#define pmvdbg(...)
+#define pmllvdbg(...)
 #endif
 
 #ifdef CONFIG_DEBUG_PAGING_ERROR
 #define pgdbg(format, ...)    dbg(format, ##__VA_ARGS__)
 #define pglldbg(format, ...)  lldbg(format, ##__VA_ARGS__)
 #else
-#define pgdbg(x...)
-#define pglldbg(x...)
+#define pgdbg(...)
+#define pglldbg(...)
 #endif
 
 #ifdef CONFIG_DEBUG_PAGING_WARN
 #define pgwdbg(format, ...)    wdbg(format, ##__VA_ARGS__)
 #define pgllwdbg(format, ...)  llwdbg(format, ##__VA_ARGS__)
 #else
-#define pgwdbg(x...)
-#define pgllwdbg(x...)
+#define pgwdbg(...)
+#define pgllwdbg(...)
 #endif
 
 #ifdef CONFIG_DEBUG_PAGING_INFO
 #define pgvdbg(format, ...)   vdbg(format, ##__VA_ARGS__)
 #define pgllvdbg(format, ...) llvdbg(format, ##__VA_ARGS__)
 #else
-#define pgvdbg(x...)
-#define pgllvdbg(x...)
+#define pgvdbg(...)
+#define pgllvdbg(...)
 #endif
 
 #ifdef CONFIG_DEBUG_DMA_ERROR
 #define dmadbg(format, ...)    dbg(format, ##__VA_ARGS__)
 #define dmalldbg(format, ...)  lldbg(format, ##__VA_ARGS__)
 #else
-#define dmadbg(x...)
-#define dmalldbg(x...)
+#define dmadbg(...)
+#define dmalldbg(...)
 #endif
 
 #ifdef CONFIG_DEBUG_DMA_WARN
 #define dmawdbg(format, ...)    wdbg(format, ##__VA_ARGS__)
 #define dmallwdbg(format, ...)  llwdbg(format, ##__VA_ARGS__)
 #else
-#define dmawdbg(x...)
-#define dmallwdbg(x...)
+#define dmawdbg(...)
+#define dmallwdbg(...)
 #endif
 
 #ifdef CONFIG_DEBUG_DMA_INFO
 #define dmavdbg(format, ...)   vdbg(format, ##__VA_ARGS__)
 #define dmallvdbg(format, ...) llvdbg(format, ##__VA_ARGS__)
 #else
-#define dmavdbg(x...)
-#define dmallvdbg(x...)
+#define dmavdbg(...)
+#define dmallvdbg(...)
 #endif
 
 #ifdef CONFIG_DEBUG_NET_ERROR
 #define ndbg(format, ...)    dbg(format, ##__VA_ARGS__)
 #define nlldbg(format, ...)  lldbg(format, ##__VA_ARGS__)
 #else
-#define ndbg(x...)
-#define nlldbg(x...)
+#define ndbg(...)
+#define nlldbg(...)
 #endif
 
 #ifdef CONFIG_DEBUG_NET_WARN
 #define nwdbg(format, ...)    wdbg(format, ##__VA_ARGS__)
 #define nllwdbg(format, ...)  llwdbg(format, ##__VA_ARGS__)
 #else
-#define nwdbg(x...)
-#define nllwdbg(x...)
+#define nwdbg(...)
+#define nllwdbg(...)
 #endif
 
 #ifdef CONFIG_DEBUG_NET_INFO
 #define nvdbg(format, ...)   vdbg(format, ##__VA_ARGS__)
 #define nllvdbg(format, ...) llvdbg(format, ##__VA_ARGS__)
 #else
-#define nvdbg(x...)
-#define nllvdbg(x...)
+#define nvdbg(...)
+#define nllvdbg(...)
 #endif
 
 #ifdef CONFIG_DEBUG_USB_ERROR
 #define udbg(format, ...)    dbg(format, ##__VA_ARGS__)
 #define ulldbg(format, ...)  lldbg(format, ##__VA_ARGS__)
 #else
-#define udbg(x...)
-#define ulldbg(x...)
+#define udbg(...)
+#define ulldbg(...)
 #endif
 
 #ifdef CONFIG_DEBUG_USB_WARN
 #define uwdbg(format, ...)    wdbg(format, ##__VA_ARGS__)
 #define ullwdbg(format, ...)  llwdbg(format, ##__VA_ARGS__)
 #else
-#define uwdbg(x...)
-#define ullwdbg(x...)
+#define uwdbg(...)
+#define ullwdbg(...)
 #endif
 
 #ifdef CONFIG_DEBUG_USB_INFO
 #define uvdbg(format, ...)   vdbg(format, ##__VA_ARGS__)
 #define ullvdbg(format, ...) llvdbg(format, ##__VA_ARGS__)
 #else
-#define uvdbg(x...)
-#define ullvdbg(x...)
+#define uvdbg(...)
+#define ullvdbg(...)
 #endif
 
 #ifdef CONFIG_DEBUG_FS_ERROR
 #define fdbg(format, ...)    dbg(format, ##__VA_ARGS__)
 #define flldbg(format, ...)  lldbg(format, ##__VA_ARGS__)
 #else
-#define fdbg(x...)
-#define flldbg(x...)
+#define fdbg(...)
+#define flldbg(...)
 #endif
 
 #ifdef CONFIG_DEBUG_FS_WARN
 #define fwdbg(format, ...)    wdbg(format, ##__VA_ARGS__)
 #define fllwdbg(format, ...)  llwdbg(format, ##__VA_ARGS__)
 #else
-#define fwdbg(x...)
-#define fllwdbg(x...)
+#define fwdbg(...)
+#define fllwdbg(...)
 #endif
 
 #ifdef CONFIG_DEBUG_FS_INFO
@@ -449,225 +449,225 @@ Once LOGM is approved, each module should have its own index
 #define fsdbg(format, ...)   dbg_noarg(format, ##__VA_ARGS__)
 #define fllvdbg(format, ...) llvdbg(format, ##__VA_ARGS__)
 #else
-#define fvdbg(x...)
+#define fvdbg(...)
 #define fsdbg(format, ...)
-#define fllvdbg(x...)
+#define fllvdbg(...)
 #endif
 
 #ifdef CONFIG_DEBUG_DM_ERROR
 #define dmdbg(format, ...)    dbg(format, ##__VA_ARGS__)
 #define dmlldbg(format, ...)  lldbg(format, ##__VA_ARGS__)
 #else
-#define dmdbg(x...)
-#define dmlldbg(x...)
+#define dmdbg(...)
+#define dmlldbg(...)
 #endif
 
 #ifdef CONFIG_DEBUG_DM_WARN
 #define dmwdbg(format, ...)    wdbg(format, ##__VA_ARGS__)
 #define dmllwdbg(format, ...)  llwdbg(format, ##__VA_ARGS__)
 #else
-#define dmwdbg(x...)
-#define dmllwdbg(x...)
+#define dmwdbg(...)
+#define dmllwdbg(...)
 #endif
 
 #ifdef  CONFIG_DEBUG_DM_INFO
 #define dmvdbg(format, ...)   vdbg(format, ##__VA_ARGS__)
 #define dmllvdbg(format, ...) llvdbg(format, ##__VA_ARGS__)
 #else
-#define dmvdbg(x...)
-#define dmllvdbg(x...)
+#define dmvdbg(...)
+#define dmllvdbg(...)
 #endif
 
 #ifdef CONFIG_DEBUG_INPUT_ERROR
 #define idbg(format, ...)    dbg(format, ##__VA_ARGS__)
 #define illdbg(format, ...)  lldbg(format, ##__VA_ARGS__)
 #else
-#define idbg(x...)
-#define illdbg(x...)
+#define idbg(...)
+#define illdbg(...)
 #endif
 
 #ifdef CONFIG_DEBUG_INPUT_WARN
 #define iwdbg(format, ...)    wdbg(format, ##__VA_ARGS__)
 #define illwdbg(format, ...)  llwdbg(format, ##__VA_ARGS__)
 #else
-#define iwdbg(x...)
-#define illwdbg(x...)
+#define iwdbg(...)
+#define illwdbg(...)
 #endif
 
 #ifdef CONFIG_DEBUG_INPUT_INFO
 #define ivdbg(format, ...)   vdbg(format, ##__VA_ARGS__)
 #define illvdbg(format, ...) llvdbg(format, ##__VA_ARGS__)
 #else
-#define ivdbg(x...)
-#define illvdbg(x...)
+#define ivdbg(...)
+#define illvdbg(...)
 #endif
 
 #ifdef CONFIG_DEBUG_SENSORS_ERROR
 #define sndbg(format, ...)    dbg(format, ##__VA_ARGS__)
 #define snlldbg(format, ...)  lldbg(format, ##__VA_ARGS__)
 #else
-#define sndbg(x...)
-#define snlldbg(x...)
+#define sndbg(...)
+#define snlldbg(...)
 #endif
 
 #ifdef CONFIG_DEBUG_SENSORS_WARN
 #define snwdbg(format, ...)    wdbg(format, ##__VA_ARGS__)
 #define snllwdbg(format, ...)  llwdbg(format, ##__VA_ARGS__)
 #else
-#define snwdbg(x...)
-#define snllwdbg(x...)
+#define snwdbg(...)
+#define snllwdbg(...)
 #endif
 
 #ifdef CONFIG_DEBUG_SENSORS_INFO
 #define snvdbg(format, ...)   vdbg(format, ##__VA_ARGS__)
 #define snllvdbg(format, ...) llvdbg(format, ##__VA_ARGS__)
 #else
-#define snvdbg(x...)
-#define snllvdbg(x...)
+#define snvdbg(...)
+#define snllvdbg(...)
 #endif
 
 #ifdef CONFIG_DEBUG_ANALOG_ERROR
 #define adbg(format, ...)    dbg(format, ##__VA_ARGS__)
 #define alldbg(format, ...)  lldbg(format, ##__VA_ARGS__)
 #else
-#define adbg(x...)
-#define alldbg(x...)
+#define adbg(...)
+#define alldbg(...)
 #endif
 
 #ifdef CONFIG_DEBUG_ANALOG_WARN
 #define awdbg(format, ...)    wdbg(format, ##__VA_ARGS__)
 #define allwdbg(format, ...)  llwdbg(format, ##__VA_ARGS__)
 #else
-#define awdbg(x...)
-#define allwdbg(x...)
+#define awdbg(...)
+#define allwdbg(...)
 #endif
 
 #ifdef CONFIG_DEBUG_ANALOG_INFO
 #define avdbg(format, ...)   vdbg(format, ##__VA_ARGS__)
 #define allvdbg(format, ...) llvdbg(format, ##__VA_ARGS__)
 #else
-#define avdbg(x...)
-#define allvdbg(x...)
+#define avdbg(...)
+#define allvdbg(...)
 #endif
 
 #ifdef CONFIG_DEBUG_GRAPHICS_ERROR
 #define gdbg(format, ...)    dbg(format, ##__VA_ARGS__)
 #define glldbg(format, ...)  lldbg(format, ##__VA_ARGS__)
 #else
-#define gdbg(x...)
-#define glldbg(x...)
+#define gdbg(...)
+#define glldbg(...)
 #endif
 
 #ifdef CONFIG_DEBUG_GRAPHICS_WARN
 #define gwdbg(format, ...)    wdbg(format, ##__VA_ARGS__)
 #define gllwdbg(format, ...)  llwdbg(format, ##__VA_ARGS__)
 #else
-#define gwdbg(x...)
-#define gllwdbg(x...)
+#define gwdbg(...)
+#define gllwdbg(...)
 #endif
 
 #ifdef CONFIG_DEBUG_GRAPHICS_INFO
 #define gvdbg(format, ...)   vdbg(format, ##__VA_ARGS__)
 #define gllvdbg(format, ...) llvdbg(format, ##__VA_ARGS__)
 #else
-#define gvdbg(x...)
-#define gllvdbg(x...)
+#define gvdbg(...)
+#define gllvdbg(...)
 #endif
 
 #ifdef CONFIG_DEBUG_LIB_ERROR
 #define ldbg(format, ...)    dbg(format, ##__VA_ARGS__)
 #define llldbg(format, ...)  lldbg(format, ##__VA_ARGS__)
 #else
-#define ldbg(x...)
-#define llldbg(x...)
+#define ldbg(...)
+#define llldbg(...)
 #endif
 
 #ifdef CONFIG_DEBUG_LIB_WARN
 #define lwdbg(format, ...)    wdbg(format, ##__VA_ARGS__)
 #define lllwdbg(format, ...)  llwdbg(format, ##__VA_ARGS__)
 #else
-#define lwdbg(x...)
-#define lllwdbg(x...)
+#define lwdbg(...)
+#define lllwdbg(...)
 #endif
 
 #ifdef CONFIG_DEBUG_LIB_INFO
 #define lvdbg(format, ...)   vdbg(format, ##__VA_ARGS__)
 #define lllvdbg(format, ...) llvdbg(format, ##__VA_ARGS__)
 #else
-#define lvdbg(x...)
-#define lllvdbg(x...)
+#define lvdbg(...)
+#define lllvdbg(...)
 #endif
 
 #ifdef CONFIG_DEBUG_AUDIO_ERROR
 #define auddbg(format, ...)    dbg(format, ##__VA_ARGS__)
 #define audlldbg(format, ...)  lldbg(format, ##__VA_ARGS__)
 #else
-#define auddbg(x...)
-#define audlldbg(x...)
+#define auddbg(...)
+#define audlldbg(...)
 #endif
 
 #ifdef CONFIG_DEBUG_AUDIO_WARN
 #define audwdbg(format, ...)    wdbg(format, ##__VA_ARGS__)
 #define audllwdbg(format, ...)  llwdbg(format, ##__VA_ARGS__)
 #else
-#define audwdbg(x...)
-#define audllwdbg(x...)
+#define audwdbg(...)
+#define audllwdbg(...)
 #endif
 
 #ifdef CONFIG_DEBUG_AUDIO_INFO
 #define audvdbg(format, ...)   vdbg(format, ##__VA_ARGS__)
 #define audllvdbg(format, ...) llvdbg(format, ##__VA_ARGS__)
 #else
-#define audvdbg(x...)
-#define audllvdbg(x...)
+#define audvdbg(...)
+#define audllvdbg(...)
 #endif
 
 #ifdef CONFIG_DEBUG_I2C_ERROR
 #define i2cerr(format, ...)    dbg(format, ##__VA_ARGS__)
 #define i2clldbg(format, ...)  lldbg(format, ##__VA_ARGS__)
 #else
-#define i2cerr(x...)
-#define i2clldbg(x...)
+#define i2cerr(...)
+#define i2clldbg(...)
 #endif
 
 #ifdef CONFIG_DEBUG_I2C_WARN
 #define i2cwarn(format, ...)    wdbg(format, ##__VA_ARGS__)
 #define i2cllwdbg(format, ...)  llwdbg(format, ##__VA_ARGS__)
 #else
-#define i2cwarn(x...)
-#define i2cllwdbg(x...)
+#define i2cwarn(...)
+#define i2cllwdbg(...)
 #endif
 
 #ifdef CONFIG_DEBUG_I2C_INFO
 #define i2cinfo(format, ...)   vdbg(format, ##__VA_ARGS__)
 #define i2cllvdbg(format, ...) llvdbg(format, ##__VA_ARGS__)
 #else
-#define i2cinfo(x...)
-#define i2cllvdbg(x...)
+#define i2cinfo(...)
+#define i2cllvdbg(...)
 #endif
 
 #ifdef CONFIG_DEBUG_I2S_ERROR
 #define i2serr(format, ...)    dbg(format, ##__VA_ARGS__)
 #define i2slldbg(format, ...)  lldbg(format, ##__VA_ARGS__)
 #else
-#define i2serr(x...)
-#define i2slldbg(x...)
+#define i2serr(...)
+#define i2slldbg(...)
 #endif
 
 #ifdef CONFIG_DEBUG_I2S_WARN
 #define i2swarn(format, ...)    wdbg(format, ##__VA_ARGS__)
 #define i2sllwdbg(format, ...)  llwdbg(format, ##__VA_ARGS__)
 #else
-#define i2swarn(x...)
-#define i2sllwdbg(x...)
+#define i2swarn(...)
+#define i2sllwdbg(...)
 #endif
 
 #ifdef CONFIG_DEBUG_I2S_INFO
 #define i2sinfo(format, ...)   vdbg(format, ##__VA_ARGS__)
 #define i2sllvdbg(format, ...) llvdbg(format, ##__VA_ARGS__)
 #else
-#define i2sinfo(x...)
-#define i2sllvdbg(x...)
+#define i2sinfo(...)
+#define i2sllvdbg(...)
 #endif
 
 
@@ -675,8 +675,8 @@ Once LOGM is approved, each module should have its own index
 #define lwipdbg(format, ...)    dbg(format, ##__VA_ARGS__)
 #define lwiplldbg(format, ...)  lldbg(format, ##__VA_ARGS__)
 #else
-#define lwipdbg(x...)
-#define lwiplldbg(x...)
+#define lwipdbg(...)
+#define lwiplldbg(...)
 #endif
 
 #ifdef CONFIG_DEBUG_TTRACE
@@ -689,40 +689,40 @@ Once LOGM is approved, each module should have its own index
 #define meddbg(format, ...)    dbg(format, ##__VA_ARGS__)
 #define medlldbg(format, ...)  lldbg(format, ##__VA_ARGS__)
 #else
-#define meddbg(x...)
-#define medlldbg(x...)
+#define meddbg(...)
+#define medlldbg(...)
 #endif
 
 #ifdef CONFIG_DEBUG_MEDIA_WARN
 #define medwdbg(format, ...)    wdbg(format, ##__VA_ARGS__)
 #define medllwdbg(format, ...)  llwdbg(format, ##__VA_ARGS__)
 #else
-#define medwdbg(x...)
-#define medllwdbg(x...)
+#define medwdbg(...)
+#define medllwdbg(...)
 #endif
 
 #ifdef CONFIG_DEBUG_MEDIA_INFO
 #define medvdbg(format, ...)    vdbg(format, ##__VA_ARGS__)
 #define medllvdbg(format, ...)  llvdbg(format, ##__VA_ARGS__)
 #else
-#define medvdbg(x...)
-#define medllvdbg(x...)
+#define medvdbg(...)
+#define medllvdbg(...)
 #endif
 
 #ifdef CONFIG_DEBUG_TASK_MANAGER
 #ifdef CONFIG_DEBUG_TASK_MANAGER_ERROR
 #define tmdbg(format, ...)      dbg(format, ##__VA_ARGS__)
 #else
-#define tmdbg(x...)
+#define tmdbg(...)
 #endif
 #ifdef CONFIG_DEBUG_TASK_MANAGER_INFO
 #define tmvdbg(format, ...)     vdbg(format, ##__VA_ARGS__)
 #else
-#define tmvdbg(x...)
+#define tmvdbg(...)
 #endif
 #else
-#define tmdbg(x...)
-#define tmvdbg(x...)
+#define tmdbg(...)
+#define tmvdbg(...)
 #endif
 
 #else							/* CONFIG_CPP_HAVE_VARARGS */
@@ -1098,7 +1098,7 @@ Once LOGM is approved, each module should have its own index
 #define medllvdbg   llvdbg
 #else
 #define medllvdbg   (void)
-#define medllvdbg   (x...)
+#define medllvdbg   (...)
 #endif
 
 #endif							/* CONFIG_CPP_HAVE_VARARGS */

--- a/os/include/tinyara/spi/spi_bitbang.c
+++ b/os/include/tinyara/spi/spi_bitbang.c
@@ -96,11 +96,11 @@
 #ifdef CONFIG_DEBUG_VERBOSE
 #define spivdbg lldbg
 #else
-#define spivdbg(x...)
+#define spivdbg(...)
 #endif
 #else
-#define spidbg(x...)
-#define spivdbg(x...)
+#define spidbg(...)
+#define spivdbg(...)
 #endif
 
 /****************************************************************************

--- a/os/include/tinyara/spi/spi_bitbang.h
+++ b/os/include/tinyara/spi/spi_bitbang.h
@@ -82,11 +82,11 @@
 #ifdef CONFIG_DEBUG_VERBOSE
 #define spivdbg lldbg
 #else
-#define spivdbg(x...)
+#define spivdbg(...)
 #endif
 #else
-#define spidbg(x...)
-#define spivdbg(x...)
+#define spidbg(...)
+#define spivdbg(...)
 #endif
 
 /****************************************************************************

--- a/os/mm/mm_heap/mm_sem.c
+++ b/os/mm/mm_heap/mm_sem.c
@@ -78,7 +78,7 @@
 #endif
 #else
 #ifdef CONFIG_CPP_HAVE_VARARGS
-#define msemdbg(x...)
+#define msemdbg(...)
 #else
 #define msemdbg (void)
 #endif


### PR DESCRIPTION
- following gnu docs, fix variadic-macros warnings
- https://gcc.gnu.org/onlinedocs/gcc-4.5.2/gcc/Variadic-Macros.html

- when building c++, below warnings occur more than 10,000 lines. (This makes the build logs too long)
```
/home/TizenRT/os/include/debug.h:653:17: warning: ISO C++ does not permit named variadic macros [-Wvariadic-macros]
 #define i2cerr(x...)
                ^~~
/home/TizenRT/os/include/debug.h:654:19: warning: ISO C++ does not permit named variadic macros [-Wvariadic-macros]
 #define i2clldbg(x...)
                  ^~~
/home/TizenRT/os/include/debug.h:661:18: warning: ISO C++ does not permit named variadic macros [-Wvariadic-macros]
 #define i2cwarn(x...)
                 ^~~
/home/TizenRT/os/include/debug.h:662:20: warning: ISO C++ does not permit named variadic macros [-Wvariadic-macros]
 #define i2cllwdbg(x...)
                   ^~~
```