### PR TITLE
external/DHCP: Modify Makefile to minimize defconfig modification

### DIFF
--- a/external/dhcpc/Makefile
+++ b/external/dhcpc/Makefile
@@ -53,15 +53,14 @@
 -include $(TOPDIR)/.config
 -include $(TOPDIR)/Make.defs
 
-ifeq ($(CONFIG_NET_DHCP),y)
-ASRCS		=
-CSRCS		= dhcpc.c
-else
 ifeq ($(CONFIG_NET_LWIP_DHCP),y)
 ASRCS		=
 CSRCS		= dhcpc_lwip.c
+else
+ASRCS		=
+CSRCS		= dhcpc.c
 endif
-endif
+
 AOBJS		= $(ASRCS:.S=$(OBJEXT))
 COBJS		= $(CSRCS:.c=$(OBJEXT))
 

--- a/external/dhcpd/Makefile
+++ b/external/dhcpd/Makefile
@@ -53,14 +53,12 @@
 -include $(TOPDIR)/.config
 -include $(TOPDIR)/Make.defs
 
-ifeq ($(CONFIG_NET_DHCP),y)
-ASRCS		=
-CSRCS		= dhcpd.c
-else
 ifeq ($(CONFIG_NET_LWIP_DHCP),y)
 ASRCS		=
 CSRCS		= dhcpd_lwip.c
-endif
+else
+ASRCS		=
+CSRCS		= dhcpd.c
 endif
 
 AOBJS		= $(ASRCS:.S=$(OBJEXT))


### PR DESCRIPTION
- By default, complie dhcpc.c/dhcpd.c, not checking CONFIG_NET_DHCP