### PR TITLE
iotivity/Kconfig: Add the dependency of iotivity security

### DIFF
--- a/external/iotivity/Kconfig
+++ b/external/iotivity/Kconfig
@@ -61,6 +61,7 @@ config IOTIVITY_RECEIVEHANDLER_PTHREAD_STACKSIZE
 config ENABLE_IOTIVITY_SECURED
 	bool "enable iotivity security"
 	default n
+	select NET_SECURITY_TLS
 	---help---
 		select to enable the security for iotivity stack in tinyara
 


### PR DESCRIPTION
- NET_SECURITY_TLS is needed to use tls in iotivity.