### PR TITLE
configs: modify changable paths like "arm", "armv7-r" to CONFIG_XX

### DIFF
--- a/build/configs/artik053/cxxtest/Make.defs
+++ b/build/configs/artik053/cxxtest/Make.defs
@@ -52,7 +52,8 @@
 
 include ${TOPDIR}/.config
 include ${TOPDIR}/tools/Config.mk
-include ${TOPDIR}/arch/arm/src/armv7-r/Toolchain.defs
+ARCH_FAMILY = $(patsubst "%",%,$(CONFIG_ARCH_FAMILY))
+include ${TOPDIR}/arch/$(CONFIG_ARCH)/src/$(ARCH_FAMILY)/Toolchain.defs
 
 LDSCRIPT = flash.ld
 

--- a/build/configs/artik053/extra/Make.defs
+++ b/build/configs/artik053/extra/Make.defs
@@ -52,7 +52,8 @@
 
 include ${TOPDIR}/.config
 include ${TOPDIR}/tools/Config.mk
-include ${TOPDIR}/arch/arm/src/armv7-r/Toolchain.defs
+ARCH_FAMILY = $(patsubst "%",%,$(CONFIG_ARCH_FAMILY))
+include ${TOPDIR}/arch/$(CONFIG_ARCH)/src/$(ARCH_FAMILY)/Toolchain.defs
 
 LDSCRIPT = flash.ld
 

--- a/build/configs/artik053/grpc/Make.defs
+++ b/build/configs/artik053/grpc/Make.defs
@@ -18,7 +18,8 @@
 
 include ${TOPDIR}/.config
 include ${TOPDIR}/tools/Config.mk
-include ${TOPDIR}/arch/arm/src/armv7-r/Toolchain.defs
+ARCH_FAMILY = $(patsubst "%",%,$(CONFIG_ARCH_FAMILY))
+include ${TOPDIR}/arch/$(CONFIG_ARCH)/src/$(ARCH_FAMILY)/Toolchain.defs
 
 LDSCRIPT = flash.ld
 

--- a/build/configs/artik053/hello/Make.defs
+++ b/build/configs/artik053/hello/Make.defs
@@ -52,7 +52,8 @@
 
 include ${TOPDIR}/.config
 include ${TOPDIR}/tools/Config.mk
-include ${TOPDIR}/arch/arm/src/armv7-r/Toolchain.defs
+ARCH_FAMILY = $(patsubst "%",%,$(CONFIG_ARCH_FAMILY))
+include ${TOPDIR}/arch/$(CONFIG_ARCH)/src/$(ARCH_FAMILY)/Toolchain.defs
 
 LDSCRIPT = flash.ld
 

--- a/build/configs/artik053/helloxx/Make.defs
+++ b/build/configs/artik053/helloxx/Make.defs
@@ -52,7 +52,8 @@
 
 include ${TOPDIR}/.config
 include ${TOPDIR}/tools/Config.mk
-include ${TOPDIR}/arch/arm/src/armv7-r/Toolchain.defs
+ARCH_FAMILY = $(patsubst "%",%,$(CONFIG_ARCH_FAMILY))
+include ${TOPDIR}/arch/$(CONFIG_ARCH)/src/$(ARCH_FAMILY)/Toolchain.defs
 
 LDSCRIPT = flash.ld
 

--- a/build/configs/artik053/iotivity/Make.defs
+++ b/build/configs/artik053/iotivity/Make.defs
@@ -52,7 +52,8 @@
 
 include ${TOPDIR}/.config
 include ${TOPDIR}/tools/Config.mk
-include ${TOPDIR}/arch/arm/src/armv7-r/Toolchain.defs
+ARCH_FAMILY = $(patsubst "%",%,$(CONFIG_ARCH_FAMILY))
+include ${TOPDIR}/arch/$(CONFIG_ARCH)/src/$(ARCH_FAMILY)/Toolchain.defs
 
 LDSCRIPT = flash.ld
 

--- a/build/configs/artik053/iotjs/Make.defs
+++ b/build/configs/artik053/iotjs/Make.defs
@@ -52,7 +52,8 @@
 
 include ${TOPDIR}/.config
 include ${TOPDIR}/tools/Config.mk
