### PR TITLE
Replace ioctlsocket() with ioctl()

### DIFF
--- a/apps/examples/testcase/le_tc/network/tc_net_ioctl.c
+++ b/apps/examples/testcase/le_tc/network/tc_net_ioctl.c
@@ -30,10 +30,10 @@
 #include <netutils/netlib.h>
 
 #include <sys/socket.h>
+#include <sys/ioctl.h>
 
 #include "tc_internal.h"
 
-extern int ioctlsocket(int s, long cmd, void *argp);
 
 /**
    * @testcase		   :tc_net_ioctl_p
@@ -52,9 +52,8 @@ static void tc_net_ioctl_p(void)
 		printf("fail %s:%d\n", __FUNCTION__, __LINE__);
 		return;
 	}
-	long a = 0;
-
-	int ret = ioctlsocket(fd, FIONBIO, &a);
+	int dummy = 0;
+	int ret = ioctl(fd, FIONBIO, (unsigned long)&dummy);
 	close(fd);
 
 	TC_ASSERT_NEQ("ioctl", ret, -1);
@@ -79,9 +78,8 @@ static void tc_net_ioctl_fionread_n(void)
 		printf("fail %s:%d\n", __FUNCTION__, __LINE__);
 		return;
 	}
-	long a = 10;
-
-	int ret = ioctlsocket(fd, FIONREAD, &a);
+	int dummy = 10;
+	int ret = ioctl(fd, FIONREAD, (unsigned long)&dummy);
 	close(fd);
 
 	TC_ASSERT_NEQ("ioctl", ret, 0);
@@ -101,7 +99,7 @@ static void tc_net_ioctl_n(void)
 {
 
 	int fd = -1;
-	int ret = ioctlsocket(fd, FIONBIO, 0);
+	int ret = ioctl(fd, FIONBIO, 0);
 
 	TC_ASSERT_NEQ("ioctl", ret, 0);
 	TC_SUCCESS_RESULT();

--- a/external/curl/curl_config.h
+++ b/external/curl/curl_config.h
@@ -1,6 +1,8 @@
 #include <tinyara/config.h>
 #include <sys/select.h>
 
+#define ioctlsocket(x,y,z) ioctl(x,y,z)
+
 /* lib/curl_config.h.  Generated from curl_config.h.in by configure.  */
 /* lib/curl_config.h.in.  Generated from configure.ac by autoheader.  */
 

--- a/external/grpc/third_party/cares/config-tizenrt.h
+++ b/external/grpc/third_party/cares/config-tizenrt.h
@@ -1,3 +1,20 @@
+/****************************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
 #ifndef HEADER_CONFIG_TIZENRT_H
 #define HEADER_CONFIG_TIZENRT_H
 
@@ -8,6 +25,7 @@
 
 #define PACKAGE  "c-ares"
 
+#define ioctlsocket(x,y,z) ioctl(x,y,z)
 #define HAVE_ERRNO_H           1
 #define HAVE_GETENV            1
 #define HAVE_GETTIMEOFDAY      1

--- a/os/include/net/lwip/sockets.h
+++ b/os/include/net/lwip/sockets.h
@@ -388,7 +388,7 @@ typedef struct ip_mreq {
 #define IPTOS_PREC_ROUTINE              0x00
 
 /*
- * Commands for ioctlsocket(),  taken from the BSD file fcntl.h.
+ * Commands for ioctl(),  taken from the BSD file fcntl.h.
  * lwip_ioctl only supports FIONREAD and FIONBIO, for now
  *
  * Ioctl's have the command encoded in the lower word,

--- a/os/net/socket/bsd_socket_api.c
+++ b/os/net/socket/bsd_socket_api.c
@@ -224,11 +224,6 @@ int select(int maxfdp1, fd_set *readset, fd_set *writeset, fd_set *exceptset, st
 }
 #endif
 
-int ioctlsocket(int s, long cmd, void *argp)
-{
-	return lwip_ioctl(s, cmd, argp);
-}
-
 #ifdef CONFIG_NET_LWIP_NETDB
 struct hostent *gethostbyname(const char *name)
 {


### PR DESCRIPTION
- Current ioctlsocket() calls lwip_ioctl() but ioctlsocket API is for Window OS, so it needs to be replaced with ioctl().
Not to call lwip_ioctl() from the user space, socket ioctl operation with FIONREAD/FIONBIO commands will be handled in netdev ioctl.