### PR TITLE
apps/examples/ftpc/ftpc_cmds.c Typo codingrule

### DIFF
--- a/apps/examples/ftpc/ftpc_cmds.c
+++ b/apps/examples/ftpc/ftpc_cmds.c
@@ -103,7 +103,7 @@ int cmd_rquit(SESSION handle, int argc, char **argv)
 		printf("quit failed: %d\n", errno);
 		return ERROR;
 	}
-	printf("Exitting...\n");
+	printf("Exiting...\n");
 	return OK;
 }
 

--- a/apps/examples/kernel_sample/kernel_sample_main.c
+++ b/apps/examples/kernel_sample/kernel_sample_main.c
@@ -488,7 +488,7 @@ static int user_main(int argc, char *argv[])
 #endif
 	}
 
-	printf("user_main: Exitting\n");
+	printf("user_main: Exiting\n");
 	return 0;
 }
 

--- a/apps/examples/sensorbd_demo/examples/i2c_tcs34725.c
+++ b/apps/examples/sensorbd_demo/examples/i2c_tcs34725.c
@@ -178,7 +178,7 @@ static void tcs34725_initialize(void)
 
 	tcs34725_read(TCS34725_ID, &reg, 1);
 	if ((reg != 0x44) && (reg != 0x10)) {
-		printf("Bad devie id(0x%02x)\n", reg);
+		printf("Bad device id(0x%02x)\n", reg);
 		return;
 	}
 	printf("Successfully read device id(0x%02x)\n", reg);

--- a/apps/examples/telnetd/telnetd.c
+++ b/apps/examples/telnetd/telnetd.c
@@ -295,7 +295,7 @@ int telnetd_main(int argc, char *argv[])
 	printf("telnetd_main: Starting the Telnet daemon\n");
 	ret = telnetd_start(&config);
 	if (ret < 0) {
-		printf("Failed to tart the Telnet daemon\n");
+		printf("Failed to start the Telnet daemon\n");
 	}
 
 	printf("telnetd_main: Exiting\n");


### PR DESCRIPTION
apps/examples/ftpc/ftpc_cmds.c

106 line Exitting -> Exiting

apps/examples/kernel_sample/kernel_sample_main.c

491 line Exitting -> Exiting
