### PR TITLE
 os/drivers/wireless: Support binary separation

### DIFF
--- a/os/arch/arm/src/imxrt/imxrt_usbhost.c
+++ b/os/arch/arm/src/imxrt/imxrt_usbhost.c
@@ -85,14 +85,14 @@
  ************************************************************************************/
 
 #ifndef CONFIG_USBHOST_DEFPRIO
-#define CONFIG_USBHOST_DEFPRIO 50
+#define CONFIG_USBHOST_DEFPRIO 120
 #endif
 
 #ifndef CONFIG_USBHOST_STACKSIZE
 #ifdef CONFIG_USBHOST_HUB
 #define CONFIG_USBHOST_STACKSIZE 1536
 #else
-#define CONFIG_USBHOST_STACKSIZE 1024
+#define CONFIG_USBHOST_STACKSIZE 8192
 #endif
 #endif
 
@@ -234,7 +234,7 @@ void imxrt_usbhost_vbusdrive(int rhport, bool enable)
 
 	/* The LPC3131 has only a single root hub port */
 
-#ifdef NEED_REFERENCE 
+#ifdef NEED_REFERENCE
 	if (rhport == 0) {
 		/* Then enable or disable VBUS power */
 

--- a/os/drivers/wireless/realtek/platform/usb/usb_io_realtek.c
+++ b/os/drivers/wireless/realtek/platform/usb/usb_io_realtek.c
@@ -14,7 +14,7 @@ int usbhost_cancel_bulk_in(void *priv);
 int usbhost_cancel_bulk_out(void *priv);
 
 extern void *g_rtk_wifi_usb;
-unsigned char g_rtk_wifi_connect;
+extern unsigned char g_rtk_wifi_connect;
 static unsigned char rtk_usb_running = 0;
 extern unsigned char usb_thread_active;
 extern _mutex usb_host_mutex;
@@ -37,7 +37,7 @@ static void rtw_usb_probe(void)
 	printf("rtw_usb_probe <------- \n");
 }
 
-void usb_thread(void *priv)
+int usb_thread(int argc, char *argv[])
 {
 	extern PADAPTER padapter_for_Tizenrt;
 	extern ssize_t nread_bytes;
@@ -84,10 +84,10 @@ void usb_thread(void *priv)
 	_func_exit_;
 
 	printf("exit usb read port thread \n");
-	pthread_exit((void *)NULL);
+	return 0;
 }
 
-pthread_startroutine_t _usb_thread = &usb_thread;
+main_t _usb_thread = &usb_thread;
 
 static int rtw_usb_ctrl_req(void *priv, unsigned char bdir_in, unsigned int wvalue, unsigned char *buf, unsigned int len)
 {

--- a/os/drivers/wireless/realtek/platform/usb/usb_io_realtek.h
+++ b/os/drivers/wireless/realtek/platform/usb/usb_io_realtek.h
@@ -9,7 +9,7 @@ typedef struct USB_DATA_S {
 	void *usb_intf;
 } USB_DATA, *PUSB_DATA;
 
-void usb_thread(void *priv);
+int usb_thread(int argc, char *argv[]);
 
 typedef void (*usb_complete)(void *arg, ssize_t result);
 


### PR DESCRIPTION
os/drivers: Support binary separation for usbhost driver
- Replace pthread_create to kernel_thread
- Replace printf to udbg


os/drivers/wireless: Support binary separation
- Replace task_create or pthread_create to kernel_thread
- Replace free to kmm_free