### PR TITLE
framework/messaging : Add unicast messaging IPC

### DIFF
--- a/framework/include/messaging/messaging.h
+++ b/framework/include/messaging/messaging.h
@@ -1,0 +1,120 @@
+/****************************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+/**
+ * @defgroup Messaging Messaging
+ * @ingroup Messaging
+ * @brief Provides APIs for Messaging
+ * @{
+ */
+
+/**
+ * @file messaging/messaging.h
+ */
+#ifndef __MESSAGING_H__
+#define __MESSAGING_H__
+
+#include <tinyara/config.h>
+
+/**
+ * @brief The type of sending message
+ * @details MSG_SEND_SYNC  : A sender waits after sending message until receiving a reply message.\n
+ * 	    MSG_SEND_ASYNC : A sender continues to run after sending message.
+ */
+#define MSG_SEND_SYNC     0
+#define MSG_SEND_ASYNC    1
+
+/**
+ * @brief The type of receiving message
+ * @details MSG_RECV_BLOCK    : A receiver blocks until receiving the message.\n
+ * 	    MSG_RECV_NONBLOCK : A receiver sets callback function for receiving message and continues to run.
+ */
+#define MSG_RECV_BLOCK    2
+#define MSG_RECV_NONBLOCK 3
+
+/**
+ * @brief Called when a message is received
+ */
+typedef void (*msg_callback_t)(void *data, void *callback_data);
+
+/**
+ * @brief The structure of parameters which used for sending
+ */
+struct msg_send_param_s {
+	int priority;
+	int type; /* for sender : MSG_SEND_SYNC or MSG_SEND_ASYNC */
+	char *sync_msg;
+	int sync_msglen;
+};
+typedef struct msg_send_param_s msg_send_param_t;
+
+/**
+ * @brief The structure of parameters which used for receiving
+ */
+struct msg_recv_param_s {
+	int type; /* for receiver : MSG_RECV_BLOCK or MSG_RECV_NONBLOCK */
+	msg_callback_t cb_func;
+};
+typedef struct msg_recv_param_s msg_recv_param_t;
+/**
+ * @brief Send unicast message to specified message port
+ * @details @b #include <messaging/messaging.h>\n
+ * @param[in] port_name The message port name to send
+ * @param[in] msg The message to be sent
+ * @param[in] msglen The length of message to be sent
+ * @param[in/out] param\n
+ * 		priority    : A non-negative integer that specifies the priority of this message\n
+ * 		type        : MSG_SEND_SYNC or MSG_SEND_ASYNC\n
+ * 		sync_msg    : A message buffer to receive the sync reply message\n
+ * 		sync_msglen : A message size for sync reply message
+ * @return On success, OK is returned. On failure, Error is returned.
+ * @since TizenRT v2.0
+ */
+int messaging_send(const char *port_name, const char *msg, size_t msglen, msg_send_param_t *param);
+/**
+ * @brief Wait to receive unicast message from specified message port
+ * @details @b #include <messaging/messaging.h>\n
+ * @param[in] port_name The message port name to receive
+ * @param[in] msg The message buffer to receive the message
+ * @param[in] msglen The length of message to receive
+ * @param[in] param\n
+ * 		type    : MSG_RECV_BLOCK or MSG_RECV_NONBLOCK\n
+ * 		cb_func : user callback function for nonblocking receive
+ * @return On success, OK is returned. On failure, Error is returned.
+ * @since TizenRT v2.0
+ */
+int messaging_recv(const char *port_name, char *msg, size_t msglen, msg_recv_param_t *param);
+/**
+ * @brief Reply unicast message to specified message port when received sync message
+ * @details @b #include <messaging/messaging.h>\n
+ * @param[in] port_name The message port name to send\n
+ * 			This port name should be matched to original port name which received the message.
+ * @param[in] msg The message to be sent
+ * @param[in] msglen The length of message to be sent
+ * @return On success, OK is returned. On failure, Error is returned.
+ * @since TizenRT v2.0
+ */
+int messaging_send_reply(const char *port_name, const char *msg, size_t msglen);
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
+
+#endif
+/**
+ * @}
+ */

