### PR TITLE
Add sdram function by SEMC interface in IMXRT

### DIFF
--- a/os/arch/arm/src/imxrt/Make.defs
+++ b/os/arch/arm/src/imxrt/Make.defs
@@ -117,7 +117,8 @@ CHIP_CSRCS  = imxrt_allocateheap.c imxrt_start.c imxrt_clockconfig.c
 CHIP_CSRCS += imxrt_periphclks.c imxrt_irq.c imxrt_clrpend.c imxrt_gpio.c
 CHIP_CSRCS += imxrt_daisy.c imxrt_wdog.c imxrt_iomuxc.c imxrt_serial.c
 CHIP_CSRCS += imxrt_lowputc.c imxrt_flexspi.c imxrt_clock.c imxrt_log.c
-CHIP_CSRCS += imxrt_dmamux.c
+CHIP_CSRCS += imxrt_dmamux.c imxrt_flexram.c imxrt_semc.c
+CHIP_CSRCS += imxrt_semc_sdram.c
 
 # Configuration-dependent i.MX RT files
 

--- a/os/arch/arm/src/imxrt/imxrt_flexram.c
+++ b/os/arch/arm/src/imxrt/imxrt_flexram.c
@@ -1,0 +1,423 @@
+/****************************************************************************
+ *
+ * Copyright 2019 NXP Semiconductors All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+/*
+ * Copyright 2017 NXP
+ * All rights reserved.
+ *
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+#include <stddef.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <tinyara/irq.h>
+#include <tinyara/arch.h>
+#include "cache.h"
+#include "imxrt_clock.h"
+#include "imxrt_flexram.h"
+#include "imxrt_log.h"
+
+/*******************************************************************************
+ * Definitions
+ ******************************************************************************/
+#if defined(CONFIG_ARCH_CHIP_FAMILY_IMXRT102x)
+#define IMXRT_FLEXRAM_OCRAM_START_ADDR 0x20200000
+#define IMXRT_FLEXRAM_OCRAM_MAGIC_ADDR 0x202000A0
+
+#define IMXRT_FLEXRAM_DTCM_START_ADDR 0x20000000
+#define IMXRT_FLEXRAM_DTCM_MAGIC_ADDR 0x200000A0
+
+#define IMXRT_FLEXRAM_ITCM_START_ADDR 0x0
+#define IMXRT_FLEXRAM_ITCM_MAGIC_ADDR 0xA0
+
+/* OCRAM relocate definition */
+//#define IMXRT_OCRAM_SIZE (256 * 1024U)
+#define IMXRT_OCRAM_ALLOCATE_BANK_NUM 2
+#define IMXRT_ITCM_ALLOCATE_BANK_NUM 4
+#define IMXRT_DTCM_ALLOCATE_BANK_NUM 2
+#elif defined(CONFIG_ARCH_CHIP_FAMILY_IMXRT105x)
+#define IMXRT_FLEXRAM_OCRAM_START_ADDR 0x20200000
+#define IMXRT_FLEXRAM_OCRAM_MAGIC_ADDR 0x202000A0
+
+#define IMXRT_FLEXRAM_DTCM_START_ADDR 0x20000000
+#define IMXRT_FLEXRAM_DTCM_MAGIC_ADDR 0x200000A0
+
+#define IMXRT_FLEXRAM_ITCM_START_ADDR 0x0
+#define IMXRT_FLEXRAM_ITCM_MAGIC_ADDR 0xA0
+
+/* OCRAM relocate definition */
+//#define IMXRT_OCRAM_SIZE (512 * 1024U)
+#define IMXRT_OCRAM_ALLOCATE_BANK_NUM 16
+#define IMXRT_ITCM_ALLOCATE_BANK_NUM 0
+#define IMXRT_DTCM_ALLOCATE_BANK_NUM 0
+#else
+#error Unrecognized i.MX RT architecture
+#endif
+
+
+/*******************************************************************************
+ * Prototypes
+ ******************************************************************************/
+/*!
+ * @brief Gets the instance from the base address to be used to gate or ungate the module clock
+ *
+ * @param base FLEXRAM base address
+ *
+ * @return The FLEXRAM instance
+ */
+static uint32_t imxrt_flexram_getinstance(FLEXRAM_Type *base);
+
+/*!
+ * @brief FLEXRAM map TCM size to register value
+ *
+ * @param tcmBankNum tcm banknumber
+ * @retval register value correspond to the tcm size
+  */
+static uint8_t imxrt_flexram_maptcmsizetoregister(uint8_t tcmBankNum);
+
+/*******************************************************************************
+ * Variables
+ ******************************************************************************/
+/*! @brief Pointers to FLEXRAM bases for each instance. */
+static FLEXRAM_Type *const s_flexramBases[] = FLEXRAM_BASE_PTRS;
+
+#if !(defined(FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL) && FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL)
+/*! @brief Pointers to FLEXRAM clocks for each instance. */
+static const clock_ip_name_t s_flexramClocks[] = FLEXRAM_CLOCKS;
+#endif /* FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL */
+
+/*******************************************************************************
+ * Code
+ ******************************************************************************/
+/****************************************************************************
+ * Function: imxrt_flexram_getinstance
+ *
+ * Description:
+ *   brief get instance for flexram
+ *
+ * Input Parameters:
+ *   base FLEXRAM base address.
+ *
+ * Returned Value:
+ *   Returns the intance
+ *
+ ****************************************************************************/
+static uint32_t imxrt_flexram_getinstance(FLEXRAM_Type *base)
+{
+    uint32_t instance;
+
+    /* Find the instance index from base address mappings. */
+    for (instance = 0; instance < ARRAY_SIZE(s_flexramBases); instance++)
+    {
+        if (s_flexramBases[instance] == base)
+        {
+            break;
+        }
+    }
+
+    assert(instance < ARRAY_SIZE(s_flexramBases));
+
+    return instance;
+}
+
+/****************************************************************************
+ * Function: imxrt_flexram_init
+ *
+ * Description:
+ *   brief FLEXRAM module initialization function.
+ *
+ * Input Parameters:
+ *   base FLEXRAM base address.
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+void imxrt_flexram_init(FLEXRAM_Type *base)
+{
+#if !(defined(FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL) && FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL)
+    /* Ungate ENET clock. */
+    imxrt_clock_enableclock(s_flexramClocks[imxrt_flexram_getinstance(base)]);
+#endif /* FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL */
+
+    /* enable all the interrupt status */
+    base->INT_STAT_EN |= kFLEXRAM_InterruptStatusAll;
+    /* clear all the interrupt status */
+    base->INT_STATUS |= kFLEXRAM_InterruptStatusAll;
+    /* disable all the interrpt */
+    base->INT_SIG_EN = 0U;
+}
+
+/****************************************************************************
+ * Function: imxrt_flexram_deinit
+ *
+ * Description:
+ *   brief Deinitializes the FLEXRAM.
+ *
+ * Input Parameters:
+ *   base FLEXRAM base address.
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+void imxrt_flexram_deinit(FLEXRAM_Type *base)
+{
+#if !(defined(FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL) && FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL)
+    /* Ungate ENET clock. */
+    imxrt_clock_disableclock(s_flexramClocks[imxrt_flexram_getinstance(base)]);
+#endif /* FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL */
+}
+
+/****************************************************************************
+ * Function: imxrt_flexram_maptcmsizetoregister
+ *
+ * Description:
+ *   brief map tcm size to register
+ *
+ * Input Parameters:
+ *   tcmBankNum tcm Bank Number.
+ *
+ * Returned Value:
+ *   Return tcmConfig
+ *
+ ****************************************************************************/
+static uint8_t imxrt_flexram_maptcmsizetoregister(uint8_t tcmBankNum)
+{
+    uint8_t tcmSizeConfig = 0U;
+    uint32_t totalTcmSize = 0U;
+
+    /* if bank number is a odd value, use a new bank number which bigger than target */
+    do
+    {
+        if ((tcmBankNum & (tcmBankNum - 1U)) == 0U)
+        {
+            break;
+        }
+    } while (++tcmBankNum < FSL_FEATURE_FLEXRAM_INTERNAL_RAM_TOTAL_BANK_NUMBERS);
+
+    totalTcmSize = tcmBankNum * (FSL_FEATURE_FLEXRAM_INTERNAL_RAM_BANK_SIZE >> 10U);
+    /* get bit '1' position */
+    while (totalTcmSize)
+    {
+        if ((totalTcmSize & 1U) == 0U)
+        {
+            tcmSizeConfig++;
+        }
+        else
+        {
+            break;
+        }
+        totalTcmSize >>= 1U;
+    }
+
+    return tcmSizeConfig + 1U;
+}
+
+/****************************************************************************
+ * Function: imxrt_flexram_settcmsize
+ *
+ * Description:
+ *   brief map tcm size to register
+ *
+ * Input Parameters:
+ *   itcmBankNum itcm Bank Number.
+ *   dtcmBankNum dtcm Bank Number
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+void imxrt_flexram_settcmsize(uint8_t itcmBankNum, uint8_t dtcmBankNum)
+{
+    char tempLog[128];
+    uint8_t size = 0;
+
+    assert(itcmBankNum <= FSL_FEATURE_FLEXRAM_INTERNAL_RAM_TOTAL_BANK_NUMBERS);
+    assert(dtcmBankNum <= FSL_FEATURE_FLEXRAM_INTERNAL_RAM_TOTAL_BANK_NUMBERS);
+
+    IMXLOG("imxrt_flexram_settcmsize:");
+    snprintf(tempLog, sizeof(tempLog), "itcmBankNum %d", itcmBankNum);
+    IMXLOG(tempLog);
+    snprintf(tempLog, sizeof(tempLog), "dtcmBankNum %d", dtcmBankNum);
+    IMXLOG(tempLog);
+
+    size = imxrt_flexram_maptcmsizetoregister(dtcmBankNum);
+    snprintf(tempLog, sizeof(tempLog), "dtcm size %d", size);
+    IMXLOG(tempLog);
+
+    /* dtcm configuration */
+    if (dtcmBankNum != 0U)
+    {
+        IOMUXC_GPR->GPR14 &= ~IOMUXC_GPR_GPR14_CM7_CFGDTCMSZ_MASK;
+        IOMUXC_GPR->GPR14 |= IOMUXC_GPR_GPR14_CM7_CFGDTCMSZ(imxrt_flexram_maptcmsizetoregister(dtcmBankNum));
+        IOMUXC_GPR->GPR16 |= IOMUXC_GPR_GPR16_INIT_DTCM_EN_MASK;
+    }
+    else
+    {
+        IOMUXC_GPR->GPR16 &= ~IOMUXC_GPR_GPR16_INIT_DTCM_EN_MASK;
+    }
+
+    size = imxrt_flexram_maptcmsizetoregister(itcmBankNum);
+    snprintf(tempLog, sizeof(tempLog), "itcm size %d", size);
+    IMXLOG(tempLog);
+
+    /* itcm configuration */
+    if (itcmBankNum != 0U)
+    {
+        IOMUXC_GPR->GPR14 &= ~IOMUXC_GPR_GPR14_CM7_CFGITCMSZ_MASK;
+        IOMUXC_GPR->GPR14 |= IOMUXC_GPR_GPR14_CM7_CFGITCMSZ(imxrt_flexram_maptcmsizetoregister(itcmBankNum));
+        IOMUXC_GPR->GPR16 |= IOMUXC_GPR_GPR16_INIT_ITCM_EN_MASK;
+    }
+    else
+    {
+        //IOMUXC_GPR->GPR16 &= ~IOMUXC_GPR_GPR16_INIT_ITCM_EN_MASK;
+    }
+}
+
+/****************************************************************************
+ * Function: imxrt_flexram_allocateram
+ *
+ * Description:
+ *   LEXRAM allocate on-chip ram for OCRAM,ITCM,DTCM
+ *   This function is independent of FLEXRAM_Init, it can be called directly if ram re-allocate
+ *   is needed.
+ *
+ * Input Parameters:
+ *   config allocate configuration.
+ *
+ * Returned Value:
+ *   Returns kStatus_InvalidArgument the argument is invalid
+ *   Returns kStatus_Success allocate success
+ *
+ ****************************************************************************/
+status_t imxrt_flexram_allocateram(flexram_allocate_ram_t *config)
+{
+    assert(config != NULL);
+
+    uint8_t dtcmBankNum = config->dtcmBankNum;
+    uint8_t itcmBankNum = config->itcmBankNum;
+    uint8_t ocramBankNum = config->ocramBankNum;
+    uint32_t bankCfg = 0U, i = 0U;
+
+    /* check the arguments */
+    if (FSL_FEATURE_FLEXRAM_INTERNAL_RAM_TOTAL_BANK_NUMBERS < (dtcmBankNum + itcmBankNum + ocramBankNum))
+    {
+        return kStatus_InvalidArgument;
+    }
+
+    /* flexram bank config value */
+    for (i = 0U; i < FSL_FEATURE_FLEXRAM_INTERNAL_RAM_TOTAL_BANK_NUMBERS; i++)
+    {
+        if (i < ocramBankNum)
+        {
+            bankCfg |= ((uint32_t)kFLEXRAM_BankOCRAM) << (i * 2);
+            continue;
+        }
+
+        if (i < (dtcmBankNum + ocramBankNum))
+        {
+            bankCfg |= ((uint32_t)kFLEXRAM_BankDTCM) << (i * 2);
+            continue;
+        }
+
+        if (i < (dtcmBankNum + ocramBankNum + itcmBankNum))
+        {
+            bankCfg |= ((uint32_t)kFLEXRAM_BankITCM) << (i * 2);
+            continue;
+        }
+    }
+    IOMUXC_GPR->GPR17 = bankCfg;
+    /* set TCM size */
+    imxrt_flexram_settcmsize(itcmBankNum, dtcmBankNum);
+    /* select ram allocate source from FLEXRAM_BANK_CFG */
+    imxrt_flexram_setallocateramsrc(kFLEXRAM_BankAllocateThroughBankCfg);
+
+    return kStatus_Success;
+}
+
+/****************************************************************************
+ * Function: imxrt_ocram_reallocate
+ *
+ * Description:
+ *   LEXRAM allocate on-chip ram for OCRAM,ITCM,DTCM
+ *   This function is independent of FLEXRAM_Init, it can be called directly if ram re-allocate
+ *   is needed.
+ *
+ * Input Parameters:
+ *   config allocate configuration.
+ *
+ * Returned Value:
+ *   Returns kStatus_InvalidArgument the argument is invalid
+ *   Returns kStatus_Success allocate success
+ *
+ ****************************************************************************/
+static status_t imxrt_ocram_reallocate(void)
+{
+    char tempLog[128];
+
+    flexram_allocate_ram_t ramAllocate = {
+        .ocramBankNum = IMXRT_OCRAM_ALLOCATE_BANK_NUM,
+        .dtcmBankNum = IMXRT_ITCM_ALLOCATE_BANK_NUM,
+        .itcmBankNum = IMXRT_DTCM_ALLOCATE_BANK_NUM,
+    };
+
+    IMXLOG("Allocate on-chip ram:");
+    snprintf(tempLog, sizeof(tempLog), "OCRAM bank numbers %d", ramAllocate.ocramBankNum);
+    IMXLOG(tempLog);
+    snprintf(tempLog, sizeof(tempLog), "DTCM  bank numbers %d", ramAllocate.dtcmBankNum);
+    IMXLOG(tempLog);
+    snprintf(tempLog, sizeof(tempLog), "ITCM  bank numbers %d", ramAllocate.itcmBankNum);
+    IMXLOG(tempLog);
+
+    if (imxrt_flexram_allocateram(&ramAllocate) != kStatus_Success)
+    {
+        IMXLOG("Allocate on-chip ram fail");
+        return kStatus_Fail;
+    }
+    else
+    {
+        IMXLOG("Allocate on-chip ram success");
+    }
+
+    return kStatus_Success;
+}
+
+/****************************************************************************
+ * Function: imxrt_flexram_initialize
+ *
+ * Description:
+ *   FlexRam Initialize
+ *
+ * Input Parameters:
+ *   None
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+void imxrt_flexram_initialize(void)
+{
+    arch_disable_dcache();
+
+    up_enable_irq(IMXRT_IRQ_CM7FR);
+
+    imxrt_ocram_reallocate();
+
+    imxrt_flexram_init(FLEXRAM);
+}

--- a/os/arch/arm/src/imxrt/imxrt_flexram.h
+++ b/os/arch/arm/src/imxrt/imxrt_flexram.h
@@ -1,0 +1,436 @@
+/****************************************************************************
+ *
+ * Copyright 2019 NXP Semiconductors All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+/*
+ * Copyright 2017 NXP
+ * All rights reserved.
+ *
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef _IMXRT_FLEXRAM_H_
+#define _IMXRT_FLEXRAM_H_
+
+#include <stdint.h>
+#include <tinyara/config.h>
+
+#if defined(CONFIG_ARCH_CHIP_FAMILY_IMXRT102x)
+#include <chip/imxrt102x_features.h>
+#include "chip/imxrt102x_config.h"
+#elif defined(CONFIG_ARCH_CHIP_FAMILY_IMXRT105x)
+#include <chip/imxrt105x_features.h>
+#include "chip/imxrt105x_config.h"
+#else
+#error Unrecognized i.MX RT architecture
+#endif
+
+#include "imxrt_config.h"
+
+/*!
+ * @addtogroup flexram
+ * @{
+ */
+
+/******************************************************************************
+ * Definitions.
+ *****************************************************************************/
+/*! @brief flexram write read sel */
+enum _flexram_wr_rd_sel
+{
+    kFLEXRAM_Read = 0U,  /*!< read */
+    kFLEXRAM_Write = 1U, /*!< write */
+};
+
+/*! @brief Interrupt status flag mask */
+enum _flexram_interrupt_status
+{
+    kFLEXRAM_OCRAMAccessError = FLEXRAM_INT_STATUS_OCRAM_ERR_STATUS_MASK, /*!< ocram access unallocated address */
+    kFLEXRAM_DTCMAccessError = FLEXRAM_INT_STATUS_DTCM_ERR_STATUS_MASK,   /*!< dtcm access unallocated address */
+    kFLEXRAM_ITCMAccessError = FLEXRAM_INT_STATUS_ITCM_ERR_STATUS_MASK,   /*!< itcm access unallocated address */
+
+    kFLEXRAM_InterruptStatusAll = FLEXRAM_INT_STATUS_OCRAM_ERR_STATUS_MASK | FLEXRAM_INT_STATUS_DTCM_ERR_STATUS_MASK |
+                                  FLEXRAM_INT_STATUS_ITCM_ERR_STATUS_MASK, /*!< all the interrupt status mask */
+};
+
+/*! @brief FLEXRAM TCM access mode
+* Fast access mode expected to be finished in 1-cycle
+* Wait access mode expected to be finished in 2-cycle
+* Wait access mode is a feature of the flexram and it should be used when
+* the cpu clock too fast to finish tcm access in 1-cycle.
+* Normally, fast mode is the default mode, the efficiency of the tcm access will better.
+*/
+typedef enum _flexram_tcm_access_mode
+{
+    kFLEXRAM_TCMAccessFastMode = 0U, /*!< fast access mode */
+    kFLEXRAM_TCMAccessWaitMode = 1U, /*!< wait access mode */
+} flexram_tcm_access_mode_t;
+
+/*! @brief FLEXRAM bank type */
+enum _flexram_bank_type
+{
+    kFLEXRAM_BankNotUsed = 0U, /*!< bank is not used */
+    kFLEXRAM_BankOCRAM = 1U,   /*!< bank is OCRAM */
+    kFLEXRAM_BankDTCM = 2U,    /*!< bank is DTCM */
+    kFLEXRAM_BankITCM = 3U,    /*!< bank is ITCM */
+};
+
+/*! @brief FLEXRAM tcm support size */
+enum _flexram_tcm_size
+{
+    kFLEXRAM_TCMSize32KB = 32 * 1024U,   /*!< TCM total size 32KB */
+    kFLEXRAM_TCMSize64KB = 64 * 1024U,   /*!< TCM total size 64KB */
+    kFLEXRAM_TCMSize128KB = 128 * 1024U, /*!< TCM total size 128KB */
+    kFLEXRAM_TCMSize256KB = 256 * 1024U, /*!< TCM total size 256KB */
+    kFLEXRAM_TCMSize512KB = 512 * 1024U, /*!< TCM total size 512KB */
+};
+
+/*! @brief FLEXRAM bank allocate source */
+typedef enum _flexram_bank_allocate_src
+{
+    kFLEXRAM_BankAllocateThroughHardwareFuse = 0U, /*!< allocate ram through hardware fuse value */
+    kFLEXRAM_BankAllocateThroughBankCfg = 1U,      /*!< allocate ram through FLEXRAM_BANK_CFG */
+} flexram_bank_allocate_src_t;
+
+/*! @brief FLEXRAM allocate ocram, itcm, dtcm size */
+typedef struct _flexram_allocate_ram
+{
+    const uint8_t ocramBankNum; /*!< ocram banknumber which the SOC support */
+    const uint8_t dtcmBankNum;  /*!< dtcm bank number to allocate, the number should be power of 2 */
+    const uint8_t itcmBankNum;  /*!< itcm bank number to allocate, the number should be power of 2 */
+} flexram_allocate_ram_t;
+
+/*******************************************************************************
+ * APIs
+ ******************************************************************************/
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+/*!
+ * @name Initialization and deinitialization
+ * @{
+ */
+
+/****************************************************************************
+ * Function: imxrt_flexram_init
+ *
+ * Description:
+ *   brief FLEXRAM module initialization function.
+ *
+ * Input Parameters:
+ *   base FLEXRAM base address.
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+void imxrt_flexram_init(FLEXRAM_Type *base);
+
+/****************************************************************************
+ * Function: imxrt_flexram_deinit
+ *
+ * Description:
+ *   brief Deinitializes the FLEXRAM.
+ *
+ * Input Parameters:
+ *   base FLEXRAM base address.
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+void imxrt_flexram_deinit(FLEXRAM_Type *base);
+
+/* @} */
+
+/*!
+ * @name Status
+ * @{
+ */
+/****************************************************************************
+ * Function: imxrt_flexram_getinterruptstatus
+ *
+ * Description:
+ *   brief FLEXRAM module get interrupt status.
+ *
+ * Input Parameters:
+ *   base FLEXRAM base address.
+ *
+ * Returned Value:
+ *   Return the interrupt status
+ *
+ ****************************************************************************/
+static inline uint32_t imxrt_flexram_getinterruptstatus(FLEXRAM_Type *base)
+{
+    return base->INT_STATUS & kFLEXRAM_InterruptStatusAll;
+}
+
+/****************************************************************************
+ * Function: imxrt_flexram_clearinterruptstatus
+ *
+ * Description:
+ *   brief FLEXRAM module clear interrupt status.
+ *
+ * Input Parameters:
+ *   base FLEXRAM base address.
+ *   status status to clear.
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+static inline void imxrt_flexram_clearinterruptstatus(FLEXRAM_Type *base, uint32_t status)
+{
+    base->INT_STATUS |= status;
+}
+
+/****************************************************************************
+ * Function: imxrt_flexram_enableinterruptstatus
+ *
+ * Description:
+ *   brief FLEXRAM module enable interrupt status.
+ *
+ * Input Parameters:
+ *   base FLEXRAM base address.
+ *   status status to enable.
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+static inline void imxrt_flexram_enableinterruptstatus(FLEXRAM_Type *base, uint32_t status)
+{
+    base->INT_STAT_EN |= status;
+}
+
+/****************************************************************************
+ * Function: imxrt_flexram_disableinterruptstatus
+ *
+ * Description:
+ *   FLEXRAM module disable interrupt status.
+ *
+ * Input Parameters:
+ *   base FLEXRAM base address.
+ *   status status to disable.
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+static inline void imxrt_flexram_disableinterruptstatus(FLEXRAM_Type *base, uint32_t status)
+{
+    base->INT_STAT_EN &= ~status;
+}
+
+/* @} */
+
+/*!
+ * @name Interrupts
+ * @{
+ */
+
+/****************************************************************************
+ * Function: imxrt_flexram_enableinterruptsignal
+ *
+ * Description:
+ *   FLEXRAM module enable interrupt.
+ *
+ * Input Parameters:
+ *   base FLEXRAM base address.
+ *   status status interrupt to enable.
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+static inline void imxrt_flexram_enableinterruptsignal(FLEXRAM_Type *base, uint32_t status)
+{
+    base->INT_SIG_EN |= status;
+}
+
+/****************************************************************************
+ * Function: imxrt_flexram_disableinterruptsignal
+ *
+ * Description:
+ *   FLEXRAM module disable interrupt.
+ *
+ * Input Parameters:
+ *   base FLEXRAM base address.
+ *   status status interrupt to disable.
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+static inline void imxrt_flexram_disableinterruptsignal(FLEXRAM_Type *base, uint32_t status)
+{
+    base->INT_SIG_EN &= ~status;
+}
+/* @} */
+
+/*!
+ * @name functional
+ * @{
+ */
+
+/****************************************************************************
+ * Function: imxrt_flexram_settcmreadaccessmode
+ *
+ * Description:
+ *   FLEXRAM module set TCM read access mode
+ *
+ * Input Parameters:
+ *   base FLEXRAM base address.
+ *   mode  access mode.
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+static inline void imxrt_flexram_settcmreadaccessmode(FLEXRAM_Type *base, flexram_tcm_access_mode_t mode)
+{
+    base->TCM_CTRL &= ~FLEXRAM_TCM_CTRL_TCM_RWAIT_EN_MASK;
+    base->TCM_CTRL |= mode;
+}
+
+/****************************************************************************
+ * Function: imxrt_flexram_settcmwriteaccessmode
+ *
+ * Description:
+ *   FLEXRAM module set TCM write access mode
+ *
+ * Input Parameters:
+ *   base FLEXRAM base address.
+ *   mode  access mode.
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+static inline void imxrt_flexram_settcmwriteaccessmode(FLEXRAM_Type *base, flexram_tcm_access_mode_t mode)
+{
+    base->TCM_CTRL &= ~FLEXRAM_TCM_CTRL_TCM_WWAIT_EN_MASK;
+    base->TCM_CTRL |= mode;
+}
+
+/****************************************************************************
+ * Function: imxrt_flexram_enableforceramclockon
+ *
+ * Description:
+ *   FLEXRAM module force ram clock on
+ *
+ * Input Parameters:
+ *   base FLEXRAM base address.
+ *   enable enable or disable clock force on.
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+static inline void imxrt_flexram_enableforceramclockon(FLEXRAM_Type *base, bool enable)
+{
+    if (enable)
+    {
+        base->TCM_CTRL |= FLEXRAM_TCM_CTRL_FORCE_CLK_ON_MASK;
+    }
+    else
+    {
+        base->TCM_CTRL &= ~FLEXRAM_TCM_CTRL_FORCE_CLK_ON_MASK;
+    }
+}
+
+/****************************************************************************
+ * Function: imxrt_flexram_allocateram
+ *
+ * Description:
+ *   brief FLEXRAM allocate on-chip ram for OCRAM,ITCM,DTCM
+ *   This function is independent of FLEXRAM_Init, it can be called directly if ram re-allocate
+ *   is needed.
+ *
+ * Input Parameters:
+ *   config allocate configuration.
+ *
+ * Returned Value:
+ *   Returns kStatus_InvalidArgument the argument is invalid
+ *   Returns kStatus_Success allocate success
+ *
+ ****************************************************************************/
+status_t imxrt_flexram_allocateram(flexram_allocate_ram_t *config);
+
+/****************************************************************************
+ * Function: imxrt_flexram_setallocateramsrc
+ *
+ * Description:
+ *   brief FLEXRAM set allocate on-chip ram source
+ *
+ * Input Parameters:
+ *   src bank config source select value.
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+static inline void imxrt_flexram_setallocateramsrc(flexram_bank_allocate_src_t src)
+{
+    IOMUXC_GPR->GPR16 &= ~IOMUXC_GPR_GPR16_FLEXRAM_BANK_CFG_SEL_MASK;
+    IOMUXC_GPR->GPR16 |= IOMUXC_GPR_GPR16_FLEXRAM_BANK_CFG_SEL(src);
+}
+
+/****************************************************************************
+ * Function: imxrt_flexram_settcmsize
+ *
+ * Description:
+ *   brief FLEXRAM configure TCM size
+ *   This function  is used to set the TCM to the target size. If a odd bank number is used,
+ *   a new banknumber will be used which is bigger than target value, application can set tcm
+ *   size to the biggest bank number always, then boundary access error can be captured by flexram only.
+ *   When access to the TCM memory boundary ,hardfault will raised by core.
+ *
+ * Input Parameters:
+ *   itcmBankNum itcm bank number to allocate
+ *   dtcmBankNum dtcm bank number to allocate
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+void imxrt_flexram_settcmsize(uint8_t itcmBankNum, uint8_t dtcmBankNum);
+
+/****************************************************************************
+ * Function: imxrt_flexram_initialize
+ *
+ * Description:
+ *   brief FLEXRAM initialize
+ *
+ * Input Parameters:
+ *   None
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+void imxrt_flexram_initialize(void);
+
+#if defined(__cplusplus)
+}
+#endif
+
+/*! @}*/
+
+#endif

