### PR TITLE
tools: Add TizenRT Application Generator

### DIFF
--- a/apps/appgen/README.md
+++ b/apps/appgen/README.md
@@ -1,0 +1,34 @@
+# TizenRT Application Generator
+
+### Requirements
+- Latest bash
+- Generally, Ubuntu linux has the latest bash
+
+### How to use?
+
+In the apps directory, run the appgen shell script and just enter the application name that you would make.
+
+Your application would be generated at the apps/examples/
+
+```sh
+TizenRT/apps$ appgen/appgen.sh
+TizenRT Application Generator
+======================= v 1.0
+Enter application name: test application
+[Summary]
+Application Name: test application
+Configuration Key: CONFIG_APP_TEST_APPLICATION
+Entry Function: test_application_main
+Continue? (y/N): y
+Generating...
+Done..
+```
+
+### After generated
+```sh
+TizenRT/os$ make menuconfig
+```
+
+- Enter "Application Configuration/Examples"
+- Turn on your application
+- Set the entry point to your application

--- a/apps/appgen/README.md
+++ b/apps/appgen/README.md
@@ -17,16 +17,23 @@ TizenRT Application Generator
 Enter application name: test application
 [Summary]
 -------------------------------
-Application Name: test application
-Configuration Key: CONFIG_APP_TEST_APPLICATION
-Entry Function: test_application_main
-Location: /home/gcjjyy/workspace/github.com/gcjjyy/TizenRT/apps/examples/test_application
-This year: 2018
+* Application Name: test application
+* Configuration Key: CONFIG_APP_TEST_APPLICATION
+* Entry Function: test_application_main
+* Location: /home/gcjjyy/workspace/github.com/gcjjyy/TizenRT/apps/examples/test_application
+* This year: 2018
 -------------------------------
 Continue? (y/N): y
 Generating...
 
-Done..
+* How to setup your application
+Run) TizenRT/os/tools$ ./configure.sh <BOARD>/<CONFIG>
+Run) TizenRT/os$ make menuconfig
+1. Turn on your application in Application Configuration/Examples menu
+2. Set the entry point to your application in Application Configuration menu
+------------------------------
+Done!!
+
 ```
 
 ### After generated

--- a/apps/appgen/README.md
+++ b/apps/appgen/README.md
@@ -6,12 +6,12 @@
 
 ### How to use?
 
-In the apps directory, run the appgen shell script and just enter the application name that you would make.
+In any directory, run the appgen shell script and just enter the application name that you would make.
 
 Your application would be generated at the apps/examples/
 
 ```sh
-TizenRT/apps$ appgen/appgen.sh
+TizenRT/os$ tools/appgen.sh
 TizenRT Application Generator
 ======================= v 1.0
 Enter application name: test application
@@ -21,6 +21,7 @@ Configuration Key: CONFIG_APP_TEST_APPLICATION
 Entry Function: test_application_main
 Continue? (y/N): y
 Generating...
+Your application is located at /home/gcjjyy/workspace/github.com/gcjjyy/TizenRT/apps/examples/test_application
 Done..
 ```
 

--- a/apps/appgen/README.md
+++ b/apps/appgen/README.md
@@ -16,12 +16,16 @@ TizenRT Application Generator
 ======================= v 1.0
 Enter application name: test application
 [Summary]
+-------------------------------
 Application Name: test application
 Configuration Key: CONFIG_APP_TEST_APPLICATION
 Entry Function: test_application_main
+Location: /home/gcjjyy/workspace/github.com/gcjjyy/TizenRT/apps/examples/test_application
+This year: 2018
+-------------------------------
 Continue? (y/N): y
 Generating...
-Your application is located at /home/gcjjyy/workspace/github.com/gcjjyy/TizenRT/apps/examples/test_application
+
 Done..
 ```
 

