### PR TITLE
framework/messaging : Add unicast messaging IPC

### DIFF
--- a/apps/examples/messaging_sample/.gitignore
+++ b/apps/examples/messaging_sample/.gitignore
@@ -1,0 +1,11 @@
+/Make.dep
+/.depend
+/.built
+/*.asm
+/*.obj
+/*.rel
+/*.lst
+/*.sym
+/*.adb
+/*.lib
+/*.src

--- a/apps/examples/messaging_sample/Kconfig
+++ b/apps/examples/messaging_sample/Kconfig
@@ -1,0 +1,14 @@
+#
+# For a description of the syntax of this configuration file,
+# see kconfig-language at https://www.kernel.org/doc/Documentation/kbuild/kconfig-language.txt
+#
+
+config EXAMPLES_MESSAGING_SAMPLE
+	bool "Messaging Framework sample"
+	default n
+	---help---
+		Enable the Messaging Framework sample
+
+config USER_ENTRYPOINT
+	string
+	default "messaging_main" if ENTRY_MESSAGING_SAMPLE

--- a/apps/examples/messaging_sample/Kconfig_ENTRY
+++ b/apps/examples/messaging_sample/Kconfig_ENTRY
@@ -1,0 +1,3 @@
+config ENTRY_MESSAGING_SAMPLE
+	bool "Messaging Framework sample"
+	depends on EXAMPLES_MESSAGING_SAMPLE

--- a/apps/examples/messaging_sample/Make.defs
+++ b/apps/examples/messaging_sample/Make.defs
@@ -1,0 +1,55 @@
+###########################################################################
+#
+# Copyright 2019 Samsung Electronics All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+#
+###########################################################################
+############################################################################
+# apps/examples/messaging_sample/Make.defs
+#
+#   Copyright (C) 2015 Gregory Nutt. All rights reserved.
+#   Author: Gregory Nutt <gnutt@nuttx.org>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in
+#    the documentation and/or other materials provided with the
+#    distribution.
+# 3. Neither the name NuttX nor the names of its contributors may be
+#    used to endorse or promote products derived from this software
+#    without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+# OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+# AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+############################################################################
+
+ifeq ($(CONFIG_EXAMPLES_MESSAGING_SAMPLE),y)
+CONFIGURED_APPS += examples/messaging_sample
+endif

--- a/apps/examples/messaging_sample/Makefile
+++ b/apps/examples/messaging_sample/Makefile
@@ -1,0 +1,158 @@
+###########################################################################
+#
+# Copyright 2019 Samsung Electronics All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+#
+###########################################################################
+############################################################################
+# apps/examples/messaging_sample/Makefile
+#
+#   Copyright (C) 2008, 2010-2013 Gregory Nutt. All rights reserved.
+#   Author: Gregory Nutt <gnutt@nuttx.org>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in
+#    the documentation and/or other materials provided with the
+#    distribution.
+# 3. Neither the name NuttX nor the names of its contributors may be
+#    used to endorse or promote products derived from this software
+#    without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+# OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+# AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+############################################################################
+
+-include $(TOPDIR)/.config
+-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
+
+# messaging sample application info
+
+APPNAME = messaging
+FUNCNAME = $(APPNAME)_main
+THREADEXEC = TASH_EXECMD_ASYNC
+
+# messaging sample
+
+ASRCS =
+CSRCS =
+MAINSRC = messaging_main.c
+
+AOBJS = $(ASRCS:.S=$(OBJEXT))
+COBJS = $(CSRCS:.c=$(OBJEXT))
+MAINOBJ = $(MAINSRC:.c=$(OBJEXT))
+
+SRCS = $(ASRCS) $(CSRCS) $(MAINSRC)
+OBJS = $(AOBJS) $(COBJS)
+
+ifneq ($(CONFIG_BUILD_KERNEL),y)
+  OBJS += $(MAINOBJ)
+endif
+
+ifeq ($(CONFIG_WINDOWS_NATIVE),y)
+  BIN = ..\..\libapps$(LIBEXT)
+else
+ifeq ($(WINTOOL),y)
+  BIN = ..\\..\\libapps$(LIBEXT)
+else
+  BIN = ../../libapps$(LIBEXT)
+endif
+endif
+
+ifeq ($(WINTOOL),y)
+  INSTALL_DIR = "${shell cygpath -w $(BIN_DIR)}"
+else
+  INSTALL_DIR = $(BIN_DIR)
+endif
+
+CONFIG_EXAMPLES_MESSAGING_PROGNAME ?= messaging$(EXEEXT)
+PROGNAME = $(CONFIG_EXAMPLES_MESSAGING_PROGNAME)
+
+ROOTDEPPATH = --dep-path .
+
+# Common build
+
+VPATH =
+
+all: .built
+.PHONY: clean depend distclean
+
+$(AOBJS): %$(OBJEXT): %.S
+	$(call ASSEMBLE, $<, $@)
+
+$(COBJS) $(MAINOBJ): %$(OBJEXT): %.c
+	$(call COMPILE, $<, $@)
+
+.built: $(OBJS)
+	$(call ARCHIVE, $(BIN), $(OBJS))
+	@touch .built
+
+ifeq ($(CONFIG_BUILD_KERNEL),y)
+$(BIN_DIR)$(DELIM)$(PROGNAME): $(OBJS) $(MAINOBJ)
+	@echo "LD: $(PROGNAME)"
+	$(Q) $(LD) $(LDELFFLAGS) $(LDLIBPATH) -o $(INSTALL_DIR)$(DELIM)$(PROGNAME) $(ARCHCRT0OBJ) $(MAINOBJ) $(LDLIBS)
+	$(Q) $(NM) -u  $(INSTALL_DIR)$(DELIM)$(PROGNAME)
+
+install: $(BIN_DIR)$(DELIM)$(PROGNAME)
+
+else
+install:
+
+endif
+
+ifeq ($(CONFIG_BUILTIN_APPS)$(CONFIG_EXAMPLES_MESSAGING_SAMPLE),yy)
+$(BUILTIN_REGISTRY)$(DELIM)$(FUNCNAME).bdat: $(DEPCONFIG) Makefile
+	$(Q) $(call REGISTER,$(APPNAME),$(FUNCNAME),$(THREADEXEC),$(PRIORITY),$(STACKSIZE))
+
+context: $(BUILTIN_REGISTRY)$(DELIM)$(FUNCNAME).bdat
+
+else
+context:
+
+endif
+
+.depend: Makefile $(SRCS)
+	@$(MKDEP) $(ROOTDEPPATH) "$(CC)" -- $(CFLAGS) -- $(SRCS) >Make.dep
+	@touch $@
+
+depend: .depend
+
+clean:
+	$(call DELFILE, .built)
+	$(call CLEAN)
+
+distclean: clean
+	$(call DELFILE, Make.dep)
+	$(call DELFILE, .depend)
+
+-include Make.dep
+.PHONY: preconfig
+preconfig:

--- a/apps/examples/messaging_sample/messaging_main.c
+++ b/apps/examples/messaging_sample/messaging_main.c
@@ -1,0 +1,271 @@
+/****************************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+/****************************************************************************
+ * apps/examples/messaging_sample/messaging_main.c
+ *
+ *   Copyright (C) 2008, 2011-2012 Gregory Nutt. All rights reserved.
+ *   Author: Gregory Nutt <gnutt@nuttx.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <tinyara/config.h>
+#include <sched.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <sys/types.h>
+#include <messaging/messaging.h>
+
+#define TEST1_PORT "test1_port"
+#define TEST1_DATA "TEST1"
+
+#define TEST2_PORT "test2_port"
+#define TEST2_DATA "TEST2"
+#define TEST2_REPLY "REPLY_MSG"
+
+#define MSG_PRIO 10
+#define TASK_PRIO 100
+#define STACKSIZE 2048
+#define BUFFER_SIZE 10
+
+static char *sync_send_alloc;
+
+static void recv_callback(int msg_type, pid_t sender_pid, void *data, void *recv_data)
+{
+	printf("Success to receive with non-block mode in recv callback from PID[%d]. : %s\n", sender_pid, (char *)recv_data);
+}
+
+int async_send(int argc, FAR char *argv[])
+{
+	int ret;
+	msg_send_data_t param;
+	param.priority = MSG_PRIO;
+	param.type = MSG_SEND_TYPE_ASYNC;
+	param.msg = TEST1_DATA;
+	param.msglen = sizeof(TEST1_DATA);
+
+	printf("- Send %s data with async mode.\n", TEST1_DATA);
+	ret = messaging_send(TEST1_PORT, &param, NULL);
+	if (ret != OK) {
+		printf("Fail to async send message.\n");
+		return ERROR;
+	}
+
+	return 0;
+}
+
+int sync_send(int argc, FAR char *argv[])
+{
+	int ret;
+	msg_send_data_t send_data;
+	msg_data_t reply_data;
+	send_data.priority = MSG_PRIO;
+	send_data.type = MSG_SEND_TYPE_SYNC;
+	send_data.msg = TEST2_DATA;
+	send_data.msglen = sizeof(TEST2_DATA);
+
+	reply_data.msglen = BUFFER_SIZE;
+	reply_data.msg = (char *)malloc(BUFFER_SIZE);
+	if (reply_data.msg == NULL) {
+		printf("Fail to sync send message : out of memory.\n");
+		return ERROR;
+	}
+	sync_send_alloc = reply_data.msg;
+
+	printf("- Send %s data with sync mode.\n", TEST2_DATA);
+	ret = messaging_send(TEST2_PORT, &send_data, &reply_data);
+	if (ret != OK) {
+		printf("Fail to sync send message.\n");
+		free(reply_data.msg);
+		return ERROR;
+	}
+
+	printf("Success to receive reply from receiver. : %s\n", (char *)reply_data.msg);
+	free(reply_data.msg);
+
+	return 0;
+}
+
+int nonblock_recv(int argc, FAR char *argv[])
+{
+	int ret;
+	msg_recv_param_t param;
+	msg_data_t data;
+
+	param.type = MSG_RECV_TYPE_NONBLOCK;
+	param.cb_func = recv_callback;
+	data.msg = (char *)malloc(BUFFER_SIZE);
+	if (data.msg == NULL) {
+		printf("Fail to recv nonblock message : out of memory.\n");
+		return ERROR;
+	}
+	data.msglen = BUFFER_SIZE;
+
+	ret = messaging_recv(TEST1_PORT, &data, &param);
+	if (ret != OK) {
+		printf("Fail to receive with non-block mode.\n");
+		free(data.msg);
+		return ERROR;
+	}
+
+	free(data.msg);
+	return OK;
+}
+
+int block_recv(int argc, FAR char *argv[])
+{
+	int ret;
+	msg_recv_param_t recv_param;
+	msg_data_t recv_data;
+	msg_data_t reply_data;
+
+	recv_param.type = MSG_RECV_TYPE_BLOCK;
+	recv_data.msg = (char *)malloc(BUFFER_SIZE);
+	if (recv_data.msg == NULL) {
+		printf("Fail to receive, because out of memory.\n");
+		return ERROR;
+	}
+	recv_data.msglen = BUFFER_SIZE;
+
+	ret = messaging_recv(TEST2_PORT, &recv_data, &recv_param);
+	if (ret != OK) {
+		printf("Fail to receive with block mode.\n");
+		free(recv_data.msg);
+		return ERROR;
+	}
+
+	printf("Success to receive with block mode in receiver. : %s\n", (char *)recv_data.msg);
+	printf("- Reply to sender %s data.\n", TEST2_REPLY);
+
+	reply_data.msg = TEST2_REPLY;
+	reply_data.msglen = sizeof(TEST2_REPLY);
+	reply_data.sender_pid = recv_data.sender_pid;
+	if (recv_data.msg_type == MSG_SEND_TYPE_SYNC) {
+		ret = messaging_send_reply(TEST2_PORT, &reply_data);
+		if (ret != OK) {
+			printf("Fail to reply.\n");
+			free(recv_data.msg);
+			return ERROR;
+		}
+	} else {
+		printf("We will not reply, because received msg is not sync type.\n");
+	}
+
+	free(recv_data.msg);
+	return OK;
+}
+
+void async_nonblock_messaging_test(void)
+{
+	int ret;
+	int sender_pid;
+
+	printf("\n=== Start the Async Non-block messaging test. ===\n");
+
+	sender_pid = task_create("async_send", TASK_PRIO, STACKSIZE, async_send, NULL);
+	if (sender_pid < 0) {
+		printf("Fail to create async_send task.\n");
+		return;
+	}
+
+	ret = task_create("nonblock_recv", TASK_PRIO, STACKSIZE, nonblock_recv, NULL);
+	if (ret < 0) {
+		task_delete(sender_pid);
+		printf("Fail to create nonblock_recv task.\n");
+		return;
+	}
+
+	/* Wait for finishing async_send and nonblock_recv tasks. */
+	sleep(1);
+
+	ret = messaging_unregister(TEST1_PORT);
+	if (ret != OK) {
+		printf("Fail to unregister TEST1_PORT.\n");
+		return;
+	}
+}
+
+void sync_block_messaging_test(void)
+{
+	int ret;
+	int sender_pid;
+
+	printf("\n=== Start the Sync Block messaging test. ===\n");
+
+	sender_pid = task_create("sync_send", TASK_PRIO, STACKSIZE, sync_send, NULL);
+	if (sender_pid < 0) {
+		printf("Fail to create sync_send task.\n");
+		return;
+	}
+
+	ret = task_create("block_recv", TASK_PRIO, STACKSIZE, block_recv, NULL);
+	if (ret < 0) {
+		free(sync_send_alloc);
+		task_delete(sender_pid);
+		printf("Fail to create block_recv task.\n");
+		return;
+	}
+}
+
+#ifdef CONFIG_BUILD_KERNEL
+int main(int argc, FAR char *argv[])
+#else
+int messaging_main(int argc, char *argv[])
+#endif
+{
+	async_nonblock_messaging_test();
+
+	/* Wait for finishing previous test. */
+	sleep(1);
+
+	sync_block_messaging_test();
+
+	return 0;
+}

