### PR TITLE
 framework/iotbus: Add enumerator for GPIO signal vale

### DIFF
--- a/apps/examples/iotbus_test/iotbus_test_main.c
+++ b/apps/examples/iotbus_test/iotbus_test_main.c
@@ -80,8 +80,8 @@
 #define BUTTON_RELEASE 0
 #define BUTTON_PRESS   1
 
-#define LED_ON  0
-#define LED_OFF 1
+#define LED_ON  IOTBUS_GPIO_LOW
+#define LED_OFF IOTBUS_GPIO_HIGH
 
 /****************************************************************************
  * iotbus_main

--- a/apps/examples/st_things/blink/blink.c
+++ b/apps/examples/st_things/blink/blink.c
@@ -18,7 +18,7 @@
 
 #include "blink.h"
 
-static int g_power = 0;
+static int g_power = IOTBUS_GPIO_LOW;
 static int is_led_chaged = 0;
 static int g_blink_led = 0;
 
@@ -53,9 +53,9 @@ static void* blink_loop(void* data)
 int set_led_power(char *power)
 {
 	if (strncmp(power, "off" , strlen("off")) == 0) {
-		g_power = 0;
+		g_power = IOTBUS_GPIO_LOW;
 	} else if (strncmp(power, "on", strlen("on")) == 0) {
-		g_power = 1;
+		g_power = IOTBUS_GPIO_HIGH;
 	} else {
 		printf("input Error");
 		return -1;

--- a/apps/examples/testcase/ta_tc/systemio/utc/utc_gpio.c
+++ b/apps/examples/testcase/ta_tc/systemio/utc/utc_gpio.c
@@ -190,7 +190,7 @@ static void utc_systemio_gpio_get_drive_mode_p(void)
 
 static void utc_systemio_gpio_write_p(void)
 {
-	TC_ASSERT_EQ("iotbus_gpio_write", iotbus_gpio_write(gpio, 1), IOTBUS_ERROR_NONE);
+	TC_ASSERT_EQ("iotbus_gpio_write", iotbus_gpio_write(gpio, IOTBUS_GPIO_HIGH), IOTBUS_ERROR_NONE);
 	TC_SUCCESS_RESULT();
 }
 
@@ -241,10 +241,10 @@ static void utc_systemio_gpio_register_p(void)
 	gpio_callback_flag = 0;
 
 	int ret = iotbus_gpio_register_cb(gpio2, IOTBUS_GPIO_EDGE_RISING, gpio_callback_event, (void *)gpio2);
-	int data = 0;
+	int data = IOTBUS_GPIO_LOW;
 	iotbus_gpio_write(gpio, data);
 	sleep(1);
-	data = 1;
+	data = IOTBUS_GPIO_HIGH;
 	iotbus_gpio_write(gpio, data);
 	sleep(2);
 

--- a/framework/include/iotbus/iotbus_gpio.h
+++ b/framework/include/iotbus/iotbus_gpio.h
@@ -33,6 +33,18 @@
 
 #include <tinyara/config.h>
 /**
+ * @brief Enumeration of Gpio signal value
+ * @details
+ * Enumeration Details:\n
+ * IOTBUS_GPIO_LOW = 0, Low value on Gpio
+ * IOTBUS_GPIO_HIGH = 1, High value on Gpio
+ */
+typedef enum {
+	IOTBUS_GPIO_LOW    = 0, /* Low value on Gpio */
+	IOTBUS_GPIO_HIGH    = 1, /* High value on Gpio */
+} iotbus_gpio_val_e;
+
+/**
  * @brief Enumeration of Gpio output mode
  * @details
  * Enumeration Details:\n
@@ -185,7 +197,7 @@ int iotbus_gpio_read(iotbus_gpio_context_h dev);
  *
  * @details @b #include <iotbus/iotbus_gpio.h>
  * @param[in] dev handle of gpio_context
- * @param[in] value signal value
+ * @param[in] value Gpio signal value
  * @return On success, 0 is returned. On failure, a negative value is returned.
  * @since TizenRT v1.0
  */

--- a/framework/src/iotbus/iotbus_gpio.c
+++ b/framework/src/iotbus/iotbus_gpio.c
@@ -438,7 +438,7 @@ int iotbus_gpio_write(iotbus_gpio_context_h dev, int value)
 		return IOTBUS_ERROR_INVALID_PARAMETER;
 	}
 
-	if (value != 0 && value != 1) {
+	if (value != IOTBUS_GPIO_LOW && value != IOTBUS_GPIO_HIGH) {
 		return IOTBUS_ERROR_INVALID_PARAMETER;
 	}
 


### PR DESCRIPTION
Commit 8bea8eb: 
framework/iotbus: Add enumerator for GPIO signal vale
- Define IOTBUS_GPIO_LOW and IOTBUS_GPIO_HIGH as 0 and 1, respectively
- Modify iotbus_gpio_write function input from int to enum

Commit 737e676
apps/examples: Modify GPIO utc of iotbus_gpio_write
- Apply the new definition of IOTBUS_GPIO_LOW and IOTBUS_GPIO_HIGH for iotbus_gpio_write function input