### PR TITLE
Ramdump

### DIFF
--- a/tools/ramdump/ramdump.sh
+++ b/tools/ramdump/ramdump.sh
@@ -28,14 +28,16 @@ gcc ramdump_tool.c -o ramdump
 # Run Ramdump Tool
 RAMDUMP_FILE=./ramdump_0x*.bin
 rm -f ${RAMDUMP_FILE}
-sudo ./ramdump /dev/ttyUSB1
-echo "copying $(basename ${RAMDUMP_FILE}) to  $(readlink -f ${BUILD_BIN_PATH})"
+ok=true
+sudo ./ramdump /dev/ttyUSB1 || ok=false
 
+if "$ok"; then
+echo "\nCopying..."
+find ./ -iname "ramdump_0x*.bin"
+echo "to  $(readlink -f ${BUILD_BIN_PATH})\n"
 cp ${RAMDUMP_FILE} ${BUILD_BIN_PATH}
-
+fi
 
 # clean up
 rm -f ramdump
-
 #end
-

--- a/tools/ramdump/ramdump_protocol.txt
+++ b/tools/ramdump/ramdump_protocol.txt
@@ -4,18 +4,24 @@ RAMDUMP PROTOCOL :
 HOST  ------------> TARGET
 HOST  <-----------  TARGET
 
-1. TARGET will be waiting for Handshake string from HOST application.
-2. HOST will send handshake string to TARGET.
-3. TARGET will receive handshake string.
-4. TARGET will check if the handshake string is the expected one,
+1.  TARGET will be waiting for Handshake string from HOST application.
+2.  HOST will send handshake string to TARGET.
+3.  TARGET will receive handshake string.
+4.  TARGET will check if the handshake string is the expected one,
 	if success, TARGET will send character 'A' as acknowledge.
 	if failure, TARGET will send character 'N' as negative acknowlede.
-5. TARGET will send 4 bytes holding RAMDUMP start address.
-6. HOST will receive 4 bytes RAMDUMP start address.
-7. TARGET will send 4 bytes holding RAMDUMP size.
-8. HOST will receive 4 bytes RAMDUMP size.
-9. TARGET will send RAMDUMP size bytes in a loop.
-10. HOST will receive RAMDUMP size bytes in a loop untill all "size" bytes received.
+5.  TARGET will send 1 byte holding number of memory regions.
+6.  HOST will receive1 byte holding number of memory regions.
+7.  TARGET will send 4 bytes holding RAMDUMP start address for all memory regions.
+8.  HOST will receive 4 bytes RAMDUMP start address for all memory regions.
+9.  TARGET will send 4 bytes holding RAMDUMP size for all memory regions.
+10. HOST will receive 4 bytes RAMDUMP size for all memory regions.
+11. TARGET will send 1 byte holding heap index for all memory regions.
+12. HOST will receive 1 byte holding heap index for all memory regions.
+13. HOST will send 1 byte holding number of memory regions to be dumped by target.
+14. TARGET will receive 1 byte holding number of memory regions to be dumped.
+15. TARGET will send RAMDUMP size bytes in a loop for each memory region to be dumped.
+16. HOST will receive RAMDUMP size bytes in a loop untill all "size" bytes received for each memory region to be dumped.
 
 Note :
 Handshake string is "RAMDUMP".


### PR DESCRIPTION
Update UART ramdump to memory region selective ramdump & its support for artik05x.
This patch updates the ramdump tool which dumps the whole memory together.
The updated tool will dump memory region wise based on user's input as below:
        Please enter desired ramdump option as below:
                1 for ALL
                2 for Region 0
                25 for Region 0 & 3 ...
Each region will be dumped into a seperate bin file of respective region size.
