### PR TITLE
iotbus: fix spi open error in iotbus

### DIFF
--- a/framework/src/iotbus/iotbus_spi.c
+++ b/framework/src/iotbus/iotbus_spi.c
@@ -79,7 +79,7 @@ iotbus_spi_context_h iotbus_spi_open(unsigned int bus, const struct iotbus_spi_c
 
 	/*	Open driver */
 	char spi_dev[16] = { 0, };
-	snprintf(spi_dev, 16, "/dev/spi%d", bus);
+	snprintf(spi_dev, 16, "/dev/spi-%d", bus);
 	int fd = open(spi_dev, O_RDWR);
 	if (fd < 0) {
 		ibdbg("open %s failed: %d\n", spi_dev, errno);

--- a/os/arch/arm/src/s5j/s5j_spi.c
+++ b/os/arch/arm/src/s5j/s5j_spi.c
@@ -592,12 +592,8 @@ void s5j_spi_register(int bus)
 	spi = up_spiinitialize(bus);
 
 #ifdef CONFIG_SPI_USERIO
-	char path[16];
-	if (spi != NULL) {
-		snprintf(path, 16, "/dev/spi-%d", bus);
-		if (spi_uioregister(path, spi) < 0) {
-			lldbg("fail to register SPI");
-		}
+	if (spi_uioregister(bus, spi) < 0) {
+		lldbg("fail to register SPI");
 	}
 #endif
 }

--- a/os/board/imxrt1050-evk/src/imxrt_boot.c
+++ b/os/board/imxrt1050-evk/src/imxrt_boot.c
@@ -161,13 +161,11 @@ void imxrt_spi_initialize(void)
 	struct spi_dev_s *spi;
 	spi = up_spiinitialize(1);
 
-	char path[10];
-	if (spi != NULL) {
-		snprintf(path, sizeof(path), "/dev/spi%d", 1);
-		if (spi_uioregister(path, spi) < 0) {
-			lldbg("Failed to register SPI%d\n", 1);
-		}
+#ifdef CONFIG_SPI_USERIO
+	if (spi_uioregister(1, spi) < 0) {
+		lldbg("Failed to register SPI%d\n", 1);
 	}
+#endif
 #endif
 }
 

--- a/os/drivers/spi/spi_uio.c
+++ b/os/drivers/spi/spi_uio.c
@@ -208,9 +208,15 @@ static int spi_uioctrl(FAR struct file *filep, int cmd, unsigned long arg)
  *   register device.
  *
  ****************************************************************************/
-int spi_uioregister(FAR const char *path, FAR struct spi_dev_s *dev)
+int spi_uioregister(FAR int bus, FAR struct spi_dev_s *dev)
 {
 	SPI_ENTRY;
+	if (!dev) {
+		return -1;
+	}
+	char path[16] = {0,};
+	snprintf(path, 16, "/dev/spi-%d", bus);
+
 	spidbg("Registering %s\n", path);
 	return register_driver(path, &g_spiops, 0666, dev);
 }

--- a/os/include/tinyara/spi/spi.h
+++ b/os/include/tinyara/spi/spi.h
@@ -495,7 +495,7 @@ extern "C" {
 
 FAR struct spi_dev_s *up_spiinitialize(int port);
 
-FAR int spi_uioregister(FAR const char *path, FAR struct spi_dev_s *dev);
+FAR int spi_uioregister(FAR int bus, FAR struct spi_dev_s *dev);
 
 #undef EXTERN
 #if defined(__cplusplus)


### PR DESCRIPTION
TizenRT register SPI to driver following format "spi-{bus}", But
iotbus tried to open it with spi{bus} so it causes errors on ITC and
UTC.
Issues found: TizenRT Daily Quality Status [ Platform - 2019-05-18 ]