### PR TITLE
Memory management for binary separation

### DIFF
--- a/build/configs/artik05x/scripts/user-space.ld
+++ b/build/configs/artik05x/scripts/user-space.ld
@@ -78,6 +78,7 @@ SECTIONS
 
     .text : {
         _stext = ABSOLUTE(.);
+        *(.usrheapptr)
         *(.text .text.*)
         *(.fixup)
         *(.gnu.warning)

--- a/os/arch/arm/src/common/up_allocateheap.c
+++ b/os/arch/arm/src/common/up_allocateheap.c
@@ -220,11 +220,11 @@ void up_addregion(void)
 
 	for (region_cnt = 1; region_cnt < CONFIG_MM_REGIONS; region_cnt++) {
 		if (heapx_is_init[regionx_heap_idx[region_cnt]] != true) {
-			mm_initialize(&g_mmheap[regionx_heap_idx[region_cnt]], regionx_start[region_cnt], regionx_size[region_cnt]);
+			mm_initialize(&USR_HEAP[regionx_heap_idx[region_cnt]], regionx_start[region_cnt], regionx_size[region_cnt]);
 			heapx_is_init[regionx_heap_idx[region_cnt]] = true;
 			continue;
 		}
-		mm_addregion(&g_mmheap[regionx_heap_idx[region_cnt]], regionx_start[region_cnt], regionx_size[region_cnt]);
+		mm_addregion(&USR_HEAP[regionx_heap_idx[region_cnt]], regionx_start[region_cnt], regionx_size[region_cnt]);
 	}
 }
 #endif

