### PR TITLE
Static object reset & handle atexit/onexit registration dynamically

### DIFF
--- a/lib/libxx/libxx_cxa_atexit.cxx
+++ b/lib/libxx/libxx_cxa_atexit.cxx
@@ -59,6 +59,7 @@
 #include <cassert>
 
 #include "libxx_internal.hxx"
+#include "libxx_cxa_guard.hxx"
 
 //***************************************************************************
 // Pre-processor Definitions
@@ -91,6 +92,24 @@ extern "C"
   //*************************************************************************
 
   //*************************************************************************
+  // Name: __cxa_guard_reset
+  // Description : This function is to support resetting the static object
+  // 	after destruction. So that Static object can be instantiated again
+  //*************************************************************************
+
+  static void __cxa_guard_reset(void *__pstatic)
+  {
+    // Get to the guard pointer:
+    // if __ARM_EABI__, then -32 bytes from the object otherwise -64 bytes
+    __guard *g = (__guard *)__pstatic - 1;
+#ifdef __ARM_EABI__
+    *g = 0;
+#else
+    *(char *)g = 0;
+#endif
+  }
+
+  //*************************************************************************
   // Name: __cxa_callback
   //
   // Description:
@@ -107,6 +126,7 @@ extern "C"
     DEBUGASSERT(alloc && alloc->func);
 
     alloc->func(alloc->arg);
+    __cxa_guard_reset(alloc->arg);
     lib_free(alloc);
   }
 #endif

--- a/lib/libxx/libxx_cxa_guard.cxx
+++ b/lib/libxx/libxx_cxa_guard.cxx
@@ -54,30 +54,7 @@
 // Included Files
 //***************************************************************************
 
-#include <tinyara/compiler.h>
-
-//***************************************************************************
-// Pre-processor Definitions
-//***************************************************************************
-
-//***************************************************************************
-// Private Types
-//***************************************************************************
-
-#ifdef __ARM_EABI__
-// The 32-bit ARM C++ ABI specifies that the guard is a 32-bit
-// variable and the least significant bit contains 0 prior to
-// initialization, and 1 after.
-
-typedef int __guard;
-
-#else
-// The "standard" C++ ABI specifies that the guard is a 64-bit
-// variable and the first byte contains 0 prior to initialization, and
-// 1 after.
-
-__extension__ typedef int __guard __attribute__((mode(__DI__)));
-#endif
+#include "libxx_cxa_guard.hxx"
 
 //***************************************************************************
 // Private Data

--- a/lib/libxx/libxx_cxa_guard.hxx
+++ b/lib/libxx/libxx_cxa_guard.hxx
@@ -1,0 +1,46 @@
+/****************************************************************************
+ *
+ * Copyright 2018 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+//***************************************************************************
+// Included Files
+//***************************************************************************
+
+#include <tinyara/compiler.h>
+
+//***************************************************************************
+// Pre-processor Definitions
+//***************************************************************************
+
+//***************************************************************************
+// Private Types
+//***************************************************************************
+
+#ifdef __ARM_EABI__
+// The 32-bit ARM C++ ABI specifies that the guard is a 32-bit
+// variable and the least significant bit contains 0 prior to
+// initialization, and 1 after.
+
+typedef int __guard;
+
+#else
+// The "standard" C++ ABI specifies that the guard is a 64-bit
+// variable and the first byte contains 0 prior to initialization, and
+// 1 after.
+
+__extension__ typedef int __guard __attribute__((mode(__DI__)));
+#endif

--- a/os/include/tinyara/sched.h
+++ b/os/include/tinyara/sched.h
@@ -361,23 +361,12 @@ struct task_group_s {
 #if defined(CONFIG_SCHED_ATEXIT) && !defined(CONFIG_SCHED_ONEXIT)
 	/* atexit support *********************************************************** */
 
-#if defined(CONFIG_SCHED_ATEXIT_MAX) && CONFIG_SCHED_ATEXIT_MAX > 1
-	atexitfunc_t tg_atexitfunc[CONFIG_SCHED_ATEXIT_MAX];
-#else
-	atexitfunc_t tg_atexitfunc;	/* Called when exit is called.             */
-#endif
+	dq_queue_t tg_atexitfunc;
 #endif
 
 #ifdef CONFIG_SCHED_ONEXIT
 	/* on_exit support ********************************************************** */
-
-#if defined(CONFIG_SCHED_ONEXIT_MAX) && CONFIG_SCHED_ONEXIT_MAX > 1
-	onexitfunc_t tg_onexitfunc[CONFIG_SCHED_ONEXIT_MAX];
-	FAR void *tg_onexitarg[CONFIG_SCHED_ONEXIT_MAX];
-#else
-	onexitfunc_t tg_onexitfunc;	/* Called when exit is called.             */
-	FAR void *tg_onexitarg;		/* The argument passed to the function     */
-#endif
+	dq_queue_t tg_onexitfunc;
 #endif
 
 #if defined(CONFIG_SCHED_HAVE_PARENT) && defined(CONFIG_SCHED_CHILD_STATUS)

