### PR TITLE
board/imxrt1020-evk: add DEPPATH in flash partition conditional

### DIFF
--- a/os/board/imxrt1020-evk/src/Makefile
+++ b/os/board/imxrt1020-evk/src/Makefile
@@ -81,6 +81,7 @@ CSRCS += imxrt_ethernet.c
 endif
 
 ifeq ($(CONFIG_FLASH_PARTITION),y)
+DEPPATH += --dep-path $(TOPDIR)/board/common
 VPATH += :$(TOPDIR)/board/common
 CSRCS += partitions.c
 endif


### PR DESCRIPTION
This fixes build warning as shown below:
make[2]: Entering directory '/home/sunghan/Work/TinyAra/Forked_TizenRT/os/board/imxrt1020-evk/src'
Makefile:126: recipe for target '.depend' failed
make[2]: *** [.depend] Error 1
make[2]: Leaving directory '/home/sunghan/Work/TinyAra/Forked_TizenRT/os/board/imxrt1020-evk/src'
Makefile:223: recipe for target '.depend' failed
make[1]: *** [.depend] Error 2

Signed-off-by: sunghan-chang <sh924.chang@samsung.com>