### PR TITLE
os/tools/mkexport.sh: Change exported library name to tizenrt

### DIFF
--- a/os/tools/mkexport.sh
+++ b/os/tools/mkexport.sh
@@ -141,7 +141,7 @@ fi
 
 # Create the export directory
 
-EXPORTSUBDIR="nuttx-export${VERSION}"
+EXPORTSUBDIR="tizenrt-export${VERSION}"
 EXPORTDIR="${TOPDIR}/${EXPORTSUBDIR}"
 
 # If the export directory already exists, then remove it and create a new one
@@ -361,15 +361,15 @@ for lib in ${LIBLIST}; do
 		fi
 
 		# Rename each object file (to avoid collision when they are combined)
-		# and add the file to libnuttx
+		# and add the file to libtizenrt
 
 		for file in `ls`; do
 			mv "${file}" "${shortname}-${file}"
 			if [ "X${WINTOOL}" = "Xy" ]; then
-				WLIB=`cygpath -w "${EXPORTDIR}/libs/libnuttx${LIBEXT}"`
+				WLIB=`cygpath -w "${EXPORTDIR}/libs/libtizenrt${LIBEXT}"`
 				${AR} rcs "${WLIB}" "${shortname}-${file}"
 			else
-				${AR} rcs "${EXPORTDIR}/libs/libnuttx${LIBEXT}" "${shortname}-${file}"
+				${AR} rcs "${EXPORTDIR}/libs/libtizenrt${LIBEXT}" "${shortname}-${file}"
 			fi
 		done
 


### PR DESCRIPTION
"make export" makes TizenRT as a library, but there is a incorrect naming rule.
The output file name is tizenrt-export-x.y.zip.(x, y is a version for TizenRT)