### PR TITLE
testcase/kernel: fix compilation warnings and remove a dependancy

### DIFF
--- a/apps/examples/testcase/le_tc/kernel/Kconfig
+++ b/apps/examples/testcase/le_tc/kernel/Kconfig
@@ -163,6 +163,7 @@ config TC_KERNEL_PTHREAD
 config TC_KERNEL_ROUNDROBIN
 	bool "RoundRobin"
 	default n
+	depends on RR_INTERVAL != 0
 
 config TC_KERNEL_SCHED
 	bool "Sched"

--- a/apps/examples/testcase/le_tc/kernel/Kconfig
+++ b/apps/examples/testcase/le_tc/kernel/Kconfig
@@ -6,7 +6,6 @@
 menuconfig EXAMPLES_TESTCASE_KERNEL
 	bool "Kernel TestCase Example"
 	default y
-	select KERNEL_TEST_DRV
 	---help---
 		Enable the Kernel TestCase Example
 


### PR DESCRIPTION
1. fix compilation warings 
2. remove a KERNEL_TEST_DRV dependancy