### PR TITLE
framework/task_manager: fix compilation warnings of missing header

### DIFF
--- a/framework/src/task_manager/task_manager_core.c
+++ b/framework/src/task_manager/task_manager_core.c
@@ -29,6 +29,7 @@
 #include <errno.h>
 #include <debug.h>
 #include <sys/types.h>
+#include <sys/ioctl.h>
 #include <apps/builtin.h>
 #include <tinyara/fs/ioctl.h>
 #include <tinyara/task_manager_drv.h>

--- a/framework/src/task_manager/task_manager_internal.h
+++ b/framework/src/task_manager/task_manager_internal.h
@@ -19,6 +19,7 @@
 #ifndef __TASK_MANAGER_INTERNAL_H__
 #define __TASK_MANAGER_INTERNAL_H__
 
+#include <stdlib.h>
 #include <stdbool.h>
 #include <unistd.h>
 

--- a/framework/src/task_manager/task_manager_state.c
+++ b/framework/src/task_manager/task_manager_state.c
@@ -18,8 +18,9 @@
 /****************************************************************************
  * Included Files
  ****************************************************************************/
-#include <sys/types.h>
 #include <stdio.h>
+#include <sys/types.h>
+#include <sys/ioctl.h>
 #include <tinyara/fs/ioctl.h>
 #include <task_manager/task_manager.h>
 #include "task_manager_internal.h"


### PR DESCRIPTION
1. Include <stdlib.h> to use malloc() and free()
2. Include <sys/ioctl.h> to use ioctl()

CC:  src/task_manager/task_manager_register.c
In file included from src/task_manager/task_manager_register.c:26:0:
src/task_manager/task_manager_register.c: In function 'task_manager_register':
src/task_manager/task_manager_internal.h:47:22: warning: implicit declaration of function 'malloc' [-Wimplicit-function-declaration]
 #define TM_ALLOC(a)  malloc(a)
                      ^
src/task_manager/task_manager_register.c:45:29: note: in expansion of macro 'TM_ALLOC'
  request_msg.data = (void *)TM_ALLOC(strlen(name) + 1);
                             ^~~~~~~~
src/task_manager/task_manager_internal.h:48:22: warning: implicit declaration of function 'free' [-Wimplicit-function-declaration]
 #define TM_FREE(a)   free(a)
                      ^
src/task_manager/task_manager_register.c:55:4: note: in expansion of macro 'TM_FREE'
    TM_FREE(request_msg.data);
    ^~~~~~~
CC:  src/task_manager/task_manager_unregister.c
In file included from src/task_manager/task_manager_unregister.c:26:0:
src/task_manager/task_manager_unregister.c: In function 'task_manager_unregister':
src/task_manager/task_manager_internal.h:48:22: warning: implicit declaration of function 'free' [-Wimplicit-function-declaration]
 #define TM_FREE(a)   free(a)
                      ^
src/task_manager/task_manager_unregister.c:57:4: note: in expansion of macro 'TM_FREE'
    TM_FREE(request_msg.q_name);
    ^~~~~~~
CC:  src/task_manager/task_manager_start.c
In file included from src/task_manager/task_manager_start.c:26:0:
src/task_manager/task_manager_start.c: In function 'task_manager_start':
src/task_manager/task_manager_internal.h:48:22: warning: implicit declaration of function 'free' [-Wimplicit-function-declaration]
 #define TM_FREE(a)   free(a)
                      ^
src/task_manager/task_manager_start.c:58:4: note: in expansion of macro 'TM_FREE'
    TM_FREE(request_msg.q_name);
    ^~~~~~~
CC:  src/task_manager/task_manager_terminate.c
In file included from src/task_manager/task_manager_terminate.c:26:0:
src/task_manager/task_manager_terminate.c: In function 'task_manager_terminate':
src/task_manager/task_manager_internal.h:48:22: warning: implicit declaration of function 'free' [-Wimplicit-function-declaration]
 #define TM_FREE(a)   free(a)
                      ^
src/task_manager/task_manager_terminate.c:58:4: note: in expansion of macro 'TM_FREE'
    TM_FREE(request_msg.q_name);
    ^~~~~~~
CC:  src/task_manager/task_manager_restart.c
In file included from src/task_manager/task_manager_restart.c:26:0:
src/task_manager/task_manager_restart.c: In function 'task_manager_restart':
src/task_manager/task_manager_internal.h:48:22: warning: implicit declaration of function 'free' [-Wimplicit-function-declaration]
 #define TM_FREE(a)   free(a)
                      ^
src/task_manager/task_manager_restart.c:57:4: note: in expansion of macro 'TM_FREE'
    TM_FREE(request_msg.q_name);
    ^~~~~~~
CC:  src/task_manager/task_manager_pause.c
In file included from src/task_manager/task_manager_pause.c:26:0:
src/task_manager/task_manager_pause.c: In function 'task_manager_pause':
src/task_manager/task_manager_internal.h:48:22: warning: implicit declaration of function 'free' [-Wimplicit-function-declaration]
 #define TM_FREE(a)   free(a)
                      ^
