### PR TITLE
[net/lwip]: Fix debug formatter for lwip

### DIFF
--- a/os/include/net/lwip/arch.h
+++ b/os/include/net/lwip/arch.h
@@ -132,7 +132,7 @@ typedef uintptr_t mem_ptr_t;
 #if !LWIP_NO_INTTYPES_H
 #include <inttypes.h>
 #ifndef X8_F
-#define X8_F  "02"
+#define X8_F  "02x"
 #endif
 #ifndef U16_F
 #define U16_F "hu"


### PR DESCRIPTION
Debug formatter `X8_F` corrected in this commit.