### PR TITLE
framework/task_manager: Add pthread_detach before stopping a pthread

### DIFF
--- a/framework/src/task_manager/task_manager_core.c
+++ b/framework/src/task_manager/task_manager_core.c
@@ -324,6 +324,7 @@ static int taskmgr_stop(int handle, int caller_pid)
 	}
 #ifndef CONFIG_DISABLE_PTHREAD
 	else {
+		(void)pthread_detach(TM_PID(handle));
 		ret = pthread_cancel(TM_PID(handle));
 	}
 #endif


### PR DESCRIPTION
if not detaching, joininfo is not destroyed when cancelling the pthread