--- a/apps/appgen/appgen.sh
+++ b/apps/appgen/appgen.sh
@@ -1,0 +1,60 @@
+#! /bin/bash
+echo "TizenRT Application Generator"
+echo "======================= v 1.0"
+
+read -p "Enter application name: " APP_NAME
+
+APP_NAME_UPPER=${APP_NAME^^}
+APP_NAME_UPPER="${APP_NAME_UPPER// /_}"
+APP_NAME_LOWER=${APP_NAME,,}
+APP_NAME_LOWER="${APP_NAME_LOWER// /_}"
+ENTRY_FUNC="${APP_NAME_LOWER}_main"
+
+echo "[Summary]"
+echo "Application Name: ${APP_NAME}"
+echo "Configuration Key: CONFIG_APP_${APP_NAME_UPPER}"
+echo "Entry Function: ${ENTRY_FUNC}"
+
+read -p "Continue? (y/N): " confirm && [[ $confirm == [yY] || $confirm == [yY][eE][sS] ]] || exit 1
+
+echo "Generating..."
+
+KCONFIG_FILENAME="examples/${APP_NAME_LOWER}/Kconfig"
+KCONFIG_ENTRY_FILENAME="examples/${APP_NAME_LOWER}/Kconfig_ENTRY"
+MAIN_FILENAME="examples/${APP_NAME_LOWER}/${ENTRY_FUNC}.c"
+MAKE_DEFS_FILENAME="examples/${APP_NAME_LOWER}/Make.defs"
+MAKEFILE_FILENAME="examples/${APP_NAME_LOWER}/Makefile"
+
+mkdir "examples/${APP_NAME_LOWER}"
+cp appgen/template_Kconfig ${KCONFIG_FILENAME}
+cp appgen/template_Kconfig_ENTRY ${KCONFIG_ENTRY_FILENAME}
+cp appgen/template_main.c_source ${MAIN_FILENAME}
+cp appgen/template_Make.defs ${MAKE_DEFS_FILENAME}
+cp appgen/template_Makefile ${MAKEFILE_FILENAME}
+
+sed -i -e "s/##APP_NAME_UPPER##/${APP_NAME_UPPER}/g" ${KCONFIG_FILENAME}
+sed -i -e "s/##APP_NAME_UPPER##/${APP_NAME_UPPER}/g" ${KCONFIG_ENTRY_FILENAME}
+sed -i -e "s/##APP_NAME_UPPER##/${APP_NAME_UPPER}/g" ${MAIN_FILENAME}
+sed -i -e "s/##APP_NAME_UPPER##/${APP_NAME_UPPER}/g" ${MAKE_DEFS_FILENAME}
+sed -i -e "s/##APP_NAME_UPPER##/${APP_NAME_UPPER}/g" ${MAKEFILE_FILENAME}
+
+sed -i -e "s/##APP_NAME_LOWER##/${APP_NAME_LOWER}/g" ${KCONFIG_FILENAME}
+sed -i -e "s/##APP_NAME_LOWER##/${APP_NAME_LOWER}/g" ${KCONFIG_ENTRY_FILENAME}
+sed -i -e "s/##APP_NAME_LOWER##/${APP_NAME_LOWER}/g" ${MAIN_FILENAME}
+sed -i -e "s/##APP_NAME_LOWER##/${APP_NAME_LOWER}/g" ${MAKE_DEFS_FILENAME}
+sed -i -e "s/##APP_NAME_LOWER##/${APP_NAME_LOWER}/g" ${MAKEFILE_FILENAME}
+
+sed -i -e "s/##APP_NAME##/${APP_NAME}/g" ${KCONFIG_FILENAME}
+sed -i -e "s/##APP_NAME##/${APP_NAME}/g" ${KCONFIG_ENTRY_FILENAME}
+sed -i -e "s/##APP_NAME##/${APP_NAME}/g" ${MAIN_FILENAME}
+sed -i -e "s/##APP_NAME##/${APP_NAME}/g" ${MAKE_DEFS_FILENAME}
+sed -i -e "s/##APP_NAME##/${APP_NAME}/g" ${MAKEFILE_FILENAME}
+
+sed -i -e "s/##ENTRY_FUNC##/${ENTRY_FUNC}/g" ${KCONFIG_FILENAME}
+sed -i -e "s/##ENTRY_FUNC##/${ENTRY_FUNC}/g" ${KCONFIG_ENTRY_FILENAME}
+sed -i -e "s/##ENTRY_FUNC##/${ENTRY_FUNC}/g" ${MAIN_FILENAME}
+sed -i -e "s/##ENTRY_FUNC##/${ENTRY_FUNC}/g" ${MAKE_DEFS_FILENAME}
+sed -i -e "s/##ENTRY_FUNC##/${ENTRY_FUNC}/g" ${MAKEFILE_FILENAME}
+
+echo "Done.."
+

