### PR TITLE
Add MPU setting for SD-RAM kernel heap

### DIFF
--- a/os/arch/arm/src/imxrt/imxrt_mpuinit.c
+++ b/os/arch/arm/src/imxrt/imxrt_mpuinit.c
@@ -89,6 +89,11 @@ const struct mpu_region_info regions_info[] = {
 	{
 		&mpu_privintsram, (uintptr_t)__ksram_segment_start__, (uintptr_t)__ksram_segment_size__, MPU_REG_KERN_DATA,
 	},
+#ifdef CONFIG_IMXRT_SEMC_SDRAM
+	{
+		&mpu_privintsram, (uintptr_t)CONFIG_IMXRT_SDRAM_START, (uintptr_t)CONFIG_MM_KERNEL_HEAPSIZE, MPU_REG_KERN_HEAP,
+	},
+#endif
 	{
 		&mpu_userflash, (uintptr_t)__uflash_segment_start__, (uintptr_t)__uflash_segment_size__, MPU_REG_USER_CODE,
 	},
@@ -141,6 +146,7 @@ void imxrt_mpu_initialize(void)
 	int i;
 
 	for (i = 0; i < (sizeof(regions_info) / sizeof(struct mpu_region_info)); i++) {
+		lldbg("Region = %u base = 0x%x size = %u\n", regions_info[i].rgno, regions_info[i].base, regions_info[i].size);
 		regions_info[i].call(regions_info[i].rgno, regions_info[i].base, regions_info[i].size);
 	}
 

--- a/os/arch/arm/src/imxrt/mpu-reg.h
+++ b/os/arch/arm/src/imxrt/mpu-reg.h
@@ -37,20 +37,19 @@
  ****************************************************************************/
 /*
  * Region definitions for our platform
- * To provide MPU based memory protection in protected build, below four
- * definations should be defined. But they can be assigned any region
- * depending on the availability of the mpu regions in the specific chip. 
+ * We use the follwoing enum to map the MPU region type to the MPU region
+ * registers.
  */
-#define MPU_REG_KERN_CODE	MPU_REG0
-#define MPU_REG_KERN_DATA	MPU_REG1
-#define MPU_REG_USER_CODE	MPU_REG2
-#define MPU_REG_USER_DATA	MPU_REG3
-/*
- * For application memory protection we will have single mpu region with
- * app's memory range, during context switch the corresponding app's
- * memory range is set.
- */
-#define MPU_REG_APP		MPU_REG4
+enum {
+	MPU_REG_KERN_CODE,
+	MPU_REG_KERN_DATA,
+#ifdef CONFIG_IMXRT_SEMC_SDRAM
+	MPU_REG_KERN_HEAP,
+#endif
+	MPU_REG_USER_CODE,
+	MPU_REG_USER_DATA,
+	MPU_REG_APP
+};
 
 #ifndef __ASSEMBLY__
 typedef void (*fptr)(uint8_t region, uintptr_t base, size_t size);


### PR DESCRIPTION
If SD RAM is enabled, then we allocate kernel heap region on SD RAM.
This patch adds MPU protection for this heap region. Also, we will
use enum based region type to region number mapping.