-include ${TOPDIR}/arch/arm/src/armv7-r/Toolchain.defs
+ARCH_FAMILY = $(patsubst "%",%,$(CONFIG_ARCH_FAMILY))
+include ${TOPDIR}/arch/$(CONFIG_ARCH)/src/$(ARCH_FAMILY)/Toolchain.defs
 
 LDSCRIPT = flash.ld
 

--- a/build/configs/artik053/kernel_sample/Make.defs
+++ b/build/configs/artik053/kernel_sample/Make.defs
@@ -52,7 +52,8 @@
 
 include ${TOPDIR}/.config
 include ${TOPDIR}/tools/Config.mk
-include ${TOPDIR}/arch/arm/src/armv7-r/Toolchain.defs
+ARCH_FAMILY = $(patsubst "%",%,$(CONFIG_ARCH_FAMILY))
+include ${TOPDIR}/arch/$(CONFIG_ARCH)/src/$(ARCH_FAMILY)/Toolchain.defs
 
 LDSCRIPT = flash.ld
 

--- a/build/configs/artik053/minimal/Make.defs
+++ b/build/configs/artik053/minimal/Make.defs
@@ -52,7 +52,8 @@
 
 include ${TOPDIR}/.config
 include ${TOPDIR}/tools/Config.mk
-include ${TOPDIR}/arch/arm/src/armv7-r/Toolchain.defs
+ARCH_FAMILY = $(patsubst "%",%,$(CONFIG_ARCH_FAMILY))
+include ${TOPDIR}/arch/$(CONFIG_ARCH)/src/$(ARCH_FAMILY)/Toolchain.defs
 
 LDSCRIPT = flash.ld
 

--- a/build/configs/artik053/nettest/Make.defs
+++ b/build/configs/artik053/nettest/Make.defs
@@ -52,7 +52,8 @@
 
 include ${TOPDIR}/.config
 include ${TOPDIR}/tools/Config.mk
-include ${TOPDIR}/arch/arm/src/armv7-r/Toolchain.defs
+ARCH_FAMILY = $(patsubst "%",%,$(CONFIG_ARCH_FAMILY))
+include ${TOPDIR}/arch/$(CONFIG_ARCH)/src/$(ARCH_FAMILY)/Toolchain.defs
 
 LDSCRIPT = flash.ld
 

--- a/build/configs/artik053/st_things/Make.defs
+++ b/build/configs/artik053/st_things/Make.defs
@@ -18,7 +18,8 @@
 
 include ${TOPDIR}/.config
 include ${TOPDIR}/tools/Config.mk
-include ${TOPDIR}/arch/arm/src/armv7-r/Toolchain.defs
+ARCH_FAMILY = $(patsubst "%",%,$(CONFIG_ARCH_FAMILY))
+include ${TOPDIR}/arch/$(CONFIG_ARCH)/src/$(ARCH_FAMILY)/Toolchain.defs
 
 LDSCRIPT = flash.ld
 

--- a/build/configs/artik053/tc/Make.defs
+++ b/build/configs/artik053/tc/Make.defs
@@ -52,7 +52,8 @@
 
 include ${TOPDIR}/.config
 include ${TOPDIR}/tools/Config.mk
-include ${TOPDIR}/arch/arm/src/armv7-r/Toolchain.defs
+ARCH_FAMILY = $(patsubst "%",%,$(CONFIG_ARCH_FAMILY))
+include ${TOPDIR}/arch/$(CONFIG_ARCH)/src/$(ARCH_FAMILY)/Toolchain.defs
 
 LDSCRIPT = flash.ld
 

--- a/build/configs/artik053/tc_libcxx/Make.defs
+++ b/build/configs/artik053/tc_libcxx/Make.defs
@@ -52,7 +52,8 @@
 
 include ${TOPDIR}/.config
 include ${TOPDIR}/tools/Config.mk
-include ${TOPDIR}/arch/arm/src/armv7-r/Toolchain.defs
+ARCH_FAMILY = $(patsubst "%",%,$(CONFIG_ARCH_FAMILY))
+include ${TOPDIR}/arch/$(CONFIG_ARCH)/src/$(ARCH_FAMILY)/Toolchain.defs
 
 LDSCRIPT = flash.ld
 

