### PR TITLE
framework/st_things   :  Change the check management for readonly exist

### DIFF
--- a/framework/src/st_things/st_things_request_handler.c
+++ b/framework/src/st_things/st_things_request_handler.c
@@ -977,8 +977,8 @@ bool handle_post_req_helper(const char *res_uri, const char *query, OCRepPayload
 		}
 
 		if (!IS_WRITABLE(properties[index]->rw)) {
-			if (OCRepPayloadIsNull(req_payload, properties[index]->key)) {
-				THINGS_LOG_E(TAG, "(%s) is not present in the request.", properties[index]->key);
+			if (!OCRepPayloadIsNull(req_payload, properties[index]->key)) {
+				THINGS_LOG_E(TAG, "(%s) is present in the request.", properties[index]->key);
 				res = false;
 				break;
 			}


### PR DESCRIPTION
framework/src/st_things : Change the check management for readonly exist

Change the "if statement" logic to check whether a read only attribute is present or not in the request.
signed off by: uvasistha-samsung  utkarsh.m@samsung.com