### PR TITLE
Dynamic loader support

### DIFF
--- a/lib/libc/Kconfig
+++ b/lib/libc/Kconfig
@@ -247,6 +247,10 @@ config LIB_SENDFILE_BUFSIZE
 	---help---
 		Size of the I/O buffer to allocate in sendfile().  Default: 512b
 
+config LIBC_ARCH_ELF
+	bool "Architecture support for ELF"
+	default n
+
 config ARCH_HAVE_ROMGETC
 	bool
 
@@ -421,6 +425,14 @@ config ARCH_BZERO
 		of bzero().
 
 endif # ARCH_OPTIMIZED_FUNCTIONS
+
+config LIB_ENVPATH
+        bool "Support PATH Environment Variable"
+        default n
+        depends on !DISABLE_ENVIRON
+        ---help---
+                Use the contents of the common environment variable to locate executable
+                or library files.  Default: n
 
 comment "Non-standard Library Support"
 

--- a/lib/libc/Kconfig
+++ b/lib/libc/Kconfig
@@ -434,6 +434,28 @@ config LIB_ENVPATH
                 Use the contents of the common environment variable to locate executable
                 or library files.  Default: n
 
+comment "Program Execution Options"
+
+config LIBC_EXECFUNCS
+	bool "Enable exec[l|v] Support"
+	default n
+	depends on !BINFMT_DISABLE
+	---help---
+		Enable support for the exec[l|v] family of functions that can be
+		used to start other programs, terminating the current program and
+		the posix_spawn() familty of functions that can be used start other
+		programs without terminating the current program.  The typical
+		usage of the exec[l|v] functions is (1) first call vfork() to create
+		a new thread, then (2) call exec[l|v] to replace the new thread with
+		a program from the file system.
+
+		NOTE 1: This two step process start is completely unnecessary in
+		NuttX and is provided only for compatibily with Unix systems.  These
+		functions are essentially just wrapper functions that (1) call the
+		non-standard binfmt function 'exec', and then (2) exit(0).  Since
+		the new thread will be terminated by the exec[l|v] call, it really
+		served no purpose other than to suport Unix compatility.
+
 comment "Non-standard Library Support"
 
 if BUILD_PROTECTED || BUILD_KERNEL

--- a/lib/libc/Makefile
+++ b/lib/libc/Makefile
@@ -82,6 +82,7 @@ include stdio/Make.defs
 include stdlib/Make.defs
 include unistd/Make.defs
 include sched/Make.defs
+include symtab/Make.defs
 include syslog/Make.defs
 include string/Make.defs
 include aio/Make.defs
@@ -89,6 +90,7 @@ include pthread/Make.defs
 include semaphore/Make.defs
 include signal/Make.defs
 include mqueue/Make.defs
+include machine/Make.defs
 include math/Make.defs
 include fixedmath/Make.defs
 include net/Make.defs

--- a/lib/libc/machine/Make.defs
+++ b/lib/libc/machine/Make.defs
@@ -1,0 +1,55 @@
+###########################################################################
+#
+# Copyright 2019 Samsung Electronics All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+#
+###########################################################################
+############################################################################
+# lib/libc/machine/Make.defs
+#
+#   Copyright (C) 2017 Gregory Nutt. All rights reserved.
+#   Author: Gregory Nutt <gnutt@nuttx.org>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in
+#    the documentation and/or other materials provided with the
+#    distribution.
+# 3. Neither the name NuttX nor the names of its contributors may be
+#    used to endorse or promote products derived from this software
+#    without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+# OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+# AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+############################################################################
+
+ifeq ($(CONFIG_ARCH_ARM),y)
+include ${TOPDIR}/../lib/libc/machine/arm/Make.defs
+endif

--- a/lib/libc/machine/arm/Make.defs
+++ b/lib/libc/machine/arm/Make.defs
@@ -1,0 +1,61 @@
+###########################################################################
+#
+# Copyright 2019 Samsung Electronics All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+#
+###########################################################################
+############################################################################
+# lib/libc/machine/arm/Make.defs
+#
+#   Copyright (C) 2017 Gregory Nutt. All rights reserved.
+#   Author: Gregory Nutt <gnutt@nuttx.org>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in
+#    the documentation and/or other materials provided with the
+#    distribution.
+# 3. Neither the name NuttX nor the names of its contributors may be
+#    used to endorse or promote products derived from this software
+#    without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+# OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+# AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+############################################################################
+
+ifeq ($(CONFIG_ARCH_CORTEXR4),y)   # Cortex-R4 is ARMv7-R
+include ${TOPDIR}/../lib/libc/machine/arm/armv7-r/Make.defs
+else ifeq ($(CONFIG_ARCH_CORTEXR4F),y)  # Cortex-R4F is ARMv7-R
+include ${TOPDIR}/../lib/libc/machine/arm/armv7-r/Make.defs
+else ifeq ($(CONFIG_ARCH_CORTEXM3),y)   # Cortex-M3 is ARMv7-M
+include ${TOPDIR}/../lib/libc/machine/arm/armv7-m/Make.defs
+else ifeq ($(CONFIG_ARCH_CORTEXM4),y)   # Cortex-M4 is ARMv7E-M
+include ${TOPDIR}/../lib/libc/machine/arm/armv7-m/Make.defs
+endif

--- a/lib/libc/machine/arm/armv7-m/Make.defs
+++ b/lib/libc/machine/arm/armv7-m/Make.defs
@@ -1,0 +1,60 @@
+###########################################################################
+#
+# Copyright 2019 Samsung Electronics All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+#
+###########################################################################
+############################################################################
+# lib/libc/machine/arm/armv7-m/Make.defs
+#
+#   Copyright (C) 2017 Gregory Nutt. All rights reserved.
+#   Author: Gregory Nutt <gnutt@nuttx.org>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in
+#    the documentation and/or other materials provided with the
+#    distribution.
+# 3. Neither the name NuttX nor the names of its contributors may be
+#    used to endorse or promote products derived from this software
+#    without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+# OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+# AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+############################################################################
+
+ifeq ($(CONFIG_LIBC_ARCH_ELF),y)
+
+CSRCS += arch_elf.c
+
+DEPPATH += --dep-path machine/arm/armv7-m
+VPATH += :machine/arm/armv7-m
+
+endif

--- a/lib/libc/machine/arm/armv7-m/arch_elf.c
+++ b/lib/libc/machine/arm/armv7-m/arch_elf.c
@@ -1,0 +1,465 @@
+/****************************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+/****************************************************************************
+ * lib/libc/machine/arm/armv7-m/arch_elf.c
+ *
+ *   Copyright (C) 2012, 2014, 2017 Gregory Nutt. All rights reserved.
+ *   Author: Gregory Nutt <gnutt@nuttx.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <tinyara/config.h>
+
+#include <stdlib.h>
+#include <errno.h>
+#include <debug.h>
+
+#include <arch/elf.h>
+#include <tinyara/elf.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: up_checkarch
+ *
+ * Description:
+ *   Given the ELF header in 'hdr', verify that the ELF file is appropriate
+ *   for the current, configured architecture.  Every architecture that uses
+ *   the ELF loader must provide this function.
+ *
+ * Input Parameters:
+ *   hdr - The ELF header read from the ELF file.
+ *
+ * Returned Value:
+ *   True if the architecture supports this ELF file.
+ *
+ ****************************************************************************/
+
+bool up_checkarch(FAR const Elf32_Ehdr *ehdr)
+{
+	/* Make sure it's an ARM executable */
+
+	if (ehdr->e_machine != EM_ARM) {
+		berr("ERROR: Not for ARM: e_machine=%04x\n", ehdr->e_machine);
+		return false;
+	}
+
+	/* Make sure that 32-bit objects are supported */
+
+	if (ehdr->e_ident[EI_CLASS] != ELFCLASS32) {
+		berr("ERROR: Need 32-bit objects: e_ident[EI_CLASS]=%02x\n", ehdr->e_ident[EI_CLASS]);
+		return false;
+	}
+
+	/* Verify endian-ness */
+
+#ifdef CONFIG_ENDIAN_BIG
+	if (ehdr->e_ident[EI_DATA] != ELFDATA2MSB)
+#else
+	if (ehdr->e_ident[EI_DATA] != ELFDATA2LSB)
+#endif
+	{
+		berr("ERROR: Wrong endian-ness: e_ident[EI_DATA]=%02x\n", ehdr->e_ident[EI_DATA]);
+		return false;
+	}
+
+	/* TODO:  Check ABI here. */
+	return true;
+}
+
+/****************************************************************************
+ * Name: up_relocate and up_relocateadd
+ *
+ * Description:
+ *   Perform on architecture-specific ELF relocation.  Every architecture
+ *   that uses the ELF loader must provide this function.
+ *
+ * Input Parameters:
+ *   rel - The relocation type
+ *   sym - The ELF symbol structure containing the fully resolved value.
+ *         There are a few relocation types for a few architectures that do
+ *         not require symbol information.  For those, this value will be
+ *         NULL.  Implementations of these functions must be able to handle
+ *         that case.
+ *   addr - The address that requires the relocation.
+ *
+ * Returned Value:
+ *   Zero (OK) if the relocation was successful.  Otherwise, a negated errno
+ *   value indicating the cause of the relocation failure.
+ *
+ ****************************************************************************/
+
+int up_relocate(FAR const Elf32_Rel *rel, FAR const Elf32_Sym *sym, uintptr_t addr)
+{
+	int32_t offset;
+	uint32_t upper_insn;
+	uint32_t lower_insn;
+	unsigned int relotype;
+
+	/* All relocations except R_ARM_V4BX depend upon having valid symbol
+	 * information.
+	 */
+
+	relotype = ELF32_R_TYPE(rel->r_info);
+	if (sym == NULL && relotype != R_ARM_NONE && relotype != R_ARM_V4BX) {
+		return -EINVAL;
+	}
+
+	/* Handle the relocation by relocation type */
+
+	switch (relotype) {
+	case R_ARM_NONE: {
+		/* No relocation */
+	}
+	break;
+
+	case R_ARM_PC24:
+	case R_ARM_CALL:
+	case R_ARM_JUMP24: {
+		binfo("Performing PC24 [%d] link at addr %08lx [%08lx] to sym '%p' st_value=%08lx\n", ELF32_R_TYPE(rel->r_info), (long)addr, (long)(*(uint32_t *)addr), sym, (long)sym->st_value);
+
+		offset = (*(uint32_t *)addr & 0x00ffffff) << 2;
+		if (offset & 0x02000000) {
+			offset -= 0x04000000;
+		}
+
+		offset += sym->st_value - addr;
+		if (offset & 3 || offset < (int32_t)0xfe000000 || offset >= (int32_t)0x02000000) {
+			berr("ERROR:   ERROR: PC24 [%d] relocation out of range, offset=%08lx\n", ELF32_R_TYPE(rel->r_info), offset);
+
+			return -EINVAL;
+		}
+
+		offset >>= 2;
+
+		*(uint32_t *)addr &= 0xff000000;
+		*(uint32_t *)addr |= offset & 0x00ffffff;
+	}
+	break;
+
+	case R_ARM_ABS32:
+	case R_ARM_TARGET1: {	/* New ABI:  TARGET1 always treated as ABS32 */
+		binfo("Performing ABS32 link at addr=%08lx [%08lx] to sym=%p st_value=%08lx\n", (long)addr, (long)(*(uint32_t *)addr), sym, (long)sym->st_value);
+
+		*(uint32_t *)addr += sym->st_value;
+	}
+	break;
+
+#ifdef CONFIG_ARMV7M_TARGET2_PREL
+	case R_ARM_TARGET2:		/* TARGET2 is a platform-specific relocation: gcc-arm-none-eabi
+								 * performs a self relocation */
+	{
+		binfo("Performing TARGET2 link at addr=%08lx [%08lx] to sym=%p st_value=%08lx\n", (long)addr, (long)(*(uint32_t *)addr), sym, (long)sym->st_value);
+
+		*(uint32_t *)addr += sym->st_value - addr;
+	}
+	break;
+#endif
+
+	case R_ARM_THM_CALL:
+	case R_ARM_THM_JUMP24: {
+		uint32_t S;
+		uint32_t J1;
+		uint32_t J2;
+
+		/* Thumb BL and B.W instructions. Encoding:
+		 *
+		 * upper_insn:
+		 *
+		 *  1   1   1   1   1   1
+		 *  5   4   3   2   1   0   9   8   7   6   5   4   3   2   1   0
+		 * +----------+---+-------------------------------+--------------+
+		 * |1   1   1 |OP1|     OP2                       |              | 32-Bit Instructions
+		 * +----------+---+--+-----+----------------------+--------------+
+		 * |1   1   1 | 1   0|  S  |              imm10                  | BL Instruction
+		 * +----------+------+-----+-------------------------------------+
+		 *
+		 * lower_insn:
+		 *
+		 *  1   1   1   1   1   1
+		 *  5   4   3   2   1   0   9   8   7   6   5   4   3   2   1   0
+		 * +---+---------------------------------------------------------+
+		 * |OP |                                                         | 32-Bit Instructions
+		 * +---+--+---+---+---+------------------------------------------+
+		 * |1   1 |J1 | 1 |J2 |                 imm11                    | BL Instruction
+		 * +------+---+---+---+------------------------------------------+
+		 *
+		 * The branch target is encoded in these bits:
+		 *
+		 *   S     = upper_insn[10]
+		 *   imm10 = upper_insn[0:9]
+		 *   imm11 = lower_insn[0:10]
+		 *   J1    = lower_insn[13]
+		 *   J2    = lower_insn[11]
+		 */
+
+		upper_insn = (uint32_t)(*(uint16_t *)addr);
+		lower_insn = (uint32_t)(*(uint16_t *)(addr + 2));
+
+		binfo("Performing THM_JUMP24 [%d] link at addr=%08lx [%04x %04x] to sym=%p st_value=%08lx\n", ELF32_R_TYPE(rel->r_info), (long)addr, (int)upper_insn, (int)lower_insn, sym, (long)sym->st_value);
+
+		/* Extract the 25-bit offset from the 32-bit instruction:
+		 *
+		 *   offset[24]    = S
+		 *   offset[23]    = ~(J1 ^ S)
+		 *   offset[22]    = ~(J2 ^ S)]
+		 *   offset[12:21] = imm10
+		 *   offset[1:11]  = imm11
+		 *   offset[0]     = 0
+		 */
+
+		S = (upper_insn >> 10) & 1;
+		J1 = (lower_insn >> 13) & 1;
+		J2 = (lower_insn >> 11) & 1;
+
+		offset = (S << 24) |	/* S -   > offset[24] */
+				 ((~(J1 ^ S) & 1) << 23) |	/* J1    -> offset[23] */
+				 ((~(J2 ^ S) & 1) << 22) |	/* J2    -> offset[22] */
+				 ((upper_insn & 0x03ff) << 12) |	/* imm10 -> offset[12:21] */
+				 ((lower_insn & 0x07ff) << 1);	/* imm11 -> offset[1:11] */
+		/* 0     -> offset[0] */
+
+		/* Sign extend */
+
+		if (offset & 0x01000000) {
+			offset -= 0x02000000;
+		}
+
+		/* And perform the relocation */
+
+		binfo("  S=%d J1=%d J2=%d offset=%08lx branch target=%08lx\n", S, J1, J2, (long)offset, offset + sym->st_value - addr);
+
+		offset += sym->st_value - addr;
+
+		/* Is this a function symbol?  If so, then the branch target must be
+		 * an odd Thumb address
+		 */
+
+		if (ELF32_ST_TYPE(sym->st_info) == STT_FUNC && (offset & 1) == 0) {
+			berr("ERROR:   ERROR: JUMP24 [%d] requires odd offset, offset=%08lx\n", ELF32_R_TYPE(rel->r_info), offset);
+
+			return -EINVAL;
+		}
+
+		/* Check the range of the offset */
+
+		if (offset < (int32_t) 0xff000000 || offset >= (int32_t)0x01000000) {
+			berr("ERROR:   ERROR: JUMP24 [%d] relocation out of range, branch target=%08lx\n", ELF32_R_TYPE(rel->r_info), offset);
+
+			return -EINVAL;
+		}
+
+		/* Now, reconstruct the 32-bit instruction using the new, relocated
+		 * branch target.
+		 */
+
+		S = (offset >> 24) & 1;
+		J1 = S ^ (~(offset >> 23) & 1);
+		J2 = S ^ (~(offset >> 22) & 1);
+
+		upper_insn = ((upper_insn & 0xf800) | (S << 10) | ((offset >> 12) & 0x03ff));
+		*(uint16_t *)addr = (uint16_t)upper_insn;
+
+		lower_insn = ((lower_insn & 0xd000) | (J1 << 13) | (J2 << 11) | ((offset >> 1) & 0x07ff));
+		*(uint16_t *)(addr + 2) = (uint16_t)lower_insn;
+
+		binfo("  S=%d J1=%d J2=%d insn [%04x %04x]\n", S, J1, J2, (int)upper_insn, (int)lower_insn);
+	}
+	break;
+
+	case R_ARM_V4BX: {
+		binfo("Performing V4BX link at addr=%08lx [%08lx]\n", (long)addr, (long)(*(uint32_t *)addr));
+
+		/* Preserve only Rm and the condition code */
+
+		*(uint32_t *)addr &= 0xf000000f;
+
+		/* Change instruction to 'mov pc, Rm' */
+
+		*(uint32_t *)addr |= 0x01a0f000;
+	}
+	break;
+
+	case R_ARM_PREL31: {
+		binfo("Performing PREL31 link at addr=%08lx [%08lx] to sym=%p st_value=%08lx\n", (long)addr, (long)(*(uint32_t *)addr), sym, (long)sym->st_value);
+
+		offset = *(uint32_t *)addr + sym->st_value - addr;
+		*(uint32_t *)addr = offset & 0x7fffffff;
+	}
+	break;
+
+	case R_ARM_MOVW_ABS_NC:
+	case R_ARM_MOVT_ABS: {
+		binfo("Performing MOVx_ABS [%d] link at addr=%08lx [%08lx] to sym=%p st_value=%08lx\n", ELF32_R_TYPE(rel->r_info), (long)addr, (long)(*(uint32_t *)addr), sym, (long)sym->st_value);
+
+		offset = *(uint32_t *)addr;
+		offset = ((offset & 0xf0000) >> 4) | (offset & 0xfff);
+
+		offset += sym->st_value;
+		if (ELF32_R_TYPE(rel->r_info) == R_ARM_MOVT_ABS) {
+			offset >>= 16;
+		}
+
+		*(uint32_t *)addr &= 0xfff0f000;
+		*(uint32_t *)addr |= ((offset & 0xf000) << 4) | (offset & 0x0fff);
+	}
+	break;
+
+	case R_ARM_THM_MOVW_ABS_NC:
+	case R_ARM_THM_MOVT_ABS: {
+		/* Thumb BL and B.W instructions. Encoding:
+		 *
+		 * upper_insn:
+		 *
+		 *  1   1   1   1   1   1
+		 *  5   4   3   2   1   0   9   8   7   6   5   4   3   2   1   0
+		 * +----------+---+-------------------------------+--------------+
+		 * |1   1   1 |OP1|     OP2                       |              | 32-Bit Instructions
+		 * +----------+---+--+-----+----------------------+--------------+
+		 * |1   1   1 | 1   0|  i  | 1  0   1   1   0   0 |    imm4      | MOVT Instruction
+		 * +----------+------+-----+----------------------+--------------+
+		 *
+		 * lower_insn:
+		 *
+		 *  1   1   1   1   1   1
+		 *  5   4   3   2   1   0   9   8   7   6   5   4   3   2   1   0
+		 * +---+---------------------------------------------------------+
+		 * |OP |                                                         | 32-Bit Instructions
+		 * +---+----------+--------------+-------------------------------+
+		 * |0  |   imm3   |      Rd      |            imm8               | MOVT Instruction
+		 * +---+----------+--------------+-------------------------------+
+		 *
+		 * The 16-bit immediate value is encoded in these bits:
+		 *
+		 *   i    = imm16[11]    = upper_insn[10]
+		 *   imm4 = imm16[12:15] = upper_insn[3:0]
+		 *   imm3 = imm16[8:10]  = lower_insn[14:12]
+		 *   imm8 = imm16[0:7]   = lower_insn[7:0]
+		 */
+
+		upper_insn = (uint32_t)(*(uint16_t *)addr);
+		lower_insn = (uint32_t)(*(uint16_t *)(addr + 2));
+
+		binfo("Performing THM_MOVx [%d] link at addr=%08lx [%04x %04x] to sym=%p st_value=%08lx\n", ELF32_R_TYPE(rel->r_info), (long)addr, (int)upper_insn, (int)lower_insn, sym, (long)sym->st_value);
+
+		/* Extract the 16-bit offset from the 32-bit instruction */
+
+		offset = ((upper_insn & 0x000f) << 12) |	/* imm4 -> imm16[8:10] */
+				 ((upper_insn & 0x0400) << 1) |	/* i    -> imm16[11] */
+				 ((lower_insn & 0x7000) >> 4) |	/* imm3 -> imm16[8:10] */
+				 (lower_insn & 0x00ff);	/* imm8 -> imm16[0:7] */
+
+		/* And perform the relocation */
+
+		binfo("  offset=%08lx branch target=%08lx\n", (long)offset, offset + sym->st_value);
+
+		offset += sym->st_value;
+
+		/* Update the immediate value in the instruction.  For MOVW we want the bottom
+		 * 16-bits; for MOVT we want the top 16-bits.
+		 */
+
+		if (ELF32_R_TYPE(rel->r_info) == R_ARM_THM_MOVT_ABS) {
+			offset >>= 16;
+		}
+
+		upper_insn = ((upper_insn & 0xfbf0) | ((offset & 0xf000) >> 12) | ((offset & 0x0800) >> 1));
+		*(uint16_t *)addr = (uint16_t)upper_insn;
+
+		lower_insn = ((lower_insn & 0x8f00) | ((offset & 0x0700) << 4) | (offset & 0x00ff));
+		*(uint16_t *)(addr + 2) = (uint16_t)lower_insn;
+
+		binfo("  insn [%04x %04x]\n", (int)upper_insn, (int)lower_insn);
+	}
+	break;
+
+	case R_ARM_THM_JUMP11: {
+		offset = (uint32_t)(*(uint16_t *)addr & 0x7ff) << 1;
+		if (offset & 0x0800) {
+			offset -= 0x1000;
+		}
+
+		offset += sym->st_value - addr;
+
+		if (ELF32_ST_TYPE(sym->st_info) == STT_FUNC && (offset & 1) == 0) {
+			berr("ERROR: JUMP11 [%d] requires odd offset, offset=%08lx\n", ELF32_R_TYPE(rel->r_info), offset);
+
+			return -EINVAL;
+		}
+
+		/* Check the range of the offset */
+
+		if (offset < (int32_t)0xfffff800 || offset >= (int32_t)0x0800) {
+			berr("ERROR: JUMP11 [%d] relocation out of range, branch taget=%08lx\n", ELF32_R_TYPE(rel->r_info), offset);
+
+			return -EINVAL;
+		}
+
+		offset >>= 1;
+
+		*(uint16_t *)addr &= 0xf800;
+		*(uint16_t *)addr |= offset & 0x7ff;
+	}
+	break;
+
+	default:
+		berr("ERROR: Unsupported relocation: %d\n", ELF32_R_TYPE(rel->r_info));
+		return -EINVAL;
+	}
+
+	return OK;
+}
+
+int up_relocateadd(FAR const Elf32_Rela *rel, FAR const Elf32_Sym *sym, uintptr_t addr)
+{
+	berr("ERROR: RELA relocation not supported\n");
+	return -ENOSYS;
+}

--- a/lib/libc/machine/arm/armv7-r/Make.defs
+++ b/lib/libc/machine/arm/armv7-r/Make.defs
@@ -1,0 +1,60 @@
+###########################################################################
+#
+# Copyright 2019 Samsung Electronics All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+#
+###########################################################################
+############################################################################
+# lib/libc/machine/arm/armv7-r/Make.defs
+#
+#   Copyright (C) 2017 Gregory Nutt. All rights reserved.
+#   Author: Gregory Nutt <gnutt@nuttx.org>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in
+#    the documentation and/or other materials provided with the
+#    distribution.
+# 3. Neither the name NuttX nor the names of its contributors may be
+#    used to endorse or promote products derived from this software
+#    without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+# OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+# AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+############################################################################
+
+ifeq ($(CONFIG_LIBC_ARCH_ELF),y)
+
+CSRCS += arch_elf.c
+
+DEPPATH += --dep-path machine/arm/armv7-r
+VPATH += :machine/arm/armv7-r
+
+endif

--- a/lib/libc/machine/arm/armv7-r/arch_elf.c
+++ b/lib/libc/machine/arm/armv7-r/arch_elf.c
@@ -1,0 +1,263 @@
+/****************************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+/****************************************************************************
+ * lib/libc/machine/arm/armv7-r/arm_elf.c
+ *
+ *   Copyright (C) 2015, 2017 Gregory Nutt. All rights reserved.
+ *   Author: Gregory Nutt <gnutt@nuttx.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <tinyara/config.h>
+
+#include <stdlib.h>
+#include <errno.h>
+#include <debug.h>
+
+#include <arch/elf.h>
+#include <tinyara/elf.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: up_checkarch
+ *
+ * Description:
+ *   Given the ELF header in 'hdr', verify that the ELF file is appropriate
+ *   for the current, configured architecture.  Every architecture that uses
+ *   the ELF loader must provide this function.
+ *
+ * Input Parameters:
+ *   hdr - The ELF header read from the ELF file.
+ *
+ * Returned Value:
+ *   True if the architecture supports this ELF file.
+ *
+ ****************************************************************************/
+
+bool up_checkarch(FAR const Elf32_Ehdr *ehdr)
+{
+	/* Make sure it's an ARM executable */
+
+	if (ehdr->e_machine != EM_ARM) {
+		berr("ERROR: Not for ARM: e_machine=%04x\n", ehdr->e_machine);
+		return false;
+	}
+
+	/* Make sure that 32-bit objects are supported */
+
+	if (ehdr->e_ident[EI_CLASS] != ELFCLASS32) {
+		berr("ERROR: Need 32-bit objects: e_ident[EI_CLASS]=%02x\n", ehdr->e_ident[EI_CLASS]);
+		return false;
+	}
+
+	/* Verify endian-ness */
+
+#ifdef CONFIG_ENDIAN_BIG
+	if (ehdr->e_ident[EI_DATA] != ELFDATA2MSB)
+#else
+	if (ehdr->e_ident[EI_DATA] != ELFDATA2LSB)
+#endif
+	{
+		berr("ERROR: Wrong endian-ness: e_ident[EI_DATA]=%02x\n", ehdr->e_ident[EI_DATA]);
+		return false;
+	}
+
+	/* Make sure the entry point address is properly aligned */
+
+	if ((ehdr->e_entry & 3) != 0) {
+		berr("ERROR: Entry point is not properly aligned: %08x\n", ehdr->e_entry);
+		return false;
+	}
+
+	/* TODO:  Check ABI here. */
+	return true;
+}
+
+/****************************************************************************
+ * Name: up_relocate and up_relocateadd
+ *
+ * Description:
+ *   Perform on architecture-specific ELF relocation.  Every architecture
+ *   that uses the ELF loader must provide this function.
+ *
+ * Input Parameters:
+ *   rel - The relocation type
+ *   sym - The ELF symbol structure containing the fully resolved value.
+ *         There are a few relocation types for a few architectures that do
+ *         not require symbol information.  For those, this value will be
+ *         NULL.  Implementations of these functions must be able to handle
+ *         that case.
+ *   addr - The address that requires the relocation.
+ *
+ * Returned Value:
+ *   Zero (OK) if the relocation was successful.  Otherwise, a negated errno
+ *   value indicating the cause of the relocation failure.
+ *
+ ****************************************************************************/
+
+int up_relocate(FAR const Elf32_Rel *rel, FAR const Elf32_Sym *sym, uintptr_t addr)
+{
+	int32_t offset;
+	unsigned int relotype;
+
+	/* All relocations except R_ARM_V4BX depend upon having valid symbol
+	 * information.
+	 */
+
+	relotype = ELF32_R_TYPE(rel->r_info);
+	if (sym == NULL && relotype != R_ARM_NONE && relotype != R_ARM_V4BX) {
+		return -EINVAL;
+	}
+
+	/* Handle the relocation by relocation type */
+
+	switch (relotype) {
+	case R_ARM_NONE: {
+		/* No relocation */
+	}
+	break;
+
+	case R_ARM_PC24:
+	case R_ARM_CALL:
+	case R_ARM_JUMP24: {
+		binfo("Performing PC24 [%d] link at addr %08lx [%08lx] to sym '%p' st_value=%08lx\n", ELF32_R_TYPE(rel->r_info), (long)addr, (long)(*(uint32_t *)addr), sym, (long)sym->st_value);
+
+		offset = (*(uint32_t *)addr & 0x00ffffff) << 2;
+		if (offset & 0x02000000) {
+			offset -= 0x04000000;
+		}
+
+		offset += sym->st_value - addr;
+		if (offset & 3 || offset < (int32_t)0xfe000000 || offset >= (int32_t)0x02000000) {
+			berr("ERROR:   ERROR: PC24 [%d] relocation out of range, offset=%08lx\n", ELF32_R_TYPE(rel->r_info), offset);
+
+			return -EINVAL;
+		}
+
+		offset >>= 2;
+
+		*(uint32_t *)addr &= 0xff000000;
+		*(uint32_t *)addr |= offset & 0x00ffffff;
+	}
+	break;
+
+	case R_ARM_ABS32:
+	case R_ARM_TARGET1: {	/* New ABI:  TARGET1 always treated as ABS32 */
+		binfo("Performing ABS32 link at addr=%08lx [%08lx] to sym=%p st_value=%08lx\n", (long)addr, (long)(*(uint32_t *)addr), sym, (long)sym->st_value);
+
+		*(uint32_t *)addr += sym->st_value;
+	}
+	break;
+
+	case R_ARM_V4BX: {
+		binfo("Performing V4BX link at addr=%08lx [%08lx]\n", (long)addr, (long)(*(uint32_t *)addr));
+
+		/* Preserve only Rm and the condition code */
+
+		*(uint32_t *)addr &= 0xf000000f;
+
+		/* Change instruction to 'mov pc, Rm' */
+
+		*(uint32_t *)addr |= 0x01a0f000;
+	}
+	break;
+
+	case R_ARM_PREL31: {
+		binfo("Performing PREL31 link at addr=%08lx [%08lx] to sym=%p st_value=%08lx\n", (long)addr, (long)(*(uint32_t *)addr), sym, (long)sym->st_value);
+
+		offset = *(uint32_t *)addr + sym->st_value - addr;
+		*(uint32_t *)addr = offset & 0x7fffffff;
+	}
+	break;
+
+	case R_ARM_MOVW_ABS_NC:
+	case R_ARM_MOVT_ABS: {
+		binfo("Performing MOVx_ABS [%d] link at addr=%08lx [%08lx] to sym=%p st_value=%08lx\n", ELF32_R_TYPE(rel->r_info), (long)addr, (long)(*(uint32_t *)addr), sym, (long)sym->st_value);
+
+		offset = *(uint32_t *)addr;
+		offset = ((offset & 0xf0000) >> 4) | (offset & 0xfff);
+
+		offset += sym->st_value;
+		if (ELF32_R_TYPE(rel->r_info) == R_ARM_MOVT_ABS) {
+			offset >>= 16;
+		}
+
+		*(uint32_t *)addr &= 0xfff0f000;
+		*(uint32_t *)addr |= ((offset & 0xf000) << 4) | (offset & 0x0fff);
+	}
+	break;
+
+	default:
+		berr("ERROR: Unsupported relocation: %d\n", ELF32_R_TYPE(rel->r_info));
+		return -EINVAL;
+	}
+
+	return OK;
+}
+
+int up_relocateadd(FAR const Elf32_Rela *rel, FAR const Elf32_Sym *sym, uintptr_t addr)
+{
+	berr("ERROR: RELA relocation not supported\n");
+	return -ENOSYS;
+}

--- a/lib/libc/misc/Make.defs
+++ b/lib/libc/misc/Make.defs
@@ -92,6 +92,12 @@ ifeq ($(CONFIG_DEBUG),y)
 CSRCS += lib_dbg.c
 endif
 
+# Environment search path support
+
+ifeq ($(CONFIG_LIB_ENVPATH),y)
+CSRCS += lib_envpath.c
+endif
+
 # Add the misc directory to the build
 
 DEPPATH += --dep-path misc

