### PR TITLE
 framework/task_manager: Add procedures for NULL setting after free

### DIFF
--- a/framework/src/task_manager/task_manager_core.c
+++ b/framework/src/task_manager/task_manager_core.c
@@ -1279,7 +1279,9 @@ int task_manager_run_exit_cb(int pid)
 			if (EXIT_CBDATA(handle) != NULL) {
 				(*EXIT_CBFUNC(handle))(EXIT_CBDATA_MSG(handle));
 				TM_FREE(EXIT_CBDATA_MSG(handle));
+				EXIT_CBDATA_MSG(handle) = NULL;
 				TM_FREE(EXIT_CBDATA(handle));
+				EXIT_CBDATA(handle) = NULL;
 			} else {
 				(*EXIT_CBFUNC(handle))(NULL);
 			}


### PR DESCRIPTION
1. If not set to NULL after free, callback msg and callback data can be treated as having data, even they are empty.
2. testcase/task_manager: Modify return check for stop task and Add semaphore for callback flag