### PR TITLE
apps/examples/timer: dedicated timer thread with sigwait()

### DIFF
--- a/apps/examples/timer/timer_main.c
+++ b/apps/examples/timer/timer_main.c
@@ -87,42 +87,31 @@
 #  define EXAMPLE_TIMER_SIGNO    17
 #endif
 
-#define TIMER_THEAD_SIZE                1024
+#define TIMER_THEAD_SIZE                2048
 #define TIMER_THEAD_PRIORITY            100
 
-/****************************************************************************
- * Private Data
- ****************************************************************************/
-static sem_t g_sem;
 
 /****************************************************************************
  * Private Functions
  ****************************************************************************/
-static void timer_sighandler(int signo, FAR siginfo_t *siginfo,
-							 FAR void *context)
-{
-	/*
-	 * Does nothing in this example except for increment a count of signals
-	 * received.
-	 *
-	 * NOTE: The use of signal handler is not recommended if you are concerned
-	 * about the signal latency.  Instead, a dedicated, high-priority thread
-	 * that waits on sigwaitinfo() is recommended.  High priority is required
-	 * if you want a deterministic wake-up time when the signal occurs.
-	 */
-	sem_post(&g_sem);
-}
 
 static pthread_addr_t timer_thread(pthread_addr_t arg)
 {
+	int count = (int)arg;
 	int nbr = 0;
-	int i = (int)arg;
 
-	while (i--) {
-		sem_wait(&g_sem);
-		fprintf(stdout, "time limits(%d)\n", ++nbr);
+	sigset_t sig_set;
+	sigemptyset(&sig_set);
+	sigaddset(&sig_set, EXAMPLE_TIMER_SIGNO);
+
+	pthread_sigmask(SIG_BLOCK, &sig_set, NULL);
+
+	while (count--) {
+		if (sigwaitinfo(&sig_set, NULL) == EXAMPLE_TIMER_SIGNO)
+			fprintf(stdout, "time limits(%d)\n", ++nbr);
 	}
-
+	fprintf(stdout, "signal received:%d\n", (int)arg);
+	pthread_sigmask(SIG_UNBLOCK, &sig_set, NULL);
 	pthread_exit(NULL);
 
 	return NULL;
@@ -134,12 +123,6 @@ static pthread_t create_timer_thread(void *arg)
 	pthread_attr_t attr;
 	struct sched_param sparam;
 	int ret = OK;
-
-	ret = sem_init(&g_sem, 0, 0);
-	if (ret != 0) {
-		fprintf(stderr, "failed to set semaphore init(%d)\n", ret);
-		return -ret;
-	}
 
 	ret = pthread_attr_init(&attr);
 	if (ret != 0) {
@@ -172,7 +155,7 @@ static pthread_t create_timer_thread(void *arg)
 		return -ret;
 	}
 
-	pthread_setname_np(tid, "time handler thread");
+	pthread_setname_np(tid, "time sigwait thread");
 	pthread_detach(tid);
 
 	return tid;
@@ -190,7 +173,7 @@ static pthread_t create_timer_thread(void *arg)
 		"  -n [REPEAT]  Number of samples to repeat test.\n" \
 		"               DEFAULT 10\n" \
 		"  -t [INTR]    Timer interval\n" \
-		"               Millisecond unit. (DEFAULT 1000msec)\n" \
+		"               Microsecond unit. (DEFAULT 1000000usec)\n" \
 		"     -h        display this help and exit\n"
 
 /****************************************************************************
@@ -202,9 +185,8 @@ int main(int argc, FAR char *argv[])
 int timer_main(int argc, char *argv[])
 #endif
 {
+	pthread_t tid;
 	struct timer_notify_s notify;
-	struct sigaction act;
-	int tid = 0;
 	int fd;
 	int opt = 0;
 
@@ -218,7 +200,7 @@ int timer_main(int argc, char *argv[])
 	while ((opt = getopt(argc, argv, "t:n:f:h")) != -1) {
 		switch (opt) {
 		case 't':
-			intval = strtol(optarg, NULL, 10) * MSEC_PER_SEC;
+			intval = strtol(optarg, NULL, 10);
 			break;
 		case 'n':
 			repeat = strtol(optarg, NULL, 10);
@@ -275,31 +257,13 @@ int timer_main(int argc, char *argv[])
 	}
 
 	/*
-	 * Attach a signal handler to catch the notifications.  NOTE that using
-	 * signal handler is very slow.  A much more efficient thing to do is to
-	 * create a separate pthread that waits on sigwaitinfo() for timer events.
-	 * Much less overhead in that case.
-	 */
-	act.sa_sigaction = timer_sighandler;
-	act.sa_flags     = SA_SIGINFO;
-
-	(void)sigfillset(&act.sa_mask);
-	(void)sigdelset(&act.sa_mask, EXAMPLE_TIMER_SIGNO);
-
-	if (sigaction(EXAMPLE_TIMER_SIGNO, &act, NULL) != OK) {
-		fprintf(stderr, "ERROR: Fsigaction failed: %d\n", errno);
-		close(fd);
-		return EXIT_FAILURE;
-	}
-
-	/*
 	 * Register a callback for notifications using the configured signal.
 	 * NOTE: If no callback is attached, the timer stop at the first interrupt.
 	 */
 	fprintf(stdout, "Attach timer handler\n");
 
 	notify.arg   = NULL;
-	notify.pid   = getpid();
+	notify.pid   = (pid_t)tid;
 	notify.signo = EXAMPLE_TIMER_SIGNO;
 
 	if (ioctl(fd, TCIOC_NOTIFICATION,
@@ -319,7 +283,6 @@ int timer_main(int argc, char *argv[])
 
 	/* Wait a bit showing timer thread */
 	pthread_join(tid, NULL);
-	sem_destroy(&g_sem);
 
 	/* Stop the timer */
 	fprintf(stdout, "Stop the timer\n");
@@ -329,10 +292,6 @@ int timer_main(int argc, char *argv[])
 		close(fd);
 		return EXIT_FAILURE;
 	}
-
-	/* Detach the signal handler */
-	act.sa_handler = SIG_DFL;
-	sigaction(EXAMPLE_TIMER_SIGNO, &act, NULL);
 
 	/* Close the timer driver */
 	fprintf(stdout, "Finished\n");


### PR DESCRIPTION
This patch is to mitigate nested signal issues with
high-resolution timer interrupts. Nested signal situation
occurs if the time-period is smaller and next timer interrupt
occurs before the current interrupt signal is delivered.
This causes stack corruption due to multiple pending signals

This patch implements a dedicated thread that waits on sigwait()
It provides a deterministic wake-up time when the signal occurs
With this, we can achieve upto 30us timer events without suppressing
timer interrupts.

For more resolution requirement, we need to increase the stack for the thread waiting for signal