### PR TITLE
syscall: fix wrong type in STUB_boardctl

### DIFF
--- a/os/syscall/syscall_stublookup.c
+++ b/os/syscall/syscall_stublookup.c
@@ -197,7 +197,7 @@ uintptr_t STUB_aio_cancel(int nbr, uintptr_t parm1, uintptr_t parm2);
 
 /* Board support */
 
-uintptr-t STUB_boardctl(int nbr, uintptr_t parm1, uinptr_1 parm2);
+uintptr_t STUB_boardctl(int nbr, uintptr_t parm1, uintptr_t parm2);
 
 /* The following are defined if file descriptors are enabled */
 


### PR DESCRIPTION
Signed-off-by: Manohara HK <manohara.hk@samsung.com>