### PR TITLE
kernel/binary_manager: Use one loading thread without creating loading thread every loading

### DIFF
--- a/os/kernel/binary_manager/binary_manager.h
+++ b/os/kernel/binary_manager/binary_manager.h
@@ -22,6 +22,8 @@
 /****************************************************************************
  * Included Files
  ****************************************************************************/
+#include <queue.h>
+#include <semaphore.h>
 
 #include <tinyara/config.h>
 #include <tinyara/binary_manager.h>
@@ -65,6 +67,19 @@ enum loading_thread_cmd {
 	LOADCMD_LOAD_MAX,
 };
 
+struct loading_data_s {
+	struct loading_data_s *flink;
+	int type;
+	char name[BIN_NAME_MAX];
+};
+typedef struct loading_data_s loading_data_t;
+
+struct loading_list_s {
+	sq_queue_t list;
+	sem_t sem;
+};
+typedef struct loading_list_s loading_list_t;
+
 /* Binary data type in binary table */
 struct binmgr_bininfo_s {
 	pid_t bin_id;
@@ -94,7 +109,6 @@ typedef struct binmgr_bininfo_s binmgr_bininfo_t;
 #define BIN_KERNEL_VER(bin_idx)                         bin_table[bin_idx].kernel_ver
 
 extern binmgr_bininfo_t bin_table[BINARY_COUNT];
-
 /****************************************************************************
  * Function Prototypes
  ****************************************************************************/
@@ -121,8 +135,9 @@ extern binmgr_bininfo_t bin_table[BINARY_COUNT];
 void binary_manager_recovery(int pid);
 #endif
 
+int binary_manager_loading_initialize(void);
 int binary_manager_load_binary(int bin_idx);
-int binary_manager_loading(char *loading_data[]);
+int binary_manager_loading(int type, char *name);
 int binary_manager_get_binary_count(void);
 int binary_manager_get_index_with_binid(int bin_id);
 int binary_manager_get_info_with_name(int request_pid, char *bin_name);

--- a/os/kernel/binary_manager/binary_manager_recovery.c
+++ b/os/kernel/binary_manager/binary_manager_recovery.c
@@ -38,7 +38,6 @@
 #include "binary_manager.h"
 
 extern bool abort_mode;
-
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
@@ -134,10 +133,7 @@ void binary_manager_recovery(int pid)
 	int ret;
 	int bin_id;
 	int bin_idx;
-	char type_str[1];
-	char data_str[1];
 	struct tcb_s *tcb;
-	char *loading_data[LOADTHD_ARGC + 1];
 
 	bmllvdbg("Try to recover fault with pid %d\n", pid);
 
@@ -161,12 +157,8 @@ void binary_manager_recovery(int pid)
 		ret = recovery_exclude_scheduling(bin_id);
 		if (ret == OK) {
 			/* load binary and update binid */
-			memset(loading_data, 0, sizeof(char *) * (LOADTHD_ARGC + 1));
-			loading_data[0] = itoa(LOADCMD_RELOAD, type_str, 10);
-			loading_data[1] = BIN_NAME(bin_idx);
-			loading_data[2] = NULL;
-			ret = binary_manager_loading(loading_data);
-			if (ret > 0) {
+			ret = binary_manager_loading(LOADCMD_RELOAD, BIN_NAME(bin_idx));
+			if (ret == OK) {
 				abort_mode = false;
 				bmllvdbg("Loading thread with pid %d will reload binaries!\n", ret);
 				return 0;


### PR DESCRIPTION
With current implementation, it is inefficient to create loading thread every loading time.
So binary manager creates loading thread at the start time and communicating with it using semaphore.