### PR TITLE
os/tools: add zipdownload script

### DIFF
--- a/os/tools/download.bat
+++ b/os/tools/download.bat
@@ -1,0 +1,92 @@
+@echo off
+
+rem
+rem Copyright 2018 Samsung Electronics All Rights Reserved.
+rem
+rem Licensed under the Apache License, Version 2.0 (the "License");
+rem you may not use this file except in compliance with the License.
+rem You may obtain a copy of the License at
+rem
+rem http://www.apache.org/licenses/LICENSE-2.0
+rem
+rem Unless required by applicable law or agreed to in writing,
+rem software distributed under the License is distributed on an
+rem "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+rem either express or implied. See the License for the specific
+rem language governing permissions and limitations under the License.
+rem
+
+set CURPATH=%CD%
+set BATPATH=%~dp0
+set BUILDPATH=%BATPATH%..\..\build
+set BINPATH=%BUILDPATH%\output\bin
+reg Query "HKLM\Hardware\Description\System\CentralProc>essor\0" | find /i "x86" > NUL && set OSBIT=win32 || set OSBIT=win64
+
+if "%1"=="" goto :NoBoard
+if "%1"=="-b" goto :SetBoard
+if "%1"=="--help" goto :ShowUsage
+if "%1"=="/?" goto :ShowUsage
+
+:SetBoard
+shift
+set BOARD=%1
+
+if "%BOARD%"=="artik053" goto :DownloadARTIK
+if "%BOARD%"=="artik053s" goto :DownloadARTIK
+if "%BOARD%"=="artik055s" goto :DownloadARTIK
+if "%BOARD%"=="cy4390x" goto :DownloadCypress
+goto :NoBoard
+
+:DownloadARTIK
+set OPENOCDPATH=%BUILDPATH%\tools\openocd\%OSBIT%
+set SCRIPTPATH=%BUILDPATH%\configs\artik05x\scripts
+set PREBUILTBINPATH=%BUILDPATH%\configs\%BOARD%\bin
+set PREBUILTCOMMANDS="flash_protect off; flash_write bl1 bl1.bin; flash_protect on; flash_write bl2 bl2.bin; flash_write sssfw sssfw.bin; flash_write wlanfw wlanfw.bin; "
+if exist %BINPATH%\romfs.img set ROMFS=flash_write rom romfs.img;
+if exist %BINPATH%\ota.bin set OTA=flash_write ota ota.bin;
+set OSCOMMANDS="flash_write os tinyara_head.bin; %ROMFS% %OTA% "
+
+cd %PREBUILTBINPATH%
+%OPENOCDPATH%\openocd.exe -f artik05x.cfg -s %SCRIPTPATH% -c %PREBUILTCOMMANDS% -c "init; reset; exit; "
+
+cd %BINPATH%
+%OPENOCDPATH%\openocd.exe -f artik05x.cfg -s %SCRIPTPATH% -c %OSCOMMANDS% -c "init; reset; exit; "
+goto End
+
+:DownloadCypress
+set CYTOOLSPATH=%BUILDPATH%\configs\%BOARD%\tools
+set PREBUILTBINPATH=%CYTOOLSPATH%\binary
+set OPENOCDPATH=%CYTOOLSPATH%\OpenOCD\%OSBIT%
+
+set CFGFILE1=%CYTOOLSPATH%\OpenOCD\BCM9WCD1EVAL1.cfg
+set CFGFILE2=%CYTOOLSPATH%\OpenOCD\BCM4390x.cfg
+set CFGFILE3=%CYTOOLSPATH%\OpenOCD\BCM4390x_gdb_jtag.cfg
+set STRIPFILE=tinyara_master_strip
+set ROMFSFILE=romfs.img
+set BLFILE=waf.bootloader.43909.trx.bin
+
+set BLCOMMAND="sflash_write_file %BLFILE% 0x00000000 BCM943909WCD1_3-P320-SoC.43909 1 43909; "
+
+if exist %BINPATH%\romfs.img set ROMCOMMAND="sflash_write_file %ROMFSFILE% 0x00408000 BCM943909WCD1_3-P320-SoC.43909 0 43909; "
+set OSCOMMAND="sflash_write_file %STRIPFILE%  0x0008D000 BCM943909WCD1_3-P320-SoC.43909 0 43909; %ROMCOMMAND% "
+
+cd %PREBUILTBINPATH%
+%OPENOCDPATH%\openocd.exe -f %CFGFILE1% -f %CFGFILE2% -f %CFGFILE3% -c %BLCOMMAND% -c shutdown
+
+cd %BINPATH%
+%OPENOCDPATH%\openocd.exe -f %CFGFILE1% -f %CFGFILE2% -f %CFGFILE3% -c %OSCOMMAND% -c shutdown
+
+goto End
+
+:NoBoard
+echo Wrong Board Name
+
+:ShowUsage
+echo Usage: %~nx0 -b BOARD
+echo Download TizenRT binary into BOARD
+echo 	-b BOARD      Set board name like artik053, cy4390x
+echo 	--help        Show this text and exit
+
+:End
+cd %CURPATH%
+

--- a/os/tools/download.sh
+++ b/os/tools/download.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+###########################################################################
+#
+# Copyright 2018 Samsung Electronics All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+#
+###########################################################################
+
+TOOLPATH=`test -d ${0%/*} && cd ${0%/*}; pwd`
+OSPATH="${TOOLPATH}/.."
+
+cd ${OSPATH}
+
+if test $# -eq 0; then
+	make download all
+	exit 0
+fi
+
+make download $1 $2 $3 $4 $5 $6
+exit 0

