### PR TITLE
framework/media: Move codec functions out of media namespace

### DIFF
--- a/framework/src/media/Decoder.h
+++ b/framework/src/media/Decoder.h
@@ -22,6 +22,7 @@
 #include <tinyara/config.h>
 #include <stdio.h>
 #include <memory>
+#include <media/MediaTypes.h>
 
 #ifdef CONFIG_AUDIO_CODEC
 #include "codec/audio_decoder.h"

--- a/framework/src/media/Make.defs
+++ b/framework/src/media/Make.defs
@@ -55,10 +55,11 @@ CXXSRCS += HttpInputDataSource.cpp
 ifeq ($(CONFIG_ENABLE_CURL), y)
 CXXSRCS += HttpStream.cpp
 endif
-CXXSRCS += Decoder.cpp audio_decoder.cpp wav_decoder_api.cpp
+CXXSRCS += Decoder.cpp audio_decoder.cpp
 ifeq ($(CONFIG_CODEC_LIBOPUS), y)
 CSRCS += opus_decoder_api.c
 endif
+CSRCS += wav_decoder_api.c
 endif
 
 ifeq ($(CONFIG_MEDIA_RECORDER), y)

--- a/framework/src/media/codec/audio_decoder.cpp
+++ b/framework/src/media/codec/audio_decoder.cpp
@@ -25,11 +25,12 @@
 #include <assert.h>
 #include <pthread.h>
 #include <debug.h>
+#include <media/MediaTypes.h>
 #include "audio_decoder.h"
 #include "../utils/internal_defs.h"
 #include "../audio/resample/samplerate.h"
 
-namespace media {
+using namespace media;
 
 // MP3 tag frame header len
 #define MP3_HEAD_ID3_TAG_LEN 10
@@ -1169,5 +1170,3 @@ int audio_decoder_finish(audio_decoder_p decoder)
 
 	return AUDIO_DECODER_OK;
 }
-
-} // namespace media

--- a/framework/src/media/codec/audio_decoder.h
+++ b/framework/src/media/codec/audio_decoder.h
@@ -19,7 +19,6 @@
 #ifndef STREAMING_DECODER_H
 #define STREAMING_DECODER_H
 
-#include <media/MediaTypes.h>
 #include "../utils/rb.h"
 #include "../utils/rbs.h"
 #include "mp3/pvmp3decoder_api.h"
@@ -32,7 +31,10 @@
 #define AUDIO_DECODER_OK 0
 #define AUDIO_DECODER_ERROR -1
 
