### PR TITLE
kernel/task_restart : Restarted was had sigprocmask set.

### DIFF
--- a/os/kernel/task/task_restart.c
+++ b/os/kernel/task/task_restart.c
@@ -199,9 +199,12 @@ int task_restart(pid_t pid)
 		tcb->cmn.task_state = TSTATE_TASK_INVALID;
 		irqrestore(state);
 
+#ifndef CONFIG_DISABLE_SIGNALS
 		/* Deallocate anything left in the TCB's queues */
 
 		sig_cleanup((FAR struct tcb_s *)tcb);	/* Deallocate Signal lists */
+		tcb->cmn.sigprocmask = NULL_SIGNAL_SET;
+#endif
 
 		/* Reset the current task priority  */
 


### PR DESCRIPTION
After restarting the task, sigprocmask should be restored.