### PR TITLE
kernel/sched: Remove resources in RAM partition to be unloaded from a list of delayed free before unloading

### DIFF
--- a/os/binfmt/binfmt_loadbinary.c
+++ b/os/binfmt/binfmt_loadbinary.c
@@ -120,6 +120,7 @@ int load_binary(FAR const char *filename, load_attr_t *load_attr)
 	bin->priority = load_attr->priority;
 #ifdef CONFIG_APP_BINARY_SEPARATION
 	bin->uheap = (struct mm_heap_s *)start_addr;
+	bin->uheap_size = size;
 #endif
 	bin->compression_type = load_attr->compression_type;
 

--- a/os/include/tinyara/binfmt/binfmt.h
+++ b/os/include/tinyara/binfmt/binfmt.h
@@ -99,6 +99,7 @@ struct binary_s {
 
 #ifdef CONFIG_APP_BINARY_SEPARATION
 	struct mm_heap_s *uheap;	/* User heap pointer to allocate memory for sections */
+	uint32_t uheap_size;		/* The size of user heap */
 #endif
 
 #if defined(CONFIG_ARCH_ADDRENV) && defined(CONFIG_BUILD_KERNEL)

--- a/os/include/tinyara/sched.h
+++ b/os/include/tinyara/sched.h
@@ -504,6 +504,10 @@ struct task_group_s {
 };
 #endif
 
+#ifdef CONFIG_BINFMT_LOADABLE
+#define IS_LOADED_MODULE(group)    (group->tg_bininfo != NULL)   /* Points loading data if it is loaded */
+#endif
+
 /* struct tcb_s ******************************************************************/
 
 FAR struct wdog_s;				/* Forward reference                   */


### PR DESCRIPTION
When binary manager terminates task/pthreads for update or recovery, it doesn't need to free resources in user memory.
That's because user RAM partition is freed when main task is unloaded in binary separation.