### PR TITLE
utils/kdbg: fix bug and change strtok to strtok_r for tokenizing stat info of proc

### DIFF
--- a/apps/system/utils/kdbg_heapinfo.c
+++ b/apps/system/utils/kdbg_heapinfo.c
@@ -120,10 +120,10 @@ static void heapinfo_print_values(char *buf)
 	int i;
 	stat_data stat_info[PROC_STAT_MAX];
 
-	stat_info[0] = strtok(buf, " ");
+	stat_info[0] = buf;
 
-	for (i = 1; i < PROC_STAT_MAX; i++) {
-		stat_info[i] = strtok(NULL, " ");
+	for (i = 0; i < PROC_STAT_MAX - 1; i++) {
+		stat_info[i] = strtok_r(stat_info[i], " ", &stat_info[i + 1]);
 	}
 	printf("%3s", stat_info[PROC_STAT_PID]);
 #if defined(CONFIG_SCHED_HAVE_PARENT) && !defined(HAVE_GROUP_MEMBERS)

--- a/apps/system/utils/kdbg_ps.c
+++ b/apps/system/utils/kdbg_ps.c
@@ -97,10 +97,10 @@ static void ps_print_values(char *buf)
 	int state;
 	stat_data stat_info[PROC_STAT_MAX];
 
-	stat_info[0] = strtok(buf, " ");
+	stat_info[0] = buf;
 
-	for (i = 1; i < PROC_STAT_MAX; i++) {
-		stat_info[i] = strtok(NULL, " ");
+	for (i = 0; i < PROC_STAT_MAX - 1; i++) {
+		stat_info[i] = strtok_r(stat_info[i], " ", &stat_info[i + 1]);
 	}
 
 	flags = atoi(stat_info[PROC_STAT_FLAG]);

--- a/apps/system/utils/kdbg_stackmonitor.c
+++ b/apps/system/utils/kdbg_stackmonitor.c
@@ -154,11 +154,12 @@ static void stkmon_print_active_values(char *buf)
 	int i;
 	stat_data stat_info[PROC_STAT_MAX];
 
-	stat_info[0] = strtok(buf, " ");
+	stat_info[0] = buf;
 
-	for (i = 1; i < PROC_STAT_MAX; i++) {
-		stat_info[i] = strtok(NULL, " ");
+	for (i = 0; i < PROC_STAT_MAX - 1; i++) {
+		stat_info[i] = strtok_r(stat_info[i], " ", &stat_info[i + 1]);
 	}
+
 	printf("%5s | %8s | %8s", stat_info[PROC_STAT_PID], "ACTIVE", stat_info[PROC_STAT_TOTALSTACK]);
 #ifdef CONFIG_STACK_COLORATION
 	printf(" | %10s", stat_info[PROC_STAT_PEAKSTACK]);


### PR DESCRIPTION
kdbg commands use strtok for tokenizing stat info of proc.
But strtok is not thread-safe because it use a global variable, g_saveptr.
So it should be changed to strtok_r.