### PR TITLE
external/wakaama: Fix stack based buffer overflow in Wakaama

### DIFF
--- a/external/wakaama/core/er-coap-13/er-coap-13.h
+++ b/external/wakaama/core/er-coap-13/er-coap-13.h
@@ -92,8 +92,14 @@
 
 /* Bitmap for set options */
 enum { OPTION_MAP_SIZE = sizeof(uint8_t) * 8 };
-#define SET_OPTION(packet, opt) ((packet)->options[opt / OPTION_MAP_SIZE] |= 1 << (opt % OPTION_MAP_SIZE))
-#define IS_OPTION(packet, opt) ((packet)->options[opt / OPTION_MAP_SIZE] & (1 << (opt % OPTION_MAP_SIZE)))
+#define SET_OPTION(packet, opt)	\
+	do {	\
+		if (opt > COAP_OPTION_PROXY_URI) {	\
+			return 0;	\
+		}	\
+		((packet)->options[opt / OPTION_MAP_SIZE] |= 1 << (opt % OPTION_MAP_SIZE));	\
+	} while (0)
+#define IS_OPTION(packet, opt)	(opt > COAP_OPTION_PROXY_URI) ? 0 : ((packet)->options[opt / OPTION_MAP_SIZE] & (1 << (opt % OPTION_MAP_SIZE)))
 
 #ifndef MIN
 #define MIN(a, b) ((a) < (b)? (a) : (b))


### PR DESCRIPTION
Implementation of CoAP protocol used by Wakaama library is vulnerable to stack based buffer overflow attacks leading to remote code execution (RCE) triggered by single malformed CoAP packet.
The SET_OPTION macro should limit the number of CoAP option to the size of the options bitmap (COAP_OPTION_PROXY_URI/ OPTION_MAP_SIZE).