### PR TITLE
framework/task_manager: Refactoring task manager core

### DIFF
--- a/framework/src/task_manager/task_manager_internal.h
+++ b/framework/src/task_manager/task_manager_internal.h
@@ -181,7 +181,7 @@ typedef struct tm_internal_msg_s tm_internal_msg_t;
 struct tm_broadcast_internal_msg_s {
 	int size;
 	void *user_data;
-	tm_broadcast_info_t *info;
+	tm_broadcast_info_t *cb_info;
 };
 typedef struct tm_broadcast_internal_msg_s tm_broadcast_internal_msg_t;
 
@@ -196,8 +196,8 @@ typedef struct tm_broadcast_internal_msg_s tm_broadcast_internal_msg_t;
 #define TM_PERMISSION(handle)           TM_LIST_ADDR(handle)->permission
 #define TM_UNICAST_CB(handle)           TM_LIST_ADDR(handle)->unicast_cb
 #define TM_BROADCAST_INFO_LIST(handle)  TM_LIST_ADDR(handle)->broadcast_info_list
-#define TM_STOP_INFO(handle)            TM_LIST_ADDR(handle)->stop_cb_info
-#define TM_EXIT_INFO(handle)            TM_LIST_ADDR(handle)->exit_cb_info
+#define TM_STOP_CB_INFO(handle)         TM_LIST_ADDR(handle)->stop_cb_info
+#define TM_EXIT_CB_INFO(handle)         TM_LIST_ADDR(handle)->exit_cb_info
 
 extern app_list_t tm_app_list[CONFIG_TASK_MANAGER_MAX_TASKS];
 

--- a/framework/src/task_manager/task_manager_set_callback.c
+++ b/framework/src/task_manager/task_manager_set_callback.c
@@ -66,7 +66,7 @@ void taskmgr_msg_cb(int signo, siginfo_t *data)
 	} else {
 		user_data = ((tm_broadcast_internal_msg_t *)data->si_value.sival_ptr)->user_data;
 		user_data_size = ((tm_broadcast_internal_msg_t *)data->si_value.sival_ptr)->size;
-		cb_data = ((tm_broadcast_info_t *)((tm_broadcast_internal_msg_t *)data->si_value.sival_ptr)->info)->cb_data;
+		cb_data = ((tm_broadcast_info_t *)((tm_broadcast_internal_msg_t *)data->si_value.sival_ptr)->cb_info)->cb_data;
 
 		if (user_data_size >= 0) {
 			broadcast_param = (tm_msg_t *)TM_ALLOC(sizeof(tm_msg_t));
@@ -92,7 +92,7 @@ void taskmgr_msg_cb(int signo, siginfo_t *data)
 			broadcast_param = NULL;
 		}
 
-		(*((tm_broadcast_info_t *)((tm_broadcast_internal_msg_t *)data->si_value.sival_ptr)->info)->cb)(broadcast_param, cb_data);
+		(*((tm_broadcast_info_t *)((tm_broadcast_internal_msg_t *)data->si_value.sival_ptr)->cb_info)->cb)(broadcast_param, cb_data);
 
 		if (broadcast_param != NULL) {
 			TM_FREE(broadcast_param);
@@ -114,23 +114,23 @@ void taskmgr_stop_cb(int signo, siginfo_t *data)
 {
 	int taskmgr_pid;
 	union sigval msg;
-	tm_termination_info_t *info;
-	info = (tm_termination_info_t *)data->si_value.sival_ptr;
+	tm_termination_info_t *cb_info;
+	cb_info = (tm_termination_info_t *)data->si_value.sival_ptr;
 
 	/* Call callback function with callback data */
-	if (info != NULL && info->cb != NULL) {
-		if (info->cb_data != NULL) {
-			(*info->cb)(info->cb_data->msg);
-			TM_FREE(info->cb_data->msg);
-			TM_FREE(info->cb_data);
+	if (cb_info != NULL && cb_info->cb != NULL) {
+		if (cb_info->cb_data != NULL) {
+			(*cb_info->cb)(cb_info->cb_data->msg);
+			TM_FREE(cb_info->cb_data->msg);
+			TM_FREE(cb_info->cb_data);
 		} else {
-			(*info->cb)(NULL);
+			(*cb_info->cb)(NULL);
 		}
 	} else {
 		tmdbg("stop callback information is not correct.\n");
 		return;
 	}
-	TM_FREE(info);
+	TM_FREE(cb_info);
 
 	taskmgr_pid = taskmgr_get_task_manager_pid();
 	if (taskmgr_pid == TM_TASK_MGR_NOT_ALIVE) {


### PR DESCRIPTION
1. taskmgr_get_drvfd() and ioctl() were unified to taskmgr_handle_tcb().
According to the change, taskmgr_adj_pthread_parent() and taskmgr_broadcast() were modified.
(taskmgr_get_drvfd() and ioctl() were replaced with taskmgr_handle_tcb())

2. In order to avoid the misreading, TM_STOP_INFO(X) and TM_EXIT_INFO(X) were changed to TM_STOP_CB_INFO(X) and TM_EXIT_CB_INFO(X).