### PR TITLE
[fs/procfs]: Fix procfs for error report

### DIFF
--- a/os/fs/procfs/fs_procfs.c
+++ b/os/fs/procfs/fs_procfs.c
@@ -162,7 +162,8 @@ static const struct procfs_entry_s g_procfsentries[] = {
 #endif
 
 #if !defined(CONFIG_FS_PROCFS_EXCLUDE_EREPORT)
-	{"ereport/**", &ereport_operations},
+	{"ereport**", &ereport_operations},
+	{"ereport/*", &ereport_operations},
 #endif
 
 	{NULL, NULL}


### PR DESCRIPTION
Procfs for `error_report` module throws errors with Filesystem testcase when trying to read from `/proc/ereport`. This was caused by a lack of proper foldername name matching, and is addressed in this commit. Additionally, procfs for `error_report` now includes a `stat` function to allow directory listing.