### PR TITLE
os/mm/mm_heap: Fix error in mm_get_heap when App separation is enabled

### DIFF
--- a/os/include/tinyara/mm/mm.h
+++ b/os/include/tinyara/mm/mm.h
@@ -691,6 +691,13 @@ struct mm_heap_s *mm_get_heap(void *address);
 struct mm_heap_s *mm_get_heap_with_index(int index);
 
 int mm_get_heapindex(void *mem);
+
+#if defined(CONFIG_APP_BINARY_SEPARATION) && defined(__KERNEL__)
+void mm_initialize_app_heap(void);
+void mm_add_app_heap_list(struct mm_heap_s *heap);
+void mm_remove_app_heap_list(struct mm_heap_s *heap);
+#endif
+
 #if CONFIG_MM_NHEAPS > 1
 struct heapinfo_total_info_s {
 	int total_heap_size;

--- a/os/mm/mm_heap/mm_partition_mgr.c
+++ b/os/mm/mm_heap/mm_partition_mgr.c
@@ -109,6 +109,7 @@ void mm_initialize_ram_partitions(void)
 	mm_initialize(&g_pheap, start, (uint32_t)(REGION_END - start));
 	mvdbg("Initialized partition heap start = 0x%x size = %u\n", start, (uint32_t)(REGION_END - start));
 #endif
+	mm_initialize_app_heap();
 }
 
 /****************************************************************************
@@ -149,6 +150,7 @@ int8_t mm_allocate_ram_partition(uint32_t **start_addr, uint32_t *size)
 
 	/* struct mm_heap_s will be situated at start of partition and heap will be initialized after this */
 	mm_initialize((struct mm_heap_s *)*start_addr, (uint8_t *)*start_addr + sizeof(struct mm_heap_s), *size);
+	mm_add_app_heap_list((struct mm_heap_s *)*start_addr);
 
 	mvdbg("Allocated RAM partition with start = 0x%x size = %u\n", *start_addr, *size);
 	return OK;
@@ -173,6 +175,7 @@ int8_t mm_allocate_ram_partition(uint32_t **start_addr, uint32_t *size)
 
 void mm_free_ram_partition(uint32_t address)
 {
+	mm_remove_app_heap_list((struct mm_heap_s *)address);
 	mm_free(&g_pheap, (void *)address);
 	mvdbg("Freed RAM partition at 0x%x\n", address);
 }


### PR DESCRIPTION
When App Separation is enabled, then we are getting error log from mm_get_heap.
This is because, the mm_get_heap is designed to search for the address in kernel
and user heap only. However, since we added new heaps for each application and
also a different heap for partition manager, we need to add more logic to the
mm_get_heap() API to search for the address in the app heaps if it could not be
found in the kernel and user heap.