--- a/os/arch/arm/src/imxrt/imxrt_semc.c
+++ b/os/arch/arm/src/imxrt/imxrt_semc.c
@@ -1,0 +1,1222 @@
+/****************************************************************************
+ *
+ * Copyright 2019 NXP Semiconductors All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+/*
+ * Copyright 2017-2018 NXP
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+#include <stddef.h>
+#include <string.h>
+#include "imxrt_clock.h"
+#include "imxrt_semc.h"
+
+/*******************************************************************************
+ * Definitions
+ ******************************************************************************/
+
+/*! @brief Define macros for SEMC driver. */
+#define SEMC_IPCOMMANDDATASIZEBYTEMAX (4U)
+#define SEMC_IPCOMMANDMAGICKEY (0xA55A)
+#define SEMC_IOCR_PINMUXBITWIDTH (0x3U)
+#define SEMC_IOCR_NAND_CE (4U)
+#define SEMC_IOCR_NOR_CE (5U)
+#define SEMC_IOCR_NOR_CE_A8 (2U)
+#define SEMC_IOCR_PSRAM_CE (6U)
+#define SEMC_IOCR_PSRAM_CE_A8 (3U)
+#define SEMC_IOCR_DBI_CSX (7U)
+#define SEMC_IOCR_DBI_CSX_A8 (4U)
+#define SEMC_NORFLASH_SRAM_ADDR_PORTWIDTHBASE (24U)
+#define SEMC_NORFLASH_SRAM_ADDR_PORTWIDTHMAX (28U)
+#define SEMC_BMCR0_TYPICAL_WQOS (5U)
+#define SEMC_BMCR0_TYPICAL_WAGE (8U)
+#define SEMC_BMCR0_TYPICAL_WSH (0x40U)
+#define SEMC_BMCR0_TYPICAL_WRWS (0x10U)
+#define SEMC_BMCR1_TYPICAL_WQOS (5U)
+#define SEMC_BMCR1_TYPICAL_WAGE (8U)
+#define SEMC_BMCR1_TYPICAL_WPH (0x60U)
+#define SEMC_BMCR1_TYPICAL_WBR (0x40U)
+#define SEMC_BMCR1_TYPICAL_WRWS (0x24U)
+#define SEMC_STARTADDRESS (0x80000000U)
+#define SEMC_ENDADDRESS (0xDFFFFFFFU)
+#define SEMC_BR_MEMSIZE_MIN (4)
+#define SEMC_BR_MEMSIZE_OFFSET (2)
+#define SEMC_BR_MEMSIZE_MAX (4 * 1024 * 1024)
+#define SEMC_SDRAM_MODESETCAL_OFFSET (4)
+#define SEMC_BR_REG_NUM (9)
+#define SEMC_BYTE_NUMBIT (8)
+/*******************************************************************************
+ * Prototypes
+ ******************************************************************************/
+/****************************************************************************
+ * Function: imxrt_semc_getinstance
+ *
+ * Description:
+ *   brief Get instance number for SEMC module.
+ *
+ * Input Parameters:
+ *   base  SEMC peripheral base address.
+ *
+ * Returned Value:
+ *   Returns instance.
+ *
+ ****************************************************************************/
+static uint32_t imxrt_semc_getinstance(SEMC_Type *base);
+
+/****************************************************************************
+ * Function: imxrt_semc_convertmemorysize
+ *
+ * Description:
+ *   brief Covert the input memory size to internal register set value.
+ *
+ * Input Parameters:
+ *   base  SEMC peripheral base address.
+ *   size_kbytes SEMC memory size in unit of kbytes.
+ *   sizeConverted SEMC converted memory size to 0 ~ 0x1F.
+ *
+ * Returned Value:
+ *   Returns Execution status..
+ *
+ ****************************************************************************/
+static status_t imxrt_semc_convertmemorysize(SEMC_Type *base, uint32_t size_kbytes, uint8_t *sizeConverted);
+
+/****************************************************************************
+ * Function: imxrt_semc_converttiming
+ *
+ * Description:
+ *   brief Covert the external timing nanosecond to internal clock cycle.
+ *
+ * Input Parameters:
+ *   time_ns   SEMC external time interval in unit of nanosecond.
+ *   clkSrc_Hz SEMC clock source frequency.
+ *
+ * Returned Value:
+ *   Returns The changed internal clock cycle.
+ *
+ ****************************************************************************/
+static uint8_t imxrt_semc_converttiming(uint32_t time_ns, uint32_t clkSrc_Hz);
+
+/****************************************************************************
+ * Function: imxrt_semc_configureipcommand
+ *
+ * Description:
+ *   brief Configure IP command.
+ *
+ * Input Parameters:
+ *   base SEMC peripheral base address.
+ *   size_bytes SEMC IP command data size.
+ *
+ * Returned Value:
+ *   Returns Execution status.
+ *
+ ****************************************************************************/
+static status_t imxrt_semc_configureipcommand(SEMC_Type *base, uint8_t size_bytes);
+
+/****************************************************************************
+ * Function: imxrt_semc_isipcommanddone
+ *
+ * Description:
+ *   brief Check if the IP command has finished.
+ *
+ * Input Parameters:
+ *   base SEMC peripheral base address.
+ *
+ * Returned Value:
+ *   Returns Execution status.
+ *
+ ****************************************************************************/
+static status_t imxrt_semc_isipcommanddone(SEMC_Type *base);
+
+/*******************************************************************************
+ * Variables
+ ******************************************************************************/
+
+#if !(defined(FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL) && FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL)
+/*! @brief Pointers to SEMC clocks for each instance. */
+static const clock_ip_name_t s_semcClock[FSL_FEATURE_SOC_SEMC_COUNT] = SEMC_CLOCKS;
+static const clock_ip_name_t s_semcExtClock[FSL_FEATURE_SOC_SEMC_COUNT] = SEMC_EXSC_CLOCKS;
+#endif /* FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL */
+
+/*! @brief Pointers to SEMC bases for each instance. */
+static SEMC_Type *const s_semcBases[] = SEMC_BASE_PTRS;
+/*******************************************************************************
+ * Code
+ ******************************************************************************/
+static uint32_t imxrt_semc_getinstance(SEMC_Type *base)
+{
+    uint32_t instance;
+
+    /* Find the instance index from base address mappings. */
+    for (instance = 0; instance < ARRAY_SIZE(s_semcBases); instance++)
+    {
+        if (s_semcBases[instance] == base)
+        {
+            break;
+        }
+    }
+
+    assert(instance < ARRAY_SIZE(s_semcBases));
+
+    return instance;
+}
+
+static status_t imxrt_semc_convertmemorysize(SEMC_Type *base, uint32_t size_kbytes, uint8_t *sizeConverted)
+{
+    assert(sizeConverted);
+    uint32_t memsize;
+
+    if ((size_kbytes < SEMC_BR_MEMSIZE_MIN) || (size_kbytes > SEMC_BR_MEMSIZE_MAX))
+    {
+        return kStatus_SEMC_InvalidMemorySize;
+    }
+
+    *sizeConverted = 0;
+    memsize = size_kbytes / 8;
+    while (memsize)
+    {
+        memsize >>= 1;
+        (*sizeConverted)++;
+    }
+    return kStatus_Success;
+}
+
+static uint8_t imxrt_semc_converttiming(uint32_t time_ns, uint32_t clkSrc_Hz)
+{
+    assert(clkSrc_Hz);
+
+    uint8_t clockCycles = 0;
+    uint32_t tClk_us;
+
+    clkSrc_Hz /= 1000000;
+    tClk_us = 1000000 / clkSrc_Hz;
+
+    while (tClk_us * clockCycles < (time_ns * 1000))
+    {
+        clockCycles++;
+    }
+
+    return clockCycles;
+}
+
+static status_t imxrt_semc_configureipcommand(SEMC_Type *base, uint8_t size_bytes)
+{
+    if ((size_bytes > SEMC_IPCOMMANDDATASIZEBYTEMAX) || (!size_bytes))
+    {
+        return kStatus_SEMC_InvalidIpcmdDataSize;
+    }
+
+    /* Set data size. */
+    /* Note: It is better to set data size as the device data port width when transfering
+     *    device command data. but for device memory data transfer, it can be set freely.
+     * Note: If the data size is greater than data port width, for example, datsz = 4, data port = 16bit,
+     *    then the 4-byte data transfer will be split into two 2-byte transfer, the slave address
+     *    will be switched automatically according to connected device type*/
+    base->IPCR1 = SEMC_IPCR1_DATSZ(size_bytes);
+    /* Clear data size. */
+    base->IPCR2 = 0;
+    /* Set data size. */
+    if (size_bytes < 4)
+    {
+        base->IPCR2 |= SEMC_IPCR2_BM3_MASK;
+    }
+    if (size_bytes < 3)
+    {
+        base->IPCR2 |= SEMC_IPCR2_BM2_MASK;
+    }
+    if (size_bytes < 2)
+    {
+        base->IPCR2 |= SEMC_IPCR2_BM1_MASK;
+    }
+    return kStatus_Success;
+}
+
+static status_t imxrt_semc_isipcommanddone(SEMC_Type *base)
+{
+    /* Poll status bit till command is done*/
+    while (!(base->INTR & SEMC_INTR_IPCMDDONE_MASK))
+    {
+    };
+
+    /* Clear status bit */
+    base->INTR |= SEMC_INTR_IPCMDDONE_MASK;
+
+    /* Check error status */
+    if (base->INTR & SEMC_INTR_IPCMDERR_MASK)
+    {
+        base->INTR |= SEMC_INTR_IPCMDERR_MASK;
+        return kStatus_SEMC_IpCommandExecutionError;
+    }
+
+    return kStatus_Success;
+}
+
+/****************************************************************************
+ * Function: imxrt_semc_getdefaultconfig
+ *
+ * Description:
+ *   brief Gets the SEMC default basic configuration structure.
+ *   
+ *   The purpose of this API is to get the default SEMC
+ *   configure structure for SEMC_Init(). User may use the initialized
+ *   structure unchanged in SEMC_Init(), or modify some fields of the
+ *   structure before calling SEMC_Init().
+ *   Example:
+     code
+     semc_config_t config;
+     imxrt_semc_getdefaultconfig(&config);
+     endcode
+ *
+ * Input Parameters:
+ *   config The SEMC configuration structure pointer.
+ *
+ * Returned Value:
+ *   None.
+ *
+ ****************************************************************************/
+void imxrt_semc_getdefaultconfig(semc_config_t *config)
+{
+    assert(config);
+
+    /* Initializes the configure structure to zero. */
+    memset(config, 0, sizeof(*config));
+
+    semc_queuea_weight_struct_t *queueaWeight = &(config->queueWeight.queueaWeight.queueaConfig);
+    semc_queueb_weight_struct_t *queuebWeight = &(config->queueWeight.queuebWeight.queuebConfig);
+
+    /* Get default settings. */
+    config->dqsMode = kSEMC_Loopbackinternal;
+    config->cmdTimeoutCycles = 0;
+    config->busTimeoutCycles = 0x1F;
+
+    queueaWeight->qos = SEMC_BMCR0_TYPICAL_WQOS;
+    queueaWeight->aging = SEMC_BMCR0_TYPICAL_WAGE;
+    queueaWeight->slaveHitSwith = SEMC_BMCR0_TYPICAL_WSH;
+    queueaWeight->slaveHitNoswitch = SEMC_BMCR0_TYPICAL_WRWS;
+    queuebWeight->qos = SEMC_BMCR1_TYPICAL_WQOS;
+    queuebWeight->aging = SEMC_BMCR1_TYPICAL_WAGE;
+    queuebWeight->slaveHitSwith = SEMC_BMCR1_TYPICAL_WRWS;
+    queuebWeight->weightPagehit = SEMC_BMCR1_TYPICAL_WPH;
+    queuebWeight->bankRotation = SEMC_BMCR1_TYPICAL_WBR;
+}
+
+/****************************************************************************
+ * Function: imxrt_semc_init
+ *
+ * Description:
+ *   brief Initializes SEMC.
+ *   This function ungates the SEMC clock and initializes SEMC.
+ *   This function must be called before calling any other SEMC driver functions.
+ *
+ * Input Parameters:
+ *   base SEMC peripheral base address.
+ *   configure The SEMC configuration structure pointer.
+ *
+ * Returned Value:
+ *   None.
+ *
+ ****************************************************************************/
+void imxrt_semc_init(SEMC_Type *base, semc_config_t *configure)
+{
+    assert(configure);
+
+    uint8_t index = 0;
+
+#if !(defined(FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL) && FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL)
+    /* Un-gate sdram controller clock. */
+    imxrt_clock_enableclock(s_semcClock[imxrt_semc_getinstance(base)]);
+    imxrt_clock_enableclock(s_semcExtClock[imxrt_semc_getinstance(base)]);
+#endif /* FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL */
+
+    /* Initialize all BR to zero due to the default base address set. */
+    for (index = 0; index < SEMC_BR_REG_NUM; index++)
+    {
+        base->BR[index] = 0;
+    }
+
+    /* Software reset for SEMC internal logical . */
+    base->MCR = SEMC_MCR_SWRST_MASK;
+    while (base->MCR & SEMC_MCR_SWRST_MASK)
+    {
+    }
+
+    /* Configure, disable module first. */
+    base->MCR |= SEMC_MCR_MDIS_MASK | SEMC_MCR_BTO(configure->busTimeoutCycles) |
+                 SEMC_MCR_CTO(configure->cmdTimeoutCycles) | SEMC_MCR_DQSMD(configure->dqsMode);
+
+    /* Configure Queue 0/1 for AXI bus. */
+    base->BMCR0 = (uint32_t)(configure->queueWeight.queueaWeight.queueaValue);
+    base->BMCR1 = (uint32_t)(configure->queueWeight.queuebWeight.queuebValue);
+
+    /* Enable SEMC. */
+    base->MCR &= ~SEMC_MCR_MDIS_MASK;
+}
+
+/****************************************************************************
+ * Function: imxrt_semc_deinit
+ *
+ * Description:
+ *   brief Deinitializes the SEMC module and gates the clock.
+ *   This function gates the SEMC clock. As a result, the SEMC
+ *   module doesn't work after calling this function.
+ *
+ * Input Parameters:
+ *   base SEMC peripheral base address.
+ *
+ * Returned Value:
+ *   None.
+ *
+ ****************************************************************************/
+void imxrt_semc_deinit(SEMC_Type *base)
+{
+    /* Disable module.  Check there is no pending command before disable module.  */
+    while (!(base->STS0 & SEMC_STS0_IDLE_MASK))
+    {
+        ;
+    }
+
+    base->MCR |= SEMC_MCR_MDIS_MASK | SEMC_MCR_SWRST_MASK;
+
+#if !(defined(FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL) && FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL)
+    /* Disable SDRAM clock. */
+    imxrt_clock_disableclock(s_semcClock[imxrt_semc_getinstance(base)]);
+    imxrt_clock_disableclock(s_semcExtClock[imxrt_semc_getinstance(base)]);
+#endif /* FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL */
+}
+
+/****************************************************************************
+ * Function: imxrt_semc_configuresdram
+ *
+ * Description:
+ *   brief Configures SDRAM controller in SEMC.
+ *
+ * Input Parameters:
+ *   base SEMC peripheral base address.
+ *   cs The chip selection.
+ *   config The sdram configuration.
+ *   clkSrc_Hz The SEMC clock frequency.
+ *
+ * Returned Value:
+ *   Returns status.
+ *
+ ****************************************************************************/
+status_t imxrt_semc_configuresdram(SEMC_Type *base, semc_sdram_cs_t cs, semc_sdram_config_t *config, uint32_t clkSrc_Hz)
+{
+    assert(config);
+    assert(clkSrc_Hz);
+    assert(config->refreshBurstLen);
+
+    uint8_t memsize;
+    status_t result = kStatus_Success;
+    uint16_t prescale = config->tPrescalePeriod_Ns / 16 / (1000000000 / clkSrc_Hz);
+    uint16_t refresh;
+    uint16_t urgentRef;
+    uint16_t idle;
+    uint16_t mode;
+
+    if ((config->address < SEMC_STARTADDRESS) || (config->address > SEMC_ENDADDRESS))
+    {
+        return kStatus_SEMC_InvalidBaseAddress;
+    }
+
+    if (config->csxPinMux == kSEMC_MUXA8)
+    {
+        return kStatus_SEMC_InvalidSwPinmuxSelection;
+    }
+
+    if (prescale > 256)
+    {
+        return kStatus_SEMC_InvalidTimerSetting;
+    }
+
+    refresh = config->refreshPeriod_nsPerRow / config->tPrescalePeriod_Ns;
+    urgentRef = config->refreshUrgThreshold / config->tPrescalePeriod_Ns;
+    idle = config->tIdleTimeout_Ns / config->tPrescalePeriod_Ns;
+
+    uint32_t iocReg = base->IOCR & ~(SEMC_IOCR_PINMUXBITWIDTH << config->csxPinMux);
+
+    /* Base control. */
+    result = imxrt_semc_convertmemorysize(base, config->memsize_kbytes, &memsize);
+    if (result != kStatus_Success)
+    {
+        return result;
+    }
+
+    base->BR[cs] = (config->address & SEMC_BR_BA_MASK) | SEMC_BR_MS(memsize) | SEMC_BR_VLD_MASK;
+    base->SDRAMCR0 = SEMC_SDRAMCR0_PS(config->portSize) | SEMC_SDRAMCR0_BL(config->burstLen) |
+                     SEMC_SDRAMCR0_COL(config->columnAddrBitNum) | SEMC_SDRAMCR0_CL(config->casLatency);
+    /* IOMUX setting. */
+    if (cs)
+    {
+        base->IOCR = iocReg | (cs << config->csxPinMux);
+    }
+
+    base->IOCR &= ~SEMC_IOCR_MUX_A8_MASK;
+
+    /* Timing setting. */
+    base->SDRAMCR1 = SEMC_SDRAMCR1_PRE2ACT(imxrt_semc_converttiming(config->tPrecharge2Act_Ns, clkSrc_Hz) - 1) |
+                     SEMC_SDRAMCR1_ACT2RW(imxrt_semc_converttiming(config->tAct2ReadWrite_Ns, clkSrc_Hz) - 1) |
+                     SEMC_SDRAMCR1_RFRC(imxrt_semc_converttiming(config->tRefreshRecovery_Ns, clkSrc_Hz) - 1) |
+                     SEMC_SDRAMCR1_WRC(imxrt_semc_converttiming(config->tWriteRecovery_Ns, clkSrc_Hz) - 1) |
+                     SEMC_SDRAMCR1_CKEOFF(imxrt_semc_converttiming(config->tCkeOff_Ns, clkSrc_Hz) - 1) |
+                     SEMC_SDRAMCR1_ACT2PRE(imxrt_semc_converttiming(config->tAct2Prechage_Ns, clkSrc_Hz) - 1);
+    base->SDRAMCR2 =
+        SEMC_SDRAMCR2_SRRC(imxrt_semc_converttiming(config->tSelfRefRecovery_Ns, clkSrc_Hz) - 1) |
+        SEMC_SDRAMCR2_REF2REF(
+            imxrt_semc_converttiming(config->tRefresh2Refresh_Ns, clkSrc_Hz)) |           /* No Minus one to keep with RM */
+        SEMC_SDRAMCR2_ACT2ACT(imxrt_semc_converttiming(config->tAct2Act_Ns, clkSrc_Hz)) | /* No Minus one to keep with RM */
+        SEMC_SDRAMCR2_ITO(idle);
+    base->SDRAMCR3 = SEMC_SDRAMCR3_REBL(config->refreshBurstLen - 1) |
+                     /* N * 16 * 1s / clkSrc_Hz = config->tPrescalePeriod_Ns */
+                     SEMC_SDRAMCR3_PRESCALE(prescale) | SEMC_SDRAMCR3_RT(refresh) | SEMC_SDRAMCR3_UT(urgentRef);
+
+    SEMC->IPCR1 = 0x2;
+    SEMC->IPCR2 = 0;
+
+    result = imxrt_semc_sendipcommand(base, kSEMC_MemType_SDRAM, config->address, kSEMC_SDRAMCM_Prechargeall, 0, NULL);
+    if (result != kStatus_Success)
+    {
+        return result;
+    }
+    result = imxrt_semc_sendipcommand(base, kSEMC_MemType_SDRAM, config->address, kSEMC_SDRAMCM_AutoRefresh, 0, NULL);
+    if (result != kStatus_Success)
+    {
+        return result;
+    }
+    result = imxrt_semc_sendipcommand(base, kSEMC_MemType_SDRAM, config->address, kSEMC_SDRAMCM_AutoRefresh, 0, NULL);
+    if (result != kStatus_Success)
+    {
+        return result;
+    }
+    /* Mode setting value. */
+    mode = (uint16_t)config->burstLen | (uint16_t)(config->casLatency << SEMC_SDRAM_MODESETCAL_OFFSET);
+    result = imxrt_semc_sendipcommand(base, kSEMC_MemType_SDRAM, config->address, kSEMC_SDRAMCM_Modeset, mode, NULL);
+    if (result != kStatus_Success)
+    {
+        return result;
+    }
+    /* Enables refresh */
+    base->SDRAMCR3 |= SEMC_SDRAMCR3_REN_MASK;
+
+    return kStatus_Success;
+}
+
+/****************************************************************************
+ * Function: imxrt_semc_configurenand
+ *
+ * Description:
+ *   brief Configures NAND controller in SEMC.
+ *
+ * Input Parameters:
+ *   base SEMC peripheral base address.
+ *   config The nand configuration.
+ *   clkSrc_Hz The SEMC clock frequency.
+ *
+ * Returned Value:
+ *   Returns status.
+ *
+ ****************************************************************************/
+status_t imxrt_semc_configurenand(SEMC_Type *base, semc_nand_config_t *config, uint32_t clkSrc_Hz)
+{
+    assert(config);
+    assert(config->timingConfig);
+
+    uint8_t memsize;
+    status_t result;
+
+    if ((config->axiAddress < SEMC_STARTADDRESS) || (config->axiAddress > SEMC_ENDADDRESS))
+    {
+        return kStatus_SEMC_InvalidBaseAddress;
+    }
+
+    if (config->cePinMux == kSEMC_MUXRDY)
+    {
+        return kStatus_SEMC_InvalidSwPinmuxSelection;
+    }
+
+    uint32_t iocReg = base->IOCR & ~((SEMC_IOCR_PINMUXBITWIDTH << config->cePinMux) | SEMC_IOCR_MUX_RDY_MASK);
+
+    /* Base control. */
+    if (config->rdyactivePolarity == kSEMC_RdyActivehigh)
+    {
+        base->MCR |= SEMC_MCR_WPOL1_MASK;
+    }
+    else
+    {
+        base->MCR &= ~SEMC_MCR_WPOL1_MASK;
+    }
+    result = imxrt_semc_convertmemorysize(base, config->axiMemsize_kbytes, &memsize);
+    if (result != kStatus_Success)
+    {
+        return result;
+    }
+    base->BR[4] = (config->axiAddress & SEMC_BR_BA_MASK) | SEMC_BR_MS(memsize) | SEMC_BR_VLD_MASK;
+
+    result = imxrt_semc_convertmemorysize(base, config->ipgMemsize_kbytes, &memsize);
+    if (result != kStatus_Success)
+    {
+        return result;
+    }
+    base->BR[8] = (config->ipgAddress & SEMC_BR_BA_MASK) | SEMC_BR_MS(memsize) | SEMC_BR_VLD_MASK;
+
+    /* IOMUX setting. */
+    if (config->cePinMux)
+    {
+        base->IOCR = iocReg | (SEMC_IOCR_NAND_CE << config->cePinMux);
+    }
+    else
+    {
+        base->IOCR = iocReg | (1U << config->cePinMux);
+    }
+
+    base->NANDCR0 = SEMC_NANDCR0_PS(config->portSize) | SEMC_NANDCR0_BL(config->burstLen) |
+                    SEMC_NANDCR0_EDO(config->edoModeEnabled) | SEMC_NANDCR0_COL(config->columnAddrBitNum);
+
+    /* Timing setting. */
+    base->NANDCR1 = SEMC_NANDCR1_CES(imxrt_semc_converttiming(config->timingConfig->tCeSetup_Ns, clkSrc_Hz) - 1) |
+                    SEMC_NANDCR1_CEH(imxrt_semc_converttiming(config->timingConfig->tCeHold_Ns, clkSrc_Hz) - 1) |
+                    SEMC_NANDCR1_WEL(imxrt_semc_converttiming(config->timingConfig->tWeLow_Ns, clkSrc_Hz) - 1) |
+                    SEMC_NANDCR1_WEH(imxrt_semc_converttiming(config->timingConfig->tWeHigh_Ns, clkSrc_Hz) - 1) |
+                    SEMC_NANDCR1_REL(imxrt_semc_converttiming(config->timingConfig->tReLow_Ns, clkSrc_Hz) - 1) |
+                    SEMC_NANDCR1_REH(imxrt_semc_converttiming(config->timingConfig->tReHigh_Ns, clkSrc_Hz) - 1) |
+                    SEMC_NANDCR1_TA(imxrt_semc_converttiming(config->timingConfig->tTurnAround_Ns, clkSrc_Hz) - 1) |
+                    SEMC_NANDCR1_CEITV(imxrt_semc_converttiming(config->timingConfig->tCeInterval_Ns, clkSrc_Hz) - 1);
+    base->NANDCR2 = SEMC_NANDCR2_TWHR(imxrt_semc_converttiming(config->timingConfig->tWehigh2Relow_Ns, clkSrc_Hz) - 1) |
+                    SEMC_NANDCR2_TRHW(imxrt_semc_converttiming(config->timingConfig->tRehigh2Welow_Ns, clkSrc_Hz) - 1) |
+                    SEMC_NANDCR2_TADL(imxrt_semc_converttiming(config->timingConfig->tAle2WriteStart_Ns, clkSrc_Hz) - 1) |
+                    SEMC_NANDCR2_TRR(imxrt_semc_converttiming(config->timingConfig->tReady2Relow_Ns, clkSrc_Hz) - 1) |
+                    SEMC_NANDCR2_TWB(imxrt_semc_converttiming(config->timingConfig->tWehigh2Busy_Ns, clkSrc_Hz) - 1);
+    base->NANDCR3 = config->arrayAddrOption;
+    return kStatus_Success;
+}
+
+/****************************************************************************
+ * Function: imxrt_semc_configurenor
+ *
+ * Description:
+ *   brief Configures NOR controller in SEMC.
+ *
+ * Input Parameters:
+ *   base SEMC peripheral base address.
+ *   config The nor configuration.
+ *   clkSrc_Hz The SEMC clock frequency.
+ *
+ * Returned Value:
+ *   Returns status.
+ *
+ ****************************************************************************/
+status_t imxrt_semc_configurenor(SEMC_Type *base, semc_nor_config_t *config, uint32_t clkSrc_Hz)
+{
+    assert(config);
+
+    uint8_t memsize;
+    status_t result;
+
+    if ((config->address < SEMC_STARTADDRESS) || (config->address > SEMC_ENDADDRESS))
+    {
+        return kStatus_SEMC_InvalidBaseAddress;
+    }
+
+    uint32_t iocReg = base->IOCR & ~(SEMC_IOCR_PINMUXBITWIDTH << config->cePinMux);
+    uint32_t muxCe = (config->cePinMux == kSEMC_MUXRDY) ?
+                         SEMC_IOCR_NOR_CE - 1 :
+                         ((config->cePinMux == kSEMC_MUXA8) ? SEMC_IOCR_NOR_CE_A8 : SEMC_IOCR_NOR_CE);
+
+    /* IOMUX setting. */
+    base->IOCR = iocReg | (muxCe << config->cePinMux);
+    /* Address bit setting. */
+    if (config->addrPortWidth > SEMC_NORFLASH_SRAM_ADDR_PORTWIDTHBASE)
+    {
+        if (config->addrPortWidth >= SEMC_NORFLASH_SRAM_ADDR_PORTWIDTHBASE + 1)
+        {
+            /* Address bit 24 (A24) */
+            base->IOCR &= (uint32_t)~SEMC_IOCR_MUX_CSX0_MASK;
+            if (config->cePinMux == kSEMC_MUXCSX0)
+            {
+                return kStatus_SEMC_InvalidSwPinmuxSelection;
+            }
+        }
+        if (config->addrPortWidth >= SEMC_NORFLASH_SRAM_ADDR_PORTWIDTHBASE + 2)
+        {
+            /* Address bit 25 (A25) */
+            base->IOCR &= (uint32_t)~SEMC_IOCR_MUX_CSX1_MASK;
+            if (config->cePinMux == kSEMC_MUXCSX1)
+            {
+                return kStatus_SEMC_InvalidSwPinmuxSelection;
+            }
+        }
+        if (config->addrPortWidth >= SEMC_NORFLASH_SRAM_ADDR_PORTWIDTHBASE + 3)
+        {
+            /* Address bit 26 (A26) */
+            base->IOCR &= (uint32_t)~SEMC_IOCR_MUX_CSX2_MASK;
+            if (config->cePinMux == kSEMC_MUXCSX2)
+            {
+                return kStatus_SEMC_InvalidSwPinmuxSelection;
+            }
+        }
+        if (config->addrPortWidth >= SEMC_NORFLASH_SRAM_ADDR_PORTWIDTHBASE + 4)
+        {
+            if (config->addr27 == kSEMC_NORA27_MUXCSX3)
+            {
+                /* Address bit 27 (A27) */
+                base->IOCR &= (uint32_t)~SEMC_IOCR_MUX_CSX3_MASK;
+            }
+            else if (config->addr27 == kSEMC_NORA27_MUXRDY)
+            {
+                base->IOCR |= SEMC_IOCR_MUX_RDY_MASK;
+            }
+            else
+            {
+                return kStatus_SEMC_InvalidSwPinmuxSelection;
+            }
+            if (config->cePinMux == kSEMC_MUXCSX3)
+            {
+                return kStatus_SEMC_InvalidSwPinmuxSelection;
+            }
+        }
+        if (config->addrPortWidth > SEMC_NORFLASH_SRAM_ADDR_PORTWIDTHMAX)
+        {
+            return kStatus_SEMC_InvalidAddressPortWidth;
+        }
+    }
+
+    /* Base control. */
+    if (config->rdyactivePolarity == kSEMC_RdyActivehigh)
+    {
+        base->MCR |= SEMC_MCR_WPOL0_MASK;
+    }
+    else
+    {
+        base->MCR &= ~SEMC_MCR_WPOL0_MASK;
+    }
+    result = imxrt_semc_convertmemorysize(base, config->memsize_kbytes, &memsize);
+    if (result != kStatus_Success)
+    {
+        return result;
+    }
+    base->BR[5] = (config->address & SEMC_BR_BA_MASK) | SEMC_BR_MS(memsize) | SEMC_BR_VLD_MASK;
+    base->NORCR0 = SEMC_NORCR0_PS(config->portSize) | SEMC_NORCR0_BL(config->burstLen) |
+                   SEMC_NORCR0_AM(config->addrMode) | SEMC_NORCR0_ADVP(config->advActivePolarity) |
+                   SEMC_NORCR0_COL(config->columnAddrBitNum);
+
+    /* Timing setting. */
+    base->NORCR1 = SEMC_NORCR1_CES(imxrt_semc_converttiming(config->tCeSetup_Ns, clkSrc_Hz)) |
+                   SEMC_NORCR1_CEH(imxrt_semc_converttiming(config->tCeHold_Ns, clkSrc_Hz)) |
+                   SEMC_NORCR1_AS(imxrt_semc_converttiming(config->tAddrSetup_Ns, clkSrc_Hz)) |
+                   SEMC_NORCR1_AH(imxrt_semc_converttiming(config->tAddrHold_Ns, clkSrc_Hz)) |
+                   SEMC_NORCR1_WEL(imxrt_semc_converttiming(config->tWeLow_Ns, clkSrc_Hz)) |
+                   SEMC_NORCR1_WEH(imxrt_semc_converttiming(config->tWeHigh_Ns, clkSrc_Hz)) |
+                   SEMC_NORCR1_REL(imxrt_semc_converttiming(config->tReLow_Ns, clkSrc_Hz)) |
+                   SEMC_NORCR1_REH(imxrt_semc_converttiming(config->tReHigh_Ns, clkSrc_Hz));
+    base->NORCR2 =
+#if defined(FSL_FEATURE_SEMC_HAS_NOR_WDS_TIME) && (FSL_FEATURE_SEMC_HAS_NOR_WDS_TIME)
+        SEMC_NORCR2_WDS(imxrt_semc_converttiming(config->tWriteSetup_Ns, clkSrc_Hz)) |
+#endif /* FSL_FEATURE_SEMC_HAS_NOR_WDS_TIME */
+#if defined(FSL_FEATURE_SEMC_HAS_NOR_WDH_TIME) && (FSL_FEATURE_SEMC_HAS_NOR_WDH_TIME)
+        SEMC_NORCR2_WDH(imxrt_semc_converttiming(config->tWriteHold_Ns, clkSrc_Hz)) |
+#endif /* FSL_FEATURE_SEMC_HAS_NOR_WDH_TIME */
+        SEMC_NORCR2_TA(imxrt_semc_converttiming(config->tTurnAround_Ns, clkSrc_Hz)) |
+        SEMC_NORCR2_AWDH(imxrt_semc_converttiming(config->tAddr2WriteHold_Ns, clkSrc_Hz) + 1) |
+        SEMC_NORCR2_LC(config->latencyCount) | SEMC_NORCR2_RD(config->readCycle) |
+        SEMC_NORCR2_CEITV(imxrt_semc_converttiming(config->tCeInterval_Ns, clkSrc_Hz));
+
+    return imxrt_semc_configureipcommand(base, (config->portSize + 1));
+}
+
+/****************************************************************************
+ * Function: imxrt_semc_configuresram
+ *
+ * Description:
+ *   brief Configures SRAM controller in SEMC.
+ *
+ * Input Parameters:
+ *   base SEMC peripheral base address.
+ *   config The sram configuration.
+ *   clkSrc_Hz The SEMC clock frequency.
+ *
+ * Returned Value:
+ *   Returns status.
+ *
+ ****************************************************************************/
+status_t imxrt_semc_configuresram(SEMC_Type *base, semc_sram_config_t *config, uint32_t clkSrc_Hz)
+{
+    assert(config);
+
+    uint8_t memsize;
+    status_t result = kStatus_Success;
+
+    if ((config->address < SEMC_STARTADDRESS) || (config->address > SEMC_ENDADDRESS))
+    {
+        return kStatus_SEMC_InvalidBaseAddress;
+    }
+
+    uint32_t iocReg = base->IOCR & ~(SEMC_IOCR_PINMUXBITWIDTH << config->cePinMux);
+    uint32_t muxCe = (config->cePinMux == kSEMC_MUXRDY) ?
+                         SEMC_IOCR_PSRAM_CE - 1 :
+                         ((config->cePinMux == kSEMC_MUXA8) ? SEMC_IOCR_PSRAM_CE_A8 : SEMC_IOCR_PSRAM_CE);
+
+    /* IOMUX setting. */
+    base->IOCR = iocReg | (muxCe << config->cePinMux);
+    /* Address bit setting. */
+    if (config->addrPortWidth > SEMC_NORFLASH_SRAM_ADDR_PORTWIDTHBASE)
+    {
+        if (config->addrPortWidth >= SEMC_NORFLASH_SRAM_ADDR_PORTWIDTHBASE + 1)
+        {
+            /* Address bit 24 (A24) */
+            base->IOCR &= (uint32_t)~SEMC_IOCR_MUX_CSX0_MASK;
+            if (config->cePinMux == kSEMC_MUXCSX0)
+            {
+                return kStatus_SEMC_InvalidSwPinmuxSelection;
+            }
+        }
+        if (config->addrPortWidth >= SEMC_NORFLASH_SRAM_ADDR_PORTWIDTHBASE + 2)
+        {
+            /* Address bit 25 (A25) */
+            base->IOCR &= (uint32_t)~SEMC_IOCR_MUX_CSX1_MASK;
+            if (config->cePinMux == kSEMC_MUXCSX1)
+            {
+                return kStatus_SEMC_InvalidSwPinmuxSelection;
+            }
+        }
+        if (config->addrPortWidth >= SEMC_NORFLASH_SRAM_ADDR_PORTWIDTHBASE + 3)
+        {
+            /* Address bit 26 (A26) */
+            base->IOCR &= (uint32_t)~SEMC_IOCR_MUX_CSX2_MASK;
+            if (config->cePinMux == kSEMC_MUXCSX2)
+            {
+                return kStatus_SEMC_InvalidSwPinmuxSelection;
+            }
+        }
+        if (config->addrPortWidth >= SEMC_NORFLASH_SRAM_ADDR_PORTWIDTHBASE + 4)
+        {
+            if (config->addr27 == kSEMC_NORA27_MUXCSX3)
+            {
+                /* Address bit 27 (A27) */
+                base->IOCR &= (uint32_t)~SEMC_IOCR_MUX_CSX3_MASK;
+            }
+            else if (config->addr27 == kSEMC_NORA27_MUXRDY)
+            {
+                base->IOCR |= SEMC_IOCR_MUX_RDY_MASK;
+            }
+            else
+            {
+                return kStatus_SEMC_InvalidSwPinmuxSelection;
+            }
+
+            if (config->cePinMux == kSEMC_MUXCSX3)
+            {
+                return kStatus_SEMC_InvalidSwPinmuxSelection;
+            }
+        }
+        if (config->addrPortWidth > SEMC_NORFLASH_SRAM_ADDR_PORTWIDTHMAX)
+        {
+            return kStatus_SEMC_InvalidAddressPortWidth;
+        }
+    }
+    /* Base control. */
+    result = imxrt_semc_convertmemorysize(base, config->memsize_kbytes, &memsize);
+    if (result != kStatus_Success)
+    {
+        return result;
+    }
+    base->BR[6] = (config->address & SEMC_BR_BA_MASK) | SEMC_BR_MS(memsize) | SEMC_BR_VLD_MASK;
+    base->SRAMCR0 = SEMC_SRAMCR0_PS(config->portSize) | SEMC_SRAMCR0_BL(config->burstLen) |
+                    SEMC_SRAMCR0_AM(config->addrMode) | SEMC_SRAMCR0_ADVP(config->advActivePolarity) |
+                    SEMC_SRAMCR0_COL_MASK;
+
+    /* Timing setting. */
+    base->SRAMCR1 = SEMC_SRAMCR1_CES(imxrt_semc_converttiming(config->tCeSetup_Ns, clkSrc_Hz)) |
+                    SEMC_SRAMCR1_CEH(imxrt_semc_converttiming(config->tCeHold_Ns, clkSrc_Hz)) |
+                    SEMC_SRAMCR1_AS(imxrt_semc_converttiming(config->tAddrSetup_Ns, clkSrc_Hz)) |
+                    SEMC_SRAMCR1_AH(imxrt_semc_converttiming(config->tAddrHold_Ns, clkSrc_Hz)) |
+                    SEMC_SRAMCR1_WEL(imxrt_semc_converttiming(config->tWeLow_Ns, clkSrc_Hz)) |
+                    SEMC_SRAMCR1_WEH(imxrt_semc_converttiming(config->tWeHigh_Ns, clkSrc_Hz)) |
+                    SEMC_SRAMCR1_REL(imxrt_semc_converttiming(config->tReLow_Ns, clkSrc_Hz)) |
+                    SEMC_SRAMCR1_REH(imxrt_semc_converttiming(config->tReHigh_Ns, clkSrc_Hz));
+
+    base->SRAMCR2 = SEMC_SRAMCR2_WDS(imxrt_semc_converttiming(config->tWriteSetup_Ns, clkSrc_Hz)) |
+                    SEMC_SRAMCR2_WDH(imxrt_semc_converttiming(config->tWriteHold_Ns, clkSrc_Hz)) |
+                    SEMC_SRAMCR2_TA(imxrt_semc_converttiming(config->tTurnAround_Ns, clkSrc_Hz)) |
+                    SEMC_SRAMCR2_AWDH(imxrt_semc_converttiming(config->tAddr2WriteHold_Ns, clkSrc_Hz) + 1) |
+                    SEMC_SRAMCR2_LC(config->latencyCount) | SEMC_SRAMCR2_RD(config->readCycle) |
+                    SEMC_SRAMCR2_CEITV(imxrt_semc_converttiming(config->tCeInterval_Ns, clkSrc_Hz));
+
+    return result;
+}
+
+/****************************************************************************
+ * Function: imxrt_semc_configuredbi
+ *
+ * Description:
+ *   brief Configures DBI controller in SEMC.
+ *
+ * Input Parameters:
+ *   base SEMC peripheral base address.
+ *   config The dbi configuration.
+ *   clkSrc_Hz The SEMC clock frequency.
+ *
+ * Returned Value:
+ *   Returns status.
+ *
+ ****************************************************************************/
+status_t imxrt_semc_configuredbi(SEMC_Type *base, semc_dbi_config_t *config, uint32_t clkSrc_Hz)
+{
+    assert(config);
+
+    uint8_t memsize;
+    status_t result;
+
+    if ((config->address < SEMC_STARTADDRESS) || (config->address > SEMC_ENDADDRESS))
+    {
+        return kStatus_SEMC_InvalidBaseAddress;
+    }
+
+    uint32_t iocReg = base->IOCR & ~(SEMC_IOCR_PINMUXBITWIDTH << config->csxPinMux);
+    uint32_t muxCsx = (config->csxPinMux == kSEMC_MUXRDY) ?
+                          SEMC_IOCR_DBI_CSX - 1 :
+                          ((config->csxPinMux == kSEMC_MUXA8) ? SEMC_IOCR_DBI_CSX_A8 : SEMC_IOCR_DBI_CSX);
+
+    /* IOMUX setting. */
+    base->IOCR = iocReg | (muxCsx << config->csxPinMux);
+    /* Base control. */
+    result = imxrt_semc_convertmemorysize(base, config->memsize_kbytes, &memsize);
+    if (result != kStatus_Success)
+    {
+        return result;
+    }
+    base->BR[7] = (config->address & SEMC_BR_BA_MASK) | SEMC_BR_MS(memsize) | SEMC_BR_VLD_MASK;
+    base->DBICR0 =
+        SEMC_DBICR0_PS(config->portSize) | SEMC_DBICR0_BL(config->burstLen) | SEMC_DBICR0_COL(config->columnAddrBitNum);
+
+    /* Timing setting. */
+    base->DBICR1 = SEMC_DBICR1_CES(imxrt_semc_converttiming(config->tCsxSetup_Ns, clkSrc_Hz) - 1) |
+                   SEMC_DBICR1_CEH(imxrt_semc_converttiming(config->tCsxHold_Ns, clkSrc_Hz) - 1) |
+                   SEMC_DBICR1_WEL(imxrt_semc_converttiming(config->tWexLow_Ns, clkSrc_Hz) - 1) |
+                   SEMC_DBICR1_WEH(imxrt_semc_converttiming(config->tWexHigh_Ns, clkSrc_Hz) - 1) |
+                   SEMC_DBICR1_REL(imxrt_semc_converttiming(config->tRdxLow_Ns, clkSrc_Hz) - 1) |
+                   SEMC_DBICR1_REH(imxrt_semc_converttiming(config->tRdxHigh_Ns, clkSrc_Hz) - 1) |
+                   SEMC_DBICR1_CEITV(imxrt_semc_converttiming(config->tCsxInterval_Ns, clkSrc_Hz) - 1);
+    return imxrt_semc_configureipcommand(base, (config->portSize + 1));
+}
+
+/****************************************************************************
+ * Function: imxrt_semc_sendipcommand
+ *
+ * Description:
+ *   brief SEMC IP command access.
+ *
+ * Input Parameters:
+ *   base SEMC peripheral base address.
+ *   type  SEMC memory type. refer to "semc_mem_type_t"
+ *   address  SEMC device address.
+ *   command  SEMC IP command.
+ *     For NAND device, we should use the SEMC_BuildNandIPCommand to get the right nand command.
+ *     For NOR/DBI device, take refer to "semc_ipcmd_nor_dbi_t".
+ *     For SRAM device, take refer to "semc_ipcmd_sram_t".
+ *     For SDRAM device, take refer to "semc_ipcmd_sdram_t".
+ *   write  Data for write access.
+ *   read   Data pointer for read data out.
+ *
+ * Returned Value:
+ *   Returns status.
+ *
+ ****************************************************************************/
+status_t imxrt_semc_sendipcommand(
+    SEMC_Type *base, semc_mem_type_t type, uint32_t address, uint16_t command, uint32_t write, uint32_t *read)
+{
+    uint32_t cmdMode;
+    bool readCmd = 0;
+    bool writeCmd = 0;
+    status_t result;
+
+    /* Clear status bit */
+    base->INTR |= SEMC_INTR_IPCMDDONE_MASK;
+    /* Set address. */
+    base->IPCR0 = address;
+
+    /* Check command mode. */
+    cmdMode = command & 0xFU;
+    switch (type)
+    {
+        case kSEMC_MemType_NAND:
+            readCmd = (cmdMode == kSEMC_NANDCM_CommandAddressRead) || (cmdMode == kSEMC_NANDCM_CommandRead) ||
+                      (cmdMode == kSEMC_NANDCM_Read);
+            writeCmd = (cmdMode == kSEMC_NANDCM_CommandAddressWrite) || (cmdMode == kSEMC_NANDCM_CommandWrite) ||
+                       (cmdMode == kSEMC_NANDCM_Write);
+            break;
+        case kSEMC_MemType_NOR:
+        case kSEMC_MemType_8080:
+            readCmd = (cmdMode == kSEMC_NORDBICM_Read);
+            writeCmd = (cmdMode == kSEMC_NORDBICM_Write);
+            break;
+        case kSEMC_MemType_SRAM:
+            readCmd = (cmdMode == kSEMC_SRAMCM_ArrayRead) || (cmdMode == kSEMC_SRAMCM_RegRead);
+            writeCmd = (cmdMode == kSEMC_SRAMCM_ArrayWrite) || (cmdMode == kSEMC_SRAMCM_RegWrite);
+            break;
+        case kSEMC_MemType_SDRAM:
+            readCmd = (cmdMode == kSEMC_SDRAMCM_Read);
+            writeCmd = (cmdMode == kSEMC_SDRAMCM_Write) || (cmdMode == kSEMC_SDRAMCM_Modeset);
+            break;
+        default:
+            break;
+    }
+
+    if (writeCmd)
+    {
+        /* Set data. */
+        base->IPTXDAT = write;
+    }
+
+    /* Set command code. */
+    base->IPCMD = command | SEMC_IPCMD_KEY(SEMC_IPCOMMANDMAGICKEY);
+    /* Wait for command done. */
+    result = imxrt_semc_isipcommanddone(base);
+    if (result != kStatus_Success)
+    {
+        return result;
+    }
+
+    if (readCmd)
+    {
+        /* Get the read data */
+        *read = base->IPRXDAT;
+    }
+
+    return kStatus_Success;
+}
+
+/****************************************************************************
+ * Function: imxrt_semc_ipcommandnandwrite
+ *
+ * Description:
+ *   brief SEMC NAND device memory write through IP command.
+ *
+ * Input Parameters:
+ *   base SEMC peripheral base address.
+ *   address  SEMC NAND device address.
+ *   data  Data for write access.
+ *   size_bytes   Data length.
+ *
+ * Returned Value:
+ *   Returns status.
+ *
+ ****************************************************************************/
+status_t imxrt_semc_ipcommandnandwrite(SEMC_Type *base, uint32_t address, uint8_t *data, uint32_t size_bytes)
+{
+    assert(data);
+
+    status_t result = kStatus_Success;
+    uint16_t ipCmd;
+    uint32_t tempData = 0;
+
+    /* Write command built */
+    ipCmd = imxrt_semc_buildnandipcommand(0, kSEMC_NANDAM_ColumnRow, kSEMC_NANDCM_Write);
+    while (size_bytes >= SEMC_IPCOMMANDDATASIZEBYTEMAX)
+    {
+        /* Configure IP command data size. */
+        imxrt_semc_configureipcommand(base, SEMC_IPCOMMANDDATASIZEBYTEMAX);
+        result = imxrt_semc_sendipcommand(base, kSEMC_MemType_NAND, address, ipCmd, *(uint32_t *)data, NULL);
+        if (result != kStatus_Success)
+        {
+            break;
+        }
+
+        data += SEMC_IPCOMMANDDATASIZEBYTEMAX;
+        size_bytes -= SEMC_IPCOMMANDDATASIZEBYTEMAX;
+    }
+
+    if ((result == kStatus_Success) && size_bytes)
+    {
+        imxrt_semc_configureipcommand(base, size_bytes);
+
+        while (size_bytes)
+        {
+            tempData |= ((uint32_t) * (data + size_bytes - 1) << ((size_bytes - 1) * SEMC_BYTE_NUMBIT));
+            size_bytes--;
+        }
+
+        result = imxrt_semc_sendipcommand(base, kSEMC_MemType_NAND, address, ipCmd, tempData, NULL);
+    }
+
+    return result;
+}
+
+/****************************************************************************
+ * Function: imxrt_semc_ipcommandnandread
+ *
+ * Description:
+ *   brief SEMC NAND device memory read through IP command.
+ *
+ * Input Parameters:
+ *   base SEMC peripheral base address.
+ *   address  SEMC NAND device address.
+ *   data  Data pointer for data read out.
+ *   size_bytes   Data length.
+ *
+ * Returned Value:
+ *   Returns status.
+ *
+ ****************************************************************************/
+status_t imxrt_semc_ipcommandnandread(SEMC_Type *base, uint32_t address, uint8_t *data, uint32_t size_bytes)
+{
+    assert(data);
+
+    status_t result = kStatus_Success;
+    uint16_t ipCmd;
+    uint32_t tempData = 0;
+
+    /* Configure IP command data size. */
+    imxrt_semc_configureipcommand(base, SEMC_IPCOMMANDDATASIZEBYTEMAX);
+    /* Read command built */
+    ipCmd = imxrt_semc_buildnandipcommand(0, kSEMC_NANDAM_ColumnRow, kSEMC_NANDCM_Read);
+
+    while (size_bytes >= SEMC_IPCOMMANDDATASIZEBYTEMAX)
+    {
+        result = imxrt_semc_sendipcommand(base, kSEMC_MemType_NAND, address, ipCmd, 0, (uint32_t *)data);
+        if (result != kStatus_Success)
+        {
+            break;
+        }
+
+        data += SEMC_IPCOMMANDDATASIZEBYTEMAX;
+        size_bytes -= SEMC_IPCOMMANDDATASIZEBYTEMAX;
+    }
+
+    if ((result == kStatus_Success) && size_bytes)
+    {
+        imxrt_semc_configureipcommand(base, size_bytes);
+        result = imxrt_semc_sendipcommand(base, kSEMC_MemType_NAND, address, ipCmd, 0, &tempData);
+
+        while (size_bytes)
+        {
+            size_bytes--;
+            *(data + size_bytes) = (tempData >> (SEMC_BYTE_NUMBIT * size_bytes)) & 0xFFU;
+        }
+    }
+
+    return result;
+}
+
+/****************************************************************************
+ * Function: imxrt_semc_ipcommandnorread
+ *
+ * Description:
+ *   brief SEMC NOR device memory read through IP command.
+ *
+ * Input Parameters:
+ *   base SEMC peripheral base address.
+ *   address  SEMC NOR device address.
+ *   data  Data pointer for data read out.
+ *   size_bytes   Data length.
+ *
+ * Returned Value:
+ *   Returns status.
+ *
+ ****************************************************************************/
+status_t imxrt_semc_ipcommandnorread(SEMC_Type *base, uint32_t address, uint8_t *data, uint32_t size_bytes)
+{
+    assert(data);
+
+    uint32_t tempData = 0;
+    status_t result = kStatus_Success;
+    uint8_t dataSize = base->NORCR0 & SEMC_NORCR0_PS_MASK;
+
+    /* Configure IP command data size. */
+    imxrt_semc_configureipcommand(base, SEMC_IPCOMMANDDATASIZEBYTEMAX);
+
+    while (size_bytes >= SEMC_IPCOMMANDDATASIZEBYTEMAX)
+    {
+        result = imxrt_semc_sendipcommand(base, kSEMC_MemType_NOR, address, kSEMC_NORDBICM_Read, 0, (uint32_t *)data);
+        if (result != kStatus_Success)
+        {
+            break;
+        }
+
+        data += SEMC_IPCOMMANDDATASIZEBYTEMAX;
+        size_bytes -= SEMC_IPCOMMANDDATASIZEBYTEMAX;
+    }
+
+    if ((result == kStatus_Success) && size_bytes)
+    {
+        imxrt_semc_configureipcommand(base, size_bytes);
+        result = imxrt_semc_sendipcommand(base, kSEMC_MemType_NOR, address, kSEMC_NORDBICM_Read, 0, &tempData);
+        while (size_bytes)
+        {
+            size_bytes--;
+            *(data + size_bytes) = (tempData >> (SEMC_BYTE_NUMBIT * size_bytes)) & 0xFFU;
+        }
+    }
+
+    imxrt_semc_configureipcommand(base, dataSize);
+    return result;
+}
+
+/****************************************************************************
+ * Function: imxrt_semc_ipcommandnorwrite
+ *
+ * Description:
+ *   brief SEMC NOR device memory write through IP command.
+ *
+ * Input Parameters:
+ *   base SEMC peripheral base address.
+ *   address  SEMC NOR device address.
+ *   data  Data for write access.
+ *   size_bytes   Data length.
+ *
+ * Returned Value:
+ *   Returns status.
+ *
+ ****************************************************************************/
+status_t imxrt_semc_ipcommandnorwrite(SEMC_Type *base, uint32_t address, uint8_t *data, uint32_t size_bytes)
+{
+    assert(data);
+
+    uint32_t tempData = 0;
+    status_t result = kStatus_Success;
+    uint8_t dataSize = base->NORCR0 & SEMC_NORCR0_PS_MASK;
+
+    /* Write command built */
+    while (size_bytes >= SEMC_IPCOMMANDDATASIZEBYTEMAX)
+    {
+        /* Configure IP command data size. */
+        imxrt_semc_configureipcommand(base, SEMC_IPCOMMANDDATASIZEBYTEMAX);
+        result = imxrt_semc_sendipcommand(base, kSEMC_MemType_NOR, address, kSEMC_NORDBICM_Write, *(uint32_t *)data, NULL);
+        if (result != kStatus_Success)
+        {
+            break;
+        }
+        size_bytes -= SEMC_IPCOMMANDDATASIZEBYTEMAX;
+        data += SEMC_IPCOMMANDDATASIZEBYTEMAX;
+    }
+
+    if ((result == kStatus_Success) && size_bytes)
+    {
+        imxrt_semc_configureipcommand(base, size_bytes);
+
+        while (size_bytes)
+        {
+            tempData |= ((uint32_t) * (data + size_bytes - 1) << ((size_bytes - 1) * SEMC_BYTE_NUMBIT));
+            size_bytes--;
+        }
+
+        result = imxrt_semc_sendipcommand(base, kSEMC_MemType_NOR, address, kSEMC_NORDBICM_Write, tempData, NULL);
+    }
+    imxrt_semc_configureipcommand(base, dataSize);
+
+    return result;
+}

