### PR TITLE
libc, libcxx: fix direct use of errno

### DIFF
--- a/external/include/libcxx/locale
+++ b/external/include/libcxx/locale
@@ -710,12 +710,12 @@ __num_get_signed_integral(const char* __a, const char* __a_end,
     if (__a != __a_end)
     {
         typename remove_reference<decltype(errno)>::type __save_errno = errno;
-        errno = 0;
+        set_errno(0);
         char *__p2;
         long long __ll = strtoll_l(__a, &__p2, __base, _LIBCPP_GET_C_LOCALE);
         typename remove_reference<decltype(errno)>::type __current_errno = errno;
         if (__current_errno == 0)
-            errno = __save_errno;
+            set_errno(__save_errno);
         if (__p2 != __a_end)
         {
             __err = ios_base::failbit;
@@ -750,12 +750,12 @@ __num_get_unsigned_integral(const char* __a, const char* __a_end,
             return 0;
         }
         typename remove_reference<decltype(errno)>::type __save_errno = errno;
-        errno = 0;
+        set_errno(0);
         char *__p2;
         unsigned long long __ll = strtoull_l(__a, &__p2, __base, _LIBCPP_GET_C_LOCALE);
         typename remove_reference<decltype(errno)>::type __current_errno = errno;
         if (__current_errno == 0)
-            errno = __save_errno;
+            set_errno(__save_errno);
         if (__p2 != __a_end)
         {
             __err = ios_base::failbit;
@@ -802,12 +802,12 @@ __num_get_float(const char* __a, const char* __a_end, ios_base::iostate& __err)
     if (__a != __a_end)
     {
         typename remove_reference<decltype(errno)>::type __save_errno = errno;
-        errno = 0;
+        set_errno(0);
         char *__p2;
         _Tp __ld = __do_strtod<_Tp>(__a, &__p2);
         typename remove_reference<decltype(errno)>::type __current_errno = errno;
         if (__current_errno == 0)
-            errno = __save_errno;
+            set_errno(__save_errno);
         if (__p2 != __a_end)
         {
             __err = ios_base::failbit;

--- a/external/libcxx/string.cxx
+++ b/external/libcxx/string.cxx
@@ -83,9 +83,15 @@ as_integer_helper(const string& func, const S& str, size_t* idx, int base, F f)
     typename S::value_type* ptr = nullptr;
     const typename S::value_type* const p = str.c_str();
     typename remove_reference<decltype(errno)>::type errno_save = errno;
-    errno = 0;
+    typename remove_reference<decltype(errno)>::type errno_tmp;
+    set_errno(0);
     V r = f(p, &ptr, base);
-    swap(errno, errno_save);
+
+    /* swap errno */
+    errno_tmp = errno_save;
+    errno_save = errno;
+    set_errno(errno_tmp);
+
     if (errno_save == ERANGE)
         throw_from_string_out_of_range(func);
     if (ptr == p)
@@ -200,9 +206,15 @@ as_float_helper(const string& func, const S& str, size_t* idx, F f )
     typename S::value_type* ptr = nullptr;
     const typename S::value_type* const p = str.c_str();
     typename remove_reference<decltype(errno)>::type errno_save = errno;
-    errno = 0;
+    typename remove_reference<decltype(errno)>::type errno_tmp;
+    set_errno(0);
     V r = f(p, &ptr);
-    swap(errno, errno_save);
+
+    /* swap errno */
+    errno_tmp = errno_save;
+    errno_save = errno;
+    set_errno(errno_tmp);
+
     if (errno_save == ERANGE)
         throw_from_string_out_of_range(func);
     if (ptr == p)

--- a/lib/libc/stdlib/lib_wctomb.c
+++ b/lib/libc/stdlib/lib_wctomb.c
@@ -81,7 +81,7 @@ int wctomb(FAR char *s, wchar_t wc)
 	/* Verify that wchar is a valid single-byte character.  */
 
 	if ((size_t) wc >= 0x100) {
-		errno = EILSEQ;
+		set_errno(EILSEQ);
 		return -1;
 	}
 

--- a/lib/libc/time/lib_localtime.c
+++ b/lib/libc/time/lib_localtime.c
@@ -2041,7 +2041,7 @@ static time_t time1(FAR struct tm *const tmp, FAR struct tm * (*const funcp)(FAR
 	int okay;
 
 	if (tmp == NULL) {
-		errno = EINVAL;
+		set_errno(EINVAL);
 		return -1;
 	}
 


### PR DESCRIPTION
direct write on errno may not be possible when syscall is enabled