### PR TITLE
security: Add seclink and HAL for a SE device

### DIFF
--- a/framework/src/seclink/Kconfig
+++ b/framework/src/seclink/Kconfig
@@ -1,0 +1,10 @@
+#
+# For a description of the syntax of this configuration file,
+# see kconfig-language at https://www.kernel.org/doc/Documentation/kbuild/kconfig-language.txt
+#
+
+config SECURITY_LINK
+    bool "Enable Security Link"
+    default n
+    ---help---
+        Intercommunicate between Security features in User space and HAL which is in kernel space

--- a/framework/src/seclink/Make.defs
+++ b/framework/src/seclink/Make.defs
@@ -1,0 +1,27 @@
+###########################################################################
+#
+# Copyright 2019 Samsung Electronics All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+#
+###########################################################################
+
+ifeq ($(CONFIG_SECURITY_LINK), y)
+
+CSRCS += seclink.c
+
+DEPPATH += --dep-path src/seclink
+VPATH += :src/seclink
+
+endif
+

--- a/framework/src/seclink/seclink.c
+++ b/framework/src/seclink/seclink.c
@@ -1,0 +1,575 @@
+/****************************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+#include <tinyara/config.h>
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <debug.h>
+#include <sys/ioctl.h>
+#include <tinyara/seclink.h>
+
+#ifdef SECLINK_PATH
+#undef SECLINK_PATH
+#endif
+#define SECLINK_PATH "/dev/seclink"
+
+#define SL_LOG dbg
+
+#define SL_TAG "[SECLINK]"
+
+#define SL_ERR(fd)														\
+	do {																\
+		SL_LOG(SL_TAG"[ERR:%s] %s %s:%d ret(%d) code(%s)\n",			\
+			   SL_TAG, __FUNCTION__, __FILE__, __LINE__, fd, strerror(errno)); \
+	} while (0)
+
+#define SL_CALL(hnd, code, param)										\
+	do {																\
+		int res = ioctl(hnd->fd, code, (unsigned long)((uintptr_t)&param)); \
+		if (res < 0) {													\
+			SL_ERR(res);												\
+			return SECLINK_ERROR;										\
+		}																\
+	} while (0)
+
+#define SL_ENTER														\
+	do {																\
+		SL_LOG(SL_TAG"%s\t%s:%d\n", __FUNCTION__, __FILE__, __LINE__);	\
+	} while (0)
+
+#define SL_CLOSE(fd)							 \
+	do {										 \
+		close(fd);								 \
+		fd = -1;								 \
+	} while (0)
+
+
+#define SL_CHECK_VALID(hnd)									 \
+	do {													 \
+		if (!hnd || ((struct _seclink_s_ *)hnd)->fd <= 0) {	 \
+			return SECLINK_ERROR;							 \
+		}													 \
+	} while (0)
+
+#define SL_SET_MEMPOOL(hdata)                                 \
+	do {                                                      \
+		memset(g_mem.mem, 0, SECLINK_MEM_MAX_SIZE);           \
+		hdata->data = g_mem.mem;                              \
+		hdata->data_len = SECLINK_MEM_MAX_SIZE;               \
+	} while (0)
+
+#define SL_SET_MEMPOOL_PRIV(hdata)                            \
+	do {                                                      \
+		memset(g_mem.mem_priv, 0, SECLINK_MEM_PRIV_MAX_SIZE); \
+		hdata->priv = g_mem.mem_priv;                         \
+		hdata->priv_len = SECLINK_MEM_PRIV_MAX_SIZE;          \
+	} while (0)
+
+/*
+ * Structure
+ */
+struct _seclink_s_ {
+	int fd;
+};
+
+/* global */
+seclink_mem g_mem = {0, };
+
+/*  Common */
+int sl_init(sl_ctx *hnd)
+{
+	SL_ENTER;
+
+	int fd = open(SECLINK_PATH, O_RDWR);
+	if (fd < 0) {
+		SL_ERR(fd);
+		return SECLINK_ERROR;
+	}
+
+	struct _seclink_s_ *handle = (struct _seclink_s_ *)malloc(sizeof(struct _seclink_s_));
+	if (!handle) {
+		SL_ERR(fd);
+		close(fd);
+		return SECLINK_ERROR;
+	}
+
+	handle->fd = fd;
+	*hnd = handle;
+
+	g_mem.mem = (void *)malloc(SECLINK_MEM_MAX_SIZE);
+	if (!g_mem.mem) {
+		SL_ERR(fd);
+		close(fd);
+		return SECLINK_ERROR;
+	}
+	g_mem.mem_priv = (void *)malloc(SECLINK_MEM_PRIV_MAX_SIZE);
+	if (!g_mem.mem_priv) {
+		SL_ERR(fd);
+		close(fd);
+		free(g_mem.mem);
+		return SECLINK_ERROR;
+	}
+
+	return SECLINK_OK;
+}
+
+int sl_deinit(sl_ctx hnd)
+{
+	SL_ENTER;
+
+	SL_CHECK_VALID(hnd);
+
+	struct _seclink_s_ *sl = (struct _seclink_s_ *)hnd;
+	SL_CLOSE(sl->fd);
+
+	free(sl);
+	free(g_mem.mem);
+	free(g_mem.mem_priv);
+
+	return SECLINK_OK;
+}
+
+/*  key manager */
+int sl_set_key(sl_ctx hnd, hal_key_type mode, uint32_t key_idx, hal_data *key, hal_data *prikey)
+{
+	SL_ENTER;
+
+	SL_CHECK_VALID(hnd);
+
+	struct _seclink_s_ *sl = (struct _seclink_s_ *)hnd;
+	struct seclink_key_info info = {mode, key_idx, key, prikey};
+	struct seclink_req req = {.req_type.key = &info, 0};
+
+	SL_CALL(sl, SECLINKIOC_SETKEY, req);
+
+	return req.res;
+}
+
+int sl_get_key(sl_ctx hnd, hal_key_type mode, uint32_t key_idx, _OUT_ hal_data *key)
+{
+	SL_ENTER;
+
+	SL_CHECK_VALID(hnd);
+	SL_SET_MEMPOOL(key);
+	SL_SET_MEMPOOL_PRIV(key);
+
+	struct _seclink_s_ *sl = (struct _seclink_s_ *)hnd;
+	struct seclink_key_info info = {mode, key_idx, key, NULL};
+	struct seclink_req req = {.req_type.key = &info, 0};
+
+	SL_CALL(sl, SECLINKIOC_GETKEY, req);
+
+	return req.res;
+}
+
+int sl_remove_key(sl_ctx hnd, hal_key_type mode, uint32_t key_idx)
+{
+	SL_ENTER;
+
+	SL_CHECK_VALID(hnd);
+
+	struct _seclink_s_ *sl = (struct _seclink_s_ *)hnd;
+	struct seclink_key_info info = {mode, key_idx, NULL, NULL};
+	struct seclink_req req = {.req_type.key = &info, 0};
+
+	SL_CALL(sl, SECLINKIOC_REMOVEKEY, req);
+
+	return req.res;
+}
+
+int sl_generate_key(sl_ctx hnd, hal_key_type mode, uint32_t key_idx)
+{
+	SL_ENTER;
+
+	SL_CHECK_VALID(hnd);
+
+	struct _seclink_s_ *sl = (struct _seclink_s_ *)hnd;
+	struct seclink_key_info info = {mode, key_idx, NULL, NULL};
+	struct seclink_req req = {.req_type.key = &info, 0};
+
+	SL_CALL(sl, SECLINKIOC_GENERATEKEY, req);
+
+	return req.res;
+}
+
+
+/*  Authenticate */
+int sl_generate_random(sl_ctx hnd, uint32_t len, _OUT_ hal_data *random)
+{
+	SL_ENTER;
+
+	SL_CHECK_VALID(hnd);
+	SL_SET_MEMPOOL(random);
+
+	struct _seclink_s_ *sl = (struct _seclink_s_ *)hnd;
+	struct seclink_auth_info info = {.auth_type.random_len = len, -1, random, .auth_data.data = NULL};
+	struct seclink_req req = {.req_type.auth = &info, 0};
+
+	SL_CALL(sl, SECLINKIOC_GENERATERANDOM, info);
+
+	return req.res;
+}
+
+int sl_get_hash(sl_ctx hnd, hal_hash_type mode, hal_data *input, _OUT_ hal_data *hash)
+{
+	SL_ENTER;
+
+	SL_CHECK_VALID(hnd);
+	SL_SET_MEMPOOL(hash);
+
+	struct _seclink_s_ *sl = (struct _seclink_s_ *)hnd;
+	struct seclink_auth_info info = {.auth_type.hash_type = mode, -1, input, .auth_data.data = hash};
+	struct seclink_req req = {.req_type.auth = &info, 0};
+
+	SL_CALL(sl, SECLINKIOC_GETHASH, req);
+
+	return req.res;
+}
+
+int sl_get_hmac(sl_ctx hnd, hal_hmac_type mode, hal_data *input, uint32_t key_idx, _OUT_ hal_data *hmac)
+{
+	SL_ENTER;
+
+	SL_CHECK_VALID(hnd);
+	SL_SET_MEMPOOL(hmac);
+
+	struct _seclink_s_ *sl = (struct _seclink_s_ *)hnd;
+	struct seclink_auth_info info = {.auth_type.hmac_type = mode, key_idx, input, .auth_data.data = hmac};
+	struct seclink_req req = {.req_type.auth = &info, 0};
+
+	SL_CALL(sl, SECLINKIOC_GETHMAC, req);
+
+	return req.res;
+}
+
+int sl_rsa_sign_md(sl_ctx hnd, hal_rsa_mode mode, hal_data *hash, uint32_t key_idx, _OUT_ hal_data *sign)
+{
+	SL_ENTER;
+
+	SL_CHECK_VALID(hnd);
+	SL_SET_MEMPOOL(sign);
+
+	struct _seclink_s_ *sl = (struct _seclink_s_ *)hnd;
+	struct seclink_auth_info info = {.auth_type.rsa_type = mode, key_idx, hash, .auth_data.data = sign};
+	struct seclink_req req = {.req_type.auth = &info, 0};
+
+	SL_CALL(sl, SECLINKIOC_RSASIGNMD, req);
+
+	return req.res;
+}
+
+int sl_rsa_verify_md(sl_ctx hnd, hal_rsa_mode mode, hal_data *hash, hal_data *sign, uint32_t key_idx)
+{
+	SL_ENTER;
+
+	SL_CHECK_VALID(hnd);
+
+	struct _seclink_s_ *sl = (struct _seclink_s_ *)hnd;
+	struct seclink_auth_info info = {.auth_type.rsa_type = mode, key_idx, hash, .auth_data.data = sign};
+	struct seclink_req req = {.req_type.auth = &info, 0};
+
+	SL_CALL(sl, SECLINKIOC_RSAVERIFYMD, req);
+
+	return req.res;
+}
+
+int sl_ecdsa_sign_md(sl_ctx hnd, hal_ecdsa_mode mode, hal_data *hash, uint32_t key_idx, _OUT_ hal_data *sign)
+{
+	SL_ENTER;
+
+	SL_CHECK_VALID(hnd);
+	SL_SET_MEMPOOL(sign);
+
+	struct _seclink_s_ *sl = (struct _seclink_s_ *)hnd;
+	struct seclink_auth_info info = {.auth_type.ecdsa_type = mode, key_idx, hash, .auth_data.data = sign};
+	struct seclink_req req = {.req_type.auth = &info, 0};
+
+	SL_CALL(sl, SECLINKIOC_ECDSASIGNMD, req);
+
+	return req.res;
+}
+
+int sl_ecdsa_verify_md(sl_ctx hnd, hal_ecdsa_mode mode, hal_data *hash, hal_data *sign, uint32_t key_idx)
+{
+	SL_ENTER;
+
+	SL_CHECK_VALID(hnd);
+
+	struct _seclink_s_ *sl = (struct _seclink_s_ *)hnd;
+	struct seclink_auth_info info = {.auth_type.ecdsa_type = mode, key_idx, hash, .auth_data.data = sign};
+	struct seclink_req req = {.req_type.auth = &info, 0};
+
+	SL_CALL(sl, SECLINKIOC_ECDSAVERIFYMD, req);
+
+	return req.res;
+}
+
+int sl_dh_generate_param(sl_ctx hnd, uint32_t dh_idx, _INOUT_ hal_dh_data *dh_param)
+{
+	SL_ENTER;
+
+	SL_CHECK_VALID(hnd);
+	SL_SET_MEMPOOL(dh_param->pubkey);
+
+	struct _seclink_s_ *sl = (struct _seclink_s_ *)hnd;
+	struct seclink_auth_info info = {.auth_type.random_len = 0, dh_idx, NULL, .auth_data.dh_param = dh_param};
+	struct seclink_req req = {.req_type.auth = &info, 0};
+
+	SL_CALL(sl, SECLINKIOC_DHGENERATEPARAM, req);
+
+	return req.res;
+}
+
+int sl_dh_compute_shared_secret(sl_ctx hnd, hal_dh_data *dh_param, uint32_t dh_idx, _OUT_ hal_data *shared_secret)
+{
+	SL_ENTER;
+
+	SL_CHECK_VALID(hnd);
+	SL_SET_MEMPOOL(shared_secret);
+
+	struct _seclink_s_ *sl = (struct _seclink_s_ *)hnd;
+	struct seclink_auth_info info = {.auth_type.random_len = 0, dh_idx, shared_secret, .auth_data.dh_param = dh_param};
+	struct seclink_req req = {.req_type.auth = &info, 0};
+
+	SL_CALL(sl, SECLINKIOC_DHCOMPUTESHAREDSECRET, req);
+
+	return req.res;
+}
+
+int sl_ecdh_compute_shared_secret(sl_ctx hnd, hal_ecdh_data *ecdh_mode, uint32_t key_idx, _OUT_ hal_data *shared_secret)
+{
+	SL_ENTER;
+
+	SL_CHECK_VALID(hnd);
+	SL_SET_MEMPOOL(shared_secret);
+
+	struct _seclink_s_ *sl = (struct _seclink_s_ *)hnd;
+	struct seclink_auth_info info = {.auth_type.random_len = 0, key_idx, shared_secret, .auth_data.ecdh_param = ecdh_mode};
+	struct seclink_req req = {.req_type.auth = &info, 0};
+
+	SL_CALL(sl, SECLINKIOC_ECDHCOMPUTESHAREDSECRET, req);
+
+	return req.res;
+}
+
+int sl_set_certificate(sl_ctx hnd, uint32_t cert_idx, hal_data *cert_in)
+{
+	SL_ENTER;
+
+	SL_CHECK_VALID(hnd);
+
+	struct _seclink_s_ *sl = (struct _seclink_s_ *)hnd;
+	struct seclink_auth_info info = {.auth_type.random_len = 0, cert_idx, cert_in, .auth_data.data = NULL};
+	struct seclink_req req = {.req_type.auth = &info, 0};
+
+	SL_CALL(sl, SECLINKIOC_SETCERTIFICATE, req);
+
+	return req.res;
+}
+
+int sl_get_certificate(sl_ctx hnd, uint32_t cert_idx, _OUT_ hal_data *cert_out)
+{
+	SL_ENTER;
+
+	SL_CHECK_VALID(hnd);
+	SL_SET_MEMPOOL(cert_out);
+
+	struct _seclink_s_ *sl = (struct _seclink_s_ *)hnd;
+	struct seclink_auth_info info = {.auth_type.random_len = 0, cert_idx, cert_out, .auth_data.data = NULL};
+	struct seclink_req req = {.req_type.auth = &info, 0};
+
+	SL_CALL(sl, SECLINKIOC_GETCERTIFICATE, req);
+
+	return req.res;
+}
+
+int sl_remove_certificate(sl_ctx hnd, uint32_t cert_idx)
+{
+	SL_ENTER;
+
+	SL_CHECK_VALID(hnd);
+
+	struct _seclink_s_ *sl = (struct _seclink_s_ *)hnd;
+	struct seclink_auth_info info = {.auth_type.random_len = 0, cert_idx, 0, .auth_data.data = NULL};
+	struct seclink_req req = {.req_type.auth = &info, 0};
+
+	SL_CALL(sl, SECLINKIOC_REMOVECERTIFICATE, req);
+
+	return req.res;
+}
+
+int sl_get_factory_key(sl_ctx hnd, uint32_t key_idx, hal_data *key)
+{
+	SL_ENTER;
+
+	SL_CHECK_VALID(hnd);
+
+	struct _seclink_s_ *sl = (struct _seclink_s_ *)hnd;
+	struct seclink_auth_info info = {.auth_type.random_len = 0, key_idx, key, .auth_data.data = NULL};
+	struct seclink_req req = {.req_type.auth = &info, 0};
+
+	SL_CALL(sl, SECLINKIOC_GETFACTORY_KEY, req);
+
+	return req.res;
+}
+
+int sl_get_factory_cert(sl_ctx hnd, uint32_t cert_idx, hal_data *cert)
+{
+	SL_ENTER;
+
+	SL_CHECK_VALID(hnd);
+
+	struct _seclink_s_ *sl = (struct _seclink_s_ *)hnd;
+	struct seclink_auth_info info = {.auth_type.random_len = 0, cert_idx, cert, .auth_data.data = NULL};
+	struct seclink_req req = {.req_type.auth = &info, 0};
+
+	SL_CALL(sl, SECLINKIOC_GETFACTORY_CERT, req);
+
+	return req.res;
+}
+
+int sl_get_factory_data(sl_ctx hnd, uint32_t data_idx, hal_data *data)
+{
+	SL_ENTER;
+
+	SL_CHECK_VALID(hnd);
+
+	struct _seclink_s_ *sl = (struct _seclink_s_ *)hnd;
+	struct seclink_auth_info info = {.auth_type.random_len = 0, data_idx, data, .auth_data.data = NULL};
+	struct seclink_req req = {.req_type.auth = &info, 0};
+
+	SL_CALL(sl, SECLINKIOC_GETFACTORY_DATA, req);
+
+	return req.res;
+}
+
+/*  Crypto */
+int sl_aes_encrypt(sl_ctx hnd, hal_data *dec_data, hal_aes_param *aes_param, uint32_t key_idx, _OUT_ hal_data *enc_data)
+{
+	SL_ENTER;
+
+	SL_CHECK_VALID(hnd);
+	SL_SET_MEMPOOL(enc_data);
+
+	struct _seclink_s_ *sl = (struct _seclink_s_ *)hnd;
+	struct seclink_crypto_info info = {key_idx, dec_data, enc_data, aes_param, NULL};
+	struct seclink_req req = {.req_type.crypto = &info, 0};
+
+	SL_CALL(sl, SECLINKIOC_AESENCRYPT, req);
+
+	return req.res;
+}
+
+int sl_aes_decrypt(sl_ctx hnd, hal_data *enc_data, hal_aes_param *aes_param, uint32_t key_idx, _OUT_ hal_data *dec_data)
+{
+	SL_ENTER;
+
+	SL_CHECK_VALID(hnd);
+	SL_SET_MEMPOOL(dec_data);
+
+	struct _seclink_s_ *sl = (struct _seclink_s_ *)hnd;
+	struct seclink_crypto_info info = {key_idx, enc_data, dec_data, aes_param, NULL};
+	struct seclink_req req = {.req_type.crypto = &info, 0};
+
+	SL_CALL(sl, SECLINKIOC_AESDECRYPT, req);
+
+	return req.res;
+}
+
+int sl_rsa_encrypt(sl_ctx hnd, hal_data *dec_data, hal_rsa_mode *rsa_mode, uint32_t key_idx, _OUT_ hal_data *enc_data)
+{
+	SL_ENTER;
+
+	SL_CHECK_VALID(hnd);
+	SL_SET_MEMPOOL(enc_data);
+
+	struct _seclink_s_ *sl = (struct _seclink_s_ *)hnd;
+	struct seclink_crypto_info info = {key_idx, dec_data, enc_data, NULL, rsa_mode};
+	struct seclink_req req = {.req_type.crypto = &info, 0};
+
+	SL_CALL(sl, SECLINKIOC_RSADECRYPT, req);
+
+	return req.res;
+}
+
+int sl_rsa_decrypt(sl_ctx hnd, hal_data *enc_data, hal_rsa_mode *rsa_mode, uint32_t key_idx, _OUT_ hal_data *dec_data)
+{
+	SL_ENTER;
+
+	SL_CHECK_VALID(hnd);
+	SL_SET_MEMPOOL(dec_data);
+
+	struct _seclink_s_ *sl = (struct _seclink_s_ *)hnd;
+	struct seclink_crypto_info info = {key_idx, enc_data, dec_data, NULL, rsa_mode};
+	struct seclink_req req = {.req_type.crypto = &info, 0};
+
+	SL_CALL(sl, SECLINKIOC_RSADECRYPT, req);
+
+	return req.res;
+}
+
+
+/*  Secure Storage */
+int sl_write_storage(sl_ctx hnd, uint32_t ss_idx, hal_data *data)
+{
+	SL_ENTER;
+
+	SL_CHECK_VALID(hnd);
+
+	struct _seclink_s_ *sl = (struct _seclink_s_ *)hnd;
+	struct seclink_ss_info info = {ss_idx, data};
+	struct seclink_req req = {.req_type.ss = &info, 0};
+
+	SL_CALL(sl, SECLINKIOC_WRITESTORAGE, req);
+
+	return req.res;
+}
+
+int sl_read_storage(sl_ctx hnd, uint32_t ss_idx, _OUT_ hal_data *data)
+{
+	SL_ENTER;
+
+	SL_CHECK_VALID(hnd);
+	SL_SET_MEMPOOL(data);
+
+	struct _seclink_s_ *sl = (struct _seclink_s_ *)hnd;
+	struct seclink_ss_info info = {ss_idx, data};
+	struct seclink_req req = {.req_type.ss = &info, 0};
+
+	SL_CALL(sl, SECLINKIOC_READSTORAGE, req);
+
+	return req.res;
+}
+
+int sl_delete_storage(sl_ctx hnd, uint32_t ss_idx)
+{
+	SL_ENTER;
+
+	SL_CHECK_VALID(hnd);
+
+	struct _seclink_s_ *sl = (struct _seclink_s_ *)hnd;
+	struct seclink_ss_info info = {ss_idx, NULL};
+	struct seclink_req req = {.req_type.ss = &info, 0};
+
+	SL_CALL(sl, SECLINKIOC_DELETESTORAGE, req);
+
+	return req.res;
+}