--- a/framework/include/messaging/messaging.h
+++ b/framework/include/messaging/messaging.h
@@ -1,0 +1,160 @@
+/****************************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+/**
+ * @defgroup Messaging Messaging
+ * @ingroup Messaging
+ * @brief Provides APIs for Messaging
+ * @{
+ */
+
+/**
+ * @file messaging/messaging.h
+ */
+#ifndef __MESSAGING_H__
+#define __MESSAGING_H__
+
+/**
+ * @brief Called when a message is received
+ */
+typedef void (*msg_callback_t)(int msg_type, pid_t sender_pid, void *callback_data, void *user_data);
+
+/**
+ * @brief The type of sending message
+ * @details MSG_SEND_TYPE_SYNC  : A sender waits after sending message until receiving a reply message.\n
+ *	    MSG_SEND_TYPE_ASYNC : A sender continues to run after sending message.
+ */
+enum msg_send_type_e {
+	MSG_SEND_TYPE_SYNC = 0,
+	MSG_SEND_TYPE_ASYNC = 1,
+	MSG_SEND_TYPE_MAX
+};
+typedef enum msg_send_type_e msg_send_type_t;
+
+/**
+ * @brief The structure of parameters which used for sending
+ */
+struct msg_send_data_s {
+	int priority;
+	msg_send_type_t type; /* for sender : MSG_SEND_TYPE_SYNC or MSG_SEND_TYPE_ASYNC */
+	const char *msg;
+	int msglen;
+};
+typedef struct msg_send_data_s msg_send_data_t;
+
+/**
+ * @brief The type of receiving message
+ * @details MSG_RECV_TYPE_BLOCK    : A receiver blocks until receiving the message.\n
+ *	    MSG_RECV_TYPE_NONBLOCK : A receiver sets callback function for receiving message and continues to run.
+ */
+enum msg_recv_type_e {
+	MSG_RECV_TYPE_BLOCK = 0,
+	MSG_RECV_TYPE_NONBLOCK = 1,
+	MSG_RECV_TYPE_MAX
+};
+typedef enum msg_recv_type_e msg_recv_type_t;
+
+/**
+ * @brief The structure of data buffer which used for receiving and replying
+ */
+struct msg_data_s {
+	char *msg;
+	int msglen;
+	pid_t sender_pid;
+	int msg_type;
+};
+typedef struct msg_data_s msg_data_t;
+
+/**
+ * @brief The structure of parameters which used for receiving
+ */
+struct msg_recv_param_s {
+	msg_recv_type_t type; /* for receiver : MSG_RECV_BLOCK or MSG_RECV_NONBLOCK */
+	msg_callback_t cb_func;
+	char *cb_data;
+};
+typedef struct msg_recv_param_s msg_recv_param_t;
+/**
+ * @brief Send unicast message to specified message port
+ * @details @b #include <messaging/messaging.h>\n
+ * @param[in] port_name The message port name to send
+ * @param[in] send_data
+ *		  msg          : The message to be sent\n
+ *		  msglen       : The length of message to be sent\n
+ *		  priority     : A non-negative integer that specifies the priority of this message\n
+ *		  type         : MSG_SEND_TYPE_SYNC or MSG_SEND_TYPE_ASYNC\n
+ * @param reply_data
+ *		  [out] reply_msg    : A message buffer to receive the sync reply message\n
+ *		  [in] reply_msglen  : A message size for sync reply message
+ *		  [out] sender_pid   : The pid who replies this message\n
+ *		  [out] msg_type     : For replying, msg_type is set to default, MSG_SEND_TYPE_ASYNC.
+ * @return On success, OK is returned. On failure, Error is returned.
+ * @since TizenRT v3.0
+ */
+int messaging_send(const char *port_name, msg_send_data_t *send_data, msg_data_t *reply_data);
+/**
+ * @brief Wait to receive unicast message from specified message port
+ * @details @b #include <messaging/messaging.h>\n
+ * @param[in] port_name The message port name to receive
+ * @param data\n
+ *		[out] msg         : The message buffer to receive the message\n
+ *		[in] msglen       : The length of message to receive\n
+ *		[out] sender_pid  : The pid who sends this message\n
+ *		[out] msg_type    : The received message type, MSG_SEND_TYPE_SYNC or MSG_SEND_TYPE_ASYNC.\n
+ *				   If msg_type is MSG_SEND_TYPE_SYNC, receiver should reply with messaging_send_reply.
+ * @param[in] param\n
+ *		type    : MSG_RECV_BLOCK or MSG_RECV_NONBLOCK\n
+ *		cb_func : user callback function for nonblocking receive\n
+ *		cb_data : user callback data for nonblocking receive\n
+ * @return On success, OK is returned. On failure, Error is returned.
+ * @since TizenRT v3.0
+ */
+int messaging_recv(const char *port_name, msg_data_t *data, msg_recv_param_t *param);
+/**
+ * @brief Reply unicast message to specified message port when received sync message
+ * @details @b #include <messaging/messaging.h>\n
+ * Receiver should set sender_pid in reply_data who receives this reply.
+ * @param[in] port_name The message port name to send\n
+ *		This port name should be matched to original port name which received the message.
+ * @param[in] reply_data
+ *		  reply_msg    : The message to be sent\n
+ *		  reply_msglen : The length of message to be sent\n
+ *		  sender_pid   : The pid who will receive this reply\n
+ * 		  msg_type     : For replying, msg_type is set to default, MSG_SEND_TYPE_ASYNC.
+ * @return On success, OK is returned. On failure, Error is returned.
+ * @since TizenRT v3.0
+ */
+int messaging_send_reply(const char *port_name, msg_data_t *reply_data);
+/**
+ * @brief Unregister the messaging port when set non-block receive
+ * @details @b #include <messaging/messaging.h>\n
+ * @param[in] port_name The message port name to unregister\n
+ *		This API should be called when calling messaging_recv with non-block type.\n
+ *		If this API is not called, memory leak can happen.
+ * @return On success, OK is returned. On failure, Error is returned.
+ * @since TizenRT v3.0
+ */
+int messaging_unregister(const char *port_name);
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
+
+#endif
+/**
+ * @}
+ */

