### PR TITLE
framework/wifi_manager: Modify deinit API and add UTC for new APIs

### DIFF
--- a/framework/src/wifi_manager/wifi_manager.c
+++ b/framework/src/wifi_manager/wifi_manager.c
@@ -753,7 +753,6 @@ wifi_manager_result_e _wifimgr_deinit(void)
 {
 	WM_LOG_START;
 	WIFIMGR_CHECK_UTILRESULT(wifi_utils_deinit(), "[WM] wifi_utils_deinit fail", WIFI_MANAGER_FAIL);
-
 #ifdef CONFIG_ENABLE_IOTIVITY
 	int ret = mq_close(g_dw_nwevent_mqfd);
 	if (ret < 0) {
@@ -762,6 +761,12 @@ wifi_manager_result_e _wifimgr_deinit(void)
 		return WIFI_MANAGER_FAIL;
 	}
 #endif
+	int i = 0;
+	for (i = 0; i < WIFIMGR_NUM_CALLBACKS; i++) {
+		if (g_manager_info.cb[i] != NULL) {
+			g_manager_info.cb[i] = NULL;
+		}
+	}
 	return WIFI_MANAGER_SUCCESS;
 }
 


### PR DESCRIPTION
- Deinitialize callback function pointer when deinit is executed
- Add two UTCs for newly added APIs; wifi_manager_register_cb and wifi_manager_unregister_cb