### PR TITLE
testcase/le_tc/kernel: Add protected build dependency in timer testcases to resolve asserts

### DIFF
--- a/apps/examples/testcase/le_tc/kernel/tc_timer.c
+++ b/apps/examples/testcase/le_tc/kernel/tc_timer.c
@@ -30,6 +30,7 @@
 
 int sig_no = SIGRTMIN;
 
+#ifndef CONFIG_BUILD_PROTECTED
 /**
 * @fn                   :tc_timer_timer_create_delete
 * @brief                :Create and delete a POSIX per-process timer
@@ -118,6 +119,7 @@ static void tc_timer_timer_create_delete(void)
 
 	TC_SUCCESS_RESULT();
 }
+#endif	/* CONFIG_BUILD_PROTECTED */
 
 #ifndef CONFIG_DISABLE_POSIX_TIMERS
 /**
@@ -273,7 +275,10 @@ static void tc_timer_timer_initialize(void)
 
 int timer_main(void)
 {
+#ifndef CONFIG_BUILD_PROTECTED
 	tc_timer_timer_create_delete();
+#endif	
+
 #ifndef CONFIG_DISABLE_POSIX_TIMERS
 	tc_timer_timer_getoverrun();
 #endif                     /* CONFIG_DISABLE_POSIX_TIMERS */


### PR DESCRIPTION
Timer make direct calls to kernel specific structures
which results in assert. In continuation with PR no: 3003

So this patch adds config dependency for above mentioned kernel testcase.

Signed-off-by: Nilabh <n.shant@partner.samsung.com>