### PR TITLE
media: Flush outputhandler when recorder stops

### DIFF
--- a/framework/src/media/MediaRecorderImpl.cpp
+++ b/framework/src/media/MediaRecorderImpl.cpp
@@ -312,6 +312,8 @@ void MediaRecorderImpl::stopRecorder(recorder_result_t ret)
 		return;
 	}
 
+	mOutputHandler.flush();
+
 	audio_manager_result_t result = stop_audio_stream_in();
 	if (result != AUDIO_MANAGER_SUCCESS) {
 		meddbg("stop_audio_stream_in failed ret : %d\n", result);

--- a/framework/src/media/OutputHandler.h
+++ b/framework/src/media/OutputHandler.h
@@ -66,6 +66,7 @@ public:
 	void unregisterEncoder();
 
 private:
+	void writeToSource(size_t size);
 	std::shared_ptr<OutputDataSource> mOutputDataSource;
 	std::shared_ptr<Encoder> mEncoder;
 	std::shared_ptr<StreamBuffer> mStreamBuffer;
@@ -77,6 +78,8 @@ private:
 	bool mIsWorkerAlive;
 	std::mutex mMutex;
 	std::condition_variable mCondv;
+	std::mutex mFlushMutex;
+	std::condition_variable mFlushCondv;
 
 	std::weak_ptr<MediaRecorderImpl> mRecorder;
 };


### PR DESCRIPTION
MediaRecorder::stopRecorder calls OutputHandler::flush.
It ensure that all data are written.