### PR TITLE
os\arch\xtensa:refine the esp32 spiram initialization

### DIFF
--- a/os/arch/xtensa/src/esp32/esp32_allocateheap.c
+++ b/os/arch/xtensa/src/esp32/esp32_allocateheap.c
@@ -99,7 +99,7 @@ void up_allocate_heap(FAR void **heap_start, size_t *heap_size)
 }
 
 /****************************************************************************
- * Name: xtensa_up_addregion
+ * Name: up_addregion
  *
  * Description:
  *   Memory may be added in non-contiguous chunks.  Additional chunks are
@@ -112,13 +112,6 @@ void up_allocate_heap(FAR void **heap_start, size_t *heap_size)
  ****************************************************************************/
 void up_addregion(void)
 {
-}
-
-/****************************************************************************
- * Name: up_addregion after spiram initialized
- ****************************************************************************/
-void xtensa_up_addregion(void)
-{
 	int region_cnt;
 
 	for (region_cnt = 1; region_cnt < CONFIG_MM_REGIONS; region_cnt++) {
@@ -129,6 +122,5 @@ void xtensa_up_addregion(void)
 		}
 		mm_addregion(&g_mmheap[regionx_heap_idx[region_cnt]], regionx_start[region_cnt], regionx_size[region_cnt]);
 	}
-
 }
 #endif

--- a/os/arch/xtensa/src/xtensa/xtensa.h
+++ b/os/arch/xtensa/src/xtensa/xtensa.h
@@ -353,9 +353,6 @@ void weak_function xtensa_dma_initialize(void);
 
 /* Memory management */
 
-#if CONFIG_MM_REGIONS > 1
-void xtensa_up_addregion(void); //add region after spiram initialized
-#endif
 
 /* Serial output */
 

--- a/os/board/esp32_devkit/src/esp32_boot.c
+++ b/os/board/esp32_devkit/src/esp32_boot.c
@@ -76,6 +76,11 @@
 #include "esp32_adc.h"
 #include <tinyara/analog/adc.h>
 #endif
+#ifdef CONFIG_SPIRAM_SUPPORT
+extern void esp_spiram_init_cache();
+extern int esp_spiram_init();
+#endif
+
 /************************************************************************************
  * Pre-processor Definitions
  ************************************************************************************/
@@ -128,6 +133,11 @@ void esp32_devKit_mount_partions(void)
 
 void esp32_board_initialize(void)
 {
+	/*Init SPI RAM*/
+#ifdef CONFIG_SPIRAM_SUPPORT
+	esp_spiram_init_cache();
+	esp_spiram_init();
+#endif
 }
 
 static void board_gpio_initialize(void)
@@ -232,18 +242,6 @@ void board_initialize(void)
 
 #if defined(CONFIG_ADC)
 	board_adc_initialize();
-#endif
-
-	/*Init SPI RAM*/
-#ifdef CONFIG_SPIRAM_SUPPORT
-	esp_spiram_init_cache();
-	esp_spiram_init();
-#endif
-
-//memory management of tizenrt
-#if CONFIG_MM_REGIONS > 1
-/*addregion after spiram init, to replace common up_addregion in os_start*/
-	xtensa_up_addregion();
 #endif
 
 }


### PR DESCRIPTION
move forward the spiram initialization, before os_start, to make
this external memory available during os_start. it's necessary
for the module like net(lwip) initialization
@xixidodo @sunghan-chang 