### PR TITLE
framework/st_things: Enable network monitor by default

### DIFF
--- a/build/configs/artik053/st_things/defconfig
+++ b/build/configs/artik053/st_things/defconfig
@@ -821,6 +821,7 @@ CONFIG_WIFIMGR_STA_IFNAME="wl1"
 # Network utilities
 #
 CONFIG_NETUTILS_NETLIB=y
+CONFIG_NET_NETMON=y
 
 #
 # Audio Support


### PR DESCRIPTION
- Add CONFIG_NET_NETMON=y into defconfig for st_things configuration