### PR TITLE
 kernel/init : Fill idle stack information in g_idletcb when os boot up.

### DIFF
--- a/os/fs/procfs/fs_procfsproc.c
+++ b/os/fs/procfs/fs_procfsproc.c
@@ -90,7 +90,6 @@
 #if !defined(CONFIG_DISABLE_MOUNTPOINT) && defined(CONFIG_FS_PROCFS)
 #ifndef CONFIG_FS_PROCFS_EXCLUDE_PROCESS
 
-extern const uint32_t g_idle_topstack;
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
@@ -367,10 +366,6 @@ static ssize_t proc_entry_stat(FAR struct proc_file_s *procfile, FAR struct tcb_
 	struct mm_heap_s *heap;
 	pid_t hash_pid;
 #endif
-	if (tcb->pid == 0) {
-		tcb->adj_stack_size = CONFIG_IDLETHREAD_STACKSIZE;
-		tcb->stack_alloc_ptr = (void *)(g_idle_topstack - CONFIG_IDLETHREAD_STACKSIZE);
-	}
 
 	remaining = buflen;
 	totalsize = 0;

--- a/os/kernel/init/os_start.c
+++ b/os/kernel/init/os_start.c
@@ -95,6 +95,7 @@
 #include <tinyara/testcase_drv.h>
 #endif
 
+extern const uint32_t g_idle_topstack;
 #include <tinyara/mm/heap_regioninfo.h>
 extern bool heapx_is_init[CONFIG_MM_NHEAPS];
 
@@ -358,6 +359,10 @@ void os_start(void)
 #endif							/* CONFIG_TASK_NAME_SIZE */
 	g_idleargv[1]  = NULL;
 	g_idletcb.argv = g_idleargv;
+
+	/* Fill the stack information to Idle task's tcb */
+	g_idletcb.cmn.adj_stack_size = CONFIG_IDLETHREAD_STACKSIZE;
+	g_idletcb.cmn.stack_alloc_ptr = (void *)(g_idle_topstack - CONFIG_IDLETHREAD_STACKSIZE);
 
 	/* Then add the idle task's TCB to the head of the ready to run list */
 


### PR DESCRIPTION
Idle task's tcb doesn't have stack information(stack size and stack alloc pointer), because it is not allocated by mm.
For debugging, we need idle task's stack information.(Ex: stack monitor, heapinfo, assert log.)
