### PR TITLE
Fix issues with MPU settings

### DIFF
--- a/os/arch/arm/include/armv7-m/irq_lazyfpu.h
+++ b/os/arch/arm/include/armv7-m/irq_lazyfpu.h
@@ -159,34 +159,9 @@
 #define SW_FPU_REGS       (0)
 #endif
 
-#if defined(CONFIG_ARMV7M_MPU)
-#define REG_USR_CFG1       (SW_INT_REGS + SW_FPU_REGS)
-#define REG_RNUM           (REG_USR_CFG1 + 0)
-#define REG_RBASE          (REG_USR_CFG1 + 1)
-#define REG_RATTR          (REG_USR_CFG1 + 2)
-
-#define REG_USR_CFG0       (REG_RATTR + 1)
-#define REG_RNUM_0         (REG_USR_CFG0 + 0)
-#define REG_RBASE_0        (REG_USR_CFG0 + 1)
-#define REG_RATTR_0        (REG_USR_CFG0 + 2)
-
-#define REG_USR_STK        (REG_RATTR_0 + 1)
-#define REG_RNUM_STK       (REG_USR_STK + 0)
-#define REG_RBASE_STK      (REG_USR_STK + 1)
-#define REG_RATTR_STK      (REG_USR_STK + 2)
-
-/* Total number of regions for user, including the user task region */
-#define MPU_TOTAL_USER_REG  (REG_RATTR_STK - REG_USR_CFG1 + 1)
-
-#define MPU_CONTEXT_REGS    (4 * MPU_TOTAL_USER_REG)	/* user configurable registers are available */
-#define MPU_CONTEXT_SIZE    (4 * MPU_CONTEXT_REGS)	/* 3 regions, each region has 4 info, each info is 4 byte */
-#else
-#define MPU_CONTEXT_REGS    (0)
-#endif
-
 /* The total number of registers saved by software */
 
-#define SW_XCPT_REGS        (SW_INT_REGS + SW_FPU_REGS + MPU_CONTEXT_REGS)
+#define SW_XCPT_REGS        (SW_INT_REGS + SW_FPU_REGS)
 #define SW_XCPT_SIZE        (4 * SW_XCPT_REGS)
 
 /* On entry into an IRQ, the hardware automatically saves the following

--- a/os/arch/arm/src/armv7-m/up_copyarmstate.c
+++ b/os/arch/arm/src/armv7-m/up_copyarmstate.c
@@ -122,12 +122,6 @@ void up_copyarmstate(uint32_t *dest, uint32_t *src)
 		src += SW_FPU_REGS;
 		dest += SW_FPU_REGS;
 
-#ifdef CONFIG_ARMV7M_MPU
-		for (i = 0; i < MPU_CONTEXT_REGS; i++) {
-			*dest++ = *src++;
-		}
-#endif
-
 		for (i = 0; i < HW_XCPT_REGS; i++) {
 			*dest++ = *src++;
 		}

--- a/os/arch/arm/src/imxrt/Make.defs
+++ b/os/arch/arm/src/imxrt/Make.defs
@@ -134,11 +134,11 @@ CHIP_CSRCS += imxrt_gpioirq.c
 endif
 
 ifeq ($(CONFIG_BUILD_PROTECTED),y)
-ifeq ($(CONFIG_ARMV7M_MPU),y)
-CHIP_CSRCS += imxrt_mpuinit.c
+CHIP_CSRCS += imxrt_userspace.c
 endif
 
-CHIP_CSRCS += imxrt_userspace.c
+ifeq ($(CONFIG_ARMV7M_MPU),y)
+CHIP_CSRCS += imxrt_mpuinit.c
 endif
 
 ifeq ($(CONFIG_IMXRT_EDMA),y)

--- a/os/arch/arm/src/imxrt/imxrt_allocateheap.c
+++ b/os/arch/arm/src/imxrt/imxrt_allocateheap.c
@@ -363,7 +363,7 @@ void up_addregion(void)
 
 	kumm_addregion((FAR void *)REGION1_RAM_START, REGION1_RAM_SIZE);
 
-#if defined(CONFIG_BUILD_PROTECTED) && defined(CONFIG_MM_KERNEL_HEAP) && defined(CONFIG_ARMV7M_MPU)
+#if defined(CONFIG_BUILD_PROTECTED) && defined(CONFIG_MM_KERNEL_HEAP)
 	/* Allow user-mode access to region 1 */
 
 	imxrt_mpu_uheap((uintptr_t)REGION1_RAM_START, REGION1_RAM_SIZE);
@@ -374,7 +374,7 @@ void up_addregion(void)
 
 	kumm_addregion((FAR void *)REGION2_RAM_START, REGION2_RAM_SIZE);
 
