### PR TITLE
media : sync parameter type refer to tinyalsa & audio driver

### DIFF
--- a/apps/examples/testcase/ta_tc/media/utc/utc_media_fileoutputdatasource.cpp
+++ b/apps/examples/testcase/ta_tc/media/utc/utc_media_fileoutputdatasource.cpp
@@ -24,9 +24,9 @@ using namespace std;
 using namespace media;
 using namespace media::stream;
 
-static unsigned char channels = 2;
+static unsigned int channels = 2;
 static unsigned int sampleRate = 16000;
-static int pcmFormat = AUDIO_FORMAT_TYPE_S16_LE;
+static audio_format_type_t pcmFormat = AUDIO_FORMAT_TYPE_S16_LE;
 static const char *filePath = "/ramfs/record";
 
 static void utc_media_FileOutputDataSource_getChannels_p(void)
@@ -53,7 +53,7 @@ static void utc_media_FileOutputDataSource_getPcmFormat_p(void)
 static void utc_media_FileOutputDataSource_setChannels_p(void)
 {
 	FileOutputDataSource dataSource(filePath);
-	unsigned short compare_channels = 3;
+	unsigned int compare_channels = 3;
 	dataSource.setChannels(compare_channels);
 	TC_ASSERT_EQ("utc_media_FileOutputDataSource_setChannels", dataSource.getChannels(), compare_channels);
 	TC_SUCCESS_RESULT();
@@ -71,7 +71,7 @@ static void utc_media_FileOutputDataSource_setSampleRate_p(void)
 static void utc_media_FileOutputDataSource_setPcmFormat_p(void)
 {
 	FileOutputDataSource dataSource(filePath);
-	int compare_pcmFormat = media::AUDIO_FORMAT_TYPE_S8;
+	media::audio_format_type_t compare_pcmFormat = media::AUDIO_FORMAT_TYPE_S8;
 	dataSource.setPcmFormat(media::AUDIO_FORMAT_TYPE_S8);
 	TC_ASSERT_EQ("utc_media_FileOutputDataSource_setPcmFormat", dataSource.getPcmFormat(), compare_pcmFormat);
 	TC_SUCCESS_RESULT();
@@ -156,7 +156,7 @@ static void utc_media_FileOutputDataSource_write_p(void)
 {
 	FileOutputDataSource dataSource(filePath);
 	unsigned char dummy[] = "dummy";
-	size_t dummySize = 6;
+	ssize_t dummySize = 6;
 
 	dataSource.open();
 	TC_ASSERT_EQ("utc_media_FileOutputDataSource_write", dataSource.write(dummy, dummySize), dummySize);

--- a/apps/examples/testcase/ta_tc/media/utc/utc_media_mediarecorder.cpp
+++ b/apps/examples/testcase/ta_tc/media/utc/utc_media_mediarecorder.cpp
@@ -25,9 +25,9 @@ using namespace std;
 using namespace media;
 using namespace media::stream;
 
-static unsigned char channels = 2;
+static unsigned int channels = 2;
 static unsigned int sampleRate = 16000;
-static int pcmFormat = AUDIO_FORMAT_TYPE_S16_LE;
+static audio_format_type_t pcmFormat = AUDIO_FORMAT_TYPE_S16_LE;
 static const char *filePath = "/ramfs/record";
 
 static void utc_media_MediaRecorder_create_p(void)

--- a/framework/include/media/DataSource.h
+++ b/framework/include/media/DataSource.h
@@ -63,7 +63,7 @@ public:
 	 * param[in] pcmFormat  The pcmFormat that the pcm format of audio
 	 * @since TizenRT v2.0 PRE
 	 */
-	DataSource(unsigned short channels, unsigned int sampleRate, int pcmFormat);
+	DataSource(unsigned int channels, unsigned int sampleRate, audio_format_type_t pcmFormat);
 	/**
 	 * @brief Copy constructs for DataSource.
 	 * @details @b #include <media/DataSource.h>
@@ -103,7 +103,7 @@ public:
 	 * @return The channel count of the stream data.
 	 * @since TizenRT v2.0 PRE
 	 */
-	unsigned char getChannels();
+	unsigned int getChannels();
 	/**
 	 * @brief Gets the sample rate of the stream data.
 	 * @details @b #include <media/DataSource.h>
@@ -117,7 +117,7 @@ public:
 	 * @return The pcm format of the stream data.
 	 * @since TizenRT v2.0 PRE
 	 */
-	int getPcmFormat();
+	audio_format_type_t getPcmFormat();
 
 	/**
 	 * @brief Sets the channel count of the stream data.
@@ -125,7 +125,7 @@ public:
 	 * @param[in] channels The channels that the channel count of stream data
 	 * @since TizenRT v2.0 PRE
 	 */
-	void setChannels(unsigned char channels);
+	void setChannels(unsigned int channels);
 	/**
 	 * @brief Sets the sample rate of the stream data.
 	 * @details @b #include <media/DataSource.h>
@@ -139,12 +139,12 @@ public:
 	 * @param[in] pcmFormat The pcmFormat that the pcm format of stream data
 	 * @since TizenRT v2.0 PRE
 	 */
-	void setPcmFormat(int pcmFormat);
+	void setPcmFormat(audio_format_type_t pcmFormat);
 
 private:
 	unsigned char mChannels;
 	unsigned int mSampleRate;
-	int mPcmFormat;
+	audio_format_type_t mPcmFormat;
 };
 } // namespace media
 

--- a/framework/include/media/FileOutputDataSource.h
+++ b/framework/include/media/FileOutputDataSource.h
@@ -65,7 +65,7 @@ public:
 	 * param[in] datapath   The datapath that the path of data
 	 * @since TizenRT v2.0 PRE
 	 */
-	FileOutputDataSource(unsigned short channels, unsigned int sampleRate, int pcmFormat, const std::string& dataPath);
+	FileOutputDataSource(unsigned int channels, unsigned int sampleRate, audio_format_type_t pcmFormat, const std::string& dataPath);
 	/**
 	 * @brief Copy constructs for FileOutputDataSource.
 	 * @details @b #include <media/FileOutputDataSource.h>

--- a/framework/include/media/OutputDataSource.h
+++ b/framework/include/media/OutputDataSource.h
@@ -56,7 +56,7 @@ public:
 	 * param[in] pcmFormat  The pcmFormat that the pcm format of audio
 	 * @since TizenRT v2.0 PRE
 	 */
-	OutputDataSource(unsigned short channels, unsigned int sampleRate, int pcmFormat);
+	OutputDataSource(unsigned int channels, unsigned int sampleRate, audio_format_type_t pcmFormat);
 
 	/**
 	 * @brief Copy constructs for OutputDataSource.

--- a/framework/include/media/SocketOutputDataSource.h
+++ b/framework/include/media/SocketOutputDataSource.h
@@ -71,7 +71,7 @@ public:
 	 * param[in] port       The port number for connecting to the socket server
 	 * @since TizenRT v2.0 PRE
 	 */
-	SocketOutputDataSource(unsigned short channels, unsigned int sampleRate, int pcmFormat, const std::string& ipAddr, const uint16_t port);
+	SocketOutputDataSource(unsigned int channels, unsigned int sampleRate, audio_format_type_t pcmFormat, const std::string& ipAddr, const uint16_t port);
 	/**
 	 * @brief Copy constructs for SocketOutputDataSource.
 	 * @details @b #include <media/SocketOutputDataSource.h>

--- a/framework/src/media/DataSource.cpp
+++ b/framework/src/media/DataSource.cpp
@@ -28,7 +28,7 @@ DataSource::DataSource()
 	medvdbg("DataSource::DataSource()\n");
 }
 
-DataSource::DataSource(unsigned short channels, unsigned int sampleRate, int pcmFormat)
+DataSource::DataSource(unsigned int channels, unsigned int sampleRate, audio_format_type_t pcmFormat)
 	: mChannels(channels)
 	, mSampleRate(sampleRate)
 	, mPcmFormat(pcmFormat)
@@ -51,7 +51,7 @@ DataSource& DataSource::operator=(const DataSource& source)
 	return *this;
 }
 
-unsigned char DataSource::getChannels()
+unsigned int DataSource::getChannels()
 {
 	return mChannels;
 }
@@ -61,12 +61,12 @@ unsigned int DataSource::getSampleRate()
 	return mSampleRate;
 }
 
-int DataSource::getPcmFormat()
+audio_format_type_t DataSource::getPcmFormat()
 {
 	return mPcmFormat;
 }
 
-void DataSource::setChannels(unsigned char channels)
+void DataSource::setChannels(unsigned int channels)
 {
 	mChannels = channels;
 }
@@ -76,7 +76,7 @@ void DataSource::setSampleRate(unsigned int sampleRate)
 	mSampleRate = sampleRate;
 }
 
-void DataSource::setPcmFormat(int pcmFormat)
+void DataSource::setPcmFormat(audio_format_type_t pcmFormat)
 {
 	mPcmFormat = pcmFormat;
 }

--- a/framework/src/media/FileInputDataSource.cpp
+++ b/framework/src/media/FileInputDataSource.cpp
@@ -165,7 +165,7 @@ ssize_t FileInputDataSource::read(unsigned char *buf, size_t size)
 		return rlen;
 	}
 
-	return rlen;
+	return readRet;
 }
 
 int FileInputDataSource::readAt(long offset, int origin, unsigned char *buf, size_t size)

--- a/framework/src/media/FileOutputDataSource.cpp
+++ b/framework/src/media/FileOutputDataSource.cpp
@@ -28,7 +28,7 @@ FileOutputDataSource::FileOutputDataSource(const std::string& dataPath)
 {
 }
 
-FileOutputDataSource::FileOutputDataSource(unsigned short channels, unsigned int sampleRate, int pcmFormat, const std::string& dataPath)
+FileOutputDataSource::FileOutputDataSource(unsigned int channels, unsigned int sampleRate, audio_format_type_t pcmFormat, const std::string& dataPath)
 	: OutputDataSource(channels, sampleRate, pcmFormat), mDataPath(dataPath), mFp(nullptr)
 {
 }

--- a/framework/src/media/MediaRecorderImpl.cpp
+++ b/framework/src/media/MediaRecorderImpl.cpp
@@ -152,7 +152,7 @@ void MediaRecorderImpl::prepareRecorder(recorder_result_t& ret)
 		return notifySync();
 	}
 
-	mBuffSize = get_input_frames_byte_size(get_input_frame_count());
+	mBuffSize = get_input_frames_to_byte(get_input_frame_count());
 
 	if (mBuffSize <= 0) {
 		meddbg("Buffer size is too small size : %d\n", mBuffSize);
@@ -385,7 +385,7 @@ void MediaRecorderImpl::setRecorderVolume(int vol, recorder_result_t& ret)
 		return notifySync();
 	}
 
-	audio_manager_result_t result = set_input_audio_volume(vol);
+	audio_manager_result_t result = set_input_audio_volume((uint8_t)vol);
 	if (result != AUDIO_MANAGER_SUCCESS) {
 		meddbg("set_input_audio_volume failed vol : %d ret : %d\n", vol, result);
 		return notifySync();
@@ -481,7 +481,7 @@ void MediaRecorderImpl::capture()
 	int frames = start_audio_stream_in(mBuffer, get_input_frame_count());
 
 	if (frames > 0) {
-		int size = get_input_frames_byte_size(frames);
+		int size = get_input_frames_to_byte(frames);
 
 		int ret = 0;
 		while (size > 0) {

--- a/framework/src/media/OutputDataSource.cpp
+++ b/framework/src/media/OutputDataSource.cpp
@@ -25,7 +25,7 @@ OutputDataSource::OutputDataSource()
 {
 }
 
-OutputDataSource::OutputDataSource(unsigned short channels, unsigned int sampleRate, int pcmFormat)
+OutputDataSource::OutputDataSource(unsigned int channels, unsigned int sampleRate, audio_format_type_t pcmFormat)
 	: DataSource(channels, sampleRate, pcmFormat)
 {
 }

--- a/framework/src/media/SocketOutputDataSource.cpp
+++ b/framework/src/media/SocketOutputDataSource.cpp
@@ -34,7 +34,7 @@ SocketOutputDataSource::SocketOutputDataSource(const std::string& ipAddr, const 
 {
 }
 
-SocketOutputDataSource::SocketOutputDataSource(unsigned short channels, unsigned int sampleRate, int pcmFormat, const std::string& ipAddr, const uint16_t port)
+SocketOutputDataSource::SocketOutputDataSource(unsigned int channels, unsigned int sampleRate, audio_format_type_t pcmFormat, const std::string& ipAddr, const uint16_t port)
 	: OutputDataSource(channels, sampleRate, pcmFormat), mIpAddr(ipAddr), mPort(port), mSockFd(INVALID_SOCKET)
 {
 }

--- a/framework/src/media/audio/audio_manager.h
+++ b/framework/src/media/audio/audio_manager.h
@@ -96,7 +96,7 @@ audio_manager_result_t init_audio_stream_out(void);
  * Returned Value:
  *   On success, AUDIO_MANAGER_SUCCESS. Otherwise a negative value.
  ****************************************************************************/
-audio_manager_result_t set_audio_stream_in(uint8_t channels, uint32_t sample_rate, uint8_t format);
+audio_manager_result_t set_audio_stream_in(unsigned int channels, unsigned int sample_rate, int format);
 
 /****************************************************************************
  * Name: set_audio_stream_out
@@ -114,7 +114,7 @@ audio_manager_result_t set_audio_stream_in(uint8_t channels, uint32_t sample_rat
  * Returned Value:
  *   On success, AUDIO_MANAGER_SUCCESS. Otherwise, a negative value.
  ****************************************************************************/
-audio_manager_result_t set_audio_stream_out(uint8_t channels, uint32_t sample_rate, uint8_t format);
+audio_manager_result_t set_audio_stream_out(unsigned int channels, unsigned int sample_rate, int format);
 
 /****************************************************************************
  * Name: start_audio_stream_in
@@ -131,7 +131,7 @@ audio_manager_result_t set_audio_stream_out(uint8_t channels, uint32_t sample_ra
  * Returned Value:
  *   On success, the number of frames read. Otherwise, a negative value.
  ****************************************************************************/
-int start_audio_stream_in(void *data, uint32_t frames);
+int start_audio_stream_in(void *data, unsigned int frames);
 
 /****************************************************************************
  * Name: start_audio_stream_out
@@ -148,7 +148,7 @@ int start_audio_stream_in(void *data, uint32_t frames);
  * Returned Value:
  *   On success, the number of frames written. Otherwise, a negative value.
  ****************************************************************************/
-int start_audio_stream_out(void *data, uint32_t frames);
+int start_audio_stream_out(void *data, unsigned int frames);
 
 /****************************************************************************
  * Name: pause_audio_stream_in
@@ -239,10 +239,10 @@ audio_manager_result_t stop_audio_stream_out(void);
  * Returned Value:
  *   On success, the size of the pcm buffer for input streams. Otherwise, 0.
  ****************************************************************************/
-uint32_t get_input_frame_count(void);
+unsigned int get_input_frame_count(void);
 
 /****************************************************************************
- * Name: get_input_frames_byte_size
+ * Name: get_input_frames_to_byte
  *
  * Description:
  *   Get the byte size of the given frame value in input stream.
@@ -250,10 +250,10 @@ uint32_t get_input_frame_count(void);
  * Returned Value:
  *   On success, the byte size of the frame in input stream. Otherwise, 0.
  ****************************************************************************/
-uint32_t get_input_frames_byte_size(uint32_t frames);
+unsigned int get_input_frames_to_byte(unsigned int frames);
 
 /****************************************************************************
- * Name: get_input_bytes_frame_count
+ * Name: get_input_bytes_to_frame
  *
  * Description:
  *   Get the number of frames for the given byte size in input stream.
@@ -261,7 +261,7 @@ uint32_t get_input_frames_byte_size(uint32_t frames);
  * Returned Value:
  *   On success, the number of frames in input stream. Otherwise, 0.
  ****************************************************************************/
-uint32_t get_input_bytes_frame_count(uint32_t bytes);
+unsigned int get_input_bytes_to_frame(unsigned int bytes);
 
 /****************************************************************************
  * Name: get_output_frame_count
@@ -272,10 +272,10 @@ uint32_t get_input_bytes_frame_count(uint32_t bytes);
  * Returned Value:
  *   On success, the size of the pcm buffer for output streams. Otherwise, 0.
  ****************************************************************************/
-uint32_t get_output_frame_count(void);
+unsigned int get_output_frame_count(void);
 
 /****************************************************************************
- * Name: get_output_frames_byte_size
+ * Name: get_output_frames_to_byte
  *
  * Description:
  *   Get the byte size of the given frame value in output stream.
@@ -283,10 +283,10 @@ uint32_t get_output_frame_count(void);
  * Returned Value:
  *   On success, the byte size of the frame in output stream. Otherwise, 0.
  ****************************************************************************/
-uint32_t get_output_frames_byte_size(uint32_t frames);
+unsigned int get_output_frames_to_byte(unsigned int frames);
 
 /****************************************************************************
- * Name: get_output_bytes_frame_count
+ * Name: get_output_bytes_to_frame
  *
  * Description:
  *   Get the number of frames for the given byte size in output stream.
@@ -294,7 +294,7 @@ uint32_t get_output_frames_byte_size(uint32_t frames);
  * Returned Value:
  *   On success, the number of frames in output stream. Otherwise, 0.
  ****************************************************************************/
-uint32_t get_output_bytes_frame_count(uint32_t bytes);
+unsigned int get_output_bytes_to_frame(unsigned int bytes);
 
 /****************************************************************************
  * Name: get_audio_volume

--- a/os/drivers/audio/alc5658.c
+++ b/os/drivers/audio/alc5658.c
@@ -615,12 +615,12 @@ static int alc5658_getcaps(FAR struct audio_lowerhalf_s *dev, int type, FAR stru
 
 		switch (caps->ac_format.hw) {
 		case AUDIO_FU_VOLUME:
-			caps->ac_controls.b[0] = ALC5658_HP_VOL_MAX;
-			caps->ac_controls.b[1] = priv->volume;
+			caps->ac_controls.hw[0] = ALC5658_HP_VOL_MAX;
+			caps->ac_controls.hw[1] = priv->volume;
 			break;
 		case AUDIO_FU_INP_GAIN:
-			caps->ac_controls.b[0] = ALC5658_GAIN_MAX;
-			caps->ac_controls.b[1] = priv->gain;
+			caps->ac_controls.hw[0] = ALC5658_GAIN_MAX;
+			caps->ac_controls.hw[1] = priv->gain;
 			break;
 		default:
 			break;
@@ -1219,6 +1219,9 @@ static int alc5658_ioctl(FAR struct audio_lowerhalf_s *dev, int cmd, unsigned lo
 	case AUDIOIOC_GETBUFFERINFO: {
 		/* Report our preferred buffer size and quantity */
 		audvdbg("AUDIOIOC_GETBUFFERINFO:\n");
+		/* Take semaphore */
+		alc5658_takesem(&priv->devsem);
+		
 		bufinfo = (FAR struct ap_buffer_info_s *)arg;
 #ifdef CONFIG_AUDIO_DRIVER_SPECIFIC_BUFFERS
 		bufinfo->buffer_size = CONFIG_ALC5658_BUFFER_SIZE;
@@ -1234,6 +1237,9 @@ static int alc5658_ioctl(FAR struct audio_lowerhalf_s *dev, int cmd, unsigned lo
 			bufinfo->nbuffers = CONFIG_ALC5658_NUM_BUFFERS;
 		}
 		audvdbg("buffer_size : %d nbuffers : %d buf_size : %d\n", bufinfo->buffer_size, bufinfo->nbuffers, buf_size);
+
+		/* Give semaphore */
+		alc5658_givesem(&priv->devsem);
 #endif
 	}
 	break;


### PR DESCRIPTION
1. Sync up parameter type in audio manager same as tinyalsa & audio driver
2. fix bug of read in FileInputDataSource, to return read size properly for pcm type
3. Add semaphore in configure logic in alc5658
4. remove unneccessary state checking routine in mediaplayer