### PR TITLE
apps/examples/esp32_wifi_demo: Add espressif wifi demo.

### DIFF
--- a/apps/examples/esp32_wifi_demo/Kconfig
+++ b/apps/examples/esp32_wifi_demo/Kconfig
@@ -1,0 +1,45 @@
+#
+# For a description of the syntax of this configuration file,
+# see kconfig-language at https://www.kernel.org/doc/Documentation/kbuild/kconfig-language.txt
+#
+menuconfig EXAMPLES_ESP32WIFIDEMO
+	bool "ESP32 wifi example"
+	depends on ESP32_WIFI_SUPPORT
+	default n
+	---help---
+		esp32 wifi example,it directly call esp wifi driver interface.
+
+if EXAMPLES_ESP32WIFIDEMO
+
+config ESP_WIFI_MODE_STATION
+	bool "ESP32 wifi station test"
+	default y
+	---help---
+		enable esp32 wifi station mode example, say N enable softap mode example
+
+config ESP_WIFI_SSID
+	string "WiFi SSID"
+	default "myssid"
+	---help---
+		SSID (network name) to connect to or softap network name.
+
+config ESP_WIFI_PASSWORD
+	string "WiFi Password"
+	default "mypassword"
+	---help---
+		WiFi password (WPA or WPA2) for the example to use.
+
+if ESP_WIFI_MODE_STATION
+config ESP_MAXIMUM_RETRY
+	int "Maximum retry"
+	default 5
+	---help---
+		Set the Maximum retry to avoid station reconnecting to the AP unlimited when the AP is really inexistent.
+endif
+
+config ESP_MAX_STA_CONN
+	int "Maximal STA connections"
+	default 4
+	---help---
+		Max number of the STA connects to AP.
+endif

--- a/apps/examples/esp32_wifi_demo/Make.defs
+++ b/apps/examples/esp32_wifi_demo/Make.defs
@@ -1,0 +1,21 @@
+###########################################################################
+#
+# Copyright 2019 Samsung Electronics All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+#
+###########################################################################
+
+ifeq ($(CONFIG_EXAMPLES_ESP32WIFIDEMO),y)
+CONFIGURED_APPS += examples/esp32_wifi_demo
+endif

