### PR TITLE
framework/task_manager: Remove setting sigprocmask to NULL after restart

### DIFF
--- a/framework/src/task_manager/task_manager_core.c
+++ b/framework/src/task_manager/task_manager_core.c
@@ -419,7 +419,6 @@ static int taskmgr_stop(int handle, int caller_pid)
 static int taskmgr_restart(int handle, int caller_pid)
 {
 	int ret;
-	int fd;
 
 	if (IS_INVALID_HANDLE(handle) || caller_pid < 0) {
 		return TM_INVALID_PARAM;
@@ -464,16 +463,6 @@ static int taskmgr_restart(int handle, int caller_pid)
 	ret = task_restart(TM_PID(handle));
 	if (ret != OK) {
 		tmdbg("Fail to restart the task\n");
-		return TM_OPERATION_FAIL;
-	}
-
-	fd = taskmgr_get_drvfd();
-	if (fd < 0) {
-		return TM_INVALID_DRVFD;
-	}
-
-	ret = ioctl(fd, TMIOC_RESTART, TM_PID(handle));
-	if (ret != OK) {
 		return TM_OPERATION_FAIL;
 	}
 

--- a/os/drivers/task_manager/task_manager_drv.c
+++ b/os/drivers/task_manager/task_manager_drv.c
@@ -154,15 +154,6 @@ static int taskmgr_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
 			ret = OK;
 		}
 		break;
-	case TMIOC_RESTART:
-		tcb = sched_gettcb((int)arg);
-		if (tcb == NULL) {
-			tmdbg("No task with this pid %d.\n", (int)arg);
-			return ERROR;
-		}
-		(void)sigprocmask(SIG_SETMASK, NULL, &tcb->sigprocmask);
-		ret = OK;
-		break;
 	case TMIOC_BROADCAST:
 		tcb = sched_gettcb((int)arg);
 		if (tcb == NULL) {

--- a/os/include/tinyara/fs/ioctl.h
+++ b/os/include/tinyara/fs/ioctl.h
@@ -361,11 +361,10 @@
 #define TMIOC_START                _TMIOC(0x0001)
 #define TMIOC_PAUSE                _TMIOC(0x0002)
 #define TMIOC_RESUME               _TMIOC(0x0003)
-#define TMIOC_RESTART              _TMIOC(0x0004)
-#define TMIOC_UNICAST              _TMIOC(0x0005)
-#define TMIOC_BROADCAST            _TMIOC(0x0006)
-#define TMIOC_CHECK_ALIVE          _TMIOC(0x0007)
-#define TMIOC_TERMINATE            _TMIOC(0x0008)
+#define TMIOC_UNICAST              _TMIOC(0x0004)
+#define TMIOC_BROADCAST            _TMIOC(0x0005)
+#define TMIOC_CHECK_ALIVE          _TMIOC(0x0006)
+#define TMIOC_TERMINATE            _TMIOC(0x0007)
 
 /****************************************************************************
  * Public Type Definitions


### PR DESCRIPTION
after task_restart, sigprocmask sets to NULL by default.
So task manager does not need to set.