### PR TITLE
apps/system: Support fs commands in protected build

### DIFF
--- a/apps/system/init/init.c
+++ b/apps/system/init/init.c
@@ -67,7 +67,7 @@ static void tash_register_cmds(void)
 	system_register_utilcmds();
 #endif
 
-#if !defined(CONFIG_BUILD_PROTECTED) && defined(CONFIG_FS_CMDS)
+#ifdef CONFIG_FS_CMDS
 	fs_register_utilcmds();
 #endif
 

--- a/apps/system/utils/Makefile
+++ b/apps/system/utils/Makefile
@@ -75,9 +75,7 @@ ifeq ($(CONFIG_SYSTEM_CMDS),y)
 CSRCS += systemcmd.c
 
 ifeq ($(CONFIG_FS_CMDS),y)
-ifneq ($(CONFIG_BUILD_PROTECTED), y)
 CSRCS += fscmd.c
-endif
 endif
 
 ifeq ($(CONFIG_NET_CMDS),y)


### PR DESCRIPTION
FS commands can be used in protected build now.