### PR TITLE
framework/st_things: Using IoTivity APIs with Thread-Safety.

### DIFF
--- a/framework/src/st_things/things_stack/Make.defs
+++ b/framework/src/st_things/things_stack/Make.defs
@@ -16,7 +16,7 @@
 #
 ###########################################################################
 
-CSRCS += port_tinyara.c things_stack.c
+CSRCS += port_tinyara.c things_iotivity_lock.c things_stack.c
 
 DEPPATH += --dep-path src/st_things/things_stack
 VPATH += :src/st_things/things_stack

--- a/framework/src/st_things/things_stack/cloud/cloud_connector.c
+++ b/framework/src/st_things/things_stack/cloud/cloud_connector.c
@@ -39,6 +39,7 @@
 #include "logging/things_logger.h"
 #include "easy-setup/es_common.h"
 #include "cloud_connector.h"
+#include "things_iotivity_lock.h"
 #include "utils/things_wait_handler.h"
 #include "framework/things_data_manager.h"
 #include <wifi_manager/wifi_manager.h>
@@ -78,7 +79,7 @@ int CICheckDomain(const char *DomainName, char **pIP)
 			}
 			return 0;
 		}
-	} 
+	}
 
 	THINGS_LOG_E(TAG, " Failed to get the IP");
 
