### PR TITLE
framework/wifi_manager: Return already_connected in connected state

### DIFF
--- a/framework/src/wifi_manager/wifi_manager.c
+++ b/framework/src/wifi_manager/wifi_manager.c
@@ -1168,6 +1168,9 @@ wifi_manager_result_e _handler_on_connected_state(_wifimgr_msg_s *msg)
 		WIFIMGR_CHECK_RESULT(_wifimgr_scan(), "fail scan\n", WIFI_MANAGER_FAIL);
 		WIFIMGR_STORE_PREV_STATE;
 		WIFIMGR_SET_STATE(WIFIMGR_SCANNING);
+	} else if (msg->event == EVT_CONNECT) {
+		WIFIADD_ERR_RECORD(ERR_WIFIMGR_INVALID_EVENT);
+		return WIFI_MANAGER_ALREADY_CONNECTED;
 	} else {
 		WIFIADD_ERR_RECORD(ERR_WIFIMGR_INVALID_EVENT);
 		return WIFI_MANAGER_FAIL;


### PR DESCRIPTION
- Return WIFI_MANAGER_ALREADY_CONNECTED when EVT_CONNECT occurs in connected state