### PR TITLE
external/esp_idf_port: change including ".config" mode in Makefile.

### DIFF
--- a/external/esp_idf_port/esp32/Makefile
+++ b/external/esp_idf_port/esp32/Makefile
@@ -1,4 +1,4 @@
-include ${TOPDIR}/.config
+-include ${TOPDIR}/.config
 include ${TOPDIR}/tools/Config.mk
 include ${TOPDIR}/arch/xtensa/src/lx6/Toolchain.defs
 


### PR DESCRIPTION
".config" is made via issuing configure.sh, if not exist, run "make clean"
will report error "No such file", change including mode with prefix "-"
will fix this issue.

@sunghan-chang 
