### PR TITLE
make: make a romfs.img on Makefile, not download script

### DIFF
--- a/build/configs/artik05x/artik05x_download.sh
+++ b/build/configs/artik05x/artik05x_download.sh
@@ -54,26 +54,6 @@ Options:
 EOF
 }
 
-make_romfs()
-{
-	for part in "$@"; do
-		case "${part}" in
-			rom)
-				# Make romfs.img
-				pushd ${OS_DIR_PATH} > /dev/null
-				sh ../tools/fs/mkromfsimg.sh
-				if [ ! -f "${OUTPUT_BINARY_PATH}/romfs.img" ]; then
-					echo "ROMFS image is not present"
-					exit 1
-				fi
-				popd > /dev/null
-				;;
-			*)
-				;;
-		esac
-	done
-}
-
 compute_fw_parts()
 {
 	bl1=0; bl2=0; sssfw=0; wlanfw=0; os=0; rom=0; ota=0;
@@ -170,12 +150,9 @@ download()
 	parts=$(compute_fw_parts $1)
 	echo "The \"${parts}\" partition(s) will be flashed"
 
-	# Generate ROMFS image
-	make_romfs ${parts}
-
 	# Make Openocd commands for parts
 	commands=$(compute_ocd_commands ${parts})
-    echo "ocd command to run: ${commands}"
+	echo "ocd command to run: ${commands}"
 
 	# Generate Partition Map
 	${SCRIPTS_PATH}/partition_gen.sh

--- a/build/configs/sidk_s5jt200/sidk_s5jt200_download.sh
+++ b/build/configs/sidk_s5jt200/sidk_s5jt200_download.sh
@@ -33,8 +33,6 @@ OUTPUT_BIN_PATH=${BUILD_DIR_PATH}/output/bin
 BOARD_DIR_PATH=${BUILD_DIR_PATH}/configs/${BOARD_NAME}
 OPENOCD_DIR_PATH=${BOARD_DIR_PATH}/tools/openocd
 FW_DIR_PATH=${BOARD_DIR_PATH}/boot_bin
-FSTOOLS_DIR_PATH=${OS_DIR_PATH}/../tools/fs
-RESOURCE_DIR_PATH=${FSTOOLS_DIR_PATH}/contents
 
 SYSTEM_TYPE=`getconf LONG_BIT`
 if [ "$SYSTEM_TYPE" = "64" ]; then
@@ -42,18 +40,6 @@ if [ "$SYSTEM_TYPE" = "64" ]; then
 else
 	OPENOCD_BIN_PATH=${OPENOCD_DIR_PATH}/linux32
 fi
-
-# ROMFS
-prepare_resource()
-{
-	if [ -d "${RESOURCE_DIR_PATH}" ]; then
-		echo "Packing resources into romfs.img ..."
-
-		# create romfs.img
-		sh ${FSTOOLS_DIR_PATH}/mkromfsimg.sh
-	fi
-}
-
 
 # MAIN
 main()
@@ -82,14 +68,6 @@ main()
 				[ ! -f "${FW_DIR_PATH}/t20.wlan.bin" ]; then
 				echo "Firmware binaries for sidk_s5jt200 are not existed"
 				exit 1
-			fi
-
-			if [ "${CONFIG_FS_ROMFS}" == "y" ]; then
-				prepare_resource
-				if [ ! -f "${OUTPUT_BIN_PATH}/romfs.img" ]; then
-					echo "ROMFS image is not present"
-					exit 1
-				fi
 			fi
 
 			# Generate Partition Map

--- a/os/Makefile.unix
+++ b/os/Makefile.unix
@@ -237,7 +237,7 @@ endif
 BIN_EXE = tinyara$(EXEEXT)
 BIN = $(BIN_DIR)/$(BIN_EXE)
 
-memstat: $(BIN)
+memstat: $(BIN) romfs
 
 all: memstat
 .PHONY: context clean_context check_context config oldconfig menuconfig nconfig qconfig gconfig export subdir_clean clean subdir_distclean distclean apps_clean apps_distclean force_build applist appupdate
@@ -696,4 +696,14 @@ endif
 appupdate:
 ifneq ($(APPDIR),)
 	$(Q) $(MAKE) -C "$(TOPDIR)/$(APPDIR)" TOPDIR="$(TOPDIR)" appupdate
+endif
+
+# romfs
+#
+# The romfs target will make a romfs image by calling mkromfsimg.sh.
+# The content of romfs should be in $(TOPDIR)/../tools/fs/contents folder.
+
+romfs:
+ifeq ($(CONFIG_FS_ROMFS),y)
+	$(Q) ../tools/fs/mkromfsimg.sh
 endif


### PR DESCRIPTION
Currently, romfs.img is made when download script is executed.
But it is not a step of downloading, it is a kind of binary
building.
It is better executing on Makefile, not download script.
"make", "make all" and "make romfs" makes romfs.img when CONFIG_FS_ROMFS
is enabled.

Signed-off-by: sunghan-chang <sh924.chang@samsung.com>