### PR TITLE
build/tools: Fix image downloading issue for esp32 board.

### DIFF
--- a/build/tools/esp32/esptool_py/Makefile
+++ b/build/tools/esp32/esptool_py/Makefile
@@ -76,7 +76,7 @@ ESPTOOL_ALL_FLASH_ARGS += $(ESPTOOL_BOOTLOADER_FLASH_ARGS)
 
 ALL:flash
 
-APP:app-flash
+OS:app-flash
 
 ROMFS:romfs
 


### PR DESCRIPTION
	Modify the image downloading command from "make download APP" to "make download OS".

Signed-off-by: xiarihf qiang3.zhang@samsung.com