src/task_manager/task_manager_pause.c:57:4: note: in expansion of macro 'TM_FREE'
    TM_FREE(request_msg.q_name);
    ^~~~~~~
CC:  src/task_manager/task_manager_resume.c
In file included from src/task_manager/task_manager_resume.c:26:0:
src/task_manager/task_manager_resume.c: In function 'task_manager_resume':
src/task_manager/task_manager_internal.h:48:22: warning: implicit declaration of function 'free' [-Wimplicit-function-declaration]
 #define TM_FREE(a)   free(a)
                      ^
src/task_manager/task_manager_resume.c:58:4: note: in expansion of macro 'TM_FREE'
    TM_FREE(request_msg.q_name);
    ^~~~~~~
CC:  src/task_manager/task_manager_getinfo.c
In file included from src/task_manager/task_manager_getinfo.c:26:0:
src/task_manager/task_manager_getinfo.c: In function 'task_manager_getinfo_with_name':
src/task_manager/task_manager_internal.h:47:22: warning: implicit declaration of function 'malloc' [-Wimplicit-function-declaration]
 #define TM_ALLOC(a)  malloc(a)
                      ^
src/task_manager/task_manager_getinfo.c:45:29: note: in expansion of macro 'TM_ALLOC'
  request_msg.data = (void *)TM_ALLOC(strlen(name) + 1);
                             ^~~~~~~~
src/task_manager/task_manager_internal.h:48:22: warning: implicit declaration of function 'free' [-Wimplicit-function-declaration]
 #define TM_FREE(a)   free(a)
                      ^
src/task_manager/task_manager_getinfo.c:54:3: note: in expansion of macro 'TM_FREE'
   TM_FREE(request_msg.data);
   ^~~~~~~
CC:  src/task_manager/task_manager_unicast.c
In file included from src/task_manager/task_manager_unicast.c:26:0:
src/task_manager/task_manager_unicast.c: In function 'task_manager_unicast':
src/task_manager/task_manager_internal.h:47:22: warning: implicit declaration of function 'malloc' [-Wimplicit-function-declaration]
 #define TM_ALLOC(a)  malloc(a)
                      ^
src/task_manager/task_manager_unicast.c:46:30: note: in expansion of macro 'TM_ALLOC'
   request_msg.data = (void *)TM_ALLOC(msg_size);
                              ^~~~~~~~
src/task_manager/task_manager_internal.h:48:22: warning: implicit declaration of function 'free' [-Wimplicit-function-declaration]
 #define TM_FREE(a)   free(a)
                      ^
src/task_manager/task_manager_unicast.c:62:4: note: in expansion of macro 'TM_FREE'
    TM_FREE(request_msg.data);
    ^~~~~~~
CC:  src/task_manager/task_manager_cleaninfo.c
In file included from src/task_manager/task_manager_cleaninfo.c:23:0:
src/task_manager/task_manager_cleaninfo.c: In function 'task_manager_clean_info':
src/task_manager/task_manager_internal.h:48:22: warning: implicit declaration of function 'free' [-Wimplicit-function-declaration]
 #define TM_FREE(a)   free(a)
                      ^
src/task_manager/task_manager_cleaninfo.c:35:3: note: in expansion of macro 'TM_FREE'
   TM_FREE((*info)->name);
   ^~~~~~~
CC:  src/task_manager/task_manager_set_callback.c
CC:  src/task_manager/task_manager_state.c
src/task_manager/task_manager_state.c: In function 'taskmgr_update_task_state':
src/task_manager/task_manager_state.c:40:8: warning: implicit declaration of function 'ioctl' [-Wimplicit-function-declaration]
  ret = ioctl(fd, TMIOC_CHECK_ALIVE, TASK_PID(handle));
        ^~~~~
CC:  src/task_manager/task_manager_permission.c
CC:  src/task_manager/task_manager_core.c
src/task_manager/task_manager_core.c: In function 'taskmgr_start':
src/task_manager/task_manager_core.c:207:8: warning: implicit declaration of function 'ioctl' [-Wimplicit-function-declaration]
  ret = ioctl(fd, TMIOC_START, pid);
        ^~~~~
CC:  src/task_manager/task_manager_interface.c
CC:  src/task_manager/task_manager_broadcast.c
In file included from src/task_manager/task_manager_broadcast.c:24:0:
src/task_manager/task_manager_broadcast.c: In function 'task_manager_broadcast':
src/task_manager/task_manager_internal.h:47:22: warning: implicit declaration of function 'malloc' [-Wimplicit-function-declaration]
 #define TM_ALLOC(a)  malloc(a)
                      ^
src/task_manager/task_manager_broadcast.c:42:29: note: in expansion of macro 'TM_ALLOC'
  request_msg.data = (void *)TM_ALLOC(sizeof(int));
                             ^~~~~~~~
src/task_manager/task_manager_internal.h:48:22: warning: implicit declaration of function 'free' [-Wimplicit-function-declaration]
 #define TM_FREE(a)   free(a)
                      ^
src/task_manager/task_manager_broadcast.c:50:3: note: in expansion of macro 'TM_FREE'
   TM_FREE(request_msg.data);
   ^~~~~~~

Signed-off-by: sunghan-chang <sh924.chang@samsung.com>