### PR TITLE
framework/st_things: fixes indentation of definitions.

### DIFF
--- a/framework/src/st_things/things_stack/cloud/cloud_connector.h
+++ b/framework/src/st_things/things_stack/cloud/cloud_connector.h
@@ -26,20 +26,20 @@
 
 #define DEFAULT_CONTEXT_VALUE   0x99
 
-#define KEY_TOKEN_ACCESS           "accesstoken"	// mandatory
-#define KEY_TOKEN_ACCESS_REFRESH   "refreshtoken"	// mandatory
-#define KEY_TOKEN_TYPE			   "token_type"	// mandatory
-#define KEY_EXPIRE_TIME			   "expiresin"	// mandatory
-#define KEY_ID_USER                "uid"	// mandatory
-#define KEY_SERVER_REDIRECT_URI    "redirect_uri"	// option
-#define KEY_CERTIFICATE_FILE       "certificate"	// option
-#define KEY_SERVER_ID              "sid"	// option
+#define KEY_TOKEN_ACCESS           "accesstoken"    // mandatory
+#define KEY_TOKEN_ACCESS_REFRESH   "refreshtoken"   // mandatory
+#define KEY_TOKEN_TYPE             "token_type"     // mandatory
+#define KEY_EXPIRE_TIME            "expiresin"      // mandatory
+#define KEY_ID_USER                "uid"            // mandatory
+#define KEY_SERVER_REDIRECT_URI    "redirect_uri"   // option
+#define KEY_CERTIFICATE_FILE       "certificate"    // option
+#define KEY_SERVER_ID              "sid"            // option
 #define KEY_ID_DEVICE              "di"
 #define KEY_LOGINOUT               "login"
 #define KEY_ICORE_VER              "coreversion"
 #define KEY_IOTIVITY_VER           "verticalversion"
 #define KEY_TYPE_GRANT             "granttype"
-#define CLOUD_ERROR_CODE            "code"
+#define CLOUD_ERROR_CODE           "code"
 #define VALUE_TYPE_GRANT_TOKEN     "refresh_token"
 
 
@@ -93,5 +93,4 @@ extern OCStackResult things_cloud_topic_publish_topic(const char *host,
 		OCRepPayload *payload,
 		OCClientResponseHandler response);
 
-#endif	/* 
- */
+#endif

--- a/framework/src/st_things/things_stack/cloud/cloud_manager.h
+++ b/framework/src/st_things/things_stack/cloud/cloud_manager.h
@@ -25,19 +25,19 @@
 #include "framework/things_server_builder.h"
 #include <stdint.h>
 
-#define CI_COMMON_REFRESH_TIME      12	// access token Refresh period time without accesstoken-expire. (unit: hour)
-#define CI_TOKEN_EXPIRECHECK_TIME   3000	// access token Check period time whether it's expired or available. (unit: second)
+#define CI_COMMON_REFRESH_TIME      12      // access token Refresh period time without accesstoken-expire. (unit: hour)
+#define CI_TOKEN_EXPIRECHECK_TIME   3000    // access token Check period time whether it's expired or available. (unit: second)
 
-#define CLOUD_EXPIRESIN_INVALID		-1
+#define CLOUD_EXPIRESIN_INVALID     -1
 
 #ifdef __SECURED__
-#define DEFAULT_COAP_TCP_HOST "coaps+tcp://"
-#define UNSUPPORT_COAP_TCP_HOST "coap+tcp://"
-#define DEFAULT_COAP_PORT "443"
+#define DEFAULT_COAP_TCP_HOST       "coaps+tcp://"
+#define UNSUPPORT_COAP_TCP_HOST     "coap+tcp://"
+#define DEFAULT_COAP_PORT           "443"
 #else
-#define DEFAULT_COAP_TCP_HOST "coap+tcp://"
-#define UNSUPPORT_COAP_TCP_HOST "coaps+tcp://"
-#define DEFAULT_COAP_PORT "5683"
+#define DEFAULT_COAP_TCP_HOST       "coap+tcp://"
+#define UNSUPPORT_COAP_TCP_HOST     "coaps+tcp://"
+#define DEFAULT_COAP_PORT           "5683"
 #endif
 
 typedef enum rp_target_e {


### PR DESCRIPTION
Aligns the value of definitions using space(' ') instead of tab('\t').