### PR TITLE
framework/task_manager: Apply TM_ASPRINTF macro

### DIFF
--- a/framework/src/task_manager/task_manager_alloc_broadcast_msg.c
+++ b/framework/src/task_manager/task_manager_alloc_broadcast_msg.c
@@ -39,7 +39,7 @@ int task_manager_alloc_broadcast_msg(void)
 	request_msg.caller_pid = getpid();
 	request_msg.timeout = TM_RESPONSE_WAIT_INF;
 
-	asprintf(&request_msg.q_name, "%s%d", TM_PRIVATE_MQ, request_msg.caller_pid);
+	TM_ASPRINTF(&request_msg.q_name, "%s%d", TM_PRIVATE_MQ, request_msg.caller_pid);
 	if (request_msg.q_name == NULL) {
 		return TM_OUT_OF_MEMORY;
 	}

--- a/framework/src/task_manager/task_manager_dealloc_broadcast_msg.c
+++ b/framework/src/task_manager/task_manager_dealloc_broadcast_msg.c
@@ -52,7 +52,7 @@ int task_manager_dealloc_broadcast_msg(int msg, int timeout)
 	*((int *)request_msg.data) = msg;
 	
 	if (timeout != TM_NO_RESPONSE) {
-		asprintf(&request_msg.q_name, "%s%d", TM_PRIVATE_MQ, request_msg.caller_pid);
+		TM_ASPRINTF(&request_msg.q_name, "%s%d", TM_PRIVATE_MQ, request_msg.caller_pid);
 		if (request_msg.q_name == NULL) {
 			TM_FREE(request_msg.data);
 			return TM_OUT_OF_MEMORY;

--- a/framework/src/task_manager/task_manager_getinfo.c
+++ b/framework/src/task_manager/task_manager_getinfo.c
@@ -49,7 +49,7 @@ app_info_list_t *task_manager_getinfo_with_name(char *name, int timeout)
 	strncpy((char *)request_msg.data, name, strlen(name) + 1);
 	request_msg.timeout = timeout;
 
-	asprintf(&request_msg.q_name, "%s%d", TM_PRIVATE_MQ, getpid());
+	TM_ASPRINTF(&request_msg.q_name, "%s%d", TM_PRIVATE_MQ, getpid());
 	if (request_msg.q_name == NULL) {
 		TM_FREE(request_msg.data);
 		return NULL;
@@ -92,7 +92,7 @@ app_info_t *task_manager_getinfo_with_handle(int handle, int timeout)
 	request_msg.handle = handle;
 	request_msg.timeout = timeout;
 
-	asprintf(&request_msg.q_name, "%s%d", TM_PRIVATE_MQ, getpid());
+	TM_ASPRINTF(&request_msg.q_name, "%s%d", TM_PRIVATE_MQ, getpid());
 	if (request_msg.q_name == NULL) {
 		return NULL;
 	}
@@ -133,7 +133,7 @@ app_info_list_t *task_manager_getinfo_with_group(int group, int timeout)
 	request_msg.handle = group;
 	request_msg.timeout = timeout;
 
-	asprintf(&request_msg.q_name, "%s%d", TM_PRIVATE_MQ, getpid());
+	TM_ASPRINTF(&request_msg.q_name, "%s%d", TM_PRIVATE_MQ, getpid());
 	if (request_msg.q_name == NULL) {
 		return NULL;
 	}
@@ -173,7 +173,7 @@ app_info_t *task_manager_getinfo_with_pid(int pid, int timeout)
 	request_msg.caller_pid = pid;
 	request_msg.timeout = timeout;
 
-	asprintf(&request_msg.q_name, "%s%d", TM_PRIVATE_MQ, getpid());
+	TM_ASPRINTF(&request_msg.q_name, "%s%d", TM_PRIVATE_MQ, getpid());
 	if (request_msg.q_name == NULL) {
 		return NULL;
 	}

--- a/framework/src/task_manager/task_manager_internal.h
+++ b/framework/src/task_manager/task_manager_internal.h
@@ -72,6 +72,11 @@
 /* Wrapper of allocation APIs */
 #define TM_ALLOC(a)  malloc(a)
 #define TM_FREE(a)   free(a)
+#ifdef CONFIG_CPP_HAVE_VARARGS
+#define TM_ASPRINTF(p, f, ...) asprintf(p, f, ##__VA_ARGS__)
+#else
+#define TM_ASPRINTF asprintf
+#endif
 
 /* Temporary State for Cancel */
 #define TM_APP_STATE_CANCELLING -1

--- a/framework/src/task_manager/task_manager_pause.c
+++ b/framework/src/task_manager/task_manager_pause.c
@@ -45,7 +45,7 @@ int task_manager_pause(int handle, int timeout)
 	request_msg.timeout = timeout;
 
 	if (timeout != TM_NO_RESPONSE) {
-		asprintf(&request_msg.q_name, "%s%d", TM_PRIVATE_MQ, request_msg.caller_pid);
+		TM_ASPRINTF(&request_msg.q_name, "%s%d", TM_PRIVATE_MQ, request_msg.caller_pid);
 		if (request_msg.q_name == NULL) {
 			return TM_OUT_OF_MEMORY;
 		}

--- a/framework/src/task_manager/task_manager_register.c
+++ b/framework/src/task_manager/task_manager_register.c
@@ -51,7 +51,7 @@ int task_manager_register_builtin(char *name, int permission, int timeout)
 	request_msg.timeout = timeout;
 
 	if (timeout != TM_NO_RESPONSE) {
-		asprintf(&request_msg.q_name, "%s%d", TM_PRIVATE_MQ, request_msg.caller_pid);
+		TM_ASPRINTF(&request_msg.q_name, "%s%d", TM_PRIVATE_MQ, request_msg.caller_pid);
 		if (request_msg.q_name == NULL) {
 			TM_FREE(request_msg.data);
 			return TM_OUT_OF_MEMORY;
@@ -105,7 +105,7 @@ int task_manager_register_task(char *name, int priority, int stack_size, main_t 
 	request_msg.timeout = timeout;
 
 	if (timeout != TM_NO_RESPONSE) {
-		asprintf(&request_msg.q_name, "%s%d", TM_PRIVATE_MQ, request_msg.caller_pid);
+		TM_ASPRINTF(&request_msg.q_name, "%s%d", TM_PRIVATE_MQ, request_msg.caller_pid);
 		if (request_msg.q_name == NULL) {
 			TM_FREE(request_msg.data);
 			return TM_OUT_OF_MEMORY;
@@ -159,7 +159,7 @@ int task_manager_register_pthread(char *name, pthread_attr_t *attr, pthread_star
 	request_msg.timeout = timeout;
 
 	if (timeout != TM_NO_RESPONSE) {
-		asprintf(&request_msg.q_name, "%s%d", TM_PRIVATE_MQ, request_msg.caller_pid);
+		TM_ASPRINTF(&request_msg.q_name, "%s%d", TM_PRIVATE_MQ, request_msg.caller_pid);
 		if (request_msg.q_name == NULL) {
 			TM_FREE(request_msg.data);
 			return TM_OUT_OF_MEMORY;

--- a/framework/src/task_manager/task_manager_restart.c
+++ b/framework/src/task_manager/task_manager_restart.c
@@ -45,7 +45,7 @@ int task_manager_restart(int handle, int timeout)
 	request_msg.timeout = timeout;
 
 	if (timeout != TM_NO_RESPONSE) {
-		asprintf(&request_msg.q_name, "%s%d", TM_PRIVATE_MQ, request_msg.caller_pid);
+		TM_ASPRINTF(&request_msg.q_name, "%s%d", TM_PRIVATE_MQ, request_msg.caller_pid);
 		if (request_msg.q_name == NULL) {
 			return TM_OUT_OF_MEMORY;
 		}

--- a/framework/src/task_manager/task_manager_resume.c
+++ b/framework/src/task_manager/task_manager_resume.c
@@ -46,7 +46,7 @@ int task_manager_resume(int handle, int timeout)
 	request_msg.timeout = timeout;
 
 	if (timeout != TM_NO_RESPONSE) {
-		asprintf(&request_msg.q_name, "%s%d", TM_PRIVATE_MQ, request_msg.caller_pid);
+		TM_ASPRINTF(&request_msg.q_name, "%s%d", TM_PRIVATE_MQ, request_msg.caller_pid);
 		if (request_msg.q_name == NULL) {
 			return TM_OUT_OF_MEMORY;
 		}

--- a/framework/src/task_manager/task_manager_set_callback.c
+++ b/framework/src/task_manager/task_manager_set_callback.c
@@ -127,7 +127,7 @@ int task_manager_set_broadcast_cb(int msg, void (*func)(void *data), void *cb_da
 	((tm_broadcast_info_t *)request_msg.data)->msg = msg;
 	((tm_broadcast_info_t *)request_msg.data)->cb = (_tm_broadcast_t)func;
 	((tm_broadcast_info_t *)request_msg.data)->cb_data = cb_data;
-	asprintf(&request_msg.q_name, "%s%d", TM_PRIVATE_MQ, request_msg.caller_pid);
+	TM_ASPRINTF(&request_msg.q_name, "%s%d", TM_PRIVATE_MQ, request_msg.caller_pid);
 	if (request_msg.q_name == NULL) {
 		TM_FREE(request_msg.data);
 		return TM_OUT_OF_MEMORY;

--- a/framework/src/task_manager/task_manager_start.c
+++ b/framework/src/task_manager/task_manager_start.c
@@ -46,7 +46,7 @@ int task_manager_start(int handle, int timeout)
 	request_msg.timeout = timeout;
 
 	if (timeout != TM_NO_RESPONSE) {
-		asprintf(&request_msg.q_name, "%s%d", TM_PRIVATE_MQ, request_msg.caller_pid);
+		TM_ASPRINTF(&request_msg.q_name, "%s%d", TM_PRIVATE_MQ, request_msg.caller_pid);
 		if (request_msg.q_name == NULL) {
 			return TM_OUT_OF_MEMORY;
 		}

--- a/framework/src/task_manager/task_manager_stop.c
+++ b/framework/src/task_manager/task_manager_stop.c
@@ -46,7 +46,7 @@ int task_manager_stop(int handle, int timeout)
 	request_msg.timeout = timeout;
 
 	if (timeout != TM_NO_RESPONSE) {
-		asprintf(&request_msg.q_name, "%s%d", TM_PRIVATE_MQ, request_msg.caller_pid);
+		TM_ASPRINTF(&request_msg.q_name, "%s%d", TM_PRIVATE_MQ, request_msg.caller_pid);
 		if (request_msg.q_name == NULL) {
 			return TM_OUT_OF_MEMORY;
 		}

--- a/framework/src/task_manager/task_manager_unicast.c
+++ b/framework/src/task_manager/task_manager_unicast.c
@@ -73,7 +73,7 @@ int task_manager_unicast(int handle, tm_unicast_msg_t *send_msg, tm_unicast_msg_
 	request_msg.timeout = timeout;
 
 	if (timeout != TM_NO_RESPONSE) {
-		asprintf(&request_msg.q_name, "%s%d", TM_PRIVATE_MQ, request_msg.caller_pid);
+		TM_ASPRINTF(&request_msg.q_name, "%s%d", TM_PRIVATE_MQ, request_msg.caller_pid);
 		if (request_msg.q_name == NULL) {
 			TM_FREE(((tm_unicast_internal_msg_t *)request_msg.data)->msg);
 			TM_FREE(request_msg.data);

--- a/framework/src/task_manager/task_manager_unregister.c
+++ b/framework/src/task_manager/task_manager_unregister.c
@@ -45,7 +45,7 @@ int task_manager_unregister(int handle, int timeout)
 	request_msg.timeout = timeout;
 
 	if (timeout != TM_NO_RESPONSE) {
-		asprintf(&request_msg.q_name, "%s%d", TM_PRIVATE_MQ, request_msg.caller_pid);
+		TM_ASPRINTF(&request_msg.q_name, "%s%d", TM_PRIVATE_MQ, request_msg.caller_pid);
 		if (request_msg.q_name == NULL) {
 			return TM_OUT_OF_MEMORY;
 		}

--- a/framework/src/task_manager/task_manager_unset_broadcast_cb.c
+++ b/framework/src/task_manager/task_manager_unset_broadcast_cb.c
@@ -48,7 +48,7 @@ int task_manager_unset_broadcast_cb(int msg, int timeout)
 	*((int *)request_msg.data) = msg;
 	
 	if (timeout != TM_NO_RESPONSE) {
-		asprintf(&request_msg.q_name, "%s%d", TM_PRIVATE_MQ, request_msg.caller_pid);
+		TM_ASPRINTF(&request_msg.q_name, "%s%d", TM_PRIVATE_MQ, request_msg.caller_pid);
 		if (request_msg.q_name == NULL) {
 			TM_FREE(request_msg.data);
 			return TM_OUT_OF_MEMORY;


### PR DESCRIPTION
asprintf uses malloc. for checking TM memory usage, TM_ASPRINTF macro is needed.