### PR TITLE
kernel/signal : Change sig_dispatch about delivering the signal to th…

### DIFF
--- a/os/include/tinyara/sched.h
+++ b/os/include/tinyara/sched.h
@@ -553,6 +553,9 @@ struct tcb_s {
 #ifdef CONFIG_SIGKILL_HANDLER
 	_sa_sigaction_t sigkillusrhandler; /* User defined SIGKILL handler      */
 #endif
+#ifdef HAVE_GROUP_MEMBERS
+	sigset_t sigrecvmask;		/* Signals that are blocked by receiving signals */
+#endif
 #endif
 
 	/* POSIX Named Message Queue Fields ****************************************** */

--- a/os/kernel/signal/sig_deliver.c
+++ b/os/kernel/signal/sig_deliver.c
@@ -142,6 +142,10 @@ void sig_deliver(FAR struct tcb_s *stcb)
 
 		savesigprocmask = stcb->sigprocmask;
 		stcb->sigprocmask = savesigprocmask | sigq->mask | SIGNO2SET(sigq->info.si_signo);
+#ifdef HAVE_GROUP_MEMBERS
+		/* Turn on the mask for checking which signo is blocked for handling the signal. */
+		stcb->sigrecvmask |= SIGNO2SET(sigq->info.si_signo);
+#endif
 
 		/* Deliver the signal.  In the kernel build this has to be handled
 		 * differently if we are dispatching to a signal handler in a user-
@@ -174,6 +178,10 @@ void sig_deliver(FAR struct tcb_s *stcb)
 		/* Restore the original sigprocmask */
 
 		stcb->sigprocmask = savesigprocmask;
+#ifdef HAVE_GROUP_MEMBERS
+		/* Turn off the checking mask. */
+		stcb->sigrecvmask &= ~SIGNO2SET(sigq->info.si_signo);
+#endif
 
 		/* Now, handle the (rare?) case where (a) a blocked signal was
 		 * received while the signal handling executed but (b) restoring the


### PR DESCRIPTION
…e specified pid

sig_dispatch runs like below
1. if pid task/pthread is alive and unblock the signo, it can get the signal first even HAVE_GROUP_MEMBERS is enabled.
2. if pid task/pthread is dead or block the signo, then one of the members in group will receive the signal when HAVE_GROUP_MEMBERS is enabled.