### PR TITLE
proxies : fix warning - 'noreturn' function does return

### DIFF
--- a/os/tools/mksyscall.c
+++ b/os/tools/mksyscall.c
@@ -100,6 +100,13 @@ static bool is_union(const char *type)
 	return (strncmp(type, "union", 5) == 0);
 }
 
+static bool is_noreturn_func(const char *func_name)
+{
+	return ((strncmp(func_name, "_exit", 5) == 0) ||
+			(strncmp(func_name, "exit", 4) == 0) ||
+			(strncmp(func_name, "pthread_exit", 12) == 0));
+}
+
 static const char *check_funcptr(const char *type)
 {
 	const char *str = strstr(type, "(*)");
@@ -323,7 +330,12 @@ static void generate_proxy(int nparms)
 
 	/* Handle the tail end of the function. */
 
-	fprintf(stream, ");\n}\n\n");
+	if (is_noreturn_func(g_parm[NAME_INDEX])) {
+		fprintf(stream, ");%s\n}\n\n", "\n  while(1);");
+	} else {
+		fprintf(stream, ");\n}\n\n");
+	}
+
 	if (g_parm[COND_INDEX][0] != '\0')
 		fprintf(stream, "#endif /* %s */\n", g_parm[COND_INDEX]);
 


### PR DESCRIPTION
This patch fixes the below warnings in the protected build

/TizenRT/os/include/unistd.h: In function '_exit':
proxies/PROXY__exit.c:10:1: warning: 'noreturn' function does return
 }
 ^

/TizenRT/os/include/stdlib.h: In function 'exit':
proxies/PROXY_exit.c:10:1: warning: 'noreturn' function does return
 }
 ^

/TizenRT/os/include/pthread.h: In function 'pthread_exit':
proxies/PROXY_pthread_exit.c:12:1: warning: 'noreturn' function does return
 }

Verification:
1. ./tools/configure.sh imxrt1050-evk/loadable_elf_apps
2. make

Confirming to:
gcc version 6.3.1 20170215 (release) [ARM/embedded-6-branch revision 245512]

Signed-off-by: Manohara HK <manohara.hk@samsung.com>