### PR TITLE
os/mm/umm_heap: add common logic to support esp spiram

### DIFF
--- a/os/arch/Kconfig
+++ b/os/arch/Kconfig
@@ -764,6 +764,15 @@ config RAM_REGIONx_HEAP_INDEX
 		It means that its region can be handled to the index-th heap. 
 		Index can be from 0 to (MM_NHEAPS-1).
 
+config RAM_MALLOC_PRIOR_INDEX
+	int "prior region index(0 MM_NHEAPS-1) of RAM used in malloc"
+	default 0
+	depends on MM_NHEAPS != 1
+	---help---
+		The prior region index of RAM used in malloc.
+		It means alloc memory from the index-th region with priority.
+		Index can be from 0 to (MM_NHEAPS-1).
+
 config FS_TMPFS_HEAP_INDEX
 	int "TMPFS Heap index"
 	default 1

--- a/os/include/tinyara/kmalloc.h
+++ b/os/include/tinyara/kmalloc.h
@@ -121,10 +121,15 @@ extern "C" {
  * (CONFIG_BUILD_KERNEL), the following are declared in stdlib.h and are
  * directly callable.
  */
-
+#ifdef CONFIG_KMM_FORCE_ALLOC_AT
+#define kumm_malloc(s)          malloc_at(CONFIG_KMM_FORCE_ALLOC_IDX, s)
+#define kumm_zalloc(s)          zalloc_at(CONFIG_KMM_FORCE_ALLOC_IDX, s)
+#define kumm_realloc(p, s)      realloc_at(CONFIG_KMM_FORCE_ALLOC_IDX, p, s)
+#else
 #define kumm_malloc(s)          malloc(s)
 #define kumm_zalloc(s)          zalloc(s)
 #define kumm_realloc(p, s)      realloc(p, s)
+#endif
 #define kumm_memalign(a, s)     memalign(a, s)
 #define kumm_free(p)            free(p)
 #define kumm_mallinfo()         mallinfo()
@@ -143,9 +148,15 @@ extern "C" {
 #define kmm_trysemaphore(a)      umm_trysemaphore(a)
 #define kmm_givesemaphore(a)     umm_givesemaphore(a)
 
+#ifdef CONFIG_KMM_FORCE_ALLOC_AT
+#define kmm_malloc(s)          malloc_at(CONFIG_KMM_FORCE_ALLOC_IDX, s)
+#define kmm_zalloc(s)          zalloc_at(CONFIG_KMM_FORCE_ALLOC_IDX, s)
+#define kmm_realloc(p, s)      realloc_at(CONFIG_KMM_FORCE_ALLOC_IDX, p, s)
+#else
 #define kmm_malloc(s)          malloc(s)
 #define kmm_zalloc(s)          zalloc(s)
 #define kmm_realloc(p, s)      realloc(p, s)
+#endif
 
 #define kmm_memalign(a, s)     memalign(a, s)
 #define kmm_free(p)            free(p)

--- a/os/mm/Kconfig
+++ b/os/mm/Kconfig
@@ -77,6 +77,21 @@ config MM_NHEAPS
 		split for multi-heap.
 		You can refer to "https://github.com/Samsung/TizenRT/blob/master/docs/HowToUseMultiHeap.md"
 
+config KMM_FORCE_ALLOC_AT
+	bool "Force to alloc at specific mm heap for kernel"
+	default n
+	depends on MM_NHEAPS != 1
+	---help---
+		When Enable multi heap, it's possible that need to alloc memory from
+		specific heap for kernel
+
+config KMM_FORCE_ALLOC_IDX
+	int "Heap index for kernel memory"
+	default 0
+	depends on KMM_FORCE_ALLOC_AT
+	---help---
+		Index of the heap that need to alloc for kernel forcedly
+
 config GRAN
 	bool "Enable Granule Allocator"
 	default n

--- a/os/mm/umm_heap/umm_malloc.c
+++ b/os/mm/umm_heap/umm_malloc.c
@@ -119,6 +119,42 @@ void *malloc_at(int heap_index, size_t size)
 }
 #endif
 
+#ifndef CONFIG_BUILD_KERNEL
+/************************************************************************
+ * Name: heap_malloc
+ *
+ * Description:
+ *   Traverse the user heap arrays by index, and try to alloc memory.
+ *
+ * Parameters:
+ *   size - Size (in bytes) of the memory region to be allocated.
+ *   s     - Start index
+ *   e     - End index
+ *   retaddr - caller function return address, used only for DEBUG_MM_HEAPINFO
+ * Return Value:
+ *   The address of the allocated memory (NULL on failure to allocate)
+ *
+ ************************************************************************/
+static void *heap_malloc(size_t size, int s, int e, size_t retaddr)
+{
+	int heap_idx;
+	void *ret;
+
+	for (heap_idx = s; heap_idx < e; heap_idx++) {
+#ifdef CONFIG_DEBUG_MM_HEAPINFO
+		ret = mm_malloc(&g_mmheap[heap_idx], size, retaddr);
+#else
+		ret = mm_malloc(&g_mmheap[heap_idx], size);
+#endif
+		if (ret != NULL) {
+			return ret;
+		}
+	}
+
+	return NULL;
+}
+#endif
+
 /************************************************************************
  * Name: malloc
  *
@@ -163,22 +199,30 @@ FAR void *malloc(size_t size)
 	return mem;
 #else /* CONFIG_BUILD_KERNEL */
 
-	int heap_idx;
-	void *ret;
+	int heap_idx = 0;
+	void *ret = NULL;
+
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
 	ARCH_GET_RET_ADDRESS
-#endif
-	for (heap_idx = 0; heap_idx < CONFIG_MM_NHEAPS; heap_idx++) {
-#ifdef CONFIG_DEBUG_MM_HEAPINFO
-		ret = mm_malloc(&g_mmheap[heap_idx], size, retaddr);
 #else
-		ret = mm_malloc(&g_mmheap[heap_idx], size);
+	size_t retaddr = 0;
 #endif
-		if (ret != NULL) {
-			return ret;
-		}
+
+#ifdef CONFIG_RAM_MALLOC_PRIOR_INDEX
+	heap_idx = CONFIG_RAM_MALLOC_PRIOR_INDEX;
+#endif
+
+	ret = heap_malloc(size, heap_idx, CONFIG_MM_NHEAPS, retaddr);
+	if (ret != NULL) {
+		return ret;
 	}
-	return NULL;
+
+#if (defined(CONFIG_RAM_MALLOC_PRIOR_INDEX) && CONFIG_RAM_MALLOC_PRIOR_INDEX > 0)
+	/* Try to mm_calloc to other heaps */
+	ret = heap_malloc(size, 0, CONFIG_RAM_MALLOC_PRIOR_INDEX, retaddr);
+#endif
+
+	return ret;
 #endif /* CONFIG_BUILD_KERNEL */
 }
 

--- a/os/mm/umm_heap/umm_zalloc.c
+++ b/os/mm/umm_heap/umm_zalloc.c
@@ -97,6 +97,43 @@ void *zalloc_at(int heap_index, size_t size)
 #endif
 }
 #endif
