### PR TITLE
os/debug: Remove vendor-specific dependency in debug

### DIFF
--- a/os/drivers/lwnl/Kconfig
+++ b/os/drivers/lwnl/Kconfig
@@ -26,15 +26,17 @@ config DEBUG_LWNL80211_INFO
 		Enable LWNL80211 INFO DEBUG
 
 if LWNL80211_SLSI
-config DEBUG_LWNL80211_SLSI_ERROR
-	bool "SLSIDRV ERROR DEBUG"
+config DEBUG_LWNL80211_VENDOR_DRV_ERROR
+	bool "Vendor-specific driver interface ERROR DEBUG"
 	default n
+	depends on DEBUG_ERROR
 	---help---
-		Enable SLSI driver ERROR DEBUG
+		Enable Vendor-Specific Driver ERROR Debug
 
 config DEBUG_LWNL80211_SLSI_INFO
-	bool "SLSIDRV INFO DEBUG"
+	bool "Vendor-specific driver interface INFO DEBUG"
 	default n
+	depends on DEBUG_VERBOSE
 	---help---
-		Enable SLSI driver INFO DEBUG
+		Enable Vendor-Specific Driver INFO Debug
 endif

--- a/os/drivers/lwnl/slsi_drv.c
+++ b/os/drivers/lwnl/slsi_drv.c
@@ -143,20 +143,20 @@ fetch_scan_results(lwnl80211_scan_list_s **scan_list, slsi_scan_info_t **slsi_sc
 		while (wifi_scan_iter) {
 #if SLSI_DRV_SCAN_DEBUG
 			/* Debug */
-			sddbg("SSID (");
+			vddbg("SSID (");
 			int i = 0;
 			for (; i < wifi_scan_iter->ssid_len; i++) {
-				sddbg("%c", wifi_scan_iter->ssid[i]);
+				vddbg("%c", wifi_scan_iter->ssid[i]);
 			}
-			sddbg(")\n");
-			sddbg("rssi(%d)\n", wifi_scan_iter->rssi);
-			sddbg("beacon_period(%d)\n", wifi_scan_iter->beacon_period);
-			sddbg("channel(%d)\n", wifi_scan_iter->channel);
-			sddbg("physical mode(%d)\n", wifi_scan_iter->phy_mode);
-			sddbg("bss type(%d)\n", wifi_scan_iter->bss_type);
-			sddbg("wps support(%d)\n", wifi_scan_iter->wps_support);
-			sddbg("num_sec modes(%d)\n", wifi_scan_iter->num_sec_modes);
-			sddbg("-----------------------------------------------\n");
+			vddbg(")\n");
+			vddbg("rssi(%d)\n", wifi_scan_iter->rssi);
+			vddbg("beacon_period(%d)\n", wifi_scan_iter->beacon_period);
+			vddbg("channel(%d)\n", wifi_scan_iter->channel);
+			vddbg("physical mode(%d)\n", wifi_scan_iter->phy_mode);
+			vddbg("bss type(%d)\n", wifi_scan_iter->bss_type);
+			vddbg("wps support(%d)\n", wifi_scan_iter->wps_support);
+			vddbg("num_sec modes(%d)\n", wifi_scan_iter->num_sec_modes);
+			vddbg("-----------------------------------------------\n");
 #endif
 			cur = (lwnl80211_scan_list_s *)malloc(sizeof(lwnl80211_scan_list_s));
 			if (!cur) {
@@ -189,10 +189,10 @@ fetch_scan_results(lwnl80211_scan_list_s **scan_list, slsi_scan_info_t **slsi_sc
 			wifi_scan_iter = wifi_scan_iter->next;
 			cnt++;
 		}
-		sddbg("%d records scanned\n", cnt);
+		vddbg("%d records scanned\n", cnt);
 		result = LWNL80211_SUCCESS;
 	} else {
-		sddbg("Scanning result is null...\n");
+		vddbg("Scanning result is null...\n");
 	}
 	return result;
 }
@@ -206,18 +206,18 @@ static int slsi_drv_callback_handler(void *arg)
 	lwnl80211_cb_status status;
 
 	if (!g_dev) {
-		sddbg("Failed to find upper driver\n");
+		vddbg("Failed to find upper driver\n");
 		free(type);
 		return -1;
 	}
 
 	if (!g_dev->cbk) {
-		sddbg("Failed to find callback function\n");
+		vddbg("Failed to find callback function\n");
 		free(type);
 		return -1;
 	}
 
-	sddbg("Got callback from SLSI drv (%d)\n", status);
+	vddbg("Got callback from SLSI drv (%d)\n", status);
 	switch (*type) {
 	case 1:
 		status = LWNL80211_STA_CONNECTED;
@@ -254,7 +254,7 @@ static void linkup_handler(slsi_reason_t *reason)
 {
 	int *type = (int *)malloc(sizeof(int));
 	if (type == NULL) {
-		sddbg("malloc error\n");
+		vddbg("malloc error\n");
 		return;
 	}
 
@@ -270,7 +270,7 @@ static void linkup_handler(slsi_reason_t *reason)
 	pthread_t tid;
 	int ret = pthread_create(&tid, NULL, (pthread_startroutine_t)slsi_drv_callback_handler, (void *)type);
 	if (ret != 0) {
-		sddbg("pthread create fail(%d)\n", errno);
+		vddbg("pthread create fail(%d)\n", errno);
 		free(type);
 		return;
 	}
@@ -282,7 +282,7 @@ static void linkdown_handler(slsi_reason_t *reason)
 {
 	int *type = (int *)malloc(sizeof(int));
 	if (type == NULL) {
-		sddbg("malloc error linkdown\n");
+		vddbg("malloc error linkdown\n");
 		return;
 	}
 	*type = 4;
@@ -294,7 +294,7 @@ static void linkdown_handler(slsi_reason_t *reason)
 	pthread_t tid;
 	int ret = pthread_create(&tid, NULL, (pthread_startroutine_t)slsi_drv_callback_handler, (void *)type);
 	if (ret != 0) {
-		sddbg("pthread create fail(%d)\n", errno);
+		vddbg("pthread create fail(%d)\n", errno);
 		free(type);
 		return;
 	}
@@ -308,13 +308,13 @@ static int8_t slsi_drv_scan_callback_handler(slsi_reason_t *reason)
 	lwnl80211_scan_list_s *scan_list = NULL;
 	lwnl80211_cb_status status;
 	if (!g_dev) {
-		sddbg("Failed to find upper driver\n");
+		vddbg("Failed to find upper driver\n");
 		return -1;
 	}
-	sddbg("Got scan callback from SLSI drv (%d)\n", status);
+	vddbg("Got scan callback from SLSI drv (%d)\n", status);
 
 	if (reason->reason_code != SLSI_STATUS_SUCCESS) {
-		sddbg("Scan failed %d\n");
+		vddbg("Scan failed %d\n");
 		status = LWNL80211_SCAN_FAILED;
 		g_dev->cbk((struct lwnl80211_lowerhalf_s *)g_dev, status, NULL);
 		return SLSI_STATUS_ERROR;
@@ -349,28 +349,28 @@ lwnl80211_result_e slsidrv_init(struct lwnl80211_lowerhalf_s *dev)
 		int ret = SLSI_STATUS_SUCCESS;
 		ret = WiFiStart(SLSI_WIFI_STATION_IF, NULL);
 		if (ret != SLSI_STATUS_SUCCESS) {
-			sddbg("Failed to start STA mode\n");
+			vddbg("Failed to start STA mode\n");
 			return result;
 		}
 		g_mode = SLSI_WIFI_STATION_IF;
 
 		ret = WiFiRegisterLinkCallback(&linkup_handler, &linkdown_handler);
 		if (ret != SLSI_STATUS_SUCCESS) {
-			sddbg("Link callback handles: register failed !\n");
+			vddbg("Link callback handles: register failed !\n");
 			return result;
 		} else {
-			sdvdbg("Link callback handles: registered\n");
+			vdvdbg("Link callback handles: registered\n");
 		}
 
 		ret = WiFiRegisterScanCallback(&slsi_drv_scan_callback_handler);
 		if (ret != SLSI_STATUS_SUCCESS) {
-			sddbg("[ERR] Register Scan Callback(%d)\n", ret);
+			vddbg("[ERR] Register Scan Callback(%d)\n", ret);
 			return result;
 		}
 		g_dev = dev;
 		result = LWNL80211_SUCCESS;
 	} else {
-		sddbg("Already %d\n", g_mode);
+		vddbg("Already %d\n", g_mode);
 	}
 	return result;
 }
@@ -385,7 +385,7 @@ lwnl80211_result_e slsidrv_deinit(void)
 		result = LWNL80211_SUCCESS;
 		g_dev = NULL;
 	} else {
-		sddbg("Failed to stop STA mode\n");
+		vddbg("Failed to stop STA mode\n");
 	}
 	return result;
 }
@@ -396,16 +396,16 @@ lwnl80211_result_e slsidrv_scan_ap(void *arg)
 	lwnl80211_result_e result = LWNL80211_FAIL;
 	int8_t ret = WiFiRegisterScanCallback(&slsi_drv_scan_callback_handler);
 	if (ret != SLSI_STATUS_SUCCESS) {
-		sddbg("[ERR] Register Scan Callback(%d)\n", ret);
+		vddbg("[ERR] Register Scan Callback(%d)\n", ret);
 		return result;
 	}
 	ret = WiFiScanNetwork();
 	if (ret != SLSI_STATUS_SUCCESS) {
-		sddbg("[ERR] WiFi scan fail(%d)\n", ret);
+		vddbg("[ERR] WiFi scan fail(%d)\n", ret);
 		return result;
 	}
 	result = LWNL80211_SUCCESS;
-	sddbg("WIFi Scan success\n");
+	vddbg("WIFi Scan success\n");
 	return result;
 }
 
