### PR TITLE
testcase/fs: apply coding rule

### DIFF
--- a/apps/examples/testcase/le_tc/filesystem/tc_fs_procfs.c
+++ b/apps/examples/testcase/le_tc/filesystem/tc_fs_procfs.c
@@ -126,7 +126,7 @@ static int procfs_uptime_ops(char *dirpath)
 	struct stat st;
 	fd = open(PROC_UPTIME_PATH, O_RDONLY);
 	if (fd < 0) {
-		printf("Failed to open \n" );
+		printf("Failed to open \n");
 		return ERROR;
 	}
 
@@ -212,7 +212,7 @@ static int procfs_rewind_tc(const char *dirpath)
 	} while (dirent != NULL);
 
 	if (count != 0) {
-		printf("rewind operation failed %s \n",dirpath);
+		printf("rewind operation failed %s \n", dirpath);
 		closedir(dir);
 		return ERROR;
 	}
@@ -250,7 +250,7 @@ void tc_fs_smartfs_procfs_main(void)
 
 	/* entry not found condition */
 
-	fd = open(PROC_SMARTFS_FILE_PATH, O_RDWR | O_CREAT );
+	fd = open(PROC_SMARTFS_FILE_PATH, O_RDWR | O_CREAT);
 	TC_ASSERT_EQ("open", fd, ERROR);
 
 	fd = open(INVALID_PATH, O_RDONLY);


### PR DESCRIPTION
apps/examples/testcase/le_tc/filesystem/tc_fs_procfs.c:129: ERROR: [SPC_M_SEP] space prohibited before that close parenthesis ')'
apps/examples/testcase/le_tc/filesystem/tc_fs_procfs.c:215: ERROR: [SPC_M_OPR] space required after that ',' (ctx:VxV)
apps/examples/testcase/le_tc/filesystem/tc_fs_procfs.c:253: ERROR: [SPC_M_SEP] space prohibited before that close parenthesis ')'