+
+#ifndef CONFIG_ARCH_ADDRENV
+/************************************************************************
+ * Name: heap_zalloc
+ *
+ * Description:
+ *   Traverse the user heap arrays by index, and try to alloc memory.
+ *
+ * Parameters:
+ *   size - Size (in bytes) of the memory region to be allocated.
+ *   s     - Start index
+ *   e     - End index
+ *   retaddr - caller function return address, used only for DEBUG_MM_HEAPINFO
+ * Return Value:
+ *   The address of the allocated memory (NULL on failure to allocate)
+ *
+ ************************************************************************/
+static void *heap_zalloc(size_t size, int s, int e, size_t retaddr)
+{
+	int heap_idx;
+	void *ret;
+
+	for (heap_idx = s; heap_idx < e; heap_idx++) {
+#ifdef CONFIG_DEBUG_MM_HEAPINFO
+		ret = mm_zalloc(&g_mmheap[heap_idx], size, retaddr);
+#else
+		ret = mm_zalloc(&g_mmheap[heap_idx], size);
+#endif
+		if (ret != NULL) {
+			return ret;
+		}
+	}
+
+	return NULL;
+}
+#endif
+
 /************************************************************************
  * Name: zalloc
  *
@@ -125,22 +162,30 @@ FAR void *zalloc(size_t size)
 
 #else /* CONFIG_ARCH_ADDRENV */
 	/* Use mm_zalloc() becuase it implements the clear */
-	int heap_idx;
-	void *ret;
+	int heap_idx = 0;
+	void *ret = NULL;
+
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
 	ARCH_GET_RET_ADDRESS
-#endif
-	for (heap_idx = 0; heap_idx < CONFIG_MM_NHEAPS; heap_idx++) {
-#ifdef CONFIG_DEBUG_MM_HEAPINFO
-		ret = mm_zalloc(&g_mmheap[heap_idx], size, retaddr);
 #else
-		ret = mm_zalloc(&g_mmheap[heap_idx], size);
+	size_t retaddr = 0;
 #endif
-		if (ret != NULL) {
-			return ret;
-		}
+
+#ifdef CONFIG_RAM_MALLOC_PRIOR_INDEX
+	heap_idx = CONFIG_RAM_MALLOC_PRIOR_INDEX;
+#endif
+
+	ret = heap_zalloc(size, heap_idx, CONFIG_MM_NHEAPS, retaddr);
+	if (ret != NULL) {
+		return ret;
 	}
-	return NULL;
+
+#if (defined(CONFIG_RAM_MALLOC_PRIOR_INDEX) && CONFIG_RAM_MALLOC_PRIOR_INDEX > 0)
+	/* Try to mm_calloc to other heaps */
+	ret = heap_zalloc(size, 0, CONFIG_RAM_MALLOC_PRIOR_INDEX, retaddr);
+#endif
+
+	return ret;
 #endif /* CONFIG_ARCH_ADDRENV */
 }
 


### PR DESCRIPTION
Allow alloc memory on spiram with common malloc/calloc/zalloc
1.apply simple strategy use CONFIG_RAM_MALLOC_PRIOR_INDEX in umm api.
start alloc from this index, default 0, while set 1 to malloc from spiram
2. in kmalloc.h, when enable spiram, use alloc_at(0) for kumm and kmm api
to alloc internal ram for them
@sunghan-chang 