### PR TITLE
kernel/init: allow CONFIG_USER_ENTRYPOINT to be NULL

### DIFF
--- a/os/kernel/init/os_bringup.c
+++ b/os/kernel/init/os_bringup.c
@@ -104,7 +104,7 @@
 #if defined(CONFIG_INIT_ENTRYPOINT)
 /* Initialize by starting a task at an entry point */
 
-#ifndef CONFIG_USER_ENTRYPOINT
+#if !defined(CONFIG_USER_ENTRYPOINT) && !defined(CONFIG_TASH)
 /* Entry point name must have been provided */
 
 #error CONFIG_USER_ENTRYPOINT must be defined
@@ -279,9 +279,10 @@ static inline void os_do_appstart(void)
 	svdbg("Starting application main thread\n");
 
 #ifdef CONFIG_BUILD_PROTECTED
-	DEBUGASSERT(USERSPACE->us_entrypoint != NULL);
-	pid = task_create("appmain", SCHED_PRIORITY_DEFAULT, CONFIG_USERMAIN_STACKSIZE, USERSPACE->us_entrypoint, (FAR char *const *)NULL);
-#else
+	if (USERSPACE->us_entrypoint != NULL) {
+		pid = task_create("appmain", SCHED_PRIORITY_DEFAULT, CONFIG_USERMAIN_STACKSIZE, USERSPACE->us_entrypoint, (FAR char *const *)NULL);
+	}
+#elif defined(CONFIG_USER_ENTRYPOINT)
 	pid = task_create("appmain", SCHED_PRIORITY_DEFAULT, CONFIG_USERMAIN_STACKSIZE, (main_t)CONFIG_USER_ENTRYPOINT, (FAR char *const *)NULL);
 #endif
 	ASSERT(pid > 0);

--- a/os/tools/mkconfig.c
+++ b/os/tools/mkconfig.c
@@ -289,12 +289,6 @@ int main(int argc, char **argv, char **envp)
 	printf("# undef CONFIG_DEBUG_SPI\n");
 	printf("# undef CONFIG_DEBUG_HEAP\n");
 	printf("#endif\n\n");
-	printf("/* User entry point. This is provided as a fall-back to keep compatibility\n");
-	printf(" * with existing code, for builds which do not define CONFIG_USER_ENTRYPOINT.\n");
-	printf(" */\n\n");
-	printf("#ifndef CONFIG_USER_ENTRYPOINT\n");
-	printf("# define CONFIG_USER_ENTRYPOINT main\n");
-	printf("#endif\n\n");
 	printf("#endif /* __INCLUDE_CONFIG_H */\n");
 	fclose(stream);
 


### PR DESCRIPTION
Originally CONFIG_USER_ENTRYPOINT can not be undefined with
normal usages. But someone modifies defconfig directly (actually
it is wrong usages). For that case, mkconfig.c has a conditional.
If it is undefined, mkconfig.c defines it as "main".
But we can't guarantee it is right so that this commit removes it
to be a compilation error.

Additionally TizenRT allows to execute an application from TASH.
That means someone can use TizenRT without user entry point
which is started automatically at bootup.
When CONFIG_TASH is enabled, this commit allows that
CONFIG_USER_ENTRYPOINT is undefined.
At that case, TizenRT just starts TizenRT's services only.
User application should be launched from TASH.

Signed-off-by: sunghan-chang <sh924.chang@samsung.com>