### PR TITLE
os/syscall: delete unused syscall and fix typos.

### DIFF
--- a/os/syscall/syscall.csv
+++ b/os/syscall/syscall.csv
@@ -16,7 +16,6 @@
 "connect", "sys/socket.h", "CONFIG_NSOCKET_DESCRIPTORS > 0 && defined(CONFIG_NET)", "int", "int", "FAR const struct sockaddr*", "socklen_t"
 "dup", "unistd.h", "CONFIG_NFILE_DESCRIPTORS > 0", "int", "int"
 "dup2", "unistd.h", "CONFIG_NFILE_DESCRIPTORS > 0", "int", "int", "int"
-"execv", "unistd.h", "defined(CONFIG_LIBC_EXECFUNCS)", "int", "FAR const char *", "FAR char *const []|FAR char *const *"
 "exit", "stdlib.h", "", "void", "int"
 "fcntl", "fcntl.h", "CONFIG_NFILE_DESCRIPTORS > 0", "int", "int", "int", "..."
 "fs_fdopen", "tinyara/fs/fs.h", "CONFIG_NFILE_DESCRIPTORS > 0 && CONFIG_NFILE_STREAMS > 0", "FAR struct file_struct*", "int", "int", "FAR struct tcb_s*"

--- a/os/syscall/syscall_lookup.h
+++ b/os/syscall/syscall_lookup.h
@@ -146,7 +146,7 @@ SYSCALL_LOOKUP(nanosleep,               2, STUB_nanosleep)
  * TinyAra configuration.
  */
 
-SYSCALL_LOOKUP(syscall_clock,           0, STUB_clock)
+SYSCALL_LOOKUP(clock,                   0, STUB_clock)
 SYSCALL_LOOKUP(clock_getres,            2, STUB_clock_getres)
 SYSCALL_LOOKUP(clock_gettime,           2, STUB_clock_gettime)
 SYSCALL_LOOKUP(clock_settime,           2, STUB_clock_settime)


### PR DESCRIPTION
1. syscall 'execv' is not used.
2. fix typos.