### PR TITLE
arch/xtensa: add header file stdarg.h

### DIFF
--- a/os/arch/xtensa/include/stdarg.h
+++ b/os/arch/xtensa/include/stdarg.h
@@ -1,0 +1,42 @@
+/******************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************/
+
+#ifndef __ARCH_XTENSA_INCLUDE_STDARG_H
+#define __ARCH_XTENSA_INCLUDE_STDARG_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+/* This should work with any modern gcc (newer than 3.4 or so) */
+
+#define va_start(v, l)  __builtin_va_start(v, l)
+#define va_end(v)       __builtin_va_end(v)
+#define va_arg(v, l)    __builtin_va_arg(v, l)
+#define va_copy(d, s)   __builtin_va_copy(d, s)
+
+/****************************************************************************
+ * Public Types
+ ****************************************************************************/
+
+typedef __builtin_va_list va_list;
+
+#endif /* __ARCH_XTENSA_INCLUDE_STDARG_H */


### PR DESCRIPTION
`stdarg.h` is required in some modules.