### PR TITLE
system/utils/stackmonitor : Move terminated task logging func to kernel

### DIFF
--- a/apps/system/utils/Kconfig
+++ b/apps/system/utils/Kconfig
@@ -193,9 +193,9 @@ config ENABLE_STACKMONITOR
 if ENABLE_STACKMONITOR
 config STACKMONITOR_STACKSIZE
 	int "Stack monitor daemon stack size"
-	default 2048
+	default 4096
 	---help---
-		The stack size of the stack monitor daemon.  Default: 2048 bytes
+		The stack size of the stack monitor daemon.  Default: 4096 bytes
 
 config STACKMONITOR_PRIORITY
 	int "Stack monitor daemon priority"

--- a/apps/system/utils/utils_proc.h
+++ b/apps/system/utils/utils_proc.h
@@ -21,23 +21,6 @@
 
 #include <tinyara/config.h>
 #include <dirent.h>
-#ifdef CONFIG_ENABLE_STACKMONITOR
-#include <tinyara/clock.h>
-#include <sys/types.h>
-
-struct stkmon_save_s {
-	clock_t timestamp;
-	pid_t chk_pid;
-	size_t chk_stksize;
-	size_t chk_peaksize;
-#ifdef CONFIG_DEBUG_MM_HEAPINFO
-	int chk_peakheap;
-#endif
-#if (CONFIG_TASK_NAME_SIZE > 0)
-	char chk_name[CONFIG_TASK_NAME_SIZE + 1];
-#endif
-};
-#endif
 
 #if defined(CONFIG_ENABLE_IRQINFO) || defined(CONFIG_ENABLE_IRQINFO) || defined(CONFIG_ENABLE_PS) || defined(CONFIG_ENABLE_STACKMONITOR) || defined(CONFIG_ENABLE_HEAPINFO)
 #define ENABLE_PROC_UTILS

--- a/os/include/sys/prctl.h
+++ b/os/include/sys/prctl.h
@@ -90,6 +90,10 @@
  * @ingroup SCHED_KERNEL
  */
 #define PR_GET_NAME 2
+/**
+ * @ingroup SCHED_KERNEL
+ */
+#define PR_GET_STKLOG 3
 
 /****************************************************************************
  * Public Type Definitions

--- a/os/include/tinyara/sched.h
+++ b/os/include/tinyara/sched.h
@@ -69,6 +69,13 @@
 #include <mqueue.h>
 #include <time.h>
 
+#if defined(CONFIG_ENABLE_STACKMONITOR) && defined(CONFIG_DEBUG)
+#include <tinyara/clock.h>
+#ifdef CONFIG_DEBUG_MM_HEAPINFO
+#include <tinyara/mm/mm.h>
+#endif
+#endif
+
 #include <tinyara/irq.h>
 #include <tinyara/mm/shm.h>
 #include <tinyara/fs/fs.h>
@@ -665,6 +672,32 @@ typedef void (*sched_foreach_t)(FAR struct tcb_s *tcb, FAR void *arg);
 
 #endif							/* __ASSEMBLY__ */
 
+/* 
+ * @cond
+ * @internal
+ * {
+ */
+#define STKMON_MAX_LOGS (CONFIG_MAX_TASKS * 2)
+
+/* Structure for saving terminated task/pthread information with stack monitor. */
+struct stkmon_save_s {
+	clock_t timestamp;
+	pid_t chk_pid;
+	size_t chk_stksize;
+	size_t chk_peaksize;
+#ifdef CONFIG_DEBUG_MM_HEAPINFO
+	int chk_peakheap;
+#endif
+#if (CONFIG_TASK_NAME_SIZE > 0)
+	char chk_name[CONFIG_TASK_NAME_SIZE + 1];
+#endif
+};
+
+void stkmon_copy_log(struct stkmon_save_s *dest_arr);
+/* 
+ * }
+ * @endcond
+ */
 /********************************************************************************
  * Public Data
  ********************************************************************************/

--- a/os/kernel/sched/Make.defs
+++ b/os/kernel/sched/Make.defs
@@ -60,6 +60,10 @@ CSRCS += sched_setscheduler.c sched_getscheduler.c
 CSRCS += sched_yield.c sched_rrgetinterval.c sched_foreach.c
 CSRCS += sched_lock.c sched_unlock.c sched_lockcount.c sched_self.c
 
+ifeq ($(CONFIG_ENABLE_STACKMONITOR)$(CONFIG_DEBUG),yy)
+CSRCS += sched_save_terminated_stackinfo.c
+endif
+
 ifeq ($(CONFIG_PRIORITY_INHERITANCE),y)
 CSRCS += sched_reprioritize.c
 endif

--- a/os/kernel/sched/sched_releasetcb.c
+++ b/os/kernel/sched/sched_releasetcb.c
@@ -69,9 +69,6 @@
 #include "sched/sched.h"
 #include "group/group.h"
 #include "timer/timer.h"
-#if defined(CONFIG_ENABLE_STACKMONITOR) && defined(CONFIG_DEBUG)
-#include <apps/system/utils.h>
-#endif
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
 #include <tinyara/mm/mm.h>
 
