### PR TITLE
Fix Error in Tinyalsa during audio playback

### DIFF
--- a/framework/src/tinyalsa/tinyalsa.c
+++ b/framework/src/tinyalsa/tinyalsa.c
@@ -1173,8 +1173,8 @@ int pcm_drain(struct pcm *pcm)
 			if (msg.msgId == AUDIO_MSG_DEQUEUE) {
 				pcm->buf_idx--;
 			} else if (msg.msgId == AUDIO_MSG_XRUN) {
-				/* Underrun to be handled by client */
-				return -EPIPE;
+				/* Ignore Underrun since we are trying to flush and close */
+				continue;
 			}
 		}
 


### PR DESCRIPTION
During audio playback, the media player tries to call pcm_drain API
at the end of playback to flush the data and close the device. However,
since we have stopped enqueuing new buffers to the codec and waiting
for dequeue msg, the codec generates underrun errors in the meantime.
Since we are in the phase of closing the audio device, we can ignore
any underrun related errors. Hence, modify tinyasla to ignore underrun
during pcm_drain.