### PR TITLE
apps/exaple/testcase/ : fix svace issue for kernel and network ITC

### DIFF
--- a/apps/examples/testcase/le_tc/kernel/itc_pthread.c
+++ b/apps/examples/testcase/le_tc/kernel/itc_pthread.c
@@ -147,8 +147,11 @@ static void *task_thread(void *param)
 	timeout.tv_nsec = WAIT_TIME_0;
 	sigemptyset(&mask);
 	sigaddset(&mask, SIGUSR1);
-	pthread_sigmask(SIG_BLOCK, &mask, NULL);
-
+	ret = pthread_sigmask(SIG_BLOCK, &mask, NULL);
+	if (ret != 0) {
+		printf("pthread_sigmask Called failed  \n");
+		return NULL;
+	}
 	ret = sigtimedwait(&mask, &info, &timeout);
 	if (ret < SIG_ERROR) {
 		printf("Signal SIGSUR1:  Not Received inside  task_thread in =%d sec  \n", timeout.tv_sec);

--- a/apps/examples/testcase/le_tc/network/itc_net_connect.c
+++ b/apps/examples/testcase/le_tc/network/itc_net_connect.c
@@ -120,7 +120,7 @@ static void *server_connect(void *ptr_num_clients)
 		strncpy(buffer + recv_len, ptr_msg, sizeof(SERVER_MSG));
 		total_send = strlen(buffer);
 		while (total_send) {
-			valsend = send(client_socket, buffer + send_len, strlen(buffer) - send_len, 0);
+			valsend = send(client_socket, buffer + send_len, strlen(buffer) - send_len + 1, 0);
 			printf("server send: %s\n", buffer);
 			if (valsend == -1) {
 				close(client_socket);
@@ -175,7 +175,7 @@ static void *client_connect(void *ptr_id)
 	char buffer[BUFF_LEN] = {0};
 	int total_recv;
 	int total_send;
-	int recv_len = 0;
+	unsigned int recv_len = 0;
 	int send_len = 0;
 	int *pret = malloc(sizeof(int));
 	if (NULL == pret) {
@@ -202,7 +202,7 @@ static void *client_connect(void *ptr_id)
 	client_msg[strlen(client_msg) - 2] = '0' + (*id);
 	total_send = strlen(client_msg);
 	while (total_send) {
-		valsend = send(sock, client_msg + send_len, strlen(client_msg) - send_len, 0);
+		valsend = send(sock, client_msg + send_len, strlen(client_msg) - send_len + 1, 0);
 		printf("client send: %s\n", client_msg);
 		if (valsend == -1) {
 			close(sock);


### PR DESCRIPTION
Changes are as below:
itc_pthread.c ->
1. add return check for api pthread_sigmask()

itc_net_connect.c ->
1. integer underflow resolved by increasing length by 1
2. change recv_len type to unsigned int for avoide integer range

Signed-off-by: Manoj Gupta <manoj.g2@samsung.com>