### PR TITLE
build/config: Enable virtual driver for a build issue in kernel tc.

### DIFF
--- a/build/configs/esp32_DevKitC/tc/defconfig
+++ b/build/configs/esp32_DevKitC/tc/defconfig
@@ -436,7 +436,7 @@ CONFIG_UART1_2STOP=0
 # Wireless Device Options
 #
 # CONFIG_DRIVERS_WIRELESS is not set
-# CONFIG_KERNEL_TEST_DRV is not set
+CONFIG_KERNEL_TEST_DRV=y
 
 #
 # Networking Support

--- a/build/configs/esp_wrover_kit/tc/defconfig
+++ b/build/configs/esp_wrover_kit/tc/defconfig
@@ -436,7 +436,7 @@ CONFIG_UART1_2STOP=0
 # Wireless Device Options
 #
 # CONFIG_DRIVERS_WIRELESS is not set
-# CONFIG_KERNEL_TEST_DRV is not set
+CONFIG_KERNEL_TEST_DRV=y
 
 #
 # Networking Support


### PR DESCRIPTION
    Enable CONFIG_KERNEL_TEST_DRV for a build issue in kernel tc.

    The build issue is:
    CC:  le_tc/kernel/kernel_tc_main.c
    le_tc/kernel/kernel_tc_main.c: In function 'tc_kernel_main':
    le_tc/kernel/kernel_tc_main.c:50:17: error: 'TESTCASE_DRVPATH' undeclared (first use in this function)
    g_tc_fd = open(TESTCASE_DRVPATH, O_WRONLY);

Signed-off-by: xiarihf qiang3.zhang@samsung.com