### PR TITLE
imxrt: add CONFIG_IMXRT_TIMER_INTERFACE support

### DIFF
--- a/os/arch/arm/src/imxrt/Kconfig
+++ b/os/arch/arm/src/imxrt/Kconfig
@@ -515,14 +515,22 @@ if IMXRT_TIMER
 config IMXRT_GPT
 	bool "Enable General Purpose Timer"
 	default n
+	select IMXRT_TIMER_INTERFACE if TIMER
 
 config IMXRT_PIT
 	bool "Enable Periodic Interrupt Timer"
 	default n
+	select IMXRT_TIMER_INTERFACE if TIMER
 
 config IMXRT_QTMR
 	bool "Enable Quad Timer"
 	default n
+	select IMXRT_TIMER_INTERFACE if TIMER
+
+config IMXRT_TIMER_INTERFACE
+	bool
+	default n
+	depends on TIMER
 
 endif # IMXRT_TIMER
 

--- a/os/arch/arm/src/imxrt/Make.defs
+++ b/os/arch/arm/src/imxrt/Make.defs
@@ -158,11 +158,10 @@ endif
 ifeq ($(CONFIG_IMXRT_QTMR),y)
 CHIP_CSRCS += imxrt_qtmr.c
 endif
-endif
-
-ifeq ($(CONFIG_TIMER),y)
+ifeq ($(CONFIG_IMXRT_TIMER_INTERFACE),y)
 CHIP_CSRCS += imxrt_timer_lowerhalf.c
 endif
+endif # CONFIG_IMXRT_TIMER
 
 ifeq ($(CONFIG_ARMV7M_MPU),y)
 CHIP_CSRCS += imxrt_mpuinit.c

--- a/os/board/imxrt1020-evk/src/imxrt_bringup.c
+++ b/os/board/imxrt1020-evk/src/imxrt_bringup.c
@@ -220,7 +220,7 @@ void imxrt_filesystem_initialize(void)
  * Name: imxrt_spidev_initialize
  *
  * Description:
- *   Called to configure SPI chip select GPIO pins for the imxrt1050-evk board.
+ *   Called to configure SPI chip select GPIO pins for the imxrt1020-evk board.
  *
  ************************************************************************************/
 

--- a/os/board/imxrt1020-evk/src/imxrt_userleds.c
+++ b/os/board/imxrt1020-evk/src/imxrt_userleds.c
@@ -72,7 +72,7 @@
 
 #include "imxrt_gpio.h"
 #include "imxrt_iomuxc.h"
-#include "imxrt1050-evk.h"
+#include "imxrt1020-evk.h"
 
 #include <arch/board/board.h>
 

--- a/os/board/imxrt1020-evk/userspace/imxrt_userspace.c
+++ b/os/board/imxrt1020-evk/userspace/imxrt_userspace.c
@@ -16,7 +16,7 @@
 *
 ******************************************************************/
 /****************************************************************************
- * os/board/imxrt1050-evk/userspace/imxrt_userspace.c
+ * os/board/imxrt1020-evk/userspace/imxrt_userspace.c
  *
  *   Copyright (C) 2018 Gregory Nutt. All rights reserved.
  *   Author: Gregory Nutt <gnutt@nuttx.org>

--- a/os/board/imxrt1050-evk/src/imxrt_boot.c
+++ b/os/board/imxrt1050-evk/src/imxrt_boot.c
@@ -75,7 +75,7 @@
 #include "imxrt_flash.h"
 #include "imxrt_gpio.h"
 #include "imxrt_lpspi.h"
-#ifdef CONFIG_TIMER
+#ifdef CONFIG_IMXRT_GPT
 #include "imxrt_gpt.h"
 #endif
 #ifdef CONFIG_IMXRT_SEMC_SDRAM
@@ -276,15 +276,17 @@ void board_initialize(void)
 
 	imxrt_board_adc_initialize();
 
-#ifdef CONFIG_TIMER
+#ifdef CONFIG_IMXRT_TIMER_INTERFACE
 	{
 		int timer_idx;
 		char timer_path[CONFIG_PATH_MAX];
 
+#ifdef CONFIG_IMXRT_GPT
 		for (timer_idx = 0; timer_idx < IMXRT_GPT_CH_MAX; timer_idx++) {
 			snprintf(timer_path, sizeof(timer_path), "/dev/timer%d", timer_idx);
 			imxrt_timer_initialize(timer_path, timer_idx);
 		}
+#endif
 	}
 #endif
 }


### PR DESCRIPTION
When one of timer is enabled and timer driver is enabled,
timer initialization is necessary to use timer driver.
This commit adds CONFIG_IMXRT_TIMER_INTERFACE for that and
fix build break as shown below.

LD: tinyara
build/output/libraries/libkarch.a(imxrt_timer_lowerhalf.o): In function `imxrt_gpt_setcallback':
os/arch/arm/src/chip/imxrt_timer_lowerhalf.c:334: undefined reference to `imxrt_gpt_setisr'
os/arch/arm/src/chip/imxrt_timer_lowerhalf.c:338: undefined reference to `imxrt_gpt_setisr'
build/output/libraries/libkarch.a(imxrt_timer_lowerhalf.o): In function `imxrt_gpt_stop':
os/arch/arm/src/chip/imxrt_timer_lowerhalf.c:216: undefined reference to `imxrt_gpt_setisr'
build/output/libraries/libkarch.a(imxrt_timer_lowerhalf.o): In function `imxrt_gpt_start':
os/arch/arm/src/chip/imxrt_timer_lowerhalf.c:178: undefined reference to `imxrt_gpt_setisr'
build/output/libraries/libkarch.a(imxrt_timer_lowerhalf.o): In function `imxrt_gpt_handler':
os/arch/arm/src/chip/imxrt_timer_lowerhalf.c:148: undefined reference to `imxrt_gpt_convert_time_tick'
build/output/libraries/libkarch.a(imxrt_timer_lowerhalf.o): In function `imxrt_gpt_settimeout':
os/arch/arm/src/chip/imxrt_timer_lowerhalf.c:298: undefined reference to `imxrt_gpt_convert_time_tick'
build/output/libraries/libkarch.a(imxrt_timer_lowerhalf.o): In function `imxrt_gpt_getstatus':
os/arch/arm/src/chip/imxrt_timer_lowerhalf.c:264: undefined reference to `imxrt_gpt_convert_time_tick'
os/arch/arm/src/chip/imxrt_timer_lowerhalf.c:269: undefined reference to `imxrt_gpt_convert_time_tick'
build/output/libraries/libkarch.a(imxrt_timer_lowerhalf.o): In function `imxrt_timer_initialize':
os/arch/arm/src/chip/imxrt_timer_lowerhalf.c:433: undefined reference to `imxrt_gpt_getdefaultconfig'
os/arch/arm/src/chip/imxrt_timer_lowerhalf.c:435: undefined reference to `imxrt_gpt_configure'
Makefile:195: recipe for target '../build/output/bin/tinyara' failed

Signed-off-by: sunghan-chang <sh924.chang@samsung.com>