### PR TITLE
os/net/lwip: Add a logic to handle broadcast address

### DIFF
--- a/os/net/lwip/src/core/ipv4/ip4.c
+++ b/os/net/lwip/src/core/ipv4/ip4.c
@@ -179,7 +179,11 @@ struct netif *ip4_route(const ip4_addr_t *dest)
 		/* is the netif up, does it have a link and a valid address? */
 		if (netif_is_up(netif) && netif_is_link_up(netif) && !ip4_addr_isany_val(*netif_ip4_addr(netif))) {
 			/* network mask matches? */
+			ip4_addr_t broadcast_ip = {0xffffffff};
 			if (ip4_addr_netcmp(dest, netif_ip4_addr(netif), netif_ip4_netmask(netif))) {
+				/* return netif on which to forward IP packet */
+				return netif;
+			} else if (((netif->flags & NETIF_FLAG_BROADCAST) > 0) && ip4_addr_cmp(dest, &broadcast_ip)) {
 				/* return netif on which to forward IP packet */
 				return netif;
 			}

--- a/os/net/netdev/netdev_ioctl.c
+++ b/os/net/netdev/netdev_ioctl.c
@@ -1119,6 +1119,8 @@ void netdev_ifup(FAR struct netif *dev)
 				 * operated as non-blocking, so disalbe netdev_ifdown temporarily until API is fixed
 				 */
 				sleep(3);
+				netif_set_up(dev);
+				netif_set_link_up(dev);
 			}
 		}
 	}
@@ -1131,6 +1133,8 @@ void netdev_ifdown(FAR struct netif *dev)
 	if (dev->d_ifdown) {
 		/* Is the interface already down? */
 
+		netif_set_link_down(dev);
+		netif_set_down(dev);
 		if ((dev->d_flags & IFF_UP) != 0) {
 			/* No, take the interface down now */
 


### PR DESCRIPTION
- Add a logic to handle two types of broadcast address when assigning the network interface in lwip;
1) general baddr 0xffffffff
2) specific baddr belonging to subnet

Note that lwip fails to match a proper network interface without this modification, expecially when the NIC is mappted into the several (virtual) interfaces such as wl1 and wl2.