@@ -424,7 +424,7 @@ lwnl80211_result_e slsidrv_connect_ap(lwnl80211_ap_config_s *ap_connect_config, 
 	if (ap_connect_config->passphrase_length > 0) {
 		config = (slsi_security_config_t *)zalloc(sizeof(slsi_security_config_t));
 		if (!config) {
-			sddbg("Memory allocation failed!\n");
+			vddbg("Memory allocation failed!\n");
 			goto connect_ap_fail;
 		}
 
@@ -467,26 +467,26 @@ lwnl80211_result_e slsidrv_connect_ap(lwnl80211_ap_config_s *ap_connect_config, 
 			}
 		} else {
 			/* wrong security type */
-			sddbg("Wrong security type\n");
+			vddbg("Wrong security type\n");
 			goto connect_ap_fail;
 		}
 	} else {
-		sddbg("No passphrase!\n");
+		vddbg("No passphrase!\n");
 		goto connect_ap_fail;
 	}
 
 	ret = WiFiNetworkJoin((uint8_t *)ap_connect_config->ssid, ap_connect_config->ssid_length, NULL, config);
 	if (ret != SLSI_STATUS_SUCCESS) {
 		if (ret == SLSI_STATUS_ALREADY_CONNECTED) {
-			sdvdbg("WiFiNetworkJoin already connected\n");
+			vdvdbg("WiFiNetworkJoin already connected\n");
 			result = LWNL80211_ALREADY_CONNECTED;
 		} else {
-			sddbg("WiFiNetworkJoin failed: %d, %s\n", ret, ap_connect_config->ssid);
+			vddbg("WiFiNetworkJoin failed: %d, %s\n", ret, ap_connect_config->ssid);
 			goto connect_ap_fail;
 		}
 	} else {
 		result = LWNL80211_SUCCESS;
-		sdvdbg("Successfully joined the network: %s(%d)\n", ap_connect_config->ssid,
+		vdvdbg("Successfully joined the network: %s(%d)\n", ap_connect_config->ssid,
 			  ap_connect_config->ssid_length);
 	}
 
@@ -505,10 +505,10 @@ lwnl80211_result_e slsidrv_disconnect_ap(void *arg)
 	lwnl80211_result_e result = LWNL80211_FAIL;
 	int ret = WiFiNetworkLeave();
 	if (ret == SLSI_STATUS_SUCCESS) {
-		sddbg("WiFiNetworkLeave success\n");
+		vddbg("WiFiNetworkLeave success\n");
 		result = LWNL80211_SUCCESS;
 	} else {
-		sddbg("WiFiNetworkLeave fail because of %d\n", ret);
+		vddbg("WiFiNetworkLeave fail because of %d\n", ret);
 	}
 
 	return result;
@@ -540,10 +540,10 @@ lwnl80211_result_e slsidrv_get_info(lwnl80211_info *wifi_info)
 				}
 				result = LWNL80211_SUCCESS;
 			} else {
-				sddbg("no MAC exists\n");
+				vddbg("no MAC exists\n");
 			}
 		} else {
-			sddbg("need to init... get info fail\n");
+			vddbg("need to init... get info fail\n");
 		}
 	}
 	return result;
