### PR TITLE
framework/task_manager: Fix wrong usage of setting timeout for mq_tim…

### DIFF
--- a/apps/examples/testcase/ta_tc/task_manager/utc/utc_task_manager_main.c
+++ b/apps/examples/testcase/ta_tc/task_manager/utc/utc_task_manager_main.c
@@ -758,7 +758,7 @@ static void utc_task_manager_unregister_p(void)
 	ret = task_manager_unregister(tm_broadcast_handle3, TM_RESPONSE_WAIT_INF);
 	TC_ASSERT_EQ("task_manager_unregister", ret, OK);
 
-	ret = task_manager_start(tm_sample_handle, 100);
+	ret = task_manager_start(tm_sample_handle, TM_RESPONSE_WAIT_INF);
 	TC_ASSERT_EQ("task_manager_start", ret, TM_UNREGISTERED_APP);
 
 	ret = task_manager_restart(tm_sample_handle, TM_RESPONSE_WAIT_INF);

--- a/framework/src/task_manager/task_manager_interface.c
+++ b/framework/src/task_manager/task_manager_interface.c
@@ -120,9 +120,13 @@ int taskmgr_receive_response(char *q_name, tm_response_t *response_msg, int time
 	if (timeout == TM_RESPONSE_WAIT_INF) {
 		status = mq_receive(private_mqfd, (char *)response_msg, sizeof(tm_response_t), 0);
 	} else {
-		time.tv_sec = timeout / MSEC_PER_SEC;
-		time.tv_nsec = (timeout - MSEC_PER_SEC * time.tv_sec) * NSEC_PER_MSEC;
-		status = mq_timedreceive(private_mqfd, (char *)response_msg, sizeof(tm_response_t), 0, &time);
+		status = taskmgr_calc_time(&time, timeout);
+		if (status != OK) {
+			mq_close(private_mqfd);
+			mq_unlink(q_name);
+			return TM_COMMUCATION_FAIL;
+		}
+		status = mq_timedreceive(private_mqfd, (char *)response_msg, sizeof(tm_response_t), NULL, &time);
 	}
 
 	mq_close(private_mqfd);

--- a/framework/src/task_manager/task_manager_internal.h
+++ b/framework/src/task_manager/task_manager_internal.h
@@ -195,5 +195,6 @@ bool taskmgr_is_permitted(int handle, pid_t pid);
 int taskmgr_get_task_state(int handle);
 int taskmgr_get_drvfd(void);
 int taskmgr_get_handle_by_pid(int pid);
+int taskmgr_calc_time(struct timespec *time, int timeout);
 
 #endif


### PR DESCRIPTION
…edreceive

To wait for the timeout which user wants, set timeout param of mq_timedreceive to the time from the current time.