### PR TITLE
arch/imxrt: split hprtc conditional from lpsrtc in Make.defs

### DIFF
--- a/os/arch/arm/src/imxrt/Make.defs
+++ b/os/arch/arm/src/imxrt/Make.defs
@@ -157,8 +157,8 @@ endif
 
 ifeq ($(CONFIG_IMXRT_SNVS_LPSRTC),y)
 CHIP_CSRCS += imxrt_lpsrtc.c
-CHIP_CSRCS += imxrt_hprtc.c
-else ifeq ($(CONFIG_IMXRT_SNVS_HPRTC),y)
+endif
+ifeq ($(CONFIG_IMXRT_SNVS_HPRTC),y)
 CHIP_CSRCS += imxrt_hprtc.c
 endif
 


### PR DESCRIPTION
When LPSRTC is enabled, its config enables hprtc by selecting.
It means that Make.defs does not need the hprtc file to include
compilation under lpsrtc. Make.defs can include hprtc under hprtc
conditional.

Signed-off-by: sunghan-chang <sh924.chang@samsung.com>