### PR TITLE
framework/media: Modify audio_decoder_init_decoder function name.

### DIFF
--- a/framework/include/media/InputDataSource.h
+++ b/framework/include/media/InputDataSource.h
@@ -135,7 +135,7 @@ protected:
 protected:
 	void setAudioType(audio_type_t audioType);
 	audio_type_t getAudioType();
-	void registerDecoder(audio_type_t audioType, unsigned int channels, unsigned int sampleRate);
+	bool registerDecoder(audio_type_t audioType, unsigned int channels, unsigned int sampleRate);
 	void unregisterDecoder();
 	size_t getDecodeFrames(unsigned char *buf, size_t *size);
 

--- a/framework/src/media/Decoder.cpp
+++ b/framework/src/media/Decoder.cpp
@@ -173,8 +173,8 @@ bool Decoder::mConfig(int audioType)
 		mp3_ext.pOutputBuffer = outputBuf;
 		mp3_ext.outputFrameSize = sizeof(outputBuf) / sizeof(int16_t);
 
-		if (audio_decoder_init_decoder(&mDecoder, audioType, &mp3_ext) != AUDIO_DECODER_OK) {
-			meddbg("Error! audio_decoder_init_decoder failed!\n");
+		if (audio_decoder_config_decoder(&mDecoder, audioType, &mp3_ext) != AUDIO_DECODER_OK) {
+			meddbg("Error! audio_decoder_config_decoder failed!\n");
 			return false;
 		}
 		break;
@@ -188,8 +188,8 @@ bool Decoder::mConfig(int audioType)
 		aac_ext.pOutputBuffer = outputBuf;
 		aac_ext.aacPlusEnabled = 1;
 
-		if (audio_decoder_init_decoder(&mDecoder, audioType, &aac_ext) != AUDIO_DECODER_OK) {
-			meddbg("Error! audio_decoder_init_decoder failed!\n");
+		if (audio_decoder_config_decoder(&mDecoder, audioType, &aac_ext) != AUDIO_DECODER_OK) {
+			meddbg("Error! audio_decoder_config_decoder failed!\n");
 			return false;
 		}
 		break;
@@ -205,8 +205,8 @@ bool Decoder::mConfig(int audioType)
 		opus_ext.desiredSampleRate = mSampleRate;
 		opus_ext.desiredChannels = mChannels;
 
-		if (audio_decoder_init_decoder(&mDecoder, audioType, &opus_ext) != AUDIO_DECODER_OK) {
-			meddbg("Error! audio_decoder_init_decoder failed!\n");
+		if (audio_decoder_config_decoder(&mDecoder, audioType, &opus_ext) != AUDIO_DECODER_OK) {
+			meddbg("Error! audio_decoder_config_decoder failed!\n");
 			return false;
 		}
 		break;

--- a/framework/src/media/Decoder.cpp
+++ b/framework/src/media/Decoder.cpp
@@ -23,17 +23,13 @@
 
 namespace media {
 
-Decoder::Decoder(unsigned short channels, unsigned int sampleRate)
-	: mChannels(channels)
+Decoder::Decoder(audio_type_t audioType, unsigned short channels, unsigned int sampleRate)
+	: mAudioType(audioType)
+	, mChannels(channels)
 	, mSampleRate(sampleRate)
 {
-#ifdef CONFIG_AUDIO_CODEC
-	memset(&mDecoder, 0, sizeof(audio_decoder_t));
-	if (audio_decoder_init(&mDecoder, CONFIG_AUDIO_CODEC_RINGBUFFER_SIZE) != AUDIO_DECODER_OK) {
-		meddbg("Error! audio_decoder_init failed!\n");
-	}
-#endif
 }
+
 
 Decoder::Decoder(const Decoder *source)
 {
@@ -49,6 +45,48 @@ Decoder::~Decoder()
 		meddbg("Error! audio_decoder_finish failed!\n");
 	}
 #endif
+}
+
+std::shared_ptr<Decoder> Decoder::create(audio_type_t audioType, unsigned short channels, unsigned int sampleRate)
+{
+#ifdef CONFIG_AUDIO_CODEC
+	medvdbg("(%d,%d,%d)\n", audioType, channels, sampleRate);
+	
+	std::shared_ptr<Decoder> instance(new Decoder(audioType, channels, sampleRate));
+	if (instance) {
+		if (instance->init()) {
+			return instance;
+		}
+	}
+
+	meddbg("Error! (%d,%d,%d), failed!\n", audioType, channels, sampleRate);
+	return nullptr;
+#endif
+	return nullptr;
+}
+
+bool Decoder::init(void)
+{
+#ifdef CONFIG_AUDIO_CODEC
+	memset(&mDecoder, 0, sizeof(audio_decoder_t));
+	if (audio_decoder_init(&mDecoder, CONFIG_AUDIO_CODEC_RINGBUFFER_SIZE) != AUDIO_DECODER_OK) {
+		meddbg("Error! audio_decoder_init failed!\n");
+		return false;
+	}
+
+	mDecoder.audio_type = mAudioType;
+	if (mDecoder.audio_type != AUDIO_TYPE_UNKNOWN) {
+		if (!mConfig(mDecoder.audio_type)) {
+			meddbg("Error! mConfig() failed!\n");
+			return false;
+		}
+	} else {
+		/*If the unknown audio type, will get audio type and config in the getFrame function*/
+	}
+
+	return true;
+#endif	
+	return false;
 }
 
 size_t Decoder::pushData(unsigned char *buf, size_t size)

--- a/framework/src/media/Decoder.h
+++ b/framework/src/media/Decoder.h
@@ -18,6 +18,7 @@
 
 #include <tinyara/config.h>
 #include <stdio.h>
+#include <memory>
 
 #ifdef CONFIG_AUDIO_CODEC
 #include "streaming/audio_decoder.h"
@@ -28,11 +29,13 @@ namespace media {
 class Decoder
 {
 public:
-	Decoder(unsigned short channels, unsigned int sampleRate);
+	Decoder(audio_type_t audioType, unsigned short channels, unsigned int sampleRate);
 	Decoder(const Decoder *source);
 	~Decoder();
 
 public:
+	static std::shared_ptr<Decoder> create(audio_type_t audioType, unsigned short channels, unsigned int sampleRate);
+	bool init(void);
 	size_t pushData(unsigned char *buf, size_t size);
 	bool getFrame(unsigned char *buf, size_t *size, unsigned int *sampleRate, unsigned short *channels);
 	bool empty();
@@ -43,6 +46,7 @@ private:
 	//static int _configFunc(void *user_data, int audio_type, void *dec_ext);
 	bool mConfig(int audioType);
 	audio_decoder_t mDecoder;
+	audio_type_t mAudioType;
 	unsigned short mChannels;
 	unsigned int mSampleRate;
 #endif

--- a/framework/src/media/FileInputDataSource.cpp
+++ b/framework/src/media/FileInputDataSource.cpp
@@ -73,7 +73,10 @@ bool FileInputDataSource::open()
 
 	if (!mFp) {
 		setAudioType(utils::getAudioTypeFromPath(mDataPath));
-		registerDecoder(getAudioType(), getChannels(), getSampleRate());
+		if (!registerDecoder(getAudioType(), getChannels(), getSampleRate())) {
+			meddbg("registerDecoder failed!\n");
+			return false;
+		}
 
 		mFp = fopen(mDataPath.c_str(), "rb");
 		if (mFp) {

--- a/framework/src/media/InputDataSource.cpp
+++ b/framework/src/media/InputDataSource.cpp
@@ -53,14 +53,14 @@ InputDataSource::~InputDataSource()
 {
 }
 
-void InputDataSource::registerDecoder(audio_type_t audioType, unsigned int channels, unsigned int sampleRate)
+bool InputDataSource::registerDecoder(audio_type_t audioType, unsigned int channels, unsigned int sampleRate)
 {
 	std::shared_ptr<Decoder> decoder = nullptr;
 	switch (audioType) {
 	case AUDIO_TYPE_MP3:
 	case AUDIO_TYPE_AAC:
 	case AUDIO_TYPE_OPUS:
-		decoder = std::make_shared<Decoder>(channels, sampleRate);
+		decoder = Decoder::create(getAudioType(), getChannels(), getSampleRate());
 		break;
 	case AUDIO_TYPE_FLAC:
 		/* To be supported */
@@ -68,7 +68,7 @@ void InputDataSource::registerDecoder(audio_type_t audioType, unsigned int chann
 		break;
 	case AUDIO_TYPE_PCM:
 		medvdbg("AUDIO_TYPE_PCM does not need the decoder\n");
-		break;
+		return true;
 	default:
 		/* Don't set any decoder for unsupported formats */
 		meddbg("Decoder is not set\n");
@@ -76,6 +76,12 @@ void InputDataSource::registerDecoder(audio_type_t audioType, unsigned int chann
 	}
 
 	mDecoder = decoder;
+	if (!mDecoder) {
+		meddbg("mDecoder is nullptr!\n");
+	    return false;
+	}
+	
+	return true;
 }
 
 void InputDataSource::unregisterDecoder()

--- a/framework/src/media/streaming/audio_decoder.cpp
+++ b/framework/src/media/streaming/audio_decoder.cpp
@@ -992,7 +992,7 @@ int audio_decoder_get_audio_type(audio_decoder_p decoder)
 	return decoder->audio_type;
 }
 
-int audio_decoder_init_decoder(audio_decoder_p decoder, int audio_type, void *dec_ext)
+int audio_decoder_config_decoder(audio_decoder_p decoder, int audio_type, void *dec_ext)
 {
 	assert(decoder != NULL);
 

--- a/framework/src/media/streaming/audio_decoder.cpp
+++ b/framework/src/media/streaming/audio_decoder.cpp
@@ -387,21 +387,24 @@ static bool mp3_resync(rbstream_p fp, uint32_t match_header, ssize_t *inout_pos,
 }
 
 // Initialize the MP3 reader.
-bool mp3_init(rbstream_p mFp, ssize_t *offset, uint32_t *header)
+int mp3_init(audio_decoder_p decoder, void *dec_ext)
 {
-	// Sync to the first valid frame.
-	bool success = mp3_resync(mFp, 0, offset, header);
-	RETURN_VAL_IF_FAIL((success == true), false);
+	decoder->dec_ext = calloc(1, sizeof(tPVMP3DecoderExternal));
+	RETURN_VAL_IF_FAIL((decoder->dec_ext != NULL), AUDIO_DECODER_ERROR);
 
-	// Policy: Pop out data when *offset updated!
-	rbs_seek_ext(mFp, *offset, SEEK_SET);
+	decoder->dec_mem = calloc(1, pvmp3_decoderMemRequirements());
+	RETURN_VAL_IF_FAIL((decoder->dec_mem != NULL), AUDIO_DECODER_ERROR);
 
-	size_t frame_size;
-	return _parse_header(*header, &frame_size);
+	*((tPVMP3DecoderExternal *) decoder->dec_ext) = *((tPVMP3DecoderExternal *) dec_ext);
+
+	pvmp3_resetDecoder(decoder->dec_mem);
+	pvmp3_InitDecoder((tPVMP3DecoderExternal *) decoder->dec_ext, decoder->dec_mem);
+
+	return AUDIO_DECODER_OK;
 }
 
 // Get the next valid MP3 frame.
-bool mp3_get_frame(rbstream_p mFp, ssize_t *offset, uint32_t fixed_header, void *buffer, uint32_t *size)
+bool mp3_get_frame(rbstream_p mFp, ssize_t *offset, uint32_t *fixed_header, void *buffer, uint32_t *size)
 {
 	size_t frame_size;
 
@@ -411,14 +414,14 @@ bool mp3_get_frame(rbstream_p mFp, ssize_t *offset, uint32_t fixed_header, void 
 
 		uint32_t header = _u32_at((const uint8_t *)buffer);
 
-		if ((header & MP3_FRAME_HEADER_MASK) == (fixed_header & MP3_FRAME_HEADER_MASK)
+		if ((header & MP3_FRAME_HEADER_MASK) == (*fixed_header & MP3_FRAME_HEADER_MASK)
 			&& _parse_header(header, &frame_size)) {
 			break;
 		}
 
 		// Lost sync.
 		ssize_t pos = *offset;
-		if (!mp3_resync(mFp, fixed_header, &pos, NULL /*out_header */)) {
+		if (!mp3_resync(mFp, *fixed_header, &pos, fixed_header)) {
 			// Unable to mp3_resync. Signalling end of stream.
 			return false;
 		}
@@ -548,15 +551,21 @@ static bool aac_resync(rbstream_p fp, ssize_t *inout_pos)
 }
 
 // Initialize the aac reader.
-bool aac_init(rbstream_p mFp, ssize_t *offset)
+int aac_init(audio_decoder_p decoder, void *dec_ext)
 {
-	// Sync to the first valid frame.
-	bool success = aac_resync(mFp, offset);
-	RETURN_VAL_IF_FAIL((success == true), false);
+	decoder->dec_ext = calloc(1, sizeof(tPVMP4AudioDecoderExternal));
+	RETURN_VAL_IF_FAIL((decoder->dec_ext != NULL), AUDIO_DECODER_ERROR);
 
-	// Policy: Pop out data when *offset updated!
-	rbs_seek_ext(mFp, *offset, SEEK_SET);
-	return true;
+	decoder->dec_mem = calloc(1, PVMP4AudioDecoderGetMemRequirements());
+	RETURN_VAL_IF_FAIL((decoder->dec_mem != NULL), AUDIO_DECODER_ERROR);
+
+	*((tPVMP4AudioDecoderExternal *) decoder->dec_ext) = *((tPVMP4AudioDecoderExternal *) dec_ext);
+
+	PVMP4AudioDecoderResetBuffer(decoder->dec_mem);
+	Int err = PVMP4AudioDecoderInitLibrary((tPVMP4AudioDecoderExternal *) decoder->dec_ext, decoder->dec_mem);
+	RETURN_VAL_IF_FAIL((err == MP4AUDEC_SUCCESS), AUDIO_DECODER_ERROR);
+
+	return AUDIO_DECODER_OK;
 }
 
 // Get the next valid aac frame.
@@ -698,15 +707,21 @@ static bool opus_resync(rbstream_p fp, ssize_t *inout_pos)
 }
 
 // Initialize the Opus reader.
-bool opus_init(rbstream_p mFp, ssize_t *offset)
+int opus_init(audio_decoder_p decoder, void *dec_ext)
 {
-	// Sync to the first valid frame.
-	bool success = opus_resync(mFp, offset);
-	RETURN_VAL_IF_FAIL((success == true), false);
+	decoder->dec_ext = calloc(1, sizeof(opus_dec_external_t));
+	RETURN_VAL_IF_FAIL((decoder->dec_ext != NULL), AUDIO_DECODER_ERROR);
 
-	// Policy: Pop out data when *offset updated!
-	rbs_seek_ext(mFp, *offset, SEEK_SET);
-	return true;
+	decoder->dec_mem = calloc(1, opus_decoderMemRequirements());
+	RETURN_VAL_IF_FAIL((decoder->dec_mem != NULL), AUDIO_DECODER_ERROR);
+
+	*((opus_dec_external_t *) decoder->dec_ext) = *((opus_dec_external_t *) dec_ext);
+
+	opus_resetDecoder(decoder->dec_mem);
+	int err = opus_initDecoder((opus_dec_external_t *) decoder->dec_ext, decoder->dec_mem);
+	RETURN_VAL_IF_FAIL((err == OPUS_OK), AUDIO_DECODER_ERROR);
+
+	return AUDIO_DECODER_OK;
 }
 
 // Get the next valid Opus frame.
@@ -782,7 +797,7 @@ bool _get_frame(audio_decoder_p decoder)
 	switch (decoder->audio_type) {
 	case AUDIO_TYPE_MP3: {
 		tPVMP3DecoderExternal *mp3_ext = (tPVMP3DecoderExternal *) decoder->dec_ext;
-		return mp3_get_frame(decoder->rbsp, &priv->mCurrentPos, priv->mFixedHeader, (void *)mp3_ext->pInputBuffer, (uint32_t *)&mp3_ext->inputBufferCurrentLength);
+		return mp3_get_frame(decoder->rbsp, &priv->mCurrentPos, &priv->mFixedHeader, (void *)mp3_ext->pInputBuffer, (uint32_t *)&mp3_ext->inputBufferCurrentLength);
 	}
 
 	case AUDIO_TYPE_AAC: {
@@ -815,57 +830,21 @@ int _init_decoder(audio_decoder_p decoder, void *dec_ext)
 
 	switch (decoder->audio_type) {
 	case AUDIO_TYPE_MP3: {
-		decoder->dec_ext = calloc(1, sizeof(tPVMP3DecoderExternal));
-		RETURN_VAL_IF_FAIL((decoder->dec_ext != NULL), AUDIO_DECODER_ERROR);
-
-		decoder->dec_mem = calloc(1, pvmp3_decoderMemRequirements());
-		RETURN_VAL_IF_FAIL((decoder->dec_mem != NULL), AUDIO_DECODER_ERROR);
-
-		*((tPVMP3DecoderExternal *) decoder->dec_ext) = *((tPVMP3DecoderExternal *) dec_ext);
-
-		pvmp3_resetDecoder(decoder->dec_mem);
-		pvmp3_InitDecoder((tPVMP3DecoderExternal *) decoder->dec_ext, decoder->dec_mem);
-
-		bool ret = mp3_init(decoder->rbsp, &priv->mCurrentPos, &priv->mFixedHeader);
-		RETURN_VAL_IF_FAIL((ret == true), AUDIO_DECODER_ERROR);
+		int ret = mp3_init(decoder, dec_ext);
+		RETURN_VAL_IF_FAIL((ret == AUDIO_DECODER_OK), ret);
 		break;
 	}
 
 	case AUDIO_TYPE_AAC: {
-		decoder->dec_ext = calloc(1, sizeof(tPVMP4AudioDecoderExternal));
-		RETURN_VAL_IF_FAIL((decoder->dec_ext != NULL), AUDIO_DECODER_ERROR);
-
-		decoder->dec_mem = calloc(1, PVMP4AudioDecoderGetMemRequirements());
-		RETURN_VAL_IF_FAIL((decoder->dec_mem != NULL), AUDIO_DECODER_ERROR);
-
-		*((tPVMP4AudioDecoderExternal *) decoder->dec_ext) = *((tPVMP4AudioDecoderExternal *) dec_ext);
-
-		PVMP4AudioDecoderResetBuffer(decoder->dec_mem);
-		Int err = PVMP4AudioDecoderInitLibrary((tPVMP4AudioDecoderExternal *) decoder->dec_ext, decoder->dec_mem);
-		RETURN_VAL_IF_FAIL((err == MP4AUDEC_SUCCESS), AUDIO_DECODER_ERROR);
-
-		bool ret = aac_init(decoder->rbsp, &priv->mCurrentPos);
-		RETURN_VAL_IF_FAIL((ret == true), AUDIO_DECODER_ERROR);
+		int ret = aac_init(decoder, dec_ext);
+		RETURN_VAL_IF_FAIL((ret == AUDIO_DECODER_OK), ret);
 		break;
 	}
 
 #ifdef CONFIG_CODEC_LIBOPUS
 	case AUDIO_TYPE_OPUS: {
-		decoder->dec_ext = calloc(1, sizeof(opus_dec_external_t));
-		RETURN_VAL_IF_FAIL((decoder->dec_ext != NULL), AUDIO_DECODER_ERROR);
-
-		decoder->dec_mem = calloc(1, opus_decoderMemRequirements());
-		RETURN_VAL_IF_FAIL((decoder->dec_mem != NULL), AUDIO_DECODER_ERROR);
-
-		*((opus_dec_external_t *) decoder->dec_ext) = *((opus_dec_external_t *) dec_ext);
-
-		opus_resetDecoder(decoder->dec_mem);
-		int err = opus_initDecoder((opus_dec_external_t *) decoder->dec_ext, decoder->dec_mem);
-		RETURN_VAL_IF_FAIL((err == OPUS_OK), AUDIO_DECODER_ERROR);
-
-		priv->mCurrentPos = 0;
-		bool ret = opus_init(decoder->rbsp, &priv->mCurrentPos);
-		RETURN_VAL_IF_FAIL((ret == true), AUDIO_DECODER_ERROR);
+		int ret = opus_init(decoder, dec_ext);
+		RETURN_VAL_IF_FAIL((ret == AUDIO_DECODER_OK), ret);
 		break;
 	}
 #endif

--- a/framework/src/media/streaming/audio_decoder.h
+++ b/framework/src/media/streaming/audio_decoder.h
@@ -147,7 +147,7 @@ int audio_decoder_get_audio_type(audio_decoder_p decoder);
  * @return 0 on success, -1 on failure.
  * @see audio_decoder_get_audio_type()
  */
-int audio_decoder_init_decoder(audio_decoder_p decoder, int audio_type, void *dec_ext);
+int audio_decoder_config_decoder(audio_decoder_p decoder, int audio_type, void *dec_ext);
 
 /**
  * @brief  Get sample frames in 16bit-PCM format.


### PR DESCRIPTION
@Taejun-Kwon 
Issue: In decoder, api name is hard to understand, audio_decoder_init_decoder & audio_decoder_init
Solution: modify audio_decoder_init_decoder to audio_decoder_cofig_decoder, it is only called in mConfig().