### PR TITLE
testcase/systemio: make systemio sub-tests independent

### DIFF
--- a/apps/examples/testcase/ta_tc/systemio/itc/Make.defs
+++ b/apps/examples/testcase/ta_tc/systemio/itc/Make.defs
@@ -52,7 +52,27 @@
 ############################################################################
 
 ifeq ($(CONFIG_EXAMPLES_TESTCASE_SYSTEMIO_ITC),y)
-CSRCS += itc_sysio_main.c itc_uart.c itc_spi.c itc_i2c.c itc_pwm.c itc_gpio.c
+CSRCS += itc_sysio_main.c 
+
+ifeq ($(CONFIG_SYSIO_ITC_UART),y)
+CSRCS += itc_uart.c 
+endif
+
+ifeq ($(CONFIG_SYSIO_ITC_SPI),y)
+CSRCS += itc_spi.c 
+endif
+
+ifeq ($(CONFIG_SYSIO_ITC_I2C),y)
+CSRCS += itc_i2c.c 
+endif
+
+ifeq ($(CONFIG_SYSIO_ITC_PWM),y)
+CSRCS += itc_pwm.c 
+endif
+
+ifeq ($(CONFIG_SYSIO_ITC_GPIO),y)
+CSRCS += itc_gpio.c 
+endif
 
 CFLAGS += -I$(TOPDIR)/../framework/include/iotbus
 

--- a/apps/examples/testcase/ta_tc/systemio/utc/Make.defs
+++ b/apps/examples/testcase/ta_tc/systemio/utc/Make.defs
@@ -52,7 +52,27 @@
 ############################################################################
 
 ifeq ($(CONFIG_EXAMPLES_TESTCASE_SYSTEMIO_UTC),y)
-CSRCS += utc_sysio_main.c utc_gpio.c utc_i2c.c utc_pwm.c utc_spi.c utc_uart.c
+CSRCS += utc_sysio_main.c 
+
+ifeq ($(CONFIG_SYSIO_UTC_UART),y)
+CSRCS += utc_uart.c 
+endif
+
+ifeq ($(CONFIG_SYSIO_UTC_SPI),y)
+CSRCS += utc_spi.c 
+endif
+
+ifeq ($(CONFIG_SYSIO_UTC_I2C),y)
+CSRCS += utc_i2c.c 
+endif
+
+ifeq ($(CONFIG_SYSIO_UTC_PWM),y)
+CSRCS += utc_pwm.c 
+endif
+
+ifeq ($(CONFIG_SYSIO_UTC_GPIO),y)
+CSRCS += utc_gpio.c 
+endif
 
 # Include system io build support
 


### PR DESCRIPTION
make systemio subtests: uart, i2c, spi, gpio, and pwm test independent.
Signed-off-by: tianfu.huang <tianfu.huang@samsung.com>
@sunghan-chang 