### PR TITLE
Artik download script changes

### DIFF
--- a/build/configs/artik05x/artik05x_download.sh
+++ b/build/configs/artik05x/artik05x_download.sh
@@ -145,11 +145,19 @@ compute_ocd_commands()
 
 download()
 {
-        parts_default=`grep -A 2 'config FLASH_PART_NAME' ${PARTITION_KCONFIG} | sed -n 's/\tdefault "\(.*\)".*/\1/p'`
-        parts2=${CONFIG_FLASH_PART_NAME:=${parts_default}}
-        parts=`echo $parts2 | sed "s/,/ /g"`
+	parts=$1;
 
-        # Make Openocd commands for parts
+	if [[ -n $parts ]] && [[ "$parts" != "all" ]] && [[ "$parts" != "ALL" ]]
+	then
+		echo "##Download $parts"
+		parts=$(echo $parts | tr '[:upper:]' '[:lower:]')
+	else
+	        default_parts=`grep -A 2 'config FLASH_PART_NAME' ${PARTITION_KCONFIG} | sed -n 's/\tdefault "\(.*\)".*/\1/p'`
+		configured_parts=${CONFIG_FLASH_PART_NAME:=${default_parts}}
+		parts=`echo $configured_parts | sed "s/,/ /g"`
+	fi
+
+	# Make Openocd commands for parts
 	commands=$(compute_ocd_commands ${parts})
 	echo "ocd command to run: ${commands}"
 


### PR DESCRIPTION
This commit adds provision to download/update a SINGLE binary for a single partition.
This don't verify against parrtitions in Kconfig/.config.

Example: make download bl2/BL2  <update only bl2>
         make download ALL/all  <update all binaries for all partitions
				menioned in .config or default paritions in Kconfig>
	 make download          <same as ALL/all >