### PR TITLE
external/netmon: Remove warning of missing braces around initializer

### DIFF
--- a/apps/system/utils/netcmd_netmon.c
+++ b/apps/system/utils/netcmd_netmon.c
@@ -205,7 +205,7 @@ int cmd_netmon(int argc, char **argv)
 		printf("wifi option will be supported\n");
 	} else {
 #ifdef CONFIG_NET_STATS
-		struct netmon_netdev_stats stats = {0};
+		struct netmon_netdev_stats stats;
 		char *intf = NULL;
 		/* Get network interface stats if exists: SIOCGDEVSTATS */
 		intf = argv[1];


### PR DESCRIPTION
- Remove bad initialization format due to warning
- The structure is composed of one character array and four integer variables, where 0 initialization for the array might not be appropriate.