### PR TITLE
docker/dbuild.sh: change docker options for sevral build env.

### DIFF
--- a/os/dbuild.sh
+++ b/os/dbuild.sh
@@ -287,9 +287,15 @@ function BUILD()
 		mv build.log build.log.old
 	fi
 
+	if [ "$1" == "menuconfig" ]; then
+		DOCKER_OPT="-it"
+	else
+		DOCKER_OPT="-i"
+	fi
+	
 	docker rm -f tizenrt > /dev/null 2>&1
-	docker run --rm -it -d -v ${TOPDIR}:/root/tizenrt --name tizenrt -w /root/tizenrt/os tizenrt/tizenrt /bin/bash
-	docker exec -it tizenrt ${BUILD_CMD} $1 2>&1 | tee build.log
+	docker run --rm ${DOCKER_OPT} -d -v ${TOPDIR}:/root/tizenrt --name tizenrt -w /root/tizenrt/os tizenrt/tizenrt /bin/bash
+	docker exec ${DOCKER_OPT} tizenrt ${BUILD_CMD} $1 2>&1 | tee build.log
 	docker stop tizenrt > /dev/null 2>&1
 
 	if [ "$1" == "distclean" ]; then


### PR DESCRIPTION
- '-it' option is only for 'menuconfig'
- in general, '-i' would be used.