### PR TITLE
binary_manager: Fix wrong usages of binary manager

### DIFF
--- a/build/configs/imxrt1050-evk/imxrt1050-evk_download.sh
+++ b/build/configs/imxrt1050-evk/imxrt1050-evk_download.sh
@@ -58,9 +58,9 @@ echo "Downloading tinyara_flash.bin for App binary separation"
 BIN_PATH=${OS_DIR_PATH}/../build/output/bin
 KERN_IMG=${BIN_PATH}/tinyara.bin
 USER_IMG=${BIN_PATH}/tinyara_user.bin
-APP1_IMG1=${OS_DIR_PATH}/../apps/examples/elf/micomapp/micom
+APP1_IMG1=${BIN_PATH}/micom
 APP1_IMG2=${BIN_PATH}/micom
-APP2_IMG1=${OS_DIR_PATH}/../apps/examples/elf/wifiapp/wifi
+APP2_IMG1=${BIN_PATH}/wifi
 APP2_IMG2=${BIN_PATH}/wifi
 FLASH_IMG=${BIN_PATH}/tinyara_flash.bin
 

--- a/os/kernel/binary_manager/binary_manager_load.c
+++ b/os/kernel/binary_manager/binary_manager_load.c
@@ -407,7 +407,12 @@ int binary_manager_loading(int type, void *data)
 	argv[2] = NULL;
 
 	ret = kernel_thread(LOADINGTHD_NAME, LOADINGTHD_PRIORITY, LOADINGTHD_STACKSIZE, loading_thread, (char * const *)argv);
-	free(argv);
+	if (ret > 0) {
+		bmvdbg("Execute loading thread with pid %d\n", ret);
+	} else {
+		bmdbg("Loading Fail\n");
+	}
+	kmm_free(argv);
 
 	return ret;
 }

--- a/os/kernel/binary_manager/binary_manager_recovery.c
+++ b/os/kernel/binary_manager/binary_manager_recovery.c
@@ -226,7 +226,7 @@ void binary_manager_recovery(int pid)
 
 		ret = kernel_thread(RECOVERYTHD_NAME, RECOVERYTHD_PRIORITY, RECOVERYTHD_STACKSIZE, recovery_thread, (char * const *)argv);
 		if (ret > 0) {
-			free(argv);
+			kmm_free(argv);
 			bmllvdbg("Execute recovery thread with pid %d\n", pid);
 			return;
 		}


### PR DESCRIPTION
- build/imxrt1050: fix wrong path of binary output
- kernel/binary_manager: modify free to kmm_free in binary manager