### PR TITLE
network: fix build error while network feature turn off.

### DIFF
--- a/os/fs/vfs/fs_ioctl.c
+++ b/os/fs/vfs/fs_ioctl.c
@@ -61,9 +61,8 @@
 #include <errno.h>
 #include <assert.h>
 
-#include <net/if.h>
-
 #if defined(CONFIG_NET) && CONFIG_NSOCKET_DESCRIPTORS > 0
+#include <net/if.h>
 #include <tinyara/net/net.h>
 #endif
 


### PR DESCRIPTION
A header file called "net/if.h" is needed when network module is
on. so it should be inside CONFIG_NET macro.