### PR TITLE
kernel/binary_manager: Unlink kernel resources when binary is reloaded

### DIFF
--- a/os/fs/mount/fs_mount.c
+++ b/os/fs/mount/fs_mount.c
@@ -63,6 +63,9 @@
 #include <debug.h>
 
 #include <tinyara/fs/fs.h>
+#ifdef CONFIG_BINARY_MANAGER
+#include <tinyara/binary_manager.h>
+#endif
 
 #include "inode/inode.h"
 #include "driver/block/driver.h"
@@ -368,6 +371,10 @@ int mount(FAR const char *source, FAR const char *target, FAR const char *filesy
 	{
 		inode_release(blkdrvr_inode);
 	}
+#endif
+
+#ifdef CONFIG_BINARY_MANAGER
+	binary_manager_register_resource(BIN_RESOURCE_MOUNTPT, target);
 #endif
 
 	return OK;

--- a/os/fs/mount/fs_umount.c
+++ b/os/fs/mount/fs_umount.c
@@ -58,7 +58,11 @@
 
 #include <sys/mount.h>
 #include <errno.h>
+
 #include <tinyara/fs/fs.h>
+#ifdef CONFIG_BINARY_MANAGER
+#include <tinyara/binary_manager.h>
+#endif
 
 #include "inode/inode.h"
 
@@ -194,6 +198,9 @@ int umount(const char *target)
 	if (blkdrvr_inode) {
 		inode_release(blkdrvr_inode);
 	}
+#ifdef CONFIG_BINARY_MANAGER
+	binary_manager_unregister_resource(BIN_RESOURCE_MOUNTPT, target);
+#endif
 
 	return OK;
 

--- a/os/fs/mqueue/mq_open.c
+++ b/os/fs/mqueue/mq_open.c
@@ -65,6 +65,9 @@
 
 #include <tinyara/mqueue.h>
 #include <tinyara/fs/fs.h>
+#ifdef CONFIG_BINARY_MANAGER
+#include <tinyara/binary_manager.h>
+#endif
 
 #include "inode/inode.h"
 #include "mqueue/mqueue.h"
@@ -215,10 +218,12 @@ mqd_t mq_open(FAR const char *mq_name, int oflags, ...)
 		INODE_SET_MQUEUE(inode);
 		inode->u.i_mqueue = msgq;
 		msgq->inode = inode;
-
 		/* Set the initial reference count on this inode to one */
 
 		inode->i_crefs = 1;
+#ifdef CONFIG_BINARY_MANAGER
+		binary_manager_register_resource(BIN_RESOURCE_MQ, mq_name);
+#endif
 	}
 
 	sched_unlock();

--- a/os/fs/mqueue/mq_unlink.c
+++ b/os/fs/mqueue/mq_unlink.c
@@ -62,6 +62,9 @@
 #include <errno.h>
 
 #include <tinyara/mqueue.h>
+#ifdef CONFIG_BINARY_MANAGER
+#include <tinyara/binary_manager.h>
+#endif
 
 #include "inode/inode.h"
 #include "mqueue/mqueue.h"
@@ -154,6 +157,11 @@ int mq_unlink(FAR const char *mq_name)
 
 	inode_semgive();
 	mq_inode_release(inode);
+
+#ifdef CONFIG_BINARY_MANAGER
+	binary_manager_unregister_resource(BIN_RESOURCE_MQ, mq_name);
+#endif
+
 	sched_unlock();
 	return OK;
 

--- a/os/fs/semaphore/sem_open.c
+++ b/os/fs/semaphore/sem_open.c
@@ -68,6 +68,9 @@
 #include <tinyara/kmalloc.h>
 #include <tinyara/semaphore.h>
 #include <tinyara/fs/fs.h>
+#ifdef CONFIG_BINARY_MANAGER
+#include <tinyara/binary_manager.h>
+#endif
 
 #include "inode/inode.h"
 #include "semaphore/semaphore.h"
