### PR TITLE
Back-port Nuttx patch for protected build MM

### DIFF
--- a/build/configs/artik05x/scripts/user-space.ld
+++ b/build/configs/artik05x/scripts/user-space.ld
@@ -111,6 +111,7 @@ SECTIONS
 
     .data : {
         _sdata = ABSOLUTE(.);
+        *(.uspace.data)
         *(.data .data.*)
         *(.gnu.linkonce.d.*)
         CONSTRUCTORS

--- a/os/arch/arm/src/common/up_allocateheap.c
+++ b/os/arch/arm/src/common/up_allocateheap.c
@@ -220,11 +220,11 @@ void up_addregion(void)
 
 	for (region_cnt = 1; region_cnt < CONFIG_MM_REGIONS; region_cnt++) {
 		if (heapx_is_init[regionx_heap_idx[region_cnt]] != true) {
-			mm_initialize(&g_mmheap[regionx_heap_idx[region_cnt]], regionx_start[region_cnt], regionx_size[region_cnt]);
+			mm_initialize(&USR_HEAP[regionx_heap_idx[region_cnt]], regionx_start[region_cnt], regionx_size[region_cnt]);
 			heapx_is_init[regionx_heap_idx[region_cnt]] = true;
 			continue;
 		}
-		mm_addregion(&g_mmheap[regionx_heap_idx[region_cnt]], regionx_start[region_cnt], regionx_size[region_cnt]);
+		mm_addregion(&USR_HEAP[regionx_heap_idx[region_cnt]], regionx_start[region_cnt], regionx_size[region_cnt]);
 	}
 }
 #endif

--- a/os/arch/arm/src/common/up_userspace.c
+++ b/os/arch/arm/src/common/up_userspace.c
@@ -60,6 +60,7 @@
 #include <assert.h>
 
 #include <tinyara/userspace.h>
+#include <tinyara/arch.h>
 
 #ifdef CONFIG_BUILD_PROTECTED
 
@@ -70,6 +71,12 @@
 /****************************************************************************
  * Private Data
  ****************************************************************************/
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+extern uint32_t __usram_segment_start__[];
+struct userspace_s *g_k_userspace = ((FAR struct userspace_s *)CONFIG_TINYARA_USERSPACE);
 
 /****************************************************************************
  * Private Functions
@@ -97,7 +104,6 @@ void up_userspace(void)
 	uint8_t	*end;
 
 	/* Clear all of user-space .bss */
-
 	DEBUGASSERT(USERSPACE->us_bssstart != 0 && USERSPACE->us_bssend != 0 &&
 			USERSPACE->us_bssstart <= USERSPACE->us_bssend);
 
@@ -122,5 +128,14 @@ void up_userspace(void)
 		*dest++ = *src++;
 	}
 
+	/* Initialize shared userspace object */
+	src = (uint8_t *)g_k_userspace;
+	end = (uint8_t *)src + sizeof(struct userspace_s);
+	g_k_userspace = (FAR struct userspace_s *)__usram_segment_start__;
+	dest = (uint8_t *)g_k_userspace;
+
+	while (src != end) {
+		*dest++ = *src++;
+	}
 }
 #endif /* CONFIG_BUILD_PROTECTED */

--- a/os/board/artik05x/userspace/up_userspace.c
+++ b/os/board/artik05x/userspace/up_userspace.c
@@ -99,7 +99,9 @@ extern uint32_t _edata;           /* End+1 of .data */
 extern uint32_t _sbss;            /* Start of .bss */
 extern uint32_t _ebss;            /* End+1 of .bss */
 
