### PR TITLE
framework/st_things: fix bug what mismatch with ST Things wifi description guide.

### DIFF
--- a/framework/src/st_things/things_stack/easy-setup/easysetup_manager.c
+++ b/framework/src/st_things/things_stack/easy-setup/easysetup_manager.c
@@ -224,7 +224,7 @@ esm_result_e esm_init_easysetup(int restart_flag, things_server_builder_s *serve
 		if (wifiIntf & 0x08) {
 			wifi_mode[mode_count++] = WiFi_11N;
 		}
-		if (wifiIntf & 0x10) {
+		if (wifiIntf & 0x16) {
 			wifi_mode[mode_count++] = WiFi_11AC;
 		}
 	}


### PR DESCRIPTION
It uses predefined key(0x10) for wifi ac. but is was wrong.
Regarding SmartThings Spec., Things SDK should use 0x16.

ref :
    https://developer.tizen.org/development/iot-preview/iot-apis/things-sdk-api/device-definition