### PR TITLE
libc/net: Add network C libraries

### DIFF
--- a/lib/libc/libc.csv
+++ b/lib/libc/libc.csv
@@ -58,6 +58,7 @@
 "imaxabs", "inttypes.h", "", "intmax_t", "intmax_t"
 "imaxdiv", "inttypes.h", "", "intmax_t", "intmax_t", "imaxdiv_t"
 "inet_addr", "arpa/inet.h", "", "in_addr_t", "FAR const char "
+"inet_aton", "arpa/inet.h", "", "int", "FAR const char *", "FAR struct in_addr *"
 "inet_ntoa", "arpa/inet.h", "defined(CONFIG_NET_IPv4) && defined(CONFIG_CAN_PASS_STRUCTS)", "FAR char", "struct in_addr"
 "inet_ntop", "arpa/inet.h", "", "FAR const char", "int", "FAR const void *", "FAR char *", "socklen_t"
 "inet_pton", "arpa/inet.h", "", "int", "int", "FAR const char *", "FAR void *"

--- a/lib/libc/net/Make.defs
+++ b/lib/libc/net/Make.defs
@@ -62,7 +62,9 @@ ifeq ($(CONFIG_NET_ROUTE),y)
 CSRCS += lib_addroute.c lib_delroute.c
 endif
 
-CSRCS += lib_etherntoa.c
+CSRCS += lib_etherntoa.c lib_htonl.c lib_htons.c
+CSRCS += lib_inetaddr.c lib_inetaton.c lib_inetntoa.c
+CSRCS += lib_inetntop.c lib_inetpton.c
 
 # Add the net directory to the build
 

--- a/lib/libc/net/lib_htonl.c
+++ b/lib/libc/net/lib_htonl.c
@@ -1,0 +1,82 @@
+/****************************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+/****************************************************************************
+ * lib/libc/net/lib_ntohl.c
+ *
+ *   Copyright (C) 2007, 2009, 2011 Gregory Nutt. All rights reserved.
+ *   Author: Gregory Nutt <gnutt@nuttx.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <tinyara/config.h>
+
+#include <stdint.h>
+#include <arpa/inet.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+uint32_t htonl(uint32_t hl)
+{
+#ifdef CONFIG_ENDIAN_BIG
+	return hl;
+#else
+	return (((hl) >> 24) | (((hl) >> 8) & 0x0000ff00) | (((hl) << 8) & 0x00ff0000) | ((hl) << 24));
+#endif
+}
+
+uint32_t ntohl(uint32_t nl)
+{
+#ifdef CONFIG_ENDIAN_BIG
+	return nl;
+#else
+	return htonl(nl);
+#endif
+}

--- a/lib/libc/net/lib_htons.c
+++ b/lib/libc/net/lib_htons.c
@@ -1,0 +1,78 @@
+/****************************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+/****************************************************************************
+ * lib/libc/net/lib_htons.c
+ *
+ *   Copyright (C) 2007-2009, 2011 Gregory Nutt. All rights reserved.
+ *   Author: Gregory Nutt <gnutt@nuttx.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <tinyara/config.h>
+
+#include <stdint.h>
+#include <arpa/inet.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+uint16_t htons(uint16_t hs)
+{
+	return HTONS(hs);
+}
+
+uint16_t ntohs(uint16_t ns)
+{
+#ifdef CONFIG_ENDIAN_BIG
+	return ns;
+#else
+	return htons(ns);
+#endif
+}

--- a/lib/libc/net/lib_inetaddr.c
+++ b/lib/libc/net/lib_inetaddr.c
@@ -1,0 +1,103 @@
+/****************************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+/****************************************************************************
+ * lib/libc/net/lib_inetaddr.c
+ *
+ *   Copyright (C) 2011 Yu Qiang. All rights reserved.
+ *   Author: Yu Qiang <yuq825@gmail.com>
+ *
+ * This file is a part of NuttX:
+ *
+ *   Copyright (C) 2011 Gregory Nutt. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <stdio.h>
+#include <arpa/inet.h>
+
+typedef unsigned char u8_t;
+typedef unsigned int u32_t;
+
+/** 255.255.255.255 */
+#define IPADDR_NONE         ((u32_t)0xffffffffUL)
+
+#define in_range(c, lo, up)  ((u8_t)c >= lo && (u8_t)c <= up)
+#define isdigit(c)           in_range(c, '0', '9')
+
+/****************************************************************************
+ * name inet_addr
+ *
+ * Description:
+ *   The inet_addr() function converts the string pointed to by cp, in the
+ *   standard IPv4 dotted decimal notation, to an integer value suitable for
+ *   use as an Internet address.
+ *
+ ****************************************************************************/
+
+in_addr_t inet_addr(FAR const char *cp)
+{
+	unsigned int a;
+	unsigned int b;
+	unsigned int c;
+	unsigned int d;
+	uint32_t result;
+
+	if (!isdigit((char)*cp)) {
+		return (IPADDR_NONE);
+	}
+
+	sscanf(cp, "%u.%u.%u.%u", &a, &b, &c, &d);
+	result = a << 8;
+	result |= b;
+	result <<= 8;
+	result |= c;
+	result <<= 8;
+	result |= d;
+	return HTONL(result);
+}

