### PR TITLE
iotivity: socket error fix with code 23

### DIFF
--- a/external/iotivity/iotivity_1.2-rel/resource/csdk/connectivity/src/tcp_adapter/catcpserver.c
+++ b/external/iotivity/iotivity_1.2-rel/resource/csdk/connectivity/src/tcp_adapter/catcpserver.c
@@ -745,6 +745,7 @@ static CAResult_t CATCPCreateSocket(int family, CATCPSessionInfo_t *svritem)
     if (connect(fd, (struct sockaddr *)&sa, socklen) < 0)
     {
         OIC_LOG_V(ERROR, TAG, "failed to connect socket, %s", strerror(errno));
+        close(fd);
         CALogSendStateInfo(svritem->sep.endpoint.adapter, svritem->sep.endpoint.addr,
                            svritem->sep.endpoint.port, 0, false, strerror(errno));
         return CA_SOCKET_OPERATION_FAILED;


### PR DESCRIPTION
If DNS is not working(e.g. AP is unplugged), then Iotivity attempts to
connect to the cloud server with wrong IP address that AP give. Some
AP reply a wrong IP address even though internet is not connected. So
Iotivity stack fails to connect, but it doesn't call close().
So it caused a socket list to run out. therefore it makes socket error code 23