### PR TITLE
 arch/armv7-m/up_assert: Add abort handling in fault manager for armv7-m

### DIFF
--- a/os/arch/arm/src/armv7-r/arm_syscall.c
+++ b/os/arch/arm/src/armv7-r/arm_syscall.c
@@ -526,6 +526,7 @@ uint32_t *arm_syscall(uint32_t *regs)
 	lldbg("SYSCALL from 0x%x\n", regs[REG_PC]);
 	current_regs = regs;
 	PANIC();
+	return regs;
 }
 
 #endif

--- a/os/include/assert.h
+++ b/os/include/assert.h
@@ -208,9 +208,9 @@ extern "C" {
  ****************************************************************************/
 
 #ifdef CONFIG_HAVE_FILENAME
-void up_assert(FAR const uint8_t *filename, int linenum) noreturn_function;
+void up_assert(FAR const uint8_t *filename, int linenum);
 #else
-void up_assert(void) noreturn_function;
+void up_assert(void);
 #endif
 
 #ifdef CONFIG_FRAME_POINTER

--- a/os/kernel/binary_manager/binary_manager_recovery.c
+++ b/os/kernel/binary_manager/binary_manager_recovery.c
@@ -78,7 +78,7 @@ static void recovery_kill_each(FAR struct tcb_s *tcb, FAR void *arg)
 		return;
 	}
 
-	if (tcb->group->tg_loadtask == info->binid && tcb->pid != info->binid && tcb->pid != info->faultid) {
+	if (tcb->group->tg_loadtask == info->binid && tcb->pid != info->binid) {
 		bmllvdbg("KILL!! %d\n", tcb->pid);
 		ret = task_terminate(tcb->pid, true);
 	}


### PR DESCRIPTION
This patch adds support of abort handling in fault manger for armv7-m architecture.
All kinds of hard faults is handled by fault manager.