### PR TITLE
loadable_apps: Fix build error during protected build

### DIFF
--- a/loadable_apps/Makefile
+++ b/loadable_apps/Makefile
@@ -53,6 +53,7 @@
 -include $(TOPDIR)/.config
 -include $(TOPDIR)/Make.defs
 
+ifeq ($(CONFIG_APP_BINARY_SEPARATION),y)
 BUILD_SUBDIRS = micomapp wifiapp
 
 USER_BIN_DIR = $(TOPDIR)/../build/output/bin
@@ -81,6 +82,10 @@ install: $(foreach DIR, $(BUILD_SUBDIRS), $(DIR)_install)
 # Verify each program for undefined symbols
 
 verify: $(foreach DIR, $(BUILD_SUBDIRS), $(DIR)_verify)
+else
+all:
+
+endif
 
 # context
 context:


### PR DESCRIPTION
Following build error happens during protected build.

nm: '/home/kishore/tinyara/TizenRT_kishore/loadable_apps/micomapp/micom': No such file
CC: /home/kishore/tinyara/TizenRT_kishore/os/board/common/userspace/up_userspace.c
/home/kishore/tinyara/TizenRT_kishore/os/board/common/userspace/up_userspace.c:57:28: fatal error: tinyara/config.h: No such file or directory
 #include <tinyara/config.h>
                            ^
compilation terminated.

In order to fix this error, we disable building of loadable apps in
protected build configuration.

Signed-off-by: Kishore SN <kishore.sn@samsung.com>