### PR TITLE
binary_manager: Add dependency of BCH and enable it in imxrt1020-evk/loadable_elf_apps

### DIFF
--- a/build/configs/imxrt1020-evk/loadable_elf_apps/defconfig
+++ b/build/configs/imxrt1020-evk/loadable_elf_apps/defconfig
@@ -489,7 +489,7 @@ CONFIG_SPI_EXCHANGE=y
 # CONFIG_GPIO is not set
 CONFIG_I2S=y
 # CONFIG_AUDIO_DEVICES is not set
-# CONFIG_BCH is not set
+CONFIG_BCH=y
 # CONFIG_RTC is not set
 # CONFIG_WATCHDOG is not set
 # CONFIG_TIMER is not set

--- a/os/kernel/Kconfig
+++ b/os/kernel/Kconfig
@@ -1094,7 +1094,7 @@ config BINARY_MANAGER
 	bool "Enable Binary Manager"
 	default n
 	depends on APP_BINARY_SEPARATION && BINFMT_LOADABLE && !DISABLE_MQUEUE
-	depends on MTD_FTL && FLASH_PARTITION && MTD_PARTITION_NAMES
+	depends on BCH && MTD_FTL && FLASH_PARTITION && MTD_PARTITION_NAMES
 	---help---
 		This is kernel thread which manages binaries.
 		It loads/unloads binaries and recovers any fault occurs in a system.


### PR DESCRIPTION
- kernel/binary_manager: Add dependency of BCH driver
- configs/imxrt1020-evk: Enable BCH driver by default