### PR TITLE
Fix build error due to MPU init

### DIFF
--- a/os/arch/arm/src/imxrt/Make.defs
+++ b/os/arch/arm/src/imxrt/Make.defs
@@ -134,11 +134,11 @@ CHIP_CSRCS += imxrt_gpioirq.c
 endif
 
 ifeq ($(CONFIG_BUILD_PROTECTED),y)
-CHIP_CSRCS += imxrt_userspace.c
-endif
-
 ifeq ($(CONFIG_ARMV7M_MPU),y)
 CHIP_CSRCS += imxrt_mpuinit.c
+endif
+
+CHIP_CSRCS += imxrt_userspace.c
 endif
 
 ifeq ($(CONFIG_IMXRT_EDMA),y)

--- a/os/arch/arm/src/imxrt/imxrt_start.c
+++ b/os/arch/arm/src/imxrt/imxrt_start.c
@@ -374,7 +374,6 @@ void __start(void)
 	 */
 
 	imxrt_userspace();
-#endif
 
 #ifdef  CONFIG_ARMV7M_MPU
 	/* Configure the MPU to permit user-space access to its FLASH and RAM (for
@@ -383,6 +382,7 @@ void __start(void)
 	 */
 
 	imxrt_mpu_initialize();
+#endif
 #endif
 
 	/* Enable I- and D-Caches */


### PR DESCRIPTION
Fix build error due to MPU init in flat build.
Include mpu init under protected build config.
