### PR TITLE
media: remove unused id for recorderobserverinterface

### DIFF
--- a/framework/include/media/MediaRecorderObserverInterface.h
+++ b/framework/include/media/MediaRecorderObserverInterface.h
@@ -50,13 +50,6 @@ class MediaRecorderObserverInterface
 {
 public:
 	/**
-	 * @brief Id means unique id of MediaRecorder.
-	 * @details @b #include <media/MediaRecorderObserverInterface.h>
-	 * support multi-recorders according to device specifications
-	 * @since TizenRT v2.0 PRE
-	 */
-	using Id = uint64_t;
-	/**
 	 * @brief informs the user of the recording has begun.
 	 * @details @b #include <media/MediaRecorderObserverInterface.h>
 	 * @since TizenRT v2.0 PRE


### PR DESCRIPTION
remove instance id(not required) - #2038 
  : Use the mediarecorder object instead of instance id

Signed-off-by: jaesick.shin <jaesick.shin@samsung.com>