### PR TITLE
apps/example/testcase/ : fix media ITC build fail and new ITC develope

### DIFF
--- a/apps/examples/testcase/ta_tc/media/itc/Make.defs
+++ b/apps/examples/testcase/ta_tc/media/itc/Make.defs
@@ -18,6 +18,10 @@
 
 ifeq ($(CONFIG_EXAMPLES_TESTCASE_MEDIA_ITC),y)
 CXXSRCS += itc_media_main.cpp
+CXXSRCS += itc_media_focusrequest.cpp
+CXXSRCS += itc_media_focusmanager.cpp
+CXXSRCS += itc_media_bufferoutputdatasource.cpp
+
 ifeq ($(CONFIG_MEDIA_PLAYER),y)
 CXXSRCS += itc_media_mediaplayer.cpp
 CXXSRCS += itc_media_fileinputdatasource.cpp

--- a/apps/examples/testcase/ta_tc/media/itc/itc_media_bufferoutputdatasource.cpp
+++ b/apps/examples/testcase/ta_tc/media/itc/itc_media_bufferoutputdatasource.cpp
@@ -1,0 +1,139 @@
+/****************************************************************************
+ *
+ * Copyright 2018 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+#include <media/BufferOutputDataSource.h>
+#include "tc_common.h"
+#include <errno.h>
+
+using namespace std;
+using namespace media;
+using namespace media::stream;
+
+static unsigned int channels = 2;
+static unsigned int sampleRate = 16000;
+static audio_format_type_t pcmFormat = AUDIO_FORMAT_TYPE_S16_LE;
+
+static void itc_media_BufferOutputDataSource_getChannels_setChannels_p(void)
+{
+	unsigned int compare_channels = 3;
+	BufferOutputDataSource dataSource(channels, sampleRate, pcmFormat);
+	TC_ASSERT_EQ("getChannels", dataSource.getChannels(), 2);
+	dataSource.setChannels(compare_channels);
+	TC_ASSERT_EQ("getChannels", dataSource.getChannels(), compare_channels);
+	dataSource.setChannels(0);
+	TC_ASSERT_EQ("getChannels", dataSource.getChannels(), 0);
+	TC_SUCCESS_RESULT();
+}
+
+static void itc_media_BufferOutputDataSource_getSampleRate_setSampleRate_p(void)
+{
+	audio_sample_rate_t sample_rate[] = { AUDIO_SAMPLE_RATE_7350,
+		AUDIO_SAMPLE_RATE_8000,
+		AUDIO_SAMPLE_RATE_11025,
+		AUDIO_SAMPLE_RATE_12000,
+		AUDIO_SAMPLE_RATE_16000,
+		AUDIO_SAMPLE_RATE_22050,
+		AUDIO_SAMPLE_RATE_24000,
+		AUDIO_SAMPLE_RATE_32000,
+		AUDIO_SAMPLE_RATE_44100,
+		AUDIO_SAMPLE_RATE_48000,
+		AUDIO_SAMPLE_RATE_64000,
+		AUDIO_SAMPLE_RATE_88200,
+		AUDIO_SAMPLE_RATE_96000
+	};
+	int enum_size = sizeof(sample_rate) / sizeof(sample_rate[0]);
+	int enum_counter = 0;
+
+	BufferOutputDataSource dataSource(channels, sampleRate, pcmFormat);
+	TC_ASSERT_EQ("getSampleRate", dataSource.getSampleRate(), sampleRate);
+
+	for (enum_counter = 0; enum_counter < enum_size; enum_counter++) {
+		dataSource.setSampleRate(sample_rate[enum_counter]);
+		TC_ASSERT_EQ("getSampleRate", dataSource.getSampleRate(), sample_rate[enum_counter]);
+	}
+	TC_SUCCESS_RESULT();
+}
+
+static void itc_media_BufferOutputDataSource_getPcmFormat_setPcmFormat_p(void)
+{
+	audio_format_type_t audio_type[] = {
+		AUDIO_FORMAT_TYPE_S8,
+		AUDIO_FORMAT_TYPE_S16_LE,
+		AUDIO_FORMAT_TYPE_S32_LE
+	};
+	int enum_size = sizeof(audio_type) / sizeof(audio_type[0]);
+	int enum_counter = 0;
+
+	BufferOutputDataSource dataSource(channels, sampleRate, pcmFormat);
+	TC_ASSERT_EQ("getPcmFormat", dataSource.getPcmFormat(), media::AUDIO_FORMAT_TYPE_S16_LE);
+
+	for (enum_counter = 0; enum_counter < enum_size; enum_counter++) {
+		dataSource.setPcmFormat(audio_type[enum_counter]);
+		TC_ASSERT_EQ("getPcmFormat", dataSource.getPcmFormat(), audio_type[enum_counter]);
+	}
+
+	TC_SUCCESS_RESULT();
+}
+
+static void itc_media_BufferOutputDataSource_getAudioType_setAudioType_p(void)
+{
+	audio_type_t  audio_type[] = {
+		AUDIO_TYPE_INVALID,
+		AUDIO_TYPE_UNKNOWN,
+		AUDIO_TYPE_MP3,
+		AUDIO_TYPE_AAC,
+		AUDIO_TYPE_PCM,
+		AUDIO_TYPE_OPUS,
+		AUDIO_TYPE_FLAC,
+		AUDIO_TYPE_WAVE
+	};
+	int enum_size = sizeof(audio_type) / sizeof(audio_type[0]);
+	int enum_counter = 0;
+
+	BufferOutputDataSource dataSource(channels, sampleRate, pcmFormat);
+	TC_ASSERT_EQ("getAudioType", dataSource.getAudioType(), media::AUDIO_TYPE_INVALID);
+
+	for (enum_counter = 0; enum_counter < enum_size; enum_counter++) {
+		dataSource.setAudioType(audio_type[enum_counter]);
+		TC_ASSERT_EQ("getAudioType", dataSource.getAudioType(), audio_type[enum_counter]);
+	}
+
+	TC_SUCCESS_RESULT();
+}
+
+static void itc_media_BufferOutputDataSource_reopen_p(void)
+{
+	BufferOutputDataSource dataSource;
+
+	TC_ASSERT_EQ("itc_media_BufferOutputDataSource_open", dataSource.open(), true);
+	TC_ASSERT_EQ("itc_media_BufferOutputDataSource_open", dataSource.open(), true);
+	dataSource.close();
+
+	TC_SUCCESS_RESULT();
+}
+
+int itc_media_bufferoutputdatasource_main(void)
+{
+	itc_media_BufferOutputDataSource_getChannels_setChannels_p();
+	itc_media_BufferOutputDataSource_getSampleRate_setSampleRate_p();
+	itc_media_BufferOutputDataSource_getPcmFormat_setPcmFormat_p();
+	itc_media_BufferOutputDataSource_getAudioType_setAudioType_p();
+
+	itc_media_BufferOutputDataSource_reopen_p();
+	return 0;
+}

--- a/apps/examples/testcase/ta_tc/media/itc/itc_media_fileoutputdatasource.cpp
+++ b/apps/examples/testcase/ta_tc/media/itc/itc_media_fileoutputdatasource.cpp
@@ -29,7 +29,9 @@ using namespace media::stream;
  ****************************************************************************/
 #define MEDIA_TEST_FILE_PATH "/tmp/record";
 #define FILE_DEFAULT_RATE 16000
