### PR TITLE
framework/task_manager: Rename task_manager_register -> task_manager_…

### DIFF
--- a/apps/examples/task_manager_sample/action_manager.c
+++ b/apps/examples/task_manager_sample/action_manager.c
@@ -126,7 +126,7 @@ int action_manager_main(int argc, char *argv[])
 
 	exit_flag = 0;
 
-	handle_alarm = task_manager_register("alarm", TM_APP_PERMISSION_ALL, TM_RESPONSE_WAIT_INF);
+	handle_alarm = task_manager_register_builtin("alarm", TM_APP_PERMISSION_ALL, TM_RESPONSE_WAIT_INF);
 	if (handle_alarm < 0) {
 		printf("FAIL TO REGISTER ALARM ACTION, %d\n", handle_alarm);
 	} else if (handle_alarm >= 0) {
@@ -135,7 +135,7 @@ int action_manager_main(int argc, char *argv[])
 
 	printf("\nRegister LED On Action\n");
 
-	handle_ledon = task_manager_register("led_on", TM_APP_PERMISSION_ALL, TM_RESPONSE_WAIT_INF);
+	handle_ledon = task_manager_register_builtin("led_on", TM_APP_PERMISSION_ALL, TM_RESPONSE_WAIT_INF);
 	if (handle_ledon < 0) {
 		printf("FAIL TO REGISTER LED ON ACTION, %d\n", handle_ledon);
 	} else if (handle_ledon >= 0) {
@@ -144,7 +144,7 @@ int action_manager_main(int argc, char *argv[])
 
 	printf("\nRegister LED Off Action\n");
 
-	handle_ledoff = task_manager_register("led_off", TM_APP_PERMISSION_ALL, TM_RESPONSE_WAIT_INF);
+	handle_ledoff = task_manager_register_builtin("led_off", TM_APP_PERMISSION_ALL, TM_RESPONSE_WAIT_INF);
 	if (handle_ledoff < 0) {
 		printf("FAIL TO REGISTER LED OFF ACTION, %d\n", handle_ledoff);
 	} else if (handle_ledoff >= 0) {

--- a/apps/examples/task_manager_sample/task_manager_sample_main.c
+++ b/apps/examples/task_manager_sample/task_manager_sample_main.c
@@ -49,7 +49,7 @@ int task_manager_sample_main(int argc, char *argv[])
 
 	printf("Task Manager Sample is started\nRegister Action Manager\n");
 
-	handle_actionmanager = task_manager_register("action_manager", TM_APP_PERMISSION_ALL, TM_RESPONSE_WAIT_INF);
+	handle_actionmanager = task_manager_register_builtin("action_manager", TM_APP_PERMISSION_ALL, TM_RESPONSE_WAIT_INF);
 	if (handle_actionmanager < 0) {
 		printf("FAIL TO REGISTER ACTION MANAGER, %d\n", handle_actionmanager);
 	} else if (handle_actionmanager >= 0) {
@@ -57,7 +57,7 @@ int task_manager_sample_main(int argc, char *argv[])
 	}
 
 	printf("\nRegister User App\n");
-	handle_user = task_manager_register("user", TM_APP_PERMISSION_ALL, TM_RESPONSE_WAIT_INF);
+	handle_user = task_manager_register_builtin("user", TM_APP_PERMISSION_ALL, TM_RESPONSE_WAIT_INF);
 	if (handle_user < 0) {
 		printf("FAIL TO REGISTER USER APP, %d\n", handle_user);
 	} else if (handle_user >= 0) {

--- a/apps/examples/testcase/ta_tc/task_manager/utc/utc_task_manager_main.c
+++ b/apps/examples/testcase/ta_tc/task_manager/utc/utc_task_manager_main.c
@@ -127,7 +127,7 @@ int tm_sample_main(int argc, char *argv[])
 {
 	int ret;
 
-	tm_noperm_handle = task_manager_register(TM_NOPERM_NAME, TM_APP_PERMISSION_DEDICATE, 100);
+	tm_noperm_handle = task_manager_register_builtin(TM_NOPERM_NAME, TM_APP_PERMISSION_DEDICATE, 100);
 
 	ret = task_manager_set_unicast_cb(test_unicast_handler);
 	if (ret != OK) {
@@ -185,13 +185,13 @@ int tm_broadcast3_main(int argc, char *argv[])
 static void utc_task_manager_register_n(void)
 {
 	int ret;
-	ret = task_manager_register(NULL, TM_APP_PERMISSION_DEDICATE, TM_NO_RESPONSE);
+	ret = task_manager_register_builtin(NULL, TM_APP_PERMISSION_DEDICATE, TM_NO_RESPONSE);
 	TC_ASSERT_EQ("task_manager_register", ret, TM_INVALID_PARAM);
 
-	ret = task_manager_register(TM_SAMPLE_NAME, TM_INVALID_PERMISSION, TM_NO_RESPONSE);
+	ret = task_manager_register_builtin(TM_SAMPLE_NAME, TM_INVALID_PERMISSION, TM_NO_RESPONSE);
 	TC_ASSERT_EQ("task_manager_register", ret, TM_INVALID_PARAM);
 
-	ret = task_manager_register(TM_SAMPLE_NAME, TM_APP_PERMISSION_GROUP, TM_INVALID_TIMEOUT);
+	ret = task_manager_register_builtin(TM_SAMPLE_NAME, TM_APP_PERMISSION_GROUP, TM_INVALID_TIMEOUT);
 	TC_ASSERT_EQ("task_manager_register", ret, TM_INVALID_PARAM);
 
 	TC_SUCCESS_RESULT();
@@ -199,19 +199,19 @@ static void utc_task_manager_register_n(void)
 
 static void utc_task_manager_register_p(void)
 {
-	tm_sample_handle = task_manager_register("invalid", TM_APP_PERMISSION_DEDICATE, TM_RESPONSE_WAIT_INF);
+	tm_sample_handle = task_manager_register_builtin("invalid", TM_APP_PERMISSION_DEDICATE, TM_RESPONSE_WAIT_INF);
 	TC_ASSERT_EQ("task_manager_register", tm_sample_handle, TM_OPERATION_FAIL);
 
-	tm_sample_handle = task_manager_register(TM_SAMPLE_NAME, TM_APP_PERMISSION_DEDICATE, TM_RESPONSE_WAIT_INF);
+	tm_sample_handle = task_manager_register_builtin(TM_SAMPLE_NAME, TM_APP_PERMISSION_DEDICATE, TM_RESPONSE_WAIT_INF);
 	TC_ASSERT_GEQ("task_manager_register", tm_sample_handle, 0);
 
-	tm_broadcast_handle1 = task_manager_register(TM_BROADCAST1_NAME, TM_APP_PERMISSION_DEDICATE, TM_RESPONSE_WAIT_INF);
+	tm_broadcast_handle1 = task_manager_register_builtin(TM_BROADCAST1_NAME, TM_APP_PERMISSION_DEDICATE, TM_RESPONSE_WAIT_INF);
 	TC_ASSERT_GEQ("task_manager_register", tm_broadcast_handle1, 0);
 
-	tm_broadcast_handle2 = task_manager_register(TM_BROADCAST2_NAME, TM_APP_PERMISSION_DEDICATE, TM_RESPONSE_WAIT_INF);
+	tm_broadcast_handle2 = task_manager_register_builtin(TM_BROADCAST2_NAME, TM_APP_PERMISSION_DEDICATE, TM_RESPONSE_WAIT_INF);
 	TC_ASSERT_GEQ("task_manager_register", tm_broadcast_handle2, 0);
 
-	tm_broadcast_handle3 = task_manager_register(TM_BROADCAST3_NAME, TM_APP_PERMISSION_DEDICATE, TM_RESPONSE_WAIT_INF);
+	tm_broadcast_handle3 = task_manager_register_builtin(TM_BROADCAST3_NAME, TM_APP_PERMISSION_DEDICATE, TM_RESPONSE_WAIT_INF);
 	TC_ASSERT_GEQ("task_manager_register", tm_broadcast_handle3, 0);
 
 	TC_SUCCESS_RESULT();

--- a/framework/include/task_manager/task_manager.h
+++ b/framework/include/task_manager/task_manager.h
@@ -122,7 +122,7 @@ typedef void (*_tm_unicast_t)(tm_unicast_msg_t *);
  * Public Function Prototypes
  ****************************************************************************/
 /**
- * @brief Request to register a task
+ * @brief Request to register a builtin task
  * @details @b #include <task_manager/task_manager.h>\n
  * This API can request to register a builtin task.\n
  * Find apps/builtin/README.md to know how to use builtin task.
@@ -135,7 +135,7 @@ typedef void (*_tm_unicast_t)(tm_unicast_msg_t *);
  * @return On success, handle id is returned. On failure, defined negative value is returned.
  * @since TizenRT v2.0 PRE
  */
-int task_manager_register(char *name, int permission, int timeout);
+int task_manager_register_builtin(char *name, int permission, int timeout);
 /**
  * @brief Request to register a task which is not in builtin list
  * @details @b #include <task_manager/task_manager.h>\n

--- a/framework/src/task_manager/task_manager_core.c
+++ b/framework/src/task_manager/task_manager_core.c
@@ -124,7 +124,7 @@ static int taskmgr_assign_handle(void)
 	return TM_BUSY;
 }
 
-static int taskmgr_register(char *name, int permission, int caller_pid)
+static int taskmgr_register_builtin(char *name, int permission, int caller_pid)
 {
 	int chk_idx;
 	int handle;
@@ -937,8 +937,8 @@ int task_manager(int argc, char *argv[])
 
 		tmvdbg("Recevied Request msg : cmd = %d\n", request_msg.cmd);
 		switch (request_msg.cmd) {
-		case TASKMGRCMD_REGISTER:
-			ret = taskmgr_register(request_msg.data, request_msg.handle, request_msg.caller_pid);
+		case TASKMGRCMD_REGISTER_BUILTIN:
+			ret = taskmgr_register_builtin(request_msg.data, request_msg.handle, request_msg.caller_pid);
 			break;
 
 		case TASKMGRCMD_UNREGISTER:

--- a/framework/src/task_manager/task_manager_internal.h
+++ b/framework/src/task_manager/task_manager_internal.h
@@ -28,7 +28,7 @@
 #include <sys/types.h>
 
 /* Command Types */
-#define TASKMGRCMD_REGISTER                0
+#define TASKMGRCMD_REGISTER_BUILTIN        0
 #define TASKMGRCMD_UNREGISTER              1
 #define TASKMGRCMD_START                   2
 #define TASKMGRCMD_STOP                    3

--- a/framework/src/task_manager/task_manager_register.c
+++ b/framework/src/task_manager/task_manager_register.c
@@ -27,9 +27,9 @@
 #include "task_manager_internal.h"
 
 /****************************************************************************
- * task_manager_register
+ * task_manager_register_builtin
  ****************************************************************************/
-int task_manager_register(char *name, int permission, int timeout)
+int task_manager_register_builtin(char *name, int permission, int timeout)
 {
 	int status;
 	tm_request_t request_msg;
@@ -40,7 +40,7 @@ int task_manager_register(char *name, int permission, int timeout)
 	}
 
 	memset(&request_msg, 0, sizeof(tm_request_t));
-	request_msg.cmd = TASKMGRCMD_REGISTER;
+	request_msg.cmd = TASKMGRCMD_REGISTER_BUILTIN;
 	request_msg.caller_pid = getpid();
 	request_msg.handle = permission;
 	request_msg.data = (void *)TM_ALLOC(strlen(name) + 1);


### PR DESCRIPTION
…register_builtin

There are three types of registering to task manager : builtin task, normal task, pthread
task_manager_register requests to register builtin task only, so change the API name.