### PR TITLE
framework/arastorage: set a maximum value of tuples defined in db_options.h

### DIFF
--- a/framework/src/arastorage/db_options.h
+++ b/framework/src/arastorage/db_options.h
@@ -165,7 +165,7 @@
 
 /* The maximum number of tuples in a relation. */
 #ifndef DB_TUPLE_LIMIT
-#define DB_TUPLE_LIMIT          256
+#define DB_TUPLE_LIMIT          1000
 #endif							/* DB_TUPLE_LIMIT */
 
 /* The number of int array in a cursor. */


### PR DESCRIPTION
DB_TUPLE_LIMIT is a maximum number of tuples in a relation.
This value should be set according to use case.
A arastorage utc has test cases with more than 800 tuples.
So DB_TUPLE_LIMIT should be bigger than this value.