### PR TITLE
media: Add subtype parameter in audio_manager API

### DIFF
--- a/framework/src/media/audio/audio_manager.c
+++ b/framework/src/media/audio/audio_manager.c
@@ -1481,7 +1481,7 @@ audio_manager_result_t find_stream_in_device_with_process_type(device_process_ty
 	return AUDIO_MANAGER_DEVICE_NOT_SUPPORT;
 }
 
-audio_manager_result_t request_stream_in_device_process(int card_id, int device_id, int cmd)
+audio_manager_result_t request_stream_in_device_process(int card_id, int device_id, int cmd, device_process_subtype_t subtype)
 {
 	char path[AUDIO_DEVICE_FULL_PATH_LENGTH];
 	int fd;
@@ -1506,7 +1506,7 @@ audio_manager_result_t request_stream_in_device_process(int card_id, int device_
 		return AUDIO_MANAGER_NO_AVAIL_CARD;
 	}
 
-	ret = ioctl(fd, cmd, 0);
+	ret = ioctl(fd, cmd, subtype);
 	close(fd);
 	pthread_mutex_unlock(&(card->card_mutex));
 	if (ret < 0) {
@@ -1516,12 +1516,12 @@ audio_manager_result_t request_stream_in_device_process(int card_id, int device_
 	return AUDIO_MANAGER_SUCCESS;
 }
 
-audio_manager_result_t start_stream_in_device_process(int card_id, int device_id)
+audio_manager_result_t start_stream_in_device_process(int card_id, int device_id, device_process_subtype_t subtype)
 {
-	return request_stream_in_device_process(card_id, device_id, AUDIOIOC_STARTPROCESS);
+	return request_stream_in_device_process(card_id, device_id, AUDIOIOC_STARTPROCESS, subtype);
 }
 
-audio_manager_result_t stop_stream_in_device_process(int card_id, int device_id)
+audio_manager_result_t stop_stream_in_device_process(int card_id, int device_id, device_process_subtype_t subtype)
 {
 	audio_card_info_t *card;
 	audio_manager_result_t result;
@@ -1533,7 +1533,7 @@ audio_manager_result_t stop_stream_in_device_process(int card_id, int device_id)
 	card = &g_audio_in_cards[card_id];
 	
 	/* Stop First */
-	result = request_stream_in_device_process(card_id, device_id, AUDIOIOC_STOPPROCESS);
+	result = request_stream_in_device_process(card_id, device_id, AUDIOIOC_STOPPROCESS, subtype);
 
 	/* Consume all remained msg */
 	if (result == AUDIO_MANAGER_SUCCESS) {
@@ -1664,7 +1664,7 @@ audio_manager_result_t register_stream_in_device_process_handler(int card_id, in
 	return AUDIO_MANAGER_SUCCESS;
 }
 
-audio_manager_result_t unregister_stream_in_device_process(int card_id, int device_id)
+audio_manager_result_t unregister_stream_in_device_process_type(int card_id, int device_id, device_process_subtype_t subtype)
 {
 	char path[AUDIO_DEVICE_FULL_PATH_LENGTH];
 	int ret;
@@ -1691,7 +1691,7 @@ audio_manager_result_t unregister_stream_in_device_process(int card_id, int devi
 	}
 
 	/* Register our message queue with the audio device */
-	ret = ioctl(fd, AUDIOIOC_UNREGISTERPROCESS, 0);
+	ret = ioctl(fd, AUDIOIOC_UNREGISTERPROCESS, subtype);
 	close(fd);
 	pthread_mutex_unlock(&(card->card_mutex));
 	if (ret < 0) {

--- a/framework/src/media/audio/audio_manager.h
+++ b/framework/src/media/audio/audio_manager.h
@@ -489,11 +489,12 @@ audio_manager_result_t register_stream_in_device_process_type(int card_id, int d
  *
  * Input parameter:
  *   card_id : Target card id , device_id : Target device id
+ *   subtype : Process Subtype
  *
  * Return Value:
  *   On success, AUDIO_MANAGER_SUCCESS. Otherwise, a negative value.
  ****************************************************************************/
-audio_manager_result_t start_stream_in_device_process(int card_id, int device_id);
+audio_manager_result_t start_stream_in_device_process(int card_id, int device_id, device_process_subtype_t subtype);
 
 /****************************************************************************
  * Name: stop_stream_in_device_process
@@ -503,25 +504,27 @@ audio_manager_result_t start_stream_in_device_process(int card_id, int device_id
  *
  * Input parameter:
  *   card_id : Target card id , device_id : Target device id
+ *   subtype : Process Subtype
  *
  * Return Value:
  *   On success, AUDIO_MANAGER_SUCCESS. Otherwise, a negative value.
  ****************************************************************************/
-audio_manager_result_t stop_stream_in_device_process(int card_id, int device_id);
+audio_manager_result_t stop_stream_in_device_process(int card_id, int device_id, device_process_subtype_t subtype);
 
 /****************************************************************************
- * Name: unregister_stream_in_device_process
+ * Name: unregister_stream_in_device_process_type
  *
  * Description:
  *   Release device process and unregister it
  *
  * Input parameter:
  *   card_id : Target card id , device_id : Target device id
+ *   subtype : Process Subtype
  *
  * Return Value:
  *   On success, AUDIO_MANAGER_SUCCESS. Otherwise, a negative value.
  ****************************************************************************/
-audio_manager_result_t unregister_stream_in_device_process(int card_id, int device_id);
+audio_manager_result_t unregister_stream_in_device_process_type(int card_id, int device_id, device_process_subtype_t subtype);
 
 /****************************************************************************
  * Name: get_device_process_handler_message

--- a/framework/src/media/voice/HardwareEndPointDetector.cpp
+++ b/framework/src/media/voice/HardwareEndPointDetector.cpp
@@ -55,7 +55,7 @@ bool HardwareEndPointDetector::init(uint32_t samprate, uint8_t channels)
 		return false;
 	}
 
-	result = start_stream_in_device_process(mCard, mDevice);
+	result = start_stream_in_device_process(mCard, mDevice, AUDIO_DEVICE_SPEECH_DETECT_EPD);
 	if (result != AUDIO_MANAGER_SUCCESS) {
 		meddbg("Error: start_stream_in_device_process(%d, %d) failed!\n", mCard, mDevice);
 		return false;
@@ -86,10 +86,10 @@ void HardwareEndPointDetector::deinit()
 {
 	audio_manager_result_t result;
 
-	result = unregister_stream_in_device_process(mCard, mDevice);
+	result = unregister_stream_in_device_process_type(mCard, mDevice, AUDIO_DEVICE_SPEECH_DETECT_EPD);
 
 	if (result != AUDIO_MANAGER_SUCCESS) {
-		meddbg("Error: unregister_stream_in_device_process(%d, %d) failed!\n", mCard, mDevice);
+		meddbg("Error: unregister_stream_in_device_process_type(%d, %d) failed!\n", mCard, mDevice);
 	}
 }
 
@@ -105,7 +105,7 @@ void *HardwareEndPointDetector::endPointDetectThread(void *param)
 		usleep(30 * 1000);
 	}
 
-	unregister_stream_in_device_process(detector->mCard, detector->mDevice);
+	unregister_stream_in_device_process_type(detector->mCard, detector->mDevice, AUDIO_DEVICE_SPEECH_DETECT_EPD);
 
 	return NULL;
 }
@@ -119,7 +119,7 @@ bool HardwareEndPointDetector::processEPDFrame(short *sample, int numSample)
 
 	if (result == AUDIO_MANAGER_SUCCESS) {
 		if (msgId == AUDIO_DEVICE_SPEECH_DETECT_EPD) {
-			stop_stream_in_device_process(mCard, mDevice);
+			stop_stream_in_device_process(mCard, mDevice, AUDIO_DEVICE_SPEECH_DETECT_EPD);
 			return true;
 		}
 	} else if (result == AUDIO_MANAGER_INVALID_DEVICE) {

--- a/framework/src/media/voice/HardwareKeywordDetector.cpp
+++ b/framework/src/media/voice/HardwareKeywordDetector.cpp
@@ -64,10 +64,10 @@ void HardwareKeywordDetector::deinit()
 {
 	audio_manager_result_t result;
 
-	result = unregister_stream_in_device_process(mCard, mDevice);
+	result = unregister_stream_in_device_process_type(mCard, mDevice, AUDIO_DEVICE_SPEECH_DETECT_KD);
 
 	if (result != AUDIO_MANAGER_SUCCESS) {
-		meddbg("Error: unregister_stream_in_device_process(%d, %d) failed!\n", mCard, mDevice);
+		meddbg("Error: unregister_stream_in_device_process_type(%d, %d) failed!\n", mCard, mDevice);
 	}
 }
 
@@ -94,7 +94,7 @@ void *HardwareKeywordDetector::keywordDetectThread(void *param)
 		usleep(30 * 1000);
 	}
 
-	stop_stream_in_device_process(detector->mCard, detector->mDevice);
+	stop_stream_in_device_process(detector->mCard, detector->mDevice, AUDIO_DEVICE_SPEECH_DETECT_KD);
 
 	return NULL;
 }
@@ -107,7 +107,7 @@ bool HardwareKeywordDetector::startKeywordDetect(uint32_t timeout)
 
 	medvdbg("startKeywordDetect for %d %d\n", mCard, mDevice);
 
-	result = start_stream_in_device_process(mCard, mDevice);
+	result = start_stream_in_device_process(mCard, mDevice, AUDIO_DEVICE_SPEECH_DETECT_KD);
 
 	if (result != AUDIO_MANAGER_SUCCESS) {
 		meddbg("Error: start_stream_in_device_process(%d, %d) failed!\n", mCard, mDevice);


### PR DESCRIPTION
unregister_stream_in_device_process, start_stream_in_device_process,
stop_stream_in_device_process have new subtype parameter.
User can control stream_in_device subtype by subtype