### PR TITLE
framework/media: Fix buildwarning

### DIFF
--- a/framework/include/media/media_init.h
+++ b/framework/include/media/media_init.h
@@ -28,7 +28,7 @@
 extern "C" {
 #endif
 
-int media_init();
+int media_init(void);
 
 #if defined(__cplusplus)
 } /* extern "C" */


### PR DESCRIPTION
Add void argument to fix `warning: function declaration isn't a prototype [-Wstrict-prototypes]`