### PR TITLE
media: modify observer for recorder

### DIFF
--- a/apps/examples/testcase/ta_tc/media/utc/utc_media_mediarecorder.cpp
+++ b/apps/examples/testcase/ta_tc/media/utc/utc_media_mediarecorder.cpp
@@ -35,7 +35,7 @@ static const char *filePath = "/tmp/record";
 static void utc_media_MediaRecorder_create_p(void)
 {
 	MediaRecorder mr;
-	TC_ASSERT_EQ("utc_media_mediarecorder_create", mr.create(), RECORDER_OK);
+	TC_ASSERT_EQ("utc_media_mediarecorder_create", mr.create(), RECORDER_ERROR_NONE);
 
 	mr.destroy();
 	TC_SUCCESS_RESULT();
@@ -46,7 +46,7 @@ static void utc_media_MediaRecorder_create_n(void)
 	MediaRecorder mr;
 	mr.create();
 
-	TC_ASSERT_EQ("utc_media_mediarecorder_create", mr.create(), RECORDER_ERROR);
+	TC_ASSERT_EQ("utc_media_mediarecorder_create", mr.create(), RECORDER_ERROR_INVALID_STATE);
 
 	mr.destroy();
 	TC_SUCCESS_RESULT();
@@ -56,7 +56,7 @@ static void utc_media_MediaRecorder_destroy_p(void)
 {
 	MediaRecorder mr;
 	mr.create();
-	TC_ASSERT_EQ("utc_media_MediaRecorder_destroy", mr.destroy(), RECORDER_OK);
+	TC_ASSERT_EQ("utc_media_MediaRecorder_destroy", mr.destroy(), RECORDER_ERROR_NONE);
 
 	TC_SUCCESS_RESULT();
 }
@@ -65,11 +65,11 @@ static void utc_media_MediaRecorder_destroy_n(void)
 {
 	MediaRecorder mr;
 	unique_ptr<FileOutputDataSource> dataSource = unique_ptr<FileOutputDataSource>(new FileOutputDataSource(channels, sampleRate, pcmFormat, filePath));
-	TC_ASSERT_EQ("utc_media_MediaRecorder_destroy", mr.destroy(), RECORDER_ERROR);
+	TC_ASSERT_EQ("utc_media_MediaRecorder_destroy", mr.destroy(), RECORDER_ERROR_NOT_ALIVE);
 	mr.create();
 	mr.setDataSource(std::move(dataSource));
 	mr.prepare();
-	TC_ASSERT_EQ("utc_media_MediaRecorder_destroy", mr.destroy(), RECORDER_ERROR);
+	TC_ASSERT_EQ("utc_media_MediaRecorder_destroy", mr.destroy(), RECORDER_ERROR_INVALID_STATE);
 	mr.unprepare();
 	mr.destroy();
 
@@ -81,7 +81,7 @@ static void utc_media_MediaRecorder_setDataSource_p(void)
 	MediaRecorder mr;
 	mr.create();
 	unique_ptr<FileOutputDataSource> dataSource = unique_ptr<FileOutputDataSource>(new FileOutputDataSource(channels, sampleRate, pcmFormat, filePath));
-	TC_ASSERT_EQ("utc_media_mediarecorder_setDataSource", mr.setDataSource(std::move(dataSource)), RECORDER_OK);
+	TC_ASSERT_EQ("utc_media_mediarecorder_setDataSource", mr.setDataSource(std::move(dataSource)), RECORDER_ERROR_NONE);
 	mr.destroy();
 
 	TC_SUCCESS_RESULT();
@@ -94,12 +94,12 @@ static void utc_media_MediaRecorder_setDataSource_n(void)
 
 	unique_ptr<FileOutputDataSource> dataSource = unique_ptr<FileOutputDataSource>(new FileOutputDataSource(channels, sampleRate, pcmFormat, filePath));
 	mr.create();
-	TC_ASSERT_EQ("utc_media_mediarecorder_setDataSource", mr.setDataSource(std::move(nullptr)), RECORDER_ERROR);
-	TC_ASSERT_EQ("utc_media_mediarecorder_setDataSource", mr2.setDataSource(std::move(dataSource)), RECORDER_ERROR);
+	TC_ASSERT_EQ("utc_media_mediarecorder_setDataSource", mr.setDataSource(std::move(nullptr)), RECORDER_ERROR_INVALID_DATASOURCE);
+	TC_ASSERT_EQ("utc_media_mediarecorder_setDataSource", mr2.setDataSource(std::move(dataSource)), RECORDER_ERROR_INVALID_STATE);
 	mr.destroy();
-
 	dataSource = unique_ptr<FileOutputDataSource>(new FileOutputDataSource(channels, sampleRate, pcmFormat, filePath));
-	TC_ASSERT_EQ("utc_media_mediarecorder_setDataSource", mr.setDataSource(std::move(dataSource)), RECORDER_ERROR);
+	TC_ASSERT_EQ("utc_media_mediarecorder_setDataSource", mr.setDataSource(std::move(dataSource)), RECORDER_ERROR_NOT_ALIVE);
+
 	TC_SUCCESS_RESULT();
 }
 
@@ -110,7 +110,7 @@ static void utc_media_MediaRecorder_setVolume_p(void)
 	mr.create();
 	mr.setDataSource(std::move(dataSource));
 	mr.prepare();
-	TC_ASSERT_EQ("utc_media_mediarecorder_setVolume", mr.setVolume(10), RECORDER_OK);
+	TC_ASSERT_EQ("utc_media_mediarecorder_setVolume", mr.setVolume(10), RECORDER_ERROR_NONE);
 	mr.unprepare();
 	mr.destroy();
 	TC_SUCCESS_RESULT();
@@ -120,11 +120,11 @@ static void utc_media_MediaRecorder_setVolume_n(void)
 {
 	MediaRecorder mr;
 	unique_ptr<FileOutputDataSource> dataSource = unique_ptr<FileOutputDataSource>(new FileOutputDataSource(channels, sampleRate, pcmFormat, filePath));
-	TC_ASSERT_EQ("utc_media_mediarecorder_setVolume", mr.setVolume(10), RECORDER_ERROR);
+	TC_ASSERT_EQ("utc_media_mediarecorder_setVolume", mr.setVolume(10), RECORDER_ERROR_NOT_ALIVE);
 	mr.create();
 	mr.setDataSource(std::move(dataSource));
 	mr.prepare();
-	TC_ASSERT_EQ("utc_media_mediarecorder_setVolume", mr.setVolume(11), RECORDER_OK);
+	TC_ASSERT_EQ("utc_media_mediarecorder_setVolume", mr.setVolume(11), RECORDER_ERROR_NONE);
 	mr.unprepare();
 	mr.destroy();
 	TC_SUCCESS_RESULT();
@@ -155,7 +155,15 @@ static void utc_media_MediaRecorder_getVolume_p(void)
 static void utc_media_MediaRecorder_getVolume_n(void)
 {
 	MediaRecorder mr;
+	uint8_t volume;
+	unique_ptr<FileOutputDataSource> dataSource = unique_ptr<FileOutputDataSource>(new FileOutputDataSource(channels, sampleRate, pcmFormat, filePath));
+	TC_ASSERT_EQ("utc_media_MediaRecorder_getVolume", mr.getVolume(&volume), RECORDER_ERROR_NOT_ALIVE);
+	mr.create();
+	mr.setDataSource(std::move(dataSource));
+	mr.prepare();
 	TC_ASSERT_EQ("utc_media_MediaRecorder_getVolume", mr.getVolume(nullptr), RECORDER_ERROR_INVALID_PARAM);
+	mr.unprepare();
+	mr.destroy();
 
 	TC_SUCCESS_RESULT();
 }
@@ -167,7 +175,7 @@ static void utc_media_MediaRecorder_prepare_p(void)
 
 	mr.create();
 	mr.setDataSource(std::move(dataSource));
-	TC_ASSERT_EQ("utc_media_MediaRecorder_prepare", mr.prepare(), RECORDER_OK);
+	TC_ASSERT_EQ("utc_media_MediaRecorder_prepare", mr.prepare(), RECORDER_ERROR_NONE);
 	mr.unprepare();
 	mr.destroy();
 
@@ -182,7 +190,7 @@ static void utc_media_MediaRecorder_prepare_n(void)
 	mr.create();
 	mr.setDataSource(std::move(dataSource));
 	mr.prepare();
-	TC_ASSERT_EQ("utc_media_MediaRecorder_prepare", mr.prepare(), RECORDER_ERROR);
+	TC_ASSERT_EQ("utc_media_MediaRecorder_prepare", mr.prepare(), RECORDER_ERROR_INVALID_STATE);
 	mr.unprepare();
 	mr.destroy();
 
@@ -197,7 +205,7 @@ static void utc_media_MediaRecorder_unprepare_p(void)
 	mr.create();
 	mr.setDataSource(std::move(dataSource));
 	mr.prepare();
-	TC_ASSERT_EQ("utc_media_MediaRecorder_unprepare", mr.unprepare(), RECORDER_OK);
+	TC_ASSERT_EQ("utc_media_MediaRecorder_unprepare", mr.unprepare(), RECORDER_ERROR_NONE);
 	mr.destroy();
 
 	TC_SUCCESS_RESULT();
@@ -212,7 +220,7 @@ static void utc_media_MediaRecorder_unprepare_n(void)
 	mr.setDataSource(std::move(dataSource));
 	mr.prepare();
 	mr.unprepare();
-	TC_ASSERT_EQ("utc_media_MediaRecorder_unprepare", mr.unprepare(), RECORDER_ERROR);
+	TC_ASSERT_EQ("utc_media_MediaRecorder_unprepare", mr.unprepare(), RECORDER_ERROR_INVALID_STATE);
 	mr.destroy();
 
 	TC_SUCCESS_RESULT();
@@ -224,19 +232,27 @@ public:
 	RecorderTest() {}
 	~RecorderTest() {}
 
-	void onRecordStarted(Id id) override
+	void onRecordStarted(MediaRecorder& mediaRecorder) override
 	{
 		notifyStarted();
 	}
-	void onRecordPaused(Id id) override
+	void onRecordPaused(MediaRecorder& mediaRecorder) override
 	{
 		notifyPaused();
 	}
-	void onRecordFinished(Id id) override
+	void onRecordFinished(MediaRecorder& mediaRecorder) override
 	{
 		notifyFinished();
 	}
-	void onRecordError(Id id) override
+	void onRecordStartError(MediaRecorder& mediaRecorder, int ret) override
+	{
+		notifyError();
+	}
+	void onRecordPauseError(MediaRecorder& mediaRecorder, int ret) override
+	{
+		notifyError();
+	}
+	void onRecordStopError(MediaRecorder& mediaRecorder, int ret) override
 	{
 		notifyError();
 	}
@@ -318,8 +334,8 @@ static void utc_media_MediaRecorder_setDuration_p(void)
 	mr.setObserver(observer);
 	mr.setDataSource(std::move(dataSource));
 
-	TC_ASSERT_EQ("utc_media_MediaRecorder_setDuration", mr.setDuration(RECORD_DURATION), RECORDER_OK);
-	TC_ASSERT_EQ("utc_media_MediaRecorder_setDuration", mr.prepare(), RECORDER_OK);
+	TC_ASSERT_EQ("utc_media_MediaRecorder_setDuration", mr.setDuration(RECORD_DURATION), RECORDER_ERROR_NONE);
+	TC_ASSERT_EQ("utc_media_MediaRecorder_setDuration", mr.prepare(), RECORDER_ERROR_NONE);
 	mr.start();
 	sleep(RECORD_DURATION + 1);
 	mr.stop();
@@ -342,7 +358,7 @@ static void utc_media_MediaRecorder_setDuration_p(void)
 		break;
 	}
 
-	TC_ASSERT_EQ("utc_media_MediaRecorder_setDuration", get_file_size(), RECORD_DURATION * channels * sampleRate * byte);
+	TC_ASSERT_EQ("utc_media_MediaRecorder_setDuration", get_file_size(), (int)(RECORD_DURATION * channels * sampleRate * byte));
 
 	TC_SUCCESS_RESULT();
 }
