### PR TITLE
mm/umm_heap : Change g_mmheap to USR_HEAP

### DIFF
--- a/os/mm/umm_heap/umm_malloc.c
+++ b/os/mm/umm_heap/umm_malloc.c
@@ -141,9 +141,9 @@ static void *heap_malloc(size_t size, int s, int e, size_t retaddr)
 
 	for (heap_idx = s; heap_idx < e; heap_idx++) {
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
-		ret = mm_malloc(&g_mmheap[heap_idx], size, retaddr);
+		ret = mm_malloc(&USR_HEAP[heap_idx], size, retaddr);
 #else
-		ret = mm_malloc(&g_mmheap[heap_idx], size);
+		ret = mm_malloc(&USR_HEAP[heap_idx], size);
 #endif
 		if (ret != NULL) {
 			return ret;

--- a/os/mm/umm_heap/umm_zalloc.c
+++ b/os/mm/umm_heap/umm_zalloc.c
@@ -120,9 +120,9 @@ static void *heap_zalloc(size_t size, int s, int e, size_t retaddr)
 
 	for (heap_idx = s; heap_idx < e; heap_idx++) {
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
-		ret = mm_zalloc(&g_mmheap[heap_idx], size, retaddr);
+		ret = mm_zalloc(&USR_HEAP[heap_idx], size, retaddr);
 #else
-		ret = mm_zalloc(&g_mmheap[heap_idx], size);
+		ret = mm_zalloc(&USR_HEAP[heap_idx], size);
 #endif
 		if (ret != NULL) {
 			return ret;


### PR DESCRIPTION
For protected build, USR_HEAP will be automatically mapped to user heap address.
Sometimes, g_mmheap is not the meaning of the user heap anymore.