### PR TITLE
board : Add AUTOGEN_MEMORY_LDSCRIPT selection on imxrt1020-evk config

### DIFF
--- a/os/board/Kconfig
+++ b/os/board/Kconfig
@@ -93,6 +93,7 @@ config ARCH_BOARD_IMXRT1020_EVK
 	select ARCH_HAVE_LEDS
 	select ARCH_HAVE_BUTTONS
 	select ARCH_HAVE_IRQBUTTONS
+	select AUTOGEN_MEMORY_LDSCRIPT if BUILD_PROTECTED
 	---help---
 		This is the board configuration for the port of TinyARA to the NXP i.MXRT
 		evaluation kit, MIMXRT1020-EVKB.  This board features the MIMXRT1021CAF4A MCU.


### PR DESCRIPTION
i.MXRT1020-evk board is same as i.MXRT1050-evk requires auto generated
memory linker script. Let's add same selection at i.MXRT1020-evk config.