### PR TITLE
build/tools: Remove erase entire flash command.

### DIFF
--- a/build/tools/esp32/esptool_py/Makefile
+++ b/build/tools/esp32/esptool_py/Makefile
@@ -74,7 +74,7 @@ $(APP_BIN_UNSIGNED): $(APP_ELF) $(ESPTOOLPY_SRC)
 
 ESPTOOL_ALL_FLASH_ARGS += $(ESPTOOL_BOOTLOADER_FLASH_ARGS)
 
-ALL:erase_flash flash romfs
+ALL: flash romfs
 
 OS:app-flash
 


### PR DESCRIPTION
Remove erase entire flash command before downloading all images,
as it will take side effect for applications involves SPIRAM.