### PR TITLE
os/net/socket: fix recvmsg API

### DIFF
--- a/os/net/socket/recvmsg.c
+++ b/os/net/socket/recvmsg.c
@@ -94,6 +94,7 @@ ssize_t recvmsg(int sockfd, struct msghdr *msg, int flags)
 	size_t len = msg->msg_iov->iov_len;
 	struct sockaddr *from = (struct sockaddr *)msg->msg_name;
 	socklen_t *addrlen = &(msg->msg_namelen);
+	msg->msg_controllen = 0;
 
 	//printf("\n[Received IOTIVITY Packet][%s:%d] \n", __FUNCTION__, __LINE__);
 


### PR DESCRIPTION
- set msg_controllen to 0.
- TizenRT doesn't support cmsg.