### PR TITLE
network/wifi_manager: fix build issue on wifi_profile

### DIFF
--- a/framework/src/wifi_manager/wifi_profile.c
+++ b/framework/src/wifi_manager/wifi_profile.c
@@ -118,7 +118,6 @@ static void _wifi_profile_deserialize(wifi_manager_ap_config_s *config, char *bu
 	if (config->ap_auth_type == WIFI_MANAGER_AUTH_OPEN) {
 		return;
 	}
-	
 	DECODE_INTEGER(buf, config->passphrase_length, pos);
 	DECODE_STRING(buf, config->passphrase, pos, config->passphrase_length);
 
@@ -262,14 +261,13 @@ wifi_utils_result_e wifi_profile_read(wifi_manager_ap_config_s *config)
 	if (ret != SEE_OK) {
 		return WIFI_UTILS_FILE_ERROR;
 	}
+	nvdbg("read data len(%u)\n", readlen);
 #else
 	ret = _wifi_profile_read_file(buf, WIFI_PROFILE_BUFSIZE);
 	if (ret < 0) {
 		return WIFI_UTILS_FILE_ERROR;
 	}
 #endif
-	nvdbg("readed data len(%d)\n", readlen);
-
 	_wifi_profile_deserialize(config, buf);
 
 	return WIFI_UTILS_SUCCESS;


### PR DESCRIPTION
if CONFIG_WIFI_PROFILE_SECURESTORAGE is disabled then it can't refer readlen
which is used only above config so it causes a build error.