### PR TITLE
framework/messaging : Fix wrong free calling and Add condition for ms…

### DIFF
--- a/framework/src/messaging/messaging_sndinternal.c
+++ b/framework/src/messaging/messaging_sndinternal.c
@@ -148,7 +148,7 @@ int messaging_send_packet(const char *port_name, msg_send_type_t msg_type, msg_s
 	sender_pid = getpid();
 	memcpy(send_packet, &sender_pid, sizeof(pid_t));
 	/* Add data header for send type. */
-	if (msg_type == MSG_SEND_NOREPLY) {
+	if (msg_type == MSG_SEND_NOREPLY || msg_type == MSG_SEND_MULTI) {
 		send_type = MSG_REPLY_NO_REQUIRED;
 	} else if (msg_type == MSG_SEND_REPLY) {
 		send_type = MSG_SEND_REPLY;

--- a/framework/src/messaging/messaging_unicast_send.c
+++ b/framework/src/messaging/messaging_unicast_send.c
@@ -79,10 +79,10 @@ static int messaging_sync_recv(const char *port_name, msg_recv_buf_t *reply_buf)
 		ret = OK;
 	}
 
-	MSG_FREE(reply_data);
-	MSG_FREE(sync_portname);
 	mq_close(sync_mqdes);
 	mq_unlink(sync_portname);
+	MSG_FREE(reply_data);
+	MSG_FREE(sync_portname);
 
 	return ret;
 }


### PR DESCRIPTION
…g type

1. Port name should not be freed before unlinking the mq in messaging_sync_recv()
2. Multicast message type should be set to MSG_REPLY_NO_REQUIRED.