--- a/lib/libc/misc/lib_envpath.c
+++ b/lib/libc/misc/lib_envpath.c
@@ -1,0 +1,287 @@
+/****************************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+/****************************************************************************
+ * lib/libc/misc/lib_envpath.c
+ *
+ *   Copyright (C) 2012, 2018 Gregory Nutt. All rights reserved.
+ *   Author: Gregory Nutt <gnutt@nuttx.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <tinyara/config.h>
+
+#include <sys/types.h>
+#include <sys/stat.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <assert.h>
+
+#include <tinyara/envpath.h>
+
+#include "libc.h"
+
+#if defined(CONFIG_LIB_ENVPATH)
+
+/****************************************************************************
+ * Private Types
+ ****************************************************************************/
+
+struct envpath_s {
+	FAR char *next;				/* Pointer to the next (unterminated) value in the PATH variable */
+	char path[1];
+};
+
+#define SIZEOF_ENVPATH_S(n) (sizeof(struct envpath_s) + (n) - 1)
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: envpath_init
+ *
+ * Description:
+ *   Initialize for the traversal of each value in the PATH variable.  The
+ *   usage is sequence is as follows:
+ *
+ *   1) Call envpath_init() to initialize for the traversal.  envpath_init()
+ *      will return an opaque handle that can then be provided to
+ *      envpath_next() and envpath_release().
+ *   2) Call envpath_next() repeatedly to examine every file that lies
+ *      in the directories of the PATH variable
+ *   3) Call envpath_release() to free resources set aside by envpath_init().
+ *
+ * Input Parameters:
+ *   None
+ *
+ * Returned Value:
+ *   On success, envpath_init() return a non-NULL, opaque handle that may
+ *   subsequently be used in calls to envpath_next() and envpath_release().
+ *   On error, a NULL handle value will be returned.  The most likely cause
+ *   of an error would be that there is no value associated with the PATH
+ *   variable.
+ *
+ ****************************************************************************/
+
+ENVPATH_HANDLE envpath_init(FAR const char *name)
+{
+	FAR struct envpath_s *envpath;
+	FAR char *path;
+
+	/* Get the value of the PATH variable */
+
+	path = getenv(name);
+	if (!path) {
+		/* getenv() will return a NULL value if the PATH variable does not
+		 * exist in the environment.
+		 */
+		printf("%s variable does not exist in the environment\n", name);
+		return (ENVPATH_HANDLE) NULL;
+	}
+
+	/* Allocate a container for the PATH variable contents */
+
+	envpath = (FAR struct envpath_s *)
+			  lib_malloc(SIZEOF_ENVPATH_S(strlen(path) + 1));
+
+	if (!envpath) {
+		/* Ooops.. we are out of memory */
+
+		printf("Allocate a container failed\n");
+		return (ENVPATH_HANDLE) NULL;
+	}
+
+	/* Populate the container */
+
+	strcpy(envpath->path, path);
+	envpath->next = envpath->path;
+
+	/* And return the containing cast to an opaque handle */
+
+	return (ENVPATH_HANDLE) envpath;
+}
+
+/****************************************************************************
+ * Name: envpath_next
+ *
+ * Description:
+ *   Traverse all possible values in the PATH variable in attempt to find
+ *   the full path to an envcutable file when only a relative path is
+ *   provided.
+ *
+ * Input Parameters:
+ *   handle - The handle value returned by envpath_init
+ *   relpath - The relative path to the file to be found.
+ *
+ * Returned Value:
+ *   On success, a non-NULL pointer to a null-terminated string is provided.
+ *   This is the full path to a file that exists in the file system.  This
+ *   function will verify that the file exists (but will not verify that it
+ *   is marked envcutable).
+ *
+ *   NOTE: The string pointer return in the success case points to allocated
+ *   memory.  This memory must be freed by the called by calling lib_free().
+ *
+ *   NULL is returned if no path is found to any file with the provided
+ *   'relpath' from any absolute path in the PATH variable.  In this case,
+ *   there is no point in calling envpath_next() further; envpath_release()
+ *   must be called to release resources set aside by expath_init().
+ *
+ ****************************************************************************/
+
+FAR char *envpath_next(ENVPATH_HANDLE handle, FAR const char *relpath)
+{
+	FAR struct envpath_s *envpath = (FAR struct envpath_s *)handle;
+	struct stat buf;
+	FAR char *endptr;
+	FAR char *path;
+	FAR char *fullpath;
+	int pathlen;
+	int ret;
+
+	/* Verify that a value handle and relative path were provided */
+
+	DEBUGASSERT(envpath && relpath);
+	DEBUGASSERT(relpath[0] != '\0' && relpath[0] != '/');
+
+	/* Loop until (1) we find a file with this relative path from one of the
+	 * absolute paths in the PATH variable, or (2) all of the absolute paths
+	 * in the PATH variable have been considered.
+	 */
+
+	for (;;) {
+		/* Make sure that envpath->next points to the beginning of a string */
+
+		path = envpath->next;
+		if (*path == '\0') {
+			/* If it points to a NULL it means that either (1) the PATH varialbe
+			 * is empty, or (2) we have already examined all of the paths in the
+			 * path variable.
+			 */
+
+			printf("PATH variable is empty or all of the paths are examined\n");
+			return (FAR char *)NULL;
+		}
+
+		/* Okay... 'path' points to the beginning of the string.  The string may
+		 * be termined either with (1) ':' which separates the path from the
+		 * next path in the list, or (2) NUL which marks the end of the list.
+		 */
+
+		endptr = strchr(path, ':');
+		if (endptr == NULL) {
+			/* If strchr returns NUL it means that ':' does not appear in the
+			 * string.  Therefore, this must be the final path in the PATH
+			 * variable content.
+			 */
+
+			endptr = &path[strlen(path)];
+			envpath->next = endptr;
+			DEBUGASSERT(*endptr == '\0');
+		} else {
+			DEBUGASSERT(*endptr == ':');
+			envpath->next = endptr + 1;
+			*endptr = '\0';
+		}
+
+		pathlen = strlen(path) + strlen(relpath) + 2;
+		fullpath = (FAR char *)lib_malloc(pathlen);
+		if (fullpath == NULL) {
+			/* Failed to allocate memory */
+
+			printf("Failed to allocate memory\n");
+			return (FAR char *)NULL;
+		}
+
+		/* Construct the full path */
+
+		sprintf(fullpath, "%s/%s", path, relpath);
+
+		/* Verify that a regular file exists at this path */
+
+		ret = stat(fullpath, &buf);
+		if (ret == OK && S_ISREG(buf.st_mode)) {
+			return fullpath;
+		}
+
+		/* Failed to stat the file.  Just free the allocated memory and
+		 * continue to try the next path.
+		 */
+
+		lib_free(fullpath);
+	}
+
+	/* We will not get here */
+}
+
+/****************************************************************************
+ * Name: envpath_release
+ *
+ * Description:
+ *   Release all resources set aside by envpath_init() when the handle value
+ *   was created.  The handle value is invalid on return from this function.
+ *   Attempts to all envpath_next() or envpath_release() with such a 'stale'
+ *   handle will result in undefined (i.e., not good) behavior.
+ *
+ * Input Parameters:
+ *   handle - The handle value returned by envpath_init
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+void envpath_release(ENVPATH_HANDLE handle)
+{
+	lib_free(handle);
+}
+
+#endif							/* CONFIG_LIBC_ENVPATH */

--- a/lib/libc/symtab/Make.defs
+++ b/lib/libc/symtab/Make.defs
@@ -1,0 +1,61 @@
+###########################################################################
+#
+# Copyright 2019 Samsung Electronics All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+#
+###########################################################################
+############################################################################
+# libc/symtab/Make.defs
+#
+#   Copyright (C) 2015 Gregory Nutt. All rights reserved.
+#   Author: Gregory Nutt <gnutt@nuttx.org>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in
+#    the documentation and/or other materials provided with the
+#    distribution.
+# 3. Neither the name NuttX nor the names of its contributors may be
+#    used to endorse or promote products derived from this software
+#    without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+# OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+# AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+############################################################################
+
+# Symbol table source files
+
+CSRCS += symtab_findbyname.c symtab_findbyvalue.c
+CSRCS += symtab_findorderedbyname.c symtab_sortbyname.c
+
+# Add the symtab directory to the build
+
+DEPPATH += --dep-path symtab
+VPATH += :symtab

--- a/lib/libc/symtab/symtab_findbyname.c
+++ b/lib/libc/symtab/symtab_findbyname.c
@@ -1,0 +1,95 @@
+/****************************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+/****************************************************************************
+ * lib/libc/symtab/symtab_findbyname.c
+ *
+ *   Copyright (C) 2009, 2015 Gregory Nutt. All rights reserved.
+ *   Author: Gregory Nutt <gnutt@nuttx.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <tinyara/config.h>
+
+#include <string.h>
+#include <debug.h>
+#include <assert.h>
+#include <errno.h>
+
+#include <tinyara/symtab.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: symtab_findbyname
+ *
+ * Description:
+ *   Find the symbol in the symbol table with the matching name.
+ *   This version assumes that table is not ordered with respect to symbol
+ *   name and, hence, access time will be linear with respect to nsyms.
+ *
+ * Returned Value:
+ *   A reference to the symbol table entry if an entry with the matching
+ *   name is found; NULL is returned if the entry is not found.
+ *
+ ****************************************************************************/
+
+FAR const struct symtab_s *symtab_findbyname(FAR const struct symtab_s *symtab, FAR const char *name, int nsyms)
+{
+	DEBUGASSERT(name != NULL);
+	for (; nsyms > 0; symtab++, nsyms--) {
+		DEBUGASSERT(symtab != NULL);
+
+		if (strcmp(name, symtab->sym_name) == 0) {
+			return symtab;
+		}
+	}
+	return NULL;
+}

--- a/lib/libc/symtab/symtab_findbyvalue.c
+++ b/lib/libc/symtab/symtab_findbyvalue.c
@@ -1,0 +1,116 @@
+/****************************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+/****************************************************************************
+ * libc/symtab/symtab_findbyvalue.c
+ *
+ *   Copyright (C) 2009, 2015 Gregory Nutt. All rights reserved.
+ *   Author: Gregory Nutt <gnutt@nuttx.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <tinyara/config.h>
+
+#include <stddef.h>
+#include <debug.h>
+#include <assert.h>
+#include <errno.h>
+
+#include <tinyara/symtab.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: symtab_findbyvalue
+ *
+ * Description:
+ *   Find the symbol in the symbol table whose value closest (but not greater
+ *   than), the provided value. This version assumes that table is not ordered
+ *   with respect to symbol name and, hence, access time will be linear with
+ *   respect to nsyms.
+ *
+ * Returned Value:
+ *   A reference to the symbol table entry if an entry with the matching
+ *   name is found; NULL is returned if the entry is not found.
+ *
+ ****************************************************************************/
+
+FAR const struct symtab_s *symtab_findbyvalue(FAR const struct symtab_s *symtab, FAR void *value, int nsyms)
+{
+	FAR const struct symtab_s *retval = NULL;
+
+	for (; nsyms > 0; symtab++, nsyms--) {
+		DEBUGASSERT(symtab != NULL);
+
+		/* Look for symbols of lesser or equal value (probably address) to value */
+
+		if (symtab->sym_value <= value) {
+			/* Found one.  Is it the largest we have found so far? */
+
+			if (!retval || symtab->sym_value > retval->sym_value) {
+				/* Yes, then it is the new candidate for the symbol whose value
+				 * just below 'value'
+				 */
+
+				retval = symtab;
+
+				/* If it is exactly equal to the search 'value', then we might as
+				 * well terminate early because we can't do any better than that.
+				 */
+
+				if (retval->sym_value == value) {
+					break;
+				}
+			}
+		}
+	}
+
+	return retval;
+}

--- a/lib/libc/symtab/symtab_findorderedbyname.c
+++ b/lib/libc/symtab/symtab_findorderedbyname.c
@@ -1,0 +1,134 @@
+/****************************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+/****************************************************************************
+ * libc/symtab/symtab_findorderedbyname.c
+ *
+ *   Copyright (C) 2009, 2014-2015 Gregory Nutt. All rights reserved.
+ *   Author: Gregory Nutt <gnutt@nuttx.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <tinyara/config.h>
+
+#include <string.h>
+#include <debug.h>
+#include <assert.h>
+#include <errno.h>
+
+#include <tinyara/symtab.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: symtab_findorderedbyname
+ *
+ * Description:
+ *   Find the symbol in the symbol table with the matching name.
+ *   This version assumes that table ordered with respect to symbol name.
+ *
+ *   This function is a lot larger than symbtab_findbyname().  This function
+ *   not be used, unless the symbol table is large and the performance
+ *   benefit is worth the increased size.
+ *
+ * Returned Value:
+ *   A reference to the symbol table entry if an entry with the matching
+ *   name is found; NULL is returned if the entry is not found.
+ *
+ ****************************************************************************/
+
+FAR const struct symtab_s *symtab_findorderedbyname(FAR const struct symtab_s *symtab, FAR const char *name, int nsyms)
+{
+	int low = 0;
+	int high = nsyms - 1;
+	int mid;
+	int cmp;
+
+	/* Loop until the range has been isolated to a single symbol table
+	 * entry that may or may not match the search name.
+	 */
+
+	DEBUGASSERT(symtab != NULL && name != NULL);
+	while (low < high) {
+		/* Compare the name to the one in the middle.  (or just below
+		 * the middle in the case where one is even and one is odd).
+		 */
+
+		mid = (low + high) >> 1;
+		cmp = strcmp(name, symtab[mid].sym_name);
+		if (cmp < 0) {
+			/* name < symtab[mid].sym_name
+			 *
+			 * NOTE: Because of truncation in the calculation of 'mid'.
+			 * 'mid' could be equal to 'low'
+			 */
+
+			high = mid > low ? mid - 1 : low;
+		} else if (cmp > 0) {
+			/* name > symtab[mid].sym_name */
+
+			low = mid + 1;
+		} else {
+			/* symtab[mid].sym_name == name */
+
+			return &symtab[mid];
+		}
+	}
+
+	/* low == high... One final check.  We might not have actually tested
+	 * the final symtab[] name.
+	 *
+	 *   Example: Only the last pass through loop, suppose low = 1, high = 2,
+	 *   mid = 1, and symtab[high].sym_name == name.  Then we would get here with
+	 *   low = 2, high = 2, but symtab[2].sym_name was never tested.
+	 */
+
+	return strcmp(name, symtab[low].sym_name) == 0 ? &symtab[low] : NULL;
+}

--- a/lib/libc/symtab/symtab_sortbyname.c
+++ b/lib/libc/symtab/symtab_sortbyname.c
@@ -1,0 +1,96 @@
+/****************************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+/****************************************************************************
+ * lib/libc/symtab/symtab_sortbyname.c
+ *
+ *   Copyright (C) 2019 Pinecone Inc. All rights reserved.
+ *   Author: Xiang Xiao <xiaoxiang@pinecone.net>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <tinyara/config.h>
+
+#include <stdlib.h>
+#include <string.h>
+#include <assert.h>
+
+#include <tinyara/symtab.h>
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+static int symtab_comparename(FAR const void *arg1, FAR const void *arg2)
+{
+	FAR const struct symtab_s *symtab1 = arg1;
+	FAR const struct symtab_s *symtab2 = arg2;
+
+	return strcmp(symtab1->sym_name, symtab2->sym_name);
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: symtab_sortbyname
+ *
+ * Description:
+ *   Sort the symbol table by name.
+ *
+ * Returned Value:
+ *   None.
+ *
+ ****************************************************************************/
+
+void symtab_sortbyname(FAR struct symtab_s *symtab, int nsyms)
+{
+	DEBUGASSERT(symtab != NULL && nsyms != 0);
+	qsort(symtab, nsyms, sizeof(symtab[0]), symtab_comparename);
+}

--- a/os/Directories.mk
+++ b/os/Directories.mk
@@ -142,6 +142,9 @@ endif
 
 NONFSDIRS = kernel $(ARCH_SRC) $(TINYARA_ADDONS)
 FSDIRS = fs drivers
+ifneq ($(CONFIG_BINFMT_DISABLE),y)
+FSDIRS += binfmt
+endif
 CONTEXTDIRS = $(APPDIR)
 CONTEXTDIRS += $(TOOLSDIR)
 CONTEXTDIRS += mm

--- a/os/FlatLibs.mk
+++ b/os/FlatLibs.mk
@@ -124,6 +124,10 @@ else
 TINYARALIBS += $(LIBRARIES_DIR)$(DELIM)libfs$(LIBEXT) $(LIBRARIES_DIR)$(DELIM)libdrivers$(LIBEXT)
 endif
 
+ifneq ($(CONFIG_BINFMT_DISABLE),y)
+TINYARALIBS += $(LIBRARIES_DIR)$(DELIM)libbinfmt$(LIBEXT)
+endif
+
 # Add libraries for the Audio sub-system
 
 ifeq ($(CONFIG_AUDIO),y)

--- a/os/Kconfig
+++ b/os/Kconfig
@@ -488,7 +488,6 @@ source Kconfig.debug
 endmenu
 
 menu "System Call"
-	depends on BUILD_PROTECTED
 source syscall/Kconfig
 endmenu
 
@@ -499,6 +498,10 @@ endmenu
 
 menu "External Libraries"
 source "$EXTERNALDIR/Kconfig"
+endmenu
+
+menu "Binary Loader"
+source binfmt/Kconfig
 endmenu
 
 menu "Application Configuration"

--- a/os/Kconfig.debug
+++ b/os/Kconfig.debug
@@ -77,6 +77,38 @@ config DEBUG_AUDIO_INFO
 
 endif #DEBUG_AUDIO
 
+config DEBUG_BINFMT
+        bool "Binary Loader Debug Features"
+        default n
+        depends on !BINFMT_DISABLE
+        ---help---
+                Enable binary loader debug features.
+
+if DEBUG_BINFMT
+
+config DEBUG_BINFMT_ERROR
+        bool "Binary Loader Error Output"
+        default n
+        depends on DEBUG_ERROR
+        ---help---
+                Enable binary loader error output to SYSLOG.
+
+config DEBUG_BINFMT_WARN
+        bool "Binary Loader Warnings Output"
+        default n
+        depends on DEBUG_WARN
+        ---help---
+                Enable binary loader warning output to SYSLOG.
+
+config DEBUG_BINFMT_INFO
+        bool "Binary Loader Informational Output"
+        default n
+        depends on DEBUG_VERBOSE
+        ---help---
+                Enable binary loader informational output to SYSLOG.
+
+endif # DEBUG_BINFMT
+
 config DEBUG_LIB
 	bool "C Library Debug Output"
 	default n

--- a/os/KernelLibs.mk
+++ b/os/KernelLibs.mk
@@ -119,6 +119,10 @@ else
 TINYARALIBS += $(LIBRARIES_DIR)$(DELIM)libfs$(LIBEXT) $(LIBRARIES_DIR)$(DELIM)libdrivers$(LIBEXT)
 endif
 
+ifneq ($(CONFIG_BINFMT_DISABLE),y)
+TINYARALIBS += $(LIBRARIES_DIR)$(DELIM)libbinfmt$(LIBEXT)
+endif
+
 # Add library for wifi driver
 TINYARALIBS += $(LIBRARIES_DIR)$(DELIM)libwifidriver$(LIBEXT)
 # Add library for wifi stack

--- a/os/LibTargets.mk
+++ b/os/LibTargets.mk
@@ -123,6 +123,14 @@ drivers$(DELIM)libdrivers$(LIBEXT): context
 $(LIBRARIES_DIR)$(DELIM)libdrivers$(LIBEXT): drivers$(DELIM)libdrivers$(LIBEXT)
 	$(Q) install drivers$(DELIM)libdrivers$(LIBEXT) $(LIBRARIES_DIR)$(DELIM)libdrivers$(LIBEXT)
 
+ifneq ($(CONFIG_BINFMT_DISABLE),y)
+binfmt$(DELIM)libbinfmt$(LIBEXT): context
+	$(Q) $(MAKE) -C binfmt TOPDIR="$(TOPDIR)" libbinfmt$(LIBEXT) KERNEL=y EXTRADEFINES=$(KDEFINE)
+
+$(LIBRARIES_DIR)$(DELIM)libbinfmt$(LIBEXT): binfmt$(DELIM)libbinfmt$(LIBEXT)
+	$(Q) install binfmt$(DELIM)libbinfmt$(LIBEXT) $(LIBRARIES_DIR)$(DELIM)libbinfmt$(LIBEXT)
+endif
+
 # Special case
 
 syscall$(DELIM)libstubs$(LIBEXT): context

--- a/os/ProtectedLibs.mk
+++ b/os/ProtectedLibs.mk
@@ -130,6 +130,10 @@ else
 TINYARALIBS += $(LIBRARIES_DIR)$(DELIM)libfs$(LIBEXT) $(LIBRARIES_DIR)$(DELIM)libdrivers$(LIBEXT)
 endif
 
+ifneq ($(CONFIG_BINFMT_DISABLE),y)
+TINYARALIBS += $(LIBRARIES_DIR)$(DELIM)libbinfmt$(LIBEXT)
+endif
+
 # Add libraries for iotjs support
 
 ifeq ($(CONFIG_ENABLE_IOTJS),y)

--- a/os/arch/arm/include/elf.h
+++ b/os/arch/arm/include/elf.h
@@ -1,0 +1,260 @@
+/****************************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+/****************************************************************************
+ * arch/arm/include/elf.h
+ *
+ *   Copyright (C) 2012 Gregory Nutt. All rights reserved.
+ *   Author: Gregory Nutt <gnutt@nuttx.org>
+ *
+ * Reference: "ELF for the ARM® Architecture," ARM IHI 0044D, current through
+ *   ABI release 2.08, October 28, 2009, ARM Limited.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#ifndef __ARCH_ARM_INCLUDE_ELF_H
+#define __ARCH_ARM_INCLUDE_ELF_H
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/* 4.3.1 ELF Identification.  Should have:
+ *
+ * e_machine         = EM_ARM
+ * e_ident[EI_CLASS] = ELFCLASS32
+ * e_ident[EI_DATA]  = ELFDATA2LSB (little endian) or ELFDATA2MSB (big endian)
+ */
+
+#if 0 /* Defined in include/elf32.h */
+#define EM_ARM                   40
+#endif
+
+/* Table 4-2, ARM-specific e_flags */
+
+#define EF_ARM_EABI_MASK         0xff000000
+#define EF_ARM_EABI_UNKNOWN      0x00000000
+#define EF_ARM_EABI_VER1         0x01000000
+#define EF_ARM_EABI_VER2         0x02000000
+#define EF_ARM_EABI_VER3         0x03000000
+#define EF_ARM_EABI_VER4         0x04000000
+#define EF_ARM_EABI_VER5         0x05000000
+
+#define EF_ARM_BE8               0x00800000
+
+/* Table 4-4, Processor specific section types */
+
+#define SHT_ARM_EXIDX            0x70000001 /* Exception Index table */
+#define SHT_ARM_PREEMPTMAP       0x70000002 /* BPABI DLL dynamic linking pre-emption map */
+#define SHT_ARM_ATTRIBUTES       0x70000003 /* Object file compatibility attributes */
+#define SHT_ARM_DEBUGOVERLAY     0x70000004
+#define SHT_ARM_OVERLAYSECTION   0x70000005
+
+/* 4.7.1 Relocation codes
+ *
+ * S (when used on its own) is the address of the symbol.
+ * A is the addend for the relocation.
+ * P is the address of the place being relocated (derived from r_offset).
+ * Pa is the adjusted address of the place being relocated, defined as (P & 0xFFFFFFFC).
+ * T is 1 if the target symbol S has type STT_FUNC and the symbol addresses a Thumb instruction;
+ *   it is 0 otherwise.
+ * B(S) is the addressing origin of the output segment defining the symbol S.
+ * GOT_ORG is the addressing origin of the Global Offset Table
+ * GOT(S) is the address of the GOT entry for the symbol S.
+ */
+
+#define R_ARM_NONE               0             /* No relocation */
+#define R_ARM_PC24               1             /* ARM       ((S + A) | T) - P */
+#define R_ARM_ABS32              2             /* Data      (S + A) | T */
+#define R_ARM_REL32              3             /* Data      ((S + A) | T) - P */
+#define R_ARM_LDR_PC_G0          4             /* ARM       S + A - P */
+#define R_ARM_ABS16              5             /* Data      S + A */
+#define R_ARM_ABS12              6             /* ARM       S + A */
+#define R_ARM_THM_ABS5           7             /* Thumb16   S + A */
+#define R_ARM_ABS8               8             /* Data      S + A */
+#define R_ARM_SBREL32            9             /* Data      ((S + A) | T) - B(S) */
+#define R_ARM_THM_CALL           10            /* Thumb32   ((S + A) | T) - P */
+#define R_ARM_THM_PC8            11            /* Thumb16   S + A - Pa */
+#define R_ARM_BREL_ADJ           12            /* Data      ?B(S) + A */
+#define R_ARM_TLS_DESC           13            /* Data     */
+#define R_ARM_THM_SWI8           14            /* Obsolete */
+#define R_ARM_XPC25              15            /* Obsolete */
+#define R_ARM_THM_XPC22          16            /* Obsolete */
+#define R_ARM_TLS_DTPMOD32       17            /* Data      Module[S] */
+#define R_ARM_TLS_DTPOFF32       18            /* Data      S + A - TLS */
+#define R_ARM_TLS_TPOFF32        19            /* Data      S + A - tp */
+#define R_ARM_COPY               20            /* Miscellaneous */
+#define R_ARM_GLOB_DAT           21            /* Data      (S + A) | T */
+#define R_ARM_JUMP_SLOT          22            /* Data      (S + A) | T */
+#define R_ARM_RELATIVE           23            /* Data      B(S) + A */
+#define R_ARM_GOTOFF32           24            /* Data      ((S + A) | T) - GOT_ORG */
+#define R_ARM_BASE_PREL          25            /* Data      B(S) + A - P */
+#define R_ARM_GOT_BREL           26            /* Data      GOT(S) + A - GOT_ORG */
+#define R_ARM_PLT32              27            /* ARM       ((S + A) | T) - P */
+#define R_ARM_CALL               28            /* ARM       ((S + A) | T) - P */
+#define R_ARM_JUMP24             29            /* ARM       ((S + A) | T) - P */
+#define R_ARM_THM_JUMP24         30            /* Thumb32   ((S + A) | T) - P */
+#define R_ARM_BASE_ABS           31            /* Data      B(S) + A */
+#define R_ARM_ALU_PCREL_7_0      32            /* Obsolete */
+#define R_ARM_ALU_PCREL_15_8     33            /* Obsolete */
+#define R_ARM_ALU_PCREL_23_15    34            /* Obsolete */
+#define R_ARM_LDR_SBREL_11_0_NC  35            /* ARM       S + A - B(S) */
+#define R_ARM_ALU_SBREL_19_12_NC 36            /* ARM       S + A - B(S) */
+#define R_ARM_ALU_SBREL_27_20_CK 37            /* ARM       S + A - B(S) */
+#define R_ARM_TARGET1            38            /* Miscellaneous (S + A) | T or ((S + A) | T) - P */
+#define R_ARM_SBREL31            39            /* Data      ((S + A) | T) - B(S) */
+#define R_ARM_V4BX               40            /* Miscellaneous */
+#define R_ARM_TARGET2            41            /* Miscellaneous */
+#define R_ARM_PREL31             42            /* Data      ((S + A) | T) - P */
+#define R_ARM_MOVW_ABS_NC        43            /* ARM       (S + A) | T */
+#define R_ARM_MOVT_ABS           44            /* ARM       S + A */
+#define R_ARM_MOVW_PREL_NC       45            /* ARM       ((S + A) | T) - P */
+#define R_ARM_MOVT_PREL          46            /* ARM       S + A - P */
+#define R_ARM_THM_MOVW_ABS_NC    47            /* Thumb32   (S + A) | T */
+#define R_ARM_THM_MOVT_ABS       48            /* Thumb32   S + A */
+#define R_ARM_THM_MOVW_PREL_NC   49            /* Thumb32   ((S + A) | T) - P */
+#define R_ARM_THM_MOVT_PREL      50            /* Thumb32   S + A - P */
+#define R_ARM_THM_JUMP19         51            /* Thumb32   ((S + A) | T) - P */
+#define R_ARM_THM_JUMP6          52            /* Thumb16   S + A - P */
+#define R_ARM_THM_ALU_PREL_11_0  53            /* Thumb32   ((S + A) | T) - Pa */
+#define R_ARM_THM_PC12           54            /* Thumb32   S + A - Pa */
+#define R_ARM_ABS32_NOI          55            /* Data      S + A */
+#define R_ARM_REL32_NOI          56            /* Data      S + A - P */
+#define R_ARM_ALU_PC_G0_NC       57            /* ARM       ((S + A) | T) - P */
+#define R_ARM_ALU_PC_G0          58            /* ARM       ((S + A) | T) - P */
+#define R_ARM_ALU_PC_G1_NC       59            /* ARM       ((S + A) | T) - P */
+#define R_ARM_ALU_PC_G1          60            /* ARM       ((S + A) | T) - P */
+#define R_ARM_ALU_PC_G2          61            /* ARM       ((S + A) | T) - P */
+#define R_ARM_LDR_PC_G1          62            /* ARM       S + A - P */
+#define R_ARM_LDR_PC_G2          63            /* ARM       S + A - P */
+#define R_ARM_LDRS_PC_G0         64            /* ARM       S + A - P */
+#define R_ARM_LDRS_PC_G1         65            /* ARM       S + A - P */
+#define R_ARM_LDRS_PC_G2         66            /* ARM       S + A - P */
+#define R_ARM_LDC_PC_G0          67            /* ARM       S + A - P */
+#define R_ARM_LDC_PC_G1          68            /* ARM       S + A - P */
+#define R_ARM_LDC_PC_G2          69            /* ARM       S + A - P */
+#define R_ARM_ALU_SB_G0_NC       70            /* ARM       ((S + A) | T) - B(S) */
+#define R_ARM_ALU_SB_G0          71            /* ARM       ((S + A) | T) - B(S) */
+#define R_ARM_ALU_SB_G1_NC       72            /* ARM       ((S + A) | T) - B(S) */
+#define R_ARM_ALU_SB_G1          73            /* ARM       ((S + A) | T) - B(S) */
+#define R_ARM_ALU_SB_G2          74            /* ARM       ((S + A) | T) - B(S) */
+#define R_ARM_LDR_SB_G0          75            /* ARM       S + A - B(S) */
+#define R_ARM_LDR_SB_G1          76            /* ARM       S + A - B(S) */
+#define R_ARM_LDR_SB_G2          77            /* ARM       S + A - B(S) */
+#define R_ARM_LDRS_SB_G0         78            /* ARM       S + A - B(S) */
+#define R_ARM_LDRS_SB_G1         79            /* ARM       S + A - B(S) */
+#define R_ARM_LDRS_SB_G2         80            /* ARM       S + A - B(S) */
+#define R_ARM_LDC_SB_G0          81            /* ARM       S + A - B(S) */
+#define R_ARM_LDC_SB_G1          82            /* ARM       S + A - B(S) */
+#define R_ARM_LDC_SB_G2          83            /* ARM       S + A - B(S) */
+#define R_ARM_MOVW_BREL_NC       84            /* ARM       ((S + A) | T) - B(S) */
+#define R_ARM_MOVT_BREL          85            /* ARM       S + A - B(S) */
+#define R_ARM_MOVW_BREL          86            /* ARM       ((S + A) | T) - B(S) */
+#define R_ARM_THM_MOVW_BREL_NC   87            /* Thumb32   ((S + A) | T) - B(S) */
+#define R_ARM_THM_MOVT_BREL      88            /* Thumb32   S + A - B(S) */
+#define R_ARM_THM_MOVW_BREL      89            /* Thumb32   ((S + A) | T) - B(S) */
+#define R_ARM_TLS_GOTDESC        90            /* Data */
+#define R_ARM_TLS_CALL           91            /* ARM */
+#define R_ARM_TLS_DESCSEQ        92            /* ARM       TLS relaxation */
+#define R_ARM_THM_TLS_CALL       93            /* Thumb32 */
+#define R_ARM_PLT32_ABS          94            /* Data      PLT(S) + A */
+#define R_ARM_GOT_ABS            95            /* Data      GOT(S) + A */
+#define R_ARM_GOT_PREL           96            /* Data      GOT(S) + A - P */
+#define R_ARM_GOT_BREL12         97            /* ARM       GOT(S) + A - GOT_ORG */
+#define R_ARM_GOTOFF12           98            /* ARM       S + A - GOT_ORG */
+#define R_ARM_GOTRELAX           99            /* Miscellaneous */
+#define R_ARM_GNU_VTENTRY        100           /* Data */
+#define R_ARM_GNU_VTINHERIT      101           /* Data */
+#define R_ARM_THM_JUMP11         102           /* Thumb16   S + A - P */
+#define R_ARM_THM_JUMP8          103           /* Thumb16   S + A - P */
+#define R_ARM_TLS_GD32           104           /* Data      GOT(S) + A - P */
+#define R_ARM_TLS_LDM32          105           /* Data      GOT(S) + A - P */
+#define R_ARM_TLS_LDO32          106           /* Data      S + A - TLS */
+#define R_ARM_TLS_IE32           107           /* Data      GOT(S) + A - P */
+#define R_ARM_TLS_LE32           108           /* Data      S + A - tp */
+#define R_ARM_TLS_LDO12          109           /* ARM       S + A - TLS */
+#define R_ARM_TLS_LE12           110           /* ARM       S + A - tp */
+#define R_ARM_TLS_IE12GP         111           /* ARM       GOT(S) + A - GOT_ORG */
+#define R_ARM_ME_TOO             128           /* Obsolete */
+#define R_ARM_THM_TLS_DESCSEQ16  129           /* Thumb16 */
+#define R_ARM_THM_TLS_DESCSEQ32  130           /* Thumb32 */
+
+/* 5.2.1 Platform architecture compatibility data */
+
+#define PT_ARM_ARCHEXT_FMTMSK       0xff000000
+#define PT_ARM_ARCHEXT_PROFMSK      0x00ff0000
+#define PT_ARM_ARCHEXT_ARCHMSK      0x000000ff
+
+#define PT_ARM_ARCHEXT_FMT_OS       0x00000000
+#define PT_ARM_ARCHEXT_FMT_ABI      0x01000000
+
+#define PT_ARM_ARCHEXT_PROF_NONE    0x00000000
+#define PT_ARM_ARCHEXT_PROF_ARM     0x00410000
+#define PT_ARM_ARCHEXT_PROF_RT      0x00520000
+#define PT_ARM_ARCHEXT_PROF_MC      0x004d0000
+#define PT_ARM_ARCHEXT_PROF_CLASSIC 0x00530000
+
+#define PT_ARM_ARCHEXT_ARCH_UNKNOWN 0x00
+#define PT_ARM_ARCHEXT_ARCHv4       0x01
+#define PT_ARM_ARCHEXT_ARCHv4T      0x02
+#define PT_ARM_ARCHEXT_ARCHv5T      0x03
+#define PT_ARM_ARCHEXT_ARCHv5TE     0x04
+#define PT_ARM_ARCHEXT_ARCHv5TEJ    0x05
+#define PT_ARM_ARCHEXT_ARCHv6       0x06
+#define PT_ARM_ARCHEXT_ARCHv6KZ     0x07
+#define PT_ARM_ARCHEXT_ARCHv6T2     0x08
+#define PT_ARM_ARCHEXT_ARCHv6K      0x09
+#define PT_ARM_ARCHEXT_ARCHv7       0x0a
+#define PT_ARM_ARCHEXT_ARCHv6M      0x0b
+#define PT_ARM_ARCHEXT_ARCHv6SM     0x0c
+#define PT_ARM_ARCHEXT_ARCHv7EM     0x0d
+
+/* Table 5-6, ARM-specific dynamic array tags */
+
+#define DT_ARM_RESERVED1         0x70000000
+#define DT_ARM_SYMTABSZ          0x70000001
+#define DT_ARM_PREEMPTMAP        0x70000002
+#define DT_ARM_RESERVED2         0x70000003
+
+#endif /* __ARCH_ARM_INCLUDE_ELF_H */

--- a/os/arch/arm/src/armv7-r/cp15_coherent_dcache.S
+++ b/os/arch/arm/src/armv7-r/cp15_coherent_dcache.S
@@ -18,7 +18,7 @@
 /****************************************************************************
  * arch/arm/src/armv7-r/cp15_coherent_dcache.S
  *
- *   Copyright (C) 2015 Gregory Nutt. All rights reserved.
+ *   Copyright (C) 2015, 2017 Gregory Nutt. All rights reserved.
  *   Author: Gregory Nutt <gnutt@nuttx.org>
  *
  * References:
@@ -144,8 +144,10 @@ cp15_coherent_dcache:
 	blo		1b
 
 	mov		r0, #0
+#ifdef CONFIG_SMP
 	mcr		CP15_BPIALLIS(r0)		/* Invalidate entire branch predictor array Inner Shareable */
-	mcr		CP15_BPIALL(r0)			/* Invalidate entire branch predictor array Inner Shareable */
+#endif
+	mcr		CP15_BPIALL(r0)			/* Invalidate entire branch predictors */
 
 	dsb
 	isb

--- a/os/arch/arm/src/bcm4390x/Make.defs
+++ b/os/arch/arm/src/bcm4390x/Make.defs
@@ -79,9 +79,9 @@ CMN_CSRCS += arm_l2cc_pl310.c
 endif
 
 ifeq ($(CONFIG_ELF),y)
-CMN_CSRCS += arm_elf.c arm_coherent_dcache.c
+CMN_CSRCS += arm_coherent_dcache.c
 else ifeq ($(CONFIG_MODULE),y)
-CMN_CSRCS += arm_elf.c arm_coherent_dcache.c
+CMN_CSRCS += arm_coherent_dcache.c
 endif
 
 ifeq ($(CONFIG_ARCH_FPU),y)

