### PR TITLE
apps/st_things: Avoiding the usage of internal function.

### DIFF
--- a/apps/examples/st_things/light/sample_light_things.c
+++ b/apps/examples/st_things/light/sample_light_things.c
@@ -58,7 +58,7 @@ static void gpio_callback_event_trigger_light_switch(void *user_data)
 {
 	printf("gpio_callback_event to notify switch resource's observers manually!!\n");
 	change_switch_value();
-	printf("Notify to observer :: %d\n", things_notify_observers(g_res_switch));
+	printf("Notify to observer :: %d\n", st_things_notify_observers(g_res_switch));
 }
 #endif
 


### PR DESCRIPTION
AS IS: things_notify_observers() - This is an internal function which is not supposed to be called from application.
TO BE: st_things_notify_observers() - Actual function which is supposed to be called.

Signed-off-by: Senthil Kumar G S <senthil.gs@samsung.com>