### PR TITLE
board/imxrt1050-evk: fix a compilation error

### DIFF
--- a/os/board/imxrt1050-evk/src/Makefile
+++ b/os/board/imxrt1050-evk/src/Makefile
@@ -81,6 +81,7 @@ CSRCS += imxrt_ethernet.c
 endif
 
 ifeq ($(CONFIG_FLASH_PARTITION),y)
+DEPPATH += --dep-path $(TOPDIR)/board/common
 VPATH += :$(TOPDIR)/board/common
 CSRCS += partitions.c
 endif


### PR DESCRIPTION
To build a file from another path, DEPPATH should be added.
This commit fixes a compilation error as below:

make[2]: Entering directory '/TinyAra/Forked_TizenRT/os/board/imxrt1050-evk/src'
Makefile:126: recipe for target '.depend' failed
make[2]: *** [.depend] Error 1

Signed-off-by: sunghan-chang <sh924.chang@samsung.com>