### PR TITLE
framework/st_things: Add error handling logic for data manager.

### DIFF
--- a/framework/src/st_things/things_stack/framework/things_data_manager.c
+++ b/framework/src/st_things/things_stack/framework/things_data_manager.c
@@ -553,6 +553,10 @@ char *get_json_string_from_file(const char *filename)
 	}
 
 	json_str = (char *)things_malloc(size + 1);
+	if (json_str == NULL) {
+		THINGS_LOG_E(TAG, "Failed to allocate memory(%d).", size + 1);
+		return NULL;
+	}
 
 	// 1. File Read
 	fp = fopen(filename, "r");


### PR DESCRIPTION
There can be a case which device has not enough memory to allocate.
And things_malloc can return NULL.