--- a/os/tools/zipdownload.sh
+++ b/os/tools/zipdownload.sh
@@ -1,0 +1,158 @@
+#!/bin/bash
+###########################################################################
+#
+# Copyright 2018 Samsung Electronics All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+#
+###########################################################################
+
+# Usages
+
+USAGE="
+
+USAGE: ${0} [-d] [FILE-NAME]
+Zip binary, debug files like elf and map and flash tool files
+
+  -d         include debug files, elf and map into zip file
+  FILE-NAME  zip file name
+               when not configured, "TizenRT_\<board-name\>_\<commit_hash\>.tar" used
+"
+
+# Parsing arguments
+
+unset DEBUG
+unset FILENAME
+
+while [ ! -z "$1" ]; do
+	case "$1" in
+	--help )
+		echo "$USAGE"
+		exit 0
+		;;
+	-d )
+		DEBUG=y
+		;;
+	*)
+		if [ ! -z "${FILENAME}" ]; then
+			echo ""
+			echo "File name defined twice"
+			echo "$USAGE"
+			exit 1
+		fi
+		FILENAME=$1
+		;;
+	esac
+	shift
+done
+
+# Zip command & option
+
+TAR=tar
+TAROPT=-cf
+
+# Get folder path
+
+OSTOOLDIR=`test -d ${0%/*} && cd ${0%/*}; pwd`
+TOPDIR="${OSTOOLDIR}/../.."
+OSDIR="${TOPDIR}/os"
+BUILDDIR="${TOPDIR}/build"
+BINDIR="${BUILDDIR}/output/bin"
+
+# Get fixed file
+
+CONFIG=${OSDIR}/.config
+if [ ! -f ${CONFIG} ]; then
+	echo "No .config file"
+	exit 1
+fi
+MAKEFILES="${OSDIR}/Makefile ${OSDIR}/Makefile.unix ${OSDIR}/Makefile.win ${OSDIR}/Directories.mk ${OSDIR}/FlatLibs.mk ${OSDIR}/LibTargets.mk ${OSDIR}/Make.defs ${OSDIR}/tools/Config.mk"
+DOWNLOADSCRIPTS="${OSDIR}/tools/download.sh ${OSDIR}/tools/download.bat"
+
+TINYARABIN=${BINDIR}/tinyara.bin
+if [ ! -f "${TINYARABIN}" ]; then
+	echo "No binary file"
+	exit 1
+fi
+
+unset ROMFSIMG
+if [ -f "${BINDIR}/romfs.img" ]; then
+	ROMFSIMG="${BINDIR}/romfs.img"
+fi
+
+unset OTABIN
+if [ -f "${BINDIR}/ota.bin" ]; then
+	OTABIN="${BINDIR}/ota.bin"
+fi
+
+unset ELF
+unset MAP
+if [ "${DEBUG}" == "y" ]; then
+	ELF=${BINDIR}/tinyara
+	MAP=${BINDIR}/tinyara.map
+fi
+
+# Get configuration
+
+source ${CONFIG}
+
+BOARD=${CONFIG_ARCH_BOARD}
+
+# Get file according to .config
+
+BOARDSCRIPT="${BUILDDIR}/configs/${BOARD}"
+TOOLCHAINDEFS="${OSDIR}/arch/${CONFIG_ARCH}/src/${CONFIG_ARCH_FAMILY}/Toolchain.defs"
+
+# Get GIT information (if not provided on the command line)
+
+if [ -z "${FILENAME}" ]; then
+	GITINFO=`git log 2>/dev/null | head -1`
+	if [ -z "${GITINFO}" ]; then
+		echo "GIT version information is not available"
+		BUILD=NA
+	else
+		BUILD=`echo ${GITINFO} | cut -d' ' -f2`
+		BUILD=`echo ${BUILD:0:7}`
+		if [ -z "${BUILD}" ]; then
+			echo "GIT build information not found"
+			BUILD=NA
+		fi
+	fi
+
+	FILENAME=tizenrt_${BOARD}_${BUILD}.tar
+fi
+
+# Board specific
+
+unset FLASHTOOLDIR
+
+if [ "${BOARD}" == "artik05x" ]; then
+	FLASHTOOLDIR="${BUILDDIR}/tools/openocd"
+	BOARDBIN="${BUILDDIR}/configs/artik053 ${BUILDDIR}/configs/artik053s ${BUILDDIR}/configs/artik055s ${BINDIR}/tinyara_head.bin"
+fi
+
+if [ "${BOARD}" == "cy4390x" ]; then
+	BOARDBIN="${BINDIR}/tinyara_master_strip"
+fi
+
+# Execute
+
+BINARIES="${TINYARABIN} ${ROMFSIMG} ${OTABIN}"
+DEBUGFILES="${ELF} ${MAP}"
+TINYARAFILES="${CONFIG} ${MAKEFILES} ${DOWNLOADSCRIPTS} ${TOOLCHAINDEFS}"
+BOARDSPECIFIC="${BOARDSCRIPT} ${BOARDBIN}"
+
+${TAR} ${TAROPT} ${FILENAME} ${TINYARAFILES} ${BINARIES} ${DEBUGFILES} ${FLASHTOOLDIR} ${BOARDSPECIFIC} || exit 1
+
+echo "${FILENAME} zipped!"
+exit 0


### PR DESCRIPTION
Someone wants flash TizenRT binary without any enviorments like
cloning source codes, setting up build env and so on.
This script zips necessary files to download.
After installing USB driver, "make download" on os folder allows
flashing binary.

Signed-off-by: sunghan-chang <sh924.chang@samsung.com>