### PR TITLE
board/common: change a location of sub-title in Kconfig

### DIFF
--- a/os/board/Kconfig
+++ b/os/board/Kconfig
@@ -268,7 +268,6 @@ endif
 if ARCH_BOARD_IMXRT1050_EVK
 source board/imxrt1050-evk/Kconfig
 endif
-comment "Board-Partition Options"
 
 source board/common/Kconfig
 

--- a/os/board/common/Kconfig
+++ b/os/board/common/Kconfig
@@ -9,13 +9,14 @@ config ARCH_USE_FLASH
 	---help---
 		This shows that user enables FLASH to use.
 
+if ARCH_USE_FLASH && (NFILE_DESCRIPTORS != 0)
+comment "Board-Partition Options"
+
 config FLASH_PARTITION
 	bool "Enable partition support on FLASH"
 	default n
 	select MTD
 	select MTD_PARTITION
-	depends on ARCH_USE_FLASH
-	depends on NFILE_DESCRIPTORS != 0
 	---help---
 		Enables creation of partitions on the FLASH
 
@@ -48,4 +49,5 @@ config FLASH_PART_NAME
 	---help---
 		Comma separated list of partition names.
 
-endif
+endif # FLASH_PARTITION
+endif # ARCH_USE_FLASH && (NFILE_DESCRIPTORS != 0)


### PR DESCRIPTION
A sub-title of flash partition was in board/Kconfig and it
prints sub-title before sourcing board/common/Kconfig.
Because of this, when it is not available, only sub-title
is come up without any config as shown below:

(4096) Page size of external flash memory (in bytes)
    *** Board-Partition Options ***

To hidden it when it is not available, move it inside of
board/common/Kconfig and cover it using conditionals.

Signed-off-by: sunghan-chang <sh924.chang@samsung.com>