### PR TITLE
framework/media: Fix logic when playback is finish

### DIFF
--- a/framework/src/media/MediaPlayerImpl.h
+++ b/framework/src/media/MediaPlayerImpl.h
@@ -124,6 +124,7 @@ private:
 	void unpreparePlayer(player_result_t &ret);
 	void startPlayer();
 	void stopPlayer(player_result_t ret);
+	player_result_t stopPlayback();
 	void pausePlayer();
 	void getPlayerVolume(uint8_t *vol, player_result_t &ret);
 	void getPlayerMaxVolume(uint8_t *vol, player_result_t &ret);


### PR DESCRIPTION
Don't call stop at the playback finish time to prevent
playback_stopped and playback_finished callback from being called
together.