### PR TITLE
framework/task_manager: Support stop and exit callback

### DIFF
--- a/apps/examples/testcase/ta_tc/task_manager/utc/utc_task_manager_main.c
+++ b/apps/examples/testcase/ta_tc/task_manager/utc/utc_task_manager_main.c
@@ -254,24 +254,24 @@ static void utc_task_manager_set_broadcast_cb_p(void)
 	TC_SUCCESS_RESULT();
 }
 
-static void utc_task_manager_set_termination_cb_n(void)
+static void utc_task_manager_set_exit_cb_n(void)
 {
 	int ret;
-	ret = task_manager_set_termination_cb(NULL);
-	TC_ASSERT_EQ("task_manager_set_termination_cb", ret, TM_INVALID_PARAM);
+	ret = task_manager_set_exit_cb(NULL);
+	TC_ASSERT_EQ("task_manager_set_exit_cb", ret, TM_INVALID_PARAM);
 
 	TC_SUCCESS_RESULT();
 }
 
-static void utc_task_manager_set_termination_cb_p(void)
+static void utc_task_manager_set_exit_cb_p(void)
 {
 	int ret;
 	/* No meaningful malloc for testing resource collection handler */
 	addr = (int *)malloc(123);
 	addr2 = (int *)malloc(456);
 
-	ret = task_manager_set_termination_cb(free_handler);
-	TC_ASSERT_EQ_CLEANUP("task_manager_set_termination_cb", ret, OK, free(addr); free(addr2));
+	ret = task_manager_set_exit_cb(free_handler);
+	TC_ASSERT_EQ_CLEANUP("task_manager_set_exit_cb", ret, OK, free(addr); free(addr2));
 
 	TC_SUCCESS_RESULT();
 }
@@ -611,8 +611,8 @@ int utc_task_manager_main(int argc, char *argv[])
 	utc_task_manager_set_broadcast_cb_n();
 	utc_task_manager_set_broadcast_cb_p();
 
-	utc_task_manager_set_termination_cb_n();
-	utc_task_manager_set_termination_cb_p();
+	utc_task_manager_set_exit_cb_n();
+	utc_task_manager_set_exit_cb_p();
 
 	utc_task_manager_unicast_n();
 	utc_task_manager_unicast_p();

--- a/framework/include/task_manager/task_manager.h
+++ b/framework/include/task_manager/task_manager.h
@@ -274,13 +274,21 @@ int task_manager_set_unicast_cb(void (*func)(void *data));
  */
 int task_manager_set_broadcast_cb(int msg_mask, void (*func)(int data));
 /**
- * @brief Set callback function for resource deallocation API. If you set the callback, it will works when task is terminated.
+ * @brief Set callback function for resource deallocation API. If you set the callback, it will works when task terminates.
  * @details @b #include <task_manager/task_manager.h>
  * @param[in] func the callback function which deallocate resources\n
  * @return On success, OK is returned. On failure, defined negative value is returned.
  * @since TizenRT v2.0 PRE
  */
-int task_manager_set_termination_cb(void (*func)(void));
+int task_manager_set_exit_cb(void (*func)(void));
+/**
+ * @brief Set callback function for resource deallocation API. If you set the callback, it will works when task is cancelled.
+ * @details @b #include <task_manager/task_manager.h>
+ * @param[in] func the callback function which deallocate resources\n
+ * @return On success, OK is returned. On failure, defined negative value is returned.
+ * @since TizenRT v2.0 PRE
+ */
+int task_manager_set_stop_cb(void (*func)(void));
 /**
  * @brief Get task information list through task name
  * @details @b #include <task_manager/task_manager.h>

--- a/framework/src/task_manager/task_manager_internal.h
+++ b/framework/src/task_manager/task_manager_internal.h
@@ -42,6 +42,8 @@
 #define TASKMGRCMD_SCAN_GROUP              13
 #define TASKMGRCMD_REGISTER_TASK           14
 #define TASKMGRCMD_REGISTER_PTHREAD        15
+#define TASKMGRCMD_SET_STOP_CB             16
+#define TASKMGRCMD_SET_EXIT_CB             17
 
 /* Task Type */
 #define TM_BUILTIN_TASK			0
