### PR TITLE
binfmt/libelf : place holder to keep user space heap object pointer

### DIFF
--- a/os/binfmt/libelf/gnu-elf.ld
+++ b/os/binfmt/libelf/gnu-elf.ld
@@ -55,6 +55,12 @@ SECTIONS
   .text 0x00000000 :
     {
       _stext = . ;
+      /* Place holder to keep the heap object at the top
+       * 4 bytes is reserved at the top of the text segment,
+       * which can be used to place user heap object, which
+       * eventually used by user space memory allocator
+       */
+      LONG(0);
       *(.text)
       *(.text.*)
       *(.gnu.warning)


### PR DESCRIPTION
Userspace memory allocator is statically linked to each application
and hence it would leverage the allocator to use per app heap object
which would be initialized during binary load time.

Signed-off-by: Manohara HK <manohara.hk@samsung.com>