### PR TITLE
net/dhcp: Fix bad logic and return values

### DIFF
--- a/external/dhcpc/dhcpc_lwip.c
+++ b/external/dhcpc/dhcpc_lwip.c
@@ -81,15 +81,15 @@
 		int res = -1;					\
 		res = netlib_set_ipv4addr(intf, &ip);		\
 		if (res == -1) {				\
-			nvdbg("[DHCPC] set ipv4 addr error\n");	\
+			nvdbg("set ipv4 addr error\n");	\
 		}						\
 		res = netlib_set_ipv4netmask(intf, &netmask);	\
 		if (res == -1) {				\
-			nvdbg("[DHCPC] set netmask addr error\n");	\
+			nvdbg("set netmask addr error\n");	\
 		}						\
 		res = netlib_set_dripv4addr(intf, &gateway);	\
 		if (res == -1) {				\
-			nvdbg("[DHCPC] set route addr error\n");	\
+			nvdbg("set route addr error\n");	\
 		}						\
 	} while (0)
 
@@ -115,7 +115,7 @@ int dhcp_client_start(const char *intf)
 
 	int sockfd = socket(AF_INET, SOCK_DGRAM, 0);
 	if (sockfd < 0) {
-		printf("socket() failed with errno: %d\n", errno);
+		ndbg("socket() failed with errno: %d\n", errno);
 		return ret;
 	}
 
@@ -125,7 +125,7 @@ int dhcp_client_start(const char *intf)
 
 	ret = ioctl(sockfd, SIOCLWIP, (unsigned long)&req);
 	if (ret == ERROR) {
-		printf("ioctl() failed with errno: %d\n", errno);
+		ndbg("ioctl() failed with errno: %d\n", errno);
 		close(sockfd);
 		return ret;
 	}
@@ -144,7 +144,7 @@ void dhcp_client_stop(const char *intf)
 
 	int sockfd = socket(AF_INET, SOCK_DGRAM, 0);
 	if (sockfd < 0) {
-		printf("socket() failed with errno: %d\n", errno);
+		ndbg("socket() failed with errno: %d\n", errno);
 		return;
 	}
 

--- a/os/net/netdev/netdev_dhcpd.c
+++ b/os/net/netdev/netdev_dhcpd.c
@@ -55,6 +55,8 @@
  ****************************************************************************/
 #include <tinyara/config.h>		/* TinyAra configuration */
 
+#include <sys/types.h>
+
 #include <stdio.h>
 #include <stdint.h>
 #include <stdbool.h>
@@ -103,16 +105,16 @@ int netdev_dhcp_server_status(char *intf)
 	struct netif *cur_netif;
 	cur_netif = netif_find(intf);
 	if (cur_netif == NULL) {
-		ndbg("[DHCPS] no network interface for dhcpd start\n");
-		return 0;
+		ndbg("no network interface for dhcpd start\n");
+		return ERROR;
 	}
 
 	if (cur_netif->dhcps_pcb == NULL) {
-		ndbg("[DHCPS] DHCP server closed\n");
-		return 0;
+		ndbg("DHCP server closed\n");
+		return ERROR;
 	} else {
-		ndbg("[DHCPS] DHCP server opened\n");
-		return 1;
+		ndbg("DHCP server opened\n");
+		return OK;
 	}
 }
 
@@ -124,22 +126,22 @@ int netdev_dhcp_server_start(char *intf, dhcp_sta_joined dhcp_join_cb)
 	struct netif *cur_netif;
 	cur_netif = netif_find(intf);
 	if (cur_netif == NULL) {
-		ndbg("[DHCPS] no network interface for dhcpd start\n");
-		return -1;
+		ndbg("no network interface for dhcpd start\n");
+		return ERROR;
 	}
 	if (dhcp_join_cb) {
-		if (dhcps_register_cb(dhcp_join_cb) != ERR_OK) {
-			ndbg("[DHCPS] link callback fail\n");
-			return -1;
+		if (dhcps_register_cb(dhcp_join_cb) != OK) {
+			ndbg("link callback fail\n");
+			return ERROR;
 		}
 	}
 
-	if (netifapi_dhcps_start(cur_netif) == ERR_OK) {
-		ndbg("[DHCPS] started successfully (LWIP)\n");
+	if (netifapi_dhcps_start(cur_netif) == OK) {
+		ndbg("started successfully (LWIP)\n");
 		return OK;
 	}
 
-	return -1;
+	return ERROR;
 }
 
 /****************************************************************************
@@ -150,16 +152,16 @@ int netdev_dhcp_server_stop(char *intf)
 	struct netif *cur_netif;
 	cur_netif = netif_find(intf);
 	if (cur_netif == NULL) {
-		ndbg("[DHCPS] no network interface for dhcpd start\n");
-		return -1;
+		ndbg("no network interface for dhcpd start\n");
+		return ERROR;
 	}
 	if (cur_netif->dhcps_pcb == NULL) {
-		ndbg("[DHCPS] stop dhcpd fail: no pcb\n");
-		return -1;
+		ndbg("stop dhcpd fail: no pcb\n");
+		return ERROR;
 	}
 
 	netifapi_dhcps_stop(cur_netif);
-	ndbg("[DHCPS] stopped successfully (LWIP)\n");
+	ndbg("stopped successfully (LWIP)\n");
 
 	return OK;
 }


### PR DESCRIPTION
- Replace 0 to OK and -1 to ERROR
- Return valid error type for lwip_func_ioctl
- Replace printf to ndbg