### PR TITLE
external/websocket : fix key length error

### DIFF
--- a/external/websocket/websocket.c
+++ b/external/websocket/websocket.c
@@ -332,7 +332,7 @@ int websocket_client_handshake(websocket_t *client, char *host, char *port, char
 	}
 
 	memset(accept_key, 0, WEBSOCKET_ACCEPT_KEY_LEN);
-	if (keyhdend - keyhdstart > WEBSOCKET_CLIENT_KEY_LEN) {
+	if (keyhdend - keyhdstart > WEBSOCKET_ACCEPT_KEY_LEN) {
 		WEBSOCKET_DEBUG("error key length\n");
 		goto EXIT_WEBSOCKET_HANDSHAKE_ERROR;
 	}


### PR DESCRIPTION
When handshake, client informs "error key length". Client should use WEBSOCKET_ACCEPT_KEY_LEN to judge the length of accept key instead of WEBSOCKET_CLIENT_KEY_LEN.