### PR TITLE
framework/st_things: Removed unused code in request handler.

### DIFF
--- a/framework/src/st_things/things_stack/framework/things_req_handler.c
+++ b/framework/src/st_things/things_stack/framework/things_req_handler.c
@@ -56,10 +56,7 @@ static handle_request_func_type g_handle_request_set_cb = NULL;
 
 extern things_server_builder_s *g_builder;
 
-static int g_handle_res_cnt = 0;
-static char **g_handle_res_list = NULL;
 static handle_request_func_type g_handle_req_cb = NULL;
-static get_notify_obs_uri_cb g_get_notify_obs_uri = NULL;
 
 static handle_request_interface_cb g_handle_request_interface_cb = NULL;
 
@@ -452,7 +449,6 @@ static OCEntityHandlerResult process_post_request(things_resource_s **target_res
 
 static OCEntityHandlerResult process_get_request(things_resource_s *target_resource)
 {
-
 	OCEntityHandlerResult eh_result = OC_EH_ERROR;
 
 	char *device_id = NULL;
@@ -554,16 +550,6 @@ int notify_things_observers(const char *uri, const char *query)
 	if (NULL != uri) {
 		int remainLen = MAX_RESOURCE_LEN - 1;
 		char tempUri[MAX_RESOURCE_LEN] = { 0 };
-
-		if (NULL != g_get_notify_obs_uri) {
-			char *temp = g_get_notify_obs_uri(uri, query);
-			if (NULL != temp) {
-				things_strncpy(tempUri, temp, remainLen);
-				remainLen -= strnlen(tempUri, MAX_RESOURCE_LEN - 1);
-				things_free(temp);
-			}
-		}
-
 		if (strnlen(tempUri, MAX_RESOURCE_LEN - 1) < 1) {
 			things_strncpy(tempUri, uri, remainLen);
 			remainLen -= strnlen(tempUri, MAX_RESOURCE_LEN - 1);
@@ -729,19 +715,6 @@ void init_handler()
 void deinit_handler()
 {
 	g_quit_flag = 1;
-
-	int iter = 0;
-	if (g_handle_res_list != NULL) {
-		for (iter = 0; iter < g_handle_res_cnt; iter++) {
-			if (g_handle_res_list[iter] != NULL) {
-				things_free(g_handle_res_list[iter]);
-				g_handle_res_list[iter] = NULL;
-			}
-		}
-		things_free(g_handle_res_list);
-		g_handle_res_list = NULL;
-	}
-	g_handle_res_cnt = 0;
 }
 
 struct things_request_handler_s *get_handler_instance()

--- a/framework/src/st_things/things_stack/framework/things_req_handler.h
+++ b/framework/src/st_things/things_stack/framework/things_req_handler.h
@@ -37,7 +37,6 @@ things_request_handler_s *get_handler_instance();
 
 typedef int (*stop_softap_func_type)(int value);
 typedef int (*handle_request_func_type)(struct things_resource_s *res);
-typedef char *(*get_notify_obs_uri_cb)(const char *Uri, const char *query);
 typedef OCEntityHandlerResult(*handle_request_interface_cb)(things_resource_s **ppst_target_resource);
 
 void release_handler_instance(things_request_handler_s *);


### PR DESCRIPTION
Request handler has unused variables which are related to maintaining resource list and a callback to get the observer uri.
This patch removes those lines of dead code.

Signed-off-by: Senthil Kumar G S <senthil.gs@samsung.com>