### PR TITLE
framework/media: Add APIs and UTCs to get maximum audio volume

### DIFF
--- a/apps/examples/mediaplayer/mediaplayer_main.cpp
+++ b/apps/examples/mediaplayer/mediaplayer_main.cpp
@@ -45,7 +45,18 @@ static const int TEST_AAC = 2;
 static const int TEST_OPUS = 3;
 static const int TEST_BUFFER = 4;
 
-enum test_command_e { APP_OFF, PLAYER_START, PLAYER_PAUSE, PLAYER_RESUME, PLAYER_STOP, VOLUME_UP, VOLUME_DOWN };
+static const int TEST_COMMAND_NUM = 8;
+
+enum test_command_e {
+	APP_OFF = 0,
+	PLAYER_START = 1,
+	PLAYER_PAUSE,
+	PLAYER_RESUME,
+	PLAYER_STOP,
+	GET_MAX_VOLUME,
+	VOLUME_UP,
+	VOLUME_DOWN
+};
 
 class MyMediaPlayer : public MediaPlayerObserverInterface,
 					  public FocusChangeListener,
@@ -158,14 +169,29 @@ void MyMediaPlayer::doCommand(int command)
 		}
 		isSourceSet = false;
 		break;
+	case GET_MAX_VOLUME:
+		cout << "GET_MAX_VOLUME is selected" << endl;
+		if (mp.getMaxVolume(&volume) != PLAYER_OK) {
+			cout << "MediaPlayer::getMaxVolume failed" << endl;
+		} else {
+			cout << "Max Volume is " << (int)volume << endl;
+		}
+		break;
 	case VOLUME_UP:
+		uint8_t max_volume;
 		cout << "VOLUME_UP is selected" << endl;
+		if (mp.getMaxVolume(&max_volume) != PLAYER_OK) {
+			cout << "MediaPlayer::getMaxVolume failed" << endl;
+		}
 		if (mp.getVolume(&volume) != PLAYER_OK) {
 			cout << "MediaPlayer::getVolume failed" << endl;
 		} else {
 			cout << "Volume was " << (int)volume << endl;
 		}