--- a/framework/src/messaging/Kconfig
+++ b/framework/src/messaging/Kconfig
@@ -1,0 +1,42 @@
+#
+# For a description of the syntax of this configuration file,
+# see kconfig-language at https://www.kernel.org/doc/Documentation/kbuild/kconfig-language.txt
+#
+
+config MESSAGING_IPC
+	bool "Enable Messaging APIs"
+	default y
+	depends on !DISABLE_MQUEUE
+	depends on !DISABLE_SIGNALS
+	---help---
+		Enables Messaging APIs.
+		Users can send and receive the data with unicast messaging IPC.
+		unicast messaging IPC supports like below.
+		send : sync/async mode
+			- sync : sender waits after sending msg
+			- async : sender just sends msg and be finished.
+		receive : block/non-block mode
+			- block : receiver waits for getting msg
+			- non-block : receiver sets msg callback func and continue to run.
+		reply : send reply msg from receiver to sender when sender sends sync msg
+			- using same port name for sending reply
+		The maximum size of unicast message is as same as MQ_MAXSIZE.
+
+
+if MESSAGING_IPC
+config MESSAGING_UNICAST_MAXMSG
+	int "Max message number for unicast"
+	default 100
+	---help---
+		Max number of unicast messaging
+
+config MESSAGING_UNICAST_MSGSIZE
+	int "Max message size for unicast"
+	range 0 MQ_MAXMSGSIZE
+	default MQ_MAXMSGSIZE
+	---help---
+		Max size of unicast messaging.
+		This can be from 0 to MQ_MAXMSGSIZE.
+
+endif
+