--- a/os/binfmt/.gitignore
+++ b/os/binfmt/.gitignore
@@ -1,0 +1,10 @@
+/Make.dep
+/.depend
+/*.src
+/*.obj
+/*.asm
+/*.rel
+/*.lst
+/*.sym
+/*.adb
+/*.lib

--- a/os/binfmt/Kconfig
+++ b/os/binfmt/Kconfig
@@ -1,0 +1,78 @@
+#
+# For a description of the syntax of this configuration file,
+# see kconfig-language at https://www.kernel.org/doc/Documentation/kbuild/kconfig-language.txt
+#
+
+config BINFMT_DISABLE
+	bool "Disable BINFMT support"
+	default n
+	---help---
+		By default, support for loadable binary formats is built.  This logic
+		may be suppressed be defining this setting.
+
+if !BINFMT_DISABLE
+
+config PATH_INITIAL
+	string "Initial PATH Value"
+	default ""
+	depends on LIB_ENVPATH
+	---help---
+		The initial value of the PATH variable.  This is the colon-separated
+		list of absolute paths.  E.g., "/bin:/usr/bin:/sbin"
+
+config BINFMT_LOADABLE
+	bool
+	default n
+	---help---
+		Automatically selected if a loadable binary format is selected.
+
+config ELF
+	bool "Enable the ELF Binary Format"
+	default n
+	select BINFMT_LOADABLE
+	select LIBC_ARCH_ELF
+	---help---
+		Enable support for the ELF binary format.  Default: n
+
+if ELF
+source binfmt/libelf/Kconfig
+endif
+
+config BUILTIN
+	bool "Support Builtin Applications"
+	default n
+	depends on (!BUILD_PROTECTED && !BUILD_KERNEL) || EXPERIMENTAL
+	---help---
+		Enable support for builtin applications.  This features assigns a string
+		name to an application and in addition if FS_BINFS is defined, retaining
+		those names in a file system from which they can be executed.  This feature
+		is also the underlying requirement to support built-in applications in the
+		NuttShell (NSH).
+
+		ISSUES:  This feature is highly coupled with logic in the apps/
+		sub-directory and, as a consequence, cannot be used in environments
+		that do not include the standard apps/ nor in build
+		configurations using BUILD_PROTECTED or BUILD_KERNEL.
+
+if BUILTIN
+source binfmt/libbuiltin/Kconfig
+endif
+
+endif
+
+config BINFMT_CONSTRUCTORS
+	bool "C++ Static Constructor Support"
+	default n
+	depends on HAVE_CXX && SCHED_STARTHOOK && ELF
+	---help---
+		Build in support for C++ constructors in loaded modules.  Currently
+		only support for ELF binary formats.
+
+config SYMTAB_ORDEREDBYNAME
+	bool "Symbol Tables Ordered by Name"
+	default n
+	---help---
+		Select if the symbol table is ordered by symbol name.  In this case,
+		the logic can perform faster lookups using a binary search.
+		Otherwise, the symbol table is assumed to be un-ordered an only
+		slow, linear searches are supported.

--- a/os/binfmt/Makefile
+++ b/os/binfmt/Makefile
@@ -1,0 +1,120 @@
+###########################################################################
+#
+# Copyright 2019 Samsung Electronics All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+#
+###########################################################################
+############################################################################
+# os/binfmt/Makefile
+#
+#   Copyright (C) 2007-2009, 2012-2016, 2018 Gregory Nutt. All rights
+#     reserved.
+#   Author: Gregory Nutt <gnutt@nuttx.org>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in
+#    the documentation and/or other materials provided with the
+#    distribution.
+# 3. Neither the name NuttX nor the names of its contributors may be
+#    used to endorse or promote products derived from this software
+#    without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+# OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+# AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+############################################################################
+
+-include $(TOPDIR)/Make.defs
+DELIM ?= $(strip /)
+
+ifeq ($(WINTOOL),y)
+INCDIROPT = -w
+endif
+CFLAGS += ${shell $(INCDIR) $(INCDIROPT) "$(CC)" "$(TOPDIR)$(DELIM)kernel"}
+
+# Basic BINFMT source files
+
+BINFMT_ASRCS  =
+BINFMT_CSRCS  = binfmt_globals.c binfmt_initialize.c binfmt_register.c binfmt_unregister.c
+BINFMT_CSRCS += binfmt_loadmodule.c binfmt_unloadmodule.c binfmt_execmodule.c
+BINFMT_CSRCS += binfmt_exec.c binfmt_copyargv.c binfmt_dumpmodule.c
+
+ifeq ($(CONFIG_BINFMT_LOADABLE),y)
+BINFMT_CSRCS += binfmt_exit.c
+endif
+
+ifeq ($(CONFIG_LIBC_EXECFUNCS),y)
+BINFMT_CSRCS += binfmt_execsymtab.c
+endif
+
+# Add configured binary modules
+
+VPATH =
+SUBDIRS =
+DEPPATH = --dep-path .
+
+include libelf$(DELIM)Make.defs
+include libbuiltin$(DELIM)Make.defs
+
+BINFMT_AOBJS = $(BINFMT_ASRCS:.S=$(OBJEXT))
+BINFMT_COBJS = $(BINFMT_CSRCS:.c=$(OBJEXT))
+
+BINFMT_SRCS = $(BINFMT_ASRCS) $(BINFMT_CSRCS)
+BINFMT_OBJS = $(BINFMT_AOBJS) $(BINFMT_COBJS)
+
+BIN = libbinfmt$(LIBEXT)
+
+all: $(BIN)
+.PHONY: depend clean distclean
+
+$(BINFMT_AOBJS): %$(OBJEXT): %.S
+	$(call ASSEMBLE, $<, $@)
+
+$(BINFMT_COBJS): %$(OBJEXT): %.c
+	$(call COMPILE, $<, $@)
+
+$(BIN): $(BINFMT_OBJS)
+	$(call ARCHIVE, $@, $(BINFMT_OBJS))
+
+.depend: Makefile $(BINFMT_SRCS)
+	$(Q) $(MKDEP) $(DEPPATH) "$(CC)" -- $(CFLAGS) -- $(BINFMT_SRCS) >Make.dep
+	$(Q) touch $@
+
+depend: .depend
+
+clean:
+	$(call DELFILE, $(BIN))
+	$(call CLEAN)
+
+distclean: clean
+	$(call DELFILE, Make.dep)
+	$(call DELFILE, .depend)
+
+-include Make.dep

--- a/os/binfmt/binfmt.h
+++ b/os/binfmt/binfmt.h
@@ -1,0 +1,156 @@
+/****************************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+/****************************************************************************
+ * os/binfmt/binfmt.h
+ *
+ *   Copyright (C) 2009 Gregory Nutt. All rights reserved.
+ *   Author: Gregory Nutt <gnutt@nuttx.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#ifndef __BINFMT_BINFMT_H
+#define __BINFMT_BINFMT_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <tinyara/config.h>
+
+#include <tinyara/binfmt/binfmt.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+#undef EXTERN
+#if defined(__cplusplus)
+#define EXTERN extern "C"
+extern "C" {
+#else
+#define EXTERN extern
+#endif
+
+/* This is a list of registered handlers for different binary formats.  This
+ * list should only be accessed by normal user programs.  It should be sufficient
+ * protection to simply disable pre-emption when accessing this list.
+ */
+
+EXTERN FAR struct binfmt_s *g_binfmts;
+
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: dump_module
+ *
+ * Description:
+ *   Dump the contents of struct binary_s.
+ *
+ * Input Parameter:
+ *   bin      - Load structure
+ *
+ * Returned Value:
+ *   Zero (OK) on success; a negater errno value on failure
+ *
+ ****************************************************************************/
+
+#if defined(CONFIG_DEBUG) && defined(CONFIG_DEBUG_BINFMT)
+int dump_module(FAR const struct binary_s *bin);
+#else
+#define dump_module(bin)
+#endif
+
+/****************************************************************************
+ * Name: binfmt_copyargv
+ *
+ * Description:
+ *   In the kernel build, the argv list will likely lie in the caller's
+ *   address environment and, hence, by inaccessible when we swith to the
+ *   address environment of the new process address environment.  So we
+ *   do not have any real option other than to copy the callers argv[] list.
+ *
+ * Input Parameter:
+ *   bin      - Load structure
+ *   argv     - Argument list
+ *
+ * Returned Value:
+ *   Zero (OK) on sucess; a negater erro value on failure.
+ *
+ ****************************************************************************/
+
+int binfmt_copyargv(FAR struct binary_s *bin, FAR char *const *argv);
+
+/****************************************************************************
+ * Name: binfmt_freeargv
+ *
+ * Description:
+ *   Release the copied argv[] list.
+ *
+ * Input Parameters:
+ *   bin      - Load structure
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+#if defined(CONFIG_ARCH_ADDRENV) && defined(CONFIG_BUILD_KERNEL)
+void binfmt_freeargv(FAR struct binary_s *bin);
+#else
+#define binfmt_freeargv(bin)
+#endif
+
+#undef EXTERN
+#if defined(__cplusplus)
+}
+#endif
+
+#endif							/* __BINFMT_BINFMT_H */

--- a/os/binfmt/binfmt_copyargv.c
+++ b/os/binfmt/binfmt_copyargv.c
@@ -1,0 +1,207 @@
+/****************************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+/****************************************************************************
+ * os/binfmt/binfmt_copyargv.c
+ *
+ *   Copyright (C) 2009, 2013-2015 Gregory Nutt. All rights reserved.
+ *   Author: Gregory Nutt <gnutt@nuttx.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <tinyara/config.h>
+
+#include <string.h>
+#include <debug.h>
+#include <errno.h>
+
+#include <tinyara/kmalloc.h>
+#include <tinyara/binfmt/binfmt.h>
+
+#include "binfmt.h"
+
+#ifndef CONFIG_BINFMT_DISABLE
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+/* This is an artificial limit to detect error conditions where an argv[]
+ * list is not properly terminated.
+ */
+
+#define MAX_EXEC_ARGS 256
+
+/****************************************************************************
+ * Public Function
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: binfmt_copyargv
+ *
+ * Description:
+ *   In the kernel build, the argv list will likely lie in the caller's
+ *   address environment and, hence, by inaccessible when we switch to the
+ *   address environment of the new process address environment.  So we
+ *   do not have any real option other than to copy the callers argv[] list.
+ *
+ * Input Parameters:
+ *   bin      - Load structure
+ *   argv     - Argument list
+ *
+ * Returned Value:
+ *   Zero (OK) on success; a negated erro value on failure.
+ *
+ ****************************************************************************/
+
+int binfmt_copyargv(FAR struct binary_s *bin, FAR char *const *argv)
+{
+#if defined(CONFIG_ARCH_ADDRENV) && defined(CONFIG_BUILD_KERNEL)
+	FAR char *ptr;
+	size_t argvsize;
+	size_t argsize;
+	int nargs;
+	int i;
+
+	/* Get the number of arguments and the size of the argument list */
+
+	bin->argv = (FAR char **)NULL;
+	bin->argbuffer = (FAR char *)NULL;
+
+	if (argv) {
+		argsize = 0;
+		nargs = 0;
+
+		for (i = 0; argv[i]; i++) {
+			/* Increment the size of the allocation with the size of the next string */
+
+			argsize += (strlen(argv[i]) + 1);
+			nargs++;
+
+			/* This is a sanity check to prevent running away with an unterminated
+			 * argv[] list.  MAX_EXEC_ARGS should be sufficiently large that this
+			 * never happens in normal usage.
+			 */
+
+			if (nargs > MAX_EXEC_ARGS) {
+				berr("ERROR: Too many arguments: %lu\n", (unsigned long)argvsize);
+				return -E2BIG;
+			}
+		}
+
+		binfo("args=%d argsize=%lu\n", nargs, (unsigned long)argsize);
+
+		/* Allocate the argv array and an argument buffer */
+
+		if (argsize > 0) {
+			argvsize = (nargs + 1) * sizeof(FAR char *);
+			bin->argbuffer = (FAR char *)kmm_malloc(argvsize + argsize);
+			if (!bin->argbuffer) {
+				berr("ERROR: Failed to allocate the argument buffer\n");
+				return -ENOMEM;
+			}
+
+			/* Copy the argv list */
+
+			bin->argv = (FAR char **)bin->argbuffer;
+			ptr = bin->argbuffer + argvsize;
+			for (i = 0; argv[i]; i++) {
+				bin->argv[i] = ptr;
+				argsize = strlen(argv[i]) + 1;
+				memcpy(ptr, argv[i], argsize);
+				ptr += argsize;
+			}
+
+			/* Terminate the argv[] list */
+
+			bin->argv[i] = (FAR char *)NULL;
+		}
+	}
+
+	return OK;
+
+#else
+	/* Just save the caller's argv pointer */
+
+	bin->argv = argv;
+	return OK;
+#endif
+}
+
+/****************************************************************************
+ * Name: binfmt_freeargv
+ *
+ * Description:
+ *   Release the copied argv[] list.
+ *
+ * Input Parameters:
+ *   binp - Load structure
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+#if defined(CONFIG_ARCH_ADDRENV) && defined(CONFIG_BUILD_KERNEL)
+void binfmt_freeargv(FAR struct binary_s *binp)
+{
+	/* Is there an allocated argument buffer */
+
+	if (binp->argbuffer) {
+		/* Free the argument buffer */
+
+		kmm_free(binp->argbuffer);
+	}
+
+	/* Nullify the allocated argv[] array and the argument buffer pointers */
+
+	binp->argbuffer = (FAR char *)NULL;
+	binp->argv = (FAR char **)NULL;
+}
+#endif
+
+#endif							/* !CONFIG_BINFMT_DISABLE */

--- a/os/binfmt/binfmt_dumpmodule.c
+++ b/os/binfmt/binfmt_dumpmodule.c
@@ -1,0 +1,108 @@
+/****************************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+/****************************************************************************
+ * os/binfmt/binfmt_dumpmodule.c
+ *
+ *   Copyright (C) 2009, 2012 Gregory Nutt. All rights reserved.
+ *   Author: Gregory Nutt <gnutt@nuttx.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <tinyara/config.h>
+
+#include <sched.h>
+#include <debug.h>
+#include <errno.h>
+
+#include <tinyara/binfmt/binfmt.h>
+
+#include "binfmt.h"
+
+#if defined(CONFIG_DEBUG) && defined(CONFIG_DEBUG_BINFMT) && !defined(CONFIG_BINFMT_DISABLE)
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: dump_module
+ *
+ * Description:
+ *   Load a module into memory and prep it for execution.
+ *
+ * Returned Value:
+ *   This is a internal function so it follows the convention that
+ *   0 (OK) is returned on success and a negated errno is returned on
+ *   failure.
+ *
+ ****************************************************************************/
+
+int dump_module(FAR const struct binary_s *bin)
+{
+	if (bin) {
+		berr("Module:\n");
+		berr("  filename:  %s\n", bin->filename);
+		berr("  argv:      %p\n", bin->argv);
+		berr("  entrypt:   %p\n", bin->entrypt);
+		berr("  mapped:    %p size=%d\n", bin->mapped, bin->mapsize);
+		berr("  alloc:     %p %p %p\n", bin->alloc[0], bin->alloc[1], bin->alloc[2]);
+#ifdef CONFIG_BINFMT_CONSTRUCTORS
+		berr("  ctors:     %p nctors=%d\n", bin->ctors, bin->nctors);
+		berr("  dtors:     %p ndtors=%d\n", bin->dtors, bin->ndtors);
+#endif
+#ifdef CONFIG_ARCH_ADDRENV
+		berr("  addrenv:   %p\n", bin->addrenv);
+#endif
+		berr("  stacksize: %d\n", bin->stacksize);
+		berr("  unload:    %p\n", bin->unload);
+	}
+
+	return OK;
+}
+#endif

--- a/os/binfmt/binfmt_exec.c
+++ b/os/binfmt/binfmt_exec.c
@@ -1,0 +1,226 @@
+/****************************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+/****************************************************************************
+ * os/binfmt/binfmt_exec.c
+ *
+ *   Copyright (C) 2009, 2013-2014, 2017-2018 Gregory Nutt. All rights
+ *     reserved.
+ *   Author: Gregory Nutt <gnutt@nuttx.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <tinyara/config.h>
+
+#include <string.h>
+#include <debug.h>
+#include <errno.h>
+
+#include <tinyara/kmalloc.h>
+#include <tinyara/sched.h>
+#include <tinyara/binfmt/binfmt.h>
+
+#include "binfmt.h"
+
+#ifndef CONFIG_BINFMT_DISABLE
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: exec
+ *
+ * Description:
+ *   This is a convenience function that wraps load_ and exec_module into
+ *   one call.  If CONFIG_BINFMT_LOADABLE is defined, this function will
+ *   schedule to unload the module when task exits.
+ *
+ *   This non-standard function is similar to execv() and
+ *   posix_spawn() but differs in the following ways;
+ *
+ *   - Unlike execv() and posix_spawn() this function accepts symbol table
+ *     information as input parameters. This means that the symbol table
+ *     used to link the application prior to execution is provided by the
+ *     caller, not by the system.
+ *   - Unlike execv(), this function always returns.
+ *
+ *   This non-standard interface is included as a official API only
+ *   because it is needed in certain build modes: exec() is probably the
+ *   only want to load programs in the PROTECTED mode. Other file execution
+ *   APIs rely on a symbol table provided by the OS. In the PROTECTED build
+ *   mode, the OS cannot provide any meaningful symbolic information for
+ *   execution of code in the user-space blob so that is the exec() function
+ *   is really needed in that build case
+ *
+ *   The interface is available in the FLAT build mode although it is not
+ *   really necessary in that case. It is currently used by some example
+ *   code under the apps/ that that generate their own symbol tables for
+ *   linking test programs. So althought it is not necessary, it can still
+ *   be useful.
+ *
+ *   The interface would be completely useless and will not be supported in
+ *   in the KERNEL build mode where the contrary is true: An application
+ *   process cannot provide any meaning symbolic information for use in
+ *   linking a different process.
+ *
+ *   NOTE: This function is flawed and useless without CONFIG_BINFMT_LOADABLE
+ *   because without that features there is then no mechanism to unload the
+ *   module once it exits.
+ *
+ * Input Parameters:
+ *   filename - The path to the program to be executed. If
+ *              CONFIG_LIB_ENVPATH is defined in the configuration, then
+ *              this may be a relative path from the current working
+ *              directory. Otherwise, path must be the absolute path to the
+ *              program.
+ *   argv     - A pointer to an array of string arguments. The end of the
+ *              array is indicated with a NULL entry.
+ *   exports  - The address of the start of the caller-provided symbol
+ *              table. This symbol table contains the addresses of symbols
+ *              exported by the caller and made available for linking the
+ *              module into the system.
+ *   nexports - The number of symbols in the exports table.
+ *
+ * Returned Value:
+ *   This is an end-user function, so it follows the normal convention:
+ *   It returns the PID of the exec'ed module.  On failure, it returns
+ *   -1 (ERROR) and sets errno appropriately.
+ *
+ ****************************************************************************/
+
+int exec(FAR const char *filename, FAR char *const *argv, FAR const struct symtab_s *exports, int nexports)
+{
+	FAR struct binary_s *bin;
+	int pid;
+	int errcode;
+	int ret;
+
+	/* Allocate the load information */
+
+	bin = (FAR struct binary_s *)kmm_zalloc(sizeof(struct binary_s));
+	if (!bin) {
+		berr("ERROR: Failed to allocate binary_s\n");
+		errcode = ENOMEM;
+		goto errout;
+	}
+
+	/* Initialize the binary structure */
+
+	bin->filename = filename;
+	bin->exports = exports;
+	bin->nexports = nexports;
+
+	/* Copy the argv[] list */
+
+	ret = binfmt_copyargv(bin, argv);
+	if (ret < 0) {
+		errcode = -ret;
+		berr("ERROR: Failed to copy argv[]: %d\n", errcode);
+		goto errout_with_bin;
+	}
+
+	/* Load the module into memory */
+
+	ret = load_module(bin);
+	if (ret < 0) {
+		errcode = -ret;
+		berr("ERROR: Failed to load program '%s': %d\n", filename, errcode);
+		goto errout_with_argv;
+	}
+
+	/* Disable pre-emption so that the executed module does
+	 * not return until we get a chance to connect the on_exit
+	 * handler.
+	 */
+
+	sched_lock();
+
+	/* Then start the module */
+
+	pid = exec_module(bin);
+	if (pid < 0) {
+		errcode = -pid;
+		berr("ERROR: Failed to execute program '%s': %d\n", filename, errcode);
+		goto errout_with_lock;
+	}
+#ifdef CONFIG_BINFMT_LOADABLE
+	/* Set up to unload the module (and free the binary_s structure)
+	 * when the task exists.
+	 */
+
+	ret = group_exitinfo(pid, bin);
+	if (ret < 0) {
+		berr("ERROR: Failed to schedule unload '%s': %d\n", filename, ret);
+	}
+#else
+	/* Free the binary_s structure here */
+
+	binfmt_freeargv(bin);
+	kmm_free(bin);
+
+	/* TODO: How does the module get unloaded in this case? */
+#endif
+
+	sched_unlock();
+	return pid;
+
+errout_with_lock:
+	sched_unlock();
+	(void)unload_module(bin);
+errout_with_argv:
+	binfmt_freeargv(bin);
+errout_with_bin:
+	kmm_free(bin);
+errout:
+	set_errno(errcode);
+	return ERROR;
+
+}
+
+#endif							/* !CONFIG_BINFMT_DISABLE */

--- a/os/binfmt/binfmt_execmodule.c
+++ b/os/binfmt/binfmt_execmodule.c
@@ -1,0 +1,309 @@
+/****************************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+/****************************************************************************
+ * os/binfmt/binfmt_execmodule.c
+ *
+ *   Copyright (C) 2009, 2013-2014, 2017 Gregory Nutt. All rights reserved.
+ *   Author: Gregory Nutt <gnutt@nuttx.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <tinyara/config.h>
+
+#include <sys/types.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <sched.h>
+#include <debug.h>
+#include <errno.h>
+
+#include <tinyara/arch.h>
+#include <tinyara/kmalloc.h>
+#include <tinyara/mm/shm.h>
+#include <tinyara/binfmt/binfmt.h>
+
+#include "sched/sched.h"
+#include "binfmt.h"
+
+#ifndef CONFIG_BINFMT_DISABLE
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+/* If C++ constructors are used, then CONFIG_SCHED_STARTHOOK must also be
+ * selected be the start hook is used to schedule execution of the
+ * constructors.
+ */
+
+#if defined(CONFIG_BINFMT_CONSTRUCTORS) && !defined(CONFIG_SCHED_STARTHOOK)
+#errror "CONFIG_SCHED_STARTHOOK must be defined to use constructors"
+#endif
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: exec_ctors
+ *
+ * Description:
+ *   Execute C++ static constructors.  This function is registered as a
+ *   start hook and runs on the thread of the newly created task before
+ *   the new task's main function is called.
+ *
+ * Input Parameters:
+ *   arg - Argument is instance of load state info structure cast to void *.
+ *
+ * Returned Value:
+ *   0 (OK) is returned on success and a negated errno is returned on
+ *   failure.
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_BINFMT_CONSTRUCTORS
+static void exec_ctors(FAR void *arg)
+{
+	FAR const struct binary_s *binp = (FAR const struct binary_s *)arg;
+	binfmt_ctor_t *ctor = binp->ctors;
+	int i;
+
+	/* Execute each constructor */
+
+	for (i = 0; i < binp->nctors; i++) {
+		binfo("Calling ctor %d at %p\n", i, (FAR void *)ctor);
+
+		(*ctor)();
+		ctor++;
+	}
+}
+#endif
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: exec_module
+ *
+ * Description:
+ *   Execute a module that has been loaded into memory by load_module().
+ *
+ * Returned Value:
+ *   This is a internal function so it follows the convention that
+ *   0 (OK) is returned on success and a negated errno is returned on
+ *   failure.
+ *
+ ****************************************************************************/
+
+int exec_module(FAR const struct binary_s *binp)
+{
+	FAR struct task_tcb_s *tcb;
+#if defined(CONFIG_ARCH_ADDRENV) && defined(CONFIG_BUILD_KERNEL)
+	save_addrenv_t oldenv;
+#endif
+	FAR uint32_t *stack;
+	pid_t pid;
+	int ret;
+
+	/* Sanity checking */
+
+#ifdef CONFIG_DEBUG
+	if (!binp || !binp->entrypt || binp->stacksize <= 0) {
+		return -EINVAL;
+	}
+#endif
+
+	binfo("Executing %s\n", binp->filename);
+
+	/* Allocate a TCB for the new task. */
+
+	tcb = (FAR struct task_tcb_s *)kmm_zalloc(sizeof(struct task_tcb_s));
+	if (!tcb) {
+		return -ENOMEM;
+	}
+#if defined(CONFIG_ARCH_ADDRENV) && defined(CONFIG_BUILD_KERNEL)
+	/* Instantiate the address environment containing the user heap */
+
+	ret = up_addrenv_select(&binp->addrenv, &oldenv);
+	if (ret < 0) {
+		berr("ERROR: up_addrenv_select() failed: %d\n", ret);
+		goto errout_with_tcb;
+	}
+#endif
+
+	/* Allocate the stack for the new task.
+	 *
+	 * REVISIT:  This allocation is currently always from the user heap.  That
+	 * will need to change if/when we want to support dynamic stack allocation.
+	 */
+
+	stack = (FAR uint32_t *)kumm_malloc(binp->stacksize);
+	if (!stack) {
+		ret = -ENOMEM;
+		goto errout_with_addrenv;
+	}
+
+	/* Initialize the task */
+
+	ret = task_init((FAR struct tcb_s *)tcb, binp->filename, binp->priority, stack, binp->stacksize, binp->entrypt, binp->argv);
+	if (ret < 0) {
+		ret = -get_errno();
+		berr("task_init() failed: %d\n", ret);
+		goto errout_with_addrenv;
+	}
+
+	/* We can free the argument buffer now.
+	 * REVISIT:  It is good to free up memory as soon as possible, but
+	 * unfortunately here 'binp' is 'const'.  So to do this properly, we will
+	 * have to make some more extensive changes.
+	 */
+
+	binfmt_freeargv((FAR struct binary_s *)binp);
+
+	/* Note that tcb->flags are not modified.  0=normal task */
+	/* tcb->flags |= TCB_FLAG_TTYPE_TASK; */
+
+#if defined(CONFIG_ARCH_ADDRENV) && defined(CONFIG_BUILD_KERNEL)
+	/* Allocate the kernel stack */
+
+	ret = up_addrenv_kstackalloc(&tcb->cmn);
+	if (ret < 0) {
+		berr("ERROR: up_addrenv_select() failed: %d\n", ret);
+		goto errout_with_tcbinit;
+	}
+#endif
+
+#if defined(CONFIG_BUILD_KERNEL) && defined(CONFIG_MM_SHM)
+	/* Initialize the shared memory virtual page allocator */
+
+	ret = shm_group_initialize(tcb->cmn.group);
+	if (ret < 0) {
+		berr("ERROR: shm_group_initialize() failed: %d\n", ret);
+		goto errout_with_tcbinit;
+	}
+#endif
+
+#ifdef CONFIG_PIC
+	/* Add the D-Space address as the PIC base address.  By convention, this
+	 * must be the first allocated address space.
+	 */
+
+	tcb->cmn.dspace = binp->alloc[0];
+
+	/* Re-initialize the task's initial state to account for the new PIC base */
+
+	up_initial_state(&tcb->cmn);
+#endif
+
+#ifdef CONFIG_ARCH_ADDRENV
+	/* Assign the address environment to the new task group */
+
+	ret = up_addrenv_clone(&binp->addrenv, &tcb->cmn.group->tg_addrenv);
+	if (ret < 0) {
+		berr("ERROR: up_addrenv_clone() failed: %d\n", ret);
+		goto errout_with_tcbinit;
+	}
+
+	/* Mark that this group has an address environment */
+
+	tcb->cmn.group->tg_flags |= GROUP_FLAG_ADDRENV;
+#endif
+
+#ifdef CONFIG_BINFMT_CONSTRUCTORS
+	/* Setup a start hook that will execute all of the C++ static constructors
+	 * on the newly created thread.  The struct binary_s must persist at least
+	 * until the new task has been started.
+	 */
+
+	if (binp->nctors > 0) {
+		task_starthook(tcb, exec_ctors, (FAR void *)binp);
+	}
+#endif
+
+	/* Get the assigned pid before we start the task */
+
+	pid = tcb->cmn.pid;
+
+	/* Then activate the task at the provided priority */
+
+	ret = task_activate((FAR struct tcb_s *)tcb);
+	if (ret < 0) {
+		ret = -get_errno();
+		berr("task_activate() failed: %d\n", ret);
+		goto errout_with_tcbinit;
+	}
+#if defined(CONFIG_ARCH_ADDRENV) && defined(CONFIG_BUILD_KERNEL)
+	/* Restore the address environment of the caller */
+
+	ret = up_addrenv_restore(&oldenv);
+	if (ret < 0) {
+		berr("ERROR: up_addrenv_select() failed: %d\n", ret);
+		goto errout_with_tcbinit;
+	}
+#endif
+
+	return (int)pid;
+
+errout_with_tcbinit:
+	tcb->cmn.stack_alloc_ptr = NULL;
+	sched_releasetcb(&tcb->cmn, TCB_FLAG_TTYPE_TASK);
+	kumm_free(stack);
+	return ret;
+
+errout_with_addrenv:
+#if defined(CONFIG_ARCH_ADDRENV) && defined(CONFIG_BUILD_KERNEL)
+	(void)up_addrenv_restore(&oldenv);
+
+errout_with_tcb:
+#endif
+	kmm_free(tcb);
+	return ret;
+}
+
+#endif							/* CONFIG_BINFMT_DISABLE */

--- a/os/binfmt/binfmt_execsymtab.c
+++ b/os/binfmt/binfmt_execsymtab.c
@@ -1,0 +1,185 @@
+/****************************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+/****************************************************************************
+ * os/binfmt/binfmt_execsymtab.c
+ *
+ *   Copyright (C) 2013, 2016, 2018 Gregory Nutt. All rights reserved.
+ *   Author: Gregory Nutt <gnutt@nuttx.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <tinyara/config.h>
+
+#include <assert.h>
+
+#include <tinyara/irq.h>
+#include <tinyara/arch.h>
+#include <tinyara/binfmt/symtab.h>
+
+#ifdef CONFIG_LIBC_EXECFUNCS
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+/* If CONFIG_LIBC_EXECFUNCS is defined in the configuration, then the
+ * following must also be defined:
+ */
+
+#ifdef CONFIG_EXECFUNCS_HAVE_SYMTAB
+/* Symbol table used by exec[l|v] */
+
+#ifndef CONFIG_EXECFUNCS_SYMTAB_ARRAY
+#error "CONFIG_EXECFUNCS_SYMTAB_ARRAY must be defined"
+#endif
+
+/* Number of Symbols in the Table */
+
+#ifndef CONFIG_EXECFUNCS_NSYMBOLS_VAR
+#error "CONFIG_EXECFUNCS_NSYMBOLS_VAR must be defined"
+#endif
+#endif
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+#ifdef CONFIG_EXECFUNCS_HAVE_SYMTAB
+extern const struct symtab_s CONFIG_EXECFUNCS_SYMTAB_ARRAY[];
+extern int CONFIG_EXECFUNCS_NSYMBOLS_VAR;
+#endif
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+static FAR const struct symtab_s *g_exec_symtab;
+static int g_exec_nsymbols;
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: exec_getsymtab
+ *
+ * Description:
+ *   Get the current symbol table selection as an atomic operation.
+ *
+ * Input Parameters:
+ *   symtab - The location to store the symbol table.
+ *   nsymbols - The location to store the number of symbols in the symbol table.
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+void exec_getsymtab(FAR const struct symtab_s **symtab, FAR int *nsymbols)
+{
+	irqstate_t flags;
+
+	DEBUGASSERT(symtab != NULL && nsymbols != NULL);
+
+	/* Disable interrupts very briefly so that both the symbol table and its
+	 * size are returned as a single atomic operation.
+	 */
+
+	flags = irqsave();
+
+#ifdef CONFIG_EXECFUNCS_HAVE_SYMTAB
+	/* If a bring-up symbol table has been provided and if the exec symbol
+	 * table has not yet been initialized, then use the provided start-up
+	 * symbol table.
+	 */
+
+	if (g_exec_symtab == NULL) {
+		g_exec_symtab = CONFIG_EXECFUNCS_SYMTAB_ARRAY;
+		g_exec_nsymbols = CONFIG_EXECFUNCS_NSYMBOLS_VAR;
+	}
+#endif
+
+	/* Return the symbol table and its size */
+
+	*symtab = g_exec_symtab;
+	*nsymbols = g_exec_nsymbols;
+	irqrestore(flags);
+}
+
+/****************************************************************************
+ * Name: exec_setsymtab
+ *
+ * Description:
+ *   Select a new symbol table selection as an atomic operation.
+ *
+ * Input Parameters:
+ *   symtab - The new symbol table.
+ *   nsymbols - The number of symbols in the symbol table.
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+void exec_setsymtab(FAR const struct symtab_s *symtab, int nsymbols)
+{
+	irqstate_t flags;
+
+	DEBUGASSERT(symtab != NULL);
+
+	/* Disable interrupts very briefly so that both the symbol table and its
+	 * size are set as a single atomic operation.
+	 */
+
+	flags = irqsave();
+	g_exec_symtab = symtab;
+	g_exec_nsymbols = nsymbols;
+	irqrestore(flags);
+}
+
+#endif							/* CONFIG_LIBC_EXECFUNCS */

--- a/os/binfmt/binfmt_exit.c
+++ b/os/binfmt/binfmt_exit.c
@@ -1,0 +1,112 @@
+/****************************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+/****************************************************************************
+ * os/binfmt/binfmt_exit.c
+ *
+ *   Copyright (C) 2013, 2016-2018 Gregory Nutt. All rights reserved.
+ *   Author: Gregory Nutt <gnutt@nuttx.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <tinyara/config.h>
+
+#include <sys/types.h>
+#include <assert.h>
+#include <debug.h>
+
+#include <tinyara/kmalloc.h>
+#include <tinyara/binfmt/binfmt.h>
+
+#include "binfmt.h"
+
+#ifdef CONFIG_BINFMT_LOADABLE
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: binfmt_exit
+ *
+ * Description:
+ *   This function may be called when a tasked loaded into RAM exits.
+ *   This function will unload the module when the task exits and reclaim
+ *   all resources used by the module.
+ *
+ * Input Parameters:
+ *   bin - This structure must have been allocated with kmm_malloc() and must
+ *         persist until the task unloads
+ *
+ * Returned Value:
+ *   This is a internal function so it follows the convention that
+ *   0 (OK) is returned on success and a negated errno is returned on
+ *   failure.
+ *
+ ****************************************************************************/
+
+int binfmt_exit(FAR struct binary_s *bin)
+{
+	int ret;
+
+	DEBUGASSERT(bin != NULL);
+
+	/* Unload the module */
+
+	ret = unload_module(bin);
+	if (ret < 0) {
+		berr("ERROR: unload_module() failed: %d\n", ret);
+	}
+
+	/* Free the load structure */
+
+	kmm_free(bin);
+	return ret;
+}
+
+#endif							/* CONFIG_BINFMT_LOADABLE */

--- a/os/binfmt/binfmt_globals.c
+++ b/os/binfmt/binfmt_globals.c
@@ -1,0 +1,86 @@
+/****************************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+/****************************************************************************
+ * os/binfmt/binfmt_globals.c
+ *
+ *   Copyright (C) 2009 Gregory Nutt. All rights reserved.
+ *   Author: Gregory Nutt <gnutt@nuttx.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <tinyara/config.h>
+
+#include <tinyara/binfmt/binfmt.h>
+
+#ifndef CONFIG_BINFMT_DISABLE
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+/* This is a list of registered handlers for different binary formats.  This
+ * list should only be accessed by normal user programs.  It should be sufficient
+ * protection to simply disable pre-emption when accessing this list.
+ */
+
+FAR struct binfmt_s *g_binfmts;
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+#endif							/* CONFIG_BINFMT_DISABLE */