-		if (mp.setVolume(volume + 1) != PLAYER_OK) {
+		if (volume < max_volume) {
+			volume++;
+		}
+		if (mp.setVolume(volume) != PLAYER_OK) {
 			cout << "MediaPlayer::setVolume failed" << endl;
 		}
 		if (mp.getVolume(&volume) != PLAYER_OK) {
@@ -181,7 +207,10 @@ void MyMediaPlayer::doCommand(int command)
 		} else {
 			cout << "Volume was " << (int)volume << endl;
 		}
-		if (mp.setVolume(volume - 1) != PLAYER_OK) {
+		if (volume > 0) {
+			volume--;
+		}
+		if (mp.setVolume(volume) != PLAYER_OK) {
 			cout << "MediaPlayer::setVolume failed" << endl;
 		}
 		if (mp.getVolume(&volume) != PLAYER_OK) {
@@ -329,10 +358,11 @@ private:
 		cout << " 2. PLAYER_PAUSE    " << endl;
 		cout << " 3. PLAYER_RESUME   " << endl;
 		cout << " 4. PLAYER_STOP     " << endl;
-		cout << " 5. VOLUME_UP       " << endl;
-		cout << " 6. VOLUME_DOWN     " << endl;
+		cout << " 5. GET_MAX_VOLUME  " << endl;
+		cout << " 6. VOLUME_UP       " << endl;
+		cout << " 7. VOLUME_DOWN     " << endl;
 		cout << "====================" << endl;
-		return userInput(0, 6);
+		return userInput(0, TEST_COMMAND_NUM - 1);
 	}
 	shared_ptr<MyMediaPlayer> mPlayer[2];
 };

--- a/apps/examples/mediarecorder/mediarecorder_main.cpp
+++ b/apps/examples/mediarecorder/mediarecorder_main.cpp
@@ -32,17 +32,6 @@
 #include <iostream>
 #include <memory>
 
-constexpr int APP_ON = 1;
-constexpr int RECORDER_START = 2;
-constexpr int RECORDER_PAUSE = 3;
-constexpr int RECORDER_RESUME = 4;
-constexpr int RECORDER_STOP = 5;
-constexpr int VOLUME_UP = 6;
-constexpr int VOLUME_DOWN = 7;
-constexpr int PLAY_DATA = 8;
-constexpr int DELETE_FILE = 9;
-constexpr int APP_OFF = 0;
-
 using namespace std;
 using namespace media;
 using namespace media::stream;
@@ -54,6 +43,20 @@ static const int TEST_DATASOURCE_TYPE_FILE = 0;
 static const int TEST_DATASOURCE_TYPE_BUFFER = 1;
 
 static const char *filePath = "";
+
+enum test_command_e {
+	APP_ON = 0,
+	RECORDER_START = 1,
+	RECORDER_PAUSE,
+	RECORDER_RESUME,
+	RECORDER_STOP,
+	GET_MAX_VOLUME,
+	VOLUME_UP,
+	VOLUME_DOWN,
+	PLAY_DATA,
+	DELETE_FILE,
+	APP_OFF,
+};
 
 class MediaRecorderTest : public MediaRecorderObserverInterface,
 						  public MediaPlayerObserverInterface,
@@ -229,14 +232,29 @@ public:
 				std::cout << "PLAY_DATA" << std::endl;
 				play_data();
 				break;
+			case GET_MAX_VOLUME:
+				cout << "GET_MAX_VOLUME is selected" << endl;
+				if (mMr.getMaxVolume(&volume) != RECORDER_ERROR_NONE) {
+					cout << "MediaRecorder::getMaxVolume failed" << endl;
+				} else {
+					cout << "Max Volume is " << (int)volume << endl;
+				}
+				break;
 			case VOLUME_UP:
+				uint8_t max_volume;
 				cout << "VOLUME_UP is selected" << endl;
+				if (mMr.getMaxVolume(&max_volume) != RECORDER_ERROR_NONE) {
+					cout << "MediaRecorder::getMaxVolume failed" << endl;
+				}
 				if (mMr.getVolume(&volume) != RECORDER_ERROR_NONE) {
 					cout << "MediaRecorder::getVolume failed" << endl;
 				} else {
 					cout << "Volume was " << (int)volume << endl;
 				}
-				if (mMr.setVolume(volume + 1) != RECORDER_ERROR_NONE) {
+				if (volume < max_volume) {
+					volume++;
+				}
+				if (mMr.setVolume(volume) != RECORDER_ERROR_NONE) {
 					cout << "MediaRecorder::setVolume failed" << endl;
 				}
 				if (mMr.getVolume(&volume) != RECORDER_ERROR_NONE) {
@@ -252,7 +270,10 @@ public:
 				} else {
 					cout << "Volume was " << (int)volume << endl;
 				}
-				if (mMr.setVolume(volume - 1) != RECORDER_ERROR_NONE) {
+				if (volume > 0) {
+					volume--;
+				}
+				if (mMr.setVolume(volume) != RECORDER_ERROR_NONE) {
 					cout << "MediaRecorder::setVolume failed" << endl;
 				}
 				if (mMr.getVolume(&volume) != RECORDER_ERROR_NONE) {
@@ -323,16 +344,17 @@ public:
 	void printRecorderMenu()
 	{
 		std::cout << "========================================" << std::endl;
-		std::cout << "1. RECORDER APP ON" << std::endl;
-		std::cout << "2. RECORDER Start" << std::endl;
-		std::cout << "3. RECORDER Pause" << std::endl;
-		std::cout << "4. RECORDER Resume" << std::endl;
-		std::cout << "5. RECORDER Stop" << std::endl;
-		std::cout << "6. RECORDER Volume Up" << std::endl;
-		std::cout << "7. RECORDER Volume Down" << std::endl;
-		std::cout << "8. play Data" << std::endl;
-		std::cout << "9. Delete file" << std::endl;
-		std::cout << "0. RECORDER APP OFF" << std::endl;
+		std::cout << "0.  RECORDER APP ON" << std::endl;
+		std::cout << "1.  RECORDER Start" << std::endl;
+		std::cout << "2.  RECORDER Pause" << std::endl;
+		std::cout << "3.  RECORDER Resume" << std::endl;
+		std::cout << "4.  RECORDER Stop" << std::endl;
+		std::cout << "5.  RECORDER Get Max Volume" << std::endl;
+		std::cout << "6.  RECORDER Volume Up" << std::endl;
+		std::cout << "7.  RECORDER Volume Down" << std::endl;
+		std::cout << "8.  Play Data" << std::endl;
+		std::cout << "9.  Delete file" << std::endl;
+		std::cout << "10. RECORDER APP OFF" << std::endl;
 		std::cout << "========================================" << std::endl;
 	}
 

--- a/apps/examples/testcase/ta_tc/media/utc/utc_media_mediaplayer.cpp
+++ b/apps/examples/testcase/ta_tc/media/utc/utc_media_mediaplayer.cpp
@@ -417,6 +417,20 @@ static void utc_media_MediaPlayer_getVolume_n(void)
 	TC_SUCCESS_RESULT();
 }
 
+static void utc_media_MediaPlayer_getMaxVolume_p(void)
+{
+	uint8_t volume;
+	media::MediaPlayer mp;
+
+	mp.create();
+
+	mp.getMaxVolume(&volume);
+	TC_ASSERT_EQ_CLEANUP("utc_media_MediaPlayer_getMaxVolume", volume, 10, mp.destroy());
+
+	mp.destroy();
+	TC_SUCCESS_RESULT();
+}
+
 static void utc_media_MediaPlayer_setVolume_p(void)
 {
 	uint8_t prev, volume;
@@ -487,6 +501,8 @@ int utc_media_MediaPlayer_main(void)
 
 	utc_media_MediaPlayer_getVolume_p();
 	utc_media_MediaPlayer_getVolume_n();
+
+	utc_media_MediaPlayer_getMaxVolume_p();
 
 	utc_media_MediaPlayer_setVolume_p();
 	utc_media_MediaPlayer_setVolume_n();

--- a/apps/examples/testcase/ta_tc/media/utc/utc_media_mediarecorder.cpp
+++ b/apps/examples/testcase/ta_tc/media/utc/utc_media_mediarecorder.cpp
@@ -178,6 +178,21 @@ static void utc_media_MediaRecorder_getVolume_n(void)
 	TC_SUCCESS_RESULT();
 }
 
+static void utc_media_MediaRecorder_getMaxVolume_p(void)
+{
+	uint8_t volume;
+	MediaRecorder mr;
+	unique_ptr<FileOutputDataSource> dataSource = unique_ptr<FileOutputDataSource>(new FileOutputDataSource(channels, sampleRate, pcmFormat, filePath));
+
+	mr.create();
+
+	mr.getVolume(&volume);
+	TC_ASSERT_EQ_CLEANUP("utc_media_MediaRecorder_getMaxVolume", volume, 10, mr.destroy());
+
+	mr.destroy();
+	TC_SUCCESS_RESULT();
+}
+
 static void utc_media_MediaRecorder_prepare_p(void)
 {
 	MediaRecorder mr;
@@ -541,6 +556,8 @@ int utc_media_mediarecorder_main(void)
 
 	utc_media_MediaRecorder_getVolume_p();
 	utc_media_MediaRecorder_getVolume_n();
+
+	utc_media_MediaRecorder_getMaxVolume_p();
 
 	utc_media_MediaRecorder_prepare_p();
 	utc_media_MediaRecorder_prepare_n();

--- a/framework/include/media/MediaPlayer.h
+++ b/framework/include/media/MediaPlayer.h
@@ -70,14 +70,14 @@ class MediaPlayer
 {
 public:
 	/**
-	 * @brief Constructs an empty MediaPlayer.
+	 * @brief Construct an empty MediaPlayer.
 	 * @details @b #include <media/MediaPlayer.h>
 	 * @since TizenRT v2.0
 	 */
 	MediaPlayer();
 
 	/**
-	 * @brief Deconstructs an empty MediaPlayer.
+	 * @brief Deconstruct an empty MediaPlayer.
 	 * @details @b #include <media/MediaPlayer.h>
 	 * @since TizenRT v2.0
 	 */
@@ -86,7 +86,7 @@ public:
 	/**
 	 * @brief Create the MediaPlayer for playback
 	 * @details @b #include <media/MediaPlayer.h>
-	 * This function is a synchronous api
+	 * This function is a synchronous API
 	 * @return The result of the create operation
 	 * @since TizenRT v2.0
 	 */
@@ -95,7 +95,7 @@ public:
 	/**
 	 * @brief Destroy MediaPlayer
 	 * @details @b #include <media/MediaPlayer.h>
-	 * This function is a synchronous api
+	 * This function is a synchronous API
 	 * @return The result of the destroy operation
 	 * @since TizenRT v2.0
 	 */
@@ -104,7 +104,7 @@ public:
 	/**
 	 * @brief Allocate and prepare resources related to the player, it should be called before start
 	 * @details @b #include <media/MediaPlayer.h>
-	 * This function is a synchronous api
+	 * This function is a synchronous API
 	 * @return The result of the prepare operation
 	 * @since TizenRT v2.0
 	 */
@@ -113,7 +113,7 @@ public:
 	/**
 	 * @brief Releases allocated resources related to the player.
 	 * @details @b #include <media/MediaPlayer.h>
-	 * This function is a synchronous api
+	 * This function is a synchronous API
 	 * @return The result of the unpreapre operation
 	 * @since TizenRT v2.0
 	 */
@@ -122,9 +122,9 @@ public:
 	/**
 	 * @brief Start playback.
 	 * @details @b #include <media/MediaPlayer.h>
-	 * This function is a asynchronous api
+	 * This function is a asynchronous API
 	 * Order to MediaPlayerWorker begin playback through the queue
-	 * @return The result of the unpreapre operation
+	 * @return The result of the unprepare operation
 	 * @since TizenRT v2.0
 	 */
 	player_result_t start();
@@ -132,7 +132,7 @@ public:
 	/**
 	 * @brief Pause playback.
 	 * @details @b #include <media/MediaPlayer.h>
-	 * This function is a asynchronous api
+	 * This function is a asynchronous API
 	 * Order to MediaPlayerWorker pause playback through the queue
 	 * @return The result of the pause operation
 	 * @since TizenRT v2.0
@@ -142,7 +142,7 @@ public:
 	/**
 	 * @brief Stop playback.
 	 * @details @b #include <media/MediaPlayer.h>
-	 * This function is a asynchronous api
+	 * This function is a asynchronous API
 	 * Order to MediaPlayerWorker stop playback through the queue
 	 * @return The result of the stop operation
 	 * @since TizenRT v2.0
@@ -150,27 +150,36 @@ public:
 	player_result_t stop();
 
 	/**
-	 * @brief Gets the current volume
+	 * @brief Get the current volume
 	 * @details @b #include <media/MediaPlayer.h>
-	 * This function is a synchronous api
+	 * This function is a synchronous API
 	 * @return The value of current volume
 	 * @since TizenRT v2.0
 	 */
 	player_result_t getVolume(uint8_t *volume);
 
 	/**
-	 * @brief Sets the volume adjusted
+	 * @brief Get the maximum output volume
 	 * @details @b #include <media/MediaPlayer.h>
-	 * This function is a synchronous api
-	 * @param[in] vol The vol that the value of mic volume
+	 * This function is a synchronous API
+	 * @return The value of the maximum volume
+	 * @since TizenRT v2.0
+	 */
+	player_result_t getMaxVolume(uint8_t *volume);
+
+	/**
+	 * @brief Set the volume adjusted
+	 * @details @b #include <media/MediaPlayer.h>
+	 * This function is a synchronous API
+	 * @param[in] vol The volume value to set
 	 * @since TizenRT v2.0
 	 */
 	player_result_t setVolume(uint8_t);
 
 	/**
-	 * @brief Sets the DataSource of input data
+	 * @brief Set the DataSource of input data
 	 * @details @b #include <media/MediaPlayer.h>
-	 * This function is a synchronous api
+	 * This function is a synchronous API
 	 * @param[in] dataSource The dataSource that the config of input data
 	 * @return The result of the setDataSource operation
 	 * @since TizenRT v2.0
@@ -178,9 +187,9 @@ public:
 	player_result_t setDataSource(std::unique_ptr<stream::InputDataSource>);
 
 	/**
-	 * @brief Sets the observer of MediaPlayer
+	 * @brief Set the observer of MediaPlayer
 	 * @details @b #include <media/MediaPlayer.h>
-	 * This function is a synchronous api
+	 * This function is a synchronous API
 	 * It sets the user's function
 	 * @param[in] observer The callback to be set for Media Player Observer.
 	 * @return The result of the setObserver operation
@@ -191,7 +200,7 @@ public:
 	/**
 	 * @brief MediaPlayer operator==
 	 * @details @b #include <media/MediaPlayer.h>
-	 * This function is a synchronous api
+	 * This function is a synchronous API
 	 * Compares the MediaPlayer objects for equality
 	 * @return The result of the compare operation for MediaPlayer object
 	 * @since TizenRT v2.0

--- a/framework/include/media/MediaRecorder.h
+++ b/framework/include/media/MediaRecorder.h
@@ -71,14 +71,14 @@ class MediaRecorder
 {
 public:
 	/**
-	 * @brief Constructs an empty MediaRecorder.
+	 * @brief Construct an empty MediaRecorder.
 	 * @details @b #include <media/MediaRecorder.h>
 	 * @since TizenRT v2.0
 	 */
 	MediaRecorder();
 	
 	/**
-	 * @brief Deconstructs an empty MediaRecorder.
+	 * @brief Deconstruct an empty MediaRecorder.
 	 * @details @b #include <media/MediaRecorder.h>
 	 * @since TizenRT v2.0
 	 */
@@ -87,7 +87,7 @@ public:
 	/**
 	 * @brief Create MediaRecorder for capturing
 	 * @details @b #include <media/MediaRecorder.h>
-	 * This function is a synchronous api
+	 * This function is a synchronous API
 	 * @return The result of the create operation
 	 * @since TizenRT v2.0
 	 */
@@ -96,7 +96,7 @@ public:
 	/**
 	 * @brief Destroy MediaRecorder
 	 * @details @b #include <media/MediaRecorder.h>
-	 * This function is a synchronous api
+	 * This function is a synchronous API
 	 * @return The result of the destroy operation
 	 * @since TizenRT v2.0
 	 */
@@ -105,16 +105,16 @@ public:
 	/**
 	 * @brief Allocate and prepare resources related to the recorder, it should be called before start
 	 * @details @b #include <media/MediaRecorder.h>
-	 * This function is a synchronous api
+	 * This function is a synchronous API
 	 * @return The result of the prepare operation
 	 * @since TizenRT v2.0
 	 */
 	recorder_result_t prepare();
 	
 	/**
-	 * @brief Releases allocated resources related to the recorder.
+	 * @brief Release allocated resources related to the recorder.
 	 * @details @b #include <media/MediaRecorder.h>
-	 * This function is a synchronous api
+	 * This function is a synchronous API
 	 * @return The result of the unpreapre operation
 	 * @since TizenRT v2.0
 	 */
@@ -123,7 +123,7 @@ public:
 	/**
 	 * @brief Start recording.
 	 * @details @b #include <media/MediaRecorder.h>
-	 * This function is a asynchronous api
+	 * This function is a asynchronous API
 	 * Order to MediaRecordWorker begin recording through the queue
 	 * @return The result of the unpreapre operation
 	 * @since TizenRT v2.0
@@ -133,7 +133,7 @@ public:
 	/**
 	 * @brief Pause recording.
 	 * @details @b #include <media/MediaRecorder.h>
-	 * This function is a asynchronous api
+	 * This function is a asynchronous API
 	 * Order to MediaRecordWorker pause recording through the queue
 	 * @return The result of the pause operation
 	 * @since TizenRT v2.0
@@ -143,7 +143,7 @@ public:
 	/**
 	 * @brief Stop recording.
 	 * @details @b #include <media/MediaRecorder.h>
-	 * This function is a asynchronous api
+	 * This function is a asynchronous API
 	 * Order to MediaRecordWorker stop recording through the queue
 	 * @return The result of the stop operation
 	 * @since TizenRT v2.0
@@ -151,18 +151,27 @@ public:
 	recorder_result_t stop();
 	
 	/**
-	 * @brief Gets the current volume
+	 * @brief Get the current volume
 	 * @details @b #include <media/MediaRecorder.h>
-	 * This function is a synchronous api
-	 * @return The value of current mic volume
+	 * This function is a synchronous API
+	 * @return The value of current MIC volume
 	 * @since TizenRT v2.0
 	 */
 	recorder_result_t getVolume(uint8_t *vol);
 	
 	/**
-	 * @brief Sets the volume adjusted
+	 * @brief Get the Maximum input gain
 	 * @details @b #include <media/MediaRecorder.h>
-	 * This function is a synchronous api
+	 * This function is a synchronous API
+	 * @return The value of the maximum MIC gain
+	 * @since TizenRT v2.0
+	 */
+	recorder_result_t getMaxVolume(uint8_t *vol);
+
+	/**
+	 * @brief Set the volume adjusted
+	 * @details @b #include <media/MediaRecorder.h>
+	 * This function is a synchronous API
 	 * @param[in] vol The vol that the value of mic volume
 	 * @return The result of setting the mic volume
 	 * @since TizenRT v2.0
@@ -170,9 +179,9 @@ public:
 	recorder_result_t setVolume(uint8_t vol);
 	
 	/**
-	 * @brief Sets the DataSource of output data
+	 * @brief Set the DataSource of output data
 	 * @details @b #include <media/MediaRecorder.h>
-	 * This function is a synchronous api
+	 * This function is a synchronous API
 	 * @param[in] dataSource The dataSource that the config of output data
 	 * @return The result of setting the datasource
 	 * @since TizenRT v2.0
@@ -180,9 +189,9 @@ public:
 	recorder_result_t setDataSource(std::unique_ptr<stream::OutputDataSource> dataSource);
 	
 	/**
-	 * @brief Sets the observer of MediaRecorder
+	 * @brief Set the observer of MediaRecorder
 	 * @details @b #include <media/MediaRecorder.h>
-	 * This function is a synchronous api
+	 * This function is a synchronous API
 	 * It sets the user's function
 	 * @param[in] observer The callback to be set for Media Recorder Observer.
 	 * @return The result of setting the observer
@@ -194,7 +203,7 @@ public:
 	 * @brief Set limitation of recording time by given value(second), will be stopped when it reaches that.
 	 * This should be called after setDataSource but before prepare
 	 * @details @b #include <media/MediaRecorder.h>
-	 * This function is a synchronous api
+	 * This function is a synchronous API
 	 * It sets the user's function
  	 * @param[in] Max duration(second), No limitation If zero or negative.
 	 * @return The result of setting the duration
@@ -217,7 +226,7 @@ public:
 	/**
 	 * @brief MediaRecorder operator==
 	 * @details @b #include <media/MediaRecorder.h>
-	 * This function is a synchronous api
+	 * This function is a synchronous API
 	 * Compares the MediaRecorder objects for equality
 	 * @return The result of the compare operation for MediaRecorder object
 	 * @since TizenRT v2.0

--- a/framework/src/media/MediaPlayer.cpp
+++ b/framework/src/media/MediaPlayer.cpp
@@ -67,6 +67,11 @@ player_result_t MediaPlayer::getVolume(uint8_t *vol)
 	return mPMpImpl->getVolume(vol);
 }
 
+player_result_t MediaPlayer::getMaxVolume(uint8_t *vol)
+{
+	return mPMpImpl->getMaxVolume(vol);
+}
+
 player_result_t MediaPlayer::setVolume(uint8_t vol)
 {
 	return mPMpImpl->setVolume(vol);

--- a/framework/src/media/MediaPlayerImpl.h
+++ b/framework/src/media/MediaPlayerImpl.h
@@ -91,6 +91,7 @@ public:
 	player_result_t stop();
 
 	player_result_t getVolume(uint8_t *vol);
+	player_result_t getMaxVolume(uint8_t *vol);
 	player_result_t setVolume(uint8_t vol);
 
 	player_result_t setDataSource(std::unique_ptr<stream::InputDataSource>);
@@ -112,6 +113,7 @@ private:
 	void stopPlayer(player_result_t ret);
 	void pausePlayer();
 	void getPlayerVolume(uint8_t *vol, player_result_t &ret);
+	void getPlayerMaxVolume(uint8_t *vol, player_result_t &ret);
 	void setPlayerVolume(uint8_t vol, player_result_t &ret);
 	void setPlayerObserver(std::shared_ptr<MediaPlayerObserverInterface> observer);
 	void setPlayerDataSource(std::shared_ptr<stream::InputDataSource> dataSource, player_result_t &ret);

--- a/framework/src/media/MediaRecorder.cpp
+++ b/framework/src/media/MediaRecorder.cpp
@@ -67,6 +67,11 @@ recorder_result_t MediaRecorder::getVolume(uint8_t *vol)
 	return mPMrImpl->getVolume(vol);
 }
 
+recorder_result_t MediaRecorder::getMaxVolume(uint8_t *vol)
+{
+	return mPMrImpl->getMaxVolume(vol);
+}
+
 recorder_result_t MediaRecorder::setVolume(uint8_t vol)
 {
 	return mPMrImpl->setVolume(vol);

--- a/framework/src/media/MediaRecorderImpl.h
+++ b/framework/src/media/MediaRecorderImpl.h
@@ -94,6 +94,7 @@ public:
 	recorder_result_t stop();
 
 	recorder_result_t getVolume(uint8_t *vol);
+	recorder_result_t getMaxVolume(uint8_t *vol);
 	recorder_result_t setVolume(uint8_t vol);
 	recorder_result_t setDataSource(std::unique_ptr<stream::OutputDataSource> dataSource);
 	recorder_state_t getState();
@@ -113,6 +114,7 @@ private:
 	void pauseRecorder();
 	void stopRecorder(recorder_result_t ret);
 	void getRecorderVolume(uint8_t *vol, recorder_result_t& ret);
+	void getRecorderMaxVolume(uint8_t *vol, recorder_result_t& ret);
 	void setRecorderVolume(uint8_t vol, recorder_result_t& ret);
 	void setRecorderObserver(std::shared_ptr<MediaRecorderObserverInterface> observer);
 	void setRecorderDataSource(std::shared_ptr<stream::OutputDataSource> dataSource, recorder_result_t& ret);


### PR DESCRIPTION
- getMaxVolume() API is added to media recorder and player source code, respectively.
- UTCs for getMaxVolume() is added also.
- The command to call getMaxVolume() is added also into media examples.