### PR TITLE
apps/wm_test: Add string null check logic in get_auth_type

### DIFF
--- a/apps/examples/wifi_manager_sample/wm_test.c
+++ b/apps/examples/wifi_manager_sample/wm_test.c
@@ -313,11 +313,12 @@ wifi_manager_ap_auth_type_e get_auth_type(const char *method)
 	int list_size = sizeof(wifi_test_auth_method)/sizeof(wifi_test_auth_method[0]);
 	for (; i < list_size; i++) {
 		if ((strcmp(method, wifi_test_auth_method[i]) == 0) || (strcmp(result[0], wifi_test_auth_method[i]) == 0)) {
-			if (strcmp(result[2], "ent") == 0) {
-				return auth_type_table[i + 2];
-			} else {
-				return auth_type_table[i];
+			if (result[2] != NULL) {		
+				if (strcmp(result[2], "ent") == 0) {
+					return auth_type_table[i + 3];
+				}
 			}
+			return auth_type_table[i];
 		}
 	}
 	return WIFI_MANAGER_AUTH_UNKNOWN;


### PR DESCRIPTION
- result[2] used in get_auth_type function can be null when the network is not enterprise WiFi. Therefore, we add null check logic of result[2], not to be used as an input of strcmp, which causes crash in specific board.