### PR TITLE
Fix issue with concurrent socket select and socket close

### DIFF
--- a/os/fs/vfs/fs_poll.c
+++ b/os/fs/vfs/fs_poll.c
@@ -332,6 +332,7 @@ int poll(FAR struct pollfd *fds, nfds_t nfds, int timeout)
 	int count = 0;
 	int ret;
 
+	DEBUGASSERT((fds != NULL));
 	/* poll() is a cancellation point */
 	(void)enter_cancellation_point();
 


### PR DESCRIPTION
Fix issue with concurrent socket select and socket close.

Scenario: 2 threads 1 and 2.

Thread 1 select-waits on a socket fd, while Thread 2 closes the same socket fd. 

At present: TizenRT does not de-allocate the said socket fd.
Fix: Exit the select wait, and also de-allocate the socket fd.