@@ -159,7 +156,7 @@ int sched_releasetcb(FAR struct tcb_s *tcb, uint8_t ttype)
 
 	if (tcb) {
 #if defined(CONFIG_ENABLE_STACKMONITOR) && defined(CONFIG_DEBUG)
-		stkmon_logging(tcb);
+		sched_save_terminated_stackinfo(tcb);
 #endif
 
 #ifdef CONFIG_DEBUG_MM_HEAPINFO

--- a/os/kernel/sched/sched_save_terminated_stackinfo.c
+++ b/os/kernel/sched/sched_save_terminated_stackinfo.c
@@ -1,0 +1,152 @@
+/****************************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+/****************************************************************************
+ * kernel/sched/sched_stkmon_logging.c
+ *
+ *   Copyright (C) 2007, 2009 Gregory Nutt. All rights reserved.
+ *   Author: Gregory Nutt <gnutt@nuttx.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <tinyara/config.h>
+#include <time.h>
+#include <sys/types.h>
+
+#include <tinyara/clock.h>
+#include <tinyara/sched.h>
+#ifdef CONFIG_DEBUG_MM_HEAPINFO
+#include <tinyara/mm/mm.h>
+#endif
+
+/****************************************************************************
+ * Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Type Declarations
+ ****************************************************************************/
+
+/****************************************************************************
+ * Global Variables
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Variables
+ ****************************************************************************/
+static struct stkmon_save_s terminated_thread_stkinfo[CONFIG_MAX_TASKS * 2];
+static int stkmon_chk_idx;
+
+/****************************************************************************
+ * Private Function Prototypes
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+/****************************************************************************
+ * Name: stkmon_copy_log
+ *
+ * Description:
+ *   This function copies the terminated task/pthread's information to
+ *  user buffer.
+ *
+ ****************************************************************************/
+void stkmon_copy_log(struct stkmon_save_s *dest_arr)
+{
+	int thread_idx;
+
+	for (thread_idx = 0; thread_idx < STKMON_MAX_LOGS; thread_idx++) {
+		if (terminated_thread_stkinfo[thread_idx].timestamp != 0) {
+			memcpy(&dest_arr[thread_idx], &terminated_thread_stkinfo[thread_idx], sizeof(struct stkmon_save_s));
+		}
+	}
+}
+
+/****************************************************************************
+ * Name: sched_save_terminated_stackinfo
+ *
+ * Description:
+ *   This function saves the terminated task/pthread's information for
+ *  stack monitor.
+ *
+ ****************************************************************************/
+void sched_save_terminated_stackinfo(struct tcb_s *tcb)
+{
+#if (CONFIG_TASK_NAME_SIZE > 0)
+	int name_idx;
+#endif
+#ifdef CONFIG_DEBUG_MM_HEAPINFO
+	struct mm_heap_s *heap;
+#endif
+	terminated_thread_stkinfo[stkmon_chk_idx % STKMON_MAX_LOGS].timestamp = clock();
+	terminated_thread_stkinfo[stkmon_chk_idx % STKMON_MAX_LOGS].chk_pid = tcb->pid;
+	terminated_thread_stkinfo[stkmon_chk_idx % STKMON_MAX_LOGS].chk_stksize = tcb->adj_stack_size;
+#ifdef CONFIG_STACK_COLORATION
+	terminated_thread_stkinfo[stkmon_chk_idx % STKMON_MAX_LOGS].chk_peaksize = up_check_tcbstack(tcb);
+#endif
+#ifdef CONFIG_DEBUG_MM_HEAPINFO
+	heap = mm_get_heap(tcb->stack_alloc_ptr);
+	if (heap == NULL) {
+		return;
+	}
+	terminated_thread_stkinfo[stkmon_chk_idx % STKMON_MAX_LOGS].chk_peakheap = heap->alloc_list[PIDHASH(tcb->pid)].peak_alloc_size;
+#endif
+#if (CONFIG_TASK_NAME_SIZE > 0)
+	for (name_idx = 0; name_idx < CONFIG_TASK_NAME_SIZE + 1; name_idx++) {
+		terminated_thread_stkinfo[stkmon_chk_idx % STKMON_MAX_LOGS].chk_name[name_idx] = tcb->name[name_idx];
+	}
+#endif
+	stkmon_chk_idx %= STKMON_MAX_LOGS;
+	stkmon_chk_idx++;
+}
+

--- a/os/kernel/task/task_prctl.c
+++ b/os/kernel/task/task_prctl.c
@@ -166,21 +166,27 @@ int prctl(int option, ...)
 	goto errout;
 #endif
 
+	case PR_GET_STKLOG:
+	{
+#if defined(CONFIG_ENABLE_STACKMONITOR) && defined(CONFIG_DEBUG)
+		struct stkmon_save_s *dest_buf = va_arg(ap, struct stkmon_save_s *);
+		stkmon_copy_log(dest_buf);
+#else
+		sdbg("Not supported StackMonitor Logging\n");
+		err = ENOSYS;
+		goto errout;
+#endif
+	}
+	break;
 	default:
 		sdbg("Unrecognized option: %d\n", option);
 		err = EINVAL;
 		goto errout;
 	}
 
-	/* Not reachable unless CONFIG_TASK_NAME_SIZE is > 0.  NOTE: This might
-	 * change if additional commands are supported.
-	 */
-
-#if CONFIG_TASK_NAME_SIZE > 0
 	va_end(ap);
 	trace_end(TTRACE_TAG_TASK);
 	return OK;
-#endif
 
 errout:
 	va_end(ap);


### PR DESCRIPTION
Previously, kernel used app/system resource(stkmon_arr) for logging terminated task information.
Now kernel has resource for logging, and stackmonitor in app/system copies the data when they need.