### PR TITLE
framework/media: Send buffer data via RecorderObserverWorker

### DIFF
--- a/apps/examples/mediarecorder/mediarecorder_main.cpp
+++ b/apps/examples/mediarecorder/mediarecorder_main.cpp
@@ -89,7 +89,7 @@ public:
 		std::cout << "onRecordStopError!! errCode : " << errCode << std::endl;
 	}
 
-	void onRecordBufferDataReached(MediaRecorder& mediaRecorder, unsigned char *data, size_t size)
+	void onRecordBufferDataReached(MediaRecorder& mediaRecorder, std::shared_ptr<unsigned char> data, size_t size)
 	{
 		std::cout << "onRecordBufferDataReached, data size : " << size << std::endl;
 	}

--- a/framework/include/media/MediaRecorderObserverInterface.h
+++ b/framework/include/media/MediaRecorderObserverInterface.h
@@ -29,6 +29,7 @@
 #ifndef __MEDIA_MEDIARECOREROBSERVERINTERFACE_H
 #define __MEDIA_MEDIARECOREROBSERVERINTERFACE_H
 
+#include <memory>
 #include <media/MediaTypes.h>
 
 namespace media {
@@ -93,7 +94,7 @@ public:
 	 * @details @b #include <media/MediaRecorderObserverInterface.h>
 	 * @since TizenRT v2.0 PRE
 	 */
-	virtual void onRecordBufferDataReached(MediaRecorder& mediaRecorder, unsigned char *data, size_t size) {}
+	virtual void onRecordBufferDataReached(MediaRecorder& mediaRecorder, std::shared_ptr<unsigned char> data, size_t size) {}
 	/**
 	 * @brief informs the user the recorder buffer state: overrun.
 	 * @details @b #include <media/MediaRecorderObserverInterface.h>

--- a/framework/src/media/BufferOutputDataSource.cpp
+++ b/framework/src/media/BufferOutputDataSource.cpp
@@ -97,7 +97,7 @@ ssize_t BufferOutputDataSource::onStreamBufferReadable(bool isFlush)
 		if (recorder) {
 			recorder->notifyObserver(OBSERVER_COMMAND_BUFFER_DATAREACHED, buffer, size);
 		}
-		delete[] buffer;
+		// DO NOT `delete[]`, `buffer` will be managed in std::shared_ptr<> and released automatically!
 		return size;
 	}
 

--- a/framework/src/media/MediaRecorderImpl.cpp
+++ b/framework/src/media/MediaRecorderImpl.cpp
@@ -657,9 +657,8 @@ void MediaRecorderImpl::notifyObserver(observer_command_t cmd, ...)
 			medvdbg("OBSERVER_COMMAND_BUFFER_DATAREACHED\n");
 			unsigned char *data = va_arg(ap, unsigned char *);
 			size_t size = va_arg(ap, size_t);
-			// Call observer directly, not via RecorderWorker.
-			// Because data buffer would be released after this function returned.
-			mRecorderObserver->onRecordBufferDataReached(mRecorder, data, size);
+			std::shared_ptr<unsigned char> autodata(data, [](unsigned char *p){ delete[] p; });
+			row.enQueue(&MediaRecorderObserverInterface::onRecordBufferDataReached, mRecorderObserver, mRecorder, autodata, size);
 		} break;
 		}
 


### PR DESCRIPTION
Previous direct call to observer may cause unknown scheduling issue.
Use shared_ptr<> manage buffer and auto delete it after application read data.
@Taejun-Kwon @junmin-kim @gcjjyy @jsdosa 