### PR TITLE
framework/task_manager: Add pthread_detach after pthread_create and Remove it in task_manager_stop

### DIFF
--- a/framework/src/task_manager/task_manager_core.c
+++ b/framework/src/task_manager/task_manager_core.c
@@ -337,6 +337,7 @@ static int taskmgr_start(int handle, int caller_pid)
 			return TM_OPERATION_FAIL;
 		}
 		pthread_setname_np(thread, pthread_info->name);
+		pthread_detach(thread);
 		pid = (int)thread;
 	}
 #endif
@@ -416,7 +417,6 @@ static int taskmgr_stop(int handle, int caller_pid)
 		}
 #ifndef CONFIG_DISABLE_PTHREAD
 		else {
-			(void)pthread_detach(TM_PID(handle));
 			ret = pthread_cancel(TM_PID(handle));
 		}
 #endif


### PR DESCRIPTION
 Without pthread_detach, pjoin will be remained and it can be leak.
 Because of adding pthread_detach after pthread creation, pthread_detach after task_manager_stop is not needed anymore.