### PR TITLE
framework/wifi_manager: Distinguish RECONNECT and DISCONNECT when callback

### DIFF
--- a/apps/examples/mediastreamer/mediastreamer_main.cpp
+++ b/apps/examples/mediastreamer/mediastreamer_main.cpp
@@ -52,7 +52,7 @@ static void wifi_sta_connected(wifi_manager_result_e result) {
 	std::cout << __FUNCTION__ << std::endl;
 }
 
-static void wifi_sta_disconnected() {
+static void wifi_sta_disconnected(wifi_manager_disconnect_e disconn) {
 	std::cout << __FUNCTION__ << std::endl;
 }
 

--- a/apps/examples/testcase/le_tc/tcp_tls/tcp_tls_stress.c
+++ b/apps/examples/testcase/le_tc/tcp_tls/tcp_tls_stress.c
@@ -97,7 +97,7 @@ typedef enum {
  * Callbacks
  */
 static void wm_sta_connected(wifi_manager_result_e);
-static void wm_sta_disconnected(void);
+static void wm_sta_disconnected(wifi_manager_disconnect_e);
 
 /*
  * Global
@@ -129,7 +129,7 @@ void wm_sta_connected(wifi_manager_result_e res)
 	WM_TEST_SIGNAL;
 }
 
-void wm_sta_disconnected(void)
+void wm_sta_disconnected(wifi_manager_disconnect_e disconn)
 {
 	printf(" T%d --> %s\n", getpid(), __FUNCTION__);
 	WM_TEST_SIGNAL;

--- a/apps/examples/testcase/ta_tc/wifi_manager/itc/itc_wifi_manager_main.c
+++ b/apps/examples/testcase/ta_tc/wifi_manager/itc/itc_wifi_manager_main.c
@@ -53,7 +53,7 @@ static pthread_cond_t g_wifi_manager_test_cond;
 	} while (0)
 
 static void wifi_sta_connected_cb(wifi_manager_result_e res); // in station mode, connected to ap
-static void wifi_sta_disconnected_cb(void); // in station mode, disconnected from ap
+static void wifi_sta_disconnected_cb(wifi_manager_disconnect_e disconn); // in station mode, disconnected from ap
 static void wifi_scan_ap_done_cb(wifi_manager_scan_info_s **scan_info, wifi_manager_scan_result_e res); // called when scanning ap is done
 
 static wifi_manager_cb_s wifi_callbacks = {
@@ -70,7 +70,7 @@ static void wifi_sta_connected_cb(wifi_manager_result_e res)
 	WIFITEST_SIGNAL;
 }
 
-static void wifi_sta_disconnected_cb(void)
+static void wifi_sta_disconnected_cb(wifi_manager_disconnect_e disconn)
 {
 	printf("wifi_sta_disconnected: send signal!!! \n");
 	WIFITEST_SIGNAL;

--- a/apps/examples/testcase/ta_tc/wifi_manager/utc/utc_wifi_manager_main.c
+++ b/apps/examples/testcase/ta_tc/wifi_manager/utc/utc_wifi_manager_main.c
@@ -41,7 +41,7 @@ do {										\
 	pthread_mutex_unlock(&g_wifi_manager_test_mutex);			\
 } while (0)
 void wifi_sta_connected(wifi_manager_result_e result);		// in station mode, connected to ap
-void wifi_sta_disconnected(void);	// in station mode, disconnected from ap
+void wifi_sta_disconnected(wifi_manager_disconnect_e disconn);	// in station mode, disconnected from ap
 void wifi_softap_sta_joined(void);	// in softap mode, a station joined
 void wifi_softap_sta_left(void);		// in softap mode, a station left
 void wifi_scan_ap_done(wifi_manager_scan_info_s **scan_info, wifi_manager_scan_result_e res); // called when scanning ap is done
@@ -68,7 +68,7 @@ void wifi_sta_connected(wifi_manager_result_e result)
 	WIFITEST_SIGNAL;
 }
 
-void wifi_sta_disconnected(void)
+void wifi_sta_disconnected(wifi_manager_disconnect_e disconn)
 {
 	printf("wifi_sta_disconnected: send signal!!! \n");
 	WIFITEST_SIGNAL;

--- a/apps/examples/wifi_manager_sample/wm_test.c
+++ b/apps/examples/wifi_manager_sample/wm_test.c
@@ -82,7 +82,7 @@ int wm_signal_init(void);
  * callbacks
  */
 static void wm_sta_connected(wifi_manager_result_e);
-static void wm_sta_disconnected(void);
+static void wm_sta_disconnected(wifi_manager_disconnect_e);
 static void wm_softap_sta_join(void);
 static void wm_softap_sta_leave(void);
 static void wm_scan_done(wifi_manager_scan_info_s **scan_result, wifi_manager_scan_result_e res);
@@ -334,7 +334,7 @@ void wm_sta_connected(wifi_manager_result_e res)
 }
 
 
-void wm_sta_disconnected(void)
+void wm_sta_disconnected(wifi_manager_disconnect_e disconn)
 {
 	sleep(2);
 	printf(" T%d --> %s\n", getpid(), __FUNCTION__);

--- a/apps/examples/wifi_manager_sample/wm_test_stress.c
+++ b/apps/examples/wifi_manager_sample/wm_test_stress.c
@@ -56,7 +56,7 @@
  * callbacks
  */
 static void wm_sta_connected(wifi_manager_result_e);
-static void wm_sta_disconnected(void);
+static void wm_sta_disconnected(wifi_manager_disconnect_e);
 static void wm_softap_sta_join(void);
 static void wm_softap_sta_leave(void);
 static void wm_scan_done(wifi_manager_scan_info_s **scan_result, wifi_manager_scan_result_e res);
@@ -85,7 +85,7 @@ void wm_sta_connected(wifi_manager_result_e res)
 }
 
 
-void wm_sta_disconnected(void)
+void wm_sta_disconnected(wifi_manager_disconnect_e disconn)
 {
 	printf(" T%d --> %s\n", getpid(), __FUNCTION__);
 	WM_TEST_SIGNAL;

--- a/framework/include/wifi_manager/wifi_manager.h
+++ b/framework/include/wifi_manager/wifi_manager.h
@@ -68,6 +68,14 @@ typedef enum {
 } wifi_manager_result_e;
 
 /**
+ * @brief Wi-Fi disconnect event reason
+ */
+typedef enum {
+	WIFI_MANAGER_DISCONNECT,
+	WIFI_MANAGER_RECONNECT, //AUTOCONNECT
+} wifi_manager_disconnect_to;
+
+/**
  * @brief Mode of Wi-Fi interface such as station mode or ap mode
  */
 typedef enum {
@@ -116,7 +124,7 @@ typedef struct wifi_manager_scan_info_s wifi_manager_scan_info_s;
  */
 typedef struct {
 	void (*sta_connected)(wifi_manager_result_e);	// in station mode, connected to ap
-	void (*sta_disconnected)(void);		// in station mode, disconnected from ap
+	void (*sta_disconnected)(wifi_manager_disconnect_to);		// in station mode, disconnected from ap
 	void (*softap_sta_joined)(void);	// in softap mode, a station joined
 	void (*softap_sta_left)(void);		// in softap mode, a station left
 	void (*scan_ap_done)(wifi_manager_scan_info_s **, wifi_manager_scan_result_e); // scanning ap is done

--- a/framework/include/wifi_manager/wifi_manager.h
+++ b/framework/include/wifi_manager/wifi_manager.h
@@ -73,7 +73,7 @@ typedef enum {
 typedef enum {
 	WIFI_MANAGER_DISCONNECT,
 	WIFI_MANAGER_RECONNECT, //AUTOCONNECT
-} wifi_manager_disconnect_to;
+} wifi_manager_disconnect_e;
 
 /**
  * @brief Mode of Wi-Fi interface such as station mode or ap mode
@@ -124,7 +124,7 @@ typedef struct wifi_manager_scan_info_s wifi_manager_scan_info_s;
  */
 typedef struct {
 	void (*sta_connected)(wifi_manager_result_e);	// in station mode, connected to ap
-	void (*sta_disconnected)(wifi_manager_disconnect_to);		// in station mode, disconnected from ap
+	void (*sta_disconnected)(wifi_manager_disconnect_e);		// in station mode, disconnected from ap
 	void (*softap_sta_joined)(void);	// in softap mode, a station joined
 	void (*softap_sta_left)(void);		// in softap mode, a station left
 	void (*scan_ap_done)(wifi_manager_scan_info_s **, wifi_manager_scan_result_e); // scanning ap is done

--- a/framework/src/st_things/things_stack/utils/things_network.c
+++ b/framework/src/st_things/things_stack/utils/things_network.c
@@ -301,7 +301,7 @@ void things_wifi_sta_connected(wifi_manager_result_e res)
 	}
 }
 
-void things_wifi_sta_disconnected(void)
+void things_wifi_sta_disconnected(wifi_manager_disconnect_e disconn)
 {
 	THINGS_LOG_V(TAG, "T%d --> %s", getpid(), __FUNCTION__);
 	things_wifi_changed_call_func(0, NULL, NULL);


### PR DESCRIPTION
- Pass an additional parameter, wifi_manager_disconnect_to, to disconnect callback
  in order for the callback function to distinguish
  whether Wi-Fi Manager goes into RE(AUTO)CONNECT or not
- Add enum, wifi_manager_disconnect_to,  to distinguish RECONNECT and DISCONNECT
  when calling disconnect callback
- Modify the location of link up/down messages passed to iotivity
- Modify all of the sta_disconnected callback functions used in the applications