### PR TITLE
network/realtek: fix build path

### DIFF
--- a/os/drivers/Makefile
+++ b/os/drivers/Makefile
@@ -62,8 +62,6 @@ ASRCS =
 CSRCS =
 VPATH = .
 
-CFLAGS += -I $(TOPDIR)/include
-
 ifeq ($(CONFIG_TASK_MANAGER),y)
 CFLAGS += -I $(TOPDIR)/kernel
 endif

--- a/os/drivers/wireless/realtek/Make.defs
+++ b/os/drivers/wireless/realtek/Make.defs
@@ -141,10 +141,7 @@ IFLAGS += $(TOPDIR)$(DELIM)drivers$(DELIM)wireless$(DELIM)realtek$(DELIM)platfor
 
 IFLAGS += $(TOPDIR)$(DELIM)drivers$(DELIM)wireless$(DELIM)realtek$(DELIM)wifi_util_interface
 
-IFLAGS += $(TOPDIR)$(DELIM)include$(DELIM)net
-IFLAGS += $(TOPDIR)$(DELIM)include$(DELIM)net$(DELIM)lwip
 IFLAGS += $(TOPDIR)$(DELIM)arch$(DELIM)arm$(DELIM)src$(DELIM)imxrt
-IFLAGS += $(TOPDIR)$(DELIM)include$(DELIM)tinyara$(DELIM)usb
 ######################### END OF INCLUDE FILES #################################
 
 ############################ COMPILE FLAG ####################################

--- a/os/drivers/wireless/realtek/platform/ethernetif_tizenrt.c
+++ b/os/drivers/wireless/realtek/platform/ethernetif_tizenrt.c
@@ -43,20 +43,20 @@
  * something that better describes your network interface.
  */
 
-#include "lwip/opt.h"
-#include "lwip/def.h"
-#include "lwip/mem.h"
-#include "lwip/pbuf.h"
-#include "lwip/sys.h"
-#include "lwip/tcpip.h"
-#include "lwip/icmp.h"
-#include "netif/etharp.h"
-#include "err.h"
+#include "net/lwip/opt.h"
+#include "net/lwip/def.h"
+#include "net/lwip/mem.h"
+#include "net/lwip/pbuf.h"
+#include "net/lwip/sys.h"
+#include "net/lwip/tcpip.h"
+#include "net/lwip/icmp.h"
+#include "net/lwip/netif/etharp.h"
+#include "net/lwip/err.h"
 #include "ethernetif_tizenrt.h"
 #include "queue.h"
 #include "rtk_lwip_netconf.h"
 
-#include "lwip/ethip6.h" //Add for ipv6
+#include "net/lwip/ethip6.h" //Add for ipv6
 
 #if CONFIG_WLAN
 #include <lwip_intf_tizenrt.h>

--- a/os/drivers/wireless/realtek/platform/ethernetif_tizenrt.h
+++ b/os/drivers/wireless/realtek/platform/ethernetif_tizenrt.h
@@ -1,8 +1,8 @@
 #ifndef __ETHERNETIF_H__
 #define __ETHERNETIF_H__
 
-#include "lwip/err.h"
-#include "lwip/netif.h"
+#include "net/lwip/err.h"
+#include "net/lwip/netif.h"
 
 //----- ------------------------------------------------------------------
 // Ethernet Buffer

--- a/os/drivers/wireless/realtek/platform/lwip_intf_tizenrt.c
+++ b/os/drivers/wireless/realtek/platform/lwip_intf_tizenrt.c
@@ -17,7 +17,7 @@
 #define CONFIG_LWIP_LAYER 1
 
 #include <lwip_intf_tizenrt.h>
-#include <lwip/netif.h>
+#include <net/lwip/netif.h>
 #include <osdep_service.h>
 
 //----- ------------------------------------------------------------------

--- a/os/drivers/wireless/realtek/platform/usb/usb_io_realtek.h
+++ b/os/drivers/wireless/realtek/platform/usb/usb_io_realtek.h
@@ -2,8 +2,8 @@
 #define _USB_IO_REALTEK_H
 
 #include "tizenrt_service.h"
-#include "usb.h"
-#include "usbhost.h"
+#include "tinyara/usb/usb.h"
+#include "tinyara/usb/usbhost.h"
 
 typedef struct USB_DATA_S {
 	void *usb_intf;

--- a/os/drivers/wireless/realtek/wifi_util_interface/rtk_lwip_netconf.c
+++ b/os/drivers/wireless/realtek/wifi_util_interface/rtk_lwip_netconf.c
@@ -23,20 +23,20 @@
 #include <stdio.h>
 #include <string.h>
 
-#include "lwip/mem.h"
-#include "lwip/memp.h"
-#include "lwip/dhcp.h"
+#include "net/lwip/mem.h"
+#include "net/lwip/memp.h"
+#include "net/lwip/dhcp.h"
 #if LWIP_DNS
 #if LWIP_VERSION_MAJOR >= 2
-#include "lwip/prot/dns.h"
+#include "net/lwip/prot/dns.h"
 #endif
 #endif
-#include "lwip/netif.h"
-#include "lwip/tcp.h"
+#include "net/lwip/netif.h"
+#include "net/lwip/tcp.h"
 #include "ethernetif_tizenrt.h"
 #include "rtk_lwip_netconf.h"
 
-#include "tcpip.h"
+#include "net/lwip/tcpip.h"
 #include "wifi_ind.h"
 
 //#include <platform/platform_stdlib.h>

--- a/os/drivers/wireless/realtek/wifi_util_interface/rtk_lwip_netconf.h
+++ b/os/drivers/wireless/realtek/wifi_util_interface/rtk_lwip_netconf.h
@@ -15,14 +15,14 @@
 extern "C" {
 #endif
 
-#include "tcpip.h"
-#include "init.h" //for lwip version control
+#include "net/lwip/tcpip.h"
+#include "net/lwip/init.h" //for lwip version control
 /* Includes ------------------------------------------------------------------*/
 //#include <platform/platform_stdlib.h>
 //#include "platform_opts.h"
 //#include "autoconf.h"
 
-#include "err.h"
+#include "net/lwip/err.h"
 // macros
 /* Give default value if not defined */
 

--- a/os/drivers/wireless/realtek/wifi_util_interface/wifi_interactive_mode.c
+++ b/os/drivers/wireless/realtek/wifi_util_interface/wifi_interactive_mode.c
@@ -5,18 +5,18 @@
 #include <string.h>
 #include <stdint.h>
 #include <debug.h>
-#include <netif.h>
+#include <net/lwip/netif.h>
 #include <rtk_lwip_netconf.h>
 
 #include "osdep_service.h"
 #include "wifi_conf.h"
 #include "wifi_util.h"
 #include "rtk_lwip_netconf.h"
-#include "ip_addr.h"
-#include "ip4_addr.h"
+#include "net/lwip/ip_addr.h"
+#include "net/lwip/ip4_addr.h"
 #include "wifi_common.h"
 #include "rtk_wifi_utils.h"
-#include "tcpip.h"
+#include "net/lwip/tcpip.h"
 
 #include <../../framework/src/wifi_manager/wifi_common.h>
 


### PR DESCRIPTION
including (TOPDIR)/include causes unexpected errors which is hard to
find. therefore remove the script line and fix the referenced path.