### PR TITLE
framework/media: Conceal FocusRequest methods

### DIFF
--- a/apps/examples/testcase/ta_tc/media/utc/utc_media_focusrequest.cpp
+++ b/apps/examples/testcase/ta_tc/media/utc/utc_media_focusrequest.cpp
@@ -83,86 +83,11 @@ static void utc_media_FocusRequest_Builder_build_n(void)
 	TC_SUCCESS_RESULT();
 }
 
-static void utc_media_FocusRequest_getId_p(void)
-{
-	{
-		stream_info_t *info;
-		stream_info_create(STREAM_TYPE_MEDIA, &info);
-		auto deleter = [](stream_info_t *ptr) { stream_info_destroy(ptr); };
-		auto stream_info = std::shared_ptr<stream_info_t>(info, deleter);
-		auto focusRequest = media::FocusRequest::Builder()
-								.setStreamInfo(stream_info)
-								.setFocusChangeListener(nullptr)
-								.build();
-		auto ret1 = focusRequest->getId();
-		auto ret2 = focusRequest->getId();
-		TC_ASSERT_EQ("utc_media_FocusRequest_getId", ret1.compare(ret2), 0);
-	}
-	{
-		stream_info_t *info;
-		stream_info_create(STREAM_TYPE_MEDIA, &info);
-		auto deleter = [](stream_info_t *ptr) { stream_info_destroy(ptr); };
-		auto stream_info1 = std::shared_ptr<stream_info_t>(info, deleter);
-		stream_info_create(STREAM_TYPE_MEDIA, &info);
-		auto stream_info2 = std::shared_ptr<stream_info_t>(info, deleter);
-		auto focusRequest1 = media::FocusRequest::Builder()
-								 .setStreamInfo(stream_info1)
-								 .setFocusChangeListener(nullptr)
-								 .build();
-		auto focusRequest2 = media::FocusRequest::Builder()
-								 .setStreamInfo(stream_info2)
-								 .setFocusChangeListener(nullptr)
-								 .build();
-		auto ret1 = focusRequest1->getId();
-		auto ret2 = focusRequest2->getId();
-		TC_ASSERT_NEQ("utc_media_FocusRequest_getId", ret1.compare(ret2), 0);
-	}
-	{
-		stream_info_t *info;
-		stream_info_create(STREAM_TYPE_MEDIA, &info);
-		auto deleter = [](stream_info_t *ptr) { stream_info_destroy(ptr); };
-		auto stream_info1 = std::shared_ptr<stream_info_t>(info, deleter);
-		stream_info_create(STREAM_TYPE_MEDIA, &info);
-		auto stream_info2 = std::shared_ptr<stream_info_t>(info, deleter);
-		auto listener = std::make_shared<EmptyFocusChangeListener>();
-		auto focusRequest1 = media::FocusRequest::Builder()
-								 .setStreamInfo(stream_info1)
-								 .setFocusChangeListener(listener)
-								 .build();
-		auto focusRequest2 = media::FocusRequest::Builder()
-								 .setStreamInfo(stream_info2)
-								 .setFocusChangeListener(listener)
-								 .build();
-		auto ret1 = focusRequest1->getId();
-		auto ret2 = focusRequest2->getId();
-		TC_ASSERT_NEQ("utc_media_FocusRequest_getId", ret1.compare(ret2), 0);
-	}
-	TC_SUCCESS_RESULT();
-}
-
-static void utc_media_FocusRequest_getListener_p(void)
-{
-	stream_info_t *info;
-	stream_info_create(STREAM_TYPE_MEDIA, &info);
-	auto deleter = [](stream_info_t *ptr) { stream_info_destroy(ptr); };
-	auto stream_info = std::shared_ptr<stream_info_t>(info, deleter);
-	auto listener = std::make_shared<EmptyFocusChangeListener>();
-	auto focusRequest = media::FocusRequest::Builder()
-							.setStreamInfo(stream_info)
-							.setFocusChangeListener(listener)
-							.build();
-	auto ret = focusRequest->getListener();
-	TC_ASSERT_EQ("utc_media_FocusRequest_getListener", ret.get(), listener.get());
-	TC_SUCCESS_RESULT();
-}
-
 int utc_media_FocusRequest_main(void)
 {
 	utc_media_FocusRequest_Builder_setStreamInfo_p();
 	utc_media_FocusRequest_Builder_setFocusChangeListener_p();
 	utc_media_FocusRequest_Builder_build_p();
 	utc_media_FocusRequest_Builder_build_n();
-	utc_media_FocusRequest_getId_p();
-	utc_media_FocusRequest_getListener_p();
 	return 0;
 }

