### PR TITLE
imxrt/semc: make a dependency with C99_BOOL8 and cover it with CONFIG

### DIFF
--- a/os/arch/arm/src/imxrt/Kconfig
+++ b/os/arch/arm/src/imxrt/Kconfig
@@ -490,16 +490,17 @@ config IMXRT_SEMC_SDRAM
 	bool "External SDRAM installed"
 	default n
 	depends on IMXRT_SEMC
+	select C99_BOOL8
 
 if IMXRT_SEMC_SDRAM
 
 config IMXRT_SDRAM_START
 	hex "SDRAM start address"
-	default 0x10000000
+	default 0x80000000
 
 config IMXRT_SDRAM_SIZE
 	int "SDRAM size (bytes)"
-	default 268435456
+	default 33554432
 
 endif # IMXRT_SEMC_SDRAM
 

--- a/os/arch/arm/src/imxrt/Make.defs
+++ b/os/arch/arm/src/imxrt/Make.defs
@@ -117,8 +117,14 @@ CHIP_CSRCS  = imxrt_allocateheap.c imxrt_start.c imxrt_clockconfig.c
 CHIP_CSRCS += imxrt_periphclks.c imxrt_irq.c imxrt_clrpend.c imxrt_gpio.c
 CHIP_CSRCS += imxrt_daisy.c imxrt_wdog.c imxrt_iomuxc.c imxrt_serial.c
 CHIP_CSRCS += imxrt_lowputc.c imxrt_flexspi.c imxrt_clock.c imxrt_log.c
-CHIP_CSRCS += imxrt_dmamux.c imxrt_flexram.c imxrt_semc.c
+CHIP_CSRCS += imxrt_dmamux.c imxrt_flexram.c 
+
+ifeq ($(CONFIG_IMXRT_SEMC),y)
+CHIP_CSRCS += imxrt_semc.c
+ifeq ($(CONFIG_IMXRT_SEMC_SDRAM),y)
 CHIP_CSRCS += imxrt_semc_sdram.c
+endif # IMXRT_SEMC_SDRAM
+endif # IMXRT_SEMC
 
 # Configuration-dependent i.MX RT files
 

--- a/os/board/imxrt1020-evk/src/imxrt_boot.c
+++ b/os/board/imxrt1020-evk/src/imxrt_boot.c
@@ -62,7 +62,9 @@
 #include "imxrt_start.h"
 #include "imxrt1020-evk.h"
 #include "imxrt_flash.h"
+#ifdef CONFIG_IMXRT_SEMC_SDRAM
 #include "imxrt_semc_sdram.h"
+#endif
 
 /****************************************************************************
  * Name: imxrt_boardinitialize
@@ -82,8 +84,9 @@ void imxrt_boardinitialize(void)
 #ifdef CONFIG_ARCH_LEDS
 	imxrt_autoled_initialize();
 #endif
-
+#ifdef CONFIG_IMXRT_SEMC_SDRAM
 	imxrt_semc_sdram_init();
+#endif
 	imxrt_flash_init();
 }
 

--- a/os/board/imxrt1050-evk/src/imxrt_boot.c
+++ b/os/board/imxrt1050-evk/src/imxrt_boot.c
@@ -62,7 +62,9 @@
 #include "imxrt_start.h"
 #include "imxrt1050-evk.h"
 #include "imxrt_flash.h"
+#ifdef CONFIG_IMXRT_SEMC_SDRAM
 #include "imxrt_semc_sdram.h"
+#endif
 
 /****************************************************************************
  * Name: imxrt_boardinitialize
@@ -82,8 +84,9 @@ void imxrt_boardinitialize(void)
 #ifdef CONFIG_ARCH_LEDS
 	imxrt_autoled_initialize();
 #endif
-
+#ifdef CONFIG_IMXRT_SEMC_SDRAM
 	imxrt_semc_sdram_init();
+#endif
 	imxrt_flash_init();
 }
 


### PR DESCRIPTION
Configuration of SEMC is not working with source code.
There are some configurations in Kconfig of imxrt but they are not used.
Let's cover semc source files with appropriatary configs.

To use SEMC, CONFIG_C99_BOOL8 should be turned on.
Let's make a dependency with it to enable it automatically.

Signed-off-by: sunghan-chang <sh924.chang@samsung.com>