### PR TITLE
media: Add include guard at Decoder.h, Encoder.h

### DIFF
--- a/framework/src/media/Decoder.h
+++ b/framework/src/media/Decoder.h
@@ -16,6 +16,9 @@
  *
  ******************************************************************/
 
+#ifndef __MEDIA_DECODER_H
+#define __MEDIA_DECODER_H
+
 #include <tinyara/config.h>
 #include <stdio.h>
 
@@ -48,3 +51,5 @@ private:
 #endif
 };
 } // namespace media
+
+#endif

--- a/framework/src/media/Encoder.h
+++ b/framework/src/media/Encoder.h
@@ -16,6 +16,9 @@
  *
  ******************************************************************/
 
+#ifndef __MEDIA_ENCODER_H
+#define __MEDIA_ENCODER_H
+
 #include <tinyara/config.h>
 #include <stdio.h>
 #include <media/MediaTypes.h>
@@ -48,3 +51,5 @@ private:
 #endif
 };
 } // namespace media
+
+#endif


### PR DESCRIPTION
Include guard is needed to void double inclusion