@@ -562,7 +562,7 @@ lwnl80211_result_e slsidrv_start_softap(lwnl80211_softap_config_s *softap_config
 
 	ap_config = (slsi_ap_config_t *)zalloc(sizeof(slsi_ap_config_t));
 	if (!ap_config) {
-		sddbg("Memory allocation failed!\n");
+		vddbg("Memory allocation failed!\n");
 		return LWNL80211_FAIL;
 	}
 
@@ -572,7 +572,7 @@ lwnl80211_result_e slsidrv_start_softap(lwnl80211_softap_config_s *softap_config
 	ap_config->phy_mode = 1; //1 for 11n, 0 for legacy
 
 	if (softap_config->channel > 14 || softap_config->channel < 1) {
-		sddbg("Channel needs to be between 1 and 14" " (highest channel depends on regulatory of countries)\n");
+		vddbg("Channel needs to be between 1 and 14" " (highest channel depends on regulatory of countries)\n");
 		goto start_soft_ap_fail;
 	} else {
 		ap_config->channel = softap_config->channel;
@@ -590,7 +590,7 @@ lwnl80211_result_e slsidrv_start_softap(lwnl80211_softap_config_s *softap_config
 	} else {
 		security_config = (slsi_security_config_t *)zalloc(sizeof(slsi_security_config_t));
 		if (!security_config) {
-			sddbg("Memory allocation failed!\n");
+			vddbg("Memory allocation failed!\n");
 			goto start_soft_ap_fail;
 		}
 		memcpy(security_config->passphrase, softap_config->passphrase, softap_config->passphrase_length);
@@ -607,29 +607,29 @@ lwnl80211_result_e slsidrv_start_softap(lwnl80211_softap_config_s *softap_config
 		security_config->secmode = (SLSI_SEC_MODE_WPA_MIXED | SLSI_SEC_MODE_WPA2_MIXED);
 	} else {
 		// if not WPA-TKIP, WPA2-AES, WPA/WPA2 TKIP/AES/MIXED, return fail.
-		sddbg("Wrong security config. Match proper auth and crypto.\n");
+		vddbg("Wrong security config. Match proper auth and crypto.\n");
 		goto start_soft_ap_fail;
 	}
 	ap_config->security = security_config;
 
 	if (WiFiStart(SLSI_WIFI_SOFT_AP_IF, ap_config) != SLSI_STATUS_SUCCESS) {
-		sddbg("Failed to start AP mode\n");
+		vddbg("Failed to start AP mode\n");
 		goto start_soft_ap_fail;
 	}
 	g_mode = SLSI_WIFI_SOFT_AP_IF;
-	sdvdbg("SoftAP with SSID: %s has successfully started!\n", softap_config->ssid);
+	vdvdbg("SoftAP with SSID: %s has successfully started!\n", softap_config->ssid);
 
 	ret = WiFiRegisterLinkCallback(&linkup_handler, &linkdown_handler);
 	if (ret != SLSI_STATUS_SUCCESS) {
-		sddbg("Link callback handles: register failed !\n");
+		vddbg("Link callback handles: register failed !\n");
 		return LWNL80211_FAIL;
 	} else {
-		sdvdbg("Link callback handles: registered\n");
+		vdvdbg("Link callback handles: registered\n");
 	}
 
 	ret = WiFiRegisterScanCallback(&slsi_drv_scan_callback_handler);
 	if (ret != SLSI_STATUS_SUCCESS) {
-		sddbg("[ERR] Register Scan Callback(%d)\n", ret);
+		vddbg("[ERR] Register Scan Callback(%d)\n", ret);
 		return LWNL80211_FAIL;
 	}
 
@@ -657,19 +657,19 @@ lwnl80211_result_e slsidrv_start_sta(void)
 		g_mode = SLSI_WIFI_STATION_IF;
 		ret = WiFiRegisterLinkCallback(&linkup_handler, &linkdown_handler);
 		if (ret == SLSI_STATUS_SUCCESS) {
-			sdvdbg("Link callback handles: registered\n");
+			vdvdbg("Link callback handles: registered\n");
 			ret = WiFiRegisterScanCallback(&slsi_drv_scan_callback_handler);
 			if (ret == SLSI_STATUS_SUCCESS) {
-				sdvdbg("Scan callback handles: registered\n");
+				vdvdbg("Scan callback handles: registered\n");
 				result = LWNL80211_SUCCESS;
 			} else {
-				sddbg("[ERR] Register Scan Callback(%d)\n", ret);
+				vddbg("[ERR] Register Scan Callback(%d)\n", ret);
 			}
 		} else {
-			sddbg("[ERR] Register Link Callback(%d)\n", ret);
+			vddbg("[ERR] Register Link Callback(%d)\n", ret);
 		}
 	} else {
-		sddbg("Failed to start STA mode\n");
+		vddbg("Failed to start STA mode\n");
 	}
 	return result;
 }
@@ -683,12 +683,12 @@ lwnl80211_result_e slsidrv_stop_softap(void)
 		ret = WiFiStop();
 		if (ret == SLSI_STATUS_SUCCESS) {
 			result = LWNL80211_SUCCESS;
-			sddbg("Stop AP mode successfully\n");
+			vddbg("Stop AP mode successfully\n");
 		} else {
-			sddbg("Stop AP mode fail\n");
+			vddbg("Stop AP mode fail\n");
 		}
 	} else {
-		sddbg("Mode is not AP mode\n");
+		vddbg("Mode is not AP mode\n");
 	}
 	return result;
 }
