### PR TITLE
framework/task_manager: Modify the termination cb type

### DIFF
--- a/apps/examples/testcase/ta_tc/task_manager/utc/utc_task_manager_main.c
+++ b/apps/examples/testcase/ta_tc/task_manager/utc/utc_task_manager_main.c
@@ -62,8 +62,6 @@ static bool flag;
 static app_info_t *sample_info;
 static app_info_list_t *group_list_info;
 static app_info_list_t *sample_list_info;
-static int *addr;
-static int *addr2;
 static int broad_wifi_on_cnt;
 static int broad_wifi_off_cnt;
 static int broad_undefined_cnt;
@@ -136,10 +134,9 @@ static void test_broadcast_handler(void *info)
 	}
 }
 
-void free_handler(void)
+void free_handler(void *info)
 {
-	free(addr);
-	free(addr2);
+	free(info);
 }
 
 int tm_sample_main(int argc, char *argv[])
@@ -163,15 +160,15 @@ int tm_broadcast1_main(int argc, char *argv[])
 {
 	int ret;
 
-	ret = task_manager_set_broadcast_cb(TM_BROADCAST_WIFI_ON, test_broadcast_handler, ((void *)TM_BROAD_WIFI_ON_DATA));
+	ret = task_manager_set_broadcast_cb(TM_BROADCAST_WIFI_ON, test_broadcast_handler, (void *)TM_BROAD_WIFI_ON_DATA);
 	if (ret != OK) {
 		printf("ERROR : fail to set callback ERR: %d\n", ret);
 	}
-	ret = task_manager_set_broadcast_cb(TM_BROADCAST_WIFI_OFF, test_broadcast_handler, ((void *)TM_BROAD_WIFI_OFF_DATA));
+	ret = task_manager_set_broadcast_cb(TM_BROADCAST_WIFI_OFF, test_broadcast_handler, (void *)TM_BROAD_WIFI_OFF_DATA);
 	if (ret != OK) {
 		printf("ERROR : fail to set callback ERR: %d\n", ret);
 	}
-	ret = task_manager_set_broadcast_cb(tm_broadcast_undefined_msg, test_broadcast_handler, ((void *)TM_BROAD_UNDEFINED_MSG_DATA));
+	ret = task_manager_set_broadcast_cb(tm_broadcast_undefined_msg, test_broadcast_handler, (void *)TM_BROAD_UNDEFINED_MSG_DATA);
 	if (ret != OK) {
 		printf("ERROR : fail to set callback ERR: %d\n", ret);
 	}
@@ -185,11 +182,11 @@ int tm_broadcast2_main(int argc, char *argv[])
 {
 	int ret;
 
-	ret = task_manager_set_broadcast_cb(TM_BROADCAST_WIFI_ON, test_broadcast_handler, ((void *)TM_BROAD_WIFI_ON_DATA));
+	ret = task_manager_set_broadcast_cb(TM_BROADCAST_WIFI_ON, test_broadcast_handler, (void *)TM_BROAD_WIFI_ON_DATA);
 	if (ret != OK) {
 		printf("ERROR : fail to set callback ERR: %d\n", ret);
 	}
-	ret = task_manager_set_broadcast_cb(TM_BROADCAST_WIFI_OFF, test_broadcast_handler, ((void *)TM_BROAD_WIFI_OFF_DATA));
+	ret = task_manager_set_broadcast_cb(TM_BROADCAST_WIFI_OFF, test_broadcast_handler, (void *)TM_BROAD_WIFI_OFF_DATA);
 	if (ret != OK) {
 		printf("ERROR : fail to set callback ERR: %d\n", ret);
 	}
@@ -203,7 +200,7 @@ int tm_broadcast3_main(int argc, char *argv[])
 {
 	int ret;
 
-	ret = task_manager_set_broadcast_cb(tm_broadcast_undefined_msg, test_broadcast_handler, ((void *)TM_BROAD_UNDEFINED_MSG_DATA));
+	ret = task_manager_set_broadcast_cb(tm_broadcast_undefined_msg, test_broadcast_handler, (void *)TM_BROAD_UNDEFINED_MSG_DATA);
 	if (ret != OK) {
 		printf("ERROR : fail to set callback ERR: %d\n", ret);
 	}
@@ -306,10 +303,10 @@ static void utc_task_manager_set_unicast_cb_p(void)
 static void utc_task_manager_set_broadcast_cb_n(void)
 {
 	int ret;
-	ret = task_manager_set_broadcast_cb(TM_INVALID_BROAD_MSG, test_broadcast_handler, ((void *)NULL));
+	ret = task_manager_set_broadcast_cb(TM_INVALID_BROAD_MSG, test_broadcast_handler, (void *)NULL);
 	TC_ASSERT_EQ("task_manager_set_broadcast_cb", ret, TM_INVALID_PARAM);
 
-	ret = task_manager_set_broadcast_cb(TM_BROADCAST_WIFI_ON, NULL, ((void *)NULL));
+	ret = task_manager_set_broadcast_cb(TM_BROADCAST_WIFI_ON, NULL, (void *)NULL);
 	TC_ASSERT_EQ("task_manager_set_broadcast_cb", ret, TM_INVALID_PARAM);
 
 	TC_SUCCESS_RESULT();
@@ -319,10 +316,10 @@ static void utc_task_manager_set_broadcast_cb_p(void)
 {
 	int ret;
 
-	ret = task_manager_set_broadcast_cb(TM_BROAD_UNDEFINED_MSG_NOT_USED, test_broadcast_handler, ((void *)NULL));
+	ret = task_manager_set_broadcast_cb(TM_BROAD_UNDEFINED_MSG_NOT_USED, test_broadcast_handler, (void *)NULL);
 	TC_ASSERT_EQ("task_manager_set_broadcast_cb", ret, TM_UNREGISTERED_MSG);
 
-	ret = task_manager_set_broadcast_cb(tm_broadcast_undefined_msg, test_broadcast_handler, ((void *)TM_BROAD_WIFI_ON_DATA));
+	ret = task_manager_set_broadcast_cb(tm_broadcast_undefined_msg, test_broadcast_handler, (void *)TM_BROAD_WIFI_ON_DATA);
 	TC_ASSERT_EQ("task_manager_set_broadcast_cb", ret, OK);
 
 	TC_SUCCESS_RESULT();
@@ -331,7 +328,7 @@ static void utc_task_manager_set_broadcast_cb_p(void)
 static void utc_task_manager_set_exit_cb_n(void)
 {
 	int ret;
-	ret = task_manager_set_exit_cb(NULL);
+	ret = task_manager_set_exit_cb(NULL, (void *)NULL);
 	TC_ASSERT_EQ("task_manager_set_exit_cb", ret, TM_INVALID_PARAM);
 
 	TC_SUCCESS_RESULT();
@@ -341,11 +338,10 @@ static void utc_task_manager_set_exit_cb_p(void)
 {
 	int ret;
 	/* No meaningful malloc for testing resource collection handler */
-	addr = (int *)malloc(123);
-	addr2 = (int *)malloc(456);
+	int *addr = (int *)malloc(123);
 
-	ret = task_manager_set_exit_cb(free_handler);
-	TC_ASSERT_EQ_CLEANUP("task_manager_set_exit_cb", ret, OK, free(addr); free(addr2));
+	ret = task_manager_set_exit_cb(free_handler, (void *)addr);
+	TC_ASSERT_EQ_CLEANUP("task_manager_set_exit_cb", ret, OK, free(addr));
 
 	TC_SUCCESS_RESULT();
 }

--- a/framework/include/task_manager/task_manager.h
+++ b/framework/include/task_manager/task_manager.h
@@ -134,6 +134,11 @@ typedef void (*_tm_unicast_t)(tm_unicast_msg_t *);
  */
 typedef void (*_tm_broadcast_t)(void *);
 
+/**
+ * @brief Termination callback function type
+ */
+typedef void (*_tm_termination_t)(void *);
+
 /****************************************************************************
  * Public Function Prototypes
  ****************************************************************************/
@@ -315,19 +320,21 @@ int task_manager_set_broadcast_cb(int msg, void (*func)(void *data), void *cb_da
 /**
  * @brief Set callback function for resource deallocation API. If you set the callback, it will works when task terminates.
  * @details @b #include <task_manager/task_manager.h>
- * @param[in] func the callback function which deallocate resources\n
+ * @param[in] func the callback function that is called when the task or thread terminates normally.
+ * @param[in] cb_data a data pointer to pass to the callback function func.
  * @return On success, OK is returned. On failure, defined negative value is returned.
  * @since TizenRT v2.0 PRE
  */
-int task_manager_set_exit_cb(void (*func)(void));
+int task_manager_set_exit_cb(void (*func)(void *data), void *cb_data);
 /**
  * @brief Set callback function for resource deallocation API. If you set the callback, it will works when task is cancelled.
  * @details @b #include <task_manager/task_manager.h>
- * @param[in] func the callback function which deallocate resources\n
+ * @param[in] func the callback function that is called when the task or thread is stopped by task manager.
+ * @param[in] cb_data a data pointer to pass to the callback function func.
  * @return On success, OK is returned. On failure, defined negative value is returned.
  * @since TizenRT v2.0 PRE
  */
-int task_manager_set_stop_cb(void (*func)(void));
+int task_manager_set_stop_cb(void (*func)(void *data), void *cb_data);
 /**
  * @brief Get task information list through task name
  * @details @b #include <task_manager/task_manager.h>

--- a/framework/src/task_manager/task_manager_internal.h
+++ b/framework/src/task_manager/task_manager_internal.h
@@ -81,7 +81,11 @@
 #define TM_UNICAST_SYNC      (0)
 #define TM_UNICAST_ASYNC     (1)
 
-typedef void (*_tm_termination_t)(void);
+struct tm_termination_info_s {
+	_tm_termination_t cb;
+	void *cb_data;
+};
+typedef struct tm_termination_info_s tm_termination_info_t;
 
 struct app_list_s {
 	int pid;
@@ -96,10 +100,10 @@ struct app_list_data_s {
 	int tm_gid;
 	int status;
 	int permission;
-	_tm_termination_t stop_cb;
-	_tm_termination_t exit_cb;
 	_tm_unicast_t unicast_cb;
 	sq_queue_t broadcast_info_list;
+	tm_termination_info_t *stop_cb_info;
+	tm_termination_info_t *exit_cb_info;
 };
 typedef struct app_list_data_s app_list_data_t;
 
@@ -163,9 +167,9 @@ typedef struct tm_unicast_internal_msg_s tm_unicast_internal_msg_t;
 #define TM_STATUS(handle)               TM_LIST_ADDR(handle)->status
 #define TM_PERMISSION(handle)           TM_LIST_ADDR(handle)->permission
 #define TM_UNICAST_CB(handle)           TM_LIST_ADDR(handle)->unicast_cb
-#define TM_STOP_CB(handle)              TM_LIST_ADDR(handle)->stop_cb
-#define TM_EXIT_CB(handle)              TM_LIST_ADDR(handle)->exit_cb
 #define TM_BROADCAST_INFO_LIST(handle)  TM_LIST_ADDR(handle)->broadcast_info_list
+#define TM_STOP_CB_INFO(handle)         TM_LIST_ADDR(handle)->stop_cb_info
+#define TM_EXIT_CB_INFO(handle)         TM_LIST_ADDR(handle)->exit_cb_info
 
 extern app_list_t tm_app_list[CONFIG_TASK_MANAGER_MAX_TASKS];
 

--- a/framework/src/task_manager/task_manager_set_callback.c
+++ b/framework/src/task_manager/task_manager_set_callback.c
@@ -149,7 +149,7 @@ int task_manager_set_broadcast_cb(int msg, void (*func)(void *data), void *cb_da
 /****************************************************************************
  * task_manager_set_exit_cb
  ****************************************************************************/
-int task_manager_set_exit_cb(void (*func)(void))
+int task_manager_set_exit_cb(void (*func)(void *data), void *cb_data)
 {
 	int ret = OK;
 	tm_request_t request_msg;
@@ -163,10 +163,16 @@ int task_manager_set_exit_cb(void (*func)(void))
 	/* Set the request msg */
 	request_msg.cmd = TASKMGRCMD_SET_EXIT_CB;
 	request_msg.caller_pid = getpid();
-	request_msg.data = (void *)func;
 	request_msg.timeout = TM_NO_RESPONSE;
+	request_msg.data = (void *)TM_ALLOC(sizeof(tm_termination_info_t));
+	if (request_msg.data == NULL) {
+		return TM_OUT_OF_MEMORY;
+	}
+	((tm_termination_info_t *)request_msg.data)->cb = (_tm_termination_t)func;
+	((tm_termination_info_t *)request_msg.data)->cb_data = cb_data;
 	ret = taskmgr_send_request(&request_msg);
 	if (ret < 0) {
+		TM_FREE(request_msg.data);
 		return ret;
 	}
 
@@ -176,7 +182,7 @@ int task_manager_set_exit_cb(void (*func)(void))
 /****************************************************************************
  * task_manager_set_stop_cb
  ****************************************************************************/
-int task_manager_set_stop_cb(void (*func)(void))
+int task_manager_set_stop_cb(void (*func)(void *data), void *cb_data)
 {
 	int ret = OK;
 	tm_request_t request_msg;
@@ -190,10 +196,16 @@ int task_manager_set_stop_cb(void (*func)(void))
 	/* Set the request msg */
 	request_msg.cmd = TASKMGRCMD_SET_STOP_CB;
 	request_msg.caller_pid = getpid();
-	request_msg.data = (void *)func;
 	request_msg.timeout = TM_NO_RESPONSE;
+	request_msg.data = (void *)TM_ALLOC(sizeof(tm_termination_info_t));
+	if (request_msg.data == NULL) {
+		return TM_OUT_OF_MEMORY;
+	}
+	((tm_termination_info_t *)request_msg.data)->cb = (_tm_termination_t)func;
+	((tm_termination_info_t *)request_msg.data)->cb_data = cb_data;
 	ret = taskmgr_send_request(&request_msg);
 	if (ret < 0) {
+		TM_FREE(request_msg.data);
 		return ret;
 	}
 


### PR DESCRIPTION
Modify the termination cb type, corresponding APIs, and its TC.

1. Modify the termination cb type to deliver a data when it becomes set.
2. As the termination cb type is changed, corresponding APIs (task_manager_set_exit_cb and task_manager_set_stop_cb) are changed.
3. As the APIs are changed, corresponding TC is changed.