### PR TITLE
media: Add getCurrentRequesterPid api

### DIFF
--- a/apps/examples/testcase/ta_tc/media/utc/utc_media_focusmanager.cpp
+++ b/apps/examples/testcase/ta_tc/media/utc/utc_media_focusmanager.cpp
@@ -16,6 +16,7 @@
  *
  ****************************************************************************/
 
+#include <unistd.h>
 #include <media/FocusRequest.h>
 #include <media/FocusManager.h>
 #include "tc_common.h"
@@ -34,11 +35,12 @@ static void utc_media_FocusManager_requestFocus_p(void)
 	auto focusRequest = media::FocusRequest::Builder().build();
 	auto &focusManger = media::FocusManager::getFocusManager();
 	auto ret = focusManger.requestFocus(focusRequest);
-	TC_ASSERT_EQ("utc_media_FocusManager_requestFocus", ret, media::FOCUS_REQUEST_SUCCESS);
-
-	focusManger.abandonFocus(focusRequest);
+	TC_ASSERT_EQ_CLEANUP("utc_media_FocusManager_requestFocus", ret, media::FOCUS_REQUEST_SUCCESS, goto cleanup);
 
 	TC_SUCCESS_RESULT();
+
+cleanup:
+	focusManger.abandonFocus(focusRequest);
 }
 
 static void utc_media_FocusManager_requestFocus_n(void)
@@ -70,6 +72,39 @@ static void utc_media_FocusManager_abandonFocus_n(void)
 	TC_SUCCESS_RESULT();
 }
 
+static void utc_media_FocusManager_getCurrentRequesterPid_p(void)
+{
+	auto focusRequest = media::FocusRequest::Builder().build();
+	auto &focusManger = media::FocusManager::getFocusManager();
+	focusManger.requestFocus(focusRequest);
+	auto ret = focusManger.getCurrentRequesterPid();
+	TC_ASSERT_EQ_CLEANUP("utc_media_FocusManager_getCurrentRequesterPid", ret, getpid(), goto cleanup);
+
+	TC_SUCCESS_RESULT();
+
+cleanup:
+	focusManger.abandonFocus(focusRequest);
+}
+
+static void utc_media_FocusManager_getCurrentRequesterPid_n(void)
+{
+	{
+		auto &focusManger = media::FocusManager::getFocusManager();
+		auto ret = focusManger.getCurrentRequesterPid();
+		TC_ASSERT_EQ("utc_media_FocusManager_getCurrentRequesterPid", ret, 0);
+	}
+	{
+		auto focusRequest = media::FocusRequest::Builder().build();
+		auto &focusManger = media::FocusManager::getFocusManager();
+		focusManger.requestFocus(focusRequest);
+		focusManger.abandonFocus(focusRequest);
+		auto ret = focusManger.getCurrentRequesterPid();
+		TC_ASSERT_EQ("utc_media_FocusManager_getCurrentRequesterPid", ret, 0);
+	}
+
+	TC_SUCCESS_RESULT();
+}
+
 int utc_media_FocusManager_main(void)
 {
 	utc_media_FocusManager_getFocusManager_p();
@@ -77,5 +112,7 @@ int utc_media_FocusManager_main(void)
 	utc_media_FocusManager_requestFocus_n();
 	utc_media_FocusManager_abandonFocus_p();
 	utc_media_FocusManager_abandonFocus_n();
+	utc_media_FocusManager_getCurrentRequesterPid_p();
+	utc_media_FocusManager_getCurrentRequesterPid_n();
 	return 0;
 }

--- a/framework/include/media/FocusManager.h
+++ b/framework/include/media/FocusManager.h
@@ -34,6 +34,8 @@
 #include <mutex>
 #include <string>
 
+#include <unistd.h>
+
 #include <media/FocusRequest.h>
 
 namespace media {
@@ -59,6 +61,7 @@ public:
 	static FocusManager &getFocusManager();
 	/**
 	 * @brief Abandon Focus
+	 * @remarks Do not call this funtion within FocusChangeListner::onFocusChange()
 	 * @details @b #include <media/FocusManager.h>
 	 * param[in] focusRequest FocusRequest to abandon
 	 * @return return FOCUS_REQUEST_SUCCESS on Success, else return FOCUS_REQUEST_FAIL
@@ -67,29 +70,41 @@ public:
 	int abandonFocus(std::shared_ptr<FocusRequest> focusRequest);
 	/**
 	 * @brief Request Focus
+	 * @remarks Do not call this funtion within FocusChangeListner::onFocusChange()
 	 * @details @b #include <media/FocusManager.h>
 	 * param[in] focusRequest FocusRequest to request
 	 * @return return FOCUS_REQUEST_SUCCESS on Success, else return FOCUS_REQUEST_FAIL
 	 * @since TizenRT v2.0
 	 */
 	int requestFocus(std::shared_ptr<FocusRequest> focusRequest);
+	/**
+	 * @brief Get a pid of the current FocusRequester
+	 * @remarks Do not call this funtion within FocusChangeListner::onFocusChange()
+	 * @details @b #include <media/FocusManager.h>
+	 * @return return pid of the current focused thread
+	 * @since TizenRT v2.0
+	 */
+	pid_t getCurrentRequesterPid();
 
 private:
 	class FocusRequester
 	{
 	public:
-		FocusRequester(std::string id, std::shared_ptr<FocusChangeListener> listener);
+		FocusRequester(std::string id, std::shared_ptr<FocusChangeListener> listener, pid_t pid);
 		bool hasSameId(std::string id);
 		void notify(int focusChange);
+		pid_t getpid();
 
 	private:
 		std::string mId;
 		std::shared_ptr<FocusChangeListener> mListener;
+		pid_t mPid;
 	};
 
-	FocusManager() = default;
+	FocusManager();
 	virtual ~FocusManager() = default;
 	void removeFocusElement(std::string id);
+	pid_t mCurrentRequesterPid;
 	std::list<std::shared_ptr<FocusRequester>> mFocusList;
 	std::mutex mFocusLock;
 };

