### PR TITLE
apps/examples: Add ifdefs to exclude some fscmd functions in protected build

### DIFF
--- a/apps/examples/testcase/le_tc/filesystem/fs_main.c
+++ b/apps/examples/testcase/le_tc/filesystem/fs_main.c
@@ -273,7 +273,7 @@ static void tc_fs_vfs_mount(void)
 
 	/*For each mountpt operation*/
 
-#ifndef CONFIG_DISABLE_ENVIRON
+#if !defined(CONFIG_DISABLE_ENVIRON) && !defined(CONFIG_BUILD_PROTECTED)
 	ret = mount_show();
 	TC_ASSERT_EQ("mount_show", ret, OK);
 #endif
@@ -3730,7 +3730,7 @@ int tc_filesystem_main(int argc, char *argv[])
 #ifdef CONFIG_ITC_FS
 	itc_fs_main();
 #endif
-#if defined(CONFIG_TC_FS_PROCFS) && !defined(CONFIG_SMARTFS_MULTI_ROOT_DIRS)
+#if defined(CONFIG_TC_FS_PROCFS) && !defined(CONFIG_SMARTFS_MULTI_ROOT_DIRS) && !defined(CONFIG_BUILD_PROTECTED)
 	tc_fs_smartfs_mksmartfs();
 #endif
 	(void)tc_handler(TC_END, "FileSystem TC");

--- a/apps/examples/testcase/le_tc/filesystem/tc_fs_procfs.c
+++ b/apps/examples/testcase/le_tc/filesystem/tc_fs_procfs.c
@@ -224,7 +224,7 @@ static int procfs_rewind_tc(const char *dirpath)
 
 	return OK;
 }
-#ifndef CONFIG_SMARTFS_MULTI_ROOT_DIRS
+#if !defined(CONFIG_SMARTFS_MULTI_ROOT_DIRS) && !defined(CONFIG_BUILD_PROTECTED)
 void tc_fs_smartfs_mksmartfs(void)
 {
 	int ret;


### PR DESCRIPTION

- CONFIG_BUILD_PROTECTED is added to some of file system testcases to prevent
  errors from protected build cases.