### PR TITLE
build/configs: Modify ld scripts for esp32

### DIFF
--- a/build/configs/esp32_DevKitC/scripts/esp32_flash.ld
+++ b/build/configs/esp32_DevKitC/scripts/esp32_flash.ld
@@ -81,6 +81,30 @@ SECTIONS
 
   /* Shared RAM */
 
+  .dram0.data :
+  {
+    /* .data initialized on power-up in ROMed configurations. */
+
+    _sdata = ABSOLUTE(.);
+    KEEP (*(.data))
+    KEEP (*(.data.*))
+    KEEP (*(.gnu.linkonce.d.*))
+    KEEP (*(.data1))
+    KEEP (*(.sdata))
+    KEEP (*(.sdata.*))
+    KEEP (*(.gnu.linkonce.s.*))
+    KEEP (*(.sdata2))
+    KEEP (*(.sdata2.*))
+    KEEP (*(.gnu.linkonce.s2.*))
+    KEEP (*(.jcr))
+    *(.dram1 .dram1.*)
+    *libesp32.a:panic.*(.rodata .rodata.*)
+    *libphy.a:(.rodata .rodata.*)
+    *libsoc.a:rtc_clk.*(.rodata .rodata.*)
+    _edata = ABSOLUTE(.);
+
+  } >dram0_0_seg
+
   .dram0.bss (NOLOAD) :
   {
     /* .bss initialized on power-up */
@@ -105,36 +129,12 @@ SECTIONS
     _ebss = ABSOLUTE(.);
 
     /* Uninitialized .bss */
-
     *(.noinit)
-  } >dram0_0_seg
 
-  .dram0.data :
-  {
-    /* .data initialized on power-up in ROMed configurations. */
-
-    _sdata = ABSOLUTE(.);
-    KEEP (*(.data))
-    KEEP (*(.data.*))
-    KEEP (*(.gnu.linkonce.d.*))
-    KEEP (*(.data1))
-    KEEP (*(.sdata))
-    KEEP (*(.sdata.*))
-    KEEP (*(.gnu.linkonce.s.*))
-    KEEP (*(.sdata2))
-    KEEP (*(.sdata2.*))
-    KEEP (*(.gnu.linkonce.s2.*))
-    KEEP (*(.jcr))
-    *(.dram1 .dram1.*)
-    *libesp32.a:panic.*(.rodata .rodata.*)
-    *libphy.a:(.rodata .rodata.*)
-    *libsoc.a:rtc_clk.*(.rodata .rodata.*)  
-    _edata = ABSOLUTE(.);
     . = ALIGN(4);
-
     /* Heap starts at the end of .data */
-
     _sheap = ABSOLUTE(.);
+
   } >dram0_0_seg
 
   .flash.rodata :

--- a/build/configs/esp32_DevKitC/scripts/esp32_iram.ld
+++ b/build/configs/esp32_DevKitC/scripts/esp32_iram.ld
@@ -91,34 +91,6 @@ SECTIONS
 
   /* Shared RAM */
 
-  .dram0.bss (NOLOAD) :
-  {
-    /* .bss initialized on power-up */
-
-    . = ALIGN (8);
-    _sbss = ABSOLUTE(.);
-    *(.dynsbss)
-    *(.sbss)
-    *(.sbss.*)
-    *(.gnu.linkonce.sb.*)
-    *(.scommon)
-    *(.sbss2)
-    *(.sbss2.*)
-    *(.gnu.linkonce.sb2.*)
-    *(.dynbss)
-    KEEP (*(.bss))
-    *(.bss.*)
-    *(.share.mem)
-    *(.gnu.linkonce.b.*)
-    *(COMMON)
-    . = ALIGN (8);
-    _ebss = ABSOLUTE(.);
-
-    /* Uninitialized .bss */
-
-    *(.noinit)
-  } >dram0_0_seg
-
   .dram0.data :
   {
     /* .data initialized on power-up in ROMed configurations. */
@@ -183,11 +155,39 @@ SECTIONS
     *(.lit4.*)
     *(.gnu.linkonce.lit4.*)
     _lit4_end = ABSOLUTE(.);
+
+  } >dram0_0_seg
+
+  .dram0.bss (NOLOAD) :
+  {
+    /* .bss initialized on power-up */
+
+    . = ALIGN (8);
+    _sbss = ABSOLUTE(.);
+    *(.dynsbss)
+    *(.sbss)
+    *(.sbss.*)
+    *(.gnu.linkonce.sb.*)
+    *(.scommon)
+    *(.sbss2)
+    *(.sbss2.*)
+    *(.gnu.linkonce.sb2.*)
+    *(.dynbss)
+    KEEP (*(.bss))
+    *(.bss.*)
+    *(.share.mem)
+    *(.gnu.linkonce.b.*)
+    *(COMMON)
+    . = ALIGN (8);
+    _ebss = ABSOLUTE(.);
+
+    /* Uninitialized .bss */
+    *(.noinit)
+
     . = ALIGN(4);
-
     /* Heap starts at the end of .data */
-
     _sheap = ABSOLUTE(.);
+
   } >dram0_0_seg
 
   .rtc.text :

--- a/build/configs/esp_wrover_kit/scripts/esp32_flash.ld
+++ b/build/configs/esp_wrover_kit/scripts/esp32_flash.ld
@@ -81,6 +81,30 @@ SECTIONS
 
   /* Shared RAM */
 