--- a/os/FlatLibs.mk
+++ b/os/FlatLibs.mk
@@ -136,6 +136,10 @@ ifeq ($(CONFIG_CRYPTO),y)
 TINYARALIBS += $(LIBRARIES_DIR)$(DELIM)libcrypto$(LIBEXT)
 endif
 
+ifeq ($(CONFIG_SE),y)
+TINYARALIBS += $(LIBRARIES_DIR)$(DELIM)libse$(LIBEXT)
+endif
+
 # Add library for Framework
 TINYARALIBS += $(LIBRARIES_DIR)$(DELIM)libframework$(LIBEXT)
 

--- a/os/Kconfig
+++ b/os/Kconfig
@@ -443,6 +443,10 @@ menu "Board Selection"
 source board/Kconfig
 endmenu
 
+menu "SE Selection"
+source se/Kconfig
+endmenu
+
 menu "Crypto Module"
 source crypto/Kconfig
 endmenu
@@ -529,7 +533,4 @@ menu "IoTBus Framework"
 source "$FRAMEWORK_DIR/src/iotbus/Kconfig"
 endmenu
 
-menu "SE"
-source se/Kconfig
-endmenu
 

--- a/os/Kconfig
+++ b/os/Kconfig
@@ -528,3 +528,8 @@ endmenu
 menu "IoTBus Framework"
 source "$FRAMEWORK_DIR/src/iotbus/Kconfig"
 endmenu
+
+menu "SE"
+source se/Kconfig
+endmenu
+

--- a/os/KernelLibs.mk
+++ b/os/KernelLibs.mk
@@ -85,6 +85,11 @@ ifeq ($(CONFIG_AUDIO),y)
 TINYARALIBS += $(LIBRARIES_DIR)$(DELIM)libaudio$(LIBEXT)
 endif
 
+# Add libraries for se support
+ifeq ($(CONFIG_SE),y)
+TINYARALIBS += $(LIBRARIES_DIR)$(DELIM)libse$(LIBEXT)
+endif
+
 # Add libraries for crypto support
 ifeq ($(CONFIG_CRYPTO),y)
 TINYARALIBS += $(LIBRARIES_DIR)$(DELIM)libcrypto$(LIBEXT)

--- a/os/LibTargets.mk
+++ b/os/LibTargets.mk
@@ -111,6 +111,12 @@ audio$(DELIM)libaudio$(LIBEXT): context
 $(LIBRARIES_DIR)$(DELIM)libaudio$(LIBEXT): audio$(DELIM)libaudio$(LIBEXT)
 	$(Q) install audio$(DELIM)libaudio$(LIBEXT) $(LIBRARIES_DIR)$(DELIM)libaudio$(LIBEXT)
 
+se$(DELIM)libse$(LIBEXT): context
+	$(Q) $(MAKE) -C se TOPDIR="$(TOPDIR)" libse$(LIBEXT) KERNEL=y EXTRADEFINES=$(KDEFINE)
+
+$(LIBRARIES_DIR)$(DELIM)libse$(LIBEXT): se$(DELIM)libse$(LIBEXT)
+	$(Q) install se$(DELIM)libse$(LIBEXT) $(LIBRARIES_DIR)$(DELIM)libse$(LIBEXT)
+
 crypto$(DELIM)libcrypto$(LIBEXT): context
 	$(Q) $(MAKE) -C crypto TOPDIR="$(TOPDIR)" libcrypto$(LIBEXT) KERNEL=y EXTRADEFINES=$(KDEFINE)
 

--- a/os/ProtectedLibs.mk
+++ b/os/ProtectedLibs.mk
@@ -105,6 +105,11 @@ ifeq ($(CONFIG_AUDIO),y)
 TINYARALIBS += $(LIBRARIES_DIR)$(DELIM)libaudio$(LIBEXT)
 endif
 
+# Add libraries for se module
+ifeq ($(CONFIG_SE),y)
+TINYARALIBS += $(LIBRARIES_DIR)$(DELIM)libse$(LIBEXT)
+endif
+
 # Add libraries for crypto module
 
 ifeq ($(CONFIG_CRYPTO),y)

--- a/os/arch/arm/src/s5j/Make.defs
+++ b/os/arch/arm/src/s5j/Make.defs
@@ -185,7 +185,7 @@ endif
 
 ifeq ($(CONFIG_S5J_SSS),y)
 VPATH += chip/sss
-CHIP_CSRCS += sss_driver_io.c	sssro_verify.c security_hal_wrapper.c
+CHIP_CSRCS += sss_driver_io.c sssro_verify.c
 
 # built-in static library
 EXTRA_LIBS += chip/sss/libispdriver.a

--- a/os/drivers/Kconfig
+++ b/os/drivers/Kconfig
@@ -496,3 +496,4 @@ menuconfig DRIVERS_WIRELESS
 		Drivers for various wireless devices.
 
 source drivers/wireless/Kconfig
+source drivers/seclink/Kconfig

--- a/os/drivers/Makefile
+++ b/os/drivers/Makefile
@@ -80,6 +80,7 @@ include i2c$(DELIM)Make.defs
 include net$(DELIM)Make.defs
 include pipes$(DELIM)Make.defs
 include power$(DELIM)Make.defs
+include seclink$(DELIM)Make.defs
 include sensors$(DELIM)Make.defs
 include serial$(DELIM)Make.defs
 include spi$(DELIM)Make.defs

--- a/os/drivers/seclink/Kconfig
+++ b/os/drivers/seclink/Kconfig
@@ -1,0 +1,16 @@
+#
+# For a description of the syntax of this configuration file,
+# see kconfig-language at https://www.kernel.org/doc/Documentation/kbuild/kconfig-language.txt
+#
+
+config SECURITY_LINK_DRV
+	bool "seclink Driver Support"
+	select SECURITY_LINK
+	default n
+	---help---
+		Enable seclink Driver to support communication between HAL and security API.
+
+if SECURITY_LINK_DRV
+source "$FRAMEWORK_DIR/src/seclink/Kconfig""
+endif #SECURITY_LINK_DRV
+

--- a/os/drivers/seclink/Make.defs
+++ b/os/drivers/seclink/Make.defs
@@ -1,0 +1,32 @@
+##########################################################################
+#
+# Copyright 2019 Samsung Electronics All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+#
+############################################################################
+# Include testcase drivers
+
+ifeq ($(CONFIG_SECURITY_LINK_DRV),y)
+
+CSRCS += seclink_drv.c
+CSRCS += seclink_drv_key.c seclink_drv_auth.c seclink_drv_common.c seclink_drv_ss.c seclink_drv_crypto.c
+
+CFLAGS += -I$(TOPDIR)/../external/security/hal/
+
+# Include testcase driver support
+
+DEPPATH += --dep-path seclink
+VPATH += :seclink
+
+endif

