### PR TITLE
kernel/binary_manager: Remove the TCB from the task list associated with the state in recovery

### DIFF
--- a/os/kernel/binary_manager/binary_manager.h
+++ b/os/kernel/binary_manager/binary_manager.h
@@ -100,22 +100,20 @@ extern binmgr_bininfo_t bin_table[BINARY_COUNT];
  ****************************************************************************/
 #ifdef CONFIG_BINMGR_RECOVERY
 /****************************************************************************
- * Name: recovery_thread
+ * Name: binary_manager_recovery
  *
  * Description:
- *   This function create recovery thread to handle fault with pid.
- *   Recovery thread will check if it is one of the registered binary with binary manager.
- *   If the binary is registered then it will be restarted after killing its
- *   child processes, and if it is not registered then board will be rebooted.
+ *   This function will receive the faulty pid and check if its binary id is one
+ *   of the registered binary with binary manager.
+ *   If the binary is registered, it excludes its children from scheduling
+ *   and creates loading thread which will terminate them and load binary again.
+ *   Otherwise, board will be rebooted.
  *
  * Input parameters:
- *   None
+ *   pid   -   The pid of recovery message
  *
  * Returned Value:
- *   Zero (OK) on success; otherwise -1 (ERROR) value is returned.
- *
- * Assumptions:
- *    All the binaries of the system will be registered with the binary manager
+ *   None
  *
  ****************************************************************************/
 void binary_manager_recovery(int pid);

--- a/os/kernel/binary_manager/binary_manager_recovery.c
+++ b/os/kernel/binary_manager/binary_manager_recovery.c
@@ -23,6 +23,7 @@
 #include <stdio.h>
 #include <debug.h>
 #include <stdlib.h>
+#include <queue.h>
 #include <errno.h>
 #include <sys/types.h>
 #ifdef CONFIG_BOARD_ASSERT_AUTORESET
@@ -75,10 +76,11 @@ static void recovery_exclude_scheduling_each(FAR struct tcb_s *tcb, FAR void *ar
 
 	if (tcb->group->tg_loadtask == binid) {
 		flags = irqsave();
-		(void)sched_removereadytorun(tcb);
+		/* Remove the TCB from the task list associated with the state */
+		dq_rem((FAR dq_entry_t *)tcb, (dq_queue_t *)g_tasklisttable[tcb->task_state].list);
 		sched_addblocked(tcb, TSTATE_TASK_INACTIVE);
 		irqrestore(flags);
-		bmllvdbg("Remove pid %d from readytorun list\n", tcb->pid);
+		bmllvdbg("Remove pid %d from task list\n", tcb->pid);
 	}
 }
 
@@ -86,8 +88,8 @@ static void recovery_exclude_scheduling_each(FAR struct tcb_s *tcb, FAR void *ar
  * Name: recovery_exclude_scheduling
  *
  * Description:
- *   This function will remove all the tasks and threads created by the binary
- *   i.e input pid from readytorun list.
+ *   This function will move all the tasks and threads created by the binary
+ *   i.e input pid to inactive task list to exclude them from scheduling.
  *
  * Input parameters:
  *   pid   -   The pid of the binary, whoes all children to be killed
@@ -106,7 +108,7 @@ static int recovery_exclude_scheduling(int binid)
 		return ERROR;
 	}
 
-	/* Remove all tasks and pthreads created in a binary which has 'binid' from the readytorun list */
+	/* Exclude all tasks and pthreads created in a binary which has 'binid' from scheduling */
 	sched_foreach(recovery_exclude_scheduling_each, (FAR void *)binid);
 
 	return OK;
@@ -118,7 +120,7 @@ static int recovery_exclude_scheduling(int binid)
  * Description:
  *   This function will receive the faulty pid and check if its binary id is one
  *   of the registered binary with binary manager.
- *   If the binary is registered, it removes its children from ready to run list
+ *   If the binary is registered, it excludes its children from scheduling
  *   and creates loading thread which will terminate them and load binary again.
  *   Otherwise, board will be rebooted.
  *
@@ -157,7 +159,7 @@ void binary_manager_recovery(int pid)
 			goto reboot_board;
 		}
 
-		/* Remove its all children from readytorun list if the binary is registered with the binary manager */
+		/* Exclude its all children from scheduling if the binary is registered with the binary manager */
 		ret = recovery_exclude_scheduling(bin_id);
 		if (ret == OK) {
 			/* load binary and update binid */


### PR DESCRIPTION
When binary manager handles a fault, All children created in a same binary are excluded from scheduling.
At this time, we need to remove the TCB from the task list associated with the state.