### PR TITLE
Get the current location from script file path on shell scripts

### DIFF
--- a/build/configs/artik05x/artik05x_download.sh
+++ b/build/configs/artik05x/artik05x_download.sh
@@ -20,10 +20,13 @@
 # File   : artik05x_download.sh
 # Description : Download script for ARTIK 05X
 
-source .config
+THIS_PATH=`test -d ${0%/*} && cd ${0%/*}; pwd`
 
-# Remember, make is invoked from "os" directory
-OS_DIR_PATH=${PWD}
+# When location of this script is changed, only OS_DIR_PATH should be changed together!!!
+OS_DIR_PATH=${THIS_PATH}/../../../os
+
+source ${OS_DIR_PATH}/.config
+
 BUILD_DIR_PATH=${OS_DIR_PATH}/../build
 CONFIGS_DIR_PATH=${BUILD_DIR_PATH}/configs
 OUTPUT_BINARY_PATH=${BUILD_DIR_PATH}/output/bin

--- a/build/configs/artik05x/artik05x_make_bin.sh
+++ b/build/configs/artik05x/artik05x_make_bin.sh
@@ -22,8 +22,10 @@
 
 set -e
 
-# Remember, make is invoked from "os" directory
-OS_DIR_PATH=${PWD}
+THIS_PATH=`test -d ${0%/*} && cd ${0%/*}; pwd`
+
+# When location of this script is changed, only OS_DIR_PATH should be changed together!!!
+OS_DIR_PATH=${THIS_PATH}/../../../os
 BUILD_DIR_PATH=${OS_DIR_PATH}/../build
 CONFIGS_DIR_PATH=${BUILD_DIR_PATH}/configs
 OUTPUT_BINARY_PATH=${BUILD_DIR_PATH}/output/bin

--- a/build/configs/artik05x/artik05x_ota.sh
+++ b/build/configs/artik05x/artik05x_ota.sh
@@ -20,8 +20,10 @@
 # File   : artik05x_ota.sh
 # Description : Attach CRC and Signing in TizenRT Binary
 
-# Remember, make is invoked from "os" directory
-OS_DIR_PATH=${PWD}
+THIS_PATH=`test -d ${0%/*} && cd ${0%/*}; pwd`
+
+# When location of this script is changed, only OS_DIR_PATH should be changed together!!!
+OS_DIR_PATH=${THIS_PATH}/../../../os
 OUTPUT_BINARY_PATH=${OS_DIR_PATH}/../build/output/bin
 TIZENRT_BIN=${OUTPUT_BINARY_PATH}/tinyara_head.bin
 

--- a/build/configs/artik05x/scripts/partition_gen.sh
+++ b/build/configs/artik05x/scripts/partition_gen.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-
 ###########################################################################
 #
 # Copyright 2017 Samsung Electronics All Rights Reserved.
@@ -23,12 +22,15 @@
 # Created partition map cfg file can be included in the main openocd cfg script
 # for flashing.
 
-source .config
+THIS_PATH=`test -d ${0%/*} && cd ${0%/*}; pwd`
+# When location of this script is changed, only OS_DIR_PATH should be changed together!!!
+OS_DIR_PATH=${THIS_PATH}/../../../../os
+
+source ${OS_DIR_PATH}/.config
 
 # Path ENV
 BOARD_NAME=${CONFIG_ARCH_BOARD}
-OS_DIR_PATH=${PWD}
-PARTMAP_DIR_PATH=${OS_DIR_PATH}/../build/configs/artik05x/scripts
+PARTMAP_DIR_PATH=${THIS_PATH}
 BOARD_KCONFIG=${OS_DIR_PATH}/board/${BOARD_NAME}/Kconfig
 
 # FLASH BASE ADDRESS (Can it be made to read dynamically from .config?)

--- a/build/configs/cy4390x/cy4390x_make_bin.sh
+++ b/build/configs/cy4390x/cy4390x_make_bin.sh
@@ -20,8 +20,10 @@
 # File   : cy4390x_make_bin.sh
 # Description : make cy4390x specific binary
 
-# Remember, make is invoked from "os" directory
-OS_DIR_PATH=${PWD}
+THIS_PATH=`test -d ${0%/*} && cd ${0%/*}; pwd`
+
+# When location of this script is changed, only OS_DIR_PATH should be changed together!!!
+OS_DIR_PATH=${THIS_PATH}/../../../os
 BIN_DIR_PATH=${OS_DIR_PATH}/../build/output/bin
 
 TIZENRT_BIN=${BIN_DIR_PATH}/tinyara

--- a/build/configs/sidk_s5jt200/sidk_s5jt200_download.sh
+++ b/build/configs/sidk_s5jt200/sidk_s5jt200_download.sh
@@ -20,14 +20,17 @@
 # File   : sidk_s5jt200_download.sh
 # Description : interface script for sidk_s5jt200 download
 