--- a/os/drivers/seclink/seclink_drv.c
+++ b/os/drivers/seclink/seclink_drv.c
@@ -1,0 +1,208 @@
+/****************************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+#include <tinyara/config.h>
+
+#include <unistd.h>
+#include <time.h>
+#include <errno.h>
+#include <string.h>
+#include <stdlib.h>
+#include <debug.h>
+
+#include <tinyara/fs/fs.h>
+#include <tinyara/testcase_drv.h>
+#include <tinyara/sched.h>
+#include <tinyara/seclink.h>
+#include <tinyara/seclink_drv.h>
+#include "seclink_drv_req.h"
+#include "seclink_drv_utils.h"
+
+#define SL_IS_COMMON_REQ(cmd)  ((cmd & 0xf0) & (SECLINKIOC_COMMON & 0xf0))
+#define SL_IS_CRYPTO_REQ(cmd)  ((cmd & 0xf0) & (SECLINKIOC_CRYPTO & 0xf0))
+#define SL_IS_AUTH_REQ(cmd)    ((cmd & 0xf0) & (SECLINKIOC_AUTH & 0xf0))
+#define SL_IS_SS_REQ(cmd)      ((cmd & 0xf0) & (SECLINKIOC_SS & 0xf0))
+#define SL_IS_KEYMGR_REQ(cmd)  ((cmd & 0xf0) & (SECLINKIOC_KEYMGR & 0xf0))
+
+/****************************************************************************
+ * Private Function Prototypes
+ ****************************************************************************/
+
+static int seclink_open(FAR struct file *filep);
+static int seclink_close(FAR struct file *filep);
+static ssize_t seclink_read(FAR struct file *filep, FAR char *buffer, size_t len);
+static ssize_t seclink_write(FAR struct file *filep, FAR const char *buffer, size_t len);
+static int seclink_ioctl(FAR struct file *filep, int cmd, unsigned long arg);
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+static const struct file_operations g_seclink_fops = {
+	seclink_open,                                                   /* open */
+	seclink_close,                                                   /* close */
+	seclink_read,
+	seclink_write,
+	0,                                                   /* seek */
+	seclink_ioctl                                        /* ioctl */
+#ifndef CONFIG_DISABLE_POLL
+	, 0                                                  /* poll */
+#endif
+};
+
+int seclink_open(FAR struct file *filep)
+{
+	SLDRV_ENTER;
+
+	FAR struct inode *inode = filep->f_inode;
+	FAR struct sec_upperhalf_s *upper = inode->i_private;
+	upper->refcnt++;
+
+	return 0;
+}
+
+int seclink_close(FAR struct file *filep)
+{
+	SLDRV_ENTER;
+
+	FAR struct inode *inode = filep->f_inode;
+	FAR struct sec_upperhalf_s *upper = inode->i_private;
+	upper->refcnt--;
+
+	return 0;
+}
+
+ssize_t seclink_read(FAR struct file *filep, FAR char *buffer, size_t len)
+{
+	SLDRV_ENTER;
+
+	return 0;
+}
+
+ssize_t seclink_write(FAR struct file *filep, FAR const char *buffer, size_t len)
+{
+	SLDRV_ENTER;
+
+	return 0;
+}
+
+int seclink_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
+{
+	SLDRV_ENTER;
+
+	SLDRV_LOG("-->%s (%d)(%x)\n", __FUNCTION__, cmd, arg);
+
+	FAR struct inode *inode = filep->f_inode;
+	FAR struct sec_upperhalf_s *upper = inode->i_private;
+
+	/* If there are a couple of tasks that request SE then
+	 * calling lower's function should be protected. But
+	 * current design consider that only one task that is seclink can
+	 * request to HAL
+	 */
+	int res = 0;
+	if (SL_IS_COMMON_REQ(cmd)) {
+		res = hd_handle_common_request(cmd, arg, (void *)upper->lower);
+	} else if (SL_IS_AUTH_REQ(cmd)) {
+		res = hd_handle_auth_reqeust(cmd, arg, (void *)upper->lower);
+	} else if (SL_IS_AUTH_REQ(cmd)) {
+		res = hd_handle_key_request(cmd, arg, (void *)upper->lower);
+	} else if (SL_IS_SS_REQ(cmd)) {
+		res = hd_handle_ss_request(cmd, arg, (void *)upper->lower);
+	} else if (SL_IS_COMMON_REQ(cmd)) {
+		res = hd_handle_crypto_request(cmd, arg, (void *)upper->lower);
+	}
+
+	return res;
+}
+
+/****************************************************************************
+ * Name: se_register
+ *
+ * Description:
+ *   Register Secure Element device.
+ *
+ ****************************************************************************/
+int se_register(const char *path, struct sec_lowerhalf_s *lower)
+{
+	vdbg("Registering %s\n", path);
+
+	if (!lower) {
+		return -1;
+	}
+
+	struct sec_upperhalf_s *upper = (struct sec_upperhalf_s *)malloc(sizeof(struct sec_upperhalf_s));
+	if (!upper) {
+		return -1;
+	}
+
+	/*  initialize upper */
+	char *drv_path = (char *)malloc(strlen(path) + 1);
+	if (!drv_path) {
+		free(upper);
+		return -1;
+	}
+	memcpy(drv_path, path, strlen(path) + 1);
+	upper->path = drv_path;
+	upper->refcnt = 0;
+
+	upper->lower = lower;
+	lower->parent = upper;
+
+	return register_driver(path, &g_seclink_fops, 0666, upper);
+}
+
+
+/****************************************************************************
+ * Name: se_unregister
+ *
+ * Description:
+ *   Unregister Secure Element device.
+ *
+ ****************************************************************************/
+int se_unregister(FAR struct sec_lowerhalf_s *lower)
+{
+	if (!lower) {
+		return -1;
+	}
+	// de-initialize  upper
+	struct sec_upperhalf_s *upper = lower->parent;
+	if (!upper) {
+		dbg("upper is null\n");
+		assert(0);
+	}
+
+	if (!upper->path) {
+		dbg("upper path is null\n");
+		assert(0);
+	}
+
+	vdbg("unregister driver(%s)\n", upper->path);
+	int res = unregister_driver(upper->path);
+	if (res != 0) {
+		dbg("unregister driver path fail\n");
+	}
+
+	free(upper->path);
+	free(upper);
+
+	return res;
+}

--- a/os/drivers/seclink/seclink_drv_auth.c
+++ b/os/drivers/seclink/seclink_drv_auth.c
@@ -1,0 +1,104 @@
+/****************************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+#include <tinyara/config.h>
+
+#include <stdio.h>
+#include <errno.h>
+#include <tinyara/seclink.h>
+#include <tinyara/seclink_drv.h>
+#include "seclink_drv_req.h"
+#include "seclink_drv_utils.h"
+
+/*  Debugging */
+#ifdef SLDRV_TAG
+#undef SLDRV_TAG
+#endif
+#define SLDRV_TAG "[SECLINK_DRV_AUTH]"
+
+int hd_handle_auth_reqeust(int cmd, unsigned long arg, void *lower)
+{
+	SLDRV_ENTER;
+
+	struct seclink_req *req = (struct seclink_req *)arg;
+	if (!req) {
+		return -EINVAL;
+	}
+
+	struct seclink_auth_info *info = req->req_type.auth;
+	if (!info) {
+		return -EINVAL;
+	}
+
+	struct sec_lowerhalf_s *se = (struct sec_lowerhalf_s *)lower;
+	if (!se || !(se->ops)) {
+		return -EINVAL;
+	}
+
+	switch (cmd) {
+	case SECLINKIOC_GENERATERANDOM:
+		req->res = se->ops->generate_random(info->auth_type.random_len, info->data);
+		break;
+	case SECLINKIOC_GETHASH:
+		req->res = se->ops->get_hash(info->auth_type.hash_type, info->data, info->auth_data.data);
+		break;
+	case SECLINKIOC_GETHMAC:
+		req->res = se->ops->get_hmac(info->auth_type.hmac_type, info->data, info->key_idx, info->auth_data.data);
+		break;
+	case SECLINKIOC_RSASIGNMD:
+		req->res = se->ops->rsa_sign_md(info->auth_type.rsa_type, info->data, info->key_idx, info->auth_data.data);
+		break;
+	case SECLINKIOC_RSAVERIFYMD:
+		req->res = se->ops->rsa_verify_md(info->auth_type.rsa_type, info->data, info->auth_data.data, info->key_idx);
+		break;
+	case SECLINKIOC_ECDSASIGNMD:
+		req->res = se->ops->ecdsa_sign_md(info->data, info->key_idx, &info->auth_type.ecdsa_type, info->auth_data.data);
+		break;
+	case SECLINKIOC_ECDSAVERIFYMD:
+		req->res = se->ops->ecdsa_verify_md(info->auth_type.ecdsa_type, info->data, info->auth_data.data, info->key_idx);
+		break;
+	case SECLINKIOC_DHGENERATEPARAM:
+		req->res = se->ops->dh_generate_param(info->key_idx, info->auth_data.dh_param);
+		break;
+	case SECLINKIOC_DHCOMPUTESHAREDSECRET:
+		req->res = se->ops->dh_compute_shared_secret(info->auth_data.dh_param, info->key_idx, info->data);
+		break;
+	case SECLINKIOC_ECDHCOMPUTESHAREDSECRET:
+		req->res = se->ops->ecdh_compute_shared_secret(info->auth_data.ecdh_param, info->key_idx, info->data);
+		break;
+	case SECLINKIOC_SETCERTIFICATE:
+		req->res = se->ops->set_certificate(info->key_idx, info->data);
+		break;
+	case SECLINKIOC_GETCERTIFICATE:
+		req->res = se->ops->get_certificate(info->key_idx, info->data);
+		break;
+	case SECLINKIOC_REMOVECERTIFICATE:
+		req->res = se->ops->remove_certificate(info->key_idx);
+		break;
+	case SECLINKIOC_GETFACTORY_KEY:
+		req->res = se->ops->get_factory_key(info->key_idx, info->data);
+		break;
+	case SECLINKIOC_GETFACTORY_CERT:
+		req->res = se->ops->get_factory_key(info->key_idx, info->data);
+		break;
+	case SECLINKIOC_GETFACTORY_DATA:
+		req->res = se->ops->get_factory_key(info->key_idx, info->data);
+		break;
+	}
+	return 0;
+}

--- a/os/drivers/seclink/seclink_drv_common.c
+++ b/os/drivers/seclink/seclink_drv_common.c
@@ -1,0 +1,61 @@
+/****************************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+#include <tinyara/config.h>
+
+#include <stdio.h>
+#include <errno.h>
+#include <tinyara/seclink.h>
+#include <tinyara/seclink_drv.h>
+#include "seclink_drv_req.h"
+#include "seclink_drv_utils.h"
+
+/*  Debugging */
+#ifdef SLDRV_TAG
+#undef SLDRV_TAG
+#endif
+#define SLDRV_TAG "[SECLINK_DRV_COM]"
+
+
+int hd_handle_common_request(int cmd, unsigned long arg, void *lower)
+{
+	SLDRV_ENTER;
+
+	struct seclink_req *req = (struct seclink_req *)arg;
+	hal_init_param *params = NULL;
+
+	if (!req) {
+		return -EINVAL;
+	}
+
+	struct sec_lowerhalf_s *se = (struct sec_lowerhalf_s *)lower;
+	if (!se | !(se->ops)) {
+		return -EINVAL;
+	}
+
+	switch (cmd) {
+	case SECLINKIOC_INIT:
+		params = (hal_init_param *)req->params;
+		req->res = se->ops->init(params);
+		break;
+	case SECLINKIOC_DEINIT:
+		req->res = se->ops->deinit();
+		break;
+	}
+
+	return 0;
+}

--- a/os/drivers/seclink/seclink_drv_crypto.c
+++ b/os/drivers/seclink/seclink_drv_crypto.c
@@ -1,0 +1,69 @@
+/****************************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+#include <tinyara/config.h>
+
+#include <stdio.h>
+#include <errno.h>
+#include <tinyara/seclink.h>
+#include <tinyara/seclink_drv.h>
+
+#include "seclink_drv_req.h"
+#include "seclink_drv_utils.h"
+
+/*  Debugging */
+#ifdef SLDRV_TAG
+#undef SLDRV_TAG
+#endif
+#define SLDRV_TAG "[SECLINK_DRV_CRYPTO]"
+
+int hd_handle_crypto_request(int cmd, unsigned long arg, void *lower)
+{
+	SLDRV_ENTER;
+
+	struct seclink_req *req = (struct seclink_req *)arg;
+	if (!req) {
+		return -EINVAL;
+	}
+
+	struct seclink_crypto_info *info = (struct seclink_crypto_info *)req->req_type.crypto;
+	if (!info) {
+		return -EINVAL;
+	}
+
+	struct sec_lowerhalf_s *se = (struct sec_lowerhalf_s *)lower;
+	if (!se || !(se->ops)) {
+		return -EINVAL;
+	}
+
+	switch (cmd) {
+	case SECLINKIOC_AESENCRYPT:
+		req->res = se->ops->aes_encrypt(info->input, info->aes_param, info->key_idx, info->output);
+		break;
+	case SECLINKIOC_AESDECRYPT:
+		req->res = se->ops->aes_decrypt(info->input, info->aes_param, info->key_idx, info->output);
+		break;
+	case SECLINKIOC_RSAENCRYPT:
+		req->res = se->ops->rsa_encrypt(info->input, info->rsa_mode, info->key_idx, info->output);
+		break;
+	case SECLINKIOC_RSADECRYPT:
+		req->res = se->ops->rsa_decrypt(info->input, info->rsa_mode, info->key_idx, info->output);
+		break;
+	}
+
+	return 0;
+}

--- a/os/drivers/seclink/seclink_drv_key.c
+++ b/os/drivers/seclink/seclink_drv_key.c
@@ -1,0 +1,68 @@
+/****************************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+#include <tinyara/config.h>
+
+#include <stdio.h>
+#include <errno.h>
+#include <tinyara/seclink.h>
+#include <tinyara/seclink_drv.h>
+#include "seclink_drv_req.h"
+#include "seclink_drv_utils.h"
+
+#ifdef SLDRV_TAG
+#undef SLDRV_TAG
+#endif
+#define SLDRV_TAG "[SECLINK_DRV_KEY]"
+
+int hd_handle_key_request(int cmd, unsigned long arg, void *lower)
+{
+	SLDRV_ENTER;
+
+	struct seclink_req *req = (struct seclink_req *)arg;
+	if (!req) {
+		return -EINVAL;
+	}
+
+	struct seclink_key_info *info = (struct seclink_key_info *)req->req_type.key;
+	if (!info) {
+		return -EINVAL;
+	}
+
+	struct sec_lowerhalf_s *se = (struct sec_lowerhalf_s *)lower;
+	if (!se || !(se->ops)) {
+		return -EINVAL;
+	}
+
+	SLDRV_LOG("keymgr request cmd(%x) (%d)\n", cmd, info->mode);
+	switch (cmd) {
+	case SECLINKIOC_SETKEY:
+		req->res = se->ops->set_key(info->mode, info->key_idx, info->key, info->prikey);
+		break;
+	case SECLINKIOC_GETKEY:
+		req->res = se->ops->get_key(info->mode, info->key_idx, info->key);
+		break;
+	case SECLINKIOC_REMOVEKEY:
+		req->res = se->ops->remove_key(info->mode, info->key_idx);
+		break;
+	case SECLINKIOC_GENERATEKEY:
+		req->res = se->ops->generate_key(info->mode, info->key_idx);
+		break;
+	}
+
+	return 0;
+}

--- a/os/drivers/seclink/seclink_drv_req.h
+++ b/os/drivers/seclink/seclink_drv_req.h
@@ -1,0 +1,28 @@
+/****************************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+#ifndef __SECLINK_DRV_REQ_H__
+#define __SECLINK_DRV_REQ_H__
+
+int hd_handle_common_request(int cmd, unsigned long arg, void *lower);
+int hd_handle_auth_reqeust(int cmd, unsigned long arg, void *lower);
+int hd_handle_key_request(int cmd, unsigned long arg, void *lower);
+int hd_handle_ss_request(int cmd, unsigned long arg, void *lower);
+int hd_handle_crypto_request(int cmd, unsigned long arg, void *lower);
+
+#endif // __SECLINK_DRV_REQ_H__
+

--- a/os/drivers/seclink/seclink_drv_ss.c
+++ b/os/drivers/seclink/seclink_drv_ss.c
@@ -1,0 +1,67 @@
+/****************************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+#include <tinyara/config.h>
+
+#include <stdio.h>
+#include <errno.h>
+#include <tinyara/seclink.h>
+#include <tinyara/seclink_drv.h>
+#include "seclink_drv_req.h"
+#include "seclink_drv_utils.h"
+
+/*  Debugging */
+#ifdef SLDRV_TAG
+#undef SLDRV_TAG
+#endif
+#define SLDRV_TAG "[SECLINK_DRV_SS]"
+
+int hd_handle_ss_request(int cmd, unsigned long arg, void *lower)
+{
+	SLDRV_ENTER;
+
+	struct seclink_req *req = (struct seclink_req *)arg;
+	if (!req) {
+		return -EINVAL;
+	}
+
+	struct seclink_ss_info *info = req->req_type.ss;
+	if (!info) {
+		return -EINVAL;
+	}
+
+	struct sec_lowerhalf_s *se = (struct sec_lowerhalf_s *)lower;
+	if (!se || !(se->ops)) {
+		return -EINVAL;
+	}
+
+	SLDRV_LOG("[securestorage] request cmd(%x)\n", cmd);
+
+	switch (cmd) {
+	case SECLINKIOC_WRITESTORAGE:
+		req->res = se->ops->write_storage(info->key_idx, info->data);
+		break;
+	case SECLINKIOC_READSTORAGE:
+		req->res = se->ops->read_storage(info->key_idx, info->data);
+		break;
+	case SECLINKIOC_DELETESTORAGE:
+		req->res = se->ops->delete_storage(info->key_idx);
+		break;
+	}
+
+	return 0;
+}