-#define CHANNELS 2
+#define FILE_CUSTOM_RATE 16000
+#define DEFAULT_CHANNELS 2
+#define CUSTOM_CHANNELS 16
 #define NULL 0
 #define COUNT 10
 
@@ -51,11 +53,14 @@ static const char *file_path = MEDIA_TEST_FILE_PATH;
 static void itc_media_FileOutputDataSource_getChannels_setChannels_p(void)
 {
 	media::stream::FileOutputDataSource source(file_path);
+
 	TC_ASSERT_EQ("open", source.open(), 1);
-	TC_ASSERT_EQ("getChannels", source.getChannels(), 2);
-	source.setChannels(16);
-	TC_ASSERT_EQ("getChannels", source.getChannels(), 16);
+	TC_ASSERT_EQ_CLEANUP("getChannels", source.getChannels(), DEFAULT_CHANNELS, source.close());
+	source.setChannels(CUSTOM_CHANNELS);
+
+	TC_ASSERT_EQ_CLEANUP("getChannels", source.getChannels(), CUSTOM_CHANNELS, source.close());
 	TC_ASSERT_EQ("close", source.close(), 1);
+
 	TC_SUCCESS_RESULT();
 }
 
@@ -71,10 +76,12 @@ static void itc_media_FileOutputDataSource_getSampleRate_setSampleRate_p(void)
 {
 	media::stream::FileOutputDataSource source(file_path);
 	TC_ASSERT_EQ("open", source.open(), 1);
-	TC_ASSERT_EQ("getSampleRate", source.getSampleRate(), FILE_DEFAULT_RATE);
-	source.setSampleRate(20000);
-	TC_ASSERT_EQ("getSampleRate", source.getSampleRate(), 20000);
+	TC_ASSERT_EQ_CLEANUP("getSampleRate", source.getSampleRate(), FILE_DEFAULT_RATE, source.close());
+	source.setSampleRate(FILE_CUSTOM_RATE);
+	TC_ASSERT_EQ_CLEANUP("getSampleRate", source.getSampleRate(), FILE_CUSTOM_RATE, source.close());
+
 	TC_ASSERT_EQ("close", source.close(), 1);
+
 	TC_SUCCESS_RESULT();
 }
 
