### PR TITLE
imxrt/timer: Support to set irq proirity with ioctl

### DIFF
--- a/os/arch/arm/src/imxrt/imxrt_timer_lowerhalf.c
+++ b/os/arch/arm/src/imxrt/imxrt_timer_lowerhalf.c
@@ -64,6 +64,9 @@
 
 #include <tinyara/timer.h>
 #include <tinyara/irq.h>
+#ifdef CONFIG_ARCH_IRQPRIO
+#include <tinyara/arch.h>
+#endif
 
 #include "chip.h"
 #include "imxrt_gpt.h"
@@ -408,6 +411,11 @@ static int imxrt_gpt_ioctl(struct timer_lowerhalf_s *lower, int cmd,
 		}
 		ret = OK;
 		break;
+#ifdef CONFIG_ARCH_IRQPRIO
+	case TCIOC_SETIRQPRIO:
+		ret = up_prioritize_irq(priv->gpt->irq_id, arg);
+		break;
+#endif
 	default:
 		tmrdbg("Invalid cmd %d\n", cmd);
 		break;

--- a/os/include/tinyara/timer.h
+++ b/os/include/tinyara/timer.h
@@ -112,6 +112,9 @@
 #define TCIOC_SETDIV        _TCIOC(0x0006)
 #define TCIOC_GETDIV        _TCIOC(0x0007)
 #define TCIOC_SETFREERUN    _TCIOC(0x0008)
+#ifdef CONFIG_ARCH_IRQPRIO
+#define TCIOC_SETIRQPRIO    _TCIOC(0x0009)
+#endif
 
 /* Bit Settings *************************************************************/
 /* Bit settings for the struct timer_status_s flags field */


### PR DESCRIPTION
User can set a priority of timer irq using ioctl with TCIOC_SETIRQPRIO.