### PR TITLE
framework/task_manager: Modify naming and internal fucntion.

### DIFF
--- a/framework/src/task_manager/task_manager_broadcast.c
+++ b/framework/src/task_manager/task_manager_broadcast.c
@@ -27,7 +27,7 @@
 /****************************************************************************
  * task_manager_broadcast
  ****************************************************************************/
-int task_manager_broadcast(int msg, tm_msg_t *data, int timeout)
+int task_manager_broadcast(int msg, tm_msg_t *broadcast_data, int timeout)
 {
 	int status;
 	tm_request_t request_msg;
@@ -46,14 +46,14 @@ int task_manager_broadcast(int msg, tm_msg_t *data, int timeout)
 	if (request_msg.data == NULL) {
 		return TM_OUT_OF_MEMORY;
 	}
-	if (data != NULL) {
-		((tm_internal_msg_t *)request_msg.data)->msg = (void *)TM_ALLOC(data->msg_size);
+	if (broadcast_data != NULL) {
+		((tm_internal_msg_t *)request_msg.data)->msg = (void *)TM_ALLOC(broadcast_data->msg_size);
 		if (((tm_internal_msg_t *)request_msg.data)->msg == NULL) {
 			TM_FREE(request_msg.data);
 			return TM_OUT_OF_MEMORY;
 		}
-		memcpy(((tm_internal_msg_t *)request_msg.data)->msg, data->msg, data->msg_size);
-		((tm_internal_msg_t *)request_msg.data)->msg_size = data->msg_size;
+		memcpy(((tm_internal_msg_t *)request_msg.data)->msg, broadcast_data->msg, broadcast_data->msg_size);
+		((tm_internal_msg_t *)request_msg.data)->msg_size = broadcast_data->msg_size;
 	} else {
 		((tm_internal_msg_t *)request_msg.data)->msg_size = 0;
 		((tm_internal_msg_t *)request_msg.data)->msg = NULL;

--- a/framework/src/task_manager/task_manager_core.c
+++ b/framework/src/task_manager/task_manager_core.c
@@ -38,7 +38,7 @@
 #include <apps/builtin.h>
 #include <tinyara/fs/ioctl.h>
 #include <tinyara/clock.h>
-#include <tinyara/task_manager_internal.h>
+#include <tinyara/task_manager_drv.h>
 #include <task_manager/task_manager.h>
 #ifdef CONFIG_TASK_MANAGER_USER_SPECIFIC_BROADCAST
 #include <task_manager/task_manager_broadcast_list.h>
@@ -950,7 +950,7 @@ static int taskmgr_set_msg_cb(int type, void *data, int pid)
 		return handle;
 	}
 	if (type == TYPE_UNICAST) {
-		TM_UNICAST_CB(handle) = (_tm_unicast_t)data;
+		TM_UNICAST_CB(handle) = (tm_unicast_callback_t)data;
 	} else {
 		if (!taskmgr_is_tm_broadcast_msg_init()) {
 			taskmgr_broadcast_msg_init();

--- a/framework/src/task_manager/task_manager_internal.h
+++ b/framework/src/task_manager/task_manager_internal.h
@@ -98,7 +98,7 @@
 #define TM_UNICAST_ASYNC     (1)
 
 struct tm_termination_info_s {
-	_tm_termination_t cb;
+	tm_termination_callback_t cb;
 	tm_msg_t *cb_data;
 };
 typedef struct tm_termination_info_s tm_termination_info_t;
@@ -116,7 +116,7 @@ struct app_list_data_s {
 	int tm_gid;
 	int status;
 	int permission;
-	_tm_unicast_t unicast_cb;
+	tm_unicast_callback_t unicast_cb;
 	sq_queue_t broadcast_info_list;
 	tm_termination_info_t *stop_cb_info;
 	tm_termination_info_t *exit_cb_info;
@@ -142,7 +142,7 @@ typedef struct tm_response_s tm_response_t;
 struct tm_broadcast_info_s {
 	struct tm_broadcast_info_s *flink;
 	int msg;
-	_tm_broadcast_t cb;
+	tm_broadcast_callback_t cb;
 	void* cb_data;
 };
 typedef struct tm_broadcast_info_s tm_broadcast_info_t;

--- a/framework/src/task_manager/task_manager_set_callback.c
+++ b/framework/src/task_manager/task_manager_set_callback.c
@@ -120,7 +120,7 @@ void taskmgr_stop_cb(int signo, siginfo_t *data)
 /****************************************************************************
  * task_manager_set_unicast_cb
  ****************************************************************************/
-int task_manager_set_unicast_cb(void (*func)(tm_msg_t *data))
+int task_manager_set_unicast_cb(tm_unicast_callback_t func)
 {
 	int ret = OK;
 	struct sigaction act;
@@ -165,7 +165,7 @@ int task_manager_set_unicast_cb(void (*func)(tm_msg_t *data))
 /****************************************************************************
  * task_manager_set_broadcast_cb
  ****************************************************************************/
-int task_manager_set_broadcast_cb(int msg, void (*func)(void *user_data, void *data), tm_msg_t *cb_data)
+int task_manager_set_broadcast_cb(int msg, tm_broadcast_callback_t func, tm_msg_t *cb_data)
 {
 	int status;
 	tm_request_t request_msg;
@@ -197,7 +197,7 @@ int task_manager_set_broadcast_cb(int msg, void (*func)(void *user_data, void *d
 		return TM_OUT_OF_MEMORY;
 	}
 	((tm_broadcast_info_t *)request_msg.data)->msg = msg;
-	((tm_broadcast_info_t *)request_msg.data)->cb = (_tm_broadcast_t)func;
+	((tm_broadcast_info_t *)request_msg.data)->cb = (tm_broadcast_callback_t)func;
 	if (cb_data != NULL) {
 		((tm_broadcast_info_t *)request_msg.data)->cb_data = (tm_msg_t *)TM_ALLOC(sizeof(tm_msg_t));
 		if (((tm_broadcast_info_t *)request_msg.data)->cb_data == NULL) {
@@ -242,7 +242,7 @@ int task_manager_set_broadcast_cb(int msg, void (*func)(void *user_data, void *d
 /****************************************************************************
  * task_manager_set_exit_cb
  ****************************************************************************/
-int task_manager_set_exit_cb(void (*func)(void *data), tm_msg_t *cb_data)
+int task_manager_set_exit_cb(tm_termination_callback_t func, tm_msg_t *cb_data)
 {
 	int ret = OK;
 	tm_request_t request_msg;
@@ -261,7 +261,7 @@ int task_manager_set_exit_cb(void (*func)(void *data), tm_msg_t *cb_data)
 	if (request_msg.data == NULL) {
 		return TM_OUT_OF_MEMORY;
 	}
-	REQ_CBFUNC(request_msg) = (_tm_termination_t)func;
+	REQ_CBFUNC(request_msg) = (tm_termination_callback_t)func;
 	if (cb_data != NULL) {
 		REQ_CBDATA(request_msg) = TM_ALLOC(sizeof(tm_msg_t));
 		if (REQ_CBDATA(request_msg) == NULL) {
@@ -296,7 +296,7 @@ int task_manager_set_exit_cb(void (*func)(void *data), tm_msg_t *cb_data)
 /****************************************************************************
  * task_manager_set_stop_cb
  ****************************************************************************/
-int task_manager_set_stop_cb(void (*func)(void *data), tm_msg_t *cb_data)
+int task_manager_set_stop_cb(tm_termination_callback_t func, tm_msg_t *cb_data)
 {
 	int ret = OK;
 	struct sigaction act;
@@ -332,7 +332,7 @@ int task_manager_set_stop_cb(void (*func)(void *data), tm_msg_t *cb_data)
 	if (request_msg.data == NULL) {
 		return TM_OUT_OF_MEMORY;
 	}
-	REQ_CBFUNC(request_msg) = (_tm_termination_t)func;
+	REQ_CBFUNC(request_msg) = (tm_termination_callback_t)func;
 	if (cb_data != NULL) {
 		REQ_CBDATA(request_msg) = TM_ALLOC(sizeof(tm_msg_t));
 		if (REQ_CBDATA(request_msg) == NULL) {

--- a/os/drivers/task_manager/task_manager_drv.c
+++ b/os/drivers/task_manager/task_manager_drv.c
@@ -31,7 +31,7 @@
 #include <tinyara/fs/fs.h>
 #include <tinyara/fs/ioctl.h>
 #include <tinyara/wdog.h>
-#include <tinyara/task_manager_internal.h>
+#include <tinyara/task_manager_drv.h>
 
 #include "sched/sched.h"
 

--- a/os/include/tinyara/task_manager_drv.h
+++ b/os/include/tinyara/task_manager_drv.h
@@ -16,8 +16,8 @@
  *
  ****************************************************************************/
 
-#ifndef __INCLUDE_TINYARA_TASK_MANAGER_INTERNAL_H
-#define __INCLUDE_TINYARA_TASK_MANAGER_INTERNAL_H
+#ifndef __INCLUDE_TINYARA_TASK_MANAGER_DRV_H
+#define __INCLUDE_TINYARA_TASK_MANAGER_DRV_H
 
 /* This file will be used to provide definitions to support
  * task manager framework
@@ -53,4 +53,4 @@ extern "C" {
 }
 #endif
 
-#endif /* __INCLUDE_TINYARA_TASK_MANAGER_INTERNAL_H */
+#endif /* __INCLUDE_TINYARA_TASK_MANAGER_DRV_H */

--- a/os/kernel/init/os_bringup.c
+++ b/os/kernel/init/os_bringup.c
@@ -73,7 +73,7 @@
 #include <tinyara/logm.h>
 #endif
 #ifdef CONFIG_TASK_MANAGER
-#include <tinyara/task_manager_internal.h>
+#include <tinyara/task_manager_drv.h>
 #endif
 #include "wqueue/wqueue.h"
 #include "init/init.h"

--- a/os/kernel/task/task_exithook.c
+++ b/os/kernel/task/task_exithook.c
@@ -72,7 +72,7 @@
 
 #ifdef CONFIG_TASK_MANAGER
 #include <task_manager/task_manager.h>
-#include <tinyara/task_manager_internal.h>
+#include <tinyara/task_manager_drv.h>
 #endif
 
 /****************************************************************************


### PR DESCRIPTION
framework/task_manager: Modify file name and declared variable names.

In order to reduce the opportunity of misreadings, file name and several variable names were changed.
1. File name change
 - include/tinyara/task_manager_internal.h -> include/tinyara/task_manager_drv.h
2. Variable name chage
 - typedef of callback (_tm_unicast_t -> tm_unicast_callback_t / _tm_broadcast_t -> tm_broadcast_callback_t / _tm_termination_t -> tm_termination_callback_t)


framework/task_manager: Modify internal function (taskmgr_getinfo_with_name).

According to the type of task/thread (built_in task, task, pthread), the lists that stores name of task/thread are different.
Therefore, an invalid referencing can occur which can result in an assert problem.
The procedure of selecting the lists to find the name of task/thread was added according to the type.