### PR TITLE
tools/nxfuse: Add support for generating smartfs image

### DIFF
--- a/build/configs/imxrt1020-evk/imxrt1020-evk_download.sh
+++ b/build/configs/imxrt1020-evk/imxrt1020-evk_download.sh
@@ -98,6 +98,7 @@ function get_executable_name()
 		app) echo "tinyara_user.bin";;
 		micom) echo "micom";;
 		wifi) echo "wifi";;
+		userfs) echo "imxrt1020-evk_smartfs.bin";;
 		*) echo "No Binary Match"
 		exit 1
 	esac
@@ -111,6 +112,14 @@ function get_partition_index()
 		app | App | APP) echo "1";;
 		micom | Micom | MICOM) echo "2";;
 		wifi | Wifi | WIFI) echo "4";;
+		userfs | Userfs | USERFS)
+		for i in "${!parts[@]}"
+		do
+		   if [[ "${parts[$i]}" = "userfs" ]]; then
+			echo $i
+		   fi
+		done
+		;;
 		*) echo "No Matching Partition"
 		exit 1
 	esac

--- a/os/Makefile.unix
+++ b/os/Makefile.unix
@@ -231,7 +231,7 @@ BIN = $(OUTBIN_DIR)/$(BIN_EXE)
 memstat: $(BIN) romfs
 
 all: memstat
-.PHONY: context clean_context check_context config oldconfig menuconfig nconfig qconfig gconfig export subdir_clean clean subdir_distclean distclean apps_clean apps_distclean force_build applist appupdate
+.PHONY: context clean_context check_context config oldconfig menuconfig nconfig qconfig gconfig export subdir_clean clean subdir_distclean distclean apps_clean apps_distclean force_build applist appupdate smartfs
 
 # Target used to copy include/tinyara/math.h.  If CONFIG_ARCH_MATH_H is
 # defined, then there is an architecture specific math.h header file
@@ -705,3 +705,11 @@ tools/compression/mkcompresstool.sh: include/tinyara/config.h
 ifeq ($(CONFIG_COMPRESSED_BINARY),y)
 	$(Q) tools/compression/mkcompresstool.sh
 endif
+
+# smartfs
+#
+# The smartfs target will make a smartfs image by calling mksmartfsimg.sh and mknxfuse.sh
+# Contents need to be placed in $(TOPDIR)/../tools/fs/contents/$BOARDNAME/base-files folder
+smartfs: include/tinyara/config.h
+	$(Q) ./../tools/nxfuse/mknxfuse.sh
+	$(Q) tools/mksmartfsimg.sh

--- a/os/include/debug.h
+++ b/os/include/debug.h
@@ -68,14 +68,25 @@
  ****************************************************************************/
 
 #include <tinyara/config.h>
+#ifndef NXFUSE_HOST_BUILD
 #include <tinyara/compiler.h>
 #include <tinyara/logm.h>
+#endif
 
 #include <syslog.h>
 
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
+#ifdef NXFUSE_HOST_BUILD
+#define FAR
+#define DEBUGASSERT(x)
+#define ASSERT(x) DEBUGASSERT(x)
+#define OK    0
+#define ERROR 1
+
+int get_errno(void);
+#endif
 
 /* Debug macros to runtime filter the debug messages sent to the console.  In
  * general, there are four forms of the debug macros:

--- a/os/include/tinyara/fs/fs.h
+++ b/os/include/tinyara/fs/fs.h
@@ -57,7 +57,9 @@
  ****************************************************************************/
 
 #include <tinyara/config.h>
+#ifndef NXFUSE_HOST_BUILD
 #include <tinyara/compiler.h>
+#endif
 
 #include <sys/types.h>
 #include <stdarg.h>
@@ -94,6 +96,10 @@
 #ifdef CONFIG_FS_TMPFS
 #define TMPFS_FSTYPE "tmpfs"
 #define TMPFS_MOUNT_POINT "/tmp"
+#endif
+#ifdef NXFUSE_HOST_BUILD
+#define  O_WROK    1
+#define  O_RDOK    2
 #endif
 
 /****************************************************************************
@@ -282,6 +288,9 @@ struct inode {
 struct file {
 	int f_oflags;				/* Open mode flags */
 	off_t f_pos;				/* File position */
+#ifdef NXFUSE_HOST_BUILD
+	off_t f_seekpos;                        /* File seek position */
+#endif
 	FAR struct inode *f_inode;	/* Driver interface */
 	void *f_priv;				/* Per file driver private data */
 };

--- a/os/include/tinyara/fs/ioctl.h
+++ b/os/include/tinyara/fs/ioctl.h
@@ -123,7 +123,9 @@
 
 /* Terminal I/O IOCTL definitions are retained in tioctl.h */
 
+#ifndef NXFUSE_HOST_BUILD
 #include <tinyara/serial/tioctl.h>
+#endif
 
 /* Watchdog driver ioctl commands *******************************************/
 

--- a/os/include/tinyara/fs/mtd.h
+++ b/os/include/tinyara/fs/mtd.h
@@ -62,7 +62,9 @@
 #include <sys/types.h>
 #include <stdint.h>
 
+#ifndef NXFUSE_HOST_BUILD
 #include <tinyara/spi/spi.h>
+#endif
 
 /****************************************************************************
  * Pre-Processor Definitions

--- a/os/include/tinyara/math.h
+++ b/os/include/tinyara/math.h
@@ -105,7 +105,9 @@
  ****************************************************************************/
 
 #include <tinyara/config.h>
+#ifndef NXFUSE_HOST_BUILD
 #include <tinyara/compiler.h>
+#endif
 #include <fixedmath.h>
 
 /****************************************************************************

--- a/os/include/tinyara/mqueue.h
+++ b/os/include/tinyara/mqueue.h
@@ -57,7 +57,9 @@
  ****************************************************************************/
 
 #include <tinyara/config.h>
+#ifndef NXFUSE_HOST_BUILD
 #include <tinyara/compiler.h>
+#endif
 
 #include <sys/types.h>
 #include <stdint.h>

--- a/tools/nxfuse/.gitignore
+++ b/tools/nxfuse/.gitignore
@@ -1,0 +1,4 @@
+.config
+include/tinyara/config.h
+nxfuse
+

