### PR TITLE
kernel/binary_manager: Set the size for each partition in binary table

### DIFF
--- a/os/include/tinyara/binary_manager.h
+++ b/os/include/tinyara/binary_manager.h
@@ -116,6 +116,13 @@ struct binary_info_s {
 };
 typedef struct binary_info_s binary_info_t;
 
+/* The sturcture of partition information */
+struct part_info_s {
+	uint32_t part_size;         /* Partition size */
+	int8_t part_num;            /* Partition number */
+};
+typedef struct part_info_s part_info_t;
+
 /* The structure of load attr configuration */
 struct load_attr_s {
 	uint32_t bin_size;			/* The size of ELF binary to be loaded */

--- a/os/kernel/binary_manager/binary_manager.c
+++ b/os/kernel/binary_manager/binary_manager.c
@@ -75,15 +75,15 @@ void binary_manager_register_partition(int part_num, int part_type, char *name, 
 	if (part_type == BINMGR_PART_LOADPARAM) {
 		g_loadparam_part = part_num;
 	} else if (part_type == BINMGR_PART_KERNEL) {
-		if (BIN_PARTSIZE(KERNEL_IDX) > 0) {
+		if (BIN_PARTSIZE(KERNEL_IDX, 0) > 0) {
 			/* Already registered first kernel partition, register it as second partition. */
+			BIN_PARTSIZE(KERNEL_IDX, 1) = part_size;
 			BIN_PARTNUM(KERNEL_IDX, 1) = part_num;
 		} else {
 			BIN_USEIDX(KERNEL_IDX) = 0;
 			BIN_STATE(KERNEL_IDX) = BINARY_RUNNING;
 			BIN_PARTNUM(KERNEL_IDX, 0) = part_num;
-			BIN_PARTNUM(KERNEL_IDX, 1) = -1;
-			BIN_PARTSIZE(KERNEL_IDX) = part_size;
+			BIN_PARTSIZE(KERNEL_IDX, 0) = part_size;
 			strncpy(BIN_VER(KERNEL_IDX), KERNEL_VER, KERNEL_VER_MAX);
 			strncpy(BIN_KERNEL_VER(KERNEL_IDX), KERNEL_VER, KERNEL_VER_MAX);
 			strncpy(BIN_NAME(KERNEL_IDX), "kernel", BIN_NAME_MAX);
@@ -95,7 +95,8 @@ void binary_manager_register_partition(int part_num, int part_type, char *name, 
 			/* Found in the list, then register it as second partition */
 			if (!strncmp(BIN_NAME(bin_idx), name, strlen(name) + 1)) {
 				BIN_PARTNUM(bin_idx, 1) = part_num;
-				bmvdbg("[USER2 : %d] %s %d %d \n", bin_idx, BIN_NAME(bin_idx), BIN_PARTNUM(bin_idx, 0), BIN_PARTNUM(bin_idx, 1));
+				BIN_PARTSIZE(bin_idx, 1) = part_size;
+				bmvdbg("[USER%d : 2] %s size %d num %d\n", bin_idx, BIN_NAME(bin_idx), BIN_PARTSIZE(bin_idx, 1), BIN_PARTNUM(bin_idx, 1));
 				return;
 			}
 		}
@@ -104,11 +105,10 @@ void binary_manager_register_partition(int part_num, int part_type, char *name, 
 		BIN_ID(g_bin_count) = -1;
 		BIN_STATE(g_bin_count) = BINARY_INACTIVE;
 		BIN_PARTNUM(g_bin_count, 0) = part_num;
-		BIN_PARTNUM(g_bin_count, 1) = -1;
-		BIN_PARTSIZE(g_bin_count) = part_size;
+		BIN_PARTSIZE(g_bin_count, 0) = part_size;
 		strncpy(BIN_NAME(g_bin_count), name, BIN_NAME_MAX);
 		sq_init(&BIN_CBLIST(g_bin_count));
-		bmvdbg("[USER1 : %d] %s size %d %d \n", g_bin_count, BIN_NAME(g_bin_count), BIN_PARTSIZE(g_bin_count), BIN_PARTNUM(g_bin_count, 0));
+		bmvdbg("[USER%d : 1] %s size %d num %d\n", g_bin_count, BIN_NAME(g_bin_count), BIN_PARTSIZE(g_bin_count, 0), BIN_PARTNUM(g_bin_count, 0));
 	}
 }
 

--- a/os/kernel/binary_manager/binary_manager.h
+++ b/os/kernel/binary_manager/binary_manager.h
@@ -87,9 +87,8 @@ struct binmgr_bininfo_s {
 	pid_t bin_id;
 	uint8_t state;
 	uint8_t inuse_idx;
-	uint32_t part_size;
 	load_attr_t load_attr;
-	int8_t part_num[PARTS_PER_BIN];
+	part_info_t part_info[PARTS_PER_BIN];
 	char name[BIN_NAME_MAX];
 	char bin_ver[BIN_VER_MAX];
 	char kernel_ver[KERNEL_VER_MAX];
@@ -107,8 +106,8 @@ typedef struct statecb_node_s statecb_node_t;
 #define BIN_ID(bin_idx)                                 bin_table[bin_idx].bin_id
 #define BIN_STATE(bin_idx)                              bin_table[bin_idx].state
 #define BIN_USEIDX(bin_idx)                             bin_table[bin_idx].inuse_idx
-#define BIN_PARTSIZE(bin_idx)                           bin_table[bin_idx].part_size
-#define BIN_PARTNUM(bin_idx, part_idx)                  bin_table[bin_idx].part_num[part_idx]
+#define BIN_PARTSIZE(bin_idx, part_idx)                 bin_table[bin_idx].part_info[part_idx].part_size
+#define BIN_PARTNUM(bin_idx, part_idx)                  bin_table[bin_idx].part_info[part_idx].part_num
 
 #define BIN_NAME(bin_idx)                               bin_table[bin_idx].name
 #define BIN_VER(bin_idx)                                bin_table[bin_idx].bin_ver

--- a/os/kernel/binary_manager/binary_manager_getinfo.c
+++ b/os/kernel/binary_manager/binary_manager_getinfo.c
@@ -106,7 +106,7 @@ int binary_manager_get_info_with_name(int requester_pid, char *bin_name)
 	for (bin_idx = 0; bin_idx <= bin_count; bin_idx++) {
 		if (!strncmp(BIN_NAME(bin_idx), bin_name, BIN_NAME_MAX)) {
 			response_msg.result = BINMGR_OK;
-			response_msg.data.part_size = BIN_PARTSIZE(bin_idx);
+			response_msg.data.part_size = BIN_PARTSIZE(bin_idx, (BIN_USEIDX(bin_idx) ^ 1));
 			strncpy(response_msg.data.name, BIN_NAME(bin_idx) , BIN_NAME_MAX);
 			strncpy(response_msg.data.version, BIN_VER(bin_idx), BIN_VER_MAX);
 			if (BIN_PARTNUM(bin_idx, (BIN_USEIDX(bin_idx) ^ 1)) != -1) {
@@ -138,7 +138,7 @@ int binary_manager_get_info_all(int requester_pid)
 	bin_count = binary_manager_get_binary_count();
 	if (bin_count > 0) {
 		for (bin_idx = 0; bin_idx < bin_count + 1; bin_idx++) {
-			response_msg.data.bin_info[bin_idx].part_size = BIN_PARTSIZE(bin_idx);
+			response_msg.data.bin_info[bin_idx].part_size = BIN_PARTSIZE(bin_idx, (BIN_USEIDX(bin_idx) ^ 1));
 			strncpy(response_msg.data.bin_info[bin_idx].name, BIN_NAME(bin_idx) , BIN_NAME_MAX);
 			strncpy(response_msg.data.bin_info[bin_idx].version, BIN_VER(bin_idx), BIN_VER_MAX);
 			if (BIN_PARTNUM(bin_idx, (BIN_USEIDX(bin_idx) ^ 1)) != -1) {


### PR DESCRIPTION
User can set the different size for each partition.