### PR TITLE
 framework/wifi_manager: Add configurations for autoconnect operation

### DIFF
--- a/external/include/slsi_wifi/slsi_wifi_api.h
+++ b/external/include/slsi_wifi/slsi_wifi_api.h
@@ -421,6 +421,15 @@ int8_t WiFiSetCountryCode(const char *country_code);
  */
 int8_t WiFiSaveConfig(void);
 
+/**
+ * Request to set the autoconnect of external driver.
+ *	@check		1 for enabling and 0 for disabling external autoconnect
+ * Return: Completed successfully or failed
+ *
+ *   Will set external autoconnect enabled or disabled
+ */
+int8_t WiFiSetAutoconnect(uint8_t check);
+
 #undef EXTERN
 #ifdef  __cplusplus
 }

--- a/external/slsi_wifi/slsi_wifi_api.c
+++ b/external/slsi_wifi/slsi_wifi_api.c
@@ -3125,10 +3125,10 @@ static int8_t slsi_init(WiFi_InterFace_ID_t interface_id, const slsi_ap_config_t
 			slsi_set_updateconfig();
 			slsi_set_scan_interval(SLSI_SCAN_INTERVAL);
 			slsi_set_bss_expiration();
-			if (interface_id == SLSI_WIFI_SOFT_AP_IF) {
-				slsi_set_autoconnect(0);
-			} else {
+			if (interface_id == SLSI_WIFI_STATION_IF) {
 				slsi_set_autoconnect(1);
+			} else {
+				slsi_set_autoconnect(0);
 			}
 
 		} else {
@@ -3698,3 +3698,24 @@ int8_t WiFiSaveConfig(void)
 #endif
 	return result;
 }
+
+int8_t WiFiSetAutoconnect(uint8_t check)
+{
+	int8_t result = SLSI_STATUS_NOT_SUPPORTED;
+
+	ENTER_CRITICAL;
+	if (slsi_get_op_mode() == SLSI_WIFI_STATION_IF) {
+		DPRINT("WiFiSetAutoconnect - set to %d\n", (int)check);
+		slsi_set_autoconnect(check);
+		result = SLSI_STATUS_SUCCESS;
+	} else if (g_state == SLSI_WIFIAPI_STATE_NOT_STARTED) {
+		DPRINT("WiFiSetAutoconnect - not started\n");
+	} else {
+		DPRINT("WiFiSetAutoconnect - not allowed during AP mode\n");
+		result = SLSI_STATUS_NOT_ALLOWED;
+	}
+	LEAVE_CRITICAL;
+
+	return result;
+}
+

--- a/framework/src/wifi_manager/Kconfig
+++ b/framework/src/wifi_manager/Kconfig
@@ -70,5 +70,16 @@ config WIFIMGR_DISABLE_AUTO_GET_IP
 	bool "disable auto get ip (ipv4 dhcp)"
 	default n
 
+config DISABLE_EXTERNAL_AUTOCONNECT
+	bool "disable external autoconnect"
+	default n
+
+if DISABLE_EXTERNAL_AUTOCONNECT
+config WIFIMGR_INTERNAL_AUTOCONNECT
+	bool "enable internal auto(re)connect"
+	default y
+
+endif #WIFIMGR_DISABLE_EXTERNAL_AUTOCONNECT
+
 endif #WIFI_MANAGER
 

--- a/framework/src/wifi_manager/wifi_manager.c
+++ b/framework/src/wifi_manager/wifi_manager.c
@@ -147,7 +147,13 @@ typedef struct _wifimgr_info _wifimgr_info_s;
 
 #define WIFIMGR_MAX_CONN_RETRIES 10
 #define WIFIMGR_IPC_PORT 9098
+
+/* Check if external wifi driver supports auto(re)connect */
+#ifndef CONFIG_DISABLE_EXTERNAL_AUTOCONNECT
 #define WIFIDRIVER_SUPPORT_AUTOCONNECT 1
+#else
+#define WIFIDRIVER_SUPPORT_AUTOCONNECT 0
+#endif
 
 #define WIFIMGR_CHECK_STATE(s) ((s) != g_manager_info.state)
 #define WIFIMGR_IS_STATE(s) ((s) == g_manager_info.state)
@@ -319,7 +325,13 @@ typedef struct _wifimgr_info _wifimgr_info_s;
 #define WM_LOG_HANDLER_START nvdbg("[WM] T%d %s:%d state(%d) evt(%d)\n", getpid(), __FUNCTION__, __LINE__, g_manager_info.state, msg->event);
 #define WM_APINFO_INITIALIZER {{0,}, 0, {0,}, 0, WIFI_MANAGER_AUTH_UNKNOWN, WIFI_MANAGER_CRYPTO_UNKNOWN}
 #define WM_RECONN_INITIALIZER {WIFI_RECONN_NONE, -1, -1}
+
+#ifdef CONFIG_WIFIMGR_INTERNAL_AUTOCONNECT
 #define WIFIMGR_DEFAULT_CONN_CONFIG {WIFI_RECONN_INTERVAL, 77, 128}
+#else
+#define WIFIMGR_DEFAULT_CONN_CONFIG {WIFI_RECONN_NONE, -1, -1}
+#endif
+
 #define WIFIMGR_SOTFAP_CONFIG {{0,}, {0,}, 1}
 
 /**
@@ -706,7 +718,11 @@ wifi_manager_result_e _wifimgr_run_sta(void)
 {
 	WM_LOG_START;
 	WIFIMGR_CHECK_UTILRESULT(wifi_utils_start_sta(), "[WM] Starting STA failed.", WIFI_MANAGER_FAIL);
-
+#if WIFIDRIVER_SUPPORT_AUTOCONNECT
+	WIFIMGR_CHECK_UTILRESULT(wifi_utils_set_autoconnect(1), "[WM] Set Autoconnect failed", WIFI_MANAGER_FAIL);
+#else
+	WIFIMGR_CHECK_UTILRESULT(wifi_utils_set_autoconnect(0), "[WM] Set Autoconnect failed", WIFI_MANAGER_FAIL);
+#endif
 	return WIFI_MANAGER_SUCCESS;
 }
 
@@ -888,6 +904,12 @@ wifi_manager_result_e _handler_on_uninitialized_state(_wifimgr_msg_s *msg)
 	}
 #endif
 	WIFIMGR_CHECK_UTILRESULT(wifi_utils_init(), "[WM] wifi_utils_init fail\n", WIFI_MANAGER_FAIL);
+#if WIFIDRIVER_SUPPORT_AUTOCONNECT
+	WIFIMGR_CHECK_UTILRESULT(wifi_utils_set_autoconnect(1), "[WM] Set Autoconnect failed", WIFI_MANAGER_FAIL);
+#else
+	WIFIMGR_CHECK_UTILRESULT(wifi_utils_set_autoconnect(0), "[WM] Set Autoconnect failed", WIFI_MANAGER_FAIL);
+#endif
+
 	WIFIMGR_CHECK_UTILRESULT(wifi_profile_init(), "[WM] wifi_profile init fail\n", WIFI_MANAGER_FAIL);
 	wifi_manager_cb_s *cb = (wifi_manager_cb_s *)msg->param;
 	wifi_utils_cb_s util_cb = {
@@ -1059,15 +1081,9 @@ wifi_manager_result_e _handler_on_connected_state(_wifimgr_msg_s *msg)
 			WIFIMGR_SET_STATE(WIFIMGR_STA_RECONNECT);
 		}
 #else /* WIFIDRIVER_SUPPORT_AUTOCONNECT */
-		if (g_manager_info.conn_config.type == WIFI_RECONN_NONE) {
-			_handle_user_cb(CB_STA_DISCONNECTED, NULL);
-			WIFIMGR_CHECK_RESULT(_wifimgr_disconnect_ap(), "critical error", WIFI_MANAGER_FAIL);
-			WIFIMGR_SET_STATE(WIFIMGR_STA_DISCONNECTED);
-		} else {
-			ndbg("[WM] AUTOCONNECT: go to RECONNECT state\n");
-			_handle_user_cb(CB_STA_RECONNECTED, NULL);
-			WIFIMGR_SET_STATE(WIFIMGR_STA_RECONNECT);
-		}
+		ndbg("[WM] AUTOCONNECT: go to RECONNECT state\n");
+		_handle_user_cb(CB_STA_RECONNECTED, NULL);
+		WIFIMGR_SET_STATE(WIFIMGR_STA_RECONNECT);
 #endif /* WIFIDRIVER_SUPPORT_AUTOCONNECT */
 	} else if (msg->event == EVT_SET_SOFTAP) {
 		WIFIMGR_CHECK_RESULT(_wifimgr_disconnect_ap(), "critical error", WIFI_MANAGER_FAIL);

--- a/framework/src/wifi_manager/wifi_utils.h
+++ b/framework/src/wifi_manager/wifi_utils.h
@@ -230,4 +230,15 @@ wifi_utils_result_e wifi_utils_start_sta(void);
  */
 wifi_utils_result_e wifi_utils_stop_softap(void);
 
+/**
+ * @brief enable/disable external autoconnect
+ *
+ * @param[in]   check :  enable/disable external autoconnect
+ *
+ * @return WIFI_UTILS_SUCCESS       :  success
+ * @return WIFI_UTILS_FAIL          :  fail
+ */
+wifi_utils_result_e wifi_utils_set_autoconnect(uint8_t check);
+
+
 #endif							//WIFI_UTILS_H

--- a/framework/src/wifi_manager/wpa_wifi_utils.c
+++ b/framework/src/wifi_manager/wpa_wifi_utils.c
@@ -614,3 +614,17 @@ wifi_utils_result_e wifi_utils_stop_softap(void)
 	}
 	return wuret;
 }
+
+wifi_utils_result_e wifi_utils_set_autoconnect(uint8_t check)
+{
+	wifi_utils_result_e wuret = WIFI_UTILS_FAIL;
+	int ret = WiFiSetAutoconnect(check);
+	if (ret == SLSI_STATUS_SUCCESS) {
+		wuret = WIFI_UTILS_SUCCESS;
+		ndbg("[WU] External Autoconnect set to %d\n", check);
+	} else {
+		ndbg("[WU] External Autoconnect failed to set %d", check);
+	}
+	return wuret;
+}
+


### PR DESCRIPTION
framework/wifi_manager: 
1. WIFIMGR_DISABLE_EXTERNAL_AUTOCONNECT, to disable an external autoconnect operation defined in wifi dirver
2. WIFIMGR_ENABLE_INTERNAL_AUTOCONNECT, to enable an internal autoconnect operation defined in Wi-Fi Manager
3. WIFIMGR_INTERNAL_AUTOCONNECT_INTERVAL, to set an interval of internal autoconnect operation

external/slsi_wifi: 
1. Add definition of WPA_AUTOCONNECT to enable/disable WPA's AUTOCONNECT operation