### PR TITLE
framework/task_manager: Support register a callback fuction for each …

### DIFF
--- a/apps/examples/testcase/Makefile
+++ b/apps/examples/testcase/Makefile
@@ -191,6 +191,7 @@ ifeq ($(CONFIG_EXAMPLES_TESTCASE_TASK_MANAGER_UTC),y)
 	$(Q) $(call REGISTER,tm_broadcast1,tm_broadcast1_main,TASH_EXECMD_ASYNC,101,1024)
 	$(Q) $(call REGISTER,tm_broadcast2,tm_broadcast2_main,TASH_EXECMD_ASYNC,101,1024)
 	$(Q) $(call REGISTER,tm_broadcast3,tm_broadcast3_main,TASH_EXECMD_ASYNC,101,1024)
+	$(Q) $(call REGISTER,tm_utc,tm_utc_main,TASH_EXECMD_ASYNC,101,1024)
 endif
 ifeq ($(CONFIG_EXAMPLES_TESTCASE_TTRACE),y)
 	$(Q) $(call REGISTER,ttrace_tc,tc_ttrace_main,TASH_EXECMD_ASYNC,100,2048)

--- a/framework/include/task_manager/task_manager_broadcast_list.h
+++ b/framework/include/task_manager/task_manager_broadcast_list.h
@@ -1,0 +1,64 @@
+/****************************************************************************
+ *
+ * Copyright 2018 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+ /****************************************************************************
+ * Included Files
+ ****************************************************************************/
+#include <task_manager/task_manager.h>
+
+/**
+ * @ingroup Task_Manager
+ * @brief User specific broadcast messages are declared at this file.
+ * @{
+ */
+
+/**
+ * @file task_manager/task_manager_broadcast_list.h
+ */
+#ifndef __TASK_MANAGER_BROADCAST_LIST_H__
+#define __TASK_MANAGER_BROADCAST_LIST_H__
+
+/**
+ * @brief User specific broadcast message list
+ * @details These values can be used for broadcast messges.\n
+ * If user wants to add some other types of broadcast message,\n
+ * user can add their own broadcast messages at here.\n
+ * \n
+ * User must avoid setting an arbitrary value to their broadcast message.\n
+ * First user specific broadcast message would be set as (TM_BROADCAST_USER_SPECIFIC_MAX + 1).\n
+ * Other user specific broadcast messages are automatically set as asceding order.\n
+ * An example of a user specific broadcast message is shown below\n
+ * \n
+ * enum tm_user_specific_broadcast_msg {\n
+ *		TM_BROADCAST_USER_SPECIFIC_MIN = TM_BROADCAST_SYSTEM_MSG_MAX,\n
+ *		TM_USER_SPECIFIC_BROADCAST_MSG_1,\n
+ *		TM_USER_SPECIFIC_BROADCAST_MSG_2,\n
+ *		TM_BROADCAST_MSG_MAX,\n
+ * };
+ */
+
+enum tm_user_specific_broadcast_msg {
+	TM_BROADCAST_USER_SPECIFIC_MIN = TM_BROADCAST_SYSTEM_MSG_MAX,
+		
+/* Please Add User Specific Broadcast Message at HERE */
+	
+	TM_BROADCAST_MSG_MAX,
+};
+#endif
+/**
+ * @}
+ */

--- a/framework/src/task_manager/Kconfig
+++ b/framework/src/task_manager/Kconfig
@@ -27,4 +27,9 @@ config TASK_MANAGER_MAX_MSG
 	---help---
 		Task Manager can receive under this value.
 
+config TASK_MANAGER_USER_SPECIFIC_BROADCAST
+	bool "Enable User Specific Broadcast Message"
+	default n
+	---help---
+		User defined broadcast messages are enabled to use at the Task Manager.
 endif

--- a/framework/src/task_manager/Make.defs
+++ b/framework/src/task_manager/Make.defs
@@ -20,7 +20,7 @@ ifeq ($(CONFIG_TASK_MANAGER),y)
 
 CSRCS += task_manager_register.c task_manager_unregister.c task_manager_start.c task_manager_stop.c task_manager_restart.c task_manager_pause.c task_manager_resume.c
 CSRCS += task_manager_getinfo.c task_manager_unicast.c task_manager_cleaninfo.c task_manager_set_callback.c task_manager_state.c task_manager_permission.c
-CSRCS += task_manager_core.c task_manager_interface.c task_manager_broadcast.c
+CSRCS += task_manager_core.c task_manager_interface.c task_manager_broadcast.c task_manager_alloc_broadcast_msg.c task_manager_unset_broadcast_cb.c task_manager_dealloc_broadcast_msg.c
 
 DEPPATH += --dep-path src/task_manager
 VPATH += :src/task_manager

