### PR TITLE
kernel/binary_manager: Add dependency of binary manager

### DIFF
--- a/os/kernel/Kconfig
+++ b/os/kernel/Kconfig
@@ -1093,7 +1093,8 @@ menu "Binary Manager"
 config BINARY_MANAGER
 	bool "Enable Binary Manager"
 	default n
-	depends on APP_BINARY_SEPARATION
+	depends on APP_BINARY_SEPARATION && BINFMT_LOADABLE && !DISABLE_MQUEUE
+	depends on MTD_FTL && FLASH_PART_SIZE && FLASH_PART_TYPE && FLASH_PART_NAME
 	---help---
 		This is kernel thread which manages binaries.
 		It loads/unloads binaries and recovers any fault occurs in a system.
@@ -1103,7 +1104,6 @@ if BINARY_MANAGER
 config BINMGR_RECOVERY
 	bool "Enable Recovery Management"
 	default y
-	depends on APP_BINARY_SEPARATION
 	---help---
 		Enable the recovery management.
 		If any fault occurs in a system, it will either restart binary or reboot the system

--- a/os/kernel/binary_manager/binary_manager.c
+++ b/os/kernel/binary_manager/binary_manager.c
@@ -25,7 +25,9 @@
 #include <debug.h>
 #include <fcntl.h>
 #include <string.h>
+#if !defined(CONFIG_DISABLE_SIGNALS)
 #include <signal.h>
+#endif
 #include <stdlib.h>
 #include <tinyara/binary_manager.h>
 
@@ -115,7 +117,9 @@ int binary_manager(int argc, char *argv[])
 {
 	int ret;
 	int nbytes;
+#if !defined(CONFIG_DISABLE_SIGNALS)
 	sigset_t sigset;
+#endif
 	char type_str[1];
 	char data_str[1];
 	char *loading_data[LOADTHD_ARGC + 1];
@@ -128,10 +132,12 @@ int binary_manager(int argc, char *argv[])
 
 	bmvdbg("Binary Manager STARTED\n");
 
+#if !defined(CONFIG_DISABLE_SIGNALS)
 	/* Unset all signals except for SIGKILL */
 	sigfillset(&sigset);
 	sigdelset(&sigset, SIGKILL);
 	(void)sigprocmask(SIG_SETMASK, &sigset, NULL);
+#endif
 
 	/* Create binary manager message queue */
 	g_binmgr_mq_fd = mq_open(BINMGR_REQUEST_MQ, O_RDWR | O_CREAT, 0666, &attr);


### PR DESCRIPTION
Add some dependencies of binary manager, APP_BINARY_SEPARATION, BINFMT_LOADABLE, !DISABLE_MQUEUE, FLASH_PARTITION, MTD_FTL and MTD_PARTITION_NAMES.
and missing !CONFIG_DISABLE_SIGNALS for using signal.