### PR TITLE
external/audiocodec: fix make clean

### DIFF
--- a/external/audiocodec/Makefile
+++ b/external/audiocodec/Makefile
@@ -106,6 +106,7 @@ depend: .depend
 clean:
 	$(call DELFILE, .built)
 	$(call CLEAN)
+	find . -name "*.o" -exec rm -rf {} \;
 
 distclean: clean
 	$(call DELFILE, Make.dep)


### PR DESCRIPTION
sub directory objects are not cleaned after make clean

Steps:
./configure.sh /artik055s/audio
make
make clean
find . -name "*.o"

Signed-off-by: Manohara HK <manohara.hk@samsung.com>