### PR TITLE
framework/st_things: fix an arithmetic operator misuse

### DIFF
--- a/framework/src/st_things/things_stack/framework/things_data_manager.c
+++ b/framework/src/st_things/things_stack/framework/things_data_manager.c
@@ -1686,7 +1686,7 @@ static int parse_device_json(cJSON *device)
 			g_device->ver_p = (char *) things_malloc(sizeof(char) * (sizeof(DEVICE_PLATFORM_VERSION)));
 			strncpy(g_device->ver_p, DEVICE_PLATFORM_VERSION, sizeof(DEVICE_PLATFORM_VERSION));
 
-			g_device->ver_os = (char *) things_malloc(sizeof(char) + (sizeof(DEVICE_OS_VERSION)));
+			g_device->ver_os = (char *) things_malloc(sizeof(char) * (sizeof(DEVICE_OS_VERSION)));
 			strncpy(g_device->ver_os, DEVICE_OS_VERSION, sizeof(DEVICE_OS_VERSION));
 
 			g_device->ver_hw = (char *) things_malloc(sizeof(char) * (sizeof(DEVICE_HARDWARE_VERSION)));


### PR DESCRIPTION
memory size shall be char size multiple sizeof string literal