--- a/build/configs/artik053/tc_minimal_kernel/Make.defs
+++ b/build/configs/artik053/tc_minimal_kernel/Make.defs
@@ -52,7 +52,8 @@
 
 include ${TOPDIR}/.config
 include ${TOPDIR}/tools/Config.mk
-include ${TOPDIR}/arch/arm/src/armv7-r/Toolchain.defs
+ARCH_FAMILY = $(patsubst "%",%,$(CONFIG_ARCH_FAMILY))
+include ${TOPDIR}/arch/$(CONFIG_ARCH)/src/$(ARCH_FAMILY)/Toolchain.defs
 
 LDSCRIPT = flash.ld
 

--- a/build/configs/artik053s/nettest/Make.defs
+++ b/build/configs/artik053s/nettest/Make.defs
@@ -52,7 +52,8 @@
 
 include ${TOPDIR}/.config
 include ${TOPDIR}/tools/Config.mk
-include ${TOPDIR}/arch/arm/src/armv7-r/Toolchain.defs
+ARCH_FAMILY = $(patsubst "%",%,$(CONFIG_ARCH_FAMILY))
+include ${TOPDIR}/arch/$(CONFIG_ARCH)/src/$(ARCH_FAMILY)/Toolchain.defs
 
 LDSCRIPT = flash.ld
 

--- a/build/configs/artik053s/st_things/Make.defs
+++ b/build/configs/artik053s/st_things/Make.defs
@@ -52,7 +52,8 @@
 
 include ${TOPDIR}/.config
 include ${TOPDIR}/tools/Config.mk
-include ${TOPDIR}/arch/arm/src/armv7-r/Toolchain.defs
+ARCH_FAMILY = $(patsubst "%",%,$(CONFIG_ARCH_FAMILY))
+include ${TOPDIR}/arch/$(CONFIG_ARCH)/src/$(ARCH_FAMILY)/Toolchain.defs
 
 LDSCRIPT = flash.ld
 

--- a/build/configs/artik055s/audio/Make.defs
+++ b/build/configs/artik055s/audio/Make.defs
@@ -52,7 +52,8 @@
 
 include ${TOPDIR}/.config
 include ${TOPDIR}/tools/Config.mk
-include ${TOPDIR}/arch/arm/src/armv7-r/Toolchain.defs
+ARCH_FAMILY = $(patsubst "%",%,$(CONFIG_ARCH_FAMILY))
+include ${TOPDIR}/arch/$(CONFIG_ARCH)/src/$(ARCH_FAMILY)/Toolchain.defs
 
 LDSCRIPT = flash.ld
 

--- a/build/configs/artik055s/minimal/Make.defs
+++ b/build/configs/artik055s/minimal/Make.defs
@@ -52,7 +52,8 @@
 
 include ${TOPDIR}/.config
 include ${TOPDIR}/tools/Config.mk
-include ${TOPDIR}/arch/arm/src/armv7-r/Toolchain.defs
+ARCH_FAMILY = $(patsubst "%",%,$(CONFIG_ARCH_FAMILY))
+include ${TOPDIR}/arch/$(CONFIG_ARCH)/src/$(ARCH_FAMILY)/Toolchain.defs
 
 LDSCRIPT = flash.ld
 

--- a/build/configs/artik055s/nettest/Make.defs
+++ b/build/configs/artik055s/nettest/Make.defs
@@ -52,7 +52,8 @@
 
 include ${TOPDIR}/.config
 include ${TOPDIR}/tools/Config.mk
-include ${TOPDIR}/arch/arm/src/armv7-r/Toolchain.defs
+ARCH_FAMILY = $(patsubst "%",%,$(CONFIG_ARCH_FAMILY))
+include ${TOPDIR}/arch/$(CONFIG_ARCH)/src/$(ARCH_FAMILY)/Toolchain.defs
 
 LDSCRIPT = flash.ld
 

--- a/build/configs/artik055s/st_things/Make.defs
+++ b/build/configs/artik055s/st_things/Make.defs
@@ -52,7 +52,8 @@
 
 include ${TOPDIR}/.config
 include ${TOPDIR}/tools/Config.mk
