### PR TITLE
testcase/kernel: Change signal for waking up a receiver thread in mqe…

### DIFF
--- a/apps/examples/testcase/le_tc/kernel/tc_mqueue.c
+++ b/apps/examples/testcase/le_tc/kernel/tc_mqueue.c
@@ -619,7 +619,7 @@ static void tc_mqueue_mq_open_close_send_receive(void)
 #ifndef CONFIG_DISABLE_SIGNALS
 	/* Wake up the receiver thread with a signal */
 
-	pthread_kill(receiver, 9);
+	pthread_kill(receiver, SIGUSR1);
 
 	/* Wait a bit to see if the thread exits on its own */
 


### PR DESCRIPTION
…ue tc.

Signo 9 is for terminating the task or pthread, not for waking up.
If pthread_kill(PID, 9) is sent, receiver will be terminated, so returns for pthread_cancel and pthread_join will be changed unexpected.