### PR TITLE
external/esp_idf_port: refine wifi internal alloc api

### DIFF
--- a/external/esp_idf_port/esp32/esp32_wifi_os_adapter.c
+++ b/external/esp_idf_port/esp32/esp32_wifi_os_adapter.c
@@ -630,7 +630,11 @@ uint32_t IRAM_ATTR esp_get_free_heap_size(void)
 
 static void *IRAM_ATTR malloc_internal_wrapper(size_t size)
 {
+#if (defined(CONFIG_SPIRAM_SUPPORT) && CONFIG_MM_REGIONS > 1)
+	return malloc_at(0, size);
+#else
 	return malloc(size);
+#endif
 }
 
 static void *IRAM_ATTR realloc_internal_wrapper(void *ptr, size_t size)
@@ -640,13 +644,20 @@ static void *IRAM_ATTR realloc_internal_wrapper(void *ptr, size_t size)
 
 static void *IRAM_ATTR calloc_internal_wrapper(size_t n, size_t size)
 {
+#if (defined(CONFIG_SPIRAM_SUPPORT) && CONFIG_MM_REGIONS > 1)
+	return calloc_at(0, n, size);
+#else
 	return calloc(n, size);
+#endif
 }
 
 static void *IRAM_ATTR zalloc_internal_wrapper(size_t size)
 {
-	void *ptr = zalloc(size);
-	return ptr;
+#if (defined(CONFIG_SPIRAM_SUPPORT) && CONFIG_MM_REGIONS > 1)
+	return zalloc_at(0, size);
+#else
+	return zalloc(size);
+#endif
 }
 
 void *IRAM_ATTR wifi_malloc(size_t size)


### PR DESCRIPTION
Add logic for SPIRAM enable case in wifi_os_adapter,
to alloc from DRAM instead of external ram for internal alloc api
@sunghan-chang 