### PR TITLE
utils/heapinfo : Support multi-heap heapinfo command

### DIFF
--- a/apps/system/utils/kdbg_heapinfo.c
+++ b/apps/system/utils/kdbg_heapinfo.c
@@ -25,9 +25,26 @@
 #ifdef CONFIG_HEAPINFO_USER_GROUP
 #include <stdbool.h>
 #include <tinyara/mm/heapinfo_internal.h>
+extern int max_group;
+extern struct heapinfo_group_s heapinfo_group[HEAPINFO_USER_GROUP_NUM];
 extern struct heapinfo_group_info_s group_info[HEAPINFO_THREAD_NUM];
 static char *ptr = CONFIG_HEAPINFO_USER_GROUP_LIST;
 const static char *end_list = CONFIG_HEAPINFO_USER_GROUP_LIST + sizeof(CONFIG_HEAPINFO_USER_GROUP_LIST) - 1;
+#endif
+
+#define HEAPINFO_DISPLAY_ALL            0
+#define HEAPINFO_DISPLAY_SPECIFIC_HEAP  1
+#define HEAPINFO_DISPLAY_GROUP          2
+#define HEAPINFO_DISPLAY_SUMMARY        3
+#if CONFIG_MM_REGIONS > 1
+#define HEAPINFO_DISPLAY_REGION         4
+extern void *regionx_start[CONFIG_MM_REGIONS];
+extern size_t regionx_size[CONFIG_MM_REGIONS];
+extern int regionx_heap_idx[CONFIG_MM_REGIONS];
+#endif
+
+#if CONFIG_MM_NHEAPS > 1
+extern heapinfo_total_info_t total_info;
 #endif
 
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
@@ -81,20 +98,45 @@ static void kdbg_heapinfo_group_threadlist(void)
 }
 #endif
 
