### PR TITLE
docs: Fix  *.md file for usability

### DIFF
--- a/apps/system/utils/README.md
+++ b/apps/system/utils/README.md
@@ -272,7 +272,7 @@ Application Configuration -> System Libraries and Add-Ons -> [*] Kernel shell co
 
 ## getenv/setenv/unsetenv
 These commands are related with setting or getting the environment variables.  
-The **getenv** prints all of environment variables. If specific environment name is given, this prints the value of given envionment.   
+The **getenv** prints all of environment variables. If specific environment name is given, this prints the value of given environment.   
 The **setenv** save new environment variable with given value.  
 The **unsetenv** unsets environment variable with NAME.
 ```bash

--- a/build/configs/artik053/hello/README.md
+++ b/build/configs/artik053/hello/README.md
@@ -2,7 +2,7 @@
 This prints "hello world" like minimal. But it has more functionality on kernel and file system.  
 If network functionality is not mandatory, it can be used.  
 
-Because of enabled many configs and big number of arrays comparsed with minimal,  
+Because of enabled many configs and big number of arrays compared with minimal,  
 the [minimal](../minimal/README.md) config is better to know minimal the TizenRT kernel footprint.
 
 ## Enabled Feature

--- a/build/configs/qemu/HowToRunNetworkStackOnQemu.md
+++ b/build/configs/qemu/HowToRunNetworkStackOnQemu.md
@@ -1,5 +1,5 @@
-# How to run Network Stack on QEMU
-This document explains steps to be followed to run Network Stack on QEMU.  
+# How to run network stack on QEMU
+This document explains steps to be followed to run network stack on QEMU.  
 
 ## Steps to verify network stack on QEMU is as follows
 

--- a/build/configs/qemu/README.md
+++ b/build/configs/qemu/README.md
@@ -104,5 +104,5 @@ Select `NONE`(64KB) or `Build for SRAM increased QEMU Hardware`(16MB)
 Enter `Chip Selection` -> `Boot Memory Configuration`  
 Set `Primary RAM size` to `65536`(64KB) or `16777216`(16MB)
 
-### How to run Network Stack on QEMU
-To run the Network stack on QEMU please refer [How to run network stack on Qemu](HowToRunNetworkStackOnQemu.md).
+### How to run network stack on QEMU
+To run the network stack on QEMU please refer [How to run network stack on Qemu](HowToRunNetworkStackOnQemu.md).

--- a/build/configs/sidk_s5jt200/README.md
+++ b/build/configs/sidk_s5jt200/README.md
@@ -105,7 +105,7 @@ SUBSYSTEMS=="usb",ATTRS{idVendor}=="0403",ATTRS{idProduct}=="6010",MODE="0666" R
 
 ## How to program a binary
 
-After buiding a TizenRT, execute below at $TIZENRT_BASEDIR/os folder.  
+After building a TizenRT, execute below at $TIZENRT_BASEDIR/os folder.  
 See [[Getting the sources]](https://github.com/Samsung/TizenRT#getting-the-sources) for how to set *TIZENRT_BASEDIR*.
 ```bash
 ./dbuild.sh download ALL
@@ -170,7 +170,7 @@ There are three configuration sets for sidk_s5jt200, including 'hello_with_tash'
  for running kernel functions
 
 #### tc
- for runnig unit test cases
+ for running unit test cases
 
 #### sidk_tash_aws
  for running AWS IoT SDK examples.

