### PR TITLE
Modify Kconfig help for AUTOMOUNT_USERFS_DEVNAME

### DIFF
--- a/os/arch/arm/src/artik05x/Kconfig
+++ b/os/arch/arm/src/artik05x/Kconfig
@@ -105,6 +105,8 @@ config ARTIK05X_AUTOMOUNT_USERFS_DEVNAME
 	---help---
 		Specifies the device name (/dev/smart0pX) of the partition
 		for user r/w file system.
+		when SMARTFS_MULTI_ROOT_DIRS is enabled the device name
+		will be appended by "d1" (/dev/smart0pxd1).
 
 config ARTIK05X_AUTOMOUNT_USERFS_MOUNTPOINT
 	string "Mountpoint of the partition for user r/w file system"

--- a/os/arch/arm/src/sidk_s5jt200/Kconfig
+++ b/os/arch/arm/src/sidk_s5jt200/Kconfig
@@ -136,6 +136,8 @@ config SIDK_S5JT200_AUTOMOUNT_USERFS_DEVNAME
 	---help---
 		Specifies the device name (/dev/smart0pX) of the partition
 		for user r/w file system.
+		when SMARTFS_MULTI_ROOT_DIRS config is enabled the device name
+		will be appended by "d1" (/dev/smart0pxd1).
 
 config SIDK_S5JT200_AUTOMOUNT_USERFS_MOUNTPOINT
 	string "Mountpoint of the partition for user r/w file system"


### PR DESCRIPTION

This patch modifies Kconfig help to mention that AUTOMOUNT_USERFS_DEVNAME
will be changed when SMARTFS_MULTI_ROOT_DIRS is enabled.

Signed-off-by: Kavya <kavya.nunna@partner.samsung.com>