### PR TITLE
vfs/fs_truncate: Add truncate and ftruncate APIs

### DIFF
--- a/lib/libc/unistd/Make.defs
+++ b/lib/libc/unistd/Make.defs
@@ -65,6 +65,10 @@ CSRCS += lib_execl.c
 endif
 endif
 
+ifneq ($(CONFIG_DISABLE_MOUNTPOINT),y)
+CSRCS += lib_truncate.c
+endif
+
 ifneq ($(CONFIG_DISABLE_SIGNALS),y)
 CSRCS += lib_sleep.c lib_usleep.c
 endif

--- a/lib/libc/unistd/lib_truncate.c
+++ b/lib/libc/unistd/lib_truncate.c
@@ -1,0 +1,146 @@
+/****************************************************************************
+ *
+ * Copyright 2018 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+/****************************************************************************
+ * lib/libc/unistd/lib_truncate.c
+ *
+ *   Copyright (C) 2018 Gregory Nutt. All rights reserved.
+ *   Author: Gregory Nutt <gnutt@nuttx.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <tinyara/config.h>
+
+#include <unistd.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <assert.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: truncate
+ *
+ * Description:
+ *   The truncate() function causes the regular file named by path to have
+ *   a size of length bytes.
+ *
+ *   If the file previously was larger than length, the extra data is
+ *   discarded.  If it was previously shorter than length, it is unspecified
+ *   whether the file is changed or its size increased.  If the file is
+ *   extended, the extended area appears as if it were zero-filled.
+
+ *   With truncate(), the file must be open for writing; for truncate(),
+ *   the process must have write permission for the file.
+ *
+ *   truncate() does not modify the file offset for any open file
+ *   descriptions associated with the file.
+ *
+ * Input Parameters:
+ *   path   - The path to the regular file to be truncated.
+ *   length - The new length of the regular file.
+ *
+ * Returned Value:
+ *    Upon successful completion, truncate() return 0s. Otherwise a -1 is
+ *    returned, and errno is set to indicate the error.
+
+ *    EINTR
+ *      - A signal was caught during execution.
+ *    EINVAL
+ *      - The length argument was less than 0.
+ *    EFBIG or EINVAL
+ *      - The length argument was greater than the maximum file size.
+ *    EIO
+ *      - An I/O error occurred while reading from or writing to a file
+ *        system.
+ *    EACCES
+ *      - A component of the path prefix denies search permission, or write
+ *        permission is denied on the file.
+ *    EISDIR
+ *      - The named file is a directory.
+ *    ELOOP
+ *      - Too many symbolic links were encountered in resolving path.
+ *    ENAMETOOLONG
+ *      - The length of the specified pathname exceeds PATH_MAX bytes, or
+ *        the length of a component of the pathname exceeds NAME_MAX bytes.
+ *    ENOENT
+ *      - A component of path does not name an existing file or path is an
+ *        empty string.
+ *    ENOTDIR
+ *      - A component of the path prefix of path is not a directory.
+ *    EROFS
+ *      - he named file resides on a read-only file system.
+ *    ENAMETOOLONG
+ *      - Pathname resolution of a symbolic link produced an intermediate
+ *        result whose length exceeds PATH_MAX.
+ *
+ ****************************************************************************/
+
+int truncate(FAR const char *path, off_t length)
+{
+	int fd;
+	int ret;
+
+	DEBUGASSERT(path != NULL && length >= 0);
+
+	/* Open the regular file at 'path' for write-only access */
+
+	fd = open(path, O_WRONLY);
+	if (fd < 0) {
+		return ERROR;
+	}
+
+	/* Then let ftruncate() do the work */
+
+	ret = ftruncate(fd, length);
+
+	close(fd);
+	return ret;
+}

--- a/lib/libc/unistd/lib_truncate.c
+++ b/lib/libc/unistd/lib_truncate.c
@@ -54,8 +54,6 @@
  * Included Files
  ****************************************************************************/
 
-#include <tinyara/config.h>
-
 #include <unistd.h>
 #include <fcntl.h>
 #include <errno.h>

