### PR TITLE
framework/st_things: Fix bug for mnid, vid value

### DIFF
--- a/framework/src/st_things/things_stack/framework/things_data_manager.c
+++ b/framework/src/st_things/things_stack/framework/things_data_manager.c
@@ -1477,29 +1477,32 @@ static int parse_device_json(cJSON *device)
 			cJSON *model_number = cJSON_GetObjectItem(spec_platform, KEY_DEVICE_SPECIFICATION_PLATFORM_MODELNUMBER);
 			cJSON *firmware_version = cJSON_GetObjectItem(spec_platform, KEY_DEVICE_SPECIFICATION_PLATFORM_FIRMWAREVERSION);
 			cJSON *vid = cJSON_GetObjectItem(spec_platform, KEY_DEVICE_SPECIFICATION_PLATFORM_VID);
-			
+
 			if (mnid == NULL) {
 				mnid = cJSON_GetObjectItem(spec_platform, KEY_DEVICE_SPECIFICATION_PLATFORM_MANUFACTURERNAME); // Backward compatibility for existing published IDEs
 				if (mnid == NULL) {
 					goto JSON_ERROR;
 				}
+			}
 
-				if (strlen(mnid->valuestring) != 4) {
-					THINGS_LOG_V(TAG, "MNID exceeds 4 bytes. please check (4 bytes are fixed sizes.)");
-					goto JSON_ERROR;
-				}
+			if (strlen(mnid->valuestring) != 4) {
+				THINGS_LOG_V(TAG, "MNID exceeds 4 bytes. please check (4 bytes are fixed sizes.)");
+				goto JSON_ERROR;
+			}
 
-				g_device->mnid = (char *) things_malloc(sizeof(char) * (strlen(mnid->valuestring) + 1));
-				strncpy(g_device->mnid, mnid->valuestring, strlen(mnid->valuestring) + 1);
-			}			
+			g_device->mnid = (char *) things_malloc(sizeof(char) * (strlen(mnid->valuestring) + 1));
+			strncpy(g_device->mnid, mnid->valuestring, strlen(mnid->valuestring) + 1);
+
 			if (vid == NULL) {
 				vid = cJSON_GetObjectItem(spec_platform, KEY_DEVICE_SPECIFICATION_PLATFORM_VENDORID); // Backward compatibility for existing published IDEs
 				if (vid == NULL) {
 					goto JSON_ERROR;
 				}
-				g_device->vid = (char *) things_malloc(sizeof(char) * (strlen(vid->valuestring) + 1));
-				strncpy(g_device->vid, vid->valuestring, strlen(vid->valuestring) + 1);
 			}
+
+			g_device->vid = (char *) things_malloc(sizeof(char) * (strlen(vid->valuestring) + 1));
+			strncpy(g_device->vid, vid->valuestring, strlen(vid->valuestring) + 1);
+
 			if (manufacturer_url != NULL) {
 				g_device->manufacturer_url = (char *) things_malloc(sizeof(char) * (strlen(manufacturer_url->valuestring) + 1));
 				strncpy(g_device->manufacturer_url, manufacturer_url->valuestring, strlen(manufacturer_url->valuestring) + 1);


### PR DESCRIPTION
This patch fix mnid and vid setting bugs. When loading device
information from device_def.json, the mnid and vid are not stored to
variables due to invalid NULL check logic.

For example, if mnid is not NULL, copy mnid->valuestring to
g_device->mnid is not work. The vid also same.

Signed-off-by: Inho Oh <webispy@gmail.com>