@@ -131,7 +132,7 @@ OCStackResult things_cloud_signup(const char *host, const char *device_id, const
 	OCCallbackData cb_data;
 	OCRepPayload *registerPayload = NULL;
 	OCRepPayload *aafPayload = NULL;
-	char *mnid = NULL;	
+	char *mnid = NULL;
 
 	if (host == NULL || device_id == NULL || event_data == NULL || (event_data->accesstoken[0] == 0 && event_data->auth_code[0] == 0)) {
 		THINGS_LOG_E(TAG, "Invalid event_data.");
@@ -201,8 +202,9 @@ OCStackResult things_cloud_signup(const char *host, const char *device_id, const
 #endif
 
 	if (things_is_empty_request_handle() == true) {
+		iotivity_api_lock();
 		result = OCDoResource(&g_req_handle, OC_REST_POST, targetUri, NULL, (OCPayload *) registerPayload, CT_ADAPTER_TCP, OC_LOW_QOS, &cb_data, NULL, 0);
-
+		iotivity_api_unlock();
 		if (result == OC_STACK_OK && timeoutHandler != NULL) {
 			if (things_add_request_handle(g_req_handle) == NULL) {
 				THINGS_LOG_E(TAG, "[Error] ReqHandles array space is small.");
@@ -264,7 +266,10 @@ OCStackResult things_cloud_session(const char *host, const char *uId, const char
 		goto no_memory;
 	}
 
-	if (OCGetPropertyValue(PAYLOAD_TYPE_DEVICE, OC_RSRVD_SPEC_VERSION, (void **)&coreVer) != OC_STACK_OK || (IoTivityVer = things_strdup(IOTIVITY_VERSION)) == NULL)
+	iotivity_api_lock();
+	OCStackResult getPropRes = OCGetPropertyValue(PAYLOAD_TYPE_DEVICE, OC_RSRVD_SPEC_VERSION, (void **)&coreVer);
+	iotivity_api_unlock();
+	if (getPropRes != OC_STACK_OK || (IoTivityVer = things_strdup(IOTIVITY_VERSION)) == NULL)
 //            OCGetPropertyValue(PAYLOAD_TYPE_PLATFORM, OC_RSRVD_PLATFORM_VERSION, (void**)&IoTivityVer) != OC_STACK_OK )
 	{
 		THINGS_LOG_E(TAG, "Getting Core_Spec_Ver or IoTivity_Ver is failed.");
@@ -288,8 +293,9 @@ OCStackResult things_cloud_session(const char *host, const char *uId, const char
 #endif
 
 	if (things_is_empty_request_handle() == true) {
+		iotivity_api_lock();
 		result = OCDoResource(&g_req_handle, OC_REST_POST, targetUri, NULL, (OCPayload *) loginoutPayload, CT_ADAPTER_TCP, OC_LOW_QOS, &cb_data, NULL, 0);
-
+		iotivity_api_unlock();
 		if (result == OC_STACK_OK && timeoutHandler != NULL) {
 			if (things_add_request_handle(g_req_handle) == NULL) {
 				THINGS_LOG_E(TAG, "[Error] ReqHandles array space is small.");
@@ -359,6 +365,7 @@ OCStackResult things_cloud_rsc_publish(char *host, things_resource_s **list, int
 	}
 
 	uint8_t numResource = 0;
+	iotivity_api_lock();
 	OCGetNumberOfResources(&numResource);
 	if (numResource > 0) {
 		for (uint8_t index = 0; index < numResource; index++) {
@@ -372,13 +379,13 @@ OCStackResult things_cloud_rsc_publish(char *host, things_resource_s **list, int
 			}
 		}
 	}
-
 	if (things_is_empty_request_handle() == true) {
 		result = OCRDPublish(&g_req_handle, host, CT_ADAPTER_TCP, resourceHandles, iter, &cb_data, OC_LOW_QOS);
 
 		if (result == OC_STACK_OK && timeoutHandler != NULL) {
 			if (things_add_request_handle(g_req_handle) == NULL) {
 				THINGS_LOG_E(TAG, "[Error] ReqHandles array space is small.");
+				iotivity_api_unlock();
 				return OC_STACK_ERROR;
 			}
 
@@ -386,6 +393,7 @@ OCStackResult things_cloud_rsc_publish(char *host, things_resource_s **list, int
 		}
 	}
 
+	iotivity_api_unlock();
 	return result;
 }
 
@@ -412,7 +420,9 @@ OCStackResult things_cloud_rsc_publish_with_device_id(char *host, const char *id
 	}
 
 	if (iter > 0) {
+		iotivity_api_lock();
 		result = OCRDPublishWithDeviceId(&g_req_handle, host, id, CT_ADAPTER_TCP, resourceHandles, iter, &cb_data, OC_LOW_QOS);
+		iotivity_api_unlock();
 	}
 //    if(result == OC_STACK_OK && timeoutHandler != NULL )
 //    {
@@ -495,8 +505,9 @@ OCStackResult things_cloud_dev_profile_publish(char *host, OCClientResponseHandl
 	OCRepPayloadSetPropObjectArray(payload, "devices", arrayPayload, dimensions);
 
 	if (things_is_empty_request_handle() == true) {
+		iotivity_api_lock();
 		result = OCDoResource(&g_req_handle, OC_REST_POST, targetUri, NULL, (OCPayload *) payload, CT_ADAPTER_TCP, OC_LOW_QOS, &cb_data, NULL, 0);
-
+		iotivity_api_unlock();
 		if (result == OC_STACK_OK && timeoutHandler != NULL) {
 			if (things_add_request_handle((OCDoHandle) 1) == NULL) {
 				THINGS_LOG_E(TAG, "[Error] ReqHandles array space is small.");
@@ -586,7 +597,10 @@ OCStackResult things_cloud_refresh(const char *host, const char *uId, const char
 	//CASelectCipherSuite(0x35, (1 << 4));
 #endif
 
-	return OCDoResource(NULL, OC_REST_POST, targetUri, NULL, (OCPayload *) refreshPayload, CT_ADAPTER_TCP, OC_LOW_QOS, &cb_data, NULL, 0);
+	iotivity_api_lock();
+	OCStackResult res = OCDoResource(NULL, OC_REST_POST, targetUri, NULL, (OCPayload *) refreshPayload, CT_ADAPTER_TCP, OC_LOW_QOS, &cb_data, NULL, 0);
+	iotivity_api_unlock();
+	return res;
 
 no_memory:
 	OCRepPayloadDestroy(refreshPayload);
@@ -611,7 +625,11 @@ OCStackResult things_cloud_topic_publish_topic(const char *host, const char *top
 #if defined(__WITH_DTLS__) || defined(__WITH_TLS__)
 	//CASelectCipherSuite(0x35, (1 << 4));
 #endif
-	return OCDoResource(NULL, OC_REST_POST, targetUri, NULL, (OCPayload *) message, CT_ADAPTER_TCP, OC_LOW_QOS, &cb_data, NULL, 0);
+
+	iotivity_api_lock();
+	OCStackResult res = OCDoResource(NULL, OC_REST_POST, targetUri, NULL, (OCPayload *) message, CT_ADAPTER_TCP, OC_LOW_QOS, &cb_data, NULL, 0);
+	iotivity_api_unlock();
+	return res;
 
 no_memory:
 	OCRepPayloadDestroy(message);
@@ -638,8 +656,10 @@ static OCRepPayload *make_dev_profile_payload(const st_device_s *dev_info)
 		return NULL;
 	}
 
+	iotivity_api_lock();
 	if (OCGetPropertyValue(PAYLOAD_TYPE_DEVICE, OC_RSRVD_SPEC_VERSION, (void **)&coreVer) != OC_STACK_OK) {
 		THINGS_LOG_E(TAG, "Getting CoreVersion of IoTivity is failed.");
+		iotivity_api_unlock();
 		goto GOTO_OUT;
 	}
 
@@ -647,9 +667,11 @@ static OCRepPayload *make_dev_profile_payload(const st_device_s *dev_info)
 
 	if (OCGetPropertyValue(PAYLOAD_TYPE_PLATFORM, OC_RSRVD_MFG_NAME, (void **)&manuFactory) != OC_STACK_OK) {
 		THINGS_LOG_E(TAG, "Getting manufacturer-name is failed.");
+		iotivity_api_unlock();
 		goto GOTO_OUT;
 	}
 
+	iotivity_api_unlock();
 	OCRepPayloadSetPropString(payload, "di", dev_info->device_id);
 	OCRepPayloadSetPropString(payload, "n", dev_info->name);
 	OCRepPayloadSetPropString(payload, "icv", coreVer);

--- a/framework/src/st_things/things_stack/easy-setup/easysetup_manager.c
+++ b/framework/src/st_things/things_stack/easy-setup/easysetup_manager.c
@@ -34,6 +34,7 @@
 #include "utils/things_wait_handler.h"
 #include "easysetup_manager.h"
 #include "resource_handler.h"
+#include "things_iotivity_lock.h"
 #include "cloud/cloud_manager.h"
 #include "easysetup.h"
 #include "logging/things_logger.h"
@@ -284,7 +285,7 @@ esm_result_e esm_init_easysetup(int restart_flag, things_server_builder_s *serve
 		THINGS_LOG_E(TAG, "[Error] g_server_builder is NULL.");
 		return ESM_ERROR;
 	}
-	
+
 #ifdef __SECURED__
 	bool g_is_secured = true;
 #else
@@ -409,7 +410,11 @@ static void *cloud_refresh_check_loop(void *param)
 	int *i_continue = (int *)param;
 	int hour_cnt_24 = 0;
 
+#ifdef CONFIG_DEBUG_ST_THINGS_DEBUG
+	iotivity_api_lock();
 	THINGS_LOG_D(TAG, "device ID = %s", OCGetServerInstanceIDString());
+	iotivity_api_unlock();
+#endif
 
 	// Close Loop Thread.
 	while (*i_continue) {
@@ -879,7 +884,7 @@ int esm_save_easysetup_state(int state)
 {
 	THINGS_LOG_D(TAG, THINGS_FUNC_ENTRY);
 	if (state == ES_COMPLETE) { // Done
-		THINGS_LOG_D(TAG, "File open : %s", PATH_MNT FILE_ES_STATE);		
+		THINGS_LOG_D(TAG, "File open : %s", PATH_MNT FILE_ES_STATE);
 		FILE *fp = fopen(PATH_MNT FILE_ES_STATE, "w+");
 		if (!fp) {
 			THINGS_LOG_E(TAG, "File open error(%d)", errno);
@@ -904,7 +909,7 @@ int esm_save_easysetup_state(int state)
 
 int esm_read_easysetup_state(void)
 {
-	THINGS_LOG_D(TAG, "File open : %s", PATH_MNT FILE_ES_STATE);	
+	THINGS_LOG_D(TAG, "File open : %s", PATH_MNT FILE_ES_STATE);
 	FILE *fp = fopen(PATH_MNT FILE_ES_STATE, "r");
 	if (!fp) {
 		THINGS_LOG_D(TAG, "File does not exist(%d)", errno);

--- a/framework/src/st_things/things_stack/framework/things_data_manager.c
+++ b/framework/src/st_things/things_stack/framework/things_data_manager.c
@@ -29,6 +29,7 @@
 #include "ocstackconfig.h"
 #include "ocrandom.h"
 #include "things_def.h"
+#include "things_iotivity_lock.h"
 #include "logging/things_logger.h"
 #include "utils/things_malloc.h"
 #include "utils/things_util.h"
@@ -2104,7 +2105,9 @@ bool dm_register_device_id(void)
 		return false;
 	}
 	// Set Main-Device ID
+	iotivity_api_lock();
 	id = OCGetServerInstanceIDString();
+	iotivity_api_unlock();
 	dev_list[0] = dm_get_info_of_dev(0);
 
 	if (id == NULL || dev_list[0] == NULL) {
@@ -2168,6 +2171,7 @@ int dm_register_resource(things_server_builder_s *p_builder)
 
 			p_collection_resource = p_builder->create_collection_resource(p_builder, res_uri, device->collection[0].resource_types[0]);
 
+			iotivity_api_lock();
 			for (int rt_num = 1; rt_num < device->collection[0].rt_cnt; rt_num++) {
 				OCBindResourceTypeToResource(p_builder, device->collection[0].resource_types[rt_num]);
 			}
@@ -2176,6 +2180,7 @@ int dm_register_resource(things_server_builder_s *p_builder)
 			for (int it_num = 1; it_num < device->collection[0].if_cnt; it_num++) {
 				OCBindResourceInterfaceToResource(p_builder, device->collection[0].interface_types[it_num]);
 			}
+			iotivity_api_unlock();
 
 			THINGS_LOG_D(TAG, "AFTER REGISTERGING DEVICE RESOURCE");
 
@@ -2554,7 +2559,7 @@ char *dm_get_access_token()
 }
 
 char *dm_get_uid()
-{ 
+{
 	es_cloud_signup_s *cloud_data = NULL;
 	char *cloud_uid = NULL;
 

--- a/framework/src/st_things/things_stack/framework/things_resource.c
+++ b/framework/src/st_things/things_stack/framework/things_resource.c
@@ -26,6 +26,7 @@
 
 #include "things_def.h"
 #include "things_common.h"
+#include "things_iotivity_lock.h"
 #include "logging/things_logger.h"
 #include "utils/things_malloc.h"
 #include "utils/things_string.h"
@@ -342,13 +343,17 @@ void get_uri(struct things_resource_s *res, char **value)
 int get_num_of_res_types(struct things_resource_s *res)
 {
 	uint8_t num = 0;
+	iotivity_api_lock();
 	OCGetNumberOfResourceTypes((OCResourceHandle) res->resource_handle, &num);
+	iotivity_api_unlock();
 	return (int)num;
 }
 
 const char *get_res_type(struct things_resource_s *res, int index)
 {
+	iotivity_api_lock();
 	const char *resourcType = OCGetResourceTypeName((OCResourceHandle) res->resource_handle, index);
+	iotivity_api_unlock();
 	THINGS_LOG_D(TAG, "=====>  RH : %x cnt : %d", res->resource_handle, index);
 	THINGS_LOG_D(TAG, "=====>  RT : %s ", resourcType);
 
@@ -358,13 +363,17 @@ const char *get_res_type(struct things_resource_s *res, int index)
 int get_num_of_inf_types(struct things_resource_s *res)
 {
 	uint8_t num = 0;
+	iotivity_api_lock();
 	OCGetNumberOfResourceInterfaces((OCResourceHandle) res->resource_handle, &num);
+	iotivity_api_unlock();
 	return (int)num;
 }
 
 const char *get_inf_type(struct things_resource_s *res, int index)
 {
+	iotivity_api_lock();
 	const char *interface_type = OCGetResourceInterfaceName((OCResourceHandle) res->resource_handle, index);
+	iotivity_api_unlock();
 	THINGS_LOG_D(TAG, "=====>  RH : %x cnt : %d", res->resource_handle, index);
 	THINGS_LOG_D(TAG, "=====>  IT : %s ", interface_type);
 
@@ -522,6 +531,7 @@ void /*OCRepPayload */ *create_payload(struct things_resource_s *res, char *quer
 		uint8_t number_of_interfaces = 0;
 		uint8_t number_of_resource_type = 0;
 
+		iotivity_api_lock();
 		OCGetNumberOfResourceInterfaces((OCResourceHandle) res->resource_handle, &number_of_interfaces);
 
 		THINGS_LOG_D(TAG, "@@  IF # : %d ", number_of_interfaces);
@@ -540,6 +550,7 @@ void /*OCRepPayload */ *create_payload(struct things_resource_s *res, char *quer
 			THINGS_LOG_D(TAG, "=====>  RT : %s ", rt);
 			OCRepPayloadAddResourceType(payload, rt);
 		}
+		iotivity_api_unlock();
 	} else if (strstr(query, OC_RSRVD_INTERFACE_BATCH)) {
 		THINGS_LOG_D(TAG, "Batch only supported by Collection Resource");
 	} else if (strstr(query, OC_RSRVD_INTERFACE_LL)) {
@@ -591,6 +602,7 @@ bool is_supporting_interface_type(struct things_resource_s *res, char *query)
 	bool result = false;
 	uint8_t number_of_interfaces = 0;
 
+	iotivity_api_lock();
 	OCGetNumberOfResourceInterfaces((OCResourceHandle) res->resource_handle, &number_of_interfaces);
 
 	THINGS_LOG_D(TAG, "@@  IF # : %d ", number_of_interfaces);
@@ -607,6 +619,8 @@ bool is_supporting_interface_type(struct things_resource_s *res, char *query)
 			}
 		}
 	}
+
+	iotivity_api_unlock();
 	THINGS_LOG_D(TAG, THINGS_FUNC_EXIT);
 	return result;
 }
@@ -617,6 +631,7 @@ bool is_supporting_resource_type(struct things_resource_s *res, char *query)
 	bool result = false;
 	uint8_t number_of_resource_type = 0;
 
+	iotivity_api_lock();
 	OCGetNumberOfResourceTypes((OCResourceHandle) res->resource_handle, &number_of_resource_type);
 
 	THINGS_LOG_D(TAG, "@@  RT # : %d ", number_of_resource_type);
@@ -631,6 +646,8 @@ bool is_supporting_resource_type(struct things_resource_s *res, char *query)
 			break;
 		}
 	}
+
+	iotivity_api_unlock();
 	THINGS_LOG_D(TAG, THINGS_FUNC_EXIT);
 	return result;
 }
@@ -758,7 +775,9 @@ things_resource_s *create_resource_inst_impl(void *requesthd, void *resourcehd, 
 	res->request_handle = requesthd;
 
 	res->uri = NULL;
+	iotivity_api_lock();
 	const char *uri = OCGetResourceUri(resourcehd);
+	iotivity_api_unlock();
 	if (uri != NULL && strlen(uri) > 0) {
 		res->uri = (char *)things_malloc(sizeof(char) * strlen(uri) + 1);
 		memset(res->uri, 0, strlen(uri) + 1);

--- a/framework/src/st_things/things_stack/things_iotivity_lock.c
+++ b/framework/src/st_things/things_stack/things_iotivity_lock.c
@@ -1,0 +1,75 @@
+/****************************************************************************
+ *
+ * Copyright 2018 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+#include "things_iotivity_lock.h"
+#include "logging/things_logger.h"
+
+#define TAG "[things_iotivity_api_lock]"
+
+static pthread_mutex_t g_iotivity_lock;
+static pthread_mutexattr_t g_mutex_attr;
+
+void init_iotivity_api_lock(void)
+{
+	int err = pthread_mutexattr_init(&g_mutex_attr);
+	if (err) {
+		THINGS_LOG_E(TAG, "pthread_mutexattr_init failed with error code (%d).", err);
+		return;
+	}
+
+	err = pthread_mutexattr_settype(&g_mutex_attr, PTHREAD_MUTEX_RECURSIVE);
+	if (err) {
+		THINGS_LOG_E(TAG, "pthread_mutexattr_settype failed with error code (%d).", err);
+		return;
+	}
+
+	err = pthread_mutex_init(&g_iotivity_lock, &g_mutex_attr);
+	if (err) {
+		THINGS_LOG_E(TAG, "pthread_mutex_init failed with error code (%d).", err);
+	}
+}
+
+void iotivity_api_lock(void)
+{
+	int err = pthread_mutex_lock(&g_iotivity_lock);
+	if (err) {
+		THINGS_LOG_E(TAG, "Failed to acquire lock on iotivity APIs. Error code: (%d).", err);
+	}
+}
+
+void iotivity_api_unlock(void)
+{
+	int err = pthread_mutex_unlock(&g_iotivity_lock);
+	if (err) {
+		THINGS_LOG_E(TAG, "Failed to release lock on iotivity APIs. Error code: (%d).", err);
+	}
+}
+
+void deinit_iotivity_api_lock(void)
+{
+	int err = pthread_mutexattr_destroy(&g_mutex_attr);
+	if (err) {
+		THINGS_LOG_E(TAG, "pthread_mutexattr_destroy failed with error code (%d).", err);
+		return;
+	}
+
+	err = pthread_mutex_destroy(&g_iotivity_lock);
+	if (err) {
+		THINGS_LOG_E(TAG, "pthread_mutex_destroy failed with error code (%d).", err);
+	}
+}

--- a/framework/src/st_things/things_stack/things_iotivity_lock.h
+++ b/framework/src/st_things/things_stack/things_iotivity_lock.h
@@ -1,0 +1,40 @@
+/****************************************************************************
+ *
+ * Copyright 2018 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+#ifndef THINGS_IOTIVITY_LOCK_H_
+#define THINGS_IOTIVITY_LOCK_H_
+
+#include <pthread.h>
+
+/* Initializes the mutex variables. Returns 'true' if initialization is successful.
+This function should not be called more than once. */
+void init_iotivity_api_lock(void);
+
+/* Locks the mutex. Returns 'true' if lock is successful.
+This function should be called after init_iotivity_api_lock(). */
+void iotivity_api_lock(void);
+
+/* Unlocks the mutex. Returns 'true' if unlock is successful.
+This function should be called after init_iotivity_api_lock(). */
+void iotivity_api_unlock(void);
+
+/* De-initializes the mutex variables. Returns 'true' if de-initialization is successful.
+This function should be called after init_iotivity_api_lock(). */
+void deinit_iotivity_api_lock(void);
+
+#endif // THINGS_IOTIVITY_LOCK_H_

--- a/framework/src/st_things/things_stack/things_stack.c
+++ b/framework/src/st_things/things_stack/things_stack.c
@@ -34,6 +34,7 @@
 #include "things_api.h"
 #include "things_types.h"
 #include "things_def.h"
+#include "things_iotivity_lock.h"
 #include "things_resource.h"
 
 #include "framework/things_common.h"
@@ -250,6 +251,8 @@ int things_initialize_stack(const char *json_path, bool *easysetup_completed)
 		return 0;
 	}
 
+	init_iotivity_api_lock();
+
 	if (things_network_initialize() != 0) {
 		THINGS_LOG_E(TAG, "ERROR things_network initialize");
 		things_free(abs_json_path);
@@ -290,6 +293,8 @@ int things_deinitialize_stack(void)
 	THINGS_LOG_D(TAG, THINGS_FUNC_ENTRY);
 
 	dm_termiate_module();
+
+	deinit_iotivity_api_lock();
 
 	is_things_module_initialized = 0;
 
@@ -699,7 +704,9 @@ static void *__attribute__((optimize("O0"))) t_things_reset_loop(reset_args_s *a
 	THINGS_LOG_D(TAG, "Disable Notification Module.");
 	things_set_reset_mask(RST_NOTI_MODULE_DISABLE);
 
+	iotivity_api_lock();
 	OCClearObserverlist();		// delete All Observer. (for remote Client)
+	iotivity_api_unlock();
 
 	// 4. Cloud Manager : Terminate
 	THINGS_LOG_D(TAG, "Terminate Cloud Module.");
@@ -719,7 +726,9 @@ static void *__attribute__((optimize("O0"))) t_things_reset_loop(reset_args_s *a
 	}
 	THINGS_LOG_V(TAG, "Reset done: cloud provisioning data");
 
+	iotivity_api_lock();
 	OCClearCallBackList();		// delete All Client Call-Back List. (for SET Self-Request)
+	iotivity_api_unlock();
 
 	// 7. Security Reset.
 #ifdef __SECURED__

--- a/framework/src/st_things/things_stack/utils/things_ping.c
+++ b/framework/src/st_things/things_stack/utils/things_ping.c
@@ -807,7 +807,10 @@ static int find_resource_oic_ping(things_ping_s *ping)
 	set_mask(ping, PING_ST_DISCOVERY);
 
 	THINGS_LOG_D(TAG, "Send OCFindKeepAliveResouce request to %s.", hostAddr);
-	if (OCFindKeepAliveResource(&g_req_handle, hostAddr, &cb) == OC_STACK_OK) {
+	iotivity_api_lock();
+	OCStackResult res = OCFindKeepAliveResource(&g_req_handle, hostAddr, &cb);
+	iotivity_api_unlock();
+	if (res == OC_STACK_OK) {
 		THINGS_LOG_D(TAG, "Waiting for /oic/ping Cloud-response.(%s)", ping->addr);
 		sleepTime = 5;
 	} else {
@@ -880,7 +883,10 @@ static int send_things_ping_request(things_ping_s *ping)
 	THINGS_LOG_D(TAG, "interval = %lld", interval);
 
 	THINGS_LOG_D(TAG, "Send OCSendKeepAliveRequest request to %s.", hostAddr);
-	if ((result = OCSendKeepAliveRequest(&g_req_handle, hostAddr, payload, &cb)) == OC_STACK_OK)
+	iotivity_api_lock();
+	result = OCSendKeepAliveRequest(&g_req_handle, hostAddr, payload, &cb);
+	iotivity_api_unlock();
+	if (result == OC_STACK_OK)
 	//if( (result= SendKeepAliveRequest(hostAddr, interval, &cb)) == OC_STACK_OK )
 	{
 		THINGS_LOG_V(TAG, "\e[35mSending Success about common-Ping request.\e[m");


### PR DESCRIPTION
Used mutex (recursive) to synchronize the usage of IoTivity APIs.

**IoTivity Path:** external/iotivity
**IoTivity CSDK API Path:** external\iotivity\iotivity_1.2-rel\resource\csdk\stack\include\ocstack.h

IoTivity CSDK (C API) is not thread-safe. As per its design, it doesn't allow multiple threads to call its functions at the same time. User of the APIs is required to maintain a single lock for all IoTivity API calls to protect the functions from thread synchronization issues.

**Reference:** 
IoTivity CPP SDK (C++ API) maintains a single lock for calling IoTivity CSDK APIs.
It's path: external\iotivity\iotivity_1.2-rel\resource\src\InProcServerWrapper.cpp

Signed-off-by: Senthil Kumar G S <senthil.gs@samsung.com>