### PR TITLE
os/drivers: Add filesystem command driver

### DIFF
--- a/os/drivers/Kconfig
+++ b/os/drivers/Kconfig
@@ -496,3 +496,4 @@ menuconfig DRIVERS_WIRELESS
 		Drivers for various wireless devices.
 
 source drivers/wireless/Kconfig
+source drivers/fscmd/Kconfig

--- a/os/drivers/Makefile
+++ b/os/drivers/Makefile
@@ -74,6 +74,7 @@ include analog$(DELIM)Make.defs
 include audio$(DELIM)Make.defs
 include bch$(DELIM)Make.defs
 include fota$(DELIM)Make.defs
+include fscmd$(DELIM)Make.defs
 include gpio$(DELIM)Make.defs
 include heapinfo$(DELIM)Make.defs
 include i2c$(DELIM)Make.defs

--- a/os/drivers/fscmd/Kconfig
+++ b/os/drivers/fscmd/Kconfig
@@ -1,0 +1,11 @@
+#
+# For a description of the syntax of this configuration file,
+# see kconfig-language at https://www.kernel.org/doc/Documentation/kbuild/kconfig-language.txt
+#
+
+config FSCMD_DRV
+	bool "File System Command Driver"
+	default y
+	depends on FS_CMDS
+	---help---
+		Support Kernel Context Access to File System Commands Used in the Tash Shell.

--- a/os/drivers/fscmd/Make.defs
+++ b/os/drivers/fscmd/Make.defs
@@ -1,0 +1,27 @@
+##########################################################################
+#
+# Copyright 2019 Samsung Electronics All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+#
+############################################################################
+# Include Filesystem command drivers
+
+#ifeq ($(CONFIG_FSCMD_DRV),y)
+
+CSRCS += fscmd_drv.c
+
+DEPPATH += --dep-path fscmd
+VPATH += :fscmd
+
+#endif

