### PR TITLE
apps/system/utils: fix wrong conditional for netcmd and fscmd

### DIFF
--- a/apps/system/utils/Makefile
+++ b/apps/system/utils/Makefile
@@ -73,6 +73,7 @@ endif
 
 ifeq ($(CONFIG_SYSTEM_CMDS),y)
 CSRCS += systemcmd.c
+endif
 
 ifeq ($(CONFIG_FS_CMDS),y)
 CSRCS += fscmd.c
@@ -97,8 +98,6 @@ endif
 ifeq ($(CONFIG_NETUTILS_TFTPC),y)
 CSRCS += netcmd_tftpc.c
 endif
-
-endif #CONFIG_TASH
 
 ifeq ($(CONFIG_ENABLE_CPULOAD),y)
 CSRCS += utils_cpuload.c


### PR DESCRIPTION
SYSTEM_CMDS, FS_CMDS and NET_CMDS are separated commands sets.
They should be in SYSTEM_CMDS conditional.

Signed-off-by: sunghan-chang <sh924.chang@samsung.com>