### PR TITLE
framework/media: Add missed header

### DIFF
--- a/framework/include/media/BufferObserverInterface.h
+++ b/framework/include/media/BufferObserverInterface.h
@@ -29,6 +29,8 @@
 #ifndef __MEDIA_STREAMOBSERVERINTERFACE_H
 #define __MEDIA_STREAMOBSERVERINTERFACE_H
 
+#include <sys/types.h>
+
 namespace media {
 namespace stream {
 /**

--- a/framework/src/media/InputHandler.cpp
+++ b/framework/src/media/InputHandler.cpp
@@ -18,6 +18,7 @@
 
 #include <tinyara/config.h>
 
+#include <debug.h>
 #include <pthread.h>
 
 #include "InputHandler.h"


### PR DESCRIPTION
- BufferObserverInterface needs <sys/types.h> becase of ssize_t
- InputHandler needs <debug.h> because of meddbg