### PR TITLE
mm/realloc: Fix realloc when alloc to another heap and Fix mm_get_hea…

### DIFF
--- a/os/mm/mm_heap/mm_get_heapindex.c
+++ b/os/mm/mm_heap/mm_get_heapindex.c
@@ -37,6 +37,9 @@ extern struct mm_heap_s g_mmheap[CONFIG_MM_NHEAPS];
 int mm_get_heapindex(void *mem)
 {
 	int heap_idx;
+	if (mem == NULL) {
+		return 0;
+	}
 	for (heap_idx = 0; heap_idx < CONFIG_MM_NHEAPS; heap_idx++) {
 		if (mem < (void *)(g_mmheap[heap_idx].mm_heapstart + g_mmheap[heap_idx].mm_heapsize) && mem >= (void *)g_mmheap[heap_idx].mm_heapstart) {
 			return heap_idx;


### PR DESCRIPTION
…pindex

1. When realloc to another heap, we should free the previous mem
2. If mem is NULL in mm_get_heapindex, we cannot find the heapindex. In this case, mm_get_heapindex returns 0(first heap index).