### PR TITLE
network/wifi_manager: Add register, unregister callback API

### DIFF
--- a/framework/include/wifi_manager/wifi_manager.h
+++ b/framework/include/wifi_manager/wifi_manager.h
@@ -82,6 +82,7 @@ typedef enum {
 	WIFI_MANAGER_TIMEOUT,
 	WIFI_MANAGER_BUSY,
 	WIFI_MANAGER_ALREADY_CONNECTED,
+	WIFI_MANAGER_CALLBACK_NOT_REGISTERED,
 } wifi_manager_result_e;
 
 /**
@@ -259,6 +260,27 @@ wifi_manager_result_e wifi_manager_init(wifi_manager_cb_s *wmcb);
  * @since TizenRT v1.1
  */
 wifi_manager_result_e wifi_manager_deinit(void);
+
+/**
+ * @brief Register the callback to receive wi-fi events
+ * @details @b #include <wifi_manager/wifi_manager.h>
+ *          if it fails to register the callbacks with result WIFI_MANAGER_DEINITIALIZED
+ *          then it have to call wifi_manager_init to run Wi-Fi
+ * @param[in] wmcb callback functions called when wi-fi events happen
+ * @return On success, WIFI_MANAGER_SUCCESS (i.e., 0) is returned. On failure, non-zero value is returned.
+ * @since TizenRT v2.0
+ */
+wifi_manager_result_e wifi_manager_register_cb(wifi_manager_cb_s *wmcb);
+
+/**
+ * @brief Unregister the callback to receive wi-fi events
+ * @details @b #include <wifi_manager/wifi_manager.h>
+ * @param[in] wmcb callback functions are used to find registered callback
+ * @return On success, WIFI_MANAGER_SUCCESS (i.e., 0) is returned. On failure, non-zero value is returned.
+ * @since TizenRT v2.0
+ */
+wifi_manager_result_e wifi_manager_unregister_cb(wifi_manager_cb_s *wmcb);
+
 
 /**
  * @brief Change the Wi-Fi mode to station or AP.

--- a/framework/include/wifi_manager/wifi_manager.h
+++ b/framework/include/wifi_manager/wifi_manager.h
@@ -273,7 +273,7 @@ wifi_manager_result_e wifi_manager_deinit(void);
 wifi_manager_result_e wifi_manager_register_cb(wifi_manager_cb_s *wmcb);
 
 /**
- * @brief Unregister the callback to receive wi-fi events
+ * @brief Unregister the callback not to receive wi-fi events
  * @details @b #include <wifi_manager/wifi_manager.h>
  * @param[in] wmcb callback functions are used to find registered callback
  * @return On success, WIFI_MANAGER_SUCCESS (i.e., 0) is returned. On failure, non-zero value is returned.
@@ -304,8 +304,8 @@ wifi_manager_result_e wifi_manager_get_info(wifi_manager_info_s *info);
 /**
  * @brief Connect to an access point.
  * @details @b #include <wifi_manager/wifi_manager.h>
- * @param[in] config ssid, passphrase, authentication type, and cryto type of the access point which the wi-fi interface connect to.
- * @param[in] reconn_config reconnect type, interval, minimum or maximun intervalis set
+ * @param[in] config ssid, passphrase, authentication type, and crypto type of the access point which the wi-fi interface connect to.
+ * @param[in] reconn_config reconnect type, interval, minimum or maximum interval is set
  * @return On success, WIFI_MANAGER_SUCCESS (i.e., 0) is returned. On failure, non-zero value is returned.
  * @since TizenRT v1.1
  */