--- a/os/include/unistd.h
+++ b/os/include/unistd.h
@@ -74,12 +74,6 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-/* The number of functions that may be registered to be called
- * at program exit.
- */
-
-#define ATEXIT_MAX 1
-
 /* Values for seeking */
 
 #define SEEK_SET    0			/* From the start of the file */

--- a/os/kernel/Kconfig
+++ b/os/kernel/Kconfig
@@ -727,38 +727,11 @@ config SCHED_ATEXIT
 	---help---
 		Enables the atexit() API
 
-config SCHED_ATEXIT_MAX
-	int "Max number of atexit() functions"
-	default 1
-	depends on SCHED_ATEXIT && !SCHED_ONEXIT
-	---help---
-		By default if SCHED_ATEXIT is selected, only a single atexit() function
-		is supported. That number can be increased by defined this setting to
-		the number that you require.
-
-		If both SCHED_ONEXIT and SCHED_ATEXIT are selected, then atexit() is built
-		on top of the on_exit() implementation.  In that case, SCHED_ONEXIT_MAX
-		determines the size of the combined number of atexit(0) and on_exit calls
-		and SCHED_ATEXIT_MAX is not used.
-
 config SCHED_ONEXIT
 	bool "Enable on_exit() API"
 	default n
 	---help---
 		Enables the on_exit() API
-
-config SCHED_ONEXIT_MAX
-	int "Max number of on_exit() functions"
-	default 1
-	depends on SCHED_ONEXIT
-	---help---
-		By default if SCHED_ONEXIT is selected, only a single on_exit() function
-		is supported. That number can be increased by defined this setting to the
-		number that you require.
-
-		If both SCHED_ONEXIT and SCHED_ATEXIT are selected, then atexit() is built
-		on top of the on_exit() implementation.  In that case, SCHED_ONEXIT_MAX
-		determines the size of the combined number of atexit(0) and on_exit calls.
 
 endmenu # RTOS hooks
 

--- a/os/kernel/group/group_create.c
+++ b/os/kernel/group/group_create.c
@@ -331,6 +331,17 @@ int group_initialize(FAR struct task_tcb_s *tcb)
 #if !defined(CONFIG_DISABLE_PTHREAD) && defined(CONFIG_SCHED_HAVE_PARENT)
 	group->tg_task = tcb->cmn.pid;
 #endif
+#if defined(CONFIG_SCHED_ATEXIT) && !defined(CONFIG_SCHED_ONEXIT)
+	/* atexit support *********************************************************** */
+
+	dq_init(&(group->tg_atexitfunc));
+#endif
+
+#ifdef CONFIG_SCHED_ONEXIT
+	/* on_exit support ********************************************************** */
+
+	dq_init(&(group->tg_onexitfunc));
+#endif
 
 	/* Mark that there is one member in the group, the main task */
 

--- a/os/kernel/task/task.h
+++ b/os/kernel/task/task.h
@@ -73,6 +73,23 @@
  * Public Type Definitions
  ****************************************************************************/
 
+#if defined(CONFIG_SCHED_ATEXIT) && !defined(CONFIG_SCHED_ONEXIT)
+struct atexit_s {
+	struct atexit_s *flink;
+	struct atexit_s *blink;
+	atexitfunc_t atexitfunc;
+};
+#endif
+
+#ifdef CONFIG_SCHED_ONEXIT
+struct onexit_s {
+	struct onexit_s *flink;
+	struct onexit_s *blink;
+	onexitfunc_t onexitfunc;
+	void *onexitarg;
+};
+#endif
+
 /****************************************************************************
  * Global Variables
  ****************************************************************************/

--- a/os/kernel/task/task_atexit.c
+++ b/os/kernel/task/task_atexit.c
@@ -110,15 +110,8 @@
  *
  *    Limitiations in the current implementation:
  *
- *      1. Only a single atexit function can be registered unless
- *         CONFIG_SCHED_ATEXIT_MAX defines a larger number.
- *      2. atexit functions are not inherited when a new task is
+ *      1. atexit functions are not inherited when a new task is
  *         created.
- *      3. If both SCHED_ONEXIT and SCHED_ATEXIT are selected, then atexit()
- *         is built on top of the on_exit() implementation.  In that case,
- *         CONFIG_SCHED_ONEXIT_MAX determines the size of the combined
- *         number of atexit() and on_exit() calls and SCHED_ATEXIT_MAX is
- *         not used.
  *
  * Input Parameters:
  *   func - A pointer to the function to be called when the task exits.
@@ -137,9 +130,10 @@ int atexit(void (*func)(void))
 
 	return on_exit((onexitfunc_t)func, NULL);
 
-#elif defined(CONFIG_SCHED_ATEXIT_MAX) && CONFIG_SCHED_ATEXIT_MAX > 1
+#else
 	FAR struct tcb_s *tcb = this_task();
 	FAR struct task_group_s *group = tcb->group;
+	FAR struct atexit_s *patexit;
 	int index;
 	int ret = ERROR;
 
