### PR TITLE
tidyup on binfmt and set messaging framework disabled by default

### DIFF
--- a/framework/src/messaging/Kconfig
+++ b/framework/src/messaging/Kconfig
@@ -5,7 +5,7 @@
 
 config MESSAGING_IPC
 	bool "Enable Messaging APIs"
-	default y
+	default n
 	depends on !DISABLE_MQUEUE
 	depends on !DISABLE_SIGNALS
 	---help---

--- a/os/binfmt/binfmt.h
+++ b/os/binfmt/binfmt.h
@@ -102,7 +102,7 @@ EXTERN FAR struct binfmt_s *g_binfmts;
  *
  ****************************************************************************/
 
-#if defined(CONFIG_DEBUG) && defined(CONFIG_DEBUG_BINFMT)
+#ifdef CONFIG_DEBUG_BINFMT
 int dump_module(FAR const struct binary_s *bin);
 #else
 #define dump_module(bin)

--- a/os/binfmt/binfmt_dumpmodule.c
+++ b/os/binfmt/binfmt_dumpmodule.c
@@ -64,7 +64,7 @@
 
 #include "binfmt.h"
 
-#if defined(CONFIG_DEBUG) && defined(CONFIG_DEBUG_BINFMT) && defined(CONFIG_BINFMT_ENABLE)
+#ifdef CONFIG_DEBUG_BINFMT
 
 /****************************************************************************
  * Public Functions

--- a/os/binfmt/elf.c
+++ b/os/binfmt/elf.c
@@ -101,7 +101,7 @@
  ****************************************************************************/
 
 static int elf_loadbinary(FAR struct binary_s *binp);
-#if defined(CONFIG_DEBUG) && defined(CONFIG_DEBUG_BINFMT)
+#ifdef CONFIG_DEBUG_BINFMT
 static void elf_dumploadinfo(FAR struct elf_loadinfo_s *loadinfo);
 #endif
 
@@ -123,7 +123,7 @@ static struct binfmt_s g_elfbinfmt = {
  * Name: elf_dumploadinfo
  ****************************************************************************/
 
-#if defined(CONFIG_DEBUG) && defined(CONFIG_DEBUG_BINFMT)
+#ifdef CONFIG_DEBUG_BINFMT
 static void elf_dumploadinfo(FAR struct elf_loadinfo_s *loadinfo)
 {
 	int i;

--- a/os/syscall/syscall.csv
+++ b/os/syscall/syscall.csv
@@ -18,7 +18,7 @@
 "dup", "unistd.h", "CONFIG_NFILE_DESCRIPTORS > 0", "int", "int"
 "dup2", "unistd.h", "CONFIG_NFILE_DESCRIPTORS > 0", "int", "int", "int"
 "exec","tinyara/binfmt/binfmt.h","defined(CONFIG_BINFMT_ENABLE) && !defined(CONFIG_BUILD_KERNEL)","int","FAR const char *","FAR char * const *","FAR const struct symtab_s *","int"
-"execv","unistd.h","defined(CONFIG_BINFMT_ENABLE) && defined(CONFIG_LIBC_EXECFUNCS)","int","FAR const char *","FAR char *const []|FAR char *const *"
+"execv","unistd.h","defined(CONFIG_LIBC_EXECFUNCS)","int","FAR const char *","FAR char *const []|FAR char *const *"
 "exit", "stdlib.h", "", "void", "int"
 "fcntl", "fcntl.h", "CONFIG_NFILE_DESCRIPTORS > 0", "int", "int", "int", "..."
 "fs_fdopen", "tinyara/fs/fs.h", "CONFIG_NFILE_DESCRIPTORS > 0 && CONFIG_NFILE_STREAMS > 0", "FAR struct file_struct*", "int", "int", "FAR struct tcb_s*"


### PR DESCRIPTION
binfmt, syscall: remove duplicated conditionals
framework/messaging: set disabled by default