--- a/os/fs/procfs/fs_procfs.c
+++ b/os/fs/procfs/fs_procfs.c
@@ -210,6 +210,7 @@ const struct mountpt_operations procfs_operations = {
 	NULL,						/* sync */
 	procfs_dup,					/* dup */
 	NULL,						/* fstat */
+	NULL,						/* truncate */
 
 	procfs_opendir,				/* opendir */
 	procfs_closedir,			/* closedir */

--- a/os/fs/romfs/fs_romfs.c
+++ b/os/fs/romfs/fs_romfs.c
@@ -132,8 +132,9 @@ const struct mountpt_operations romfs_operations = {
 	NULL,						/* sync */
 	romfs_dup,					/* dup */
 	romfs_fstat,					/* fstat */
+	NULL,						/* truncate */
 
-	romfs_opendir,				/* opendir */
+	romfs_opendir,					/* opendir */
 	NULL,						/* closedir */
 	romfs_readdir,				/* readdir */
 	romfs_rewinddir,			/* rewinddir */

--- a/os/fs/smartfs/Kconfig
+++ b/os/fs/smartfs/Kconfig
@@ -20,6 +20,7 @@ menu "SMARTFS options"
 config SMARTFS_ERASEDSTATE
 	hex "FLASH erased state"
 	default 0xff
+	range 0x00 0xff
 	---help---
 		The erased state of FLASH.
 		This must have one of the values of 0xff or 0x00.

--- a/os/fs/smartfs/smartfs.h
+++ b/os/fs/smartfs/smartfs.h
@@ -492,7 +492,7 @@ struct journal_transaction_manager_s {
  ****************************************************************************/
 
 /****************************************************************************
- * Internal function prototypes
+ * Public Functions
  ****************************************************************************/
 
 /* Semaphore access for internal use */
@@ -506,19 +506,25 @@ struct smartfs_mountpt_s;
 
 /* Utility functions */
 
-int smartfs_mount(struct smartfs_mountpt_s *fs, bool writeable);
+int smartfs_mount(FAR struct smartfs_mountpt_s *fs, bool writeable);
 
-int smartfs_unmount(struct smartfs_mountpt_s *fs);
+int smartfs_unmount(FAR struct smartfs_mountpt_s *fs);
 
-int smartfs_finddirentry(struct smartfs_mountpt_s *fs, struct smartfs_entry_s *direntry, const char *relpath, uint16_t *parentdirsector, const char **filename);
+int smartfs_finddirentry(FAR struct smartfs_mountpt_s *fs, FAR struct smartfs_entry_s *direntry, FAR const char *relpath, FAR uint16_t *parentdirsector, FAR const char **filename);
 
-int smartfs_createentry(struct smartfs_mountpt_s *fs, uint16_t parentdirsector, const char *filename, uint16_t type, mode_t mode, struct smartfs_entry_s *direntry, uint16_t sectorno, FAR struct smartfs_ofile_s *sf);
+int smartfs_createentry(FAR struct smartfs_mountpt_s *fs, uint16_t parentdirsector, FAR const char* filename, uint16_t type, mode_t mode, FAR struct smartfs_entry_s *direntry, uint16_t sectorno, FAR struct smartfs_ofile_s *sf);
 
-int smartfs_deleteentry(struct smartfs_mountpt_s *fs, struct smartfs_entry_s *entry);
+int smartfs_deleteentry(FAR struct smartfs_mountpt_s *fs, FAR struct smartfs_entry_s *entry);
 
-int smartfs_countdirentries(struct smartfs_mountpt_s *fs, struct smartfs_entry_s *entry);
+int smartfs_countdirentries(FAR struct smartfs_mountpt_s *fs, FAR struct smartfs_entry_s *entry);
 
-int smartfs_truncatefile(struct smartfs_mountpt_s *fs, struct smartfs_entry_s *entry, FAR struct smartfs_ofile_s *sf);
+int smartfs_sync_internal(FAR struct smartfs_mountpt_s *fs, FAR struct smartfs_ofile_s *sf);
+
+off_t smartfs_seek_internal(FAR struct smartfs_mountpt_s *fs, FAR struct smartfs_ofile_s *sf, off_t offset, int whence);
+
+int smartfs_shrinkfile(FAR struct smartfs_mountpt_s *fs, FAR struct smartfs_ofile_s *sf, off_t length);
+
+int smartfs_extendfile(FAR struct smartfs_mountpt_s *fs, FAR struct smartfs_ofile_s *sf, off_t length);
 
 uint16_t smartfs_rdle16(FAR const void *val);
 

--- a/os/fs/smartfs/smartfs.h
+++ b/os/fs/smartfs/smartfs.h
@@ -225,6 +225,11 @@
 
 #define SMARTFS_ERASEDSTATE_16BIT (uint16_t)((CONFIG_SMARTFS_ERASEDSTATE << 8) | \
 								  CONFIG_SMARTFS_ERASEDSTATE)
+/* Size of temporary buffer used when a file is zero extended by ftruncate()
+ * logic.
+ */
+
+#define SMARTFS_TRUNCBUFFER_SIZE 512
 
 #ifndef offsetof
 #define offsetof(type, member)   ((size_t)&(((type *)0)->member))

--- a/os/fs/smartfs/smartfs_smart.c
+++ b/os/fs/smartfs/smartfs_smart.c
@@ -100,6 +100,7 @@ static int smartfs_ioctl(FAR struct file *filep, int cmd, unsigned long arg);
 static int smartfs_sync(FAR struct file *filep);
 static int smartfs_dup(FAR const struct file *oldp, FAR struct file *newp);
 static int smartfs_fstat(FAR const struct file *filep, FAR struct stat *buf);
+static int smartfs_truncate(FAR struct file *filep, off_t length);
 
 static int smartfs_opendir(struct inode *mountpt, const char *relpath, struct fs_dirent_s *dir);
 static int smartfs_readdir(struct inode *mountpt, struct fs_dirent_s *dir);
@@ -145,7 +146,7 @@ const struct mountpt_operations smartfs_operations = {
 	smartfs_sync,				/* sync */
 	smartfs_dup,				/* dup */
 	smartfs_fstat,				/* fstat */
-	NULL,					/* ftruncate */
+	smartfs_truncate,			/* ftruncate */
 
 	smartfs_opendir,			/* opendir */
 	NULL,					/* closedir */
@@ -1319,6 +1320,263 @@ static int smartfs_fstat(FAR const struct file *filep, FAR struct stat *buf)
 	smartfs_stat_common(fs, &sf->entry, buf);
 	smartfs_semgive(fs);
 	return OK;
+}
+
+/****************************************************************************
+ * Name: smartfs_truncate
+ *
+ * Description:
+ *   Set the length of the open, regular file associated with the file
+ *   structure 'filep' to 'length'.
+ *
+ ****************************************************************************/
+
+static int smartfs_truncate(FAR struct file *filep, off_t length)
+{
+	struct smart_read_write_s readwrite;
+	FAR struct inode *inode;
+	FAR struct smartfs_mountpt_s *fs;
+	FAR struct smartfs_ofile_s *sf;
+	FAR struct smartfs_chain_header_s *header;
+#ifndef CONFIG_SMARTFS_USE_SECTOR_BUFFER
+	FAR uint8_t *buffer;
+#endif
+	off_t remaining;
+	off_t savepos;
+	off_t oldsize;
+	int ret;
+
+	DEBUGASSERT(filep->f_priv != NULL && filep->f_inode != NULL);
+
+	/* Recover our private data from the struct file instance */
+
+	sf = filep->f_priv;
+	inode = filep->f_inode;
+	fs = inode->i_private;
+
+	DEBUGASSERT(fs != NULL);
+
+	/* Take the semaphore */
+
+	smartfs_semtake(fs);
+
+	/* Test the permissions.  Only allow truncation if the file was opened with
+	 * write flags.
+	 */
+
+	if ((sf->oflags & O_WROK) == 0) {
+		ret = -EACCES;
+		goto errout_with_semaphore;
+	}
+
+	/* Are we shrinking the file?  Or extending it? */
+
+	oldsize = sf->entry.datlen;
+	if (oldsize == length) {
+		ret = OK;
+		goto errout_with_semaphore;
+	} else if (oldsize > length) {
+		/* We are shrinking the file */
+		/* REVISIT:  Logic to shrink the file has not yet been implemented */
+
+		ret = -ENOSYS;
+		goto errout_with_semaphore;
+	}
+
+	/* Otherwise we are extending the file.  This is essentially the same as a
+	 * write except that (1) we write zeros and (2) we don't update the file
+	 * position.
+	 */
+
+#ifndef CONFIG_SMARTFS_USE_SECTOR_BUFFER
+	/* In order to perform the writes we will have to have a sector buffer.  If
+	 * SmartFS is not configured with a sector buffer then we will, then we
+	 * will, unfortunately, need to allocate one.
+	 */
+
+	buffer = (FAR uint8_t *)kmm_malloc(SMARTFS_TRUNCBUFFER_SIZE);
+	if (buffer == NULL) {
+		ret = -ENOMEM;
+		goto errout_with_semaphore;
+	}
+#endif
+
+	/* Seek to the end of the file (remembering the current file position) */
+
+	savepos = sf->filepos;
+	(void)smartfs_seek_internal(fs, sf, 0, SEEK_END);
+
+	/* Loop until either (1) the file has been fully extended with zeroed data
+	 * or (2) an error occurs.  We assume we start with the current sector in
+	 * cache (ff_currentsector)
+	 */
+
+	remaining = length - oldsize;
+	while (remaining > 0) {
+		/* We will fill up the current sector. Write data to the current
+		 * sector first.
+		 */
+
+#ifdef CONFIG_SMARTFS_USE_SECTOR_BUFFER
+		readwrite.count = fs->fs_llformat.availbytes - sf->curroffset;
+		if (readwrite.count > remaining) {
+			readwrite.count = remaining;
+		}
+
+		memset(&sf->buffer[sf->curroffset], 0, readwrite.count);
+		sf->bflags |= SMARTFS_BFLAG_DIRTY;
+
+#else  /* CONFIG_SMARTFS_USE_SECTOR_BUFFER */
+		readwrite.offset = sf->curroffset;
+		readwrite.logsector = sf->currsector;
+		readwrite.buffer = buffer;
+
+		/* Select max size that available in the current sector */
+
+		readwrite.count = fs->fs_llformat.availbytes - sf->curroffset;
+		if (readwrite.count > remaining) {
+			/* Limit the write to the size for our smaller working buffer*/
+
+			readwrite.count = SMARTFS_TRUNCBUFFER_SIZE;
+		}
+
+		if (readwrite.count > remaining) {
+			/* Futher limit the write to the remaining bytes to write */
+
+			readwrite.count = remaining;
+		}
+
+		/* Perform the write */
+
+		if (readwrite.count > 0) {
+			ret = FS_IOCTL(fs, BIOC_WRITESECT, (unsigned long) &readwrite);
+			if (ret < 0) {
+				fdbg("ERROR: Error %d writing sector %d data\n", ret, sf->currsector);
+				goto errout_with_buffer;
+			}
+		}
+#endif  /* CONFIG_SMARTFS_USE_SECTOR_BUFFER */
+
+		/* Update our control variables */
+
+		sf->entry.datlen += readwrite.count;
+		sf->byteswritten += readwrite.count;
+		sf->curroffset += readwrite.count;
+		remaining -= readwrite.count;
+
+		/* Test if we wrote a full sector of data */
+
+#ifdef CONFIG_SMARTFS_USE_SECTOR_BUFFER
+		if (sf->curroffset == fs->fs_llformat.availbytes && remaining) {
+			/* First get a new chained sector */
+
+			ret = FS_IOCTL(fs, BIOC_ALLOCSECT, 0xFFFF);
+			if (ret < 0) {
+				fdbg("ERROR: Error %d allocating new sector\n", ret);
+				goto errout_with_buffer;
+			}
+
+			/* Copy the new sector to the old one and chain it */
+
+			header = (struct smartfs_chain_header_s *) sf->buffer;
+			*((uint16_t *) header->nextsector) = (uint16_t) ret;
+
+			/* Now sync the file to write this sector out */
+
+			ret = smartfs_sync_internal(fs, sf);
+			if (ret != OK) {
+				goto errout_with_buffer;
+			}
+
+			/* Record the new sector in our tracking variables and reset the
+			 * offset to "zero".
+			 */
+
+			if (sf->currsector == SMARTFS_NEXTSECTOR(header)) {
+				/* Error allocating logical sector! */
+
+				fdbg("ERROR: Duplicate logical sector %d\n", sf->currsector);
+			}
+
+			sf->bflags = SMARTFS_BFLAG_DIRTY;
+			sf->currsector = SMARTFS_NEXTSECTOR(header);
+			sf->curroffset = sizeof(struct smartfs_chain_header_s);
+			memset(sf->buffer, CONFIG_SMARTFS_ERASEDSTATE, fs->fs_llformat.availbytes);
+			header->type = SMARTFS_DIRENT_TYPE_FILE;
+		}
+#else  /* CONFIG_SMARTFS_USE_SECTOR_BUFFER */
+
+		if (sf->curroffset == fs->fs_llformat.availbytes) {
+			/* Sync the file to write this sector out */
+
+			ret = smartfs_sync_internal(fs, sf);
+			if (ret != OK) {
+				goto errout_with_buffer;
+			}
+
+			/* Allocate a new sector if needed */
+
+			if (remaining > 0) {
+				/* Allocate a new sector */
+
+				ret = FS_IOCTL(fs, BIOC_ALLOCSECT, 0xFFFF);
+				if (ret < 0) {
+					fdbg("ERROR: Error %d allocating new sector\n", ret);
+					goto errout_with_buffer;
+				}
+
+				/* Copy the new sector to the old one and chain it */
+
+				header = (struct smartfs_chain_header_s *)fs->fs_rwbuffer;
+				*((uint16_t *) header->nextsector) = (uint16_t) ret;
+
+				readwrite.offset = offsetof(struct smartfs_chain_header_s, nextsector);
+				readwrite.buffer = (uint8_t *) header->nextsector;
+				readwrite.count = sizeof(uint16_t);
+
+				ret = FS_IOCTL(fs, BIOC_WRITESECT, (unsigned long) &readwrite);
+				if (ret < 0) {
+					fdbg("ERROR: Error %d writing next sector\n", ret);
+					goto errout_with_buffer;
+				}
+
+				/* Record the new sector in our tracking variables and
+				 * reset the offset to "zero".
+				 */
+
+				if (sf->currsector == SMARTFS_NEXTSECTOR(header)) {
+					/* Error allocating logical sector! */
+
+					fdbg("ERROR: Duplicate logical sector %d\n", sf->currsector);
+				}
+
+				sf->currsector = SMARTFS_NEXTSECTOR(header);
+				sf->curroffset = sizeof(struct smartfs_chain_header_s);
+			}
+		}
+#endif /* CONFIG_SMARTFS_USE_SECTOR_BUFFER */
+	}
+
+	/* The file was successfully extended with zeros */
+
+	ret = OK;
+
+errout_with_buffer:
+	/* Restore the original file position */
+
+	(void)smartfs_seek_internal(fs, sf, savepos, SEEK_SET);
+
+	/* Release the allocated buffer */
+
+#ifdef CONFIG_SMARTFS_USE_SECTOR_BUFFER
+	kmm_free(buffer);
+#endif
+
+errout_with_semaphore:
+	/* Relinquish exclusive access */
+
+	smartfs_semgive(fs);
+	return ret;
 }
 
 /****************************************************************************

--- a/os/fs/smartfs/smartfs_smart.c
+++ b/os/fs/smartfs/smartfs_smart.c
@@ -145,9 +145,10 @@ const struct mountpt_operations smartfs_operations = {
 	smartfs_sync,				/* sync */
 	smartfs_dup,				/* dup */
 	smartfs_fstat,				/* fstat */
+	NULL,					/* ftruncate */
 
 	smartfs_opendir,			/* opendir */
-	NULL,						/* closedir */
+	NULL,					/* closedir */
 	smartfs_readdir,			/* readdir */
 	smartfs_rewinddir,			/* rewinddir */
 

--- a/os/fs/smartfs/smartfs_utils.c
+++ b/os/fs/smartfs/smartfs_utils.c
@@ -1579,84 +1579,349 @@ errout:
 }
 
 /****************************************************************************
- * Name: smartfs_truncatefile
+ * Name: smartfs_sync_internal
  *
- * Description: Truncates an existing file on the device so that it occupies
- *              zero bytes and can be completely re-written.
+ * Description: 
+ *   Synchronize the file state on disk to match internal, in-memory state.
  *
  ****************************************************************************/
 
-int smartfs_truncatefile(struct smartfs_mountpt_s *fs, struct smartfs_entry_s *entry, FAR struct smartfs_ofile_s *sf)
+int smartfs_sync_internal(FAR struct smartfs_mountpt_s *fs, FAR struct smartfs_ofile_s *sf)
 {
-	int ret;
-	uint16_t nextsector;
-	uint16_t sector;
-	struct smartfs_chain_header_s *header;
+	FAR struct smartfs_chain_header_s *header;
 	struct smart_read_write_s readwrite;
+	int ret = OK;
+#ifdef CONFIG_SMARTFS_USE_SECTOR_BUFFER
+	if (sf->bflags & SMARTFS_BFLAG_DIRTY) {
+		/* Update the header with the number of bytes written */
 
-	/* Walk through the directory's sectors and count entries */
+		header = (struct smartfs_chain_header_s *)sf->buffer;
+		if (*((uint16_t *)header->used) == SMARTFS_ERASEDSTATE_16BIT) {
+			*((uint16_t *)header->used) = sf->byteswritten;
+		} else {
+			*((uint16_t *)header->used) += sf->byteswritten;
+		}
 
-	nextsector = entry->firstsector;
+		/* Write the entire sector to FLASH */
+
+		readwrite.logsector = sf->currsector;
+		readwrite.offset = 0;
+		readwrite.count = fs->fs_llformat.availbytes;
+		readwrite.buffer = sf->buffer;
+
+		ret = FS_IOCTL(fs, BIOC_WRITESECT, (unsigned long)&readwrite);
+		if (ret < 0) {
+			fdbg("ERROR: Error %d writing used bytes for sector %d\n", sf->currsector);
+			goto errout;
+		}
+
+		sf->byteswritten = 0;
+		sf->bflags = 0;
+	}
+#else  /* CONFIG_SMARTFS_USE_SECTOR_BUFFER */
+
+	/* Test if we have written bytes to the current sector that
+	 * need to be recorded in the chain header's used bytes field. */
+
+	if (sf->byteswritten > 0) {
+		fvdbg("Syncing sector %d\n", sf->currsector);
+
+		/* Read the existing sector used bytes value */
+
+		readwrite.logsector = sf->currsector;
+		readwrite.offset = 0;
+		readwrite.buffer = (uint8_t *)fs->fs_rwbuffer;
+		readwrite.count = sizeof(struct smartfs_chain_header_s);
+
+		ret = FS_IOCTL(fs, BIOC_READSECT, (unsigned long)&readwrite);
+		if (ret < 0) {
+			fdbg("ERROR: Error %d reading sector %d data\n", ret, sf->currsector);
+			goto errout;
+		}
+
+		/* Add new byteswritten to existing value */
+
+		header = (struct smartfs_chain_header_s *)fs->fs_rwbuffer;
+		if (*((uint16_t *) header->used) == SMARTFS_ERASEDSTATE_16BIT) {
+			*((uint16_t *)header->used) = sf->byteswritten;
+		} else {
+			*((uint16_t *)header->used) += sf->byteswritten;
+		}
+
+		readwrite.offset = offsetof(struct smartfs_chain_header_s, used);
+		readwrite.count  = sizeof(uint16_t);
+		readwrite.buffer = (uint8_t *)&fs->fs_rwbuffer[readwrite.offset];
+
+		ret = FS_IOCTL(fs, BIOC_WRITESECT, (unsigned long)&readwrite);
+		if (ret < 0) {
+			fdbg("ERROR: Error %d writing used bytes for sector %d\n", ret, sf->currsector);
+			goto errout;
+		}
+
+		sf->byteswritten = 0;
+	}
+#endif  /* CONFIG_SMARTFS_USE_SECTOR_BUFFER */
+
+errout:
+	return ret;
+}
+
+/****************************************************************************
+ * Name: smartfs_seek_internal
+ *
+ * Description:
+ *   Performs the logic of the seek function.  This is an internal function
+ *   because it does not provide semaphore protection and therefore must be
+ *   called from one of the other public interface routines (open, seek,
+ *   etc.).
+ *
+ ****************************************************************************/
+
+off_t smartfs_seek_internal(FAR struct smartfs_mountpt_s *fs, FAR struct smartfs_ofile_s *sf, off_t offset, int whence)
+{
+	FAR struct smartfs_chain_header_s *header;
+	struct smart_read_write_s readwrite;
+	off_t newpos;
+	off_t sectorstartpos;
+	int ret;
+
+	/* Test if this is a seek to get the current file pos */
+
+	if ((whence == SEEK_CUR) && (offset == 0)) {
+		return sf->filepos;
+	}
+
+	/* Test if we need to sync the file */
+
+	if (sf->byteswritten > 0) {
+		/* Perform a sync */
+
+		smartfs_sync_internal(fs, sf);
+	}
+
+	/* Calculate the file position to seek to based on current position */
+
+	switch (whence) {
+	case SEEK_SET:
+	default:
+		newpos = offset;
+		break;
+
+	case SEEK_CUR:
+		newpos = sf->filepos + offset;
+		break;
+
+	case SEEK_END:
+		newpos = sf->entry.datlen + offset;
+		break;
+	}
+
+	/* Ensure newpos is in range */
+
+	if (newpos < 0) {
+		newpos = 0;
+	}
+
+	if (newpos > sf->entry.datlen) {
+		newpos = sf->entry.datlen;
+	}
+
+	/* Now perform the seek.  Test if we are seeking within the current
+	 * sector and can skip the search to save time.
+	 */
+
+	sectorstartpos = sf->filepos - (sf->curroffset - sizeof(struct smartfs_chain_header_s));
+
+	if (newpos >= sectorstartpos && newpos < sectorstartpos + fs->fs_llformat.availbytes - sizeof(struct smartfs_chain_header_s)) {
+		/* Seeking within the current sector.  Just update the offset */
+
+		sf->curroffset = sizeof(struct smartfs_chain_header_s) + newpos-sectorstartpos;
+		sf->filepos = newpos;
+
+		return newpos;
+	}
+
+	/* Nope, we have to search for the sector and offset.  If the new pos is greater
+	 * than the current pos, then we can start from the beginning of the current
+	 * sector, otherwise we have to start from the beginning of the file.
+	 */
+
+	if (newpos > sf->filepos) {
+		sf->filepos = sectorstartpos;
+	} else {
+		sf->currsector = sf->entry.firstsector;
+		sf->filepos = 0;
+	}
+
 	header = (struct smartfs_chain_header_s *)fs->fs_rwbuffer;
+	while ((sf->currsector != SMARTFS_ERASEDSTATE_16BIT) && (sf->filepos + fs->fs_llformat.availbytes - sizeof(struct smartfs_chain_header_s) < newpos)) {
+		/* Read the sector's header */
 
-	while (nextsector != SMARTFS_ERASEDSTATE_16BIT) {
-		/* Read the next sector's header into our buffer */
-
-		readwrite.logsector = nextsector;
+		readwrite.logsector = sf->currsector;
 		readwrite.offset = 0;
 		readwrite.count = sizeof(struct smartfs_chain_header_s);
 		readwrite.buffer = (uint8_t *)fs->fs_rwbuffer;
+
+		ret = FS_IOCTL(fs, BIOC_READSECT, (unsigned long)&readwrite);
+		if (ret < 0) {
+			fdbg("ERROR: Error %d reading sector %d header\n", ret, sf->currsector);
+			goto errout;
+		}
+
+		/* Point to next sector and update filepos */
+
+		sf->currsector = SMARTFS_NEXTSECTOR(header);
+		sf->filepos += SMARTFS_USED(header);
+	}
+
+#ifdef CONFIG_SMARTFS_USE_SECTOR_BUFFER
+
+	/* When using sector buffering, we must read in the last buffer to our
+	 * sf->buffer in case any changes are made.
+	 */
+
+	if (sf->currsector != SMARTFS_ERASEDSTATE_16BIT) {
+		readwrite.logsector = sf->currsector;
+		readwrite.offset = 0;
+		readwrite.count = fs->fs_llformat.availbytes;
+		readwrite.buffer = (uint8_t *)sf->buffer;
+		ret = FS_IOCTL(fs, BIOC_READSECT, (unsigned long)&readwrite);
+		if (ret < 0) {
+			fdbg("ERROR: Error %d reading sector %d header\n", ret, sf->currsector);
+			goto errout;
+		}
+	}
+#endif
+
+	/* Now calculate the offset */
+
+	sf->curroffset = sizeof(struct smartfs_chain_header_s) + newpos - sf->filepos;
+	sf->filepos = newpos;
+	return newpos;
+
+errout:
+	return ret;
+}
+
+/****************************************************************************
+ * Name: smartfs_shrinkfile
+ *
+ * Description:
+ *   Shrink the size existing file to to the specified length
+ *
+ ****************************************************************************/
+
+int smartfs_shrinkfile(FAR struct smartfs_mountpt_s *fs, FAR struct smartfs_ofile_s *sf, off_t length)
+{
+	FAR struct smartfs_chain_header_s *header;
+	FAR struct smartfs_entry_s *entry;
+	FAR uint8_t *dest;
+	struct smart_read_write_s readwrite;
+	uint16_t nextsector;
+	uint16_t sector;
+	off_t remaining;
+	off_t destsize;
+	off_t available;
+	off_t offset;
+	int ret;
+
+	/* Walk through the directory's sectors and count entries */
+
+	entry = &sf->entry;
+	nextsector = entry->firstsector;
+	header = (struct smartfs_chain_header_s *)fs->fs_rwbuffer;
+	remaining = length;
+	available = fs->fs_llformat.availbytes - sizeof(struct smartfs_chain_header_s);
+
+	while (nextsector != SMARTFS_ERASEDSTATE_16BIT) {
+		/* Read the next sector into our buffer */
+
+		readwrite.logsector = nextsector;
+		readwrite.offset = 0;
+		readwrite.count = fs->fs_llformat.availbytes;
+		readwrite.buffer = (uint8_t *)fs->fs_rwbuffer;
+
 		ret = FS_IOCTL(fs, BIOC_READSECT, (unsigned long)&readwrite);
 		if (ret < 0) {
 			fdbg("Error reading sector %d header\n", nextsector);
-			goto errout;
+			return ret;
 		}
 
 		/* Get the next chained sector */
 
 		sector = SMARTFS_NEXTSECTOR(header);
 
-		/* If this is the 1st sector of the file, then just overwrite
-		 * the sector data with the erased state value.  The underlying
-		 * SMART block driver will detect this and release the old
-		 * sector and create a new one with the new (blank) data.
+#ifdef CONFIG_SMARTFS_USE_SECTOR_BUFFER
+		/* When we have a sector buffer in use, simply skip the first sector.
+		 * It will be handled below.
 		 */
 
 		if (nextsector == entry->firstsector) {
-#ifdef CONFIG_SMARTFS_USE_SECTOR_BUFFER
+			if (remaining > available) {
+				remaining -= available;
+			} else {
+				remaining = 0;
+			}
+		} else
+#endif
+			/* Are we retaining the sector it its entirety? */
 
-			/* When we have a sector buffer in use, simply skip the first sector */
+		if (remaining >= available) {
+		/* Yes... skip to the next sector */
 
-			nextsector = sector;
-			continue;
+			remaining -= available;
+		}
 
-#else
+		/* Are we removing the sector it its entirety? */
 
-			/* Fill our buffer with erased data */
+		else if (remaining <= 0 && nextsector != entry->firstsector) {
+			/* Yes.. just release the sector */
 
-			memset(fs->fs_rwbuffer, CONFIG_SMARTFS_ERASEDSTATE, fs->fs_llformat.availbytes);
+			ret = FS_IOCTL(fs, BIOC_FREESECT, (unsigned long)nextsector);
+			if (ret < 0) {
+				fdbg("ERROR: Error freeing sector %d\n", nextsector);
+				return ret;
+			}
+		} else {
+			/* No.. Fill our buffer with erased data, retaining any still-
+			 * valid bytes at the beginning of the buffer.
+			 *
+			 * Because of the preceding tests we know that
+			 * 0 <= remaining < available.  A special case is remaining == 0
+			 * and nextsector == firstsector.  In that case, we need to
+			 * overwrite the sector data with the erased state value.  The
+			 * underlying SMART block driver will detect this and release the
+			 * old sector and create a new one with the new (blank) data.
+			 *
+			 * Otherwise, we need to preserve the header and overwrite some of
+			 * the data.
+			 */
+
+			if (remaining == 0) {
+				dest = (FAR uint8_t *)fs->fs_rwbuffer;
+				destsize = fs->fs_llformat.availbytes;
+			} else {
+				offset = sizeof(struct smartfs_chain_header_s) + remaining;
+				dest = (FAR uint8_t *)&fs->fs_rwbuffer[offset];
+				destsize = fs->fs_llformat.availbytes - offset;
+
+				*((uint16_t *)header->used) = remaining;
+				*((uint16_t *)header->nextsector) = SMARTFS_ERASEDSTATE_16BIT;
+
+				remaining = 0;
+			}
+
+			memset(dest, CONFIG_SMARTFS_ERASEDSTATE, destsize);
 			header->type = SMARTFS_SECTOR_TYPE_FILE;
 
 			/* Now write the new sector data */
 
 			readwrite.count = fs->fs_llformat.availbytes;
+
 			ret = FS_IOCTL(fs, BIOC_WRITESECT, (unsigned long)&readwrite);
 			if (ret < 0) {
-				fdbg("Error blanking 1st sector (%d) of file\n", nextsector);
-				goto errout;
-			}
-
-			/* Set the entry's data length to zero ... we just truncated */
-
-			entry->datlen = 0;
-#endif							/* CONFIG_SMARTFS_USE_SECTOR_BUFFER */
-		} else {
-			/* Not the 1st sector -- release it */
-
-			ret = FS_IOCTL(fs, BIOC_FREESECT, (unsigned long)nextsector);
-			if (ret < 0) {
-				fdbg("Error freeing sector %d\n", nextsector);
-				goto errout;
+				fdbg("ERROR: Error blanking 1st sector (%d) of file\n", nextsector);
+				return ret;
 			}
 		}
 
@@ -1665,33 +1930,268 @@ int smartfs_truncatefile(struct smartfs_mountpt_s *fs, struct smartfs_entry_s *e
 		nextsector = sector;
 	}
 
+#ifdef CONFIG_SMARTFS_USE_SECTOR_BUFFER
 	/* Now deal with the first sector in the event we are using a sector buffer
-	   like we would be if CRC is enabled.
+	 * like we would be if CRC is enabled.
+	 *
+	 * Using sector buffer and we have an open file context.  Just update the
+	 * sector buffer in the open file context.
 	 */
 
-#ifdef CONFIG_SMARTFS_USE_SECTOR_BUFFER
-	if (sf) {
-		/* Using sector buffer and we have an open file context.  Just update
-		 * the sector buffer in the open file context.
-		 */
+	if (length < fs->fs_llformat.availbytes) {
+		/* Read the entire sector */
 
 		readwrite.logsector = entry->firstsector;
 		readwrite.offset = 0;
-		readwrite.count = sizeof(struct smartfs_chain_header_s);
-		readwrite.buffer = (uint8_t *)fs->fs_rwbuffer;
-		ret = FS_IOCTL(fs, BIOC_READSECT, (unsigned long)&readwrite);
+		readwrite.count = fs->fs_llformat.availbytes;
+		readwrite.buffer = (uint8_t *)sf->buffer;
 
-		memset(sf->buffer, CONFIG_SMARTFS_ERASEDSTATE, fs->fs_llformat.availbytes);
+		ret = FS_IOCTL(fs, BIOC_READSECT, (unsigned long)&readwrite);
+		if (ret < 0) {
+			return ret;
+		}
+
+		/* Retain any valid data at the beginning of the sector, including the
+		 * header.  Special case length == 0
+		 */
+
+		if (length == 0) {
+			dest = (FAR uint8_t *)&sf->buffer;
+			destsize = fs->fs_llformat.availbytes;
+		} else {
+			offset = sizeof(struct smartfs_chain_header_s) + length;
+			dest = (FAR uint8_t *)&sf->buffer[offset];
+			destsize = fs->fs_llformat.availbytes - offset;
+
+			header = (struct smartfs_chain_header_s *)sf->buffer;
+			*((uint16_t *)header->used) = length;
+			*((uint16_t *)header->nextsector) = SMARTFS_ERASEDSTATE_16BIT;
+		}
+
+		memset(dest, CONFIG_SMARTFS_ERASEDSTATE, destsize);
+
 		header = (struct smartfs_chain_header_s *)sf->buffer;
 		header->type = SMARTFS_SECTOR_TYPE_FILE;
 		sf->bflags = SMARTFS_BFLAG_DIRTY;
-		entry->datlen = 0;
 	}
 #endif
 
+	entry->datlen = length;
+	return OK;
+}
+
+/****************************************************************************
+ * Name: smartfs_extendfile
+ *
+ * Description:
+ *   Zero-extend the length of a regular file to 'length'.
+ *
+ ****************************************************************************/
+
+int smartfs_extendfile(FAR struct smartfs_mountpt_s *fs, FAR struct smartfs_ofile_s *sf, off_t length)
+{
+	struct smart_read_write_s readwrite;
+	FAR struct smartfs_chain_header_s *header;
+#ifndef CONFIG_SMARTFS_USE_SECTOR_BUFFER
+	FAR uint8_t *buffer;
+#endif
+	off_t remaining;
+	off_t savepos;
+	off_t oldsize;
+	int ret;
+
+	/* We are zero-extending the file.  This is essentially the same as a
+	 * write except that (1) we write zeros and (2) we don't update the file
+	 * position.
+	 */
+
+#ifndef CONFIG_SMARTFS_USE_SECTOR_BUFFER
+	/* In order to perform the writes we will have to have a sector buffer.  If
+	 * SmartFS is not configured with a sector buffer then we will, then we
+	 * will, unfortunately, need to allocate one.
+	 */
+
+	buffer = (FAR uint8_t *)kmm_malloc(SMARTFS_TRUNCBUFFER_SIZE);
+	if (buffer == NULL) {
+		return -ENOMEM;
+	}
+#endif
+
+	/* Loop until either (1) the file has been fully extended with zeroed data
+	 * or (2) an error occurs.  We assume we start with the current sector in
+	 * cache (ff_currentsector)
+	 */
+
+	oldsize = sf->entry.datlen;
+	remaining = length - oldsize;
+	DEBUGASSERT(length > oldsize);
+
+	/* Seek to the end of the file for the append/write operation, remembering
+	 * the current file position.  It will be retored before returneding; the
+	 * truncate operation must not alter the file position.
+	 */
+
+	savepos = sf->filepos;
+	(void)smartfs_seek_internal(fs, sf, 0, SEEK_END);
+
+	while (remaining > 0) {
+		/* We will fill up the current sector. Write data to the current
+		 * sector first.
+		 */
+
+#ifdef CONFIG_SMARTFS_USE_SECTOR_BUFFER
+		readwrite.count = fs->fs_llformat.availbytes - sf->curroffset;
+		if (readwrite.count > remaining) {
+			readwrite.count = remaining;
+		}
+
+		memset(&sf->buffer[sf->curroffset], 0, readwrite.count);
+		sf->bflags |= SMARTFS_BFLAG_DIRTY;
+
+#else  /* CONFIG_SMARTFS_USE_SECTOR_BUFFER */
+		readwrite.offset = sf->curroffset;
+		readwrite.logsector = sf->currsector;
+		readwrite.buffer = buffer;
+
+		/* Select max size that available in the current sector */
+
+		readwrite.count = fs->fs_llformat.availbytes - sf->curroffset;
+		if (readwrite.count > remaining) {
+			/* Limit the write to the size for our smaller working buffer*/
+
+			readwrite.count = SMARTFS_TRUNCBUFFER_SIZE;
+		}
+
+		if (readwrite.count > remaining) {
+			/* Futher limit the write to the remaining bytes to write */
+
+			readwrite.count = remaining;
+		}
+
+		/* Perform the write */
+
+		if (readwrite.count > 0) {
+			ret = FS_IOCTL(fs, BIOC_WRITESECT, (unsigned long)&readwrite);
+			if (ret < 0) {
+				fdbg("ERROR: Error %d writing sector %d data\n", ret, sf->currsector);
+				goto errout_with_buffer;
+			}
+		}
+#endif  /* CONFIG_SMARTFS_USE_SECTOR_BUFFER */
+
+		/* Update our control variables */
+
+		sf->entry.datlen += readwrite.count;
+		sf->byteswritten += readwrite.count;
+		sf->curroffset += readwrite.count;
+		remaining -= readwrite.count;
+
+		/* Test if we wrote a full sector of data */
+
+#ifdef CONFIG_SMARTFS_USE_SECTOR_BUFFER
+		if (sf->curroffset == fs->fs_llformat.availbytes && remaining) {
+			/* First get a new chained sector */
+
+			ret = FS_IOCTL(fs, BIOC_ALLOCSECT, 0xFFFF);
+			if (ret < 0) {
+				fdbg("ERROR: Error %d allocating new sector\n", ret);
+				goto errout_with_buffer;
+			}
+
+			/* Copy the new sector to the old one and chain it */
+
+			header = (struct smartfs_chain_header_s *)sf->buffer;
+			*((uint16_t *)header->nextsector) = (uint16_t)ret;
+
+			/* Now sync the file to write this sector out */
+
+			ret = smartfs_sync_internal(fs, sf);
+			if (ret != OK) {
+				goto errout_with_buffer;
+			}
+
+			/* Record the new sector in our tracking variables and reset the
+			 * offset to "zero".
+			 */
+
+			if (sf->currsector == SMARTFS_NEXTSECTOR(header)) {
+				/* Error allocating logical sector! */
+
+				fdbg("ERROR: Duplicate logical sector %d\n", sf->currsector);
+			}
+
+			sf->bflags = SMARTFS_BFLAG_DIRTY;
+			sf->currsector = SMARTFS_NEXTSECTOR(header);
+			sf->curroffset = sizeof(struct smartfs_chain_header_s);
+			memset(sf->buffer, CONFIG_SMARTFS_ERASEDSTATE, fs->fs_llformat.availbytes);
+			header->type = SMARTFS_DIRENT_TYPE_FILE;
+		}
+#else  /* CONFIG_SMARTFS_USE_SECTOR_BUFFER */
+
+		if (sf->curroffset == fs->fs_llformat.availbytes) {
+			/* Sync the file to write this sector out */
+
+			ret = smartfs_sync_internal(fs, sf);
+			if (ret != OK) {
+				goto errout_with_buffer;
+			}
+
+			/* Allocate a new sector if needed */
+
+			if (remaining > 0) {
+				/* Allocate a new sector */
+
+				ret = FS_IOCTL(fs, BIOC_ALLOCSECT, 0xFFFF);
+				if (ret < 0) {
+					fdbg("ERROR: Error %d allocating new sector\n", ret);
+					goto errout_with_buffer;
+				}
+
+				/* Copy the new sector to the old one and chain it */
+
+				header = (struct smartfs_chain_header_s *)fs->fs_rwbuffer;
+				*((FAR uint16_t *)header->nextsector) = (uint16_t)ret;
+
+				readwrite.offset = offsetof(struct smartfs_chain_header_s, nextsector);
+				readwrite.buffer = (FAR uint8_t *)header->nextsector;
+				readwrite.count = sizeof(uint16_t);
+
+				ret = FS_IOCTL(fs, BIOC_WRITESECT, (unsigned long) &readwrite);
+				if (ret < 0) {
+					fdbg("ERROR: Error %d writing next sector\n", ret);
+					goto errout_with_buffer;
+				}
+
+				/* Record the new sector in our tracking variables and
+				 * reset the offset to "zero".
+				 */
+
+				if (sf->currsector == SMARTFS_NEXTSECTOR(header)) {
+					/* Error allocating logical sector! */
+
+					fdbg("ERROR: Duplicate logical sector %d\n", sf->currsector);
+				}
+
+				sf->currsector = SMARTFS_NEXTSECTOR(header);
+				sf->curroffset = sizeof(struct smartfs_chain_header_s);
+			}
+		}
+#endif /* CONFIG_SMARTFS_USE_SECTOR_BUFFER */
+	}
+
+	/* The file was successfully extended with zeros */
+
 	ret = OK;
 
-errout:
+errout_with_buffer:
+#ifdef CONFIG_SMARTFS_USE_SECTOR_BUFFER
+	/* Release the allocated buffer */
+
+	kmm_free(buffer);
+#endif
+	/* Restore the original file position */
+
+	(void)smartfs_seek_internal(fs, sf, savepos, SEEK_SET);
 	return ret;
 }
 

--- a/os/fs/vfs/Make.defs
+++ b/os/fs/vfs/Make.defs
@@ -85,7 +85,7 @@ CSRCS += fs_stat.c fs_statfs.c fs_select.c fs_unlink.c fs_write.c
 # Certain interfaces are not available if there is no mountpoint support
 
 ifneq ($(CONFIG_DISABLE_MOUNTPOINT),y)
-CSRCS += fs_fsync.c
+CSRCS += fs_fsync.c fs_truncate.c
 endif
 
 # Support for positional file access

--- a/os/fs/vfs/fs_truncate.c
+++ b/os/fs/vfs/fs_truncate.c
@@ -54,8 +54,6 @@
  * Included Files
  ****************************************************************************/
 
-#include <tinyara/config.h>
-
 #include <unistd.h>
 #include <fcntl.h>
 #include <errno.h>
@@ -188,8 +186,6 @@ int ftruncate(int fd, off_t length)
 		fdbg("ERROR: Could no get file structure: %d\n", ret);
 		goto errout;
 	}
-
-	DEBUGASSERT(filep != NULL);
 
 	/* Perform the truncate operation */
 

--- a/os/fs/vfs/fs_truncate.c
+++ b/os/fs/vfs/fs_truncate.c
@@ -138,7 +138,6 @@ int file_truncate(FAR struct file *filep, off_t length)
  *   references a shared memory object, ftruncate() sets the size of the
  *   shared memory object to length. If the file is not a regular file or
  *   a shared memory object, the result is unspecified.
-
  *   With ftruncate(), the file must be open for writing; for truncate(),
  *   the process must have write permission for the file.
  *
@@ -199,7 +198,7 @@ int ftruncate(int fd, off_t length)
 		return 0;
 	}
 
-	fwdbg("WARNING: file_truncate() failed: %d\n", ret);
+	fwdbg("WARNING: file_truncate() failed\n", ret);
 
 errout:
 	set_errno(-ret);

--- a/os/fs/vfs/fs_truncate.c
+++ b/os/fs/vfs/fs_truncate.c
@@ -1,0 +1,207 @@
+/****************************************************************************
+ *
+ * Copyright 2018 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+/****************************************************************************
+ * os/fs/vfs/fs_truncate.c
+ *
+ *   Copyright (C) 2018 Gregory Nutt. All rights reserved.
+ *   Author: Gregory Nutt <gnutt@nuttx.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <tinyara/config.h>
+
+#include <unistd.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <assert.h>
+#include <debug.h>
+#include <tinyara/fs/fs.h>
+
+#include "inode/inode.h"
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: file_truncate
+ *
+ * Description:
+ *   Equivalent to the standard ftruncate() function except that is accepts
+ *   a struct file instance instead of a file descriptor and it does not set
+ *   the errno variable.
+ *
+ ****************************************************************************/
+
+int file_truncate(FAR struct file *filep, off_t length)
+{
+	struct inode *inode;
+
+	/* Was this file opened for write access? */
+
+	if ((filep->f_oflags & O_WROK) == 0) {
+		fwdbg("WARNING: Cannot truncate a file opened read-only\n");
+		return -EBADF;
+	}
+
+	/* Is this inode a registered mountpoint? Does it support the
+	 * truncate operations may be relevant to device drivers but only
+	 * the mountpoint operations vtable contains a truncate method.
+	 */
+
+	inode = filep->f_inode;
+	if (inode == NULL || !INODE_IS_MOUNTPT(inode) || inode->u.i_mops == NULL) {
+		fwdbg("WARNING:  Not a (regular) file on a mounted file system.\n");
+		return -EBADF;
+	}
+
+	/* A NULL write() method is an indicator of a read-only file system (but
+	 * possible not the only indicator)
+	 */
+
+	if (inode->u.i_mops->write == NULL) {
+		fwdbg("WARNING: File system is read-only\n");
+		return -EBADF;
+	}
+
+	/* Does the file system support the truncate method?  It should if it is
+	 * a write-able file system.
+	 */
+
+	if (inode->u.i_mops->truncate == NULL) {
+		fwdbg("WARNING: File system does not support the truncate() method\n");
+		return -EBADF;
+	}
+
+	/* Yes, then tell the file system to truncate this file */
+
+	return inode->u.i_mops->truncate(filep, length);
+}
+
+/****************************************************************************
+ * Name: ftruncate
+ *
+ * Description:
+ *   The ftruncate() function causes the regular file referenced by fd to
+ *   have a size of length bytes.
+ *
+ *   If the file previously was larger than length, the extra data is
+ *   discarded.  If it was previously shorter than length, it is unspecified
+ *   whether the file is changed or its size increased.  If the file is
+ *   extended, the extended area appears as if it were zero-filled.  If fd
+ *   references a shared memory object, ftruncate() sets the size of the
+ *   shared memory object to length. If the file is not a regular file or
+ *   a shared memory object, the result is unspecified.
+
+ *   With ftruncate(), the file must be open for writing; for truncate(),
+ *   the process must have write permission for the file.
+ *
+ *   ftruncate() does not modify the file offset for any open file
+ *   descriptions associated with the file.
+ *
+ * Input Parameters:
+ *   fd     - A reference to an open, regular file or shared memory object
+ *            to be truncated.
+ *   length - The new length of the file or shared memory object.
+ *
+ * Returned Value:
+ *    Upon successful completion, ftruncate() return 0s. Otherwise a -1 is
+ *    returned, and errno is set to indicate the error.
+ *
+ *    EINTR
+ *      - A signal was caught during execution.
+ *    EINVAL
+ *      - The length argument was less than 0.
+ *    EFBIG or EINVAL
+ *      - The length argument was greater than the maximum file size.
+ *    EIO
+ *      - An I/O error occurred while reading from or writing to a file
+ *        system.
+ *    EBADF or EINVAL
+ *       - the fd argument is not a file descriptor open for writing.
+ *    EFBIG
+ *       - The file is a regular file and length is greater than the offset
+ *         maximum established in the open file description associated with
+ *         fd.
+ *    EINVAL
+ *       - The fd argument references a file that was opened without write
+ *         permission.
+ *    EROFS
+ *       - The named file resides on a read-only file system.
+ *
+ ****************************************************************************/
+
+int ftruncate(int fd, off_t length)
+{
+	FAR struct file *filep;
+	int ret;
+
+	/* Get the file structure corresponding to the file descriptor. */
+
+	filep = fs_getfilep(fd);
+	if (filep == NULL) {
+		fdbg("ERROR: Could no get file structure: %d\n", ret);
+		goto errout;
+	}
+
+	DEBUGASSERT(filep != NULL);
+
+	/* Perform the truncate operation */
+
+	ret = file_truncate(filep, length);
+	if (ret >= 0) {
+		return 0;
+	}
+
+	fwdbg("WARNING: file_truncate() failed: %d\n", ret);
+
+errout:
+	set_errno(-ret);
+	return ERROR;
+}

--- a/os/include/sys/syscall.h
+++ b/os/include/sys/syscall.h
@@ -295,13 +295,14 @@
 
 #if !defined(CONFIG_DISABLE_MOUNTPOINT)
 #define SYS_fsync                      (__SYS_mountpoint+0)
-#define SYS_mkdir                      (__SYS_mountpoint+1)
-#define SYS_mount                      (__SYS_mountpoint+2)
-#define SYS_rename                     (__SYS_mountpoint+3)
-#define SYS_rmdir                      (__SYS_mountpoint+4)
-#define SYS_umount                     (__SYS_mountpoint+5)
-#define SYS_unlink                     (__SYS_mountpoint+6)
-#define __SYS_shm                      (__SYS_mountpoint+7)
+#define SYS_ftruncate                  (__SYS_mountpoint+1)
+#define SYS_mkdir                      (__SYS_mountpoint+2)
+#define SYS_mount                      (__SYS_mountpoint+3)
+#define SYS_rename                     (__SYS_mountpoint+4)
+#define SYS_rmdir                      (__SYS_mountpoint+5)
+#define SYS_umount                     (__SYS_mountpoint+6)
+#define SYS_unlink                     (__SYS_mountpoint+7)
+#define __SYS_shm                      (__SYS_mountpoint+8)
 #else
 #define __SYS_shm                      __SYS_mountpoint
 #endif

--- a/os/include/tinyara/fs/fs.h
+++ b/os/include/tinyara/fs/fs.h
@@ -109,7 +109,7 @@ struct file_operations {
 	int (*open)(FAR struct file *filep);
 
 	/* The following methods must be identical in signature and position because
-	 * the struct file_operations and struct mountp_operations are treated like
+	 * the struct file_operations and struct mountpt_operations are treated like
 	 * unions.
 	 */
 
@@ -175,7 +175,7 @@ struct mountpt_operations {
 	int (*open)(FAR struct file *filep, FAR const char *relpath, int oflags, mode_t mode);
 
 	/* The following methods must be identical in signature and position
-	 * because the struct file_operations and struct mountp_operations are
+	 * because the struct file_operations and struct mountpt_operations are
 	 * treated like unions.
 	 */
 
@@ -195,6 +195,7 @@ struct mountpt_operations {
 	int (*sync)(FAR struct file *filep);
 	int (*dup)(FAR const struct file *oldp, FAR struct file *newp);
 	int (*fstat)(FAR const struct file *filep, FAR struct stat *buf);
+	int (*truncate)(FAR struct file *filep, off_t length);
 
 	/* Directory operations */
 
@@ -295,10 +296,10 @@ struct filelist {
  *
  * When buffering us used, the following described the usage of the I/O buffer.
  * The buffer can be used for reading or writing -- but not both at the same time.
- * An fflush is implied between each change in directionof access.
+ * An fflush is implied between each change in direction of access.
  *
  * The field fs_bufread determines whether the buffer is being used for reading or
- * for writing as fillows:
+ * for writing as follows:
  *
  *              BUFFER
  *     +----------------------+ <- fs_bufstart Points to the beginning of the buffer.
@@ -310,7 +311,7 @@ struct filelist {
  *     |                      |                RD: Points to next char to return
  *     +----------------------+
  *     | WR: Available        | <- fs_bufread  Top+1 of buffered read data
- *     | RD: Available        |                WR: =bufstart buffer used for writing.
+ *     | RD: Available        |                WR: bufstart buffer used for writing.
  *     |                      |                RD: Pointer to last buffered read char+1
  *     +----------------------+
  *                              <- fs_bufend   Points to end end of the buffer+1
@@ -421,7 +422,7 @@ int foreach_mountpoint(foreach_mountpoint_t handler, FAR void *arg);
  * Input parameters:
  *   path - The path to the inode to create
  *   fops - The file operations structure
- *   mode - inmode priviledges (not used)
+ *   mode - inmode privileges (not used)
  *   priv - Private, user data that will be associated with the inode.
  *
  * Returned Value:
@@ -541,7 +542,7 @@ int file_dup2(FAR struct file *filep1, FAR struct file *filep2);
  * Name: fs_dupfd OR dup
  *
  * Description:
- *   Clone a file descriptor 'fd' to an arbitray descriptor number (any value
+ *   Clone a file descriptor 'fd' to an arbitrary descriptor number (any value
  *   greater than or equal to 'minfd'). If socket descriptors are
  *   implemented, then this is called by dup() for the case of file
  *   descriptors.  If socket descriptors are not implemented, then this
@@ -579,7 +580,7 @@ int file_dup(FAR struct file *filep, int minfd);
  *   then this function IS dup2().
  *
  *   This alternative naming is used when dup2 could operate on both file and
- *   socket descritors to avoid drawing unused socket support into the link.
+ *   socket descriptors to avoid drawing unused socket support into the link.
  *
  ****************************************************************************/
 
@@ -813,8 +814,23 @@ off_t file_seek(FAR struct file *filep, off_t offset, int whence);
  *
  ****************************************************************************/
 
-#if CONFIG_NFILE_DESCRIPTORS > 0
+#if CONFIG_NFILE_DESCRIPTORS > 0 && !defined(CONFIG_DISABLE_MOUNTPOINT)
 int file_fsync(FAR struct file *filep);
+#endif
+
+/* fs/fs_truncate.c *********************************************************/
+/****************************************************************************
+ * Name: file_truncate
+ *
+ * Description:
+ *   Equivalent to the standard ftruncate() function except that is accepts
+ *   a struct file instance instead of a file descriptor and it does not set
+ *   the errno variable.
+ *
+ ****************************************************************************/
+
+#if CONFIG_NFILE_DESCRIPTORS > 0 && !defined(CONFIG_DISABLE_MOUNTPOINT)
+int file_truncate(FAR struct file *filep, off_t length);
 #endif
 
 /* fs/fs_fcntl.c ************************************************************/

--- a/os/include/unistd.h
+++ b/os/include/unistd.h
@@ -314,6 +314,21 @@ ssize_t pread(int fd, FAR void *buf, size_t nbytes, off_t offset);
  * @since TizenRT v1.0
  */
 ssize_t pwrite(int fd, FAR const void *buf, size_t nbytes, off_t offset);
+/**
+ * @cond
+ * @internal
+ */
+/**
+ * @brief truncate a file to a specified length
+ * @details @b #include <unistd.h> \n
+ * SYSTEM CALL API \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @since TizenRT v2.0 PRE
+ */
+int ftruncate(int fd, off_t length);
+/**
+ * @endcond
+ */
 
 /**
  * @}
@@ -390,6 +405,21 @@ int rmdir(FAR const char *pathname);
  * @since TizenRT v1.0
  */
 int unlink(FAR const char *pathname);
+/**
+ * @cond
+ * @internal
+ */
+/**
+ * @ingroup UNISTD_KERNEL
+ * @brief truncate a file to a specified length
+ * @details @b #include <unistd.h> \n
+ * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
+ * @since TizenRT v2.0 PRE
+ */
+int truncate(FAR const char *path, off_t length);
+/**
+ * @endcond
+ */
 
 /* Execution of programs from files */
 

--- a/os/syscall/syscall.csv
+++ b/os/syscall/syscall.csv
@@ -21,6 +21,7 @@
 "fs_fdopen", "tinyara/fs/fs.h", "CONFIG_NFILE_DESCRIPTORS > 0 && CONFIG_NFILE_STREAMS > 0", "FAR struct file_struct*", "int", "int", "FAR struct tcb_s*"
 "fs_ioctl", "tinyara/fs/fs.h", "defined(CONFIG_LIBC_IOCTL_VARIADIC) && (CONFIG_NSOCKET_DESCRIPTORS > 0 || CONFIG_NFILE_DESCRIPTORS > 0)", "int", "int", "int", "unsigned long"
 "fsync", "unistd.h", "CONFIG_NFILE_DESCRIPTORS > 0 && !defined(CONFIG_DISABLE_MOUNTPOINT)", "int", "int"
+"ftruncate","unistd.h","CONFIG_NFILE_DESCRIPTORS > 0 && !defined(CONFIG_DISABLE_MOUNTPOINT)","int","int","off_t"
 "get_errno", "errno.h", "", "int"
 "getenv", "stdlib.h", "!defined(CONFIG_DISABLE_ENVIRON)", "FAR char*", "FAR const char*"
 "get_environ_ptr", "stdlib.h", "!defined(CONFIG_DISABLE_ENVIRON)", "FAR char*", "size_t *"

--- a/os/syscall/syscall_lookup.h
+++ b/os/syscall/syscall_lookup.h
@@ -216,6 +216,7 @@ SYSCALL_LOOKUP(sched_getstreams,        0, STUB_sched_getstreams)
 
 #  if !defined(CONFIG_DISABLE_MOUNTPOINT)
 SYSCALL_LOOKUP(fsync,                   1, STUB_fsync)
+SYSCALL_LOOKUP(ftruncate,               2, STUB_ftruncate)
 SYSCALL_LOOKUP(mkdir,                   2, STUB_mkdir)
 SYSCALL_LOOKUP(mount,                   5, STUB_mount)
 SYSCALL_LOOKUP(rename,                  2, STUB_rename)

--- a/os/syscall/syscall_stublookup.c
+++ b/os/syscall/syscall_stublookup.c
@@ -224,6 +224,7 @@ uintptr_t STUB_sched_getstreams(int nbr);
 ssize_t sendfile(int outfd, int infd, FAR off_t *offset, size_t count);
 
 uintptr_t STUB_fsync(int nbr, uintptr_t parm1);
+uintptr_t STUB_ftruncate(int nbr, uintptr_t parm1, uintptr_t parm2);
 uintptr_t STUB_mkdir(int nbr, uintptr_t parm1, uintptr_t parm2);
 uintptr_t STUB_mount(int nbr, uintptr_t parm1, uintptr_t parm2,
 					 uintptr_t parm3, uintptr_t parm4, uintptr_t parm5);


### PR DESCRIPTION
Squashed commit of the following:

    fs: Add truncate() support for userfs
    fs/tmpfs:  Add ftruncate() support to tmpfs
    syscall/: Add system call support for ftruncate()
    fs:  Add basic framework to support truncate() and ftruncate().  The infrastructure is complete.  Now, however, the actual implementation of ftruncate() will have to be done for each file system.