### PR TITLE
apps/utils/kill: support a thread termination in kernel context with SIGKILL signal

### DIFF
--- a/apps/system/utils/Kconfig
+++ b/apps/system/utils/Kconfig
@@ -158,7 +158,10 @@ config ENABLE_KILL_CMD
 	default y
 	depends on !BUILD_PROTECTED
 	---help---
-		Send a signal to processes or process groups
+		Send a signal to processes or process groups.
+		When SIGKILL(9) is sent, a task/pthread which received signal will be terminated without any garbage collection.
+		Users can register their own handler for SIGKILL to free the allocated memory.
+		CONFIG_SIGKILL_HANDLER should be enabled for user's own handler.
 
 config ENABLE_KILLALL_CMD
 	bool "killall"

--- a/os/include/signal.h
+++ b/os/include/signal.h
@@ -136,6 +136,10 @@
 #endif
 #endif
 
+/* When SIGKILL is sent, a task/pthread which received signal will be terminated without any garbage collection.
+ * For freeing the allocated memory, user's own handler for SIGKILL is needed.
+ * CONFIG_SIGKILL_HANDLER should be enabled for user's own handler.
+ */		
 #ifndef CONFIG_SIG_SIGKILL
 #define SIGKILL       9			/* Sent to cause process to terminate */
 #else

--- a/os/include/tinyara/sched.h
+++ b/os/include/tinyara/sched.h
@@ -550,6 +550,9 @@ struct tcb_s {
 	sq_queue_t sigpendactionq;	/* List of pending signal actions      */
 	sq_queue_t sigpostedq;		/* List of posted signals              */
 	siginfo_t sigunbinfo;		/* Signal info when task unblocked     */
+#ifdef CONFIG_SIGKILL_HANDLER
+	_sa_sigaction_t sigkillusrhandler; /* User defined SIGKILL handler      */
+#endif
 #endif
 
 	/* POSIX Named Message Queue Fields ****************************************** */

--- a/os/kernel/Kconfig
+++ b/os/kernel/Kconfig
@@ -372,6 +372,13 @@ config SCHED_WAITPID
 		compliant) and will enable the waitid() and wait() interfaces as
 		well.
 
+config SIGKILL_HANDLER
+	bool "Enable user defined SIGKILL handler"
+	default y
+	---help---
+		SIGKILL terminates the task/pthread, but allocated memory is not freed by default.
+		User can register user's own signal handler for SIGKILL to free the allocates.
+
 endmenu # Tasks and Scheduling
 
 menu "Pthread Options"

--- a/os/kernel/signal/sig_action.c
+++ b/os/kernel/signal/sig_action.c
@@ -190,6 +190,13 @@ int sigaction(int signo, FAR const struct sigaction *act, FAR struct sigaction *
 		return ERROR;
 	}
 
+#ifdef CONFIG_SIGKILL_HANDLER
+	if (signo == SIGKILL) {
+		rtcb->sigkillusrhandler = act->sa_sigaction;
+		return OK;
+	}
+#endif
+
 	/* Find the signal in the sigactionq */
 
 	sigact = sig_findaction(rtcb, signo);

--- a/os/kernel/task/task_activate.c
+++ b/os/kernel/task/task_activate.c
@@ -60,6 +60,14 @@
 #include <debug.h>
 
 #include <tinyara/arch.h>
+#ifndef CONFIG_DISABLE_SIGNALS
+#include <pthread.h>
+#include <unistd.h>
+#include <signal.h>
+#include <errno.h>
+#include <tinyara/signal.h>
+#include "sched/sched.h"
+#endif
 
 /****************************************************************************
  * Pre-processor Definitions
@@ -84,6 +92,40 @@
 /****************************************************************************
  * Private Functions
  ****************************************************************************/
+#ifndef CONFIG_DISABLE_SIGNALS
+void thread_termination_handler(int signo, siginfo_t *data)
+{
+	struct tcb_s *rtcb = sched_gettcb(getpid());
+	if (!rtcb) {
+		set_errno(ESRCH);
+		return;
+	}
+
+#ifdef CONFIG_SIGKILL_HANDLER
+	if (rtcb->sigkillusrhandler != NULL) {
+		rtcb->sigkillusrhandler(signo, data, NULL);
+	}
+#endif
+
+	switch ((rtcb->flags & TCB_FLAG_TTYPE_MASK) >> TCB_FLAG_TTYPE_SHIFT) {
+	case TCB_FLAG_TTYPE_TASK:
+	case TCB_FLAG_TTYPE_KERNEL:
+		/* tasks and kernel threads has to use this interface */
+		(void)task_delete(rtcb->pid);
+		break;
+#ifndef CONFIG_DISABLE_PTHREAD
+	case TCB_FLAG_TTYPE_PTHREAD:
+		(void)pthread_cancel(rtcb->pid);
+		(void)pthread_join(rtcb->pid, NULL);
+		break;
+#endif
+	default:
+		set_errno(EINVAL);
+		break;
+	}
+	return;
+}
+#endif
 
 /****************************************************************************
  * Public Functions
@@ -107,7 +149,19 @@
 int task_activate(FAR struct tcb_s *tcb)
 {
 	irqstate_t flags = irqsave();
+#ifndef CONFIG_DISABLE_SIGNALS
+	int ret;
+	struct sigaction act;
 
+	act.sa_sigaction = (_sa_sigaction_t)thread_termination_handler;
+	act.sa_flags = 0;
+	(void)sigemptyset(&act.sa_mask);
+
+	ret = sig_sethandler(tcb, SIGKILL, &act);
+	if (ret != OK) {
+		sdbg("Fail to set SIGKILL handler for activating tcb.\n");
+	}
+#endif
 	up_unblock_task(tcb);
 	irqrestore(flags);
 	return OK;


### PR DESCRIPTION
When creating a task/pthread, SIGKILL handler will be registered by default.
Its handler terminates itself when a task/pthread gets SIGKILL signal.
But there is no garbage collection for teminating, so if user wants to free the allocates,
user should register the user's own handler for SIGKILL.