### PR TITLE
build/configs: modify esp32 link script's IROM/DROM layout

### DIFF
--- a/build/configs/esp32_DevKitC/scripts/esp32.template
+++ b/build/configs/esp32_DevKitC/scripts/esp32.template
@@ -47,7 +47,12 @@ MEMORY
 
   /* Even though the segment name is iram, it is actually mapped to flash */
 
-  iram0_2_seg (RX) :     org = 0x400D0018, len = 0x330000
+  /*
+    (0x18 offset above is a convenience for the app binary image generation. Flash cache has 64KB pages. The .bin file
+    which is flashed to the chip has a 0x18 byte file header. Setting this offset makes it simple to meet the flash
+    cache MMU's constraint that (paddr % 64KB == vaddr % 64KB).)
+  */
+  iram0_2_seg (RX) :     org = 0x400D0018, len = 0x330000-0x18
 
   /* Shared data RAM, excluding memory reserved for ROM bss/data/stack.
    * Enabling Bluetooth & Trace Memory features in menuconfig will decrease
@@ -61,8 +66,8 @@ MEMORY
                          len = 0x30000 - CONFIG_ESP32_TRACEMEM_RESERVE_DRAM - CONFIG_ESP32_BT_RESERVE_DRAM
 
   /* Flash mapped constant data */
-
-  drom0_0_seg (R) :      org = 0x3f400010, len = 0x800000
+  /* esp32 DevKitC board actually with 4MB(0x400000) SPI flash*/
+  drom0_0_seg (R) :      org = 0x3f400018, len = 0x400000-0x18
 
   /* RTC fast memory (executable). Persists over deep sleep. */
 

--- a/build/configs/esp_wrover_kit/scripts/esp32.template
+++ b/build/configs/esp_wrover_kit/scripts/esp32.template
@@ -47,7 +47,13 @@ MEMORY
 
   /* Even though the segment name is iram, it is actually mapped to flash */
 
-  iram0_2_seg (RX) :     org = 0x400D0018, len = 0x330000
+  /*
+    (0x18 offset above is a convenience for the app binary image generation. Flash cache has 64KB pages. The .bin file
+    which is flashed to the chip has a 0x18 byte file header. Setting this offset makes it simple to meet the flash
+    cache MMU's constraint that (paddr % 64KB == vaddr % 64KB).)
+  */
+
+  iram0_2_seg (RX) :     org = 0x400D0018, len = 0x330000-0x18
 
   /* Shared data RAM, excluding memory reserved for ROM bss/data/stack.
    * Enabling Bluetooth & Trace Memory features in menuconfig will decrease
@@ -62,8 +68,8 @@ MEMORY
                          len = 0x30000 - CONFIG_ESP32_TRACEMEM_RESERVE_DRAM - CONFIG_ESP32_BT_RESERVE_DRAM
 
   /* Flash mapped constant data */
-
-  drom0_0_seg (R) :      org = 0x3f400010, len = 0x800000
+  /* esp32 wrover kit board actually with 4MB(0x400000) SPI flash*/ 
+  drom0_0_seg (R) :      org = 0x3f400018, len = 0x400000-0x18
 
   /* RTC fast memory (executable). Persists over deep sleep. */
 


### PR DESCRIPTION
the main modifcation is as below.
1) modify iram0_2_seg length.
2) modify drom0_0_seg offset and length.

and the modification is  originated from esp-idf 
(1) commit id: c230e4280c039b0b709d54e974f63eed358c1c2a
Limit DROM/IROM section lengths correctly

(2) d92c541b1a75d7ced244e73b5c840511f03e348a
 esptool: Optimise generated image size by using RAM-loaded data for padding
 