-namespace media {
+#ifdef __cplusplus
+extern "C"
+{
+#endif
 
 struct audio_decoder_s;
 typedef struct audio_decoder_s audio_decoder_t;
@@ -163,7 +165,9 @@ int audio_decoder_configure(audio_decoder_p decoder, int audio_type, void *dec_e
  */
 size_t audio_decoder_get_frames(audio_decoder_p decoder, unsigned char *buf, size_t max, unsigned int *sr, unsigned short *ch);
 
-} // namespace media
+#ifdef __cplusplus
+} // extern "C"
+#endif
 
 #endif /* STREAMING_DECODER_H */
 

--- a/framework/src/media/codec/audio_encoder.cpp
+++ b/framework/src/media/codec/audio_encoder.cpp
@@ -25,10 +25,11 @@
 #include <assert.h>
 #include <pthread.h>
 #include <debug.h>
+#include <media/MediaTypes.h>
 #include "audio_encoder.h"
 #include "../utils/internal_defs.h"
 
-namespace media {
+using namespace media;
 
 /****************************************************************************
  * Private Declarations
@@ -185,7 +186,7 @@ int audio_encoder_getframe(audio_encoder_p encoder, void *data, size_t len)
 	}
 }
 
-int audio_encoder_init(audio_encoder_p encoder, size_t rbuf_size, audio_type_t audio_type, void *enc_ext)
+int audio_encoder_init(audio_encoder_p encoder, size_t rbuf_size, int audio_type, void *enc_ext)
 {
 	assert(encoder != NULL);
 	RETURN_VAL_IF_FAIL(audio_encoder_check_audio_type(audio_type), AUDIO_ENCODER_ERROR);
@@ -255,6 +256,3 @@ int audio_encoder_finish(audio_encoder_p encoder)
 
 	return AUDIO_ENCODER_OK;
 }
-
-} // namespace media
-

--- a/framework/src/media/codec/audio_encoder.h
+++ b/framework/src/media/codec/audio_encoder.h
@@ -21,7 +21,6 @@
 
 #include "../utils/rb.h"
 #include "../utils/rbs.h"
-#include <media/MediaTypes.h>
 #ifdef CONFIG_CODEC_LIBOPUS
 #include "opus/opus_encoder_api.h"
 #endif
@@ -29,7 +28,10 @@
 #define AUDIO_ENCODER_OK 0
 #define AUDIO_ENCODER_ERROR -1
 
-namespace media {
+#ifdef __cplusplus
+extern "C"
+{
+#endif
 
 struct audio_encoder_s;
 typedef struct audio_encoder_s audio_encoder_t;
@@ -80,7 +82,7 @@ struct audio_encoder_s {
  * @param  enc_ext : Pointer to encoder external struct, ex: opus use opus_enc_external_t
  * @return 0 on success, otherwise, return -1.
  */
-int audio_encoder_init(audio_encoder_p encoder, size_t rbuf_size, audio_type_t audio_type, void *enc_ext);
+int audio_encoder_init(audio_encoder_p encoder, size_t rbuf_size, int audio_type, void *enc_ext);
 
 /**
  * @brief  stream encoder register user data and user input callback.
@@ -138,7 +140,9 @@ bool audio_encoder_dataspace_is_empty(audio_encoder_p encoder);
  */
 int audio_encoder_getframe(audio_encoder_p encoder, void * data, size_t len);
 
-} // namespace media
+#ifdef __cplusplus
+} // extern "C"
+#endif
 
 #endif /* STREAMING_ENCODER_H */
 

--- a/framework/src/media/codec/wav/wav_decoder_api.c
+++ b/framework/src/media/codec/wav/wav_decoder_api.c
@@ -22,18 +22,17 @@
 #include <string.h>
 #include <stdlib.h>
 #include <debug.h>
-#include <media/MediaTypes.h>
 #include "../../utils/internal_defs.h"
 #include "../../utils/rbs.h"
 #include "../../audio/resample/samplerate.h"
 #include "../audio_decoder.h"
 #include "wav_decoder_api.h"
 
-namespace media {
 
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
+#define WAVE_HEADER_LENGTH      44
 #define WAVE_HDR_CHUNK_ID       "RIFF"
 #define WAVE_FORMAT_STR         "WAVE"
 #define WAVE_FMT_CHUNK_ID       "fmt "
@@ -298,6 +297,4 @@ int wav_decode_frame(wav_dec_external_p dec_ext, void *dec_mem, src_handle_t *re
 	dec_ext->outputFrameSize = nFrames;
 	dec_ext->samplingRate = wav_fmt_ex->nSamplesPerSec;
 	return AUDIO_DECODER_OK;
-}
-
 }

--- a/framework/src/media/codec/wav/wav_decoder_api.h
+++ b/framework/src/media/codec/wav/wav_decoder_api.h
@@ -22,7 +22,10 @@
 #include "../../utils/rbs.h"
 #include <stdint.h>
 
-namespace media {
+#ifdef __cplusplus
+extern "C"
+{
+#endif
 
 struct audio_decoder_s;
 typedef struct audio_decoder_s *audio_decoder_p;
@@ -88,7 +91,9 @@ bool wav_check_type(rbstream_p rbsp);
 bool wav_get_frame(rbstream_p mFp, ssize_t *offset, void *dec_mem, void *buffer, uint32_t *size);
 int wav_decode_frame(wav_dec_external_p dec_ext, void *dec_mem, src_handle_t *resampler);
 
-}
+#ifdef __cplusplus
+} // extern "C"
+#endif
 
 #endif /* WAV_DECODER_API_H */
 


### PR DESCRIPTION
- rename wav_decoder_api.cpp to wav_decoder_api.c
- remove media namespace from head files
- use namespace media in audio_decoder.cpp & audio_encoder.cpp,
  because media::audio_type_t is reused in these two files.