### PR TITLE
kernel/group: use group_free to release memory allocated for group streamlist

### DIFF
--- a/lib/libc/misc/lib_stream.c
+++ b/lib/libc/misc/lib_stream.c
@@ -183,9 +183,11 @@ void lib_stream_release(FAR struct task_group_s *group)
 
 		if (stream->fs_bufstart != NULL && (stream->fs_flags & __FS_FLAG_UBF) == 0) {
 #ifndef CONFIG_BUILD_KERNEL
-			/* Release memory from the user heap */
+			/* Release memory appropriate previously allocated via group_malloc()
+			 * using the appropriate memory manager.
+			 */
 
-			sched_ufree(stream->fs_bufstart);
+			group_free(group, stream->fs_bufstart);
 #else
 			/* If the exiting group is unprivileged, then it has an address
 			 * environment.  Don't bother to release the memory in this case...


### PR DESCRIPTION
In protected build or kernel build, the stream list is allocated at user or kernel heap according to privilege of group.
It should be released by appropriate memory manager by calling group_free.