### PR TITLE
os/include/debug.h: Remove re-direction of dbg to lldbg

### DIFF
--- a/os/arch/arm/src/armv7-m/mpu.h
+++ b/os/arch/arm/src/armv7-m/mpu.h
@@ -237,7 +237,7 @@ static inline void mpu_showtype(void)
 {
 #if defined(CONFIG_DEBUG) && defined(CONFIG_DEBUG_ERROR)
 	uint32_t regval = getreg32(MPU_TYPE);
-	dbg("%s MPU Regions: data=%d instr=%d\n",
+	lldbg("%s MPU Regions: data=%d instr=%d\n",
 		(regval & MPU_TYPE_SEPARATE) != 0 ? "Separate" : "Unified",
 		(regval & MPU_TYPE_DREGION_MASK) >> MPU_TYPE_DREGION_SHIFT,
 		(regval & MPU_TYPE_IREGION_MASK) >> MPU_TYPE_IREGION_SHIFT);

--- a/os/include/debug.h
+++ b/os/include/debug.h
@@ -153,16 +153,8 @@
  * @details @b #include <debug.h>
  * @since TizenRT v1.0
  */
-#ifdef CONFIG_ARCH_CHIP_IMXRT
-/* TODO: This is a temporary fix to redirect dbg messages to lldbg.
- *       After IMXRT dbg implementation is fixed, this needs to be removed.
- */
-#define dbg(format, ...) \
-	lldbg(format, ##__VA_ARGS__)
-#else
 #define dbg(format, ...) \
 	syslog(LOG_ERR, EXTRA_FMT format EXTRA_ARG, ##__VA_ARGS__)
-#endif
 
 #define dbg_noarg(format, ...) \
 	syslog(LOG_ERR, format, ##__VA_ARGS__)
@@ -199,16 +191,8 @@
  * @details @b #include <debug.h>
  * @since TizenRT v1.0
  */
-#ifdef CONFIG_ARCH_CHIP_IMXRT
-/* TODO: This is a temporary fix to redirect dbg messages to lldbg.
- *       After IMXRT dbg implementation is fixed, this needs to be removed.
- */
-#define wdbg(format, ...) \
-	llwdbg(format, ##__VA_ARGS__)
-#else
 #define wdbg(format, ...) \
 	syslog(LOG_WARNING, EXTRA_FMT format EXTRA_ARG, ##__VA_ARGS__)
-#endif
 
 #ifdef CONFIG_ARCH_LOWPUTC
 /**
@@ -242,16 +226,8 @@
  * @details @b #include <debug.h>
  * @since TizenRT v1.0
  */
-#ifdef CONFIG_ARCH_CHIP_IMXRT
-/* TODO: This is a temporary fix to redirect dbg messages to lldbg.
- *       After IMXRT dbg implementation is fixed, this needs to be removed.
- */
-#define vdbg(format, ...) \
-	llvdbg(format, ##__VA_ARGS__)
-#else
 #define vdbg(format, ...) \
 	syslog(LOG_INFO, EXTRA_FMT format EXTRA_ARG, ##__VA_ARGS__)
-#endif
 
 #ifdef CONFIG_ARCH_LOWPUTC
 /**


### PR DESCRIPTION
* This patch eliminates the re-direction of dbg to lldbg
commands.
* Also, "dbg" cannot be called prior to driver registration
since it uses write system call. So, this patch changes
"dbg" to "lldbg" prior to driver registration.

Signed-off-by: Yashwanth <v.yashwanth@samsung.com>