### PR TITLE
imxrt1050-evk/userspace: Add config dependency (CONFIG_SYSTEM_PREAPP_INIT)

### DIFF
--- a/os/board/imxrt1050-evk/userspace/imxrt_userspace.c
+++ b/os/board/imxrt1050-evk/userspace/imxrt_userspace.c
@@ -125,7 +125,9 @@ const struct userspace_s userspace __attribute__((section(".userspace"))) = {
 
 	/* pre-application entry points (declared in include/tinyara/init.h) */
 
+#ifdef CONFIG_SYSTEM_PREAPP_INIT
 	.preapp_start    = preapp_start,
+#endif
 };
 
 /****************************************************************************

--- a/os/include/tinyara/userspace.h
+++ b/os/include/tinyara/userspace.h
@@ -135,7 +135,9 @@ struct userspace_s {
 
 	/* Pre - Application Start */
 
+#ifdef CONFIG_SYSTEM_PREAPP_INIT
 	preapp_main_t preapp_start;
+#endif
 };
 
 /****************************************************************************


### PR DESCRIPTION
This patch adds config check for system pre-application init.

Signed-off-by: Nilabh <n.shant@partner.samsung.com>