### PR TITLE
include/cxx/cstddef: Add C11++ std::nullptr_t

### DIFF
--- a/external/include/libcxx/cstddef
+++ b/external/include/libcxx/cstddef
@@ -94,6 +94,9 @@ namespace std
 
   using ::socklen_t;
   using ::sa_family_t;
+#if __cplusplus >= 201103L
+  using nullptr_t = decltype(nullptr);
+#endif
 }
 
 #endif // __INCLUDE_CXX_CSTDDEF


### PR DESCRIPTION
This commit is taken from nuttx