-const struct userspace_s userspace __attribute__((section(".userspace"))) = {
+struct userspace_s g_userspace __attribute__((section(".uspace.data")));
+
+struct userspace_s userspace __attribute__((section(".userspace"))) = {
 	/* General memory map */
 
 	.us_entrypoint    = (main_t)CONFIG_USER_ENTRYPOINT,
@@ -122,25 +124,12 @@ const struct userspace_s userspace __attribute__((section(".userspace"))) = {
 #ifndef CONFIG_DISABLE_SIGNALS
 	.signal_handler   = up_signal_handler,
 #endif
-	/* Memory manager entry points (declared in include/tinyara/mm/mm.h) */
-
-	.mm_initialize    = umm_initialize,
-	.mm_addregion     = umm_addregion,
-	.mm_trysemaphore  = umm_trysemaphore,
-	.mm_givesemaphore = umm_givesemaphore,
-
-	/* Memory manager entry points (declared in include/stdlib.h) */
-
-	.mm_memalign      = memalign,
-	.mm_malloc        = malloc,
-	.mm_realloc       = realloc,
-	.mm_zalloc        = zalloc,
-	.mm_free          = free,
 
 	/* pre-application entry points (declared in include/tinyara/init.h) */
 
 	.preapp_start    = preapp_start,
 };
+
 
 /****************************************************************************
  * Public Functions

--- a/os/include/tinyara/kmalloc.h
+++ b/os/include/tinyara/kmalloc.h
@@ -104,32 +104,12 @@ extern "C" {
 #define kumm_trysemaphore(a)      umm_trysemaphore(a)
 #define kumm_givesemaphore(a)     umm_givesemaphore(a)
 
-#ifdef CONFIG_BUILD_PROTECTED
-/* In the kernel-phase of the protected build, the these macros are defined
- * in userspace.h.  These macros version call into user-space via a header
- * at the beginning of the user-space blob.
- */
-
-#define kumm_malloc(s)         umm_malloc(s)
-#define kumm_zalloc(s)         umm_zalloc(s)
-#define kumm_realloc(p, s)     umm_realloc(p, s)
-#define kumm_memalign(a, s)    umm_memalign(a, s)
-#define kumm_free(p)           umm_free(p)
-#define kumm_mallinfo()        umm_mallinfo()
-#else
-/* In the flat build (CONFIG_BUILD_FLAT) and in the kernel build
- * (CONFIG_BUILD_KERNEL), the following are declared in stdlib.h and are
- * directly callable.
- */
-
 #define kumm_malloc(s)          malloc(s)
 #define kumm_zalloc(s)          zalloc(s)
 #define kumm_realloc(p, s)      realloc(p, s)
 #define kumm_memalign(a, s)     memalign(a, s)
 #define kumm_free(p)            free(p)
 #define kumm_mallinfo()         mallinfo()
-
-#endif
 
 /* This family of allocators is used to manage kernel protected memory */
 

--- a/os/include/tinyara/mm/mm.h
+++ b/os/include/tinyara/mm/mm.h
@@ -401,7 +401,6 @@ extern "C" {
 #define EXTERN extern
 #endif
 
-#if !defined(CONFIG_BUILD_PROTECTED) || !defined(__KERNEL__)
 /* User heap structure:
  *
  * - Flat build:  In the FLAT build, the user heap structure is a globally
@@ -412,6 +411,25 @@ extern "C" {
  *   structure is associated with the address environment and there is
  *   no global user heap structure.
  */
+ #if defined(CONFIG_ARCH_ADDRENV) && defined(CONFIG_BUILD_KERNEL)
+/* In the kernel build, there a multiple user heaps; one for each task
+ * group.  In this build configuration, the user heap structure lies
+ * in a reserved region at the beginning of the .bss/.data address
+ * space (CONFIG_ARCH_DATA_VBASE).  The size of that region is given by
+ * ARCH_DATA_RESERVE_SIZE
+ */
+
+#elif defined(CONFIG_BUILD_PROTECTED) && defined(__KERNEL__)
+/* In the protected mode, there are two heaps:  A kernel heap and a single
+ * user heap.  In that case the user heap structure lies in the user space
+ * (with a reference in the userspace interface).
+ */
+
+#elif defined(CONFIG_BUILD_PROTECTED) && !defined(__KERNEL__)
+#include <tinyara/userspace.h>
+extern struct userspace_s g_userspace;
+#else
+/* Otherwise, the user heap data structures are in common .bss */
 extern struct mm_heap_s g_mmheap[CONFIG_MM_NHEAPS];
 #endif
 
@@ -432,6 +450,12 @@ EXTERN struct mm_heap_s g_kmmheap;
 #include <tinyara/addrenv.h>
 #define BASE_HEAP (&ARCH_DATA_RESERVE->ar_usrheap)
 
+#elif defined(CONFIG_BUILD_PROTECTED) && !defined(__KERNEL__)
+/*The user heap data structure is in shared userspace object */
+#define BASE_HEAP &(g_userspace.us_heap[0])
+#elif defined(CONFIG_BUILD_PROTECTED) && defined(__KERNEL__)
+#include <tinyara/userspace.h>
+#define BASE_HEAP &(USERSPACE->us_heap[0])
 #else
 /* Otherwise, the user heap data structures are in common .bss */
 
@@ -786,6 +810,7 @@ void *zalloc_at(int heap_index, size_t size);
 #undef EXTERN
 #ifdef __cplusplus
 }
+
 #endif
 
 #endif							/* __INCLUDE_MM_MM_H */

--- a/os/kernel/init/os_start.c
+++ b/os/kernel/init/os_start.c
@@ -374,6 +374,7 @@ void os_start(void)
 
 	sem_initialize();
 
+
 #if defined(MM_KERNEL_USRHEAP_INIT) || defined(CONFIG_MM_KERNEL_HEAP) || defined(CONFIG_MM_PGALLOC)
 	/* Initialize the memory manager */
 
@@ -386,8 +387,9 @@ void os_start(void)
 		 * the user-mode memory allocator.
 		 */
 		up_allocate_heap(&heap_start, &heap_size);
+
 #if CONFIG_MM_REGIONS > 1
-		mm_initialize(&g_mmheap[regionx_heap_idx[0]], heap_start, heap_size);
+		mm_initialize(&USR_HEAP[regionx_heap_idx[0]], heap_start, heap_size);
 		heapx_is_init[regionx_heap_idx[0]] = true;
 		up_addregion();
 #else

--- a/os/mm/mm_heap/mm_getheap.c
+++ b/os/mm/mm_heap/mm_getheap.c
@@ -26,8 +26,16 @@
 #include <tinyara/sched.h>
 #endif
 
-#if !defined(CONFIG_BUILD_PROTECTED) || !defined(__KERNEL__)
+#if defined(CONFIG_BUILD_PROTECTED) && defined(__KERNEL__)
+#include <tinyara/userspace.h>
+#define USR_HEAP	(USERSPACE->us_heap)
+#elif defined(CONFIG_BUILD_PROTECTED)
+#include <tinyara/userspace.h>
+extern struct userspace_s g_userspace;
+#define USR_HEAP	(g_userspace.us_heap)
+#else
 extern struct mm_heap_s g_mmheap[CONFIG_MM_NHEAPS];
+#define USR_HEAP	g_mmheap
 #endif
 /****************************************************************************
  * Pre-processor Definitions
@@ -47,24 +55,20 @@ struct mm_heap_s *mm_get_heap(void *address)
 {
 #ifdef CONFIG_MM_KERNEL_HEAP
 	if (address >= (FAR void *)g_kmmheap.mm_heapstart[0] && address < (FAR void *)g_kmmheap.mm_heapend[0]) {
-                return &g_kmmheap;
-        }
+		return &g_kmmheap;
+	}
 #endif
-#if !defined(CONFIG_BUILD_PROTECTED) || !defined(__KERNEL__)
 	int heap_idx;
 	heap_idx = mm_get_heapindex(address);
 	if (heap_idx == INVALID_HEAP_IDX) {
 		mdbg("address is not in heap region.\n");
 		return NULL;
 	}
-	return &g_mmheap[heap_idx];
-#endif
 
-	return NULL;
+	return &USR_HEAP[heap_idx];
 }
 
 
-#if !defined(CONFIG_BUILD_PROTECTED) || !defined(__KERNEL__)
 /****************************************************************************
  * Name: mm_get_heap_with_index
  ****************************************************************************/
@@ -74,7 +78,8 @@ struct mm_heap_s *mm_get_heap_with_index(int index)
 		mdbg("heap index is out of range.\n");
 		return NULL;
 	}
-	return &g_mmheap[index];
+
+	return &USR_HEAP[index];
 }
 
 /****************************************************************************
@@ -83,14 +88,14 @@ struct mm_heap_s *mm_get_heap_with_index(int index)
 int mm_get_heapindex(void *mem)
 {
 	int heap_idx;
+
 	if (mem == NULL) {
 		return 0;
 	}
 	for (heap_idx = 0; heap_idx < CONFIG_MM_NHEAPS; heap_idx++) {
-		if (mem < (void *)(g_mmheap[heap_idx].mm_heapstart + g_mmheap[heap_idx].mm_heapsize) && mem >= (void *)g_mmheap[heap_idx].mm_heapstart) {
+		if (mem < (void *)(USR_HEAP[heap_idx].mm_heapstart + USR_HEAP[heap_idx].mm_heapsize) && mem >= (void *)USR_HEAP[heap_idx].mm_heapstart) {
 			return heap_idx;
 		}
 	}
 	return INVALID_HEAP_IDX;
 }
-#endif

--- a/os/mm/umm_heap/umm_addregion.c
+++ b/os/mm/umm_heap/umm_addregion.c
@@ -57,8 +57,6 @@
 #include <tinyara/config.h>
 #include <tinyara/mm/mm.h>
 
-#if !defined(CONFIG_BUILD_PROTECTED) || !defined(__KERNEL__)
-
 /************************************************************************
  * Pre-processor definition
  ************************************************************************/
