### PR TITLE
media: Fix build error because of invalid type casting

### DIFF
--- a/apps/examples/mediarecorder/mediarecorder_main.cpp
+++ b/apps/examples/mediarecorder/mediarecorder_main.cpp
@@ -104,7 +104,7 @@ public:
 	void onRecordBufferDataReached(MediaRecorder& mediaRecorder, std::shared_ptr<unsigned char> data, size_t size)
 	{
 		if (mfp != NULL) {
-			fwrite(data, sizeof(unsigned char), size, mfp);
+			fwrite((const void *)data.get(), sizeof(unsigned char), size, mfp);
 		}
 		std::cout << "onRecordBufferDataReached, data size : " << size << std::endl;
 	}


### PR DESCRIPTION
onRecordBufferDataReached method prototype has changed.
But the example app didn't apply it.