### PR TITLE
media: Automatically close only if stream is alive

### DIFF
--- a/framework/src/media/FileInputDataSource.cpp
+++ b/framework/src/media/FileInputDataSource.cpp
@@ -48,7 +48,9 @@ FileInputDataSource &FileInputDataSource::operator=(const FileInputDataSource &s
 
 FileInputDataSource::~FileInputDataSource()
 {
-	close();
+	if (mFp) {
+		close();
+	}
 }
 
 bool FileInputDataSource::open()

--- a/framework/src/media/FileOutputDataSource.cpp
+++ b/framework/src/media/FileOutputDataSource.cpp
@@ -157,7 +157,9 @@ ssize_t FileOutputDataSource::write(unsigned char* buf, size_t size)
 
 FileOutputDataSource::~FileOutputDataSource()
 {
-	close();
+	if (mFp) {
+		close();
+	}
 }
 } // namespace stream
 } // namespace media


### PR DESCRIPTION
At destruction time, check if stream is alive and close it