### PR TITLE
mm : Modify about using mm_get_heap for NULL case

### DIFF
--- a/apps/examples/testcase/le_tc/kernel/tc_umm_heap.c
+++ b/apps/examples/testcase/le_tc/kernel/tc_umm_heap.c
@@ -77,6 +77,7 @@ static void tc_umm_heap_malloc_free(void)
 			TC_ASSERT_NEQ("malloc", mem_ptr[alloc_cnt], NULL);
 		}
 		heap = mm_get_heap(mem_ptr[alloc_cnt - 1]);
+		TC_ASSERT_NEQ_CLEANUP("malloc", heap, NULL, mem_deallocate_func(mem_ptr, ALLOC_FREE_TIMES));
 		TC_ASSERT_EQ_ERROR_CLEANUP("malloc", heap->alloc_list[hash_pid].curr_alloc_size, TOTAL_ALLOC_SIZE, get_errno(), mem_deallocate_func(mem_ptr, ALLOC_FREE_TIMES));
 		mem_deallocate_func(mem_ptr, ALLOC_FREE_TIMES);
 		TC_ASSERT_EQ("malloc", heap->alloc_list[hash_pid].curr_alloc_size, ALL_FREE);
@@ -109,6 +110,7 @@ static void tc_umm_heap_calloc(void)
 			TC_ASSERT_NEQ("calloc", mem_ptr[alloc_cnt], NULL);
 		}
 		heap = mm_get_heap(mem_ptr[alloc_cnt - 1]);
+		TC_ASSERT_NEQ_CLEANUP("calloc", heap, NULL, mem_deallocate_func(mem_ptr, ALLOC_FREE_TIMES));
 		TC_ASSERT_EQ_ERROR_CLEANUP("calloc", heap->alloc_list[hash_pid].curr_alloc_size, TOTAL_ALLOC_SIZE, get_errno(), mem_deallocate_func(mem_ptr, ALLOC_FREE_TIMES));
 		mem_deallocate_func(mem_ptr, ALLOC_FREE_TIMES);
 
@@ -144,6 +146,7 @@ static void tc_umm_heap_realloc(void)
 			TC_ASSERT_NEQ("realloc", mem_ptr[alloc_cnt], NULL);
 		}
 		heap = mm_get_heap(mem_ptr[alloc_cnt - 1]);
+		TC_ASSERT_NEQ_CLEANUP("realloc", heap, NULL, mem_deallocate_func(mem_ptr, ALLOC_FREE_TIMES));
 		TC_ASSERT_EQ_ERROR_CLEANUP("realloc", heap->alloc_list[hash_pid].curr_alloc_size, TOTAL_ALLOC_SIZE, get_errno(), mem_deallocate_func(mem_ptr, ALLOC_FREE_TIMES));
 		mem_deallocate_func(mem_ptr, ALLOC_FREE_TIMES);
 
@@ -177,6 +180,7 @@ static void tc_umm_heap_memalign(void)
 			TC_ASSERT_NEQ("memalign", mem_ptr[alloc_cnt], NULL);
 		}
 		heap = mm_get_heap(mem_ptr[alloc_cnt - 1]);
+		TC_ASSERT_NEQ_CLEANUP("memalign", heap, NULL, mem_deallocate_func(mem_ptr, ALLOC_FREE_TIMES));
 		TC_ASSERT_EQ_ERROR_CLEANUP("memalign", heap->alloc_list[hash_pid].curr_alloc_size, TOTAL_ALLOC_SIZE, get_errno(), mem_deallocate_func(mem_ptr, ALLOC_FREE_TIMES));
 		mem_deallocate_func(mem_ptr, ALLOC_FREE_TIMES);
 
@@ -238,6 +242,7 @@ static void tc_umm_heap_random_malloc(void)
 			}
 		}
 		heap = mm_get_heap(mem_ptr[alloc_cnt - 1]);
+		TC_ASSERT_NEQ_CLEANUP("malloc", heap, NULL, mem_deallocate_func(mem_ptr, ALLOC_FREE_TIMES));
 		TC_ASSERT_EQ_ERROR_CLEANUP("malloc", heap->alloc_list[hash_pid].curr_alloc_size, allocated_size, get_errno(), mem_deallocate_func(mem_ptr, ALLOC_FREE_TIMES));
 		mem_deallocate_func(mem_ptr, ALLOC_FREE_TIMES);
 		TC_ASSERT_EQ("random_malloc", heap->alloc_list[hash_pid].curr_alloc_size, ALL_FREE);

--- a/apps/system/utils/kdbg_stackmonitor.c
+++ b/apps/system/utils/kdbg_stackmonitor.c
@@ -296,6 +296,9 @@ void stkmon_logging(struct tcb_s *tcb)
 #endif
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
 	heap = mm_get_heap(tcb->stack_alloc_ptr);
+	if (heap == NULL) {
+		return;
+	}
 	stkmon_arr[stkmon_chk_idx % (CONFIG_MAX_TASKS * 2)].chk_peakheap = heap->alloc_list[PIDHASH(tcb->pid)].peak_alloc_size;
 #endif
 #if (CONFIG_TASK_NAME_SIZE > 0)

