### PR TITLE
framework/wifi_manager: Add RECONNECT status and update its log

### DIFF
--- a/apps/examples/wifi_manager_sample/wm_test.c
+++ b/apps/examples/wifi_manager_sample/wm_test.c
@@ -549,6 +549,10 @@ void wm_display_state(void *arg)
 			printf("rssi: %d\n", info.rssi);
 		} else if (info.status == AP_DISCONNECTED) {
 			printf("MODE: station (disconnected)\n");
+		} else if (info.status == AP_RECONNECTING) {
+			printf("MODE: station (reconnecting)\n");
+			printf("IP: %s\n", info.ip4_address);
+			printf("SSID: %s\n", info.ssid);
 		}
 		if (wm_mac_addr_to_mac_str(info.mac_address, mac_str) < 0) {
 			goto exit;
@@ -575,7 +579,7 @@ void wm_sta_start(void *arg)
 		printf(" Set STA mode Fail\n");
 		return ;
 	}
-	printf(" Connecting to AP\n");
+	printf("Start STA mode\n");
 	WM_TEST_LOG_END;
 }
 

--- a/framework/include/wifi_manager/wifi_manager.h
+++ b/framework/include/wifi_manager/wifi_manager.h
@@ -47,6 +47,7 @@ typedef enum {
 	// STA mode status
 	AP_DISCONNECTED,
 	AP_CONNECTED,
+	AP_RECONNECTING,
 
 	// SOFT AP mode status
 	CLIENT_CONNECTED,

--- a/framework/src/wifi_manager/wifi_manager.c
+++ b/framework/src/wifi_manager/wifi_manager.c
@@ -613,6 +613,7 @@ void _convert_state_to_info(connect_status_e *conn, wifi_manager_mode_e *mode, _
 	case WIFIMGR_STA_DISCONNECTING:
 	case WIFIMGR_STA_CONNECTING:
 	case WIFIMGR_SOFTAP_DISCONNECTING_STA:
+	case WIFIMGR_STA_CONNECT_CANCEL:
 		*mode = STA_MODE;
 		*conn = AP_DISCONNECTED;
 		break;
@@ -628,9 +629,14 @@ void _convert_state_to_info(connect_status_e *conn, wifi_manager_mode_e *mode, _
 			*conn = CLIENT_DISCONNECTED;
 		}
 		break;
+	case WIFIMGR_STA_RECONNECT:
+	case WIFIMGR_STA_RECONNECTING:
+		*mode = STA_MODE;
+		*conn = AP_RECONNECTING;
+		break;
 	default:
 		// CRITICAL ERROR
-		ndbg("[WM] CRITICAL ERROR: BAD STATE\n");
+		ndbg("[WM] CRITICAL ERROR: BAD STATE (%d)\n", state);
 		break;
 	}
 }
@@ -1078,11 +1084,13 @@ wifi_manager_result_e _handler_on_connected_state(_wifimgr_msg_s *msg)
 			if (ret != 0) {				// critical error
 				ndbg("[WM] [error] pthread_create fail\n");
 				WIFIADD_ERR_RECORD(ERR_WIFIMGR_INTERNAL_FAIL);
+			} else {
+				ndbg("[WM] Internal AUTOCONNECT: go to RECONNECT state\n");
 			}
 			WIFIMGR_SET_STATE(WIFIMGR_STA_RECONNECT);
 		}
 #else /* WIFIDRIVER_SUPPORT_AUTOCONNECT */
-		ndbg("[WM] AUTOCONNECT: go to RECONNECT state\n");
+		ndbg("[WM] External AUTOCONNECT: go to RECONNECT state\n");
 		_handle_user_cb(CB_STA_RECONNECTED, NULL);
 		WIFIMGR_SET_STATE(WIFIMGR_STA_RECONNECT);
 #endif /* WIFIDRIVER_SUPPORT_AUTOCONNECT */


### PR DESCRIPTION
- Add a AP_RECONNECTING status
- Add the new state handling on _convert_state_to_info
- Modify wm_test to recognize the reconnect state and print it