### PR TITLE
build: start iotivity build before apps

### DIFF
--- a/os/ProtectedLibs.mk
+++ b/os/ProtectedLibs.mk
@@ -80,6 +80,12 @@ endif
 
 USERLIBS += $(LIBRARIES_DIR)$(DELIM)libexternal$(LIBEXT)
 
+# Add libraries for iotivity support
+
+ifeq ($(CONFIG_ENABLE_IOTIVITY),y)
+USERLIBS += $(LIBRARIES_DIR)$(DELIM)libiotivity$(LIBEXT)
+endif
+
 # Add library for application support.
 
 ifneq ($(APPDIR),)
@@ -90,12 +96,6 @@ endif
 
 ifeq ($(CONFIG_NET),y)
 TINYARALIBS += $(LIBRARIES_DIR)$(DELIM)libnet$(LIBEXT)
-endif
-
-# Add libraries for iotivity support
-
-ifeq ($(CONFIG_ENABLE_IOTIVITY),y)
-USERLIBS += $(LIBRARIES_DIR)$(DELIM)libiotivity$(LIBEXT)
 endif
 
 # Add libraries for audio module


### PR DESCRIPTION
Same purpose of commit a027c6c.
Somecases, apps use iotivity feature. Then, iotivity should
be built first.

Signed-off-by: sunghan-chang <sh924.chang@samsung.com>