### PR TITLE
build/tools/esp32: erasing entire flash before downloading all images.

### DIFF
--- a/build/tools/esp32/esptool_py/Makefile
+++ b/build/tools/esp32/esptool_py/Makefile
@@ -74,7 +74,7 @@ $(APP_BIN_UNSIGNED): $(APP_ELF) $(ESPTOOLPY_SRC)
 
 ESPTOOL_ALL_FLASH_ARGS += $(ESPTOOL_BOOTLOADER_FLASH_ARGS)
 
-ALL:flash romfs
+ALL:erase_flash flash romfs
 
 OS:app-flash
 

--- a/build/tools/esp32/esptool_py/Makefile
+++ b/build/tools/esp32/esptool_py/Makefile
@@ -80,7 +80,7 @@ OS:app-flash
 
 ROMFS:romfs
 
-romfs: $(ROMFS_IMG) $(ESPTOOLPY_SRC)
+romfs: $(ESPTOOLPY_SRC)
 ifneq ($(ROMFS_OFFSET),-1)
 	@echo "Flashing romfs image to serial port $(ESPPORT), offset $(ROMFS_OFFSET)..."
 	$(ESPTOOLPY_WRITE_FLASH) $(ROMFS_OFFSET) $(ROMFS_IMG)


### PR DESCRIPTION
Enhance 1)
build/tools/esp32: erasing entire flash before downloading all images.
Add step of erasing entire flash before downloading all images
to flash, it helps fix unexpected read/write issue for file systems
based on flash. 

Enhance 2)
build/tools/esp32: Remove dependent for make target "romfs"
if dependent "ROMFS_IMG" image not exist, "No rule to make target"
error will report, and this image will be checked by another script,
so this dependent can be removed.

@sunghan-chang 