### PR TITLE
mm_heap/mm_malloc: remove redundant logic when getting nodelist index.

### DIFF
--- a/os/mm/mm_heap/mm_malloc.c
+++ b/os/mm/mm_heap/mm_malloc.c
@@ -133,17 +133,11 @@ FAR void *mm_malloc(FAR struct mm_heap_s *heap, size_t size)
 
 	mm_takesemaphore(heap);
 
-	/* Get the location in the node list to start the search. Special case
-	 * really big allocations
+	/* Get the location in the node list to start the search
+	 * by converting the request size into a nodelist index.
 	 */
 
-	if (size >= MM_MAX_CHUNK) {
-		ndx = MM_NNODES - 1;
-	} else {
-		/* Convert the request size into a nodelist index */
-
-		ndx = mm_size2ndx(size);
-	}
+	ndx = mm_size2ndx(size);
 
 	/* Search for a large enough chunk in the list of nodes. This list is
 	 * ordered by size, but will have occasional zero sized nodes as we visit


### PR DESCRIPTION
In mm_size2ndx(), there is the logic that check if the request size is bigger than MM_MAX_CHUNK. So it's not necessary to have the same logic right before entering mm_size2ndx().