### PR TITLE
framework/media: Modify comparison condition of MediaRecorder

### DIFF
--- a/framework/src/media/MediaRecorderImpl.cpp
+++ b/framework/src/media/MediaRecorderImpl.cpp
@@ -187,7 +187,7 @@ void MediaRecorderImpl::prepareRecorder(recorder_result_t& ret)
 		return notifySync();
 	}
 
-	if (mDuration > 0) {
+	if (mDuration >= 0) {
 		mTotalFrames = mDuration * source->getSampleRate();
 	}
 
@@ -552,8 +552,8 @@ void MediaRecorderImpl::setRecorderDuration(int second, recorder_result_t& ret)
 		ret = RECORDER_ERROR_INVALID_STATE;
 		return notifySync();
 	}
-	if (second > 0) {
-		medvdbg("second is greater than zero, set limit : %d\n", second);
+	if (second >= 0) {
+		medvdbg("second is greater than or eqaul to zero, set limit : %d\n", second);
 		mDuration = second;
 	}
 


### PR DESCRIPTION
Modify comparison condition to guarantee the re-setting duration of MediaRecorder.

At first, Set the duration of MediaRecorder to 3 seconds.
And then set it back to 0 for endless recording.
But, Under the current comparison condition, it can't be back to 0.