### PR TITLE
os/fs: Prevent and handle powercut failures

### DIFF
--- a/os/fs/driver/mtd/smart.c
+++ b/os/fs/driver/mtd/smart.c
@@ -173,6 +173,8 @@
 #if CONFIG_SMARTFS_ERASEDSTATE == 0xFF
 #define SECTOR_IS_RELEASED(h) ((h.status & SMART_STATUS_RELEASED) == 0 ? true : false)
 #define SECTOR_IS_COMMITTED(h) ((h.status & SMART_STATUS_COMMITTED) == 0 ? true : false)
+#define SECTOR_IS_VALID(h, t)   ((UINT8TOUINT16(h.logicalsector) < t || UINT8TOUINT16(h.logicalsector) == 0xffff) ? true : false)
+
 #if SMART_STATUS_VERSION == 1
 #define HEADER_IS_CLEAN(h) ((UINT8TOUINT16(h.logicalsector) == 0xFFFF && h.seq == 0xFF && h.crc8 == 0xFF && h.status == 0xFF))
 #elif SMART_STATUS_VERSION == 2
@@ -183,6 +185,8 @@
 #else
 #define SECTOR_IS_RELEASED(h) ((h.status & SMART_STATUS_RELEASED) == SMART_STATUS_RELEASED ? true : false)
 #define SECTOR_IS_COMMITTED(h) ((h.status & SMART_STATUS_COMMITTED) == SMART_STATUS_COMMITTED ? true : false)
+#define SECTOR_IS_VALID(h, t)   ((UINT8TOUINT16(h.logicalsector) < t || UINT8TOUINT16(h.logicalsector) == 0x0000) ? true : false)
+
 #if SMART_STATUS_VERSION == 1
 #define HEADER_IS_CLEAN(h) ((UINT8TOUINT16(h.logicalsector) == 0x0000 && h.seq == 0x00 && h.crc8 == 0x00 && h.status == 0x00))
 #elif SMART_STATUS_VERSION == 2
