### PR TITLE
artik05x: Modify Debug Symbol Display feature

### DIFF
--- a/build/configs/artik05x/artik05x_download.sh
+++ b/build/configs/artik05x/artik05x_download.sh
@@ -90,6 +90,9 @@ compute_fw_parts()
 			if [ "${CONFIG_FS_ROMFS}" == "y" ]; then
 				rom=1
 			fi
+			if [ "${CONFIG_DEBUG_DISPLAY_SYMBOL}" == "y" ]; then
+				symtab=1
+			fi
 			;;
 		BL1|bl1)
 			bl1=1
@@ -119,7 +122,7 @@ compute_fw_parts()
 	esac
 
 	parts=
-	for var in bl1 bl2 sssfw wlanfw os rom ota; do
+	for var in bl1 bl2 sssfw wlanfw os rom ota symtab; do
 		eval value='${'${var}:-}
 		if [ "x${value:-}" == x1 ]; then
 			parts+=" ${var}"
@@ -161,6 +164,10 @@ compute_ocd_commands()
 			rom)
 				ensure_file ${OUTPUT_BINARY_PATH}/romfs.img
 				commands+="flash_write ${part} ${OUTPUT_BINARY_PATH}/romfs.img ${VERIFY}; "
+				;;
+			symtab)
+				ensure_file ${OUTPUT_BINARY_PATH}/Symtab.bin
+				commands+="flash_write ${part} ${OUTPUT_BINARY_PATH}/Symtab.bin ${VERIFY}; "
 				;;
 			*)
 				echo "Unrecognized firmware part ${part}"
@@ -247,7 +254,7 @@ while test $# -gt 0; do
 		--verify)
 			VERIFY=verify
 			;;
-		ALL|OS|ROMFS|BL1|BL2|SSSFW|WLANFW|OTA|all|os|romfs|bl1|bl2|sssfw|wlanfw|ota)
+		ALL|OS|ROMFS|BL1|BL2|SSSFW|WLANFW|OTA|all|os|romfs|bl1|bl2|sssfw|wlanfw|ota|symtab)
 			download $1
 			;;
 		ERASE_*)

--- a/build/configs/artik05x/scripts/partition_gen.sh
+++ b/build/configs/artik05x/scripts/partition_gen.sh
@@ -121,6 +121,9 @@ do
 		pname_text="ROM FS"
 		ro=0
 		romfs_part_exist=1
+	elif [ "$pname" == "symtab" ]; then
+		pname_text="Symbol Table"
+		ro=0
 	elif [ "$pname" == "nvram" ]; then
 		pname_text="WiFi NVRAM"
 		ro=1

--- a/os/Makefile.unix
+++ b/os/Makefile.unix
@@ -679,3 +679,10 @@ romfs:
 ifeq ($(CONFIG_FS_ROMFS),y)
 	$(Q) ../tools/fs/mkromfsimg.sh
 endif
+
+#Symbol table formatter
+#
+# This script executes the symbol table formatter application
+ifeq ($(CONFIG_DEBUG_DISPLAY_SYMBOL),y)
+	./tools/symtab_formatter.sh
+endif

--- a/os/arch/Kconfig
+++ b/os/arch/Kconfig
@@ -452,7 +452,6 @@ config DEBUG_DISPLAY_SYMBOL
 	select DEBUG_SYMBOLS
 	select FRAME_POINTER
 	depends on ARCH_STACKDUMP
-	depends on FS_ROMFS
 	---help---
 		Enable to show symbol on call stack dump
 

--- a/os/board/artik05x/include/symtab.h
+++ b/os/board/artik05x/include/symtab.h
@@ -1,0 +1,24 @@
+/****************************************************************************
+ *
+ * Copyright 2018 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+#ifndef __BOARD_ARTIK05X_INCLUDE_SYMTAB_H__
+#define __BOARD_ARTIK05X_INCLUDE_SYMTAB_H__
+#define FLASH_BASE 0x04000000
+int up_symtab_flashdrv_init(void);
+void up_symtab_flashdrv_read(void *buffer, uint32_t offset_addr, int bytes);
+
+#endif /* __BOARD_ARTIK05X_INCLUDE_SYMTAB_H__ */