@@ -100,5 +98,3 @@ void umm_addregion(FAR void *heap_start, size_t heap_size)
 {
 	mm_addregion(BASE_HEAP, heap_start, heap_size);
 }
-
-#endif							/* !CONFIG_BUILD_PROTECTED || !__KERNEL__ */

--- a/os/mm/umm_heap/umm_brkaddr.c
+++ b/os/mm/umm_heap/umm_brkaddr.c
@@ -58,8 +58,6 @@
 #include <assert.h>
 #include <tinyara/mm/mm.h>
 
-#if !defined(CONFIG_BUILD_PROTECTED) || !defined(__KERNEL__)
-
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
@@ -81,4 +79,3 @@ FAR void *umm_brkaddr(int region)
 	return mm_brkaddr(BASE_HEAP, region);
 }
 
-#endif							/* !CONFIG_BUILD_PROTECTED || !__KERNEL__ */

--- a/os/mm/umm_heap/umm_calloc.c
+++ b/os/mm/umm_heap/umm_calloc.c
@@ -59,7 +59,7 @@
 #include <debug.h>
 #include <tinyara/mm/mm.h>
 
-#if !defined(CONFIG_BUILD_PROTECTED) || !defined(__KERNEL__)
+#include "umm_heap.h"
 
 /****************************************************************************
  * Pre-processor Definitions
@@ -90,9 +90,9 @@ void *calloc_at(int heap_index, size_t n, size_t elem_size)
 	}
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
 	ARCH_GET_RET_ADDRESS
-	return mm_calloc(&g_mmheap[heap_index], n, elem_size, retaddr);
+	return mm_calloc(&USR_HEAP[heap_index], n, elem_size, retaddr);
 #else
-	return mm_calloc(&g_mmheap[heap_index], n, elem_size);
+	return mm_calloc(&USR_HEAP[heap_index], n, elem_size);
 #endif
 }
 #endif
@@ -113,9 +113,9 @@ FAR void *calloc(size_t n, size_t elem_size)
 #endif
 	for (heap_idx = 0; heap_idx < CONFIG_MM_NHEAPS; heap_idx++) {
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
-		ret = mm_calloc(&g_mmheap[heap_idx], n, elem_size, retaddr);
+		ret = mm_calloc(&USR_HEAP[heap_idx], n, elem_size, retaddr);
 #else
-		ret = mm_calloc(&g_mmheap[heap_idx], n, elem_size);
+		ret = mm_calloc(&USR_HEAP[heap_idx], n, elem_size);
 #endif
 		if (ret != NULL) {
 			return ret;
@@ -124,4 +124,3 @@ FAR void *calloc(size_t n, size_t elem_size)
 	return NULL;
 }
 
-#endif							/* !CONFIG_BUILD_PROTECTED || !__KERNEL__ */

