### PR TITLE
testcase/kernel/misc: add usleep() before testing lib_dumpbuffer()

### DIFF
--- a/apps/examples/testcase/le_tc/kernel/tc_libc_misc.c
+++ b/apps/examples/testcase/le_tc/kernel/tc_libc_misc.c
@@ -365,6 +365,9 @@ static void tc_libc_misc_lib_dumpbuffer(void)
 	unsigned char *buf = NULL;
 	int idx;
 
+	/* To guarantee flushing other printf messages before using lowsyslog */
+	usleep(10);
+
 	/**
 	 * As lib_dumpbuffer returns void, there in no way to check the success or failure case
 	 * we need to manually check the dump output


### PR DESCRIPTION
The lib_dumpbuffer() uses lowsyslog so that serial logs can be
a mess. Let's add usleep() before testing it.

[tc_libc_misc_crc16part] PASS
_c_tl_liic_misb_crcc_miscSS
ltcilibc__iscdcru32mpbt]uffer (401_lb2c5mc8):
g: 000mple0
[t: lib53mis4_d14] d5SS3554e472d54697a656e5254                                    SAMSUNG-TizenRT
tc_libc_misc_lib_dumpbuffer (401b2640):
0000: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a ................ ................