### PR TITLE
framework/st_things: Remove POST request handling for /sec/provisioninginfo

### DIFF
--- a/framework/src/st_things/things_stack/things_api.h
+++ b/framework/src/st_things/things_stack/things_api.h
@@ -32,7 +32,6 @@ typedef void (*things_pin_display_close_func_type)(void);
 typedef void (*things_pin_generated_func_type)(char *pin_data, size_t pin_size);
 typedef void (*things_get_easysetup_state_func_type)(things_es_enrollee_state_e state);
 typedef void (*things_cloud_con_result_func_type)(int result, char *domain, char *access_token);
-typedef void (*things_abort_easysetup_func_type)(things_es_enrollee_abort_e level);
 typedef void (*things_sec_otm_state_func_type)(const char *addr, uint16_t port, const char *uuid, int event);
 typedef int (*things_stop_soft_ap_func_type)(int value);
 typedef int (*things_get_user_confirm_func_type)(void);

--- a/framework/src/st_things/things_stack/things_stack.c
+++ b/framework/src/st_things/things_stack/things_stack.c
@@ -92,16 +92,6 @@ static volatile rst_state_e m_reset_bit_mask = RST_COMPLETE;
 
 static void *t_things_reset_loop(reset_args_s *args);
 
-#ifdef CONFIG_ST_THINGS_EASYSETUP_ABORT
-typedef struct s_abort_s {
-	pthread_t *h_thread;
-	things_es_enrollee_abort_e level;
-} s_abort_s;
-
-things_abort_easysetup_func_type g_abort_easysetup = NULL;
-static void *t_things_abort_loop(s_abort_s *contents);
-#endif
-
 int things_register_easysetup_state_func(things_get_easysetup_state_func_type func)
 {
 	int res = 0;
@@ -788,68 +778,6 @@ GOTO_OUT:
 	THINGS_LOG_D(TAG, "Exit.");
 	return NULL;
 }
-
-#ifdef CONFIG_ST_THINGS_EASYSETUP_ABORT
-OCEntityHandlerResult things_abort(pthread_t *h_thread_abort, things_es_enrollee_abort_e level)
-{
-	OCEntityHandlerResult eh_result = OC_EH_ERROR;
-
-	if (h_thread_abort == NULL) {
-		THINGS_LOG_E(TAG, "h_thread_abort is NULL.");
-		return eh_result;
-	}
-
-	if ((*h_thread_abort) == 0) {
-		s_abort_s *ARGs = (s_abort_s *)things_malloc(sizeof(s_abort_s));
-		if (ARGs == NULL) {
-			THINGS_LOG_E(TAG, "Memory Allocation is failed.(for abort Thread)");
-			return OC_EH_ERROR;
-		}
-
-		ARGs->h_thread = h_thread_abort;
-		ARGs->level = level;
-
-		eh_result = OC_EH_OK;
-
-		if (pthread_create_rtos(h_thread_abort, NULL, (pthread_func_type) t_things_abort_loop, ARGs, THINGS_STACK_ABORT_THREAD) != 0) {
-			THINGS_LOG_E(TAG, "Create thread is failed.(for abort Thread)");
-			*h_thread_abort = 0;
-			things_free(ARGs);
-			pthread_detach(h_thread_abort);
-			eh_result = OC_EH_ERROR;
-		}
-	} else {
-		THINGS_LOG_D(TAG, "Already called Thread. So, OC_EH_NOT_ACCEPTABLE");
-		eh_result = OC_EH_NOT_ACCEPTABLE;
-	}
-
-	return eh_result;
-}
-
-static void *__attribute__((optimize("O0"))) t_things_abort_loop(s_abort_s *contents)
-{
-	THINGS_LOG_D(TAG, "Enter.");
-
-	if (contents == NULL) {
-		THINGS_LOG_E(TAG, "contents is NULL.");
-		goto GOTO_OUT;
-	}
-
-	if (g_abort_easysetup != NULL) {
-		THINGS_LOG_E(TAG, "Registered Abort Function. So, Call Function st_things API.");
-		g_abort_easysetup(contents->level);
-	}
-
-GOTO_OUT:
-	if (contents) {
-		*(contents->h_thread) = 0;
-		things_free(contents);
-	}
-
-	THINGS_LOG_D(TAG, "Exit.");
-	return NULL;
-}
-#endif
 
 int things_is_things_module_initialized(void)
 {

--- a/framework/src/st_things/things_stack/things_types.h
+++ b/framework/src/st_things/things_stack/things_types.h
@@ -163,28 +163,6 @@ typedef enum {
 	RST_ENUM_EOF
 } things_es_enrollee_reset_e;
 
-typedef enum {
-	/**
-	 * Default Abort State.
-	 */
-	ABORT_INIT = 0,
-
-	/**
-	 * Abort Status indicating cancel Reset Confirm.
-	 */
-	ABORT_BEFORE_RESET_CONFIRM = 1,
-
-	/**
-	 * Abort Status indicating cancel Security Confirm.
-	 */
-	ABORT_BEFORE_SEC_CONFIRM = 2,
-
-	/**
-	 * Abort Status indicating being security-process to delete Owned Security Data.
-	 */
-	ABORT_BEFORE_DATA_PROVISIONING = 3
-} things_es_enrollee_abort_e;
-
 /**
  * @brief Indicate enrollee and provisioning status. Provisioning status is shown in "provisioning
  *        status" property in provisioning resource.


### PR DESCRIPTION
POST on /sec/provisioning resource are for "abort" and "reset" from cloud.
"abort" is neither used nor fully implemented.
"reset" is fully implemented but unused.
We will implement them later based on future requirements.

Signed-off-by: Senthil Kumar G S <senthil.gs@samsung.com>