### PR TITLE
testcase/audio: Fix audio_utc error

### DIFF
--- a/apps/examples/testcase/ta_tc/audio/utc/utc_audio_main.c
+++ b/apps/examples/testcase/ta_tc/audio/utc/utc_audio_main.c
@@ -1528,7 +1528,7 @@ int utc_audio_main(int argc, char *argv[])
 	utc_audio_pcm_mmap_read_p();
 	utc_audio_pcm_mmap_write_p();
 #endif
-
+	clean_all_data(0, NULL);
 	/* after test, unlink the file */
 	unlink(AUDIO_TEST_FILE);
 


### PR DESCRIPTION
An error occurs when audio_utc executes twice.
because it dose not do pcm_close when end.
so added pcm_close.