### PR TITLE
testcase/kernel : Fix the abstime2tikcs test scenario

### DIFF
--- a/apps/examples/testcase/le_tc/kernel/tc_clock.c
+++ b/apps/examples/testcase/le_tc/kernel/tc_clock.c
@@ -168,23 +168,12 @@ static void tc_clock_clock_gettimeofday(void)
 static void tc_clock_clock_abstime2ticks(void)
 {
 	int fd;
-	int base_tick;
-	int comparison_tick;
-	struct timespec base_time;
-	struct timespec comparison_time;
+	int ret;
 
 	fd = tc_get_drvfd();
-	clock_gettime(CLOCK_REALTIME, &base_time);
-	comparison_time.tv_sec = base_time.tv_sec + 1;
+	ret = ioctl(fd, TESTIOC_CLOCK_ABSTIME2TICKS_TEST, 0);
 
-	base_tick = ioctl(fd, TESTIOC_CLOCK_ABSTIME2TICKS, base_time.tv_sec);
-	TC_ASSERT_NEQ("clock_abstime2ticks", base_tick, ERROR);
-
-	comparison_tick = ioctl(fd, TESTIOC_CLOCK_ABSTIME2TICKS, comparison_time.tv_sec);
-	TC_ASSERT_NEQ("clock_abstime2ticks", comparison_tick, ERROR);
-
-	/* the difference can be 0 or 1, but should be smaller than 2 */
-	TC_ASSERT_GEQ("clock_abstime2ticks", comparison_tick - (base_tick * 2), 2);
+	TC_ASSERT_NEQ("clock_abstime2ticks", ret, ERROR);
 
 	TC_SUCCESS_RESULT();
 }

--- a/os/include/tinyara/testcase_drv.h
+++ b/os/include/tinyara/testcase_drv.h
@@ -53,17 +53,17 @@
  */
 
 #define TESTIOC_ANALOG                         _TESTIOC(1)
-#define TESTIOC_CLOCK_ABSTIME2TICKS            _TESTIOC(2)
-#define TESTIOC_GET_SIG_FINDACTION_ADD         _TESTIOC(3)
-#define TESTIOC_GET_SELF_PID                   _TESTIOC(4)
-#define TESTIOC_IS_ALIVE_THREAD                _TESTIOC(5)
-#define TESTIOC_GET_TCB_SIGPROCMASK            _TESTIOC(6)
-#define TESTIOC_GET_TCB_ADJ_STACK_SIZE         _TESTIOC(7)
+#define TESTIOC_GET_SIG_FINDACTION_ADD         _TESTIOC(2)
+#define TESTIOC_GET_SELF_PID                   _TESTIOC(3)
+#define TESTIOC_IS_ALIVE_THREAD                _TESTIOC(4)
+#define TESTIOC_GET_TCB_SIGPROCMASK            _TESTIOC(5)
+#define TESTIOC_GET_TCB_ADJ_STACK_SIZE         _TESTIOC(6)
 #ifdef CONFIG_TC_KERNEL_ROUNDROBIN
-#define TESTIOC_GET_TCB_TIMESLICE              _TESTIOC(8)
+#define TESTIOC_GET_TCB_TIMESLICE              _TESTIOC(7)
 #endif
-#define TESTIOC_SCHED_FOREACH                  _TESTIOC(9)
-#define TESTIOC_SIGNAL_PAUSE                   _TESTIOC(10)
+#define TESTIOC_SCHED_FOREACH                  _TESTIOC(8)
+#define TESTIOC_SIGNAL_PAUSE                   _TESTIOC(9)
+#define TESTIOC_CLOCK_ABSTIME2TICKS_TEST       _TESTIOC(10)
 #define TESTIOC_TIMER_INITIALIZE_TEST          _TESTIOC(11)
 #define TESTIOC_SEM_TICK_WAIT_TEST             _TESTIOC(12)
 


### PR DESCRIPTION
Tset clock_abstime2ticks through the virtual driver.