### PR TITLE
arch/arm/src/armv7-m: Disabling MPU shareablity for user memory.

### DIFF
--- a/os/arch/arm/src/armv7-m/up_mpu.c
+++ b/os/arch/arm/src/armv7-m/up_mpu.c
@@ -338,7 +338,6 @@ void mpu_user_intsram_context(uint32_t region, uintptr_t base, size_t size, uint
 	regval = MPU_RASR_ENABLE |      /* Enable region */
 			MPU_RASR_SIZE_LOG2((uint32_t)l2size) | /* Region size   */
 			((uint32_t)subregions << MPU_RASR_SRD_SHIFT) | /* Sub-regions   */
-			MPU_RASR_S |                   /* Shareable     */
 			MPU_RASR_C |                   /* Cacheable     */
 			MPU_RASR_AP_RWRW;              /* P:RW   U:RW   */
 	regs[2] = regval;


### PR DESCRIPTION
Shareability is not required for applications, it is used only when multiprocessor or DMA operation is required.