-#if defined(CONFIG_BUILD_PROTECTED) && defined(CONFIG_MM_KERNEL_HEAP) && defined(CONFIG_ARMV7M_MPU)
+#if defined(CONFIG_BUILD_PROTECTED) && defined(CONFIG_MM_KERNEL_HEAP)
 	/* Allow user-mode access to region 2 */
 
 	imxrt_mpu_uheap((uintptr_t)REGION2_RAM_START, REGION2_RAM_SIZE);

--- a/os/arch/arm/src/imxrt/imxrt_mpuinit.c
+++ b/os/arch/arm/src/imxrt/imxrt_mpuinit.c
@@ -73,11 +73,11 @@
  ****************************************************************************/
 
 #ifndef MAX
-#define MAX(a,b) a > b ? a : b
+#define MAX(a, b) a > b ? a : b
 #endif
 
 #ifndef MIN
-#define MIN(a,b) a < b ? a : b
+#define MIN(a, b) a < b ? a : b
 #endif
 
 /****************************************************************************
@@ -95,7 +95,7 @@
 
 void imxrt_mpu_initialize(void)
 {
-#ifdef CONFIG_ARMV7M_MPU
+#ifdef CONFIG_BUILD_PROTECTED
 	uintptr_t datastart;
 	uintptr_t dataend;
 #endif
@@ -117,7 +117,7 @@ void imxrt_mpu_initialize(void)
 #endif
 #endif
 
-#ifdef CONFIG_ARMV7M_MPU
+#ifdef CONFIG_BUILD_PROTECTED
 	/* Configure user flash and SRAM space */
 
 	DEBUGASSERT(USERSPACE->us_textend >= USERSPACE->us_textstart);
@@ -147,7 +147,7 @@ void imxrt_mpu_initialize(void)
  *
  ****************************************************************************/
 
-#ifdef CONFIG_ARMV7M_MPU
+#ifdef CONFIG_BUILD_PROTECTED
 void imxrt_mpu_uheap(uintptr_t start, size_t size)
 {
 	mpu_user_intsram(start, size);

--- a/os/arch/arm/src/imxrt/imxrt_start.c
+++ b/os/arch/arm/src/imxrt/imxrt_start.c
@@ -280,13 +280,13 @@ static void go_os_start(void *pv, unsigned int nbytes)
 	 */
 
 	__asm__ __volatile__("\tmovs r1, r1, lsr #2\n"	/* R1 = nwords = nbytes >> 2 */
-                         "\tcmp  r1, #0\n"           /* Check (nwords == 0) */
+			"\tcmp  r1, #0\n"           /* Check (nwords == 0) */
 						 "\tbeq  2f\n"	/* (should not happen) */
 						 "\tbic  r0, r0, #3\n"	/* R0 = Aligned stackptr */
 						 "\tmovw r2, #0xbeef\n"	/* R2 = STACK_COLOR = 0xdeadbeef */
-                         "\tmovt r2, #0xdead\n"
+			"\tmovt r2, #0xdead\n"
 
-                         "1:\n"                      /* Top of the loop */
+			"1:\n"                      /* Top of the loop */
 						 "\tsub  r1, r1, #1\n"	/* R1 nwords-- */
 						 "\tcmp  r1, #0\n"	/* Check (nwords == 0) */
 						 "\tstr  r2, [r0], #4\n"	/* Save stack color word, increment stackptr */
@@ -318,7 +318,7 @@ void __start(void)
 #ifdef CONFIG_ARMV7M_STACKCHECK
 	/* Set the stack limit before we attempt to call any functions */
 
-	__asm__ volatile("sub r10, sp, %0"::"r"(CONFIG_IDLETHREAD_STACKSIZE - 64):);
+	__asm__ volatile("sub r10, sp, %0" : : "r"(CONFIG_IDLETHREAD_STACKSIZE - 64) : );
 #endif
 
 	/* Clear .bss.  We'll do this inline (vs. calling memset) just to be
@@ -374,6 +374,7 @@ void __start(void)
 	 */
 
 	imxrt_userspace();
+#endif
 
 #ifdef  CONFIG_ARMV7M_MPU
 	/* Configure the MPU to permit user-space access to its FLASH and RAM (for
@@ -382,7 +383,6 @@ void __start(void)
 	 */
 
 	imxrt_mpu_initialize();
-#endif
 #endif
 
 	/* Enable I- and D-Caches */


### PR DESCRIPTION
MPU settings are not done properly. This results in build and boot up
issues in flat and protected build. Make changes to fix this.

- Remove MPU registers from list of context registers
- Remove code to initialize or save MPU registers in context
- Fix src and Makefile with proper usage of CONFIG_PROTECTED flag