### PR TITLE
kernel/binary_manager : Set priority and stack size when loading binary

### DIFF
--- a/apps/examples/elf/micomapp/Makefile
+++ b/apps/examples/elf/micomapp/Makefile
@@ -90,6 +90,8 @@ BIN_TYPE = ELF
 DYNAMIC_RAM_SIZE = 20480
 BIN_VER = 20190421
 KERNEL_VER = 2.0
+STACKSIZE = 2048
+PRIORITY = 220
 
 SRCS = micomapp.c
 OBJS = $(SRCS:.c=$(OBJEXT))
@@ -117,7 +119,7 @@ ifeq ($(CONFIG_ELF_EXCLUDE_SYMBOLS),y)
 	$(Q) cp $(USER_BIN_DIR)/$(BIN) $(USER_BIN_DIR)/$(BIN)_dbg
 	$(Q) $(STRIP) -g $(USER_BIN_DIR)/$(BIN) -o $(USER_BIN_DIR)/$(BIN)
 endif
-	$(Q) $(TOPDIR)/tools/mkbinheader.py $(USER_BIN_DIR)/$(BIN) $(BIN_TYPE) $(KERNEL_VER) $(BIN) $(BIN_VER) $(DYNAMIC_RAM_SIZE)
+	$(Q) $(TOPDIR)/tools/mkbinheader.py $(USER_BIN_DIR)/$(BIN) $(BIN_TYPE) $(KERNEL_VER) $(BIN) $(BIN_VER) $(DYNAMIC_RAM_SIZE) $(STACKSIZE) $(PRIORITY)
 	$(Q) $(TOPDIR)/tools/mkchecksum.py $(USER_BIN_DIR)/$(BIN)
 
 verify:

--- a/apps/examples/elf/wifiapp/Makefile
+++ b/apps/examples/elf/wifiapp/Makefile
@@ -91,6 +91,8 @@ BIN_TYPE = ELF
 BIN_VER = 20190412
 DYNAMIC_RAM_SIZE = 51200
 KERNEL_VER = 2.0
+STACKSIZE = 4096
+PRIORITY = 180
 
 SRCS = wifiapp.c
 OBJS = $(SRCS:.c=$(OBJEXT))
@@ -118,7 +120,7 @@ ifeq ($(CONFIG_ELF_EXCLUDE_SYMBOLS),y)
 	$(Q) cp $(USER_BIN_DIR)/$(BIN) $(USER_BIN_DIR)/$(BIN)_dbg
 	$(Q) $(STRIP) -g $(USER_BIN_DIR)/$(BIN) -o $(USER_BIN_DIR)/$(BIN)
 endif
-	$(Q) $(TOPDIR)/tools/mkbinheader.py $(USER_BIN_DIR)/$(BIN) $(BIN_TYPE) $(KERNEL_VER) $(BIN) $(BIN_VER) $(DYNAMIC_RAM_SIZE)
+	$(Q) $(TOPDIR)/tools/mkbinheader.py $(USER_BIN_DIR)/$(BIN) $(BIN_TYPE) $(KERNEL_VER) $(BIN) $(BIN_VER) $(DYNAMIC_RAM_SIZE) $(STACKSIZE) $(PRIORITY)
 	$(Q) $(TOPDIR)/tools/mkchecksum.py $(USER_BIN_DIR)/$(BIN)
 
 verify:

