### PR TITLE
Makefile: rename BIN_DIR to OUTBIN_DIR at os side

### DIFF
--- a/docs/HowToAddStaticLibrary.md
+++ b/docs/HowToAddStaticLibrary.md
@@ -20,7 +20,7 @@ EXTRA_LIBS += chip/abc/libnew.a
 
 This change makes it add to TizenRT binary by Makefile which is at *os/arch/arm/src* folder.
 ```
-$(BIN_DIR)/tinyara$(EXEEXT): $(HEAD_OBJ) board/libboard$(LIBEXT)
+$(OUTBIN_DIR)/tinyara$(EXEEXT): $(HEAD_OBJ) board/libboard$(LIBEXT)
 	$(Q) echo "LD: tinyara"
 	$(Q) $(LD) --entry=__start $(LDFLAGS) $(LIBPATHS) $(EXTRA_LIBPATHS) \
 		-o $(TINYARA) $(HEAD_OBJ) $(EXTRA_OBJS) \

--- a/os/Makefile.unix
+++ b/os/Makefile.unix
@@ -123,7 +123,7 @@ TOOLSDIR := ${shell if [ -r $(CONFIG_TOOLS_DIR)/Makefile ]; then echo "$(CONFIG_
 BUILD_DIR = ../build
 OUTPUT_DIR = $(BUILD_DIR)/output
 LIBRARIES_DIR = $(OUTPUT_DIR)/libraries
-BIN_DIR = $(OUTPUT_DIR)/bin
+OUTBIN_DIR = $(OUTPUT_DIR)/bin
 LIB_DIR = ../lib
 
 # Add-on directories.  These may or may not be in place in the
@@ -227,7 +227,7 @@ endif
 # This is the name of the final target (relative to the top level directorty)
 
 BIN_EXE = tinyara$(EXEEXT)
-BIN = $(BIN_DIR)/$(BIN_EXE)
+BIN = $(OUTBIN_DIR)/$(BIN_EXE)
 
 memstat: $(BIN) romfs
 
@@ -383,8 +383,8 @@ dirlinks: include/arch include/arch/board include/arch/chip $(ARCH_SRC)/board $(
 
 context: check_context include/tinyara/config.h include/tinyara/version.h include/math.h include/float.h include/stdarg.h dirlinks
 	$(Q)if [ -e ${BIN} ]; then \
-		echo "Previous Build Outputs - $(BIN_DIR) - are deleted"; \
-		rm -rf ${BIN_DIR}/*; \
+		echo "Previous Build Outputs - $(OUTBIN_DIR) - are deleted"; \
+		rm -rf ${OUTBIN_DIR}/*; \
 	fi
 	$(Q) for dir in $(CONTEXTDIRS) ; do \
 		$(MAKE) -C $$dir TOPDIR="$(TOPDIR)" EXTDIR="$(EXTDIR)" context; \
@@ -461,7 +461,7 @@ endif
 pass2deps: pass2dep $(TINYARALIBS)
 
 pass2: pass2deps
-	$(Q) $(MAKE) -C $(ARCH_SRC) TOPDIR="$(TOPDIR)" BIN_DIR="$(BIN_DIR)" LIBRARIES_DIR="$(LIBRARIES_DIR)" EXTRA_OBJS="$(EXTRA_OBJS)" LINKLIBS="$(LINKLIBS)" EXTRADEFINES=$(KDEFINE) $(BIN)
+	$(Q) $(MAKE) -C $(ARCH_SRC) TOPDIR="$(TOPDIR)" OUTBIN_DIR="$(OUTBIN_DIR)" LIBRARIES_DIR="$(LIBRARIES_DIR)" EXTRA_OBJS="$(EXTRA_OBJS)" LINKLIBS="$(LINKLIBS)" EXTRADEFINES=$(KDEFINE) $(BIN)
 	$(Q) if [ -w /tftpboot ] ; then \
 		cp -f $(BIN) /tftpboot/$(BIN_EXE).${CONFIG_ARCH}; \
 	fi
@@ -481,7 +481,7 @@ ifeq ($(CONFIG_UBOOT_UIMAGE),y)
 	fi
 endif
 ifeq ($(CONFIG_DEBUG_DISPLAY_SYMBOL),y)
-	cp ${BIN_DIR}/System.map ${TOOLSDIR}/fs/contents/System.map
+	cp ${OUTBIN_DIR}/System.map ${TOOLSDIR}/fs/contents/System.map
 else
 	$(call DELFILE, ${TOOLSDIR}/fs/contents/System.map)
 endif
@@ -597,7 +597,7 @@ ifeq ($(CONFIG_BUILD_2PASS),y)
 endif
 
 clean: subdir_clean
-	$(call DELFILE, $(BIN_DIR)/*)
+	$(call DELFILE, $(OUTBIN_DIR)/*)
 	$(call DELFILE, _SAVED_APPS_config)
 	$(call DELFILE, tinyara-export*)
 	$(call DELFILE, tinyara_user*)

--- a/os/Makefile.win
+++ b/os/Makefile.win
@@ -103,7 +103,7 @@ EXTDIR := ${shell if exist "$(CONFIG_EXTERNAL_DIR)\Makefile" echo $(CONFIG_EXTER
 BUILD_DIR = ..\build
 OUTPUT_DIR = $(BUILD_DIR)\output
 LIBRARIES_DIR = $(OUTPUT_DIR)\libraries
-BIN_DIR = $(OUTPUT_DIR)\bin
+OUTBIN_DIR = $(OUTPUT_DIR)\bin
 LIB_DIR = ..\lib
 
 # Add-on directories.  These may or may not be in place in the
@@ -194,7 +194,7 @@ endif
 # This is the name of the final target (relative to the top level directorty)
 
 BIN_EXE = tinyara$(EXEEXT)
-BIN = $(BIN_DIR)\$(BIN_EXE)
+BIN = $(OUTBIN_DIR)\$(BIN_EXE)
 
 all: $(BIN)
 .PHONY: context clean_context check_context configenv config oldconfig menuconfig export subdir_clean clean subdir_distclean distclean apps_clean apps_distclean
@@ -381,8 +381,8 @@ dirlinks: include\arch include\arch\board include\arch\chip $(ARCH_SRC)\board $(
 
 context: check_context include\tinyara\config.h include\tinyara\version.h include\math.h include\float.h include\stdarg.h dirlinks
 	$(Q) if exist $(BIN) (
-		echo "Previous Build Outputs - $(BIN_DIR) - are deleted"
-		$(call DELFILE, $(BIN_DIR)\*.*)
+		echo "Previous Build Outputs - $(OUTBIN_DIR) - are deleted"
+		$(call DELFILE, $(OUTBIN_DIR)\*.*)
 	)
 	$(Q) for %%G in ($(CONTEXTDIRS)) do ( $(MAKE) -C %%G TOPDIR="$(TOPDIR)" context )
 	$(call DELFILE, $(APPDIR)\builtin\registry\*.?dat)
@@ -454,7 +454,7 @@ endif
 pass2deps: pass2dep $(TINYARALIBS)
 
 pass2: pass2deps
-	$(Q) $(MAKE) -C $(ARCH_SRC) TOPDIR="$(TOPDIR)" BIN_DIR="$(BIN_DIR)" LIBRARIES_DIR="$(LIBRARIES_DIR)" EXTRA_OBJS="$(EXTRA_OBJS)" LINKLIBS="$(LINKLIBS)" EXTRADEFINES=$(KDEFINE) $(BIN)
+	$(Q) $(MAKE) -C $(ARCH_SRC) TOPDIR="$(TOPDIR)" OUTBIN_DIR="$(OUTBIN_DIR)" LIBRARIES_DIR="$(LIBRARIES_DIR)" EXTRA_OBJS="$(EXTRA_OBJS)" LINKLIBS="$(LINKLIBS)" EXTRADEFINES=$(KDEFINE) $(BIN)
 ifeq ($(CONFIG_INTELHEX_BINARY),y)
 	@echo "CP: $(BIN_EXE).hex"
 	$(Q) $(OBJCOPY) $(OBJCOPYARGS) -O ihex $(BIN) $(BIN).hex
@@ -548,7 +548,7 @@ ifeq ($(CONFIG_BUILD_2PASS),y)
 endif
 
 clean: subdir_clean
-	$(call DELFILE, $(BIN_DIR)\*)
+	$(call DELFILE, $(OUTBIN_DIR)\*)
 	$(call DELFILE, _SAVED_APPS_config)
 	$(call DELFILE, tinyara-export*)
 	$(call DELFILE, tinyara_user*)

--- a/os/arch/arm/src/Makefile
+++ b/os/arch/arm/src/Makefile
@@ -73,7 +73,7 @@ endif
 
 ifeq ($(CONFIG_WINDOWS_NATIVE),y)
   ARCH_SRCDIR = $(TOPDIR)\arch\$(CONFIG_ARCH)\src
-  TINYARA = "$(TOPDIR)\$(BIN_DIR)\tinyara$(EXEEXT)"
+  TINYARA = "$(TOPDIR)\$(OUTBIN_DIR)\tinyara$(EXEEXT)"
   CFLAGS += -I$(ARCH_SRCDIR)\chip
   CFLAGS += -I$(ARCH_SRCDIR)\common
   CFLAGS += -I$(ARCH_SRCDIR)\$(ARCH_SUBDIR)
@@ -81,13 +81,13 @@ ifeq ($(CONFIG_WINDOWS_NATIVE),y)
 else
   ARCH_SRCDIR = $(TOPDIR)/arch/$(CONFIG_ARCH)/src
 ifeq ($(WINTOOL),y)
-  TINYARA = "${shell cygpath -w $(TOPDIR)/$(BIN_DIR)/tinyara$(EXEEXT)}"
+  TINYARA = "${shell cygpath -w $(TOPDIR)/$(OUTBIN_DIR)/tinyara$(EXEEXT)}"
   CFLAGS += -I "${shell cygpath -w $(ARCH_SRCDIR)/chip}"
   CFLAGS += -I "${shell cygpath -w $(ARCH_SRCDIR)/common}"
   CFLAGS += -I "${shell cygpath -w $(ARCH_SRCDIR)/$(ARCH_SUBDIR)}"
   CFLAGS += -I "${shell cygpath -w $(TOPDIR)/kernel}"
 else
-  TINYARA = "$(TOPDIR)/$(BIN_DIR)/tinyara$(EXEEXT)"
+  TINYARA = "$(TOPDIR)/$(OUTBIN_DIR)/tinyara$(EXEEXT)"
   CFLAGS += -I$(ARCH_SRCDIR)/chip
   CFLAGS += -I$(ARCH_SRCDIR)/common
   CFLAGS += -I$(ARCH_SRCDIR)/$(ARCH_SUBDIR)
@@ -191,7 +191,7 @@ $(UBIN): $(UOBJS)
 board$(DELIM)libboard$(LIBEXT):
 	$(Q) $(MAKE) -C board TOPDIR="$(TOPDIR)" libboard$(LIBEXT) EXTRADEFINES=$(EXTRADEFINES)
 
-$(BIN_DIR)/tinyara$(EXEEXT): $(HEAD_OBJ) board/libboard$(LIBEXT)
+$(OUTBIN_DIR)/tinyara$(EXEEXT): $(HEAD_OBJ) board/libboard$(LIBEXT)
 	$(Q) echo "LD: tinyara"
 	$(Q) $(LD) --entry=__start $(LDFLAGS) $(LIBPATHS) $(EXTRA_LIBPATHS) \
 		-o $(TINYARA) $(HEAD_OBJ) $(EXTRA_OBJS) \
@@ -199,7 +199,7 @@ $(BIN_DIR)/tinyara$(EXEEXT): $(HEAD_OBJ) board/libboard$(LIBEXT)
 ifneq ($(CONFIG_WINDOWS_NATIVE),y)
 	$(Q) $(NM) $(TINYARA) | \
 	grep -v '\(compiled\)\|\(\$(OBJEXT)$$\)\|\( [aUw] \)\|\(\.\.ng$$\)\|\(LASH[RL]DI\)' | \
-	sort > $(TOPDIR)/$(BIN_DIR)/System.map
+	sort > $(TOPDIR)/$(OUTBIN_DIR)/System.map
 endif
 
 # This is part of the top-level export target

--- a/os/arch/xtensa/src/Makefile
+++ b/os/arch/xtensa/src/Makefile
@@ -67,7 +67,7 @@ CXXFLAGS += $(EXTRADEFINES)
 
 ifeq ($(CONFIG_WINDOWS_NATIVE),y)
   ARCH_SRCDIR = $(TOPDIR)\arch\$(CONFIG_ARCH)\src
-  TINYARA = "$(TOPDIR)\$(BIN_DIR)\tinyara$(EXEEXT)"
+  TINYARA = "$(TOPDIR)\$(OUTBIN_DIR)\tinyara$(EXEEXT)"
   CFLAGS += -I$(ARCH_SRCDIR)\chip
   CFLAGS += -I$(ARCH_SRCDIR)\common
   CFLAGS += -I$(ARCH_SRCDIR)\$(ARCH_SUBDIR)
@@ -75,13 +75,13 @@ ifeq ($(CONFIG_WINDOWS_NATIVE),y)
 else
   ARCH_SRCDIR = $(TOPDIR)/arch/$(CONFIG_ARCH)/src
 ifeq ($(WINTOOL),y)
-  TINYARA = "${shell cygpath -w $(TOPDIR)/$(BIN_DIR)/tinyara$(EXEEXT)}"
+  TINYARA = "${shell cygpath -w $(TOPDIR)/$(OUTBIN_DIR)/tinyara$(EXEEXT)}"
   CFLAGS += -I "${shell cygpath -w $(ARCH_SRCDIR)/chip}"
   CFLAGS += -I "${shell cygpath -w $(ARCH_SRCDIR)/common}"
   CFLAGS += -I "${shell cygpath -w $(ARCH_SRCDIR)/$(ARCH_SUBDIR)}"
   CFLAGS += -I "${shell cygpath -w $(TOPDIR)/sched}"
 else
-  TINYARA = "$(TOPDIR)/$(BIN_DIR)/tinyara$(EXEEXT)"
+  TINYARA = "$(TOPDIR)/$(OUTBIN_DIR)/tinyara$(EXEEXT)"
   CFLAGS += -I$(ARCH_SRCDIR)/chip
   CFLAGS += -I$(ARCH_SRCDIR)/common
   CFLAGS += -I$(ARCH_SRCDIR)/$(ARCH_SUBDIR)
@@ -166,7 +166,7 @@ libarch$(LIBEXT): $(OBJS)
 board/libboard$(LIBEXT):
 	$(Q) $(MAKE) -C board TOPDIR="$(TOPDIR)" all EXTRADEFINES=$(EXTRADEFINES)
 
-$(BIN_DIR)/tinyara$(EXEEXT): $(STARTUP_OBJS) board/libboard$(LIBEXT)
+$(OUTBIN_DIR)/tinyara$(EXEEXT): $(STARTUP_OBJS) board/libboard$(LIBEXT)
 	$(Q) echo "LD: tinyara"
 	$(Q) $(LD) --entry=__start $(LDFLAGS) $(LIBPATHS) $(EXTRA_LIBPATHS) \
 		-o $(TINYARA) $(STARTUP_OBJS) $(EXTRA_OBJS) \
@@ -174,7 +174,7 @@ $(BIN_DIR)/tinyara$(EXEEXT): $(STARTUP_OBJS) board/libboard$(LIBEXT)
 ifneq ($(CONFIG_WINDOWS_NATIVE),y)
 	$(Q) $(NM) $(TINYARA) | \
 	grep -v '\(compiled\)\|\(\$(OBJEXT)$$\)\|\( [aUw] \)\|\(\.\.ng$$\)\|\(LASH[RL]DI\)' | \
-	sort > $(TOPDIR)/$(BIN_DIR)/System.map
+	sort > $(TOPDIR)/$(OUTBIN_DIR)/System.map
 endif
 
 # This is part of the top-level export target


### PR DESCRIPTION
APP's Makefile uses BIN_DIR to save installable application
binary with Kernel build. It is duplicated with BIN_DIR of
Makefile.unix. Let's rename BIN_DIR to OUTBIN_DIR at os side.

Signed-off-by: sunghan-chang <sh924.chang@samsung.com>