### PR TITLE
framework/media : Change header from absolute reference to relative r…

### DIFF
--- a/framework/include/media/MediaRecorder.h
+++ b/framework/include/media/MediaRecorder.h
@@ -32,7 +32,7 @@
 
 #include <memory>
 #include <media/OutputDataSource.h>
-#include "MediaRecorderObserverInterface.h"
+#include <media/MediaRecorderObserverInterface.h>
 
 namespace media {
 


### PR DESCRIPTION
…eference

- Because MediaRecorderObserverInterface.h is a public header file, it changes to a relative reference