### PR TITLE
fs/poll: Modify assert condition in poll()

### DIFF
--- a/os/fs/vfs/fs_poll.c
+++ b/os/fs/vfs/fs_poll.c
@@ -332,7 +332,8 @@ int poll(FAR struct pollfd *fds, nfds_t nfds, int timeout)
 	int count = 0;
 	int ret;
 
-	DEBUGASSERT((fds != NULL));
+	DEBUGASSERT((nfds == 0) || (fds != NULL));
+
 	/* poll() is a cancellation point */
 	(void)enter_cancellation_point();
 


### PR DESCRIPTION
API: int poll(FAR struct pollfd *fds, nfds_t nfds, int timeout)
We only need to check `fds` null when `nfds` is nonzero.
Without this patch, assertion occurs in poll() when running below code:
```c
	struct timeval tv;
	/* Wait up to 3 seconds. */
	tv.tv_sec = 3;
	tv.tv_usec = 0;
	/* test select sleep functionality */
	select(0, NULL, NULL, NULL, &tv);
```
@sunghan-chang 