### PR TITLE
kdbg/heapinfo: Move calling sched_gettcb to kdbg driver for heapinfo

### DIFF
--- a/apps/system/utils/kdbg_heapinfo.c
+++ b/apps/system/utils/kdbg_heapinfo.c
@@ -15,13 +15,16 @@
  * language governing permissions and limitations under the License.
  *
  ****************************************************************************/
+#include <tinyara/config.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
+#include <errno.h>
+#include <fcntl.h>
 #include <tinyara/sched.h>
-#include <tinyara/config.h>
 #include <tinyara/mm/mm.h>
+#include <tinyara/kdbg_drv.h>
 #ifdef CONFIG_HEAPINFO_USER_GROUP
 #include <stdbool.h>
 #include <tinyara/mm/heapinfo_internal.h>
@@ -46,6 +49,8 @@ extern int regionx_heap_idx[CONFIG_MM_REGIONS];
 #if CONFIG_MM_NHEAPS > 1
 extern heapinfo_total_info_t total_info;
 #endif
+
+int g_heapinfo_fd;
 
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
 static void kdbg_heapinfo_init(FAR struct tcb_s *tcb, FAR void *arg)
@@ -127,6 +132,12 @@ int kdbg_heapinfo(int argc, char **args)
 
 	if (argc >= 2 && !strncmp(args[1], "--help", strlen("--help") + 1)) {
 		goto usage;
+	}
+
+	g_heapinfo_fd = open(KDBG_DRVPATH, O_RDWR);
+	if (g_heapinfo_fd < 0) {
+		printf("Failed to open kdbg driver %d\n", errno);
+		return ERROR;
 	}
 
 #if CONFIG_MM_NHEAPS > 1

--- a/os/drivers/Makefile
+++ b/os/drivers/Makefile
@@ -75,6 +75,7 @@ include audio$(DELIM)Make.defs
 include bch$(DELIM)Make.defs
 include fota$(DELIM)Make.defs
 include gpio$(DELIM)Make.defs
+include kdbg$(DELIM)Make.defs
 include i2c$(DELIM)Make.defs
 include net$(DELIM)Make.defs
 include pipes$(DELIM)Make.defs

--- a/os/drivers/kdbg/Make.defs
+++ b/os/drivers/kdbg/Make.defs
@@ -1,0 +1,29 @@
+##########################################################################
+#
+# Copyright 2019 Samsung Electronics All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+#
+##########################################################################
+# Include kernel debug drivers
+
+ifeq ($(CONFIG_KERNEL_CMDS),y)
+
+CSRCS += kdbg_drv.c
+
+# Include kernel debug driver support
+
+DEPPATH += --dep-path kdbg
+VPATH += :kdbg
+
+endif

