### PR TITLE
heapinfo : Modify heapinfo to run in protected build

### DIFF
--- a/apps/system/utils/kdbg_heapinfo.c
+++ b/apps/system/utils/kdbg_heapinfo.c
@@ -55,6 +55,7 @@ extern size_t regionx_size[CONFIG_MM_REGIONS];
 extern int regionx_heap_idx[CONFIG_MM_REGIONS];
 #endif
 
+extern struct mm_heap_s g_mmheap[CONFIG_MM_NHEAPS];
 #ifdef CONFIG_MM_KERNEL_HEAP
 static int heapinfo_fd;
 #endif
@@ -271,7 +272,11 @@ int kdbg_heapinfo(int argc, char **args)
 #if CONFIG_MM_NHEAPS > 1
 	heapinfo_init_totalinfo();
 #endif
+#ifdef CONFIG_MM_KERNEL_HEAP
+	struct mm_heap_s *heap = g_kmmheap;
+#else
 	struct mm_heap_s *heap = g_mmheap;
+#endif
 	while ((option = getopt(argc, args, "iap:fge:rk")) != ERROR) {
 #if CONFIG_MM_NHEAPS > 1
 		summary_option = false;

--- a/os/binfmt/binfmt_execmodule.c
+++ b/os/binfmt/binfmt_execmodule.c
@@ -68,6 +68,10 @@
 #include <tinyara/mm/shm.h>
 #include <tinyara/binfmt/binfmt.h>
 
+#ifdef CONFIG_DEBUG_MM_HEAPINFO
+#include <tinyara/mm/mm.h>
+#endif
+
 #include "sched/sched.h"
 #include "binfmt.h"
 
@@ -182,7 +186,12 @@ int exec_module(FAR const struct binary_s *binp)
 #endif
 
 #ifdef CONFIG_APP_BINARY_SEPARATION
+#ifdef CONFIG_DEBUG_MM_HEAPINFO
+	ARCH_GET_RET_ADDRESS
+	stack = (FAR uint32_t *)mm_malloc(binp->uheap, binp->stacksize, retaddr);
+#else
 	stack = (FAR uint32_t *)mm_malloc(binp->uheap, binp->stacksize);
+#endif
 #else
 	stack = (FAR uint32_t *)kumm_malloc(binp->stacksize);
 #endif

--- a/os/binfmt/libelf/libelf_addrenv.c
+++ b/os/binfmt/libelf/libelf_addrenv.c
@@ -62,6 +62,10 @@
 #include <tinyara/arch.h>
 #include <tinyara/kmalloc.h>
 
+#ifdef CONFIG_DEBUG_MM_HEAPINFO
+#include <tinyara/mm/mm.h>
+#endif
+
 #include "libelf.h"
 
 /****************************************************************************
@@ -145,7 +149,12 @@ int elf_addrenv_alloc(FAR struct elf_loadinfo_s *loadinfo, size_t textsize, size
 	/* Allocate memory to hold the ELF image */
 
 #ifdef CONFIG_APP_BINARY_SEPARATION
+#ifdef CONFIG_DEBUG_MM_HEAPINFO
+	ARCH_GET_RET_ADDRESS
+	loadinfo->textalloc = (uintptr_t)mm_malloc(loadinfo->uheap, textsize + datasize, retaddr);
+#else
 	loadinfo->textalloc = (uintptr_t)mm_malloc(loadinfo->uheap, textsize + datasize);
+#endif
 #else
 	loadinfo->textalloc = (uintptr_t)kumm_malloc(textsize + datasize);
 #endif

--- a/os/binfmt/libelf/libelf_ctors.c
+++ b/os/binfmt/libelf/libelf_ctors.c
@@ -176,7 +176,12 @@ int elf_loadctors(FAR struct elf_loadinfo_s *loadinfo)
 			/* Allocate memory to hold a copy of the .ctor section */
 
 #ifdef CONFIG_APP_BINARY_SEPARATION
+#ifdef CONFIG_DEBUG_MM_HEAPINFO
+			ARCH_GET_RET_ADDRESS
+			loadinfo->ctoralloc = (binfmt_ctor_t *)mm_malloc(loadinfo->uheap, ctorsize, retaddr);
+#else
 			loadinfo->ctoralloc = (binfmt_ctor_t *)mm_malloc(loadinfo->uheap, ctorsize);
+#endif
 #else
 			loadinfo->ctoralloc = (binfmt_ctor_t *)kumm_malloc(ctorsize);
 #endif

--- a/os/binfmt/libelf/libelf_dtors.c
+++ b/os/binfmt/libelf/libelf_dtors.c
@@ -176,7 +176,12 @@ int elf_loaddtors(FAR struct elf_loadinfo_s *loadinfo)
 			/* Allocate memory to hold a copy of the .dtor section */
 
 #ifdef CONFIG_APP_BINARY_SEPARATION
+#ifdef CONFIG_DEBUG_MM_HEAPINFO
+			ARCH_GET_RET_ADDRESS
+			loadinfo->dtoralloc = (binfmt_dtor_t *)mm_malloc(loadinfo->uheap, dtorsize, retaddr);
+#else
 			loadinfo->dtoralloc = (binfmt_dtor_t *)mm_malloc(loadinfo->uheap, dtorsize);
+#endif
 #else
 			loadinfo->dtoralloc = (binfmt_dtor_t *)kumm_malloc(dtorsize);
 #endif

--- a/os/drivers/heapinfo/heapinfo_drv.c
+++ b/os/drivers/heapinfo/heapinfo_drv.c
@@ -95,10 +95,6 @@ static int heapinfo_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
 		ret = g_kmmheap.mm_nregions;
 		break;
 #endif
-	case HEAPINFOIOC_INIT_KHEAP:
-		heapinfo_init(g_kmmheap);
-		ret = OK;
-		break;
 #endif
 	default:
 		break;

--- a/os/include/tinyara/fs/ioctl.h
+++ b/os/include/tinyara/fs/ioctl.h
@@ -385,7 +385,6 @@
 #define HEAPINFOIOC_PPID              _HEAPINFOIOC(0x0003)
 #define HEAPINFOIOC_STKSIZE           _HEAPINFOIOC(0x0004)
 #define HEAPINFOIOC_TASKNAME          _HEAPINFOIOC(0x0005)
-#define HEAPINFOIOC_INIT_KHEAP        _HEAPINFOIOC(0x0006)
 
 /****************************************************************************
  * Public Type Definitions


### PR DESCRIPTION
1. Change no syscall API to syscall API : sched_gettcb to sched_getparam
2. Remove unnecessary codes
3. Add return address param for mm_malloc