--- a/framework/src/messaging/Make.defs
+++ b/framework/src/messaging/Make.defs
@@ -1,0 +1,25 @@
+###########################################################################
+#
+# Copyright 2019 Samsung Electronics All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+#
+###########################################################################
+
+ifeq ($(CONFIG_MESSAGING_IPC),y)
+
+CSRCS += messaging_send.c messaging_recv.c
+
+DEPPATH += --dep-path src/messaging
+VPATH += :src/messaging
+endif

--- a/framework/src/messaging/messaging_internal.h
+++ b/framework/src/messaging/messaging_internal.h
@@ -1,0 +1,39 @@
+/****************************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+#include <tinyara/compiler.h>
+#include <mqueue.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <messaging/messaging.h>
+
+#define MSG_ALLOC(a) malloc(a)
+#define MSG_FREE(a) free(a)
+#ifdef CONFIG_CPP_HAVE_VARARGS
+#define MSG_ASPRINTF(p, f, ...) asprintf(p, f, ##__VA_ARGS__)
+#else
+#define MSG_ASPRINTF asprintf
+#endif
+
+#define MSG_HEADER_SIZE (sizeof(pid_t) + sizeof(int))
+
+struct msg_recv_info_s {
+	mqd_t mqdes;
+	msg_callback_t user_cb;
+	char *cb_data;
+};
+typedef struct msg_recv_info_s msg_recv_info_t;

--- a/framework/src/messaging/messaging_recv.c
+++ b/framework/src/messaging/messaging_recv.c
@@ -1,0 +1,440 @@
+/****************************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+#include <tinyara/config.h>
+#include <debug.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <mqueue.h>
+#include <stdlib.h>
+#include <signal.h>
+#include <string.h>
+#include <unistd.h>
+#include <queue.h>
+#include <sys/types.h>
+#include <messaging/messaging.h>
+#include "messaging_internal.h"
+
+#define MAX_PORT_NAME_SIZE 64
+sq_queue_t g_port_info_list;
+struct msg_port_info_s {
+	struct msg_port_info_s *flink;
+	char name[MAX_PORT_NAME_SIZE];
+	mqd_t mqdes;
+};
+typedef struct msg_port_info_s msg_port_info_t;
+
+/****************************************************************************
+ * private functions
+ ****************************************************************************/
+/****************************************************************************
+ * Name : messaging_set_notification
+ * 
+ * Description:
+ *  This function calls mq_notify to set message queue notification.
+ ****************************************************************************/
+static int messaging_set_notification(msg_recv_info_t *data)
+{
+	int ret;
+	struct sigevent notification;
+
+	notification.sigev_notify = SIGEV_SIGNAL;
+	notification.sigev_signo = SIGMSG_UNICAST;
+	notification.sigev_value.sival_ptr = data;
+
+	ret = mq_notify(data->mqdes, &notification);
+	if (ret < 0) {
+		msgdbg("message recv fail : set notification fail. %d\n", errno);
+		MSG_FREE(data);
+		return ERROR;
+	}
+	return OK;
+}
+
+/****************************************************************************
+ * Name : messaging_run_nonblock_callback
+ * 
+ * Description:
+ *  This function is wrapper callback function for waiting until receiving the message.
+ ****************************************************************************/
+static void messaging_run_nonblock_callback(int signo, siginfo_t *data)
+{
+	int ret;
+	ssize_t size;
+	msg_recv_info_t *recv_info;
+	char msg[CONFIG_MESSAGING_UNICAST_MSGSIZE - (MSG_HEADER_SIZE)];
+	struct mq_attr attr;
+	char *recv_data;
+	pid_t sender_pid;
+	int msg_type;
+
+	if (data == NULL) {
+		msgdbg("message recv fail : wrong param for wrapper callback(data).\n");
+		return;
+	}
+
+	recv_info = (msg_recv_info_t *)data->si_value.sival_ptr;
+	if (recv_info == NULL) {
+		msgdbg("message recv fail : wrong param for wrapper callback(info).\n");
+		return;
+	}
+
+	recv_data = (char *)MSG_ALLOC(CONFIG_MESSAGING_UNICAST_MSGSIZE);
+	if (recv_data == NULL) {
+		msgdbg("message recv fail : out of memory for including header.\n");
+		return;
+	}
+
+	while (1) {
+		size = mq_receive(recv_info->mqdes, recv_data, sizeof(msg_recv_info_t), 0);
+		if (size != sizeof(msg_recv_info_t)) {
+			msgdbg("message recv fail : mq_receive fail. %d\n", errno);
+			mq_close(recv_info->mqdes);
+			MSG_FREE(recv_data);
+			MSG_FREE(data);
+			return;
+		}
+		memcpy(&sender_pid, recv_data, sizeof(pid_t));
+		memcpy(&msg_type, recv_data + sizeof(pid_t), sizeof(int));
+		memcpy(msg, recv_data + MSG_HEADER_SIZE, CONFIG_MESSAGING_UNICAST_MSGSIZE - sizeof(pid_t));
+		/* Call user callback */
+		(*recv_info->user_cb)(msg_type, sender_pid, recv_info->cb_data, &msg);
+		MSG_FREE(recv_data);
+
+		ret = mq_getattr(recv_info->mqdes, &attr);
+		if (ret < 0) {
+			msgdbg("message recv fail : mq_getattr fail.\n");
+			mq_close(recv_info->mqdes);
+			MSG_FREE(data);
+			return;
+		} else if (attr.mq_curmsgs == 0) {
+			/* All requests are handled. Register notification again. */
+			messaging_set_notification(recv_info);
+			break;
+		}
+	}
+}
+
+/****************************************************************************
+ * Name : messaging_set_notify_signal
+ * 
+ * Description:
+ *  This function registers the wrapper callback for notification.
+ *
+ * Return Value:
+ *  On success, 0 (OK) is returned.; On failure, -1 (ERROR) is returned.
+ ****************************************************************************/
+static int messaging_set_notify_signal(void)
+{
+	int ret;
+	struct sigaction act;
+	act.sa_sigaction = (_sa_sigaction_t)messaging_run_nonblock_callback;
+	act.sa_flags = 0;
+	(void)sigemptyset(&act.sa_mask);
+
+	ret = sigaddset(&act.sa_mask, SIGMSG_UNICAST);
+	if (ret < 0) {
+		msgdbg("message recv fail : sigaddset error.\n");
+		return ERROR;
+	}
+
+	ret = sigaction(SIGMSG_UNICAST, &act, NULL);
+	if (ret == (int)SIG_ERR) {
+		msgdbg("message recv fail : sigaction error.\n");
+		return ERROR;
+	}
+	return OK;
+}
+
+/****************************************************************************
+ * Name : messaging_recv_nonblock
+ * 
+ * Description:
+ *  This function is for non-blocking mq_receive.
+ * If there is a message in the queue, this function calls the callback with msg.
+ * If there is no message, then calls the notification function to register callback. 
+ *
+ * Input Parameters:
+ *  mqdes     : Message queue descriptor
+ *  port_name : The message port name to receive
+ *  msg       : The message buffer to receive the message
+ *  msglen    : The length of message to receive
+ *  param     :
+ *	type    : MSG_RECV_TYPE_BLOCK or MSG_RECV_TYPE_NONBLOCK\n
+ *	cb_func : user callback function for nonblocking receive
+ * 
+ * Return Value:
+ *  On success, 0 (OK) is returned.; On failure, -1 (ERROR) is returned.
+ *  Sender pid is passed to callback function as 3rd argument.
+ ****************************************************************************/
+static int messaging_recv_nonblock(mqd_t mqdes, const char *port_name, msg_data_t *data, msg_recv_param_t *param)
+{
+	int ret;
+	ssize_t recv_size_chk;
+	msg_recv_info_t *nonblock_data;
+	msg_port_info_t *port_info;
+	int recv_size;
+	char *recv_data;
+	pid_t sender_pid;
+
+	recv_size = data->msglen + MSG_HEADER_SIZE;
+	recv_data = MSG_ALLOC(recv_size);
+	if (recv_data == NULL) {
+		msgdbg("message recv fail : out of memory for including header.\n");
+		goto cleanup_mq;
+	}
+	/* Check there was msg already before setting notification */
+	while (1) {
+		recv_size_chk = mq_receive(mqdes, recv_data, recv_size, 0);
+		if (recv_size_chk > 0 && recv_size_chk <= recv_size) {
+			memcpy(&sender_pid, recv_data, sizeof(pid_t));
+			memcpy(&data->msg_type, recv_data + sizeof(pid_t), sizeof(int));
+			memcpy(data->msg, recv_data + MSG_HEADER_SIZE, data->msglen);
+			(*param->cb_func)(data->msg_type, sender_pid, param->cb_data, data->msg);
+		} else if (recv_size_chk == ERROR && errno == EAGAIN) {
+			msgdbg("message recv : the queue was empty, and the NONBLOCK flag was set.\n");
+			break;
+		} else {
+			msgdbg("message recv fail : recv fail errno %d, recv_size %d.\n", errno, recv_size_chk);
+			MSG_FREE(recv_data);
+			goto cleanup_mq;
+		}
+	}
+	MSG_FREE(recv_data);
+
+	/* Update the messag port info list. */
+	port_info = (msg_port_info_t *)MSG_ALLOC(sizeof(msg_port_info_t));
+	if (port_info == NULL) {
+		msgdbg("message recv fail : out of memory for msg_port_info.\n");
+		goto cleanup_mq;
+	}
+	port_info->mqdes = mqdes;
+	strncpy(port_info->name, port_name, strlen(port_name) + 1);
+	sq_addlast((FAR sq_entry_t *)port_info, &g_port_info_list);
+
+	/* There was no msg, then set notification. */
+	ret = messaging_set_notify_signal();
+	if (ret != OK) {
+		msgdbg("message recv fail : set notification error.\n");
+		goto cleanup_all;
+	}
+
+	nonblock_data = (msg_recv_info_t *)MSG_ALLOC(sizeof(msg_recv_info_t));
+	if (nonblock_data == NULL) {
+		msgdbg("message recv fail : out of memory.\n");
+		goto cleanup_all;
+	}
+	nonblock_data->mqdes = mqdes;
+	nonblock_data->user_cb = param->cb_func;
+	nonblock_data->cb_data = param->cb_data;
+
+	ret = messaging_set_notification(nonblock_data);
+	if (ret != OK) {
+		goto cleanup_all;
+	}
+	MSG_FREE(nonblock_data);
+	return OK;
+
+cleanup_all:
+	sq_rem((FAR sq_entry_t *)port_info, &g_port_info_list);
+	MSG_FREE(port_info);
+cleanup_mq:
+	mq_close(mqdes);
+	mq_unlink(port_name);
+	return ERROR;
+}
+
+/****************************************************************************
+ * Name : messaging_recv_block
+ * 
+ * Description:
+ *  This function calls mq_receive with block mode.
+ *
+ * Input Parameters:
+ *  mqdes     : Message queue descriptor
+ *  port_name : The message port name to receive
+ *  msg       : The message buffer to receive the message
+ *  msglen    : The length of message to receive
+ * 
+ * Return Value:
+ *  On success, sender pid (>=0) is returned.; On failure, -1 (ERROR) is returned.
+ ****************************************************************************/
+static int messaging_recv_block(mqd_t mqdes, const char *port_name, msg_data_t *data)
+{
+	int ret = OK;
+	int recv_size;
+	char *recv_data;
+	pid_t sender_pid;
+
+	recv_size = MSG_HEADER_SIZE + data->msglen;
+	recv_data = MSG_ALLOC(recv_size);
+	if (recv_data == NULL) {
+		msgdbg("message recv fail : out of memory for including header.\n");
+		ret = ERROR;
+		goto cleanup_return;
+	}
+
+	ret = mq_receive(mqdes, recv_data, CONFIG_MESSAGING_UNICAST_MSGSIZE, 0);
+	if (ret < 0) {
+		msgdbg("message recv fail : recv fail %d.\n", errno);
+		ret = ERROR;
+		goto cleanup_return;
+	}
+	memcpy(&sender_pid, recv_data, sizeof(pid_t));
+	ret = (int)sender_pid;
+	memcpy(&data->msg_type, recv_data + sizeof(pid_t), sizeof(int));
+	memcpy(data->msg, recv_data + MSG_HEADER_SIZE, data->msglen);
+
+cleanup_return:
+	MSG_FREE(recv_data);
+	mq_close(mqdes);
+	mq_unlink(port_name);
+	return ret;
+}
+/****************************************************************************
+ * Name : messaging_recv_internal
+ * 
+ * Description:
+ *  This function calls receive function based on receive type.
+ *
+ * Input Parameters:
+ *  port_name : The message port name to receive
+ *  param :
+ *	msg     : The message buffer to receive the message
+ *	msglen  : The length of message to receive
+ *	type    : MSG_RECV_TYPE_BLOCK or MSG_RECV_TYPE_NONBLOCK\n
+ *	cb_func : user callback function for nonblocking receive
+ * 
+ * Return Value:
+ *  On success, 0 (OK) is returned.; On failure, -1 (ERROR) is returned.
+ ****************************************************************************/
+static int messaging_recv_internal(const char *port_name, msg_data_t *data, msg_recv_param_t *param)
+{
+	int ret = OK;
+	mqd_t mqdes;
+	struct mq_attr internal_attr;
+
+	internal_attr.mq_maxmsg = CONFIG_MESSAGING_UNICAST_MAXMSG;
+	internal_attr.mq_msgsize = data->msglen + MSG_HEADER_SIZE;
+	internal_attr.mq_flags = 0;
+
+	if (param->type == MSG_RECV_TYPE_BLOCK) {
+		mqdes = mq_open(port_name, O_RDONLY | O_CREAT, 0666, &internal_attr);
+		if (mqdes == (mqd_t)ERROR) {
+			msgdbg("message recv fail : open fail %d.\n", errno);
+			return ERROR;
+		}
+		ret = messaging_recv_block(mqdes, port_name, data);
+		if (ret >= 0) {
+			data->sender_pid = ret;
+			ret = OK;
+		}
+	} else {
+		if (param->cb_func == NULL) {
+			msgdbg("message recv fail : invalid parameter.\n");
+			return ERROR;
+		}
+		mqdes = mq_open(port_name, O_RDONLY | O_CREAT | O_NONBLOCK, 0666, &internal_attr);
+		if (mqdes == (mqd_t)ERROR) {
+			msgdbg("message recv fail : open fail %d.\n", errno);
+			return ERROR;
+		}
+		ret = messaging_recv_nonblock(mqdes, port_name, data, param);
+	}
+	return ret;
+}
+/****************************************************************************
+ * Name : messaging_recv
+ *
+ * Description :
+ *  Wait to receive unicast message from specified message port
+ * 
+ * Input Parameters:
+ *  port_name : The message port name to receive
+ *  data      :
+ *	msg    : The message buffer to receive the message\n
+ *	msglen : The length of message to receive\n
+ *  param
+ *	type    : MSG_RECV_BLOCK or MSG_RECV_NONBLOCK\n
+ *	cb_func : user callback function for nonblocking receive\n
+ *	cb_data : user callback data for nonblocking receive\n
+ *
+ * Return Value:
+ *  On success, 0 (OK) is returned.; On failure, -1 (ERROR) is returned.
+ ****************************************************************************/
+int messaging_recv(const char *port_name, msg_data_t *data, msg_recv_param_t *param)
+{
+	int ret = OK;
+
+	if ((param->type < MSG_RECV_TYPE_BLOCK) || (param->type > MSG_RECV_TYPE_NONBLOCK) || (param->type == MSG_RECV_TYPE_NONBLOCK && param->cb_func == NULL)) {
+		msgdbg("message recv fail : invalid param.\n");
+		return ERROR;
+	}
+
+	ret = messaging_recv_internal(port_name, data, param);
+	if (ret == ERROR) {
+		msgdbg("message recv fail : recv fail.\n");
+		return ret;
+	}
+
+	return OK;
+}
+/****************************************************************************
+ * Name : messaging_unregister
+ * 
+ * Description:
+ *  Unregister the messaging port when set non-block receive.
+ *
+ * Input Parameters:
+ *	port_name : The message port name to unregister\n
+ *		This API should be called when calling messaging_recv with non-block type.\n
+ *		If this API is not called, memory leak can happen.
+ * 
+ * Return Value:
+ *  On success, 0 (OK) is returned.; On failure, -1 (ERROR) is returned.
+ ****************************************************************************/
+int messaging_unregister(const char *port_name)
+{
+	int ret;
+	msg_port_info_t *port_info;
+
+	if (port_name == NULL) {
+		msgdbg("message unregister fail : invalid param.\n");
+		return ERROR;
+	}
+
+	port_info = (msg_port_info_t *)sq_peek(&g_port_info_list);
+	while (port_info != NULL) {
+		if (strncmp(port_info->name, port_name, strlen(port_name) + 1) == 0) {
+			mq_close(port_info->mqdes);
+			sq_rem((FAR sq_entry_t *)port_info, &g_port_info_list);
+			MSG_FREE(port_info);
+			break;
+		}
+		port_info = (msg_port_info_t *)sq_next(port_info);
+	}
+	
+	ret = mq_unlink(port_name);
+	if (ret != OK && errno != ENOENT) {
+		msgdbg("message unregister fail : unlink error %d.\n", errno);
+		return ERROR;
+	}
+	return OK;
+}