--- a/lib/libc/net/lib_inetaton.c
+++ b/lib/libc/net/lib_inetaton.c
@@ -1,0 +1,135 @@
+/****************************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+/****************************************************************************
+ * lib/libc/net/lib_inetaton
+ *
+ *   Copyright (C) 2018 Gregory Nutt. All rights reserved.
+ *   Author: Juha Niskanen <juha.niskanen@haltian.com>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <stdint.h>
+#include <arpa/inet.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: inet_aton
+ *
+ * Description:
+ *   The inet_aton() function converts the string pointed to by cp, in the
+ *   standard IPv4 dotted decimal notation, to an integer value suitable for
+ *   use as an Internet address.
+ *
+ * Note:
+ *   inet_aton() returns nonzero if the address is valid, zero if not.
+ *   Therefore macros OK and ERROR are not used here.
+ *
+ ****************************************************************************/
+
+int inet_aton(FAR const char *cp, FAR struct in_addr *inp)
+{
+	int dots = 0;
+	uint32_t num = 0;
+	uint32_t addr = 0;
+	int c;
+
+	do {
+		c = *cp;
+
+		switch (c) {
+		case '0':
+		case '1':
+		case '2':
+		case '3':
+		case '4':
+		case '5':
+		case '6':
+		case '7':
+		case '8':
+		case '9':
+			num = 10 * num + (c - '0');
+			break;
+
+		case '.':
+			dots++;
+			if (dots > 3) {
+				return 0;
+			}
+
+			/* no break */
+
+		case '\0':
+			if (num > 255) {
+				return 0;
+			}
+
+			addr = addr << 8 | num;
+			num = 0;
+			break;
+
+		default:
+			return 0;
+		}
+	} while (*cp++);
+
+	/* Normalize it */
+
+	if (dots < 3) {
+		addr <<= 8 * (3 - dots);
+	}
+
+	if (inp) {
+		inp->s_addr = HTONL(addr);
+	}
+
+	return 1;
+}

