### PR TITLE
framework/task_manager : Support managing for task and pthread which …

### DIFF
--- a/apps/examples/task_manager_sample/action_manager.c
+++ b/apps/examples/task_manager_sample/action_manager.c
@@ -126,7 +126,7 @@ int action_manager_main(int argc, char *argv[])
 
 	exit_flag = 0;
 
-	handle_alarm = task_manager_register("alarm", TM_TASK_PERMISSION_ALL, TM_RESPONSE_WAIT_INF);
+	handle_alarm = task_manager_register("alarm", TM_APP_PERMISSION_ALL, TM_RESPONSE_WAIT_INF);
 	if (handle_alarm < 0) {
 		printf("FAIL TO REGISTER ALARM ACTION, %d\n", handle_alarm);
 	} else if (handle_alarm >= 0) {
@@ -135,7 +135,7 @@ int action_manager_main(int argc, char *argv[])
 
 	printf("\nRegister LED On Action\n");
 
-	handle_ledon = task_manager_register("led_on", TM_TASK_PERMISSION_ALL, TM_RESPONSE_WAIT_INF);
+	handle_ledon = task_manager_register("led_on", TM_APP_PERMISSION_ALL, TM_RESPONSE_WAIT_INF);
 	if (handle_ledon < 0) {
 		printf("FAIL TO REGISTER LED ON ACTION, %d\n", handle_ledon);
 	} else if (handle_ledon >= 0) {
@@ -144,7 +144,7 @@ int action_manager_main(int argc, char *argv[])
 
 	printf("\nRegister LED Off Action\n");
 
-	handle_ledoff = task_manager_register("led_off", TM_TASK_PERMISSION_ALL, TM_RESPONSE_WAIT_INF);
+	handle_ledoff = task_manager_register("led_off", TM_APP_PERMISSION_ALL, TM_RESPONSE_WAIT_INF);
 	if (handle_ledoff < 0) {
 		printf("FAIL TO REGISTER LED OFF ACTION, %d\n", handle_ledoff);
 	} else if (handle_ledoff >= 0) {

--- a/apps/examples/task_manager_sample/task_manager_sample_main.c
+++ b/apps/examples/task_manager_sample/task_manager_sample_main.c
@@ -49,7 +49,7 @@ int task_manager_sample_main(int argc, char *argv[])
 
 	printf("Task Manager Sample is started\nRegister Action Manager\n");
 
-	handle_actionmanager = task_manager_register("action_manager", TM_TASK_PERMISSION_ALL, TM_RESPONSE_WAIT_INF);
+	handle_actionmanager = task_manager_register("action_manager", TM_APP_PERMISSION_ALL, TM_RESPONSE_WAIT_INF);
 	if (handle_actionmanager < 0) {
 		printf("FAIL TO REGISTER ACTION MANAGER, %d\n", handle_actionmanager);
 	} else if (handle_actionmanager >= 0) {
@@ -57,7 +57,7 @@ int task_manager_sample_main(int argc, char *argv[])
 	}
 
 	printf("\nRegister User App\n");
-	handle_user = task_manager_register("user", TM_TASK_PERMISSION_ALL, TM_RESPONSE_WAIT_INF);
+	handle_user = task_manager_register("user", TM_APP_PERMISSION_ALL, TM_RESPONSE_WAIT_INF);
 	if (handle_user < 0) {
 		printf("FAIL TO REGISTER USER APP, %d\n", handle_user);
 	} else if (handle_user >= 0) {

--- a/apps/examples/task_manager_sample/user.c
+++ b/apps/examples/task_manager_sample/user.c
@@ -40,7 +40,7 @@ int user_main(int argc, char *argv[])
 {
 	int handle_actionmanager = 0;
 	int ret;
-	task_info_list_t *action_manager_info;
+	app_info_list_t *action_manager_info;
 
 	char *msg1 = (char *)malloc(sizeof(char) * 9);
 	char *msg2 = (char *)malloc(sizeof(char) * 12);
@@ -53,7 +53,7 @@ int user_main(int argc, char *argv[])
 	strcpy(msg4, "alarm_restart");
 	strcpy(msg5, "alarm_off");
 
-	action_manager_info = (task_info_list_t *)task_manager_getinfo_with_name("action_manager", TM_RESPONSE_WAIT_INF);
+	action_manager_info = (app_info_list_t *)task_manager_getinfo_with_name("action_manager", TM_RESPONSE_WAIT_INF);
 	if (action_manager_info != NULL) {
 		handle_actionmanager = action_manager_info->task.handle;
 	}

--- a/apps/examples/testcase/ta_tc/task_manager/utc/utc_task_manager_main.c
+++ b/apps/examples/testcase/ta_tc/task_manager/utc/utc_task_manager_main.c
@@ -46,9 +46,9 @@ static int tm_broadcast_handle2;
 static int tm_broadcast_handle3;
 static int tm_noperm_handle;
 static bool flag;
-static task_info_t *sample_info;
-static task_info_list_t *group_list_info;
-static task_info_list_t *sample_list_info;
+static app_info_t *sample_info;
+static app_info_list_t *group_list_info;
+static app_info_list_t *sample_list_info;
 static int *addr;
 static int *addr2;
 static int broad_wifi_on_cnt;
@@ -91,7 +91,7 @@ int tm_sample_main(int argc, char *argv[])
 {
 	int ret;
 
-	tm_noperm_handle = task_manager_register(TM_NOPERM_NAME, TM_TASK_PERMISSION_DEDICATE, 100);
+	tm_noperm_handle = task_manager_register(TM_NOPERM_NAME, TM_APP_PERMISSION_DEDICATE, 100);
 
 	ret = task_manager_set_unicast_cb(test_unicast_handler);
 	if (ret != OK) {
@@ -149,13 +149,13 @@ int tm_broadcast3_main(int argc, char *argv[])
 static void utc_task_manager_register_n(void)
 {
 	int ret;
-	ret = task_manager_register(NULL, TM_TASK_PERMISSION_DEDICATE, TM_NO_RESPONSE);
+	ret = task_manager_register(NULL, TM_APP_PERMISSION_DEDICATE, TM_NO_RESPONSE);
 	TC_ASSERT_EQ("task_manager_register", ret, TM_INVALID_PARAM);
 
 	ret = task_manager_register(TM_SAMPLE_NAME, TM_INVALID_PERMISSION, TM_NO_RESPONSE);
 	TC_ASSERT_EQ("task_manager_register", ret, TM_INVALID_PARAM);
 
-	ret = task_manager_register(TM_SAMPLE_NAME, TM_TASK_PERMISSION_GROUP, TM_INVALID_TIMEOUT);
+	ret = task_manager_register(TM_SAMPLE_NAME, TM_APP_PERMISSION_GROUP, TM_INVALID_TIMEOUT);
 	TC_ASSERT_EQ("task_manager_register", ret, TM_INVALID_PARAM);
 
 	TC_SUCCESS_RESULT();
@@ -163,19 +163,19 @@ static void utc_task_manager_register_n(void)
 
 static void utc_task_manager_register_p(void)
 {
-	tm_sample_handle = task_manager_register("invalid", TM_TASK_PERMISSION_DEDICATE, TM_RESPONSE_WAIT_INF);
+	tm_sample_handle = task_manager_register("invalid", TM_APP_PERMISSION_DEDICATE, TM_RESPONSE_WAIT_INF);
 	TC_ASSERT_EQ("task_manager_register", tm_sample_handle, TM_OPERATION_FAIL);
 
-	tm_sample_handle = task_manager_register(TM_SAMPLE_NAME, TM_TASK_PERMISSION_DEDICATE, TM_RESPONSE_WAIT_INF);
+	tm_sample_handle = task_manager_register(TM_SAMPLE_NAME, TM_APP_PERMISSION_DEDICATE, TM_RESPONSE_WAIT_INF);
 	TC_ASSERT_GEQ("task_manager_register", tm_sample_handle, 0);
 
-	tm_broadcast_handle1 = task_manager_register(TM_BROADCAST1_NAME, TM_TASK_PERMISSION_DEDICATE, TM_RESPONSE_WAIT_INF);
+	tm_broadcast_handle1 = task_manager_register(TM_BROADCAST1_NAME, TM_APP_PERMISSION_DEDICATE, TM_RESPONSE_WAIT_INF);
 	TC_ASSERT_GEQ("task_manager_register", tm_broadcast_handle1, 0);
 
-	tm_broadcast_handle2 = task_manager_register(TM_BROADCAST2_NAME, TM_TASK_PERMISSION_DEDICATE, TM_RESPONSE_WAIT_INF);
+	tm_broadcast_handle2 = task_manager_register(TM_BROADCAST2_NAME, TM_APP_PERMISSION_DEDICATE, TM_RESPONSE_WAIT_INF);
 	TC_ASSERT_GEQ("task_manager_register", tm_broadcast_handle2, 0);
 
-	tm_broadcast_handle3 = task_manager_register(TM_BROADCAST3_NAME, TM_TASK_PERMISSION_DEDICATE, TM_RESPONSE_WAIT_INF);
+	tm_broadcast_handle3 = task_manager_register(TM_BROADCAST3_NAME, TM_APP_PERMISSION_DEDICATE, TM_RESPONSE_WAIT_INF);
 	TC_ASSERT_GEQ("task_manager_register", tm_broadcast_handle3, 0);
 
 	TC_SUCCESS_RESULT();
@@ -201,7 +201,7 @@ static void utc_task_manager_start_p(void)
 	TC_ASSERT_EQ("task_manager_start", ret, OK);
 
 	ret = task_manager_start(tm_sample_handle, TM_RESPONSE_WAIT_INF);
-	TC_ASSERT_EQ("task_manager_start", ret, TM_ALREADY_STARTED_TASK);
+	TC_ASSERT_EQ("task_manager_start", ret, TM_ALREADY_STARTED_APP);
 
 	ret = task_manager_start(tm_broadcast_handle1, TM_RESPONSE_WAIT_INF);
 	TC_ASSERT_EQ("task_manager_start", ret, OK);
@@ -399,14 +399,14 @@ static void utc_task_manager_resume_p(void)
 
 static void utc_task_manager_getinfo_with_name_n(void)
 {
-	task_info_list_t *ret;
-	ret = (task_info_list_t *)task_manager_getinfo_with_name(NULL, TM_NO_RESPONSE);
+	app_info_list_t *ret;
+	ret = (app_info_list_t *)task_manager_getinfo_with_name(NULL, TM_NO_RESPONSE);
 	TC_ASSERT_EQ("task_manager_getinfo_with_name", ret, NULL);
 
-	ret = (task_info_list_t *)task_manager_getinfo_with_name(TM_SAMPLE_NAME, TM_INVALID_TIMEOUT);
+	ret = (app_info_list_t *)task_manager_getinfo_with_name(TM_SAMPLE_NAME, TM_INVALID_TIMEOUT);
 	TC_ASSERT_EQ("task_manager_getinfo_with_name", ret, NULL);
 
-	ret = (task_info_list_t *)task_manager_getinfo_with_name(TM_SAMPLE_NAME, TM_NO_RESPONSE);
+	ret = (app_info_list_t *)task_manager_getinfo_with_name(TM_SAMPLE_NAME, TM_NO_RESPONSE);
 	TC_ASSERT_EQ("task_manager_getinfo_with_name", ret, NULL);
 
 	TC_SUCCESS_RESULT();
@@ -414,7 +414,7 @@ static void utc_task_manager_getinfo_with_name_n(void)
 
 static void utc_task_manager_getinfo_with_name_p(void)
 {
-	sample_list_info = (task_info_list_t *)task_manager_getinfo_with_name(TM_SAMPLE_NAME, TM_RESPONSE_WAIT_INF);
+	sample_list_info = (app_info_list_t *)task_manager_getinfo_with_name(TM_SAMPLE_NAME, TM_RESPONSE_WAIT_INF);
 	TC_ASSERT_NEQ("task_manager_getinfo_with_name", sample_list_info, NULL);
 
 	TC_SUCCESS_RESULT();
@@ -422,14 +422,14 @@ static void utc_task_manager_getinfo_with_name_p(void)
 
 static void utc_task_manager_getinfo_with_handle_n(void)
 {
-	task_info_t *ret;
-	ret = (task_info_t *)task_manager_getinfo_with_handle(TM_INVALID_HANDLE, TM_NO_RESPONSE);
+	app_info_t *ret;
+	ret = (app_info_t *)task_manager_getinfo_with_handle(TM_INVALID_HANDLE, TM_NO_RESPONSE);
 	TC_ASSERT_EQ("task_manager_getinfo_with_handle", ret, NULL);
 
-	ret = (task_info_t *)task_manager_getinfo_with_handle(tm_sample_handle, TM_INVALID_TIMEOUT);
+	ret = (app_info_t *)task_manager_getinfo_with_handle(tm_sample_handle, TM_INVALID_TIMEOUT);
 	TC_ASSERT_EQ("task_manager_getinfo_with_handle", ret, NULL);
 
-	ret = (task_info_t *)task_manager_getinfo_with_handle(tm_sample_handle, TM_NO_RESPONSE);
+	ret = (app_info_t *)task_manager_getinfo_with_handle(tm_sample_handle, TM_NO_RESPONSE);
 	TC_ASSERT_EQ("task_manager_getinfo_with_handle", ret, NULL);
 
 	TC_SUCCESS_RESULT();
@@ -437,7 +437,7 @@ static void utc_task_manager_getinfo_with_handle_n(void)
 
 static void utc_task_manager_getinfo_with_handle_p(void)
 {
-	sample_info = (task_info_t *)task_manager_getinfo_with_handle(tm_sample_handle, TM_RESPONSE_WAIT_INF);
+	sample_info = (app_info_t *)task_manager_getinfo_with_handle(tm_sample_handle, TM_RESPONSE_WAIT_INF);
 	TC_ASSERT_NEQ("task_manager_getinfo_with_handle", sample_info, NULL);
 
 	TC_SUCCESS_RESULT();
@@ -445,19 +445,19 @@ static void utc_task_manager_getinfo_with_handle_p(void)
 
 static void utc_task_manager_getinfo_with_group_n(void)
 {
-	task_info_list_t *ret;
-	ret = (task_info_list_t *)task_manager_getinfo_with_group(TM_INVALID_HANDLE, TM_NO_RESPONSE);
+	app_info_list_t *ret;
+	ret = (app_info_list_t *)task_manager_getinfo_with_group(TM_INVALID_HANDLE, TM_NO_RESPONSE);
 	TC_ASSERT_EQ("task_manager_getinfo_with_group", ret, NULL);
 
 	if (!sample_info) {
-		sample_info = (task_info_t *)task_manager_getinfo_with_handle(tm_sample_handle, TM_RESPONSE_WAIT_INF);
+		sample_info = (app_info_t *)task_manager_getinfo_with_handle(tm_sample_handle, TM_RESPONSE_WAIT_INF);
 		TC_ASSERT_NEQ("task_manager_getinfo_with_handle", sample_info, NULL);
 	}
 
-	ret = (task_info_list_t *)task_manager_getinfo_with_group(sample_info->tm_gid, TM_INVALID_TIMEOUT);
+	ret = (app_info_list_t *)task_manager_getinfo_with_group(sample_info->tm_gid, TM_INVALID_TIMEOUT);
 	TC_ASSERT_EQ("task_manager_getinfo_with_group", ret, NULL);
 
-	ret = (task_info_list_t *)task_manager_getinfo_with_group(sample_info->tm_gid, TM_NO_RESPONSE);
+	ret = (app_info_list_t *)task_manager_getinfo_with_group(sample_info->tm_gid, TM_NO_RESPONSE);
 	TC_ASSERT_EQ("task_manager_getinfo_with_group", ret, NULL);
 
 	TC_SUCCESS_RESULT();
@@ -466,11 +466,11 @@ static void utc_task_manager_getinfo_with_group_n(void)
 static void utc_task_manager_getinfo_with_group_p(void)
 {
 	if (!sample_info) {
-		sample_info = (task_info_t *)task_manager_getinfo_with_handle(tm_sample_handle, TM_RESPONSE_WAIT_INF);
+		sample_info = (app_info_t *)task_manager_getinfo_with_handle(tm_sample_handle, TM_RESPONSE_WAIT_INF);
 		TC_ASSERT_NEQ("task_manager_getinfo_with_handle", sample_info, NULL);
 	}
 
-	group_list_info = (task_info_list_t *)task_manager_getinfo_with_group(sample_info->tm_gid, TM_RESPONSE_WAIT_INF);
+	group_list_info = (app_info_list_t *)task_manager_getinfo_with_group(sample_info->tm_gid, TM_RESPONSE_WAIT_INF);
 	TC_ASSERT_NEQ("task_manager_getinfo_with_group", group_list_info, NULL);
 
 	task_manager_clean_infolist(&group_list_info);
@@ -481,7 +481,7 @@ static void utc_task_manager_getinfo_with_group_p(void)
 static void utc_task_manager_clean_infolist_p(void)
 {
 	task_manager_clean_infolist(&sample_list_info);
-	TC_ASSERT_NEQ("task_manager_clean_infolist", (task_info_list_t *)&sample_list_info, NULL);
+	TC_ASSERT_NEQ("task_manager_clean_infolist", (app_info_list_t *)&sample_list_info, NULL);
 
 	TC_SUCCESS_RESULT();
 }
@@ -489,7 +489,7 @@ static void utc_task_manager_clean_infolist_p(void)
 static void utc_task_manager_clean_info_p(void)
 {
 	task_manager_clean_info(&sample_info);
-	TC_ASSERT_NEQ("task_manager_clean_info", (task_info_t *)&sample_info, NULL);
+	TC_ASSERT_NEQ("task_manager_clean_info", (app_info_t *)&sample_info, NULL);
 
 	TC_SUCCESS_RESULT();
 }
@@ -513,7 +513,7 @@ static void utc_task_manager_stop_p(void)
 	TC_ASSERT_EQ("task_manager_stop", ret, OK);
 
 	ret = task_manager_stop(tm_sample_handle, TM_RESPONSE_WAIT_INF);
-	TC_ASSERT_EQ("task_manager_stop", ret, TM_ALREADY_STOPPED_TASK);
+	TC_ASSERT_EQ("task_manager_stop", ret, TM_ALREADY_STOPPED_APP);
 
 	ret = task_manager_stop(tm_broadcast_handle1, TM_RESPONSE_WAIT_INF);
 	TC_ASSERT_EQ("task_manager_stop", ret, OK);
@@ -578,13 +578,13 @@ static void utc_task_manager_unregister_p(void)
 	TC_ASSERT_EQ("task_manager_unregister", ret, OK);
 
 	ret = task_manager_start(tm_sample_handle, 100);
-	TC_ASSERT_EQ("task_manager_start", ret, TM_UNREGISTERED_TASK);
+	TC_ASSERT_EQ("task_manager_start", ret, TM_UNREGISTERED_APP);
 
 	ret = task_manager_restart(tm_sample_handle, TM_RESPONSE_WAIT_INF);
-	TC_ASSERT_EQ("task_manager_restart", ret, TM_UNREGISTERED_TASK);
+	TC_ASSERT_EQ("task_manager_restart", ret, TM_UNREGISTERED_APP);
 
 	ret = task_manager_unregister(tm_sample_handle, TM_RESPONSE_WAIT_INF);
-	TC_ASSERT_EQ("task_manager_unregister", ret, TM_UNREGISTERED_TASK);
+	TC_ASSERT_EQ("task_manager_unregister", ret, TM_UNREGISTERED_APP);
 
 	TC_SUCCESS_RESULT();
 }

--- a/framework/include/task_manager/task_manager.h
+++ b/framework/include/task_manager/task_manager.h
@@ -34,22 +34,22 @@
 /**
  * @brief Task State which managed by Task Manager
  */
-#define TM_TASK_STATE_RUNNING      (1)
-#define TM_TASK_STATE_PAUSE        (2)
-#define TM_TASK_STATE_STOP         (3)
-#define TM_TASK_STATE_UNREGISTERED (4)
+#define TM_APP_STATE_RUNNING      (1)
+#define TM_APP_STATE_PAUSE        (2)
+#define TM_APP_STATE_STOP         (3)
+#define TM_APP_STATE_UNREGISTERED (4)
 
 /**
  * @brief Task Permission
  * @details
- * TM_TASK_PERMISSION_ALL : Any Task can request the control to Task Manager
- * TM_TASK_PERMISSION_GROUP : Only same group task can request the control to Task Manager
+ * TM_APP_PERMISSION_ALL : Any Task can request the control to Task Manager
+ * TM_APP_PERMISSION_GROUP : Only same group task can request the control to Task Manager
  *                     -> group : Tasks set which registered from same parent task
- * TM_TASK_PERMISSION_DEDICATE : Only a task which requested to register that task can request the control to Task Manager
+ * TM_APP_PERMISSION_DEDICATE : Only a task which requested to register that task can request the control to Task Manager
  */
-#define TM_TASK_PERMISSION_ALL      (0)
-#define TM_TASK_PERMISSION_GROUP    (1)
-#define TM_TASK_PERMISSION_DEDICATE (2)
+#define TM_APP_PERMISSION_ALL      (0)
+#define TM_APP_PERMISSION_GROUP    (1)
+#define TM_APP_PERMISSION_DEDICATE (2)
 
 /**
  * @brief Returnable Flag from Task Manager
@@ -64,10 +64,10 @@
  * @details If operation is failed, these defined values will be returned.
  */
 enum tm_result_error_e {
-	TM_ALREADY_STARTED_TASK = -1,
-	TM_ALREADY_PAUSED_TASK = -2,
-	TM_ALREADY_STOPPED_TASK = -3,
-	TM_UNREGISTERED_TASK = -4,
+	TM_ALREADY_STARTED_APP = -1,
+	TM_ALREADY_PAUSED_APP = -2,
+	TM_ALREADY_STOPPED_APP = -3,
+	TM_UNREGISTERED_APP = -4,
 	TM_OPERATION_FAIL = -5,
 	TM_COMMUCATION_FAIL = -6,
 	TM_BUSY = -7,
@@ -90,20 +90,20 @@ enum tm_result_error_e {
 /**
  * @brief Task Info Structure
  */
-struct task_info_s {
+struct app_info_s {
 	char *name;
 	int tm_gid;
 	int handle;
 	int status;
 	int permission;
 };
-typedef struct task_info_s task_info_t;
+typedef struct app_info_s app_info_t;
 
-struct task_info_list_s {
-	task_info_t task;
-	struct task_info_list_s *next;
+struct app_info_list_s {
+	app_info_t task;
+	struct app_info_list_s *next;
 };
-typedef struct task_info_list_s task_info_list_t;
+typedef struct app_info_list_s app_info_list_t;
 
 /****************************************************************************
  * Public Function Prototypes
@@ -293,7 +293,7 @@ int task_manager_set_termination_cb(void (*func)(void));
  * @return On success, the list of task information is returned(at the end of the list, NULL will be returned). On failure, NULL is returned.
  * @since TizenRT v2.0 PRE
  */
-task_info_list_t *task_manager_getinfo_with_name(char *name, int timeout);
+app_info_list_t *task_manager_getinfo_with_name(char *name, int timeout);
 /**
  * @brief Get task information through handle
  * @details @b #include <task_manager/task_manager.h>
@@ -306,7 +306,7 @@ task_info_list_t *task_manager_getinfo_with_name(char *name, int timeout);
  * @return On success, the task information is returned. On failure, NULL is returned.
  * @since TizenRT v2.0 PRE
  */
-task_info_t *task_manager_getinfo_with_handle(int handle, int timeout);
+app_info_t *task_manager_getinfo_with_handle(int handle, int timeout);
 /**
  * @brief Get task information list through group
  * @details @b #include <task_manager/task_manager.h>
@@ -319,7 +319,7 @@ task_info_t *task_manager_getinfo_with_handle(int handle, int timeout);
  * @return On success, the task information is returned. On failure, NULL is returned.
  * @since TizenRT v2.0 PRE
  */
-task_info_list_t *task_manager_getinfo_with_group(int group, int timeout);
+app_info_list_t *task_manager_getinfo_with_group(int group, int timeout);
 /**
  * @brief Clean task information
  * @details @b #include <task_manager/task_manager.h>
@@ -327,7 +327,7 @@ task_info_list_t *task_manager_getinfo_with_group(int group, int timeout);
  * @return none
  * @since TizenRT v2.0 PRE
  */
-void task_manager_clean_info(task_info_t **info);
+void task_manager_clean_info(app_info_t **info);
 /**
  * @brief Clean task information list
  * @details @b #include <task_manager/task_manager.h>
@@ -335,7 +335,7 @@ void task_manager_clean_info(task_info_t **info);
  * @return none
  * @since TizenRT v2.0 PRE
  */
-void task_manager_clean_infolist(task_info_list_t **info_list);
+void task_manager_clean_infolist(app_info_list_t **info_list);
 
 #endif
 /**

--- a/framework/include/task_manager/task_manager.h
+++ b/framework/include/task_manager/task_manager.h
@@ -29,6 +29,7 @@
 #define __TASK_MANAGER_H__
 
 #include <signal.h>
+#include <pthread.h>
 
 /**
  * @brief Task State which managed by Task Manager
@@ -74,6 +75,7 @@ enum tm_result_error_e {
 	TM_INVALID_DRVFD = -9,
 	TM_OUT_OF_MEMORY = -10,
 	TM_NO_PERMISSION = -11,
+	TM_NOT_SUPPORTED = -12,
 };
 
 /**
@@ -109,7 +111,7 @@ typedef struct task_info_list_s task_info_list_t;
 /**
  * @brief Request to register a task
  * @details @b #include <task_manager/task_manager.h>\n
- * Only builtin task can be managed by task manager.\n
+ * This API can request to register a builtin task.\n
  * Find apps/builtin/README.md to know how to use builtin task.
  * @param[in] name the name of task to be registered
  * @param[in] permission the permission of task to be registered
@@ -121,6 +123,40 @@ typedef struct task_info_list_s task_info_list_t;
  * @since TizenRT v2.0 PRE
  */
 int task_manager_register(char *name, int permission, int timeout);
+/**
+ * @brief Request to register a task which is not in builtin list
+ * @details @b #include <task_manager/task_manager.h>\n
+ * Find apps/builtin/README.md to know how to use builtin task.
+ * @param[in] name the name of task to be registered
+ * @param[in] priority the priority of task to be registered
+ * @param[in] stack_size the stack_size of task to be registered
+ * @param[in] entry the entry function pointer
+ * @param[in] argv the argument to pass when task creation
+ * @param[in] permission the permission of task to be registered
+ * @param[in] timeout returnable flag. It can be one of the below.\n
+ *			TM_NO_RESPONSE : Ignore the response of request from task manager\n
+ *			TM_RESPONSE_WAIT_INF : Blocked until get the response from task manager\n
+ *			integer value : Specifies an upper limit on the time for which will block in milliseconds
+ * @return On success, handle id is returned. On failure, defined negative value is returned.
+ * @since TizenRT v2.0 PRE
+ */
+int task_manager_register_task(char *name, int priority, int stack_size, main_t entry, char * argv[], int permission, int timeout);
+/**
+ * @brief Request to register a pthread which is not in builtin list
+ * @details @b #include <task_manager/task_manager.h>\n
+ * @param[in] name the name of pthread to be registered
+ * @param[in] attr the attribute of pthread to be registered
+ * @param[in] start_routine the entry function pointer
+ * @param[in] arg the argument to pass when task creation
+ * @param[in] permission the permission of task to be registered
+ * @param[in] timeout returnable flag. It can be one of the below.\n
+ *			TM_NO_RESPONSE : Ignore the response of request from task manager\n
+ *			TM_RESPONSE_WAIT_INF : Blocked until get the response from task manager\n
+ *			integer value : Specifies an upper limit on the time for which will block in milliseconds
+ * @return On success, handle id is returned. On failure, defined negative value is returned.
+ * @since TizenRT v2.0 PRE
+ */
+int task_manager_register_pthread(char *name, pthread_attr_t *attr, pthread_startroutine_t start_routine, pthread_addr_t arg, int permission, int timeout);
 /**
  * @brief Request to unregister a task
  * @details @b #include <task_manager/task_manager.h>

--- a/framework/src/task_manager/task_manager_broadcast.c
+++ b/framework/src/task_manager/task_manager_broadcast.c
@@ -37,7 +37,7 @@ int task_manager_broadcast(int msg)
 
 	memset(&request_msg, 0, sizeof(tm_request_t));
 	/* Set the request msg */
-	request_msg.cmd = TASKMGR_BROADCAST;
+	request_msg.cmd = TASKMGRCMD_BROADCAST;
 	request_msg.timeout = TM_NO_RESPONSE;
 	request_msg.data = (void *)TM_ALLOC(sizeof(int));
 	if (request_msg.data == NULL) {

--- a/framework/src/task_manager/task_manager_cleaninfo.c
+++ b/framework/src/task_manager/task_manager_cleaninfo.c
@@ -25,7 +25,7 @@
 /****************************************************************************
  * task_manager_clean_info
  ****************************************************************************/
-void task_manager_clean_info(task_info_t **info)
+void task_manager_clean_info(app_info_t **info)
 {
 	if (*info == NULL) {
 		return;
@@ -43,9 +43,9 @@ void task_manager_clean_info(task_info_t **info)
 /****************************************************************************
  * task_manager_clean_infolist
  ****************************************************************************/
-void task_manager_clean_infolist(task_info_list_t **info_list)
+void task_manager_clean_infolist(app_info_list_t **info_list)
 {
-	task_info_list_t *curr_info;
+	app_info_list_t *curr_info;
 
 	if (*info_list == NULL) {
 		return;

--- a/framework/src/task_manager/task_manager_getinfo.c
+++ b/framework/src/task_manager/task_manager_getinfo.c
@@ -28,7 +28,7 @@
 /****************************************************************************
  * task_manager_getinfo_with_name
  ****************************************************************************/
-task_info_list_t *task_manager_getinfo_with_name(char *name, int timeout)
+app_info_list_t *task_manager_getinfo_with_name(char *name, int timeout)
 {
 	int status;
 	tm_request_t request_msg;
@@ -41,7 +41,7 @@ task_info_list_t *task_manager_getinfo_with_name(char *name, int timeout)
 	memset(&request_msg, 0, sizeof(tm_request_t));
 
 	/* Set the request msg */
-	request_msg.cmd = TASKMGR_SCAN_NAME;
+	request_msg.cmd = TASKMGRCMD_SCAN_NAME;
 	request_msg.data = (void *)TM_ALLOC(strlen(name) + 1);
 	if (request_msg.data == NULL) {
 		return NULL;
@@ -75,7 +75,7 @@ task_info_list_t *task_manager_getinfo_with_name(char *name, int timeout)
 /****************************************************************************
  * task_manager_getinfo_with_handle
  ****************************************************************************/
-task_info_t *task_manager_getinfo_with_handle(int handle, int timeout)
+app_info_t *task_manager_getinfo_with_handle(int handle, int timeout)
 {
 	int status;
 	tm_request_t request_msg;
@@ -88,7 +88,7 @@ task_info_t *task_manager_getinfo_with_handle(int handle, int timeout)
 	memset(&request_msg, 0, sizeof(tm_request_t));
 
 	/* Set the request msg */
-	request_msg.cmd = TASKMGR_SCAN_HANDLE;
+	request_msg.cmd = TASKMGRCMD_SCAN_HANDLE;
 	request_msg.handle = handle;
 	request_msg.timeout = timeout;
 
@@ -116,7 +116,7 @@ task_info_t *task_manager_getinfo_with_handle(int handle, int timeout)
 /****************************************************************************
  * task_manager_getinfo_with_group
  ****************************************************************************/
-task_info_list_t *task_manager_getinfo_with_group(int group, int timeout)
+app_info_list_t *task_manager_getinfo_with_group(int group, int timeout)
 {
 	int status;
 	tm_request_t request_msg;
@@ -129,7 +129,7 @@ task_info_list_t *task_manager_getinfo_with_group(int group, int timeout)
 	memset(&request_msg, 0, sizeof(tm_request_t));
 
 	/* Set the request msg */
-	request_msg.cmd = TASKMGR_SCAN_GROUP;
+	request_msg.cmd = TASKMGRCMD_SCAN_GROUP;
 	request_msg.handle = group;
 	request_msg.timeout = timeout;
 

--- a/framework/src/task_manager/task_manager_internal.h
+++ b/framework/src/task_manager/task_manager_internal.h
@@ -26,22 +26,22 @@
 #include <sys/types.h>
 
 /* Command Types */
-#define TASKMGR_REGISTER                0
-#define TASKMGR_UNREGISTER              1
-#define TASKMGR_START                   2
-#define TASKMGR_STOP                    3
-#define TASKMGR_RESTART                 4
-#define TASKMGR_PAUSE                   5
-#define TASKMGR_RESUME                  6
-#define TASKMGR_UNICAST                 7
-#define TASKMGR_BROADCAST               8
-#define TASKMGR_SET_UNICAST_CB          9
-#define TASKMGR_SET_BROADCAST_CB        10
-#define TASKMGR_SCAN_NAME               11
-#define TASKMGR_SCAN_HANDLE             12
-#define TASKMGR_SCAN_GROUP              13
-#define TASKMGR_REGISTER_TASK           14
-#define TASKMGR_REGISTER_PTHREAD        15
+#define TASKMGRCMD_REGISTER                0
+#define TASKMGRCMD_UNREGISTER              1
+#define TASKMGRCMD_START                   2
+#define TASKMGRCMD_STOP                    3
+#define TASKMGRCMD_RESTART                 4
+#define TASKMGRCMD_PAUSE                   5
+#define TASKMGRCMD_RESUME                  6
+#define TASKMGRCMD_UNICAST                 7
+#define TASKMGRCMD_BROADCAST               8
+#define TASKMGRCMD_SET_UNICAST_CB          9
+#define TASKMGRCMD_SET_BROADCAST_CB        10
+#define TASKMGRCMD_SCAN_NAME               11
+#define TASKMGRCMD_SCAN_HANDLE             12
+#define TASKMGRCMD_SCAN_GROUP              13
+#define TASKMGRCMD_REGISTER_TASK           14
+#define TASKMGRCMD_REGISTER_PTHREAD        15
 
 /* Task Type */
 #define TM_BUILTIN_TASK			0
@@ -60,13 +60,13 @@
 typedef void (*_tm_unicast_t)(void *);
 typedef void (*_tm_broadcast_t)(int);
 
-struct task_list_s {
+struct app_list_s {
 	int pid;
 	void *addr;
 };
-typedef struct task_list_s task_list_t;
+typedef struct app_list_s app_list_t;
 
-struct task_list_data_s {
+struct app_list_data_s {
 	int type;
 	int idx;
 	int pid;
@@ -77,7 +77,7 @@ struct task_list_data_s {
 	_tm_unicast_t unicast_cb;
 	_tm_broadcast_t broadcast_cb;
 };
-typedef struct task_list_data_s task_list_data_t;
+typedef struct app_list_data_s app_list_data_t;
 
 struct tm_request_s {
 	int cmd;
@@ -91,7 +91,7 @@ typedef struct tm_request_s tm_request_t;
 
 struct tm_response_s {
 	int status;
-	task_info_list_t *data;
+	app_info_list_t *data;
 };
 typedef struct tm_response_s tm_response_t;
 
@@ -120,18 +120,18 @@ typedef struct tm_pthread_info_s tm_pthread_info_t;
 
 #define IS_INVALID_HANDLE(i) (i < 0 || i >= CONFIG_TASK_MANAGER_MAX_TASKS)
 
-#define TASK_LIST_ADDR(handle)       ((task_list_data_t *)tm_handle_list[handle].addr)
-#define TASK_PID(handle)             tm_handle_list[handle].pid
-#define TASK_TYPE(handle)            TASK_LIST_ADDR(handle)->type
-#define TASK_IDX(handle)             TASK_LIST_ADDR(handle)->idx
-#define TASK_TM_GID(handle)          TASK_LIST_ADDR(handle)->tm_gid
-#define TASK_STATUS(handle)          TASK_LIST_ADDR(handle)->status
-#define TASK_PERMISSION(handle)      TASK_LIST_ADDR(handle)->permission
-#define TASK_MSG_MASK(handle)        TASK_LIST_ADDR(handle)->msg_mask
-#define TASK_UNICAST_CB(handle)      TASK_LIST_ADDR(handle)->unicast_cb
-#define TASK_BROADCAST_CB(handle)    TASK_LIST_ADDR(handle)->broadcast_cb
+#define TM_LIST_ADDR(handle)       ((app_list_data_t *)tm_app_list[handle].addr)
+#define TM_PID(handle)             tm_app_list[handle].pid
+#define TM_TYPE(handle)            TM_LIST_ADDR(handle)->type
+#define TM_IDX(handle)             TM_LIST_ADDR(handle)->idx
+#define TM_GID(handle)          TM_LIST_ADDR(handle)->tm_gid
+#define TM_STATUS(handle)          TM_LIST_ADDR(handle)->status
+#define TM_PERMISSION(handle)      TM_LIST_ADDR(handle)->permission
+#define TM_MSG_MASK(handle)        TM_LIST_ADDR(handle)->msg_mask
+#define TM_UNICAST_CB(handle)      TM_LIST_ADDR(handle)->unicast_cb
+#define TM_BROADCAST_CB(handle)    TM_LIST_ADDR(handle)->broadcast_cb
 
-extern task_list_t tm_handle_list[CONFIG_TASK_MANAGER_MAX_TASKS];
+extern app_list_t tm_app_list[CONFIG_TASK_MANAGER_MAX_TASKS];
 
 int taskmgr_send_request(tm_request_t *request_msg);
 int taskmgr_send_response(char *q_name, tm_response_t *response_msg);

--- a/framework/src/task_manager/task_manager_pause.c
+++ b/framework/src/task_manager/task_manager_pause.c
@@ -39,7 +39,7 @@ int task_manager_pause(int handle, int timeout)
 	}
 
 	memset(&request_msg, 0, sizeof(tm_request_t));
-	request_msg.cmd = TASKMGR_PAUSE;
+	request_msg.cmd = TASKMGRCMD_PAUSE;
 	request_msg.handle = handle;
 	request_msg.caller_pid = getpid();
 	request_msg.timeout = timeout;

--- a/framework/src/task_manager/task_manager_permission.c
+++ b/framework/src/task_manager/task_manager_permission.c
@@ -30,22 +30,22 @@ bool taskmgr_is_permitted(int handle, pid_t pid)
 {
 	int chk_idx;
 	int builtin_cnt;
-	int permission = TASK_PERMISSION(handle);
+	int permission = TM_PERMISSION(handle);
 
 	builtin_cnt = get_builtin_list_cnt();
 
-	if (permission == TM_TASK_PERMISSION_ALL \
-		|| (permission == TM_TASK_PERMISSION_DEDICATE && TASK_TM_GID(handle) == pid)) {
+	if (permission == TM_APP_PERMISSION_ALL \
+		|| (permission == TM_APP_PERMISSION_DEDICATE && TM_GID(handle) == pid)) {
 		return true;
 	}
 
-	if (permission == TM_TASK_PERMISSION_GROUP) {
-		if (pid == TASK_TM_GID(handle)) {
+	if (permission == TM_APP_PERMISSION_GROUP) {
+		if (pid == TM_GID(handle)) {
 			return true;
 		}
 		/* check pid's group id */
 		for (chk_idx = 0; chk_idx < builtin_cnt; chk_idx++) {
-			if (TASK_PID(chk_idx) == pid && TASK_TM_GID(chk_idx) == TASK_TM_GID(handle)) {
+			if (TM_PID(chk_idx) == pid && TM_GID(chk_idx) == TM_GID(handle)) {
 				return true;
 			}
 		}

--- a/framework/src/task_manager/task_manager_register.c
+++ b/framework/src/task_manager/task_manager_register.c
@@ -35,12 +35,12 @@ int task_manager_register(char *name, int permission, int timeout)
 	tm_request_t request_msg;
 	tm_response_t response_msg;
 
-	if (name == NULL || timeout < TM_RESPONSE_WAIT_INF || permission < TM_TASK_PERMISSION_ALL || permission > TM_TASK_PERMISSION_DEDICATE) {
+	if (name == NULL || timeout < TM_RESPONSE_WAIT_INF || permission < TM_APP_PERMISSION_ALL || permission > TM_APP_PERMISSION_DEDICATE) {
 		return TM_INVALID_PARAM;
 	}
 
 	memset(&request_msg, 0, sizeof(tm_request_t));
-	request_msg.cmd = TASKMGR_REGISTER;
+	request_msg.cmd = TASKMGRCMD_REGISTER;
 	request_msg.caller_pid = getpid();
 	request_msg.handle = permission;
 	request_msg.data = (void *)TM_ALLOC(strlen(name) + 1);
@@ -81,12 +81,12 @@ int task_manager_register_task(char *name, int priority, int stack_size, main_t 
 	tm_request_t request_msg;
 	tm_response_t response_msg;
 
-	if (name == NULL || timeout < TM_RESPONSE_WAIT_INF || permission < TM_TASK_PERMISSION_ALL || permission > TM_TASK_PERMISSION_DEDICATE || priority < SCHED_PRIORITY_MIN || priority > SCHED_PRIORITY_MAX || stack_size < 1 || entry == NULL) {
+	if (name == NULL || timeout < TM_RESPONSE_WAIT_INF || permission < TM_APP_PERMISSION_ALL || permission > TM_APP_PERMISSION_DEDICATE || priority < SCHED_PRIORITY_MIN || priority > SCHED_PRIORITY_MAX || stack_size < 1 || entry == NULL) {
 		return TM_INVALID_PARAM;
 	}
 
 	memset(&request_msg, 0, sizeof(tm_request_t));
-	request_msg.cmd = TASKMGR_REGISTER;
+	request_msg.cmd = TASKMGRCMD_REGISTER;
 	request_msg.caller_pid = getpid();
 	request_msg.handle = permission;
 	request_msg.data = (void *)TM_ALLOC(sizeof(tm_task_info_t));
@@ -131,12 +131,12 @@ int task_manager_register_pthread(char *name, pthread_attr_t *attr, pthread_star
 	tm_request_t request_msg;
 	tm_response_t response_msg;
 
-	if (name == NULL || timeout < TM_RESPONSE_WAIT_INF || permission < TM_TASK_PERMISSION_ALL || permission > TM_TASK_PERMISSION_DEDICATE || attr == NULL || start_routine == NULL) {
+	if (name == NULL || timeout < TM_RESPONSE_WAIT_INF || permission < TM_APP_PERMISSION_ALL || permission > TM_APP_PERMISSION_DEDICATE || attr == NULL || start_routine == NULL) {
 		return TM_INVALID_PARAM;
 	}
 
 	memset(&request_msg, 0, sizeof(tm_request_t));
-	request_msg.cmd = TASKMGR_REGISTER;
+	request_msg.cmd = TASKMGRCMD_REGISTER;
 	request_msg.caller_pid = getpid();
 	request_msg.handle = permission;
 	request_msg.data = (void *)TM_ALLOC(sizeof(tm_pthread_info_t));

--- a/framework/src/task_manager/task_manager_register.c
+++ b/framework/src/task_manager/task_manager_register.c
@@ -21,6 +21,7 @@
 #include <string.h>
 #include <stdio.h>
 #include <unistd.h>
+#include <pthread.h>
 #include <sys/types.h>
 #include <task_manager/task_manager.h>
 #include "task_manager_internal.h"
@@ -47,6 +48,105 @@ int task_manager_register(char *name, int permission, int timeout)
 		return TM_OUT_OF_MEMORY;
 	}
 	strncpy((char *)request_msg.data, name, strlen(name) + 1);
+	request_msg.timeout = timeout;
+
+	if (timeout != TM_NO_RESPONSE) {
+		asprintf(&request_msg.q_name, "%s%d", TM_PRIVATE_MQ, request_msg.caller_pid);
+		if (request_msg.q_name == NULL) {
+			TM_FREE(request_msg.data);
+			return TM_OUT_OF_MEMORY;
+		}
+	}
+
+	status = taskmgr_send_request(&request_msg);
+	if (status < 0) {
+		TM_FREE(request_msg.data);
+		if (request_msg.q_name != NULL) {
+			TM_FREE(request_msg.q_name);
+		}
+		return status;
+	}
+
+	if (timeout != TM_NO_RESPONSE) {
+		status = taskmgr_receive_response(request_msg.q_name, &response_msg, timeout);
+		TM_FREE(request_msg.q_name);
+	}
+
+	return status;
+}
+
+int task_manager_register_task(char *name, int priority, int stack_size, main_t entry, char * argv[], int permission, int timeout)
+{
+	int status;
+	tm_request_t request_msg;
+	tm_response_t response_msg;
+
+	if (name == NULL || timeout < TM_RESPONSE_WAIT_INF || permission < TM_TASK_PERMISSION_ALL || permission > TM_TASK_PERMISSION_DEDICATE || priority < SCHED_PRIORITY_MIN || priority > SCHED_PRIORITY_MAX || stack_size < 1 || entry == NULL) {
+		return TM_INVALID_PARAM;
+	}
+
+	memset(&request_msg, 0, sizeof(tm_request_t));
+	request_msg.cmd = TASKMGR_REGISTER;
+	request_msg.caller_pid = getpid();
+	request_msg.handle = permission;
+	request_msg.data = (void *)TM_ALLOC(sizeof(tm_task_info_t));
+	if (request_msg.data == NULL) {
+		return TM_OUT_OF_MEMORY;
+	}
+	strncpy(((tm_task_info_t *)request_msg.data)->name, name, strlen(name) + 1);
+	((tm_task_info_t *)request_msg.data)->priority = priority;
+	((tm_task_info_t *)request_msg.data)->stack_size = stack_size;
+	((tm_task_info_t *)request_msg.data)->entry = entry;
+	((tm_task_info_t *)request_msg.data)->argv = argv;
+	request_msg.timeout = timeout;
+
+	if (timeout != TM_NO_RESPONSE) {
+		asprintf(&request_msg.q_name, "%s%d", TM_PRIVATE_MQ, request_msg.caller_pid);
+		if (request_msg.q_name == NULL) {
+			TM_FREE(request_msg.data);
+			return TM_OUT_OF_MEMORY;
+		}
+	}
+
+	status = taskmgr_send_request(&request_msg);
+	if (status < 0) {
+		TM_FREE(request_msg.data);
+		if (request_msg.q_name != NULL) {
+			TM_FREE(request_msg.q_name);
+		}
+		return status;
+	}
+
+	if (timeout != TM_NO_RESPONSE) {
+		status = taskmgr_receive_response(request_msg.q_name, &response_msg, timeout);
+		TM_FREE(request_msg.q_name);
+	}
+
+	return status;
+}
+
+int task_manager_register_pthread(char *name, pthread_attr_t *attr, pthread_startroutine_t start_routine, pthread_addr_t arg, int permission, int timeout)
+{
+	int status;
+	tm_request_t request_msg;
+	tm_response_t response_msg;
+
+	if (name == NULL || timeout < TM_RESPONSE_WAIT_INF || permission < TM_TASK_PERMISSION_ALL || permission > TM_TASK_PERMISSION_DEDICATE || attr == NULL || start_routine == NULL) {
+		return TM_INVALID_PARAM;
+	}
+
+	memset(&request_msg, 0, sizeof(tm_request_t));
+	request_msg.cmd = TASKMGR_REGISTER;
+	request_msg.caller_pid = getpid();
+	request_msg.handle = permission;
+	request_msg.data = (void *)TM_ALLOC(sizeof(tm_pthread_info_t));
+	if (request_msg.data == NULL) {
+		return TM_OUT_OF_MEMORY;
+	}
+	strncpy(((tm_pthread_info_t *)request_msg.data)->name, name, strlen(name) + 1);
+	((tm_pthread_info_t *)request_msg.data)->attr = attr;
+	((tm_pthread_info_t *)request_msg.data)->entry = start_routine;
+	((tm_pthread_info_t *)request_msg.data)->arg = arg;
 	request_msg.timeout = timeout;
 
 	if (timeout != TM_NO_RESPONSE) {

--- a/framework/src/task_manager/task_manager_restart.c
+++ b/framework/src/task_manager/task_manager_restart.c
@@ -39,7 +39,7 @@ int task_manager_restart(int handle, int timeout)
 	}
 
 	memset(&request_msg, 0, sizeof(tm_request_t));
-	request_msg.cmd = TASKMGR_RESTART;
+	request_msg.cmd = TASKMGRCMD_RESTART;
 	request_msg.handle = handle;
 	request_msg.caller_pid = getpid();
 	request_msg.timeout = timeout;

--- a/framework/src/task_manager/task_manager_resume.c
+++ b/framework/src/task_manager/task_manager_resume.c
@@ -40,7 +40,7 @@ int task_manager_resume(int handle, int timeout)
 
 	memset(&request_msg, 0, sizeof(tm_request_t));
 	/* Set the request msg */
-	request_msg.cmd = TASKMGR_RESUME;
+	request_msg.cmd = TASKMGRCMD_RESUME;
 	request_msg.handle = handle;
 	request_msg.caller_pid = getpid();
 	request_msg.timeout = timeout;

--- a/framework/src/task_manager/task_manager_set_callback.c
+++ b/framework/src/task_manager/task_manager_set_callback.c
@@ -31,14 +31,14 @@ void taskmgr_msg_cb(int signo, siginfo_t *data)
 {
 	int handle;
 	handle = taskmgr_get_handle_by_pid(getpid());
-	if (handle == TM_UNREGISTERED_TASK) {
+	if (handle == TM_UNREGISTERED_APP) {
 		tmdbg("Fail to get handle by pid\n");
 		return;
 	}
 	if (signo == CONFIG_SIG_SIGTM_UNICAST) {
-		(*TASK_UNICAST_CB(handle))((void *)data->si_value.sival_ptr);
+		(*TM_UNICAST_CB(handle))((void *)data->si_value.sival_ptr);
 	} else {
-		(*TASK_BROADCAST_CB(handle))(data->si_value.sival_int);
+		(*TM_BROADCAST_CB(handle))(data->si_value.sival_int);
 	}
 }
 /****************************************************************************
@@ -74,7 +74,7 @@ int task_manager_set_unicast_cb(void (*func)(void *data))
 
 	memset(&request_msg, 0, sizeof(tm_request_t));
 	/* Set the request msg */
-	request_msg.cmd = TASKMGR_SET_UNICAST_CB;
+	request_msg.cmd = TASKMGRCMD_SET_UNICAST_CB;
 	request_msg.caller_pid = getpid();
 	request_msg.data = (void *)func;
 	request_msg.timeout = TM_NO_RESPONSE;
@@ -116,7 +116,7 @@ int task_manager_set_broadcast_cb(int msg_mask, void (*func)(int data))
 	}
 
 	memset(&request_msg, 0, sizeof(tm_request_t));
-	request_msg.cmd = TASKMGR_SET_BROADCAST_CB;
+	request_msg.cmd = TASKMGRCMD_SET_BROADCAST_CB;
 	request_msg.caller_pid = getpid();
 	request_msg.timeout = TM_NO_RESPONSE;
 	request_msg.data = (void *)TM_ALLOC(sizeof(tm_broadcast_t));

--- a/framework/src/task_manager/task_manager_start.c
+++ b/framework/src/task_manager/task_manager_start.c
@@ -40,7 +40,7 @@ int task_manager_start(int handle, int timeout)
 
 	memset(&request_msg, 0, sizeof(tm_request_t));
 	/* Set the request msg */
-	request_msg.cmd = TASKMGR_START;
+	request_msg.cmd = TASKMGRCMD_START;
 	request_msg.handle = handle;
 	request_msg.caller_pid = getpid();
 	request_msg.timeout = timeout;

--- a/framework/src/task_manager/task_manager_state.c
+++ b/framework/src/task_manager/task_manager_state.c
@@ -38,9 +38,9 @@ static void taskmgr_update_task_state(int handle)
 		return;
 	}
 
-	ret = ioctl(fd, TMIOC_CHECK_ALIVE, TASK_PID(handle));
-	if (ret != OK && TASK_LIST_ADDR(handle) != NULL) {
-		TASK_STATUS(handle) = TM_TASK_STATE_STOP;
+	ret = ioctl(fd, TMIOC_CHECK_ALIVE, TM_PID(handle));
+	if (ret != OK && TM_LIST_ADDR(handle) != NULL) {
+		TM_STATUS(handle) = TM_APP_STATE_STOP;
 	}
 }
 
@@ -49,11 +49,11 @@ static void taskmgr_update_task_state(int handle)
  ****************************************************************************/
 int taskmgr_get_task_state(int handle)
 {
-	if (IS_INVALID_HANDLE(handle) || TASK_LIST_ADDR(handle) == NULL) {
-		return TM_TASK_STATE_UNREGISTERED;
+	if (IS_INVALID_HANDLE(handle) || TM_LIST_ADDR(handle) == NULL) {
+		return TM_APP_STATE_UNREGISTERED;
 	}
 
 	taskmgr_update_task_state(handle);
 
-	return (TASK_STATUS(handle));
+	return (TM_STATUS(handle));
 }

--- a/framework/src/task_manager/task_manager_stop.c
+++ b/framework/src/task_manager/task_manager_stop.c
@@ -40,7 +40,7 @@ int task_manager_stop(int handle, int timeout)
 
 	memset(&request_msg, 0, sizeof(tm_request_t));
 	/* Set the request msg */
-	request_msg.cmd = TASKMGR_STOP;
+	request_msg.cmd = TASKMGRCMD_STOP;
 	request_msg.handle = handle;
 	request_msg.caller_pid = getpid();
 	request_msg.timeout = timeout;

--- a/framework/src/task_manager/task_manager_unicast.c
+++ b/framework/src/task_manager/task_manager_unicast.c
@@ -51,7 +51,7 @@ int task_manager_unicast(int handle, void *msg, int msg_size, int timeout)
 	}
 
 	/* Set the request msg */
-	request_msg.cmd = TASKMGR_UNICAST;
+	request_msg.cmd = TASKMGRCMD_UNICAST;
 	request_msg.handle = handle;
 	request_msg.caller_pid = getpid();
 	request_msg.timeout = timeout;

--- a/framework/src/task_manager/task_manager_unregister.c
+++ b/framework/src/task_manager/task_manager_unregister.c
@@ -39,7 +39,7 @@ int task_manager_unregister(int handle, int timeout)
 	}
 
 	memset(&request_msg, 0, sizeof(tm_request_t));
-	request_msg.cmd = TASKMGR_UNREGISTER;
+	request_msg.cmd = TASKMGRCMD_UNREGISTER;
 	request_msg.handle = handle;
 	request_msg.caller_pid = getpid();
 	request_msg.timeout = timeout;


### PR DESCRIPTION
…are not in a builtin-list

Task Manager can manage not only builtin tasks, but also task and pthread which are not in a builtin list.
Most of the functionality in Task Manager are adapted to normal tasks and pthreads.
But restart is not supported for pthreads.