### PR TITLE
configs: change a build log level, V to 3

### DIFF
--- a/build/configs/artik053/.buildSpec.xml
+++ b/build/configs/artik053/.buildSpec.xml
@@ -28,7 +28,7 @@
             <param name="buildOption" value="${BOARD}/${BUILD_OPTION}"/>
         </command>
         <command name="build" command="make" path="${PROJECT_PATH}/os" shellcmd="true">
-            <param name="V" value="V=1"/>
+            <param name="V" value="V=3"/>
         </command>
         <command name="buildWithToolchain" command=". ./setenv.sh ${TOOLCHAIN_PATH};make V=1" path="${PROJECT_PATH}/os" shellcmd="true" shell="/bin/bash"/>
         <command name="clean" command="make clean" path="${PROJECT_PATH}/os" shellcmd="true">

--- a/build/configs/artik053s/.buildSpec.xml
+++ b/build/configs/artik053s/.buildSpec.xml
@@ -28,7 +28,7 @@
             <param name="buildOption" value="${BOARD}/${BUILD_OPTION}"/>
         </command>
         <command name="build" command="make" path="${PROJECT_PATH}/os" shellcmd="true">
-            <param name="V" value="V=1"/>
+            <param name="V" value="V=3"/>
         </command>
         <command name="buildWithToolchain" command=". ./setenv.sh ${TOOLCHAIN_PATH};make V=1" path="${PROJECT_PATH}/os" shellcmd="true" shell="/bin/bash"/>
         <command name="clean" command="make clean" path="${PROJECT_PATH}/os" shellcmd="true">

--- a/build/configs/artik055s/.buildSpec.xml
+++ b/build/configs/artik055s/.buildSpec.xml
@@ -28,7 +28,7 @@
             <param name="buildOption" value="${BOARD}/${BUILD_OPTION}"/>
         </command>
         <command name="build" command="make" path="${PROJECT_PATH}/os" shellcmd="true">
-            <param name="V" value="V=1"/>
+            <param name="V" value="V=3"/>
         </command>
         <command name="buildWithToolchain" command=". ./setenv.sh ${TOOLCHAIN_PATH};make V=1" path="${PROJECT_PATH}/os" shellcmd="true" shell="/bin/bash"/>
         <command name="clean" command="make clean" path="${PROJECT_PATH}/os" shellcmd="true">

--- a/build/configs/qemu/.buildSpec.xml
+++ b/build/configs/qemu/.buildSpec.xml
@@ -28,7 +28,7 @@
             <param name="buildOption" value="${BOARD}/${BUILD_OPTION}"/>
         </command>
         <command name="build" command="make" path="${PROJECT_PATH}/os" shellcmd="true">
-            <param name="V" value="V=1"/>
+            <param name="V" value="V=3"/>
         </command>
         <command name="buildWithToolchain" command=". ./setenv.sh ${TOOLCHAIN_PATH};make V=1" path="${PROJECT_PATH}/os" shellcmd="true" shell="/bin/bash"/>
         <command name="clean" command="make clean" path="${PROJECT_PATH}/os" shellcmd="true">

--- a/build/configs/sidk_s5jt200/.buildSpec.xml
+++ b/build/configs/sidk_s5jt200/.buildSpec.xml
@@ -28,7 +28,7 @@
             <param name="buildOption" value="${BOARD}/${BUILD_OPTION}"/>
         </command>
         <command name="build" command="make" path="${PROJECT_PATH}/os" shellcmd="true">
-            <param name="V" value="V=1"/>
+            <param name="V" value="V=3"/>
         </command>
         <command name="buildWithToolchain" command=". ./setenv.sh ${TOOLCHAIN_PATH};make V=1" path="${PROJECT_PATH}/os" shellcmd="true" shell="/bin/bash"/>
         <command name="clean" command="make clean" path="${PROJECT_PATH}/os" shellcmd="true">


### PR DESCRIPTION
V=1 means enabling echo of commands. But it is not needed at
normal build so that let's set it 3 to disable verbose logs.
FYI, 2 means enabling bug/verbose options in tools and scripts.

Signed-off-by: sunghan-chang <sh924.chang@samsung.com>