--- a/os/mm/umm_heap/umm_extend.c
+++ b/os/mm/umm_heap/umm_extend.c
@@ -56,8 +56,7 @@
 
 #include <tinyara/config.h>
 #include <tinyara/mm/mm.h>
-
-#if !defined(CONFIG_BUILD_PROTECTED) || !defined(__KERNEL__)
+#include "umm_heap.h"
 
 /****************************************************************************
  * Pre-processor Definitions
@@ -81,8 +80,7 @@ void umm_extend(FAR void *mem, size_t size, int region)
 	int heap_idx;
 	heap_idx = mm_get_heapindex(mem);
 	if (heap_idx != INVALID_HEAP_IDX) {
-		mm_extend(&g_mmheap[heap_idx], mem, size, region);
+		mm_extend(&USR_HEAP[heap_idx], mem, size, region);
 	}
 }
 
-#endif							/* !CONFIG_BUILD_PROTECTED || !__KERNEL__ */

--- a/os/mm/umm_heap/umm_initialize.c
+++ b/os/mm/umm_heap/umm_initialize.c
@@ -58,8 +58,6 @@
 #include <assert.h>
 #include <tinyara/mm/mm.h>
 
-#if !defined(CONFIG_BUILD_PROTECTED) || !defined(__KERNEL__)
-
 /************************************************************************
  * Pre-processor definition
  ************************************************************************/
