### PR TITLE
framework/seclink: Fix deinit logic of seclink

### DIFF
--- a/framework/src/seclink/seclink.c
+++ b/framework/src/seclink/seclink.c
@@ -61,7 +61,6 @@
 		fd = -1;								 \
 	} while (0)
 
-
 #define SL_CHECK_VALID(hnd)									 \
 	do {													 \
 		if (!hnd || ((struct _seclink_s_ *)hnd)->fd <= 0) {	 \
@@ -131,20 +130,22 @@ int sl_init(sl_ctx *hnd)
 	return SECLINK_OK;
 }
 
-int sl_deinit(sl_ctx hnd)
+void sl_deinit(sl_ctx hnd)
 {
 	SL_ENTER;
 
-	SL_CHECK_VALID(hnd);
+	if (!hnd || ((struct _seclink_s_ *)hnd)->fd <= 0) {
+		SL_ERR(((struct _seclink_s_ *)hnd)->fd);
+		return;
+	}
 
 	struct _seclink_s_ *sl = (struct _seclink_s_ *)hnd;
 	SL_CLOSE(sl->fd);
-
 	free(sl);
 	free(g_mem.mem);
 	free(g_mem.mem_priv);
 
-	return SECLINK_OK;
+	return;
 }
 
 /*  key manager */

--- a/os/include/tinyara/seclink.h
+++ b/os/include/tinyara/seclink.h
@@ -162,7 +162,7 @@ struct seclink_req {
 
 /*  Common */
 int sl_init(sl_ctx *hnd);
-int sl_deinit(sl_ctx hnd);
+void sl_deinit(sl_ctx hnd);
 
 /*  key manager */
 int sl_set_key(sl_ctx hnd, hal_key_type mode, uint32_t key_idx, hal_data *key, hal_data *prikey);


### PR DESCRIPTION
- Modify return type of seclink to void
- Fix error handling logic in sl_deinit
