### PR TITLE
docs/multiheap: Add supported APIs description

### DIFF
--- a/docs/HowToUseMultiHeap.md
+++ b/docs/HowToUseMultiHeap.md
@@ -4,21 +4,24 @@ There are two cases to use multi-heap.
 1. continuous physical RAM but want to split regions
 2. separated physical RAMs but want to use for heap  
 
-To use multi-heap, please find three steps as shown below:
+To enable multi-heap, please find three steps as shown below:
 - [Set number of Regions](#1-set-number-of-regions)
 - [Set number of Heaps](#2-set-number-of-heaps)
 - [Set Region start address, size and heap index](#3-set-region-start-address-size-and-heap-index)
 
+To use multi-heap, please find a link as shown below:  
+[Supported APIs](#supported-apis)
+
 ## 1. Set number of Regions
 
-Set **CONFIG_MM_REGIONS** value which shows how many regions are.
+In menuconfig, Set **CONFIG_MM_REGIONS** value which shows how many regions are.
 ```
 Memory Management -> Number of memory regions -> change a number over 2
 ```
 
 ## 2. Set number of Heaps
 
-Set **CONFIG_MM_NHEAPS** value which indicates how many heaps are.
+In menuconfig, Set **CONFIG_MM_NHEAPS** value which indicates how many heaps are.
 ```
 Memory Management -> Number of heaps -> change a number over 2
 ```
@@ -28,18 +31,18 @@ Memory Management -> Number of heaps -> change a number over 2
 
 ## 3. Set Region start address, size and heap index
 
-Set start addresses, **CONFIG_RAM_REGIONx_START** with hexa values,  set sizes, **CONFIG_RAM_REGIONx_SIZE** with decimal values(in bytes) of new heap, and set indexes, **CONFIG_RAM_REGIONx_HEAP_INDEX** with decimal values of new heap.  
+Set start addresses, **CONFIG_RAM_REGIONx_START** with hexa values,  set sizes, **CONFIG_RAM_REGIONx_SIZE** with decimal values(in bytes) of new heap, and set indexes, **CONFIG_RAM_REGIONx_HEAP_INDEX** with decimal values of new heap in menuconfig.  
 **CONFIG_RAM_REGIONx_HEAP_INDEX** can be start from 0.
 ```
 Hardware Configuration -> Chip Selection -> List of start address for RAM region -> set values
 Hardware Configuration -> Chip Selection -> List of size for RAM region
 Hardware Configuration -> Chip Selection -> List of heap index for RAM region
 ```
-Each region is separated by ```','``` as shown below example:
+Each region is separated by `','` and all config should be in `" "` as shown below example:
 ```
-0x02000000,0x04000000,0x07000000
-100,400,200
-0,1,0
+"0x02000000,0x04000000,0x07000000"
+"100,400,200"
+"0,1,0"
 ```
 
 Based on above configurations, *up_addregion()* function sets new regions automatically.
@@ -57,3 +60,15 @@ CONFIG_RAM_REGIONx_SIZE="1024,512,2048,512,256,4096"
 CONFIG_RAM_REGIONx_HEAP_INDEX="0,1,1,2,2,3"
 ```
 
+## Supported APIs
+A header file [mm.h](../os/include/tinyara/mm/mm.h) provides following APIs which support to allocate memory for a specific heap as shown below:
+```
+void *malloc_at(int heap_index, size_t size);
+void *calloc_at(int heap_index, size_t n, size_t elem_size);
+void *memalign_at(int heap_index, size_t alignment, size_t size);
+void *realloc_at(int heap_index, void *oldmem, size_t size);
+void *zalloc_at(int heap_index, size_t size);
+```
+The difference between Xalloc and Xalloc_at is like below :  
+Xalloc_at tries to allocate memory for a specific heap which passed by api argument. If there is no enough space to allocate, it will return NULL.  
+Xalloc tries to allocate memory for base heap which heap index is 0. If there is no enough space to allocate, it will try to allocate in order from the next index for whole heaps.

--- a/os/include/tinyara/mm/mm.h
+++ b/os/include/tinyara/mm/mm.h
@@ -679,10 +679,73 @@ struct heapinfo_total_info_s {
 };
 typedef struct heapinfo_total_info_s heapinfo_total_info_t;
 
+/**
+ * @cond
+ * @internal
+ */
+
+/**
+ * @brief Allocate memory to the specific heap.
+ * @details @b #include <tinyara/mm/mm.h>\n
+ *   malloc_at tries to allocate memory for a specific heap which passed by api argument.
+ *   If there is no enough space to allocate, it will return NULL.
+ * @param[in] heap_index Index of specific heap
+ * @param[in] size size (in bytes) of the memory region to be allocated
+ * 
+ * @return On success, the address of the allocated memory is returned. On failure, NULL is returned.
+ * @since TizenRT v2.1 PRE
+ */
 void *malloc_at(int heap_index, size_t size);
+/**
+ * @brief Calloc to the specific heap.
+ * @details @b #include <tinyara/mm/mm.h>\n
+ *   calloc_at tries to allocate memory for a specific heap which passed by api argument.
+ *   If there is no enough space to allocate, it will return NULL.
+ * @param[in] heap_index Index of specific heap
+ * @param[in] n the number of elements to be allocated
+ * @param[in] elem_size the size of elements
+ * 
+ * @return On success, the address of the allocated memory is returned. On failure, NULL is returned.
+ * @since TizenRT v2.1 PRE
+ */
 void *calloc_at(int heap_index, size_t n, size_t elem_size);
+/**
+ * @brief Memalign to the specific heap.
+ * @details @b #include <tinyara/mm/mm.h>\n
+ *   memalign_at tries to align the memory for a specific heap which passed by api argument.
+ *   If there is no enough space, it will return NULL.
+ * @param[in] heap_index Index of specific heap
+ * @param[in] alignment A power of two for alignment
+ * @param[in] size Allocated memory size
+ * 
+ * @return On success, the address of the allocated memory is returned. On failure, NULL is returned.
+ * @since TizenRT v2.1 PRE
+ */
 void *memalign_at(int heap_index, size_t alignment, size_t size);
+/**
+ * @brief Realloc to the specific heap.
+ * @details @b #include <tinyara/mm/mm.h>\n
+ *   realloc_at tries to allocate memory for a specific heap which passed by api argument.
+ *   If there is no enough space to allocate, it will return NULL.
+ * @param[in] heap_index Index of specific heap
+ * @param[in] oldmem the pointer to a memory block previously allocated
+ * @param[in] size the new size for the memory block
+ * 
+ * @return On success, the address of the allocated memory is returned. On failure, NULL is returned.
+ * @since TizenRT v2.1 PRE
+ */
 void *realloc_at(int heap_index, void *oldmem, size_t size);
+/**
+ * @brief Zalloc to the specific heap.
+ * @details @b #include <tinyara/mm/mm.h>\n
+ *   zalloc_at tries to allocate memory for a specific heap which passed by api argument.
+ *   If there is no enough space to allocate, it will return NULL.
+ * @param[in] heap_index Index of specific heap
+ * @param[in] size size (in bytes) of the memory region to be allocated
+ * 
+ * @return On success, the address of the allocated memory is returned. On failure, NULL is returned.
+ * @since TizenRT v2.1 PRE
+ */
 void *zalloc_at(int heap_index, size_t size);
 #else
 #define malloc_at(heap_index, size)              malloc(size)
@@ -691,6 +754,10 @@ void *zalloc_at(int heap_index, size_t size);
 #define realloc_at(heap_index, oldmem, size)     realloc(oldmem, size)
 #define zalloc_at(heap_index, size)              zalloc(size)
 #endif
+
+/**
+ * @endcond
+ */
 
 #undef EXTERN
 #ifdef __cplusplus

--- a/os/mm/umm_heap/umm_calloc.c
+++ b/os/mm/umm_heap/umm_calloc.c
@@ -72,6 +72,8 @@
  *
  * Description:
  *   calloc to the specific heap.
+ *   calloc_at tries to allocate memory for a specific heap which passed by api argument.
+ *   If there is no enough space to allocate, it will return NULL.
  *
  * Return Value:
  *   The address of the allocated memory (NULL on failure to allocate)

--- a/os/mm/umm_heap/umm_malloc.c
+++ b/os/mm/umm_heap/umm_malloc.c
@@ -91,6 +91,8 @@
  *
  * Description:
  *   Allocate memory to the specific heap.
+ *   malloc_at tries to allocate memory for a specific heap which passed by api argument.
+ *   If there is no enough space to allocate, it will return NULL.
  *
  * Parameters:
  *   heap_index - Index of specific heap.

--- a/os/mm/umm_heap/umm_memalign.c
+++ b/os/mm/umm_heap/umm_memalign.c
@@ -76,6 +76,8 @@
  *
  * Description:
  *   memalign to the specific heap.
+ *   memalign_at tries to align the memory for a specific heap which passed by api argument.
+ *   If there is no enough space, it will return NULL.
  *
  * Return Value:
  *   The address of the allocated memory (NULL on failure to allocate)

--- a/os/mm/umm_heap/umm_realloc.c
+++ b/os/mm/umm_heap/umm_realloc.c
@@ -77,6 +77,8 @@
  *
  * Description:
  *   realloc to the specific heap.
+ *   realloc_at tries to allocate memory for a specific heap which passed by api argument.
+ *   If there is no enough space to allocate, it will return NULL.
  *
  * Return Value:
  *   The address of the allocated memory (NULL on failure to allocate)

--- a/os/mm/umm_heap/umm_zalloc.c
+++ b/os/mm/umm_heap/umm_zalloc.c
@@ -73,6 +73,8 @@
  *
  * Description:
  *   zalloc to the specific heap.
+ *   zalloc_at tries to allocate memory for a specific heap which passed by api argument.
+ *   If there is no enough space to allocate, it will return NULL.
  *
  * Return Value:
  *   The address of the allocated memory (NULL on failure to allocate)


### PR DESCRIPTION
Xalloc_at APIs can be used to allocate memory for a specific heap.