@@ -261,6 +264,10 @@ FAR sem_t *sem_open(FAR const char *name, int oflags, ...)
 			/* Return a reference to the semaphore */
 
 			sem = &nsem->ns_sem;
+
+#ifdef CONFIG_BINARY_MANAGER
+			binary_manager_register_resource(BIN_RESOURCE_NAMEDSEM, name);
+#endif
 		}
 
 		sched_unlock();

--- a/os/fs/semaphore/sem_unlink.c
+++ b/os/fs/semaphore/sem_unlink.c
@@ -64,6 +64,9 @@
 #include <assert.h>
 
 #include <tinyara/kmalloc.h>
+#ifdef CONFIG_BINARY_MANAGER
+#include <tinyara/binary_manager.h>
+#endif
 
 #include "inode/inode.h"
 #include "semaphore/semaphore.h"
@@ -177,6 +180,12 @@ int sem_unlink(FAR const char *name)
 
 	inode_semgive();
 	ret = sem_close((FAR sem_t *)inode->u.i_nsem);
+#ifdef CONFIG_BINARY_MANAGER
+	if (ret == OK) {
+		binary_manager_unregister_resource(BIN_RESOURCE_NAMEDSEM, name);
+	}
+#endif
+
 	sched_unlock();
 	return ret;
 

--- a/os/fs/vfs/fs_open.c
+++ b/os/fs/vfs/fs_open.c
@@ -67,6 +67,9 @@
 
 #include <tinyara/cancelpt.h>
 #include <tinyara/fs/fs.h>
+#ifdef CONFIG_BINARY_MANAGER
+#include <tinyara/binary_manager.h>
+#endif
 
 #include "inode/inode.h"
 #include "driver/block/driver.h"
@@ -223,6 +226,11 @@ int open(const char *path, int oflags, ...)
 #ifndef CONFIG_DISABLE_MOUNTPOINT
 		if (INODE_IS_MOUNTPT(inode)) {
 			ret = inode->u.i_mops->open(filep, relpath, oflags, mode);
+#ifdef CONFIG_BINARY_MANAGER
+		if (ret == OK && (oflags & O_CREAT) != 0 && (oflags & (O_APPEND | O_TRUNC)) == 0) {
+			binary_manager_register_resource(BIN_RESOURCE_FILE, path);
+		}
+#endif
 		} else
 #endif
 		{
@@ -236,6 +244,7 @@ int open(const char *path, int oflags, ...)
 	}
 
 	leave_cancellation_point();
+
 	return fd;
 
 errout_with_fd:

--- a/os/fs/vfs/fs_unlink.c
+++ b/os/fs/vfs/fs_unlink.c
@@ -59,6 +59,9 @@
 #include <unistd.h>
 #include <errno.h>
 #include <tinyara/fs/fs.h>
+#ifdef CONFIG_BINARY_MANAGER
+#include <tinyara/binary_manager.h>
+#endif
 
 #include "inode/inode.h"
 
@@ -137,6 +140,11 @@ int unlink(FAR const char *pathname)
 				errcode = -ret;
 				goto errout_with_inode;
 			}
