### PR TITLE
system/init: remove redundant headers

### DIFF
--- a/apps/system/init/init.c
+++ b/apps/system/init/init.c
@@ -36,10 +36,6 @@
 #ifdef CONFIG_SYSTEM_INFORMATION
 #include <apps/system/sysinfo.h>
 #endif
-#if defined(CONFIG_BUILD_PROTECTED) && defined(CONFIG_FS_PROCFS)
-#include <errno.h>
-#include <sys/mount.h>
-#endif
 
 /****************************************************************************
  * Pre-processor Definitions


### PR DESCRIPTION
Commit 8427254 removes mounting procfs from preapp_start().
But headers which are used to do above are not removed.
This commit removes redundant headers.

Signed-off-by: sunghan-chang <sh924.chang@samsung.com>