### PR TITLE
mm/mm_heap : algorithm enhancement to reduce temporal cost of malloc()

### DIFF
--- a/apps/examples/heap_performance_test/Kconfig
+++ b/apps/examples/heap_performance_test/Kconfig
@@ -1,0 +1,14 @@
+#
+# For a description of the syntax of this configuration file,
+# see kconfig-language at https://www.kernel.org/doc/Documentation/kbuild/kconfig-language.txt
+#
+
+config EXAMPLES_HEAP_PERFORMANCE_TEST
+	bool "Heap performance test"
+	default n
+	---help---
+		Measure the elapsed time while simply repeating memory allocation and release.
+
+config USER_ENTRYPOINT
+	string
+	default "heaptest_main" if ENTRY_HEAP_PERFORMANCE_TEST

--- a/apps/examples/heap_performance_test/Kconfig_ENTRY
+++ b/apps/examples/heap_performance_test/Kconfig_ENTRY
@@ -1,0 +1,3 @@
+config ENTRY_HEAP_PERFORMANCE_TEST
+	bool "Heap performance test"
+	depends on EXAMPLES_HEAP_PERFORMANCE_TEST

--- a/apps/examples/heap_performance_test/Make.defs
+++ b/apps/examples/heap_performance_test/Make.defs
@@ -1,0 +1,21 @@
+###########################################################################
+#
+# Copyright 2019 Samsung Electronics All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+#
+###########################################################################
+
+ifeq ($(CONFIG_EXAMPLES_HEAP_PERFORMANCE_TEST),y)
+CONFIGURED_APPS += examples/heap_performance_test
+endif

--- a/apps/examples/heap_performance_test/Makefile
+++ b/apps/examples/heap_performance_test/Makefile
@@ -1,0 +1,122 @@
+###########################################################################
+#
+# Copyright 2019 Samsung Electronics All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+#
+###########################################################################
+
+-include $(TOPDIR)/.config
+-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
+
+# built-in application info
+
+APPNAME = heaptest
+FUNCNAME = $(APPNAME)_main
+THREADEXEC = TASH_EXECMD_ASYNC
+
+# Example for heap test
+
+ASRCS =
+CSRCS =
+MAINSRC = heap_performance_test.c
+
+AOBJS = $(ASRCS:.S=$(OBJEXT))
+COBJS = $(CSRCS:.c=$(OBJEXT))
+MAINOBJ = $(MAINSRC:.c=$(OBJEXT))
+
+SRCS = $(ASRCS) $(CSRCS) $(MAINSRC)
+OBJS = $(AOBJS) $(COBJS)
+
+ifneq ($(CONFIG_BUILD_KERNEL),y)
+  OBJS += $(MAINOBJ)
+endif
+
+ifeq ($(CONFIG_WINDOWS_NATIVE),y)
+  BIN = ..\..\libapps$(LIBEXT)
+else
+ifeq ($(WINTOOL),y)
+  BIN = ..\\..\\libapps$(LIBEXT)
+else
+  BIN = ../../libapps$(LIBEXT)
+endif
+endif
+
+ifeq ($(WINTOOL),y)
+  INSTALL_DIR = "${shell cygpath -w $(BIN_DIR)}"
+else
+  INSTALL_DIR = $(BIN_DIR)
+endif
+
+CONFIG_EXAMPLES_HEAP_PERFORMANCE_TEST_PROGNAME ?= heaptest$(EXEEXT)
+PROGNAME = $(CONFIG_EXAMPLES_HEAP_PERFORMANCE_TEST_PROGNAME)
+
+ROOTDEPPATH = --dep-path .
+
+# Common build
+
+all: .built
+.PHONY: clean depend distclean
+
+$(AOBJS): %$(OBJEXT): %.S
+	$(call ASSEMBLE, $<, $@)
+
+$(COBJS) $(MAINOBJ): %$(OBJEXT): %.c
+	$(call COMPILE, $<, $@)
+
+.built: $(OBJS)
+	$(call ARCHIVE, $(BIN), $(OBJS))
+	@touch .built
+
+ifeq ($(CONFIG_BUILD_KERNEL),y)
+$(BIN_DIR)$(DELIM)$(PROGNAME): $(OBJS) $(MAINOBJ)
+	@echo "LD: $(PROGNAME)"
+	$(Q) $(LD) $(LDELFFLAGS) $(LDLIBPATH) -o $(INSTALL_DIR)$(DELIM)$(PROGNAME) $(ARCHCRT0OBJ) $(MAINOBJ) $(LDLIBS)
+	$(Q) $(NM) -u  $(INSTALL_DIR)$(DELIM)$(PROGNAME)
+
+install: $(BIN_DIR)$(DELIM)$(PROGNAME)
+
+else
+install:
+
+endif
+
+ifeq ($(CONFIG_BUILTIN_APPS)$(CONFIG_EXAMPLES_HEAP_PERFORMANCE_TEST),yy)
+$(BUILTIN_REGISTRY)$(DELIM)$(FUNCNAME).bdat: $(DEPCONFIG) Makefile
+	$(call REGISTER,$(APPNAME),$(FUNCNAME),$(THREADEXEC))
+
+context: $(BUILTIN_REGISTRY)$(DELIM)$(APPNAME)_main.bdat
+
+else
+context:
+
+endif
+
+.depend: Makefile $(SRCS)
+	@$(MKDEP) $(ROOTDEPPATH) "$(CC)" -- $(CFLAGS) -- $(SRCS) >Make.dep
+	@touch $@
+
+depend: .depend
+
+clean:
+	$(call DELFILE, .built)
+	$(call CLEAN)
+
+distclean: clean
+	$(call DELFILE, Make.dep)
+	$(call DELFILE, .depend)
+
+-include Make.dep
+.PHONY: preconfig
+preconfig:

