### PR TITLE
apps/system/utils/heapinfo : Support heapinfo for binary separation

### DIFF
--- a/apps/system/utils/utils_heapinfo.c
+++ b/apps/system/utils/utils_heapinfo.c
@@ -137,13 +137,13 @@ static void heapinfo_print_values(char *buf)
 	printf(")\n");
 }
 
-static int heapinfo_read_proc(pid_t pid)
+static int heapinfo_read_proc(FAR struct dirent *entryp, FAR void *arg)
 {
 	int ret;
 	char *filepath;
 	char buf[HEAPINFO_BUFLEN];
 
-	asprintf(&filepath, "%s/%d/%s", PROCFS_MOUNT_POINT, pid, "stat");
+	asprintf(&filepath, "%s/%s/%s", PROCFS_MOUNT_POINT, entryp->d_name, "stat");
 	ret = utils_readfile(filepath, buf, HEAPINFO_BUFLEN, heapinfo_print_values);
 	if (ret < 0) {
 		printf("Failed to read %s\n", filepath);
@@ -187,8 +187,6 @@ static void heapinfo_show_group(void)
 
 static void heapinfo_show_taskinfo(struct mm_heap_s *heap)
 {
-	int tcb_idx;
-	int heap_idx;
 #if !defined(CONFIG_FS_AUTOMOUNT_PROCFS)
 	int ret;
 	bool is_mounted;
@@ -218,13 +216,7 @@ static void heapinfo_show_taskinfo(struct mm_heap_s *heap)
 #endif
 	printf("-------|-----------|-----------|----------\n");
 
-	for (heap_idx = 0; heap_idx < CONFIG_MM_NHEAPS; heap_idx++) {
-		for (tcb_idx = 0; tcb_idx < CONFIG_MAX_TASKS; tcb_idx++) {
-			if (heap[heap_idx].alloc_list[tcb_idx].pid != HEAPINFO_INIT_INFO) {
-				heapinfo_read_proc(heap[heap_idx].alloc_list[tcb_idx].pid);
-			}
-		}
-	}
+	utils_proc_pid_foreach(heapinfo_read_proc);
 
 #if !defined(CONFIG_FS_AUTOMOUNT_PROCFS)
 	if (!is_mounted) {
@@ -269,7 +261,22 @@ int utils_heapinfo(int argc, char **args)
 #if CONFIG_MM_NHEAPS > 1
 	heapinfo_init_totalinfo();
 #endif
-	struct mm_heap_s *heap = g_mmheap;
+#ifdef CONFIG_MM_KERNEL_HEAP
+	struct mm_heap_s *heap = g_kmmheap;
+#else
+	void *temp_addr = malloc(1);
+	if (temp_addr == NULL) {
+		printf("Fail to run heapinfo : Out of memory.\n");
+		return -ENOMEM;
+	}
+	struct mm_heap_s *heap = mm_get_heap(temp_addr);
+	free(temp_addr);
+	if (heap == NULL) {
+		printf("Fail to run heapinfo : Operation fail.\n");
+		return -EFAULT;
+	}
+#endif
+
 	while ((option = getopt(argc, args, "iap:fge:rk")) != ERROR) {
 #if CONFIG_MM_NHEAPS > 1
 		summary_option = false;

--- a/os/fs/procfs/fs_procfsproc.c
+++ b/os/fs/procfs/fs_procfsproc.c
@@ -381,7 +381,11 @@ static ssize_t proc_entry_stat(FAR struct proc_file_s *procfile, FAR struct tcb_
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
 	if (tcb->pid == 0) {
 		/* Idle task normally uses heap with index 0. */
+#ifndef CONFIG_BUILD_PROTECTED
 		heap = mm_get_heap_with_index(0);
+#else
+		heap = &g_kmmheap;
+#endif
 	} else {
 		heap = mm_get_heap(tcb->stack_alloc_ptr);
 	}

--- a/os/mm/mm_heap/mm_initialize.c
+++ b/os/mm/mm_heap/mm_initialize.c
@@ -231,6 +231,7 @@ void mm_initialize(FAR struct mm_heap_s *heap, FAR void *heapstart, size_t heaps
 	for (i = 0; i < CONFIG_MAX_TASKS; i++) {
 		heap->alloc_list[i].pid = HEAPINFO_INIT_INFO;
 	}
+	heap->total_alloc_size = heap->peak_alloc_size = 0;
 #ifdef CONFIG_HEAPINFO_USER_GROUP
 	heapinfo_update_group_info(-1, -1, HEAPINFO_INIT_INFO);
 #endif


### PR DESCRIPTION
1. change getting user heap with temp allocated memory
2. show whole task/pthread current and peak heap usage
3. add initialization for total and peak alloc size of user heap