### PR TITLE
fs/smartfs: Change config dependency on variables

### DIFF
--- a/os/fs/smartfs/smartfs_smart.c
+++ b/os/fs/smartfs/smartfs_smart.c
@@ -596,7 +596,7 @@ static int smartfs_sync_internal(struct smartfs_mountpt_s *fs, struct smartfs_of
 	int used_value;
 #endif
 
-#ifdef CONFIG_SMARTFS_JOURNALING
+#if defined(CONFIG_SMARTFS_JOURNALING) && !defined(CONFIG_SMARTFS_USE_SECTOR_BUFFER)
 	int retj;
 	uint16_t used_bytes;
 	uint16_t t_sector, t_offset;


### PR DESCRIPTION
If both journaling(CONFIG_SMARTFS_JOURNALING) and smart crc(CONFIG_MTD_SMART_ENABLE_CRC),
compilation error occurs in smartfs_sync_internal.

smartfs/smartfs_smart.c: In function 'smartfs_sync_internal':
smartfs/smartfs_smart.c:602:21: error: unused variable 't_offset' [-Werror=unused-variable]
  uint16_t t_sector, t_offset;

This patch eliminates the build error.

Signed-off-by: Yashwanth <v.yashwanth@samsung.com>