### PR TITLE
os: Define wint_t in types.h

### DIFF
--- a/os/include/sys/types.h
+++ b/os/include/sys/types.h
@@ -128,8 +128,6 @@
 typedef unsigned long __kernel_size_t;
 
 #ifdef CONFIG_ENABLE_IOTIVITY
-
-typedef int wint_t;
 typedef unsigned short __kernel_sa_family_t;
 typedef unsigned short __u16;
 

--- a/os/include/wchar.h
+++ b/os/include/wchar.h
@@ -66,6 +66,7 @@
 
 #include <stdio.h>
 #include <stddef.h>
+#include <sys/types.h>
 
 /****************************************************************************
  * Pre-processor Definitions


### PR DESCRIPTION
Observed issue while building iotivity-constrained:

  arm-none-eabi-gcc -c -o obj/cborencoder.o (...)
  In file included from
  .../gcc-arm-none-eabi-6-2017-q1-update/.../reent.h:15:0,
  from
  .../arm-none-eabi/include/math.h:5,
  from ../../deps/tinycbor/src/compilersupport_p.h:40,
  .../sys/_types.h:168:5: error: unknown type name 'wint_t'
  wint_t __wch;

Bug: https://jira.iotivity.org/projects/LITE/issues/LITE-4
Change-Id: I328e902ad4320f4772af3b802e1fbea8239f5c61
Signed-off-by: Philippe Coval <p.coval@samsung.com>