--- a/framework/src/messaging/messaging_send.c
+++ b/framework/src/messaging/messaging_send.c
@@ -1,0 +1,234 @@
+/****************************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+#include <tinyara/config.h>
+#include <debug.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <mqueue.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/types.h>
+#include <messaging/messaging.h>
+#include "messaging_internal.h"
+
+#define MSG_REPLY_PRIO 10
+/****************************************************************************
+ * private functions
+ ****************************************************************************/
+/****************************************************************************
+ * Name : messaging_sync_recv
+ * 
+ * Description:
+ *  This function is for waiting reply from receiver.
+ *
+ * Input Parameters:
+ *  port_name : The message port name to send
+ *  param     :
+ *	priority    : A non-negative integer that specifies the priority of this message\n
+ *	type        : MSG_SEND_SYNC or MSG_SEND_ASYNC\n
+ *	sync_msg    : A message buffer to receive the sync reply message\n
+ *	sync_msglen : A message size for sync reply message
+ * 
+ * Return Value:
+ *  On success, 0 (OK) is returned.; On failure, -1 (ERROR) is returned.
+ ****************************************************************************/
+static int messaging_sync_recv(const char *port_name, msg_data_t *reply_buf)
+{
+	int ret = OK;
+	mqd_t sync_mqdes;
+	char *sync_portname;
+	struct mq_attr internal_attr;
+	char *reply_data;
+	int reply_size;
+
+	reply_size = reply_buf->msglen + MSG_HEADER_SIZE;
+
+	internal_attr.mq_maxmsg = CONFIG_MESSAGING_UNICAST_MAXMSG;
+	internal_attr.mq_msgsize = reply_size;
+	internal_attr.mq_flags = 0;
+
+	/* sender waits the reply with "port_name + sender_pid". */
+	MSG_ASPRINTF(&sync_portname, "%s%d", port_name, getpid());
+	if (sync_portname == NULL) {
+		msgdbg("message send fail : sync portname allocation fail.\n");
+		return ERROR;
+	}
+	sync_mqdes = mq_open(sync_portname, O_RDONLY | O_CREAT, 0666, &internal_attr);
+	if (sync_mqdes == (mqd_t)ERROR) {
+		msgdbg("message send fail : sync open fail %d.\n", errno);
+		MSG_FREE(sync_portname);
+		return ERROR;
+	}
+
+	reply_data = (char *)MSG_ALLOC(reply_size);
+	if (reply_data == NULL) {
+		msgdbg("message send fail : out of memory for including header~\n");
+		return ERROR;
+	}
+
+	ret = mq_receive(sync_mqdes, reply_data, reply_size, 0);
+	if (ret < 0) {
+		msgdbg("message send fail : sync recv fail %d.\n", errno);
+		ret = ERROR;
+	} else {
+		memcpy(&reply_buf->sender_pid, reply_data, sizeof(pid_t));
+		memcpy(reply_buf->msg, reply_data + MSG_HEADER_SIZE, reply_buf->msglen);
+		ret = OK;
+	}
+
+	MSG_FREE(reply_data);
+	MSG_FREE(sync_portname);
+	mq_close(sync_mqdes);
+	mq_unlink(sync_portname);
+
+	return ret;
+}
+/****************************************************************************
+ * Name : messaging_send_internal
+ * 
+ * Description:
+ *  This function calls receive function based on receive type.
+ *
+ * Input Parameters:
+ *  port_name : The message port name to send
+ *  msg       : The message to be sent
+ *  msglen    : The length of message to be sent
+ *  priority  : A non-negative integer that specifies the priority of this message
+ * 
+ * Return Value:
+ *  On success, 0 (OK) is returned.; On failure, -1 (ERROR) is returned.
+ ****************************************************************************/
+static int messaging_send_internal(const char *port_name, msg_send_data_t *send_data)
+{
+	int ret = OK;
+	mqd_t mqdes;
+	struct mq_attr internal_attr;
+	char *send_packet;
+	int send_size;
+	pid_t sender_pid;
+	int msg_type;
+
+	send_size = MSG_HEADER_SIZE + send_data->msglen;
+
+	internal_attr.mq_maxmsg = CONFIG_MESSAGING_UNICAST_MAXMSG;
+	internal_attr.mq_msgsize = send_size;
+	internal_attr.mq_flags = 0;
+
+	mqdes = mq_open(port_name, O_WRONLY | O_CREAT, 0666, &internal_attr);
+	if (mqdes == (mqd_t)ERROR) {
+		msgdbg("message send fail : open fail %d.\n", errno);
+		return ERROR;
+	}
+
+	send_packet = (char *)MSG_ALLOC(send_size);
+	if (send_packet == NULL) {
+		msgdbg("message send fail : out of memory for including header.\n");
+		return ERROR;
+	}
+
+	/* Send packet is like below.
+	 * +-----------------------------------------+
+	 * | sender_pid | send type | message        |
+	 * +-----------------------------------------+
+	 */
+
+	/* Add data header for sender pid. */
+	sender_pid = getpid();
+	memcpy(send_packet, &sender_pid, sizeof(pid_t));
+	/* Add data header for send type. */
+	msg_type = send_data->type;
+	memcpy(send_packet + sizeof(pid_t), &msg_type, sizeof(int));
+	/* Copy the real send message. */
+	memcpy(send_packet + MSG_HEADER_SIZE, send_data->msg, send_data->msglen);
+
+	ret = mq_send(mqdes, (char *)send_packet, send_size, send_data->priority);
+	if (ret != OK) {
+		msgdbg("message send fail : send fail %d.\n", errno);
+		MSG_FREE(send_packet);
+		mq_close(mqdes);
+		mq_unlink(port_name);
+		return ERROR;
+	}
+
+	MSG_FREE(send_packet);
+	mq_close(mqdes);
+	return ret;
+}
+
+/****************************************************************************
+ * messaging_send
+ ****************************************************************************/
+int messaging_send(const char *port_name, msg_send_data_t *send_data, msg_data_t *reply_data)
+{
+	int ret;
+
+	if ((send_data->type < MSG_SEND_TYPE_SYNC) || (send_data->type > MSG_SEND_TYPE_ASYNC) || (send_data->type == MSG_SEND_TYPE_SYNC && reply_data->msg == NULL)) {
+		msgdbg("message send fail : invalid param2.\n");
+		return ERROR;
+	}
+
+	ret = messaging_send_internal(port_name, send_data);
+	if (ret != OK) {
+		return ERROR;
+	}
+
+	if (send_data->type == MSG_SEND_TYPE_SYNC) {
+		ret = messaging_sync_recv(port_name, reply_data);
+		if (ret != OK) {
+			return ERROR;
+		}
+	}
+	return OK;
+}
+
+/****************************************************************************
+ * messaging_send_reply
+ ****************************************************************************/
+int messaging_send_reply(const char *port_name, msg_data_t *reply_data)
+{
+	int ret = OK;
+	char *reply_portname;
+	msg_send_data_t reply;
+
+	if (reply_data->sender_pid < 0) {
+		msgdbg("message reply fail : invalid sender pid.\n");
+		return ERROR;
+	}
+
+	/* sender waits the reply with "port_name + sender_pid". */
+	MSG_ASPRINTF(&reply_portname, "%s%d", port_name, reply_data->sender_pid);
+	if (reply_portname == NULL) {
+		msgdbg("message reply fail : out of memory.\n");
+		return ERROR;
+	}
+
+	reply.msg = reply_data->msg;
+	reply.msglen = reply_data->msglen;
+	reply.priority = MSG_REPLY_PRIO;
+	reply.type = MSG_SEND_TYPE_ASYNC;
+	ret = messaging_send_internal(reply_portname, &reply);
+	if (ret != OK) {
+		msgdbg("message reply fail.\n");
+	}
+	MSG_FREE(reply_portname);
+	return ret;
+}

