### PR TITLE
os/Makefile.unix: remove duplicate prerequisite

### DIFF
--- a/os/Makefile.unix
+++ b/os/Makefile.unix
@@ -346,7 +346,7 @@ include/arch: Make.defs
 
 # Link the configs/<board-name>/include directory to include/arch/board
 
-include/arch/board: include/arch Make.defs include/arch
+include/arch/board: include/arch Make.defs 
 	@echo "LN: include/arch/board to $(BOARD_DIR)/include"
 	$(Q) $(DIRLINK) $(TOPDIR)/$(BOARD_DIR)/include include/arch/board
 


### PR DESCRIPTION
remove duplicate prerequisite for include/arch/board target