### PR TITLE
os/fs: Fix typos in comments

### DIFF
--- a/os/fs/inode/fs_inode.c
+++ b/os/fs/inode/fs_inode.c
@@ -77,9 +77,9 @@
 /* Implements a re-entrant mutex for inode access.  This must be re-entrant
  * because there can be cycles.  For example, it may be necessary to destroy
  * a block driver inode on umount() after a removable block device has been
- * removed.  In that case umount() hold the inode semaphore, but the block
+ * removed.  In that case umount() holds the inode semaphore, but the block
  * driver may callback to unregister_blockdriver() after the un-mount,
- * requiring the seamphore again.
+ * requiring the semaphore again.
  */
 
 struct inode_sem_s {
@@ -125,10 +125,10 @@ static int _inode_compare(FAR const char *fname, FAR struct inode *node)
 	}
 
 	for (;;) {
-		/* At end of node name? */
+		/* At the end of node name? */
 
 		if (!*nname) {
-			/* Yes.. also end of find name? */
+			/* Yes.. also the end of find name? */
 
 			if (!*fname || *fname == '/') {
 				/* Yes.. return match */
@@ -141,7 +141,7 @@ static int _inode_compare(FAR const char *fname, FAR struct inode *node)
 			}
 		}
 
-		/* At end of find name? */
+		/* At the end of find name? */
 
 		else if (!*fname || *fname == '/') {
 			/* Yes... return find name < node name */
@@ -157,7 +157,7 @@ static int _inode_compare(FAR const char *fname, FAR struct inode *node)
 			return -1;
 		}
 
-		/* Not at the end of either string and all of the
+		/* Not at the end of either string or all of the
 		 * characters still match.  keep looking.
 		 */
 
@@ -227,7 +227,7 @@ void inode_semtake(void)
 
 	else {
 		while (sem_wait(&g_inode_sem.sem) != 0) {
-			/* The only case that an error should occr here is if
+			/* The only case that an error should occur here is that
 			 * the wait was awakened by a signal.
 			 */
 
@@ -295,7 +295,7 @@ FAR struct inode *inode_search(FAR const char **path, FAR struct inode **peer, F
 		/* Case 1:  The name is less than the name of the node.
 		 * Since the names are ordered, these means that there
 		 * is no peer node with this name and that there can be
-		 * no match in the fileystem.
+		 * no match in the filesystem.
 		 */
 
 		if (result < 0) {
@@ -319,7 +319,7 @@ FAR struct inode *inode_search(FAR const char **path, FAR struct inode **peer, F
 			/* Now there are three more possibilities:
 			 *   (1) This is the node that we are looking for or,
 			 *   (2) The node we are looking for is "below" this one.
-			 *   (3) This node is a mountpoint and will absorb all request
+			 *   (3) This node is a mountpoint and will absorb all requests
 			 *       below this one
 			 */
 

--- a/os/fs/inode/fs_inodereserve.c
+++ b/os/fs/inode/fs_inodereserve.c
@@ -157,14 +157,14 @@ static void inode_insert(FAR struct inode *node, FAR struct inode *peer, FAR str
  * Name: select_last_inode
  ****************************************************************************/
 
-static void* select_last_inode(FAR const char *name)
+static void *select_last_inode(FAR const char *name)
 {
 	const char *tmp = name;
 	void *last = NULL;
 
 	while (*tmp && *tmp != '\0') {
 		if (*tmp == '/') {
-			last = (void*)tmp;
+			last = (void *)tmp;
 		}
 		tmp++;
 	}
@@ -230,7 +230,7 @@ int inode_reserve(FAR const char *path, FAR struct inode **inode)
 		return -EEXIST;
 	}
 
-	/* Now we now where to insert the subtree */
+	/* Now we know the exact position to insert the subtree */
 
 	for (;;) {
 		FAR struct inode *node;

--- a/os/fs/smartfs/smartfs.h
+++ b/os/fs/smartfs/smartfs.h
@@ -297,7 +297,7 @@ struct smartfs_entry_s {
 	uint32_t datlen;			/* Length of inode data */
 };
 
-/* This is an on-device representation of the SMART inode it esists on
+/* This is an on-device representation of the SMART inode which exists on
  * the FLASH.
  */
 
@@ -369,7 +369,7 @@ struct smartfs_mountpt_s {
 	struct smartfs_mountpt_s *fs_next;	/* Pointer to next SMART filesystem */
 #endif
 	FAR struct inode *fs_blkdriver;	/* Our underlying block device */
-	sem_t *fs_sem;			/* Used to assure thread-safe access */
+	sem_t *fs_sem;				/* Used to assure thread-safe access */
 	FAR struct smartfs_ofile_s
 			*fs_head;					/* A singly-linked list of open files */
 	bool fs_mounted;			/* true: The file system is ready */
@@ -425,8 +425,8 @@ struct smartfs_logging_entry_s {
 								 */
 
 	uint8_t crc16[2];			/*      For CRC value to check validation of journal entry
-							     *      First 8bits for entry, next 8bits for entry + data
-							     */
+								 *      First 8bits for entry, next 8bits for entry + data
+								 */
 
 	uint16_t curr_sector;		/*      Transaction type : Use
 								 *        1) T_WRITE  : sector number of sector to be written.
@@ -472,14 +472,14 @@ struct smartfs_logging_entry_s {
   This structure provides the transaction manager for all journaling operations
 */
 struct journal_transaction_manager_s {
-	bool enabled;               /* State value to check journaling enabled or not */
-	int8_t jarea;				/* 0 or 1. Specifies which journal area is usable */
+	bool enabled;				/* State value to check whether journaling is enabled or not */
+	int8_t jarea;				/* 0 or 1. Specify which journal area is usable */
 	uint16_t sector;			/* Sector number where next logging entry has to be written */
 	uint16_t offset;			/* Offset in the sector above */
 	uint16_t availbytes;		/* Total space in a logging sector to write entries */
-	uint8_t *buffer;			/* buffer to hold logging entry header and data */
-	uint8_t *active_sectors;	/* map to mark sectors which are written but not yet synced */
-	struct active_write_node_s *list;	/* linked list to hold information about writes which need sync */
+	uint8_t *buffer;			/* Buffer to hold logging entry header and data */
+	uint8_t *active_sectors;	/* Map to mark sectors which are written but not yet synced */
+	struct active_write_node_s *list;	/* Linked list to hold information about writes which need sync */
 };
 #endif
 /****************************************************************************


### PR DESCRIPTION
- Weird expressions and words are modified.
- cformatter is applied.