### PR TITLE
libelf: Support for binary loading from MTD part 

### DIFF
--- a/os/binfmt/Makefile
+++ b/os/binfmt/Makefile
@@ -65,6 +65,7 @@ BINFMT_ASRCS  =
 BINFMT_CSRCS  = binfmt_globals.c binfmt_initialize.c binfmt_register.c binfmt_unregister.c
 BINFMT_CSRCS += binfmt_loadmodule.c binfmt_unloadmodule.c binfmt_execmodule.c
 BINFMT_CSRCS += binfmt_exec.c binfmt_copyargv.c binfmt_dumpmodule.c
+BINFMT_CSRCS += binfmt_loadbinary.c
 
 ifeq ($(CONFIG_BINFMT_LOADABLE),y)
 BINFMT_CSRCS += binfmt_exit.c

--- a/os/binfmt/binfmt_loadbinary.c
+++ b/os/binfmt/binfmt_loadbinary.c
@@ -1,0 +1,157 @@
+/****************************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <tinyara/config.h>
+
+#include <string.h>
+#include <debug.h>
+#include <errno.h>
+
+#include <tinyara/kmalloc.h>
+#include <tinyara/sched.h>
+#include <tinyara/binfmt/binfmt.h>
+
+#include "binfmt.h"
+
+#ifndef CONFIG_BINFMT_DISABLE
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: load_binary
+ *
+ * Description:
+ *   This is a convenience function that wraps load_module and exec_module into
+ *   one call.  If CONFIG_BINFMT_LOADABLE is defined, this function will
+ *   schedule to unload the module when task exits.
+ *
+ * Input Parameters:
+ *   filename - The path to the program to be executed. If
+ *              CONFIG_LIB_ENVPATH is defined in the configuration, then
+ *              this may be a relative path from the current working
+ *              directory. Otherwise, path must be the absolute path to the
+ *              program.
+ *
+ *   binsize  - The size of ELF binary to be loaded, if this value is less than
+ *              will return with invalid parameter.
+ *
+ *   offset   - The offset from which ELF binary has to be read in MTD partition.
+ *
+ * Returned Value:
+ *   This is an end-user function, so it follows the normal convention:
+ *   It returns the PID of the exec'ed module.  On failure, it returns
+ *   -1 (ERROR) and sets errno appropriately.
+ *
+ ****************************************************************************/
+int load_binary(FAR const char *filename, size_t binsize, size_t offset)
+{
+	FAR struct binary_s *bin;
+	int pid;
+	int errcode;
+	int ret;
+
+	/* Sanity check */
+	if (binsize <= 0) {
+		berr("ERROR: Invalid file length!\n");
+		errcode = EINVAL;
+		goto errout;
+	}
+
+	/* Allocate the load information */
+
+	bin = (FAR struct binary_s *)kmm_zalloc(sizeof(struct binary_s));
+	if (!bin) {
+		berr("ERROR: Failed to allocate binary_s\n");
+		errcode = ENOMEM;
+		goto errout;
+	}
+
+	/* Initialize the binary structure */
+
+	bin->filename = filename;
+	bin->exports = NULL;
+	bin->nexports = 0;
+	bin->filelen = binsize;
+	bin->offset = offset;
+
+	/* Load the module into memory */
+
+	ret = load_module(bin);
+	if (ret < 0) {
+		errcode = -ret;
+		berr("ERROR: Failed to load program '%s': %d\n", filename, errcode);
+		goto errout_with_bin;
+	}
+
+	/* Disable pre-emption so that the executed module does
+	 * not return until we get a chance to connect the on_exit
+	 * handler.
+	 */
+
+	sched_lock();
+
+	/* Then start the module */
+
+	pid = exec_module(bin);
+	if (pid < 0) {
+		errcode = -pid;
+		berr("ERROR: Failed to execute program '%s': %d\n", filename, errcode);
+		goto errout_with_lock;
+	}
+
+#ifdef CONFIG_BINFMT_LOADABLE
+	/* Set up to unload the module (and free the binary_s structure)
+	 * when the task exists.
+	 */
+
+	ret = group_exitinfo(pid, bin);
+	if (ret < 0) {
+		berr("ERROR: Failed to schedule unload '%s': %d\n", filename, ret);
+	}
+#else
+	/* Free the binary_s structure here */
+
+	binfmt_freeargv(bin);
+	kmm_free(bin);
+
+	/* TODO: How does the module get unloaded in this case? */
+#endif
+
+	binfo("%s loaded @ 0x%08x and running with pid = %d\n", bin->filename, bin->alloc[0], pid);
+
+	sched_unlock();
+	return pid;
+
+errout_with_lock:
+	sched_unlock();
+	(void)unload_module(bin);
+errout_with_bin:
+	kmm_free(bin);
+errout:
+	set_errno(errcode);
+	return ERROR;
+
+}
+
+#endif							/* !CONFIG_BINFMT_DISABLE */

