### PR TITLE
framework/media: Init the audio codec when data source calls open().

### DIFF
--- a/framework/src/media/Decoder.cpp
+++ b/framework/src/media/Decoder.cpp
@@ -23,17 +23,13 @@
 
 namespace media {
 
-Decoder::Decoder(unsigned short channels, unsigned int sampleRate)
-	: mChannels(channels)
+Decoder::Decoder(audio_type_t audio_type, unsigned short channels, unsigned int sampleRate)
+	: mAudioType(audio_type)
+	, mChannels(channels)
 	, mSampleRate(sampleRate)
 {
-#ifdef CONFIG_AUDIO_CODEC
-	memset(&mDecoder, 0, sizeof(audio_decoder_t));
-	if (audio_decoder_init(&mDecoder, CONFIG_AUDIO_CODEC_RINGBUFFER_SIZE) != AUDIO_DECODER_OK) {
-		meddbg("Error! audio_decoder_init failed!\n");
-	}
-#endif
 }
+
 
 Decoder::Decoder(const Decoder *source)
 {
@@ -49,6 +45,48 @@ Decoder::~Decoder()
 		meddbg("Error! audio_decoder_finish failed!\n");
 	}
 #endif
+}
+
+std::shared_ptr<Decoder> Decoder::create(audio_type_t audioType, unsigned short channels, unsigned int sampleRate)
+{
+#ifdef CONFIG_AUDIO_CODEC
+	medvdbg("Decoder::create(%d,%d,%d)\n", audioType, channels, sampleRate);
+	
+	std::shared_ptr<Decoder> instance(new Decoder(audioType, channels, sampleRate));
+	if (instance) {
+		if (instance->init()) {
+			return instance;
+		}
+	}
+
+	meddbg("Decoder::create(%d,%d,%d), init failed!\n", audioType, channels, sampleRate);
+	return nullptr;
+#endif
+	return nullptr;
+}
+
+bool Decoder::init(void)
+{
+#ifdef CONFIG_AUDIO_CODEC
+	memset(&mDecoder, 0, sizeof(audio_decoder_t));
+	if (audio_decoder_init(&mDecoder, CONFIG_AUDIO_CODEC_RINGBUFFER_SIZE) != AUDIO_DECODER_OK) {
+		meddbg("Error! audio_decoder_init failed!\n");
+		return false;
+	}
+
+	mDecoder.audio_type = mAudioType;
+	if (mDecoder.audio_type != AUDIO_TYPE_UNKNOWN) {
+		if (!mConfig(mDecoder.audio_type)) {
+			meddbg("Error! mConfig() failed!\n");
+			return false;
+		}
+	} else {
+		/*If the unknown audio type, will get audio type and config in the getFrame function*/
+	}
+
+	return true;
+#endif	
+	return false;
 }
 
 size_t Decoder::pushData(unsigned char *buf, size_t size)

--- a/framework/src/media/Decoder.h
+++ b/framework/src/media/Decoder.h
@@ -18,6 +18,7 @@
 
 #include <tinyara/config.h>
 #include <stdio.h>
+#include <memory>
 
 #ifdef CONFIG_AUDIO_CODEC
 #include "streaming/audio_decoder.h"
