### PR TITLE
Exit build on undefined symbols in elf

### DIFF
--- a/apps/examples/elf/Makefile
+++ b/apps/examples/elf/Makefile
@@ -62,12 +62,13 @@ $(1)_$(2):
 	$(Q) $(MAKE) -C $(1) $(3) TOPDIR="$(TOPDIR)" APPDIR="$(APPDIR)" SYSTEM_BIN_DIR="$(SYSTEM_BIN_DIR)" CROSSDEV=$(CROSSDEV)
 endef
 
-all: build install
-.PHONY: all build clean install distclean
+all: build verify install
+.PHONY: all build clean install distclean verify
 
 $(foreach DIR, $(BUILD_SUBDIRS), $(eval $(call DIR_template,$(DIR),build, all)))
 $(foreach DIR, $(BUILD_SUBDIRS), $(eval $(call DIR_template,$(DIR),clean,clean)))
 $(foreach DIR, $(BUILD_SUBDIRS), $(eval $(call DIR_template,$(DIR),install,install)))
+$(foreach DIR, $(BUILD_SUBDIRS), $(eval $(call DIR_template,$(DIR),verify,verify)))
 
 # Build program(s) in each sub-directory
 
@@ -76,6 +77,10 @@ build: $(foreach DIR, $(BUILD_SUBDIRS), $(DIR)_build)
 # Install each program in the romfs directory
 
 install: $(foreach DIR, $(BUILD_SUBDIRS), $(DIR)_install)
+
+# Verify each program for undefined symbols
+
+verify: $(foreach DIR, $(BUILD_SUBDIRS), $(DIR)_verify)
 
 # context
 context:

--- a/apps/examples/elf/micomapp/Makefile
+++ b/apps/examples/elf/micomapp/Makefile
@@ -84,12 +84,12 @@ LDLIBS += $(LIBGCC)
 endif
 
 BIN = micomapp
-
+BIN_CHECK = $(shell nm -u $(PWD)/$(BIN)/$(BIN) | wc -l)
 SRCS = micomapp.c
 OBJS = $(SRCS:.c=$(OBJEXT))
 
 all: $(BIN)
-.PHONY: clean install
+.PHONY: clean install verify
 
 $(OBJS): %$(OBJEXT): %.c
 	@echo "CC: $<"
@@ -107,3 +107,13 @@ clean:
 install:
 	$(Q) mkdir -p $(SYSTEM_BIN_DIR)
 	$(Q) install $(BIN) $(SYSTEM_BIN_DIR)/$(BIN)
+
+verify:
+ifneq ($(BIN_CHECK),0)
+	@echo "Undefined Symbols"
+	$(Q) $(NM) -u -l $(BIN)
+	$(call DELFILE, $(SYSTEM_BIN_DIR)/$(BIN))
+	$(call DELFILE, $(BIN))
+	$(call CLEAN)
+	exit 1
+endif

--- a/apps/examples/elf/wifiapp/Makefile
+++ b/apps/examples/elf/wifiapp/Makefile
@@ -85,12 +85,12 @@ LDLIBS += $(LIBGCC)
 endif
 
 BIN = wifiapp
-
+BIN_CHECK = $(shell nm -u $(PWD)/$(BIN)/$(BIN) | wc -l)
 SRCS = wifiapp.c
 OBJS = $(SRCS:.c=$(OBJEXT))
 
 all: $(BIN)
-.PHONY: clean install
+.PHONY: clean install verify
 
 $(OBJS): %$(OBJEXT): %.c
 	@echo "CC: $<"
@@ -108,3 +108,14 @@ clean:
 install:
 	$(Q) mkdir -p $(SYSTEM_BIN_DIR)
 	$(Q) install $(BIN) $(SYSTEM_BIN_DIR)/$(BIN)
+
+verify:
+ifneq ($(BIN_CHECK),0)
+	@echo "Undefined Symbols"
+	$(Q) $(NM) -u -l $(BIN)
+	$(call DELFILE, $(SYSTEM_BIN_DIR)/$(BIN))
+	$(call DELFILE, $(BIN))
+	$(call CLEAN)
+	exit 1
+endif
+


### PR DESCRIPTION
Add verification of elf using nm command,  since the elf are relocatable undefined symbols will not be considered as error during linking. With this check build will stop if any undefined symbols is observed during build.

