### PR TITLE
testcase: register all of testcase at Makefile when builtin enabled

### DIFF
--- a/apps/examples/testcase/Makefile
+++ b/apps/examples/testcase/Makefile
@@ -15,7 +15,6 @@
 # language governing permissions and limitations under the License.
 #
 ###########################################################################
-
 ############################################################################
 # apps/examples/testcase/Makefile
 #
@@ -55,14 +54,7 @@
 -include $(TOPDIR)/Make.defs
 include $(APPDIR)/Make.defs
 
-# built-in application info
-
-APPNAME = tc
-FUNCNAME = $(APPNAME)_main
-THREADEXEC = TASH_EXECMD_ASYNC
 CXXEXT ?= .cpp
-PRIORITY = 100
-STACKSIZE = 1024
 
 # testcase example
 
@@ -138,16 +130,82 @@ endif
 install:
 
 ifeq ($(CONFIG_BUILTIN_APPS)$(CONFIG_EXAMPLES_TESTCASE),yy)
-$(BUILTIN_REGISTRY)$(DELIM)$(FUNCNAME).bdat: $(DEPCONFIG) Makefile
-	$(Q) $(call REGISTER,$(APPNAME),$(FUNCNAME),$(THREADEXEC),$(PRIORITY),$(STACKSIZE))
+$(BUILTIN_REGISTRY)$(DELIM)testcase.bdat: $(DEPCONFIG) Makefile
+ifeq ($(CONFIG_EXAMPLES_TESTCASE_ARASTORAGE_UTC),y)
+	$(Q) $(call REGISTER,arastorage_utc,utc_arastorage_main,TASH_EXECMD_ASYNC,100,4096)
+endif
+ifeq ($(CONFIG_EXAMPLES_TESTCASE_ARASTORAGE_ITC),y)
+	$(Q) $(call REGISTER,arastorage_itc,itc_arastorage_main,TASH_EXECMD_ASYNC,100,4096)
+endif
+ifeq ($(CONFIG_EXAMPLES_TESTCASE_AUDIO_UTC),y)
+	$(Q) $(call REGISTER,audio_utc,utc_audio_main,TASH_EXECMD_ASYNC,100,2048)
+endif
+ifeq ($(CONFIG_EXAMPLES_TESTCASE_AUDIO_ITC),y)
+	$(Q) $(call REGISTER,audio_itc,itc_audio_main,TASH_EXECMD_ASYNC,100,2048)
+endif
+ifeq ($(CONFIG_EXAMPLES_TESTCASE_DM_UTC),y)
+	$(Q) $(call REGISTER,dm_utc,utc_dm_main,TASH_EXECMD_ASYNC,100,2048)
+endif
+ifeq ($(CONFIG_EXAMPLES_TESTCASE_DM_ITC),y)
+	$(Q) $(call REGISTER,dm_itc,itc_dm_main,TASH_EXECMD_ASYNC,100,2048)
+endif
+ifeq ($(CONFIG_EXAMPLES_TESTCASE_DRIVERS),y)
+	$(Q) $(call REGISTER,drivers_tc,tc_drivers_main,TASH_EXECMD_ASYNC,100,2048)
+endif
+ifeq ($(CONFIG_EXAMPLES_TESTCASE_FILESYSTEM),y)
+	$(Q) $(call REGISTER,filesystem_tc,tc_filesystem_main,TASH_EXECMD_ASYNC,100,4096)
+endif
+ifeq ($(CONFIG_EXAMPLES_TESTCASE_KERNEL),y)
+	$(Q) $(call REGISTER,kernel_tc,tc_kernel_main,TASH_EXECMD_ASYNC,100,2048)
+endif
+ifeq ($(CONFIG_LIBCXX_UTC),y)
+	$(Q) $(call REGISTER,libcxx_utc,utc_libcxx_main,TASH_EXECMD_ASYNC,100,4096)
+endif
+ifeq ($(CONFIG_EXAMPLES_TESTCASE_MEDIA_UTC),y)
+	$(Q) $(call REGISTER,media_utc,utc_media_main,TASH_EXECMD_ASYNC,100,8192)
+endif
+ifeq ($(CONFIG_EXAMPLES_TESTCASE_MEDIA_ITC),y)
+	$(Q) $(call REGISTER,media_itc,itc_media_main,TASH_EXECMD_ASYNC,100,8192)
+endif
+ifeq ($(CONFIG_EXAMPLES_TESTCASE_MPU),y)
+	$(Q) $(call REGISTER,mpu_tc,tc_mpu_main,TASH_EXECMD_ASYNC,100,2048)
+endif
+ifeq ($(CONFIG_EXAMPLES_TESTCASE_MQTT_UTC),y)
+	$(Q) $(call REGISTER,mqtt_utc,utc_mqtt_main,TASH_EXECMD_ASYNC,100,4096)
+endif
+ifeq ($(CONFIG_EXAMPLES_TESTCASE_MQTT_ITC),y)
+	$(Q) $(call REGISTER,mqtt_itc,itc_mqtt_main,TASH_EXECMD_ASYNC,100,4096)
+endif
+ifeq ($(CONFIG_EXAMPLES_TESTCASE_NETWORK),y)
+	$(Q) $(call REGISTER,network_tc,tc_network_main,TASH_EXECMD_ASYNC,100,2048)
+endif
+ifeq ($(CONFIG_EXAMPLES_TESTCASE_SYSTEMIO_UTC),y)
+	$(Q) $(call REGISTER,sysio_utc,utc_sysio_main,TASH_EXECMD_ASYNC,100,2048)
+endif
+ifeq ($(CONFIG_EXAMPLES_TESTCASE_SYSTEMIO_ITC),y)
+	$(Q) $(call REGISTER,sysio_itc,itc_sysio_main,TASH_EXECMD_ASYNC,100,2048)
+endif
 ifeq ($(CONFIG_EXAMPLES_TESTCASE_TASK_MANAGER_UTC),y)
