### PR TITLE
driver/usb: Change the creation of task

### DIFF
--- a/os/arch/arm/src/imxrt/imxrt_usbhost.c
+++ b/os/arch/arm/src/imxrt/imxrt_usbhost.c
@@ -201,7 +201,7 @@ int imxrt_usbhost_initialize(void)
 	}
 
 	/* Start a thread to handle device connection. */
-	pid = task_create("EHCI Monitor", CONFIG_USBHOST_DEFPRIO, CONFIG_USBHOST_STACKSIZE, (main_t)ehci_waiter, (FAR char *const *)NULL);
+	pid = kernel_thread("EHCI Monitor", CONFIG_USBHOST_DEFPRIO, CONFIG_USBHOST_STACKSIZE, (main_t)ehci_waiter, (FAR char *const *)NULL);
 	if (pid < 0) {
 		IMXLOG("ERROR: Failed to create ehci_waiter task\n");
 		return pid;


### PR DESCRIPTION
Calling task_create() fails in binary protection mode.
so change it to kernel_thread