### PR TITLE
external: Change FTPC temporary directory

### DIFF
--- a/external/include/protocols/ftpc.h
+++ b/external/include/protocols/ftpc.h
@@ -88,7 +88,7 @@
 #endif
 
 #ifndef CONFIG_FTP_TMPDIR
-#define CONFIG_FTP_TMPDIR "/tmp"
+#define CONFIG_FTP_TMPDIR "/mnt"
 #endif
 
 #ifndef CONFIG_FTP_BUFSIZE


### PR DESCRIPTION
If FTPC temporary directory is set to "/tmp", put and get commands do not work normally.
Changed the temporary directory to "/mnt".