@@ -150,40 +144,21 @@ int atexit(void (*func)(void))
 	if (func) {
 		sched_lock();
 
-		/* Search for the first available slot.  atexit() functions are registered
-		 * from lower to higher array indices; they must be called in the reverse
-		 * order of registration when task exists, i.e., from higher to lower
-		 * indices.
+		/* Allocate an atexit_s structure, initialize with functions and arguments;
+	         * then add it to the dqueue at last. These must be called back in the
+                 * reverse order during task exit i.e, remove from last.
 		 */
-
-		for (index = 0; index < CONFIG_SCHED_ATEXIT_MAX; index++) {
-			if (!group->tg_atexitfunc[index]) {
-				group->tg_atexitfunc[index] = func;
-				ret = OK;
-				break;
-			}
+		patexit = (struct atexit_s *)kmm_malloc(sizeof(struct atexit_s));
+		if (patexit) {
+			patexit->atexitfunc = func;
+			dq_addlast((dq_entry_t *)patexit, &(group->tg_atexitfunc));
+			ret = OK;
 		}
 
 		sched_unlock();
+
 	}
 
-	return ret;
-#else
-	FAR struct tcb_s *tcb = this_task();
-	FAR struct task_group_s *group = tcb->group;
-	int ret = ERROR;
-
-	DEBUGASSERT(group);
-
-	/* The following must be atomic */
-
-	sched_lock();
-	if (func && !group->tg_atexitfunc) {
-		group->tg_atexitfunc = func;
-		ret = OK;
-	}
-
-	sched_unlock();
 	return ret;
 #endif
 }

--- a/os/kernel/task/task_onexit.c
+++ b/os/kernel/task/task_onexit.c
@@ -116,9 +116,7 @@
  *
  *    Limitiations in the current implementation:
  *
- *      1. Only a single on_exit function can be registered unless
- *         CONFIG_SCHED_ONEXIT_MAX defines a larger number.
- *      2. on_exit functions are not inherited when a new task is
+ *      1. on_exit functions are not inherited when a new task is
  *         created.
  *
  * Parameters:
@@ -133,11 +131,10 @@
 
 int on_exit(CODE void (*func)(int, FAR void *), FAR void *arg)
 {
-#if defined(CONFIG_SCHED_ONEXIT_MAX) && CONFIG_SCHED_ONEXIT_MAX > 1
 	FAR struct tcb_s *tcb = this_task();
 	FAR struct task_group_s *group = tcb->group;
-	int index;
-	int ret = ENOSPC;
+	FAR struct onexit_s *ponexit;
+	int ret = ERROR;
 
 	trace_begin(TTRACE_TAG_TASK, "on_exit");
 	DEBUGASSERT(group);
@@ -147,45 +144,23 @@ int on_exit(CODE void (*func)(int, FAR void *), FAR void *arg)
 	if (func) {
 		sched_lock();
 
-		/* Search for the first available slot.  on_exit() functions are registered
-		 * from lower to higher arry indices; they must be called in the reverse
-		 * order of registration when task exists, i.e., from higher to lower
-		 * indices.
+		/* Allocate an onexit_s structure, initialize with functions and arguments;
+	         * then add it to the dqueue at last. These must be called back in the
+                 * reverse order during task exit i.e, remove from last.
 		 */
-
-		for (index = 0; index < CONFIG_SCHED_ONEXIT_MAX; index++) {
-			if (!group->tg_onexitfunc[index]) {
-				group->tg_onexitfunc[index] = func;
-				group->tg_onexitarg[index] = arg;
-				ret = OK;
-				break;
-			}
+		ponexit = (struct onexit_s *)kmm_malloc(sizeof(struct onexit_s));
+		if (ponexit) {
+			ponexit->onexitfunc = func;
+			ponexit->onexitarg = arg;
+			dq_addlast((dq_entry_t *)ponexit, &(group->tg_onexitfunc));
+			ret = OK;
 		}
 
 		sched_unlock();
+
 	}
 	trace_end(TTRACE_TAG_TASK);
 	return ret;
-#else
-	FAR struct tcb_s *tcb = this_task();
-	FAR struct task_group_s *group = tcb->group;
-	int ret = ENOSPC;
-
-	DEBUGASSERT(group);
-
-	/* The following must be atomic */
-
-	sched_lock();
-	if (func && !group->tg_onexitfunc) {
-		group->tg_onexitfunc = func;
-		group->tg_onexitarg = arg;
-		ret = OK;
-	}
-
-	sched_unlock();
-	trace_end(TTRACE_TAG_TASK);
-	return ret;
-#endif
 }
 
 #endif							/* CONFIG_SCHED_ONEXIT */


### PR DESCRIPTION
1. Reset static object after destruction, to allow object construnction again.
2. There is a limitations in the current implementation that
    only a single atexit/onexit function can be registered unless
    CONFIG_SCHED_ATEXIT_MAX/CONFIG_SCHED_ONEXIT_MAX/ defines a
    larger number. To overcome this limitation this patch removes the support of static
    array of callbacks and keeps the callbacks in the dynamically allocated
    space at runtime using dqueue.