@@ -700,9 +700,9 @@ lwnl80211_result_e slsidrv_set_autoconnect(uint8_t check)
 	int ret = WiFiSetAutoconnect(check);
 	if (ret == SLSI_STATUS_SUCCESS) {
 		result = LWNL80211_SUCCESS;
-		sddbg("External Autoconnect set to %d\n", check);
+		vddbg("External Autoconnect set to %d\n", check);
 	} else {
-		sddbg("External Autoconnect failed to set %d", check);
+		vddbg("External Autoconnect failed to set %d", check);
 	}
 	return result;
 }

--- a/os/include/debug.h
+++ b/os/include/debug.h
@@ -829,20 +829,20 @@
 #define nlllvdbg(...)
 #endif
 
-#ifdef CONFIG_DEBUG_LWNL80211_SLSI_ERROR
-#define sddbg(format, ...)      dbg(format, ##__VA_ARGS__)
-#define sdlldbg(format, ...)    lldbg(format, ##__VA_ARGS__)
+#ifdef CONFIG_DEBUG_LWNL80211_VENDOR_DRV_ERROR
+#define vddbg(format, ...)      dbg(format, ##__VA_ARGS__)
+#define vdlldbg(format, ...)    lldbg(format, ##__VA_ARGS__)
 #else
-#define sddbg(...)
-#define sdlldbg(...)
+#define vddbg(...)
+#define vdlldbg(...)
 #endif
 
