### PR TITLE
testcase/kernel : Use a virtual driver to test kernel internal APIs.

### DIFF
--- a/apps/examples/testcase/le_tc/kernel/tc_clock.c
+++ b/apps/examples/testcase/le_tc/kernel/tc_clock.c
@@ -27,7 +27,8 @@
 #include <time.h>
 #include <tinyara/time.h>
 #include <sys/time.h>
-#include "../../../../../os/kernel/clock/clock.h"
+#include <sys/ioctl.h>
+#include <tinyara/testcase_drv.h>
 #include "tc_internal.h"
 
 const long double l_day = 86400;
@@ -166,23 +167,23 @@ static void tc_clock_clock_gettimeofday(void)
  */
 static void tc_clock_clock_abstime2ticks(void)
 {
-	int ret_chk;
+	int fd;
 	int base_tick;
 	int comparison_tick;
 	struct timespec base_time;
 	struct timespec comparison_time;
 
+	fd = tc_get_drvfd();
 	clock_gettime(CLOCK_REALTIME, &base_time);
 	comparison_time.tv_sec = base_time.tv_sec + 1;
 
-	ret_chk = clock_abstime2ticks(CLOCK_REALTIME, &base_time, &base_tick);
-	TC_ASSERT_EQ("clock_abstime2ticks", ret_chk, OK);
+	base_tick = ioctl(fd, TESTIOC_CLOCK_ABSTIME2TICKS, base_time.tv_sec);
+	TC_ASSERT_NEQ("clock_abstime2ticks", base_tick, ERROR);
 
-	ret_chk = clock_abstime2ticks(CLOCK_REALTIME, &comparison_time, &comparison_tick);
-	TC_ASSERT_EQ("clock_abstime2ticks", ret_chk, OK);
+	comparison_tick = ioctl(fd, TESTIOC_CLOCK_ABSTIME2TICKS, comparison_time.tv_sec);
+	TC_ASSERT_NEQ("clock_abstime2ticks", comparison_tick, ERROR);
 
 	/* the difference can be 0 or 1, but should be smaller than 2 */
-
 	TC_ASSERT_GEQ("clock_abstime2ticks", comparison_tick - (base_tick * 2), 2);
 
 	TC_SUCCESS_RESULT();

--- a/apps/examples/testcase/le_tc/kernel/tc_internal.h
+++ b/apps/examples/testcase/le_tc/kernel/tc_internal.h
@@ -98,6 +98,6 @@ int itc_semaphore_main(void);
 int itc_sched_main(void);
 int itc_timer_main(void);
 int itc_pthread_main(void);
-
+int tc_get_drvfd(void);
 
 #endif /* __EXAMPLES_TESTCASE_KERNEL_TC_INTERNAL_H */

--- a/apps/examples/testcase/le_tc/kernel/tc_timer.c
+++ b/apps/examples/testcase/le_tc/kernel/tc_timer.c
@@ -21,6 +21,8 @@
 #include <tinyara/config.h>
 #include <stdio.h>
 #include <errno.h>
+#include <sys/ioctl.h>
+#include <tinyara/testcase_drv.h>
 #include "../../os/kernel/timer/timer.h"
 #include "tc_internal.h"
 
@@ -264,6 +266,9 @@ static void tc_timer_timer_initialize(void)
 	FAR struct posix_timer_s *timer;
 	FAR struct posix_timer_s *next;
 
+	int fd;
+	fd = tc_get_drvfd();
+
 	int initalloc_cnt = 0;
 	int initfree_cnt = 0;
 	int createalloc_cnt = 0;
@@ -277,7 +282,7 @@ static void tc_timer_timer_initialize(void)
 	st_sigevent.sigev_value.sival_ptr = &timer_id;
 
 	/* check the count for g_alloctimers and g_freetimers after timer_initialize */
-	timer_initialize();
+	(void)ioctl(fd, TESTIOC_TIMER_INITIALIZE, 0);
 
 	for (timer = (FAR struct posix_timer_s *)g_alloctimers.head; timer; timer = next) {
 		next = timer->flink;
@@ -305,7 +310,7 @@ static void tc_timer_timer_initialize(void)
 	}
 
 	/* check the count for g_alloctimers and g_freetimers after timer_initialize now they change to original value */
-	timer_initialize();
+	(void)ioctl(fd, TESTIOC_TIMER_INITIALIZE, 0);
 
 	for (timer = (FAR struct posix_timer_s *)g_alloctimers.head; timer; timer = next) {
 		next = timer->flink;

--- a/os/drivers/testcase/Make.defs
+++ b/os/drivers/testcase/Make.defs
@@ -21,6 +21,8 @@ ifeq ($(CONFIG_KERNEL_TEST_DRV),y)
 
 CSRCS += testcase_drv.c
 
+CFLAGS += -I$(TOPDIR)/kernel
+
 # Include testcase driver support
 
 DEPPATH += --dep-path testcase

--- a/os/drivers/testcase/testcase_drv.c
+++ b/os/drivers/testcase/testcase_drv.c
@@ -22,8 +22,14 @@
 #include <tinyara/config.h>
 #include <errno.h>
 #include <debug.h>
+#include <unistd.h>
+#include <time.h>
 #include <tinyara/fs/fs.h>
 #include <tinyara/testcase_drv.h>
+#include <tinyara/sched.h>
+#include "clock/clock.h"
+#include "signal/signal.h"
+#include "timer/timer.h"
 
 /****************************************************************************
  * Private Function Prototypes
@@ -37,20 +43,21 @@ static ssize_t testdrv_write(FAR struct file *filep, FAR const char *buffer, siz
  ****************************************************************************/
 
 static const struct file_operations testdrv_fops = {
-	0,							/* open */
-	0,							/* close */
-	testdrv_read,						/* read */
-	testdrv_write,						/* write */
-	0,							/* seek */
-	testdrv_ioctl						/* ioctl */
+	0,                                                   /* open */
+	0,                                                   /* close */
+	testdrv_read,                                        /* read */
+	testdrv_write,                                       /* write */
+	0,                                                   /* seek */
+	testdrv_ioctl                                        /* ioctl */
 #ifndef CONFIG_DISABLE_POLL
-	, 0							/* poll */
+	, 0                                                  /* poll */
 #endif
 };
 
 /****************************************************************************
  * Private Functions
  ****************************************************************************/
+
 /************************************************************************************
  * Name: testdrv_ioctl
  *
@@ -61,9 +68,9 @@ static const struct file_operations testdrv_fops = {
 static int testdrv_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
 {
 	int ret = -EINVAL;
-
-	vdbg("cmd: %d arg: %ld\n", cmd, arg);
-
+	struct timespec base_time;
+	struct tcb_s *tcb;
+	FAR sigactq_t *sigact;
 	/* Handle built-in ioctl commands */
 
 	switch (cmd) {
@@ -72,8 +79,94 @@ static int testdrv_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
 	 *   ioctl argument:  An integer value indicating the particular test to be run
 	 */
 
-	case TESTIOC_DRIVER_ANALOG: {
+	case TESTIOC_ANALOG: {
 
+	}
+	break;
+
+	case TESTIOC_CLOCK_ABSTIME2TICKS: {
+		base_time.tv_sec = (time_t)arg;
+		base_time.tv_nsec = 0;
+		if (clock_abstime2ticks(CLOCK_REALTIME, &base_time, &ret) != OK) {
+			ret = ERROR;
+		}
+	}
+	break;
+
+	case TESTIOC_GET_SELF_PID: {
+		tcb =  sched_self();
+		if (tcb == NULL) {
+			ret = ERROR;
+			break;
+		}
+		ret = tcb->pid;
+	}
+	break;
+
+	case TESTIOC_GET_SIG_FINDACTION_ADD: {
+		sigact = sig_findaction(sched_self(), (int)arg);
+		ret = (int)sigact;
+	}
+	break;
+
+	case TESTIOC_IS_ALIVE_THREAD: {
+		tcb = sched_gettcb((pid_t)arg);
+		if (tcb == NULL) {
+			ret = ERROR;
+			break;
+		}
+		ret = OK;
+	}
+	break;
+
+	case TESTIOC_GET_TCB_SIGPROCMASK: {
+		tcb = sched_gettcb((pid_t)arg);
+		if (tcb == NULL) {
+			ret = ERROR;
+			break;
+		}
+		ret = tcb->sigprocmask;
+	}
+	break;
+
+	case TESTIOC_GET_TCB_ADJ_STACK_SIZE: {
+		tcb = sched_gettcb((pid_t)arg);
+		if (tcb == NULL) {
+			ret = ERROR;
+			break;
+		}
+		ret = tcb->adj_stack_size;
+	}
+	break;
+
+	case TESTIOC_GET_TCB_TIMESLICE: {
+		tcb = sched_gettcb((pid_t)arg);
+		if (tcb == NULL) {
+			ret = ERROR;
+			break;
+		}
+		ret = tcb->timeslice;
+	}
+	break;
+
+	case TESTIOC_SCHED_FOREACH: {
+		sched_foreach((void *)arg, NULL);
+	}
+	break;
+
+	case TESTIOC_SIGNAL_PAUSE: {
+		ret = pause();              /* pause() always return -1 */
+		if (ret == ERROR && get_errno() == EINTR) {
+			ret = OK;
+		} else {
+			ret = ERROR;
+		}
+	}
+	break;
+
+	case TESTIOC_TIMER_INITIALIZE: {
+		timer_initialize();
+		ret = OK;
 	}
 	break;
 
@@ -112,5 +205,5 @@ static ssize_t testdrv_write(FAR struct file *filep, FAR const char *buffer, siz
 
 void test_drv_register(void)
 {
-	(void)register_driver("/dev/testcase", &testdrv_fops, 0666, NULL);
+	(void)register_driver(TESTCASE_DRVPATH, &testdrv_fops, 0666, NULL);
 }

--- a/os/include/tinyara/testcase_drv.h
+++ b/os/include/tinyara/testcase_drv.h
@@ -52,7 +52,19 @@
  *
  */
 
-#define TESTIOC_DRIVER_ANALOG            _TESTIOC(1)
+#define TESTIOC_ANALOG                         _TESTIOC(1)
+#define TESTIOC_CLOCK_ABSTIME2TICKS            _TESTIOC(2)
+#define TESTIOC_GET_SIG_FINDACTION_ADD         _TESTIOC(3)
+#define TESTIOC_GET_SELF_PID                   _TESTIOC(4)
+#define TESTIOC_IS_ALIVE_THREAD                _TESTIOC(5)
+#define TESTIOC_GET_TCB_SIGPROCMASK            _TESTIOC(6)
+#define TESTIOC_GET_TCB_ADJ_STACK_SIZE         _TESTIOC(7)
+#define TESTIOC_GET_TCB_TIMESLICE              _TESTIOC(8)
+#define TESTIOC_SCHED_FOREACH                  _TESTIOC(9)
+#define TESTIOC_SIGNAL_PAUSE                   _TESTIOC(10)
+#define TESTIOC_TIMER_INITIALIZE               _TESTIOC(11)
+
+#define TESTCASE_DRVPATH                       "/dev/testcase"
 
 /****************************************************************************
  * Public Data


### PR DESCRIPTION
1. Register an os api that is not registered with syscall.
2. In the case of tcb, only brought the information I needed for the state.