### PR TITLE
tools: chdir to use gui_dumpParser in another dir

### DIFF
--- a/tools/ramdump/gui_dumpParser.py
+++ b/tools/ramdump/gui_dumpParser.py
@@ -142,6 +142,7 @@ class DumpParser(Tk):
 				resText.insert(INSERT, data)
 
 if __name__ == "__main__":
+	os.chdir(os.path.dirname(os.path.realpath(__file__)))
 	app = DumpParser()
 	app.title("Dump Parser")
 	app.mainloop()


### PR DESCRIPTION
Since gui_dumpParser.py use relative dir, change directory when the
script starts.