### PR TITLE
[DO NOT MERGE] Provide read permission to App for GPT register area 

### DIFF
--- a/os/arch/arm/src/armv7-m/mpu-reg.h
+++ b/os/arch/arm/src/armv7-m/mpu-reg.h
@@ -46,6 +46,7 @@ enum {
 	MPU_REG_USER_DATA,
 #endif
 	MPU_REG_APP,
+	MPU_REG_APP_PERIPH_RO,
 };
 
 #ifndef __ASSEMBLY__

--- a/os/arch/arm/src/imxrt/imxrt_mpuinit.c
+++ b/os/arch/arm/src/imxrt/imxrt_mpuinit.c
@@ -91,6 +91,10 @@ const struct mpu_region_info regions_info[] = {
 		&mpu_userintsram, (uintptr_t)__usram_segment_start__, (uintptr_t)__usram_segment_size__, MPU_REG_USER_DATA,
 	},
 #endif
+	{
+		&mpu_peripheral_user, (uintptr_t)IMXRT_GPT1_BASE, (uintptr_t)(32*1024), MPU_REG_APP_PERIPH_RO,
+	},
+
 };
 #endif
 


### PR DESCRIPTION
Since GPT register access through ioctl is taking more time, we are
provideing RO access permission for app to directly access the GPT
registers. This results in addition of a new region in the MPU. All
applications will have RO permission to access the GPT registers.

Signed-off-by: Kishore SN <kishore.sn@samsung.com>