### PR TITLE
framework/media: Remove unnecessary code

### DIFF
--- a/framework/src/media/FocusRequest.cpp
+++ b/framework/src/media/FocusRequest.cpp
@@ -47,8 +47,8 @@ std::shared_ptr<FocusRequest> FocusRequest::Builder::build()
 	ss << static_cast<const void *>(focusRequest.get());
 	ss << static_cast<const void *>(mListener.get());
 	mId = ss.str();
-	focusRequest.get()->mId = mId;
-	focusRequest.get()->mListener = mListener;
+	focusRequest->mId = mId;
+	focusRequest->mListener = mListener;
 	return focusRequest;
 }
 } // namespace media


### PR DESCRIPTION
.get() is not necessary to using arrow operator