### PR TITLE
media: modify recorder app for invalid call

### DIFF
--- a/apps/examples/mediarecorder/mediarecorder_main.cpp
+++ b/apps/examples/mediarecorder/mediarecorder_main.cpp
@@ -90,10 +90,6 @@ public:
 		std::cout << "onPlaybackFinished" << std::endl;
 		isPlaying = false;
 
-		if (mp.stop() == PLAYER_ERROR) {
-			std::cout << "Mediaplayer::stop failed" << std::endl;
-		}
-
 		if (mp.unprepare() == PLAYER_ERROR) {
 			std::cout << "Mediaplayer::unprepare failed" << std::endl;
 		}


### PR DESCRIPTION
called the stop function incorrectly
when the onPlaybackFinished callback function was called.

Signed-off-by: jaesick.shin <jaesick.shin@samsung.com>