### PR TITLE
kernel/binary_manager : Reload the previous version elf when fail to …

### DIFF
--- a/os/kernel/binary_manager/binary_manager.h
+++ b/os/kernel/binary_manager/binary_manager.h
@@ -57,6 +57,10 @@
 
 #define BINMGR_DEVNAME_FMT         "/dev/mtdblock%d"
 
+#if (defined(CONFIG_BUILD_PROTECTED) || defined(CONFIG_BUILD_KERNEL)) && defined(CONFIG_MM_KERNEL_HEAP)
+#define MAX_WAIT_COUNT             3                          /* The maximum number of times you can wait to process a delayed free */
+#endif
+
 /* Loading thread cmd types */
 enum loading_thread_cmd {
 	LOADCMD_LOAD = 0,


### PR DESCRIPTION
…load the latest version elf

When the latest version can not be loaded, it will exit.
However, we should try to load the previous version.