### PR TITLE
board/artik05x: remove stale elf file after protected build

### DIFF
--- a/os/board/artik05x/userspace/Makefile
+++ b/os/board/artik05x/userspace/Makefile
@@ -94,6 +94,7 @@ OBJS  = $(COBJS)
 # Targets:
 
 all: $(USER_BINPATH)$(DELIM)tinyara_user.elf $(USER_BINPATH)$(DELIM)User.map
+	$(call DELFILE, tinyara_user.elf)
 .PHONY: tinyara_user.elf depend clean distclean
 
 $(COBJS): %$(OBJEXT): %.c


### PR DESCRIPTION
board/artik05x/userspace/tinyara_user.elf is copied to
build/output/bin/ and no longer required.

Verification:
run git status after build

Signed-off-by: Manohara HK <manohara.hk@samsung.com>