### PR TITLE
framework/task_manager: Modify task_manager_broadcast to receive the …

### DIFF
--- a/apps/examples/testcase/ta_tc/task_manager/utc/utc_task_manager_main.c
+++ b/apps/examples/testcase/ta_tc/task_manager/utc/utc_task_manager_main.c
@@ -426,7 +426,7 @@ static void utc_task_manager_unicast_p(void)
 static void utc_task_manager_broadcast_n(void)
 {
 	int ret;
-	ret = task_manager_broadcast(TM_INVALID_BROAD_MSG, NULL);
+	ret = task_manager_broadcast(TM_INVALID_BROAD_MSG, NULL, TM_RESPONSE_WAIT_INF);
 	TC_ASSERT_EQ("task_manager_broadcast", ret, TM_INVALID_PARAM);
 
 	TC_SUCCESS_RESULT();
@@ -447,7 +447,7 @@ static void utc_task_manager_broadcast_p(void)
 	user_data.msg_size = strlen("WIFI_ON") + 1;
 	strncpy(user_data.msg, "WIFI_ON", user_data.msg_size);
 
-	(void)task_manager_broadcast(TM_BROADCAST_WIFI_ON, &user_data);
+	(void)task_manager_broadcast(TM_BROADCAST_WIFI_ON, &user_data, TM_NO_RESPONSE);
 	while (1) {
 		sleep(1);
 		if (broad_wifi_on_cnt == TM_BROAD_TASK_NUM) {
@@ -466,7 +466,7 @@ static void utc_task_manager_broadcast_p(void)
 	broad_wifi_off_cnt = 0;
 	broad_undefined_cnt = 0;
 	sleep_cnt = 0;
-	(void)task_manager_broadcast(TM_BROADCAST_WIFI_OFF, NULL);
+	(void)task_manager_broadcast(TM_BROADCAST_WIFI_OFF, NULL, TM_NO_RESPONSE);
 	while (1) {
 		usleep(500);
 		if (broad_wifi_off_cnt == TM_BROAD_TASK_NUM) {
@@ -483,7 +483,7 @@ static void utc_task_manager_broadcast_p(void)
 	broad_wifi_off_cnt = 0;
 	broad_undefined_cnt = 0;
 	sleep_cnt = 0;
-	(void)task_manager_broadcast(tm_broadcast_undefined_msg, NULL);
+	(void)task_manager_broadcast(tm_broadcast_undefined_msg, NULL, TM_NO_RESPONSE);
 	while (1) {
 		usleep(500);
 		if (broad_undefined_cnt == TM_BROAD_TASK_NUM) {

--- a/framework/include/task_manager/task_manager.h
+++ b/framework/include/task_manager/task_manager.h
@@ -295,12 +295,16 @@ int task_manager_unicast(int handle, tm_msg_t *send_msg, tm_msg_t *reply_msg, in
  * @details @b #include <task_manager/task_manager.h>
  * @param[in] msg message structure to be unicasted
  * @param[in] data data and its size to be broadcasted
+ * @param[in] timeout returnable flag. It can be one of the below.\n
+ *			TM_NO_RESPONSE : Ignore the response of request from task manager\n
+ *			TM_RESPONSE_WAIT_INF : Blocked until get the response from task manager\n
+ *			integer value : Specifies an upper limit on the time for which will block in milliseconds
  * @return On success, OK is returned. On failure, defined negative value is returned.\n
  *         (This return value only checks whether a broadcast message has been requested\n
  *          to the task manager to broadcast.)
  * @since TizenRT v2.0 PRE
  */
-int task_manager_broadcast(int msg, tm_msg_t *data);
+int task_manager_broadcast(int msg, tm_msg_t *data, int timeout);
 /**
  * @brief Set unicast callback function API
  * @details @b #include <task_manager/task_manager.h>


### PR DESCRIPTION
…result

task_manager_broadcast can receive the result for broadcasting.
the result is about failure to send broadcast at all like TM_INVALID_DRVFD, TM_OUT_OF_MEMORY and TM_UNREGISTERED_MSG.
but this is not an error case for all tasks not to receive broadcasts.