### PR TITLE
framework/task_manager: Modify late unregister with pthread

### DIFF
--- a/framework/include/task_manager/task_manager.h
+++ b/framework/include/task_manager/task_manager.h
@@ -37,11 +37,12 @@
 /**
  * @brief Task State which managed by Task Manager
  */
-#define TM_APP_STATE_RUNNING      (1)
-#define TM_APP_STATE_PAUSE        (2)
-#define TM_APP_STATE_STOP         (3)
-#define TM_APP_STATE_UNREGISTERED (4)
-#define TM_APP_STATE_CANCELLING   (5)
+#define TM_APP_STATE_RUNNING         (1)
+#define TM_APP_STATE_PAUSE           (2)
+#define TM_APP_STATE_STOP            (3)
+#define TM_APP_STATE_UNREGISTERED    (4)
+#define TM_APP_STATE_CANCELLING      (5)
+#define TM_APP_STATE_WAIT_UNREGISTER (6)
 
 /**
  * @brief Task Permission

--- a/framework/src/task_manager/task_manager_internal.h
+++ b/framework/src/task_manager/task_manager_internal.h
@@ -81,6 +81,17 @@
 #endif
 
 /**
+ * @brief Late Unregister Options
+ */
+#ifdef CONFIG_SCHED_LPWORK
+#define TM_LATE_UNREGISTER_PRIO CONFIG_SCHED_LPWORKPRIORITY
+#else
+#define TM_LATE_UNREGISTER_PRIO 50
+#endif
+
+#define TM_INTERVAL_TRY_UNREGISTER 3
+
+/**
  * @brief Unicast Type
  */
 #define TM_UNICAST_SYNC      (0)

--- a/framework/src/task_manager/task_manager_set_callback.c
+++ b/framework/src/task_manager/task_manager_set_callback.c
@@ -105,6 +105,7 @@ void taskmgr_stop_cb(int signo, siginfo_t *data)
 		tmdbg("stop callback information is not correct.\n");
 		return;
 	}
+	TM_FREE(info);
 
 	taskmgr_pid = taskmgr_get_task_manager_pid();
 	if (taskmgr_pid == TM_TASK_MGR_NOT_ALIVE) {

--- a/framework/src/task_manager/task_manager_state.c
+++ b/framework/src/task_manager/task_manager_state.c
@@ -40,7 +40,9 @@ static void taskmgr_update_task_state(int handle)
 
 	ret = ioctl(fd, TMIOC_CHECK_ALIVE, TM_PID(handle));
 	if (ret != OK && TM_LIST_ADDR(handle) != NULL) {
-		TM_STATUS(handle) = TM_APP_STATE_STOP;
+		if (TM_STATUS(handle) == TM_APP_STATE_RUNNING || TM_STATUS(handle) == TM_APP_STATE_PAUSE) {
+			TM_STATUS(handle) = TM_APP_STATE_STOP;
+		}
 	}
 }
 


### PR DESCRIPTION
1.     framework/task_manager: Modify late unregister with pthread instead of lpwork
    
    If there is no lpwork, task manager cannot support late unregister.
    So changed to pthread which treats the late unregister functionality.

2.     testcase/task_manager : Modify tc for removing unnecessary semaphore and add sleep