### PR TITLE
Fix the network testcase 'tc_net_ioctl_fionread_n'

### DIFF
--- a/apps/examples/testcase/le_tc/network/tc_net_ioctl.c
+++ b/apps/examples/testcase/le_tc/network/tc_net_ioctl.c
@@ -62,14 +62,14 @@ static void tc_net_ioctl_p(void)
 }
 
 /**
-   * @testcase		   :tc_net_ioctl_fionread_n
+   * @testcase		   :tc_net_ioctl_fionread_p
    * @brief		   :
    * @scenario		   :
    * @apicovered	   :ioctl()
    * @precondition	   :
    * @postcondition	   :
    */
-static void tc_net_ioctl_fionread_n(void)
+static void tc_net_ioctl_fionread_p(void)
 {
 
 	int fd = -1;
@@ -82,7 +82,7 @@ static void tc_net_ioctl_fionread_n(void)
 	int ret = ioctl(fd, FIONREAD, (unsigned long)&dummy);
 	close(fd);
 
-	TC_ASSERT_NEQ("ioctl", ret, 0);
+	TC_ASSERT_NEQ("ioctl", ret, -1);
 	TC_SUCCESS_RESULT();
 
 }
@@ -114,7 +114,7 @@ int net_ioctl_main(void)
 {
 
 	tc_net_ioctl_p();
-	tc_net_ioctl_fionread_n();
+	tc_net_ioctl_fionread_p();
 
 	tc_net_ioctl_n();
 

--- a/os/include/net/lwip/sockets.h
+++ b/os/include/net/lwip/sockets.h
@@ -412,9 +412,6 @@ typedef struct ip_mreq {
 #define _IOW(x, y, t)     (IOC_IN | (((long)sizeof(t) & IOCPARM_MASK) << 16) | ((x) << 8) | (y))
 #endif							/* !defined(FIONREAD) || !defined(FIONBIO) */
 
-#ifndef FIONREAD
-#define FIONREAD    _IOR('f', 127, unsigned long)	/* get # bytes to read */
-#endif
 #ifndef FIONBIO
 #define FIONBIO     _IOW('f', 126, unsigned long)	/* set/clear non-blocking i/o */
 #endif


### PR DESCRIPTION
The ioctl command FIONREAD is defined twice both in tinyara/fs/ioctl.h and net/lwip/sockets.h,
and lwip_ioctl fuction uses the command defined in tinyara/fs/ioctl.h.
We disable FIONREAD in net/lwip/sockets.h to avoid conflict.

The testcase 'tc_net_ioctl_fionread_n' was passed because the parameter FIONREAD which is defined in net/lwip/sockets.h didn't match that used in lwip_ioctl function.
So we change this testcase to a positive case because it works well with FIONREAD command.