### PR TITLE
 kernel/cpuload: support multiple CPU load measurement and cpuload command

### DIFF
--- a/apps/system/utils/Kconfig
+++ b/apps/system/utils/Kconfig
@@ -50,6 +50,39 @@ config NET_PING_CMD_ICOUNT
 
 endif #NET_CMDS
 
+config ENABLE_CPULOAD_CMD
+	bool "cpuload"
+	default y
+	depends on SCHED_CPULOAD
+	---help---
+		Display current cpuload or start/stop CPU load monitor.
+		CPU load monitor is a daemon that will periodically assess
+		CPU usage by all live tasks and threads in the system.
+
+config ENABLE_CPULOAD_MONITOR
+	bool "cpuload monitor"
+	default y
+	depends on ENABLE_CPULOAD_CMD && !CONFIG_DISABLE_PTHREAD && !CONFIG_DISABLE_SIGNALS
+	---help---
+		The CPU load monitor is a daemon that will periodically assess
+		CPU usage by all live tasks and threads in the system.
+		It is available if both signal and pthread are supported only, !DISABLE_SIGNALS && !DISABLE_PTHREAD.
+
+config CPULOADMONITOR_PRIORITY
+	int "CPU load monitor daemon priority"
+	default 100
+	depends on ENABLE_CPULOAD_MONITOR
+	---help---
+		The priority to use the the CPU load monitor daemon.  Default: 100
+
+config CPULOADMONITOR_INTERVAL
+	int "CPU load monitor frequency"
+	default 5
+	depends on ENABLE_CPULOAD_MONITOR
+	---help---
+		The rate in seconds that the CPU load monitor will wait before dumping
+		the next set CPU load usage information.  Default:  5 seconds.
+
 config ENABLE_DATE
 	bool "date"
 	default y

--- a/apps/system/utils/Makefile
+++ b/apps/system/utils/Makefile
@@ -100,6 +100,10 @@ endif
 
 endif #CONFIG_TASH
 
+ifeq ($(CONFIG_ENABLE_CPULOAD_CMD),y)
+CSRCS += kdbg_cpuload.c
+endif
+
 ifeq ($(CONFIG_ENABLE_DATE),y)
 CSRCS += kdbg_date.c
 endif

--- a/apps/system/utils/kdbg_commands.h
+++ b/apps/system/utils/kdbg_commands.h
@@ -21,6 +21,10 @@
 
 #include <tinyara/config.h>
 
+#if defined(CONFIG_ENABLE_CPULOAD_CMD)
+int kdbg_cpuload(int argc, char **args);
+#endif
+
 #if defined(CONFIG_ENABLE_DATE)
 int kdbg_date(int argc, char **args);
 #endif

