### PR TITLE
os/board: Update the makefile of artik05x

### DIFF
--- a/os/board/artik05x/src/Makefile
+++ b/os/board/artik05x/src/Makefile
@@ -85,6 +85,7 @@ CSRCS += artik05x_wlan.c
 endif
 
 ifeq ($(CONFIG_FLASH_PARTITION),y)
+DEPPATH += --dep-path $(TOPDIR)/board/common
 VPATH += :$(TOPDIR)/board/common
 CSRCS += partitions.c
 endif


### PR DESCRIPTION
- A DEPPATH is added to fix a build error completely caused by partitions.o