### PR TITLE
arch/imxrt_ehci: Fix mem leak for exceptional logic

### DIFF
--- a/os/arch/arm/src/imxrt/imxrt_ehci.c
+++ b/os/arch/arm/src/imxrt/imxrt_ehci.c
@@ -2496,6 +2496,7 @@ static void worker_handler(void *input)
 			result = work_queue(HPWORK, &arg->worker, worker_handler, arg, 0);   \
 		} else {                                                                 \
 			udbg("workQueue is not allowed\n");                                  \
+			kmm_free(arg);                                                       \
 			return -1;                                                           \
 		}                                                                        \
 	} while (0);


### PR DESCRIPTION
- When worker handler is not available,
we should free usb_asynch_work structure in imxrt_ehci.c