--- a/os/drivers/seclink/seclink_drv_utils.h
+++ b/os/drivers/seclink/seclink_drv_utils.h
@@ -1,0 +1,22 @@
+#ifndef _SECLINK_DRIVER_UTILS_H__
+#define _SECLINK_DRIVER_UTILS_H__
+
+#include <debug.h>
+
+#define SLDRV_LOG vdbg
+
+#define SLDRV_TAG "[SECLINK_DRV]"
+
+#define SLDRV_ERR(fd)													\
+	do {																\
+		SLDRV_LOG(SL_TAG"[ERR:%s] %s %s:%d ret(%d) code(%s)\n",			\
+				  SL_TAG, __FUNCTION__, __FILE__, __LINE__, fd, strerror(errno)); \
+	} while (0)
+
+#define SLDRV_ENTER														\
+	do {																\
+		SLDRV_LOG(SLDRV_TAG"%s\t%s:%d\n", __FUNCTION__, __FILE__, __LINE__); \
+	} while (0)
+
+
+#endif // _SECLINK_DRIVER_UTILS_H__

--- a/os/include/tinyara/fs/ioctl.h
+++ b/os/include/tinyara/fs/ioctl.h
@@ -96,6 +96,7 @@
 #define _TMBASE         (0x2100)	/* Task Management ioctl commands */
 #define _HEAPINFOBASE   (0x2200)	/* Heapinfo ioctl commands */
 #define _SPIBASE        (0x2300)	/* SPI ioctl commands */
+#define _SECLINKBASE    (0x2400)	/* seclink ioctl commands */
 #define _TESTIOCBASE (0xfe00)	/* KERNEL TEST DRV module ioctl commands */
 
 /* boardctl() commands share the same number space */
@@ -353,6 +354,10 @@
 #define _BOARDIOCVALID(c)  (_IOC_TYPE(c) == _BOARDBASE)
 #define _BOARDIOC(nr)      _IOC(_BOARDBASE, nr)
 
+/* seclink driver ioctl definitions ********************************************/
+/* (see include/tinyara/seclink.h */
+#define _SECLINKIOCVALID(c)   (_IOC_TYPE(c) == _SECLINKBASE)
+#define _SECLINKIOC(nr)       _IOC(_SECLINKBASE, nr)
 
 /* Kernel_tc driver ioctl definitions *************************************/
 /* (see tinyara/testcase_drv.h) */

--- a/os/include/tinyara/seclink.h
+++ b/os/include/tinyara/seclink.h
@@ -1,0 +1,228 @@
+#ifndef __SECLINK_H__
+#define __SECLINK_H__
+
+#include <stdint.h>
+#include <sys/ioctl.h>
+#include <tinyara/security_hal.h>
+
+#define SECLINK_OK                               0
+#define SECLINK_ERROR                            -1
+
+#define SECLINK_MEM_MAX_SIZE                     4096
+#define SECLINK_MEM_PRIV_MAX_SIZE                256
+
+/*  common */
+#define SECLINKIOC_COMMON                       _SECLINKIOC(0x00)
+#define SECLINKIOC_INIT                         _SECLINKIOC((SECLINKIOC_COMMON | 0x00))
+#define SECLINKIOC_DEINIT                       _SECLINKIOC((SECLINKIOC_COMMON | 0x01))
+
+/*  Crypto */
+#define SECLINKIOC_CRYPTO                       _SECLINKIOC(0x10)
+#define SECLINKIOC_AESENCRYPT                   _SECLINKIOC((SECLINKIOC_CRYPTO | 0x00))
+#define SECLINKIOC_AESDECRYPT                   _SECLINKIOC((SECLINKIOC_CRYPTO | 0x01))
+#define SECLINKIOC_RSAENCRYPT                   _SECLINKIOC((SECLINKIOC_CRYPTO | 0x02))
+#define SECLINKIOC_RSADECRYPT                   _SECLINKIOC((SECLINKIOC_CRYPTO | 0x03))
+
+/*  Authenticate */
+#define SECLINKIOC_AUTH                         _SECLINKIOC(0x20)
+#define SECLINKIOC_GENERATERANDOM               _SECLINKIOC((SECLINKIOC_AUTH | 0x00))
+#define SECLINKIOC_GETHASH                      _SECLINKIOC((SECLINKIOC_AUTH | 0x01))
+#define SECLINKIOC_GETHMAC                      _SECLINKIOC((SECLINKIOC_AUTH | 0x02))
+#define SECLINKIOC_RSASIGNMD                    _SECLINKIOC((SECLINKIOC_AUTH | 0x03))
+#define SECLINKIOC_RSAVERIFYMD                  _SECLINKIOC((SECLINKIOC_AUTH | 0x04))
+#define SECLINKIOC_ECDSASIGNMD                  _SECLINKIOC((SECLINKIOC_AUTH | 0x05))
+#define SECLINKIOC_ECDSAVERIFYMD                _SECLINKIOC((SECLINKIOC_AUTH | 0x06))
+#define SECLINKIOC_DHGENERATEPARAM              _SECLINKIOC((SECLINKIOC_AUTH | 0x07))
+#define SECLINKIOC_DHCOMPUTESHAREDSECRET        _SECLINKIOC((SECLINKIOC_AUTH | 0x08))
+#define SECLINKIOC_ECDHCOMPUTESHAREDSECRET      _SECLINKIOC((SECLINKIOC_AUTH | 0x09))
+#define SECLINKIOC_SETCERTIFICATE               _SECLINKIOC((SECLINKIOC_AUTH | 0x0a))
+#define SECLINKIOC_GETCERTIFICATE               _SECLINKIOC((SECLINKIOC_AUTH | 0x0b))
+#define SECLINKIOC_REMOVECERTIFICATE            _SECLINKIOC((SECLINKIOC_AUTH | 0x0c))
+#define SECLINKIOC_GETFACTORY_KEY               _SECLINKIOC((SECLINKIOC_AUTH | 0x0d))
+#define SECLINKIOC_GETFACTORY_CERT              _SECLINKIOC((SECLINKIOC_AUTH | 0x0e))
+#define SECLINKIOC_GETFACTORY_DATA              _SECLINKIOC((SECLINKIOC_AUTH | 0x0f))
+
+/*  Secure Storage */
+#define SECLINKIOC_SS                           _SECLINKIOC(0x40)
+#define SECLINKIOC_WRITESTORAGE                 _SECLINKIOC((SECLINKIOC_SS | 0x00))
+#define SECLINKIOC_READSTORAGE                  _SECLINKIOC((SECLINKIOC_SS | 0x01))
+#define SECLINKIOC_DELETESTORAGE                _SECLINKIOC((SECLINKIOC_SS | 0x02))
+
+/*  Key manager */
+#define SECLINKIOC_KEYMGR                       _SECLINKIOC(0x0080)
+#define SECLINKIOC_SETKEY                       _SECLINKIOC((SECLINKIOC_KEYMGR | 0x0000))
+#define SECLINKIOC_GETKEY                       _SECLINKIOC((SECLINKIOC_KEYMGR | 0x0001))
+#define SECLINKIOC_REMOVEKEY                    _SECLINKIOC((SECLINKIOC_KEYMGR | 0x0002))
+#define SECLINKIOC_GENERATEKEY                  _SECLINKIOC((SECLINKIOC_KEYMGR | 0x0003))
+
+/*
+#define SECLINK_HAL_INIT                         0x0001
+#define SECLINK_HAL_DEINIT                       0x0002
+
+#define SECLINK_KEY                              0x0010
+#define SECLINK_HAL_SETKEY                       0x0011
+#define SECLINK_HAL_GETKEY                       0x0012
+#define SECLINK_HAL_REMOVEKEY                    0x0013
+#define SECLINK_HAL_GENERATEKEY                  0x0014
+
+#define SECLINK_AUTH                             0x0020
+#define SECLINK_HAL_GENERATERANDOM               0x0021
+#define SECLINK_HAL_GETHASH                      0x0022
+#define SECLINK_HAL_GETHMAC                      0x0023
+#define SECLINK_HAL_RSASIGNMD                    0x0024
+#define SECLINK_HAL_RSAVERIFYMD                  0x0025
+#define SECLINK_HAL_ECDSASIGNMD                  0x0026
+#define SECLINK_HAL_ECDSAVERIFYMD                0x0027
+#define SECLINK_HAL_DHGENERATEPARAM              0x0028
+#define SECLINK_HAL_DHCOMPUTESHAREDSECRET        0x0029
+#define SECLINK_HAL_ECDHCOMPUTESHAREDSECRET      0x002a
+#define SECLINK_HAL_SETCERTIFICATE               0x002b
+#define SECLINK_HAL_GETCERTIFICATE               0x002c
+#define SECLINK_HAL_REMOVECERTIFICATE            0x002d
+#define SECLINK_HAL_GETFACTORY_KEY               0x002e
+#define SECLINK_HAL_GETFACTORY_CERT              0x0030
+#define SECLINK_HAL_GETFACTORY_DATA              0x0031
+
+#define SECLINK_CRYPTO                           0x0040
+#define SECLINK_HAL_AESENCRYPT                   0x0041
+#define SECLINK_HAL_AESDECRYPT                   0x0042
+#define SECLINK_HAL_RSAENCRYPT                   0x0043
+#define SECLINK_HAL_RSADECRYPT                   0x0044
+
+#define SECLINK_SS                               0x0080
+#define SECLINK_HAL_WRITESTORAGE                 0x0081
+#define SECLINK_HAL_READSTORAGE                  0x0082
+#define SECLINK_HAL_DELETESTORAGE                0x0083
+*/
+
+struct _seclink_s_;
+typedef struct _seclink_s_ *sl_ctx;
+
+typedef struct _seclink_mempool_s {
+	void *mem;
+	void *mem_priv;
+} seclink_mem;
+
+struct seclink_init_param {
+	uint32_t i2c_port;
+	uint32_t gpio;
+};
+
+struct seclink_key_info {
+	hal_key_type mode;
+	uint32_t key_idx;
+	hal_data *key;
+	hal_data *prikey;
+};
+
+struct seclink_auth_info {
+	union {
+		hal_hash_type hash_type;
+		hal_hmac_type hmac_type;
+		hal_rsa_mode rsa_type;
+		hal_ecdsa_mode ecdsa_type;
+		uint32_t random_len;
+	} auth_type;
+	uint32_t key_idx;
+	hal_data *data;
+	union {
+		hal_data *data;
+		hal_dh_data *dh_param;
+		hal_ecdh_data *ecdh_param
+	} auth_data;
+};
+
+struct seclink_crypto_info {
+	uint32_t key_idx;
+	hal_data *input;
+	hal_data *output;
+	hal_aes_param *aes_param;
+	hal_rsa_mode *rsa_mode;
+};
+
+struct seclink_ss_info {
+	uint32_t key_idx;
+	hal_data *data;
+};
+
+struct seclink_comm_info {
+	uint8_t *priv;
+};
+struct seclink_req {
+	union {
+		struct seclink_key_info *key;
+		struct seclink_auth_info *auth;
+		struct seclink_crypto_info *crypto;
+		struct seclink_ss_info *ss;
+		struct seclink_comm_info *comm;
+	} req_type;
+	struct seclink_init_param *params;
+	int32_t res;
+};
+
+/*  Common */
+int sl_init(sl_ctx *hnd);
+int sl_deinit(sl_ctx hnd);
+
+/*  key manager */
+int sl_set_key(sl_ctx hnd, hal_key_type mode, uint32_t key_idx, hal_data *key, hal_data *prikey);
+
+int sl_get_key(sl_ctx hnd, hal_key_type mode, uint32_t key_idx, _OUT_ hal_data *key);
+
+int sl_remove_key(sl_ctx hnd, hal_key_type mode, uint32_t key_idx);
+
+int sl_generate_key(sl_ctx hnd, hal_key_type mode, uint32_t key_idx);
+
+
+/*  Authenticate */
+int sl_generate_random(sl_ctx hnd, uint32_t len, _OUT_ hal_data *random);
+
+int sl_get_hash(sl_ctx hnd, hal_hash_type mode, hal_data *input, _OUT_ hal_data *hash);
+
+int sl_get_hmac(sl_ctx hnd, hal_hmac_type mode, hal_data *input, uint32_t key_idx, _OUT_ hal_data *hmac);
+
+int sl_rsa_sign_md(sl_ctx hnd, hal_rsa_mode mode, hal_data *hash, uint32_t key_idx, _OUT_ hal_data *sign);
+
+int sl_rsa_verify_md(sl_ctx hnd, hal_rsa_mode mode, hal_data *hash, hal_data *sign, uint32_t key_idx);
+
+int sl_ecdsa_sign_md(sl_ctx hnd, hal_ecdsa_mode mode, hal_data *hash, uint32_t key_idx, _OUT_ hal_data *sign);
+
+int sl_ecdsa_verify_md(sl_ctx hnd, hal_ecdsa_mode mode, hal_data *hash, hal_data *sign, uint32_t key_idx);
+
+int sl_dh_generate_param(sl_ctx hnd, uint32_t dh_idx, _INOUT_ hal_dh_data *dh_param);
+
+int sl_dh_compute_shared_secret(sl_ctx hnd, hal_dh_data *dh_param, uint32_t dh_idx, _OUT_ hal_data *shared_secret);
+
+int sl_ecdh_compute_shared_secret(sl_ctx hnd, hal_ecdh_data *ecdh_mode, uint32_t key_idx, _OUT_ hal_data *shared_secret);
+
+int sl_set_certificate(sl_ctx hnd, uint32_t cert_idx, hal_data *cert_in);
+
+int sl_get_certificate(sl_ctx hnd, uint32_t cert_idx, _OUT_ hal_data *cert_out);
+
+int sl_remove_certificate(sl_ctx hnd, uint32_t cert_idx);
+
+int sl_get_factory_key(sl_ctx hnd, uint32_t key_idx, hal_data *key);
+
+int sl_get_factory_cert(sl_ctx hnd, uint32_t cert_idx, hal_data *cert);
+
+int sl_get_factory_data(sl_ctx hnd, uint32_t data_idx, hal_data *data);
+
+
+/*  Crypto */
+int sl_aes_encrypt(sl_ctx hnd, hal_data *dec_data, hal_aes_param *aes_param, uint32_t key_idx, _OUT_ hal_data *enc_data);
+
+int sl_aes_decrypt(sl_ctx hnd, hal_data *enc_data, hal_aes_param *aes_param, uint32_t key_idx, _OUT_ hal_data *dec_data);
+
+int sl_rsa_encrypt(sl_ctx hnd, hal_data *dec_data, hal_rsa_mode *rsa_mode, uint32_t key_idx, _OUT_ hal_data *enc_data);
+
+int sl_rsa_decrypt(sl_ctx hnd, hal_data *enc_data, hal_rsa_mode *rsa_mode, uint32_t key_idx, _OUT_ hal_data *dec_data);
+
+
+/*  Secure Storage */
+int sl_write_storage(sl_ctx hnd, uint32_t ss_idx, hal_data *data);
+
+int sl_read_storage(sl_ctx hnd, uint32_t ss_idx, _OUT_ hal_data *data);
+
+int sl_delete_storage(sl_ctx hnd, uint32_t ss_idx);
+
+#endif // __SECLINK_H__

