### PR TITLE
framework/media: Remove unnecessary code and add missing break

### DIFF
--- a/apps/examples/mediaplayer/mediaplayer_main.cpp
+++ b/apps/examples/mediaplayer/mediaplayer_main.cpp
@@ -130,6 +130,7 @@ bool MyMediaPlayer::init(int test)
 			source->setPcmFormat(AUDIO_FORMAT_TYPE_S16_LE);
 			return std::move(source);
 		};
+		break;
 	case TEST_BUFFER:
 		makeSource = []() {
 			auto source = std::move(unique_ptr<BufferInputDataSource>(new BufferInputDataSource()));

--- a/framework/src/media/utils/MediaUtils.cpp
+++ b/framework/src/media/utils/MediaUtils.cpp
@@ -322,14 +322,13 @@ bool header_parsing(FILE *fp, audio_type_t audioType, unsigned int *channel, uns
 				ret = fseek(fp, -1, SEEK_CUR);
 				if (ret != OK) {
 					meddbg("file seek failed errno : %d\n", errno);
-					free(header);
 					return false;
 				}
 			}
 		}
 		if (isHeader) {
 			header = (unsigned char *)malloc(sizeof(unsigned char) * (MP3_HEADER_LENGTH + 1));
-			
+
 			if (header == NULL) {
 				meddbg("malloc failed error\n");
 				return false;


### PR DESCRIPTION
1. Trying to free an uninitialized pointer `header` is dangerous.
2. Add missing `break`.