--- a/framework/src/task_manager/task_manager_alloc_broadcast_msg.c
+++ b/framework/src/task_manager/task_manager_alloc_broadcast_msg.c
@@ -1,0 +1,59 @@
+
+/****************************************************************************
+ *
+ * Copyright 2018 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+#include <string.h>
+#include <unistd.h>
+#include <sys/types.h>
+#include <task_manager/task_manager.h>
+#include "task_manager_internal.h"
+
+/****************************************************************************
+ * task_manager_alloc_broadcast_msg
+ ****************************************************************************/
+int task_manager_alloc_broadcast_msg(void)
+{
+	int status;
+	tm_request_t request_msg;
+	tm_response_t response_msg;
+
+	memset(&request_msg, 0, sizeof(tm_request_t));
+	request_msg.cmd = TASKMGRCMD_ALLOC_BROADCAST_MSG;
+	request_msg.caller_pid = getpid();
+	request_msg.timeout = TM_RESPONSE_WAIT_INF;
+
+	asprintf(&request_msg.q_name, "%s%d", TM_PRIVATE_MQ, request_msg.caller_pid);
+	if (request_msg.q_name == NULL) {
+		return TM_OUT_OF_MEMORY;
+	}
+	
+	status = taskmgr_send_request(&request_msg);
+	if (status < 0) {
+		if (request_msg.q_name != NULL) {
+			TM_FREE(request_msg.q_name);
+		}
+		return status;
+	}
+	
+	status = taskmgr_receive_response(request_msg.q_name, &response_msg, TM_RESPONSE_WAIT_INF);
+	TM_FREE(request_msg.q_name);
+	
+	return status;
+}

--- a/framework/src/task_manager/task_manager_core.c
+++ b/framework/src/task_manager/task_manager_core.c
@@ -28,12 +28,16 @@
 #include <fcntl.h>
 #include <errno.h>
 #include <debug.h>
+#include <queue.h>
 #include <sys/types.h>
 #include <sys/ioctl.h>
 #include <apps/builtin.h>
 #include <tinyara/fs/ioctl.h>
 #include <tinyara/task_manager_internal.h>
 #include <task_manager/task_manager.h>
+#ifdef CONFIG_TASK_MANAGER_USER_SPECIFIC_BROADCAST
+#include <task_manager/task_manager_broadcast_list.h>
+#endif
 #include "task_manager_internal.h"
 
 /****************************************************************************
@@ -52,6 +56,7 @@ tm_pthread_info_t tm_pthread_list[CONFIG_TASK_MANAGER_MAX_TASKS];
 app_list_t tm_app_list[CONFIG_TASK_MANAGER_MAX_TASKS];
 tm_task_info_t tm_task_list[CONFIG_TASK_MANAGER_MAX_TASKS];
 static bool g_handle_hash[CONFIG_TASK_MANAGER_MAX_TASKS];
+int tm_broadcast_msg[TM_BROADCAST_MSG_MAX + CONFIG_TASK_MANAGER_MAX_TASKS];
 
 #define MAX_HANDLE_MASK (CONFIG_TASK_MANAGER_MAX_TASKS - 1)
 #define HANDLE_HASH(handle)  ((handle) & MAX_HANDLE_MASK)
@@ -164,11 +169,21 @@ static int taskmgr_register(char *name, int permission, int caller_pid)
 		TM_PERMISSION(handle) = permission;
 		TM_STOP_CB(handle) = NULL;
 		TM_EXIT_CB(handle) = NULL;
+		sq_init(&TM_BROADCAST_INFO_LIST(handle));
 		tmvdbg("Registered handle %d\n", handle);
 		handle_cnt++;
 	}
 
 	return handle;
+}
+
+static void taskmgr_clear_broadcast_info_list(int handle)
+{
+	tm_broadcast_info_t *curr;
+
+	while ((curr = (tm_broadcast_info_t *)sq_remfirst(&TM_BROADCAST_INFO_LIST(handle))) != NULL) {
+		TM_FREE(curr);
+	}
 }
 
 static int taskmgr_unregister(int handle)
@@ -201,6 +216,7 @@ static int taskmgr_unregister(int handle)
 	TM_PID(handle) = 0;
 	TM_STOP_CB(handle) = NULL;
 	TM_EXIT_CB(handle) = NULL;
+	taskmgr_clear_broadcast_info_list(handle);
 	TM_FREE(tm_app_list[handle].addr);
 	tm_app_list[handle].addr = NULL;
 	g_handle_hash[handle] = false;
@@ -290,6 +306,7 @@ static int taskmgr_stop(int handle, int caller_pid)
 	if (!taskmgr_is_permitted(handle, caller_pid)) {
 		return TM_NO_PERMISSION;
 	}
+
 
 	/* Call stop callback */
 	TM_STATUS(handle) = TM_APP_STATE_CANCELLING;
