### PR TITLE
partition : Modify about the name in mtd

### DIFF
--- a/os/board/common/partitions.c
+++ b/os/board/common/partitions.c
@@ -38,6 +38,8 @@ void configure_partitions(void)
 	const char *types = CONFIG_FLASH_PART_TYPE;
 #if defined(CONFIG_MTD_PARTITION_NAMES)
 	const char *names = CONFIG_FLASH_PART_NAME;
+	char part_name[MTD_PARTNAME_LEN + 1];
+	int index = 0;
 #endif
 	FAR struct mtd_dev_s *mtd;
 	FAR struct mtd_geometry_s geo;
@@ -121,17 +123,32 @@ void configure_partitions(void)
 		}
 
 #if defined(CONFIG_MTD_PARTITION_NAMES)
+
 		if (*names) {
-			mtd_setpartitionname(mtd_part, names);
+			while (*names) {
+				if (*names == ',') {
+					part_name[index] = '\0';
+					index = 0;
+					names++;
+					break;
+				}
+				if (index < MTD_PARTNAME_LEN) {
+					part_name[index++] = *(names++);
+				} else {
+					part_name[index] = '\0';
+					index = 0;
+					lldbg("ERROR: Partition name is so long. Please make it smaller than %d\n", MTD_PARTNAME_LEN);
+					while (*names) {
+						if (*(names++) == ',') {
+							break;
+						}
+					}
+					break;
+				}
+			}
+			mtd_setpartitionname(mtd_part, part_name);
 		}
 
-		while (*names) {
-			if (*names == ',') {
-				names++;
-				break;
-			}
-			names++;
-		}
 #endif
 
 		while (*parts) {

--- a/os/fs/driver/mtd/mtd_partition.c
+++ b/os/fs/driver/mtd/mtd_partition.c
@@ -78,6 +78,7 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
+#define PART_NAME_MAX           15
 /****************************************************************************
  * Private Types
  ****************************************************************************/
@@ -107,7 +108,7 @@ struct mtd_partition_s {
 	uint16_t tagnumber;			/* Number of tag to classify each MTD driver */
 	struct mtd_partition_s *pnext;	/* Pointer to next partition struct */
 #ifdef CONFIG_MTD_PARTITION_NAMES
-	char name[11];                /* Name of the partition */
+	char name[PART_NAME_MAX + 1];   /* Name of the partition */
 #endif
 };
 
@@ -533,7 +534,7 @@ static ssize_t part_procfs_read(FAR struct file *filep, FAR char *buffer, size_t
 	/* Output a header before the first entry */
 	if (filep->f_pos == 0) {
 #ifdef CONFIG_MTD_PARTITION_NAMES
-		total = snprintf(buffer, buflen, "Name        Start    Size");
+		total = snprintf(buffer, buflen, "%-*s  Start    Size   MTD\n", PART_NAME_MAX, "Name");
 #else
 		total = snprintf(buffer, buflen, "  Start    Size");
 #endif

--- a/os/fs/driver/mtd/mtd_partition.c
+++ b/os/fs/driver/mtd/mtd_partition.c
@@ -78,7 +78,6 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-#define PART_NAME_MAX           15
 /****************************************************************************
  * Private Types
  ****************************************************************************/
@@ -108,7 +107,7 @@ struct mtd_partition_s {
 	uint16_t tagnumber;			/* Number of tag to classify each MTD driver */
 	struct mtd_partition_s *pnext;	/* Pointer to next partition struct */
 #ifdef CONFIG_MTD_PARTITION_NAMES
-	char name[PART_NAME_MAX + 1];   /* Name of the partition */
+	char name[MTD_PARTNAME_LEN + 1];   /* Name of the partition */
 #endif
 };
 
@@ -119,10 +118,6 @@ struct part_procfs_file_s {
 	struct procfs_file_s base;	/* Base open file structure */
 	struct mtd_partition_s *nextpart;
 };
-#endif
-
-#ifdef CONFIG_MTD_PARTITION_NAMES
-#define MTD_PARTNAME_LEN 11
 #endif
 
 /****************************************************************************
@@ -534,7 +529,7 @@ static ssize_t part_procfs_read(FAR struct file *filep, FAR char *buffer, size_t
 	/* Output a header before the first entry */
 	if (filep->f_pos == 0) {
 #ifdef CONFIG_MTD_PARTITION_NAMES
-		total = snprintf(buffer, buflen, "%-*s  Start    Size   MTD\n", PART_NAME_MAX, "Name");
+		total = snprintf(buffer, buflen, "%-*s  Start    Size   MTD\n", MTD_PARTNAME_LEN, "Name");
 #else
 		total = snprintf(buffer, buflen, "  Start    Size");
 #endif

--- a/os/include/tinyara/fs/mtd.h
+++ b/os/include/tinyara/fs/mtd.h
@@ -68,6 +68,9 @@
  * Pre-Processor Definitions
  ****************************************************************************/
 
+#ifdef CONFIG_MTD_PARTITION_NAMES
+#define MTD_PARTNAME_LEN       15
+#endif
 /* Macros to hide implementation */
 
 #define MTD_ERASE(d, s, n)     ((d)->erase  ? (d)->erase(d, s, n)     : (-ENOSYS))


### PR DESCRIPTION
drivers/mtd/mtd_partition.c: Copy the partition name to internal buffer so that the caller can free the name argument

drivers/mtd/mtd_partition.c: Remove the hard code partition name length

os/board/common : Fix a partition name parsing logic in 'configure_partitions'