### PR TITLE
framework/task_manager: Fix dereferencing error and Add return when m…

### DIFF
--- a/framework/src/task_manager/task_manager_register.c
+++ b/framework/src/task_manager/task_manager_register.c
@@ -161,6 +161,7 @@ int task_manager_register_pthread(char *name, pthread_attr_t *attr, pthread_star
 	if (((tm_pthread_info_t *)request_msg.data)->attr == NULL) {
 		TM_FREE(((tm_pthread_info_t *)request_msg.data)->name);
 		TM_FREE(request_msg.data);
+		return TM_OUT_OF_MEMORY;
 	}
 	memcpy(((tm_pthread_info_t *)request_msg.data)->attr, attr, sizeof(pthread_attr_t));
 	((tm_pthread_info_t *)request_msg.data)->entry = start_routine;

--- a/framework/src/task_manager/task_manager_set_callback.c
+++ b/framework/src/task_manager/task_manager_set_callback.c
@@ -265,8 +265,8 @@ int task_manager_set_exit_cb(void (*func)(void *data), tm_msg_t *cb_data)
 		REQ_CBDATA_MSG_SIZE(request_msg) = cb_data->msg_size;
 		REQ_CBDATA_MSG(request_msg) = TM_ALLOC(cb_data->msg_size);
 		if (REQ_CBDATA_MSG(request_msg) == NULL) {
-			TM_FREE(request_msg.data);
 			TM_FREE(REQ_CBDATA(request_msg));
+			TM_FREE(request_msg.data);
 			return TM_OUT_OF_MEMORY;
 		}
 		memcpy(REQ_CBDATA_MSG(request_msg), cb_data->msg, cb_data->msg_size);


### PR DESCRIPTION
…emory alloc fail case.

1. WID:8421966 Pointer '&request_msg.data->attr' is dereferenced at task_manager_register.c:165 after the referenced memory was deallocated at task_manager_register.c:163 by calling function 'free'.
2. WID:8421968 Pointer '&request_msg.data->cb_data' is dereferenced at task_manager_set_callback.c:242 after the referenced memory was deallocated at task_manager_set_callback.c:241 by calling function 'free'.