### PR TITLE
framework/media: Rename DataSource interface

### DIFF
--- a/apps/examples/mediaplayer/BufferInputDataSource.cpp
+++ b/apps/examples/mediaplayer/BufferInputDataSource.cpp
@@ -29,7 +29,7 @@ BufferInputDataSource::BufferInputDataSource()
 
 }
 
-bool BufferInputDataSource::isPrepare()
+bool BufferInputDataSource::isPrepared()
 {
 	return mFp && mSrcBuf && mSrcSize;
 }

--- a/apps/examples/mediaplayer/BufferInputDataSource.h
+++ b/apps/examples/mediaplayer/BufferInputDataSource.h
@@ -27,7 +27,7 @@ class BufferInputDataSource : public media::stream::InputDataSource
 public:
 	BufferInputDataSource();
 	virtual ~BufferInputDataSource() = default;
-	bool isPrepare() override;
+	bool isPrepared() override;
 	bool open() override;
 	bool close() override;
 	ssize_t read(unsigned char *buf, size_t size) override;

--- a/apps/examples/testcase/ta_tc/media/itc/itc_media_fileinputdatasource.cpp
+++ b/apps/examples/testcase/ta_tc/media/itc/itc_media_fileinputdatasource.cpp
@@ -180,36 +180,36 @@ static void itc_media_FileInputDataSource_close_n(void)
 }
 
 /**
-* @testcase         itc_media_FileInputDataSource_isPrepare_p
-* @brief            open, isPrepare and close for FileInputDataSource
-* @scenario         open, isPrepare and close and check its validation
-* @apicovered       open, close, isPrepare
+* @testcase         itc_media_FileInputDataSource_isPrepared_p
+* @brief            open, isPrepared and close for FileInputDataSource
+* @scenario         open, isPrepared and close and check its validation
+* @apicovered       open, close, isPrepared
 * @precondition     NA
 * @postcondition    NA
 */
-static void itc_media_FileInputDataSource_isPrepare_p(void)
+static void itc_media_FileInputDataSource_isPrepared_p(void)
 {
 	media::stream::FileInputDataSource source(file_path);
 	TC_ASSERT_EQ("open", source.open(), 1);
-	TC_ASSERT_EQ_CLEANUP("isPrepare", source.isPrepare(), 1, source.close());
+	TC_ASSERT_EQ_CLEANUP("isPrepared", source.isPrepared(), 1, source.close());
 	TC_ASSERT_EQ("close", source.close(), 1);
 	TC_SUCCESS_RESULT();
 }
 
 /**
-* @testcase         itc_media_FileInputDataSource_isPrepare_n
-* @brief            open, close and isPrepare for FileInputDataSource
-* @scenario         open, close and isPrepare and  check its validation
-* @apicovered       open, close, isPrepare
+* @testcase         itc_media_FileInputDataSource_isPrepared_n
+* @brief            open, close and isPrepared for FileInputDataSource
+* @scenario         open, close and isPrepared and  check its validation
+* @apicovered       open, close, isPrepared
 * @precondition     NA
 * @postcondition    NA
 */
-static void itc_media_FileInputDataSource_isPrepare_n(void)
+static void itc_media_FileInputDataSource_isPrepared_n(void)
 {
 	media::stream::FileInputDataSource source(file_path);
 	TC_ASSERT_EQ("open", source.open(), 1);
 	TC_ASSERT_EQ("close", source.close(), 1);
-	TC_ASSERT_EQ("isPrepare", source.isPrepare(), 0);
+	TC_ASSERT_EQ("isPrepared", source.isPrepared(), 0);
 	TC_SUCCESS_RESULT();
 }
 
@@ -257,8 +257,8 @@ int itc_media_FileInputDataSource_main(void)
 		itc_media_FileInputDataSource_open_close_p();
 		itc_media_FileInputDataSource_open_n();
 		itc_media_FileInputDataSource_close_n();
-		itc_media_FileInputDataSource_isPrepare_p();
-		itc_media_FileInputDataSource_isPrepare_n();
+		itc_media_FileInputDataSource_isPrepared_p();
+		itc_media_FileInputDataSource_isPrepared_n();
 		itc_media_FileInputDataSource_read_p();
 		itc_media_FileInputDataSource_read_n();
 	}

