### PR TITLE
apps/example/timer : Add FRT measurement before and after the timer e…

### DIFF
--- a/apps/examples/timer/Kconfig
+++ b/apps/examples/timer/Kconfig
@@ -11,3 +11,12 @@ config EXAMPLES_TIMER
 		This application is an example program that opens /dev/timer0
 		to set the timer and registers the callback which is called at
 		the end of the timer.
+
+if EXAMPLES_TIMER
+config EXAMPLES_TIMER_FRT_MEASUREMENT
+	bool "FRT Measurement"
+	default y
+	---help---
+		If this config is enabled, elapsed time before and after the timer event
+		is measured by Free Run Timer.
+endif


### PR DESCRIPTION
…vent

Add FRT measurement for summarizing the elpased time.
Expected result is like below:
>> Summary
        Expected 500000, Estimated 500259, Ratio 0.000517964
        PASS : Estimated Elapsed time is within the expected range.