### PR TITLE
framework/messaging : cleanup internal data only if that data is from itself

### DIFF
--- a/framework/include/messaging/messaging.h
+++ b/framework/include/messaging/messaging.h
@@ -195,7 +195,8 @@ int messaging_recv_nonblock(const char *port_name, msg_recv_buf_t *recv_buf, msg
  * @brief Remove the messaging port information if this message port is not used anymore.
  * @details @b #include <messaging/messaging.h>\n
  * @param[in] port_name The message port name.\n
- *		This API should be called if messaging_recv_nonblock or messaging_unicast_send_async was called.\n
+ *		This API should be called from task/pthread who called\n
+ *		messaging_recv_nonblock or messaging_unicast_send_async.\n
  *		If this API is not called, memory leak can happen.
  * @return On success, OK is returned. On failure, Error is returned.
  * @since TizenRT v3.0

--- a/framework/src/messaging/messaging_cleanup.c
+++ b/framework/src/messaging/messaging_cleanup.c
@@ -70,6 +70,7 @@ int messaging_cleanup(const char *port_name)
 	int ret = ERROR;
 	int cleanup_pid = INVALID_PID;
 	msg_port_info_t *port_info;
+	pid_t my_pid = getpid();
 
 	if (port_name == NULL) {
 		msgdbg("[Messaging] cleanup fail : invalid param.\n");
@@ -84,7 +85,7 @@ int messaging_cleanup(const char *port_name)
 	/* Remove the receiver information by port_name from the info list. */
 	port_info = (msg_port_info_t *)sq_peek(&g_port_info_list);
 	while (port_info != NULL) {
-		if (strncmp(port_info->name, port_name, strlen(port_name) + 1) == 0) {
+		if ((strncmp(port_info->name, port_name, strlen(port_name) + 1) == 0) && (my_pid == port_info->pid)) {
 			cleanup_pid = port_info->pid;
 			mq_close(port_info->mqdes);
 			sq_rem((FAR sq_entry_t *)port_info, &g_port_info_list);


### PR DESCRIPTION
Previous cleanup logic removes all data which related with port_name.
But in that case with multicast, before receiving, some internal data can be removed because of another receivers.
So cleanup should be remove only its data.