### PR TITLE
arch/esp32/gpio: disable previous GPIO direction before changing

### DIFF
--- a/os/arch/xtensa/src/esp32/esp32_gpio_lowerhalf.c
+++ b/os/arch/xtensa/src/esp32/esp32_gpio_lowerhalf.c
@@ -144,8 +144,10 @@ static int esp32_gpio_setdir(FAR struct gpio_lowerhalf_s *lower, unsigned long a
 	priv->pincfg &= ~FUNCTION_MASK;
 
 	if (arg == GPIO_DIRECTION_OUT) {
+		priv->pincfg &= ~INPUT;
 		priv->pincfg |= OUTPUT;
 	} else {
+		priv->pincfg &= ~OUTPUT;
 		priv->pincfg |= INPUT;
 	}
 


### PR DESCRIPTION
- before changing gpio direction, previous flag should be disabled.
- if INPUT & OUTPUT are set together, it occurs bugs.