### PR TITLE
apps/slsiwifi: Use sleep() instead of up_mdelay() 

### DIFF
--- a/apps/examples/slsiwifi/nettest_functions.c
+++ b/apps/examples/slsiwifi/nettest_functions.c
@@ -912,7 +912,7 @@ int slsi_udp_client(void)
 		}
 		UNUSED(nBytes);
 		nlldbg("Received from server: %s\n", buffer);
-		up_mdelay(3000);
+		sleep(3);
 
 	}
 	close(clientSocket);


### PR DESCRIPTION
- Remove kernel API, up_mdelay() call in slsiwifi example application
- Modify up_mdelay(3000) to sleep(3)