### PR TITLE
framework/task_manager: Modify task_manager_set_broadcast_cb to alloc…

### DIFF
--- a/apps/examples/testcase/ta_tc/task_manager/utc/utc_task_manager_main.c
+++ b/apps/examples/testcase/ta_tc/task_manager/utc/utc_task_manager_main.c
@@ -46,9 +46,10 @@
 #define TM_INVALID_BROAD_MSG            -2
 #define TM_INVALID_PID                  -2
 #define TM_BROAD_TASK_NUM               2
-#define TM_BROAD_WIFI_ON_DATA           1
-#define TM_BROAD_WIFI_OFF_DATA          2
-#define TM_BROAD_UNDEFINED_MSG_DATA     20
+#define TM_BROAD_UNDEF_NUM              3
+#define TM_BROAD_WIFI_ON_DATA           "BROAD_WIFI_ON"
+#define TM_BROAD_WIFI_OFF_DATA          "BROAD_WIFI_OFF"
+#define TM_BROAD_UNDEFINED_MSG_DATA     "BROAD_UNDEFINED"
 #define TM_BROAD_UNDEFINED_MSG_NOT_USED (TM_BROADCAST_MSG_MAX + 2)
 
 static int tm_sample_handle;
@@ -111,30 +112,22 @@ static void test_unicast_handler(tm_msg_t *info)
 
 static void test_broadcast_handler(void *user_data, void *info)
 {
-	int rec = (int)info;
-
-	switch (rec) {
-	case TM_BROAD_WIFI_ON_DATA:
+	if (strncmp((char *)info, TM_BROAD_WIFI_ON_DATA, strlen(TM_BROAD_WIFI_ON_DATA) + 1) == 0) {
 		broadcast_data_flag = strncmp((char *)user_data, "WIFI_ON", strlen("WIFI_ON") + 1);
 		sem_wait(&tm_broad_sem);
 		broad_wifi_on_cnt++;
 		sem_post(&tm_broad_sem);
-		break;
-
-	case TM_BROAD_WIFI_OFF_DATA:
+		(void)task_manager_unset_broadcast_cb(TM_BROADCAST_WIFI_ON, TM_NO_RESPONSE);
+	} else if (strncmp((char *)info, TM_BROAD_WIFI_OFF_DATA, strlen(TM_BROAD_WIFI_OFF_DATA) + 1) == 0) {
 		sem_wait(&tm_broad_sem);
 		broad_wifi_off_cnt++;
 		sem_post(&tm_broad_sem);
-		break;
-
-	case TM_BROAD_UNDEFINED_MSG_DATA:
+		(void)task_manager_unset_broadcast_cb(TM_BROADCAST_WIFI_OFF, TM_NO_RESPONSE);
+	} else if (strncmp((char *)info, TM_BROAD_UNDEFINED_MSG_DATA, strlen(TM_BROAD_UNDEFINED_MSG_DATA) + 1) == 0) {
 		sem_wait(&tm_broad_sem);
 		broad_undefined_cnt++;
 		sem_post(&tm_broad_sem);
-		break;
-
-	default:
-		break;
+		(void)task_manager_unset_broadcast_cb(tm_broadcast_undefined_msg, TM_NO_RESPONSE);
 	}
 }
 
@@ -163,16 +156,31 @@ int tm_sample_main(int argc, char *argv[])
 int tm_broadcast1_main(int argc, char *argv[])
 {
 	int ret;
+	tm_msg_t data;
 
-	ret = task_manager_set_broadcast_cb(TM_BROADCAST_WIFI_ON, test_broadcast_handler, (void *)TM_BROAD_WIFI_ON_DATA);
+	data.msg_size = strlen(TM_BROAD_WIFI_ON_DATA) + 1;
+	data.msg = malloc(data.msg_size);
+	memcpy(data.msg, TM_BROAD_WIFI_ON_DATA, data.msg_size);
+	ret = task_manager_set_broadcast_cb(TM_BROADCAST_WIFI_ON, test_broadcast_handler, &data);
+	free(data.msg);
 	if (ret != OK) {
 		printf("ERROR : fail to set callback ERR: %d\n", ret);
 	}
-	ret = task_manager_set_broadcast_cb(TM_BROADCAST_WIFI_OFF, test_broadcast_handler, (void *)TM_BROAD_WIFI_OFF_DATA);
+
+	data.msg_size = strlen(TM_BROAD_WIFI_OFF_DATA) + 1;
+	data.msg = malloc(data.msg_size);
+	memcpy(data.msg, TM_BROAD_WIFI_OFF_DATA, data.msg_size);
+	ret = task_manager_set_broadcast_cb(TM_BROADCAST_WIFI_OFF, test_broadcast_handler, &data);
+	free(data.msg);
 	if (ret != OK) {
 		printf("ERROR : fail to set callback ERR: %d\n", ret);
 	}
-	ret = task_manager_set_broadcast_cb(tm_broadcast_undefined_msg, test_broadcast_handler, (void *)TM_BROAD_UNDEFINED_MSG_DATA);
+
+	data.msg_size = strlen(TM_BROAD_UNDEFINED_MSG_DATA) + 1;
+	data.msg = malloc(data.msg_size);
+	memcpy(data.msg, TM_BROAD_UNDEFINED_MSG_DATA, data.msg_size);
+	ret = task_manager_set_broadcast_cb(tm_broadcast_undefined_msg, test_broadcast_handler, &data);
+	free(data.msg);
 	if (ret != OK) {
 		printf("ERROR : fail to set callback ERR: %d\n", ret);
 	}
@@ -185,12 +193,22 @@ int tm_broadcast1_main(int argc, char *argv[])
 int tm_broadcast2_main(int argc, char *argv[])
 {
 	int ret;
+	tm_msg_t data;
 
-	ret = task_manager_set_broadcast_cb(TM_BROADCAST_WIFI_ON, test_broadcast_handler, (void *)TM_BROAD_WIFI_ON_DATA);
+	data.msg_size = strlen(TM_BROAD_WIFI_ON_DATA) + 1;
+	data.msg = malloc(data.msg_size);
+	memcpy(data.msg, TM_BROAD_WIFI_ON_DATA, data.msg_size);
+	ret = task_manager_set_broadcast_cb(TM_BROADCAST_WIFI_ON, test_broadcast_handler, &data);
+	free(data.msg);
 	if (ret != OK) {
 		printf("ERROR : fail to set callback ERR: %d\n", ret);
 	}
-	ret = task_manager_set_broadcast_cb(TM_BROADCAST_WIFI_OFF, test_broadcast_handler, (void *)TM_BROAD_WIFI_OFF_DATA);
+
+	data.msg_size = strlen(TM_BROAD_WIFI_OFF_DATA) + 1;
+	data.msg = malloc(data.msg_size);
+	memcpy(data.msg, TM_BROAD_WIFI_OFF_DATA, data.msg_size);
+	ret = task_manager_set_broadcast_cb(TM_BROADCAST_WIFI_OFF, test_broadcast_handler, &data);
+	free(data.msg);
 	if (ret != OK) {
 		printf("ERROR : fail to set callback ERR: %d\n", ret);
 	}
@@ -203,8 +221,13 @@ int tm_broadcast2_main(int argc, char *argv[])
 int tm_broadcast3_main(int argc, char *argv[])
 {
 	int ret;
+	tm_msg_t data;
 
-	ret = task_manager_set_broadcast_cb(tm_broadcast_undefined_msg, test_broadcast_handler, (void *)TM_BROAD_UNDEFINED_MSG_DATA);
+	data.msg_size = strlen(TM_BROAD_UNDEFINED_MSG_DATA) + 1;
+	data.msg = malloc(data.msg_size);
+	memcpy(data.msg, TM_BROAD_UNDEFINED_MSG_DATA, data.msg_size);
+	ret = task_manager_set_broadcast_cb(tm_broadcast_undefined_msg, test_broadcast_handler, &data);
+	free(data.msg);
 	if (ret != OK) {
 		printf("ERROR : fail to set callback ERR: %d\n", ret);
 	}
@@ -319,13 +342,18 @@ static void utc_task_manager_set_broadcast_cb_n(void)
 static void utc_task_manager_set_broadcast_cb_p(void)
 {
 	int ret;
+	tm_msg_t data;
 
 	ret = task_manager_set_broadcast_cb(TM_BROAD_UNDEFINED_MSG_NOT_USED, test_broadcast_handler, (void *)NULL);
 	TC_ASSERT_EQ("task_manager_set_broadcast_cb", ret, TM_UNREGISTERED_MSG);
 
-	ret = task_manager_set_broadcast_cb(tm_broadcast_undefined_msg, test_broadcast_handler, (void *)TM_BROAD_WIFI_ON_DATA);
-	TC_ASSERT_EQ("task_manager_set_broadcast_cb", ret, OK);
+	data.msg_size = strlen(TM_BROAD_UNDEFINED_MSG_DATA) + 1;
+	data.msg = malloc(data.msg_size);
+	memcpy(data.msg, TM_BROAD_UNDEFINED_MSG_DATA, data.msg_size);
+	ret = task_manager_set_broadcast_cb(tm_broadcast_undefined_msg, test_broadcast_handler, &data);
+	TC_ASSERT_EQ_CLEANUP("task_manager_set_broadcast_cb", ret, OK, free(data.msg));
 
+	free(data.msg);
 	TC_SUCCESS_RESULT();
 }
 
@@ -486,7 +514,7 @@ static void utc_task_manager_broadcast_p(void)
 	(void)task_manager_broadcast(tm_broadcast_undefined_msg, NULL, TM_NO_RESPONSE);
 	while (1) {
 		usleep(500);
-		if (broad_undefined_cnt == TM_BROAD_TASK_NUM) {
+		if (broad_undefined_cnt == TM_BROAD_UNDEF_NUM) {
 			break;
 		}
 		TC_ASSERT_LEQ_CLEANUP("task_manager_broadcast", sleep_cnt, 10, sem_destroy(&tm_broad_sem));
@@ -494,7 +522,7 @@ static void utc_task_manager_broadcast_p(void)
 	}
 	TC_ASSERT_EQ_CLEANUP("task_manager_broadcast", broad_wifi_on_cnt, 0, sem_destroy(&tm_broad_sem));
 	TC_ASSERT_EQ_CLEANUP("task_manager_broadcast", broad_wifi_off_cnt, 0, sem_destroy(&tm_broad_sem));
-	TC_ASSERT_EQ_CLEANUP("task_manager_broadcast", broad_undefined_cnt, TM_BROAD_TASK_NUM, sem_destroy(&tm_broad_sem));
+	TC_ASSERT_EQ_CLEANUP("task_manager_broadcast", broad_undefined_cnt, TM_BROAD_UNDEF_NUM, sem_destroy(&tm_broad_sem));
 
 	sem_destroy(&tm_broad_sem);
 	TC_SUCCESS_RESULT();
@@ -521,7 +549,7 @@ static void utc_task_manager_unset_broadcast_cb_p(void)
 	TC_ASSERT_EQ("task_manager_unset_broadcast_cb", ret, TM_UNREGISTERED_MSG);
 
 	ret = task_manager_unset_broadcast_cb(tm_broadcast_undefined_msg, TM_RESPONSE_WAIT_INF);
-	TC_ASSERT_EQ("task_manager_unset_broadcast_cb", ret, OK);
+	TC_ASSERT_EQ("task_manager_unset_broadcast_cb", ret, TM_UNREGISTERED_MSG);
 
 	TC_SUCCESS_RESULT();
 }
@@ -907,9 +935,6 @@ void tm_utc_main(void)
 	utc_task_manager_unicast_n();
 	utc_task_manager_unicast_p();
 
-	utc_task_manager_unset_broadcast_cb_n();
-	utc_task_manager_unset_broadcast_cb_p();
-
 	utc_task_manager_broadcast_n();
 	utc_task_manager_broadcast_p();
 
@@ -918,6 +943,9 @@ void tm_utc_main(void)
 
 	utc_task_manager_resume_n();
 	utc_task_manager_resume_p();
+
+	utc_task_manager_unset_broadcast_cb_n();
+	utc_task_manager_unset_broadcast_cb_p();
 
 	utc_task_manager_getinfo_with_name_n();
 	utc_task_manager_getinfo_with_name_p();

--- a/framework/include/task_manager/task_manager.h
+++ b/framework/include/task_manager/task_manager.h
@@ -323,11 +323,11 @@ int task_manager_set_unicast_cb(void (*func)(tm_msg_t *data));
  *            If this message is not pre defined at the <task_manager/task_manager.h> and <task_manager/task_manager_broadcast_list.h>,\n
  *            user should use task_manager_alloc_broadcast_msg() API to get a new broadacast message.
  * @param[in] func the callback function which will be called when a msg is received.
- * @param[in] cb_data a data pointer to pass to the callback function func.
+ * @param[in] cb_data a message structure to pass to the callback function func.
  * @return On success, OK is returned. On failure, defined negative value is returned.
  * @since TizenRT v2.0 PRE
  */
-int task_manager_set_broadcast_cb(int msg, void (*func)(void *user_data, void *data), void *cb_data);
+int task_manager_set_broadcast_cb(int msg, void (*func)(void *user_data, void *data), tm_msg_t *cb_data);
 /**
  * @brief Set callback function for resource deallocation API. If you set the callback, it will works when task terminates.
  * @details @b #include <task_manager/task_manager.h>

--- a/framework/src/task_manager/task_manager_set_callback.c
+++ b/framework/src/task_manager/task_manager_set_callback.c
@@ -127,7 +127,7 @@ int task_manager_set_unicast_cb(void (*func)(tm_msg_t *data))
 /****************************************************************************
  * task_manager_set_broadcast_cb
  ****************************************************************************/
-int task_manager_set_broadcast_cb(int msg, void (*func)(void *user_data, void *data), void *cb_data)
+int task_manager_set_broadcast_cb(int msg, void (*func)(void *user_data, void *data), tm_msg_t *cb_data)
 {
 	int status;
 	tm_request_t request_msg;
@@ -160,15 +160,34 @@ int task_manager_set_broadcast_cb(int msg, void (*func)(void *user_data, void *d
 	}
 	((tm_broadcast_info_t *)request_msg.data)->msg = msg;
 	((tm_broadcast_info_t *)request_msg.data)->cb = (_tm_broadcast_t)func;
-	((tm_broadcast_info_t *)request_msg.data)->cb_data = cb_data;
+	if (cb_data != NULL) {
+		((tm_broadcast_info_t *)request_msg.data)->cb_data = (tm_msg_t *)TM_ALLOC(sizeof(tm_msg_t));
+		if (((tm_broadcast_info_t *)request_msg.data)->cb_data == NULL) {
+			TM_FREE(request_msg.data);
+			return TM_OUT_OF_MEMORY;
+		}
+		((tm_msg_t *)((tm_broadcast_info_t *)request_msg.data)->cb_data)->msg_size = cb_data->msg_size;
+		((tm_msg_t *)((tm_broadcast_info_t *)request_msg.data)->cb_data)->msg = TM_ALLOC(cb_data->msg_size);
+		if (((tm_msg_t *)((tm_broadcast_info_t *)request_msg.data)->cb_data)->msg == NULL) {
+			TM_FREE(request_msg.data);
+			TM_FREE(((tm_broadcast_info_t *)request_msg.data)->cb_data);
+			return TM_OUT_OF_MEMORY;
+		}
+		memcpy(((tm_msg_t *)((tm_broadcast_info_t *)request_msg.data)->cb_data)->msg, cb_data->msg, cb_data->msg_size);
+	} else {
+		((tm_broadcast_info_t *)request_msg.data)->cb_data = NULL;
+	}
+
 	TM_ASPRINTF(&request_msg.q_name, "%s%d", TM_PRIVATE_MQ, request_msg.caller_pid);
 	if (request_msg.q_name == NULL) {
 		TM_FREE(request_msg.data);
+		TM_FREE(((tm_broadcast_info_t *)request_msg.data)->cb_data);
 		return TM_OUT_OF_MEMORY;
 	}
 	status = taskmgr_send_request(&request_msg);
 	if (status < 0) {
 		TM_FREE(request_msg.data);
+		TM_FREE(((tm_broadcast_info_t *)request_msg.data)->cb_data);
 		if (request_msg.q_name != NULL) {
 			TM_FREE(request_msg.q_name);
 		}


### PR DESCRIPTION
… for callback data

1. when setting broadcast callback, user can pass callback data. it will be allocated, not only has pointer.
2. Change its TC for passing callback data with tm_msg_t type