### PR TITLE
utils/netcmd_netmon : remove a build warning cause

### DIFF
--- a/apps/system/utils/netcmd_netmon.c
+++ b/apps/system/utils/netcmd_netmon.c
@@ -205,7 +205,7 @@ int cmd_netmon(int argc, char **argv)
 		printf("wifi option will be supported\n");
 	} else {
 #ifdef CONFIG_NET_STATS
-		struct netmon_netdev_stats stats = {0};
+		struct netmon_netdev_stats stats = {{0,}, 0, 0, 0, 0};
 		char *intf = NULL;
 		/* Get network interface stats if exists: SIOCGDEVSTATS */
 		intf = argv[1];


### PR DESCRIPTION
Just initializing struct netmon_netdev_stats by {0} gives rise to a build warning.
It needs to be initialized by {{0,}, 0, 0, 0, 0}.