### PR TITLE
net/lwIP: fix build error on lwIP

### DIFF
--- a/os/include/net/lwip/sockets.h
+++ b/os/include/net/lwip/sockets.h
@@ -523,6 +523,7 @@ int lwip_select(int maxfdp1, fd_set * readset, fd_set * writeset, fd_set * excep
 int lwip_ioctl(int s, long cmd, void *argp);
 int lwip_fcntl(int s, int cmd, int val);
 
+int lwip_poll(int fd, struct pollfd *fds, bool setup);
 #ifdef __cplusplus
 }
 #endif

--- a/os/include/net/lwip/sys.h
+++ b/os/include/net/lwip/sys.h
@@ -90,6 +90,7 @@ typedef u8_t sys_mbox_t;
 #define sys_mbox_set_invalid_val(m)
 
 #define sys_thread_new(n, t, a, s, p)
+#define sys_kernel_thread_new(n, t, a, s, p)
 
 #define sys_msleep(t)
 
@@ -343,6 +344,8 @@ void sys_mbox_set_invalid(sys_mbox_t * mbox);
  * @param stacksize stack size in bytes for the new thread (may be ignored by ports)
  * @param prio priority of the new thread (may be ignored by ports) */
 sys_thread_t sys_thread_new(const char *name, lwip_thread_fn thread, void *arg, int stacksize, int prio);
+
+sys_thread_t sys_kernel_thread_new(const char *name, lwip_thread_fn entry_function, void *arg, int stacksize, int priority);
 
 #endif							/* NO_SYS */
 

--- a/os/net/lwip/src/core/raw.c
+++ b/os/net/lwip/src/core/raw.c
@@ -136,12 +136,16 @@ static u8_t raw_input_match(struct raw_pcb *pcb, u8_t broadcast)
 u8_t raw_input(struct pbuf *p, struct netif *inp)
 {
 	struct raw_pcb *pcb, *prev;
-	s16_t proto;
+	/* s16_t proto; */
 	u8_t eaten = 0;
 	u8_t broadcast = ip_addr_isbroadcast(ip_current_dest_addr(), ip_current_netif());
 
 	LWIP_UNUSED_ARG(inp);
 
+	/* Below codes make a build error with option -Wunused-but-set-variable
+	 * I commented it because the value proto can show protocol information later.
+	 */
+#if 0
 #if LWIP_IPV6
 #if LWIP_IPV4
 	if (IP_HDR_GET_VERSION(p->payload) == 6)
@@ -159,6 +163,7 @@ u8_t raw_input(struct pbuf *p, struct netif *inp)
 		proto = IPH_PROTO((struct ip_hdr *)p->payload);
 	}
 #endif							/* LWIP_IPV4 */
+#endif
 
 	prev = NULL;
 	pcb = raw_pcbs;


### PR DESCRIPTION
lwIP generates build errors with options -Wimplicit-function-declaration, -Wunused-but-set-variable.