### PR TITLE
kernel/init: start the preapp task regardless of binary manager

### DIFF
--- a/os/kernel/init/os_bringup.c
+++ b/os/kernel/init/os_bringup.c
@@ -252,21 +252,18 @@ static inline void os_do_appstart(void)
 	net_initialize();
 #endif
 
-	/* Start the application initialization task.  In a flat build, this is
-	 * entrypoint is given by the definitions, CONFIG_USER_ENTRYPOINT.  In
-	 * the protected build, however, we must get the address of the
-	 * entrypoint from the header at the beginning of the user-space blob.
-	 */
-
-	svdbg("Starting application init thread\n");
-
 #ifdef CONFIG_BINARY_MANAGER
+	svdbg("Starting binary manager thread\n");
+
 	pid = kernel_thread(BINARY_MANAGER_NAME, BINARY_MANAGER_PRIORITY, BINARY_MANAGER_STACKSIZE, binary_manager, NULL);
 	if (pid < 0) {
 		sdbg("Failed to start binary manager");
 	}
+#endif
 
 #ifdef CONFIG_SYSTEM_PREAPP_INIT
+	svdbg("Starting application init task\n");
+
 #ifdef CONFIG_BUILD_PROTECTED
 	DEBUGASSERT(USERSPACE->preapp_start != NULL);
 	pid = task_create("appinit", SCHED_PRIORITY_DEFAULT, CONFIG_SYSTEM_PREAPP_STACKSIZE, USERSPACE->preapp_start, (FAR char *const *)NULL);
@@ -295,9 +292,15 @@ static inline void os_do_appstart(void)
 	}
 #endif
 
-#else //binary manager
 
-	svdbg("Starting application main thread\n");
+#if !defined(CONFIG_BINARY_MANAGER)
+	/* Start the application initialization task.  In a flat build, this is
+	 * entrypoint is given by the definitions, CONFIG_USER_ENTRYPOINT.  In
+	 * the protected build, however, we must get the address of the
+	 * entrypoint from the header at the beginning of the user-space blob.
+	 */
+
+	svdbg("Starting application main task\n");
 
 #ifdef CONFIG_BUILD_PROTECTED
 	if (USERSPACE->us_entrypoint != NULL) {
@@ -306,8 +309,8 @@ static inline void os_do_appstart(void)
 #elif defined(CONFIG_USER_ENTRYPOINT)
 	pid = task_create("appmain", SCHED_PRIORITY_DEFAULT, CONFIG_USERMAIN_STACKSIZE, (main_t)CONFIG_USER_ENTRYPOINT, (FAR char *const *)NULL);
 #endif
+#endif // !CONFIG_BINARY_MANAGER
 
-#endif
 	ASSERT(pid > 0);
 }
 


### PR DESCRIPTION
The preapp task which launches TASH and system tasks does not
have any dependency with binary manager.
So, it should be outside of binary manager conditional.
This commit fixes an issue that TASH is not come up.

Signed-off-by: sunghan-chang <sh924.chang@samsung.com>