--- a/apps/examples/heap_performance_test/README.txt
+++ b/apps/examples/heap_performance_test/README.txt
@@ -1,0 +1,7 @@
+examples/heap_performance_test
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+  This is an example to measure the elapsed time while simply repeating memory allocation and release.
+  
+  Configs (see the details on Kconfig):
+  * CONFIG_EXAMPLES_HEAP_PERFORMANCE_TEST

--- a/apps/examples/heap_performance_test/heap_performance_test.c
+++ b/apps/examples/heap_performance_test/heap_performance_test.c
@@ -1,0 +1,123 @@
+/****************************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+/// @file heap_performance_test.c
+
+/// @brief Measure the elapsed time while simply repeating memory allocation and release.
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+#include <tinyara/config.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
+
+#define NUM_ALLOC 100
+
+static int heap_performance_test(int argc, char *argv[])
+{
+	struct timespec ts1, ts2;
+	int repeat = NUM_ALLOC;
+	int size = 32;
+	int i, j, k;
+	char *data[100];
+	int test_repeat = 11;
+	uint32_t elapsed = 0;
+	uint32_t total_elapsed = 0;
+	int sizes[11] = {16, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192};
+	int interval = 1;
+
+	for (j = 0; j < NUM_ALLOC; ++j) {
+		data[j] = NULL;
+	}
+
+	if (argc == 4) {
+		int in = strtol(argv[2], (char **)NULL, 10);
+		if (in > 0) {
+			interval = in;
+		}
+		in = strtol(argv[3], (char **)NULL, 10);
+		if (in > 0) {
+			repeat = in;
+		}
+	} else {
+		printf("Usage:	%s param1 param2\n", argv[1]);
+		printf("	param1 is the interval between tests each of which handles a different size.\n");
+		printf("	param2 is the number of repetition of one experiment.\n");
+		printf("	In one experiment, param1-sized memory is allocated a hundred times and then released.\n\n");
+		printf("At this time, %s will be performed with default values.\n\n", argv[1]);
+	}
+
+	printf("\nTest with interval %d, repetition %d.\n", interval, repeat);
+	printf("Elapsed time doing a cycle of malloc() and free() %u times:\n", NUM_ALLOC * repeat);
+
+	for (k = 0; k < test_repeat; ++k) {
+		size = sizes[k];
+		if (clock_gettime(CLOCK_REALTIME, &ts1) == -1) {
+			printf("gettime error occured.\n");
+			return 0;
+		}
+
+		for (i = 0; i < repeat; ++i) {
+			for (j = 0; j < NUM_ALLOC; ++j) {
+				data[j] = (char *)malloc(size);
+				if (data[j] == NULL) {
+					printf("With size %d, %d-th, Test failed due to malloc failure.\n", size, j);
+					for (i = 0; i < j; ++i) {
+						free(data[i]);
+					}
+					return 0;
+				}
+			}
+			for (j = 0; j < NUM_ALLOC; ++j) {
+				free(data[j]);
+			}
+		}
+		if (clock_gettime(CLOCK_REALTIME, &ts2) == -1) {
+			printf("gettime error occured.\n");
+			return 0;
+		}
+
+		if (k > 0) {
+			elapsed = ((ts2.tv_sec - ts1.tv_sec) * 1000 + (ts2.tv_nsec - ts1.tv_nsec) / 1000000);
+			total_elapsed += elapsed;
+			printf("Size %u bytes	: %u mseconds.\n", size, elapsed);
+		}
+
+		sleep(interval);
+	}
+
+	printf("Total elapsed time : %u mseconds\n", total_elapsed);
+
+	return 0;
+}
+
+#ifdef CONFIG_BUILD_KERNEL
+int main(int argc, FAR char *argv[])
+#else
+int heaptest_main(int argc, char *argv[])
+#endif
+{
+	printf("Heap Performance Test!!\n");
+	task_create("Heap performance test", 100, 6144, heap_performance_test, argv);
+
+	sleep(1);
+
+	return 0;
+}

--- a/os/include/tinyara/mm/mm.h
+++ b/os/include/tinyara/mm/mm.h
@@ -153,6 +153,8 @@
 
 #define MM_MIN_SHIFT    4		/* 16 bytes */
 #define MM_MAX_SHIFT   15		/* 32 Kb */
