### PR TITLE
iotbus: Modifying SPI in iotbus to support binary separation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ tags
 /tmp/
 *.tmp
 *.tmp.*
+*.log
+*.log.old

--- a/framework/src/iotbus/iotbus_spi.c
+++ b/framework/src/iotbus/iotbus_spi.c
@@ -22,20 +22,22 @@
  */
 
 #include <tinyara/config.h>
+#include <stdio.h>
 #include <stdlib.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <sys/ioctl.h>
 #include <sys/types.h>
 #include <tinyara/spi/spi.h>
 #include <iotbus/iotbus_error.h>
 #include <iotbus/iotbus_spi.h>
+#include "iotbus_internal.h"
 
 #define _IOTBUS_SPI_MAX_FREQUENCY 12000000 //12Mhz
 
 struct _iotbus_spi_s {
-	unsigned int bpw;
-	int freq; // clock speed
-	int cs;
-	iotbus_spi_mode_e mode;
-	struct spi_dev_s *sdev;
+	int fd;
+	struct spi_io_config config;
 };
 
 struct _iotbus_spi_wrapper_s {
@@ -49,23 +51,23 @@ extern "C" {
 /**
  * Public Functions
  */
-iotbus_spi_context_h iotbus_spi_open(unsigned int bus, const struct iotbus_spi_config_s *config)
+iotbus_spi_context_h iotbus_spi_open(unsigned int bus, const struct iotbus_spi_config_s *user_config)
 {
-	struct spi_dev_s *spi_dev;
 	struct _iotbus_spi_s *handle;
 	iotbus_spi_context_h dev;
 
-	if (!config) {
+	/*  validate input parameters */
+	if (!user_config) {
 		return NULL;
 	}
-	if (config->bits_per_word != 8) {
+	if (user_config->bits_per_word != 8) {
 		return NULL;
 	}
-	if (config->frequency == 0 || config->frequency > _IOTBUS_SPI_MAX_FREQUENCY) {
+	if (user_config->frequency == 0 || user_config->frequency > _IOTBUS_SPI_MAX_FREQUENCY) {
 		return NULL;
 	}
 
-	switch (config->mode) {
+	switch (user_config->mode) {
 	case IOTBUS_SPI_MODE0:
 	case IOTBUS_SPI_MODE1:
 	case IOTBUS_SPI_MODE2:
@@ -75,36 +77,43 @@ iotbus_spi_context_h iotbus_spi_open(unsigned int bus, const struct iotbus_spi_c
 		return NULL;
 	}
 
+	/*	Open driver */
+	char spi_dev[16] = { 0, };
+	snprintf(spi_dev, 16, "/dev/spi-%d", bus);
+	int fd = open(spi_dev, O_RDWR);
+	if (fd < 0) {
+		ibdbg("open %s failed: %d\n", spi_dev, errno);
+		return NULL;
+	}
+
+	struct spi_io_config config = {user_config->bits_per_word,
+								   user_config->frequency,
+								   user_config->chip_select,
+								   user_config->mode};
+	int res = ioctl(fd, SPIIOC_SET_CONFIG, (unsigned long)((uintptr_t)&config));
+	if (res < 0) {
+		ibdbg("set config fail\n");
+		close(fd);
+		return NULL;
+	}
+
+	/*  create handle */
 	handle = (struct _iotbus_spi_s *)malloc(sizeof(struct _iotbus_spi_s));
 	if (!handle) {
+		close(fd);
 		return NULL;
 	}
 
 	dev = (struct _iotbus_spi_wrapper_s *)malloc(sizeof(struct _iotbus_spi_wrapper_s));
 	if (!dev) {
+		close(fd);
 		free(handle);
 		return NULL;
 	}
 
-	spi_dev = up_spiinitialize(bus);
-	if (!spi_dev) {
-		free(handle);
-		free(dev);
-		return NULL;
-	}
+	handle->fd = fd;
+	handle->config = config;
 
-	handle->bpw = config->bits_per_word;
-	handle->freq = config->frequency;
-	handle->cs = config->chip_select;
-	handle->mode = config->mode;
-
-	SPI_LOCK(spi_dev, true);
-	SPI_SETMODE(spi_dev, handle->mode);
-	SPI_SETBITS(spi_dev, handle->bpw);
-	SPI_SETFREQUENCY(spi_dev, handle->freq);
-	SPI_LOCK(spi_dev, false);
-
-	handle->sdev = spi_dev;
 	dev->handle = handle;
 
 	return dev;
@@ -112,7 +121,6 @@ iotbus_spi_context_h iotbus_spi_open(unsigned int bus, const struct iotbus_spi_c
 
 int iotbus_spi_write(iotbus_spi_context_h hnd, uint8_t *txbuf, size_t length)
 {
-	struct spi_dev_s *dev;
 	struct _iotbus_spi_s *handle;
 
 	if (!hnd || !hnd->handle) {
@@ -124,19 +132,17 @@ int iotbus_spi_write(iotbus_spi_context_h hnd, uint8_t *txbuf, size_t length)
 	}
 
 	handle = (struct _iotbus_spi_s *)hnd->handle;
-	dev = (struct spi_dev_s *)handle->sdev;
-	SPI_LOCK(dev, true);
-	SPI_SELECT(dev, handle->cs, true);
-	SPI_SNDBLOCK(dev, txbuf, length); // return type is void
-	SPI_SELECT(dev, handle->cs, false);
-	SPI_LOCK(dev, false);
+
+	int res = write(handle->fd, txbuf, length);
+	if (res < 0) {
+		return IOTBUS_ERROR_UNKNOWN;
+	}
 
 	return IOTBUS_ERROR_NONE;
 }
 
 int iotbus_spi_recv(iotbus_spi_context_h hnd, uint8_t *rxbuf, size_t length)
 {
-	struct spi_dev_s *dev;
 	struct _iotbus_spi_s *handle;
 
 	if (!hnd || !hnd->handle) {
@@ -148,20 +154,17 @@ int iotbus_spi_recv(iotbus_spi_context_h hnd, uint8_t *rxbuf, size_t length)
 	}
 
 	handle = (struct _iotbus_spi_s *)hnd->handle;
-	dev = (struct spi_dev_s *)handle->sdev;
-	SPI_LOCK(dev, true);
-	SPI_SELECT(dev, handle->cs, true);
-	SPI_RECVBLOCK(dev, rxbuf, length); // return type is void
-	SPI_SELECT(dev, handle->cs, false);
-	SPI_LOCK(dev, false);
+
+	int res = read(handle->fd, rxbuf, length);
+	if (res < 0) {
+		return IOTBUS_ERROR_NONE;
+	}
 
 	return IOTBUS_ERROR_NONE;
 }
 
-#ifdef CONFIG_SPI_EXCHANGE
 int iotbus_spi_transfer_buf(iotbus_spi_context_h hnd, uint8_t *txbuf, uint8_t *rxbuf, size_t length)
 {
-	struct spi_dev_s *dev;
 	struct _iotbus_spi_s *handle;
 
 	if (!hnd || !hnd->handle) {
@@ -173,22 +176,23 @@ int iotbus_spi_transfer_buf(iotbus_spi_context_h hnd, uint8_t *txbuf, uint8_t *r
 	}
 
 	handle = (struct _iotbus_spi_s *)hnd->handle;
-	dev = (struct spi_dev_s *)handle->sdev;
-	SPI_LOCK(dev, true);
-	SPI_SELECT(dev, handle->cs, true);
-	SPI_EXCHANGE(dev, txbuf, rxbuf, length);
-	SPI_SELECT(dev, handle->cs, false);
-	SPI_LOCK(dev, false);
+
+	struct spi_io_msg msg = {rxbuf, txbuf, length};
+	int res = ioctl(handle->fd, SPIIOC_EXCHANGE, (unsigned long)((uintptr_t)&msg));
+	if (res < 0) {
+		return IOTBUS_ERROR_UNKNOWN;
+	}
+
 	return 0;
 }
-#endif
 
 int iotbus_spi_close(iotbus_spi_context_h hnd)
 {
 	if (!hnd || !hnd->handle) {
 		return IOTBUS_ERROR_INVALID_PARAMETER;
 	}
-
+	struct _iotbus_spi_s *handle = (struct _iotbus_spi_s *)hnd->handle;
+	close(handle->fd);
 	free(hnd->handle);
 	hnd->handle = NULL;
 	free(hnd);

--- a/os/.gitignore
+++ b/os/.gitignore
@@ -17,5 +17,3 @@
 /tinyara_NO_XIP
 /tinyara_memstats.txt
 /.appSpec
-/*.log
-/*.log.old

--- a/os/arch/arm/src/s5j/s5j_spi.h
+++ b/os/arch/arm/src/s5j/s5j_spi.h
@@ -91,6 +91,8 @@ typedef enum {
 	SPI_PORT_MAX,
 } SPI_PORT;
 
+void s5j_spi_register(int bus);
+
 #ifdef __cplusplus
 }
 #endif

--- a/os/board/artik05x/src/artik05x_boot.c
+++ b/os/board/artik05x/src/artik05x_boot.c
@@ -143,6 +143,22 @@ static void board_i2c_initialize(void)
 }
 
 /****************************************************************************
+ * Name: board_spi_initialize
+ *
+ * Description:
+ *  Expose board dependent SPIs
+ ****************************************************************************/
+static void board_spi_initialize(void)
+{
+#if defined(CONFIG_SPI) && defined(CONFIG_S5J_SPI)
+	s5j_spi_register(0);
+	s5j_spi_register(1);
+	s5j_spi_register(2);
+	s5j_spi_register(3);
+#endif
+}
+
+/****************************************************************************
  * Name: board_audio_initialize
  *
  * Description:
@@ -278,6 +294,7 @@ void board_initialize(void)
 
 	board_gpio_initialize();
 	board_i2c_initialize();
+	board_spi_initialize();
 	board_audio_initialize();
 	board_sensor_initialize();
 	board_wdt_initialize();

--- a/os/drivers/spi/Kconfig
+++ b/os/drivers/spi/Kconfig
@@ -5,6 +5,10 @@
 
 if SPI
 
+config SPI_USERIO
+	bool "Support the SPI User/IO mode"
+	default y
+
 config SPI_OWNBUS
 	bool "SPI single device"
 	default n

--- a/os/drivers/spi/Make.defs
+++ b/os/drivers/spi/Make.defs
@@ -55,6 +55,9 @@
 ifeq ($(CONFIG_SPI),y)
 
 # Include the selected SPI drivers
+ifeq ($(CONFIG_SPI_USERIO),y)
+CSRCS += spi_uio.c
+endif
 
 ifeq ($(CONFIG_SPI_BITBANG),y)
   CSRCS += spi_bitbang.c

--- a/os/drivers/spi/spi_uio.c
+++ b/os/drivers/spi/spi_uio.c
@@ -1,0 +1,217 @@
+/****************************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <tinyara/config.h>
+#include <assert.h>
+#include <errno.h>
+#include <debug.h>
+#include <tinyara/fs/fs.h>
+#include <tinyara/fs/ioctl.h>
+#include <tinyara/spi/spi.h>
+
+#include <semaphore.h>
+
+#define spidbg dbg
+#define SPI_ENTRY spidbg("-->%s\t%s:%d\n", __FUNCTION__, __FILE__, __LINE__)
+/******************************************************************************
+ * Private Variables
+ *****************************************************************************/
+static int spi_uio_open(FAR struct file *filep);
+static int spi_uio_close(FAR struct file *filep);
+static int spi_uioctrl(FAR struct file *filep, int cmd, unsigned long arg);
+static ssize_t spi_uioread(FAR struct file *filep, FAR char *buffer, size_t buflen);
+static ssize_t spi_uiowrite(FAR struct file *filep, FAR const char *buffer, size_t buflen);
+
+static const struct file_operations g_spiops = {
+	spi_uio_open,				/* open */
+	spi_uio_close,				/* close */
+	spi_uioread,				/* read */
+	spi_uiowrite,				/* write */
+	NULL,						/* seek */
+	spi_uioctrl,				/* ioctl */
+#ifndef CONFIG_DISABLE_POLL
+	NULL						/* poll */
+#endif
+};
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+
+/****************************************************************************
+ * Name: spidrvr_open
+ ****************************************************************************/
+
+static int spi_uio_open(FAR struct file *filep)
+{
+	SPI_ENTRY;
+	FAR struct inode *inode;
+	FAR struct spi_dev_s *dev;
+
+	/* Get our private data structure */
+	DEBUGASSERT(filep != NULL && filep->f_inode != NULL);
+	inode = filep->f_inode;
+
+	dev = (FAR struct spi_dev_s *)inode->i_private;
+	DEBUGASSERT(dev);
+
+	return 0;
+}
+
+/****************************************************************************
+ * Name: spidrvr_close
+ ****************************************************************************/
+static int spi_uio_close(FAR struct file *filep)
+{
+	SPI_ENTRY;
+	FAR struct inode *inode;
+	FAR struct spi_dev_s *dev;
+
+	/* Get our private data structure */
+
+	DEBUGASSERT(filep != NULL && filep->f_inode != NULL);
+	inode = filep->f_inode;
+
+	dev = (FAR struct spi_dev_s *)inode->i_private;
+	DEBUGASSERT(dev);
+
+	return 0;
+}
+
+
+/****************************************************************************
+ * Name: spi_uioread
+ *
+ * Description:
+ *   Read SPI Data. This function is automatically called when you're doing
+ *   read() API on userspace.
+ *
+ ****************************************************************************/
+static ssize_t spi_uioread(FAR struct file *filep, FAR char *buffer, size_t buflen)
+{
+	SPI_ENTRY;
+	FAR struct inode *inode = filep->f_inode;
+	FAR struct spi_dev_s *dev = inode->i_private;
+
+	SPI_LOCK(dev, true);
+	SPI_SETMODE(dev, dev->config.mode);
+	SPI_SETBITS(dev, dev->config.bpw);
+	SPI_SETFREQUENCY(dev, dev->config.freq);
+	SPI_SELECT(dev, dev->config.cs, true);
+	SPI_RECVBLOCK(dev, buffer, buflen); // return type is void
+	SPI_SELECT(dev, dev->config.cs, false);
+	SPI_LOCK(dev, false);
+
+	return 0;
+}
+
+/****************************************************************************
+ * Name: spi_uiowrite
+ *
+ * Description:
+ *   Write SPI Data. This function is automatically called when you're doing
+ *   write() API on userspace.
+ *
+ ****************************************************************************/
+static ssize_t spi_uiowrite(FAR struct file *filep, FAR const char *buffer, size_t buflen)
+{
+	SPI_ENTRY;
+	FAR struct inode *inode = filep->f_inode;
+	FAR struct spi_dev_s *dev = inode->i_private;
+
+	SPI_LOCK(dev, true);
+	SPI_SETMODE(dev, dev->config.mode);
+	SPI_SETBITS(dev, dev->config.bpw);
+	SPI_SETFREQUENCY(dev, dev->config.freq);
+	SPI_SELECT(dev, dev->config.cs, true);
+	SPI_SNDBLOCK(dev, buffer, buflen); // return type is void
+	SPI_SELECT(dev, dev->config.cs, false);
+	SPI_LOCK(dev, false);
+
+	return 0;
+}
+
+/****************************************************************************
+ * Name: spi_uioctrl
+ *
+ * Description:
+ *   Control SPI Data. This function is automatically called when you're doing
+ *   ctrl() API on userspace.
+ *
+ ****************************************************************************/
+static int spi_uioctrl(FAR struct file *filep, int cmd, unsigned long arg)
+{
+	SPI_ENTRY;
+
+	FAR struct inode *inode = filep->f_inode;
+	FAR struct spi_dev_s *dev = inode->i_private;
+
+	if (cmd == SPIIOC_SET_CONFIG) {
+		struct spi_io_config *user_config = (struct spi_io_config *)arg;
+		dev->config = *user_config;
+		spidbg("bpw:%d freq:%d cs:%d mode%d",
+			   dev->config.bpw,
+			   dev->config.freq,
+			   dev->config.cs,
+			   dev->config.mode);
+		SPI_LOCK(dev, true);
+		SPI_SETMODE(dev, dev->config.mode);
+		SPI_SETBITS(dev, dev->config.bpw);
+		SPI_SETFREQUENCY(dev, dev->config.freq);
+		SPI_LOCK(dev, false);
+	}
+#ifdef CONFIG_SPI_EXCHANGE
+	else if (cmd == SPIIOC_EXCHANGE) {
+		struct spi_io_msg *msg = (struct spi_io_msg *)arg;
+		spidbg("IO EXCHAnge %p %p %d", msg->txbuf, msg->rxbuf, msg->length);
+		SPI_LOCK(dev, true);
+		SPI_SETMODE(dev, dev->config.mode);
+		SPI_SETBITS(dev, dev->config.bpw);
+		SPI_SETFREQUENCY(dev, dev->config.freq);
+		SPI_SELECT(dev, dev->config.cs, true);
+		SPI_EXCHANGE(dev, msg->txbuf, msg->rxbuf, msg->length);
+		SPI_SELECT(dev, dev->config.cs, false);
+		SPI_LOCK(dev, false);
+	}
+#endif
+	else {
+		return -ENOTTY;
+	}
+
+	return 0;
+}
+
+/****************************************************************************
+ * Name: spi_uioregister
+ *
+ * Description:
+ *   register device.
+ *
+ ****************************************************************************/
+int spi_uioregister(FAR const char *path, FAR struct spi_dev_s *dev)
+{
+	SPI_ENTRY;
+	spidbg("Registering %s\n", path);
+	return register_driver(path, &g_spiops, 0666, dev);
+}

--- a/os/include/tinyara/fs/ioctl.h
+++ b/os/include/tinyara/fs/ioctl.h
@@ -95,6 +95,7 @@
 #define _GPIOBASE       (0x2000)	/* GPIO ioctl commands */
 #define _TMBASE         (0x2100)	/* Task Management ioctl commands */
 #define _HEAPINFOBASE   (0x2200)	/* Heapinfo ioctl commands */
+#define _SPIBASE        (0x2300)	/* SPI ioctl commands */
 #define _TESTIOCBASE (0xfe00)	/* KERNEL TEST DRV module ioctl commands */
 
 /* boardctl() commands share the same number space */
@@ -342,6 +343,11 @@
 /* (see include/tinyara/gpio.h */
 #define _GPIOIOCVALID(c)   (_IOC_TYPE(c) == _GPIOBASE)
 #define _GPIOIOC(nr)       _IOC(_GPIOBASE, nr)
+
+/* SPI driver ioctl definitions ********************************************/
+/* (see include/tinyara/spi/spi.h */
+#define _SPIIOCVALID(c)   (_IOC_TYPE(c) == _SPIBASE)
+#define _SPIIOC(nr)       _IOC(_SPIBASE, nr)
 
 /* boardctl() command definitions *******************************************/
 #define _BOARDIOCVALID(c)  (_IOC_TYPE(c) == _BOARDBASE)

--- a/os/include/tinyara/spi/spi.h
+++ b/os/include/tinyara/spi/spi.h
@@ -62,6 +62,11 @@
 #include <stdint.h>
 #include <stdbool.h>
 
+#include <tinyara/fs/ioctl.h>
+
+#define SPIIOC_SET_CONFIG          _SPIIOC(0x0001)	/* Set SPI configurations */
+#define SPIIOC_EXCHANGE            _SPIIOC(0x0002)	/* Exchange Data */
+
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
@@ -389,6 +394,22 @@ enum spi_mode_e {
 	SPIDEV_MODE3				/* CPOL=1 CHPHA=1 */
 };
 
+/*
+ * Structure for a communication between kernel and user spac
+ */
+struct spi_io_config {
+	unsigned int bpw;
+	int freq; // clock speed
+	int cs;
+	enum spi_mode_e mode;
+};
+
+struct spi_io_msg {
+	unsigned char *rxbuf;
+	unsigned char *txbuf;
+	unsigned int length;
+};
+
 /* The SPI vtable */
 
 struct spi_dev_s;
@@ -419,8 +440,11 @@ struct spi_ops_s {
  * add additional, device specific fields
  */
 
+
 struct spi_dev_s {
 	FAR const struct spi_ops_s *ops;
+	FAR struct spi_io_config config;
+	FAR void *priv;
 };
 
 /****************************************************************************
@@ -470,6 +494,8 @@ extern "C" {
  ****************************************************************************/
 
 FAR struct spi_dev_s *up_spiinitialize(int port);
+
+FAR int spi_uioregister(FAR const char *path, FAR struct spi_dev_s *dev);
 
 #undef EXTERN
 #if defined(__cplusplus)


### PR DESCRIPTION
* I reopened this commit because there is menuconfig error in spi/Kconfig
- Change the interface of spi driver in kernel to VFS
- Register SPI driver at /dev directory
- Change iotbus SPI API to operate to new SPI interface.
- Fix a bug in s5j spi driver