### PR TITLE
mm_heap/heapinfo: fix overflow in percentage calculation

### DIFF
--- a/os/mm/mm_heap/mm_heapinfo.c
+++ b/os/mm/mm_heap/mm_heapinfo.c
@@ -191,9 +191,9 @@ void heapinfo_parse(FAR struct mm_heap_s *heap, int mode, pid_t pid)
 	printf("****************************************************************\n");
 	printf("Total                           : %u (100%%)\n", heap->mm_heapsize);
 	printf("  - Allocated (Current / Peak)  : %u (%d%%) / %u (%d%%)\n",\
-		heap->total_alloc_size, heap->total_alloc_size * 100 / heap->mm_heapsize,\
-		heap->peak_alloc_size,  heap->peak_alloc_size * 100 / heap->mm_heapsize);
-	printf("  - Free (Current)              : %u (%d%%)\n", fordblks, fordblks * 100 / heap->mm_heapsize);
+		heap->total_alloc_size, (size_t)((uint64_t)(heap->total_alloc_size) * 100 / heap->mm_heapsize),\
+		heap->peak_alloc_size,  (size_t)((uint64_t)(heap->peak_alloc_size) * 100 / heap->mm_heapsize));
+	printf("  - Free (Current)              : %u (%d%%)\n", fordblks, (size_t)((uint64_t)fordblks * 100 / heap->mm_heapsize));
 	printf("  - Reserved                    : %u\n", SIZEOF_MM_ALLOCNODE * 2);
 
 	printf("\n****************************************************************\n");


### PR DESCRIPTION
There is a possibility of overflow over 32 bit while multiplying
large free size with 100.

Example overflowed heapinfo output:
Total                           : 125870864 (100%)
  - Allocated (Current / Peak)  : 1204032 (0%) / 1245776 (0%)
  - Free (Current)              : 124666800 (30%)
  - Reserved                    : 32

Signed-off-by: Manohara HK <manohara.hk@samsung.com>
Signed-off-by: Yashwanth <v.yashwanth@samsung.com>