### PR TITLE
media: Fix build error on linux

### DIFF
--- a/framework/src/media/FileInputDataSource.cpp
+++ b/framework/src/media/FileInputDataSource.cpp
@@ -16,9 +16,11 @@
  *
  ******************************************************************/
 
+#include <stdio.h>
+#include <debug.h>
+
 #include <media/FileInputDataSource.h>
 #include "utils/MediaUtils.h"
-#include <debug.h>
 #include "Decoder.h"
 
 namespace media {

--- a/framework/src/media/FileOutputDataSource.cpp
+++ b/framework/src/media/FileOutputDataSource.cpp
@@ -16,8 +16,8 @@
  *
  ******************************************************************/
 
+#include <stdio.h>
 #include <debug.h>
-
 #include <media/FileOutputDataSource.h>
 
 namespace media {

--- a/framework/src/media/MediaQueue.h
+++ b/framework/src/media/MediaQueue.h
@@ -24,6 +24,7 @@
 #include <queue>
 #include <atomic>
 #include <iostream>
+#include <functional>
 
 namespace media {
 class MediaQueue

--- a/framework/src/media/SocketOutputDataSource.cpp
+++ b/framework/src/media/SocketOutputDataSource.cpp
@@ -73,7 +73,7 @@ bool SocketOutputDataSource::open()
 
 	if (connect(mSockFd, (struct sockaddr *)&serveraddr, addrlen) < 0) {
 		meddbg("Errro: Fail to connect socket (errno=%d)\n", errno);
-		closesocket(mSockFd);
+		::close(mSockFd);
 		return false;
 	}
 
@@ -84,7 +84,7 @@ bool SocketOutputDataSource::open()
 
 bool SocketOutputDataSource::close()
 {
-	if ((mSockFd != INVALID_SOCKET) && closesocket(mSockFd) != EOF) {
+	if ((mSockFd != INVALID_SOCKET) && ::close(mSockFd) != EOF) {
 		mSockFd = INVALID_SOCKET;
 		return true;
 	}


### PR DESCRIPTION
MediaFramework should be built on TizenRT and Linux both.
Linux build is more strict than TizenRT.