### PR TITLE
update Protobuf README

### DIFF
--- a/external/protobuf/README.md
+++ b/external/protobuf/README.md
@@ -3,6 +3,14 @@
 Protocol Buffers (a.k.a. `protobuf`) is Google's language-neutral, platform-neutral, extensible mechanism for serializing structured data. TizenRT features a port for `protobuf` version 3.5.1, with support for C++ language. 
 You can find details of `protobuf` at https://github.com/google/protobuf.
 
+Before you proceed with the rest of the documentation below, please note the following points:
+
+## Note
+1. **In case you have just recently installed `gRPC`, and wish to install `Protobuf` to work along with `gRPC`, please ignore this document, and refer to the installation instructions under [Installing Protobuf with gRPC](https://github.com/Samsung/TizenRT/blob/master/external/grpc/README.md#pre-requisites) instead.**
+
+2. **In case you have installed `Protobuf` using the instructions in this document, and wish to additionally install `gRPC`, then please make sure you install the correct version of `protobuf` to use along with `gRPC`. It is not really necessary to un-install this version of protobuf, but you will need to maintain different protobuf versions at different paths, and establish the precedence in the $PATH variable. Therefore, to avoid complicating the build, it is recommended to un-install any previous version of `protobuf` and install the version that you need.**
+
+
 The following sections detail the steps required to build `protobuf` on TizenRT, and to build and run TizenRT applications that use `protobuf`.
 
 # Build `protobuf` 


### PR DESCRIPTION
Update Protobuf README.md to refer to gRPC's README.md for instructions how to install Protobuf. 