### PR TITLE
imxrt : Fix kernel debug logs

### DIFF
--- a/build/configs/imxrt1050-evk/nxp_demo/defconfig
+++ b/build/configs/imxrt1050-evk/nxp_demo/defconfig
@@ -297,10 +297,6 @@ CONFIG_IMXRT_AUTOMOUNT_USERFS_DEVNAME="/dev/smart0p8"
 CONFIG_IMXRT_AUTOMOUNT_USERFS_MOUNTPOINT="/mnt"
 # CONFIG_IMXRT_AUTOMOUNT_SSSRW is not set
 # CONFIG_IMXRT_AUTOMOUNT_ROMFS is not set
-
-#
-# Board-Partition Options
-#
 # CONFIG_ARCH_USE_FLASH is not set
 
 #
@@ -491,6 +487,7 @@ CONFIG_STANDARD_SERIAL=y
 CONFIG_SERIAL_NPOLLWAITERS=2
 # CONFIG_SERIAL_IFLOWCONTROL is not set
 # CONFIG_SERIAL_OFLOWCONTROL is not set
+# CONFIG_SERIAL_TIOCSERGSTRUCT is not set
 CONFIG_ARCH_HAVE_SERIAL_TERMIOS=y
 # CONFIG_SERIAL_TERMIOS is not set
 # CONFIG_OTHER_SERIAL_CONSOLE is not set
@@ -531,6 +528,7 @@ CONFIG_LPUART1_2STOP=0
 # CONFIG_LPUART1_DMA is not set
 # CONFIG_SENSOR is not set
 # CONFIG_USBDEV is not set
+# CONFIG_USBHOST is not set
 # CONFIG_FOTA_DRIVER is not set
 
 #
@@ -694,7 +692,39 @@ CONFIG_MM_NHEAPS=1
 #
 # Debug Options
 #
-# CONFIG_DEBUG is not set
+CONFIG_DEBUG=y
+CONFIG_DEBUG_ERROR=y
+# CONFIG_DEBUG_WARN is not set
+# CONFIG_DEBUG_VERBOSE is not set
+
+#
+# Subsystem Debug Options
+#
+# CONFIG_DEBUG_AUDIO is not set
+# CONFIG_DEBUG_BINFMT is not set
+# CONFIG_DEBUG_LIB is not set
+# CONFIG_DEBUG_FS is not set
+# CONFIG_DEBUG_MM is not set
+# CONFIG_DEBUG_SCHED is not set
+# CONFIG_DEBUG_TASH is not set
+
+#
+# OS Function Debug Options
+#
+# CONFIG_DEBUG_DMA is not set
+# CONFIG_ARCH_HAVE_HEAPCHECK is not set
+# CONFIG_DEBUG_MM_HEAPINFO is not set
+# CONFIG_DEBUG_IRQ is not set
+
+#
+# Driver Debug Options
+#
+# CONFIG_DEBUG_I2S is not set
+
+#
+# System Debug Options
+#
+# CONFIG_DEBUG_SYSTEM is not set
 
 #
 # Stack Debug Options
@@ -712,6 +742,11 @@ CONFIG_DEBUG_SYMBOLS=y
 # Logger Module
 #
 # CONFIG_LOGM is not set
+
+#
+# System Call
+#
+# CONFIG_LIB_SYSCALL is not set
 
 #
 # Built-in Libraries
@@ -744,7 +779,14 @@ CONFIG_ARCH_LOWPUTC=y
 # CONFIG_LIBC_LOCALTIME is not set
 # CONFIG_TIME_EXTENDED is not set
 CONFIG_LIB_SENDFILE_BUFSIZE=512
+# CONFIG_LIBC_ARCH_ELF is not set
 # CONFIG_ARCH_OPTIMIZED_FUNCTIONS is not set
+# CONFIG_LIB_ENVPATH is not set
+
+#
+# Program Execution Options
+#
+# CONFIG_LIBC_EXECFUNCS is not set
 
 #
 # Non-standard Library Support
@@ -773,6 +815,15 @@ CONFIG_LIB_SENDFILE_BUFSIZE=512
 # CONFIG_LIBTUV is not set
 # CONFIG_STRESS_TOOL is not set
 # CONFIG_VOICE_SOFTWARE_EPD is not set
+
+#
+# Binary Loader
+#
+# CONFIG_BINFMT_DISABLE is not set
+# CONFIG_BINFMT_LOADABLE is not set
+# CONFIG_ELF is not set
+# CONFIG_BUILTIN is not set
+# CONFIG_SYMTAB_ORDEREDBYNAME is not set
 
 #
 # Application Configuration

