### PR TITLE
framework/wifi_manager: Arrange SSID and Passphrase length

### DIFF
--- a/apps/examples/testcase/le_tc/tcp_tls/tcp_tls_stress.c
+++ b/apps/examples/testcase/le_tc/tcp_tls/tcp_tls_stress.c
@@ -212,13 +212,11 @@ tcp_tls_result_e tcp_tls_config_get(tls_config * config)
 
 static void wm_get_apinfo(wifi_manager_ap_config_s *apconfig)
 {
-	strncpy(apconfig->ssid, WM_AP_SSID, WIFIMGR_SSID_LEN-1);
-	apconfig->ssid[WIFIMGR_SSID_LEN-1] = '\0';
+	strncpy(apconfig->ssid, WM_AP_SSID, sizeof(WM_AP_SSID));
 	apconfig->ssid_length = strlen(WM_AP_SSID);
 	apconfig->ap_auth_type = WM_AP_AUTH;
 	if (WM_AP_AUTH != WIFI_MANAGER_AUTH_OPEN) {
-		strncpy(apconfig->passphrase, WM_AP_PASSWORD, WIFIMGR_PASSPHRASE_LEN-1);
-		apconfig->passphrase[WIFIMGR_PASSPHRASE_LEN-1] = '\0';
+		strncpy(apconfig->passphrase, WM_AP_PASSWORD, sizeof(WM_AP_PASSWORD));
 		apconfig->passphrase_length = strlen(WM_AP_PASSWORD);
 		apconfig->ap_crypto_type = WM_AP_CRYPTO;
 	}

--- a/apps/examples/wifi_manager_sample/wm_test.c
+++ b/apps/examples/wifi_manager_sample/wm_test.c
@@ -412,13 +412,13 @@ void wm_set_info(void *arg)
 	WM_TEST_LOG_START;
 	struct options *ap_info = (struct options *)arg;
 	wifi_manager_ap_config_s apconfig;
-	strncpy(apconfig.ssid, ap_info->ssid, WIFIMGR_SSID_LEN-1);
+	strncpy(apconfig.ssid, ap_info->ssid, WIFIMGR_SSID_LEN);
 	apconfig.ssid_length = strlen(ap_info->ssid);
-	apconfig.ssid[WIFIMGR_SSID_LEN-1] = '\0';
+	apconfig.ssid[WIFIMGR_SSID_LEN] = '\0';
 	apconfig.ap_auth_type = ap_info->auth_type;
 	if (apconfig.ap_auth_type != WIFI_MANAGER_AUTH_OPEN) {
-		strncpy(apconfig.passphrase, ap_info->password, WIFIMGR_PASSPHRASE_LEN-1);
-		apconfig.passphrase[WIFIMGR_PASSPHRASE_LEN-1] = '\0';
+		strncpy(apconfig.passphrase, ap_info->password, WIFIMGR_PASSPHRASE_LEN);
+		apconfig.passphrase[WIFIMGR_PASSPHRASE_LEN] = '\0';
 		apconfig.passphrase_length = strlen(ap_info->password);
 		apconfig.ap_crypto_type = ap_info->crypto_type;
 	}
@@ -546,13 +546,13 @@ void wm_connect(void *arg)
 	WM_TEST_LOG_START;
 	struct options *ap_info = (struct options *)arg;
 	wifi_manager_ap_config_s apconfig;
-	strncpy(apconfig.ssid, ap_info->ssid, WIFIMGR_SSID_LEN-1);
+	strncpy(apconfig.ssid, ap_info->ssid, WIFIMGR_SSID_LEN);
 	apconfig.ssid_length = strlen(ap_info->ssid);
-	apconfig.ssid[WIFIMGR_SSID_LEN-1] = '\0';
+	apconfig.ssid[WIFIMGR_SSID_LEN] = '\0';
 	apconfig.ap_auth_type = ap_info->auth_type;
 	if (ap_info->auth_type != WIFI_MANAGER_AUTH_OPEN) {
-		strncpy(apconfig.passphrase, ap_info->password, WIFIMGR_PASSPHRASE_LEN-1);
-		apconfig.passphrase[WIFIMGR_PASSPHRASE_LEN-1] = '\0';
+		strncpy(apconfig.passphrase, ap_info->password, WIFIMGR_PASSPHRASE_LEN);
+		apconfig.passphrase[WIFIMGR_PASSPHRASE_LEN] = '\0';
 		apconfig.passphrase_length = strlen(ap_info->password);
 		apconfig.ap_crypto_type = ap_info->crypto_type;
 	}
@@ -641,20 +641,20 @@ void wm_coverage(void *arg)
 
 	/* Set SoftAP Configuration */
 	wifi_manager_softap_config_s softap_config;
-	strncpy(softap_config.ssid, info->softap_ssid, WIFIMGR_SSID_LEN-1);
-	softap_config.ssid[WIFIMGR_SSID_LEN-1] = '\0';
-	strncpy(softap_config.passphrase, info->softap_password, WIFIMGR_PASSPHRASE_LEN-1);
-	softap_config.passphrase[WIFIMGR_PASSPHRASE_LEN-1] = '\0';
+	strncpy(softap_config.ssid, info->softap_ssid, WIFIMGR_SSID_LEN);
+	softap_config.ssid[WIFIMGR_SSID_LEN] = '\0';
+	strncpy(softap_config.passphrase, info->softap_password, WIFIMGR_PASSPHRASE_LEN);
+	softap_config.passphrase[WIFIMGR_PASSPHRASE_LEN] = '\0';
 	softap_config.channel = 1;
 
 	/* Set AP Configuration */
 	wifi_manager_ap_config_s ap_config;
-	strncpy(ap_config.ssid, info->ssid, WIFIMGR_SSID_LEN-1);
+	strncpy(ap_config.ssid, info->ssid, WIFIMGR_SSID_LEN);
 	ap_config.ssid_length = strlen(info->ssid);
-	ap_config.ssid[WIFIMGR_SSID_LEN-1] = '\0';
-	strncpy(ap_config.passphrase, info->password, WIFIMGR_PASSPHRASE_LEN-1);
+	ap_config.ssid[WIFIMGR_SSID_LEN] = '\0';
+	strncpy(ap_config.passphrase, info->password, WIFIMGR_PASSPHRASE_LEN);
 	ap_config.passphrase_length = strlen(info->password);
-	ap_config.passphrase[WIFIMGR_PASSPHRASE_LEN-1] = '\0';
+	ap_config.passphrase[WIFIMGR_PASSPHRASE_LEN] = '\0';
 	ap_config.ap_auth_type = info->auth_type;
 	ap_config.ap_crypto_type = info->crypto_type;
 
@@ -663,8 +663,8 @@ void wm_coverage(void *arg)
 	wifi_manager_ap_config_s ap_fake_config;
 	ap_fake_config.ssid_length = strlen(fake_long_ssid);
 	strncpy(ap_fake_config.ssid, fake_long_ssid, ap_fake_config.ssid_length + 1);
-	strncpy(ap_fake_config.passphrase, info->password, WIFIMGR_PASSPHRASE_LEN-1);
-	ap_fake_config.passphrase[WIFIMGR_PASSPHRASE_LEN-1] = '\0';
+	strncpy(ap_fake_config.passphrase, info->password, WIFIMGR_PASSPHRASE_LEN);
+	ap_fake_config.passphrase[WIFIMGR_PASSPHRASE_LEN] = '\0';
 	ap_fake_config.passphrase_length = strlen(info->password);
 	ap_fake_config.ap_auth_type = info->auth_type;
 	ap_fake_config.ap_crypto_type = info->crypto_type;
@@ -704,8 +704,8 @@ void wm_coverage(void *arg)
 	
 	/* Connect to fake AP */
 	printf("Connecting to AP (bad SSID)\n");
-	strncpy(ap_config.ssid, info->bad_ssid, WIFIMGR_SSID_LEN-1);
-	ap_config.ssid[WIFIMGR_SSID_LEN-1] = '\0';
+	strncpy(ap_config.ssid, info->bad_ssid, WIFIMGR_SSID_LEN);
+	ap_config.ssid[WIFIMGR_SSID_LEN] = '\0';
 	ap_config.ssid_length = strlen(info->bad_ssid);
 	print_wifi_ap_profile(&ap_config, "Connecting AP Info");
 	res = wifi_manager_connect_ap(&ap_config);
@@ -718,11 +718,11 @@ void wm_coverage(void *arg)
 
 	/* Connect to fake AP */
 	printf("Connecting to AP (wrong passphrase)\n");
-	strncpy(ap_config.ssid, info->ssid, WIFIMGR_SSID_LEN-1);
-	ap_config.ssid[WIFIMGR_SSID_LEN-1] = '\0';
+	strncpy(ap_config.ssid, info->ssid, WIFIMGR_SSID_LEN);
+	ap_config.ssid[WIFIMGR_SSID_LEN] = '\0';
 	ap_config.ssid_length = strlen(info->ssid);
-	strncpy(ap_config.passphrase, info->bad_password, WIFIMGR_PASSPHRASE_LEN-1);
-	ap_config.passphrase[WIFIMGR_PASSPHRASE_LEN-1] = '\0';
+	strncpy(ap_config.passphrase, info->bad_password, WIFIMGR_PASSPHRASE_LEN);
+	ap_config.passphrase[WIFIMGR_PASSPHRASE_LEN] = '\0';
 	ap_config.passphrase_length = strlen(info->bad_password);
 	print_wifi_ap_profile(&ap_config, "Connecting AP Info");
 	res = wifi_manager_connect_ap(&ap_config);
@@ -736,9 +736,9 @@ void wm_coverage(void *arg)
 	/* Connect to fake AP */
 	printf("Connecting to fake AP (Auth/Crypto type 1/3)\n");
 	ap_config.ap_auth_type = WIFI_MANAGER_AUTH_WEP_SHARED;
-	strncpy(ap_config.passphrase, info->password, WIFIMGR_PASSPHRASE_LEN-1);
+	strncpy(ap_config.passphrase, info->password, WIFIMGR_PASSPHRASE_LEN);
 	ap_config.passphrase_length = strlen(info->password);
-	ap_config.passphrase[WIFIMGR_PASSPHRASE_LEN-1] = '\0';
+	ap_config.passphrase[WIFIMGR_PASSPHRASE_LEN] = '\0';
 	print_wifi_ap_profile(&ap_config, "Connecting AP Info");
 	res = wifi_manager_connect_ap(&ap_config);
 	// Both WIFI_MANAGER_SUCCESS and WIFI_MANAGER_FAIL can be possible, depending on the device driver
@@ -1017,20 +1017,20 @@ void wm_auto_test(void *arg)
 	struct options *info = (struct options *)arg;
 	/* Set SoftAP Configuration */
 	wifi_manager_softap_config_s softap_config;
-	strncpy(softap_config.ssid, info->softap_ssid, WIFIMGR_SSID_LEN-1);
-	softap_config.ssid[WIFIMGR_SSID_LEN-1] = '\0';
-	strncpy(softap_config.passphrase, info->softap_password, WIFIMGR_PASSPHRASE_LEN-1);
-	softap_config.passphrase[WIFIMGR_PASSPHRASE_LEN-1] = '\0';
+	strncpy(softap_config.ssid, info->softap_ssid, WIFIMGR_SSID_LEN);
+	softap_config.ssid[WIFIMGR_SSID_LEN] = '\0';
+	strncpy(softap_config.passphrase, info->softap_password, WIFIMGR_PASSPHRASE_LEN);
+	softap_config.passphrase[WIFIMGR_PASSPHRASE_LEN] = '\0';
 	softap_config.channel = 1;
 
 	/* Set AP Configuration */
 	wifi_manager_ap_config_s ap_config;
-	strncpy(ap_config.ssid, info->ssid, WIFIMGR_SSID_LEN-1);
+	strncpy(ap_config.ssid, info->ssid, WIFIMGR_SSID_LEN);
 	ap_config.ssid_length = strlen(info->ssid);
-	ap_config.ssid[WIFIMGR_SSID_LEN-1] = '\0';
-	strncpy(ap_config.passphrase, info->password, WIFIMGR_PASSPHRASE_LEN-1);
+	ap_config.ssid[WIFIMGR_SSID_LEN] = '\0';
+	strncpy(ap_config.passphrase, info->password, WIFIMGR_PASSPHRASE_LEN);
 	ap_config.passphrase_length = strlen(info->password);
-	ap_config.passphrase[WIFIMGR_PASSPHRASE_LEN-1] = '\0';
+	ap_config.passphrase[WIFIMGR_PASSPHRASE_LEN] = '\0';
 	ap_config.ap_auth_type = info->auth_type;
 	ap_config.ap_crypto_type = info->crypto_type;
 

--- a/apps/examples/wifi_manager_sample/wm_test_stress.c
+++ b/apps/examples/wifi_manager_sample/wm_test_stress.c
@@ -127,11 +127,11 @@ void wm_scan_done(wifi_manager_scan_info_s **scan_result, wifi_manager_scan_resu
 
 static void wm_get_apinfo(wifi_manager_ap_config_s *apconfig)
 {
-	strncpy(apconfig->ssid, WM_AP_SSID, 33);
+	strncpy(apconfig->ssid, WM_AP_SSID, sizeof(WM_AP_SSID));
 	apconfig->ssid_length = strlen(WM_AP_SSID);
 	apconfig->ap_auth_type = WM_AP_AUTH;
 	if (WM_AP_AUTH != WIFI_MANAGER_AUTH_OPEN) {
-		strncpy(apconfig->passphrase, WM_AP_PASSWORD, 64);
+		strncpy(apconfig->passphrase, WM_AP_PASSWORD, sizeof(WM_AP_PASSWORD));
 		apconfig->passphrase_length = strlen(WM_AP_PASSWORD);
 		apconfig->ap_crypto_type = WM_AP_CRYPTO;
 	}
@@ -139,10 +139,8 @@ static void wm_get_apinfo(wifi_manager_ap_config_s *apconfig)
 
 static void wm_get_softapinfo(wifi_manager_softap_config_s *ap_config)
 {
-	strcpy(ap_config->ssid, WM_SOFTAP_SSID);
-	ap_config->ssid[strlen(WM_SOFTAP_SSID)] = '\0';
-	strcpy(ap_config->passphrase, WM_SOFTAP_PASSWORD);
-	ap_config->passphrase[strlen(WM_SOFTAP_PASSWORD)] = '\0';
+	strncpy(ap_config->ssid, WM_SOFTAP_SSID, sizeof(WM_SOFTAP_SSID));
+	strncpy(ap_config->passphrase, WM_SOFTAP_PASSWORD, sizeof(WM_SOFTAP_PASSWORD));
 	ap_config->channel = WM_SOFTAP_CHANNEL;
 }
 /*

--- a/framework/include/wifi_manager/wifi_manager.h
+++ b/framework/include/wifi_manager/wifi_manager.h
@@ -33,7 +33,7 @@
 
 /* Length defines */
 #define WIFIMGR_MACADDR_LEN        6
-#define WIFIMGR_MACADDR_STR_LEN    18
+#define WIFIMGR_MACADDR_STR_LEN    17
 #define WIFIMGR_SSID_LEN           32
 #define WIFIMGR_PASSPHRASE_LEN     64
 
@@ -134,8 +134,8 @@ typedef enum {
  * @brief Keep information of nearby access points as scan results
  */
 struct wifi_manager_scan_info_s {
-	char ssid[WIFIMGR_SSID_LEN];	// 802.11 spec defined unspecified or uint8
-	char bssid[WIFIMGR_MACADDR_STR_LEN];	// char string e.g. xx:xx:xx:xx:xx:xx
+	char ssid[WIFIMGR_SSID_LEN + 1];        	// 802.11 spec defined unspecified or uint8
+	char bssid[WIFIMGR_MACADDR_STR_LEN + 1];	// char string e.g. xx:xx:xx:xx:xx:xx
 	int8_t rssi;		// received signal strength indication
 	uint8_t channel;	// channel/frequency
 	uint8_t phy_mode;	// 0:legacy 1: 11N HT
@@ -161,9 +161,9 @@ typedef struct {
  * @brief Keep Wi-Fi Manager information including ip/mac address, ssid, rssi, etc.
  */
 typedef struct {
-	char ip4_address[WIFIMGR_MACADDR_STR_LEN];
-	char ssid[WIFIMGR_SSID_LEN];
-	char mac_address[WIFIMGR_MACADDR_LEN];	   /**<  MAC address of wifi interface             */
+	char ip4_address[WIFIMGR_MACADDR_STR_LEN + 1];
+	char ssid[WIFIMGR_SSID_LEN + 1];
+	char mac_address[WIFIMGR_MACADDR_LEN + 1];	   /**<  MAC address of wifi interface             */
 	int rssi;
 	connect_status_e status;
 	wifi_manager_mode_e mode;
@@ -173,8 +173,8 @@ typedef struct {
  * @brief Specify information of soft access point (softAP) such as ssid and channel number
  */
 typedef struct {
-	char ssid[WIFIMGR_SSID_LEN];
-	char passphrase[64];
+	char ssid[WIFIMGR_SSID_LEN + 1];
+	char passphrase[WIFIMGR_PASSPHRASE_LEN + 1];
 	uint16_t channel;
 } wifi_manager_softap_config_s;
 
@@ -195,9 +195,9 @@ typedef struct {
  * @brief Specify which access point (AP) a client connects to
  */
 typedef struct {
-	char ssid[WIFIMGR_SSID_LEN];							 /**<  Service Set Identification         */
+	char ssid[WIFIMGR_SSID_LEN + 1];						 /**<  Service Set Identification         */
 	unsigned int ssid_length;				 /**<  Service Set Identification Length  */
-	char passphrase[WIFIMGR_PASSPHRASE_LEN];					 /**<  ap passphrase(password)            */
+	char passphrase[WIFIMGR_PASSPHRASE_LEN + 1];					 /**<  ap passphrase(password)            */
 	unsigned int passphrase_length;			 /**<  ap passphrase length               */
 	wifi_manager_ap_auth_type_e ap_auth_type;	  /**<  @ref wifi_utils_ap_auth_type   */
 	wifi_manager_ap_crypto_type_e ap_crypto_type;  /**<  @ref wifi_utils_ap_crypto_type */

--- a/framework/src/wifi_manager/wifi_manager.c
+++ b/framework/src/wifi_manager/wifi_manager.c
@@ -105,8 +105,8 @@ struct _wifimgr_msg {
 typedef struct _wifimgr_msg _wifimgr_msg_s;
 
 struct _wifimgr_info {
-	char ssid[32];             // SSID of Connected AP if mode is a station, SoftAP SSID if mode is a soft ap
-	char mac_address[6];	   // MAC address of wifi interface
+	char ssid[WIFIMGR_SSID_LEN + 1];             // SSID of Connected AP if mode is a station, SoftAP SSID if mode is a soft ap
+	char mac_address[WIFIMGR_MACADDR_LEN];	   // MAC address of wifi interface
 	int rssi;                  // It is only used for a station mode
 	int num_sta;               // It is only used for a softap mode, it shows the number of stations connected
 	uint32_t ip4_address;
@@ -151,147 +151,152 @@ typedef struct _wifimgr_info _wifimgr_info_s;
 #define WIFIMGR_RESET_CBK_CHK (g_manager_info.chk_cbk = 0)
 #define WIFIMGR_CHECK_CBK (g_manager_info.chk_cbk == 0)
 
-#define WIFIMGR_SOFTAP_WAIT_CALLBACK												   \
-	do {																			   \
-		pthread_mutex_lock(&g_manager_info.softap_lock);							   \
-		pthread_cond_wait(&g_manager_info.softap_signal, &g_manager_info.softap_lock); \
-		pthread_mutex_unlock(&g_manager_info.softap_lock);	                           \
-		nvdbg("[WM] T%d wait disconnect callback\n", getpid());										   \
+#define WIFIMGR_SOFTAP_WAIT_CALLBACK                                                                    \
+	do {                                                                                            \
+		pthread_mutex_lock(&g_manager_info.softap_lock);					\
+		pthread_cond_wait(&g_manager_info.softap_signal, &g_manager_info.softap_lock);          \
+		pthread_mutex_unlock(&g_manager_info.softap_lock);	                                \
+		nvdbg("[WM] T%d wait disconnect callback\n", getpid());					\
 	} while (0)
 
-#define WIFIMGR_SOFTAP_CALLBACK_RECEIVED											   \
-	do {																			   \
-		pthread_mutex_lock(&g_manager_info.softap_lock);							   \
-		pthread_cond_signal(&g_manager_info.softap_signal);                            \
-		pthread_mutex_unlock(&g_manager_info.softap_lock);	                           \
-		nvdbg("[WM] T%d received disconnect callback\n", getpid());										   \
+#define WIFIMGR_SOFTAP_CALLBACK_RECEIVED					\
+	do {									\
+		pthread_mutex_lock(&g_manager_info.softap_lock);		\
+		pthread_cond_signal(&g_manager_info.softap_signal);             \
+		pthread_mutex_unlock(&g_manager_info.softap_lock);	        \
+		nvdbg("[WM] T%d received disconnect callback\n", getpid());	\
 	} while (0)
 
 #define WIFIMGR_GET_PREVSTATE g_manager_info.prev_state
 #define WIFIMGR_STORE_PREV_STATE (g_manager_info.prev_state = g_manager_info.state)
 #define WIFIMGR_RESTORE_STATE								\
-	do {													\
-		g_manager_info.state = g_manager_info.prev_state;	\
-		g_manager_info.prev_state = WIFIMGR_NONE;			\
+	do {										\
+		g_manager_info.state = g_manager_info.prev_state;	                \
+		g_manager_info.prev_state = WIFIMGR_NONE;			        \
 	} while (0)
 
-#define WIFIMGR_SET_SSID(s)							\
-	do {											\
+#define WIFIMGR_SET_SSID(s)					\
+	do {							\
 		strncpy(g_manager_info.ssid, s, strlen(s));	\
+		g_manager_info.ssid[strlen(s)] = '\0';          \
 	} while (0)
 
-#define WIFIMGR_COPY_SOFTAP_CONFIG(dest, src)													\
-	do {																				\
-		(dest).channel = (src)->channel;													\
-		strncpy((dest).ssid, (src)->ssid, strlen((src)->ssid) + 1);						\
-		strncpy((dest).passphrase, (src)->passphrase, strlen((src)->passphrase) + 1);	\
+#define WIFIMGR_COPY_SOFTAP_CONFIG(dest, src)							\
+	do {											\
+		(dest).channel = (src)->channel;						\
+		strncpy((dest).ssid, (src)->ssid, strlen((src)->ssid)); 			\
+                (dest).ssid[strlen((src)->ssid)] = '\0';                                        \
+		strncpy((dest).passphrase, (src)->passphrase, strlen((src)->passphrase));	\
+                (dest).passphrase[strlen((src)->passphrase)] = '\0';                            \
 	} while (0)
 
-#define WIFIMGR_COPY_AP_INFO(dest, src)									\
-	do {																\
-		(dest).ssid_length = (src).ssid_length;							\
+#define WIFIMGR_COPY_AP_INFO(dest, src)								\
+	do {											\
+		(dest).ssid_length = (src).ssid_length;						\
 		(dest).passphrase_length = (src).passphrase_length;				\
-		strncpy((dest).ssid, (src).ssid, (src).ssid_length + 1);		\
-		strncpy((dest).passphrase, (src).passphrase, (src).passphrase_length + 1); \
-		(dest).ap_auth_type = (src).ap_auth_type;						\
+		strncpy((dest).ssid, (src).ssid, (src).ssid_length);		                \
+                (dest).ssid[(src).ssid_length] = '\0';                                          \
+		strncpy((dest).passphrase, (src).passphrase, (src).passphrase_length);          \
+                (dest).passphrase[(src).passphrase_length] = '\0';                              \
+		(dest).ap_auth_type = (src).ap_auth_type;					\
 		(dest).ap_crypto_type = (src).ap_crypto_type;					\
 	} while (0)
 
 #define WIFIMGR_COPY_RECONN_INFO(dest, src)			\
-	do {											\
-		(dest).type = (src).type;					\
-		(dest).interval = (src).interval;			\
+	do {							\
+		(dest).type = (src).type;			\
+		(dest).interval = (src).interval;		\
 		(dest).max_interval = (src).max_interval;	\
 	} while (0)
 
-#define WIFIMGR_SET_IP4ADDR(intf, ip, netmask, gateway)	\
-	do {												\
-		int res = -1;									\
-		res = netlib_set_ipv4addr(intf, &ip);			\
-		if (res == -1) {								\
-			nvdbg("[WM] set ipv4 addr error\n");		\
-		}												\
+#define WIFIMGR_SET_IP4ADDR(intf, ip, netmask, gateway)	        \
+	do {							\
+		int res = -1;					\
+		res = netlib_set_ipv4addr(intf, &ip);		\
+		if (res == -1) {				\
+			nvdbg("[WM] set ipv4 addr error\n");	\
+		}						\
 		res = netlib_set_ipv4netmask(intf, &netmask);	\
-		if (res == -1) {								\
-			nvdbg("[WM] set netmask addr error\n");		\
-		}												\
+		if (res == -1) {				\
+			nvdbg("[WM] set netmask addr error\n");	\
+		}						\
 		res = netlib_set_dripv4addr(intf, &gateway);	\
-		if (res == -1) {								\
-			nvdbg("[WM] set route addr error\n");		\
-		}												\
-		g_manager_info.ip4_address = ip.s_addr;			\
+		if (res == -1) {				\
+			nvdbg("[WM] set route addr error\n");	\
+		}						\
+		g_manager_info.ip4_address = ip.s_addr;		\
 	} while (0)
 
-#define WIFIMGR_INC_NUM_CLIENT								\
-	do {													\
+#define WIFIMGR_INC_NUM_CLIENT						\
+	do {								\
 		pthread_mutex_lock(&g_manager_info.info_lock);		\
-		g_manager_info.num_sta++;							\
+		g_manager_info.num_sta++;				\
 		pthread_mutex_unlock(&g_manager_info.info_lock);	\
 	} while (0)
 
-#define WIFIMGR_DEC_NUM_CLIENT								\
-	do {													\
+#define WIFIMGR_DEC_NUM_CLIENT						\
+	do {								\
 		pthread_mutex_lock(&g_manager_info.info_lock);		\
-		g_manager_info.num_sta--;							\
+		g_manager_info.num_sta--;				\
 		pthread_mutex_unlock(&g_manager_info.info_lock);	\
 	} while (0)
 
 #define WIFIMGR_SPC // to pass the code check ruls
 #define WIFIMGR_CHECK_RESULT_CLEANUP(func, msg, ret, free_rsc)	\
-	do {														\
-		wifi_manager_result_e wmres = func;						\
-		if (wmres != WIFI_MANAGER_SUCCESS) {					\
-			ndbg(msg);											\
-			free_rsc;											\
-			return ret;											\
-		}														\
+	do {							\
+		wifi_manager_result_e wmres = func;		\
+		if (wmres != WIFI_MANAGER_SUCCESS) {		\
+			ndbg(msg);				\
+			free_rsc;				\
+			return ret;				\
+		}						\
 	} while (0)
 
 #define WIFIMGR_CHECK_RESULT(func, msg, ret) WIFIMGR_CHECK_RESULT_CLEANUP(func, msg, ret, WIFIMGR_SPC)
-#define WIFIMGR_CHECK_RESULT_NORET(func, msg)					\
-	do {														\
-		wifi_manager_result_e wmres = func;						\
+#define WIFIMGR_CHECK_RESULT_NORET(func, msg)				\
+	do {								\
+		wifi_manager_result_e wmres = func;			\
 		if (wmres != WIFI_MANAGER_SUCCESS) {                    \
-			WIFIADD_ERR_RECORD(ERR_WIFIMGR_API_FAIL);\
-			ndbg(msg);											\
-		}														\
+			WIFIADD_ERR_RECORD(ERR_WIFIMGR_API_FAIL);       \
+			ndbg(msg);					\
+		}							\
 	} while (0)													\
 
-#define WIFIMGR_CHECK_UTILRESULT(func, msg, ret)	\
-	do {											\
+#define WIFIMGR_CHECK_UTILRESULT(func, msg, ret)	                \
+	do {								\
 		wifi_utils_result_e res = func;				\
 		if (res != WIFI_UTILS_SUCCESS) {			\
-			ndbg(msg);								\
-			ndbg("error code(%d)\n", res);          \
-			WIFIADD_ERR_RECORD(ERR_WIFIMGR_UTILS_FAIL);\
-			return ret;								\
-		}											\
+			ndbg(msg);					\
+			ndbg("error code(%d)\n", res);                  \
+			WIFIADD_ERR_RECORD(ERR_WIFIMGR_UTILS_FAIL);     \
+			return ret;					\
+		}							\
 	} while (0)
 
-#define WIFIMGR_CHECK_AP_CONFIG(config)									\
-	do {																\
-		if (config->ssid_length > 31 ||									\
-			config->passphrase_length > 63 ||							\
-			strlen(config->ssid) > 31 ||								\
-			strlen(config->passphrase) > 63) {							\
-			ndbg("[WM] AP configuration fails: too long ssid or passphrase\n");	\
-			ndbg("[WM] Make sure that length of SSID < 32 and length of passphrase < 64\n");\
-			WIFIADD_ERR_RECORD(ERR_WIFIMGR_INVALID_ARGUMENTS);				\
-			return WIFI_MANAGER_INVALID_ARGS;							\
-		}																\
+#define WIFIMGR_CHECK_AP_CONFIG(config)									    \
+	do {												    \
+		if (config->ssid_length > WIFIMGR_SSID_LEN ||						    \
+			config->passphrase_length > WIFIMGR_PASSPHRASE_LEN ||				    \
+			strlen(config->ssid) > WIFIMGR_SSID_LEN ||					    \
+			strlen(config->passphrase) > WIFIMGR_PASSPHRASE_LEN) {				    \
+			ndbg("[WM] AP configuration fails: too long ssid or passphrase\n");	            \
+			ndbg("[WM] Make sure that length of SSID < 33 and length of passphrase < 65\n");    \
+			WIFIADD_ERR_RECORD(ERR_WIFIMGR_INVALID_ARGUMENTS);				    \
+			return WIFI_MANAGER_INVALID_ARGS;						    \
+		}											    \
 	} while (0)
 
 #define LOCK_WIFIMGR pthread_mutex_lock(&g_manager_info.state_lock)
 #define UNLOCK_WIFIMGR pthread_mutex_unlock(&g_manager_info.state_lock)
 
-#define WIFIMGR_FREE_CONNMSG(msg)				\
-	do {										\
-		free(msg->config);						\
-		msg->config = NULL;						\
-		free(msg->conn_config);					\
-		msg->conn_config = NULL;				\
-		close(msg->fd);							\
-		free(msg);								\
+#define WIFIMGR_FREE_CONNMSG(msg)		\
+	do {					\
+		free(msg->config);		\
+		msg->config = NULL;		\
+		free(msg->conn_config);		\
+		msg->conn_config = NULL;	\
+		close(msg->fd);			\
+		free(msg);			\
 	} while (0)
 
 /**
@@ -543,8 +548,8 @@ _convert_scan_info(wifi_manager_scan_info_s **wm_scan_list, wifi_utils_scan_list
 		cur->phy_mode = iter->ap_info.phy_mode;
 		cur->ap_auth_type = iter->ap_info.ap_auth_type;
 		cur->ap_crypto_type = iter->ap_info.ap_crypto_type;
-		strncpy(cur->ssid, (char *)iter->ap_info.ssid, 32);
-		strncpy(cur->bssid, (char *)iter->ap_info.bssid, 17);
+		strncpy(cur->ssid, (char *)iter->ap_info.ssid, WIFIMGR_SSID_LEN);
+		strncpy(cur->bssid, (char *)iter->ap_info.bssid, WIFIMGR_MACADDR_STR_LEN);
 
 		if (!prev) {
 			*wm_scan_list = cur;
@@ -695,9 +700,11 @@ wifi_manager_result_e _wifimgr_connect_ap(wifi_manager_ap_config_s *config)
 {
 	WM_LOG_START;
 	wifi_utils_ap_config_s util_config;
-	strncpy(util_config.ssid, config->ssid, config->ssid_length + 1);
+	strncpy(util_config.ssid, config->ssid, config->ssid_length);
+        util_config.ssid[config->ssid_length] = '\0';
 	util_config.ssid_length = config->ssid_length;
-	strncpy(util_config.passphrase, config->passphrase, config->passphrase_length + 1);
+	strncpy(util_config.passphrase, config->passphrase, config->passphrase_length);
+        util_config.passphrase[config->passphrase_length] = '\0';
 	util_config.passphrase_length = config->passphrase_length;
 	util_config.ap_auth_type = config->ap_auth_type;
 	util_config.ap_crypto_type = config->ap_crypto_type;
@@ -709,7 +716,7 @@ wifi_manager_result_e _wifimgr_connect_ap(wifi_manager_ap_config_s *config)
 		WIFIADD_ERR_RECORD(ERR_WIFIMGR_CONNECT_FAIL);
 		return WIFI_MANAGER_FAIL;
 	}
-	strncpy(g_manager_info.ssid, config->ssid, config->ssid_length + 1);
+        WIFIMGR_SET_SSID(config->ssid);
 
 	return WIFI_MANAGER_SUCCESS;
 }
@@ -734,15 +741,17 @@ wifi_manager_result_e _wifimgr_run_softap(wifi_manager_softap_config_s *config)
 	softap_config.ap_auth_type = WIFI_UTILS_AUTH_WPA2_PSK;
 	softap_config.ssid_length = strlen(config->ssid);
 	softap_config.passphrase_length = strlen(config->passphrase);
-	strncpy(softap_config.ssid, config->ssid, softap_config.ssid_length + 1);
-	strncpy(softap_config.passphrase, config->passphrase, softap_config.passphrase_length + 1);
+	strncpy(softap_config.ssid, config->ssid, softap_config.ssid_length);
+        softap_config.ssid[softap_config.ssid_length] = '\0';
+	strncpy(softap_config.passphrase, config->passphrase, softap_config.passphrase_length);
+        softap_config.passphrase[softap_config.passphrase_length] = '\0';
 
 	WIFIMGR_CHECK_UTILRESULT(wifi_utils_start_softap(&softap_config), "[WM] Starting softap mode failed.", WIFI_MANAGER_FAIL);
 	WIFIMGR_CHECK_RESULT(_start_dhcpd(), "[WM] Starting DHCP server failed.\n", WIFI_MANAGER_FAIL);
 
 	/* update wifi_manager_info */
-	strncpy(g_manager_info.ssid, config->ssid, softap_config.ssid_length + 1);
-	g_manager_info.num_sta = 0;
+	WIFIMGR_SET_SSID(config->ssid);
+        g_manager_info.num_sta = 0;
 
 	if (g_manager_info.state == WIFIMGR_SOFTAP_DISCONNECTING_STA) {
 		WIFIMGR_SOFTAP_CALLBACK_RECEIVED;	
@@ -868,7 +877,7 @@ wifi_manager_result_e _handler_on_uninitialized_state(_wifimgr_msg_s *msg)
 	}
 
 	g_manager_info.cb = *cb;
-	memcpy(g_manager_info.mac_address, info.mac_address, 6);
+	memcpy(g_manager_info.mac_address, info.mac_address, WIFIMGR_MACADDR_LEN);
 
 	WIFIMGR_SET_STATE(WIFIMGR_STA_DISCONNECTED);
 
@@ -1374,8 +1383,8 @@ wifi_manager_result_e wifi_manager_get_info(wifi_manager_info_s *info)
 	LOCK_WIFIMGR;
 	uint8_t *ip = (uint8_t *)&g_manager_info.ip4_address;
 	snprintf(info->ip4_address, 18, "%d.%d.%d.%d", ip[0], ip[1], ip[2], ip[3]);
-	memcpy(info->ssid, g_manager_info.ssid, 32);
-	memcpy(info->mac_address, g_manager_info.mac_address, 6);
+	memcpy(info->ssid, g_manager_info.ssid, WIFIMGR_SSID_LEN + 1);
+	memcpy(info->mac_address, g_manager_info.mac_address, WIFIMGR_MACADDR_LEN);
 	/* Get RSSI */
 	wifi_utils_info info_utils;
 	wifi_utils_result_e wres = wifi_utils_get_info(&info_utils);
@@ -1487,7 +1496,7 @@ wifi_manager_result_e wifi_manager_mac_str_to_mac_addr(char mac_str[20], char ma
 	wifi_manager_result_e wret = WIFI_MANAGER_INVALID_ARGS;
 	if (mac_addr && mac_str) {
 		int ret = sscanf(mac_str, "%hhx:%hhx:%hhx:%hhx:%hhx:%hhx%*c", &mac_addr[0], &mac_addr[1], &mac_addr[2], &mac_addr[3], &mac_addr[4], &mac_addr[5]);
-		if (ret == 6) {
+		if (ret == WIFIMGR_MACADDR_LEN) {
 			wret = WIFI_MANAGER_SUCCESS;	
 		}
 	} else {

--- a/framework/src/wifi_manager/wifi_utils.h
+++ b/framework/src/wifi_manager/wifi_utils.h
@@ -23,8 +23,7 @@
 
 /* Length defines */
 #define WIFI_UTILS_MACADDR_LEN        6
-#define WIFI_UTILS_MACADDR_STR_LEN    18
-/* The maximum length of an SSID - excluding '\0' is case of all characters used */
+#define WIFI_UTILS_MACADDR_STR_LEN    17
 #define WIFI_UTILS_SSID_LEN           32
 #define WIFI_UTILS_PASSPHRASE_LEN     64
 
@@ -67,9 +66,9 @@ typedef enum {
  */
 typedef struct {
 	unsigned int channel;				  /**<  Radio channel that the AP beacon was received on       */
-	char ssid[WIFI_UTILS_SSID_LEN];						  /**<  Service Set Identification (i.e. Name of Access Point) */
+	char ssid[WIFI_UTILS_SSID_LEN + 1];						  /**<  Service Set Identification (i.e. Name of Access Point) */
 	unsigned int ssid_length;			  /**<  The length of Service Set Identification               */
-	unsigned char bssid[WIFI_UTILS_MACADDR_STR_LEN];				  /**<  MAC address (xx:xx:xx:xx:xx:xx) of Access Point */
+	unsigned char bssid[WIFI_UTILS_MACADDR_STR_LEN + 1];				  /**<  MAC address (xx:xx:xx:xx:xx:xx) of Access Point */
 	unsigned int max_rate;				  /**<  Maximum data rate in kilobits/s                        */
 	int rssi;							  /**<  Receive Signal Strength Indication in dBm              */
 	uint8_t phy_mode;					// 0:legacy 1: 11N HT
@@ -82,9 +81,9 @@ typedef struct {
  * @brief wifi ap connect config
  */
 typedef struct {
-	char ssid[WIFI_UTILS_SSID_LEN];							 /**<  Service Set Identification         */
+	char ssid[WIFI_UTILS_SSID_LEN + 1];							 /**<  Service Set Identification         */
 	unsigned int ssid_length;				 /**<  Service Set Identification Length  */
-	char passphrase[WIFI_UTILS_PASSPHRASE_LEN];					 /**<  ap passphrase(password)            */
+	char passphrase[WIFI_UTILS_PASSPHRASE_LEN + 1];					 /**<  ap passphrase(password)            */
 	unsigned int passphrase_length;			 /**<  ap passphrase length               */
 	wifi_utils_ap_auth_type_e ap_auth_type;		  /**<  @ref wifi_utils_ap_auth_type            */
 	wifi_utils_ap_crypto_type_e ap_crypto_type;	  /**<  @ref wifi_utils_ap_crypto_type          */
@@ -95,9 +94,9 @@ typedef struct {
  */
 typedef struct {
 	unsigned int channel;					 /**<  soft ap wifi channel               */
-	char ssid[WIFI_UTILS_SSID_LEN];							 /**<  Service Set Identification         */
+	char ssid[WIFI_UTILS_SSID_LEN + 1];							 /**<  Service Set Identification         */
 	unsigned int ssid_length;				 /**<  Service Set Identification Length  */
-	char passphrase[WIFI_UTILS_PASSPHRASE_LEN];					 /**<  ap passphrase(password)            */
+	char passphrase[WIFI_UTILS_PASSPHRASE_LEN + 1];					 /**<  ap passphrase(password)            */
 	unsigned int passphrase_length;			 /**<  ap passphrase length               */
 	wifi_utils_ap_auth_type_e ap_auth_type;		  /**<  @ref wifi_utils_ap_auth_type            */
 	wifi_utils_ap_crypto_type_e ap_crypto_type;	  /**<  @ref wifi_utils_ap_crypto_type          */

--- a/framework/src/wifi_manager/wpa_wifi_utils.c
+++ b/framework/src/wifi_manager/wpa_wifi_utils.c
@@ -23,9 +23,6 @@
 #include <slsi_wifi/slsi_wifi_api.h>
 #include "wifi_utils.h"
 
-#define MACADDR_LENGTH			6
-#define SSID_LENGTH_MAX			32
-#define PASSPHRASE_LENGTH_MAX	64
 #define DHCP_RETRY_COUNT		1
 #define WIFI_UTILS_DEBUG        0
 
@@ -135,7 +132,8 @@ fetch_scan_results(wifi_utils_scan_list_s **scan_list, slsi_scan_info_t **slsi_s
 					&cur->ap_info.ap_auth_type, &cur->ap_info.ap_crypto_type);
 			strncpy(cur->ap_info.ssid, (char *)wifi_scan_iter->ssid, wifi_scan_iter->ssid_len);
 			cur->ap_info.ssid_length = (unsigned int)wifi_scan_iter->ssid_len;
-			strncpy(cur->ap_info.bssid, (char *)wifi_scan_iter->bssid, SLSI_MACADDR_STR_LEN);
+			strncpy(cur->ap_info.bssid, (char *)wifi_scan_iter->bssid, WIFI_UTILS_MACADDR_STR_LEN);
+                        cur->ap_info.bssid[WIFI_UTILS_MACADDR_STR_LEN] = '\0';
 
 			if (!prev) {
 				*scan_list = cur;


### PR DESCRIPTION
- Set the SSID and Passphrase string length to 33 and 65 bytes, respectively
- Insert null after strncpy, only when the string is not initialized (to null)
- In case WiFi Manager recieves callback msg (such as scanning result), check the SSID length not to be larger than 32
- Change SSID and Passphrase length condition in wm_test, wm_test_stress, and tcp_tls_stress (commit 
7a8937e)