### PR TITLE
Add header for fixing build warnings of file partitions.c

### DIFF
--- a/os/board/common/partitions.c
+++ b/os/board/common/partitions.c
@@ -25,6 +25,8 @@
 #include <errno.h>
 #include <string.h>
 #include <sys/types.h>
+#include <stdlib.h>
+#include <stdio.h>
 
 #include <tinyara/fs/mtd.h>
 #include <tinyara/fs/ioctl.h>

--- a/os/board/esp32_devkit/src/Makefile
+++ b/os/board/esp32_devkit/src/Makefile
@@ -81,12 +81,14 @@ ifeq ($(WINTOOL),y)
   CFLAGS += -I "${shell cygpath -w $(ARCH_SRCDIR)/chip/chip}"
   CFLAGS += -I "${shell cygpath -w $(ARCH_SRCDIR)/chip/rom}"
   CFLAGS += -I "${shell cygpath -w $(BOARD_DIR)/include}"
+  CFLAGS += -I "${shell cygpath -w $(TOPDIR)/board/common}"
 else
   CFLAGS += -I$(ARCH_SRCDIR)/chip
   CFLAGS += -I$(ARCH_SRCDIR)/common
   CFLAGS += -I$(ARCH_SRCDIR)/chip/chip
   CFLAGS += -I$(ARCH_SRCDIR)/chip/rom
   CFLAGS += -I$(BOARD_DIR)/include
+  CFLAGS += -I$(TOPDIR)/board/common
 endif
 
 all: depend context libboard$(LIBEXT) depend context

--- a/os/board/esp32_devkit/src/esp32_boot.c
+++ b/os/board/esp32_devkit/src/esp32_boot.c
@@ -68,6 +68,7 @@
 #include "esp32_gpio.h"
 #include "esp32_core.h"
 #include "esp32_i2c.h"
+#include "common.h"
 #include <tinyara/gpio.h>
 #ifdef CONFIG_SPIRAM_USE_CAPS_ALLOC
 #include <esp_heap_caps.h>
@@ -225,7 +226,7 @@ void board_initialize(void)
 {
 	/* Perform board-specific initialization */
 	(void)esp32_bringup();
-    configure_partitions();
+	configure_partitions();
 	esp32_devKit_mount_partions();
 	board_gpio_initialize();
 	board_i2c_initialize();


### PR DESCRIPTION
Add header file for building partitions.c, to clean up build warnings.