### PR TITLE
apps/iperf: fix direct access to errno

### DIFF
--- a/apps/system/iperf/iperf_api.c
+++ b/apps/system/iperf/iperf_api.c
@@ -2694,8 +2694,6 @@ struct iperf_stream *iperf_new_stream(struct iperf_test *test, int s)
 	}
 #endif
 
-	h_errno = 0;
-
 	sp = (struct iperf_stream *)malloc(sizeof(struct iperf_stream));
 	if (!sp) {
 		i_errno = IECREATESTREAM;

--- a/apps/system/iperf/iperf_client_api.c
+++ b/apps/system/iperf/iperf_client_api.c
@@ -296,7 +296,7 @@ int iperf_handle_message_client(struct iperf_test *test)
 			i_errno = IECTRLREAD;
 			return -1;
 		}
-		errno = ntohl(err);
+		set_errno(ntohl(err));
 		return -1;
 	default:
 		i_errno = IEMESSAGE;
@@ -403,7 +403,7 @@ int iperf_run_client(struct iperf_test *test)
 		(void)gettimeofday(&now, NULL);
 		timeout = tmr_timeout(&now);
 		result = select(test->max_fd + 1, &read_set, &write_set, NULL, timeout);
-		if (result < 0 && errno != EINTR) {
+		if (result < 0 && get_errno() != EINTR) {
 			i_errno = IESELECT;
 			return -1;
 		}

--- a/apps/system/iperf/iperf_net.c
+++ b/apps/system/iperf/iperf_net.c
@@ -128,7 +128,7 @@ int netdial(int domain, int proto, char *local, int local_port, char *server, in
 	}
 
 	((struct sockaddr_in *)server_res->ai_addr)->sin_port = htons(port);
-	if (connect(s, (struct sockaddr *)server_res->ai_addr, server_res->ai_addrlen) < 0 && errno != EINPROGRESS) {
+	if (connect(s, (struct sockaddr *)server_res->ai_addr, server_res->ai_addrlen) < 0 && get_errno() != EINPROGRESS) {
 		close(s);
 		freeaddrinfo(server_res);
 		return -1;
@@ -238,7 +238,8 @@ int Nread(int fd, char *buf, size_t count, int prot)
 	while (nleft > 0) {
 		r = read(fd, buf, nleft);
 		if (r < 0) {
-			if (errno == EINTR || errno == EAGAIN || errno == EWOULDBLOCK) {
+			int errcode = get_errno();
+			if (errcode == EINTR || errcode == EAGAIN || errcode == EWOULDBLOCK) {
 				break;
 			} else {
 				return NET_HARDERROR;
@@ -265,7 +266,7 @@ int Nwrite(int fd, const char *buf, size_t count, int prot)
 	while (nleft > 0) {
 		r = write(fd, buf, nleft);
 		if (r < 0) {
-			switch (errno) {
+			switch (get_errno()) {
 			case EINTR:
 			case EAGAIN:
 #if (EAGAIN != EWOULDBLOCK)
@@ -331,10 +332,10 @@ int Nsendfile(int fromfd, int tofd, const char *buf, size_t count)
 #else
 		/* Shouldn't happen. */
 		r = -1;
-		errno = ENOSYS;
+		set_errno(ENOSYS);
 #endif
 		if (r < 0) {
-			switch (errno) {
+			switch (get_errno()) {
 			case EINTR:
 			case EAGAIN:
 #if (EAGAIN != EWOULDBLOCK)
@@ -361,7 +362,7 @@ int Nsendfile(int fromfd, int tofd, const char *buf, size_t count)
 	}
 	return count;
 #else							/* HAVE_SENDFILE */
-	errno = ENOSYS;				/* error if somehow get called without HAVE_SENDFILE */
+	set_errno(ENOSYS);				/* error if somehow get called without HAVE_SENDFILE */
 	return NET_HARDERROR;
 #endif							/* HAVE_SENDFILE */
 }

--- a/apps/system/iperf/iperf_tcp.c
+++ b/apps/system/iperf/iperf_tcp.c
@@ -203,10 +203,10 @@ int iperf_tcp_listen(struct iperf_test *test)
 		if (test->no_delay) {
 			opt = 1;
 			if (setsockopt(s, IPPROTO_TCP, TCP_NODELAY, &opt, sizeof(opt)) < 0) {
-				saved_errno = errno;
+				saved_errno = get_errno();
 				close(s);
 				freeaddrinfo(res);
-				errno = saved_errno;
+				set_errno(saved_errno);
 				i_errno = IESETNODELAY;
 				return -1;
 			}
@@ -215,10 +215,10 @@ int iperf_tcp_listen(struct iperf_test *test)
 		// XXX: Setting MSS is very buggy!
 		if ((opt = test->settings->mss)) {
 			if (setsockopt(s, IPPROTO_TCP, TCP_MAXSEG, &opt, sizeof(opt)) < 0) {
-				saved_errno = errno;
+				saved_errno = get_errno();
 				close(s);
 				freeaddrinfo(res);
-				errno = saved_errno;
+				set_errno(saved_errno);
 				i_errno = IESETMSS;
 				return -1;
 			}
@@ -226,18 +226,18 @@ int iperf_tcp_listen(struct iperf_test *test)
 #endif
 		if ((opt = test->settings->socket_bufsize)) {
 			if (setsockopt(s, SOL_SOCKET, SO_RCVBUF, &opt, sizeof(opt)) < 0) {
-				saved_errno = errno;
+				saved_errno = get_errno();
 				close(s);
 				freeaddrinfo(res);
-				errno = saved_errno;
+				set_errno(saved_errno);
 				i_errno = IESETBUF;
 				return -1;
 			}
 			if (setsockopt(s, SOL_SOCKET, SO_SNDBUF, &opt, sizeof(opt)) < 0) {
-				saved_errno = errno;
+				saved_errno = get_errno();
 				close(s);
 				freeaddrinfo(res);
-				errno = saved_errno;
+				set_errno(saved_errno);
 				i_errno = IESETBUF;
 				return -1;
 			}
@@ -245,10 +245,10 @@ int iperf_tcp_listen(struct iperf_test *test)
 		if (test->debug) {
 			socklen_t optlen = sizeof(opt);
 			if (getsockopt(s, SOL_SOCKET, SO_SNDBUF, &opt, &optlen) < 0) {
-				saved_errno = errno;
+				saved_errno = get_errno();
 				close(s);
 				freeaddrinfo(res);
-				errno = saved_errno;
+				set_errno(saved_errno);
 				i_errno = IESETBUF;
 				return -1;
 			}
@@ -282,10 +282,10 @@ int iperf_tcp_listen(struct iperf_test *test)
 #endif							/* HAVE_SO_MAX_PACING_RATE */
 		opt = 1;
 		if (setsockopt(s, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt)) < 0) {
-			saved_errno = errno;
+			saved_errno = get_errno();
 			close(s);
 			freeaddrinfo(res);
-			errno = saved_errno;
+			set_errno(saved_errno);
 			i_errno = IEREUSEADDR;
 			return -1;
 		}
@@ -303,10 +303,10 @@ int iperf_tcp_listen(struct iperf_test *test)
 				opt = 1;
 			}
 			if (setsockopt(s, IPPROTO_IPV6, IPV6_V6ONLY, (char *)&opt, sizeof(opt)) < 0) {
-				saved_errno = errno;
+				saved_errno = get_errno();
 				close(s);
 				freeaddrinfo(res);
-				errno = saved_errno;
+				set_errno(saved_errno);
 				i_errno = IEV6ONLY;
 				return -1;
 			}
@@ -314,10 +314,10 @@ int iperf_tcp_listen(struct iperf_test *test)
 #endif							/* IPV6_V6ONLY */
 
 		if (bind(s, (struct sockaddr *)res->ai_addr, res->ai_addrlen) < 0) {
-			saved_errno = errno;
+			saved_errno = get_errno();
 			close(s);
 			freeaddrinfo(res);
-			errno = saved_errno;
+			set_errno(saved_errno);
 			i_errno = IESTREAMLISTEN;
 			return -1;
 		}
@@ -388,11 +388,11 @@ int iperf_tcp_connect(struct iperf_test *test)
 		local_res->ai_addr = (struct sockaddr *)lcladdr;
 
 		if (bind(s, (struct sockaddr *)local_res->ai_addr, local_res->ai_addrlen) < 0) {
-			saved_errno = errno;
+			saved_errno = get_errno();
 			close(s);
 			freeaddrinfo(local_res);
 			freeaddrinfo(server_res);
-			errno = saved_errno;
+			set_errno(saved_errno);
 			i_errno = IESTREAMCONNECT;
 			return -1;
 		}
@@ -403,10 +403,10 @@ int iperf_tcp_connect(struct iperf_test *test)
 	if (test->no_delay) {
 		opt = 1;
 		if (setsockopt(s, IPPROTO_TCP, TCP_NODELAY, &opt, sizeof(opt)) < 0) {
-			saved_errno = errno;
+			saved_errno = get_errno();
 			close(s);
 			freeaddrinfo(server_res);
-			errno = saved_errno;
+			set_errno(saved_errno);
 			i_errno = IESETNODELAY;
 			return -1;
 		}
@@ -414,10 +414,10 @@ int iperf_tcp_connect(struct iperf_test *test)
 #if defined(HAVE_TCP_MAXSEG)
 	if ((opt = test->settings->mss)) {
 		if (setsockopt(s, IPPROTO_TCP, TCP_MAXSEG, &opt, sizeof(opt)) < 0) {
-			saved_errno = errno;
+			saved_errno = get_errno();
 			close(s);
 			freeaddrinfo(server_res);
-			errno = saved_errno;
+			set_errno(saved_errno);
 			i_errno = IESETMSS;
 			return -1;
 		}
@@ -425,18 +425,18 @@ int iperf_tcp_connect(struct iperf_test *test)
 #endif
 	if ((opt = test->settings->socket_bufsize)) {
 		if (setsockopt(s, SOL_SOCKET, SO_RCVBUF, &opt, sizeof(opt)) < 0) {
-			saved_errno = errno;
+			saved_errno = get_errno();
 			close(s);
 			freeaddrinfo(server_res);
-			errno = saved_errno;
+			set_errno(saved_errno);
 			i_errno = IESETBUF;
 			return -1;
 		}
 		if (setsockopt(s, SOL_SOCKET, SO_SNDBUF, &opt, sizeof(opt)) < 0) {
-			saved_errno = errno;
+			saved_errno = get_errno();
 			close(s);
 			freeaddrinfo(server_res);
-			errno = saved_errno;
+			set_errno(saved_errno);
 			i_errno = IESETBUF;
 			return -1;
 		}
@@ -444,10 +444,10 @@ int iperf_tcp_connect(struct iperf_test *test)
 	if (test->debug) {
 		socklen_t optlen = sizeof(opt);
 		if (getsockopt(s, SOL_SOCKET, SO_SNDBUF, &opt, &optlen) < 0) {
-			saved_errno = errno;
+			saved_errno = get_errno();
 			close(s);
 			freeaddrinfo(server_res);
-			errno = saved_errno;
+			set_errno(saved_errno);
 			i_errno = IESETBUF;
 			return -1;
 		}
@@ -456,10 +456,10 @@ int iperf_tcp_connect(struct iperf_test *test)
 #if defined(HAVE_FLOWLABEL)
 	if (test->settings->flowlabel) {
 		if (server_res->ai_addr->sa_family != AF_INET6) {
-			saved_errno = errno;
+			saved_errno = get_errno();
 			close(s);
 			freeaddrinfo(server_res);
-			errno = saved_errno;
+			set_errno(saved_errno);
 			i_errno = IESETFLOW;
 			return -1;
 		} else {
@@ -476,10 +476,10 @@ int iperf_tcp_connect(struct iperf_test *test)
 			memcpy(&freq->flr_dst, &sa6P->sin6_addr, 16);
 
 			if (setsockopt(s, IPPROTO_IPV6, IPV6_FLOWLABEL_MGR, freq, freq_len) < 0) {
-				saved_errno = errno;
+				saved_errno = get_errno();
 				close(s);
 				freeaddrinfo(server_res);
-				errno = saved_errno;
+				set_errno(saved_errno);
 				i_errno = IESETFLOW;
 				return -1;
 			}
@@ -487,10 +487,10 @@ int iperf_tcp_connect(struct iperf_test *test)
 
 			opt = 1;
 			if (setsockopt(s, IPPROTO_IPV6, IPV6_FLOWINFO_SEND, &opt, sizeof(opt)) < 0) {
-				saved_errno = errno;
+				saved_errno = get_errno();
 				close(s);
 				freeaddrinfo(server_res);
-				errno = saved_errno;
+				set_errno(saved_errno);
 				i_errno = IESETFLOW;
 				return -1;
 			}
@@ -527,10 +527,10 @@ int iperf_tcp_connect(struct iperf_test *test)
 #endif							/* HAVE_SO_MAX_PACING_RATE */
 
 	if (connect(s, (struct sockaddr *)server_res->ai_addr, server_res->ai_addrlen) < 0 && errno != EINPROGRESS) {
-		saved_errno = errno;
+		saved_errno = get_errno();
 		close(s);
 		freeaddrinfo(server_res);
-		errno = saved_errno;
+		set_errno(saved_errno);
 		i_errno = IESTREAMCONNECT;
 		return -1;
 	}
@@ -539,9 +539,9 @@ int iperf_tcp_connect(struct iperf_test *test)
 
 	/* Send cookie for verification */
 	if (Nwrite(s, test->cookie, COOKIE_SIZE, Ptcp) < 0) {
-		saved_errno = errno;
+		saved_errno = get_errno();
 		close(s);
-		errno = saved_errno;
+		set_errno(saved_errno);
 		i_errno = IESENDCOOKIE;
 		return -1;
 	}


### PR DESCRIPTION
- Use set/get_errno() APIs instead of direct access