### PR TITLE
kernel: Unify the pid hash

### DIFF
--- a/apps/examples/testcase/le_tc/kernel/tc_roundrobin.c
+++ b/apps/examples/testcase/le_tc/kernel/tc_roundrobin.c
@@ -29,6 +29,7 @@
 #include <sys/types.h>
 #include <sys/ioctl.h>
 #include <tinyara/testcase_drv.h>
+#include <tinyara/sched.h>
 #include "../../../../../os/kernel/clock/clock.h"
 #include "tc_internal.h"
 
@@ -43,8 +44,6 @@
 #else
 #define NTHREAD  3
 #endif
-#define MAX_TASKS_MASK      (CONFIG_MAX_TASKS-1)
-#define PIDHASH(pid)        ((pid) & MAX_TASKS_MASK)
 #define TEST_STACK_SIZE     (1024)
 /****************************************************************************
 * Private Data

--- a/apps/examples/testcase/le_tc/kernel/tc_umm_heap.c
+++ b/apps/examples/testcase/le_tc/kernel/tc_umm_heap.c
@@ -30,6 +30,7 @@
 #include <errno.h>
 #include <sched.h>
 #include <tinyara/mm/mm.h>
+#include <tinyara/sched.h>
 #include "tc_internal.h"
 
 #define ALLOC_SIZE_VAL 10
@@ -68,7 +69,7 @@ static void tc_umm_heap_malloc_free(void)
 	int alloc_tc_cnt;
 	pid_t hash_pid;
 	struct mm_heap_s *heap;
-	hash_pid = PID_HASH(getpid());
+	hash_pid = PIDHASH(getpid());
 
 	for (alloc_tc_cnt = 0; alloc_tc_cnt < TEST_TIMES; alloc_tc_cnt++) {
 		for (alloc_cnt = 0; alloc_cnt < ALLOC_FREE_TIMES; alloc_cnt++) {
@@ -100,7 +101,7 @@ static void tc_umm_heap_calloc(void)
 	int alloc_tc_cnt;
 	pid_t hash_pid;
 	struct mm_heap_s *heap;
-	hash_pid = PID_HASH(getpid());
+	hash_pid = PIDHASH(getpid());
 
 	for (alloc_tc_cnt = 0; alloc_tc_cnt < TEST_TIMES; alloc_tc_cnt++) {
 		for (alloc_cnt = 0; alloc_cnt < ALLOC_FREE_TIMES; alloc_cnt++) {
@@ -135,7 +136,7 @@ static void tc_umm_heap_realloc(void)
 	int alloc_tc_cnt;
 	pid_t hash_pid;
 	struct mm_heap_s *heap;
-	hash_pid = PID_HASH(getpid());
+	hash_pid = PIDHASH(getpid());
 
 	for (alloc_tc_cnt = 0; alloc_tc_cnt < TEST_TIMES; alloc_tc_cnt++) {
 		for (alloc_cnt = 0; alloc_cnt < ALLOC_FREE_TIMES; alloc_cnt++) {
@@ -168,7 +169,7 @@ static void tc_umm_heap_memalign(void)
 	int alloc_tc_cnt;
 	pid_t hash_pid;
 	struct mm_heap_s *heap;
-	hash_pid = PID_HASH(getpid());
+	hash_pid = PIDHASH(getpid());
 
 	for (alloc_tc_cnt = 0; alloc_tc_cnt < TEST_TIMES; alloc_tc_cnt++) {
 		for (alloc_cnt = 0; alloc_cnt < ALLOC_FREE_TIMES; alloc_cnt++) {
@@ -204,7 +205,7 @@ static void tc_umm_heap_random_malloc(void)
 	int allocated_size = 0;
 	pid_t hash_pid;
 	struct mm_heap_s *heap;
-	hash_pid = PID_HASH(getpid());
+	hash_pid = PIDHASH(getpid());
 
 	srand(time(NULL));
 

--- a/apps/system/utils/kdbg_stackmonitor.c
+++ b/apps/system/utils/kdbg_stackmonitor.c
@@ -296,7 +296,7 @@ void stkmon_logging(struct tcb_s *tcb)
 #endif
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
 	heap = mm_get_heap(tcb->stack_alloc_ptr);
-	stkmon_arr[stkmon_chk_idx % (CONFIG_MAX_TASKS * 2)].chk_peakheap = heap->alloc_list[PID_HASH(tcb->pid)].peak_alloc_size;
+	stkmon_arr[stkmon_chk_idx % (CONFIG_MAX_TASKS * 2)].chk_peakheap = heap->alloc_list[PIDHASH(tcb->pid)].peak_alloc_size;
 #endif
 #if (CONFIG_TASK_NAME_SIZE > 0)
 	for (name_idx = 0; name_idx < CONFIG_TASK_NAME_SIZE + 1; name_idx++) {

--- a/external/libtuv/source/tinyara/uv_tinyara_signal.c
+++ b/external/libtuv/source/tinyara/uv_tinyara_signal.c
@@ -44,6 +44,7 @@
 #include <string.h>
 #include <unistd.h>
 #include <semaphore.h>
+#include <tinyara/sched.h>
 
 #include <uv.h>
 
@@ -65,9 +66,6 @@ static uv_once_t uv__signal_global_init_guard = UV_ONCE_INIT;
 static struct uv__signal_tree_s uv__signal_tree[CONFIG_MAX_TASKS] =
     {RB_INITIALIZER(uv__signal_tree), };
 static sem_t uv_sig_sem;
-
-#define MAX_PID_MASK   (CONFIG_MAX_TASKS - 1)
-#define PID_HASH(pid)  ((pid) & MAX_PID_MASK)
 
 
 RB_GENERATE_STATIC(uv__signal_tree_s,
@@ -131,7 +129,7 @@ static uv_signal_t* uv__signal_first_handle(int signum) {
   lookup.signum = signum;
   lookup.loop = NULL;
 
-  index = PID_HASH(getpid());
+  index = PIDHASH(getpid());
   if (index < 0 || index >= CONFIG_MAX_TASKS) {
 	  return NULL;
   }
@@ -154,7 +152,7 @@ static void uv__signal_handler(int signum) {
   saved_errno = errno;
   memset(&msg, 0, sizeof msg);
 
-  index = PID_HASH(getpid());
+  index = PIDHASH(getpid());
   if (index < 0 || index >= CONFIG_MAX_TASKS) {
     errno = saved_errno;
     return;
@@ -320,7 +318,7 @@ int uv_signal_start(uv_signal_t* handle, uv_signal_cb signal_cb, int signum) {
     return -EINVAL;
 
   /* If index is invalid, processing signal would be failed. */
