### PR TITLE
mm/mm_heap: Add mm_get_heap_info_with_index and Move mm_get_heap_info…

### DIFF
--- a/apps/examples/slsiwifi/slsiwifi_main.c
+++ b/apps/examples/slsiwifi/slsiwifi_main.c
@@ -57,6 +57,7 @@ sem_t g_sem_result;
 sem_t g_sem_join;
 static uint8_t g_join_result = 0;
 #define  WPA_MAX_SSID_LEN (4*32+1)	/* SSID encoded in a string - worst case is all 4-octet hex digits + '\0' */
+#define  BASE_HEAP_INDEX 0
 
 /****************************************************************************
  * Defines
@@ -104,7 +105,7 @@ static struct mm_heap_s *g_user_heap;
 int g_memstat_total = 0;
 static int getMemUsage(void)
 {
-	g_user_heap = mm_get_heap_info();
+	g_user_heap = mm_get_heap_with_index(BASE_HEAP_INDEX);
 	printf("\n\tCurrent memory usage (total): %d bytes\n", g_user_heap->total_alloc_size);
 	return g_user_heap->total_alloc_size;
 }
@@ -118,7 +119,7 @@ int getMemLeaks(void)
 		// situations where the the blocks are freed while
 		// exiting
 		//print heapinfo
-		heapinfo_parse(mm_get_heap_info(), HEAPINFO_TRACE);
+		heapinfo_parse(mm_get_heap_with_index(BASE_HEAP_INDEX), HEAPINFO_DETAIL_ALL, HEAPINFO_PID_ALL);
 		printf(" ______________________________________________________________ \n");
 		printf("|                                                              |\n");
 		printf("| WARNING: %6.6d bytes leaked during this run                 |\n", result);

--- a/os/include/tinyara/mm/mm.h
+++ b/os/include/tinyara/mm/mm.h
@@ -662,8 +662,9 @@ void heapinfo_check_group_list(pid_t pid, char *name);
 #endif
 void mm_is_sem_available(void *address);
 
-/* Functions to get heap information */
-struct mm_heap_s *mm_get_heap_info(void *address);
+/* Functions to get the address of heap structure */
+struct mm_heap_s *mm_get_heap(void *address);
+struct mm_heap_s *mm_get_heap_with_index(int index);
 
 int mm_get_heapindex(void *mem);
 #if CONFIG_MM_NHEAPS > 1

--- a/os/kernel/sched/sched_garbage.c
+++ b/os/kernel/sched/sched_garbage.c
@@ -112,7 +112,7 @@ static inline void sched_kucleanup(void)
 		if (!address) {
 			return;
 		}
-		heap = mm_get_heap_info(address);
+		heap = mm_get_heap(address);
 		if (heap && heap->mm_semaphore.semcount <= 0) {
 			continue;
 		}

--- a/os/mm/mm_heap/Make.defs
+++ b/os/mm/mm_heap/Make.defs
@@ -55,7 +55,7 @@
 CSRCS += mm_initialize.c mm_sem.c mm_addfreechunk.c mm_size2ndx.c
 CSRCS += mm_shrinkchunk.c
 CSRCS += mm_brkaddr.c mm_calloc.c mm_extend.c mm_free.c mm_mallinfo.c
-CSRCS += mm_malloc.c mm_memalign.c mm_realloc.c mm_zalloc.c mm_heap_regioninfo.c mm_get_heapindex.c
+CSRCS += mm_malloc.c mm_memalign.c mm_realloc.c mm_zalloc.c mm_heap_regioninfo.c mm_getheap.c
 
 ifeq ($(CONFIG_BUILD_KERNEL),y)
 CSRCS += mm_sbrk.c

--- a/os/mm/mm_heap/mm_getheap.c
+++ b/os/mm/mm_heap/mm_getheap.c
@@ -20,6 +20,7 @@
  ****************************************************************************/
 
 #include <tinyara/config.h>
+#include <debug.h>
 #include <tinyara/mm/mm.h>
 
 extern struct mm_heap_s g_mmheap[CONFIG_MM_NHEAPS];
