### PR TITLE
framework/media: Move mAudioType to DataSource

### DIFF
--- a/framework/include/media/DataSource.h
+++ b/framework/include/media/DataSource.h
@@ -140,11 +140,26 @@ public:
 	 * @since TizenRT v2.0 PRE
 	 */
 	void setPcmFormat(audio_format_type_t pcmFormat);
+	/**
+	 * @brief Sets the audio type of the stream data.
+	 * @details @b #include <media/DataSource.h>
+	 * @param[in] audioType The audioType that the audio type of stream data
+	 * @since TizenRT v2.0 PRE
+	 */
+	void setAudioType(audio_type_t audioType);
+	/**
+	 * @brief Gets the audio type of the stream data.
+	 * @details @b #include <media/DataSource.h>
+	 * @return The audio type of the stream data.
+	 * @since TizenRT v2.0 PRE
+	 */
+	audio_type_t getAudioType();
 
 private:
 	unsigned char mChannels;
 	unsigned int mSampleRate;
 	audio_format_type_t mPcmFormat;
+	audio_type_t mAudioType;
 };
 } // namespace media
 

--- a/framework/include/media/InputDataSource.h
+++ b/framework/include/media/InputDataSource.h
@@ -96,11 +96,6 @@ public:
 	 */
 	virtual int readAt(long offset, int origin, unsigned char *buf, size_t size);
 
-	void setAudioType(audio_type_t audioType);
-	audio_type_t getAudioType();
-
-private:
-	audio_type_t mAudioType;
 };
 
 } // namespace stream

--- a/framework/include/media/OutputDataSource.h
+++ b/framework/include/media/OutputDataSource.h
@@ -119,8 +119,6 @@ protected:
 protected:
 	const std::shared_ptr<Encoder> getEncoder();
 	void setEncoder(std::shared_ptr<Encoder> encoder);
-	void setAudioType(audio_type_t audioType);
-	audio_type_t getAudioType();
 
 	void setStreamBuffer(std::shared_ptr<StreamBuffer>);
 	std::shared_ptr<StreamBuffer> getStreamBuffer() { return mStreamBuffer; }
@@ -131,7 +129,6 @@ protected:
 	ssize_t writeToStreamBuffer(unsigned char *buf, size_t size);
 
 private:
-	audio_type_t mAudioType;
 	std::shared_ptr<Encoder> mEncoder;
 	std::shared_ptr<StreamBuffer> mStreamBuffer;
 	std::shared_ptr<StreamBufferReader> mBufferReader;

--- a/framework/src/media/DataSource.cpp
+++ b/framework/src/media/DataSource.cpp
@@ -24,6 +24,7 @@ DataSource::DataSource()
 	: mChannels(2)
 	, mSampleRate(16000)
 	, mPcmFormat(AUDIO_FORMAT_TYPE_S16_LE)
+	, mAudioType(AUDIO_TYPE_INVALID)
 {
 	medvdbg("DataSource::DataSource()\n");
 }
@@ -32,6 +33,7 @@ DataSource::DataSource(unsigned int channels, unsigned int sampleRate, audio_for
 	: mChannels(channels)
 	, mSampleRate(sampleRate)
 	, mPcmFormat(pcmFormat)
+	, mAudioType(AUDIO_TYPE_INVALID)
 {
 	medvdbg("DataSource::DataSource(unsigned int channels, unsigned int sampleRate, audio_format_type_t pcmFormat)\n");
 }
@@ -40,6 +42,7 @@ DataSource::DataSource(const DataSource& source)
 	: mChannels(source.mChannels)
 	, mSampleRate(source.mSampleRate)
 	, mPcmFormat(source.mPcmFormat)
+	, mAudioType(source.mAudioType)
 {
 }
 
@@ -48,6 +51,7 @@ DataSource& DataSource::operator=(const DataSource& source)
 	mChannels = source.mChannels;
 	mSampleRate = source.mSampleRate;
 	mPcmFormat = source.mPcmFormat;
+	mAudioType = source.mAudioType;
 	return *this;
 }
 
