### PR TITLE
fix violations of coding rules

### DIFF
--- a/os/arch/arm/src/armv7-m/mpu.h
+++ b/os/arch/arm/src/armv7-m/mpu.h
@@ -661,7 +661,8 @@ static inline void mpu_peripheral(uint32_t region, uintptr_t base, size_t size)
 }
 
 #if defined(CONFIG_APP_BINARY_SEPARATION)
-static inline void up_set_mpu_app_configuration(struct tcb_s *rtcb) {
+static inline void up_set_mpu_app_configuration(struct tcb_s *rtcb)
+{
 	if ((rtcb->flags & TCB_FLAG_TTYPE_MASK) != TCB_FLAG_TTYPE_KERNEL) {
 		putreg32(rtcb->mpu_regs[REG_RNR], MPU_RNR);
 		putreg32(rtcb->mpu_regs[REG_RBAR], MPU_RBAR);

--- a/os/binfmt/binfmt_exec.c
+++ b/os/binfmt/binfmt_exec.c
@@ -212,7 +212,7 @@ int exec(FAR const char *filename, FAR char *const *argv, FAR const struct symta
 
 	/* Initialize the MPU registers in tcb with suitable protection values */
 #ifdef CONFIG_ARMV7M_MPU
-        mpu_user_intsram_context(g_app_mpu_region, start_addr, size, tcb->mpu_regs);
+	mpu_user_intsram_context(g_app_mpu_region, start_addr, size, tcb->mpu_regs);
 #endif
 
 #endif


### PR DESCRIPTION
os/arch/arm/src/armv7-m/mpu.h:664: ERROR: [BRC_M_FTN] open brace '{' following function declarations go on the next line
os/binfmt/binfmt_exec.c:215: ERROR: [IDT_M_TAB] code indent should use tabs where possible
os/binfmt/binfmt_exec.c:215: ERROR: [IDT_M_TAB] please, no spaces at the start of a line

Signed-off-by: sunghan-chang <sh924.chang@samsung.com>