### PR TITLE
system/utils: Fix wrong logics

### DIFF
--- a/apps/system/utils/fscmd.c
+++ b/apps/system/utils/fscmd.c
@@ -223,6 +223,10 @@ static int tash_echo(int argc, char **args)
 	}
 
 	if (1 == n_opt) {
+		if (len >= FSCMD_BUFFER_LEN) {
+			FSCMD_OUTPUT("%s : Too long input text\n", args[0]);
+			goto error_with_close;
+		}
 		memcpy(fscmd_buffer + len, "\n", 1);
 		len += 1;
 	}

--- a/apps/system/utils/utils_heapinfo.c
+++ b/apps/system/utils/utils_heapinfo.c
@@ -145,12 +145,12 @@ static int heapinfo_read_proc(pid_t pid)
 
 	asprintf(&filepath, "%s/%d/%s", PROCFS_MOUNT_POINT, pid, "stat");
 	ret = utils_readfile(filepath, buf, HEAPINFO_BUFLEN, heapinfo_print_values);
-	free(filepath);
 	if (ret < 0) {
 		printf("Failed to read %s\n", filepath);
+		free(filepath);
 		return ERROR;
 	}
-
+	free(filepath);
 	return OK;
 }
 

--- a/apps/system/utils/utils_proc.c
+++ b/apps/system/utils/utils_proc.c
@@ -65,8 +65,10 @@ int utils_proc_pid_foreach(procentry_handler_t handler)
 		return ERROR;
 	}
 
+	ret = OK;
+
 	/* Read each directory entry */
-	
+
 	for (;;) {
 		
 		entryp = readdir(dirp);

--- a/apps/system/utils/utils_ps.c
+++ b/apps/system/utils/utils_ps.c
@@ -134,12 +134,12 @@ static int ps_read_proc(FAR struct dirent *entryp, FAR void *arg)
 
 	asprintf(&filepath, "%s/%s/%s", PROCFS_MOUNT_POINT, entryp->d_name, "stat");
 	ret = utils_readfile(filepath, buf, PS_BUFLEN, ps_print_values);
-	free(filepath);
 	if (ret < 0) {
 		printf("Failed to read %s\n", filepath);
+		free(filepath);
 		return ERROR;
 	}
-
+	free(filepath);
 	return OK;
 }
 

--- a/apps/system/utils/utils_stackmonitor.c
+++ b/apps/system/utils/utils_stackmonitor.c
@@ -184,12 +184,12 @@ static int stkmon_read_proc(FAR struct dirent *entryp, FAR void *arg)
 
 	asprintf(&filepath, "%s/%s/%s", PROCFS_MOUNT_POINT, entryp->d_name, "stat");
 	ret = utils_readfile(filepath, buf, STKMON_BUFLEN, stkmon_print_active_values);
-	free(filepath);
 	if (ret < 0) {
 		printf("Failed to read %s\n", filepath);
+		free(filepath);
 		return ERROR;
 	}
-
+	free(filepath);
 	return OK;
 }
 


### PR DESCRIPTION
- system/utils: Check the length of input data in tash_echo
- system/utils: Initialize local variable 'ret' in function
- system/utils: Free allocated memory after usage in log message on failure