### PR TITLE
arch/arm/imxrt : Support ticks and clock freq in timer status

### DIFF
--- a/os/arch/arm/src/imxrt/imxrt_gpt.c
+++ b/os/arch/arm/src/imxrt/imxrt_gpt.c
@@ -165,7 +165,7 @@ void imxrt_gpt_setisr(struct imxrt_gpt_chipinfo_s *gpt, xcpt_t handler, void *ar
 	up_enable_irq(gpt->irq_id);
 }
 
-static uint32_t imxrt_gpt_get_clockfreq(gpt_clock_source_t clock)
+uint32_t imxrt_gpt_get_clockfreq(gpt_clock_source_t clock)
 {
 	uint32_t freq;
 

--- a/os/arch/arm/src/imxrt/imxrt_gpt.h
+++ b/os/arch/arm/src/imxrt/imxrt_gpt.h
@@ -190,6 +190,8 @@ void imxrt_gpt_deinit(GPT_Type *base);
  */
 void imxrt_gpt_getdefaultconfig(gpt_config_t *config);
 
+uint32_t imxrt_gpt_get_clockfreq(gpt_clock_source_t clock);
+
 struct imxrt_gpt_chipinfo_s *imxrt_gpt_configure(int timer, gpt_config_t *config);
 
 uint32_t imxrt_gpt_convert_time_tick(imxrt_timer_convert_dir_t dir, gpt_clock_source_t clock_source, uint32_t value);

--- a/os/arch/arm/src/imxrt/imxrt_timer_lowerhalf.c
+++ b/os/arch/arm/src/imxrt/imxrt_timer_lowerhalf.c
@@ -267,6 +267,10 @@ static int imxrt_gpt_getstatus(struct timer_lowerhalf_s *lower,
 
 	ticks = imxrt_gpt_getcurrenttimercount(priv->gpt->base);
 	status->timeleft = imxrt_gpt_convert_time_tick(TICK2TIME, priv->config.clockSource, ticks);
+#if defined(CONFIG_ARCH_BOARD_IMXRT1020_EVK) || defined(CONFIG_ARCH_BOARD_IMXRT1050_EVK)
+	status->clock_freq = imxrt_gpt_get_clockfreq(priv->config.clockSource);
+	status->ticks = ticks;
+#endif
 
 	return OK;
 }

--- a/os/include/tinyara/timer.h
+++ b/os/include/tinyara/timer.h
@@ -138,6 +138,10 @@ struct timer_status_s {
 	uint32_t timeout;  /* The current timeout setting (in microseconds) */
 	uint32_t timeleft; /* Time left until the timer expiration
 			    * (in microseconds) */
+#if defined(CONFIG_ARCH_BOARD_IMXRT1020_EVK) || defined(CONFIG_ARCH_BOARD_IMXRT1050_EVK)
+	uint32_t clock_freq;
+	uint32_t ticks;
+#endif
 };
 
 /* This is the type of the argument passed to the TCIOC_NOTIFICATION ioctl */


### PR DESCRIPTION
When using Board IMXRT10x, it supports clock freq and ticks
in timer status.