+#define MM_SHIFT_FOR_NDX (MM_MIN_SHIFT + 1)
+#define MM_SHIFT_MASK    ~(1 << MM_SHIFT_FOR_NDX)
 
 #elif defined(CONFIG_HAVE_LONG_LONG)
 /* Four byte offsets; Pointers may be 4 or 8 bytes
@@ -161,8 +163,12 @@
 
 #if UINTPTR_MAX <= UINT32_MAX
 #define MM_MIN_SHIFT  4			/* 16 bytes */
+#define MM_SHIFT_FOR_NDX 5		/* MM_MIN_SHIFT + 1 */
+#define MM_SHIFT_MASK    0xffffffe0	/* ~(1 << MM_SHIFT_FOR_NDX) */
 #elif UINTPTR_MAX <= UINT64_MAX
 #define MM_MIN_SHIFT  5			/* 32 bytes */
+#define MM_SHIFT_FOR_NDX 6		/* MM_MIN_SHIFT + 1 */
+#define MM_SHIFT_MASK    0xffffffc0	/* ~(1 << MM_SHIFT_FOR_NDX) */
 #endif
 #define MM_MAX_SHIFT   22		/*  4 Mb */
 
@@ -173,6 +179,8 @@
 
 #define MM_MIN_SHIFT    4		/* 16 bytes */
 #define MM_MAX_SHIFT   22		/*  4 Mb */
+#define MM_SHIFT_FOR_NDX 5		/* MM_MIN_SHIFT + 1 */
+#define MM_SHIFT_MASK    0xffffffe0	/* ~(1 << MM_SHIFT_FOR_NDX) */
 #endif
 
 /* All other definitions derive from these two */
@@ -383,7 +391,7 @@ struct mm_heap_s {
 	 * speed searches for free nodes.
 	 */
 
-	struct mm_freenode_s mm_nodelist[MM_NNODES];
+	struct mm_freenode_s mm_nodelist[MM_NNODES + 1];
 };
 
 /****************************************************************************

--- a/os/mm/mm_heap/mm_addfreechunk.c
+++ b/os/mm/mm_heap/mm_addfreechunk.c
@@ -88,9 +88,9 @@ void mm_addfreechunk(FAR struct mm_heap_s *heap, FAR struct mm_freenode_s *node)
 
 	int ndx = mm_size2ndx(node->size);
 
-	/* Now put the new node int the next */
+	/* Now put the new free node in a descending order */
 
-	for (prev = &heap->mm_nodelist[ndx], next = heap->mm_nodelist[ndx].flink; next && next->size && next->size < node->size; prev = next, next = next->flink) ;
+	for (prev = &heap->mm_nodelist[ndx], next = prev->flink; next && next->size > node->size; prev = next, next = next->flink) ;
 
 	/* Does it go in mid next or at the end? */
 