--- a/apps/examples/esp32_wifi_demo/Makefile
+++ b/apps/examples/esp32_wifi_demo/Makefile
@@ -1,0 +1,135 @@
+###########################################################################
+#
+# Copyright 2019 Samsung Electronics All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+#
+###########################################################################
+-include $(TOPDIR)/.config
+-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
+
+
+# built-in application info
+
+APPNAME = esp32wifi
+FUNCNAME = $(APPNAME)_main
+THREADEXEC = TASH_EXECMD_ASYNC
+PRIORITY = 100
+STACKSIZE = 4096
+
+CFLAGS += -I$(TOPDIR)/../external/esp_idf_port/include
+CFLAGS += -I$(TOPDIR)/../external/esp_idf_port/log/include
+CFLAGS += -I$(TOPDIR)/../external/esp_idf_port/tcpip_adapter/include
+CFLAGS += -I$(TOPDIR)/arch/xtensa/src/esp32
+
+ASRCS =
+CSRCS =
+MAINSRC = esp32_wifi_demo.c
+
+ifeq ($(CONFIG_ESP_WIFI_MODE_STATION),y)
+	MAINSRC += station.c
+else
+	MAINSRC += softap.c
+endif
+
+AOBJS = $(ASRCS:.S=$(OBJEXT))
+COBJS = $(CSRCS:.c=$(OBJEXT))
+MAINOBJ = $(MAINSRC:.c=$(OBJEXT))
+
+SRCS = $(ASRCS) $(CSRCS) $(MAINSRC)
+OBJS = $(AOBJS) $(COBJS)
+
+ifneq ($(CONFIG_BUILD_KERNEL),y)
+  OBJS += $(MAINOBJ)
+endif
+
+ifeq ($(CONFIG_WINDOWS_NATIVE),y)
+  BIN = ..\..\libapps$(LIBEXT)
+else
+ifeq ($(WINTOOL),y)
+  BIN = ..\\..\\libapps$(LIBEXT)
+else
+  BIN = ../../libapps$(LIBEXT)
+endif
+endif
+
+ifeq ($(WINTOOL),y)
+  INSTALL_DIR = "${shell cygpath -w $(BIN_DIR)}"
+else
+  INSTALL_DIR = $(BIN_DIR)
+endif
+
+CONFIG_EXAMPLES_HELLO_PROGNAME ?= hello$(EXEEXT)
+PROGNAME = $(CONFIG_EXAMPLES_HELLO_PROGNAME)
+
+ROOTDEPPATH = --dep-path .
+
+# Common build
+
+VPATH =
+
+all: .built
+.PHONY: clean depend distclean
+
+$(AOBJS): %$(OBJEXT): %.S
+	$(call ASSEMBLE, $<, $@)
+
+$(COBJS) $(MAINOBJ): %$(OBJEXT): %.c
+	$(call COMPILE, $<, $@)
+
+.built: $(OBJS)
+	$(call ARCHIVE, $(BIN), $(OBJS))
+	@touch .built
+
+ifeq ($(CONFIG_BUILD_KERNEL),y)
+$(BIN_DIR)$(DELIM)$(PROGNAME): $(OBJS) $(MAINOBJ)
+	@echo "LD: $(PROGNAME)"
+	$(Q) $(LD) $(LDELFFLAGS) $(LDLIBPATH) -o $(INSTALL_DIR)$(DELIM)$(PROGNAME) $(ARCHCRT0OBJ) $(MAINOBJ) $(LDLIBS)
+	$(Q) $(NM) -u  $(INSTALL_DIR)$(DELIM)$(PROGNAME)
+
+install: $(BIN_DIR)$(DELIM)$(PROGNAME)
+
+else
+install:
+
+endif
+
+ifeq ($(CONFIG_BUILTIN_APPS)$(CONFIG_EXAMPLES_ESP32WIFIDEMO),yy)
+$(BUILTIN_REGISTRY)$(DELIM)$(FUNCNAME).bdat: $(DEPCONFIG) Makefile
+	$(Q) $(call REGISTER,$(APPNAME),$(FUNCNAME),$(THREADEXEC),$(PRIORITY),$(STACKSIZE))
+
+context: $(BUILTIN_REGISTRY)$(DELIM)$(APPNAME)_main.bdat
+
+else
+context:
+
+endif
+
+.depend: Makefile $(SRCS)
+	@$(MKDEP) $(ROOTDEPPATH) "$(CC)" -- $(CFLAGS) -- $(SRCS) >Make.dep
+	@touch $@
+
+depend: .depend
+
+clean:
+	$(call DELFILE, .built)
+	$(call CLEAN)
+
+distclean: clean
+	$(call DELFILE, Make.dep)
+	$(call DELFILE, .depend)
+
+-include Make.dep
+.PHONY: preconfig
+preconfig:

--- a/apps/examples/esp32_wifi_demo/esp32_wifi_demo.c
+++ b/apps/examples/esp32_wifi_demo/esp32_wifi_demo.c
@@ -1,0 +1,42 @@
+/******************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************/
+#include <tinyara/config.h>
+
+#include <stdio.h>
+#include <pthread.h>
+
+extern void wifi_station_entry(void);
+extern void wifi_softap_entry(void);
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+#ifdef CONFIG_BUILD_KERNEL
+int main(int argc, FAR char *argv[])
+#else
+int esp32wifi_main(int argc, char **args)
+{
+#ifdef CONFIG_ESP_WIFI_MODE_STATION
+	wifi_station_entry();
+#else
+	wifi_softap_entry();
+#endif
+	return 0;
+}
+#endif

