### PR TITLE
arch/armv7-m/up_assert: Add abort handling in fault manager for armv7-m

### DIFF
--- a/os/include/assert.h
+++ b/os/include/assert.h
@@ -208,9 +208,9 @@ extern "C" {
  ****************************************************************************/
 
 #ifdef CONFIG_HAVE_FILENAME
-void up_assert(FAR const uint8_t *filename, int linenum) noreturn_function;
+int up_assert(FAR const uint8_t *filename, int linenum);
 #else
-void up_assert(void) noreturn_function;
+int up_assert(void);
 #endif
 
 #ifdef CONFIG_FRAME_POINTER

--- a/os/syscall/syscall.csv
+++ b/os/syscall/syscall.csv
@@ -155,7 +155,7 @@
 "umount", "sys/mount.h", "CONFIG_NFILE_DESCRIPTORS > 0 && !defined(CONFIG_DISABLE_MOUNTPOINT)", "int", "const char*"
 "unlink", "unistd.h", "CONFIG_NFILE_DESCRIPTORS > 0 && !defined(CONFIG_DISABLE_MOUNTPOINT)", "int", "FAR const char*"
 "unsetenv", "stdlib.h", "!defined(CONFIG_DISABLE_ENVIRON)", "int", "const char*"
-"up_assert", "assert.h", "", "void", "FAR const uint8_t*", "int"
+"up_assert", "assert.h", "", "int", "FAR const uint8_t*", "int"
 #"up_assert","assert.h","","void"
 "vfork", "unistd.h", "defined(CONFIG_ARCH_HAVE_VFORK) && defined(CONFIG_SCHED_WAITPID)", "pid_t"
 "wait", "sys/wait.h", "defined(CONFIG_SCHED_WAITPID) && defined(CONFIG_SCHED_HAVE_PARENT)", "pid_t", "int*"


### PR DESCRIPTION
This patch adds support of abort handling in fault manger for armv7-m architecture.

All kinds of hard faults is handled by fault manager