### PR TITLE
iotjs_startup/Kconfig: Remove unncessary select option and Move ENABL…

### DIFF
--- a/apps/examples/iotjs_startup/Kconfig
+++ b/apps/examples/iotjs_startup/Kconfig
@@ -6,6 +6,7 @@
 config EXAMPLES_IOTJS_STARTUP
 	bool "IoT.js StartUp example"
 	default n
+	select ENABLE_IOTJS
 	---help---
 		Enable the IoT.js StartUp example,
 		that run a Javascript on start using IoT.js
@@ -23,8 +24,6 @@ config EXAMPLES_IOTJS_STARTUP_PROGNAME
 config EXAMPLES_IOTJS_STARTUP_JS_FILE
 	string "Main javascript file"
 	default "/rom/example/index.js"
-	select ENABLE_IOTJS
-	select ROMFS
 	---help---
 		This is the name of the javascript loaded by IoT.js runtime
 


### PR DESCRIPTION
…E_IOTJS option for all

1. ROMFS is not needed for EXAMPLES_IOTJS_STARTUP_JS_FILE. Because EXAMPLES_IOTJS_STARTUP_JS_FILE can be run without ROMFS.
2. Move select ENABLE_IOTJS to EXAMPLES_IOTJS_STARTUP. All other configs need this configuration.