--- a/lib/libc/net/lib_inetntoa.c
+++ b/lib/libc/net/lib_inetntoa.c
@@ -1,0 +1,98 @@
+/****************************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+/****************************************************************************
+ * lib/libc/net/lib_inetntoa.c
+ *
+ *   Copyright (C) 2007-2008, 2011-2012, 2015 Gregory Nutt. All rights reserved.
+ *   Author: Gregory Nutt <gnutt@nuttx.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <tinyara/config.h>
+
+#include <stdio.h>
+
+#include <arpa/inet.h>
+#include <netinet/in.h>
+
+#if defined(CONFIG_NET_IPv4)
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: inet_ntoa
+ *
+ * Description:
+ *   The inet_ntoa() function converts the Internet host address given in
+ *   network byte order to a string in standard numbers-and-dots notation.
+ *   The string is returned in a statically allocated buffer, which subsequent
+ *   calls will overwrite.
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_CAN_PASS_STRUCTS
+FAR char *inet_ntoa(struct in_addr in)
+{
+	static char buffer[INET_ADDRSTRLEN + 2];
+	FAR unsigned char *ptr = (FAR unsigned char *)&in.s_addr;
+	sprintf(buffer, "%u.%u.%u.%u", ptr[0], ptr[1], ptr[2], ptr[3]);
+	return buffer;
+}
+#else
+FAR char *_inet_ntoa(in_addr_t in)
+{
+	static char buffer[INET_ADDRSTRLEN + 2];
+	FAR unsigned char *ptr = (FAR unsigned char *)&in;
+	sprintf(buffer, "%u.%u.%u.%u", ptr[0], ptr[1], ptr[2], ptr[3]);
+	return buffer;
+}
+#endif
+#endif							/* CONFIG_NET_IPv4 */

