### PR TITLE
 apps/system/utils: Increase stack monitor daemon stack size

### DIFF
--- a/apps/system/utils/Kconfig
+++ b/apps/system/utils/Kconfig
@@ -191,6 +191,12 @@ config ENABLE_STACKMONITOR
 		not available if the kernel build or protected build is selected.
 
 if ENABLE_STACKMONITOR
+config STACKMONITOR_STACKSIZE
+	int "Stack monitor daemon stack size"
+	default 2048
+	---help---
+		The stack size of the stack monitor daemon.  Default: 2048 bytes
+
 config STACKMONITOR_PRIORITY
 	int "Stack monitor daemon priority"
 	default 100

--- a/apps/system/utils/utils_stackmonitor.c
+++ b/apps/system/utils/utils_stackmonitor.c
@@ -87,7 +87,9 @@
 #define STKMON_BUFLEN 64
 /* Configuration ************************************************************/
 
-#define STACKMONITOR_STACKSIZE 1024
+#ifndef CONFIG_STACKMONITOR_STACKSIZE
+#define CONFIG_STACKMONITOR_STACKSIZE 2048
+#endif
 
 #ifndef CONFIG_STACKMONITOR_PRIORITY
 #define CONFIG_STACKMONITOR_PRIORITY 100
@@ -341,7 +343,7 @@ int utils_stackmonitor(int argc, char **args)
 		stkmon_started = TRUE;
 
 		pthread_attr_init(&stkmon_attr);
-		stkmon_attr.stacksize = STACKMONITOR_STACKSIZE;
+		stkmon_attr.stacksize = CONFIG_STACKMONITOR_STACKSIZE;
 		stkmon_attr.priority = CONFIG_STACKMONITOR_PRIORITY;
 		stkmon_attr.inheritsched = PTHREAD_EXPLICIT_SCHED;
 

--- a/os/arch/xtensa/src/xtensa/xtensa_checkstack.c
+++ b/os/arch/xtensa/src/xtensa/xtensa_checkstack.c
@@ -63,7 +63,9 @@
 #include <debug.h>
 
 #include <tinyara/arch.h>
+#ifdef CONFIG_TLS
 #include <tinyara/tls.h>
+#endif
 #include <tinyara/board.h>
 
 #include "xtensa.h"


### PR DESCRIPTION
For esp32 case, the peek stack size of stack-monitor-daemon is more than 1024 bytes.
- It's necessary to increase the default size
- Remove a building error when stkmon enabled.