### PR TITLE
apps/appgen: Add templates for a sample application of the task manager and the eventloop

### DIFF
--- a/apps/appgen/README.md
+++ b/apps/appgen/README.md
@@ -6,7 +6,8 @@
 
 ### How to use?
 
-In any directory, run the appgen shell script and just enter the application name that you would make.
+In any directory, run the appgen shell script first.
+Then, just enter the type of application and the application name that you would make.
 
 Your application would be generated at the apps/examples/
 
@@ -14,9 +15,16 @@ Your application would be generated at the apps/examples/
 TizenRT/os$ tools/appgen.sh
 TizenRT Application Generator
 ======================= v 1.0
+Select Application Type
+1. Hello World Sample
+2. Task Manager Sample
+3. Eventloop Sample
+=============================
+Select application type: 1
 Enter application name: test application
 [Summary]
 -------------------------------
+* Application Type: Hello World Sample
 * Application Name: test application
 * Configuration Key: CONFIG_APP_TEST_APPLICATION
 * Entry Function: test_application_main
@@ -28,7 +36,7 @@ Generating...
 
 * How to setup your application
 Run) TizenRT/os/tools$ ./configure.sh <BOARD>/<CONFIG>
-Run) TizenRT/os$ make menuconfig
+Run) TizenRT/os$ ./dbuild.sh menuconfig
 1. Turn on your application in Application Configuration/Examples menu
 2. Set the entry point to your application in Application Configuration menu
 ------------------------------
@@ -38,7 +46,7 @@ Done!!
 
 ### After generated
 ```sh
-TizenRT/os$ make menuconfig
+TizenRT/os$ ./dbuild.sh menuconfig
 ```
 
 - Enter "Application Configuration/Examples"

--- a/apps/appgen/template_Kconfig_eventloop
+++ b/apps/appgen/template_Kconfig_eventloop
@@ -1,0 +1,15 @@
+#
+# For a description of the syntax of this configuration file,
+# see kconfig-language at https://www.kernel.org/doc/Documentation/kbuild/kconfig-language.txt
+#
+
+config APP_##APP_NAME_UPPER##
+	bool "\"##APP_NAME##\" Application"
+	default n
+	select EVENTLOOP
+	---help---
+		Enable the \"##APP_NAME##\" Application
+
+config USER_ENTRYPOINT
+	string
+	default "##ENTRY_FUNC##" if ENTRY_##APP_NAME_UPPER##

--- a/apps/appgen/template_Kconfig_task_manager
+++ b/apps/appgen/template_Kconfig_task_manager
@@ -1,0 +1,15 @@
+#
+# For a description of the syntax of this configuration file,
+# see kconfig-language at https://www.kernel.org/doc/Documentation/kbuild/kconfig-language.txt
+#
+
+config APP_##APP_NAME_UPPER##
+	bool "\"##APP_NAME##\" Application"
+	default n
+	select TASK_MANAGER
+	---help---
+		Enable the \"##APP_NAME##\" Application
+
+config USER_ENTRYPOINT
+	string
+	default "##ENTRY_FUNC##" if ENTRY_##APP_NAME_UPPER##

--- a/apps/appgen/template_eventloop_sample_main.c_source
+++ b/apps/appgen/template_eventloop_sample_main.c_source
@@ -1,0 +1,103 @@
+/****************************************************************************
+ *
+ * Copyright ##YEAR## Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <tinyara/config.h>
+#include <stdio.h>
+
+#include <eventloop/eventloop.h>
+
+/************************************************************************
+ * Pre-processor Definitions
+ ************************************************************************/
+
+#define EVENTLOOP_TIMER_INTERVAL 2000
+#define EVENTLOOP_EVENT_DATA     "WIFI_ON"
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+static bool sample_timer_callback(void *data)
+{
+	printf("Hello, sample timer callback is called! callback data: %s\n", (char *)data);
+
+	/* Timer callback is no longer called 
+	 * when it returns EVENTLOOP_CALLBACK_STOP */
+
+	return EVENTLOOP_CALLBACK_STOP;
+}
+
+static bool sample_event_callback(void *registered_cb_data, void *received_event_data)
+{
+	printf("Registered callback data: %s, Received event data: %s\n", (char *)registered_cb_data, (char *)received_event_data);
+
+	/* Event callback is no longer called 
+	 * when it returns EVENTLOOP_CALLBACK_STOP */
+
+	return EVENTLOOP_CALLBACK_STOP;
+}
+
+/****************************************************************************
+ * ##ENTRY_FUNC##
+ ****************************************************************************/
+
+#ifdef CONFIG_BUILD_KERNEL
+int main(int argc, FAR char *argv[])
+#else
+int ##ENTRY_FUNC##(int argc, char *argv[])
+#endif
+{
+	int ret;
+
+	el_timer_t *timer;
+	el_event_t *event;
+	char *timer_cb_data = "Hello Timer";
+	char *event_cb_data = "Hello Event";
+
+	timer = eventloop_add_timer(EVENTLOOP_TIMER_INTERVAL, true, sample_timer_callback, timer_cb_data);
+	if (timer == NULL) {
+		printf("Failed to add timer!\n");
+	}
+
+	event = eventloop_add_event_handler(EL_EVENT_WIFI_ON, sample_event_callback, event_cb_data);
+	if (event == NULL) {
+		printf("Failed to add event handler!\n");
+	}
+
+	ret = eventloop_send_event(EL_EVENT_WIFI_ON, (void *)EVENTLOOP_EVENT_DATA, strlen(EVENTLOOP_EVENT_DATA) + 1);
+	if (ret != OK) {
+		printf("Failed to send event\n");
+	}
+
+	/* Please add timers or event handlers before eventloop_loop_run() */
+
+	ret = eventloop_loop_run();
+	if (ret != OK) {
+		printf("eventloop_loop_run() is failed.\n");
+	} else {
+		/* If there is nothing to process in the eventloop, the eventloop is ended. */
+
+		printf("Loop is ended!\n");
+	}
+
+	return 0;
+}

