### PR TITLE
arch/arm/assert : Display used stack size of idle task when asserted.

### DIFF
--- a/os/arch/arm/src/armv7-m/up_assert.c
+++ b/os/arch/arm/src/armv7-m/up_assert.c
@@ -199,11 +199,7 @@ static void up_taskdump(FAR struct tcb_s *tcb, FAR void *arg)
 {
 	size_t used_stack_size;
 
-	if (tcb->pid == 0) {
-		used_stack_size = 0;
-	} else {
-		used_stack_size = up_check_tcbstack(tcb);
-	}
+	used_stack_size = up_check_tcbstack(tcb);
 
 	/* Dump interesting properties of this task */
 
@@ -217,7 +213,7 @@ static void up_taskdump(FAR struct tcb_s *tcb, FAR void *arg)
 			(unsigned long)tcb->adj_stack_size);
 #endif
 
-	if (tcb->pid != 0 && used_stack_size == tcb->adj_stack_size) {
+	if (used_stack_size == tcb->adj_stack_size) {
 		lldbg("  !!! PID (%d) STACK OVERFLOW !!! \n", tcb->pid);
 	}
 
@@ -295,13 +291,8 @@ static void up_dumpstate(void)
 
 	/* Get the limits on the user stack memory */
 
-	if (rtcb->pid == 0) {
-		ustackbase = g_idle_topstack - 4;
-		ustacksize = CONFIG_IDLETHREAD_STACKSIZE;
-	} else {
-		ustackbase = (uint32_t)rtcb->adj_stack_ptr;
-		ustacksize = (uint32_t)rtcb->adj_stack_size;
-	}
+	ustackbase = (uint32_t)rtcb->adj_stack_ptr;
+	ustacksize = (uint32_t)rtcb->adj_stack_size;
 
 #if CONFIG_ARCH_INTERRUPTSTACK > 3
 	/* Get the limits on the interrupt stack memory */

--- a/os/arch/arm/src/armv7-r/arm_assert.c
+++ b/os/arch/arm/src/armv7-r/arm_assert.c
@@ -475,19 +475,22 @@ void dump_stack(void)
 #ifdef CONFIG_STACK_COLORATION
 static void up_taskdump(FAR struct tcb_s *tcb, FAR void *arg)
 {
+	size_t used_stack_size;
+
+	used_stack_size = up_check_tcbstack(tcb);
 	/* Dump interesting properties of this task */
 
 #if CONFIG_TASK_NAME_SIZE > 0
 	lldbg("%10s | %5d | %4d | %7lu / %7lu\n",
 			tcb->name, tcb->pid, tcb->sched_priority,
-			(unsigned long)up_check_tcbstack(tcb), (unsigned long)tcb->adj_stack_size);
+			(unsigned long)used_stack_size, (unsigned long)tcb->adj_stack_size);
 #else
 	lldbg("%5d | %4d | %7lu / %7lu\n",
-			tcb->pid, tcb->sched_priority, (unsigned long)up_check_tcbstack(tcb),
+			tcb->pid, tcb->sched_priority, (unsigned long)used_stack_size,
 			(unsigned long)tcb->adj_stack_size);
 #endif
 
-	if (tcb->pid != 0 && up_check_tcbstack(tcb) == tcb->adj_stack_size) {
+	if (used_stack_size == tcb->adj_stack_size) {
 		lldbg("  !!! PID (%d) STACK OVERFLOW !!! \n", tcb->pid);
 	}
 }
@@ -758,16 +761,11 @@ static void up_dumpstate(void)
 
 	/* Get the limits on the user stack memory */
 
-	if (rtcb->pid == 0) {
-		ustackbase = g_idle_topstack - 4;
-		ustacksize = CONFIG_IDLETHREAD_STACKSIZE;
-	} else {
-		ustackbase = (uint32_t)rtcb->adj_stack_ptr;
-		ustacksize = (uint32_t)rtcb->adj_stack_size;
+	ustackbase = (uint32_t)rtcb->adj_stack_ptr;
+	ustacksize = (uint32_t)rtcb->adj_stack_size;
 #ifdef CONFIG_MPU_STACKGUARD
-		uguardsize = (uint32_t)rtcb->guard_size;
+	uguardsize = (uint32_t)rtcb->guard_size;
 #endif
-	}
 
 	lldbg("Current sp: %08x\n", sp);
 

--- a/os/kernel/init/os_start.c
+++ b/os/kernel/init/os_start.c
@@ -363,6 +363,7 @@ void os_start(void)
 	/* Fill the stack information to Idle task's tcb */
 	g_idletcb.cmn.adj_stack_size = CONFIG_IDLETHREAD_STACKSIZE;
 	g_idletcb.cmn.stack_alloc_ptr = (void *)(g_idle_topstack - CONFIG_IDLETHREAD_STACKSIZE);
+	g_idletcb.cmn.adj_stack_size = g_idle_topstack - 4;
 
 	/* Then add the idle task's TCB to the head of the ready to run list */
 


### PR DESCRIPTION
Idle task's tcb has stack information now, so we can display the current used stack size when asserted.