### PR TITLE
examples/grpc_*: Fix .gitignore

### DIFF
--- a/apps/examples/grpc_greeter_client/.gitignore
+++ b/apps/examples/grpc_greeter_client/.gitignore
@@ -1,5 +1,3 @@
 # Ignore auto-generated files from protobuf
-./*.pb.h
-./*.pb.cc
-./*.grpc.pb.h
-./*.grpc.cc
+*.pb.h
+*.pb.cc

--- a/apps/examples/grpc_route_client/.gitignore
+++ b/apps/examples/grpc_route_client/.gitignore
@@ -1,5 +1,3 @@
 # Ignore auto-generated files from protobuf
-./*.pb.h
-./*.pb.cc
-./*.grpc.pb.h
-./*.grpc.cc
+*.pb.h
+*.pb.cc


### PR DESCRIPTION
- `./` doesn't mean current directory.
- `*.grpc.pb.h`, `*.grpc.pb.cc` are unnecessary since `*.pb.h`,
`*.pb.cc` include them.