--- a/os/include/tinyara/kmalloc.h
+++ b/os/include/tinyara/kmalloc.h
@@ -104,32 +104,12 @@ extern "C" {
 #define kumm_trysemaphore(a)      umm_trysemaphore(a)
 #define kumm_givesemaphore(a)     umm_givesemaphore(a)
 
-#ifdef CONFIG_BUILD_PROTECTED
-/* In the kernel-phase of the protected build, the these macros are defined
- * in userspace.h.  These macros version call into user-space via a header
- * at the beginning of the user-space blob.
- */
-
-#define kumm_malloc(s)         umm_malloc(s)
-#define kumm_zalloc(s)         umm_zalloc(s)
-#define kumm_realloc(p, s)     umm_realloc(p, s)
-#define kumm_memalign(a, s)    umm_memalign(a, s)
-#define kumm_free(p)           umm_free(p)
-#define kumm_mallinfo()        umm_mallinfo()
-#else
-/* In the flat build (CONFIG_BUILD_FLAT) and in the kernel build
- * (CONFIG_BUILD_KERNEL), the following are declared in stdlib.h and are
- * directly callable.
- */
-
 #define kumm_malloc(s)          malloc(s)
 #define kumm_zalloc(s)          zalloc(s)
 #define kumm_realloc(p, s)      realloc(p, s)
 #define kumm_memalign(a, s)     memalign(a, s)
 #define kumm_free(p)            free(p)
 #define kumm_mallinfo()         mallinfo()
-
-#endif
 
 /* This family of allocators is used to manage kernel protected memory */
 

--- a/os/include/tinyara/mm/mm.h
+++ b/os/include/tinyara/mm/mm.h
@@ -780,9 +780,9 @@ void *zalloc_at(int heap_index, size_t size);
 #define MM_PART_USED    1
 
 struct mm_ram_partition_s {
-        uint32_t start;         /* Start address of the partition */
-        uint32_t size;          /* Size of the partition in bytes */
-        uint8_t status;         /* Current status of the partition, free / used */
+	uint32_t start;         /* Start address of the partition */
+	uint32_t size;          /* Size of the partition in bytes */
+	uint8_t status;         /* Current status of the partition, free / used */
 };
 
 /* Functions contained in mm_partition_mgr.c **************************************/

--- a/os/include/tinyara/mm/mm.h
+++ b/os/include/tinyara/mm/mm.h
@@ -398,20 +398,6 @@ extern "C" {
 #define EXTERN extern
 #endif
 
-#if !defined(CONFIG_BUILD_PROTECTED) || !defined(__KERNEL__)
-/* User heap structure:
- *
- * - Flat build:  In the FLAT build, the user heap structure is a globally
- *   accessible variable.
- * - Protected build:  The user heap structure is directly available only
- *   in user space.
- * - Kernel build: There are multiple heaps, one per process.  The heap
- *   structure is associated with the address environment and there is
- *   no global user heap structure.
- */
-extern struct mm_heap_s g_mmheap[CONFIG_MM_NHEAPS];
-#endif
-
 #ifdef CONFIG_MM_KERNEL_HEAP
 /* This is the kernel heap */
 
@@ -425,14 +411,22 @@ EXTERN struct mm_heap_s g_kmmheap;
  * space (CONFIG_ARCH_DATA_VBASE).  The size of that region is given by
  * ARCH_DATA_RESERVE_SIZE
  */
-
 #include <tinyara/addrenv.h>
 #define BASE_HEAP (&ARCH_DATA_RESERVE->ar_usrheap)
 
+#elif defined(CONFIG_BUILD_PROTECTED) && !defined(__KERNEL__)
+extern uint32_t _stext;
+#define BASE_HEAP ((struct mm_heap_s *)_stext)
+
+#elif defined(CONFIG_BUILD_PROTECTED) && defined(__KERNEL__)
+#include <tinyara/userspace.h>
+#define BASE_HEAP ((struct mm_heap_s *)(*(uint32_t *)(CONFIG_TINYARA_USERSPACE + sizeof(struct userspace_s))))
+
 #else
 /* Otherwise, the user heap data structures are in common .bss */
-
+extern struct mm_heap_s g_mmheap[CONFIG_MM_NHEAPS];
 #define BASE_HEAP &g_mmheap[0]
+
 #endif
 
 /****************************************************************************
@@ -801,6 +795,7 @@ void mm_free_ram_partition(uint32_t address);
 #undef EXTERN
 #ifdef __cplusplus
 }
+
 #endif
 
 #endif							/* __INCLUDE_MM_MM_H */

--- a/os/include/tinyara/userspace.h
+++ b/os/include/tinyara/userspace.h
@@ -99,21 +99,8 @@
  * they can be called through the userspace structure.
  */
 
-#if defined(CONFIG_BUILD_PROTECTED) && defined(__KERNEL__)
-#define umm_initialize(b, s) USERSPACE->mm_initialize(b, s)
-#define umm_addregion(b, s)  USERSPACE->mm_addregion(b, s)
-#define umm_trysemaphore(a)   USERSPACE->mm_trysemaphore(a)
-#define umm_givesemaphore(a)  USERSPACE->mm_givesemaphore(a)
-#define umm_malloc(s)        USERSPACE->mm_malloc(s)
-#define umm_zalloc(s)        USERSPACE->mm_zalloc(s)
-#define umm_realloc(p, s)    USERSPACE->mm_realloc(p, s)
-#define umm_memalign(a, s)   USERSPACE->mm_memalign(a, s)
-#define umm_free(p)          USERSPACE->mm_free(p)
-#define umm_mallinfo()       USERSPACE->mm_mallinfo()
-#endif
-
 /****************************************************************************
- * Type Definitions
+ * Public Type Definitions
  ****************************************************************************/
 /* Every user-space blob starts with a header that provides information about
  * the blob.  The form of that header is provided by struct userspace_s.  An
@@ -145,20 +132,6 @@ struct userspace_s {
 #ifndef CONFIG_DISABLE_SIGNALS
 	void (*signal_handler)(_sa_sigaction_t sighand, int signo, FAR siginfo_t *info, FAR void *ucontext);
 #endif
-
-	/* Memory manager entry points */
-
-	void (*mm_initialize)(FAR void *heap_start, size_t heap_size);
-	void (*mm_addregion)(FAR void *heap_start, size_t heap_size);
-	int (*mm_trysemaphore)(void *address);
-	void (*mm_givesemaphore)(void *address);
-
-	FAR void *(*mm_malloc)(size_t size);
-	FAR void *(*mm_realloc)(FAR void *oldmem, size_t newsize);
-	FAR void *(*mm_memalign)(size_t alignment, size_t size);
-	FAR void *(*mm_zalloc)(size_t size);
-	FAR struct mallinfo(*mm_mallinfo)(void);
-	void (*mm_free)(FAR void *mem);
 
 	/* Pre - Application Start */
 

--- a/os/kernel/init/os_start.c
+++ b/os/kernel/init/os_start.c
@@ -375,6 +375,7 @@ void os_start(void)
 
 	sem_initialize();
 
+
 #if defined(MM_KERNEL_USRHEAP_INIT) || defined(CONFIG_MM_KERNEL_HEAP) || defined(CONFIG_MM_PGALLOC)
 	/* Initialize the memory manager */
 
@@ -387,8 +388,9 @@ void os_start(void)
 		 * the user-mode memory allocator.
 		 */
 		up_allocate_heap(&heap_start, &heap_size);
+
 #if CONFIG_MM_REGIONS > 1
-		mm_initialize(&g_mmheap[regionx_heap_idx[0]], heap_start, heap_size);
+		mm_initialize(&USR_HEAP[regionx_heap_idx[0]], heap_start, heap_size);
 		heapx_is_init[regionx_heap_idx[0]] = true;
 		up_addregion();
 #else

--- a/os/mm/umm_heap/umm_addregion.c
+++ b/os/mm/umm_heap/umm_addregion.c
@@ -57,8 +57,6 @@
 #include <tinyara/config.h>
 #include <tinyara/mm/mm.h>
 
-#if !defined(CONFIG_BUILD_PROTECTED) || !defined(__KERNEL__)
-
 /************************************************************************
  * Pre-processor definition
  ************************************************************************/
@@ -100,5 +98,3 @@ void umm_addregion(FAR void *heap_start, size_t heap_size)
 {
 	mm_addregion(BASE_HEAP, heap_start, heap_size);
 }
-
-#endif							/* !CONFIG_BUILD_PROTECTED || !__KERNEL__ */

--- a/os/mm/umm_heap/umm_brkaddr.c
+++ b/os/mm/umm_heap/umm_brkaddr.c
@@ -58,8 +58,6 @@
 #include <assert.h>
 #include <tinyara/mm/mm.h>
 
-#if !defined(CONFIG_BUILD_PROTECTED) || !defined(__KERNEL__)
-
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
@@ -81,4 +79,3 @@ FAR void *umm_brkaddr(int region)
 	return mm_brkaddr(BASE_HEAP, region);
 }
 
-#endif							/* !CONFIG_BUILD_PROTECTED || !__KERNEL__ */

--- a/os/mm/umm_heap/umm_calloc.c
+++ b/os/mm/umm_heap/umm_calloc.c
@@ -59,7 +59,7 @@
 #include <debug.h>
 #include <tinyara/mm/mm.h>
 
-#if !defined(CONFIG_BUILD_PROTECTED) || !defined(__KERNEL__)
+#include "umm_heap.h"
 
 /****************************************************************************
  * Pre-processor Definitions
@@ -90,9 +90,9 @@ void *calloc_at(int heap_index, size_t n, size_t elem_size)
 	}
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
 	ARCH_GET_RET_ADDRESS
-	return mm_calloc(&g_mmheap[heap_index], n, elem_size, retaddr);
+	return mm_calloc(&USR_HEAP[heap_index], n, elem_size, retaddr);
 #else
-	return mm_calloc(&g_mmheap[heap_index], n, elem_size);
+	return mm_calloc(&USR_HEAP[heap_index], n, elem_size);
 #endif
 }
 #endif
@@ -113,9 +113,9 @@ FAR void *calloc(size_t n, size_t elem_size)
 #endif
 	for (heap_idx = 0; heap_idx < CONFIG_MM_NHEAPS; heap_idx++) {
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
-		ret = mm_calloc(&g_mmheap[heap_idx], n, elem_size, retaddr);
+		ret = mm_calloc(&USR_HEAP[heap_idx], n, elem_size, retaddr);
 #else
-		ret = mm_calloc(&g_mmheap[heap_idx], n, elem_size);
+		ret = mm_calloc(&USR_HEAP[heap_idx], n, elem_size);
 #endif
 		if (ret != NULL) {
 			return ret;
@@ -124,4 +124,3 @@ FAR void *calloc(size_t n, size_t elem_size)
 	return NULL;
 }
 
-#endif							/* !CONFIG_BUILD_PROTECTED || !__KERNEL__ */

--- a/os/mm/umm_heap/umm_extend.c
+++ b/os/mm/umm_heap/umm_extend.c
@@ -56,8 +56,7 @@
 
 #include <tinyara/config.h>
 #include <tinyara/mm/mm.h>
-
-#if !defined(CONFIG_BUILD_PROTECTED) || !defined(__KERNEL__)
+#include "umm_heap.h"
 
 /****************************************************************************
  * Pre-processor Definitions
@@ -81,8 +80,7 @@ void umm_extend(FAR void *mem, size_t size, int region)
 	int heap_idx;
 	heap_idx = mm_get_heapindex(mem);
 	if (heap_idx != INVALID_HEAP_IDX) {
-		mm_extend(&g_mmheap[heap_idx], mem, size, region);
+		mm_extend(&USR_HEAP[heap_idx], mem, size, region);
 	}
 }
 
-#endif							/* !CONFIG_BUILD_PROTECTED || !__KERNEL__ */

--- a/os/mm/umm_heap/umm_free.c
+++ b/os/mm/umm_heap/umm_free.c
@@ -57,8 +57,7 @@
 #include <tinyara/config.h>
 #include <stdlib.h>
 #include <tinyara/mm/mm.h>
-
-#if !defined(CONFIG_BUILD_PROTECTED) || !defined(__KERNEL__)
+#include "umm_heap.h"
 
 /****************************************************************************
  * Pre-processor Definitions
@@ -86,8 +85,7 @@ void free(FAR void *mem)
 	int heap_idx;
 	heap_idx = mm_get_heapindex(mem);
 	if (heap_idx != INVALID_HEAP_IDX) {
-		mm_free(&g_mmheap[heap_idx], mem);
+		mm_free(&USR_HEAP[heap_idx], mem);
 	}
 }
 
-#endif							/* !CONFIG_BUILD_PROTECTED || !__KERNEL__ */

--- a/os/mm/umm_heap/umm_initialize.c
+++ b/os/mm/umm_heap/umm_initialize.c
@@ -58,8 +58,6 @@
 #include <assert.h>
 #include <tinyara/mm/mm.h>
 
-#if !defined(CONFIG_BUILD_PROTECTED) || !defined(__KERNEL__)
-
 /************************************************************************
  * Pre-processor definition
  ************************************************************************/
@@ -73,10 +71,13 @@
  ************************************************************************/
 #if !defined(CONFIG_ARCH_ADDRENV) || !defined(CONFIG_BUILD_KERNEL)
 /* Otherwise, the user heap data structures are in common .bss */
-
 struct mm_heap_s g_mmheap[CONFIG_MM_NHEAPS];
 #endif
 
+
+#if defined(CONFIG_BUILD_PROTECTED)
+struct mm_heap_s *g_mmheap_p __attribute__((section(".usrheapptr"))) = g_mmheap;
+#endif
 /************************************************************************
  * Private Functions
  ************************************************************************/
@@ -134,5 +135,3 @@ void umm_initialize(FAR void *heap_start, size_t heap_size)
 {
 	mm_initialize(BASE_HEAP, heap_start, heap_size);
 }
-
-#endif							/* !CONFIG_BUILD_PROTECTED || !__KERNEL__ */

--- a/os/mm/umm_heap/umm_mallinfo.c
+++ b/os/mm/umm_heap/umm_mallinfo.c
@@ -58,8 +58,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <tinyara/mm/mm.h>
-
-#if !defined(CONFIG_BUILD_PROTECTED) || !defined(__KERNEL__)
+#include "umm_heap.h"
 
 /****************************************************************************
  * Pre-processor Definitions
@@ -95,7 +94,7 @@ struct mallinfo mallinfo(void)
 	memset(&info, 0, sizeof(struct mallinfo));
 #endif
 	for (heap_idx = 0; heap_idx < CONFIG_MM_NHEAPS; heap_idx++) {
-		mm_mallinfo(&g_mmheap[heap_idx], &info);
+		mm_mallinfo(&USR_HEAP[heap_idx], &info);
 	}
 	return info;
 }
@@ -106,10 +105,9 @@ int mallinfo(struct mallinfo *info)
 {
 	int heap_idx;
 	for (heap_idx = 0; heap_idx < CONFIG_MM_NHEAPS; heap_idx++) {
-		mm_mallinfo(&g_mmheap[heap_idx], info);
+		mm_mallinfo(&USR_HEAP[heap_idx], info);
 	}
 	return OK;
 }
 
 #endif							/* CONFIG_CAN_PASS_STRUCTS */
-#endif							/* !CONFIG_BUILD_PROTECTED || !__KERNEL__ */

--- a/os/mm/umm_heap/umm_malloc.c
+++ b/os/mm/umm_heap/umm_malloc.c
@@ -59,8 +59,7 @@
 #include <unistd.h>
 #include <debug.h>
 #include <tinyara/mm/mm.h>
-
-#if !defined(CONFIG_BUILD_PROTECTED) || !defined(__KERNEL__)
+#include "umm_heap.h"
 
 /****************************************************************************
  * Pre-processor Definitions
@@ -112,9 +111,9 @@ void *malloc_at(int heap_index, size_t size)
 	}
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
 	ARCH_GET_RET_ADDRESS
-	return mm_malloc(&g_mmheap[heap_index], size, retaddr);
+	return mm_malloc(&USR_HEAP[heap_index], size, retaddr);
 #else
-	return mm_malloc(&g_mmheap[heap_index], size);
+	return mm_malloc(&USR_HEAP[heap_index], size);
 #endif
 }
 #endif
@@ -170,9 +169,9 @@ FAR void *malloc(size_t size)
 #endif
 	for (heap_idx = 0; heap_idx < CONFIG_MM_NHEAPS; heap_idx++) {
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
-		ret = mm_malloc(&g_mmheap[heap_idx], size, retaddr);
+		ret = mm_malloc(&USR_HEAP[heap_idx], size, retaddr);
 #else
-		ret = mm_malloc(&g_mmheap[heap_idx], size);
+		ret = mm_malloc(&USR_HEAP[heap_idx], size);
 #endif
 		if (ret != NULL) {
 			return ret;
@@ -181,5 +180,3 @@ FAR void *malloc(size_t size)
 	return NULL;
 #endif /* CONFIG_BUILD_KERNEL */
 }
