### PR TITLE
testcase/task_manager: Reverse the wrong param for task_manager_regis…

### DIFF
--- a/apps/examples/testcase/ta_tc/task_manager/utc/utc_task_manager_main.c
+++ b/apps/examples/testcase/ta_tc/task_manager/utc/utc_task_manager_main.c
@@ -848,7 +848,7 @@ static void utc_task_manager_register_task_n(void)
 
 static void utc_task_manager_register_task_p(void)
 {
-	tm_not_builtin_handle = task_manager_register_task("not_builtin", 100, 1024, 0 , NULL, TM_APP_PERMISSION_DEDICATE, TM_RESPONSE_WAIT_INF);
+	tm_not_builtin_handle = task_manager_register_task("not_builtin", 100, 1024, not_builtin_task, NULL, TM_APP_PERMISSION_DEDICATE, TM_RESPONSE_WAIT_INF);
 	TC_ASSERT_GEQ("task_manager_register_task", tm_not_builtin_handle, 0);
 
 	TC_SUCCESS_RESULT();


### PR DESCRIPTION
…ter_task TC

The 4th param of task_manager_register_task should be entry point for task.