### PR TITLE
Took too much out of tools/mkconfig.c recently.

### DIFF
--- a/os/tools/mkconfig.c
+++ b/os/tools/mkconfig.c
@@ -121,7 +121,7 @@ int main(int argc, char **argv, char **envp)
 	printf("#ifndef CONFIG_RR_INTERVAL\n");
 	printf("# define CONFIG_RR_INTERVAL 0\n");
 	printf("#endif\n\n");
-	printf("/* The correct way to disable filesystem supuport is to set the number of\n");
+	printf("/* The correct way to disable filesystem support is to set the number of\n");
 	printf(" * file descriptors to zero.\n");
 	printf(" */\n\n");
 	printf("#ifndef CONFIG_NFILE_DESCRIPTORS\n");
@@ -259,10 +259,19 @@ int main(int argc, char **argv, char **envp)
 	printf("# undef  CONFIG_FS_WRITABLE\n");
 	printf("# define CONFIG_FS_WRITABLE 1\n");
 	printf("#endif\n\n");
+
+	printf("/* The correct way to disable socket support is to set the number of\n");
+	printf(" * socket descriptors to zero.\n");
+	printf(" */\n\n");
+	printf("#ifndef CONFIG_NSOCKET_DESCRIPTORS\n");
+	printf("#  define CONFIG_NSOCKET_DESCRIPTORS 0\n");
+	printf("#endif\n\n");
+
 	printf("/* There can be no network support with no socket descriptors */\n\n");
 	printf("#if CONFIG_NSOCKET_DESCRIPTORS <= 0\n");
 	printf("# undef CONFIG_NET\n");
 	printf("#endif\n\n");
+
 	printf("/* Conversely, if there is no network support, there is no need for\n");
 	printf(" * socket descriptors\n");
 	printf(" */\n\n");


### PR DESCRIPTION
This commit is cherry-picked from Nuttx, commit 599c796.
This resolves a compilation waring as shown below:
os/include/tinyara/config.h:481:5: warning: "CONFIG_NSOCKET_DESCRIPTORS" is not defined [-Wundef]
^~~~~~~~~~~~~~~~~~~~~~~~~~

When CONFIG_NET is disabled, CONFIG_NSOCKET_DESCRIPTORS is not defined.
But every source code uses it without checking definition because
it is a mandatory CONFIG.
This commit guarantees the definition of CONFIG_NSOCKET_DESCROPTORS.