--- a/apps/appgen/template_Kconfig
+++ b/apps/appgen/template_Kconfig
@@ -1,0 +1,14 @@
+#
+# For a description of the syntax of this configuration file,
+# see kconfig-language at https://www.kernel.org/doc/Documentation/kbuild/kconfig-language.txt
+#
+
+config APP_##APP_NAME_UPPER##
+	bool "\"##APP_NAME##\" Application"
+	default n
+	---help---
+		Enable the \"##APP_NAME##\" Application
+
+config USER_ENTRYPOINT
+	string
+	default "##ENTRY_FUNC##" if ENTRY_##APP_NAME_UPPER##

--- a/apps/appgen/template_Kconfig_ENTRY
+++ b/apps/appgen/template_Kconfig_ENTRY
@@ -1,0 +1,3 @@
+config ENTRY_##APP_NAME_UPPER##
+	bool "\"##APP_NAME##\" Application"
+	depends on APP_##APP_NAME_UPPER##

--- a/apps/appgen/template_Make.defs
+++ b/apps/appgen/template_Make.defs
@@ -1,0 +1,21 @@
+###########################################################################
+#
+# Copyright 2018 Samsung Electronics All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+#
+###########################################################################
+
+ifeq ($(CONFIG_APP_##APP_NAME_UPPER##),y)
+CONFIGURED_APPS += examples/##APP_NAME_LOWER##
+endif

--- a/apps/appgen/template_Make.defs
+++ b/apps/appgen/template_Make.defs
@@ -1,6 +1,6 @@
 ###########################################################################
 #
-# Copyright 2018 Samsung Electronics All Rights Reserved.
+# Copyright ##YEAR## Samsung Electronics All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/apps/appgen/template_Makefile
+++ b/apps/appgen/template_Makefile
@@ -1,0 +1,123 @@
+###########################################################################
+#
+# Copyright 2018 Samsung Electronics All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+#
+###########################################################################
+-include $(TOPDIR)/.config
+-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
+
+# ##APP_NAME## built-in application info
+
+APPNAME = ##APP_NAME_LOWER##
+FUNCNAME = ##ENTRY_FUNC##
+THREADEXEC = TASH_EXECMD_ASYNC
+
+# ##APP_NAME## Application
+
+ASRCS =
+CSRCS =
+MAINSRC = ##ENTRY_FUNC##.c
+
+AOBJS = $(ASRCS:.S=$(OBJEXT))
+COBJS = $(CSRCS:.c=$(OBJEXT))
+MAINOBJ = $(MAINSRC:.c=$(OBJEXT))
+
+SRCS = $(ASRCS) $(CSRCS) $(MAINSRC)
+OBJS = $(AOBJS) $(COBJS)
+
+ifneq ($(CONFIG_BUILD_KERNEL),y)
+  OBJS += $(MAINOBJ)
+endif
+
+ifeq ($(CONFIG_WINDOWS_NATIVE),y)
+  BIN = ..\..\libapps$(LIBEXT)
+else
+ifeq ($(WINTOOL),y)
+  BIN = ..\\..\\libapps$(LIBEXT)
+else
+  BIN = ../../libapps$(LIBEXT)
+endif
+endif
+
+ifeq ($(WINTOOL),y)
+  INSTALL_DIR = "${shell cygpath -w $(BIN_DIR)}"
+else
+  INSTALL_DIR = $(BIN_DIR)
+endif
+
+CONFIG_APP_##APP_NAME_UPPER##_PROGNAME ?= ##APP_NAME_LOWER##$(EXEEXT)
+PROGNAME = $(CONFIG_APP_##APP_NAME_UPPER##_PROGNAME)
+
+ROOTDEPPATH = --dep-path .
+
+# Common build
+
+VPATH =
+
+all: .built
+.PHONY: clean depend distclean
+
+$(AOBJS): %$(OBJEXT): %.S
+	$(call ASSEMBLE, $<, $@)
+
+$(COBJS) $(MAINOBJ): %$(OBJEXT): %.c
+	$(call COMPILE, $<, $@)
+
+.built: $(OBJS)
+	$(call ARCHIVE, $(BIN), $(OBJS))
+	@touch .built
+
+ifeq ($(CONFIG_BUILD_KERNEL),y)
+$(BIN_DIR)$(DELIM)$(PROGNAME): $(OBJS) $(MAINOBJ)
+	@echo "LD: $(PROGNAME)"
+	$(Q) $(LD) $(LDELFFLAGS) $(LDLIBPATH) -o $(INSTALL_DIR)$(DELIM)$(PROGNAME) $(ARCHCRT0OBJ) $(MAINOBJ) $(LDLIBS)
+	$(Q) $(NM) -u  $(INSTALL_DIR)$(DELIM)$(PROGNAME)
+
+install: $(BIN_DIR)$(DELIM)$(PROGNAME)
+
+else
+install:
+
+endif
+
+ifeq ($(CONFIG_BUILTIN_APPS)$(CONFIG_APP_##APP_NAME_UPPER##),yy)
+$(BUILTIN_REGISTRY)$(DELIM)$(FUNCNAME).bdat: $(DEPCONFIG) Makefile
+	$(Q) $(call REGISTER,$(APPNAME),$(FUNCNAME),$(THREADEXEC),$(PRIORITY),$(STACKSIZE))
+
+context: $(BUILTIN_REGISTRY)$(DELIM)$(FUNCNAME).bdat
+
+else
+context:
+
+endif
+
+.depend: Makefile $(SRCS)
+	@$(MKDEP) $(ROOTDEPPATH) "$(CC)" -- $(CFLAGS) -- $(SRCS) >Make.dep
+	@touch $@
+
+depend: .depend
+
+clean:
+	$(call DELFILE, .built)
+	$(call CLEAN)
+
+distclean: clean
+	$(call DELFILE, Make.dep)
+	$(call DELFILE, .depend)
+
+-include Make.dep
+.PHONY: preconfig
+preconfig:

--- a/apps/appgen/template_Makefile
+++ b/apps/appgen/template_Makefile
@@ -1,6 +1,6 @@
 ###########################################################################
 #
-# Copyright 2018 Samsung Electronics All Rights Reserved.
+# Copyright ##YEAR## Samsung Electronics All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/apps/appgen/template_main.c_source
+++ b/apps/appgen/template_main.c_source
@@ -1,0 +1,38 @@
+/****************************************************************************
+ *
+ * Copyright 2018 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <tinyara/config.h>
+#include <stdio.h>
+
+/****************************************************************************
+ * ##ENTRY_FUNC##
+ ****************************************************************************/
+
+#ifdef CONFIG_BUILD_KERNEL
+int main(int argc, FAR char *argv[])
+#else
+int ##ENTRY_FUNC##(int argc, char *argv[])
+#endif
+{
+	printf("Hello, ##APP_NAME##!!\n");
+	return 0;
+}

--- a/apps/appgen/template_main.c_source
+++ b/apps/appgen/template_main.c_source
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- * Copyright 2018 Samsung Electronics All Rights Reserved.
+ * Copyright ##YEAR## Samsung Electronics All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/os/tools/appgen.sh
+++ b/os/tools/appgen.sh
@@ -7,6 +7,8 @@ cd ${TIZENRT_ROOT}
 TIZENRT_ROOT=$(pwd)
 cd -
 
+CUR_YEAR=$(date +"%Y")
+
 read -p "Enter application name: " APP_NAME
 
 APP_NAME_UPPER=${APP_NAME^^}
@@ -16,10 +18,13 @@ APP_NAME_LOWER="${APP_NAME_LOWER// /_}"
 ENTRY_FUNC="${APP_NAME_LOWER}_main"
 
 echo "[Summary]"
+echo "-------------------------------"
 echo "* Application Name: ${APP_NAME}"
 echo "* Configuration Key: CONFIG_APP_${APP_NAME_UPPER}"
 echo "* Entry Function: ${ENTRY_FUNC}"
-
+echo "* Location: ${TIZENRT_ROOT}/apps/examples/${APP_NAME_LOWER}"
+echo "* This year: ${CUR_YEAR}"
+echo "-------------------------------"
 read -p "Continue? (y/N): " confirm && [[ $confirm == [yY] || $confirm == [yY][eE][sS] ]] || exit 1
 
 echo "Generating..."
@@ -36,6 +41,12 @@ cp ${TIZENRT_ROOT}/apps/appgen/template_Kconfig_ENTRY ${KCONFIG_ENTRY_FILENAME}
 cp ${TIZENRT_ROOT}/apps/appgen/template_main.c_source ${MAIN_FILENAME}
 cp ${TIZENRT_ROOT}/apps/appgen/template_Make.defs ${MAKE_DEFS_FILENAME}
 cp ${TIZENRT_ROOT}/apps/appgen/template_Makefile ${MAKEFILE_FILENAME}
+
+sed -i -e "s/##YEAR##/${CUR_YEAR}/g" ${KCONFIG_FILENAME}
+sed -i -e "s/##YEAR##/${CUR_YEAR}/g" ${KCONFIG_ENTRY_FILENAME}
+sed -i -e "s/##YEAR##/${CUR_YEAR}/g" ${MAIN_FILENAME}
+sed -i -e "s/##YEAR##/${CUR_YEAR}/g" ${MAKE_DEFS_FILENAME}
+sed -i -e "s/##YEAR##/${CUR_YEAR}/g" ${MAKEFILE_FILENAME}
 
 sed -i -e "s/##APP_NAME_UPPER##/${APP_NAME_UPPER}/g" ${KCONFIG_FILENAME}
 sed -i -e "s/##APP_NAME_UPPER##/${APP_NAME_UPPER}/g" ${KCONFIG_ENTRY_FILENAME}
@@ -61,6 +72,11 @@ sed -i -e "s/##ENTRY_FUNC##/${ENTRY_FUNC}/g" ${MAIN_FILENAME}
 sed -i -e "s/##ENTRY_FUNC##/${ENTRY_FUNC}/g" ${MAKE_DEFS_FILENAME}
 sed -i -e "s/##ENTRY_FUNC##/${ENTRY_FUNC}/g" ${MAKEFILE_FILENAME}
 
-echo "Your application is located at ${TIZENRT_ROOT}/apps/examples/${APP_NAME_LOWER}"
-echo "Done.."
+echo ""
+echo "* How to setup your application"
+echo "Run) TizenRT/os\$ make menuconfig"
+echo "1. Turn on your application in Application Configuration/Examples menu"
+echo "2. Set the entry point to your application in Application Configuration menu"
+echo "------------------------------"
+echo "Done!!"
 

--- a/os/tools/appgen.sh
+++ b/os/tools/appgen.sh
@@ -1,13 +1,15 @@
 #! /bin/bash
-echo "TizenRT Application Generator"
-echo "======================= v 1.0"
 
+BOLD=$(tput bold)
+NORMAL=$(tput sgr0)
+CUR_YEAR=$(date +"%Y")
 TIZENRT_ROOT="$(dirname $0)/../.."
 cd ${TIZENRT_ROOT}
-TIZENRT_ROOT=$(pwd)
-cd -
+TIZENRT_ROOT="$(pwd)"
+cd - > /dev/null
 
-CUR_YEAR=$(date +"%Y")
+echo "${BOLD}TizenRT Application Generator${NORMAL}"
+echo "======================= v 1.0"
 
 read -p "Enter application name: " APP_NAME
 
@@ -17,13 +19,13 @@ APP_NAME_LOWER=${APP_NAME,,}
 APP_NAME_LOWER="${APP_NAME_LOWER// /_}"
 ENTRY_FUNC="${APP_NAME_LOWER}_main"
 
-echo "[Summary]"
+echo "${BOLD}[Summary]${NORMAL}"
 echo "-------------------------------"
-echo "* Application Name: ${APP_NAME}"
-echo "* Configuration Key: CONFIG_APP_${APP_NAME_UPPER}"
-echo "* Entry Function: ${ENTRY_FUNC}"
-echo "* Location: ${TIZENRT_ROOT}/apps/examples/${APP_NAME_LOWER}"
-echo "* This year: ${CUR_YEAR}"
+echo "* Application Name: ${BOLD}${APP_NAME}${NORMAL}"
+echo "* Configuration Key: ${BOLD}CONFIG_APP_${APP_NAME_UPPER}${NORMAL}"
+echo "* Entry Function: ${BOLD}${ENTRY_FUNC}${NORMAL}"
+echo "* Location: ${BOLD}${TIZENRT_ROOT}/apps/examples/${APP_NAME_LOWER}${NORMAL}"
+echo "* This year: ${BOLD}${CUR_YEAR}${NORMAL}"
 echo "-------------------------------"
 read -p "Continue? (y/N): " confirm && [[ $confirm == [yY] || $confirm == [yY][eE][sS] ]] || exit 1
 
@@ -74,9 +76,10 @@ sed -i -e "s/##ENTRY_FUNC##/${ENTRY_FUNC}/g" ${MAKEFILE_FILENAME}
 
 echo ""
 echo "* How to setup your application"
-echo "Run) TizenRT/os\$ make menuconfig"
-echo "1. Turn on your application in Application Configuration/Examples menu"
-echo "2. Set the entry point to your application in Application Configuration menu"
+echo "Run) ${BOLD}TizenRT/os/tools\$${NORMAL} ./configure.sh <BOARD>/<CONFIG>"
+echo "Run) ${BOLD}TizenRT/os\$${NORMAL} make menuconfig"
+echo "1. Turn on your application in ${BOLD}Application Configuration/Examples${NORMAL} menu"
+echo "2. Set the entry point to your application in ${BOLD}Application Configuration${NORMAL} menu"
 echo "------------------------------"
 echo "Done!!"
 

--- a/os/tools/appgen.sh
+++ b/os/tools/appgen.sh
@@ -2,6 +2,11 @@
 echo "TizenRT Application Generator"
 echo "======================= v 1.0"
 
+TIZENRT_ROOT="$(dirname $0)/../.."
+cd ${TIZENRT_ROOT}
+TIZENRT_ROOT=$(pwd)
+cd -
+
 read -p "Enter application name: " APP_NAME
 
 APP_NAME_UPPER=${APP_NAME^^}
@@ -11,26 +16,26 @@ APP_NAME_LOWER="${APP_NAME_LOWER// /_}"
 ENTRY_FUNC="${APP_NAME_LOWER}_main"
 
 echo "[Summary]"
-echo "Application Name: ${APP_NAME}"
-echo "Configuration Key: CONFIG_APP_${APP_NAME_UPPER}"
-echo "Entry Function: ${ENTRY_FUNC}"
+echo "* Application Name: ${APP_NAME}"
+echo "* Configuration Key: CONFIG_APP_${APP_NAME_UPPER}"
+echo "* Entry Function: ${ENTRY_FUNC}"
 
 read -p "Continue? (y/N): " confirm && [[ $confirm == [yY] || $confirm == [yY][eE][sS] ]] || exit 1
 
 echo "Generating..."
 
-KCONFIG_FILENAME="examples/${APP_NAME_LOWER}/Kconfig"
-KCONFIG_ENTRY_FILENAME="examples/${APP_NAME_LOWER}/Kconfig_ENTRY"
-MAIN_FILENAME="examples/${APP_NAME_LOWER}/${ENTRY_FUNC}.c"
-MAKE_DEFS_FILENAME="examples/${APP_NAME_LOWER}/Make.defs"
-MAKEFILE_FILENAME="examples/${APP_NAME_LOWER}/Makefile"
+KCONFIG_FILENAME="${TIZENRT_ROOT}/apps/examples/${APP_NAME_LOWER}/Kconfig"
+KCONFIG_ENTRY_FILENAME="${TIZENRT_ROOT}/apps/examples/${APP_NAME_LOWER}/Kconfig_ENTRY"
+MAIN_FILENAME="${TIZENRT_ROOT}/apps/examples/${APP_NAME_LOWER}/${ENTRY_FUNC}.c"
+MAKE_DEFS_FILENAME="${TIZENRT_ROOT}/apps/examples/${APP_NAME_LOWER}/Make.defs"
+MAKEFILE_FILENAME="${TIZENRT_ROOT}/apps/examples/${APP_NAME_LOWER}/Makefile"
 
-mkdir "examples/${APP_NAME_LOWER}"
-cp appgen/template_Kconfig ${KCONFIG_FILENAME}
-cp appgen/template_Kconfig_ENTRY ${KCONFIG_ENTRY_FILENAME}
-cp appgen/template_main.c_source ${MAIN_FILENAME}
-cp appgen/template_Make.defs ${MAKE_DEFS_FILENAME}
-cp appgen/template_Makefile ${MAKEFILE_FILENAME}
+mkdir "${TIZENRT_ROOT}/apps/examples/${APP_NAME_LOWER}"
+cp ${TIZENRT_ROOT}/apps/appgen/template_Kconfig ${KCONFIG_FILENAME}
+cp ${TIZENRT_ROOT}/apps/appgen/template_Kconfig_ENTRY ${KCONFIG_ENTRY_FILENAME}
+cp ${TIZENRT_ROOT}/apps/appgen/template_main.c_source ${MAIN_FILENAME}
+cp ${TIZENRT_ROOT}/apps/appgen/template_Make.defs ${MAKE_DEFS_FILENAME}
+cp ${TIZENRT_ROOT}/apps/appgen/template_Makefile ${MAKEFILE_FILENAME}
 
 sed -i -e "s/##APP_NAME_UPPER##/${APP_NAME_UPPER}/g" ${KCONFIG_FILENAME}
 sed -i -e "s/##APP_NAME_UPPER##/${APP_NAME_UPPER}/g" ${KCONFIG_ENTRY_FILENAME}
@@ -56,5 +61,6 @@ sed -i -e "s/##ENTRY_FUNC##/${ENTRY_FUNC}/g" ${MAIN_FILENAME}
 sed -i -e "s/##ENTRY_FUNC##/${ENTRY_FUNC}/g" ${MAKE_DEFS_FILENAME}
 sed -i -e "s/##ENTRY_FUNC##/${ENTRY_FUNC}/g" ${MAKEFILE_FILENAME}
 
+echo "Your application is located at ${TIZENRT_ROOT}/apps/examples/${APP_NAME_LOWER}"
 echo "Done.."
 


### PR DESCRIPTION
# TizenRT Application Generator

### Requirements
- Latest bash
- Generally, Ubuntu linux has the latest bash

### How to use?

In any directory, run the appgen shell script and just enter the application name that you would make.

Your application would be generated at the apps/examples/

```sh
TizenRT/os$ tools/appgen.sh
TizenRT Application Generator
======================= v 1.0
Enter application name: test application
[Summary]
-------------------------------
* Application Name: test application
* Configuration Key: CONFIG_APP_TEST_APPLICATION
* Entry Function: test_application_main
* Location: /home/gcjjyy/workspace/github.com/gcjjyy/TizenRT/apps/examples/test_application
* This year: 2018
-------------------------------
Continue? (y/N): y
Generating...

* How to setup your application
Run) TizenRT/os/tools$ ./configure.sh <BOARD>/<CONFIG>
Run) TizenRT/os$ make menuconfig
1. Turn on your application in Application Configuration/Examples menu
2. Set the entry point to your application in Application Configuration menu
------------------------------
Done!!

```

### After generated
```sh
TizenRT/os$ make menuconfig
```

- Enter "Application Configuration/Examples"
- Turn on your application
- Set the entry point to your application