-# Include the configuration file
-source .config
+THIS_PATH=`test -d ${0%/*} && cd ${0%/*}; pwd`
+
+# When location of this script is changed, only OS_DIR_PATH should be changed together!!!
+OS_DIR_PATH=${THIS_PATH}/../../../os
+
+source ${OS_DIR_PATH}/.config
 
 # Board name for which tinyara has been compiled
 BOARD_NAME=${CONFIG_ARCH_BOARD}
 
 # ENV : Set to proper path's
-OS_DIR_PATH=${PWD}
 BUILD_DIR_PATH=${OS_DIR_PATH}/../build
 OUTPUT_BIN_PATH=${BUILD_DIR_PATH}/output/bin
 BOARD_DIR_PATH=${BUILD_DIR_PATH}/configs/${BOARD_NAME}

--- a/build/configs/sidk_s5jt200/sidk_s5jt200_make_bin.sh
+++ b/build/configs/sidk_s5jt200/sidk_s5jt200_make_bin.sh
@@ -23,7 +23,10 @@
 set -e
 
 # Remember, make is invoked from "os" directory
-OS_DIR_PATH=${PWD}
+THIS_PATH=`test -d ${0%/*} && cd ${0%/*}; pwd`
+
+# When location of this script is changed, only OS_DIR_PATH should be changed together!!!
+OS_DIR_PATH=${THIS_PATH}/../../../os
 OUTPUT_BINARY_PATH=${OS_DIR_PATH}/../build/output/bin
 
 while test $# -gt 0; do

--- a/build/configs/sidk_s5jt200/tools/openocd/partition_gen.sh
+++ b/build/configs/sidk_s5jt200/tools/openocd/partition_gen.sh
@@ -23,11 +23,15 @@
 # Created partition map cfg file can be included in the main openocd cfg script
 # for flashing.
 
-source .config
+THIS_PATH=`test -d ${0%/*} && cd ${0%/*}; pwd`
+
+# When location of this script is changed, only OS_DIR_PATH should be changed together!!!
+OS_DIR_PATH=${THIS_PATH}/../../../../../os
+
+source ${OS_DIR_PATH}/.config
 
 # Path ENV
 BOARD_NAME=${CONFIG_ARCH_BOARD}
-OS_DIR_PATH=${PWD}
 BUILD_DIR_PATH=${OS_DIR_PATH}/../build
 BOARD_DIR_PATH=${BUILD_DIR_PATH}/configs/${BOARD_NAME}
 OPENOCD_DIR_PATH=${BOARD_DIR_PATH}/tools/openocd

--- a/tools/fs/mkromfsimg.sh
+++ b/tools/fs/mkromfsimg.sh
@@ -51,28 +51,21 @@
 #
 ############################################################################
 
-# Make sure we understand where we are
-if [ ! -f ../tools/fs/mkromfsimg.sh ]; then
-  cd .. || { echo "ERROR: cd .. failed"; exit 1; }
-  if [ ! -f ../tools/fs/mkromfsimg.sh ]; then
-    error "This script must be executed from the top-level os/ directory"
-    exit 1
-  fi
-fi
-
 echo "Making romfs.img..."
 
 # Environmental stuff
 
-topdir=$PWD
-buildpath=${topdir}/../build
-contentsdir=${topdir}/../tools/fs/contents
-romfsimg=${buildpath}/output/bin/romfs.img
+FSTOOL_PATH=`test -d ${0%/*} && cd ${0%/*}; pwd`
+# When location of this script is changed, only OS_PATH should be changed together!!!
+OS_PATH=${FSTOOL_PATH}/../../os
+BIN_PATH=${OS_PATH}/../build/output/bin
+CONTENTS_PATH=${FSTOOL_PATH}/contents
+ROMFS_IMG=${BIN_PATH}/romfs.img
 
 # Sanity checks
 
-if [ ! -d "${contentsdir}" ]; then
-  echo "ERROR: Directory ${contentsdir} does not exist"
+if [ ! -d "${CONTENTS_PATH}" ]; then
+  echo "ERROR: Directory ${CONTENTS_PATH} does not exist"
   exit 1
 fi
 