--- a/framework/src/messaging/Kconfig
+++ b/framework/src/messaging/Kconfig
@@ -1,0 +1,27 @@
+#
+# For a description of the syntax of this configuration file,
+# see kconfig-language at https://www.kernel.org/doc/Documentation/kbuild/kconfig-language.txt
+#
+
+config MESSAGING_IPC
+	bool "Enable Messaging APIs"
+	default y
+	depends on !DISABLE_MQUEUE
+	---help---
+		Enables Messaging APIs.
+
+if MESSAGING_IPC
+config MESSAGING_UNICAST_MAXMSG
+	int "Max message number for unicast"
+	default 100
+	---help---
+		Max number of unicast messaging
+
+config MESSAGING_UNICAST_MSGSIZE
+	int "Max message size for unicast"
+	default MQ_MAXMSGSIZE
+	---help---
+		Max size of unicast messaging
+
+endif
+

--- a/framework/src/messaging/Make.defs
+++ b/framework/src/messaging/Make.defs
@@ -1,0 +1,25 @@
+###########################################################################
+#
+# Copyright 2019 Samsung Electronics All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+#
+###########################################################################
+
+ifeq ($(CONFIG_MESSAGING_IPC),y)
+
+CSRCS += messaging_send.c messaging_recv.c
+
+DEPPATH += --dep-path src/messaging
+VPATH += :src/messaging
+endif

