### PR TITLE
framework/wifi_manager: Add configuration to disable getting IP 

### DIFF
--- a/framework/src/wifi_manager/Kconfig
+++ b/framework/src/wifi_manager/Kconfig
@@ -66,5 +66,9 @@ config WIFIMGR_STA_IFNAME
 	string "interface name of station mode"
 	default "wl1"
 
+config WIFIMGR_DISABLE_AUTO_GET_IP
+	bool "disable auto get ip (ipv4 dhcp)"
+	default n
+
 endif #WIFI_MANAGER
 

--- a/framework/src/wifi_manager/wifi_manager.c
+++ b/framework/src/wifi_manager/wifi_manager.c
@@ -986,8 +986,9 @@ wifi_manager_result_e _handler_on_softap_disconnecting_state(_wifimgr_msg_s *msg
 wifi_manager_result_e _handler_on_connecting_state(_wifimgr_msg_s *msg)
 {
 	WM_LOG_HANDLER_START;
-	wifi_manager_result_e wret;
 	if (msg->event == EVT_STA_CONNECTED) {
+#ifndef CONFIG_WIFIMGR_DISABLE_AUTO_GET_IP
+		wifi_manager_result_e wret;
 		wret = _get_ipaddr_dhcp();
 		if (wret != WIFI_MANAGER_SUCCESS) {
 			_handle_user_cb(CB_STA_CONNECT_FAILED, NULL);
@@ -996,6 +997,7 @@ wifi_manager_result_e _handler_on_connecting_state(_wifimgr_msg_s *msg)
 			WIFIMGR_SET_STATE(WIFIMGR_STA_DISCONNECTING);
 			return wret;
 		}
+#endif
 		_handle_user_cb(CB_STA_CONNECTED, NULL);
 		WIFIMGR_SET_STATE(WIFIMGR_STA_CONNECTED);
 	} else if (msg->event == EVT_STA_CONNECT_FAILED) {


### PR DESCRIPTION
- Add WIFIMGR_DISABLE_AUTO_GET_IP to enable/disable automatic IP after association/authentication
- DHCP for IPv4 and nothing to do for IPv6 yet