### PR TITLE
build/configs: Fix reset issue at imxrt flash init

### DIFF
--- a/build/configs/imxrt1020-evk/scripts/flash-ocram.ld
+++ b/build/configs/imxrt1020-evk/scripts/flash-ocram.ld
@@ -93,7 +93,7 @@ SECTIONS
 	{
 		_stext = ABSOLUTE(.);
 		*(.vectors)
-		*(.text .text.*)
+		*(EXCLUDE_FILE(*imxrt_flexspi.o *imxrt_norflash.o) .text*)
 		*(.fixup)
 		*(.gnu.warning)
 		*(.rodata .rodata.*)
@@ -134,6 +134,8 @@ SECTIONS
 		*(.data .data.*)
 		*(.gnu.linkonce.d.*)
 		CONSTRUCTORS
+		*imxrt_flexspi.o(.text*)
+		*imxrt_norflash.o(.text*)
 		_edata = ABSOLUTE(.);
 	} > sram AT > flash
 

--- a/build/configs/imxrt1050-evk/scripts/flash-ocram.ld
+++ b/build/configs/imxrt1050-evk/scripts/flash-ocram.ld
@@ -92,7 +92,7 @@ SECTIONS
 	{
 		_stext = ABSOLUTE(.);
 		*(.vectors)
-		*(.text .text.*)
+		*(EXCLUDE_FILE(*imxrt_flexspi.o *imxrt_hyperflash.o) .text*)
 		*(.fixup)
 		*(.gnu.warning)
 		*(.rodata .rodata.*)
@@ -133,6 +133,8 @@ SECTIONS
 		*(.data .data.*)
 		*(.gnu.linkonce.d.*)
 		CONSTRUCTORS
+		*imxrt_flexspi.o(.text*)
+		*imxrt_hyperflash.o(.text*)
 		_edata = ABSOLUTE(.);
 	} > sram AT > flash
 


### PR DESCRIPTION
Modify linker scripts to fix flexspi flash configuration issue
In case of XIP, flexispi and hyperflash objects run on top of flash,
if we copy these in flash itself then unexpected behavior results.
So these are copied to data section to execute the flash init and config
from outside.

Signed-off-by: Sangamanatha <sangam.swami@samsung.com>