--- a/framework/src/messaging/messaging_internal.h
+++ b/framework/src/messaging/messaging_internal.h
@@ -1,0 +1,38 @@
+/****************************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+#include <tinyara/config.h>
+#include <mqueue.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <messaging/messaging.h>
+
+#define MSG_SYNC_PORTNAME_PREFIX "_s"
+
+#define MSG_ALLOC(a) malloc(a)
+#define MSG_FREE(a) free(a)
+#ifdef CONFIG_CPP_HAVE_VARARGS
+#define MSG_ASPRINTF(p, f, ...) asprintf(p, f, ##__VA_ARGS__)
+#else
+#define MSG_ASPRINTF asprintf
+#endif
+
+struct messaging_recv_info_s {
+	mqd_t mqdes;
+	msg_callback_t user_cb;
+};
+typedef struct messaging_recv_info_s messaging_recv_info_t;

--- a/framework/src/messaging/messaging_recv.c
+++ b/framework/src/messaging/messaging_recv.c
@@ -1,0 +1,210 @@
+/****************************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+#include <tinyara/config.h>
+#include <debug.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <mqueue.h>
+#include <stdlib.h>
+#include <signal.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/types.h>
+#include <messaging/messaging.h>
+#include "messaging_internal.h"
+
+/****************************************************************************
+ * private functions
+ ****************************************************************************/
+static void set_notification(messaging_recv_info_t *data)
+{
+	int ret;
+	struct sigevent notification;
+
+	notification.sigev_notify = SIGEV_SIGNAL;
+	notification.sigev_signo = SIGMSG_UNICAST;
+	notification.sigev_value.sival_ptr = data;
+
+	ret = mq_notify(data->mqdes, &notification);
+	if (ret < 0) {
+		printf("message recv fail : set notification fail. %d\n", errno);
+		MSG_FREE(data);
+		mq_close(data->mqdes);
+		return;
+	}
+}
+
+static void wrapper_callback(int signo, siginfo_t *data)
+{
+	int ret;
+	messaging_recv_info_t *info;
+	char msg[CONFIG_MESSAGING_UNICAST_MSGSIZE];
+	struct mq_attr attr;
+
+	info = (messaging_recv_info_t *)data->si_value.sival_ptr;
+	if (info == NULL) {
+		printf("message recv fail : wrong param for wrapper callback.\n");
+		return;
+	}
+
+	while (1) {
+		ret = mq_receive(info->mqdes, (char *)&msg, sizeof(messaging_recv_info_t), 0);
+		if (ret < 0) {
+			printf("message recv fail : mq_receive fail. %d\n", errno);
+			mq_close(info->mqdes);
+			MSG_FREE(data);
+			return;
+		}
+		/* Call user callback */
+		(*info->user_cb)(NULL, &msg);
+
+		ret = mq_getattr(info->mqdes, &attr);
+		if (ret < 0) {
+			printf("message recv fail : mq_getattr fail.\n");
+			mq_close(info->mqdes);
+			MSG_FREE(data);
+			return;
+		} else if (attr.mq_curmsgs == 0) {
+			/* All requests are handled. Register notification again. */
+			set_notification(info);
+			break;
+		}
+	}
+}
+
+static int set_notify_signal(void)
+{
+	int ret;
+	struct sigaction act;
+	act.sa_sigaction = (_sa_sigaction_t)wrapper_callback;
+	act.sa_flags = 0;
+	(void)sigemptyset(&act.sa_mask);
+
+	ret = sigaddset(&act.sa_mask, SIGMSG_UNICAST);
+	if (ret < 0) {
+		printf("message recv fail : nonblock recv 1.\n");
+		return ERROR;
+	}
+
+	ret = sigaction(SIGMSG_UNICAST, &act, NULL);
+	if (ret == (int)SIG_ERR) {
+		printf("message recv fail : nonblock recv 2.\n");
+		return ERROR;
+	}
+	return OK;
+}
+
+static int messaging_recv_nonblock(mqd_t *mqdes, const char *port_name, char *msg, size_t msglen, msg_recv_param_t *param)
+{
+	int ret;
+	messaging_recv_info_t *nonblock_data;
+
+	/* Check there was msg already before setting notification */
+	ret = mq_receive(*mqdes, msg, CONFIG_MESSAGING_UNICAST_MSGSIZE, 0);
+	if (ret > 0) {
+		mq_close(*mqdes);
+		mq_unlink(port_name);
+		return OK;
+	} else if (ret != ERROR) {
+		printf("message recv fail : recv fail %d.\n", errno);
+		return ERROR;
+	}
+
+	/* There was no msg, then set notification. */
+	ret = set_notify_signal();
+	if (ret != OK) {
+		return ERROR;
+	}
+
+	nonblock_data = (messaging_recv_info_t *)MSG_ALLOC(sizeof(messaging_recv_info_t));
+	if (nonblock_data == NULL) {
+		printf("message recv fail : out of memory.\n");
+		return ERROR;
+	}
+	nonblock_data->mqdes = *mqdes;
+	nonblock_data->user_cb = param->cb_func;
+
+	set_notification(nonblock_data);
+	MSG_FREE(nonblock_data);
+	return OK;
+}
+
+static int messaging_recv_block(mqd_t *mqdes, const char *port_name, char *msg, size_t msglen)
+{
+	int ret = OK;
+
+	ret = mq_receive(*mqdes, msg, CONFIG_MESSAGING_UNICAST_MSGSIZE, 0);
+	if (ret < 0) {
+		printf("message recv fail : recv fail %d.\n", errno);
+	}
+
+	mq_close(*mqdes);
+	mq_unlink(port_name);
+	return ret;
+}
+
+static int messaging_recv_internal(const char *port_name, char *msg, size_t msglen, msg_recv_param_t *param)
+{
+	int ret = OK;
+	mqd_t mqdes;
+	struct mq_attr internal_attr;
+
+	internal_attr.mq_maxmsg = CONFIG_MESSAGING_UNICAST_MAXMSG;
+	internal_attr.mq_msgsize = msglen;
+	internal_attr.mq_flags = 0;
+
+	if (param->type == MSG_RECV_BLOCK) {
+		mqdes = mq_open(port_name, O_RDONLY | O_CREAT, 0666, &internal_attr);
+		if (mqdes == (mqd_t)ERROR) {
+			printf("message recv fail : open fail %d.\n", errno);
+			return ERROR;
+		}
+		ret = messaging_recv_block(&mqdes, port_name, msg, msglen);
+	} else {
+		mqdes = mq_open(port_name, O_RDONLY | O_CREAT | O_NONBLOCK, 0666, &internal_attr);
+		if (mqdes == (mqd_t)ERROR) {
+			printf("message recv fail : open fail %d.\n", errno);
+			return ERROR;
+		}
+		ret = messaging_recv_nonblock(&mqdes, port_name, msg, msglen, param);
+	}
+	return ret;
+}
+/****************************************************************************
+ * messaging_recv
+ ****************************************************************************/
+int messaging_recv(const char *port_name, char *msg, size_t msglen, msg_recv_param_t *param)
+{
+	int ret = OK;
+
+	if (param->type == MSG_RECV_NONBLOCK && param->cb_func == NULL) {
+		printf("message recv fail : invalid param.\n");
+		return ERROR;
+	}
+
+	ret = messaging_recv_internal(port_name, msg, msglen, param);
+	if (ret == ERROR) {
+		printf("message recv fail : recv fail.\n");
+		return ret;
+	}
+
+	return OK;
+}

