### PR TITLE
framework/task_manager: Fix memory deallocation after task_manager_restart

### DIFF
--- a/apps/examples/testcase/ta_tc/task_manager/utc/utc_task_manager_main.c
+++ b/apps/examples/testcase/ta_tc/task_manager/utc/utc_task_manager_main.c
@@ -733,6 +733,7 @@ static void utc_task_manager_stop_p(void)
 {
 	int ret;
 
+	sleep(1);
 	cb_flag = false;
 	ret = task_manager_stop(tm_sample_handle, TM_RESPONSE_WAIT_INF);
 	TC_ASSERT_EQ("task_manager_stop", ret, OK);
@@ -1050,9 +1051,9 @@ int utc_task_manager_main(int argc, char *argv[])
 
 	handle_tm_utc = task_manager_register_builtin("tm_utc", TM_APP_PERMISSION_DEDICATE, TM_RESPONSE_WAIT_INF);
 	(void)task_manager_start(handle_tm_utc, TM_NO_RESPONSE);
-	sleep(3);	//wait for starting tm_utc
-	
-	waitpid(pid_tm_utc, &status, 0);
+	sleep(5);	//wait for starting tm_utc
+
+	(void)waitpid(pid_tm_utc, &status, 0);
 
 	(void)task_manager_unregister(handle_tm_utc, TM_NO_RESPONSE);
 

--- a/framework/src/task_manager/task_manager_core.c
+++ b/framework/src/task_manager/task_manager_core.c
@@ -384,6 +384,32 @@ static int taskmgr_restart(int handle, int caller_pid)
 		return TM_NO_PERMISSION;
 	}
 
+	if (TM_STOP_CB_INFO(handle) != NULL) {
+		if (STOP_CBDATA(handle) != NULL) {
+			if (STOP_CBDATA_MSG(handle) != NULL) {
+				TM_FREE(STOP_CBDATA_MSG(handle));
+				STOP_CBDATA_MSG(handle) = NULL;
+			}
+			TM_FREE(STOP_CBDATA(handle));
+			STOP_CBDATA(handle) = NULL;
+		}
+		TM_FREE(TM_STOP_CB_INFO(handle));
+		TM_STOP_CB_INFO(handle) = NULL;
+	}
+
+	if (TM_EXIT_CB_INFO(handle) != NULL) {
+		if (EXIT_CBDATA(handle) != NULL) {
+			if (EXIT_CBDATA_MSG(handle) != NULL) {
+				TM_FREE(EXIT_CBDATA_MSG(handle));
+				EXIT_CBDATA_MSG(handle) = NULL;
+			}
+			TM_FREE(EXIT_CBDATA(handle));
+			EXIT_CBDATA(handle) = NULL;
+		}
+		TM_FREE(TM_EXIT_CB_INFO(handle));
+		TM_EXIT_CB_INFO(handle) = NULL;
+	}
+
 	ret = task_restart(TM_PID(handle));
 	if (ret != OK) {
 		tmdbg("Fail to restart the task\n");


### PR DESCRIPTION
Before restarting the task, STOP_CB information and EXIT_CB information should be freed.