### PR TITLE
os/arch/xtensa: change function board_app_initialize() defination to …

### DIFF
--- a/os/arch/xtensa/src/esp32/esp_err.h
+++ b/os/arch/xtensa/src/esp32/esp_err.h
@@ -16,6 +16,10 @@
  *
  ******************************************************************/
 
+#ifndef _ESP_ERR_H_
+#define _ESP_ERR_H_ 1
+
+#include "stdint.h"
 
 typedef int32_t esp_err_t;
 #define ESP_OK          0		/*!< esp_err_t value indicating success (no error) */
@@ -35,3 +39,5 @@ typedef int32_t esp_err_t;
 
 #define ESP_ERR_WIFI_BASE       0x3000	/*!< Starting number of WiFi error codes */
 #define ESP_ERR_MESH_BASE       0x4000	/*!< Starting number of MESH error codes */
+
+#endif //_ESP_ERR_H_

--- a/os/board/esp32_devkit/src/esp32_appinit.c
+++ b/os/board/esp32_devkit/src/esp32_appinit.c
@@ -94,7 +94,7 @@
  *
  ****************************************************************************/
 
-int board_app_initialize(uintptr_t arg)
+int board_app_initialize(void)
 {
 #ifdef CONFIG_BOARD_INITIALIZE
 	/* Board initialization already performed by board_initialize() */


### PR DESCRIPTION
argument in board_app_initialize() defination is different with its prototype in os\include\tinyara\board.h;  esp_err.h may be include more than one time.