### PR TITLE
examples/elf : Add Messaging F/W Sample

### DIFF
--- a/apps/examples/elf/Kconfig
+++ b/apps/examples/elf/Kconfig
@@ -14,6 +14,22 @@ config EXAMPLES_ELF
 if EXAMPLES_ELF
 
 menu "Enable Test Scenarios"
+config EXAMPLES_MESSAGING_TEST
+	bool "Messaging Framework Test"
+	default y
+	---help---
+		Enable the Messaging Framework Test"
+
+if EXAMPLES_MESSAGING_TEST
+config MESSAGING_TEST_REPETITION_NUM
+	int
+	default 1
+	---help---
+		Messaging F/W Test repetition number.
+		To be updated.
+
+endif
+
 config EXAMPLES_RECOVERY_TEST
 	bool "Binary Manager Recovery example"
 	default y

--- a/apps/examples/elf/micomapp/Makefile
+++ b/apps/examples/elf/micomapp/Makefile
@@ -79,6 +79,10 @@ else
 LDLIBS += -lmm
 endif
 
+ifeq ($(CONFIG_EXAMPLES_MESSAGING_TEST),y)
+LDLIBS += -lframework
+endif
+
 LIBGCC = "${shell "$(CC)" $(ARCHCFLAGS) -print-libgcc-file-name}"
 LDLIBS += $(LIBGCC)
 endif
@@ -87,13 +91,16 @@ BIN = micom
 BIN_CHECK = $(shell nm -u $(PWD)/$(BIN)app/$(BIN) | wc -l)
 # need to update
 BIN_TYPE = ELF
-DYNAMIC_RAM_SIZE = 20480
+DYNAMIC_RAM_SIZE = 40960
 BIN_VER = 20190421
 KERNEL_VER = 2.0
 STACKSIZE = 2048
 PRIORITY = 220
 
 SRCS = micomapp.c
+ifeq ($(CONFIG_EXAMPLES_MESSAGING_TEST),y)
+SRCS += messaging.c
+endif
 OBJS = $(SRCS:.c=$(OBJEXT))
 
 all: $(BIN)