@@ -644,14 +661,6 @@ static void taskmgr_termination_callback(void)
 	mq_unlink(TM_PUBLIC_MQ);
 }
 
-static int taskmgr_check_msg_mask(int msg_mask, int handle)
-{
-	if (msg_mask & TM_MSG_MASK(handle)) {
-		return OK;
-	}
-	return ERROR;
-}
-
 int taskmgr_get_handle_by_pid(int pid)
 {
 	int handle;
@@ -663,56 +672,172 @@ int taskmgr_get_handle_by_pid(int pid)
 	return TM_UNREGISTERED_APP;
 }
 
+static int taskmgr_check_broad_msg(int msg)
+{
+	if (tm_broadcast_msg[msg - 1] == msg) {
+		return OK;
+	}
+	return TM_UNREGISTERED_MSG;
+}
+
+static tm_broadcast_info_t *taskmgr_search_broadcast_info(int msg, int handle)
+{
+	tm_broadcast_info_t *curr;
+
+	if (taskmgr_check_broad_msg(msg) != OK) {
+		tmdbg("Not regiseterd broadcast msg: %d\n", msg);
+		return NULL;
+	}
+	curr = (tm_broadcast_info_t *)sq_peek(&TM_BROADCAST_INFO_LIST(handle));
+	while (curr) {
+		if (curr->msg == msg) {
+			return curr;
+		}
+		curr = sq_next(curr);
+	}
+	return curr;
+}
+
 static void taskmgr_broadcast(int msg)
 {
 	int handle;
 	int fd;
 	int ret;
 	union sigval msg_broad;
+	tm_broadcast_info_t *broadcast_info;
 
 	fd = taskmgr_get_drvfd();
 	if (fd < 0) {
 		return;
 	}
-	msg_broad.sival_int = msg;
+
+	ret = taskmgr_check_broad_msg(msg);
+	if (ret == TM_UNREGISTERED_MSG) {
+		return;
+	}
+
 	for (handle = 0; handle < CONFIG_TASK_MANAGER_MAX_TASKS; handle++) {
 		if (TM_LIST_ADDR(handle) != NULL) {
 			ret = taskmgr_get_task_state(handle);
 			if (ret == TM_APP_STATE_STOP || ret == TM_APP_STATE_UNREGISTERED) {
 				continue;
 			}
-			ret = taskmgr_check_msg_mask(msg, handle);
-			if (ret != OK) {
-				continue;
-			}
 			ret = ioctl(fd, TMIOC_BROADCAST, TM_PID(handle));
 			if (ret != OK) {
 				continue;
 			}
+			broadcast_info = taskmgr_search_broadcast_info(msg, handle);
+			if (broadcast_info == NULL) {
+				continue;
+			}
+			msg_broad.sival_ptr = broadcast_info;
 			(void)sigqueue(TM_PID(handle), SIGTM_BROADCAST, msg_broad);
 		}
 	}
 }
 
