### PR TITLE
driver/otp: Add otp driver to access one time program area

### DIFF
--- a/os/drivers/Kconfig
+++ b/os/drivers/Kconfig
@@ -498,6 +498,23 @@ menuconfig DRIVERS_WIRELESS
 
 source drivers/wireless/Kconfig
 
+config OTP
+	bool "OTP Driver Support"
+	default n
+	depends on NFILE_DESCRIPTORS != 0
+	---help---
+		This selection enables building of the "upper-half" OTP
+		driver. See include/tinyara/otp.h for further OTP driver
+		information.
+
+if OTP
+config OTP_NULL
+	bool "OTP Null device"
+	default n
+	---help---
+		Virtual OTP device
+endif
+
 menuconfig LWNL80211
 	bool "Enable light-weight netlink for 80211"
 	default n

--- a/os/drivers/Makefile
+++ b/os/drivers/Makefile
@@ -80,6 +80,7 @@ include i2c$(DELIM)Make.defs
 include iotdev$(DELIM)Make.defs
 include lwnl${DELIM}Make.defs
 include net$(DELIM)Make.defs
+include otp$(DELIM)Make.defs
 include pipes$(DELIM)Make.defs
 include power$(DELIM)Make.defs
 include seclink$(DELIM)Make.defs

--- a/os/drivers/otp/Make.defs
+++ b/os/drivers/otp/Make.defs
@@ -1,0 +1,35 @@
+###########################################################################
+#
+# Copyright 2019 Samsung Electronics All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+#
+###########################################################################
+
+# Don't build anything if there is no OTP support
+
+ifeq ($(CONFIG_OTP),y)
+
+CSRCS += otp.c
+
+ifeq ($(CONFIG_OTP_NULL), y)
+CSRCS += otpnull.c
+endif
+
+# Include OTP device driver build support
+
+DEPPATH += --dep-path otp
+VPATH += :otp
+CFLAGS += ${shell $(INCDIR) $(INCDIROPT) "$(CC)" $(TOPDIR)$(DELIM)drivers$(DELIM)otp}
+endif
+

