### PR TITLE
examples/binary_update : Add sample scenario for download valid and invalid binary

### DIFF
--- a/apps/examples/binary_update/binary_update_main.c
+++ b/apps/examples/binary_update/binary_update_main.c
@@ -31,7 +31,7 @@
 #define APP1_NAME "micom"
 #define APP2_NAME "wifi"
 
-#define EXEC_NORMAL   0
+#define EXEC_FINITE   0
 #define EXEC_INFINITE 1
 
 static volatile bool is_running;
@@ -163,9 +163,9 @@ int binary_update_main(int argc, char *argv[])
 {
 	int repetition_num = 1;
 	int option;
-	char *cmd_arg = NULL;
-	char *cnt_arg = NULL;
-	int execution_type = EXEC_NORMAL;
+	char *cmd_arg;
+	char *cnt_arg;
+	int execution_type;
 
 	if (argc >= 4 || argc == 2) {
 		goto usage;
@@ -178,7 +178,7 @@ int binary_update_main(int argc, char *argv[])
 			cmd_arg = optarg;
 			break;
 		case 'n':
-			execution_type = EXEC_NORMAL;
+			execution_type = EXEC_FINITE;
 			cnt_arg = optarg;
 			break;
 		case '?':
@@ -189,13 +189,13 @@ int binary_update_main(int argc, char *argv[])
 
 	/* Execute the binary update example. */
 	if (execution_type == EXEC_INFINITE) {
-		if (cmd_arg && strncmp(cmd_arg, "start", strlen("start") + 1) == 0) {
+		if (strncmp(cmd_arg, "start", strlen("start") + 1) == 0) {
 			if (is_running) {
 				goto already_running;
 			}
 			inf_flag = true;
 			binary_update_execute_infinitely();
-		} else if (cmd_arg && strncmp(cmd_arg, "stop", strlen("stop") + 1) == 0) {
+		} else if (strncmp(cmd_arg, "stop", strlen("stop") + 1) == 0) {
 			if (inf_flag == false) {
 				printf("There is no infinite running Binary Update example. Cannot stop the sample.\n");
 				return -1;

--- a/apps/examples/binary_update/binary_update_main.c
+++ b/apps/examples/binary_update/binary_update_main.c
@@ -28,8 +28,7 @@
 
 #include <binary_manager/binary_manager.h>
 
-#define APP1_NAME "micom"
-#define APP2_NAME "wifi"
+#define APP_NAME "micom"
 
 #define EXEC_FINITE   0
 #define EXEC_INFINITE 1
@@ -108,11 +107,9 @@ static void binary_update_reload(char *name)
 static void binary_update_run_tests(int repetition_num)
 {
 	printf("\n** Binary Update Example %d-th Iteration.\n", repetition_num);
-	binary_update_getinfo(APP1_NAME);
-	binary_update_getinfo(APP2_NAME);
+	binary_update_getinfo(APP_NAME);
 	binary_update_getinfo_all();
-	binary_update_reload(APP1_NAME);
-	binary_update_reload(APP2_NAME);
+	binary_update_reload(APP_NAME);
 
 	/* Wait for finishing previous test. */
 	sleep(1);

--- a/apps/examples/binary_update/binary_update_main.c
+++ b/apps/examples/binary_update/binary_update_main.c
@@ -24,18 +24,51 @@
 #include <stdbool.h>
 #include <string.h>
 #include <unistd.h>
+#include <fcntl.h>
+#include <crc32.h>
 #include <sys/types.h>
 
 #include <binary_manager/binary_manager.h>
 
 #define APP_NAME "micom"
 
-#define EXEC_FINITE   0
-#define EXEC_INFINITE 1
+#define EXEC_FINITE                 0
+#define EXEC_INFINITE               1
+
+#define DOWNLOAD_VALID_BIN          0
+#define DOWNLOAD_INVALID_BIN        1
+
+#define CHECKSUM_SIZE               4
+#define CRC_BUFFER_SIZE             512
+
+/* The maximum length of binary name */
+#define BIN_NAME_MAX                16
+
+/* The maximum length of version name */
+#define BIN_VER_MAX                 16
+
+/* The length of dev name */
+#define KERNEL_VER_MAX              8
+
+struct binary_header_s {
+	uint16_t header_size;
+	uint8_t bin_type;
+	uint8_t compression_type;
+	uint8_t bin_priority;
+	uint32_t bin_size;
+	char bin_name[BIN_NAME_MAX];
+	char bin_ver[BIN_VER_MAX];
+	uint32_t bin_ramsize;
+	uint32_t bin_stacksize;
+	char kernel_ver[KERNEL_VER_MAX];
+	uint32_t jump_addr;
+} __attribute__((__packed__));
+typedef struct binary_header_s binary_header_t;
 
 static volatile bool is_running;
 static volatile bool inf_flag = true;
 static int fail_cnt = 0;
+static unsigned int new_version = 20190422;
 
 static void print_binary_info(binary_info_t *binary_info)
 {
@@ -61,6 +94,133 @@ static void print_binary_info_list(binary_info_list_t *binary_info_list)
 	printf(" ==================================================== \n");
 }
 
+static void binary_update_check_test_result(binary_info_t *pre_bin_info, binary_info_t *cur_bin_info, int condition)
+{
+	printf(" === [%5s] Update info === \n", cur_bin_info->name);
+	printf(" %4s | %8s | %s \n", "Con", "Version", "Inactive part");
+	printf(" ------------------------- \n");
+	printf(" %4s | %8s | %s \n", "Pre", pre_bin_info->version, pre_bin_info->dev_path);
+	printf(" %4s | %8s | %s \n", "Cur", cur_bin_info->version, cur_bin_info->dev_path);
+	printf(" ========================= \n");
+
+	if (condition == DOWNLOAD_VALID_BIN) {
+		if (strncmp(pre_bin_info->dev_path, cur_bin_info->dev_path, sizeof(pre_bin_info->dev_path) == 0)) {
+			fail_cnt++;
+			printf("Fail to load valid higher version binary.\n");
+		} else {
+			printf("Success to load valid higher version binary.\n");
+		}
+	} else { //DOWNLOAD_INVALID_BIN
+		if (strncmp(pre_bin_info->dev_path, cur_bin_info->dev_path, sizeof(pre_bin_info->dev_path) != 0)) {
+			fail_cnt++;
+			printf("Warning! Load invalid binary.\n");
+		} else {
+			printf("No update with invalid binary.\n");
+		}
+	}
+}
+
+static void binary_update_write_binary(char *devname, int condition, uint32_t crc_hash, binary_header_t *header_data)
+{
+	int fd;
+	int ret;
+	fd = open(devname, O_WRONLY);
+	if (fd < 0) {
+		printf("Failed to open %s: %d, errno: %d\n", devname, ret, get_errno());
+		return;
+	}
+
+	if (condition == DOWNLOAD_VALID_BIN) {
+		/* Write new crc */
+		ret = write(fd, (FAR uint8_t *)&crc_hash, CHECKSUM_SIZE);
+		if (ret != CHECKSUM_SIZE) {
+			printf("Failed to read %s: %d\n", devname, ret);
+			close(fd);
+			return;
+		}
+		printf("Download to valid binary\n");
+	} else {
+		/*Dose not write new crc. jump to header information. */
+		ret = lseek(fd, CHECKSUM_SIZE, SEEK_SET);
+		if (ret == ERROR) {
+			printf("Failed to lseek %s\n", devname);
+			close(fd);
+			return;
+		}
+		printf("Download to invalid binary\n");
+	}
+
+	/* Write new version. */
+	ret = write(fd, (FAR uint8_t *)header_data, sizeof(binary_header_t));
+	if (ret != sizeof(binary_header_t)) {
+		printf("Failed to write %s: %d\n", devname, ret);
+		close(fd);
+		return;
+	}
+
+	close(fd);
+}
+
+static void binary_update_download_binary(char *devname, int condition)
+{
+	int fd;
+	int ret;
+	int file_size;
+	int read_size;
+	uint32_t crc_hash = 0;
+	uint8_t crc_buffer[CRC_BUFFER_SIZE];
+	binary_header_t header_data;
+
+	printf("\n** Binary Update Download [%s] %s case test.\n", devname, condition == DOWNLOAD_VALID_BIN ? "Valid" : "Invalid");
+
+	fd = open(devname, O_RDONLY);
+	if (fd < 0) {
+		fail_cnt++;
+		printf("Failed to open %s: %d, errno: %d\n", devname, ret, get_errno());
+		return;
+	}
+
+	/* Jump to header information. */
+	ret = lseek(fd, CHECKSUM_SIZE, SEEK_SET);
+	if (ret == ERROR) {
+		printf("Failed to lseek %s\n", devname);
+		close(fd);
+		return;
+	}
+
+	/* Read the binary header. */
+	ret = read(fd, (FAR uint8_t *)&header_data, sizeof(binary_header_t));
+	if (ret != sizeof(binary_header_t)) {
+		printf("Failed to read %s: %d\n", devname, ret);
+		close(fd);
+		return;
+	}
+
+	/* Version update */
+	snprintf(header_data.bin_ver, BIN_VER_MAX, "%u", new_version);
+
+	/* Version is updated to create a new crc. */
+	if (condition == DOWNLOAD_VALID_BIN) {
+		crc_hash = crc32part((uint8_t *)&header_data, header_data.header_size, crc_hash);
+		file_size = header_data.bin_size;
+
+		while (file_size > 0) {
+			read_size = file_size < CRC_BUFFER_SIZE ? file_size : CRC_BUFFER_SIZE;
+			ret = read(fd, (FAR uint8_t *)crc_buffer, read_size);
+			if (ret != read_size) {
+				printf("Failed to read %s: %d\n", devname, ret);
+				close(fd);
+				return;
+			}
+			crc_hash = crc32part(crc_buffer, read_size, crc_hash);
+			file_size -= read_size;
+		}
+	}
+
+	close(fd);
+
+	binary_update_write_binary(devname, condition, crc_hash, &header_data);
+}
 
 static void binary_update_getinfo_all(void)
 {
@@ -77,15 +237,14 @@ static void binary_update_getinfo_all(void)
 	}
 }
 
-static void binary_update_getinfo(char *name)
+static void binary_update_getinfo(char *name, binary_info_t *bin_info)
 {
 	int ret;
-	binary_info_t bin_info;
 
 	printf("\n** Binary Update GETINFO [%s] test.\n", name);
-	ret = binary_manager_get_update_info(name, &bin_info);
+	ret = binary_manager_get_update_info(name, bin_info);
 	if (ret == OK) {
-		print_binary_info(&bin_info);
+		print_binary_info(bin_info);
 	} else {
 		printf("Get binary info FAIL, ret %d\n", ret);
 	}
@@ -106,10 +265,28 @@ static void binary_update_reload(char *name)
 
 static void binary_update_run_tests(int repetition_num)
 {
+	new_version++;
+
+	binary_info_t pre_bin_info;
+	binary_info_t cur_bin_info;
 	printf("\n** Binary Update Example %d-th Iteration.\n", repetition_num);
-	binary_update_getinfo(APP_NAME);
-	binary_update_getinfo_all();
+
+	binary_update_getinfo(APP_NAME, &pre_bin_info);
+	/* Test invalid APP binary download. */
+	binary_update_download_binary(&pre_bin_info.dev_path, DOWNLOAD_INVALID_BIN);
 	binary_update_reload(APP_NAME);
+	binary_update_getinfo(APP_NAME, &cur_bin_info);
+
+	binary_update_check_test_result(&pre_bin_info, &cur_bin_info, DOWNLOAD_INVALID_BIN);
+
+	/* Test valid APP binary download. */
+	binary_update_download_binary(&cur_bin_info.dev_path, DOWNLOAD_VALID_BIN);
+	binary_update_reload(APP_NAME);
+	binary_update_getinfo(APP_NAME, &cur_bin_info);
+
+	binary_update_check_test_result(&pre_bin_info, &cur_bin_info, DOWNLOAD_VALID_BIN);
+
+	binary_update_getinfo_all();
 
 	/* Wait for finishing previous test. */
 	sleep(1);


### PR DESCRIPTION
…ccess

It made a sample test by adding the situation where the download
failed and the situation that succeeded.

** Binary Update example : executes 1-times.

** Binary Update Example 1-th Iteration.

** Binary Update GETINFO [micom] test.
 ========= binary [micom] info ==========
  Version | Partsize | Inactive part
 ---------------------------------------
 20190423 |   262144 | /dev/mtdblock2
 ========================================

** Binary Update Download [/dev/mtdblock2] Fail case test.
Failed to download

** Binary Update RELOAD [micom] test.
RELOAD [micom] SUCCESS

** Binary Update GETINFO [micom] test.
 ========= binary [micom] info ==========
  Version | Partsize | Inactive part
 ---------------------------------------
 20190423 |   262144 | /dev/mtdblock2
 ========================================
 === [micom] Update info ===
  Con |  Version | Inactive part
 -------------------------
  Pre | 20190423 | /dev/mtdblock2
  Cur | 20190423 | /dev/mtdblock2
 =========================
Binary Update Download Fail Case SUCCESS.

** Binary Update Download [/dev/mtdblock2] Success case test.
Succeed to download

** Binary Update RELOAD [micom] test.
RELOAD [micom] SUCCESS

** Binary Update GETINFO [micom] test.
 ========= binary [micom] info ==========
  Version | Partsize | Inactive part
 ---------------------------------------
 20190423 |   262144 | /dev/mtdblock3
 ========================================
 === [micom] Update info ===
  Con |  Version | Inactive part
 -------------------------
  Pre | 20190423 | /dev/mtdblock2
  Cur | 20190423 | /dev/mtdblock3
 =========================
Binary Update Download Success Case SUCCESS.

** Binary Update GETINFO [wifi] test.
 ========= binary [wifi] info ==========
  Version | Partsize | Inactive part
 ---------------------------------------
 20190423 |   262144 | /dev/mtdblock4
 ========================================

** Binary Update Download [/dev/mtdblock4] Fail case test.
Failed to download

** Binary Update RELOAD [wifi] test.
This is WIFI App
RELOAD [wifi] SUCCESS

** Binary Update GETINFO [wifi] test.
 ========= binary [wifi] info ==========
  Version | Partsize | Inactive part
 ---------------------------------------
 20190423 |   262144 | /dev/mtdblock4
 ========================================
 === [wifi] Update info ===
  Con |  Version | Inactive part
 -------------------------
  Pre | 20190423 | /dev/mtdblock4
  Cur | 20190423 | /dev/mtdblock4
 =========================
Binary Update Download Fail Case SUCCESS.

** Binary Update Download [/dev/mtdblock4] Success case test.
Succeed to download

** Binary Update RELOAD [wifi] test.
This is WIFI App
RELOAD [wifi] SUCCESS

** Binary Update GETINFO [wifi] test.
 ========= binary [wifi] info ==========
  Version | Partsize | Inactive part
 ---------------------------------------
 20190423 |   262144 | /dev/mtdblock5
 ========================================
 === [wifi] Update info ===
  Con |  Version | Inactive part
 -------------------------
  Pre | 20190423 | /dev/mtdblock4
  Cur | 20190423 | /dev/mtdblock5
 =========================
Binary Update Download Success Case SUCCESS.

** Binary Update GETINFO_ALL test.
 ============ ALL binary info : 3 count ==============
  Idx |   Name |  Version | Partsize | Inactive part
 ----------------------------------------------------
    0 | kernel |      2.0 |   262144 |
    1 |  micom | 20190423 |   262144 | /dev/mtdblock3
    2 |   wifi | 20190423 |   262144 | /dev/mtdblock5
 ====================================================

*** Binary Update Example is finished. (run 1-times)
 - success : 1, fail 0