-
-#endif							/* !CONFIG_BUILD_PROTECTED || !__KERNEL__ */

--- a/os/mm/umm_heap/umm_memalign.c
+++ b/os/mm/umm_heap/umm_memalign.c
@@ -58,8 +58,7 @@
 #include <stdlib.h>
 #include <debug.h>
 #include <tinyara/mm/mm.h>
-
-#if !defined(CONFIG_BUILD_PROTECTED) || !defined(__KERNEL__)
+#include "umm_heap.h"
 
 /****************************************************************************
  * Pre-processor Definitions
@@ -94,9 +93,9 @@ void *memalign_at(int heap_index, size_t alignment, size_t size)
 	}
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
 	ARCH_GET_RET_ADDRESS
-	return mm_memalign(&g_mmheap[heap_index], alignment, size, retaddr);
+	return mm_memalign(&USR_HEAP[heap_index], alignment, size, retaddr);
 #else
-	return mm_memalign(&g_mmheap[heap_index], alignment, size);
+	return mm_memalign(&USR_HEAP[heap_index], alignment, size);
 #endif
 }
 #endif
@@ -122,9 +121,9 @@ FAR void *memalign(size_t alignment, size_t size)
 #endif
 	for (heap_idx = 0; heap_idx < CONFIG_MM_NHEAPS; heap_idx++) {
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
-		ret = mm_memalign(&g_mmheap[heap_idx], alignment, size, retaddr);
+		ret = mm_memalign(&USR_HEAP[heap_idx], alignment, size, retaddr);
 #else
-		ret = mm_memalign(&g_mmheap[heap_idx], alignment, size);
+		ret = mm_memalign(&USR_HEAP[heap_idx], alignment, size);
 #endif
 		if (ret != NULL) {
 			return ret;
@@ -133,4 +132,3 @@ FAR void *memalign(size_t alignment, size_t size)
 	return NULL;
 }
 
-#endif							/* !CONFIG_BUILD_PROTECTED || !__KERNEL__ */

