### PR TITLE
arch/arm/common : Add up_stack_color() in up_usestack()

### DIFF
--- a/os/arch/arm/src/common/up_usestack.c
+++ b/os/arch/arm/src/common/up_usestack.c
@@ -178,5 +178,8 @@ int up_use_stack(struct tcb_s *tcb, void *stack, size_t stack_size)
 	tcb->adj_stack_ptr = (uint32_t *)top_of_stack;
 	tcb->adj_stack_size = size_of_stack;
 
+#ifdef CONFIG_STACK_COLORATION
+	up_stack_color(tcb->stack_alloc_ptr, tcb->adj_stack_size);
+#endif
 	return OK;
 }


### PR DESCRIPTION
     We cannot check the used stack size for pre-allocated stack, because pre-allocated stack is not filled with color.
    up_use_stack() sets up the stack-related information in the TCB, so add up_stack_color() at the end of the up_use_stack().
