### PR TITLE
external/iotivity: Force delete libcoap.a from external/libcoap for 'make clean'.

### DIFF
--- a/external/iotivity/iotivity_1.2-rel/extlibs/libcoap/SConscript
+++ b/external/iotivity/iotivity_1.2-rel/extlibs/libcoap/SConscript
@@ -53,7 +53,7 @@ libcoap_checkout_command = 'git clone ' + libcoap_repo_url + '.git extlibs/libco
 if GetOption('clean'):
     lib_path = os.path.join(src_dir, 'extlibs', 'libcoap', 'libcoap.a')
     if os.path.exists(lib_path):
-        result = os.system('rm %s' %lib_path)
+        result = os.system('rm -f %s' %lib_path)
         if result != 0:
             print 'Failed to remove the libcoap library in extlibs/libcoap'
     Return('libcoap_env')


### PR DESCRIPTION
The 'make clean' will show below message and wait the user confirm.
'rm: remove write-protected regular file '*/external/iotivity/iotivity_1.2-rel/extlibs/libcoap/libcoap.a'?'

But it doesn't need and it will not be showing when user uses './dbulid.sh menu' to clean.
So the rm command is able to use '-f' option.