--- a/tools/nxfuse/Makefile
+++ b/tools/nxfuse/Makefile
@@ -1,0 +1,164 @@
+###########################################################################
+#
+# Copyright 2019 Samsung Electronics All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+#
+###########################################################################
+# ==========================================================================
+#   Copyright (C) 2016 Ken Pettit. All rights reserved.
+#   Author: Ken Pettit <pettitkd@gmail.com>
+#
+#   nxfuse is a Linux FUSE filesystem that allows native mounting of
+#          NuttX filesystems within Linux.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in
+#    the documentation and/or other materials provided with the
+#    distribution.
+# 3. Neither the name NuttX nor the names of its contributors may be
+#    used to endorse or promote products derived from this software
+#    without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+# OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+# AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+# ==========================================================================
+
+.silent:
+
+-include .config
+
+TINYARADIR	?= ../../os
+
+APPNAME		= nxfuse
+
+OBJDIR		=  obj
+DEPDIR		=  dep
+SRCDIR		=  src
+
+CC		=  $(CROSS_COMPILE)gcc
+LDFLAGS		+=  -g
+LIBFILES	+=  -lm -lpthread -lfuse
+ifeq ($(RELEASE),)
+CFLAGS		+=  -g -Wall -I include -DFAR= -DTRUE=1 -DFALSE=0 -Wno-unused-value -D_FILE_OFFSET_BITS=64 -DNXFUSE_HOST_BUILD
+else
+CFLAGS		+=  -O2 -Wall -I include -DFAR= -DTRUE=1 -DFALSE=0 -Wno-unused-value -D_FILE_OFFSET_BITS=64 -DNXFUSE_HOST_BUILD
+endif
+
+SOURCES		=  $(wildcard $(SRCDIR)/*.c)
+
+ifeq ($(CONFIG_FS_SMARTFS),y)
+SOURCES		+= $(wildcard $(SRCDIR)/smartfs/*.c)
+endif
+
+SRCTMP		=  $(patsubst $(SRCDIR)/%,%,$(SOURCES))
+OBJTMP		=  $(SRCTMP:.c=.o)
+OBJECTS		=  $(patsubst %,$(OBJDIR)/%,$(OBJTMP))
+DEPS		=  $(patsubst $(OBJDIR)/%.o,$(DEPDIR)/%.d,$(OBJECTS))
+CCONFIG		=  include/tinyara/config.h
+CONFIG		=  .config
+
+all: init $(APPNAME)
+
+.PHONY: init clean context depend
+init:
+	@mkdir -p $(OBJDIR)/smartfs
+	@mkdir -p $(DEPDIR)/smartfs
+
+#Include our built dependencies
+-include $(DEPS)
+
+# Create dependencies
+
+.depend: init Makefile $(CCONFIG) $(SOURCES)
+	$(Q) $(MKDEP) $(ROOTDEPPATH) "$(CC)" -- $(CFLAGS) -- $(SOURCES) >Make.dep
+	$(Q) touch $@
+
+depend: .depend
+
+# ============================================================
+# Rule for compiling source files.
+# ============================================================
+$(OBJDIR)/%.o: $(SRCDIR)/%.c
+	@echo Compiling $<
+	@$(CC) $(CFLAGS) -c -o $@ $<
+	@$(CC) -MM -MT $(OBJDIR)/$*.o $(CFLAGS) $(SRCDIR)/$*.c > $(DEPDIR)/$*.d
+
+# ========================
+# Rule to build nxfuse
+# ========================
+$(APPNAME): Makefile $(CONFIG) $(CCONFIG) $(OBJECTS)
+	@echo Linking $@
+	@$(CC) $(LDFLAGS) $(OBJECTS) $(LIBFILES) -o $@
+
+$(CCONFIG): $(TINYARADIR)/include/tinyara/config.h
+	@echo "CP: config.h"
+	@cp $(TINYARADIR)/include/tinyara/config.h include/tinyara
+
+# =================================
+# Rule to retrieve the .config file
+# =================================
+$(CONFIG): $(TINYARADIR)/.config
+	@echo "CP: .config"
+	@cp $(TINYARADIR)/.config .
+	@$(MAKE)
+
+# =============================
+# Rule to clean all build files
+# =============================
+.PHONY: clean
+clean:
+	@echo "=== cleaning ===";
+	@rm -rf $(OBJDIR) $(DEPDIR)
+	@rm -rf *.o
+	@rm -f $(APPNAME)
+	@rm -f $(CCONFIG)
+	@rm -f $(CONFIG)
+
+
+# ==================================
+# Rule to install nxfuse
+#
+# Note:
+#    This is a simple installation
+#    in lieu of having an actual
+#    autoconf configure script.
+#
+# This install script always installs
+# nxfuse to /usr/bin and the man
+# page to /usr/share/man/man1
+#
+# Run 'make install' with sudo
+# ==================================
+.PHONY: install
+install: $(APPNAME)
+	@echo "=== installing to /usr/bin ===";
+	@cp $(APPNAME) /usr/bin
+	@cp man/nxfuse.1 /usr/share/man/man1
+

--- a/tools/nxfuse/README.txt
+++ b/tools/nxfuse/README.txt
@@ -1,0 +1,116 @@
+nxfuse
+======
+
+A Linux FUSE implmentation that enables native mounting of TizenRT filesystems
+in Linux.  Currently the implementation supports SmartFS.  The
+Some of the Linux utilities depend on this capability (overwriting an existing file
+with new content for instance) and may fail.
+
+To build nxfuse, you must first install the libfuse-dev and fuse library as
+root:
+
+  sudo apt-get install libfuse-dev
+  sudo apt-get install fuse
+
+  sudo yum install libfuse-dev
+  sudo yum install fuse
+  etc.
+
+Then just type 'make' within the smartfuse directory.  This project does
+not contain an autoconf configuration script.  It was developed under
+Ubuntu and so it may need slight modifications for other distributions.
+
+To compile correctly, all of the the TizenRT FS and support code that has
+been copied from the TizenRT source directory depends on a valid config.h file
+to define the system configuration.  The make system automatically copies
+this config file from the Tinyara directory $(TINYARADIR) of a pre-configured
+NuttX build into the nxfuse/include/nuttx directory.  If the TINYARADIR variable
+is not define, the Makefile will use the default value of "../../os",
+which makes the assumption that the NuttX tools repo is located at the same
+directory level as the main "nuttx" source repo.
+
+To enable / disable SmartFS features (wear leveling, CRC, etc.) in the
+nxfuse implementation, run the 'make menuconfig' routine from within the nuttx
+directory and select the features required.  Then run 'make context' within
+the nuttx directory.  The newly generated tinyara/include/tinyara/config.h file
+will be copied to the tools/nxfuse/include/tinyara directory when the nxfuse is
+next built.
+
+
+Using nxfuse
+============
+
+To use nxfuse, invoke it directly from within the nxfuse directory or run the
+'make install' command as root (or sudo) to install it in /usr/bin.  The
+invocation format for nxfuse is:
+
+   nxfuse [options] [-t fstype] [fuse_options] mount_dir data_source
+
+The mount_dir must already exist in the Linux filesystem as a normal directory.
+For details about the options, see the man page (automatically installed by the
+'make install' target).  To view the man page without installing it, simply
+use the command 'man -l man/nxfuse.1'.  The default options for nxfuse are:
+
+   fstype:       smartfs
+   erasesize:    Set by CONFIG_FILEMTD_ERASESIZE in the config file
+   pagesize:     Set by CONFIG_FILEMTD_BLOCKSIZE in the config file
+   logsectsize:  Set by CONFIG_MTD_SMART_SECTOR_SIZE in config file
+
+An example invocation might be:
+
+   ./nxfuse -t smartfs /tmp/fuse /tmp/smartfs_data_file.bin
+
+For a list of fuse_options that are supported, add the -h option to the command
+line as follows:
+
+   ./nxfuse -h /tmp/fuse /tmp/smartfs_data_file.bin
+
+When using nxfuse with a block device, such as /dev/sdb, etc. the nxfuse
+command will likely need to be executed with 'sudo' access.  Doing this will
+cause the resuling mount (e.g. /tmp/fuse) to be inaccesable to anyone but
+root.  To get around this, the fuse_option "-o allow_other" can be used on the
+nxfuse command line.  This will cause the mounted directory to be setup
+with "rwxrwxrwx" permissions, allowing any user to access the mount.  As an
+example:
+
+   mkdir /tmp/fuse
+   sudo losetup /dev/loop0 /tmp/smartfs_data_file.bin
+   sudo ./nxfuse -o allow_other -t smartfs /tmp/fuse /dev/loop0
+   ls -l /tmp/fuse
+
+To unmount a FUSE device, use the fusermount command as follows:
+
+   fusermount -u /tmp/fuse
+
+
+Formatting / reformatting
+=========================
+
+The nxfuse command also has the ability to create (or re-create) a new
+fiilesystem within the data file (a built-in 'mkfs').  This is done by
+specifying the -m option on the command line (-m for mkfs).  When invoked
+with the -m option, the mount_point argument should be ommited, such as:
+
+   ./nxfuse -t smartfs -m /tmp/emptyfile
+
+If the target file already contains a valid filesystem, then nxfuse will
+report an error and request the addition of the -c option for confirmation
+of the re-format.  After the format is complete, the newly created filesystem
+is not mounted ... mounting must be performed as detailed above as a
+secondary step.
+
+Usage
+=========================
+
+SMARTFS file system needs to be enabled in order to use SMARTFS image. To build nxfuse, you must first install the libfuse-dev library as
+root using "sudo apt-get install libfuse-dev".
+
+1) Build Setup -> Binary Output Formats -> Enable "Make smartfs binary image" (=y)
+
+2) Board Selection -> Adjust smartfs partition size
+
+3) File Systems -> Memory Technology Device (MTD) Support -> SMART Device options ->  set "SMART Device sector size" = (512 bytes)
+
+4) File Systems -> Memory Technology Device (MTD) Support -> SMART Device options ->  Enable "Enable Sector CRC error detection" (=y)
+
+5) Adjust blkcount in os/tools/mksmartfsimg.sh. blkcount multiplied by blksize should be equal to SMARTFS partition size.

--- a/tools/nxfuse/include/tinyara/nxfuse_kmalloc.h
+++ b/tools/nxfuse/include/tinyara/nxfuse_kmalloc.h
@@ -1,0 +1,70 @@
+/****************************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+/****************************************************************************
+ * include/tinyara/kmalloc.h
+ *
+ *   Copyright (C) 2007-2008, 2011, 2013 Gregory Nutt. All rights reserved.
+ *   Author: Gregory Nutt <gnutt@nuttx.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#ifndef __INCLUDE_NXFUSE_KMALLOC_H
+#define __INCLUDE_NXFUSE_KMALLOC_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <sys/types.h>
+#include <stdbool.h>
+#include <stdlib.h>
+
+#define kmm_malloc(s)		malloc(s)
+#define kmm_zalloc(s)		calloc(s, 1)
+#define kmm_realloc(p, s)	realloc(p, s)
+#define kmm_memalign(a, s)	memalign(a, s)
+#define kmm_free(p)		free(p)
+
+#endif							/* __INCLUDE_NXFUSE_KMALLOC_H */

--- a/tools/nxfuse/man/nxfuse.1
+++ b/tools/nxfuse/man/nxfuse.1
@@ -1,0 +1,126 @@
+.\" Manpage for nxfuse
+.TH NXFUSE "1" "January 2016" "1.2" "User Commands"
+.SH NAME
+nxfuse \- mount NuttX filesystems using FUSE
+.SH SYNOPSIS
+.B nxfuse
+[\fIOPTION\fR]... [\fIFUSE-OPTION\fR]... \fIdir\fR \fIdatasource\fR
+.PP
+.B nxfuse
+-h \fIdir\fR
+.PP
+.B nxfuse
+-m [\fIOPTION\fR]... \fIdatasource\fR
+.SH DESCRIPTION
+.\" Add any additional description here
+.PP
+Mount or create (-m option) a NuttX filesystem on \fIdatasource\fR (file or block device).
+Using the first invocation format, the NuttX filesystem contained on \fIdatasource\fR will
+be mounted as a native Linux filesystem at the mount point specified by \fIdir\fR.  As with
+any Linux mount point, this directory must exist prior to invocation of nxfuse.
+.SH OPTIONS
+.TP
+\fB\-e\fR erasesize
+set the \fIdatasource\fR erase block size
+.TP
+\fB\-g\fR fs_specific_data
+sets generic, filesystem specific data used during mkfs
+.TP
+\fB\-l\fR sectsize
+set the filesystem logical sector size
+.TP
+\fB\-m\fR
+create (mkfs) a new NuttX filesystem on \fIdatasource\fR
+.TP
+\fB\-p\fR pagesize
+set the \fIdatasource\fR page read/write size
+.TP
+\fB\-t\fR fstype
+specify the NuttX filesystem type (smartfs, nxffs, etc.)
+.TP
+\fB\-v\fR
+report the nxfuse version
+.SH FUSE-OPTIONS
+For a list of FUSE options, use the second invocation format or 'man fuse'.
+.SH GENERIC ARGUMENT
+Filesystem specifc data is passed using the -g generic data argument.  The format and meaning
+of the generic data is filesystem specific, but in general will consist of a comma separated
+list of options.  Details for currently implemented generic arguments are detailed below.
+.TP
+\fBSMARTFS\fR
+.br
+When nxfuse has been compiled with SmartFS MULTI_ROOT_DIR support, the -g generic data argument
+will be a simple integer representing the root directory number to be mounted (1-8) during
+mount operations, or the number of root directories to create during mkfs operations.
+.PD 1
+.TP 14
+\fB       nxfuse\fR -t smartfs -g 3 /tmp/smart /tmp/smartfs.bin
+Mounts directory number 3 (equivalent to /dev/smart0d3) within the /tmp/smartfs.bin file at mount point /tmp/smart.
+.LP
+.TP 14
+\fB       nxfuse\fR -t smartfs -m -c -g 4 /tmp/smartfs.bin
+Reformats /tmp/smartfs.bin with a new filesystem containing 4 root directory entries.
+.SH EXAMPLES
+.LP
+.TP
+\fBdd\fR if=/dev/zero of=/tmp/smart.bin bs=1024 count=2048
+.PD 0
+.TP
+\fBnxfuse\fR -m -t smartfs /tmp/smart.bin
+.PD 1
+.IP
+Creates a RAM based, zero-filled 2 MByte file and initializes it with a new SmartFS filesystem (mkfs).
+.LP
+.TP
+\fBnxfuse\fR -t smartfs /tmp/smart /tmp/smart.bin
+.PD 1
+.IP
+Mounts the SmartFS filesystem contained within /tmp/smart.b at the mount point /tmp/smart
+.LP
+.TP
+\fBdd\fR if=/dev/zero of=/tmp/nxffs.bin bs=1024 count=8192
+.PD 0
+.TP
+\fBmkdir\fR /tmp/nxffs
+.LP
+.TP
+\fBnxfuse\fR -t nxffs -e 32768 /tmp/nxffs /tmp/nxffs.bin
+.PD 1
+.IP
+Creates a RAM based, 8 MByte file, initializes it with a new NXFFS filesystem and mounts it at /tmp/nxffs.
+.TP
+\fBnxfuse\fR -t smartfs -e 2048 -o allow_other /tmp/smart /dev/loop0
+.PD 1
+.IP
+Mounts the SmartFS filesystem managed by the block device /dev/loop0 at the mount point /tmp/smart
+with a block erase size of 2KB.
+Since /dev/loop0 is a root acceess device, this command will likely need to be executed with sudo.
+In this case, the -o allow_other FUSE option causes FUSE to setup the mount at /tmp/smart such that it
+can be accessed by any user.
+.TP
+\fBnxfuse\fR -m -c -l 256 -e 32768 -b 256 -t smartfs /tmp/smart.bin
+.PD 1
+.IP
+Creates or re-creates a SmartFS filesystem in /tmp/smart.bin with a logical sector size of 256 bytes
+and a block erase size of 32K bytes.  This overrides whatever sizes had been compiled into nxfuse
+based on the config file that was copied from the NuttX directory.
+.LP
+.TP 14
+       NOTE:
+When mounting the /tmp/smart.bin file, the '-e 32768' and '-b 256' options will need to be
+supplied on the nxfuse command line for proper mounting.  The logical sector size is stored
+withing the SmartFS filesystem, but the erase block and page sizes of the underlying
+file-based "block device" are not.
+.SH AUTHOR
+Written by Ken Pettit.
+.SH "REPORTING BUGS"
+Report nxfuse bugs to pettitkd@gmail.com
+.SH COPYRIGHT
+Copyright \(co 2016 Ken Pettit
+.br
+License: BSD-style 3 clause license
+.br
+This is free software: you are free to change and redistribute it.
+There is NO WARRANTY, to the extent permitted by law.
+.SH "SEE ALSO"
+fusermount(2) - Unmount a FUSE filesystem

--- a/tools/nxfuse/mknxfuse.sh
+++ b/tools/nxfuse/mknxfuse.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+###########################################################################
+#
+# Copyright 2019 Samsung Electronics All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+#
+###########################################################################
+
+NXFUSE_TOOL_PATH=`test -d ${0%/*} && cd ${0%/*}; pwd`
+
+SRCDIR=$NXFUSE_TOOL_PATH/src
+DEPDIR=$NXFUSE_TOOL_PATH/dep
+OBJDIR=$NXFUSE_TOOL_PATH/obj
+SMARTFS_TMPDIR=$SRCDIR/smartfs
+BASE_DIR=$NXFUSE_TOOL_PATH/../..
+SMARTFSDIR=$BASE_DIR/os/fs/smartfs
+BASE_INCLUDE_DIR=$BASE_DIR/os/include
+DEST_INLCUDE_DIR=$NXFUSE_TOOL_PATH/include
+
+APPNAME=nxfuse
+
+echo "==========Copying Smartfs files====================="
+mkdir -p $DEST_INLCUDE_DIR
+mkdir -p $DEST_INLCUDE_DIR/sys
+mkdir -p $DEST_INLCUDE_DIR/tinyara
+mkdir -p $DEST_INLCUDE_DIR/tinyara/fs
+mkdir -p $SMARTFS_TMPDIR
+
+ln -sf $SMARTFSDIR/smartfs.h $SMARTFS_TMPDIR/smartfs.h
+ln -sf $SMARTFSDIR/smartfs_utils.c $SMARTFS_TMPDIR/smartfs_utils.c
+ln -sf $SMARTFSDIR/smartfs_smart.c $SMARTFS_TMPDIR/smartfs_smart.c
+ln -sf $SMARTFSDIR/../driver/mtd/smart.c $SMARTFS_TMPDIR/smart.c
+
+#Header Files
+ln -sf $BASE_INCLUDE_DIR/crc16.h $DEST_INLCUDE_DIR/crc16.h
+ln -sf $BASE_INCLUDE_DIR/crc32.h $DEST_INLCUDE_DIR/crc32.h
+ln -sf $BASE_INCLUDE_DIR/crc8.h $DEST_INLCUDE_DIR/crc8.h
+ln -sf $BASE_INCLUDE_DIR/debug.h $DEST_INLCUDE_DIR/debug.h
+ln -sf $BASE_INCLUDE_DIR/dirent.h $DEST_INLCUDE_DIR/dirent.h
+ln -sf $BASE_INCLUDE_DIR/fixedmath.h $DEST_INLCUDE_DIR/fixedmath.h
+ln -sf $BASE_INCLUDE_DIR/queue.h $DEST_INLCUDE_DIR/queue.h
+ln -sf $BASE_INCLUDE_DIR/sys/statfs.h $DEST_INLCUDE_DIR/sys/statfs.h
+ln -sf $BASE_INCLUDE_DIR/tinyara/math.h $DEST_INLCUDE_DIR/tinyara/math.h
+ln -sf $BASE_INCLUDE_DIR/tinyara/mqueue.h $DEST_INLCUDE_DIR/tinyara/mqueue.h
+ln -sf $BASE_INCLUDE_DIR/tinyara/fs/mtd.h $DEST_INLCUDE_DIR/tinyara/fs/mtd.h
+ln -sf $DEST_INLCUDE_DIR/tinyara/nxfuse_kmalloc.h $DEST_INLCUDE_DIR/tinyara/kmalloc.h
+ln -sf $BASE_INCLUDE_DIR/tinyara/fs/smart.h $DEST_INLCUDE_DIR/tinyara/fs/smart.h
+ln -sf $BASE_INCLUDE_DIR/tinyara/fs/smart_procfs.h $DEST_INLCUDE_DIR/tinyara/fs/smart_procfs.h
+ln -sf $BASE_INCLUDE_DIR/tinyara/fs/dirent.h $DEST_INLCUDE_DIR/tinyara/fs/dirent.h
+ln -sf $BASE_INCLUDE_DIR/tinyara/fs/ioctl.h $DEST_INLCUDE_DIR/tinyara/fs/ioctl.h
+ln -sf $BASE_INCLUDE_DIR/tinyara/fs/fs.h $DEST_INLCUDE_DIR/tinyara/fs/fs.h
+
+#Source Files
+ln -sf $BASE_DIR/lib/libc/misc/lib_crc16.c $SRCDIR/lib_crc16.c
+ln -sf $BASE_DIR/lib/libc/misc/lib_crc32.c $SRCDIR/lib_crc32.c
+ln -sf $BASE_DIR/lib/libc/misc/lib_crc8.c $SRCDIR/lib_crc8.c
+
+echo "Copying Done"
+
+echo "============Executing Make command====================="
+make -C $NXFUSE_TOOL_PATH
+
+#Waiting for make to complete
+#After build done, remove the copied source & header files
+rm -rf $SRCDIR/lib_crc*
+rm -rf $DEST_INLCUDE_DIR/crc16.h
+rm -rf $DEST_INLCUDE_DIR/crc32.h
+rm -rf $DEST_INLCUDE_DIR/crc8.h
+rm -rf $DEST_INLCUDE_DIR/debug.h
+rm -rf $DEST_INLCUDE_DIR/dirent.h
+rm -rf $DEST_INLCUDE_DIR/fixedmath.h
+rm -rf $DEST_INLCUDE_DIR/queue.h
+rm -rf $DEST_INLCUDE_DIR/sys/statfs.h
+rm -rf $DEST_INLCUDE_DIR/tinyara/math.h
+rm -rf $DEST_INLCUDE_DIR/tinyara/mqueue.h
+rm -rf $DEST_INLCUDE_DIR/tinyara/kmalloc.h
+rm -rf $DEST_INLCUDE_DIR/tinyara/fs/mtd.h
+rm -rf $DEST_INLCUDE_DIR/tinyara/fs/smart.h
+rm -rf $DEST_INLCUDE_DIR/tinyara/fs/smart_procfs.h
+rm -rf $DEST_INLCUDE_DIR/tinyara/fs/dirent.h
+rm -rf $DEST_INLCUDE_DIR/tinyara/fs/fs.h
+rm -rf $DEST_INLCUDE_DIR/tinyara/fs/ioctl.h
+
+rm -rf $DEST_INLCUDE_DIR/sys
+rm -rf $DEST_INLCUDE_DIR/tinyara/fs
+rm -rf $SMARTFS_TMPDIR
+rm -rf $DEPDIR
+rm -rf $OBJDIR
+
+echo -e "============Generated nxfuse in path ============ \nDone"

--- a/tools/nxfuse/src/filemtd.c
+++ b/tools/nxfuse/src/filemtd.c
@@ -1,0 +1,620 @@
+/****************************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+/****************************************************************************
+ * drivers/mtd/filemtd.c
+ *
+ *   Copyright (C) 2015 Ken Pettit. All rights reserved.
+ *   Author: Ken Pettit <pettitkd@gmail.com>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <tinyara/config.h>
+
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <stdint.h>
+#include <fcntl.h>
+#include <string.h>
+#include <assert.h>
+#include <errno.h>
+#include <debug.h>
+#include <unistd.h>
+#include <sys/ioctl.h>
+#include <linux/fs.h>
+
+#include <tinyara/kmalloc.h>
+#include <tinyara/fs/ioctl.h>
+#include <tinyara/fs/mtd.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+/* Configuration ************************************************************/
+
+#ifndef CONFIG_FILEMTD_BLOCKSIZE
+#define CONFIG_FILEMTD_BLOCKSIZE 512
+#endif
+
+#ifndef CONFIG_FILEMTD_ERASESIZE
+#define CONFIG_FILEMTD_ERASESIZE 4096
+#endif
+
+#ifndef CONFIG_FILEMTD_ERASESTATE
+#define CONFIG_FILEMTD_ERASESTATE 0xff
+#endif
+
+#if CONFIG_FILEMTD_ERASESTATE != 0xff && CONFIG_FILEMTD_ERASESTATE != 0x00
+#error "Unsupported value for CONFIG_FILEMTD_ERASESTATE"
+#endif
+
+#if CONFIG_FILEMTD_BLOCKSIZE > CONFIG_FILEMTD_ERASESIZE
+#error "Must have CONFIG_FILEMTD_BLOCKSIZE <= CONFIG_FILEMTD_ERASESIZE"
+#endif
+
+#undef  FILEMTD_BLKPER
+#define FILEMTD_BLKPER (CONFIG_FILEMTD_ERASESIZE / CONFIG_FILEMTD_BLOCKSIZE)
+
+#if FILEMTD_BLKPER*CONFIG_FILEMTD_BLOCKSIZE != CONFIG_FILEMTD_ERASESIZE
+#error "CONFIG_FILEMTD_ERASESIZE must be an even multiple of CONFIG_FILEMTD_BLOCKSIZE"
+#endif
+
+/****************************************************************************
+ * Private Types
+ ****************************************************************************/
+
+/* This type represents the state of the MTD device.  The struct mtd_dev_s
+ * must appear at the beginning of the definition so that you can freely
+ * cast between pointers to struct mtd_dev_s and struct file_dev_s.
+ */
+
+struct file_dev_s {
+	struct mtd_dev_s mtd;		/* MTD device */
+	int fd;						/* File descriptor of underlying file */
+	size_t nblocks;				/* Number of erase blocks */
+	size_t offset;				/* Offset from start of file */
+	size_t erasesize;			/* Offset from start of file */
+	size_t blocksize;			/* Offset from start of file */
+	size_t blkper;				/* Blocks per erase block */
+};
+
+/****************************************************************************
+ * Private Function Prototypes
+ ****************************************************************************/
+
+static ssize_t filemtd_read(FAR struct file_dev_s *priv, FAR unsigned char *buffer, size_t offsetbytes, unsigned int nbytes);
+static ssize_t filemtd_write(FAR struct file_dev_s *priv, size_t offset, FAR const void *src, size_t len);
+
+/* MTD driver methods */
+
+static int file_erase(FAR struct mtd_dev_s *dev, off_t startblock, size_t nblocks);
+static ssize_t file_bread(FAR struct mtd_dev_s *dev, off_t startblock, size_t nblocks, FAR uint8_t *buf);
+static ssize_t file_bwrite(FAR struct mtd_dev_s *dev, off_t startblock, size_t nblocks, FAR const uint8_t *buf);
+static ssize_t file_byteread(FAR struct mtd_dev_s *dev, off_t offset, size_t nbytes, FAR uint8_t *buf);
+#ifdef CONFIG_MTD_BYTE_WRITE
+static ssize_t file_bytewrite(FAR struct mtd_dev_s *dev, off_t offset, size_t nbytes, FAR const uint8_t *buf);
+#endif
+static int file_ioctl(FAR struct mtd_dev_s *dev, int cmd, unsigned long arg);
+
+extern uint64_t linux_get_block_dev_size(int fd);
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: filemtd_write
+ ****************************************************************************/
+
+static ssize_t filemtd_write(FAR struct file_dev_s *priv, size_t offset, FAR const void *src, size_t len)
+{
+	FAR const uint8_t *pin = (FAR const uint8_t *)src;
+	FAR uint8_t *pout;
+	char buf[128];
+	int buflen = 0;
+	uint8_t oldvalue;
+	uint8_t srcvalue;
+	uint8_t newvalue;
+	size_t seekpos;
+
+	/* Set the starting location in the file */
+
+	seekpos = priv->offset + offset;
+
+	while (len-- > 0) {
+		if (buflen == 0) {
+			/* Read more data from the file */
+
+			lseek(priv->fd, seekpos, SEEK_SET);
+			buflen = read(priv->fd, buf, sizeof(buf));
+			pout = (FAR uint8_t *)buf;
+		}
+
+		/* Get the source and destination values */
+
+		oldvalue = *pout;
+		srcvalue = *pin++;
+
+		/* Get the new destination value, accounting for bits that cannot be
+		 * changes because they are not in the erased state.
+		 */
+
+#if CONFIG_FILEMTD_ERASESTATE == 0xff
+		newvalue = oldvalue & srcvalue;	/* We can only clear bits */
+#else							/* CONFIG_FILEMTD_ERASESTATE == 0x00 */
+		newvalue = oldvalue | srcvalue;	/* We can only set bits */
+#endif
+
+		/* Report any attempt to change the value of bits that are not in the
+		 * erased state.
+		 */
+
+#ifdef CONFIG_DEBUG
+		if (newvalue != srcvalue) {
+			dbg("ERROR: Bad write: source=%02x dest=%02x result=%02x\n", srcvalue, oldvalue, newvalue);
+		}
+#endif
+
+		/* Write the modified value to simulated FLASH */
+
+		*pout++ = newvalue;
+		buflen--;
+
+		/* If our buffer is full, then seek back to beginning of
+		 * the file and write the buffer contents
+		 */
+
+		if (buflen == 0) {
+			lseek(priv->fd, seekpos, SEEK_SET);
+			write(priv->fd, buf, sizeof(buf));
+			seekpos += sizeof(buf);
+		}
+	}
+
+	/* Write remaining bytes */
+
+	if (buflen != 0) {
+		lseek(priv->fd, seekpos, SEEK_SET);
+		write(priv->fd, buf, sizeof(buf));
+	}
+
+	return len;
+}
+
+/****************************************************************************
+ * Name: filemtd_read
+ ****************************************************************************/
+
+static ssize_t filemtd_read(FAR struct file_dev_s *priv, FAR unsigned char *buffer, size_t offsetbytes, unsigned int nbytes)
+{
+	/* Set the starting location in the file */
+
+	lseek(priv->fd, priv->offset + offsetbytes, SEEK_SET);
+
+	return read(priv->fd, buffer, nbytes);
+}
+
+/****************************************************************************
+ * Name: file_erase
+ ****************************************************************************/
+
+static int file_erase(FAR struct mtd_dev_s *dev, off_t startblock, size_t nblocks)
+{
+	FAR struct file_dev_s *priv = (FAR struct file_dev_s *)dev;
+	size_t nbytes;
+	size_t offset;
+	char buffer[128];
+
+	DEBUGASSERT(dev);
+
+	/* Don't let the erase exceed the original size of the file */
+
+	if (startblock >= priv->nblocks) {
+		return 0;
+	}
+
+	if (startblock + nblocks > priv->nblocks) {
+		nblocks = priv->nblocks - startblock;
+	}
+
+	/* Convert the erase block to a logical block and the number of blocks
+	 * in logical block numbers
+	 */
+
+	startblock *= priv->blkper;
+	nblocks *= priv->blkper;
+
+	/* Get the offset corresponding to the first block and the size
+	 * corresponding to the number of blocks.
+	 */
+
+	offset = startblock * priv->blocksize;
+	nbytes = nblocks * priv->blocksize;
+
+	/* Then erase the data in the file */
+
+	lseek(priv->fd, priv->offset + offset, SEEK_SET);
+	memset(buffer, CONFIG_FILEMTD_ERASESTATE, sizeof(buffer));
+	while (nbytes) {
+		write(priv->fd, buffer, sizeof(buffer));
+		nbytes -= sizeof(buffer);
+	}
+
+	return OK;
+}
+
+/****************************************************************************
+ * Name: file_bread
+ ****************************************************************************/
+
+static ssize_t file_bread(FAR struct mtd_dev_s *dev, off_t startblock, size_t nblocks, FAR uint8_t *buf)
+{
+	FAR struct file_dev_s *priv = (FAR struct file_dev_s *)dev;
+	off_t offset;
+	off_t maxblock;
+	size_t nbytes;
+
+	DEBUGASSERT(dev && buf);
+
+	/* Don't let the read exceed the original size of the file */
+
+	maxblock = priv->nblocks * priv->blkper;
+	if (startblock >= maxblock) {
+		return 0;
+	}
+
+	if (startblock + nblocks > maxblock) {
+		nblocks = maxblock - startblock;
+	}
+
+	/* Get the offset corresponding to the first block and the size
+	 * corresponding to the number of blocks.
+	 */
+
+	offset = startblock * priv->blocksize;
+	nbytes = nblocks * priv->blocksize;
+
+	/* Then read the data from the file */
+
+	filemtd_read(priv, buf, offset, nbytes);
+	return nblocks;
+}
+
+/****************************************************************************
+ * Name: file_bwrite
+ ****************************************************************************/
+
+static ssize_t file_bwrite(FAR struct mtd_dev_s *dev, off_t startblock, size_t nblocks, FAR const uint8_t *buf)
+{
+	FAR struct file_dev_s *priv = (FAR struct file_dev_s *)dev;
+	off_t offset;
+	off_t maxblock;
+	size_t nbytes;
+
+	DEBUGASSERT(dev && buf);
+
+	/* Don't let the write exceed the original size of the file */
+
+	maxblock = priv->nblocks * priv->blkper;
+	if (startblock >= maxblock) {
+		return 0;
+	}
+
+	if (startblock + nblocks > maxblock) {
+		nblocks = maxblock - startblock;
+	}
+
+	/* Get the offset corresponding to the first block and the size
+	 * corresponding to the number of blocks.
+	 */
+
+	offset = startblock * priv->blocksize;
+	nbytes = nblocks * priv->blocksize;
+
+	/* Then write the data to the file */
+
+	filemtd_write(priv, offset, buf, nbytes);
+	return nblocks;
+}
+
+/****************************************************************************
+ * Name: file_byteread
+ ****************************************************************************/
+
+static ssize_t file_byteread(FAR struct mtd_dev_s *dev, off_t offset, size_t nbytes, FAR uint8_t *buf)
+{
+	FAR struct file_dev_s *priv = (FAR struct file_dev_s *)dev;
+
+	DEBUGASSERT(dev && buf);
+
+	/* Don't let read read past end of buffer */
+
+	if (offset + nbytes > priv->nblocks * priv->erasesize) {
+		return 0;
+	}
+
+	filemtd_read(priv, buf, offset, nbytes);
+	return nbytes;
+}
+
+/****************************************************************************
+ * Name: file_bytewrite
+ ****************************************************************************/
+
+#ifdef CONFIG_MTD_BYTE_WRITE
+static ssize_t file_bytewrite(FAR struct mtd_dev_s *dev, off_t offset, size_t nbytes, FAR const uint8_t *buf)
+{
+	FAR struct file_dev_s *priv = (FAR struct file_dev_s *)dev;
+	off_t maxoffset;
+
+	DEBUGASSERT(dev && buf);
+
+	/* Don't let the write exceed the original size of the file */
+
+	maxoffset = priv->nblocks * priv->erasesize;
+	if (offset + nbytes > maxoffset) {
+		return 0;
+	}
+
+	/* Then write the data to the file */
+
+	filemtd_write(priv, offset, buf, nbytes);
+	return nbytes;
+}
+#endif
+
+/****************************************************************************
+ * Name: file_ioctl
+ ****************************************************************************/
+
+static int file_ioctl(FAR struct mtd_dev_s *dev, int cmd, unsigned long arg)
+{
+	FAR struct file_dev_s *priv = (FAR struct file_dev_s *)dev;
+	int ret = -EINVAL;			/* Assume good command with bad parameters */
+
+	switch (cmd) {
+	case MTDIOC_GEOMETRY: {
+		FAR struct mtd_geometry_s *geo = (FAR struct mtd_geometry_s *)((uintptr_t)arg);
+
+		if (geo) {
+			/* Populate the geometry structure with information need to know
+			 * the capacity and how to access the device.
+			 */
+
+			geo->blocksize = priv->blocksize;
+			geo->erasesize = priv->erasesize;
+			geo->neraseblocks = priv->nblocks;
+			ret = OK;
+		}
+	}
+	break;
+
+	case MTDIOC_XIPBASE:
+		ret = -ENOTTY;			/* Bad command */
+		break;
+
+	case MTDIOC_BULKERASE: {
+		/* Erase the entire device */
+
+		file_erase(dev, 0, priv->nblocks);
+		ret = OK;
+	}
+	break;
+
+	default:
+		ret = -ENOTTY;			/* Bad command */
+		break;
+	}
+
+	return ret;
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: filemtd_initialize
+ *
+ * Description:
+ *   Create and initialize a FILE MTD device instance.
+ *
+ * Input Parameters:
+ *   path - Path name of the file backing the MTD device
+ *
+ ****************************************************************************/
+
+FAR struct mtd_dev_s *filemtd_initialize(FAR const char *path, size_t offset, int16_t sectsize, int32_t erasesize)
+{
+	FAR struct file_dev_s *priv;
+	struct stat sb;
+	size_t nblocks;
+	size_t filelen;
+	int mode, ret;
+
+	/* Create an instance of the FILE MTD device state structure */
+
+	priv = (FAR struct file_dev_s *)kmm_zalloc(sizeof(struct file_dev_s));
+	if (!priv) {
+		fdbg("Failed to allocate the FILE MTD state structure\n");
+		return NULL;
+	}
+
+	/* Determine the file open mode */
+
+	mode = O_RDONLY;
+#ifdef CONFIG_FS_WRITABLE
+	mode |= O_RDWR;
+#endif
+
+	/* Stat the file */
+
+	ret = stat(path, &sb);
+	if (ret < 0) {
+		dbg("Failed to stat %s: %d\n", path, get_errno());
+		return NULL;
+	}
+
+	filelen = sb.st_size;
+
+	/* Try to open the file */
+
+	priv->fd = open(path, mode);
+	if (priv->fd == -1) {
+		fdbg("Failed to open the FILE MTD file %s\n", path);
+		kmm_free(priv);
+		return NULL;
+	}
+
+	if (filelen == 0) {
+		filelen = linux_get_block_dev_size(priv->fd);
+	}
+
+	/* Set the block size based on the provided sectsize parameter */
+
+	if (sectsize <= 0) {
+		priv->blocksize = CONFIG_FILEMTD_BLOCKSIZE;
+	} else {
+		priv->blocksize = sectsize;
+	}
+
+	/* Set the erase size based on the provided erasesize parameter */
+
+	if (erasesize <= 0) {
+		priv->erasesize = CONFIG_FILEMTD_ERASESIZE;
+	} else {
+		priv->erasesize = erasesize;
+	}
+
+	priv->blkper = priv->erasesize / priv->blocksize;
+
+	/* Force the size to be an even number of the erase block size */
+
+	nblocks = (filelen - offset) / priv->erasesize;
+	if (nblocks < 3) {
+		fdbg("Need to provide at least three full erase block\n");
+		kmm_free(priv);
+		return NULL;
+	}
+
+	/* Perform initialization as necessary. (unsupported methods were
+	 * nullified by kmm_zalloc).
+	 */
+
+	priv->mtd.erase = file_erase;
+	priv->mtd.bread = file_bread;
+	priv->mtd.bwrite = file_bwrite;
+	priv->mtd.read = file_byteread;
+#ifdef CONFIG_MTD_BYTE_WRITE
+	priv->mtd.write = file_bytewrite;
+#endif
+	priv->mtd.ioctl = file_ioctl;
+	priv->offset = offset;
+	priv->nblocks = nblocks;
+
+	/* Register the MTD with the procfs system if enabled */
+
+#ifdef CONFIG_MTD_REGISTRATION
+	mtd_register(&priv->mtd, "filemtd");
+#endif
+
+	return &priv->mtd;
+}
+
+/****************************************************************************
+ * Name: filemtd_teardown
+ *
+ * Description:
+ *   Teardown a previously created filemtd device.
+ *
+ * Input Parameters:
+ *   path - Path name of the file backing the MTD device
+ *
+ ****************************************************************************/
+
+void filemtd_teardown(FAR struct mtd_dev_s *dev)
+{
+	FAR struct file_dev_s *priv;
+
+	/* Close the enclosed file */
+
+	priv = (FAR struct file_dev_s *)dev;
+	close(priv->fd);
+
+	/* Register the MTD with the procfs system if enabled */
+
+#ifdef CONFIG_MTD_REGISTRATION
+	mtd_unregister(&priv->mtd);
+#endif
+
+	/* Free the memory */
+
+	kmm_free(priv);
+}
+
+/****************************************************************************
+ * Name: filemtd_isfilemtd
+ *
+ * Description:
+ *   Tests if the provided mtd is a filemtd device.
+ *
+ * Input Parameters:
+ *   mtd - Pointer to the mtd.
+ *
+ ****************************************************************************/
+
+bool filemtd_isfilemtd(FAR struct mtd_dev_s *dev)
+{
+	FAR struct file_dev_s *priv = (FAR struct file_dev_s *)dev;
+
+	if (priv->mtd.erase == file_erase) {
+		return 1;
+	}
+
+	return 0;
+}

--- a/tools/nxfuse/src/linux_ops.c
+++ b/tools/nxfuse/src/linux_ops.c
@@ -1,0 +1,31 @@
+/****************************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+#include <stdlib.h>
+#include <sys/ioctl.h>
+#include <linux/fs.h>
+#include <stdint.h>
+
+uint64_t linux_get_block_dev_size(int fd)
+{
+	uint64_t len;
+
+	ioctl(fd, BLKGETSIZE64, &len);
+
+	return len;
+}

--- a/tools/nxfuse/src/main.c
+++ b/tools/nxfuse/src/main.c
@@ -1,0 +1,303 @@
+/****************************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+/****************************************************************************
+ * SmartFUSE - A FUSE filesystem for mounting NuttX FS natively under Linux.
+ *
+ * tools/nxfuse/main.c
+ *
+ *   Copyright (C) 2016 Ken Pettit. All rights reserved.
+ *   Author: Ken Pettit <pettitkd@gmail.com>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#define NXFUSE_VERSION  "1.2"
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <unistd.h>
+#include <debug.h>
+#include <string.h>
+
+#define FUSE_USE_VERSION 26
+
+#include <fuse.h>
+
+#include "nxfuse.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Extern data references
+ ****************************************************************************/
+
+extern struct fuse_operations nxfuse_oper;
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name:  main
+ *
+ * Main entry point for the FUSE based filesystem.
+ *
+ * Invocation Format:
+ *
+ *     nxfuse [-e erasesize] [-s sectorsize] mount_point filename
+ *
+ ****************************************************************************/
+
+int main(int argc, char *argv[])
+{
+	int opt, ret;
+	int erasesize = 0;
+	int sectsize = 0;
+	int pagesize = 0;
+	int fuse_argc;
+	int confirm = 0;
+	char *generic = "";
+	int opt_mkfs = 0;
+	int no_mount = 0;
+	char **fuse_argv;
+	const char *filename;
+	char *mount_point;
+	struct inode *pinode;
+	struct nxfuse_state *nxfuse_data;
+	const char *fs_type = "smartfs";
+	char fsname[128];
+
+	/* We will recreate the argv array for fuse_main with only those
+	 * options that FUSE understands, pulling out our additions.
+	 */
+
+	fuse_argc = 1;
+	fuse_argv = malloc(sizeof(char *));
+	fuse_argv[0] = argv[0];
+
+	/* Parse the options.  This includes our own custom options as well
+	 * as the standard FUSE -d -f -h -s -o and -V options.
+	 */
+
+	while ((opt = getopt(argc, argv, "cde:fg:ho:l:mp:st:Vv")) != -1) {
+		switch (opt) {
+		case 'd':
+			/* Add this arg to the fuse_main args */
+
+			fuse_argc++;
+			fuse_argv = realloc(fuse_argv, sizeof(char *) * fuse_argc);
+			fuse_argv[fuse_argc - 1] = "-d";
+			break;
+
+		case 'h':
+			/* Add this arg to the fuse_main args */
+
+			no_mount = 1;
+			fuse_argc++;
+			fuse_argv = realloc(fuse_argv, sizeof(char *) * fuse_argc);
+			fuse_argv[fuse_argc - 1] = "-h";
+			break;
+
+		case 'V':
+			/* Add this arg to the fuse_main args */
+
+			no_mount = 1;
+			fuse_argc++;
+			fuse_argv = realloc(fuse_argv, sizeof(char *) * fuse_argc);
+			fuse_argv[fuse_argc - 1] = "-V";
+			break;
+
+		case 's':
+			/* Add this arg to the fuse_main args */
+
+			fuse_argc++;
+			fuse_argv = realloc(fuse_argv, sizeof(char *) * fuse_argc);
+			fuse_argv[fuse_argc - 1] = "-s";
+			break;
+
+		case 'f':
+			/* Add this arg to the fuse_main args */
+
+			fuse_argc++;
+			fuse_argv = realloc(fuse_argv, sizeof(char *) * fuse_argc);
+			fuse_argv[fuse_argc - 1] = "-f";
+			break;
+
+		case 'o':
+			/* Add this arg to the fuse_main args */
+
+			fuse_argc += 2;
+			fuse_argv = realloc(fuse_argv, sizeof(char *) * fuse_argc);
+			fuse_argv[fuse_argc - 2] = "-o";
+			fuse_argv[fuse_argc - 1] = optarg;
+			break;
+
+			/* MTD Page size option */
+
+		case 'p':
+			pagesize = atoi(optarg);
+			break;
+
+			/* Erase size option */
+
+		case 'e':
+			erasesize = atoi(optarg);
+			break;
+
+			/* Logical sector size option */
+
+		case 'l':
+			sectsize = atoi(optarg);
+			break;
+
+			/* FS type option */
+
+		case 't':
+			/* Save the FS type */
+
+			fs_type = optarg;
+			break;
+
+		case 'c':
+			confirm = 1;
+			break;
+
+		case 'm':
+			opt_mkfs = 1;
+			no_mount = 1;
+			break;
+
+		case 'g':
+			generic = optarg;
+			break;
+
+		case 'v':
+			printf("nxfuse version %s\n", NXFUSE_VERSION);
+			printf("Copyright (C) 2016 Ken Pettit.  All rights reserved.\n");
+			return 1;
+
+		}
+	}
+
+	/* If mkfs or help option provided, then we only expect 1 arg */
+
+	if (no_mount) {
+		/* We should have 1 args left */
+
+		if (argc - optind != 1) {
+			printf("Usage: %s [-e erasesize] [-l logical_sectorsize] [-t fstype] [fuse options] mount_point datasource\n", argv[0]);
+			return -1;
+		}
+
+		if (opt_mkfs) {
+			filename = argv[optind];
+		} else {
+			mount_point = argv[optind];
+		}
+	} else {
+		/* We should have 2 args left */
+
+		if (argc - optind != 2) {
+			printf("Usage: %s [-e erasesize] [-l logical_sectorsize] [-t fstype] [fuse options] mount_point datasource\n", argv[0]);
+			return -1;
+		}
+
+		mount_point = argv[optind];
+		filename = argv[optind + 1];
+	}
+
+	/* Test for mkfs option */
+
+	if (opt_mkfs) {
+		mkfs(filename, fs_type, erasesize, sectsize, pagesize, generic, confirm);
+		return 0;
+	}
+
+	/* If no in help mode, mount the NuttX FS */
+
+	if (!no_mount) {
+		/* Try to virtually mount the NuttX Filesystem */
+
+		pinode = vmount(filename, mount_point, fs_type, erasesize, sectsize, pagesize, generic);
+		if (pinode == NULL) {
+			/* Error mounting the NuttX filesystem */
+
+			printf("Unable to mount filesytem on %s of type %s\n", mount_point, fs_type);
+			return -1;
+		}
+
+		/* Setup the FUSE environment */
+
+		nxfuse_data = malloc(sizeof(struct nxfuse_state));
+		nxfuse_data->rootdir = mount_point;
+		nxfuse_data->pinode = pinode;
+	}
+
+	/* Add the fs_type to the fuse arguments */
+
+	fuse_argc += 2;
+	fuse_argv = realloc(fuse_argv, sizeof(char *) * fuse_argc);
+	fuse_argv[fuse_argc - 2] = "-o";
+	sprintf(fsname, "subtype=%s", fs_type);
+	fuse_argv[fuse_argc - 1] = fsname;
+
+	/* Add the mount_point to the fuse arguments */
+
+	fuse_argc++;
+	fuse_argv = realloc(fuse_argv, sizeof(char *) * fuse_argc);
+	fuse_argv[fuse_argc - 1] = mount_point;
+
+	/* Call fuse_main to start the FS */
+
+	ret = fuse_main(fuse_argc, fuse_argv, &nxfuse_oper, nxfuse_data);
+
+	return ret;
+}

--- a/tools/nxfuse/src/nxfuse.c
+++ b/tools/nxfuse/src/nxfuse.c
@@ -1,0 +1,960 @@
+/****************************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+/****************************************************************************
+ * nxfuse - A FUSE filesystem for mounting NuttX FS natively under Linux.
+ *
+ * tools/nxfuse/nxfuse.c
+ *
+ *   Copyright (C) 2016 Ken Pettit. All rights reserved.
+ *   Author: Ken Pettit <pettitkd@gmail.com>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+#include <unistd.h>
+#include <errno.h>
+#include <debug.h>
+#include <utime.h>
+#include <sys/statfs.h>
+
+#define FUSE_USE_VERSION 26
+
+#include <fuse.h>
+
+#ifdef HAVE_SYS_XATTR_H
+#include <sys/xattr.h>
+#endif
+
+#include <tinyara/fs/fs.h>
+#include <tinyara/fs/ioctl.h>
+#include <tinyara/fs/dirent.h>
+#include "nxfuse.h"
+
+/****************************************************************************
+ * Name: nxfuse_getattr
+ *
+ *      FUSE callback to get file attribute
+ *
+ ****************************************************************************/
+
+static int nxfuse_getattr(const char *path, struct stat *fs)
+{
+	int ret = 0;
+	struct nxfuse_state *pdata = (struct nxfuse_state *)(fuse_get_context()->private_data);
+
+	/* Validate stat is implemented by VFS */
+
+	if (pdata->pinode->u.i_mops->stat == NULL) {
+		return -ENOSYS;
+	}
+
+	/* Remove leading '/' from path */
+
+	if (*path == '/') {
+		path++;
+	}
+
+	/* Call the FS stat function */
+
+	if (*path == '\0') {
+		/* For the root dir stat, just set the values */
+
+		fs->st_mode = S_IFDIR | 0777;
+		fs->st_nlink = 3;
+	} else {
+		/* Stat the file on the filesystem */
+
+		ret = pdata->pinode->u.i_mops->stat(pdata->pinode, path, fs);
+		fs->st_mode &= 0770777;
+	}
+
+	/* Set the UID and GID to the current user (not defined in NuttX) */
+
+	fs->st_uid = getuid();
+	fs->st_gid = getgid();
+
+	return ret;
+}
+
+/****************************************************************************
+ * Name: nxfuse_mkdir
+ *
+ *      FUSE callback to create a new directory
+ *
+ ****************************************************************************/
+
+static int nxfuse_mkdir(const char *path, mode_t mode)
+{
+	int ret;
+	struct nxfuse_state *pdata = (struct nxfuse_state *)(fuse_get_context()->private_data);
+
+	/* Validate open is implemented by VFS */
+
+	if (pdata->pinode->u.i_mops->mkdir == NULL) {
+		return -ENOSYS;
+	}
+
+	/* Remove leading '/' from path */
+
+	if (*path == '/') {
+		path++;
+	}
+
+	/* Perform the mkdir */
+
+	ret = pdata->pinode->u.i_mops->mkdir(pdata->pinode, path, mode);
+	return ret;
+}
+
+/****************************************************************************
+ * Name: nxfuse_unlink
+ *
+ *      FUSE callback to delete a regular file
+ *
+ ****************************************************************************/
+
+static int nxfuse_unlink(const char *path)
+{
+	int ret;
+	struct nxfuse_state *pdata = (struct nxfuse_state *)(fuse_get_context()->private_data);
+
+	/* Validate opendir is implemented by VFS */
+
+	if (pdata->pinode->u.i_mops->unlink == NULL) {
+		return -ENOSYS;
+	}
+
+	/* Remove leading '/' from path */
+
+	if (*path == '/') {
+		path++;
+	}
+
+	/* Perform the rename operation */
+
+	ret = pdata->pinode->u.i_mops->unlink(pdata->pinode, path);
+	return ret;
+}
+
+/****************************************************************************
+ * Name: nxfuse_rmdir
+ *
+ *      FUSE callback to delete a directory
+ *
+ ****************************************************************************/
+
+static int nxfuse_rmdir(const char *path)
+{
+	int ret;
+	struct nxfuse_state *pdata = (struct nxfuse_state *)(fuse_get_context()->private_data);
+
+	/* Validate open is implemented by VFS */
+
+	if (pdata->pinode->u.i_mops->rmdir == NULL) {
+		return -ENOSYS;
+	}
+
+	/* Remove leading '/' from path */
+
+	if (*path == '/') {
+		path++;
+	}
+
+	/* Perform the mkdir */
+
+	ret = pdata->pinode->u.i_mops->rmdir(pdata->pinode, path);
+	return ret;
+}
+
+/****************************************************************************
+ * Name: nxfuse_rename
+ *
+ *      FUSE callback to rename a file
+ *
+ ****************************************************************************/
+
+static int nxfuse_rename(const char *path, const char *newpath)
+{
+	int ret;
+	struct nxfuse_state *pdata = (struct nxfuse_state *)(fuse_get_context()->private_data);
+
+	/* Validate opendir is implemented by VFS */
+
+	if (pdata->pinode->u.i_mops->rename == NULL) {
+		return -ENOSYS;
+	}
+
+	/* Remove leading '/' from path and newpath */
+
+	if (*path == '/') {
+		path++;
+	}
+	if (*newpath == '/') {
+		newpath++;
+	}
+
+	/* Perform the rename operation */
+
+	ret = pdata->pinode->u.i_mops->rename(pdata->pinode, path, newpath);
+	return ret;
+}
+
+/****************************************************************************
+ * Name: nxfuse_chmod
+ *
+ *      FUSE callback to update the file mode bits
+ *
+ ****************************************************************************/
+
+static int nxfuse_chmod(const char *path, mode_t mode)
+{
+	int ret;
+	struct file *filep;
+	struct nxfuse_state *pdata = (struct nxfuse_state *)(fuse_get_context()->private_data);
+
+	/* Validate opendir is implemented by VFS */
+
+	if (pdata->pinode->u.i_mops->open == NULL || pdata->pinode->u.i_mops->ioctl == NULL) {
+		return -ENOSYS;
+	}
+
+	/* Remove leading '/' from path and newpath */
+
+	if (*path == '/') {
+		path++;
+	}
+
+	filep = (struct file *)malloc(sizeof(struct file));
+	filep->f_seekpos = 0;
+	filep->f_inode = pdata->pinode;
+	filep->f_priv = NULL;
+	filep->f_oflags = O_RDOK | O_WROK;
+
+	/* First try to open the file */
+
+	ret = pdata->pinode->u.i_mops->open(filep, path, filep->f_oflags, mode);
+	if (ret != OK) {
+		free(filep);
+		return ret;
+	}
+
+	/* Now issue the FIOUTIME ioctl */
+
+	ret = pdata->pinode->u.i_mops->ioctl(filep, FIOCHMOD, mode);
+	ret = pdata->pinode->u.i_mops->close(filep);
+	free(filep);
+
+	return ret;
+}
+
+/****************************************************************************
+ * Name: nxfuse_chown
+ *
+ *      FUSE callback to update the file ownership
+ *
+ ****************************************************************************/
+
+static int nxfuse_chown(const char *path, uid_t uid, gid_t gid)
+{
+	return OK;
+}
+
+/****************************************************************************
+ * Name: nxfuse_truncate
+ *
+ *      FUSE callback to tuncate a file to a given length
+ *
+ ****************************************************************************/
+
+static int nxfuse_truncate(const char *path, off_t newsize)
+{
+	return OK;
+}
+
+/****************************************************************************
+ * Name: nxfuse_utime
+ *
+ *      FUSE callback to update the modified time of a file
+ *
+ ****************************************************************************/
+
+static int nxfuse_utime(const char *path, struct utimbuf *ubuf)
+{
+	int mode;
+	int ret;
+	struct file *filep;
+	struct nxfuse_state *pdata = (struct nxfuse_state *)(fuse_get_context()->private_data);
+
+	/* Validate opendir is implemented by VFS */
+
+	if (pdata->pinode->u.i_mops->open == NULL || pdata->pinode->u.i_mops->ioctl == NULL) {
+		return -ENOSYS;
+	}
+
+	/* Remove leading '/' from path and newpath */
+
+	if (*path == '/') {
+		path++;
+	}
+
+	filep = (struct file *)malloc(sizeof(struct file));
+	filep->f_seekpos = 0;
+	filep->f_inode = pdata->pinode;
+	filep->f_priv = NULL;
+	filep->f_oflags = O_RDOK | O_WROK;
+	mode = 0666;
+
+	/* First try to open the file */
+
+	ret = pdata->pinode->u.i_mops->open(filep, path, filep->f_oflags, mode);
+	if (ret != OK) {
+		free(filep);
+		return ret;
+	}
+
+	/* Now issue the FIOUTIME ioctl */
+
+	ret = pdata->pinode->u.i_mops->ioctl(filep, FIOUTIME, ubuf->modtime);
+	ret = pdata->pinode->u.i_mops->close(filep);
+	free(filep);
+
+	return ret;
+}
+
+/****************************************************************************
+ * Name: nxfuse_statfs
+ *
+ *      FUSE callback to stat the filesystem
+ *
+ ****************************************************************************/
+
+static int nxfuse_statfs(const char *path, struct statvfs *vfs)
+{
+	struct statfs buf;
+	struct nxfuse_state *pdata = (struct nxfuse_state *)(fuse_get_context()->private_data);
+
+	/* Validate statfs is implemented by VFS */
+
+	if (pdata->pinode->u.i_mops->statfs == NULL) {
+		return -ENOSYS;
+	}
+
+	/* Stat the filesystem */
+
+	pdata->pinode->u.i_mops->statfs(pdata->pinode, &buf);
+
+	/* Return the FS values */
+
+	vfs->f_bsize = buf.f_bsize;
+	vfs->f_ffree = buf.f_ffree;
+	vfs->f_bavail = buf.f_bavail;
+	vfs->f_blocks = buf.f_blocks;
+	vfs->f_files = buf.f_files;
+	vfs->f_bfree = buf.f_bfree;
+	vfs->f_namemax = buf.f_namelen;
+
+	return OK;
+}
+
+/****************************************************************************
+ * Name: nxfuse_flush
+ *
+ *      FUSE callback to flush updates to a file
+ *
+ ****************************************************************************/
+
+static int nxfuse_flush(const char *path, struct fuse_file_info *fi)
+{
+	int ret = OK;
+	struct file *filep;
+	struct nxfuse_state *pdata = (struct nxfuse_state *)(fuse_get_context()->private_data);
+
+	/* Validate sync is implemented by VFS */
+
+	if (pdata->pinode->u.i_mops->sync == NULL) {
+		return OK;
+	}
+
+	/* Get our private file data from the FUSE file handle */
+
+	filep = (struct file *)fi->fh;
+
+	/* Perform the file sync */
+
+	ret = pdata->pinode->u.i_mops->sync(filep);
+
+	return ret;
+}
+
+/****************************************************************************
+ * Name: nxfuse_opendir
+ *
+ *      FUSE callback to open a directory for reading
+ *
+ ****************************************************************************/
+
+static int nxfuse_opendir(const char *path, struct fuse_file_info *fi)
+{
+	int ret;
+	struct fs_dirent_s *de;
+	struct nxfuse_state *pdata = (struct nxfuse_state *)(fuse_get_context()->private_data);
+
+	/* Validate opendir is implemented by VFS */
+
+	if (pdata->pinode->u.i_mops->opendir == NULL) {
+		return -ENOSYS;
+	}
+
+	/* Remove leading '/' from path */
+
+	if (*path == '/') {
+		path++;
+	}
+
+	/* Perform the opendir operation */
+
+	de = malloc(sizeof(struct fs_dirent_s));
+	if (de == NULL) {
+		return -ENOMEM;
+	}
+
+	/* Perform the opendir operation */
+
+	ret = pdata->pinode->u.i_mops->opendir(pdata->pinode, path, de);
+
+	/* Save the opendir data in the file info */
+
+	fi->fh = (intptr_t) de;
+	return ret;
+}
+
+/****************************************************************************
+ * Name: nxfuse_readdir
+ *
+ *      FUSE callback to read file content from a directory
+ *
+ ****************************************************************************/
+
+static int nxfuse_readdir(const char *path, void *buf, fuse_fill_dir_t filler, off_t offset, struct fuse_file_info *fi)
+{
+	int ret;
+	struct stat fs;
+	struct fs_dirent_s *de;
+	struct nxfuse_state *pdata = (struct nxfuse_state *)(fuse_get_context()->private_data);
+
+	/* Validate readdir is implemented by VFS */
+
+	if (pdata->pinode->u.i_mops->readdir == NULL) {
+		return -ENOSYS;
+	}
+
+	/* Remove leading '/' from path */
+
+	if (*path == '/') {
+		path++;
+	}
+
+	/* Get pointer to the directory entry struct */
+
+	de = (struct fs_dirent_s *)fi->fh;
+
+	/* Read the first entry */
+
+	ret = pdata->pinode->u.i_mops->readdir(pdata->pinode, de);
+	if (ret != OK) {
+		return ret;
+	}
+
+	/* Fill the buffer with all entries */
+
+	do {
+		/* Get the file stat info */
+
+		pdata->pinode->u.i_mops->stat(pdata->pinode, path, &fs);
+
+		/* Fill this entry's data using the FUSE filler function */
+
+		if (filler(buf, de->fd_dir.d_name, &fs, 0) != 0) {
+			return -ENOMEM;
+		}
+
+		/* Loop until no more directory entries */
+
+	} while ((ret = pdata->pinode->u.i_mops->readdir(pdata->pinode, de)) == OK);
+
+	return OK;
+}
+
+/****************************************************************************
+ * Name: nxfuse_releasedir
+ *
+ *      FUSE callback to close an opendir
+ *
+ ****************************************************************************/
+
+static int nxfuse_releasedir(const char *path, struct fuse_file_info *fi)
+{
+	struct fs_dirent_s *de;
+	struct nxfuse_state *pdata = (struct nxfuse_state *)(fuse_get_context()->private_data);
+
+	/* Get pointer to the directory entry struct */
+
+	de = (struct fs_dirent_s *)fi->fh;
+
+	/* Call the closedir function */
+
+	if (pdata->pinode->u.i_mops->closedir != NULL) {
+		pdata->pinode->u.i_mops->closedir(pdata->pinode, de);
+	}
+
+	/* Free the de struct */
+
+	free(de);
+	return OK;
+}
+
+/****************************************************************************
+ * Name: nxfuse_open
+ *
+ *      FUSE callback to open an existing file
+ *
+ ****************************************************************************/
+
+static int nxfuse_open(const char *path, struct fuse_file_info *fi)
+{
+	int ret, mode;
+	struct file *filep;
+	struct nxfuse_state *pdata = (struct nxfuse_state *)(fuse_get_context()->private_data);
+
+	/* Validate open is implemented by VFS */
+
+	if (pdata->pinode->u.i_mops->open == NULL) {
+		return -ENOSYS;
+	}
+
+	/* Remove leading '/' from path */
+
+	if (*path == '/') {
+		path++;
+	}
+
+	/* Allocate a private file data struct to track things */
+
+	filep = (struct file *)malloc(sizeof(struct file));
+	filep->f_seekpos = 0;
+	filep->f_pos = 0;
+	filep->f_inode = pdata->pinode;
+	filep->f_priv = NULL;
+	filep->f_oflags = fi->flags;
+
+	/* Map O_RDWR open flags to O_RDOK | O_WROK */
+
+	if (fi->flags & O_RDWR) {
+		filep->f_oflags |= O_RDOK | O_WROK;
+	} else if (fi->flags & O_WRONLY) {
+		filep->f_oflags |= O_WROK;
+	} else {
+		filep->f_oflags |= O_RDOK;
+	}
+
+	mode = 0666;
+
+	/* Perform the open */
+
+	if ((ret = pdata->pinode->u.i_mops->open(filep, path, filep->f_oflags, mode)) != OK) {
+		/* Error opening file.  Free the filep struct and return */
+
+		free(filep);
+		return ret;
+	}
+
+	/* Save the pointer to our file data in the FUSE file info */
+
+	fi->fh = (intptr_t) filep;
+	return OK;
+}
+
+/****************************************************************************
+ * Name: nxfuse_access
+ *
+ *      FUSE callback to test if filesystem access is granted
+ *
+ ****************************************************************************/
+
+static int nxfuse_access(const char *path, int mask)
+{
+	return OK;
+}
+
+/****************************************************************************
+ * Name: nxfuse_create
+ *
+ *      FUSE callback to create a new file in the filesystem
+ *
+ ****************************************************************************/
+
+static int nxfuse_create(const char *path, mode_t mode, struct fuse_file_info *fi)
+{
+	int ret;
+	struct file *filep;
+	struct nxfuse_state *pdata = (struct nxfuse_state *)(fuse_get_context()->private_data);
+
+	/* Validate open is implemented by VFS */
+
+	if (pdata->pinode->u.i_mops->open == NULL) {
+		return -ENOSYS;
+	}
+
+	/* Remove leading '/' from path */
+
+	if (*path == '/') {
+		path++;
+	}
+
+	/* Allocate a private file data struct to track things */
+
+	filep = (struct file *)malloc(sizeof(struct file));
+	filep->f_seekpos = 0;
+	filep->f_inode = pdata->pinode;
+	filep->f_priv = NULL;
+
+	/* Append the O_CREAT and O_TRUNC flags to perform force create / recreate */
+
+	filep->f_oflags = fi->flags | O_CREAT | O_TRUNC;	// | O_WROK;
+
+	/* Perform the open */
+
+	if ((ret = pdata->pinode->u.i_mops->open(filep, path, filep->f_oflags, mode)) != OK) {
+		free(filep);
+		return ret;
+	}
+
+	/* Save the pointer to our file data in the FUSE file info */
+
+	fi->fh = (intptr_t) filep;
+	return OK;
+}
+
+/****************************************************************************
+ * Name: nxfuse_ftruncate
+ *
+ *      FUSE callback to truncate an already opened file.
+ *
+ ****************************************************************************/
+
+static int nxfuse_ftruncate(const char *path, off_t offset, struct fuse_file_info *fi)
+{
+	return OK;
+}
+
+/****************************************************************************
+ * Name: nxfuse_read
+ *
+ *      FUSE callback to read from an opened file
+ *
+ ****************************************************************************/
+
+static int nxfuse_read(const char *path, char *buf, size_t size, off_t offset, struct fuse_file_info *fi)
+{
+	int ret;
+	struct file *filep;
+	struct nxfuse_state *pdata = (struct nxfuse_state *)(fuse_get_context()->private_data);
+
+	/* Validate read is implemented by VFS */
+
+	if (pdata->pinode->u.i_mops->read == NULL) {
+		return -ENOSYS;
+	}
+
+	/* Get our private file data from the FUSE file handle */
+
+	filep = (struct file *)fi->fh;
+
+	/* Test if seek needed  */
+
+	if (filep->f_seekpos != offset) {
+		/* Seek to new location */
+
+		if (pdata->pinode->u.i_mops->seek == NULL) {
+			return -ENOSYS;
+		}
+
+		pdata->pinode->u.i_mops->seek(filep, offset, SEEK_SET);
+		filep->f_seekpos = offset;
+	}
+
+	/* Perform the read */
+
+	ret = pdata->pinode->u.i_mops->read(filep, buf, size);
+
+	/* Keep track of the file position for seeking */
+
+	if (ret > 0) {
+		filep->f_seekpos += ret;
+	}
+
+	/* Return the number of bytes read */
+
+	return ret;
+}
+
+/****************************************************************************
+ * Name: nxfuse_write
+ *
+ *      FUSE callback to write to an opened file
+ *
+ ****************************************************************************/
+
+static int nxfuse_write(const char *path, const char *buf, size_t size, off_t offset, struct fuse_file_info *fi)
+{
+	int ret;
+	struct file *filep;
+	struct nxfuse_state *pdata = (struct nxfuse_state *)(fuse_get_context()->private_data);
+
+	/* Validate write is implemented by VFS */
+
+	if (pdata->pinode->u.i_mops->write == NULL) {
+		return -ENOSYS;
+	}
+
+	/* Get our private file data from the FUSE file handle */
+
+	filep = (struct file *)fi->fh;
+
+	/* Test if seek needed  */
+
+	if (filep->f_seekpos != offset) {
+		/* Seek to new location */
+
+		if (pdata->pinode->u.i_mops->seek == NULL) {
+			return -ENOSYS;
+		}
+
+		pdata->pinode->u.i_mops->seek(filep, offset, SEEK_SET);
+		filep->f_seekpos = offset;
+	}
+
+	/* Perform the write */
+
+	ret = pdata->pinode->u.i_mops->write(filep, buf, size);
+
+	/* Keep track of the file position for seeking */
+
+	if (ret > 0) {
+		filep->f_seekpos += ret;
+	}
+
+	/* Return the number of bytes read */
+
+	return ret;
+}
+
+/****************************************************************************
+ * Name: nxfuse_release
+ *
+ *      FUSE callback to close an open file
+ *
+ ****************************************************************************/
+
+static int nxfuse_release(const char *path, struct fuse_file_info *fi)
+{
+	int ret = OK;
+	struct file *filep;
+	struct nxfuse_state *pdata = (struct nxfuse_state *)(fuse_get_context()->private_data);
+
+	/* Get our private file data from the FUSE file handle */
+
+	filep = (struct file *)fi->fh;
+
+	/* Perform the close and free memory */
+
+	if (pdata->pinode->u.i_mops->close != NULL) {
+		ret = pdata->pinode->u.i_mops->close(filep);
+	}
+
+	free(filep);
+	fi->fh = 0;
+
+	return ret;
+}
+
+/****************************************************************************
+ * Name: nxfuse_fsync
+ *
+ *      FUSE callback to sync a file
+ *
+ ****************************************************************************/
+
+static int nxfuse_fsync(const char *path, int datasync, struct fuse_file_info *fi)
+{
+	int ret = OK;
+	struct file *filep;
+	struct nxfuse_state *pdata = (struct nxfuse_state *)(fuse_get_context()->private_data);
+
+	/* Validate sync is implemented by VFS */
+
+	if (pdata->pinode->u.i_mops->sync == NULL) {
+		return -ENOSYS;
+	}
+
+	/* Get our private file data from the FUSE file handle */
+
+	filep = (struct file *)fi->fh;
+
+	/* Perform the file sync */
+
+	ret = pdata->pinode->u.i_mops->sync(filep);
+
+	return ret;
+}
+
+/****************************************************************************
+ * Name: nxfuse_init
+ *
+ *      FUSE callback to init the filesystem
+ *
+ ****************************************************************************/
+
+static void *nxfuse_init(struct fuse_conn_info *conn)
+{
+	return fuse_get_context()->private_data;
+}
+
+/****************************************************************************
+ * Name: nxfuse_fgetattr
+ *
+ *      FUSE callback to get attributes of an open file
+ *
+ ****************************************************************************/
+
+static int nxfuse_fgetattr(const char *path, struct stat *fs, struct fuse_file_info *fi)
+{
+	int ret = 0;
+	struct nxfuse_state *pdata = (struct nxfuse_state *)(fuse_get_context()->private_data);
+
+	/* Validate stat is implemented by VFS */
+
+	if (pdata->pinode->u.i_mops->stat == NULL) {
+		return -ENOSYS;
+	}
+
+	/* Remove leading '/' from path */
+
+	if (*path == '/') {
+		path++;
+	}
+
+	/* Call the FS stat function */
+
+	if (*path == '\0') {
+		/* For the root dir stat, just set the values */
+
+		fs->st_mode = S_IFDIR | 0777;
+		fs->st_nlink = 3;
+	} else {
+		/* Stat the file on the filesystem */
+
+		ret = pdata->pinode->u.i_mops->stat(pdata->pinode, path, fs);
+		fs->st_mode &= 0770777;
+	}
+
+	return ret;
+}
+
+/****************************************************************************
+ * Name: nxfuse_oper
+ *
+ *      FUSE operations structure
+ *
+ ****************************************************************************/
+
+struct fuse_operations nxfuse_oper = {
+	.getattr = nxfuse_getattr,
+	.readlink = NULL,
+	.getdir = NULL,
+	.mknod = NULL,
+	.mkdir = nxfuse_mkdir,
+	.unlink = nxfuse_unlink,
+	.rmdir = nxfuse_rmdir,
+	.symlink = NULL,
+	.rename = nxfuse_rename,
+	.link = NULL,
+	.chmod = nxfuse_chmod,
+	.chown = nxfuse_chown,
+	.truncate = nxfuse_truncate,
+	.utime = nxfuse_utime,
+	.open = nxfuse_open,
+	.read = nxfuse_read,
+	.write = nxfuse_write,
+	.statfs = nxfuse_statfs,
+	.flush = nxfuse_flush,
+	.release = nxfuse_release,
+	.fsync = nxfuse_fsync,
+
+#ifdef HAVE_SYS_XATTR_H
+	.setxattr = NULL,
+	.getxattr = NULL,
+	.listxattr = NULL,
+	.removexattr = NULL,
+#endif
+
+	.opendir = nxfuse_opendir,
+	.readdir = nxfuse_readdir,
+	.releasedir = nxfuse_releasedir,
+	.fsyncdir = NULL,
+	.init = nxfuse_init,
+	.destroy = NULL,
+	.access = nxfuse_access,
+	.create = nxfuse_create,
+	.ftruncate = nxfuse_ftruncate,
+	.fgetattr = nxfuse_fgetattr
+};

--- a/tools/nxfuse/src/nxfuse.h
+++ b/tools/nxfuse/src/nxfuse.h
@@ -1,0 +1,112 @@
+/****************************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+/****************************************************************************
+ * nxfuse - A FUSE filesystem for mounting NuttX FS natively under Linux.
+ *
+ * src/nxfuse.h:   Prototypes and definitions for nxfuse
+ *
+ *   Copyright (C) 2016 Ken Pettit. All rights reserved.
+ *   Author: Ken Pettit <pettitkd@gmail.com>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#ifndef _SRC_NXFUSE_H
+#define _SRC_NXFUSE_H
+
+#define FIOUTIME        _FIOC(0x0007)  /* IN:  None
+                                                                                * OUT: OK if successful, -ENOSYS if not
+                                                                                */
+#define FIOCHMOD        _FIOC(0x0008)  /* IN:  New mode flags (int)
+                                                                                * OUT: OK if successful, -ENOSYS if not
+/* The logical sector number of the root directory. */
+
+#define SMARTFS_ROOT_DIR_SECTOR   3
+
+/* Defines the sector types */
+
+#define SMARTFS_SECTOR_TYPE_DIR   1
+#define SMARTFS_SECTOR_TYPE_FILE  2
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Types
+ ****************************************************************************/
+
+/* nxfuse private data state control context */
+
+struct nxfuse_state {
+	const char *rootdir;
+	struct inode *pinode;
+};
+
+/****************************************************************************
+ * Function Prototypes
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: vmount
+ *
+ * Description:
+ *   This is called from the FUSE main routine to virtually mount a
+ *   NuttX filesystem.
+ *
+ ****************************************************************************/
+struct inode *vmount(const char *filename, const char *mount_point, const char *fs_type, int erasesize, int sectsize, int pagesize, char *generic);
+
+/****************************************************************************
+ * Name: mkfs
+ *
+ * Description:
+ *   This is called from main when the -m 'mkfs' option is specified.
+ *   It attempts to perform a mkfs on the specified source device using the
+ *   specified NuttX filesystem type.
+ *
+ ****************************************************************************/
+int mkfs(const char *filename, const char *fs_type, int erasesize, int sectsize, int pagesize, char *generic, int confirm);
+
+#endif							/* _SRC_NXFUSE_H */

--- a/tools/nxfuse/src/tinyara_services.c
+++ b/tools/nxfuse/src/tinyara_services.c
@@ -1,0 +1,604 @@
+/****************************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+/****************************************************************************
+ * SmartFUSE - A FUSE filesystem for mounting NuttX FS natively under Linux.
+ *
+ * tools/nxfuse/tinyara_services.c:
+ *
+ *   Contains wrapper functions and virtual mount services to emulate
+ *   to emulate NuttX operations.
+ *
+ *   Copyright (C) 2016 Ken Pettit. All rights reserved.
+ *   Author: Ken Pettit <pettitkd@gmail.com>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+#include <stdarg.h>
+#include <errno.h>
+#include <debug.h>
+
+#include <tinyara/config.h>
+#include <tinyara/fs/fs.h>
+#include <tinyara/fs/mtd.h>
+#include <tinyara/fs/smart.h>
+#include <tinyara/fs/ioctl.h>
+
+#include "nxfuse.h"
+
+/****************************************************************************
+ * Private Types
+ ****************************************************************************/
+
+struct fs_ops_s {
+	const char *fs_name;
+	void *(*vmount)(const char *datasource, const char *mount_point, int erasesize, int sectsize, int pagesize, char *generic);
+	int (*mkfs)(const char *datasource, int erasesize, int sectsize, int pagesize, char *, int confirm);
+	const struct mountpt_operations *pops;
+};
+
+/****************************************************************************
+ * Extern referenced data
+ ****************************************************************************/
+
+#ifdef CONFIG_FS_SMARTFS
+extern const struct mountpt_operations smartfs_operations;
+#endif
+
+/****************************************************************************
+ * Private Function Prototypes
+ ****************************************************************************/
+
+#ifdef CONFIG_FS_SMARTFS
+static void *smartfs_vmount(const char *datasource, const char *mount_point, int erasesize, int sectsize, int pagesize, char *generic);
+static int smartfs_mkfs(const char *datasource, int erasesize, int sectsize, int pagesize, char *generic, int confirm);
+#endif
+
+/****************************************************************************
+ * Private Variables
+ ****************************************************************************/
+
+static struct inode *g_inodes[10];
+static int g_inode_count = 0;
+
+/* Table of known NuttX FS types we can mount */
+
+static struct fs_ops_s g_fs_ops[] = {
+#ifdef CONFIG_FS_SMARTFS
+	{"smartfs", smartfs_vmount, smartfs_mkfs, &smartfs_operations},
+#endif
+
+	{"", NULL, NULL}
+};
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: get_errno
+ ****************************************************************************/
+
+int get_errno(void)
+{
+	return errno;
+}
+
+/****************************************************************************
+ * Name: mtd_register
+ *
+ *  Dummy stub function
+ *
+ ****************************************************************************/
+
+int mtd_register(FAR struct mtd_dev_s *mtd, FAR const char *name)
+{
+	return 0;
+}
+
+/****************************************************************************
+ * Name: mtd_unregister
+ *
+ *  Dummy stub function
+ *
+ ****************************************************************************/
+
+int mtd_unregister(FAR struct mtd_dev_s *mtd)
+{
+	return 0;
+}
+
+/****************************************************************************
+ * Name: register_driver
+ *
+ *  Dummy stub function
+ *
+ ****************************************************************************/
+
+int register_driver(FAR const char *path, FAR const struct file_operations *fops, mode_t mode, FAR void *priv)
+{
+	return 0;
+}
+
+/****************************************************************************
+ * Name: register_blockdriver
+ *
+ *  Simple registration support
+ *
+ ****************************************************************************/
+
+int register_blockdriver(FAR const char *path, FAR const struct block_operations *bops, mode_t mode, FAR void *priv)
+{
+	struct inode *node;
+	int ret;
+
+	node = calloc(sizeof(struct inode) + strlen(path), 1);
+	if (node == NULL) {
+		return -1;
+	}
+
+	strcpy(node->i_name, path);
+	node->i_crefs = 0;
+	node->i_peer = NULL;
+	node->i_child = NULL;
+	node->u.i_bops = bops;
+#ifdef CONFIG_FILE_MODE
+	node->i_mode = mode;
+#endif
+	node->i_private = priv;
+	ret = OK;
+
+	g_inodes[g_inode_count++] = node;
+
+	return ret;
+}
+
+/****************************************************************************
+ * Name: open_blockdriver
+ *
+ *  Simple find / open support for block drivers
+ *
+ ****************************************************************************/
+
+int open_blockdriver(FAR const char *pathname, int mountflags, FAR struct inode **ppinode)
+{
+	int x;
+
+	for (x = 0; x < g_inode_count; x++) {
+		if (strcmp(pathname, g_inodes[x]->i_name) == 0) {
+			*ppinode = g_inodes[x];
+			g_inodes[x]->i_crefs++;
+			return 0;
+		}
+	}
+
+	*ppinode = NULL;
+	return -1;
+}
+
+/****************************************************************************
+ * Name: close_blockdriver
+ *
+ *  Simple close support for block drivers
+ *
+ ****************************************************************************/
+
+int close_blockdriver(FAR struct inode *pinode)
+{
+	pinode->i_crefs--;
+	return OK;
+}
+
+/****************************************************************************
+ * Name: unregister_blockdriver
+ *
+ *  Simple unregister support for block drivers
+ *
+ ****************************************************************************/
+
+int unregister_blockdriver(FAR const char *pathname)
+{
+	int x;
+	struct inode *pinode;
+
+	for (x = 0; x < g_inode_count; x++) {
+		if (strcmp(pathname, g_inodes[x]->i_name) == 0) {
+			pinode = g_inodes[x];
+			g_inodes[x] = g_inodes[--g_inode_count];
+			free(pinode);
+		}
+	}
+
+	return OK;
+}
+
+/****************************************************************************
+ * Name: dbg
+ *
+ *  A dbg implementation that maps to printf
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_DEBUG
+int dbg(const char *fmt, ...)
+{
+	va_list args;
+	int ret;
+
+	va_start(args, fmt);
+	ret = vprintf(fmt, args);
+	va_end(args);
+	return ret;
+}
+#endif
+
+/****************************************************************************
+ * Name: vdbg
+ *
+ *  A dbg implementation that maps to printf
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_DEBUG
+int vdbg(const char *fmt, ...)
+{
+	va_list args;
+	int ret;
+
+	va_start(args, fmt);
+	ret = vprintf(fmt, args);
+	va_end(args);
+	return ret;
+}
+#endif
+
+/****************************************************************************
+ * Name: vmount
+ *
+ *  A virtual mount implemention for registered NuttX filesystems.  Mount
+ *  is performed based on the provided fs_type.
+ *
+ ****************************************************************************/
+
+struct inode *vmount(const char *datasource, const char *mount_point, const char *fs_type, int erasesize, int sectsize, int pagesize, char *generic)
+{
+	int x;
+	void *fs_handle;
+	struct inode *pinode;
+
+	/* Loop for all known NuttX FS types */
+
+	for (x = 0; g_fs_ops[x].vmount != NULL; x++) {
+		/* Test if this is the FS we need to mount */
+
+		if (strcmp(fs_type, g_fs_ops[x].fs_name) == 0) {
+			/* Mount this FS */
+
+			fs_handle = g_fs_ops[x].vmount(datasource, mount_point, erasesize, sectsize, pagesize, generic);
+
+			/* Test if mount failed */
+
+			if (fs_handle == NULL) {
+				return NULL;
+			}
+
+			/* Setup a new inode */
+
+			pinode = calloc(sizeof(struct inode), 1);
+			pinode->i_crefs = 1;
+			pinode->i_private = fs_handle;
+			pinode->u.i_mops = g_fs_ops[x].pops;
+
+			return pinode;
+		}
+	}
+
+	/* Unknown fs_type */
+
+	dbg("Unknown filesystem type: %s\n", fs_type);
+
+	return NULL;
+}
+
+/****************************************************************************
+ * Name: smartfs_vmount
+ *
+ *  The mount implementation for SmartFS type FS.
+ *
+ *  This creates a file based MTD device using the given datasource and
+ *  initialized smart MTD and SmartFS on that filemtd device.
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_FS_SMARTFS
+void *smartfs_vmount(const char *datasource, const char *mount_point, int erasesize, int sectsize, int pagesize, char *generic)
+{
+	int ret;
+	int offset = 0;
+	struct mtd_dev_s *mtd;
+	void *fshandle;
+	struct inode *blkdriver;
+#ifdef CONFIG_SMARTFS_MULTI_ROOT_DIRS
+	char blkname[20];
+	int nrootdirs;
+#endif
+
+	/* Try to create a filemtd device using the filename provided */
+
+	mtd = filemtd_initialize(datasource, offset, pagesize, erasesize);
+	if (mtd == NULL) {
+		printf("error %d opening %s\n", errno, datasource);
+		return NULL;
+	}
+
+	/* Now initialize the SMART routines on the MTD */
+
+	ret = smart_initialize(0, mtd, NULL);
+	if (ret != OK) {
+		printf("error initializing SmartFS on %s\n", datasource);
+		filemtd_teardown(mtd);
+		return NULL;
+	}
+
+	/* Setup the SmartFS */
+
+#ifdef CONFIG_SMARTFS_MULTI_ROOT_DIRS
+
+	/* The generic parameter is the directory number to mount */
+
+	nrootdirs = atoi(generic);
+	if (nrootdirs == 0) {
+		/* If the root directory number is not specified,
+		 * then default to 1.
+		 */
+
+		nrootdirs++;
+	}
+
+	snprintf(blkname, sizeof(blkname), "/dev/smart0d%d", nrootdirs);
+	ret = open_blockdriver(blkname, 0, &blkdriver);
+#else
+	ret = open_blockdriver("/dev/smart0", 0, &blkdriver);
+#endif
+	ret = smartfs_operations.bind(blkdriver, NULL, &fshandle);
+
+	if (ret != OK) {
+		return NULL;
+	}
+
+	return fshandle;
+}
+#endif							/* CONFIG_FS_SMARTFS */
+
+/****************************************************************************
+ * Name: mkfs
+ *
+ *  A virtual mount implemention for registered NuttX filesystems.  Mount
+ *  is performed based on the provided fs_type.
+ *
+ ****************************************************************************/
+
+int mkfs(const char *datasource, const char *fs_type, int erasesize, int sectsize, int pagesize, char *generic, int confirm)
+{
+	int x;
+	int ret = -ENODEV;
+
+	/* Loop for all known NuttX FS types */
+
+	for (x = 0; g_fs_ops[x].vmount != NULL; x++) {
+		/* Test if this is the FS we need to mount */
+
+		if (strcmp(fs_type, g_fs_ops[x].fs_name) == 0) {
+			/* Call this FS's mkfs routine */
+
+			if (g_fs_ops[x].mkfs != NULL) {
+				ret = g_fs_ops[x].mkfs(datasource, erasesize, sectsize, pagesize, generic, confirm);
+			}
+
+			return ret;
+		}
+	}
+
+	/* Unknown fs_type */
+
+	dbg("Unknown filesystem type: %s\n", fs_type);
+
+	return ret;
+}
+
+/****************************************************************************
+ * Name: smartfs_umount
+ *
+ *  Unmounts a previously mounted SmartFS
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_FS_SMARTFS
+static int smartfs_umount(struct inode *blkdriver, void *fshandle)
+{
+	int ret;
+	struct mtd_dev_s *mtd;
+
+	/* Get the block driver */
+
+#ifdef CONFIG_SMARTFS_MULTI_ROOT_DIRS
+	ret = open_blockdriver("/dev/smart0d1", 0, &blkdriver);
+#else
+	ret = open_blockdriver("/dev/smart0", 0, &blkdriver);
+#endif
+	free(fshandle);
+
+	/* The blkdriver private data is an MTD pointer */
+
+	mtd = *((struct mtd_dev_s **)blkdriver->i_private);
+	filemtd_teardown(mtd);
+
+	free(blkdriver->i_private);
+#ifdef CONFIG_SMARTFS_MULTI_ROOT_DIRS
+	unregister_blockdriver("/dev/smart0d1");
+#else
+	unregister_blockdriver("/dev/smart0");
+#endif
+
+	return ret;
+}
+
+/****************************************************************************
+ * Name: smartfs_mkfs
+ *
+ *  Creates a SmartfS filesystem on the datasource
+ *
+ ****************************************************************************/
+
+static int smartfs_mkfs(const char *datasource, int erasesize, int sectsize, int pagesize, char *generic, int confirm)
+{
+	int ret = OK, x;
+	void *fshandle;
+	struct inode *blkdriver;
+	uint8_t type;
+	struct smart_read_write_s request;
+
+	/* Try to mount the device to see if there is a format already */
+
+	fshandle = smartfs_vmount(datasource, "/tmp", erasesize, sectsize, pagesize, "");
+	if (fshandle != NULL) {
+		/* Test if confirm was specified */
+
+		if (!confirm) {
+			printf("\nSheepishly refusing to reformat ... use -c to confirm\n\n");
+
+			/* Unmount the datasource */
+
+			smartfs_umount(blkdriver, fshandle);
+
+			return -EACCES;
+		}
+	}
+
+	/* Okay to format the device.  Get the block driver inode */
+
+	if (fshandle == NULL) {
+		printf("\nFormatting %s with smartfs format\n", datasource);
+	} else {
+		printf("\nReformatting %s with smartfs format\n", datasource);
+	}
+#ifdef CONFIG_SMARTFS_MULTI_ROOT_DIRS
+	ret = open_blockdriver("/dev/smart0d1", 0, &blkdriver);
+#else
+	ret = open_blockdriver("/dev/smart0", 0, &blkdriver);
+#endif
+
+	/* Perform a low-level SMART format */
+
+#ifdef CONFIG_SMARTFS_MULTI_ROOT_DIRS
+	ret = blkdriver->u.i_bops->ioctl(blkdriver, BIOC_LLFORMAT, (sectsize << 16) | atoi(generic));
+#else
+	ret = blkdriver->u.i_bops->ioctl(blkdriver, BIOC_LLFORMAT, sectsize << 16);
+#endif
+	if (ret != OK) {
+		close_blockdriver(blkdriver);
+		printf("Error %d during low-level format\n", ret);
+		return ret;
+	}
+
+	/* Unmount the datasource */
+
+	smartfs_umount(blkdriver, fshandle);
+	fshandle = smartfs_vmount(datasource, "/tmp", erasesize, sectsize, pagesize, "");
+#ifdef CONFIG_SMARTFS_MULTI_ROOT_DIRS
+	ret = open_blockdriver("/dev/smart0d1", 0, &blkdriver);
+#else
+	ret = open_blockdriver("/dev/smart0", 0, &blkdriver);
+#endif
+
+	/* Now Write the filesystem to media.  Loop for each root dir entry and
+	 * allocate the reserved Root Dir Enty, then write a blank root dir for it.
+	 */
+
+	type = SMARTFS_SECTOR_TYPE_DIR;
+	request.offset = 0;
+	request.count = 1;
+	request.buffer = &type;
+	x = 0;
+#ifdef CONFIG_SMARTFS_MULTI_ROOT_DIRS
+	for (; x < atoi(generic); x++)
+#endif
+	{
+		ret = blkdriver->u.i_bops->ioctl(blkdriver, BIOC_ALLOCSECT, SMARTFS_ROOT_DIR_SECTOR + x);
+		if (ret != SMARTFS_ROOT_DIR_SECTOR + x) {
+			ret = -EIO;
+			printf("Error %d allocating sector\n", ret);
+			return ret;
+		}
+
+		/* Mark this block as a directory entry */
+
+		request.logsector = SMARTFS_ROOT_DIR_SECTOR + x;
+
+		/* Issue a write to the sector, single byte */
+
+		ret = blkdriver->u.i_bops->ioctl(blkdriver, BIOC_WRITESECT, (unsigned long)&request);
+		if (ret != 0) {
+			ret = -EIO;
+			printf("Error %d writing rootdir sector\n", ret);
+			return ret;
+		}
+	}
+
+	if (ret == OK) {
+		printf("Format successful\n");
+	} else {
+		printf("Error %d during format\n", ret);
+	}
+	return ret;
+}
+#endif							/* CONFIG_FS_SMARTFS */


### PR DESCRIPTION
* First commit adds support for downloading Smartfs image onto the flash memory in artik05x.

* Second commit contains the sources for nxfuse tool which is required for generation of Smartfs image.
This patch has been back-ported from nuttx.