### PR TITLE
arch/imxrt/gpt: set proper divider with clock source in imxrt_gpt_init

### DIFF
--- a/os/arch/arm/src/imxrt/imxrt_gpt.c
+++ b/os/arch/arm/src/imxrt/imxrt_gpt.c
@@ -86,7 +86,11 @@ void imxrt_gpt_init(GPT_Type *base, const gpt_config_t *initConfig)
 		(initConfig->enableRunInDbg ? GPT_CR_DBGEN_MASK : 0U) | (initConfig->enableMode ? GPT_CR_ENMOD_MASK : 0U);
 
 	imxrt_gpt_setclocksource(base, initConfig->clockSource);
-	imxrt_gpt_setclockdivider(base, initConfig->divider);
+	if (initConfig->clockSource == kGPT_ClockSource_Osc) {
+		imxrt_gpt_setoscclockdivider(base, initConfig->divider);
+	} else {
+		imxrt_gpt_setclockdivider(base, initConfig->divider);
+	}
 }
 
 /*!


### PR DESCRIPTION
There are two functions of setting clock divider, imxrt_gpt_setclockdivider and
imxrt_gpt_setoscclockdivider.
When clock source is kGPT_ClockSource_Osc, imxrt_gpt_setoscclockdivider should
be used to set.
But imxrt_gpt_init function only uses setclockdivider so that it is wrong with
OSC clock.
This commit adds a conditional to check clock source and uses proper function.

Signed-off-by: sunghan-chang <sh924.chang@samsung.com>