### PR TITLE
framework/task_manager : Move task manager creation to preapp

### DIFF
--- a/apps/system/init/init.c
+++ b/apps/system/init/init.c
@@ -36,6 +36,9 @@
 #ifdef CONFIG_SYSTEM_INFORMATION
 #include <apps/system/sysinfo.h>
 #endif
+#ifdef CONFIG_TASK_MANAGER
+#include <tinyara/init.h>
+#endif
 #ifdef CONFIG_EVENTLOOP
 #include <tinyara/eventloop.h>
 #endif
@@ -100,7 +103,7 @@ int main(int argc, FAR char *argv[])
 int preapp_start(int argc, char *argv[])
 #endif
 {
-#if defined(CONFIG_LIB_USRWORK) || defined(CONFIG_TASH) || defined(CONFIG_EVENTLOOP)
+#if defined(CONFIG_LIB_USRWORK) || defined(CONFIG_TASH) || defined(CONFIG_EVENTLOOP) || defined(CONFIG_TASK_MANAGER)
 	int pid;
 #endif
 #if defined(CONFIG_MEDIA)
@@ -129,6 +132,17 @@ int preapp_start(int argc, char *argv[])
 	}
 
 	tash_register_cmds();
+#endif
+
+#ifdef CONFIG_TASK_MANAGER
+#define TASKMGR_STACK_SIZE 2048
+#define TASKMGR_PRIORITY 200
+	printf("Starting task manager\n");
+
+	pid = task_create("task_manager", TASKMGR_PRIORITY, TASKMGR_STACK_SIZE, task_manager, (FAR char *const *)NULL);
+	if (pid < 0) {
+		svdbg("Failed to create Task Manager\n");
+	}
 #endif
 
 #ifdef CONFIG_EVENTLOOP

--- a/os/kernel/init/os_bringup.c
+++ b/os/kernel/init/os_bringup.c
@@ -83,6 +83,9 @@
 #ifdef CONFIG_PAGING
 #include "paging/paging.h"
 #endif
+#ifdef CONFIG_BINARY_MANAGER
+#include "binary_manager/binary_manager.h"
+#endif
 
 /****************************************************************************
  * Pre-processor Definitions
@@ -253,16 +256,9 @@ static inline void os_do_appstart(void)
 	net_initialize();
 #endif
 
-	/* Start the application initialization task.  In a flat build, this is
-	 * entrypoint is given by the definitions, CONFIG_USER_ENTRYPOINT.  In
-	 * the protected build, however, we must get the address of the
-	 * entrypoint from the header at the beginning of the user-space blob.
-	 */
+#if defined(CONFIG_SYSTEM_PREAPP_INIT) && !defined(CONFIG_APP_BINARY_SEPARATION)
+	svdbg("Starting application init task\n");
 
-	svdbg("Starting application init thread\n");
-
-
-#ifdef CONFIG_SYSTEM_PREAPP_INIT
 #ifdef CONFIG_BUILD_PROTECTED
 	DEBUGASSERT(USERSPACE->preapp_start != NULL);
 	pid = task_create("appinit", SCHED_PRIORITY_DEFAULT, CONFIG_SYSTEM_PREAPP_STACKSIZE, USERSPACE->preapp_start, (FAR char *const *)NULL);
@@ -274,23 +270,32 @@ static inline void os_do_appstart(void)
 	}
 #endif
 
+#ifdef CONFIG_BINARY_MANAGER
+	svdbg("Starting binary manager thread\n");
+
+	pid = kernel_thread(BINARY_MANAGER_NAME, BINARY_MANAGER_PRIORITY, BINARY_MANAGER_STACKSIZE, binary_manager, NULL);
+	if (pid < 0) {
+		sdbg("Failed to start binary manager");
+	}
+#endif
+
 #ifdef CONFIG_ENABLE_HEAPINFO
 	heapinfo_drv_register();
 #endif
 
 #ifdef CONFIG_TASK_MANAGER
-#define TASKMGR_STACK_SIZE 2048
-#define TASKMGR_PRIORITY 200
-
-	svdbg("Starting task manager\n");
 	task_manager_drv_register();
-
-	pid = task_create("task_manager", TASKMGR_PRIORITY, TASKMGR_STACK_SIZE, task_manager, (FAR char *const *)NULL);
-	if (pid < 0) {
-		svdbg("Failed to create Task Manager\n");
-	}
 #endif
-	svdbg("Starting application main thread\n");
+
+#if !defined(CONFIG_BINARY_MANAGER)
+	/* Start the application initialization task.  In a flat build, this is
+	 * entrypoint is given by the definitions, CONFIG_USER_ENTRYPOINT.  In
+	 * the protected build, however, we must get the address of the
+	 * entrypoint from the header at the beginning of the user-space blob.
+	 */
+
+	svdbg("Starting application main task\n");
+
 #ifdef CONFIG_BUILD_PROTECTED
 	if (USERSPACE->us_entrypoint != NULL) {
 		pid = task_create("appmain", SCHED_PRIORITY_DEFAULT, CONFIG_USERMAIN_STACKSIZE, USERSPACE->us_entrypoint, (FAR char *const *)NULL);
@@ -298,6 +303,8 @@ static inline void os_do_appstart(void)
 #elif defined(CONFIG_USER_ENTRYPOINT)
 	pid = task_create("appmain", SCHED_PRIORITY_DEFAULT, CONFIG_USERMAIN_STACKSIZE, (main_t)CONFIG_USER_ENTRYPOINT, (FAR char *const *)NULL);
 #endif
+#endif // !CONFIG_BINARY_MANAGER
+
 	ASSERT(pid > 0);
 }
 


### PR DESCRIPTION
The creation of task manager is not the kernel role, so moved to preapp.