+static void taskmgr_broadcast_msg_init(void)
+{
+	int chk_idx;
+	int msg_num;
+
+	for (chk_idx = 0; chk_idx < TM_BROADCAST_MSG_MAX + CONFIG_TASK_MANAGER_MAX_TASKS; chk_idx++) {
+		msg_num = chk_idx + 1;
+		if (chk_idx < (TM_BROADCAST_MSG_MAX - 1)) {
+			tm_broadcast_msg[chk_idx] = msg_num;
+		} else {
+			tm_broadcast_msg[chk_idx] = -1;
+		}
+	}
+}
+
+static int taskmgr_is_tm_broadcast_msg_init(void)
+{
+	if ((tm_broadcast_msg[0] != 1) && (tm_broadcast_msg[0] != -1)) {
+		 return 0;
+	}
+	return 1;
+}
+
 static int taskmgr_set_msg_cb(int type, void *data, int pid)
 {
 	int handle;
+	int ret;
+	tm_broadcast_info_t *broadcast_info;
 
 	if (data == NULL) {
 		return TM_INVALID_PARAM;
 	}
+	handle = taskmgr_get_handle_by_pid(pid);
+	if (handle == TM_UNREGISTERED_APP) {
+		return handle;
+	}
+	if (type == TYPE_UNICAST) {
+		TM_UNICAST_CB(handle) = (_tm_unicast_t)data;
+	} else {
+		if (!taskmgr_is_tm_broadcast_msg_init()) {
+			taskmgr_broadcast_msg_init();
+		}
+		ret = taskmgr_check_broad_msg(((tm_broadcast_info_t *)data)->msg);
+		if (ret == TM_UNREGISTERED_MSG) {
+			return ret;
+		}
+		broadcast_info = taskmgr_search_broadcast_info(((tm_broadcast_info_t *)data)->msg, handle);
+		if (broadcast_info == NULL) {
+			broadcast_info = (tm_broadcast_info_t *)TM_ALLOC(sizeof(tm_broadcast_info_t));
+			if (broadcast_info == NULL) {
+				return TM_OUT_OF_MEMORY;
+			}
+			((tm_broadcast_info_t *)broadcast_info)->flink = NULL;
+			((tm_broadcast_info_t *)broadcast_info)->msg = ((tm_broadcast_info_t *)data)->msg;
+			((tm_broadcast_info_t *)broadcast_info)->cb = ((tm_broadcast_info_t *)data)->cb;
+			((tm_broadcast_info_t *)broadcast_info)->cb_data = ((tm_broadcast_info_t *)data)->cb_data;
+			sq_addlast((FAR sq_entry_t *)broadcast_info, &TM_BROADCAST_INFO_LIST(handle));
+		} else {
+			if ((broadcast_info->cb == ((tm_broadcast_info_t *)data)->cb) && broadcast_info->cb_data == ((tm_broadcast_info_t *)data)->cb_data) {
+				return TM_ALREADY_REGISTERED_CB;
+			}
+			((tm_broadcast_info_t *)broadcast_info)->cb = ((tm_broadcast_info_t *)data)->cb;
+			((tm_broadcast_info_t *)broadcast_info)->cb_data = ((tm_broadcast_info_t *)data)->cb_data;
+		}
+		
+	}
+	return OK;
+}
+
+static int taskmgr_alloc_broadcast_msg(void)
+{
+	int chk_idx;
+	int msg_num;
+
+	if (!taskmgr_is_tm_broadcast_msg_init()) {
+		taskmgr_broadcast_msg_init();
+	}
+	for (chk_idx = 0; chk_idx < TM_BROADCAST_MSG_MAX + CONFIG_TASK_MANAGER_MAX_TASKS; chk_idx++) {
+		msg_num = chk_idx + 1;
+		if (tm_broadcast_msg[chk_idx] == -1) {
+			tm_broadcast_msg[chk_idx] = msg_num;
+			return msg_num;
+		}
+	}
+	return TM_OUT_OF_MEMORY;
+}
+
+static int taskmgr_unset_broadcast_cb(int msg, int pid)
+{
+	int handle;
+	tm_broadcast_info_t *broadcast_info;
 
 	handle = taskmgr_get_handle_by_pid(pid);
 	if (handle == TM_UNREGISTERED_APP) {
 		return handle;
 	}
-
-	if (type == TYPE_UNICAST) {
-		TM_UNICAST_CB(handle) = (_tm_unicast_t)data;
-	} else {
-		TM_MSG_MASK(handle) = ((tm_broadcast_t *)data)->msg_mask;
-		TM_BROADCAST_CB(handle) = ((tm_broadcast_t *)data)->cb;
+	broadcast_info = taskmgr_search_broadcast_info(msg, handle);
+	if (broadcast_info == NULL) {
+		return TM_UNREGISTERED_MSG;
 	}
+	sq_rem((FAR sq_entry_t *)broadcast_info, &TM_BROADCAST_INFO_LIST(handle));
+	TM_FREE(broadcast_info);
 	return OK;
 }
 
@@ -774,6 +899,7 @@ static int taskmgr_register_task(tm_task_info_t *task_info, int permission, int 
 		TM_PERMISSION(handle) = permission;
 		TM_STOP_CB(handle) = NULL;
 		TM_EXIT_CB(handle) = NULL;
+		sq_init(&TM_BROADCAST_INFO_LIST(handle));
 		tmvdbg("Registered handle %d\n", handle);
 		handle_cnt++;
 	}
@@ -839,6 +965,7 @@ static int taskmgr_register_pthread(tm_pthread_info_t *pthread_info, int permiss
 		TM_PERMISSION(handle) = permission;
 		TM_STOP_CB(handle) = NULL;
 		TM_EXIT_CB(handle) = NULL;
+		sq_init(&TM_BROADCAST_INFO_LIST(handle));
 		tmvdbg("Registered handle %d\n", handle);
 		handle_cnt++;
 	}
@@ -885,6 +1012,20 @@ int task_manager_run_exit_cb(int pid)
 	return OK;
 }
 #endif
