### PR TITLE
TizenRT/apps/examples/wifi_manager_sample/wm_test_stress.c : fix a typo error

### DIFF
--- a/apps/examples/wifi_manager_sample/wm_test_stress.c
+++ b/apps/examples/wifi_manager_sample/wm_test_stress.c
@@ -73,7 +73,7 @@ static wifi_manager_cb_s g_wifi_callbacks = {
 	wm_scan_done,
 };
 
-static pthread_mutex_t g_wm_mutex = PTHREAD_MUTEX_INITIALIZER;;
+static pthread_mutex_t g_wm_mutex = PTHREAD_MUTEX_INITIALIZER;
 static pthread_cond_t g_wm_cond = PTHREAD_COND_INITIALIZER;
 
 /*


### PR DESCRIPTION
lines 76 been spoted by [SeonghoByeon](https://github.com/SeonghoByeon)
There is no reason to use the semi-colon as twice