### PR TITLE
kernel/binary_manager: refactor binary manager recovery

### DIFF
--- a/apps/system/binary_update/binary_update.c
+++ b/apps/system/binary_update/binary_update.c
@@ -103,7 +103,6 @@ int binary_update_reload_binary(char *binary_name)
 {
 	int ret;
 	binmgr_request_t request_msg;
-	binmgr_reload_response_t response_msg;
 
 	if (binary_name == NULL || strlen(binary_name) > BIN_NAME_MAX - 1) {
 		bmdbg("load_new_binary failed : invalid binary name\n");
@@ -120,13 +119,7 @@ int binary_update_reload_binary(char *binary_name)
 		return BINMGR_COMMUNICATION_FAIL;
 	}
 
-	ret = binary_update_receive_response(&response_msg, sizeof(binmgr_reload_response_t));
-	if (ret < 0) {
-		bmdbg("Failed to receive response msg %d\n", ret);
-		return BINMGR_COMMUNICATION_FAIL;
-	}
-
-	return response_msg.result;
+	return BINMGR_OK;
 }
 
 int binary_update_get_binary_info(char *binary_name, binary_info_t *binary_info)

--- a/os/include/tinyara/binary_manager.h
+++ b/os/include/tinyara/binary_manager.h
@@ -120,11 +120,6 @@ struct binmgr_request_s {
 };
 typedef struct binmgr_request_s binmgr_request_t;
 
-struct binmgr_reload_response_s {
-	int result;
-};
-typedef struct binmgr_reload_response_s binmgr_reload_response_t;
-
 struct binmgr_getinfo_response_s {
 	int result;
 	binary_info_t data;

--- a/os/kernel/binary_manager/binary_manager.c
+++ b/os/kernel/binary_manager/binary_manager.c
@@ -27,7 +27,6 @@
 #include <string.h>
 #include <signal.h>
 #include <stdlib.h>
-#include <tinyara/sched.h>
 #include <tinyara/binary_manager.h>
 
 #include "binary_manager.h"
@@ -163,8 +162,6 @@ int binary_manager(int argc, char *argv[])
 			continue;
 		}
 
-		sched_lock();
-
 		bmvdbg("Recevied Request msg : cmd = %d\n", request_msg);
 		switch (request_msg.cmd) {
 #ifdef CONFIG_BINMGR_RECOVERY
@@ -191,8 +188,6 @@ int binary_manager(int argc, char *argv[])
 		default:
 			break;
 		}
-
-		sched_unlock();
 	}
 
 binary_manager_exit:

--- a/os/kernel/binary_manager/binary_manager.c
+++ b/os/kernel/binary_manager/binary_manager.c
@@ -179,9 +179,8 @@ int binary_manager(int argc, char *argv[])
 			memset(type_str, 0, 1);
 			memset(data_str, 0, 1);
 			loading_data[0] = itoa(LOADCMD_RELOAD, type_str, 10);
-			loading_data[1] = itoa(request_msg.requester_pid, data_str, 10);
-			loading_data[2] = request_msg.bin_name;
-			loading_data[3] = NULL;
+			loading_data[1] = request_msg.bin_name;
+			loading_data[2] = NULL;
 			ret = binary_manager_loading(loading_data);
 			break;
 

--- a/os/kernel/binary_manager/binary_manager.h
+++ b/os/kernel/binary_manager/binary_manager.h
@@ -53,7 +53,7 @@
 #define CRC_BUFFER_SIZE            512
 
 /* The number of arguments for loading thread */
-#define LOADTHD_ARGC     3
+#define LOADTHD_ARGC               2
 
 #define BINMGR_DEVNAME_FMT         "/dev/mtdblock%d"
 


### PR DESCRIPTION
In fault recovery, remove all tcb of tasks/pthreads created by same loaded task from readytorunlist only without calling task_terminate.
After that, they are terminated before binary manager reload binary.