### PR TITLE
arch/xtensa: fix build error when CONFIG_RR_INTERVAL is not defined

### DIFF
--- a/os/arch/xtensa/src/xtensa/xtensa_blocktask.c
+++ b/os/arch/xtensa/src/xtensa/xtensa_blocktask.c
@@ -140,7 +140,9 @@ void up_block_task(struct tcb_s *tcb, tstate_t task_state)
 			 */
 
 			rtcb = this_task();
+#if CONFIG_RR_INTERVAL > 0
 			rtcb->timeslice = MSEC2TICK(CONFIG_RR_INTERVAL);
+#endif
 
 			/* Then switch contexts.  Any necessary address environment
 			 * changes will be made when the interrupt returns.
@@ -185,7 +187,9 @@ void up_block_task(struct tcb_s *tcb, tstate_t task_state)
 			(void)group_addrenv(rtcb);
 #endif
 
+#if CONFIG_RR_INTERVAL > 0
 			rtcb->timeslice = MSEC2TICK(CONFIG_RR_INTERVAL);
+#endif
 
 			/* Then switch contexts */
 

--- a/os/arch/xtensa/src/xtensa/xtensa_unblocktask.c
+++ b/os/arch/xtensa/src/xtensa/xtensa_unblocktask.c
@@ -129,7 +129,9 @@ void up_unblock_task(struct tcb_s *tcb)
 			/* Update scheduler parameters */
 
 			//sched_resume_scheduler(rtcb);
+#if CONFIG_RR_INTERVAL > 0
 			rtcb->timeslice = MSEC2TICK(CONFIG_RR_INTERVAL);
+#endif
 
 			/* Then switch contexts.  Any necessary address environment
 			 * changes will be made when the interrupt returns.
@@ -178,7 +180,9 @@ void up_unblock_task(struct tcb_s *tcb)
 			/* Update scheduler parameters */
 
 			//sched_resume_scheduler(rtcb);
+#if CONFIG_RR_INTERVAL > 0
 			rtcb->timeslice = MSEC2TICK(CONFIG_RR_INTERVAL);
+#endif
 
 			/* Then switch contexts */
 


### PR DESCRIPTION
If CONFIG_RR_INTERVAL is not defined, there are build errors.