### PR TITLE
loadable_apps : Add timer test in micom app

### DIFF
--- a/loadable_apps/Kconfig
+++ b/loadable_apps/Kconfig
@@ -44,6 +44,28 @@ config ENABLE_RECOVERY_AGING_TEST
 		Enable Recovery Aging test. Another Test cannot run at the same time.
 endif
 
+config EXAMPLES_MICOM_TIMER_TEST
+	bool "Micom Timer Test"
+	default n
+	---help---
+		Enable Timer test in micom app.
+		If this test is enabled, another test will not run.
+
+if EXAMPLES_MICOM_TIMER_TEST
+config EXAMPLES_MICOM_TIMER_REPEAT
+	string "Repetition Number of Micom Timer Test"
+	default 10
+	---help---
+		Repetition Number of Micom Timer Test
+
+config EXAMPLES_MICOM_TIMER_INTERVAL
+	string "Interval for Micom Timer Test"
+	default 100
+	---help---
+		Time Interval for testing Timer.
+		Interval is based on microsecond.
+endif
+
 endmenu
 
 config EXAMPLES_ELF_FULLYLINKED

--- a/loadable_apps/micomapp/Makefile
+++ b/loadable_apps/micomapp/Makefile
@@ -101,6 +101,10 @@ ifeq ($(CONFIG_EXAMPLES_MESSAGING_TEST),y)
 SRCS += messaging.c
 endif
 OBJS = $(SRCS:.c=$(OBJEXT))
+ifeq ($(CONFIG_EXAMPLES_TIMER)$(CONFIG_EXAMPLES_MICOM_TIMER_TEST),yy)
+SRCS += timer.c
+OBJS += $(TOPDIR)$(DELIM)../apps/examples/timer/timer_main.o
+endif
 
 prebuild:
 	$(call DELFILE, $(TOPDIR)$(DELIM)board$(DELIM)common$(DELIM)userspace$(DELIM)up_userspace.o)

--- a/loadable_apps/micomapp/micomapp.c
+++ b/loadable_apps/micomapp/micomapp.c
@@ -32,8 +32,21 @@
  ****************************************************************************/
 int main(int argc, char **argv)
 {
-#ifdef CONFIG_BINARY_MANAGER
 	int ret;
+#ifdef CONFIG_EXAMPLES_MICOM_TIMER_TEST
+	char *timer_args[TIMER_ARG_NUM];
+
+	ret = alloc_timer_args(timer_args);
+	if (ret != OK) {
+		printf("TIMER TEST FAIL : out of memory.\n");
+		return ERROR;
+	}
+
+	timer_main(TIMER_ARG_NUM, timer_args);
+
+	free_timer_args(timer_args);
+#else /* CONFIG_EXAMPLES_MICOM_TIMER_TEST */
+#ifdef CONFIG_BINARY_MANAGER
 	ret = binary_manager_notify_binary_started();
 	if (ret < 0) {
 		printf("MICOM notify 'START' state FAIL\n", ret);
@@ -43,6 +56,7 @@ int main(int argc, char **argv)
 #ifdef CONFIG_EXAMPLES_MESSAGING_TEST
 	messaging_test();
 #endif
+#endif /* CONFIG_EXAMPLES_MICOM_TIMER_TEST */
 
 	while (1) {
 		sleep(10);
@@ -50,4 +64,5 @@ int main(int argc, char **argv)
 	}
 
 	return 0;
+
 }

--- a/loadable_apps/micomapp/micomapp_internal.h
+++ b/loadable_apps/micomapp/micomapp_internal.h
@@ -22,4 +22,11 @@
 void messaging_test(void);
 #endif
 
+#ifdef CONFIG_EXAMPLES_MICOM_TIMER_TEST
+#define TIMER_ARG_NUM 5
+#define TIMER_ARG_MAX 10
+int alloc_timer_args(char **timer_args);
+void free_timer_args(char **timer_args);
+#endif
+
 #endif

--- a/loadable_apps/micomapp/timer.c
+++ b/loadable_apps/micomapp/timer.c
@@ -1,0 +1,81 @@
+/****************************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+#include <tinyara/config.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "micomapp_internal.h"
+
+int alloc_timer_args(char **timer_args)
+{
+	int arg_idx;
+	for (arg_idx = 0; arg_idx < TIMER_ARG_NUM; arg_idx++) {
+		timer_args[arg_idx] = NULL;
+	}
+
+	timer_args[0] = strndup("timer", strlen("timer") + 1);
+	if (timer_args[0] == NULL) {
+		goto timer_errout;
+	}
+
+	timer_args[1] = strndup("-n", strlen("-n") + 1);
+	if (timer_args[1] == NULL) {
+		goto timer_errout;
+	}
+
+	timer_args[2] = strndup(CONFIG_EXAMPLES_MICOM_TIMER_REPEAT, strlen(CONFIG_EXAMPLES_MICOM_TIMER_REPEAT) + 1);
+	if (timer_args[2] == NULL) {
+		goto timer_errout;
+	}
+
+	timer_args[3] = strndup("-t", strlen("-t") + 1);
+	if (timer_args[3] == NULL) {
+		goto timer_errout;
+	}
+
+	timer_args[4] = strndup(CONFIG_EXAMPLES_MICOM_TIMER_INTERVAL, strlen(CONFIG_EXAMPLES_MICOM_TIMER_INTERVAL) + 1);
+	if (timer_args[4] == NULL) {
+		goto timer_errout;
+	}
+
+	return OK;
+
+timer_errout:
+	for (arg_idx = 0; arg_idx < TIMER_ARG_NUM; arg_idx++) {
+		if (timer_args[arg_idx] != NULL) {
+			free(timer_args[arg_idx]);
+			timer_args[arg_idx] = NULL;
+		}
+	}
+	return ERROR;
+}
+
+void free_timer_args(char **timer_args)
+{
+	int arg_idx;
+	for (arg_idx = 0; arg_idx < TIMER_ARG_NUM; arg_idx++) {
+		if (timer_args[arg_idx] != NULL) {
+			free(timer_args[arg_idx]);
+		}
+	}
+}

--- a/loadable_apps/wifiapp/wifiapp.c
+++ b/loadable_apps/wifiapp/wifiapp.c
@@ -57,6 +57,7 @@ int main(int argc, char **argv)
 
 	printf("This is WIFI App\n");
 
+#ifndef CONFIG_EXAMPLES_MICOM_TIMER_TEST
 #ifdef CONFIG_BINARY_MANAGER
 	int ret;
 	ret = binary_manager_notify_binary_started();
@@ -98,6 +99,8 @@ int main(int argc, char **argv)
 #else
 	recovery_test();
 #endif
+
+#endif /* CONFIG_EXAMPLES_MICOM_TIMER_TEST */
 	while (1) {
 		sleep(10);
 		printf("[%d] WIFI ALIVE\n", getpid());


### PR DESCRIPTION
We can test timer in micom app.
CONFIG_EXAMPLES_MICOM_TIMER_REPEAT and CONFIG_EXAMPLES_MICOM_TIMER_INTERVAL should be set for testing.