### PR TITLE
external/mbedtls: Remove redundant heap memory check logic

### DIFF
--- a/external/mbedtls/ssl_tls.c
+++ b/external/mbedtls/ssl_tls.c
@@ -7019,16 +7019,6 @@ int mbedtls_ssl_handshake( mbedtls_ssl_context *ssl )
 {
     int ret = 0;
 
-#if defined(MBED_TIZENRT)
-    struct mallinfo data = mallinfo();
-
-    if( data.fordblks < MBEDTLS_MAXIMUM_HANDSHAKE_MEMORY_USAGE )
-    {
-        MBEDTLS_SSL_DEBUG_MSG( 2, ( "System memory is not enough to do handshake (mem: %d)", data.fordblks ) );
-        return( MBEDTLS_ERR_SSL_ALLOC_FAILED );
-    }
-#endif
-
     if( ssl == NULL || ssl->conf == NULL )
         return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
 


### PR DESCRIPTION
- Remove a comparison logic of mallinfo fordblks and MBEDTLS_MAXIMUM_HANDSHAKE_MEMORY_USAGE
1) It increases unnecessary time overhead
2) fordblks shows the whole (discontinuous) heap size
3) Memory allocation failure will be returned if it fails