### PR TITLE
nxp/config: fix configuration

### DIFF
--- a/build/configs/imxrt1020-evk/loadable_elf_apps/defconfig
+++ b/build/configs/imxrt1020-evk/loadable_elf_apps/defconfig
@@ -1341,3 +1341,4 @@ CONFIG_IOTBUS_ADC=y
 # Security Framework
 #
 # CONFIG_SECURITY_API is not set
+CONFIG_PROD_HEADER="prod/fac.h"

--- a/build/configs/imxrt1020-evk/nxp_demo/defconfig
+++ b/build/configs/imxrt1020-evk/nxp_demo/defconfig
@@ -929,3 +929,4 @@ CONFIG_ENABLE_UPTIME=y
 # Security Framework
 #
 # CONFIG_SECURITY_API is not set
+CONFIG_PROD_HEADER="prod/fac.h"

--- a/build/configs/imxrt1050-evk/nxp_demo/defconfig
+++ b/build/configs/imxrt1050-evk/nxp_demo/defconfig
@@ -1256,3 +1256,4 @@ CONFIG_IOTBUS_ADC=y
 # Security Framework
 #
 # CONFIG_SECURITY_API is not set
+CONFIG_PROD_HEADER="prod/fac.h"


### PR DESCRIPTION
if CONFIG_PROD_HEADER is not defined then it'll cause the build error