--- a/framework/src/messaging/messaging_send.c
+++ b/framework/src/messaging/messaging_send.c
@@ -1,0 +1,142 @@
+/****************************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+#include <tinyara/config.h>
+#include <debug.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <mqueue.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/types.h>
+#include <messaging/messaging.h>
+#include "messaging_internal.h"
+
+#define MSG_REPLY_PRIO 10
+/****************************************************************************
+ * private functions
+ ****************************************************************************/
+
+static int messaging_sync_recv(const char *port_name, msg_send_param_t *param)
+{
+	int ret = OK;
+	mqd_t sync_mqdes;
+	char *sync_portname;
+	struct mq_attr internal_attr;
+
+	internal_attr.mq_maxmsg = CONFIG_MESSAGING_UNICAST_MAXMSG;
+	internal_attr.mq_msgsize = CONFIG_MESSAGING_UNICAST_MSGSIZE;
+	internal_attr.mq_flags = 0;
+
+	/* sender waits the reply with "port_name + MSG_SYNC_PORTNAME_PREFIX". */
+	MSG_ASPRINTF(&sync_portname, "%s%s", port_name, MSG_SYNC_PORTNAME_PREFIX);
+	if (sync_portname == NULL) {
+		printf("message send fail : sync portname allocation fail.\n");
+		return ERROR;
+	}
+	sync_mqdes = mq_open(sync_portname, O_RDONLY | O_CREAT, 0666, &internal_attr);
+	if (sync_mqdes == (mqd_t)ERROR) {
+		printf("message send fail : sync open fail %d.\n", errno);
+		MSG_FREE(sync_portname);
+		return ERROR;
+	}
+
+	ret = mq_receive(sync_mqdes, (char *)param->sync_msg, param->sync_msglen, 0);
+	if (ret != OK) {
+		printf("message send fail : sync recv fail %d.\n", errno);
+	}
+
+	MSG_FREE(sync_portname);
+	mq_close(sync_mqdes);
+	mq_unlink(sync_portname);
+
+	return ret;
+}
+
+static int messaging_send_internal(const char *port_name, const char *msg, size_t msglen, int prio)
+{
+	int ret = OK;
+	mqd_t mqdes;
+	struct mq_attr internal_attr;
+
+	internal_attr.mq_maxmsg = CONFIG_MESSAGING_UNICAST_MAXMSG;
+	internal_attr.mq_msgsize = CONFIG_MESSAGING_UNICAST_MSGSIZE;
+	internal_attr.mq_flags = 0;
+
+	mqdes = mq_open(port_name, O_WRONLY | O_CREAT, 0666, &internal_attr);
+	if (mqdes == (mqd_t)ERROR) {
+		printf("message send fail : open fail %d.\n", errno);
+		return ERROR;
+	}
+
+	ret = mq_send(mqdes, (char *)msg, msglen, prio);
+	if (ret != OK) {
+		printf("message send fail : send fail %d.\n", errno);
+	}
+
+	mq_close(mqdes);
+	return ret;
+}
+
+/****************************************************************************
+ * messaging_send
+ ****************************************************************************/
+int messaging_send(const char *port_name, const char *msg, size_t msglen, msg_send_param_t *param)
+{
+	int ret;
+
+	if (param->type != MSG_SEND_ASYNC || (param->type == MSG_SEND_SYNC && param->sync_msg == NULL)) {
+		printf("message send fail : invalid param.\n");
+		return ERROR;
+	}
+
+	ret = messaging_send_internal(port_name, msg, msglen, param->priority);
+	if (ret != OK) {
+		goto send_fail;
+	}
+
+	if (param->type == MSG_SEND_SYNC) {
+		ret = messaging_sync_recv(port_name, param);
+		if (ret != OK) {
+			goto send_fail;
+		}
+	}
+	return OK;
+
+send_fail:
+	return ERROR;
+}
+
+int messaging_send_reply(const char *port_name, const char *msg, size_t msglen)
+{
+	int ret = OK;
+	char *reply_portname;
+
+	/* sender waits the reply with "port_name + MSG_SYNC_PORTNAME_PREFIX". */
+	MSG_ASPRINTF(&reply_portname, "%s%s", port_name, MSG_SYNC_PORTNAME_PREFIX);
+
+	ret = messaging_send_internal(reply_portname, msg, msglen, MSG_REPLY_PRIO);
+	if (ret != OK) {
+		printf("message reply fail.\n");
+	}
+	MSG_FREE(reply_portname);
+	return ret;
+}