--- a/framework/src/media/FocusManager.cpp
+++ b/framework/src/media/FocusManager.cpp
@@ -16,12 +16,19 @@
  *
  ******************************************************************/
 
+#include <debug.h>
+
 #include <media/FocusManager.h>
 
 namespace media {
 
-FocusManager::FocusRequester::FocusRequester(std::string id, std::shared_ptr<FocusChangeListener> listener)
-	: mId(id), mListener(listener)
+FocusManager::FocusManager() :
+	mCurrentRequesterPid(0)
+{
+}
+
+FocusManager::FocusRequester::FocusRequester(std::string id, std::shared_ptr<FocusChangeListener> listener, pid_t pid) :
+	mId(id), mListener(listener), mPid(pid)
 {
 }
 
@@ -37,6 +44,11 @@ void FocusManager::FocusRequester::notify(int focusChange)
 	}
 }
 
+pid_t FocusManager::FocusRequester::getpid()
+{
+	return mPid;
+}
+
 FocusManager &FocusManager::getFocusManager()
 {
 	static FocusManager focusManager;
@@ -47,6 +59,7 @@ int FocusManager::abandonFocus(std::shared_ptr<FocusRequest> focusRequest)
 {
 	std::lock_guard<std::mutex> lock(mFocusLock);
 	if (focusRequest == nullptr) {
+		meddbg("%s[line : %d] Fail : nullptr parameter\n", __func__, __LINE__);
 		return FOCUS_REQUEST_FAIL;
 	}
 
@@ -55,7 +68,13 @@ int FocusManager::abandonFocus(std::shared_ptr<FocusRequest> focusRequest)
 		mFocusList.pop_front();
 		focus->notify(FOCUS_LOSS);
 		if (!mFocusList.empty()) {
-			mFocusList.front()->notify(FOCUS_GAIN);
+			auto currentFocus = mFocusList.front();
+			mCurrentRequesterPid = currentFocus->getpid();
+			medvdbg("Focus changed : current focus pid : %u\n", mCurrentRequesterPid);
+			currentFocus->notify(FOCUS_GAIN);
+		} else {
+			medvdbg("All focus are lost\n");
+			mCurrentRequesterPid = 0;
 		}
 	} else {
 		removeFocusElement(focusRequest->getId());
@@ -68,6 +87,7 @@ int FocusManager::requestFocus(std::shared_ptr<FocusRequest> focusRequest)
 {
 	std::lock_guard<std::mutex> lock(mFocusLock);
 	if (focusRequest == nullptr) {
+		meddbg("%s[line : %d] Fail : nullptr parameter\n", __func__, __LINE__);
 		return FOCUS_REQUEST_FAIL;
 	}
 
@@ -81,11 +101,19 @@ int FocusManager::requestFocus(std::shared_ptr<FocusRequest> focusRequest)
 		mFocusList.front()->notify(FOCUS_LOSS);
 	}
 
-	auto focusRequester = std::make_shared<FocusRequester>(focusRequest->getId(), focusRequest->getListener());
+	auto focusRequester = std::make_shared<FocusRequester>(focusRequest->getId(), focusRequest->getListener(), getpid());
 	mFocusList.push_front(focusRequester);
+	mCurrentRequesterPid = focusRequester->getpid();
+	medvdbg("Focus changed : current focus pid : %u\n", mCurrentRequesterPid);
 	focusRequester->notify(FOCUS_GAIN);
 
 	return FOCUS_REQUEST_SUCCESS;
+}
+
+pid_t FocusManager::getCurrentRequesterPid()
+{
+	std::lock_guard<std::mutex> lock(mFocusLock);
+	return mCurrentRequesterPid;
 }
 
 void FocusManager::removeFocusElement(std::string id)


### PR DESCRIPTION
FocusManager::getCurrentFocusedPid returns current focused pid