@@ -79,6 +83,16 @@ void DataSource::setSampleRate(unsigned int sampleRate)
 void DataSource::setPcmFormat(audio_format_type_t pcmFormat)
 {
 	mPcmFormat = pcmFormat;
+}
+
+void DataSource::setAudioType(audio_type_t audioType)
+{
+	mAudioType = audioType;
+}
+
+audio_type_t DataSource::getAudioType()
+{
+	return mAudioType;
 }
 
 DataSource::~DataSource()

--- a/framework/src/media/InputDataSource.cpp
+++ b/framework/src/media/InputDataSource.cpp
@@ -35,37 +35,24 @@ namespace media {
 namespace stream {
 
 InputDataSource::InputDataSource() :
-	DataSource(),
-	mAudioType(AUDIO_TYPE_INVALID)
+	DataSource()
 {
 }
 
 InputDataSource::InputDataSource(const InputDataSource &source) :
-	DataSource(source),
-	mAudioType(source.mAudioType)
+	DataSource(source)
 {
 }
 
 InputDataSource &InputDataSource::operator=(const InputDataSource &source)
 {
 	DataSource::operator=(source);
-	this->mAudioType = source.mAudioType;
 
 	return *this;
 }
 
 InputDataSource::~InputDataSource()
 {
-}
-
-void InputDataSource::setAudioType(audio_type_t audioType)
-{
-	mAudioType = audioType;
-}
-
-audio_type_t InputDataSource::getAudioType()
-{
-	return mAudioType;
 }
 
 int InputDataSource::readAt(long offset, int origin, unsigned char *buf, size_t size)
@@ -80,3 +67,4 @@ int InputDataSource::readAt(long offset, int origin, unsigned char *buf, size_t 
 
 } // namespace stream
 } // namespace media
+

--- a/framework/src/media/OutputDataSource.cpp
+++ b/framework/src/media/OutputDataSource.cpp
@@ -35,7 +35,6 @@ namespace media {
 namespace stream {
 OutputDataSource::OutputDataSource() :
 	DataSource(),
-	mAudioType(AUDIO_TYPE_INVALID),
 	mEncoder(nullptr),
 	mIsFlushing(false),
 	mIsWorkerAlive(false),
@@ -45,7 +44,6 @@ OutputDataSource::OutputDataSource() :
 
 OutputDataSource::OutputDataSource(unsigned int channels, unsigned int sampleRate, audio_format_type_t pcmFormat) :
 	DataSource(channels, sampleRate, pcmFormat),
-	mAudioType(AUDIO_TYPE_INVALID),
 	mEncoder(nullptr),
 	mIsFlushing(false),
 	mIsWorkerAlive(false),
@@ -55,7 +53,6 @@ OutputDataSource::OutputDataSource(unsigned int channels, unsigned int sampleRat
 
 OutputDataSource::OutputDataSource(const OutputDataSource &source) :
 	DataSource(source),
-	mAudioType(source.mAudioType),
 	mEncoder(source.mEncoder),
 	mIsFlushing(false),
 	mIsWorkerAlive(false),
@@ -81,16 +78,6 @@ void OutputDataSource::setEncoder(std::shared_ptr<Encoder> encoder)
 const std::shared_ptr<Encoder> OutputDataSource::getEncoder()
 {
 	return mEncoder;
-}
-
-void OutputDataSource::setAudioType(audio_type_t audioType)
-{
-	mAudioType = audioType;
-}
-
-audio_type_t OutputDataSource::getAudioType()
-{
-	return mAudioType;
 }
 
 void OutputDataSource::setStreamBuffer(std::shared_ptr<StreamBuffer> streamBuffer)
@@ -330,3 +317,4 @@ void OutputDataSource::onBufferUpdated(ssize_t change, size_t current)
 
 } // namespace stream
 } // namespace media
+


### PR DESCRIPTION
mAudioType was a member of InputDataSource and OutputDataSource.
Move it to base class; DataSource.