### PR TITLE
kernel/semaphore: Manage the list of semaphore holder

### DIFF
--- a/os/kernel/semaphore/Make.defs
+++ b/os/kernel/semaphore/Make.defs
@@ -57,6 +57,8 @@ CSRCS += sem_post.c sem_recover.c sem_reset.c sem_waitirq.c sem_tickwait.c
 
 ifeq ($(CONFIG_PRIORITY_INHERITANCE),y)
 CSRCS += sem_initialize.c sem_holder.c sem_setprotocol.c
+else ifeq ($(CONFIG_APP_BINARY_SEPARATION),y)
+CSRCS += sem_holder.c
 endif
 
 # Include semaphore build support

--- a/os/kernel/semaphore/semaphore.h
+++ b/os/kernel/semaphore/semaphore.h
@@ -107,14 +107,16 @@ void sem_recover(FAR struct tcb_s *tcb);
  * holders of semaphores.
  */
 
-#ifdef CONFIG_PRIORITY_INHERITANCE
+#if defined(CONFIG_PRIORITY_INHERITANCE) || defined(CONFIG_APP_BINARY_SEPARATION)
 void sem_initholders(void);
 void sem_destroyholder(FAR sem_t *sem);
 void sem_addholder(FAR sem_t *sem);
 void sem_addholder_tcb(FAR struct tcb_s *tcb, FAR sem_t *sem);
+#if defined(CONFIG_PRIORITY_INHERITANCE)
 void sem_boostpriority(FAR sem_t *sem);
 void sem_releaseholder(FAR sem_t *sem);
 void sem_restorebaseprio(FAR struct tcb_s *stcb, FAR sem_t *sem);
+#endif
 #ifndef CONFIG_DISABLE_SIGNALS
 void sem_canceled(FAR struct tcb_s *stcb, FAR sem_t *sem);
 #else


### PR DESCRIPTION
1. A list of all semaphores in kernel region
- Add semaphore to the list when it is created(initialized)
- Remove semaphore from the list when it is destroyed

2. A list of all holders for each semaphore
- Save tcb of holder when it takes semaphore
- Clear its own holder data when it gives semaphore
- Post semaphore and Clear its own holder data when task is terminated with taking semaphore