### PR TITLE
Revert "include/tinyara/audio/audio.h: Change member samp of apb to p…

### DIFF
--- a/lib/libc/audio/lib_buffer.c
+++ b/lib/libc/audio/lib_buffer.c
@@ -156,7 +156,6 @@ int apb_alloc(FAR struct audio_buf_desc_s *bufdesc)
 		apb->nmaxbytes = bufdesc->numbytes;
 		apb->nbytes = 0;
 		apb->flags = 0;
-		apb->samp = (FAR uint8_t *)(apb + 1);
 #ifdef CONFIG_AUDIO_MULTI_SESSION
 		apb->session = bufdesc->session;
 #endif

--- a/os/include/tinyara/audio/audio.h
+++ b/os/include/tinyara/audio/audio.h
@@ -426,7 +426,7 @@ struct ap_buffer_s {
 	sem_t sem;					/* Reference locking semaphore */
 	uint16_t flags;				/* Buffer flags */
 	uint16_t crefs;				/* Number of reference counts */
-	uint8_t *samp;				/* Offset of the first sample */
+	uint8_t samp[0];			/* Offset of the first sample */
 } packed_struct;
 
 /* Structure defining the messages passed to a listening audio thread


### PR DESCRIPTION
…ointer so driver can customize sample buffer allocation"

This reverts commit 07787e4c2f14231ad674723d11efca7052c3f53a.