### PR TITLE
apps/dm_wifi_test: Replace closesocket() with close()

### DIFF
--- a/apps/examples/dm_wifi_test/dm_wifi_test.c
+++ b/apps/examples/dm_wifi_test/dm_wifi_test.c
@@ -219,7 +219,7 @@ int wifi_test_proc(int argc, char *argv[])
 		if (sendto(fd, payload, strlen(payload), 0, (struct sockaddr *)&dest, sizeof(struct sockaddr_in)) == -1) {
 			printf("[WiFi] Failed to sendto UDP.\n");
 			ret = -1;
-			closesocket(fd);
+			close(fd);
 			goto error_out;
 		}
 		/* Type in code to free WiFi scan data. Do check and


### PR DESCRIPTION
closesocket() is a kernel level API that cannot directly called from the app.
The function will work by calling close() instead of closesocket().