--- a/os/Kconfig
+++ b/os/Kconfig
@@ -521,6 +521,10 @@ menu "Event Loop Framework"
 source "$FRAMEWORK_DIR/src/eventloop/Kconfig"
 endmenu
 
+menu "Messaging Framework"
+source "$FRAMEWORK_DIR/src/messaging/Kconfig"
+endmenu
+
 menu "Things Management"
 source Kconfig.things
 endmenu

--- a/os/include/debug.h
+++ b/os/include/debug.h
@@ -733,6 +733,14 @@ Once LOGM is approved, each module should have its own index
 #define medllvdbg(...)
 #endif
 
+#ifdef CONFIG_MESSAGE_IPC
+#define msgdbg(format, ...)      dbg(format, ##__VA_ARGS__)
+#define msglldbg(format, ...)    lldbg(format, ##__VA_ARGS__)
+#else
+#define msgdbg(...)
+#define msglldbg(...)
+#endif
+
 #ifdef CONFIG_DEBUG_TASK_MANAGER_ERROR
 #define tmdbg(format, ...)      dbg(format, ##__VA_ARGS__)
 #define tmlldbg(format, ...)    lldbg(format, ##__VA_ARGS__)
@@ -1163,6 +1171,14 @@ Once LOGM is approved, each module should have its own index
 #else
 #define medllvdbg   (void)
 #define medllvdbg   (...)