--- a/os/include/tinyara/seclink_drv.h
+++ b/os/include/tinyara/seclink_drv.h
@@ -1,0 +1,23 @@
+#ifndef _SECLINK_DRV_H__
+#define _SECLINK_DRV_H__
+
+#include <stdint.h>
+
+struct sec_lowerhalf_s;
+struct sec_upperhalf_s {
+	struct sec_lowerhalf_s *lower;
+	char *path;
+	int32_t refcnt;
+};
+
+struct sec_ops_s;
+struct sec_lowerhalf_s {
+	struct sec_ops_s *ops;
+	struct sec_upperhalf_s *parent;
+};
+
+int se_register(const char *path, struct sec_lowerhalf_s *lower);
+
+int se_unregister(struct sec_lowerhalf_s *lower);
+
+#endif // _SECLINK_DRV_H__

--- a/os/include/tinyara/security_hal.h
+++ b/os/include/tinyara/security_hal.h
@@ -217,7 +217,7 @@ typedef struct _hal_ss_info {
  * Return value: hal_result_e
  * NOTE: Initialize secure channel
  */
-int hal_init(_IN_ hal_init_param *params);
+typedef int (*hal_init)(_IN_ hal_init_param *params);
 
 /*
  * Reference
@@ -225,13 +225,13 @@ int hal_init(_IN_ hal_init_param *params);
  * Return value: hal_result_e
  * NOTE: Deinitialize secure channel
  */
-int hal_deinit(void);
+typedef int (*hal_deinit)(void);
 
 /*
  * Reference
  * Desc: Free memory allocated within HAL 
  */
-int hal_free_data(_IN_ hal_data *data);
+typedef int (*hal_free_data)(_IN_ hal_data *data);
 
 /*
  * Reference
@@ -239,7 +239,7 @@ int hal_free_data(_IN_ hal_data *data);
  * Return value: hal_result_e
  * NOTE: BUSY/IDLE check should be conducted within each HAL APIs as well.
  */
-int hal_get_status(void);
+typedef int (*hal_get_status)(void);
 
 /**
  * Key Manager
@@ -250,7 +250,7 @@ int hal_get_status(void);
  * Return value: hal_result_e
  * Note: If key type is asymmetric then private key can be stored.
  */
-int hal_set_key(_IN_ hal_key_type mode, _IN_ uint32_t key_idx, _IN_ hal_data *key, _IN_ hal_data *prikey);
+typedef int (*hal_set_key)(_IN_ hal_key_type mode, _IN_ uint32_t key_idx, _IN_ hal_data *key, _IN_ hal_data *prikey);
 
 
 /*
@@ -259,7 +259,7 @@ int hal_set_key(_IN_ hal_key_type mode, _IN_ uint32_t key_idx, _IN_ hal_data *ke
  * Return value: hal_result_e
  * NOTE: Return pubkey_X to key->data and pubkey_Y to key->priv for ECC
  */
-int hal_get_key(_IN_ hal_key_type mode, _IN_ uint32_t key_idx, _OUT_ hal_data *key);
+typedef int (*hal_get_key)(_IN_ hal_key_type mode, _IN_ uint32_t key_idx, _OUT_ hal_data *key);
 
 
 /*
@@ -267,7 +267,7 @@ int hal_get_key(_IN_ hal_key_type mode, _IN_ uint32_t key_idx, _OUT_ hal_data *k
  * Desc: Remove key in SE
  * Return value: hal_result_e
  */
-int hal_remove_key(_IN_ hal_key_type mode, _IN_ uint32_t key_idx);
+typedef int (*hal_remove_key)(_IN_ hal_key_type mode, _IN_ uint32_t key_idx);
 
 
 /*
@@ -275,7 +275,7 @@ int hal_remove_key(_IN_ hal_key_type mode, _IN_ uint32_t key_idx);
  * Desc: Generate key in SE
  * Return value: hal_result_e
  */
-int hal_generate_key(_IN_ hal_key_type mode, _IN_ uint32_t key_idx);
+typedef int (*hal_generate_key)(_IN_ hal_key_type mode, _IN_ uint32_t key_idx);
 
 
 /**
@@ -287,14 +287,14 @@ int hal_generate_key(_IN_ hal_key_type mode, _IN_ uint32_t key_idx);
  * Desc: Generate random
  * Return value: hal_result_e
  */
-int hal_generate_random(_IN_ uint32_t len, _OUT_ hal_data *random);
+typedef int (*hal_generate_random)(_IN_ uint32_t len, _OUT_ hal_data *random);
 
 /*
  * Reference
  * Desc: Get HASH
  * Return value: hal_result_e
  */
-int hal_get_hash(_IN_ hal_hash_type mode, _IN_ hal_data *input, _OUT_ hal_data *hash);
+typedef int (*hal_get_hash)(_IN_ hal_hash_type mode, _IN_ hal_data *input, _OUT_ hal_data *hash);
 
 /*
  * Reference
@@ -302,35 +302,35 @@ int hal_get_hash(_IN_ hal_hash_type mode, _IN_ hal_data *input, _OUT_ hal_data *
  * Return value: hal_result_e
  * w
  */
-int hal_get_hmac(_IN_ hal_hmac_type mode, _IN_ hal_data *input, _IN_ uint32_t key_idx, _OUT_ hal_data *hmac);
+typedef int (*hal_get_hmac)(_IN_ hal_hmac_type mode, _IN_ hal_data *input, _IN_ uint32_t key_idx, _OUT_ hal_data *hmac);
 
 /*
  * Reference
  * Desc: Get signature using RSA
  * Return value: hal_result_e
  */
-int hal_rsa_sign_md(_IN_ hal_rsa_mode mode, _IN_ hal_data *hash, _IN_ uint32_t key_idx, _OUT_ hal_data *sign);
+typedef int (*hal_rsa_sign_md)(_IN_ hal_rsa_mode mode, _IN_ hal_data *hash, _IN_ uint32_t key_idx, _OUT_ hal_data *sign);
 
 /*
  * Reference
  * Desc: Verify message digest (signature) using RSA
  * Return value: hal_result_e
  */
-int hal_rsa_verify_md(_IN_ hal_rsa_mode mode, _IN_ hal_data *hash, _IN_ hal_data *sign, _IN_ uint32_t key_idx);
+typedef int (*hal_rsa_verify_md)(_IN_ hal_rsa_mode mode, _IN_ hal_data *hash, _IN_ hal_data *sign, _IN_ uint32_t key_idx);
 
 /*
  * Reference
  * Desc: Get signature using ECC
  * Return value: hal_result_e
  */
-int hal_ecdsa_sign_md(_IN_ hal_data *hash, _IN_ uint32_t key_idx, _INOUT_ hal_ecdsa_mode *mode, _OUT_ hal_data *sign);
+typedef int (*hal_ecdsa_sign_md)(_IN_ hal_data *hash, _IN_ uint32_t key_idx, _INOUT_ hal_ecdsa_mode *mode, _OUT_ hal_data *sign);
 
 /*
  * Reference
  * Desc: Verify message digest (signature) using ECC
  * Return value: hal_result_e
  */
-int hal_ecdsa_verify_md(_IN_ hal_ecdsa_mode mode, _IN_ hal_data *hash, _IN_ hal_data *sign, _IN_ uint32_t key_idx);
+typedef int (*hal_ecdsa_verify_md)(_IN_ hal_ecdsa_mode mode, _IN_ hal_data *hash, _IN_ hal_data *sign, _IN_ uint32_t key_idx);
 
 
 /*
@@ -341,14 +341,14 @@ int hal_ecdsa_verify_md(_IN_ hal_ecdsa_mode mode, _IN_ hal_data *hash, _IN_ hal_
  *       X have to be removed by using hal_remove_key()
  * Return value: hal_result_e
  */
-int hal_dh_generate_param(_IN_ uint32_t dh_idx, _INOUT_ hal_dh_data *dh_param);
+typedef int (*hal_dh_generate_param)(_IN_ uint32_t dh_idx, _INOUT_ hal_dh_data *dh_param);
 
 /*
  * Reference
  * Desc: Compute DH shared secret
  * Return value: hal_result_e
  */
-int hal_dh_compute_shared_secret(_IN_ hal_dh_data *dh_param, _IN_ uint32_t dh_idx, _OUT_ hal_data *shared_secret);
+typedef int (*hal_dh_compute_shared_secret)(_IN_ hal_dh_data *dh_param, _IN_ uint32_t dh_idx, _OUT_ hal_data *shared_secret);
 
 /*
  * Reference
@@ -356,27 +356,27 @@ int hal_dh_compute_shared_secret(_IN_ hal_dh_data *dh_param, _IN_ uint32_t dh_id
  * NOTE: Pubkey denotes a public key from the target which tries to share a secret
  * Return value: hal_result_e
  */
-int hal_ecdh_compute_shared_secret(_IN_ hal_ecdh_data *ecdh_mode, _IN_ uint32_t key_idx, _OUT_ hal_data *shared_secret);
+typedef int (*hal_ecdh_compute_shared_secret)(_IN_ hal_ecdh_data *ecdh_mode, _IN_ uint32_t key_idx, _OUT_ hal_data *shared_secret);
 
 /*
  * Reference
  * Desc: Set certificate in SE
  * Return value: hal_result_e
  */
-int hal_set_certificate(_IN_ uint32_t cert_idx, _IN_ hal_data *cert_in);
+typedef int (*hal_set_certificate)(_IN_ uint32_t cert_idx, _IN_ hal_data *cert_in);
 
 /*
  * Reference
  * Desc: Get certificate in SE
  * Return value: hal_result_e
  */
-int hal_get_certificate(_IN_ uint32_t cert_idx, _OUT_ hal_data *cert_out);
+typedef int (*hal_get_certificate)(_IN_ uint32_t cert_idx, _OUT_ hal_data *cert_out);
 /*
  * Reference
  * Desc: Remove certificate in SE
  * Return value: hal_result_e
  */
-int hal_remove_certificate(_IN_ uint32_t cert_idx);
+typedef int (*hal_remove_certificate)(_IN_ uint32_t cert_idx);
 
 /*
  * Reference
@@ -384,7 +384,7 @@ int hal_remove_certificate(_IN_ uint32_t cert_idx);
  * Return value: hal_result_e
  */
 
-int hal_get_factory_key(_IN_ uint32_t key_idx, _IN_ hal_data *key);
+typedef int (*hal_get_factory_key)(_IN_ uint32_t key_idx, _IN_ hal_data *key);
 /*
  * Reference
  * Desc: Get factory cert
@@ -393,14 +393,15 @@ int hal_get_factory_key(_IN_ uint32_t key_idx, _IN_ hal_data *key);
  * ISP: int isp_get_factorykey2_data(unsigned char *data, unsigned int *data_byte_len, unsigned int data_id);
  * Return value: hal_result_e
  */
-int hal_get_factory_cert(_IN_ uint32_t cert_idx, _IN_ hal_data *cert);
+typedef int (*hal_get_factory_cert)(_IN_ uint32_t cert_idx, _IN_ hal_data *cert);
 
 /*
  * Reference
  * Desc: Get factory data
  * Return value: hal_result_e
  */
-int hal_get_factory_data(_IN_ uint32_t data_idx, _IN_ hal_data *data);
+typedef int (*hal_get_factory_data)(_IN_ uint32_t data_idx, _IN_ hal_data *data);
+
 
 /**
  * Crypto
@@ -411,28 +412,28 @@ int hal_get_factory_data(_IN_ uint32_t data_idx, _IN_ hal_data *data);
  * Desc: Encrypt data using AES
  * Return value: hal_result_e
  */
-int hal_aes_encrypt(_IN_ hal_data *dec_data, _IN_ hal_aes_param *aes_param, _IN_ uint32_t key_idx, _OUT_ hal_data *enc_data);
+typedef int (*hal_aes_encrypt)(_IN_ hal_data *dec_data, _IN_ hal_aes_param *aes_param, _IN_ uint32_t key_idx, _OUT_ hal_data *enc_data);
 
 /*
  * Reference
  * Desc: Decrypt data using AES
  * Return value: hal_result_e
  */
-int hal_aes_decrypt(_IN_ hal_data *enc_data, _IN_ hal_aes_param *aes_param, _IN_ uint32_t key_idx, _OUT_ hal_data *dec_data);
+typedef int (*hal_aes_decrypt)(_IN_ hal_data *enc_data, _IN_ hal_aes_param *aes_param, _IN_ uint32_t key_idx, _OUT_ hal_data *dec_data);
 
 /*
  * Reference
  * Desc: Encrypt data using RSA
  * Return value: hal_result_e
  */
-int hal_rsa_encrypt(_IN_ hal_data *dec_data, _IN_ hal_rsa_mode *mode, _IN_ uint32_t key_idx, _OUT_ hal_data *enc_data);
+typedef int (*hal_rsa_encrypt)(_IN_ hal_data *dec_data, _IN_ hal_rsa_mode *mode, _IN_ uint32_t key_idx, _OUT_ hal_data *enc_data);
 
 /*
  * Reference
  * Desc: Decrypt data using RSA
  * Return value: hal_result_e
  */
-int hal_rsa_decrypt(_IN_ hal_data *enc_data, _IN_ hal_rsa_mode *mode, _IN_ uint32_t key_idx, _OUT_ hal_data *dec_data);
+typedef int (*hal_rsa_decrypt)(_IN_ hal_data *enc_data, _IN_ hal_rsa_mode *mode, _IN_ uint32_t key_idx, _OUT_ hal_data *dec_data);
 
 
 /**
@@ -444,21 +445,55 @@ int hal_rsa_decrypt(_IN_ hal_data *enc_data, _IN_ hal_rsa_mode *mode, _IN_ uint3
  * Desc: Write data in SE
  * Return value: hal_result_e
  */
-int hal_write_storage(_IN_ uint32_t ss_idx, _IN_ hal_data *data);
+typedef int (*hal_write_storage)(_IN_ uint32_t ss_idx, _IN_ hal_data *data);
 
 /*
  * Reference
  * Desc: Read data from SE
  * Return value: hal_result_e
  */
-int hal_read_storage(_IN_ uint32_t ss_idx, _OUT_ hal_data *data);
+typedef int (*hal_read_storage)(_IN_ uint32_t ss_idx, _OUT_ hal_data *data);
 
 /*
  * Reference
- * Desc: Delete data in SE
- * Return value: hal_result_e
+ * Desc: Delete data in secure storage of ss_idx
  */
-int hal_delete_storage(_IN_ uint32_t ss_idx);
+typedef int (*hal_delete_storage)(_IN_ uint32_t ss_idx);
 
+struct sec_ops_s {
+	hal_init init;
+	hal_deinit deinit;
+	hal_free_data free_data;
+	hal_get_status get_status;
+	hal_set_key set_key;
+	hal_get_key get_key;
+	hal_remove_key remove_key;
+	hal_generate_key generate_key;
+	hal_generate_random generate_random;
+	hal_get_hash get_hash;
+	hal_get_hmac get_hmac;
+	hal_rsa_sign_md rsa_sign_md;
+	hal_rsa_verify_md rsa_verify_md;
+	hal_ecdsa_sign_md ecdsa_sign_md;
+	hal_ecdsa_verify_md ecdsa_verify_md;
+	hal_dh_generate_param dh_generate_param;
+	hal_dh_compute_shared_secret dh_compute_shared_secret;
+	hal_ecdh_compute_shared_secret ecdh_compute_shared_secret;
+	hal_set_certificate set_certificate;
+	hal_get_certificate get_certificate;
+	hal_remove_certificate remove_certificate;
+	hal_get_factory_key get_factory_key;
+	hal_get_factory_cert get_factory_cert;
+	hal_get_factory_data get_factory_data;
+	hal_aes_encrypt aes_encrypt;
+	hal_aes_decrypt aes_decrypt;
+	hal_rsa_encrypt rsa_encrypt;
+	hal_rsa_decrypt rsa_decrypt;
+	hal_write_storage write_storage;
+	hal_read_storage read_storage;
+	hal_delete_storage delete_storage;
+};
+
+int se_initialize(void);
 
 #endif // __SECURITY_HAL_H__

--- a/os/kernel/init/os_bringup.c
+++ b/os/kernel/init/os_bringup.c
@@ -239,6 +239,10 @@ static inline void os_do_appstart(void)
 	board_initialize();
 #endif
 
+#ifdef CONFIG_SE
+	se_initialize();
+#endif
+
 #ifdef CONFIG_NET
 	/* Initialize the network system & Create network task if required */
 

--- a/os/se/Kconfig
+++ b/os/se/Kconfig
@@ -1,0 +1,42 @@
+#
+# For a description of the syntax of this configuration file,
+# see kconfig-language at https://www.kernel.org/doc/Documentation/kbuild/kconfig-language.txt
+#
+
+config SE
+	bool "Enable embedded SE"
+
+if SE
+choice
+	prompt "SE selection"
+	default SE_SSS
+
+config SE_SSS
+	bool "Samsung SSS"
+	---help---
+		Samsung SE chip
+
+config SE_KONAI
+	bool "KONAI"
+	---help---
+		KONAI SE chip
+
+config SE_VIRTUAL
+	bool "Virtual SE chip"
+	---help---
+		Enable Virtual SE chip for testing
+endchoice
+
+if SE_SSS
+source se/sss/Kconfig
+endif
+
+if SE_KONAI
+source se/konai/Kconfig
+endif
+
+if SE_VIRTUAL
+source se/virtual/Kconfig
+endif
+
+endif

--- a/os/se/Makefile
+++ b/os/se/Makefile
@@ -1,0 +1,92 @@
+############################################################################
+#
+# Copyright 2019 Samsung Electronics All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+#
+############################################################################
+
+# -include $(TOPDIR)/.config
+-include $(TOPDIR)/Make.defs
+
+DEPPATH = --dep-path .
+SE_PATH		=
+SE_CSRCS	=
+SE_SRCS		=
+SE_LIB 	=
+SE_LIB_OBJS =
+VPATH = .
+
+CFLAGS += -I$(TOPDIR)/../external/include/security/hal/
+
+SE_DIRS   := $(dir $(wildcard */Make.defs))
+
+define ADD_SE_MAKE_DEF
+  include $(1)Make.defs
+endef
+
+$(foreach SDIR, $(SE_DIRS), $(eval $(call ADD_SE_MAKE_DEF, $(SDIR))))
+
+ifneq ($(SE_CSRCS),)
+SE_SRCS = $(addprefix $(SE_PATH)/, $(SE_CSRCS))
+endif
+
+ifneq ($(SE_LIB_GEN),)
+SE_LIB_SRCS = $(addprefix $(SE_PATH)/, $(SE_LIB_GEN))
+SE_LIB_OBJS = $(SE_LIB_SRCS:.c=$(OBJEXT))
+SE_SRCS += $(SE_LIB_SRCS)
+endif
+
+ifneq ($(SE_LIB),)
+SE_LIB_NAME=$(patsubst %$(LIBEXT), %_$(CONFIG_ARCH)$(LIBEXT), $(SE_LIB))
+endif
+
+SE_OBJS = $(SE_SRCS:.c=$(OBJEXT))
+SE_BIN	= libse$(LIBEXT)
+
+all: $(SE_BIN)
+.PHONY: depend clean distclean
+
+$(SE_LIB_OUT):
+	$(call ARCHIVE, $(patsubst %$(LIBEXT), %_$(CONFIG_ARCH)$(LIBEXT), $@), $(SE_LIB_OBJS))
+	$(Q) $(CROSSDEV)strip -d $(patsubst %$(LIBEXT), %_$(CONFIG_ARCH)$(LIBEXT), $@)
+
+$(SE_LIB):
+ifneq (, $(wildcard $(addprefix $(SE_PATH)/, $(SE_LIB_NAME))))
+	$(Q) cp $(addprefix $(SE_PATH)/, $(SE_LIB_NAME)) $(SE_BIN)
+else
+	$(error "$(addprefix $(SE_PATH)/, $(SE_LIB_NAME)) should exist to build SE.")
+endif
+	
+$(SE_OBJS): %$(OBJEXT): %.c
+	$(call COMPILE, $<, $@)
+
+$(SE_BIN): $(SE_LIB) $(SE_OBJS) $(SE_LIB_OUT)
+	$(call ARCHIVE, $@, $(SE_OBJS))
+
+.depend: Makefile $(SE_SRCS)
+	$(Q) $(MKDEP) $(DEPPATH) "$(CC)" -- $(CFLAGS) -- $(SE_SRCS) >Make.dep
+	$(Q) touch $@
+
+depend: .depend
+
+clean:
+	$(call DELFILE, $(SE_BIN))
+	$(call CLEAN)
+	$(Q) find . -name "*.o" -exec rm -rf {} \;
+
+distclean: clean
+	$(call DELFILE, Make.dep)
+	$(call DELFILE, .depend)
+
+-include Make.dep

--- a/os/se/Makefile
+++ b/os/se/Makefile
@@ -19,12 +19,13 @@
 # -include $(TOPDIR)/.config
 -include $(TOPDIR)/Make.defs
 
-DEPPATH = --dep-path .
-SE_PATH		=
+SE_PATH	=
 SE_CSRCS	=
-SE_SRCS		=
-SE_LIB 	=
-SE_LIB_OBJS =
+SE_SRCS	=
+SE_LIB	=
+SE_LIB_OBJS	=
+
+DEPPATH = --dep-path .
 VPATH = .
 
 CFLAGS += -I$(TOPDIR)/../external/include/security/hal/
@@ -67,7 +68,7 @@ ifneq (, $(wildcard $(addprefix $(SE_PATH)/, $(SE_LIB_NAME))))
 else
 	$(error "$(addprefix $(SE_PATH)/, $(SE_LIB_NAME)) should exist to build SE.")
 endif
-	
+
 $(SE_OBJS): %$(OBJEXT): %.c
 	$(call COMPILE, $<, $@)
 

--- a/os/se/konai/Kconfig
+++ b/os/se/konai/Kconfig
@@ -11,4 +11,3 @@ config HW_RSA_ENC
 	---help---
 		Encrypts a data based on hardware.
 		Supporting key size : 1024, 2048
-		

--- a/os/se/konai/Kconfig
+++ b/os/se/konai/Kconfig
@@ -1,0 +1,14 @@
+config HW_RNG
+	bool "HW RNG"
+	default n
+	---help---
+		Supports true random generator by hardware
+		Maximum random size is 256 bytes at one time.
+
+config HW_RSA_ENC
+	bool "HW rsa encryption"
+	default n
+	---help---
+		Encrypts a data based on hardware.
+		Supporting key size : 1024, 2048
+		

--- a/os/se/konai/Make.defs
+++ b/os/se/konai/Make.defs
@@ -1,0 +1,59 @@
+###########################################################################
+#
+# Copyright 2019 Samsung Electronics All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+#
+###########################################################################
+############################################################################
+# se/konai/Make.defs
+#
+#   Copyright (C) 2013-2014 Gregory Nutt. All rights reserved.
+#   Author: Gregory Nutt <gnutt@nuttx.org>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in
+#    the documentation and/or other materials provided with the
+#    distribution.
+# 3. Neither the name Gregory Nutt nor the names of its contributors may be
+#    used to endorse or promote products derived from this software
+#    without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+# OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+# AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+############################################################################
+
+ifeq ($(CONFIG_SE_KONAI),y)
+SE_PATH = konai
+SE_CSRCS =
+SE_LIB =
+SE_LIB_GEN = konai.c
+SE_LIB_OUT = libkonai.a
+endif

--- a/os/se/konai/konai.c
+++ b/os/se/konai/konai.c
@@ -1,0 +1,227 @@
+/****************************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <tinyara/security_hal.h>
+#define _IN_
+#define _OUT_
+#define _INOUT_
+
+//NOTE: THIS FILE IS AN EMPTY SHELL.
+int hal_free_data(_IN_ hal_data *data)
+{
+	if(data) {
+		if(data->data) {
+			free(data->data);
+		}
+	}
+	return 0;
+}
+
+int hal_get_status(void)
+{
+	return 0;
+}
+
+/**
+ * Key Manager
+ */
+int hal_set_key(_IN_ hal_key_type mode, _IN_ uint32_t key_idx, _IN_ hal_data *key, _IN_ hal_data *prikey)
+{
+	return 0;
+}
+
+int hal_get_key(_IN_ hal_key_type mode, _IN_ uint32_t key_idx, _OUT_ hal_data *key)
+{
+	return 0;
+}
+
+int hal_remove_key(_IN_ hal_key_type mode, _IN_ uint32_t key_idx)
+{
+	return 0;
+}
+
+int hal_generate_key(_IN_ hal_key_type mode, _IN_ uint32_t key_idx)
+{
+	return 0;
+}
+
+/**
+ * Authenticate
+ */
+int hal_generate_random(_IN_ uint32_t len, _OUT_ hal_data *random)
+{
+	return 0;
+}
+
+int hal_get_hash(_IN_ hal_hash_type mode, _IN_ hal_data *input, _OUT_ hal_data *hash)
+{
+	return 0;
+}
+
+int hal_get_hmac(_IN_ hal_hmac_type mode, _IN_ hal_data *input, _IN_ uint32_t key_idx, _OUT_ hal_data *hmac)
+{
+	return 0;
+}
+
+int hal_rsa_sign_md(_IN_ hal_rsa_mode mode, _IN_ hal_data *hash, _IN_ uint32_t key_idx, _OUT_ hal_data *sign)
+{
+	return 0;
+}
+
+int hal_rsa_verify_md(_IN_ hal_rsa_mode mode, _IN_ hal_data *hash, _IN_ hal_data *sign, _IN_ uint32_t key_idx)
+{
+	return 0;
+}
+
+int hal_ecdsa_sign_md(_IN_ hal_data *hash, _IN_ uint32_t key_idx, _INOUT_ hal_ecdsa_mode *mode, _OUT_ hal_data *sign)
+{
+	return 0;
+}
+
+int hal_ecdsa_verify_md(_IN_ hal_ecdsa_mode mode, _IN_ hal_data *hash, _IN_ hal_data *sign, _IN_ uint32_t key_idx)
+{
+	return 0;
+}
+
+int hal_dh_generate_param(_IN_ uint32_t dh_idx, _INOUT_ hal_dh_data *dh_param)
+{
+	return 0;
+}
+
+int hal_dh_compute_shared_secret(_IN_ hal_dh_data *dh_param, _IN_ uint32_t dh_idx, _OUT_ hal_data *shared_secret)
+{
+	return 0;
+}
+
+int hal_ecdh_compute_shared_secret(_IN_ hal_ecdh_data *ecdh_mode, _IN_ uint32_t key_idx, _OUT_ hal_data *shared_secret)
+{
+	return 0;
+}
+
+static hal_data cert_s;
+int hal_set_certificate(_IN_ uint32_t cert_idx, _IN_ hal_data *cert_in)
+{
+	cert_s.data = (unsigned char *)malloc(cert_in->data_len);
+	memcpy(cert_s.data, cert_in->data, cert_in->data_len);
+	cert_s.data_len = cert_in->data_len;
+
+	return 0;
+}
+
+int hal_get_certificate(_IN_ uint32_t cert_idx, _OUT_ hal_data *cert_out)
+{
+	cert_out->data = (unsigned char *)malloc(cert_s.data_len);
+	memcpy(cert_out->data, cert_s.data, cert_s.data_len);
+	cert_out->data_len = cert_s.data_len;
+
+	return 0;
+}
+
+int hal_remove_certificate(_IN_ uint32_t cert_idx)
+{
+	free(cert_s.data);
+	cert_s.data_len = 0;
+
+	return 0;
+}
+
+static hal_data factory_s = {"factory", 7, NULL};
+int hal_get_factory_key(_IN_ uint32_t key_idx, _IN_ hal_data *key)
+{
+	key->data = (unsigned char *)malloc(7);
+	memcpy(key->data, factory_s.data, 7);
+
+	return 0;
+}
+
+int hal_get_factory_cert(_IN_ uint32_t cert_idx, _IN_ hal_data *cert)
+{
+	cert->data = (unsigned char *)malloc(7);
+	memcpy(cert->data, factory_s.data, 7);
+
+	return 0;
+}
+
+int hal_get_factory_data(_IN_ uint32_t data_idx, _IN_ hal_data *data)
+{
+	data->data = (unsigned char *)malloc(7);
+	memcpy(data->data, factory_s.data, 7);
+
+	return 0;
+}
+
+/**
+ * Crypto
+ */
+int hal_aes_encrypt(_IN_ hal_data *dec_data, _IN_ hal_aes_param *aes_param, _IN_ uint32_t key_idx, _OUT_ hal_data *enc_data)
+{
+	enc_data->data = (unsigned char *)malloc(dec_data->data_len);
+	memcpy(enc_data->data, dec_data->data,dec_data->data_len);
+	enc_data->data_len = dec_data->data_len;
+
+	return 0;
+}
+
+int hal_aes_decrypt(_IN_ hal_data *enc_data, _IN_ hal_aes_param *aes_param, _IN_ uint32_t key_idx, _OUT_ hal_data *dec_data)
+{
+	dec_data->data = (unsigned char *)malloc(enc_data->data_len);
+	memcpy(dec_data->data, enc_data->data,enc_data->data_len);
+	dec_data->data_len = enc_data->data_len;
+
+	return 0;
+}
+
+int hal_rsa_encrypt(_IN_ hal_data *dec_data, _IN_ hal_rsa_mode *mode, _IN_ uint32_t key_idx, _OUT_ hal_data *enc_data)
+{
+	enc_data->data = (unsigned char *)malloc(dec_data->data_len);
+	memcpy(enc_data->data, dec_data->data,dec_data->data_len);
+	enc_data->data_len = dec_data->data_len;
+
+	return 0;
+}
+int hal_rsa_decrypt(_IN_ hal_data *enc_data, _IN_ hal_rsa_mode *mode, _IN_ uint32_t key_idx, _OUT_ hal_data *dec_data)
+{
+	dec_data->data = (unsigned char *)malloc(enc_data->data_len);
+	memcpy(dec_data->data, enc_data->data,enc_data->data_len);
+	dec_data->data_len = enc_data->data_len;
+
+	return 0;
+}
+
+/**
+ * Secure Storage
+ */
+int hal_write_storage(_IN_ uint32_t ss_idx, _IN_ hal_data *data)
+{
+	return 0;
+}
+
+int hal_read_storage(_IN_ uint32_t ss_idx, _OUT_ hal_data *data)
+{
+	return 0;
+}
+
+int hal_delete_storage(_IN_ uint32_t ss_idx)
+{
+	return 0;
+}

--- a/os/se/konai/mbed_port/config.h
+++ b/os/se/konai/mbed_port/config.h
@@ -1,0 +1,3 @@
+#include <stdio.h>
+
+#define CONFIG_NAME "konai"

--- a/os/se/sss/Kconfig
+++ b/os/se/sss/Kconfig
@@ -1,0 +1,52 @@
+config HW_RNG
+	bool "HW RNG"
+	default n
+	---help---
+		Supports true random generator by hardware
+		Maximum random size is 256 bytes at one time.
+
+config HW_DH_PARAM
+	bool "HW supports DH params"
+	default n
+	---help---
+		Generates and caculates diffie-hellman parameter with hardware.
+		Supporting parameter size : 1024, 2048
+
+config HW_ECDH_PARAM
+	bool "HW supports ECDH params"
+	default n
+	---help---
+		Generates and caculates eliptic curve params with hardware.
+                Supporting curves :
+		 . SECP 192, 224, 256, 384, 512
+		 . Brainpool 256
+
+config HW_RSA_VERIFICATION
+	bool "HW rsa verification"
+	default n
+	---help---
+		Verifing a RSA signature based on hardware.
+		Supporting key size : 1024, 2048
+
+config HW_ECDSA_VERIFICATION
+	bool "HW ecdsa verification"
+	default n
+	---help---
+		Verifing a ECDSA signature based on hardware.
+		Supporting curves :
+		 . SECP 192, 224, 256, 384, 512
+		 . Brainpool 256
+
+config HW_RSA_ENC
+	bool "HW rsa encryption"
+	default n
+	---help---
+		Encrypts a data based on hardware.
+		Supporting key size : 1024, 2048
+
+config SE_STORAGE
+	bool "Secure Storage Support"
+	default n
+	---help---
+		SE supports Secure Stroage
+		

--- a/os/se/sss/Make.defs
+++ b/os/se/sss/Make.defs
@@ -1,0 +1,58 @@
+###########################################################################
+#
+# Copyright 2019 Samsung Electronics All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+#
+###########################################################################
+############################################################################
+# se/sss/Make.defs
+#
+#   Copyright (C) 2013-2014 Gregory Nutt. All rights reserved.
+#   Author: Gregory Nutt <gnutt@nuttx.org>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in
+#    the documentation and/or other materials provided with the
+#    distribution.
+# 3. Neither the name Gregory Nutt nor the names of its contributors may be
+#    used to endorse or promote products derived from this software
+#    without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+# OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+# AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+############################################################################
+
+ifeq ($(CONFIG_SE_SSS),y)
+SE_PATH = sss
+SE_CSRCS = security_hal_wrapper.c
+SE_LIB_GEN =
+SE_LIB_OUT =
+endif

--- a/os/se/sss/Make.defs
+++ b/os/se/sss/Make.defs
@@ -55,4 +55,5 @@ SE_PATH = sss
 SE_CSRCS = security_hal_wrapper.c
 SE_LIB_GEN =
 SE_LIB_OUT =
+CFLAGS += -I$(TOPDIR)/arch/arm/src/s5j/sss/
 endif

--- a/os/se/sss/security_hal_wrapper.c
+++ b/os/se/sss/security_hal_wrapper.c
@@ -41,12 +41,12 @@
  */
 
 #include <tinyara/config.h>
+#include <tinyara/seclink_drv.h>
 #include <tinyara/security_hal.h>
 
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-
 #include "isp_custom.h"
 
 #define ISP_CHECKBUSY() while (isp_get_status()) {}

--- a/os/se/sss/security_hal_wrapper.c
+++ b/os/se/sss/security_hal_wrapper.c
@@ -480,19 +480,19 @@ static int hal_asn1_get_mpi(unsigned char **p, const unsigned char *end, hal_mpi
 /**
  * Common
  */
-int hal_init(hal_init_param *params)
+int sss_hal_init(hal_init_param *params)
 {
 	HWRAP_ENTER;
 	return HAL_NOT_SUPPORTED;
 }
 
-int hal_deinit(void)
+int sss_hal_deinit(void)
 {
 	HWRAP_ENTER;
 	return HAL_NOT_SUPPORTED;
 }
 
-int hal_free_data(hal_data *data)
+int sss_hal_free_data(hal_data *data)
 {
 	HWRAP_ENTER;
 	if (data) {
@@ -507,7 +507,7 @@ int hal_free_data(hal_data *data)
 
 }
 
-int hal_get_status(void)
+int sss_hal_get_status(void)
 {
 	HWRAP_ENTER;
 	return isp_get_status();
@@ -516,7 +516,7 @@ int hal_get_status(void)
 /**
  * Key Manager
  */
-int hal_set_key(hal_key_type mode, uint32_t key_idx, hal_data *key, hal_data *prikey)
+int sss_hal_set_key(hal_key_type mode, uint32_t key_idx, hal_data *key, hal_data *prikey)
 {
 	HWRAP_ENTER;
 	if (prikey != NULL) {
@@ -574,7 +574,7 @@ int hal_set_key(hal_key_type mode, uint32_t key_idx, hal_data *key, hal_data *pr
 	return HAL_SUCCESS;
 }
 
-int hal_get_key(hal_key_type mode, uint32_t key_idx, hal_data *key)
+int sss_hal_get_key(hal_key_type mode, uint32_t key_idx, hal_data *key)
 {
 	HWRAP_ENTER;
 	uint32_t ret;
@@ -644,7 +644,7 @@ int hal_get_key(hal_key_type mode, uint32_t key_idx, hal_data *key)
 	return HAL_SUCCESS;
 }
 
-static int hal_get_key_type(hal_key_type mode, unsigned int *key_type)
+static int _hal_get_key_type(hal_key_type mode, unsigned int *key_type)
 {
 	switch (mode) {
 	case HAL_KEY_AES_128:
@@ -687,13 +687,13 @@ static int hal_get_key_type(hal_key_type mode, unsigned int *key_type)
 	return HAL_SUCCESS;
 }
 
-int hal_remove_key(hal_key_type mode, uint32_t key_idx)
+int sss_hal_remove_key(hal_key_type mode, uint32_t key_idx)
 {
 	HWRAP_ENTER;
 	unsigned int key_type;
 	uint32_t ret;
 
-	ret = hal_get_key_type(mode, &key_type);
+	ret = _hal_get_key_type(mode, &key_type);
 	if (ret != HAL_SUCCESS) {
 		return ret;
 	}
@@ -706,7 +706,7 @@ int hal_remove_key(hal_key_type mode, uint32_t key_idx)
 	return HAL_SUCCESS;
 }
 
-int hal_generate_key(hal_key_type mode, uint32_t key_idx)
+int sss_hal_generate_key(hal_key_type mode, uint32_t key_idx)
 {
 	HWRAP_ENTER;
 	uint32_t ret;
@@ -788,7 +788,7 @@ int hal_generate_key(hal_key_type mode, uint32_t key_idx)
  * Authenticate
  */
 
-int hal_generate_random(uint32_t len, hal_data *random)
+int sss_hal_generate_random(uint32_t len, hal_data *random)
 {
 	HWRAP_ENTER;
 	uint32_t ret;
@@ -815,7 +815,7 @@ int hal_generate_random(uint32_t len, hal_data *random)
 	return HAL_SUCCESS;
 }
 
-int hal_get_hash(hal_hash_type mode, hal_data *input, hal_data *hash)
+int sss_hal_get_hash(hal_hash_type mode, hal_data *input, hal_data *hash)
 {
 	HWRAP_ENTER;
 	uint32_t ret;
@@ -865,14 +865,14 @@ int hal_get_hash(hal_hash_type mode, hal_data *input, hal_data *hash)
 	return HAL_SUCCESS;
 }
 
-int hal_get_hmac(hal_hmac_type mode, hal_data *input, uint32_t key_idx, hal_data *hmac)
+int sss_hal_get_hmac(hal_hmac_type mode, hal_data *input, uint32_t key_idx, hal_data *hmac)
 {
 	HWRAP_ENTER;
 
 	return HAL_NOT_SUPPORTED;
 }
 
-int hal_rsa_sign_md(hal_rsa_mode mode, hal_data *hash, uint32_t key_idx, hal_data *sign)
+int sss_hal_rsa_sign_md(hal_rsa_mode mode, hal_data *hash, uint32_t key_idx, hal_data *sign)
 {
 	HWRAP_ENTER;
 	uint32_t ret;
@@ -924,7 +924,7 @@ int hal_rsa_sign_md(hal_rsa_mode mode, hal_data *hash, uint32_t key_idx, hal_dat
 	return HAL_SUCCESS;
 }
 
-int hal_rsa_verify_md(hal_rsa_mode mode, hal_data *hash, hal_data *sign, uint32_t key_idx)
+int sss_hal_rsa_verify_md(hal_rsa_mode mode, hal_data *hash, hal_data *sign, uint32_t key_idx)
 {
 	HWRAP_ENTER;
 	uint32_t ret;
@@ -969,7 +969,7 @@ int hal_rsa_verify_md(hal_rsa_mode mode, hal_data *hash, hal_data *sign, uint32_
 	return HAL_SUCCESS;
 }
 
-int hal_ecdsa_sign_md(hal_data *hash, uint32_t key_idx, hal_ecdsa_mode *mode, hal_data *sign)
+int sss_hal_ecdsa_sign_md(hal_data *hash, uint32_t key_idx, hal_ecdsa_mode *mode, hal_data *sign)
 {
 	HWRAP_ENTER;
 	uint32_t ret;
@@ -1060,7 +1060,7 @@ cleanup:
 	return HAL_FAIL;
 }
 
-int hal_ecdsa_verify_md(hal_ecdsa_mode mode, hal_data *hash, hal_data *sign, uint32_t key_idx)
+int sss_hal_ecdsa_verify_md(hal_ecdsa_mode mode, hal_data *hash, hal_data *sign, uint32_t key_idx)
 {
 	HWRAP_ENTER;
 	uint32_t ret;
@@ -1167,7 +1167,7 @@ cleanup:
 	return ret;
 }
 
-int hal_dh_generate_param(uint32_t dh_idx, hal_dh_data *dh_param)
+int sss_hal_dh_generate_param(uint32_t dh_idx, hal_dh_data *dh_param)
 {
 	HWRAP_ENTER;
 	uint32_t ret;
@@ -1218,7 +1218,7 @@ int hal_dh_generate_param(uint32_t dh_idx, hal_dh_data *dh_param)
 	return HAL_SUCCESS;
 }
 
-int hal_dh_compute_shared_secret(hal_dh_data *dh_param, uint32_t dh_idx, hal_data *shared_secret)
+int sss_hal_dh_compute_shared_secret(hal_dh_data *dh_param, uint32_t dh_idx, hal_data *shared_secret)
 {
 	HWRAP_ENTER;
 	uint32_t ret;
@@ -1256,7 +1256,7 @@ int hal_dh_compute_shared_secret(hal_dh_data *dh_param, uint32_t dh_idx, hal_dat
 	return HAL_SUCCESS;
 }
 
-int hal_ecdh_compute_shared_secret(hal_ecdh_data *ecdh_param, uint32_t key_idx, hal_data *shared_secret)
+int sss_hal_ecdh_compute_shared_secret(hal_ecdh_data *ecdh_param, uint32_t key_idx, hal_data *shared_secret)
 {
 	HWRAP_ENTER;
 	uint32_t ret;
@@ -1308,7 +1308,7 @@ int hal_ecdh_compute_shared_secret(hal_ecdh_data *ecdh_param, uint32_t key_idx, 
 	return HAL_SUCCESS;
 }
 
-int hal_set_certificate(uint32_t cert_idx, hal_data *cert_in)
+int sss_hal_set_certificate(uint32_t cert_idx, hal_data *cert_in)
 {
 	HWRAP_ENTER;
 	uint32_t ret;
@@ -1326,7 +1326,7 @@ int hal_set_certificate(uint32_t cert_idx, hal_data *cert_in)
 	return HAL_SUCCESS;
 }
 
-int hal_get_certificate(uint32_t cert_idx, hal_data *cert_out)
+int sss_hal_get_certificate(uint32_t cert_idx, hal_data *cert_out)
 {
 	HWRAP_ENTER;
 	uint32_t ret;
@@ -1355,13 +1355,13 @@ int hal_get_certificate(uint32_t cert_idx, hal_data *cert_out)
 	return HAL_SUCCESS;
 }
 
-int hal_remove_certificate(uint32_t cert_idx)
+int sss_hal_remove_certificate(uint32_t cert_idx)
 {
 	HWRAP_ENTER;
 	return HAL_NOT_SUPPORTED;
 }
 
-int hal_get_factory_key(uint32_t key_idx, hal_data *key)
+int sss_hal_get_factory_key(uint32_t key_idx, hal_data *key)
 {
 	HWRAP_ENTER;
 	uint32_t ret;
@@ -1380,7 +1380,7 @@ int hal_get_factory_key(uint32_t key_idx, hal_data *key)
 	return HAL_SUCCESS;
 }
 
-int hal_get_factory_cert(uint32_t cert_idx, hal_data *cert)
+int sss_hal_get_factory_cert(uint32_t cert_idx, hal_data *cert)
 {
 	HWRAP_ENTER;
 	uint32_t ret;
@@ -1399,7 +1399,7 @@ int hal_get_factory_cert(uint32_t cert_idx, hal_data *cert)
 	return HAL_SUCCESS;
 }
 
-int hal_get_factory_data(uint32_t data_idx, hal_data *data)
+int sss_hal_get_factory_data(uint32_t data_idx, hal_data *data)
 {
 	HWRAP_ENTER;
 	return HAL_NOT_SUPPORTED;
@@ -1410,7 +1410,7 @@ int hal_get_factory_data(uint32_t data_idx, hal_data *data)
  * Crypto
  */
 
-int hal_aes_encrypt(hal_data *dec_data, hal_aes_param *aes_param, uint32_t key_idx, hal_data *enc_data)
+int sss_hal_aes_encrypt(hal_data *dec_data, hal_aes_param *aes_param, uint32_t key_idx, hal_data *enc_data)
 {
 	HWRAP_ENTER;
 	uint32_t ret;
@@ -1458,7 +1458,7 @@ int hal_aes_encrypt(hal_data *dec_data, hal_aes_param *aes_param, uint32_t key_i
 	return HAL_SUCCESS;
 }
 
-int hal_aes_decrypt(hal_data *enc_data, hal_aes_param *aes_param, uint32_t key_idx, hal_data *dec_data)
+int sss_hal_aes_decrypt(hal_data *enc_data, hal_aes_param *aes_param, uint32_t key_idx, hal_data *dec_data)
 {
 	HWRAP_ENTER;
 	uint32_t ret;
@@ -1506,7 +1506,7 @@ int hal_aes_decrypt(hal_data *enc_data, hal_aes_param *aes_param, uint32_t key_i
 	return HAL_SUCCESS;
 }
 
-int hal_rsa_encrypt(hal_data *dec_data, hal_rsa_mode *rsa_mode, uint32_t key_idx, hal_data *enc_data)
+int sss_hal_rsa_encrypt(hal_data *dec_data, hal_rsa_mode *rsa_mode, uint32_t key_idx, hal_data *enc_data)
 {
 	HWRAP_ENTER;
 	uint32_t ret;
@@ -1525,7 +1525,7 @@ int hal_rsa_encrypt(hal_data *dec_data, hal_rsa_mode *rsa_mode, uint32_t key_idx
 	return HAL_SUCCESS;
 }
 
-int hal_rsa_decrypt(hal_data *enc_data, hal_rsa_mode *rsa_mode, uint32_t key_idx, hal_data *dec_data)
+int sss_hal_rsa_decrypt(hal_data *enc_data, hal_rsa_mode *rsa_mode, uint32_t key_idx, hal_data *dec_data)
 {
 	HWRAP_ENTER;
 	uint32_t ret;
@@ -1547,7 +1547,7 @@ int hal_rsa_decrypt(hal_data *enc_data, hal_rsa_mode *rsa_mode, uint32_t key_idx
  * Secure Storage
  */
 
-int hal_write_storage(uint32_t ss_idx, hal_data *data)
+int sss_hal_write_storage(uint32_t ss_idx, hal_data *data)
 {
 	HWRAP_ENTER;
 	uint32_t ret;
@@ -1563,7 +1563,7 @@ int hal_write_storage(uint32_t ss_idx, hal_data *data)
 	return HAL_SUCCESS;
 }
 
-int hal_read_storage(uint32_t ss_idx, hal_data *data)
+int sss_hal_read_storage(uint32_t ss_idx, hal_data *data)
 {
 	HWRAP_ENTER;
 	uint32_t ret;
@@ -1582,7 +1582,7 @@ int hal_read_storage(uint32_t ss_idx, hal_data *data)
 	return HAL_SUCCESS;
 }
 
-int hal_delete_storage(uint32_t ss_idx)
+int sss_hal_delete_storage(uint32_t ss_idx)
 {
 	HWRAP_ENTER;
 	return HAL_NOT_SUPPORTED;
@@ -1635,4 +1635,3 @@ int se_initialize(void)
 
 	return 0;
 }
-

--- a/os/se/virtual/Kconfig
+++ b/os/se/virtual/Kconfig
@@ -1,0 +1,13 @@
+config HW_RNG
+	bool "HW RNG"
+	default n
+	---help---
+		Supports true random generator by hardware
+		Maximum random size is 256 bytes at one time.
+
+config HW_RSA_ENC
+	bool "HW rsa encryption"
+	default n
+	---help---
+		Encrypts a data based on hardware.
+		Supporting key size : 1024, 2048

--- a/os/se/virtual/Make.defs
+++ b/os/se/virtual/Make.defs
@@ -1,0 +1,23 @@
+###########################################################################
+#
+# Copyright 2019 Samsung Electronics All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+#
+###########################################################################
+
+ifeq ($(CONFIG_SE_VIRTUAL),y)
+SE_PATH = virtual
+SE_CSRCS += hal_virtual.c
+#SE_LIB += libkonai.a
+endif

--- a/os/se/virtual/hal_virtual.c
+++ b/os/se/virtual/hal_virtual.c
@@ -1,0 +1,379 @@
+/****************************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+#include <tinyara/config.h>
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <tinyara/seclink_drv.h>
+#include <tinyara/security_hal.h>
+
+#define _IN_
+#define _OUT_
+#define _INOUT_
+
+#define VH_TAG "[VH]"
+
+#define VH_LOG printf
+
+#define VH_ENTER														\
+	do {																\
+		VH_LOG(VH_TAG"[INFO] %s %s:%d\n", __FUNCTION__, __FILE__, __LINE__ ); \
+	} while (0)
+
+#define VH_ERR(fd)														\
+	do {																\
+		VH_LOG("[ERR:%s] %s %s:%d ret(%d) code(%s)\n",					\
+			   VH_TAG, __FUNCTION__, __FILE__, __LINE__, fd); \
+	} while(0)
+
+#define SECLINK_PATH "/dev/seclink"
+
+/**
+ * Common
+ */
+//NOTE: THIS FILE IS AN EMPTY SHELL.
+int virtual_hal_free_data(_IN_ hal_data *data)
+{
+	if(data) {
+		if(data->data) {
+			free(data->data);
+		}
+	}
+	return 0;
+}
+
+int virtual_hal_get_status(void)
+{
+	return 0;
+}
+
+int virtual_hal_init(_IN_ hal_init_param *params)
+{
+	VH_ENTER;
+
+	return 0;
+}
+
+int virtual_hal_deinit(void)
+{
+	VH_ENTER;
+
+	return 0;
+}
+
+
+/**
+ * Key Manager
+ */
+int virtual_hal_set_key(_IN_ hal_key_type mode, _IN_ uint32_t key_idx, _IN_ hal_data *key, _IN_ hal_data *prikey)
+{
+	VH_ENTER;
+	VH_LOG("mode(%d) key index(%d) key(%p) private key(%p)\n", mode, key_idx, key, prikey);
+
+	return 0;
+}
+
+int virtual_hal_get_key(_IN_ hal_key_type mode, _IN_ uint32_t key_idx, _OUT_ hal_data *key)
+{
+	VH_ENTER;
+
+	VH_LOG("mode(%d) key index(%d) key(%p)\n", mode, key_idx, key);
+
+	// return dummy key data to check data is sent well.
+	uint8_t pubkey_data[] = {"hal_key_sssssssssssstttttttttt"};
+	key->data_len = sizeof(pubkey_data);
+	uint8_t *data = (uint8_t *)malloc(key->data_len);
+	if (!data) {
+		return -1;
+	}
+
+	memcpy(data, pubkey_data, key->data_len);
+
+	key->data = data;
+
+	return 0;
+}
+
+int virtual_hal_remove_key(_IN_ hal_key_type mode, _IN_ uint32_t key_idx)
+{
+	VH_ENTER;
+	VH_LOG("mode(%d) key index(%d)\n", mode, key_idx);
+
+	return 0;
+}
+
+int virtual_hal_generate_key(_IN_ hal_key_type mode, _IN_ uint32_t key_idx)
+{
+	VH_ENTER;
+	VH_LOG("mode(%d) key index(%d)\n", mode, key_idx);
+
+	return 0;
+}
+
+/**
+ * Authenticate
+ */
+int virtual_hal_generate_random(_IN_ uint32_t len, _OUT_ hal_data *random)
+{
+	VH_ENTER;
+	return 0;
+}
+
+int virtual_hal_get_hash(_IN_ hal_hash_type mode, _IN_ hal_data *input, _OUT_ hal_data *hash)
+{
+	VH_ENTER;
+	return 0;
+}
+
+int virtual_hal_get_hmac(_IN_ hal_hmac_type mode, _IN_ hal_data *input, _IN_ uint32_t key_idx, _OUT_ hal_data *hmac)
+{
+	VH_ENTER;
+	return 0;
+}
+
+int virtual_hal_rsa_sign_md(_IN_ hal_rsa_mode mode, _IN_ hal_data *hash, _IN_ uint32_t key_idx, _OUT_ hal_data *md)
+{
+	VH_ENTER;
+	return 0;
+}
+
+int virtual_hal_rsa_verify_md(_IN_ hal_rsa_mode mode, _IN_ hal_data *hash, _IN_ hal_data *sign, _IN_ uint32_t key_idx)
+{
+	VH_ENTER;
+	return 0;
+}
+
+int virtual_hal_ecdsa_sign_md(_IN_ hal_data *hash, _IN_ uint32_t key_idx, _INOUT_ hal_ecdsa_mode *mode, _OUT_ hal_data *sign)
+{
+	VH_ENTER;
+	return 0;
+}
+
+int virtual_hal_ecdsa_verify_md(_IN_ hal_ecdsa_mode mode, _IN_ hal_data *hash, _IN_ hal_data *sign, _IN_ uint32_t key_idx)
+{
+	VH_ENTER;
+	return 0;
+}
+
+int virtual_hal_dh_generate_param(_IN_ uint32_t dh_idx, _INOUT_ hal_dh_data *dh_param)
+{
+	VH_ENTER;
+	return 0;
+}
+
+int virtual_hal_dh_compute_shared_secret(_IN_ hal_dh_data *param, _IN_ uint32_t dh_idx, _OUT_ hal_data *shared_secret)
+{
+	VH_ENTER;
+	return 0;
+}
+
+int virtual_hal_ecdh_compute_shared_secret(_IN_ hal_ecdh_data *ecdh_mode, _IN_ uint32_t key_idx, _OUT_ hal_data *shared_secret)
+{
+	VH_ENTER;
+	return 0;
+}
+
+
+
+int virtual_hal_set_certificate(_IN_ uint32_t cert_idx, _IN_ hal_data *cert_in)
+{
+	VH_ENTER;
+
+	if (!cert_in || !cert_in->data) {
+		return -1;
+	}
+	VH_LOG("cert len(%d)\n", cert_in->data_len);
+
+	return 0;
+}
+
+int virtual_hal_get_certificate(_IN_ uint32_t cert_idx, _OUT_ hal_data *cert_out)
+{
+	VH_ENTER;
+
+	char *cert_data = {"cert_ccccccccccccceeeeeeeeeeeerrrrrrrrrrrttttttttttt"};
+	hal_data cert_s;
+	cert_s.data = (void *)cert_data;
+	cert_s.data_len = sizeof(cert_data);
+
+	cert_out->data = (unsigned char *)malloc(cert_s.data_len);
+	memcpy(cert_out->data, cert_s.data, cert_s.data_len);
+	cert_out->data_len = cert_s.data_len;
+
+	return 0;
+}
+
+int virtual_hal_remove_certificate(_IN_ uint32_t cert_idx)
+{
+	VH_ENTER;
+
+	return 0;
+}
+
+int virtual_hal_get_factory_key(_IN_ uint32_t key_idx, _IN_ hal_data *key)
+{
+	VH_ENTER;
+
+	hal_data factory_s = {"factory", 7, NULL};
+
+	key->data = (unsigned char *)malloc(7);
+	memcpy(key->data, factory_s.data, 7);
+
+	return 0;
+}
+
+int virtual_hal_get_factory_cert(_IN_ uint32_t cert_idx, _IN_ hal_data *cert)
+{
+	VH_ENTER;
+
+	hal_data factory_s = {"factory", 7, NULL};
+
+	cert->data = (unsigned char *)malloc(7);
+	memcpy(cert->data, factory_s.data, 7);
+
+	return 0;
+}
+
+int virtual_hal_get_factory_data(_IN_ uint32_t data_idx, _IN_ hal_data *data)
+{
+	VH_ENTER;
+
+	hal_data factory_s = {"factory", 7, NULL};
+
+	data->data = (unsigned char *)malloc(7);
+	memcpy(data->data, factory_s.data, 7);
+
+	return 0;
+}
+
+/**
+ * Crypto
+ */
+int virtual_hal_aes_encrypt(_IN_ hal_data *dec_data, _IN_ hal_aes_param *aes_param, _IN_ uint32_t key_idx, _OUT_ hal_data *enc_data)
+{
+	VH_ENTER;
+
+	enc_data->data = (unsigned char *)malloc(dec_data->data_len);
+	memcpy(enc_data->data, dec_data->data,dec_data->data_len);
+	enc_data->data_len = dec_data->data_len;
+
+	return 0;
+}
+
+int virtual_hal_aes_decrypt(_IN_ hal_data *enc_data, _IN_ hal_aes_param *aes_param, _IN_ uint32_t key_idx, _OUT_ hal_data *dec_data)
+{
+	VH_ENTER;
+
+	dec_data->data = (unsigned char *)malloc(enc_data->data_len);
+	memcpy(dec_data->data, enc_data->data,enc_data->data_len);
+	dec_data->data_len = enc_data->data_len;
+
+	return 0;
+}
+
+int virtual_hal_rsa_encrypt(_IN_ hal_data *dec_data, _IN_ hal_rsa_mode *mode, _IN_ uint32_t key_idx, _OUT_ hal_data *enc_data)
+{
+	VH_ENTER;
+
+	enc_data->data = (unsigned char *)malloc(dec_data->data_len);
+	memcpy(enc_data->data, dec_data->data,dec_data->data_len);
+	enc_data->data_len = dec_data->data_len;
+
+	return 0;
+}
+
+int virtual_hal_rsa_decrypt(_IN_ hal_data *enc_data, _IN_ hal_rsa_mode *mode, _IN_ uint32_t key_idx, _OUT_ hal_data *dec_data)
+{
+	VH_ENTER;
+
+	dec_data->data = (unsigned char *)malloc(enc_data->data_len);
+	memcpy(dec_data->data, enc_data->data,enc_data->data_len);
+	dec_data->data_len = enc_data->data_len;
+
+	return 0;
+}
+
+/**
+ * Secure Storage
+ */
+int virtual_hal_write_storage(_IN_ uint32_t ss_idx, _IN_ hal_data *data)
+{
+	VH_ENTER;
+	return 0;
+}
+
+int virtual_hal_read_storage(_IN_ uint32_t ss_idx, _OUT_ hal_data *data)
+{
+	VH_ENTER;
+	return 0;
+}
+
+int virtual_hal_delete_storage(_IN_ uint32_t ss_idx)
+{
+	VH_ENTER;
+	return 0;
+}
+
+static struct sec_ops_s g_virtual_ops = {
+	virtual_hal_init,
+	virtual_hal_deinit,
+	virtual_hal_free_data,
+	virtual_hal_get_status,
+	virtual_hal_set_key,
+	virtual_hal_get_key,
+	virtual_hal_remove_key,
+	virtual_hal_generate_key,
+	virtual_hal_generate_random,
+	virtual_hal_get_hash,
+	virtual_hal_get_hmac,
+	virtual_hal_rsa_sign_md,
+	virtual_hal_rsa_verify_md,
+	virtual_hal_ecdsa_sign_md,
+	virtual_hal_ecdsa_verify_md,
+	virtual_hal_dh_generate_param,
+	virtual_hal_dh_compute_shared_secret,
+	virtual_hal_ecdh_compute_shared_secret,
+	virtual_hal_set_certificate,
+	virtual_hal_get_certificate,
+	virtual_hal_remove_certificate,
+	virtual_hal_get_factory_key,
+	virtual_hal_get_factory_cert,
+	virtual_hal_get_factory_data,
+	virtual_hal_aes_encrypt,
+	virtual_hal_aes_decrypt,
+	virtual_hal_rsa_encrypt,
+	virtual_hal_rsa_decrypt,
+	virtual_hal_write_storage,
+	virtual_hal_read_storage,
+	virtual_hal_delete_storage,
+};
+
+static struct sec_lowerhalf_s g_virtual_lower = {&g_virtual_ops, NULL};
+
+int se_initialize(void)
+{
+	int res = se_register(SECLINK_PATH, &g_virtual_lower);
+	if (res != 0) {
+		VH_ERR(res);
+		return -1;
+	}
+
+	return 0;
+}


### PR DESCRIPTION
1. Add seclink to communicate between kernel and user-space
2. Add security HAL to provide general abstraction layer to SE vendor