### PR TITLE
configs/imxrt1050-evk, imxrt1020-evk: get board name and path configured

### DIFF
--- a/build/configs/imxrt1020-evk/nxp_demo/Make.defs
+++ b/build/configs/imxrt1020-evk/nxp_demo/Make.defs
@@ -126,6 +126,6 @@ HOSTCFLAGS = -Wall -Wstrict-prototypes -Wshadow -Wundef -g -pipe
 HOSTLDFLAGS =
 
 define DOWNLOAD
-  $(TOPDIR)/../build/configs/imxrt1020-evk/imxrt1020-evk_download.sh
+  $(TOPDIR)/../build/configs/$(CONFIG_ARCH_BOARD)/$(CONFIG_ARCH_BOARD)_download.sh
 endef
 

--- a/build/configs/imxrt1050-evk/nxp_demo/Make.defs
+++ b/build/configs/imxrt1050-evk/nxp_demo/Make.defs
@@ -126,6 +126,6 @@ HOSTCFLAGS = -Wall -Wstrict-prototypes -Wshadow -Wundef -g -pipe
 HOSTLDFLAGS =
 
 define DOWNLOAD
-  $(TOPDIR)/../build/configs/imxrt1050-evk/imxrt1050-evk_download.sh
+  $(TOPDIR)/../build/configs/$(CONFIG_ARCH_BOARD)/$(CONFIG_ARCH_BOARD)_download.sh
 endef
 

--- a/build/configs/imxrt1050-evk/tc/Make.defs
+++ b/build/configs/imxrt1050-evk/tc/Make.defs
@@ -92,6 +92,6 @@ HOSTCFLAGS = -Wall -Wstrict-prototypes -Wshadow -Wundef -g -pipe
 HOSTLDFLAGS =
 
 define DOWNLOAD
-  $(TOPDIR)/../build/configs/imxrt1050-evk/imxrt1050-evk_download.sh
+  $(TOPDIR)/../build/configs/$(CONFIG_ARCH_BOARD)/$(CONFIG_ARCH_BOARD)_download.sh
 endef
 


### PR DESCRIPTION
Folder path and board name is configured by .config.
Let's get them from .config.

Signed-off-by: sunghan-chang <sh924.chang@samsung.com>