### PR TITLE
framework/st_things : Add EncType and SecType values for AP scan list

### DIFF
--- a/framework/src/st_things/things_stack/easy-setup/easysetup_manager.c
+++ b/framework/src/st_things/things_stack/easy-setup/easysetup_manager.c
@@ -584,8 +584,8 @@ void wifi_prov_cb_in_app(es_wifi_prov_data_s *event_data)
 	// TODO : Fix Bug for 64bit support.
 	memset(p_info->e_ssid, 0, WIFIMGR_SSID_LEN + 1);
 	memset(p_info->security_key, 0, WIFIMGR_PASSPHRASE_LEN + 1);
-	memset(p_info->enc_type, 0, MAX_TYPE_ENC);
-	memset(p_info->auth_type, 0, MAX_TYPE_AUTH);
+	memset(p_info->enc_type, 0, MAX_TYPE_ENC + 1);
+	memset(p_info->auth_type, 0, MAX_TYPE_AUTH + 1);
 	memset(p_info->channel, 0, MAX_CHANNEL);
 	memset(p_info->bss_id, 0, WIFIMGR_MACADDR_STR_LEN + 1);
 	memset(p_info->signal_level, 0, MAX_LEVEL_SIGNAL);

--- a/framework/src/st_things/things_stack/easy-setup/easysetup_manager.c
+++ b/framework/src/st_things/things_stack/easy-setup/easysetup_manager.c
@@ -598,49 +598,49 @@ void wifi_prov_cb_in_app(es_wifi_prov_data_s *event_data)
 		things_strncpy(p_info->security_key, event_data->pwd, strlen(event_data->pwd));
 	}
 
