### PR TITLE
sched/cpuload: Define function to clear cpuload count of defunct thread

### DIFF
--- a/os/kernel/sched/sched.h
+++ b/os/kernel/sched/sched.h
@@ -235,14 +235,6 @@ extern struct pidhash_s g_pidhash[CONFIG_MAX_TASKS];
 
 extern const struct tasklist_s g_tasklisttable[NUM_TASK_STATES];
 
-#ifdef CONFIG_SCHED_CPULOAD
-/* This is the total number of clock tick counts.  Essentially the
- * 'denominator' for all CPU load calculations.
- */
-
-extern volatile uint32_t g_cpuload_total[SCHED_NCPULOAD];
-#endif
-
 /****************************************************************************
  * Public Function Prototypes
  ****************************************************************************/
@@ -272,8 +264,11 @@ void sched_timer_reassess(void);
 #define sched_timer_reassess()
 #endif
 
-#if defined(CONFIG_SCHED_CPULOAD) && !defined(CONFIG_SCHED_CPULOAD_EXTCLK)
+#ifdef CONFIG_SCHED_CPULOAD
+#ifndef CONFIG_SCHED_CPULOAD_EXTCLK
 void weak_function sched_process_cpuload(void);
+#endif
+void sched_clear_cpuload(pid_t pid);
 #endif
 
 bool sched_verifytcb(FAR struct tcb_s *tcb);

--- a/os/kernel/sched/sched_releasetcb.c
+++ b/os/kernel/sched/sched_releasetcb.c
@@ -62,9 +62,6 @@
 
 #include <tinyara/arch.h>
 #include <tinyara/sched.h>
-#ifdef CONFIG_SCHED_CPULOAD
-#include <tinyara/clock.h>
-#endif
 
 #include "sched/sched.h"
 #include "group/group.h"
@@ -111,15 +108,10 @@ static void sched_releasepid(pid_t pid)
 	g_pidhash[hash_ndx].pid = INVALID_PROCESS_ID;
 
 #ifdef CONFIG_SCHED_CPULOAD
-	/* Decrement the total CPU load count held by this thread from the
-	 * total for all threads.  Then we can reset the count on this
-	 * defunct thread to zero.
+	/* Decrement the total CPU load count held by this thread from total
+	 * for all threads and reset the load count on this defunct thread
 	 */
-	int cpuload_idx;
-	for (cpuload_idx = 0; cpuload_idx < SCHED_NCPULOAD; cpuload_idx++) {
-		g_cpuload_total[cpuload_idx] -= g_pidhash[hash_ndx].ticks[cpuload_idx];
-		g_pidhash[hash_ndx].ticks[cpuload_idx] = 0;
-	}
+	sched_clear_cpuload(pid);
 #endif
 	/* Decrement the alive task count as task is exiting */
 	g_alive_taskcount--;


### PR DESCRIPTION
Define function to clear cpuload count of defunct thread and call it when releasing pid