@@ -73,8 +71,9 @@
  ************************************************************************/
 #if !defined(CONFIG_ARCH_ADDRENV) || !defined(CONFIG_BUILD_KERNEL)
 /* Otherwise, the user heap data structures are in common .bss */
-
+#if !defined(CONFIG_BUILD_PROTECTED)
 struct mm_heap_s g_mmheap[CONFIG_MM_NHEAPS];
+#endif
 #endif
 
 /************************************************************************
@@ -134,5 +133,3 @@ void umm_initialize(FAR void *heap_start, size_t heap_size)
 {
 	mm_initialize(BASE_HEAP, heap_start, heap_size);
 }
-
-#endif							/* !CONFIG_BUILD_PROTECTED || !__KERNEL__ */

--- a/os/mm/umm_heap/umm_mallinfo.c
+++ b/os/mm/umm_heap/umm_mallinfo.c
@@ -58,8 +58,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <tinyara/mm/mm.h>
-
-#if !defined(CONFIG_BUILD_PROTECTED) || !defined(__KERNEL__)
+#include "umm_heap.h"
 
 /****************************************************************************
  * Pre-processor Definitions
@@ -95,7 +94,7 @@ struct mallinfo mallinfo(void)
 	memset(&info, 0, sizeof(struct mallinfo));
 #endif
 	for (heap_idx = 0; heap_idx < CONFIG_MM_NHEAPS; heap_idx++) {
-		mm_mallinfo(&g_mmheap[heap_idx], &info);
+		mm_mallinfo(&USR_HEAP[heap_idx], &info);
 	}
 	return info;
 }
@@ -106,10 +105,9 @@ int mallinfo(struct mallinfo *info)
 {
 	int heap_idx;
 	for (heap_idx = 0; heap_idx < CONFIG_MM_NHEAPS; heap_idx++) {
-		mm_mallinfo(&g_mmheap[heap_idx], info);
+		mm_mallinfo(&USR_HEAP[heap_idx], info);
 	}
 	return OK;
 }
 
 #endif							/* CONFIG_CAN_PASS_STRUCTS */
-#endif							/* !CONFIG_BUILD_PROTECTED || !__KERNEL__ */

--- a/os/mm/umm_heap/umm_malloc.c
+++ b/os/mm/umm_heap/umm_malloc.c
@@ -59,8 +59,7 @@
 #include <unistd.h>
 #include <debug.h>
 #include <tinyara/mm/mm.h>
