### PR TITLE
[framework/wifi_manager]: Fix wifi utils to allow connection to open AP

### DIFF
--- a/framework/src/wifi_manager/slsi_wifi_utils.c
+++ b/framework/src/wifi_manager/slsi_wifi_utils.c
@@ -402,7 +402,8 @@ wifi_utils_result_e wifi_utils_connect_ap(wifi_utils_ap_config_s *ap_connect_con
 			ndbg("[WU] Wrong security type\n");
 			goto connect_ap_fail;
 		}
-	} else {
+	} else if (ap_connect_config->ap_auth_type !=  WIFI_UTILS_AUTH_OPEN ||
+				ap_connect_config->ap_crypto_type != WIFI_UTILS_CRYPTO_NONE) {
 		ndbg("[WU] No passphrase!\n");
 		goto connect_ap_fail;
 	}


### PR DESCRIPTION
Presently, wifi utils does not allow connection to WiFi access point in unsecured mode. This pull request makes the necessary fixes to allow the feature.