### PR TITLE
external/esp_idf_port: Remove useless config file in Makefile.

### DIFF
--- a/external/esp_idf_port/soc/Makefile
+++ b/external/esp_idf_port/soc/Makefile
@@ -1,4 +1,3 @@
-include ${TOPDIR}/.config
 include ${TOPDIR}/tools/Config.mk
 include ${TOPDIR}/arch/xtensa/src/lx6/Toolchain.defs
 


### PR DESCRIPTION
there is no CONFIG_XXX used in the external/esp_idf_port/soc/Makefile,
Remove useless included ".config" file.
@sunghan-chang 
