### PR TITLE
media: Close automatically at destruction time

### DIFF
--- a/framework/src/media/BufferOutputDataSource.cpp
+++ b/framework/src/media/BufferOutputDataSource.cpp
@@ -107,7 +107,6 @@ ssize_t BufferOutputDataSource::onStreamBufferReadable(bool isFlush)
 
 BufferOutputDataSource::~BufferOutputDataSource()
 {
-	close();
 }
 
 } // namespace stream

--- a/framework/src/media/DataSource.cpp
+++ b/framework/src/media/DataSource.cpp
@@ -84,5 +84,8 @@ void DataSource::setPcmFormat(audio_format_type_t pcmFormat)
 DataSource::~DataSource()
 {
 	medvdbg("DataSource::~DataSource()\n");
+	if (isPrepare()) {
+		close();
+	}
 }
 } // namespace media

--- a/framework/src/media/FileInputDataSource.cpp
+++ b/framework/src/media/FileInputDataSource.cpp
@@ -126,7 +126,7 @@ bool FileInputDataSource::close()
 bool FileInputDataSource::isPrepare()
 {
 	if (mFp == nullptr) {
-		meddbg("mFp is null\n");
+		medvdbg("mFp is nullptr\n");
 		return false;
 	}
 	return true;
@@ -159,7 +159,6 @@ int FileInputDataSource::seek(long offset, int origin)
 
 FileInputDataSource::~FileInputDataSource()
 {
-	close();
 }
 
 } // namespace stream

--- a/framework/src/media/FileOutputDataSource.cpp
+++ b/framework/src/media/FileOutputDataSource.cpp
@@ -123,7 +123,7 @@ bool FileOutputDataSource::close()
 bool FileOutputDataSource::isPrepare()
 {
 	if (mFp == nullptr) {
-		meddbg("mFp is null\n");
+		medvdbg("mFp is nullptr\n");
 		return false;
 	}
 	return true;
@@ -157,9 +157,6 @@ ssize_t FileOutputDataSource::onStreamBufferReadable(bool isFlush)
 
 FileOutputDataSource::~FileOutputDataSource()
 {
-	if (mFp) {
-		close();
-	}
 }
 
 } // namespace stream


### PR DESCRIPTION
~DataSource() check whether datasource is prepared and close if prepared