### PR TITLE
framework/task_manager, apps/shell: use a static variable and a definition instead of globals

### DIFF
--- a/apps/shell/tash_command.c
+++ b/apps/shell/tash_command.c
@@ -57,8 +57,6 @@
  * Global Variables
  ****************************************************************************/
 
-extern int tash_running;
-
 /****************************************************************************
  * Private Type Declarations
  ****************************************************************************/
@@ -173,7 +171,7 @@ static int tash_help(int argc, char **args)
 static int tash_exit(int argc, char **args)
 {
 	printf("TASH: Good bye!!\n");
-	tash_running = FALSE;
+	tash_stop();
 	exit(0);
 }
 

--- a/apps/shell/tash_internal.h
+++ b/apps/shell/tash_internal.h
@@ -57,6 +57,7 @@ extern void tash_register_basic_cmds(void);
 extern int tash_execute_cmdline(char *buff);
 extern int tash_execute_cmd(char **args, int argc);
 extern int tash_init(void);
+extern void tash_stop(void);
 #ifdef CONFIG_TASH_SCRIPT
 extern int tash_script(int argc, char **args);
 #endif

--- a/apps/shell/tash_main.c
+++ b/apps/shell/tash_main.c
@@ -49,10 +49,10 @@ enum tash_input_state_e {
 #define TASH_TASK_STACKSIZE   (4096)
 #define TASH_TASK_PRIORITY    (125)
 
-const char tash_prompt[] = "TASH>>";
+#define TASH_PROMPT           "TASH>>"
 #endif							/* CONFIG_TASH */
 
-int tash_running = FALSE;
+static int tash_running = FALSE;
 
 static void tash_remove_char(char *char_pos)
 {
@@ -197,7 +197,7 @@ static int tash_main(int argc, char *argv[])
 	tash_running = TRUE;
 
 	do {
-		nbytes = write(fd, tash_prompt, sizeof(tash_prompt));
+		nbytes = write(fd, (const void *)TASH_PROMPT, sizeof(TASH_PROMPT));
 		if (nbytes <= 0) {
 			shdbg("TASH: prompt is not displayed (errno = %d)\n", get_errno());
 #ifndef CONFIG_DISABLE_SIGNALS
@@ -230,6 +230,11 @@ int tash_start(void)
 	}
 
 	return pid;
+}
+
+void tash_stop(void)
+{
+	tash_running = FALSE;
 }
 #endif							/* CONFIG_TASH */
 

--- a/apps/system/utils/utils_stackmonitor.c
+++ b/apps/system/utils/utils_stackmonitor.c
@@ -107,7 +107,7 @@
  * Private Data
  ****************************************************************************/
 static volatile bool stkmon_started;
-struct stkmon_save_s stkmon_arr[CONFIG_MAX_TASKS * 2];
+static struct stkmon_save_s stkmon_arr[CONFIG_MAX_TASKS * 2];
 static int stkmon_chk_idx;
 
 /****************************************************************************

--- a/framework/src/task_manager/task_manager_core.c
+++ b/framework/src/task_manager/task_manager_core.c
@@ -54,12 +54,12 @@ static int handle_cnt;
 static int task_cnt;
 #ifndef CONFIG_DISABLE_PTHREAD
 static int pthread_cnt;
-tm_pthread_info_t tm_pthread_list[CONFIG_TASK_MANAGER_MAX_TASKS];
+static tm_pthread_info_t tm_pthread_list[CONFIG_TASK_MANAGER_MAX_TASKS];
 #endif
-app_list_t tm_app_list[CONFIG_TASK_MANAGER_MAX_TASKS];
-tm_task_info_t tm_task_list[CONFIG_TASK_MANAGER_MAX_TASKS];
+static app_list_t tm_app_list[CONFIG_TASK_MANAGER_MAX_TASKS];
+static tm_task_info_t tm_task_list[CONFIG_TASK_MANAGER_MAX_TASKS];
 static bool g_handle_hash[CONFIG_TASK_MANAGER_MAX_TASKS];
-int tm_broadcast_msg[TM_BROADCAST_MSG_MAX + CONFIG_TASK_MANAGER_MAX_TASKS];
+static int tm_broadcast_msg[TM_BROADCAST_MSG_MAX + CONFIG_TASK_MANAGER_MAX_TASKS];
 static int task_manager_pid;
 
 #define MAX_HANDLE_MASK (CONFIG_TASK_MANAGER_MAX_TASKS - 1)


### PR DESCRIPTION
TASH prompt is used in tash_main.c and it is never changed.
Let's use a definition, TASH_PROMPT instead of const char *tash_prompt.

The tash_running is used to stop and it is rarelly used.
Let's make it as static and provide a function, tash_stop() to stop.

Signed-off-by: sunghan-chang <sh924.chang@samsung.com>