### PR TITLE
os/arch: Fix a wrong ifdef in up_initialize().

### DIFF
--- a/os/arch/arm/src/common/up_initialize.c
+++ b/os/arch/arm/src/common/up_initialize.c
@@ -208,7 +208,7 @@ void up_initialize(void)
 	devnull_register();			/* Standard /dev/null */
 #endif
 
-#ifdef CONFIG_DEV_URANDOM
+#if defined(CONFIG_DEV_URANDOM)
 	devurandom_register();			/* /dev/urandom */
 #endif
 


### PR DESCRIPTION
- ifdef for 'devurandom_register()' doesn't work correctly, so it is changed to 'if defined'