--- a/framework/include/media/FocusManager.h
+++ b/framework/include/media/FocusManager.h
@@ -78,18 +78,18 @@ private:
 	class FocusRequester
 	{
 	public:
-		FocusRequester(std::string id, std::shared_ptr<FocusChangeListener> listener);
-		bool hasSameId(std::string id);
+		FocusRequester(stream_info_id_t id, std::shared_ptr<FocusChangeListener> listener);
+		bool hasSameId(std::shared_ptr<FocusRequest> focusRequest);
 		void notify(int focusChange);
 
 	private:
-		std::string mId;
+		stream_info_id_t mId;
 		std::shared_ptr<FocusChangeListener> mListener;
 	};
 
 	FocusManager() = default;
 	virtual ~FocusManager() = default;
-	void removeFocusElement(std::string id);
+	void removeFocusElement(std::shared_ptr<FocusRequest> focusRequest);
 	std::list<std::shared_ptr<FocusRequester>> mFocusList;
 	std::mutex mFocusLock;
 };

--- a/framework/include/media/FocusRequest.h
+++ b/framework/include/media/FocusRequest.h
@@ -35,6 +35,7 @@
 #include <media/FocusChangeListener.h>
 
 namespace media {
+class FocusManager;
 /**
  * @class 
  * @brief This class is focus request
@@ -88,22 +89,10 @@ public:
 		std::shared_ptr<FocusChangeListener> mListener;
 	};
 
-	/**
-	 * @brief Get FocusRequest Id
-	 * @details @b #include <media/FocusRequest.h>
-	 * @return FocusRequest Id
-	 * @since TizenRT v2.0
-	 */
-	std::string getId();
-	/**
-	 * @brief Get FocusChangeListener of FocusRequest
-	 * @details @b #include <media/FocusRequest.h>
-	 * @return shared_ptr of FocusChangeListener
-	 * @since TizenRT v2.0
-	 */
-	std::shared_ptr<FocusChangeListener> getListener();
-
 private:
+	friend class FocusManager;
+	std::shared_ptr<stream_info_t> getStreamInfo();
+	std::shared_ptr<FocusChangeListener> getListener();
 	std::shared_ptr<stream_info_t> mStreamInfo;
 	std::shared_ptr<FocusChangeListener> mListener;
 };

--- a/framework/include/media/stream_info.h
+++ b/framework/include/media/stream_info.h
@@ -56,9 +56,10 @@ enum stream_policy_e {
 };
 
 typedef enum stream_policy_e stream_policy_t;
+typedef uint64_t stream_info_id_t;
 
 struct stream_info_s {
-	uint64_t id;
+	stream_info_id_t id;
 	stream_policy_t policy;
 };
 

--- a/framework/src/media/FocusRequest.cpp
+++ b/framework/src/media/FocusRequest.cpp
@@ -19,9 +19,9 @@
 #include <media/FocusRequest.h>
 
 namespace media {
-std::string FocusRequest::getId()
+std::shared_ptr<stream_info_t> FocusRequest::getStreamInfo()
 {
-	return std::to_string(mStreamInfo->id);
+	return mStreamInfo;
 }
 
 std::shared_ptr<FocusChangeListener> FocusRequest::getListener()


### PR DESCRIPTION
User don't have to call FocusRequest methods directly.
FocusManager will call them internally.