### PR TITLE
apps : Add --gc-sections flag in application Makefile

### DIFF
--- a/apps/AppLibs.mk
+++ b/apps/AppLibs.mk
@@ -60,4 +60,5 @@ LDLIBS_LIST = $(patsubst %.a, %, $(patsubst lib%,-l%,$(LINKLIBS)))
 LDLIBS = $(patsubst -lapps%, %, $(LDLIBS_LIST))
 endif
 
+LDELFFLAGS += --gc-sections
 -include Make.dep


### PR DESCRIPTION
This patch adds --gc-sections flag in application makefile.
this tells linker to remove unused sections from the code,
which results in reducing code size.
