### PR TITLE
Mac OSX support

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,12 @@ Please find project details at [Wiki](https://github.com/Samsung/TizenRT/wiki) e
 ## Quick Start
 ### Getting the toolchain
 
-Get the build in binaries and libraries, [gcc-arm-none-eabi-6-2017-q1-update-linux.tar.bz2](https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads/6-2017-q1-update)  
-Untar the gcc-arm-none-eabi-6-2017-q1-update-linux.tar.bz2 and export the path like
+Install the OS specific toolchain. Supported OS Type's are "linux" and "mac".  
+Get the build in binaries and libraries, [gcc-arm-none-eabi-6-2017-q1-update-*OS Type*.tar.bz2](https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads/6-2017-q1-update)  
+Untar the gcc-arm-none-eabi-6-2017-q1-update-*OS Type*.tar.bz2 and export the path like
 
 ```bash
-tar xvjf gcc-arm-none-eabi-6-2017-q1-update-linux.tar.bz2
+tar xvjf gcc-arm-none-eabi-6-2017-q1-update-[OS Type].tar.bz2
 export PATH=<Your Toolchain PATH>:$PATH
 ```
 Be aware that recommanded toolchain is fully working on 64bits machine.

--- a/build/configs/artik05x/artik05x_cmn.sh
+++ b/build/configs/artik05x/artik05x_cmn.sh
@@ -34,10 +34,10 @@ CODESIGNER_PATH=${ARTIK05X_DIR_PATH}/tools/codesigner
 CODESIGNER_DIR_PATH=${ARTIK05X_DIR_PATH}/tools/codesigner
 OPENOCD_DIR_PATH=${BUILD_DIR_PATH}/tools/openocd
 
-if [[ $CONFIG_HOST_OSX == 'y' ]]; then
+if [[ $OSTYPE == "darwin"* ]]; then
 	OPENOCD_BIN_PATH=${OPENOCD_DIR_PATH}/macos
 	CODESIGNER_PATH=${CODESIGNER_DIR_PATH}/macos
-else
+elif [[ $OSTYPE == "linux"* ]]; then
 	SYSTEM_TYPE=`getconf LONG_BIT`
 	if [ "$SYSTEM_TYPE" = "64" ]; then
 		OPENOCD_BIN_PATH=${OPENOCD_DIR_PATH}/linux64
@@ -46,7 +46,11 @@ else
 		OPENOCD_BIN_PATH=${OPENOCD_DIR_PATH}/linux32
 		CODESIGNER_PATH=${CODESIGNER_DIR_PATH}/linux32
 	fi
+else
+    echo "Doesn’t support Host OS: $OSTYPE"
+    exit 1
 fi
+
 OPENOCD=${OPENOCD_BIN_PATH}/openocd
 
 signing() {

--- a/tools/fs/README_ROMFS.md
+++ b/tools/fs/README_ROMFS.md
@@ -2,9 +2,43 @@
 # Contents for ROMFS
 
 ### Prerequisites
+Install genromfs  
+On Linux, It can be directly installed from package manager using below command
 ```bash
 sudo apt-get install genromfs
 ```
+Otherwise, Install genromfs from source.
+
+1. Getting the sources
+```bash
+git clone https://github.com/chexum/genromfs.git
+```
+2. Switch to genromfs 0.5.2 (released) version
+```bash
+cd genromfs
+git checkout 0.5.2 -b 0.5.2
+```
+3. Patch genromfs with below change
+```
+diff --git a/Makefile b/Makefile
+index d278efc..72a4c5c 100644
+--- a/Makefile
++++ b/Makefile
+@@ -16,7 +16,7 @@ FILES = COPYING NEWS ChangeLog Makefile \
+  readme-kernel-patch genrommkdev romfs.txt \
+  checkdist
+
+-prefix = /usr
++prefix = /usr/local
+ bindir = $(prefix)/bin
+ mandir = $(prefix)/man
+```
+4. Build and Install genromfs
+```bash
+make
+sudo make install
+```
+
 ### Steps
 1. Enable ROMFS config through menuconfig at *os* folder.
 ```bash


### PR DESCRIPTION
1. Update README.md  to provide TizenRT developement on Mac OS X HOST
2. Update romfs README to install genromfs from source which would work on both linux and Mac OS X
3. select HOST OS specific openocd and codesigner in artik05x