### PR TITLE
security/utc: Fix security UTC bug

### DIFF
--- a/apps/examples/testcase/ta_tc/security/utc/utc_auth.c
+++ b/apps/examples/testcase/ta_tc/security/utc/utc_auth.c
@@ -1131,7 +1131,10 @@ static void utc_auth_generate_dhparams_hnd_n(void)
  */
 static void utc_auth_generate_dhparams_name_n(void)
 {
-	security_dh_param param;
+	security_data G;
+	security_data P;
+	security_data pubkey;
+	security_dh_param param = {DH_1024, &G, &P, &pubkey};
 	security_error res = auth_generate_dhparams(g_hnd, NULL, &param);
 
 	TC_ASSERT_EQ("auth_generate_dhparams_name_n", res, SECURITY_INVALID_KEY_INDEX);
@@ -1270,7 +1273,10 @@ static void utc_auth_compute_dhparams_secret_n(void)
  */
 static void utc_auth_generate_ecdhkey_p(void)
 {
-	security_ecdh_param param;
+	security_ecdsa_mode curve = ECDSA_UNKNOWN;
+	security_data px;
+	security_data py;
+	security_ecdh_param param = {curve, &px, &py};
 	security_error res = auth_generate_ecdhkey(g_hnd, UTC_CRYPTO_KEY_NAME, &param);
 
 	TC_ASSERT_EQ("auth_generate_ecdhkey_p", res, SECURITY_OK);
@@ -1287,7 +1293,10 @@ static void utc_auth_generate_ecdhkey_p(void)
  */
 static void utc_auth_generate_ecdhkey_hnd_n(void)
 {
-	security_ecdh_param param;
+	security_ecdsa_mode curve = ECDSA_UNKNOWN;
+	security_data px;
+	security_data py;
+	security_ecdh_param param = {curve, &px, &py};
 	security_error res = auth_generate_ecdhkey(NULL, UTC_CRYPTO_KEY_NAME, &param);
 
 	TC_ASSERT_EQ("auth_generate_ecdhkey_hnd_n", res, SECURITY_INVALID_INPUT_PARAMS);
@@ -1304,7 +1313,10 @@ static void utc_auth_generate_ecdhkey_hnd_n(void)
  */
 static void utc_auth_generate_ecdhkey_name_n(void)
 {
-	security_ecdh_param param;
+	security_ecdsa_mode curve = ECDSA_UNKNOWN;
+	security_data px;
+	security_data py;
+	security_ecdh_param param = {curve, &px, &py};
 	security_error res = auth_generate_ecdhkey(g_hnd, NULL, &param);
 
 	TC_ASSERT_EQ("auth_generate_ecdhkey_name_n", res, SECURITY_INVALID_KEY_INDEX);

--- a/apps/examples/testcase/ta_tc/security/utc/utc_keymgr.c
+++ b/apps/examples/testcase/ta_tc/security/utc/utc_keymgr.c
@@ -268,7 +268,7 @@ static void utc_keymgr_get_key_p(void)
 	}
 
 	for (i = 0; i < sizeof(g_asym_key_type_table)/sizeof(security_key_type); i++) {
-		security_error res = keymgr_get_key(g_hnd, g_sym_key_type_table[i], UTC_CRYPTO_KEY_NAME, &pubkey, &privkey);
+		security_error res = keymgr_get_key(g_hnd, g_asym_key_type_table[i], UTC_CRYPTO_KEY_NAME, &pubkey, &privkey);
 		TC_ASSERT_EQ("keymgr_get_key_p", res, SECURITY_OK);
 		TC_SUCCESS_RESULT();
 	}
@@ -366,9 +366,10 @@ static void utc_keymgr_remove_key_p(void)
 	}
 
 	for (i = 0; i < sizeof(g_asym_key_type_table)/sizeof(security_key_type); i++) {
-		security_error res = keymgr_get_key(g_hnd, g_sym_key_type_table[i], UTC_CRYPTO_KEY_NAME, &pubkey, &privkey);
+		security_error res = keymgr_set_key(g_hnd, g_asym_key_type_table[i], UTC_CRYPTO_KEY_NAME, &pubkey, &privkey);
 		TC_ASSERT_EQ("keymgr_remove_key_p", res, SECURITY_OK);
-		res = keymgr_remove_key(g_hnd, g_sym_key_type_table[i], UTC_CRYPTO_KEY_NAME);
+
+		res = keymgr_remove_key(g_hnd, g_asym_key_type_table[i], UTC_CRYPTO_KEY_NAME);
 		TC_ASSERT_EQ("keymgr_remove_key_p", res, SECURITY_OK);
 		TC_SUCCESS_RESULT();
 	}

--- a/apps/examples/testcase/ta_tc/security/utc/utc_ss.c
+++ b/apps/examples/testcase/ta_tc/security/utc/utc_ss.c
@@ -260,7 +260,7 @@ static void utc_ss_get_size_secure_storage_name_n(void)
 	unsigned int size = 0;
 	security_error res = ss_get_size_secure_storage(g_hnd, NULL, &size);
 
-	TC_ASSERT_EQ("ss_get_size_secure_storage_name_n", res, SECURITY_INVALID_INPUT_PARAMS);
+	TC_ASSERT_EQ("ss_get_size_secure_storage_name_n", res, SECURITY_INVALID_KEY_INDEX);
 	TC_SUCCESS_RESULT();
 }
 

--- a/os/se/virtual/hal_virtual.c
+++ b/os/se/virtual/hal_virtual.c
@@ -194,6 +194,7 @@ int virtual_hal_get_key(_IN_ hal_key_type type, _IN_ uint32_t key_idx, _OUT_ hal
 		V_COPY_DATA(key, g_virtual_sym);
 		key->priv_len = 0;
 	}
+	VH_LOG("key(%p), len(%d)\n", key->data, key->data_len);
 
 	return 0;
 }


### PR DESCRIPTION
There are several issues in security UTC.
1) confuse asymmetric key list and symmetric key list which are
defined at UTC. so it causes unexpected errors
2) there is no logic that checks whether seconds public key is
exist. so it allocate unused memory for key and make an error.