### PR TITLE
apps/examples/testcase: Add dependency configuration filesystem tc

### DIFF
--- a/apps/examples/testcase/le_tc/filesystem/Kconfig
+++ b/apps/examples/testcase/le_tc/filesystem/Kconfig
@@ -6,6 +6,7 @@
 config EXAMPLES_TESTCASE_FILESYSTEM
 	bool "FileSystem TestCase Example"
 	default n
+	depends on !BUILD_PROTECTED
 	---help---
 		Enable the FileSystem TestCase example
 


### PR DESCRIPTION
I made filesystem TC dependent on the !BUILD_PROTECTED setting.

reason1 : The file system TC has an API that calls the kernel context. Therefore, it is disabled in the BUILD_PROTECTED state.

reason2 : Because the file system TC is created for testing purposes, not for actual code, disabling BUILD_PROTECTED does not cause any problems