+#ifdef CONFIG_BINARY_MANAGER
+			else {
+				binary_manager_register_resource(BIN_RESOURCE_FILE, pathname);
+			}
+#endif
 		} else {
 			errcode = ENOSYS;
 			goto errout_with_inode;

--- a/os/include/tinyara/binary_manager.h
+++ b/os/include/tinyara/binary_manager.h
@@ -26,7 +26,7 @@
 #include <tinyara/config.h>
 
 #ifdef CONFIG_BINARY_MANAGER
-
+#include <stdint.h>
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
@@ -78,6 +78,18 @@ enum binmgr_partition_type {
 	BINMGR_PART_USRBIN,
 	BINMGR_PART_LOADPARAM,
 	BINMGR_PART_MAX,
+};
+
+/* Types of resources which use kernel resource, inode */
+enum binmgr_resource_type {
+	BIN_RESOURCE_MQ = 0,
+#if !defined(CONFIG_DISABLE_MOUNTPOINT) && CONFIG_NFILE_DESCRIPTORS > 0
+	BIN_RESOURCE_FILE = 1,
+	BIN_RESOURCE_MOUNTPT = 2,
+#endif
+#ifdef CONFIG_FS_NAMED_SEMAPHORES
+	BIN_RESOURCE_NAMEDSEM = 3,
+#endif
 };
 
 /* Message type for binary manager */
@@ -181,6 +193,8 @@ typedef struct binmgr_getinfo_all_response_s binmgr_getinfo_all_response_t;
 /****************************************************************************
  * Public Function Prototypes
  ****************************************************************************/
+void binary_manager_register_resource(int type, const char *name);
+void binary_manager_unregister_resource(int type, const char *name);
 void binary_manager_register_partition(int part_num, int part_type, char *name, int part_size);
 
 #ifdef __cplusplus

--- a/os/kernel/binary_manager/Make.defs
+++ b/os/kernel/binary_manager/Make.defs
@@ -19,8 +19,7 @@
 # Add binary manager files
 
 ifeq ($(CONFIG_BINARY_MANAGER),y)
-
-CSRCS += binary_manager.c binary_manager_load.c binary_manager_getinfo.c binary_manager_response.c binary_manager_callback.c
+CSRCS += binary_manager.c binary_manager_load.c binary_manager_getinfo.c binary_manager_response.c binary_manager_callback.c binary_manager_resource.c
 
 ifeq ($(CONFIG_BINMGR_RECOVERY),y)
 CSRCS += binary_manager_recovery.c

--- a/os/kernel/binary_manager/binary_manager.c
+++ b/os/kernel/binary_manager/binary_manager.c
@@ -25,6 +25,7 @@
 #include <debug.h>
 #include <fcntl.h>
 #include <assert.h>
+#include <queue.h>
 #include <string.h>
 #include <signal.h>
 #include <stdlib.h>
@@ -108,6 +109,8 @@ void binary_manager_register_partition(int part_num, int part_type, char *name, 
 		BIN_PARTSIZE(g_bin_count) = part_size;
 		strncpy(BIN_NAME(g_bin_count), name, BIN_NAME_MAX);
 		sq_init(&BIN_CBLIST(g_bin_count));
+		sq_init(&BIN_RESOURCELIST(g_bin_count));
+
 		bmvdbg("[USER1 : %d] %s size %d %d \n", g_bin_count, BIN_NAME(g_bin_count), BIN_PARTSIZE(g_bin_count), BIN_PARTNUM(g_bin_count, 0));
 	}
 }

--- a/os/kernel/binary_manager/binary_manager.h
+++ b/os/kernel/binary_manager/binary_manager.h
@@ -28,6 +28,8 @@
 
 #include <tinyara/binary_manager.h>
 