--- a/os/binfmt/elf.c
+++ b/os/binfmt/elf.c
@@ -236,7 +236,14 @@ static int elf_loadbinary(FAR struct binary_s *binp)
 
 	binfo("Loading file: %s\n", binp->filename);
 
+	/* Clear the load info structure */
+
+	memset(&loadinfo, 0, sizeof(struct elf_loadinfo_s));
+
 	/* Initialize the ELF library to load the program binary. */
+	loadinfo.offset = binp->offset;
+	loadinfo.filelen = binp->filelen;
+
 
 	ret = elf_init(binp->filename, &loadinfo);
 	elf_dumploadinfo(&loadinfo);

--- a/os/binfmt/libelf/libelf_init.c
+++ b/os/binfmt/libelf/libelf_init.c
@@ -161,16 +161,15 @@ int elf_init(FAR const char *filename, FAR struct elf_loadinfo_s *loadinfo)
 
 	binfo("filename: %s loadinfo: %p\n", filename, loadinfo);
 
-	/* Clear the load info structure */
+	/* Read size in case of FS, size will be passed in load_binary api otherwise */
+	if (loadinfo->filelen == 0) {
+		/* Get the length of the file. */
 
-	memset(loadinfo, 0, sizeof(struct elf_loadinfo_s));
-
-	/* Get the length of the file. */
-
-	ret = elf_filelen(loadinfo, filename);
-	if (ret < 0) {
-		berr("elf_filelen failed: %d\n", ret);
-		return ret;
+		ret = elf_filelen(loadinfo, filename);
+		if (ret < 0) {
+			berr("elf_filelen failed: %d\n", ret);
+			return ret;
+		}
 	}
 
 	/* Open the binary file for reading (only) */

--- a/os/binfmt/libelf/libelf_read.c
+++ b/os/binfmt/libelf/libelf_read.c
@@ -129,6 +129,9 @@ int elf_read(FAR struct elf_loadinfo_s *loadinfo, FAR uint8_t *buffer, size_t re
 	ssize_t nbytes;				/* Number of bytes read */
 	off_t rpos;					/* Position returned by lseek */
 
+	/* Advance offset by binary header size, loadinfo->offset will be 0 in normal exec call*/
+	offset += loadinfo->offset;
+
 	binfo("Read %ld bytes from offset %ld\n", (long)readsize, (long)offset);
 
 	/* Loop until all of the requested data has been read. */

--- a/os/include/tinyara/binfmt/binfmt.h
+++ b/os/include/tinyara/binfmt/binfmt.h
@@ -137,6 +137,8 @@ struct binary_s {
 
 	uint8_t priority;			/* Task execution priority */
 	size_t stacksize;			/* Size of the stack in bytes (unallocated) */
+	size_t filelen;                 /* Size of binary size, used only when underlying is MTD */
+	size_t offset;                  /* Offset of binary from partition start*/
 
 	/* Unload module callback */
 
@@ -348,6 +350,33 @@ int exec(FAR const char *filename, FAR char *const *argv, FAR const struct symta
 #ifdef CONFIG_BINFMT_LOADABLE
 int binfmt_exit(FAR struct binary_s *bin);
 #endif
+/****************************************************************************
+ * Name: load_binary
+ *
+ * Description:
+ *   This is a convenience function that wraps load_module and exec_module into
+ *   one call.  If CONFIG_BINFMT_LOADABLE is defined, this function will
+ *   schedule to unload the module when task exits.
+ *
+ * Input Parameters:
+ *   filename - The path to the program to be executed. If
+ *              CONFIG_LIB_ENVPATH is defined in the configuration, then
+ *              this may be a relative path from the current working
+ *              directory. Otherwise, path must be the absolute path to the
+ *              program.
+ *
+ *   binsize  - The size of ELF binary to be loaded, if this value is less than
+ *              will return with invalid parameter.
+ *
+ *   offset   - The offset from which ELF binary has to be read in MTD partition.
+ *
+ * Returned Value:
+ *   This is an end-user function, so it follows the normal convention:
+ *   It returns the PID of the exec'ed module.  On failure, it returns
+ *   -1 (ERROR) and sets errno appropriately.
+ *
+ ****************************************************************************/
+int load_binary(FAR const char *filename, size_t binsize, size_t offset);
 
 #undef EXTERN
 #if defined(__cplusplus)

--- a/os/include/tinyara/binfmt/elf.h
+++ b/os/include/tinyara/binfmt/elf.h
@@ -158,6 +158,7 @@ struct elf_loadinfo_s {
 	uint16_t strtabidx;			/* String table section index */
 	uint16_t buflen;			/* size of iobuffer[] */
 	int filfd;					/* Descriptor for the file being loaded */
+	uint16_t offset;             /* elf offset when binary header is included */
 };
 
 /****************************************************************************


### PR DESCRIPTION
elf size will be read from header instead of stats
elf offset will be shifted by the size of binary header
config name will be corrected to binary manager config later.