### PR TITLE
fs/poll: Clear slot for the poll structure reference when closing file

### DIFF
--- a/os/fs/vfs/fs_poll.c
+++ b/os/fs/vfs/fs_poll.c
@@ -207,6 +207,7 @@ static inline int poll_setup(FAR struct pollfd *fds, nfds_t nfds, sem_t *sem)
 		fds[i].sem = sem;
 		fds[i].revents = 0;
 		fds[i].priv = NULL;
+		fds[i].filep = NULL;
 
 		/* Check for invalid descriptors. "If the value of fd is less than 0,
 		 * events shall be ignored, and revents shall be set to 0 in that entry

--- a/os/include/poll.h
+++ b/os/include/poll.h
@@ -138,6 +138,7 @@ struct pollfd {
 	pollevent_t events;			/* The input event flags */
 	pollevent_t revents;		/* The output event flags */
 	FAR void *priv;				/* For use by drivers */
+	FAR void *filep;			/* The file pointer corresponding to fd */
 #ifdef CONFIG_NET_LWIP
 	FAR void *scb;
 #endif


### PR DESCRIPTION
Check if file pointer is registered in a list of waiters for polling.
For example, when task A is blocked by calling poll and task B try to terminate task A, a pollfd of A remains in this list.
If it is, it should be cleared.