### PR TITLE
mdt/mtc_config: Fix testcase failure issues

### DIFF
--- a/apps/examples/testcase/le_tc/filesystem/fs_main.c
+++ b/apps/examples/testcase/le_tc/filesystem/fs_main.c
@@ -1635,7 +1635,7 @@ static void tc_driver_mtd_config_ops(void)
 	int fd;
 	int ret;
 	struct config_data_s config;
-	char *buf = "test";
+	char buf[8] = "test";
 
 	fd = open(MTD_CONFIG_PATH, O_RDOK);
 	TC_ASSERT_GEQ("open", fd, 0);

--- a/os/fs/driver/mtd/mtd_config.c
+++ b/os/fs/driver/mtd/mtd_config.c
@@ -1160,6 +1160,10 @@ static int mtdconfig_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
 	FAR struct mtdconfig_struct_s *dev = inode->i_private;
 	FAR struct config_data_s *pdata;
 	int ret = -ENOSYS;
+	if (arg == 0) {
+		fdbg("Error config item of CFGDIOC_SETCONFIG is NULL!\n");
+		return -EINVAL;
+	}
 
 	switch (cmd) {
 	case CFGDIOC_SETCONFIG:


### PR DESCRIPTION
 check input argement, if NULL, return EINVAL; in test case, change the buf assiged to configdata to be writable array;
Signed-off-by: glb1013@163.com