### PR TITLE
framework/media: Modify audio_decoder_init_decoder function name.

### DIFF
--- a/framework/src/media/Decoder.cpp
+++ b/framework/src/media/Decoder.cpp
@@ -135,8 +135,8 @@ bool Decoder::mConfig(int audioType)
 		mp3_ext.pOutputBuffer = outputBuf;
 		mp3_ext.outputFrameSize = sizeof(outputBuf) / sizeof(int16_t);
 
-		if (audio_decoder_init_decoder(&mDecoder, audioType, &mp3_ext) != AUDIO_DECODER_OK) {
-			meddbg("Error! audio_decoder_init_decoder failed!\n");
+		if (audio_decoder_configure(&mDecoder, audioType, &mp3_ext) != AUDIO_DECODER_OK) {
+			meddbg("Error! audio_decoder_configure failed!\n");
 			return false;
 		}
 		break;
@@ -150,8 +150,8 @@ bool Decoder::mConfig(int audioType)
 		aac_ext.pOutputBuffer = outputBuf;
 		aac_ext.aacPlusEnabled = 1;
 
-		if (audio_decoder_init_decoder(&mDecoder, audioType, &aac_ext) != AUDIO_DECODER_OK) {
-			meddbg("Error! audio_decoder_init_decoder failed!\n");
+		if (audio_decoder_configure(&mDecoder, audioType, &aac_ext) != AUDIO_DECODER_OK) {
+			meddbg("Error! audio_decoder_configure failed!\n");
 			return false;
 		}
 		break;
@@ -167,8 +167,8 @@ bool Decoder::mConfig(int audioType)
 		opus_ext.desiredSampleRate = mSampleRate;
 		opus_ext.desiredChannels = mChannels;
 
-		if (audio_decoder_init_decoder(&mDecoder, audioType, &opus_ext) != AUDIO_DECODER_OK) {
-			meddbg("Error! audio_decoder_init_decoder failed!\n");
+		if (audio_decoder_configure(&mDecoder, audioType, &opus_ext) != AUDIO_DECODER_OK) {
+			meddbg("Error! audio_decoder_configure failed!\n");
 			return false;
 		}
 		break;

--- a/framework/src/media/streaming/audio_decoder.cpp
+++ b/framework/src/media/streaming/audio_decoder.cpp
@@ -1013,7 +1013,7 @@ int audio_decoder_get_audio_type(audio_decoder_p decoder)
 	return decoder->audio_type;
 }
 
-int audio_decoder_init_decoder(audio_decoder_p decoder, int audio_type, void *dec_ext)
+int audio_decoder_configure(audio_decoder_p decoder, int audio_type, void *dec_ext)
 {
 	assert(decoder != NULL);
 

--- a/framework/src/media/streaming/audio_decoder.h
+++ b/framework/src/media/streaming/audio_decoder.h
@@ -147,7 +147,7 @@ int audio_decoder_get_audio_type(audio_decoder_p decoder);
  * @return 0 on success, -1 on failure.
  * @see audio_decoder_get_audio_type()
  */
-int audio_decoder_init_decoder(audio_decoder_p decoder, int audio_type, void *dec_ext);
+int audio_decoder_configure(audio_decoder_p decoder, int audio_type, void *dec_ext);
 
 /**
  * @brief  Get sample frames in 16bit-PCM format.


### PR DESCRIPTION
@Taejun-Kwon
 Issue: In decoder, api name is hard to understand, audio_decoder_init_decoder & audio_decoder_init
 Solution: modify audio_decoder_init_decoder to audio_decoder_cofig_decoder.