@@ -420,7 +424,9 @@ static uint16_t smart_findfreephyssector(FAR struct smart_struct_s *dev, uint8_t
 static int smart_writesector(FAR struct smart_struct_s *dev, unsigned long arg);
 #endif
 static int smart_readsector(FAR struct smart_struct_s *dev, unsigned long arg);
-
+#ifdef CONFIG_FS_WRITABLE
+static int smart_allocsector(FAR struct smart_struct_s *dev, unsigned long requested);
+#endif
 #ifdef CONFIG_MTD_SMART_WEAR_LEVEL
 static int smart_read_wearstatus(FAR struct smart_struct_s *dev);
 static int smart_relocate_static_data(FAR struct smart_struct_s *dev, uint16_t block);
@@ -1686,6 +1692,44 @@ static int smart_set_wear_level(FAR struct smart_struct_s *dev, uint16_t block, 
 	return 0;
 }
 #endif
+
+static bool smart_validate_erase_block(FAR struct smart_struct_s *dev)
+{
+	FAR struct smart_sect_header_s header;
+	bool corrupted = false;
+	int i;
+	int ret;
+
+	memcpy(&header, dev->rwbuffer, sizeof(struct smart_sect_header_s));
+
+	/* Check the crc of header first. */
+	ret = smart_validate_crc(dev);
+	if (ret != OK) {
+		if (HEADER_IS_CLEAN(header)) {
+			/* If header is erased state, then check contents */
+			for (i = sizeof(struct smart_sect_header_s); i < dev->sectorsize; i++) {
+				if (dev->rwbuffer[i] != CONFIG_SMARTFS_ERASEDSTATE) {
+					fdbg("It is not Erased value offset %u, %x------------------\n", i, dev->rwbuffer[i]);
+					corrupted = true;
+					break;
+				}
+			}
+		} else {
+			/* If header is not clean & crc is not matched, then it is corrupted sector */
+			fdbg("Header is not clean but crc is not matched logical : %d crc : %d sta :%d seq :%d\n", UINT8TOUINT16(header.logicalsector), header.crc8, header.status, header.seq);
+			corrupted = true;
+		}
+	} else {
+		/* Very rarely, crc can be matched with abnormal header value, so we should check boundary */
+		if (!SECTOR_IS_VALID(header, dev->totalsectors)) {
+			fdbg("header is out of boundary, sector : %x\n", header.logicalsector);
+			corrupted = true;	
+		}
+	} 
+
+	return corrupted;
+}
+
 /****************************************************************************
  * Name: smart_scan
  *
@@ -1700,7 +1744,7 @@ static int smart_scan(FAR struct smart_struct_s *dev)
 	int sector;
 	int ret;
 	uint16_t totalsectors;
-	uint16_t sectorsize, prerelease;
+	uint16_t prerelease;
 	uint16_t logicalsector;
 	uint16_t loser;
 	uint16_t winner;
@@ -1711,7 +1755,6 @@ static int smart_scan(FAR struct smart_struct_s *dev)
 	struct smart_sect_header_s header;
 	uint8_t *sector_seq_log = NULL;
 	bool status_released, status_committed;
-	bool corrupted;
 #ifdef CONFIG_MTD_SMART_MINIMIZE_RAM
 	int dupsector;
 	uint16_t duplogsector;
@@ -1721,49 +1764,11 @@ static int smart_scan(FAR struct smart_struct_s *dev)
 	char devname[22];
 	FAR struct smart_multiroot_device_s *rootdirdev;
 #endif
-	int i;
 
-	fvdbg("Entry\n");
-
-	/* Find the sector size on the volume by reading headers from
-	 * sectors of decreasing size.  On a formatted volume, the sector
-	 * size is saved in the header status byte of seach sector, so
-	 * by starting with the largest supported sector size and
-	 * decreasing from there, we will be sure to find data that is
-	 * a header and not sector data.
-	 */
-
-	sectorsize = 0xFFFF;
-	offset = 16384;
-
-	while (sectorsize == 0xFFFF) {
-		readaddress = 0;
-
-		while (readaddress < dev->erasesize * dev->geo.neraseblocks) {
-			/* Read the next sector from the device. */
-
-			ret = MTD_READ(dev->mtd, readaddress, sizeof(struct smart_sect_header_s), (FAR uint8_t *)&header);
-			if (ret != sizeof(struct smart_sect_header_s)) {
-				goto err_out;
-			}
-
-			if (header.status != CONFIG_SMARTFS_ERASEDSTATE) {
-				sectorsize = (header.status & SMART_STATUS_SIZEBITS) << 7;
-				break;
-			}
-
-			readaddress += offset;
-		}
-
-		offset >>= 1;
-		if (offset < 256 && sectorsize == 0xFFFF) {
-			sectorsize = CONFIG_MTD_SMART_SECTOR_SIZE;
-		}
-	}
-
-	/* Now set the sectorsize and other sectorsize derived variables. */
-
-	ret = smart_setsectorsize(dev, sectorsize);
+	// ToDo: Revert to the flexible logic that searches sectors and
+	//       reads sector sizes stored in the sectors instead of
+	//		 using CONFIG_MTD_SMART_SECTOR_SIZE.
+	ret = smart_setsectorsize(dev, CONFIG_MTD_SMART_SECTOR_SIZE);
 	if (ret != OK) {
 		goto err_out;
 	}
@@ -1823,62 +1828,37 @@ static int smart_scan(FAR struct smart_struct_s *dev)
 
 	for (sector = 0; sector < totalsectors; sector++) {
 		winner = sector;
-		corrupted = false;
 		fvdbg("Scan sector %d\n", sector);
 
 		/* Calculate the read address for this sector. */
 
 		readaddress = sector * dev->mtdBlksPerSector * dev->geo.blocksize;
 
-		/* Read the header for this sector. */
+		/* Read the whole sector for this sector. */
 
 		ret = MTD_BREAD(dev->mtd, sector * dev->mtdBlksPerSector, dev->mtdBlksPerSector, (uint8_t *)dev->rwbuffer);
 		if (ret != dev->mtdBlksPerSector) {
 			fdbg("Error reading physical sector %d.\n", sector);
 			goto err_out;
 		}
-
+		/* copy header data only, will be used below */
 		memcpy(&header, dev->rwbuffer, sizeof(struct smart_sect_header_s));
-		ret = smart_validate_crc(dev);
-		if (ret != OK) {
-			if (HEADER_IS_CLEAN(header)) {
-				/* Header is cleaned but all blocks are not cleaned, it means corruption occurs during erasing. */
-				for (i = sizeof(struct smart_sect_header_s); i < dev->sectorsize; i++) {
-					if (dev->rwbuffer[i] != 0xFF) {
-						fdbg("It is not Erased value sector %u, offset %u, %x------------------\n", sector, i, dev->rwbuffer[i]);
-						corrupted = true;
-						break;
-					}
-				}
-				if (corrupted) {
-					fdbg("It seems erase-fail, physical sector : %d eraseblock : %d\n", sector, sector / dev->sectorsPerBlk);
-					smart_erase_block_if_empty(dev, sector / dev->sectorsPerBlk, TRUE);
-					sector = ((sector / dev->sectorsPerBlk) * dev->sectorsPerBlk) + dev->sectorsPerBlk - 1;
-					continue;
-				}
-			} else {
-				fdbg("It seems corrupted, physical sector : %d eraseblock : %d\n", sector, sector / dev->sectorsPerBlk);
-#ifdef CONFIG_DEBUG_FS
-//#if defined(CONFIG_DEBUG_FS) && defined(CONFIG_DEBUG_VERBOSE)
-				for (i = 0; i < sizeof(struct smart_sect_header_s); i++) {
-					fsdbg("%02x ", dev->rwbuffer[i]);
-				}
-				fsdbg("\n");
-#endif
-				fdbg("set Released and commited sector : %d\n", sector);
-#if CONFIG_SMARTFS_ERASEDSTATE == 0xFF
-				header.status = header.status & ~(SMART_STATUS_COMMITTED | SMART_STATUS_RELEASED);
-#else
-				header.status = header.status | SMART_STATUS_COMMITTED | SMART_STATUS_RELEASED;
-#endif
-				ret = smart_bytewrite(dev, readaddress + offsetof(struct smart_sect_header_s, status), 1, &header.status);
-				if (ret < 0) {
-					goto err_out;
-				}
 
+		/* If current sector is corrupted because of erase fail, restore it */
+		if (smart_validate_erase_block(dev)) {
+			fdbg("It seems that erase failed, release current sector. block : %d sector : %d\n", sector / dev->sectorsPerBlk, sector);
+			/* Erase current block forcely */
+#if CONFIG_SMARTFS_ERASEDSTATE == 0xFF
+			header.status = header.status & ~(SMART_STATUS_COMMITTED | SMART_STATUS_RELEASED);
+#else
+			header.status = header.status | SMART_STATUS_COMMITTED | SMART_STATUS_RELEASED;
+#endif
+
+			ret = smart_bytewrite(dev, readaddress + offsetof(struct smart_sect_header_s, status), 1, &header.status);
+			if (ret < 0) {
+				goto err_out;
 			}
 		}
-
 
 		/* Get the logical sector number for this physical sector. */
 		logicalsector = UINT8TOUINT16(header.logicalsector);
@@ -1890,7 +1870,7 @@ static int smart_scan(FAR struct smart_struct_s *dev)
 
 		status_released = SECTOR_IS_RELEASED(header);
 		status_committed = SECTOR_IS_COMMITTED(header);
-		fvdbg("released : %d committed : %d logical : %d physical : %d sta :%d seq :%d\n", status_released, status_committed, logicalsector, sector, header.status, header.seq);
+		fvdbg("released : %d committed : %d logical : %d physical : %d crc : %d sta :%d seq :%d\n", status_released, status_committed, logicalsector, sector, header.crc8, header.status, header.seq);
 		if (logicalsector > 0 && header.status != CONFIG_SMARTFS_ERASEDSTATE && !status_released && status_committed) {
 
 			/* Map the sector and update the free sector counts. */
@@ -1955,6 +1935,7 @@ static int smart_scan(FAR struct smart_struct_s *dev)
 				status_released = true;
 				ret = smart_bytewrite(dev, readaddress + offsetof(struct smart_sect_header_s, status), 1, &header.status);
 				if (ret < 0) {
+					fdbg("checkpoint line %d\n", __LINE__);
 					goto err_out;
 				}
 			} else {
@@ -2013,9 +1994,25 @@ static int smart_scan(FAR struct smart_struct_s *dev)
 
 			ret = MTD_READ(dev->mtd, readaddress, 32, (FAR uint8_t *)dev->rwbuffer);
 			if (ret != 32) {
-				fdbg("Error reading physical sector %d.\n", sector);
+				fdbg("Error reading physical sector %d at line %d.\n", sector, __LINE__);
 				goto err_out;
 			}
+
+			/* Validate the format signature */
+
+			if (dev->rwbuffer[SMART_FMT_POS1] != SMART_FMT_SIG1 ||
+					dev->rwbuffer[SMART_FMT_POS2] != SMART_FMT_SIG2 ||
+					dev->rwbuffer[SMART_FMT_POS3] != SMART_FMT_SIG3 ||
+					dev->rwbuffer[SMART_FMT_POS4] != SMART_FMT_SIG4) {
+				/* Invalid signature on a sector claiming to be sector 0!
+				 * What should we do?  Release it?
+				 */
+				fdbg("INVALID SIGNATURE!! %c %c %c %c\n", dev->rwbuffer[SMART_FMT_POS1], dev->rwbuffer[SMART_FMT_POS2],
+						dev->rwbuffer[SMART_FMT_POS3], dev->rwbuffer[SMART_FMT_POS4]);
+				continue;
+			}
+
+			/* Mark the volume as formatted and set the sector size */
 
 			dev->formatstatus = SMART_FMT_STAT_FORMATTED;
 			dev->namesize = dev->rwbuffer[SMART_FMT_NAMESIZE_POS];
@@ -2071,7 +2068,7 @@ static int smart_scan(FAR struct smart_struct_s *dev)
 			 * the same logical sector.  Use the sequence number information
 			 * to resolve who wins.
 			 */
-
+			fvdbg("Duplication occurs!!\n, Popular Physical Sector = %d\n", dev->sMap[logicalsector]);
 #if SMART_STATUS_VERSION == 1
 			if (header.status & SMART_STATUS_CRC) {
 				seq2 = header.seq;
@@ -2282,6 +2279,7 @@ static int smart_scan(FAR struct smart_struct_s *dev)
 	fdbg("   Erase count:  %10d\n", dev->neraseblocks);
 	fdbg("   Sect/block:   %10d\n", dev->sectorsPerBlk);
 	fdbg("   MTD Blk/Sect: %10d\n", dev->mtdBlksPerSector);
+	fdbg("avail sect/block %10d\n", dev->availSectPerBlk);
 #ifdef CONFIG_MTD_SMART_ALLOC_DEBUG
 	fdbg("   Allocations:\n");
 	for (sector = 0; sector < SMART_MAX_ALLOCS; sector++) {
@@ -2326,7 +2324,7 @@ static inline int smart_getformat(FAR struct smart_struct_s *dev, FAR struct sma
 
 	if (dev->formatstatus != SMART_FMT_STAT_FORMATTED) {
 		/* Perform the scan. */
-
+		fvdbg("not formatted, scan start status : %d\n", dev->formatstatus);
 		ret = smart_scan(dev);
 
 		if (ret != OK) {
@@ -2348,6 +2346,7 @@ static inline int smart_getformat(FAR struct smart_struct_s *dev, FAR struct sma
 
 	fmt->nfreesectors = dev->freesectors;
 	fmt->namesize = dev->namesize;
+	fdbg("namesize : %d\n", dev->namesize);
 #ifdef CONFIG_SMARTFS_MULTI_ROOT_DIRS
 	fmt->nrootdirentries = dev->rootdirentries;
 	fmt->rootdirnum = rootdirnum;
@@ -2394,6 +2393,7 @@ static void smart_erase_block_if_empty(FAR struct smart_struct_s *dev, uint16_t 
 		dev->blockerases++;
 #endif
 		MTD_ERASE(dev->mtd, block, 1);
+
 
 #ifdef CONFIG_MTD_SMART_SECTOR_ERASE_DEBUG
 		if (dev->erasecounts) {
@@ -2864,16 +2864,16 @@ static inline int smart_llformat(FAR struct smart_struct_s *dev, unsigned long a
 	sectorheader->logicalsector[1] = 0;
 	//*((FAR uint16_t *)sectorheader->logicalsector) = 0;
 	sectorheader->status = (uint8_t)~(SMART_STATUS_COMMITTED | SMART_STATUS_VERBITS | SMART_STATUS_SIZEBITS) | SMART_STATUS_VERSION | sectsize;
-#ifdef CONFIG_MTD_SMART_ENABLE_CRC
+
 	sectorheader->status &= ~SMART_STATUS_CRC;
-#endif							/* CONFIG_MTD_SMART_ENABLE_CRC */
+
 
 #else							/* CONFIG_SMARTFS_ERASEDSTATE == 0xFF */
 	*((FAR uint16_t *)sectorheader->logicalsector) = 0xFFFF;
 	sectorheader->status = (uint8_t)(SMART_STATUS_COMMITTED | SMART_STATUS_VERSION | sectsize);
-#ifdef CONFIG_MTD_SMART_ENABLE_CRC
+
 	sectorheader->status |= SMART_STATUS_CRC;
-#endif							/* CONFIG_MTD_SMART_ENABLE_CRC */
+
 #endif							/* CONFIG_SMARTFS_ERASEDSTATE == 0xFF */
 
 	/* Now add the format signature to the sector. */
@@ -2888,7 +2888,7 @@ static inline int smart_llformat(FAR struct smart_struct_s *dev, unsigned long a
 
 	/* Record the number of root directory entries we have. */
 
-	dev->rwbuffer[SMART_FMT_ROOTDIRS_POS] = (uint8_t)arg;
+	dev->rwbuffer[SMART_FMT_ROOTDIRS_POS] = (uint8_t) (arg & 0xff);
 
 #ifdef CONFIG_SMART_CRC_8
 	sectorheader->crc8 = smart_calc_sector_crc(dev);
@@ -3094,8 +3094,10 @@ static int smart_relocate_sector(FAR struct smart_struct_s *dev, uint16_t oldsec
 		fdbg("Error %d releasing old sector %d\n" - ret, oldsector);
 	}
 #ifndef CONFIG_MTD_SMART_ENABLE_CRC
+
 errout:
 #endif
+	fvdbg("relocate physical sector - logical: %d --> oldsector: %d,  newsector: %d\n", UINT8TOUINT16(header->logicalsector), oldsector, newsector);
 
 	return ret;
 }
@@ -3601,6 +3603,14 @@ error:
 			kmm_free(sector_buff);
 			goto retry;
 		}
+		for (x = allocblock * dev->sectorsPerBlk; x < allocblock * dev->sectorsPerBlk + dev->availSectPerBlk; x++) {
+			readaddr = x * dev->mtdBlksPerSector * dev->geo.blocksize;
+			ret = MTD_READ(dev->mtd, readaddr, sizeof(struct smart_sect_header_s), (FAR uint8_t *)&header);
+			if (ret == sizeof(struct smart_sect_header_s)) {
+				fdbg("Error case block : %d sector : %d logicalsector : %d seq : %d crc :%d status : %d\n", allocblock,\
+					x, UINT8TOUINT16(header.logicalsector), header.seq, header.crc8, header.status);
+			}
+		}
 		if (physicalsector == 0xFFFF) {
 			dbg("Program bug!  Expected a free sector %d\n", allocblock);
 		} else if (physicalsector >= dev->totalsectors) {
@@ -3785,8 +3795,8 @@ static int smart_write_wearstatus(struct smart_struct_s *dev)
 		/* Calculate the number of bytes to write to this sector. */
 
 		towrite = remaining;
-		if (towrite > dev->sectorsize - SMARTFS_FMT_WEAR_POS) {
-			towrite = dev->sectorsize - SMARTFS_FMT_WEAR_POS;
+		if (towrite > dev->sectorsize - SMARTFS_FMT_WEAR_POS + sizeof(struct smart_sect_header_s)) {
+			towrite = dev->sectorsize - SMARTFS_FMT_WEAR_POS + sizeof(struct smart_sect_header_s);
 		}
 
 		/* Setup the sector write request (we are our own client). */
@@ -3841,7 +3851,7 @@ errout:
 #ifdef CONFIG_MTD_SMART_WEAR_LEVEL
 static inline int smart_read_wearstatus(FAR struct smart_struct_s *dev)
 {
-	uint16_t sector;
+	uint16_t sector, physsector;
 	uint16_t remaining, toread;
 	struct smart_read_write_s req;
 	int ret;
@@ -3890,8 +3900,8 @@ static inline int smart_read_wearstatus(FAR struct smart_struct_s *dev)
 		/* Calculate number of bytes to read from this sector. */
 
 		toread = remaining;
-		if (toread > dev->sectorsize - SMARTFS_FMT_WEAR_POS) {
-			toread = dev->sectorsize - SMARTFS_FMT_WEAR_POS;
+		if (toread > dev->sectorsize - SMARTFS_FMT_WEAR_POS + sizeof(struct smart_sect_header_s)) {
+			toread = dev->sectorsize - SMARTFS_FMT_WEAR_POS + sizeof(struct smart_sect_header_s);
 		}
 
 		/* Setup the sector read request (we are our own client). */
@@ -3901,6 +3911,26 @@ static inline int smart_read_wearstatus(FAR struct smart_struct_s *dev)
 		req.count = toread;
 		req.buffer = &dev->wearstatus[(dev->geo.neraseblocks >> SMART_WEAR_BIT_DIVIDE) - remaining];
 
+      /* Validate wear status sector has been allocated */
+
+#ifndef CONFIG_MTD_SMART_MINIMIZE_RAM
+		physsector = dev->sMap[req.logsector];
+#else
+		physsector = smart_cache_lookup(dev, req.logsector);
+#endif
+		if ((sector != 0) && (physsector == 0xffff)) {
+#ifdef CONFIG_FS_WRITABLE
+
+		/* This logical sector does not exist yet.  We must allocate it */
+
+		ret = smart_allocsector(dev, sector);
+		if (ret != sector) {
+			fdbg("ERROR: Unable to allocate wear level status sector %d\n", sector);
+			ret = -EINVAL;
+			goto errout;
+		}
+#endif
+		}
 		/* Read the sector. */
 
 		ret = smart_readsector(dev, (unsigned long)&req);
@@ -3986,7 +4016,7 @@ static int smart_write_alloc_sector(FAR struct smart_struct_s *dev, uint16_t log
 
 #ifndef CONFIG_MTD_SMART_ENABLE_CRC
 	header->crc8 = smart_calc_sector_crc(dev);
-	fvdbg("Write MTD block %d\n", physical * dev->mtdBlksPerSector);
+	fvdbg("Write MTD block ALLOCATION!!! Logical %d -> Physical %d\n", logical, physical);
 	ret = MTD_BWRITE(dev->mtd, physical * dev->mtdBlksPerSector, 1, (FAR uint8_t *)dev->rwbuffer);
 	if (ret != 1) {
 		/* The block is not empty!!  What to do? */
@@ -4037,6 +4067,9 @@ static int smart_validate_crc(FAR struct smart_struct_s *dev)
 #else
 	/* Test 8-bit CRC for CRC8 & basic case for smart_scan. */
 	if (crc != header->crc8) {
+		if (header->crc8 != 0xff) {
+			fdbg("calculated crc %d != header crc %d\n", crc, header->crc8);
+		}
 		return -EIO;
 	}
 
@@ -4322,6 +4355,7 @@ relocate_good_sector:
 		}
 
 		/* Check BAD Sector or not. */
+		fdbg("Physical sector %d is newly written by relocation!\n", physsector);
 #ifdef CONFIG_SMARTFS_BAD_SECTOR
 
 		int bsm_ret = MTD_BREAD(dev->mtd, physsector * dev->mtdBlksPerSector,
@@ -4395,6 +4429,7 @@ relocate_good_sector:
 		/* Update the sector map. */
 
 #ifndef CONFIG_MTD_SMART_MINIMIZE_RAM
+		fdbg("sMap is updated, Logical %d -> %d (from old physical sector %d)\n", req->logsector, physsector, dev->sMap[req->logsector]);
 		dev->sMap[req->logsector] = physsector;
 #else
 		smart_update_cache(dev, req->logsector, physsector);
@@ -4654,7 +4689,7 @@ static int smart_readsector(FAR struct smart_struct_s *dev, unsigned long arg)
 	if ((UINT8TOUINT16(header.logicalsector) != req->logsector) || (!(SECTOR_IS_COMMITTED(header)))) {
 		/* Error in sector header! How do we handle this? */
 
-		fdbg("Error in logical sector %d header, phys=%d\n", req->logsector, physsector);
+		fdbg("Error in logical sector %d header, phys=%d read sector : %d expected sector : %d\n", req->logsector, physsector, UINT8TOUINT16(header.logicalsector), req->logsector);
 		ret = -EIO;
 		goto errout;
 	}
@@ -4685,7 +4720,7 @@ errout:
  ****************************************************************************/
 
 #ifdef CONFIG_FS_WRITABLE
-static inline int smart_allocsector(FAR struct smart_struct_s *dev, unsigned long requested)
+static int smart_allocsector(FAR struct smart_struct_s *dev, unsigned long requested)
 {
 	int x;
 	uint16_t logsector = 0xFFFF;	/* Logical sector number selected */
@@ -4726,7 +4761,7 @@ static inline int smart_allocsector(FAR struct smart_struct_s *dev, unsigned lon
 	/* Check if a specific sector is being requested and allocate that
 	 * sector if it isn't already in use. */
 
-	if ((requested > 2) && (requested < dev->totalsectors)) {
+	if ((requested > 0) && (requested < dev->totalsectors)) {
 		/* Validate the sector is not already allocated. */
 
 #ifndef CONFIG_MTD_SMART_MINIMIZE_RAM
@@ -5063,8 +5098,13 @@ static int smart_ioctl(FAR struct inode *inode, int cmd, unsigned long arg)
 
 	case BIOC_ALLOCSECT:
 
-		/* Allocate a logical sector for the upper layer file system. */
+		/* Ensure the FS is not trying to allocate a reserved sector */
 
+		if (arg < 3) {
+			arg = (unsigned long) -1;
+		}
+
+		/* Allocate a logical sector for the upper layer file system. */
 		ret = smart_allocsector(dev, arg);
 		goto ok_out;
 
@@ -5336,7 +5376,7 @@ int smart_initialize(int minor, FAR struct mtd_dev_s *mtd, FAR const char *partn
 		}
 
 		/* Do a scan of the device. */
-
+		fdbg("smart_initialize, scan start\n");
 		smart_scan(dev);
 	}
 

--- a/os/include/debug.h
+++ b/os/include/debug.h
@@ -314,6 +314,7 @@
 #ifdef CONFIG_DEBUG_FS_ERROR
 #define fdbg(format, ...)    dbg(format, ##__VA_ARGS__)
 #define flldbg(format, ...)  lldbg(format, ##__VA_ARGS__)
+#define fsdbg(format, ...)   dbg_noarg(format, ##__VA_ARGS__)
 #else
 #define fdbg(...)
 #define flldbg(...)


### PR DESCRIPTION
- A sector size is fixed at the beginning of smart_scan since
existing sectors are deleted when the sector size is changed.
- Dangling entry chains are cleaned when accessed.
- The existence of the sector to save wear status of all sectors
is checked before it is accessed.