### PR TITLE
framework/wifi_manager: Return WIFI_MANAGER_FAIL for invalid command

### DIFF
--- a/framework/src/wifi_manager/wifi_manager.c
+++ b/framework/src/wifi_manager/wifi_manager.c
@@ -1224,6 +1224,9 @@ wifi_manager_result_e _handler_on_reconnect_state(_wifimgr_msg_s *msg)
 		nvdbg("[WM] deinit\n");
 		WIFIMGR_CHECK_RESULT(_wifimgr_deinit(), "critical error\n", WIFI_MANAGER_FAIL);
 		WIFIMGR_SET_STATE(WIFIMGR_UNINITIALIZED);
+	} else {
+		WIFIADD_ERR_RECORD(ERR_WIFIMGR_INVALID_EVENT);
+		return WIFI_MANAGER_FAIL;
 	}
 #else /* WIFIDRIVER_SUPPORT_AUTOCONNECT*/
 	if (msg->event == EVT_DISCONNECT) {
@@ -1240,6 +1243,9 @@ wifi_manager_result_e _handler_on_reconnect_state(_wifimgr_msg_s *msg)
 		ndbg("[WM] AUTOCONNECT fail: go to DEINIT\n");
 		WIFIMGR_CHECK_RESULT(_wifimgr_deinit(), "critical error\n", WIFI_MANAGER_FAIL);
 		WIFIMGR_SET_STATE(WIFIMGR_UNINITIALIZED);
+	} else {
+		WIFIADD_ERR_RECORD(ERR_WIFIMGR_INVALID_EVENT);
+		return WIFI_MANAGER_FAIL;
 	}
 #endif /* WIFIDRIVER_SUPPORT_AUTOCONNECT*/
 	return WIFI_MANAGER_SUCCESS;
@@ -1267,6 +1273,9 @@ wifi_manager_result_e _handler_on_reconnecting_state(_wifimgr_msg_s *msg)
 		WIFIMGR_TERMINATE_RECONN_WORKER;
 		_handle_user_cb(CB_STA_CONNECTED, NULL);
 		WIFIMGR_SET_STATE(WIFIMGR_STA_CONNECTED);
+	} else {
+		WIFIADD_ERR_RECORD(ERR_WIFIMGR_INVALID_EVENT);
+		return WIFI_MANAGER_FAIL;
 	}
 #endif /* WIFIDRIVER_SUPPORT_AUTOCONNECT*/
 	return WIFI_MANAGER_SUCCESS;


### PR DESCRIPTION
- Return WIFI_MANAGER_FAIL for RECONNECT/RECONNECTING state,  when an invalid command (join/leave) comes from user application. Note that RECONNECT or RECONNECTING state should wait driver's callback not user command (except EVT_DEINIT).