### PR TITLE
framework/task_manager: Set tcb->sigprocmask to NULL after restart

### DIFF
--- a/framework/src/task_manager/task_manager_core.c
+++ b/framework/src/task_manager/task_manager_core.c
@@ -369,6 +369,7 @@ static int taskmgr_stop(int handle, int caller_pid)
 static int taskmgr_restart(int handle, int caller_pid)
 {
 	int ret;
+	int fd;
 
 	if (IS_INVALID_HANDLE(handle) || caller_pid < 0) {
 		return TM_INVALID_PARAM;
@@ -387,6 +388,16 @@ static int taskmgr_restart(int handle, int caller_pid)
 	ret = task_restart(TM_PID(handle));
 	if (ret != OK) {
 		tmdbg("Fail to restart the task\n");
+		return TM_OPERATION_FAIL;
+	}
+
+	fd = taskmgr_get_drvfd();
+	if (fd < 0) {
+		return TM_INVALID_DRVFD;
+	}
+
+	ret = ioctl(fd, TMIOC_RESTART, TM_PID(handle));
+	if (ret != OK) {
 		return TM_OPERATION_FAIL;
 	}
 

--- a/os/drivers/task_manager/task_manager_drv.c
+++ b/os/drivers/task_manager/task_manager_drv.c
@@ -155,6 +155,12 @@ static int taskmgr_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
 		}
 		break;
 	case TMIOC_RESTART:
+		tcb = sched_gettcb((int)arg);
+		if (tcb == NULL) {
+			tmdbg("No task with this pid %d.\n", (int)arg);
+			return ERROR;
+		}
+		(void)sigprocmask(SIG_SETMASK, NULL, &tcb->sigprocmask);
 		break;
 	case TMIOC_BROADCAST:
 		tcb = sched_gettcb((int)arg);


### PR DESCRIPTION
task_restart calls sig_cleanup, and sig_cleanup sets tcb->sigprocmask to ALL.
if tcb->sigprocmask sets to ALL, it will be added to pendingsignal, but task_manager doesn't want to pend the signal.