### PR TITLE
framework/task_manager: Add procedure to change the group of tcb.

### DIFF
--- a/os/drivers/task_manager/task_manager_drv.c
+++ b/os/drivers/task_manager/task_manager_drv.c
@@ -34,6 +34,9 @@
 #include <tinyara/task_manager_drv.h>
 
 #include "sched/sched.h"
+#if defined(HAVE_TASK_GROUP) && !defined(CONFIG_DISABLE_PTHREAD)
+#include "group/group.h"
+#endif
 
 /****************************************************************************
  * Private Function Prototypes
@@ -92,6 +95,81 @@ static int taskmgr_task_init(pid_t pid)
 	return sig_sethandler(tcb, SIGTM_PAUSE, &act);
 }
 
+#if defined(HAVE_TASK_GROUP) && !defined(CONFIG_DISABLE_PTHREAD)
+static void taskmgr_pthread_group_detach(pid_t pthread_pid)
+{
+	FAR struct tcb_s *pthread_tcb;
+
+	pthread_tcb = sched_gettcb(pthread_pid);
+	if (pthread_tcb) {
+		group_leave(pthread_tcb);
+	}
+}
+
+static struct task_group_s *taskmgr_get_group_struct(pid_t pid)
+{
+	struct tcb_s *tcb;
+
+	tcb = sched_gettcb(pid);
+	if (!tcb) {
+		tmdbg("[TM] tcb is invalid. pid = %d.\n", pid);
+		return NULL;
+	}
+
+	return tcb->group;
+}
+
+static int taskmgr_group_bind(struct task_group_s *parent_group, struct pthread_tcb_s *child_tcb)
+{
+	if (parent_group == NULL || child_tcb == NULL) {
+		tmdbg("[TM] Invalid parameter! Group bind is failed.\n");
+		return ERROR;
+	}
+
+	child_tcb->cmn.group = parent_group;
+	return OK;
+}
+
+static int taskmgr_pthread_group_join(pid_t parent_pid, pid_t child_pid)
+{
+	struct task_group_s *parent_group;
+	struct pthread_tcb_s *child_tcb;
+	int ret;
+
+	parent_group = taskmgr_get_group_struct(parent_pid);
+	child_tcb = (struct pthread_tcb_s *)sched_gettcb(child_pid);
+	ret = taskmgr_group_bind(parent_group, child_tcb);
+	if (ret != OK) {
+		tmdbg("[TM] Group bind is failed.\n");
+		return ERROR;
+	}
+
+	ret = group_join(child_tcb);
+	if (ret != OK) {
+		tmdbg("[TM] Group join is failed.\n");
+		return ERROR;
+	}
+
+	return OK;
+}
+
+#if defined(CONFIG_SCHED_HAVE_PARENT) && !defined(HAVE_GROUP_MEMBERS)
+static int taskmgr_pthread_ppid_change(pid_t parent_pid, pid_t child_pid)
+{
+	struct pthread_tcb_s *ptcb;
+	ptcb = (struct pthread_tcb_s *)sched_gettcb(child_pid);
+
+	if (ptcb == NULL) {
+		tmdbg("[TM] Invalid pthread tcb. Pthread ppid change failed.\n");
+		return ERROR;
+	}
+
+	ptcb->cmn.ppid = parent_pid;
+	return OK;
+}
+#endif			/* CONFIG_SCHED_HAVE_PARENT && !HAVE_GROUP_MEMBERS */
+#endif			/* HAVE_TASK_GROUP && !CONFIG_DISABLE_PTHREAD */
+
 static ssize_t taskmgr_read(FAR struct file *filep, FAR char *buffer, size_t len)
 {
 	return 0;
@@ -112,6 +190,7 @@ static int taskmgr_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
 {
 	int ret = ERROR;
 	struct tcb_s *tcb;
+	tm_pthread_pid_t *group_info;
 
 	tmvdbg("cmd: %d arg: %ld\n", cmd, arg);
 
@@ -198,6 +277,31 @@ static int taskmgr_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
 		}
 #endif
 		break;
+#if defined(HAVE_TASK_GROUP) && !defined(CONFIG_DISABLE_PTHREAD)
+	case TMIOC_PTHREAD_PARENT:
+		group_info = (tm_pthread_pid_t *)arg;
+		if (group_info == NULL) {
+			return ERROR;
+		}
+
+		/* First, the group of pthread is detached from the task manager */
+		taskmgr_pthread_group_detach(group_info->child_pid);
+
+		/* After the group detach procedure, the pthread group is joined with the group of parent */
+		ret = taskmgr_pthread_group_join(group_info->parent_pid, group_info->child_pid);
+		if (ret != OK) {
+			return ERROR;
+		}
+
+#if defined(CONFIG_SCHED_HAVE_PARENT) && !defined(HAVE_GROUP_MEMBERS)
+		/* Afeter the pthread group join proceduere, the parent pid of pthread is changed into parent pid */
+		ret = taskmgr_pthread_ppid_change(group_info->parent_pid, group_info->child_pid);
+		if (ret != OK) {
+			return ERROR;
+		}
+#endif
+		break;
+#endif
 	default:
 		tmdbg("Unrecognized cmd: %d arg: %ld\n", cmd, arg);
 		break;

--- a/os/include/tinyara/fs/ioctl.h
+++ b/os/include/tinyara/fs/ioctl.h
@@ -365,6 +365,9 @@
 #define TMIOC_BROADCAST            _TMIOC(0x0005)
 #define TMIOC_CHECK_ALIVE          _TMIOC(0x0006)
 #define TMIOC_TERMINATE            _TMIOC(0x0007)
+#if defined(HAVE_TASK_GROUP) && !defined(CONFIG_DISABLE_PTHREAD)
+#define TMIOC_PTHREAD_PARENT       _TMIOC(0x0008)
+#endif
 
 /****************************************************************************
  * Public Type Definitions

--- a/os/include/tinyara/task_manager_drv.h
+++ b/os/include/tinyara/task_manager_drv.h
@@ -34,6 +34,14 @@
  ****************************************************************************/
 #define TASK_MANAGER_DRVPATH     "/dev/taskmgr"
 
+#if defined(HAVE_TASK_GROUP) && !defined(CONFIG_DISABLE_PTHREAD)
+struct tm_pthread_pid_s {
+	pid_t parent_pid;
+	pid_t child_pid;
+};
+typedef struct tm_pthread_pid_s tm_pthread_pid_t;
+#endif
+
 void task_manager_drv_register(void);
 
 /**


### PR DESCRIPTION
Previously, when pthread is created by task manager (when task_manager_start() is called), the group of pthread's tcb is set as the group of task manager.
The group of pthreads' tcb needs to be set as the group of the caller.
Otherwise, this can leed to a inappropriate result.

Therefore, additional procedures were added to prevent this problem.
After a pthread is created by task manager, the group of pthread's tcb is detached from the task manager.
Then, the group of pthread's tcb is joined to the group of caller.