### PR TITLE
system: remove mounting procfs and reading it for sysinfo

### DIFF
--- a/apps/system/init/init.c
+++ b/apps/system/init/init.c
@@ -102,14 +102,6 @@ int preapp_start(int argc, char *argv[])
 	int pid;
 #endif
 
-#if defined(CONFIG_BUILD_PROTECTED) && defined(CONFIG_FS_PROCFS)
-	int ret;
-	ret = mount(NULL, "/proc", "procfs", 0, NULL);
-	if (ret < 0) {
-		printf("procfs mount is failed, error code is %d\n", get_errno());
-	}
-#endif
-
 #ifdef CONFIG_SYSTEM_INFORMATION
 	sysinfo();
 #endif

--- a/apps/system/sysinfo/sysinfo.c
+++ b/apps/system/sysinfo/sysinfo.c
@@ -83,28 +83,9 @@ void sysinfo(void)
 	printf("System Information:\n");
 
 	/* Print OS version and Build information */
-#ifdef CONFIG_BUILD_PROTECTED
-	/* When Protected build, get values from reading version entry in procfs */
-	int fd;
-	ssize_t nread;
-
-	fd = open(PROC_VERSION_PATH, O_RDONLY);
-	if (fd > 0) {
-		do {
-			nread = read(fd, sysinfo_str, MAX_BUF_SIZE);
-			sysinfo_str[nread] = '\0';
-			printf("\t%s", sysinfo_str);
-		} while (nread == MAX_BUF_SIZE);
-		close(fd);
-		printf("\n");
-	} else {
-		printf("Procfs is not mounted so that we can not printf sysinfo\n");
-	}
-#else
-	/* When flat build, just get values defined in version.h */
+	/* just get values defined in version.h */
 	printf("\tVersion: " CONFIG_VERSION_STRING "\n\tCommit Hash: %s\n", CONFIG_VERSION_BUILD);
 	printf("\tBuild User: " CONFIG_VERSION_BUILD_USER "\n\tBuild Time: %s\n", CONFIG_VERSION_BUILD_TIME);
-#endif
 
 	/* Get the current time as specific format in the buffer */
 	now = time(NULL);


### PR DESCRIPTION
1. mount procfs
 CONFIG_FS_AUTOMOUNT_PROCFS does it on fs_auto_mount() so that
 mounting it on preapp_start() should be removed.
2. read version info from procfs
 Even if CONFIG_BUILD_PROTECTED is enabled, version.h can be
 read from anywhere. That is not a value of kernel context.

Signed-off-by: sunghan-chang <sh924.chang@samsung.com>