### PR TITLE
examples/sensorbd_demo: use sleep()/usleep() instead of up_mdelay()

### DIFF
--- a/apps/examples/sensorbd_demo/examples/gpio_ledonoff.c
+++ b/apps/examples/sensorbd_demo/examples/gpio_ledonoff.c
@@ -50,6 +50,7 @@
  *
  ****************************************************************************/
 
+#include <unistd.h>
 #include <fcntl.h>
 #include <tinyara/gpio.h>
 
@@ -120,7 +121,7 @@ void ledonoff_main(int argc, char *argv[])
 		}
 		printf("\n");
 
-		up_mdelay(500);
+		usleep(500000);
 	}
 	gpio_write(51, 0);
 	gpio_write(52, 0);

--- a/apps/examples/sensorbd_demo/examples/gpio_starterled.c
+++ b/apps/examples/sensorbd_demo/examples/gpio_starterled.c
@@ -50,6 +50,7 @@
  *
  ****************************************************************************/
 
+#include <unistd.h>
 #include <fcntl.h>
 #include <tinyara/gpio.h>
 
@@ -119,7 +120,7 @@ void starterled_main(int argc, char *argv[])
 			gpio_write(b_led, 0);
 		}
 
-		up_mdelay(500);
+		usleep(500000);
 	}
 	gpio_write(r_led, 0);
 	gpio_write(b_led, 0);

--- a/apps/examples/sensorbd_demo/examples/i2c_mpu9250.c
+++ b/apps/examples/sensorbd_demo/examples/i2c_mpu9250.c
@@ -51,6 +51,7 @@
  ****************************************************************************/
 
 #include <stdio.h>
+#include <unistd.h>
 #include <sys/types.h>
 #include <tinyara/i2c.h>
 
@@ -98,7 +99,7 @@ static int mpu9250_get_axis(uint16_t *x, uint16_t *y, uint16_t *z)
 		return -ret;
 	}
 
-	up_mdelay(1);
+	usleep(1000);
 
 	ret = i2c_read(i2c_dev, &configs, data, 6);
 	if (ret < 0) {
@@ -176,7 +177,7 @@ int mpu9250_main(int argc, char *argv[])
 			printf("ACC:      %-10d%-10d%-10d\n", (int16_t)data[0], (int16_t)data[1], (int16_t)data[2]);
 		}
 
-		up_mdelay(500);
+		usleep(500000);
 	}
 
 	return OK;

--- a/apps/examples/sensorbd_demo/examples/i2c_tcs34725.c
+++ b/apps/examples/sensorbd_demo/examples/i2c_tcs34725.c
@@ -52,6 +52,7 @@
 
 #include <stdio.h>
 #include <sys/types.h>
+#include <unistd.h>
 #include <tinyara/i2c.h>
 #include <tinyara/math.h>
 
@@ -112,22 +113,22 @@ static void tcs34725_getdata(uint16_t *r, uint16_t *g, uint16_t *b, uint16_t *c)
 
 	switch (tcs34725IntegrationTime) {
 	case TCS34725_INTEGRATIONTIME_2_4MS:
-		up_mdelay(3);
+		usleep(3000);
 		break;
 	case TCS34725_INTEGRATIONTIME_24MS:
-		up_mdelay(24);
+		usleep(24000);
 		break;
 	case TCS34725_INTEGRATIONTIME_50MS:
-		up_mdelay(50);
+		usleep(50000);
 		break;
 	case TCS34725_INTEGRATIONTIME_101MS:
-		up_mdelay(101);
+		usleep(101000);
 		break;
 	case TCS34725_INTEGRATIONTIME_154MS:
-		up_mdelay(154);
+		usleep(154000);
 		break;
 	case TCS34725_INTEGRATIONTIME_700MS:
-		up_mdelay(700);
+		usleep(700000);
 		break;
 	}
 }
@@ -186,10 +187,10 @@ static void tcs34725_initialize(void)
 	tcs34725_write(TCS34725_ATIME, tcs34725IntegrationTime);
 	tcs34725_write(TCS34725_CONTROL, TCS34725_GAIN_4X);
 	tcs34725_write(TCS34725_ENABLE, TCS34725_ENABLE_PON);
-	up_mdelay(10);
+	usleep(10000);
 
 	tcs34725_write(TCS34725_ENABLE, TCS34725_ENABLE_PON | TCS34725_ENABLE_AEN);
