### PR TITLE
framework/st_things, apps/st_things: Call internal thing_stop_stack() during stack de-initialize.

### DIFF
--- a/apps/examples/st_things/blink/sample_blink_things.c
+++ b/apps/examples/st_things/blink/sample_blink_things.c
@@ -66,10 +66,30 @@ static bool handle_set_request(st_things_set_request_message_s *req_msg, st_thin
 	return false;
 }
 
-int ess_process(void)
+int ess_process(bool stop)
 {
+	if (stop) {
+		st_things_error_e res = st_things_deinitialize();
+		if (res == ST_THINGS_ERROR_NONE) {
+			printf("[%s]=====================================================\n", TAG);
+			printf("[%s]                    Stack Stopped & Deinitialized                    \n", TAG);
+			printf("[%s]=====================================================\n", TAG);
+		} else {
+			printf("[%s]Failed to stop & deinitialize the stack. Error code: %d\n", TAG, res);
+		}
+		return 0;
+	}
+
 	bool easysetup_complete = false;
-	st_things_initialize("device_def.json", &easysetup_complete);
+	st_things_error_e err_code = st_things_initialize("device_def.json", &easysetup_complete);
+	if (err_code == ST_THINGS_ERROR_NONE) {
+		printf("[%s]=====================================================\n", TAG);
+		printf("[%s]                    Stack Initialized                    \n", TAG);
+		printf("[%s]=====================================================\n", TAG);
+	} else {
+		printf("[%s]Failed to initialize. Error code: %d\n", TAG, err_code);
+		return 0;
+	}
 
 	blink_init();
 	blink_start();
@@ -80,6 +100,8 @@ int ess_process(void)
 		printf("[%s]=====================================================\n", TAG);
 		printf("[%s]                    Stack Started                    \n", TAG);
 		printf("[%s]=====================================================\n", TAG);
+	} else {
+		printf("[%s]Failed to start. Error code: %d\n", TAG, err_code);
 	}
 
 	return 0;

--- a/apps/examples/st_things/light/sample_light_things.c
+++ b/apps/examples/st_things/light/sample_light_things.c
@@ -115,8 +115,20 @@ static bool handle_set_request(st_things_set_request_message_s *req_msg, st_thin
 	return false;
 }
 