-	if (event_data->authtype >= NONE_AUTH && event_data->authtype <= WPA2_PSK) {
-		switch (event_data->authtype) {
+	if (event_data->sectype >= NONE_SEC && event_data->sectype <= WPA2_PSK) {
+		switch (event_data->sectype) {
 		case WEP:
-			things_strncpy(p_info->sec_type, "WEP", strlen("WEP"));
+			things_strncpy(p_info->sec_type, SEC_TYPE_WEP, strlen(SEC_TYPE_WEP));
 			break;
 		case WPA_PSK:
-			things_strncpy(p_info->sec_type, "WPA-PSK", strlen("WPA-PSK"));
+			things_strncpy(p_info->sec_type, SEC_TYPE_WPA_PSK, strlen(SEC_TYPE_WPA_PSK));
 			break;
 		case WPA2_PSK:
-			things_strncpy(p_info->sec_type, "WPA2-PSK", strlen("WPA2-PSK"));
+			things_strncpy(p_info->sec_type, SEC_TYPE_WPA2_PSK, strlen(SEC_TYPE_WPA2_PSK));
 			break;
-		case NONE_AUTH:
+		case NONE_SEC:
 		default:
-			things_strncpy(p_info->sec_type, "NONE", strlen("NONE"));
+			things_strncpy(p_info->sec_type, SEC_TYPE_NONE, strlen(SEC_TYPE_NONE));
 			break;
 		}
 	} else {
-		things_strncpy(p_info->sec_type, "NONE", strlen("NONE"));
+		things_strncpy(p_info->sec_type, SEC_TYPE_NONE, strlen(SEC_TYPE_NONE));
 	}
 
 	if (event_data->enctype >= NONE_ENC && event_data->enctype <= TKIP_AES) {
 		switch (event_data->enctype) {
 		case WEP_64:
-			things_strncpy(p_info->enc_type, "WEP_64", strlen("WEP_64"));
+			things_strncpy(p_info->enc_type, ENC_TYPE_WEP_64, strlen(ENC_TYPE_WEP_64));
 			break;
 		case WEP_128:
-			things_strncpy(p_info->enc_type, "WEP_128", strlen("WEP_128"));
+			things_strncpy(p_info->enc_type, ENC_TYPE_WEP_128, strlen(ENC_TYPE_WEP_128));
 			break;
 		case TKIP:
-			things_strncpy(p_info->enc_type, "TKIP", strlen("TKIP"));
+			things_strncpy(p_info->enc_type, ENC_TYPE_TKIP, strlen(ENC_TYPE_TKIP));
 			break;
 		case AES:
-			things_strncpy(p_info->enc_type, "AES", strlen("AES"));
+			things_strncpy(p_info->enc_type, ENC_TYPE_AES, strlen(ENC_TYPE_AES));
 			break;
 		case TKIP_AES:
-			things_strncpy(p_info->enc_type, "TKIP_AES", strlen("TKIP_AES"));
+			things_strncpy(p_info->enc_type, ENC_TYPE_TKIP_AES, strlen(ENC_TYPE_TKIP_AES));
 			break;
 		default:
-			things_strncpy(p_info->enc_type, "NONE", strlen("NONE"));
+			things_strncpy(p_info->enc_type, ENC_TYPE_NONE, strlen(ENC_TYPE_NONE));
 			break;
 		}
 	} else {
-		things_strncpy(p_info->enc_type, "NONE", strlen("NONE"));
+		things_strncpy(p_info->enc_type, ENC_TYPE_NONE, strlen(ENC_TYPE_NONE));
 	}
 
 	if (event_data->discovery_channel != -1) {
@@ -656,7 +656,7 @@ void wifi_prov_cb_in_app(es_wifi_prov_data_s *event_data)
 	THINGS_LOG_D(TAG, "Copied pwd = %s", g_wifi_prov_data->pwd);
 	THINGS_LOG_D(TAG, "Copied enctype = %d", g_wifi_prov_data->enctype);
 	THINGS_LOG_D(TAG, "Copied discovery_channel = %d", g_wifi_prov_data->discovery_channel);
-	THINGS_LOG_D(TAG, "Copied authtype = %d", g_wifi_prov_data->authtype);
+	THINGS_LOG_D(TAG, "Copied sectype = %d", g_wifi_prov_data->sectype);
 
 	// Connect to AP
 	if (gthread_id_network_status_check == 0) {

--- a/framework/src/st_things/things_stack/easy-setup/easysetup_manager.c
+++ b/framework/src/st_things/things_stack/easy-setup/easysetup_manager.c
@@ -585,7 +585,7 @@ void wifi_prov_cb_in_app(es_wifi_prov_data_s *event_data)
 	memset(p_info->e_ssid, 0, WIFIMGR_SSID_LEN + 1);
 	memset(p_info->security_key, 0, WIFIMGR_PASSPHRASE_LEN + 1);
 	memset(p_info->enc_type, 0, MAX_TYPE_ENC + 1);
-	memset(p_info->auth_type, 0, MAX_TYPE_AUTH + 1);
+	memset(p_info->sec_type, 0, MAX_TYPE_SEC + 1);
 	memset(p_info->channel, 0, MAX_CHANNEL);
 	memset(p_info->bss_id, 0, WIFIMGR_MACADDR_STR_LEN + 1);
 	memset(p_info->signal_level, 0, MAX_LEVEL_SIGNAL);
@@ -601,21 +601,21 @@ void wifi_prov_cb_in_app(es_wifi_prov_data_s *event_data)
 	if (event_data->authtype >= NONE_AUTH && event_data->authtype <= WPA2_PSK) {
 		switch (event_data->authtype) {
 		case WEP:
-			things_strncpy(p_info->auth_type, "WEP", strlen("WEP"));
+			things_strncpy(p_info->sec_type, "WEP", strlen("WEP"));
 			break;
 		case WPA_PSK:
-			things_strncpy(p_info->auth_type, "WPA-PSK", strlen("WPA-PSK"));
+			things_strncpy(p_info->sec_type, "WPA-PSK", strlen("WPA-PSK"));
 			break;
 		case WPA2_PSK:
-			things_strncpy(p_info->auth_type, "WPA2-PSK", strlen("WPA2-PSK"));
+			things_strncpy(p_info->sec_type, "WPA2-PSK", strlen("WPA2-PSK"));
 			break;
 		case NONE_AUTH:
 		default:
-			things_strncpy(p_info->auth_type, "NONE", strlen("NONE"));
+			things_strncpy(p_info->sec_type, "NONE", strlen("NONE"));
 			break;
 		}
 	} else {
-		things_strncpy(p_info->auth_type, "NONE", strlen("NONE"));
+		things_strncpy(p_info->sec_type, "NONE", strlen("NONE"));
 	}
 
 	if (event_data->enctype >= NONE_ENC && event_data->enctype <= TKIP_AES) {
@@ -649,7 +649,7 @@ void wifi_prov_cb_in_app(es_wifi_prov_data_s *event_data)
 
 	THINGS_LOG_D(TAG, "e_ssid : %s", p_info->e_ssid);
 	THINGS_LOG_D(TAG, "security_key : %s", p_info->security_key);
-	THINGS_LOG_D(TAG, "auth_type : %s", p_info->auth_type);
+	THINGS_LOG_D(TAG, "sec_type : %s", p_info->sec_type);
 	THINGS_LOG_D(TAG, "enc_type : %s", p_info->enc_type);
 	THINGS_LOG_D(TAG, "channel : %s", p_info->channel);
 	THINGS_LOG_D(TAG, "Copied ssid = %s", g_wifi_prov_data->ssid);

--- a/framework/src/st_things/things_stack/easy-setup/es_common.h
+++ b/framework/src/st_things/things_stack/easy-setup/es_common.h
@@ -37,7 +37,7 @@
 #define THINGS_RSRVD_ES_SUPPORTEDWIFIFREQ        "swf"
 #define THINGS_RSRVD_ES_SSID                     "tnn"
 #define THINGS_RSRVD_ES_CRED                     "cd"
-#define THINGS_RSRVD_ES_AUTHTYPE                 "wat"
+#define THINGS_RSRVD_ES_SECTYPE                  "wat"
 #define THINGS_RSRVD_ES_ENCTYPE                  "wet"
 #define THINGS_RSRVD_ES_AUTHCODE                 "ac"
 #define THINGS_RSRVD_ES_AUTHPROVIDER             "apn"

--- a/framework/src/st_things/things_stack/easy-setup/resource_handler.c
+++ b/framework/src/st_things/things_stack/easy-setup/resource_handler.c
@@ -310,7 +310,7 @@ OCStackResult init_wifi_resource(bool is_secured)
 	g_wifi_resource.supported_mode[3] = WiFi_11N;
 	g_wifi_resource.supported_mode[4] = WiFi_11AC;
 	g_wifi_resource.num_mode = 5;
-	g_wifi_resource.auth_type = NONE_AUTH;
+	g_wifi_resource.sec_type = NONE_SEC;
 	g_wifi_resource.enc_type = NONE_ENC;
 	memset(g_wifi_resource.ssid, 0, sizeof(char) *WIFIMGR_SSID_LEN);
 	memset(g_wifi_resource.cred, 0, sizeof(char) *WIFIMGR_PASSPHRASE_LEN);
@@ -392,7 +392,7 @@ static void init_es_wifi_prov_data(es_wifi_prov_data_s *p_wifi_data)
 
 	memset(p_wifi_data->ssid, 0, sizeof(char) *WIFIMGR_SSID_LEN);
 	memset(p_wifi_data->pwd, 0, sizeof(char) *WIFIMGR_PASSPHRASE_LEN);
-	p_wifi_data->authtype = -1;
+	p_wifi_data->sectype = -1;
 	p_wifi_data->enctype = -1;
 	p_wifi_data->discovery_channel = -1;
 }
@@ -402,19 +402,19 @@ void set_ssid_in_wifi_resource(const char *ssid)
 	if (ssid == NULL) {
 		memset(g_wifi_resource.ssid, 0, sizeof(char) *WIFIMGR_SSID_LEN);
 		memset(g_wifi_resource.cred, 0, sizeof(char) *WIFIMGR_PASSPHRASE_LEN);
-		g_wifi_resource.auth_type = NONE_AUTH;
+		g_wifi_resource.sec_type = NONE_SEC;
 		g_wifi_resource.enc_type = NONE_ENC;
 		g_wifi_resource.discovery_channel = 0;
 	} else if (strncmp(ssid, g_wifi_data.ssid, strlen(ssid)) == 0) {
 		things_strncpy(g_wifi_resource.ssid, g_wifi_data.ssid, sizeof(char) *WIFIMGR_SSID_LEN);
 		things_strncpy(g_wifi_resource.cred, g_wifi_data.pwd, sizeof(char) *WIFIMGR_PASSPHRASE_LEN);
-		g_wifi_resource.auth_type = g_wifi_data.authtype;
+		g_wifi_resource.sec_type = g_wifi_data.sectype;
 		g_wifi_resource.enc_type = g_wifi_data.enctype;
 		g_wifi_resource.discovery_channel = g_wifi_data.discovery_channel;
 	} else {
 		things_strncpy(g_wifi_resource.ssid, ssid, sizeof(char) *WIFIMGR_SSID_LEN);
 		memset(g_wifi_resource.cred, 0, sizeof(char) *WIFIMGR_PASSPHRASE_LEN);
-		g_wifi_resource.auth_type = NONE_AUTH;
+		g_wifi_resource.sec_type = NONE_SEC;
 		g_wifi_resource.enc_type = NONE_ENC;
 		g_wifi_resource.discovery_channel = 1;
 	}
@@ -502,10 +502,10 @@ void update_wifi_resource(OCRepPayload *input)
 		THINGS_LOG_D(ES_RH_TAG, "g_wifi_data.pwd %s", g_wifi_data.pwd);
 	}
 
-	int64_t auth_type = -1;
-	if (OCRepPayloadGetPropInt(input, THINGS_RSRVD_ES_AUTHTYPE, &auth_type)) {
-		g_wifi_data.authtype = auth_type;
-		THINGS_LOG_D(ES_RH_TAG, "g_wifi_data.authtype %u", g_wifi_data.authtype);
+	int64_t sec_type = -1;
+	if (OCRepPayloadGetPropInt(input, THINGS_RSRVD_ES_SECTYPE, &sec_type)) {
+		g_wifi_data.sectype = sec_type;
+		THINGS_LOG_D(ES_RH_TAG, "g_wifi_data.sectype %u", g_wifi_data.sectype);
 	}
 
 	int64_t enc_type = -1;
@@ -520,7 +520,7 @@ void update_wifi_resource(OCRepPayload *input)
 		THINGS_LOG_D(ES_RH_TAG, "g_wifi_data.discovery_channel %u", g_wifi_data.discovery_channel);
 	}
 
-	if (ssid || cred || auth_type != -1 || enc_type != -1) {
+	if (ssid || cred || sec_type != -1 || enc_type != -1) {
 		THINGS_LOG_V(ES_RH_TAG, "Send WiFiRsrc Callback To ES");
 		PROFILING_TIME("WiFi Provisioning Start.");
 
@@ -775,7 +775,7 @@ OCRepPayload *construct_response_of_wifi(const char *interface)
 	OCRepPayloadSetPropInt(payload, THINGS_RSRVD_ES_SUPPORTEDWIFIFREQ, g_wifi_resource.supported_freq);
 	OCRepPayloadSetPropString(payload, THINGS_RSRVD_ES_SSID, g_wifi_resource.ssid);
 	OCRepPayloadSetPropString(payload, THINGS_RSRVD_ES_CRED, g_wifi_resource.cred);
-	OCRepPayloadSetPropInt(payload, THINGS_RSRVD_ES_AUTHTYPE, (int)g_wifi_resource.auth_type);
+	OCRepPayloadSetPropInt(payload, THINGS_RSRVD_ES_SECTYPE, (int)g_wifi_resource.sec_type);
 	OCRepPayloadSetPropInt(payload, THINGS_RSRVD_ES_ENCTYPE, (int)g_wifi_resource.enc_type);
 	OCRepPayloadSetPropInt(payload, THINGS_RSRVD_ES_VENDOR_DISCOVERYCHANNEL, (int)g_wifi_resource.discovery_channel);
 

--- a/framework/src/st_things/things_stack/easy-setup/resource_handler.h
+++ b/framework/src/st_things/things_stack/easy-setup/resource_handler.h
@@ -51,7 +51,7 @@ typedef struct {
 	wifi_freq_e supported_freq;
 	char ssid[WIFIMGR_SSID_LEN+1];		// target network name, i.e. SSID for WLAN, MAC address for BT.
 	char cred[WIFIMGR_PASSPHRASE_LEN+1];		// credential information.
-	wifi_auth_type_e auth_type;
+	wifi_sec_type_e sec_type;
 	wifi_enc_type_e enc_type;
 	int discovery_channel;
 } wifi_resource_s;

--- a/framework/src/st_things/things_stack/framework/things_req_handler.c
+++ b/framework/src/st_things/things_stack/framework/things_req_handler.c
@@ -213,10 +213,14 @@ static OCEntityHandlerResult convert_ap_infor(things_resource_s *target_resource
 		THINGS_LOG_V(TAG, "e_ssid : %s", wifi_scan_iter->e_ssid);
 		THINGS_LOG_V(TAG, "signal_level : %s", wifi_scan_iter->signal_level);
 		THINGS_LOG_V(TAG, "bss_id : %s", wifi_scan_iter->bss_id);
+		THINGS_LOG_V(TAG, "sec_type : %s", wifi_scan_iter->auth_type);
+		THINGS_LOG_V(TAG, "enc_type : %s", wifi_scan_iter->enc_type);
 		child_rep[iter] = things_create_representation_inst(NULL);
 		child_rep[iter]->things_set_value(child_rep[iter], SEC_ATTRIBUTE_AP_MACADDR, wifi_scan_iter->bss_id);
 		child_rep[iter]->things_set_value(child_rep[iter], SEC_ATTRIBUTE_AP_RSSI, wifi_scan_iter->signal_level);
 		child_rep[iter]->things_set_value(child_rep[iter], SEC_ATTRIBUTE_AP_SSID, wifi_scan_iter->e_ssid);
+		child_rep[iter]->things_set_value(child_rep[iter], SEC_ATTRIBUTE_AP_SECTYPE, wifi_scan_iter->auth_type);
+		child_rep[iter]->things_set_value(child_rep[iter], SEC_ATTRIBUTE_AP_ENCTYPE, wifi_scan_iter->enc_type);
 		wifi_scan_iter = wifi_scan_iter->next;
 	}
 	rep->things_set_arrayvalue(rep, SEC_ATTRIBUTE_AP_ITEMS, list_cnt, child_rep);

--- a/framework/src/st_things/things_stack/framework/things_req_handler.c
+++ b/framework/src/st_things/things_stack/framework/things_req_handler.c
@@ -213,13 +213,13 @@ static OCEntityHandlerResult convert_ap_infor(things_resource_s *target_resource
 		THINGS_LOG_V(TAG, "e_ssid : %s", wifi_scan_iter->e_ssid);
 		THINGS_LOG_V(TAG, "signal_level : %s", wifi_scan_iter->signal_level);
 		THINGS_LOG_V(TAG, "bss_id : %s", wifi_scan_iter->bss_id);
-		THINGS_LOG_V(TAG, "sec_type : %s", wifi_scan_iter->auth_type);
+		THINGS_LOG_V(TAG, "sec_type : %s", wifi_scan_iter->sec_type);
 		THINGS_LOG_V(TAG, "enc_type : %s", wifi_scan_iter->enc_type);
 		child_rep[iter] = things_create_representation_inst(NULL);
 		child_rep[iter]->things_set_value(child_rep[iter], SEC_ATTRIBUTE_AP_MACADDR, wifi_scan_iter->bss_id);
 		child_rep[iter]->things_set_value(child_rep[iter], SEC_ATTRIBUTE_AP_RSSI, wifi_scan_iter->signal_level);
 		child_rep[iter]->things_set_value(child_rep[iter], SEC_ATTRIBUTE_AP_SSID, wifi_scan_iter->e_ssid);
-		child_rep[iter]->things_set_value(child_rep[iter], SEC_ATTRIBUTE_AP_SECTYPE, wifi_scan_iter->auth_type);
+		child_rep[iter]->things_set_value(child_rep[iter], SEC_ATTRIBUTE_AP_SECTYPE, wifi_scan_iter->sec_type);
 		child_rep[iter]->things_set_value(child_rep[iter], SEC_ATTRIBUTE_AP_ENCTYPE, wifi_scan_iter->enc_type);
 		wifi_scan_iter = wifi_scan_iter->next;
 	}

--- a/framework/src/st_things/things_stack/things_def.h
+++ b/framework/src/st_things/things_stack/things_def.h
@@ -63,6 +63,7 @@
 #define SEC_TYPE_WEP                    "WEP"
 #define SEC_TYPE_WPA_PSK                "WPA-PSK"
 #define SEC_TYPE_WPA2_PSK               "WPA2-PSK"
+#define SEC_TYPE_NONE                   "NONE"
 
 /* EncType value */
 #define ENC_TYPE_WEP_64                 "WEP-64"
@@ -70,6 +71,7 @@
 #define ENC_TYPE_TKIP                   "TKIP"
 #define ENC_TYPE_AES                    "AES"
 #define ENC_TYPE_TKIP_AES               "TKIP_AES"
+#define ENC_TYPE_NONE                   "NONE"
 
 #define DEVICE_OS_VERSION               "1.1"
 #define DEVICE_PLATFORM_VERSION         "1.1"

--- a/framework/src/st_things/things_stack/things_def.h
+++ b/framework/src/st_things/things_stack/things_def.h
@@ -50,13 +50,26 @@
 #define SEC_ATTRIBUTE_AP_MACADDR            "x.com.samsung.macAddress"
 #define SEC_ATTRIBUTE_AP_RSSI               "x.com.samsung.rssi"
 #define SEC_ATTRIBUTE_AP_SSID               "x.com.samsung.ssid"
-
+#define SEC_ATTRIBUTE_AP_SECTYPE            "x.com.samsung.securityType"
+#define SEC_ATTRIBUTE_AP_ENCTYPE            "x.com.samsung.encryptionType"
 /* Resource URI */
 #define URI_SEC                         "/sec"
 #define URI_PROVINFO                    "/provisioninginfo"
 #define URI_DEVICE_COL                  "/device"
 #define URI_FIRMWARE                    "/firmware"
 #define URI_ACCESSPOINTLIST             "/accesspointlist"
+
+/* SecType value */
+#define SEC_TYPE_WEP                    "WEP"
+#define SEC_TYPE_WPA_PSK                "WPA-PSK"
+#define SEC_TYPE_WPA2_PSK               "WPA2-PSK"
+
+/* EncType value */
+#define ENC_TYPE_WEP_64                 "WEP-64"
+#define ENC_TYPE_WEP_128                "WEP-128"
+#define ENC_TYPE_TKIP                   "TKIP"
+#define ENC_TYPE_AES                    "AES"
+#define ENC_TYPE_TKIP_AES               "TKIP_AES"
 
 #define DEVICE_OS_VERSION               "1.1"
 #define DEVICE_PLATFORM_VERSION         "1.1"

--- a/framework/src/st_things/things_stack/things_types.h
+++ b/framework/src/st_things/things_stack/things_types.h
@@ -39,7 +39,7 @@
 #define MAX_RT_CNT            10
 
 #define MAX_LEVEL_SIGNAL      12
-#define MAX_TYPE_AUTH         16
+#define MAX_TYPE_SEC          16
 #define MAX_TYPE_ENC          16
 #define MAX_CHANNEL           8
 
@@ -254,7 +254,7 @@ typedef enum {
 typedef struct access_point_info_s {
 	char e_ssid[WIFIMGR_SSID_LEN + 1];		// mandatory
 	char security_key[WIFIMGR_PASSPHRASE_LEN + 1];	// mandatory
-	char auth_type[MAX_TYPE_AUTH +1];	// mandatory (None | WEP | WPA-PSK | WPA2-PSK)
+	char sec_type[MAX_TYPE_SEC +1];	// mandatory (None | WEP | WPA-PSK | WPA2-PSK)
 	char enc_type[MAX_TYPE_ENC +1];	// mandatory (WEP-64 | WEP-128 | TKIP | AES | TKIP_AES)
 	char channel[MAX_CHANNEL];	// optional
 	char signal_level[MAX_LEVEL_SIGNAL];	// optional

--- a/framework/src/st_things/things_stack/things_types.h
+++ b/framework/src/st_things/things_stack/things_types.h
@@ -66,11 +66,11 @@ typedef enum {
 } wifi_freq_e;
 
 typedef enum {
-	NONE_AUTH = 0,
+	NONE_SEC = 0,
 	WEP,
 	WPA_PSK,
 	WPA2_PSK
-} wifi_auth_type_e;
+} wifi_sec_type_e;
 
 typedef enum {
 	NONE_ENC = 0,
@@ -84,7 +84,7 @@ typedef enum {
 typedef struct {
 	char ssid[WIFIMGR_SSID_LEN + 1];	/**< ssid of the Enroller**/
 	char pwd[WIFIMGR_PASSPHRASE_LEN + 1]; /**< pwd of the Enroller**/
-	wifi_auth_type_e authtype;	/**< auth type of the Enroller**/
+	wifi_sec_type_e sectype;	/**< security type of the Enroller**/
 	wifi_enc_type_e enctype; /**< encryption type of the Enroller**/
 	int discovery_channel;		// samsung specific property
 } es_wifi_prov_data_s;

--- a/framework/src/st_things/things_stack/things_types.h
+++ b/framework/src/st_things/things_stack/things_types.h
@@ -254,8 +254,8 @@ typedef enum {
 typedef struct access_point_info_s {
 	char e_ssid[WIFIMGR_SSID_LEN + 1];		// mandatory
 	char security_key[WIFIMGR_PASSPHRASE_LEN + 1];	// mandatory
-	char auth_type[MAX_TYPE_AUTH];	// mandatory (None | WEP | WPA-PSK | WPA2-PSK)
-	char enc_type[MAX_TYPE_ENC];	// mandatory (WEP-64 | WEP-128 | TKIP | AES | TKIP_AES)
+	char auth_type[MAX_TYPE_AUTH +1];	// mandatory (None | WEP | WPA-PSK | WPA2-PSK)
+	char enc_type[MAX_TYPE_ENC +1];	// mandatory (WEP-64 | WEP-128 | TKIP | AES | TKIP_AES)
 	char channel[MAX_CHANNEL];	// optional
 	char signal_level[MAX_LEVEL_SIGNAL];	// optional
 	char bss_id[WIFIMGR_MACADDR_STR_LEN + 1];		// optional

--- a/framework/src/st_things/things_stack/utils/things_network.c
+++ b/framework/src/st_things/things_stack/utils/things_network.c
@@ -254,7 +254,8 @@ int things_get_ap_list(access_point_info_s** p_info, int* p_count)
 			snprintf(pinfo->e_ssid, WIFIMGR_SSID_LEN, "%s", wifi_scan_iter->e_ssid);
 			snprintf(pinfo->bss_id, WIFIMGR_MACADDR_STR_LEN, "%s", wifi_scan_iter->bss_id);
 			snprintf(pinfo->signal_level, MAX_LEVEL_SIGNAL, "%d", wifi_scan_iter->signal_level);
-
+			snprintf(pinfo->auth_type, MAX_TYPE_AUTH, "%s", wifi_scan_iter->auth_type);
+			snprintf(pinfo->enc_type, MAX_TYPE_ENC, "%s", wifi_scan_iter->enc_type);
 			if (*p_info == NULL) {
 				*p_info = pinfo;
 			} else {
@@ -380,12 +381,41 @@ void things_wifi_scan_done(wifi_manager_scan_info_s **scan_result, int res)
 	access_point_info_s *pinfo = NULL;
 	access_point_info_s *p_last_info = NULL;
 	while (wifi_scan_iter != NULL) {
-		if (wifi_scan_iter->ssid != NULL) {
+		if ((wifi_scan_iter->ssid != NULL) && (strlen(wifi_scan_iter->ssid)) != 0) {
 			pinfo = (access_point_info_s*)things_malloc(sizeof(access_point_info_s));
 			pinfo->next = NULL;
 			snprintf(pinfo->e_ssid, WIFIMGR_SSID_LEN, "%s", wifi_scan_iter->ssid);
 			snprintf(pinfo->bss_id, WIFIMGR_MACADDR_STR_LEN, "%s", wifi_scan_iter->bssid);
 			snprintf(pinfo->signal_level, MAX_LEVEL_SIGNAL, "%d", wifi_scan_iter->rssi);
+			// Set auth type
+			const char *sec_type;
+			if (wifi_scan_iter->ap_auth_type == WIFI_MANAGER_AUTH_WEP_SHARED) {
+				sec_type = SEC_TYPE_WEP;
+			} else if (wifi_scan_iter->ap_auth_type == WIFI_MANAGER_AUTH_WPA_PSK) {
+				sec_type = SEC_TYPE_WPA_PSK;
+			} else if (wifi_scan_iter->ap_auth_type == WIFI_MANAGER_AUTH_WPA2_PSK) {
+				sec_type = SEC_TYPE_WPA2_PSK;
+			} else {
+				sec_type = "NONE";
+			}
+			snprintf(pinfo->auth_type, MAX_TYPE_AUTH, "%s", sec_type);
+
+			// Set encryption type
+			const char *enc_type;
+			if (wifi_scan_iter->ap_crypto_type == WIFI_MANAGER_CRYPTO_WEP_64) {
+				enc_type = ENC_TYPE_WEP_64;
+			} else if (wifi_scan_iter->ap_crypto_type == WIFI_MANAGER_CRYPTO_WEP_128) {
+				enc_type = ENC_TYPE_WEP_128;
+			} else if (wifi_scan_iter->ap_crypto_type == WIFI_MANAGER_CRYPTO_TKIP) {
+				enc_type = ENC_TYPE_TKIP;
+			} else if (wifi_scan_iter->ap_crypto_type == WIFI_MANAGER_CRYPTO_AES) {
+				enc_type = ENC_TYPE_AES;
+			} else if (wifi_scan_iter->ap_crypto_type == WIFI_MANAGER_CRYPTO_TKIP_AND_AES) {
+				enc_type = ENC_TYPE_TKIP_AES;
+			} else {
+				enc_type = "NONE";
+			}
+			snprintf(pinfo->enc_type, MAX_TYPE_ENC, "%s", enc_type);
 			if (g_wifi_scan_info == NULL) {
 				g_wifi_scan_info = pinfo;
 			} else {

--- a/framework/src/st_things/things_stack/utils/things_network.c
+++ b/framework/src/st_things/things_stack/utils/things_network.c
@@ -200,23 +200,23 @@ int things_set_ap_connection(access_point_info_s *p_info)
 	THINGS_LOG_V(TAG, "[%s] ssid : %s", __FUNCTION__, connect_config.ssid);
 
 	// set sec type
-	if (strncmp(p_info->sec_type, "WEP", strlen("WEP")) == 0) {
+	if (strncmp(p_info->sec_type, SEC_TYPE_WEP, strlen(SEC_TYPE_WEP)) == 0) {
 		connect_config.ap_auth_type = WIFI_MANAGER_AUTH_WEP_SHARED;
-	} else if (strncmp(p_info->sec_type, "WPA-PSK", strlen("WPA-PSK")) == 0) {
+	} else if (strncmp(p_info->sec_type, SEC_TYPE_WPA_PSK, strlen(SEC_TYPE_WPA_PSK)) == 0) {
 		connect_config.ap_auth_type = WIFI_MANAGER_AUTH_WPA_PSK;
-	} else if (strncmp(p_info->sec_type, "WPA2-PSK", strlen("WPA2-PSK")) == 0) {
+	} else if (strncmp(p_info->sec_type, SEC_TYPE_WPA2_PSK, strlen(SEC_TYPE_WPA2_PSK)) == 0) {
 		connect_config.ap_auth_type = WIFI_MANAGER_AUTH_WPA2_PSK;
 	}
 	// set encryption crypto type
-	if (strncmp(p_info->enc_type, "WEP-64", strlen("WEP-64")) == 0) {
+	if (strncmp(p_info->enc_type, ENC_TYPE_WEP_64, strlen(ENC_TYPE_WEP_64)) == 0) {
 		connect_config.ap_crypto_type = WIFI_MANAGER_CRYPTO_WEP_64;
-	} else if (strncmp(p_info->enc_type, "WEP-128", strlen("WEP-128")) == 0) {
+	} else if (strncmp(p_info->enc_type, ENC_TYPE_WEP_128, strlen(ENC_TYPE_WEP_128)) == 0) {
 		connect_config.ap_crypto_type = WIFI_MANAGER_CRYPTO_WEP_128;
-	} else if (strncmp(p_info->enc_type, "TKIP", strlen("TKIP")) == 0) {
+	} else if (strncmp(p_info->enc_type, ENC_TYPE_TKIP, strlen(ENC_TYPE_TKIP)) == 0) {
 		connect_config.ap_crypto_type = WIFI_MANAGER_CRYPTO_TKIP;
-	} else if (strncmp(p_info->enc_type, "AES", strlen("AES")) == 0) {
+	} else if (strncmp(p_info->enc_type, ENC_TYPE_AES, strlen(ENC_TYPE_AES)) == 0) {
 		connect_config.ap_crypto_type = WIFI_MANAGER_CRYPTO_AES;
-	} else if (strncmp(p_info->enc_type, "TKIP_AES", strlen("TKIP_AES")) == 0) {
+	} else if (strncmp(p_info->enc_type, ENC_TYPE_TKIP_AES, strlen(ENC_TYPE_TKIP_AES)) == 0) {
 		connect_config.ap_crypto_type = WIFI_MANAGER_CRYPTO_TKIP_AND_AES;
 	}
 
@@ -396,7 +396,7 @@ void things_wifi_scan_done(wifi_manager_scan_info_s **scan_result, int res)
 			} else if (wifi_scan_iter->ap_auth_type == WIFI_MANAGER_AUTH_WPA2_PSK) {
 				sec_type = SEC_TYPE_WPA2_PSK;
 			} else {
-				sec_type = "NONE";
+				sec_type = SEC_TYPE_NONE;
 			}
 			snprintf(pinfo->sec_type, MAX_TYPE_SEC, "%s", sec_type);
 
@@ -413,7 +413,7 @@ void things_wifi_scan_done(wifi_manager_scan_info_s **scan_result, int res)
 			} else if (wifi_scan_iter->ap_crypto_type == WIFI_MANAGER_CRYPTO_TKIP_AND_AES) {
 				enc_type = ENC_TYPE_TKIP_AES;
 			} else {
-				enc_type = "NONE";
+				enc_type = ENC_TYPE_NONE;
 			}
 			snprintf(pinfo->enc_type, MAX_TYPE_ENC, "%s", enc_type);
 			if (g_wifi_scan_info == NULL) {

--- a/framework/src/st_things/things_stack/utils/things_network.c
+++ b/framework/src/st_things/things_stack/utils/things_network.c
@@ -199,12 +199,12 @@ int things_set_ap_connection(access_point_info_s *p_info)
 
 	THINGS_LOG_V(TAG, "[%s] ssid : %s", __FUNCTION__, connect_config.ssid);
 
-	// set auth type
-	if (strncmp(p_info->auth_type, "WEP", strlen("WEP")) == 0) {
+	// set sec type
+	if (strncmp(p_info->sec_type, "WEP", strlen("WEP")) == 0) {
 		connect_config.ap_auth_type = WIFI_MANAGER_AUTH_WEP_SHARED;
-	} else if (strncmp(p_info->auth_type, "WPA-PSK", strlen("WPA-PSK")) == 0) {
+	} else if (strncmp(p_info->sec_type, "WPA-PSK", strlen("WPA-PSK")) == 0) {
 		connect_config.ap_auth_type = WIFI_MANAGER_AUTH_WPA_PSK;
-	} else if (strncmp(p_info->auth_type, "WPA2-PSK", strlen("WPA2-PSK")) == 0) {
+	} else if (strncmp(p_info->sec_type, "WPA2-PSK", strlen("WPA2-PSK")) == 0) {
 		connect_config.ap_auth_type = WIFI_MANAGER_AUTH_WPA2_PSK;
 	}
 	// set encryption crypto type
@@ -254,7 +254,7 @@ int things_get_ap_list(access_point_info_s** p_info, int* p_count)
 			snprintf(pinfo->e_ssid, WIFIMGR_SSID_LEN, "%s", wifi_scan_iter->e_ssid);
 			snprintf(pinfo->bss_id, WIFIMGR_MACADDR_STR_LEN, "%s", wifi_scan_iter->bss_id);
 			snprintf(pinfo->signal_level, MAX_LEVEL_SIGNAL, "%d", wifi_scan_iter->signal_level);
-			snprintf(pinfo->auth_type, MAX_TYPE_AUTH, "%s", wifi_scan_iter->auth_type);
+			snprintf(pinfo->sec_type, MAX_TYPE_SEC, "%s", wifi_scan_iter->sec_type);
 			snprintf(pinfo->enc_type, MAX_TYPE_ENC, "%s", wifi_scan_iter->enc_type);
 			if (*p_info == NULL) {
 				*p_info = pinfo;
@@ -398,7 +398,7 @@ void things_wifi_scan_done(wifi_manager_scan_info_s **scan_result, int res)
 			} else {
 				sec_type = "NONE";
 			}
-			snprintf(pinfo->auth_type, MAX_TYPE_AUTH, "%s", sec_type);
+			snprintf(pinfo->sec_type, MAX_TYPE_SEC, "%s", sec_type);
 
 			// Set encryption type
 			const char *enc_type;


### PR DESCRIPTION
1. Add EncType value WEP_SHARED,WPA_PSK,WPA2_PSK
2. Add SecType value WEP-64,WEP-128,TKIP,AES,TKIP_AES

Signed-off-by: harish191 <harish.191@samsung.com>