### PR TITLE
[external/iotivity]: Remove libcoap.a from external/libcoap/ for 'make clean'

### DIFF
--- a/external/iotivity/iotivity_1.2-rel/extlibs/libcoap/SConscript
+++ b/external/iotivity/iotivity_1.2-rel/extlibs/libcoap/SConscript
@@ -50,6 +50,14 @@ libcoap_zip_file         = os.path.join(src_dir, 'extlibs', 'libcoap', libcoap_b
 libcoap_url              = libcoap_repo_url + '/archive/' + libcoap_branch + '.zip'
 libcoap_checkout_command = 'git clone ' + libcoap_repo_url + '.git extlibs/libcoap/libcoap --branch ' + libcoap_branch
 
+if GetOption('clean'):
+    lib_path = os.path.join(src_dir, 'extlibs', 'libcoap', 'libcoap.a')
+    if os.path.exists(lib_path):
+        result = os.system('rm %s' %lib_path)
+        if result != 0:
+            print 'Failed to remove the libcoap library in extlibs/libcoap'
+    Return('libcoap_env')
+
 if with_upstream_libcoap == '1':
     print '*** Checking for installation of libCoAP ***'
     if not os.path.exists(libcoap_dir):
@@ -167,4 +175,3 @@ else:
 libcoap = libcoap_env.StaticLibrary('coap', libcoap_src, OBJPREFIX='libcoap_')
 
 libcoap_env.InstallTarget([libcoap], 'coap')
-


### PR DESCRIPTION
AS IS: libcoap.a library was not removed after 'make clean'.
TO BE: Remove libcoap.a after 'make clean'.

Signed-off-by: Senthil Kumar G S <senthil.gs@samsung.com>