### PR TITLE
include/sys/prctl.h : Change prctl type to enum value

### DIFF
--- a/os/include/sys/prctl.h
+++ b/os/include/sys/prctl.h
@@ -84,31 +84,16 @@
 
 /**
  * @ingroup SCHED_KERNEL
+ * @brief Types of Prctl API
  */
-#define PR_SET_NAME 1
-/**
- * @ingroup SCHED_KERNEL
- */
-#define PR_GET_NAME 2
-/**
- * @ingroup SCHED_KERNEL
- */
-#define PR_GET_STKLOG 3
-
-#ifdef CONFIG_MESSAGING_IPC
-/**
- * @ingroup SCHED_KERNEL
- */
-#define PR_MSG_SAVE 4
-/**
- * @ingroup SCHED_KERNEL
- */
-#define PR_MSG_READ 5
-/**
- * @ingroup SCHED_KERNEL
- */
-#define PR_MSG_REMOVE 6
-#endif
+enum prctl_type_e {
+	PR_SET_NAME = 1,
+	PR_GET_NAME = 2,
+	PR_GET_STKLOG = 3,
+	PR_MSG_SAVE = 4,
+	PR_MSG_READ = 5,
+	PR_MSG_REMOVE = 6,
+};
 
 /****************************************************************************
  * Public Type Definitions

--- a/os/kernel/task/task_prctl.c
+++ b/os/kernel/task/task_prctl.c
@@ -165,6 +165,11 @@ int prctl(int option, ...)
 		}
 	}
 	break;
+#else
+		sdbg("Option not enabled: %d\n", option);
+		err = ENOSYS;
+		goto errout;
+#endif
 #ifdef CONFIG_MESSAGING_IPC
 	case PR_MSG_SAVE:
 	{
@@ -209,13 +214,17 @@ int prctl(int option, ...)
 		ret = messaging_remove_list(port_name);
 		return ret;
 	}
-#endif
-#else
-	sdbg("Option not enabled: %d\n", option);
-	err = ENOSYS;
-	goto errout;
-#endif
-
+	break;
+#else /* CONFIG_MESSAGING_IPC */
+	case PR_MSG_SAVE:
+	case PR_MSG_READ:
+	case PR_MSG_REMOVE:
+	{
+		sdbg("Not supported.\n");
+		err = ENOSYS;
+		goto errout;
+	}
+#endif /* CONFIG_MESSAGING_IPC */
 	case PR_GET_STKLOG:
 	{
 #if defined(CONFIG_ENABLE_STACKMONITOR) && defined(CONFIG_DEBUG)


### PR DESCRIPTION
Previous prctl only supports PR_SET_NAME, and PR_GET_NAME. For supporting more types, changed to enum value.