--- a/os/binfmt/binfmt_loadbinary.c
+++ b/os/binfmt/binfmt_loadbinary.c
@@ -77,7 +77,7 @@ extern void mpu_user_intsram_context(uint32_t region, uintptr_t base, size_t siz
  *   -1 (ERROR) and sets errno appropriately.
  *
  ****************************************************************************/
-int load_binary(FAR const char *filename, size_t binsize, size_t offset, size_t ram_size)
+int load_binary(FAR const char *filename, size_t binsize, size_t offset, size_t ram_size, size_t stack_size, uint8_t priority)
 {
 	FAR struct binary_s *bin;
 	int pid;
@@ -120,6 +120,8 @@ int load_binary(FAR const char *filename, size_t binsize, size_t offset, size_t 
 	bin->nexports = 0;
 	bin->filelen = binsize;
 	bin->offset = offset;
+	bin->stacksize = stack_size;
+	bin->priority = priority;
 #ifdef CONFIG_APP_BINARY_SEPARATION
 	bin->uheap = (struct mm_heap_s *)start_addr;
 #endif
@@ -154,12 +156,8 @@ int load_binary(FAR const char *filename, size_t binsize, size_t offset, size_t 
 #endif
 
 #endif
-#ifdef CONFIG_BINARY_MANAGER
-	/* Temp code*/
-	bin->priority = BINMGR_LOAD_PRIORITY_DEFAULT;
-#endif
-	/* Then start the module */
 
+	/* Then start the module */
 	pid = exec_module(bin);
 	if (pid < 0) {
 		errcode = -pid;

--- a/os/binfmt/binfmt_loadmodule.c
+++ b/os/binfmt/binfmt_loadmodule.c
@@ -192,11 +192,12 @@ int load_module(FAR struct binary_s *bin)
 	if (bin && bin->filename)
 #endif
 	{
-		/* Set the default priority of the new program. */
-
-		ret = load_default_priority(bin);
-		if (ret < 0) {
-			return ret;
+		if (bin->priority == 0) {
+			/* Set the default priority of the new program. */
+			ret = load_default_priority(bin);
+			if (ret < 0) {
+				return ret;
+			}
 		}
 
 		/* Were we given a relative path?  Or an absolute path to the file to

--- a/os/binfmt/elf.c
+++ b/os/binfmt/elf.c
@@ -275,7 +275,9 @@ static int elf_loadbinary(FAR struct binary_s *binp)
 	/* Return the load information */
 
 	binp->entrypt = (main_t)(loadinfo.textalloc + loadinfo.ehdr.e_entry);
-	binp->stacksize = CONFIG_ELF_STACKSIZE;
+	if (binp->stacksize == 0) {
+		binp->stacksize = CONFIG_ELF_STACKSIZE;
+	}
 
 	/* Add the ELF allocation to the alloc[] only if there is no address
 	 * environment.  If there is an address environment, it will automatically

--- a/os/include/tinyara/binary_manager.h
+++ b/os/include/tinyara/binary_manager.h
@@ -52,9 +52,6 @@
 /* The length of dev name */
 #define BINMGR_DEVNAME_LEN               16
 
-/* Default priority of task loaded by binary manager */
-#define BINMGR_LOAD_PRIORITY_DEFAULT     120
-
 /* The number of User binaries */
 #ifdef CONFIG_NUM_APPS
 #define USER_BIN_COUNT                   CONFIG_NUM_APPS

--- a/os/include/tinyara/binfmt/binfmt.h
+++ b/os/include/tinyara/binfmt/binfmt.h
@@ -384,7 +384,7 @@ int binfmt_exit(FAR struct binary_s *bin);
  *   -1 (ERROR) and sets errno appropriately.
  *
  ****************************************************************************/
-int load_binary(FAR const char *filename, size_t binsize, size_t offset, size_t ram_size);
+int load_binary(FAR const char *filename, size_t binsize, size_t offset, size_t ram_size, size_t stack_size, uint8_t priority);
 
 #undef EXTERN
 #if defined(__cplusplus)

--- a/os/kernel/binary_manager/binary_manager.h
+++ b/os/kernel/binary_manager/binary_manager.h
@@ -73,6 +73,8 @@ struct binmgr_bininfo_s {
 	uint16_t bin_offset;
 	uint16_t inuse_idx;
 	uint32_t part_size;
+	uint32_t bin_stacksize;
+	uint8_t bin_priority;
 	int8_t part_num[PARTS_PER_BIN];
 	char name[BIN_NAME_MAX];
 	char bin_ver[BIN_VER_MAX];
@@ -92,6 +94,8 @@ typedef struct binmgr_bininfo_s binmgr_bininfo_t;
 #define BIN_NAME(bin_idx)                               bin_table[bin_idx].name
 #define BIN_VER(bin_idx)                                bin_table[bin_idx].bin_ver
 #define BIN_KERNEL_VER(bin_idx)                         bin_table[bin_idx].kernel_ver
+#define BIN_STACKSIZE(bin_idx)                          bin_table[bin_idx].bin_stacksize
+#define BIN_PRIORITY(bin_idx)                           bin_table[bin_idx].bin_priority
 
 extern binmgr_bininfo_t bin_table[BINARY_COUNT];
 


### PR DESCRIPTION
Added binary priority and stack size to the binary header.
It can set the priority and stack size when loading binary
by loading header.