### PR TITLE
framework/st_things, external/iotivity: Remove build warnings. 

### DIFF
--- a/external/iotivity/iotivity_1.2-rel/resource/c_common/ocrandom/include/ocrandom.h
+++ b/external/iotivity/iotivity_1.2-rel/resource/c_common/ocrandom/include/ocrandom.h
@@ -52,13 +52,13 @@ typedef enum
  * Android and Linux uses current time. Arduino uses Analog reading on pin ANALOG_IN
  * @retval 0 for Success, otherwise some error value
  */
-int8_t OCSeedRandom();
+int8_t OCSeedRandom(void);
 
 /**
  * Generate a uniformly [0,2^32] distributed random number
  * @retval On Success, it returns the random value.
  */
-uint32_t OCGetRandom();
+uint32_t OCGetRandom(void);
 
 /**
  * Generate a uniformly [0,2^8] distributed random number

--- a/external/iotivity/iotivity_1.2-rel/resource/c_common/ocrandom/src/ocrandom.c
+++ b/external/iotivity/iotivity_1.2-rel/resource/c_common/ocrandom/src/ocrandom.c
@@ -118,7 +118,7 @@ uint8_t GetRandomBit()
 }
 #endif
 
-int8_t OCSeedRandom()
+int8_t OCSeedRandom(void)
 {
 #ifndef ARDUINO
     // Get current time to Seed.
@@ -197,7 +197,7 @@ void OCFillRandomMem(uint8_t * location, uint16_t len)
     }
 }
 
-uint32_t OCGetRandom()
+uint32_t OCGetRandom(void)
 {
     uint32_t result = 0;
     OCFillRandomMem((uint8_t*) &result, 4);

--- a/external/iotivity/iotivity_1.2-rel/resource/csdk/connectivity/api/cainterface.h
+++ b/external/iotivity/iotivity_1.2-rel/resource/csdk/connectivity/api/cainterface.h
@@ -94,7 +94,7 @@ CAResult_t CAInitialize(CATransportAdapter_t transportType);
  * Terminate the connectivity abstraction module.
  * All threads, data structures are destroyed for next initializations.
  */
-void CATerminate();
+void CATerminate(void);
 
 /**
  * Starts listening servers.
@@ -102,14 +102,14 @@ void CATerminate();
  * Based on the adapters configurations, different kinds of servers are started.
  * @return  ::CA_STATUS_OK or ::CA_STATUS_FAILED or ::CA_STATUS_NOT_INITIALIZED
  */
-CAResult_t CAStartListeningServer();
+CAResult_t CAStartListeningServer(void);
 
 /**
  * Stops the server from receiving the multicast traffic. This is used by sleeping
  * device to not receives the multicast traffic.
  * @return  ::CA_STATUS_OK or ::CA_STATUS_FAILED or ::CA_STATUS_NOT_INITIALIZED
  */
-CAResult_t CAStopListeningServer();
+CAResult_t CAStopListeningServer(void);
 
 /**
  * Starts discovery servers.
@@ -117,7 +117,7 @@ CAResult_t CAStopListeningServer();
  * Based on the adapters configurations, different kinds of servers are started.
  * @return  ::CA_STATUS_OK or ::CA_STATUS_FAILED or ::CA_STATUS_NOT_INITIALIZED
  */
-CAResult_t CAStartDiscoveryServer();
+CAResult_t CAStartDiscoveryServer(void);
 
 /**
  * Register request callbacks and response callbacks.
@@ -222,7 +222,7 @@ CAResult_t CAGetNetworkInformation(CAEndpoint_t **info, uint32_t *size);
  * To Handle the Request or Response.
  * @return   ::CA_STATUS_OK or ::CA_STATUS_NOT_INITIALIZED
  */
-CAResult_t CAHandleRequestResponse();
+CAResult_t CAHandleRequestResponse(void);
 
 #ifdef RA_ADAPTER
 /**

--- a/external/iotivity/iotivity_1.2-rel/resource/csdk/connectivity/api/cautilinterface.h
+++ b/external/iotivity/iotivity_1.2-rel/resource/csdk/connectivity/api/cautilinterface.h
@@ -142,24 +142,24 @@ CAResult_t CASetScanResponseData(const char* data, int length);
 /**
  * initialize client connection manager
  */
-CAResult_t CAUtilClientInitialize();
+CAResult_t CAUtilClientInitialize(void);
 
 /**
  * terminate client connection manager
  */
-CAResult_t CAUtilClientTerminate();
+CAResult_t CAUtilClientTerminate(void);
 
 /**
  * stop LE scan.
  * @return  ::CA_STATUS_OK or ::CA_NOT_SUPPORTED
  */
-CAResult_t CAUtilStopLEScan();
+CAResult_t CAUtilStopLEScan(void);
 
 /**
  * start LE scan.
  * @return  ::CA_STATUS_OK or ::CA_NOT_SUPPORTED
  */
-CAResult_t CAUtilStartLEScan();
+CAResult_t CAUtilStartLEScan(void);
 #endif
 
 #ifdef __ANDROID__
@@ -222,7 +222,7 @@ CAResult_t CAUtilSetLEScanInterval(jint intervalTime, jint workingCount);
  *
  * @return  ::CA_STATUS_OK or ::CA_NOT_SUPPORTED
  */
-CAResult_t CAUtilStopLEScan();
+CAResult_t CAUtilStopLEScan(void);
 #endif
 
 // BLE util
@@ -230,13 +230,13 @@ CAResult_t CAUtilStopLEScan();
  * start BLE advertising.
  * @return  ::CA_STATUS_OK or ERROR CODES (::CAResult_t error codes in cacommon.h).
  */
-CAResult_t CAUtilStartLEAdvertising();
+CAResult_t CAUtilStartLEAdvertising(void);
 
 /**
  * stop BLE advertising.
  * @return  ::CA_STATUS_OK or ERROR CODES (::CAResult_t error codes in cacommon.h).
  */
-CAResult_t CAUtilStopLEAdvertising();
+CAResult_t CAUtilStopLEAdvertising(void);
 
 /**
  * set CAUtil BT configure.

--- a/external/iotivity/iotivity_1.2-rel/resource/csdk/connectivity/src/caconnectivitymanager.c
+++ b/external/iotivity/iotivity_1.2-rel/resource/csdk/connectivity/src/caconnectivitymanager.c
@@ -81,7 +81,7 @@ CAResult_t CAInitialize(CATransportAdapter_t transportType)
     return CA_STATUS_OK;
 }
 
-void CATerminate()
+void CATerminate(void)
 {
     OIC_LOG(DEBUG, TAG, "CATerminate");
 
@@ -94,7 +94,7 @@ void CATerminate()
     }
 }
 
-CAResult_t CAStartListeningServer()
+CAResult_t CAStartListeningServer(void)
 {
     OIC_LOG(DEBUG, TAG, "CAStartListeningServer");
 
@@ -106,7 +106,7 @@ CAResult_t CAStartListeningServer()
     return CAStartListeningServerAdapters();
 }
 
-CAResult_t CAStopListeningServer()
+CAResult_t CAStopListeningServer(void)
 {
     OIC_LOG(DEBUG, TAG, "CAStopListeningServer");
 
@@ -118,7 +118,7 @@ CAResult_t CAStopListeningServer()
     return CAStopListeningServerAdapters();
 }
 
-CAResult_t CAStartDiscoveryServer()
+CAResult_t CAStartDiscoveryServer(void)
 {
     OIC_LOG(DEBUG, TAG, "CAStartDiscoveryServer");
 
@@ -481,7 +481,7 @@ CAResult_t CAUnSelectNetwork(CATransportAdapter_t nonInterestedNetwork)
     return res;
 }
 
-CAResult_t CAHandleRequestResponse()
+CAResult_t CAHandleRequestResponse(void)
 {
     if (!g_isInitialized)
     {

--- a/external/iotivity/iotivity_1.2-rel/resource/csdk/connectivity/util/src/cautilinterface.c
+++ b/external/iotivity/iotivity_1.2-rel/resource/csdk/connectivity/util/src/cautilinterface.c
@@ -73,7 +73,7 @@ CAResult_t CAUnsetAutoConnectionDeviceInfo(const char *address)
 /**
  * initialize client connection manager
  */