--- a/docs/HowToPortTizenRTOnWiFiChipset.md
+++ b/docs/HowToPortTizenRTOnWiFiChipset.md
@@ -125,7 +125,7 @@ config SELECT_DRIVER_NONE
 	depends on SELECT_<SUPPLICANT_LIBRARY_NAME>
 ```
 Please add the above lines *ONLY* if you do not need wireless driver support from TizenRT. Also note, that in such cases, you should interface TizenRT's network stack directly
-to the WiFi library. These details are covered further in [Interfacing WiFi Driver to Network Stack](#1-interfacing-the-wifi-driver-to-the-network-stack).
+to the WiFi library. These details are covered further in [Interfacing WiFi Driver to network stack](#1-interfacing-the-wifi-driver-to-the-network-stack).
 
 ### Choosing the right WiFi utils for build
 
@@ -179,7 +179,7 @@ Make sure you create your board-specific files at *os/arch/arm/src/\<board_name\
 driver initialization function as shown in the example above.
 
 Next, inside your board specific directory, create a *\<board\>_wlan.c* file. This file should include following functionalities:
-#### 1. Interfacing the WiFi driver to the Network Stack
+#### 1. Interfacing the WiFi driver to the network stack
 In TizenRT, the *netif* structure links the WiFi driver to the overlying network layer. Netif creation and initialization should
 follow immediately after WiFi driver initialization. Inside the *\<board\>_wlan.c* file, this can be implemented as a three step process
 1. Allocate memory for LWIP's netif structure, and populate its fields with the driver API

--- a/docs/HowToSetEnv.md
+++ b/docs/HowToSetEnv.md
@@ -9,7 +9,7 @@ Untar the gcc-arm-none-eabi-6-2017-q1-update-*OS Type*.tar.bz2 and export the pa
 tar xvjf gcc-arm-none-eabi-6-2017-q1-update-[OS Type].tar.bz2
 export PATH=<Your Toolchain PATH>:$PATH
 ```
-Be aware that recommanded toolchain is fully working on 64bits machine.
+Be aware that recommended toolchain is fully working on 64bits machine.
 
 ## Getting the source code
 

--- a/docs/HowToUseAudio.md
+++ b/docs/HowToUseAudio.md
@@ -33,7 +33,7 @@ Depending on the board schematics, a control path (i2c, spi, etc) and a data pat
 
 Board_initialize sets up audio codec with the instance of the control path and data path.
 
-Psuedocode
+Pseudocode
 ```
 void board_initialize()  
 {  
@@ -41,7 +41,7 @@ void board_initialize()
 	i2c = initialize i2c();
 
 	/* Get an i2s instance */
-	i2s = initalize_i2s(); 
+	i2s = initialize_i2s(); 
 
 	/* Setup audio codec */
 	codec_lowerhalf = initialize_audio_codec(i2c, i2s, ..);
@@ -52,7 +52,7 @@ void board_initialize()
 
 After setting up audio codec, the codec's lowerhalf is wrapped around in an audio device upperhalf.
 
-Psuedocode
+Pseudocode
 
 ```
 	/*Embed codec device within audio device */

--- a/docs/HowToUseLoggingSystem.md
+++ b/docs/HowToUseLoggingSystem.md
@@ -71,7 +71,7 @@ LogM takes stronger precedence over syslog, so if LogM and either syslog devices
 ### How to enable LogM
 For details pertaining to LogM, please refer to [README](../os/logm/README.md).
 
