### PR TITLE
external/esp_idf: Initialize timer structure before using

### DIFF
--- a/external/esp_idf_port/esp32/esp32_wifi_os_adapter.c
+++ b/external/esp_idf_port/esp32/esp32_wifi_os_adapter.c
@@ -424,7 +424,7 @@ static void IRAM_ATTR timer_setfn_wrapper(void *ptimer, void *pfunction, void *p
 	ETSTimer *etimer = (ETSTimer *) ptimer;
 
 	if (etimer->timer_period != TIMER_INITIALIZED_VAL) {
-		memset(ptimer, 0, sizeof(*ptimer));
+		memset(etimer, 0, sizeof(ETSTimer));
 		etimer->timer_period = TIMER_INITIALIZED_VAL;
 	}
 
@@ -435,7 +435,7 @@ static void IRAM_ATTR timer_setfn_wrapper(void *ptimer, void *pfunction, void *p
 		}
 		etimer->timer_func = pfunction;
 		etimer->timer_expire = (uint32_t) parg;
-		etimer->timer_next = (struct work_s *)malloc(sizeof(struct work_s));
+		etimer->timer_next = (struct work_s *)zalloc(sizeof(struct work_s));
 	}
 }
 


### PR DESCRIPTION
A crash may happens when we call work_cancel() and
pass an uninitialized work_s structure (work_s.worker is not NULL).
Apply this patch to initilize work_s structure after allocated.

Signed-off-by: zhouxinhe xinhe.zhou@samsung.com