### PR TITLE
media: Return 0 when OutputDatasource size is 0

### DIFF
--- a/framework/src/media/BufferOutputDataSource.cpp
+++ b/framework/src/media/BufferOutputDataSource.cpp
@@ -78,6 +78,10 @@ bool BufferOutputDataSource::isPrepare()
 
 ssize_t BufferOutputDataSource::write(unsigned char *buf, size_t size)
 {
+	if (size == 0) {
+		return 0;
+	}
+
 	if (!isPrepare()) {
 		return EOF;
 	}

--- a/framework/src/media/FileOutputDataSource.cpp
+++ b/framework/src/media/FileOutputDataSource.cpp
@@ -105,6 +105,10 @@ bool FileOutputDataSource::isPrepare()
 
 ssize_t FileOutputDataSource::write(unsigned char *buf, size_t size)
 {
+	if (size == 0) {
+		return 0;
+	}
+
 	if (!isPrepare()) {
 		return EOF;
 	}

--- a/framework/src/media/SocketOutputDataSource.cpp
+++ b/framework/src/media/SocketOutputDataSource.cpp
@@ -99,6 +99,10 @@ bool SocketOutputDataSource::isPrepare()
 
 ssize_t SocketOutputDataSource::write(unsigned char* buf, size_t size)
 {
+	if (size == 0) {
+		return 0;
+	}
+
 	if (!buf) {
 		return EOF;
 	}


### PR DESCRIPTION
0 length fwrite(FileOutputDataSource) or array(BufferOutputSource)
are not verified. So just return 0 if size is 0