@@ -90,12 +97,15 @@ static void itc_media_FileOutputDataSource_getPcmFormat_setPcmFormat_p(void)
 {
 	media::stream::FileOutputDataSource source(file_path);
 	TC_ASSERT_EQ("open", source.open(), 1);
-	TC_ASSERT_EQ("getPcmFormat", source.getPcmFormat(), MEDIA_FORMAT_TYPE);
-	source.setPcmFormat(1);
-	TC_ASSERT_EQ("getPcmFormat", source.getPcmFormat(), 1);
-	source.setPcmFormat(2);
-	TC_ASSERT_EQ("getPcmFormat", source.getPcmFormat(), 2);
+	TC_ASSERT_EQ_CLEANUP("getPcmFormat", source.getPcmFormat(), media::AUDIO_FORMAT_TYPE_S16_LE, source.close());
+	source.setPcmFormat(media::AUDIO_FORMAT_TYPE_S8);
+	TC_ASSERT_EQ_CLEANUP("getPcmFormat", source.getPcmFormat(), media::AUDIO_FORMAT_TYPE_S8, source.close());
+
+	source.setPcmFormat(media::AUDIO_FORMAT_TYPE_S32_LE);
+	TC_ASSERT_EQ_CLEANUP("getPcmFormat", source.getPcmFormat(), media::AUDIO_FORMAT_TYPE_S32_LE, source.close());
+
 	TC_ASSERT_EQ("close", source.close(), 1);
+
 	TC_SUCCESS_RESULT();
 }
 
