### PR TITLE
kernel/task_exithook : Remove ppid initialization when task termination

### DIFF
--- a/os/kernel/task/task_exithook.c
+++ b/os/kernel/task/task_exithook.c
@@ -410,9 +410,6 @@ static inline void task_signalparent(FAR struct tcb_s *ctcb, int status)
 
 	task_sigchild(ptcb, ctcb, status);
 
-	/* Forget who our parent was */
-
-	ctcb->group->tg_ppid = INVALID_PROCESS_ID;
 	sched_unlock();
 #endif
 }


### PR DESCRIPTION
Ppid initialization is not needed when task/pthread is terminated.
Because, even if one of the task/pthread in group is terminated, the remaining may be needed the ppid.