### PR TITLE
external/grpc: remove a duplicate function link of crc32

### DIFF
--- a/external/grpc/Makefile
+++ b/external/grpc/Makefile
@@ -64,6 +64,7 @@ CXXSRCS		=
 CXXFLAGS += -D__TizenRT__
 CXXFLAGS += -I./extlib/include -I./extlib/zlib -I./third_party/cares
 CXXFLAGS += -I .
+CFLAGS += -D__TizenRT__
 CFLAGS	+= -I third_party/cares/.
 
 CSRCS	+= \

--- a/external/grpc/extlib/zlib/crc32.c
+++ b/external/grpc/extlib/zlib/crc32.c
@@ -234,7 +234,11 @@ unsigned long ZEXPORT crc32_z(crc, buf, len)
 }
 
 /* ========================================================================= */
+#ifdef __TizenRT__
+unsigned long ZEXPORT grpc_crc32(crc, buf, len)
+#else
 unsigned long ZEXPORT crc32(crc, buf, len)
+#endif
     unsigned long crc;
     const unsigned char FAR *buf;
     uInt len;

--- a/external/grpc/extlib/zlib/zlib.h
+++ b/external/grpc/extlib/zlib/zlib.h
@@ -1722,7 +1722,11 @@ ZEXTERN uLong ZEXPORT adler32_combine OF((uLong adler1, uLong adler2,
    negative, the result has no meaning or utility.
 */
 
+#ifdef __TizenRT__
+ZEXTERN uLong ZEXPORT grpc_crc32   OF((uLong crc, const Bytef *buf, uInt len));
+#else
 ZEXTERN uLong ZEXPORT crc32   OF((uLong crc, const Bytef *buf, uInt len));
+#endif
 /*
      Update a running CRC-32 with the bytes buf[0..len-1] and return the
    updated CRC-32.  If buf is Z_NULL, this function returns the required


### PR DESCRIPTION
- Change the name of crc32 defined in grpc/extlib to grpc_crc32 because crc32 is defined in lib/libc/misc/ and os/include/