### PR TITLE
drivers/audio: fix coding rule violations

### DIFF
--- a/os/drivers/audio/alc5658.c
+++ b/os/drivers/audio/alc5658.c
@@ -852,7 +852,7 @@ static int alc5658_configure(FAR struct audio_lowerhalf_s *dev, FAR const struct
 
 	case AUDIO_TYPE_PROCESSING:
 		break;
-	default :
+	default:
 		ret = -EINVAL;
 		break;
 	}

--- a/os/drivers/audio/audio_null.c
+++ b/os/drivers/audio/audio_null.c
@@ -853,7 +853,7 @@ static int null_enqueuebuffer(FAR struct audio_lowerhalf_s *dev, FAR struct ap_b
 	FAR struct null_dev_s *priv = (FAR struct null_dev_s *)dev;
 	bool done;
 
-    audvdbg("apb=%p curbyte=%d nbytes=%d nmaxbytes %d\n", apb, apb->curbyte, apb->nbytes, apb->nmaxbytes);
+	audvdbg("apb=%p curbyte=%d nbytes=%d nmaxbytes %d\n", apb, apb->curbyte, apb->nbytes, apb->nmaxbytes);
 
 	/* Say that we consumed all of the data */
 


### PR DESCRIPTION
alc5658.c line 855 : space prohibited before that ':'
audio_null.c line 856 : please, no spaces at the start of a line

Signed-off-by: sunghan-chang <sh924.chang@samsung.com>