### PR TITLE
driver/seclink, board/imxrt1020-evk: fix errors of Kconfig usages

### DIFF
--- a/os/board/imxrt1020-evk/Kconfig
+++ b/os/board/imxrt1020-evk/Kconfig
@@ -113,7 +113,6 @@ config IMXRT_AUTOMOUNT_SSSRW_MOUNTPOINT
 config IMXRT_AUTOMOUNT_ROMFS
 	bool "Automount romfs partiton"
 	default y
-	select MTD_FTL
 	depends on IMXRT_AUTOMOUNT
 	depends on FS_ROMFS
 	---help---

--- a/os/drivers/seclink/Kconfig
+++ b/os/drivers/seclink/Kconfig
@@ -11,6 +11,6 @@ config SECURITY_LINK_DRV
 		Enable seclink Driver to support communication between HAL and security API.
 
 if SECURITY_LINK_DRV
-source "$FRAMEWORK_DIR/src/seclink/Kconfig""
+source "$FRAMEWORK_DIR/src/seclink/Kconfig"
 endif #SECURITY_LINK_DRV
 


### PR DESCRIPTION
This commit fixes belows:
drivers/seclink/Kconfig:14:warning: multi-line strings not supported
fs/romfs/Kconfig:6:error: recursive dependency detected!
For a resolution refer to Documentation/kbuild/kconfig-language.txt
subsection "Kconfig recursive dependency limitations"
fs/romfs/Kconfig:6:	symbol FS_ROMFS depends on MTD_FTL
For a resolution refer to Documentation/kbuild/kconfig-language.txt
subsection "Kconfig recursive dependency limitations"
fs/driver/mtd/Kconfig:63:	symbol MTD_FTL is selected by IMXRT_AUTOMOUNT_ROMFS
For a resolution refer to Documentation/kbuild/kconfig-language.txt
subsection "Kconfig recursive dependency limitations"
board/imxrt1020-evk/Kconfig:74:	symbol IMXRT_AUTOMOUNT_ROMFS depends on FS_ROMFS

Signed-off-by: sunghan-chang <sh924.chang@samsung.com>