### PR TITLE
arch/arm/imxrt : Configure FlexRAM banks for DTCM and 64KB OCRAM

### DIFF
--- a/os/arch/arm/src/imxrt/imxrt_start.c
+++ b/os/arch/arm/src/imxrt/imxrt_start.c
@@ -338,14 +338,15 @@ void imxrt_configure_ocram()
 
 void imxrt_configure_dtcm()
 {
-	/* Configure FlexRAM banks for DTCM*/
-	IOMUXC_GPR->GPR17 |= IOMUXC_GPR_GPR17_FLEXRAM_BANK_CFG(0xaaaaaaaa);
+	/* Configure FlexRAM banks for DTCM and 64KB OCRAM */
+	/* It is mandatory to have at least 64KB as OCRAM to boot the board */
+	IOMUXC_GPR->GPR17 |= IOMUXC_GPR_GPR17_FLEXRAM_BANK_CFG(0x55aaaaaa);
 	IOMUXC_GPR->GPR16 |= IOMUXC_GPR_GPR16_FLEXRAM_BANK_CFG_SEL(0x1);
 
-	/* Configure and enable DTCM */
+	/* Configure and enable DTCM for 256KB */
 	IOMUXC_GPR->GPR16 &= ~IOMUXC_GPR_GPR16_INIT_DTCM_EN_MASK;
 	IOMUXC_GPR->GPR14 &= ~IOMUXC_GPR_GPR14_CM7_CFGDTCMSZ_MASK;
-	IOMUXC_GPR->GPR14 |= IOMUXC_GPR_GPR14_CM7_CFGDTCMSZ(0xa);
+	IOMUXC_GPR->GPR14 |= IOMUXC_GPR_GPR14_CM7_CFGDTCMSZ(0x9);
 	IOMUXC_GPR->GPR16 |= IOMUXC_GPR_GPR16_INIT_DTCM_EN_MASK;
 
 	/* Disable ITCM */


### PR DESCRIPTION
Boot failure happening due to improper FlexRAM configuration in case of
DTCM usage. It is mandatory to have 64KB FlexRAM allocated for OCRAM at
all times. Due to this max size of DTCM is limited to 256KB. Issue was
happening because we were configuring complete 512KB FlexRAM as DTCM.
Change this configuration to reserve 64KB for OCRAM and 256KB for DTCM.