### PR TITLE
framework/st_things: Add function to debug payload for request/response.

### DIFF
--- a/framework/src/st_things/things_stack/framework/things_req_handler.c
+++ b/framework/src/st_things/things_stack/framework/things_req_handler.c
@@ -165,6 +165,8 @@ OCEntityHandlerResult send_response(OCRequestHandle request_handle, OCResourceHa
 
 		THINGS_LOG_V(TAG, "\t\t\tRes. : %s ( %d )", (response.ehResult == OC_EH_OK ? "NORMAL" : "ERROR"), response.ehResult);
 
+		THINGS_LOG_RESPONSE(TAG, &response);
+
 		iotivity_api_lock();
 		OCStackResult ret = OCDoResponse(&response);
 		iotivity_api_unlock();
@@ -566,6 +568,8 @@ OCEntityHandlerResult entity_handler(OCEntityHandlerFlag flag, OCEntityHandlerRe
 	iotivity_api_lock();
 	const char *uri = OCGetResourceUri(entity_handler_request->resource);
 	iotivity_api_unlock();
+
+	THINGS_LOG_REQUEST(TAG, flag, entity_handler_request);
 
 	// Observe Request Handling
 	if (flag & OC_OBSERVE_FLAG) {

--- a/framework/src/st_things/things_stack/logging/things_logger.c
+++ b/framework/src/st_things/things_stack/logging/things_logger.c
@@ -34,6 +34,9 @@
 #include <sys/types.h>
 #include <pthread.h>
 
+#include "ocpayload.h"
+#include "ocstack.h"
+
 static const char *LEVEL[] __attribute__((unused)) = {
 	"DEBUG", "INFOR", "WARNING", "ERROR", "FATAL"
 };
@@ -129,4 +132,257 @@ void things_logv(things_log_level_e level, const char *tag, const char *func_nam
 	vsnprintf(buffer, sizeof buffer - 1, format, args);
 	va_end(args);
 	things_log(level, tag, func_name, line_num, buffer);
+}
+
+struct num_str {
+	int number;
+	char *str;
+};
+
+/**
+ * CoAP Option Numbers
+ * http://www.iana.org/assignments/core-parameters/core-parameters.xhtml
+ */
+static struct num_str g_coap_options[] = {
+	{ 0, "Reserved" },
+	{ 1, "If-Match" },
+	{ 3, "Uri-Host" },
+	{ 4, "ETag" },
+	{ 5, "If-None-Match" },
+	{ 6, "Observe" },
+	{ 7, "Uri-Port" },
+	{ 8, "Location-Path" },
+	{ 11, "Uri-Path" },
+	{ 12, "Content-Format" },
+	{ 14, "Max-Age" },
+	{ 15, "Uri-Query" },
+	{ 17, "Accept" },
+	{ 20, "Location-Query" },
+	{ 23, "Block2" },
+	{ 27, "Block1" },
+	{ 28, "Size2" },
+	{ 35, "Proxy-Uri" },
+	{ 39, "Proxy-Scheme" },
+	{ 60, "Size1" },
+	{ 128, "Reserved" },
+	{ 132, "Reserved" },
+	{ 136, "Reserved" },
+	{ 140, "Reserved" },
+	{ 258, "No-Response" },
+	{ 2049, "OCF-Accept-Content-Format-Version" },
+	{ 2053, "OCF-Content-Format-Version" },
+};
+
+static const char *_coap_opt_name(int number)
+{
+	if (number < 0 || 2053 < number) {
+		return "Unknown";
+	}
+
+	unsigned int i;
+
+	for (i = 0; i < sizeof(g_coap_options) / sizeof(struct num_str); i++) {
+		if (g_coap_options[i].number == number)
+			return g_coap_options[i].str;
+	}
+
+	return "Unknown";
+}
+
+static void payload_ll(things_log_level_e level, const char *tag, const char *func_name, const int16_t line_num,
+							OCStringLL *ll)
+{
+	OCStringLL *cur = ll;
+
+	while (cur) {
+		things_logv(level, tag, func_name, line_num, "\t\t  %s ", cur->value);
+		cur = cur->next;
+	}
+}
+
+static void payload_ll_rep_value(things_log_level_e level, const char *tag, const char *func_name, const int16_t line_num,
+							OCRepPayloadValue *values)
+{
+	OCRepPayloadValue *cur = values;
+
+	while (cur) {
+		switch (cur->type) {
+		case OCREP_PROP_INT:
+			things_logv(level, tag, func_name, line_num, "\t  {\"%s\":  %zd} ", cur->name, cur->i);
+			break;
+		case OCREP_PROP_DOUBLE:
+			things_logv(level, tag, func_name, line_num, "\t  {\"%s\":  %f} ", cur->name, cur->d);
+			break;
+		case OCREP_PROP_BOOL:
+			things_logv(level, tag, func_name, line_num, "\t  {\"%s\":  %d} ", cur->name, cur->b);
+			break;
+		case OCREP_PROP_STRING:
+			things_logv(level, tag, func_name, line_num, "\t  {\"%s\":  \"%s\"} ", cur->name, cur->str);
+			break;
+		case OCREP_PROP_BYTE_STRING:
+			things_logv(level, tag, func_name, line_num, "\t  {\"%s\":  len=%zd [...]} ", cur->name, cur->ocByteStr.len);
+			break;
+		case OCREP_PROP_OBJECT:
+			things_logv(level, tag, func_name, line_num, "\t  {\"%s\":  {0x%p}}", cur->name, cur->obj);
+			break;
+		case OCREP_PROP_ARRAY:
+			things_logv(level, tag, func_name, line_num, "\t  {\"%s\":  [type=%d]}", cur->name, cur->arr.type);
+			break;
+		default:
+			things_logv(level, tag, func_name, line_num, "\t  {\"%s\":  unknown} ");
+			break;
+		}
+
+		cur = cur->next;
+	}
+}
+
+static void things_log_payload_flag(things_log_level_e level, const char *tag, const char *func_name, const int16_t line_num,
+							OCEntityHandlerFlag flag) {
+	if (flag & OC_REQUEST_FLAG) {
+		things_logv(level, tag, func_name, line_num, "\t\t\t  %s", "REQUEST ");
+	}
+	if (flag & OC_OBSERVE_FLAG) {
+		things_logv(level, tag, func_name, line_num, "\t\t\t  %s", "OBSERVE ");
+	}
+}
+
+static void things_log_payload_method(things_log_level_e level, const char *tag, const char *func_name, const int16_t line_num,
+							OCMethod method) {
+	if (method & OC_REST_NOMETHOD) {
+		things_logv(level, tag, func_name, line_num, "\t\t\t  %s", "NOMETHOD ");
+	}
+	if (method & OC_REST_GET) {
+		things_logv(level, tag, func_name, line_num, "\t\t\t  %s", "GET ");
+	}
+	if (method & OC_REST_PUT) {
+		things_logv(level, tag, func_name, line_num, "\t\t\t  %s", "PUT ");
+	}
+	if (method & OC_REST_POST) {
+		things_logv(level, tag, func_name, line_num, "\t\t\t  %s", "POST ");
+	}
+	if (method & OC_REST_DELETE) {
+		things_logv(level, tag, func_name, line_num, "\t\t\t  %s", "DELETE ");
+	}
+	if (method & OC_REST_OBSERVE) {
+		things_logv(level, tag, func_name, line_num, "\t\t\t  %s", "OBSERVE ");
+	}
+	if (method & OC_REST_OBSERVE_ALL) {
+		things_logv(level, tag, func_name, line_num, "\t\t\t  %s", "OBSERVE_ALL ");
+	}
+	if (method & OC_REST_PRESENCE) {
+		things_logv(level, tag, func_name, line_num, "\t\t\t  %s", "PRESENCE ");
+	}
+	if (method & OC_REST_DISCOVER) {
+		things_logv(level, tag, func_name, line_num, "\t\t\t  %s", "DISCOVER ");
+	}
+}
+
+static void things_log_payload_header_options(things_log_level_e level, const char *tag, const char *func_name, const int16_t line_num,
+							OCHeaderOption *opt, uint8_t count)
+{
+	int i;
+	int j;
+
+	things_logv(level, tag, func_name, line_num, "  - vendor specific header count: %d", count);
+	for (i = 0; i < count; i++) {
+		things_logv(level, tag, func_name, line_num, "\t- [%d] ", i);
+
+		if (opt[i].protocolID != 2) {
+			things_logv(level, tag, func_name, line_num, "Invalid protocol(%d), option_id=0x%x, len=%d",
+					opt[i].protocolID, opt[i].optionID,
+					opt[i].optionLength);
+			continue;
+		}
+
+		things_logv(level, tag, func_name, line_num, "CoAP option_id=0x%x (%s), option_len=%d",
+				opt[i].optionID,
+				_coap_opt_name(opt[i].optionID),
+				opt[i].optionLength);
+
+		if (opt[i].optionLength > 0) {
+			things_logv(level, tag, func_name, line_num, "\t  Data: ");
+			for (j = 0; j < opt[i].optionLength; j++)
+				things_logv(level, tag, func_name, line_num, "%02X ", opt[i].optionData[j]);
+		}
+	}
+}
+
+static void things_log_payload_payload_representation(things_log_level_e level, const char *tag, const char *func_name, const int16_t line_num,
+							OCRepPayload *payload)
+{
+	things_logv(level, tag, func_name, line_num, "  - payload-type: %d (%s)", payload->base.type,
+			"Representation");
+	things_logv(level, tag, func_name, line_num, "\t- uri: %s", payload->uri);
+
+	if (payload->types) {
+		things_logv(level, tag, func_name, line_num, "\t- types: ");
+		payload_ll(level, tag, func_name, line_num, payload->types);
+	}
+
+	if (payload->interfaces) {
+		things_logv(level, tag, func_name, line_num, "\t- interfaces: ");
+		payload_ll(level, tag, func_name, line_num, payload->interfaces);
+	}
+
+	if (payload->values) {
+		things_logv(level, tag, func_name, line_num, "\t- values: ");
+		payload_ll_rep_value(level, tag, func_name, line_num, payload->values);
+	}
+}
+
+void things_log_request(things_log_level_e level, const char *tag, const char *func_name, const int16_t line_num,
+							OCEntityHandlerFlag flag, OCEntityHandlerRequest *req)
+{
+	if (!req) {
+		return;
+	}
+
+	things_logv(level, tag, func_name, line_num, "IncomingRequest: (id: %d)", req->messageID);
+	things_logv(level, tag, func_name, line_num, "  - resourceHandle: 0x%p", req->resource);
+	things_logv(level, tag, func_name, line_num, "\t- uri: \"%s\"", OCGetResourceUri(req->resource));
+	things_logv(level, tag, func_name, line_num, "\t- property: 0x%X",	OCGetResourceProperties(req->resource));
+	things_logv(level, tag, func_name, line_num, "  - flag: 0x%X", flag);
+	things_log_payload_flag(level, tag, func_name, line_num, flag);
+	things_logv(level, tag, func_name, line_num, "  - method: %d", req->method);
+	things_log_payload_method(level, tag, func_name, line_num, req->method);
+	things_logv(level, tag, func_name, line_num, "  - query: '%s'", req->query);
+	things_logv(level, tag, func_name, line_num, "  - dev_addr: adapter:%d, flags:0x%X, port:%d",
+															req->devAddr.adapter, req->devAddr.flags,
+															req->devAddr.port);
+
+	if (req->numRcvdVendorSpecificHeaderOptions > 0) {
+		things_log_payload_header_options(level, tag, func_name, line_num,
+						req->rcvdVendorSpecificHeaderOptions,
+						req->numRcvdVendorSpecificHeaderOptions);
+	}
+
+	if (req->payload) {
+		if (req->payload->type == PAYLOAD_TYPE_REPRESENTATION) {
+			things_log_payload_payload_representation(level, tag, func_name, line_num,
+							(OCRepPayload *)req->payload);
+		}
+	}
+}
+
+void things_log_response(things_log_level_e level, const char *tag, const char *func_name, const int16_t line_num,
+							OCEntityHandlerResponse *resp)
+{
+	things_logv(level, tag, func_name, line_num, "OutgoingResponse:");
+	things_logv(level, tag, func_name, line_num, "  - resourceHandle: 0x%p", resp->resourceHandle);
+	things_logv(level, tag, func_name, line_num, "  - result: %d", resp->ehResult);
+	things_logv(level, tag, func_name, line_num, "  - resourceUri: '%s'", resp->resourceUri);
+	things_logv(level, tag, func_name, line_num, "  - persistentBufferFlag: %d", resp->persistentBufferFlag);
+
+	if (resp->numSendVendorSpecificHeaderOptions > 0) {
+		things_log_payload_header_options(
+						level, tag, func_name, line_num,
+						resp->sendVendorSpecificHeaderOptions,
+						resp->numSendVendorSpecificHeaderOptions);
+	}
+
+	if (resp->payload) {
+		things_log_payload_payload_representation(level, tag, func_name, line_num,
+							(OCRepPayload *)resp->payload);
+	}
 }

--- a/framework/src/st_things/things_stack/logging/things_logger.h
+++ b/framework/src/st_things/things_stack/logging/things_logger.h
@@ -22,7 +22,9 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <stdarg.h>
+
 #include "things_def.h"
+#include "ocpayload.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -92,8 +94,12 @@ const char *__get_timestamp__(void);
 
 #ifdef CONFIG_DEBUG_ST_THINGS_DEBUG
 #define THINGS_LOG_D(tag, ...)   things_logv((THINGS_DEBUG), (tag), __FUNCTION__, __LINE__, __VA_ARGS__)
+#define THINGS_LOG_REQUEST(tag, flag, payload)     things_log_request((THINGS_DEBUG), (tag), __FUNCTION__, __LINE__, flag, payload);
+#define THINGS_LOG_RESPONSE(tag, payload)    things_log_response((THINGS_DEBUG), (tag), __FUNCTION__, __LINE__, payload);
 #else //CONFIG_DEBUG_ST_THINGS_DEBUG
 #define THINGS_LOG_D(tag, ...)
+#define THINGS_LOG_REQUEST(tag, flag, payload)
+#define THINGS_LOG_RESPONSE(tag, payload)
 #endif
 
 #ifdef CONFIG_DEBUG_ST_THINGS_INFO

--- a/framework/src/st_things/things_stack/utils/things_network.c
+++ b/framework/src/st_things/things_stack/utils/things_network.c
@@ -428,7 +428,7 @@ void things_wifi_scan_done(wifi_manager_scan_info_s **scan_result, wifi_manager_
 	}
 	pinfo = g_wifi_scan_info;
 	while (pinfo != NULL) {
-		THINGS_LOG_V(TAG, "WiFi AP - SSID: %-20s, WiFi AP BSSID: %-20s, WiFi Rssi: %d\n",
+		THINGS_LOG_V(TAG, "WiFi AP - SSID: %-20s, WiFi AP BSSID: %-20s, WiFi Rssi: %d",
 				   pinfo->e_ssid, pinfo->bss_id, pinfo->signal_level);
 		pinfo = pinfo->next;
 	}


### PR DESCRIPTION
It can show the payload what attributes are included
when enabled the CONFIG_DEBUG_ST_THINGS_DEBUG config.

log format example:
IncomingRequest: (id: 0)
- resourceHandle: 0x00000000
- uri: "/capability/switch/main/0"
- property: 0x0
- flag: 0x0
			  REQUEST
 			  OBSERVE
- method: 1
 			  GET
- query: 'if=oic.if.baseline'
	- values:
 	  {"power":  "off"}
- dev_addr: adapter:00, flags:0x00, port:000

OutgoingResponse:
   - resourceHandle: 0x0000000
   - result: 0
   - resourceUri: ''
   - persistentBufferFlag: 0
   - payload-type: 4 (Representation)
 	- uri: /capability/switch/main/0
 	- types:
		  x.com.st.powerswitch
		  x.com.st.powerswitch
	- interfaces:
		  oic.if.baseline
		  oic.if.a
		  oic.if.baseline
		  oic.if.a
	- values:
 	  {"power":  "off"}