### PR TITLE
fix build warnings on network features

### DIFF
--- a/apps/system/utils/netcmd.c
+++ b/apps/system/utils/netcmd.c
@@ -356,7 +356,6 @@ int cmd_ifconfig(int argc, char **argv)
 			else if (strstr(hostip, ":") != NULL) {
 				ip6_addr_t temp;
 				s8_t idx;
-				int result;
 
 				netif = netif_find(intf);
 				if (netif) {
@@ -380,7 +379,7 @@ int cmd_ifconfig(int argc, char **argv)
 					netif_set_ip6_autoconfig_enabled(netif, 1);
 #endif /* CONFIG_NET_IPv6_AUTOCONFIG */
 					/* add static ipv6 address */
-					result = netif_add_ip6_address(netif, &temp, &idx);
+					(void)netif_add_ip6_address(netif, &temp, &idx);
 
 #ifdef CONFIG_NET_IPv6_MLD
 					ip6_addr_t solicit_addr;

--- a/apps/system/utils/netcmd_dhcpd.c
+++ b/apps/system/utils/netcmd_dhcpd.c
@@ -65,6 +65,7 @@
 #include <net/if.h>
 
 #include <protocols/dhcpd.h>
+#include <netutils/netlib.h>
 
 /****************************************************************************
  * Preprocessor Definitions

--- a/external/include/protocols/dhcpd.h
+++ b/external/include/protocols/dhcpd.h
@@ -91,6 +91,13 @@ extern "C" {
 typedef void (*dhcp_sta_joined)(void);
 
 /**
+ * @brief Get DHCP server status which means server is running or not.
+ *
+ * @return When server is running, returns 1. When stopped, returns 0.
+*/
+int dhcpd_status(void);
+
+/**
  * @brief Starts DHCP server which is attached given network interface.
  *
  * @param[in] intf the name of network interface to run DHCP server
@@ -105,6 +112,11 @@ int dhcpd_run(void *arg);
  * @return On success, 0. On failure, returns -1
 */
 int dhcpd_start(char *intf, dhcp_sta_joined dhcp_join_cb);
+
+/**
+ * @brief Stops DHCP server.
+*/
+void dhcpd_stop(void);
 
 #undef EXTERN
 #ifdef __cplusplus

--- a/external/ntpclient/ntpclient.c
+++ b/external/ntpclient/ntpclient.c
@@ -72,6 +72,7 @@
 #include <errno.h>
 #include <debug.h>
 #include <netinet/in.h>
+#include <arpa/inet.h>
 #include <protocols/ntpclient.h>
 #include <netdb.h>
 #include "ntpv3.h"


### PR DESCRIPTION
netcmd.c: In function 'cmd_ifconfig':
netcmd.c:359:9: warning: variable 'result' set but not used [-Wunused-but-set-variable]
     int result;
         ^~~~~~
 => remove the result variable

CC:  netcmd_dhcpd.c
netcmd_dhcpd.c: In function 'cmd_dhcpd':
netcmd_dhcpd.c:131:7: warning: implicit declaration of function 'dhcpd_status' [-Wimplicit-function-declaration]
   if (dhcpd_status()) {
       ^~~~~~~~~~~~
 => add prototype at protocol/dhcpd.h

netcmd_dhcpd.c:137:7: warning: implicit declaration of function 'netlib_getifstatus' [-Wimplicit-function-declaration]
   if (netlib_getifstatus(argv[2], &flags) == ERROR) {
       ^~~~~~~~~~~~~~~~~~
 => include <netutils/netlib.h>

netcmd_dhcpd.c:158:4: warning: implicit declaration of function 'dhcpd_stop' [-Wimplicit-function-declaration]
    dhcpd_stop();
    ^~~~~~~~~~
 => add prototype at protocol/dhcpd.h

ntpclient.c: In function 'ntpc_daemon':
ntpclient.c:395:21: warning: implicit declaration of function 'htons' [-Wimplicit-function-declaration]
   server.sin_port = htons(g_ntps.server[srv_index].conn.port);
                     ^~~~~
 => include <arpa/inet.h>