### PR TITLE
imxrt/timer: Support to set FreeRun mode for gpt with ioctl

### DIFF
--- a/os/arch/arm/src/imxrt/imxrt_gpt.h
+++ b/os/arch/arm/src/imxrt/imxrt_gpt.h
@@ -322,6 +322,26 @@ static inline void imxrt_gpt_stoptimer(GPT_Type *base)
 }
 
 /*!
+ * @brief Set the FreeRun mode.
+ *
+ * @param base GPT peripheral base address.
+ */
+static inline void imxrt_gpt_setfreerunmode(GPT_Type *base)
+{
+	base->CR |= GPT_CR_FRR_MASK;
+}
+
+/*!
+ * @brief Unset the FreeRun mode.
+ *
+ * @param base GPT peripheral base address.
+ */
+static inline void imxrt_gpt_unsetfreerunmode(GPT_Type *base)
+{
+	base->CR &= ~GPT_CR_FRR_MASK;
+}
+
+/*!
  * @name Read the timer period
  * @{
  */

--- a/os/arch/arm/src/imxrt/imxrt_timer_lowerhalf.c
+++ b/os/arch/arm/src/imxrt/imxrt_timer_lowerhalf.c
@@ -400,6 +400,14 @@ static int imxrt_gpt_ioctl(struct timer_lowerhalf_s *lower, int cmd,
 			ret = (int)imxrt_gpt_getclockdivider(priv->gpt->base);
 		}
 		break;
+	case TCIOC_SETFREERUN:
+		if ((bool)arg == true) {
+			imxrt_gpt_setfreerunmode(priv->gpt->base);
+		} else {
+			imxrt_gpt_unsetfreerunmode(priv->gpt->base);
+		}
+		ret = OK;
+		break;
 	default:
 		tmrdbg("Invalid cmd %d\n", cmd);
 		break;

--- a/os/include/tinyara/timer.h
+++ b/os/include/tinyara/timer.h
@@ -111,6 +111,7 @@
 #define TCIOC_NOTIFICATION	_TCIOC(0x0005)
 #define TCIOC_SETDIV        _TCIOC(0x0006)
 #define TCIOC_GETDIV        _TCIOC(0x0007)
+#define TCIOC_SETFREERUN    _TCIOC(0x0008)
 
 /* Bit Settings *************************************************************/
 /* Bit settings for the struct timer_status_s flags field */


### PR DESCRIPTION
By default, a timer is running with Restart mode that timeleft is set as interval when timeout.
User can set or unset FreeRun mode with ioctl like ioctl(fd, TCIOC_SETFREERUN, true or false).