### PR TITLE
mm/umm_heap: Add missing include about debug

### DIFF
--- a/os/mm/umm_heap/umm_calloc.c
+++ b/os/mm/umm_heap/umm_calloc.c
@@ -56,6 +56,7 @@
 
 #include <tinyara/config.h>
 #include <stdlib.h>
+#include <debug.h>
 #include <tinyara/mm/mm.h>
 
 #if !defined(CONFIG_BUILD_PROTECTED) || !defined(__KERNEL__)

--- a/os/mm/umm_heap/umm_memalign.c
+++ b/os/mm/umm_heap/umm_memalign.c
@@ -56,6 +56,7 @@
 
 #include <tinyara/config.h>
 #include <stdlib.h>
+#include <debug.h>
 #include <tinyara/mm/mm.h>
 
 #if !defined(CONFIG_BUILD_PROTECTED) || !defined(__KERNEL__)

--- a/os/mm/umm_heap/umm_zalloc.c
+++ b/os/mm/umm_heap/umm_zalloc.c
@@ -57,6 +57,7 @@
 #include <tinyara/config.h>
 #include <stdlib.h>
 #include <string.h>
+#include <debug.h>
 #include <tinyara/mm/mm.h>
 
 #if !defined(CONFIG_BUILD_PROTECTED) || !defined(__KERNEL__)


### PR DESCRIPTION
for using mdbg, #include <debug.h> is required.