### PR TITLE
include/mm: include heap_regioninfo.h header file

### DIFF
--- a/os/include/tinyara/mm/mm.h
+++ b/os/include/tinyara/mm/mm.h
@@ -61,6 +61,7 @@
 #include <sys/types.h>
 #include <stdbool.h>
 #include <semaphore.h>
+#include <tinyara/mm/heap_regioninfo.h>
 #ifdef CONFIG_HEAPINFO_USER_GROUP
 #include <tinyara/mm/heapinfo_internal.h>
 #endif


### PR DESCRIPTION
Due to missing header file, there is a compilation error as shown below:
/root/tizenrt/os/include/tinyara/mm/mm.h:211:30: error: 'regionx_start' undeclared (first use in this function)

The prototype of regionx_start is in heap_regioninfo.h so that
including header is necessary.

Signed-off-by: sunghan-chang <sh924.chang@samsung.com>