### PR TITLE
arch/imxrt/flexpwm: Update the flexpwm driver based on channel

### DIFF
--- a/framework/src/iotbus/iotbus_pwm.c
+++ b/framework/src/iotbus/iotbus_pwm.c
@@ -170,23 +170,19 @@ int iotbus_pwm_set_duty_cycle_in_integer(iotbus_pwm_context_h pwm, uint16_t duty
 
 int iotbus_pwm_set_idle(iotbus_pwm_context_h pwm, iotbus_pwm_val_e val)
 {
-	int ret;
-	struct _iotbus_pwm_s *handle;
-
 	if (!pwm || !pwm->handle) {
 		return IOTBUS_ERROR_INVALID_PARAMETER;
 	}
 
-	handle = (struct _iotbus_pwm_s *)pwm->handle;
-	handle->idle = val;
-
-	ret = ioctl(handle->fd, PWMIOC_IDLE, (unsigned long)(handle->idle));
-	if (ret < 0) {
-		ibdbg("ioctl(PWMIOC_IDLE) failed: %d\n", errno);
-		return IOTBUS_ERROR_UNKNOWN;
+	if (val == IOTBUS_PWM_HIGH) {
+		iotbus_pwm_set_duty_cycle_in_integer(pwm, IOTBUS_PWM_MAX_RESOLUTION);
+		return IOTBUS_ERROR_NONE;
+	} else if (val == IOTBUS_PWM_LOW) {
+		iotbus_pwm_set_duty_cycle_in_integer(pwm, 0);
+		return IOTBUS_ERROR_NONE;
 	}
 
-	return IOTBUS_ERROR_NONE;
+	return IOTBUS_ERROR_INVALID_PARAMETER;
 }
 
 // period : us

--- a/os/arch/arm/src/imxrt/Kconfig
+++ b/os/arch/arm/src/imxrt/Kconfig
@@ -379,20 +379,353 @@ config IMXRT_PWM
 if IMXRT_PWM
 
 	config IMXRT_PWM1
-		bool "PWM IMXRT_PWM1"
-		default n
-
-	config IMXRT_PWM2
-		bool "PWM IMXRT_PWM2"
+		bool "PWM Controller 1, Channel 1 to Channel 8"
 		default n
 	
-	if ARCH_CHIP_FAMILY_IMXRT102x
+	if IMXRT_PWM1
+		choice
+			prompt "** PWM Submodule1 Clock"
+			default PWM1_SUB1_CLOCK1
+
+		config PWM1_SUB1_CLOCK1
+			bool "fclk/1"
+		config PWM1_SUB1_CLOCK2
+			bool "fclk/2"
+		config PWM1_SUB1_CLOCK3
+			bool "fclk/4"
+		config PWM1_SUB1_CLOCK4
+			bool "fclk/8"
+		config PWM1_SUB1_CLOCK5
+			bool "fclk/16"
+		config PWM1_SUB1_CLOCK6
+			bool "fclk/32"
+		config PWM1_SUB1_CLOCK7
+			bool "fclk/64"
+		config PWM1_SUB1_CLOCK8
+			bool "fclk/128"
+
+		endchoice
+
+		config PWM1_SUB1_CLOCK
+			int
+			default 0 if PWM1_SUB1_CLOCK1
+			default 1 if PWM1_SUB1_CLOCK2
+			default 2 if PWM1_SUB1_CLOCK3
+			default 3 if PWM1_SUB1_CLOCK4
+			default 4 if PWM1_SUB1_CLOCK5
+			default 5 if PWM1_SUB1_CLOCK6
+			default 6 if PWM1_SUB1_CLOCK7
+			default 7 if PWM1_SUB1_CLOCK8
+
+		config IMXRT_PWM_CHANNEL1
+			bool "PWM Controller 1, Channel 1"
+			default n
+		config IMXRT_PWM_CHANNEL2
+			bool "PWM Controller 1, Channel 2"
+			default n
+		
+		choice
+			prompt "** PWM Submodule2 Clock"
+			default PWM1_SUB2_CLOCK1
+
+		config PWM1_SUB2_CLOCK1
+			bool "fclk/1"
+		config PWM1_SUB2_CLOCK2
+			bool "fclk/2"
+		config PWM1_SUB2_CLOCK3
+			bool "fclk/4"
+		config PWM1_SUB2_CLOCK4
+			bool "fclk/8"
+		config PWM1_SUB2_CLOCK5
+			bool "fclk/16"
+		config PWM1_SUB2_CLOCK6
+			bool "fclk/32"
+		config PWM1_SUB2_CLOCK7
+			bool "fclk/64"
+		config PWM1_SUB2_CLOCK8
+			bool "fclk/128"
+
+		endchoice
+
+		config PWM1_SUB2_CLOCK
+			int
+			default 0 if PWM1_SUB2_CLOCK1
+			default 1 if PWM1_SUB2_CLOCK2
+			default 2 if PWM1_SUB2_CLOCK3
+			default 3 if PWM1_SUB2_CLOCK4
+			default 4 if PWM1_SUB2_CLOCK5
+			default 5 if PWM1_SUB2_CLOCK6
+			default 6 if PWM1_SUB2_CLOCK7
+			default 7 if PWM1_SUB2_CLOCK8
+
+		config IMXRT_PWM_CHANNEL3
+			bool "PWM Controller 1, Channel 3"
+			default n
+		config IMXRT_PWM_CHANNEL4
+			bool "PWM Controller 1, Channel 4"
+			default n
+		
+		choice
+			prompt "** PWM Submodule3 Clock"
+			default PWM1_SUB3_CLOCK1
+
+		config PWM1_SUB3_CLOCK1
+			bool "fclk/1"
+		config PWM1_SUB3_CLOCK2
+			bool "fclk/2"
+		config PWM1_SUB3_CLOCK3
+			bool "fclk/4"
+		config PWM1_SUB3_CLOCK4
+			bool "fclk/8"
+		config PWM1_SUB3_CLOCK5
+			bool "fclk/16"
+		config PWM1_SUB3_CLOCK6
+			bool "fclk/32"
+		config PWM1_SUB3_CLOCK7
+			bool "fclk/64"
+		config PWM1_SUB3_CLOCK8
+			bool "fclk/128"
+
+		endchoice
+
+		config PWM1_SUB3_CLOCK
+			int
+			default 0 if PWM1_SUB3_CLOCK1
+			default 1 if PWM1_SUB3_CLOCK2
+			default 2 if PWM1_SUB3_CLOCK3
+			default 3 if PWM1_SUB3_CLOCK4
+			default 4 if PWM1_SUB3_CLOCK5
+			default 5 if PWM1_SUB3_CLOCK6
+			default 6 if PWM1_SUB3_CLOCK7
+			default 7 if PWM1_SUB3_CLOCK8
+
+		config IMXRT_PWM_CHANNEL5
+			bool "PWM Controller 1, Channel 5"
+			default n
+		config IMXRT_PWM_CHANNEL6
+			bool "PWM Controller 1, Channel 6"
+			default n
+		
+		choice
+			prompt "** PWM Submodule4 Clock"
+			default PWM1_SUB4_CLOCK1
+
+		config PWM1_SUB4_CLOCK1
+			bool "fclk/1"
+		config PWM1_SUB4_CLOCK2
+			bool "fclk/2"
+		config PWM1_SUB4_CLOCK3
+			bool "fclk/4"
+		config PWM1_SUB4_CLOCK4
+			bool "fclk/8"
+		config PWM1_SUB4_CLOCK5
+			bool "fclk/16"
+		config PWM1_SUB4_CLOCK6
+			bool "fclk/32"
+		config PWM1_SUB4_CLOCK7
+			bool "fclk/64"
+		config PWM1_SUB4_CLOCK8
+			bool "fclk/128"
+
+		endchoice
+
+		config PWM1_SUB4_CLOCK
+			int
+			default 0 if PWM1_SUB4_CLOCK1
+			default 1 if PWM1_SUB4_CLOCK2
+			default 2 if PWM1_SUB4_CLOCK3
+			default 3 if PWM1_SUB4_CLOCK4
+			default 4 if PWM1_SUB4_CLOCK5
+			default 5 if PWM1_SUB4_CLOCK6
+			default 6 if PWM1_SUB4_CLOCK7
+			default 7 if PWM1_SUB4_CLOCK8
+
+		config IMXRT_PWM_CHANNEL7
+			bool "PWM Controller 1, Channel 7"
+			default n
+		config IMXRT_PWM_CHANNEL8
+			bool "PWM Controller 1, Channel 8"
+			default n
+	endif
+
+	config IMXRT_PWM2
+		bool "PWM Controller 2, Channel 9 to Channel 16"
+		default n
+
+	if IMXRT_PWM2
+
+		choice
+			prompt "** PWM Submodule1 Clock"
+			default PWM2_SUB1_CLOCK1
+
+		config PWM2_SUB1_CLOCK1
+			bool "fclk/1"
+		config PWM2_SUB1_CLOCK2
+			bool "fclk/2"
+		config PWM2_SUB1_CLOCK3
+			bool "fclk/4"
+		config PWM2_SUB1_CLOCK4
+			bool "fclk/8"
+		config PWM2_SUB1_CLOCK5
+			bool "fclk/16"
+		config PWM2_SUB1_CLOCK6
+			bool "fclk/32"
+		config PWM2_SUB1_CLOCK7
+			bool "fclk/64"
+		config PWM2_SUB1_CLOCK8
+			bool "fclk/128"
+
+		endchoice
+
+		config PWM2_SUB1_CLOCK
+			int
+			default 0 if PWM2_SUB1_CLOCK1
+			default 1 if PWM2_SUB1_CLOCK2
+			default 2 if PWM2_SUB1_CLOCK3
+			default 3 if PWM2_SUB1_CLOCK4
+			default 4 if PWM2_SUB1_CLOCK5
+			default 5 if PWM2_SUB1_CLOCK6
+			default 6 if PWM2_SUB1_CLOCK7
+			default 7 if PWM2_SUB1_CLOCK8
+
+		config IMXRT_PWM_CHANNEL9
+			bool "PWM Controller 2, Channel 1"
+			default n
+		config IMXRT_PWM_CHANNEL10
+			bool "PWM Controller 2, Channel 2"
+			default n
+
+		choice
+			prompt "** PWM Submodule2 Clock"
+			default PWM2_SUB2_CLOCK1
+
+		config PWM2_SUB2_CLOCK1
+			bool "fclk/1"
+		config PWM2_SUB2_CLOCK2
+			bool "fclk/2"
+		config PWM2_SUB2_CLOCK3
+			bool "fclk/4"
+		config PWM2_SUB2_CLOCK4
+			bool "fclk/8"
+		config PWM2_SUB2_CLOCK5
+			bool "fclk/16"
+		config PWM2_SUB2_CLOCK6
+			bool "fclk/32"
+		config PWM2_SUB2_CLOCK7
+			bool "fclk/64"
+		config PWM2_SUB2_CLOCK8
+			bool "fclk/128"
+
+		endchoice
+
+		config PWM2_SUB1_CLOCK
+			int
+			default 0 if PWM2_SUB2_CLOCK1
+			default 1 if PWM2_SUB2_CLOCK2
+			default 2 if PWM2_SUB2_CLOCK3
+			default 3 if PWM2_SUB2_CLOCK4
+			default 4 if PWM2_SUB2_CLOCK5
+			default 5 if PWM2_SUB2_CLOCK6
+			default 6 if PWM2_SUB2_CLOCK7
+			default 7 if PWM2_SUB2_CLOCK8
+
+		config IMXRT_PWM_CHANNEL11
+			bool "PWM Controller 2, Channel 3"
+			default n
+		config IMXRT_PWM_CHANNEL12
+			bool "PWM Controller 2, Channel 4"
+			default n
+
+		choice
+			prompt "** PWM Submodule3 Clock"
+			default PWM2_SUB3_CLOCK1
+
+		config PWM2_SUB3_CLOCK1
+			bool "fclk/1"
+		config PWM2_SUB3_CLOCK2
+			bool "fclk/2"
+		config PWM2_SUB3_CLOCK3
+			bool "fclk/4"
+		config PWM2_SUB3_CLOCK4
+			bool "fclk/8"
+		config PWM2_SUB3_CLOCK5
+			bool "fclk/16"
+		config PWM2_SUB3_CLOCK6
+			bool "fclk/32"
+		config PWM2_SUB3_CLOCK7
+			bool "fclk/64"
+		config PWM2_SUB3_CLOCK8
+			bool "fclk/128"
+
+		endchoice
+
+		config PWM2_SUB3_CLOCK
+			int
+			default 0 if PWM2_SUB3_CLOCK1
+			default 1 if PWM2_SUB3_CLOCK2
+			default 2 if PWM2_SUB3_CLOCK3
+			default 3 if PWM2_SUB3_CLOCK4
+			default 4 if PWM2_SUB3_CLOCK5
+			default 5 if PWM2_SUB3_CLOCK6
+			default 6 if PWM2_SUB3_CLOCK7
+			default 7 if PWM2_SUB3_CLOCK8
+
+		config IMXRT_PWM_CHANNEL13
+			bool "PWM Controller 2, Channel 5"
+			default n
+		config IMXRT_PWM_CHANNEL14
+			bool "PWM Controller 2, Channel 6"
+			default n
+
+		choice
+			prompt "** PWM Submodule4 Clock"
+			default PWM2_SUB4_CLOCK1
+
+		config PWM2_SUB4_CLOCK1
+			bool "fclk/1"
+		config PWM2_SUB4_CLOCK2
+			bool "fclk/2"
+		config PWM2_SUB4_CLOCK3
+			bool "fclk/4"
+		config PWM2_SUB4_CLOCK4
+			bool "fclk/8"
+		config PWM2_SUB4_CLOCK5
+			bool "fclk/16"
+		config PWM2_SUB4_CLOCK6
+			bool "fclk/32"
+		config PWM2_SUB4_CLOCK7
+			bool "fclk/64"
+		config PWM2_SUB4_CLOCK8
+			bool "fclk/128"
+
+		endchoice
+
+		config PWM2_SUB4_CLOCK
+			int
+			default 0 if PWM2_SUB4_CLOCK1
+			default 1 if PWM2_SUB4_CLOCK2
+			default 2 if PWM2_SUB4_CLOCK3
+			default 3 if PWM2_SUB4_CLOCK4
+			default 4 if PWM2_SUB4_CLOCK5
+			default 5 if PWM2_SUB4_CLOCK6
+			default 6 if PWM2_SUB4_CLOCK7
+			default 7 if PWM2_SUB4_CLOCK8
+
+		config IMXRT_PWM_CHANNEL15
+			bool "PWM Controller 2, Channel 7 (UART1 Pins)"
+			default n
+		config IMXRT_PWM_CHANNEL16
+			bool "PWM Controller 2, Channel 8 (UART1 Pins)"
+			default n
+	endif
+	
+	if ARCH_CHIP_FAMILY_IMXRT105x
 	config IMXRT_PWM3
-		bool "PWM IMXRT_PWM3"
+		bool "PWM Controller 3, Channel 17 to Channel 24"
 		default n
 
 	config IMXRT_PWM4
-		bool "PWM IMXRT_PWM4"
+		bool "PWM Controller 4, Channel 25 to Channel 32"
 		default n
 	endif
 endif # IMXRT_PWM

--- a/os/arch/arm/src/imxrt/imxrt_pwm.c
+++ b/os/arch/arm/src/imxrt/imxrt_pwm.c
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- * Copyright 2016 Samsung Electronics All Rights Reserved.
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -81,13 +81,72 @@
 /****************************************************************************
  * Private Types
  ****************************************************************************/
-struct imxrt_pwmtimer_s {
-	FAR const struct pwm_ops_s *ops;
+#ifndef CONFIG_PWM1_SUB1_CLOCK
+#define CONFIG_PWM1_SUB1_CLOCK	0
+#endif
+#ifndef CONFIG_PWM1_SUB2_CLOCK
+#define CONFIG_PWM1_SUB2_CLOCK	0
+#endif
+#ifndef CONFIG_PWM1_SUB3_CLOCK
+#define CONFIG_PWM1_SUB3_CLOCK	0
+#endif
+#ifndef CONFIG_PWM1_SUB4_CLOCK
+#define CONFIG_PWM1_SUB4_CLOCK	0
+#endif
+#ifndef CONFIG_PWM2_SUB1_CLOCK
+#define CONFIG_PWM2_SUB1_CLOCK	0
+#endif
+#ifndef CONFIG_PWM2_SUB2_CLOCK
+#define CONFIG_PWM2_SUB2_CLOCK	0
+#endif
+#ifndef CONFIG_PWM2_SUB3_CLOCK
+#define CONFIG_PWM2_SUB3_CLOCK	0
+#endif
+#ifndef CONFIG_PWM2_SUB4_CLOCK
+#define CONFIG_PWM2_SUB4_CLOCK	0
+#endif
 
-	PWM_Type *base;
-	uint8_t id;
+#if defined(CONFIG_ARCH_CHIP_FAMILY_IMXRT105x)
+#ifndef CONFIG_PWM3_SUB1_CLOCK
+#define CONFIG_PWM3_SUB1_CLOCK	0
+#endif
+#ifndef CONFIG_PWM3_SUB2_CLOCK
+#define CONFIG_PWM3_SUB2_CLOCK	0
+#endif
+#ifndef CONFIG_PWM3_SUB3_CLOCK
+#define CONFIG_PWM3_SUB3_CLOCK	0
+#endif
+#ifndef CONFIG_PWM3_SUB4_CLOCK
+#define CONFIG_PWM3_SUB4_CLOCK	0
+#endif
+#ifndef CONFIG_PWM4_SUB1_CLOCK
+#define CONFIG_PWM4_SUB1_CLOCK	0
+#endif
+#ifndef CONFIG_PWM4_SUB2_CLOCK
+#define CONFIG_PWM4_SUB2_CLOCK	0
+#endif
+#ifndef CONFIG_PWM4_SUB3_CLOCK
+#define CONFIG_PWM4_SUB3_CLOCK	0
+#endif
+#ifndef CONFIG_PWM4_SUB4_CLOCK
+#define CONFIG_PWM4_SUB4_CLOCK	0
+#endif
+#endif
+
+/* channel structure */
+struct imxrt_pwmch_s {
+	FAR const struct pwm_ops_s *ops; /* PWM operations */
+	uint8_t ch_id;					 /* Channel ID {1,...,32} */
+	uint8_t controller_id;			 /* Which controller the channel is in */
+	uint8_t submodule_id;			 /* Which submodule the channel is in */
+	uint8_t ch_name;				 /* See the pwm_channels_t definitions */
+	PWM_Type *base;					 /* The controller register base */
+	uint8_t submodule_mode;			 /* See the pwm_chnl_pair_operation_t definitions */
+	uint8_t ch_mode;				 /* See the pwm_mode_t definitions */
+	uint32_t pincfg;				 /* Output pin configuration */
+	uint32_t freq;					 /* Current output frequency */
+	uint32_t duty;					 /* Current output duty */
 };
-
 /*******************************************************************************
  * Prototypes
  ******************************************************************************/
@@ -174,7 +233,7 @@ status_t imxrt_pwm_init(PWM_Type *base, pwm_submodule_t subModule, const pwm_con
 		* source of the force output signal, operation in debug & wait modes and reload source select
 		*/
 	reg &= ~(PWM_CTRL2_CLK_SEL_MASK | PWM_CTRL2_FORCE_SEL_MASK | PWM_CTRL2_INIT_SEL_MASK | PWM_CTRL2_INDEP_MASK |
-				PWM_CTRL2_WAITEN_MASK | PWM_CTRL2_DBGEN_MASK | PWM_CTRL2_RELOAD_SEL_MASK);
+			 PWM_CTRL2_WAITEN_MASK | PWM_CTRL2_DBGEN_MASK | PWM_CTRL2_RELOAD_SEL_MASK);
 	reg |= (PWM_CTRL2_CLK_SEL(config->clockSource) | PWM_CTRL2_FORCE_SEL(config->forceTrigger) |
 			PWM_CTRL2_INIT_SEL(config->initializationControl) | PWM_CTRL2_DBGEN(config->enableDebugMode) |
 			PWM_CTRL2_WAITEN(config->enableWait) | PWM_CTRL2_RELOAD_SEL(config->reloadSelect));
@@ -488,10 +547,10 @@ status_t imxrt_pwm_setuppwm(PWM_Type *base,
  *                          100=active signal (100% duty cycle)
  */
 void imxrt_pwm_updatepwmdutycycle(PWM_Type *base,
-									pwm_submodule_t subModule,
-									pwm_channels_t pwmSignal,
-									pwm_mode_t currPwmMode,
-									uint8_t dutyCyclePercent)
+								  pwm_submodule_t subModule,
+								  pwm_channels_t pwmSignal,
+								  pwm_mode_t currPwmMode,
+								  uint8_t dutyCyclePercent)
 {
 	assert(dutyCyclePercent <= 100);
 	assert(pwmSignal < 2);
@@ -574,18 +633,18 @@ void imxrt_pwm_updatepwmdutycycle(PWM_Type *base,
  * param inputCaptureParams Parameters passed in to set up the input pin
  */
 void imxrt_pwm_setupinputcapture(PWM_Type *base,
-								pwm_submodule_t subModule,
-								pwm_channels_t pwmChannel,
-								const pwm_input_capture_param_t *inputCaptureParams)
+								 pwm_submodule_t subModule,
+								 pwm_channels_t pwmChannel,
+								 const pwm_input_capture_param_t *inputCaptureParams)
 {
 	uint32_t reg = 0;
 	switch (pwmChannel) {
 	case kPWM_PwmA:
 		/* Setup the capture paramters for PWM A pin */
 		reg = (PWM_CAPTCTRLA_INP_SELA(inputCaptureParams->captureInputSel) |
-				PWM_CAPTCTRLA_EDGA0(inputCaptureParams->edge0) | PWM_CAPTCTRLA_EDGA1(inputCaptureParams->edge1) |
-				PWM_CAPTCTRLA_ONESHOTA(inputCaptureParams->enableOneShotCapture) |
-				PWM_CAPTCTRLA_CFAWM(inputCaptureParams->fifoWatermark));
+			   PWM_CAPTCTRLA_EDGA0(inputCaptureParams->edge0) | PWM_CAPTCTRLA_EDGA1(inputCaptureParams->edge1) |
+			   PWM_CAPTCTRLA_ONESHOTA(inputCaptureParams->enableOneShotCapture) |
+			   PWM_CAPTCTRLA_CFAWM(inputCaptureParams->fifoWatermark));
 		/* Enable the edge counter if using the output edge counter */
 		if (inputCaptureParams->captureInputSel) {
 			reg |= PWM_CAPTCTRLA_EDGCNTA_EN_MASK;
@@ -604,9 +663,9 @@ void imxrt_pwm_setupinputcapture(PWM_Type *base,
 	case kPWM_PwmB:
 		/* Setup the capture paramters for PWM B pin */
 		reg = (PWM_CAPTCTRLB_INP_SELB(inputCaptureParams->captureInputSel) |
-				PWM_CAPTCTRLB_EDGB0(inputCaptureParams->edge0) | PWM_CAPTCTRLB_EDGB1(inputCaptureParams->edge1) |
-				PWM_CAPTCTRLB_ONESHOTB(inputCaptureParams->enableOneShotCapture) |
-				PWM_CAPTCTRLB_CFBWM(inputCaptureParams->fifoWatermark));
+			   PWM_CAPTCTRLB_EDGB0(inputCaptureParams->edge0) | PWM_CAPTCTRLB_EDGB1(inputCaptureParams->edge1) |
+			   PWM_CAPTCTRLB_ONESHOTB(inputCaptureParams->enableOneShotCapture) |
+			   PWM_CAPTCTRLB_CFBWM(inputCaptureParams->fifoWatermark));
 		/* Enable the edge counter if using the output edge counter */
 		if (inputCaptureParams->captureInputSel) {
 			reg |= PWM_CAPTCTRLB_EDGCNTB_EN_MASK;
@@ -623,9 +682,9 @@ void imxrt_pwm_setupinputcapture(PWM_Type *base,
 		break;
 	case kPWM_PwmX:
 		reg = (PWM_CAPTCTRLX_INP_SELX(inputCaptureParams->captureInputSel) |
-				PWM_CAPTCTRLX_EDGX0(inputCaptureParams->edge0) | PWM_CAPTCTRLX_EDGX1(inputCaptureParams->edge1) |
-				PWM_CAPTCTRLX_ONESHOTX(inputCaptureParams->enableOneShotCapture) |
-				PWM_CAPTCTRLX_CFXWM(inputCaptureParams->fifoWatermark));
+			   PWM_CAPTCTRLX_EDGX0(inputCaptureParams->edge0) | PWM_CAPTCTRLX_EDGX1(inputCaptureParams->edge1) |
+			   PWM_CAPTCTRLX_ONESHOTX(inputCaptureParams->enableOneShotCapture) |
+			   PWM_CAPTCTRLX_CFXWM(inputCaptureParams->fifoWatermark));
 		/* Enable the edge counter if using the output edge counter */
 		if (inputCaptureParams->captureInputSel) {
 			reg |= PWM_CAPTCTRLX_EDGCNTX_EN_MASK;
@@ -852,9 +911,15 @@ void imxrt_pwm_clearstatusflags(PWM_Type *base, pwm_submodule_t subModule, uint3
  ****************************************************************************/
 static int imxrt_pwm_setup(FAR struct pwm_lowerhalf_s *dev)
 {
-	FAR struct imxrt_pwmtimer_s *priv = (FAR struct imxrt_pwmtimer_s *)dev;
+	FAR struct imxrt_pwmch_s *priv = (FAR struct imxrt_pwmch_s *)dev;
+	PWM_Type *base;
+	pwm_submodule_t submodule;
 
-	imxrt_pwm_setpwmldok(priv->base, kPWM_Control_Module_0 | kPWM_Control_Module_1 | kPWM_Control_Module_2, true);
+	base = priv->base;
+	submodule = priv->submodule_id;
+
+	base->SM[submodule].DISMAP[0] = 0;
+	base->SM[submodule].DISMAP[1] = 0;
 
 	return OK;
 }
@@ -874,11 +939,149 @@ static int imxrt_pwm_setup(FAR struct pwm_lowerhalf_s *dev)
  *
  ****************************************************************************/
 static int imxrt_pwm_start(FAR struct pwm_lowerhalf_s *dev,
-						 FAR const struct pwm_info_s *info)
+						   FAR const struct pwm_info_s *info)
 {
-	FAR struct imxrt_pwmtimer_s *priv = (FAR struct imxrt_pwmtimer_s *)dev;
+	FAR struct imxrt_pwmch_s *priv = (FAR struct imxrt_pwmch_s *)dev;
+	PWM_Type *base;
+	pwm_submodule_t submodule;
+	pwm_mode_t mode;
+	uint8_t pwm_ch;
+	uint32_t pwmClock;
+	uint32_t srcClock_Hz;
+	uint16_t pulseCnt = 0;
+	uint16_t pwmHighPulse = 0;
+	uint16_t dutycycle = 32768;
+	int16_t modulo = 0;
+	uint8_t polarityShift = 0;
+	uint8_t outputEnableShift = 0;
+	pwm_level_select_t level = kPWM_HighTrue;
+	uint16_t deadtimeValue = 0;
+	uint32_t pwmFreq_Hz = 10000;
 
-	imxrt_pwm_starttimer(priv->base, kPWM_Control_Module_0 | kPWM_Control_Module_1 | kPWM_Control_Module_2);
+	srcClock_Hz = imxrt_clock_getfreq(kCLOCK_IpgClk);
+
+	base = priv->base;
+	submodule = priv->submodule_id;
+	pwm_ch = priv->ch_id;
+	mode = priv->ch_mode;
+
+	dutycycle = info->duty;
+	if (!info->frequency)
+		return -1;
+	pwmFreq_Hz = info->frequency;
+
+	/* Divide the clock by the prescale value */
+	pwmClock = (srcClock_Hz / (1U << ((base->SM[submodule].CTRL & PWM_CTRL_PRSC_MASK) >> PWM_CTRL_PRSC_SHIFT)));
+	pulseCnt = (pwmClock / pwmFreq_Hz);
+	/* Setup each PWM channel */
+	/* Calculate pulse width */
+	pwmHighPulse = ((uint32_t)pulseCnt * (uint32_t)dutycycle) / 65535;
+	/* Setup the different match registers to generate the PWM signal */
+	switch (mode) {
+	case kPWM_SignedCenterAligned:
+		/* Setup the PWM period for a signed center aligned signal */
+		modulo = pulseCnt >> 1;
+		/* Indicates the start of the PWM period */
+		base->SM[submodule].INIT = (-modulo);
+		/* Indicates the center value */
+		base->SM[submodule].VAL0 = 0;
+		/* Indicates the end of the PWM period */
+		base->SM[submodule].VAL1 = modulo;
+
+		/* Setup the PWM dutycycle */
+		if (pwm_ch % 2) {
+			base->SM[submodule].VAL2 = (-(pwmHighPulse / 2));
+			base->SM[submodule].VAL3 = (pwmHighPulse / 2);
+		} else {
+			base->SM[submodule].VAL4 = (-(pwmHighPulse / 2));
+			base->SM[submodule].VAL5 = (pwmHighPulse / 2);
+		}
+		break;
+	case kPWM_CenterAligned:
+		/* Setup the PWM period for an unsigned center aligned signal */
+		/* Indicates the start of the PWM period */
+		base->SM[submodule].INIT = 0;
+		/* Indicates the center value */
+		base->SM[submodule].VAL0 = (pulseCnt / 2);
+		/* Indicates the end of the PWM period */
+		base->SM[submodule].VAL1 = pulseCnt;
+
+		/* Setup the PWM dutycycle */
+		if (pwm_ch % 2) {
+			base->SM[submodule].VAL2 = ((pulseCnt - pwmHighPulse) / 2);
+			base->SM[submodule].VAL3 = ((pulseCnt + pwmHighPulse) / 2);
+		} else {
+			base->SM[submodule].VAL4 = ((pulseCnt - pwmHighPulse) / 2);
+			base->SM[submodule].VAL5 = ((pulseCnt + pwmHighPulse) / 2);
+		}
+		break;
+	case kPWM_SignedEdgeAligned:
+		/* Setup the PWM period for a signed edge aligned signal */
+		modulo = pulseCnt >> 1;
+		/* Indicates the start of the PWM period */
+		base->SM[submodule].INIT = (-modulo);
+		/* Indicates the center value */
+		base->SM[submodule].VAL0 = 0;
+		/* Indicates the end of the PWM period */
+		base->SM[submodule].VAL1 = modulo;
+
+		/* Setup the PWM dutycycle */
+		if (pwm_ch % 2) {
+			base->SM[submodule].VAL2 = (-modulo);
+			base->SM[submodule].VAL3 = (-modulo + pwmHighPulse);
+		} else {
+			base->SM[submodule].VAL4 = (-modulo);
+			base->SM[submodule].VAL5 = (-modulo + pwmHighPulse);
+		}
+		break;
+	case kPWM_EdgeAligned:
+		/* Setup the PWM period for a unsigned edge aligned signal */
+		/* Indicates the start of the PWM period */
+		base->SM[submodule].INIT = 0;
+		/* Indicates the center value */
+		base->SM[submodule].VAL0 = (pulseCnt / 2);
+		/* Indicates the end of the PWM period */
+		base->SM[submodule].VAL1 = pulseCnt;
+
+		/* Setup the PWM dutycycle */
+		if (pwm_ch % 2) {
+			base->SM[submodule].VAL2 = 0;
+			base->SM[submodule].VAL3 = pwmHighPulse;
+		} else {
+			base->SM[submodule].VAL4 = 0;
+			base->SM[submodule].VAL5 = pwmHighPulse;
+		}
+		break;
+	default:
+		break;
+	}
+	/* Setup register shift values based on the channel being configured.
+	* Also setup the deadtime value
+	*/
+	if (pwm_ch % 2) {
+		polarityShift = PWM_OCTRL_POLA_SHIFT;
+		outputEnableShift = PWM_OUTEN_PWMA_EN_SHIFT;
+		base->SM[submodule].DTCNT0 = PWM_DTCNT0_DTCNT0(deadtimeValue);
+	} else {
+		polarityShift = PWM_OCTRL_POLB_SHIFT;
+		outputEnableShift = PWM_OUTEN_PWMB_EN_SHIFT;
+		base->SM[submodule].DTCNT1 = PWM_DTCNT1_DTCNT1(deadtimeValue);
+	}
+
+	/* Setup signal active level */
+	if (level == kPWM_HighTrue) {
+		base->SM[submodule].OCTRL &= ~(1U << polarityShift);
+	} else {
+		base->SM[submodule].OCTRL |= (1U << polarityShift);
+	}
+	/* Enable PWM output */
+	base->OUTEN |= (1U << (outputEnableShift + submodule));
+
+	/* Set the load okay bit for all submodules to load registers from their buffer */
+	imxrt_pwm_setpwmldok(base, 1U << submodule, true);
+
+	/* Start the PWM generation from Submodules  */
+	imxrt_pwm_starttimer(base, 1U << submodule);
 
 	return OK;
 }
@@ -903,13 +1106,24 @@ static int imxrt_pwm_start(FAR struct pwm_lowerhalf_s *dev,
  ****************************************************************************/
 static int imxrt_pwm_stop(FAR struct pwm_lowerhalf_s *dev)
 {
-	FAR struct imxrt_pwmtimer_s *priv = (FAR struct imxrt_pwmtimer_s *)dev;
+	FAR struct imxrt_pwmch_s *priv = (FAR struct imxrt_pwmch_s *)dev;
 
-	imxrt_pwm_stoptimer(priv->base, kPWM_Control_Module_0 | kPWM_Control_Module_1 | kPWM_Control_Module_2);
+	PWM_Type *base;
+	pwm_submodule_t submodule;
+	uint8_t pwm_ch;
+
+	base = priv->base;
+	submodule = priv->submodule_id;
+	pwm_ch = priv->ch_id;
+
+	if (pwm_ch % 2) {
+		base->OUTEN &= ~(1U << (PWM_OUTEN_PWMA_EN_SHIFT + submodule));
+	} else {
+		base->OUTEN &= ~(1U << (PWM_OUTEN_PWMB_EN_SHIFT + submodule));
+	}
 
 	return OK;
 }
-
 /****************************************************************************
  * Name: imxrt_pwm_shutdown
  *
@@ -927,14 +1141,18 @@ static int imxrt_pwm_stop(FAR struct pwm_lowerhalf_s *dev)
  ****************************************************************************/
 static int imxrt_pwm_shutdown(FAR struct pwm_lowerhalf_s *dev)
 {
-	FAR struct imxrt_pwmtimer_s *priv = (FAR struct imxrt_pwmtimer_s *)dev;
+	FAR struct imxrt_pwmch_s *priv = (FAR struct imxrt_pwmch_s *)dev;
 
-	/* Make sure that the output has been stopped */
-	imxrt_pwm_stop(dev);
+	PWM_Type *base;
+	pwm_submodule_t submodule;
+	uint8_t pwm_ch;
 
-	/* Then put the GPIO pins back to the default state */
-	imxrt_pwm_deinit(priv->base, kPWM_Control_Module_0 | kPWM_Control_Module_1 | kPWM_Control_Module_2);
+	base = priv->base;
+	submodule = priv->submodule_id;
+	pwm_ch = priv->ch_id;
 
+	/* Stop the submodule */
+	base->MCTRL &= ~(1U << (PWM_MCTRL_RUN_SHIFT + submodule));
 	return OK;
 }
 
@@ -954,9 +1172,9 @@ static int imxrt_pwm_shutdown(FAR struct pwm_lowerhalf_s *dev)
  *
  ****************************************************************************/
 static int imxrt_pwm_ioctl(FAR struct pwm_lowerhalf_s *dev, int cmd,
-						 unsigned long arg)
+						   unsigned long arg)
 {
-	return -ENOTTY;
+	return OK;
 }
 
 /****************************************************************************
@@ -977,8 +1195,6 @@ static int imxrt_pwm_ioctl(FAR struct pwm_lowerhalf_s *dev, int cmd,
  ****************************************************************************/
 static void imxrt_pwm_reset(FAR struct pwm_lowerhalf_s *dev, int timer)
 {
-	FAR struct imxrt_pwmtimer_s *priv = (FAR struct imxrt_pwmtimer_s *)dev;
-
 	imxrt_pwm_stop(dev);
 }
 
@@ -986,43 +1202,439 @@ static void imxrt_pwm_reset(FAR struct pwm_lowerhalf_s *dev, int timer)
  * Private Data
  ****************************************************************************/
 static const struct pwm_ops_s g_pwm_ops = {
-	.setup		= imxrt_pwm_setup,
-	.shutdown	= imxrt_pwm_shutdown,
-	.start		= imxrt_pwm_start,
-	.stop		= imxrt_pwm_stop,
-	.ioctl		= imxrt_pwm_ioctl,
+	.setup = imxrt_pwm_setup,
+	.shutdown = imxrt_pwm_shutdown,
+	.start = imxrt_pwm_start,
+	.stop = imxrt_pwm_stop,
+	.ioctl = imxrt_pwm_ioctl,
 };
 
 #ifdef CONFIG_IMXRT_PWM1
-static struct imxrt_pwmtimer_s g_pwm0_1 = {
-	.ops	= &g_pwm_ops,
-	.id		= 1,
-	.base	= (PWM_Type *)PWM1_BASE,
+static struct imxrt_pwmch_s g_ch1dev = {
+	.ops = &g_pwm_ops,
+	.ch_id = 1,
+	.controller_id = 0,
+	.submodule_id = kPWM_Module_0,
+	.ch_name = kPWM_PwmA,
+	.base = (PWM_Type *)PWM1_BASE,
+	.submodule_mode = kPWM_Independent,
+	.ch_mode = kPWM_SignedCenterAligned,
+	.pincfg = 0,
+	.freq = 0,
+	.duty = 0,
+};
+static struct imxrt_pwmch_s g_ch2dev = {
+	.ops = &g_pwm_ops,
+	.ch_id = 2,
+	.controller_id = 0,
+	.submodule_id = kPWM_Module_0,
+	.ch_name = kPWM_PwmB,
+	.base = (PWM_Type *)PWM1_BASE,
+	.submodule_mode = kPWM_Independent,
+	.ch_mode = kPWM_SignedCenterAligned,
+	.pincfg = 0,
+	.freq = 0,
+	.duty = 0,
+};
+static struct imxrt_pwmch_s g_ch3dev = {
+	.ops = &g_pwm_ops,
+	.ch_id = 3,
+	.controller_id = 0,
+	.submodule_id = kPWM_Module_1,
+	.ch_name = kPWM_PwmA,
+	.base = (PWM_Type *)PWM1_BASE,
+	.submodule_mode = kPWM_Independent,
+	.ch_mode = kPWM_SignedCenterAligned,
+	.pincfg = 0,
+	.freq = 0,
+	.duty = 0,
+};
+static struct imxrt_pwmch_s g_ch4dev = {
+	.ops = &g_pwm_ops,
+	.ch_id = 4,
+	.controller_id = 0,
+	.submodule_id = kPWM_Module_1,
+	.ch_name = kPWM_PwmB,
+	.base = (PWM_Type *)PWM1_BASE,
+	.submodule_mode = kPWM_Independent,
+	.ch_mode = kPWM_SignedCenterAligned,
+	.pincfg = 0,
+	.freq = 0,
+	.duty = 0,
+};
+static struct imxrt_pwmch_s g_ch5dev = {
+	.ops = &g_pwm_ops,
+	.ch_id = 5,
+	.controller_id = 0,
+	.submodule_id = kPWM_Module_2,
+	.ch_name = kPWM_PwmA,
+	.base = (PWM_Type *)PWM1_BASE,
+	.submodule_mode = kPWM_Independent,
+	.ch_mode = kPWM_SignedCenterAligned,
+	.pincfg = 0,
+	.freq = 0,
+	.duty = 0,
+};
+static struct imxrt_pwmch_s g_ch6dev = {
+	.ops = &g_pwm_ops,
+	.ch_id = 6,
+	.controller_id = 0,
+	.submodule_id = kPWM_Module_2,
+	.ch_name = kPWM_PwmB,
+	.base = (PWM_Type *)PWM1_BASE,
+	.submodule_mode = kPWM_Independent,
+	.ch_mode = kPWM_SignedCenterAligned,
+	.pincfg = 0,
+	.freq = 0,
+	.duty = 0,
+};
+static struct imxrt_pwmch_s g_ch7dev = {
+	.ops = &g_pwm_ops,
+	.ch_id = 7,
+	.controller_id = 0,
+	.submodule_id = kPWM_Module_3,
+	.ch_name = kPWM_PwmA,
+	.base = (PWM_Type *)PWM1_BASE,
+	.submodule_mode = kPWM_Independent,
+	.ch_mode = kPWM_SignedCenterAligned,
+	.pincfg = 0,
+	.freq = 0,
+	.duty = 0,
+};
+static struct imxrt_pwmch_s g_ch8dev = {
+	.ops = &g_pwm_ops,
+	.ch_id = 8,
+	.controller_id = 0,
+	.submodule_id = kPWM_Module_3,
+	.ch_name = kPWM_PwmB,
+	.base = (PWM_Type *)PWM1_BASE,
+	.submodule_mode = kPWM_Independent,
+	.ch_mode = kPWM_SignedCenterAligned,
+	.pincfg = 0,
+	.freq = 0,
+	.duty = 0,
 };
 #endif
 
 #ifdef CONFIG_IMXRT_PWM2
-static struct imxrt_pwmtimer_s g_pwm0_2 = {
-	.ops	= &g_pwm_ops,
-	.id		= 2,
-	.base	= (PWM_Type *)PWM2_BASE,
+static struct imxrt_pwmch_s g_ch9dev = {
+	.ops = &g_pwm_ops,
+	.ch_id = 9,
+	.controller_id = 1,
+	.submodule_id = kPWM_Module_0,
+	.ch_name = kPWM_PwmA,
+	.base = (PWM_Type *)PWM2_BASE,
+	.submodule_mode = kPWM_Independent,
+	.ch_mode = kPWM_SignedCenterAligned,
+	.pincfg = 0,
+	.freq = 0,
+	.duty = 0,
+};
+static struct imxrt_pwmch_s g_ch10dev = {
+	.ops = &g_pwm_ops,
+	.ch_id = 10,
+	.controller_id = 1,
+	.submodule_id = kPWM_Module_0,
+	.ch_name = kPWM_PwmB,
+	.base = (PWM_Type *)PWM2_BASE,
+	.submodule_mode = kPWM_Independent,
+	.ch_mode = kPWM_SignedCenterAligned,
+	.pincfg = 0,
+	.freq = 0,
+	.duty = 0,
+};
+static struct imxrt_pwmch_s g_ch11dev = {
+	.ops = &g_pwm_ops,
+	.ch_id = 11,
+	.controller_id = 1,
+	.submodule_id = kPWM_Module_1,
+	.ch_name = kPWM_PwmA,
+	.base = (PWM_Type *)PWM2_BASE,
+	.submodule_mode = kPWM_Independent,
+	.ch_mode = kPWM_SignedCenterAligned,
+	.pincfg = 0,
+	.freq = 0,
+	.duty = 0,
+};
+static struct imxrt_pwmch_s g_ch12dev = {
+	.ops = &g_pwm_ops,
+	.ch_id = 12,
+	.controller_id = 1,
+	.submodule_id = kPWM_Module_1,
+	.ch_name = kPWM_PwmB,
+	.base = (PWM_Type *)PWM2_BASE,
+	.submodule_mode = kPWM_Independent,
+	.ch_mode = kPWM_SignedCenterAligned,
+	.pincfg = 0,
+	.freq = 0,
+	.duty = 0,
+};
+static struct imxrt_pwmch_s g_ch13dev = {
+	.ops = &g_pwm_ops,
+	.ch_id = 13,
+	.controller_id = 1,
+	.submodule_id = kPWM_Module_2,
+	.ch_name = kPWM_PwmA,
+	.base = (PWM_Type *)PWM2_BASE,
+	.submodule_mode = kPWM_Independent,
+	.ch_mode = kPWM_SignedCenterAligned,
+	.pincfg = 0,
+	.freq = 0,
+	.duty = 0,
+};
+static struct imxrt_pwmch_s g_ch14dev = {
+	.ops = &g_pwm_ops,
+	.ch_id = 14,
+	.controller_id = 1,
+	.submodule_id = kPWM_Module_2,
+	.ch_name = kPWM_PwmB,
+	.base = (PWM_Type *)PWM2_BASE,
+	.submodule_mode = kPWM_Independent,
+	.ch_mode = kPWM_SignedCenterAligned,
+	.pincfg = 0,
+	.freq = 0,
+	.duty = 0,
+};
+static struct imxrt_pwmch_s g_ch15dev = {
+	.ops = &g_pwm_ops,
+	.ch_id = 15,
+	.controller_id = 1,
+	.submodule_id = kPWM_Module_3,
+	.ch_name = kPWM_PwmA,
+	.base = (PWM_Type *)PWM2_BASE,
+	.submodule_mode = kPWM_Independent,
+	.ch_mode = kPWM_SignedCenterAligned,
+	.pincfg = 0,
+	.freq = 0,
+	.duty = 0,
+};
+static struct imxrt_pwmch_s g_ch16dev = {
+	.ops = &g_pwm_ops,
+	.ch_id = 16,
+	.controller_id = 1,
+	.submodule_id = kPWM_Module_3,
+	.ch_name = kPWM_PwmB,
+	.base = (PWM_Type *)PWM2_BASE,
+	.submodule_mode = kPWM_Independent,
+	.ch_mode = kPWM_SignedCenterAligned,
+	.pincfg = 0,
+	.freq = 0,
+	.duty = 0,
 };
 #endif
 
 #if defined(CONFIG_ARCH_CHIP_FAMILY_IMXRT105x)
 #ifdef CONFIG_IMXRT_PWM3
-static struct imxrt_pwmtimer_s g_pwm0_3 = {
-	.ops	= &g_pwm_ops,
-	.id		= 3,
-	.base	= (PWM_Type *)PWM3_BASE,
+static struct imxrt_pwmch_s g_ch17dev = {
+	.ops = &g_pwm_ops,
+	.ch_id = 17,
+	.controller_id = 2,
+	.submodule_id = kPWM_Module_0,
+	.ch_name = kPWM_PwmA,
+	.base = (PWM_Type *)PWM3_BASE,
+	.submodule_mode = kPWM_Independent,
+	.ch_mode = kPWM_SignedCenterAligned,
+	.pincfg = 0,
+	.freq = 0,
+	.duty = 0,
+};
+static struct imxrt_pwmch_s g_ch18dev = {
+	.ops = &g_pwm_ops,
+	.ch_id = 18,
+	.controller_id = 2,
+	.submodule_id = kPWM_Module_0,
+	.ch_name = kPWM_PwmB,
+	.base = (PWM_Type *)PWM3_BASE,
+	.submodule_mode = kPWM_Independent,
+	.ch_mode = kPWM_SignedCenterAligned,
+	.pincfg = 0,
+	.freq = 0,
+	.duty = 0,
+};
+static struct imxrt_pwmch_s g_ch19dev = {
+	.ops = &g_pwm_ops,
+	.ch_id = 19,
+	.controller_id = 2,
+	.submodule_id = kPWM_Module_1,
+	.ch_name = kPWM_PwmA,
+	.base = (PWM_Type *)PWM3_BASE,
+	.submodule_mode = kPWM_Independent,
+	.ch_mode = kPWM_SignedCenterAligned,
+	.pincfg = 0,
+	.freq = 0,
+	.duty = 0,
+};
+static struct imxrt_pwmch_s g_ch20dev = {
+	.ops = &g_pwm_ops,
+	.ch_id = 20,
+	.controller_id = 2,
+	.submodule_id = kPWM_Module_1,
+	.ch_name = kPWM_PwmB,
+	.base = (PWM_Type *)PWM3_BASE,
+	.submodule_mode = kPWM_Independent,
+	.ch_mode = kPWM_SignedCenterAligned,
+	.pincfg = 0,
+	.freq = 0,
+	.duty = 0,
+};
+static struct imxrt_pwmch_s g_ch21dev = {
+	.ops = &g_pwm_ops,
+	.ch_id = 21,
+	.controller_id = 2,
+	.submodule_id = kPWM_Module_2,
+	.ch_name = kPWM_PwmA,
+	.base = (PWM_Type *)PWM3_BASE,
+	.submodule_mode = kPWM_Independent,
+	.ch_mode = kPWM_SignedCenterAligned,
+	.pincfg = 0,
+	.freq = 0,
+	.duty = 0,
+};
+static struct imxrt_pwmch_s g_ch22dev = {
+	.ops = &g_pwm_ops,
+	.ch_id = 22,
+	.controller_id = 2,
+	.submodule_id = kPWM_Module_2,
+	.ch_name = kPWM_PwmB,
+	.base = (PWM_Type *)PWM3_BASE,
+	.submodule_mode = kPWM_Independent,
+	.ch_mode = kPWM_SignedCenterAligned,
+	.pincfg = 0,
+	.freq = 0,
+	.duty = 0,
+};
+static struct imxrt_pwmch_s g_ch23dev = {
+	.ops = &g_pwm_ops,
+	.ch_id = 23,
+	.controller_id = 2,
+	.submodule_id = kPWM_Module_3,
+	.ch_name = kPWM_PwmA,
+	.base = (PWM_Type *)PWM3_BASE,
+	.submodule_mode = kPWM_Independent,
+	.ch_mode = kPWM_SignedCenterAligned,
+	.pincfg = 0,
+	.freq = 0,
+	.duty = 0,
+};
+static struct imxrt_pwmch_s g_ch24dev = {
+	.ops = &g_pwm_ops,
+	.ch_id = 24,
+	.controller_id = 2,
+	.submodule_id = kPWM_Module_3,
+	.ch_name = kPWM_PwmB,
+	.base = (PWM_Type *)PWM3_BASE,
+	.submodule_mode = kPWM_Independent,
+	.ch_mode = kPWM_SignedCenterAligned,
+	.pincfg = 0,
+	.freq = 0,
+	.duty = 0,
 };
 #endif
 
 #ifdef CONFIG_IMXRT_PWM4
-static struct imxrt_pwmtimer_s g_pwm0_4 = {
-	.ops	= &g_pwm_ops,
-	.id		= 4,
-	.base	= (PWM_Type *)PWM4_BASE,
+static struct imxrt_pwmch_s g_ch25dev = {
+	.ops = &g_pwm_ops,
+	.ch_id = 25,
+	.controller_id = 3,
+	.submodule_id = kPWM_Module_0,
+	.ch_name = kPWM_PwmA,
+	.base = (PWM_Type *)PWM4_BASE,
+	.submodule_mode = kPWM_Independent,
+	.ch_mode = kPWM_SignedCenterAligned,
+	.pincfg = 0,
+	.freq = 0,
+	.duty = 0,
+};
+static struct imxrt_pwmch_s g_ch26dev = {
+	.ops = &g_pwm_ops,
+	.ch_id = 26,
+	.controller_id = 3,
+	.submodule_id = kPWM_Module_0,
+	.ch_name = kPWM_PwmB,
+	.base = (PWM_Type *)PWM4_BASE,
+	.submodule_mode = kPWM_Independent,
+	.ch_mode = kPWM_SignedCenterAligned,
+	.pincfg = 0,
+	.freq = 0,
+	.duty = 0,
+};
+static struct imxrt_pwmch_s g_ch27dev = {
+	.ops = &g_pwm_ops,
+	.ch_id = 27,
+	.controller_id = 3,
+	.submodule_id = kPWM_Module_1,
+	.ch_name = kPWM_PwmA,
+	.base = (PWM_Type *)PWM4_BASE,
+	.submodule_mode = kPWM_Independent,
+	.ch_mode = kPWM_SignedCenterAligned,
+	.pincfg = 0,
+	.freq = 0,
+	.duty = 0,
+};
+static struct imxrt_pwmch_s g_ch28dev = {
+	.ops = &g_pwm_ops,
+	.ch_id = 28,
+	.controller_id = 3,
+	.submodule_id = kPWM_Module_1,
+	.ch_name = kPWM_PwmB,
+	.base = (PWM_Type *)PWM4_BASE,
+	.submodule_mode = kPWM_Independent,
+	.ch_mode = kPWM_SignedCenterAligned,
+	.pincfg = 0,
+	.freq = 0,
+	.duty = 0,
+};
+static struct imxrt_pwmch_s g_ch29dev = {
+	.ops = &g_pwm_ops,
+	.ch_id = 29,
+	.controller_id = 3,
+	.submodule_id = kPWM_Module_2,
+	.ch_name = kPWM_PwmA,
+	.base = (PWM_Type *)PWM4_BASE,
+	.submodule_mode = kPWM_Independent,
+	.ch_mode = kPWM_SignedCenterAligned,
+	.pincfg = 0,
+	.freq = 0,
+	.duty = 0,
+};
+static struct imxrt_pwmch_s g_ch30dev = {
+	.ops = &g_pwm_ops,
+	.ch_id = 30,
+	.controller_id = 3,
+	.submodule_id = kPWM_Module_2,
+	.ch_name = kPWM_PwmB,
+	.base = (PWM_Type *)PWM4_BASE,
+	.submodule_mode = kPWM_Independent,
+	.ch_mode = kPWM_SignedCenterAligned,
+	.pincfg = 0,
+	.freq = 0,
+	.duty = 0,
+};
+static struct imxrt_pwmch_s g_ch31dev = {
+	.ops = &g_pwm_ops,
+	.ch_id = 31,
+	.controller_id = 3,
+	.submodule_id = kPWM_Module_3,
+	.ch_name = kPWM_PwmA,
+	.base = (PWM_Type *)PWM4_BASE,
+	.submodule_mode = kPWM_Independent,
+	.ch_mode = kPWM_SignedCenterAligned,
+	.pincfg = 0,
+	.freq = 0,
+	.duty = 0,
+};
+static struct imxrt_pwmch_s g_ch32dev = {
+	.ops = &g_pwm_ops,
+	.ch_id = 32,
+	.controller_id = 3,
+	.submodule_id = kPWM_Module_3,
+	.ch_name = kPWM_PwmB,
+	.base = (PWM_Type *)PWM4_BASE,
+	.submodule_mode = kPWM_Independent,
+	.ch_mode = kPWM_SignedCenterAligned,
+	.pincfg = 0,
+	.freq = 0,
+	.duty = 0,
 };
 #endif
 #endif
@@ -1034,117 +1646,211 @@ static struct imxrt_pwmtimer_s g_pwm0_4 = {
  *   Initialize pin setting in pwm
  *
  ************************************************************************************/
-static inline void imxrt_pwm_pins_init(void)
+static inline void imxrt_pwm_pins_init(uint8_t channel)
 {
-	imxrt_clock_enableclock(kCLOCK_Iomuxc);           /* iomuxc clock (iomuxc_clk_enable): 0x03u */
+	uint8_t pwm_ch = channel;
 
-	#if defined(CONFIG_ARCH_CHIP_FAMILY_IMXRT102x)
-	imxrt_iomuxc_setpinmux(
-		IOMUXC_GPIO_AD_B1_06_FLEXPWM1_PWMA00,   /* GPIO_AD_B1_06 is configured as FLEXPWM1_PWMA00 */
-		0U);                                    /* Software Input On Field: Input Path is determined by functionality */
-	imxrt_iomuxc_setpinmux(
-		IOMUXC_GPIO_AD_B1_07_FLEXPWM1_PWMB00,   /* GPIO_AD_B1_07 is configured as FLEXPWM1_PWMB00 */
-		0U);                                    /* Software Input On Field: Input Path is determined by functionality */
-	imxrt_iomuxc_setpinmux(
-		IOMUXC_GPIO_AD_B1_08_FLEXPWM1_PWMA01,   /* GPIO_AD_B1_08 is configured as FLEXPWM1_PWMA01 */
-		0U);                                    /* Software Input On Field: Input Path is determined by functionality */
-	imxrt_iomuxc_setpinmux(
-		IOMUXC_GPIO_AD_B1_10_FLEXPWM1_PWMA02,   /* GPIO_AD_B1_10 is configured as FLEXPWM1_PWMA02 */
-		0U);                                    /* Software Input On Field: Input Path is determined by functionality */
-	imxrt_iomuxc_setpinconfig(
-		IOMUXC_GPIO_AD_B1_06_FLEXPWM1_PWMA00,   /* GPIO_AD_B1_06 PAD functional properties : */
-		0x10B0u);                               /* Slew Rate Field: Slow Slew Rate
-													Drive Strength Field: R0/6
-													Speed Field: medium(100MHz)
-													Open Drain Enable Field: Open Drain Disabled
-													Pull / Keep Enable Field: Pull/Keeper Enabled
-													Pull / Keep Select Field: Keeper
-													Pull Up / Down Config. Field: 100K Ohm Pull Down
-													Hyst. Enable Field: Hysteresis Disabled */
-	imxrt_iomuxc_setpinconfig(
-		IOMUXC_GPIO_AD_B1_07_FLEXPWM1_PWMB00,   /* GPIO_AD_B1_07 PAD functional properties : */
-		0x10B0u);                               /* Slew Rate Field: Slow Slew Rate
-													Drive Strength Field: R0/6
-													Speed Field: medium(100MHz)
-													Open Drain Enable Field: Open Drain Disabled
-													Pull / Keep Enable Field: Pull/Keeper Enabled
-													Pull / Keep Select Field: Keeper
-													Pull Up / Down Config. Field: 100K Ohm Pull Down
-													Hyst. Enable Field: Hysteresis Disabled */
-	imxrt_iomuxc_setpinconfig(
-		IOMUXC_GPIO_AD_B1_08_FLEXPWM1_PWMA01,   /* GPIO_AD_B1_08 PAD functional properties : */
-		0x10B0u);                               /* Slew Rate Field: Slow Slew Rate
-													Drive Strength Field: R0/6
-													Speed Field: medium(100MHz)
-													Open Drain Enable Field: Open Drain Disabled
-													Pull / Keep Enable Field: Pull/Keeper Enabled
-													Pull / Keep Select Field: Keeper
-													Pull Up / Down Config. Field: 100K Ohm Pull Down
-													Hyst. Enable Field: Hysteresis Disabled */
-	imxrt_iomuxc_setpinconfig(
-		IOMUXC_GPIO_AD_B1_10_FLEXPWM1_PWMA02,   /* GPIO_AD_B1_10 PAD functional properties : */
-		0x10B0u);                               /* Slew Rate Field: Slow Slew Rate
-													Drive Strength Field: R0/6
-													Speed Field: medium(100MHz)
-													Open Drain Enable Field: Open Drain Disabled
-													Pull / Keep Enable Field: Pull/Keeper Enabled
-													Pull / Keep Select Field: Keeper
-													Pull Up / Down Config. Field: 100K Ohm Pull Down
-													Hyst. Enable Field: Hysteresis Disabled */
-	#elif defined(CONFIG_ARCH_CHIP_FAMILY_IMXRT105x)
-	imxrt_iomuxc_setpinmux(
-		IOMUXC_GPIO_SD_B0_00_FLEXPWM1_PWMA00,   /* GPIO_SD_B0_00 is configured as FLEXPWM1_PWMA00 */
-		0U);                                    /* Software Input On Field: Input Path is determined by functionality */
-	imxrt_iomuxc_setpinmux(
-		IOMUXC_GPIO_SD_B0_01_FLEXPWM1_PWMB00,   /* GPIO_SD_B0_01 is configured as FLEXPWM1_PWMB00 */
-		0U);                                    /* Software Input On Field: Input Path is determined by functionality */
-	imxrt_iomuxc_setpinmux(
-		IOMUXC_GPIO_SD_B0_02_FLEXPWM1_PWMA01,   /* GPIO_SD_B0_02 is configured as FLEXPWM1_PWMA01 */
-		0U);                                    /* Software Input On Field: Input Path is determined by functionality */
-	imxrt_iomuxc_setpinmux(
-		IOMUXC_GPIO_SD_B0_04_FLEXPWM1_PWMA02,   /* GPIO_SD_B0_04 is configured as FLEXPWM1_PWMA02 */
-		0U);                                    /* Software Input On Field: Input Path is determined by functionality */
-	imxrt_iomuxc_setpinconfig(
-		IOMUXC_GPIO_SD_B0_00_FLEXPWM1_PWMA00,   /* GPIO_SD_B0_00 PAD functional properties : */
-		0x10B0u);                               /* Slew Rate Field: Slow Slew Rate
-													Drive Strength Field: R0/6
-													Speed Field: medium(100MHz)
-													Open Drain Enable Field: Open Drain Disabled
-													Pull / Keep Enable Field: Pull/Keeper Enabled
-													Pull / Keep Select Field: Keeper
-													Pull Up / Down Config. Field: 100K Ohm Pull Down
-													Hyst. Enable Field: Hysteresis Disabled */
-	imxrt_iomuxc_setpinconfig(
-		IOMUXC_GPIO_SD_B0_01_FLEXPWM1_PWMB00,   /* GPIO_SD_B0_01 PAD functional properties : */
-		0x10B0u);                               /* Slew Rate Field: Slow Slew Rate
-													Drive Strength Field: R0/6
-													Speed Field: medium(100MHz)
-													Open Drain Enable Field: Open Drain Disabled
-													Pull / Keep Enable Field: Pull/Keeper Enabled
-													Pull / Keep Select Field: Keeper
-													Pull Up / Down Config. Field: 100K Ohm Pull Down
-													Hyst. Enable Field: Hysteresis Disabled */
-	imxrt_iomuxc_setpinconfig(
-		IOMUXC_GPIO_SD_B0_02_FLEXPWM1_PWMA01,   /* GPIO_SD_B0_02 PAD functional properties : */
-		0x10B0u);                               /* Slew Rate Field: Slow Slew Rate
-													Drive Strength Field: R0/6
-													Speed Field: medium(100MHz)
-													Open Drain Enable Field: Open Drain Disabled
-													Pull / Keep Enable Field: Pull/Keeper Enabled
-													Pull / Keep Select Field: Keeper
-													Pull Up / Down Config. Field: 100K Ohm Pull Down
-													Hyst. Enable Field: Hysteresis Disabled */
-	imxrt_iomuxc_setpinconfig(
-		IOMUXC_GPIO_SD_B0_04_FLEXPWM1_PWMA02,   /* GPIO_SD_B0_04 PAD functional properties : */
-		0x10B0u);                               /* Slew Rate Field: Slow Slew Rate
-													Drive Strength Field: R0/6
-													Speed Field: medium(100MHz)
-													Open Drain Enable Field: Open Drain Disabled
-													Pull / Keep Enable Field: Pull/Keeper Enabled
-													Pull / Keep Select Field: Keeper
-													Pull Up / Down Config. Field: 100K Ohm Pull Down
-													Hyst. Enable Field: Hysteresis Disabled */
-	#endif
+	switch (pwm_ch) {
+#if defined(CONFIG_ARCH_CHIP_FAMILY_IMXRT102x)
+	case 1:
+		imxrt_iomuxc_setpinmux(IOMUXC_GPIO_AD_B1_06_FLEXPWM1_PWMA00, 0U);
+		imxrt_iomuxc_setpinconfig(IOMUXC_GPIO_AD_B1_06_FLEXPWM1_PWMA00, 0x10B0u);
+		break;
+	case 2:
+		imxrt_iomuxc_setpinmux(IOMUXC_GPIO_AD_B1_07_FLEXPWM1_PWMB00, 0U);
+		imxrt_iomuxc_setpinconfig(IOMUXC_GPIO_AD_B1_07_FLEXPWM1_PWMB00, 0x10B0u);
+		break;
+	case 3:
+		imxrt_iomuxc_setpinmux(IOMUXC_GPIO_AD_B1_08_FLEXPWM1_PWMA01, 0U);
+		imxrt_iomuxc_setpinconfig(IOMUXC_GPIO_AD_B1_08_FLEXPWM1_PWMA01, 0x10B0u);
+		break;
+	case 4:
+		imxrt_iomuxc_setpinmux(IOMUXC_GPIO_AD_B1_09_FLEXPWM1_PWMB01, 0U);
+		imxrt_iomuxc_setpinconfig(IOMUXC_GPIO_AD_B1_09_FLEXPWM1_PWMB01, 0x10B0u);
+		break;
+	case 5:
+		imxrt_iomuxc_setpinmux(IOMUXC_GPIO_AD_B1_10_FLEXPWM1_PWMA02, 0U);
+		imxrt_iomuxc_setpinconfig(IOMUXC_GPIO_AD_B1_10_FLEXPWM1_PWMA02, 0x10B0u);
+		break;
+	case 6:
+		imxrt_iomuxc_setpinmux(IOMUXC_GPIO_AD_B1_11_FLEXPWM1_PWMB02, 0U);
+		imxrt_iomuxc_setpinconfig(IOMUXC_GPIO_AD_B1_11_FLEXPWM1_PWMB02, 0x10B0u);
+		break;
+	case 7:
+		imxrt_iomuxc_setpinmux(IOMUXC_GPIO_AD_B1_12_FLEXPWM1_PWMA03, 0U);
+		imxrt_iomuxc_setpinconfig(IOMUXC_GPIO_AD_B1_12_FLEXPWM1_PWMA03, 0x10B0u);
+		break;
+	case 8:
+		imxrt_iomuxc_setpinmux(IOMUXC_GPIO_AD_B1_13_FLEXPWM1_PWMB03, 0U);
+		imxrt_iomuxc_setpinconfig(IOMUXC_GPIO_AD_B1_13_FLEXPWM1_PWMB03, 0x10B0u);
+		break;
+	case 9:
+		imxrt_iomuxc_setpinmux(IOMUXC_GPIO_AD_B0_14_FLEXPWM2_PWMA00, 0U);
+		imxrt_iomuxc_setpinconfig(IOMUXC_GPIO_AD_B0_14_FLEXPWM2_PWMA00, 0x10B0u);
+		break;
+	case 10:
+		imxrt_iomuxc_setpinmux(IOMUXC_GPIO_AD_B0_15_FLEXPWM2_PWMB00, 0U);
+		imxrt_iomuxc_setpinconfig(IOMUXC_GPIO_AD_B0_15_FLEXPWM2_PWMB00, 0x10B0u);
+		break;
+	case 11:
+		imxrt_iomuxc_setpinmux(IOMUXC_GPIO_AD_B0_12_FLEXPWM2_PWMA01, 0U);
+		imxrt_iomuxc_setpinconfig(IOMUXC_GPIO_AD_B0_12_FLEXPWM2_PWMA01, 0x10B0u);
+		break;
+	case 12:
+		imxrt_iomuxc_setpinmux(IOMUXC_GPIO_AD_B0_13_FLEXPWM2_PWMB01, 0U);
+		imxrt_iomuxc_setpinconfig(IOMUXC_GPIO_AD_B0_13_FLEXPWM2_PWMB01, 0x10B0u);
+		break;
+	case 13:
+		imxrt_iomuxc_setpinmux(IOMUXC_GPIO_AD_B0_10_FLEXPWM2_PWMA02, 0U);
+		imxrt_iomuxc_setpinconfig(IOMUXC_GPIO_AD_B0_10_FLEXPWM2_PWMA02, 0x10B0u);
+		break;
+	case 14:
+		imxrt_iomuxc_setpinmux(IOMUXC_GPIO_AD_B0_11_FLEXPWM2_PWMB02, 0U);
+		imxrt_iomuxc_setpinconfig(IOMUXC_GPIO_AD_B0_11_FLEXPWM2_PWMB02, 0x10B0u);
+		break;
+	case 15:
+		imxrt_iomuxc_setpinmux(IOMUXC_GPIO_AD_B0_06_FLEXPWM2_PWMA03, 0U);
+		imxrt_iomuxc_setpinconfig(IOMUXC_GPIO_AD_B0_06_FLEXPWM2_PWMA03, 0x10B0u);
+		break;
+	case 16:
+		imxrt_iomuxc_setpinmux(IOMUXC_GPIO_AD_B0_07_FLEXPWM2_PWMB03, 0U);
+		imxrt_iomuxc_setpinconfig(IOMUXC_GPIO_AD_B0_07_FLEXPWM2_PWMB03, 0x10B0u);
+		break;
+	default:
+		break;
+#elif defined(CONFIG_ARCH_CHIP_FAMILY_IMXRT105x)
+	case 1:
+		imxrt_iomuxc_setpinmux(IOMUXC_GPIO_SD_B0_00_FLEXPWM1_PWMA00, 0U);
+		imxrt_iomuxc_setpinconfig(IOMUXC_GPIO_SD_B0_00_FLEXPWM1_PWMA00, 0x10B0u);
+		break;
+	case 2:
+		imxrt_iomuxc_setpinmux(IOMUXC_GPIO_SD_B0_01_FLEXPWM1_PWMB00, 0U);
+		imxrt_iomuxc_setpinconfig(IOMUXC_GPIO_SD_B0_01_FLEXPWM1_PWMB00, 0x10B0u);
+		break;
+	case 3:
+		imxrt_iomuxc_setpinmux(IOMUXC_GPIO_SD_B0_02_FLEXPWM1_PWMA01, 0U);
+		imxrt_iomuxc_setpinconfig(IOMUXC_GPIO_SD_B0_02_FLEXPWM1_PWMA01, 0x10B0u);
+		break;
+	case 4:
+		imxrt_iomuxc_setpinmux(IOMUXC_GPIO_SD_B0_03_FLEXPWM1_PWMB01, 0U);
+		imxrt_iomuxc_setpinconfig(IOMUXC_GPIO_SD_B0_03_FLEXPWM1_PWMB01, 0x10B0u);
+		break;
+	case 5:
+		imxrt_iomuxc_setpinmux(IOMUXC_GPIO_SD_B0_04_FLEXPWM1_PWMA02, 0U);
+		imxrt_iomuxc_setpinconfig(IOMUXC_GPIO_SD_B0_04_FLEXPWM1_PWMA02, 0x10B0u);
+		break;
+	case 6:
+		imxrt_iomuxc_setpinmux(IOMUXC_GPIO_SD_B0_05_FLEXPWM1_PWMB02, 0U);
+		imxrt_iomuxc_setpinconfig(IOMUXC_GPIO_SD_B0_05_FLEXPWM1_PWMB02, 0x10B0u);
+		break;
+	case 7:
+		imxrt_iomuxc_setpinmux(IOMUXC_GPIO_SD_B1_00_FLEXPWM1_PWMA03, 0U);
+		imxrt_iomuxc_setpinconfig(IOMUXC_GPIO_SD_B1_00_FLEXPWM1_PWMA03, 0x10B0u);
+		break;
+	case 8:
+		imxrt_iomuxc_setpinmux(IOMUXC_GPIO_SD_B1_01_FLEXPWM1_PWMB03, 0U);
+		imxrt_iomuxc_setpinconfig(IOMUXC_GPIO_SD_B1_01_FLEXPWM1_PWMB03, 0x10B0u);
+		break;
+	case 9:
+		imxrt_iomuxc_setpinmux(IOMUXC_GPIO_B0_06_FLEXPWM2_PWMA00, 0U);
+		imxrt_iomuxc_setpinconfig(IOMUXC_GPIO_B0_06_FLEXPWM2_PWMA00, 0x10B0u);
+		break;
+	case 10:
+		imxrt_iomuxc_setpinmux(IOMUXC_GPIO_B0_07_FLEXPWM2_PWMB00, 0U);
+		imxrt_iomuxc_setpinconfig(IOMUXC_GPIO_B0_07_FLEXPWM2_PWMB00, 0x10B0u);
+		break;
+	case 11:
+		imxrt_iomuxc_setpinmux(IOMUXC_GPIO_B0_08_FLEXPWM2_PWMA01, 0U);
+		imxrt_iomuxc_setpinconfig(IOMUXC_GPIO_B0_08_FLEXPWM2_PWMA01, 0x10B0u);
+		break;
+	case 12:
+		imxrt_iomuxc_setpinmux(IOMUXC_GPIO_B0_09_FLEXPWM2_PWMB01, 0U);
+		imxrt_iomuxc_setpinconfig(IOMUXC_GPIO_B0_09_FLEXPWM2_PWMB01, 0x10B0u);
+		break;
+	case 13:
+		imxrt_iomuxc_setpinmux(IOMUXC_GPIO_B0_10_FLEXPWM2_PWMA02, 0U);
+		imxrt_iomuxc_setpinconfig(IOMUXC_GPIO_B0_10_FLEXPWM2_PWMA02, 0x10B0u);
+		break;
+	case 14:
+		imxrt_iomuxc_setpinmux(IOMUXC_GPIO_B0_11_FLEXPWM2_PWMB02, 0U);
+		imxrt_iomuxc_setpinconfig(IOMUXC_GPIO_B0_11_FLEXPWM2_PWMB02, 0x10B0u);
+		break;
+	case 15:
+		imxrt_iomuxc_setpinmux(IOMUXC_GPIO_B1_02_FLEXPWM2_PWMA03, 0U);
+		imxrt_iomuxc_setpinconfig(IOMUXC_GPIO_B1_02_FLEXPWM2_PWMA03, 0x10B0u);
+		break;
+	case 16:
+		imxrt_iomuxc_setpinmux(IOMUXC_GPIO_SD_B1_03_FLEXPWM2_PWMB03, 0U);
+		imxrt_iomuxc_setpinconfig(IOMUXC_GPIO_SD_B1_03_FLEXPWM2_PWMB03, 0x10B0u);
+		break;
+	case 17:
+		imxrt_iomuxc_setpinmux(IOMUXC_GPIO_EMC_29_FLEXPWM3_PWMA00, 0U);
+		imxrt_iomuxc_setpinconfig(IOMUXC_GPIO_EMC_29_FLEXPWM3_PWMA00, 0x10B0u);
+		break;
+	case 18:
+		imxrt_iomuxc_setpinmux(IOMUXC_GPIO_EMC_30_FLEXPWM3_PWMB00, 0U);
+		imxrt_iomuxc_setpinconfig(IOMUXC_GPIO_EMC_30_FLEXPWM3_PWMB00, 0x10B0u);
+		break;
+	case 19:
+		imxrt_iomuxc_setpinmux(IOMUXC_GPIO_EMC_31_FLEXPWM3_PWMA01, 0U);
+		imxrt_iomuxc_setpinconfig(IOMUXC_GPIO_EMC_31_FLEXPWM3_PWMA01, 0x10B0u);
+		break;
+	case 20:
+		imxrt_iomuxc_setpinmux(IOMUXC_GPIO_EMC_32_FLEXPWM3_PWMB01, 0U);
+		imxrt_iomuxc_setpinconfig(IOMUXC_GPIO_EMC_32_FLEXPWM3_PWMB01, 0x10B0u);
+		break;
+	case 21:
+		imxrt_iomuxc_setpinmux(IOMUXC_GPIO_EMC_33_FLEXPWM3_PWMA02, 0U);
+		imxrt_iomuxc_setpinconfig(IOMUXC_GPIO_EMC_33_FLEXPWM3_PWMA02, 0x10B0u);
+		break;
+	case 22:
+		imxrt_iomuxc_setpinmux(IOMUXC_GPIO_EMC_34_FLEXPWM3_PWMB02, 0U);
+		imxrt_iomuxc_setpinconfig(IOMUXC_GPIO_EMC_34_FLEXPWM3_PWMB02, 0x10B0u);
+		break;
+	case 23:
+		imxrt_iomuxc_setpinmux(IOMUXC_GPIO_EMC_21_FLEXPWM3_PWMA03, 0U);
+		imxrt_iomuxc_setpinconfig(IOMUXC_GPIO_EMC_21_FLEXPWM3_PWMA03, 0x10B0u);
+		break;
+	case 24:
+		imxrt_iomuxc_setpinmux(IOMUXC_GPIO_EMC_22_FLEXPWM3_PWMB03, 0U);
+		imxrt_iomuxc_setpinconfig(IOMUXC_GPIO_EMC_22_FLEXPWM3_PWMB03, 0x10B0u);
+		break;
+	case 25:
+		imxrt_iomuxc_setpinmux(IOMUXC_GPIO_AD_B1_08_FLEXPWM4_PWMA00, 0U);
+		imxrt_iomuxc_setpinconfig(IOMUXC_GPIO_AD_B1_08_FLEXPWM4_PWMA00, 0x10B0u);
+		break;
+	case 26:
+		imxrt_iomuxc_setpinmux(IOMUXC_GPIO_EMC_01_FLEXPWM4_PWMB00, 0U);
+		imxrt_iomuxc_setpinconfig(IOMUXC_GPIO_EMC_01_FLEXPWM4_PWMB00, 0x10B0u);
+		break;
+	case 27:
+		imxrt_iomuxc_setpinmux(IOMUXC_GPIO_AD_B1_09_FLEXPWM4_PWMA01, 0U);
+		imxrt_iomuxc_setpinconfig(IOMUXC_GPIO_AD_B1_09_FLEXPWM4_PWMA01, 0x10B0u);
+		break;
+	case 28:
+		imxrt_iomuxc_setpinmux(IOMUXC_GPIO_EMC_03_FLEXPWM4_PWMB01, 0U);
+		imxrt_iomuxc_setpinconfig(IOMUXC_GPIO_EMC_03_FLEXPWM4_PWMB01, 0x10B0u);
+		break;
+	case 29:
+		imxrt_iomuxc_setpinmux(IOMUXC_GPIO_B1_14_FLEXPWM4_PWMA02, 0U);
+		imxrt_iomuxc_setpinconfig(IOMUXC_GPIO_B1_14_FLEXPWM4_PWMA02, 0x10B0u);
+		break;
+	case 30:
+		imxrt_iomuxc_setpinmux(IOMUXC_GPIO_EMC_05_FLEXPWM4_PWMB02, 0U);
+		imxrt_iomuxc_setpinconfig(IOMUXC_GPIO_EMC_05_FLEXPWM4_PWMB02, 0x10B0u);
+		break;
+	case 31:
+		imxrt_iomuxc_setpinmux(IOMUXC_GPIO_B1_15_FLEXPWM4_PWMA03, 0U);
+		imxrt_iomuxc_setpinconfig(IOMUXC_GPIO_B1_15_FLEXPWM4_PWMA03, 0x10B0u);
+		break;
+	case 32:
+		imxrt_iomuxc_setpinmux(IOMUXC_GPIO_EMC_18_FLEXPWM4_PWMB03, 0U);
+		imxrt_iomuxc_setpinconfig(IOMUXC_GPIO_EMC_18_FLEXPWM4_PWMB03, 0x10B0u);
+		break;
+	default:
+		break;
+#endif
+	}
 }
 
 /************************************************************************************
@@ -1160,94 +1866,87 @@ static inline void imxrt_pwm_clock_init(void)
 	imxrt_clock_setdiv(kCLOCK_IpgDiv, 0x3); /* Set IPG PODF to 3, divede by 4 */
 }
 
-static void imxrt_pwm_drv_init3phpwm(int numPWM)
+static pwm_clock_prescale_t imxrt_set_sub_freq(FAR struct imxrt_pwmch_s *lower)
 {
-	uint16_t deadTimeVal;
-	pwm_signal_param_t pwmSignal[2];
-	uint32_t pwmSourceClockInHz;
-	uint32_t pwmFrequencyInHz = 1000;
+	uint8_t controller = lower->controller_id;
+	uint8_t submodule = lower->submodule_id;
 
-	pwmSourceClockInHz = imxrt_clock_getfreq(kCLOCK_IpgClk);
+	pwm_clock_prescale_t ret = kPWM_Prescale_Divide_1;
 
-	/* Set deadtime count, we set this to about 650ns */
-	deadTimeVal = ((uint64_t)pwmSourceClockInHz * 650) / 1000000000;
-
-	pwmSignal[0].pwmChannel = kPWM_PwmA;
-	pwmSignal[0].level = kPWM_HighTrue;
-	pwmSignal[0].dutyCyclePercent = 50; /* 1 percent dutycycle */
-	pwmSignal[0].deadtimeValue = deadTimeVal;
-
-	pwmSignal[1].pwmChannel = kPWM_PwmB;
-	pwmSignal[1].level = kPWM_HighTrue;
-	/* Dutycycle field of PWM B does not matter as we are running in PWM A complementary mode */
-	pwmSignal[1].dutyCyclePercent = 50;
-	pwmSignal[1].deadtimeValue = deadTimeVal;
-
-	switch (numPWM) {
-	case 0:
-	/*********** PWMA_SM0 - phase A, configuration, setup 2 channel as an example ************/
-	imxrt_pwm_setuppwm((PWM_Type *)PWM1_BASE, kPWM_Module_0, pwmSignal, 2, kPWM_SignedCenterAligned, pwmFrequencyInHz,
-				pwmSourceClockInHz);
-
-	/*********** PWMA_SM1 - phase B configuration, setup PWM A channel only ************/
-	imxrt_pwm_setuppwm((PWM_Type *)PWM1_BASE, kPWM_Module_1, pwmSignal, 1, kPWM_SignedCenterAligned, pwmFrequencyInHz,
-				pwmSourceClockInHz);
-
-	/*********** PWMA_SM2 - phase C configuration, setup PWM A channel only ************/
-	imxrt_pwm_setuppwm((PWM_Type *)PWM1_BASE, kPWM_Module_2, pwmSignal, 1, kPWM_SignedCenterAligned, pwmFrequencyInHz,
-				pwmSourceClockInHz);
-	break;
-
-	case 1:
-	/*********** PWMA_SM0 - phase A, configuration, setup 2 channel as an example ************/
-	imxrt_pwm_setuppwm((PWM_Type *)PWM2_BASE, kPWM_Module_0, pwmSignal, 2, kPWM_SignedCenterAligned, pwmFrequencyInHz,
-				pwmSourceClockInHz);
-
-	/*********** PWMA_SM1 - phase B configuration, setup PWM A channel only ************/
-	imxrt_pwm_setuppwm((PWM_Type *)PWM2_BASE, kPWM_Module_1, pwmSignal, 1, kPWM_SignedCenterAligned, pwmFrequencyInHz,
-				pwmSourceClockInHz);
-
-	/*********** PWMA_SM2 - phase C configuration, setup PWM A channel only ************/
-	imxrt_pwm_setuppwm((PWM_Type *)PWM2_BASE, kPWM_Module_2, pwmSignal, 1, kPWM_SignedCenterAligned, pwmFrequencyInHz,
-				pwmSourceClockInHz);
-	break;
-
-	#if defined(CONFIG_ARCH_CHIP_FAMILY_IMXRT105x)
-	case 2:
-	/*********** PWMA_SM0 - phase A, configuration, setup 2 channel as an example ************/
-	imxrt_pwm_setuppwm((PWM_Type *)PWM3_BASE, kPWM_Module_0, pwmSignal, 2, kPWM_SignedCenterAligned, pwmFrequencyInHz,
-				pwmSourceClockInHz);
-
-	/*********** PWMA_SM1 - phase B configuration, setup PWM A channel only ************/
-	imxrt_pwm_setuppwm((PWM_Type *)PWM3_BASE, kPWM_Module_1, pwmSignal, 1, kPWM_SignedCenterAligned, pwmFrequencyInHz,
-				pwmSourceClockInHz);
-
-	/*********** PWMA_SM2 - phase C configuration, setup PWM A channel only ************/
-	imxrt_pwm_setuppwm((PWM_Type *)PWM3_BASE, kPWM_Module_2, pwmSignal, 1, kPWM_SignedCenterAligned, pwmFrequencyInHz,
-				pwmSourceClockInHz);
-	break;
-
-	case 3:
-	/*********** PWMA_SM0 - phase A, configuration, setup 2 channel as an example ************/
-	imxrt_pwm_setuppwm((PWM_Type *)PWM4_BASE, kPWM_Module_0, pwmSignal, 2, kPWM_SignedCenterAligned, pwmFrequencyInHz,
-				pwmSourceClockInHz);
-
-	/*********** PWMA_SM1 - phase B configuration, setup PWM A channel only ************/
-	imxrt_pwm_setuppwm((PWM_Type *)PWM4_BASE, kPWM_Module_1, pwmSignal, 1, kPWM_SignedCenterAligned, pwmFrequencyInHz,
-				pwmSourceClockInHz);
-
-	/*********** PWMA_SM2 - phase C configuration, setup PWM A channel only ************/
-	imxrt_pwm_setuppwm((PWM_Type *)PWM4_BASE, kPWM_Module_2, pwmSignal, 1, kPWM_SignedCenterAligned, pwmFrequencyInHz,
-				pwmSourceClockInHz);
-	break;
-	#endif
-
-	default:
-	break;
+	if (controller == 0) {
+		switch (submodule) {
+		case kPWM_Module_0:
+			ret = CONFIG_PWM1_SUB1_CLOCK;
+			break;
+		case kPWM_Module_1:
+			ret = CONFIG_PWM1_SUB2_CLOCK;
+			break;
+		case kPWM_Module_2:
+			ret = CONFIG_PWM1_SUB3_CLOCK;
+			break;
+		case kPWM_Module_3:
+			ret = CONFIG_PWM1_SUB4_CLOCK;
+			break;
+		default:
+			break;
+		}
+	} else if (controller == 1) {
+		switch (submodule) {
+		case kPWM_Module_0:
+			ret = CONFIG_PWM2_SUB1_CLOCK;
+			break;
+		case kPWM_Module_1:
+			ret = CONFIG_PWM2_SUB2_CLOCK;
+			break;
+		case kPWM_Module_2:
+			ret = CONFIG_PWM2_SUB3_CLOCK;
+			break;
+		case kPWM_Module_3:
+			ret = CONFIG_PWM2_SUB4_CLOCK;
+			break;
+		default:
+			break;
+		}
+#if defined(CONFIG_ARCH_CHIP_FAMILY_IMXRT105x)
+	} else if (controller == 2) {
+		switch (submodule) {
+		case kPWM_Module_0:
+			ret = CONFIG_PWM3_SUB1_CLOCK;
+			break;
+		case kPWM_Module_1:
+			ret = CONFIG_PWM3_SUB2_CLOCK;
+			break;
+		case kPWM_Module_2:
+			ret = CONFIG_PWM3_SUB3_CLOCK;
+			break;
+		case kPWM_Module_3:
+			ret = CONFIG_PWM3_SUB4_CLOCK;
+			break;
+		default:
+			break;
+		}
+	} else if (controller == 3) {
+		switch (submodule) {
+		case kPWM_Module_0:
+			ret = CONFIG_PWM3_SUB1_CLOCK;
+			break;
+		case kPWM_Module_1:
+			ret = CONFIG_PWM3_SUB2_CLOCK;
+			break;
+		case kPWM_Module_2:
+			ret = CONFIG_PWM3_SUB3_CLOCK;
+			break;
+		case kPWM_Module_3:
+			ret = CONFIG_PWM3_SUB4_CLOCK;
+			break;
+		default:
+			break;
+		}
+#endif
 	}
+
+	return ret;
 }
-
-
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
@@ -1256,156 +1955,166 @@ static void imxrt_pwm_drv_init3phpwm(int numPWM)
  * Name: imxrt_pwminitialize
  *
  * Description:
- *   Initialize one timer for use with the upper_level PWM driver.
+ *   Initialize one channel for use with the upper_level PWM driver.
  *
  * Input Parameters:
- *   timer - A number identifying the timer use. The number of valid timer
- *     IDs varies but is somewhere in the range of
- *     {0,...,5}.
+ *   channel - A number identifying the channel use. The number of valid channel
+ *   IDs varies with the IMXRT MCU and MCU family but is somewhere in the range of
+ *   {1,..,16}. They are organized as 8 pair channels: [1,2],[3,4],[5,6],[7,8],
+ *   [9,10],[11,12],[13,14],[15,16], and must work with same frequency for two channels
+ *   in one pair. Each pair can work on complementary mode for motor control. However
+ *   the two channels in one pair can also work on individual mode, the duty for each
+ *   channel can be set individually. (with the same frequency)
  *
  * Returned Value:
- *   On success, a pointer to the lower-half PWM driver is returned.
+ *   On success, a pointer to the IMXRT lower half PWM driver is returned.
  *   NULL is returned on any failure.
  *
  ****************************************************************************/
-FAR struct pwm_lowerhalf_s *imxrt_pwminitialize(int timer)
+
+FAR struct pwm_lowerhalf_s *imxrt_pwminitialize(int channel)
 {
-	struct pwm_lowerhalf_s *lower = NULL;
-	pwm_config_t pwmConfig;
+	FAR struct imxrt_pwmch_s *lower;
+	uint8_t pwm_ch = (uint8_t)channel;
+	pwm_config_t pwmconfig;
+	PWM_Type *base;
+	pwm_submodule_t submodule;
 
-	imxrt_pwm_pins_init();
-	imxrt_pwm_clock_init();
+	vdbg("pwm channel %d init\n", channel);
+	imxrt_pwm_pins_init(channel);
+	imxrt_pwm_getdefaultconfig(&pwmconfig);
 
-	imxrt_pwm_getdefaultconfig(&pwmConfig);
-
+	switch (channel) {
 #ifdef CONFIG_IMXRT_PWM1
-	if (timer == 0) {
-		/* Use full cycle reload */
-		pwmConfig.reloadLogic = kPWM_ReloadPwmFullCycle;
-		/* PWM A & PWM B form a complementary PWM pair */
-		pwmConfig.pairOperation = kPWM_ComplementaryPwmA;
-		pwmConfig.enableDebugMode = true;
-		if (imxrt_pwm_init((PWM_Type *)PWM1_BASE, kPWM_Module_0, &pwmConfig) == kStatus_Fail) {
-			lldbg("PWM initialization failed\n");
-			return NULL;
-		}
-
-		/* Initialize submodule 1 */
-		pwmConfig.clockSource = kPWM_Submodule0Clock;
-		pwmConfig.initializationControl = kPWM_Initialize_MasterSync;
-		if (imxrt_pwm_init((PWM_Type *)PWM1_BASE, kPWM_Module_1, &pwmConfig) == kStatus_Fail) {
-			lldbg("PWM initialization failed\n");
-			return NULL;
-		}
-
-		if (imxrt_pwm_init((PWM_Type *)PWM1_BASE, kPWM_Module_2, &pwmConfig) == kStatus_Fail) {
-			lldbg("PWM initialization failed\n");
-			return NULL;
-		}
-
-		imxrt_pwm_drv_init3phpwm(timer);
-
-		lower = (struct pwm_lowerhalf_s *)&g_pwm0_1;
-	} else
+	case 1:
+		lower = &g_ch1dev;
+		break;
+	case 2:
+		lower = &g_ch2dev;
+		break;
+	case 3:
+		lower = &g_ch3dev;
+		break;
+	case 4:
+		lower = &g_ch4dev;
+		break;
+	case 5:
+		lower = &g_ch5dev;
+		break;
+	case 6:
+		lower = &g_ch6dev;
+		break;
+	case 7:
+		lower = &g_ch7dev;
+		break;
+	case 8:
+		lower = &g_ch8dev;
+		break;
 #endif
 #ifdef CONFIG_IMXRT_PWM2
-	if (timer == 1) {
-		/* Use full cycle reload */
-		pwmConfig.reloadLogic = kPWM_ReloadPwmFullCycle;
-		/* PWM A & PWM B form a complementary PWM pair */
-		pwmConfig.pairOperation = kPWM_ComplementaryPwmA;
-		pwmConfig.enableDebugMode = true;
-		if (imxrt_pwm_init((PWM_Type *)PWM2_BASE, kPWM_Module_0, &pwmConfig) == kStatus_Fail) {
-			lldbg("PWM initialization failed\n");
-			return NULL;
-		}
-
-		/* Initialize submodule 1 */
-		pwmConfig.clockSource = kPWM_Submodule0Clock;
-		pwmConfig.initializationControl = kPWM_Initialize_MasterSync;
-		if (imxrt_pwm_init((PWM_Type *)PWM2_BASE, kPWM_Module_1, &pwmConfig) == kStatus_Fail) {
-			lldbg("PWM initialization failed\n");
-			return NULL;
-		}
-
-		if (imxrt_pwm_init((PWM_Type *)PWM2_BASE, kPWM_Module_2, &pwmConfig) == kStatus_Fail) {
-			lldbg("PWM initialization failed\n");
-			return NULL;
-		}
-
-		imxrt_pwm_drv_init3phpwm(timer);
-
-		lower = (struct pwm_lowerhalf_s *)&g_pwm0_2;
-	} else
+	case 9:
+		lower = &g_ch9dev;
+		break;
+	case 10:
+		lower = &g_ch10dev;
+		break;
+	case 11:
+		lower = &g_ch11dev;
+		break;
+	case 12:
+		lower = &g_ch12dev;
+		break;
+	case 13:
+		lower = &g_ch13dev;
+		break;
+	case 14:
+		lower = &g_ch14dev;
+		break;
+	case 15:
+		lower = &g_ch15dev;
+		break;
+	case 16:
+		lower = &g_ch16dev;
+		break;
 #endif
 #if defined(CONFIG_ARCH_CHIP_FAMILY_IMXRT105x)
 #ifdef CONFIG_IMXRT_PWM3
-	if (timer == 2) {
-		/* Use full cycle reload */
-		pwmConfig.reloadLogic = kPWM_ReloadPwmFullCycle;
-		/* PWM A & PWM B form a complementary PWM pair */
-		pwmConfig.pairOperation = kPWM_ComplementaryPwmA;
-		pwmConfig.enableDebugMode = true;
-		if (imxrt_pwm_init((PWM_Type *)PWM3_BASE, kPWM_Module_0, &pwmConfig) == kStatus_Fail) {
-			lldbg("PWM initialization failed\n");
-			return NULL;
-		}
-
-		/* Initialize submodule 1 */
-		pwmConfig.clockSource = kPWM_Submodule0Clock;
-		pwmConfig.initializationControl = kPWM_Initialize_MasterSync;
-		if (imxrt_pwm_init((PWM_Type *)PWM3_BASE, kPWM_Module_1, &pwmConfig) == kStatus_Fail) {
-			lldbg("PWM initialization failed\n");
-			return NULL;
-		}
-
-		if (imxrt_pwm_init((PWM_Type *)PWM3_BASE, kPWM_Module_2, &pwmConfig) == kStatus_Fail) {
-			lldbg("PWM initialization failed\n");
-			return NULL;
-		}
-
-		imxrt_pwm_drv_init3phpwm(timer);
-
-		lower = (struct pwm_lowerhalf_s *)&g_pwm0_3;
-	} else
+	case 17:
+		lower = &g_ch17dev;
+		break;
+	case 18:
+		lower = &g_ch18dev;
+		break;
+	case 19:
+		lower = &g_ch19dev;
+		break;
+	case 20:
+		lower = &g_ch20dev;
+		break;
+	case 21:
+		lower = &g_ch21dev;
+		break;
+	case 22:
+		lower = &g_ch22dev;
+		break;
+	case 23:
+		lower = &g_ch23dev;
+		break;
+	case 24:
+		lower = &g_ch24dev;
+		break;
 #endif
 #ifdef CONFIG_IMXRT_PWM4
-	if (timer == 3) {
-		/* Use full cycle reload */
-		pwmConfig.reloadLogic = kPWM_ReloadPwmFullCycle;
-		/* PWM A & PWM B form a complementary PWM pair */
-		pwmConfig.pairOperation = kPWM_ComplementaryPwmA;
-		pwmConfig.enableDebugMode = true;
-		if (imxrt_pwm_init((PWM_Type *)PWM4_BASE, kPWM_Module_0, &pwmConfig) == kStatus_Fail) {
-			lldbg("PWM initialization failed\n");
-			return NULL;
-		}
-
-		/* Initialize submodule 1 */
-		pwmConfig.clockSource = kPWM_Submodule0Clock;
-		pwmConfig.initializationControl = kPWM_Initialize_MasterSync;
-		if (imxrt_pwm_init((PWM_Type *)PWM4_BASE, kPWM_Module_1, &pwmConfig) == kStatus_Fail) {
-			lldbg("PWM initialization failed\n");
-			return NULL;
-		}
-
-		if (imxrt_pwm_init((PWM_Type *)PWM4_BASE, kPWM_Module_2, &pwmConfig) == kStatus_Fail) {
-			lldbg("PWM initialization failed\n");
-			return NULL;
-		}
-
-		imxrt_pwm_drv_init3phpwm(timer);
-
-		lower = (struct pwm_lowerhalf_s *)&g_pwm0_4;
-	} else
+	case 25:
+		lower = &g_ch25dev;
+		break;
+	case 26:
+		lower = &g_ch26dev;
+		break;
+	case 27:
+		lower = &g_ch27dev;
+		break;
+	case 28:
+		lower = &g_ch28dev;
+		break;
+	case 29:
+		lower = &g_ch29dev;
+		break;
+	case 30:
+		lower = &g_ch30dev;
+		break;
+	case 31:
+		lower = &g_ch31dev;
+		break;
+	case 32:
+		lower = &g_ch32dev;
+		break;
 #endif
 #endif
-	{
-		lldbg("ERROR: invalid PWM is requested\n");
+
+	default:
 		return NULL;
 	}
 
-	imxrt_pwm_reset(lower, timer);
+	base = lower->base;
+	submodule = lower->submodule_id;
 
-	return lower;
+	pwmconfig.prescale = imxrt_set_sub_freq(lower);
+
+	/* Use full cycle reload */
+	pwmconfig.reloadLogic = kPWM_ReloadPwmFullCycle;
+	pwmconfig.pairOperation = lower->submodule_mode;
+	pwmconfig.enableDebugMode = true;
+
+	if (imxrt_pwm_init(base, submodule, &pwmconfig) == kStatus_Fail) {
+		return NULL;
+	}
+	if (pwm_ch % 2) {
+		base->OUTEN &= ~(1U << (PWM_OUTEN_PWMA_EN_SHIFT + submodule));
+	} else {
+		base->OUTEN &= ~(1U << (PWM_OUTEN_PWMB_EN_SHIFT + submodule));
+	}
+	imxrt_pwm_setup((FAR struct pwm_lowerhalf_s *)lower);
+
+	return (FAR struct pwm_lowerhalf_s *)lower;
 }

--- a/os/board/imxrt1020-evk/src/imxrt_bringup.c
+++ b/os/board/imxrt1020-evk/src/imxrt_bringup.c
@@ -73,7 +73,9 @@
 
 #include <syslog.h>
 #include <tinyara/i2c.h>
-#include <imxrt_lpi2c.h>
+#include <tinyara/pwm.h>
+#include "imxrt_lpi2c.h"
+#include "imxrt_pwm.h"
 #include "imxrt_log.h"
 
 #if defined(CONFIG_FLASH_PARTITION)
@@ -113,6 +115,38 @@ static void imxrt_i2c_register(int bus)
 	}
 }
 #endif
+
+/****************************************************************************
+ * Name: board_pwmm_initialize
+ *
+ * Description:
+ *   PWM intialization for imxrt
+ *
+ ****************************************************************************/
+static void imxrt_pwm_register(int ch)
+{
+#ifdef CONFIG_PWM
+	struct pwm_lowerhalf_s *pwm_ch;
+	char path[16];
+	int ret;
+
+	/* The last two channels(15, 16) multiplex the PINs with LPUART1,
+	 * so for debugging they are not be set to PWM PINs */
+	pwm_ch = imxrt_pwminitialize(ch);
+	if (!pwm_ch) {
+		dbg("Failed to get imxrt PWM Channel lower half\n");
+		return;
+	}
+
+	/* Register the PWM channel driver at "/dev/pwmx" */
+	snprintf(path, sizeof(path), "/dev/pwm%d", ch);
+	ret = pwm_register(path, pwm_ch);
+	if (ret < 0) {
+		dbg("Imxrt PWM registeration failure: %d\n", ret);
+	}
+#endif
+	return;
+}
 
 void imxrt_filesystem_initialize(void)
 {
@@ -280,6 +314,57 @@ int imxrt_bringup(void)
 #endif
 #if defined(CONFIG_I2C_DRIVER) && defined(CONFIG_IMXRT_LPI2C4)
 	imxrt_i2c_register(4);
+#endif
+
+#ifdef CONFIG_PWM
+#if defined(CONFIG_IMXRT_PWM_CHANNEL1)
+	imxrt_pwm_register(1);
+#endif
+#if defined(CONFIG_IMXRT_PWM_CHANNEL2)
+	imxrt_pwm_register(2);
+#endif
+#if defined(CONFIG_IMXRT_PWM_CHANNEL3)
+	imxrt_pwm_register(3);
+#endif
+#if defined(CONFIG_IMXRT_PWM_CHANNEL4)
+	imxrt_pwm_register(4);
+#endif
+#if defined(CONFIG_IMXRT_PWM_CHANNEL5)
+	imxrt_pwm_register(5);
+#endif
+#if defined(CONFIG_IMXRT_PWM_CHANNEL6)
+	imxrt_pwm_register(6);
+#endif
+#if defined(CONFIG_IMXRT_PWM_CHANNEL7)
+	imxrt_pwm_register(7);
+#endif
+#if defined(CONFIG_IMXRT_PWM_CHANNEL8)
+	imxrt_pwm_register(8);
+#endif
+#if defined(CONFIG_IMXRT_PWM_CHANNEL9)
+	imxrt_pwm_register(9);
+#endif
+#if defined(CONFIG_IMXRT_PWM_CHANNEL10)
+	imxrt_pwm_register(10);
+#endif
+#if defined(CONFIG_IMXRT_PWM_CHANNEL11)
+	imxrt_pwm_register(11);
+#endif
+#if defined(CONFIG_IMXRT_PWM_CHANNEL12)
+	imxrt_pwm_register(12);
+#endif
+#if defined(CONFIG_IMXRT_PWM_CHANNEL13)
+	imxrt_pwm_register(13);
+#endif
+#if defined(CONFIG_IMXRT_PWM_CHANNEL14)
+	imxrt_pwm_register(14);
+#endif
+#if defined(CONFIG_IMXRT_PWM_CHANNEL15)
+	imxrt_pwm_register(15);
+#endif
+#if defined(CONFIG_IMXRT_PWM_CHANNEL16)
+	imxrt_pwm_register(16);
+#endif
 #endif
 
 #ifdef CONFIG_USBHOST


### PR DESCRIPTION
iMXRT flexpwm controller has several pwm channels, they are
organized like:

	flexpwm controller 0 ---> submodule 0 ---> channel [A, B, X]
			     |--> submodule 1 ---> channel [A, B, X]
			     |--> submodule 2 ---> channel [A, B, X]
			     |--> submodule 3 ---> channel [A, B, X]

Each submodule has one source clock, so the three channels: A, B, X
will work at the same output frequency, but each of the duty can be
set separately. Channel A and B can also work on complementary for
motor control, and channel X has some specific charecters.

In general, channel A and B can be configured as normal pwm output
working in individual mode. This pwm driver supports to enable and
use the channels under the individual mode, and numbers all channels
in uniform.

For RT1020, there are 2 flexpwm controllers, each controller has 4
submodules, each submodule has channel A and channel B, so the number
of total channels is (2 * 4 * 2) = 16. they are numbered from pwm 1
to pwm 16.

	pwm 1 --> controller 0 ---> submodule 0 ---> channel A
	pwm 2 --> controller 0 ---> submodule 0 ---> channel B
	pwm 3 --> controller 0 ---> submodule 1 ---> channel A
	pwm 4 --> controller 0 ---> submodule 1 ---> channel B

	...

	pwm 13 --> controller 1 ---> submodule 2 ---> channel A
	pwm 14 --> controller 1 ---> submodule 2 ---> channel B
	pwm 15 --> controller 1 ---> submodule 3 ---> channel A
	pwm 16 --> controller 1 ---> submodule 3 ---> channel B

Signed-off-by: Liu Gang <Gang.Liu@nxp.com>