-CAResult_t CAUtilClientInitialize()
+CAResult_t CAUtilClientInitialize(void)
 {
     OIC_LOG(DEBUG, TAG, "CAUtilClientInitialize");
 
@@ -95,7 +95,7 @@ CAResult_t CAUtilClientInitialize()
 /**
  * terminate client connection manager
  */
-CAResult_t CAUtilClientTerminate()
+CAResult_t CAUtilClientTerminate(void)
 {
     OIC_LOG(DEBUG, TAG, "CAUtilClientTerminate");
 #ifdef LE_ADAPTER
@@ -106,7 +106,7 @@ CAResult_t CAUtilClientTerminate()
 #endif
 }
 
-CAResult_t CAUtilStopLEScan()
+CAResult_t CAUtilStopLEScan(void)
 {
     OIC_LOG(DEBUG, TAG, "CAUtilStopLEScan");
 #ifdef LE_ADAPTER
@@ -118,7 +118,7 @@ CAResult_t CAUtilStopLEScan()
 #endif
 }
 
-CAResult_t CAUtilStartLEScan()
+CAResult_t CAUtilStartLEScan(void)
 {
     OIC_LOG(DEBUG, TAG, "CAUtilStartLEScan");
 #ifdef LE_ADAPTER
@@ -351,7 +351,7 @@ CAResult_t CAUtilSetLEScanInterval(jint intervalTime, jint workingCount)
 #endif
 }
 
-CAResult_t CAUtilStopLEScan()
+CAResult_t CAUtilStopLEScan(void)
 {
     OIC_LOG(DEBUG, TAG, "CAUtilStopLEScan");
 #ifdef LE_ADAPTER
@@ -364,7 +364,7 @@ CAResult_t CAUtilStopLEScan()
 }
 #endif // __ANDROID__
 
-CAResult_t CAUtilStartLEAdvertising()
+CAResult_t CAUtilStartLEAdvertising(void)
 {
     OIC_LOG(DEBUG, TAG, "CAUtilStartLEAdvertising");
 #if (defined(__ANDROID__) || defined(__TIZEN__)) && defined(LE_ADAPTER)
@@ -375,7 +375,7 @@ CAResult_t CAUtilStartLEAdvertising()
 #endif
 }
 
-CAResult_t CAUtilStopLEAdvertising()
+CAResult_t CAUtilStopLEAdvertising(void)
 {
     OIC_LOG(DEBUG, TAG, "CAUtilStopLEAdvertising");
 #if (defined(__ANDROID__) || defined(__TIZEN__)) && defined(LE_ADAPTER)

--- a/external/iotivity/iotivity_1.2-rel/resource/csdk/security/include/internal/aclresource.h
+++ b/external/iotivity/iotivity_1.2-rel/resource/csdk/security/include/internal/aclresource.h
@@ -30,13 +30,13 @@ extern "C" {
  *
  * @return ::OC_STACK_OK for Success, otherwise some error value.
  */
-OCStackResult InitACLResource();
+OCStackResult InitACLResource(void);
 
 /**
  * Perform cleanup for ACL resources.
  *
  */
-OCStackResult DeInitACLResource();
+OCStackResult DeInitACLResource(void);
 
 /**
  * This method is used by PolicyEngine to retrieve ACL for a Subject.
@@ -146,7 +146,7 @@ OCStackResult AppendACL2(const OicSecAcl_t* acl);
  *
  * @retval OC_STACK_OK for Success, otherwise some error value
  */
-OCStackResult UpdateDefaultSecProvACE();
+OCStackResult UpdateDefaultSecProvACE(void);
 
 /**
  * Internal function to update resource owner

--- a/external/iotivity/iotivity_1.2-rel/resource/csdk/security/include/internal/credresource.h
+++ b/external/iotivity/iotivity_1.2-rel/resource/csdk/security/include/internal/credresource.h
@@ -35,7 +35,7 @@ extern "C" {
  * @return ::OC_STACK_OK, if initialization is successful, else ::OC_STACK_ERROR if
  * initialization fails.
  */
-OCStackResult InitCredResource();
+OCStackResult InitCredResource(void);
 
 /**
  * Perform cleanup for credential resources.
@@ -44,7 +44,7 @@ OCStackResult InitCredResource();
  * ::OC_STACK_NO_RESOURCE, if resource not found.
  * ::OC_STACK_INVALID_PARAM, if invalid param.
  */
-OCStackResult DeInitCredResource();
+OCStackResult DeInitCredResource(void);
 
 /**
  * This method is used by tinydtls/SRM to retrieve credential for given subject.
@@ -182,7 +182,7 @@ OCStackResult AddTmpPskWithPIN(const OicUuid_t* tmpSubject, OicSecCredType_t cre
  *
  * @return ::credential list
  */
-const OicSecCred_t* GetCredList();
+OicSecCred_t* GetCredList(void);
 
 /**
  * Function to deallocate allocated memory to OicSecCred_t.

--- a/external/iotivity/iotivity_1.2-rel/resource/csdk/security/include/oxmverifycommon.h
+++ b/external/iotivity/iotivity_1.2-rel/resource/csdk/security/include/oxmverifycommon.h
@@ -80,7 +80,7 @@ void SetDisplayNumCB(void * ptr, DisplayNumCallback displayNumCB);
 /*
  * Unset Callback for displaying verification PIN
  */
-void* UnsetDisplayNumCB();
+void* UnsetDisplayNumCB(void);
 
 /*
  * Set Callback for getting user confirmation
@@ -90,7 +90,7 @@ void SetUserConfirmCB(void * ptr, UserConfirmCallback userConfirmCB);
 /*
  * Unset Callback for getting user confirmation
  */
-void* UnsetUserConfirmCB();
+void* UnsetUserConfirmCB(void);
 
 /*
  * Set verification method option.

--- a/external/iotivity/iotivity_1.2-rel/resource/csdk/security/include/pinoxmcommon.h
+++ b/external/iotivity/iotivity_1.2-rel/resource/csdk/security/include/pinoxmcommon.h
@@ -89,19 +89,19 @@ void SetClosePinDisplayCB(ClosePinDisplayCallback closeCB);
  * Function to unset the input PIN callback.
  * NOTE : Do not call this function while PIN based ownership transfer.
  */
-void UnsetInputPinCB();
+void UnsetInputPinCB(void);
 
 /**
  * Function to unset the PIN generation callback.
  * NOTE : Do not call this function while PIN based ownership transfer.
  */
-void UnsetGeneratePinCB();
+void UnsetGeneratePinCB(void);
 
 /**
  * Function to unset the PIN close callback.
  * NOTE : Do not call this function while PIN based ownership transfer is in progress.
  */
-void UnsetClosePinCB();
+void UnsetClosePinCB(void);
 
 /**
  * Function to generate random PIN.
@@ -128,7 +128,7 @@ OCStackResult InputPin(char* pinBuffer, size_t bufferSize);
  * Function to invoke the callback for close a PIN dispaly.
  * NOTE : This function will be invoked from SRM while OTM
  */
-void ClosePinDisplay();
+void ClosePinDisplay(void);
 
 #ifdef MULTIPLE_OWNER
 /**

--- a/external/iotivity/iotivity_1.2-rel/resource/csdk/security/src/aclresource.c
+++ b/external/iotivity/iotivity_1.2-rel/resource/csdk/security/src/aclresource.c
@@ -2297,7 +2297,7 @@ exit:
     return ret;
 }
 
-OCStackResult InitACLResource()
+OCStackResult InitACLResource(void)
 {
     OCStackResult ret = OC_STACK_ERROR;
 
@@ -2342,7 +2342,7 @@ exit:
     return ret;
 }
 
-OCStackResult DeInitACLResource()
+OCStackResult DeInitACLResource(void)
 {
     OCStackResult ret =  OCDeleteResource(gAclHandle);
     gAclHandle = NULL;
@@ -2693,7 +2693,7 @@ exit:
 
 }
 
-OCStackResult UpdateDefaultSecProvACE()
+OCStackResult UpdateDefaultSecProvACE(void)
 {
     OCStackResult ret = OC_STACK_OK;
     OicSecAce_t *ace = NULL;

--- a/external/iotivity/iotivity_1.2-rel/resource/csdk/security/src/credresource.c
+++ b/external/iotivity/iotivity_1.2-rel/resource/csdk/security/src/credresource.c
@@ -2256,7 +2256,7 @@ OCStackResult CreateCredResource()
     return ret;
 }
 
-OCStackResult InitCredResource()
+OCStackResult InitCredResource(void)
 {
     OCStackResult ret = OC_STACK_ERROR;
     OicSecCred_t* cred = NULL;
@@ -2334,7 +2334,7 @@ exit:
     return ret;
 }
 
-OCStackResult DeInitCredResource()
+OCStackResult DeInitCredResource(void)
 {
     OCStackResult result = OCDeleteResource(gCredHandle);
     DeleteCredList(gCred);
@@ -2361,7 +2361,7 @@ OicSecCred_t* GetCredResourceData(const OicUuid_t* subject)
     return NULL;
 }
 
-const OicSecCred_t* GetCredList()
+OicSecCred_t* GetCredList(void)
 {
     return gCred;
 }

--- a/external/iotivity/iotivity_1.2-rel/resource/csdk/security/src/oxmpincommon.c
+++ b/external/iotivity/iotivity_1.2-rel/resource/csdk/security/src/oxmpincommon.c
@@ -125,22 +125,22 @@ void SetClosePinDisplayCB(ClosePinDisplayCallback closeCB)
 }
 
 
-void UnsetInputPinCB()
+void UnsetInputPinCB(void)
 {
     gInputPinCallback = NULL;
 }
 
-void UnsetGeneratePinCB()
+void UnsetGeneratePinCB(void)
 {
     gGenPinCallback = NULL;
 }
 
-void UnsetClosePinDisplayCB()
+void UnsetClosePinDisplayCB(void)
 {
     gClosePinDispalyCallback = NULL;
 }
 
-void ClosePinDisplay()
+void ClosePinDisplay(void)
 {
     if (gClosePinDispalyCallback)
     {

--- a/external/iotivity/iotivity_1.2-rel/resource/csdk/security/src/oxmverifycommon.c
+++ b/external/iotivity/iotivity_1.2-rel/resource/csdk/security/src/oxmverifycommon.c
@@ -46,7 +46,7 @@ void SetDisplayNumCB(void * ptr, DisplayNumCallback displayNumCB)
     OIC_LOG(DEBUG, TAG, "OUT SetDisplayNumCB");
 }
 
-void* UnsetDisplayNumCB()
+void* UnsetDisplayNumCB(void)
 {
     OIC_LOG(DEBUG, TAG, "IN UnsetDisplayNumCB");
     void *prevctx = gDisplayNumContext.context;
@@ -69,7 +69,7 @@ void SetUserConfirmCB(void * ptr, UserConfirmCallback userConfirmCB)
     OIC_LOG(DEBUG, TAG, "OUT SetUserConfirmCB");
 }
 
-void* UnsetUserConfirmCB()
+void* UnsetUserConfirmCB(void)
 {
     OIC_LOG(DEBUG, TAG, "IN UnsetUserConfirmCB");
     void *prevctx = gUserConfirmContext.context;

--- a/external/iotivity/iotivity_1.2-rel/resource/csdk/stack/include/ocpayload.h
+++ b/external/iotivity/iotivity_1.2-rel/resource/csdk/stack/include/ocpayload.h
@@ -68,7 +68,7 @@ typedef struct OCResource OCResource;
 void OCPayloadDestroy(OCPayload* payload);
 
 // Representation Payload
-OCRepPayload* OCRepPayloadCreate();
+OCRepPayload* OCRepPayloadCreate(void);
 
 size_t calcDimTotal(const size_t dimensions[MAX_REP_ARRAY_DEPTH]);
 
@@ -230,7 +230,7 @@ bool OCRepPayloadGetPropObjectArray(const OCRepPayload* payload, const char* nam
 void OCRepPayloadDestroy(OCRepPayload* payload);
 
 // Discovery Payload
-OCDiscoveryPayload* OCDiscoveryPayloadCreate();
+OCDiscoveryPayload* OCDiscoveryPayloadCreate(void);
 
 OCSecurityPayload* OCSecurityPayloadCreate(const uint8_t* securityData, size_t size);
 void OCSecurityPayloadDestroy(OCSecurityPayload* payload);

--- a/external/iotivity/iotivity_1.2-rel/resource/csdk/stack/include/ocstack.h
+++ b/external/iotivity/iotivity_1.2-rel/resource/csdk/stack/include/ocstack.h
@@ -98,7 +98,7 @@ OCStackResult OCSetRAInfo(const OCRAInfo_t *raInfo);
  *
  * @return ::OC_STACK_OK on success, some other value upon failure.
  */
-OCStackResult OCStop();
+OCStackResult OCStop(void);
 
 /**
  * This function starts receiving the multicast traffic. This can be only called
@@ -107,7 +107,7 @@ OCStackResult OCStop();
  *
  * @return ::OC_STACK_OK on success, some other value upon failure.
  */
-OCStackResult OCStartMulticastServer();
+OCStackResult OCStartMulticastServer(void);
 
 /**
  * This function stops receiving the multicast traffic. The rest of the stack
@@ -117,7 +117,7 @@ OCStackResult OCStartMulticastServer();
  *
  * @return ::OC_STACK_OK on success, some other value upon failure.
  */
-OCStackResult OCStopMulticastServer();
+OCStackResult OCStopMulticastServer(void);
 
 /**
  * This function is Called in main loop of OC client or server.
@@ -125,7 +125,7 @@ OCStackResult OCStopMulticastServer();
  *
  * @return ::OC_STACK_OK on success, some other value upon failure.
  */
-OCStackResult OCProcess();
+OCStackResult OCProcess(void);
 
 /**
  * This function discovers or Perform requests on a specified resource
@@ -276,7 +276,7 @@ OCStackResult OCStartPresence(const uint32_t ttl);
  * @return ::OC_STACK_OK on success, some other value upon failure.
  */
 
-OCStackResult OCStopPresence();
+OCStackResult OCStopPresence(void);
 #endif
 
 
@@ -605,7 +605,7 @@ const OCDPDev_t* OCDiscoverDirectPairingDevices(unsigned short waittime);
  *
  * @return OCDirectPairingDev_t pointer in case of success and NULL otherwise.
  */
-const OCDPDev_t* OCGetDirectPairedDevices();
+const OCDPDev_t* OCGetDirectPairedDevices(void);
 
 /**
  * The function is responsible for establishment of direct-pairing. It will proceed mode negotiation
@@ -803,12 +803,12 @@ OCStackResult OCGetPropertyValue(OCPayloadType type, const char *propName, void 
 /**
 * Delete client callback info all.
 */
-void OCClearCallBackList();
+void OCClearCallBackList(void);
 
 /**
  * Delete observer info all.
  */
-void OCClearObserverlist();
+void OCClearObserverlist(void);
 
 /**
  * API to encrypt the un-encrypted DB file before OCRegisterPersistentStorageHandler

--- a/external/iotivity/iotivity_1.2-rel/resource/csdk/stack/src/ocpayload.c
+++ b/external/iotivity/iotivity_1.2-rel/resource/csdk/stack/src/ocpayload.c
@@ -65,7 +65,7 @@ void OCPayloadDestroy(OCPayload* payload)
     }
 }
 
-OCRepPayload* OCRepPayloadCreate()
+OCRepPayload* OCRepPayloadCreate(void)
 {
     OCRepPayload* payload = (OCRepPayload*)OICCalloc(1, sizeof(OCRepPayload));
 
@@ -1631,7 +1631,7 @@ void OCRepPayloadDestroy(OCRepPayload* payload)
     OICFree(payload);
 }
 
-OCDiscoveryPayload* OCDiscoveryPayloadCreate()
+OCDiscoveryPayload* OCDiscoveryPayloadCreate(void)
 {
     OCDiscoveryPayload* payload = (OCDiscoveryPayload*)OICCalloc(1, sizeof(OCDiscoveryPayload));
 

--- a/external/iotivity/iotivity_1.2-rel/resource/csdk/stack/src/ocstack.c
+++ b/external/iotivity/iotivity_1.2-rel/resource/csdk/stack/src/ocstack.c
@@ -2478,7 +2478,7 @@ exit:
     return result;
 }
 
-OCStackResult OCStop()
+OCStackResult OCStop(void)
 {
     OIC_LOG(INFO, TAG, "Entering OCStop");
 
@@ -2538,7 +2538,7 @@ OCStackResult OCStop()
     return OC_STACK_OK;
 }
 
-OCStackResult OCStartMulticastServer()
+OCStackResult OCStartMulticastServer(void)
 {
     if(stackState != OC_STACK_INITIALIZED)
     {
@@ -2554,7 +2554,7 @@ OCStackResult OCStartMulticastServer()
     return OC_STACK_OK;
 }
 
-OCStackResult OCStopMulticastServer()
+OCStackResult OCStopMulticastServer(void)
 {
     CAResult_t ret = CAStopListeningServer();
     if (CA_STATUS_OK != ret)
@@ -3243,7 +3243,7 @@ OCStackResult OCRegisterPersistentStorageHandler(OCPersistentStorage* persistent
 
 #ifdef WITH_PRESENCE
 
-OCStackResult OCProcessPresence()
+OCStackResult OCProcessPresence(void)
 {
     OCStackResult result = OC_STACK_OK;
 
@@ -3415,7 +3415,7 @@ OCStackResult OCStartPresence(const uint32_t ttl)
             OC_PRESENCE_TRIGGER_CREATE);
 }
 
-OCStackResult OCStopPresence()
+OCStackResult OCStopPresence(void)
 {
     OIC_LOG(INFO, TAG, "Entering OCStopPresence");
     OCStackResult result = OC_STACK_ERROR;
@@ -4328,7 +4328,7 @@ const OCDPDev_t* OCDiscoverDirectPairingDevices(unsigned short waittime)
     return (const OCDPDev_t*)DPGetDiscoveredDevices();
 }
 
-const OCDPDev_t* OCGetDirectPairedDevices()
+const OCDPDev_t* OCGetDirectPairedDevices(void)
 {
     return (const OCDPDev_t*)DPGetPairedDevices();
 }
@@ -5452,12 +5452,12 @@ OCStackResult OCGetDeviceOwnedState(bool *isOwned)
     return ret;
 }
 
-void OCClearCallBackList()
+void OCClearCallBackList(void)
 {
     DeleteClientCBList();
 }
 
-void OCClearObserverlist()
+void OCClearObserverlist(void)
 {
     DeleteObserverList();
 }

--- a/external/iotivity/iotivity_1.2-rel/service/notification/include/NSProviderInterface.h
+++ b/external/iotivity/iotivity_1.2-rel/service/notification/include/NSProviderInterface.h
@@ -82,7 +82,7 @@ NSResult NSStartProvider(NSProviderConfig config);
  * Terminate notification service for provider
  * @return ::NS_OK if the action is requested succesfully
  */
-NSResult NSStopProvider();
+NSResult NSStopProvider(void);
 
 /**
  * Request to publish resource using remote relay server
@@ -138,7 +138,7 @@ NSResult NSProviderSendSyncInfo(uint64_t messageId, NSSyncType type);
  * Service sets mandatory fields which message id and provider(device) id are filled with.
  * @return ::NSMessage *
  */
-NSMessage * NSCreateMessage();
+NSMessage * NSCreateMessage(void);
 
 /**
  * Add topic to topic list which is located in provider service storage
@@ -181,7 +181,7 @@ NSTopicLL * NSProviderGetConsumerTopics(const char * consumerId);
  * Request topics list already registered by provider user
  * @return :: Topic list
  */
-NSTopicLL * NSProviderGetTopics();
+NSTopicLL * NSProviderGetTopics(void);
 
 #ifdef __cplusplus
 }

--- a/external/iotivity/iotivity_1.2-rel/service/notification/src/provider/NSProviderInterface.c
+++ b/external/iotivity/iotivity_1.2-rel/service/notification/src/provider/NSProviderInterface.c
@@ -117,7 +117,7 @@ NSResult NSStartProvider(NSProviderConfig config)
     return NS_OK;
 }
 
-NSResult NSStopProvider()
+NSResult NSStopProvider(void)
 {
     NS_LOG(DEBUG, "NSStopProvider - IN");
     pthread_mutex_lock(&nsInitMutex);
@@ -309,7 +309,7 @@ NSResult NSAcceptSubscription(const char * consumerId, bool accepted)
     return NS_OK;
 }
 
-NSMessage * NSCreateMessage()
+NSMessage * NSCreateMessage(void)
 {
     NS_LOG(DEBUG, "NSCreateMessage - IN");
     pthread_mutex_lock(&nsInitMutex);
@@ -350,7 +350,7 @@ NSTopicLL * NSProviderGetConsumerTopics(const char * consumerId)
     return topicSync.topics;
 }
 
-NSTopicLL * NSProviderGetTopics()
+NSTopicLL * NSProviderGetTopics(void)
 {
     NS_LOG(DEBUG, "NSProviderGetTopics - IN");
     pthread_mutex_lock(&nsInitMutex);

--- a/framework/src/st_things/st_things.c
+++ b/framework/src/st_things/st_things.c
@@ -30,6 +30,7 @@
 #include "things_resource.h"
 #include "ocpayload.h"
 #include "octypes.h"
+#include "ocstack.h"
 
 #define TAG "[st_things_sdk]"
 
@@ -550,7 +551,7 @@ int st_things_notify_observers(const char *resource_uri)
 	return ST_THINGS_ERROR_NONE;
 }
 
-st_things_representation_s *st_things_create_representation_inst()
+st_things_representation_s *st_things_create_representation_inst(void)
 {
 	THINGS_LOG_D(TAG, THINGS_FUNC_ENTRY);
 	st_things_representation_s *rep = create_representation_inst();

--- a/framework/src/st_things/st_things_request_handler.c
+++ b/framework/src/st_things/st_things_request_handler.c
@@ -24,6 +24,7 @@
 #include "utils/things_malloc.h"
 #include "utils/things_util.h"
 #include "logging/things_logger.h"
+#include "utils/things_string.h"
 
 #include "things_api.h"
 #include "octypes.h"
@@ -355,18 +356,18 @@ static bool get_supported_properties(const char *res_type, const char *res_uri, 
 		// 2. Get the properties for each resource type.
 		props = (things_attribute_info_s ***) things_calloc(type_count, sizeof(things_attribute_info_s **));
 		if (NULL == props) {
-			THINGS_LOG_E(THINGS_ERROR, TAG, "Failed to allocate memory for resource properties.");
+			THINGS_LOG_E(TAG, "Failed to allocate memory for resource properties.");
 			goto EXIT_WITH_ERROR;
 		}
 		prop_count = (int *)things_calloc(type_count, sizeof(int));
 		if (NULL == prop_count) {
-			THINGS_LOG_E(THINGS_ERROR, TAG, "Failed to allocate memory for resource properties.");
+			THINGS_LOG_E(TAG, "Failed to allocate memory for resource properties.");
 			goto EXIT_WITH_ERROR;
 		}
 
 		for (int index = 0; index < type_count; index++) {
 			if (!things_get_attributes_by_resource_type(res_types[index], &prop_count[index], &props[index])) {
-				THINGS_LOG_V(THINGS_ERROR, TAG, "Failed to get the properties of resource type (%s).", res_types[index]);
+				THINGS_LOG_V(TAG, "Failed to get the properties of resource type (%s).", res_types[index]);
 				goto EXIT_WITH_ERROR;
 			}
 			THINGS_LOG_D(TAG, "Number of properties of resource type(%s): %d.", res_types[index], prop_count[index]);
@@ -377,21 +378,21 @@ static bool get_supported_properties(const char *res_type, const char *res_uri, 
 
 		*properties = (things_attribute_info_s **) things_calloc(*count, sizeof(things_attribute_info_s *));
 		if (NULL == *properties) {
-			THINGS_LOG_E(THINGS_ERROR, TAG, "Failed to allocate memory for resource properties.");
+			THINGS_LOG_E(TAG, "Failed to allocate memory for resource properties.");
 			goto EXIT_WITH_ERROR;
 		}
 
 		int cur_index = 0;
 		for (int index = 0; index < type_count; index++) {
 			if (NULL == props[index]) {
-				THINGS_LOG_V(THINGS_ERROR, TAG, "Resource type(%s) doesn't have any properties.", res_types[index]);
+				THINGS_LOG_V(TAG, "Resource type(%s) doesn't have any properties.", res_types[index]);
 				goto EXIT_WITH_ERROR;
 			}
 
 			for (int sub_index = 0; sub_index < prop_count[index]; sub_index++) {
 				things_attribute_info_s *prop = *(props[index] + sub_index);
 				if (NULL == prop) {
-					THINGS_LOG_E(THINGS_ERROR, TAG, "NULL Property.");
+					THINGS_LOG_E(TAG, "NULL Property.");
 					goto EXIT_WITH_ERROR;
 				}
 				// If this prop is already added, then ignore it and decrement the total count by 1.
@@ -601,7 +602,7 @@ static bool add_property_in_post_req_msg(st_things_set_request_message_s *req_ms
 		char **value = NULL;
 		size_t dimensions[MAX_REP_ARRAY_DEPTH] = { 0 };
 		if (OCRepPayloadGetStringArray(req_payload, prop->key, &value, dimensions)) {
-			result = OCRepPayloadSetStringArray(resp_payload, prop->key, value, dimensions);
+			result = OCRepPayloadSetStringArray(resp_payload, prop->key, (const char **)value, dimensions);
 			if (!result) {
 				THINGS_LOG_E(TAG, "Failed to set the string array value of '%s' in request message", prop->key);
 			}
@@ -617,7 +618,7 @@ static bool add_property_in_post_req_msg(st_things_set_request_message_s *req_ms
 		OCRepPayload **value = NULL;
 		size_t dimensions[MAX_REP_ARRAY_DEPTH] = { 0 };
 		if (OCRepPayloadGetPropObjectArray(req_payload, prop->key, &value, dimensions)) {
-			result = OCRepPayloadSetPropObjectArray(resp_payload, prop->key, value, dimensions);
+			result = OCRepPayloadSetPropObjectArray(resp_payload, prop->key, (const OCRepPayload **)value, dimensions);
 			if (!result) {
 				THINGS_LOG_E(TAG, "Failed to set the object array value of '%s' in request message", prop->key);
 			}
@@ -879,7 +880,7 @@ static int handle_get_req_on_single_rsrc(things_resource_s *single_rsrc)
 	char *if_type = NULL;
 	if (NULL != single_rsrc->query && strlen(single_rsrc->query) > 0) {
 		bool found = false;
-		bool result = get_query_value_internal(single_rsrc->query, OC_RSRVD_INTERFACE, &if_type, &found);
+		result = get_query_value_internal(single_rsrc->query, OC_RSRVD_INTERFACE, &if_type, &found);
 		if (found && !result) {	// If query is present but API returns false.
 			THINGS_LOG_E(TAG, "Failed to get the interface type from query parameter(%s).", single_rsrc->query);
 			things_release_representation_inst(resp_rep);

--- a/framework/src/st_things/things_stack/cloud/cloud_connector.c
+++ b/framework/src/st_things/things_stack/cloud/cloud_connector.c
@@ -450,8 +450,6 @@ OCStackResult things_cloud_dev_profile_publish(char *host, OCClientResponseHandl
 	OCDoHandle g_req_handle = NULL;
 	OCStackResult result = OC_STACK_ERROR;
 	char targetUri[MAX_URI_LENGTH * 2] = { 0, };
-	char *coreVer = NULL;
-	char *IoTivityVer = NULL;
 
 	snprintf(targetUri, MAX_URI_LENGTH * 2, "%s%s", host, OC_RSRVD_ACCOUNT_DEVPROFILE_URI);
 
@@ -492,7 +490,7 @@ OCStackResult things_cloud_dev_profile_publish(char *host, OCClientResponseHandl
 	}
 
 	size_t dimensions[MAX_REP_ARRAY_DEPTH] = { cntArrayPayload, 0, 0 };
-	OCRepPayloadSetPropObjectArray(payload, "devices", arrayPayload, dimensions);
+	OCRepPayloadSetPropObjectArray(payload, "devices", (const OCRepPayload **)arrayPayload, dimensions);
 
 	if (things_is_empty_request_handle() == true) {
 		iotivity_api_lock();

--- a/framework/src/st_things/things_stack/cloud/cloud_manager.c
+++ b/framework/src/st_things/things_stack/cloud/cloud_manager.c
@@ -33,6 +33,7 @@
 #include "cacommon.h"
 #include "utils/things_string.h"
 #include "things_def.h"
+#include "things_api.h"
 #include "logging/things_logger.h"
 #include "utils/things_malloc.h"
 #include "utils/things_string.h"
@@ -310,7 +311,7 @@ static int set_def_cloud_info(es_cloud_signup_s *cloud_info, const char *cloud_a
 		if (strchr(t_domain, ':') != NULL) {
 			ip_port = strchr(t_domain, ':');
 			if (ip_port) {
-				*ip_port = NULL;
+				*ip_port = '\0';
 			}
 			ip_port++;
 		} else {
@@ -1311,7 +1312,7 @@ OCStackResult log_in_out_to_cloud(bool value, things_timeout_s *timeout)
 	OCStackResult res = OC_STACK_ERROR;
 	OCClientResponseHandler callback = NULL;
 	things_check_time_out_call_func calltimeout = NULL;
-	char *device_id = NULL;
+	const char *device_id = NULL;
 
 	if (signed_up_data == NULL || signed_up_data->access_token == NULL || strlen(signed_up_data->access_token) < 1) {
 		THINGS_LOG_E(TAG, "No Session Key Retrived from the Cloud ");
@@ -1356,7 +1357,7 @@ OCStackResult log_in_out_to_cloud(bool value, things_timeout_s *timeout)
 			things_strncpy(g_cloud_port, signed_up_data->port, IP_PORT);
 
 			port = atoi(g_cloud_port);
-			if (g_cloud_ip[0] == NULL || g_cloud_port[0] == NULL || 0 >= port || port > 65535) {
+			if (g_cloud_ip[0] == 0 || g_cloud_port[0] == 0 || 0 >= port || port > 65535) {
 				THINGS_LOG_E(TAG, "Cloud info is invalid.(g_cloud_ip=%s, g_cloud_port=%s, port=%d)", g_cloud_ip, g_cloud_port, port);
 				goto GOTO_OUT;
 			}
@@ -1438,7 +1439,7 @@ OCStackResult find_cloud_resource(void)
 	char *sz_query_uri = NULL;
 	int length = MAX_CI_ADDRESS;
 	int length_query = 0;
-	char *device_id = NULL;
+	const char *device_id = NULL;
 
 	iotivity_api_lock();
 	device_id = OCGetServerInstanceIDString();
@@ -1502,7 +1503,7 @@ static OCStackResult register_server_into_cloud(es_cloud_prov_data_s *event_data
 		signed_up_data = NULL;
 	}
 
-	if (g_cloud_ip[0] == NULL || g_cloud_port[0] == NULL) {
+	if (g_cloud_ip[0] == 0 || g_cloud_port[0] == 0) {
 		THINGS_LOG_E(TAG, "g_cloud_ip is NULL or g_cloud_port is NULL");
 		return res;
 	}
@@ -1520,7 +1521,7 @@ static OCStackResult register_server_into_cloud(es_cloud_prov_data_s *event_data
 	things_ping_set_mask(g_cloud_ip, (uint16_t) port, PING_ST_ISCLOUD);
 
 	// Get Session Key
-	char *device_id = NULL;
+	const char *device_id = NULL;
 	iotivity_api_lock();
 	device_id = OCGetServerInstanceIDString();
 	iotivity_api_unlock();
@@ -1544,7 +1545,7 @@ OCStackResult refresh_token_into_cloud(void)
 	if (signed_up_data == NULL || signed_up_data->access_token == NULL || strlen(signed_up_data->access_token) < 1) {
 		THINGS_LOG_E(TAG, "No Session Key Retrived from the Cloud ");
 	} else {
-		char *device_id = NULL;
+		const char *device_id = NULL;
 		iotivity_api_lock();
 		device_id = OCGetServerInstanceIDString();
 		iotivity_api_unlock();
@@ -2126,6 +2127,8 @@ static int es_cloud_state_set_and_notify(things_cloud_status_e state, es_error_c
 		break;
 	case ES_STATE_PUBLISHED_RESOURCES_TO_CLOUD:
 		ci_finish_cloud_con(1);
+		break;
+	default:
 		break;
 	}
 

--- a/framework/src/st_things/things_stack/easy-setup/easysetup.c
+++ b/framework/src/st_things/things_stack/easy-setup/easysetup.c
@@ -152,15 +152,18 @@ things_es_enrollee_state_e es_get_state(void)
 
 bool es_get_cloud_login_state(void)
 {
+	bool res;
 	switch (get_enrollee_state()) {
 	case ES_STATE_REGISTERED_TO_CLOUD:
 	case ES_STATE_PUBLISHING_RESOURCES_TO_CLOUD:
 	case ES_STATE_PUBLISHED_RESOURCES_TO_CLOUD:
 	case ES_STATE_FAILED_TO_PUBLISH_RESOURCES_TO_CLOUD:
-		return true;
+		res = true;
+	default:
+		res = false;
 	}
 
-	return false;
+	return res;
 }
 
 es_result_e es_set_device_property(es_device_property *device_property)

--- a/framework/src/st_things/things_stack/easy-setup/easysetup_manager.c
+++ b/framework/src/st_things/things_stack/easy-setup/easysetup_manager.c
@@ -55,6 +55,7 @@
 #define MAX_REFRESHCHECK_CNT    30	// 30 times
 
 #define FILE_ES_STATE "easysetup_state.dat"
+#define DEF_DEVICE_NAME "ST_Things Device"
 
 es_dev_conf_prov_data_s *g_dev_conf_prov_data = NULL;
 es_wifi_prov_data_s *g_wifi_prov_data = NULL;
@@ -74,7 +75,6 @@ static const int i_fail_sleep_sec = 60;	// 60 sec
 static pthread_mutex_t g_es_mutex = PTHREAD_MUTEX_INITIALIZER;
 
 static es_device_property device_property;
-static const char *def_device_name = "ST_Things Device";
 
 static int g_es_state = 0; // 0 : EasySetup Need, 1 : Easysetup Done
 
@@ -170,7 +170,7 @@ int esm_set_device_property(char *name, const wifi_mode_e *mode, int ea_mode, co
 	}
 
 	if (name == NULL) {
-		name = def_device_name;
+		name = DEF_DEVICE_NAME;
 	}
 
 	if (ea_mode > NUM_WIFIMODE - 1) {
@@ -337,7 +337,7 @@ esm_result_e esm_init_easysetup(int restart_flag, things_server_builder_s *serve
 	return ESM_OK;
 }
 
-esm_result_e esm_terminate_easysetup()
+esm_result_e esm_terminate_easysetup(void)
 {
 	THINGS_LOG_D(TAG, "Terminate EasySetup");
 	esm_continue = 0;

--- a/framework/src/st_things/things_stack/easy-setup/resource_handler.c
+++ b/framework/src/st_things/things_stack/easy-setup/resource_handler.c
@@ -241,7 +241,7 @@ void register_dev_conf_rsrc_event_callback(es_dev_conf_cb cb)
 	g_dev_conf_rsrc_evt_cb = cb;
 }
 
-void unregister_resource_event_callback()
+void unregister_resource_event_callback(void)
 {
 	if (g_wifi_rsrc_evt_cb) {
 		g_wifi_rsrc_evt_cb = NULL;
@@ -570,7 +570,7 @@ bool update_cloud_resource(OCRepPayload *input)
 		THINGS_LOG_D(ES_RH_TAG, "g_cloud_resource.accesstoken %s", g_cloud_resource.accesstoken);
 	}
 
-	int accesstokenType = NULL;
+	int64_t accesstokenType = 0;
 	if (OCRepPayloadGetPropInt(input, THINGS_RSRVD_ES_VENDOR_ACCESS_TOKEN_TYPE, &accesstokenType)) {
 		g_cloud_resource.actoken_type = accesstokenType;
 		g_cloud_data.actoken_type = accesstokenType;
@@ -1196,7 +1196,7 @@ OCStackResult create_easysetup_resources(bool is_secured, es_resource_mask_e res
 	return res;
 }
 
-OCStackResult delete_easysetup_resources()
+OCStackResult delete_easysetup_resources(void)
 {
 	iotivity_api_lock();
 	OCStackResult res = OC_STACK_ERROR;
@@ -1539,6 +1539,8 @@ OCStackResult set_enrollee_state(things_es_enrollee_state_e es_state)
 			THINGS_LOG_V(ES_RH_TAG, "State(%s) is not allowed by Status Policy.(pre-status: %s)", get_prov_status(es_state), get_prov_status(g_prov_resource.status));
 			goto GOTO_OUT;
 		}
+		break;
+	default:
 		break;
 	}
 

--- a/framework/src/st_things/things_stack/fota/fmwup_util_data.c
+++ b/framework/src/st_things/things_stack/fota/fmwup_util_data.c
@@ -76,7 +76,7 @@ char *fmwup_data_get_update_string(int64_t cmd)
 	return "";
 }
 
-int key_manager_init()
+int key_manager_init(void)
 {
 	THINGS_LOG_D(TAG, THINGS_FUNC_ENTRY);
 	int is_valid = 1;
@@ -202,7 +202,7 @@ int key_manager_remove_data(const char *name)
 	return 0;
 }
 
-int key_manager_save_data()
+int key_manager_save_data(void)
 {
 	THINGS_LOG_D(TAG, THINGS_FUNC_ENTRY);
 
@@ -215,7 +215,7 @@ int key_manager_save_data()
 	return 0;
 }
 
-int key_manager_reset_data()
+int key_manager_reset_data(void)
 {
 	THINGS_LOG_D(TAG, THINGS_FUNC_ENTRY);
 
@@ -271,7 +271,7 @@ char *platform_get_data(const char *name)
 	return NULL;
 }
 
-fmwup_data_s *fmwup_data_get_properties()
+fmwup_data_s *fmwup_data_get_properties(void)
 {
 	THINGS_LOG_D(TAG, THINGS_FUNC_ENTRY);
 

--- a/framework/src/st_things/things_stack/fota/fmwup_util_internal.c
+++ b/framework/src/st_things/things_stack/fota/fmwup_util_internal.c
@@ -36,7 +36,7 @@ static int g_thread_running = 0;
 static pthread_mutex_t _lock = PTHREAD_MUTEX_INITIALIZER;
 static pthread_cond_t _cond = PTHREAD_COND_INITIALIZER;
 
-void fmwup_internal_propagate_timed_wait()
+void fmwup_internal_propagate_timed_wait(void)
 {
 	THINGS_LOG_D(TAG, THINGS_FUNC_ENTRY);
 
@@ -68,7 +68,7 @@ void fmwup_internal_propagate_timed_wait()
 	return;
 }
 
-void fmwup_internal_propagate_cond_signal()
+void fmwup_internal_propagate_cond_signal(void)
 {
 	THINGS_LOG_D(TAG, THINGS_FUNC_ENTRY);
 	pthread_mutex_lock(&_lock);

--- a/framework/src/st_things/things_stack/framework/things_data_manager.h
+++ b/framework/src/st_things/things_stack/framework/things_data_manager.h
@@ -102,7 +102,7 @@ const char *dm_get_svrdb_file_path(void);
 const char *dm_get_certificate_file_path(void);
 const char *dm_get_privatekey_file_path(void);
 const char *dm_get_filename(int filenum);
-const char *dm_get_things_device_type(int device_id);
+const char *dm_get_things_device_type(const char* device_id);
 const char *dm_get_things_cloud_address(char *customized_ci_server);
 
 const int dm_get_file_id(int filenum);
@@ -147,7 +147,7 @@ char *dm_get_access_token(void);
  */
 char *dm_get_uid(void);
 
-int dm_validate_attribute_in_request(char *res_type, const void *payload);
+int dm_validate_attribute_in_request(const char *res_type, const void *payload);
 
 char *dm_get_firmware_version(void);
 char *dm_get_vendor_id(void);

--- a/framework/src/st_things/things_stack/framework/things_req_handler.c
+++ b/framework/src/st_things/things_stack/framework/things_req_handler.c
@@ -57,12 +57,6 @@ static handle_request_func_type g_handle_request_set_cb = NULL;
 
 extern things_server_builder_s *g_builder;
 
-static handle_request_func_type g_handle_req_cb = NULL;
-
-static handle_request_interface_cb g_handle_request_interface_cb = NULL;
-
-static pthread_t g_req_handle;
-
 static int g_quit_flag = 0;
 
 /**
@@ -83,7 +77,6 @@ static int verify_request(OCEntityHandlerRequest *eh_request, const char *uri, i
 								  eh_request->resource,
 								  eh_request->query,
 								  eh_request->payload);	//g_builder->get_resource(g_builder, uri);
-	things_resource_s *child = NULL;
 	/*! Added by st_things for memory Leak fix
 	 */
 	pst_temp_resource = resource;
@@ -157,7 +150,7 @@ OCEntityHandlerResult send_response(OCRequestHandle request_handle, OCResourceHa
 	memset(response.sendVendorSpecificHeaderOptions, 0, sizeof response.sendVendorSpecificHeaderOptions);
 	memset(response.resourceUri, 0, sizeof(response.resourceUri));
 
-	if (NULL != request_handle && NULL != resource) {
+	if (0 != request_handle && 0 != resource) {
 		response.requestHandle = request_handle;	//eh_request->request_handle;
 		response.resourceHandle = resource;	//eh_request->resource;
 		response.persistentBufferFlag = 0;
@@ -271,7 +264,7 @@ static OCEntityHandlerResult get_provisioning_info(things_resource_s *target_res
 {
 	OCEntityHandlerResult eh_result = OC_EH_ERROR;
 
-	const char *device_rt = dm_get_things_device_type(0);
+	const char *device_rt = dm_get_things_device_type("0");
 	bool is_owned = false;
 	bool is_reset = things_get_reset_mask(RST_ALL_FLAG);
 
@@ -293,13 +286,13 @@ static OCEntityHandlerResult get_provisioning_info(things_resource_s *target_res
 	things_representation_s *child_rep[1] = { NULL };
 
 	child_rep[0] = things_create_representation_inst(NULL);
-	child_rep[0]->things_set_value(child_rep[0], SEC_ATTRIBUTE_PROV_TARGET_ID, device_id);
-	child_rep[0]->things_set_value(child_rep[0], SEC_ATTRIBUTE_PROV_TARGET_RT, device_rt);
+	child_rep[0]->things_set_value(child_rep[0], SEC_ATTRIBUTE_PROV_TARGET_ID, (char *)device_id);
+	child_rep[0]->things_set_value(child_rep[0], SEC_ATTRIBUTE_PROV_TARGET_RT, (char *)device_rt);
 	child_rep[0]->things_set_bool_value(child_rep[0], SEC_ATTRIBUTE_PROV_TARGET_PUBED, dm_is_rsc_published());
 
 	target_resource->rep->things_set_arrayvalue(target_resource->rep, SEC_ATTRIBUTE_PROV_TARGETS, 1, child_rep);
 	target_resource->rep->things_set_bool_value(target_resource->rep, SEC_ATTRIBUTE_PROV_TARGET_OWNED, is_owned);
-	target_resource->rep->things_set_value(target_resource->rep, SEC_ATTRIBUTE_PROV_EZSETDI, device_id);
+	target_resource->rep->things_set_value(target_resource->rep, SEC_ATTRIBUTE_PROV_EZSETDI, (char *)device_id);
 	target_resource->rep->things_set_bool_value(target_resource->rep, SEC_ATTRIBUTE_PROV_RESET, is_reset);
 	target_resource->rep->things_set_int_value(target_resource->rep, SEC_ATTRIBUTE_PROV_ABORT, 0);
 
@@ -328,7 +321,7 @@ static OCEntityHandlerResult trigger_reset_request(things_resource_s *target_res
 	THINGS_LOG_D(TAG, "==> RESET : %s", (reset == true ? "YES" : "NO"));
 
 	if (reset == true) {
-		things_resource_s *clone_resource = clone_resource_inst(target_resource);
+		things_resource_s *clone_resource = things_clone_resource_inst(target_resource);
 		int res = things_reset((void *)clone_resource, RST_NEED_CONFIRM);
 
 		switch (res) {
@@ -359,6 +352,7 @@ static OCEntityHandlerResult process_post_request(things_resource_s **target_res
 	things_resource_s *target_resource = *target_res;
 
 	if (strstr(target_resource->uri, URI_SEC) != NULL && strstr(target_resource->uri, URI_PROVINFO) != NULL) {
+		THINGS_LOG_D(TAG, "POST Request for %s resource. It will be ignored", URI_PROVINFO);
 		eh_result = OC_EH_NOT_IMPLEMENTED;
 #ifdef CONFIG_ST_THINGS_FOTA
 	} else if (strstr(target_resource->uri, URI_FIRMWARE) != NULL) {
@@ -473,7 +467,7 @@ void notify_result_of_reset(things_resource_s *target_resource, bool result)
 	THINGS_LOG_D(TAG, THINGS_FUNC_EXIT);
 }
 
-int notify_things_observers(const char *uri, const char *query)
+int notify_things_observers(const char *uri)
 {
 	THINGS_LOG_D(TAG, THINGS_FUNC_ENTRY);
 

--- a/framework/src/st_things/things_stack/framework/things_resource.c
+++ b/framework/src/st_things/things_stack/framework/things_resource.c
@@ -731,7 +731,7 @@ things_representation_s *things_create_representation_inst(void *rep_payload)
 	return rep;
 }
 
-things_resource_s *create_resource_inst_impl(void *requesthd, void *resourcehd, void *query, void *rep_payload)
+static things_resource_s *create_resource_inst_impl(OCRequestHandle requesthd, OCResourceHandle resourcehd, void *query, void *rep_payload)
 {
 	things_resource_s *res = (things_resource_s *) things_malloc(sizeof(things_resource_s));
 	if (NULL == res) {
@@ -841,7 +841,7 @@ things_resource_s *things_create_resource_inst(OCRequestHandle requesthd, OCReso
 	return res;
 }
 
-things_resource_s *clone_resource_inst(things_resource_s *pori)
+things_resource_s *things_clone_resource_inst(things_resource_s *pori)
 {
 	if (pori == NULL) {
 		return NULL;

--- a/framework/src/st_things/things_stack/framework/things_security_manager.c
+++ b/framework/src/st_things/things_stack/framework/things_security_manager.c
@@ -60,9 +60,9 @@ typedef enum {
 	OIC_SEC_INVALID_PARAM = 2
 } OICSecurityResult;
 
-#if __MIPS__
+#if defined(__MIPS__)
 #define STRING_SVR_DB_PATH "/data1/oic_svr_db_server.dat"
-#elif __TIZEN__
+#elif defined(__TIZEN__)
 #define STRING_SVR_DB_PATH "/opt/data/ocfData/oic_svr_db_server.dat"
 #else
 #define STRING_SVR_DB_PATH "./oic_svr_db_server.dat"
@@ -244,7 +244,7 @@ static OCStackResult seckey_setup(const char *filename, OicSecKey_t *key, OicEnc
 	}
 
 	if (encoding == OIC_ENCODING_UNKNOW) {
-		char *file_ext;
+		const char *file_ext;
 		int filename_len = strlen(filename);
 		file_ext = filename + filename_len;
 
@@ -493,9 +493,6 @@ static OCStackResult sm_secure_resource_check(OicUuid_t *device_id)
 
 static int get_mac_addr(unsigned char *p_id_buf, size_t p_id_buf_size, unsigned int *p_id_out_len)
 {
-	struct ifaddrs *ifaddr = NULL;
-	struct ifaddrs *ifa = NULL;
-
 	THINGS_LOG_D(TAG, "In %s", __func__);
 
 #ifdef __ST_THINGS_RTOS__
@@ -510,6 +507,9 @@ static int get_mac_addr(unsigned char *p_id_buf, size_t p_id_buf_size, unsigned 
 
 	snprintf((char *)p_id_buf, MAC_BUF_SIZE - 1, "%02X%02X%02X%02X%02X%02X", st_wifi_info.mac_address[0], st_wifi_info.mac_address[1], st_wifi_info.mac_address[2], st_wifi_info.mac_address[3], st_wifi_info.mac_address[4], st_wifi_info.mac_address[5]);
 #else
+	struct ifaddrs *ifaddr = NULL;
+	struct ifaddrs *ifa = NULL;
+
 	if (getifaddrs(&ifaddr) == -1) {
 		THINGS_LOG_E(TAG, "Failed to read network address information.");
 		return OIC_SEC_ERROR;
@@ -737,7 +737,7 @@ static OicSecKey_t primary_cert;
 static OicSecKey_t primary_key;
 
 //Samsung_OCF_RootCA.der
-const unsigned char g_regional_root_ca[] = {
+unsigned char g_regional_root_ca[] = {
 	0x30, 0x82, 0x02, 0x5D, 0x30, 0x82, 0x02, 0x01, 0xA0, 0x03, 0x02, 0x01, 0x02, 0x02, 0x01, 0x01, 0x30, 0x0C, 0x06, 0x08,
 	0x2A, 0x86, 0x48, 0xCE, 0x3D, 0x04, 0x03, 0x02, 0x05, 0x00, 0x30, 0x6B, 0x31, 0x28, 0x30, 0x26, 0x06, 0x03, 0x55, 0x04,
 	0x03, 0x13, 0x1F, 0x53, 0x61, 0x6D, 0x73, 0x75, 0x6E, 0x67, 0x20, 0x45, 0x6C, 0x65, 0x63, 0x74, 0x72, 0x6F, 0x6E, 0x69,
@@ -772,7 +772,7 @@ const unsigned char g_regional_root_ca[] = {
 };
 
 #ifdef CONFIG_ST_THINGS_STG_MODE
-const unsigned char g_regional_test_root_ca[] = {
+unsigned char g_regional_test_root_ca[] = {
 	0x30, 0x82, 0x02, 0x68, 0x30, 0x82, 0x02, 0x0C, 0xA0, 0x03, 0x02, 0x01, 0x02, 0x02, 0x01, 0x02, 0x30, 0x0C, 0x06, 0x08,
 	0x2A, 0x86, 0x48, 0xCE, 0x3D, 0x04, 0x03, 0x02, 0x05, 0x00, 0x30, 0x70, 0x31, 0x2D, 0x30, 0x2B, 0x06, 0x03, 0x55, 0x04,
 	0x03, 0x13, 0x24, 0x53, 0x61, 0x6D, 0x73, 0x75, 0x6E, 0x67, 0x20, 0x45, 0x6C, 0x65, 0x63, 0x74, 0x72, 0x6F, 0x6E, 0x69,
@@ -813,8 +813,10 @@ const unsigned char g_regional_test_root_ca[] = {
  *
  * NOTE : This API should be invoked after sm_generate_mac_based_device_id invoked.
  */
+#ifdef CONFIG_ST_THINGS_ARTIK_HW_CERT_KEY
 static bool g_b_init_key;
 static bool g_b_init_cert;
+#endif
 
 static OCStackResult save_signed_asymmetric_key(OicUuid_t *subject_uuid)
 {
@@ -835,7 +837,7 @@ static OCStackResult save_signed_asymmetric_key(OicUuid_t *subject_uuid)
 	}
 	THINGS_LOG_D(TAG, "Samsung_OCF_Test_RootCA.der saved w/ cred ID=%d", cred_id);
 #else
-	OCStackResult res = CredSaveTrustCertChain(subject_uuid, g_regional_root_ca, sizeof(g_regional_root_ca), OIC_ENCODING_DER, TRUST_CA, &cred_id);
+	OCStackResult res = CredSaveTrustCertChain(subject_uuid, (uint8_t *)g_regional_root_ca, sizeof(g_regional_root_ca), OIC_ENCODING_DER, TRUST_CA, &cred_id);
 	if (OC_STACK_OK != res) {
 		THINGS_LOG_E(TAG, "SRPCredSaveTrustCertChain #1 error");
 		return res;

--- a/framework/src/st_things/things_stack/framework/things_server_builder.c
+++ b/framework/src/st_things/things_stack/framework/things_server_builder.c
@@ -121,7 +121,7 @@ struct things_resource_s *create_resource(struct things_server_builder_s *builde
 		return NULL;
 	}
 
-	res = things_create_resource_inst(NULL, hd, NULL, NULL);
+	res = things_create_resource_inst(0, hd, NULL, NULL);
 
 	if (NULL == res) {
 		THINGS_LOG_E(TAG, "things_create_resource_inst is failed");
@@ -305,7 +305,7 @@ void deinit_builder(things_server_builder_s *builder)
 		pthread_cancel(g_thread_id_server);
 		pthread_join(g_thread_id_server, NULL);
 		pthread_detach(g_thread_id_server);
-		g_thread_id_server = NULL;
+		g_thread_id_server = 0;
 
 		// 1.    Need to unregister those registered resource in the Stack
 		// 2.    Free the payload of each resources

--- a/framework/src/st_things/things_stack/logging/things_logger.c
+++ b/framework/src/st_things/things_stack/logging/things_logger.c
@@ -37,7 +37,6 @@
 static const char *LEVEL[] __attribute__((unused)) = {
 	"DEBUG", "INFOR", "WARNING", "ERROR", "FATAL"
 };
-static char ts_buf[64] = { 0 };
 
 static pthread_mutex_t lock = PTHREAD_MUTEX_INITIALIZER;
 

--- a/framework/src/st_things/things_stack/port_tinyara.c
+++ b/framework/src/st_things/things_stack/port_tinyara.c
@@ -27,7 +27,6 @@
 #include <net/lwip/netif.h>
 #include <ocstack.h>
 #include "uuid/uuid.h"
-#include "securevirtualresourcetypes.h"
 
 #if CONFIG_NSOCKET_DESCRIPTORS > 0
 extern struct netif *g_netdevices;
@@ -46,29 +45,9 @@ void uuid_generate_random(uuid_t out)
 	out[8] = (out[8] & 0x3F) | 0x80;
 }
 
-#if defined(CONFIG_ST_THINGS_ARTIK_HW_CERT_KEY) && defined(CONFIG_TLS_WITH_SSS)
-static void uuid_get_from_artik(uuid_t out)
-{
-	OicUuid_t device_id;
-	unsigned char uuid_str[((UUID_LENGTH * 2) + 4 + 1)];
-	unsigned int uuid_len;
-
-	memset(uuid_str, 0, sizeof(uuid_str));
-	get_artik_crt_uuid(uuid_str, &uuid_len);
-
-	ConvertStrToUuid(uuid_str, &device_id);
-
-	memcpy(out, device_id.id, sizeof(uuid_t));
-}
-#endif
-
 void uuid_generate(uuid_t out)
 {
-#if defined(CONFIG_ST_THINGS_ARTIK_HW_CERT_KEY) && defined(CONFIG_TLS_WITH_SSS)
-	uuid_get_from_artik(out);
-#else
 	uuid_generate_random(out);
-#endif
 }
 
 void uuid_unparse_lower(const uuid_t uu, char *out)
@@ -114,10 +93,4 @@ error:
 unsigned int if_nametoindex(const char *ifname)
 {
 	return 0;					// TODO: Now supports only 1 device
-}
-
-const char *gai_strerror(int errcode)
-{
-	static const char *n_str = "null";
-	return n_str;
 }

--- a/framework/src/st_things/things_stack/utils/things_hashmap.c
+++ b/framework/src/st_things/things_stack/utils/things_hashmap.c
@@ -203,7 +203,7 @@ unsigned long hashmap_get_hashval(unsigned char *str)
 	unsigned long hash = 5381;
 	int c = 0;
 
-	while (c = *str++) {
+	while ((c = *str++)) {
 		hash = ((hash << 5) + hash) + c;	/* hash * 33 + c */
 	}
 

--- a/framework/src/st_things/things_stack/utils/things_hashmap.h
+++ b/framework/src/st_things/things_stack/utils/things_hashmap.h
@@ -51,4 +51,6 @@ extern void hashmap_delete(struct hashmap_s *);
 
 extern unsigned long hashmap_get_hashval(unsigned char *str);
 
+extern unsigned long* hashmap_get_keyset(struct hashmap_s *);
+
 #endif							//_THINGS_HASHMAP_H

--- a/framework/src/st_things/things_stack/utils/things_list.c
+++ b/framework/src/st_things/things_stack/utils/things_list.c
@@ -71,7 +71,7 @@ int list_size(list_s *p_list)
 //    THINGS_LOG_D(TAG, THINGS_FUNC_ENTRY);
 
 	pthread_mutex_lock(&(p_list->q_mutex));
-	int n_size = p_list->list_size;
+	int n_size = (int)p_list->list_size;
 	pthread_mutex_unlock(&(p_list->q_mutex));
 
 //    THINGS_LOG_D(TAG, THINGS_FUNC_EXIT);

--- a/framework/src/st_things/things_stack/utils/things_ping.c
+++ b/framework/src/st_things/things_stack/utils/things_ping.c
@@ -598,7 +598,7 @@ static void check_ping_thread(things_ping_s *ping)
 
 	if (get_mask(ping, PING_ST_ISCLOUD | PING_ST_SIGNIN | PING_ST_TCPCONNECT) == false) {
 		THINGS_LOG_D(TAG, "Not need things_ping_s, So, Terminate things_ping_s.(IP=%s)", ping->addr);
-		if ((ping = list->erase_by_key(list, is_ip_key_equal, ping->addr)) != NULL) {
+		if ((ping = list->erase_by_key(list, (key_compare)is_ip_key_equal, ping->addr)) != NULL) {
 			THINGS_LOG_D(TAG, "Erase node-element Success in List.");
 			terminate_things_ping_s(ping);
 		}
@@ -811,7 +811,7 @@ static int send_things_ping_request(things_ping_s *ping)
 
 	THINGS_LOG_D(TAG, "Send OCSendKeepAliveRequest request to %s.", hostAddr);
 	iotivity_api_lock();
-	result = OCSendKeepAliveRequest(&g_req_handle, hostAddr, payload, &cb);
+	result = OCSendKeepAliveRequest(&g_req_handle, hostAddr, (OCPayload *)payload, &cb);
 	iotivity_api_unlock();
 	if (result == OC_STACK_OK)
 	//if( (result= SendKeepAliveRequest(hostAddr, interval, &cb)) == OC_STACK_OK )

--- a/framework/src/st_things/things_stack/utils/things_rtos_util.c
+++ b/framework/src/st_things/things_stack/utils/things_rtos_util.c
@@ -33,7 +33,7 @@ typedef const struct thread_info_s {
 	int thread_size;
 } thread_info_s;
 
-static const thread_info_s things_stack_thread_name[THINGS_STACK_MAX_INDEX] = { {"THINGS_STACK_PING", 4 * 1024},	/*THINGS_STACK_PING_THREAD */
+static const thread_info_s things_stack_thread_name[THINGS_STACK_MAX_INDEX + 1] = { {"THINGS_STACK_PING", 4 * 1024},	/*THINGS_STACK_PING_THREAD */
 	{"THINGS_STACK_RESET", 4 * 1024},		/*THINGS_STACK_RESETLOOP_THREAD */
 	{"THINGS_STACK_CLOUD_CONNECT", 4 * 1024},	/*THINGS_STACK_CICONNETION_INIT_THREAD */
 	{"THINGS_STACK_CICONN_WAIT", 6 * 1024},	/*THINGS_STACK_CICONNETION_WAIT_THREAD */
@@ -49,7 +49,7 @@ static const thread_info_s things_stack_thread_name[THINGS_STACK_MAX_INDEX] = { 
 	{"THINGS_STACK_MAX_INDEX", 8 * 1024}		/*THINGS_STACK_MAX_INDEX */
 };
 
-char *get_pthread_attr_details(things_stack_thread_name_e e_thread_name, pthread_attr_t *pstThread)
+const char *get_pthread_attr_details(things_stack_thread_name_e e_thread_name, pthread_attr_t *pstThread)
 {
 	if (e_thread_name >= THINGS_STACK_MAX_INDEX) {
 		e_thread_name = THINGS_STACK_MAX_INDEX;
@@ -72,7 +72,7 @@ char *get_pthread_attr_details(things_stack_thread_name_e e_thread_name, pthread
 int pthread_create_rtos(FAR pthread_t *thread, FAR const pthread_attr_t *attr, pthread_startroutine_t start_routine, pthread_addr_t arg, things_stack_thread_name_e e_thread_name)
 {
 	pthread_attr_t st_ptr;
-	char *pch_tname = get_pthread_attr_details(e_thread_name, &st_ptr);
+	char *pch_tname = (char *)get_pthread_attr_details(e_thread_name, &st_ptr);
 	int ret = pthread_create(thread, &st_ptr, start_routine, (void *)arg);
 	if (ret == 0) {
 		pthread_setname_np(*thread, pch_tname);

--- a/framework/src/st_things/things_stack/utils/things_wait_handler.c
+++ b/framework/src/st_things/things_stack/utils/things_wait_handler.c
@@ -220,7 +220,7 @@ unsigned long int things_create_time_out_process(OCDoHandle hadler, things_check
 		return 0;
 	}
 
-	pTimeOutManager->gthreadId = NULL;
+	pTimeOutManager->gthreadId = (pthread_t)0;
 	pTimeOutManager->handleVal = hadler;
 	pTimeOutManager->funcName = CallFunc;
 	if (timeOut == NULL) {


### PR DESCRIPTION
1. Remove warning message from St things framework which is generated
   at build time. 
          commit-id: 5d3e7b5822eedb85e2b2aaebc3bf9c1cb76d8246
2. Remove warning message from Iotivity which is generated at build
   time. 
          commit-id: 19e5c57f5f8c462fe5fb84df0402934212dcfffc
3. Fix prototype warnings.
4. Fix unused-variable type warnings.
5. Mismatch function argument type warnings.
6. Shadows variable declaration and cast type warnings.

Signed-off-by: harish191 <harish.191@samsung.com>
Signed-off-by: hyunjun2.kim <hyunjun2.kim@samsung.com>