### PR TITLE
arch/arm: enhence assert display

### DIFF
--- a/os/arch/arm/src/armv7-m/up_assert.c
+++ b/os/arch/arm/src/armv7-m/up_assert.c
@@ -191,11 +191,11 @@ static void up_taskdump(FAR struct tcb_s *tcb, FAR void *arg)
 	/* Dump interesting properties of this task */
 
 #if CONFIG_TASK_NAME_SIZE > 0
-	lldbg("%s: PID=%d PRI=%d Stack Used=%lu of %lu\n",
+	lldbg("%10s | %5d | %4d | %7lu / %7lu\n",
 			tcb->name, tcb->pid, tcb->sched_priority,
 			(unsigned long)up_check_tcbstack(tcb), (unsigned long)tcb->adj_stack_size);
 #else
-	lldbg("PID: %d PRI=%d Stack Used=%lu of %lu\n",
+	lldbg("%5d | %4d | %7lu / %7lu\n",
 			tcb->pid, tcb->sched_priority, (unsigned long)up_check_tcbstack(tcb),
 			(unsigned long)tcb->adj_stack_size);
 #endif
@@ -212,6 +212,14 @@ static inline void up_showtasks(void)
 	lldbg("*******************************************\n");
 	lldbg("List of all tasks in the system:\n");
 	lldbg("*******************************************\n");
+
+#if CONFIG_TASK_NAME_SIZE > 0
+	lldbg("   NAME   |  PID  |  PRI |    USED /  TOTAL STACK\n");
+	lldbg("--------------------------------------------------\n");
+#else
+	lldbg("  PID | PRI |   USED / TOTAL STACK\n");
+	lldbg("----------------------------------\n");
+#endif
 
 	/* Dump interesting properties of each task in the crash environment */
 

--- a/os/arch/arm/src/armv7-m/up_assert.c
+++ b/os/arch/arm/src/armv7-m/up_assert.c
@@ -199,6 +199,10 @@ static void up_taskdump(FAR struct tcb_s *tcb, FAR void *arg)
 			tcb->pid, tcb->sched_priority, (unsigned long)up_check_tcbstack(tcb),
 			(unsigned long)tcb->adj_stack_size);
 #endif
+
+	if (tcb->pid != 0 && up_check_tcbstack(tcb) == tcb->adj_stack_size) {
+		lldbg("  !!! PID (%d) STACK OVERFLOW !!! \n", tcb->pid);
+	}
 }
 #endif
 
@@ -215,7 +219,7 @@ static inline void up_showtasks(void)
 
 #if CONFIG_TASK_NAME_SIZE > 0
 	lldbg("   NAME   |  PID  |  PRI |    USED /  TOTAL STACK\n");
-	lldbg("--------------------------------------------------\n");
+	lldbg("-------------------------------------------------\n");
 #else
 	lldbg("  PID | PRI |   USED / TOTAL STACK\n");
 	lldbg("----------------------------------\n");

--- a/os/arch/arm/src/armv7-r/arm_assert.c
+++ b/os/arch/arm/src/armv7-r/arm_assert.c
@@ -478,9 +478,13 @@ static void up_taskdump(FAR struct tcb_s *tcb, FAR void *arg)
 	/* Dump interesting properties of this task */
 
 #if CONFIG_TASK_NAME_SIZE > 0
-	lldbg("%s: PID=%d PRI=%d Stack Used=%lu of %lu\n", tcb->name, tcb->pid, tcb->sched_priority, (unsigned long)up_check_tcbstack(tcb), (unsigned long)tcb->adj_stack_size);
+	lldbg("%10s | %5d | %4d | %7lu / %7lu\n",
+			tcb->name, tcb->pid, tcb->sched_priority,
+			(unsigned long)up_check_tcbstack(tcb), (unsigned long)tcb->adj_stack_size);
 #else
-	lldbg("PID: %d PRI=%d Stack Used=%lu of %lu\n", tcb->pid, tcb->sched_priority, (unsigned long)up_check_tcbstack(tcb), (unsigned long)tcb->adj_stack_size);
+	lldbg("%5d | %4d | %7lu / %7lu\n",
+			tcb->pid, tcb->sched_priority, (unsigned long)up_check_tcbstack(tcb),
+			(unsigned long)tcb->adj_stack_size);
 #endif
 }
 #endif
@@ -495,6 +499,14 @@ static inline void up_showtasks(void)
 	lldbg("*******************************************\n");
 	lldbg("List of all tasks in the system:\n");
 	lldbg("*******************************************\n");
+
+#if CONFIG_TASK_NAME_SIZE > 0
+	lldbg("   NAME   |  PID  |  PRI |    USED /  TOTAL STACK\n");
+	lldbg("--------------------------------------------------\n");
+#else
+	lldbg("  PID | PRI |   USED / TOTAL STACK\n");
+	lldbg("----------------------------------\n");
+#endif
 
 	/* Dump interesting properties of each task in the crash environment */
 

--- a/os/arch/arm/src/armv7-r/arm_assert.c
+++ b/os/arch/arm/src/armv7-r/arm_assert.c
@@ -486,6 +486,10 @@ static void up_taskdump(FAR struct tcb_s *tcb, FAR void *arg)
 			tcb->pid, tcb->sched_priority, (unsigned long)up_check_tcbstack(tcb),
 			(unsigned long)tcb->adj_stack_size);
 #endif
+
+	if (tcb->pid != 0 && up_check_tcbstack(tcb) == tcb->adj_stack_size) {
+		lldbg("  !!! PID (%d) STACK OVERFLOW !!! \n", tcb->pid);
+	}
 }
 #endif
 


### PR DESCRIPTION
1. change a format of task information
```
Previousely displaying format of task information at assert is
little difficult to see.

up_showtasks: *******************************************
up_showtasks: List of all tasks in the system:
up_showtasks: *******************************************
up_taskdump: Idle Task: PID=0 PRI=0 Stack Used=0 of 0
up_taskdump: hpwork: PID=1 PRI=224 Stack Used=164 of 2028
up_taskdump: tash: PID=3 PRI=125 Stack Used=372 of 4076
up_taskdump: appmain: PID=4 PRI=100 Stack Used=372 of 2028

This commit aligns items as shown below:

up_showtasks: *******************************************
up_showtasks: List of all tasks in the system:
up_showtasks: *******************************************
up_showtasks:    NAME   |  PID  |  PRI |    USED /  TOTAL STACK
up_showtasks: --------------------------------------------------
up_taskdump:  Idle Task |     0 |    0 |       0 /       0
up_taskdump:     hpwork |     1 |  224 |     164 /    2028
up_taskdump:       tash |     3 |  125 |     372 /    4076
up_taskdump:    appmain |     4 |  100 |     372 /    2028
```
2. display stack-overflowed threads
```
To know easily, let's print stack-overflowed threads at
assert information.

up_showtasks: *******************************************
up_showtasks: List of all tasks in the system:
up_showtasks: *******************************************
up_showtasks:    NAME   |  PID  |  PRI |    USED /  TOTAL STACK
up_showtasks: --------------------------------------------------
up_taskdump:  Idle Task |     0 |    0 |       0 /       0
up_taskdump:     hpwork |     1 |  224 |     164 /    2028
up_taskdump:       tash |     3 |  125 |     372 /    4076
up_taskdump:    appmain |     4 |  100 |     236 /     236
up_taskdump:   !!! PID (4) STACK OVERFLOW !!!
```