+#if CONFIG_MM_NHEAPS > 1
+static void kdbg_init_total_info(void)
+{
+	total_info.total_heap_size = 0;
+	total_info.cur_free = 0;
+	total_info.largest_free_size = 0;
+	total_info.cur_dead_thread = 0;
+	total_info.sum_of_stacks = 0;
+	total_info.sum_of_heaps = 0;
+}
+#endif
+
 int kdbg_heapinfo(int argc, char **args)
 {
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
 	int option;
-	bool show_group = false;
+	int display_flag = HEAPINFO_DISPLAY_ALL;
 	int mode = HEAPINFO_SIMPLE;
 	int pid = HEAPINFO_PID_ALL;
+#if CONFIG_MM_REGIONS > 1
+	int region_idx;
+#endif
+#if CONFIG_MM_NHEAPS > 1
+	bool summary_option = true;
+	int heap_idx = -1;
+#endif
 
 	if (argc >= 2 && !strncmp(args[1], "--help", strlen("--help") + 1)) {
 		goto usage;
 	}
 
-	struct mm_heap_s *user_heap = mm_get_heap_info(BASE_HEAP);
-	while ((option = getopt(argc, args, "iap:fg")) != ERROR) {
+#if CONFIG_MM_NHEAPS > 1
+	kdbg_init_total_info();
+#endif
+	struct mm_heap_s *user_heap = g_mmheap;
+	while ((option = getopt(argc, args, "iap:fge:r")) != ERROR) {
+#if CONFIG_MM_NHEAPS > 1
+		summary_option = false;
+#endif
 		switch (option) {
 		case 'i':
 			sched_foreach(kdbg_heapinfo_init, NULL);
@@ -103,17 +145,39 @@ int kdbg_heapinfo(int argc, char **args)
 		case 'a':
 			mode = HEAPINFO_DETAIL_ALL;
 			pid = HEAPINFO_PID_ALL;
+			display_flag = HEAPINFO_DISPLAY_ALL;
+#if CONFIG_MM_NHEAPS > 1
+			summary_option = true;
+#endif
 			break;
 		case 'p':
 			mode = HEAPINFO_DETAIL_PID;
 			pid = atoi(optarg);
+			display_flag = HEAPINFO_DISPLAY_ALL;
 			break;
 		case 'f':
 			mode = HEAPINFO_DETAIL_FREE;
 			pid = HEAPINFO_PID_ALL;
+			display_flag = HEAPINFO_DISPLAY_ALL;
 			break;
 		case 'g':
-			show_group = true;
+			display_flag = HEAPINFO_DISPLAY_GROUP;
+			break;
+		case 'e':
+#if CONFIG_MM_NHEAPS > 1
+			mode = HEAPINFO_DETAIL_SPECIFIC_HEAP;
+			heap_idx = atoi(optarg);
+			display_flag = HEAPINFO_DISPLAY_SPECIFIC_HEAP;
+#else
+			goto usage;
+#endif
+			break;
+		case 'r':
+#if CONFIG_MM_REGIONS > 1
+			display_flag = HEAPINFO_DISPLAY_REGION;
+#else
+			goto usage;
+#endif
 			break;
 		case '?':
 		default:
@@ -121,8 +185,78 @@ int kdbg_heapinfo(int argc, char **args)
 			goto usage;
 		}
 	}
+#if CONFIG_MM_REGIONS > 1
+	if (display_flag == HEAPINFO_DISPLAY_REGION) {
+		printf("****************************************************************\n");
+		printf("RAM Region Information (Size in Bytes)\n");
+		printf("****************************************************************\n");
+		printf(" Region # | Start Addr |  End Addr  |  SIZE   | Heap Idx \n");
+		printf("----------------------------------------------------------\n");
+		for (region_idx = 0; region_idx < CONFIG_MM_REGIONS; region_idx++) {
+			printf("    %2d    | 0x%8x | 0x%8x |%8d |    %2d    \n", region_idx, regionx_start[region_idx], regionx_start[region_idx] + regionx_size[region_idx], regionx_size[region_idx], regionx_heap_idx[region_idx]);
+		}
+		return OK;
+	}
+#endif
+
+#if CONFIG_MM_NHEAPS > 1
+	if (display_flag == HEAPINFO_DISPLAY_ALL) {
+		for (heap_idx = 0; heap_idx < CONFIG_MM_NHEAPS; heap_idx++) {
+			if (summary_option == false) {
+				printf("\n\n****************************************************************\n");
+				printf("%c[1;33m", 27);
+				printf("HEAP[%d] has %d Region(s).\n", heap_idx, user_heap[heap_idx].mm_nregions);
+				printf("%c[0m", 27);
+			}
+			heapinfo_parse(&user_heap[heap_idx], mode, pid);
+		}
+	} else if (display_flag == HEAPINFO_DISPLAY_SPECIFIC_HEAP) {
+		if (heap_idx < 0 || heap_idx >= CONFIG_MM_NHEAPS) {
+			goto usage;
+		}
+		printf("****************************************************************\n");
+		printf("HEAP[%d] Allocation Info- (Size in Bytes)\n", heap_idx);
+		heapinfo_parse(&user_heap[heap_idx], mode, HEAPINFO_PID_ALL);
+	} else
+#endif
 	heapinfo_parse(user_heap, mode, pid);
 
+#if CONFIG_MM_NHEAPS > 1
+	if (summary_option == true) {
+		printf("\n****************************************************************\n");
+		printf("%c[1;33m", 27);
+		printf("     Summary of Total Heap Usages (Size in Bytes)\n");
+		printf("%c[0m", 27);
+		printf("****************************************************************\n");
+		/* Print the total heap details. */
+
+		printf("Total                           : %u (100%%)\n", total_info.total_heap_size);
+		printf("  - Allocated (Current / Peak)  : %u (%d%%) / %u (%d%%)\n",\
+			total_info.cur_alloc_size, (size_t)((uint64_t)(total_info.cur_alloc_size) * 100 / total_info.total_heap_size),\
+			total_info.peak_alloc_size,  (size_t)((uint64_t)(total_info.peak_alloc_size) * 100 / total_info.total_heap_size));
+		printf("  - Free (Current)              : %u (%d%%)\n", total_info.cur_free, (size_t)((uint64_t)total_info.cur_free * 100 / total_info.total_heap_size));
+		printf("  - Reserved                    : %u\n", CONFIG_MM_NHEAPS * SIZEOF_MM_ALLOCNODE * 2);
+
+		printf("\n****************************************************************\n");
+		printf("     Details of Total Heap Usages (Size in Bytes)\n");
+		printf("****************************************************************\n");
+		printf("< Free >\n");
+		printf("  - Largest Free Node Size            : %u\n", total_info.largest_free_size);
+		printf("\n< Allocation >\n");
+		printf("  - Current Size (Alive Allocation) = (1) + (2) + (3)\n");
+		printf("     . by Dead Threads (*) (1)        : %u\n", total_info.cur_dead_thread);
+		printf("     . by Alive Threads\n");
+		printf("        - Sum of \"STACK\"(**) (2)      : %u\n", total_info.sum_of_stacks);
+		printf("        - Sum of \"CURR_HEAP\" (3)      : %u\n", total_info.sum_of_heaps);
+
+		printf("** NOTE **\n");
+		printf("(*)  Alive allocation by dead threads might be used by others or might be a leakage.\n");
+		printf("(**) Only Idle task has a separate stack region,\n");
+		printf("  rest are all allocated on the heap region.\n");
+
+		printf("\n** For details, \"heapinfo -a\" or \"heapinfo -e [HEAP_IDX]\"\n");
+	}
+#endif
 	printf("\n< by Alive Threads >\n");
 	printf("%3s | ", "PID");
 #if defined(CONFIG_SCHED_HAVE_PARENT) && !defined(HAVE_GROUP_MEMBERS)
@@ -137,7 +271,7 @@ int kdbg_heapinfo(int argc, char **args)
 	sched_foreach(kdbg_heapinfo_task, NULL);
 
 #ifdef CONFIG_HEAPINFO_USER_GROUP
-	if (show_group == true) {
+	if (display_flag == HEAPINFO_DISPLAY_GROUP) {
 		int group_idx;
 		printf("****************************************************************\n");
 		printf("Heap Allocation Information per User defined Group\n");
@@ -145,13 +279,13 @@ int kdbg_heapinfo(int argc, char **args)
 		printf(" PEAK | HEAP_ON_PEAK | STACK_ON_PEAK | THREADS_IN_GROUP \n");
 		printf("----------------------------------------------------------------\n");
 
-		for (group_idx = 0; group_idx <= user_heap->max_group; group_idx++) {
-			printf(" %4d | %12d | %13d | ", user_heap->group[group_idx].peak_size, user_heap->group[group_idx].heap_size, user_heap->group[group_idx].stack_size);
+		for (group_idx = 0; group_idx <= max_group; group_idx++) {
+			printf(" %4d | %12d | %13d | ", heapinfo_group[group_idx].peak_size, heapinfo_group[group_idx].heap_size, heapinfo_group[group_idx].stack_size);
 			kdbg_heapinfo_group_threadlist();
 		}
 	}
 #else
-	if (show_group == true) {
+	if (display_flag == HEAPINFO_DISPLAY_GROUP) {
 		printf("NOT supported!! Please enable CONFIG_HEAPINFO_USER_GROUP\n");
 	}
 #endif
@@ -167,6 +301,12 @@ usage:
 	printf(" -f           Show the free list \n");
 #ifdef CONFIG_HEAPINFO_USER_GROUP
 	printf(" -g           Show the User defined group allocation details \n");
+#endif
+#if CONFIG_MM_NHEAPS > 1
+	printf(" -e HEAP_IDX  Show the heap[HEAP_IDX] allocation details(HEAP_IDX range : 0 ~ %d)\n", CONFIG_MM_NHEAPS - 1);
+#endif
+#if CONFIG_MM_REGIONS > 1
+	printf(" -r           Show the all region information\n");
 #endif
 #endif
 	return ERROR;

--- a/os/include/tinyara/mm/mm.h
+++ b/os/include/tinyara/mm/mm.h
@@ -202,6 +202,7 @@
 #define HEAPINFO_DETAIL_ALL 2
 #define HEAPINFO_DETAIL_PID 3
 #define HEAPINFO_DETAIL_FREE 4
+#define HEAPINFO_DETAIL_SPECIFIC_HEAP 5
 #define HEAPINFO_PID_ALL -1
 #define HEAPINFO_INIT_INFO 0
 #define HEAPINFO_ADD_INFO 1
@@ -666,6 +667,18 @@ struct mm_heap_s *mm_get_heap_info(void *address);
 
 int mm_get_heapindex(void *mem);
 #if CONFIG_MM_NHEAPS > 1
+struct heapinfo_total_info_s {
+	int total_heap_size;
+	int cur_free;
+	int largest_free_size;
+	int cur_dead_thread;
+	int sum_of_stacks;
+	int sum_of_heaps;
+	int cur_alloc_size;
+	int peak_alloc_size;
+};
+typedef struct heapinfo_total_info_s heapinfo_total_info_t;
+
 void *malloc_at(int heap_index, size_t size);
 void *calloc_at(int heap_index, size_t n, size_t elem_size);
 void *memalign_at(int heap_index, size_t alignment, size_t size);


### PR DESCRIPTION
'-e HEAP_IDX'(HEAP_IDX'th heap information) and '-r'(region information) options are added.
The results are below:
1. -e option
```
TASH>>heapinfo -e 1
****************************************************************
HEAP[1] Allocation Info- (Size in Bytes)
****************************************************************
REGION #0 Start=0x2032800, End=0x20467f0, Size=81920
****************************************************************
  MemAddr |   Size   | Status |    Owner   |  Pid  |
----------|----------|--------|------------|-------|
0x2032800 |       16 |   A    | 0x    dead |   0   |
0x2032810 |       32 |   A    | 0x 40d3570 |   4   |
0x2032830 |     4112 |   A    | 0x 40d3580 |   4   |
0x2033840 |    77744 |   F    |            |       |
** PID(S) in Pid colum means that mem is used for stack of PID

.....
```
2. -r option
```
TASH>>heapinfo -r
****************************************************************
RAM Region Information (Size in Bytes)
****************************************************************
 Region # | Start Addr |  End Addr  |  SIZE   | Heap Idx
----------------------------------------------------------
     0    | 0x 2023800 | 0x 2032800 |   61440 |     0
     1    | 0x 2032800 | 0x 2046800 |   81920 |     1
     2    | 0x 2046800 | 0x 2110000 |  825344 |     0
```