### PR TITLE
media/utc: Restore volume after test

### DIFF
--- a/apps/examples/testcase/ta_tc/media/utc/utc_media_mediaplayer.cpp
+++ b/apps/examples/testcase/ta_tc/media/utc/utc_media_mediaplayer.cpp
@@ -408,18 +408,20 @@ static void utc_media_MediaPlayer_getVolume_n(void)
 
 static void utc_media_MediaPlayer_setVolume_p(void)
 {
-	uint8_t volume;
+	uint8_t prev, volume;
 	media::MediaPlayer mp;
 	std::unique_ptr<media::stream::FileInputDataSource> source = std::move(std::unique_ptr<media::stream::FileInputDataSource>(new media::stream::FileInputDataSource(dummyfilepath)));
 	mp.create();
 	mp.setDataSource(std::move(source));
 	mp.prepare();
+	mp.getVolume(&prev);
 
-	auto ret = mp.setVolume(0);
-	TC_ASSERT_EQ("utc_media_MediaPlayer_setVolume", ret, media::PLAYER_OK);
+	TC_ASSERT_EQ_CLEANUP("utc_media_MediaPlayer_setVolume", mp.setVolume(0), media::PLAYER_OK, goto cleanup);
 	mp.getVolume(&volume);
-	TC_ASSERT_EQ("utc_media_MediaPlayer_setVolume", volume, 0);
+	TC_ASSERT_EQ_CLEANUP("utc_media_MediaPlayer_setVolume", volume, 0, goto cleanup);
 
+cleanup:
+	mp.setVolume(prev);
 	mp.unprepare();
 	mp.destroy();
 	TC_SUCCESS_RESULT();

--- a/apps/examples/testcase/ta_tc/media/utc/utc_media_mediarecorder.cpp
+++ b/apps/examples/testcase/ta_tc/media/utc/utc_media_mediarecorder.cpp
@@ -105,12 +105,20 @@ static void utc_media_MediaRecorder_setDataSource_n(void)
 
 static void utc_media_MediaRecorder_setVolume_p(void)
 {
+	uint8_t prev, volume;
 	MediaRecorder mr;
 	unique_ptr<FileOutputDataSource> dataSource = unique_ptr<FileOutputDataSource>(new FileOutputDataSource(channels, sampleRate, pcmFormat, filePath));
 	mr.create();
 	mr.setDataSource(std::move(dataSource));
 	mr.prepare();
-	TC_ASSERT_EQ("utc_media_mediarecorder_setVolume", mr.setVolume(10), RECORDER_OK);
+	mr.getVolume(&prev);
+
+	TC_ASSERT_EQ_CLEANUP("utc_media_mediarecorder_setVolume", mr.setVolume(10), RECORDER_OK, goto cleanup);
+	mr.getVolume(&volume);
+	TC_ASSERT_EQ_CLEANUP("utc_media_mediarecorder_setVolume", volume, 10, goto cleanup);
+
+cleanup:
+	mr.setVolume(prev);
 	mr.unprepare();
 	mr.destroy();
 	TC_SUCCESS_RESULT();
@@ -118,13 +126,18 @@ static void utc_media_MediaRecorder_setVolume_p(void)
 
 static void utc_media_MediaRecorder_setVolume_n(void)
 {
+	uint8_t prev;
 	MediaRecorder mr;
 	unique_ptr<FileOutputDataSource> dataSource = unique_ptr<FileOutputDataSource>(new FileOutputDataSource(channels, sampleRate, pcmFormat, filePath));
 	TC_ASSERT_EQ("utc_media_mediarecorder_setVolume", mr.setVolume(10), RECORDER_ERROR_NOT_ALIVE);
 	mr.create();
 	mr.setDataSource(std::move(dataSource));
 	mr.prepare();
-	TC_ASSERT_EQ("utc_media_mediarecorder_setVolume", mr.setVolume(11), RECORDER_OK);
+	mr.getVolume(&prev);
+	TC_ASSERT_EQ_CLEANUP("utc_media_mediarecorder_setVolume", mr.setVolume(11), RECORDER_OK, goto cleanup);
+
+cleanup:
+	mr.setVolume(prev);
 	mr.unprepare();
 	mr.destroy();
 	TC_SUCCESS_RESULT();


### PR DESCRIPTION
Before testing setVolume, save previous volume and restore after test