### PR TITLE
libc/time: fix wrong calculation and remove unnecessary codes

### DIFF
--- a/lib/libc/time/lib_calendar2utc.c
+++ b/lib/libc/time/lib_calendar2utc.c
@@ -199,7 +199,7 @@ time_t clock_calendar2utc(int year, int month, int day)
 
 	/* Add in the extra days for the leap years prior to the current year. */
 
-	days += (year - EPOCH_YEAR - 1) >> 2;
+	days += (year - (EPOCH_YEAR - 1)) >> 2;
 
 	/* Add in the days up to the beginning of this month. */
 

--- a/lib/libc/time/lib_mktime.c
+++ b/lib/libc/time/lib_mktime.c
@@ -101,7 +101,6 @@
  *
  ****************************************************************************/
 
-#ifdef CONFIG_GREGORIAN_TIME
 time_t mktime(FAR struct tm *tp)
 {
 	time_t ret;
@@ -111,7 +110,7 @@ time_t mktime(FAR struct tm *tp)
 	 * month, and date
 	 */
 
-	jdn = clock_calendar2utc(tp->tm_year + TM_YEAR_BASE, tp->tm_mon + 1, tp->tm_mday);
+	jdn = clock_calendar2utc(tp->tm_year + TM_YEAR_BASE, tp->tm_mon, tp->tm_mday);
 	svdbg("jdn=%d tm_year=%d tm_mon=%d tm_mday=%d\n", (int)jdn, tp->tm_year, tp->tm_mon, tp->tm_mday);
 
 	/* Return the seconds into the julian day. */
@@ -121,35 +120,3 @@ time_t mktime(FAR struct tm *tp)
 
 	return ret;
 }
-#else
-
-/* Simple version that only works for dates within a (relatively) small range
- * from the epoch.  It does not handle earlier days or longer days where leap
- * seconds, etc. apply.
- */
-
-time_t mktime(FAR struct tm *tp)
-{
-	unsigned int days;
-
-	/* Years since epoch in units of days (ignoring leap years). */
-
-	days = (tp->tm_year - 70) * 365;
-
-	/* Add in the extra days for the leap years prior to the current year. */
-
-	days += (tp->tm_year - 69) >> 2;
-
-	/* Add in the days up to the beginning of this month. */
-
-	days += (time_t)clock_daysbeforemonth(tp->tm_mon, clock_isleapyear(tp->tm_year + TM_YEAR_BASE));
-
-	/* Add in the days since the beginning of this month (days are 1-based). */
-
-	days += tp->tm_mday - 1;
-
-	/* Then convert the seconds and add in hours, minutes, and seconds */
-
-	return ((days * 24 + tp->tm_hour) * 60 + tp->tm_min) * 60 + tp->tm_sec;
-}
-#endif							/* CONFIG_GREGORIAN_TIME */


### PR DESCRIPTION
1. fix wrong calculation of month in mktime()
 The month index starts from 0, not from 1 so that
mktime has not to add 1 for clock_calendar2utc().

2. remove unncessary codes for mktime()
 There are two mktime() functions with CONFIG_GREGORIAN_TIME.
 But they are same so that let's remove one.

3. fix wrong calculation of leap year in clock_calendar2utc
 To calculate the days of leap years, it has to subtract 1969
 from year value. But it misses ( ) so that it does 1971.

Signed-off-by: sunghan-chang <sh924.chang@samsung.com>