### PR TITLE
os/include/debug.h : Revert dbg commands re-direction.

### DIFF
--- a/apps/examples/testcase/le_tc/kernel/tc_libc_misc.c
+++ b/apps/examples/testcase/le_tc/kernel/tc_libc_misc.c
@@ -257,6 +257,7 @@ static void tc_libc_misc_dbg(void)
 	TC_SUCCESS_RESULT();
 }
 
+#ifndef CONFIG_BUILD_PROTECTED
 /**
  * @fn                  :tc_libc_misc_lldbg
  * @brief               :Identical to [a-z]dbg() except this is uses special interfaces provided by architecture-specific logic to \n
@@ -317,6 +318,7 @@ static void tc_libc_misc_llvdbg(void)
 
 	TC_SUCCESS_RESULT();
 }
+#endif
 
 /**
  * @fn                  :tc_libc_misc_vdbg
@@ -435,16 +437,16 @@ int libc_misc_main(void)
 #ifdef CONFIG_DEBUG_ERROR
 	tc_libc_misc_dbg();
 	tc_libc_misc_lib_dumpbuffer();
+#ifndef CONFIG_BUILD_PROTECTED
 #ifdef CONFIG_ARCH_LOWPUTC
 	tc_libc_misc_lldbg();
+	tc_libc_misc_llvdbg();
 #endif
+#endif /* CONFIG_BUILD_PROTECTED */
 #endif
 
 #ifdef CONFIG_DEBUG_VERBOSE
 	tc_libc_misc_vdbg();
-#ifdef CONFIG_ARCH_LOWPUTC
-	tc_libc_misc_llvdbg();
-#endif
 #endif
 #endif /* CONFIG_DEBUG */
 	tc_libc_misc_match();

--- a/apps/examples/testcase/le_tc/kernel/tc_libc_syslog.c
+++ b/apps/examples/testcase/le_tc/kernel/tc_libc_syslog.c
@@ -137,6 +137,7 @@ static void tc_libc_syslog_vsyslog(void)
 	TC_SUCCESS_RESULT();
 }
 
+#ifndef CONFIG_BUILD_PROTECTED
 #if defined(CONFIG_ARCH_LOWPUTC) || defined(CONFIG_SYSLOG)
 /**
  * @fn                  :tc_libc_syslog_lowsyslog
@@ -204,6 +205,7 @@ static void tc_libc_syslog_lowvsyslog(void)
 }
 
 #endif
+#endif
 
 /****************************************************************************
  * Name: libc_syslog
@@ -214,9 +216,11 @@ int libc_syslog_main(void)
 	tc_libc_syslog_setlogmask();
 	tc_libc_syslog_syslog();
 	tc_libc_syslog_vsyslog();
+#ifndef CONFIG_BUILD_PROTECTED
 #if defined(CONFIG_ARCH_LOWPUTC) || defined(CONFIG_SYSLOG)
 	tc_libc_syslog_lowsyslog();
 	tc_libc_syslog_lowvsyslog();
+#endif
 #endif
 	return 0;
 }

--- a/os/arch/arm/src/armv7-m/mpu.h
+++ b/os/arch/arm/src/armv7-m/mpu.h
@@ -237,7 +237,7 @@ static inline void mpu_showtype(void)
 {
 #if defined(CONFIG_DEBUG) && defined(CONFIG_DEBUG_ERROR)
 	uint32_t regval = getreg32(MPU_TYPE);
-	dbg("%s MPU Regions: data=%d instr=%d\n",
+	lldbg("%s MPU Regions: data=%d instr=%d\n",
 		(regval & MPU_TYPE_SEPARATE) != 0 ? "Separate" : "Unified",
 		(regval & MPU_TYPE_DREGION_MASK) >> MPU_TYPE_DREGION_SHIFT,
 		(regval & MPU_TYPE_IREGION_MASK) >> MPU_TYPE_IREGION_SHIFT);

--- a/os/include/debug.h
+++ b/os/include/debug.h
@@ -153,16 +153,9 @@
  * @details @b #include <debug.h>
  * @since TizenRT v1.0
  */
-#ifdef CONFIG_ARCH_CHIP_IMXRT
-/* TODO: This is a temporary fix to redirect dbg messages to lldbg.
- *       After IMXRT dbg implementation is fixed, this needs to be removed.
- */
-#define dbg(format, ...) \
-	lldbg(format, ##__VA_ARGS__)
-#else
+
 #define dbg(format, ...) \
 	syslog(LOG_ERR, EXTRA_FMT format EXTRA_ARG, ##__VA_ARGS__)
-#endif
 
 #define dbg_noarg(format, ...) \
 	syslog(LOG_ERR, format, ##__VA_ARGS__)
@@ -199,16 +192,9 @@
  * @details @b #include <debug.h>
  * @since TizenRT v1.0
  */
-#ifdef CONFIG_ARCH_CHIP_IMXRT
-/* TODO: This is a temporary fix to redirect dbg messages to lldbg.
- *       After IMXRT dbg implementation is fixed, this needs to be removed.
- */
-#define wdbg(format, ...) \
-	llwdbg(format, ##__VA_ARGS__)
-#else
+
 #define wdbg(format, ...) \
 	syslog(LOG_WARNING, EXTRA_FMT format EXTRA_ARG, ##__VA_ARGS__)
-#endif
 
 #ifdef CONFIG_ARCH_LOWPUTC
 /**
@@ -242,16 +228,9 @@
  * @details @b #include <debug.h>
  * @since TizenRT v1.0
  */
-#ifdef CONFIG_ARCH_CHIP_IMXRT
-/* TODO: This is a temporary fix to redirect dbg messages to lldbg.
- *       After IMXRT dbg implementation is fixed, this needs to be removed.
- */
-#define vdbg(format, ...) \
-	llvdbg(format, ##__VA_ARGS__)
-#else
+
 #define vdbg(format, ...) \
 	syslog(LOG_INFO, EXTRA_FMT format EXTRA_ARG, ##__VA_ARGS__)
-#endif
 
 #ifdef CONFIG_ARCH_LOWPUTC
 /**


### PR DESCRIPTION
* First patch adds dependency on Protected build on the following TC's: lldbg, llvdbg, lowsyslog, lowvsyslog. These API's call up_lowputc which is not accessible from userspace.
* Second patch eliminates the redirection of dbg to lldbg commands.
* Also, "dbg" cannot be called prior to driver registration since it uses write system call. So, this patch changes "dbg" to "lldbg" prior to driver registration.
