### PR TITLE
board/imxrt1020-evk: Add Quad Timer support for imxrt1020

### DIFF
--- a/os/arch/arm/src/imxrt/imxrt_qtmr.c
+++ b/os/arch/arm/src/imxrt/imxrt_qtmr.c
@@ -77,6 +77,7 @@ static struct imxrt_qtmr_chipinfo_s imxrt_qtmr1_chipinfo = {
 
 };
 
+#ifdef CONFIG_ARCH_CHIP_FAMILY_IMXRT105x
 static struct imxrt_qtmr_chipinfo_s imxrt_qtmr2_chipinfo = {
 	.base = TMR3,
 	.irq_id = IMXRT_IRQ_QTIMER3,
@@ -86,6 +87,7 @@ static struct imxrt_qtmr_chipinfo_s imxrt_qtmr3_chipinfo = {
 	.base = TMR4,
 	.irq_id = IMXRT_IRQ_QTIMER4,
 };
+#endif
 
 struct imxrt_qtmr_lowerhalf_s {
 	const struct timer_ops_s *ops;		/* Lowerhalf operations */
@@ -155,6 +157,7 @@ static struct imxrt_qtmr_lowerhalf_s g_qtmr1_3_lowerhalf = {
 	.tmr = kQTMR_1,
 };
 
+#ifdef CONFIG_ARCH_CHIP_FAMILY_IMXRT105x
 static struct imxrt_qtmr_lowerhalf_s g_qtmr2_0_lowerhalf = {
 	.ops = &qtmr_timer_ops,
 	.channel = kQTMR_Channel_0,
@@ -202,6 +205,7 @@ static struct imxrt_qtmr_lowerhalf_s g_qtmr3_3_lowerhalf = {
 	.channel = kQTMR_Channel_3,
 	.tmr = kQTMR_3,
 };
+#endif
 
 /*******************************************************************************
  * Code
@@ -771,7 +775,7 @@ struct imxrt_qtmr_chipinfo_s *imxrt_qtmr_configure(int timer, qtmr_config_t *con
 	case kQTMR_1:
 		qtmr = &imxrt_qtmr1_chipinfo;
 		break;
-
+#ifdef CONFIG_ARCH_CHIP_FAMILY_IMXRT105x
 	case kQTMR_2:
 		qtmr = &imxrt_qtmr2_chipinfo;
 		break;
@@ -779,6 +783,7 @@ struct imxrt_qtmr_chipinfo_s *imxrt_qtmr_configure(int timer, qtmr_config_t *con
 	case kQTMR_3:
 		qtmr = &imxrt_qtmr3_chipinfo;
 		break;
+#endif
 	}
 
 	imxrt_qtmr_init(qtmr->base, channel, config);
@@ -969,6 +974,7 @@ int imxrt_qtmr_initialize(const char *devpath, int timer)
 		lower = &g_qtmr1_0_lowerhalf;
 		break;
 
+#ifdef CONFIG_ARCH_CHIP_FAMILY_IMXRT105x
 	case kQTMR_2:
 		lower = &g_qtmr2_0_lowerhalf;
 		break;
@@ -976,6 +982,7 @@ int imxrt_qtmr_initialize(const char *devpath, int timer)
 	case kQTMR_3:
 		lower = &g_qtmr3_0_lowerhalf;
 		break;
+#endif
 	}
 
 	if (!lower) {

--- a/os/arch/arm/src/imxrt/imxrt_qtmr.h
+++ b/os/arch/arm/src/imxrt/imxrt_qtmr.h
@@ -160,8 +160,10 @@ enum imxrt_qtmr_channel_e {
 typedef enum _qtmr_selection {
 	kQTMR_0,
 	kQTMR_1,
+#ifdef CONFIG_ARCH_CHIP_FAMILY_IMXRT105x
 	kQTMR_2,
 	kQTMR_3,
+#endif
 	kQTMR_MAX,
 } qtmr_selection_t;
 

--- a/os/board/imxrt1020-evk/src/imxrt_boot.c
+++ b/os/board/imxrt1020-evk/src/imxrt_boot.c
@@ -78,6 +78,11 @@
 #include "imxrt_pit.h"
 #define PIT_DEVPATH	"/dev/pit"
 #endif
+
+#ifdef CONFIG_IMXRT_QTMR
+#include "imxrt_qtmr.h"
+#endif
+
 /****************************************************************************
  * Name: imxrt_board_adc_initialize
  *
@@ -230,6 +235,14 @@ void board_initialize(void)
 #endif
 #ifdef CONFIG_IMXRT_PIT
 		imxrt_pit_initialize(PIT_DEVPATH);
+#endif
+
+#ifdef CONFIG_IMXRT_QTMR
+		for (timer_idx = 0; timer_idx < kQTMR_MAX; timer_idx++) {
+			snprintf(timer_path, sizeof(timer_path), "/dev/qtimer%d", timer_idx);
+			imxrt_qtmr_initialize(timer_path, timer_idx);
+		}
+
 #endif
 	}
 #endif


### PR DESCRIPTION
This patch adds support of quad timer on imxrt1020-evk
chipset

Signed-off-by: Yashwanth <v.yashwanth@samsung.com>