### PR TITLE
.clang-format: Add BreakConstructorInitializers

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -21,4 +21,5 @@ TabWidth:        4 #[M08]
 UseTab:          Always #[M08]
 PointerAlignment: Right
 SortIncludes: false
+BreakConstructorInitializers: AfterColon
 ...


### PR DESCRIPTION
Break constructor initializers after the colon and commas.
ex)
Constructor() :
    initializer1(),
    initializer2()