### PR TITLE
ProtectedLibs.mk : Add libframework to USERLIB

### DIFF
--- a/os/ProtectedLibs.mk
+++ b/os/ProtectedLibs.mk
@@ -70,6 +70,7 @@ TINYARALIBS += $(LIBRARIES_DIR)$(DELIM)libstubs$(LIBEXT) $(LIBRARIES_DIR)$(DELIM
 TINYARALIBS += $(LIBRARIES_DIR)$(DELIM)libkmm$(LIBEXT) $(LIBRARIES_DIR)$(DELIM)libkarch$(LIBEXT)
 USERLIBS  += $(LIBRARIES_DIR)$(DELIM)libproxies$(LIBEXT) $(LIBRARIES_DIR)$(DELIM)libuc$(LIBEXT)
 USERLIBS  += $(LIBRARIES_DIR)$(DELIM)libumm$(LIBEXT) $(LIBRARIES_DIR)$(DELIM)libuarch$(LIBEXT)
+USERLIBS  += $(LIBRARIES_DIR)$(DELIM)libframework$(LIBEXT)
 
 # Add libraries for C++ support.  CXX, CXXFLAGS, and COMPILEXX must
 # be defined in Make.defs for this to work!


### PR DESCRIPTION
For using framework in user, libframework should be included to USERLIB