--- a/os/arch/arm/src/imxrt/imxrt_lowputc.c
+++ b/os/arch/arm/src/imxrt/imxrt_lowputc.c
@@ -514,10 +514,10 @@ int imxrt_lpuart_configure(uint32_t base, FAR const struct uart_config_s *config
  *
  ************************************************************************************/
 
-#if defined(HAVE_LPUART_DEVICE) && defined(CONFIG_DEBUG_FEATURES)
+#if defined(HAVE_LPUART_DEVICE) && defined(CONFIG_DEBUG)
 void imxrt_lowputc(int ch)
 {
-	while ((getreg32(IMXRT_CONSOLE_BASE + IMXRT_LPUART_STAT_OFFSET) & LPUART_STAT_TDRE) == 0) {
+	while ((getreg32(IMXRT_CONSOLE_BASE + IMXRT_LPUART_STAT_OFFSET) & LPUART_STAT_TDRE(1U)) == 0) {
 	}
 
 	/* If the character to output is a newline, then pre-pend a carriage return */
@@ -531,7 +531,7 @@ void imxrt_lowputc(int ch)
 		 * the TX Buffer FIFO is empty.
 		 */
 
-		while ((getreg32(IMXRT_CONSOLE_BASE + IMXRT_LPUART_STAT_OFFSET) & LPUART_STAT_TDRE) == 0) {
+		while ((getreg32(IMXRT_CONSOLE_BASE + IMXRT_LPUART_STAT_OFFSET) & LPUART_STAT_TDRE(1U)) == 0) {
 		}
 	}
 
@@ -543,7 +543,7 @@ void imxrt_lowputc(int ch)
 	 * the TX Buffer FIFO is empty.
 	 */
 
-	while ((getreg32(IMXRT_CONSOLE_BASE + IMXRT_LPUART_STAT_OFFSET) & LPUART_STAT_TDRE) == 0) {
+	while ((getreg32(IMXRT_CONSOLE_BASE + IMXRT_LPUART_STAT_OFFSET) & LPUART_STAT_TDRE(1U)) == 0) {
 	}
 }
 #endif

--- a/os/arch/arm/src/imxrt/imxrt_lowputc.h
+++ b/os/arch/arm/src/imxrt/imxrt_lowputc.h
@@ -68,6 +68,7 @@
 #include "chip.h"
 #include "imxrt_config.h"
 
+
 /****************************************************************************
  * Public Types
  ****************************************************************************/
@@ -122,7 +123,7 @@ int imxrt_lpuart_configure(uint32_t base, FAR const struct uart_config_s *config
  *
  ************************************************************************************/
 
-#if defined(HAVE_LPUART_DEVICE) && defined(CONFIG_DEBUG_FEATURES)
+#if defined(HAVE_LPUART_DEVICE) && defined(CONFIG_DEBUG)
 void imxrt_lowputc(int ch);
 #else
 #define imxrt_lowputc(ch)

--- a/os/arch/arm/src/imxrt/imxrt_serial.c
+++ b/os/arch/arm/src/imxrt/imxrt_serial.c
@@ -105,34 +105,42 @@
 #define CONSOLE_DEV         g_uart1port	/* LPUART1 is console */
 #define TTYS0_DEV           g_uart1port	/* LPUART1 is ttyS0 */
 #define UART1_ASSIGNED      1
+#define HAVE_SERIAL_CONSOLE 1
 #elif defined(CONFIG_LPUART2_SERIAL_CONSOLE)
 #define CONSOLE_DEV         g_uart2port	/* LPUART2 is console */
 #define TTYS0_DEV           g_uart2port	/* LPUART2 is ttyS0 */
 #define UART2_ASSIGNED      1
+#define HAVE_SERIAL_CONSOLE 1
 #elif defined(CONFIG_LPUART3_SERIAL_CONSOLE)
 #define CONSOLE_DEV         g_uart3port	/* LPUART3 is console */
 #define TTYS0_DEV           g_uart3port	/* LPUART3 is ttyS0 */
 #define UART3_ASSIGNED      1
+#define HAVE_SERIAL_CONSOLE 1
 #elif defined(CONFIG_LPUART4_SERIAL_CONSOLE)
 #define CONSOLE_DEV         g_uart4port	/* LPUART4 is console */
 #define TTYS0_DEV           g_uart4port	/* LPUART4 is ttyS0 */
 #define UART4_ASSIGNED      1
+#define HAVE_SERIAL_CONSOLE 1
 #elif defined(CONFIG_LPUART5_SERIAL_CONSOLE)
 #define CONSOLE_DEV         g_uart5port	/* LPUART5 is console */
 #define TTYS0_DEV           g_uart5port /* LPUART5 is ttyS0 */
 #define UART5_ASSIGNED      1
+#define HAVE_SERIAL_CONSOLE 1
 #elif defined(CONFIG_LPUART6_SERIAL_CONSOLE)
 #define CONSOLE_DEV         g_uart6port	/* LPUART6 is console */
 #define TTYS0_DEV           g_uart6port /* LPUART6 is ttyS0 */
 #define UART6_ASSIGNED      1
+#define HAVE_SERIAL_CONSOLE 1
 #elif defined(CONFIG_LPUART7_SERIAL_CONSOLE)
 #define CONSOLE_DEV         g_uart7port	/* LPUART7 is console */
 #define TTYS0_DEV           g_uart7port /* LPUART7 is ttyS0 */
 #define UART7_ASSIGNED      1
+#define HAVE_SERIAL_CONSOLE 1
 #elif defined(CONFIG_LPUART8_SERIAL_CONSOLE)
 #define CONSOLE_DEV         g_uart8port	/* LPUART8 is console */
 #define TTYS0_DEV           g_uart8port /* LPUART8 is ttyS0 */
 #define UART8_ASSIGNED      1
+#define HAVE_SERIAL_CONSOLE 1
 #else
 #undef CONSOLE_DEV				/* No console */
 #if defined(CONFIG_IMXRT_LPUART1)
@@ -1520,12 +1528,11 @@ int up_putc(int ch)
 
 	if (ch == '\n') {
 		/* Add CR */
-
-		up_lowputc('\r');
+		imxrt_lowputc('\r');
 	}
 
-	up_lowputc(ch);
-	imxrt_restoreuartint(priv, intset);
+	imxrt_lowputc(ch);
+	imxrt_restoreuartint(priv, ie);
 #endif
 
 	return ch;

--- a/os/include/debug.h
+++ b/os/include/debug.h
@@ -153,8 +153,17 @@ Once LOGM is approved, each module should have its own index
  * @details @b #include <debug.h>
  * @since TizenRT v1.0
  */
+#ifdef CONFIG_ARCH_CHIP_IMXRT
+/* TODO: This is a temporary fix to redirect dbg messages to lldbg.
+         After IMXRT dbg implementation is fixed, this needs to be removed.
+*/
+#define dbg(format, ...) \
+	lldbg(format, ##__VA_ARGS__)
+#else
 #define dbg(format, ...) \
 	syslog(LOG_ERR, EXTRA_FMT format EXTRA_ARG, ##__VA_ARGS__)
+#endif
+
 #define dbg_noarg(format, ...) \
 	syslog(LOG_ERR, format, ##__VA_ARGS__)
 
@@ -190,8 +199,16 @@ Once LOGM is approved, each module should have its own index
  * @details @b #include <debug.h>
  * @since TizenRT v1.0
  */
+#ifdef CONFIG_ARCH_CHIP_IMXRT
+/* TODO: This is a temporary fix to redirect dbg messages to lldbg.
+         After IMXRT dbg implementation is fixed, this needs to be removed.
+*/
+#define wdbg(format, ...) \
+	llwdbg(format, ##__VA_ARGS__)
+#else
 #define wdbg(format, ...) \
 	syslog(LOG_WARNING, EXTRA_FMT format EXTRA_ARG, ##__VA_ARGS__)
+#endif
 
 #ifdef CONFIG_ARCH_LOWPUTC
 /**
@@ -225,8 +242,16 @@ Once LOGM is approved, each module should have its own index
  * @details @b #include <debug.h>
  * @since TizenRT v1.0
  */
+#ifdef CONFIG_ARCH_CHIP_IMXRT
+/* TODO: This is a temporary fix to redirect dbg messages to lldbg.
+         After IMXRT dbg implementation is fixed, this needs to be removed.
+*/
+#define vdbg(format, ...) \
+	llvdbg(format, ##__VA_ARGS__)
+#else
 #define vdbg(format, ...) \
 	syslog(LOG_INFO, EXTRA_FMT format EXTRA_ARG, ##__VA_ARGS__)
+#endif
 
 #ifdef CONFIG_ARCH_LOWPUTC
 /**


### PR DESCRIPTION
Kernel debug logs are not coming since some implementation for lldbg and dbg is missing. 
In this PR, I have done following:
- Fix implementation of lldbg
- Redirect dbg to lldbg (This is temporary and will be reverted when dbg implementation in imxrt is fixed)
- Enabled CONFIG_DEBUG and CONFIG_DEBUG_ERROR