--- a/apps/examples/testcase/ta_tc/media/itc/itc_media_fileoutputdatasource.cpp
+++ b/apps/examples/testcase/ta_tc/media/itc/itc_media_fileoutputdatasource.cpp
@@ -169,36 +169,36 @@ static void itc_media_FileOutputDataSource_close_n(void)
 }
 
 /**
-* @testcase         itc_media_FileOutputDataSource_isPrepare_p
-* @brief            open, isPrepare and close for FileOutputDataSource
-* @scenario         open, isPrepare and close and check its validation
-* @apicovered       open, close, isPrepare
+* @testcase         itc_media_FileOutputDataSource_isPrepared_p
+* @brief            open, isPrepared and close for FileOutputDataSource
+* @scenario         open, isPrepared and close and check its validation
+* @apicovered       open, close, isPrepared
 * @precondition     NA
 * @postcondition    NA
 */
-static void itc_media_FileOutputDataSource_isPrepare_p(void)
+static void itc_media_FileOutputDataSource_isPrepared_p(void)
 {
 	media::stream::FileOutputDataSource source(file_path);
 	TC_ASSERT_EQ("open", source.open(), 1);
-	TC_ASSERT_EQ_CLEANUP("isPrepare", source.isPrepare(), 1, source.close());
+	TC_ASSERT_EQ_CLEANUP("isPrepared", source.isPrepared(), 1, source.close());
 	TC_ASSERT_EQ("close", source.close(), 1);
 
 	TC_SUCCESS_RESULT();
 }
 /**
-* @testcase         itc_media_FileOutputDataSource_isPrepare_n
-* @brief            open, close and isPrepare for FileOutputDataSource
-* @scenario         open, close and isPrepare and  check its validation
-* @apicovered       open, close, isPrepare
+* @testcase         itc_media_FileOutputDataSource_isPrepared_n
+* @brief            open, close and isPrepared for FileOutputDataSource
+* @scenario         open, close and isPrepared and  check its validation
+* @apicovered       open, close, isPrepared
 * @precondition     NA
 * @postcondition    NA
 */
-static void itc_media_FileOutputDataSource_isPrepare_n(void)
+static void itc_media_FileOutputDataSource_isPrepared_n(void)
 {
 	media::stream::FileOutputDataSource source(file_path);
 	TC_ASSERT_EQ("open", source.open(), 1);
 	TC_ASSERT_EQ("close", source.close(), 1);
-	TC_ASSERT_EQ("isPrepare", source.isPrepare(), 0);
+	TC_ASSERT_EQ("isPrepared", source.isPrepared(), 0);
 
 	TC_SUCCESS_RESULT();
 }
@@ -252,8 +252,8 @@ int itc_media_fileoutputdatasource_main(void)
 	itc_media_FileOutputDataSource_open_close_p();
 	itc_media_FileOutputDataSource_open_n();
 	itc_media_FileOutputDataSource_close_n();
-	itc_media_FileOutputDataSource_isPrepare_p();
-	itc_media_FileOutputDataSource_isPrepare_n();
+	itc_media_FileOutputDataSource_isPrepared_p();
+	itc_media_FileOutputDataSource_isPrepared_n();
 	itc_media_FileOutputDataSource_write_p();
 	itc_media_FileOutputDataSource_write_n();
 

--- a/apps/examples/testcase/ta_tc/media/utc/gmock/utc_media_fileinputdatasource.cpp
+++ b/apps/examples/testcase/ta_tc/media/utc/gmock/utc_media_fileinputdatasource.cpp
@@ -85,18 +85,18 @@ TEST_F(FileInputDataSourceTest, closeTwice)
 	EXPECT_FALSE(source->close());
 }
 
-TEST_F(FileInputDataSourceTest, isPrepare)
+TEST_F(FileInputDataSourceTest, isPrepared)
 {
 	source->open();
 
-	EXPECT_TRUE(source->isPrepare());
+	EXPECT_TRUE(source->isPrepared());
 
 	source->close();
 }
 
 TEST_F(FileInputDataSourceTest, isPrepareWithoutOpen)
 {
-	EXPECT_FALSE(source->isPrepare());
+	EXPECT_FALSE(source->isPrepared());
 }
 
 TEST_F(FileInputDataSourceTest, read)

