### PR TITLE
Fix problem with up_progmem_ispageerased on s5j

### DIFF
--- a/os/arch/arm/src/s5j/s5j_sflash.c
+++ b/os/arch/arm/src/s5j/s5j_sflash.c
@@ -149,8 +149,8 @@ ssize_t up_progmem_ispageerased(size_t page)
 
 	bwritten = 0;
 	addr = up_progmem_getaddress(page);
-	for (count = up_progmem_pagesize(page); count; count--) {
-		if (getreg32(addr) != 0xffffff) {
+	for (count = (up_progmem_pagesize(page)/sizeof(int)); count; count--) {
+		if (getreg32(addr) != 0xffffffff) {
 			bwritten++;
 		}
 		addr += sizeof(int);


### PR DESCRIPTION
The implementation of the up_progmem_ispageerased() function checked for changes in 4 pages instead of just one. This could return false results. It also checks against the wrong erased flash value (correct is all 0xFFFFFFFF).