--- a/os/drivers/kdbg/kdbg_drv.c
+++ b/os/drivers/kdbg/kdbg_drv.c
@@ -1,0 +1,133 @@
+/****************************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+#include <tinyara/config.h>
+#include <string.h>
+#include <sys/types.h>
+#include <tinyara/sched.h>
+#include <tinyara/mm/mm.h>
+#include <tinyara/fs/fs.h>
+#include <tinyara/fs/ioctl.h>
+#include <tinyara/kdbg_drv.h>
+
+/****************************************************************************
+ * Private Function Prototypes
+ ****************************************************************************/
+
+static int kdbg_ioctl(FAR struct file *filep, int cmd, unsigned long arg);
+static ssize_t kdbg_read(FAR struct file *filep, FAR char *buffer, size_t len);
+static ssize_t kdbg_write(FAR struct file *filep, FAR const char *buffer, size_t len);
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+struct kdbg_dev_s {
+	mqd_t mqdes;	   /* A mqueue descriptor */
+};
+
+static const struct file_operations kdbg_fops = {
+	0,                          /* open */
+	0,                          /* close */
+	kdbg_read,               /* read */
+	kdbg_write,              /* write */
+	0,                          /* seek */
+	kdbg_ioctl               /* ioctl */
+#ifndef CONFIG_DISABLE_POLL
+	, 0                         /* poll */
+#endif
+};
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+static ssize_t kdbg_read(FAR struct file *filep, FAR char *buffer, size_t len)
+{
+	return 0;
+}
+
+static ssize_t kdbg_write(FAR struct file *filep, FAR const char *buffer, size_t len)
+{
+	return 0;
+}
+
+/************************************************************************************
+ * Name: kdbg_ioctl
+ *
+ * Description:  The ioctl method for kernel debug.
+ *
+ ************************************************************************************/
+static int kdbg_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
+{
+	int ret = ERROR;
+	struct tcb_s *tcb;
+	heapinfo_data_t *data;
+
+	/* Handle built-in ioctl commands */
+
+	switch (cmd) {
+	case KDBGIOC_HEAPINFO_ADDSIZE:
+		data = (heapinfo_data_t *)arg;
+		tcb = sched_gettcb(data->pid);
+		if (tcb) {
+			tcb->curr_alloc_size += data->size;
+			tcb->num_alloc_free++;
+			if (tcb->curr_alloc_size > tcb->peak_alloc_size) {
+				tcb->peak_alloc_size = tcb->curr_alloc_size;
+			}
+			ret = OK;
+		}
+		break;
+	case KDBGIOC_HEAPINFO_SUBSIZE:
+		data = (heapinfo_data_t *)arg;
+		tcb = sched_gettcb(data->pid);
+		if (tcb) {
+			tcb->curr_alloc_size -= data->size;
+			tcb->num_alloc_free--;
+			ret = OK;
+		}
+		break;
+	case KDBGIOC_HEAPINFO_EXCLUDE_STACKSIZE:
+		tcb = sched_gettcb((int)arg);
+		ASSERT(tcb);
+		tcb->curr_alloc_size -= arg;
+		ret = OK;
+		break;
+	default:
+		break;
+	}
+	return ret;
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: kdbg_drv_register
+ *
+ * Description:
+ *   Register kdbg path, KDBG_DRVPATH
+ *
+ ****************************************************************************/
+
+void kdbg_drv_register(void)
+{
+	(void)register_driver(KDBG_DRVPATH, &kdbg_fops, 0666, NULL);
+}

--- a/os/include/tinyara/fs/ioctl.h
+++ b/os/include/tinyara/fs/ioctl.h
@@ -94,6 +94,7 @@
 #define _FOTABASE       (0x1900)	/* FOTA ioctl commands */
 #define _GPIOBASE       (0x2000)	/* GPIO ioctl commands */
 #define _TMBASE         (0x2100)	/* Task Management ioctl commands */
+#define _KDBGBASE       (0x2200)	/* Kdbg ioctl commands */
 #define _TESTIOCBASE (0xfe00)	/* KERNEL TEST DRV module ioctl commands */
 
 /* boardctl() commands share the same number space */
@@ -368,6 +369,14 @@
 #if defined(HAVE_TASK_GROUP) && !defined(CONFIG_DISABLE_PTHREAD)
 #define TMIOC_PTHREAD_PARENT       _TMIOC(0x0008)
 #endif
+
+/* Kdbg driver ioctl definitions *******************************************/
+#define _KDBGIOCVALID(c)   (_IOC_TYPE(c) == _KDBGBASE)
+#define _KDBGIOC(nr)       _IOC(_KDBGBASE, nr)
+
+#define KDBGIOC_HEAPINFO_ADDSIZE           _KDBGIOC(0x0001)
+#define KDBGIOC_HEAPINFO_SUBSIZE           _KDBGIOC(0x0002)
+#define KDBGIOC_HEAPINFO_EXCLUDE_STACKSIZE _KDBGIOC(0x0003)
 
 /****************************************************************************
  * Public Type Definitions

--- a/os/include/tinyara/kdbg_drv.h
+++ b/os/include/tinyara/kdbg_drv.h
@@ -1,0 +1,54 @@
+/****************************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __INCLUDE_TINYARA_KDBG_DRV_H
+#define __INCLUDE_TINYARA_KDBG_DRV_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <tinyara/config.h>
+#include <sys/types.h>
+#include <tinyara/mm/mm.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+#define KDBG_DRVPATH     "/dev/kdbg"
+
+struct heapinfo_data_s {
+	pid_t pid;
+	mmsize_t size;
+};
+typedef struct heapinfo_data_s heapinfo_data_t;
+void kdbg_drv_register(void);
+
+#ifdef __cplusplus
+#define EXTERN extern "C"
+extern "C" {
+#else
+#define EXTERN extern
+#endif
+
+#undef EXTERN
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __INCLUDE_TINYARA_KDBG_DRV_H */

--- a/os/kernel/init/os_bringup.c
+++ b/os/kernel/init/os_bringup.c
@@ -75,6 +75,9 @@
 #ifdef CONFIG_TASK_MANAGER
 #include <tinyara/task_manager_drv.h>
 #endif
+#ifdef CONFIG_KERNEL_CMDS
+#include <tinyara/kdbg_drv.h>
+#endif
 #include "wqueue/wqueue.h"
 #include "init/init.h"
 #ifdef CONFIG_PAGING
@@ -274,6 +277,10 @@ static inline void os_do_appstart(void)
 	if (pid < 0) {
 		svdbg("Failed to create Task Manager\n");
 	}
+#endif
+
+#ifdef CONFIG_KERNEL_CMDS
+	kdbg_drv_register();
 #endif
 
 	svdbg("Starting application main thread\n");


### PR DESCRIPTION
Make kdbg register and Add heapinfo functionality in ioctl.
so calling sched_gettcb is moved to ioctl.