--- a/apps/examples/esp32_wifi_demo/softap.c
+++ b/apps/examples/esp32_wifi_demo/softap.c
@@ -1,0 +1,100 @@
+/******************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************/
+
+/* WiFi SoftAP Example
+   This example code is in the Public Domain (or CC0 licensed, at your option.)
+   Unless required by applicable law or agreed to in writing, this
+   software is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+   CONDITIONS OF ANY KIND, either express or implied.
+*/
+#include <tinyara/config.h>
+
+#include "esp_wifi.h"
+#include "esp_log.h"
+#include "esp_event_loop.h"
+#include "esp_wifi_internal.h"
+
+static const char *TAG = "AP";
+
+static esp_err_t event_handler(void *ctx, system_event_t *event)
+{
+	switch (event->event_id) {
+	case SYSTEM_EVENT_AP_STACONNECTED:
+		ESP_LOGI(TAG, "station:" MACSTR " join, AID=%d", MAC2STR(event->event_info.sta_connected.mac), event->event_info.sta_connected.aid);
+		break;
+	case SYSTEM_EVENT_AP_STADISCONNECTED:
+		ESP_LOGI(TAG, "station:" MACSTR "leave, AID=%d", MAC2STR(event->event_info.sta_disconnected.mac), event->event_info.sta_disconnected.aid);
+		break;
+	default:
+		break;
+	}
+	return ESP_OK;
+}
+
+/* Initialize Wi-Fi as sotfap mode */
+static void wifi_init_softap(void)
+{
+	esp_err_t ret;
+	tcpip_adapter_init();
+	ret = esp_event_loop_init(event_handler, NULL);
+	if (ret) {
+		ESP_LOGI(TAG, "esp_event_loop_init failed, %d\n", ret);
+		return;
+	}
+	wifi_init_config_t cfg = WIFI_INIT_CONFIG_DEFAULT();
+	ret = esp_wifi_init(&cfg);
+	if (ret) {
+		ESP_LOGI(TAG, "esp_wifi_init failed, %d\n", ret);
+		return;
+	}
+	wifi_config_t wifi_config = {
+		.ap = {
+			.ssid = CONFIG_ESP_WIFI_SSID,
+			.ssid_len = strlen(CONFIG_ESP_WIFI_SSID),
+			.password = CONFIG_ESP_WIFI_PASSWORD,
+			.max_connection = CONFIG_ESP_MAX_STA_CONN,
+			.authmode = WIFI_AUTH_WPA_WPA2_PSK
+		}
+		,
+	};
+	if (strlen(CONFIG_ESP_WIFI_PASSWORD) == 0) {
+		wifi_config.ap.authmode = WIFI_AUTH_OPEN;
+	}
+	ret = esp_wifi_set_mode(WIFI_MODE_AP);
+	if (ret) {
+		ESP_LOGI(TAG, "esp_wifi_set_mode failed, %d\n", ret);
+		return;
+	}
+	ret = esp_wifi_set_config(ESP_IF_WIFI_AP, &wifi_config);
+	if (ret) {
+		ESP_LOGI(TAG, "esp_wifi_set_config failed, %d\n", ret);
+		return;
+	}
+	ret = esp_wifi_start();
+	if (ret) {
+		ESP_LOGI(TAG, "esp_wifi_set_start failed, %d\n", ret);
+		return;
+	}
+	ESP_LOGI(TAG, "wifi_init_softap finished.SSID:%s password:%s", CONFIG_ESP_WIFI_SSID, CONFIG_ESP_WIFI_PASSWORD);
+}
+
+void wifi_softap_entry(void)
+{
+	ESP_LOGI(TAG, "ESP_WIFI_MODE_AP");
+	wifi_init_softap();
+}

