### PR TITLE
Clean Protobuf-generated C++ sources in Makefile

### DIFF
--- a/apps/Make.defs
+++ b/apps/Make.defs
@@ -93,3 +93,21 @@ ifeq ($(CONFIG_WINDOWS_NATIVE),y)
 else
   MKKCONFIG = $(APPDIR)/tools/mkkconfig.sh
 endif
+
+ifeq ($(CONFIG_GRPC), y)
+ifeq ($(CONFIG_WINDOWS_NATIVE),y)
+define DEL_GRPCFILES
+	if exist *.pb.h (del /f /q *.pb.h)
+	if exist *.pb.cc (del /f /q *.pb.cc)
+	if exist *.grpc.pb.h (del /f /q *.grpc.pb.h)
+	if exist *.grpc.pb.cc (del /f /q *.grpc.pb.cc)
+endef
+else
+define DEL_GRPCFILES
+	$(Q) rm -f *.pb.h
+	$(Q) rm -f *.pb.cc
+	$(Q) rm -f *.grpc.pb.h
+	$(Q) rm -f *.grpc.pb.cc
+endef
+endif
+endif

--- a/apps/examples/grpc_greeter_client/Makefile
+++ b/apps/examples/grpc_greeter_client/Makefile
@@ -152,6 +152,7 @@ depend: .depend
 clean:
 	$(call DELFILE, .built)
 	$(call CLEAN)
+	$(call DEL_GRPCFILES)
 
 distclean: clean
 	$(call DELFILE, Make.dep)

--- a/apps/examples/grpc_route_client/Makefile
+++ b/apps/examples/grpc_route_client/Makefile
@@ -157,6 +157,7 @@ depend: .depend
 clean:
 	$(call DELFILE, .built)
 	$(call CLEAN)
+	$(call DEL_GRPCFILES)
 
 distclean: clean
 	$(call DELFILE, Make.dep)


### PR DESCRIPTION
Clean C++ files auto-generated by the `protoc` compiler, upon typing `make clean`. This will prevent possible errorneous mismatches between successive builds by different `protobuf` versions.