### PR TITLE
apps/appgen: Add templates for a sample application of the task manager

### DIFF
--- a/apps/appgen/README.md
+++ b/apps/appgen/README.md
@@ -6,7 +6,8 @@
 
 ### How to use?
 
-In any directory, run the appgen shell script and just enter the application name that you would make.
+In any directory, run the appgen shell script first.  
+Then, just enter the type of application and the application name that you would make.
 
 Your application would be generated at the apps/examples/
 
@@ -14,9 +15,15 @@ Your application would be generated at the apps/examples/
 TizenRT/os$ tools/appgen.sh
 TizenRT Application Generator
 ======================= v 1.0
+Select Application Type
+1. Hello World Sample
+2. Task Manager Sample
+=============================
+Select application type: 1
 Enter application name: test application
 [Summary]
 -------------------------------
+* Application Type: Hello World Sample
 * Application Name: test application
 * Configuration Key: CONFIG_APP_TEST_APPLICATION
 * Entry Function: test_application_main
@@ -28,7 +35,7 @@ Generating...
 
 * How to setup your application
 Run) TizenRT/os/tools$ ./configure.sh <BOARD>/<CONFIG>
-Run) TizenRT/os$ make menuconfig
+Run) TizenRT/os$ ./dbuild.sh menuconfig
 1. Turn on your application in Application Configuration/Examples menu
 2. Set the entry point to your application in Application Configuration menu
 ------------------------------
@@ -38,7 +45,7 @@ Done!!
 
 ### After generated
 ```sh
-TizenRT/os$ make menuconfig
+TizenRT/os$ ./dbuild.sh menuconfig
 ```
 
 - Enter "Application Configuration/Examples"

--- a/apps/appgen/template_Kconfig_task_manager
+++ b/apps/appgen/template_Kconfig_task_manager
@@ -1,0 +1,15 @@
+#
+# For a description of the syntax of this configuration file,
+# see kconfig-language at https://www.kernel.org/doc/Documentation/kbuild/kconfig-language.txt
+#
+
+config APP_##APP_NAME_UPPER##
+	bool "\"##APP_NAME##\" Application"
+	default n
+	select TASK_MANAGER
+	---help---
+		Enable the \"##APP_NAME##\" Application
+
+config USER_ENTRYPOINT
+	string
+	default "##ENTRY_FUNC##" if ENTRY_##APP_NAME_UPPER##

--- a/apps/appgen/template_task_manager_sample_main.c_source
+++ b/apps/appgen/template_task_manager_sample_main.c_source
@@ -1,0 +1,99 @@
+/****************************************************************************
+ *
+ * Copyright ##YEAR## Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <tinyara/config.h>
+#include <stdio.h>
+
+#include <task_manager/task_manager.h>
+
+#define SAMPLE_TASK_NAME         "sample_task"
+#define SAMPLE_TASK_PRIORITY     100
+#define SAMPLE_TASK_STACKSIZE    1024
+#define SAMPLE_TASK_ARGV         NULL
+#define SAMPLE_TASK_PERMISSION   TM_APP_PERMISSION_ALL
+#define SAMPLE_TASK_TIMEOUT      TM_RESPONSE_WAIT_INF
+
+/****************************************************************************
+ * Private Function
+ ****************************************************************************/
+
+static void sample_unicast_cb(tm_msg_t *unicast_data)
+{
+	printf("Hello, sample unicast callback!\n");
+}
+
+static void sample_broadcast_cb(void *broadcast_data, void *cb_data)
+{
+	printf("Hello, Wi-Fi is on!\n");
+}
+
+static int sample_task(int argc, char *argv[])
+{
+	int ret;
+
+	ret = task_manager_set_unicast_cb(sample_unicast_cb);
+	if (ret < 0) {
+		printf("Failed to set unicast callback! Return: %d\n", ret);
+	}
+
+	/* If user want to set the callback data, please replace 'NULL' with the own callback data.
+	 * ex: ret = task_manager_set_broadcast_cb(TM_BROADCAST_WIFI_ON, sample_broadcast_cb, broadcast_cb_data); */
+
+	ret = task_manager_set_broadcast_cb(TM_BROADCAST_WIFI_ON, sample_broadcast_cb, NULL);
+	if (ret < 0) {
+		printf("Failed to set broadcast callback! Return: %d\n", ret);
+	}
+
+	printf("Hello, sample_task is started by the task manager!\n");
+	return 0;
+}
+
+
+/****************************************************************************
+ * ##ENTRY_FUNC##
+ ****************************************************************************/
+
+#ifdef CONFIG_BUILD_KERNEL
+int main(int argc, FAR char *argv[])
+#else
+int ##ENTRY_FUNC##(int argc, char *argv[])
+#endif
+{
+	int handle;
+	int ret;
+
+	handle = task_manager_register_task(SAMPLE_TASK_NAME, SAMPLE_TASK_PRIORITY, SAMPLE_TASK_STACKSIZE, sample_task, SAMPLE_TASK_ARGV, SAMPLE_TASK_PERMISSION, SAMPLE_TASK_TIMEOUT);
+	if (handle < 0) {
+		printf("Failed to register sample_task to the task manager! Return: %d\n", handle);
+	}
+
+	ret = task_manager_start(handle, SAMPLE_TASK_TIMEOUT);
+	if (ret < 0) {
+		printf("Failed to start sample_task! Return: %d\n", ret);
+	}
+
+	/* User should unregister the registered task if user no longer wants to use registered task.
+	 * Otherwise, a memory leak may occur.
+	 * ret = task_manager_unregister(handle, SAMPLE_TASK_TIMEOUT); */
+
+	return 0;
+}