--- a/os/board/artik05x/src/Makefile
+++ b/os/board/artik05x/src/Makefile
@@ -76,6 +76,10 @@ ifeq ($(CONFIG_BOARD_CRASHDUMP),y)
 CSRCS += artik05x_crashdump.c
 endif
 
+ifeq ($(CONFIG_DEBUG_DISPLAY_SYMBOL),y)
+CSRCS += artik05x_symtab.c
+endif
+
 ifeq ($(CONFIG_MTD_PROGMEM),y)
 CSRCS += artik05x_progmem.c
 endif

--- a/os/board/artik05x/src/artik05x_symtab.c
+++ b/os/board/artik05x/src/artik05x_symtab.c
@@ -1,0 +1,112 @@
+/*****************************************************************************
+ *
+ * Copyright 2018 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+#include <stdint.h>
+#include <stdio.h>
+#include <assert.h>
+#include <stdlib.h>
+#include <stdbool.h>
+#include <arch/board/symtab.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+#define MAX_SYMBOL_NAME_LEN 256
+/****************************************************************************
+ * Private Variables
+ ****************************************************************************/
+static uint32_t symtab_base_addr = 0;
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+int up_symtab_flashdrv_init(void)
+{
+	char *a;
+	char *b;
+	int name_ind = 0;
+	int len_ind = 0;
+	char s[MAX_SYMBOL_NAME_LEN];
+
+	a = CONFIG_ARTIK05X_FLASH_PART_NAME;
+	b = CONFIG_ARTIK05X_FLASH_PART_LIST;
+
+	if (a == NULL || b == NULL) {
+		printf("Invalid Configs\n");
+		return -1;
+	}
+
+	/* Computing the name_ind for symtab partition */
+	while (a[0] != '\0') {
+		if (a[0] == 's') {
+			if (strncmp("symtab", a, 6) == 0) {
+				break;
+			}
+		}
+		while (a[0] != ',') {
+			a++;
+		}
+		a++;
+		name_ind++;
+	}
+
+	if (a == NULL) {
+		printf("Unable to initialize the flash driver for symbol table \n");
+		return -1;
+	}
+
+	memset(s, '\0', sizeof(s));
+	/* Computing the offset length for symtab partition */
+
+	while (b[0] != '\0') {
+		if (name_ind == 0) {
+			break;
+		} else {
+			s[len_ind] = b[0];
+			len_ind++;
+			b++;
+			if (b[0] == ',') {
+				int part_size;
+				sscanf(s, "%d", &part_size);
+				symtab_base_addr += part_size * 1024;
+
+				b++;
+				name_ind--;
+				len_ind = 0;
+				memset(s, '\0', sizeof(s));
+			}
+		}
+	}
+	if (symtab_base_addr == 0) {
+		return -1;
+	}
+
+	/* Symbol table offset length is added to the flash base address */
+	symtab_base_addr += (uint32_t)FLASH_BASE;
+	return OK;
+}
+
+void up_symtab_flashdrv_read(void *buffer, uint32_t offset_addr, int bytes)
+{
+	if (buffer == NULL || bytes < 0) {
+		return;
+	}
+	memcpy(buffer, (void *)(symtab_base_addr + offset_addr), bytes);
+}

--- a/os/kernel/init/os_start.c
+++ b/os/kernel/init/os_start.c
@@ -550,6 +550,10 @@ void os_start(void)
 
 	lib_initialize();
 
+#ifdef CONFIG_DEBUG_DISPLAY_SYMBOL
+	up_symtab_init();
+#endif
+
 	/* IDLE Group Initialization **********************************************/
 #ifdef HAVE_TASK_GROUP
 	/* Allocate the IDLE group */

--- a/os/kernel/semaphore/sem_wait.c
+++ b/os/kernel/semaphore/sem_wait.c
@@ -81,9 +81,6 @@
 /****************************************************************************
  * Global Variables
  ****************************************************************************/
-#ifdef CONFIG_DEBUG_DISPLAY_SYMBOL
-extern bool abort_mode;
-#endif
 
 /****************************************************************************
  * Private Variables
@@ -125,15 +122,7 @@ int sem_wait(FAR sem_t *sem)
 	irqstate_t saved_state;
 	int ret = ERROR;
 	/* This API should not be called from interrupt handlers */