-	up_mdelay(10);
+	usleep(10000);
 }
 
 void tcs34725_main(int argc, char *argv[])
@@ -217,6 +218,6 @@ void tcs34725_main(int argc, char *argv[])
 		lux = tcs34725_calclux(r, g, b);
 
 		printf("(R:%d), (G:%d), (B:%d), (C:%d), (Color Temp:%d), (Lux:%d)\n", r, g, b, c, temp, lux);
-		up_mdelay(500);
+		usleep(500000);
 	}
 }

--- a/apps/examples/sensorbd_demo/examples/pwm_buzzer.c
+++ b/apps/examples/sensorbd_demo/examples/pwm_buzzer.c
@@ -50,6 +50,7 @@
  *
  ****************************************************************************/
 
+#include <unistd.h>
 #include <fcntl.h>
 #include <tinyara/pwm.h>
 
@@ -91,13 +92,13 @@ void pwmbuzzer_main(int argc, char *argv[])
 		ioctl(fd, PWMIOC_SETCHARACTERISTICS, (unsigned long)((uintptr_t)&pwm_info));
 		ioctl(fd, PWMIOC_START);
 
-		up_mdelay(400);
+		usleep(400000);
 	}
 
 	ioctl(fd, PWMIOC_STOP);
 	close(fd);
 
-	up_mdelay(1000);
+	sleep(1);
 
 	/* device 0 channel 2 */
 	fd = open("/dev/pwm2", O_RDWR);
@@ -112,7 +113,7 @@ void pwmbuzzer_main(int argc, char *argv[])
 		ioctl(fd, PWMIOC_SETCHARACTERISTICS, (unsigned long)((uintptr_t)&pwm_info));
 		ioctl(fd, PWMIOC_START);
 
-		up_mdelay(400);
+		usleep(400000);
 	}
 
 	ioctl(fd, PWMIOC_STOP);

--- a/apps/examples/sensorbd_demo/examples/pwm_led.c
+++ b/apps/examples/sensorbd_demo/examples/pwm_led.c
@@ -50,6 +50,7 @@
  *
  ****************************************************************************/
 
+#include <unistd.h>
 #include <fcntl.h>
 #include <tinyara/pwm.h>
 
@@ -105,10 +106,10 @@ void ledpwm_main(int argc, char *argv[])
 		ioctl(fd3, PWMIOC_START);
 		ioctl(fd4, PWMIOC_START);
 
-		up_mdelay(200);
+		usleep(200000);
 	}
 
-	up_mdelay(2000);
+	sleep(2);
 	ioctl(fd1, PWMIOC_STOP);
 	ioctl(fd2, PWMIOC_STOP);
 	ioctl(fd3, PWMIOC_STOP);

--- a/apps/examples/sensorbd_demo/examples/spi_k6ds3.c
+++ b/apps/examples/sensorbd_demo/examples/spi_k6ds3.c
@@ -50,6 +50,7 @@
  *
  ****************************************************************************/
 
+#include <unistd.h>
 #include <tinyara/spi/spi.h>
 
 #define K6DS3_FACTORY_ID		0x69
@@ -169,6 +170,6 @@ void k6ds3_main(int argc, char *argv[])
 
 		printf("ACCEL:x(0x%04X) y(0x%04X) z(0x%04X) GYRO:x(0x%04X) y(0x%04X) z(0x%04X)\n", ax, ay, az, gx, gy, gz);
 
-		up_mdelay(500);
+		usleep(500000);
 	}
 }

--- a/apps/examples/sensorbd_demo/examples/spi_lis3lv02qd.c
+++ b/apps/examples/sensorbd_demo/examples/spi_lis3lv02qd.c
@@ -50,6 +50,7 @@
  *
  ****************************************************************************/
 
+#include <unistd.h>
 #include <tinyara/spi/spi.h>
 
 #define LIS3LV02DQ_CONF_REG_1	0x20
@@ -148,6 +149,6 @@ void lis3lv02qd_main(int argc, char *argv[])
 
 		printf("x(0x%04x), y(0x%04x), z(0x%04x)\n", x, y, z);
 
-		up_mdelay(500);
+		usleep(500000);
 	}
 }


### PR DESCRIPTION
The up_mdelay() should be only used inside kernel context,
user should not.
Let's use sleep() and usleep() instead of it.

Signed-off-by: sunghan-chang <sh924.chang@samsung.com>