### PR TITLE
os/driver: Fix a syntax error in SPI Kconfig.

### DIFF
--- a/os/drivers/spi/Kconfig
+++ b/os/drivers/spi/Kconfig
@@ -7,7 +7,7 @@ if SPI
 
 config SPI_USERIO
 	bool "Support the SPI User/IO mode"
-	default y>
+	default y
 
 config SPI_OWNBUS
 	bool "SPI single device"


### PR DESCRIPTION
- A typo is deleted in the SPI Kconfig.