### PR TITLE
pm: Add pm_querystate function

### DIFF
--- a/os/include/tinyara/pm/pm.h
+++ b/os/include/tinyara/pm/pm.h
@@ -517,6 +517,22 @@ enum pm_state_e pm_checkstate(int domain);
 
 int pm_changestate(int domain, enum pm_state_e newstate);
 
+/****************************************************************************
+ * Name: pm_querystate
+ *
+ * Description:
+ *   This function returns the current power management state.
+ *
+ * Input Parameters:
+ *   domain - The PM domain to check
+ *
+ * Returned Value:
+ *   The current power management state.
+ *
+ ****************************************************************************/
+
+enum pm_state_e pm_querystate(int domain);
+
 #undef EXTERN
 #ifdef __cplusplus
 }
@@ -540,6 +556,7 @@ int pm_changestate(int domain, enum pm_state_e newstate);
 #define pm_activity(domain, prio)
 #define pm_checkstate(domain)       (0)
 #define pm_changestate(domain, state)
+#define pm_querystate(domain)       (0)
 
 #endif							/* CONFIG_PM */
 #endif							/* __INCLUDE_TINYARA_POWER_PM_H */

--- a/os/pm/pm_changestate.c
+++ b/os/pm/pm_changestate.c
@@ -257,4 +257,23 @@ int pm_changestate(int domain_indx, enum pm_state_e newstate)
 	return ret;
 }
 
+/****************************************************************************
+ * Name: pm_querystate
+ *
+ * Description:
+ *   This function returns the current power management state.
+ *
+ * Input Parameters:
+ *   domain - The PM domain to check
+ *
+ * Returned Value:
+ *   The current power management state.
+ *
+ ****************************************************************************/
+
+enum pm_state_e pm_querystate(int domain)
+{
+	return g_pmglobals.domain[domain].state;
+}
+
 #endif							/* CONFIG_PM */


### PR DESCRIPTION
pm_querystate function returns the current power management state

Back Ported from Nuttx
(https://bitbucket.org/nuttx/nuttx/commits/7d9787d530bc4c05f354f682cf1d2aa140eb9160)

Signed-off-by: Shadakshari K P <shari.kps@samsung.com>