@@ -358,7 +374,7 @@ static void utc_media_MediaRecorder_setDuration_n(void)
 	mr.setDataSource(std::move(dataSource));
 	mr.prepare();
 
-	TC_ASSERT_EQ("utc_media_MediaRecorder_setDuration", mr.setDuration(RECORD_DURATION), RECORDER_ERROR);
+	TC_ASSERT_EQ("utc_media_MediaRecorder_setDuration", mr.setDuration(RECORD_DURATION), RECORDER_ERROR_INVALID_STATE);
 	mr.start();
 	observer->waitStarted();
 	mr.stop();
@@ -486,7 +502,7 @@ static void utc_media_MediaRecorder_setObserver_p(void)
 	MediaRecorder mr;
 	mr.create();
 
-	TC_ASSERT_EQ("utc_media_MediaRecorder_setObserver", mr.setObserver(nullptr), RECORDER_OK);
+	TC_ASSERT_EQ("utc_media_MediaRecorder_setObserver", mr.setObserver(nullptr), RECORDER_ERROR_NONE);
 
 	mr.destroy();
 	TC_SUCCESS_RESULT();
@@ -496,7 +512,7 @@ static void utc_media_MediaRecorder_setObserver_n(void)
 {
 	MediaRecorder mr;
 
-	TC_ASSERT_EQ("utc_media_MediaRecorder_setObserver", mr.setObserver(nullptr), RECORDER_ERROR);
+	TC_ASSERT_EQ("utc_media_MediaRecorder_setObserver", mr.setObserver(nullptr), RECORDER_ERROR_NOT_ALIVE);
 
 	TC_SUCCESS_RESULT();
 }

