### PR TITLE
examples/media: Init all members at construction

### DIFF
--- a/apps/examples/mediaplayer/mediaplayer_main.cpp
+++ b/apps/examples/mediaplayer/mediaplayer_main.cpp
@@ -49,7 +49,7 @@ class MyMediaPlayer : public MediaPlayerObserverInterface,
 					  public enable_shared_from_this<MyMediaPlayer>
 {
 public:
-	MyMediaPlayer() : volume(0){};
+	MyMediaPlayer() : volume(0), isSourceSet(false) {};
 	virtual ~MyMediaPlayer(){};
 	bool init(int test);
 	void doCommand(int command);

--- a/apps/examples/mediarecorder/mediarecorder_main.cpp
+++ b/apps/examples/mediarecorder/mediarecorder_main.cpp
@@ -359,7 +359,7 @@ public:
 		return input;
 	}
 
-	MediaRecorderTest() : mAppRunning(false), mIsPaused(false), mIsPlaying(false)
+	MediaRecorderTest() : mAppRunning(false), mIsPaused(false), mIsPlaying(false), mfp(nullptr), mMediaType(TEST_MEDIATYPE_PCM), mDataSourceType(TEST_DATASOURCE_TYPE_FILE)
 	{
 	}
 	~MediaRecorderTest()


### PR DESCRIPTION
Constructor inits all primitive data