### PR TITLE
dbuild: add applist and appupdate support

### DIFF
--- a/os/dbuild.sh
+++ b/os/dbuild.sh
@@ -98,6 +98,9 @@ function SELECT_OPTION()
 		x|exit)
 			exit 1
 			;;
+		applist|appupdate)
+			BUILD ${SELECTED_START}
+			;;
 		*)
 			;;
 		esac


### PR DESCRIPTION
The applist and appupdate are hidden menu of make, because
only IDE uses them. For IDE, in build option selection,
if you type applist or appupdate or ./dbuild.sh applist (appupdate),
it will work.

Signed-off-by: sunghan-chang <sh924.chang@samsung.com>