### PR TITLE
Remove unnecessary check for builtin count and Fix unregister return value

### DIFF
--- a/apps/builtin/builtin_list.c
+++ b/apps/builtin/builtin_list.c
@@ -101,7 +101,7 @@ void register_examples_cmds(void)
 	}
 }
 
-int get_builtin_list_cnt(void)
+unsigned int get_builtin_list_cnt(void)
 {
 	return sizeof(builtin_list) / sizeof(builtin_list[0]) - 1;
 }

--- a/apps/include/builtin.h
+++ b/apps/include/builtin.h
@@ -32,7 +32,7 @@ typedef struct builtin_info_s builtin_info_t;
 
 #ifdef CONFIG_BUILTIN_APPS
 extern const builtin_info_t builtin_list[];
-int get_builtin_list_cnt(void);
+unsigned int get_builtin_list_cnt(void);
 void register_examples_cmds(void);
 #endif
 

--- a/framework/src/task_manager/Kconfig
+++ b/framework/src/task_manager/Kconfig
@@ -6,7 +6,6 @@
 config TASK_MANAGER
 	bool "Enable Task Manager"
 	default n
-	select BUILTIN_APPS
 	select SCHED_ATEXIT
 	select SCHED_WORKQUEUE if !BUILD_PROTECTED
 	select LIB_USRWORK if BUILD_PROTECTED


### PR DESCRIPTION
Previous Task Manager cannot run without builtin-apps.
But, now Task Manager can run without builtin-apps.