--- a/lib/libc/net/lib_inetntop.c
+++ b/lib/libc/net/lib_inetntop.c
@@ -1,0 +1,288 @@
+/****************************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+/****************************************************************************
+ * lib/libc/net/lib_inetntop.c
+ *
+ *   Copyright (C) 2012, 2015 Gregory Nutt. All rights reserved.
+ *   Author: Gregory Nutt <gnutt@nuttx.org>
+ *
+ * Includes some logic extracted from hwport_ftpd, written by Jaehyuk Cho
+ * <minzkn@minzkn.com> which was released under the BSD license.
+ *
+ *   Copyright (C) HWPORT.COM. All rights reserved.
+ *   Author: JAEHYUK CHO <mailto:minzkn@minzkn.com>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <tinyara/config.h>
+
+#include <sys/socket.h>
+
+#include <stdio.h>
+#include <string.h>
+#include <errno.h>
+
+#include <arpa/inet.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+#define MAX_OFFSET_VALUE	8
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: inet_ipv4_ntop
+ *
+ * Description:
+ *  The inet_ipv4_ntop() function converts a numeric IPv4 address into a
+ *  text string suitable for presentation.
+ *
+ * Input Parameters:
+ *   src  - The src argument points to a buffer holding an address of the
+ *          specified type.  The address must be in network byte order.
+ *   dest - The dest argument points to a buffer where the function stores
+ *          the resulting text string; it shall not be NULL.
+ *   size - The size argument specifies the size of this buffer, which must
+ *          be large enough to hold the text string (INET_ADDRSTRLEN
+ *          characters for IPv4, INET6_ADDRSTRLEN characters for IPv6).
+ *
+ * Returned Value:
+ *   inet_ntop() returns a pointer to the buffer containing the text string
+ *   if the conversion succeeds.  Otherwise, NULL is returned and the errno
+ *   is set to indicate the error.  There follow errno values may be set:
+ *
+ *   ENOSPC - The size of the inet_ntop() result buffer is inadequate
+ *
+ ****************************************************************************/
+
+#if defined(CONFIG_NET_IPv4)
+static int inet_ipv4_ntop(FAR const void *src, FAR char *dest, socklen_t size)
+{
+	FAR uint8_t *ptr;
+
+	if (size < INET_ADDRSTRLEN) {
+		return -ENOSPC;
+	}
+
+	ptr = (FAR uint8_t *)src;
+	sprintf(dest, "%u.%u.%u.%u", ptr[0], ptr[1], ptr[2], ptr[3]);
+	return OK;
+}
+#endif
+
+/****************************************************************************
+ * Name: inet_ipv6_ntop
+ *
+ * Description:
+ *  The inet_ipv6_ntop() function converts a numeric IPv6 address into a
+ *  text string suitable for presentation.
+ *
+ * Input Parameters:
+ *   af   - The af argument specifies the family of the address. This can be
+ *          AF_INET or AF_INET6.
+ *   src  - The src argument points to a buffer holding an address of the
+ *          specified type.  The address must be in network byte order.
+ *   dest - The dest argument points to a buffer where the function stores
+ *          the resulting text string; it shall not be NULL.
+ *   size - The size argument specifies the size of this buffer, which must
+ *          be large enough to hold the text string (INET_ADDRSTRLEN
+ *          characters for IPv4, INET6_ADDRSTRLEN characters for IPv6).
+ *
+ * Returned Value:
+ *   inet_ntop() returns a pointer to the buffer containing the text string
+ *   if the conversion succeeds.  Otherwise, NULL is returned and the errno
+ *   is set to indicate the error.  There follow errno values may be set:
+ *
+ *   EAFNOSUPPORT - The af argument is invalid.
+ *   ENOSPC - The size of the inet_ntop() result buffer is inadequate
+ *
+ ****************************************************************************/
+
+#if defined(CONFIG_NET_IPv6)
+static int inet_ipv6_ntop(FAR const void *src, FAR char *dest, socklen_t size)
+{
+	FAR const struct in6_addr *in6_addr;
+	uint16_t warray[MAX_OFFSET_VALUE];
+	int offset;
+	int entry;
+	int count;
+	int maxentry;
+	int maxcount;
+
+	if (size < INET6_ADDRSTRLEN) {
+		return -ENOSPC;
+	}
+
+	in6_addr = (FAR const struct in6_addr *)src;
+	entry = -1;
+	maxentry = -1;
+	maxcount = 0;
+	offset = 0;
+
+	while (offset < 8) {
+		warray[offset] = ntohs(in6_addr->s6_addr16[offset]);
+		if (warray[offset] == 0) {
+			entry = offset;
+			count = 1;
+			offset++;
+
+			while (offset < 8) {
+				warray[offset] = ntohs(in6_addr->s6_addr16[offset]);
+				if (warray[offset] != 0) {
+					break;
+				}
+				offset++;
+				count++;
+			}
+
+			if (count > maxcount) {
+				maxentry = entry;
+				maxcount = count;
+			}
+		}
+		offset++;
+	}
+
+	offset = 0;
+	dest[0] = '\0';
+
+	while (offset < 8) {
+		if (offset == maxentry) {
+			size -= snprintf(&dest[strlen(dest)], size, ":");
+			offset += maxcount;
+			if (offset >= 8) {
+				size -= snprintf(&dest[strlen(dest)], size, ":");
+			}
+		} else {
+			if (offset > 0) {
+				size -= snprintf(&dest[strlen(dest)], size, ":");
+			}
+
+			size -= snprintf(&dest[strlen(dest)], size, "%x", warray[offset]);
+			offset++;
+		}
+	}
+
+	return OK;
+}
+#endif
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: inet_ntop
+ *
+ * Description:
+ *  The inet_ntop() function converts a numeric address into a text string
+ *  suitable for presentation.
+ *
+ * Input Parameters:
+ *   af   - The af argument specifies the family of the address. This can be
+ *          AF_INET or AF_INET6.
+ *   src  - The src argument points to a buffer holding an address of the
+ *          specified type.  The address must be in network byte order.
+ *   dest - The dest argument points to a buffer where the function stores
+ *          the resulting text string; it shall not be NULL.
+ *   size - The size argument specifies the size of this buffer, which must
+ *          be large enough to hold the text string (INET_ADDRSTRLEN
+ *          characters for IPv4, INET6_ADDRSTRLEN characters for IPv6).
+ *
+ * Returned Value:
+ *   inet_ntop() returns a pointer to the buffer containing the text string
+ *   if the conversion succeeds.  Otherwise, NULL is returned and the errno
+ *   is set to indicate the error.  There follow errno values may be set:
+ *
+ *   EAFNOSUPPORT - The af argument is invalid.
+ *   ENOSPC - The size of the inet_ntop() result buffer is inadequate
+ *
+ ****************************************************************************/
+
+FAR const char *inet_ntop(int af, FAR const void *src, FAR char *dest, socklen_t size)
+{
+	int ret;
+
+	DEBUGASSERT(src && dest);
+
+	/* Do the conversion according to the IP version */
+
+	switch (af) {
+#if defined(CONFIG_NET_IPv4)
+	case AF_INET:
+		ret = inet_ipv4_ntop(src, dest, size);
+		break;
+#endif
+
+#if defined(CONFIG_NET_IPv6)
+	case AF_INET6:
+		ret = inet_ipv6_ntop(src, dest, size);
+		break;
+#endif
+
+	default:
+		ret = -EAFNOSUPPORT;
+		break;
+	}
+
+	/* Handle errors in the conversion */
+
+	if (ret < 0) {
+		set_errno(-ret);
+		memset(dest, 0, size);
+		return NULL;
+	}
+
+	/* Return success */
+
+	return dest;
+}

