### PR TITLE
framework/task_manager: Add NULL check procedure

### DIFF
--- a/framework/src/task_manager/task_manager_core.c
+++ b/framework/src/task_manager/task_manager_core.c
@@ -1035,9 +1035,12 @@ static int taskmgr_set_msg_cb(int type, void *data, int pid)
 				broadcast_info->cb_data = NULL;
 			}
 		}
-		TM_FREE(((tm_msg_t *)((tm_broadcast_info_t *)data)->cb_data)->msg);
-		TM_FREE(((tm_broadcast_info_t *)data)->cb_data);
-		
+		if (((tm_broadcast_info_t *)data)->cb_data != NULL) {
+			if (((tm_msg_t *)((tm_broadcast_info_t *)data)->cb_data)->msg != NULL) {
+				TM_FREE(((tm_msg_t *)((tm_broadcast_info_t *)data)->cb_data)->msg);
+			}
+			TM_FREE(((tm_broadcast_info_t *)data)->cb_data);
+		}
 	}
 	return OK;
 }


### PR DESCRIPTION
When user uses task_manager_set_broadcast_cb() with 'NULL' value as the cb_data, an assert problem occurs.
In order to prevent this problem, NULL check procedure is added.