@@ -28,11 +29,13 @@ namespace media {
 class Decoder
 {
 public:
-	Decoder(unsigned short channels, unsigned int sampleRate);
+	Decoder(audio_type_t audio_type, unsigned short channels, unsigned int sampleRate);
 	Decoder(const Decoder *source);
 	~Decoder();
 
 public:
+	static std::shared_ptr<Decoder> create(audio_type_t audioType, unsigned short channels, unsigned int sampleRate);
+	bool init(void);
 	size_t pushData(unsigned char *buf, size_t size);
 	bool getFrame(unsigned char *buf, size_t *size, unsigned int *sampleRate, unsigned short *channels);
 	bool empty();
@@ -43,6 +46,7 @@ private:
 	//static int _configFunc(void *user_data, int audio_type, void *dec_ext);
 	bool mConfig(int audioType);
 	audio_decoder_t mDecoder;
+	audio_type_t mAudioType;
 	unsigned short mChannels;
 	unsigned int mSampleRate;
 #endif

--- a/framework/src/media/Encoder.h
+++ b/framework/src/media/Encoder.h
@@ -19,6 +19,7 @@
 #include <tinyara/config.h>
 #include <stdio.h>
 #include <media/MediaTypes.h>
+#include <memory>
 
 #ifdef CONFIG_AUDIO_CODEC
 #include "streaming/audio_encoder.h"
@@ -34,6 +35,8 @@ public:
 	~Encoder();
 
 public:
+	static std::shared_ptr<Encoder> create(audio_type_t audioType, unsigned short channels, unsigned int sampleRate);
+	bool init(void);
 	size_t pushData(unsigned char *buf, size_t size);
 	bool getFrame(unsigned char *buf, size_t *size);
 	bool empty();
@@ -43,6 +46,9 @@ private:
 	Encoder() {}
 #ifdef CONFIG_AUDIO_CODEC
 	audio_encoder_t mEncoder;
+	audio_type_t mAudioType;
+	unsigned short mChannels;
+	unsigned int mSampleRate;
 	signed short *inputBuf;
 	unsigned char *outputBuf;
 #endif

--- a/framework/src/media/FileInputDataSource.cpp
+++ b/framework/src/media/FileInputDataSource.cpp
@@ -78,9 +78,15 @@ bool FileInputDataSource::open()
 		switch (getAudioType()) {
 		case AUDIO_TYPE_MP3:
 		case AUDIO_TYPE_AAC:
-		case AUDIO_TYPE_OPUS:
-			setDecoder(std::make_shared<Decoder>(getChannels(), getSampleRate()));
+		case AUDIO_TYPE_OPUS: {
+			auto decoder = Decoder::create(getAudioType(), getChannels(), getSampleRate());
+			if (!decoder) {
+				meddbg("decoder is nullptr!\n");
+			    return false;
+			}
+			setDecoder(decoder);
 			break;
+		}
 		case AUDIO_TYPE_FLAC:
 			/* To be supported */
 			break;

--- a/framework/src/media/FileOutputDataSource.cpp
+++ b/framework/src/media/FileOutputDataSource.cpp
@@ -77,10 +77,15 @@ bool FileOutputDataSource::open()
 		setAudioType(utils::getAudioTypeFromPath(mDataPath));
 
 		switch (getAudioType()) {
-		case AUDIO_TYPE_OPUS:
-			setEncoder(std::make_shared<Encoder>(AUDIO_TYPE_OPUS, getChannels(), getSampleRate()));
+		case AUDIO_TYPE_OPUS: {
+			auto encoder = Encoder::create(AUDIO_TYPE_OPUS, getChannels(), getSampleRate());
+			if (!encoder) {
+				meddbg("encoder is nullptr!\n");
+			    return false;
+			}
+			setEncoder(encoder);
 			break;
-
+		}
 		default:
 			/* Don't set any encoder for unsupported formats */
 			break;

--- a/framework/src/media/streaming/audio_decoder.cpp
+++ b/framework/src/media/streaming/audio_decoder.cpp
@@ -387,21 +387,24 @@ static bool mp3_resync(rbstream_p fp, uint32_t match_header, ssize_t *inout_pos,
 }
 
 // Initialize the MP3 reader.
-bool mp3_init(rbstream_p mFp, ssize_t *offset, uint32_t *header)
+bool mp3_init(audio_decoder_p decoder, void *dec_ext)
 {
-	// Sync to the first valid frame.
-	bool success = mp3_resync(mFp, 0, offset, header);
-	RETURN_VAL_IF_FAIL((success == true), false);
+	decoder->dec_ext = calloc(1, sizeof(tPVMP3DecoderExternal));
+	RETURN_VAL_IF_FAIL((decoder->dec_ext != NULL), AUDIO_DECODER_ERROR);
 
-	// Policy: Pop out data when *offset updated!
-	rbs_seek_ext(mFp, *offset, SEEK_SET);
+	decoder->dec_mem = calloc(1, pvmp3_decoderMemRequirements());
+	RETURN_VAL_IF_FAIL((decoder->dec_mem != NULL), AUDIO_DECODER_ERROR);
 
-	size_t frame_size;
-	return _parse_header(*header, &frame_size);
+	*((tPVMP3DecoderExternal *) decoder->dec_ext) = *((tPVMP3DecoderExternal *) dec_ext);
+
+	pvmp3_resetDecoder(decoder->dec_mem);
+	pvmp3_InitDecoder((tPVMP3DecoderExternal *) decoder->dec_ext, decoder->dec_mem);
+
+	return true;
 }
 
 // Get the next valid MP3 frame.
-bool mp3_get_frame(rbstream_p mFp, ssize_t *offset, uint32_t fixed_header, void *buffer, uint32_t *size)
+bool mp3_get_frame(rbstream_p mFp, ssize_t *offset, uint32_t* fixed_header, void *buffer, uint32_t *size)
 {
 	size_t frame_size;
 
@@ -411,14 +414,14 @@ bool mp3_get_frame(rbstream_p mFp, ssize_t *offset, uint32_t fixed_header, void 
 
 		uint32_t header = _u32_at((const uint8_t *)buffer);
 
-		if ((header & MP3_FRAME_HEADER_MASK) == (fixed_header & MP3_FRAME_HEADER_MASK)
+		if ((header & MP3_FRAME_HEADER_MASK) == (*fixed_header & MP3_FRAME_HEADER_MASK)
 			&& _parse_header(header, &frame_size)) {
 			break;
 		}
 
 		// Lost sync.
 		ssize_t pos = *offset;
-		if (!mp3_resync(mFp, fixed_header, &pos, NULL /*out_header */)) {
+		if (!mp3_resync(mFp, *fixed_header, &pos, fixed_header)) {
 			// Unable to mp3_resync. Signalling end of stream.
 			return false;
 		}
@@ -548,14 +551,20 @@ static bool aac_resync(rbstream_p fp, ssize_t *inout_pos)
 }
 
 // Initialize the aac reader.
-bool aac_init(rbstream_p mFp, ssize_t *offset)
+bool aac_init(audio_decoder_p decoder, void *dec_ext)
 {
-	// Sync to the first valid frame.
-	bool success = aac_resync(mFp, offset);
-	RETURN_VAL_IF_FAIL((success == true), false);
+	decoder->dec_ext = calloc(1, sizeof(tPVMP4AudioDecoderExternal));
+	RETURN_VAL_IF_FAIL((decoder->dec_ext != NULL), AUDIO_DECODER_ERROR);
 
-	// Policy: Pop out data when *offset updated!
-	rbs_seek_ext(mFp, *offset, SEEK_SET);
+	decoder->dec_mem = calloc(1, PVMP4AudioDecoderGetMemRequirements());
+	RETURN_VAL_IF_FAIL((decoder->dec_mem != NULL), AUDIO_DECODER_ERROR);
+
+	*((tPVMP4AudioDecoderExternal *) decoder->dec_ext) = *((tPVMP4AudioDecoderExternal *) dec_ext);
+
+	PVMP4AudioDecoderResetBuffer(decoder->dec_mem);
+	Int err = PVMP4AudioDecoderInitLibrary((tPVMP4AudioDecoderExternal *) decoder->dec_ext, decoder->dec_mem);
+	RETURN_VAL_IF_FAIL((err == MP4AUDEC_SUCCESS), AUDIO_DECODER_ERROR);
+
 	return true;
 }
 
@@ -698,14 +707,20 @@ static bool opus_resync(rbstream_p fp, ssize_t *inout_pos)
 }
 
 // Initialize the Opus reader.
-bool opus_init(rbstream_p mFp, ssize_t *offset)
+bool opus_init(audio_decoder_p decoder, void *dec_ext)
 {
-	// Sync to the first valid frame.
-	bool success = opus_resync(mFp, offset);
-	RETURN_VAL_IF_FAIL((success == true), false);
+	decoder->dec_ext = calloc(1, sizeof(opus_dec_external_t));
+	RETURN_VAL_IF_FAIL((decoder->dec_ext != NULL), AUDIO_DECODER_ERROR);
 
-	// Policy: Pop out data when *offset updated!
-	rbs_seek_ext(mFp, *offset, SEEK_SET);
+	decoder->dec_mem = calloc(1, opus_decoderMemRequirements());
+	RETURN_VAL_IF_FAIL((decoder->dec_mem != NULL), AUDIO_DECODER_ERROR);
+
+	*((opus_dec_external_t *) decoder->dec_ext) = *((opus_dec_external_t *) dec_ext);
+
+	opus_resetDecoder(decoder->dec_mem);
+	int err = opus_initDecoder((opus_dec_external_t *) decoder->dec_ext, decoder->dec_mem);
+	RETURN_VAL_IF_FAIL((err == OPUS_OK), AUDIO_DECODER_ERROR);
+
 	return true;
 }
 
@@ -782,7 +797,7 @@ bool _get_frame(audio_decoder_p decoder)
 	switch (decoder->audio_type) {
 	case AUDIO_TYPE_MP3: {
 		tPVMP3DecoderExternal *mp3_ext = (tPVMP3DecoderExternal *) decoder->dec_ext;
-		return mp3_get_frame(decoder->rbsp, &priv->mCurrentPos, priv->mFixedHeader, (void *)mp3_ext->pInputBuffer, (uint32_t *)&mp3_ext->inputBufferCurrentLength);
+		return mp3_get_frame(decoder->rbsp, &priv->mCurrentPos, &priv->mFixedHeader, (void *)mp3_ext->pInputBuffer, (uint32_t *)&mp3_ext->inputBufferCurrentLength);
 	}
 
 	case AUDIO_TYPE_AAC: {
@@ -815,56 +830,20 @@ int _init_decoder(audio_decoder_p decoder, void *dec_ext)
 
 	switch (decoder->audio_type) {
 	case AUDIO_TYPE_MP3: {
-		decoder->dec_ext = calloc(1, sizeof(tPVMP3DecoderExternal));
-		RETURN_VAL_IF_FAIL((decoder->dec_ext != NULL), AUDIO_DECODER_ERROR);
-
-		decoder->dec_mem = calloc(1, pvmp3_decoderMemRequirements());
-		RETURN_VAL_IF_FAIL((decoder->dec_mem != NULL), AUDIO_DECODER_ERROR);
-
-		*((tPVMP3DecoderExternal *) decoder->dec_ext) = *((tPVMP3DecoderExternal *) dec_ext);
-
-		pvmp3_resetDecoder(decoder->dec_mem);
-		pvmp3_InitDecoder((tPVMP3DecoderExternal *) decoder->dec_ext, decoder->dec_mem);
-
-		bool ret = mp3_init(decoder->rbsp, &priv->mCurrentPos, &priv->mFixedHeader);
+		bool ret = mp3_init(decoder, dec_ext);
 		RETURN_VAL_IF_FAIL((ret == true), AUDIO_DECODER_ERROR);
 		break;
 	}
 
 	case AUDIO_TYPE_AAC: {
-		decoder->dec_ext = calloc(1, sizeof(tPVMP4AudioDecoderExternal));
-		RETURN_VAL_IF_FAIL((decoder->dec_ext != NULL), AUDIO_DECODER_ERROR);
-
-		decoder->dec_mem = calloc(1, PVMP4AudioDecoderGetMemRequirements());
-		RETURN_VAL_IF_FAIL((decoder->dec_mem != NULL), AUDIO_DECODER_ERROR);
-
-		*((tPVMP4AudioDecoderExternal *) decoder->dec_ext) = *((tPVMP4AudioDecoderExternal *) dec_ext);
-
-		PVMP4AudioDecoderResetBuffer(decoder->dec_mem);
-		Int err = PVMP4AudioDecoderInitLibrary((tPVMP4AudioDecoderExternal *) decoder->dec_ext, decoder->dec_mem);
-		RETURN_VAL_IF_FAIL((err == MP4AUDEC_SUCCESS), AUDIO_DECODER_ERROR);
-
-		bool ret = aac_init(decoder->rbsp, &priv->mCurrentPos);
+		bool ret = aac_init(decoder, dec_ext);
 		RETURN_VAL_IF_FAIL((ret == true), AUDIO_DECODER_ERROR);
 		break;
 	}
 
 #ifdef CONFIG_CODEC_LIBOPUS
 	case AUDIO_TYPE_OPUS: {
-		decoder->dec_ext = calloc(1, sizeof(opus_dec_external_t));
-		RETURN_VAL_IF_FAIL((decoder->dec_ext != NULL), AUDIO_DECODER_ERROR);
-
-		decoder->dec_mem = calloc(1, opus_decoderMemRequirements());
-		RETURN_VAL_IF_FAIL((decoder->dec_mem != NULL), AUDIO_DECODER_ERROR);
-
-		*((opus_dec_external_t *) decoder->dec_ext) = *((opus_dec_external_t *) dec_ext);
-
-		opus_resetDecoder(decoder->dec_mem);
-		int err = opus_initDecoder((opus_dec_external_t *) decoder->dec_ext, decoder->dec_mem);
-		RETURN_VAL_IF_FAIL((err == OPUS_OK), AUDIO_DECODER_ERROR);
-
-		priv->mCurrentPos = 0;
-		bool ret = opus_init(decoder->rbsp, &priv->mCurrentPos);
+		bool ret = opus_init(decoder, dec_ext);
 		RETURN_VAL_IF_FAIL((ret == true), AUDIO_DECODER_ERROR);
 		break;
 	}


### PR DESCRIPTION
1. Fix the mConfig return false issue.  
2. Add Decoder::create()/ Encoder::create() interface, and call it in data source open() fucntion.
@Taejun-Kwon 