### PR TITLE
gitignore: add pyc file pattern

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ Make.dep
 .gdbinit
 cscope.out
 tags
+*.pyc
 
 # ctags index file
 .tags


### PR DESCRIPTION
ESP32 flash tools use python scripts,  pyc file pattern need to be added in gitignore.
