### PR TITLE
kernel/binary_manager: remove binary recovery thread

### DIFF
--- a/os/kernel/binary_manager/binary_manager.c
+++ b/os/kernel/binary_manager/binary_manager.c
@@ -117,7 +117,9 @@ int binary_manager(int argc, char *argv[])
 	int ret;
 	int nbytes;
 	sigset_t sigset;
-	loading_data_t loading_data;
+	char type_str[1];
+	char data_str[1];
+	char *loading_data[LOADTHD_ARGC + 1];
 	binmgr_request_t request_msg;
 
 	struct mq_attr attr;
@@ -140,7 +142,10 @@ int binary_manager(int argc, char *argv[])
 	}
 
 	/* Execute loading thread for load all binaries */
-	ret = binary_manager_loading(LOADCMD_LOAD_ALL, NULL);
+	loading_data[0] = itoa(LOADCMD_LOAD_ALL, type_str, 10);
+	loading_data[1] = NULL;
+
+	ret = binary_manager_loading(loading_data);
 	if (ret <= 0) {
 		bmdbg("Failed to create loading thread\n");
 		goto binary_manager_exit;
@@ -174,9 +179,13 @@ int binary_manager(int argc, char *argv[])
 			ret = binary_manager_get_info_all(request_msg.requester_pid);
 			break;
 		case BINMGR_RELOAD:
-			loading_data.pid = request_msg.requester_pid;
-			loading_data.bin_name = request_msg.bin_name;
-			ret = binary_manager_loading(LOADCMD_RELOAD, &loading_data);
+			memset(type_str, 0, 1);
+			memset(data_str, 0, 1);
+			loading_data[0] = itoa(LOADCMD_RELOAD, type_str, 10);
+			loading_data[1] = itoa(request_msg.requester_pid, data_str, 10);
+			loading_data[2] = request_msg.bin_name;
+			loading_data[3] = NULL;
+			ret = binary_manager_loading(loading_data);
 			break;
 
 		default:

--- a/os/kernel/binary_manager/binary_manager.h
+++ b/os/kernel/binary_manager/binary_manager.h
@@ -35,13 +35,6 @@
 #define BINARY_MANAGER_STACKSIZE   2048                       /* Binary manager main thread stack size */
 #define BINARY_MANAGER_PRIORITY    225                        /* Binary manager main thread priority */
 
-#ifdef CONFIG_BINMGR_RECOVERY
-/* Recovery Thread information */
-#define RECOVERYTHD_NAME           "recovery_thread"          /* Recovery thread name */
-#define RECOVERYTHD_STACKSIZE      2048                       /* Recovery thread stack size */
-#define RECOVERYTHD_PRIORITY       255                        /* Recovery thread priority */
-#endif
-
 /* Loading Thread information */
 #define LOADINGTHD_NAME           "loading_thread"            /* Loading thread name */
 #define LOADINGTHD_STACKSIZE      2048                        /* Loading thread stack size */
@@ -59,20 +52,18 @@
 #define CHECKSUM_SIZE              4
 #define CRC_BUFFER_SIZE            512
 
+/* The number of arguments for loading thread */
+#define LOADTHD_ARGC     3
+
 #define BINMGR_DEVNAME_FMT         "/dev/mtdblock%d"
 
 /* Loading thread cmd types */
 enum loading_thread_cmd {
-	LOADCMD_LOAD_ALL = 0,
-	LOADCMD_RELOAD = 1,
+	LOADCMD_LOAD = 0,
+	LOADCMD_LOAD_ALL = 1,
+	LOADCMD_RELOAD = 2,
 	LOADCMD_LOAD_MAX,
 };
-
-struct loading_data_s {
-	int pid;
-	char *bin_name;
-};
-typedef struct loading_data_s loading_data_t;
 
 /* Binary data type in binary table */
 struct binmgr_bininfo_s {
@@ -131,7 +122,7 @@ void binary_manager_recovery(int pid);
 #endif
 
 int binary_manager_load_binary(int bin_idx);
-int binary_manager_loading(int type, loading_data_t *data);
+int binary_manager_loading(char *loading_data[]);
 int binary_manager_get_binary_count(void);
 int binary_manager_get_index_with_binid(int bin_id);
 int binary_manager_get_info_with_name(int request_pid, char *bin_name);


### PR DESCRIPTION
Binary manager handles fault recovery without recovery thread