-### How to enable Syslog Devices
+### How to enable syslog devices
 Using Menuconfig, syslog devices can be enabled as shown below:
 ```
 cd $TIZENRT_BASEDIR

--- a/docs/HowToUseMPU.md
+++ b/docs/HowToUseMPU.md
@@ -49,7 +49,7 @@ mpu_user_intsram_wb()      : Read Write        Read Write
 
 ```mpu_priv_noncache()``` - This function is used to configure a memory region as internal memory with _not cacheable_, _not bufferable_, _shareable_ and _instruction access disable_ attributes.
 
-```mpu_peripheral()``` - This function is used to configure a memory region as periperal address space with _shareable_, _bufferable_ and _instruction access disable_ attributes.
+```mpu_peripheral()``` - This function is used to configure a memory region as peripheral address space with _shareable_, _bufferable_ and _instruction access disable_ attributes.
 
 ```mpu_priv_flash()``` - This function is used to configure a memory region as privileged program flash with _cacheable_ attributes.
 

--- a/docs/HowToUsePeripheral.md
+++ b/docs/HowToUsePeripheral.md
@@ -302,7 +302,7 @@ int i2c_uioregister(FAR const char *path, FAR struct i2c_dev_s *dev);
 ### I2C Initialization  
 I2C is initialized by invoking up_i2cinitialize.  
 Initialization takes one i2c port and returns a i2c device structure.  
-Initialization is done either as part of _up_intitialize()_ or as part of _board_initialize()_.  
+Initialization is done either as part of _up_initialize()_ or as part of _board_initialize()_.  
 
 Please refer to **[i2c.h](../os/include/tinyara/i2c.h)** to know more about the i2c functions and declarations.  
 

--- a/docs/HowToUseTinyAlsa.md
+++ b/docs/HowToUseTinyAlsa.md
@@ -102,7 +102,7 @@ At any point of time, the user is free to exit the record/play loop and close th
 **pcm_mmap_write**
 These are additional API's provided for the sake of compatibility with the ALSA API list. These API's internally make use of the mmap API's to transfer data. However, these API's require the user to allocate data buffers and then copy the data from these buffer to the mmap buffers internally. Hence, they do not provide the advantage of low latency which would be provided by using the other mmap API's directly. Hence, it is recommended to avoid the use of these API's for improving latency reduction.
 
-The psuedocode below briefly illustrates the use of mmap API's for recording audio:
+The pseudocode below briefly illustrates the use of mmap API's for recording audio:
 ```
 #include <tinyalsa/tinyalsa.h>
 ...

--- a/external/aws/CHANGELOG.md
+++ b/external/aws/CHANGELOG.md
@@ -113,7 +113,7 @@ Bugfixes/Improvements:
 
 Features:
 
-  - Testing with mbedTLS, prepping for relase
+  - Testing with mbedTLS, prepping for release
 
 Bugfixes/Improvements:
 

--- a/external/aws/PortingGuide.md
+++ b/external/aws/PortingGuide.md
@@ -43,7 +43,7 @@ All makefiles in this SDK were configured using the documented folder structure 
 
 ##Integrating the SDK into your environment
 
-This section explains the API calls that need to be implemented in order for the Device SDK to run on your platform. The SDK interfaces follow the driver model where only prototypes are defined by the Device SDK itself while the implementation is delegated to the user of the SDK to adjust it to the platform in use. The following sections list the needed functionality for the device SDK to run successfully on any given platform.
+This section explains the API calls that need to be implemented in order for the device SDK to run on your platform. The SDK interfaces follow the driver model where only prototypes are defined by the device SDK itself while the implementation is delegated to the user of the SDK to adjust it to the platform in use. The following sections list the needed functionality for the device SDK to run successfully on any given platform.
 
 ###Timer Functions
 

--- a/external/grpc/README.md
+++ b/external/grpc/README.md
@@ -5,7 +5,7 @@ The following covers the pre-requisites to building grpc on TizenRT.
 
 ## Pre-Requisites
 TizenRT's version of gRPC supports only C++ binding, so it is expected that the developer should write C++ applications in order to 
