### PR TITLE
framework/media : Add rechannel function and can play mono auido.

### DIFF
--- a/framework/src/media/audio/audio_manager.h
+++ b/framework/src/media/audio/audio_manager.h
@@ -36,6 +36,11 @@ extern "C" {
  * Public Data
  ****************************************************************************/
 /**
+ * @brief Define the supported output channels
+ */
+#define AUDIO_OUTPUT_CHANNELS 2
+
+/**
  * @brief Result types of Audio Manager APIs such as FAIL, SUCCESS, or INVALID ARGS
  */
 enum audio_manager_result_e {


### PR DESCRIPTION
framework/media : Add rechannel function and can play mono audio.

When play the mono channel audio, should read half mBuffersize data. Becasue the rechannel function will use the left half buffer.

@zhouxinhe @Taejun-Kwon @chanijjani 