--- a/apps/examples/elf/micomapp/messaging.c
+++ b/apps/examples/elf/micomapp/messaging.c
@@ -1,0 +1,333 @@
+/****************************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+#include <tinyara/config.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <messaging/messaging.h>
+
+#define SYNC_BLOCK_PORT "sync_block_port"
+#define SYNC_BLOCK_DATA "sync_block_msg"
+#define SYNC_BLOCK_REPLY "reply_msg"
+
+#define NOREPLY_NONBLOCK_PORT "noreply_nonblock"
+#define NOREPLY_NONBLOCK_DATA "noreply_data"
+
+#define MULTICAST_PORT "multicast_port"
+
+#define CHECK_PORT "check_port"
+#define CHECK_MSG  "do_next"
+
+#define BUFFER_SIZE 20
+#define MSG_PRIO 10
+#define TASK_PRIO 130
+#define STACKSIZE 2048
+
+static sem_t nonblock_sem;
+static sem_t multi_sem;
+
+static int multicast_fail_cnt;
+static int block_fail_cnt;
+static int nonblock_fail_cnt;
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+static int block_recv(int argc, FAR char *argv[])
+{
+	int ret;
+	msg_recv_buf_t recv_data;
+	msg_send_data_t reply_data;
+
+	recv_data.buf = (char *)malloc(BUFFER_SIZE);
+	if (recv_data.buf == NULL) {
+		printf("[MICOM] Fail to receive, because out of memory.\n");
+		return ERROR;
+	}
+	recv_data.buflen = BUFFER_SIZE;
+
+	ret = messaging_recv_block(SYNC_BLOCK_PORT, &recv_data);
+	if (ret < 0) {
+		free(recv_data.buf);
+		printf("[MICOM] Fail to receive with block mode.\n");
+		return ERROR;
+	}
+
+	printf("[MICOM] Success to receive with block mode in receiver. msg : [%s]\n", (char *)recv_data.buf);
+	printf("[MICOM] - Reply to sender [%s] data.\n", SYNC_BLOCK_REPLY);
+
+	reply_data.msg = SYNC_BLOCK_REPLY;
+	reply_data.msglen = sizeof(SYNC_BLOCK_REPLY);
+	if (ret == MSG_REPLY_REQUIRED) {
+		ret = messaging_reply(SYNC_BLOCK_PORT, recv_data.sender_pid, &reply_data);
+		if (ret != OK) {
+			free(recv_data.buf);
+			printf("[MICOM] Fail to reply.\n");
+			return ERROR;
+		}
+	} else {
+		printf("[MICOM] We will not reply, because received msg is not sync type. %d\n", ret);
+	}
+
+	free(recv_data.buf);
+	return OK;
+}
+
+void recv_callback(msg_reply_type_t msg_type, msg_recv_buf_t *recv_data, void *cb_data)
+{
+	if (recv_data == NULL) {
+		printf("[MICOM] Fail to receive unicast message with non-block mode.\n");
+		nonblock_fail_cnt++;
+		return;
+	}
+	printf("[MICOM] Success to receive with non-block mode in recv callback from PID(%d). msg : [%s]\n", recv_data->sender_pid, (char *)recv_data->buf);
+	sem_post(&nonblock_sem);
+}
+
+static int nonblock_recv(int argc, FAR char *argv[])
+{
+	int ret;
+	msg_callback_info_t cb_info;
+	msg_recv_buf_t data;
+
+	sem_init(&nonblock_sem, 0, 0);
+
+	cb_info.cb_func = recv_callback;
+	cb_info.cb_data = NULL;
+
+	data.buf = (char *)malloc(BUFFER_SIZE);
+	if (data.buf == NULL) {
+		printf("[MICOM] Fail to recv nonblock message : out of memory.\n");
+		return ERROR;
+	}
+	data.buflen = BUFFER_SIZE;
+
+	ret = messaging_recv_nonblock(NOREPLY_NONBLOCK_PORT, &data, &cb_info);
+	if (ret != OK) {
+		free(data.buf);
+		printf("[MICOM] Fail to receive with non-block mode.\n");
+		return ERROR;
+	}
+
+	/* Wait not to finish this task, because of receiving data through the callback. */
+	sem_wait(&nonblock_sem);
+	sem_destroy(&nonblock_sem);
+
+	ret = messaging_cleanup(NOREPLY_NONBLOCK_PORT);
+	if (ret != OK) {
+		free(data.buf);
+		printf("[MICOM] Fail to cleanup NOREPLY_NONBLOCK_PORT.\n");
+		return ERROR;
+	}
+
+	free(data.buf);
+	return OK;
+}
+
+static void multi_recv_callback(msg_reply_type_t msg_type, msg_recv_buf_t *recv_data, void *cb_data)
+{
+	if (recv_data == NULL) {
+		printf("[MICOM] Fail to receive multicast message with non-block mode.\n");
+		multicast_fail_cnt++;
+		return;
+	}
+	printf("[MICOM] Success to receive multicast message in recv callback. [%s]\n", (char *)recv_data->buf);
+}
+
+static int multi_recv_nonblock(int argc, FAR char *argv[])
+{
+	int ret;
+	msg_callback_info_t cb_info;
+	msg_recv_buf_t data;
+
+	cb_info.cb_func = multi_recv_callback;
+	cb_info.cb_data = NULL;
+
+	sem_init(&multi_sem, 0, 0);
+
+	data.buf = (char *)zalloc(BUFFER_SIZE);
+	if (data.buf == NULL) {
+		printf("[MICOM] Fail to recv nonblock multicast message : out of memory.\n");
+		multicast_fail_cnt++;
+		sem_destroy(&multi_sem);
+		return ERROR;
+	}
+	data.buflen = BUFFER_SIZE;
+
+	ret = messaging_recv_nonblock(MULTICAST_PORT, &data, &cb_info);
+	if (ret != OK) {
+		multicast_fail_cnt++;
+		printf("[MICOM] Fail to receive multicast with non-block mode.\n");
+		free(data.buf);
+		sem_destroy(&multi_sem);
+		return ERROR;
+	}
+
+	/* Wait not to finish this task, because of receiving data through the callback. */
+	sem_wait(&multi_sem);
+	sem_destroy(&multi_sem);
+
+	free(data.buf);
+
+	ret = messaging_cleanup(MULTICAST_PORT);
+	if (ret != OK) {
+		multicast_fail_cnt++;
+		printf("[MICOM] Fail to cleanup MULTICAST_PORT.\n");
+		return ERROR;
+	}
+	return OK;
+}
+
+static int multi_recv_block(int argc, FAR char *argv[])
+{
+	int ret;
+	msg_recv_buf_t msg;
+
+	msg.buflen = BUFFER_SIZE;
+	msg.buf = (char *)zalloc(BUFFER_SIZE);
+	if (msg.buf == NULL) {
+		multicast_fail_cnt++;
+		printf("[MICOM] Fail to malloc for multi_recv buffer.\n");
+		return ERROR;
+	}
+
+	ret = messaging_recv_block(MULTICAST_PORT, &msg);
+	if (ret < 0) {
+		multicast_fail_cnt++;
+		printf("[MICOM] Fail to receive multicast message in multi_recv.\n");
+		return ERROR;
+	}
+
+	printf("[MICOM] Success to receive multicast message [%s], receiver pid : %d\n", msg.buf, getpid());
+	free(msg.buf);
+	
+	return OK;
+}
+
+static int block_recv_test(void)
+{
+	int pid;
+
+	pid = task_create("block_recv", 120, STACKSIZE, block_recv, NULL);
+	if (pid < 0) {
+		printf("[MICOM] Fail to create block_recv task.\n");
+		return ERROR;
+	}
+	return 0;
+}
+
+static int nonblock_recv_test(void)
+{
+	int pid;
+
+	pid = task_create("nonblock_recv", TASK_PRIO, STACKSIZE, nonblock_recv, NULL);
+	if (pid < 0) {
+		printf("[MICOM] Fail to create nonblock_recv task.\n");
+		return ERROR;
+	}
+	return 0;
+}
+
+static int multicast_recv_test(void)
+{
+	int recv1_pid;
+	int recv2_pid;
+	int recv3_pid;
+
+	recv1_pid = task_create("multi_recv_nonblock", TASK_PRIO - 1, STACKSIZE, multi_recv_nonblock, NULL);
+	if (recv1_pid < 0) {
+		printf("[MICOM] Fail to create multi_recv_nonblock task.\n");
+		return ERROR;
+	}
+
+	recv2_pid = task_create("multi_recv_block1", TASK_PRIO, STACKSIZE, multi_recv_block, NULL);
+	if (recv2_pid < 0) {
+		printf("[MICOM] Fail to create multi_recv_block1 task.\n");
+		return ERROR;
+	}
+
+	recv3_pid = task_create("multi_recv_block2", TASK_PRIO, STACKSIZE, multi_recv_block, NULL);
+	if (recv3_pid < 0) {
+		printf("[MICOM] Fail to create multi_recv_block2 task.\n");
+		return ERROR;
+	}
+
+	return OK;
+}
+
+static void check_can_do_next(void)
+{
+	msg_recv_buf_t recv_data;
+
+	recv_data.buf = (char *)malloc(BUFFER_SIZE);
+	if (recv_data.buf == NULL) {
+		printf("[MICOM] Fail to receive, because out of memory.\n");
+		return;
+	}
+	recv_data.buflen = BUFFER_SIZE;
+
+	while (strncmp(recv_data.buf, CHECK_MSG, strlen(CHECK_MSG) + 1) != 0) {
+		memset(recv_data.buf, 0, BUFFER_SIZE);
+		(void)messaging_recv_block(CHECK_PORT, &recv_data);
+	}
+
+	free(recv_data.buf);
+}
+
+void messaging_test(void)
+{
+	int ret;
+	int rep_cnt;
+	int repetition_num = CONFIG_MESSAGING_TEST_REPETITION_NUM;
+
+	if (repetition_num < 0) {
+		repetition_num = 10;
+	}
+
+	for (rep_cnt = 1; rep_cnt <= repetition_num; rep_cnt++) {
+		ret = multicast_recv_test();
+		if (ret != OK) {
+			multicast_fail_cnt++;
+		}
+
+		ret = block_recv_test();
+		if (ret != OK) {
+			block_fail_cnt++;
+		}
+
+		ret = nonblock_recv_test();
+		if (ret != OK) {
+			nonblock_fail_cnt++;
+		}
+
+		check_can_do_next();
+		if (CONFIG_MESSAGING_TEST_REPETITION_NUM < 0) {
+			/* Test will run infinitely. */
+			rep_cnt = 1;
+		}
+	}
+
+	printf("<<Receiver>> Summary\n");
+	printf(" - Total : %d iteration\n", CONFIG_MESSAGING_TEST_REPETITION_NUM);
+	printf(" - Block mode : %d fails\n", block_fail_cnt);
+	printf(" - Non-block mode : %d fails\n", nonblock_fail_cnt);
+	printf(" - Multicast mode : %d fails\n", multicast_fail_cnt);
+
+}