+	$(Q) $(call REGISTER,taskmgr_utc,utc_task_manager_main,TASH_EXECMD_ASYNC,100,2048)
 	$(Q) $(call REGISTER,tm_sample,tm_sample_main,TASH_EXECMD_ASYNC,101,1024)
 	$(Q) $(call REGISTER,tm_broadcast1,tm_broadcast1_main,TASH_EXECMD_ASYNC,101,1024)
 	$(Q) $(call REGISTER,tm_broadcast2,tm_broadcast2_main,TASH_EXECMD_ASYNC,101,1024)
 	$(Q) $(call REGISTER,tm_broadcast3,tm_broadcast3_main,TASH_EXECMD_ASYNC,101,1024)
 endif
+ifeq ($(CONFIG_EXAMPLES_TESTCASE_TTRACE),y)
+	$(Q) $(call REGISTER,ttrace_tc,tc_ttrace_main,TASH_EXECMD_ASYNC,100,2048)
+endif
+ifeq ($(CONFIG_EXAMPLES_TESTCASE_WIFI_MANAGER_UTC),y)
+	$(Q) $(call REGISTER,wifi_manager_utc,utc_wifi_manager_main,TASH_EXECMD_ASYNC,100,4096)
+endif
+ifeq ($(CONFIG_EXAMPLES_TESTCASE_WIFI_MANAGER_ITC),y)
+	$(Q) $(call REGISTER,wifi_manager_itc,itc_wifi_manager_main,TASH_EXECMD_ASYNC,100,4096)
+endif
+ifeq ($(CONFIG_EXAMPLES_TESTCASE_TCP_TLS_STRESS),y)
+	$(Q) $(call REGISTER,tcp_tls_stress,tc_tcp_tls_main,TASH_EXECMD_ASYNC,100,8192)
+endif
 
-context: $(BUILTIN_REGISTRY)$(DELIM)$(FUNCNAME).bdat
+context: $(BUILTIN_REGISTRY)$(DELIM)testcase.bdat
 
 else
 context:

--- a/apps/examples/testcase/tc_main.c
+++ b/apps/examples/testcase/tc_main.c
@@ -27,7 +27,7 @@
 #include <semaphore.h>
 #include "tc_common.h"
 
-#ifdef CONFIG_TASH
+#if defined(CONFIG_TASH) && !defined(CONFIG_BUILTIN_APPS)
 #include <apps/shell/tash.h>
 #else
 #if defined(CONFIG_EXAMPLES_TESTCASE_ARASTORAGE_UTC) || defined(CONFIG_EXAMPLES_TESTCASE_ARASTORAGE_ITC)
@@ -118,7 +118,7 @@ extern int tc_mpu_main(int argc, char *argv[]);
 extern int utc_libcxx_main(int argc, char *argv[]);
 #endif
 
-#ifdef CONFIG_TASH
+#if defined(CONFIG_TASH) && !defined(CONFIG_BUILTIN_APPS)
 static const tash_cmdlist_t tc_cmds[] = {
 #ifdef CONFIG_EXAMPLES_TESTCASE_ARASTORAGE_UTC
 	{"arastorage_utc", utc_arastorage_main, TASH_EXECMD_ASYNC},
@@ -242,10 +242,12 @@ int main(int argc, FAR char *argv[])
 int tc_main(int argc, char *argv[])
 #endif
 {
-#ifdef CONFIG_TASH
+#if defined(CONFIG_TASH)
+#if !defined(CONFIG_BUILTIN_APPS)
 	tash_cmdlist_install(tc_cmds);
+#endif
 	printf("\nTestcase registers TASH commands named \"<MODULE_NAME>_tc\".\nPlease find them using \"help\" and execute them in TASH\n");
-#else
+#else // !CONFIG_TASH
 	int pid;
 
 #ifdef CONFIG_EXAMPLES_TESTCASE_ARASTORAGE_UTC


### PR DESCRIPTION
The builtin supports a functionality to set priority and stacksize
to each ASYNC command. But tash does not do it on API side.
To allow setting each different value, register all of testcase
at Makefile when builtin is enabled.

Signed-off-by: sunghan-chang <sh924.chang@samsung.com>