--- a/apps/examples/testcase/ta_tc/media/utc/gmock/utc_media_fileoutputdatasource.cpp
+++ b/apps/examples/testcase/ta_tc/media/utc/gmock/utc_media_fileoutputdatasource.cpp
@@ -106,7 +106,7 @@ TEST_F(FileOutputDataSourceTest, OpenFileNegative)
 TEST_F(FileOutputDataSourceTest, CloseFilePositiveWithIsPrepare)
 {
 	dataSource->close();
-	bool ret = dataSource->isPrepare();
+	bool ret = dataSource->isPrepared();
 
 	EXPECT_EQ(ret, false);
 }

--- a/apps/examples/testcase/ta_tc/media/utc/utc_media_bufferoutputdatasource.cpp
+++ b/apps/examples/testcase/ta_tc/media/utc/utc_media_bufferoutputdatasource.cpp
@@ -133,20 +133,20 @@ static void utc_media_BufferOutputDataSource_close_p(void)
 	TC_SUCCESS_RESULT();
 }
 
-static void utc_media_BufferOutputDataSource_isPrepare_p(void)
+static void utc_media_BufferOutputDataSource_isPrepared_p(void)
 {
 	BufferOutputDataSource dataSource;
 
 	dataSource.open();
-	TC_ASSERT_EQ("utc_media_BufferOutputDataSource_isPrepare", dataSource.isPrepare(), true);
+	TC_ASSERT_EQ("utc_media_BufferOutputDataSource_isPrepared", dataSource.isPrepared(), true);
 	dataSource.close();
 	TC_SUCCESS_RESULT();
 }
 
-static void utc_media_BufferOutputDataSource_isPrepare_n(void)
+static void utc_media_BufferOutputDataSource_isPrepared_n(void)
 {
 	BufferOutputDataSource dataSource;
-	TC_ASSERT_EQ("utc_media_BufferOutputDataSource_isPrepare", dataSource.isPrepare(), false);
+	TC_ASSERT_EQ("utc_media_BufferOutputDataSource_isPrepared", dataSource.isPrepared(), false);
 	TC_SUCCESS_RESULT();
 }
 
@@ -196,8 +196,8 @@ int utc_media_bufferoutputdatasource_main(void)
 
 	utc_media_BufferOutputDataSource_close_p();
 
-	utc_media_BufferOutputDataSource_isPrepare_p();
-	utc_media_BufferOutputDataSource_isPrepare_n();
+	utc_media_BufferOutputDataSource_isPrepared_p();
+	utc_media_BufferOutputDataSource_isPrepared_n();
 
 	utc_media_BufferOutputDataSource_write_p();
 	utc_media_BufferOutputDataSource_write_n();

--- a/apps/examples/testcase/ta_tc/media/utc/utc_media_fileinputdatasource.cpp
+++ b/apps/examples/testcase/ta_tc/media/utc/utc_media_fileinputdatasource.cpp
@@ -166,22 +166,22 @@ static void utc_media_FileInputDataSource_close_n(void)
 	TC_SUCCESS_RESULT();
 }
 
-static void utc_media_FileInputDataSource_isPrepare_p(void)
+static void utc_media_FileInputDataSource_isPrepared_p(void)
 {
 	media::stream::FileInputDataSource source(dummyfilepath);
 	source.open();
 
-	TC_ASSERT_EQ("utc_media_FileInputDataSource_isPrepare", source.isPrepare(), true);
+	TC_ASSERT_EQ("utc_media_FileInputDataSource_isPrepared", source.isPrepared(), true);
 
 	source.close();
 	TC_SUCCESS_RESULT();
 }
 
-static void utc_media_FileInputDataSource_isPrepare_n(void)
+static void utc_media_FileInputDataSource_isPrepared_n(void)
 {
 	media::stream::FileInputDataSource source(dummyfilepath);
 
-	TC_ASSERT_EQ("utc_media_FileInputDataSource_isPrepare", source.isPrepare(), false);
+	TC_ASSERT_EQ("utc_media_FileInputDataSource_isPrepared", source.isPrepared(), false);
 
 	TC_SUCCESS_RESULT();
 }
@@ -236,8 +236,8 @@ int utc_media_FileInputDataSource_main(void)
 	utc_media_FileInputDataSource_close_p();
 	utc_media_FileInputDataSource_close_n();
 
