### PR TITLE
libc/math: Remove duplicate definition of FORCE_EVAL

### DIFF
--- a/lib/libc/math/lib_gamma.c
+++ b/lib/libc/math/lib_gamma.c
@@ -83,35 +83,13 @@
 #include <sys/types.h>
 #include <math.h>
 
+#include "libm.h"
+
 #ifdef CONFIG_HAVE_DOUBLE
 
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
-
-#define FORCE_EVAL(x)                       \
-  do                                        \
-    {                                       \
-      if (sizeof(x) == sizeof(float))       \
-        {                                   \
-          volatile float __x;               \
-          UNUSED(__x);                      \
-          __x = (x);                        \
-        }                                   \
-      else if (sizeof(x) == sizeof(double)) \
-        {                                   \
-          volatile double __x;              \
-          UNUSED(__x);                      \
-          __x = (x);                        \
-        }                                   \
-      else                                  \
-        {                                   \
-          volatile long double __x;         \
-          UNUSED(__x);                      \
-          __x = (x);                        \
-        }                                   \
-    } \
-  while(0)
 
 #define N 12
 

--- a/lib/libc/math/libm.h
+++ b/lib/libc/math/libm.h
@@ -91,19 +91,24 @@ union ldshape {
  *	Pre-processor Definitions
  ***************************************************************************/
 
-#define FORCE_EVAL(x)                               \
-	do {                                            \
-		if (sizeof(x) == sizeof(float)) {           \
-			volatile float __x;                     \
-			__x = (x);                              \
-		} else if (sizeof(x) == sizeof(double)) {   \
-			volatile double __x;                    \
-			__x = (x);                              \
-		} else {                                    \
-			volatile long double __x;               \
-			__x = (x);                              \
-	}                                               \
-} while (0)
+#define FORCE_EVAL(x)                             \
+	do {                                          \
+		if (sizeof(x) == sizeof(float)) {         \
+			volatile float __x;                   \
+			UNUSED(__x);                          \
+			__x = (x);                            \
+		} else if (sizeof(x) == sizeof(double)) { \
+			volatile double __x;                  \
+			UNUSED(__x);                          \
+			__x = (x);                            \
+		}                                         \
+		else {                                    \
+			volatile long double __x;             \
+			UNUSED(__x);                          \
+			__x = (x);                            \
+		}                                         \
+	} while (0)
+
 
 /* Get two 32 bit ints from a double.  */
 #define EXTRACT_WORDS(hi, lo, d)    \


### PR DESCRIPTION
This patch removes duplicate definition of FORCE_EVAL in lib_gamma.c.
Also it updates the FORCE_EVAL to use UNUSED macro to fix 'unused variable' warning from compiler.

Signed-off-by: Lokesh B V <lokesh.bv@partner.samsung.com>