### PR TITLE
framework/wifi_manager: Remove unappropriate Public APIs

### DIFF
--- a/apps/examples/wifi_manager_sample/wm_test.c
+++ b/apps/examples/wifi_manager_sample/wm_test.c
@@ -74,6 +74,11 @@ struct options {
 /**
  * Functions
  */
+/**
+ * Internal functions
+ */
+static int wm_mac_addr_to_mac_str(char mac_addr[6], char mac_str[20]);
+static int wm_mac_str_to_mac_addr(char mac_str[20], char mac_addr[6]);
 /*
  * Signal
  */
@@ -87,7 +92,6 @@ static void wm_sta_disconnected(wifi_manager_disconnect_e);
 static void wm_softap_sta_join(void);
 static void wm_softap_sta_leave(void);
 static void wm_scan_done(wifi_manager_scan_info_s **scan_result, wifi_manager_scan_result_e res);
-
 /*
  * handler
  */
@@ -206,7 +210,6 @@ static const char *wifi_test_auth_method[] = {
 	"wpa2_mixed",
 };
 
-
 static const wifi_manager_ap_auth_type_e auth_type_table[] = {
 	WIFI_MANAGER_AUTH_OPEN,                    /**<  open mode                      */
 	WIFI_MANAGER_AUTH_WEP_SHARED,              /**<  use shared key (wep key)       */
@@ -215,7 +218,6 @@ static const wifi_manager_ap_auth_type_e auth_type_table[] = {
 	WIFI_MANAGER_AUTH_WPA_AND_WPA2_PSK,        /**<  WPA_PSK and WPA_PSK mixed mode */
 	WIFI_MANAGER_AUTH_UNKNOWN,                 /**<  unknown type                   */
 };
-
 
 static const wifi_manager_ap_crypto_type_e crypto_type_table[] = {
 	WIFI_MANAGER_CRYPTO_NONE,                  /**<  none encryption                */
@@ -267,7 +269,6 @@ wifi_manager_ap_auth_type_e get_auth_type(const char *method)
 	return WIFI_MANAGER_AUTH_UNKNOWN;
 }
 
-
 wifi_manager_ap_crypto_type_e get_crypto_type(const char *method)
 {
 	int i = 0;
@@ -280,7 +281,34 @@ wifi_manager_ap_crypto_type_e get_crypto_type(const char *method)
 	return WIFI_MANAGER_CRYPTO_UNKNOWN;
 }
 
+/*
+ * Internal functions
+ */
+static int wm_mac_addr_to_mac_str(char mac_addr[6], char mac_str[20])
+{
+	int wret = -1;
+	if (mac_addr && mac_str) {
+		snprintf(mac_str, 18, "%02X:%02X:%02X:%02X:%02X:%02X", mac_addr[0], mac_addr[1], mac_addr[2], mac_addr[3], mac_addr[4], mac_addr[5]);
+		wret = OK;
+	}
+	return wret;
+}
 
+static int wm_mac_str_to_mac_addr(char mac_str[20], char mac_addr[6])
+{
+	int wret = -1;
+	if (mac_addr && mac_str) {
+		int ret = sscanf(mac_str, "%hhx:%hhx:%hhx:%hhx:%hhx:%hhx%*c", &mac_addr[0], &mac_addr[1], &mac_addr[2], &mac_addr[3], &mac_addr[4], &mac_addr[5]);
+		if (ret == WIFIMGR_MACADDR_LEN) {
+			wret = OK;
+		}
+	}
+	return wret;
+}
+
+/*
+ * Signal
+ */
 int wm_signal_init(void)
 {
 	if (g_mode != 0) {
@@ -314,7 +342,6 @@ int wm_signal_init(void)
 	return 0;
 }
 
-
 void wm_signal_deinit(void)
 {
 	pthread_mutex_destroy(&g_wm_func_mutex);
@@ -323,7 +350,6 @@ void wm_signal_deinit(void)
 	pthread_cond_destroy(&g_wm_cond);
 	g_mode = 0;
 }
-
 
 /*
  * Callback
@@ -334,7 +360,6 @@ void wm_sta_connected(wifi_manager_result_e res)
 	WM_TEST_SIGNAL;
 }
 
-
 void wm_sta_disconnected(wifi_manager_disconnect_e disconn)
 {
 	sleep(2);
@@ -342,20 +367,17 @@ void wm_sta_disconnected(wifi_manager_disconnect_e disconn)
 	WM_TEST_SIGNAL;
 }
 
-
 void wm_softap_sta_join(void)
 {
 	printf(" T%d --> %s\n", getpid(), __FUNCTION__);
 	WM_TEST_SIGNAL;
 }
 
-
 void wm_softap_sta_leave(void)
 {
 	printf(" T%d --> %s\n", getpid(), __FUNCTION__);
 	WM_TEST_SIGNAL;
 }
-
 
 void wm_scan_done(wifi_manager_scan_info_s **scan_result, wifi_manager_scan_result_e res)
 {
@@ -376,7 +398,6 @@ void wm_scan_done(wifi_manager_scan_info_s **scan_result, wifi_manager_scan_resu
 	}
 	WM_TEST_SIGNAL;
 }
-
 
 /*
  * Control Functions
@@ -462,7 +483,6 @@ void wm_start(void *arg)
 	WM_TEST_LOG_END;
 }
 
-
 void wm_stop(void *arg)
 {
 	WM_TEST_LOG_START;
@@ -472,7 +492,6 @@ void wm_stop(void *arg)
 	}
 	WM_TEST_LOG_END;
 }
-
 
 void wm_scan(void *arg)
 {
@@ -487,7 +506,6 @@ void wm_scan(void *arg)
 	WM_TEST_WAIT; // wait the scan result
 	WM_TEST_LOG_END;
 }
-
 
 void wm_display_state(void *arg)
 {
@@ -507,13 +525,11 @@ void wm_display_state(void *arg)
 		}
 		printf("IP: %s\n", info.ip4_address);
 		printf("SSID: %s\n", info.ssid);
-		res = wifi_manager_mac_addr_to_mac_str(info.mac_address, mac_str);
-		if (res != WIFI_MANAGER_SUCCESS) {
+		if (wm_mac_addr_to_mac_str(info.mac_address, mac_str) < 0) {
 			goto exit;
 		}
 		printf("MAC: %s\n", mac_str);
-		res = wifi_manager_mac_str_to_mac_addr(mac_str, mac_char);
-		if (res != WIFI_MANAGER_SUCCESS) {
+		if (wm_mac_str_to_mac_addr(mac_str, mac_char) < 0) {
 			goto exit;
 		}
 	} else if (info.mode == STA_MODE) {
@@ -525,13 +541,11 @@ void wm_display_state(void *arg)
 		} else if (info.status == AP_DISCONNECTED) {
 			printf("MODE: station (disconnected)\n");
 		}
-		res = wifi_manager_mac_addr_to_mac_str(info.mac_address, mac_str);	
-		if (res != WIFI_MANAGER_SUCCESS) {
+		if (wm_mac_addr_to_mac_str(info.mac_address, mac_str) < 0) {
 			goto exit;
 		}
 		printf("MAC: %s\n", mac_str);
-		res = wifi_manager_mac_str_to_mac_addr(mac_str, mac_char);
-		if (res != WIFI_MANAGER_SUCCESS) {
+		if (wm_mac_str_to_mac_addr(mac_str, mac_char) < 0) {
 			goto exit;
 		}
 	} else {
@@ -541,7 +555,6 @@ exit:
 	WM_TEST_LOG_END;
 	return ;
 }
-
 
 void wm_sta_start(void *arg)
 {
@@ -556,7 +569,6 @@ void wm_sta_start(void *arg)
 	printf(" Connecting to AP\n");
 	WM_TEST_LOG_END;
 }
-
 
 void wm_connect(void *arg)
 {
@@ -588,7 +600,6 @@ void wm_connect(void *arg)
 	WM_TEST_LOG_END;
 }
 
-
 void wm_disconnect(void *arg)
 {
 	WM_TEST_LOG_START;
@@ -603,7 +614,6 @@ void wm_disconnect(void *arg)
 	WM_TEST_LOG_END;;
 }
 
-
 void wm_cancel(void *arg)
 {
 	WM_TEST_LOG_START;
@@ -616,7 +626,6 @@ void wm_cancel(void *arg)
 	}
 	WM_TEST_LOG_END;
 }
-
 
 void wm_softap_start(void *arg)
 {
@@ -643,8 +652,6 @@ void wm_softap_start(void *arg)
 	}
 	WM_TEST_LOG_END;
 }
-
-
 
 /****************************************************************************
  * ocf_wifi_test
@@ -1028,6 +1035,7 @@ void wm_coverage(void *arg)
 
 	return ;
 }
+
 void wm_auto_test(void *arg)
 {
 	wifi_manager_result_e res = WIFI_MANAGER_SUCCESS;
@@ -1193,7 +1201,6 @@ void wm_auto_test(void *arg)
 	return ;
 }
 
-
 int wm_parse_commands(struct options *opt, int argc, char *argv[])
 {
 	if (argc < 3) {
@@ -1302,7 +1309,6 @@ int wm_parse_commands(struct options *opt, int argc, char *argv[])
 	return 0;
 }
 
-
 void wm_process(int argc, char *argv[])
 {
 	struct options opt;
@@ -1315,7 +1321,6 @@ void wm_process(int argc, char *argv[])
 exit:
 	WM_TEST_FUNC_SIGNAL;
 }
-
 
 #ifdef CONFIG_BUILD_KERNEL
 int main(int argc, FAR char *argv[])

--- a/framework/include/wifi_manager/wifi_manager.h
+++ b/framework/include/wifi_manager/wifi_manager.h
@@ -339,34 +339,6 @@ wifi_manager_result_e wifi_manager_get_connected_config(wifi_manager_ap_config_s
  */
 wifi_manager_result_e wifi_manager_get_stats(wifi_manager_stats_s *stats);
 
-/**
- * @brief convert mac address (48bit) to mac address string (FF:FF:FF:FF:FF:FF)
- *
- * @param[in]  mac_addr  :  mac address 48bit
- * @param[out] mac_str   :  mac address string
- *
- * @return WIFI_MANAGER_SUCCESS       :  success
- * @return WIFI_MANAGER_FAIL          :  fail
- * @return WIFI_MANAGER_INVALID_ARGS  :  input parameter invalid
- * @since TinzeRT v2.0 PRE
- */
-
-wifi_manager_result_e wifi_manager_mac_addr_to_mac_str(char mac_addr[6], char mac_str[20]);
-
-/**
- * @brief convert mac address string (FF:FF:FF:FF:FF:FF)to mac address (48bit)
- *
- * @param[in]   mac_str   :  mac address string
- * @param[out]  mac_addr  :  mac address 48bit
- *
- * @return WIFI_MANAGER_SUCCESS       :  success
- * @return WIFI_MANAGER_FAIL          :  fail
- * @return WIFI_MANAGER_INVALID_ARGS  :  input parameter invalid
- * @since TinzeRT v2.0 PRE
- */
-
-wifi_manager_result_e wifi_manager_mac_str_to_mac_addr(char mac_str[20], char mac_addr[6]);
-
 #endif
 /**
  *@}

--- a/framework/src/wifi_manager/wifi_manager.c
+++ b/framework/src/wifi_manager/wifi_manager.c
@@ -1543,30 +1543,3 @@ wifi_manager_result_e wifi_manager_get_stats(wifi_manager_stats_s *stats)
 	}
 	return wret;
 }
-
-wifi_manager_result_e wifi_manager_mac_addr_to_mac_str(char mac_addr[6], char mac_str[20])
-{
-	wifi_manager_result_e wret = WIFI_MANAGER_INVALID_ARGS;
-	if (mac_addr && mac_str) {
-		snprintf(mac_str, 18, "%02X:%02X:%02X:%02X:%02X:%02X", mac_addr[0], mac_addr[1], mac_addr[2], mac_addr[3], mac_addr[4], mac_addr[5]);
-		wret = WIFI_MANAGER_SUCCESS;
-	} else {
-		WIFIADD_ERR_RECORD(ERR_WIFIMGR_INVALID_ARGUMENTS);
-	}
-	return wret;
-}
-
-wifi_manager_result_e wifi_manager_mac_str_to_mac_addr(char mac_str[20], char mac_addr[6])
-{
-	wifi_manager_result_e wret = WIFI_MANAGER_INVALID_ARGS;
-	if (mac_addr && mac_str) {
-		int ret = sscanf(mac_str, "%hhx:%hhx:%hhx:%hhx:%hhx:%hhx%*c", &mac_addr[0], &mac_addr[1], &mac_addr[2], &mac_addr[3], &mac_addr[4], &mac_addr[5]);
-		if (ret == WIFIMGR_MACADDR_LEN) {
-			wret = WIFI_MANAGER_SUCCESS;	
-		}
-	} else {
-		WIFIADD_ERR_RECORD(ERR_WIFIMGR_INVALID_ARGUMENTS);
-	}
-	return wret;
-}
-


### PR DESCRIPTION
- APIs dealing with MAC addr are not suitable as public APIs, which are removed.
- Those APIs are moved into the application wm_test
- Arrange line spacing of wm_test