### PR TITLE
os/mm/mm_heap : Block context switching when managing heap memory

### DIFF
--- a/os/mm/mm_heap/mm_extend.c
+++ b/os/mm/mm_heap/mm_extend.c
@@ -57,6 +57,7 @@
 #include <tinyara/config.h>
 
 #include <assert.h>
+#include <sched.h>
 
 #include <tinyara/mm/mm.h>
 
@@ -106,6 +107,7 @@ void mm_extend(FAR struct mm_heap_s *heap, FAR void *mem, size_t size, int regio
 	/* Take the memory manager semaphore */
 
 	mm_takesemaphore(heap);
+	sched_lock();
 
 	/* Get the terminal node in the old heap.  The block to extend must
 	 * immediately follow this node.
@@ -133,6 +135,7 @@ void mm_extend(FAR struct mm_heap_s *heap, FAR void *mem, size_t size, int regio
 	newnode->preceding = oldnode->size | MM_ALLOC_BIT;
 
 	heap->mm_heapend[region] = newnode;
+	sched_unlock();
 	mm_givesemaphore(heap);
 
 	/* Finally "free" the new block of memory where the old terminal node was

--- a/os/mm/mm_heap/mm_free.c
+++ b/os/mm/mm_heap/mm_free.c
@@ -58,6 +58,7 @@
 
 #include <assert.h>
 #include <debug.h>
+#include <sched.h>
 
 #include <tinyara/mm/mm.h>
 
@@ -116,6 +117,7 @@ void mm_free(FAR struct mm_heap_s *heap, FAR void *mem)
 	 */
 
 	mm_takesemaphore(heap);
+	sched_lock();
 
 	/* Map the memory chunk into a free node */
 
@@ -202,5 +204,6 @@ void mm_free(FAR struct mm_heap_s *heap, FAR void *mem)
 	/* Add the merged node to the nodelist */
 
 	mm_addfreechunk(heap, node);
+	sched_unlock();
 	mm_givesemaphore(heap);
 }

--- a/os/mm/mm_heap/mm_heapinfo.c
+++ b/os/mm/mm_heap/mm_heapinfo.c
@@ -59,6 +59,7 @@
 #include <unistd.h>
 #include <stdint.h>
 #include <stdio.h>
+#include <sched.h>
 #ifdef CONFIG_HEAPINFO_USER_GROUP
 #include <string.h>
 #include <tinyara/mm/heapinfo_internal.h>
@@ -138,6 +139,7 @@ void heapinfo_parse(FAR struct mm_heap_s *heap, int mode, pid_t pid)
 		 * Retake the semaphore for each region to reduce latencies
 		 */
 		mm_takesemaphore(heap);
+		sched_lock();
 
 		if (mode != HEAPINFO_SIMPLE) {
 			printf("****************************************************************\n");
@@ -195,6 +197,7 @@ void heapinfo_parse(FAR struct mm_heap_s *heap, int mode, pid_t pid)
 		if (mode != HEAPINFO_SIMPLE) {
 			printf("** PID(S) in Pid colum means that mem is used for stack of PID\n\n");
 		}
+		sched_unlock();
 		mm_givesemaphore(heap);
 	}
 #undef region
@@ -245,6 +248,7 @@ void heapinfo_parse(FAR struct mm_heap_s *heap, int mode, pid_t pid)
 	printf("\nAvailable fragmented memory segments in heap memory\n");
 
 	mm_takesemaphore(heap);
+	sched_lock();
 
 	for (ndx = 0; ndx < MM_NNODES; ++ndx) {
 		for (fnode = heap->mm_nodelist[ndx].flink; fnode && fnode->size; fnode = fnode->flink) {
@@ -253,6 +257,7 @@ void heapinfo_parse(FAR struct mm_heap_s *heap, int mode, pid_t pid)
 		}
 	}
 
+	sched_unlock();
 	mm_givesemaphore(heap);
 
 	for (ndx = 0; ndx < MM_NNODES; ++ndx) {

--- a/os/mm/mm_heap/mm_mallinfo.c
+++ b/os/mm/mm_heap/mm_mallinfo.c
@@ -59,6 +59,7 @@
 #include <assert.h>
 #include <debug.h>
 #include <unistd.h>
+#include <sched.h>
 #include <tinyara/mm/mm.h>
 #include <tinyara/sched.h>
 /****************************************************************************
@@ -110,6 +111,7 @@ int mm_mallinfo(FAR struct mm_heap_s *heap, FAR struct mallinfo *info)
 		 */
 
 		mm_takesemaphore(heap);
+		sched_lock();
 
 		for (node = heap->mm_heapstart[region]; node < heap->mm_heapend[region]; node = (struct mm_allocnode_s *)((char *)node + node->size)) {
 			mvdbg("region=%d node=%p size=%p preceding=%p (%c)\n", region, node, node->size, (node->preceding & ~MM_ALLOC_BIT), (node->preceding & MM_ALLOC_BIT) ? 'A' : 'F');
@@ -127,6 +129,7 @@ int mm_mallinfo(FAR struct mm_heap_s *heap, FAR struct mallinfo *info)
 			}
 		}
 
