### PR TITLE
os/arch/arm/src: Fix performance issue caused by MPU settings

### DIFF
--- a/os/arch/arm/src/armv7-m/mpu.h
+++ b/os/arch/arm/src/armv7-m/mpu.h
@@ -663,7 +663,11 @@ static inline void mpu_peripheral(uint32_t region, uintptr_t base, size_t size)
 #if defined(CONFIG_APP_BINARY_SEPARATION)
 static inline void up_set_mpu_app_configuration(struct tcb_s *rtcb)
 {
-	if ((rtcb->flags & TCB_FLAG_TTYPE_MASK) != TCB_FLAG_TTYPE_KERNEL) {
+	/* We update the MPU registers only if:
+	 * This is not a kernel thread AND
+	 * It has a non zero value of base address (This ensures valid MPU setting)
+	 */
+	if ((rtcb->flags & TCB_FLAG_TTYPE_MASK) != TCB_FLAG_TTYPE_KERNEL && rtcb->mpu_regs[REG_RBAR]) {
 		putreg32(rtcb->mpu_regs[REG_RNR], MPU_RNR);
 		putreg32(rtcb->mpu_regs[REG_RBAR], MPU_RBAR);
 		putreg32(rtcb->mpu_regs[REG_RASR], MPU_RASR);

--- a/os/arch/arm/src/imxrt/imxrt_mpuinit.c
+++ b/os/arch/arm/src/imxrt/imxrt_mpuinit.c
@@ -83,23 +83,14 @@
 
 #if defined(CONFIG_BUILD_PROTECTED)
 const struct mpu_region_info regions_info[] = {
-	{
-		&mpu_privflash, (uintptr_t)__kflash_segment_start__, (uintptr_t)__kflash_segment_size__, MPU_REG_KERN_CODE,
-	},
-	{
-		&mpu_privintsram, (uintptr_t)__ksram_segment_start__, (uintptr_t)__ksram_segment_size__, MPU_REG_KERN_DATA,
-	},
-#ifdef CONFIG_IMXRT_SEMC_SDRAM
-	{
-		&mpu_privintsram, (uintptr_t)CONFIG_IMXRT_SDRAM_START, (uintptr_t)CONFIG_MM_KERNEL_HEAPSIZE, MPU_REG_KERN_HEAP,
-	},
-#endif
+#ifdef CONFIG_SYSTEM_PREAPP_INIT
 	{
 		&mpu_userflash, (uintptr_t)__uflash_segment_start__, (uintptr_t)__uflash_segment_size__, MPU_REG_USER_CODE,
 	},
 	{
 		&mpu_userintsram, (uintptr_t)__usram_segment_start__, (uintptr_t)__usram_segment_size__, MPU_REG_USER_DATA,
 	},
+#endif
 };
 #endif
 

--- a/os/arch/arm/src/imxrt/mpu-reg.h
+++ b/os/arch/arm/src/imxrt/mpu-reg.h
@@ -41,14 +41,11 @@
  * registers.
  */
 enum {
-	MPU_REG_KERN_CODE,
-	MPU_REG_KERN_DATA,
-#ifdef CONFIG_IMXRT_SEMC_SDRAM
-	MPU_REG_KERN_HEAP,
-#endif
+#ifdef CONFIG_SYSTEM_PREAPP_INIT
 	MPU_REG_USER_CODE,
 	MPU_REG_USER_DATA,
-	MPU_REG_APP
+#endif
+	MPU_REG_APP,
 };
 
 #ifndef __ASSEMBLY__


### PR DESCRIPTION
Enabling the MPU and adding MPU regions is causing a degradation
of system performance. Each additional MPU region setting results
in a reduction of performance. Hence, we need to make sure that
we are using the minimum required MPU regions.

This commit contains following changes:
- Remove Kernel MPU regions, since Kernel has access to complete address space
- Enable USER_CODE and USER_DATA region only if user app is enabled
- Fix issues that happen during task start and context switch

Signed-off-by: Kishore SN <kishore.sn@samsung.com>