### PR TITLE
external/websocket: modify Makefile to remove unremoved objects

### DIFF
--- a/external/websocket/Makefile
+++ b/external/websocket/Makefile
@@ -53,13 +53,13 @@
 -include $(TOPDIR)/.config
 -include $(TOPDIR)/Make.defs
 
-ASRCS		=
-CSRCS		= websocket.c
+ASRCS   =
+CSRCS   = websocket.c
 
-CSRCS += wslay/wslay_net.c \
-	  wslay/wslay_queue.c \
-	  wslay/wslay_frame.c \
-	  wslay/wslay_event.c
+DEPPATH = --dep-path .
+VPATH   =
+
+include wslay/Make.defs
 
 AOBJS		= $(ASRCS:.S=$(OBJEXT))
 COBJS		= $(CSRCS:.c=$(OBJEXT))
@@ -76,12 +76,6 @@ else
   BIN		= ../libexternal$(LIBEXT)
 endif
 endif
-
-DEPPATH	= --dep-path .
-
-# Common build
-
-VPATH		=
 
 all: .built
 .PHONY: depend clean distclean

--- a/external/websocket/wslay/Make.defs
+++ b/external/websocket/wslay/Make.defs
@@ -1,0 +1,25 @@
+###########################################################################
+#
+# Copyright 2018 Samsung Electronics All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+#
+###########################################################################
+
+CSRCS += wslay_net.c \
+	wslay_queue.c \
+	wslay_frame.c \
+	wslay_event.c
+
+DEPPATH += --dep-path wslay
+VPATH += :wslay


### PR DESCRIPTION
The websocket builds wslay c files but they are not removed
when clean/distclean build is executed.
And it is better to maintain in each folder.
This commit adds Make.defs in wslay folder and Makefile of
websocket uses it.

Signed-off-by: sunghan-chang <sh924.chang@samsung.com>