@@ -314,8 +314,8 @@ wifi_manager_result_e wifi_manager_connect_ap_config(wifi_manager_ap_config_s *c
 /**
  * @brief Connect to an access point.
  * @details @b #include <wifi_manager/wifi_manager.h>
- * @param[in] config ssid, passphrase, authentication type, and cryto type of the access point which the wi-fi interface connect to.
- * @param[in] conn_config reconnect type, interval, minimum or maximun intervalis set 
+ * @param[in] config ssid, passphrase, authentication type, and crypto type of the access point which the wi-fi interface connect to.
+ * @param[in] reconn_config reconnect type, interval, minimum or maximum intervals is set
  * @return On success, WIFI_MANAGER_SUCCESS (i.e., 0) is returned. On failure, non-zero value is returned.
  * @since TizenRT v1.1
  */

--- a/framework/src/wifi_manager/wifi_manager.c
+++ b/framework/src/wifi_manager/wifi_manager.c
@@ -1,4 +1,4 @@
-/****************************************************************************
+/**************************************************************************** 
  *
  * Copyright 2017 Samsung Electronics All Rights Reserved.
  *
@@ -990,7 +990,7 @@ wifi_manager_result_e _handler_on_disconnected_state(_wifimgr_msg_s *msg)
 		WIFIMGR_CHECK_RESULT(_wifimgr_run_softap((wifi_manager_softap_config_s *)msg->param), "run_softap fail", WIFI_MANAGER_FAIL);
 		WIFIMGR_SET_STATE(WIFIMGR_SOFTAP);
 	} else if (msg->event == EVT_SCAN) {
-		WIFIMGR_PASS_RESULT(_wifimgr_scan(), "fail scan");
+		WIFIMGR_CHECK_RESULT(_wifimgr_scan(), "fail scan", WIFI_MANAGER_FAIL);
 		WIFIMGR_STORE_PREV_STATE;
 		WIFIMGR_SET_STATE(WIFIMGR_SCANNING);
 	} else {
@@ -1129,7 +1129,7 @@ wifi_manager_result_e _handler_on_connected_state(_wifimgr_msg_s *msg)
 		WIFIMGR_CHECK_RESULT(_wifimgr_deinit(), "critical error\n", WIFI_MANAGER_FAIL);
 		WIFIMGR_SET_STATE(WIFIMGR_UNINITIALIZED);
 	} else if (msg->event == EVT_SCAN) {
-		WIFIMGR_PASS_RESULT(_wifimgr_scan(), "fail scan\n");
+		WIFIMGR_CHECK_RESULT(_wifimgr_scan(), "fail scan\n", WIFI_MANAGER_FAIL);
 		WIFIMGR_STORE_PREV_STATE;
 		WIFIMGR_SET_STATE(WIFIMGR_SCANNING);
 	} else {
@@ -1259,7 +1259,7 @@ wifi_manager_result_e _handler_on_softap_state(_wifimgr_msg_s *msg)
 		WIFIMGR_CHECK_RESULT(_wifimgr_run_sta(), "critical error\n", WIFI_MANAGER_FAIL);
 		WIFIMGR_SET_STATE(WIFIMGR_STA_DISCONNECTED);
 	} else if (msg->event == EVT_SCAN) {
-		WIFIMGR_PASS_RESULT(_wifimgr_scan(), "fail scan\n");
+		WIFIMGR_CHECK_RESULT(_wifimgr_scan(), "fail scan\n", WIFI_MANAGER_FAIL);
 		WIFIMGR_STORE_PREV_STATE;
 		WIFIMGR_SET_STATE(WIFIMGR_SCANNING);
 	} else if (msg->event == EVT_JOINED) {

--- a/framework/src/wifi_manager/wifi_manager.c
+++ b/framework/src/wifi_manager/wifi_manager.c
@@ -1322,9 +1322,9 @@ void _handle_user_cb(_wifimgr_usr_cb_type_e evt, void *arg)
 			break;
 		case CB_STA_DISCONNECTED:
 			nvdbg("[WM] call sta disconnect event\n");
-	#ifdef CONFIG_ENABLE_IOTIVITY
+#ifdef CONFIG_ENABLE_IOTIVITY
 			__tizenrt_manual_linkset("del");
-	#endif
+#endif
 			cbk->sta_disconnected(WIFI_MANAGER_DISCONNECT);
 			break;
 		case CB_STA_RECONNECTED:
@@ -1612,13 +1612,19 @@ wifi_manager_result_e wifi_manager_get_stats(wifi_manager_stats_s *stats)
 wifi_manager_result_e wifi_manager_register_cb(wifi_manager_cb_s *wmcb)
 {
 	wifi_manager_result_e res = WIFI_MANAGER_FAIL;
+	int i;
 
 	LOCK_WIFIMGR;
 	// g_manager_info.cb[0] is assigned to the callback which is registered by wifi_manager_init
-	int i = 1;
-	for (; i < WIFIMGR_NUM_CALLBACKS; i++) {
+	if (g_manager_info.cb[0] == NULL) {
+		UNLOCK_WIFIMGR;
+		return WIFI_MANAGER_DEINITIALIZED;
+	}
+	for (i = 1; i < WIFIMGR_NUM_CALLBACKS; i++) {
 		if (g_manager_info.cb[i] == NULL) {
 			g_manager_info.cb[i] = wmcb;
+			res = WIFI_MANAGER_SUCCESS;
+			break;
 		}
 	}
 	UNLOCK_WIFIMGR;
@@ -1628,13 +1634,15 @@ wifi_manager_result_e wifi_manager_register_cb(wifi_manager_cb_s *wmcb)
 wifi_manager_result_e wifi_manager_unregister_cb(wifi_manager_cb_s *wmcb)
 {
 	wifi_manager_result_e res = WIFI_MANAGER_FAIL;
-
+	int i;
+	
 	LOCK_WIFIMGR;
 	// g_manager_info.cb[0] is assigned to the callback which is registered by wifi_manager_init
-	int i = 1;
-	for (; i < WIFIMGR_NUM_CALLBACKS; i++) {
+	for (i = 1; i < WIFIMGR_NUM_CALLBACKS; i++) {
 		if (g_manager_info.cb[i] == wmcb) {
 			g_manager_info.cb[i] = NULL;
+			res = WIFI_MANAGER_SUCCESS;
+			break;
 		}
 	}
 	UNLOCK_WIFIMGR;

--- a/framework/src/wifi_manager/wifi_manager.c
+++ b/framework/src/wifi_manager/wifi_manager.c
@@ -44,6 +44,7 @@
 #define ndbg printf
 #undef nvdbg
 #define nvdbg printf
+#define WIFIMGR_NUM_CALLBACKS 3
 
 enum _wifimgr_state {
 	WIFIMGR_UNINITIALIZED,
@@ -126,8 +127,8 @@ struct _wifimgr_info {
 	pthread_mutex_t state_lock;
 	pthread_mutex_t info_lock;
 	pthread_mutex_t softap_lock;
-	pthread_cond_t softap_signal; 
-	wifi_manager_cb_s cb;
+	pthread_cond_t softap_signal;
+	wifi_manager_cb_s *cb[WIFIMGR_NUM_CALLBACKS];
 
 	//
 	// Reconnect
@@ -280,13 +281,27 @@ typedef struct _wifimgr_info _wifimgr_info_s;
 	} while (0)
 
 #define WIFIMGR_CHECK_RESULT(func, msg, ret) WIFIMGR_CHECK_RESULT_CLEANUP(func, msg, ret, WIFIMGR_SPC)
-#define WIFIMGR_CHECK_RESULT_NORET(func, msg)				\
-	do {								\
-		wifi_manager_result_e wmres = func;			\
-		if (wmres != WIFI_MANAGER_SUCCESS) {                    \
+
+#define WIFIMGR_PASS_RESULT_CLEANUP(func, msg, free_rsc)	\
+	do {													\
+		wifi_manager_result_e wmres = func;					\
+		if (wmres != WIFI_MANAGER_SUCCESS) {				\
+			ndbg(msg);										\
 			WIFIADD_ERR_RECORD(ERR_WIFIMGR_API_FAIL);       \
-			ndbg(msg);					\
-		}							\
+			free_rsc;										\
+			return wmres;									\
+		}													\
+	} while (0)
+
+#define WIFIMGR_PASS_RESULT(func, msg) WIFIMGR_PASS_RESULT_CLEANUP(func, msg, WIFIMGR_SPC)
+
+#define WIFIMGR_CHECK_RESULT_NORET(func, msg)					\
+	do {														\
+		wifi_manager_result_e wmres = func;						\
+		if (wmres != WIFI_MANAGER_SUCCESS) {					\
+			WIFIADD_ERR_RECORD(ERR_WIFIMGR_API_FAIL);       \
+			ndbg(msg);											\
+		}														\
 	} while (0)													\
 
 #define WIFIMGR_CHECK_UTILRESULT(func, msg, ret)	                \
@@ -351,7 +366,7 @@ static _wifimgr_info_s g_manager_info = {{0}, {0}, {0}, 0, 0, 0,
 										 PTHREAD_MUTEX_INITIALIZER,
 										 PTHREAD_MUTEX_INITIALIZER,
 										 PTHREAD_COND_INITIALIZER,
-										 {NULL, NULL, NULL, NULL, NULL},
+										 {NULL, NULL, NULL},
 										 0,
 										 WM_APINFO_INITIALIZER,
 										 WM_RECONN_INITIALIZER,
@@ -835,12 +850,13 @@ wifi_manager_result_e _wifimgr_stop_softap(void)
 wifi_manager_result_e _wifimgr_scan(void)
 {
 	WM_LOG_START;
-	wifi_manager_cb_s *cbk = &g_manager_info.cb;
+	wifi_manager_cb_s *cbk = g_manager_info.cb[0];
 	wifi_manager_result_e wret = WIFI_MANAGER_FAIL;
-	if (cbk->scan_ap_done) {
-		WIFIMGR_CHECK_UTILRESULT(wifi_utils_scan_ap(NULL), "[WM] request scan to wifi utils is fail\n", WIFI_MANAGER_FAIL);
-		wret = WIFI_MANAGER_SUCCESS;
+	if (!cbk->scan_ap_done) {
+		return WIFI_MANAGER_CALLBACK_NOT_REGISTERED;
 	}
+	WIFIMGR_CHECK_UTILRESULT(wifi_utils_scan_ap(NULL), "[WM] request scan to wifi utils is fail\n", WIFI_MANAGER_FAIL);
+	wret = WIFI_MANAGER_SUCCESS;
 	return wret;
 }
 
@@ -945,7 +961,7 @@ wifi_manager_result_e _handler_on_uninitialized_state(_wifimgr_msg_s *msg)
 		WIFIMGR_CHECK_UTILRESULT(wifi_utils_deinit(), "critical error\n", WIFI_MANAGER_FAIL);
 	}
 
-	g_manager_info.cb = *cb;
+	g_manager_info.cb[0] = cb;
 	memcpy(g_manager_info.mac_address, info.mac_address, WIFIMGR_MACADDR_LEN);
 
 	WIFIMGR_SET_STATE(WIFIMGR_STA_DISCONNECTED);
@@ -974,7 +990,7 @@ wifi_manager_result_e _handler_on_disconnected_state(_wifimgr_msg_s *msg)
 		WIFIMGR_CHECK_RESULT(_wifimgr_run_softap((wifi_manager_softap_config_s *)msg->param), "run_softap fail", WIFI_MANAGER_FAIL);
 		WIFIMGR_SET_STATE(WIFIMGR_SOFTAP);
 	} else if (msg->event == EVT_SCAN) {
-		WIFIMGR_CHECK_RESULT(_wifimgr_scan(), "fail scan", WIFI_MANAGER_FAIL);
+		WIFIMGR_PASS_RESULT(_wifimgr_scan(), "fail scan");
 		WIFIMGR_STORE_PREV_STATE;
 		WIFIMGR_SET_STATE(WIFIMGR_SCANNING);
 	} else {
@@ -1113,7 +1129,7 @@ wifi_manager_result_e _handler_on_connected_state(_wifimgr_msg_s *msg)
 		WIFIMGR_CHECK_RESULT(_wifimgr_deinit(), "critical error\n", WIFI_MANAGER_FAIL);
 		WIFIMGR_SET_STATE(WIFIMGR_UNINITIALIZED);
 	} else if (msg->event == EVT_SCAN) {
-		WIFIMGR_CHECK_RESULT(_wifimgr_scan(), "fail scan\n", WIFI_MANAGER_FAIL);
+		WIFIMGR_PASS_RESULT(_wifimgr_scan(), "fail scan\n");
 		WIFIMGR_STORE_PREV_STATE;
 		WIFIMGR_SET_STATE(WIFIMGR_SCANNING);
 	} else {
@@ -1243,7 +1259,7 @@ wifi_manager_result_e _handler_on_softap_state(_wifimgr_msg_s *msg)
 		WIFIMGR_CHECK_RESULT(_wifimgr_run_sta(), "critical error\n", WIFI_MANAGER_FAIL);
 		WIFIMGR_SET_STATE(WIFIMGR_STA_DISCONNECTED);
 	} else if (msg->event == EVT_SCAN) {
-		WIFIMGR_CHECK_RESULT(_wifimgr_scan(), "fail scan\n", WIFI_MANAGER_FAIL);
+		WIFIMGR_PASS_RESULT(_wifimgr_scan(), "fail scan\n");
 		WIFIMGR_STORE_PREV_STATE;
 		WIFIMGR_SET_STATE(WIFIMGR_SCANNING);
 	} else if (msg->event == EVT_JOINED) {
@@ -1285,60 +1301,66 @@ wifi_manager_result_e _handler_on_scanning_state(_wifimgr_msg_s *msg)
 void _handle_user_cb(_wifimgr_usr_cb_type_e evt, void *arg)
 {
 	WM_LOG_START;
-	wifi_manager_cb_s *cbk = &g_manager_info.cb;
-	switch (evt) {
-	case CB_STA_CONNECTED:
-		nvdbg("[WM] call sta connect success event\n");
-#ifdef CONFIG_ENABLE_IOTIVITY
-		__tizenrt_manual_linkset("gen");
-#endif
-		cbk->sta_connected(WIFI_MANAGER_SUCCESS);
-		break;
-	case CB_STA_CONNECT_FAILED:
-		nvdbg("[WM] call sta connect fail event\n");
-		WIFIADD_ERR_RECORD(ERR_WIFIMGR_CONNECT_FAIL);
-		cbk->sta_connected(WIFI_MANAGER_FAIL);
-		break;
-	case CB_STA_DISCONNECTED:
-		nvdbg("[WM] call sta disconnect event\n");
-#ifdef CONFIG_ENABLE_IOTIVITY
-		__tizenrt_manual_linkset("del");
-#endif
-		cbk->sta_disconnected(WIFI_MANAGER_DISCONNECT);
-		break;
-	case CB_STA_RECONNECTED:
-		nvdbg("[WM] call sta disconnect event\n");
-#ifdef CONFIG_ENABLE_IOTIVITY
-		__tizenrt_manual_linkset("del");
-#endif
-		cbk->sta_disconnected(WIFI_MANAGER_RECONNECT);
-		break;
-	case CB_STA_JOINED:
-		nvdbg("[WM] call sta join event\n");
-		cbk->softap_sta_joined();
-		break;
-	case CB_STA_LEFT:
-		nvdbg("[WM] call sta leave event\n");
-		cbk->softap_sta_left();
-		break;
-	case CB_SCAN_DONE:
-		nvdbg("[WM] call sta scan event\n");
-		/* convert scan data.*/
-		wifi_manager_scan_info_s *info = NULL;
-		wifi_utils_scan_list_s *list = (wifi_utils_scan_list_s *)arg;
-		if (list) {
-			WIFIMGR_CHECK_RESULT_CLEANUP(_convert_scan_info(&info, (wifi_utils_scan_list_s *)arg), "parse error", , cbk->scan_ap_done(NULL, WIFI_SCAN_FAIL));
-			cbk->scan_ap_done(&info, WIFI_SCAN_SUCCESS);
-			_free_scan_info(info);
-		} else {
-			WIFIADD_ERR_RECORD(ERR_WIFIMGR_SCAN_FAIL);
-			cbk->scan_ap_done(NULL, WIFI_SCAN_FAIL);
+	int i = 0;
+	for (; i < WIFIMGR_NUM_CALLBACKS; i++) {
+		wifi_manager_cb_s *cbk = g_manager_info.cb[i];
+		if (!cbk) {
+			continue;
 		}
-		break;
-	default:
-		WIFIADD_ERR_RECORD(ERR_WIFIMGR_INVALID_EVENT);
-		ndbg("[WM] Invalid State\n");
-		return;
+		switch (evt) {
+		case CB_STA_CONNECTED:
+			nvdbg("[WM] call sta connect success event\n");
+#ifdef CONFIG_ENABLE_IOTIVITY
+			__tizenrt_manual_linkset("gen");
+#endif
+			cbk->sta_connected(WIFI_MANAGER_SUCCESS);
+			break;
+		case CB_STA_CONNECT_FAILED:
+			nvdbg("[WM] call sta connect fail event\n");
+			WIFIADD_ERR_RECORD(ERR_WIFIMGR_CONNECT_FAIL);
+			cbk->sta_connected(WIFI_MANAGER_FAIL);
+			break;
+		case CB_STA_DISCONNECTED:
+			nvdbg("[WM] call sta disconnect event\n");
+	#ifdef CONFIG_ENABLE_IOTIVITY
+			__tizenrt_manual_linkset("del");
+	#endif
+			cbk->sta_disconnected(WIFI_MANAGER_DISCONNECT);
+			break;
+		case CB_STA_RECONNECTED:
+			nvdbg("[WM] call sta disconnect event\n");
+#ifdef CONFIG_ENABLE_IOTIVITY
+			__tizenrt_manual_linkset("del");
+#endif
+			cbk->sta_disconnected(WIFI_MANAGER_RECONNECT);
+			break;
+		case CB_STA_JOINED:
+			nvdbg("[WM] call sta join event\n");
+			cbk->softap_sta_joined();
+			break;
+		case CB_STA_LEFT:
+			nvdbg("[WM] call sta leave event\n");
+			cbk->softap_sta_left();
+			break;
+		case CB_SCAN_DONE:
+			nvdbg("[WM] call sta scan event\n");
+			/* convert scan data.*/
+			wifi_manager_scan_info_s *info = NULL;
+			wifi_utils_scan_list_s *list = (wifi_utils_scan_list_s *)arg;
+			if (list) {
+				WIFIMGR_CHECK_RESULT_CLEANUP(_convert_scan_info(&info, (wifi_utils_scan_list_s *)arg), "parse error", , cbk->scan_ap_done(NULL, WIFI_SCAN_FAIL));
+				cbk->scan_ap_done(&info, WIFI_SCAN_SUCCESS);
+				_free_scan_info(info);
+			} else {
+				WIFIADD_ERR_RECORD(ERR_WIFIMGR_SCAN_FAIL);
+				cbk->scan_ap_done(NULL, WIFI_SCAN_FAIL);
+			}
+			break;
+		default:
+			WIFIADD_ERR_RECORD(ERR_WIFIMGR_INVALID_EVENT);
+			ndbg("[WM] Invalid State\n");
+			return;
+		}
 	}
 	WIFIMGR_STATS_INC(evt);
 }
@@ -1585,4 +1607,36 @@ wifi_manager_result_e wifi_manager_get_stats(wifi_manager_stats_s *stats)
 		WIFIADD_ERR_RECORD(ERR_WIFIMGR_INVALID_ARGUMENTS);
 	}
 	return wret;
