### PR TITLE
os/se/sss: Add security hal isp wrapper debug in debug.h

### DIFF
--- a/os/include/debug.h
+++ b/os/include/debug.h
@@ -845,6 +845,22 @@
 #define sdllvdbg(...)
 #endif
 
+#ifdef CONFIG_DEBUG_SECURE_ELEMENT_ERROR
+#define sedbg(format, ...)     dbg(format, ##__VA_ARGS__)
+#define selldbg(format, ...)   lldbg(format, ##__VA_ARGS__)
+#else
+#define sedbg(...)
+#define selldbg(...)
+#endif
+
+#ifdef CONFIG_DEBUG_SECURE_ELEMENT_INFO
+#define sevdbg(format, ...)     vdbg(format, ##__VA_ARGS__)
+#define sellvdbg(format, ...)   llvdbg(format, ##__VA_ARGS__)
+#else
+#define sevdbg(...)
+#define sellvdbg(...)
+#endif
+
 #else							/* CONFIG_CPP_HAVE_VARARGS */
 
 /* Variadic macros NOT supported */
@@ -1309,6 +1325,23 @@
 #define sdvdbg     (void)
 #define sdllvdbg   (void)
 #endif
+
+#ifdef CONFIG_DEBUG_SECURE_ELEMENT_ERROR
+#define sedbg      dbg
+#define selldbg    lldbg
+#else
+#define sedbg      (void)
+#define selldbg    (void)
+#endif
+
+#ifdef CONFIG_DEBUG_SECURE_ELEMENT_INFO
+#define sevdbg     vdbg
+#define sellvdbg   llvdbg
+#else
+#define sevdbg     (void)
+#define sellvdbg   (void)
+#endif
+
 #endif							/* CONFIG_CPP_HAVE_VARARGS */
 
 /* Buffer dumping macros do not depend on varargs */

--- a/os/se/Kconfig
+++ b/os/se/Kconfig
@@ -9,6 +9,21 @@ config SE
 	select SECURITY_LINK_DRV
 
 if SE
+
+config DEBUG_SECURE_ELEMENT_ERROR
+	bool "Secure element debug ERROR"
+	default n
+	depends on DEBUG_ERROR
+	---help---
+		Enable Secure Element ERROR Debug
+
+config DEBUG_SECURE_ELEMENT_INFO
+	bool "Secure element debug INFO"
+	default n
+	depends on DEBUG_VERBOSE
+	---help---
+		Enable Secure Element INFO Debug
+
 choice
 	prompt "SE selection"
 	default SE_SSS

--- a/os/se/sss/Kconfig
+++ b/os/se/sss/Kconfig
@@ -49,4 +49,3 @@ config SE_STORAGE
 	default n
 	---help---
 		SE supports Secure Stroage
-		

--- a/os/se/sss/security_hal_wrapper.c
+++ b/os/se/sss/security_hal_wrapper.c
@@ -51,11 +51,11 @@
 
 #define ISP_CHECKBUSY() while (isp_get_status()) {}
 
-#define HWRAP_LOG printf
 #define HWRAP_TAG "[HAL_WRAPPER]"
+
 #define HWRAP_ENTER                                                         \
 	do {                                                                    \
-		HWRAP_LOG(HWRAP_TAG"%s\t%s:%d\n", __FUNCTION__, __FILE__, __LINE__);\
+		sedbg(HWRAP_TAG"%s:%d\n", __FILE__, __LINE__);                      \
 	} while (0)
 
 #define HAL_MAX_RANDOM_SIZE 256