--- a/apps/examples/elf/micomapp/micomapp.c
+++ b/apps/examples/elf/micomapp/micomapp.c
@@ -23,11 +23,16 @@
 #include <stdio.h>
 #include <unistd.h>
 
+#include "micomapp_internal.h"
+
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
 int main(int argc, char **argv)
 {
+#ifdef CONFIG_EXAMPLES_MESSAGING_TEST
+	messaging_test();
+#endif
 	while (1) {
 		sleep(10);
 		printf("[%d] MICOM ALIVE\n", getpid());

--- a/apps/examples/elf/micomapp/micomapp_internal.h
+++ b/apps/examples/elf/micomapp/micomapp_internal.h
@@ -15,12 +15,9 @@
  * language governing permissions and limitations under the License.
  *
  ****************************************************************************/
-#ifndef __EXAMPLES_ELF_WIFIAPP_INTERNAL_H
-#define __EXAMPLES_ELF_WIFIAPP_INTERNAL_H
+#ifndef __EXAMPLES_ELF_MICOMAPP_INTERNAL_H
+#define __EXAMPLES_ELF_MICOMAPP_INTERNAL_H
 
-#ifdef CONFIG_EXAMPLES_RECOVERY_TEST
-void recovery_test(void);
-#endif
 #ifdef CONFIG_EXAMPLES_MESSAGING_TEST
 void messaging_test(void);
 #endif

--- a/apps/examples/elf/wifiapp/Makefile
+++ b/apps/examples/elf/wifiapp/Makefile
@@ -80,6 +80,10 @@ else
 LDLIBS += -lmm
 endif
 
+ifeq ($(CONFIG_EXAMPLES_MESSAGING_TEST),y)
+LDLIBS += -lframework
+endif
+
 LIBGCC = "${shell "$(CC)" $(ARCHCFLAGS) -print-libgcc-file-name}"
 LDLIBS += $(LIBGCC)
 endif
@@ -95,9 +99,13 @@ STACKSIZE = 4096
 PRIORITY = 180
 
 SRCS = wifiapp.c
+ifeq ($(CONFIG_EXAMPLES_MESSAGING_TEST),y)
+SRCS += messaging.c
+endif
 ifeq ($(CONFIG_EXAMPLES_RECOVERY_TEST),y)
 SRCS += recovery.c
 endif
+
 OBJS = $(SRCS:.c=$(OBJEXT))
 
 all: $(BIN)

--- a/apps/examples/elf/wifiapp/messaging.c
+++ b/apps/examples/elf/wifiapp/messaging.c
@@ -1,0 +1,207 @@
+/****************************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+#include <tinyara/config.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <errno.h>
+#include <sched.h>
+#include <semaphore.h>
+
+#include <messaging/messaging.h>
+
+#define SYNC_BLOCK_PORT "sync_block_port"
+#define SYNC_BLOCK_DATA "sync_block_msg"
+#define SYNC_BLOCK_REPLY "reply_msg"
+
+#define NOREPLY_NONBLOCK_PORT "noreply_nonblock"
+#define NOREPLY_NONBLOCK_DATA "noreply_data"
+
+#define MULTICAST_PORT "multicast_port"
+#define MULTICAST_DATA "multi_msg"
+
+#define CHECK_PORT "check_port"
+#define CHECK_MSG  "do_next"
+
+#define BUFFER_SIZE 20
+#define MSG_PRIO 10
+
+static sem_t sender_sem;
+
+static int sync_fail_cnt;
+static int noreply_fail_cnt;
+static int multicast_fail_cnt;
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+static int sync_send_test(void)
+{
+	int ret;
+	msg_send_data_t send_data;
+	msg_recv_buf_t reply_data;
+
+	sem_wait(&sender_sem);
+
+	send_data.priority = MSG_PRIO;
+	send_data.msg = SYNC_BLOCK_DATA;
+	send_data.msglen = sizeof(SYNC_BLOCK_DATA);
+
+	reply_data.buflen = BUFFER_SIZE;
+	reply_data.buf = (char *)malloc(BUFFER_SIZE);
+	if (reply_data.buf == NULL) {
+		sem_post(&sender_sem);
+		printf("[WIFI] Fail to sync send message : out of memory.\n");
+		return ERROR;
+	}
+
+	printf("[WIFI] - Send [%s] data with sync mode.\n", SYNC_BLOCK_DATA);
+	ret = messaging_send_sync(SYNC_BLOCK_PORT, &send_data, &reply_data);
+	if (ret != OK) {
+		free(reply_data.buf);
+		sem_post(&sender_sem);
+		printf("[WIFI] Fail to sync send message.\n");
+		return ERROR;
+	}
+
+	printf("[WIFI] Success to receive reply from receiver. msg : [%s]\n", (char *)reply_data.buf);
+	free(reply_data.buf);
+
+	sem_post(&sender_sem);
+	return 0;
+}
+
+static int noreply_send_test(void)
+{
+	int ret;
+	msg_send_data_t param;
+
+	sem_wait(&sender_sem);
+
+	param.priority = MSG_PRIO;
+	param.msg = NOREPLY_NONBLOCK_DATA;
+	param.msglen = sizeof(NOREPLY_NONBLOCK_DATA);
+
+	printf("[WIFI] - Send [%s] data with noreply mode.\n", NOREPLY_NONBLOCK_DATA);
+	ret = messaging_send(NOREPLY_NONBLOCK_PORT, &param);
+	if (ret != OK) {
+		sem_post(&sender_sem);
+		printf("[WIFI] Fail to noreply send message.\n");
+		return ERROR;
+	}
+
+	sem_post(&sender_sem);
+	return 0;
+}
+
+static int multicast_send_test(void)
+{
+	int ret;
+	msg_send_data_t data;
+
+	sem_wait(&sender_sem);
+
+	data.priority = MSG_PRIO;
+	data.msg = MULTICAST_DATA;
+	data.msglen = sizeof(MULTICAST_DATA);
+
+	printf("[WIFI] - Send Multicast [%s] data.\n", MULTICAST_DATA);
+	ret = messaging_multicast(MULTICAST_PORT, &data);
+	if (ret != 3) {
+		sem_post(&sender_sem);
+		printf("[WIFI] Fail to send multicast.\n");
+		return ERROR;
+	}
+
+	sem_post(&sender_sem);
+	return 0;
+}
+
+static void check_can_do_next(void)
+{
+	msg_send_data_t param;
+
+	param.priority = MSG_PRIO;
+	param.msg = CHECK_MSG;
+	param.msglen = sizeof(CHECK_MSG);
+
+	(void)messaging_send(CHECK_PORT, &param);
+}
+
+void messaging_test(void)
+{
+	int ret;
+	int rep_cnt;
+
+	int repetition_num = CONFIG_MESSAGING_TEST_REPETITION_NUM;
+
+	if (repetition_num < 0) {
+		repetition_num = 10;
+	}
+
+	sem_init(&sender_sem, 0, 1);
+
+	for (rep_cnt = 1; rep_cnt <= repetition_num; rep_cnt++) {
+		printf("\n\n=== Messaging F/W Test : %d-th iteration. ===\n", rep_cnt);
+
+		printf("\n--- Sync Send & Block Receive Test. ---\n");
+		ret = sync_send_test();
+		if (ret != OK) {
+			sync_fail_cnt++;
+		}
+
+		/* Wait for finishing previous test. */
+		sleep(1);
+
+		printf("\n--- NoReply Send & NonBlock Receive Test. ---\n");
+		ret = noreply_send_test();
+		if (ret != OK) {
+			noreply_fail_cnt++;
+		}
+
+		/* Wait for finishing previous test. */
+		sleep(1);
+
+		printf("\n--- Multicast Send & Receive Test. ---\n");
+		ret = multicast_send_test();
+		if (ret != OK) {
+			multicast_fail_cnt++;
+		}
+
+		check_can_do_next();
+
+		sleep(3);
+		if (CONFIG_MESSAGING_TEST_REPETITION_NUM < 0) {
+			/* Test will run infinitely. */
+			rep_cnt = 1;
+		}
+	}
+
+	printf("<<Sender>> Summary\n");
+	printf(" - Total : %d iteration\n", CONFIG_MESSAGING_TEST_REPETITION_NUM);
+	printf(" - Sync mode : %d fails\n", sync_fail_cnt);
+	printf(" - Noreply mode : %d fails\n", noreply_fail_cnt);
+	printf(" - Multicast mode : %d fails\n", multicast_fail_cnt);
+
+	sem_wait(&sender_sem);
+	sem_destroy(&sender_sem);
+}

