### PR TITLE
os/include: Fill argument names for API's in all string.h definitions

### DIFF
--- a/lib/libc/string/lib_strcoll.c
+++ b/lib/libc/string/lib_strcoll.c
@@ -69,8 +69,8 @@
  *
  ****************************************************************************/
 
-int strcoll(const char *a, const char *b)
+int strcoll(const char *s1, const char *s2)
 {
-	return strcmp(a, b);
+	return strcmp(s1, s2);
 }
 #endif

--- a/os/include/string.h
+++ b/os/include/string.h
@@ -114,12 +114,12 @@ FAR char *strndup(FAR const char *s, size_t size);
  * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since TizenRT v1.0
  */
-FAR const char *strerror(int);
+FAR const char *strerror(int errnum);
 /**
  * @cond
  * @internal
  */
-int strerror_r(int, FAR char *, size_t);
+int strerror_r(int errnum, FAR char *buf, size_t buflen);
 /**
  * @endcond
  */
@@ -129,48 +129,48 @@ int strerror_r(int, FAR char *, size_t);
  * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since TizenRT v1.0
  */
-size_t strlen(FAR const char *);
+size_t strlen(FAR const char *s);
 /**
  * @brief get length of fixed size string
  * @details @b #include <string.h> \n
  * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since TizenRT v1.0
  */
-size_t strnlen(FAR const char *, size_t);
+size_t strnlen(FAR const char *s, size_t maxlen);
 /**
  * @brief concatenate two strings
  * @details @b #include <string.h> \n
  * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since TizenRT v1.0
  */
-FAR char *strcat(FAR char *, FAR const char *);
+FAR char *strcat(FAR char *dest, FAR const char *src);
 /**
  * @brief concatenate a string with part of another
  * @details @b #include <string.h> \n
  * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since TizenRT v1.0
  */
-FAR char *strncat(FAR char *, FAR const char *, size_t);
+FAR char *strncat(FAR char *dest, FAR const char *src, size_t n);
 /**
  * @brief compare two strings
  * @details @b #include <string.h> \n
  * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since TizenRT v1.0
  */
-int strcmp(FAR const char *, FAR const char *);
+int strcmp(FAR const char *cs, FAR const char *ct);
 /**
  * @brief compare part of two strings
  * @details @b #include <string.h> \n
  * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since TizenRT v1.0
  */
-int strncmp(FAR const char *, FAR const char *, size_t);
+int strncmp(FAR const char *cs, FAR const char *ct, size_t nb);
 
 /**
  * @cond
  * @internal
  */
-int strcoll(FAR const char *, FAR const char *s2);
+int strcoll(FAR const char *s1, FAR const char *s2);
 /**
  * @endcond
  */
@@ -194,14 +194,14 @@ FAR char *stpcpy(FAR char *dest, FAR const char *src);
  * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since TizenRT v1.0
  */
-FAR char *strncpy(FAR char *, FAR const char *, size_t);
+FAR char *strncpy(FAR char *dest, FAR const char *src, size_t n);
 /**
  * @brief scan a string for a byte
  * @details @b #include <string.h> \n
  * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since TizenRT v1.0
  */
-FAR char *strpbrk(FAR const char *, FAR const char *);
+FAR char *strpbrk(FAR const char *str, FAR const char *charset);
 /**
  * @brief string scanning operation
  * @details @b #include <string.h> \n
@@ -222,21 +222,21 @@ FAR char *strrchr(FAR const char *s, int c);
  * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since TizenRT v1.0
  */
-size_t strspn(FAR const char *, FAR const char *);
+size_t strspn(FAR const char *s, FAR const char *accept);
 /**
  * @brief get the length of a complementary substring
  * @details @b #include <string.h> \n
  * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since TizenRT v1.0
  */
-size_t strcspn(FAR const char *, FAR const char *);
+size_t strcspn(FAR const char *s, FAR const char *reject);
 /**
  * @brief find a substring
  * @details @b #include <string.h> \n
  * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since TizenRT v1.0
  */
-FAR char *strstr(FAR const char *, FAR const char *);
+FAR char *strstr(FAR const char *str, FAR const char *substr);
 /**
  * @brief locate a substring
  * @details @b #include <string.h> \n
@@ -244,26 +244,26 @@ FAR char *strstr(FAR const char *, FAR const char *);
  * @param[in] substr substring
  * @since TizenRT v1.0
  */
-FAR char *strcasestr(FAR const char *, FAR const char *);
+FAR char *strcasestr(FAR const char *str, FAR const char *substr);
 /**
  * @brief split string into tokens
  * @details @b #include <string.h> \n
  * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since TizenRT v1.0
  */
-FAR char *strtok(FAR char *, FAR const char *);
+FAR char *strtok(FAR char *str, FAR const char *delim);
 /**
  * @brief split string into tokens
  * @details @b #include <string.h> \n
  * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since TizenRT v1.0
  */
-FAR char *strtok_r(FAR char *, FAR const char *, FAR char **);
+FAR char *strtok_r(FAR char *str, FAR const char *delim, FAR char **saveptr);
 /**
  * @cond
  * @internal
  */
-size_t strxfrm(FAR char *, FAR const char *, size_t n);
+size_t strxfrm(FAR char *s1, FAR const char *s2, size_t n);
 /**
  * @endcond
  */


### PR DESCRIPTION
This patch modifies API definitions in string.h as per coding rule and
adds valid arguments names to each one of them.

Signed-off-by: Vidisha Thapa <thapa.v@samsung.com>