--- a/os/binfmt/binfmt_initialize.c
+++ b/os/binfmt/binfmt_initialize.c
@@ -1,0 +1,112 @@
+/****************************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+/****************************************************************************
+ * os/binfmt/binfmt_initialize.c
+ *
+ *   Copyright (C) 2018 Pinecone Inc. All rights reserved.
+ *   Author: Xiang Xiao <xiaoxiang@pinecone.net>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <tinyara/config.h>
+
+#include <tinyara/binfmt/binfmt.h>
+#include <tinyara/binfmt/builtin.h>
+#include <tinyara/binfmt/elf.h>
+
+#ifndef CONFIG_BINFMT_DISABLE
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: binfmt_initialize
+ *
+ * Description:
+ *   initialize binfmt subsystem
+ *
+ ****************************************************************************/
+
+void binfmt_initialize(void)
+{
+	int ret;
+
+#ifdef CONFIG_FS_BINFS
+	ret = builtin_initialize();
+	if (ret < 0) {
+		berr("ERROR: builtin_initialize failed: %d\n", ret);
+	}
+#endif
+
+#ifdef CONFIG_ELF
+	ret = elf_initialize();
+	if (ret < 0) {
+		berr("ERROR: elf_initialize failed: %d\n", ret);
+	}
+#endif
+
+#ifdef CONFIG_BINFMT_PCODE
+	ret = pcode_initialize();
+	if (ret < 0) {
+		berr("ERROR: pcode_initialize failed: %d\n", ret);
+	}
+#endif
+
+#ifdef CONFIG_NXFLAT
+	ret = nxflat_initialize();
+	if (ret < 0) {
+		berr("ERROR: nxflat_initialize failed: %d\n", ret);
+	}
+#endif
+
+	UNUSED(ret);
+}
+
+#endif							/* CONFIG_BINFMT_DISABLE */

--- a/os/binfmt/binfmt_loadmodule.c
+++ b/os/binfmt/binfmt_loadmodule.c
@@ -1,0 +1,264 @@
+/****************************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+/****************************************************************************
+ * os/binfmt/binfmt_loadmodule.c
+ *
+ *   Copyright (C) 2009, 2014, 2017-2018 Gregory Nutt. All rights reserved.
+ *   Author: Gregory Nutt <gnutt@nuttx.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <tinyara/config.h>
+
+#include <sched.h>
+#include <debug.h>
+#include <errno.h>
+
+#include <tinyara/envpath.h>
+#include <tinyara/sched.h>
+#include <tinyara/kmalloc.h>
+#include <tinyara/binfmt/binfmt.h>
+
+#include "binfmt.h"
+
+#ifndef CONFIG_BINFMT_DISABLE
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: load_default_priority
+ *
+ * Description:
+ *   Set the default priority of the module to be loaded.  This may be
+ *   changed (1) by the actions of the binary format's load() method if
+ *   the binary format contains priority information, or (2) by the user
+ *   between calls to load_module() and exec_module().
+ *
+ * Returned Value:
+ *   Zero (OK) is returned on success; Otherwise a negated errno value is
+ *   returned.
+ *
+ ****************************************************************************/
+
+static int load_default_priority(FAR struct binary_s *bin)
+{
+	struct sched_param param;
+	int ret;
+
+	/* Get the priority of this thread */
+
+	ret = sched_getparam(0, &param);
+	if (ret < 0) {
+		berr("ERROR: sched_getparam failed: %d\n", ret);
+		return ret;
+	}
+
+	/* Save that as the priority of child thread */
+
+	bin->priority = param.sched_priority;
+	if (bin->priority <= 0) {
+		bin->priority = SCHED_PRIORITY_DEFAULT;
+	}
+
+	return ret;
+}
+
+/****************************************************************************
+ * Name: load_absmodule
+ *
+ * Description:
+ *   Load a module into memory, bind it to an exported symbol take, and
+ *   prep the module for execution.  bin->filename is known to be an absolute
+ *   path to the file to be loaded.
+ *
+ * Returned Value:
+ *   Zero (OK) is returned on success; a negated errno value is returned on
+ *   failure.
+ *
+ ****************************************************************************/
+
+static int load_absmodule(FAR struct binary_s *bin)
+{
+	FAR struct binfmt_s *binfmt;
+	int ret = -ENOENT;
+
+	binfo("Loading %s\n", bin->filename);
+
+	/* Disabling pre-emption should be sufficient protection while accessing
+	 * the list of registered binary format handlers.
+	 */
+
+	sched_lock();
+
+	/* Traverse the list of registered binary format handlers.  Stop
+	 * when either (1) a handler recognized and loads the format, or
+	 * (2) no handler recognizes the format.
+	 */
+
+	for (binfmt = g_binfmts; binfmt; binfmt = binfmt->next) {
+		/* Use this handler to try to load the format */
+
+		ret = binfmt->load(bin);
+		if (ret == OK) {
+			/* Successfully loaded -- break out with ret == 0 */
+
+			binfo("Successfully loaded module %s\n", bin->filename);
+
+			/* Save the unload method for use by unload_module */
+
+			bin->unload = binfmt->unload;
+			dump_module(bin);
+			break;
+		}
+	}
+
+	sched_unlock();
+	return ret;
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: load_module
+ *
+ * Description:
+ *   Load a module into memory, bind it to an exported symbol take, and
+ *   prep the module for execution.
+ *
+ * Returned Value:
+ *   This is a internal function so it follows the convention that
+ *   0 (OK) is returned on success and a negated errno is returned on
+ *   failure.
+ *
+ ****************************************************************************/
+
+int load_module(FAR struct binary_s *bin)
+{
+	int ret = -EINVAL;
+
+	/* Verify that we were provided something to work with */
+
+#ifdef CONFIG_DEBUG
+	if (bin && bin->filename)
+#endif
+	{
+		/* Set the default priority of the new program. */
+
+		ret = load_default_priority(bin);
+		if (ret < 0) {
+			return ret;
+		}
+
+		/* Were we given a relative path?  Or an absolute path to the file to
+		 * be loaded?  Absolute paths start with '/'.
+		 */
+
+#ifdef CONFIG_LIB_ENVPATH
+		if (bin->filename[0] != '/') {
+			FAR const char *relpath;
+			FAR char *fullpath;
+			ENVPATH_HANDLE handle;
+
+			/* Set aside the relative path */
+
+			relpath = bin->filename;
+			ret = -ENOENT;
+
+			/* Initialize to traverse the PATH variable */
+
+			handle = envpath_init("PATH");
+			if (handle) {
+				/* Get the next absolute file path */
+
+				while ((fullpath = envpath_next(handle, relpath)) != NULL) {
+					/* Try to load the file at this path */
+
+					bin->filename = fullpath;
+					ret = load_absmodule(bin);
+
+					/* Free the allocated fullpath */
+
+					kmm_free(fullpath);
+
+					/* Break out of the loop with ret == OK on success */
+
+					if (ret == OK) {
+						break;
+					}
+				}
+
+				/* Release the traversal handle */
+
+				envpath_release(handle);
+			}
+
+			/* Restore the relative path.  This is not needed for anything
+			 * but debug output after the file has been loaded.
+			 */
+
+			bin->filename = relpath;
+		} else
+#endif
+		{
+			/* We already have the one and only absolute path to the file to
+			 * be loaded.
+			 */
+
+			ret = load_absmodule(bin);
+		}
+	}
+
+	return ret;
+}
+
+#endif							/* CONFIG_BINFMT_DISABLE */

--- a/os/binfmt/binfmt_register.c
+++ b/os/binfmt/binfmt_register.c
@@ -1,0 +1,104 @@
+/****************************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+/****************************************************************************
+ * os/binfmt/binfmt_register.c
+ *
+ *   Copyright (C) 2009 Gregory Nutt. All rights reserved.
+ *   Author: Gregory Nutt <gnutt@nuttx.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <tinyara/config.h>
+
+#include <string.h>
+#include <sched.h>
+#include <debug.h>
+#include <errno.h>
+
+#include <tinyara/binfmt/binfmt.h>
+
+#include "binfmt.h"
+
+#ifndef CONFIG_BINFMT_DISABLE
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: register_binfmt
+ *
+ * Description:
+ *   Register a loader for a binary format
+ *
+ * Returned Value:
+ *   This is a internal function so it follows the convention that
+ *   0 (OK) is returned on success and a negated errno is returned on
+ *   failure.
+ *
+ ****************************************************************************/
+
+int register_binfmt(FAR struct binfmt_s *binfmt)
+{
+	if (binfmt) {
+		/* Add the new binary format handler to the head of the list of
+		 * handlers
+		 */
+
+		sched_lock();
+		binfmt->next = g_binfmts;
+		g_binfmts = binfmt;
+		sched_unlock();
+		return OK;
+	}
+
+	return -EINVAL;
+}
+
+#endif							/* CONFIG_BINFMT_DISABLE */

--- a/os/binfmt/binfmt_unloadmodule.c
+++ b/os/binfmt/binfmt_unloadmodule.c
@@ -1,0 +1,207 @@
+/****************************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+/****************************************************************************
+ * os/binfmt/binfmt_unloadmodule.c
+ *
+ *   Copyright (C) 2009, 2012-2013, 2017 Gregory Nutt. All rights reserved.
+ *   Author: Gregory Nutt <gnutt@nuttx.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <tinyara/config.h>
+
+#include <sys/mman.h>
+#include <stdlib.h>
+#include <sched.h>
+#include <debug.h>
+#include <errno.h>
+
+#include <tinyara/kmalloc.h>
+#include <tinyara/binfmt/binfmt.h>
+
+#include "binfmt.h"
+
+#ifndef CONFIG_BINFMT_DISABLE
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: exec_dtors
+ *
+ * Description:
+ *   Execute C++ static destructors.
+ *
+ * Input Parameters:
+ *   binp - Load state information
+ *
+ * Returned Value:
+ *   0 (OK) is returned on success and a negated errno is returned on
+ *   failure.
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_BINFMT_CONSTRUCTORS
+static inline int exec_dtors(FAR struct binary_s *binp)
+{
+	binfmt_dtor_t *dtor = binp->dtors;
+#ifdef CONFIG_ARCH_ADDRENV
+	save_addrenv_t oldenv;
+	int ret;
+#endif
+	int i;
+
+	/* Instantiate the address environment containing the destructors */
+
+#ifdef CONFIG_ARCH_ADDRENV
+	ret = up_addrenv_select(&binp->addrenv, &oldenv);
+	if (ret < 0) {
+		berr("ERROR: up_addrenv_select() failed: %d\n", ret);
+		return ret;
+	}
+#endif
+
+	/* Execute each destructor */
+
+	for (i = 0; i < binp->ndtors; i++) {
+		binfo("Calling dtor %d at %p\n", i, (FAR void *)dtor);
+
+		(*dtor)();
+		dtor++;
+	}
+
+	/* Restore the address environment */
+
+#ifdef CONFIG_ARCH_ADDRENV
+	return up_addrenv_restore(&oldenv);
+#else
+	return OK;
+#endif
+}
+#endif
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: unload_module
+ *
+ * Description:
+ *   Unload a (non-executing) module from memory.  If the module has
+ *   been started (via exec_module) and has not exited, calling this will
+ *   be fatal.
+ *
+ *   However, this function must be called after the module exits.  How
+ *   this is done is up to your logic.  Perhaps you register it to be
+ *   called by on_exit()?
+ *
+ * Returned Value:
+ *   This is a internal function so it follows the convention that
+ *   0 (OK) is returned on success and a negated errno is returned on
+ *   failure.
+ *
+ ****************************************************************************/
+
+int unload_module(FAR struct binary_s *binp)
+{
+	int ret;
+	int i;
+
+	if (binp) {
+		/* Perform any format-specific unload operations */
+
+		if (binp->unload) {
+			ret = binp->unload(binp);
+			if (ret < 0) {
+				berr("binp->unload() failed: %d\n", ret);
+				return ret;
+			}
+		}
+#ifdef CONFIG_BINFMT_CONSTRUCTORS
+		/* Execute C++ destructors */
+
+		ret = exec_dtors(binp);
+		if (ret < 0) {
+			berr("exec_ctors() failed: %d\n", ret);
+			return ret;
+		}
+#endif
+
+		/* Free any allocated argv[] strings */
+
+		binfmt_freeargv(binp);
+
+		/* Unmap mapped address spaces */
+
+		if (binp->mapped) {
+			binfo("Unmapping address space: %p\n", binp->mapped);
+
+			munmap(binp->mapped, binp->mapsize);
+		}
+
+		/* Free allocated address spaces */
+
+		for (i = 0; i < BINFMT_NALLOC; i++) {
+			if (binp->alloc[i]) {
+				binfo("Freeing alloc[%d]: %p\n", i, binp->alloc[i]);
+				kumm_free((FAR void *)binp->alloc[i]);
+			}
+		}
+
+		/* Notice that the address environment is not destroyed.  This should
+		 * happen automatically when the task exits.
+		 */
+	}
+
+	return OK;
+}
+
+#endif							/* CONFIG_BINFMT_DISABLE */

--- a/os/binfmt/binfmt_unregister.c
+++ b/os/binfmt/binfmt_unregister.c
@@ -1,0 +1,131 @@
+/****************************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+/****************************************************************************
+ * os/binfmt/binfmt_unregister.c
+ *
+ *   Copyright (C) 2009 Gregory Nutt. All rights reserved.
+ *   Author: Gregory Nutt <gnutt@nuttx.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <tinyara/config.h>
+
+#include <string.h>
+#include <sched.h>
+#include <debug.h>
+#include <errno.h>
+
+#include <tinyara/binfmt/binfmt.h>
+
+#include "binfmt.h"
+
+#ifndef CONFIG_BINFMT_DISABLE
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: unregister_binfmt
+ *
+ * Description:
+ *   Unregister a loader for a binary format
+ *
+ * Returned Value:
+ *   This is a internal function so it follows the convention that
+ *   0 (OK) is returned on success and a negated errno is returned on
+ *   failure.
+ *
+ ****************************************************************************/
+
+int unregister_binfmt(FAR struct binfmt_s *binfmt)
+{
+	FAR struct binfmt_s *curr;
+	FAR struct binfmt_s *prev;
+	int ret = -EINVAL;
+
+	if (binfmt) {
+		/* Disabling pre-emption should be sufficient protection while
+		 * accessing the list of registered binary format handlers.
+		 */
+
+		sched_lock();
+
+		/* Search the list of registered binary format handlers for the
+		 * one to be unregistered.
+		 */
+
+		for (prev = NULL, curr = g_binfmts; curr && curr != binfmt; prev = curr, curr = curr->next) ;
+
+		/* Was it in the list? */
+
+		if (curr) {
+			/* Yes.. was it at the head of the list? */
+
+			if (!prev) {
+				/* Yes.. remove it from the head of the list */
+
+				g_binfmts = binfmt->next;
+			} else {
+				/* No.. remove it from the middle/end of the list */
+
+				prev->next = binfmt->next;
+			}
+
+			binfmt->next = NULL;
+			ret = OK;
+		}
+
+		sched_unlock();
+	}
+
+	return ret;
+}
+
+#endif							/* CONFIG_BINFMT_DISABLE */

--- a/os/binfmt/builtin.c
+++ b/os/binfmt/builtin.c
@@ -1,0 +1,212 @@
+/****************************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+/****************************************************************************
+ * os/binfmt/builtin.c
+ *
+ *   Copyright (C) 2012 Gregory Nutt. All rights reserved.
+ *   Author: Gregory Nutt <gnutt@nuttx.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <tinyara/config.h>
+
+#include <sys/types.h>
+#include <sys/ioctl.h>
+
+#include <stdint.h>
+#include <string.h>
+#include <fcntl.h>
+#include <debug.h>
+#include <errno.h>
+
+#include <tinyara/fs/fs.h>
+#include <tinyara/fs/ioctl.h>
+#include <tinyara/binfmt/binfmt.h>
+#include <tinyara/binfmt/builtin.h>
+
+#ifdef CONFIG_BUILTIN
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Function Prototypes
+ ****************************************************************************/
+
+static int builtin_loadbinary(FAR struct binary_s *binp);
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+static struct binfmt_s g_builtin_binfmt = {
+	NULL,						/* next */
+	builtin_loadbinary,			/* load */
+	NULL,						/* unload */
+};
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: builtin_loadbinary
+ *
+ * Description:
+ *   Verify that the file is an builtin binary.
+ *
+ ****************************************************************************/
+
+static int builtin_loadbinary(struct binary_s *binp)
+{
+	FAR const char *filename;
+	FAR const struct builtin_s *builtin;
+	int fd;
+	int index;
+	int ret;
+
+	binfo("Loading file: %s\n", binp->filename);
+
+	/* Open the binary file for reading (only) */
+
+	fd = open(binp->filename, O_RDONLY);
+	if (fd < 0) {
+		berr("ERROR: Failed to open binary %s: %d\n", binp->filename, fd);
+		return fd;
+	}
+
+	/* If this file is a BINFS file system, then we can recover the name of
+	 * the file using the FIOC_FILENAME ioctl() call.
+	 */
+
+	ret = ioctl(fd, FIOC_FILENAME, (unsigned long)((uintptr_t) & filename));
+	if (ret < 0) {
+		int errval = get_errno();
+		berr("ERROR: FIOC_FILENAME ioctl failed: %d\n", errval);
+		close(fd);
+		return -errval;
+	}
+
+	/* Other file systems may also support FIOC_FILENAME, so the real proof
+	 * is that we can look up the index to this name in g_builtins[].
+	 */
+
+	index = builtin_isavail(filename);
+	if (index < 0) {
+		int errval = get_errno();
+		berr("ERROR: %s is not a builtin application\n", filename);
+		close(fd);
+		return -errval;
+
+	}
+
+	/* Return the load information.  NOTE: that there is no way to configure
+	 * the priority.  That is a bug and needs to be fixed.
+	 */
+
+	builtin = builtin_for_index(index);
+	binp->entrypt = builtin->main;
+	binp->stacksize = builtin->stacksize;
+	binp->priority = builtin->priority;
+	close(fd);
+	return OK;
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: builtin_initialize
+ *
+ * Description:
+ *   In order to use the builtin binary format, this function must be called
+ *   during system initialize to register the builtin binary format.
+ *
+ * Returned Value:
+ *   This is a internal function so it follows the convention that
+ *   0 (OK) is returned on success and a negated errno is returned on
+ *   failure.
+ *
+ ****************************************************************************/
+
+int builtin_initialize(void)
+{
+	int ret;
+
+	/* Register ourselves as a binfmt loader */
+
+	binfo("Registering Builtin Loader\n");
+
+	ret = register_binfmt(&g_builtin_binfmt);
+	if (ret != 0) {
+		berr("Failed to register binfmt: %d\n", ret);
+	}
+
+	return ret;
+}
+
+/****************************************************************************
+ * Name: builtin_uninitialize
+ *
+ * Description:
+ *   Unregister the builtin binary loader
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+void builtin_uninitialize(void)
+{
+	(void)unregister_binfmt(&g_builtin_binfmt);
+}
+
+#endif							/* CONFIG_BUILTIN */

--- a/os/binfmt/elf.c
+++ b/os/binfmt/elf.c
@@ -1,0 +1,364 @@
+/****************************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+/****************************************************************************
+ * os/binfmt/elf.c
+ *
+ *   Copyright (C) 2012, 2014 Gregory Nutt. All rights reserved.
+ *   Author: Gregory Nutt <gnutt@nuttx.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <tinyara/config.h>
+
+#include <sys/types.h>
+#include <stdint.h>
+#include <string.h>
+#include <debug.h>
+#include <errno.h>
+
+#include <tinyara/arch.h>
+#include <tinyara/binfmt/binfmt.h>
+#include <tinyara/binfmt/elf.h>
+
+#include "libelf/libelf.h"
+
+#ifdef CONFIG_ELF
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/* CONFIG_DEBUG, CONFIG_DEBUG_INFO, and CONFIG_DEBUG_BINFMT have to be
+ * defined or CONFIG_ELF_DUMPBUFFER does nothing.
+ */
+
+#if !defined(CONFIG_DEBUG_INFO) || !defined (CONFIG_DEBUG_BINFMT)
+#undef CONFIG_ELF_DUMPBUFFER
+#endif
+
+#ifndef CONFIG_ELF_STACKSIZE
+#define CONFIG_ELF_STACKSIZE 2048
+#endif
+
+#ifdef CONFIG_ELF_DUMPBUFFER
+#define elf_dumpbuffer(m,b,n) binfodumpbuffer(m,b,n)
+#else
+#define elf_dumpbuffer(m,b,n)
+#endif
+
+#ifndef MIN
+#define MIN(a,b) (a < b ? a : b)
+#endif
+
+/****************************************************************************
+ * Private Function Prototypes
+ ****************************************************************************/
+
+static int elf_loadbinary(FAR struct binary_s *binp);
+#if defined(CONFIG_DEBUG) && defined(CONFIG_DEBUG_BINFMT)
+static void elf_dumploadinfo(FAR struct elf_loadinfo_s *loadinfo);
+#endif
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+static struct binfmt_s g_elfbinfmt = {
+	NULL,						/* next */
+	elf_loadbinary,				/* load */
+	NULL,						/* unload */
+};
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: elf_dumploadinfo
+ ****************************************************************************/
+
+#if defined(CONFIG_DEBUG) && defined(CONFIG_DEBUG_BINFMT)
+static void elf_dumploadinfo(FAR struct elf_loadinfo_s *loadinfo)
+{
+	int i;
+
+	berr("LOAD_INFO:\n");
+	berr("  textalloc:    %08lx\n", (long)loadinfo->textalloc);
+	berr("  dataalloc:    %08lx\n", (long)loadinfo->dataalloc);
+	berr("  textsize:     %ld\n", (long)loadinfo->textsize);
+	berr("  datasize:     %ld\n", (long)loadinfo->datasize);
+	berr("  filelen:      %ld\n", (long)loadinfo->filelen);
+#ifdef CONFIG_BINFMT_CONSTRUCTORS
+	berr("  ctoralloc:    %08lx\n", (long)loadinfo->ctoralloc);
+	berr("  ctors:        %08lx\n", (long)loadinfo->ctors);
+	berr("  nctors:       %d\n", loadinfo->nctors);
+	berr("  dtoralloc:    %08lx\n", (long)loadinfo->dtoralloc);
+	berr("  dtors:        %08lx\n", (long)loadinfo->dtors);
+	berr("  ndtors:       %d\n", loadinfo->ndtors);
+#endif
+	berr("  filfd:        %d\n", loadinfo->filfd);
+	berr("  symtabidx:    %d\n", loadinfo->symtabidx);
+	berr("  strtabidx:    %d\n", loadinfo->strtabidx);
+
+	berr("ELF Header:\n");
+	berr("  e_ident:      %02x %02x %02x %02x\n", loadinfo->ehdr.e_ident[0], loadinfo->ehdr.e_ident[1], loadinfo->ehdr.e_ident[2], loadinfo->ehdr.e_ident[3]);
+	berr("  e_type:       %04x\n", loadinfo->ehdr.e_type);
+	berr("  e_machine:    %04x\n", loadinfo->ehdr.e_machine);
+	berr("  e_version:    %08x\n", loadinfo->ehdr.e_version);
+	berr("  e_entry:      %08lx\n", (long)loadinfo->ehdr.e_entry);
+	berr("  e_phoff:      %d\n", loadinfo->ehdr.e_phoff);
+	berr("  e_shoff:      %d\n", loadinfo->ehdr.e_shoff);
+	berr("  e_flags:      %08x\n", loadinfo->ehdr.e_flags);
+	berr("  e_ehsize:     %d\n", loadinfo->ehdr.e_ehsize);
+	berr("  e_phentsize:  %d\n", loadinfo->ehdr.e_phentsize);
+	berr("  e_phnum:      %d\n", loadinfo->ehdr.e_phnum);
+	berr("  e_shentsize:  %d\n", loadinfo->ehdr.e_shentsize);
+	berr("  e_shnum:      %d\n", loadinfo->ehdr.e_shnum);
+	berr("  e_shstrndx:   %d\n", loadinfo->ehdr.e_shstrndx);
+
+	if (loadinfo->shdr && loadinfo->ehdr.e_shnum > 0) {
+		for (i = 0; i < loadinfo->ehdr.e_shnum; i++) {
+			FAR Elf32_Shdr *shdr = &loadinfo->shdr[i];
+			berr("Sections %d:\n", i);
+			berr("  sh_name:      %08x\n", shdr->sh_name);
+			berr("  sh_type:      %08x\n", shdr->sh_type);
+			berr("  sh_flags:     %08x\n", shdr->sh_flags);
+			berr("  sh_addr:      %08x\n", shdr->sh_addr);
+			berr("  sh_offset:    %d\n", shdr->sh_offset);
+			berr("  sh_size:      %d\n", shdr->sh_size);
+			berr("  sh_link:      %d\n", shdr->sh_link);
+			berr("  sh_info:      %d\n", shdr->sh_info);
+			berr("  sh_addralign: %d\n", shdr->sh_addralign);
+			berr("  sh_entsize:   %d\n", shdr->sh_entsize);
+		}
+	}
+}
+#else
+#define elf_dumploadinfo(i)
+#endif
+
+/****************************************************************************
+ * Name: elf_dumpentrypt
+ ****************************************************************************/
+
+#ifdef CONFIG_ELF_DUMPBUFFER
+static void elf_dumpentrypt(FAR struct binary_s *binp, FAR struct elf_loadinfo_s *loadinfo)
+{
+#ifdef CONFIG_ARCH_ADDRENV
+	int ret;
+
+	/* If CONFIG_ARCH_ADDRENV=y, then the loaded ELF lies in a virtual address
+	 * space that may not be in place now.  elf_addrenv_select() will
+	 * temporarily instantiate that address space.
+	 */
+
+	ret = elf_addrenv_select(loadinfo);
+	if (ret < 0) {
+		berr("ERROR: elf_addrenv_select() failed: %d\n", ret);
+		return;
+	}
+#endif
+
+	elf_dumpbuffer("Entry code", (FAR const uint8_t *)binp->entrypt, MIN(loadinfo->textsize - loadinfo->ehdr.e_entry, 512));
+
+#ifdef CONFIG_ARCH_ADDRENV
+	/* Restore the original address environment */
+
+	ret = elf_addrenv_restore(loadinfo);
+	if (ret < 0) {
+		berr("ERROR: elf_addrenv_restore() failed: %d\n", ret);
+	}
+#endif
+}
+#else
+#define elf_dumpentrypt(b,l)
+#endif
+
+/****************************************************************************
+ * Name: elf_loadbinary
+ *
+ * Description:
+ *   Verify that the file is an ELF binary and, if so, load the ELF
+ *   binary into memory
+ *
+ ****************************************************************************/
+
+static int elf_loadbinary(FAR struct binary_s *binp)
+{
+	struct elf_loadinfo_s loadinfo;	/* Contains globals for libelf */
+	int ret;
+
+	binfo("Loading file: %s\n", binp->filename);
+
+	/* Initialize the ELF library to load the program binary. */
+
+	ret = elf_init(binp->filename, &loadinfo);
+	elf_dumploadinfo(&loadinfo);
+	if (ret != 0) {
+		berr("Failed to initialize for load of ELF program: %d\n", ret);
+		goto errout;
+	}
+
+	/* Load the program binary */
+
+	ret = elf_load(&loadinfo);
+	elf_dumploadinfo(&loadinfo);
+	if (ret != 0) {
+		berr("Failed to load ELF program binary: %d\n", ret);
+		goto errout_with_init;
+	}
+
+	/* Bind the program to the exported symbol table */
+
+	ret = elf_bind(&loadinfo, binp->exports, binp->nexports);
+	if (ret != 0) {
+		berr("Failed to bind symbols program binary: %d\n", ret);
+		goto errout_with_load;
+	}
+
+	/* Return the load information */
+
+	binp->entrypt = (main_t)(loadinfo.textalloc + loadinfo.ehdr.e_entry);
+	binp->stacksize = CONFIG_ELF_STACKSIZE;
+
+	/* Add the ELF allocation to the alloc[] only if there is no address
+	 * environment.  If there is an address environment, it will automatically
+	 * be freed when the function exits
+	 *
+	 * REVISIT:  If the module is loaded then unloaded, wouldn't this cause
+	 * a memory leak?
+	 */
+
+#ifdef CONFIG_ARCH_ADDRENV
+	/* Save the address environment in the binfmt structure.  This will be
+	 * needed when the module is executed.
+	 */
+
+	up_addrenv_clone(&loadinfo.addrenv, &binp->addrenv);
+#else
+	binp->alloc[0] = (FAR void *)loadinfo.textalloc;
+#ifdef CONFIG_BINFMT_CONSTRUCTORS
+	binp->alloc[1] = loadinfo.ctoralloc;
+	binp->alloc[2] = loadinfo.dtoralloc;
+#endif
+#endif
+
+#ifdef CONFIG_BINFMT_CONSTRUCTORS
+	/* Save information about constructors and destructors. */
+
+	binp->ctors = loadinfo.ctors;
+	binp->nctors = loadinfo.nctors;
+
+	binp->dtors = loadinfo.dtors;
+	binp->ndtors = loadinfo.ndtors;
+#endif
+
+	elf_dumpentrypt(binp, &loadinfo);
+	elf_uninit(&loadinfo);
+	return OK;
+
+errout_with_load:
+	elf_unload(&loadinfo);
+errout_with_init:
+	elf_uninit(&loadinfo);
+errout:
+	return ret;
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: elf_initialize
+ *
+ * Description:
+ *   In order to use the ELF binary format, this function must be called
+ *   during system initialization to register the ELF binary format.
+ *
+ * Returned Value:
+ *   This is a internal function so it follows the convention that
+ *   0 (OK) is returned on success and a negated errno is returned on
+ *   failure.
+ *
+ ****************************************************************************/
+
+int elf_initialize(void)
+{
+	int ret;
+
+	/* Register ourselves as a binfmt loader */
+
+	binfo("Registering ELF\n");
+
+	ret = register_binfmt(&g_elfbinfmt);
+	if (ret != 0) {
+		berr("Failed to register binfmt: %d\n", ret);
+	}
+
+	return ret;
+}
+
+/****************************************************************************
+ * Name: elf_uninitialize
+ *
+ * Description:
+ *   Unregister the ELF binary loader
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+void elf_uninitialize(void)
+{
+	(void)unregister_binfmt(&g_elfbinfmt);
+}
+
+#endif							/* CONFIG_ELF */

--- a/os/binfmt/libbuiltin/Kconfig
+++ b/os/binfmt/libbuiltin/Kconfig
@@ -1,0 +1,4 @@
+#
+# For a description of the syntax of this configuration file,
+# see kconfig-language at https://www.kernel.org/doc/Documentation/kbuild/kconfig-language.txt
+#

--- a/os/binfmt/libbuiltin/Make.defs
+++ b/os/binfmt/libbuiltin/Make.defs
@@ -1,0 +1,69 @@
+###########################################################################
+#
+# Copyright 2019 Samsung Electronics All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+#
+###########################################################################
+############################################################################
+# os/binfmt/libbuiltin/Make.defs
+#
+#   Copyright (C) 2013 Gregory Nutt. All rights reserved.
+#   Author: Gregory Nutt <gnutt@nuttx.org>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in
+#    the documentation and/or other materials provided with the
+#    distribution.
+# 3. Neither the name NuttX nor the names of its contributors may be
+#    used to endorse or promote products derived from this software
+#    without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+# OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+# AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+############################################################################
+
+ifeq ($(CONFIG_BUILTIN),y)
+
+# Builtin application interfaces
+
+BINFMT_CSRCS += builtin.c
+
+# Builtin library interfaces
+
+BINFMT_CSRCS += libbuiltin_getname.c libbuiltin_isavail.c
+
+# Hook the libbuiltin subdirectory into the build
+
+VPATH += libbuiltin
+SUBDIRS += libbuiltin
+DEPPATH += --dep-path libbuiltin
+
+endif

--- a/os/binfmt/libbuiltin/libbuiltin_getname.c
+++ b/os/binfmt/libbuiltin/libbuiltin_getname.c
@@ -1,0 +1,92 @@
+/****************************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+/****************************************************************************
+ * os/binfmt/libbuiltin/libbuiltin_getname.c
+ *
+ * Originally by:
+ *
+ *   Copyright (C) 2011 Uros Platise. All rights reserved.
+ *   Author: Uros Platise <uros.platise@isotel.eu>
+ *
+ * With subsequent updates, modifications, and general maintenance by:
+ *
+ *   Copyright (C) 2012-2013 Gregory Nutt.  All rights reserved.
+ *   Author: Gregory Nutt <gnutt@nuttx.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <tinyara/config.h>
+
+#include <tinyara/binfmt/builtin.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: builtin_getname
+ *
+ * Description:
+ *   Return the name of the application at index in the table of builtin
+ *   applications.
+ *
+ ****************************************************************************/
+
+FAR const char *builtin_getname(int index)
+{
+	FAR const struct builtin_s *builtin;
+
+	builtin = builtin_for_index(index);
+
+	if (builtin != NULL) {
+		return builtin->name;
+	}
+
+	return NULL;
+}

--- a/os/binfmt/libbuiltin/libbuiltin_isavail.c
+++ b/os/binfmt/libbuiltin/libbuiltin_isavail.c
@@ -1,0 +1,98 @@
+/****************************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+/****************************************************************************
+ * os/binfmt/libbuiltin/libbuiltin_isavail.c
+ *
+ * Originally by:
+ *
+ *   Copyright (C) 2011 Uros Platise. All rights reserved.
+ *   Author: Uros Platise <uros.platise@isotel.eu>
+ *
+ * With subsequent updates, modifications, and general maintenance by:
+ *
+ *   Copyright (C) 2012-2013 Gregory Nutt.  All rights reserved.
+ *   Author: Gregory Nutt <gnutt@nuttx.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <tinyara/config.h>
+
+#include <string.h>
+#include <limits.h>
+#include <errno.h>
+
+#include <tinyara/binfmt/builtin.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: builtin_isavail
+ *
+ * Description:
+ *   Return the index into the table of applications for the application with
+ *   the name 'appname'.
+ *
+ ****************************************************************************/
+
+int builtin_isavail(FAR const char *appname)
+{
+	FAR const char *name;
+	int i;
+
+	for (i = 0; (name = builtin_getname(i)); i++) {
+		if (!strncmp(name, appname, NAME_MAX)) {
+			return i;
+		}
+	}
+
+	set_errno(ENOENT);
+	return ERROR;
+}

--- a/os/binfmt/libelf/Kconfig
+++ b/os/binfmt/libelf/Kconfig
@@ -1,0 +1,50 @@
+#
+# For a description of the syntax of this configuration file,
+# see kconfig-language at https://www.kernel.org/doc/Documentation/kbuild/kconfig-language.txt
+#
+
+config ELF_ALIGN_LOG2
+	int "Log2 Section Alignment"
+	default 2
+	---help---
+		Align all sections to this Log2 value:  0->1, 1->2, 2->4, etc.
+
+config ELF_STACKSIZE
+	int "ELF Stack Size"
+	default 2048
+	---help---
+		This is the default stack size that will be used when starting ELF binaries.
+
+config ELF_BUFFERSIZE
+	int "ELF I/O Buffer Size"
+	default 32
+	---help---
+		This is an I/O buffer that is used to access the ELF file.  Variable length items
+		will need to be read (such as symbol names).  This is really just this initial
+		size of the buffer; it will be reallocated as necessary to hold large symbol
+		names).  Default: 32
+
+config ELF_BUFFERINCR
+	int "ELF I/O Buffer Realloc Increment"
+	default 32
+	---help---
+		This is an I/O buffer that is used to access the ELF file.  Variable length items
+		will need to be read (such as symbol names).  This value specifies the size
+		increment to use each time the buffer is reallocated.  Default: 32
+
+config ELF_DUMPBUFFER
+	bool "Dump ELF buffers"
+	default n
+	depends on DEBUG_INFO
+	---help---
+		Dump various ELF buffers for debug purposes
+
+config ELF_EXIDX_SECTNAME
+	string "ELF Section Name for Exception Index"
+	default ".ARM.exidx"
+	depends on CXX_EXCEPTION
+	---help---
+		Set the name string for the exception index section on the ELF modules to
+		be loaded by the ELF binary loader.
+
+		This is needed to support exception handling on loadable ELF modules.

--- a/os/binfmt/libelf/Make.defs
+++ b/os/binfmt/libelf/Make.defs
@@ -1,0 +1,75 @@
+###########################################################################
+#
+# Copyright 2019 Samsung Electronics All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+#
+###########################################################################
+############################################################################
+# os/binfmt/libelf/Make.defs
+#
+#   Copyright (C) 2012 Gregory Nutt. All rights reserved.
+#   Author: Gregory Nutt <gnutt@nuttx.org>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in
+#    the documentation and/or other materials provided with the
+#    distribution.
+# 3. Neither the name NuttX nor the names of its contributors may be
+#    used to endorse or promote products derived from this software
+#    without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+# OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+# AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+############################################################################
+
+ifeq ($(CONFIG_ELF),y)
+
+# ELF application interfaces
+
+BINFMT_CSRCS += elf.c
+
+# ELF library
+
+BINFMT_CSRCS += libelf_bind.c libelf_init.c libelf_addrenv.c libelf_iobuffer.c
+BINFMT_CSRCS += libelf_load.c libelf_read.c libelf_sections.c libelf_symbols.c
+BINFMT_CSRCS += libelf_uninit.c libelf_unload.c libelf_verify.c
+
+ifeq ($(CONFIG_BINFMT_CONSTRUCTORS),y)
+BINFMT_CSRCS += libelf_ctors.c libelf_dtors.c
+endif
+
+# Hook the libelf subdirectory into the build
+
+VPATH += libelf
+SUBDIRS += libelf
+DEPPATH += --dep-path libelf
+
+endif

--- a/os/binfmt/libelf/gnu-elf.ld
+++ b/os/binfmt/libelf/gnu-elf.ld
@@ -1,0 +1,146 @@
+/****************************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+/****************************************************************************
+ * os/binfmt/libelf/gnu-elf.ld
+ *
+ *   Copyright (C) 2012 Gregory Nutt. All rights reserved.
+ *   Author: Gregory Nutt <gnutt@nuttx.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+SECTIONS
+{
+  .text 0x00000000 :
+    {
+      _stext = . ;
+      *(.text)
+      *(.text.*)
+      *(.gnu.warning)
+      *(.stub)
+      *(.glue_7)
+      *(.glue_7t)
+      *(.jcr)
+
+      /* C++ support:  The .init and .fini sections contain specific logic
+       * to manage static constructors and destructors.
+       */
+
+      *(.gnu.linkonce.t.*)
+      *(.init)             /* Old ABI */
+      *(.fini)             /* Old ABI */
+      _etext = . ;
+    }
+
+  .rodata :
+    {
+      _srodata = . ;
+      *(.rodata)
+      *(.rodata1)
+      *(.rodata.*)
+      *(.gnu.linkonce.r*)
+      _erodata = . ;
+    }
+
+  .data :
+    {
+      _sdata = . ;
+      *(.data)
+      *(.data1)
+      *(.data.*)
+      *(.gnu.linkonce.d*)
+      _edata = . ;
+    }
+
+  /* C++ support. For each global and static local C++ object,
+   * GCC creates a small subroutine to construct the object. Pointers
+   * to these routines (not the routines themselves) are stored as
+   * simple, linear arrays in the .ctors section of the object file.
+   * Similarly, pointers to global/static destructor routines are
+   * stored in .dtors.
+   */
+
+  .ctors :
+    {
+      _sctors = . ;
+      *(.ctors)       /* Old ABI:  Unallocated */
+      *(.init_array)  /* New ABI:  Allocated */
+      _ectors = . ;
+    }
+
+  .dtors :
+    {
+      _sdtors = . ;
+      *(.dtors)       /* Old ABI:  Unallocated */
+      *(.fini_array)  /* New ABI:  Allocated */
+      _edtors = . ;
+    }
+
+  .bss :
+    {
+      _sbss = . ;
+      *(.bss)
+      *(.bss.*)
+      *(.sbss)
+      *(.sbss.*)
+      *(.gnu.linkonce.b*)
+      *(COMMON)
+      _ebss = . ;
+    }
+
+    /* Stabs debugging sections.    */
+
+    .stab 0 : { *(.stab) }
+    .stabstr 0 : { *(.stabstr) }
+    .stab.excl 0 : { *(.stab.excl) }
+    .stab.exclstr 0 : { *(.stab.exclstr) }
+    .stab.index 0 : { *(.stab.index) }
+    .stab.indexstr 0 : { *(.stab.indexstr) }
+    .comment 0 : { *(.comment) }
+    .debug_abbrev 0 : { *(.debug_abbrev) }
+    .debug_info 0 : { *(.debug_info) }
+    .debug_line 0 : { *(.debug_line) }
+    .debug_pubnames 0 : { *(.debug_pubnames) }
+    .debug_aranges 0 : { *(.debug_aranges) }
+}

