### PR TITLE
build/configs: Narrow the range of esp32's dram0 segment.

### DIFF
--- a/build/configs/esp32_DevKitC/scripts/esp32.template
+++ b/build/configs/esp32_DevKitC/scripts/esp32.template
@@ -52,10 +52,13 @@ MEMORY
   /* Shared data RAM, excluding memory reserved for ROM bss/data/stack.
    * Enabling Bluetooth & Trace Memory features in menuconfig will decrease
    * the amount of RAM available.
+   * Note: Length of this section *should* be 0x50000, and this extra DRAM is available
+   * in heap at runtime. However due to static ROM memory usage at this 176KB mark, the
+   * additional static memory temporarily cannot be used.
    */
 
   dram0_0_seg (RW) :     org = 0x3ffb0000 + CONFIG_ESP32_BT_RESERVE_DRAM,
-                         len = 0x50000 - CONFIG_ESP32_TRACEMEM_RESERVE_DRAM - CONFIG_ESP32_BT_RESERVE_DRAM
+                         len = 0x30000 - CONFIG_ESP32_TRACEMEM_RESERVE_DRAM - CONFIG_ESP32_BT_RESERVE_DRAM
 
   /* Flash mapped constant data */
 

--- a/build/configs/esp_wrover_kit/scripts/esp32.template
+++ b/build/configs/esp_wrover_kit/scripts/esp32.template
@@ -52,10 +52,14 @@ MEMORY
   /* Shared data RAM, excluding memory reserved for ROM bss/data/stack.
    * Enabling Bluetooth & Trace Memory features in menuconfig will decrease
    * the amount of RAM available.
+   *
+   * Note: Length of this section *should* be 0x50000, and this extra DRAM is available
+   * in heap at runtime. However due to static ROM memory usage at this 176KB mark, the
+   * additional static memory temporarily cannot be used.
    */
 
   dram0_0_seg (RW) :     org = 0x3ffb0000 + CONFIG_ESP32_BT_RESERVE_DRAM,
-                         len = 0x50000 - CONFIG_ESP32_TRACEMEM_RESERVE_DRAM - CONFIG_ESP32_BT_RESERVE_DRAM
+                         len = 0x30000 - CONFIG_ESP32_TRACEMEM_RESERVE_DRAM - CONFIG_ESP32_BT_RESERVE_DRAM
 
   /* Flash mapped constant data */
 


### PR DESCRIPTION
Narrow the range of esp32's dram0 segment as extral
memory during booting is not available.

after booting, the additional memory will add to heap usage.
