### PR TITLE
.clang-format: Remove column limit

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,6 +1,6 @@
 ---
 Language:        Cpp
-ColumnLimit: 120
+ColumnLimit: 0
 # BasedOnStyle:  LLVM
 AccessModifierOffset: -4
 AllowShortFunctionsOnASingleLine: false


### PR DESCRIPTION
A column limit of 0 means that there is no column limit.