### PR TITLE
net/lwip: Initialize global variables used in udp and tcp of lwip

### DIFF
--- a/os/net/lwip/src/core/tcp.c
+++ b/os/net/lwip/src/core/tcp.c
@@ -129,14 +129,14 @@ static const u8_t tcp_persist_backoff[7] = { 3, 6, 12, 24, 48, 96, 120 };
 /* The TCP PCB lists. */
 
 /** List of all TCP PCBs bound but not yet (connected || listening) */
-struct tcp_pcb *tcp_bound_pcbs;
+struct tcp_pcb *tcp_bound_pcbs = NULL;
 /** List of all TCP PCBs in LISTEN state */
 union tcp_listen_pcbs_t tcp_listen_pcbs;
 /** List of all TCP PCBs that are in a state in which
  * they accept or send data. */
-struct tcp_pcb *tcp_active_pcbs;
+struct tcp_pcb *tcp_active_pcbs = NULL;
 /** List of all TCP PCBs in TIME-WAIT state */
-struct tcp_pcb *tcp_tw_pcbs;
+struct tcp_pcb *tcp_tw_pcbs = NULL;
 
 /** An array with all (non-temporary) PCB lists, mainly used for smaller code size */
 struct tcp_pcb **const tcp_pcb_lists[] = { &tcp_listen_pcbs.pcbs, &tcp_bound_pcbs,

--- a/os/net/lwip/src/core/udp.c
+++ b/os/net/lwip/src/core/udp.c
@@ -95,7 +95,7 @@ static u16_t udp_port = UDP_LOCAL_PORT_RANGE_START;
 
 /* The list of UDP PCBs */
 /* exported in udp.h (was static) */
-struct udp_pcb *udp_pcbs;
+struct udp_pcb *udp_pcbs = NULL;
 
 /**
  * Initialize this module.


### PR DESCRIPTION
- Initialize global variables of udp_pcbs, tcp_bound_pcbs, tcp_active_pcbs, and tcp_tw_pcbs in lwip core module
- Cypress board currently does not initialize variables during the flashing, these variables should be initialized in order to prevent false references