### PR TITLE
build: start external build before apps

### DIFF
--- a/os/FlatLibs.mk
+++ b/os/FlatLibs.mk
@@ -78,15 +78,15 @@ ifeq ($(CONFIG_HAVE_CXX),y)
 TINYARALIBS += $(LIBRARIES_DIR)$(DELIM)libcxx$(LIBEXT)
 endif
 
+# Add library for external support.
+
+TINYARALIBS += $(LIBRARIES_DIR)$(DELIM)libexternal$(LIBEXT)
+
 # Add library for application support.
 
 ifneq ($(APPDIR),)
 TINYARALIBS += $(LIBRARIES_DIR)$(DELIM)libapps$(LIBEXT)
 endif
-
-# Add library for external support.
-
-TINYARALIBS += $(LIBRARIES_DIR)$(DELIM)libexternal$(LIBEXT)
 
 # Add libraries for network support
 

--- a/os/ProtectedLibs.mk
+++ b/os/ProtectedLibs.mk
@@ -78,6 +78,8 @@ ifeq ($(CONFIG_HAVE_CXX),y)
 USERLIBS += $(LIBRARIES_DIR)$(DELIM)libcxx$(LIBEXT)
 endif
 
+USERLIBS += $(LIBRARIES_DIR)$(DELIM)libexternal$(LIBEXT)
+
 # Add library for application support.
 
 ifneq ($(APPDIR),)
@@ -89,9 +91,6 @@ endif
 ifeq ($(CONFIG_NET),y)
 TINYARALIBS += $(LIBRARIES_DIR)$(DELIM)libnet$(LIBEXT)
 endif
-
-
-USERLIBS += $(LIBRARIES_DIR)$(DELIM)libexternal$(LIBEXT)
 
 # Add libraries for iotivity support
 


### PR DESCRIPTION
Somecases, application requires external library and
main purpose of external library is supporting some features to apps.
Let's build external before apps builds start.

Signed-off-by: sunghan-chang <sh924.chang@samsung.com>