### PR TITLE
kernel/task_exit: Move and divide checking availability for heap sema…

### DIFF
--- a/os/include/tinyara/mm/mm.h
+++ b/os/include/tinyara/mm/mm.h
@@ -655,6 +655,7 @@ void heapinfo_update_group_info(pid_t pid, int group, int type);
 void heapinfo_check_group_list(pid_t pid, char *name);
 #endif
 #endif
+void mm_is_sem_available(void);
 
 /* Functions to get heap information */
 struct mm_heap_s *mm_get_heap_info(void);

--- a/os/mm/mm_heap/mm_sem.c
+++ b/os/mm/mm_heap/mm_sem.c
@@ -226,3 +226,18 @@ void mm_givesemaphore(FAR struct mm_heap_s *heap)
 		ASSERT(sem_post(&heap->mm_semaphore) == 0);
 	}
 }
+
+/****************************************************************************
+ * Name: mm_is_sem_available
+ *
+ * Description:
+ *   Check availability of mm semaphore 
+ *
+ ****************************************************************************/
+void mm_is_sem_available(void)
+{
+	struct mm_heap_s *heap = mm_get_heap_info();
+
+	mm_takesemaphore(heap);
+	mm_givesemaphore(heap);
+}


### PR DESCRIPTION
…phore

Since context switching should not occur during task_exit,
in order to release the heap used by dtcb, it is necessary
to check whether heap->mm_semaphore is acquired before executing exit.
But checking mm_semaphore is not in a task feature, so moved and divided.