### PR TITLE
sched/group: Move fields related to parent/child task relationship out of TCB into group structure.

### DIFF
--- a/os/drivers/task_manager/task_manager_drv.c
+++ b/os/drivers/task_manager/task_manager_drv.c
@@ -164,7 +164,7 @@ static int taskmgr_pthread_ppid_change(pid_t parent_pid, pid_t child_pid)
 		return ERROR;
 	}
 
-	ptcb->cmn.ppid = parent_pid;
+	ptcb->cmn.group->tg_ppid = parent_pid;
 	return OK;
 }
 #endif			/* CONFIG_SCHED_HAVE_PARENT && !HAVE_GROUP_MEMBERS */

--- a/os/fs/procfs/fs_procfsproc.c
+++ b/os/fs/procfs/fs_procfsproc.c
@@ -393,7 +393,7 @@ static ssize_t proc_entry_stat(FAR struct proc_file_s *procfile, FAR struct tcb_
 #endif
 
 #if defined(CONFIG_SCHED_HAVE_PARENT) && !defined(HAVE_GROUP_MEMBERS)
-	ppid = tcb->ppid;
+	ppid = tcb->group->tg_ppid;
 #else
 	ppid = -1;
 #endif

--- a/os/include/tinyara/sched.h
+++ b/os/include/tinyara/sched.h
@@ -369,11 +369,22 @@ struct task_group_s {
 	sq_queue_t tg_onexitfunc;
 #endif
 
-#if defined(CONFIG_SCHED_HAVE_PARENT) && defined(CONFIG_SCHED_CHILD_STATUS)
+#ifdef CONFIG_SCHED_HAVE_PARENT
 	/* Child exit status ********************************************************* */
 
-	FAR struct child_status_s *tg_children;	/* Head of a list of child status     */
+#ifdef CONFIG_SCHED_CHILD_STATUS
+	FAR struct child_status_s *tg_children; /* Head of a list of child status     */
 #endif
+
+#ifndef HAVE_GROUP_MEMBERS
+	/* REVISIT: What if parent thread exits?  Should use tg_pgid. */
+
+	pid_t    tg_ppid;                 /* This is the ID of the parent thread      */
+#ifndef CONFIG_SCHED_CHILD_STATUS
+	uint16_t tg_nchildren;            /* This is the number active children       */
+#endif
+#endif /* HAVE_GROUP_MEMBERS */
+#endif /* CONFIG_SCHED_HAVE_PARENT */
 
 #if defined(CONFIG_SCHED_WAITPID) && !defined(CONFIG_SCHED_HAVE_PARENT)
 	/* waitpid support *********************************************************** */
@@ -483,15 +494,6 @@ struct tcb_s {
 	/* Task Management Fields **************************************************** */
 
 	pid_t pid;					/* This is the ID of the thread        */
-
-#ifdef CONFIG_SCHED_HAVE_PARENT	/* Support parent-child relationship   */
-#ifndef HAVE_GROUP_MEMBERS		/* Don't know pids of group members    */
-	pid_t ppid;					/* This is the ID of the parent thread */
-#ifndef CONFIG_SCHED_CHILD_STATUS	/* Retain child thread status          */
-	uint16_t nchildren;			/* This is the number active children  */
-#endif
-#endif
-#endif							/* CONFIG_SCHED_HAVE_PARENT */
 
 	start_t start;				/* Thread start function               */
 	entry_t entry;				/* Entry Point into the thread         */

--- a/os/kernel/sched/sched_waitid.c
+++ b/os/kernel/sched/sched_waitid.c
@@ -225,14 +225,15 @@ int waitid(idtype_t idtype, id_t id, FAR siginfo_t *info, int options)
 		err = ECHILD;
 		goto errout_with_errno;
 	} else if (idtype == P_PID) {
-		/* Get the TCB corresponding to this PID and make sure it is our child. */
+		/* Get the TCB corresponding to this PID and make sure that the thread it is our child. */
 
 		ctcb = sched_gettcb((pid_t)id);
 #ifdef HAVE_GROUP_MEMBERS
-		if (!ctcb || ctcb->group->tg_pgid != rtcb->group->tg_gid)
+		if (ctcb == NULL || ctcb->group->tg_pgid != rtcb->group->tg_gid)
 #else
-		if (!ctcb || ctcb->ppid != rtcb->pid)
+		if (ctcb == NULL || ctcb->group->tg_ppid != rtcb->pid)
 #endif
+
 		{
 			err = ECHILD;
 			goto errout_with_errno;
@@ -252,20 +253,21 @@ int waitid(idtype_t idtype, id_t id, FAR siginfo_t *info, int options)
 		}
 	}
 #else
-	if (rtcb->nchildren == 0) {
+	if (rtcb->group->tg_nchildren == 0) {
 		/* There are no children */
 
 		err = ECHILD;
 		goto errout_with_errno;
 	} else if (idtype == P_PID) {
-		/* Get the TCB corresponding to this PID and make sure it is our child. */
+		/* Get the TCB corresponding to this PID and make sure that the thread it is our child. */
 
 		ctcb = sched_gettcb((pid_t)id);
 #ifdef HAVE_GROUP_MEMBERS
-		if (!ctcb || ctcb->group->tg_pgid != rtcb->group->tg_gid)
+		if (ctcb == NULL || ctcb->group->tg_pgid != rtcb->group->tg_gid)
 #else
-		if (!ctcb || ctcb->ppid != rtcb->pid)
+		if (ctcb == NULL || ctcb->group->tg_ppid != rtcb->pid)
 #endif
+
 		{
 			err = ECHILD;
 			goto errout_with_errno;
@@ -340,7 +342,7 @@ int waitid(idtype_t idtype, id_t id, FAR siginfo_t *info, int options)
 		 * instead).
 		 */
 
-		if (rtcb->nchildren == 0 || (idtype == P_PID && (ret = kill((pid_t)id, 0)) < 0)) {
+		if (rtcb->group->tg_nchildren == 0 || (idtype == P_PID && (ret = kill((pid_t)id, 0)) < 0)) {
 			/* We know that the child task was running okay we stared,
 			 * so we must have lost the signal.  What can we do?
 			 * Let's return ECHILD.. that is at least informative.

--- a/os/kernel/sched/sched_waitpid.c
+++ b/os/kernel/sched/sched_waitpid.c
@@ -228,7 +228,7 @@ pid_t waitpid(pid_t pid, int *stat_loc, int options)
 	/* Get the TCB corresponding to this PID */
 
 	ctcb = sched_gettcb(pid);
-	if (!ctcb) {
+	if (ctcb == NULL) {
 		err = ECHILD;
 		goto errout_with_errno;
 	}
@@ -343,14 +343,15 @@ pid_t waitpid(pid_t pid, int *stat_loc, int options)
 		err = ECHILD;
 		goto errout_with_errno;
 	} else if (pid != (pid_t)-1) {
-		/* Get the TCB corresponding to this PID and make sure it is our child. */
+		/* Get the TCB corresponding to this PID and make sure that the thread it is our child. */
 
 		ctcb = sched_gettcb(pid);
 #ifdef HAVE_GROUP_MEMBERS
-		if (!ctcb || ctcb->group->tg_pgid != rtcb->group->tg_gid)
+		if (ctcb == NULL || ctcb->group->tg_pgid != rtcb->group->tg_gid)
 #else
-		if (!ctcb || ctcb->ppid != rtcb->pid)
+		if (ctcb == NULL || ctcb->group->tg_ppid != rtcb->pid)
 #endif
+
 		{
 			err = ECHILD;
 			goto errout_with_errno;
@@ -369,20 +370,21 @@ pid_t waitpid(pid_t pid, int *stat_loc, int options)
 	}
 #else							/* CONFIG_SCHED_CHILD_STATUS */
 
-	if (rtcb->nchildren == 0) {
+	if (rtcb->group->tg_nchildren == 0) {
 		/* There are no children */
 
 		err = ECHILD;
 		goto errout_with_errno;
 	} else if (pid != (pid_t)-1) {
-		/* Get the TCB corresponding to this PID and make sure it is our child. */
+		/* Get the TCB corresponding to this PID and make sure that the thread it is our child. */
 
 		ctcb = sched_gettcb(pid);
 #ifdef HAVE_GROUP_MEMBERS
-		if (!ctcb || ctcb->group->tg_pgid != rtcb->group->tg_gid)
+		if (ctcb == NULL || ctcb->group->tg_pgid != rtcb->group->tg_gid)
 #else
-		if (!ctcb || ctcb->ppid != rtcb->pid)
+		if (ctcb == NULL || ctcb->group->tg_ppid != rtcb->pid)
 #endif
+
 		{
 			err = ECHILD;
 			goto errout_with_errno;
@@ -471,7 +473,7 @@ pid_t waitpid(pid_t pid, int *stat_loc, int options)
 		 * instead).
 		 */
 
-		if (rtcb->nchildren == 0 || (pid != (pid_t)-1 && (ret = kill(pid, 0)) < 0)) {
+		if (rtcb->group->tg_nchildren == 0 || (pid != (pid_t)-1 && (ret = kill(pid, 0)) < 0)) {
 			/* We know that the child task was running okay we stared,
 			 * so we must have lost the signal.  What can we do?
 			 * Let's return ECHILD.. that is at least informative.

--- a/os/kernel/task/task_exithook.c
+++ b/os/kernel/task/task_exithook.c
@@ -344,11 +344,12 @@ static inline void task_sigchild(FAR struct tcb_s *ptcb, FAR struct tcb_s *ctcb,
 		task_exitstatus(ptcb->group, status);
 
 #else							/* CONFIG_SCHED_CHILD_STATUS */
+		/* Exit status is not retained.  Just decrement the number of
+		 * children from this parent.
+		 */
 
-		/* Decrement the number of children from this parent */
-
-		DEBUGASSERT(ptcb->nchildren > 0);
-		ptcb->nchildren--;
+		DEBUGASSERT(ptcb->group != NULL && ptcb->group->tg_nchildren > 0);
+		ptcb->group->tg_nchildren--;
 
 #endif							/* CONFIG_SCHED_CHILD_STATUS */
 
@@ -412,13 +413,13 @@ static inline void task_signalparent(FAR struct tcb_s *ctcb, int status)
 	sched_lock();
 
 	/* Get the TCB of the receiving, parent task.  We do this early to
-	 * handle multiple calls to task_signalparent.  ctcb->ppid is set to an
-	 * invalid value below and the following call will fail if we are
-	 * called again.
+	 * handle multiple calls to task_signalparent.  ctcb->group->tg_ppid is
+	 * set to an invalid value below and the following call will fail if we
+	 * are called again.
 	 */
 
-	ptcb = sched_gettcb(ctcb->ppid);
-	if (!ptcb) {
+	ptcb = sched_gettcb(ctcb->group->tg_ppid);
+	if (ptcb == NULL) {
 		/* The parent no longer exists... bail */
 
 		sched_unlock();
@@ -431,7 +432,7 @@ static inline void task_signalparent(FAR struct tcb_s *ctcb, int status)
 
 	/* Forget who our parent was */
 
-	ctcb->ppid = INVALID_PROCESS_ID;
+	ctcb->group->tg_ppid = INVALID_PROCESS_ID;
 	sched_unlock();
 #endif
 }

--- a/os/kernel/task/task_reparent.c
+++ b/os/kernel/task/task_reparent.c
@@ -197,10 +197,10 @@ int task_reparent(pid_t ppid, pid_t chpid)
 
 #else							/* CONFIG_SCHED_CHILD_STATUS */
 
-	DEBUGASSERT(otcb->nchildren > 0);
+	DEBUGASSERT(ogrp->tg_nchildren > 0);
 
-	otcb->nchildren--;			/* The orignal parent now has one few children */
-	ptcb->nchildren++;			/* The new parent has one additional child */
+	ogrp->tg_nchildren--;  /* The orignal parent now has one few children */
+	pgrp->tg_nchildren++;  /* The new parent has one additional child */
 	ret = OK;
 
 #endif							/* CONFIG_SCHED_CHILD_STATUS */
@@ -238,7 +238,7 @@ int task_reparent(pid_t ppid, pid_t chpid)
 
 	/* Get the PID of the child task's parent (opid) */
 
-	opid = chtcb->ppid;
+	opid = chtcb->group->tg_ppid;
 
 	/* Get the TCB of the child task's parent (otcb) */
 
@@ -248,13 +248,13 @@ int task_reparent(pid_t ppid, pid_t chpid)
 		goto errout_with_ints;
 	}
 
-	/* If new parent task's PID (ppid) is zero, then new parent is the
+	/* If new parent task's PID (tg_ppid) is zero, then new parent is the
 	 * grandparent will be the new parent, i.e., the parent of the current
 	 * parent task.
 	 */
 
 	if (ppid == 0) {
-		ppid = otcb->ppid;
+		ppid = otcb->group->tg_ppid;
 	}
 
 	/* Get the new parent task's TCB (ptcb) */
@@ -265,9 +265,9 @@ int task_reparent(pid_t ppid, pid_t chpid)
 		goto errout_with_ints;
 	}
 
-	/* Then reparent the child */
+	/* Then reparent the child.  The task specified by ppid is the new parent. */
 
-	chtcb->ppid = ppid;			/* The task specified by ppid is the new parent */
+	chtcb->group->tg_ppid = ppid;
 
 #ifdef CONFIG_SCHED_CHILD_STATUS
 	/* Remove the child status entry from old parent TCB */
@@ -299,10 +299,10 @@ int task_reparent(pid_t ppid, pid_t chpid)
 
 #else							/* CONFIG_SCHED_CHILD_STATUS */
 
-	DEBUGASSERT(otcb->nchildren > 0);
+	DEBUGASSERT(otcb->group != NULL && otcb->group->tg_nchildren > 0);
 
-	otcb->nchildren--;			/* The orignal parent now has one few children */
-	ptcb->nchildren++;			/* The new parent has one additional child */
+	otcb->group->tg_nchildren--;  /* The orignal parent now has one few children */
+	ptcb->group->tg_nchildren++;  /* The new parent has one additional child */
 	ret = OK;
 
 #endif							/* CONFIG_SCHED_CHILD_STATUS */

--- a/os/kernel/task/task_setup.c
+++ b/os/kernel/task/task_setup.c
@@ -224,7 +224,7 @@ static inline void task_saveparent(FAR struct tcb_s *tcb, uint8_t ttype)
 	FAR struct tcb_s *rtcb = this_task();
 
 #if defined(HAVE_GROUP_MEMBERS) || defined(CONFIG_SCHED_CHILD_STATUS)
-	DEBUGASSERT(tcb && tcb->group && rtcb->group);
+	DEBUGASSERT(tcb != NULL && tcb->group != NULL && rtcb->group != NULL);
 #else
 #endif
 
@@ -244,15 +244,18 @@ static inline void task_saveparent(FAR struct tcb_s *tcb, uint8_t ttype)
 
 		tcb->group->tg_pgid = rtcb->group->tg_gid;
 	}
+
 #else
 	DEBUGASSERT(tcb);
 
-	/* Save the parent task's ID in the child task's TCB.  I am not sure if
-	 * this makes sense for the case of pthreads or not, but I don't think it
-	 * is harmful in any event.
-	 */
+#ifndef CONFIG_DISABLE_PTHREAD
+	if ((tcb->flags & TCB_FLAG_TTYPE_MASK) != TCB_FLAG_TTYPE_PTHREAD)
+#endif
+	{
+		/* Save the parent task's ID in the child task's group. */
 
-	tcb->ppid = rtcb->pid;
+		tcb->group->tg_ppid = rtcb->pid;
+	}
 #endif
 
 #ifndef CONFIG_DISABLE_PTHREAD
@@ -295,8 +298,8 @@ static inline void task_saveparent(FAR struct tcb_s *tcb, uint8_t ttype)
 			}
 		}
 #else
-		DEBUGASSERT(rtcb->nchildren < UINT16_MAX);
-		rtcb->nchildren++;
+		DEBUGASSERT(rtcb->group != NULL && rtcb->group->tg_nchildren < UINT16_MAX);
+		rtcb->group->tg_nchildren++;
 #endif
 	}
 }


### PR DESCRIPTION
- sched/: Move fields related to parent/child task relationship out of TCB into group structure.
- sched/group : Update location of ppid according to the changes from tcb to group structure.