### PR TITLE
example/security_test: fix build failure.

### DIFF
--- a/apps/examples/security_test/security_api/Makefile
+++ b/apps/examples/security_test/security_api/Makefile
@@ -30,6 +30,7 @@ ASRCS =
 #CSRCS += security_api_auth_test.c  security_api_keymgr_test.c security_api_ss_test.c
 CSRCS += security_api_utils.c
 CSRCS += security_api_keymgr_test.c security_api_crypto_test.c security_api_ss_test.c
+CSRCS += security_api_auth_test.c
 MAINSRC = security_api_test.c
 
 AOBJS = $(ASRCS:.S=$(OBJEXT))

--- a/apps/examples/security_test/security_api/security_api_auth_test.c
+++ b/apps/examples/security_test/security_api/security_api_auth_test.c
@@ -32,12 +32,13 @@
 void test_authenticate(void)
 {
 	security_handle hnd;
-	security_data rand = {NULL, 0};
-	security_data cert = {NULL, 0};
-	security_data plaintext = {NULL, 0};
-	security_data hashed = {NULL, 0};
-	security_data sign = {NULL, 0};
-	security_data hmac = {NULL, 0};
+	char buff[4096] = {0};
+	security_data rand = {buff, 0};
+	security_data cert = {buff, 0};
+	security_data plaintext = {buff, 0};
+	security_data hashed = {buff, 0};
+	security_data sign = {buff, 0};
+	security_data hmac = {buff, 0};
 //	security_data hash_gen_key;
 
 	plaintext.data = "01234567890123456789";
@@ -82,7 +83,6 @@ void test_authenticate(void)
 	PrintBuffer("Plain Text", plaintext.data, plaintext.length);
 	PrintBuffer("Hashed Data", hashed.data, hashed.length);
 
-
 	/*	does ecdsa require certificate to get signature? */
 	printf("  . SEC Get ECDSA Signature ...\n");
 	fflush(stdout);
@@ -90,7 +90,7 @@ void test_authenticate(void)
 	mode.curve = ECDSA_SEC_P256R1;
 	mode.hash_t = HASH_SHA256;
 
-	if (0 != auth_get_ecdsa_signature(hnd, mode, ARTIK_CERT, &hashed, &sign)) {
+	if (0 != auth_get_ecdsa_signature(hnd, &mode, ARTIK_CERT, &hashed, &sign)) {
 		printf("  fail\n  ! auth_get_ecdsa_signature\n");
 		goto exit;
 	}
@@ -100,7 +100,7 @@ void test_authenticate(void)
 
 	printf("  . SEC Verify ECDSA Signature ...\n");
 	fflush(stdout);
-	if (0 != auth_verify_ecdsa_signature(hnd, mode, ARTIK_CERT, &hashed, &sign)) {
+	if (0 != auth_verify_ecdsa_signature(hnd, &mode, ARTIK_CERT, &hashed, &sign)) {
 		printf("  fail\n  ! auth_verify_ecdsa_signature\n");
 		goto exit;
 	}

--- a/apps/examples/security_test/security_api/security_api_crypto_test.c
+++ b/apps/examples/security_test/security_api/security_api_crypto_test.c
@@ -75,7 +75,7 @@ test_crypto(void)
 	aes_param.iv = iv.data;
 	aes_param.iv_len = iv.length;
 
-	if (0 != crypto_aes_encryption(hnd, aes_param, AES128_KEY, &input, &aes_enc_data)) {
+	if (0 != crypto_aes_encryption(hnd, &aes_param, AES128_KEY, &input, &aes_enc_data)) {
 		printf("Fail\n	! crypto_aes_encryption\n");
 		goto exit;
 	}
@@ -85,7 +85,7 @@ test_crypto(void)
 
 	printf("  . SEC AES Decryption ...\n");
 	fflush(stdout);
-	if (0 != crypto_aes_decryption(hnd, aes_param, AES128_KEY, &aes_enc_data, &aes_dec_data)) {
+	if (0 != crypto_aes_decryption(hnd, &aes_param, AES128_KEY, &aes_enc_data, &aes_dec_data)) {
 		printf("Fail\n	! security_aes_decryption\n");
 		goto exit;
 	}
@@ -117,7 +117,7 @@ test_crypto(void)
 	rsa_param.mgf = 0;
 	rsa_param.salt_byte_len = 0;
 
-	if (0 != crypto_rsa_encryption(hnd, rsa_param, RSA1024_KEY, &input, &rsa_enc_data)) {
+	if (0 != crypto_rsa_encryption(hnd, &rsa_param, RSA1024_KEY, &input, &rsa_enc_data)) {
 		printf("Fail\n	! crypto_rsa_encryption\n");
 		goto exit;
 	}
@@ -127,7 +127,7 @@ test_crypto(void)
 
 	printf("  . SEC RSA Decryption ...\n");
 	fflush(stdout);
-	if (0 != crypto_rsa_decryption(hnd, rsa_param, RSA1024_KEY, &rsa_enc_data, &rsa_dec_data)) {
+	if (0 != crypto_rsa_decryption(hnd, &rsa_param, RSA1024_KEY, &rsa_enc_data, &rsa_dec_data)) {
 		printf("Fail\n	! crypto_rsa_decryption\n");
 		goto exit;
 	}

--- a/apps/examples/security_test/security_api/security_api_ss_test.c
+++ b/apps/examples/security_test/security_api/security_api_ss_test.c
@@ -30,9 +30,7 @@
 void
 test_securestorage(void)
 {
-	int i;
 	unsigned int storage_size;
-	unsigned int count;
 	security_storage_list list;
 	security_handle hnd;
 	security_data input = {NULL, 0};
@@ -76,15 +74,18 @@ test_securestorage(void)
 	PrintBuffer(TEST_SS_PATH, output.data, output.length);
 
 	printf("  . SEC Get Secure Storage List ...\n");
-
-	if (0 != ss_get_list_secure_storage(hnd, &count, &list)) {
+	if (0 != ss_get_list_secure_storage(hnd, &list)) {
 		printf("Fail\n	! ss_get_list_secure_storage\n");
 		goto exit;
 	}
 	printf("ok\n");
 	printf("[%20s] [%8s]\n", "FILE NAME", "FILE ATTR");
-	for (i = 0; i < count; i++) {
-		printf("[%20s] [%08x]\n", list[i].name, list[i].attr);
+	// It will be paased why list will be null always.
+	{
+		security_storage_list ptr = list;
+		while (ptr != NULL) {
+			printf("[%20s] [%08x]\n", ptr->name, ptr->attr);
+		}
 	}
 
 	printf("  . SEC Delete secure storage ...\n");
@@ -97,8 +98,6 @@ test_securestorage(void)
 
 exit:
 	free_security_data(&output);
-	if (count > 0)
-		free(list);
 
 	printf("  . SEC Deinitialize ...\n");
 	security_deinit(hnd);

--- a/framework/src/security/security_auth.c
+++ b/framework/src/security/security_auth.c
@@ -235,10 +235,6 @@ security_error auth_get_ecdsa_signature(security_handle hnd, security_ecdsa_para
 		SECAPI_HAL_RETURN(hres);
 	}
 
-	sign->data = (unsigned char *)malloc(h_sign.data_len);
-	if (!sign->data) {
-		SECAPI_RETURN(SECURITY_ALLOC_ERROR);
-	}
 	SECAPI_DATA_DCOPY(h_sign, sign);
 
 	SECAPI_RETURN(SECURITY_OK);
@@ -276,7 +272,6 @@ security_error auth_verify_ecdsa_signature(security_handle hnd,
 		SECAPI_HAL_RETURN(hres);
 	}
 
-
 	SECAPI_HAL_RETURN(hres);
 }
 
@@ -302,11 +297,6 @@ security_error auth_get_hash(security_handle hnd, security_hash_mode mode, secur
 	SECAPI_CALL(sl_get_hash(ctx->sl_hnd, h_type, &input, &output, &hres));
 	if (hres != HAL_SUCCESS) {
 		SECAPI_HAL_RETURN(hres);
-	}
-
-	hash->data = (unsigned char *)malloc(output.data_len);
-	if (!hash->data) {
-		SECAPI_RETURN(SECURITY_ALLOC_ERROR);
 	}
 
 	SECAPI_DATA_DCOPY(output, hash);
@@ -344,11 +334,6 @@ security_error auth_get_hmac(security_handle hnd,
 	SECAPI_CALL(sl_get_hmac(ctx->sl_hnd, h_type, &input, key_idx, &output, &hres));
 	if (hres != HAL_SUCCESS) {
 		SECAPI_HAL_RETURN(hres);
-	}
-
-	hmac->data = (unsigned char *)malloc(output.data_len);
-	if (!hmac->data) {
-		SECAPI_RETURN(SECURITY_ALLOC_ERROR);
 	}
 
 	SECAPI_DATA_DCOPY(output, hmac);

--- a/framework/src/security/security_keymgr.c
+++ b/framework/src/security/security_keymgr.c
@@ -118,10 +118,6 @@ security_error keymgr_get_key(security_handle hnd, security_key_type algo, const
 		SECAPI_RETURN(SECURITY_INVALID_INPUT_PARAMS);
 	}
 
-	pubkey_x->data = (unsigned char *)malloc(h_pubkey.data_len);
-	if (!pubkey_x->data) {
-		SECAPI_RETURN(SECURITY_ALLOC_ERROR);
-	}
 	SECAPI_DATA_DCOPY(h_pubkey, pubkey_x);
 
 	// check pubkey_y for ECDH
@@ -129,11 +125,6 @@ security_error keymgr_get_key(security_handle hnd, security_key_type algo, const
 		SECAPI_RETURN(SECURITY_OK);
 	}
 
-	pubkey_y->data = (unsigned char *)malloc(h_pubkey.priv_len);
-	if (!pubkey_y->data) {
-		SECAPI_FREE(pubkey_x);
-		SECAPI_RETURN(SECURITY_ALLOC_ERROR);
-	}
 	SECAPI_PRIV_DCOPY(h_pubkey, pubkey_y);
 
 	SECAPI_RETURN(SECURITY_OK);


### PR DESCRIPTION
Update UTC for security APIs. 

1. fix build failure.
2. Remove malloc without free why It is a memory leak, bug. 
   We have decided that user should pass buffer which is allocated some memory into security API.

