### PR TITLE
apps/examples: Fix define mtd mount path

### DIFF
--- a/apps/examples/testcase/le_tc/filesystem/fs_main.c
+++ b/apps/examples/testcase/le_tc/filesystem/fs_main.c
@@ -143,7 +143,13 @@
 #define INV_FD -3
 
 #define MTD_CONFIG_PATH "/dev/config"
+
+#if defined(CONFIG_ARCH_BOARD_CY4390x)
+#define MTD_FTL_PATH "/dev/smart1p1"
+#else
 #define MTD_FTL_PATH "/dev/mtdblock1"
+#endif
+
 #define BUF_SIZE 4096
 
 #define DEV_PATH "/dev"


### PR DESCRIPTION
fix mtd paths that depend on the board.