### PR TITLE
framework/security: fix security bug

### DIFF
--- a/framework/src/security/security_auth.c
+++ b/framework/src/security/security_auth.c
@@ -114,6 +114,11 @@ security_error auth_get_certificate(security_handle hnd, const char *cert_name, 
 		SECAPI_HAL_RETURN(hres);
 	}
 
+	cert->data = (unsigned char *)malloc(cert_out.data_len);
+	if (!cert->data) {
+		SECAPI_RETURN(SECURITY_ALLOC_ERROR);
+	}
+
 	SECAPI_DATA_DCOPY(cert_out, cert);
 
 	SECAPI_RETURN(SECURITY_OK);

--- a/framework/src/security/security_ss.c
+++ b/framework/src/security/security_ss.c
@@ -48,6 +48,11 @@ security_error ss_read_secure_storage(security_handle hnd, const char *ss_name, 
 		SECAPI_HAL_RETURN(hres);
 	}
 
+	data->data = (unsigned char *)malloc(ss.data_len);
+	if (!data->data) {
+		SECAPI_RETURN(SECURITY_ALLOC_ERROR);
+	}
+
 	SECAPI_DATA_DCOPY(ss, data);
 
 	SECAPI_RETURN(SECURITY_OK);

--- a/framework/src/security/security_utils.c
+++ b/framework/src/security/security_utils.c
@@ -267,11 +267,8 @@ int secutils_convert_path_s2h(const char *path, uint32_t *slot)
 	if (!strncmp(path, SS_PATH, sizeof(SS_PATH) - 1)) {
 		*slot = atoi(&path[3]);
 		return 0;
-	} else if (!strncmp(path, FACTORY_PATH, sizeof(FACTORY_PATH) - 1)) {
-		*slot = FACTORYKEY_ARTIK_CERT;
-		return 0;
 	}
-
+	
 	return -1;
 }
 


### PR DESCRIPTION
if it doesn't allocate memory in security layer it'll cause crash
becuase of dangling pointer. furthermore sl_init function doesn't
deallocate handle when it fails to call ioctl or to get error message
from SE driver. handle should be freed both cases