### PR TITLE
external/netlib: Add a command to get netdev stats in network monitor

### DIFF
--- a/os/include/net/if.h
+++ b/os/include/net/if.h
@@ -272,6 +272,14 @@ struct netmon_sock {
 	pid_t pid;
 	char  pid_name[CONFIG_TASK_NAME_SIZE];
 };
+/* Netdev info. */
+struct netmon_netdev_stats {
+   char devname[IFNAMSIZ + 1];
+   u32_t devinpkts;
+   u32_t devinoctets;
+   u32_t devoutpkts;
+   u32_t devoutoctets;
+};
 #endif                              /* CONFIG_NET_NETMON */
 /*******************************************************************************************
  * Public Function Prototypes

--- a/os/include/tinyara/net/ioctl.h
+++ b/os/include/tinyara/net/ioctl.h
@@ -199,6 +199,8 @@
 
 /* Network monitor **********************************************************/
 #define SIOCGETSOCK		 _SIOC(0x0053)  /* Get socket info */
+#define SIOCGDSTATS      _SIOC(0x0054)  /* Get dev stats */
+
 
 /****************************************************************************
  * Type Definitions

--- a/os/net/mac/ethernetif.c
+++ b/os/net/mac/ethernetif.c
@@ -35,6 +35,8 @@
 #include <net/lwip/pbuf.h>
 #include <net/lwip/stats.h>
 #include <net/lwip/ip_addr.h>
+#include <net/lwip/snmp.h>
+
 
 #include <net/lwip/netif/etharp.h>
 #include <net/lwip/ethip6.h>
@@ -172,6 +174,7 @@ int ethernetif_input(struct netif *netif)
 			p = NULL;
 		} else {
 			LINK_STATS_INC(link.recv);
+
 		}
 	} else {
 		LWIP_DEBUGF(NETIF_DEBUG, ("mem error\n"));

--- a/os/net/netdev/Make.defs
+++ b/os/net/netdev/Make.defs
@@ -57,8 +57,8 @@ NETDEV_CSRCS += netdev_findbyname.c
 NETDEV_CSRCS += netdev_count.c
 NETDEV_CSRCS += netdev_foreach.c
 NETDEV_CSRCS += netdev_sem.c
+NETDEV_CSRCS += netdev_getstats.c
 
 # Include netdev build support
-
 DEPPATH += --dep-path netdev
 VPATH += :netdev

--- a/os/net/netdev/netdev.h
+++ b/os/net/netdev/netdev.h
@@ -181,6 +181,12 @@ void netdev_ipv6_rxnotify(FAR const net_ipv6addr_t ripaddr);
 int netdev_count(void);
 #endif
 
+/* netdev_getstats.c *******************************************************/
+
+#if CONFIG_NSOCKET_DESCRIPTORS > 0
+int netdev_getstats(void *arg);
+#endif
+
 #undef EXTERN
 #ifdef __cplusplus
 }

--- a/os/net/netdev/netdev_ioctl.c
+++ b/os/net/netdev/netdev_ioctl.c
@@ -826,7 +826,7 @@ static FAR struct netif *netdev_imsfdev(FAR struct ip_msfilter *imsf)
  * Parameters:
  *   sock    Socket structure
  *   cmd     The ioctl command
- *   data    The argument of ioctl command
+ *   arg    The argument of ioctl command
  *
  * Return:
  *   >=0 on success (positive non-zero values are cmd-specific)
@@ -840,7 +840,7 @@ static int netdev_nmioctl(FAR struct socket *sock, int cmd, void  *arg)
 	int ret = -EINVAL;
 	int num_copy;
 	switch (cmd) {
-	case SIOCGETSOCK:
+	case SIOCGETSOCK:          /* Get socket info. */
 		num_copy = copy_socket(arg);
 		/* num_copy shoud be larger than 0 (this socket) */
 		if (num_copy > 0) {
@@ -848,12 +848,16 @@ static int netdev_nmioctl(FAR struct socket *sock, int cmd, void  *arg)
 		} else {
 			ret = ERROR;
 		}
-		break;
-	default:
-		ret = -ENOTTY;
-		break;
-	}
-	return ret;
+	    break;
+    case SIOCGDSTATS:          /* Get netdev info. */
+        ret = netdev_getstats(arg);
+        break;
+    default:
+        ret = -ENOTTY;
+        break;
+    } /* end switch */
+
+    return ret;
 }
 #endif                            /* CONFIG_NET_NETMON */
 


### PR DESCRIPTION
- Add a network monitor command to extract netdev stats 'netmon [netdev]' in netlib_netmon.c
- Add a network monitor ioctl command SIOCGDSTATS in net/ioctl.h
- Add a corresponding data structure in net/if.h
- Manage netdev specific stats structure in ethernet.c
- When the input [netdev] exists in the netdev list,
extract the corresponding stats by calling netdev_getstats()
newly defined in os/net/netdev/netdev_getstats.c