+#endif
+
+#ifdef CONFIG_MESSAGE_IPC
+#define msgdbg       dbg
+#define msglldbg     lldbg
+#else
+#define msgdbg       (void)
+#define msglldbg     (void)
 #endif
 
 #ifdef CONFIG_DEBUG_TASK_MANAGER_ERROR

--- a/os/include/signal.h
+++ b/os/include/signal.h
@@ -215,6 +215,13 @@
 #define SIGEL_EVENT       CONFIG_SIG_SIGEL_EVENT
 #endif
 
+/* SIG_SIGEL_EVENT is used for event handling in Event Loop */
+#ifndef CONFIG_SIG_MESSAGING_UNICAST
+#define SIGMSG_UNICAST    25			/* Messaging unicast signal */
+#else
+#define SIGMSG_UNICAST    CONFIG_SIG_MESSAGING_UNICAST
+#endif
+
 /* sigprocmask() "how" definitions. Only one of the following can be specified: */
 
 #define SIG_BLOCK       1		/* Block the given signals */

--- a/os/kernel/Kconfig
+++ b/os/kernel/Kconfig
@@ -885,6 +885,15 @@ config SIG_SIGEL_EVENT
 		This setting specifies the signal number that will be used for SIG_SIGEL_EVENT.
 		Default: 24
 
+config SIG_MESSAGING_UNICAST
+	int "MESSAGE RECV SIGNAL"
+	default 25
+	depends on MESSAGING_IPC
+	---help---
+		SIG_MESSAGING_UNICAST is a non-standard signal used to notify to message receiver.
+		This setting specifies the signal number that will be used for SIG_MESSAGING_UNICAST.
+		Default: 25
+
 endmenu # Signal Numbers
 
 menu "POSIX Message Queue Options"


### PR DESCRIPTION
Users can send and receive the data with unicast messaging IPC.
unicast messaging IPC supports like below.
1. send : sync/async mode
  - sync : sender waits after sending msg
  - async : sender just sends msg and be finished.
2. receive : block/non-block mode
  - block : receiver waits for getting msg
  - non-block : receiver sets msg callback func and continue to run.
3. reply : send reply msg from receiver to sender when sender sends sync msg
  - using same port name for sending reply