### PR TITLE
external/libtuv: Add QUEUE_MOVE() API and modify uv__async_event() API

### DIFF
--- a/external/include/libtuv/queue.h
+++ b/external/include/libtuv/queue.h
@@ -64,6 +64,17 @@ typedef void *QUEUE[2];
   }                                                                           \
   while (0)
 
+#define QUEUE_MOVE(h, n)                                                      \
+  do {                                                                        \
+    if (QUEUE_EMPTY(h))                                                       \
+      QUEUE_INIT(n);                                                          \
+    else {                                                                    \
+      QUEUE* q_ptr = QUEUE_HEAD(h);                                           \
+      QUEUE_SPLIT(h, q_ptr, n);                                               \
+    }                                                                         \
+  }                                                                           \
+  while (0)
+
 #define QUEUE_INSERT_HEAD(h, q)                                               \
   do {                                                                        \
     QUEUE_NEXT(q) = QUEUE_NEXT(h);                                            \

--- a/external/libtuv/source/uv_async.c
+++ b/external/libtuv/source/uv_async.c
@@ -45,11 +45,16 @@
 
 static void uv__async_event(uv_loop_t *loop, struct uv__async *w, unsigned int nevents)
 {
+	QUEUE queue;
 	QUEUE *q;
 	uv_async_t *h;
 
-	QUEUE_FOREACH(q, &loop->async_handles) {
+	QUEUE_MOVE(&loop->async_handles, &queue);
+	while (!QUEUE_EMPTY(&queue)) {
+		q = QUEUE_HEAD(&queue);
 		h = QUEUE_DATA(q, uv_async_t, queue);
+		QUEUE_REMOVE(q);
+		QUEUE_INSERT_TAIL(&loop->async_handles, q);
 
 		if (h->pending == 0) {
 			continue;


### PR DESCRIPTION
These source codes are got from libtuv github, https://github.com/Samsung/libtuv

1. Add QUEUE_MOVE() API at queue.h
2. Modify uv__async_event() API
In some cases, QUEUE_FOREACH() casues an infinite loop.
Therefore, QUEUE_FOREACH() is changed into while (!QUEUE_EMPTY())