+		sched_unlock();
 		mm_givesemaphore(heap);
 
 		mvdbg("region=%d node=%p heapend=%p\n", region, node, heap->mm_heapend[region]);

--- a/os/mm/mm_heap/mm_malloc.c
+++ b/os/mm/mm_heap/mm_malloc.c
@@ -58,6 +58,7 @@
 
 #include <assert.h>
 #include <debug.h>
+#include <sched.h>
 
 #include <tinyara/mm/mm.h>
 
@@ -134,6 +135,7 @@ FAR void *mm_malloc(FAR struct mm_heap_s *heap, size_t size)
 	/* We need to hold the MM semaphore while we muck with the nodelist. */
 
 	mm_takesemaphore(heap);
+	sched_lock();
 
 	/* Get the location in the node list to start the search
 	 * by converting the request size into a nodelist index.
@@ -214,6 +216,7 @@ FAR void *mm_malloc(FAR struct mm_heap_s *heap, size_t size)
 		ret = (void *)((char *)node + SIZEOF_MM_ALLOCNODE);
 	}
 
+	sched_unlock();
 	mm_givesemaphore(heap);
 
 	/* If CONFIG_DEBUG_MM is defined, then output the result of the allocation

--- a/os/mm/mm_heap/mm_memalign.c
+++ b/os/mm/mm_heap/mm_memalign.c
@@ -57,6 +57,7 @@
 #include <tinyara/config.h>
 
 #include <assert.h>
+#include <sched.h>
 
 #include <tinyara/mm/mm.h>
 
@@ -140,6 +141,7 @@ FAR void *mm_memalign(FAR struct mm_heap_s *heap, size_t alignment, size_t size)
 	 */
 
 	mm_takesemaphore(heap);
+	sched_lock();
 
 	/* Get the node associated with the allocation and the next node after
 	 * the allocation.
@@ -239,6 +241,7 @@ FAR void *mm_memalign(FAR struct mm_heap_s *heap, size_t alignment, size_t size)
 	heapinfo_add_size(heap, node->pid, node->size);
 	heapinfo_update_total_size(heap, node->size, node->pid);
 #endif
+	sched_unlock();
 	mm_givesemaphore(heap);
 	return (FAR void *)alignedchunk;
 }

--- a/os/mm/mm_heap/mm_realloc.c
+++ b/os/mm/mm_heap/mm_realloc.c
@@ -149,6 +149,7 @@ FAR void *mm_realloc(FAR struct mm_heap_s *heap, FAR void *oldmem, size_t size)
 	/* We need to hold the MM semaphore while we muck with the nodelist. */
 
 	mm_takesemaphore(heap);
+	sched_lock();
 
 	/* Check if this is a request to reduce the size of the allocation. */
 
@@ -178,6 +179,7 @@ FAR void *mm_realloc(FAR struct mm_heap_s *heap, FAR void *oldmem, size_t size)
 
 		/* Then return the original address */
 
+		sched_unlock();
 		mm_givesemaphore(heap);
 		return oldmem;
 	}
@@ -362,6 +364,7 @@ FAR void *mm_realloc(FAR struct mm_heap_s *heap, FAR void *oldmem, size_t size)
 		heapinfo_update_total_size(heap, oldnode->size, oldnode->pid);
 #endif
 
+		sched_unlock();
 		mm_givesemaphore(heap);
 		return newmem;
 	}
@@ -374,6 +377,7 @@ FAR void *mm_realloc(FAR struct mm_heap_s *heap, FAR void *oldmem, size_t size)
 		/* Allocate a new block.  On failure, realloc must return NULL but
 		 * leave the original memory in place.
 		 */
+		sched_unlock();
 		mm_givesemaphore(heap);
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
 		newmem = (FAR void *)mm_malloc(heap, size, caller_retaddr);


### PR DESCRIPTION
When heap memory management is doing, sched_lock is applied and
when heap memory management is completed, schecd_unlock is executed.