-
-#if !defined(CONFIG_BUILD_PROTECTED) || !defined(__KERNEL__)
+#include "umm_heap.h"
 
 /****************************************************************************
  * Pre-processor Definitions
@@ -112,9 +111,9 @@ void *malloc_at(int heap_index, size_t size)
 	}
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
 	ARCH_GET_RET_ADDRESS
-	return mm_malloc(&g_mmheap[heap_index], size, retaddr);
+	return mm_malloc(&USR_HEAP[heap_index], size, retaddr);
 #else
-	return mm_malloc(&g_mmheap[heap_index], size);
+	return mm_malloc(&USR_HEAP[heap_index], size);
 #endif
 }
 #endif
@@ -170,9 +169,9 @@ FAR void *malloc(size_t size)
 #endif
 	for (heap_idx = 0; heap_idx < CONFIG_MM_NHEAPS; heap_idx++) {
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
-		ret = mm_malloc(&g_mmheap[heap_idx], size, retaddr);
+		ret = mm_malloc(&USR_HEAP[heap_idx], size, retaddr);
 #else
-		ret = mm_malloc(&g_mmheap[heap_idx], size);
+		ret = mm_malloc(&USR_HEAP[heap_idx], size);
 #endif
 		if (ret != NULL) {
 			return ret;
@@ -181,5 +180,3 @@ FAR void *malloc(size_t size)
 	return NULL;
 #endif /* CONFIG_BUILD_KERNEL */
 }
-
-#endif							/* !CONFIG_BUILD_PROTECTED || !__KERNEL__ */

--- a/os/mm/umm_heap/umm_memalign.c
+++ b/os/mm/umm_heap/umm_memalign.c
@@ -58,8 +58,7 @@
 #include <stdlib.h>
 #include <debug.h>
 #include <tinyara/mm/mm.h>
-
-#if !defined(CONFIG_BUILD_PROTECTED) || !defined(__KERNEL__)
+#include "umm_heap.h"
 
 /****************************************************************************
  * Pre-processor Definitions
@@ -94,9 +93,9 @@ void *memalign_at(int heap_index, size_t alignment, size_t size)
 	}
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
 	ARCH_GET_RET_ADDRESS
-	return mm_memalign(&g_mmheap[heap_index], alignment, size, retaddr);
+	return mm_memalign(&USR_HEAP[heap_index], alignment, size, retaddr);
 #else
-	return mm_memalign(&g_mmheap[heap_index], alignment, size);
+	return mm_memalign(&USR_HEAP[heap_index], alignment, size);
 #endif
 }
 #endif
@@ -122,9 +121,9 @@ FAR void *memalign(size_t alignment, size_t size)
 #endif
 	for (heap_idx = 0; heap_idx < CONFIG_MM_NHEAPS; heap_idx++) {
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
-		ret = mm_memalign(&g_mmheap[heap_idx], alignment, size, retaddr);
+		ret = mm_memalign(&USR_HEAP[heap_idx], alignment, size, retaddr);
 #else
-		ret = mm_memalign(&g_mmheap[heap_idx], alignment, size);
+		ret = mm_memalign(&USR_HEAP[heap_idx], alignment, size);
 #endif
 		if (ret != NULL) {
 			return ret;
@@ -133,4 +132,3 @@ FAR void *memalign(size_t alignment, size_t size)
 	return NULL;
 }
 
-#endif							/* !CONFIG_BUILD_PROTECTED || !__KERNEL__ */

--- a/os/mm/umm_heap/umm_realloc.c
+++ b/os/mm/umm_heap/umm_realloc.c
@@ -58,8 +58,7 @@
 #include <stdlib.h>
 #include <debug.h>
 #include <tinyara/mm/mm.h>
