### PR TITLE
le_tc/kernel: refine tc_umm_heap_random_malloc

### DIFF
--- a/apps/examples/testcase/le_tc/kernel/tc_umm_heap.c
+++ b/apps/examples/testcase/le_tc/kernel/tc_umm_heap.c
@@ -203,6 +203,7 @@ static void tc_umm_heap_random_malloc(void)
 {
 	struct mallinfo info;
 	int *mem_ptr[ALLOC_FREE_TIMES] = { NULL };
+	int *valid_ptr = NULL;
 	int allocated[ALLOC_FREE_TIMES] = { 0 };
 	int alloc_cnt;
 	int alloc_tc_cnt;
@@ -215,6 +216,7 @@ static void tc_umm_heap_random_malloc(void)
 
 	for (alloc_tc_cnt = 0; alloc_tc_cnt < TEST_TIMES; alloc_tc_cnt++) {
 		allocated_size = 0;
+		valid_ptr = NULL;
 		for (alloc_cnt = 0; alloc_cnt < ALLOC_FREE_TIMES; alloc_cnt++) {
 			allocated[alloc_cnt] = rand() + 1;
 #ifdef CONFIG_CAN_PASS_STRUCTS
@@ -239,9 +241,10 @@ static void tc_umm_heap_random_malloc(void)
 			   because of the chunk size */
 			if (allocated[alloc_cnt] > 0) {
 				allocated_size += MM_ALIGN_UP(allocated[alloc_cnt] + SIZEOF_MM_ALLOCNODE);
+				valid_ptr = mem_ptr[alloc_cnt];
 			}
 		}
-		heap = mm_get_heap(mem_ptr[alloc_cnt - 1]);
+		heap = mm_get_heap(valid_ptr);
 		TC_ASSERT_NEQ_CLEANUP("malloc", heap, NULL, mem_deallocate_func(mem_ptr, ALLOC_FREE_TIMES));
 		TC_ASSERT_EQ_ERROR_CLEANUP("malloc", heap->alloc_list[hash_pid].curr_alloc_size, allocated_size, get_errno(), mem_deallocate_func(mem_ptr, ALLOC_FREE_TIMES));
 		mem_deallocate_func(mem_ptr, ALLOC_FREE_TIMES);


### PR DESCRIPTION
mem_ptr[alloc_cnt-1] maybe NULL because of invalid size,
then mm_get_heap will get default g_mmheap[0], that is
incorrect logic for multi-region case
@sunghan-chang @jeongchanKim 