### PR TITLE
apps/examples/binary_update : Add example repetition functionality.

### DIFF
--- a/apps/examples/binary_update/binary_update_main.c
+++ b/apps/examples/binary_update/binary_update_main.c
@@ -21,13 +21,22 @@
 #include <tinyara/config.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <stdbool.h>
+#include <string.h>
+#include <unistd.h>
 #include <sys/types.h>
 
 #include <apps/system/binary_update.h>
 
-#define RELOAD_CMD             0
-#define GETINFO_CMD            1
-#define GETINFO_ALL_CMD        2
+#define APP1_NAME "micom"
+#define APP2_NAME "wifi"
+
+#define EXEC_NORMAL   0
+#define EXEC_INFINITE 1
+
+static volatile bool is_running;
+static volatile bool inf_flag = true;
+static int fail_cnt = 0;
 
 static void print_binary_info(binary_info_t *binary_info)
 {
@@ -59,10 +68,12 @@ static void binary_update_getinfo_all(void)
 	int ret;
 	binary_info_list_t bin_info_list;
 
+	printf("\n** Binary Update GETINFO_ALL test.\n");
 	ret = binary_update_get_binary_info_all(&bin_info_list);
 	if (ret == OK) {
 		print_binary_info_list(&bin_info_list);
 	} else {
+		fail_cnt++;
 		printf("Get binary info all FAIL %d\n", ret);
 	}
 }
@@ -72,6 +83,7 @@ static void binary_update_getinfo(char *name)
 	int ret;
 	binary_info_t bin_info;
 