-
-#if !defined(CONFIG_BUILD_PROTECTED) || !defined(__KERNEL__)
+#include "umm_heap.h"
 
 /****************************************************************************
  * Pre-processor Definitions
@@ -94,9 +93,9 @@ void *realloc_at(int heap_index, void *oldmem, size_t size)
 	}
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
 	ARCH_GET_RET_ADDRESS
-	return mm_realloc(&g_mmheap[heap_index], oldmem, size, retaddr);
+	return mm_realloc(&USR_HEAP[heap_index], oldmem, size, retaddr);
 #else
-	return mm_realloc(&g_mmheap[heap_index], oldmem, size);
+	return mm_realloc(&USR_HEAP[heap_index], oldmem, size);
 #endif
 }
 #endif
@@ -128,9 +127,9 @@ FAR void *realloc(FAR void *oldmem, size_t size)
 		return NULL;
 	}
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
-	ret = mm_realloc(&g_mmheap[heap_idx], oldmem, size, retaddr);
+	ret = mm_realloc(&USR_HEAP[heap_idx], oldmem, size, retaddr);
 #else
-	ret = mm_realloc(&g_mmheap[heap_idx], oldmem, size);
+	ret = mm_realloc(&USR_HEAP[heap_idx], oldmem, size);
 #endif
 	if (ret != NULL) {
 		return ret;
@@ -140,15 +139,14 @@ FAR void *realloc(FAR void *oldmem, size_t size)
 	prev_heap_idx = heap_idx;
 	for (heap_idx = 0; heap_idx < CONFIG_MM_NHEAPS; heap_idx++) {
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
-		ret = mm_malloc(&g_mmheap[heap_idx], size, retaddr);
+		ret = mm_malloc(&USR_HEAP[heap_idx], size, retaddr);
 #else
-		ret = mm_malloc(&g_mmheap[heap_idx], size);
+		ret = mm_malloc(&USR_HEAP[heap_idx], size);
 #endif
 		if (ret != NULL) {
-			mm_free(&g_mmheap[prev_heap_idx], oldmem);
+			mm_free(&USR_HEAP[prev_heap_idx], oldmem);
 			return ret;
 		}
 	}
 	return NULL;
 }
-#endif							/* !CONFIG_BUILD_PROTECTED || !__KERNEL__ */

--- a/os/mm/umm_heap/umm_sem.c
+++ b/os/mm/umm_heap/umm_sem.c
@@ -57,8 +57,6 @@
 #include <tinyara/config.h>
 #include <tinyara/mm/mm.h>
 
-#if !defined(CONFIG_BUILD_PROTECTED) || !defined(__KERNEL__)
-
 /************************************************************************
  * Pre-processor definition
  ************************************************************************/
@@ -125,4 +123,3 @@ void umm_givesemaphore(void *address)
 	mm_givesemaphore(heap);
 }
 
-#endif							/* !CONFIG_BUILD_PROTECTED || !__KERNEL__ */

--- a/os/mm/umm_heap/umm_zalloc.c
+++ b/os/mm/umm_heap/umm_zalloc.c
@@ -59,8 +59,7 @@
 #include <string.h>
 #include <debug.h>
 #include <tinyara/mm/mm.h>
-
-#if !defined(CONFIG_BUILD_PROTECTED) || !defined(__KERNEL__)
+#include "umm_heap.h"
 
 /****************************************************************************
  * Pre-processor Definitions
@@ -91,9 +90,9 @@ void *zalloc_at(int heap_index, size_t size)
 	}
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
 	ARCH_GET_RET_ADDRESS
-	return mm_zalloc(&g_mmheap[heap_index], size, retaddr);
+	return mm_zalloc(&USR_HEAP[heap_index], size, retaddr);
 #else
-	return mm_zalloc(&g_mmheap[heap_index], size);
+	return mm_zalloc(&USR_HEAP[heap_index], size);
 #endif
 }
 #endif
@@ -132,9 +131,9 @@ FAR void *zalloc(size_t size)
 #endif
 	for (heap_idx = 0; heap_idx < CONFIG_MM_NHEAPS; heap_idx++) {
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
-		ret = mm_zalloc(&g_mmheap[heap_idx], size, retaddr);
+		ret = mm_zalloc(&USR_HEAP[heap_idx], size, retaddr);
 #else
-		ret = mm_zalloc(&g_mmheap[heap_idx], size);
+		ret = mm_zalloc(&USR_HEAP[heap_idx], size);
 #endif
 		if (ret != NULL) {
 			return ret;
@@ -144,4 +143,3 @@ FAR void *zalloc(size_t size)
 #endif /* CONFIG_ARCH_ADDRENV */
 }
 
-#endif							/* !CONFIG_BUILD_PROTECTED || !__KERNEL__ */


### PR DESCRIPTION
This commit contains below changes for MM:
- Back port Nuttx patch (59cc4a7a7b119536089a72ca91c5cb4d3399245a) for protected build MM changes to TizenRT.
- Make changes to handle mmheap structure as part of shared userspace object.
- Move the shared userspace object from Flash to RAM at beginning of user ram area.