### PR TITLE
apps/examples/network_tc: Add a missing socket close

### DIFF
--- a/apps/examples/testcase/le_tc/network/tc_net_getpeername.c
+++ b/apps/examples/testcase/le_tc/network/tc_net_getpeername.c
@@ -276,6 +276,7 @@ void *getpeername_client(void *args)
 	ret = connect(mysocket, (struct sockaddr *)&dest, sizeof(struct sockaddr));
 	if (ret < 0) {
 		printf("connect fail %s %d\n", __FUNCTION__, __LINE__);
+		close(mysocket);
 		return 0;
 	}
 


### PR DESCRIPTION
- Add a logic to close the socket before return in getpeername_client function