-#ifdef CONFIG_DEBUG_LWNL80211_SLSI_INFO
-#define sdvdbg(format, ...)     vdbg(format, ##__VA_ARGS__)
-#define sdllvdbg(format, ...)   llvdbg(format, ##__VA_ARGS__)
+#ifdef CONFIG_DEBUG_LWNL80211_VENDER_DRV_INFO
+#define vdvdbg(format, ...)     vdbg(format, ##__VA_ARGS__)
+#define vdllvdbg(format, ...)   llvdbg(format, ##__VA_ARGS__)
 #else
-#define sdvdbg(...)
-#define sdllvdbg(...)
+#define vdvdbg(...)
+#define vdllvdbg(...)
 #endif
 
 #ifdef CONFIG_DEBUG_SECURE_ELEMENT_ERROR
@@ -1310,20 +1310,20 @@
 #define nlllvdbg   (void)
 #endif
 
-#ifdef CONFIG_DEBUG_LWNL80211_SLSI_ERROR
-#define sddbg      dbg
-#define sdlldbg    lldbg
+#ifdef CONFIG_DEBUG_LWNL80211_VENDER_DRV_ERROR
+#define vddbg      dbg
+#define vdlldbg    lldbg
 #else
-#define sddbg      (void)
-#define sdlldbg    (void)
+#define vddbg      (void)
+#define vdlldbg    (void)
 #endif
 