+  .dram0.data :
+  {
+    /* .data initialized on power-up in ROMed configurations. */
+
+    _sdata = ABSOLUTE(.);
+    KEEP (*(.data))
+    KEEP (*(.data.*))
+    KEEP (*(.gnu.linkonce.d.*))
+    KEEP (*(.data1))
+    KEEP (*(.sdata))
+    KEEP (*(.sdata.*))
+    KEEP (*(.gnu.linkonce.s.*))
+    KEEP (*(.sdata2))
+    KEEP (*(.sdata2.*))
+    KEEP (*(.gnu.linkonce.s2.*))
+    KEEP (*(.jcr))
+    *(.dram1 .dram1.*)
+    *libesp32.a:panic.*(.rodata .rodata.*)
+    *libphy.a:(.rodata .rodata.*)
+    *libsoc.a:rtc_clk.*(.rodata .rodata.*)
+    _edata = ABSOLUTE(.);
+
+  } >dram0_0_seg
+
   .dram0.bss (NOLOAD) :
   {
     /* .bss initialized on power-up */
@@ -105,36 +129,12 @@ SECTIONS
     _ebss = ABSOLUTE(.);
 
     /* Uninitialized .bss */
-
     *(.noinit)
-  } >dram0_0_seg
 
-  .dram0.data :
-  {
-    /* .data initialized on power-up in ROMed configurations. */
-
-    _sdata = ABSOLUTE(.);
-    KEEP (*(.data))
-    KEEP (*(.data.*))
-    KEEP (*(.gnu.linkonce.d.*))
-    KEEP (*(.data1))
-    KEEP (*(.sdata))
-    KEEP (*(.sdata.*))
-    KEEP (*(.gnu.linkonce.s.*))
-    KEEP (*(.sdata2))
-    KEEP (*(.sdata2.*))
-    KEEP (*(.gnu.linkonce.s2.*))
-    KEEP (*(.jcr))
-    *(.dram1 .dram1.*)
-    *libesp32.a:panic.*(.rodata .rodata.*)
-    *libphy.a:(.rodata .rodata.*)
-    *libsoc.a:rtc_clk.*(.rodata .rodata.*)  
-    _edata = ABSOLUTE(.);
     . = ALIGN(4);
-
     /* Heap starts at the end of .data */
-
     _sheap = ABSOLUTE(.);
+
   } >dram0_0_seg
 
   .flash.rodata :

--- a/build/configs/esp_wrover_kit/scripts/esp32_iram.ld
+++ b/build/configs/esp_wrover_kit/scripts/esp32_iram.ld
@@ -91,34 +91,6 @@ SECTIONS
 
   /* Shared RAM */
 
-  .dram0.bss (NOLOAD) :
-  {
-    /* .bss initialized on power-up */
-
-    . = ALIGN (8);
-    _sbss = ABSOLUTE(.);
-    *(.dynsbss)
-    *(.sbss)
-    *(.sbss.*)
-    *(.gnu.linkonce.sb.*)
-    *(.scommon)
-    *(.sbss2)
-    *(.sbss2.*)
-    *(.gnu.linkonce.sb2.*)
-    *(.dynbss)
-    KEEP (*(.bss))
-    *(.bss.*)
-    *(.share.mem)
-    *(.gnu.linkonce.b.*)
-    *(COMMON)
-    . = ALIGN (8);
-    _ebss = ABSOLUTE(.);
-
-    /* Uninitialized .bss */
-
-    *(.noinit)
-  } >dram0_0_seg
-
   .dram0.data :
   {
     /* .data initialized on power-up in ROMed configurations. */
@@ -183,11 +155,39 @@ SECTIONS
     *(.lit4.*)
     *(.gnu.linkonce.lit4.*)
     _lit4_end = ABSOLUTE(.);
+
+  } >dram0_0_seg
+
+  .dram0.bss (NOLOAD) :
+  {
+    /* .bss initialized on power-up */
+
+    . = ALIGN (8);
+    _sbss = ABSOLUTE(.);
+    *(.dynsbss)
+    *(.sbss)
+    *(.sbss.*)
+    *(.gnu.linkonce.sb.*)
+    *(.scommon)
+    *(.sbss2)
+    *(.sbss2.*)
+    *(.gnu.linkonce.sb2.*)
+    *(.dynbss)
+    KEEP (*(.bss))
+    *(.bss.*)
+    *(.share.mem)
+    *(.gnu.linkonce.b.*)
+    *(COMMON)
+    . = ALIGN (8);
+    _ebss = ABSOLUTE(.);
+
+    /* Uninitialized .bss */
+    *(.noinit)
+
     . = ALIGN(4);
-
     /* Heap starts at the end of .data */
-
     _sheap = ABSOLUTE(.);
+
   } >dram0_0_seg
 
   .rtc.text :


### PR DESCRIPTION
Move section .data before .bss
Otherwise, when .bss section size is large, loader can not load .data to ram. 
There's error like below:

```text
I (113) esp_image: segment 0: paddr=0x00010020 vaddr=0x3ffe1f80 size=0x024b0 (  9392) load
E (122) esp_image: Segment 0 end address 0x3ffe4430 too high (bootloader stack 0x3ffe3be0 limit 0x3ffdfbe0)
E (133) boot: Factory app partition is not bootable
E (138) boot: No bootable app partitions in the partition table
```

@sunghan-chang 
@xixidodo 
@xiarihf 