--- a/os/arch/arm/src/imxrt/imxrt_semc.h
+++ b/os/arch/arm/src/imxrt/imxrt_semc.h
@@ -1,0 +1,973 @@
+/****************************************************************************
+ *
+ * Copyright 2019 NXP Semiconductors All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+/*
+ * Copyright 2017-2018 NXP
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+#ifndef _IMXRT_SEMC_H_
+#define _IMXRT_SEMC_H_
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <tinyara/config.h>
+
+#if defined(CONFIG_ARCH_CHIP_FAMILY_IMXRT102x)
+#include <chip/imxrt102x_features.h>
+#include "chip/imxrt102x_config.h"
+#elif defined(CONFIG_ARCH_CHIP_FAMILY_IMXRT105x)
+#include <chip/imxrt105x_features.h>
+#include "chip/imxrt105x_config.h"
+#else
+#error Unrecognized i.MX RT architecture
+#endif
+
+#include "imxrt_config.h"
+
+/*!
+ * @addtogroup semc
+ * @{
+ */
+
+/*******************************************************************************
+ * Definitions
+ ******************************************************************************/
+
+/*! @brief SEMC status. */
+enum _semc_status {
+    kStatus_SEMC_InvalidDeviceType = MAKE_STATUS(100, 0),
+    kStatus_SEMC_IpCommandExecutionError = MAKE_STATUS(100, 1),
+    kStatus_SEMC_AxiCommandExecutionError = MAKE_STATUS(100, 2),
+    kStatus_SEMC_InvalidMemorySize = MAKE_STATUS(100, 3),
+    kStatus_SEMC_InvalidIpcmdDataSize = MAKE_STATUS(100, 4),
+    kStatus_SEMC_InvalidAddressPortWidth = MAKE_STATUS(100, 5),
+    kStatus_SEMC_InvalidDataPortWidth = MAKE_STATUS(100, 6),
+    kStatus_SEMC_InvalidSwPinmuxSelection = MAKE_STATUS(100, 7),
+    kStatus_SEMC_InvalidBurstLength = MAKE_STATUS(100, 8),
+    kStatus_SEMC_InvalidColumnAddressBitWidth = MAKE_STATUS(100, 9),
+    kStatus_SEMC_InvalidBaseAddress = MAKE_STATUS(100, 10),
+    kStatus_SEMC_InvalidTimerSetting = MAKE_STATUS(100, 11),
+};
+
+/*! @brief SEMC memory device type. */
+typedef enum _semc_mem_type {
+    kSEMC_MemType_SDRAM = 0, /*!< SDRAM */
+    kSEMC_MemType_SRAM,      /*!< SRAM */
+    kSEMC_MemType_NOR,       /*!< NOR */
+    kSEMC_MemType_NAND,      /*!< NAND */
+    kSEMC_MemType_8080       /*!< 8080. */
+} semc_mem_type_t;
+
+/*! @brief SEMC WAIT/RDY polarity. */
+typedef enum _semc_waitready_polarity {
+    kSEMC_LowActive = 0, /*!< Low active. */
+    kSEMC_HighActive,    /*!< High active. */
+} semc_waitready_polarity_t;
+
+/*! @brief SEMC SDRAM Chip selection . */
+typedef enum _semc_sdram_cs {
+    kSEMC_SDRAM_CS0 = 0, /*!< SEMC SDRAM CS0. */
+    kSEMC_SDRAM_CS1,     /*!< SEMC SDRAM CS1. */
+    kSEMC_SDRAM_CS2,     /*!< SEMC SDRAM CS2. */
+    kSEMC_SDRAM_CS3      /*!< SEMC SDRAM CS3. */
+} semc_sdram_cs_t;
+
+/*! @brief SEMC NAND device type. */
+typedef enum _semc_nand_access_type {
+    kSEMC_NAND_ACCESS_BY_AXI = 0,
+    kSEMC_NAND_ACCESS_BY_IPCMD,
+} semc_nand_access_type_t;
+
+/*! @brief SEMC interrupts . */
+typedef enum _semc_interrupt_enable {
+    kSEMC_IPCmdDoneInterrupt = SEMC_INTEN_IPCMDDONEEN_MASK, /*!< Ip command done interrupt. */
+    kSEMC_IPCmdErrInterrupt = SEMC_INTEN_IPCMDERREN_MASK,   /*!< Ip command error interrupt. */
+    kSEMC_AXICmdErrInterrupt = SEMC_INTEN_AXICMDERREN_MASK, /*!< AXI command error interrupt. */
+    kSEMC_AXIBusErrInterrupt = SEMC_INTEN_AXIBUSERREN_MASK  /*!< AXI bus error interrupt. */
+} semc_interrupt_enable_t;
+
+/*! @brief SEMC IP command data size in bytes. */
+typedef enum _semc_ipcmd_datasize {
+    kSEMC_IPcmdDataSize_1bytes = 1, /*!< The IP command data size 1 byte. */
+    kSEMC_IPcmdDataSize_2bytes,     /*!< The IP command data size 2 byte. */
+    kSEMC_IPcmdDataSize_3bytes,     /*!< The IP command data size 3 byte. */
+    kSEMC_IPcmdDataSize_4bytes      /*!< The IP command data size 4 byte. */
+} semc_ipcmd_datasize_t;
+
+/*! @brief SEMC auto-refresh timing. */
+typedef enum _semc_refresh_time {
+    kSEMC_RefreshThreeClocks = 0x0U, /*!< The refresh timing with three bus clocks. */
+    kSEMC_RefreshSixClocks,          /*!< The refresh timing with six bus clocks. */
+    kSEMC_RefreshNineClocks          /*!< The refresh timing with nine bus clocks. */
+} semc_refresh_time_t;
+
+/*! @brief CAS latency */
+typedef enum _semc_caslatency {
+    kSEMC_LatencyOne = 1, /*!< Latency  1. */
+    kSEMC_LatencyTwo,     /*!< Latency  2. */
+    kSEMC_LatencyThree,   /*!< Latency  3. */
+} semc_caslatency_t;
+
+/*! @brief SEMC sdram column address bit number. */
+typedef enum _semc_sdram_column_bit_num {
+    kSEMC_SdramColunm_12bit = 0x0U, /*!< 12 bit. */
+    kSEMC_SdramColunm_11bit,        /*!< 11 bit. */
+    kSEMC_SdramColunm_10bit,        /*!< 10 bit. */
+    kSEMC_SdramColunm_9bit,         /*!< 9 bit. */
+} semc_sdram_column_bit_num_t;
+
+/*! @brief SEMC sdram burst length. */
+typedef enum _semc_sdram_burst_len {
+    kSEMC_Sdram_BurstLen1 = 0, /*!< Burst length 1*/
+    kSEMC_Sdram_BurstLen2,     /*!< Burst length 2*/
+    kSEMC_Sdram_BurstLen4,     /*!< Burst length 4*/
+    kSEMC_Sdram_BurstLen8      /*!< Burst length 8*/
+} sem_sdram_burst_len_t;
+
+/*! @brief SEMC nand column address bit number. */
+typedef enum _semc_nand_column_bit_num {
+    kSEMC_NandColum_16bit = 0x0U, /*!< 16 bit. */
+    kSEMC_NandColum_15bit,        /*!< 15 bit. */
+    kSEMC_NandColum_14bit,        /*!< 14 bit. */
+    kSEMC_NandColum_13bit,        /*!< 13 bit. */
+    kSEMC_NandColum_12bit,        /*!< 12 bit. */
+    kSEMC_NandColum_11bit,        /*!< 11 bit. */
+    kSEMC_NandColum_10bit,        /*!< 10 bit. */
+    kSEMC_NandColum_9bit,         /*!< 9 bit. */
+} semc_nand_column_bit_num_t;
+
+/*! @brief SEMC nand burst length. */
+typedef enum _semc_nand_burst_len {
+    kSEMC_Nand_BurstLen1 = 0, /*!< Burst length 1*/
+    kSEMC_Nand_BurstLen2,     /*!< Burst length 2*/
+    kSEMC_Nand_BurstLen4,     /*!< Burst length 4*/
+    kSEMC_Nand_BurstLen8,     /*!< Burst length 8*/
+    kSEMC_Nand_BurstLen16,    /*!< Burst length 16*/
+    kSEMC_Nand_BurstLen32,    /*!< Burst length 32*/
+    kSEMC_Nand_BurstLen64     /*!< Burst length 64*/
+} sem_nand_burst_len_t;
+
+/*! @brief SEMC nor/sram column address bit number. */
+typedef enum _semc_norsram_column_bit_num {
+    kSEMC_NorColum_12bit = 0x0U, /*!< 12 bit. */
+    kSEMC_NorColum_11bit,        /*!< 11 bit. */
+    kSEMC_NorColum_10bit,        /*!< 10 bit. */
+    kSEMC_NorColum_9bit,         /*!< 9 bit. */
+    kSEMC_NorColum_8bit,         /*!< 8 bit. */
+    kSEMC_NorColum_7bit,         /*!< 7 bit. */
+    kSEMC_NorColum_6bit,         /*!< 6 bit. */
+    kSEMC_NorColum_5bit,         /*!< 5 bit. */
+    kSEMC_NorColum_4bit,         /*!< 4 bit. */
+    kSEMC_NorColum_3bit,         /*!< 3 bit. */
+    kSEMC_NorColum_2bit          /*!< 2 bit. */
+} semc_norsram_column_bit_num_t;
+
+/*! @brief SEMC nor/sram burst length. */
+typedef enum _semc_norsram_burst_len {
+    kSEMC_Nor_BurstLen1 = 0, /*!< Burst length 1*/
+    kSEMC_Nor_BurstLen2,     /*!< Burst length 2*/
+    kSEMC_Nor_BurstLen4,     /*!< Burst length 4*/
+    kSEMC_Nor_BurstLen8,     /*!< Burst length 8*/
+    kSEMC_Nor_BurstLen16,    /*!< Burst length 16*/
+    kSEMC_Nor_BurstLen32,    /*!< Burst length 32*/
+    kSEMC_Nor_BurstLen64     /*!< Burst length 64*/
+} sem_norsram_burst_len_t;
+
+/*! @brief SEMC dbi column address bit number. */
+typedef enum _semc_dbi_column_bit_num {
+    kSEMC_Dbi_Colum_12bit = 0x0U, /*!< 12 bit. */
+    kSEMC_Dbi_Colum_11bit,        /*!< 11 bit. */
+    kSEMC_Dbi_Colum_10bit,        /*!< 10 bit. */
+    kSEMC_Dbi_Colum_9bit,         /*!< 9 bit. */
+    kSEMC_Dbi_Colum_8bit,         /*!< 8 bit. */
+    kSEMC_Dbi_Colum_7bit,         /*!< 7 bit. */
+    kSEMC_Dbi_Colum_6bit,         /*!< 6 bit. */
+    kSEMC_Dbi_Colum_5bit,         /*!< 5 bit. */
+    kSEMC_Dbi_Colum_4bit,         /*!< 4 bit. */
+    kSEMC_Dbi_Colum_3bit,         /*!< 3 bit. */
+    kSEMC_Dbi_Colum_2bit          /*!< 2 bit. */
+} semc_dbi_column_bit_num_t;
+
+/*! @brief SEMC dbi burst length. */
+typedef enum _semc_dbi_burst_len {
+    kSEMC_Dbi_BurstLen1 = 0, /*!< Burst length 1*/
+    kSEMC_Dbi_BurstLen2,     /*!< Burst length 2*/
+    kSEMC_Dbi_Dbi_BurstLen4, /*!< Burst length 4*/
+    kSEMC_Dbi_BurstLen8,     /*!< Burst length 8*/
+    kSEMC_Dbi_BurstLen16,    /*!< Burst length 16*/
+    kSEMC_Dbi_BurstLen32,    /*!< Burst length 32*/
+    kSEMC_Dbi_BurstLen64     /*!< Burst length 64*/
+} sem_dbi_burst_len_t;
+
+/*! @brief SEMC IOMUXC. */
+typedef enum _semc_iomux_pin {
+    kSEMC_MUXA8 = SEMC_IOCR_MUX_A8_SHIFT,     /*!< MUX A8 pin. */
+    kSEMC_MUXCSX0 = SEMC_IOCR_MUX_CSX0_SHIFT, /*!< MUX CSX0 pin */
+    kSEMC_MUXCSX1 = SEMC_IOCR_MUX_CSX1_SHIFT, /*!< MUX CSX1 Pin.*/
+    kSEMC_MUXCSX2 = SEMC_IOCR_MUX_CSX2_SHIFT, /*!< MUX CSX2 Pin. */
+    kSEMC_MUXCSX3 = SEMC_IOCR_MUX_CSX3_SHIFT, /*!< MUX CSX3 Pin. */
+    kSEMC_MUXRDY = SEMC_IOCR_MUX_RDY_SHIFT    /*!< MUX RDY pin. */
+} semc_iomux_pin;
+
+/*! @brief SEMC NOR/PSRAM Address bit 27 A27. */
+typedef enum _semc_iomux_nora27_pin {
+    kSEMC_MORA27_NONE = 0,                           /*!< No NOR/SRAM A27 pin. */
+    kSEMC_NORA27_MUXCSX3 = SEMC_IOCR_MUX_CSX3_SHIFT, /*!< MUX CSX3 Pin. */
+    kSEMC_NORA27_MUXRDY = SEMC_IOCR_MUX_RDY_SHIFT    /*!< MUX RDY pin. */
+} semc_iomux_nora27_pin;
+
+/*! @brief SEMC port size. */
+typedef enum _semc_port_size {
+    kSEMC_PortSize8Bit = 0, /*!< 8-Bit port size. */
+    kSEMC_PortSize16Bit     /*!< 16-Bit port size. */
+} smec_port_size_t;
+
+/*! @brief SEMC address mode. */
+typedef enum _semc_addr_mode {
+    kSEMC_AddrDataMux = 0, /*!< SEMC address/data mux mode. */
+    kSEMC_AdvAddrdataMux,  /*!< Advanced address/data mux mode. */
+    kSEMC_AddrDataNonMux   /*!< Address/data non-mux mode. */
+} semc_addr_mode_t;
+
+/*! @brief SEMC DQS read strobe mode. */
+typedef enum _semc_dqs_mode {
+    kSEMC_Loopbackinternal = 0, /*!< Dummy read strobe loopbacked internally. */
+    kSEMC_Loopbackdqspad,       /*!< Dummy read strobe loopbacked from DQS pad. */
+} semc_dqs_mode_t;
+
+/*! @brief SEMC ADV signal active polarity. */
+typedef enum _semc_adv_polarity {
+    kSEMC_AdvActiveLow = 0, /*!< Adv active low. */
+    kSEMC_AdvActivehigh,    /*!< Adv active low. */
+} semc_adv_polarity_t;
+
+/*! @brief SEMC RDY signal active polarity. */
+typedef enum _semc_rdy_polarity {
+    kSEMC_RdyActiveLow = 0, /*!< Adv active low. */
+    kSEMC_RdyActivehigh,    /*!< Adv active low. */
+} semc_rdy_polarity_t;
+
+/*! @brief SEMC IP command for NAND: address mode. */
+typedef enum _semc_ipcmd_nand_addrmode {
+    kSEMC_NANDAM_ColumnRow = 0x0U, /*!< Address mode: column and row address(5Byte-CA0/CA1/RA0/RA1/RA2). */
+    kSEMC_NANDAM_ColumnCA0,        /*!< Address mode: column address only(1 Byte-CA0).  */
+    kSEMC_NANDAM_ColumnCA0CA1,     /*!< Address mode: column address only(2 Byte-CA0/CA1). */
+    kSEMC_NANDAM_RawRA0,           /*!< Address mode: row address only(1 Byte-RA0). */
+    kSEMC_NANDAM_RawRA0RA1,        /*!< Address mode: row address only(2 Byte-RA0/RA1). */
+    kSEMC_NANDAM_RawRA0RA1RA2      /*!< Address mode: row address only(3 Byte-RA0).  */
+} semc_ipcmd_nand_addrmode_t;
+
+/*! @brief SEMC IP command for NAND： command mode. */
+typedef enum _semc_ipcmd_nand_cmdmode {
+    kSEMC_NANDCM_Command = 0x2U,      /*!< command. */
+    kSEMC_NANDCM_CommandHold,         /*!< Command hold. */
+    kSEMC_NANDCM_CommandAddress,      /*!< Command address. */
+    kSEMC_NANDCM_CommandAddressHold,  /*!< Command address hold.  */
+    kSEMC_NANDCM_CommandAddressRead,  /*!< Command address read.  */
+    kSEMC_NANDCM_CommandAddressWrite, /*!< Command address write.  */
+    kSEMC_NANDCM_CommandRead,         /*!< Command read.  */
+    kSEMC_NANDCM_CommandWrite,        /*!< Command write.  */
+    kSEMC_NANDCM_Read,                /*!< Read.  */
+    kSEMC_NANDCM_Write                /*!< Write.  */
+} semc_ipcmd_nand_cmdmode_t;
+
+/*! @brief SEMC NAND address option. */
+typedef enum _semc_nand_address_option {
+    kSEMC_NandAddrOption_5byte_CA2RA3 = 0U, /*!< CA0+CA1+RA0+RA1+RA2 */
+    kSEMC_NandAddrOption_4byte_CA2RA2 = 2U, /*!< CA0+CA1+RA0+RA1 */
+    kSEMC_NandAddrOption_3byte_CA2RA1 = 4U, /*!< CA0+CA1+RA0 */
+    kSEMC_NandAddrOption_4byte_CA1RA3 = 1U, /*!< CA0+RA0+RA1+RA2 */
+    kSEMC_NandAddrOption_3byte_CA1RA2 = 3U, /*!< CA0+RA0+RA1 */
+    kSEMC_NandAddrOption_2byte_CA1RA1 = 7U, /*!< CA0+RA0 */
+} semc_nand_address_option_t;
+
+/*! @brief SEMC IP command for NOR. */
+typedef enum _semc_ipcmd_nor_dbi {
+    kSEMC_NORDBICM_Read = 0x2U, /*!< NOR read. */
+    kSEMC_NORDBICM_Write        /*!< NOR write.  */
+} semc_ipcmd_nor_dbi_t;
+
+/*! @brief SEMC IP command for SRAM. */
+typedef enum _semc_ipcmd_sram {
+    kSEMC_SRAMCM_ArrayRead = 0x2U, /*!< SRAM memory array read. */
+    kSEMC_SRAMCM_ArrayWrite,       /*!< SRAM memory array write. */
+    kSEMC_SRAMCM_RegRead,          /*!< SRAM memory register read. */
+    kSEMC_SRAMCM_RegWrite          /*!< SRAM memory register write. */
+} semc_ipcmd_sram_t;
+
+/*! @brief SEMC IP command for SDARM. */
+typedef enum _semc_ipcmd_sdram {
+    kSEMC_SDRAMCM_Read = 0x8U, /*!< SDRAM memory read. */
+    kSEMC_SDRAMCM_Write,       /*!< SDRAM memory write. */
+    kSEMC_SDRAMCM_Modeset,     /*!< SDRAM MODE SET. */
+    kSEMC_SDRAMCM_Active,      /*!< SDRAM active. */
+    kSEMC_SDRAMCM_AutoRefresh, /*!< SDRAM auto-refresh. */
+    kSEMC_SDRAMCM_SelfRefresh, /*!< SDRAM self-refresh. */
+    kSEMC_SDRAMCM_Precharge,   /*!< SDRAM precharge. */
+    kSEMC_SDRAMCM_Prechargeall /*!< SDRAM precharge all. */
+} semc_ipcmd_sdram_t;
+
+/*! @brief SEMC SDRAM configuration structure.
+ *
+ * 1. The memory size in the configuration is in the unit of KB. So memsize_kbytes
+ * should be set as 2^2, 2^3, 2^4 .etc which is base 2KB exponential function.
+ * Take refer to BR0~BR3 register in RM for details.
+ * 2. The prescalePeriod_N16Cycle is in unit of 16 clock cycle. It is a exception for prescaleTimer_n16cycle = 0,
+ * it means the prescaler timer period is 256 * 16 clock cycles. For precalerIf precalerTimer_n16cycle not equal to 0,
+ * The  prescaler timer period is prescalePeriod_N16Cycle * 16 clock cycles.
+ * idleTimeout_NprescalePeriod,  refreshUrgThreshold_NprescalePeriod, refreshPeriod_NprescalePeriod are
+ * similar to prescalePeriod_N16Cycle.
+ *
+ */
+typedef struct _semc_sdram_config {
+    semc_iomux_pin csxPinMux;       /*!< CS pin mux. The kSEMC_MUXA8 is not valid in sdram pin mux setting. */
+    uint32_t address;               /*!< The base address. */
+    uint32_t memsize_kbytes;        /*!< The memory size in unit of kbytes. */
+    smec_port_size_t portSize;      /*!< Port size. */
+    sem_sdram_burst_len_t burstLen; /*!< Burst length. */
+    semc_sdram_column_bit_num_t columnAddrBitNum; /*!< Column address bit number. */
+    semc_caslatency_t casLatency;                 /*!< CAS latency. */
+    uint8_t tPrecharge2Act_Ns;                    /*!< Precharge to active wait time in unit of nanosecond. */
+    uint8_t tAct2ReadWrite_Ns;                    /*!< Act to read/write wait time in unit of nanosecond. */
+    uint8_t tRefreshRecovery_Ns;                  /*!< Refresh recovery time in unit of nanosecond. */
+    uint8_t tWriteRecovery_Ns;                    /*!< write recovery time in unit of nanosecond. */
+    uint8_t tCkeOff_Ns;                           /*!< CKE off minimum time in unit of nanosecond. */
+    uint8_t tAct2Prechage_Ns;                     /*!< Active to precharge in unit of nanosecond. */
+    uint8_t tSelfRefRecovery_Ns;                  /*!< Self refresh recovery time in unit of nanosecond. */
+    uint8_t tRefresh2Refresh_Ns;                  /*!< Refresh to refresh wait time in unit of nanosecond. */
+    uint8_t tAct2Act_Ns;                          /*!< Active to active wait time in unit of nanosecond. */
+    uint32_t tPrescalePeriod_Ns;     /*!< Prescaler timer period should not be larger than 256 * 16 * clock cycle. */
+    uint32_t tIdleTimeout_Ns;        /*!< Idle timeout in unit of prescale time period. */
+    uint32_t refreshPeriod_nsPerRow; /*!< Refresh timer period like 64ms * 1000000/8192 . */
+    uint32_t refreshUrgThreshold;    /*!< Refresh urgent threshold. */
+    uint8_t refreshBurstLen;         /*!< Refresh burst length. */
+} semc_sdram_config_t;
+
+/*! @brief SEMC NAND device timing configuration structure. */
+typedef struct _semc_nand_timing_config {
+    uint8_t tCeSetup_Ns;        /*!< CE setup time: tCS. */
+    uint8_t tCeHold_Ns;         /*!< CE hold time: tCH. */
+    uint8_t tCeInterval_Ns;     /*!< CE interval time:tCEITV. */
+    uint8_t tWeLow_Ns;          /*!< WE low time: tWP. */
+    uint8_t tWeHigh_Ns;         /*!< WE high time: tWH. */
+    uint8_t tReLow_Ns;          /*!< RE low time: tRP. */
+    uint8_t tReHigh_Ns;         /*!< RE high time: tREH. */
+    uint8_t tTurnAround_Ns;     /*!< Turnaround time for async mode: tTA. */
+    uint8_t tWehigh2Relow_Ns;   /*!< WE# high to RE# wait time: tWHR. */
+    uint8_t tRehigh2Welow_Ns;   /*!< RE# high to WE# low wait time: tRHW. */
+    uint8_t tAle2WriteStart_Ns; /*!< ALE to write start wait time: tADL. */
+    uint8_t tReady2Relow_Ns;    /*!< Ready to RE# low min wait time: tRR. */
+    uint8_t tWehigh2Busy_Ns;    /*!< WE# high to busy wait time: tWB. */
+} semc_nand_timing_config_t;
+
+/*! @brief SEMC NAND configuration structure. */
+typedef struct _semc_nand_config {
+    semc_iomux_pin cePinMux;    /*!< The CE pin mux setting. The kSEMC_MUXRDY is not valid for CE pin setting. */
+    uint32_t axiAddress;        /*!< The base address for AXI nand. */
+    uint32_t axiMemsize_kbytes; /*!< The memory size in unit of kbytes for AXI nand. */
+    uint32_t ipgAddress;        /*!< The base address for IPG nand . */
+    uint32_t ipgMemsize_kbytes; /*!< The memory size in unit of kbytes for IPG nand. */
+    semc_rdy_polarity_t rdyactivePolarity;       /*!< Wait ready polarity. */
+    bool edoModeEnabled;                         /*!< EDO mode enabled. */
+    semc_nand_column_bit_num_t columnAddrBitNum; /*!< Column address bit number. */
+    semc_nand_address_option_t arrayAddrOption;  /*!< Address option. */
+    sem_nand_burst_len_t burstLen;               /*!< Burst length. */
+    smec_port_size_t portSize;                   /*!< Port size. */
+    semc_nand_timing_config_t *timingConfig;     /*!< SEMC nand timing configuration. */
+} semc_nand_config_t;
+
+/*! @brief SEMC NOR configuration structure. */
+typedef struct _semc_nor_config {
+    semc_iomux_pin cePinMux;                        /*!< The CE# pin mux setting. */
+    semc_iomux_nora27_pin addr27;                   /*!< The Addr bit 27 pin mux setting. */
+    uint32_t address;                               /*!< The base address. */
+    uint32_t memsize_kbytes;                        /*!< The memory size in unit of kbytes. */
+    uint8_t addrPortWidth;                          /*!< The address port width. */
+    semc_rdy_polarity_t rdyactivePolarity;          /*!< Wait ready polarity. */
+    semc_adv_polarity_t advActivePolarity;          /*!< ADV# polarity. */
+    semc_norsram_column_bit_num_t columnAddrBitNum; /*!< Column address bit number. */
+    semc_addr_mode_t addrMode;                      /*!< Address mode. */
+    sem_norsram_burst_len_t burstLen;               /*!< Burst length. */
+    smec_port_size_t portSize;                      /*!< Port size. */
+    uint8_t tCeSetup_Ns;                            /*!< The CE setup time. */
+    uint8_t tCeHold_Ns;                             /*!< The CE hold time. */
+    uint8_t tCeInterval_Ns;                         /*!< CE interval minimum time. */
+    uint8_t tAddrSetup_Ns;                          /*!< The address setup time. */
+    uint8_t tAddrHold_Ns;                           /*!< The address hold time. */
+    uint8_t tWeLow_Ns;                              /*!< WE low time for async mode. */
+    uint8_t tWeHigh_Ns;                             /*!< WE high time for async mode. */
+    uint8_t tReLow_Ns;                              /*!< RE low time for async mode. */
+    uint8_t tReHigh_Ns;                             /*!< RE high time for async mode. */
+    uint8_t tTurnAround_Ns;                         /*!< Turnaround time for async mode. */
+    uint8_t tAddr2WriteHold_Ns;                     /*!< Address to write data hold time for async mode. */
+#if defined(FSL_FEATURE_SEMC_HAS_NOR_WDS_TIME) && (FSL_FEATURE_SEMC_HAS_NOR_WDS_TIME)
+    uint8_t tWriteSetup_Ns; /*!< Write data setup time for sync mode.*/
+#endif
+#if defined(FSL_FEATURE_SEMC_HAS_NOR_WDH_TIME) && (FSL_FEATURE_SEMC_HAS_NOR_WDH_TIME)
+    uint8_t tWriteHold_Ns; /*!< Write hold time for sync mode. */
+#endif
+    uint8_t latencyCount; /*!< Latency count for sync mode. */
+    uint8_t readCycle;    /*!< Read cycle time for sync mode. */
+} semc_nor_config_t;
+
+/*! @brief SEMC SRAM  configuration structure. */
+typedef struct _semc_sram_config {
+    semc_iomux_pin cePinMux;               /*!< The CE# pin mux setting. */
+    semc_iomux_nora27_pin addr27;          /*!< The Addr bit 27 pin mux setting. */
+    uint32_t address;                      /*!< The base address. */
+    uint32_t memsize_kbytes;               /*!< The memory size in unit of kbytes. */
+    uint8_t addrPortWidth;                 /*!< The address port width. */
+    semc_adv_polarity_t advActivePolarity; /*!< ADV# polarity 1: active high, 0: active low. */
+    semc_addr_mode_t addrMode;             /*!< Address mode. */
+    sem_norsram_burst_len_t burstLen;      /*!< Burst length. */
+    smec_port_size_t portSize;             /*!< Port size. */
+    uint8_t tCeSetup_Ns;                   /*!< The CE setup time. */
+    uint8_t tCeHold_Ns;                    /*!< The CE hold time. */
+    uint8_t tCeInterval_Ns;                /*!< CE interval minimum time. */
+    uint8_t tAddrSetup_Ns;                 /*!< The address setup time. */
+    uint8_t tAddrHold_Ns;                  /*!< The address hold time. */
+    uint8_t tWeLow_Ns;                     /*!< WE low time for async mode. */
+    uint8_t tWeHigh_Ns;                    /*!< WE high time for async mode. */
+    uint8_t tReLow_Ns;                     /*!< RE low time for async mode. */
+    uint8_t tReHigh_Ns;                    /*!< RE high time for async mode. */
+    uint8_t tTurnAround_Ns;                /*!< Turnaround time for async mode. */
+    uint8_t tAddr2WriteHold_Ns;            /*!< Address to write data hold time for async mode. */
+    uint8_t tWriteSetup_Ns;                /*!< Write data setup time for sync mode.*/
+    uint8_t tWriteHold_Ns;                 /*!< Write hold time for sync mode. */
+    uint8_t latencyCount;                  /*!< Latency count for sync mode. */
+    uint8_t readCycle;                     /*!< Read cycle time for sync mode. */
+} semc_sram_config_t;
+
+/*! @brief SEMC DBI configuration structure. */
+typedef struct _semc_dbi_config {
+    semc_iomux_pin csxPinMux;                   /*!< The CE# pin mux. */
+    uint32_t address;                           /*!< The base address. */
+    uint32_t memsize_kbytes;                    /*!< The memory size in unit of 4kbytes. */
+    semc_dbi_column_bit_num_t columnAddrBitNum; /*!< Column address bit number. */
+    sem_dbi_burst_len_t burstLen;               /*!< Burst length. */
+    smec_port_size_t portSize;                  /*!< Port size. */
+    uint8_t tCsxSetup_Ns;                       /*!< The CSX setup time. */
+    uint8_t tCsxHold_Ns;                        /*!< The CSX hold time. */
+    uint8_t tWexLow_Ns;                         /*!< WEX low time. */
+    uint8_t tWexHigh_Ns;                        /*!< WEX high time. */
+    uint8_t tRdxLow_Ns;                         /*!< RDX low time. */
+    uint8_t tRdxHigh_Ns;                        /*!< RDX high time. */
+    uint8_t tCsxInterval_Ns;                    /*!< Write data setup time.*/
+} semc_dbi_config_t;
+
+/*! @brief SEMC AXI queue a weight setting structure. */
+typedef struct _semc_queuea_weight_struct {
+    uint32_t qos : 4;              /*!< weight of qos for queue 0 . */
+    uint32_t aging : 4;            /*!< weight of aging for queue 0.*/
+    uint32_t slaveHitSwith : 8;    /*!< weight of read/write switch for queue 0.*/
+    uint32_t slaveHitNoswitch : 8; /*!< weight of read/write no switch for queue 0  .*/
+} semc_queuea_weight_struct_t;
+
+/*! @brief SEMC AXI queue a weight setting union. */
+typedef union _semc_queuea_weight {
+    semc_queuea_weight_struct_t queueaConfig; /*!< Structure configuration for queueA. */
+    uint32_t queueaValue; /*!< Configuration value for queueA which could directly write to the reg. */
+} semc_queuea_weight_t;
+
+/*! @brief SEMC AXI queue b weight setting structure. */
+typedef struct _semc_queueb_weight_struct {
+    uint32_t qos : 4;           /*!< weight of qos for queue 1. */
+    uint32_t aging : 4;         /*!< weight of aging for queue 1.*/
+    uint32_t slaveHitSwith : 8; /*!< weight of read/write switch for queue 1.*/
+    uint32_t weightPagehit : 8; /*!< weight of page hit for queue 1 only .*/
+    uint32_t bankRotation : 8;  /*!< weight of bank rotation for queue 1 only .*/
+} semc_queueb_weight_struct_t;
+
+/*! @brief SEMC AXI queue b weight setting union. */
+typedef union _semc_queueb_weight {
+    semc_queueb_weight_struct_t queuebConfig; /*!< Structure configuration for queueB. */
+    uint32_t queuebValue; /*!< Configuration value for queueB which could directly write to the reg. */
+} semc_queueb_weight_t;
+
+/*! @brief SEMC AXI queue weight setting. */
+typedef struct _semc_axi_queueweight {
+    semc_queuea_weight_t queueaWeight; /*!< Weight settings for queue a. */
+    semc_queueb_weight_t queuebWeight; /*!< Weight settings for queue b. */
+} semc_axi_queueweight_t;
+
+/*!
+ * @brief SEMC configuration structure.
+ *
+ * busTimeoutCycles: when busTimeoutCycles is zero, the bus timeout cycle is
+ * 255*1024. otherwise the bus timeout cycles is busTimeoutCycles*1024.
+ * cmdTimeoutCycles: is used for command execution timeout cycles. it's
+ * similar to the busTimeoutCycles.
+ */
+typedef struct _semc_config_t {
+    semc_dqs_mode_t dqsMode;            /*!< Dummy read strobe mode: use enum in "semc_dqs_mode_t". */
+    uint8_t cmdTimeoutCycles;           /*!< Command execution timeout cycles. */
+    uint8_t busTimeoutCycles;           /*!< Bus timeout cycles. */
+    semc_axi_queueweight_t queueWeight; /*!< AXI queue weight. */
+} semc_config_t;
+
+/*******************************************************************************
+ * API
+ ******************************************************************************/
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+/*!
+ * @name SEMC Initialization and De-initialization
+ * @{
+ */
+
+/****************************************************************************
+ * Function: imxrt_semc_getdefaultconfig
+ *
+ * Description:
+ *   brief Gets the SEMC default basic configuration structure.
+ * 
+ *   The purpose of this API is to get the default SEMC
+ *   configure structure for imxrt_semc_init(). User may use the initialized
+ *   structure unchanged in imxrt_semc_init(), or modify some fields of the
+ *   structure before calling imxrt_semc_init().
+ *   Example:
+     @code
+     semc_config_t config;
+     imxrt_semc_getdefaultconfig(&config);
+     @endcode
+ *
+ * Input Parameters:
+ *   config The SEMC configuration structure pointer.
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+void imxrt_semc_getdefaultconfig(semc_config_t *config);
+
+/****************************************************************************
+ * Function: imxrt_semc_init
+ *
+ * Description:
+ *   brief Initializes SEMC.
+ * 
+ *   This function ungates the SEMC clock and initializes SEMC.
+ *   This function must be called before calling any other SEMC driver functions.
+ *
+ * Input Parameters:
+ *   base SEMC peripheral base address.
+ *   configure The SEMC configuration structure pointer.
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+void imxrt_semc_init(SEMC_Type *base, semc_config_t *configure);
+
+/****************************************************************************
+ * Function: imxrt_semc_deinit
+ *
+ * Description:
+ *   brief Deinitializes the SEMC module and gates the clock.
+ * 
+ *   This function gates the SEMC clock. As a result, the SEMC module doesn't work after
+ *   calling this function, for some IDE, calling this API may cause the next downloading
+ *   operation failed. so, please call this API cautiously. Additional, users can
+ *   using "#define FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL (1)" to disable the clock control
+ *   operation in drivers.
+ *
+ * Input Parameters:
+ *   base SEMC peripheral base address.
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+void imxrt_semc_deinit(SEMC_Type *base);
+
+/* @} */
+
+/*!
+ * @name SEMC Configuration Operation For Each Memory Type
+ * @{
+ */
+
+/****************************************************************************
+ * Function: imxrt_semc_configuresdram
+ *
+ * Description:
+ *   brief Configures SDRAM controller in SEMC.
+ *
+ * Input Parameters:
+ *   base SEMC peripheral base address.
+ *   cs The chip selection.
+ *   config The sdram configuration.
+ *   clkSrc_Hz The SEMC clock frequency.
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+status_t imxrt_semc_configuresdram(SEMC_Type *base, semc_sdram_cs_t cs, semc_sdram_config_t *config, uint32_t clkSrc_Hz);
+
+/****************************************************************************
+ * Function: imxrt_semc_configurenand
+ *
+ * Description:
+ *   Configures NAND controller in SEMC.
+ *
+ * Input Parameters:
+ *   base SEMC peripheral base address.
+ *   config The nand configuration.
+ *   clkSrc_Hz The SEMC clock frequency.
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+status_t imxrt_semc_configurenand(SEMC_Type *base, semc_nand_config_t *config, uint32_t clkSrc_Hz);
+
+/****************************************************************************
+ * Function: imxrt_semc_configurenor
+ *
+ * Description:
+ *   Configures NOR controller in SEMC.
+ *
+ * Input Parameters:
+ *   base SEMC peripheral base address.
+ *   config The nor configuration.
+ *   clkSrc_Hz The SEMC clock frequency.
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+status_t imxrt_semc_configurenor(SEMC_Type *base, semc_nor_config_t *config, uint32_t clkSrc_Hz);
+
+/****************************************************************************
+ * Function: imxrt_semc_configuresram
+ *
+ * Description:
+ *   Configures SRAM controller in SEMC.
+ *
+ * Input Parameters:
+ *   base SEMC peripheral base address.
+ *   config The sram configuration.
+ *   clkSrc_Hz The SEMC clock frequency.
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+status_t imxrt_semc_configuresram(SEMC_Type *base, semc_sram_config_t *config, uint32_t clkSrc_Hz);
+
+/****************************************************************************
+ * Function: imxrt_semc_configuredbi
+ *
+ * Description:
+ *   Configures DBI controller in SEMC.
+ *
+ * Input Parameters:
+ *   base SEMC peripheral base address.
+ *   config The dbi configuration.
+ *   clkSrc_Hz The SEMC clock frequency.
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+status_t imxrt_semc_configuredbi(SEMC_Type *base, semc_dbi_config_t *config, uint32_t clkSrc_Hz);
+
+/* @} */
+
+/*!
+ * @name SEMC Interrupt Operation
+ * @{
+ */
+
+/****************************************************************************
+ * Function: imxrt_semc_enableinterrupts
+ *
+ * Description:
+ *   brief Enables the SEMC interrupt.
+ *
+ *   This function enables the SEMC interrupts according to the provided mask. The mask
+ *   is a logical OR of enumeration members. See @ref semc_interrupt_enable_t.
+ *   For example, to enable the IP command done and error interrupt, do the following.
+ *   @code
+ *     SEMC_EnableInterrupts(ENET, kSEMC_IPCmdDoneInterrupt | kSEMC_IPCmdErrInterrupt);
+ *   @endcode
+ *
+ * Input Parameters:
+ *   base SEMC peripheral base address.
+ *   mask  SEMC interrupts to enable. This is a logical OR of the
+ *         enumeration :: semc_interrupt_enable_t.
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+static inline void imxrt_semc_enableinterrupts(SEMC_Type *base, uint32_t mask)
+{
+    base->INTEN |= mask;
+}
+
+/****************************************************************************
+ * Function: imxrt_semc_disableinterrupts
+ *
+ * Description:
+ *   brief Disables the SEMC interrupt.
+ *
+ *   This function disables the SEMC interrupts according to the provided mask. The mask
+ *   is a logical OR of enumeration members. See @ref semc_interrupt_enable_t.
+ *   For example, to disable the IP command done and error interrupt, do the following.
+ *   @code
+ *     SEMC_DisableInterrupts(ENET, kSEMC_IPCmdDoneInterrupt | kSEMC_IPCmdErrInterrupt);
+ *   @endcode
+ *
+ * Input Parameters:
+ *   base SEMC peripheral base address.
+ *   mask  SEMC interrupts to disable. This is a logical OR of the
+ *         enumeration :: semc_interrupt_enable_t.
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+static inline void imxrt_semc_disableinterrupts(SEMC_Type *base, uint32_t mask)
+{
+    base->INTEN &= ~mask;
+}
+
+/****************************************************************************
+ * Function: imxrt_semc_getstatusflag
+ *
+ * Description:
+ *   brief Gets the SEMC status.
+ *
+ *   This function gets the SEMC interrupts event status.
+ *   User can use the a logical OR of enumeration member as a mask.
+ *   See @ref semc_interrupt_enable_t.
+ *
+ * Input Parameters:
+ *   base SEMC peripheral base address.
+ *
+ * Returned Value:
+ *   Returns status flag, use status flag in semc_interrupt_enable_t to get the related status.
+ *
+ ****************************************************************************/
+static inline bool imxrt_semc_getstatusflag(SEMC_Type *base)
+{
+    return base->INTR;
+}
+
+/****************************************************************************
+ * Function: imxrt_semc_clearstatusflags
+ *
+ * Description:
+ *   brief Clears the SEMC status flag state.
+ *
+ *   This function gets the SEMC interrupts event status.
+ *   User can use the a logical OR of enumeration member as a mask.
+ *   See @ref semc_interrupt_enable_t.
+ *
+ * Input Parameters:
+ *   base SEMC peripheral base address.
+ *
+ * Returned Value:
+ *   Returns status flag, use status flag in semc_interrupt_enable_t to get the related status.
+ *
+ ****************************************************************************/
+static inline void imxrt_semc_clearstatusflags(SEMC_Type *base, uint32_t mask)
+{
+    base->INTR |= mask;
+}
+
+/* @} */
+
+/*!
+ * @name SEMC Memory Access Operation
+ * @{
+ */
+
+/****************************************************************************
+ * Function: imxrt_semc_isinidle
+ *
+ * Description:
+ *   brief Check if SEMC is in idle.
+ *
+ * Input Parameters:
+ *   base SEMC peripheral base address.
+ *
+ * Returned Value:
+ *   Returns True SEMC is in idle, false is not in idle.
+ *
+ ****************************************************************************/
+static inline bool imxrt_semc_isinidle(SEMC_Type *base)
+{
+    return (base->STS0 & SEMC_STS0_IDLE_MASK) ? true : false;
+}
+
+/****************************************************************************
+ * Function: imxrt_semc_sendipcommand
+ *
+ * Description:
+ *   brief SEMC IP command access.
+ *
+ * Input Parameters:
+ *   base SEMC peripheral base address.
+ *   type  SEMC memory type. refer to "semc_mem_type_t"
+ *   address  SEMC device address.
+ *   command  SEMC IP command.
+ *     For NAND device, we should use the SEMC_BuildNandIPCommand to get the right nand command.
+ *     For NOR/DBI device, take refer to "semc_ipcmd_nor_dbi_t".
+ *     For SRAM device, take refer to "semc_ipcmd_sram_t".
+ *     For SDRAM device, take refer to "semc_ipcmd_sdram_t".
+ *   write  Data for write access.
+ *   read   Data pointer for read data out.
+ *
+ * Returned Value:
+ *   Returns status
+ *
+ ****************************************************************************/
+status_t imxrt_semc_sendipcommand(
+    SEMC_Type *base, semc_mem_type_t type, uint32_t address, uint16_t command, uint32_t write, uint32_t *read);
+
+/****************************************************************************
+ * Function: imxrt_semc_buildnandipcommand
+ *
+ * Description:
+ *   brief Build SEMC IP command for NAND.
+ *
+ *   This function build SEMC NAND IP command. The command is build of user command code,
+ *   SEMC address mode and SEMC command mode.
+ *
+ * Input Parameters:
+ *   userCommand  NAND device normal command.
+ *   addrMode  NAND address mode. Refer to "semc_ipcmd_nand_addrmode_t".
+ *   cmdMode   NAND command mode. Refer to "semc_ipcmd_nand_cmdmode_t".
+ *
+ * Returned Value:
+ *   Returns status
+ *
+ ****************************************************************************/
+static inline uint16_t imxrt_semc_buildnandipcommand(uint8_t userCommand,
+                                               semc_ipcmd_nand_addrmode_t addrMode,
+                                               semc_ipcmd_nand_cmdmode_t cmdMode)
+{
+    return (uint16_t)((uint16_t)userCommand << 8) | (uint16_t)(addrMode << 4) | ((uint8_t)cmdMode & 0x0Fu);
+}
+
+/****************************************************************************
+ * Function: imxrt_semc_isnandready
+ *
+ * Description:
+ *   brief Check if the NAND device is ready.
+ *
+ * Input Parameters:
+ *   base  SEMC peripheral base address.
+ *
+ * Returned Value:
+ *   Returns True NAND is ready, false NAND is not ready.
+ *
+ ****************************************************************************/
+static inline bool imxrt_semc_isnandready(SEMC_Type *base)
+{
+    return (base->STS0 & SEMC_STS0_NARDY_MASK) ? true : false;
+}
+
+/****************************************************************************
+ * Function: imxrt_semc_ipcommandnandwrite
+ *
+ * Description:
+ *   brief SEMC NAND device memory write through IP command.
+ *
+ * Input Parameters:
+ *   base  SEMC peripheral base address.
+ *   address  SEMC NAND device address.
+ *   data  Data for write access.
+ *   size_bytes   Data length.
+ *
+ * Returned Value:
+ *   Returns status.
+ *
+ ****************************************************************************/
+status_t imxrt_semc_ipcommandnandwrite(SEMC_Type *base, uint32_t address, uint8_t *data, uint32_t size_bytes);
+
+/****************************************************************************
+ * Function: imxrt_semc_ipcommandnandread
+ *
+ * Description:
+ *   brief SEMC NAND device memory read through IP command.
+ *
+ * Input Parameters:
+ *   base  SEMC peripheral base address.
+ *   address  SEMC NAND device address.
+ *   data  Data pointer for data read out.
+ *   size_bytes   Data length.
+ *
+ * Returned Value:
+ *   Returns status.
+ *
+ ****************************************************************************/
+status_t imxrt_semc_ipcommandnandread(SEMC_Type *base, uint32_t address, uint8_t *data, uint32_t size_bytes);
+
+/****************************************************************************
+ * Function: imxrt_semc_ipcommandnorwrite
+ *
+ * Description:
+ *   brief SEMC NOR device memory write through IP command.
+ *
+ * Input Parameters:
+ *   base  SEMC peripheral base address.
+ *   address  SEMC NOR device address.
+ *   data  Data for write access.
+ *   size_bytes   Data length.
+ *
+ * Returned Value:
+ *   Returns status.
+ *
+ ****************************************************************************/
+status_t imxrt_semc_ipcommandnorwrite(SEMC_Type *base, uint32_t address, uint8_t *data, uint32_t size_bytes);
+
+/****************************************************************************
+ * Function: imxrt_semc_ipcommandnorread
+ *
+ * Description:
+ *   brief SEMC NOR device memory read through IP command.
+ *
+ * Input Parameters:
+ *   base  SEMC peripheral base address.
+ *   address  SEMC NOR device address.
+ *   data  Data pointer for data read out.
+ *   size_bytes   Data length.
+ *
+ * Returned Value:
+ *   Returns status.
+ *
+ ****************************************************************************/
+status_t imxrt_semc_ipcommandnorread(SEMC_Type *base, uint32_t address, uint8_t *data, uint32_t size_bytes);
+
+/* @} */
+
+#if defined(__cplusplus)
+}
+#endif
+
+/*! @}*/
+
+#endif /* _FSL_SEMC_H_*/

