### PR TITLE
framework/wifi_manager: Add a new API to extract WiFi Manager stats

### DIFF
--- a/apps/examples/wifi_manager_sample/wm_test.c
+++ b/apps/examples/wifi_manager_sample/wm_test.c
@@ -33,6 +33,7 @@
 	"\n run Wi-Fi Manager:\n"											\
 	"	 wm_test start(default: station mode)\n"						\
 	"	 wm_test stop\n"												\
+	"	 wm_test stats\n"                                               \
 	"\n softap mode options:\n"											\
 	"	 wm_test softap [ssid] [password]\n"							\
 	"\n station mode options:\n"										\
@@ -392,6 +393,22 @@ void wm_reset_info(void *arg)
 	WM_TEST_LOG_END;
 }
 
+void wm_get_stats(void *arg)
+{
+	WM_TEST_LOG_START;
+	wifi_manager_stats_s stats;
+	wifi_manager_result_e res = wifi_manager_get_stats(&stats);
+	if (res != WIFI_MANAGER_SUCCESS) {
+		printf("Get WiFi Manager stats failed\n");
+	} else {
+		printf("=======================================================================\n");
+		printf("CONN    CONNFAIL    DISCONN    RECONN    SCAN    SOFTAP    JOIN    LEFT\n");
+		printf("%-8d%-12d%-11d%-10d", stats.connect, stats.connectfail, stats.disconnect, stats.reconnect);
+		printf("%-8d%-10d%-8d%-8d\n", stats.scan, stats.softap, stats.joined, stats.left);
+		printf("=======================================================================\n");
+	}
+	WM_TEST_LOG_END;
+}
 
 void wm_get_info(void *arg)
 {
@@ -1229,6 +1246,8 @@ int wm_parse_commands(struct options *opt, int argc, char *argv[])
 		}
 		opt->crypto_type = get_crypto_type(argv[4]);
 		opt->password = argv[5];
+	} else if (strcmp(argv[2], "stats") == 0) {
+		opt->func = wm_get_stats;
 	} else if (strcmp(argv[2], "get") == 0) {
 		opt->func = wm_get_info;
 	} else if (strcmp(argv[2], "reset") == 0) {

--- a/framework/include/wifi_manager/wifi_manager.h
+++ b/framework/include/wifi_manager/wifi_manager.h
@@ -134,7 +134,7 @@ typedef enum {
  * @brief Keep information of nearby access points as scan results
  */
 struct wifi_manager_scan_info_s {
-	char ssid[WIFIMGR_SSID_LEN + 1];        	// 802.11 spec defined unspecified or uint8
+	char ssid[WIFIMGR_SSID_LEN + 1];			// 802.11 spec defined unspecified or uint8
 	char bssid[WIFIMGR_MACADDR_STR_LEN + 1];	// char string e.g. xx:xx:xx:xx:xx:xx
 	int8_t rssi;		// received signal strength indication
 	uint8_t channel;	// channel/frequency
@@ -204,6 +204,20 @@ typedef struct {
 } wifi_manager_ap_config_s;
 
 /**
+ * @brief Specify Wi-Fi Manager internal stats information
+ */
+typedef struct {
+	uint16_t connect;
+	uint16_t connectfail;
+	uint16_t disconnect;
+	uint16_t reconnect;
+	uint16_t joined;
+	uint16_t left;
+	uint16_t scan;
+	uint16_t softap;
+} wifi_manager_stats_s;
+
+/**
  * @brief Initialize Wi-Fi Manager including starting Wi-Fi interface.
  * @details @b #include <wifi_manager/wifi_manager.h>
  * @param[in] wmcb callback functions called when wi-fi events happen
@@ -225,7 +239,7 @@ wifi_manager_result_e wifi_manager_deinit(void);
  * @brief Change the Wi-Fi mode to station or AP.
  * @details @b #include <wifi_manager/wifi_manager.h>
  * @param[in] mode Wi-Fi mode (station or AP)
- * @param[in] config In case of AP mode, AP configuration infomation should be given including ssid, channel, and passphrase.
+ * @param[in] config In case of AP mode, AP configuration information should be given including ssid, channel, and passphrase.
  * @return On success, WIFI_MANAGER_SUCCESS (i.e., 0) is returned. On failure, non-zero value is returned.
  * @since TizenRT v1.1
  */
@@ -282,7 +296,7 @@ wifi_manager_result_e wifi_manager_scan_ap(void);
 /**
  * @brief Save the AP configuration at persistent storage
  * @details @b #include <wifi_manager/wifi_manager.h>
- * @param[in] config AP configuration infomation should be given including ssid, channel, and passphrase.
+ * @param[in] config AP configuration information should be given including ssid, channel, and passphrase.
  * @return On success, WIFI_MANAGER_SUCCESS (i.e., 0) is returned. On failure, non-zero value is returned.
  * @since TizenRT v2.0 PRE
  */
@@ -291,7 +305,7 @@ wifi_manager_result_e wifi_manager_save_config(wifi_manager_ap_config_s *config)
 /**
  * @brief Get the AP configuration which was saved
  * @details @b #include <wifi_manager/wifi_manager.h>
- * @param[in] config The pointer of AP configuration infomation which will be filled
+ * @param[in] config The pointer of AP configuration information which will be filled
  * @return On success, WIFI_MANAGER_SUCCESS (i.e., 0) is returned. On failure, non-zero value is returned.
  * @since TizenRT v2.0 PRE
  */
@@ -305,6 +319,15 @@ wifi_manager_result_e wifi_manager_get_config(wifi_manager_ap_config_s *config);
  * @since TizenRT v2.0 PRE
  */
 wifi_manager_result_e wifi_manager_remove_config(void);
+
+/**
+ * @brief Obtain WiFi Manager state stats
+ * @details @b #include <wifi_manager/wifi_manager.h>
+ * @param[in] The pointer of WiFi Manager stats information which will be filled
+ * @return On success, WIFI_MANAGER_SUCCESS (i.e., 0) is returned. On failure, non-zero value is returned.
+ * @since TizenRT v2.0 PRE
+ */
+wifi_manager_result_e wifi_manager_get_stats(wifi_manager_stats_s *stats);
 
 /**
  * @brief convert mac address (48bit) to mac address string (FF:FF:FF:FF:FF:FF)


### PR DESCRIPTION
- Add a new API to extract WiFi Manager run-time statistics
- Test the new API using wm_test
- Modify some spacing to remove code rule errors