### PR TITLE
framework/task_manager : Move task manager creation to preapp

### DIFF
--- a/apps/system/init/init.c
+++ b/apps/system/init/init.c
@@ -36,6 +36,9 @@
 #ifdef CONFIG_SYSTEM_INFORMATION
 #include <apps/system/sysinfo.h>
 #endif
+#ifdef CONFIG_TASK_MANAGER
+#include <task_manager/task_manager.h>
+#endif
 #ifdef CONFIG_EVENTLOOP
 #include <tinyara/eventloop.h>
 #endif
@@ -100,7 +103,7 @@ int main(int argc, FAR char *argv[])
 int preapp_start(int argc, char *argv[])
 #endif
 {
-#if defined(CONFIG_LIB_USRWORK) || defined(CONFIG_TASH) || defined(CONFIG_EVENTLOOP)
+#if defined(CONFIG_LIB_USRWORK) || defined(CONFIG_TASH) || defined(CONFIG_EVENTLOOP) || defined(CONFIG_TASK_MANAGER)
 	int pid;
 #endif
 #if defined(CONFIG_MEDIA)
@@ -131,6 +134,16 @@ int preapp_start(int argc, char *argv[])
 	tash_register_cmds();
 #endif
 
+#ifdef CONFIG_TASK_MANAGER
+#define TASKMGR_STACK_SIZE 2048
+#define TASKMGR_PRIORITY 200
+	pid = task_create("task_manager", TASKMGR_PRIORITY, TASKMGR_STACK_SIZE, task_manager, (FAR char *const *)NULL);
+	if (pid < 0) {
+		printf("Failed to create Task Manager\n");
+		goto error_out;
+	}
+#endif
+
 #ifdef CONFIG_EVENTLOOP
 	pid = eventloop_task_start();
 	if (pid <= 0) {
@@ -147,7 +160,7 @@ int preapp_start(int argc, char *argv[])
 	}
 #endif
 
-#if defined(CONFIG_LIB_USRWORK) || defined(CONFIG_TASH) || defined(CONFIG_EVENTLOOP)
+#if defined(CONFIG_LIB_USRWORK) || defined(CONFIG_TASH) || defined(CONFIG_EVENTLOOP) || defined(CONFIG_TASK_MANAGER)
 error_out:
 	return pid;
 #else

--- a/framework/include/task_manager/task_manager.h
+++ b/framework/include/task_manager/task_manager.h
@@ -157,6 +157,13 @@ extern "C" {
  * Public Function Prototypes
  ****************************************************************************/
 /**
+ * @cond
+ * @internal
+ * @brief Task Manager Main Thread
+ * @endcond
+ */
+int task_manager(int argc, char *argv[]);
+/**
  * @brief Request to register a built-in task
  * @details @b #include <task_manager/task_manager.h>\n
  * This API can request to register a built-in task.\n

--- a/os/include/tinyara/init.h
+++ b/os/include/tinyara/init.h
@@ -82,9 +82,6 @@ extern "C" {
 
 int CONFIG_USER_ENTRYPOINT(int argc, char *argv[]);
 int preapp_start(int argc, char *argv[]);
-#ifdef CONFIG_TASK_MANAGER
-int task_manager(int argc, char *argv[]);
-#endif
 
 /* Functions contained in os_task.c *****************************************/
 /* OS entry point called by boot logic */

--- a/os/kernel/init/os_bringup.c
+++ b/os/kernel/init/os_bringup.c
@@ -261,6 +261,9 @@ static inline void os_do_appstart(void)
 
 	svdbg("Starting application init thread\n");
 
+#ifdef CONFIG_TASK_MANAGER
+	task_manager_drv_register();
+#endif
 
 #ifdef CONFIG_SYSTEM_PREAPP_INIT
 #ifdef CONFIG_BUILD_PROTECTED
@@ -278,18 +281,6 @@ static inline void os_do_appstart(void)
 	heapinfo_drv_register();
 #endif
 
-#ifdef CONFIG_TASK_MANAGER
-#define TASKMGR_STACK_SIZE 2048
-#define TASKMGR_PRIORITY 200
-
-	svdbg("Starting task manager\n");
-	task_manager_drv_register();
-
-	pid = task_create("task_manager", TASKMGR_PRIORITY, TASKMGR_STACK_SIZE, task_manager, (FAR char *const *)NULL);
-	if (pid < 0) {
-		svdbg("Failed to create Task Manager\n");
-	}
-#endif
 	svdbg("Starting application main thread\n");
 #ifdef CONFIG_BUILD_PROTECTED
 	if (USERSPACE->us_entrypoint != NULL) {


### PR DESCRIPTION
The creation of task manager is not the kernel role, so moved to preapp.