--- a/os/arch/arm/src/imxrt/imxrt_semc_sdram.c
+++ b/os/arch/arm/src/imxrt/imxrt_semc_sdram.c
@@ -1,0 +1,1291 @@
+/****************************************************************************
+ *
+ * Copyright 2019 NXP Semiconductors All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+/************************************************************************************
+ * os/arch/arm/src/imxrt/imxrt_semc_sdram.c
+ *
+ *   Copyright (C) 2011 Uros Platise. All rights reserved.
+ *   Author: Uros Platise <uros.platise@isotel.eu>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ************************************************************************************/
+
+/* Provides standard flash access functions, to be used by the  flash mtd driver.
+ * The interface is defined in the include/tinyara/progmem.h
+ *
+ * Requirements during write/erase operations on FLASH:
+ *  - HSI must be ON.
+ *  - Low Power Modes are not permitted during write/erase
+ */
+
+/************************************************************************************
+ * Included Files
+ ************************************************************************************/
+
+#include <tinyara/config.h>
+#include <tinyara/arch.h>
+#include <stdio.h>
+#include <errno.h>
+
+#include "imxrt_flexspi.h"
+#include "imxrt_flash.h"
+#include "imxrt_log.h"
+
+#include "up_arch.h"
+#include <tinyara/fs/mtd.h>
+#include <tinyara/fs/ioctl.h>
+#include <tinyara/spi/spi.h>
+
+#include "imxrt_clock.h"
+#include "imxrt_iomuxc.h"
+#include "chip/imxrt_memorymap.h"
+#include "imxrt_semc.h"
+#include "imxrt_log.h"
+
+
+/************************************************************************************
+ * Pre-processor Definitions
+ ************************************************************************************/
+
+/************************************************************************************
+ * Private Data
+ ************************************************************************************/
+
+/*******************************************************************************
+ * Code
+ ******************************************************************************/
+
+/************************************************************************************
+ * Private Functions
+ ************************************************************************************/
+/************************************************************************************
+ * Name: imxrt_semc_sdram_pins_init
+ *
+ * Description:
+ *   Initialize pin setting in sdram
+ *
+ ************************************************************************************/
+static inline void imxrt_semc_sdram_pins_init(void)
+{
+    imxrt_clock_enableclock(kCLOCK_Iomuxc);           /* iomuxc clock (iomuxc_clk_enable): 0x03u */
+
+	#if defined(CONFIG_ARCH_CHIP_FAMILY_IMXRT102x)
+	imxrt_iomuxc_setpinmux(
+		IOMUXC_GPIO_EMC_00_SEMC_DATA00,         /* GPIO_EMC_00 is configured as SEMC_DATA00 */
+		0U);                                    /* Software Input On Field: Input Path is determined by functionality */
+	imxrt_iomuxc_setpinmux(
+		IOMUXC_GPIO_EMC_01_SEMC_DATA01,         /* GPIO_EMC_01 is configured as SEMC_DATA01 */
+		0U);                                    /* Software Input On Field: Input Path is determined by functionality */
+	imxrt_iomuxc_setpinmux(
+		IOMUXC_GPIO_EMC_02_SEMC_DATA02,         /* GPIO_EMC_02 is configured as SEMC_DATA02 */
+		0U);                                    /* Software Input On Field: Input Path is determined by functionality */
+	imxrt_iomuxc_setpinmux(
+		IOMUXC_GPIO_EMC_03_SEMC_DATA03,         /* GPIO_EMC_03 is configured as SEMC_DATA03 */
+		0U);                                    /* Software Input On Field: Input Path is determined by functionality */
+	imxrt_iomuxc_setpinmux(
+		IOMUXC_GPIO_EMC_04_SEMC_DATA04,         /* GPIO_EMC_04 is configured as SEMC_DATA04 */
+		0U);                                    /* Software Input On Field: Input Path is determined by functionality */
+	imxrt_iomuxc_setpinmux(
+		IOMUXC_GPIO_EMC_05_SEMC_DATA05,         /* GPIO_EMC_05 is configured as SEMC_DATA05 */
+		0U);                                    /* Software Input On Field: Input Path is determined by functionality */
+	imxrt_iomuxc_setpinmux(
+		IOMUXC_GPIO_EMC_06_SEMC_DATA06,         /* GPIO_EMC_06 is configured as SEMC_DATA06 */
+		0U);                                    /* Software Input On Field: Input Path is determined by functionality */
+	imxrt_iomuxc_setpinmux(
+		IOMUXC_GPIO_EMC_07_SEMC_DATA07,         /* GPIO_EMC_07 is configured as SEMC_DATA07 */
+		0U);                                    /* Software Input On Field: Input Path is determined by functionality */
+	imxrt_iomuxc_setpinmux(
+		IOMUXC_GPIO_EMC_08_SEMC_DM00,           /* GPIO_EMC_08 is configured as SEMC_DM00 */
+		0U);                                    /* Software Input On Field: Input Path is determined by functionality */
+	imxrt_iomuxc_setpinmux(
+		IOMUXC_GPIO_EMC_09_SEMC_WE,             /* GPIO_EMC_09 is configured as SEMC_WE */
+		0U);                                    /* Software Input On Field: Input Path is determined by functionality */
+	imxrt_iomuxc_setpinmux(
+		IOMUXC_GPIO_EMC_10_SEMC_CAS,            /* GPIO_EMC_10 is configured as SEMC_CAS */
+		0U);                                    /* Software Input On Field: Input Path is determined by functionality */
+	imxrt_iomuxc_setpinmux(
+		IOMUXC_GPIO_EMC_11_SEMC_RAS,            /* GPIO_EMC_11 is configured as SEMC_RAS */
+		0U);                                    /* Software Input On Field: Input Path is determined by functionality */
+	imxrt_iomuxc_setpinmux(
+		IOMUXC_GPIO_EMC_12_SEMC_CS0,            /* GPIO_EMC_12 is configured as SEMC_CS0 */
+		0U);                                    /* Software Input On Field: Input Path is determined by functionality */
+	imxrt_iomuxc_setpinmux(
+		IOMUXC_GPIO_EMC_13_SEMC_BA0,            /* GPIO_EMC_13 is configured as SEMC_BA0 */
+		0U);                                    /* Software Input On Field: Input Path is determined by functionality */
+	imxrt_iomuxc_setpinmux(
+		IOMUXC_GPIO_EMC_14_SEMC_BA1,            /* GPIO_EMC_14 is configured as SEMC_BA1 */
+		0U);                                    /* Software Input On Field: Input Path is determined by functionality */
+	imxrt_iomuxc_setpinmux(
+		IOMUXC_GPIO_EMC_15_SEMC_ADDR10,         /* GPIO_EMC_15 is configured as SEMC_ADDR10 */
+		0U);                                    /* Software Input On Field: Input Path is determined by functionality */
+	imxrt_iomuxc_setpinmux(
+		IOMUXC_GPIO_EMC_16_SEMC_ADDR00,         /* GPIO_EMC_16 is configured as SEMC_ADDR00 */
+		0U);                                    /* Software Input On Field: Input Path is determined by functionality */
+	imxrt_iomuxc_setpinmux(
+		IOMUXC_GPIO_EMC_17_SEMC_ADDR01,         /* GPIO_EMC_17 is configured as SEMC_ADDR01 */
+		0U);                                    /* Software Input On Field: Input Path is determined by functionality */
+	imxrt_iomuxc_setpinmux(
+		IOMUXC_GPIO_EMC_18_SEMC_ADDR02,         /* GPIO_EMC_18 is configured as SEMC_ADDR02 */
+		0U);                                    /* Software Input On Field: Input Path is determined by functionality */
+	imxrt_iomuxc_setpinmux(
+		IOMUXC_GPIO_EMC_19_SEMC_ADDR03,         /* GPIO_EMC_19 is configured as SEMC_ADDR03 */
+		0U);                                    /* Software Input On Field: Input Path is determined by functionality */
+	imxrt_iomuxc_setpinmux(
+		IOMUXC_GPIO_EMC_20_SEMC_ADDR04,         /* GPIO_EMC_20 is configured as SEMC_ADDR04 */
+		0U);                                    /* Software Input On Field: Input Path is determined by functionality */
+	imxrt_iomuxc_setpinmux(
+		IOMUXC_GPIO_EMC_21_SEMC_ADDR05,         /* GPIO_EMC_21 is configured as SEMC_ADDR05 */
+		0U);                                    /* Software Input On Field: Input Path is determined by functionality */
+	imxrt_iomuxc_setpinmux(
+		IOMUXC_GPIO_EMC_22_SEMC_ADDR06,         /* GPIO_EMC_22 is configured as SEMC_ADDR06 */
+		0U);                                    /* Software Input On Field: Input Path is determined by functionality */
+	imxrt_iomuxc_setpinmux(
+		IOMUXC_GPIO_EMC_23_SEMC_ADDR07,         /* GPIO_EMC_23 is configured as SEMC_ADDR07 */
+		0U);                                    /* Software Input On Field: Input Path is determined by functionality */
+	imxrt_iomuxc_setpinmux(
+		IOMUXC_GPIO_EMC_24_SEMC_ADDR08,         /* GPIO_EMC_24 is configured as SEMC_ADDR08 */
+		0U);                                    /* Software Input On Field: Input Path is determined by functionality */
+	imxrt_iomuxc_setpinmux(
+		IOMUXC_GPIO_EMC_25_SEMC_ADDR09,         /* GPIO_EMC_25 is configured as SEMC_ADDR09 */
+		0U);                                    /* Software Input On Field: Input Path is determined by functionality */
+	imxrt_iomuxc_setpinmux(
+		IOMUXC_GPIO_EMC_26_SEMC_ADDR11,         /* GPIO_EMC_26 is configured as SEMC_ADDR11 */
+		0U);                                    /* Software Input On Field: Input Path is determined by functionality */
+	imxrt_iomuxc_setpinmux(
+		IOMUXC_GPIO_EMC_27_SEMC_ADDR12,         /* GPIO_EMC_27 is configured as SEMC_ADDR12 */
+		0U);                                    /* Software Input On Field: Input Path is determined by functionality */
+	imxrt_iomuxc_setpinmux(
+		IOMUXC_GPIO_EMC_28_SEMC_DQS,            /* GPIO_EMC_28 is configured as SEMC_DQS */
+		1U);                                    /* Software Input On Field: Force input path of pad GPIO_EMC_28 */
+	imxrt_iomuxc_setpinmux(
+		IOMUXC_GPIO_EMC_29_SEMC_CKE,            /* GPIO_EMC_29 is configured as SEMC_CKE */
+		0U);                                    /* Software Input On Field: Input Path is determined by functionality */
+	imxrt_iomuxc_setpinmux(
+		IOMUXC_GPIO_EMC_30_SEMC_CLK,            /* GPIO_EMC_30 is configured as SEMC_CLK */
+		0U);                                    /* Software Input On Field: Input Path is determined by functionality */
+	imxrt_iomuxc_setpinmux(
+		IOMUXC_GPIO_EMC_31_SEMC_DM01,           /* GPIO_EMC_31 is configured as SEMC_DM01 */
+		0U);                                    /* Software Input On Field: Input Path is determined by functionality */
+	imxrt_iomuxc_setpinmux(
+		IOMUXC_GPIO_EMC_32_SEMC_DATA08,         /* GPIO_EMC_32 is configured as SEMC_DATA08 */
+		0U);                                    /* Software Input On Field: Input Path is determined by functionality */
+	imxrt_iomuxc_setpinmux(
+		IOMUXC_GPIO_EMC_33_SEMC_DATA09,         /* GPIO_EMC_33 is configured as SEMC_DATA09 */
+		0U);                                    /* Software Input On Field: Input Path is determined by functionality */
+	imxrt_iomuxc_setpinmux(
+		IOMUXC_GPIO_EMC_34_SEMC_DATA10,         /* GPIO_EMC_34 is configured as SEMC_DATA10 */
+		0U);                                    /* Software Input On Field: Input Path is determined by functionality */
+	imxrt_iomuxc_setpinmux(
+		IOMUXC_GPIO_EMC_35_SEMC_DATA11,         /* GPIO_EMC_35 is configured as SEMC_DATA11 */
+		0U);                                    /* Software Input On Field: Input Path is determined by functionality */
+	imxrt_iomuxc_setpinmux(
+		IOMUXC_GPIO_EMC_36_SEMC_DATA12,         /* GPIO_EMC_36 is configured as SEMC_DATA12 */
+		0U);                                    /* Software Input On Field: Input Path is determined by functionality */
+	imxrt_iomuxc_setpinmux(
+		IOMUXC_GPIO_EMC_37_SEMC_DATA13,         /* GPIO_EMC_37 is configured as SEMC_DATA13 */
+		0U);                                    /* Software Input On Field: Input Path is determined by functionality */
+	imxrt_iomuxc_setpinmux(
+		IOMUXC_GPIO_EMC_38_SEMC_DATA14,         /* GPIO_EMC_38 is configured as SEMC_DATA14 */
+		0U);                                    /* Software Input On Field: Input Path is determined by functionality */
+	imxrt_iomuxc_setpinmux(
+		IOMUXC_GPIO_EMC_39_SEMC_DATA15,         /* GPIO_EMC_39 is configured as SEMC_DATA15 */
+		0U);                                    /* Software Input On Field: Input Path is determined by functionality */
+	imxrt_iomuxc_setpinmux(
+		IOMUXC_GPIO_EMC_40_SEMC_CSX00,          /* GPIO_EMC_40 is configured as SEMC_CSX00 */
+		0U);                                    /* Software Input On Field: Input Path is determined by functionality */
+	imxrt_iomuxc_setpinmux(
+		IOMUXC_GPIO_EMC_41_SEMC_READY,          /* GPIO_EMC_41 is configured as SEMC_READY */
+		0U);   
+	imxrt_iomuxc_setpinconfig(
+		IOMUXC_GPIO_EMC_00_SEMC_DATA00,         /* GPIO_EMC_00 PAD functional properties : */
+		0xE1u);                                 /* Slew Rate Field: Fast Slew Rate
+													Drive Strength Field: R0/4
+													Speed Field: max(200MHz)
+													Open Drain Enable Field: Open Drain Disabled
+													Pull / Keep Enable Field: Pull/Keeper Disabled
+													Pull / Keep Select Field: Keeper
+													Pull Up / Down Config. Field: 100K Ohm Pull Down
+													Hyst. Enable Field: Hysteresis Disabled */
+	imxrt_iomuxc_setpinconfig(
+		IOMUXC_GPIO_EMC_01_SEMC_DATA01,         /* GPIO_EMC_01 PAD functional properties : */
+		0xE1u);                                 /* Slew Rate Field: Fast Slew Rate
+													Drive Strength Field: R0/4
+													Speed Field: max(200MHz)
+													Open Drain Enable Field: Open Drain Disabled
+													Pull / Keep Enable Field: Pull/Keeper Disabled
+													Pull / Keep Select Field: Keeper
+													Pull Up / Down Config. Field: 100K Ohm Pull Down
+													Hyst. Enable Field: Hysteresis Disabled */
+	imxrt_iomuxc_setpinconfig(
+		IOMUXC_GPIO_EMC_02_SEMC_DATA02,         /* GPIO_EMC_02 PAD functional properties : */
+		0xE1u);                                 /* Slew Rate Field: Fast Slew Rate
+													Drive Strength Field: R0/4
+													Speed Field: max(200MHz)
+													Open Drain Enable Field: Open Drain Disabled
+													Pull / Keep Enable Field: Pull/Keeper Disabled
+													Pull / Keep Select Field: Keeper
+													Pull Up / Down Config. Field: 100K Ohm Pull Down
+													Hyst. Enable Field: Hysteresis Disabled */
+	imxrt_iomuxc_setpinconfig(
+		IOMUXC_GPIO_EMC_03_SEMC_DATA03,         /* GPIO_EMC_03 PAD functional properties : */
+		0xE1u);                                 /* Slew Rate Field: Fast Slew Rate
+													Drive Strength Field: R0/4
+													Speed Field: max(200MHz)
+													Open Drain Enable Field: Open Drain Disabled
+													Pull / Keep Enable Field: Pull/Keeper Disabled
+													Pull / Keep Select Field: Keeper
+													Pull Up / Down Config. Field: 100K Ohm Pull Down
+													Hyst. Enable Field: Hysteresis Disabled */
+	imxrt_iomuxc_setpinconfig(
+		IOMUXC_GPIO_EMC_04_SEMC_DATA04,         /* GPIO_EMC_04 PAD functional properties : */
+		0xE1u);                                 /* Slew Rate Field: Fast Slew Rate
+													Drive Strength Field: R0/4
+													Speed Field: max(200MHz)
+													Open Drain Enable Field: Open Drain Disabled
+													Pull / Keep Enable Field: Pull/Keeper Disabled
+													Pull / Keep Select Field: Keeper
+													Pull Up / Down Config. Field: 100K Ohm Pull Down
+													Hyst. Enable Field: Hysteresis Disabled */
+	imxrt_iomuxc_setpinconfig(
+		IOMUXC_GPIO_EMC_05_SEMC_DATA05,         /* GPIO_EMC_05 PAD functional properties : */
+		0xE1u);                                 /* Slew Rate Field: Fast Slew Rate
+													Drive Strength Field: R0/4
+													Speed Field: max(200MHz)
+													Open Drain Enable Field: Open Drain Disabled
+													Pull / Keep Enable Field: Pull/Keeper Disabled
+													Pull / Keep Select Field: Keeper
+													Pull Up / Down Config. Field: 100K Ohm Pull Down
+													Hyst. Enable Field: Hysteresis Disabled */
+	imxrt_iomuxc_setpinconfig(
+		IOMUXC_GPIO_EMC_06_SEMC_DATA06,         /* GPIO_EMC_06 PAD functional properties : */
+		0xE1u);                                 /* Slew Rate Field: Fast Slew Rate
+													Drive Strength Field: R0/4
+													Speed Field: max(200MHz)
+													Open Drain Enable Field: Open Drain Disabled
+													Pull / Keep Enable Field: Pull/Keeper Disabled
+													Pull / Keep Select Field: Keeper
+													Pull Up / Down Config. Field: 100K Ohm Pull Down
+													Hyst. Enable Field: Hysteresis Disabled */
+	imxrt_iomuxc_setpinconfig(
+		IOMUXC_GPIO_EMC_07_SEMC_DATA07,         /* GPIO_EMC_07 PAD functional properties : */
+		0xE1u);                                 /* Slew Rate Field: Fast Slew Rate
+													Drive Strength Field: R0/4
+													Speed Field: max(200MHz)
+													Open Drain Enable Field: Open Drain Disabled
+													Pull / Keep Enable Field: Pull/Keeper Disabled
+													Pull / Keep Select Field: Keeper
+													Pull Up / Down Config. Field: 100K Ohm Pull Down
+													Hyst. Enable Field: Hysteresis Disabled */
+	imxrt_iomuxc_setpinconfig(
+		IOMUXC_GPIO_EMC_08_SEMC_DM00,           /* GPIO_EMC_08 PAD functional properties : */
+		0xE1u);                                 /* Slew Rate Field: Fast Slew Rate
+													Drive Strength Field: R0/4
+													Speed Field: max(200MHz)
+													Open Drain Enable Field: Open Drain Disabled
+													Pull / Keep Enable Field: Pull/Keeper Disabled
+													Pull / Keep Select Field: Keeper
+													Pull Up / Down Config. Field: 100K Ohm Pull Down
+													Hyst. Enable Field: Hysteresis Disabled */
+	imxrt_iomuxc_setpinconfig(
+		IOMUXC_GPIO_EMC_09_SEMC_WE,             /* GPIO_EMC_09 PAD functional properties : */
+		0xE1u);                                 /* Slew Rate Field: Fast Slew Rate
+													Drive Strength Field: R0/4
+													Speed Field: max(200MHz)
+													Open Drain Enable Field: Open Drain Disabled
+													Pull / Keep Enable Field: Pull/Keeper Disabled
+													Pull / Keep Select Field: Keeper
+													Pull Up / Down Config. Field: 100K Ohm Pull Down
+													Hyst. Enable Field: Hysteresis Disabled */
+	imxrt_iomuxc_setpinconfig(
+		IOMUXC_GPIO_EMC_10_SEMC_CAS,            /* GPIO_EMC_10 PAD functional properties : */
+		0xE1u);                                 /* Slew Rate Field: Fast Slew Rate
+													Drive Strength Field: R0/4
+													Speed Field: max(200MHz)
+													Open Drain Enable Field: Open Drain Disabled
+													Pull / Keep Enable Field: Pull/Keeper Disabled
+													Pull / Keep Select Field: Keeper
+													Pull Up / Down Config. Field: 100K Ohm Pull Down
+													Hyst. Enable Field: Hysteresis Disabled */
+	imxrt_iomuxc_setpinconfig(
+		IOMUXC_GPIO_EMC_11_SEMC_RAS,            /* GPIO_EMC_11 PAD functional properties : */
+		0xE1u);                                 /* Slew Rate Field: Fast Slew Rate
+													Drive Strength Field: R0/4
+													Speed Field: max(200MHz)
+													Open Drain Enable Field: Open Drain Disabled
+													Pull / Keep Enable Field: Pull/Keeper Disabled
+													Pull / Keep Select Field: Keeper
+													Pull Up / Down Config. Field: 100K Ohm Pull Down
+													Hyst. Enable Field: Hysteresis Disabled */
+	imxrt_iomuxc_setpinconfig(
+		IOMUXC_GPIO_EMC_12_SEMC_CS0,            /* GPIO_EMC_12 PAD functional properties : */
+		0xE1u);                                 /* Slew Rate Field: Fast Slew Rate
+													Drive Strength Field: R0/4
+													Speed Field: max(200MHz)
+													Open Drain Enable Field: Open Drain Disabled
+													Pull / Keep Enable Field: Pull/Keeper Disabled
+													Pull / Keep Select Field: Keeper
+													Pull Up / Down Config. Field: 100K Ohm Pull Down
+													Hyst. Enable Field: Hysteresis Disabled */
+	imxrt_iomuxc_setpinconfig(
+		IOMUXC_GPIO_EMC_13_SEMC_BA0,            /* GPIO_EMC_13 PAD functional properties : */
+		0xE1u);                                 /* Slew Rate Field: Fast Slew Rate
+													Drive Strength Field: R0/4
+													Speed Field: max(200MHz)
+													Open Drain Enable Field: Open Drain Disabled
+													Pull / Keep Enable Field: Pull/Keeper Disabled
+													Pull / Keep Select Field: Keeper
+													Pull Up / Down Config. Field: 100K Ohm Pull Down
+													Hyst. Enable Field: Hysteresis Disabled */
+	imxrt_iomuxc_setpinconfig(
+		IOMUXC_GPIO_EMC_14_SEMC_BA1,            /* GPIO_EMC_14 PAD functional properties : */
+		0xE1u);                                 /* Slew Rate Field: Fast Slew Rate
+													Drive Strength Field: R0/4
+													Speed Field: max(200MHz)
+													Open Drain Enable Field: Open Drain Disabled
+													Pull / Keep Enable Field: Pull/Keeper Disabled
+													Pull / Keep Select Field: Keeper
+													Pull Up / Down Config. Field: 100K Ohm Pull Down
+													Hyst. Enable Field: Hysteresis Disabled */
+	imxrt_iomuxc_setpinconfig(
+		IOMUXC_GPIO_EMC_15_SEMC_ADDR10,         /* GPIO_EMC_15 PAD functional properties : */
+		0xE1u);                                 /* Slew Rate Field: Fast Slew Rate
+													Drive Strength Field: R0/4
+													Speed Field: max(200MHz)
+													Open Drain Enable Field: Open Drain Disabled
+													Pull / Keep Enable Field: Pull/Keeper Disabled
+													Pull / Keep Select Field: Keeper
+													Pull Up / Down Config. Field: 100K Ohm Pull Down
+													Hyst. Enable Field: Hysteresis Disabled */
+	imxrt_iomuxc_setpinconfig(
+		IOMUXC_GPIO_EMC_16_SEMC_ADDR00,         /* GPIO_EMC_16 PAD functional properties : */
+		0xE1u);                                 /* Slew Rate Field: Fast Slew Rate
+													Drive Strength Field: R0/4
+													Speed Field: max(200MHz)
+													Open Drain Enable Field: Open Drain Disabled
+													Pull / Keep Enable Field: Pull/Keeper Disabled
+													Pull / Keep Select Field: Keeper
+													Pull Up / Down Config. Field: 100K Ohm Pull Down
+													Hyst. Enable Field: Hysteresis Disabled */
+	imxrt_iomuxc_setpinconfig(
+		IOMUXC_GPIO_EMC_17_SEMC_ADDR01,         /* GPIO_EMC_17 PAD functional properties : */
+		0xE1u);                                 /* Slew Rate Field: Fast Slew Rate
+													Drive Strength Field: R0/4
+													Speed Field: max(200MHz)
+													Open Drain Enable Field: Open Drain Disabled
+													Pull / Keep Enable Field: Pull/Keeper Disabled
+													Pull / Keep Select Field: Keeper
+													Pull Up / Down Config. Field: 100K Ohm Pull Down
+													Hyst. Enable Field: Hysteresis Disabled */
+	imxrt_iomuxc_setpinconfig(
+		IOMUXC_GPIO_EMC_18_SEMC_ADDR02,         /* GPIO_EMC_18 PAD functional properties : */
+		0xE1u);                                 /* Slew Rate Field: Fast Slew Rate
+													Drive Strength Field: R0/4
+													Speed Field: max(200MHz)
+													Open Drain Enable Field: Open Drain Disabled
+													Pull / Keep Enable Field: Pull/Keeper Disabled
+													Pull / Keep Select Field: Keeper
+													Pull Up / Down Config. Field: 100K Ohm Pull Down
+													Hyst. Enable Field: Hysteresis Disabled */
+	imxrt_iomuxc_setpinconfig(
+		IOMUXC_GPIO_EMC_19_SEMC_ADDR03,         /* GPIO_EMC_19 PAD functional properties : */
+		0xE1u);                                 /* Slew Rate Field: Fast Slew Rate
+													Drive Strength Field: R0/4
+													Speed Field: max(200MHz)
+													Open Drain Enable Field: Open Drain Disabled
+													Pull / Keep Enable Field: Pull/Keeper Disabled
+													Pull / Keep Select Field: Keeper
+													Pull Up / Down Config. Field: 100K Ohm Pull Down
+													Hyst. Enable Field: Hysteresis Disabled */
+	imxrt_iomuxc_setpinconfig(
+		IOMUXC_GPIO_EMC_20_SEMC_ADDR04,         /* GPIO_EMC_20 PAD functional properties : */
+		0xE1u);                                 /* Slew Rate Field: Fast Slew Rate
+													Drive Strength Field: R0/4
+													Speed Field: max(200MHz)
+													Open Drain Enable Field: Open Drain Disabled
+													Pull / Keep Enable Field: Pull/Keeper Disabled
+													Pull / Keep Select Field: Keeper
+													Pull Up / Down Config. Field: 100K Ohm Pull Down
+													Hyst. Enable Field: Hysteresis Disabled */
+	imxrt_iomuxc_setpinconfig(
+		IOMUXC_GPIO_EMC_21_SEMC_ADDR05,         /* GPIO_EMC_21 PAD functional properties : */
+		0xE1u);                                 /* Slew Rate Field: Fast Slew Rate
+													Drive Strength Field: R0/4
+													Speed Field: max(200MHz)
+													Open Drain Enable Field: Open Drain Disabled
+													Pull / Keep Enable Field: Pull/Keeper Disabled
+													Pull / Keep Select Field: Keeper
+													Pull Up / Down Config. Field: 100K Ohm Pull Down
+													Hyst. Enable Field: Hysteresis Disabled */
+	imxrt_iomuxc_setpinconfig(
+		IOMUXC_GPIO_EMC_22_SEMC_ADDR06,         /* GPIO_EMC_22 PAD functional properties : */
+		0xE1u);                                 /* Slew Rate Field: Fast Slew Rate
+													Drive Strength Field: R0/4
+													Speed Field: max(200MHz)
+													Open Drain Enable Field: Open Drain Disabled
+													Pull / Keep Enable Field: Pull/Keeper Disabled
+													Pull / Keep Select Field: Keeper
+													Pull Up / Down Config. Field: 100K Ohm Pull Down
+													Hyst. Enable Field: Hysteresis Disabled */
+	imxrt_iomuxc_setpinconfig(
+		IOMUXC_GPIO_EMC_23_SEMC_ADDR07,         /* GPIO_EMC_23 PAD functional properties : */
+		0xE1u);                                 /* Slew Rate Field: Fast Slew Rate
+													Drive Strength Field: R0/4
+													Speed Field: max(200MHz)
+													Open Drain Enable Field: Open Drain Disabled
+													Pull / Keep Enable Field: Pull/Keeper Disabled
+													Pull / Keep Select Field: Keeper
+													Pull Up / Down Config. Field: 100K Ohm Pull Down
+													Hyst. Enable Field: Hysteresis Disabled */
+	imxrt_iomuxc_setpinconfig(
+		IOMUXC_GPIO_EMC_24_SEMC_ADDR08,         /* GPIO_EMC_24 PAD functional properties : */
+		0xE1u);                                 /* Slew Rate Field: Fast Slew Rate
+													Drive Strength Field: R0/4
+													Speed Field: max(200MHz)
+													Open Drain Enable Field: Open Drain Disabled
+													Pull / Keep Enable Field: Pull/Keeper Disabled
+													Pull / Keep Select Field: Keeper
+													Pull Up / Down Config. Field: 100K Ohm Pull Down
+													Hyst. Enable Field: Hysteresis Disabled */
+	imxrt_iomuxc_setpinconfig(
+		IOMUXC_GPIO_EMC_25_SEMC_ADDR09,         /* GPIO_EMC_25 PAD functional properties : */
+		0xE1u);                                 /* Slew Rate Field: Fast Slew Rate
+													Drive Strength Field: R0/4
+													Speed Field: max(200MHz)
+													Open Drain Enable Field: Open Drain Disabled
+													Pull / Keep Enable Field: Pull/Keeper Disabled
+													Pull / Keep Select Field: Keeper
+													Pull Up / Down Config. Field: 100K Ohm Pull Down
+													Hyst. Enable Field: Hysteresis Disabled */
+	imxrt_iomuxc_setpinconfig(
+		IOMUXC_GPIO_EMC_26_SEMC_ADDR11,         /* GPIO_EMC_26 PAD functional properties : */
+		0xE1u);                                 /* Slew Rate Field: Fast Slew Rate
+													Drive Strength Field: R0/4
+													Speed Field: max(200MHz)
+													Open Drain Enable Field: Open Drain Disabled
+													Pull / Keep Enable Field: Pull/Keeper Disabled
+													Pull / Keep Select Field: Keeper
+													Pull Up / Down Config. Field: 100K Ohm Pull Down
+													Hyst. Enable Field: Hysteresis Disabled */
+	imxrt_iomuxc_setpinconfig(
+		IOMUXC_GPIO_EMC_27_SEMC_ADDR12,         /* GPIO_EMC_27 PAD functional properties : */
+		0xE1u);                                 /* Slew Rate Field: Fast Slew Rate
+													Drive Strength Field: R0/4
+													Speed Field: max(200MHz)
+													Open Drain Enable Field: Open Drain Disabled
+													Pull / Keep Enable Field: Pull/Keeper Disabled
+													Pull / Keep Select Field: Keeper
+													Pull Up / Down Config. Field: 100K Ohm Pull Down
+													Hyst. Enable Field: Hysteresis Disabled */
+	imxrt_iomuxc_setpinconfig(
+		IOMUXC_GPIO_EMC_28_SEMC_DQS,            /* GPIO_EMC_28 PAD functional properties : */
+		0xE1u);                                 /* Slew Rate Field: Fast Slew Rate
+													Drive Strength Field: R0/4
+													Speed Field: max(200MHz)
+													Open Drain Enable Field: Open Drain Disabled
+													Pull / Keep Enable Field: Pull/Keeper Disabled
+													Pull / Keep Select Field: Keeper
+													Pull Up / Down Config. Field: 100K Ohm Pull Down
+													Hyst. Enable Field: Hysteresis Disabled */
+	imxrt_iomuxc_setpinconfig(
+		IOMUXC_GPIO_EMC_29_SEMC_CKE,            /* GPIO_EMC_29 PAD functional properties : */
+		0xE1u);                                 /* Slew Rate Field: Fast Slew Rate
+													Drive Strength Field: R0/4
+													Speed Field: max(200MHz)
+													Open Drain Enable Field: Open Drain Disabled
+													Pull / Keep Enable Field: Pull/Keeper Disabled
+													Pull / Keep Select Field: Keeper
+													Pull Up / Down Config. Field: 100K Ohm Pull Down
+													Hyst. Enable Field: Hysteresis Disabled */
+	imxrt_iomuxc_setpinconfig(
+		IOMUXC_GPIO_EMC_30_SEMC_CLK,            /* GPIO_EMC_30 PAD functional properties : */
+		0xE1u);                                 /* Slew Rate Field: Fast Slew Rate
+													Drive Strength Field: R0/4
+													Speed Field: max(200MHz)
+													Open Drain Enable Field: Open Drain Disabled
+													Pull / Keep Enable Field: Pull/Keeper Disabled
+													Pull / Keep Select Field: Keeper
+													Pull Up / Down Config. Field: 100K Ohm Pull Down
+													Hyst. Enable Field: Hysteresis Disabled */
+	imxrt_iomuxc_setpinconfig(
+		IOMUXC_GPIO_EMC_31_SEMC_DM01,           /* GPIO_EMC_31 PAD functional properties : */
+		0xE1u);                                 /* Slew Rate Field: Fast Slew Rate
+													Drive Strength Field: R0/4
+													Speed Field: max(200MHz)
+													Open Drain Enable Field: Open Drain Disabled
+													Pull / Keep Enable Field: Pull/Keeper Disabled
+													Pull / Keep Select Field: Keeper
+													Pull Up / Down Config. Field: 100K Ohm Pull Down
+													Hyst. Enable Field: Hysteresis Disabled */
+	imxrt_iomuxc_setpinconfig(
+		IOMUXC_GPIO_EMC_32_SEMC_DATA08,         /* GPIO_EMC_32 PAD functional properties : */
+		0xE1u);                                 /* Slew Rate Field: Fast Slew Rate
+													Drive Strength Field: R0/4
+													Speed Field: max(200MHz)
+													Open Drain Enable Field: Open Drain Disabled
+													Pull / Keep Enable Field: Pull/Keeper Disabled
+													Pull / Keep Select Field: Keeper
+													Pull Up / Down Config. Field: 100K Ohm Pull Down
+													Hyst. Enable Field: Hysteresis Disabled */
+	imxrt_iomuxc_setpinconfig(
+		IOMUXC_GPIO_EMC_33_SEMC_DATA09,         /* GPIO_EMC_33 PAD functional properties : */
+		0xE1u);                                 /* Slew Rate Field: Fast Slew Rate
+													Drive Strength Field: R0/4
+													Speed Field: max(200MHz)
+													Open Drain Enable Field: Open Drain Disabled
+													Pull / Keep Enable Field: Pull/Keeper Disabled
+													Pull / Keep Select Field: Keeper
+													Pull Up / Down Config. Field: 100K Ohm Pull Down
+													Hyst. Enable Field: Hysteresis Disabled */
+	imxrt_iomuxc_setpinconfig(
+		IOMUXC_GPIO_EMC_34_SEMC_DATA10,         /* GPIO_EMC_34 PAD functional properties : */
+		0xE1u);                                 /* Slew Rate Field: Fast Slew Rate
+													Drive Strength Field: R0/4
+													Speed Field: max(200MHz)
+													Open Drain Enable Field: Open Drain Disabled
+													Pull / Keep Enable Field: Pull/Keeper Disabled
+													Pull / Keep Select Field: Keeper
+													Pull Up / Down Config. Field: 100K Ohm Pull Down
+													Hyst. Enable Field: Hysteresis Disabled */
+	imxrt_iomuxc_setpinconfig(
+		IOMUXC_GPIO_EMC_35_SEMC_DATA11,         /* GPIO_EMC_35 PAD functional properties : */
+		0xE1u);                                 /* Slew Rate Field: Fast Slew Rate
+													Drive Strength Field: R0/4
+													Speed Field: max(200MHz)
+													Open Drain Enable Field: Open Drain Disabled
+													Pull / Keep Enable Field: Pull/Keeper Disabled
+													Pull / Keep Select Field: Keeper
+													Pull Up / Down Config. Field: 100K Ohm Pull Down
+													Hyst. Enable Field: Hysteresis Disabled */
+	imxrt_iomuxc_setpinconfig(
+		IOMUXC_GPIO_EMC_36_SEMC_DATA12,         /* GPIO_EMC_36 PAD functional properties : */
+		0xE1u);                                 /* Slew Rate Field: Fast Slew Rate
+													Drive Strength Field: R0/4
+													Speed Field: max(200MHz)
+													Open Drain Enable Field: Open Drain Disabled
+													Pull / Keep Enable Field: Pull/Keeper Disabled
+													Pull / Keep Select Field: Keeper
+													Pull Up / Down Config. Field: 100K Ohm Pull Down
+													Hyst. Enable Field: Hysteresis Disabled */
+	imxrt_iomuxc_setpinconfig(
+		IOMUXC_GPIO_EMC_37_SEMC_DATA13,         /* GPIO_EMC_37 PAD functional properties : */
+		0xE1u);                                 /* Slew Rate Field: Fast Slew Rate
+													Drive Strength Field: R0/4
+													Speed Field: max(200MHz)
+													Open Drain Enable Field: Open Drain Disabled
+													Pull / Keep Enable Field: Pull/Keeper Disabled
+													Pull / Keep Select Field: Keeper
+													Pull Up / Down Config. Field: 100K Ohm Pull Down
+													Hyst. Enable Field: Hysteresis Disabled */
+	imxrt_iomuxc_setpinconfig(
+		IOMUXC_GPIO_EMC_38_SEMC_DATA14,         /* GPIO_EMC_38 PAD functional properties : */
+		0xE1u);                                 /* Slew Rate Field: Fast Slew Rate
+													Drive Strength Field: R0/4
+													Speed Field: max(200MHz)
+													Open Drain Enable Field: Open Drain Disabled
+													Pull / Keep Enable Field: Pull/Keeper Disabled
+													Pull / Keep Select Field: Keeper
+													Pull Up / Down Config. Field: 100K Ohm Pull Down
+													Hyst. Enable Field: Hysteresis Disabled */
+	imxrt_iomuxc_setpinconfig(
+		IOMUXC_GPIO_EMC_39_SEMC_DATA15,         /* GPIO_EMC_39 PAD functional properties : */
+		0xE1u);                                 /* Slew Rate Field: Fast Slew Rate
+													Drive Strength Field: R0/4
+													Speed Field: max(200MHz)
+													Open Drain Enable Field: Open Drain Disabled
+													Pull / Keep Enable Field: Pull/Keeper Disabled
+													Pull / Keep Select Field: Keeper
+													Pull Up / Down Config. Field: 100K Ohm Pull Down
+													Hyst. Enable Field: Hysteresis Disabled */
+	imxrt_iomuxc_setpinconfig(
+		IOMUXC_GPIO_EMC_40_SEMC_CSX00,          /* GPIO_EMC_40 PAD functional properties : */
+		0xE1u);                                 /* Slew Rate Field: Fast Slew Rate
+													Drive Strength Field: R0/4
+													Speed Field: max(200MHz)
+													Open Drain Enable Field: Open Drain Disabled
+													Pull / Keep Enable Field: Pull/Keeper Disabled
+													Pull / Keep Select Field: Keeper
+													Pull Up / Down Config. Field: 100K Ohm Pull Down
+													Hyst. Enable Field: Hysteresis Disabled */
+	imxrt_iomuxc_setpinconfig(
+		IOMUXC_GPIO_EMC_41_SEMC_READY,          /* GPIO_EMC_41 PAD functional properties : */
+		0xE1u);                                 /* Slew Rate Field: Fast Slew Rate
+													Drive Strength Field: R0/4
+													Speed Field: max(200MHz)
+													Open Drain Enable Field: Open Drain Disabled
+													Pull / Keep Enable Field: Pull/Keeper Disabled
+													Pull / Keep Select Field: Keeper
+													Pull Up / Down Config. Field: 100K Ohm Pull Down
+													Hyst. Enable Field: Hysteresis Disabled */                                 /* Software Input On Field: Input Path is determined by functionality */
+	#elif defined(CONFIG_ARCH_CHIP_FAMILY_IMXRT105x)
+	imxrt_iomuxc_setpinmux(
+		IOMUXC_GPIO_EMC_00_SEMC_DATA00,         /* GPIO_EMC_00 is configured as SEMC_DATA00 */
+		0U);                                    /* Software Input On Field: Input Path is determined by functionality */
+	imxrt_iomuxc_setpinmux(
+		IOMUXC_GPIO_EMC_01_SEMC_DATA01,         /* GPIO_EMC_01 is configured as SEMC_DATA01 */
+		0U);                                    /* Software Input On Field: Input Path is determined by functionality */
+	imxrt_iomuxc_setpinmux(
+		IOMUXC_GPIO_EMC_02_SEMC_DATA02,         /* GPIO_EMC_02 is configured as SEMC_DATA02 */
+		0U);                                    /* Software Input On Field: Input Path is determined by functionality */
+	imxrt_iomuxc_setpinmux(
+		IOMUXC_GPIO_EMC_03_SEMC_DATA03,         /* GPIO_EMC_03 is configured as SEMC_DATA03 */
+		0U);                                    /* Software Input On Field: Input Path is determined by functionality */
+	imxrt_iomuxc_setpinmux(
+		IOMUXC_GPIO_EMC_04_SEMC_DATA04,         /* GPIO_EMC_04 is configured as SEMC_DATA04 */
+		0U);                                    /* Software Input On Field: Input Path is determined by functionality */
+	imxrt_iomuxc_setpinmux(
+		IOMUXC_GPIO_EMC_05_SEMC_DATA05,         /* GPIO_EMC_05 is configured as SEMC_DATA05 */
+		0U);                                    /* Software Input On Field: Input Path is determined by functionality */
+	imxrt_iomuxc_setpinmux(
+		IOMUXC_GPIO_EMC_06_SEMC_DATA06,         /* GPIO_EMC_06 is configured as SEMC_DATA06 */
+		0U);                                    /* Software Input On Field: Input Path is determined by functionality */
+	imxrt_iomuxc_setpinmux(
+		IOMUXC_GPIO_EMC_07_SEMC_DATA07,         /* GPIO_EMC_07 is configured as SEMC_DATA07 */
+		0U);                                    /* Software Input On Field: Input Path is determined by functionality */
+	imxrt_iomuxc_setpinmux(
+		IOMUXC_GPIO_EMC_08_SEMC_DM00,           /* GPIO_EMC_08 is configured as SEMC_DM00 */
+		0U);                                    /* Software Input On Field: Input Path is determined by functionality */
+	imxrt_iomuxc_setpinmux(
+		IOMUXC_GPIO_EMC_09_SEMC_ADDR00,         /* GPIO_EMC_09 is configured as SEMC_ADDR00 */
+		0U);                                    /* Software Input On Field: Input Path is determined by functionality */
+	imxrt_iomuxc_setpinmux(
+		IOMUXC_GPIO_EMC_10_SEMC_ADDR01,         /* GPIO_EMC_10 is configured as SEMC_ADDR01 */
+		0U);                                    /* Software Input On Field: Input Path is determined by functionality */
+	imxrt_iomuxc_setpinmux(
+		IOMUXC_GPIO_EMC_11_SEMC_ADDR02,         /* GPIO_EMC_11 is configured as SEMC_ADDR02 */
+		0U);                                    /* Software Input On Field: Input Path is determined by functionality */
+	imxrt_iomuxc_setpinmux(
+		IOMUXC_GPIO_EMC_12_SEMC_ADDR03,         /* GPIO_EMC_12 is configured as SEMC_ADDR03 */
+		0U);                                    /* Software Input On Field: Input Path is determined by functionality */
+	imxrt_iomuxc_setpinmux(
+		IOMUXC_GPIO_EMC_13_SEMC_ADDR04,         /* GPIO_EMC_13 is configured as SEMC_ADDR04 */
+		0U);                                    /* Software Input On Field: Input Path is determined by functionality */
+	imxrt_iomuxc_setpinmux(
+		IOMUXC_GPIO_EMC_14_SEMC_ADDR05,         /* GPIO_EMC_14 is configured as SEMC_ADDR05 */
+		0U);                                    /* Software Input On Field: Input Path is determined by functionality */
+	imxrt_iomuxc_setpinmux(
+		IOMUXC_GPIO_EMC_15_SEMC_ADDR06,         /* GPIO_EMC_15 is configured as SEMC_ADDR06 */
+		0U);                                    /* Software Input On Field: Input Path is determined by functionality */
+	imxrt_iomuxc_setpinmux(
+		IOMUXC_GPIO_EMC_16_SEMC_ADDR07,         /* GPIO_EMC_16 is configured as SEMC_ADDR07 */
+		0U);                                    /* Software Input On Field: Input Path is determined by functionality */
+	imxrt_iomuxc_setpinmux(
+		IOMUXC_GPIO_EMC_17_SEMC_ADDR08,         /* GPIO_EMC_17 is configured as SEMC_ADDR08 */
+		0U);                                    /* Software Input On Field: Input Path is determined by functionality */
+	imxrt_iomuxc_setpinmux(
+		IOMUXC_GPIO_EMC_18_SEMC_ADDR09,         /* GPIO_EMC_18 is configured as SEMC_ADDR09 */
+		0U);                                    /* Software Input On Field: Input Path is determined by functionality */
+	imxrt_iomuxc_setpinmux(
+		IOMUXC_GPIO_EMC_19_SEMC_ADDR11,         /* GPIO_EMC_19 is configured as SEMC_ADDR11 */
+		0U);                                    /* Software Input On Field: Input Path is determined by functionality */
+	imxrt_iomuxc_setpinmux(
+		IOMUXC_GPIO_EMC_20_SEMC_ADDR12,         /* GPIO_EMC_20 is configured as SEMC_ADDR12 */
+		0U);                                    /* Software Input On Field: Input Path is determined by functionality */
+	imxrt_iomuxc_setpinmux(
+		IOMUXC_GPIO_EMC_21_SEMC_BA0,            /* GPIO_EMC_21 is configured as SEMC_BA0 */
+		0U);                                    /* Software Input On Field: Input Path is determined by functionality */
+	imxrt_iomuxc_setpinmux(
+		IOMUXC_GPIO_EMC_22_SEMC_BA1,            /* GPIO_EMC_22 is configured as SEMC_BA1 */
+		0U);                                    /* Software Input On Field: Input Path is determined by functionality */
+	imxrt_iomuxc_setpinmux(
+		IOMUXC_GPIO_EMC_23_SEMC_ADDR10,         /* GPIO_EMC_23 is configured as SEMC_ADDR10 */
+		0U);                                    /* Software Input On Field: Input Path is determined by functionality */
+	imxrt_iomuxc_setpinmux(
+		IOMUXC_GPIO_EMC_24_SEMC_CAS,            /* GPIO_EMC_24 is configured as SEMC_CAS */
+		0U);                                    /* Software Input On Field: Input Path is determined by functionality */
+	imxrt_iomuxc_setpinmux(
+		IOMUXC_GPIO_EMC_25_SEMC_RAS,            /* GPIO_EMC_25 is configured as SEMC_RAS */
+		0U);                                    /* Software Input On Field: Input Path is determined by functionality */
+	imxrt_iomuxc_setpinmux(
+		IOMUXC_GPIO_EMC_26_SEMC_CLK,            /* GPIO_EMC_26 is configured as SEMC_CLK */
+		0U);                                    /* Software Input On Field: Input Path is determined by functionality */
+	imxrt_iomuxc_setpinmux(
+		IOMUXC_GPIO_EMC_27_SEMC_CKE,            /* GPIO_EMC_27 is configured as SEMC_CKE */
+		0U);                                    /* Software Input On Field: Input Path is determined by functionality */
+	imxrt_iomuxc_setpinmux(
+		IOMUXC_GPIO_EMC_28_SEMC_WE,             /* GPIO_EMC_28 is configured as SEMC_WE */
+		0U);                                    /* Software Input On Field: Input Path is determined by functionality */
+	imxrt_iomuxc_setpinmux(
+		IOMUXC_GPIO_EMC_29_SEMC_CS0,            /* GPIO_EMC_29 is configured as SEMC_CS0 */
+		0U);                                    /* Software Input On Field: Input Path is determined by functionality */
+	imxrt_iomuxc_setpinmux(
+		IOMUXC_GPIO_EMC_30_SEMC_DATA08,         /* GPIO_EMC_30 is configured as SEMC_DATA08 */
+		0U);                                    /* Software Input On Field: Input Path is determined by functionality */
+	imxrt_iomuxc_setpinmux(
+		IOMUXC_GPIO_EMC_31_SEMC_DATA09,         /* GPIO_EMC_31 is configured as SEMC_DATA09 */
+		0U);                                    /* Software Input On Field: Input Path is determined by functionality */
+	imxrt_iomuxc_setpinmux(
+		IOMUXC_GPIO_EMC_32_SEMC_DATA10,         /* GPIO_EMC_32 is configured as SEMC_DATA10 */
+		0U);                                    /* Software Input On Field: Input Path is determined by functionality */
+	imxrt_iomuxc_setpinmux(
+		IOMUXC_GPIO_EMC_33_SEMC_DATA11,         /* GPIO_EMC_33 is configured as SEMC_DATA11 */
+		0U);                                    /* Software Input On Field: Input Path is determined by functionality */
+	imxrt_iomuxc_setpinmux(
+		IOMUXC_GPIO_EMC_34_SEMC_DATA12,         /* GPIO_EMC_34 is configured as SEMC_DATA12 */
+		0U);                                    /* Software Input On Field: Input Path is determined by functionality */
+	imxrt_iomuxc_setpinmux(
+		IOMUXC_GPIO_EMC_35_SEMC_DATA13,         /* GPIO_EMC_35 is configured as SEMC_DATA13 */
+		0U);                                    /* Software Input On Field: Input Path is determined by functionality */
+	imxrt_iomuxc_setpinmux(
+		IOMUXC_GPIO_EMC_36_SEMC_DATA14,         /* GPIO_EMC_36 is configured as SEMC_DATA14 */
+		0U);                                    /* Software Input On Field: Input Path is determined by functionality */
+	imxrt_iomuxc_setpinmux(
+		IOMUXC_GPIO_EMC_37_SEMC_DATA15,         /* GPIO_EMC_37 is configured as SEMC_DATA15 */
+		0U);                                    /* Software Input On Field: Input Path is determined by functionality */
+	imxrt_iomuxc_setpinmux(
+		IOMUXC_GPIO_EMC_38_SEMC_DM01,           /* GPIO_EMC_38 is configured as SEMC_DM01 */
+		0U);                                    /* Software Input On Field: Input Path is determined by functionality */
+	imxrt_iomuxc_setpinmux(
+		IOMUXC_GPIO_EMC_39_SEMC_DQS,            /* GPIO_EMC_39 is configured as SEMC_DQS */
+		1U);                                    /* Software Input On Field: Force input path of pad GPIO_EMC_39 */
+	imxrt_iomuxc_setpinmux(
+		IOMUXC_GPIO_EMC_40_SEMC_RDY,            /* GPIO_EMC_40 is configured as SEMC_RDY */
+		0U);                                    /* Software Input On Field: Input Path is determined by functionality */
+	imxrt_iomuxc_setpinmux(
+		IOMUXC_GPIO_EMC_41_SEMC_CSX00,          /* GPIO_EMC_41 is configured as SEMC_CSX00 */
+		0U);                                    /* Software Input On Field: Input Path is determined by functionality */
+
+	imxrt_iomuxc_setpinconfig(
+		IOMUXC_GPIO_EMC_00_SEMC_DATA00,         /* GPIO_EMC_00 PAD functional properties : */
+		0x0110F9u);                             /* Slew Rate Field: Fast Slew Rate
+													Drive Strength Field: R0/7
+													Speed Field: max(200MHz)
+													Open Drain Enable Field: Open Drain Disabled
+													Pull / Keep Enable Field: Pull/Keeper Enabled
+													Pull / Keep Select Field: Keeper
+													Pull Up / Down Config. Field: 100K Ohm Pull Down
+													Hyst. Enable Field: Hysteresis Enabled */
+	imxrt_iomuxc_setpinconfig(
+		IOMUXC_GPIO_EMC_01_SEMC_DATA01,         /* GPIO_EMC_01 PAD functional properties : */
+		0x0110F9u);                             /* Slew Rate Field: Fast Slew Rate
+													Drive Strength Field: R0/7
+													Speed Field: max(200MHz)
+													Open Drain Enable Field: Open Drain Disabled
+													Pull / Keep Enable Field: Pull/Keeper Enabled
+													Pull / Keep Select Field: Keeper
+													Pull Up / Down Config. Field: 100K Ohm Pull Down
+													Hyst. Enable Field: Hysteresis Enabled */
+	imxrt_iomuxc_setpinconfig(
+		IOMUXC_GPIO_EMC_02_SEMC_DATA02,         /* GPIO_EMC_02 PAD functional properties : */
+		0x0110F9u);                             /* Slew Rate Field: Fast Slew Rate
+													Drive Strength Field: R0/7
+													Speed Field: max(200MHz)
+													Open Drain Enable Field: Open Drain Disabled
+													Pull / Keep Enable Field: Pull/Keeper Enabled
+													Pull / Keep Select Field: Keeper
+													Pull Up / Down Config. Field: 100K Ohm Pull Down
+													Hyst. Enable Field: Hysteresis Enabled */
+	imxrt_iomuxc_setpinconfig(
+		IOMUXC_GPIO_EMC_03_SEMC_DATA03,         /* GPIO_EMC_03 PAD functional properties : */
+		0x0110F9u);                             /* Slew Rate Field: Fast Slew Rate
+													Drive Strength Field: R0/7
+													Speed Field: max(200MHz)
+													Open Drain Enable Field: Open Drain Disabled
+													Pull / Keep Enable Field: Pull/Keeper Enabled
+													Pull / Keep Select Field: Keeper
+													Pull Up / Down Config. Field: 100K Ohm Pull Down
+													Hyst. Enable Field: Hysteresis Enabled */
+	imxrt_iomuxc_setpinconfig(
+		IOMUXC_GPIO_EMC_04_SEMC_DATA04,         /* GPIO_EMC_04 PAD functional properties : */
+		0x0110F9u);                             /* Slew Rate Field: Fast Slew Rate
+													Drive Strength Field: R0/7
+													Speed Field: max(200MHz)
+													Open Drain Enable Field: Open Drain Disabled
+													Pull / Keep Enable Field: Pull/Keeper Enabled
+													Pull / Keep Select Field: Keeper
+													Pull Up / Down Config. Field: 100K Ohm Pull Down
+													Hyst. Enable Field: Hysteresis Enabled */
+	imxrt_iomuxc_setpinconfig(
+		IOMUXC_GPIO_EMC_05_SEMC_DATA05,         /* GPIO_EMC_05 PAD functional properties : */
+		0x0110F9u);                             /* Slew Rate Field: Fast Slew Rate
+													Drive Strength Field: R0/7
+													Speed Field: max(200MHz)
+													Open Drain Enable Field: Open Drain Disabled
+													Pull / Keep Enable Field: Pull/Keeper Enabled
+													Pull / Keep Select Field: Keeper
+													Pull Up / Down Config. Field: 100K Ohm Pull Down
+													Hyst. Enable Field: Hysteresis Enabled */
+	imxrt_iomuxc_setpinconfig(
+		IOMUXC_GPIO_EMC_06_SEMC_DATA06,         /* GPIO_EMC_06 PAD functional properties : */
+		0x0110F9u);                             /* Slew Rate Field: Fast Slew Rate
+													Drive Strength Field: R0/7
+													Speed Field: max(200MHz)
+													Open Drain Enable Field: Open Drain Disabled
+													Pull / Keep Enable Field: Pull/Keeper Enabled
+													Pull / Keep Select Field: Keeper
+													Pull Up / Down Config. Field: 100K Ohm Pull Down
+													Hyst. Enable Field: Hysteresis Enabled */
+	imxrt_iomuxc_setpinconfig(
+		IOMUXC_GPIO_EMC_07_SEMC_DATA07,         /* GPIO_EMC_07 PAD functional properties : */
+		0x0110F9u);                             /* Slew Rate Field: Fast Slew Rate
+													Drive Strength Field: R0/7
+													Speed Field: max(200MHz)
+													Open Drain Enable Field: Open Drain Disabled
+													Pull / Keep Enable Field: Pull/Keeper Enabled
+													Pull / Keep Select Field: Keeper
+													Pull Up / Down Config. Field: 100K Ohm Pull Down
+													Hyst. Enable Field: Hysteresis Enabled */
+	imxrt_iomuxc_setpinconfig(
+		IOMUXC_GPIO_EMC_08_SEMC_DM00,           /* GPIO_EMC_08 PAD functional properties : */
+		0x0110F9u);                             /* Slew Rate Field: Fast Slew Rate
+													Drive Strength Field: R0/7
+													Speed Field: max(200MHz)
+													Open Drain Enable Field: Open Drain Disabled
+													Pull / Keep Enable Field: Pull/Keeper Enabled
+													Pull / Keep Select Field: Keeper
+													Pull Up / Down Config. Field: 100K Ohm Pull Down
+													Hyst. Enable Field: Hysteresis Enabled */
+	imxrt_iomuxc_setpinconfig(
+		IOMUXC_GPIO_EMC_09_SEMC_ADDR00,         /* GPIO_EMC_09 PAD functional properties : */
+		0x0110F9u);                             /* Slew Rate Field: Fast Slew Rate
+													Drive Strength Field: R0/7
+													Speed Field: max(200MHz)
+													Open Drain Enable Field: Open Drain Disabled
+													Pull / Keep Enable Field: Pull/Keeper Enabled
+													Pull / Keep Select Field: Keeper
+													Pull Up / Down Config. Field: 100K Ohm Pull Down
+													Hyst. Enable Field: Hysteresis Enabled */
+	imxrt_iomuxc_setpinconfig(
+		IOMUXC_GPIO_EMC_10_SEMC_ADDR01,         /* GPIO_EMC_10 PAD functional properties : */
+		0x0110F9u);                             /* Slew Rate Field: Fast Slew Rate
+													Drive Strength Field: R0/7
+													Speed Field: max(200MHz)
+													Open Drain Enable Field: Open Drain Disabled
+													Pull / Keep Enable Field: Pull/Keeper Enabled
+													Pull / Keep Select Field: Keeper
+													Pull Up / Down Config. Field: 100K Ohm Pull Down
+													Hyst. Enable Field: Hysteresis Enabled */
+	imxrt_iomuxc_setpinconfig(
+		IOMUXC_GPIO_EMC_11_SEMC_ADDR02,         /* GPIO_EMC_11 PAD functional properties : */
+		0x0110F9u);                             /* Slew Rate Field: Fast Slew Rate
+													Drive Strength Field: R0/7
+													Speed Field: max(200MHz)
+													Open Drain Enable Field: Open Drain Disabled
+													Pull / Keep Enable Field: Pull/Keeper Enabled
+													Pull / Keep Select Field: Keeper
+													Pull Up / Down Config. Field: 100K Ohm Pull Down
+													Hyst. Enable Field: Hysteresis Enabled */
+	imxrt_iomuxc_setpinconfig(
+		IOMUXC_GPIO_EMC_12_SEMC_ADDR03,         /* GPIO_EMC_12 PAD functional properties : */
+		0x0110F9u);                             /* Slew Rate Field: Fast Slew Rate
+													Drive Strength Field: R0/7
+													Speed Field: max(200MHz)
+													Open Drain Enable Field: Open Drain Disabled
+													Pull / Keep Enable Field: Pull/Keeper Enabled
+													Pull / Keep Select Field: Keeper
+													Pull Up / Down Config. Field: 100K Ohm Pull Down
+													Hyst. Enable Field: Hysteresis Enabled */
+	imxrt_iomuxc_setpinconfig(
+		IOMUXC_GPIO_EMC_13_SEMC_ADDR04,         /* GPIO_EMC_13 PAD functional properties : */
+		0x0110F9u);                             /* Slew Rate Field: Fast Slew Rate
+													Drive Strength Field: R0/7
+													Speed Field: max(200MHz)
+													Open Drain Enable Field: Open Drain Disabled
+													Pull / Keep Enable Field: Pull/Keeper Enabled
+													Pull / Keep Select Field: Keeper
+													Pull Up / Down Config. Field: 100K Ohm Pull Down
+													Hyst. Enable Field: Hysteresis Enabled */
+	imxrt_iomuxc_setpinconfig(
+		IOMUXC_GPIO_EMC_14_SEMC_ADDR05,         /* GPIO_EMC_14 PAD functional properties : */
+		0x0110F9u);                             /* Slew Rate Field: Fast Slew Rate
+													Drive Strength Field: R0/7
+													Speed Field: max(200MHz)
+													Open Drain Enable Field: Open Drain Disabled
+													Pull / Keep Enable Field: Pull/Keeper Enabled
+													Pull / Keep Select Field: Keeper
+													Pull Up / Down Config. Field: 100K Ohm Pull Down
+													Hyst. Enable Field: Hysteresis Enabled */
+	imxrt_iomuxc_setpinconfig(
+		IOMUXC_GPIO_EMC_15_SEMC_ADDR06,         /* GPIO_EMC_15 PAD functional properties : */
+		0x0110F9u);                             /* Slew Rate Field: Fast Slew Rate
+													Drive Strength Field: R0/7
+													Speed Field: max(200MHz)
+													Open Drain Enable Field: Open Drain Disabled
+													Pull / Keep Enable Field: Pull/Keeper Enabled
+													Pull / Keep Select Field: Keeper
+													Pull Up / Down Config. Field: 100K Ohm Pull Down
+													Hyst. Enable Field: Hysteresis Enabled */
+	imxrt_iomuxc_setpinconfig(
+		IOMUXC_GPIO_EMC_16_SEMC_ADDR07,         /* GPIO_EMC_16 PAD functional properties : */
+		0x0110F9u);                             /* Slew Rate Field: Fast Slew Rate
+													Drive Strength Field: R0/7
+													Speed Field: max(200MHz)
+													Open Drain Enable Field: Open Drain Disabled
+													Pull / Keep Enable Field: Pull/Keeper Enabled
+													Pull / Keep Select Field: Keeper
+													Pull Up / Down Config. Field: 100K Ohm Pull Down
+													Hyst. Enable Field: Hysteresis Enabled */
+	imxrt_iomuxc_setpinconfig(
+		IOMUXC_GPIO_EMC_17_SEMC_ADDR08,         /* GPIO_EMC_17 PAD functional properties : */
+		0x0110F9u);                             /* Slew Rate Field: Fast Slew Rate
+													Drive Strength Field: R0/7
+													Speed Field: max(200MHz)
+													Open Drain Enable Field: Open Drain Disabled
+													Pull / Keep Enable Field: Pull/Keeper Enabled
+													Pull / Keep Select Field: Keeper
+													Pull Up / Down Config. Field: 100K Ohm Pull Down
+													Hyst. Enable Field: Hysteresis Enabled */
+	imxrt_iomuxc_setpinconfig(
+		IOMUXC_GPIO_EMC_18_SEMC_ADDR09,         /* GPIO_EMC_18 PAD functional properties : */
+		0x0110F9u);                             /* Slew Rate Field: Fast Slew Rate
+													Drive Strength Field: R0/7
+													Speed Field: max(200MHz)
+													Open Drain Enable Field: Open Drain Disabled
+													Pull / Keep Enable Field: Pull/Keeper Enabled
+													Pull / Keep Select Field: Keeper
+													Pull Up / Down Config. Field: 100K Ohm Pull Down
+													Hyst. Enable Field: Hysteresis Enabled */
+	imxrt_iomuxc_setpinconfig(
+		IOMUXC_GPIO_EMC_19_SEMC_ADDR11,         /* GPIO_EMC_19 PAD functional properties : */
+		0x0110F9u);                             /* Slew Rate Field: Fast Slew Rate
+													Drive Strength Field: R0/7
+													Speed Field: max(200MHz)
+													Open Drain Enable Field: Open Drain Disabled
+													Pull / Keep Enable Field: Pull/Keeper Enabled
+													Pull / Keep Select Field: Keeper
+													Pull Up / Down Config. Field: 100K Ohm Pull Down
+													Hyst. Enable Field: Hysteresis Enabled */
+	imxrt_iomuxc_setpinconfig(
+		IOMUXC_GPIO_EMC_20_SEMC_ADDR12,         /* GPIO_EMC_20 PAD functional properties : */
+		0x0110F9u);                             /* Slew Rate Field: Fast Slew Rate
+													Drive Strength Field: R0/7
+													Speed Field: max(200MHz)
+													Open Drain Enable Field: Open Drain Disabled
+													Pull / Keep Enable Field: Pull/Keeper Enabled
+													Pull / Keep Select Field: Keeper
+													Pull Up / Down Config. Field: 100K Ohm Pull Down
+													Hyst. Enable Field: Hysteresis Enabled */
+	imxrt_iomuxc_setpinconfig(
+		IOMUXC_GPIO_EMC_21_SEMC_BA0,            /* GPIO_EMC_21 PAD functional properties : */
+		0x0110F9u);                             /* Slew Rate Field: Fast Slew Rate
+													Drive Strength Field: R0/7
+													Speed Field: max(200MHz)
+													Open Drain Enable Field: Open Drain Disabled
+													Pull / Keep Enable Field: Pull/Keeper Enabled
+													Pull / Keep Select Field: Keeper
+													Pull Up / Down Config. Field: 100K Ohm Pull Down
+													Hyst. Enable Field: Hysteresis Enabled */
+	imxrt_iomuxc_setpinconfig(
+		IOMUXC_GPIO_EMC_22_SEMC_BA1,            /* GPIO_EMC_22 PAD functional properties : */
+		0x0110F9u);                             /* Slew Rate Field: Fast Slew Rate
+													Drive Strength Field: R0/7
+													Speed Field: max(200MHz)
+													Open Drain Enable Field: Open Drain Disabled
+													Pull / Keep Enable Field: Pull/Keeper Enabled
+													Pull / Keep Select Field: Keeper
+													Pull Up / Down Config. Field: 100K Ohm Pull Down
+													Hyst. Enable Field: Hysteresis Enabled */
+	imxrt_iomuxc_setpinconfig(
+		IOMUXC_GPIO_EMC_23_SEMC_ADDR10,         /* GPIO_EMC_23 PAD functional properties : */
+		0x0110F9u);                             /* Slew Rate Field: Fast Slew Rate
+													Drive Strength Field: R0/7
+													Speed Field: max(200MHz)
+													Open Drain Enable Field: Open Drain Disabled
+													Pull / Keep Enable Field: Pull/Keeper Enabled
+													Pull / Keep Select Field: Keeper
+													Pull Up / Down Config. Field: 100K Ohm Pull Down
+													Hyst. Enable Field: Hysteresis Enabled */
+	imxrt_iomuxc_setpinconfig(
+		IOMUXC_GPIO_EMC_24_SEMC_CAS,            /* GPIO_EMC_24 PAD functional properties : */
+		0x0110F9u);                             /* Slew Rate Field: Fast Slew Rate
+													Drive Strength Field: R0/7
+													Speed Field: max(200MHz)
+													Open Drain Enable Field: Open Drain Disabled
+													Pull / Keep Enable Field: Pull/Keeper Enabled
+													Pull / Keep Select Field: Keeper
+													Pull Up / Down Config. Field: 100K Ohm Pull Down
+													Hyst. Enable Field: Hysteresis Enabled */
+	imxrt_iomuxc_setpinconfig(
+		IOMUXC_GPIO_EMC_25_SEMC_RAS,            /* GPIO_EMC_25 PAD functional properties : */
+		0x0110F9u);                             /* Slew Rate Field: Fast Slew Rate
+													Drive Strength Field: R0/7
+													Speed Field: max(200MHz)
+													Open Drain Enable Field: Open Drain Disabled
+													Pull / Keep Enable Field: Pull/Keeper Enabled
+													Pull / Keep Select Field: Keeper
+													Pull Up / Down Config. Field: 100K Ohm Pull Down
+													Hyst. Enable Field: Hysteresis Enabled */
+	imxrt_iomuxc_setpinconfig(
+		IOMUXC_GPIO_EMC_26_SEMC_CLK,            /* GPIO_EMC_26 PAD functional properties : */
+		0x0110F9u);                             /* Slew Rate Field: Fast Slew Rate
+													Drive Strength Field: R0/7
+													Speed Field: max(200MHz)
+													Open Drain Enable Field: Open Drain Disabled
+													Pull / Keep Enable Field: Pull/Keeper Enabled
+													Pull / Keep Select Field: Keeper
+													Pull Up / Down Config. Field: 100K Ohm Pull Down
+													Hyst. Enable Field: Hysteresis Enabled */
+	imxrt_iomuxc_setpinconfig(
+		IOMUXC_GPIO_EMC_27_SEMC_CKE,            /* GPIO_EMC_27 PAD functional properties : */
+		0x0110F9u);                             /* Slew Rate Field: Fast Slew Rate
+													Drive Strength Field: R0/7
+													Speed Field: max(200MHz)
+													Open Drain Enable Field: Open Drain Disabled
+													Pull / Keep Enable Field: Pull/Keeper Enabled
+													Pull / Keep Select Field: Keeper
+													Pull Up / Down Config. Field: 100K Ohm Pull Down
+													Hyst. Enable Field: Hysteresis Enabled */
+	imxrt_iomuxc_setpinconfig(
+		IOMUXC_GPIO_EMC_28_SEMC_WE,             /* GPIO_EMC_28 PAD functional properties : */
+		0x0110F9u);                             /* Slew Rate Field: Fast Slew Rate
+													Drive Strength Field: R0/7
+													Speed Field: max(200MHz)
+													Open Drain Enable Field: Open Drain Disabled
+													Pull / Keep Enable Field: Pull/Keeper Enabled
+													Pull / Keep Select Field: Keeper
+													Pull Up / Down Config. Field: 100K Ohm Pull Down
+													Hyst. Enable Field: Hysteresis Enabled */
+	imxrt_iomuxc_setpinconfig(
+		IOMUXC_GPIO_EMC_29_SEMC_CS0,            /* GPIO_EMC_29 PAD functional properties : */
+		0x0110F9u);                             /* Slew Rate Field: Fast Slew Rate
+													Drive Strength Field: R0/7
+													Speed Field: max(200MHz)
+													Open Drain Enable Field: Open Drain Disabled
+													Pull / Keep Enable Field: Pull/Keeper Enabled
+													Pull / Keep Select Field: Keeper
+													Pull Up / Down Config. Field: 100K Ohm Pull Down
+													Hyst. Enable Field: Hysteresis Enabled */
+	imxrt_iomuxc_setpinconfig(
+		IOMUXC_GPIO_EMC_30_SEMC_DATA08,         /* GPIO_EMC_30 PAD functional properties : */
+		0x0110F9u);                             /* Slew Rate Field: Fast Slew Rate
+													Drive Strength Field: R0/7
+													Speed Field: max(200MHz)
+													Open Drain Enable Field: Open Drain Disabled
+													Pull / Keep Enable Field: Pull/Keeper Enabled
+													Pull / Keep Select Field: Keeper
+													Pull Up / Down Config. Field: 100K Ohm Pull Down
+													Hyst. Enable Field: Hysteresis Enabled */
+	imxrt_iomuxc_setpinconfig(
+		IOMUXC_GPIO_EMC_31_SEMC_DATA09,         /* GPIO_EMC_31 PAD functional properties : */
+		0x0110F9u);                             /* Slew Rate Field: Fast Slew Rate
+													Drive Strength Field: R0/7
+													Speed Field: max(200MHz)
+													Open Drain Enable Field: Open Drain Disabled
+													Pull / Keep Enable Field: Pull/Keeper Enabled
+													Pull / Keep Select Field: Keeper
+													Pull Up / Down Config. Field: 100K Ohm Pull Down
+													Hyst. Enable Field: Hysteresis Enabled */
+	imxrt_iomuxc_setpinconfig(
+		IOMUXC_GPIO_EMC_32_SEMC_DATA10,         /* GPIO_EMC_32 PAD functional properties : */
+		0x0110F9u);                             /* Slew Rate Field: Fast Slew Rate
+													Drive Strength Field: R0/7
+													Speed Field: max(200MHz)
+													Open Drain Enable Field: Open Drain Disabled
+													Pull / Keep Enable Field: Pull/Keeper Enabled
+													Pull / Keep Select Field: Keeper
+													Pull Up / Down Config. Field: 100K Ohm Pull Down
+													Hyst. Enable Field: Hysteresis Enabled */
+	imxrt_iomuxc_setpinconfig(
+		IOMUXC_GPIO_EMC_33_SEMC_DATA11,         /* GPIO_EMC_33 PAD functional properties : */
+		0x0110F9u);                             /* Slew Rate Field: Fast Slew Rate
+													Drive Strength Field: R0/7
+													Speed Field: max(200MHz)
+													Open Drain Enable Field: Open Drain Disabled
+													Pull / Keep Enable Field: Pull/Keeper Enabled
+													Pull / Keep Select Field: Keeper
+													Pull Up / Down Config. Field: 100K Ohm Pull Down
+													Hyst. Enable Field: Hysteresis Enabled */
+	imxrt_iomuxc_setpinconfig(
+		IOMUXC_GPIO_EMC_34_SEMC_DATA12,         /* GPIO_EMC_34 PAD functional properties : */
+		0x0110F9u);                             /* Slew Rate Field: Fast Slew Rate
+													Drive Strength Field: R0/7
+													Speed Field: max(200MHz)
+													Open Drain Enable Field: Open Drain Disabled
+													Pull / Keep Enable Field: Pull/Keeper Enabled
+													Pull / Keep Select Field: Keeper
+													Pull Up / Down Config. Field: 100K Ohm Pull Down
+													Hyst. Enable Field: Hysteresis Enabled */
+	imxrt_iomuxc_setpinconfig(
+		IOMUXC_GPIO_EMC_35_SEMC_DATA13,         /* GPIO_EMC_35 PAD functional properties : */
+		0x0110F9u);                             /* Slew Rate Field: Fast Slew Rate
+													Drive Strength Field: R0/7
+													Speed Field: max(200MHz)
+													Open Drain Enable Field: Open Drain Disabled
+													Pull / Keep Enable Field: Pull/Keeper Enabled
+													Pull / Keep Select Field: Keeper
+													Pull Up / Down Config. Field: 100K Ohm Pull Down
+													Hyst. Enable Field: Hysteresis Enabled */
+	imxrt_iomuxc_setpinconfig(
+		IOMUXC_GPIO_EMC_36_SEMC_DATA14,         /* GPIO_EMC_36 PAD functional properties : */
+		0x0110F9u);                             /* Slew Rate Field: Fast Slew Rate
+													Drive Strength Field: R0/7
+													Speed Field: max(200MHz)
+													Open Drain Enable Field: Open Drain Disabled
+													Pull / Keep Enable Field: Pull/Keeper Enabled
+													Pull / Keep Select Field: Keeper
+													Pull Up / Down Config. Field: 100K Ohm Pull Down
+													Hyst. Enable Field: Hysteresis Enabled */
+	imxrt_iomuxc_setpinconfig(
+		IOMUXC_GPIO_EMC_37_SEMC_DATA15,         /* GPIO_EMC_37 PAD functional properties : */
+		0x0110F9u);                             /* Slew Rate Field: Fast Slew Rate
+													Drive Strength Field: R0/7
+													Speed Field: max(200MHz)
+													Open Drain Enable Field: Open Drain Disabled
+													Pull / Keep Enable Field: Pull/Keeper Enabled
+													Pull / Keep Select Field: Keeper
+													Pull Up / Down Config. Field: 100K Ohm Pull Down
+													Hyst. Enable Field: Hysteresis Enabled */
+	imxrt_iomuxc_setpinconfig(
+		IOMUXC_GPIO_EMC_38_SEMC_DM01,           /* GPIO_EMC_38 PAD functional properties : */
+		0x0110F9u);                             /* Slew Rate Field: Fast Slew Rate
+													Drive Strength Field: R0/7
+													Speed Field: max(200MHz)
+													Open Drain Enable Field: Open Drain Disabled
+													Pull / Keep Enable Field: Pull/Keeper Enabled
+													Pull / Keep Select Field: Keeper
+													Pull Up / Down Config. Field: 100K Ohm Pull Down
+													Hyst. Enable Field: Hysteresis Enabled */
+	imxrt_iomuxc_setpinconfig(
+		IOMUXC_GPIO_EMC_39_SEMC_DQS,            /* GPIO_EMC_39 PAD functional properties : */
+		0x0110F9u);                             /* Slew Rate Field: Fast Slew Rate
+													Drive Strength Field: R0/7
+													Speed Field: max(200MHz)
+													Open Drain Enable Field: Open Drain Disabled
+													Pull / Keep Enable Field: Pull/Keeper Enabled
+													Pull / Keep Select Field: Keeper
+													Pull Up / Down Config. Field: 100K Ohm Pull Down
+													Hyst. Enable Field: Hysteresis Enabled */
+	imxrt_iomuxc_setpinconfig(
+		IOMUXC_GPIO_EMC_40_SEMC_RDY,            /* GPIO_EMC_40 PAD functional properties : */
+		0x0110F9u);                             /* Slew Rate Field: Fast Slew Rate
+													Drive Strength Field: R0/7
+													Speed Field: max(200MHz)
+													Open Drain Enable Field: Open Drain Disabled
+													Pull / Keep Enable Field: Pull/Keeper Enabled
+													Pull / Keep Select Field: Keeper
+													Pull Up / Down Config. Field: 100K Ohm Pull Down
+													Hyst. Enable Field: Hysteresis Enabled */
+	imxrt_iomuxc_setpinconfig(
+		IOMUXC_GPIO_EMC_41_SEMC_CSX00,          /* GPIO_EMC_41 PAD functional properties : */
+		0x0110F9u);                             /* Slew Rate Field: Fast Slew Rate
+													Drive Strength Field: R0/7
+													Speed Field: max(200MHz)
+													Open Drain Enable Field: Open Drain Disabled
+													Pull / Keep Enable Field: Pull/Keeper Enabled
+													Pull / Keep Select Field: Keeper
+													Pull Up / Down Config. Field: 100K Ohm Pull Down
+													Hyst. Enable Field: Hysteresis Enabled */
+	#endif
+}
+
+/************************************************************************************
+ * Name: imxrt_semc_sdram_clock_init
+ *
+ * Description:
+ *   Initialize clock setting in semc for sdram
+ *
+ ************************************************************************************/
+static inline void imxrt_semc_sdram_clock_init(void)
+{
+	imxrt_clock_initsyspfd(kCLOCK_Pfd2, 29);
+    /* Set semc clock to 163.86 MHz */
+    imxrt_clock_setmux(kCLOCK_SemcMux, 1);
+    imxrt_clock_setdiv(kCLOCK_SemcDiv, 1); 
+}
+
+/************************************************************************************
+ * Public Functions
+ ************************************************************************************/
+/****************************************************************************
+ * Public Types
+ ****************************************************************************/
+
+/************************************************************************************
+ * Name: imxrt_semc_sdram_init
+ *
+ * Description:
+ *   Initialize sdram 
+ *
+ ************************************************************************************/
+void imxrt_semc_sdram_init(void)
+{
+	semc_config_t config;
+    semc_sdram_config_t sdramconfig;
+    uint32_t clockFrq;
+	char tempLog[128];
+
+	imxrt_semc_sdram_pins_init();
+	imxrt_semc_sdram_clock_init();
+
+	imxrt_clock_enableclock(kCLOCK_Semc);
+
+	clockFrq = imxrt_clock_getfreq(kCLOCK_SemcClk);
+	snprintf(tempLog, sizeof(tempLog), "first clockFrq => %d", clockFrq);
+	IMXLOG(tempLog);
+
+    /* Initializes the MAC configure structure to zero. */
+    memset(&config, 0, sizeof(semc_config_t));
+    memset(&sdramconfig, 0, sizeof(semc_sdram_config_t));
+
+    /* Initialize SEMC. */
+    imxrt_semc_getdefaultconfig(&config);
+    config.dqsMode = kSEMC_Loopbackdqspad;  /* For more accurate timing. */
+    imxrt_semc_init(SEMC, &config);
+
+	clockFrq = imxrt_clock_getfreq(kCLOCK_SemcClk);
+	snprintf(tempLog, sizeof(tempLog), "second clockFrq => %d", clockFrq);
+	IMXLOG(tempLog);
+
+    /* Configure SDRAM. */
+    sdramconfig.csxPinMux = kSEMC_MUXCSX0;
+    sdramconfig.address = 0x80000000;
+    sdramconfig.memsize_kbytes = 32 * 1024; /* 32MB = 32*1024*1KBytes*/
+    sdramconfig.portSize = kSEMC_PortSize16Bit;
+    sdramconfig.burstLen = kSEMC_Sdram_BurstLen8;
+    sdramconfig.columnAddrBitNum = kSEMC_SdramColunm_9bit;
+    sdramconfig.casLatency = kSEMC_LatencyThree;
+    sdramconfig.tPrecharge2Act_Ns = 18;   /* Trp 18ns */
+    sdramconfig.tAct2ReadWrite_Ns = 18;   /* Trcd 18ns */
+    sdramconfig.tRefreshRecovery_Ns = 67; /* Use the maximum of the (Trfc , Txsr). */
+    sdramconfig.tWriteRecovery_Ns = 12;   /* 12ns */
+    sdramconfig.tCkeOff_Ns = 42;  /* The minimum cycle of SDRAM CLK off state. CKE is off in self refresh at a minimum period tRAS.*/
+    sdramconfig.tAct2Prechage_Ns = 42; /* Tras 42ns */
+    sdramconfig.tSelfRefRecovery_Ns = 67;
+    sdramconfig.tRefresh2Refresh_Ns = 60;
+    sdramconfig.tAct2Act_Ns = 60;
+    sdramconfig.tPrescalePeriod_Ns = 160 * (1000000000 / clockFrq);
+    sdramconfig.refreshPeriod_nsPerRow = 64 * 1000000 / 8192; /* 64ms/8192 */
+    sdramconfig.refreshUrgThreshold = sdramconfig.refreshPeriod_nsPerRow;
+    sdramconfig.refreshBurstLen = 1;
+    imxrt_semc_configuresdram(SEMC, kSEMC_SDRAM_CS0, &sdramconfig, clockFrq);
+}
+

