### PR TITLE
examples/grpc: Add protobuf generated stubs to gitignore

### DIFF
--- a/apps/examples/grpc_greeter_client/.gitignore
+++ b/apps/examples/grpc_greeter_client/.gitignore
@@ -1,0 +1,5 @@
+# Ignore auto-generated files from protobuf
+./*.pb.h
+./*.pb.cc
+./*.grpc.pb.h
+./*.grpc.cc

--- a/apps/examples/grpc_route_client/.gitignore
+++ b/apps/examples/grpc_route_client/.gitignore
@@ -1,0 +1,5 @@
+# Ignore auto-generated files from protobuf
+./*.pb.h
+./*.pb.cc
+./*.grpc.pb.h
+./*.grpc.cc


### PR DESCRIPTION
Add Protobuf-generated files to .gitignore, as they should not be versioned, and are deleted upon `make clean`.