### PR TITLE
iotjs: copy the IoT.js static libraries to the external iotjs folder

### DIFF
--- a/external/iotjs/config/tizenrt/Makefile
+++ b/external/iotjs/config/tizenrt/Makefile
@@ -35,7 +35,7 @@ build:
 	$(Q) python $(IOTJS_ROOT_DIR)/tools/build.py --target-arch=$(CONFIG_ARCH) --target-os=tizenrt \
 	--sysroot=$(TOPDIR) --target-board=$(CONFIG_ARCH_BOARD) --jerry-heaplimit=$(CONFIG_IOTJS_JERRY_HEAP) \
 	--buildtype=$(IOTJS_BUILDTYPE) --no-init-submodule $(IOTJS_BUILD_OPTION)
-	$(Q) cp $(IOTJS_LIB_DIR)/*.a $(IOTJS_ROOT_DIR)
+	$(Q) cp $(IOTJS_LIB_DIR)/*.a $(TOPDIR)/$(EXTDIR)/iotjs
 
 depend:
 


### PR DESCRIPTION
There is a build error if a custom IoT.js is used by environment variables (`IOTJS_ROOT_DIR`).

**Commands:**
```sh
$ cd <path-to-tizenrt>/os
$ tools/configure.sh artik053/iotjs
$
$ export IOTJS_ROOT_DIR=/home/.../path/to/iotjs
$ export IOTJS_BUILD_OPTION='--profile=test/profiles/tizenrt.profile'
$
$ make
```
**Output:**

```sh
make[1]: Leaving directory '/home/.../TizenRT/framework'
make: *** No rule to make target '../external/iotjs/libhttpparser.a', needed by '../build/output/libraries/libhttpparser.a'.  Stop.
```

**Reason:**   

The Makefile of IoT.js (in external/iotjs/config/tizenrt/) copies all the created iotjs static libraries from the `${IOTJS_ROOT_DIR}/build/arm-tizenrt/libs` folder to the `${IOTJS_ROOT_DIR}`. After that, [LibTargets.mk (line 225)](https://github.com/Samsung/TizenRT/blob/master/os/LibTargets.mk#L225) would like to install the static libraries from the TizenRT's own IoT.js folder (**external/iotjs**) and not from the `${IOTJS_ROOT_DIR}` folder.

This patch modifies the Makefile to copy the iotjs related static libraries always into the TizenRT's own iotjs folder. In this case the `LibTargets.mk` can find the iotjs libraries for the TizenRT build.