--- a/apps/examples/elf/wifiapp/wifiapp.c
+++ b/apps/examples/elf/wifiapp/wifiapp.c
@@ -32,6 +32,9 @@
 static void display_test_scenario(void)
 {
 	printf("\nSelect Test Scenario.\n");
+#ifdef CONFIG_EXAMPLES_MESSAGING_TEST
+	printf("\t-Press M or m : Messaging F/W Test\n");	
+#endif
 #ifdef CONFIG_EXAMPLES_RECOVERY_TEST
 	printf("\t-Press R or r : Recovery Test\n");
 #endif
@@ -49,6 +52,12 @@ int main(int argc, char **argv)
 		display_test_scenario();
 		ch = getchar();
 		switch (ch) {
+#ifdef CONFIG_EXAMPLES_MESSAGING_TEST
+		case 'M':
+		case 'm':
+			messaging_test();
+			break;
+#endif
 #ifdef CONFIG_EXAMPLES_RECOVERY_TEST
 		case 'R':
 		case 'r':


### PR DESCRIPTION
    This sample tests the messaging framework.
    Micom is a receiver and Wifi is a sender for communication.
    Repetition version will be updated with another commit.

    Expected Result>

    === Messaging F/W Test : 1-th iteration. ===

    --- Sync Send & Block Receive Test. ---
    [WIFI] - Send [sync_block_msg] data with sync mode.
    [MICOM] Success to receive with block mode in receiver. msg : [sync_block_msg]
    [MICOM] - Reply to sender [reply_msg] data.
    [WIFI] Success to receive reply from receiver. msg : [reply_msg]

    --- NoReply Send & NonBlock Receive Test. ---
    [WIFI] - Send [noreply_data] data with noreply mode.
    [MICOM] Success to receive with non-block mode in recv callback from PID(8). msg : [noreply_data]

    --- Multicast Send & Receive Test. ---
    [WIFI] - Send Multicast [multi_msg] data.
    [MICOM] Success to receive multicast message in recv callback. [multi_msg]
    [MICOM] Success to receive multicast message [multi_msg], receiver pid : 11
    [MICOM] Success to receive multicast message [multi_msg], receiver pid : 10

    <<Sender>> Summary
     - Total : 1 iteration
     - Sync mode : 0 fails
     - Noreply mode : 0 fails
     - Multicast mode : 0 fails