### PR TITLE
framework/media: Remove static global variables

### DIFF
--- a/framework/src/media/audio/audio_manager.c
+++ b/framework/src/media/audio/audio_manager.c
@@ -70,7 +70,7 @@
  * Private Types
  ****************************************************************************/
 enum audio_card_status_e {
-	AUDIO_CARD_NONE = 0,		// card not found yet, shouldn't be assigned explicitly.
+	AUDIO_CARD_NONE = 0,		// A card is not found yet.
 	AUDIO_CARD_IDLE = 1,
 	AUDIO_CARD_READY,
 	AUDIO_CARD_RUNNING,
@@ -84,6 +84,12 @@ enum manufacturer_type_e {
 enum audio_card_type_e {
 	INPUT = 0,
 	OUTPUT
+};
+
+enum audio_card_operation_e {
+	AUDIO_CARD_ENABLE = 0,
+	AUDIO_CARD_FIND,
+	AUDIO_CARD_DESTROY
 };
 
 struct audio_config_s {
@@ -106,6 +112,7 @@ struct audio_resample_s {
 };
 
 struct audio_card_info_s {
+	uint8_t card_id;
 	char card_path[256];
 	enum audio_card_status_e status;
 	uint8_t device_id;
@@ -113,6 +120,7 @@ struct audio_card_info_s {
 	struct pcm *pcm;
 	struct audio_resample_s resample;
 	pthread_mutex_t card_mutex;
+	struct audio_card_info_s *next;
 };
 
 struct audio_samprate_map_entry_s {
@@ -123,14 +131,9 @@ struct audio_samprate_map_entry_s {
 typedef enum audio_card_status_e audio_card_status_t;
 typedef enum manufacturer_type_e manufacturer_t;
 typedef enum audio_card_type_e audio_card_type_t;
+typedef enum audio_card_operation_e audio_card_operation_t;
 typedef struct audio_config_s audio_config_t;
 typedef struct audio_card_info_s audio_card_info_t;
-
-static audio_card_info_t g_audio_in_cards[CONFIG_AUDIO_MAX_INPUT_CARD_NUM];
-static audio_card_info_t g_audio_out_cards[CONFIG_AUDIO_MAX_OUTPUT_CARD_NUM];
-
-static int g_actual_audio_in_card_id = INVALID_ID;
-static int g_actual_audio_out_card_id = INVALID_ID;
 
 static const struct audio_samprate_map_entry_s g_audio_samprate_entry[] = {
 	{AUDIO_SAMP_RATE_TYPE_8K, AUDIO_SAMP_RATE_8K},
@@ -146,44 +149,134 @@ static const struct audio_samprate_map_entry_s g_audio_samprate_entry[] = {
 /****************************************************************************
  * Private Function Prototypes
  ****************************************************************************/
+static audio_manager_result_t get_audio_card_in(audio_card_operation_t card_operation, audio_handler_t **handler);
+static audio_manager_result_t get_audio_card_out(audio_card_operation_t card_operation, audio_handler_t **handler);
 static audio_manager_result_t find_audio_card(audio_card_type_t card_type);
-static int get_actual_audio_in_card_id(void);
-static int get_actual_audio_out_card_id(void);
-static void get_hardware_params(audio_card_info_t *card, audio_card_type_t card_type);
+static void get_hardware_params(audio_handler_t *handler, audio_card_type_t card_type);
 static audio_manager_result_t get_supported_sample_rate(int fd, uint8_t *sample_type, audio_card_type_t type);
-static uint32_t get_closest_samprate(unsigned origin_samprate, audio_card_type_t type);
-static unsigned int resample_stream_in(audio_card_info_t *cur_card, void *data, unsigned int frames);
-static unsigned int resample_stream_out(audio_card_info_t *cur_card, void *data, unsigned int frames);
+static uint32_t get_closest_samprate(audio_handler_t *handler, unsigned int origin_samprate);
+static unsigned int resample_stream_in(audio_handler_t *handler, void *data, unsigned int frames);
+static unsigned int resample_stream_out(audio_handler_t *handler, void *data, unsigned int frames);
 static audio_manager_result_t get_audio_volume(int fd, audio_config_t *config, audio_card_type_t card_type);
-static audio_manager_result_t set_audio_volume(audio_card_type_t type, uint8_t volume);
+static audio_manager_result_t set_audio_volume(audio_handler_t *handler, audio_card_type_t type, uint8_t volume);
 
 /****************************************************************************
  * Private Functions
  ****************************************************************************/
-static audio_manager_result_t init_audio_stream(audio_card_type_t card_type)
+static audio_manager_result_t get_audio_card_in(audio_card_operation_t card_operation, audio_handler_t **handler)
 {
-	if (((card_type == INPUT) && (g_actual_audio_in_card_id >= 0)) || ((card_type == OUTPUT) && (g_actual_audio_out_card_id >= 0))) {
-		return AUDIO_MANAGER_SUCCESS;
-	}
+	audio_manager_result_t ret = AUDIO_MANAGER_CARD_NOT_READY;
+	static audio_card_info_t *in_audio_card_tail;
+	static audio_card_info_t *in_audio_card_head;
+	static uint8_t num_enabled_card = 0;
+	audio_card_info_t *curr;
 
-	/* check available cards and try to find all cards if there's no one */
-	if (find_audio_card(card_type) != AUDIO_MANAGER_SUCCESS) {
-		meddbg("Found no active %s audio card\n", (card_type == OUTPUT ? "output" : "input"));
-		return AUDIO_MANAGER_NO_AVAIL_CARD;
-	}
+	switch (card_operation) {
+	case AUDIO_CARD_ENABLE:
+		*handler = (audio_card_info_t *)malloc(sizeof(audio_card_info_t));
 
-	/* update an actual card here */
-	if (card_type == INPUT) {
-		if ((g_actual_audio_in_card_id = get_actual_audio_in_card_id()) < 0) {
-			return AUDIO_MANAGER_NO_AVAIL_CARD;
+		if ((*handler) == NULL) {
+			meddbg("Malloc for an audio handler (in) is failed\n");
+			return AUDIO_MANAGER_FAIL;
 		}
-	} else {
-		if ((g_actual_audio_out_card_id = get_actual_audio_out_card_id()) < 0) {
-			return AUDIO_MANAGER_NO_AVAIL_CARD;
+
+		(*handler)->next = NULL;
+		if (num_enabled_card == 0) {
+			in_audio_card_tail = *handler;
+			in_audio_card_head = in_audio_card_tail;
+		} else {
+			in_audio_card_tail->next = *handler;
+			in_audio_card_tail = in_audio_card_tail->next;
 		}
+		num_enabled_card++;
+
+		ret = AUDIO_MANAGER_SUCCESS;
+		break;
+
+	case AUDIO_CARD_FIND:
+		curr = in_audio_card_head;
+		while (curr != NULL) {
+			if ((curr->status == AUDIO_CARD_IDLE)
+				|| (curr->status == AUDIO_CARD_READY)
+				|| (curr->status == AUDIO_CARD_PAUSE)) {
+				*handler = curr;
+				ret = AUDIO_MANAGER_SUCCESS;
+				break;
+			}
+			curr = curr->next;
+		}
+		break;
+
+	case AUDIO_CARD_DESTROY:
+		curr = in_audio_card_head;
+		while (curr != NULL) {
+			audio_card_info_t *temp = curr;
+			curr = curr->next;
+			free(temp);
+			ret = AUDIO_MANAGER_SUCCESS;
+		}
+		break;
 	}
 
-	return AUDIO_MANAGER_SUCCESS;
+	return ret;
+}
+
+static audio_manager_result_t get_audio_card_out(audio_card_operation_t card_operation, audio_handler_t **handler)
+{
+	audio_manager_result_t ret = AUDIO_MANAGER_NO_AVAIL_CARD;
+	static audio_card_info_t *out_audio_card_tail;
+	static audio_card_info_t *out_audio_card_head;
+	static uint8_t num_enabled_card = 0;
+	audio_card_info_t *curr;
+
+	switch (card_operation) {
+	case AUDIO_CARD_ENABLE:
+		*handler = (audio_card_info_t *)malloc(sizeof(audio_card_info_t));
+
+		if ((*handler) == NULL) {
+			meddbg("Malloc for an audio handler (out) is failed\n");
+			return AUDIO_MANAGER_FAIL;
+		}
+
+		(*handler)->next = NULL;
+		if (num_enabled_card == 0) {
+			out_audio_card_tail = *handler;
+			out_audio_card_head = out_audio_card_tail;
+		} else {
+			out_audio_card_tail->next = *handler;
+			out_audio_card_tail = out_audio_card_tail->next;
+		}
+		num_enabled_card++;
+
+		ret = AUDIO_MANAGER_SUCCESS;
+		break;
+
+	case AUDIO_CARD_FIND:
+		curr = out_audio_card_head;
+		while (curr != NULL) {
+			if ((curr->status == AUDIO_CARD_IDLE)
+				|| (curr->status == AUDIO_CARD_READY)
+				|| (curr->status == AUDIO_CARD_PAUSE)) {
+				*handler = curr;
+				ret = AUDIO_MANAGER_SUCCESS;
+				break;
+			}
+			curr = curr->next;
+		}
+		break;
+
+	case AUDIO_CARD_DESTROY:
+		curr = out_audio_card_head;
+		while (curr != NULL) {
+			audio_card_info_t *temp = curr;
+			curr = curr->next;
+			free(temp);
+			ret = AUDIO_MANAGER_SUCCESS;
+		}
+		break;
+	}
+
+	return ret;
 }
 
 static audio_manager_result_t find_audio_card(audio_card_type_t card_type)
@@ -194,7 +287,6 @@ static audio_manager_result_t find_audio_card(audio_card_type_t card_type)
 	char type;
 	struct dirent *dir_entry;
 	DIR *dir_info;
-	audio_card_info_t *card = g_audio_out_cards;
 	int max_card_num = CONFIG_AUDIO_MAX_OUTPUT_CARD_NUM;
 	char type_chr = 'p';
 	int found_cards = 0;
@@ -206,10 +298,10 @@ static audio_manager_result_t find_audio_card(audio_card_type_t card_type)
 	if (card_type == INPUT) {
 		max_card_num = CONFIG_AUDIO_MAX_INPUT_CARD_NUM;
 		type_chr = 'c';
-		card = g_audio_in_cards;
 	}
 
 	while ((dir_entry = readdir(dir_info)) != NULL) {
+		audio_card_info_t *card_ptr = NULL;
 		// TODO: Add cases for various drivers. Currently, identify 'pcm' drivers only.
 		if ((dir_entry->d_name[0] != 'p') || (dir_entry->d_name[1] != 'c') || (dir_entry->d_name[2] != 'm') || (sscanf(&dir_entry->d_name[3], "C%uD%u%c", &card_id, &device_id, &type) != 3)) {
 			continue;
@@ -217,23 +309,38 @@ static audio_manager_result_t find_audio_card(audio_card_type_t card_type)
 
 		/* Find next card if driver name isn't follow naming policy */
 		if ((card_id < 0) || (card_id >= max_card_num) || (device_id < 0) || (device_id >= MAX_AUDIO_DEVICE_NUM)) {
-			meddbg("Found wrong card card_id : %d device_id : %d\n", card_id, device_id);
+			meddbg("Found a wrong card_id : %d device_id : %d\n", card_id, device_id);
 			continue;
 		}
 
+		medvdbg("Card id = %d, path = %s\n", card_id, dir_entry->d_name);
+
 		if (type == type_chr) {
-			pthread_mutex_init(&(card[card_id].card_mutex), NULL);
-			pthread_mutex_lock(&(card[card_id].card_mutex));
+			if (card_type == INPUT) {
+				medvdbg("Before get_audio_card_in(AUDIO_CARD_ENABLE)\n");
+				if ((ret = get_audio_card_in(AUDIO_CARD_ENABLE, &card_ptr)) != AUDIO_MANAGER_SUCCESS) {
+					meddbg("Input audio card %d is unavailable", card_id);
+					goto error_out;
+				}
+			} else {
+				medvdbg("Before get_audio_card_out(AUDIO_CARD_ENABLE)\n");
+				if ((ret = get_audio_card_out(AUDIO_CARD_ENABLE, &card_ptr)) != AUDIO_MANAGER_SUCCESS) {
+					meddbg("Output audio card %d is unavailable", card_id);
+					goto error_out;
+				}
+			}
 
-			snprintf(card[card_id].card_path, strlen("/dev/audio/") + strlen(dir_entry->d_name) + 1, "%s%s", "/dev/audio/", dir_entry->d_name);
-			card[card_id].status = AUDIO_CARD_IDLE;
-			card[card_id].device_id = device_id;
+			pthread_mutex_init(&card_ptr->card_mutex, NULL);
+			pthread_mutex_lock(&card_ptr->card_mutex);
+			snprintf(card_ptr->card_path, strlen("/dev/audio/") + strlen(dir_entry->d_name) + 1, "%s%s", "/dev/audio/", dir_entry->d_name);
+			card_ptr->card_id = card_id;
+			card_ptr->status = AUDIO_CARD_IDLE;
+			card_ptr->device_id = device_id;
 			found_cards++;
-			medvdbg("Found an audio card, total card : %d id : %d, card_path : %s\n", found_cards, card_id, card[card_id].card_path);
 
-			get_hardware_params(&card[card_id], card_type);
+			get_hardware_params(card_ptr, card_type);
 
-			pthread_mutex_unlock(&(card[card_id].card_mutex));
+			pthread_mutex_unlock(&card_ptr->card_mutex);
 		}
 	}
 
@@ -241,7 +348,6 @@ static audio_manager_result_t find_audio_card(audio_card_type_t card_type)
 	if (found_cards == 0) {
 		meddbg("Failed to find card\n");
 		ret = AUDIO_MANAGER_NO_AVAIL_CARD;
-		goto error_out;
 	}
 
 error_out:
@@ -249,36 +355,36 @@ error_out:
 	return ret;
 }
 
-static void get_hardware_params(audio_card_info_t *card, audio_card_type_t card_type)
+static void get_hardware_params(audio_handler_t *handler, audio_card_type_t card_type)
 {
 	int fd;
 	int ret;
 	audio_config_t *config;
 
-	fd = open(card->card_path, O_RDONLY);
+	fd = open(handler->card_path, O_RDONLY);
 	if (fd < 0) {
-		meddbg("Failed to open audio driver, path : %s errno : %d\n", card->card_path, errno);
+		meddbg("Failed to open audio driver, path : %s errno : %d\n", handler->card_path, errno);
 		return;
 	}
 
-	config = &card->config;
+	config = &handler->config;
 #ifndef CONFIG_AUDIO_EXCLUDE_VOLUME
 	/* get volume of current card first */
 	ret = get_audio_volume(fd, config, card_type);
 
 	/* If it is failed, it doesn't return because we should get next h/w params */
 	if (ret != AUDIO_MANAGER_SUCCESS) {
-		meddbg("Get volume failed card path : %s card_type : %d ret : %d\n", card->card_path, card_type, ret);
+		meddbg("Get volume failed card path : %s card_type : %d ret : %d\n", handler->card_path, card_type, ret);
 	}
 
-	medvdbg("Max volume: %d, Current Volume : %d card path : %s\n", card->config.max_volume, card->config.volume, card->card_path);
+	medvdbg("Max volume: %d, Current Volume : %d card path : %s\n", handler->config.max_volume, handler->config.volume, handler->card_path);
 #endif
 	/* get supported sample rate type */
-	ret = get_supported_sample_rate(fd, &card->resample.samprate_types, card_type);
+	ret = get_supported_sample_rate(fd, &handler->resample.samprate_types, card_type);
 	if (ret != AUDIO_MANAGER_SUCCESS) {
-		meddbg("Get supported sample rate failed card path : %s card_type : %d ret : %d\n", card->card_path, card_type, ret);
+		meddbg("Get supported sample rate failed card path : %s card_type : %d ret : %d\n", handler->card_path, card_type, ret);
 	}
-	medvdbg("card path : %s Supported sample rate: %x\n", card->card_path, card->resample.samprate_types);
+	medvdbg("card path : %s Supported sample rate: %x\n", handler->card_path, handler->resample.samprate_types);
 	close(fd);
 }
 
@@ -303,54 +409,16 @@ static audio_manager_result_t get_supported_sample_rate(int fd, uint8_t *sample_
 	return AUDIO_MANAGER_SUCCESS;
 }
 
-/* TODO this function should consider priority of each function in future */
-static int get_actual_audio_in_card_id()
-{
-	int i;
-	for (i = 0; i < CONFIG_AUDIO_MAX_INPUT_CARD_NUM; i++) {
-		if (g_audio_in_cards[i].status == AUDIO_CARD_IDLE) {
-			g_audio_in_cards[i].status = AUDIO_CARD_READY;
-			return i;
-		}
-	}
-
-	return AUDIO_MANAGER_NO_AVAIL_CARD;
-}
-
-static int get_actual_audio_out_card_id()
-{
-	int i;
-	for (i = 0; i < CONFIG_AUDIO_MAX_OUTPUT_CARD_NUM; i++) {
-		if (g_audio_out_cards[i].status == AUDIO_CARD_IDLE) {
-			g_audio_out_cards[i].status = AUDIO_CARD_READY;
-			return i;
-		}
-	}
-
-	return AUDIO_MANAGER_NO_AVAIL_CARD;
-}
-
-static uint32_t get_closest_samprate(unsigned int origin_samprate, audio_card_type_t type)
+static uint32_t get_closest_samprate(audio_handler_t *handler, unsigned int origin_samprate)
 {
 	int i;
 	uint32_t result;
-	uint32_t samprate_types;
 	int count = sizeof(g_audio_samprate_entry) / sizeof(struct audio_samprate_map_entry_s);
-
 	ASSERT(count > 0);
 
-	if (type == INPUT) {
-		ASSERT(g_actual_audio_in_card_id >= 0);
-		samprate_types = g_audio_in_cards[g_actual_audio_in_card_id].resample.samprate_types;
-	} else {
-		ASSERT(g_actual_audio_out_card_id >= 0);
-		samprate_types = g_audio_out_cards[g_actual_audio_out_card_id].resample.samprate_types;
-	}
-
 	result = g_audio_samprate_entry[count - 1].samprate;
-
 	for (i = count - 1; i >= 0; i--) {
-		if (g_audio_samprate_entry[i].samprate_types & samprate_types) {
+		if (g_audio_samprate_entry[i].samprate_types & handler->resample.samprate_types) {
 			if (g_audio_samprate_entry[i].samprate >= origin_samprate) {
 				result = g_audio_samprate_entry[i].samprate;
 			}
@@ -360,27 +428,27 @@ static uint32_t get_closest_samprate(unsigned int origin_samprate, audio_card_ty
 	return result;
 }
 
-static unsigned int resample_stream_in(audio_card_info_t *cur_card, void *data, unsigned int frames)
+static unsigned int resample_stream_in(audio_handler_t *handler, void *data, unsigned int frames)
 {
 	unsigned int used_frames = 0;
 	unsigned int resampled_frames = 0;
 	src_data_t srcData = { 0, };
 
 	srcData.channels_num = 2;
-	srcData.origin_sample_rate = cur_card->resample.from;
+	srcData.origin_sample_rate = handler->resample.from;
 	srcData.origin_sample_width = SAMPLE_WIDTH_16BITS;
-	srcData.desired_sample_rate = cur_card->resample.to;
+	srcData.desired_sample_rate = handler->resample.to;
 	srcData.desired_sample_width = SAMPLE_WIDTH_16BITS;
 	srcData.input_frames_used = 0;
 	srcData.data_out = data;
-	srcData.out_buf_length = cur_card->resample.buffer_size;
+	srcData.out_buf_length = handler->resample.buffer_size;
 
 	while (frames > used_frames) {
-		srcData.data_in = cur_card->resample.buffer + get_input_frames_to_byte(used_frames);
+		srcData.data_in = handler->resample.buffer + get_input_frames_to_byte(handler, used_frames);
 		srcData.input_frames = frames - used_frames;
-		srcData.data_out = data + get_input_frames_to_byte(resampled_frames);
-		medvdbg("data_in addr = 0x%x + %d\t", srcData.data_in, get_input_frames_to_byte(used_frames));
-		if (src_simple(cur_card->resample.handle, &srcData) != SRC_ERR_NO_ERROR) {
+		srcData.data_out = data + get_input_frames_to_byte(handler, resampled_frames);
+		medvdbg("data_in addr = 0x%x + %d\t", srcData.data_in, get_input_frames_to_byte(handler, used_frames));
+		if (src_simple(handler->resample.handle, &srcData) != SRC_ERR_NO_ERROR) {
 			meddbg("Fail to resample in:%d/%d, out:%d, to %u from %u\n", used_frames, frames, srcData.desired_sample_rate, srcData.origin_sample_rate);
 			return AUDIO_MANAGER_RESAMPLE_FAIL;
 		}
@@ -398,28 +466,28 @@ static unsigned int resample_stream_in(audio_card_info_t *cur_card, void *data, 
 	return resampled_frames;
 }
 
-static unsigned int resample_stream_out(audio_card_info_t *cur_card, void *data, unsigned int frames)
+static unsigned int resample_stream_out(audio_handler_t *handler, void *data, unsigned int frames)
 {
 	unsigned int used_frames = 0;
 	unsigned int resampled_frames = 0;
 	src_data_t srcData = { 0, };
 
 	srcData.channels_num = 2;
-	srcData.origin_sample_rate = cur_card->resample.from;
+	srcData.origin_sample_rate = handler->resample.from;
 	srcData.origin_sample_width = SAMPLE_WIDTH_16BITS;
-	srcData.desired_sample_rate = cur_card->resample.to;
+	srcData.desired_sample_rate = handler->resample.to;
 	srcData.desired_sample_width = SAMPLE_WIDTH_16BITS;
 	srcData.input_frames_used = 0;
-	srcData.data_out = cur_card->resample.buffer;
-	srcData.out_buf_length = cur_card->resample.buffer_size;
-	medvdbg("resampler buffer_size = %d, buffer_addr = 0x%x\n", cur_card->resample.buffer_size, cur_card->resample.buffer);
+	srcData.data_out = handler->resample.buffer;
+	srcData.out_buf_length = handler->resample.buffer_size;
+	medvdbg("resampler buffer_size = %d, buffer_addr = 0x%x\n", handler->resample.buffer_size, handler->resample.buffer);
 
 	while (frames > used_frames) {
-		srcData.data_in = data + get_output_frames_to_byte(used_frames);
+		srcData.data_in = data + get_output_frames_to_byte(handler, used_frames);
 		srcData.input_frames = frames - used_frames;
-		srcData.data_out = cur_card->resample.buffer + get_output_frames_to_byte(resampled_frames);
-		medvdbg("buffer addr = 0x%x   data_out addr = 0x%x   ", cur_card->resample.buffer, srcData.data_out);
-		if (src_simple(cur_card->resample.handle, &srcData) != SRC_ERR_NO_ERROR) {
+		srcData.data_out = handler->resample.buffer + get_output_frames_to_byte(handler, resampled_frames);
+		medvdbg("buffer addr = 0x%x   data_out addr = 0x%x   ", handler->resample.buffer, srcData.data_out);
+		if (src_simple(handler->resample.handle, &srcData) != SRC_ERR_NO_ERROR) {
 			meddbg("Fail to resample in:%d/%d, out:%d, to %u from %u\n", used_frames, frames, srcData.desired_sample_rate, srcData.origin_sample_rate);
 			return AUDIO_MANAGER_RESAMPLE_FAIL;
 		}
@@ -471,32 +539,29 @@ static audio_manager_result_t get_audio_volume(int fd, audio_config_t *config, a
 	return AUDIO_MANAGER_SUCCESS;
 }
 
-static audio_manager_result_t set_audio_volume(audio_card_type_t type, uint8_t volume)
+static audio_manager_result_t set_audio_volume(audio_handler_t *handler, audio_card_type_t type, uint8_t volume)
 {
 	int ret;
 	int fd;
 	struct audio_caps_desc_s caps_desc;
-	audio_card_info_t *card;
+
+	if (type == INPUT) {
+		caps_desc.caps.ac_format.hw = AUDIO_FU_INP_GAIN;
+	} else {
+		caps_desc.caps.ac_format.hw = AUDIO_FU_VOLUME;
+	}
 
 	if (volume > AUDIO_DEVICE_MAX_VOLUME) {
 		volume = AUDIO_DEVICE_MAX_VOLUME;
 	}
 
-	if (type == INPUT) {
-		caps_desc.caps.ac_format.hw = AUDIO_FU_INP_GAIN;
-		card = &g_audio_in_cards[g_actual_audio_in_card_id];
-	} else {
-		caps_desc.caps.ac_format.hw = AUDIO_FU_VOLUME;
-		card = &g_audio_out_cards[g_actual_audio_out_card_id];
-
-	}
-	caps_desc.caps.ac_controls.hw[0] = volume * (card->config.max_volume / AUDIO_DEVICE_MAX_VOLUME);
+	caps_desc.caps.ac_controls.hw[0] = volume * (handler->config.max_volume / AUDIO_DEVICE_MAX_VOLUME);
 	caps_desc.caps.ac_len = sizeof(struct audio_caps_s);
 	caps_desc.caps.ac_type = AUDIO_TYPE_FEATURE;
 
-	fd = open(card->card_path, O_RDONLY);
+	fd = open(handler->card_path, O_RDONLY);
 	if (fd < 0) {
-		meddbg("Failed to open device path : %s type : %d\n", card->card_path, type);
+		meddbg("Failed to open device path : %s type : %d\n", handler->card_path, type);
 		return AUDIO_MANAGER_DEVICE_FAIL;
 	}
 
@@ -508,7 +573,7 @@ static audio_manager_result_t set_audio_volume(audio_card_type_t type, uint8_t v
 	}
 
 	ret = AUDIO_MANAGER_SUCCESS;
-	card->config.volume = volume;
+	handler->config.volume = volume;
 	medvdbg("Volume = %d\n", volume);
 
 errout:
@@ -519,36 +584,72 @@ errout:
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
-audio_manager_result_t init_audio_stream_in(void)
+audio_manager_result_t init_audio_handler_in(void)
 {
-	return init_audio_stream(INPUT);
+	if (find_audio_card(INPUT) != AUDIO_MANAGER_SUCCESS) {
+		meddbg("Found no active input audio card\n");
+		return AUDIO_MANAGER_NO_AVAIL_CARD;
+	}
+
+	return AUDIO_MANAGER_SUCCESS;
 }
 
-audio_manager_result_t init_audio_stream_out(void)
+audio_manager_result_t init_audio_handler_out(void)
 {
-	return init_audio_stream(OUTPUT);
+	if (find_audio_card(OUTPUT) != AUDIO_MANAGER_SUCCESS) {
+		meddbg("Found no active output audio card\n");
+		return AUDIO_MANAGER_NO_AVAIL_CARD;
+	}
+
+	return AUDIO_MANAGER_SUCCESS;
 }
 
-audio_manager_result_t set_audio_stream_in(unsigned int channels, unsigned int sample_rate, int format)
+audio_manager_result_t init_audio_stream_in(audio_handler_t **handler)
+{
+	if (get_audio_card_in(AUDIO_CARD_FIND, handler) != AUDIO_MANAGER_SUCCESS) {
+		return AUDIO_MANAGER_NO_AVAIL_CARD;
+	}
+
+	pthread_mutex_lock(&(*handler)->card_mutex);
+	if ((*handler)->status == AUDIO_CARD_IDLE) {
+		(*handler)->status = AUDIO_CARD_READY;
+	}
+	pthread_mutex_unlock(&(*handler)->card_mutex);
+
+	return AUDIO_MANAGER_SUCCESS;
+}
+
+audio_manager_result_t init_audio_stream_out(audio_handler_t **handler)
+{
+	if (get_audio_card_out(AUDIO_CARD_FIND, handler) != AUDIO_MANAGER_SUCCESS) {
+		return AUDIO_MANAGER_NO_AVAIL_CARD;
+	}
+
+	pthread_mutex_lock(&(*handler)->card_mutex);
+	if ((*handler)->status == AUDIO_CARD_IDLE) {
+		(*handler)->status = AUDIO_CARD_READY;
+	}
+	pthread_mutex_unlock(&(*handler)->card_mutex);
+
+	return AUDIO_MANAGER_SUCCESS;
+}
+
+audio_manager_result_t set_audio_stream_in(audio_handler_t *handler, unsigned int channels, unsigned int sample_rate, int format)
 {
 	struct pcm_config config;
 	audio_manager_result_t ret = AUDIO_MANAGER_SUCCESS;
 
-	if (g_actual_audio_in_card_id < 0) {
-		meddbg("Found no active input audio card\n");
-		return AUDIO_MANAGER_NO_AVAIL_CARD;
-	}
+	ASSERT(handler != NULL);
+	pthread_mutex_lock(&handler->card_mutex);
 
 	if ((channels == 0) || (sample_rate == 0)) {
 		return AUDIO_MANAGER_INVALID_PARAM;
 	}
 
-	if ((g_audio_in_cards[g_actual_audio_in_card_id].status == AUDIO_CARD_PAUSE)) {
-		medvdbg("reset previous preparing\n");
-		reset_audio_stream_out();
+	if (handler->status == AUDIO_CARD_PAUSE) {
+		medvdbg("Reset the previous pcm\n");
+		reset_audio_stream_in(handler);
 	}
-
-	pthread_mutex_lock(&(g_audio_in_cards[g_actual_audio_in_card_id].card_mutex));
 
 	if (channels > AUDIO_STREAM_CHANNEL_MONO) {
 		channels = AUDIO_STREAM_CHANNEL_STEREO;
@@ -556,66 +657,62 @@ audio_manager_result_t set_audio_stream_in(unsigned int channels, unsigned int s
 
 	memset(&config, 0, sizeof(struct pcm_config));
 	config.channels = channels;
-	config.rate = get_closest_samprate(sample_rate, INPUT);
+	config.rate = get_closest_samprate(handler, sample_rate);
 	config.format = format;
 	config.period_size = AUDIO_STREAM_VOIP_PERIOD_SIZE;
 	config.period_count = AUDIO_STREAM_VOIP_PERIOD_COUNT;
 
 	medvdbg("[IN] Device samplerate: %u, User requested: %u\n", config.rate, sample_rate);
-	g_audio_in_cards[g_actual_audio_in_card_id].pcm = pcm_open(g_actual_audio_in_card_id, 0, PCM_IN, &config);
-	if (!pcm_is_ready(g_audio_in_cards[g_actual_audio_in_card_id].pcm)) {
-		meddbg("fail to pcm_is_ready() error : %s", pcm_get_error(g_audio_in_cards[g_actual_audio_in_card_id].pcm));
+	handler->pcm = pcm_open(handler->card_id, handler->device_id, PCM_IN, &config);
+	if (!pcm_is_ready(handler->pcm)) {
+		meddbg("fail to pcm_is_ready() error : %s", pcm_get_error(handler->pcm));
 		ret = AUDIO_MANAGER_CARD_NOT_READY;
 		goto error_with_pcm;
 	}
 
-	g_audio_in_cards[g_actual_audio_in_card_id].status = AUDIO_CARD_READY;
+	handler->status = AUDIO_CARD_READY;
 
 	if (sample_rate == config.rate) {
-		g_audio_in_cards[g_actual_audio_in_card_id].resample.necessary = false;
+		handler->resample.necessary = false;
 	} else {
-		g_audio_in_cards[g_actual_audio_in_card_id].resample.necessary = true;
-		g_audio_in_cards[g_actual_audio_in_card_id].resample.from = config.rate;
-		g_audio_in_cards[g_actual_audio_in_card_id].resample.to = sample_rate;
-		g_audio_in_cards[g_actual_audio_in_card_id].resample.ratio = (float)sample_rate / (float)config.rate;
-		g_audio_in_cards[g_actual_audio_in_card_id].resample.handle = src_init(CONFIG_AUDIO_RESAMPLER_BUFSIZE);
-		g_audio_in_cards[g_actual_audio_in_card_id].resample.buffer = malloc((int)((float)get_input_frames_to_byte(get_input_frame_count()) / g_audio_in_cards[g_actual_audio_in_card_id].resample.ratio) + 1);	// +1 for floating point margin
-		if (!g_audio_in_cards[g_actual_audio_in_card_id].resample.buffer) {
+		handler->resample.necessary = true;
+		handler->resample.from = config.rate;
+		handler->resample.to = sample_rate;
+		handler->resample.ratio = (float)sample_rate / (float)config.rate;
+		handler->resample.handle = src_init(CONFIG_AUDIO_RESAMPLER_BUFSIZE);
+		handler->resample.buffer = malloc((int)((float)get_input_frames_to_byte(handler, get_input_frame_count(handler)) / handler->resample.ratio) + 1);	// +1 for floating point margin
+		if (!handler->resample.buffer) {
 			meddbg("malloc for a resampling buffer(stream_in) is failed\n");
 			ret = AUDIO_MANAGER_RESAMPLE_FAIL;
 			goto error_with_pcm;
 		}
 	}
 
-	pthread_mutex_unlock(&(g_audio_in_cards[g_actual_audio_in_card_id].card_mutex));
+	pthread_mutex_unlock(&handler->card_mutex);
 	return ret;
 
 error_with_pcm:
-	pcm_close(g_audio_in_cards[g_actual_audio_in_card_id].pcm);
-	pthread_mutex_unlock(&(g_audio_in_cards[g_actual_audio_in_card_id].card_mutex));
+	pcm_close(handler->pcm);
+	pthread_mutex_unlock(&handler->card_mutex);
 	return ret;
 }
 
-audio_manager_result_t set_audio_stream_out(unsigned int channels, unsigned int sample_rate, int format)
+audio_manager_result_t set_audio_stream_out(audio_handler_t *handler, unsigned int channels, unsigned int sample_rate, int format)
 {
 	struct pcm_config config;
 	audio_manager_result_t ret = AUDIO_MANAGER_SUCCESS;
 
-	if (g_actual_audio_out_card_id < 0) {
-		meddbg("Found no active output audio card\n");
-		return AUDIO_MANAGER_NO_AVAIL_CARD;
-	}
+	ASSERT(handler != NULL);
+	pthread_mutex_lock(&handler->card_mutex);
 
 	if ((channels == 0) || (sample_rate == 0)) {
 		return AUDIO_MANAGER_INVALID_PARAM;
 	}
 
-	if ((g_audio_out_cards[g_actual_audio_out_card_id].status == AUDIO_CARD_PAUSE)) {
-		medvdbg("reset previous preparing\n");
-		reset_audio_stream_out();
+	if (handler->status == AUDIO_CARD_PAUSE) {
+		medvdbg("Reset the previous pcm\n");
+		reset_audio_stream_out(handler);
 	}
-
-	pthread_mutex_lock(&(g_audio_out_cards[g_actual_audio_out_card_id].card_mutex));
 
 	if (channels > AUDIO_STREAM_CHANNEL_MONO) {
 		channels = AUDIO_STREAM_CHANNEL_STEREO;
@@ -623,79 +720,72 @@ audio_manager_result_t set_audio_stream_out(unsigned int channels, unsigned int 
 
 	memset(&config, 0, sizeof(struct pcm_config));
 	config.channels = channels;
-	config.rate = get_closest_samprate(sample_rate, OUTPUT);
+	config.rate = get_closest_samprate(handler, sample_rate);
 	config.format = format;
 	config.period_size = AUDIO_STREAM_VOIP_PERIOD_SIZE;
 	config.period_count = AUDIO_STREAM_VOIP_PERIOD_COUNT;
 
 	if (sample_rate == config.rate) {
-		g_audio_out_cards[g_actual_audio_out_card_id].resample.necessary = false;
+		handler->resample.necessary = false;
 	} else {
-		g_audio_out_cards[g_actual_audio_out_card_id].resample.necessary = true;
-		g_audio_out_cards[g_actual_audio_out_card_id].resample.from = sample_rate;
-		g_audio_out_cards[g_actual_audio_out_card_id].resample.to = config.rate;
-		g_audio_out_cards[g_actual_audio_out_card_id].resample.ratio = (float)config.rate / (float)sample_rate;
+		handler->resample.necessary = true;
+		handler->resample.from = sample_rate;
+		handler->resample.to = config.rate;
+		handler->resample.ratio = (float)config.rate / (float)sample_rate;
 	}
 
 	medvdbg("[OUT] Device samplerate: %u, User requested: %u, channels: %u\n", config.rate, sample_rate, channels);
 
-	medvdbg("actual output card id = %d\n", g_actual_audio_out_card_id);
-	g_audio_out_cards[g_actual_audio_out_card_id].pcm = pcm_open(g_actual_audio_out_card_id, 0, PCM_OUT, &config);
+	medvdbg("actual output card id = %d\n", handler->card_id);
+	handler->pcm = pcm_open(handler->card_id, handler->device_id, PCM_OUT, &config);
 
-	if (!pcm_is_ready(g_audio_out_cards[g_actual_audio_out_card_id].pcm)) {
-		meddbg("fail to pcm_is_ready() error : %s", pcm_get_error(g_audio_out_cards[g_actual_audio_out_card_id].pcm));
+	if (!pcm_is_ready(handler->pcm)) {
+		meddbg("fail to pcm_is_ready() error : %s", pcm_get_error(handler->pcm));
 		ret = AUDIO_MANAGER_CARD_NOT_READY;
 		goto error_with_pcm;
 	}
 
-	g_audio_out_cards[g_actual_audio_out_card_id].status = AUDIO_CARD_READY;
+	handler->status = AUDIO_CARD_READY;
 
-	if (g_audio_out_cards[g_actual_audio_out_card_id].resample.necessary) {
-		g_audio_out_cards[g_actual_audio_out_card_id].resample.handle = src_init(CONFIG_AUDIO_RESAMPLER_BUFSIZE);
-		g_audio_out_cards[g_actual_audio_out_card_id].resample.buffer_size = (int)((float)get_output_frames_to_byte(get_output_frame_count()) * g_audio_out_cards[g_actual_audio_out_card_id].resample.ratio) + 1;	// +1 for floating point margin
-		g_audio_out_cards[g_actual_audio_out_card_id].resample.buffer = malloc(g_audio_out_cards[g_actual_audio_out_card_id].resample.buffer_size);
-		if (!g_audio_out_cards[g_actual_audio_out_card_id].resample.buffer) {
+	if (handler->resample.necessary) {
+		handler->resample.handle = src_init(CONFIG_AUDIO_RESAMPLER_BUFSIZE);
+		handler->resample.buffer_size = (int)((float)get_output_frames_to_byte(handler, get_output_frame_count(handler)) * handler->resample.ratio) + 1;	// +1 for floating point margin
+		handler->resample.buffer = malloc(handler->resample.buffer_size);
+		if (!handler->resample.buffer) {
 			meddbg("malloc for a resampling buffer(stream_out) is failed\n");
 			ret = AUDIO_MANAGER_RESAMPLE_FAIL;
 			goto error_with_pcm;
 		}
-		medvdbg("resampler ratio = %f, buffer_size = %d\t", g_audio_out_cards[g_actual_audio_out_card_id].resample.ratio, g_audio_out_cards[g_actual_audio_out_card_id].resample.buffer_size);
-		medvdbg("buffer address = 0x%x\n", g_audio_out_cards[g_actual_audio_out_card_id].resample.buffer);
+		medvdbg("resampler ratio = %f, buffer_size = %d\t", handler->resample.ratio, handler->resample.buffer_size);
+		medvdbg("buffer address = 0x%x\n", handler->resample.buffer);
 	}
 
-	pthread_mutex_unlock(&(g_audio_out_cards[g_actual_audio_out_card_id].card_mutex));
+	pthread_mutex_unlock(&handler->card_mutex);
 	return ret;
 
 error_with_pcm:
-	pcm_close(g_audio_out_cards[g_actual_audio_out_card_id].pcm);
-	pthread_mutex_unlock(&(g_audio_out_cards[g_actual_audio_out_card_id].card_mutex));
+	pcm_close(handler->pcm);
+	pthread_mutex_unlock(&handler->card_mutex);
 	return ret;
 }
 
-int start_audio_stream_in(void *data, unsigned int frames)
+int start_audio_stream_in(audio_handler_t *handler, void *data, unsigned int frames)
 {
 	int ret;
 	int prepare_retry = AUDIO_STREAM_RETRY_COUNT;
-	audio_card_info_t *cur_card;
 
-	if (g_actual_audio_in_card_id < 0) {
-		meddbg("Found no active input audio card\n");
-		return AUDIO_MANAGER_NO_AVAIL_CARD;
-	}
+	ASSERT(handler != NULL);
+	pthread_mutex_lock(&handler->card_mutex);
 
-	cur_card = &g_audio_in_cards[g_actual_audio_in_card_id];
-
-	pthread_mutex_lock(&(cur_card->card_mutex));
-
-	if (cur_card->status == AUDIO_CARD_PAUSE) {
-		ret = ioctl(pcm_get_file_descriptor(cur_card->pcm), AUDIOIOC_RESUME, NULL);
+	if (handler->status == AUDIO_CARD_PAUSE) {
+		ret = ioctl(pcm_get_file_descriptor(handler->pcm), AUDIOIOC_RESUME, NULL);
 		if (ret < 0) {
 			meddbg("Fail to ioctl AUDIOIOC_RESUME, ret = %d\n", ret);
 			ret = AUDIO_MANAGER_DEVICE_FAIL;
 			goto error_with_lock;
 		}
-
-		cur_card->status = AUDIO_CARD_RUNNING;
+		//ToDo: AUDIO_CARD_RUNNING should be set with proper logics in other APIs.
+		handler->status = AUDIO_CARD_READY;
 		medvdbg("Resume the input audio card!!\n");
 	}
 
@@ -703,23 +793,23 @@ int start_audio_stream_in(void *data, unsigned int frames)
 		// Todo: Logic needs to be changed.
 		//       From: 1 pcm_readi - 1 resampling
 		//       To  : * pcm_readi - 1 resampling
-		if (cur_card->resample.necessary) {
-			unsigned int frames_to_read = (unsigned int)((float)frames / cur_card->resample.ratio);
-			if (frames_to_read > (get_input_frame_count() / cur_card->resample.ratio)) {
-				frames_to_read = (get_input_frame_count() / cur_card->resample.ratio);
+		if (handler->resample.necessary) {
+			unsigned int frames_to_read = (unsigned int)((float)frames / handler->resample.ratio);
+			if (frames_to_read > (get_input_frame_count(handler) / handler->resample.ratio)) {
+				frames_to_read = (get_input_frame_count(handler) / handler->resample.ratio);
 			}
 
-			cur_card->resample.buffer_size = get_input_frames_to_byte(frames);
+			handler->resample.buffer_size = get_input_frames_to_byte(handler, frames);
 
-			ret = pcm_readi(cur_card->pcm, cur_card->resample.buffer, frames_to_read);
+			ret = pcm_readi(handler->pcm, handler->resample.buffer, frames_to_read);
 			medvdbg("Read frames (%d/%u) for resample to %u\n", ret, frames_to_read, frames);
 		} else {
-			ret = pcm_readi(cur_card->pcm, data, frames);
+			ret = pcm_readi(handler->pcm, data, frames);
 			medvdbg("Read %d frames\n", ret);
 		}
 
 		if (ret == -EPIPE) {
-			ret = pcm_prepare(cur_card->pcm);
+			ret = pcm_prepare(handler->pcm);
 			meddbg("PCM is reprepared\n");
 			if (ret != OK) {
 				meddbg("Fail to pcm_prepare()\n");
@@ -734,62 +824,55 @@ int start_audio_stream_in(void *data, unsigned int frames)
 		}
 	} while ((ret == OK) && (prepare_retry--));
 
-	if (cur_card->resample.necessary) {
-		ret = resample_stream_in(cur_card, data, ret);
+	if (handler->resample.necessary) {
+		ret = resample_stream_in(handler, data, ret);
 		medvdbg("Resampled frames = %d\n", ret);
 	}
 
 error_with_lock:
-	pthread_mutex_unlock(&(cur_card->card_mutex));
+	pthread_mutex_unlock(&handler->card_mutex);
 
 	return ret;
 }
 
-int start_audio_stream_out(void *data, unsigned int frames)
+int start_audio_stream_out(audio_handler_t *handler, void *data, unsigned int frames)
 {
 	int ret;
 	unsigned int resampled_frames = 0;
 	int prepare_retry = AUDIO_STREAM_RETRY_COUNT;
-	audio_card_info_t *cur_card;
 	medvdbg("start_audio_stream_out(%u)\n", frames);
 
-	if (g_actual_audio_out_card_id < 0) {
-		meddbg("Found no active output audio card\n");
-		return AUDIO_MANAGER_NO_AVAIL_CARD;
-	}
+	ASSERT(handler != NULL);
+	pthread_mutex_lock(&handler->card_mutex);
 
-	cur_card = &g_audio_out_cards[g_actual_audio_out_card_id];
-
-	pthread_mutex_lock(&(cur_card->card_mutex));
-
-	if (cur_card->status == AUDIO_CARD_PAUSE) {
-		ret = ioctl(pcm_get_file_descriptor(cur_card->pcm), AUDIOIOC_RESUME, NULL);
+	if (handler->status == AUDIO_CARD_PAUSE) {
+		ret = ioctl(pcm_get_file_descriptor(handler->pcm), AUDIOIOC_RESUME, NULL);
 		if (ret < 0) {
 			meddbg("Fail to ioctl AUDIOIOC_RESUME, ret = %d\n", ret);
 			ret = AUDIO_MANAGER_DEVICE_FAIL;
 			goto error_with_lock;
 		}
-
-		cur_card->status = AUDIO_CARD_RUNNING;
+		//ToDo: AUDIO_CARD_RUNNING should be set with proper logics in other APIs.
+		handler->status = AUDIO_CARD_READY;
 		medvdbg("Resume the output audio card!!\n");
 	}
 
-	if (cur_card->resample.necessary) {
-		resampled_frames = resample_stream_out(cur_card, data, frames);
+	if (handler->resample.necessary) {
+		resampled_frames = resample_stream_out(handler, data, frames);
 	}
 
 	do {
-		medvdbg("Start Playing!! Resample : %d\t", cur_card->resample.necessary);
-		if (cur_card->resample.necessary) {
-			ret = pcm_writei(cur_card->pcm, cur_card->resample.buffer, resampled_frames);
+		medvdbg("Start Playing!! Resample : %d\t", handler->resample.necessary);
+		if (handler->resample.necessary) {
+			ret = pcm_writei(handler->pcm, handler->resample.buffer, resampled_frames);
 		} else {
-			ret = pcm_writei(cur_card->pcm, data, frames);
+			ret = pcm_writei(handler->pcm, data, frames);
 		}
 
 		if (ret < 0) {
 			if (ret == -EPIPE) {
 				if (prepare_retry > 0) {
-					ret = pcm_prepare(cur_card->pcm);
+					ret = pcm_prepare(handler->pcm);
 					if (ret != OK) {
 						meddbg("Fail to pcm_prepare()\n");
 						ret = AUDIO_MANAGER_XRUN_STATE;
@@ -813,216 +896,198 @@ int start_audio_stream_out(void *data, unsigned int frames)
 	} while (ret == OK);
 
 error_with_lock:
-	pthread_mutex_unlock(&(cur_card->card_mutex));
+	pthread_mutex_unlock(&handler->card_mutex);
 	return ret;
 }
 
-audio_manager_result_t pause_audio_stream_in(void)
+audio_manager_result_t pause_audio_stream_in(audio_handler_t *handler)
 {
 	int ret;
 
-	if (g_actual_audio_in_card_id < 0) {
-		meddbg("Found no active input audio card\n");
-		return AUDIO_MANAGER_NO_AVAIL_CARD;
-	}
+	ASSERT(handler != NULL);
+	pthread_mutex_lock(&handler->card_mutex);
 
-	pthread_mutex_lock(&(g_audio_in_cards[g_actual_audio_in_card_id].card_mutex));
-
-	ret = ioctl(pcm_get_file_descriptor(g_audio_in_cards[g_actual_audio_in_card_id].pcm), AUDIOIOC_PAUSE, NULL);
+	ret = ioctl(pcm_get_file_descriptor(handler->pcm), AUDIOIOC_PAUSE, NULL);
 	if (ret < 0) {
 		meddbg("Fail to ioctl AUDIOIOC_PAUSE, ret = %d\n", ret);
-		pthread_mutex_unlock(&(g_audio_in_cards[g_actual_audio_in_card_id].card_mutex));
+		pthread_mutex_unlock(&handler->card_mutex);
 		return AUDIO_MANAGER_DEVICE_FAIL;
 	}
 
-	g_audio_in_cards[g_actual_audio_in_card_id].status = AUDIO_CARD_PAUSE;
+	handler->status = AUDIO_CARD_PAUSE;
 
-	pthread_mutex_unlock(&(g_audio_in_cards[g_actual_audio_in_card_id].card_mutex));
+	pthread_mutex_unlock(&handler->card_mutex);
 
 	return AUDIO_MANAGER_SUCCESS;
 }
 
-audio_manager_result_t pause_audio_stream_out(void)
+audio_manager_result_t pause_audio_stream_out(audio_handler_t *handler)
 {
 	int ret;
 
-	if (g_actual_audio_out_card_id < 0) {
-		meddbg("Found no active output audio card\n");
-		return AUDIO_MANAGER_NO_AVAIL_CARD;
-	}
+	ASSERT(handler != NULL);
+	pthread_mutex_lock(&handler->card_mutex);
 
-	pthread_mutex_lock(&(g_audio_out_cards[g_actual_audio_out_card_id].card_mutex));
-
-	ret = ioctl(pcm_get_file_descriptor(g_audio_out_cards[g_actual_audio_out_card_id].pcm), AUDIOIOC_PAUSE, NULL);
+	ret = ioctl(pcm_get_file_descriptor(handler->pcm), AUDIOIOC_PAUSE, NULL);
 	if (ret < 0) {
 		meddbg("Fail to ioctl AUDIOIOC_PAUSE, ret = %d\n", ret);
-		pthread_mutex_unlock(&(g_audio_out_cards[g_actual_audio_out_card_id].card_mutex));
+		pthread_mutex_unlock(&handler->card_mutex);
 		return AUDIO_MANAGER_DEVICE_FAIL;
 	}
 
-	g_audio_out_cards[g_actual_audio_out_card_id].status = AUDIO_CARD_PAUSE;
+	handler->status = AUDIO_CARD_PAUSE;
 
-	pthread_mutex_unlock(&(g_audio_out_cards[g_actual_audio_out_card_id].card_mutex));
+	pthread_mutex_unlock(&handler->card_mutex);
 
 	return AUDIO_MANAGER_SUCCESS;
 }
 
-audio_manager_result_t stop_audio_stream_in(void)
+audio_manager_result_t stop_audio_stream_in(audio_handler_t *handler)
 {
 	int ret;
 
-	if (g_actual_audio_in_card_id < 0) {
-		meddbg("Found no active input audio card\n");
-		return AUDIO_MANAGER_NO_AVAIL_CARD;
-	}
+	ASSERT(handler != NULL);
+	pthread_mutex_lock(&handler->card_mutex);
 
-	pthread_mutex_lock(&(g_audio_in_cards[g_actual_audio_in_card_id].card_mutex));
-
-	ret = pcm_drop(g_audio_in_cards[g_actual_audio_in_card_id].pcm);
+	ret = pcm_drop(handler->pcm);
 	if (ret < 0) {
-		pthread_mutex_unlock(&(g_audio_in_cards[g_actual_audio_in_card_id].card_mutex));
+		pthread_mutex_unlock(&handler->card_mutex);
 		meddbg("pcm_drop Failed, ret = %d\n", ret);
 		return AUDIO_MANAGER_DEVICE_FAIL;
 	}
 
-	g_audio_in_cards[g_actual_audio_in_card_id].status = AUDIO_CARD_READY;
+	handler->status = AUDIO_CARD_READY;
 
-	pthread_mutex_unlock(&(g_audio_in_cards[g_actual_audio_in_card_id].card_mutex));
+	pthread_mutex_unlock(&handler->card_mutex);
 
 	return AUDIO_MANAGER_SUCCESS;
 }
 
-audio_manager_result_t stop_audio_stream_out(void)
+audio_manager_result_t stop_audio_stream_out(audio_handler_t *handler)
 {
 	int ret;
 
-	if (g_actual_audio_out_card_id < 0) {
-		meddbg("Found no active output audio card\n");
-		return AUDIO_MANAGER_NO_AVAIL_CARD;
-	}
+	ASSERT(handler != NULL);
+	pthread_mutex_lock(&handler->card_mutex);
 
-	pthread_mutex_lock(&(g_audio_out_cards[g_actual_audio_out_card_id].card_mutex));
-
-	ret = pcm_drain(g_audio_out_cards[g_actual_audio_out_card_id].pcm);
+	ret = pcm_drain(handler->pcm);
 	if (ret < 0) {
-		pthread_mutex_unlock(&(g_audio_out_cards[g_actual_audio_out_card_id].card_mutex));
+		pthread_mutex_unlock(&handler->card_mutex);
 		meddbg("pcm_drain failed ret = %d\n", ret);
 		return AUDIO_MANAGER_DEVICE_FAIL;
 	}
 
-	g_audio_out_cards[g_actual_audio_out_card_id].status = AUDIO_CARD_READY;
+	handler->status = AUDIO_CARD_READY;
 
-	pthread_mutex_unlock(&(g_audio_out_cards[g_actual_audio_out_card_id].card_mutex));
+	pthread_mutex_unlock(&handler->card_mutex);
 
 	return AUDIO_MANAGER_SUCCESS;
 }
 
-audio_manager_result_t reset_audio_stream_in(void)
+audio_manager_result_t reset_audio_stream_in(audio_handler_t *handler)
 {
-	if (g_actual_audio_in_card_id < 0) {
-		meddbg("Found no active input audio card\n");
-		return AUDIO_MANAGER_NO_AVAIL_CARD;
-	}
+	ASSERT(handler != NULL);
+	pthread_mutex_lock(&handler->card_mutex);
 
-	pthread_mutex_lock(&(g_audio_in_cards[g_actual_audio_in_card_id].card_mutex));
+	pcm_close(handler->pcm);
+	handler->pcm = NULL;
 
-	pcm_close(g_audio_in_cards[g_actual_audio_in_card_id].pcm);
-	g_audio_in_cards[g_actual_audio_in_card_id].pcm = NULL;
-
-	if (g_audio_in_cards[g_actual_audio_in_card_id].resample.necessary) {
-		if (g_audio_in_cards[g_actual_audio_in_card_id].resample.buffer) {
-			free(g_audio_in_cards[g_actual_audio_in_card_id].resample.buffer);
+	if (handler->resample.necessary) {
+		if (handler->resample.buffer) {
+			free(handler->resample.buffer);
 		}
-		src_destroy(g_audio_in_cards[g_actual_audio_in_card_id].resample.handle);
+		src_destroy(handler->resample.handle);
 	}
 
-	g_audio_in_cards[g_actual_audio_in_card_id].status = AUDIO_CARD_IDLE;
+	handler->status = AUDIO_CARD_IDLE;
 
-	pthread_mutex_unlock(&(g_audio_in_cards[g_actual_audio_in_card_id].card_mutex));
+	pthread_mutex_unlock(&handler->card_mutex);
 
 	return AUDIO_MANAGER_SUCCESS;
 }
 
-audio_manager_result_t reset_audio_stream_out(void)
+audio_manager_result_t reset_audio_stream_out(audio_handler_t *handler)
 {
-	if (g_actual_audio_out_card_id < 0) {
-		meddbg("Found no active output audio card\n");
-		return AUDIO_MANAGER_NO_AVAIL_CARD;
-	}
+	ASSERT(handler != NULL);
+	pthread_mutex_lock(&handler->card_mutex);
 
-	pthread_mutex_lock(&(g_audio_out_cards[g_actual_audio_out_card_id].card_mutex));
+	pcm_close(handler->pcm);
+	handler->pcm = NULL;
 
-	pcm_close(g_audio_out_cards[g_actual_audio_out_card_id].pcm);
-	g_audio_out_cards[g_actual_audio_out_card_id].pcm = NULL;
-
-	if (g_audio_out_cards[g_actual_audio_out_card_id].resample.necessary) {
-		if (g_audio_out_cards[g_actual_audio_out_card_id].resample.buffer) {
-			free(g_audio_out_cards[g_actual_audio_out_card_id].resample.buffer);
+	if (handler->resample.necessary) {
+		if (handler->resample.buffer) {
+			free(handler->resample.buffer);
 		}
-		src_destroy(g_audio_out_cards[g_actual_audio_out_card_id].resample.handle);
+		src_destroy(handler->resample.handle);
 	}
 
-	g_audio_out_cards[g_actual_audio_out_card_id].status = AUDIO_CARD_IDLE;
+	handler->status = AUDIO_CARD_IDLE;
 
-	pthread_mutex_unlock(&(g_audio_out_cards[g_actual_audio_out_card_id].card_mutex));
+	pthread_mutex_unlock(&handler->card_mutex);
 
 	return AUDIO_MANAGER_SUCCESS;
 }
 
-unsigned int get_input_frame_count(void)
+audio_manager_result_t destroy_audio_handler_in(void)
 {
-	if (g_actual_audio_in_card_id < 0) {
-		meddbg("No input audio card is active.\n");
-		return 0;
-	}
-
-	return pcm_get_buffer_size(g_audio_in_cards[g_actual_audio_in_card_id].pcm);
+	return get_audio_card_in(AUDIO_CARD_DESTROY, NULL);
 }
 
-unsigned int get_input_frames_to_byte(unsigned int frames)
+audio_manager_result_t destroy_audio_handler_out(void)
 {
-	if ((g_actual_audio_in_card_id < 0) || (frames == 0)) {
-		return 0;
-	}
-
-	return pcm_frames_to_bytes(g_audio_in_cards[g_actual_audio_in_card_id].pcm, frames);
+	return get_audio_card_out(AUDIO_CARD_DESTROY, NULL);
 }
 
-unsigned int get_input_bytes_to_frame(unsigned int bytes)
+unsigned int get_input_frame_count(audio_handler_t *handler)
 {
-	if ((g_actual_audio_in_card_id < 0) || (bytes == 0)) {
-		return 0;
-	}
-
-	return pcm_bytes_to_frames(g_audio_in_cards[g_actual_audio_in_card_id].pcm, bytes);
+	ASSERT(handler != NULL);
+	return pcm_get_buffer_size(handler->pcm);
 }
 
-unsigned int get_output_frame_count(void)
+unsigned int get_input_frames_to_byte(audio_handler_t *handler, unsigned int frames)
 {
-	if (g_actual_audio_out_card_id < 0) {
-		meddbg("No output audio card is active.\n");
+	if (frames == 0) {
 		return 0;
 	}
 
-	return pcm_get_buffer_size(g_audio_out_cards[g_actual_audio_out_card_id].pcm);
+	ASSERT(handler != NULL);
+	return pcm_frames_to_bytes(handler->pcm, frames);
 }
 
-unsigned int get_output_frames_to_byte(unsigned int frames)
+unsigned int get_input_bytes_to_frame(audio_handler_t *handler, unsigned int bytes)
 {
-	if ((g_actual_audio_out_card_id < 0) || (frames == 0)) {
+	if (bytes == 0) {
 		return 0;
 	}
 
-	return pcm_frames_to_bytes(g_audio_out_cards[g_actual_audio_out_card_id].pcm, frames);
+	ASSERT(handler != NULL);
+	return pcm_bytes_to_frames(handler->pcm, bytes);
 }
 
-uint32_t get_output_bytes_to_frame(unsigned int bytes)
+unsigned int get_output_frame_count(audio_handler_t *handler)
 {
-	if ((g_actual_audio_out_card_id < 0) || (bytes == 0)) {
+	ASSERT(handler != NULL);
+	return pcm_get_buffer_size(handler->pcm);
+}
+
+unsigned int get_output_frames_to_byte(audio_handler_t *handler, unsigned int frames)
+{
+	if (frames == 0) {
 		return 0;
 	}
 
-	return pcm_bytes_to_frames(g_audio_out_cards[g_actual_audio_out_card_id].pcm, bytes);
+	ASSERT(handler != NULL);
+	return pcm_frames_to_bytes(handler->pcm, frames);
+}
+
+uint32_t get_output_bytes_to_frame(audio_handler_t *handler, unsigned int bytes)
+{
+	if (bytes == 0) {
+		return 0;
+	}
+
+	ASSERT(handler != NULL);
+	return pcm_bytes_to_frames(handler->pcm, bytes);
 }
 
 uint16_t get_max_audio_volume(void)
@@ -1030,80 +1095,84 @@ uint16_t get_max_audio_volume(void)
 	return AUDIO_DEVICE_MAX_VOLUME;
 }
 
-int get_input_audio_volume(void)
+int get_input_audio_volume(audio_handler_t *handler)
 {
 #ifndef CONFIG_AUDIO_EXCLUDE_VOLUME	//TODO consider about config for gain.
 	int ret;
 	int fd;
 
-	fd = open(g_audio_in_cards[g_actual_audio_in_card_id].card_path, O_RDONLY);
+	ASSERT(handler != NULL);
+	fd = open(handler->card_path, O_RDONLY);
 	if (fd < 0) {
-		meddbg("Failed to open audio driver, path : %s errno : %d\n", g_audio_in_cards[g_actual_audio_in_card_id].card_path, errno);
+		meddbg("Failed to open audio driver, path : %s errno : %d\n", handler->card_path, errno);
 		return AUDIO_MANAGER_CARD_NOT_READY;
 	}
 
 	/* get volume of current card first */
-	if ((ret = get_audio_volume(fd, &(g_audio_in_cards[g_actual_audio_in_card_id].config), INPUT)) != AUDIO_MANAGER_SUCCESS) {
-		meddbg("Get volume failed card path : %s card_type : %d ret : %d\n", g_audio_in_cards[g_actual_audio_in_card_id].card_path, INPUT, ret);
+	if ((ret = get_audio_volume(fd, &(handler->config), INPUT)) != AUDIO_MANAGER_SUCCESS) {
+		meddbg("Get volume failed card path : %s card_type : %d ret : %d\n", handler->card_path, INPUT, ret);
 		close(fd);
 		return ret;
 	}
-	medvdbg("Max volume: %d, Current Volume : %d card path : %s\n", g_audio_in_cards[g_actual_audio_in_card_id].config.max_volume, g_audio_in_cards[g_actual_audio_in_card_id].config.volume, g_audio_in_cards[g_actual_audio_in_card_id].card_path);
+	medvdbg("Max volume: %d, Current Volume : %d card path : %s\n", handler->config.max_volume, handler->config.volume, handler->card_path);
 
 	close(fd);
 
-	return (int)g_audio_in_cards[g_actual_audio_in_card_id].config.volume;
+	return (int)handler->config.volume;
 #endif
 	return 0;
 }
 
-int get_output_audio_volume(void)
+int get_output_audio_volume(audio_handler_t *handler)
 {
 #ifndef CONFIG_AUDIO_EXCLUDE_VOLUME
 	int ret;
 	int fd;
 
-	fd = open(g_audio_out_cards[g_actual_audio_out_card_id].card_path, O_RDONLY);
+	ASSERT(handler != NULL);
+	fd = open(handler->card_path, O_RDONLY);
 	if (fd < 0) {
-		meddbg("Failed to open audio driver, path : %s errno : %d\n", g_audio_out_cards[g_actual_audio_out_card_id].card_path, errno);
+		meddbg("Failed to open audio driver, path : %s errno : %d\n", handler->card_path, errno);
 		return AUDIO_MANAGER_CARD_NOT_READY;
 	}
 
 	/* get volume of current card first */
-	if ((ret = get_audio_volume(fd, &(g_audio_out_cards[g_actual_audio_out_card_id].config), OUTPUT)) != AUDIO_MANAGER_SUCCESS) {
-		meddbg("Get volume failed card path : %s card_type : %d ret : %d\n", g_audio_out_cards[g_actual_audio_out_card_id].card_path, INPUT, ret);
+	if ((ret = get_audio_volume(fd, &(handler->config), OUTPUT)) != AUDIO_MANAGER_SUCCESS) {
+		meddbg("Get volume failed card path : %s card_type : %d ret : %d\n", handler->card_path, INPUT, ret);
 		close(fd);
 		return ret;
 	}
-	medvdbg("Max volume: %d, Current Volume : %d card path : %s\n", g_audio_out_cards[g_actual_audio_out_card_id].config.max_volume, g_audio_out_cards[g_actual_audio_out_card_id].config.volume, g_audio_out_cards[g_actual_audio_out_card_id].card_path);
+	medvdbg("Max volume: %d, Current Volume : %d card path : %s\n", handler->config.max_volume, handler->config.volume, handler->card_path);
 
 	close(fd);
 
-	return (int)g_audio_out_cards[g_actual_audio_out_card_id].config.volume;
+	return (int)handler->config.volume;
 #endif
 	return 0;
 }
 
-audio_manager_result_t set_input_audio_volume(uint8_t volume)
+audio_manager_result_t set_input_audio_volume(audio_handler_t *handler, uint8_t volume)
 {
 #ifndef CONFIG_AUDIO_EXCLUDE_VOLUME
-	if (g_audio_in_cards[g_actual_audio_in_card_id].config.volume == volume) {
+	ASSERT(handler != NULL);
+	if (handler->config.volume == volume) {
 		return AUDIO_MANAGER_SUCCESS;
 	}
 
-	return set_audio_volume(INPUT, volume);
+	return set_audio_volume(handler, INPUT, volume);
 #endif
 	return AUDIO_MANAGER_SUCCESS;
 }
 
-audio_manager_result_t set_output_audio_volume(uint8_t volume)
+audio_manager_result_t set_output_audio_volume(audio_handler_t *handler, uint8_t volume)
 {
 #ifndef CONFIG_AUDIO_EXCLUDE_VOLUME
-	if (g_audio_out_cards[g_actual_audio_out_card_id].config.volume == volume) {
+	ASSERT(handler != NULL);
+	if (handler->config.volume == volume) {
 		return AUDIO_MANAGER_SUCCESS;
 	}
 
-	return set_audio_volume(OUTPUT, volume);
+	return set_audio_volume(handler, OUTPUT, volume);
 #endif
 	return AUDIO_MANAGER_SUCCESS;
 }

--- a/framework/src/media/audio/audio_manager.h
+++ b/framework/src/media/audio/audio_manager.h
@@ -51,10 +51,32 @@ enum audio_manager_result_e {
 };
 
 typedef enum audio_manager_result_e audio_manager_result_t;
+typedef struct audio_card_info_s audio_handler_t;
 
 /****************************************************************************
  * Public Function Prototypes
  ****************************************************************************/
+/****************************************************************************
+ * Name: init_audio_handler_in
+ *
+ * Description:
+ *   Create an audio handler that has all information of the input card to be used.
+ *
+ * Returned Value:
+ *   On success, AUDIO_MANAGER_SUCCESS. Otherwise a negative value.
+ ****************************************************************************/
+audio_manager_result_t init_audio_handler_in(void);
+
+/****************************************************************************
+ * Name: init_audio_handler_out
+ *
+ * Description:
+ *   Create an audio handler that has all information of the output card to be used.
+ *
+ * Returned Value:
+ *   On success, AUDIO_MANAGER_SUCCESS. Otherwise a negative value.
+ ****************************************************************************/
+audio_manager_result_t init_audio_handler_out(void);
 
 /****************************************************************************
  * Name: init_audio_stream_in
@@ -63,10 +85,13 @@ typedef enum audio_manager_result_e audio_manager_result_t;
  *   Find all available audio cards for input stream and initialize the
  *   mutexes of each card. The one of the audio cards is set as the active one.
  *
+ * Input parameters:
+ *   handler: the pointer of the input audio handler to be allocated.
+ *
  * Returned Value:
  *   On success, AUDIO_MANAGER_SUCCESS. Otherwise a negative value.
  ****************************************************************************/
-audio_manager_result_t init_audio_stream_in(void);
+audio_manager_result_t init_audio_stream_in(audio_handler_t **handler);
 
 /****************************************************************************
  * Name: init_audio_stream_out
@@ -75,10 +100,13 @@ audio_manager_result_t init_audio_stream_in(void);
  *   Find all available audio cards for output stream and initialize the
  *   mutexes of the cards. The one of the audio cards is set as the active one.
  *
+ * Input parameters:
+ *   handler: the pointer of the output audio handler to be allocated.
+ *
  * Returned Value:
  *   On success, AUDIO_MANAGER_SUCCESS. Otherwise a negative value.
  ****************************************************************************/
-audio_manager_result_t init_audio_stream_out(void);
+audio_manager_result_t init_audio_stream_out(audio_handler_t **handler);
 
 /****************************************************************************
  * Name: set_audio_stream_in
@@ -89,14 +117,15 @@ audio_manager_result_t init_audio_stream_out(void);
  *   supported by the active input audio card, a resampling flag is set.
  *
  * Input parameters:
- *   channels: number of channels
- *   sample_rate: sample rate with which the stream is operated
- *   format: audio file format to be streamed in
+ *   handler: the audio handler which has all information of the current audio card
+ *   channels: a number of channels
+ *   sample_rate: a sample rate with which the stream is operated
+ *   format: an audio file format with which the stream is operated
  *
  * Returned Value:
  *   On success, AUDIO_MANAGER_SUCCESS. Otherwise a negative value.
  ****************************************************************************/
-audio_manager_result_t set_audio_stream_in(unsigned int channels, unsigned int sample_rate, int format);
+audio_manager_result_t set_audio_stream_in(audio_handler_t *handler, unsigned int channels, unsigned int sample_rate, int format);
 
 /****************************************************************************
  * Name: set_audio_stream_out
@@ -107,14 +136,15 @@ audio_manager_result_t set_audio_stream_in(unsigned int channels, unsigned int s
  *   supported by the active output audio card, a resampling flag is set.
  *
  * Input parameters:
- *   channels: number of channels
- *   sample_rate: sample rate with which the stream is operated
- *   format: audio file format to be streamed out
+ *   handler: the audio handler which has all information of the current audio card
+ *   channels: a number of channels
+ *   sample_rate: a sample rate with which the stream is operated
+ *   format: an audio file format with which the stream is operated
  *
  * Returned Value:
  *   On success, AUDIO_MANAGER_SUCCESS. Otherwise, a negative value.
  ****************************************************************************/
-audio_manager_result_t set_audio_stream_out(unsigned int channels, unsigned int sample_rate, int format);
+audio_manager_result_t set_audio_stream_out(audio_handler_t *handler, unsigned int channels, unsigned int sample_rate, int format);
 
 /****************************************************************************
  * Name: start_audio_stream_in
@@ -125,13 +155,14 @@ audio_manager_result_t set_audio_stream_out(unsigned int channels, unsigned int 
  *   If the resampling flag is set, resamplings are performed for all target frames.
  *
  * Input parameters:
- *   data: buffer to get the frame data
- *   frames: number of frames to be read
+ *   handler: the audio handler which has all information of the current audio card
+ *   data: a buffer to get the frame data
+ *   frames: a number of frames to be read
  *
  * Returned Value:
  *   On success, the number of frames read. Otherwise, a negative value.
  ****************************************************************************/
-int start_audio_stream_in(void *data, unsigned int frames);
+int start_audio_stream_in(audio_handler_t *handler, void *data, unsigned int frames);
 
 /****************************************************************************
  * Name: start_audio_stream_out
@@ -142,13 +173,14 @@ int start_audio_stream_in(void *data, unsigned int frames);
  *   If the resampling flag is set, resamplings are performed for all target frames.
  *
  * Input parameters:
- *   data: buffer to transfer the frame data
- *   frames: number of frames to be written
+ *   handler: the audio handler which has all information of the current audio card
+ *   data: a buffer to transfer the frame data
+ *   frames: a number of frames to be written
  *
  * Returned Value:
  *   On success, the number of frames written. Otherwise, a negative value.
  ****************************************************************************/
-int start_audio_stream_out(void *data, unsigned int frames);
+int start_audio_stream_out(audio_handler_t *handler, void *data, unsigned int frames);
 
 /****************************************************************************
  * Name: pause_audio_stream_in
@@ -158,10 +190,13 @@ int start_audio_stream_out(void *data, unsigned int frames);
  *   Note that only the active audio device currently running can be paused.
  *   If the device is resumed, the paused stream is continued.
  *
+ * Input parameters:
+ *   handler: the audio handler which has all information of the current audio card
+ *
  * Returned Value:
  *   On success, AUDIO_MANAGER_SUCCESS. Otherwise, a negative value.
  ****************************************************************************/
-audio_manager_result_t pause_audio_stream_in(void);
+audio_manager_result_t pause_audio_stream_in(audio_handler_t *handler);
 
 /****************************************************************************
  * Name: pause_audio_stream_out
@@ -171,10 +206,13 @@ audio_manager_result_t pause_audio_stream_in(void);
  *	 Note that only the active audio device currently running can be paused.
  *	 If the device is resumed, the paused stream is continued.
  *
+ * Input parameters:
+ *   handler: the audio handler which has all information of the current audio card
+ *
  * Returned Value:
  *   On success, AUDIO_MANAGER_SUCCESS. Otherwise, a negative value.
  ****************************************************************************/
-audio_manager_result_t pause_audio_stream_out(void);
+audio_manager_result_t pause_audio_stream_out(audio_handler_t *handler);
 
 /****************************************************************************
  * Name: stop_audio_stream_in
@@ -185,10 +223,13 @@ audio_manager_result_t pause_audio_stream_out(void);
  *	 Once the device is stopped, the stream should be restarted from the beginning
  *	 with calling set_audio_stream_in().
  *
+ * Input parameters:
+ *   handler: the audio handler which has all information of the current audio card
+ *
  * Returned Value:
  *   On success, AUDIO_MANAGER_SUCCESS. Otherwise, a negative value.
  ****************************************************************************/
-audio_manager_result_t stop_audio_stream_in(void);
+audio_manager_result_t stop_audio_stream_in(audio_handler_t *handler);
 
 /****************************************************************************
  * Name: stop_audio_stream_out
@@ -199,10 +240,13 @@ audio_manager_result_t stop_audio_stream_in(void);
  *	 Once the device is stopped, the stream should be restarted from the beginning
  *	 with calling set_audio_stream_out().
  *
+ * Input parameters:
+ *   handler: the audio handler which has all information of the current audio card
+ *
  * Returned Value:
  *   On success, AUDIO_MANAGER_SUCCESS. Otherwise, a negative value.
  ****************************************************************************/
-audio_manager_result_t stop_audio_stream_out(void);
+audio_manager_result_t stop_audio_stream_out(audio_handler_t *handler);
 
 /****************************************************************************
  * Name: reset_audio_stream_in
@@ -212,10 +256,13 @@ audio_manager_result_t stop_audio_stream_out(void);
  *   After the reset, the stream should be restarted from the beginning with
  *   calling set_audio_stream_in().
  *
+ * Input parameters:
+ *   handler: the audio handler which has all information of the current audio card
+ *
  * Returned Value:
  *   On success, AUDIO_MANAGER_SUCCESS. Otherwise, a negative value.
  ****************************************************************************/
-audio_manager_result_t reset_audio_stream_in(void);
+audio_manager_result_t reset_audio_stream_in(audio_handler_t *handler);
 
 /****************************************************************************
  * Name: reset_audio_stream_out
@@ -225,10 +272,35 @@ audio_manager_result_t reset_audio_stream_in(void);
  *   After the reset, the stream should be restarted from the beginning with
  *   calling set_audio_stream_out().
  *
+ * Input parameters:
+ *   handler: the audio handler which has all information of the current audio card
+ *
  * Returned Value:
  *   On success, AUDIO_MANAGER_SUCCESS. Otherwise, a negative value.
  ****************************************************************************/
-audio_manager_result_t reset_audio_stream_out(void);
+audio_manager_result_t reset_audio_stream_out(audio_handler_t *handler);
+
+/****************************************************************************
+ * Name: destroy_audio_handler_in
+ *
+ * Description:
+ *   Destroy (Deallocate) the current input audio handler.
+ *
+ * Returned Value:
+ *   On success, AUDIO_MANAGER_SUCCESS. Otherwise a negative value.
+ ****************************************************************************/
+audio_manager_result_t destroy_audio_handler_in(void);
+
+/****************************************************************************
+ * Name: destroy_audio_handler_out
+ *
+ * Description:
+ *   Destroy (Deallocate) the current output audio handler.
+ *
+ * Returned Value:
+ *   On success, AUDIO_MANAGER_SUCCESS. Otherwise a negative value.
+ ****************************************************************************/
+audio_manager_result_t destroy_audio_handler_out(void);
 
 /****************************************************************************
  * Name: get_input_frame_count
@@ -236,10 +308,13 @@ audio_manager_result_t reset_audio_stream_out(void);
  * Description:
  *   Get the frame size of the pcm buffer in the active input audio device.
  *
+ * Input parameters:
+ *   handler: the audio handler which has all information of the current audio card
+ *
  * Returned Value:
  *   On success, the size of the pcm buffer for input streams. Otherwise, 0.
  ****************************************************************************/
-unsigned int get_input_frame_count(void);
+unsigned int get_input_frame_count(audio_handler_t *handler);
 
 /****************************************************************************
  * Name: get_input_frames_to_byte
@@ -248,12 +323,13 @@ unsigned int get_input_frame_count(void);
  *   Get the byte size of the given frame value in input stream.
  *
  * Input parameters:
- *   frames: the target of which byte size is returned.
+ *   handler: the audio handler which has all information of the current audio card
+ *   frames: a frame count of which byte size is returned.
  *
  * Returned Value:
  *   On success, the byte size of the frame in input stream. Otherwise, 0.
  ****************************************************************************/
-unsigned int get_input_frames_to_byte(unsigned int frames);
+unsigned int get_input_frames_to_byte(audio_handler_t *handler, unsigned int frames);
 
 /****************************************************************************
  * Name: get_input_bytes_to_frame
@@ -262,12 +338,13 @@ unsigned int get_input_frames_to_byte(unsigned int frames);
  *   Get the number of frames for the given byte size in input stream.
  *
  * Input parameters:
- *   bytes: the target of which frame count is returned.
+ *   handler: the audio handler which has all information of the current audio card
+ *   frames: a frame count of which byte size is returned.
  *
  * Returned Value:
  *   On success, the number of frames in input stream. Otherwise, 0.
  ****************************************************************************/
-unsigned int get_input_bytes_to_frame(unsigned int bytes);
+unsigned int get_input_bytes_to_frame(audio_handler_t *handler, unsigned int bytes);
 
 /****************************************************************************
  * Name: get_output_frame_count
@@ -275,10 +352,13 @@ unsigned int get_input_bytes_to_frame(unsigned int bytes);
  * Description:
  *   Get the frame size of the pcm buffer in the active output audio device.
  *
+ * Input parameters:
+ *   handler: the audio handler which has all information of the current audio card
+ *
  * Returned Value:
  *   On success, the size of the pcm buffer for output streams. Otherwise, 0.
  ****************************************************************************/
-unsigned int get_output_frame_count(void);
+unsigned int get_output_frame_count(audio_handler_t *handler);
 
 /****************************************************************************
  * Name: get_output_frames_to_byte
@@ -287,12 +367,13 @@ unsigned int get_output_frame_count(void);
  *   Get the byte size of the given frame value in output stream.
  *
  * Input parameters:
- *   frames: the target of which byte size is returned.
+ *   handler: the audio handler which has all information of the current audio card
+ *   frames: a frame count of which byte size is returned.
  *
  * Returned Value:
  *   On success, the byte size of the frame in output stream. Otherwise, 0.
  ****************************************************************************/
-unsigned int get_output_frames_to_byte(unsigned int frames);
+unsigned int get_output_frames_to_byte(audio_handler_t *handler, unsigned int frames);
 
 /****************************************************************************
  * Name: get_output_bytes_to_frame
@@ -301,12 +382,13 @@ unsigned int get_output_frames_to_byte(unsigned int frames);
  *   Get the number of frames for the given byte size in output stream.
  *
  * Input parameters:
- *   bytes: the target of which frame count is returned.
+ *   handler: the audio handler which has all information of the current audio card
+ *   bytes: a byte size of which frame count is returned.
  *
  * Returned Value:
  *   On success, the number of frames in output stream. Otherwise, 0.
  ****************************************************************************/
-unsigned int get_output_bytes_to_frame(unsigned int bytes);
+unsigned int get_output_bytes_to_frame(audio_handler_t *handler, unsigned int bytes);
 
 /****************************************************************************
  * Name: get_audio_volume
@@ -324,10 +406,13 @@ uint16_t get_max_audio_volume(void);
  * Description:
  *   Get the current volume level of the active input audio device.
  *
+ * Input parameters:
+ *   handler: the audio handler which has all information of the current audio card
+ *
  * Returned Value:
  *   On success, the current input volume level. Otherwise, a negative value.
  ****************************************************************************/
-int get_input_audio_volume(void);
+int get_input_audio_volume(audio_handler_t *handler);
 
 /****************************************************************************
  * Name: get_output_audio_volume
@@ -335,10 +420,13 @@ int get_input_audio_volume(void);
  * Description:
  *   Get the current volume level of the active output audio device.
  *
+ * Input parameters:
+ *   handler: the audio handler which has all information of the current audio card
+ *
  * Returned Value:
  *   On success, the current output volume level. Otherwise, a negative value.
  ****************************************************************************/
-int get_output_audio_volume(void);
+int get_output_audio_volume(audio_handler_t *handler);
 
 /****************************************************************************
  * Name: set_input_audio_volume
@@ -347,12 +435,13 @@ int get_output_audio_volume(void);
  *   Adjust the volume level of the active input audio device.
  *
  * Input parameters:
- *   volume:   volume level, 0(Min) ~ 10(Max)
+ *   handler: the audio handler which has all information of the current audio card
+ *   volume: a volume level, 0(Min) ~ 10(Max)
  *
  * Returned Value:
  *   On success, AUDIO_MANAGER_SUCCESS. Otherwise, a negative value.
  ****************************************************************************/
-audio_manager_result_t set_input_audio_volume(uint8_t volume);
+audio_manager_result_t set_input_audio_volume(audio_handler_t *handler, uint8_t volume);
 
 /****************************************************************************
  * Name: set_output_audio_volume
@@ -361,12 +450,13 @@ audio_manager_result_t set_input_audio_volume(uint8_t volume);
  *   Adjust the volume level of the active output audio device.
  *
  * Input parameters:
- *   volume:   volume level, 0(Min) ~ 10(Max)
+ *   handler: the audio handler which has all information of the current audio card
+ *   volume: a volume level, 0(Min) ~ 10(Max)
  *
  * Returned Value:
  *   On success, AUDIO_MANAGER_SUCCESS. Otherwise, a negative value.
  ****************************************************************************/
-audio_manager_result_t set_output_audio_volume(uint8_t volume);
+audio_manager_result_t set_output_audio_volume(audio_handler_t *handler, uint8_t volume);
 
 #if defined(__cplusplus)
 }								/* extern "C" */


### PR DESCRIPTION
- g_audio_card_info variables are replaced as audio handlers allocated at run-time.
- audio_handler is now added to all audio manager APIs.