### PR TITLE
kernel : use single-linked queue in atexit & onexit

### DIFF
--- a/os/include/tinyara/sched.h
+++ b/os/include/tinyara/sched.h
@@ -361,12 +361,12 @@ struct task_group_s {
 #if defined(CONFIG_SCHED_ATEXIT) && !defined(CONFIG_SCHED_ONEXIT)
 	/* atexit support *********************************************************** */
 
-	dq_queue_t tg_atexitfunc;
+	sq_queue_t tg_atexitfunc;
 #endif
 
 #ifdef CONFIG_SCHED_ONEXIT
 	/* on_exit support ********************************************************** */
-	dq_queue_t tg_onexitfunc;
+	sq_queue_t tg_onexitfunc;
 #endif
 
 #if defined(CONFIG_SCHED_HAVE_PARENT) && defined(CONFIG_SCHED_CHILD_STATUS)

--- a/os/kernel/group/group_create.c
+++ b/os/kernel/group/group_create.c
@@ -334,13 +334,13 @@ int group_initialize(FAR struct task_tcb_s *tcb)
 #if defined(CONFIG_SCHED_ATEXIT) && !defined(CONFIG_SCHED_ONEXIT)
 	/* atexit support *********************************************************** */
 
-	dq_init(&(group->tg_atexitfunc));
+	sq_init(&(group->tg_atexitfunc));
 #endif
 
 #ifdef CONFIG_SCHED_ONEXIT
 	/* on_exit support ********************************************************** */
 
-	dq_init(&(group->tg_onexitfunc));
+	sq_init(&(group->tg_onexitfunc));
 #endif
 
 	/* Mark that there is one member in the group, the main task */

--- a/os/kernel/task/task_atexit.c
+++ b/os/kernel/task/task_atexit.c
@@ -145,13 +145,13 @@ int atexit(void (*func)(void))
 		sched_lock();
 
 		/* Allocate an atexit_s structure, initialize with functions and arguments;
-	         * then add it to the dqueue at last. These must be called back in the
-                 * reverse order during task exit i.e, remove from last.
+		 * then add it to the head of single linked queue. These must be called back in the
+		 * reverse order during task exit i.e, remove from head.
 		 */
 		patexit = (struct atexit_s *)kmm_malloc(sizeof(struct atexit_s));
 		if (patexit) {
 			patexit->atexitfunc = func;
-			dq_addlast((dq_entry_t *)patexit, &(group->tg_atexitfunc));
+			sq_addfirst((sq_entry_t *)patexit, &(group->tg_atexitfunc));
 			ret = OK;
 		}
 

--- a/os/kernel/task/task_exithook.c
+++ b/os/kernel/task/task_exithook.c
@@ -117,16 +117,12 @@ inline void task_atexit(FAR struct tcb_s *tcb)
 
 		/* Call each atexit function in the reverse order of registration */
 
-		while(!(dq_empty(&(group->tg_atexitfunc)))) {
-			patexit = (struct atexit_s *)dq_remlast(&(group->tg_atexitfunc));
-			if (patexit) {
+		while (!(sq_empty(&(group->tg_atexitfunc)))) {
+			patexit = (struct atexit_s *)sq_remfirst(&(group->tg_atexitfunc));
 
-				if (patexit->atexitfunc) {
-					(*patexit->atexitfunc)();
-				}
+			(*patexit->atexitfunc)();
 
-				sched_kfree(patexit);
-			}
+			sched_kfree(patexit);
 		}
 	}
 }
@@ -157,16 +153,12 @@ inline void task_onexit(FAR struct tcb_s *tcb, int status)
 
 		/* Call each on_exit function in the reverse order of registration */
 
-		while(!(dq_empty(&(group->tg_onexitfunc)))) {
-			ponexit = (struct onexit_s *)dq_remlast(&(group->tg_onexitfunc));
-			if (ponexit) {
+		while (!(sq_empty(&(group->tg_onexitfunc)))) {
+			ponexit = (struct onexit_s *)sq_remfirst(&(group->tg_onexitfunc));
 
-				if (ponexit->onexitfunc) {
-					(*ponexit->onexitfunc)(status, ponexit->onexitarg);
-				}
+			(*ponexit->onexitfunc)(status, ponexit->onexitarg);
 
-				sched_kfree(ponexit);
-			}
+			sched_kfree(ponexit);
 		}
 	}
 }

--- a/os/kernel/task/task_onexit.c
+++ b/os/kernel/task/task_onexit.c
@@ -145,14 +145,14 @@ int on_exit(CODE void (*func)(int, FAR void *), FAR void *arg)
 		sched_lock();
 
 		/* Allocate an onexit_s structure, initialize with functions and arguments;
-	         * then add it to the dqueue at last. These must be called back in the
-                 * reverse order during task exit i.e, remove from last.
+		 * then add it to the head of single linked queue. These must be called back in the
+		 * reverse order during task exit i.e, remove from head.
 		 */
 		ponexit = (struct onexit_s *)kmm_malloc(sizeof(struct onexit_s));
 		if (ponexit) {
 			ponexit->onexitfunc = func;
 			ponexit->onexitarg = arg;
-			dq_addlast((dq_entry_t *)ponexit, &(group->tg_onexitfunc));
+			sq_addfirst((sq_entry_t *)ponexit, &(group->tg_onexitfunc));
 			ret = OK;
 		}
 


### PR DESCRIPTION
Changes:
1. Use single-linked queue insted of dqueue
2. Remove unnecessary condition checks
2. Minor coding style fixes

Signed-off-by: Manohara HK <manohara.hk@samsung.com>