+
+static int taskmgr_dealloc_broadcast_msg(int msg)
+{
+	int chk_idx;
+
+	for (chk_idx = 0; chk_idx < TM_BROADCAST_MSG_MAX + CONFIG_TASK_MANAGER_MAX_TASKS; chk_idx++) {
+		if (tm_broadcast_msg[chk_idx] == msg) {
+			tm_broadcast_msg[chk_idx] = -1;
+			return OK;
+		}
+	}
+	return TM_UNREGISTERED_MSG;
+}
+
 /****************************************************************************
  * Main Function
  ****************************************************************************/
@@ -1000,6 +1141,10 @@ int task_manager(int argc, char *argv[])
 			(void)taskmgr_broadcast(*((int *)request_msg.data));
 			break;
 
+		case TASKMGRCMD_ALLOC_BROADCAST_MSG:
+			ret = taskmgr_alloc_broadcast_msg();
+			break;
+
 		case TASKMGRCMD_SET_BROADCAST_CB:
 			ret = taskmgr_set_msg_cb(TYPE_BROADCAST, request_msg.data, request_msg.caller_pid);
 			break;
@@ -1031,6 +1176,14 @@ int task_manager(int argc, char *argv[])
 		case TASKMGRCMD_SET_EXIT_CB:
 			ret = taskmgr_set_termination_cb(TYPE_EXIT, request_msg.data, request_msg.caller_pid);
 			break;
+
+		case TASKMGRCMD_UNSET_BROADCAST_CB:
+			ret = taskmgr_unset_broadcast_cb(*((int *)request_msg.data), request_msg.caller_pid);
+			break;
+
+		case TASKMGRCMD_DEALLOC_BROADCAST_MSG:
+			ret = taskmgr_dealloc_broadcast_msg(*((int *)request_msg.data));
+			break;
 			
 		default:
 			break;
@@ -1041,7 +1194,7 @@ int task_manager(int argc, char *argv[])
 			taskmgr_send_response((char *)request_msg.q_name, &response_msg);
 		}
 
