### PR TITLE
framework/task_manager: Change unicast about freeing user data

### DIFF
--- a/apps/examples/testcase/ta_tc/task_manager/utc/utc_task_manager_main.c
+++ b/apps/examples/testcase/ta_tc/task_manager/utc/utc_task_manager_main.c
@@ -79,7 +79,6 @@ static void sync_test_cb(tm_msg_t *info)
 	if (strncmp(info->msg, TM_SYNC_SEND_MSG, info->msg_size) == 0) {
 		reply_msg.msg = malloc(strlen(TM_SYNC_RECV_MSG));
 		if (reply_msg.msg != NULL) {
-			free(info->msg);
 			reply_msg.msg_size = strlen(TM_SYNC_RECV_MSG) + 1;
 			memcpy(reply_msg.msg, TM_SYNC_RECV_MSG, reply_msg.msg_size);
 			task_manager_reply_unicast(&reply_msg);
@@ -108,7 +107,6 @@ static void *tm_pthread(void *param)
 static void test_unicast_handler(tm_msg_t *info)
 {
 	flag = !strncmp((char *)info->msg, TM_SAMPLE_MSG, strlen(TM_SAMPLE_MSG));
-	free(info->msg);
 }
 
 static void test_broadcast_handler(void *user_data, void *info)

--- a/framework/include/task_manager/task_manager.h
+++ b/framework/include/task_manager/task_manager.h
@@ -276,8 +276,7 @@ int task_manager_restart(int handle, int timeout);
  * task_manager_unicast can be used with SYNC and ASYNC mode.\n
  * With SYNC mode, reply msg can be sent through task_manager_reply_unicast API.
  * @param[in] handle the handle id of task to be sent
- * @param[in] send_msg message structure to be unicasted\n
- *             @remarks The @send_msg value must be released with free() by you in unicast callback function.
+ * @param[in] send_msg message structure to be unicasted
  * @param[out] reply_msg the reply msg structure for sync. If this is NULL, task_manager_unicast works asynchronously.
  * @param[in] timeout returnable flag. It can be one of the below.\n
  *			TM_NO_RESPONSE : Ignore the response of request from task manager\n

--- a/framework/src/task_manager/task_manager_core.c
+++ b/framework/src/task_manager/task_manager_core.c
@@ -1253,7 +1253,7 @@ int task_manager(int argc, char *argv[])
 			taskmgr_send_response((char *)request_msg.q_name, &response_msg);
 		}
 
-		if (request_msg.data != NULL && request_msg.cmd != TASKMGRCMD_SET_UNICAST_CB && request_msg.cmd != TASKMGRCMD_ALLOC_BROADCAST_MSG) {
+		if (request_msg.data != NULL && request_msg.cmd != TASKMGRCMD_SET_UNICAST_CB && request_msg.cmd != TASKMGRCMD_ALLOC_BROADCAST_MSG && request_msg.cmd != TASKMGRCMD_UNICAST) {
 			if (request_msg.cmd == TASKMGRCMD_BROADCAST && ((tm_internal_msg_t *)request_msg.data)->msg != NULL) {
 				TM_FREE(((tm_internal_msg_t *)request_msg.data)->msg);
 			}


### PR DESCRIPTION
When user sends unicast msg, user should free the user data.
With this change, user don't need to free the user data. It will be freed automatically.