### PR TITLE
kernel/binary_manager: Fix wrong dependency

### DIFF
--- a/os/kernel/Kconfig
+++ b/os/kernel/Kconfig
@@ -1094,7 +1094,7 @@ config BINARY_MANAGER
 	bool "Enable Binary Manager"
 	default n
 	depends on APP_BINARY_SEPARATION && BINFMT_LOADABLE && !DISABLE_MQUEUE
-	depends on MTD_FTL && (FLASH_PART_SIZE != NULL) && (FLASH_PART_TYPE != NULL) && (FLASH_PART_NAME != NULL)
+	depends on MTD_FTL && FLASH_PARTITION && MTD_PARTITION_NAMES
 	---help---
 		This is kernel thread which manages binaries.
 		It loads/unloads binaries and recovers any fault occurs in a system.


### PR DESCRIPTION
CONFIG_FLASH_PART_SIZE and CONFIG_FLASH_PART_TYPE have string type and are defined if CONFIG_FLASH_PARTITION is enabled.
Similarly CONFIG_FLASH_PART_NAME is enabled, if CONFIG_FLASH_PARITION and CONFIG_MTD_PARTITION_NAMES are enabled.
So binary manager has a dependency on CONFIG_FLASH_PARTITION and CONFIG_MTD_PARTITION_NAMES.