-int ess_process(void)
+int ess_process(bool stop)
 {
+	if (stop) {
+		st_things_error_e res = st_things_deinitialize();
+		if (res == ST_THINGS_ERROR_NONE) {
+			printf("[%s]=====================================================\n", TAG);
+			printf("[%s]                    Stack Stopped & Deinitialized                    \n", TAG);
+			printf("[%s]=====================================================\n", TAG);
+		} else {
+			printf("[%s]Failed to stop & deinitialize the stack. Error code: %d\n", TAG, res);
+		}
+		return 0;
+	}
+
 #ifdef CONFIG_RESET_BUTTON
 	if (!check_reset_button_pin_number()) {
 		printf("Error : Invalid pin number.\n");
@@ -133,7 +145,16 @@ int ess_process(void)
 #endif
 
 	bool easysetup_complete = false;
-	st_things_initialize("device_def.json", &easysetup_complete);
+	st_things_error_e err_code = st_things_initialize("device_def.json", &easysetup_complete);
+	if (err_code == ST_THINGS_ERROR_NONE) {
+		printf("[%s]=====================================================\n", TAG);
+		printf("[%s]                    Stack Initialized                    \n", TAG);
+		printf("[%s]=====================================================\n", TAG);
+	} else {
+		printf("[%s]Failed to initialize. Error code: %d\n", TAG, err_code);
+		return 0;
+	}
+
 	st_things_register_request_cb(handle_get_request, handle_set_request);
 	st_things_register_reset_cb(handle_reset_request, handle_reset_result);
 	st_things_register_user_confirm_cb(handle_ownership_transfer_request);
@@ -143,6 +164,8 @@ int ess_process(void)
 		printf("[%s]=====================================================\n", TAG);
 		printf("[%s]                    Stack Started                    \n", TAG);
 		printf("[%s]=====================================================\n", TAG);
+	} else {
+		printf("[%s]Failed to start. Error code: %d\n", TAG, err_code);
 	}
 
 	return 0;

--- a/apps/examples/st_things/msghandling/sample_msghandling_things.c
+++ b/apps/examples/st_things/msghandling/sample_msghandling_things.c
@@ -140,10 +140,31 @@ static bool handle_set_request(st_things_set_request_message_s *req_msg, st_thin
 	return false;
 }
 
-int ess_process(void)
+int ess_process(bool stop)
 {
+	if (stop) {
+		st_things_error_e res = st_things_deinitialize();
+		if (res == ST_THINGS_ERROR_NONE) {
+			printf("[%s]=====================================================\n", TAG);
+			printf("[%s]                    Stack Stopped & Deinitialized                    \n", TAG);
+			printf("[%s]=====================================================\n", TAG);
+		} else {
+			printf("[%s]Failed to stop & deinitialize the stack. Error code: %d\n", TAG, res);
+		}
+		return 0;
+	}
+
 	bool easysetup_complete = false;
-	st_things_initialize("device_def.json", &easysetup_complete);
+	st_things_error_e err_code = st_things_initialize("device_def.json", &easysetup_complete);
+	if (err_code == ST_THINGS_ERROR_NONE) {
+		printf("[%s]=====================================================\n", TAG);
+		printf("[%s]                    Stack Initialized                    \n", TAG);
+		printf("[%s]=====================================================\n", TAG);
+	} else {
+		printf("[%s]Failed to initialize. Error code: %d\n", TAG, err_code);
+		return 0;
+	}
+
 
 	st_things_register_request_cb(handle_get_request, handle_set_request);
 	st_things_register_reset_cb(handle_reset_request, handle_reset_result);
@@ -154,8 +175,10 @@ int ess_process(void)
 
 	if (st_things_start() == ST_THINGS_ERROR_NONE) {
 		printf("[%s]=====================================================\n", TAG);
-		printf("[%s]                   Stack Started                     \n", TAG);
+		printf("[%s]                    Stack Started                    \n", TAG);
 		printf("[%s]=====================================================\n", TAG);
+	} else {
+		printf("[%s]Failed to start. Error code: %d\n", TAG, err_code);
 	}
 
 	return 0;

--- a/apps/examples/st_things/st_things_sample.h
+++ b/apps/examples/st_things/st_things_sample.h
@@ -20,7 +20,7 @@
 extern "C" {
 #endif /* __cplusplus */
 
-int ess_process(void);
+int ess_process(bool stop);
 
 #ifdef __cplusplus
 }

--- a/apps/examples/st_things/st_things_sample_main.c
+++ b/apps/examples/st_things/st_things_sample_main.c
@@ -19,7 +19,10 @@
 #include <tinyara/config.h>
 
 #include <stdio.h>
+#include <string.h>
 #include "st_things_sample.h"
+
+#define CMD_STOP "stop"
 
 #ifdef CONFIG_BUILD_KERNEL
 int main(int argc, FAR char *argv[])
@@ -28,8 +31,14 @@ int st_things_sample_main(int argc, char *argv[])
 #endif
 {
 	printf("st_things_sample!!\n");
-	
-	ess_process();
-	
+
+	if (argc == 2 && strncmp(argv[1], CMD_STOP, strlen(argv[1])) == 0) {
+		ess_process(true);
+	} else if (argc == 1) {
+		ess_process(false);
+	} else {
+		printf("Usage: st_things_sample\n   or: st_things_sample stop\n Start, or Stop st_things sample\n");
+	}
+
 	return 0;
 }

--- a/framework/include/st_things/st_things.h
+++ b/framework/include/st_things/st_things.h
@@ -40,7 +40,7 @@ extern "C" {
 #endif							/* __cplusplus */
 
 /**
- * @brief Initializes things stack and returns whether easy-setup is completed or not.
+ * @brief Initializes things stack, parses the thing definition and returns whether easy-setup is completed or not.
  *        Easy-setup enable users to acquire the ownership of things and to connect the things with the cloud.
  *        After performing easy-setup, users can access things from anywhere through the cloud.
  *        In things stack, easy-setup is a primary and the first operation to be performed on the thing.
@@ -61,10 +61,9 @@ extern "C" {
  * @retval #ST_THINGS_ERROR_INVALID_PARAMETER Invalid parameter
  * @retval #ST_THINGS_ERROR_OPERATION_FAILED Operation failed
  * @retval #ST_THINGS_ERROR_STACK_ALREADY_INITIALIZED Stack already initialized.
- *         To initialize again, stack should be deinitilized first by calling st_things_deinitialize().
+ *         To re-initialize, stack should be deinitilized first by calling st_things_deinitialize().
  * @retval #ST_THINGS_ERROR_STACK_RUNNING Stack is currently running.
- *         To initialize again, stack should be stopped first by calling st_things_stop()
- *         and then deinitialized by calling st_things_deinitialize().
+ *         To re-initialize, stack should be deinitilized first by calling st_things_deinitialize().
  * @since TizenRT v1.1
  */
 int st_things_initialize(const char *json_path, bool *easysetup_complete);
@@ -78,10 +77,8 @@ int st_things_initialize(const char *json_path, bool *easysetup_complete);
  * @return @c 0 on success, otherwise a negative error value
  * @retval #ST_THINGS_ERROR_NONE Successful
  * @retval #ST_THINGS_ERROR_OPERATION_FAILED Operation failed
- * @retval #ST_THINGS_ERROR_STACK_NOT_INITIALIZED Stack is not initialized.
+ * @retval #ST_THINGS_ERROR_STACK_NOT_INITIALIZED Stack is not yet initialized.
  *         Initialize the stack by calling st_things_initialize().
- * @retval #ST_THINGS_ERROR_STACK_RUNNING Stack is currently running.
- *         Before deinitialize, stack needs to be stopped by calling st_things_stop().
  */
 int st_things_deinitialize(void);
 //@endcond
@@ -128,10 +125,8 @@ typedef bool (*st_things_set_request_cb)(st_things_set_request_message_s *req_ms
 int st_things_register_request_cb(st_things_get_request_cb get_cb, st_things_set_request_cb set_cb);
 
 /**
- * @brief Starts things stack.
- *        Parses the thing definition(whose path is passed to st_things_initialize(), configures the thing,
- *        creates the resources and prepares it for easy-setup.
- *        If easy-setup is not done yet, onboarding will be started using either SoftAP or BLE connection.
+ * @brief Starts things stack, creates resources and configures the stack for easy-setup.
+ *        If easy-setup is not done yet, SoftAP will be created for onboarding.
  *        Onboarding creates an ad-hoc network between the thing and the client for performing easy-setup.
  *        If easy-setup is already done, thing will be connected with the cloud.
  *        Application can know whether easy-setup is done or not through st_things_initialize API.

--- a/framework/src/st_things/st_things.c
+++ b/framework/src/st_things/st_things.c
@@ -278,32 +278,26 @@ int st_things_deinitialize(void)
 {
 	THINGS_LOG_D(TAG, THINGS_FUNC_ENTRY);
 
-	if (STACK_INITIALIZED != g_stack_status) {
-		int ret_val = ST_THINGS_ERROR_OPERATION_FAILED;
-		switch (g_stack_status) {
-		case STACK_NOT_INITIALIZED:
-			THINGS_LOG_E(TAG, "Stack is not initialized.");
-			ret_val = ST_THINGS_ERROR_STACK_NOT_INITIALIZED;
-			break;
-		case STACK_STARTED:
-			THINGS_LOG_E(TAG, "Stack is currently running. Stop the stack before deinitializing it.");
-			ret_val = ST_THINGS_ERROR_STACK_RUNNING;
-			break;
-		default:
-			THINGS_LOG_E(TAG, "Invalid stack state: %d.", g_stack_status);
-			break;
-		}
+	if (STACK_INITIALIZED == g_stack_status) {
+		THINGS_LOG_D(TAG, "Stack is initialized.");
+	}
 
+	int result = 0;
+	if (1 != (result = things_stop_stack())) {
+		THINGS_LOG_E(TAG, "things_stop_stack failed (result:%d)", result);
 		THINGS_LOG_D(TAG, THINGS_FUNC_EXIT);
-		return ret_val;
+		return ST_THINGS_ERROR_OPERATION_FAILED;
+	}
+
+	if (1 != (result = things_deinitialize_stack())) {
+		THINGS_LOG_E(TAG, "things_deinitialize_stack failed (result:%d)", result);
+		THINGS_LOG_D(TAG, THINGS_FUNC_EXIT);
+		return ST_THINGS_ERROR_OPERATION_FAILED;
 	}
 
 	g_stack_status = STACK_NOT_INITIALIZED;
 
 	THINGS_LOG_D(TAG, THINGS_FUNC_EXIT);
-
-	(void)things_deinitialize_stack();
-
 	return ST_THINGS_ERROR_NONE;
 }
 

--- a/framework/src/st_things/things_stack/cloud/cloud_manager.c
+++ b/framework/src/st_things/things_stack/cloud/cloud_manager.c
@@ -2263,13 +2263,13 @@ void *es_cloud_init(things_server_builder_s *server_builder)
 
 void es_cloud_terminate(void)
 {
+	CAUnregisterNetworkMonitorHandler((CAAdapterStateChangedCB) things_adapter_state_cb, (CAConnectionStateChangedCB) things_tcp_session_state_cb);
+
 	force_session_stop(CISESS_NULL);
 	ci_cp_del_pended_data();
 	ci_cp_del_is_there_cp();
 
-	CAUnregisterNetworkMonitorHandler((CAAdapterStateChangedCB) things_adapter_state_cb, (CAConnectionStateChangedCB) things_tcp_session_state_cb);
-
-	esm_get_network_status();
+	things_ping_terminate();
 
 	es_cloud_signup_clear(signed_up_data);
 	signed_up_data = NULL;
@@ -2284,8 +2284,6 @@ void es_cloud_terminate(void)
 	// gDelDeviceCompletFunc = NULL;
 	send_cnt_sign_up = 0;
 	retranslate_rsc_publish_cnt = 0;
-
-	things_ping_terminate();
 }
 static int get_cloud_code(OCClientResponse *response, OCMethod method, ci_error_code_e *err)
 {

--- a/framework/src/st_things/things_stack/framework/things_data_manager.h
+++ b/framework/src/st_things/things_stack/framework/things_data_manager.h
@@ -94,9 +94,9 @@ typedef struct st_device_s {
 
 size_t get_json_file_size(const char *filename);
 char *get_json_string_from_file(const char *filename);
-int dm_init_module(const char *info_Path);
 
-int dm_termiate_module(void);
+int dm_init_module(const char *info_path);
+int dm_terminate_module(void);
 
 const char *dm_get_svrdb_file_path(void);
 const char *dm_get_certificate_file_path(void);

--- a/framework/src/st_things/things_stack/framework/things_req_handler.c
+++ b/framework/src/st_things/things_stack/framework/things_req_handler.c
@@ -305,46 +305,6 @@ static OCEntityHandlerResult get_provisioning_info(things_resource_s *target_res
 	return eh_result;
 }
 
-static OCEntityHandlerResult trigger_reset_request(things_resource_s *target_resource, bool reset)
-{
-	OCEntityHandlerResult eh_result = OC_EH_ERROR;
-	bool isOwned;
-
-	iotivity_api_lock();
-	OCGetDeviceOwnedState(&isOwned);
-	iotivity_api_unlock();
-
-	if (isOwned == false) {
-		return OC_EH_NOT_ACCEPTABLE;
-	}
-
-	THINGS_LOG_D(TAG, "==> RESET : %s", (reset == true ? "YES" : "NO"));
-
-	if (reset == true) {
-		things_resource_s *clone_resource = things_clone_resource_inst(target_resource);
-		int res = things_reset((void *)clone_resource, RST_NEED_CONFIRM);
-
-		switch (res) {
-		case 1:
-			THINGS_LOG_D(TAG, "Reset Thread create is success.");
-			eh_result = OC_EH_SLOW;
-			break;
-		case 0:
-			THINGS_LOG_V(TAG, "Already Run Reset-Process.");
-			eh_result = OC_EH_NOT_ACCEPTABLE;
-		default:
-			things_release_resource_inst(clone_resource);
-			clone_resource = NULL;
-			break;
-		}
-	} else {
-		THINGS_LOG_D(TAG, "reset = %d, So, can not reset start.", reset);
-		eh_result = OC_EH_OK;
-	}
-
-	return eh_result;
-}
-
 static OCEntityHandlerResult process_post_request(things_resource_s **target_res)
 {
 	OCEntityHandlerResult eh_result = OC_EH_ERROR;

--- a/framework/src/st_things/things_stack/framework/things_server_builder.c
+++ b/framework/src/st_things/things_stack/framework/things_server_builder.c
@@ -304,8 +304,7 @@ void deinit_builder(things_server_builder_s *builder)
 		g_quit_flag = 1;
 		pthread_cancel(g_thread_id_server);
 		pthread_join(g_thread_id_server, NULL);
-		pthread_detach(g_thread_id_server);
-		g_thread_id_server = 0;
+		g_thread_id_server = PTHREAD_ONCE_INIT;
 
 		// 1.    Need to unregister those registered resource in the Stack
 		// 2.    Free the payload of each resources

--- a/framework/src/st_things/things_stack/utils/Make.defs
+++ b/framework/src/st_things/things_stack/utils/Make.defs
@@ -16,7 +16,7 @@
 #
 ###########################################################################
 
-CSRCS += things_hashmap.c things_list.c things_network.c things_ping.c things_string.c things_wait_handler.c things_rtos_util.c things_malloc.c
+CSRCS += things_hashmap.c things_list.c things_network.c things_ping.c things_string.c things_wait_handler.c things_rtos_util.c things_malloc.c things_wifi_scan.c
 
 DEPPATH += --dep-path src/st_things/things_stack/utils
 VPATH += :src/st_things/things_stack/utils

--- a/framework/src/st_things/things_stack/utils/things_network.c
+++ b/framework/src/st_things/things_stack/utils/things_network.c
@@ -463,6 +463,14 @@ int things_network_initialize(void)
 	return 1;
 }
 
+int things_network_deinitialize(void)
+{
+	if (wifi_manager_deinit() != WIFI_MANAGER_SUCCESS) {
+		THINGS_LOG_E(TAG, "Failed to de-initialize WiFi manager");
+		return 0;
+	}
+	return 1;
+}
 
 /*****************************************************************************
  *

--- a/framework/src/st_things/things_stack/utils/things_network.h
+++ b/framework/src/st_things/things_stack/utils/things_network.h
@@ -27,6 +27,8 @@
 
 int things_network_initialize(void);
 
+int things_network_deinitialize(void);
+
 wifi_manager_ap_config_s *things_network_get_homeap_config(void);
 
 bool things_network_turn_on_soft_ap(void);

--- a/framework/src/st_things/things_stack/utils/things_ping.c
+++ b/framework/src/st_things/things_stack/utils/things_ping.c
@@ -163,13 +163,12 @@ bool things_ping_set_mask(const char *remote_addr, uint16_t port, ping_state_e s
 		return false;
 	}
 
-	pthread_mutex_lock(&mutex_ping_list);
 	if (list == NULL) {
 		THINGS_LOG_V(TAG, "OICPing Module is not initialized.");
-		pthread_mutex_unlock(&mutex_ping_list);
 		return false;
 	}
 
+	pthread_mutex_lock(&mutex_ping_list);
 	node = list->find_by_key(list, (key_compare) is_ip_key_equal, remote_addr);
 	if (node == NULL) {
 		THINGS_LOG_D(TAG, "Not Found things_node_s for remote(%s). So, Create Node.", remote_addr);
@@ -212,13 +211,12 @@ bool things_ping_unset_mask(const char *remote_addr, ping_state_e state)
 		return false;
 	}
 
-	pthread_mutex_lock(&mutex_ping_list);
 	if (list == NULL) {
 		THINGS_LOG_V(TAG, "OICPing Module is not initialized.");
-		pthread_mutex_unlock(&mutex_ping_list);
 		return false;
 	}
 
+	pthread_mutex_lock(&mutex_ping_list);
 	node = list->find_by_key(list, (key_compare) is_ip_key_equal, remote_addr);
 	if (node == NULL) {
 		THINGS_LOG_D(TAG, "Not Found things_node_s for remote(%s).", remote_addr);

--- a/framework/src/st_things/things_stack/utils/things_wifi_scan.c
+++ b/framework/src/st_things/things_stack/utils/things_wifi_scan.c
@@ -1,0 +1,89 @@
+/****************************************************************************
+ *
+ * Copyright 2018 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+#include <sys/types.h>
+#include <pthread.h>
+#include <time.h>
+
+#include "things_wifi_scan.h"
+#include "things_network.h"
+#include "things_rtos_util.h"
+#include "logging/things_logger.h"
+
+#define TAG "[things_wifi_scan]"
+
+#define SCAN_AP_INTERVAL 60
+
+typedef void *(*pthread_func_type)(void *);
+
+static void *auto_scanning_loop(void);
+static pthread_t g_wifi_scan_thread;
+static bool b_scan_wifi = false; //False indicates wifi  scanning is disabled.
+static pthread_mutex_t g_wifi_scan_mutex = PTHREAD_MUTEX_INITIALIZER;
+static pthread_cond_t g_wifi_scan_cond = PTHREAD_COND_INITIALIZER;
+
+static void *__attribute__((optimize("O0"))) auto_scanning_loop(void)
+{
+	struct timespec abs_time;
+	pthread_mutex_lock(&g_wifi_scan_mutex);
+	while (b_scan_wifi && !things_is_connected_ap()) {
+		if (!things_wifi_scan_ap()) {
+			break;
+		}
+
+		clock_gettime(CLOCK_REALTIME , &abs_time);
+		abs_time.tv_sec += SCAN_AP_INTERVAL;
+		pthread_cond_timedwait(&g_wifi_scan_cond, &g_wifi_scan_mutex, &abs_time);
+	}
+	b_scan_wifi = false; //Wifi scan ends.
+	pthread_mutex_unlock(&g_wifi_scan_mutex);
+	return NULL;
+}
+
+bool things_start_wifi_scan(void)
+{
+	bool result = false;
+	pthread_mutex_lock(&g_wifi_scan_mutex);
+	if (b_scan_wifi) {
+		THINGS_LOG_D(TAG, "WiFi scan is in progress.");
+		result = true; //Wifi scan which is in progress is not considered as an error.
+	} else {
+		if (pthread_create_rtos(&g_wifi_scan_thread, NULL, (pthread_func_type)auto_scanning_loop, NULL, THINGS_STACK_AP_SCAN_THREAD) == 0) {
+			b_scan_wifi = true;
+			result = true;
+		} else {
+			THINGS_LOG_E(TAG, "Failed to create thread for WiFi scan.");
+		}
+	}
+	pthread_mutex_unlock(&g_wifi_scan_mutex);
+	return result;
+}
+
+void things_stop_wifi_scan(void)
+{
+	pthread_mutex_lock(&g_wifi_scan_mutex);
+	if (!b_scan_wifi) {
+		pthread_mutex_unlock(&g_wifi_scan_mutex);
+		return;
+	}
+
+	b_scan_wifi = false;
+	pthread_cond_signal(&g_wifi_scan_cond);
+	pthread_mutex_unlock(&g_wifi_scan_mutex);
+	pthread_join(g_wifi_scan_thread, NULL);
+}

--- a/framework/src/st_things/things_stack/utils/things_wifi_scan.h
+++ b/framework/src/st_things/things_stack/utils/things_wifi_scan.h
@@ -1,0 +1,26 @@
+/****************************************************************************
+ *
+ * Copyright 2018 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+#ifndef THINGS_WIFI_SCAN_H_
+#define THINGS_WIFI_SCAN_H_
+
+bool things_start_wifi_scan(void);
+
+void things_stop_wifi_scan(void);
+
+#endif // THINGS_WIFI_SCAN_H_


### PR DESCRIPTION
1. Call thing_stop_stack() when st_things_deinitialize() is called.
things_stop_stack() performs graceful termination of things framework and iotivity.
This includes cleaning up allocated memory and stopping threads used by the sub-modules such as server builder, request handler, data manager, & network.

2. Hereafter, st_things_deinitialize() won't return ST_THINGS_ERROR_STACK_RUNNING
error code.
Because it doesn't make sense to return this error code when the actual intention of the API is to stop the running stack.

3. Replaces 'sleep' with 'timed conditional wait' for WiFi scan logic and
moves the code into its own file to reduce code complexity.

4. Includes command line option to stop st_things_sample application.
Usage: st_things_sample stop

Signed-off-by: Senthil Kumar G S <senthil.gs@samsung.com>