### PR TITLE
media: Add handler_refcnt

### DIFF
--- a/os/drivers/audio/audio_null.c
+++ b/os/drivers/audio/audio_null.c
@@ -643,7 +643,6 @@ static int null_unregisterprocess(FAR struct audio_lowerhalf_s *dev)
 	}
 
 	if (priv->dev.process_mq != NULL) {
-		mq_close(priv->dev.process_mq);
 		priv->dev.process_mq = NULL;
 	} else {
 		auddbg("mq is null\n");


### PR DESCRIPTION
Since mq_open is called in audio_manager,
mq_close should be called in audio_manager too.
And set config->process_handler as NULL at unregisteration