### PR TITLE
framework/media: Add audio rechannel feature for multi channel audio

### DIFF
--- a/framework/src/media/Decoder.h
+++ b/framework/src/media/Decoder.h
@@ -45,11 +45,16 @@ public:
 
 private:
 #ifdef CONFIG_AUDIO_CODEC
-	//static int _configFunc(void *user_data, int audio_type, void *dec_ext);
 	bool mConfig(int audioType);
 	audio_decoder_t mDecoder;
+	/* Coding format type of the input audio data. */
 	audio_type_t mAudioType;
+	/* Number of channels user desired for output PCM data.
+	 * TizenRT Media Framework supports only mono and stereo audio playback.
+	 * So for multiple channel audio playback, decoder can be asked to output PCM data in stereo layout forcely.
+	 */
 	unsigned short mChannels;
+	/* Sample rate of the input audio data. */
 	unsigned int mSampleRate;
 #endif
 };

--- a/framework/src/media/FileInputDataSource.cpp
+++ b/framework/src/media/FileInputDataSource.cpp
@@ -63,7 +63,7 @@ bool FileInputDataSource::open()
 
 		mFp = fopen(mDataPath.c_str(), "rb");
 		if (!mFp) {
-			medvdbg("file open failed error : %d\n", errno);
+			meddbg("file open failed error : %d\n", errno);
 			return false;
 		}
 
@@ -73,7 +73,7 @@ bool FileInputDataSource::open()
 		case AUDIO_TYPE_MP3:
 		case AUDIO_TYPE_AAC:
 			if (!utils::header_parsing(mFp, audioType, &channel, &sampleRate, NULL)) {
-				medvdbg("header parsing failed\n");
+				meddbg("header parsing failed\n");
 				return false;
 			}
 			setSampleRate(sampleRate);
@@ -81,11 +81,7 @@ bool FileInputDataSource::open()
 			break;
 		case AUDIO_TYPE_WAVE:
 			if (!utils::header_parsing(mFp, audioType, &channel, &sampleRate, &pcmFormat)) {
-				medvdbg("header parsing failed\n");
-				return false;
-			}
-			if (fseek(mFp, WAVE_HEADER_LENGTH, SEEK_SET) != 0) {
-				medvdbg("file seek failed error\n");
+				meddbg("header parsing failed\n");
 				return false;
 			}
 			setSampleRate(sampleRate);

--- a/framework/src/media/Make.defs
+++ b/framework/src/media/Make.defs
@@ -31,17 +31,13 @@ CFLAGS += -D__TINYARA__
 ifeq ($(CONFIG_MEDIA), y)
 CXXSRCS += MediaQueue.cpp DataSource.cpp MediaWorker.cpp
 CXXSRCS += StreamBuffer.cpp StreamBufferReader.cpp StreamBufferWriter.cpp
-CXXSRCS += MediaUtils.cpp
+CXXSRCS += MediaUtils.cpp remix.cpp
 CXXSRCS += FocusRequest.cpp FocusManager.cpp
 CSRCS += rb.c rbs.c
 DEPPATH += --dep-path src/media/utils
 VPATH += :src/media/utils
-
-ifeq ($(CONFIG_CODEC_LIBOPUS), y)
-CSRCS += opus_encoder_api.c opus_decoder_api.c
 DEPPATH += --dep-path src/media/codecs
 VPATH += :src/media/codecs
-endif
 
 ifeq ($(CONFIG_MEDIA_PLAYER), y)
 CXXSRCS += MediaPlayer.cpp PlayerWorker.cpp MediaPlayerImpl.cpp PlayerObserverWorker.cpp
@@ -51,7 +47,10 @@ CXXSRCS += HttpInputDataSource.cpp
 ifeq ($(CONFIG_ENABLE_CURL), y)
 CXXSRCS += HttpStream.cpp
 endif
-CXXSRCS += Decoder.cpp audio_decoder.cpp
+CXXSRCS += Decoder.cpp audio_decoder.cpp wav_decoder_api.cpp
+ifeq ($(CONFIG_CODEC_LIBOPUS), y)
+CSRCS += opus_decoder_api.c
+endif
 endif
 
 ifeq ($(CONFIG_MEDIA_RECORDER), y)
@@ -60,6 +59,9 @@ CXXSRCS += OutputHandler.cpp
 CXXSRCS += Encoder.cpp audio_encoder.cpp
 ifeq ($(CONFIG_NET), y)
 CXXSRCS += SocketOutputDataSource.cpp
+endif
+ifeq ($(CONFIG_CODEC_LIBOPUS), y)
+CSRCS += opus_encoder_api.c
 endif
 endif
 

