### PR TITLE
arch/arm/src/armv7-m : Add stack overflow check for nested interrupts

### DIFF
--- a/os/arch/Kconfig
+++ b/os/arch/Kconfig
@@ -584,8 +584,15 @@ config ARCH_NESTED_INTERRUPT
 	---help---
 		Enables the nested interrupt support. If defined, higher priority interrupt
 		can pre-empt the lower priority interrupt.
-endif
 
+config ARCH_NESTED_INTERRUPT_STACKCHECK
+	bool "Nested interrupt stack check support"
+	depends on ARCH_NESTED_INTERRUPT && STACK_COLORATION
+	default n
+	---help---
+		Enables the nested interrupt stack check support. It checks every time before
+		serving the interrupt, if the stack overflows, it results in panic()
+endif
 config ARCH_HAVE_HIPRI_INTERRUPT
 	bool
 	default n

--- a/os/arch/arm/src/armv7-m/up_doirq.c
+++ b/os/arch/arm/src/armv7-m/up_doirq.c
@@ -92,6 +92,7 @@ uint32_t *up_doirq(int irq, uint32_t *regs)
 {
 #if CONFIG_ARCH_INTERRUPTSTACK > 7
 	irqstate_t flags;
+	uint32_t stack_remain;
 #endif
 	board_led_on(LED_INIRQ);
 #ifdef CONFIG_SUPPRESS_INTERRUPTS
@@ -99,6 +100,17 @@ uint32_t *up_doirq(int irq, uint32_t *regs)
 #else
 
 #if CONFIG_ARCH_INTERRUPTSTACK > 7
+
+#ifdef CONFIG_ARCH_NESTED_INTERRUPT_STACKCHECK
+
+	/* check remaining stack available, assert if stack overflows */
+
+	stack_remain = (CONFIG_ARCH_INTERRUPTSTACK & ~3) - up_check_intstack();
+	if (stack_remain < 8) {
+		lldbg("STACK OVERFLOW!!\n");
+		PANIC();
+	}
+#endif
 	/* Current regs non-zero indicates that we are processing an interrupt;
 	 * regs holds the state of the interrupted logic; current_regs holds the
 	 * state of the interrupted user task.  current_regs should, therefor,


### PR DESCRIPTION
This patch adds the support of stack overflow check for nested interrupt.
If stack grows more than the configured interrupt stack size then
this check will assert the system.
