### PR TITLE
framework/task_manager: Fix memory leak possibility when fail case

### DIFF
--- a/apps/examples/testcase/ta_tc/task_manager/utc/utc_task_manager_main.c
+++ b/apps/examples/testcase/ta_tc/task_manager/utc/utc_task_manager_main.c
@@ -80,7 +80,7 @@ static void sync_test_cb(tm_msg_t *info)
 	tm_msg_t reply_msg;
 
 	if (strncmp(info->msg, TM_SYNC_SEND_MSG, info->msg_size) == 0) {
-		reply_msg.msg = malloc(strlen(TM_SYNC_RECV_MSG));
+		reply_msg.msg = malloc(strlen(TM_SYNC_RECV_MSG) + 1);
 		if (reply_msg.msg != NULL) {
 			reply_msg.msg_size = strlen(TM_SYNC_RECV_MSG) + 1;
 			memcpy(reply_msg.msg, TM_SYNC_RECV_MSG, reply_msg.msg_size);
@@ -407,8 +407,8 @@ static void utc_task_manager_unicast_n(void)
 {
 	int ret;
 	tm_msg_t send_msg;
-	send_msg.msg_size = strlen(TM_SAMPLE_MSG);
-	send_msg.msg = malloc(strlen(TM_SAMPLE_MSG));
+	send_msg.msg_size = strlen(TM_SAMPLE_MSG) + 1;
+	send_msg.msg = malloc(send_msg.msg_size);
 	TC_ASSERT_NEQ("task_manager_unicast", send_msg.msg, NULL);
 
 	strncpy(send_msg.msg, TM_SAMPLE_MSG, send_msg.msg_size);
@@ -438,7 +438,7 @@ static void utc_task_manager_unicast_p(void)
 	cb_flag = false;
 
 	send_msg.msg_size = strlen(TM_SAMPLE_MSG) + 1;
-	send_msg.msg = malloc(strlen(TM_SAMPLE_MSG));
+	send_msg.msg = malloc(send_msg.msg_size);
 	TC_ASSERT_NEQ("task_manager_unicast", send_msg.msg, NULL);
 
 	strncpy(send_msg.msg, TM_SAMPLE_MSG, send_msg.msg_size);
@@ -495,8 +495,8 @@ static void utc_task_manager_broadcast_p(void)
 	broad_undefined_cnt = 0;
 	broadcast_data_flag = -1;
 
-	user_data.msg = malloc(strlen("WIFI_ON"));
 	user_data.msg_size = strlen("WIFI_ON") + 1;
+	user_data.msg = malloc(user_data.msg_size);
 	strncpy(user_data.msg, "WIFI_ON", user_data.msg_size);
 
 	(void)task_manager_broadcast(TM_BROADCAST_WIFI_ON, &user_data, TM_NO_RESPONSE);

--- a/framework/src/task_manager/task_manager_broadcast.c
+++ b/framework/src/task_manager/task_manager_broadcast.c
@@ -72,8 +72,11 @@ int task_manager_broadcast(int msg, tm_msg_t *data, int timeout)
 	status = taskmgr_send_request(&request_msg);
 	if (status < 0) {
 		TM_FREE(((tm_internal_msg_t *)request_msg.data)->msg);
-		TM_FREE(request_msg.q_name);
 		TM_FREE(request_msg.data);
+		if (request_msg.q_name != NULL) {
+			TM_FREE(request_msg.q_name);
+		}
+		return status;
 	}
 
 	if (timeout != TM_NO_RESPONSE) {

--- a/framework/src/task_manager/task_manager_set_callback.c
+++ b/framework/src/task_manager/task_manager_set_callback.c
@@ -185,14 +185,16 @@ int task_manager_set_broadcast_cb(int msg, void (*func)(void *user_data, void *d
 
 	TM_ASPRINTF(&request_msg.q_name, "%s%d", TM_PRIVATE_MQ, request_msg.caller_pid);
 	if (request_msg.q_name == NULL) {
-		TM_FREE(request_msg.data);
+		TM_FREE(((tm_msg_t *)((tm_broadcast_info_t *)request_msg.data)->cb_data)->msg);
 		TM_FREE(((tm_broadcast_info_t *)request_msg.data)->cb_data);
+		TM_FREE(request_msg.data);
 		return TM_OUT_OF_MEMORY;
 	}
 	status = taskmgr_send_request(&request_msg);
 	if (status < 0) {
-		TM_FREE(request_msg.data);
+		TM_FREE(((tm_msg_t *)((tm_broadcast_info_t *)request_msg.data)->cb_data)->msg);
 		TM_FREE(((tm_broadcast_info_t *)request_msg.data)->cb_data);
+		TM_FREE(request_msg.data);
 		if (request_msg.q_name != NULL) {
 			TM_FREE(request_msg.q_name);
 		}


### PR DESCRIPTION
when fail to alloc, allocated memory should be released before return.