--- a/framework/src/media/audio/audio_manager.c
+++ b/framework/src/media/audio/audio_manager.c
@@ -454,13 +454,14 @@ static unsigned int resample_stream_in(audio_card_info_t *card, void *data, unsi
 	unsigned int resampled_frames = 0;
 	src_data_t srcData = { 0, };
 
-	if ((srcData.channels_num = pcm_get_channels(card->pcm)) == 0) {
+	if ((srcData.origin_channel_num = pcm_get_channels(card->pcm)) == 0) {
 		meddbg("Fail to get channel number\n");
 		return AUDIO_MANAGER_OPERATION_FAIL;
 	}
 
 	srcData.origin_sample_rate = pcm_get_rate(card->pcm);
 	srcData.origin_sample_width = SAMPLE_WIDTH_16BITS;
+	srcData.desired_channel_num = srcData.origin_channel_num; // FIXME: card->resample.user_channel
 	srcData.desired_sample_rate = card->resample.user_sample_rate;
 	srcData.desired_sample_width = SAMPLE_WIDTH_16BITS;
 	srcData.input_frames_used = 0;
@@ -504,9 +505,10 @@ static unsigned int resample_stream_out(audio_card_info_t *card, void *data, uns
 	}
 	rechanneling_ratio = device_channel_num / (float)card->resample.user_channel;
 
-	srcData.channels_num = 2;	// ToDo: Playback with mono will be added later.
+	srcData.origin_channel_num = 2; // ToDo: Playback with mono will be added later. FIXME: card->resample.user_channel
 	srcData.origin_sample_rate = card->resample.user_sample_rate;
 	srcData.origin_sample_width = SAMPLE_WIDTH_16BITS;
+	srcData.desired_channel_num = srcData.origin_channel_num; // FIXME: device_channel_num
 	srcData.desired_sample_rate = pcm_get_rate(card->pcm);
 	srcData.desired_sample_width = SAMPLE_WIDTH_16BITS;
 	srcData.input_frames_used = 0;

--- a/framework/src/media/audio/resample/samplerate.h
+++ b/framework/src/media/audio/resample/samplerate.h
@@ -86,15 +86,16 @@ struct src_data_s {
 	/* input params */
 	const void *data_in;        // pointer to input sample frames buffer (user buffer)
 	int input_frames;           // number of input frames
-	int channels_num;           // number of channels (1: mono, 2: stereo)
 	int origin_sample_rate;     // original sample rate
 	int origin_sample_width;    // original sample width (bits per sample), only support SAMPLE_WIDTH_16BITS now.
+	int origin_channel_num;     // original channel number (1-mono/2-stereo/3-surround/4-quad/5-5.0/6-5.1)
 	void *data_out;             // pointer to output sample buffer (user buffer)
 	int out_buf_length;         // length of data_out buffer (bytes)
 
 	/* input params - specify desired output */
 	int desired_sample_rate;    // target sample rate
 	int desired_sample_width;   // target sample width (bits per sample), only support SAMPLE_WIDTH_16BITS now.
+	int desired_channel_num;    // target channel number (1-mono/2-stereo)
 
 	/* output */
 	int output_frames_gen;      // number of output frames generated

--- a/framework/src/media/codecs/wav_decoder_api.cpp
+++ b/framework/src/media/codecs/wav_decoder_api.cpp
@@ -1,0 +1,299 @@
+/******************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************/
+
+#include <debug.h>
+#include <sys/types.h>
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <debug.h>
+#include <media/MediaTypes.h>
+#include "../utils/internal_defs.h"
+#include "../utils/rbs.h"
+#include "../streaming/audio_decoder.h"
+#include "../audio/resample/samplerate.h"
+#include "wav_decoder_api.h"
+
+namespace media {
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+#define WAVE_HDR_CHUNK_ID       "RIFF"
+#define WAVE_FORMAT_STR         "WAVE"
+#define WAVE_FMT_CHUNK_ID       "fmt "
+#define WAVE_DATA_CHUNK_ID      "data"
+#define WAVE_FMT_CHUNK_SIZE     16
+#define WAVE_FORMAT_PCM         0x0001 // uncompressed PCM
+#define WAVE_FORMAT_EXTENSIBLE  0XFFFE // for multi channel
+
+#define DATAFORMAT_SUBTYPE_PCM  subTypePCM
+#define BYTES_PER_SAMPLE        sizeof(signed short)
+
+/****************************************************************************
+ * Private Declarations
+ ****************************************************************************/
+struct wave_format_ex_s {
+	uint16_t wFormatTag;
+	uint16_t nChannels;
+	uint32_t nSamplesPerSec;
+	uint32_t nAvgBytesPerSec;
+	uint16_t nBlockAlign;
+	uint16_t wBitsPerSample;
+	uint16_t cbSize;
+};
+typedef struct wave_format_ex_s wave_format_ex_t;
+typedef struct wave_format_ex_s *wave_format_ex_p;
+
+struct wave_format_extensible_s {
+	wave_format_ex_t tFormat;
+	union {
+		uint16_t wValidBitsPerSample; /* bits of precision */
+		uint16_t wSamplesPerBlock;    /* valid if wBitsPerSample==0 */
+		uint16_t wReserved;           /* If neither applies, set to zero. */
+	} uSamples;
+	uint32_t dwChannelMask;           /* which channels are present in stream */
+	uint8_t subFormat[32];            /* GUID */
+};
+typedef struct wave_format_extensible_s wave_format_extensible_t;
+typedef struct wave_format_extensible_s *wave_format_extensible_p;
+
+// GUID for PCM sub-format
+static const uint8_t subTypePCM[] = {
+	0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x10, 0x00, 0x80, 0x00, 0x00, 0xaa, 0x00, 0x38, 0x9b, 0x71
+};
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+static uint32_t _le_num_at(const uint8_t *ptr, uint8_t bytes)
+{
+	unsigned int ret = 0;
+	for (int i = bytes - 1; i >= 0; i--) {
+		ret <<= 8;
+		ret |= ptr[i];
+	}
+	return ret;
+}
+
+static ssize_t _source_read_at(rbstream_p fp, ssize_t offset, void *data, size_t size)
+{
+	int retVal = rbs_seek(fp, offset, SEEK_SET);
+	RETURN_VAL_IF_FAIL((retVal == OK), SIZE_ZERO);
+
+	return rbs_read(data, 1, size, fp);
+}
+
+static bool _format_parse(void *buffer, uint32_t size, wave_format_extensible_p ext)
+{
+	RETURN_VAL_IF_FAIL((buffer != NULL || size >= 8 + WAVE_FMT_CHUNK_SIZE), false);
+	RETURN_VAL_IF_FAIL((ext != NULL), false);
+
+	RETURN_VAL_IF_FAIL((memcmp(buffer, WAVE_FMT_CHUNK_ID, 4) == OK), false);
+
+	wave_format_ex_p ex = &ext->tFormat;
+	uint8_t *fmtChunk = (uint8_t *)buffer;
+	uint32_t chunkSize = _le_num_at(&fmtChunk[4], 4);
+
+	ex->wFormatTag = _le_num_at(&fmtChunk[8], 2);
+	if ((ex->wFormatTag == WAVE_FORMAT_PCM) && (chunkSize == WAVE_FMT_CHUNK_SIZE)) {
+		ex->cbSize = 0; // uncompressed PCM
+	} else if (ex->wFormatTag == WAVE_FORMAT_EXTENSIBLE) {
+		RETURN_VAL_IF_FAIL((size >= 8 + chunkSize), false);
+		ex->cbSize = _le_num_at(&fmtChunk[8 + WAVE_FMT_CHUNK_SIZE], 2);
+		RETURN_VAL_IF_FAIL((WAVE_FMT_CHUNK_SIZE + 2 + ex->cbSize <= chunkSize), false);
+	} else {
+		meddbg("Unsupported format %u, chunkSize %u\n", ex->wFormatTag, chunkSize);
+		return false;
+	}
+
+	ex->nChannels = _le_num_at(&fmtChunk[10], 2);
+	if (ex->nChannels > 6) {
+		// we support 5.1 channel at most
+		meddbg("Unsupported channels: %u\n", ex->nChannels);
+		return false;
+	}
+
+	ex->nSamplesPerSec = _le_num_at(&fmtChunk[12], 4);
+	ex->nAvgBytesPerSec = _le_num_at(&fmtChunk[16], 4);
+	ex->nBlockAlign = _le_num_at(&fmtChunk[20], 2);
+	ex->wBitsPerSample = _le_num_at(&fmtChunk[22], 2);
+	if (ex->wBitsPerSample != 16) {
+		// we support AUDIO_FORMAT_TYPE_S16_LE only
+		meddbg("Unsupported bitsPerSample: %u\n", ex->wBitsPerSample);
+		return false;
+	}
+
+	if (ex->cbSize != 0) {
+		// There's extensible params
+		uint8_t *extraData = &fmtChunk[8 + WAVE_FMT_CHUNK_SIZE + 2];
+		ext->uSamples.wValidBitsPerSample = _le_num_at(&extraData[0], 2);
+		if (ext->uSamples.wValidBitsPerSample != 16) {
+			// we support AUDIO_FORMAT_TYPE_S16_LE only
+			meddbg("Unsupported validBitsPerSample: %u\n", ext->uSamples.wValidBitsPerSample);
+			return false;
+		}
+
+		ext->dwChannelMask = _le_num_at(&extraData[2], 4);
+		RETURN_VAL_IF_FAIL((ex->cbSize - 6 <= sizeof(ext->subFormat)), false);
+		memcpy((void *)ext->subFormat, (const void *)&extraData[6], ex->cbSize - 6);
+		if (memcmp(DATAFORMAT_SUBTYPE_PCM, ext->subFormat, sizeof(DATAFORMAT_SUBTYPE_PCM)) != OK) {
+			meddbg("Unsupported sub format...\n");
+			return false;
+		}
+	}
+
+	return true;
+}
+
+
+// Initialize the wav reader.
+int wav_init(audio_decoder_p decoder, void *dec_ext)
+{
+	decoder->dec_ext = calloc(1, sizeof(wav_dec_external_t));
+	RETURN_VAL_IF_FAIL((decoder->dec_ext != NULL), AUDIO_DECODER_ERROR);
+
+	*((wav_dec_external_t *)decoder->dec_ext) = *((wav_dec_external_t *)dec_ext);
+
+	decoder->dec_mem = calloc(1, sizeof(wave_format_extensible_t));
+	RETURN_VAL_IF_FAIL((decoder->dec_mem != NULL), AUDIO_DECODER_ERROR);
+	memset(decoder->dec_mem, 0, sizeof(wave_format_extensible_t));
+
+	return AUDIO_DECODER_OK;
+}
+
+bool wav_check_type(rbstream_p rbsp)
+{
+	uint8_t waveheader[WAVE_HEADER_LENGTH];
+	ssize_t rlen = _source_read_at(rbsp, 0, waveheader, sizeof(waveheader));
+	RETURN_VAL_IF_FAIL(((size_t)rlen == sizeof(waveheader)), false);
+	// check "RIFF" chunk
+	RETURN_VAL_IF_FAIL((memcmp(&waveheader[0], WAVE_HDR_CHUNK_ID, 4) == OK), false);
+	RETURN_VAL_IF_FAIL((memcmp(&waveheader[8], WAVE_FORMAT_STR, 4) == OK), false);
+	// check "fmt" sub-chunk
+	RETURN_VAL_IF_FAIL((memcmp(&waveheader[12], WAVE_FMT_CHUNK_ID, 4) == OK), false);
+	return true;
+}
+
+// Get frames as much as possible according to buffer size.
+bool wav_get_frame(rbstream_p mFp, ssize_t *offset, void *dec_mem, void *buffer, uint32_t *size)
+{
+	wave_format_extensible_p ext = (wave_format_extensible_p)dec_mem;
+	ssize_t n;
+	ssize_t _offset = *offset;
+	if (_offset == 0) {
+		if (!wav_check_type(mFp)) {
+			meddbg("wav_check_type failed!\n");
+			return false;
+		}
+
+		_offset = 12; // "fmt" chunk start
+		uint8_t sizeBuf[4];
+		n = _source_read_at(mFp, _offset + 4, sizeBuf, sizeof(sizeBuf));
+		RETURN_VAL_IF_FAIL(((size_t)n == sizeof(sizeBuf)), false);
+		uint32_t chunkSize = _le_num_at(&sizeBuf[0], 4);
+		uint8_t fmtChunk[8 + chunkSize];
+		n = _source_read_at(mFp, _offset, fmtChunk, sizeof(fmtChunk));
+		RETURN_VAL_IF_FAIL(((size_t)n == sizeof(fmtChunk)), false);
+		RETURN_VAL_IF_FAIL((_format_parse((void *)fmtChunk, sizeof(fmtChunk), ext)), false);
+		_offset += (8 + chunkSize);
+
+		uint8_t subChunk[8];
+		while (1) {
+			n = _source_read_at(mFp, _offset, subChunk, sizeof(subChunk));
+			RETURN_VAL_IF_FAIL(((size_t)n == sizeof(subChunk)), false);
+			_offset += n;
+			if (memcmp(&subChunk[0], WAVE_DATA_CHUNK_ID, 4) == OK) {
+				// "data" chunk found
+				break;
+			}
+
+			// Ignore all other extra chunks
+			uint32_t subChunkSize = _le_num_at(&subChunk[4], 4);
+			_offset += subChunkSize;
+		}
+
+		int ret = rbs_seek_ext(mFp, _offset, SEEK_SET);
+		RETURN_VAL_IF_FAIL((ret == OK), false);
+		*offset = _offset;
+	}
+
+	n = _source_read_at(mFp, _offset, buffer, *size);
+	RETURN_VAL_IF_FAIL((n > 0), false);
+
+	size_t frames = n / BYTES_PER_SAMPLE / ext->tFormat.nChannels;
+	*size = frames * ext->tFormat.nChannels * BYTES_PER_SAMPLE;
+	RETURN_VAL_IF_FAIL((*size > 0), false);
+
+	_offset += *size;
+	rbs_seek_ext(mFp, _offset, SEEK_SET);
+	*offset = _offset;
+	return true;
+}
+
+int wav_decode_frame(wav_dec_external_p dec_ext, void *dec_mem, src_handle_t *resampler)
+{
+	wave_format_extensible_p wav_ext = (wave_format_extensible_p)dec_mem;
+	wave_format_ex_p wav_fmt_ex = &wav_ext->tFormat;
+
+	// support uncompressed PCM(16-bit) only, just do rechanneling if necessary.
+	int32_t nFrames = dec_ext->inputBufferCurrentLength / BYTES_PER_SAMPLE / wav_fmt_ex->nChannels;
+
+	// if user specified a different channel number
+	if (wav_fmt_ex->nChannels != dec_ext->desiredChannels) {
+		// then process rechanneling
+		if (*resampler == NULL) {
+			*resampler = src_init(CONFIG_AUDIO_RESAMPLER_BUFSIZE);
+			if (*resampler == NULL) {
+				meddbg("resampler init failed!\n");
+				return AUDIO_DECODER_ERROR;
+			}
+		}
+
+		src_data_t srcData = { 0, };
+		srcData.origin_channel_num = wav_fmt_ex->nChannels;
+		srcData.desired_channel_num = dec_ext->desiredChannels;
+		srcData.origin_sample_rate = wav_fmt_ex->nSamplesPerSec;
+		srcData.desired_sample_rate = wav_fmt_ex->nSamplesPerSec;
+		srcData.origin_sample_width = SAMPLE_WIDTH_16BITS;
+		srcData.desired_sample_width = SAMPLE_WIDTH_16BITS;
+		srcData.data_in = dec_ext->pInputBuffer;
+		srcData.input_frames = nFrames;
+		srcData.data_out = dec_ext->pOutputBuffer;
+		srcData.out_buf_length = dec_ext->outputBufferMaxLength;
+
+		int ret = src_simple(*resampler, &srcData);
+		if (ret != SRC_ERR_NO_ERROR) {
+			meddbg("Fail to rechannel %d -> %d, err %d\n", wav_fmt_ex->nChannels, dec_ext->desiredChannels, ret);
+			return AUDIO_DECODER_ERROR;
+		}
+
+		if (srcData.output_frames_gen != srcData.input_frames) {
+			meddbg("need to reconfig: inputBufferMaxLength <= outputBufferMaxLength\n");
+			return AUDIO_DECODER_ERROR;
+		}
+	} else {
+		memcpy(dec_ext->pOutputBuffer, dec_ext->pInputBuffer, dec_ext->inputBufferCurrentLength);
+	}
+
+	dec_ext->outputFrameSize = nFrames;
+	dec_ext->samplingRate = wav_fmt_ex->nSamplesPerSec;
+	return AUDIO_DECODER_OK;
+}
+
+}

--- a/framework/src/media/codecs/wav_decoder_api.h
+++ b/framework/src/media/codecs/wav_decoder_api.h
@@ -1,0 +1,94 @@
+/******************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************/
+
+#ifndef WAV_DECODER_API_H
+#define WAV_DECODER_API_H
+
+#include "../utils/rbs.h"
+#include <stdint.h>
+
+namespace media {
+
+struct audio_decoder_s;
+typedef struct audio_decoder_s *audio_decoder_p;
+typedef void *src_handle_t;
+
+struct wav_dec_external_s {
+	/*
+	 * INPUT:
+	 * Pointer to the input buffer that contains the wav data.
+	 */
+	uint8_t *pInputBuffer;
+
+	/*
+	 * INPUT:
+	 * The actual size (in bytes) of the buffer.
+	 */
+	int32_t inputBufferMaxLength;
+
+	/*
+	 * INPUT:
+	 * Number of valid bytes in the input buffer, that is the bytes of whole opus packet.
+	 */
+	int32_t inputBufferCurrentLength;
+
+	/*
+	 * INPUT:
+	 * Number of requested output audio channels.
+	 * Wav decoder conversions internally.
+	 */
+	int32_t desiredChannels;
+
+	/*
+	 * INPUT: (but what is pointed to is an output)
+	 * Pointer to the output buffer to hold the 16-bit PCM audio samples.
+	 * If the output is stereo, both left and right channels will be stored in this one buffer.
+	 */
+	int16_t *pOutputBuffer;
+
+	/*
+	 * INPUT:
+	 * The actual size (in bytes) of the buffer.
+	 */
+	int32_t outputBufferMaxLength;
+
+	/*
+	 * OUTPUT:
+	 * Sample rate in Hz of the output PCM data.
+	 */
+	int32_t samplingRate;
+
+	/*
+	 * OUTPUT:
+	 * Size of the output frames, one frame consists of 16bit-PCM samples of all channels.
+	 */
+	int32_t outputFrameSize;
+};
+
+typedef struct wav_dec_external_s wav_dec_external_t;
+typedef struct wav_dec_external_s *wav_dec_external_p;
+
+int wav_init(audio_decoder_p decoder, void *dec_ext);
+bool wav_check_type(rbstream_p rbsp);
+bool wav_get_frame(rbstream_p mFp, ssize_t *offset, void *dec_mem, void *buffer, uint32_t *size);
+int wav_decode_frame(wav_dec_external_p dec_ext, void *dec_mem, src_handle_t *resampler);
+
+}
+
+#endif /* WAV_DECODER_API_H */
+

--- a/framework/src/media/streaming/audio_decoder.h
+++ b/framework/src/media/streaming/audio_decoder.h
@@ -24,6 +24,7 @@
 #include <audiocodec/mp3dec/pvmp3decoder_api.h>
 #include <audiocodec/aacdec/pvmp4audiodecoder_api.h>
 #include <media/MediaTypes.h>
+#include "../codecs/wav_decoder_api.h"
 #ifdef CONFIG_CODEC_LIBOPUS
 #include "../codecs/opus_decoder_api.h"
 #endif

--- a/framework/src/media/utils/MediaUtils.h
+++ b/framework/src/media/utils/MediaUtils.h
@@ -97,6 +97,18 @@ bool createWavHeader(FILE *fp);
  * @since TizenRT v2.1 PRE
  */
 bool writeWavHeader(FILE *fp, unsigned int channel, unsigned int sampleRate, audio_format_type_t pcmFormat, unsigned int fileSize);
+/*
+ * @brief Split specified channels from an input audio stream into separated output buffers.
+ * @details @b #include <media/MediaUtils.h>
+ * @param[in] layout: the channel layout of the input audio stream
+ * @param[in] stream: pointer to the input audio stream
+ * @param[in] frames: number of frames in input stream
+ * @param[in] channels: number of channels to split from input audio stream
+ * @param[in] ...: variable arguments in pairs <uint32_t, int16_t *> to tell channel masks and output buffers
+ * @return channel masks to tell the channels split successfully
+ * @since TizenRT v2.1 PRE
+ */
+unsigned int splitChannel(unsigned int layout, const signed short *stream, unsigned int frames, unsigned int channels, ...);
 } // namespace utils
 } // namespace media
 

--- a/framework/src/media/utils/remix.cpp
+++ b/framework/src/media/utils/remix.cpp
@@ -1,0 +1,321 @@
+/****************************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+#include <string.h>
+#include <debug.h>
+#include <media/MediaTypes.h>
+#include "internal_defs.h"
+#include "remix.h"
+
+using namespace media;
+
+// audio channel masks
+#define CH_MASK_FL                0x00000001 // Front Left
+#define CH_MASK_FR                0x00000002 // Front Right
+#define CH_MASK_FC                0x00000004 // Front Center
+#define CH_MASK_LF                0x00000008 // Low Frequency
+#define CH_MASK_BL                0x00000010 // Back Left
+#define CH_MASK_BR                0x00000020 // Back Right
+#define CH_MASK_FLC               0x00000040 // Front Left of Center
+#define CH_MASK_FRC               0x00000080 // Front Right of Center
+#define CH_MASK_BC                0x00000100 // Back Center
+#define CH_MASK_SL                0x00000200 // Side Left
+#define CH_MASK_SR                0x00000400 // Side Right
+#define CH_MASK_TC                0x00000800 // Top Center
+#define CH_MASK_TFL               0x00001000 // Top Front Left
+#define CH_MASK_TFC               0x00002000 // Top Front Center
+#define CH_MASK_TFR               0x00004000 // Top Front Right
+#define CH_MASK_TBL               0x00008000 // Top Back Left
+#define CH_MASK_TBC               0x00010000 // Top Back Center
+#define CH_MASK_TBR               0x00020000 // Top Back Right
+
+// audio channel layouts
+#define CH_LAYOUT_MONO            (CH_MASK_FC)
+#define CH_LAYOUT_STEREO          (CH_MASK_FL | CH_MASK_FR)
+#define CH_LAYOUT_2POINT1         (CH_LAYOUT_STEREO | CH_MASK_LF)
+#define CH_LAYOUT_SURROUND        (CH_LAYOUT_STEREO | CH_MASK_FC)
+#define CH_LAYOUT_3POINT1         (CH_LAYOUT_SURROUND | CH_MASK_LF)
+#define CH_LAYOUT_QUAD            (CH_LAYOUT_STEREO | CH_MASK_BL | CH_MASK_BR)
+#define CH_LAYOUT_5POINT0         (CH_LAYOUT_SURROUND | CH_MASK_SL | CH_MASK_SR)
+#define CH_LAYOUT_5POINT1         (CH_LAYOUT_5POINT0 | CH_MASK_LF)
+#define CH_LAYOUT_5POINT0_BACK    (CH_LAYOUT_SURROUND | CH_MASK_BL | CH_MASK_BR)
+#define CH_LAYOUT_5POINT1_BACK    (CH_LAYOUT_5POINT0_BACK | CH_MASK_LF)
+
+/*
+ Simply upmix or downmix audio channels as the following table:
+ [0~5] mean channel position in order in one frame.
+ For all *.1 layouts, we always ignore LOW_FREQUENCY channel.
+ (Content intended for the Low Frequency channel may not be rendered on the
+ speaker that the data is sent to. This is because there is no way to guarantee the
+ frequency range of the low frequency speaker in a user's system. For this reason,
+ a speaker that is receiving low frequency audio might filter the frequencies that
+ it cannot handle.)
+
+ In-Channels    Out-Channels    Rules
+ 1 (Mono)       2 (Stereo)      output[0] = input[0]
+                                output[1] = input[0]
+ 2 (Stereo)     1 (Mono)        output[0] = 0.5 * (input[0] + input[1])
+ 3 (2.1)        2 (Stereo)      output[0] = input[0]
+                                output[1] = input[1]
+   (Surround)   2 (Stereo)      output[0] = input[0] + 0.5 * input[2]
+                                output[1] = input[1] + 0.5 * input[2]
+ 4 (3.1)        2 (Stereo)      output[0] = input[0] + 0.5 * input[2]
+                                output[1] = input[1] + 0.5 * input[2]
+   (Quad)       2 (Stereo)      output[0] = 0.5 * (input[0] + input[2])
+                                output[1] = 0.5 * (input[1] + input[3])
+ 5 (5.0)        2 (Stereo)      output[0] = input[0] + coeff * (input[2] + input[3])
+                                output[1] = input[1] + coeff * (input[2] + input[4])
+ 6 (5.1)        2 (Stereo)      output[0] = input[0] + coeff * (input[2] + input[4])
+                                output[1] = input[1] + coeff * (input[2] + input[5])
+*/
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+#define MIX_COEFF   7071 / 1000 // 0.7071, DONOT (7071 / 1000)
+
+/****************************************************************************
+ * Private Declarations
+ ****************************************************************************/
+
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+// Map channel layout to channel number
+uint32_t layout2ch(uint32_t layout)
+{
+	switch (layout) {
+	case CH_LAYOUT_MONO:
+		return 1;
+	case CH_LAYOUT_STEREO:
+		return 2;
+	case CH_LAYOUT_2POINT1:
+		return 3;
+	case CH_LAYOUT_SURROUND:
+		return 3;
+	case CH_LAYOUT_3POINT1:
+		return 4;
+	case CH_LAYOUT_QUAD:
+		return 4;
+	case CH_LAYOUT_5POINT0_BACK:
+		return 5;
+	case CH_LAYOUT_5POINT1_BACK:
+		return 6;
+	default:
+		return 0;
+	}
+}
+
+uint32_t ch2layout(uint32_t nb_chs)
+{
+	switch (nb_chs) {
+	case 1:
+		return CH_LAYOUT_MONO;
+	case 2:
+		return CH_LAYOUT_STEREO;
+	case 3:
+		return CH_LAYOUT_SURROUND;
+	case 4:
+		return CH_LAYOUT_QUAD;
+	case 5:
+		return CH_LAYOUT_5POINT0_BACK;
+	case 6:
+		return CH_LAYOUT_5POINT1_BACK;
+	default:
+		return 0;
+	}
+}
+
+// Clip an integer value (32 bits) to a signed short type value(16 bits)
+static int16_t clip(int32_t x)
+{
+	if (x < INT16_MIN) {
+		return INT16_MIN;
+	} else if (x > INT16_MAX) {
+		return INT16_MAX;
+	}
+
+	return x;
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+int32_t rechannel(uint32_t in_layout, uint32_t out_layout, const int16_t *input, uint32_t in_frames, int16_t *output, uint32_t max_frames)
+{
+	RETURN_VAL_IF_FAIL((input != NULL), -1);
+	RETURN_VAL_IF_FAIL((output != NULL), -1);
+	RETURN_VAL_IF_FAIL((out_layout == CH_LAYOUT_MONO || out_layout == CH_LAYOUT_STEREO), -1);
+
+	uint32_t out_frames = MINIMUM(in_frames, max_frames);
+
+	if (in_layout == out_layout) {
+		// Same layout
+		if (output != input) {
+			memcpy((void *)output, (const void *)input, out_frames * layout2ch(out_layout) * sizeof(int16_t));
+		}
+		return (int32_t)out_frames;
+	}
+
+	// Multi -> mono in two steps
+	if ((in_layout != CH_LAYOUT_MONO && in_layout != CH_LAYOUT_STEREO) && (out_layout == CH_LAYOUT_MONO)) {
+		// Firstly, multi -> stereo
+		int32_t ret = rechannel(in_layout, CH_LAYOUT_STEREO, input, in_frames, output, max_frames);
+		if (ret < 0) {
+			return ret;
+		}
+		// And then, stereo -> mono
+		return rechannel(CH_LAYOUT_STEREO, CH_LAYOUT_MONO, output, (uint32_t)ret, output, max_frames);
+	}
+
+	// Now consider scenarios:
+	// stereo -> mono, mono -> stereo, multi -> stereo.
+
+	const int16_t *in_fl, *in_fr, *in_fc, /* *in_lfe, */ *in_bl, *in_br;
+	uint32_t in_ch = layout2ch(in_layout);
+	uint32_t out_ch = layout2ch(out_layout);
+	uint32_t out_samples = out_frames * out_ch;
+	int16_t *out_end = &output[out_samples];
+	int16_t *out_fl = &output[0];
+	int16_t *out_fr = &output[1];
+	int16_t *out_fc;
+
+	switch (in_layout) {
+	case CH_LAYOUT_MONO: { // out_layout: CH_LAYOUT_STEREO
+		// Maybe input == output, upmix backward.
+		in_fc = &input[out_frames * in_ch - 1];
+		out_fl = &output[out_samples - 2];
+		out_fr = &output[out_samples - 1];
+
+		while (output <= out_fl) {
+			*out_fr = *in_fc;
+			*out_fl = *in_fc;
+
+			out_fr -= out_ch;
+			out_fl -= out_ch;
+			in_fc -= in_ch;
+		}
+	} break;
+
+	case CH_LAYOUT_STEREO: { // out_layout: CH_LAYOUT_MONO
+		in_fl = &input[0];
+		in_fr = &input[1];
+		out_fc = &output[0];
+
+		while (out_fc < out_end) {
+			*out_fc = ((int32_t)*in_fl + *in_fr) / 2;
+
+			out_fc += out_ch;
+			in_fl += in_ch;
+			in_fr += in_ch;
+		}
+	} break;
+
+	// Below cases process: multi -> stereo
+
+	case CH_LAYOUT_2POINT1: {
+		in_fl = &input[0];
+		in_fr = &input[1];
+		// in_lfe at &input[2]
+
+		while (out_fl < out_end) {
+			*out_fl = *in_fl;
+			*out_fr = *in_fr;
+
+			out_fl += out_ch;
+			out_fr += out_ch;
+			in_fl += in_ch;
+			in_fr += in_ch;
+		}
+	} break;
+
+	case CH_LAYOUT_3POINT1:  // fall through
+	case CH_LAYOUT_SURROUND: {
+		in_fl = &input[0];
+		in_fr = &input[1];
+		in_fc = &input[2];
+		// in_lfe at &input[3]
+
+		while (out_fl < out_end) {
+			*out_fl = clip((int32_t)*in_fl + *in_fc / 2);
+			*out_fr = clip((int32_t)*in_fr + *in_fc / 2);
+
+			out_fl += out_ch;
+			out_fr += out_ch;
+			in_fl += in_ch;
+			in_fr += in_ch;
+			in_fc += in_ch;
+		}
+	} break;
+
+	case CH_LAYOUT_QUAD: {
+		in_fl = &input[0];
+		in_fr = &input[1];
+		in_bl = &input[2];
+		in_br = &input[3];
+
+		while (out_fl < out_end) {
+			*out_fl = ((int32_t)*in_fl + *in_bl) / 2;
+			*out_fr = ((int32_t)*in_fr + *in_br) / 2;
+
+			out_fl += out_ch;
+			out_fr += out_ch;
+			in_fl += in_ch;
+			in_fr += in_ch;
+			in_bl += in_ch;
+			in_br += in_ch;
+		}
+	} break;
+
+	case CH_LAYOUT_5POINT1_BACK: // fall through
+	case CH_LAYOUT_5POINT0_BACK: {
+		in_fl = &input[0];
+		in_fr = &input[1];
+		in_fc = &input[2];
+		if (in_layout == CH_LAYOUT_5POINT1_BACK) {
+			// in_lfe at &input[3]
+			in_bl = &input[4];
+			in_br = &input[5];
+		} else {
+			in_bl = &input[3];
+			in_br = &input[4];
+		}
+
+		while (out_fl < out_end) {
+			*out_fl = clip(*in_fl + ((int32_t)*in_fc + *in_bl) * MIX_COEFF);
+			*out_fr = clip(*in_fr + ((int32_t)*in_fc + *in_br) * MIX_COEFF);
+
+			out_fl += out_ch;
+			out_fr += out_ch;
+			in_fl += in_ch;
+			in_fr += in_ch;
+			in_fc += in_ch;
+			in_bl += in_ch;
+			in_br += in_ch;
+		}
+	} break;
+
+	default:
+		// unsupported in_layout
+		meddbg("unsupported in_layout 0x%x\n", in_layout);
+		return -1;
+	}
+
+	return (int32_t)out_frames;
+}

--- a/framework/src/media/utils/remix.h
+++ b/framework/src/media/utils/remix.h
@@ -1,0 +1,59 @@
+/****************************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+#ifndef REMIX_H
+#define REMIX_H
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
+/**
+ * @brief   Get number of channels of the given channle layout
+ * @param   layout: channel layout
+ * @return  number of channels, return 0 if the given layout is unsupported
+ */
+uint32_t layout2ch(uint32_t layout);
+
+/**
+ * @brief   Get default layout which has the given number of channels
+ * @param   nb_chs: number of channels
+ * @return  channel layout, return 0 if the given number channels is unsupported
+ */
+uint32_t ch2layout(uint32_t nb_chs);
+
+/**
+ * @brief   Remix audio channel
+ * @remarks Support multi-channel to stereo, stereo to mono, and mono to stereo.
+ * @param   in_layout: channel layout of the input audio
+ * @param   out_layout: channel layout desired for the output, supports Mono/Stereo only.
+ * @param   input: pointer to the input buffer
+ * @param   in_frames: number of frames in input buffer
+ * @param   output: pointer to the output buffer, it can be same with input buffer
+ * @param   max_frames: maximum of frames in specified layout can be stored in output buffer
+ * @return  number of frames remixed and stored in output buffer, return negative value on failure.
+ */
+int32_t rechannel(uint32_t in_layout, uint32_t out_layout, const int16_t *input, uint32_t in_frames, int16_t *output, uint32_t max_frames);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif /* __cplusplus */
+
+#endif /* REMIX_H */


### PR DESCRIPTION
1. Add remix.c to convert multichannel to stereo/mono.
2. Update samplerate.c to support rechannel in src_simple().
3. Modify Decoder.cpp and other files to support multichannel *.wav.

@Taejun-Kwon @junmin-kim @jsdosa @JeonginKim 