+}
+
+wifi_manager_result_e wifi_manager_register_cb(wifi_manager_cb_s *wmcb)
+{
+	wifi_manager_result_e res = WIFI_MANAGER_FAIL;
+
+	LOCK_WIFIMGR;
+	// g_manager_info.cb[0] is assigned to the callback which is registered by wifi_manager_init
+	int i = 1;
+	for (; i < WIFIMGR_NUM_CALLBACKS; i++) {
+		if (g_manager_info.cb[i] == NULL) {
+			g_manager_info.cb[i] = wmcb;
+		}
+	}
+	UNLOCK_WIFIMGR;
+	return res;
+}
+
+wifi_manager_result_e wifi_manager_unregister_cb(wifi_manager_cb_s *wmcb)
+{
+	wifi_manager_result_e res = WIFI_MANAGER_FAIL;
+
+	LOCK_WIFIMGR;
+	// g_manager_info.cb[0] is assigned to the callback which is registered by wifi_manager_init
+	int i = 1;
+	for (; i < WIFIMGR_NUM_CALLBACKS; i++) {
+		if (g_manager_info.cb[i] == wmcb) {
+			g_manager_info.cb[i] = NULL;
+		}
+	}
+	UNLOCK_WIFIMGR;
+	return res;
 }


### PR DESCRIPTION
- By adding these APIs, applications on TizenRT can get wi-fi events max 3 by default. 
- Note that the 0th index of the callback array is allocated by initializing Wi-Fi Manager, wifi_manager_init.