### PR TITLE
libc/netdb: Add gethostbyname and getnameinfo

### DIFF
--- a/lib/libc/netdb/Make.defs
+++ b/lib/libc/netdb/Make.defs
@@ -19,7 +19,7 @@ ifeq ($(CONFIG_NET_LWIP_NETDB),y)
 
 # Add the netdb C files to the build
 
-CSRCS += lib_freeaddrinfo.c lib_getaddrinfo.c
+CSRCS += lib_freeaddrinfo.c lib_getaddrinfo.c lib_gethostbyname.c lib_getnameinfo.c
 
 # Add the netdb directory to the build
 

--- a/lib/libc/netdb/lib_freeaddrinfo.c
+++ b/lib/libc/netdb/lib_freeaddrinfo.c
@@ -21,6 +21,7 @@
 
 #include <tinyara/config.h>
 
+#include <sys/types.h>
 #include <sys/socket.h>
 #include <sys/ioctl.h>
 
@@ -36,12 +37,12 @@
  * Name: freeaddrinfo
  *
  * Description:
- * Frees one or more addrinfo structures returned by getaddrinfo(), along with
- * any additional storage associated with those structures. If the ai_next field
- * of the structure is not null, the entire list of structures is freed.
+ *   Frees one or more addrinfo structures returned by getaddrinfo(), along with
+ *   any additional storage associated with those structures. If the ai_next field
+ *   of the structure is not null, the entire list of structures is freed.
  *
  * Input Parameters:
- *   ai  - struct addrinfo to free
+ *   ai - struct addrinfo to free
  *
  ****************************************************************************/
 

--- a/os/include/netdb.h
+++ b/os/include/netdb.h
@@ -127,18 +127,26 @@ struct servent_data {
 typedef enum {
 	GETADDRINFO,
 	FREEADDRINFO,
+	GETHOSTBYNAME,
+	GETNAMEINFO,
 	DNSSETSERVER
 } req_type;
 
 /* To send a request to lwip stack by ioctl() use */
 struct req_lwip_data {
 	req_type type;
+	int req_res;
 	const char *host_name;
 	const char *serv_name;
 	const struct addrinfo *ai_hint;
 	struct addrinfo *ai_res;
 	struct addrinfo *ai;
-	int req_res;
+	struct hostent *host_entry;
+	const struct sockaddr *sa;
+	size_t sa_len;
+	size_t host_len;
+	size_t serv_len;
+	int flags;
 	u8_t num_dns;
 	ip_addr_t *dns_server;
 };

--- a/os/net/socket/bsd_socket_api.c
+++ b/os/net/socket/bsd_socket_api.c
@@ -224,19 +224,4 @@ int select(int maxfdp1, fd_set *readset, fd_set *writeset, fd_set *exceptset, st
 }
 #endif
 
-#ifdef CONFIG_NET_LWIP_NETDB
-struct hostent *gethostbyname(const char *name)
-{
-	return lwip_gethostbyname(name);
-}
-
-#if LWIP_COMPAT_SOCKETS
-int getnameinfo(const struct sockaddr *sa, size_t salen, char *host, size_t hostlen, char *serv, size_t servlen, int flags)
-{
-	return lwip_getnameinfo(sa, salen, host, hostlen, serv, servlen, flags);
-}
-#endif							/* LWIP_COMPAT_SOCKETS */
-
-#endif							/* NET_LWIP_NETDB */
-
 #endif


### PR DESCRIPTION
Remove the implementation of gethostbyname and getnameinfo in bsd_socket_api.c,
and add them to libc/netdb not to directly call from user space to kernal space.