### PR TITLE
libc/netdb: Remove netutils/netlib.h header file reference

### DIFF
--- a/lib/libc/netdb/lib_freeaddrinfo.c
+++ b/lib/libc/netdb/lib_freeaddrinfo.c
@@ -24,7 +24,6 @@
 #include <sys/socket.h>
 #include <sys/ioctl.h>
 
-#include <netutils/netlib.h>
 #include <netdb.h>
 
 #include <errno.h>
@@ -57,7 +56,7 @@ void freeaddrinfo(FAR struct addrinfo *ai)
 	int ret = -1;
 	struct req_lwip_data req;
 
-	int sockfd = socket(AF_INET, NETLIB_SOCK_IOCTL, 0);
+	int sockfd = socket(AF_INET, SOCK_DGRAM, 0);
 	if (sockfd < 0) {
 		printf("socket() failed with errno: %d\n", errno);
 		return;

--- a/lib/libc/netdb/lib_getaddrinfo.c
+++ b/lib/libc/netdb/lib_getaddrinfo.c
@@ -24,18 +24,9 @@
 #include <sys/socket.h>
 #include <sys/ioctl.h>
 
-#include <netutils/netlib.h>
 #include <netdb.h>
 
 #include <errno.h>
-
-/****************************************************************************
- * Private Data Types
- ****************************************************************************/
-
-/****************************************************************************
- * Private Functions
- ****************************************************************************/
 
 /****************************************************************************
  * Public Functions
@@ -75,7 +66,7 @@ int getaddrinfo(FAR const char *hostname, FAR const char *servname, FAR const st
 	int ret = -1;
 	struct req_lwip_data req;
 
-	int sockfd = socket(AF_INET, NETLIB_SOCK_IOCTL, 0);
+	int sockfd = socket(AF_INET, SOCK_DGRAM, 0);
 	if (sockfd < 0) {
 		printf("socket() failed with errno: %d\n", errno);
 		return ret;


### PR DESCRIPTION
- netutils/netlib.h is in the external directory, can not be used in libc.