@@ -567,7 +567,7 @@ int sss_hal_set_key(hal_key_type mode, uint32_t key_idx, hal_data *key, hal_data
 	int ret = isp_set_securekey(key->data, key->data_len, key_type, key_idx);
 	if (ret != 0) {
 		isp_clear(0);
-		HWRAP_LOG("ISP failed (%zu)\n", ret);
+		sedbg("ISP failed (%zu)\n", ret);
 		return HAL_FAIL;;
 	}
 
@@ -617,7 +617,7 @@ int sss_hal_get_key(hal_key_type mode, uint32_t key_idx, hal_data *key)
 		ret = isp_ecdsa_get_publickey_securekey(&ecc_key, key_idx, object_id);
 		if (ret != 0) {
 			isp_clear(0);
-			HWRAP_LOG("ISP failed (%zu)\n", ret);
+			sedbg("ISP failed (%zu)\n", ret);
 			return HAL_FAIL;
 		}
 
@@ -634,7 +634,7 @@ int sss_hal_get_key(hal_key_type mode, uint32_t key_idx, hal_data *key)
 		ret = isp_get_factorykey_data(key->data, &key->data_len, key_idx);
 		if (ret != 0) {
 			isp_clear(0);
-			HWRAP_LOG("ISP failed (%zu)\n", ret);
+			sedbg("ISP failed (%zu)\n", ret);
 			return HAL_FAIL;
 		}
 	} else {
@@ -700,7 +700,7 @@ int sss_hal_remove_key(hal_key_type mode, uint32_t key_idx)
 	ret = isp_remove_key(key_type, key_idx);
 	if (ret != 0) {
 		isp_clear(0);
-		HWRAP_LOG("ISP failed (%zu)\n", ret);
+		sedbg("ISP failed (%zu)\n", ret);
 		return HAL_FAIL;
 	}
 	return HAL_SUCCESS;
@@ -777,7 +777,7 @@ int sss_hal_generate_key(hal_key_type mode, uint32_t key_idx)
 	}
 	if (ret != 0) {
 		isp_clear(0);
-		HWRAP_LOG("ISP failed (%zu)\n", ret);
+		sedbg("ISP failed (%zu)\n", ret);
 		return HAL_FAIL;
 	}
 
@@ -806,7 +806,7 @@ int sss_hal_generate_random(uint32_t len, hal_data *random)
 	ret = isp_generate_random(inbuf, len / 4);
 	if (ret != 0) {
 		isp_clear(0);
-		HWRAP_LOG("ISP failed (%zu)\n", ret);
+		sedbg("ISP failed (%zu)\n", ret);
 		return HAL_FAIL;
 	}
 
@@ -856,7 +856,7 @@ int sss_hal_get_hash(hal_hash_type mode, hal_data *input, hal_data *hash)
 	ret = isp_hash(output, &h_param, object_id);
 	if (ret != 0) {
 		isp_clear(0);
-		HWRAP_LOG("ISP failed (%zu)\n", ret);
+		sedbg("ISP failed (%zu)\n", ret);
 		return HAL_FAIL;
 	}
 
