### PR TITLE
testcase driver: cover getting timeslice value with CONFG_TC_KERNEL_R…

### DIFF
--- a/os/drivers/testcase/kernel_testcase_drv.c
+++ b/os/drivers/testcase/kernel_testcase_drv.c
@@ -142,6 +142,7 @@ static int kernel_test_drv_ioctl(FAR struct file *filep, int cmd, unsigned long 
 	}
 	break;
 
+#ifdef CONFIG_TC_KERNEL_ROUNDROBIN
 	case TESTIOC_GET_TCB_TIMESLICE: {
 		tcb = sched_gettcb((pid_t)arg);
 		if (tcb == NULL) {
@@ -151,6 +152,7 @@ static int kernel_test_drv_ioctl(FAR struct file *filep, int cmd, unsigned long 
 		ret = tcb->timeslice;
 	}
 	break;
+#endif
 
 	case TESTIOC_SCHED_FOREACH: {
 		sched_foreach((void *)arg, NULL);

--- a/os/include/tinyara/testcase_drv.h
+++ b/os/include/tinyara/testcase_drv.h
@@ -59,7 +59,9 @@
 #define TESTIOC_IS_ALIVE_THREAD                _TESTIOC(5)
 #define TESTIOC_GET_TCB_SIGPROCMASK            _TESTIOC(6)
 #define TESTIOC_GET_TCB_ADJ_STACK_SIZE         _TESTIOC(7)
+#ifdef CONFIG_TC_KERNEL_ROUNDROBIN
 #define TESTIOC_GET_TCB_TIMESLICE              _TESTIOC(8)
+#endif
 #define TESTIOC_SCHED_FOREACH                  _TESTIOC(9)
 #define TESTIOC_SIGNAL_PAUSE                   _TESTIOC(10)
 #define TESTIOC_TIMER_INITIALIZE_TEST          _TESTIOC(11)


### PR DESCRIPTION
…OUNDROBIN

The timeslice value is valid when CONFIG_RR_INTERVAL is not zero.
Getting timeslice in testcase driver is called when CONFIG_TC_KERNEL_ROUNDROBIN
is enabled.
Let's cover it with above to fix build break.

Signed-off-by: sunghan-chang <sh924.chang@samsung.com>