### PR TITLE
mm_heap : add a simple implementation of memory pool

### DIFF
--- a/os/include/tinyara/mm/mm.h
+++ b/os/include/tinyara/mm/mm.h
@@ -378,6 +378,10 @@ struct mm_heap_s {
 	int mm_nregions;
 #endif
 
+#ifdef CONFIG_SMALL_MEMORY_ISOLATION
+	FAR struct mm_allocnode_s *mm_delimiter;
+#endif
+
 	/* All free nodes are maintained in a doubly linked list.  This
 	 * array provides some hooks into the list at various points to
 	 * speed searches for free nodes.

--- a/os/mm/Kconfig
+++ b/os/mm/Kconfig
@@ -119,6 +119,41 @@ config DEBUG_GRAN
 		Just like DEBUG_MM, but only generates output from the gran
 		allocation logic.
 
+config SMALL_MEMORY_ISOLATION
+	bool "Isolate small memory segments to mitigate fragmentation"
+	default n
+	---help---
+		The main cause of fragmentation is the mix-up of small and large
+		memory segments at the same heap space. A common solution is memory pool
+		where small memory segments are forced to be allocated. To realize
+		a memory pool implementation in a simple way, this config just
+		monopolizes a certain amount of memory space for small memory segments
+		of which the size is smaller than or equal to SIZEOF_SMALL_MEMORY.
+
+config SIZEOF_ISOLATION_SPACE
+	int "Total size of isolated memory space for small memory segments"
+	default 20480
+	depends on SMALL_MEMORY_ISOLATION
+	---help---
+		All small memory segments are allocated within this space.
+		This value may be a form of 2^n. If you set other value,
+		for example, 2^n < your_value < 2^(n+1),
+		it will be changed to 2^(n+1).
+		This value along with SIZEOF_SMALL_MEMORY
+		should be carefully determined after thoroughly profiling
+		memory usage in terms of size and lifetime.
+
+config SIZEOF_SMALL_MEMORY
+	int "The maximum size of small memory segments"
+	default 64
+	depends on SMALL_MEMORY_ISOLATION
+	---help---
+		This value is the maximum size of small memory segments that
+		are allowed to be allocated within the isolated space defined by
+		MEMORY_ISOLATION_SIZE. This value along with SIZEOF_ISOLATION_SPACE
+		should be carefully determined after thoroughly profiling
+		memory usage in terms of size and lifetime.
+
 config MM_PGALLOC
 	bool "Enable Page Allocator"
 	default n


### PR DESCRIPTION
[Experimental] Please just review and do not merge before
lots of testing will have been done soon.

To mitigate memory fragmentation, this approach just divides
one large chunk of memory into two chunks. One, whose size is defined by
SIZEOF_ISOLATION_SPACE, is dedicated to being used
for allocating small memory of which the size is defined by SIZEOF_SMALL_MEMORY and
the other one is used for larger memory.
In order to use this simple version of memory pool, just turn on the config
called SMALL_MEMORY_ISOLATION and define SIZEOF_ISOLATION_SPACE and
SIZEOF_SMALL_MEMORY.