+	printf("\n** Binary Update GETINFO [%s] test.\n", name);
 	ret = binary_update_get_binary_info(name, &bin_info);
 	if (ret == OK) {
 		print_binary_info(&bin_info);
@@ -84,6 +96,7 @@ static void binary_update_reload(char *name)
 {
 	int ret;
 
+	printf("\n** Binary Update RELOAD [%s] test.\n", name);
 	ret = binary_update_reload_binary(name);
 	if (ret == OK) {
 		printf("RELOAD [%s] SUCCESS\n", name);
@@ -92,7 +105,53 @@ static void binary_update_reload(char *name)
 	}
 }
 
+static void binary_update_run_tests(int repetition_num)
+{
+	printf("\n** Binary Update Example %d-th Iteration.\n", repetition_num);
+	binary_update_getinfo(APP1_NAME);
+	binary_update_getinfo(APP2_NAME);
+	binary_update_getinfo_all();
+	binary_update_reload(APP1_NAME);
+	binary_update_reload(APP2_NAME);
 
+	/* Wait for finishing previous test. */
+	sleep(1);
+}
+
+static void binary_update_show_success_ratio(int rep_cnt)
+{
+	printf("\n*** Binary Update Example is finished. (run %d-times)\n", rep_cnt);
+	printf(" - success : %d, fail %d\n", rep_cnt - fail_cnt, fail_cnt);
+	fail_cnt = 0;
+}
+
+static void binary_update_execute_infinitely(void)
+{
+	int repetition_num;
+
+	printf("\n** Start Binary Update Example : executes infinitely. ===\n");
+	repetition_num = 0;
+	is_running = true;
+	while (inf_flag) {
+		repetition_num++;
+		binary_update_run_tests(repetition_num);
+	}
+	binary_update_show_success_ratio(repetition_num);
+	is_running = false;
+}
+
+static void binary_update_execute_ntimes(int repetition_num)
+{
+	int loop_idx;
+	is_running = true;
+	/* binary_update example executes multiple-times. */
+	printf("\n** Binary Update example : executes %d-times.\n", repetition_num);
+	for (loop_idx = 1; loop_idx <= repetition_num; loop_idx++) {
+		binary_update_run_tests(loop_idx);
+	}
+	binary_update_show_success_ratio(repetition_num);
+	is_running = false;
+}
 /****************************************************************************
  * binary_update_main
  ****************************************************************************/
@@ -102,31 +161,77 @@ int main(int argc, FAR char *argv[])
 int binary_update_main(int argc, char *argv[])
 #endif
 {
-	int type;
+	int repetition_num = 1;
+	int option;
+	char *cmd_arg = NULL;
+	char *cnt_arg = NULL;
+	int execution_type = EXEC_NORMAL;
 
-	printf("Binary update!!\n");
-
-	if (argc <= 1) {
+	if (argc >= 4 || argc == 2) {
 		goto usage;
 	}
 
-	type = (pid_t)atoi(argv[1]);
+	while ((option = getopt(argc, argv, "r:n:")) != ERROR) {
+		switch (option) {
+		case 'r':
+			execution_type = EXEC_INFINITE;
+			cmd_arg = optarg;
+			break;
+		case 'n':
+			execution_type = EXEC_NORMAL;
+			cnt_arg = optarg;
+			break;
+		case '?':
+		default:
+			goto usage;
+		}
+	}
 
-	if (type == GETINFO_ALL_CMD && argc == 2) {
-		binary_update_getinfo_all();
-	} else if (type == GETINFO_CMD && argc == 3) {
-		binary_update_getinfo(argv[2]);
-	} else if (type == RELOAD_CMD && argc == 3) {
-		binary_update_reload(argv[2]);
+	/* Execute the binary update example. */
+	if (execution_type == EXEC_INFINITE) {
+		if (cmd_arg && strncmp(cmd_arg, "start", strlen("start") + 1) == 0) {
+			if (is_running) {
+				goto already_running;
+			}
+			inf_flag = true;
+			binary_update_execute_infinitely();
+		} else if (cmd_arg && strncmp(cmd_arg, "stop", strlen("stop") + 1) == 0) {
+			if (inf_flag == false) {
+				printf("There is no infinite running Binary Update example. Cannot stop the sample.\n");
+				return -1;
+			}
+			inf_flag = false;
+		} else {
+			goto usage;
+		}
+
 	} else {
-		goto usage;
+		if (is_running) {
+			goto already_running;
+		}
+
+		if (cnt_arg != NULL) {
+			repetition_num = atoi(cnt_arg);
+			if (repetition_num <= 0) {
+				goto usage;
+			}
+		} else {
+			repetition_num = 1;
+		}
+
+		binary_update_execute_ntimes(repetition_num);
 	}
 
 	return 0;
 usage:
-	printf("\nUsage: binary_update CMD [BINARY_NAME]\n");
-	printf("CMD \n");
-	printf("   0 : RELOAD, 1 : GETINFO, 2 : GETINFO ALL \n");
-
+	printf("\nUsage : binary_update [OPTIONS]\n");
+	printf("Options:\n");
+	printf(" -r start : Execute Binary Update Example infinitely until stop cmd.\n");
+	printf("    stop  : Stop the Binary Update Example infinite execution.\n");
+	printf(" -n COUNT : Execute Binary Update Example COUNT-iterations.\n");
+	return -1;
+already_running:
+	printf("There is already running Binary Update Example.\n");
+	printf("New sample can run after that previous example is finished.\n");
 	return -1;
 }


### PR DESCRIPTION
User can decide execution repetition count like below:
Usage : binary_update [OPTIONS]
Options:
 -r start : Execute Binary Update Example infinitely until stop cmd.
    stop  : Stop the Binary Update Example infinite execution.
 -n COUNT : Execute Binary Update Example COUNT-iterations.

Expected result for one-time execution>
```
TASH>>binary_update
** Binary Update Example : executes one-time.

** Binary Update GETINFO [micom] test.
 ========= binary [micom] info ==========
  Version | Partsize | Inactive part
 ---------------------------------------
 20190421 |   131072 | /dev/mtdblock3
 ========================================

** Binary Update GETINFO [wifi] test.
 ========= binary [wifi] info ==========
  Version | Partsize | Inactive part
 ---------------------------------------
 20190412 |   262144 | /dev/mtdblock5
 ========================================

** Binary Update GETINFO_ALL test.
 ============ ALL binary info : 3 count ==============
  Idx |   Name |  Version | Partsize | Inactive part
 ----------------------------------------------------
    0 | kernel |      2.0 |   131072 |
    1 |  micom | 20190421 |   131072 | /dev/mtdblock3
    2 |   wifi | 20190412 |   262144 | /dev/mtdblock5
 ====================================================

** Binary Update RELOAD [micom] test.
APP1 Starts
RELOAD [micom] SUCCESS

** Binary Update RELOAD [wifi] test.
APP2 Starts
RELOAD [wifi] SUCCESS

*** Binary Update Example is finished. (run 1-times)
 - success : 1, fail 0
```