-	utc_media_FileInputDataSource_isPrepare_p();
-	utc_media_FileInputDataSource_isPrepare_n();
+	utc_media_FileInputDataSource_isPrepared_p();
+	utc_media_FileInputDataSource_isPrepared_n();
 
 	utc_media_FileInputDataSource_read_p();
 	utc_media_FileInputDataSource_read_n();

--- a/apps/examples/testcase/ta_tc/media/utc/utc_media_fileoutputdatasource.cpp
+++ b/apps/examples/testcase/ta_tc/media/utc/utc_media_fileoutputdatasource.cpp
@@ -152,19 +152,19 @@ static void utc_media_FileOutputDataSource_close_n(void)
 	TC_SUCCESS_RESULT();
 }
 
-static void utc_media_FileOutputDataSource_isPrepare_p(void)
+static void utc_media_FileOutputDataSource_isPrepared_p(void)
 {
 	FileOutputDataSource dataSource(filePath);
 	dataSource.open();
-	TC_ASSERT_EQ("utc_media_FileOutputDataSource_isPrepare", dataSource.isPrepare(), true);
+	TC_ASSERT_EQ("utc_media_FileOutputDataSource_isPrepared", dataSource.isPrepared(), true);
 	dataSource.close();
 	TC_SUCCESS_RESULT();
 }
 
-static void utc_media_FileOutputDataSource_isPrepare_n(void)
+static void utc_media_FileOutputDataSource_isPrepared_n(void)
 {
 	FileOutputDataSource dataSource(filePath);
-	TC_ASSERT_EQ("utc_media_FileOutputDataSource_isPrepare", dataSource.isPrepare(), false);
+	TC_ASSERT_EQ("utc_media_FileOutputDataSource_isPrepared", dataSource.isPrepared(), false);
 	TC_SUCCESS_RESULT();
 }
 
@@ -213,8 +213,8 @@ int utc_media_fileoutputdatasource_main(void)
 	utc_media_FileOutputDataSource_close_p();
 	utc_media_FileOutputDataSource_close_n();
 
-	utc_media_FileOutputDataSource_isPrepare_p();
-	utc_media_FileOutputDataSource_isPrepare_n();
+	utc_media_FileOutputDataSource_isPrepared_p();
+	utc_media_FileOutputDataSource_isPrepared_n();
 
 	utc_media_FileOutputDataSource_write_p();
 	utc_media_FileOutputDataSource_write_n();

--- a/framework/include/media/BufferOutputDataSource.h
+++ b/framework/include/media/BufferOutputDataSource.h
@@ -84,7 +84,7 @@ public:
 	 * @return True.
 	 * @since TizenRT v2.0
 	 */
-	bool isPrepare() override;
+	bool isPrepared() override;
 	/**
 	 * @brief Open the file
 	 * @details @b #include <media/BufferOutputDataSource.h>
@@ -111,7 +111,7 @@ public:
 	ssize_t write(unsigned char *buf, size_t size);
 
 private:
-	bool mIsPrepare;
+	bool mIsPrepared;
 };
 
 } // namespace stream

--- a/framework/include/media/DataSource.h
+++ b/framework/include/media/DataSource.h
@@ -35,7 +35,7 @@
 namespace media {
 
 /**
- * @class 
+ * @class
  * @brief This class is audio data structure
  * @details @b #include <media/DataSource.h>
  * @since TizenRT v2.0
@@ -95,7 +95,7 @@ public:
 	 * @details @b #include <media/DataSource.h>
 	 * @since TizenRT v2.0
 	 */
-	virtual bool isPrepare() = 0;
+	virtual bool isPrepared() = 0;
 
 	/**
 	 * @brief Gets the channel count of the stream data.

--- a/framework/include/media/FileInputDataSource.h
+++ b/framework/include/media/FileInputDataSource.h
@@ -80,7 +80,7 @@ public:
 	 * @return True is ready, False is not ready
 	 * @since TizenRT v2.0
 	 */
-	bool isPrepare() override;
+	bool isPrepared() override;
 	/**
 	 * @brief Open the file
 	 * @details @b #include <media/FileInputDataSource.h>

--- a/framework/include/media/FileOutputDataSource.h
+++ b/framework/include/media/FileOutputDataSource.h
@@ -91,7 +91,7 @@ public:
 	 * @return True is ready, False is not ready
 	 * @since TizenRT v2.0
 	 */
