### PR TITLE
net: Add in6addr_any constant only if IPv6 enabled

### DIFF
--- a/lib/libc/net/Make.defs
+++ b/lib/libc/net/Make.defs
@@ -52,6 +52,10 @@
 
 # Add the networking C files to the build
 
+ifeq ($(CONFIG_NET_IPv6),y)
+CSRCS += lib_addrconfig.c 
+endif
+
 # Routing table support
 
 ifeq ($(CONFIG_NET_ROUTE),y)


### PR DESCRIPTION
Observed issue while building master branch of IoT.js:

    arm-none-eabi-ld (...) \
        -o ".../tinyara" arm_vectortab.o  (...) \
        .../TizenRT/os/../build/output/bin/tinyara.map
    /build/output/libraries/libtuv.a(udp.c.obj): \
    In function `uv__udp_maybe_deferred_bind':
    .../libtuv/src/unix/udp.c:445: undefined reference to `in6addr_any'

Change-Id: I37d5a3a16d412682e1308dc8952faac54bd40a18
Signed-off-by: Philippe Coval <p.coval@samsung.com>