-include ${TOPDIR}/arch/arm/src/armv7-r/Toolchain.defs
+ARCH_FAMILY = $(patsubst "%",%,$(CONFIG_ARCH_FAMILY))
+include ${TOPDIR}/arch/$(CONFIG_ARCH)/src/$(ARCH_FAMILY)/Toolchain.defs
 
 LDSCRIPT = flash.ld
 

--- a/build/configs/qemu/smartfs/Make.defs
+++ b/build/configs/qemu/smartfs/Make.defs
@@ -52,7 +52,8 @@
 
 include ${TOPDIR}/.config
 include ${TOPDIR}/tools/Config.mk
-include ${TOPDIR}/arch/arm/src/armv7-m/Toolchain.defs
+ARCH_FAMILY = $(patsubst "%",%,$(CONFIG_ARCH_FAMILY))
+include ${TOPDIR}/arch/$(CONFIG_ARCH)/src/$(ARCH_FAMILY)/Toolchain.defs
 
 # Choose proper ld script
 ifeq ($(CONFIG_QEMU_SRAM),y)

--- a/build/configs/qemu/tc_16m/Make.defs
+++ b/build/configs/qemu/tc_16m/Make.defs
@@ -52,7 +52,8 @@
 
 include ${TOPDIR}/.config
 include ${TOPDIR}/tools/Config.mk
-include ${TOPDIR}/arch/arm/src/armv7-m/Toolchain.defs
+ARCH_FAMILY = $(patsubst "%",%,$(CONFIG_ARCH_FAMILY))
+include ${TOPDIR}/arch/$(CONFIG_ARCH)/src/$(ARCH_FAMILY)/Toolchain.defs
 
 # Choose proper ld script
 ifeq ($(CONFIG_QEMU_SRAM),y)

--- a/build/configs/qemu/tc_16m_grpc/Make.defs
+++ b/build/configs/qemu/tc_16m_grpc/Make.defs
@@ -52,7 +52,8 @@
 
 include ${TOPDIR}/.config
 include ${TOPDIR}/tools/Config.mk
-include ${TOPDIR}/arch/arm/src/armv7-m/Toolchain.defs
+ARCH_FAMILY = $(patsubst "%",%,$(CONFIG_ARCH_FAMILY))
+include ${TOPDIR}/arch/$(CONFIG_ARCH)/src/$(ARCH_FAMILY)/Toolchain.defs
 
 # Choose proper ld script
 ifeq ($(CONFIG_QEMU_SRAM),y)

--- a/build/configs/qemu/tc_1m/Make.defs
+++ b/build/configs/qemu/tc_1m/Make.defs
@@ -52,7 +52,8 @@
 
 include ${TOPDIR}/.config
 include ${TOPDIR}/tools/Config.mk
-include ${TOPDIR}/arch/arm/src/armv7-m/Toolchain.defs
+ARCH_FAMILY = $(patsubst "%",%,$(CONFIG_ARCH_FAMILY))
+include ${TOPDIR}/arch/$(CONFIG_ARCH)/src/$(ARCH_FAMILY)/Toolchain.defs
 
 # Choose proper ld script
 ifeq ($(CONFIG_QEMU_SRAM),y)

--- a/build/configs/qemu/tc_64k/Make.defs
+++ b/build/configs/qemu/tc_64k/Make.defs
@@ -52,7 +52,8 @@
 
 include ${TOPDIR}/.config
 include ${TOPDIR}/tools/Config.mk
-include ${TOPDIR}/arch/arm/src/armv7-m/Toolchain.defs
+ARCH_FAMILY = $(patsubst "%",%,$(CONFIG_ARCH_FAMILY))
+include ${TOPDIR}/arch/$(CONFIG_ARCH)/src/$(ARCH_FAMILY)/Toolchain.defs
 
 # Choose proper ld script
 ifeq ($(CONFIG_QEMU_SRAM),y)

--- a/build/configs/sidk_s5jt200/hello/Make.defs
+++ b/build/configs/sidk_s5jt200/hello/Make.defs
@@ -52,7 +52,8 @@
 
 include ${TOPDIR}/.config
 include ${TOPDIR}/tools/Config.mk
