### PR TITLE
board/imxrt1050-evk/Kconfig: Eliminate recursive dependecy on MTD_FTL

### DIFF
--- a/os/board/imxrt1050-evk/Kconfig
+++ b/os/board/imxrt1050-evk/Kconfig
@@ -133,7 +133,6 @@ config IMXRT_AUTOMOUNT_SSSRW_MOUNTPOINT
 config IMXRT_AUTOMOUNT_ROMFS
 	bool "Automount romfs partiton"
 	default y
-	select MTD_FTL
 	depends on IMXRT_AUTOMOUNT
 	depends on FS_ROMFS
 	---help---


### PR DESCRIPTION
This patch eliminates the dependency of "MTD_FTL" option since "FS_ROMFS"
already depends on the "MTD_FTL".

Signed-off-by: Yashwanth <v.yashwanth@samsung.com>