### PR TITLE
framework/wifi_manager: Security type and phy mode management

### DIFF
--- a/apps/examples/wifi_manager_sample/wm_test_stress.c
+++ b/apps/examples/wifi_manager_sample/wm_test_stress.c
@@ -118,8 +118,9 @@ void wm_scan_done(wifi_manager_scan_info_s **scan_result, wifi_manager_scan_resu
 	}
 	wifi_manager_scan_info_s *wifi_scan_iter = *scan_result;
 	while (wifi_scan_iter != NULL) {
-		printf("WiFi AP SSID: %-20s, WiFi AP BSSID: %-20s, WiFi Rssi: %d\n",
-			   wifi_scan_iter->ssid, wifi_scan_iter->bssid, wifi_scan_iter->rssi);
+		printf("WiFi AP SSID: %-20s, WiFi AP BSSID: %-20s, WiFi Rssi: %d, AUTH: %d, CRYPTO: %d\n",
+			   wifi_scan_iter->ssid, wifi_scan_iter->bssid, wifi_scan_iter->rssi,
+			   wifi_scan_iter->ap_auth_type, wifi_scan_iter->ap_crypto_type);
 		wifi_scan_iter = wifi_scan_iter->next;
 	}
 	WM_TEST_SIGNAL;

--- a/framework/include/wifi_manager/wifi_manager.h
+++ b/framework/include/wifi_manager/wifi_manager.h
@@ -42,6 +42,19 @@ extern "C" {
 #define WIFIMGR_PASSPHRASE_LEN     64
 
 /**
+  * @brief <b> wifi MAC/PHY standard types
+  */
+typedef enum {
+	WIFI_MANAGER_IEEE_80211_LEGACY,             /**<  IEEE 802.11a/g/b           */
+	WIFI_MANAGER_IEEE_80211_A,                  /**<  IEEE 802.11a               */
+	WIFI_MANAGER_IEEE_80211_B,                  /**<  IEEE 802.11b               */
+	WIFI_MANAGER_IEEE_80211_G,                  /**<  IEEE 802.11g               */
+	WIFI_MANAGER_IEEE_80211_N,                  /**<  IEEE 802.11n               */
+	WIFI_MANAGER_IEEE_80211_AC,                 /**<  IEEE 802.11ac              */
+	WIFI_MANAGER_NOT_SUPPORTED,                 /**<  Driver does not report     */
+} wifi_manager_standard_type_e;
+
+/**
  * @brief Status of Wi-Fi interface such as connected or disconnected
  */
 typedef enum {
@@ -118,6 +131,11 @@ typedef enum {
 	WIFI_MANAGER_AUTH_WPA_PSK,				   /**<  WPA_PSK mode                   */
 	WIFI_MANAGER_AUTH_WPA2_PSK,				   /**<  WPA2_PSK mode                  */
 	WIFI_MANAGER_AUTH_WPA_AND_WPA2_PSK,		   /**<  WPA_PSK and WPA_PSK mixed mode */
+	WIFI_MANAGER_AUTH_WPA_PSK_ENT,			 /**<  Enterprise WPA_PSK mode                   */
+	WIFI_MANAGER_AUTH_WPA2_PSK_ENT,			 /**<  Enterprise WPA2_PSK mode                  */
+	WIFI_MANAGER_AUTH_WPA_AND_WPA2_PSK_ENT,	 /**<  Enterprise WPA_PSK and WPA_PSK mixed mode */
+	WIFI_MANAGER_AUTH_IBSS_OPEN,               /**<  IBSS ad-hoc mode               */
+	WIFI_MANAGER_AUTH_WPS,					 /**<  WPS mode                       */
 	WIFI_MANAGER_AUTH_UNKNOWN,				   /**<  unknown type                   */
 } wifi_manager_ap_auth_type_e;
 
@@ -131,6 +149,9 @@ typedef enum {
 	WIFI_MANAGER_CRYPTO_AES,				   /**<  AES encryption                 */
 	WIFI_MANAGER_CRYPTO_TKIP,				   /**<  TKIP encryption                */
 	WIFI_MANAGER_CRYPTO_TKIP_AND_AES,		   /**<  TKIP and AES mixed encryption  */
+	WIFI_MANAGER_CRYPTO_AES_ENT,				 /**<  Enterprise AES encryption                 */
+	WIFI_MANAGER_CRYPTO_TKIP_ENT,				 /**<  Enterprise TKIP encryption                */
+	WIFI_MANAGER_CRYPTO_TKIP_AND_AES_ENT,		 /**<  Enterprise TKIP and AES mixed encryption  */
 	WIFI_MANAGER_CRYPTO_UNKNOWN,			   /**<  unknown encryption             */
 } wifi_manager_ap_crypto_type_e;
 
@@ -142,7 +163,7 @@ struct wifi_manager_scan_info_s {
 	char bssid[WIFIMGR_MACADDR_STR_LEN + 1];	// char string e.g. xx:xx:xx:xx:xx:xx
 	int8_t rssi;		// received signal strength indication
 	uint8_t channel;	// channel/frequency
-	uint8_t phy_mode;	// 0:legacy 1: 11N HT
+	wifi_manager_standard_type_e phy_mode;  /**< Supported MAC/PHY standard                              */
 	wifi_manager_ap_auth_type_e ap_auth_type;	  /**<  @ref wifi_utils_ap_auth_type   */
 	wifi_manager_ap_crypto_type_e ap_crypto_type;  /**<  @ref wifi_utils_ap_crypto_type */
 	struct wifi_manager_scan_info_s *next;

--- a/framework/src/wifi_manager/wifi_utils.h
+++ b/framework/src/wifi_manager/wifi_utils.h
@@ -26,6 +26,18 @@
 #define WIFI_UTILS_MACADDR_STR_LEN    17
 #define WIFI_UTILS_SSID_LEN           32
 #define WIFI_UTILS_PASSPHRASE_LEN     64
+/**
+  * @brief <b> wifi MAC/PHY standard types
+  */
+typedef enum {
+	WIFI_UTILS_IEEE_80211_LEGACY,             /**<  IEEE 802.11a/g/b          */
+	WIFI_UTILS_IEEE_80211_A,                  /**<  IEEE 802.11a              */
+	WIFI_UTILS_IEEE_80211_B,                  /**<  IEEE 802.11b              */
+	WIFI_UTILS_IEEE_80211_G,                  /**<  IEEE 802.11g              */
+	WIFI_UTILS_IEEE_80211_N,                  /**<  IEEE 802.11n              */
+	WIFI_UTILS_IEEE_80211_AC,                 /**<  IEEE 802.11ac             */
+	WIFI_UTILS_NOT_SUPPORTED,                 /**<  Driver does not report    */
+} wifi_utils_standard_type_e;
 
 /**
  * @brief <b> wifi authentication type WPA, WPA2, WPS</b>
@@ -36,6 +48,11 @@ typedef enum {
 	WIFI_UTILS_AUTH_WPA_PSK,				 /**<  WPA_PSK mode                   */
 	WIFI_UTILS_AUTH_WPA2_PSK,				 /**<  WPA2_PSK mode                  */
 	WIFI_UTILS_AUTH_WPA_AND_WPA2_PSK,		 /**<  WPA_PSK and WPA_PSK mixed mode */
+	WIFI_UTILS_AUTH_WPA_PSK_ENT,			 /**<  Enterprise WPA_PSK mode                   */
+	WIFI_UTILS_AUTH_WPA2_PSK_ENT,			 /**<  Enterprise WPA2_PSK mode                  */
+	WIFI_UTILS_AUTH_WPA_AND_WPA2_PSK_ENT,	 /**<  Enterprise WPA_PSK and WPA_PSK mixed mode */
+	WIFI_UTILS_AUTH_IBSS_OPEN,               /**<  IBSS ad-hoc mode               */
+	WIFI_UTILS_AUTH_WPS,					 /**<  WPS mode                       */
 	WIFI_UTILS_AUTH_UNKNOWN,				 /**<  unknown type                   */
 } wifi_utils_ap_auth_type_e;
 
@@ -49,6 +66,9 @@ typedef enum {
 	WIFI_UTILS_CRYPTO_AES,					 /**<  AES encryption                 */
 	WIFI_UTILS_CRYPTO_TKIP,					 /**<  TKIP encryption                */
 	WIFI_UTILS_CRYPTO_TKIP_AND_AES,			 /**<  TKIP and AES mixed encryption  */
+	WIFI_UTILS_CRYPTO_AES_ENT,				 /**<  Enterprise AES encryption                 */
+	WIFI_UTILS_CRYPTO_TKIP_ENT,				 /**<  Enterprise TKIP encryption                */
+	WIFI_UTILS_CRYPTO_TKIP_AND_AES_ENT,		 /**<  Enterprise TKIP and AES mixed encryption  */
 	WIFI_UTILS_CRYPTO_UNKNOWN,				 /**<  unknown encryption             */
 } wifi_utils_ap_crypto_type_e;
 
@@ -71,7 +91,7 @@ typedef struct {
 	unsigned char bssid[WIFI_UTILS_MACADDR_STR_LEN + 1];				  /**<  MAC address (xx:xx:xx:xx:xx:xx) of Access Point */
 	unsigned int max_rate;				  /**<  Maximum data rate in kilobits/s                        */
 	int rssi;							  /**<  Receive Signal Strength Indication in dBm              */
-	uint8_t phy_mode;					// 0:legacy 1: 11N HT
+	wifi_utils_standard_type_e phy_mode;  /**< Supported MAC/PHY standard                              */
 	wifi_utils_ap_auth_type_e ap_auth_type;	   /**<  @ref wifi_utils_ap_auth_type            */
 	wifi_utils_ap_crypto_type_e ap_crypto_type;  /**<  @ref wifi_utils_ap_crypto_type        */
 } wifi_utils_ap_scan_info_s;

--- a/framework/src/wifi_manager/wpa_wifi_utils.c
+++ b/framework/src/wifi_manager/wpa_wifi_utils.c
@@ -129,7 +129,11 @@ fetch_scan_results(wifi_utils_scan_list_s **scan_list, slsi_scan_info_t **slsi_s
 			memset(&cur->ap_info, 0x0, sizeof(wifi_utils_ap_scan_info_s));
 			cur->ap_info.rssi = wifi_scan_iter->rssi;
 			cur->ap_info.channel = wifi_scan_iter->channel;
-			cur->ap_info.phy_mode = wifi_scan_iter->phy_mode;
+			if (wifi_scan_iter->phy_mode == 1) {
+				cur->ap_info.phy_mode = WIFI_UTILS_IEEE_80211_N;
+			} else {
+				cur->ap_info.phy_mode = WIFI_UTILS_IEEE_80211_LEGACY;
+			}
 			get_security_type(wifi_scan_iter->sec_modes, wifi_scan_iter->num_sec_modes,
 			&cur->ap_info.ap_auth_type, &cur->ap_info.ap_crypto_type);
 			strncpy(cur->ap_info.ssid, (const char *)wifi_scan_iter->ssid, wifi_scan_iter->ssid_len);
@@ -493,7 +497,7 @@ wifi_utils_result_e wifi_utils_start_softap(wifi_utils_softap_config_s *softap_c
 	/* add initialization code as slsi_app */
 	ap_config->beacon_period = 100;
 	ap_config->DTIM = 1;
-	ap_config->phy_mode = 1;
+	ap_config->phy_mode = 1; //1 for 11n, 0 for legacy
 
 	if (softap_config->channel > 14 || softap_config->channel < 1) {
 		ndbg("[WU] Channel needs to be between 1 and 14" " (highest channel depends on regulatory of countries)\n");


### PR DESCRIPTION
- Add enterprise security types into wifi_manager and wifi_utils
- Modify phy_mode to denote the supported standard version