### PR TITLE
dbuild: support menu and execution list

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,19 +8,20 @@ Please find project details at [Wiki](https://github.com/Samsung/TizenRT/wiki) e
 
 ## Contents
 
-> [Quick Start](#quick-start)  
+> [Environment Setup](#environment-setup)  
+> [How to Build](#how-to-build)  
 > [Supported Board / Emulator](#supported-board--emulator)  
 
-## Quick Start
+## Environment Setup
 
 TizenRT provides the easiest way to build with the use of [Docker](https://www.docker.com/).  
 There is no need to install the required libraries and toolchains since the provided Docker container already includes everything required for TizenRT development.  
 However, if your development systems are not eligible for running the Docker container, all libraries and toolchains should be manually installed.  
 Please refer to [Manual Setup Build Environment](docs/HowToSetEnv.md).
 
-For more infomation of libraries in the TizenRT Docker Image, see https://hub.docker.com/r/tizenrt/tizenrt/.
+For more information of libraries in the TizenRT Docker Image, see https://hub.docker.com/r/tizenrt/tizenrt/.
 
-### 1. Install Docker
+### 1. Installing Docker
 
 To install OS specific Docker engines, see https://docs.docker.com/install/linux/docker-ce/ubuntu/.  
 If you already have a Docker engine, please skip this step.
@@ -35,7 +36,68 @@ TIZENRT_BASEDIR="$PWD"
 **Note**: To contribute in this community, you need to clone your forked private repository instead.  
           Github guides this by [working-with-forks](https://help.github.com/articles/working-with-forks).
 
-### 3. Configuration
+## How to build
+
+TizenRT provides an interactive tool (*dbuild.sh*) where you are prompted to select a option among multiple choices.  
+According to your selection, it consecutively provides next-step options.  
+When you become familiar to the TizenRT build system, you may use the *dbuild.sh* script with a specific build option.
+
+As the build script is running based on Docker, it requires *sudo* for root permission.  
+To run Docker without *sudo*, refer to https://docs.docker.com/install/linux/linux-postinstall/.
+
+### Using an interactive tool
+
+To get started, use the *dbuild.sh* script with the *menu* option as follows:
+```bash
+cd os
+./dbuild.sh menu
+```
+
+This command shows you the complete list of supported boards first as shown below:
+```bash
+======================================================
+  "Select Board"
+======================================================
+  "1. artik053"
+  "2. cy4390x"
+      ...
+  "x. EXIT"
+======================================================
+```
+
+After the board selection, you are prompted to select configuration of the given board:
+```bash
+======================================================
+  "Select Configuration of artik053"
+======================================================
+  "1. hello"
+  "2. tc"
+      ...
+  "x. EXIT"
+======================================================
+```
+
+Finally, you are prompted to select a build option as shown below:
+```bash
+======================================================
+  "Select build Option"
+======================================================
+  "1. Build with Current Configurations"
+  "2. Re-configure"
+  "3. Menuconfig"
+  "4. Build Clean"
+  "5. Build Dist-Clean"
+  "d. Download"
+  "x. Exit"
+======================================================
+```
+
+Once the board and configuration selection is finished,  
+you are prompted to select a build option repeatedly until you remove configuration by the *Re-configure* or *Build Dist-Clean* option.
+
+### Using specific build options
+
+#### 1. Configuration
 
 ```bash
 cd os
@@ -43,6 +105,7 @@ cd os
 ```
 
 This command retrieves the specific pre-configured file named defconfig and Make.defs according to \<board\>/\<configuration_set\>.  
+Once the configuration is done, you can skip this step next time unless you want to change your configuration.  
 You can see collection of all configuration files at *$TIZENRT_BASEDIR/build/configs*.  
 To check all pre-defined configurations, type as follows:
 
@@ -50,21 +113,18 @@ To check all pre-defined configurations, type as follows:
 ./configure.sh --help
 ```
 
-#### 3.1 Additional Configuration
+##### 1.1 Additional Configuration (optional)
 
-After basic configuration by [3. Configuration](#3-configuration), you can customize configurations optionally with **menuconfig**.
+After basic configuration by [1. Configuration](#1-configuration), you can additionally modify your configuration with *menuconfig*.
 
 ```bash
 ./dbuild.sh menuconfig
 ```
 
 **Note**: In Docker environment, ```make menuconfig``` command from other README files should be replaced with this command.  
-          It applies only in manual setup build environment.
+          ```make menuconfig``` applies only in [Manual Setup Build Environment](docs/HowToSetEnv.md).
 
-This command might require ```sudo``` for root permission.  
-To run Docker without ```sudo```, refer to https://docs.docker.com/install/linux/linux-postinstall/.
-
-### 4. Compilation
+#### 2. Compilation
 
 ```bash
 ./dbuild.sh
@@ -72,7 +132,7 @@ To run Docker without ```sudo```, refer to https://docs.docker.com/install/linux
 
 Built binaries are located in *$TIZENRT_BASEDIR/build/output/bin*.
 
-#### 4.1 Clean
+##### 2.1 Clean
 
 There are two types of clean commands, clean and distclean.
 
@@ -90,22 +150,34 @@ After modifying configuration with menuconfig, this command is required.
 This command includes the *clean* option and additionally removes configured files including .config, Make.defs and linked folders / files.  
 Before changing basic configuration with ```./configure.sh``` command, this command is required to delete pre-set configurations.
 
-### 5. Programming
+#### 3. Programming
 
 ```bash
 ./dbuild.sh download [OPTION]
 ```
 
 TizenRT supports *download* command to program a binary into a board.  
-You might be required to set up usb driver. For more information, please refer to [Supported board / Emulator](#supported-board--emulator).
+You might be required to set up USB driver. For more information, please refer to [Supported board / Emulator](#supported-board--emulator).
 
 ```OPTION``` designates which flash partitions are flashed.  
 For example, ```ALL``` means programming all of binaries. This also depends on each board.
 
+#### Advanced
+
+You can give multiple build options to the *dbuild.sh* script as mentioned below:
+```bash
+./dbuild.sh distclean configure artik053 hello build download all
+```
+This executes sequentially multiple commands including
+1. Execute distclean
+2. Configure with artik053/hello
+3. Build
+4. Program all of binaries
+
 ## Supported Board / Emulator
 
 TizenRT supports multiple boards as well as QEMU.  
-The linked page for each board includs board-specific environments, programming method, and board information.
+The linked page for each board includes board-specific environments, programming method, and board information.
 
 ARTIK053 [[details]](build/configs/artik053/README.md)
 

--- a/os/dbuild.sh
+++ b/os/dbuild.sh
@@ -18,6 +18,17 @@
 ###########################################################################
 # dbuild.sh
 
+OSDIR=`test -d ${0%/*} && cd ${0%/*}; pwd`
+CONFIGFILE="${OSDIR}/.config"
+TOPDIR="${OSDIR}/.."
+BUILDDIR="${TOPDIR}/build"
+BINDIR="${BUILDDIR}/output/bin"
+BINFILE="${BINDIR}/tinyara.bin"
+CONFIGDIR="${BUILDDIR}/configs"
+
+STATUS_LIST="NOT_CONFIGURED BOARD_CONFIGURED CONFIGURED BUILT PREPARE_DL DOWNLOAD"
+BUILD_CMD=make
+
 # Checking docker is installed
 nodocker() {
 	cat <<EOF
@@ -31,25 +42,347 @@ EOF
 }
 
 if ! which docker > /dev/null; then
-    nodocker 1>&2
-    exit 1
+	nodocker 1>&2
+	exit 1
 fi
 
-# Run TizenRT docker container
-BUILD_CMD=make
-BUILD_OPT=$1
-BUILD_OPT_LOWER=$(echo "$BUILD_OPT" | tr '[:upper:]' '[:lower:]')
+function SELECT_OPTION()
+{
+	unset SELECTED_START
 
-case "$BUILD_OPT_LOWER" in
-download )
-	${BUILD_CMD} ${BUILD_OPT_LOWER} $2 $3 $4 $5 $6
-	;;
-*)
+	if [ -f ${OSDIR}/.config ]; then
+		if [ ! -z "$1" ];then
+			SELECTED_START=$1
+		else
+			echo ======================================================
+			echo "  \"Select build Option\""
+			echo ======================================================
+			echo "  \"1. Build with Current Configurations\""
+			echo "  \"2. Re-configure\""
+			echo "  \"3. Menuconfig\""
+			echo "  \"4. Build Clean\""
+			echo "  \"5. Build Dist-Clean\""
+			if [ -f ${BINDIR}/tinyara.bin ]; then
+				echo "  \"d. Download\""
+			fi
+			echo "  \"x. Exit\""
+			echo ======================================================
+			read SELECTED_START
+		fi
+
+		case ${SELECTED_START} in
+		1|build)
+			BUILD
+			;;
+		2|configure)
+			if [ "${STATUS}" == "BUILT" ]; then
+				BUILD distclean
+			fi
+			STATUS=NOT_CONFIGURED
+			;;
+		3|menuconfig)
+			BUILD menuconfig
+			;;
+		4|clean)
+			BUILD clean
+			;;
+		5|distclean)
+			BUILD distclean
+			;;
+		
+		d|download)
+			if [ "${STATUS}" == "BUILT" ]; then
+				STATUS=PREPARE_DL
+			fi
+			;;
+		x|exit)
+			exit 1
+			;;
+		*)
+			;;
+		esac
+	else
+		SELECT_BOARD
+	fi
+}
+
+function SELECT_BOARD()
+{
+	unset BOARD
+	unset SELECTED_BOARD
+	unset CONFIGS_PATH_LIST
+	unset BOARDNAME_DUP_LIST
+
+	# make a list of full paths which includes defconfig inside
+	CONFIGS_FULLPATH_LIST=`find -L ${CONFIGDIR} -name defconfig`
+	for CONFIGS_FULLPATH_MEMBER in ${CONFIGS_FULLPATH_LIST}; do
+		# extract "boardname/configname"s from full paths
+		CONFIGS_PATH_LIST+=`dirname ${CONFIGS_FULLPATH_MEMBER} | sed -e "s,${CONFIGDIR}/,,g"`
+		CONFIGS_PATH_LIST+=" "
+	done
+
+	# extract "boardname" from "boardname/configname"
+	for CONFIGS_PATH_MEMBER in ${CONFIGS_PATH_LIST}; do
+		BOARDNAME_DUP_LIST+=`echo "${CONFIGS_PATH_MEMBER}" | sed -n 's/\/.*//p'`
+		BOARDNAME_DUP_LIST+=" "
+	done
+	# remove duplicated boardname and sort
+	BOARDNAME_LIST=`echo ${BOARDNAME_DUP_LIST} | xargs -n1 | sort -u | xargs`
+
+	# print menu
+	IDX=1
+	if [ ! -z "$1" ];then
+		SELECTED_BOARD=$1
+		for BOARDNAME_MEMBER in ${BOARDNAME_LIST}; do
+			BOARDNAME_STR[${IDX}]=${BOARDNAME_MEMBER}
+			((IDX=IDX+1))
+		done
+	else	
+		echo ======================================================
+		echo "  \"Select Board\""
+		echo ======================================================
+		for BOARDNAME_MEMBER in ${BOARDNAME_LIST}; do
+			echo "  \"${IDX}. ${BOARDNAME_MEMBER}\""
+			BOARDNAME_STR[${IDX}]=${BOARDNAME_MEMBER}
+			((IDX=IDX+1))
+		done
+		echo "  \"x. EXIT\""
+		echo ======================================================
+		read SELECTED_BOARD
+	fi
+
+	# treate "exit"
+	if [ "${SELECTED_BOARD}" == "x" -o "${SELECTED_BOARD}" == "exit" -o "${SELECTED_BOARD}" == "EXIT" ]; then
+		exit 1
+	fi
+
+	# treate selected number
+	if [ ! -z ${BOARDNAME_STR[${SELECTED_BOARD}]} ]; then
+		BOARD=${BOARDNAME_STR[${SELECTED_BOARD}]}	
+	fi
+
+	# treate given board string
+	if [ -z ${BOARD} ]; then
+		IDX=1
+		for BOARDNAME_MEMBER in ${BOARDNAME_STR[@]}; do
+			if [ "${SELECTED_BOARD}" == "${BOARDNAME_MEMBER}" ]; then
+				BOARD=${BOARDNAME_MEMBER}
+			fi
+		done
+	fi
+
+	if [ ! -z ${BOARD} ]; then
+		STATUS=BOARD_CONFIGURED
+		echo "${BOARD} is selected"
+	fi
+}
+
+function SELECT_CONFIG()
+{
+	unset CONFIG
+	unset SELECTED_CONFIG
+	unset CONFIGNAME_LIST
+
+	# make a list of full paths which includes defconfig inside
+	CONFIGS_FULLPATH_LIST=`find -L ${CONFIGDIR}/${BOARD} -name defconfig`
+	for CONFIGS_FULLPATH_MEMBER in ${CONFIGS_FULLPATH_LIST}; do
+		# extract "configname"s from full paths
+		CONFIGNAME_LIST+=`dirname ${CONFIGS_FULLPATH_MEMBER} | sed -e "s,${CONFIGDIR}/${BOARD}/,,g"`
+		CONFIGNAME_LIST+=" "
+	done
+
+	# print menu
+	IDX=1
+	if [ ! -z "$1" ];then
+		SELECTED_CONFIG=$1
+		for CONFIGNAME_MEMBER in ${CONFIGNAME_LIST}; do
+			CONFIGNAME_STR[${IDX}]=${CONFIGNAME_MEMBER}
+			((IDX=IDX+1))
+		done
+	else
+		echo ==================================================
+		echo "  \"Select Configuration of ${BOARD}\""
+		echo ==================================================
+		for CONFIGNAME_MEMBER in ${CONFIGNAME_LIST}; do
+			echo "  \"${IDX}. ${CONFIGNAME_MEMBER}\""
+			CONFIGNAME_STR[${IDX}]=${CONFIGNAME_MEMBER}
+			((IDX=IDX+1))
+		done
+		echo "  \"x. EXIT\""
+		echo ==================================================
+		read SELECTED_CONFIG
+	fi
+
+	# treate "exit"
+	if [ "${SELECTED_CONFIG}" == "x" -o "${SELECTED_CONFIG}" == "exit" -o "${SELECTED_CONFIG}" == "EXIT" ]; then
+		exit 0
+	fi
+
+	# treate selected number
+	if [ ! -z ${CONFIGNAME_STR[${SELECTED_CONFIG}]} ]; then
+		CONFIG=${CONFIGNAME_STR[${SELECTED_CONFIG}]}
+		
+	fi
+
+	# treate given config string
+	if [ -z ${CONFIG} ]; then
+		IDX=1
+		for CONFIGNAME_MEMBER in ${CONFIGNAME_STR[@]}; do
+			if [ "${SELECTED_CONFIG}" == "${CONFIGNAME_MEMBER}" ]; then
+				CONFIG=${CONFIGNAME_MEMBER}
+			fi
+		done
+	fi
+
+	if [ -z ${CONFIG} ]; then
+		echo "Error & Exit!! Should be CONFIG name after BOARD name."
+		exit 1
+	fi
+
+	echo "${CONFIG} is selected"
+
+	CONFIGURE ${BOARD}/${CONFIG} || exit 1
+}
+
+function SELECT_DL
+{
+	unset DL_ARG
+
+	if [ ! -z "$1" ];then
+		SELECTED_DL=$1
+	else
+		echo ==================================================
+		echo "  \"Select download option\""
+		echo ==================================================
+		echo "  \"1. ALL\""
+		echo "  \"2. OS\""
+		echo "  \"x. Exit\""
+		echo ==================================================
+		read SELECTED_DL
+	fi
+
+	case ${SELECTED_DL} in
+	1|all)
+		DL_ARG=all
+		;;
+	2|os)
+		DL_ARG=os
+		;;
+	x|exit)
+		exit 1
+		;;
+	*)
+		;;
+	esac
+
+	if [ ! -z "${DL_ARG}" ]; then
+		STATUS=DOWNLOAD
+	fi
+}
+
+function BUILD()
+{
 	docker rm -f tizenrt > /dev/null 2>&1
-	docker run --rm -it -d -v $(pwd)/..:/root/tizenrt --name tizenrt -w /root/tizenrt/os tizenrt/tizenrt /bin/bash
-	docker exec -it tizenrt ${BUILD_CMD} ${BUILD_OPT_LOWER}
+	docker run --rm -it -d -v ${TOPDIR}:/root/tizenrt --name tizenrt -w /root/tizenrt/os tizenrt/tizenrt /bin/bash
+	docker exec -it tizenrt ${BUILD_CMD} $1
 	docker stop tizenrt > /dev/null 2>&1
-	;;
-esac
 
+	if [ "$1" == "distclean" ]; then
+		STATUS=NOT_CONFIGURED
+	elif [ "$1" == "clean" ]; then
+		STATUS=CONFIGURED
+	else
+		STATUS=BUILT
+	fi
+}
+
+function CONFIGURE()
+{
+	${OSDIR}/tools/configure.sh $1 || exit 1
+	STATUS=CONFIGURED
+}
+
+function DOWNLOAD()
+{
+	# Currently supports ALL only, later this will have a menu
+	pushd ${OSDIR} > /dev/null
+	${BUILD_CMD} download $1 $2 $3 $4 $5
+	popd > /dev/null
+
+	exit 0
+}
+
+function CHECK_STATUS()
+{
+	if [ ! -f ${CONFIGFILE} ]; then
+		STATUS=NOT_CONFIGURED
+	elif [ -f ${BINFILE} ]; then
+		STATUS=BUILT
+	else
+		STATUS=CONFIGURED
+	fi
+}
+
+function MENU()
+{
+	while [ "${STATUS}" != "DOWNLOAD" ]; do
+		case ${STATUS} in
+		NOT_CONFIGURED)
+			SELECT_BOARD
+			SELECT_CONFIG
+			;;
+		CONFIGURED|BUILT)
+			SELECT_OPTION
+			;;
+		PREPARE_DL)
+			SELECT_DL
+			;;
+		*)
+			echo "Invalid Status!! ${STATUS}"
+			exit 1
+			;;
+		esac
+	done
+}
+
+CHECK_STATUS
+if [ -z "$1" ]; then
+	if [ "$STATUS" != "NOT_CONFIGURED" ]; then
+		BUILD
+		exit 0
+	else
+		echo "Error!! Need to configure"
+		exit 1
+	fi
+elif [ "$1" == "menu" ]; then
+	MENU
+else
+	while test $# -gt 0; do
+		ARG=$(echo $1 | tr '[:upper:]' '[:lower:]')
+		case ${STATUS} in
+		NOT_CONFIGURED)
+			SELECT_BOARD ${ARG}
+			;;
+		BOARD_CONFIGURED)
+			SELECT_CONFIG ${ARG}
+			;;
+		CONFIGURED|BUILT)
+			SELECT_OPTION ${ARG}
+			;;
+		PREPARE_DL)
+			DL_ARG+="${ARG} "
+			STATUS=DOWNLOAD
+			;;
+		*)
+			echo "Invalid Status!! ${STATUS}"
+			exit 1
+			;;
+		esac
+		shift
+	done
+fi
+
+if [ "${STATUS}" == "DOWNLOAD" ]; then
+	DOWNLOAD ${DL_ARG}
+fi
 exit 0


### PR DESCRIPTION
1. Support "menu" option
  "./dbuild.sh menu" shows menu. User can choose an option
  after seeing list of available option.
  ======================================================
    "Select Board"
  ======================================================
    "1. artik053"
    "2. artik053s"
    "3. artik055s"
    "4. cy4390x"
    "5. qemu"
    "6. sidk_s5jt200"
    "x. EXIT"
  ======================================================

2. Support exection list
  User can put the list of execution as arguments like below:
  "./dbuild.sh configure artik053 hello"
  "./dbuild.sh distclean configure cy4390 tc build download all"

Signed-off-by: sunghan-chang <sh924.chang@samsung.com>