### PR TITLE
os/mm/umm_heap: Fix memory leak in umm_free

### DIFF
--- a/os/mm/umm_heap/umm_free.c
+++ b/os/mm/umm_heap/umm_free.c
@@ -82,10 +82,13 @@
 
 void free(FAR void *mem)
 {
-	int heap_idx;
-	heap_idx = mm_get_heapindex(mem);
-	if (heap_idx != INVALID_HEAP_IDX) {
-		mm_free(&USR_HEAP[heap_idx], mem);
+	struct mm_heap_s *heap;
+	heap = mm_get_heap(mem);
+	if (heap) {
+		mm_free(heap, mem);
+		return;
 	}
+
+	mdbg("Failed to free address 0x%x\n", mem);
 }
 


### PR DESCRIPTION
umm_free can fail under the below scenario:
- Two tasks are running
- Task 1 exits. Task 2 is now active
- The task 1 clean up code calls kumm_free to free its stack
- umm_free() tries to get heap using mm_get_heapindex() API
- Since, task 2 is now active, this API returns -1

The issue is fixed by replacing mm_get_heapindex() with mm_get_heap()
which has the logic to search all the app heaps to find a match for
the given address.

Signed-off-by: Kishore SN <kishore.sn@samsung.com>