-	bool isPrepare() override;
+	bool isPrepared() override;
 	/**
 	 * @brief Open the file
 	 * @details @b #include <media/FileOutputDataSource.h>

--- a/framework/include/media/HttpInputDataSource.h
+++ b/framework/include/media/HttpInputDataSource.h
@@ -95,7 +95,7 @@ public:
 	 * @return True is ready, False is not ready
 	 * @since TizenRT v2.0
 	 */
-	bool isPrepare() override;
+	bool isPrepared() override;
 	/**
 	 * @brief Open the http source
 	 * @details @b #include <media/HttpInputDataSource.h>

--- a/framework/include/media/SocketOutputDataSource.h
+++ b/framework/include/media/SocketOutputDataSource.h
@@ -97,7 +97,7 @@ public:
 	 * @return True is ready, False is not ready
 	 * @since TizenRT v2.0
 	 */
-	bool isPrepare() override;
+	bool isPrepared() override;
 	/**
 	 * @brief Open the file
 	 * @details @b #include <media/SocketOutputDataSource.h>

--- a/framework/src/media/BufferOutputDataSource.cpp
+++ b/framework/src/media/BufferOutputDataSource.cpp
@@ -37,19 +37,19 @@ namespace media {
 namespace stream {
 BufferOutputDataSource::BufferOutputDataSource() :
 	OutputDataSource(),
-	mIsPrepare(false)
+	mIsPrepared(false)
 {
 }
 
 BufferOutputDataSource::BufferOutputDataSource(unsigned int channels, unsigned int sampleRate, audio_format_type_t pcmFormat) :
 	OutputDataSource(channels, sampleRate, pcmFormat),
-	mIsPrepare(false)
+	mIsPrepared(false)
 {
 }
 
 BufferOutputDataSource::BufferOutputDataSource(const BufferOutputDataSource &source) :
 	OutputDataSource(source),
-	mIsPrepare(false)
+	mIsPrepared(false)
 {
 }
 
@@ -61,19 +61,19 @@ BufferOutputDataSource &BufferOutputDataSource::operator=(const BufferOutputData
 
 bool BufferOutputDataSource::open()
 {
-	mIsPrepare = true;
+	mIsPrepared = true;
 	return true;
 }
 
 bool BufferOutputDataSource::close()
 {
-	mIsPrepare = false;
+	mIsPrepared = false;
 	return true;
 }
 
-bool BufferOutputDataSource::isPrepare()
+bool BufferOutputDataSource::isPrepared()
 {
-	return mIsPrepare;
+	return mIsPrepared;
 }
 
 ssize_t BufferOutputDataSource::write(unsigned char *buf, size_t size)
@@ -82,7 +82,7 @@ ssize_t BufferOutputDataSource::write(unsigned char *buf, size_t size)
 		return 0;
 	}
 
-	if (!isPrepare()) {
+	if (!isPrepared()) {
 		return EOF;
 	}
 
@@ -103,7 +103,7 @@ ssize_t BufferOutputDataSource::write(unsigned char *buf, size_t size)
 
 BufferOutputDataSource::~BufferOutputDataSource()
 {
-	if (isPrepare()) {
+	if (isPrepared()) {
 		close();
 	}
 }

--- a/framework/src/media/FileInputDataSource.cpp
+++ b/framework/src/media/FileInputDataSource.cpp
@@ -126,7 +126,7 @@ bool FileInputDataSource::close()
 	return ret;
 }
 
-bool FileInputDataSource::isPrepare()
+bool FileInputDataSource::isPrepared()
 {
 	if (mFp == nullptr) {
 		return false;
@@ -136,7 +136,7 @@ bool FileInputDataSource::isPrepare()
 
 ssize_t FileInputDataSource::read(unsigned char *buf, size_t size)
 {
-	if (!isPrepare()) {
+	if (!isPrepared()) {
 		meddbg("%s[line : %d] Fail : FileInputDataSource is not prepared\n", __func__, __LINE__);
 		return EOF;
 	}
@@ -164,7 +164,7 @@ ssize_t FileInputDataSource::read(unsigned char *buf, size_t size)
 
 FileInputDataSource::~FileInputDataSource()
 {
-	if (isPrepare()) {
+	if (isPrepared()) {
 		close();
 	}
 }

--- a/framework/src/media/FileOutputDataSource.cpp
+++ b/framework/src/media/FileOutputDataSource.cpp
@@ -95,7 +95,7 @@ bool FileOutputDataSource::close()
 	return false;
 }
 
-bool FileOutputDataSource::isPrepare()
+bool FileOutputDataSource::isPrepared()
 {
 	if (mFp == nullptr) {
 		return false;
@@ -109,7 +109,7 @@ ssize_t FileOutputDataSource::write(unsigned char *buf, size_t size)
 		return 0;
 	}
 
-	if (!isPrepare()) {
+	if (!isPrepared()) {
 		return EOF;
 	}
 
@@ -122,7 +122,7 @@ ssize_t FileOutputDataSource::write(unsigned char *buf, size_t size)
 
 FileOutputDataSource::~FileOutputDataSource()
 {
-	if (isPrepare()) {
+	if (isPrepared()) {
 		close();
 	}
 }

--- a/framework/src/media/HttpInputDataSource.cpp
+++ b/framework/src/media/HttpInputDataSource.cpp
@@ -75,7 +75,7 @@ bool HttpInputDataSource::open()
 {
 	medvdbg("HttpInputDataSource::open!\n");
 
-	if (isPrepare()) {
+	if (isPrepared()) {
 		medvdbg("HttpInputDataSource is already opened!\n");
 		return true;
 	}
@@ -200,14 +200,14 @@ bool HttpInputDataSource::close()
 	return true;
 }
 
-bool HttpInputDataSource::isPrepare()
+bool HttpInputDataSource::isPrepared()
 {
 	return ((mStreamBuffer != nullptr) && (mHttpStream != nullptr) && (getAudioType() != AUDIO_TYPE_UNKNOWN));
 }
 
 ssize_t HttpInputDataSource::read(unsigned char *buf, size_t size)
 {
-	if (!isPrepare()) {
+	if (!isPrepared()) {
 		meddbg("[line:%d] Fail : HttpInputDataSource is not prepared\n", __LINE__);
 		return EOF;
 	}
@@ -296,7 +296,7 @@ void *HttpInputDataSource::workerMain(void *arg)
 
 HttpInputDataSource::~HttpInputDataSource()
 {
-	if (isPrepare()) {
+	if (isPrepared()) {
 		close();
 	}
 }

--- a/framework/src/media/InputHandler.cpp
+++ b/framework/src/media/InputHandler.cpp
@@ -120,7 +120,7 @@ ssize_t InputHandler::read(unsigned char *buf, size_t size)
 
 bool InputHandler::start()
 {
-	if (!mInputDataSource->isPrepare()) {
+	if (!mInputDataSource->isPrepared()) {
 		return false;
 	}
 

--- a/framework/src/media/MediaRecorderImpl.cpp
+++ b/framework/src/media/MediaRecorderImpl.cpp
@@ -231,7 +231,7 @@ void MediaRecorderImpl::unprepareRecorder(recorder_result_t& ret)
 	}
 
 	auto source = mOutputHandler.getOutputDataSource();
-	if (source->isPrepare()) {
+	if (source->isPrepared()) {
 		mOutputHandler.close();
 	}
 

--- a/framework/src/media/OutputHandler.cpp
+++ b/framework/src/media/OutputHandler.cpp
@@ -134,7 +134,7 @@ ssize_t OutputHandler::write(unsigned char *buf, size_t size)
 bool OutputHandler::start()
 {
 	medvdbg("OutputHandler::start()\n");
-	if (!mOutputDataSource->isPrepare()) {
+	if (!mOutputDataSource->isPrepared()) {
 		return false;
 	}
 

--- a/framework/src/media/SocketOutputDataSource.cpp
+++ b/framework/src/media/SocketOutputDataSource.cpp
@@ -92,7 +92,7 @@ bool SocketOutputDataSource::close()
 	return false;
 }
 
-bool SocketOutputDataSource::isPrepare()
+bool SocketOutputDataSource::isPrepared()
 {
 	return (mSockFd != INVALID_SOCKET);
 }


### PR DESCRIPTION
Rename DataSource::isPrepare() to DataSource::isPrepared().
`is prepared` means data source is ready to read/write.
@Taejun-Kwon 