### PR TITLE
apps/examples/security_test: Add stdlib.h for atoi in see test app

### DIFF
--- a/apps/examples/security_test/see_api/see_test_main.c
+++ b/apps/examples/security_test/see_api/see_test_main.c
@@ -26,6 +26,7 @@
 #include "mbedtls/timing.h"
 
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
 #include "mbedtls/see_api.h"


### PR DESCRIPTION
- Add '#include <stdlib.h>' in see_test_main.c to use 'atoi'