### PR TITLE
kernel: add a BINARY_MANAGER dependency in USERMAIN_STACKSIZE

### DIFF
--- a/os/kernel/Kconfig
+++ b/os/kernel/Kconfig
@@ -1112,6 +1112,7 @@ config IDLETHREAD_STACKSIZE
 config USERMAIN_STACKSIZE
 	int "Main thread stack size"
 	default 2048
+	depends on !BINARY_MANAGER
 	---help---
 		The size of the stack to allocate for the user initialization thread
 		that is started as soon as the OS completes its initialization.


### PR DESCRIPTION
Under APP_BINARY_SEPARATION and BINARY_MANAGER conditionals,
user main task is not launching from os_bringup. so that
USERMAIN_STACKSIZE is not necessary.
This commit makes it disapeared under conditionals above.

Signed-off-by: sunghan-chang <sh924.chang@samsung.com>