### PR TITLE
framework/wifi_manager: Remove unappropriate Public APIs

### DIFF
--- a/framework/include/wifi_manager/wifi_manager.h
+++ b/framework/include/wifi_manager/wifi_manager.h
@@ -306,34 +306,6 @@ wifi_manager_result_e wifi_manager_get_config(wifi_manager_ap_config_s *config);
  */
 wifi_manager_result_e wifi_manager_remove_config(void);
 
-/**
- * @brief convert mac address (48bit) to mac address string (FF:FF:FF:FF:FF:FF)
- *
- * @param[in]  mac_addr  :  mac address 48bit
- * @param[out] mac_str   :  mac address string
- *
- * @return WIFI_MANAGER_SUCCESS       :  success
- * @return WIFI_MANAGER_FAIL          :  fail
- * @return WIFI_MANAGER_INVALID_ARGS  :  input parameter invalid
- * @since TinzeRT v2.0 PRE
- */
-
-wifi_manager_result_e wifi_manager_mac_addr_to_mac_str(char mac_addr[6], char mac_str[20]);
-
-/**
- * @brief convert mac address string (FF:FF:FF:FF:FF:FF)to mac address (48bit)
- *
- * @param[in]   mac_str   :  mac address string
- * @param[out]  mac_addr  :  mac address 48bit
- *
- * @return WIFI_MANAGER_SUCCESS       :  success
- * @return WIFI_MANAGER_FAIL          :  fail
- * @return WIFI_MANAGER_INVALID_ARGS  :  input parameter invalid
- * @since TinzeRT v2.0 PRE
- */
-
-wifi_manager_result_e wifi_manager_mac_str_to_mac_addr(char mac_str[20], char mac_addr[6]);
-
 #endif
 /**
  *@}

--- a/framework/src/wifi_manager/wifi_manager.c
+++ b/framework/src/wifi_manager/wifi_manager.c
@@ -1478,30 +1478,3 @@ wifi_manager_result_e wifi_manager_remove_config(void)
 	WIFIMGR_CHECK_UTILRESULT(wifi_profile_reset(), "wifimgr remove config fail\n", WIFI_MANAGER_FAIL);
 	return WIFI_MANAGER_SUCCESS;
 }
-
-wifi_manager_result_e wifi_manager_mac_addr_to_mac_str(char mac_addr[6], char mac_str[20])
-{
-	wifi_manager_result_e wret = WIFI_MANAGER_INVALID_ARGS;
-	if (mac_addr && mac_str) {
-		snprintf(mac_str, 18, "%02X:%02X:%02X:%02X:%02X:%02X", mac_addr[0], mac_addr[1], mac_addr[2], mac_addr[3], mac_addr[4], mac_addr[5]);
-		wret = WIFI_MANAGER_SUCCESS;
-	} else {
-		WIFIADD_ERR_RECORD(ERR_WIFIMGR_INVALID_ARGUMENTS);
-	}
-	return wret;
-}
-
-wifi_manager_result_e wifi_manager_mac_str_to_mac_addr(char mac_str[20], char mac_addr[6])
-{
-	wifi_manager_result_e wret = WIFI_MANAGER_INVALID_ARGS;
-	if (mac_addr && mac_str) {
-		int ret = sscanf(mac_str, "%hhx:%hhx:%hhx:%hhx:%hhx:%hhx%*c", &mac_addr[0], &mac_addr[1], &mac_addr[2], &mac_addr[3], &mac_addr[4], &mac_addr[5]);
-		if (ret == WIFIMGR_MACADDR_LEN) {
-			wret = WIFI_MANAGER_SUCCESS;	
-		}
-	} else {
-		WIFIADD_ERR_RECORD(ERR_WIFIMGR_INVALID_ARGUMENTS);
-	}
-	return wret;
-}
-


### PR DESCRIPTION
- APIs dealing with MAC addr are not suitable as public APIs, which are removed.
- Those APIs are moved into the application wm_test
- Arrange line spacing of wm_test (one line b/w functions)