--- a/os/mm/umm_heap/umm_realloc.c
+++ b/os/mm/umm_heap/umm_realloc.c
@@ -58,8 +58,7 @@
 #include <stdlib.h>
 #include <debug.h>
 #include <tinyara/mm/mm.h>
-
-#if !defined(CONFIG_BUILD_PROTECTED) || !defined(__KERNEL__)
+#include "umm_heap.h"
 
 /****************************************************************************
  * Pre-processor Definitions
@@ -94,9 +93,9 @@ void *realloc_at(int heap_index, void *oldmem, size_t size)
 	}
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
 	ARCH_GET_RET_ADDRESS
-	return mm_realloc(&g_mmheap[heap_index], oldmem, size, retaddr);
+	return mm_realloc(&USR_HEAP[heap_index], oldmem, size, retaddr);
 #else
-	return mm_realloc(&g_mmheap[heap_index], oldmem, size);
+	return mm_realloc(&USR_HEAP[heap_index], oldmem, size);
 #endif
 }
 #endif
@@ -128,9 +127,9 @@ FAR void *realloc(FAR void *oldmem, size_t size)
 		return NULL;
 	}
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
-	ret = mm_realloc(&g_mmheap[heap_idx], oldmem, size, retaddr);
+	ret = mm_realloc(&USR_HEAP[heap_idx], oldmem, size, retaddr);
 #else
-	ret = mm_realloc(&g_mmheap[heap_idx], oldmem, size);
+	ret = mm_realloc(&USR_HEAP[heap_idx], oldmem, size);
 #endif
 	if (ret != NULL) {
 		return ret;
@@ -140,15 +139,14 @@ FAR void *realloc(FAR void *oldmem, size_t size)
 	prev_heap_idx = heap_idx;
 	for (heap_idx = 0; heap_idx < CONFIG_MM_NHEAPS; heap_idx++) {
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
-		ret = mm_malloc(&g_mmheap[heap_idx], size, retaddr);
+		ret = mm_malloc(&USR_HEAP[heap_idx], size, retaddr);
 #else
-		ret = mm_malloc(&g_mmheap[heap_idx], size);
+		ret = mm_malloc(&USR_HEAP[heap_idx], size);
 #endif
 		if (ret != NULL) {
-			mm_free(&g_mmheap[prev_heap_idx], oldmem);
+			mm_free(&USR_HEAP[prev_heap_idx], oldmem);
 			return ret;
 		}
 	}
 	return NULL;
 }
-#endif							/* !CONFIG_BUILD_PROTECTED || !__KERNEL__ */

