### PR TITLE
framework/st_things : Fix url link error in guide

### DIFF
--- a/docs/HowToDevelopThingsUsingSTThings.md
+++ b/docs/HowToDevelopThingsUsingSTThings.md
@@ -18,16 +18,17 @@ A device developed using ST Things based TizenRT can connect to SmartThings Clou
 In order to work with the cloud, it is necessary to sign up Samsung Account at [SmartThings Developers](https://smartthings.developer.samsung.com/) site.  
 Then, follow the steps.  
 1. Get your MNID - Manufacturer ID - on [My Page](https://smartthings.developer.samsung.com/partner/dashboard)  
-2. Create a cloud-connected device [[Details]](https://smartthings.developer.samsung.com/develop/workspace/ide/create-a-cloud-connected-device.html)  
-3. Generate the Certificate Signing Request and issue a new Signing key for the device certificate [[Details]](https://smartthings.developer.samsung.com/develop/workspace/ide/about-common-tools.html)  
-4. Add `certificate.pem` and `privateKey.der` files to `$TIZENRT_BASEDIR/tools/fs/contents/`   
+2. Create a cloud-connected device [[Details]](https://smartthings.developer.samsung.com/develop/getting-started/cloud-to-cloud.html)  
+3. Generate the Certificate Signing Request and issue a new Signing key for the device certificate [[Details]](https://smartthings.developer.samsung.com/develop/workspace/general-tools/certificate-signing-request.html)  
+4. Add `certificate.pem` and `privateKey.der` files to `$TIZENRT_BASEDIR/tools/fs/contents/`  
 5. Edit Json file to match the following: JSON  
    ```  
     "certificate": "certificate.pem",    
     "privateKey": "privateKey.der"  
    ```  
 
-To develop App(SmartThings) UI and functionality, use the SmartThings SDK. Please refer to [SmartThings SDK](https://smartthings.developer.samsung.com/develop/workspace/sdk/overview.html) site.
+To develop App(SmartThings) UI and functionality, use the SmartThings SDK. Please refer to [SmartThings SDK](https://smartthings.developer.samsung.com/develop/workspace/general-tools/sdk.html) site.  
+The device definition is stored in a JSON configuration file that you need to provide [[Device Definition]](https://developer.tizen.org/development/iot-preview/iot-apis/things-sdk-api/device-definition)   
 
 ## Getting Started
 ## 1. with Tizen Studio for RT


### PR DESCRIPTION
- Fix link error through https://smartthings.developer.samsung.com internal reorganization
- Add device definition guide link