### PR TITLE
arch/debug: modify DEBUG_DISPLAY_SYMBOL dependancies

### DIFF
--- a/os/arch/Kconfig.chip
+++ b/os/arch/Kconfig.chip
@@ -441,12 +441,18 @@ config ARCH_STACKDUMP
 	bool "Dump stack on assertions"
 	default n
 	---help---
-		Enable to do stack dumps after assertions
+		Enable to do stack dumps after assertions.
+		To see symbols on call stack dump, please enable DEBUG_DISPLAY_SYMBOL.
+		It is possible to enable it when FS_ROMFS is enabled.
+		
 
 config DEBUG_DISPLAY_SYMBOL
 	bool "Display symbols on call stack dump"
 	default n
-	depends on DEBUG_SYMBOLS && FRAME_POINTER && FS_ROMFS
+	select DEBUG_SYMBOLS
+	select FRAME_POINTER
+	depends on ARCH_STACKDUMP
+	depends on FS_ROMFS
 	---help---
 		Enable to show symbol on call stack dump
 


### PR DESCRIPTION
1. add a dependancy with ARCH_STACKDUMP
  The assert shows call stack when ARCH_STACKDUMP is enabled.
  Without above config, assert shows simple information like
  below:

  up_assert: Assertion failed at file:hello_main.c line: 70 ....

  So, because DEBUG_DISPLAY_SYMBOL is meaningful with
  ARCH_STACKDUMP, let's add "depends on ARCH_STACKDUMP"

2. change a type of dependancy
  To use DEBUG_DISPLAY_SYMBOL, DEBUG_SYMBOLS, FRAME_POINTER
  and FS_ROMFS are needed so that it made dependancies
  through "depends on".
  But because first two configs (DEBUG_SYMBOLS and FRAME_POINTER)
  do not have any dependancy themself, we can use "select" instead
  of "depends on". "select" is easiler to use, gives more convenient
  to user.

Signed-off-by: sunghan-chang <sh924.chang@samsung.com>