@@ -57,8 +59,12 @@
 #define TM_ALLOC(a)  malloc(a)
 #define TM_FREE(a)   free(a)
 
+/* Temporary State for Cancel */
+#define TM_APP_STATE_CANCELLING -1
+
 typedef void (*_tm_unicast_t)(void *);
 typedef void (*_tm_broadcast_t)(int);
+typedef void (*_tm_termination_t)(void);
 
 struct app_list_s {
 	int pid;
@@ -76,6 +82,8 @@ struct app_list_data_s {
 	int msg_mask;
 	_tm_unicast_t unicast_cb;
 	_tm_broadcast_t broadcast_cb;
+	_tm_termination_t stop_cb;
+	_tm_termination_t exit_cb;
 };
 typedef struct app_list_data_s app_list_data_t;
 
@@ -124,12 +132,14 @@ typedef struct tm_pthread_info_s tm_pthread_info_t;
 #define TM_PID(handle)             tm_app_list[handle].pid
 #define TM_TYPE(handle)            TM_LIST_ADDR(handle)->type
 #define TM_IDX(handle)             TM_LIST_ADDR(handle)->idx
-#define TM_GID(handle)          TM_LIST_ADDR(handle)->tm_gid
+#define TM_GID(handle)             TM_LIST_ADDR(handle)->tm_gid
 #define TM_STATUS(handle)          TM_LIST_ADDR(handle)->status
 #define TM_PERMISSION(handle)      TM_LIST_ADDR(handle)->permission
 #define TM_MSG_MASK(handle)        TM_LIST_ADDR(handle)->msg_mask
 #define TM_UNICAST_CB(handle)      TM_LIST_ADDR(handle)->unicast_cb
 #define TM_BROADCAST_CB(handle)    TM_LIST_ADDR(handle)->broadcast_cb
+#define TM_STOP_CB(handle)         TM_LIST_ADDR(handle)->stop_cb
+#define TM_EXIT_CB(handle)         TM_LIST_ADDR(handle)->exit_cb
 
 extern app_list_t tm_app_list[CONFIG_TASK_MANAGER_MAX_TASKS];
 

--- a/framework/src/task_manager/task_manager_set_callback.c
+++ b/framework/src/task_manager/task_manager_set_callback.c
@@ -135,18 +135,55 @@ int task_manager_set_broadcast_cb(int msg_mask, void (*func)(int data))
 }
 
 /****************************************************************************
- * task_manager_set_termination_cb
+ * task_manager_set_exit_cb
  ****************************************************************************/
