### PR TITLE
configs/artik05x: fix romfs download

### DIFF
--- a/build/configs/artik05x/artik05x_download.sh
+++ b/build/configs/artik05x/artik05x_download.sh
@@ -227,7 +227,7 @@ while test $# -gt 0; do
 		--verify)
 			VERIFY=verify
 			;;
-		ALL|OS|ROMFS|BL1|BL2|SSSFW|WLANFW|OTA|all|os|romfs|bl1|bl2|sssfw|wlanfw|ota)
+		ALL|OS|ROM|BL1|BL2|SSSFW|WLANFW|OTA|all|os|rom|bl1|bl2|sssfw|wlanfw|ota)
 			download $1
 			;;
 		ERASE_*)


### PR DESCRIPTION
"make download ROMFS|romfs" doesn't work and is no more a valid interface.
It is replaced with "make download ROM|rom"

This patches adds necessary changes to make "make download ROM|rom" work

Signed-off-by: Manohara HK <manohara.hk@samsung.com>