### PR TITLE
framework/arastorage:fix index memb release issue

### DIFF
--- a/framework/src/arastorage/index_manager.c
+++ b/framework/src/arastorage/index_manager.c
@@ -275,6 +275,7 @@ db_result_t index_load(relation_t *rel, attribute_t *attr)
 		api = find_index_api(index->type);
 		if (api == NULL) {
 			DB_LOG_E("DB: No API for index type %d\n", index->type);
+			memb_free(&index_memb, index); 
 			return DB_INDEX_ERROR;
 		}
 


### PR DESCRIPTION
index_load function, after alloc index, when find_index_api
return NULL, need to release index before return error.
@Taejun-Kwon