### PR TITLE
framework/media : fix a logical error at MediaWorker::startWorker()

### DIFF
--- a/framework/src/media/MediaWorker.cpp
+++ b/framework/src/media/MediaWorker.cpp
@@ -45,6 +45,7 @@ void MediaWorker::startWorker()
 		if (ret != OK) {
 			medvdbg("Fail to create worker thread, return value : %d\n", ret);
 			--mRefCnt;
+			mIsRunning = false;
 			return;
 		}
 		pthread_setname_np(mWorkerThread, mThreadName);


### PR DESCRIPTION
Even though a worker thread creation fails, the flag of 'mIsRunning' is set to true.
Fix this logical error by moving the 'mIsRunning' update logic right after the thread creation successfully.