--- a/apps/appgen/template_task_manager_sample_main.c_source
+++ b/apps/appgen/template_task_manager_sample_main.c_source
@@ -1,0 +1,103 @@
+/****************************************************************************
+ *
+ * Copyright ##YEAR## Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <tinyara/config.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include <task_manager/task_manager.h>
+
+#define SAMPLE_TASK_NAME         "sample_task"
+#define SAMPLE_TASK_PRIORITY     100
+#define SAMPLE_TASK_STACKSIZE    1024
+#define SAMPLE_TASK_ARGV         NULL
+#define SAMPLE_TASK_PERMISSION   TM_APP_PERMISSION_ALL
+#define SAMPLE_TASK_TIMEOUT      TM_RESPONSE_WAIT_INF
+#define SAMPLE_BROADCAST_CB_DATA "Broadcast"
+
+/****************************************************************************
+ * Private Function
+ ****************************************************************************/
+
+static void sample_unicast_cb(tm_msg_t *unicast_data)
+{
+	printf("Hello, sample unicast callback!\n");
+}
+
+static void sample_broadcast_cb(void *broadcast_data, void *cb_data)
+{
+	printf("Hello, Wi-Fi is on! Callback Data: %s\n", (char *)cb_data);
+}
+
+static int sample_task(int argc, char *argv[])
+{
+	int ret;
+	tm_msg_t *broadcast_cb_data;
+
+	ret = task_manager_set_unicast_cb(sample_unicast_cb);
+	if (ret < 0) {
+		printf("Failed to set unicast callback! Return: %d\n", ret);
+	}
+
+	broadcast_cb_data = (tm_msg_t *)malloc(sizeof(tm_msg_t));
+	broadcast_cb_data->msg = (void *)SAMPLE_BROADCAST_CB_DATA;
+	broadcast_cb_data->msg_size = strlen(SAMPLE_BROADCAST_CB_DATA) + 1;
+	ret = task_manager_set_broadcast_cb(TM_BROADCAST_WIFI_ON, sample_broadcast_cb, broadcast_cb_data);
+	if (ret < 0) {
+		printf("Failed to set broadcast callback! Return: %d\n", ret);
+	}
+	free(broadcast_cb_data);
+
+	printf("Hello, sample_task is started by the task manager!\n");
+	return 0;
+}
+
+
+/****************************************************************************
+ * ##ENTRY_FUNC##
+ ****************************************************************************/
+
+#ifdef CONFIG_BUILD_KERNEL
+int main(int argc, FAR char *argv[])
+#else
+int ##ENTRY_FUNC##(int argc, char *argv[])
+#endif
+{
+	int handle;
+	int ret;
+
+	handle = task_manager_register_task(SAMPLE_TASK_NAME, SAMPLE_TASK_PRIORITY, SAMPLE_TASK_STACKSIZE, sample_task, SAMPLE_TASK_ARGV, SAMPLE_TASK_PERMISSION, SAMPLE_TASK_TIMEOUT);
+	if (handle < 0) {
+		printf("Failed to register sample_task to the task manager! Return: %d\n", handle);
+	}
+
+	ret = task_manager_start(handle, SAMPLE_TASK_TIMEOUT);
+	if (ret < 0) {
+		printf("Failed to start sample_task! Return: %d\n", ret);
+	}
+
+	/* User should unregister the registered task if user no longer wants to use registered task.
+	 * Otherwise, a memory leak may occur.
+	 * ret = task_manager_unregister(handle, SAMPLE_TASK_TIMEOUT); */
+
+	return 0;
+}