--- a/lib/libc/net/lib_inetpton.c
+++ b/lib/libc/net/lib_inetpton.c
@@ -1,0 +1,380 @@
+/****************************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+/****************************************************************************
+ * lib/libc/net/lib_inetpton.c
+ *
+ *   Copyright (C) 2012 Gregory Nutt. All rights reserved.
+ *   Author: Gregory Nutt <gnutt@nuttx.org>
+ *
+ * Includes some logic extracted from hwport_ftpd, written by Jaehyuk Cho
+ * <minzkn@minzkn.com> which was released under the BSD license.
+ *
+ *   Copyright (C) HWPORT.COM. All rights reserved.
+ *   Author: JAEHYUK CHO <mailto:minzkn@minzkn.com>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <tinyara/config.h>
+
+#include <sys/socket.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+
+#include <arpa/inet.h>
+#include <netinet/in.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: inet_ipv4_pton
+ *
+ * Description:
+ *  The inet_ipv4_pton() function converts an IPv4 address in its standard
+ *  text presentation form into its numeric binary form.
+ *
+ * Input Parameters:
+ *   src  - The src argument points to the string being passed in.
+ *   dest - The dest argument points to a numstr into which the function stores
+ *          the numeric address; this must be large enough to hold the numeric
+ *          address (32 bits for AF_INET, 128 bits for AF_INET6).
+ *
+ * Returned Value:
+ *   inet_ipv4_pton() will returns 1 if the conversion succeeds. It will
+ *   return 0 if the input is not a valid IPv4 dotted-decimal string string.
+ *
+ ****************************************************************************/
+
+#if defined(CONFIG_NET_IPv4)
+static int inet_ipv4_pton(FAR const char *src, FAR void *dest)
+{
+	size_t srcoffset;
+	size_t numoffset;
+	int value;
+	int ndots;
+	uint8_t ch;
+	char numstr[4];
+	uint8_t *ip;
+
+	(void)memset(dest, 0, sizeof(struct in_addr));
+
+	ip = (uint8_t *)dest;
+	srcoffset = 0;
+	numoffset = 0;
+	ndots = 0;
+
+	for (;;) {
+		ch = (uint8_t)src[srcoffset++];
+
+		if (ch == '.' || ch == '\0') {
+			if (ch == '.' && ndots >= 4) {
+				/* Too many dots */
+
+				break;
+			}
+
+			if (numoffset < 1) {
+				/* Empty numeric string */
+
+				break;
+			}
+
+			numstr[numoffset] = '\0';
+			numoffset = 0;
+
+			value = atoi(numstr);
+			if (value < 0 || value > 255) {
+				/* Out of range value */
+
+				break;
+			}
+
+			ip[ndots] = (uint8_t)value;
+
+			if (ch == '\0') {
+				if (ndots != 3) {
+					/* Not enough dots */
+
+					break;
+				}
+
+				/* Return 1 if the conversion succeeds */
+
+				return 1;
+			}
+
+			ndots++;
+		} else if (ch >= '0' && ch <= '9') {
+			numstr[numoffset++] = ch;
+			if (numoffset >= 4) {
+				/* Number is too long */
+
+				break;
+			}
+		} else {
+			/* Illegal character */
+
+			break;
+		}
+	}
+
+	/* Return zero if there is any problem parsing the input */
+
+	return 0;
+}
+#endif
+
+/****************************************************************************
+ * Name: inet_ipv6_pton
+ *
+ * Description:
+ *  The inet_ipv6_pton() function converts an IPv6 address in its standard
+ *  text presentation form into its numeric binary form.
+ *
+ * Input Parameters:
+ *   src  - The src argument points to the string being passed in.
+ *   dest - The dest argument points to a numstr into which the function stores
+ *          the numeric address; this must be large enough to hold the numeric
+ *          address (32 bits for AF_INET, 128 bits for AF_INET6).
+ *
+ * Returned Value:
+ *   inet_ipv6_pton() will returns 1 if the conversion succeeds. It will
+ *   return 0 if the input is not a valid IPv6 address string.
+ *
+ ****************************************************************************/
+
+#if defined(CONFIG_NET_IPv6)
+static int inet_ipv6_pton(FAR const char *src, FAR void *dest)
+{
+	size_t srcoffset;
+	size_t numoffset;
+	long value;
+	int nsep;
+	int nrsep;
+	uint8_t ch;
+	char numstr[5];
+	uint8_t ip[sizeof(struct in6_addr)];
+	uint8_t rip[sizeof(struct in6_addr)];
+	bool rtime;
+
+	(void)memset(dest, 0, sizeof(struct in6_addr));
+
+	srcoffset = 0;
+	numoffset = 0;
+	nsep = 0;
+	nrsep = 0;
+	rtime = false;
+
+	for (;;) {
+		ch = (uint8_t)src[srcoffset++];
+
+		if (ch == ':' || ch == '\0') {
+			if (ch == ':' && (nsep + nrsep) >= 8) {
+				/* Too many separators */
+
+				break;
+			}
+
+			if (ch != '\0' && numoffset < 1) {
+				/* Empty numeric string */
+
+				if (rtime && nrsep > 1) {
+					/* dup simple */
+
+					break;
+				}
+
+				numoffset = 0;
+				rtime = true;
+				continue;
+			}
+
+			numstr[numoffset] = '\0';
+			numoffset = 0;
+
+			value = strtol(numstr, NULL, 16);
+			if (value < 0 || value > 0xffff) {
+				/* Out of range value */
+
+				break;
+			}
+
+			if (!rtime) {
+				ip[(nsep << 1) + 0] = (uint8_t)((value >> 8) & 0xff);
+				ip[(nsep << 1) + 1] = (uint8_t)((value >> 0) & 0xff);
+				nsep++;
+			} else {
+				rip[(nrsep << 1) + 0] = (uint8_t)((value >> 8) & 0xff);
+				rip[(nrsep << 1) + 1] = (uint8_t)((value >> 0) & 0xff);
+				nrsep++;
+			}
+
+			if (ch == '\0' /* || ch == '/' */) {
+				if ((nsep <= 1 && nrsep <= 0) || (nsep + nrsep) < 1 || (nsep + nrsep) > 8) {
+					/* Separator count problem */
+
+					break;
+				}
+
+				if (nsep > 0) {
+					memcpy(dest, &ip[0], nsep << 1);
+				}
+
+				if (nrsep > 0) {
+					memcpy(dest + (16 - (nrsep << 1)), &rip[0], nrsep << 1);
+				}
+
+				/* Return 1 if the conversion succeeds */
+
+				return 1;
+			}
+		} else if ((ch >= '0' && ch <= '9') || (ch >= 'a' && ch <= 'f') || (ch >= 'A' && ch <= 'F')) {
+			numstr[numoffset++] = ch;
+			if (numoffset >= 5) {
+				/* Numeric string is too long */
+
+				break;
+			}
+		} else {
+			/* Illegal character */
+
+			break;
+		}
+	}
+
+	/* Return zero if there is any problem parsing the input */
+
+	return 0;
+}
+#endif
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: inet_pton
+ *
+ * Description:
+ *  The inet_pton() function converts an address in its standard text
+ *  presentation form into its numeric binary form.
+ *
+ *  If the af argument of inet_pton() is AF_INET, the src string will be
+ *  in the standard IPv4 dotted-decimal form:
+ *
+ *    ddd.ddd.ddd.ddd
+ *
+ *  where "ddd" is a one to three digit decimal number between 0 and 255.
+ *
+ *  If the af argument of inet_pton() is AF_INET6, the src string will be in
+ *  one of the following standard IPv6 text forms:
+ *
+ *  1. The preferred form is "x:x:x:x:x:x:x:x", where the 'x' s are the
+ *     hexadecimal values of the eight 16-bit pieces of the address. Leading
+ *     zeros in individual fields can be omitted, but there must be at least
+ *     one numeral in every field.
+ *
+ *  2. A string of contiguous zero fields in the preferred form can be shown
+ *     as "::". The "::" can only appear once in an address. Unspecified
+ *     addresses ( "0:0:0:0:0:0:0:0" ) may be represented simply as "::".
+ *
+ *  3. A third form that is sometimes more convenient when dealing with a
+ *     mixed environment of IPv4 and IPv6 nodes is "x:x:x:x:x:x:d.d.d.d",
+ *     where the 'x' s are the hexadecimal values of the six high-order
+ *     16-bit pieces of the address, and the 'd' s are the decimal values
+ *     of the four low-order 8-bit pieces of the address (standard IPv4
+ *     representation).
+ *
+ * Input Parameters:
+ *   af   - The af argument specifies the family of the address. This can be
+ *          AF_INET or AF_INET6.
+ *   src  - The src argument points to the string being passed in.
+ *   dest - The dest argument points to memory into which the function stores
+ *          the numeric address; this must be large enough to hold the numeric
+ *          address (32 bits for AF_INET, 128 bits for AF_INET6).
+ *
+ * Returned Value:
+ *   The inet_pton() function returns 1 if the conversion succeeds, with the
+ *   address pointed to by dest in network byte order. It will return 0 if the
+ *   input is not a valid IPv4 dotted-decimal string or a valid IPv6 address
+ *   string, or -1 with errno set to EAFNOSUPPORT if the af argument is
+ *   unknown.
+ *
+ ****************************************************************************/
+
+int inet_pton(int af, FAR const char *src, FAR void *dest)
+{
+	DEBUGASSERT(src && dest);
+
+	/* Do the conversion according to the IP version */
+
+	switch (af) {
+#if defined(CONFIG_NET_IPv4)
+	case AF_INET:
+		return inet_ipv4_pton(src, dest);
+#endif
+
+#if defined(CONFIG_NET_IPv6)
+	case AF_INET6:
+		return inet_ipv6_pton(src, dest);
+#endif
+
+	default:
+		set_errno(EAFNOSUPPORT);
+		return ERROR;
+	}
+}


### PR DESCRIPTION
**APIs added**
htonl()
ntohl()
htons()
ntohs()
inet_addr()
inet_aton()
inet_ntoa()
inet_ntop()
inet_pton()
This is back-ported from Nuttx commit cf99fb4 and 5c8a975.

Add build files in libc/net and disable some lwip APIs



