### PR TITLE
framework/st_things: Increase sleep time to apply Wi-Fi state changing.

### DIFF
--- a/framework/src/st_things/things_stack/utils/things_network.c
+++ b/framework/src/st_things/things_stack/utils/things_network.c
@@ -169,7 +169,7 @@ bool things_handle_stop_soft_ap(wifi_manager_ap_config_s *connect_config)
 			THINGS_LOG_E(TAG, "Failed to change to STA mode)");
 			return false;
 		}
-		usleep(100000);
+		usleep(500000);
 	}
 	g_retry_connect_cnt = 0;
 	result = wifi_manager_connect_ap(connect_config);


### PR DESCRIPTION
Error has been showing during Wi-Fi state changing.
It guesses that side effect of IPC changes. 

And now, there is no callback api about Wi-Fi state changes like "stop_softap_done".
So, It is one of refactoring point for st_things. 

In future, sleep will be changed to some callback to get result of Wi-Fi state changing.