### PR TITLE
apps/examples/st_things: Fix remove object file after make clean.

### DIFF
--- a/apps/examples/st_things/Makefile
+++ b/apps/examples/st_things/Makefile
@@ -28,17 +28,17 @@ THREADEXEC = TASH_EXECMD_SYNC
 
 # SmartThings Things example
 
+ROOTDEPPATH = --dep-path .
 ASRCS =
 CSRCS =
-ifeq ($(CONFIG_EXAMPLES_ST_THINGS_LIGHT),y)
-CSRCS += light/sample_light_things.c light/sample_light_user.c
-endif
-ifeq ($(CONFIG_EXAMPLES_ST_THINGS_BLINK),y)
-CSRCS += blink/sample_blink_things.c blink/sample_blink_user.c blink/iotbus_util.c
-endif
-ifeq ($(CONFIG_EXAMPLES_ST_THINGS_MSG_HANDLING),y)
-CSRCS += msghandling/sample_msghandling_things.c msghandling/sample_msghandling_user.c
-endif
+
+BUILDIRS   := $(dir $(wildcard */Make.defs))
+
+define Add_Application
+  include $(1)Make.defs
+endef
+
+$(foreach BDIR, $(BUILDIRS), $(eval $(call Add_Application,$(BDIR))))
 
 MAINSRC = st_things_sample_main.c
 
@@ -71,8 +71,6 @@ endif
 
 CONFIG_EXAMPLES_ST_THINGS_PROGNAME ?= st_things$(EXEEXT)
 PROGNAME = $(CONFIG_EXAMPLES_ST_THINGS_PROGNAME)
-
-ROOTDEPPATH = --dep-path .
 
 # Common build
 

--- a/apps/examples/st_things/blink/Make.defs
+++ b/apps/examples/st_things/blink/Make.defs
@@ -1,0 +1,24 @@
+###########################################################################
+#
+# Copyright 2018 Samsung Electronics All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+#
+###########################################################################
+
+ifeq ($(CONFIG_EXAMPLES_ST_THINGS_BLINK),y)
+CSRCS += sample_blink_things.c sample_blink_user.c iotbus_util.c
+
+ROOTDEPPATH += --dep-path blink
+VPATH += : blink
+endif

--- a/apps/examples/st_things/light/Make.defs
+++ b/apps/examples/st_things/light/Make.defs
@@ -1,0 +1,24 @@
+###########################################################################
+#
+# Copyright 2018 Samsung Electronics All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+#
+###########################################################################
+
+ifeq ($(CONFIG_EXAMPLES_ST_THINGS_LIGHT),y)
+CSRCS += sample_light_things.c sample_light_user.c
+
+ROOTDEPPATH += --dep-path light
+VPATH += : light
+endif

--- a/apps/examples/st_things/msghandling/Make.defs
+++ b/apps/examples/st_things/msghandling/Make.defs
@@ -1,0 +1,24 @@
+###########################################################################
+#
+# Copyright 2018 Samsung Electronics All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+#
+###########################################################################
+
+ifeq ($(CONFIG_EXAMPLES_ST_THINGS_MSG_HANDLING),y)
+CSRCS += sample_msghandling_things.c sample_msghandling_user.c
+
+ROOTDEPPATH += --dep-path msghandling
+VPATH += : msghandling
+endif


### PR DESCRIPTION
1. Modify the Makefile to remove  generated  object file from
   sub directory after make clean.

2. Add 'Make.defs' file in each folder(light,blink,msghandling) to provide the
   sample application file to the Makefile of st_things example.

Signed-off-by: harish191 <harish.191@samsung.com>