--- a/os/tools/appgen.sh
+++ b/os/tools/appgen.sh
@@ -10,7 +10,12 @@ cd - > /dev/null
 
 echo "${BOLD}TizenRT Application Generator${NORMAL}"
 echo "======================= v 1.0"
+echo "Select Application Type"
+echo "1. Hello World Sample"
+echo "2. Task Manager Sample"
+echo "============================="
 
+read -p "Select application type: " APP_TYPE
 read -p "Enter application name: " APP_NAME
 
 APP_NAME_UPPER=$(echo "$APP_NAME" | tr '[:lower:]' '[:upper:]')
@@ -21,6 +26,14 @@ ENTRY_FUNC="${APP_NAME_LOWER}_main"
 
 echo "${BOLD}[Summary]${NORMAL}"
 echo "-------------------------------"
+case ${APP_TYPE} in
+	1)
+		echo "* Application Type: ${BOLD}Hello World Sample${NORMAL}"
+		;;
+	2)
+		echo "* Application Type: ${BOLD}Task Manager Sample${NORMAL}"
+		;;
+esac
 echo "* Application Name: ${BOLD}${APP_NAME}${NORMAL}"
 echo "* Configuration Key: ${BOLD}CONFIG_APP_${APP_NAME_UPPER}${NORMAL}"
 echo "* Entry Function: ${BOLD}${ENTRY_FUNC}${NORMAL}"
@@ -38,9 +51,19 @@ MAKE_DEFS_FILENAME="${TIZENRT_ROOT}/apps/examples/${APP_NAME_LOWER}/Make.defs"
 MAKEFILE_FILENAME="${TIZENRT_ROOT}/apps/examples/${APP_NAME_LOWER}/Makefile"
 
 mkdir "${TIZENRT_ROOT}/apps/examples/${APP_NAME_LOWER}"
-cp ${TIZENRT_ROOT}/apps/appgen/template_Kconfig ${KCONFIG_FILENAME}
+
+case ${APP_TYPE} in
+	1)
+		cp ${TIZENRT_ROOT}/apps/appgen/template_Kconfig ${KCONFIG_FILENAME}
+		cp ${TIZENRT_ROOT}/apps/appgen/template_main.c_source ${MAIN_FILENAME}
+		;;
+	2)
+		cp ${TIZENRT_ROOT}/apps/appgen/template_Kconfig_task_manager ${KCONFIG_FILENAME}
+		cp ${TIZENRT_ROOT}/apps/appgen/template_task_manager_sample_main.c_source ${MAIN_FILENAME}
+		;;
+esac
+
 cp ${TIZENRT_ROOT}/apps/appgen/template_Kconfig_ENTRY ${KCONFIG_ENTRY_FILENAME}
-cp ${TIZENRT_ROOT}/apps/appgen/template_main.c_source ${MAIN_FILENAME}
 cp ${TIZENRT_ROOT}/apps/appgen/template_Make.defs ${MAKE_DEFS_FILENAME}
 cp ${TIZENRT_ROOT}/apps/appgen/template_Makefile ${MAKEFILE_FILENAME}
 
@@ -77,7 +100,7 @@ sed -i -e "s/##ENTRY_FUNC##/${ENTRY_FUNC}/g" ${MAKEFILE_FILENAME}
 echo ""
 echo "* How to setup your application"
 echo "Run) ${BOLD}TizenRT/os/tools\$${NORMAL} ./configure.sh <BOARD>/<CONFIG>"
-echo "Run) ${BOLD}TizenRT/os\$${NORMAL} make menuconfig"
+echo "Run) ${BOLD}TizenRT/os\$${NORMAL} ./dbuild.sh menuconfig"
 echo "1. Turn on your application in ${BOLD}Application Configuration/Examples${NORMAL} menu"
 echo "2. Set the entry point to your application in ${BOLD}Application Configuration${NORMAL} menu"
 echo "------------------------------"


### PR DESCRIPTION
- Add templates for a sample application
Sample application using the task manager of TizenRT
- Modify the appgen.sh in order to select the type of sample application.
- Revise the README.md according to the added templates and procedures.