--- a/apps/examples/esp32_wifi_demo/station.c
+++ b/apps/examples/esp32_wifi_demo/station.c
@@ -1,0 +1,114 @@
+/******************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************/
+
+/* WiFi station Example
+   This example code is in the Public Domain (or CC0 licensed, at your option.)
+   Unless required by applicable law or agreed to in writing, this
+   software is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+   CONDITIONS OF ANY KIND, either express or implied.
+*/
+#include <tinyara/config.h>
+
+#include "esp_wifi.h"
+#include "esp_log.h"
+#include "esp_event_loop.h"
+#include "esp_wifi_internal.h"
+
+/*
+ The examples use WiFi configuration that you can set via 'make menuconfig'.
+*/
+
+static const char *TAG = "station";
+static int s_retry_num = 0;
+
+static esp_err_t event_handler(void *ctx, system_event_t *event)
+{
+	switch (event->event_id) {
+	case SYSTEM_EVENT_STA_START:
+		ESP_LOGI(TAG, "SYSTEM_EVENT_STA_START");
+		if (esp_wifi_connect()) {
+			ESP_LOGI(TAG, "esp_wifi_connect failed\n");
+		}
+		break;
+	case SYSTEM_EVENT_STA_GOT_IP:
+		ESP_LOGI(TAG, "SYSTEM_EVENT_STA_GOT_IP");
+		ESP_LOGI(TAG, "Got IP: %s\n", ip4addr_ntoa(&event->event_info.got_ip.ip_info.ip));
+		break;
+	case SYSTEM_EVENT_STA_DISCONNECTED:
+		ESP_LOGI(TAG, "SYSTEM_EVENT_STA_DISCONNECTED");
+		if (s_retry_num < CONFIG_ESP_MAXIMUM_RETRY) {
+			esp_wifi_connect();
+			s_retry_num++;
+			ESP_LOGI(TAG, "retry to connect to the AP");
+		}
+		ESP_LOGI(TAG, "connect to the AP fail\n");
+		break;
+	default:
+		break;
+	}
+	return ESP_OK;
+}
+
+/* Initialize Wi-Fi as sta*/
+static void do_wifi_scan(void)
+{
+	esp_err_t ret;
+	tcpip_adapter_init();
+	ret = esp_event_loop_init(event_handler, NULL);
+	if (ret) {
+		ESP_LOGI(TAG, "esp_event_loop_init failed, %d\n", ret);
+		return;
+	}
+
+	wifi_init_config_t cfg = WIFI_INIT_CONFIG_DEFAULT();
+	ret = esp_wifi_init(&cfg);
+	if (ret) {
+		ESP_LOGI(TAG, "esp_wifi_init failed, %d\n", ret);
+		return;
+	}
+	esp_wifi_internal_set_log_level(WIFI_LOG_VERBOSE);
+	esp_wifi_internal_set_log_mod(WIFI_LOG_MODULE_ALL, WIFI_LOG_MODULE_ALL | WIFI_LOG_SUBMODULE_INIT | WIFI_LOG_SUBMODULE_IOCTL | WIFI_LOG_SUBMODULE_CONN | WIFI_LOG_SUBMODULE_SCAN, true);
+
+	wifi_config_t wifi_config = {
+		.sta = {
+			.ssid = CONFIG_ESP_WIFI_SSID,
+			.password = CONFIG_ESP_WIFI_PASSWORD,
+		}
+		,
+	};
+	ret = esp_wifi_set_mode(WIFI_MODE_STA);
+	if (ret) {
+		ESP_LOGI(TAG, "esp_wifi_set_mode failed, %d\n", ret);
+		return;
+	}
+	ret = esp_wifi_set_config(ESP_IF_WIFI_STA, &wifi_config);
+	if (ret) {
+		ESP_LOGI(TAG, "esp_wifi_set_config failed, %d\n", ret);
+		return;
+	}
+	ret = esp_wifi_start();
+	if (ret) {
+		return;
+	}
+}
+
+void wifi_station_entry(void)
+{
+	ESP_LOGI(TAG, "ESP_WIFI_MODE_STATION");
+	do_wifi_scan();
+}


### PR DESCRIPTION
Add espressif esp32 wifi demo program, this code directly call
wifi driver interface instead of TizenRT WiFi Manager. Adding it
helps debug wifi defect.

it mainly implement below function:
1) if choose station mode, configure proper AP ssid and passwd,
it can connect to AP  and get ip address (DHCP)

2) if choose softap mode,  it runs as AP with configured AP ssid and passwd.
then other client can connect it if know the passwd, and can assign ip to connect client. (DHCP)