### PR TITLE
testcase/le_tc/filesystem: Add config dependency (CONFIG_FS_SMARTFS)

### DIFF
--- a/apps/examples/testcase/le_tc/filesystem/fs_main.c
+++ b/apps/examples/testcase/le_tc/filesystem/fs_main.c
@@ -3767,7 +3767,7 @@ int tc_filesystem_main(int argc, char *argv[])
 #ifdef CONFIG_ITC_FS
 	itc_fs_main();
 #endif
-#if defined(CONFIG_TC_FS_PROCFS) && !defined(CONFIG_SMARTFS_MULTI_ROOT_DIRS) && !defined(CONFIG_BUILD_PROTECTED)
+#if defined(CONFIG_TC_FS_PROCFS) && defined(CONFIG_FS_SMARTFS) && !defined(CONFIG_SMARTFS_MULTI_ROOT_DIRS) && !defined(CONFIG_BUILD_PROTECTED)
 	tc_fs_smartfs_mksmartfs();
 #endif
 	(void)tc_handler(TC_END, "FileSystem TC");

--- a/apps/examples/testcase/le_tc/filesystem/tc_fs_procfs.c
+++ b/apps/examples/testcase/le_tc/filesystem/tc_fs_procfs.c
@@ -224,7 +224,7 @@ static int procfs_rewind_tc(const char *dirpath)
 
 	return OK;
 }
-#if !defined(CONFIG_SMARTFS_MULTI_ROOT_DIRS) && !defined(CONFIG_BUILD_PROTECTED)
+#if defined(CONFIG_FS_SMARTFS) && !defined(CONFIG_SMARTFS_MULTI_ROOT_DIRS) && !defined(CONFIG_BUILD_PROTECTED)
 void tc_fs_smartfs_mksmartfs(void)
 {
 	int ret;


### PR DESCRIPTION
This patch adds config check for smartfs while running the smartfs testcases.