### PR TITLE
framework/task_manager: Fix task_manager_register_pthread to alloc pt…

### DIFF
--- a/framework/src/task_manager/task_manager_core.c
+++ b/framework/src/task_manager/task_manager_core.c
@@ -210,6 +210,7 @@ static int taskmgr_unregister(int handle)
 		TM_FREE(tm_pthread_list[TM_IDX(handle)].name);
 		tm_pthread_list[TM_IDX(handle)].name = NULL;
 		pthread_attr_destroy(tm_pthread_list[TM_IDX(handle)].attr);
+		TM_FREE(tm_pthread_list[TM_IDX(handle)].attr);
 		tm_pthread_list[TM_IDX(handle)].entry = NULL;
 		tm_pthread_list[TM_IDX(handle)].arg = NULL;
 	}

--- a/framework/src/task_manager/task_manager_register.c
+++ b/framework/src/task_manager/task_manager_register.c
@@ -153,7 +153,8 @@ int task_manager_register_pthread(char *name, pthread_attr_t *attr, pthread_star
 		return TM_OUT_OF_MEMORY;
 	}
 	strncpy(((tm_pthread_info_t *)request_msg.data)->name, name, strlen(name) + 1);
-	((tm_pthread_info_t *)request_msg.data)->attr = attr;
+	((tm_pthread_info_t *)request_msg.data)->attr = (pthread_attr_t *)TM_ALLOC(sizeof(pthread_attr_t));
+	memcpy(((tm_pthread_info_t *)request_msg.data)->attr, attr, sizeof(pthread_attr_t));
 	((tm_pthread_info_t *)request_msg.data)->entry = start_routine;
 	((tm_pthread_info_t *)request_msg.data)->arg = arg;
 	request_msg.timeout = timeout;


### PR DESCRIPTION
…hread attribute

if not allocate the pthread attribute, attr can be disappeared when it is a local variable.