### PR TITLE
arch/arm: add the priority information at ASSERT dump

### DIFF
--- a/os/arch/arm/src/armv7-m/up_assert.c
+++ b/os/arch/arm/src/armv7-m/up_assert.c
@@ -191,12 +191,12 @@ static void up_taskdump(FAR struct tcb_s *tcb, FAR void *arg)
 	/* Dump interesting properties of this task */
 
 #if CONFIG_TASK_NAME_SIZE > 0
-	lldbg("%s: PID=%d Stack Used=%lu of %lu\n",
-			tcb->name, tcb->pid, (unsigned long)up_check_tcbstack(tcb),
-			(unsigned long)tcb->adj_stack_size);
+	lldbg("%s: PID=%d PRI=%d Stack Used=%lu of %lu\n",
+			tcb->name, tcb->pid, tcb->sched_priority,
+			(unsigned long)up_check_tcbstack(tcb), (unsigned long)tcb->adj_stack_size);
 #else
-	lldbg("PID: %d Stack Used=%lu of %lu\n",
-			tcb->pid, (unsigned long)up_check_tcbstack(tcb),
+	lldbg("PID: %d PRI=%d Stack Used=%lu of %lu\n",
+			tcb->pid, tcb->sched_priority, (unsigned long)up_check_tcbstack(tcb),
 			(unsigned long)tcb->adj_stack_size);
 #endif
 }

--- a/os/arch/arm/src/armv7-r/arm_assert.c
+++ b/os/arch/arm/src/armv7-r/arm_assert.c
@@ -478,9 +478,9 @@ static void up_taskdump(FAR struct tcb_s *tcb, FAR void *arg)
 	/* Dump interesting properties of this task */
 
 #if CONFIG_TASK_NAME_SIZE > 0
-	lldbg("%s: PID=%d Stack Used=%lu of %lu\n", tcb->name, tcb->pid, (unsigned long)up_check_tcbstack(tcb), (unsigned long)tcb->adj_stack_size);
+	lldbg("%s: PID=%d PRI=%d Stack Used=%lu of %lu\n", tcb->name, tcb->pid, tcb->sched_priority, (unsigned long)up_check_tcbstack(tcb), (unsigned long)tcb->adj_stack_size);
 #else
-	lldbg("PID: %d Stack Used=%lu of %lu\n", tcb->pid, (unsigned long)up_check_tcbstack(tcb), (unsigned long)tcb->adj_stack_size);
+	lldbg("PID: %d PRI=%d Stack Used=%lu of %lu\n", tcb->pid, tcb->sched_priority, (unsigned long)up_check_tcbstack(tcb), (unsigned long)tcb->adj_stack_size);
 #endif
 }
 #endif


### PR DESCRIPTION
The sched_priority of tcb structure per each thread will
be printed at dump information.

Signed-off-by: sunghan-chang <sh924.chang@samsung.com>