### PR TITLE
framework/media : Remove unused errout logic

### DIFF
--- a/framework/src/media/MediaPlayerImpl.cpp
+++ b/framework/src/media/MediaPlayerImpl.cpp
@@ -438,11 +438,6 @@ void MediaPlayerImpl::setVolumePlayer(uint8_t vol, player_result_t &ret)
 	medvdbg("MediaPlayer setVolume success\n");
 	ret = PLAYER_OK;
 	return notifySync();
-
-errout:
-	notifyObserver(PLAYER_OBSERVER_COMMAND_ERROR);
-	ret = PLAYER_ERROR;
-	notifySync();
 }
 
 


### PR DESCRIPTION
- fix warning error when building time.
  "warning: label 'errout' defined but not used"
  In the function, it does not need to goto logic for return.