+#include <queue.h>
+
 #ifdef CONFIG_BINARY_MANAGER
 
 /****************************************************************************
@@ -94,6 +96,7 @@ struct binmgr_bininfo_s {
 	char bin_ver[BIN_VER_MAX];
 	char kernel_ver[KERNEL_VER_MAX];
 	sq_queue_t cb_list; // list node type : statecb_node_t
+	sq_queue_t resource_list; // list node type : resource_node_t
 };
 typedef struct binmgr_bininfo_s binmgr_bininfo_t;
 
@@ -114,6 +117,7 @@ typedef struct statecb_node_s statecb_node_t;
 #define BIN_VER(bin_idx)                                bin_table[bin_idx].bin_ver
 #define BIN_KERNEL_VER(bin_idx)                         bin_table[bin_idx].kernel_ver
 #define BIN_CBLIST(bin_idx)                             bin_table[bin_idx].cb_list
+#define BIN_RESOURCELIST(bin_idx)                       bin_table[bin_idx].resource_list
 
 #define BIN_LOAD_ATTR(bin_idx)                          bin_table[bin_idx].load_attr
 #define BIN_SIZE(bin_idx)                               bin_table[bin_idx].load_attr.bin_size
@@ -154,6 +158,7 @@ int binary_manager_unregister_statecb(int pid);
 void binary_manager_clear_bin_statecb(int bin_idx);
 int binary_manager_send_statecb_msg(int recv_binidx, char *bin_name, uint8_t state, bool need_response);
 int binary_manager_notify_state_changed(int bin_idx, uint8_t state);
+void binary_manager_clear_bin_resource(int bin_idx);
 int binary_manager_load_binary(int bin_idx);
 int binary_manager_loading(char *loading_data[]);
 int binary_manager_get_binary_count(void);

--- a/os/kernel/binary_manager/binary_manager_load.c
+++ b/os/kernel/binary_manager/binary_manager_load.c
@@ -406,6 +406,9 @@ static int binary_manager_reload(char *bin_name)
 	BIN_STATE(bin_idx) = BINARY_INACTIVE;
 	binary_manager_notify_state_changed(bin_idx, BINARY_UNLOADED);
 
+	/* Clear resources of binary */
+	binary_manager_clear_bin_resource(bin_idx);
+
 	/* load binary and update binid */
 	ret = binary_manager_load_binary(bin_idx);
 	if (ret != OK) {

--- a/os/kernel/binary_manager/binary_manager_resource.c
+++ b/os/kernel/binary_manager/binary_manager_resource.c
@@ -1,0 +1,196 @@
+/****************************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+#include <tinyara/config.h>
+#include <stdio.h>
+#include <debug.h>
+#include <stdlib.h>
+#include <queue.h>
+#include <errno.h>
+#include <mqueue.h>
+#ifdef CONFIG_FS_NAMED_SEMAPHORES
+#include <semaphore.h>
+#endif
+#if !defined(CONFIG_DISABLE_MOUNTPOINT) && CONFIG_NFILE_DESCRIPTORS > 0
+#include <unistd.h>
+#include <sys/mount.h>
+#endif
+#include <sys/types.h>
+
+#include <tinyara/mm/mm.h>
+#include <tinyara/sched.h>
+#include <tinyara/init.h>
+
+#include "sched/sched.h"
+#include "binary_manager.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+#define RES_PREPATH_LEN  32
+#define RES_NAME_LEN     (RES_PREPATH_LEN + CONFIG_NAME_MAX)
+
+struct resource_node_s {
+	struct resource_node_s *flink;
+	int type;
+	char name[RES_NAME_LEN];
+};
+typedef struct resource_node_s resource_node_t;
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+/****************************************************************************
+ * Name: binary_manager_clear_bin_inode
+ *
+ * Description:
+ *   This function will clear all resource nodes registered in the binary.
+ *
+ * Input parameters:
+ *   bin_idx   -   The index of the binary in binary table
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+void binary_manager_clear_bin_resource(int bin_idx)
+{
+	int ret;
+	resource_node_t *resource_node;
+	resource_node_t *node_ptr;
+
+	node_ptr = (resource_node_t *)sq_peek(&BIN_RESOURCELIST(bin_idx));
+	while (node_ptr != NULL) {
+		sq_rem((FAR sq_entry_t *)node_ptr, &BIN_RESOURCELIST(bin_idx));
+		resource_node = node_ptr;
+		switch (resource_node->type) {
+		case BIN_RESOURCE_MQ:
+			ret = mq_unlink(resource_node->name);
+			bmvdbg("Unlink MQ %s, ret %d\n", resource_node->name, ret);
+			break;
+#if !defined(CONFIG_DISABLE_MOUNTPOINT) && CONFIG_NFILE_DESCRIPTORS > 0
+		case BIN_RESOURCE_FILE:
+			ret = unlink(resource_node->name);
+			bmvdbg("Unlink FILE %s, ret %d %d\n", resource_node->name, ret, errno);
+			break;
+		case BIN_RESOURCE_MOUNTPT:
+			if (!sq_empty(&BIN_RESOURCELIST(bin_idx))) {
+				/* mountpoint should be unmounted last */
+				sq_addlast((FAR sq_entry_t *)resource_node, &BIN_RESOURCELIST(bin_idx));
+				node_ptr = (resource_node_t *)sq_next(node_ptr);
+				continue;
+			}
+			ret = umount(resource_node->name);
+			bmvdbg("Umount MNT %s, ret %d\n", resource_node->name, ret);
+			break;
+#endif
+#ifdef CONFIG_FS_NAMED_SEMAPHORES
+		case BIN_RESOURCE_NAMEDSEM:
+			ret = sem_unlink(resource_node->name);
+			bmvdbg("Unlink NAMED SEM %s, ret %d\n", resource_node->name, ret);
+			break;
+#endif
+		default:
+			bmdbg("Invalid resource type %d, %s\n", resource_node->type, resource_node->name);
+		}
+		node_ptr = (resource_node_t *)sq_next(node_ptr);
+		kmm_free(resource_node);
+	}
+}
+
+/****************************************************************************
+ * Name: binary_manager_register_resource
+ *
+ * Description:
+ *   This function registers resource info to a resource list of binary.
+ *
+ * Input parameters:
+ *   type   -   The type of the resource
+ *              It will be one of binmgr_resource_type defined in <tinyara/binary_manager.h>
+ *   name   -   The name of the resource
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+void binary_manager_register_resource(int type, const char *name)
+{
+	int bin_idx;
+	struct tcb_s *tcb;
+	resource_node_t *resource_node;
+
+	tcb = sched_self();
+	if (tcb == NULL || tcb->group == NULL) {
+		bmdbg("Failed to get tcb self\n");
+		return;
+	}
+
+	/* Get binary id of fault task and check it is registered in binary manager */
+	bin_idx = binary_manager_get_index_with_binid(tcb->group->tg_loadtask);
+	if (bin_idx > 0) {
+		resource_node = (resource_node_t *)kmm_malloc(sizeof(resource_node_t));
+		if (resource_node == NULL) {
+			bmdbg("Failed to allocate node for inode\n");
+			return;
+		}
+		resource_node->type = type;
+		strncpy(resource_node->name, name, CONFIG_NAME_MAX);
+		sq_addlast((FAR sq_entry_t *)resource_node, &BIN_RESOURCELIST(bin_idx));
+		bmvdbg("Inode '%s' is registered in '%s'\n", name, BIN_NAME(bin_idx));
+	}
+}
+
+/****************************************************************************
+ * Name: binary_manager_unregister_resource
+ *
+ * Description:
+ *   This function unregisters resource info from a resource list of binary.
+ *
+ * Input parameters:
+ *   type   -   The type of the resource
+ *              It will be one of binmgr_resource_type defined in <tinyara/binary_manager.h>
+ *   name   -   The name of the resource
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+void binary_manager_unregister_resource(int type, const char *name)
+{
+	int count;
+	int bin_idx;
+	resource_node_t *resource_node;
+
+	count = binary_manager_get_binary_count();
+
+	for (bin_idx = 1; bin_idx < count + 1; bin_idx++) {
+		if (!sq_empty(&BIN_RESOURCELIST(bin_idx))) {
+			resource_node = (resource_node_t *)sq_peek(&BIN_RESOURCELIST(bin_idx));
+			if (resource_node->type == type && !strncmp(resource_node->name, name, strlen(name) + 1)) {
+				sq_rem((FAR sq_entry_t *)resource_node, &BIN_RESOURCELIST(bin_idx));
+				bmvdbg("Inode '%s' is unregistered\n", name);
+				kmm_free(resource_node);
+				break;
+			}
+			resource_node = (resource_node_t *)sq_next(resource_node);
+		}
+	}
+}


### PR DESCRIPTION
When binary is reload because of fault or update request, all used resources should be freed.