-int task_manager_set_termination_cb(void (*func)(void))
+int task_manager_set_exit_cb(void (*func)(void))
 {
+	int ret = OK;
+	tm_request_t request_msg;
+
 	if (func == NULL) {
 		return TM_INVALID_PARAM;
 	}
 
-	if (atexit((void *)func) != OK) {
-		tmdbg("Faile to register a function at exit\n");
-		return TM_OPERATION_FAIL;
+	/* send exit callback function to task manager */
+	memset(&request_msg, 0, sizeof(tm_request_t));
+	/* Set the request msg */
+	request_msg.cmd = TASKMGRCMD_SET_EXIT_CB;
+	request_msg.caller_pid = getpid();
+	request_msg.data = (void *)func;
+	request_msg.timeout = TM_NO_RESPONSE;
+	ret = taskmgr_send_request(&request_msg);
+	if (ret < 0) {
+		return ret;
 	}
 
-	return OK;
+	return ret;
+}
+
+/****************************************************************************
+ * task_manager_set_stop_cb
+ ****************************************************************************/
+int task_manager_set_stop_cb(void (*func)(void))
+{
+	int ret = OK;
+	tm_request_t request_msg;
+
+	if (func == NULL) {
+		return TM_INVALID_PARAM;
+	}
+
+	/* send stop callback function to task manager */
+	memset(&request_msg, 0, sizeof(tm_request_t));
+	/* Set the request msg */
+	request_msg.cmd = TASKMGRCMD_SET_STOP_CB;
+	request_msg.caller_pid = getpid();
+	request_msg.data = (void *)func;
+	request_msg.timeout = TM_NO_RESPONSE;
+	ret = taskmgr_send_request(&request_msg);
+	if (ret < 0) {
+		return ret;
+	}
+
+	return ret;
 }

--- a/os/drivers/task_manager/task_manager_drv.c
+++ b/os/drivers/task_manager/task_manager_drv.c
@@ -30,7 +30,7 @@
 #include <tinyara/fs/fs.h>
 #include <tinyara/fs/ioctl.h>
 #include <tinyara/wdog.h>
-#include <tinyara/task_manager_drv.h>
+#include <tinyara/task_manager_internal.h>
 
 /****************************************************************************
  * Private Function Prototypes

--- a/os/include/tinyara/task_manager_internal.h
+++ b/os/include/tinyara/task_manager_internal.h
@@ -16,8 +16,8 @@
  *
  ****************************************************************************/
 
-#ifndef __INCLUDE_TINYARA_TASK_MANAGER_DRV_H
-#define __INCLUDE_TINYARA_TASK_MANAGER_DRV_H
+#ifndef __INCLUDE_TINYARA_TASK_MANAGER_INTERNAL_H
+#define __INCLUDE_TINYARA_TASK_MANAGER_INTERNAL_H
 
 /* This file will be used to provide definitions to support
  * task manager framework
@@ -36,6 +36,11 @@
 
 void task_manager_drv_register(void);
 
+/**
+ * @brief function for run exit callback when task is terminated.
+ */
+int task_manager_run_exit_cb(int pid);
+
 #ifdef __cplusplus
 #define EXTERN extern "C"
 extern "C" {
@@ -48,4 +53,4 @@ extern "C" {
 }
 #endif
 
-#endif /* __INCLUDE_TINYARA_TASK_MANAGER_DRV_H */
+#endif /* __INCLUDE_TINYARA_TASK_MANAGER_INTERNAL_H */

--- a/os/kernel/init/os_bringup.c
+++ b/os/kernel/init/os_bringup.c
@@ -73,7 +73,7 @@
 #include <tinyara/logm.h>
 #endif
 #ifdef CONFIG_TASK_MANAGER
-#include <tinyara/task_manager_drv.h>
+#include <tinyara/task_manager_internal.h>
 #endif
 #include "wqueue/wqueue.h"
 #include "init/init.h"

--- a/os/kernel/task/task_exithook.c
+++ b/os/kernel/task/task_exithook.c
@@ -70,6 +70,10 @@
 #include "signal/signal.h"
 #include "task/task.h"
 
+#ifdef CONFIG_TASK_MANAGER
+#include <task_manager/task_manager.h>
+#endif
+
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
@@ -565,6 +569,10 @@ void task_exithook(FAR struct tcb_s *tcb, int status, bool nonblocking)
 	if ((tcb->flags & TCB_FLAG_EXIT_PROCESSING) != 0) {
 		return;
 	}
+
+#ifdef CONFIG_TASK_MANAGER
+	task_manager_run_exit_cb(tcb->pid);
+#endif
 
 #ifdef CONFIG_CANCELLATION_POINTS
 	/* Mark the task as non-cancelable to avoid additional calls to exit()


### PR DESCRIPTION
User can set stop and exit callback with Task Manager.
task_manager_set_termination_cb is changed to task_manager_set_exit_cb.