### PR TITLE
docs/HowToSetEnv.md: fix wrong path of installing Kconfig-frontend link

### DIFF
--- a/docs/HowToSetEnv.md
+++ b/docs/HowToSetEnv.md
@@ -39,7 +39,7 @@ cd ..
 make menuconfig
 ```
 
-Refer [kconfig-frontend installation](docs/HowtoInstallKconfigFrontend.md) to use *menuconfig*.
+Refer [kconfig-frontend installation](HowtoInstallKconfigFrontend.md) to use *menuconfig*.
 
 Finally, initiate build by make from *$TIZENRT_BASEDIR/os*.
 ```bash


### PR DESCRIPTION
HowtoSetEnv.md and HowtoInstallKconfigFrontend.md are
in same directory depth, docs folder so that link should not have
"docs/" in a link.

Signed-off-by: sunghan-chang <sh924.chang@samsung.com>