### PR TITLE
mm_heap : add 'DEBUG_CHECK_FRAGMENTATION' config to show where and ho…

### DIFF
--- a/os/Kconfig.debug
+++ b/os/Kconfig.debug
@@ -599,6 +599,13 @@ config DEBUG_MM_HEAPINFO
 	---help---
 		Enable task wise malloc debug.
 
+config DEBUG_CHECK_FRAGMENTATION
+	bool "Show where and how memory is fragmented"
+	default n
+	depends on DEBUG_MM_HEAPINFO
+	---help---
+		Count the number of freed memory segments with the range from size 2^n to 2^(n+1).
+
 config DEBUG_IRQ
 	bool "Interrupt Controller Debug Output"
 	default n


### PR DESCRIPTION
…w memory is fragmented.

Heap memory is managed with the nodelist array in the mm_heap_s structure.
i-th element has a linked list which has all freed memory whose size ranges
from 2^(i + 4) to 2^(i + 5) - 1. For example, the 2nd element manages all the memory segements
whose size is 32 ~ 63 Bytes. Here 'DEBUG_CHECK_FRAGMENTATION' config just shows
how many memory segments each element has and what its total size is.
This config will be used as a measuring tool when adopting memory pool mechanisms.