-		if (request_msg.data != NULL && request_msg.cmd != TASKMGRCMD_SET_UNICAST_CB && request_msg.cmd != TASKMGRCMD_SET_STOP_CB && request_msg.cmd != TASKMGRCMD_SET_EXIT_CB) {
+		if (request_msg.data != NULL && request_msg.cmd != TASKMGRCMD_SET_UNICAST_CB && request_msg.cmd != TASKMGRCMD_SET_STOP_CB && request_msg.cmd != TASKMGRCMD_SET_EXIT_CB && request_msg.cmd != TASKMGRCMD_ALLOC_BROADCAST_MSG) {
 			TM_FREE(request_msg.data);
 			request_msg.data = NULL;
 		}

--- a/framework/src/task_manager/task_manager_dealloc_broadcast_msg.c
+++ b/framework/src/task_manager/task_manager_dealloc_broadcast_msg.c
@@ -1,0 +1,75 @@
+/****************************************************************************
+ *
+ * Copyright 2018 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+#include <tinyara/config.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/types.h>
+#include <task_manager/task_manager.h>
+#ifdef CONFIG_TASK_MANAGER_USER_SPECIFIC_BROADCAST
+#include <task_manager/task_manager_broadcast_list.h>
+#endif
+#include "task_manager_internal.h"
+
+/****************************************************************************
+ * task_manager_dealloc_broadcast_msg
+ ****************************************************************************/
+int task_manager_dealloc_broadcast_msg(int msg, int timeout)
+{
+	int status;
+	tm_request_t request_msg;
+	tm_response_t response_msg;
+
+	if (msg < TM_BROADCAST_MSG_MAX || timeout < TM_RESPONSE_WAIT_INF) {
+		return TM_INVALID_PARAM;
+	}
+
+	memset(&request_msg, 0, sizeof(tm_request_t));
+	request_msg.cmd = TASKMGRCMD_DEALLOC_BROADCAST_MSG;
+	request_msg.caller_pid = getpid();
+	request_msg.timeout = timeout;
+	request_msg.data = (void *)TM_ALLOC(sizeof(int));
+	if (request_msg.data == NULL) {
+		return TM_OUT_OF_MEMORY;
+	}
+	*((int *)request_msg.data) = msg;
+	
+	if (timeout != TM_NO_RESPONSE) {
+		asprintf(&request_msg.q_name, "%s%d", TM_PRIVATE_MQ, request_msg.caller_pid);
+		if (request_msg.q_name == NULL) {
+			TM_FREE(request_msg.data);
+			return TM_OUT_OF_MEMORY;
+		}
+	}
+
+	status = taskmgr_send_request(&request_msg);
+	if (status < 0) {
+		TM_FREE(request_msg.data);
+		if (request_msg.q_name != NULL) {
+			TM_FREE(request_msg.q_name);
+		}
+		return status;
+	}
+	if (timeout != TM_NO_RESPONSE) {
+		status = taskmgr_receive_response(request_msg.q_name, &response_msg, timeout);
+		TM_FREE(request_msg.q_name);
+	}
+	return status;
+}

--- a/framework/src/task_manager/task_manager_internal.h
+++ b/framework/src/task_manager/task_manager_internal.h
@@ -19,13 +19,16 @@
 #ifndef __TASK_MANAGER_INTERNAL_H__
 #define __TASK_MANAGER_INTERNAL_H__
 
+#include <tinyara/config.h>
 #include <stdlib.h>
 #include <stdbool.h>
 #include <unistd.h>
 #ifndef CONFIG_DISABLE_PTHREAD
 #include <pthread.h>
 #endif
+#include <queue.h>
 #include <sys/types.h>
+#include <task_manager/task_manager.h>
 
 /* Command Types */
 #define TASKMGRCMD_REGISTER                0
@@ -48,6 +51,9 @@
 #endif
 #define TASKMGRCMD_SET_STOP_CB             16
 #define TASKMGRCMD_SET_EXIT_CB             17
+#define TASKMGRCMD_ALLOC_BROADCAST_MSG     18
+#define TASKMGRCMD_UNSET_BROADCAST_CB      19
+#define TASKMGRCMD_DEALLOC_BROADCAST_MSG   20
 
 /* Task Type */
 #define TM_BUILTIN_TASK                    0
@@ -75,7 +81,6 @@
 #define TM_UNICAST_SYNC      (0)
 #define TM_UNICAST_ASYNC     (1)
 
-typedef void (*_tm_broadcast_t)(int);
 typedef void (*_tm_termination_t)(void);
 
 struct app_list_s {
@@ -91,11 +96,10 @@ struct app_list_data_s {
 	int tm_gid;
 	int status;
 	int permission;
-	int msg_mask;
-	_tm_unicast_t unicast_cb;
-	_tm_broadcast_t broadcast_cb;
 	_tm_termination_t stop_cb;
 	_tm_termination_t exit_cb;
+	_tm_unicast_t unicast_cb;
+	sq_queue_t broadcast_info_list;
 };
 typedef struct app_list_data_s app_list_data_t;
 
@@ -115,11 +119,13 @@ struct tm_response_s {
 };
 typedef struct tm_response_s tm_response_t;
 
-struct tm_broadcast_s {
-	int msg_mask;
+struct tm_broadcast_info_s {
+	struct tm_broadcast_info_s *flink;
+	int msg;
 	_tm_broadcast_t cb;
+	void* cb_data;
 };
-typedef struct tm_broadcast_s tm_broadcast_t;
+typedef struct tm_broadcast_info_s tm_broadcast_info_t;
 
 struct tm_task_info_s {
 	char *name;
@@ -149,18 +155,17 @@ typedef struct tm_unicast_internal_msg_s tm_unicast_internal_msg_t;
 
 #define IS_INVALID_HANDLE(i) (i < 0 || i >= CONFIG_TASK_MANAGER_MAX_TASKS)
 
-#define TM_LIST_ADDR(handle)       ((app_list_data_t *)tm_app_list[handle].addr)
-#define TM_PID(handle)             tm_app_list[handle].pid
-#define TM_TYPE(handle)            TM_LIST_ADDR(handle)->type
-#define TM_IDX(handle)             TM_LIST_ADDR(handle)->idx
-#define TM_GID(handle)             TM_LIST_ADDR(handle)->tm_gid
-#define TM_STATUS(handle)          TM_LIST_ADDR(handle)->status
-#define TM_PERMISSION(handle)      TM_LIST_ADDR(handle)->permission
-#define TM_MSG_MASK(handle)        TM_LIST_ADDR(handle)->msg_mask
-#define TM_UNICAST_CB(handle)      TM_LIST_ADDR(handle)->unicast_cb
-#define TM_BROADCAST_CB(handle)    TM_LIST_ADDR(handle)->broadcast_cb
-#define TM_STOP_CB(handle)         TM_LIST_ADDR(handle)->stop_cb
-#define TM_EXIT_CB(handle)         TM_LIST_ADDR(handle)->exit_cb
+#define TM_LIST_ADDR(handle)            ((app_list_data_t *)tm_app_list[handle].addr)
+#define TM_PID(handle)                  tm_app_list[handle].pid
+#define TM_TYPE(handle)                 TM_LIST_ADDR(handle)->type
+#define TM_IDX(handle)                  TM_LIST_ADDR(handle)->idx
+#define TM_GID(handle)                  TM_LIST_ADDR(handle)->tm_gid
+#define TM_STATUS(handle)               TM_LIST_ADDR(handle)->status
+#define TM_PERMISSION(handle)           TM_LIST_ADDR(handle)->permission
+#define TM_UNICAST_CB(handle)           TM_LIST_ADDR(handle)->unicast_cb
+#define TM_STOP_CB(handle)              TM_LIST_ADDR(handle)->stop_cb
+#define TM_EXIT_CB(handle)              TM_LIST_ADDR(handle)->exit_cb
+#define TM_BROADCAST_INFO_LIST(handle)  TM_LIST_ADDR(handle)->broadcast_info_list
 
 extern app_list_t tm_app_list[CONFIG_TASK_MANAGER_MAX_TASKS];
 

--- a/framework/src/task_manager/task_manager_set_callback.c
+++ b/framework/src/task_manager/task_manager_set_callback.c
@@ -18,6 +18,7 @@
 /****************************************************************************
  * Included Files
  ****************************************************************************/
+#include <tinyara/config.h>
 #include <stdio.h>
 #include <string.h>
 #include <signal.h>
@@ -25,6 +26,9 @@
 #include <unistd.h>
 #include <sys/types.h>
 #include <task_manager/task_manager.h>
+#ifdef CONFIG_TASK_MANAGER_USER_SPECIFIC_BROADCAST
+#include <task_manager/task_manager_broadcast_list.h>
+#endif
 #include "task_manager_internal.h"
 
 void taskmgr_msg_cb(int signo, siginfo_t *data)
@@ -38,7 +42,7 @@ void taskmgr_msg_cb(int signo, siginfo_t *data)
 	if (signo == CONFIG_SIG_SIGTM_UNICAST) {
 		(*TM_UNICAST_CB(handle))((tm_unicast_msg_t *)data->si_value.sival_ptr);
 	} else {
-		(*TM_BROADCAST_CB(handle))(data->si_value.sival_int);
+		(*((tm_broadcast_info_t *)data->si_value.sival_ptr)->cb)((void *)((tm_broadcast_info_t *)data->si_value.sival_ptr)->cb_data);
 	}
 }
 /****************************************************************************
@@ -89,49 +93,57 @@ int task_manager_set_unicast_cb(void (*func)(tm_unicast_msg_t *data))
 /****************************************************************************
  * task_manager_set_broadcast_cb
  ****************************************************************************/
-int task_manager_set_broadcast_cb(int msg_mask, void (*func)(int data))
+int task_manager_set_broadcast_cb(int msg, void (*func)(void *data), void *cb_data)
 {
-	int ret;
+	int status;
 	tm_request_t request_msg;
+	tm_response_t response_msg;
 	struct sigaction act;
 
-	if (msg_mask < 0 || func == NULL) {
+	if (msg < 0 || func == NULL) {
 		return TM_INVALID_PARAM;
 	}
-
 	act.sa_sigaction = (_sa_sigaction_t)taskmgr_msg_cb;
 	act.sa_flags = 0;
 	(void)sigemptyset(&act.sa_mask);
-
-	ret = sigaddset(&act.sa_mask, SIGTM_BROADCAST);
-	if (ret < 0) {
+	status = sigaddset(&act.sa_mask, SIGTM_BROADCAST);
+	if (status < 0) {
 		tmdbg("Failed to add signal set\n");
 		return TM_OPERATION_FAIL;
 	}
-
-	ret = sigaction(SIGTM_BROADCAST, &act, NULL);
-	if (ret == (int)SIG_ERR) {
+	status = sigaction(SIGTM_BROADCAST, &act, NULL);
+	if (status == (int)SIG_ERR) {
 		tmdbg("sigaction Failed\n");
 		return TM_OPERATION_FAIL;
 	}
-
 	memset(&request_msg, 0, sizeof(tm_request_t));
 	request_msg.cmd = TASKMGRCMD_SET_BROADCAST_CB;
 	request_msg.caller_pid = getpid();
-	request_msg.timeout = TM_NO_RESPONSE;
-	request_msg.data = (void *)TM_ALLOC(sizeof(tm_broadcast_t));
+	request_msg.timeout = TM_RESPONSE_WAIT_INF;
+	request_msg.data = (void *)TM_ALLOC(sizeof(tm_broadcast_info_t));
 	if (request_msg.data == NULL) {
 		return TM_OUT_OF_MEMORY;
 	}
-	((tm_broadcast_t *)request_msg.data)->msg_mask = msg_mask;
-	((tm_broadcast_t *)request_msg.data)->cb = (_tm_broadcast_t)func;
-
-	ret = taskmgr_send_request(&request_msg);
-	if (ret < 0) {
+	((tm_broadcast_info_t *)request_msg.data)->msg = msg;
+	((tm_broadcast_info_t *)request_msg.data)->cb = (_tm_broadcast_t)func;
+	((tm_broadcast_info_t *)request_msg.data)->cb_data = cb_data;
+	asprintf(&request_msg.q_name, "%s%d", TM_PRIVATE_MQ, request_msg.caller_pid);
+	if (request_msg.q_name == NULL) {
 		TM_FREE(request_msg.data);
-		return ret;
+		return TM_OUT_OF_MEMORY;
 	}
-	return OK;
+	status = taskmgr_send_request(&request_msg);
+	if (status < 0) {
+		TM_FREE(request_msg.data);
+		if (request_msg.q_name != NULL) {
+			TM_FREE(request_msg.q_name);
+		}
+		return status;
+	}
+	status = taskmgr_receive_response(request_msg.q_name, &response_msg, TM_RESPONSE_WAIT_INF);
+	TM_FREE(request_msg.q_name);
+	
+	return status;
 }
 
 /****************************************************************************

--- a/framework/src/task_manager/task_manager_unset_broadcast_cb.c
+++ b/framework/src/task_manager/task_manager_unset_broadcast_cb.c
@@ -1,0 +1,71 @@
+/****************************************************************************
+ *
+ * Copyright 2018 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+#include <string.h>
+#include <unistd.h>
+#include <sys/types.h>
+#include <task_manager/task_manager.h>
+#include "task_manager_internal.h"
+
+/****************************************************************************
+ * task_manager_unset_broadcast_cb
+ ****************************************************************************/
+int task_manager_unset_broadcast_cb(int msg, int timeout)
+{
+	int status;
+	tm_request_t request_msg;
+	tm_response_t response_msg;
+
+	if (msg < 0 || timeout < TM_RESPONSE_WAIT_INF) {
+		return TM_INVALID_PARAM;
+	}
+
+	memset(&request_msg, 0, sizeof(tm_request_t));
+	request_msg.cmd = TASKMGRCMD_UNSET_BROADCAST_CB;
+	request_msg.caller_pid = getpid();
+	request_msg.timeout = timeout;
+	request_msg.data = (void *)TM_ALLOC(sizeof(int));
+	if (request_msg.data == NULL) {
+		return TM_OUT_OF_MEMORY;
+	}
+	*((int *)request_msg.data) = msg;
+	
+	if (timeout != TM_NO_RESPONSE) {
+		asprintf(&request_msg.q_name, "%s%d", TM_PRIVATE_MQ, request_msg.caller_pid);
+		if (request_msg.q_name == NULL) {
+			TM_FREE(request_msg.data);
+			return TM_OUT_OF_MEMORY;
+		}
+	}
+	status = taskmgr_send_request(&request_msg);
+	if (status < 0) {
+		TM_FREE(request_msg.data);
+		if (request_msg.q_name != NULL) {
+			TM_FREE(request_msg.q_name);
+		}
+		return status;
+	}
+	if (timeout != TM_NO_RESPONSE) {
+		status = taskmgr_receive_response(request_msg.q_name, &response_msg, timeout);
+		TM_FREE(request_msg.q_name);
+	}
+	
+	return status;
+}


### PR DESCRIPTION
…broadcast message

In order to register a callback function for each broadcast message, two APIs are added and two APIs are modified.

Added APIs
1. task_manager_set_new_broadcast_msg
Register a new broadcast message which is not defined in the <task_manager/task_manager.h>.

2. task_manager_unset_broadcast_cb
Unregister callback function which was used for a certain broadcast message.

Modified APIs
1. task_manager_broadcast
In order to support registering a callback function for each broadcast message, internal operations are modifed

2. task_manager_set_broadcast_cb
User can register a callback function for each broadcast message, and a data pointer to pass to the callback function is need to use this API.