### PR TITLE
framework/task_manager: Implement task_manager_getinfo_with_pid API

### DIFF
--- a/framework/include/task_manager/task_manager.h
+++ b/framework/include/task_manager/task_manager.h
@@ -368,6 +368,18 @@ app_info_t *task_manager_getinfo_with_handle(int handle, int timeout);
  */
 app_info_list_t *task_manager_getinfo_with_group(int group, int timeout);
 /**
+ * @brief Get the handle through pid
+ * @details @b #include <task_manager/task_manager.h>
+ * @param[in] pid the pid which to get its task information\n
+ * @param[in] timeout returnable flag. It can be one of the below.\n
+ *			TM_RESPONSE_WAIT_INF : Blocked until get the response from task manager\n
+ *			integer value : Specifies an upper limit on the time for which will block in milliseconds\n
+ *            For this API, timeout cannot be set to TM_NO_RESPONSE.
+ * @return On success, the task information is returned. On failure, NULL is returned.
+ * @since TizenRT v2.0 PRE
+ */
+app_info_t *task_manager_getinfo_with_pid(int pid, int timeout);
+/**
  * @brief Clean task information
  * @details @b #include <task_manager/task_manager.h>
  * @param[in] info the task information

--- a/framework/src/task_manager/task_manager_core.c
+++ b/framework/src/task_manager/task_manager_core.c
@@ -1142,6 +1142,14 @@ int task_manager(int argc, char *argv[])
 			ret = taskmgr_getinfo_with_handle(request_msg.handle, &response_msg);
 			break;
 
+		case TASKMGRCMD_SCAN_PID:
+			ret = taskmgr_get_handle_by_pid(request_msg.caller_pid);
+			if (ret == TM_UNREGISTERED_APP) {
+				break;
+			}
+			ret = taskmgr_getinfo_with_handle(ret, &response_msg);
+			break;
+
 		case TASKMGRCMD_UNICAST:
 			if (((tm_unicast_internal_msg_t *)request_msg.data)->type == TM_UNICAST_SYNC) {
 				response_msg.data = TM_ALLOC(sizeof(tm_unicast_msg_t));

--- a/framework/src/task_manager/task_manager_internal.h
+++ b/framework/src/task_manager/task_manager_internal.h
@@ -54,6 +54,7 @@
 #define TASKMGRCMD_ALLOC_BROADCAST_MSG     18
 #define TASKMGRCMD_UNSET_BROADCAST_CB      19
 #define TASKMGRCMD_DEALLOC_BROADCAST_MSG   20
+#define TASKMGRCMD_SCAN_PID                21
 
 /* Task Type */
 #define TM_BUILTIN_TASK                    0


### PR DESCRIPTION
1. framework/task_manager: Implement task_manager_getinfo_with_pid API
  User can get task information by pid which is managed by task manager
2. Add positive and negative TCs for task_manager_getinfo_with_pid()