--- a/os/mm/mm_heap/mm_initialize.c
+++ b/os/mm/mm_heap/mm_initialize.c
@@ -190,7 +190,9 @@ void mm_addregion(FAR struct mm_heap_s *heap, FAR void *heapstart, size_t heapsi
 
 void mm_initialize(FAR struct mm_heap_s *heap, FAR void *heapstart, size_t heapsize)
 {
+#ifdef CONFIG_DEBUG_MM_HEAPINFO
 	int i;
+#endif
 
 	mlldbg("Heap: start=%p size=%u\n", heapstart, heapsize);
 
@@ -214,11 +216,7 @@ void mm_initialize(FAR struct mm_heap_s *heap, FAR void *heapstart, size_t heaps
 
 	/* Initialize the node array */
 
-	memset(heap->mm_nodelist, 0, sizeof(struct mm_freenode_s) * MM_NNODES);
-	for (i = 1; i < MM_NNODES; i++) {
-		heap->mm_nodelist[i - 1].flink = &heap->mm_nodelist[i];
-		heap->mm_nodelist[i].blink = &heap->mm_nodelist[i - 1];
-	}
+	memset(heap->mm_nodelist, 0, sizeof(struct mm_freenode_s) * (MM_NNODES + 1));
 
 	/* Initialize the malloc semaphore to one (to support one-at-
 	 * a-time access to private data sets).

--- a/os/mm/mm_heap/mm_size2ndx.c
+++ b/os/mm/mm_heap/mm_size2ndx.c
@@ -77,16 +77,30 @@
 int mm_size2ndx(size_t size)
 {
 	int ndx = 0;
+	size_t o_size = size;
+	size_t mask = MM_SHIFT_MASK;
 
-	if (size >= MM_MAX_CHUNK) {
+	if ((size >> MM_MAX_SHIFT) >= 1) {
 		return MM_NNODES - 1;
 	}
 
-	size >>= MM_MIN_SHIFT;
-	while (size > 1) {
+	size >>= MM_SHIFT_FOR_NDX;
+	while(size > 1) {
 		ndx++;
 		size >>= 1;
 	}
-
-	return ndx;
+	
+	/* If free nodes are sorted in a descending order,
+	 * it would be better to use ]32, 64] instead of [32, 64[.
+	 */
+	if (size > 0) {
+		mask <<= ndx;
+		if ((o_size & (~mask)) > 0) {
+			return ++ndx;
+		} else {
+			return ndx;
+		}
+	} else {
+		return ndx;
+	}
 }


### PR DESCRIPTION
Current algorithm:
Free nodes are managed by n double-linked lists called 'mm_nodelist'.
The head of each list is not a real free node but discrimiates where each list starts.
i-th list includes free nodes whose size ranges [2^(i+4) 2^(i+5)[.
When memory allocation is requested, the current procedure is as follows:
1.compute 'ndx' with size
2.search an available node from 'mm_nodelist[ndx]
3.remove the node from the list.

Here are two problems. At the second step, we may not find an available node from ndx-th list.
Let's see an example.
The table depicted below shows the initial status of the heap memory.
When 32 bytes allocation is requested, from the step 1 the index is 1.
However, mm_nodelist[1] doesn't have any free nodes.
To handle this situation, each head is doubly-linked with adjacent head nodes at initialization.
So, searching can continue and go through mm_nodelist[2] up to mm_nodelist[15].
Finally, one available free node is found at mm_nodelist[15].
This exhaustive search just increases the temporal cost of malloc() operations.

Nodelist[0] (less than 32) : num 0, size 0 [Bytes]
Nodelist[1] (less than 64) : num 0, size 0 [Bytes]
Nodelist[2] (less than 128) : num 0, size 0 [Bytes]
Nodelist[3] (less than 256) : num 0, size 0 [Bytes]
Nodelist[4] (less than 512) : num 0, size 0 [Bytes]
Nodelist[5] (less than 1024) : num 0, size 0 [Bytes]
Nodelist[6] (less than 2048) : num 0, size 0 [Bytes]
Nodelist[7] (less than 4096) : num 0, size 0 [Bytes]
Nodelist[8] (less than 8192) : num 0, size 0 [Bytes]
Nodelist[9] (less than 16384) : num 0, size 0 [Bytes]
Nodelist[10] (less than 32768) : num 0, size 0 [Bytes]
Nodelist[11] (less than 65536) : num 0, size 0 [Bytes]
Nodelist[12] (less than 131072) : num 0, size 0 [Bytes]
Nodelist[13] (less than 262144) : num 0, size 0 [Bytes]
Nodelist[14] (less than 524288) : num 0, size 0 [Bytes]
Nodelist[15] (less than 1048576) : num 1, size 897600 [Bytes]
Nodelist[16] (less than 2097152) : num 0, size 0 [Bytes]
Nodelist[17] (less than 4194304) : num 0, size 0 [Bytes]
Nodelist[18] (less than 8388608) : num 0, size 0 [Bytes]

The second problem is more severe.
Let's see another example.
When 48 bytes allocation is requested, from the step 1 the index is 1.
mm_nodelist[1] already has 209 free nodes but all free nodes are 32 bytes-sized.
After exhaustive searching through mm_nodelist[1],
finally, one available free node, which is larger than or equal to 48 bytes,
is found at mm_nodelist[15].

Nodelist[0] (less than 32) : num 0, size 0 [Bytes]
Nodelist[1] (less than 64) : num 209, size 6688 [Bytes]
Nodelist[2] (less than 128) : num 0, size 0 [Bytes]
Nodelist[3] (less than 256) : num 0, size 0 [Bytes]
...
Nodelist[15] (less than 1048576) : num 1, size 890912 [Bytes]

New algorithm:
We're going to simply resolve this problem.
Here are our approaches:
1. To tackle the first problem, delink Nodelist[n] from Nodelist[n-1] and Nodelist[n+1].
2. To handle the second problem, each list manages free nodes not in an ascending order but in a descending order in terms of size.
That is, the first free node is the largest one in the list.
This prevents exhaustive search through the whole free nodes in the list.
Now, just look up the first node and see whether the list has an available free node.
3. If free nodes are sorted in a descending order, it would be better to use ]32, 64] instead of range [32, 64[.
Please, see the table composed by this new rule.

Nodelist[0] (less than or equal to 32) : num 0, size 0 [Bytes]
Nodelist[1] (less than or equal to 64) : num 0, size 0 [Bytes]
Nodelist[2] (less than or equal to 128) : num 0, size 0 [Bytes]

Performance (Temporal cost):
We do an experiment where m bytes memory is allocated 100 times continuously and then all allocated memory blocks are released.
We measure the elapsed time for doing this experiment 1000 times continuously on ARTIK 053.
Compared to the previous one, the proposed algorithm shows much stable temporal performance.
That is, one pair of malloc() and free() takes almost the same time regardless of sizes.
With heavy load and size of 32, the previous one shows that the time per one pair of malloc() and free() is 15.17 us which is almost larger three times compared to other sizes.
In the same case, the proposed algorithm has up to 68.45 percent reduction in temporal cost.

Time per malloc/free [us] with light load
size [bytes] | 16   | 32    | 64    | 128  | 256  | 512  | 1024 | 2048 | 4096 | 8192
before [us] | 3.79 | 3.79 | 3.99 | 4.1   | 4.19 | 4.3   | 4.29   | 4.39  | 4.29  | 4.29
after    [us] | 3.59 | 3.69 | 3.69 | 3.89 | 4.0   | 3.99 | 4.0     | 3.99  | 4.09  | 4.0

Time per malloc/free [us] with heavy load
size [bytes] | 16   | 32      | 64    | 128  | 256  | 512 | 1024 | 2048 | 4096
before [us] | 5.08 | 15.17 | 6.58 | 5.09 | 7.09 | 5.98 | 5.29  | 4.59  | 4.79
after    [us] | 3.09 | 4.77   | 4.19 | 3.7   | 3.89 | 4.09 | 4.09  | 5.08  | 4.7

On Mediatek, the almost same results are shown.
The proposed algorithm has up to 58.12 percent reduction in temporal cost in case of heavy load at size of 32.

Time per malloc/free [us] with heavy load
size [bytes] | 16   | 32      | 64      | 128  | 256  | 512  | 1024 | 2048  | 4096  | 8192
before [us] | 7.25 | 26.84 | 10.91 | 8.49 | 8.58 | 8.52  | 8.85  | 12.03 | 12.73 | 9.22
after    [us] | 7.32 | 11.24 | 9.39   | 8.80 | 8.74 | 8.88  | 9.32  | 12.02 | 11.23 | 9.86