### PR TITLE
progmem: add prototype of up_progmem_blocksize

### DIFF
--- a/os/include/tinyara/progmem.h
+++ b/os/include/tinyara/progmem.h
@@ -108,6 +108,16 @@ bool up_progmem_isuniform(void);
 size_t up_progmem_pagesize(size_t page);
 
 /****************************************************************************
+ * Name: up_progmem_blocksize
+ *
+ * Description:
+ *   Return block size
+ *
+ ****************************************************************************/
+
+size_t up_progmem_blocksize(void);
+
+/****************************************************************************
  * Name: up_progmem_getpage
  *
  * Description:


### PR DESCRIPTION
That is used in mtd_progmem.c file but there is no
prototype so that it causes a compilation warning as shown below:

driver/mtd/mtd_progmem.c:388:22: warning: implicit declaration of function 'up_progmem_blocksize' [-Wimplicit-function-declaration]
   size_t blocksize = up_progmem_blocksize();
                      ^~~~~~~~~~~~~~~~~~~~

Because other progmem prototypes like up_progmem_pagesize
are in progmem.h, let's add this there as well.

Signed-off-by: sunghan-chang <sh924.chang@samsung.com>