-include ${TOPDIR}/arch/arm/src/armv7-r/Toolchain.defs
+ARCH_FAMILY = $(patsubst "%",%,$(CONFIG_ARCH_FAMILY))
+include ${TOPDIR}/arch/$(CONFIG_ARCH)/src/$(ARCH_FAMILY)/Toolchain.defs
 
 LDSCRIPT = ld_s5jt200_flash.script
 

--- a/build/configs/sidk_s5jt200/hello_with_tash/Make.defs
+++ b/build/configs/sidk_s5jt200/hello_with_tash/Make.defs
@@ -52,7 +52,8 @@
 
 include ${TOPDIR}/.config
 include ${TOPDIR}/tools/Config.mk
-include ${TOPDIR}/arch/arm/src/armv7-r/Toolchain.defs
+ARCH_FAMILY = $(patsubst "%",%,$(CONFIG_ARCH_FAMILY))
+include ${TOPDIR}/arch/$(CONFIG_ARCH)/src/$(ARCH_FAMILY)/Toolchain.defs
 
 LDSCRIPT = ld_s5jt200_flash.script
 

--- a/build/configs/sidk_s5jt200/kernel_sample/Make.defs
+++ b/build/configs/sidk_s5jt200/kernel_sample/Make.defs
@@ -52,7 +52,8 @@
 
 include ${TOPDIR}/.config
 include ${TOPDIR}/tools/Config.mk
-include ${TOPDIR}/arch/arm/src/armv7-r/Toolchain.defs
+ARCH_FAMILY = $(patsubst "%",%,$(CONFIG_ARCH_FAMILY))
+include ${TOPDIR}/arch/$(CONFIG_ARCH)/src/$(ARCH_FAMILY)/Toolchain.defs
 
 LDSCRIPT = ld_s5jt200_flash.script
 

--- a/build/configs/sidk_s5jt200/sidk_tash_aws/Make.defs
+++ b/build/configs/sidk_s5jt200/sidk_tash_aws/Make.defs
@@ -52,7 +52,8 @@
 
 include ${TOPDIR}/.config
 include ${TOPDIR}/tools/Config.mk
-include ${TOPDIR}/arch/arm/src/armv7-r/Toolchain.defs
+ARCH_FAMILY = $(patsubst "%",%,$(CONFIG_ARCH_FAMILY))
+include ${TOPDIR}/arch/$(CONFIG_ARCH)/src/$(ARCH_FAMILY)/Toolchain.defs
 
 LDSCRIPT = ld_s5jt200_flash.script
 

--- a/build/configs/sidk_s5jt200/sidk_tash_wlan/Make.defs
+++ b/build/configs/sidk_s5jt200/sidk_tash_wlan/Make.defs
@@ -52,7 +52,8 @@
 
 include ${TOPDIR}/.config
 include ${TOPDIR}/tools/Config.mk
-include ${TOPDIR}/arch/arm/src/armv7-r/Toolchain.defs
+ARCH_FAMILY = $(patsubst "%",%,$(CONFIG_ARCH_FAMILY))
+include ${TOPDIR}/arch/$(CONFIG_ARCH)/src/$(ARCH_FAMILY)/Toolchain.defs
 
 LDSCRIPT = ld_s5jt200_flash.script
 

--- a/build/configs/sidk_s5jt200/tc/Make.defs
+++ b/build/configs/sidk_s5jt200/tc/Make.defs
@@ -52,7 +52,8 @@
 
 include ${TOPDIR}/.config
 include ${TOPDIR}/tools/Config.mk
-include ${TOPDIR}/arch/arm/src/armv7-r/Toolchain.defs
+ARCH_FAMILY = $(patsubst "%",%,$(CONFIG_ARCH_FAMILY))
+include ${TOPDIR}/arch/$(CONFIG_ARCH)/src/$(ARCH_FAMILY)/Toolchain.defs
 
 LDSCRIPT = ld_s5jt200_flash.script
 


### PR DESCRIPTION
Some paths are changable variables depends on chip architecture
of selected board.
Because CONFIG_ARCH and CONFIG_ARCH_FAMILY shows them,
this commit replace "arm" and "armv7-r" / "armv7-m" to them.