-#ifdef CONFIG_DEBUG_DISPLAY_SYMBOL
-	DEBUGASSERT((sem != NULL && up_interrupt_context() == false) || abort_mode);
-
-	if (abort_mode && up_interrupt_context() == true) {
-		return OK;
-	}
-#else
 	DEBUGASSERT(sem != NULL && up_interrupt_context() == false);
-#endif
 
 	/* The following operations must be performed with interrupts
 	 * disabled because sem_post() may be called from an interrupt

--- a/os/tools/symtab_formatter.c
+++ b/os/tools/symtab_formatter.c
@@ -1,0 +1,113 @@
+/****************************************************************************
+ *
+ * Copyright 2018 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <stdio.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <string.h>
+#include <stdlib.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define ADDR_LENGTH 4
+#define HEXADECIMAL_BASE 16
+#define MAP_FILE_PATH "../build/output/bin/System.map"
+#define BIN_FILE_PATH "../build/output/bin/Symtab.bin"
+#define MAX_NUM_SYM 8000
+#define MAX_SYM_LEN 128
+
+/****************************************************************************
+ * Global Functions
+ ****************************************************************************/
+
+static uint32_t symbolnum;
+char symbolname[MAX_NUM_SYM][MAX_SYM_LEN];
+uint32_t symboladdress[MAX_NUM_SYM] = {0};
+uint32_t symboloffset[MAX_NUM_SYM] = {0};
+char symbol[2 * MAX_SYM_LEN] = {0};
+
+int main()
+{
+	FILE *fp;
+	size_t ret;
+	char *ptr;
+	int cnt;
+
+	fp = fopen(MAP_FILE_PATH, "r");
+
+	/* If the file could not be opened */
+	if (fp == NULL) {
+		printf("Symtab.bin creation failed \n");
+		return -1;
+	}
+
+	/* Reading the system.map file line by line */
+	while (fgets(symbol, sizeof(symbol), fp) != NULL) {
+
+		ptr = symbol;
+		/* Extracting the symbol address from the symbol variable */
+
+		symboladdress[symbolnum] = (unsigned int)strtoul(ptr, &ptr, HEXADECIMAL_BASE);
+		/* Copying the symbol name */
+
+		strncpy(symbolname[symbolnum], (char *)(ptr + 3), strlen((char *)(ptr + 3)) - 1);
+
+		/* Calculating the symbol offset length */
+
+		if (symbolnum != 0) {
+			symboloffset[symbolnum] = (uint32_t)(symboloffset[symbolnum - 1] + (uint32_t)strlen(symbolname[symbolnum - 1]));
+		}
+
+		symbolnum++;
+	}
+
+	fclose(fp);
+
+	/* Opening & Writing the symbol table binary file */
+	fp = fopen(BIN_FILE_PATH, "wb");
+
+	if (fp == NULL) {
+		printf("Symtab.bin creation failed \n");
+		return 0;
+	}
+
+	/* Writing the number of symbols in the first 4 bytes of the file */
+	ret = fwrite(&symbolnum, sizeof(uint32_t), 1, fp);
+
+	/* Writing the Symbol addresses into the binary file */
+	ret = fwrite(&symboladdress, sizeof(uint32_t), symbolnum, fp);
+
+	/*Writing the symbol offset addresses into the binary file */
+	ret = fwrite(symboloffset, sizeof(uint32_t), symbolnum, fp);
+
+	cnt = 0;
+
+	while (cnt < symbolnum) {
+		/* Copying the symbol names into the binary file */
+
+		ret = fwrite(symbolname[cnt], strlen(symbolname[cnt]), 1, fp);
+		cnt++;
+	}
+
+	fclose(fp);
+}

--- a/os/tools/symtab_formatter.sh
+++ b/os/tools/symtab_formatter.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+###########################################################################
+#
+# Copyright 2018 Samsung Electronics All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+#
+###########################################################################
+# File 	 : symtab_formatter.sh
+
+# Compile symbol table formatter application
+gcc tools/symtab_formatter.c -o symtab
+
+#execute
+./symtab
+
+# clean up
+rm -f symtab
+
+echo "Successfully generated Symtab.bin file"
+#end


### PR DESCRIPTION
* This patch modifies debug symbol display feature which currently uses ROMFS file system. As a result, this feature doesn't work if any abort happens in file system or memory sub-system.
* After modification, the feature uses a raw flash driver to display symbol name without any dependencies.