### PR TITLE
media/recorder : add setDuration API

### DIFF
--- a/apps/examples/mediarecorder/mediarecorder_main.cpp
+++ b/apps/examples/mediarecorder/mediarecorder_main.cpp
@@ -59,6 +59,7 @@ public:
 	void onRecordFinished(Id id)
 	{
 		std::cout << "onRecordFinished" << std::endl;
+		mr.unprepare();
 	}
 	void onRecordError(Id id)
 	{
@@ -88,7 +89,7 @@ public:
 							isPaused = false;
 						}
 					} else {
-						if (mr.prepare() == RECORDER_OK) {
+						if (mr.setDuration(2) == RECORDER_OK && mr.prepare() == RECORDER_OK) {
 							mr.start();
 							std::cout << "START IN NONE-PAUSE STATE SUCCESS" << std::endl;
 						} else {

--- a/apps/examples/testcase/ta_tc/media/utc/utc_media_fileoutputdatasource.cpp
+++ b/apps/examples/testcase/ta_tc/media/utc/utc_media_fileoutputdatasource.cpp
@@ -170,7 +170,7 @@ static void utc_media_FileOutputDataSource_write_n(void)
 	FileOutputDataSource dataSource(filePath);
 
 	dataSource.open();
-	TC_ASSERT_EQ("utc_media_FileOutputDataSource_write", dataSource.write(nullptr, 1), 0);
+	TC_ASSERT_EQ("utc_media_FileOutputDataSource_write", dataSource.write(nullptr, 1), EOF);
 	dataSource.close();
 
 	TC_SUCCESS_RESULT();

--- a/framework/include/media/MediaPlayer.h
+++ b/framework/include/media/MediaPlayer.h
@@ -64,36 +64,41 @@ public:
 	 * @since TizenRT v2.0 PRE
 	 */
 	MediaPlayer();
+	
 	/**
 	 * @brief Deconstructs an empty MediaPlayer.
 	 * @details @b #include <media/MediaPlayer.h>
 	 * @since TizenRT v2.0 PRE
 	 */
 	~MediaPlayer();
+	
 	/**
-	 * @brief Start the MediaPlayerWorker.
+	 * @brief Create the MediaPlayer for playback
 	 * @details @b #include <media/MediaPlayer.h>
 	 * This function is sync call apis
 	 * @return The result of the create operation
 	 * @since TizenRT v2.0 PRE
 	 */
 	player_result_t create();
+	
 	/**
-	 * @brief Stop the MediaPlayerWorker.
+	 * @brief Destroy MediaPlayer
 	 * @details @b #include <media/MediaPlayer.h>
 	 * This function is sync call apis
 	 * @return The result of the destroy operation
 	 * @since TizenRT v2.0 PRE
 	 */
 	player_result_t destroy();
+	
 	/**
-	 * @brief Allocate and prepare resources related to the player.
+	 * @brief Allocate and prepare resources related to the player, it should be called before start
 	 * @details @b #include <media/MediaPlayer.h>
 	 * This function is sync call apis
 	 * @return The result of the prepare operation
 	 * @since TizenRT v2.0 PRE
 	 */
 	player_result_t prepare();
+	
 	/**
 	 * @brief Releases allocated resources related to the player.
 	 * @details @b #include <media/MediaPlayer.h>
@@ -102,6 +107,7 @@ public:
 	 * @since TizenRT v2.0 PRE
 	 */
 	player_result_t unprepare();
+	
 	/**
 	 * @brief Start playback.
 	 * @details @b #include <media/MediaPlayer.h>
@@ -111,6 +117,7 @@ public:
 	 * @since TizenRT v2.0 PRE
 	 */
 	player_result_t start();
+	
 	/**
 	 * @brief Pause playback.
 	 * @details @b #include <media/MediaPlayer.h>
@@ -120,6 +127,7 @@ public:
 	 * @since TizenRT v2.0 PRE
 	 */
 	player_result_t pause();
+	
 	/**
 	 * @brief Stop playback.
 	 * @details @b #include <media/MediaPlayer.h>
@@ -129,6 +137,7 @@ public:
 	 * @since TizenRT v2.0 PRE
 	 */
 	player_result_t stop();
+	
 	/**
 	 * @brief Gets the current volume
 	 * @details @b #include <media/MediaPlayer.h>
@@ -137,6 +146,7 @@ public:
 	 * @since TizenRT v2.0 PRE
 	 */
 	int getVolume();
+	
 	/**
 	 * @brief Sets the volume adjusted
 	 * @details @b #include <media/MediaPlayer.h>
@@ -145,6 +155,7 @@ public:
 	 * @since TizenRT v2.0 PRE
 	 */
 	player_result_t setVolume(int);
+	
 	/**
 	 * @brief Sets the DatSource of input data
 	 * @details @b #include <media/MediaPlayer.h>
@@ -154,6 +165,7 @@ public:
 	 * @since TizenRT v2.0 PRE
 	 */
 	player_result_t setDataSource(std::unique_ptr<stream::InputDataSource>);
+	
 	/**
 	 * @brief Sets the observer of MediaPlayer
 	 * @details @b #include <media/MediaPlayer.h>

--- a/framework/include/media/MediaRecorder.h
+++ b/framework/include/media/MediaRecorder.h
@@ -35,6 +35,7 @@
 #include "MediaRecorderObserverInterface.h"
 
 namespace media {
+
 /**
  * @brief result of call the apis
  * @details @b #include <media/MediaRecorder.h>
@@ -64,36 +65,41 @@ public:
 	 * @since TizenRT v2.0 PRE
 	 */
 	MediaRecorder();
+	
 	/**
 	 * @brief Deconstructs an empty MediaRecorder.
 	 * @details @b #include <media/MediaRecorder.h>
 	 * @since TizenRT v2.0 PRE
 	 */
 	~MediaRecorder();
+	
 	/**
-	 * @brief Start the MediaRecorderWorker.
+	 * @brief Create MediaRecorder for capturing
 	 * @details @b #include <media/MediaRecorder.h>
 	 * This function is sync call apis
 	 * @return The result of the create operation
 	 * @since TizenRT v2.0 PRE
 	 */
 	recorder_result_t create();
+	
 	/**
-	 * @brief Stop the MediaRecorderWorker.
+	 * @brief Destroy MediaRecorder
 	 * @details @b #include <media/MediaRecorder.h>
 	 * This function is sync call apis
 	 * @return The result of the destroy operation
 	 * @since TizenRT v2.0 PRE
 	 */
 	recorder_result_t destroy();
+	
 	/**
-	 * @brief Allocate and prepare resources related to the recorder.
+	 * @brief Allocate and prepare resources related to the recorder, it should be called before start
 	 * @details @b #include <media/MediaRecorder.h>
 	 * This function is sync call apis
 	 * @return The result of the prepare operation
 	 * @since TizenRT v2.0 PRE
 	 */
 	recorder_result_t prepare();
+	
 	/**
 	 * @brief Releases allocated resources related to the recorder.
 	 * @details @b #include <media/MediaRecorder.h>
@@ -102,6 +108,7 @@ public:
 	 * @since TizenRT v2.0 PRE
 	 */
 	recorder_result_t unprepare();
+	
 	/**
 	 * @brief Start recording.
 	 * @details @b #include <media/MediaRecorder.h>
@@ -111,6 +118,7 @@ public:
 	 * @since TizenRT v2.0 PRE
 	 */
 	recorder_result_t start();
+	
 	/**
 	 * @brief Pause recording.
 	 * @details @b #include <media/MediaRecorder.h>
@@ -120,6 +128,7 @@ public:
 	 * @since TizenRT v2.0 PRE
 	 */
 	recorder_result_t pause();
+	
 	/**
 	 * @brief Stop recording.
 	 * @details @b #include <media/MediaRecorder.h>
@@ -129,6 +138,7 @@ public:
 	 * @since TizenRT v2.0 PRE
 	 */
 	recorder_result_t stop();
+	
 	/**
 	 * @brief Gets the current volume
 	 * @details @b #include <media/MediaRecorder.h>
@@ -137,6 +147,7 @@ public:
 	 * @since TizenRT v2.0 PRE
 	 */
 	int getVolume();
+	
 	/**
 	 * @brief Sets the volume adjusted
 	 * @details @b #include <media/MediaRecorder.h>
@@ -146,6 +157,7 @@ public:
 	 * @since TizenRT v2.0 PRE
 	 */
 	recorder_result_t setVolume(int vol);
+	
 	/**
 	 * @brief Sets the DatSource of output data
 	 * @details @b #include <media/MediaRecorder.h>
@@ -155,6 +167,7 @@ public:
 	 * @since TizenRT v2.0 PRE
 	 */
 	recorder_result_t setDataSource(std::unique_ptr<stream::OutputDataSource> dataSource);
+	
 	/**
 	 * @brief Sets the observer of MediaRecorder
 	 * @details @b #include <media/MediaRecorder.h>
@@ -164,6 +177,18 @@ public:
 	 * @since TizenRT v2.0 PRE
 	 */
 	recorder_result_t setObserver(std::shared_ptr<MediaRecorderObserverInterface> observer);
+
+	/**
+	 * @brief Set limitation of recording time by given value(second), will be stopped when it reaches that.
+	 * This should be called after create but before prepare
+	 * @details @b #include <media/MediaRecorder.h>
+	 * This function is sync call apis
+	 * It sets the user's function
+ 	 * @param[in] Max duration(second), No limitation If zero or negative.
+	 * @return The result of setting the duration
+	 * @since TizenRT v2.0 PRE
+	 */
+	recorder_result_t setDuration(int second);
 
 private:
 	std::shared_ptr<MediaRecorderImpl> mPMrImpl;

--- a/framework/src/media/FileInputDataSource.cpp
+++ b/framework/src/media/FileInputDataSource.cpp
@@ -117,8 +117,8 @@ ssize_t FileInputDataSource::read(unsigned char *buf, size_t size)
 	std::shared_ptr<Decoder> decoder = getDecoder();
 
 	if (!buf) {
-		meddbg("buf is nullptr, hence return 0\n");
-		return 0;
+		meddbg("buf is nullptr, hence return EOF\n");
+		return EOF;
 	}
 
 	if (decoder) {

--- a/framework/src/media/FileOutputDataSource.cpp
+++ b/framework/src/media/FileOutputDataSource.cpp
@@ -91,11 +91,17 @@ bool FileOutputDataSource::isPrepare()
 ssize_t FileOutputDataSource::write(unsigned char* buf, size_t size)
 {
 	if (!buf) {
-		meddbg("buf is nullptr, hence return 0\n");
-		return (size_t)0;
+		meddbg("buf is nullptr, hence return EOF\n");
+		return EOF;
 	}
-
-	return fwrite(buf, sizeof(unsigned char), size, mFp);
+	
+	size_t ret;
+	ret = fwrite(buf, sizeof(unsigned char), size, mFp);
+	if (ret == 0 && ferror(mFp)) {
+		meddbg("Error : %d\n", errno);
+		return EOF;
+	}
+	return ret;
 }
 
 FileOutputDataSource::~FileOutputDataSource()

--- a/framework/src/media/MediaRecorder.cpp
+++ b/framework/src/media/MediaRecorder.cpp
@@ -80,6 +80,11 @@ recorder_result_t MediaRecorder::setObserver(std::shared_ptr<MediaRecorderObserv
 	return mPMrImpl->setObserver(observer);
 }
 
+recorder_result_t MediaRecorder::setDuration(int second)
+{
+	return mPMrImpl->setDuration(second);
+}
+
 MediaRecorder::~MediaRecorder()
 {
 }

--- a/framework/src/media/MediaRecorderImpl.cpp
+++ b/framework/src/media/MediaRecorderImpl.cpp
@@ -24,7 +24,8 @@
 
 namespace media {
 MediaRecorderImpl::MediaRecorderImpl()
-	: mCurState(RECORDER_STATE_NONE), mOutputDataSource(nullptr), mRecorderObserver(nullptr), mBuffer(nullptr), mBuffSize(0)
+	: mCurState(RECORDER_STATE_NONE), mOutputDataSource(nullptr), mRecorderObserver(nullptr), mBuffer(nullptr), mBuffSize(0),
+	mDuration(0), mTotalFrames(0), mCapturedFrames(0)
 {
 	medvdbg("MediaRecorderImpl::MediaRecorderImpl()\n");
 	static int recorderId = 1;
@@ -168,6 +169,10 @@ void MediaRecorderImpl::prepareRecorder(recorder_result_t& ret)
 		return notifySync();
 	}
 
+	if (mDuration > 0) {
+		mTotalFrames = mDuration * mOutputDataSource->getSampleRate();
+	}
+	
 	mCurState = RECORDER_STATE_READY;
 	ret = RECORDER_OK;
 	notifySync();
@@ -212,7 +217,10 @@ void MediaRecorderImpl::unprepareRecorder(recorder_result_t& ret)
 	}
 
 	mBuffSize = 0;
-
+	mDuration = 0;
+	mTotalFrames = 0;
+	mCapturedFrames = 0;
+	
 	mCurState = RECORDER_STATE_IDLE;
 	ret = RECORDER_OK;
 	notifySync();
@@ -475,21 +483,82 @@ void MediaRecorderImpl::setRecorderObserver(std::shared_ptr<MediaRecorderObserve
 	notifySync();
 }
 
+recorder_result_t MediaRecorderImpl::setDuration(int second)
+{
+	std::unique_lock<std::mutex> lock(mCmdMtx);
+
+	medvdbg("MediaRecorderImpl::setDuration()\n");
+	RecorderWorker& mrw = RecorderWorker::getWorker();
+	if (!mrw.isAlive()) {
+		meddbg("Worker is not alive\n");
+		return RECORDER_ERROR;
+	}
+
+	recorder_result_t ret = RECORDER_ERROR;
+	mrw.enQueue(&MediaRecorderImpl::setRecorderDuration, shared_from_this(), second, std::ref(ret));
+	mSyncCv.wait(lock);
+
+	return ret;
+}
+
+void MediaRecorderImpl::setRecorderDuration(int second, recorder_result_t& ret)
+{
+	medvdbg("setRecorderDuration mCurState : %d\n", (recorder_state_t)mCurState);
+
+	if (mCurState != RECORDER_STATE_IDLE) {
+		meddbg("setRecorderDuration Failed mCurState: %d\n", (recorder_state_t)mCurState);
+		return notifySync();
+	}
+	if (second > 0) {
+		medvdbg("second is greater than zero, set limit : %d\n", second);
+		mDuration = second;
+	}
+
+	ret = RECORDER_OK;
+	notifySync();
+}
+
 void MediaRecorderImpl::capture()
 {
 	medvdbg("MediaRecorderImpl::capture()\n");
-	int frames = start_audio_stream_in(mBuffer, get_input_frame_count());
+	unsigned int frameSize = get_input_frame_count();
 
+	if (mTotalFrames > 0) {
+		int64_t remainFrames = mTotalFrames - mCapturedFrames;
+		/* almost reaches size limit, adjust frame size before request capture to audio_manager */
+		if (remainFrames < frameSize) {
+			frameSize = remainFrames;
+		}
+	}
+	
+	int frames = start_audio_stream_in(mBuffer, frameSize);
 	if (frames > 0) {
-		int size = get_input_frames_to_byte(frames);
-
+		mCapturedFrames += frames;
+		if (mCapturedFrames > INT_MAX) {
+			mCapturedFrames = 0;
+			meddbg("Too huge value : %d, set 0 to prevent overflow\n", mCapturedFrames);
+		}
+		
 		int ret = 0;
+		int size = get_input_frames_to_byte(frames);
+		
 		while (size > 0) {
 			int written = mOutputDataSource->write(mBuffer + ret, size);
-			if (written <= 0) {
+			medvdbg("written : %d size : %d frames : %d\n", written, size, frames);
+			medvdbg("mCapturedFrames : %ld totalduration : %d mTotalFrames : %ld\n", mCapturedFrames, mDuration, mTotalFrames);
+			/* For Error case, we stop Capture */
+			if (written == EOF) {
 				meddbg("MediaRecorderImpl::capture() failed : errno : %d written : %d\n", errno, written);
 				RecorderWorker& mrw = RecorderWorker::getWorker();
 				mrw.enQueue(&MediaRecorderImpl::stopRecorder, shared_from_this(), false);
+				break;
+			}
+
+			/* It finished Successfully refer to file size or frame numbers*/
+			if ((written == 0) || (mTotalFrames == mCapturedFrames)) {
+				medvdbg("File write Ended\n");
+				RecorderWorker& mrw = RecorderWorker::getWorker();
+				mrw.enQueue(&MediaRecorderImpl::stopRecorder, shared_from_this(), true);
 				break;
 			}
 			size -= written;

--- a/framework/src/media/MediaRecorderImpl.h
+++ b/framework/src/media/MediaRecorderImpl.h
@@ -81,6 +81,7 @@ public:
 	recorder_result_t setDataSource(std::unique_ptr<stream::OutputDataSource> dataSource);
 	recorder_state_t getState();
 	recorder_result_t setObserver(std::shared_ptr<MediaRecorderObserverInterface> observer);
+	recorder_result_t setDuration(int second);
 	void notifySync();
 	void notifyObserver(observer_command_t cmd);
 	void capture();
@@ -97,6 +98,7 @@ private:
 	void setRecorderVolume(int vol, recorder_result_t& ret);
 	void setRecorderObserver(std::shared_ptr<MediaRecorderObserverInterface> observer);
 	void setRecorderDataSource(std::shared_ptr<stream::OutputDataSource> dataSource, recorder_result_t& ret);
+	void setRecorderDuration(int second, recorder_result_t& ret);
 
 private:
 	std::atomic<recorder_state_t> mCurState;
@@ -108,6 +110,9 @@ private:
 	mutex mCmdMtx; // command mutex
 	std::condition_variable mSyncCv;
 	int mId;
+	int mDuration;
+	uint32_t mTotalFrames;
+	uint32_t mCapturedFrames;
 };
 } // namespace media
 


### PR DESCRIPTION
1. Apply setDuration API to make limitation of duration
2. Clean each api's reference
3. return EOF if buffer is null when write or read in datasource