--- a/os/fs/procfs/fs_procfsproc.c
+++ b/os/fs/procfs/fs_procfsproc.c
@@ -384,8 +384,17 @@ static ssize_t proc_entry_stat(FAR struct proc_file_s *procfile, FAR struct tcb_
 	curr_heap = -1;
 	peak_heap = -1;
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
+	if (tcb->pid == 0) {
+		/* Idle task normally uses heap with index 0. */
+		heap = mm_get_heap_with_index(0);
+	} else {
+		heap = mm_get_heap(tcb->stack_alloc_ptr);
+	}
+	if (heap == NULL) {
+		return -1;
+	}
+
 	hash_pid = PIDHASH(tcb->pid);
-	heap = mm_get_heap(tcb->stack_alloc_ptr);
 	if (heap->alloc_list[hash_pid].pid == tcb->pid) {
 		curr_heap = heap->alloc_list[hash_pid].curr_alloc_size;
 		peak_heap = heap->alloc_list[hash_pid].peak_alloc_size;

--- a/os/kernel/sched/sched_releasetcb.c
+++ b/os/kernel/sched/sched_releasetcb.c
@@ -85,7 +85,7 @@ static void heapinfo_dealloc_tcbinfo(void *address, pid_t pid)
 	pid_t hash_pid;
 	struct mm_heap_s *heap = mm_get_heap(address);
 	hash_pid = PIDHASH(pid);
-	if (heap->alloc_list[hash_pid].pid == pid) {
+	if (heap && heap->alloc_list[hash_pid].pid == pid) {
 		heap->alloc_list[hash_pid].pid = HEAPINFO_INIT_INFO;
 		heap->alloc_list[hash_pid].curr_alloc_size = 0;
 		heap->alloc_list[hash_pid].peak_alloc_size = 0;

--- a/os/kernel/task/task_activate.c
+++ b/os/kernel/task/task_activate.c
@@ -168,7 +168,7 @@ int task_activate(FAR struct tcb_s *tcb)
 	struct mm_heap_s *heap = mm_get_heap(tcb->stack_alloc_ptr);
 
 	hash_pid = PIDHASH(tcb->pid);
-	if (heap->alloc_list[hash_pid].pid == HEAPINFO_INIT_INFO) {
+	if (heap && heap->alloc_list[hash_pid].pid == HEAPINFO_INIT_INFO) {
 		heap->alloc_list[hash_pid].pid = tcb->pid;
 		heap->alloc_list[hash_pid].curr_alloc_size = 0;
 		heap->alloc_list[hash_pid].peak_alloc_size = 0;

--- a/os/mm/mm_heap/mm_heapinfo.c
+++ b/os/mm/mm_heap/mm_heapinfo.c
@@ -394,9 +394,11 @@ void heapinfo_update_node(FAR struct mm_allocnode_s *node, mmaddress_t caller_re
 void heapinfo_exclude_stacksize(void *stack_ptr)
 {
 	struct mm_allocnode_s *node;
-	struct mm_heap_s *heap = mm_get_heap(stack_ptr);
 	pid_t hash_pid;
-
+	struct mm_heap_s *heap = mm_get_heap(stack_ptr);
+	if (heap == NULL) {
+		return;
+	}
 	node = (struct mm_allocnode_s *)(stack_ptr - SIZEOF_MM_ALLOCNODE);
 	hash_pid = PIDHASH(node->pid);
 	heap->alloc_list[hash_pid].curr_alloc_size -= node->size;

--- a/os/mm/mm_heap/mm_sem.c
+++ b/os/mm/mm_heap/mm_sem.c
@@ -239,7 +239,10 @@ void mm_is_sem_available(void *address)
 	struct mm_heap_s *heap;
 
 	heap = mm_get_heap(address);
-
+	if (heap == NULL) {
+		msemdbg("Fail to get heap.\n");
+		return;
+	}
 	mm_takesemaphore(heap);
 	mm_givesemaphore(heap);
 }

--- a/os/mm/umm_heap/umm_sem.c
+++ b/os/mm/umm_heap/umm_sem.c
@@ -55,6 +55,7 @@
  ************************************************************************/
 
 #include <tinyara/config.h>
+#include <errno.h>
 #include <tinyara/mm/mm.h>
 
 #if !defined(CONFIG_BUILD_PROTECTED) || !defined(__KERNEL__)
@@ -99,7 +100,11 @@ int umm_trysemaphore(void *address)
 {
 	struct mm_heap_s *heap;
 	heap = mm_get_heap(address);
-	return mm_trysemaphore(heap);
+	if (heap) {
+		return mm_trysemaphore(heap);
+	}
+	set_errno(EFAULT);
+	return EFAULT;
 }
 
 /************************************************************************
@@ -122,6 +127,10 @@ void umm_givesemaphore(void *address)
 {
 	struct mm_heap_s *heap;
 	heap = mm_get_heap(address);
+	if (!heap) {
+		set_errno(EFAULT);
+		return;
+	}
 	mm_givesemaphore(heap);
 }
 


### PR DESCRIPTION
1.     fs/procfs : Modify for getting Idle task's heap information in proc_entry_stat
    
    Idle task's stack pointer is not in the heap. So that mm_get_heap with idle task's stack ptr returns NULL.
    For getting idle task's heap information, called mm_get_heap_with_index(0).

2.     mm : Add NULL checking after mm_get_heap
    
    mm_get_heap can return NULL, but there are no error checking, so it can be crashed.