### PR TITLE
media:Make Decoder visible only to InputDataSource

### DIFF
--- a/framework/include/media/InputDataSource.h
+++ b/framework/include/media/InputDataSource.h
@@ -133,10 +133,10 @@ protected:
 	virtual ssize_t onStreamBufferWritable() = 0;
 
 protected:
-	void setDecoder(std::shared_ptr<Decoder> decoder);
-	const std::shared_ptr<Decoder> getDecoder();
 	void setAudioType(audio_type_t audioType);
 	audio_type_t getAudioType();
+	void registerDecoder(audio_type_t audioType, unsigned int channels, unsigned int sampleRate);
+	void unregisterDecoder();
 	size_t getDecodeFrames(unsigned char *buf, size_t *size);
 
 	void setStreamBuffer(std::shared_ptr<StreamBuffer>);

--- a/framework/src/media/MediaPlayerImpl.cpp
+++ b/framework/src/media/MediaPlayerImpl.cpp
@@ -22,7 +22,6 @@
 
 #include <debug.h>
 #include <errno.h>
-#include "Decoder.h"
 #include "audio/audio_manager.h"
 
 namespace media {


### PR DESCRIPTION
Only InputDataSource can handle Decoder.
Derived datasource call register and unresgister decoder.