--- a/os/tools/appgen.sh
+++ b/os/tools/appgen.sh
@@ -10,7 +10,13 @@ cd - > /dev/null
 
 echo "${BOLD}TizenRT Application Generator${NORMAL}"
 echo "======================= v 1.0"
+echo "Select Application Type"
+echo "1. Hello World Sample"
+echo "2. Task Manager Sample"
+echo "3. Eventloop Sample"
+echo "============================="
 
+read -p "Select application type: " APP_TYPE
 read -p "Enter application name: " APP_NAME
 
 APP_NAME_UPPER=$(echo "$APP_NAME" | tr '[:lower:]' '[:upper:]')
@@ -21,6 +27,17 @@ ENTRY_FUNC="${APP_NAME_LOWER}_main"
 
 echo "${BOLD}[Summary]${NORMAL}"
 echo "-------------------------------"
+case ${APP_TYPE} in
+	1)
+		echo "* Application Type: ${BOLD}Hello World Sample${NORMAL}"
+		;;
+	2)
+		echo "* Application Type: ${BOLD}Task Manager Sample${NORMAL}"
+		;;
+	3)
+		echo "* Application Type: ${BOLD}Eventloop Sample${NORMAL}"
+		;;
+esac
 echo "* Application Name: ${BOLD}${APP_NAME}${NORMAL}"
 echo "* Configuration Key: ${BOLD}CONFIG_APP_${APP_NAME_UPPER}${NORMAL}"
 echo "* Entry Function: ${BOLD}${ENTRY_FUNC}${NORMAL}"
@@ -38,9 +55,23 @@ MAKE_DEFS_FILENAME="${TIZENRT_ROOT}/apps/examples/${APP_NAME_LOWER}/Make.defs"
 MAKEFILE_FILENAME="${TIZENRT_ROOT}/apps/examples/${APP_NAME_LOWER}/Makefile"
 
 mkdir "${TIZENRT_ROOT}/apps/examples/${APP_NAME_LOWER}"
-cp ${TIZENRT_ROOT}/apps/appgen/template_Kconfig ${KCONFIG_FILENAME}
+
+case ${APP_TYPE} in
+	1)
+		cp ${TIZENRT_ROOT}/apps/appgen/template_Kconfig ${KCONFIG_FILENAME}
+		cp ${TIZENRT_ROOT}/apps/appgen/template_main.c_source ${MAIN_FILENAME}
+		;;
+	2)
+		cp ${TIZENRT_ROOT}/apps/appgen/template_Kconfig_task_manager ${KCONFIG_FILENAME}
+		cp ${TIZENRT_ROOT}/apps/appgen/template_task_manager_sample_main.c_source ${MAIN_FILENAME}
+		;;
+	3)
+		cp ${TIZENRT_ROOT}/apps/appgen/template_Kconfig_eventloop ${KCONFIG_FILENAME}
+		cp ${TIZENRT_ROOT}/apps/appgen/template_eventloop_sample_main.c_source ${MAIN_FILENAME}
+		;;
+esac
+
 cp ${TIZENRT_ROOT}/apps/appgen/template_Kconfig_ENTRY ${KCONFIG_ENTRY_FILENAME}
-cp ${TIZENRT_ROOT}/apps/appgen/template_main.c_source ${MAIN_FILENAME}
 cp ${TIZENRT_ROOT}/apps/appgen/template_Make.defs ${MAKE_DEFS_FILENAME}
 cp ${TIZENRT_ROOT}/apps/appgen/template_Makefile ${MAKEFILE_FILENAME}
 
@@ -77,7 +108,7 @@ sed -i -e "s/##ENTRY_FUNC##/${ENTRY_FUNC}/g" ${MAKEFILE_FILENAME}
 echo ""
 echo "* How to setup your application"
 echo "Run) ${BOLD}TizenRT/os/tools\$${NORMAL} ./configure.sh <BOARD>/<CONFIG>"
-echo "Run) ${BOLD}TizenRT/os\$${NORMAL} make menuconfig"
+echo "Run) ${BOLD}TizenRT/os\$${NORMAL} ./dbuild.sh menuconfig"
 echo "1. Turn on your application in ${BOLD}Application Configuration/Examples${NORMAL} menu"
 echo "2. Set the entry point to your application in ${BOLD}Application Configuration${NORMAL} menu"
 echo "------------------------------"


### PR DESCRIPTION
- Add templates for a sample application
1. Sample application using the task manager of TizenRT
2. Sample application using the eventloop of TizenRT

- Modify the appgen.sh in order to select the type of sample application.
- Revise the README.md according to the added templates and procedures.