@@ -110,10 +120,11 @@ static void itc_media_FileOutputDataSource_getPcmFormat_setPcmFormat_p(void)
 static void itc_media_FileOutputDataSource_open_close_p(void)
 {
 	media::stream::FileOutputDataSource source(file_path);
-	for(int i=0; i<COUNT; i++){
+	for (int i = 0; i < COUNT; i++) {
 		TC_ASSERT_EQ("open", source.open(), 1);
 		TC_ASSERT_EQ("close", source.close(), 1);
 	}
+
 	TC_SUCCESS_RESULT();
 }
 
@@ -129,10 +140,11 @@ static void itc_media_FileOutputDataSource_open_n(void)
 {
 	media::stream::FileOutputDataSource source(file_path);
 	TC_ASSERT_EQ("open", source.open(), 1);
-	for(int i=0; i<COUNT; i++){
-		TC_ASSERT_EQ("open", source.open(), 0);
+	for (int i = 0; i < COUNT; i++) {
+		TC_ASSERT_EQ("open", source.open(), 1);
 	}
 	TC_ASSERT_EQ("close", source.close(), 1);
+
 	TC_SUCCESS_RESULT();
 }
 
@@ -149,9 +161,10 @@ static void itc_media_FileOutputDataSource_close_n(void)
 	media::stream::FileOutputDataSource source(file_path);
 	TC_ASSERT_EQ("open", source.open(), 1);
 	TC_ASSERT_EQ("close", source.close(), 1);
-	for(int i=0; i<COUNT; i++){
+	for (int i = 0; i < COUNT; i++) {
 		TC_ASSERT_EQ("close", source.close(), 0);
 	}
+
 	TC_SUCCESS_RESULT();
 }
 
@@ -167,8 +180,9 @@ static void itc_media_FileOutputDataSource_isPrepare_p(void)
 {
 	media::stream::FileOutputDataSource source(file_path);
 	TC_ASSERT_EQ("open", source.open(), 1);
-	TC_ASSERT_EQ("isPrepare", source.isPrepare(), 1);
+	TC_ASSERT_EQ_CLEANUP("isPrepare", source.isPrepare(), 1, source.close());
 	TC_ASSERT_EQ("close", source.close(), 1);
+
 	TC_SUCCESS_RESULT();
 }
 /**
@@ -185,6 +199,7 @@ static void itc_media_FileOutputDataSource_isPrepare_n(void)
 	TC_ASSERT_EQ("open", source.open(), 1);
 	TC_ASSERT_EQ("close", source.close(), 1);
 	TC_ASSERT_EQ("isPrepare", source.isPrepare(), 0);
+
 	TC_SUCCESS_RESULT();
 }
 
@@ -201,12 +216,13 @@ static void itc_media_FileOutputDataSource_write_p(void)
 	media::stream::FileOutputDataSource source(file_path);
 	unsigned char buf[] = "dummydata";
 	TC_ASSERT_EQ("open", source.open(), 1);
-	TC_ASSERT_EQ("write", source.write(buf, 9), 9);
-	TC_ASSERT_EQ("write", source.write(buf, 0), 0);
-	TC_ASSERT_EQ("write", source.write(buf, 10), 10);
-	TC_ASSERT_EQ("write", source.write(buf, 24), 24);
-	TC_ASSERT_EQ("write", source.write(buf, 31), 31);
+	TC_ASSERT_EQ_CLEANUP("write", source.write(buf, 9), 9, source.close());
+	TC_ASSERT_EQ_CLEANUP("write", source.write(buf, 0), 0, source.close());
+	TC_ASSERT_EQ_CLEANUP("write", source.write(buf, 10), 10, source.close());
+	TC_ASSERT_EQ_CLEANUP("write", source.write(buf, 24), 24, source.close());
+	TC_ASSERT_EQ_CLEANUP("write", source.write(buf, 31), 31, source.close());
 	TC_ASSERT_EQ("close", source.close(), 1);
+
 	TC_SUCCESS_RESULT();
 }
 /**
@@ -222,8 +238,9 @@ static void itc_media_FileOutputDataSource_write_n(void)
 	media::stream::FileOutputDataSource source(file_path);
 	unsigned char buf[] = "dummydata";
 	TC_ASSERT_EQ("open", source.open(), 1);
-	TC_ASSERT_EQ("write", source.write(NULL,24), 0);
+	TC_ASSERT_EQ_CLEANUP("write", source.write(nullptr, 1), EOF, source.close());
 	TC_ASSERT_EQ("close", source.close(), 1);
+
 	TC_SUCCESS_RESULT();
 }
 
@@ -239,5 +256,6 @@ int itc_media_fileoutputdatasource_main(void)
 	itc_media_FileOutputDataSource_isPrepare_n();
 	itc_media_FileOutputDataSource_write_p();
 	itc_media_FileOutputDataSource_write_n();
+
 	return 0;
 }

--- a/apps/examples/testcase/ta_tc/media/itc/itc_media_focusmanager.cpp
+++ b/apps/examples/testcase/ta_tc/media/itc/itc_media_focusmanager.cpp
@@ -1,0 +1,72 @@
+/****************************************************************************
+ *
+ * Copyright 2018 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+#include <media/FocusRequest.h>
+#include <media/FocusManager.h>
+#include "tc_common.h"
+
+static void itc_media_FocusManager_getFocusManager_p(void)
+{
+	auto focusRequest = media::FocusRequest::Builder().build();
+	auto focusMangerAddr1 = &media::FocusManager::getFocusManager();
+
+	auto ret1 = focusMangerAddr1->requestFocus(focusRequest);
+	TC_ASSERT_EQ("itc_media_FocusManager_requestFocus", ret1, media::FOCUS_REQUEST_SUCCESS);
+
+	auto focusMangerAddr2 = &media::FocusManager::getFocusManager();
+	TC_ASSERT_EQ("itc_media_FocusManager_getFocusManager", focusMangerAddr1, focusMangerAddr2);
+
+	auto ret2 = focusMangerAddr1->abandonFocus(focusRequest);
+	TC_ASSERT_EQ("itc_media_FocusRequest_abandonFocus", ret2, media::FOCUS_REQUEST_SUCCESS);
+
+	auto focusMangerAddr3 = &media::FocusManager::getFocusManager();
+	TC_ASSERT_EQ("itc_media_FocusManager_getFocusManager", focusMangerAddr1, focusMangerAddr3);
+
+	auto ret3 = focusMangerAddr1->requestFocus(focusRequest);
+	TC_ASSERT_EQ("itc_media_FocusManager_requestFocus", ret3, media::FOCUS_REQUEST_SUCCESS);
+
+	auto focusMangerAddr4 = &media::FocusManager::getFocusManager();
+	TC_ASSERT_EQ("itc_media_FocusManager_getFocusManager", focusMangerAddr1, focusMangerAddr4);
+
+	TC_SUCCESS_RESULT();
+}
+
+static void itc_media_FocusManager_requestFocus_p(void)
+{
+	auto focusRequest = media::FocusRequest::Builder().build();
+	auto &focusManger = media::FocusManager::getFocusManager();
+
+	auto ret1 = focusManger.abandonFocus(focusRequest);
+	TC_ASSERT_EQ("itc_media_FocusRequest_abandonFocus", ret1, 0);
+
+	auto ret2 = focusManger.requestFocus(focusRequest);
+	TC_ASSERT_EQ("itc_media_FocusManager_requestFocus", ret2, media::FOCUS_REQUEST_SUCCESS);
+
+	auto ret3 = focusManger.abandonFocus(focusRequest);
+	TC_ASSERT_EQ("itc_media_FocusRequest_abandonFocus", ret3, media::FOCUS_REQUEST_SUCCESS);
+
+	TC_SUCCESS_RESULT();
+}
+
+int itc_media_FocusManager_main(void)
+{
+	itc_media_FocusManager_getFocusManager_p();
+	itc_media_FocusManager_requestFocus_p();
+
+	return 0;
+}

--- a/apps/examples/testcase/ta_tc/media/itc/itc_media_focusrequest.cpp
+++ b/apps/examples/testcase/ta_tc/media/itc/itc_media_focusrequest.cpp
@@ -1,0 +1,107 @@
+/****************************************************************************
+ *
+ * Copyright 2018 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+#include <media/FocusRequest.h>
+#include "tc_common.h"
+
+bool focus_checker;
+
+class EmptyFocusChangeListener : public media::FocusChangeListener
+{
+	public:
+		void onFocusChange(int focusChange) override;
+};
+
+void EmptyFocusChangeListener::onFocusChange(int focusChange)
+{
+	focus_checker = true;
+}
+
+static void itc_media_FocusRequest_getId_p(void)
+{
+	auto listener1 = std::make_shared<EmptyFocusChangeListener>();
+	auto listener2 = std::make_shared<EmptyFocusChangeListener>();
+
+	auto focusRequest1 = media::FocusRequest::Builder().setFocusChangeListener(listener1).build();
+	auto focusRequest2 = media::FocusRequest::Builder().setFocusChangeListener(listener2).build();
+
+	auto ret1 = focusRequest1->getId();
+	auto ret2 = focusRequest2->getId();
+
+	TC_ASSERT_NEQ("itc_media_FocusRequest_getId", ret1.compare(ret2), 0);
+
+	listener1 = std::make_shared<EmptyFocusChangeListener>();
+	listener2 = std::make_shared<EmptyFocusChangeListener>();
+
+	auto focusRequestBuilder1 = media::FocusRequest::Builder().setFocusChangeListener(listener1);
+	focusRequestBuilder1 = focusRequestBuilder1.setFocusChangeListener(listener2);
+
+	focusRequest1 = focusRequestBuilder1.build();
+	focusRequest2 = media::FocusRequest::Builder().setFocusChangeListener(listener2).build();
+
+	ret1 = focusRequest1->getId();
+	ret2 = focusRequest2->getId();
+
+	TC_ASSERT_NEQ("itc_media_FocusRequest_getId", ret1.compare(ret2), 0);
+
+	TC_SUCCESS_RESULT();
+}
+
+static void itc_media_FocusRequest_getListener_p(void)
+{
+	auto focusRequestBuilder1 = media::FocusRequest::Builder();
+	auto focusRequestBuilder2 = media::FocusRequest::Builder();
+
+	auto listener1 = std::make_shared<EmptyFocusChangeListener>();
+	auto listener2 = std::make_shared<EmptyFocusChangeListener>();
+
+	focusRequestBuilder1 = focusRequestBuilder1.setFocusChangeListener(listener1);
+	auto focusRequest1  = focusRequestBuilder1.build();
+	focusRequestBuilder2 = focusRequestBuilder2.setFocusChangeListener(listener2);
+	auto focusRequest2  = focusRequestBuilder2.build();
+	focusRequestBuilder1 = focusRequestBuilder1.setFocusChangeListener(listener2);
+	focusRequest1  = focusRequestBuilder1.build();
+
+	auto ret1 = focusRequest1->getListener();
+	auto ret2 = focusRequest2->getListener();
+	TC_ASSERT_EQ("itc_media_FocusRequest_getListener", ret1.get(), ret2.get());
+
+	focusRequestBuilder1 = media::FocusRequest::Builder();
+	focusRequestBuilder2 = media::FocusRequest::Builder();
+	listener1 = std::make_shared<EmptyFocusChangeListener>();
+	listener2 = std::make_shared<EmptyFocusChangeListener>();
+	focusRequestBuilder1 = focusRequestBuilder1.setFocusChangeListener(listener1);
+	focusRequestBuilder2 = focusRequestBuilder2.setFocusChangeListener(listener2);
+
+	focusRequest2  = focusRequestBuilder2.build();
+	focusRequestBuilder1 = focusRequestBuilder1.setFocusChangeListener(listener2);
+	focusRequest1  = focusRequestBuilder1.build();
+	ret1 = focusRequest1->getListener();
+	ret2 = focusRequest2->getListener();
+	TC_ASSERT_EQ("itc_media_FocusRequest_getListener", ret1.get(), ret2.get());
+
+	TC_SUCCESS_RESULT();
+}
+
+int itc_media_FocusRequest_main(void)
+{
+	focus_checker = false;
+	itc_media_FocusRequest_getId_p();
+	itc_media_FocusRequest_getListener_p();
+	return 0;
+}

--- a/apps/examples/testcase/ta_tc/media/itc/itc_media_main.cpp
+++ b/apps/examples/testcase/ta_tc/media/itc/itc_media_main.cpp
@@ -34,6 +34,9 @@ int itc_media_FileInputDataSource_main(void);
 #ifdef CONFIG_MEDIA_RECORDER
 int itc_media_mediarecorder_main(void);
 int itc_media_fileoutputdatasource_main(void);
+int itc_media_bufferoutputdatasource_main(void);
+int itc_media_FocusRequest_main(void);
+int itc_media_FocusManager_main(void);
 #endif
 
 extern "C"
@@ -57,6 +60,9 @@ int itc_media_main(int argc, char *argv[])
 #ifdef CONFIG_MEDIA_RECORDER
 	itc_media_mediarecorder_main();
 	itc_media_fileoutputdatasource_main();
+	itc_media_FocusRequest_main();
+	itc_media_FocusManager_main();
+	itc_media_bufferoutputdatasource_main();
 #endif
 
 	(void)tc_handler(TC_END, "Media ITC");

--- a/apps/examples/testcase/ta_tc/media/itc/itc_media_mediaplayer.cpp
+++ b/apps/examples/testcase/ta_tc/media/itc/itc_media_mediaplayer.cpp
@@ -31,16 +31,21 @@
  ****************************************************************************/
 static const char *file_path = "/mnt/fileinputdatasource.raw";
 static const char *test_data = "dummydata";
-static int g_flag=0;
+static int g_flag = 0;
 
 static void SetUp(void)
 {
-	FILE *fp;
-	fp = fopen(file_path, "w");
-	TC_ASSERT_NEQ("fopen", fp, NULL);
-	TC_ASSERT_NEQ_CLEANUP("fputs", fputs(test_data, fp), EOF, fclose(fp));
-	TC_ASSERT_EQ("fclose", fclose(fp), OK);
-	g_flag = 1;
+	FILE *fp = fopen(file_path, "w");
+	if (fp != NULL) {
+		int ret = fputs("dummydata", fp);
+		if (ret != (int)strlen("dummydata")) {
+			printf("fail to fputs\n");
+		}
+		fclose(fp);
+		g_flag = 1;
+	} else {
+		printf("fail to open %s, errno : %d\n", file_path, get_errno());
+	}
 }
 
 static void TearDown()
@@ -59,7 +64,7 @@ static void TearDown()
 static void itc_media_MediaPlayer_create_destroy_p(void)
 {
 	media::MediaPlayer mp;
-	for(int i=0; i<COUNT; i++){
+	for (int i = 0; i < COUNT; i++) {
 		TC_ASSERT_EQ("create", mp.create(), media::PLAYER_OK);
 		TC_ASSERT_EQ("destroy", mp.destroy(), media::PLAYER_OK);
 	}
@@ -79,12 +84,12 @@ static void itc_media_MediaPlayer_create_destroy_n(void)
 	media::MediaPlayer mp;
 	TC_ASSERT_NEQ("destroy", mp.destroy(), media::PLAYER_OK);
 	TC_ASSERT_EQ("create", mp.create(), media::PLAYER_OK);
-	for(int i=0; i<COUNT; i++){
+	for (int i = 0; i < COUNT; i++) {
 		TC_ASSERT_NEQ("recreate", mp.create(), media::PLAYER_OK);
 	}
 	TC_ASSERT_EQ("destroy", mp.destroy(), media::PLAYER_OK);
-	for(int i=0; i<COUNT; i++){
-		TC_ASSERT_NEQ("recreate", mp.destroy(), media::PLAYER_OK);
+	for (int i = 0; i < COUNT; i++) {
+		TC_ASSERT_NEQ("destroy", mp.destroy(), media::PLAYER_OK);
 	}
 	TC_SUCCESS_RESULT();
 }
@@ -92,7 +97,7 @@ static void itc_media_MediaPlayer_create_destroy_n(void)
 int itc_media_MediaPlayer_main(void)
 {
 	SetUp();
-	if(g_flag){
+	if (g_flag) {
 		itc_media_MediaPlayer_create_destroy_p();
 		itc_media_MediaPlayer_create_destroy_n();
 	}

--- a/apps/examples/testcase/ta_tc/media/itc/itc_media_mediarecorder.cpp
+++ b/apps/examples/testcase/ta_tc/media/itc/itc_media_mediarecorder.cpp
@@ -41,10 +41,11 @@ using namespace media::stream;
 static void itc_media_MediaRecorder_create_destroy_p(void)
 {
 	MediaRecorder media_recorder;
-	for(int i=0; i<COUNT; i++){
+	for (int i = 0; i < COUNT; i++) {
 		TC_ASSERT_EQ("create", media_recorder.create(), RECORDER_OK);
 		TC_ASSERT_EQ("destroy", media_recorder.destroy(), RECORDER_OK);
 	}
+
 	TC_SUCCESS_RESULT();
 }
 
@@ -60,13 +61,14 @@ static void itc_media_MediaRecorder_create_destroy_n(void)
 {
 	MediaRecorder media_recorder;
 	TC_ASSERT_EQ("create", media_recorder.create(), RECORDER_OK);
-	for(int i=0; i<COUNT; i++){
-		TC_ASSERT_EQ("create", media_recorder.create(), RECORDER_ERROR);
+	for (int i = 0; i < COUNT; i++) {
+		TC_ASSERT_NEQ("create", media_recorder.create(), RECORDER_ERROR_NONE);
 	}
 	TC_ASSERT_EQ("destroy", media_recorder.destroy(), RECORDER_OK);
-	for(int i=0; i<COUNT; i++){
-			TC_ASSERT_EQ("create", media_recorder.destroy(), RECORDER_ERROR);
-		}
+
+	for (int i = 0; i < COUNT; i++) {
+			TC_ASSERT_NEQ("destroy", media_recorder.destroy(), RECORDER_ERROR_NONE);
+	}
 	TC_SUCCESS_RESULT();
 }
 


### PR DESCRIPTION
changes are as below:
itc_media_bufferoutputdatasource.cpp->
1. develope 5 ITC for new api, itc are as below
		itc_media_BufferOutputDataSource_getChannels_setChannels_p
		itc_media_BufferOutputDataSource_getSampleRate_setSampleRate_p
		itc_media_BufferOutputDataSource_getPcmFormat_setPcmFormat_p
		itc_media_BufferOutputDataSource_getAudioType_setAudioType_p
		itc_media_BufferOutputDataSource_reopen_p

itc_media_fileinputdatasource.cpp->
fix build issue due to namespace media class change

itc_media_fileoutputdatasource.cpp->
fix build issue due to namespace media class change

itc_media_focusmanager.cpp->
1. develope 2 ITC for new api, itc are as below
	itc_media_FocusManager_getFocusManager_p
	itc_media_FocusManager_requestFocus_p

itc_media_focusrequest.cpp->
1. develope 2 ITC for new api, itc are as below
	itc_media_FocusRequest_getId
	itc_media_FocusRequest_getListener_p

itc_media_mediaplayer.cpp->
1. itc fix by file opening logic change

itc_media_mediarecorder.cpp
1. itc fix due to nchange in recorder ERROR code

Signed-off-by: manoj <manoj.g2@samsung.com>