--- a/apps/system/utils/kdbg_cpuload.c
+++ b/apps/system/utils/kdbg_cpuload.c
@@ -1,0 +1,221 @@
+/****************************************************************************
+ *
+ * Copyright 2018 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+#include <tinyara/config.h>
+#include <stdio.h>
+#include <string.h>
+#include <sched.h>
+#include <stdint.h>
+#include <stdbool.h>
+#ifdef CONFIG_ENABLE_CPULOAD_MONITOR
+#include <pthread.h>
+#endif
+#include <sys/types.h>
+#include <tinyara/clock.h>
+#include <tinyara/sched.h>
+#include "kdbg_utils.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+#ifdef CONFIG_ENABLE_CPULOAD_MONITOR
+#define CPULOADMON_PREFIX "CPUload Monitor: "
+
+#define CPULOADMONITOR_STACKSIZE 1024
+
+#ifndef CONFIG_CPULOADMONITOR_PRIORITY
+#define CONFIG_CPULOADMONITOR_PRIORITY 100
+#endif
+
+#ifndef CONFIG_CPULOADMONITOR_INTERVAL
+#define CONFIG_CPULOADMONITOR_INTERVAL 5
+#endif
+#endif
+
+extern volatile uint32_t g_cpuload_timeconstant[SCHED_NCPULOAD];
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+#ifdef CONFIG_ENABLE_CPULOAD_MONITOR
+static volatile bool is_started = false;
+static pthread_t cpuloadmon;
+#endif
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+static void cpuload_print_task(struct tcb_s *tcb, void *arg)
+{
+	struct cpuload_s cpuload;
+	uint32_t intpart;
+	uint32_t fracpart;
+	int cpuload_idx;
+	uint32_t tmp;
+
+	printf("  %d    ", tcb->pid);
+	for (cpuload_idx = 0; cpuload_idx < SCHED_NCPULOAD; cpuload_idx++) {
+
+		(void)clock_cpuload(tcb->pid, cpuload_idx, &cpuload);
+
+		if (cpuload.total > 0) {
+			tmp = (1000 * cpuload.active) / cpuload.total;
+			intpart = tmp / 10;
+			fracpart = tmp - 10 * intpart;
+		} else {
+			intpart = 0;
+			fracpart = 0;
+		}
+		printf("%3d.%d %%   ", intpart, fracpart);
+	}
+	printf("\n");
+}
+
+static void cpuload_print_tasklist(void)
+{
+	int cpuload_idx;
+
+#ifdef CONFIG_SCHED_MULTI_CPULOAD
+	printf("=====================================\n");
+#else
+	printf("=================\n");
+#endif
+	printf(" CPU USAGE\n");
+#ifdef CONFIG_SCHED_MULTI_CPULOAD
+	printf("=====================================\n");
+#else
+	printf("=================\n");
+#endif
+	printf(" PID");
+	for (cpuload_idx = 0; cpuload_idx < SCHED_NCPULOAD; cpuload_idx++) {
+		printf("%9ds", g_cpuload_timeconstant[cpuload_idx]);
+	}
+#ifdef CONFIG_SCHED_MULTI_CPULOAD
+	printf("\n-------------------------------------\n");
+#else
+	printf("\n-----------------\n");
+#endif
+
+	/* Print cpu load for each task */
+	sched_foreach(cpuload_print_task, NULL);
+
+#ifdef CONFIG_SCHED_MULTI_CPULOAD
+	printf("=====================================\n");
+#else
+	printf("=================\n");
+#endif
+}
+
+#ifdef CONFIG_ENABLE_CPULOAD_MONITOR
+static void *cpuloadmonitor_daemon(void *args)
+{
+	/* Loop until we detect that there is a request to stop. */
+	while (is_started) {
+		cpuload_print_tasklist();		
+		sleep(CONFIG_CPULOADMONITOR_INTERVAL);
+	}
+
+	return NULL;
+}
+
+static void cpuload_daemon_start(void)
+{
+	int ret;
+	pthread_attr_t attr;
+
+	if (is_started) {
+		printf(CPULOADMON_PREFIX "Already started\n");
+		return;
+	}
+
+	pthread_attr_init(&attr);
+	attr.stacksize = CPULOADMONITOR_STACKSIZE;
+	attr.priority = CONFIG_CPULOADMONITOR_PRIORITY;
+	attr.inheritsched = PTHREAD_EXPLICIT_SCHED;
+	
+	ret = pthread_create(&cpuloadmon, &attr, cpuloadmonitor_daemon, NULL);
+	if (ret != OK) {
+		printf(CPULOADMON_PREFIX "Failed to start the cpuload monitor: %d\n", ret);
+		return;
+	}
+	pthread_setname_np(cpuloadmon, "CPULoadMonitor");
+
+	ret = pthread_detach(cpuloadmon);
+	if (ret != OK) {
+		printf(CPULOADMON_PREFIX "Failed to detach the cpuload monitor: %d\n", ret);
+		pthread_cancel(cpuloadmon);
+		return;
+	}
+
+	is_started = true;
+}
+
+static void cpuload_daemon_stop(void)
+{
+	if (is_started) {
+		/* Stopped */
+		pthread_cancel(cpuloadmon);
+		is_started = false;
+		printf(CPULOADMON_PREFIX "CPU load Monitor Stopped\n");
+	} else {
+		printf(CPULOADMON_PREFIX "CPU load Monitor is not activated.\n");
+	}
+}
+#endif
+
+static void show_usage(void)
+{
+	printf("\nUsage: cpuload\n");
+#ifdef CONFIG_ENABLE_CPULOAD_MONITOR
+	printf("    Or, cpuload <start|stop>\n");
+#endif
+	printf("Print CPU load\n");
+#ifdef CONFIG_ENABLE_CPULOAD_MONITOR
+	printf("Or start/stop CPU load monitor daemon\n");
+#endif
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+int kdbg_cpuload(int argc, char **args)
+{
+	if (argc > 2) {
+		show_usage();
+		return ERROR;
+	}
+
+	if (argc == 1) {
+		/* Print CPU load once */
+		cpuload_print_tasklist();
+#ifdef CONFIG_ENABLE_CPULOAD_MONITOR
+	} else if (!strncmp(args[1], "start", strlen("start") + 1)) {
+		/* Start the cpuload monitor */
+		cpuload_daemon_start();
+	} else if (!strncmp(args[1], "stop", strlen("stop") + 1)) {
+		/* Stop the cpuload monitor */
+		cpuload_daemon_stop();
+#endif
+	} else {
+		show_usage();
+		return ERROR;
+	}
+	return OK;
+}

--- a/apps/system/utils/kernelcmd.c
+++ b/apps/system/utils/kernelcmd.c
@@ -25,6 +25,9 @@
 
 #ifdef CONFIG_KERNEL_CMDS
 const static tash_cmdlist_t kdbg_cmds[] = {
+#if defined(CONFIG_ENABLE_CPULOAD_CMD)
+	{"cpuload",  kdbg_cpuload,      TASH_EXECMD_SYNC},
+#endif
 #if defined(CONFIG_ENABLE_DATE)
 	{"date",     kdbg_date,         TASH_EXECMD_SYNC},
 #endif

--- a/os/fs/procfs/fs_procfscpuload.c
+++ b/os/fs/procfs/fs_procfscpuload.c
@@ -242,7 +242,7 @@ static ssize_t cpuload_read(FAR struct file *filep, FAR char *buffer, size_t buf
 		 * for the IDLE thread.
 		 */
 
-		DEBUGVERIFY(clock_cpuload(0, &cpuload));
+		DEBUGVERIFY(clock_cpuload(0, 0, &cpuload));
 
 		/* On the simulator, you may hit cpuload.total == 0, but probably never on
 		 * real hardware.

--- a/os/fs/procfs/fs_procfsproc.c
+++ b/os/fs/procfs/fs_procfsproc.c
@@ -521,7 +521,7 @@ static ssize_t proc_loadavg(FAR struct proc_file_s *procfile, FAR struct tcb_s *
 	 * after the procfs entry was opened.
 	 */
 
-	(void)clock_cpuload(procfile->pid, &cpuload);
+	(void)clock_cpuload(procfile->pid, 0, &cpuload);
 
 	/* On the simulator, you may hit cpuload.total == 0, but probably never on
 	 * real hardware.

--- a/os/include/tinyara/clock.h
+++ b/os/include/tinyara/clock.h
@@ -201,6 +201,12 @@ struct cpuload_s {
 	volatile uint32_t total;	/* Total number of clock ticks */
 	volatile uint32_t active;	/* Number of ticks while this thread was active */
 };
+
+#ifdef CONFIG_SCHED_MULTI_CPULOAD
+#define SCHED_NCPULOAD 3
+#else
+#define SCHED_NCPULOAD 1
+#endif
 #endif
 
 /* This type is the natural with of the system timer */
@@ -364,7 +370,7 @@ int clock_systimespec(FAR struct timespec *ts);
  * @cond
  * @internal
  */
-int clock_cpuload(int pid, FAR struct cpuload_s *cpuload);
+int clock_cpuload(int pid, int index, FAR struct cpuload_s *cpuload);
 /**
  * @endcond
  */

--- a/os/kernel/Kconfig
+++ b/os/kernel/Kconfig
@@ -530,11 +530,34 @@ config SCHED_CPULOAD_TICKSPERSEC
 
 config SCHED_CPULOAD_TIMECONSTANT
 	int "CPU load time constant"
+	depends on !SCHED_MULTI_CPULOAD
 	default 2
 	---help---
 		The accumulated CPU count is divided by two when the accumulated
 		tick count exceeds this time constant.  This time constant is in
 		units of seconds.
+
+config SCHED_MULTI_CPULOAD
+	bool "Use multi interval for cpuload measurement"
+	default n
+	---help---
+		If this option is selected, user can measure CPU load with 3 types of interval : short-term, mid-term, long-term.
+		It can bring overhead on system because it is handled in timer interrupt handler.
+
+config SCHED_CPULOAD_TIMECONSTANT_SHORT
+	int "Time constant for short-term"
+	default 2
+	depends on SCHED_MULTI_CPULOAD
+
+config SCHED_CPULOAD_TIMECONSTANT_MID
+	int "Time constant for mid-term"
+	default 5
+	depends on SCHED_MULTI_CPULOAD
+
+config SCHED_CPULOAD_TIMECONSTANT_LONG
+	int "Time constant for long-term"
+	default 10
+	depends on SCHED_MULTI_CPULOAD
 
 endif # SCHED_CPULOAD
 

--- a/os/kernel/sched/sched.h
+++ b/os/kernel/sched/sched.h
@@ -63,7 +63,9 @@
 #include <stdbool.h>
 #include <queue.h>
 #include <sched.h>
-
+#ifdef CONFIG_SCHED_CPULOAD
+#include <tinyara/clock.h>
+#endif
 #include <tinyara/kmalloc.h>
 
 /****************************************************************************
@@ -111,7 +113,7 @@ struct pidhash_s {
 	FAR struct tcb_s *tcb;		/* TCB assigned to this PID */
 	pid_t pid;					/* The full PID value */
 #ifdef CONFIG_SCHED_CPULOAD
-	uint32_t ticks;				/* Number of ticks on this thread */
+	uint32_t ticks[SCHED_NCPULOAD];				/* Number of ticks on this thread */
 #endif
 };
 
@@ -240,7 +242,7 @@ extern const struct tasklist_s g_tasklisttable[NUM_TASK_STATES];
  * 'denominator' for all CPU load calculations.
  */
 
-extern volatile uint32_t g_cpuload_total;
+extern volatile uint32_t g_cpuload_total[SCHED_NCPULOAD];
 #endif
 
 /****************************************************************************

--- a/os/kernel/sched/sched_cpuload.c
+++ b/os/kernel/sched/sched_cpuload.c
@@ -98,7 +98,16 @@
  * 'denominator' for all CPU load calculations.
  */
 
-volatile uint32_t g_cpuload_total;
+volatile uint32_t g_cpuload_total[SCHED_NCPULOAD];
+volatile uint32_t g_cpuload_timeconstant[SCHED_NCPULOAD] = {
+#ifdef CONFIG_SCHED_MULTI_CPULOAD
+	CONFIG_SCHED_CPULOAD_TIMECONSTANT_SHORT,
+	CONFIG_SCHED_CPULOAD_TIMECONSTANT_MID,
+	CONFIG_SCHED_CPULOAD_TIMECONSTANT_LONG
+#else
+	CONFIG_SCHED_CPULOAD_TIMECONSTANT
+#endif
+};
 
 /************************************************************************
  * Private Functions
@@ -131,6 +140,7 @@ void weak_function sched_process_cpuload(void)
 	FAR struct tcb_s *rtcb = this_task();
 	int hash_index;
 	int i;
+	int cpuload_idx;
 
 	/* Increment the count on the currently executing thread
 	 *
@@ -142,27 +152,29 @@ void weak_function sched_process_cpuload(void)
 	 */
 
 	hash_index = PIDHASH(rtcb->pid);
-	g_pidhash[hash_index].ticks++;
 
-	/* Increment tick count.  If the accumulated tick value exceed a time
-	 * constant, then shift the accumulators.
-	 */
+	for (cpuload_idx = 0; cpuload_idx < SCHED_NCPULOAD; cpuload_idx++) {
+			g_pidhash[hash_index].ticks[cpuload_idx]++;
 
-	if (++g_cpuload_total > (CONFIG_SCHED_CPULOAD_TIMECONSTANT * CPULOAD_TICKSPERSEC)) {
-		uint32_t total = 0;
+			/* Increment tick count.  If the accumulated tick value exceed a time
+			 * constant, then shift the accumulators.
+			 */
 
-		/* Divide the tick count for every task by two and recalculate the
-		 * total.
-		 */
+			if (++g_cpuload_total[cpuload_idx] > (g_cpuload_timeconstant[cpuload_idx] * CPULOAD_TICKSPERSEC)) {
+				uint32_t total = 0;
 
-		for (i = 0; i < CONFIG_MAX_TASKS; i++) {
-			g_pidhash[i].ticks >>= 1;
-			total += g_pidhash[i].ticks;
-		}
+				/* Divide the tick count for every task by two and recalculate the
+				 * total.
+				 */
+				for (i = 0; i < CONFIG_MAX_TASKS; i++) {
+					g_pidhash[i].ticks[cpuload_idx] >>= 1;
+					total += g_pidhash[i].ticks[cpuload_idx];
+				}
 
-		/* Save the new total. */
+				/* Save the new total. */
 
-		g_cpuload_total = total;
+				g_cpuload_total[cpuload_idx] = total;
+			}
 	}
 }
 
@@ -185,13 +197,13 @@ void weak_function sched_process_cpuload(void)
  *
  ****************************************************************************/
 
-int clock_cpuload(int pid, FAR struct cpuload_s *cpuload)
+int clock_cpuload(int pid, int index, FAR struct cpuload_s *cpuload)
 {
 	irqstate_t flags;
 	int hash_index = PIDHASH(pid);
 	int ret = -ESRCH;
 
-	DEBUGASSERT(cpuload);
+	DEBUGASSERT(cpuload && index >= 0 && index < SCHED_NCPULOAD);
 
 	/* Momentarily disable interrupts.  We need (1) the task to stay valid
 	 * while we are doing these operations and (2) the tick counts to be
@@ -214,13 +226,12 @@ int clock_cpuload(int pid, FAR struct cpuload_s *cpuload)
 	 */
 
 	if (g_pidhash[hash_index].tcb && g_pidhash[hash_index].pid == pid) {
-		cpuload->total = g_cpuload_total;
-		cpuload->active = g_pidhash[hash_index].ticks;
+		cpuload->total = g_cpuload_total[index];
+		cpuload->active = g_pidhash[hash_index].ticks[index];
 		ret = OK;
 	}
 
 	irqrestore(flags);
 	return ret;
 }
-
 #endif							/* CONFIG_SCHED_CPULOAD */

--- a/os/kernel/sched/sched_releasetcb.c
+++ b/os/kernel/sched/sched_releasetcb.c
@@ -62,6 +62,9 @@
 
 #include <tinyara/arch.h>
 #include <tinyara/sched.h>
+#ifdef CONFIG_SCHED_CPULOAD
+#include <tinyara/clock.h>
+#endif
 
 #include "sched/sched.h"
 #include "group/group.h"
@@ -101,9 +104,11 @@ static void sched_releasepid(pid_t pid)
 	 * total for all threads.  Then we can reset the count on this
 	 * defunct thread to zero.
 	 */
-
-	g_cpuload_total -= g_pidhash[hash_ndx].ticks;
-	g_pidhash[hash_ndx].ticks = 0;
+	int cpuload_idx;
+	for (cpuload_idx = 0; cpuload_idx < SCHED_NCPULOAD; cpuload_idx++) {
+		g_cpuload_total[cpuload_idx] -= g_pidhash[hash_ndx].ticks[cpuload_idx];
+		g_pidhash[hash_ndx].ticks[cpuload_idx] = 0;
+	}
 #endif
 	/* Decrement the alive task count as task is exiting */
 	g_alive_taskcount--;

--- a/os/kernel/task/task_setup.c
+++ b/os/kernel/task/task_setup.c
@@ -65,6 +65,9 @@
 
 #include <tinyara/arch.h>
 #include <tinyara/ttrace.h>
+#ifdef CONFIG_SCHED_CPULOAD
+#include <tinyara/clock.h>
+#endif
 
 #include "sched/sched.h"
 #include "pthread/pthread.h"
@@ -169,7 +172,10 @@ static int task_assignpid(FAR struct tcb_s *tcb)
 			g_pidhash[hash_ndx].tcb = tcb;
 			g_pidhash[hash_ndx].pid = next_pid;
 #ifdef CONFIG_SCHED_CPULOAD
-			g_pidhash[hash_ndx].ticks = 0;
+			int cpuload_idx;
+			for (cpuload_idx = 0; cpuload_idx < SCHED_NCPULOAD; cpuload_idx++) {
+				g_pidhash[hash_ndx].ticks[cpuload_idx] = 0;
+			}
 #endif
 			tcb->pid = next_pid;
 


### PR DESCRIPTION
- kernel/cpuload: support multiple time constant for CPU load measurement
 : It supports to measure CPU load with 3 types of interval : short-term, mid-term, long-term

- kdbg/cpuload : add 'cpuload' command
 : User can know current CPU load of all live tasks, and run CPU load monitor daemon which periodically show them.