### PR TITLE
apps/examples/testcase : add libc math testcase

### DIFF
--- a/apps/examples/testcase/le_tc/kernel/tc_libc_math.c
+++ b/apps/examples/testcase/le_tc/kernel/tc_libc_math.c
@@ -2620,7 +2620,7 @@ static void tc_libc_math_log2f(void)
  */
 static void tc_libc_math_log2l(void)
 {
-	const long double in_val[] ={ 1024, 5.5, -10.0, 0.95, 0, NAN, INFINITY, -INFINITY };
+	const long double in_val[] = { 1024, 5.5, -10.0, 0.95, 0, NAN, INFINITY, -INFINITY };
 	const long double sol_val[] = { 10.0, 2.4594316186373, NAN, -0.074000597000122, -INFINITY, NAN, INFINITY, NAN };
 	long double ret_val[SIZE(sol_val, long double)];
 	int log2l_idx;
@@ -4213,21 +4213,33 @@ static void tc_libc_math_ynf(void)
  */
 static void tc_libc_math_gamma(void)
 {
-	double value;
-	double result;
-
-	value = 2.0;
-	result = gamma(value);
-	TC_ASSERT_EQ("gamma", result, 1);
-
-	value = 3.0;
-	result = gamma(value);
-	TC_ASSERT_EQ("gamma", result, 2);
-
-	value = INFINITY;
-	result = gamma(value);
-	TC_ASSERT_EQ("gamma", result, (double)INFINITY);
-
+	double in_val[13] = { 2.0, 3.0, INFINITY, 256.5,
+						1.0e-20, -257.5, -256.5, -1.0,
+						-1.5, 8.1, 8.3, 8.8, 9.3 };
+	double sol_val[13] = { 1, 2, INFINITY, 0x1p1023 * 256.5,
+						1 / 1.0e-20, ZERO, -ZERO, NAN,
+						2.363271801, 6169.5936974846, 9281.3925257465,
+						26339.986354509, 77035.557963696 };
+	int digit = 1e5;
+	int gamma_idx;
+	/**
+	 * gamma value comparison
+	 */
+	for (gamma_idx = 0; gamma_idx < SIZE(in_val, double); gamma_idx++) {
+		if (gamma_idx >= 8) {
+			/**
+			 * Compare to the fifth decimal place (digit)
+			 */
+			TC_ASSERT_EQ("gamma", floor(gamma(in_val[gamma_idx]) * digit), floor(sol_val[gamma_idx] * digit));
+		} else if (gamma_idx == 7) {
+			/**
+			 * Compare to NAN
+			 */
+			TC_ASSERT_EQ("gamma", isnan(gamma(in_val[gamma_idx])), isnan(sol_val[gamma_idx]));
+		} else {
+			TC_ASSERT_EQ("gamma", gamma(in_val[gamma_idx]), sol_val[gamma_idx]);
+		}
+	}
 	TC_SUCCESS_RESULT();
 }
 


### PR DESCRIPTION
Add libc math gamma testcase to improve coverage.

artik053 log :

U-Boot 2017.01-g59977f7 (Nov 23 2017 - 16:09:49 +0900)

CPU:   Exynos200 @ 320 MHz
Model: ARTIK-053 based on Exynos T20
DRAM:  946 KiB
WARNING: Caches not enabled
BL1 released at 2017-3-13 15:00
SSS released at 2017-09-12
WLAN released at 2017-11-30
Flash: 8 MiB
*** Warning - bad CRC, using default environment

In:    serial@80180000
Out:   serial@80180000
Err:   serial@80180000
Hit any key to stop autoboot:  0
gpio: pin gpg16 (gpio 46) value is 1
s5j_sflash_init: FLASH Quad Enabled
i2c_uioregister: Registering /dev/i2c-0
i2c_uioregister: Registering /dev/i2c-1
up_spiinitialize: Prepare SPI0 for Master operation
up_spiinitialize: Prepare SPI1 for Master operation
up_spiinitialize: Prepare SPI2 for Master operation
up_spiinitialize: Prepare SPI3 for Master operation
System Information:
        Version: 2.0
        Commit Hash: fabda57f0b79588825d919b06540d55875abb939
        Build User: root@a5dd9faf45f9
        Build Time: 2019-05-22 01:22:04
        System Time: 01 Jan 2010, 00:00:00 [s] UTC Hardware RTC Support
TASH>>
Testcase registers TASH commands named "<MODULE_NAME>_tc".
Please find them using "help" and execute them in TASH
kernel_tc

[tc_libc_math_acos] PASS

[tc_libc_math_acosf] PASS

[tc_libc_math_acosh] PASS

[tc_libc_math_acoshf] PASS

[tc_libc_math_acoshl] PASS

[tc_libc_math_acosl] PASS

[tc_libc_math_asin] PASS

[tc_libc_math_asinf] PASS

[tc_libc_math_asinh] PASS

[tc_libc_math_asinhf] PASS

[tc_libc_math_asinhl] PASS

[tc_libc_math_asinl] PASS

[tc_libc_math_atan] PASS

[tc_libc_math_atanf] PASS

[tc_libc_math_atanh] PASS

[tc_libc_math_atanhf] PASS

[tc_libc_math_atanhl] PASS

[tc_libc_math_atanl] PASS

[tc_libc_math_atan2] PASS

[tc_libc_math_atan2f] PASS

[tc_libc_math_atan2l] PASS

[tc_libc_math_cbrt] PASS

[tc_libc_math_cbrtf] PASS

[tc_libc_math_cbrtl] PASS

[tc_libc_math_ceil] PASS

[tc_libc_math_ceilf] PASS

[tc_libc_math_ceill] PASS

[tc_libc_math_copysign] PASS

[tc_libc_math_copysignf] PASS

[tc_libc_math_copysignl] PASS

[tc_libc_math_cos] PASS

[tc_libc_math_cosf] PASS

[tc_libc_math_cosh] PASS

[tc_libc_math_coshf] PASS

[tc_libc_math_coshl] PASS

[tc_libc_math_cosl] PASS

[tc_libc_math_erf] PASS

[tc_libc_math_erff] PASS

[tc_libc_math_erfl] PASS

[tc_libc_math_exp] PASS

[tc_libc_math_expf] PASS

[tc_libc_math_expl] PASS

[tc_libc_math_exp2] PASS

[tc_libc_math_exp2f] PASS

[tc_libc_math_exp2l] PASS

[tc_libc_math_fabs] PASS

[tc_libc_math_fabsf] PASS

[tc_libc_math_fabsl] PASS

[tc_libc_math_fdim] PASS

[tc_libc_math_fdimf] PASS

[tc_libc_math_fdiml] PASS

[tc_libc_math_floor] PASS

[tc_libc_math_floorf] PASS

[tc_libc_math_floorl] PASS

[tc_libc_math_fmax] PASS

[tc_libc_math_fmaxf] PASS

[tc_libc_math_fmaxl] PASS

[tc_libc_math_fmin] PASS

[tc_libc_math_fminf] PASS

[tc_libc_math_fminl] PASS

[tc_libc_math_frexp] PASS

[tc_libc_math_frexpf] PASS

[tc_libc_math_frexpl] PASS

[tc_libc_math_gamma] PASS

[tc_libc_math_hypot] PASS

[tc_libc_math_hypotf] PASS

[tc_libc_math_hypotl] PASS

[tc_libc_math_j0] PASS

[tc_libc_math_j0f] PASS

[tc_libc_math_j1] PASS

[tc_libc_math_j1f] PASS

[tc_libc_math_jn] PASS

[tc_libc_math_jnf] PASS

[tc_libc_math_ldexp] PASS

[tc_libc_math_ldexpf] PASS

[tc_libc_math_ldexpl] PASS

[tc_libc_math_lgamma] PASS

[tc_libc_math_log] PASS

[tc_libc_math_log2] PASS

[tc_libc_math_log2f] PASS

[tc_libc_math_log2l] PASS

[tc_libc_math_log10] PASS

[tc_libc_math_log10f] PASS

[tc_libc_math_log10l] PASS

[tc_libc_math_nextafter] PASS

[tc_libc_math_nextafterf] PASS

[tc_libc_math_nextafterl] PASS

[tc_libc_math_nexttoward] PASS

[tc_libc_math_nexttowardf] PASS

[tc_libc_math_nexttowardl] PASS

[tc_libc_math_pow] PASS

[tc_libc_math_remainder] PASS

[tc_libc_math_remainderf] PASS

[tc_libc_math_remainderl] PASS

[tc_libc_math_remquo] PASS

[tc_libc_math_remquof] PASS

[tc_libc_math_remquol] PASS

[tc_libc_math_rint] PASS

[tc_libc_math_rintf] PASS

[tc_libc_math_rintl] PASS

[tc_libc_math_round] PASS

[tc_libc_math_roundf] PASS

[tc_libc_math_roundl] PASS

[tc_libc_math_scalbn] PASS

[tc_libc_math_scalbnf] PASS

[tc_libc_math_scalbnl] PASS

[tc_libc_math_sin] PASS

[tc_libc_math_sinf] PASS

[tc_libc_math_sinh] PASS

[tc_libc_math_sinhf] PASS

[tc_libc_math_sinhl] PASS

[tc_libc_math_sinl] PASS

[tc_libc_math_sqrt] PASS

[tc_libc_math_sqrtf] PASS

[tc_libc_math_sqrtl] PASS

[tc_libc_math_tan] PASS

[tc_libc_math_tanf] PASS

[tc_libc_math_tanh] PASS

[tc_libc_math_tanhf] PASS

[tc_libc_math_tanhl] PASS

[tc_libc_math_tanl] PASS

[tc_libc_math_trunc] PASS

[tc_libc_math_truncf] PASS

[tc_libc_math_y0] PASS

[tc_libc_math_y0f] PASS

[tc_libc_math_y1] PASS

[tc_libc_math_y1f] PASS

[tc_libc_math_yn] PASS

[tc_libc_math_ynf] PASS