### PR TITLE
stm32-f4-discovery: Fix acm not working in usbhost mode

### DIFF
--- a/os/Kconfig.debug
+++ b/os/Kconfig.debug
@@ -736,6 +736,38 @@ config DEBUG_TTRACE
 	---help---
 		Enable T-trace debug Feature.
 
+config DEBUG_USB
+        bool "USB Debug Features"
+        default n
+        depends on USBDEV || USBHOST
+        ---help---
+                Enable USB debug features.
+
+if DEBUG_USB
+
+config DEBUG_USB_ERROR
+        bool "USB Error Output"
+        default n
+        depends on DEBUG_ERROR
+        ---help---
+                Enable USB error output to SYSLOG.
+
+config DEBUG_USB_WARN
+        bool "USB Warnings Output"
+        default n
+        depends on DEBUG_WARN
+        ---help---
+                Enable USB warning output to SYSLOG.
+
+config DEBUG_USB_INFO
+        bool "USB Informational Output"
+        default n
+        depends on DEBUG_VERBOSE
+        ---help---
+                Enable USB informational output to SYSLOG.
+
+endif # DEBUG_USB
+
 config DEBUG_WATCHDOG
 	bool "Watchdog Timer Debug Feature"
 	default n

--- a/os/arch/arm/src/stm32/Kconfig
+++ b/os/arch/arm/src/stm32/Kconfig
@@ -1257,11 +1257,13 @@ config STM32_OTGFS
 	bool "OTG FS"
 	default n
 	depends on STM32_HAVE_OTGFS
+	select USBHOST_HAVE_ASYNCH if USBHOST
 
 config STM32_OTGHS
 	bool "OTG HS"
 	default n
 	depends on STM32_STM32F207 || STM32_STM32F40XX || STM32_STM32F429
+	select USBHOST_HAVE_ASYNCH if USBHOST
 
 config STM32_PWR
 	bool "PWR"

--- a/os/arch/arm/src/stm32/stm32_otgfshost.c
+++ b/os/arch/arm/src/stm32/stm32_otgfshost.c
@@ -4197,7 +4197,7 @@ static int stm32_ctrlout(FAR struct usbhost_driver_s *drvr, usbhost_ep_t ep0, FA
 				/* Start DATA out transfer (only one DATA packet) */
 
 				priv->chan[ep0info->outndx].outdata1 = true;
-				ret = stm32_ctrl_senddata(priv, ep0info, NULL, 0);
+				ret = stm32_ctrl_senddata(priv, ep0info, buffer, buflen);
 				if (ret < 0) {
 					usbhost_trace1(OTGFS_TRACE1_SENDDATA, -ret);
 				}

--- a/os/drivers/serial/Kconfig
+++ b/os/drivers/serial/Kconfig
@@ -11,6 +11,10 @@ config DEV_LOWCONSOLE
 	---help---
 		Use the simple, low-level, write-only serial console driver (minimal support)
 
+config SERIAL_REMOVABLE
+	bool
+	default n
+
 config SERIAL_CONSOLE
 	bool
 	default n


### PR DESCRIPTION
The patch will fix the listed issues

1) Cant enable usbhost CDCACM mode from menuconfig
2) Cant enable any of the USB logs from menuconfig
3) with "stm32-f4-discovery" board, /dev/ttyACM0 node not populating creating in usb host mode.
     3.1) Verified the Tx case from stm32 board to connected device, thru LeCroy usb pkt analyser.
     3.2) Cant verify the Rx case, as no suitable test device not found.