--- a/os/drivers/fscmd/fscmd_drv.c
+++ b/os/drivers/fscmd/fscmd_drv.c
@@ -1,0 +1,119 @@
+/****************************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+#include <tinyara/config.h>
+#include <tinyara/fscmd_drv.h>
+#include <tinyara/fs/ioctl.h>
+#include <tinyara/fs/ramdisk.h>
+#include <tinyara/fs/mksmartfs.h>
+#include <stdio.h>
+#include <errno.h>
+
+/****************************************************************************
+ * Private Function Prototypes
+ ****************************************************************************/
+static int fcdrv_ioctl(FAR struct file *filep, int cmd, unsigned long arg);
+static ssize_t fcdrv_read(FAR struct file *filep, FAR char *buffer, size_t len);
+static ssize_t fcdrv_write(FAR struct file *filep, FAR const char *buffer, size_t len);
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+static const struct file_operations fc_fops = {
+	0,													/* open */
+	0,													/* close */
+	fcdrv_read,											/* read */
+	fcdrv_write,										/* write */
+	0,													/* seek */
+	fcdrv_ioctl											/* ioctl */
+#ifndef CONFIG_DISABLE_POLL
+	, 0													/* poll */
+#endif
+};
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+static ssize_t fcdrv_read(FAR struct file *filep, FAR char *buffer, size_t len)
+{
+	printf("%s\n", __FUNCTION__);
+	return 0;
+}
+
+static ssize_t fcdrv_write(FAR struct file *filep, FAR const char *buffer, size_t len)
+{
+	printf("%s\n", __FUNCTION__);
+	return 0;
+}
+
+/****************************************************************************
+ * Name: fcdrv_ioctl
+ *
+ * Description:  The ioctl method for fscmd.
+ *
+ ****************************************************************************/
+static int fcdrv_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
+{
+	int ret = -EINVAL;
+
+	switch (cmd) {
+	case FCIOC_FOREACH_MOUNTPOINT: {
+		struct foreach_mountpoint_s *info = (struct foreach_mountpoint_s *)arg;
+		ret = foreach_mountpoint(info->handler, (FAR void *)info->arg);
+	}
+	break;
+
+	case FCIOC_RAMDISK_REGISTER: {
+		struct ramdisk_info_s *info = (struct ramdisk_info_s *)arg;
+		ret = ramdisk_register(info->minor, info->buffer, info->nsectors, info->sectsize, info->rdflags);
+	}
+	break;
+
+	case FCIOC_MAKE_SMARTFS: {
+		struct mksmartfs_info_s *info = (struct mksmartfs_info_s *)arg;
+#ifdef CONFIG_SMARTFS_MULTI_ROOT_DIRS
+		ret = mksmartfs(info->pathname, info->nrootdirs, info->force);
+#else
+		ret = mksmartfs(info->pathname, info->force);
+#endif
+	}
+	break;
+
+	}
+	return ret;
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: fscmd_drv_register
+ *
+ * Description:
+ *   Register /dev/fscmd
+ *
+ ****************************************************************************/
+
+void fscmd_drv_register(void)
+{
+	(void)register_driver(FSCMD_DRVPATH, &fc_fops, 0666, NULL);
+}

--- a/os/include/tinyara/fs/ioctl.h
+++ b/os/include/tinyara/fs/ioctl.h
@@ -96,6 +96,7 @@
 #define _TMBASE         (0x2100)	/* Task Management ioctl commands */
 #define _HEAPINFOBASE   (0x2200)	/* Heapinfo ioctl commands */
 #define _SPIBASE        (0x2300)	/* SPI ioctl commands */
+#define _FCBASE         (0x2400)	/* Tash Filesystem Function ioctl commands */
 #define _TESTIOCBASE (0xfe00)	/* KERNEL TEST DRV module ioctl commands */
 
 /* boardctl() commands share the same number space */
@@ -170,6 +171,19 @@
 #define DIOC_SETKEY     _DIOC(0X0004)	/* IN:  Encryption key
 										 * OUT: None
 										 */
+
+/* TinyAra Filesystem command driver ioctl definitions *********************/
+
+#define _FCIOCVALID(c)			(_IOC_TYPE(c) == _FCBASE)
+#define _FCIOC(nr)			_IOC(_FCBASE, nr)
+
+#define FCIOC_FOREACH_MOUNTPOINT	_FCIOC(0x0001)
+#define FCIOC_RAMDISK_REGISTER		_FCIOC(0x0002)
+#define FCIOC_MAKE_SMARTFS		_FCIOC(0x0003)
+#define FCIOC_RAM_MTD_INITIALIZE	_FCIOC(0x0004)
+#define FCIOC_FTL_INITIALIZE		_FCIOC(0x0005)
+#define FCIOC_MTD_PARTITION		_FCIOC(0x0006)
+#define UNREGISTER_BLOCKDRIVER		_FCIOC(0x0007)
 
 /* TinyAra block driver ioctl definitions *************************************/
 

--- a/os/include/tinyara/fscmd_drv.h
+++ b/os/include/tinyara/fscmd_drv.h
@@ -1,0 +1,63 @@
+/****************************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __INCLUDE_TINYARA_FSCMD_DRV_H
+#define __INCLUDE_TINYARA_FSCMD_DRV_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <tinyara/fs/fs.h>
+
+#define FSCMD_DRVPATH			"/dev/fscmd"
+
+struct foreach_mountpoint_s {
+	foreach_mountpoint_t handler;
+	FAR void *arg;
+};
+
+struct ramdisk_info_s {
+	int minor;
+	int sectsize;
+	uint8_t *buffer;
+	uint8_t rdflags;
+	uint32_t nsectors;
+};
+
+struct mksmartfs_info_s {
+	char *pathname;
+	uint8_t nrootdirs;
+	bool force;
+};
+
+void fscmd_drv_register(void);
+
+#ifdef __cplusplus
+#define EXTERN extern "C"
+extern "C" {
+#else
+#define EXTERN extern
+#endif
+
+#undef EXTERN
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __INCLUDE_TINYARA_FSCMD_DRV_H */

--- a/os/kernel/init/os_bringup.c
+++ b/os/kernel/init/os_bringup.c
@@ -78,6 +78,9 @@
 #ifdef CONFIG_TASK_MANAGER
 #include <tinyara/task_manager_drv.h>
 #endif
+#ifdef CONFIG_FSCMD_DRV
+#include <tinyara/fscmd_drv.h>
+#endif
 #include "wqueue/wqueue.h"
 #include "init/init.h"
 #ifdef CONFIG_PAGING
@@ -268,6 +271,10 @@ static inline void os_do_appstart(void)
 
 #ifdef CONFIG_ENABLE_HEAPINFO_CMD
 	heapinfo_drv_register();
+#endif
+
+#ifdef CONFIG_FSCMD_DRV
+	fscmd_drv_register();
 #endif
 
 #ifdef CONFIG_TASK_MANAGER


### PR DESCRIPTION
Added a driver that can call file system commands used in the Tash shell.
Because fscmd uses an API that calls the kernel context, it needs to be called via the driver.