### PR TITLE
framework/task_manager : Modify to unregister based on task status

### DIFF
--- a/framework/src/task_manager/Kconfig
+++ b/framework/src/task_manager/Kconfig
@@ -8,6 +8,8 @@ config TASK_MANAGER
 	default n
 	select BUILTIN_APPS
 	select SCHED_ATEXIT
+	select SCHED_WORKQUEUE if !BUILD_PROTECTED
+	select LIB_USRWORK if BUILD_PROTECTED
 	depends on !DISABLE_SIGNALS && !DISABLE_MQUEUE && TASK_NAME_SIZE != 0
 	---help---
 		Enables Task Manager.


### PR DESCRIPTION
if task is not stopped yet(task status is TM_APP_STATE_CANCELLING), unregister is passed to lpwork.
if task is stopped well, unregister the information immediately.