### PR TITLE
net/lwip: Add initialization of union variable in tcp

### DIFF
--- a/os/net/lwip/src/core/tcp.c
+++ b/os/net/lwip/src/core/tcp.c
@@ -131,9 +131,8 @@ static const u8_t tcp_persist_backoff[7] = { 3, 6, 12, 24, 48, 96, 120 };
 /** List of all TCP PCBs bound but not yet (connected || listening) */
 struct tcp_pcb *tcp_bound_pcbs = NULL;
 /** List of all TCP PCBs in LISTEN state */
-union tcp_listen_pcbs_t tcp_listen_pcbs;
-/** List of all TCP PCBs that are in a state in which
- * they accept or send data. */
+union tcp_listen_pcbs_t tcp_listen_pcbs = {NULL};
+/** List of all TCP PCBs that are in a state in which they accept or send data. */
 struct tcp_pcb *tcp_active_pcbs = NULL;
 /** List of all TCP PCBs in TIME-WAIT state */
 struct tcp_pcb *tcp_tw_pcbs = NULL;


### PR DESCRIPTION
- Initialize global union variable used in tcp of lwip
- Cypress board currently does not initialize variables during the flashing, this variable should be initialized in order to prevent false references