### PR TITLE
apps/examples/network: Avoid buffer overflow of wm_test and Add missing close socket in network_tc

### DIFF
--- a/apps/examples/testcase/le_tc/network/tc_net_getpeername.c
+++ b/apps/examples/testcase/le_tc/network/tc_net_getpeername.c
@@ -276,6 +276,7 @@ void *getpeername_client(void *args)
 	ret = connect(mysocket, (struct sockaddr *)&dest, sizeof(struct sockaddr));
 	if (ret < 0) {
 		printf("connect fail %s %d\n", __FUNCTION__, __LINE__);
+		close(mysocket);
 		return 0;
 	}
 

--- a/apps/examples/wifi_manager_sample/wm_test.c
+++ b/apps/examples/wifi_manager_sample/wm_test.c
@@ -237,10 +237,18 @@ void print_wifi_ap_profile(wifi_manager_ap_config_s *config, char *title)
 	}
 	printf("------------------------------------\n");
 	printf("SSID: %s\n", config->ssid);
-	printf("SECURITY TYPE: %s\n", wifi_test_auth_method[config->ap_auth_type]);
-	/*if (config->ap_auth_type != WIFI_MANAGER_AUTH_OPEN) {
-		printf("PASSWORD: %s\n", config->passphrase);
-		}*/
+	switch (config->ap_auth_type) {
+	case WIFI_MANAGER_AUTH_OPEN:
+	case WIFI_MANAGER_AUTH_WEP_SHARED:
+	case WIFI_MANAGER_AUTH_WPA_PSK:
+	case WIFI_MANAGER_AUTH_WPA2_PSK:
+	case WIFI_MANAGER_AUTH_WPA_AND_WPA2_PSK:
+		printf("SECURITY TYPE: %s\n", wifi_test_auth_method[config->ap_auth_type]);
+		break;
+	default:
+		printf("SECURITY TYPE: unknown\n");
+		break;
+	}
 	printf("====================================\n");
 }
 


### PR DESCRIPTION
apps/examples/wm_test: Fix svace issue of wm_test (major issues)
- Add a logic to verify that ap_auth_type is vaild, not to make an overflow in print_wifi_ap_profile function

apps/network_tc: Fix svace issue in getpeername (critical issue)
- Add close socket before return in getpeername_client function