-#ifdef CONFIG_DEBUG_LWNL80211_SLSI_INFO
-#define sdvdbg     vdbg
-#define sdllvdbg   llvdbg
+#ifdef CONFIG_DEBUG_LWNL80211_VENDOR_DRV_INFO
+#define vdvdbg     vdbg
+#define vdllvdbg   llvdbg
 #else
-#define sdvdbg     (void)
-#define sdllvdbg   (void)
+#define vdvdbg     (void)
+#define vdllvdbg   (void)
 #endif
 
 #ifdef CONFIG_DEBUG_SECURE_ELEMENT_ERROR

--- a/os/include/tinyara/lwnl/slsi_drv.h
+++ b/os/include/tinyara/lwnl/slsi_drv.h
@@ -32,13 +32,13 @@
 
 #define SLSIDRV_ERR                                                         \
 	do {                                                                    \
-		sddbg(SLSIDRV_TAG"[ERR] %s: %d line err(%s)\n",                     \
+		vddbg(SLSIDRV_TAG"[ERR] %s: %d line err(%s)\n",                     \
 				  __FILE__, __LINE__, strerror(errno));                     \
 	} while (0)
 
 #define SLSIDRV_ENTER                                                       \
 	do {                                                                    \
-		sddbg(SLSIDRV_TAG"%s:%d\n", __FILE__, __LINE__);                    \
+		vddbg(SLSIDRV_TAG"%s:%d\n", __FILE__, __LINE__);                    \
 	} while (0)
 
 /****************************************************************************


### PR DESCRIPTION
- Modify SLSI driver to a generic vendor-specific driver log in debug.h
- Modify the corresponding log in slsi_drv.c and slsi_drv.h
- Add DEBUG_ERROR or DEBUG_VERBOSE dependency in Kconfig