@@ -911,7 +911,7 @@ int sss_hal_rsa_sign_md(hal_rsa_mode mode, hal_data *hash, uint32_t key_idx, hal
 	ret = isp_rsa_sign_md_securekey(&rsa_sign, hash->data, hash->data_len, key_idx);
 	if (ret != 0) {
 		isp_clear(0);
-		HWRAP_LOG("ISP failed (%zu)\n", ret);
+		sedbg("ISP failed (%zu)\n", ret);
 		return HAL_FAIL;
 	}
 
@@ -962,7 +962,7 @@ int sss_hal_rsa_verify_md(hal_rsa_mode mode, hal_data *hash, hal_data *sign, uin
 	ret = isp_rsa_verify_md_securekey(&rsa_sign, hash->data, hash->data_len, key_idx);
 	if (ret != 0) {
 		isp_clear(0);
-		HWRAP_LOG("ISP failed (%zu)\n", ret);
+		sedbg("ISP failed (%zu)\n", ret);
 		return HAL_FAIL;
 	}
 
@@ -1024,7 +1024,7 @@ int sss_hal_ecdsa_sign_md(hal_data *hash, uint32_t key_idx, hal_ecdsa_mode *mode
 	ret = isp_ecdsa_sign_md_securekey(&ecc_sign, hash->data, hash->data_len, key_idx);
 	if (ret != 0) {
 		isp_clear(0);
-		HWRAP_LOG("ISP failed (%zu)\n", ret);
+		sedbg("ISP failed (%zu)\n", ret);
 		return HAL_FAIL;
 	}
 
@@ -1146,7 +1146,7 @@ int sss_hal_ecdsa_verify_md(hal_ecdsa_mode mode, hal_data *hash, hal_data *sign,
 	ret = isp_ecdsa_verify_md_securekey(&ecc_sign, hash->data, hash->data_len, key_idx);
 	if (ret != 0) {
 		isp_clear(0);
-		HWRAP_LOG("ISP failed (%zu)\n", ret);
+		sedbg("ISP failed (%zu)\n", ret);
 		ret = HAL_FAIL;
 		goto cleanup;
 	}
@@ -1202,7 +1202,7 @@ int sss_hal_dh_generate_param(uint32_t dh_idx, hal_dh_data *dh_param)
 	ret = isp_dh_generate_keypair_userparam_securestorage(&d_param, dh_idx);
 	if (ret != 0) {
 		isp_clear(0);
-		HWRAP_LOG("ISP failed (%zu)\n", ret);
+		sedbg("ISP failed (%zu)\n", ret);
 		return HAL_FAIL;
 	}
 
@@ -1247,7 +1247,7 @@ int sss_hal_dh_compute_shared_secret(hal_dh_data *dh_param, uint32_t dh_idx, hal
 	ret = isp_dh_compute_shared_secret_securekey(output, &shared_secret->data_len, d_param, dh_idx);
 	if (ret != 0) {
 		isp_clear(0);
-		HWRAP_LOG("ISP failed (%zu)\n", ret);
+		sedbg("ISP failed (%zu)\n", ret);
 		return HAL_FAIL;
 	}
 
@@ -1299,7 +1299,7 @@ int sss_hal_ecdh_compute_shared_secret(hal_ecdh_data *ecdh_param, uint32_t key_i
 	ret = isp_compute_ecdh_securekey(output, &shared_secret->data_len, ecc_pub, key_idx);
 	if (ret != 0) {
 		isp_clear(0);
-		HWRAP_LOG("ISP failed (%zu)\n", ret);
+		sedbg("ISP failed (%zu)\n", ret);
 		return HAL_FAIL;
 	}
 
@@ -1319,7 +1319,7 @@ int sss_hal_set_certificate(uint32_t cert_idx, hal_data *cert_in)
 	ret = isp_write_cert(cert, cert_len, cert_idx);
 	if (ret != 0) {
 		isp_clear(0);
-		HWRAP_LOG("ISP failed (%zu)\n", ret);
+		sedbg("ISP failed (%zu)\n", ret);
 		return HAL_FAIL;
 	}
 
@@ -1338,14 +1338,14 @@ int sss_hal_get_certificate(uint32_t cert_idx, hal_data *cert_out)
 		ret = isp_get_factorykey_data(buf, &buf_len, cert_idx);
 		if (ret != 0) {
 			isp_clear(0);
-			HWRAP_LOG("ISP failed (%zu)\n", ret);
+			sedbg("ISP failed (%zu)\n", ret);
 			return HAL_FAIL;
 		}
 	} else {
 		ret = isp_read_cert(buf, &buf_len, cert_idx);
 		if (ret != 0) {
 			isp_clear(0);
-			HWRAP_LOG("ISP failed (%zu)\n", ret);
+			sedbg("ISP failed (%zu)\n", ret);
 			return HAL_FAIL;
 		}
 	}
@@ -1370,7 +1370,7 @@ int sss_hal_get_factory_key(uint32_t key_idx, hal_data *key)
 		ret = isp_get_factorykey_data(key->data, &key->data_len, key_idx);
 		if (ret != 0) {
 			isp_clear(0);
-			HWRAP_LOG("ISP failed (%zu)\n", ret);
+			sedbg("ISP failed (%zu)\n", ret);
 			return HAL_FAIL;
 		}
 	} else {
@@ -1389,7 +1389,7 @@ int sss_hal_get_factory_cert(uint32_t cert_idx, hal_data *cert)
 		ret = isp_get_factorykey_data(cert->data, &cert->data_len, cert_idx);
 		if (ret != 0) {
 			isp_clear(0);
-			HWRAP_LOG("ISP failed (%zu)\n", ret);
+			sedbg("ISP failed (%zu)\n", ret);
 			return HAL_FAIL;
 		}
 	} else {
@@ -1449,7 +1449,7 @@ int sss_hal_aes_encrypt(hal_data *dec_data, hal_aes_param *aes_param, uint32_t k
 	ret = isp_aes_encrypt_securekey(&param, key_idx);;
 	if (ret != 0) {
 		isp_clear(0);
-		HWRAP_LOG("ISP failed (%zu)\n", ret);
+		sedbg("ISP failed (%zu)\n", ret);
 		return HAL_FAIL;
 	}
 
@@ -1497,7 +1497,7 @@ int sss_hal_aes_decrypt(hal_data *enc_data, hal_aes_param *aes_param, uint32_t k
 	ret = isp_aes_decrypt_securekey(&param, key_idx);;
 	if (ret != 0) {
 		isp_clear(0);
-		HWRAP_LOG("ISP failed (%zu)\n", ret);
+		sedbg("ISP failed (%zu)\n", ret);
 		return HAL_FAIL;
 	}
 
@@ -1516,7 +1516,7 @@ int sss_hal_rsa_encrypt(hal_data *dec_data, hal_rsa_mode *rsa_mode, uint32_t key
 	ret = isp_rsa_encrypt_securekey(output, &enc_data->data_len, dec_data->data, dec_data->data_len, key_idx);
 	if (ret != 0) {
 		isp_clear(0);
-		HWRAP_LOG("ISP failed (%zu)\n", ret);
+		sedbg("ISP failed (%zu)\n", ret);
 		return HAL_FAIL;
 	}
 
@@ -1534,7 +1534,7 @@ int sss_hal_rsa_decrypt(hal_data *enc_data, hal_rsa_mode *rsa_mode, uint32_t key
 	ret = isp_rsa_decrypt_securekey(output, &dec_data->data_len, enc_data->data, enc_data->data_len, key_idx);
 	if (ret != 0) {
 		isp_clear(0);
-		HWRAP_LOG("ISP failed (%zu)\n", ret);
+		sedbg("ISP failed (%zu)\n", ret);
 		return HAL_FAIL;
 	}
 
@@ -1556,7 +1556,7 @@ int sss_hal_write_storage(uint32_t ss_idx, hal_data *data)
 	ret = isp_write_storage(data->data, data->data_len, ss_idx);
 	if (ret != 0) {
 		isp_clear(0);
-		HWRAP_LOG("ISP failed (%zu)\n", ret);
+		sedbg("ISP failed (%zu)\n", ret);
 		return HAL_FAIL;
 	}
 
@@ -1573,7 +1573,7 @@ int sss_hal_read_storage(uint32_t ss_idx, hal_data *data)
 	ret = isp_read_storage(output, &data->data_len, ss_idx);
 	if (ret != 0) {
 		isp_clear(0);
-		HWRAP_LOG("ISP failed (%zu)\n", ret);
+		sedbg("ISP failed (%zu)\n", ret);
 		return HAL_FAIL;
 	}
 


### PR DESCRIPTION
- Remove printf in security_hal_wrapper.c
- Define debug configs and corresponding modules in debug.h
- Use sidbg (or sivdbg) instead of printf