--- a/os/arch/arm/src/imxrt/imxrt_semc_sdram.h
+++ b/os/arch/arm/src/imxrt/imxrt_semc_sdram.h
@@ -16,10 +16,10 @@
  *
  ****************************************************************************/
 /****************************************************************************
- * os/board/imxrt1050-evk/src/imxrt_boot.c
+ * os/arch/arm/src/imxrt/imxrt_semc_dram.h
  *
- *   Copyright (C) 2015 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ *   Copyright (C) 2018 Gregory Nutt. All rights reserved.
+ *   Author: Ivan Ucherdzhiev <ivanucherdjiev@gmail.com>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -31,7 +31,7 @@
  *    notice, this list of conditions and the following disclaimer in
  *    the documentation and/or other materials provided with the
  *    distribution.
- * 3. Neither the name TinyARA nor the names of its contributors may be
+ * 3. Neither the name NuttX nor the names of its contributors may be
  *    used to endorse or promote products derived from this software
  *    without specific prior written permission.
  *
@@ -50,61 +50,36 @@
  *
  ****************************************************************************/
 
+#ifndef __ARCH_ARM_SRC_IMXRT_IMX_SEMC_DRAM_H
+#define __ARCH_ARM_SRC_IMXRT_IMX_SEMC_DRAM_H
+
 /****************************************************************************
  * Included Files
  ****************************************************************************/
 
 #include <tinyara/config.h>
