### PR TITLE
C library: modify sscanf to read more than 128byte

### DIFF
--- a/lib/libc/stdio/lib_sscanf.c
+++ b/lib/libc/stdio/lib_sscanf.c
@@ -70,7 +70,6 @@
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
-
 #define MAXLN 128
 
 #ifndef MIN
@@ -452,7 +451,6 @@ int vsscanf(FAR const char *buf, FAR const char *fmt, va_list ap)
 						width  = fwidth;
 					}
 
-					width = MIN(sizeof(tmp) - 1, width);
 
 					/* Copy the string (if we are making an assignment) */
 
@@ -511,7 +509,6 @@ int vsscanf(FAR const char *buf, FAR const char *fmt, va_list ap)
 						width  = fwidth;
 					}
 
-					width = MIN(sizeof(tmp) - 1, width);
 
 					/* Copy the string (if we are making an assignment) */
 


### PR DESCRIPTION
C library: modify sscanf to read more than 128byte string

Modify C library vsscanf() as described below.
1) Due to MAXLN of 128 bytes, sscanf scan only upto 128 bytes string. This is issue reported by
ST things team since ST things SDK needs to scan more than 2K data.
2) So remove the 128 byte upper limit for string case, Hence it can scan any string range
3)Test procedure:
--------------------------
char *buf = "ABCDXXXX..... . .. .Z"(say 555 char)
char tmp[124];

ret = sscanf(buf,"%s", tmp)
printf("Post scan: %s\n", tmp);
--------------------------
a) O/P (without fix) : 128 characters only
b) O/P (with fix) : All 555 chars

Signed-off-by: Shadakshari K P <shari.kps@samsung.com>