### PR TITLE
add operator== and id for media recorder

### DIFF
--- a/framework/include/media/MediaRecorder.h
+++ b/framework/include/media/MediaRecorder.h
@@ -201,8 +201,19 @@ public:
 	 */
 	recorder_result_t setDuration(int second);
 
+	/**
+	 * @brief MediaRecorder operator==
+	 * @details @b #include <media/MediaRecorder.h>
+	 * This function is sync call apis
+	 * Compares the MediaRecorder objects for equality
+	 * @return The result of the compare operation for MediaRecorder object
+	 * @since TizenRT v2.0 PRE
+	 */
+	bool operator==(const MediaRecorder& rhs);
+
 private:
 	std::shared_ptr<MediaRecorderImpl> mPMrImpl;
+	uint64_t mId;
 };
 } // namespace media
 

--- a/framework/src/media/MediaRecorder.cpp
+++ b/framework/src/media/MediaRecorder.cpp
@@ -23,6 +23,8 @@
 namespace media {
 MediaRecorder::MediaRecorder() : mPMrImpl(new MediaRecorderImpl(*this))
 {
+	mId = (uint64_t)this << 32;
+	mId = mId | (uint64_t)mPMrImpl.get();
 }
 
 recorder_result_t MediaRecorder::create()
@@ -83,6 +85,11 @@ recorder_result_t MediaRecorder::setObserver(std::shared_ptr<MediaRecorderObserv
 recorder_result_t MediaRecorder::setDuration(int second)
 {
 	return mPMrImpl->setDuration(second);
+}
+
+bool MediaRecorder::operator==(const MediaRecorder& rhs)
+{
+	return this->mId == rhs.mId;
 }
 
 MediaRecorder::~MediaRecorder()


### PR DESCRIPTION
The media framework supports multiple instances
applications are trying to handle multiple instances,
and we need to compare the objects. So we added operator and id.

Signed-off-by: jaesick.shin <jaesick.shin@samsung.com>