### PR TITLE
Fix boot-up issue due to userspace object

### DIFF
--- a/apps/examples/elf/micomapp/Makefile
+++ b/apps/examples/elf/micomapp/Makefile
@@ -101,8 +101,11 @@ SRCS += messaging.c
 endif
 OBJS = $(SRCS:.c=$(OBJEXT))
 
-all: $(BIN)
-.PHONY: clean install verify
+prebuild:
+	$(call DELFILE, $(TOPDIR)$(DELIM)board$(DELIM)common$(DELIM)userspace$(DELIM)up_userspace.o)
+
+all: prebuild $(BIN)
+.PHONY: prebuild clean install verify
 
 $(OBJS): %$(OBJEXT): %.c
 	@echo "CC: $<"

--- a/apps/examples/elf/wifiapp/Makefile
+++ b/apps/examples/elf/wifiapp/Makefile
@@ -94,7 +94,7 @@ BLOCK_SIZE = 0
 endif
 
 APPDEFINE = ${shell $(TOPDIR)/tools/define.sh "$(CC)" __APP_BUILD__}
-SRCS = $(TOPDIR)/board/common/userspace/up_userspace.c
+SRCS = $(TOPDIR)$(DELIM)board$(DELIM)common$(DELIM)userspace$(DELIM)up_userspace.c
 SRCS += wifiapp.c
 ifeq ($(CONFIG_EXAMPLES_MESSAGING_TEST),y)
 SRCS += messaging.c
@@ -105,8 +105,11 @@ endif
 
 OBJS = $(SRCS:.c=$(OBJEXT))
 
-all: $(BIN)
-.PHONY: clean install verify
+prebuild:
+	$(call DELFILE, $(TOPDIR)$(DELIM)board$(DELIM)common$(DELIM)userspace$(DELIM)up_userspace.o)
+
+all: prebuild $(BIN)
+.PHONY: prebuild clean install verify
 
 $(OBJS): %$(OBJEXT): %.c
 	@echo "CC: $<"

--- a/os/Makefile.unix
+++ b/os/Makefile.unix
@@ -453,6 +453,7 @@ ifeq ($(CONFIG_BUILD_2PASS),y)
 		echo "ERROR: No Makefile in PASS1_BUILDIR"; \
 		exit 1; \
 	fi
+	$(call DELFILE, $(PASS1_BUILDIR)/up_userspace.o)
 	$(Q) $(MAKE) -C $(PASS1_BUILDIR) TOPDIR="$(TOPDIR)" LINKLIBS="$(LINKLIBS)" USERLIBS="$(USERLIBS)" "$(CONFIG_PASS1_TARGET)"
 endif
 

--- a/os/binfmt/libelf/gnu-elf.ld
+++ b/os/binfmt/libelf/gnu-elf.ld
@@ -61,7 +61,7 @@ SECTIONS
        * eventually used by user space memory allocator
        */
       LONG(0);
-      *(.userspace)
+      KEEP(*(.userspace))
       *(.text)
       *(.text.*)
       *(.gnu.warning)


### PR DESCRIPTION
The up_userspace.c is used by the app binaries as well as user binary.
But since the file is already build by the app build process, it is not
re-built during the user binary build. This is causing issues since the
user binary is missing some of the variables in the userspace object.
In order to fix this issue, we will delete the up_userspace.o object file
before the user binary build.

Signed-off-by: Kishore SN <kishore.sn@samsung.com>