--- a/framework/include/media/MediaRecorder.h
+++ b/framework/include/media/MediaRecorder.h
@@ -36,21 +36,34 @@
 
 namespace media {
 
+class MediaRecorderImpl;
+
 /**
  * @brief result of call the apis
  * @details @b #include <media/MediaRecorder.h>
  * @since TizenRT v2.0 PRE
  */
-typedef enum recorder_result_e {
+typedef enum recorder_error_e : int {
 	/** MediaRecorder Error case */
-	RECORDER_ERROR_INVALID_OPERATION = -2,
-	RECORDER_ERROR_INVALID_PARAM = -1,
-	RECORDER_ERROR,
+	RECORDER_ERROR_NOT_ALIVE = -16,
+	RECORDER_ERROR_INVALID_STATE,
+	RECORDER_ERROR_INVALID_FRAME,
+	RECORDER_ERROR_INVALID_OPERATION,
+	RECORDER_ERROR_INVALID_PARAM,
+	RECORDER_ERROR_INVALID_DATASOURCE,
+	RECORDER_ERROR_INIT_AUDIO_FAILED,
+	RECORDER_ERROR_FILE_OPEN_FAILED,
+	RECORDER_ERROR_SET_AUDIO_FAILED,
+	RECORDER_ERROR_RESET_AUDIO_FAILED,
+	RECORDER_ERROR_CAPTURE_AUDIO_FAILED,
+	RECORDER_ERROR_PAUSE_AUDIO_FAILED,
+	RECORDER_ERROR_STOP_AUDIO_FAILED,
+	RECORDER_ERROR_OUT_OF_MEMORY,
+	RECORDER_ERROR_SET_VOLUME_AUDIO_FAILED,
+	RECORDER_ERROR_GET_VOLUME_AUDIO_FAILED,
 	/** MediaRecorder Success case */
-	RECORDER_OK
-} recorder_result_t;
-
-class MediaRecorderImpl;
+	RECORDER_ERROR_NONE = 0
+} recorder_error_t;
 
 /**
  * @class 
@@ -82,7 +95,7 @@ public:
 	 * @return The result of the create operation
 	 * @since TizenRT v2.0 PRE
 	 */
-	recorder_result_t create();
+	recorder_error_t create();
 	
 	/**
 	 * @brief Destroy MediaRecorder
@@ -91,7 +104,7 @@ public:
 	 * @return The result of the destroy operation
 	 * @since TizenRT v2.0 PRE
 	 */
-	recorder_result_t destroy();
+	recorder_error_t destroy();
 	
 	/**
 	 * @brief Allocate and prepare resources related to the recorder, it should be called before start
@@ -100,7 +113,7 @@ public:
 	 * @return The result of the prepare operation
 	 * @since TizenRT v2.0 PRE
 	 */
-	recorder_result_t prepare();
+	recorder_error_t prepare();
 	
 	/**
 	 * @brief Releases allocated resources related to the recorder.
@@ -109,7 +122,7 @@ public:
 	 * @return The result of the unpreapre operation
 	 * @since TizenRT v2.0 PRE
 	 */
-	recorder_result_t unprepare();
+	recorder_error_t unprepare();
 	
 	/**
 	 * @brief Start recording.
@@ -119,7 +132,7 @@ public:
 	 * @return The result of the unpreapre operation
 	 * @since TizenRT v2.0 PRE
 	 */
-	recorder_result_t start();
+	recorder_error_t start();
 	
 	/**
 	 * @brief Pause recording.
@@ -129,7 +142,7 @@ public:
 	 * @return The result of the pause operation
 	 * @since TizenRT v2.0 PRE
 	 */
-	recorder_result_t pause();
+	recorder_error_t pause();
 	
 	/**
 	 * @brief Stop recording.
@@ -139,7 +152,7 @@ public:
 	 * @return The result of the stop operation
 	 * @since TizenRT v2.0 PRE
 	 */
-	recorder_result_t stop();
+	recorder_error_t stop();
 	
 	/**
 	 * @brief Gets the current volume
@@ -148,7 +161,7 @@ public:
 	 * @return The value of current mic volume
 	 * @since TizenRT v2.0 PRE
 	 */
-	recorder_result_t getVolume(uint8_t *vol);
+	recorder_error_t getVolume(uint8_t *vol);
 	
 	/**
 	 * @brief Sets the volume adjusted
@@ -158,7 +171,7 @@ public:
 	 * @return The result of setting the mic volume
 	 * @since TizenRT v2.0 PRE
 	 */
-	recorder_result_t setVolume(uint8_t vol);
+	recorder_error_t setVolume(uint8_t vol);
 	
 	/**
 	 * @brief Sets the DatSource of output data
@@ -168,7 +181,7 @@ public:
 	 * @return The result of setting the datasource
 	 * @since TizenRT v2.0 PRE
 	 */
-	recorder_result_t setDataSource(std::unique_ptr<stream::OutputDataSource> dataSource);
+	recorder_error_t setDataSource(std::unique_ptr<stream::OutputDataSource> dataSource);
 	
 	/**
 	 * @brief Sets the observer of MediaRecorder
@@ -179,7 +192,7 @@ public:
 	 * @return The result of setting the observer
 	 * @since TizenRT v2.0 PRE
 	 */
-	recorder_result_t setObserver(std::shared_ptr<MediaRecorderObserverInterface> observer);
+	recorder_error_t setObserver(std::shared_ptr<MediaRecorderObserverInterface> observer);
 
 	/**
 	 * @brief Set limitation of recording time by given value(second), will be stopped when it reaches that.
@@ -191,7 +204,7 @@ public:
 	 * @return The result of setting the duration
 	 * @since TizenRT v2.0 PRE
 	 */
-	recorder_result_t setDuration(int second);
+	recorder_error_t setDuration(int second);
 
 private:
 	std::shared_ptr<MediaRecorderImpl> mPMrImpl;

--- a/framework/include/media/MediaRecorderObserverInterface.h
+++ b/framework/include/media/MediaRecorderObserverInterface.h
@@ -29,7 +29,12 @@
 #ifndef __MEDIA_MEDIARECOREROBSERVERINTERFACE_H
 #define __MEDIA_MEDIARECOREROBSERVERINTERFACE_H
 
+#include <media/MediaRecorder.h>
+#include <media/MediaTypes.h>
+
 namespace media {
+
+class MediaRecorder;
 /**
  * @class
  * @brief This class provides an interface to the user.
@@ -38,6 +43,7 @@ namespace media {
  * This class informs the user of the error state of MediaRecorder
  * @since TizenRT v2.0 PRE
  */
+
 class MediaRecorderObserverInterface
 {
 public:
@@ -53,25 +59,37 @@ public:
 	 * @details @b #include <media/MediaRecorderObserverInterface.h>
 	 * @since TizenRT v2.0 PRE
 	 */
-	virtual void onRecordStarted(Id id) = 0;
+	virtual void onRecordStarted(MediaRecorder& mediaRecorder) = 0;
 	/**
 	 * @brief informs the user of the recording has paused.
 	 * @details @b #include <media/MediaRecorderObserverInterface.h>
 	 * @since TizenRT v2.0 PRE
 	 */
-	virtual void onRecordPaused(Id id) = 0;
+	virtual void onRecordPaused(MediaRecorder& mediaRecorder) = 0;
 	/**
 	 * @brief informs the user of the recording has finished.
 	 * @details @b #include <media/MediaRecorderObserverInterface.h>
 	 * @since TizenRT v2.0 PRE
 	 */
-	virtual void onRecordFinished(Id id) = 0;
+	virtual void onRecordFinished(MediaRecorder& mediaRecorder) = 0;
 	/**
-	 * @brief informs the user of the error state of recorder operation
+	 * @brief informs the user of the error state of recorder start operation
 	 * @details @b #include <media/MediaRecorderObserverInterface.h>
 	 * @since TizenRT v2.0 PRE
 	 */
-	virtual void onRecordError(Id id) = 0;
+	virtual void onRecordStartError(MediaRecorder& mediaRecorder, int errCode) = 0;
+	/**
+	 * @brief informs the user of the error state of recorder pause operation
+	 * @details @b #include <media/MediaRecorderObserverInterface.h>
+	 * @since TizenRT v2.0 PRE
+	 */
+	virtual void onRecordPauseError(MediaRecorder& mediaRecorder, int errCode) = 0;
+	/**
+	 * @brief informs the user of the error state of recorder stop operation
+	 * @details @b #include <media/MediaRecorderObserverInterface.h>
+	 * @since TizenRT v2.0 PRE
+	 */
+	virtual void onRecordStopError(MediaRecorder& mediaRecorder, int errCode) = 0;
 };
 } // namespace media
 

--- a/framework/include/media/MediaTypes.h
+++ b/framework/include/media/MediaTypes.h
@@ -33,7 +33,6 @@
 
 namespace media {
 
-
 /**
  * @brief Audio type.
  * @details
@@ -50,14 +49,14 @@ typedef enum audio_type_e {
 	AUDIO_TYPE_AAC = 2,
 	/** Audio type is PCM */
 	AUDIO_TYPE_PCM = 3,
-	/** Audio type is PCM */
+	/** Audio type is OPUS */
 	AUDIO_TYPE_OPUS = 4,
-	/** Audio type is PCM */
+	/** Audio type is FLAC */
 	AUDIO_TYPE_FLAC = 5
 } audio_type_t;
 
 /**
- * @class 
+ * @class
  * @brief Audio format type, each value follows pcm_format in tinyalsa.
  * @details
  * @since TizenRT v2.0 PRE

--- a/framework/src/media/MediaRecorder.cpp
+++ b/framework/src/media/MediaRecorder.cpp
@@ -21,66 +21,66 @@
 #include "RecorderWorker.h"
 
 namespace media {
-MediaRecorder::MediaRecorder() : mPMrImpl(new MediaRecorderImpl())
+MediaRecorder::MediaRecorder() : mPMrImpl(new MediaRecorderImpl(*this))
 {
 }
 
-recorder_result_t MediaRecorder::create()
+recorder_error_t MediaRecorder::create()
 {
 	return mPMrImpl->create();
 }
 
-recorder_result_t MediaRecorder::destroy() // sync call
+recorder_error_t MediaRecorder::destroy()
 {
 	return mPMrImpl->destroy();
 }
 
-recorder_result_t MediaRecorder::prepare()
+recorder_error_t MediaRecorder::prepare()
 {
 	return mPMrImpl->prepare();
 }
 
-recorder_result_t MediaRecorder::unprepare()
+recorder_error_t MediaRecorder::unprepare()
 {
 	return mPMrImpl->unprepare();
 }
 
-recorder_result_t MediaRecorder::start()
+recorder_error_t MediaRecorder::start()
 {
 	return mPMrImpl->start();
 }
 
-recorder_result_t MediaRecorder::stop()
+recorder_error_t MediaRecorder::stop()
 {
 	return mPMrImpl->stop();
 }
 
-recorder_result_t MediaRecorder::pause()
+recorder_error_t MediaRecorder::pause()
 {
 	return mPMrImpl->pause();
 }
 
-recorder_result_t MediaRecorder::getVolume(uint8_t *vol)
+recorder_error_t MediaRecorder::getVolume(uint8_t *vol)
 {
 	return mPMrImpl->getVolume(vol);
 }
 
-recorder_result_t MediaRecorder::setVolume(uint8_t vol)
+recorder_error_t MediaRecorder::setVolume(uint8_t vol)
 {
 	return mPMrImpl->setVolume(vol);
 }
 
-recorder_result_t MediaRecorder::setDataSource(std::unique_ptr<stream::OutputDataSource> dataSource)
+recorder_error_t MediaRecorder::setDataSource(std::unique_ptr<stream::OutputDataSource> dataSource)
 {
 	return mPMrImpl->setDataSource(std::move(dataSource));
 }
 
-recorder_result_t MediaRecorder::setObserver(std::shared_ptr<MediaRecorderObserverInterface> observer)
+recorder_error_t MediaRecorder::setObserver(std::shared_ptr<MediaRecorderObserverInterface> observer)
 {
 	return mPMrImpl->setObserver(observer);
 }
 
-recorder_result_t MediaRecorder::setDuration(int second)
+recorder_error_t MediaRecorder::setDuration(int second)
 {
 	return mPMrImpl->setDuration(second);
 }

--- a/framework/src/media/MediaRecorderImpl.h
+++ b/framework/src/media/MediaRecorderImpl.h
@@ -58,58 +58,60 @@ typedef enum observer_command_e {
 	OBSERVER_COMMAND_STARTED,
 	OBSERVER_COMMAND_PAUSED,
 	OBSERVER_COMMAND_FINISHIED,
-	OBSERVER_COMMAND_ERROR
+	OBSERVER_COMMAND_START_ERROR,
+	OBSERVER_COMMAND_PAUSE_ERROR,
+	OBSERVER_COMMAND_STOP_ERROR
 } observer_command_t;
 
 class MediaRecorderImpl : public enable_shared_from_this<MediaRecorderImpl>
 {
 public:
-	MediaRecorderImpl();
+	MediaRecorderImpl(MediaRecorder& recorder);
 	~MediaRecorderImpl();
 
-	recorder_result_t create();
-	recorder_result_t destroy();
-	recorder_result_t prepare();
-	recorder_result_t unprepare();
+	recorder_error_t create();
+	recorder_error_t destroy();
+	recorder_error_t prepare();
+	recorder_error_t unprepare();
 
-	recorder_result_t start();
-	recorder_result_t pause();
-	recorder_result_t stop();
+	recorder_error_t start();
+	recorder_error_t pause();
+	recorder_error_t stop();
 
-	recorder_result_t getVolume(uint8_t *vol);
-	recorder_result_t setVolume(uint8_t vol);
-	recorder_result_t setDataSource(std::unique_ptr<stream::OutputDataSource> dataSource);
+	recorder_error_t getVolume(uint8_t *vol);
+	recorder_error_t setVolume(uint8_t vol);
+	recorder_error_t setDataSource(std::unique_ptr<stream::OutputDataSource> dataSource);
 	recorder_state_t getState();
-	recorder_result_t setObserver(std::shared_ptr<MediaRecorderObserverInterface> observer);
-	recorder_result_t setDuration(int second);
+	recorder_error_t setObserver(std::shared_ptr<MediaRecorderObserverInterface> observer);
+	recorder_error_t setDuration(int second);
 	void notifySync();
-	void notifyObserver(observer_command_t cmd);
+	void notifyObserver(observer_command_t cmd, recorder_error_t errCode = RECORDER_ERROR_NONE);
 	void capture();
 
 private:
-	void createRecorder(recorder_result_t& ret);
-	void destroyRecorder(recorder_result_t& ret);
-	void prepareRecorder(recorder_result_t& ret);
-	void unprepareRecorder(recorder_result_t& ret);
+	void createRecorder(recorder_error_t& ret);
+	void destroyRecorder(recorder_error_t& ret);
+	void prepareRecorder(recorder_error_t& ret);
+	void unprepareRecorder(recorder_error_t& ret);
 	void startRecorder();
 	void pauseRecorder();
-	void stopRecorder(int errcode);
-	void getRecorderVolume(uint8_t *vol, recorder_result_t& ret);
-	void setRecorderVolume(uint8_t vol, recorder_result_t& ret);
+	void stopRecorder(recorder_error_t ret);
+	void getRecorderVolume(uint8_t *vol, recorder_error_t& ret);
+	void setRecorderVolume(uint8_t vol, recorder_error_t& ret);
 	void setRecorderObserver(std::shared_ptr<MediaRecorderObserverInterface> observer);
-	void setRecorderDataSource(std::shared_ptr<stream::OutputDataSource> dataSource, recorder_result_t& ret);
-	void setRecorderDuration(int second, recorder_result_t& ret);
+	void setRecorderDataSource(std::shared_ptr<stream::OutputDataSource> dataSource, recorder_error_t& ret);
+	void setRecorderDuration(int second, recorder_error_t& ret);
 
 private:
 	std::atomic<recorder_state_t> mCurState;
 	std::shared_ptr<stream::OutputDataSource> mOutputDataSource;
 	std::shared_ptr<MediaRecorderObserverInterface> mRecorderObserver;
 
+	MediaRecorder& mRecorder;
 	unsigned char* mBuffer;
 	int mBuffSize;
 	mutex mCmdMtx; // command mutex
 	std::condition_variable mSyncCv;
-	int mId;
 	int mDuration;
 	uint32_t mTotalFrames;
 	uint32_t mCapturedFrames;


### PR DESCRIPTION
1. remove instance id(not required)
  : Use the mediarecorder object instead of instance id
2. add define error types for recorder result
  : An error type is added to define each error in detail

Signed-off-by: jaesick.shin <jaesick.shin@samsung.com>