### PR TITLE
framework/task_manager: Fix bug for broadcast when user data is NULL

### DIFF
--- a/framework/src/task_manager/task_manager_core.c
+++ b/framework/src/task_manager/task_manager_core.c
@@ -746,6 +746,7 @@ static void taskmgr_broadcast(tm_internal_msg_t *arg)
 		memcpy(bm.user_data, arg->msg, arg->msg_size);
 	} else {
 		bm.user_data = NULL;
+		bm.size = 0;
 	}
 
 	for (handle = 0; handle < CONFIG_TASK_MANAGER_MAX_TASKS; handle++) {


### PR DESCRIPTION
if user_data is NULL, size var should be set to zero.