--- a/os/mm/umm_heap/umm_sem.c
+++ b/os/mm/umm_heap/umm_sem.c
@@ -57,8 +57,6 @@
 #include <tinyara/config.h>
 #include <tinyara/mm/mm.h>
 
-#if !defined(CONFIG_BUILD_PROTECTED) || !defined(__KERNEL__)
-
 /************************************************************************
  * Pre-processor definition
  ************************************************************************/
@@ -125,4 +123,3 @@ void umm_givesemaphore(void *address)
 	mm_givesemaphore(heap);
 }
 
-#endif							/* !CONFIG_BUILD_PROTECTED || !__KERNEL__ */

--- a/os/mm/umm_heap/umm_zalloc.c
+++ b/os/mm/umm_heap/umm_zalloc.c
@@ -59,8 +59,7 @@
 #include <string.h>
 #include <debug.h>
 #include <tinyara/mm/mm.h>
-
-#if !defined(CONFIG_BUILD_PROTECTED) || !defined(__KERNEL__)
+#include "umm_heap.h"
 
 /****************************************************************************
  * Pre-processor Definitions
@@ -91,9 +90,9 @@ void *zalloc_at(int heap_index, size_t size)
 	}
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
 	ARCH_GET_RET_ADDRESS
-	return mm_zalloc(&g_mmheap[heap_index], size, retaddr);
+	return mm_zalloc(&USR_HEAP[heap_index], size, retaddr);
 #else
-	return mm_zalloc(&g_mmheap[heap_index], size);
+	return mm_zalloc(&USR_HEAP[heap_index], size);
 #endif
 }
 #endif
@@ -132,9 +131,9 @@ FAR void *zalloc(size_t size)
 #endif
 	for (heap_idx = 0; heap_idx < CONFIG_MM_NHEAPS; heap_idx++) {
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
-		ret = mm_zalloc(&g_mmheap[heap_idx], size, retaddr);
+		ret = mm_zalloc(&USR_HEAP[heap_idx], size, retaddr);
 #else
-		ret = mm_zalloc(&g_mmheap[heap_idx], size);
+		ret = mm_zalloc(&USR_HEAP[heap_idx], size);
 #endif
 		if (ret != NULL) {
 			return ret;
@@ -144,4 +143,3 @@ FAR void *zalloc(size_t size)
 #endif /* CONFIG_ARCH_ADDRENV */
 }
 
-#endif							/* !CONFIG_BUILD_PROTECTED || !__KERNEL__ */


### PR DESCRIPTION
- Backport MM changes from nuttx
- Fix coding rule violations in previous commit

This is a resubmission of https://github.com/Samsung/TizenRT/pull/2746 after fixing all issues.