### PR TITLE
mm_heap/mm_addfreechunk : sorting the free nodelist

### DIFF
--- a/os/mm/mm_heap/mm_addfreechunk.c
+++ b/os/mm/mm_heap/mm_addfreechunk.c
@@ -92,6 +92,12 @@ void mm_addfreechunk(FAR struct mm_heap_s *heap, FAR struct mm_freenode_s *node)
 
 	for (prev = &heap->mm_nodelist[ndx], next = heap->mm_nodelist[ndx].flink; next && next->size && next->size < node->size; prev = next, next = next->flink) ;
 
+	/* Mitigate memory fragmentation
+	 * by sorting the list in ascending order of physical address
+	 * when the size is the same.
+	 */
+	for ( ; next && next->size == node->size && next < node; prev = next, next = next->flink) ;
+
 	/* Does it go in mid next or at the end? */
 
 	prev->flink = node;


### PR DESCRIPTION
in ascending order of physical address when the size is the same.
This can prevent higher address memory from being allocated
when lower address memory is available in the free nodelist.
Therefore, memory fragmentation can be mitigated.