### PR TITLE
os/board/Kconfig : Rename macro BOARD_ASSERT_SYSTEM_BLOCK

### DIFF
--- a/os/board/Kconfig
+++ b/os/board/Kconfig
@@ -189,7 +189,7 @@ config BOARD_ASSERT_AUTORESET
 		board reset. When fault manager is enabled this will reset the
 		system only when fault is in kernel context.
 
-config BOARD_ASSERT_SYSTEM_BLOCK
+config BOARD_ASSERT_SYSTEM_HALT
 	bool "Enable Infinite loop feature of fault manager"
 	default n
 	depends on !BOARD_ASSERT_AUTORESET && !BINMGR_RECOVERY


### PR DESCRIPTION
The macro is already been renamed to CONFIG_BOARD_ASSERT_SYSTEM_HALT
in file armv7-m/up_assert.c

So this patch rename the macro BOARD_ASSERT_SYSTEM_BLOCK to
CONFIG_BOARD_ASSERT_SYSTEM_HALT in os/board/Kconfig file.

Signed-off-by: Drashti Parikh <p.drashti@partner.samsung.com>