-use gRPC. In that context, gRPC needs specific *cpp plugins* in order to convert certain high-level RPC specifications (covered in detail under [Using `Protobuf` to generate Service and Message Classes](#using-protobuf-to-generate-service-and-message-classes)) to C++ header and source files.
+use gRPC. In that context, gRPC needs specific *cpp plugins* in order to convert certain high-level RPC specifications (covered in detail under [Using `Protobuf` to generate Service and message classes](#using-protobuf-to-generate-service-and-message-classes)) to C++ header and source files.
 At present, TizenRT's gRPC build borrows the plugins from a native build of gRPC on the host environment (usually Linux or Mac OS). This requires building gRPC 1.9.0. The following steps describe how to do so on a linux machine:
 
 1. Install Pre-requisites
@@ -66,8 +66,8 @@ This section is divided into three parts, namely,
 
 Let us look in detail at the points above.
 
-### Using `Protobuf` to generate Service and Message Classes
-The C++ binding for gRPC uses Service and Message classes to implement RPC stubs. Although the Service and Message classes can be written by hand,
+### Using `Protobuf` to generate service and message classes
+The C++ binding for gRPC uses Service and message classes to implement RPC stubs. Although the Service and message classes can be written by hand,
 the *Protocol buffer* compiler provides a convenient specification language, as well as automated C++ code generation for these classes. TizenRT has ported *Protocol buffer* under
 `external/protobuf` folder, so it is highly recommended to use this external module to generate the aforestated classes.
 Accordingly, please include `CONFIG_PROTOBUF` in your TizenRT build configuration as well. You can refer to `external/protobuf/Kconfig` for details of this configuration. In order to generate stub code from `protobuf` specifications, `gRPC` features a set of plugins, one for each programming language. TizenRT requires the `grpc-cpp-plugin` to convert `.proto` files into C++ implementation of Message and Service classes. For this purpose, additional plugins must be installed on the host build environment (your Linux machine or VM). To do so, follow the installation steps described earlier in [Pre-Requisites](#pre-requisites).
@@ -77,13 +77,13 @@ to include the `protoc` compilation command in TizenRT's application-level `Make
 
 ### Customizing `Makefile` for gRPC
 In order to understand the details below, please refer to `apps/examples/greeter_client/Makefile` as an example.
-In general, the application-level `Makefile` must include an additional step for auto-generating the Service and Message classes using the `protoc` compiler.
+In general, the application-level `Makefile` must include an additional step for auto-generating the Service and message classes using the `protoc` compiler.
 For convenience, developers are expected to create their `.proto` specification at the same application folder, and provide it to the `Makefile` as shown below:
 ```
 CXXPROTO	= <proto-filename>.proto
 ```
-Next, the `protoc` command will be invoked to generate the C++ Service and Message classes. The Service files have extensions `.grpc.pb.cc` (source) and `.grpc.pb.h` (header),
-while the Message files have extensions `.pb.cc` and `.pb.h` correspondingly. These Source and Message classes are generated in Makefile as shown:
+Next, the `protoc` command will be invoked to generate the C++ Service and message classes. The Service files have extensions `.grpc.pb.cc` (source) and `.grpc.pb.h` (header),
+while the Message files have extensions `.pb.cc` and `.pb.h` correspondingly. These Source and message classes are generated in Makefile as shown:
 ```
 # Message class
 $(CXXSRCS): %$(GENCXXEXT): %$(PROTOEXT)

--- a/external/grpc/README.md
+++ b/external/grpc/README.md
@@ -109,7 +109,7 @@ Therefore, our TizenRT application must internally use either `pthread_create` A
 Please refer to `grpc_greeter_client` and `grpc_route_client` applications under `apps/examples` folder as examples on how to achieve this.
 
 An important consideration when running gRPC on TizenRT is the stack size allocated for its threads.
-From our initial verfication, we observe that a minimum thread stack size of 16384 bytes is necessary for the main gRPC thread to run successfully on TizenRT.
+From our initial verification, we observe that a minimum thread stack size of 16384 bytes is necessary for the main gRPC thread to run successfully on TizenRT.
 This can be achieved by either using the `pthread_attr_setstacksize` API or configuring the default pthread stacksize via menuconfig, at the location `Kernel Features -> Stack size information -> Default pthread stack size`.
 Additionally, this gRPC main thread engine uses `pthread_create` internally for its run-time procedures, for which we recommend setting a stack size of 10240 bytes or higher. In order to configure this easily, TizenRT features a menuconfig parameter at the location `Networking Support -> Protocols -> gRPC -> Set thread size for grpc modules`.
 

--- a/external/iotivity/README.md
+++ b/external/iotivity/README.md
@@ -16,7 +16,7 @@ For more information refer to the [web site](http://www.scons.org/doc/production
 There are two methods to enable IoTivity. One is using a pre-set configuration(defconfig), the other is using menuconfig.  
 As a default configuration, you can use the IoTivity defconfig. Otherwise, you should enable this function with menuconfig.
 
-#### Using pre-set configration
+#### Using pre-set configuration
 Use the IoTivity configuration.  
 ```bash
 ~/TIZENRT_BASEDIR$ cd os/tools

--- a/external/iotjs/docs/contributing/Community-Guidelines.md
+++ b/external/iotjs/docs/contributing/Community-Guidelines.md
@@ -7,7 +7,7 @@ Community participants must adhere to these simple rules:
 
 <br>
 
-### Community Consensus, Lazy Consensus and Slient Consent
+### Community Consensus, Lazy Consensus and Silent Consent
 
 Community consensus about a Project issue means that the issue has been submitted to and discussed by Contributors, and that ALL discussing member agree about the issue.<p>
 Lazy consensus means that Contributors may proceed with work when they have reason to believe that other Contributors in the community will agree with the direction of their work, and do not need to stop or initiate unnecessary discussion about the work. Contributors should publish their work (that is, merge proposals to master branch) in a timely manner to allow others to possibly raise issues about the work. When the Contributor is not sure there will be consensus, they should raise a proposal to the community via appropriate public communication channels(**_currently Github issues is possible way to achieve this_**)<p>

--- a/external/iotjs/docs/devs/Coding-Style-Guidelines.md
+++ b/external/iotjs/docs/devs/Coding-Style-Guidelines.md
@@ -187,7 +187,7 @@ Do not modify prototypes of builtin objects
 ## Javascript Style Rules
 
 ### Naming
-Use lowerCamelCase for varible names and function names.
+Use lowerCamelCase for variable names and function names.
 
     var myFirstVariable;
     function myFirstFunction {

--- a/external/iotjs/docs/devs/Test-Guidelines.md
+++ b/external/iotjs/docs/devs/Test-Guidelines.md
@@ -2,7 +2,7 @@
 
 Depend on the purpose of the test case (whether it's a positive or negative one), place it under `test/run_pass` or `test/run_fail` directory. The required external resources should be placed into `test/resources`.
 
-All test case files must be named in the following form `test_<module name>[_<functionallity].js` where `<module name>`
+All test case files must be named in the following form `test_<module name>[_<functionality].js` where `<module name>`
 should match one of the JS modules name in the IoT.js. If there is a test case which can not tied to a
 module (like some js features) then the `iotjs` name can be used as module name. It is important to
 correctly specify the module name as the test executor relies on that information.

--- a/external/protobuf/README.md
+++ b/external/protobuf/README.md
@@ -16,7 +16,7 @@ The following sections detail the steps required to build `protobuf` on TizenRT,
 # Build `protobuf` 
 
 `protobuf` takes in specifications for services and messages in a special `proto` file (with file extension `.proto`), and translates these specifications to actual C++ code that can be used by applications.
-For the translation to happen, `protobuf` needs a protocol complier called `protoc` to compile the specification `.proto` file. Below are mentioned two appproaches for installing `protoc` in your build environment (host OS):
+For the translation to happen, `protobuf` needs a protocol complier called `protoc` to compile the specification `.proto` file. Below are mentioned two approaches for installing `protoc` in your build environment (host OS):
 
 ## Installing `protoc` from source
 
@@ -45,7 +45,7 @@ The following sections describes how to quickly verify the working of `protobuf`
 TizenRT provides a sample program for protobuf, named `addressbook_main` that serializes and deserializes user data.
 `addressbook_main` program could be selected under below menuconfig
 
-[`Application Configuration > Examples > Protocol Buffers exmaple`]
+[`Application Configuration > Examples > Protocol Buffers example`]
 
 Having selected the application as shown above, build it as follows:
 ```

--- a/external/protobuf/README.md
+++ b/external/protobuf/README.md
@@ -1,6 +1,6 @@
 # Introduce
 
-Protocol Buffers (a.k.a. `protobuf`) is Google's language-neutral, platform-neutral, extensible mechanism for serializing structured data. TizenRT features a port for `protobuf` version 3.5.1, with support for C++ language. 
+Protocol buffers (a.k.a. `protobuf`) is Google's language-neutral, platform-neutral, extensible mechanism for serializing structured data. TizenRT features a port for `protobuf` version 3.5.1, with support for C++ language. 
 You can find details of `protobuf` at https://github.com/google/protobuf.
 
 Before you proceed with the rest of the documentation below, please note the following points:
@@ -34,7 +34,7 @@ The appropriate `protoc` release can be fetched and installed using the steps be
 
 ## Build `protobuf` on TizenRT
 
-protocol buffer in menuconfig should be selected under [`External Libraries > protocol buffer`].
+Protocol buffers in menuconfig should be selected under [`External Libraries > protocol buffer`].
 Currently, `protobuf` configuration is supported only for applications that use `gRPC`(see `artik053/grpc` under `build/configs` directory). In the future, `protobuf` configurations will be extended to cover applications that
 do not strictly require `gRPC`.
 

--- a/external/protobuf/cmake/README.md
+++ b/external/protobuf/cmake/README.md
@@ -235,7 +235,7 @@ release libprotobuf.lib library.
 DLLs vs. static linking
 =======================
 
-Static linking is now the default for the Protocol Buffer libraries.  Due to
+Static linking is now the default for the protocol buffer libraries.  Due to
 issues with Win32's use of a separate heap for each DLL, as well as binary
 compatibility issues between different versions of MSVC's STL library, it is
 recommended that you use static linkage only.  However, it is possible to
@@ -322,14 +322,14 @@ well, or live with them.
 * C4800 - 'type' : forcing value to bool 'true' or 'false' (performance warning)
 * C4996 - 'function': was declared deprecated
 
-C4251 is of particular note, if you are compiling the Protocol Buffer library
+C4251 is of particular note, if you are compiling the protocol buffer library
 as a DLL (see previous section).  The protocol buffer library uses templates in
 its public interfaces.  MSVC does not provide any reasonable way to export
 template classes from a DLL.  However, in practice, it appears that exporting
 templates is not necessary anyway.  Since the complete definition of any
 template is available in the header files, anyone importing the DLL will just
 end up compiling instances of the templates into their own binary.  The
-Protocol Buffer implementation does not rely on static template members being
+protocol Buffer implementation does not rely on static template members being
 unique, so there should be no problem with this, but MSVC prints warning
 nevertheless.  So, we disable it.  Unfortunately, this warning will also be
 produced when compiling code which merely uses protocol buffers, meaning you

--- a/external/protobuf/java/README.md
+++ b/external/protobuf/java/README.md
@@ -92,7 +92,7 @@ Compatibility Notice
   are guaranteed for minor version releases if the user follows the guideline
   described in this section.
 
-* Protobuf major version releases may also be backwards-compatbile with the
+* Protobuf major version releases may also be backwards-compatible with the
   last release of the previous major version. See the release notice for more
   details.
 

--- a/external/protobuf/protoc-artifacts/README.md
+++ b/external/protobuf/protoc-artifacts/README.md
@@ -108,7 +108,7 @@ repository has all the binaries, close and release this repository.
 
 ## Upload zip packages to github release page.
 After uploading protoc artifacts to Maven Central repository, run the
-build-zip.sh script to bulid zip packages for these protoc binaries
+build-zip.sh script to build zip packages for these protoc binaries
 and upload these zip packages to the download section of the github
 release. For example:
 ```

--- a/tools/ramdump/HowToUseRamdump.md
+++ b/tools/ramdump/HowToUseRamdump.md
@@ -57,7 +57,7 @@ copying ramdump_0x02020000_0x0210c800.bin to  $TIZENRT_BASEDIR/build/output/bin
 ```
 
 ## How to parse RAMDUMP
-DumpParser Script privodes two interfaces: CUI and GUI
+DumpParser Script provides two interfaces: CUI and GUI
 
 ### DumpParser using CUI
 1. Run Ramdump Parser Script


### PR DESCRIPTION
commit 1. Fix some misspelling in *.md file.
commit 2. Fix not consistency to *.md file

The following two principles have been applied in commit 2.

1. The first letter of the sentence is capitalized, the rest is written in lowercase
2. The abbreviation or the name used in KCONFIG is an exception