### PR TITLE
libc/math : fix warning

### DIFF
--- a/lib/libc/math/libm.h
+++ b/lib/libc/math/libm.h
@@ -94,16 +94,16 @@ union ldshape {
 #define FORCE_EVAL(x)                             \
 	do {                                          \
 		if (sizeof(x) == sizeof(float)) {         \
-			volatile float __x;                   \
+			volatile float __x = 0;               \
 			UNUSED(__x);                          \
 			__x = (x);                            \
 		} else if (sizeof(x) == sizeof(double)) { \
-			volatile double __x;                  \
+			volatile double __x = 0;              \
 			UNUSED(__x);                          \
 			__x = (x);                            \
 		}                                         \
 		else {                                    \
-			volatile long double __x;             \
+			volatile long double __x = 0;         \
 			UNUSED(__x);                          \
 			__x = (x);                            \
 		}                                         \


### PR DESCRIPTION
Fixes below warning,

TizenRT/os/include/tinyara/compiler.h:79:20: warning: '__x' may be used
uninitialized in this function [-Wmaybe-uninitialized]
 #define UNUSED(a) ((void)(a))
                    ^
In file included from math/lib_exp2f.c:74:0:
math/libm.h:97:19: note: '__x' was declared here
    volatile float __x;                   \
                   ^
math/lib_exp2f.c:166:5: note: in expansion of macro 'FORCE_EVAL'
     FORCE_EVAL(-0x1p-149f / x);
     ^~~~~~~~~~

Signed-off-by: Manohara HK <manohara.hk@samsung.com>