### PR TITLE
[Mem-opt] Add support for Bootmem

### DIFF
--- a/build/configs/artik053/minimal/defconfig
+++ b/build/configs/artik053/minimal/defconfig
@@ -450,6 +450,7 @@ CONFIG_FS_WRITABLE=y
 CONFIG_MM_REGIONS=1
 # CONFIG_ARCH_HAVE_HEAPx is not set
 # CONFIG_GRAN is not set
+CONFIG_BOOTMEM=y
 
 #
 # Power Management

--- a/build/configs/artik055s/minimal/defconfig
+++ b/build/configs/artik055s/minimal/defconfig
@@ -450,6 +450,7 @@ CONFIG_FS_WRITABLE=y
 CONFIG_MM_REGIONS=1
 # CONFIG_ARCH_HAVE_HEAPx is not set
 # CONFIG_GRAN is not set
+CONFIG_BOOTMEM=y
 
 #
 # Power Management

--- a/os/mm/Kconfig
+++ b/os/mm/Kconfig
@@ -146,3 +146,11 @@ config MM_SHM
 	---help---
 		Build in support for the shared memory interfaces shmget(), shmat(),
 		shmctl(), and shmdt().
+
+config BOOTMEM
+	bool "Direct memory allocation during boot up"
+	default y
+	---help---
+		Enabling this config will result in all memory alloactions during
+		system boot to be performed directly fromt the system RAM by bypassing
+		the memory allocator logic. Such memory cannot be freed.

--- a/os/mm/mm_heap/mm_free.c
+++ b/os/mm/mm_heap/mm_free.c
@@ -111,6 +111,11 @@ void mm_free(FAR struct mm_heap_s *heap, FAR void *mem)
 		return;
 	}
 
+	if ((uint32_t)mem < (uint32_t)(heap->mm_heapstart)) {
+		dbg("Attempt to release memory outside heap (0x%x)\n", mem);
+		return;
+	}
+
 	/* We need to hold the MM semaphore while we muck with the
 	 * nodelist.
 	 */

--- a/os/mm/mm_heap/mm_malloc.c
+++ b/os/mm/mm_heap/mm_malloc.c
@@ -83,6 +83,10 @@
 /****************************************************************************
  * Public Data
  ****************************************************************************/
+#ifdef CONFIG_BOOTMEM
+void *g_bootmem;
+size_t g_heapsize;
+#endif
 
 /****************************************************************************
  * Private Functions
@@ -108,6 +112,18 @@ FAR void *mm_malloc(FAR struct mm_heap_s *heap, size_t size, mmaddress_t caller_
 FAR void *mm_malloc(FAR struct mm_heap_s *heap, size_t size)
 #endif
 {
+#ifdef CONFIG_BOOTMEM
+	if (g_bootmem) {
+		void *ret = g_bootmem;
+		size = MM_ALIGN_UP(size);
+		g_bootmem += size;
+		g_heapsize -= size;
+
+		mvdbg("Allocate %d bytes from bootmem (0x%x)\n", size, g_bootmem);
+		return ret;
+	}
+#endif
+
 	FAR struct mm_freenode_s *node;
 	void *ret = NULL;
 	int ndx;


### PR DESCRIPTION
Some of the memory allocations during the boot time will never be freed
during the runtime of the device. Hence, we try to avoid the overhead of
memory allocation logic for such allocations.

This commit postpones initialization of memory manager just until the
first task gets created. All allocations before start of the first task
will be done directly from BootMem region.

The Bootmem region will start at the end of the idle stack and will extend
till the start of the actual heap region. All allocations done from the
Bootmem region will be simple 4 byte aligned pointers and Bootmem will not
hold any additional information about these allocations. Memory allocated
from the Bootmem cannot be freed at anytime.