@@ -30,6 +31,45 @@ extern struct mm_heap_s g_mmheap[CONFIG_MM_NHEAPS];
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
+/****************************************************************************
+ * Name: mm_get_heap
+ *
+ * Description:
+ *   returns a heap which type is matched with ttype
+ *
+ ****************************************************************************/
+struct mm_heap_s *mm_get_heap(void *address)
+{
+	int heap_idx;
+#ifdef CONFIG_MM_KERNEL_HEAP
+	struct tcb_s *tcb;
+
+	tcb = sched_gettcb(getpid());
+	if (tcb->flags & TCB_FLAG_TTYPE_MASK == TCB_FLAG_TTYPE_KERNEL) {
+		return &g_kmmheap;
+	} else
+#endif
+	{
+		heap_idx = mm_get_heapindex(address);
+		if (heap_idx == INVALID_HEAP_IDX) {
+			mdbg("address is not in heap region.\n");
+			return NULL;
+		}
+		return &g_mmheap[heap_idx];
+	}
+
+}
+/****************************************************************************
+ * Name: mm_get_heap_with_index
+ ****************************************************************************/
+struct mm_heap_s *mm_get_heap_with_index(int index)
+{
+	if (index >= CONFIG_MM_NHEAPS) {
+		mdbg("heap index is out of range.\n");
+		return NULL;
+	}
+	return &g_mmheap[index];
+}
 
 /****************************************************************************
  * Name: mm_get_heapindex

--- a/os/mm/mm_heap/mm_mallinfo.c
+++ b/os/mm/mm_heap/mm_mallinfo.c
@@ -77,34 +77,6 @@
  * Public Functions
  ****************************************************************************/
 /****************************************************************************
- * Name: mm_get_heap_info
- *
- * Description:
- *   returns a heap which type is matched with ttype
- *
- ****************************************************************************/
-struct mm_heap_s *mm_get_heap_info(void *address)
-{
-	int heap_idx;
-#ifdef CONFIG_MM_KERNEL_HEAP
-	struct tcb_s *tcb;
-
-	tcb = sched_gettcb(getpid());
-	if (tcb->flags & TCB_FLAG_TTYPE_MASK == TCB_FLAG_TTYPE_KERNEL) {
-		return &g_kmmheap;
-	} else
-#endif
-	{
-		heap_idx = mm_get_heapindex(address);
-		if (heap_idx == INVALID_HEAP_IDX) {
-			mdbg("address is not in heap region.\n");
-			return NULL;
-		}
-		return &g_mmheap[heap_idx];
-	}
-
-}
-/****************************************************************************
  * Name: mm_mallinfo
  *
  * Description:

--- a/os/mm/mm_heap/mm_sem.c
+++ b/os/mm/mm_heap/mm_sem.c
@@ -238,7 +238,7 @@ void mm_is_sem_available(void *address)
 {
 	struct mm_heap_s *heap;
 
-	heap = mm_get_heap_info(address);
+	heap = mm_get_heap(address);
 
 	mm_takesemaphore(heap);
 	mm_givesemaphore(heap);

--- a/os/mm/umm_heap/umm_sem.c
+++ b/os/mm/umm_heap/umm_sem.c
@@ -98,7 +98,7 @@
 int umm_trysemaphore(void *address)
 {
 	struct mm_heap_s *heap;
-	heap = mm_get_heap_info(address);
+	heap = mm_get_heap(address);
 	return mm_trysemaphore(heap);
 }
 
@@ -121,7 +121,7 @@ int umm_trysemaphore(void *address)
 void umm_givesemaphore(void *address)
 {
 	struct mm_heap_s *heap;
-	heap = mm_get_heap_info(address);
+	heap = mm_get_heap(address);
 	mm_givesemaphore(heap);
 }
 


### PR DESCRIPTION
… to mm_get_heap_info.c

1. when getting heap information, user can use allocated address and heap index also.
2. change file name : mm_get_heapindex to mm_get_heap, and integrate funtions related to heap information