### PR TITLE
external/esp_idf_port: Add depend PHONY in makefile.

### DIFF
--- a/external/esp_idf_port/Makefile
+++ b/external/esp_idf_port/Makefile
@@ -121,7 +121,7 @@ OBJS        = $(CXXOBJS) $(COBJS)
 
 # Common build
 all: $(SUBDIRS) .built
-.PHONY: clean distclean
+.PHONY: .depend depend clean distclean
 
 ECHO:
 	@echo $(SUBDIRS)
@@ -131,6 +131,12 @@ $(SUBDIRS): ECHO
 
 .built: $(OBJS)
 	$(call ARCHIVE, $(BIN), $(OBJS))
+
+.depend: Makefile $(SRCS)
+	$(Q) $(MKDEP) $(DEPPATH) "$(CC)" -- $(CFLAGS) -- $(SRCS) >Make.dep
+	$(Q) touch $@
+
+depend: .depend
 
 $(CXXOBJS) : %$(OBJEXT): %.cpp
 	$(call COMPILEXX, $<, $@)


### PR DESCRIPTION
Add depend PHONY in makefile to fix the make error as below
make[2]: Leaving directory '/root/tizenrt/external/esp_idf_port'
make[2]: *** No rule to make target 'depend'.  Stop.