### PR TITLE
framework/task_manager: Modify the input parameter type of broadcast callback

### DIFF
--- a/apps/examples/testcase/ta_tc/task_manager/utc/utc_task_manager_main.c
+++ b/apps/examples/testcase/ta_tc/task_manager/utc/utc_task_manager_main.c
@@ -112,24 +112,28 @@ static void test_unicast_handler(tm_msg_t *info)
 	flag = !strncmp((char *)info->msg, TM_SAMPLE_MSG, strlen(TM_SAMPLE_MSG));
 }
 
-static void test_broadcast_handler(void *user_data, void *info)
+static void test_broadcast_handler(tm_msg_t *user_data, tm_msg_t *info)
 {
-	if (strncmp((char *)info, TM_BROAD_WIFI_ON_DATA, strlen(TM_BROAD_WIFI_ON_DATA) + 1) == 0) {
-		broadcast_data_flag = strncmp((char *)user_data, "WIFI_ON", strlen("WIFI_ON") + 1);
-		sem_wait(&tm_broad_sem);
-		broad_wifi_on_cnt++;
-		sem_post(&tm_broad_sem);
-		(void)task_manager_unset_broadcast_cb(TM_BROADCAST_WIFI_ON, TM_NO_RESPONSE);
-	} else if (strncmp((char *)info, TM_BROAD_WIFI_OFF_DATA, strlen(TM_BROAD_WIFI_OFF_DATA) + 1) == 0) {
-		sem_wait(&tm_broad_sem);
-		broad_wifi_off_cnt++;
-		sem_post(&tm_broad_sem);
-		(void)task_manager_unset_broadcast_cb(TM_BROADCAST_WIFI_OFF, TM_NO_RESPONSE);
-	} else if (strncmp((char *)info, TM_BROAD_UNDEFINED_MSG_DATA, strlen(TM_BROAD_UNDEFINED_MSG_DATA) + 1) == 0) {
-		sem_wait(&tm_broad_sem);
-		broad_undefined_cnt++;
-		sem_post(&tm_broad_sem);
-		(void)task_manager_unset_broadcast_cb(tm_broadcast_undefined_msg, TM_NO_RESPONSE);
+	if (info->msg != NULL) {
+		if (strncmp((char *)info->msg, TM_BROAD_WIFI_ON_DATA, info->msg_size) == 0) {
+			if (user_data->msg != NULL) {
+				broadcast_data_flag = strncmp((char *)user_data->msg, "WIFI_ON", user_data->msg_size);
+			}
+			sem_wait(&tm_broad_sem);
+			broad_wifi_on_cnt++;
+			sem_post(&tm_broad_sem);
+			(void)task_manager_unset_broadcast_cb(TM_BROADCAST_WIFI_ON, TM_NO_RESPONSE);
+		} else if (strncmp((char *)info->msg, TM_BROAD_WIFI_OFF_DATA, info->msg_size) == 0) {
+			sem_wait(&tm_broad_sem);
+			broad_wifi_off_cnt++;
+			sem_post(&tm_broad_sem);
+			(void)task_manager_unset_broadcast_cb(TM_BROADCAST_WIFI_OFF, TM_NO_RESPONSE);
+		} else if (strncmp((char *)info->msg, TM_BROAD_UNDEFINED_MSG_DATA, info->msg_size) == 0) {
+			sem_wait(&tm_broad_sem);
+			broad_undefined_cnt++;
+			sem_post(&tm_broad_sem);
+			(void)task_manager_unset_broadcast_cb(tm_broadcast_undefined_msg, TM_NO_RESPONSE);
+		}
 	}
 }
 

--- a/framework/include/task_manager/task_manager.h
+++ b/framework/include/task_manager/task_manager.h
@@ -141,7 +141,7 @@ typedef void (*tm_unicast_callback_t)(tm_msg_t *unicast_data);
  * The 'cb_data' is set through the task_manager_set_broadcast_cb() and the broadcast callback function will get\n
  * this argument when the task_manager_broadcast() is called from the task manager.
  */
-typedef void (*tm_broadcast_callback_t)(void *broadcast_data, void *cb_data);
+typedef void (*tm_broadcast_callback_t)(tm_msg_t *broadcast_data, tm_msg_t *cb_data);
 
 /**
  * @brief Termination callback function type

--- a/framework/src/task_manager/task_manager_broadcast.c
+++ b/framework/src/task_manager/task_manager_broadcast.c
@@ -46,7 +46,7 @@ int task_manager_broadcast(int msg, tm_msg_t *broadcast_data, int timeout)
 	if (request_msg.data == NULL) {
 		return TM_OUT_OF_MEMORY;
 	}
-	if (broadcast_data != NULL) {
+	if (broadcast_data != NULL && broadcast_data->msg_size != 0) {
 		((tm_internal_msg_t *)request_msg.data)->msg = (void *)TM_ALLOC(broadcast_data->msg_size);
 		if (((tm_internal_msg_t *)request_msg.data)->msg == NULL) {
 			TM_FREE(request_msg.data);
@@ -54,8 +54,11 @@ int task_manager_broadcast(int msg, tm_msg_t *broadcast_data, int timeout)
 		}
 		memcpy(((tm_internal_msg_t *)request_msg.data)->msg, broadcast_data->msg, broadcast_data->msg_size);
 		((tm_internal_msg_t *)request_msg.data)->msg_size = broadcast_data->msg_size;
-	} else {
+	} else if (broadcast_data != NULL && broadcast_data->msg_size == 0) {
 		((tm_internal_msg_t *)request_msg.data)->msg_size = 0;
+		((tm_internal_msg_t *)request_msg.data)->msg = NULL;
+	} else {
+		((tm_internal_msg_t *)request_msg.data)->msg_size = TM_NULL_MSG_SIZE;
 		((tm_internal_msg_t *)request_msg.data)->msg = NULL;
 	}
 	((tm_internal_msg_t *)request_msg.data)->type = msg;

--- a/framework/src/task_manager/task_manager_internal.h
+++ b/framework/src/task_manager/task_manager_internal.h
@@ -97,6 +97,11 @@
 #define TM_UNICAST_SYNC      (0)
 #define TM_UNICAST_ASYNC     (1)
 
+/**
+ * @brief Represent the msg size when input is NULL
+ */
+#define TM_NULL_MSG_SIZE     (-1)
+
 struct tm_termination_info_s {
 	tm_termination_callback_t cb;
 	tm_msg_t *cb_data;
@@ -143,7 +148,7 @@ struct tm_broadcast_info_s {
 	struct tm_broadcast_info_s *flink;
 	int msg;
 	tm_broadcast_callback_t cb;
-	void* cb_data;
+	tm_msg_t *cb_data;
 };
 typedef struct tm_broadcast_info_s tm_broadcast_info_t;
 


### PR DESCRIPTION
In order to match the input parameter type of broadcast callback with the unicast callback, the input parameter type of broadcast callbakc was changed.
Previous: typedef void (*tm_broadcast_callback_t)(void *broadcast_data, void *cb_data);
Present: typedef void (*tm_broadcast_callback_t)(tm_msg_t *broadcast_data, tm_msg_t *cb_data);

Furthermore, to prevent build error, the utc of task manager was also modified according to the revisions.