### PR TITLE
external/wpa_supplicant: Remove build error for CONFIG_NO_STDOUT_DEBUG

### DIFF
--- a/external/wpa_supplicant/src/ap/hw_features.c
+++ b/external/wpa_supplicant/src/ap/hw_features.c
@@ -24,23 +24,9 @@
 #include "beacon.h"
 #include "hw_features.h"
 
-void hostapd_free_hw_features(struct hostapd_hw_modes *hw_features, size_t num_hw_features)
-{
-	size_t i;
-
-	if (hw_features == NULL) {
-		return;
-	}
-
-	for (i = 0; i < num_hw_features; i++) {
-		os_free(hw_features[i].channels);
-		os_free(hw_features[i].rates);
-	}
-
-	os_free(hw_features);
-}
-
-#ifndef CONFIG_NO_STDOUT_DEBUG
+#ifdef CONFIG_NO_STDOUT_DEBUG
+#define dfs_info(p) NULL
+#else
 static char *dfs_info(struct hostapd_channel_data *chan)
 {
 	static char info[256];
@@ -64,10 +50,25 @@ static char *dfs_info(struct hostapd_channel_data *chan)
 	}
 	os_snprintf(info, sizeof(info), " (DFS state = %s)", state);
 	info[sizeof(info) - 1] = '\0';
-
 	return info;
 }
 #endif							/* CONFIG_NO_STDOUT_DEBUG */
+
+void hostapd_free_hw_features(struct hostapd_hw_modes *hw_features, size_t num_hw_features)
+{
+	size_t i;
+
+	if (hw_features == NULL) {
+		return;
+	}
+
+	for (i = 0; i < num_hw_features; i++) {
+		os_free(hw_features[i].channels);
+		os_free(hw_features[i].rates);
+	}
+
+	os_free(hw_features);
+}
 
 int hostapd_get_hw_features(struct hostapd_iface *iface)
 {

--- a/external/wpa_supplicant/src/utils/wpa_debug.h
+++ b/external/wpa_supplicant/src/utils/wpa_debug.h
@@ -111,17 +111,22 @@ void wpa_hexdump_ascii_key(int level, const char *title, const void *buf, size_t
 #ifdef CONFIG_NO_STDOUT_DEBUG
 
 #define wpa_debug_print_timestamp() do { } while (0)
-#define wpa_printf(args...) do { } while (0)
 #define wpa_debug_open_file(p) do { } while (0)
 #define wpa_debug_close_file() do { } while (0)
 #define wpa_debug_setup_stdout() do { } while (0)
-#define wpa_dbg(args...) do { } while (0)
 
 static inline int wpa_debug_reopen_file(void)
 {
 	return 0;
 }
-
+static inline void wpa_dbg(void *ctx, int level, const char *fmt, ...)
+{
+	return ;
+}
+static inline void wpa_printf(int level, const char *fmt, ...)
+{
+	return ;
+}
 #else							/* CONFIG_NO_STDOUT_DEBUG */
 
 int wpa_debug_open_file(const char *path);


### PR DESCRIPTION
When CONFIG_NO_STDOUT_DEBUG is enabled, serveral errors come out, which are resolved as follows.
- Change macros to inline function due to the errors from the defined but not used variable using wpa_dbg and wpa_printf
- Modify location of #ifndef CONFIG_NO_STDOUT_DEBUG not to build dfs_info
(requested by chan45.lee@samsung.com)