@@ -84,7 +77,7 @@ genromfs -h 1>/dev/null 2>&1 || { \
 
 # Now we are ready to make the ROMFS image
 
-genromfs -f ${romfsimg} -d ${contentsdir} -x .gitignore -V "TinyAraROMVol" || { echo "genromfs failed" ; exit 1 ; }
+genromfs -f ${ROMFS_IMG} -d ${CONTENTS_PATH} -x .gitignore -V "TinyAraROMVol" || { echo "genromfs failed" ; exit 1 ; }
 
 # And, finally, create the header file
-echo "${romfsimg} was made."
+echo "${ROMFS_IMG} was made."

--- a/tools/memory/g_var_profiler.sh
+++ b/tools/memory/g_var_profiler.sh
@@ -19,63 +19,61 @@
 # File 	 : g_var_profiler.sh
 # Description : parse the global variable which size is greater than <SIZE>
 
-ref_size=$1
-path=$2
-output_file=$3
-WD=`pwd`
-prefix=`echo ${PWD%/*/*}`
+REF_SIZE=$1
+ELF=$2
+OUTPUT_FILE=$3
+MEMTOOL_PATH=`test -d ${0%/*} && cd ${0%/*}; pwd`
+BASE_PATH=`echo ${MEMTOOL_PATH%/*/*}`
 
 if [ "$1" == "--help" ]
 then
-	echo "Usage: $0 [SIZE] [ELF_PATH] [OUTPUT_FILENAME]"
+	echo "Usage: $0 [SIZE] [ELF] [OUTPUT_FILENAME]"
 	echo "This script parses the global variable which size is greater than [SIZE]"
 	echo -e "\tIf no input params are specified, below is assumed"
 	echo -e "\tSIZE : 256"
-	echo -e "\tELF_PATH : ../../build/output/bin/tinyara"
+	echo -e "\tELF : ../../build/output/bin/tinyara"
 	echo -e "\tOUTPUT_FILENAME : var_list_over_SIZEbytes.txt"
 	echo "Output file info"
 	echo -e "\tSIZE : variable size(bytes)"
 	echo -e "\tTYPE : you can refer to this site <https://sourceware.org/binutils/docs/binutils/nm.html>"
+
 	exit
 fi
 
-if [ -z ${ref_size} ]
-then
-	ref_size=256
+if [ -z ${REF_SIZE} ]; then
+	REF_SIZE=256
 fi
 
-if [ -z ${path} ]
-then
-	path="${WD}/../../build/output/bin/tinyara"
+if [ -z ${ELF} ]; then
+	ELF="${MEMTOOL_PATH}/../../build/output/bin/tinyara"
 fi
 
-if [ -z ${output_file} ]
-then
-	output_file="var_list_over_${ref_size}bytes.txt"
+if [ -z ${OUTPUT_FILE} ]; then
+	OUTPUT_FILE="var_list_over_${REF_SIZE}bytes.txt"
 fi
 
 temp_output_file="temp_var_list.txt"
 
 ## find over-size global variables through nm
-nm -S --size-sort -l $path > $temp_output_file
+nm -S --size-sort -l $ELF > $temp_output_file
 
-if [ -f ${output_file} ]
+if [ -f ${OUTPUT_FILE} ]
 then
-	rm $output_file
+	rm $OUTPUT_FILE
 fi
 
-echo "SIZE(bytes)	TYPE	VARIABLE		PATH" >> $output_file
-echo "------------------------------------------------------------" >> $output_file
+echo "SIZE(bytes)	TYPE	VARIABLE		PATH" >> $OUTPUT_FILE
+echo "------------------------------------------------------------" >> $OUTPUT_FILE
 while read line 
 do
 	IFS=' ' read -a array <<< $line
 	var_size=`echo $((16#${array[1]}))`
 	#Parse only type B, b, d, D, G, g, S, s
-	if [ ${array[2]} == "B" ] || [ ${array[2]} == "b" ] || [ ${array[2]} == "d" ] || [ ${array[2]} == "D" ] || [ ${array[2]} == "G" ] || [ ${array[2]} == "g" ] || [ ${array[2]} == "s" ] || [ ${array[2]} == "S" ] && [ $ref_size -le $var_size ]; then 
-		echo -e $var_size"\t\t"${array[2]}"\t"${array[3]}"\t\t"${array[4]#$prefix} >> $output_file
+	if [ ${array[2]} == "B" ] || [ ${array[2]} == "b" ] || [ ${array[2]} == "d" ] || [ ${array[2]} == "D" ] || [ ${array[2]} == "G" ] || [ ${array[2]} == "g" ] || [ ${array[2]} == "s" ] || [ ${array[2]} == "S" ] && [ $REF_SIZE -le $var_size ]; then 
+		echo -e $var_size"\t\t"${array[2]}"\t"${array[3]}"\t\t"${array[4]#$BASE_PATH} >> $OUTPUT_FILE
 	fi
 
 done < $temp_output_file
 rm $temp_output_file
 
-echo "Output file(${output_file}) is generated."
+echo "Output file(${OUTPUT_FILE}) is generated."


### PR DESCRIPTION
Many sh files get a current path using PWD command. But it
is changed where you run it.
For example, if you run a shell script on aa/bb folder, PWD is aa/bb.
But if you run it like bb/xx.sh on aa folder, PWD is aa.
The location of executing shell script affects working of shell script.

This commit gets the current path from location of shell script which
is fixed. Wherever you run it, it works.

Signed-off-by: sunghan-chang <sh924.chang@samsung.com>