### PR TITLE
build/configs/imxrt1050-evk: Reduce total flash memory usage to 1MB

### DIFF
--- a/build/configs/imxrt1050-evk/loadable_elf_apps/Make.defs
+++ b/build/configs/imxrt1050-evk/loadable_elf_apps/Make.defs
@@ -139,7 +139,7 @@ AFLAGS = $(CFLAGS) -D__ASSEMBLY__
 CELFFLAGS = $(CFLAGS) -mlong-calls # --target1-abs
 CXXELFFLAGS = $(CXXFLAGS) -mlong-calls # --target1-abs
 
-LDELFFLAGS = -r -e main
+LDELFFLAGS = -r -e main -s
 
 ifeq ($(WINTOOL),y)
 	LDELFFLAGS += -T "${shell cygpath -w $(TOPDIR)/binfmt/libelf/gnu-elf.ld}"


### PR DESCRIPTION
The total flash memory used by the kenrel and app binaries is
reduced to 1MB. Kernel (128KB), User (128KB), App1 (128KB x 2),
App2 (256KB x 2).

With this change, we need to change the Flash Block size also. 
os/arch/arm/src/imxrt/imxrt_hyperflash.c

#define IMXRT_BLOCK_SIZE 0x20000