--- a/os/binfmt/libelf/libelf.h
+++ b/os/binfmt/libelf/libelf.h
@@ -1,0 +1,360 @@
+/****************************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+/****************************************************************************
+ * os/binfmt/libelf/libelf.h
+ *
+ *   Copyright (C) 2012, 2014 Gregory Nutt. All rights reserved.
+ *   Author: Gregory Nutt <gnutt@nuttx.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#ifndef __BINFMT_LIBELF_LIBELF_H
+#define __BINFMT_LIBELF_LIBELF_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <tinyara/config.h>
+
+#include <sys/types.h>
+
+#include <tinyara/arch.h>
+#include <tinyara/binfmt/elf.h>
+
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: elf_verifyheader
+ *
+ * Description:
+ *   Given the header from a possible ELF executable, verify that it is
+ *   an ELF executable.
+ *
+ * Returned Value:
+ *   0 (OK) is returned on success and a negated errno is returned on
+ *   failure.
+ *
+ ****************************************************************************/
+
+int elf_verifyheader(FAR const Elf32_Ehdr *header);
+
+/****************************************************************************
+ * Name: elf_read
+ *
+ * Description:
+ *   Read 'readsize' bytes from the object file at 'offset'.  The data is
+ *   read into 'buffer.' If 'buffer' is part of the ELF address environment,
+ *   then the caller is responsibile for assuring that that address
+ *   environment is in place before calling this function (i.e., that
+ *   elf_addrenv_select() has been called if CONFIG_ARCH_ADDRENV=y).
+ *
+ * Returned Value:
+ *   0 (OK) is returned on success and a negated errno is returned on
+ *   failure.
+ *
+ ****************************************************************************/
+
+int elf_read(FAR struct elf_loadinfo_s *loadinfo, FAR uint8_t *buffer, size_t readsize, off_t offset);
+
+/****************************************************************************
+ * Name: elf_loadshdrs
+ *
+ * Description:
+ *   Loads section headers into memory.
+ *
+ * Returned Value:
+ *   0 (OK) is returned on success and a negated errno is returned on
+ *   failure.
+ *
+ ****************************************************************************/
+
+int elf_loadshdrs(FAR struct elf_loadinfo_s *loadinfo);
+
+/****************************************************************************
+ * Name: elf_findsection
+ *
+ * Description:
+ *   A section by its name.
+ *
+ * Input Parameters:
+ *   loadinfo - Load state information
+ *   sectname - Name of the section to find
+ *
+ * Returned Value:
+ *   On success, the index to the section is returned; A negated errno value
+ *   is returned on failure.
+ *
+ ****************************************************************************/
+
+int elf_findsection(FAR struct elf_loadinfo_s *loadinfo, FAR const char *sectname);
+
+/****************************************************************************
+ * Name: elf_findsymtab
+ *
+ * Description:
+ *   Find the symbol table section.
+ *
+ * Returned Value:
+ *   0 (OK) is returned on success and a negated errno is returned on
+ *   failure.
+ *
+ ****************************************************************************/
+
+int elf_findsymtab(FAR struct elf_loadinfo_s *loadinfo);
+
+/****************************************************************************
+ * Name: elf_readsym
+ *
+ * Description:
+ *   Read the ELF symbol structure at the specfied index into memory.
+ *
+ * Input Parameters:
+ *   loadinfo - Load state information
+ *   index    - Symbol table index
+ *   sym      - Location to return the table entry
+ *
+ * Returned Value:
+ *   0 (OK) is returned on success and a negated errno is returned on
+ *   failure.
+ *
+ ****************************************************************************/
+
+int elf_readsym(FAR struct elf_loadinfo_s *loadinfo, int index, FAR Elf32_Sym *sym);
+
+/****************************************************************************
+ * Name: elf_symvalue
+ *
+ * Description:
+ *   Get the value of a symbol.  The updated value of the symbol is returned
+ *   in the st_value field of the symbol table entry.
+ *
+ * Input Parameters:
+ *   loadinfo - Load state information
+ *   sym      - Symbol table entry (value might be undefined)
+ *   exports  - The symbol table to use for resolving undefined symbols.
+ *   nexports - Number of symbols in the symbol table.
+ *
+ * Returned Value:
+ *   0 (OK) is returned on success and a negated errno is returned on
+ *   failure.
+ *
+ *   EINVAL - There is something inconsistent in the symbol table (should only
+ *            happen if the file is corrupted)
+ *   ENOSYS - Symbol lies in common
+ *   ESRCH  - Symbol has no name
+ *   ENOENT - Symbol undefined and not provided via a symbol table
+ *
+ ****************************************************************************/
+
+int elf_symvalue(FAR struct elf_loadinfo_s *loadinfo, FAR Elf32_Sym *sym, FAR const struct symtab_s *exports, int nexports);
+
+/****************************************************************************
+ * Name: elf_freebuffers
+ *
+ * Description:
+ *  Release all working buffers.
+ *
+ * Returned Value:
+ *   0 (OK) is returned on success and a negated errno is returned on
+ *   failure.
+ *
+ ****************************************************************************/
+
+int elf_freebuffers(FAR struct elf_loadinfo_s *loadinfo);
+
+/****************************************************************************
+ * Name: elf_allocbuffer
+ *
+ * Description:
+ *   Perform the initial allocation of the I/O buffer, if it has not already
+ *   been allocated.
+ *
+ * Returned Value:
+ *   0 (OK) is returned on success and a negated errno is returned on
+ *   failure.
+ *
+ ****************************************************************************/
+
+int elf_allocbuffer(FAR struct elf_loadinfo_s *loadinfo);
+
+/****************************************************************************
+ * Name: elf_reallocbuffer
+ *
+ * Description:
+ *   Increase the size of I/O buffer by the specified buffer increment.
+ *
+ * Returned Value:
+ *   0 (OK) is returned on success and a negated errno is returned on
+ *   failure.
+ *
+ ****************************************************************************/
+
+int elf_reallocbuffer(FAR struct elf_loadinfo_s *loadinfo, size_t increment);
+
+/****************************************************************************
+ * Name: elf_loadctors
+ *
+ * Description:
+ *   Find C++ static constructors.
+ *
+ * Input Parameters:
+ *   loadinfo - Load state information
+ *
+ * Returned Value:
+ *   0 (OK) is returned on success and a negated errno is returned on
+ *   failure.
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_BINFMT_CONSTRUCTORS
+int elf_loadctors(FAR struct elf_loadinfo_s *loadinfo);
+#endif
+
+/****************************************************************************
+ * Name: elf_loaddtors
+ *
+ * Description:
+ *  Load pointers to static destructors into an in-memory array.
+ *
+ * Input Parameters:
+ *   loadinfo - Load state information
+ *
+ * Returned Value:
+ *   0 (OK) is returned on success and a negated errno is returned on
+ *   failure.
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_BINFMT_CONSTRUCTORS
+int elf_loaddtors(FAR struct elf_loadinfo_s *loadinfo);
+#endif
+
+/****************************************************************************
+ * Name: elf_addrenv_alloc
+ *
+ * Description:
+ *   Allocate memory for the ELF image (textalloc and dataalloc). If
+ *   CONFIG_ARCH_ADDRENV=n, textalloc will be allocated using kmm_zalloc() and
+ *   dataalloc will be a offset from textalloc.  If CONFIG_ARCH_ADDRENV-y, then
+ *   textalloc and dataalloc will be allocated using up_addrenv_create().  In
+ *   either case, there will be a unique instance of textalloc and dataalloc
+ *   (and stack) for each instance of a process.
+ *
+ * Input Parameters:
+ *   loadinfo - Load state information
+ *   textsize - The size (in bytes) of the .text address environment needed
+ *     for the ELF image (read/execute).
+ *   datasize - The size (in bytes) of the .bss/.data address environment
+ *     needed for the ELF image (read/write).
+ *   heapsize - The initial size (in bytes) of the heap address environment
+ *     needed by the task.  This region may be read/write only.
+ *
+ * Returned Value:
+ *   Zero (OK) on success; a negated errno value on failure.
+ *
+ ****************************************************************************/
+
+int elf_addrenv_alloc(FAR struct elf_loadinfo_s *loadinfo, size_t textsize, size_t datasize, size_t heapsize);
+
+/****************************************************************************
+ * Name: elf_addrenv_select
+ *
+ * Description:
+ *   Temporarily select the task's address environment.
+ *
+ * Input Parameters:
+ *   loadinfo - Load state information
+ *
+ * Returned Value:
+ *   Zero (OK) on success; a negated errno value on failure.
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_ARCH_ADDRENV
+#define elf_addrenv_select(l) up_addrenv_select(&(l)->addrenv, &(l)->oldenv)
+#endif
+
+/****************************************************************************
+ * Name: elf_addrenv_restore
+ *
+ * Description:
+ *   Restore the address environment before elf_addrenv_select() was called..
+ *
+ * Input Parameters:
+ *   loadinfo - Load state information
+ *
+ * Returned Value:
+ *   Zero (OK) on success; a negated errno value on failure.
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_ARCH_ADDRENV
+#define elf_addrenv_restore(l) up_addrenv_restore(&(l)->oldenv)
+#endif
+
+/****************************************************************************
+ * Name: elf_addrenv_free
+ *
+ * Description:
+ *   Release the address environment previously created by
+ *   elf_addrenv_alloc().  This function  is called only under certain error
+ *   conditions after the module has been loaded but not yet started.
+ *   After the module has been started, the address environment will
+ *   automatically be freed when the module exits.
+ *
+ * Input Parameters:
+ *   loadinfo - Load state information
+ *
+ * Returned Value:
+ *   None.
+ *
+ ****************************************************************************/
+
+void elf_addrenv_free(FAR struct elf_loadinfo_s *loadinfo);
+
+#endif							/* __BINFMT_LIBELF_LIBELF_H */

--- a/os/binfmt/libelf/libelf_addrenv.c
+++ b/os/binfmt/libelf/libelf_addrenv.c
@@ -1,0 +1,200 @@
+/****************************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+/****************************************************************************
+ * os/binfmt/libelf/libelf_addrenv.c
+ *
+ *   Copyright (C) 2012 Gregory Nutt. All rights reserved.
+ *   Author: Gregory Nutt <gnutt@nuttx.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <tinyara/config.h>
+
+#include <errno.h>
+#include <debug.h>
+
+#include <tinyara/arch.h>
+#include <tinyara/kmalloc.h>
+
+#include "libelf.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Constant Data
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: elf_addrenv_alloc
+ *
+ * Description:
+ *   Allocate memory for the ELF image (textalloc and dataalloc). If
+ *   CONFIG_ARCH_ADDRENV=n, textalloc will be allocated using kmm_zalloc() and
+ *   dataalloc will be a offset from textalloc.  If CONFIG_ARCH_ADDRENV-y, then
+ *   textalloc and dataalloc will be allocated using up_addrenv_create().  In
+ *   either case, there will be a unique instance of textalloc and dataalloc
+ *   (and stack) for each instance of a process.
+ *
+ * Input Parameters:
+ *   loadinfo - Load state information
+ *   textsize - The size (in bytes) of the .text address environment needed
+ *     for the ELF image (read/execute).
+ *   datasize - The size (in bytes) of the .bss/.data address environment
+ *     needed for the ELF image (read/write).
+ *   heapsize - The initial size (in bytes) of the heap address environment
+ *     needed by the task.  This region may be read/write only.
+ *
+ * Returned Value:
+ *   Zero (OK) on success; a negated errno value on failure.
+ *
+ ****************************************************************************/
+
+int elf_addrenv_alloc(FAR struct elf_loadinfo_s *loadinfo, size_t textsize, size_t datasize, size_t heapsize)
+{
+#ifdef CONFIG_ARCH_ADDRENV
+	FAR void *vtext;
+	FAR void *vdata;
+	int ret;
+
+	/* Create an address environment for the new ELF task */
+
+	ret = up_addrenv_create(textsize, datasize, heapsize, &loadinfo->addrenv);
+	if (ret < 0) {
+		berr("ERROR: up_addrenv_create failed: %d\n", ret);
+		return ret;
+	}
+
+	/* Get the virtual address associated with the start of the address
+	 * environment.  This is the base address that we will need to use to
+	 * access the ELF image (but only if the address environment has been
+	 * selected.
+	 */
+
+	ret = up_addrenv_vtext(&loadinfo->addrenv, &vtext);
+	if (ret < 0) {
+		berr("ERROR: up_addrenv_vtext failed: %d\n", ret);
+		return ret;
+	}
+
+	ret = up_addrenv_vdata(&loadinfo->addrenv, textsize, &vdata);
+	if (ret < 0) {
+		berr("ERROR: up_addrenv_vdata failed: %d\n", ret);
+		return ret;
+	}
+
+	loadinfo->textalloc = (uintptr_t) vtext;
+	loadinfo->dataalloc = (uintptr_t) vdata;
+	return OK;
+#else
+	/* Allocate memory to hold the ELF image */
+
+	loadinfo->textalloc = (uintptr_t) kumm_malloc(textsize + datasize);
+	if (!loadinfo->textalloc) {
+		return -ENOMEM;
+	}
+
+	loadinfo->dataalloc = loadinfo->textalloc + textsize;
+	return OK;
+#endif
+}
+
+/****************************************************************************
+ * Name: elf_addrenv_free
+ *
+ * Description:
+ *   Release the address environment previously created by
+ *   elf_addrenv_alloc().  This function  is called only under certain error
+ *   conditions after the module has been loaded but not yet started.
+ *   After the module has been started, the address environment will
+ *   automatically be freed when the module exits.
+ *
+ * Input Parameters:
+ *   loadinfo - Load state information
+ *
+ * Returned Value:
+ *   None.
+ *
+ ****************************************************************************/
+
+void elf_addrenv_free(FAR struct elf_loadinfo_s *loadinfo)
+{
+#ifdef CONFIG_ARCH_ADDRENV
+	int ret;
+
+	/* Free the address environment */
+
+	ret = up_addrenv_destroy(&loadinfo->addrenv);
+	if (ret < 0) {
+		berr("ERROR: up_addrenv_destroy failed: %d\n", ret);
+	}
+#else
+	/* If there is an allocation for the ELF image, free it */
+
+	if (loadinfo->textalloc != 0) {
+		kumm_free((FAR void *)loadinfo->textalloc);
+	}
+#endif
+
+	/* Clear out all indications of the allocated address environment */
+
+	loadinfo->textalloc = 0;
+	loadinfo->dataalloc = 0;
+	loadinfo->textsize = 0;
+	loadinfo->datasize = 0;
+}