--- a/os/drivers/otp/otp.c
+++ b/os/drivers/otp/otp.c
@@ -1,0 +1,296 @@
+/****************************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+#include <tinyara/config.h>
+
+#include <stdio.h>
+#include <semaphore.h>
+#include <errno.h>
+#include <debug.h>
+
+#include <tinyara/kmalloc.h>
+#include <tinyara/otp.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+#define OTP_DEV_PATH "/dev/otp"
+
+#define OU_LOCK(priv)										\
+	do {													\
+		int oulock_ret = sem_wait(&priv->ou_exclsem);		\
+		if (oulock_ret < 0) {								\
+			lldbg("ERROR: ou_lock failed: %d\n", oulock_ret);	\
+			return oulock_ret;										\
+		}													\
+	} while (0)
+
+#define OU_UNLOCK(priv)									\
+	do {													\
+		int oulock_ret = sem_post(&priv->ou_exclsem);		\
+		if (oulock_ret < 0) {								\
+			lldbg("ERROR: ou unlock failed: %d\n", oulock_ret);	\
+			return oulock_ret;										\
+		}													\
+	} while (0)
+
+/****************************************************************************
+ * Private Types
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Function Prototypes
+ ****************************************************************************/
+static int     otp_open(struct file *filep);
+static int     otp_close(struct file *filep);
+static ssize_t otp_read(struct file *filep, char *buffer, size_t buflen);
+static int     otp_ioctl(struct file *filep, int cmd, unsigned long arg);
+
+static int otp_uh_read(struct otp_upperhalf_s *upper, uint32_t addr, uint8_t *data, uint32_t *length);
+static int otp_uh_write(struct otp_upperhalf_s *upper, uint32_t addr, uint8_t *data, uint32_t length);
+static int otp_uh_lock(struct otp_upperhalf_s *upper);
+
+
+/****************************************************************************
+ * Private Variables
+ ****************************************************************************/
+static const struct file_operations g_otp_ops = {
+	otp_open,	/* open	 */
+	otp_close,	/* close */
+	otp_read,	/* read	 */
+	NULL,		/* write */
+	NULL,		/* seek	 */
+	otp_ioctl,	/* ioctl */
+#ifndef CONFIG_DISABLE_POLL
+	NULL	/* poll	 */
+#endif
+};
+
+static const struct otp_upperhalf_ops_s g_uh_ops = {
+	otp_uh_write,
+	otp_uh_read,
+	otp_uh_lock,
+};
+
+static struct otp_upperhalf_s *g_otp_dev = NULL;
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+int otp_uh_read(struct otp_upperhalf_s *upper, uint32_t addr, uint8_t *data, uint32_t *length)
+{
+	FAR struct otp_lowerhalf_s *lower = upper->ou_lower;
+	OU_LOCK(upper);
+
+	// setting address should be updated
+	int res = lower->ops->read(lower, 0, data, length);
+	if (res < 0) {
+		OU_UNLOCK(upper);
+		return ENOTTY;
+	}
+	OU_UNLOCK(upper);
+
+	return *length;
+}
+
+int otp_uh_write(struct otp_upperhalf_s *upper, uint32_t addr, uint8_t *data, uint32_t length)
+{
+	FAR struct otp_lowerhalf_s *lower = upper->ou_lower;
+
+	// setting address should be updated
+	OU_LOCK(upper);
+	int res = lower->ops->write(lower, addr, data, length);
+	if (res < 0) {
+		OU_UNLOCK(upper);
+		return ENOTTY;
+	}
+	OU_UNLOCK(upper);
+	return res;
+}
+
+int otp_uh_lock(struct otp_upperhalf_s *upper)
+{
+	FAR struct otp_lowerhalf_s *lower = upper->ou_lower;
+	OU_LOCK(upper);
+	int res = lower->ops->lock(lower);
+	if (res < 0) {
+		OU_UNLOCK(upper);
+		return -1;
+	}
+	OU_UNLOCK(upper);
+	return 0;
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+
+/****************************************************************************
+ * Name: otp_read
+ *
+ * Description:
+ *    This function is automatically called when you handle the read() API in
+ *    File system.
+ *
+ ****************************************************************************/
+static ssize_t otp_read(struct file *filep, char *buffer,
+						size_t buflen)
+{
+	FAR struct inode *inode = filep->f_inode;
+	FAR struct otp_upperhalf_s *priv = inode->i_private;
+	int res = OTP_READ(priv, 0, (uint8_t *)buffer, &buflen);
+	if (res < 0) {
+		lldbg("Fail to read\n");
+		return ENOTTY;
+	}
+	return buflen;
+}
+
+/****************************************************************************
+ * Name: otp_ioctl
+ *
+ * Description:
+ *    This function is allow you to control the event.
+ *
+ ****************************************************************************/
+static int otp_ioctl(struct file *filep, int cmd, unsigned long arg)
+{
+	return 0;
+}
+
+
+/****************************************************************************
+ * Name: otp_close
+ *
+ * Description:
+ *   This routine is called when the otp gets closed.
+ *
+ ****************************************************************************/
+static int otp_close(struct file *filep)
+{
+	return 0;
+}
+
+/*****************************************************************************
+ * Name: otp_open
+ *
+ * Description:
+ *   This routine is called whenever otp is opened.
+ *
+ ****************************************************************************/
+static int otp_open(struct file *filep)
+{
+	return 0;
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: otp_register
+ *
+ * Description:
+ *   Register OTP device.
+ *
+ ****************************************************************************/
+int otp_register(struct otp_lowerhalf_s *lower)
+{
+	int ret;
+	FAR struct otp_upperhalf_s *priv;
+
+	DEBUGASSERT(lower);
+
+	if (g_otp_dev) {
+		return -1;
+	}
+
+	/* Allocate a new GPIO driver instance */
+	priv = (FAR struct otp_upperhalf_s *)
+		kmm_zalloc(sizeof(struct otp_upperhalf_s));
+	if (!priv) {
+		lldbg("ERROR: Failed to allocate device structure\n");
+		return -ENOMEM;
+	}
+
+	sem_init(&priv->ou_exclsem, 0, 1);
+	priv->ops = &g_uh_ops;
+	/* Initiailize the new GPIO driver instance */
+	priv->ou_lower = lower;
+	lower->parent = priv;
+
+	/* And register the GPIO driver */
+	ret = register_driver(OTP_DEV_PATH, &g_otp_ops, 0444, priv);
+	if (ret < 0) {
+		lldbg("ERROR: register driver failed: %d\n", ret);
+		goto errout_with_priv;
+	}
+	g_otp_dev = priv;
+
+	return OK;
+
+errout_with_priv:
+	sem_destroy(&priv->ou_exclsem);
+	kmm_free(priv);
+	return ret;
+}
+
+/****************************************************************************
+ * Name: otp_unregister
+ *
+ * Description:
+ *   unregister OTP device.
+ *
+ ****************************************************************************/
+int otp_unregister(void)
+{
+	if (!g_otp_dev) {
+		lldbg("ERROR: no registered device\n");
+		return -1;
+	}
+
+	unregister_driver(OTP_DEV_PATH);
+
+	sem_destroy(&g_otp_dev->ou_exclsem);
+	kmm_free(g_otp_dev);
+	g_otp_dev = NULL;
+
+	return 0;
+}
+
+/****************************************************************************
+ * Name: get_otp_dev
+ *
+ * Description:
+ *   Get otp lower device.
+ *   Programs(SE) in a kernel space can access otp by this function
+ *
+ ****************************************************************************/
+struct otp_upperhalf_s *get_otp_dev(void)
+{
+	if (!g_otp_dev) {
+		lldbg("ERROR: no registered device\n");
+		return NULL;
+	}
+	return g_otp_dev;
+}

--- a/os/drivers/otp/otpnull.c
+++ b/os/drivers/otp/otpnull.c
@@ -1,0 +1,47 @@
+#include <tinyara/config.h>
+#include <sys/types.h>
+#include <debug.h>
+#include <tinyara/otp.h>
+#undef dbg
+#define dbg printf
+
+static int on_write(struct otp_lowerhalf_s *dev, uint32_t address, uint8_t *data, uint32_t length)
+{
+	dbg("%s(%s:%d)\n", __FUNCTION__, __FILE__, __LINE__);
+	return 0;
+}
+static int on_read(struct otp_lowerhalf_s *dev, uint32_t address, uint8_t *data, uint32_t *length)
+{
+	dbg("%s(%s:%d)\n", __FUNCTION__, __FILE__, __LINE__);
+	return 0;
+}
+static int on_lock(struct otp_lowerhalf_s *dev)
+{
+	dbg("%s(%s:%d)\n", __FUNCTION__, __FILE__, __LINE__);
+	return 0;
+}
+
+static struct otp_ops_s g_on_ops = {
+	on_write,
+	on_read,
+	on_lock,
+};
+
+struct otp_lowerhalf_s g_on_lower = {
+	&g_on_ops,
+	NULL,
+	NULL,
+};
+
+int create_otpnull(void)
+{
+	otp_register(&g_on_lower);
+	return 0;
+}
+
+int destroy_otpnull(void)
+{
+	otp_unregister();
+	return 0;
+}
+

--- a/os/include/tinyara/otp.h
+++ b/os/include/tinyara/otp.h
@@ -1,0 +1,111 @@
+/****************************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __INCLUDE_TINYARA_OTP_H__
+#define __INCLUDE_TINYARA_OTP_H__
+
+#include <tinyara/config.h>
+#include <stdint.h>
+
+struct otp_lowerhalf_s;
+struct otp_ops_s {
+	int (*write)(struct otp_lowerhalf_s *dev, uint32_t address, uint8_t *data, uint32_t length);
+	int (*read)(struct otp_lowerhalf_s *dev, uint32_t address, uint8_t *data, uint32_t *length);
+	int (*lock)(struct otp_lowerhalf_s *dev);
+};
+
+struct otp_lowerhalf_s {
+	const struct otp_ops_s *ops;
+	struct otp_upperhalf_s *parent;
+	void *data; // contain vendor specific data
+};
+
+struct otp_upperhalf_ops_s {
+	int (*otp_uh_write)(struct otp_upperhalf_s *upper, uint32_t addr, uint8_t *buf, uint32_t length);
+	int (*otp_uh_read)(struct otp_upperhalf_s *upper, uint32_t addr, uint8_t *buf, uint32_t *length);
+	int (*otp_uh_lock)(struct otp_upperhalf_s *upper);
+};
+
+struct otp_upperhalf_s {
+	/* Saved binding to the lower-half OTP driver */
+	struct otp_lowerhalf_s *ou_lower; /* Arch-specific operations */
+	const struct otp_upperhalf_ops_s *ops;
+	sem_t ou_exclsem;	/* Supports exclusive access to the device */
+};
+
+#define OTP_WRITE(dev, addr, buf, buflen) \
+	dev->ops->otp_uh_write(dev, addr, buf, buflen)
+
+#define OTP_READ(dev, addr, buf, buflen) \
+	dev->ops->otp_uh_read(dev, addr, buf, buflen)
+
+#define OTP_LOCK(dev) \
+	dev->ops->otp_uh_lock(dev)
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+#undef EXTERN
+#if defined(__cplusplus)
+#define EXTERN extern "C"
+extern "C" {
+#else
+#define EXTERN extern
+#endif
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: otp_register
+ *
+ * Description:
+ *   Register OTP device to VFS
+ *
+ ****************************************************************************/
+int otp_register(struct otp_lowerhalf_s *lower);
+
+/****************************************************************************
+ * Name: otp_unregister
+ *
+ * Description:
+ *   Unregister OTP device to VFS
+ *
+ ****************************************************************************/
+int otp_unregister(void);
+
+/****************************************************************************
+ * Name: get_otp_dev
+ *
+ * Description:
+ *   Get otp lower device.
+ *   Programs(SE) in a kernel space can access otp by this function
+ *
+ ****************************************************************************/
+struct otp_upperhalf_s *get_otp_dev(void);
+
+#undef EXTERN
+#if defined(__cplusplus)
+}
+#endif
+
+#endif //__INCLUDE_TINYARA_OTP_H__
+
+


### PR DESCRIPTION
To provide otp service to applications and kernel modules otp driver
need to be defined. Applications can access otp by refering
"tinyara/otp.h" header. but it's not allowed to write otp. however,
kernel modules can write otp to store device specific data.