-  index = PID_HASH(getpid());
+  index = PIDHASH(getpid());
   if (index < 0 || index >= CONFIG_MAX_TASKS) {
 	  return -EINVAL;
   }
@@ -475,7 +473,7 @@ static void uv__signal_stop(uv_signal_t* handle) {
   if (handle->signum == 0)
     return;
 
-  index = PID_HASH(getpid());
+  index = PIDHASH(getpid());
   if (index < 0 || index >= CONFIG_MAX_TASKS) {
 	  return;
   }

--- a/external/libtuv/source/tinyara/uv_tinyara_signal.c
+++ b/external/libtuv/source/tinyara/uv_tinyara_signal.c
@@ -130,9 +130,6 @@ static uv_signal_t* uv__signal_first_handle(int signum) {
   lookup.loop = NULL;
 
   index = PIDHASH(getpid());
-  if (index < 0 || index >= CONFIG_MAX_TASKS) {
-	  return NULL;
-  }
 
   handle = RB_NFIND(uv__signal_tree_s, &uv__signal_tree[index], &lookup);
 
@@ -153,10 +150,6 @@ static void uv__signal_handler(int signum) {
   memset(&msg, 0, sizeof msg);
 
   index = PIDHASH(getpid());
-  if (index < 0 || index >= CONFIG_MAX_TASKS) {
-    errno = saved_errno;
-    return;
-  }
 
   if (uv__signal_lock()) {
     errno = saved_errno;
@@ -319,9 +312,6 @@ int uv_signal_start(uv_signal_t* handle, uv_signal_cb signal_cb, int signum) {
 
   /* If index is invalid, processing signal would be failed. */
   index = PIDHASH(getpid());
-  if (index < 0 || index >= CONFIG_MAX_TASKS) {
-	  return -EINVAL;
-  }
 
   /* Short circuit: if the signal watcher is already watching {signum} don't
    * go through the process of deregistering and registering the handler.
@@ -474,9 +464,6 @@ static void uv__signal_stop(uv_signal_t* handle) {
     return;
 
   index = PIDHASH(getpid());
-  if (index < 0 || index >= CONFIG_MAX_TASKS) {
-	  return;
-  }
 
   uv__signal_block_and_lock(&saved_sigmask);
 

--- a/framework/src/eventloop/eventloop_loop.c
+++ b/framework/src/eventloop/eventloop_loop.c
@@ -22,6 +22,7 @@
 
 #include <debug.h>
 #include <unistd.h>
+#include <tinyara/sched.h>
 #include <libtuv/uv.h>
 #include <libtuv/uv__types.h>
 #include <libtuv/uv__loop.h>
@@ -31,15 +32,12 @@
 
 el_loop_t *g_loop_list[CONFIG_MAX_TASKS];
 
-#define MAX_PID_MASK   (CONFIG_MAX_TASKS - 1)
-#define PID_HASH(pid)  ((pid) & MAX_PID_MASK)
-
 el_loop_t *get_app_loop(void)
 {
 	int index;
 
 	/* Get a loop assigned to own task */
-	index = PID_HASH(getpid());
+	index = PIDHASH(getpid());
 
 	if (g_loop_list[index] == NULL) {
 		g_loop_list[index] = (el_loop_t *)EL_ALLOC(sizeof(el_loop_t));
@@ -55,7 +53,7 @@ static int release_app_loop(void)
 {
 	int index;
 
-	index = PID_HASH(getpid());
+	index = PIDHASH(getpid());
 
 	if (g_loop_list[index] != NULL) {
 		if (uv_loop_close(g_loop_list[index]) < 0) {
@@ -123,7 +121,7 @@ int eventloop_loop_stop(void)
 {
 	int index;
 
-	index = PID_HASH(getpid());
+	index = PIDHASH(getpid());
 
 	/* If app loop is already finished or not exist, EVENTLOOP_LOOP_FAIL is returned. */
 	if (g_loop_list[index] == NULL) {

--- a/os/fs/procfs/fs_procfsproc.c
+++ b/os/fs/procfs/fs_procfsproc.c
@@ -384,7 +384,7 @@ static ssize_t proc_entry_stat(FAR struct proc_file_s *procfile, FAR struct tcb_
 	curr_heap = -1;
 	peak_heap = -1;
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
-	hash_pid = PID_HASH(tcb->pid);
+	hash_pid = PIDHASH(tcb->pid);
 	heap = mm_get_heap(tcb->stack_alloc_ptr);
 	if (heap->alloc_list[hash_pid].pid == tcb->pid) {
 		curr_heap = heap->alloc_list[hash_pid].curr_alloc_size;

--- a/os/include/tinyara/mm/mm.h
+++ b/os/include/tinyara/mm/mm.h
@@ -216,9 +216,6 @@
 #define REGION_END (REGION_START + REGION_SIZE)
 #define INVALID_HEAP_IDX -1
 
-#define MAX_PID_MASK   (CONFIG_MAX_TASKS - 1)
-#define PID_HASH(pid)  ((pid) & MAX_PID_MASK)
-
 /* Determines the size of the chunk size/offset type */
 
 #ifdef CONFIG_MM_SMALL

--- a/os/include/tinyara/sched.h
+++ b/os/include/tinyara/sched.h
@@ -183,6 +183,9 @@
 #define KEY_NOT_INUSE   (0)
 #define KEY_INUSE       (1)
 
+#define MAX_PID_MASK	(CONFIG_MAX_TASKS - 1)
+#define PIDHASH(pid)	((pid) & MAX_PID_MASK)
+
 /********************************************************************************
  * Public Type Definitions
  ********************************************************************************/

--- a/os/kernel/sched/sched.h
+++ b/os/kernel/sched/sched.h
@@ -83,8 +83,6 @@
 #if CONFIG_MAX_TASKS & (CONFIG_MAX_TASKS - 1)
 #error "Max number of tasks(CONFIG_MAX_TASKS) should be power of 2"
 #endif
-#define MAX_TASKS_MASK      (CONFIG_MAX_TASKS-1)
-#define PIDHASH(pid)        ((pid) & MAX_TASKS_MASK)
 
 /* These are macros to access the current CPU and the current task on a CPU.
  * These macros are intended to support a future SMP implementation.

--- a/os/kernel/sched/sched_cpuload.c
+++ b/os/kernel/sched/sched_cpuload.c
@@ -60,6 +60,7 @@
 #include <assert.h>
 
 #include <tinyara/clock.h>
+#include <tinyara/sched.h>
 #include <arch/irq.h>
 
 #include "sched/sched.h"

--- a/os/kernel/sched/sched_gettcb.c
+++ b/os/kernel/sched/sched_gettcb.c
@@ -57,6 +57,7 @@
 #include <sys/types.h>
 
 #include <sched.h>
+#include <tinyara/sched.h>
 
 #include "sched/sched.h"
 

--- a/os/kernel/sched/sched_verifytcb.c
+++ b/os/kernel/sched/sched_verifytcb.c
@@ -58,6 +58,7 @@
 
 #include <stdbool.h>
 #include <sched.h>
+#include <tinyara/sched.h>
 
 #include "sched/sched.h"
 

--- a/os/kernel/task/task_activate.c
+++ b/os/kernel/task/task_activate.c
@@ -60,6 +60,7 @@
 #include <debug.h>
 
 #include <tinyara/arch.h>
+#include <tinyara/sched.h>
 #ifndef CONFIG_DISABLE_SIGNALS
 #include <pthread.h>
 #include <unistd.h>
@@ -166,7 +167,7 @@ int task_activate(FAR struct tcb_s *tcb)
 	pid_t hash_pid;
 	struct mm_heap_s *heap = mm_get_heap(tcb->stack_alloc_ptr);
 
-	hash_pid = PID_HASH(tcb->pid);
+	hash_pid = PIDHASH(tcb->pid);
 	if (heap->alloc_list[hash_pid].pid == HEAPINFO_INIT_INFO) {
 		heap->alloc_list[hash_pid].pid = tcb->pid;
 		heap->alloc_list[hash_pid].curr_alloc_size = 0;

--- a/os/mm/mm_heap/mm_heapinfo.c
+++ b/os/mm/mm_heap/mm_heapinfo.c
@@ -67,7 +67,6 @@
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
-#define MM_PIDHASH(pid) ((pid) & (CONFIG_MAX_TASKS - 1))
 #define HEAPINFO_INT INT16_MAX
 #define HEAPINFO_NONSCHED (INT16_MAX - 1)
 
@@ -162,8 +161,8 @@ void heapinfo_parse(FAR struct mm_heap_s *heap, int mode, pid_t pid)
 				} else if (node->pid < 0 && sched_gettcb((-1) * (node->pid)) != NULL) {
 					stack_resource += node->size;
 				} else if (sched_gettcb(node->pid) == NULL) {
-					nonsched_list[MM_PIDHASH(node->pid)] = node->pid;
-					nonsched_size[MM_PIDHASH(node->pid)] += node->size;
+					nonsched_list[PIDHASH(node->pid)] = node->pid;
+					nonsched_size[PIDHASH(node->pid)] += node->size;
 					nonsched_resource += node->size;
 				} else {
 					heap_resource += node->size;
@@ -290,7 +289,7 @@ void heapinfo_add_size(struct mm_heap_s *heap, pid_t pid, mmsize_t size)
 {
 	pid_t hash_pid;
 
-	hash_pid = PID_HASH(pid);
+	hash_pid = PIDHASH(pid);
 	if (heap->alloc_list[hash_pid].pid == HEAPINFO_INIT_INFO || heap->alloc_list[hash_pid].pid == pid) {
 			heap->alloc_list[hash_pid].pid = pid;
 			heap->alloc_list[hash_pid].curr_alloc_size += size;
@@ -311,7 +310,7 @@ void heapinfo_subtract_size(struct mm_heap_s *heap, pid_t pid, mmsize_t size)
 {
 	pid_t hash_pid;
 
-	hash_pid = PID_HASH(pid);
+	hash_pid = PIDHASH(pid);
 	if (heap->alloc_list[hash_pid].pid == pid) {
 			heap->alloc_list[hash_pid].curr_alloc_size -= size;
 			heap->alloc_list[hash_pid].num_alloc_free--;
@@ -372,7 +371,7 @@ void heapinfo_exclude_stacksize(void *stack_ptr)
 	pid_t hash_pid;
 
 	node = (struct mm_allocnode_s *)(stack_ptr - SIZEOF_MM_ALLOCNODE);
-	hash_pid = PID_HASH(node->pid);
+	hash_pid = PIDHASH(node->pid);
 	heap->alloc_list[hash_pid].curr_alloc_size -= node->size;
 #ifdef CONFIG_HEAPINFO_USER_GROUP
 	int check_idx;


### PR DESCRIPTION
In each module, there is a pid hash definition, but all are same. So integrated them to one.