### PR TITLE
external/mbedtls: Remove unused configs and source files

### DIFF
--- a/external/include/mbedtls/config.h
+++ b/external/include/mbedtls/config.h
@@ -1533,7 +1533,7 @@
  *
  * Uncomment this to enable pthread mutexes.
  */
-#define MBEDTLS_THREADING_PTHREAD
+//#define MBEDTLS_THREADING_PTHREAD
 
 /**
  * \def MBEDTLS_VERSION_FEATURES
@@ -2631,7 +2631,7 @@
  *
  * Enable this layer to allow use of mutexes within mbed TLS
  */
-#define MBEDTLS_THREADING_C
+//#define MBEDTLS_THREADING_C
 
 /**
  * \def MBEDTLS_TIMING_C

--- a/external/mbedtls/Makefile
+++ b/external/mbedtls/Makefile
@@ -82,7 +82,7 @@ SRC_X509_CSRCS =      certs.c         pkcs11.c        x509.c                    
 SRC_TLS_CSRCS =       debug.c         net_sockets.c           ssl_cache.c            \
                       ssl_ciphersuites.c              ssl_tls.c                      \
                       ssl_cli.c       ssl_cookie.c    ssl_srv.c                      \
-                      ssl_ticket.c    easy_tls.c
+                      ssl_ticket.c    
 
 ifeq ($(CONFIG_TLS_WITH_SSS),y)
 SRC_SEE_CSRCS += see_api.c	see_internal.c  see_misc.c  sss_storage.c


### PR DESCRIPTION
- Unused mbedtls threading options are disabled.
- Unused source files are discarded from makefile.