### PR TITLE
media/utc: Use delete[] instead of delete

### DIFF
--- a/apps/examples/testcase/ta_tc/media/utc/utc_media_fileinputdatasource.cpp
+++ b/apps/examples/testcase/ta_tc/media/utc/utc_media_fileinputdatasource.cpp
@@ -36,7 +36,7 @@ static void TearDown()
 {
 	remove(dummyfilepath);
 
-	delete buf;
+	delete[] buf;
 }
 
 static void utc_media_FileInputDataSource_getChannels_p(void)


### PR DESCRIPTION
Allocated array should be removed by delete[]