### PR TITLE
examples/mpu : Add 'depends on ARCH_BOARD_IMXRT1020_EVK' in prebuilt-…

### DIFF
--- a/apps/examples/mpu/Kconfig
+++ b/apps/examples/mpu/Kconfig
@@ -34,7 +34,7 @@ config MPUTEST_USE_PREBUILT_BINS
 	bool "Use pre-built application binaries"
 	default n
 	depends on APP_BINARY_SEPARATION
-	depends on ARCH_BOARD_IMXRT1050_EVK
+	depends on ARCH_BOARD_IMXRT1050_EVK || ARCH_BOARD_IMXRT1020_EVK
 	depends on !EXAMPLES_ELF
 	---help---
 		To test different application access, two application binaries


### PR DESCRIPTION
…bins config

imxrt1020-evk also can mpu test. Let's add 'depends on ARCH_BOARD_IMXRT1020_EVK'
in MPUTEST_USE_PREBUILT_BINS config. so if you use imxrt1020-evk or imxrt1050-evk,
you can mpu test.