--- a/os/Kconfig
+++ b/os/Kconfig
@@ -521,6 +521,10 @@ menu "Event Loop Framework"
 source "$FRAMEWORK_DIR/src/eventloop/Kconfig"
 endmenu
 
+menu "Messaging Framework"
+source "$FRAMEWORK_DIR/src/messaging/Kconfig"
+endmenu
+
 menu "Things Management"
 source Kconfig.things
 endmenu

--- a/os/include/debug.h
+++ b/os/include/debug.h
@@ -764,6 +764,14 @@ Once LOGM is approved, each module should have its own index
 #define elllvdbg(...)
 #endif
 
+#ifdef CONFIG_MESSAGE_IPC
+#define msgdbg(format, ...)      dbg(format, ##__VA_ARGS__)
+#define msglldbg(format, ...)    lldbg(format, ##__VA_ARGS__)
+#else
+#define msgdbg(...)
+#define msglldbg(...)
+#endif
+
 #else							/* CONFIG_CPP_HAVE_VARARGS */
 
 /* Variadic macros NOT supported */
@@ -1195,6 +1203,14 @@ Once LOGM is approved, each module should have its own index
 #else
 #define elvdbg     (void)
 #define elllvdbg   (void)
+#endif
+
+#ifdef CONFIG_MESSAGE_IPC
+#define msgdbg       dbg
+#define msglldbg     lldbg
+#else
+#define msgdbg       (void)
+#define msglldbg     (void)
 #endif
 
 #endif							/* CONFIG_CPP_HAVE_VARARGS */

--- a/os/include/signal.h
+++ b/os/include/signal.h
@@ -215,6 +215,13 @@
 #define SIGEL_EVENT       CONFIG_SIG_SIGEL_EVENT
 #endif
 
+/* SIG_SIGEL_EVENT is used for event handling in Event Loop */
+#ifndef CONFIG_SIG_MESSAGING_UNICAST
+#define SIGMSG_UNICAST    25			/* Messaging unicast signal */
+#else
+#define SIGMSG_UNICAST    CONFIG_SIG_MESSAGING_UNICAST
+#endif
+
 /* sigprocmask() "how" definitions. Only one of the following can be specified: */
 
 #define SIG_BLOCK       1		/* Block the given signals */

--- a/os/kernel/Kconfig
+++ b/os/kernel/Kconfig
@@ -885,6 +885,15 @@ config SIG_SIGEL_EVENT
 		This setting specifies the signal number that will be used for SIG_SIGEL_EVENT.
 		Default: 24
 
+config SIG_MESSAGING_UNICAST
+	int "MESSAGE RECV SIGNAL"
+	default 25
+	depends on MESSAGING_IPC
+	---help---
+		SIG_MESSAGING_UNICAST is a non-standard signal used to notify to message receiver.
+		This setting specifies the signal number that will be used for SIG_MESSAGING_UNICAST.
+		Default: 25
+
 endmenu # Signal Numbers
 
 menu "POSIX Message Queue Options"


### PR DESCRIPTION
Users can send and receive the data with unicast messaging IPC.
unicast messaging IPC supports like below.
1. send : sync/async mode
  - sync : sender waits after sending msg
  - async : sender just sends msg and be finished.
2. receive : block/non-block mode
  - block : receiver waits for getting msg
  - non-block : receiver sets msg callback func and continue to run.
3. reply : send reply msg from receiver to sender when sender sends sync msg
  - using same port name for sending reply