### PR TITLE
examples/slsiwifi: Fix build error for new heap

### DIFF
--- a/apps/examples/slsiwifi/slsiwifi_main.c
+++ b/apps/examples/slsiwifi/slsiwifi_main.c
@@ -104,7 +104,7 @@ static struct mm_heap_s *g_user_heap;
 int g_memstat_total = 0;
 static int getMemUsage(void)
 {
-	g_user_heap = mm_get_heap_info();
+	g_user_heap = mm_get_heap_info(GET_BASE_HEAP_ADDR);
 	printf("\n\tCurrent memory usage (total): %d bytes\n", g_user_heap->total_alloc_size);
 	return g_user_heap->total_alloc_size;
 }
@@ -118,7 +118,7 @@ int getMemLeaks(void)
 		// situations where the the blocks are freed while
 		// exiting
 		//print heapinfo
-		heapinfo_parse(mm_get_heap_info(), HEAPINFO_TRACE);
+		heapinfo_parse(mm_get_heap_info(GET_BASE_HEAP_ADDR), HEAPINFO_DETAIL_ALL, HEAPINFO_PID_ALL);
 		printf(" ______________________________________________________________ \n");
 		printf("|                                                              |\n");
 		printf("| WARNING: %6.6d bytes leaked during this run                 |\n", result);

--- a/os/include/tinyara/mm/mm.h
+++ b/os/include/tinyara/mm/mm.h
@@ -207,6 +207,8 @@
 #define HEAPINFO_ADD_INFO 1
 #define HEAPINFO_DEL_INFO 2
 
+#define GET_BASE_HEAP_ADDR NULL
+
 #define REGION_START (size_t)regionx_start[0]
 #define REGION_SIZE  regionx_size[0]
 #define REGION_END (REGION_START + REGION_SIZE)
@@ -661,7 +663,9 @@ void heapinfo_check_group_list(pid_t pid, char *name);
 #endif
 void mm_is_sem_available(void *address);
 
-/* Functions to get heap information */
+/* Functions to get heap information.
+ * If address is GET_BASE_HEAP_ADDR, BASE_HEAP address will be returned.
+ */
 struct mm_heap_s *mm_get_heap_info(void *address);
 
 int mm_get_heapindex(void *mem);


### PR DESCRIPTION
mm_get_heap_info() was changed to pass the memory address for checking heap index
heapinfo_parse() was changed to pass 3-params