--- a/os/binfmt/libelf/libelf_bind.c
+++ b/os/binfmt/libelf/libelf_bind.c
@@ -1,0 +1,352 @@
+/****************************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+/****************************************************************************
+ * os/binfmt/libelf/libelf_bind.c
+ *
+ *   Copyright (C) 2012, 2014 Gregory Nutt. All rights reserved.
+ *   Author: Gregory Nutt <gnutt@nuttx.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <tinyara/config.h>
+
+#include <stdint.h>
+#include <string.h>
+#include <errno.h>
+#include <assert.h>
+#include <debug.h>
+
+#include <tinyara/elf.h>
+#include <tinyara/binfmt/elf.h>
+#include <tinyara/binfmt/symtab.h>
+
+#include "libelf.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/* CONFIG_DEBUG_FEATURES, CONFIG_DEBUG_INFO, and CONFIG_DEBUG_BINFMT have to be
+ * defined or CONFIG_ELF_DUMPBUFFER does nothing.
+ */
+
+#if !defined(CONFIG_DEBUG_INFO) || !defined (CONFIG_DEBUG_BINFMT)
+#undef CONFIG_ELF_DUMPBUFFER
+#endif
+
+#ifdef CONFIG_ELF_DUMPBUFFER
+#define elf_dumpbuffer(m,b,n) binfodumpbuffer(m,b,n)
+#else
+#define elf_dumpbuffer(m,b,n)
+#endif
+
+/****************************************************************************
+ * Private Types
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: elf_readrel
+ *
+ * Description:
+ *   Read the ELF32_Rel structure into memory.
+ *
+ ****************************************************************************/
+
+static inline int elf_readrel(FAR struct elf_loadinfo_s *loadinfo, FAR const Elf32_Shdr *relsec, int index, FAR Elf32_Rel *rel)
+{
+	off_t offset;
+
+	/* Verify that the symbol table index lies within symbol table */
+
+	if (index < 0 || index > (relsec->sh_size / sizeof(Elf32_Rel))) {
+		berr("Bad relocation symbol index: %d\n", index);
+		return -EINVAL;
+	}
+
+	/* Get the file offset to the symbol table entry */
+
+	offset = relsec->sh_offset + sizeof(Elf32_Rel) * index;
+
+	/* And, finally, read the symbol table entry into memory */
+
+	return elf_read(loadinfo, (FAR uint8_t *)rel, sizeof(Elf32_Rel), offset);
+}
+
+/****************************************************************************
+ * Name: elf_relocate and elf_relocateadd
+ *
+ * Description:
+ *   Perform all relocations associated with a section.
+ *
+ * Returned Value:
+ *   0 (OK) is returned on success and a negated errno is returned on
+ *   failure.
+ *
+ ****************************************************************************/
+
+static int elf_relocate(FAR struct elf_loadinfo_s *loadinfo, int relidx, FAR const struct symtab_s *exports, int nexports)
+{
+	FAR Elf32_Shdr *relsec = &loadinfo->shdr[relidx];
+	FAR Elf32_Shdr *dstsec = &loadinfo->shdr[relsec->sh_info];
+	Elf32_Rel rel;
+	Elf32_Sym sym;
+	FAR Elf32_Sym *psym;
+	uintptr_t addr;
+	int symidx;
+	int ret;
+	int i;
+
+	/* Examine each relocation in the section.  'relsec' is the section
+	 * containing the relations.  'dstsec' is the section containing the data
+	 * to be relocated.
+	 */
+
+	for (i = 0; i < relsec->sh_size / sizeof(Elf32_Rel); i++) {
+		psym = &sym;
+
+		/* Read the relocation entry into memory */
+
+		ret = elf_readrel(loadinfo, relsec, i, &rel);
+		if (ret < 0) {
+			berr("Section %d reloc %d: Failed to read relocation entry: %d\n", relidx, i, ret);
+			return ret;
+		}
+
+		/* Get the symbol table index for the relocation.  This is contained
+		 * in a bit-field within the r_info element.
+		 */
+
+		symidx = ELF32_R_SYM(rel.r_info);
+
+		/* Read the symbol table entry into memory */
+
+		ret = elf_readsym(loadinfo, symidx, &sym);
+		if (ret < 0) {
+			berr("Section %d reloc %d: Failed to read symbol[%d]: %d\n", relidx, i, symidx, ret);
+			return ret;
+		}
+
+		/* Get the value of the symbol (in sym.st_value) */
+
+		ret = elf_symvalue(loadinfo, &sym, exports, nexports);
+		if (ret < 0) {
+			/* The special error -ESRCH is returned only in one condition:  The
+			 * symbol has no name.
+			 *
+			 * There are a few relocations for a few architectures that do
+			 * no depend upon a named symbol.  We don't know if that is the
+			 * case here, but we will use a NULL symbol pointer to indicate
+			 * that case to up_relocate().  That function can then do what
+			 * is best.
+			 */
+
+			if (ret == -ESRCH) {
+				berr("Section %d reloc %d: Undefined symbol[%d] has no name: %d\n", relidx, i, symidx, ret);
+				psym = NULL;
+			} else {
+				berr("Section %d reloc %d: Failed to get value of symbol[%d]: %d\n", relidx, i, symidx, ret);
+				return ret;
+			}
+		}
+
+		/* Calculate the relocation address. */
+
+		if (rel.r_offset < 0 || rel.r_offset > dstsec->sh_size - sizeof(uint32_t)) {
+			berr("Section %d reloc %d: Relocation address out of range, offset %d size %d\n", relidx, i, rel.r_offset, dstsec->sh_size);
+			return -EINVAL;
+		}
+
+		addr = dstsec->sh_addr + rel.r_offset;
+
+		/* Now perform the architecture-specific relocation */
+
+		ret = up_relocate(&rel, psym, addr);
+		if (ret < 0) {
+			berr("ERROR: Section %d reloc %d: Relocation failed: %d\n", relidx, i, ret);
+			return ret;
+		}
+	}
+
+	return OK;
+}
+
+static int elf_relocateadd(FAR struct elf_loadinfo_s *loadinfo, int relidx, FAR const struct symtab_s *exports, int nexports)
+{
+	berr("Not implemented\n");
+	return -ENOSYS;
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: elf_bind
+ *
+ * Description:
+ *   Bind the imported symbol names in the loaded module described by
+ *   'loadinfo' using the exported symbol values provided by 'symtab'.
+ *
+ * Returned Value:
+ *   0 (OK) is returned on success and a negated errno is returned on
+ *   failure.
+ *
+ ****************************************************************************/
+
+int elf_bind(FAR struct elf_loadinfo_s *loadinfo, FAR const struct symtab_s *exports, int nexports)
+{
+#ifdef CONFIG_ARCH_ADDRENV
+	int status;
+#endif
+	int ret;
+	int i;
+
+	/* Find the symbol and string tables */
+
+	ret = elf_findsymtab(loadinfo);
+	if (ret < 0) {
+		return ret;
+	}
+
+	/* Allocate an I/O buffer.  This buffer is used by elf_symname() to
+	 * accumulate the variable length symbol name.
+	 */
+
+	ret = elf_allocbuffer(loadinfo);
+	if (ret < 0) {
+		berr("elf_allocbuffer failed: %d\n", ret);
+		return ret;
+	}
+#ifdef CONFIG_ARCH_ADDRENV
+	/* If CONFIG_ARCH_ADDRENV=y, then the loaded ELF lies in a virtual address
+	 * space that may not be in place now.  elf_addrenv_select() will
+	 * temporarily instantiate that address space.
+	 */
+
+	ret = elf_addrenv_select(loadinfo);
+	if (ret < 0) {
+		berr("ERROR: elf_addrenv_select() failed: %d\n", ret);
+		return ret;
+	}
+#endif
+
+	/* Process relocations in every allocated section */
+
+	for (i = 1; i < loadinfo->ehdr.e_shnum; i++) {
+		/* Get the index to the relocation section */
+
+		int infosec = loadinfo->shdr[i].sh_info;
+		if (infosec >= loadinfo->ehdr.e_shnum) {
+			continue;
+		}
+
+		/* Make sure that the section is allocated.  We can't relocated
+		 * sections that were not loaded into memory.
+		 */
+
+		if ((loadinfo->shdr[infosec].sh_flags & SHF_ALLOC) == 0) {
+			continue;
+		}
+
+		/* Process the relocations by type */
+
+		if (loadinfo->shdr[i].sh_type == SHT_REL) {
+			ret = elf_relocate(loadinfo, i, exports, nexports);
+		} else if (loadinfo->shdr[i].sh_type == SHT_RELA) {
+			ret = elf_relocateadd(loadinfo, i, exports, nexports);
+		}
+
+		if (ret < 0) {
+			break;
+		}
+	}
+
+#if defined(CONFIG_ARCH_ADDRENV)
+	/* Ensure that the I and D caches are coherent before starting the newly
+	 * loaded module by cleaning the D cache (i.e., flushing the D cache
+	 * contents to memory and invalidating the I cache).
+	 */
+
+#if 0							/* REVISIT... has some problems */
+	(void)up_addrenv_coherent(&loadinfo->addrenv);
+#else
+	up_coherent_dcache(loadinfo->textalloc, loadinfo->textsize);
+	up_coherent_dcache(loadinfo->dataalloc, loadinfo->datasize);
+#endif
+
+	/* Restore the original address environment */
+
+	status = elf_addrenv_restore(loadinfo);
+	if (status < 0) {
+		berr("ERROR: elf_addrenv_restore() failed: %d\n", status);
+		if (ret == OK) {
+			ret = status;
+		}
+	}
+#elif defined(CONFIG_ARCH_HAVE_COHERENT_DCACHE)
+	/* Ensure that the I and D caches are coherent before starting the newly
+	 * loaded module by cleaning the D cache (i.e., flushing the D cache
+	 * contents to memory and invalidating the I cache).
+	 */
+
+	up_coherent_dcache(loadinfo->textalloc, loadinfo->textsize);
+	up_coherent_dcache(loadinfo->dataalloc, loadinfo->datasize);
+
+#endif
+
+	return ret;
+}

--- a/os/binfmt/libelf/libelf_ctors.c
+++ b/os/binfmt/libelf/libelf_ctors.c
@@ -1,0 +1,220 @@
+/****************************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+/****************************************************************************
+ * os/binfmt/libelf/libelf_ctors.c
+ *
+ *   Copyright (C) 2012 Gregory Nutt. All rights reserved.
+ *   Author: Gregory Nutt <gnutt@nuttx.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <tinyara/config.h>
+
+#include <string.h>
+#include <errno.h>
+#include <assert.h>
+#include <debug.h>
+
+#include <tinyara/kmalloc.h>
+#include <tinyara/binfmt/elf.h>
+
+#include "libelf.h"
+
+#ifdef CONFIG_BINFMT_CONSTRUCTORS
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Types
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Constant Data
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: elf_loadctors
+ *
+ * Description:
+ *  Load pointers to static constructors into an in-memory array.
+ *
+ * Input Parameters:
+ *   loadinfo - Load state information
+ *
+ * Returned Value:
+ *   0 (OK) is returned on success and a negated errno is returned on
+ *   failure.
+ *
+ ****************************************************************************/
+
+int elf_loadctors(FAR struct elf_loadinfo_s *loadinfo)
+{
+	FAR Elf32_Shdr *shdr;
+	size_t ctorsize;
+	int ctoridx;
+	int ret;
+	int i;
+
+	DEBUGASSERT(loadinfo->ctors == NULL);
+
+	/* Allocate an I/O buffer if necessary.  This buffer is used by
+	 * elf_sectname() to accumulate the variable length symbol name.
+	 */
+
+	ret = elf_allocbuffer(loadinfo);
+	if (ret < 0) {
+		berr("elf_allocbuffer failed: %d\n", ret);
+		return -ENOMEM;
+	}
+
+	/* Find the index to the section named ".ctors."  NOTE:  On old ABI system,
+	 * .ctors is the name of the section containing the list of constructors;
+	 * On newer systems, the similar section is called .init_array.  It is
+	 * expected that the linker script will force the section name to be ".ctors"
+	 * in either case.
+	 */
+
+	ctoridx = elf_findsection(loadinfo, ".ctors");
+	if (ctoridx < 0) {
+		/* This may not be a failure.  -ENOENT indicates that the file has no
+		 * static constructor section.
+		 */
+
+		binfo("elf_findsection .ctors section failed: %d\n", ctoridx);
+		return ret == -ENOENT ? OK : ret;
+	}
+
+	/* Now we can get a pointer to the .ctor section in the section header
+	 * table.
+	 */
+
+	shdr = &loadinfo->shdr[ctoridx];
+
+	/* Get the size of the .ctor section and the number of constructors that
+	 * will need to be called.
+	 */
+
+	ctorsize = shdr->sh_size;
+	loadinfo->nctors = ctorsize / sizeof(binfmt_ctor_t);
+
+	binfo("ctoridx=%d ctorsize=%d sizeof(binfmt_ctor_t)=%d nctors=%d\n", ctoridx, ctorsize, sizeof(binfmt_ctor_t), loadinfo->nctors);
+
+	/* Check if there are any constructors.  It is not an error if there
+	 * are none.
+	 */
+
+	if (loadinfo->nctors > 0) {
+		/* Check an assumption that we made above */
+
+		DEBUGASSERT(shdr->sh_size == loadinfo->nctors * sizeof(binfmt_ctor_t));
+
+		/* In the old ABI, the .ctors section is not allocated.  In that case,
+		 * we need to allocate memory to hold the .ctors and then copy the
+		 * from the file into the allocated memory.
+		 *
+		 * SHF_ALLOC indicates that the section requires memory during
+		 * execution.
+		 */
+
+		if ((shdr->sh_flags & SHF_ALLOC) == 0) {
+			/* Allocate memory to hold a copy of the .ctor section */
+
+			loadinfo->ctoralloc = (binfmt_ctor_t *)kumm_malloc(ctorsize);
+			if (!loadinfo->ctoralloc) {
+				berr("Failed to allocate memory for .ctors\n");
+				return -ENOMEM;
+			}
+
+			loadinfo->ctors = (binfmt_ctor_t *)loadinfo->ctoralloc;
+
+			/* Read the section header table into memory */
+
+			ret = elf_read(loadinfo, (FAR uint8_t *)loadinfo->ctors, ctorsize, shdr->sh_offset);
+			if (ret < 0) {
+				berr("Failed to allocate .ctors: %d\n", ret);
+				return ret;
+			}
+
+			/* Fix up all of the .ctor addresses.  Since the addresses
+			 * do not lie in allocated memory, there will be no relocation
+			 * section for them.
+			 */
+
+			for (i = 0; i < loadinfo->nctors; i++) {
+				FAR uintptr_t *ptr = (uintptr_t *)((FAR void *)(&loadinfo->ctors)[i]);
+
+				binfo("ctor %d: %08lx + %08lx = %08lx\n", i, *ptr, (unsigned long)loadinfo->textalloc, (unsigned long)(*ptr + loadinfo->textalloc));
+
+				*ptr += loadinfo->textalloc;
+			}
+		} else {
+
+			/* Save the address of the .ctors (actually, .init_array) where it was
+			 * loaded into memory.  Since the .ctors lie in allocated memory, they
+			 * will be relocated via the normal mechanism.
+			 */
+
+			loadinfo->ctors = (binfmt_ctor_t *)shdr->sh_addr;
+		}
+	}
+
+	return OK;
+}
+
+#endif							/* CONFIG_BINFMT_CONSTRUCTORS */

--- a/os/binfmt/libelf/libelf_dtors.c
+++ b/os/binfmt/libelf/libelf_dtors.c
@@ -1,0 +1,220 @@
+/****************************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+/****************************************************************************
+ * os/binfmt/libelf/libelf_dtors.c
+ *
+ *   Copyright (C) 2012 Gregory Nutt. All rights reserved.
+ *   Author: Gregory Nutt <gnutt@nuttx.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <tinyara/config.h>
+
+#include <string.h>
+#include <errno.h>
+#include <assert.h>
+#include <debug.h>
+
+#include <tinyara/kmalloc.h>
+#include <tinyara/binfmt/elf.h>
+
+#include "libelf.h"
+
+#ifdef CONFIG_BINFMT_CONSTRUCTORS
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Types
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Constant Data
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: elf_loaddtors
+ *
+ * Description:
+ *  Load pointers to static destructors into an in-memory array.
+ *
+ * Input Parameters:
+ *   loadinfo - Load state information
+ *
+ * Returned Value:
+ *   0 (OK) is returned on success and a negated errno is returned on
+ *   failure.
+ *
+ ****************************************************************************/
+
+int elf_loaddtors(FAR struct elf_loadinfo_s *loadinfo)
+{
+	FAR Elf32_Shdr *shdr;
+	size_t dtorsize;
+	int dtoridx;
+	int ret;
+	int i;
+
+	DEBUGASSERT(loadinfo->dtors == NULL);
+
+	/* Allocate an I/O buffer if necessary.  This buffer is used by
+	 * elf_sectname() to accumulate the variable length symbol name.
+	 */
+
+	ret = elf_allocbuffer(loadinfo);
+	if (ret < 0) {
+		berr("elf_allocbuffer failed: %d\n", ret);
+		return -ENOMEM;
+	}
+
+	/* Find the index to the section named ".dtors."  NOTE:  On old ABI system,
+	 * .dtors is the name of the section containing the list of destructors;
+	 * On newer systems, the similar section is called .fini_array.  It is
+	 * expected that the linker script will force the section name to be ".dtors"
+	 * in either case.
+	 */
+
+	dtoridx = elf_findsection(loadinfo, ".dtors");
+	if (dtoridx < 0) {
+		/* This may not be a failure.  -ENOENT indicates that the file has no
+		 * static destructor section.
+		 */
+
+		binfo("elf_findsection .dtors section failed: %d\n", dtoridx);
+		return ret == -ENOENT ? OK : ret;
+	}
+
+	/* Now we can get a pointer to the .dtor section in the section header
+	 * table.
+	 */
+
+	shdr = &loadinfo->shdr[dtoridx];
+
+	/* Get the size of the .dtor section and the number of destructors that
+	 * will need to be called.
+	 */
+
+	dtorsize = shdr->sh_size;
+	loadinfo->ndtors = dtorsize / sizeof(binfmt_dtor_t);
+
+	binfo("dtoridx=%d dtorsize=%d sizeof(binfmt_dtor_t)=%d ndtors=%d\n", dtoridx, dtorsize, sizeof(binfmt_dtor_t), loadinfo->ndtors);
+
+	/* Check if there are any destructors.  It is not an error if there
+	 * are none.
+	 */
+
+	if (loadinfo->ndtors > 0) {
+		/* Check an assumption that we made above */
+
+		DEBUGASSERT(shdr->sh_size == loadinfo->ndtors * sizeof(binfmt_dtor_t));
+
+		/* In the old ABI, the .dtors section is not allocated.  In that case,
+		 * we need to allocate memory to hold the .dtors and then copy the
+		 * from the file into the allocated memory.
+		 *
+		 * SHF_ALLOC indicates that the section requires memory during
+		 * execution.
+		 */
+
+		if ((shdr->sh_flags & SHF_ALLOC) == 0) {
+			/* Allocate memory to hold a copy of the .dtor section */
+
+			loadinfo->dtoralloc = (binfmt_dtor_t *)kumm_malloc(dtorsize);
+			if (!loadinfo->dtoralloc) {
+				berr("Failed to allocate memory for .dtors\n");
+				return -ENOMEM;
+			}
+
+			loadinfo->dtors = (binfmt_dtor_t *)loadinfo->dtoralloc;
+
+			/* Read the section header table into memory */
+
+			ret = elf_read(loadinfo, (FAR uint8_t *)loadinfo->dtors, dtorsize, shdr->sh_offset);
+			if (ret < 0) {
+				berr("Failed to allocate .dtors: %d\n", ret);
+				return ret;
+			}
+
+			/* Fix up all of the .dtor addresses.  Since the addresses
+			 * do not lie in allocated memory, there will be no relocation
+			 * section for them.
+			 */
+
+			for (i = 0; i < loadinfo->ndtors; i++) {
+				FAR uintptr_t *ptr = (uintptr_t *)((FAR void *)(&loadinfo->dtors)[i]);
+
+				binfo("dtor %d: %08lx + %08lx = %08lx\n", i, *ptr, (unsigned long)loadinfo->textalloc, (unsigned long)(*ptr + loadinfo->textalloc));
+
+				*ptr += loadinfo->textalloc;
+			}
+		} else {
+
+			/* Save the address of the .dtors (actually, .init_array) where it was
+			 * loaded into memory.  Since the .dtors lie in allocated memory, they
+			 * will be relocated via the normal mechanism.
+			 */
+
+			loadinfo->dtors = (binfmt_dtor_t *)shdr->sh_addr;
+		}
+	}
+
+	return OK;
+}
+
+#endif							/* CONFIG_BINFMT_CONSTRUCTORS */

--- a/os/binfmt/libelf/libelf_init.c
+++ b/os/binfmt/libelf/libelf_init.c
@@ -1,0 +1,211 @@
+/****************************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+/****************************************************************************
+ * os/binfmt/libelf/libelf_init.c
+ *
+ *   Copyright (C) 2012 Gregory Nutt. All rights reserved.
+ *   Author: Gregory Nutt <gnutt@nuttx.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <tinyara/config.h>
+
+#include <sys/stat.h>
+
+#include <stdint.h>
+#include <string.h>
+#include <fcntl.h>
+#include <debug.h>
+#include <errno.h>
+
+#include <tinyara/fs/fs.h>
+#include <tinyara/binfmt/elf.h>
+
+#include "libelf.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/* CONFIG_DEBUG_FEATURES, CONFIG_DEBUG_INFO, and CONFIG_DEBUG_BINFMT have to be
+ * defined or CONFIG_ELF_DUMPBUFFER does nothing.
+ */
+
+#if !defined(CONFIG_DEBUG_INFO) || !defined (CONFIG_DEBUG_BINFMT)
+#undef CONFIG_ELF_DUMPBUFFER
+#endif
+
+#ifdef CONFIG_ELF_DUMPBUFFER
+#define elf_dumpbuffer(m,b,n) binfodumpbuffer(m,b,n)
+#else
+#define elf_dumpbuffer(m,b,n)
+#endif
+
+/****************************************************************************
+ * Private Constant Data
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: elf_filelen
+ *
+ * Description:
+ *  Get the size of the ELF file
+ *
+ * Returned Value:
+ *   0 (OK) is returned on success and a negated errno is returned on
+ *   failure.
+ *
+ ****************************************************************************/
+
+static inline int elf_filelen(FAR struct elf_loadinfo_s *loadinfo, FAR const char *filename)
+{
+	struct stat buf;
+	int ret;
+
+	/* Get the file stats */
+
+	ret = stat(filename, &buf);
+	if (ret < 0) {
+		int errval = get_errno();
+		berr("Failed to stat file: %d\n", errval);
+		return -errval;
+	}
+
+	/* Verify that it is a regular file */
+
+	if (!S_ISREG(buf.st_mode)) {
+		berr("Not a regular file.  mode: %d\n", buf.st_mode);
+		return -ENOENT;
+	}
+
+	/* TODO:  Verify that the file is readable.  Not really important because
+	 * we will detect this when we try to open the file read-only.
+	 */
+
+	/* Return the size of the file in the loadinfo structure */
+
+	loadinfo->filelen = buf.st_size;
+	return OK;
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: elf_init
+ *
+ * Description:
+ *   This function is called to configure the library to process an ELF
+ *   program binary.
+ *
+ * Returned Value:
+ *   0 (OK) is returned on success and a negated errno is returned on
+ *   failure.
+ *
+ ****************************************************************************/
+
+int elf_init(FAR const char *filename, FAR struct elf_loadinfo_s *loadinfo)
+{
+	int ret;
+
+	binfo("filename: %s loadinfo: %p\n", filename, loadinfo);
+
+	/* Clear the load info structure */
+
+	memset(loadinfo, 0, sizeof(struct elf_loadinfo_s));
+
+	/* Get the length of the file. */
+
+	ret = elf_filelen(loadinfo, filename);
+	if (ret < 0) {
+		berr("elf_filelen failed: %d\n", ret);
+		return ret;
+	}
+
+	/* Open the binary file for reading (only) */
+
+	loadinfo->filfd = open(filename, O_RDONLY);
+	if (loadinfo->filfd < 0) {
+		ret = loadinfo->filfd;
+		berr("Failed to open ELF binary %s: %d\n", filename, ret);
+		return ret;
+	}
+
+	/* Read the ELF ehdr from offset 0 */
+
+	ret = elf_read(loadinfo, (FAR uint8_t *)&loadinfo->ehdr, sizeof(Elf32_Ehdr), 0);
+	if (ret < 0) {
+		berr("Failed to read ELF header: %d\n", ret);
+		return ret;
+	}
+
+	elf_dumpbuffer("ELF header", (FAR const uint8_t *)&loadinfo->ehdr, sizeof(Elf32_Ehdr));
+
+	/* Verify the ELF header */
+
+	ret = elf_verifyheader(&loadinfo->ehdr);
+	if (ret < 0) {
+		/* This may not be an error because we will be called to attempt loading
+		 * EVERY binary.  If elf_verifyheader() does not recognize the ELF header,
+		 * it will -ENOEXEC whcih simply informs the system that the file is not an
+		 * ELF file.  elf_verifyheader() will return other errors if the ELF header
+		 * is not correctly formed.
+		 */
+
+		berr("Bad ELF header: %d\n", ret);
+		return ret;
+	}
+
+	return OK;
+}

--- a/os/binfmt/libelf/libelf_iobuffer.c
+++ b/os/binfmt/libelf/libelf_iobuffer.c
@@ -1,0 +1,149 @@
+/****************************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+/****************************************************************************
+ * os/binfmt/libelf/libelf_iobuffer.c
+ *
+ *   Copyright (C) 2012-2013 Gregory Nutt. All rights reserved.
+ *   Author: Gregory Nutt <gnutt@nuttx.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <tinyara/config.h>
+
+#include <debug.h>
+#include <errno.h>
+
+#include <tinyara/kmalloc.h>
+#include <tinyara/binfmt/elf.h>
+
+#include "libelf.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Constant Data
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: elf_allocbuffer
+ *
+ * Description:
+ *   Perform the initial allocation of the I/O buffer, if it has not already
+ *   been allocated.
+ *
+ * Returned Value:
+ *   0 (OK) is returned on success and a negated errno is returned on
+ *   failure.
+ *
+ ****************************************************************************/
+
+int elf_allocbuffer(FAR struct elf_loadinfo_s *loadinfo)
+{
+	/* Has a buffer been allocated> */
+
+	if (!loadinfo->iobuffer) {
+		/* No.. allocate one now */
+
+		loadinfo->iobuffer = (FAR uint8_t *)kmm_malloc(CONFIG_ELF_BUFFERSIZE);
+		if (!loadinfo->iobuffer) {
+			berr("Failed to allocate an I/O buffer\n");
+			return -ENOMEM;
+		}
+
+		loadinfo->buflen = CONFIG_ELF_BUFFERSIZE;
+	}
+
+	return OK;
+}
+
+/****************************************************************************
+ * Name: elf_reallocbuffer
+ *
+ * Description:
+ *   Increase the size of I/O buffer by the specified buffer increment.
+ *
+ * Returned Value:
+ *   0 (OK) is returned on success and a negated errno is returned on
+ *   failure.
+ *
+ ****************************************************************************/
+
+int elf_reallocbuffer(FAR struct elf_loadinfo_s *loadinfo, size_t increment)
+{
+	FAR void *buffer;
+	size_t newsize;
+
+	/* Get the new size of the allocation */
+
+	newsize = loadinfo->buflen + increment;
+
+	/* And perform the reallocation */
+
+	buffer = kmm_realloc((FAR void *)loadinfo->iobuffer, newsize);
+	if (!buffer) {
+		berr("Failed to reallocate the I/O buffer\n");
+		return -ENOMEM;
+	}
+
+	/* Save the new buffer info */
+
+	loadinfo->iobuffer = buffer;
+	loadinfo->buflen = newsize;
+	return OK;
+}

--- a/os/binfmt/libelf/libelf_load.c
+++ b/os/binfmt/libelf/libelf_load.c
@@ -1,0 +1,367 @@
+/****************************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+/****************************************************************************
+ * os/binfmt/libelf/libelf_load.c
+ *
+ *   Copyright (C) 2012 Gregory Nutt. All rights reserved.
+ *   Author: Gregory Nutt <gnutt@nuttx.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <tinyara/config.h>
+
+#include <sys/types.h>
+
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <assert.h>
+#include <errno.h>
+#include <debug.h>
+
+#include <tinyara/arch.h>
+#include <tinyara/addrenv.h>
+#include <tinyara/mm/mm.h>
+#include <tinyara/binfmt/elf.h>
+
+#include "libelf.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define ELF_ALIGN_MASK   ((1 << CONFIG_ELF_ALIGN_LOG2) - 1)
+#define ELF_ALIGNUP(a)   (((unsigned long)(a) + ELF_ALIGN_MASK) & ~ELF_ALIGN_MASK)
+#define ELF_ALIGNDOWN(a) ((unsigned long)(a) & ~ELF_ALIGN_MASK)
+
+#ifndef MAX
+#define MAX(x,y) ((x) > (y) ? (x) : (y))
+#endif
+
+#ifndef MIN
+#define MIN(x,y) ((x) < (y) ? (x) : (y))
+#endif
+
+/****************************************************************************
+ * Private Constant Data
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: elf_elfsize
+ *
+ * Description:
+ *   Calculate total memory allocation for the ELF file.
+ *
+ * Returned Value:
+ *   0 (OK) is returned on success and a negated errno is returned on
+ *   failure.
+ *
+ ****************************************************************************/
+
+static void elf_elfsize(struct elf_loadinfo_s *loadinfo)
+{
+	size_t textsize;
+	size_t datasize;
+	int i;
+
+	/* Accumulate the size each section into memory that is marked SHF_ALLOC */
+
+	textsize = 0;
+	datasize = 0;
+
+	for (i = 0; i < loadinfo->ehdr.e_shnum; i++) {
+		FAR Elf32_Shdr *shdr = &loadinfo->shdr[i];
+
+		/* SHF_ALLOC indicates that the section requires memory during
+		 * execution.
+		 */
+
+		if ((shdr->sh_flags & SHF_ALLOC) != 0) {
+			/* SHF_WRITE indicates that the section address space is write-
+			 * able
+			 */
+
+			if ((shdr->sh_flags & SHF_WRITE) != 0) {
+				datasize += ELF_ALIGNUP(shdr->sh_size);
+			} else {
+				textsize += ELF_ALIGNUP(shdr->sh_size);
+			}
+		}
+	}
+
+	/* Save the allocation size */
+
+	loadinfo->textsize = textsize;
+	loadinfo->datasize = datasize;
+}
+
+/****************************************************************************
+ * Name: elf_loadfile
+ *
+ * Description:
+ *   Read the section data into memory. Section addresses in the shdr[] are
+ *   updated to point to the corresponding position in the memory.
+ *
+ * Returned Value:
+ *   0 (OK) is returned on success and a negated errno is returned on
+ *   failure.
+ *
+ ****************************************************************************/
+
+static inline int elf_loadfile(FAR struct elf_loadinfo_s *loadinfo)
+{
+	FAR uint8_t *text;
+	FAR uint8_t *data;
+	FAR uint8_t **pptr;
+	int ret;
+	int i;
+
+	/* Read each section into memory that is marked SHF_ALLOC + SHT_NOBITS */
+
+	binfo("Loaded sections:\n");
+	text = (FAR uint8_t *)loadinfo->textalloc;
+	data = (FAR uint8_t *)loadinfo->dataalloc;
+
+	for (i = 0; i < loadinfo->ehdr.e_shnum; i++) {
+		FAR Elf32_Shdr *shdr = &loadinfo->shdr[i];
+
+		/* SHF_ALLOC indicates that the section requires memory during
+		 * execution */
+
+		if ((shdr->sh_flags & SHF_ALLOC) == 0) {
+			continue;
+		}
+
+		/* SHF_WRITE indicates that the section address space is write-
+		 * able
+		 */
+
+		if ((shdr->sh_flags & SHF_WRITE) != 0) {
+			pptr = &data;
+		} else {
+			pptr = &text;
+		}
+
+		/* SHT_NOBITS indicates that there is no data in the file for the
+		 * section.
+		 */
+
+		if (shdr->sh_type != SHT_NOBITS) {
+			/* Read the section data from sh_offset to the memory region */
+
+			ret = elf_read(loadinfo, *pptr, shdr->sh_size, shdr->sh_offset);
+			if (ret < 0) {
+				berr("ERROR: Failed to read section %d: %d\n", i, ret);
+				return ret;
+			}
+		}
+
+		/* If there is no data in an allocated section, then the allocated
+		 * section must be cleared.
+		 */
+
+		else {
+			memset(*pptr, 0, shdr->sh_size);
+		}
+
+		/* Update sh_addr to point to copy in memory */
+
+		binfo("%d. %08lx->%08lx\n", i, (unsigned long)shdr->sh_addr, (unsigned long)*pptr);
+
+		shdr->sh_addr = (uintptr_t) * pptr;
+
+		/* Setup the memory pointer for the next time through the loop */
+
+		*pptr += ELF_ALIGNUP(shdr->sh_size);
+	}
+
+	return OK;
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: elf_load
+ *
+ * Description:
+ *   Loads the binary into memory, allocating memory, performing relocations
+ *   and initializing the data and bss segments.
+ *
+ * Returned Value:
+ *   0 (OK) is returned on success and a negated errno is returned on
+ *   failure.
+ *
+ ****************************************************************************/
+
+int elf_load(FAR struct elf_loadinfo_s *loadinfo)
+{
+	size_t heapsize;
+#ifdef CONFIG_CXX_EXCEPTION
+	int exidx;
+#endif
+	int ret;
+
+	binfo("loadinfo: %p\n", loadinfo);
+	DEBUGASSERT(loadinfo && loadinfo->filfd >= 0);
+
+	/* Load section headers into memory */
+
+	ret = elf_loadshdrs(loadinfo);
+	if (ret < 0) {
+		berr("ERROR: elf_loadshdrs failed: %d\n", ret);
+		goto errout_with_buffers;
+	}
+
+	/* Determine total size to allocate */
+
+	elf_elfsize(loadinfo);
+
+	/* Determine the heapsize to allocate.  heapsize is ignored if there is
+	 * no address environment because the heap is a shared resource in that
+	 * case.  If there is no dynamic stack then heapsize must at least as big
+	 * as the fixed stack size since the stack will be allocated from the heap
+	 * in that case.
+	 */
+
+#if !defined(CONFIG_ARCH_ADDRENV)
+	heapsize = 0;
+#elif defined(CONFIG_ARCH_STACK_DYNAMIC)
+	heapsize = ARCH_HEAP_SIZE;
+#else
+	heapsize = MAX(ARCH_HEAP_SIZE, CONFIG_ELF_STACKSIZE);
+#endif
+
+	/* Allocate (and zero) memory for the ELF file. */
+
+	ret = elf_addrenv_alloc(loadinfo, loadinfo->textsize, loadinfo->datasize, heapsize);
+	if (ret < 0) {
+		berr("ERROR: elf_addrenv_alloc() failed: %d\n", ret);
+		goto errout_with_buffers;
+	}
+#ifdef CONFIG_ARCH_ADDRENV
+	/* If CONFIG_ARCH_ADDRENV=y, then the loaded ELF lies in a virtual address
+	 * space that may not be in place now.  elf_addrenv_select() will
+	 * temporarily instantiate that address space.
+	 */
+
+	ret = elf_addrenv_select(loadinfo);
+	if (ret < 0) {
+		berr("ERROR: elf_addrenv_select() failed: %d\n", ret);
+		goto errout_with_buffers;
+	}
+#ifdef CONFIG_BUILD_KERNEL
+	/* Initialize the user heap */
+
+	umm_initialize((FAR void *)CONFIG_ARCH_HEAP_VBASE, up_addrenv_heapsize(&loadinfo->addrenv));
+#endif
+#endif
+
+	/* Load ELF section data into memory */
+
+	ret = elf_loadfile(loadinfo);
+	if (ret < 0) {
+		berr("ERROR: elf_loadfile failed: %d\n", ret);
+		goto errout_with_addrenv;
+	}
+
+	/* Load static constructors and destructors. */
+
+#ifdef CONFIG_BINFMT_CONSTRUCTORS
+	ret = elf_loadctors(loadinfo);
+	if (ret < 0) {
+		berr("ERROR: elf_loadctors failed: %d\n", ret);
+		goto errout_with_addrenv;
+	}
+
+	ret = elf_loaddtors(loadinfo);
+	if (ret < 0) {
+		berr("ERROR: elf_loaddtors failed: %d\n", ret);
+		goto errout_with_addrenv;
+	}
+#endif
+
+#ifdef CONFIG_CXX_EXCEPTION
+	exidx = elf_findsection(loadinfo, CONFIG_ELF_EXIDX_SECTNAME);
+	if (exidx < 0) {
+		binfo("elf_findsection: Exception Index section not found: %d\n", exidx);
+	} else {
+		up_init_exidx(loadinfo->shdr[exidx].sh_addr, loadinfo->shdr[exidx].sh_size);
+	}
+#endif
+
+#ifdef CONFIG_ARCH_ADDRENV
+	/* Restore the original address environment */
+
+	ret = elf_addrenv_restore(loadinfo);
+	if (ret < 0) {
+		berr("ERROR: elf_addrenv_restore() failed: %d\n", ret);
+		goto errout_with_buffers;
+	}
+#endif
+
+	return OK;
+
+	/* Error exits */
+
+errout_with_addrenv:
+#ifdef CONFIG_ARCH_ADDRENV
+	(void)elf_addrenv_restore(loadinfo);
+#endif
+
+errout_with_buffers:
+	elf_unload(loadinfo);
+	return ret;
+}

--- a/os/binfmt/libelf/libelf_read.c
+++ b/os/binfmt/libelf/libelf_read.c
@@ -1,0 +1,168 @@
+/****************************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+/****************************************************************************
+ * os/binfmt/libelf/libelf_read.c
+ *
+ *   Copyright (C) 2014 Gregory Nutt. All rights reserved.
+ *   Author: Gregory Nutt <gnutt@nuttx.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <tinyara/config.h>
+
+#include <sys/types.h>
+#include <stdint.h>
+#include <unistd.h>
+#include <string.h>
+#include <debug.h>
+#include <errno.h>
+
+#include <tinyara/fs/fs.h>
+#include <tinyara/binfmt/elf.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#undef ELF_DUMP_READDATA		/* Define to dump all file data read */
+
+/****************************************************************************
+ * Private Constant Data
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: elf_dumpreaddata
+ ****************************************************************************/
+
+#if defined(ELF_DUMP_READDATA)
+static inline void elf_dumpreaddata(FAR char *buffer, int buflen)
+{
+	FAR uint32_t *buf32 = (FAR uint32_t *)buffer;
+	int i;
+	int j;
+
+	for (i = 0; i < buflen; i += 32) {
+		syslog(LOG_DEBUG, "%04x:", i);
+		for (j = 0; j < 32; j += sizeof(uint32_t)) {
+			syslog(LOG_DEBUG, "  %08x", *buf32++);
+		}
+
+		syslog(LOG_DEBUG, "\n");
+	}
+}
+#else
+#define elf_dumpreaddata(b,n)
+#endif
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: elf_read
+ *
+ * Description:
+ *   Read 'readsize' bytes from the object file at 'offset'.  The data is
+ *   read into 'buffer.' If 'buffer' is part of the ELF address environment,
+ *   then the caller is responsibile for assuring that that address
+ *   environment is in place before calling this function (i.e., that
+ *   elf_addrenv_select() has been called if CONFIG_ARCH_ADDRENV=y).
+ *
+ * Returned Value:
+ *   0 (OK) is returned on success and a negated errno is returned on
+ *   failure.
+ *
+ ****************************************************************************/
+
+int elf_read(FAR struct elf_loadinfo_s *loadinfo, FAR uint8_t *buffer, size_t readsize, off_t offset)
+{
+	ssize_t nbytes;				/* Number of bytes read */
+	off_t rpos;					/* Position returned by lseek */
+
+	binfo("Read %ld bytes from offset %ld\n", (long)readsize, (long)offset);
+
+	/* Loop until all of the requested data has been read. */
+
+	while (readsize > 0) {
+		/* Seek to the next read position */
+
+		rpos = lseek(loadinfo->filfd, offset, SEEK_SET);
+		if (rpos != offset) {
+			int errval = get_errno();
+			berr("Failed to seek to position %lu: %d\n", (unsigned long)offset, errval);
+			return -errval;
+		}
+
+		/* Read the file data at offset into the user buffer */
+
+		nbytes = read(loadinfo->filfd, buffer, readsize);
+		if (nbytes < 0) {
+			/* EINTR just means that we received a signal */
+
+			if (nbytes != -EINTR) {
+				berr("Read from offset %lu failed: %d\n", (unsigned long)offset, (int)nbytes);
+				return nbytes;
+			}
+		} else if (nbytes == 0) {
+			berr("Unexpected end of file\n");
+			return -ENODATA;
+		} else {
+			readsize -= nbytes;
+			buffer += nbytes;
+			offset += nbytes;
+		}
+	}
+
+	elf_dumpreaddata(buffer, readsize);
+	return OK;
+}

--- a/os/binfmt/libelf/libelf_sections.c
+++ b/os/binfmt/libelf/libelf_sections.c
@@ -1,0 +1,284 @@
+/****************************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+/****************************************************************************
+ * os/binfmt/libelf/libelf_sections.c
+ *
+ *   Copyright (C) 2012 Gregory Nutt. All rights reserved.
+ *   Author: Gregory Nutt <gnutt@nuttx.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <tinyara/config.h>
+
+#include <stdlib.h>
+#include <string.h>
+#include <assert.h>
+#include <errno.h>
+#include <debug.h>
+
+#include <tinyara/kmalloc.h>
+#include <tinyara/binfmt/elf.h>
+
+#include "libelf.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Constant Data
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: elf_sectname
+ *
+ * Description:
+ *   Get the symbol name in loadinfo->iobuffer[].
+ *
+ * Returned Value:
+ *   0 (OK) is returned on success and a negated errno is returned on
+ *   failure.
+ *
+ ****************************************************************************/
+
+static inline int elf_sectname(FAR struct elf_loadinfo_s *loadinfo, FAR const Elf32_Shdr *shdr)
+{
+	FAR Elf32_Shdr *shstr;
+	FAR uint8_t *buffer;
+	off_t offset;
+	size_t readlen;
+	size_t bytesread;
+	int shstrndx;
+	int ret;
+
+	/* Get the section header table index of the entry associated with the
+	 * section name string table. If the file has no section name string table,
+	 * this member holds the value SH_UNDEF.
+	 */
+
+	shstrndx = loadinfo->ehdr.e_shstrndx;
+	if (shstrndx == SHN_UNDEF) {
+		berr("No section header string table\n");
+		return -EINVAL;
+	}
+
+	/* Get the section name string table section header */
+
+	shstr = &loadinfo->shdr[shstrndx];
+
+	/* Get the file offset to the string that is the name of the section. This
+	 * is the sum of:
+	 *
+	 *   shstr->sh_offset: The file offset to the first byte of the section
+	 *     header string table data.
+	 *   shdr->sh_name: The offset to the name of the section in the section
+	 *     name table
+	 */
+
+	offset = shstr->sh_offset + shdr->sh_name;
+
+	/* Loop until we get the entire section name into memory */
+
+	bytesread = 0;
+
+	for (;;) {
+		/* Get the number of bytes to read */
+
+		readlen = loadinfo->buflen - bytesread;
+		if (offset + readlen > loadinfo->filelen) {
+			if (loadinfo->filelen <= offset) {
+				berr("At end of file\n");
+				return -EINVAL;
+			}
+
+			readlen = loadinfo->filelen - offset;
+		}
+
+		/* Read that number of bytes into the array */
+
+		buffer = &loadinfo->iobuffer[bytesread];
+		ret = elf_read(loadinfo, buffer, readlen, offset + bytesread);
+		if (ret < 0) {
+			berr("Failed to read section name\n");
+			return ret;
+		}
+
+		bytesread += readlen;
+
+		/* Did we read the NUL terminator? */
+
+		if (memchr(buffer, '\0', readlen) != NULL) {
+			/* Yes, the buffer contains a NUL terminator. */
+
+			return OK;
+		}
+
+		/* No.. then we have to read more */
+
+		ret = elf_reallocbuffer(loadinfo, CONFIG_ELF_BUFFERINCR);
+		if (ret < 0) {
+			berr("elf_reallocbuffer failed: %d\n", ret);
+			return ret;
+		}
+	}
+
+	/* We will not get here */
+
+	return OK;
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: elf_loadshdrs
+ *
+ * Description:
+ *   Loads section headers into memory.
+ *
+ * Returned Value:
+ *   0 (OK) is returned on success and a negated errno is returned on
+ *   failure.
+ *
+ ****************************************************************************/
+
+int elf_loadshdrs(FAR struct elf_loadinfo_s *loadinfo)
+{
+	size_t shdrsize;
+	int ret;
+
+	DEBUGASSERT(loadinfo->shdr == NULL);
+
+	/* Verify that there are sections */
+
+	if (loadinfo->ehdr.e_shnum < 1) {
+		berr("No sections(?)\n");
+		return -EINVAL;
+	}
+
+	/* Get the total size of the section header table */
+
+	shdrsize = (size_t) loadinfo->ehdr.e_shentsize * (size_t) loadinfo->ehdr.e_shnum;
+	if (loadinfo->ehdr.e_shoff + shdrsize > loadinfo->filelen) {
+		berr("Insufficent space in file for section header table\n");
+		return -ESPIPE;
+	}
+
+	/* Allocate memory to hold a working copy of the sector header table */
+
+	loadinfo->shdr = (FAR FAR Elf32_Shdr *)kmm_malloc(shdrsize);
+	if (!loadinfo->shdr) {
+		berr("Failed to allocate the section header table. Size: %ld\n", (long)shdrsize);
+		return -ENOMEM;
+	}
+
+	/* Read the section header table into memory */
+
+	ret = elf_read(loadinfo, (FAR uint8_t *)loadinfo->shdr, shdrsize, loadinfo->ehdr.e_shoff);
+	if (ret < 0) {
+		berr("Failed to read section header table: %d\n", ret);
+	}
+
+	return ret;
+}
+
+/****************************************************************************
+ * Name: elf_findsection
+ *
+ * Description:
+ *   A section by its name.
+ *
+ * Input Parameters:
+ *   loadinfo - Load state information
+ *   sectname - Name of the section to find
+ *
+ * Returned Value:
+ *   On success, the index to the section is returned; A negated errno value
+ *   is returned on failure.
+ *
+ ****************************************************************************/
+
+int elf_findsection(FAR struct elf_loadinfo_s *loadinfo, FAR const char *sectname)
+{
+	FAR const Elf32_Shdr *shdr;
+	int ret;
+	int i;
+
+	/* Search through the shdr[] array in loadinfo for a section named 'sectname' */
+
+	for (i = 0; i < loadinfo->ehdr.e_shnum; i++) {
+		/* Get the name of this section */
+
+		shdr = &loadinfo->shdr[i];
+		ret = elf_sectname(loadinfo, shdr);
+		if (ret < 0) {
+			berr("elf_sectname failed: %d\n", ret);
+			return ret;
+		}
+
+		/* Check if the name of this section is 'sectname' */
+
+		binfo("%d. Comparing \"%s\" and .\"%s\"\n", i, loadinfo->iobuffer, sectname);
+
+		if (strcmp((FAR const char *)loadinfo->iobuffer, sectname) == 0) {
+			/* We found it... return the index */
+
+			return i;
+		}
+	}
+
+	/* We failed to find a section with this name. */
+
+	return -ENOENT;
+}

--- a/os/binfmt/libelf/libelf_symbols.c
+++ b/os/binfmt/libelf/libelf_symbols.c
@@ -1,0 +1,334 @@
+/****************************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+/****************************************************************************
+ * os/binfmt/libelf/libelf_symbols.c
+ *
+ *   Copyright (C) 2012, 2014 Gregory Nutt. All rights reserved.
+ *   Author: Gregory Nutt <gnutt@nuttx.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <tinyara/config.h>
+
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+#include <debug.h>
+
+#include <tinyara/binfmt/elf.h>
+#include <tinyara/binfmt/symtab.h>
+
+#include "libelf.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Constant Data
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: elf_symname
+ *
+ * Description:
+ *   Get the symbol name in loadinfo->iobuffer[].
+ *
+ * Returned Value:
+ *   0 (OK) is returned on success and a negated errno is returned on
+ *   failure.
+ *
+ *   EINVAL - There is something inconsistent in the symbol table (should only
+ *            happen if the file is corrupted).
+ *   ESRCH - Symbol has no name
+ *
+ ****************************************************************************/
+
+static int elf_symname(FAR struct elf_loadinfo_s *loadinfo, FAR const Elf32_Sym *sym)
+{
+	FAR uint8_t *buffer;
+	off_t offset;
+	size_t readlen;
+	size_t bytesread;
+	int ret;
+
+	/* Get the file offset to the string that is the name of the symbol.  The
+	 * st_name member holds an offset into the file's symbol string table.
+	 */
+
+	if (sym->st_name == 0) {
+		berr("Symbol has no name\n");
+		return -ESRCH;
+	}
+
+	offset = loadinfo->shdr[loadinfo->strtabidx].sh_offset + sym->st_name;
+
+	/* Loop until we get the entire symbol name into memory */
+
+	bytesread = 0;
+
+	for (;;) {
+		/* Get the number of bytes to read */
+
+		readlen = loadinfo->buflen - bytesread;
+		if (offset + readlen > loadinfo->filelen) {
+			if (loadinfo->filelen <= offset) {
+				berr("At end of file\n");
+				return -EINVAL;
+			}
+
+			readlen = loadinfo->filelen - offset;
+		}
+
+		/* Read that number of bytes into the array */
+
+		buffer = &loadinfo->iobuffer[bytesread];
+		ret = elf_read(loadinfo, buffer, readlen, offset + bytesread);
+		if (ret < 0) {
+			berr("elf_read failed: %d\n", ret);
+			return ret;
+		}
+
+		bytesread += readlen;
+
+		/* Did we read the NUL terminator? */
+
+		if (memchr(buffer, '\0', readlen) != NULL) {
+			/* Yes, the buffer contains a NUL terminator. */
+
+			return OK;
+		}
+
+		/* No.. then we have to read more */
+
+		ret = elf_reallocbuffer(loadinfo, CONFIG_ELF_BUFFERINCR);
+		if (ret < 0) {
+			berr("elf_reallocbuffer failed: %d\n", ret);
+			return ret;
+		}
+	}
+
+	/* We will not get here */
+
+	return OK;
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: elf_findsymtab
+ *
+ * Description:
+ *   Find the symbol table section.
+ *
+ * Returned Value:
+ *   0 (OK) is returned on success and a negated errno is returned on
+ *   failure.
+ *
+ ****************************************************************************/
+
+int elf_findsymtab(FAR struct elf_loadinfo_s *loadinfo)
+{
+	int i;
+
+	/* Find the symbol table section header and its associated string table */
+
+	for (i = 1; i < loadinfo->ehdr.e_shnum; i++) {
+		if (loadinfo->shdr[i].sh_type == SHT_SYMTAB) {
+			loadinfo->symtabidx = i;
+			loadinfo->strtabidx = loadinfo->shdr[i].sh_link;
+			break;
+		}
+	}
+
+	/* Verify that there is a symbol and string table */
+
+	if (loadinfo->symtabidx == 0) {
+		berr("No symbols in ELF file\n");
+		return -EINVAL;
+	}
+
+	return OK;
+}
+
+/****************************************************************************
+ * Name: elf_readsym
+ *
+ * Description:
+ *   Read the ELF symbol structure at the specified index into memory.
+ *
+ * Input Parameters:
+ *   loadinfo - Load state information
+ *   index    - Symbol table index
+ *   sym      - Location to return the table entry
+ *
+ * Returned Value:
+ *   0 (OK) is returned on success and a negated errno is returned on
+ *   failure.
+ *
+ ****************************************************************************/
+
+int elf_readsym(FAR struct elf_loadinfo_s *loadinfo, int index, FAR Elf32_Sym *sym)
+{
+	FAR Elf32_Shdr *symtab = &loadinfo->shdr[loadinfo->symtabidx];
+	off_t offset;
+
+	/* Verify that the symbol table index lies within symbol table */
+
+	if (index < 0 || index > (symtab->sh_size / sizeof(Elf32_Sym))) {
+		berr("Bad relocation symbol index: %d\n", index);
+		return -EINVAL;
+	}
+
+	/* Get the file offset to the symbol table entry */
+
+	offset = symtab->sh_offset + sizeof(Elf32_Sym) * index;
+
+	/* And, finally, read the symbol table entry into memory */
+
+	return elf_read(loadinfo, (FAR uint8_t *) sym, sizeof(Elf32_Sym), offset);
+}
+
+/****************************************************************************
+ * Name: elf_symvalue
+ *
+ * Description:
+ *   Get the value of a symbol.  The updated value of the symbol is returned
+ *   in the st_value field of the symbol table entry.
+ *
+ * Input Parameters:
+ *   loadinfo - Load state information
+ *   sym      - Symbol table entry (value might be undefined)
+ *
+ * Returned Value:
+ *   0 (OK) is returned on success and a negated errno is returned on
+ *   failure.
+ *
+ *   EINVAL - There is something inconsistent in the symbol table (should only
+ *            happen if the file is corrupted).
+ *   ENOSYS - Symbol lies in common
+ *   ESRCH  - Symbol has no name
+ *   ENOENT - Symbol undefined and not provided via a symbol table
+ *
+ ****************************************************************************/
+
+int elf_symvalue(FAR struct elf_loadinfo_s *loadinfo, FAR Elf32_Sym *sym, FAR const struct symtab_s *exports, int nexports)
+{
+	FAR const struct symtab_s *symbol;
+	uintptr_t secbase;
+	int ret;
+
+	switch (sym->st_shndx) {
+	case SHN_COMMON: {
+		/* ELF modules should be compiled with -fno-common. */
+
+		berr("SHN_COMMON: Re-compile with -fno-common\n");
+		return -ENOSYS;
+	}
+
+	case SHN_ABS: {
+		/* st_value already holds the correct value */
+
+		binfo("SHN_ABS: st_value=%08lx\n", (long)sym->st_value);
+		return OK;
+	}
+
+	case SHN_UNDEF: {
+		/* Get the name of the undefined symbol */
+
+		ret = elf_symname(loadinfo, sym);
+		if (ret < 0) {
+			/* There are a few relocations for a few architectures that do
+			 * no depend upon a named symbol.  We don't know if that is the
+			 * case here, but return and special error to the caller to
+			 * indicate the nameless symbol.
+			 */
+
+			berr("SHN_UNDEF: Failed to get symbol name: %d\n", ret);
+			return ret;
+		}
+
+		/* Check if the base code exports a symbol of this name */
+
+#ifdef CONFIG_SYMTAB_ORDEREDBYNAME
+		symbol = symtab_findorderedbyname(exports, (FAR char *)loadinfo->iobuffer, nexports);
+#else
+		symbol = symtab_findbyname(exports, (FAR char *)loadinfo->iobuffer, nexports);
+#endif
+		if (!symbol) {
+			berr("SHN_UNDEF: Exported symbol \"%s\" not found\n", loadinfo->iobuffer);
+			return -ENOENT;
+		}
+
+		/* Yes... add the exported symbol value to the ELF symbol table entry */
+
+		binfo("SHN_UNDEF: name=%s %08x+%08x=%08x\n", loadinfo->iobuffer, sym->st_value, symbol->sym_value, sym->st_value + symbol->sym_value);
+
+		sym->st_value += (Elf32_Word)((uintptr_t) symbol->sym_value);
+	}
+	break;
+
+	default: {
+		secbase = loadinfo->shdr[sym->st_shndx].sh_addr;
+
+		binfo("Other: %08x+%08x=%08x\n", sym->st_value, secbase, sym->st_value + secbase);
+
+		sym->st_value += secbase;
+	}
+	break;
+	}
+
+	return OK;
+}

--- a/os/binfmt/libelf/libelf_uninit.c
+++ b/os/binfmt/libelf/libelf_uninit.c
@@ -1,0 +1,140 @@
+/****************************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+/****************************************************************************
+ * os/binfmt/libelf/libelf_uninit.c
+ *
+ *   Copyright (C) 2012 Gregory Nutt. All rights reserved.
+ *   Author: Gregory Nutt <gnutt@nuttx.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <tinyara/config.h>
+
+#include <unistd.h>
+#include <debug.h>
+#include <errno.h>
+
+#include <tinyara/kmalloc.h>
+#include <tinyara/binfmt/elf.h>
+
+#include "libelf.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Constant Data
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: elf_uninit
+ *
+ * Description:
+ *   Releases any resources committed by elf_init().  This essentially
+ *   undoes the actions of elf_init.
+ *
+ * Returned Value:
+ *   0 (OK) is returned on success and a negated errno is returned on
+ *   failure.
+ *
+ ****************************************************************************/
+
+int elf_uninit(struct elf_loadinfo_s *loadinfo)
+{
+	/* Free all working buffers */
+
+	elf_freebuffers(loadinfo);
+
+	/* Close the ELF file */
+
+	if (loadinfo->filfd >= 0) {
+		close(loadinfo->filfd);
+	}
+
+	return OK;
+}
+
+/****************************************************************************
+ * Name: elf_freebuffers
+ *
+ * Description:
+ *  Release all working buffers.
+ *
+ * Returned Value:
+ *   0 (OK) is returned on success and a negated errno is returned on
+ *   failure.
+ *
+ ****************************************************************************/
+
+int elf_freebuffers(struct elf_loadinfo_s *loadinfo)
+{
+	/* Release all working allocations  */
+
+	if (loadinfo->shdr) {
+		kmm_free((FAR void *)loadinfo->shdr);
+		loadinfo->shdr = NULL;
+	}
+
+	if (loadinfo->iobuffer) {
+		kmm_free((FAR void *)loadinfo->iobuffer);
+		loadinfo->iobuffer = NULL;
+		loadinfo->buflen = 0;
+	}
+
+	return OK;
+}

--- a/os/binfmt/libelf/libelf_unload.c
+++ b/os/binfmt/libelf/libelf_unload.c
@@ -1,0 +1,129 @@
+/****************************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+/****************************************************************************
+ * os/binfmt/libelf/libelf_unload.c
+ *
+ *   Copyright (C) 2012 Gregory Nutt. All rights reserved.
+ *   Author: Gregory Nutt <gnutt@nuttx.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <tinyara/config.h>
+
+#include <stdlib.h>
+#include <debug.h>
+
+#include <tinyara/kmalloc.h>
+#include <tinyara/binfmt/elf.h>
+
+#include "libelf.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Constant Data
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: elf_unload
+ *
+ * Description:
+ *   This function unloads the object from memory. This essentially undoes
+ *   the actions of elf_load.  It is called only under certain error
+ *   conditions after the module has been loaded but not yet started.
+ *
+ * Returned Value:
+ *   0 (OK) is returned on success and a negated errno is returned on
+ *   failure.
+ *
+ ****************************************************************************/
+
+int elf_unload(struct elf_loadinfo_s *loadinfo)
+{
+	/* Free all working buffers */
+
+	elf_freebuffers(loadinfo);
+
+	/* Release memory holding the relocated ELF image */
+
+	elf_addrenv_free(loadinfo);
+
+	/* Release memory used to hold static constructors and destructors */
+
+#ifdef CONFIG_BINFMT_CONSTRUCTORS
+#ifndef CONFIG_ARCH_ADDRENV
+	if (loadinfo->ctoralloc != 0) {
+		kumm_free(loadinfo->ctoralloc);
+	}
+	if (loadinfo->dtoralloc != 0) {
+		kumm_free(loadinfo->dtoralloc);
+	}
+#endif
+
+	loadinfo->ctoralloc = NULL;
+	loadinfo->ctors = NULL;
+	loadinfo->nctors = 0;
+
+	loadinfo->dtoralloc = NULL;
+	loadinfo->dtors = NULL;
+	loadinfo->ndtors = 0;
+#endif
+
+	return OK;
+}

--- a/os/binfmt/libelf/libelf_verify.c
+++ b/os/binfmt/libelf/libelf_verify.c
@@ -1,0 +1,134 @@
+/****************************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+/****************************************************************************
+ * os/binfmt/libelf/elf_verify.c
+ *
+ *   Copyright (C) 2012 Gregory Nutt. All rights reserved.
+ *   Author: Gregory Nutt <gnutt@nuttx.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <tinyara/config.h>
+
+#include <string.h>
+#include <debug.h>
+#include <errno.h>
+
+#include <tinyara/elf.h>
+#include <tinyara/binfmt/elf.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Constant Data
+ ****************************************************************************/
+
+static const char g_elfmagic[EI_MAGIC_SIZE] = {
+	0x7f, 'E', 'L', 'F'
+};
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: elf_verifyheader
+ *
+ * Description:
+ *   Given the header from a possible ELF executable, verify that it
+ *   is an ELF executable.
+ *
+ * Returned Value:
+ *   0 (OK) is returned on success and a negated errno is returned on
+ *   failure.
+ *
+ *   -ENOEXEC  : Not an ELF file
+ *   -EINVAL : Not a relocatable ELF file or not supported by the current,
+ *               configured architecture.
+ *
+ ****************************************************************************/
+
+int elf_verifyheader(FAR const Elf32_Ehdr *ehdr)
+{
+	if (!ehdr) {
+		berr("NULL ELF header!");
+		return -ENOEXEC;
+	}
+
+	/* Verify that the magic number indicates an ELF file */
+
+	if (memcmp(ehdr->e_ident, g_elfmagic, EI_MAGIC_SIZE) != 0) {
+		binfo("Not ELF magic {%02x, %02x, %02x, %02x}\n", ehdr->e_ident[0], ehdr->e_ident[1], ehdr->e_ident[2], ehdr->e_ident[3]);
+		return -ENOEXEC;
+	}
+
+	/* Verify that this is a relocatable file */
+
+	if (ehdr->e_type != ET_REL) {
+		berr("Not a relocatable file: e_type=%d\n", ehdr->e_type);
+		return -EINVAL;
+	}
+
+	/* Verify that this file works with the currently configured architecture */
+
+	if (!up_checkarch(ehdr)) {
+		berr("Not a supported architecture\n");
+		return -ENOEXEC;
+	}
+
+	/* Looks good so far... we still might find some problems later. */
+
+	return OK;
+}

--- a/os/include/debug.h
+++ b/os/include/debug.h
@@ -764,6 +764,24 @@ Once LOGM is approved, each module should have its own index
 #define elllvdbg(...)
 #endif
 
+#ifdef CONFIG_DEBUG_BINFMT_ERROR
+#  define berr(format, ...)     dbg(format, ##__VA_ARGS__)
+#else
+#  define berr(x...)
+#endif
+
+#ifdef CONFIG_DEBUG_BINFMT_WARN
+#  define bwarn(format, ...)   wdbg(format, ##__VA_ARGS__)
+#else
+#  define bwarn(x...)
+#endif
+
+#ifdef CONFIG_DEBUG_BINFMT_INFO
+#  define binfo(format, ...)   vdbg(format, ##__VA_ARGS__)
+#else
+#  define binfo(x...)
+#endif
+
 #else							/* CONFIG_CPP_HAVE_VARARGS */
 
 /* Variadic macros NOT supported */
@@ -1195,6 +1213,24 @@ Once LOGM is approved, each module should have its own index
 #else
 #define elvdbg     (void)
 #define elllvdbg   (void)
+#endif
+
+#ifdef CONFIG_DEBUG_BINFMT_ERROR
+#define berr  dbg
+#else
+#define berr  (void)
+#endif
+
+#ifdef CONFIG_DEBUG_BINFMT_WARN
+#define bwarn  wdbg
+#else
+#define bwarn  (void)
+#endif
+
+#ifdef CONFIG_DEBUG_BINFMT_INFO
+#define binfo  vdbg
+#else
+#define binfo  (void)
 #endif
 
 #endif							/* CONFIG_CPP_HAVE_VARARGS */

--- a/os/include/elf32.h
+++ b/os/include/elf32.h
@@ -1,0 +1,369 @@
+/****************************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+/****************************************************************************
+ * include/elf32.h
+ *
+ *   Copyright (C) 2012 Gregory Nutt. All rights reserved.
+ *   Author: Gregory Nutt <gnutt@nuttx.org>
+ *
+ * Reference: System V Application Binary Interface, Edition 4.1, March 18,
+ * 1997, The Santa Cruz Operation, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#ifndef __INCLUDE_ELF32_H
+#define __INCLUDE_ELF32_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <tinyara/config.h>
+
+#include <stdint.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/* Values for Elf32_Ehdr::e_type */
+
+#define ET_NONE           0       /* No file type */
+#define ET_REL            1       /* Relocatable file */
+#define ET_EXEC           2       /* Executable file */
+#define ET_DYN            3       /* Shared object file */
+#define ET_CORE           4       /* Core file */
+#define ET_LOPROC         0xff00  /* Processor-specific */
+#define ET_HIPROC         0xffff  /* Processor-specific */
+
+/* Values for Elf32_Ehdr::e_machine (most of this were not included in the
+ * original SCO document but have been gleaned from elsewhere).
+ */
+
+#define EM_NONE            0      /* No machine */
+#define EM_M32             1      /* AT&T WE 32100 */
+#define EM_SPARC           2      /* SPARC */
+#define EM_386             3      /* Intel 80386 */
+#define EM_68K             4      /* Motorola 68000 */
+#define EM_88K             5      /* Motorola 88000 */
+#define EM_486             6      /* Intel 486+ */
+#define EM_860             7      /* Intel 80860 */
+#define EM_MIPS            8      /* MIPS R3000 Big-Endian */
+#define EM_MIPS_RS4_BE     10     /* MIPS R4000 Big-Endian */
+#define EM_PARISC          15     /* HPPA */
+#define EM_SPARC32PLUS     18     /* Sun's "v8plus" */
+#define EM_PPC             20     /* PowerPC */
+#define EM_PPC64           21     /* PowerPC64 */
+#define EM_ARM             40     /* ARM */
+#define EM_SH              42     /* SuperH */
+#define EM_SPARCV9         43     /* SPARC v9 64-bit */
+#define EM_IA_64           50     /* HP/Intel IA-64 */
+#define EM_X86_64          62     /* AMD x86-64 */
+#define EM_S390            22     /* IBM S/390 */
+#define EM_CRIS            76     /* Axis Communications 32-bit embedded processor */
+#define EM_V850            87     /* NEC v850 */
+#define EM_M32R            88     /* Renesas M32R */
+#define EM_H8_300          46
+#define EM_ALPHA           0x9026
+#define EM_CYGNUS_V850     0x9080
+#define EM_CYGNUS_M32R     0x9041
+#define EM_S390_OLD        0xa390
+#define EM_FRV             0x5441
+
+/* Values for Elf32_Ehdr::e_version */
+
+#define EV_NONE            0      /* Invalid version */
+#define EV_CURRENT         1      /* The current version */
+
+/* Ehe ELF identifier */
+
+#define EI_MAG0            0      /* File identification */
+#define EI_MAG1            1      /* "  " "            " */
+#define EI_MAG2            2      /* "  " "            " */
+#define EI_MAG3            3      /* "  " "            " */
+#define EI_CLASS           4      /* File class */
+#define EI_DATA            5      /* Data encoding */
+#define EI_VERSION         6      /* File version */
+#define EI_PAD             7      /* Start of padding bytes */
+#define EI_NIDENT          16     /* Size of eident[] */
+
+#define EI_MAGIC_SIZE      4
+#define EI_MAGIC           {0x7f, 'E', 'L', 'F'}
+
+/* Values for EI_CLASS */
+
+#define ELFCLASSNONE       0      /* Invalid class */
+#define ELFCLASS32         1      /* 32-bit objects */
+#define ELFCLASS64         2      /* 64-bit objects */
+
+/* Values for EI_DATA */
+
+#define ELFDATANONE        0     /* Invalid data encoding */
+#define ELFDATA2LSB        1     /* Least significant byte occupying the lowest address */
+#define ELFDATA2MSB        2     /* Most significant byte occupying the lowest address */
+
+/* Figure 4-7: Special Section Indexes */
+
+#define SHN_UNDEF          0
+#define SHN_LORESERVE      0xff00
+#define SHN_LOPROC         0xff00
+#define SHN_HIPROC         0xff1f
+#define SHN_ABS            0xfff1
+#define SHN_COMMON         0xfff2
+#define SHN_HIRESERVE      0xffff
+
+/* Figure 4-9: Section Types, sh_type */
+
+#define SHT_NULL           0
+#define SHT_PROGBITS       1
+#define SHT_SYMTAB         2
+#define SHT_STRTAB         3
+#define SHT_RELA           4
+#define SHT_HASH           5
+#define SHT_DYNAMIC        6
+#define SHT_NOTE           7
+#define SHT_NOBITS         8
+#define SHT_REL            9
+#define SHT_SHLIB          10
+#define SHT_DYNSYM         11
+#define SHT_LOPROC         0x70000000
+#define SHT_HIPROC         0x7fffffff
+#define SHT_LOUSER         0x80000000
+#define SHT_HIUSER         0xffffffff
+
+/* Figure 4-11: Section Attribute Flags, sh_flags */
+
+#define SHF_WRITE          1
+#define SHF_ALLOC          2
+#define SHF_EXECINSTR      4
+#define SHF_MASKPROC       0xf0000000
+
+/* Definitions for Elf32_Sym::st_info */
+
+#define ELF32_ST_BIND(i)   ((i) >> 4)
+#define ELF32_ST_TYPE(i)   ((i) & 0xf)
+#define ELF32_ST_INFO(b,t) (((b) << 4) | ((t) & 0xf))
+
+/* Figure 4-16: Symbol Binding, ELF32_ST_BIND */
+
+#define STB_LOCAL          0
+#define STB_GLOBAL         1
+#define STB_WEAK           2
+#define STB_LOPROC         13
+#define STB_HIPROC         15
+
+/* Figure 4-17: Symbol Types, ELF32_ST_TYPE */
+
+#define STT_NOTYPE         0
+#define STT_OBJECT         1
+#define STT_FUNC           2
+#define STT_SECTION        3
+#define STT_FILE           4
+#define STT_LOPROC         13
+#define STT_HIPROC         15
+
+/* Definitions for Elf32_Rel*::r_info */
+
+#define ELF32_R_SYM(i)    ((i) >> 8)
+#define ELF32_R_TYPE(i)   ((i) & 0xff)
+#define ELF32_R_INFO(s,t) (((s)<< 8) | ((t) & 0xff))
+
+/* Figure 5-2: Segment Types, p_type */
+
+#define PT_NULL            0
+#define PT_LOAD            1
+#define PT_DYNAMIC         2
+#define PT_INTERP          3
+#define PT_NOTE            4
+#define PT_SHLIB           5
+#define PT_PHDR            6
+#define PT_LOPROC          0x70000000
+#define PT_HIPROC          0x7fffffff
+
+/* Figure 5-3: Segment Flag Bits, p_flags */
+
+#define PF_X               1          /* Execute */
+#define PF_W               2          /* Write */
+#define PF_R               4          /* Read */
+#define PF_MASKPROC        0xf0000000 /* Unspecified */
+
+/* Figure 5-10: Dynamic Array Tags, d_tag */
+
+#define DT_NULL            0          /* d_un=ignored */
+#define DT_NEEDED          1          /* d_un=d_val */
+#define DT_PLTRELSZ        2          /* d_un=d_val */
+#define DT_PLTGOT          3          /* d_un=d_ptr */
+#define DT_HASH            4          /* d_un=d_ptr */
+#define DT_STRTAB          5          /* d_un=d_ptr */
+#define DT_SYMTAB          6          /* d_un=d_ptr */
+#define DT_RELA            7          /* d_un=d_ptr */
+#define DT_RELASZ          8          /* d_un=d_val */
+#define DT_RELAENT         9          /* d_un=d_val */
+#define DT_STRSZ           10         /* d_un=d_val */
+#define DT_SYMENT          11         /* d_un=d_val */
+#define DT_INIT            12         /* d_un=d_ptr */
+#define DT_FINI            13         /* d_un=d_ptr */
+#define DT_SONAME          14         /* d_un=d_val */
+#define DT_RPATH           15         /* d_un=d_val */
+#define DT_SYMBOLIC        16         /* d_un=ignored */
+#define DT_REL             17         /* d_un=d_ptr */
+#define DT_RELSZ           18         /* d_un=d_val */
+#define DT_RELENT          19         /* d_un=d_val */
+#define DT_PLTREL          20         /* d_un=d_val */
+#define DT_DEBUG           21         /* d_un=d_ptr */
+#define DT_TEXTREL         22         /* d_un=ignored */
+#define DT_JMPREL          23         /* d_un=d_ptr */
+#define DT_BINDNOW         24         /* d_un=ignored */
+#define DT_LOPROC          0x70000000 /* d_un=unspecified */
+#define DT_HIPROC          0x7fffffff /* d_un= unspecified */
+
+/****************************************************************************
+ * Public Type Definitions
+ ****************************************************************************/
+
+/* Figure 4.2: 32-Bit Data Types */
+
+typedef uint32_t  Elf32_Addr;  /* Unsigned program address */
+typedef uint16_t  Elf32_Half;  /* Unsigned medium integer */
+typedef uint32_t  Elf32_Off;   /* Unsigned file offset */
+typedef int32_t   Elf32_Sword; /* Signed large integer */
+typedef uint32_t  Elf32_Word;  /* Unsigned large integer */
+
+/* Figure 4-3: ELF Header */
+
+typedef struct
+{
+  unsigned char e_ident[EI_NIDENT];
+  Elf32_Half    e_type;
+  Elf32_Half    e_machine;
+  Elf32_Word    e_version;
+  Elf32_Addr    e_entry;
+  Elf32_Off     e_phoff;
+  Elf32_Off     e_shoff;
+  Elf32_Word    e_flags;
+  Elf32_Half    e_ehsize;
+  Elf32_Half    e_phentsize;
+  Elf32_Half    e_phnum;
+  Elf32_Half    e_shentsize;
+  Elf32_Half    e_shnum;
+  Elf32_Half    e_shstrndx;
+} Elf32_Ehdr;
+
+/* Figure 4-8: Section Header */
+
+typedef struct
+{
+  Elf32_Word    sh_name;
+  Elf32_Word    sh_type;
+  Elf32_Word    sh_flags;
+  Elf32_Addr    sh_addr;
+  Elf32_Off     sh_offset;
+  Elf32_Word    sh_size;
+  Elf32_Word    sh_link;
+  Elf32_Word    sh_info;
+  Elf32_Word    sh_addralign;
+  Elf32_Word    sh_entsize;
+} Elf32_Shdr;
+
+/* Figure 4-15: Symbol Table Entry */
+
+typedef struct
+{
+  Elf32_Word    st_name;
+  Elf32_Addr    st_value;
+  Elf32_Word    st_size;
+  unsigned char st_info;
+  unsigned char st_other;
+  Elf32_Half    st_shndx;
+} Elf32_Sym;
+
+/* Figure 4-19: Relocation Entries */
+
+typedef struct
+{
+  Elf32_Addr   r_offset;
+  Elf32_Word   r_info;
+} Elf32_Rel;
+
+typedef struct
+{
+  Elf32_Addr   r_offset;
+  Elf32_Word   r_info;
+  Elf32_Sword  r_addend;
+} Elf32_Rela;
+
+/* Figure 5-1: Program Header */
+
+typedef struct
+{
+  Elf32_Word   p_type;
+  Elf32_Off    p_offset;
+  Elf32_Addr   p_vaddr;
+  Elf32_Addr   p_paddr;
+  Elf32_Word   p_filesz;
+  Elf32_Word   p_memsz;
+  Elf32_Word   p_flags;
+  Elf32_Word   p_align;
+} Elf32_Phdr;
+
+/* Figure 5-9: Dynamic Structure */
+
+typedef struct
+{
+  Elf32_Sword  d_tag;
+  union
+  {
+    Elf32_Word d_val;
+    Elf32_Addr d_ptr;
+  } d_un;
+} Elf32_Dyn;
+
+//extern Elf32_Dyn _DYNAMIC[] ;
+
+#endif /* __INCLUDE_ELF32_H */

--- a/os/include/sys/syscall.h
+++ b/os/include/sys/syscall.h
@@ -185,12 +185,33 @@
 #ifdef CONFIG_SCHED_HAVE_PARENT
 #define SYS_wait                       (__SYS_waitpid + 1)
 #define SYS_waitid                     (__SYS_waitpid + 2)
-#define __SYS_signals                  (__SYS_waitpid + 3)
+#define __SYS_exec                     (__SYS_waitpid + 3)
 #else
-#define __SYS_signals                  (__SYS_waitpid + 1)
+#define __SYS_exec                     (__SYS_waitpid + 1)
 #endif
 #else
-#define __SYS_signals                   __SYS_waitpid
+#define __SYS_exec                     __SYS_waitpid
+#endif
+
+/* The following can only be defined if we are configured to execute
+ * programs from a file system.
+ */
+
+#ifndef CONFIG_BINFMT_DISABLE
+#ifndef CONFIG_BUILD_KERNEL
+#define SYS_exec                       __SYS_exec
+#define __SYS_execv                    (__SYS_exec + 1)
+#else
+#define __SYS_execv                    __SYS_exec
+#endif
+#ifdef CONFIG_LIBC_EXECFUNCS
+#define SYS_execv                      __SYS_execv
+#define __SYS_signals                  (__SYS_execv + 1)
+#else
+#define __SYS_signals                  __SYS_execv
+#endif
+#else
+#define __SYS_signals                  __SYS_exec
 #endif
 
 /* The following are only defined is signals are supported in the TinyAra

--- a/os/include/tinyara/binfmt/binfmt.h
+++ b/os/include/tinyara/binfmt/binfmt.h
@@ -1,0 +1,356 @@
+/****************************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+/****************************************************************************
+ * include/tinyara/binfmt/binfmt.h
+ *
+ *   Copyright (C) 2009, 2012, 2014, 2017 Gregory Nutt. All rights reserved.
+ *   Author: Gregory Nutt <gnutt@nuttx.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#ifndef __INCLUDE_TINYARA_BINFMT_BINFMT_H
+#define __INCLUDE_TINYARA_BINFMT_BINFMT_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <tinyara/config.h>
+
+#include <sys/types.h>
+
+#include <tinyara/arch.h>
+#include <tinyara/sched.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define BINFMT_NALLOC 3
+
+/****************************************************************************
+ * Public Types
+ ****************************************************************************/
+
+/* The type of one C++ constructor or destructor */
+
+typedef FAR void (*binfmt_ctor_t)(void);
+typedef FAR void (*binfmt_dtor_t)(void);
+
+/* This describes the file to be loaded.
+ *
+ * NOTE 1: The 'filename' must be the full, absolute path to the file to be
+ * executed unless CONFIG_LIB_ENVPATH is defined.  In that case,
+ * 'filename' may be a relative path; a set of candidate absolute paths
+ * will be generated using the PATH environment variable and load_module()
+ * will attempt to load each file that is found at those absolute paths.
+ */
+
+struct symtab_s;
+struct binary_s {
+	/* Information provided to the loader to load and bind a module */
+
+	FAR const char *filename;	/* Full path to the binary to be loaded (See NOTE 1 above) */
+#if defined(CONFIG_ARCH_ADDRENV) && defined(CONFIG_BUILD_KERNEL)
+	FAR char *argbuffer;		/* Allocated argument list */
+	FAR char **argv;			/* Copy of argument list */
+#else
+	FAR char *const *argv;		/* Argument list */
+#endif
+	FAR const struct symtab_s *exports;	/* Table of exported symbols */
+	int nexports;				/* The number of symbols in exports[] */
+
+	/* Information provided from the loader (if successful) describing the
+	 * resources used by the loaded module.
+	 */
+
+	main_t entrypt;				/* Entry point into a program module */
+	FAR void *mapped;			/* Memory-mapped, address space */
+	FAR void *alloc[BINFMT_NALLOC];	/* Allocated address spaces */
+
+#ifdef CONFIG_BINFMT_CONSTRUCTORS
+	/* Constructors/destructors */
+
+	FAR binfmt_ctor_t *ctors;	/* Pointer to a list of constructors */
+	FAR binfmt_dtor_t *dtors;	/* Pointer to a list of destructors */
+	uint16_t nctors;			/* Number of constructors in the list */
+	uint16_t ndtors;			/* Number of destructors in the list */
+#endif
+
+#ifdef CONFIG_ARCH_ADDRENV
+	/* Address environment.
+	 *
+	 * addrenv - This is the handle created by up_addrenv_create() that can be
+	 *   used to manage the tasks address space.
+	 */
+
+	group_addrenv_t addrenv;	/* Task group address environment */
+#endif
+
+	size_t mapsize;				/* Size of the mapped address region (needed for munmap) */
+
+	/* Start-up information that is provided by the loader, but may be modified
+	 * by the caller between load_module() and exec_module() calls.
+	 */
+
+	uint8_t priority;			/* Task execution priority */
+	size_t stacksize;			/* Size of the stack in bytes (unallocated) */
+
+	/* Unload module callback */
+
+	CODE int (*unload)(FAR struct binary_s *bin);
+};
+
+/* This describes one binary format handler */
+
+struct binfmt_s {
+	/* Supports a singly-linked list */
+
+	FAR struct binfmt_s *next;
+
+	/* Verify and load binary into memory */
+
+	CODE int (*load)(FAR struct binary_s *bin);
+
+	/* Unload module callback */
+
+	CODE int (*unload)(FAR struct binary_s *bin);
+};
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: binfmt_initialize
+ *
+ * Description:
+ *   initialize binfmt subsystem
+ *
+ ****************************************************************************/
+
+void binfmt_initialize(void);
+
+/****************************************************************************
+ * Name: register_binfmt
+ *
+ * Description:
+ *   Register a loader for a binary format
+ *
+ * Returned Value:
+ *   This is a NuttX internal function so it follows the convention that
+ *   0 (OK) is returned on success and a negated errno is returned on
+ *   failure.
+ *
+ ****************************************************************************/
+
+int register_binfmt(FAR struct binfmt_s *binfmt);
+
+/****************************************************************************
+ * Name: unregister_binfmt
+ *
+ * Description:
+ *   Register a loader for a binary format
+ *
+ * Returned Value:
+ *   This is a NuttX internal function so it follows the convention that
+ *   0 (OK) is returned on success and a negated errno is returned on
+ *   failure.
+ *
+ ****************************************************************************/
+
+int unregister_binfmt(FAR struct binfmt_s *binfmt);
+
+/****************************************************************************
+ * Name: load_module
+ *
+ * Description:
+ *   Load a module into memory, bind it to an exported symbol take, and
+ *   prep the module for execution.
+ *
+ * Returned Value:
+ *   This is a internal function so it follows the convention that
+ *   0 (OK) is returned on success and a negated errno is returned on
+ *   failure.
+ *
+ ****************************************************************************/
+
+int load_module(FAR struct binary_s *bin);
+
+/****************************************************************************
+ * Name: unload_module
+ *
+ * Description:
+ *   Unload a (non-executing) module from memory.  If the module has
+ *   been started (via exec_module) and has not exited, calling this will
+ *   be fatal.
+ *
+ *   However, this function must be called after the module exist.  How
+ *   this is done is up to your logic.  Perhaps you register it to be
+ *   called by on_exit()?
+ *
+ * Returned Value:
+ *   This is a NuttX internal function so it follows the convention that
+ *   0 (OK) is returned on success and a negated errno is returned on
+ *   failure.
+ *
+ ****************************************************************************/
+
+int unload_module(FAR struct binary_s *bin);
+
+/****************************************************************************
+ * Name: exec_module
+ *
+ * Description:
+ *   Execute a module that has been loaded into memory by load_module().
+ *
+ * Returned Value:
+ *   This is a internal function so it follows the convention that
+ *   0 (OK) is returned on success and a negated errno is returned on
+ *   failure.
+ *
+ ****************************************************************************/
+
+int exec_module(FAR const struct binary_s *bin);
+
+/****************************************************************************
+ * Name: exec
+ *
+ * Description:
+ *   This is a convenience function that wraps load_ and exec_module into
+ *   one call.  If CONFIG_BINFMT_LOADABLE is defined, this function will
+ *   schedule to unload the module when task exits.
+ *
+ *   This non-standard, NuttX function is similar to execv() and
+ *   posix_spawn() but differs in the following ways;
+ *
+ *   - Unlike execv() and posix_spawn() this function accepts symbol table
+ *     information as input parameters. This means that the symbol table
+ *     used to link the application prior to execution is provided by the
+ *     caller, not by the system.
+ *   - Unlike execv(), this function always returns.
+ *
+ *   This non-standard interface is included as a official NuttX API only
+ *   because it is needed in certain build modes: exec() is probably the
+ *   only want to load programs in the PROTECTED mode. Other file execution
+ *   APIs rely on a symbol table provided by the OS. In the PROTECTED build
+ *   mode, the OS cannot provide any meaningful symbolic information for
+ *   execution of code in the user-space blob so that is the exec() function
+ *   is really needed in that build case
+ *
+ *   The interface is available in the FLAT build mode although it is not
+ *   really necessary in that case. It is currently used by some example
+ *   code under the apps/ that that generate their own symbol tables for
+ *   linking test programs. So although it is not necessary, it can still
+ *   be useful.
+ *
+ *   The interface would be completely useless and will not be supported in
+ *   in the KERNEL build mode where the contrary is true: An application
+ *   process cannot provide any meaning symbolic information for use in
+ *   linking a different process.
+ *
+ *   NOTE: This function is flawed and useless without CONFIG_BINFMT_LOADABLE
+ *   because without that features there is then no mechanism to unload the
+ *   module once it exits.
+ *
+ * Input Parameters:
+ *   filename - The path to the program to be executed. If
+ *              CONFIG_LIB_ENVPATH is defined in the configuration, then
+ *              this may be a relative path from the current working
+ *              directory. Otherwise, path must be the absolute path to the
+ *              program.
+ *   argv     - A pointer to an array of string arguments. The end of the
+ *              array is indicated with a NULL entry.
+ *   exports  - The address of the start of the caller-provided symbol
+ *              table. This symbol table contains the addresses of symbols
+ *              exported by the caller and made available for linking the
+ *              module into the system.
+ *   nexports - The number of symbols in the exports table.
+ *
+ * Returned Value:
+ *   This is an end-user function, so it follows the normal convention:
+ *   It returns the PID of the exec'ed module.  On failure, it returns
+ *   -1 (ERROR) and sets errno appropriately.
+ *
+ ****************************************************************************/
+
+int exec(FAR const char *filename, FAR char *const *argv, FAR const struct symtab_s *exports, int nexports);
+
+/****************************************************************************
+ * Name: binfmt_exit
+ *
+ * Description:
+ *   This function may be called when a tasked loaded into RAM exits.
+ *   This function will unload the module when the task exits and reclaim
+ *   all resources used by the module.
+ *
+ * Input Parameters:
+ *   bin - This structure must have been allocated with kmm_malloc() and must
+ *         persist until the task unloads
+ *
+ * Returned Value:
+ *   This is a NuttX internal function so it follows the convention that
+ *   0 (OK) is returned on success and a negated errno is returned on
+ *   failure.
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_BINFMT_LOADABLE
+int binfmt_exit(FAR struct binary_s *bin);
+#endif
+
+#undef EXTERN
+#if defined(__cplusplus)
+}
+#endif
+#endif							/* __INCLUDE_TINYARA_BINFMT_BINFMT_H */

--- a/os/include/tinyara/binfmt/builtin.h
+++ b/os/include/tinyara/binfmt/builtin.h
@@ -1,0 +1,186 @@
+/****************************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+/****************************************************************************
+ * include/tinyara/binfmt/builtin.h
+ *
+ * Originally by:
+ *
+ *   Copyright (C) 2011 Uros Platise. All rights reserved.
+ *   Author: Uros Platise <uros.platise@isotel.eu>
+ *
+ * With subsequent updates, modifications, and general maintenance by:
+ *
+ *   Copyright (C) 2012-2013 Gregory Nutt.  All rights reserved.
+ *   Author: Gregory Nutt <gnutt@nuttx.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#ifndef __INCLUDE_TINYARA_BINFMT_BUILTIN_H
+#define __INCLUDE_TINYARA_BINFMT_BUILTIN_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <tinyara/config.h>
+#include <sys/types.h>
+
+/****************************************************************************
+ * Public Types
+ ****************************************************************************/
+
+struct builtin_s {
+	const char *name;			/* Invocation name and as seen under /sbin/ */
+	int priority;				/* Use: SCHED_PRIORITY_DEFAULT */
+	int stacksize;				/* Desired stack size */
+	main_t main;				/* Entry point: main(int argc, char *argv[]) */
+};
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+#if defined(__cplusplus)
+#define EXTERN extern "C"
+extern "C" {
+#else
+#define EXTERN extern
+#endif
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: builtin_initialize
+ *
+ * Description:
+ *   In order to use the builtin binary format, this function must be called
+ *   during system initialize to register the builtin binary format.
+ *
+ * Returned Value:
+ *   This is a NuttX internal function so it follows the convention that
+ *   0 (OK) is returned on success and a negated errno is returned on
+ *   failure.
+ *
+ ****************************************************************************/
+
+int builtin_initialize(void);
+
+/****************************************************************************
+ * Name: builtin_uninitialize
+ *
+ * Description:
+ *   Unregister the builtin binary loader
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+void builtin_uninitialize(void);
+
+/****************************************************************************
+ * Name: builtin_isavail
+ *
+ * Description:
+ *   Checks for availability of application registered during compile time.
+ *
+ * Input Parameters:
+ *   filename - Name of the linked-in binary to be started.
+ *
+ * Returned Value:
+ *   This is an end-user function, so it follows the normal convention:
+ *   Returns index of builtin application. If it is not found then it
+ *   returns -1 (ERROR) and sets errno appropriately.
+ *
+ ****************************************************************************/
+
+int builtin_isavail(FAR const char *appname);
+
+/****************************************************************************
+ * Name: builtin_getname
+ *
+ * Description:
+ *   Returns pointer to a name of built-in application pointed by the
+ *   index.
+ *
+ * Input Parameters:
+ *   index, from 0 and on ...
+ *
+ * Returned Value:
+ *   Returns valid pointer pointing to the app name if index is valid.
+ *   Otherwise NULL is returned.
+ *
+ ****************************************************************************/
+
+FAR const char *builtin_getname(int index);
+
+/****************************************************************************
+ * Name: builtin_for_index
+ *
+ * Description:
+ *   Returns the builtin_s structure for the selected builtin.
+ *   If support for builtin functions is enabled in the NuttX configuration,
+ *   then this function must be provided by the application code.
+ *
+ * Input Parameters:
+ *   index, from 0 and on...
+ *
+ * Returned Value:
+ *   Returns valid pointer pointing to the builtin_s structure if index is
+ *   valid.
+ *   Otherwise, NULL is returned.
+ *
+ ****************************************************************************/
+
+FAR const struct builtin_s *builtin_for_index(int index);
+
+#undef EXTERN
+#if defined(__cplusplus)
+}
+#endif
+
+#endif							/* __INCLUDE_TINYARA_BINFMT_BUILTIN_H */

--- a/os/include/tinyara/binfmt/elf.h
+++ b/os/include/tinyara/binfmt/elf.h
@@ -1,0 +1,286 @@
+/****************************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+/****************************************************************************
+ * include/tinyara/binfmt/elf.h
+ *
+ *   Copyright (C) 2012, 2014 Gregory Nutt. All rights reserved.
+ *   Author: Gregory Nutt <gnutt@nuttx.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#ifndef __INCLUDE_TINYARA_BINFMT_ELF_H
+#define __INCLUDE_TINYARA_BINFMT_ELF_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <tinyara/config.h>
+
+#include <sys/types.h>
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <elf32.h>
+
+#include <tinyara/arch.h>
+#include <tinyara/binfmt/binfmt.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+/* Configuration ************************************************************/
+
+#ifndef CONFIG_ELF_ALIGN_LOG2
+#define CONFIG_ELF_ALIGN_LOG2 2
+#endif
+
+#ifndef CONFIG_ELF_STACKSIZE
+#define CONFIG_ELF_STACKSIZE 2048
+#endif
+
+#ifndef CONFIG_ELF_BUFFERSIZE
+#define CONFIG_ELF_BUFFERSIZE 32
+#endif
+
+#ifndef CONFIG_ELF_BUFFERINCR
+#define CONFIG_ELF_BUFFERINCR 32
+#endif
+
+/* Allocation array size and indices */
+
+#define LIBELF_ELF_ALLOC     0
+#ifdef CONFIG_BINFMT_CONSTRUCTORS
+#define LIBELF_CTORS_ALLOC 1
+#define LIBELF_CTPRS_ALLOC 2
+#define LIBELF_NALLOC      3
+#else
+#define LIBELF_NALLOC      1
+#endif
+
+/****************************************************************************
+ * Public Types
+ ****************************************************************************/
+
+/* This struct provides a description of the currently loaded instantiation
+ * of an ELF binary.
+ */
+
+struct elf_loadinfo_s {
+	/* elfalloc is the base address of the memory that is allocated to hold the
+	 * ELF program image.
+	 *
+	 * If CONFIG_ARCH_ADDRENV=n, elfalloc will be allocated using kmm_malloc() (or
+	 * kmm_zalloc()).  If CONFIG_ARCH_ADDRENV-y, then elfalloc will be allocated using
+	 * up_addrenv_create().  In either case, there will be a unique instance
+	 * of elfalloc (and stack) for each instance of a process.
+	 *
+	 * The alloc[] array in struct binary_s will hold memory that persists after
+	 * the ELF module has been loaded.
+	 */
+
+	uintptr_t textalloc;		/* .text memory allocated when ELF file was loaded */
+	uintptr_t dataalloc;		/* .bss/.data memory allocated when ELF file was loaded */
+	size_t textsize;			/* Size of the ELF .text memory allocation */
+	size_t datasize;			/* Size of the ELF .bss/.data memory allocation */
+	off_t filelen;				/* Length of the entire ELF file */
+	Elf32_Ehdr ehdr;			/* Buffered ELF file header */
+	FAR Elf32_Shdr *shdr;		/* Buffered ELF section headers */
+	uint8_t *iobuffer;			/* File I/O buffer */
+
+	/* Constructors and destructors */
+
+#ifdef CONFIG_BINFMT_CONSTRUCTORS
+	FAR void *ctoralloc;		/* Memory allocated for ctors */
+	FAR void *dtoralloc;		/* Memory allocated dtors */
+	FAR binfmt_ctor_t *ctors;	/* Pointer to a list of constructors */
+	FAR binfmt_dtor_t *dtors;	/* Pointer to a list of destructors */
+	uint16_t nctors;			/* Number of constructors */
+	uint16_t ndtors;			/* Number of destructors */
+#endif
+
+	/* Address environment.
+	 *
+	 * addrenv - This is the handle created by up_addrenv_create() that can be
+	 *   used to manage the tasks address space.
+	 * oldenv  - This is a value returned by up_addrenv_select() that must be
+	 *   used to restore the current address environment.
+	 */
+
+#ifdef CONFIG_ARCH_ADDRENV
+	group_addrenv_t addrenv;	/* Task group address environment */
+	save_addrenv_t oldenv;		/* Saved address environment */
+#endif
+
+	uint16_t symtabidx;			/* Symbol table section index */
+	uint16_t strtabidx;			/* String table section index */
+	uint16_t buflen;			/* size of iobuffer[] */
+	int filfd;					/* Descriptor for the file being loaded */
+};
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+#undef EXTERN
+#if defined(__cplusplus)
+#define EXTERN extern "C"
+extern "C" {
+#else
+#define EXTERN extern
+#endif
+
+/****************************************************************************
+ * Name: elf_initialize
+ *
+ * Description:
+ *   In order to use the ELF binary format, this function must be called
+ *   during system initialization to register the ELF binary format.
+ *
+ * Returned Value:
+ *   This is a NuttX internal function so it follows the convention that
+ *   0 (OK) is returned on success and a negated errno is returned on
+ *   failure.
+ *
+ ****************************************************************************/
+
+int elf_initialize(void);
+
+/****************************************************************************
+ * Name: elf_uninitialize
+ *
+ * Description:
+ *   Unregister the ELF binary loader
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+void elf_uninitialize(void);
+
+/****************************************************************************
+ * Name: elf_init
+ *
+ * Description:
+ *   This function is called to configure the library to process an ELF
+ *   program binary.
+ *
+ * Returned Value:
+ *   0 (OK) is returned on success and a negated errno is returned on
+ *   failure.
+ *
+ ****************************************************************************/
+
+int elf_init(FAR const char *filename, FAR struct elf_loadinfo_s *loadinfo);
+
+/****************************************************************************
+ * Name: elf_uninit
+ *
+ * Description:
+ *   Releases any resources committed by elf_init().  This essentially
+ *   undoes the actions of elf_init.
+ *
+ * Returned Value:
+ *   0 (OK) is returned on success and a negated errno is returned on
+ *   failure.
+ *
+ ****************************************************************************/
+
+int elf_uninit(FAR struct elf_loadinfo_s *loadinfo);
+
+/****************************************************************************
+ * Name: elf_load
+ *
+ * Description:
+ *   Loads the binary into memory, allocating memory, performing relocations
+ *   and initializing the data and bss segments.
+ *
+ * Returned Value:
+ *   0 (OK) is returned on success and a negated errno is returned on
+ *   failure.
+ *
+ ****************************************************************************/
+
+int elf_load(FAR struct elf_loadinfo_s *loadinfo);
+
+/****************************************************************************
+ * Name: elf_bind
+ *
+ * Description:
+ *   Bind the imported symbol names in the loaded module described by
+ *   'loadinfo' using the exported symbol values provided by 'symtab'.
+ *
+ * Returned Value:
+ *   0 (OK) is returned on success and a negated errno is returned on
+ *   failure.
+ *
+ ****************************************************************************/
+
+struct symtab_s;
+int elf_bind(FAR struct elf_loadinfo_s *loadinfo, FAR const struct symtab_s *exports, int nexports);
+
+/****************************************************************************
+ * Name: elf_unload
+ *
+ * Description:
+ *   This function unloads the object from memory. This essentially undoes
+ *   the actions of elf_load.  It is called only under certain error
+ *   conditions after the module has been loaded but not yet started.
+ *
+ * Returned Value:
+ *   0 (OK) is returned on success and a negated errno is returned on
+ *   failure.
+ *
+ ****************************************************************************/
+
+int elf_unload(struct elf_loadinfo_s *loadinfo);
+
+#undef EXTERN
+#if defined(__cplusplus)
+}
+#endif
+
+#endif							/* __INCLUDE_TINYARA_BINFMT_ELF_H */

--- a/os/include/tinyara/binfmt/symtab.h
+++ b/os/include/tinyara/binfmt/symtab.h
@@ -1,0 +1,114 @@
+/****************************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+/****************************************************************************
+ * include/tinyara/binfmt/symtab.h
+ *
+ *   Copyright (C) 2009, 2015 Gregory Nutt. All rights reserved.
+ *   Author: Gregory Nutt <gnutt@nuttx.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#ifndef __INCLUDE_TINYARA_BINFMT_SYMTAB_H
+#define __INCLUDE_TINYARA_BINFMT_SYMTAB_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <tinyara/config.h>
+#include <tinyara/symtab.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+#undef EXTERN
+#if defined(__cplusplus)
+#define EXTERN extern "C"
+extern "C" {
+#else
+#define EXTERN extern
+#endif
+
+/****************************************************************************
+ * Name: exec_getsymtab
+ *
+ * Description:
+ *   Get the current application symbol table selection as an atomic operation.
+ *
+ * Input Parameters:
+ *   symtab - The location to store the symbol table.
+ *   nsymbols - The location to store the number of symbols in the symbol table.
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+void exec_getsymtab(FAR const struct symtab_s **symtab, FAR int *nsymbols);
+
+/****************************************************************************
+ * Name: exec_setsymtab
+ *
+ * Description:
+ *   Select a new application symbol table selection as an atomic operation.
+ *
+ * Input Parameters:
+ *   symtab - The new symbol table.
+ *   nsymbols - The number of symbols in the symbol table.
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+void exec_setsymtab(FAR const struct symtab_s *symtab, int nsymbols);
+
+#undef EXTERN
+#if defined(__cplusplus)
+}
+#endif
+
+#endif							/* __INCLUDE_TINYARA_BINFMT_SYMTAB_H */

--- a/os/include/tinyara/elf.h
+++ b/os/include/tinyara/elf.h
@@ -1,0 +1,133 @@
+/****************************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+/****************************************************************************
+ * include/tinyara/elf.h
+ *
+ *   Copyright (C) 2019 Pinecone Inc. All rights reserved.
+ *   Author: Xiang Xiao <xiaoxiang@pinecone.net>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#ifndef __INCLUDE_TINYARA_ELF_H
+#define __INCLUDE_TINYARA_ELF_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <elf32.h>
+
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: up_checkarch
+ *
+ * Description:
+ *   Given the ELF header in 'hdr', verify that the module is appropriate
+ *   for the current, configured architecture.  Every architecture that uses
+ *   the module loader must provide this function.
+ *
+ * Input Parameters:
+ *   hdr - The ELF header read from the module file.
+ *
+ * Returned Value:
+ *   True if the architecture supports this module file.
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_LIBC_ARCH_ELF
+bool up_checkarch(FAR const Elf32_Ehdr *hdr);
+#endif
+
+/****************************************************************************
+ * Name: up_relocate and up_relocateadd
+ *
+ * Description:
+ *   Perform on architecture-specific ELF relocation.  Every architecture
+ *   that uses the module loader must provide this function.
+ *
+ * Input Parameters:
+ *   rel - The relocation type
+ *   sym - The ELF symbol structure containing the fully resolved value.
+ *         There are a few relocation types for a few architectures that do
+ *         not require symbol information.  For those, this value will be
+ *         NULL.  Implementations of these functions must be able to handle
+ *         that case.
+ *   addr - The address that requires the relocation.
+ *
+ * Returned Value:
+ *   Zero (OK) if the relocation was successful.  Otherwise, a negated errno
+ *   value indicating the cause of the relocation failure.
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_LIBC_ARCH_ELF
+int up_relocate(FAR const Elf32_Rel *rel, FAR const Elf32_Sym *sym, uintptr_t addr);
+int up_relocateadd(FAR const Elf32_Rela *rel, FAR const Elf32_Sym *sym, uintptr_t addr);
+#endif
+
+/****************************************************************************
+ * Name: up_init_exidx
+ *
+ * Description:
+ *   Initialize the exception index section.
+ *
+ * Input Parameters:
+ *   address - The exception index section address.
+ *   size    - The exception index section size.
+ *
+ * Returned Value:
+ *   Zero (OK) if the initialization was successful. Otherwise, a negated errno
+ *   value indicating the cause of the failure.
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_CXX_EXCEPTION
+int up_init_exidx(Elf32_Addr address, Elf32_Word size);
+#endif
+
+#endif							/* __INCLUDE_TINYARA_ELF_H */

--- a/os/include/tinyara/envpath.h
+++ b/os/include/tinyara/envpath.h
@@ -1,0 +1,175 @@
+/****************************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+/****************************************************************************
+ * include/tinyara/envpath.h
+ *
+ *   Copyright (C) 2018 Gregory Nutt. All rights reserved.
+ *   Author: Gregory Nutt <gnutt@nuttx.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#ifndef __INCLUDE_TINYARA_ENVPATH_H
+#define __INCLUDE_TINYARA_ENVPATH_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <tinyara/config.h>
+
+#ifdef CONFIG_LIB_ENVPATH
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Types
+ ****************************************************************************/
+
+/* ENVPATH_HANDLE is an opaque handle used to traverse the absolute paths
+ * assigned to the PATH environment variable.
+ */
+
+typedef FAR void *ENVPATH_HANDLE;
+
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+#ifdef __cplusplus
+#define EXTERN extern "C"
+extern "C" {
+#else
+#define EXTERN extern
+#endif
+
+/****************************************************************************
+ * Name: envpath_init
+ *
+ * Description:
+ *   Initialize for the traversal of each value in the PATH variable.  The
+ *   usage is sequence is as follows:
+ *
+ * Input Parameters:
+ *   name - The variable name of environment to searches path list.
+ *
+ *   1) Call envpath_init() to initialize for the traversal.  envpath_init()
+ *      will return an opaque handle that can then be provided to
+ *      envpath_next() and envpath_release().
+ *   2) Call envpath_next() repeatedly to examine every file that lies
+ *      in the directories of the PATH variable
+ *   3) Call envpath_release() to free resources set aside by envpath_init().
+ *
+ * Input Parameters:
+ *   None
+ *
+ * Returned Value:
+ *   On success, envpath_init() return a non-NULL, opaque handle that may
+ *   subsequently be used in calls to envpath_next() and envpath_release().
+ *   On error, a NULL handle value will be returned.  The most likely cause
+ *   of an error would be that there is no value associated with the PATH
+ *   variable.
+ *
+ ****************************************************************************/
+
+ENVPATH_HANDLE envpath_init(FAR const char *name);
+
+/****************************************************************************
+ * Name: envpath_next
+ *
+ * Description:
+ *   Traverse all possible values in the PATH variable in attempt to find
+ *   the full path to an executable file when only a relative path is
+ *   provided.
+ *
+ * Input Parameters:
+ *   handle - The handle value returned by envpath_init
+ *   relpath - The relative path to the file to be found.
+ *
+ * Returned Value:
+ *   On success, a non-NULL pointer to a null-terminated string is provided.
+ *   This is the full path to a file that exists in the file system.  This
+ *   function will verify that the file exists (but will not verify that it
+ *   is marked executable).
+ *
+ *   NOTE: The string pointer return in the success case points to allocated
+ *   memory.  This memory must be freed by the called by calling kmm_free().
+ *
+ *   NULL is returned if no path is found to any file with the provided
+ *   'relpath' from any absolute path in the PATH variable.  In this case,
+ *   there is no point in calling envpath_next() further; envpath_release()
+ *   must be called to release resources set aside by expath_init().
+ *
+ ****************************************************************************/
+
+FAR char *envpath_next(ENVPATH_HANDLE handle, FAR const char *relpath);
+
+/****************************************************************************
+ * Name: envpath_release
+ *
+ * Description:
+ *   Release all resources set aside by envpath_init() when the handle value
+ *   was created.  The handle value is invalid on return from this function.
+ *   Attempts to all envpath_next() or envpath_release() with such a 'stale'
+ *   handle will result in undefined (i.e., not good) behavior.
+ *
+ * Input Parameters:
+ *   handle - The handle value returned by envpath_init
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+void envpath_release(ENVPATH_HANDLE handle);
+
+#undef EXTERN
+#ifdef __cplusplus
+}
+#endif
+
+#endif							/* CONFIG_LIB_ENVPATH */
+#endif							/* INCLUDE_TINYARA_ENVPATH_H */

--- a/os/include/tinyara/sched.h
+++ b/os/include/tinyara/sched.h
@@ -336,6 +336,10 @@ struct dspace_s {
 struct join_s;					/* Forward reference                        */
 /* Defined in kernel/pthread/pthread.h       */
 #endif
+
+#ifdef CONFIG_BINFMT_LOADABLE
+struct binary_s;				/* Forward reference                        */
+#endif
 /** @brief Structure for Task Group Information */
 struct task_group_s {
 #if defined(HAVE_GROUP_MEMBERS) || defined(CONFIG_ARCH_ADDRENV)
@@ -367,6 +371,12 @@ struct task_group_s {
 #ifdef CONFIG_SCHED_ONEXIT
 	/* on_exit support ********************************************************** */
 	sq_queue_t tg_onexitfunc;
+#endif
+
+#ifdef CONFIG_BINFMT_LOADABLE
+	/* Loadable module support *************************************************** */
+
+	FAR struct binary_s *tg_bininfo;	/* Describes resources used by program      */
 #endif
 
 #ifdef CONFIG_SCHED_HAVE_PARENT
@@ -819,6 +829,32 @@ pid_t task_vforkstart(FAR struct task_tcb_s *child);
  * @internal
  */
 void task_vforkabort(FAR struct task_tcb_s *child, int errcode);
+
+#ifdef CONFIG_BINFMT_LOADABLE
+/****************************************************************************
+ * Name: group_exitinfo
+ *
+ * Description:
+ *   This function may be called to when a task is loaded into memory.  It
+ *   will setup the to automatically unload the module when the task exits.
+ *
+ * Input Parameters:
+ *   pid     - The task ID of the newly loaded task
+ *   bininfo - This structure allocated with kmm_malloc().  This memory
+ *             persists until the task exits and will be used unloads
+ *             the module from memory.
+ *
+ * Returned Value:
+ *   This is a NuttX internal function so it follows the convention that
+ *   0 (OK) is returned on success and a negated errno is returned on
+ *   failure.
+ *
+ ****************************************************************************/
+/**
+ * @internal
+ */
+int group_exitinfo(pid_t pid, FAR struct binary_s *bininfo);
+#endif
 /**
  * @endcond
  */

--- a/os/include/tinyara/symtab.h
+++ b/os/include/tinyara/symtab.h
@@ -1,0 +1,170 @@
+/****************************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+/****************************************************************************
+ * include/tinyara/binfmt/symtab.h
+ *
+ *   Copyright (C) 2009, 2015 Gregory Nutt. All rights reserved.
+ *   Author: Gregory Nutt <gnutt@nuttx.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#ifndef __INCLUDE_TINYARA_SYMTAB_H
+#define __INCLUDE_TINYARA_SYMTAB_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <tinyara/config.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Types
+ ****************************************************************************/
+
+/* struct symbtab_s describes one entry in the symbol table.  A symbol table
+ * is a fixed size array of struct symtab_s.  The information is intentionally
+ * minimal and supports only:
+ *
+ * 1. Function pointers as sym_values.  Of other kinds of values need to be
+ *    supported, then typing information would also need to be included in
+ *    the structure.
+ *
+ * 2. Fixed size arrays.  There is no explicit provisional for dyanamically
+ *    adding or removing entries from the symbol table (realloc might be
+ *    used for that purpose if needed).  The intention is to support only
+ *    fixed size arrays completely defined at compilation or link time.
+ */
+
+struct symtab_s {
+	FAR const char *sym_name;	/* A pointer to the symbol name string */
+	FAR const void *sym_value;	/* The value associated witht the string */
+};
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+#undef EXTERN
+#if defined(__cplusplus)
+#define EXTERN extern "C"
+extern "C" {
+#else
+#define EXTERN extern
+#endif
+
+/****************************************************************************
+ * Name: symtab_findbyname
+ *
+ * Description:
+ *   Find the symbol in the symbol table with the matching name.
+ *   This version assumes that table is not ordered with respect to symbol
+ *   name and, hence, access time will be linear with respect to nsyms.
+ *
+ * Returned Value:
+ *   A reference to the symbol table entry if an entry with the matching
+ *   name is found; NULL is returned if the entry is not found.
+ *
+ ****************************************************************************/
+
+FAR const struct symtab_s *symtab_findbyname(FAR const struct symtab_s *symtab, FAR const char *name, int nsyms);
+
+/****************************************************************************
+ * Name: symtab_findorderedbyname
+ *
+ * Description:
+ *   Find the symbol in the symbol table with the matching name.
+ *   This version assumes that table ordered with respect to symbol name.
+ *
+ * Returned Value:
+ *   A reference to the symbol table entry if an entry with the matching
+ *   name is found; NULL is returned if the entry is not found.
+ *
+ ****************************************************************************/
+
+FAR const struct symtab_s *symtab_findorderedbyname(FAR const struct symtab_s *symtab, FAR const char *name, int nsyms);
+
+/****************************************************************************
+ * Name: symtab_findbyvalue
+ *
+ * Description:
+ *   Find the symbol in the symbol table whose value closest (but not greater
+ *   than), the provided value. This version assumes that table is not ordered
+ *   with respect to symbol name and, hence, access time will be linear with
+ *   respect to nsyms.
+ *
+ * Returned Value:
+ *   A reference to the symbol table entry if an entry with the matching
+ *   name is found; NULL is returned if the entry is not found.
+ *
+ ****************************************************************************/
+
+FAR const struct symtab_s *symtab_findbyvalue(FAR const struct symtab_s *symtab, FAR void *value, int nsyms);
+
+/****************************************************************************
+ * Name: symtab_findorderedbyvalue
+ *
+ * Description:
+ *   Find the symbol in the symbol table whose value closest (but not greater
+ *   than), the provided value. This version assumes that table is ordered
+ *   with respect to symbol name.
+ *
+ * Returned Value:
+ *   A reference to the symbol table entry if an entry with the matching
+ *   name is found; NULL is returned if the entry is not found.
+ *
+ ****************************************************************************/
+
+FAR const struct symtab_s *symtab_findorderedbyvalue(FAR const struct symtab_s *symtab, FAR void *value, int nsyms);
+
+#undef EXTERN
+#if defined(__cplusplus)
+}
+#endif
+
+#endif							/* __INCLUDE_TINYARA_SYMTAB_H */

--- a/os/kernel/group/Make.defs
+++ b/os/kernel/group/Make.defs
@@ -69,6 +69,10 @@ ifneq ($(CONFIG_DISABLE_SIGNALS),y)
 CSRCS += group_signal.c
 endif
 
+ifeq ($(CONFIG_BINFMT_LOADABLE),y)
+CSRCS += group_exitinfo.c
+endif
+
 ifeq ($(CONFIG_BUILD_PROTECTED),y)
 CSRCS += group_malloc.c group_zalloc.c group_free.c
 else

--- a/os/kernel/group/group_exitinfo.c
+++ b/os/kernel/group/group_exitinfo.c
@@ -1,0 +1,125 @@
+/****************************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+/****************************************************************************
+ * kernel/group/group_exitinfo.c
+ *
+ *   Copyright (C) 2018 Gregory Nutt. All rights reserved.
+ *   Author: Gregory Nutt <gnutt@nuttx.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <tinyara/config.h>
+
+#include <sys/types.h>
+#include <errno.h>
+
+#include <tinyara/sched.h>
+#include <tinyara/irq.h>
+#include <tinyara/binfmt/binfmt.h>
+
+#include "sched/sched.h"
+#include "group/group.h"
+
+#ifdef CONFIG_BINFMT_LOADABLE
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: group_exitinfo
+ *
+ * Description:
+ *   This function may be called to when a task is loaded into memory.  It
+ *   will setup the to automatically unload the module when the task exits.
+ *
+ * Input Parameters:
+ *   pid     - The task ID of the newly loaded task
+ *   bininfo - This structure allocated with kmm_malloc().  This memory
+ *             persists until the task exits and will be used unloads
+ *             the module from memory.
+ *
+ * Returned Value:
+ *   This is a NuttX internal function so it follows the convention that
+ *   0 (OK) is returned on success and a negated errno is returned on
+ *   failure.
+ *
+ ****************************************************************************/
+
+int group_exitinfo(pid_t pid, FAR struct binary_s *bininfo)
+{
+	FAR struct tcb_s *tcb;
+	FAR struct task_group_s *group;
+	irqstate_t flags;
+
+	DEBUGASSERT(bininfo != NULL);
+	flags = irqsave();
+
+	/* Get the TCB associated with the PID */
+
+	tcb = sched_gettcb(pid);
+	if (tcb == NULL) {
+		irqrestore(flags);
+		return -ESRCH;
+	}
+
+	/* Get the group that this task belongs to */
+
+	group = tcb->group;
+	DEBUGASSERT(group != NULL && group->tg_bininfo == NULL);
+
+	/* Save the binary info for use when the task exits */
+
+	group->tg_bininfo = bininfo;
+
+	irqrestore(flags);
+	return OK;
+}
+
+#endif							/* CONFIG_BINFMT_LOADABLE */

--- a/os/kernel/group/group_leave.c
+++ b/os/kernel/group/group_leave.c
@@ -71,6 +71,10 @@
 #include "mqueue/mqueue.h"
 #include "group/group.h"
 
+#ifdef CONFIG_BINFMT_LOADABLE
+#include <tinyara/binfmt/binfmt.h>
+#endif
+
 #ifdef HAVE_TASK_GROUP
 
 /*****************************************************************************
@@ -277,6 +281,18 @@ static inline void group_release(FAR struct task_group_s *group)
 		sched_kfree(group->tg_streamlist);
 	}
 #endif
+#endif
+
+#ifdef CONFIG_BINFMT_LOADABLE
+	/* If the exiting task was loaded into RAM from a file, then we need to
+	 * lease all of the memory resource when the last thread exits the task
+	 * group.
+	 */
+
+	if (group->tg_bininfo != NULL) {
+		binfmt_exit(group->tg_bininfo);
+		group->tg_bininfo = NULL;
+	}
 #endif
 
 	/* Release the group container itself */

--- a/os/kernel/init/os_start.c
+++ b/os/kernel/init/os_start.c
@@ -61,6 +61,7 @@
 #include  <debug.h>
 
 #include  <tinyara/arch.h>
+#include  <tinyara/binfmt/binfmt.h>
 #include  <tinyara/compiler.h>
 #include  <tinyara/sched.h>
 #include  <tinyara/fs/fs.h>
@@ -549,6 +550,12 @@ void os_start(void)
 	 */
 
 	lib_initialize();
+
+#ifndef CONFIG_BINFMT_DISABLE
+	/* Initialize the binfmt system */
+
+	binfmt_initialize();
+#endif
 
 	/* IDLE Group Initialization **********************************************/
 #ifdef HAVE_TASK_GROUP

--- a/os/kernel/task/Make.defs
+++ b/os/kernel/task/Make.defs
@@ -78,6 +78,12 @@ ifeq ($(CONFIG_CANCELLATION_POINTS),y)
 CSRCS += task_setcanceltype.c task_testcancel.c task_cancelpt.c
 endif
 
+ifneq ($(CONFIG_BINFMT_DISABLE),y)
+ifeq ($(CONFIG_LIBC_EXECFUNCS),y)
+CSRCS += task_execv.c
+endif
+endif
+
 # Include task build support
 
 DEPPATH += --dep-path task

--- a/os/syscall/syscall.csv
+++ b/os/syscall/syscall.csv
@@ -17,6 +17,8 @@
 "connect", "sys/socket.h", "CONFIG_NSOCKET_DESCRIPTORS > 0 && defined(CONFIG_NET)", "int", "int", "FAR const struct sockaddr*", "socklen_t"
 "dup", "unistd.h", "CONFIG_NFILE_DESCRIPTORS > 0", "int", "int"
 "dup2", "unistd.h", "CONFIG_NFILE_DESCRIPTORS > 0", "int", "int", "int"
+"exec","tinyara/binfmt/binfmt.h","!defined(CONFIG_BINFMT_DISABLE) && !defined(CONFIG_BUILD_KERNEL)","int","FAR const char *","FAR char * const *","FAR const struct symtab_s *","int"
+"execv","unistd.h","!defined(CONFIG_BINFMT_DISABLE) && defined(CONFIG_LIBC_EXECFUNCS)","int","FAR const char *","FAR char *const []|FAR char *const *"
 "exit", "stdlib.h", "", "void", "int"
 "fcntl", "fcntl.h", "CONFIG_NFILE_DESCRIPTORS > 0", "int", "int", "int", "..."
 "fs_fdopen", "tinyara/fs/fs.h", "CONFIG_NFILE_DESCRIPTORS > 0 && CONFIG_NFILE_STREAMS > 0", "FAR struct file_struct*", "int", "int", "FAR struct tcb_s*"

--- a/os/syscall/syscall_lookup.h
+++ b/os/syscall/syscall_lookup.h
@@ -131,6 +131,19 @@ SYSCALL_LOOKUP(waitid,                  4, STUB_waitid)
 #  endif
 #endif
 
+/* The following can only be defined if we are configured to execute
+ * programs from a file system.
+ */
+
+#ifndef CONFIG_BINFMT_DISABLE
+#ifndef CONFIG_BUILD_KERNEL
+SYSCALL_LOOKUP(exec,                     4, STUB_exec)
+#endif
+#ifdef CONFIG_LIBC_EXECFUNCS
+SYSCALL_LOOKUP(execv,                    2, STUB_execv)
+#endif
+#endif
+
 /* The following are only defined is signals are supported in the TinyAra
  * configuration.
  */

--- a/os/syscall/syscall_stublookup.c
+++ b/os/syscall/syscall_stublookup.c
@@ -127,6 +127,14 @@ uintptr_t STUB_wait(int nbr, uintptr_t parm1);
 uintptr_t STUB_waitid(int nbr, uintptr_t parm1, uintptr_t parm2,
 					  uintptr_t parm3, uintptr_t parm4);
 
+/* The following can only be defined if we are configured to execute
+ * programs from a file system.
+ */
+
+uintptr_t STUB_exec(int nbr, uintptr_t parm1, uintptr_t parm2,
+					uintptr_t parm3, uintptr_t parm4);
+uintptr_t STUB_execv(int nbr, uintptr_t parm1, uintptr_t parm2);
+
 /* The following are only defined is signals are supported in the TinyAra
  * configuration.
  */


### PR DESCRIPTION
	This PR adds below features
		- Port generic loader (binfmt)
		- Port ELF loader
		- Port required misc changes for libc
		- Add exec & execv syscall
		- Fix architecture code support elf loader
	
	To be done :
		- Add sample fully linked test applications support
		- Currently it uses user heap allocation for elf loading, It needs to be replaced with per app memory allocation