### PR TITLE
external/mbedtls: update mbedtls patch

### DIFF
--- a/external/mbedtls/pk_wrap.c
+++ b/external/mbedtls/pk_wrap.c
@@ -623,9 +623,6 @@ int hw_rsa_sign_wrap(mbedtls_rsa_context *ctx, mbedtls_md_type_t md_alg, const u
 	case MBEDTLS_MD_SHA1:
 		rsa_sign.alg_type = SHA1_160 | (padding ^ 0x1);	/* 0x110X */
 		break;
-	case MBEDTLS_MD_SHA224:
-		rsa_sign.alg_type = SHA2_224 | (padding ^ 0x1);	/* 0x220X */
-		break;
 	case MBEDTLS_MD_SHA256:
 		rsa_sign.alg_type = SHA2_256 | (padding ^ 0x1);	/* 0x230X */
 		break;
@@ -899,9 +896,6 @@ int hw_rsa_verify_wrap(void *ctx, mbedtls_md_type_t md_alg, const unsigned char 
 		goto cleanup;
 	case MBEDTLS_MD_SHA1:
 		rsa_sign.alg_type = SHA1_160 | (padding ^ 0x1);	/* 0x110X */
-		break;
-	case MBEDTLS_MD_SHA224:
-		rsa_sign.alg_type = SHA2_224 | (padding ^ 0x1);	/* 0x220X */
 		break;
 	case MBEDTLS_MD_SHA256:
 		rsa_sign.alg_type = SHA2_256 | (padding ^ 0x1);	/* 0x230X */

--- a/external/mbedtls/ssl_tls.c
+++ b/external/mbedtls/ssl_tls.c
@@ -3808,11 +3808,6 @@ defined(MBEDTLS_SSL_PROTO_TLS1_2)
 			ca_crl = ssl->conf->ca_crl;
 		}
 
-		if (ca_chain == NULL) {
-			MBEDTLS_SSL_DEBUG_MSG(1, ("got no CA chain"));
-			return (MBEDTLS_ERR_SSL_CA_CHAIN_REQUIRED);
-		}
-
 		/*
 		 * Main check: verify certificate
 		 */
@@ -3832,6 +3827,7 @@ defined(MBEDTLS_SSL_PROTO_TLS1_2)
 
 			/* If certificate uses an EC key, make sure the curve is OK */
 			if (mbedtls_pk_can_do(pk, MBEDTLS_PK_ECKEY) && mbedtls_ssl_check_curve(ssl, mbedtls_pk_ec(*pk)->grp.id) != 0) {
+				ssl->session_negotiate->verify_result |= MBEDTLS_X509_BADCERT_BAD_KEY;
 				MBEDTLS_SSL_DEBUG_MSG(1, ("bad certificate (EC key curve)"));
 				if (ret == 0) {
 					ret = MBEDTLS_ERR_SSL_BAD_HS_CERTIFICATE;
@@ -3847,9 +3843,24 @@ defined(MBEDTLS_SSL_PROTO_TLS1_2)
 			}
 		}
 
-		if (authmode == MBEDTLS_SSL_VERIFY_OPTIONAL) {
+		/*
+ 		 * mbedtls_x509_crt_verify_with_profile is supposed to report a
+ 		 * verification failure through MBEDTLS_ERR_X509_CERT_VERIFY_FAILED,
+ 		 * with details encoded in the verification flags. All other kinds
+ 		 * of error codes, including those from the user provided f_vrfy
+ 		 * functions, are treated as fatal and lead to a failure of
+ 		 * ssl_parse_certificate even if verification was optional.
+ 		 */
+ 		if (authmode == MBEDTLS_SSL_VERIFY_OPTIONAL &&
+ 			(ret == MBEDTLS_ERR_X509_CERT_VERIFY_FAILED ||
+ 			ret == MBEDTLS_ERR_SSL_BAD_HS_CERTIFICATE)) {
 			ret = 0;
 		}
+
+		if (ca_chain == NULL && authmode == MBEDTLS_SSL_VERIFY_REQUIRED) {
+ 			MBEDTLS_SSL_DEBUG_MSG(1, ("got no CA chain"));
+ 			ret = MBEDTLS_ERR_SSL_CA_CHAIN_REQUIRED;
+ 		}
 	}
 
 	MBEDTLS_SSL_DEBUG_MSG(2, ("<= parse certificate"));

--- a/external/mbedtls/x509_crl.c
+++ b/external/mbedtls/x509_crl.c
@@ -487,14 +487,14 @@ int mbedtls_x509_crl_parse(mbedtls_x509_crl *chain, const unsigned char *buf, si
 			buf += use_len;
 
 			if ((ret = mbedtls_x509_crl_parse_der(chain, pem.buf, pem.buflen)) != 0) {
+				mbedtls_pem_free(&pem);
 				return (ret);
 			}
-
-			mbedtls_pem_free(&pem);
 		} else if (ret != MBEDTLS_ERR_PEM_NO_HEADER_FOOTER_PRESENT) {
 			mbedtls_pem_free(&pem);
 			return (ret);
 		}
+		mbedtls_pem_free(&pem);
 	}
 	/* In the PEM case, buflen is 1 at the end, for the terminated NULL byte.
 	 * And a valid CRL cannot be less than 1 byte anyway. */

--- a/os/arch/arm/src/s5j/sss/isp_define.h
+++ b/os/arch/arm/src/s5j/sss/isp_define.h
@@ -30,7 +30,6 @@
 #define HMAC                (0x1)
 
 #define SHA1_160            (((SHA1 << 4) | (HASH160)) << 8)  //0x00001100
-#define SHA2_224            (((SHA2 << 4) | (HASH224)) << 8)  //0x00002200
 #define SHA2_256            (((SHA2 << 4) | (HASH256)) << 8)  //0x00002300
 #define SHA2_384            (((SHA2 << 4) | (HASH384)) << 8)  //0x00002400
 #define SHA2_512            (((SHA2 << 4) | (HASH512)) << 8)  //0x00002500


### PR DESCRIPTION
### 1. artik05x: Remove SHA2_224 hw support
sssfw does not support SHA2_224, but there is SHA2_224 in source code.

### 2. mbedtls : memory leak (x509_crl)
When fail to parse crl, do not free pem resource.

reference :
https://www.bountysource.com/issues/40064024-memory-leak-in-mbedtls_x509_crl_parse

### 3. net/tls: Fix implementation of VERIFY_OPTIONAL verification mode
This commit changes the behaviour of mbedtls_ssl_parse_certificate
to make the two authentication modes MBEDTLS_SSL_VERIFY_REQUIRED and
MBEDTLS_SSL_VERIFY_OPTIONAL be in the following relationship:

    Mode == MBEDTLS_SSL_VERIFY_REQUIRED <=> Mode == MBEDTLS_SSL_VERIFY_OPTIONAL + check verify result

Also, it changes the behaviour to perform the certificate chain
verification even if the trusted CA chain is empty. Previously, the
function failed in this case, even when using optional verification,
which was brought up in Samsung#864.
(Samsung#864 ARMmbed/mbedtls#864)
