### PR TITLE
travis: modify .travis.yml to maintain latest docker image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ services:
 
 env:
   global:
-    - TIZENRT_IMG_VERSION=1.4.6
+    - TIZENRT_IMG_VERSION=latest
   matrix:
     - BUILD_CONFIG=artik055s/audio
     - BUILD_CONFIG=artik053/grpc
@@ -19,6 +19,7 @@ env:
     - BUILD_CONFIG=artik053/minimal
     - BUILD_CONFIG=qemu/tc_64k
     - BUILD_CONFIG=qemu/build_test
+    - BUILD_CONFIG=esp_wrover_kit/hello_with_tash
 
 before_install:
 - docker pull tizenrt/tizenrt:${TIZENRT_IMG_VERSION}


### PR DESCRIPTION
- TizenRT docker image is updated (ver. 1.5.0)
- new toolchain, xtensa-esp32-elf is added.