+#include <tinyara/sdio.h>
 
-#include <tinyara/board.h>
-#include <arch/board/board.h>
-
-#include "imxrt_start.h"
-#include "imxrt1050-evk.h"
-#include "imxrt_flash.h"
-#include "imxrt_semc_sdram.h"
+#include "chip.h"
 
 /****************************************************************************
- * Name: imxrt_boardinitialize
+ * Public Function Prototypes
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: imxrt_semc_sdram_init
  *
  * Description:
- *   All i.MX RT architectures must provide the following entry point.  This
- *   entry point is called early in the initialization -- after clocking and
- *   memory have been configured but before caches have been enabled and
- *   before any devices have been initialized.
+ *   Initialize SEMC for operation.
+ *
+ * Input Parameters:
+ *   None.
+ *
+ * Returned Value:
+ *   None
  *
  ****************************************************************************/
 
-void imxrt_boardinitialize(void)
-{
-	/* Configure on-board LEDs if LED support has been selected. */
+FAR void imxrt_semc_sdram_init(void);
 
-#ifdef CONFIG_ARCH_LEDS
-	imxrt_autoled_initialize();
-#endif
-
-	imxrt_semc_sdram_init();
-	imxrt_flash_init();
-}
-
-/****************************************************************************
- * Name: board_initialize
- *
- * Description:
- *   If CONFIG_BOARD_INITIALIZE is selected, then an additional
- *   initialization call will be performed in the boot-up sequence to a
- *   function called board_initialize().  board_initialize() will be
- *   called immediately after up_intitialize() is called and just before the
- *   initial application is started.  This additional initialization phase
- *   may be used, for example, to initialize board-specific device drivers.
- *
- ****************************************************************************/
-
-#ifdef CONFIG_BOARD_INITIALIZE
-void board_initialize(void)
-{
-	/* Perform board initialization */
-
-	(void)imxrt_bringup();
-}
-#endif							/* CONFIG_BOARD_INITIALIZE */
+#endif /*__ARCH_ARM_SRC_IMXRT_IMX_SEMC_DRAM_H */

--- a/os/board/imxrt1020-evk/src/imxrt_boot.c
+++ b/os/board/imxrt1020-evk/src/imxrt_boot.c
@@ -62,6 +62,7 @@
 #include "imxrt_start.h"
 #include "imxrt1020-evk.h"
 #include "imxrt_flash.h"
+#include "imxrt_semc_sdram.h"
 
 /****************************************************************************
  * Name: imxrt_boardinitialize
@@ -82,6 +83,7 @@ void imxrt_boardinitialize(void)
 	imxrt_autoled_initialize();
 #endif
 
+	imxrt_semc_sdram_init();
 	imxrt_flash_init();
 }
 


### PR DESCRIPTION
SDRAM can be access by SEMC

in menuconfig, the following setting should be enabled
Built-in Libraries
       [*] sizeof(_Bool) is 8-bits
