### PR TITLE
os/arch/arm/src/imxrt: Fix imxrt config include path

### DIFF
--- a/os/arch/arm/src/imxrt/imxrt_start.c
+++ b/os/arch/arm/src/imxrt/imxrt_start.c
@@ -76,7 +76,13 @@
 #include "imxrt_userspace.h"
 #include "imxrt_start.h"
 #include "imxrt_gpio.h"
+#if defined(CONFIG_ARCH_CHIP_FAMILY_IMXRT102x)
+#include "chip/imxrt102x_config.h"
+#elif defined(CONFIG_ARCH_CHIP_FAMILY_IMXRT105x)
 #include "chip/imxrt105x_config.h"
+#else
+#error Unrecognized i.MX RT architecture
+#endif
 
 /****************************************************************************
  * Pre-processor Definitions


### PR DESCRIPTION
Fix build error in imxrt1020x/nxp_demo config by adding proper
config.h file based on IMXRT chip version.
