### PR TITLE
Reduce loading time for block-wise compressed binaries

### DIFF
--- a/os/compression/Kconfig
+++ b/os/compression/Kconfig
@@ -29,4 +29,12 @@ config COMPRESSION_BLOCK_SIZE
 	---help---
 		Enter block size to use for compression of binary.
 
+config DECOMPRESSION_CACHE_BLOCKS
+	int "Blocks for caching when loading binary"
+	default 60
+	range 2 100
+	---help---
+		Enter number of blocks to use for caching decompressed
+		blocks from block-wise compressed binary when loading
+
 endif # COMPRESSED_BINARY

--- a/os/compression/compress_read.c
+++ b/os/compression/compress_read.c
@@ -382,8 +382,8 @@ int compress_init(int filfd, uint16_t offset, off_t *filelen)
 #if CONFIG_COMPRESSION_TYPE == 1
 	/* Allocating memory for read and out buffer to be used for LZMA decompression */
 	if (compression_header.compression_format == COMPRESSION_TYPE_LZMA) {
-		buffers.read_buffer = (unsigned char *)malloc(compression_header.blocksize + 5);
-		buffers.out_buffer = (unsigned char *)malloc(compression_header.blocksize);
+		buffers.read_buffer = (unsigned char *)kmm_malloc(compression_header.blocksize + 5);
+		buffers.out_buffer = (unsigned char *)kmm_malloc(compression_header.blocksize);
 	}
 #endif
 

--- a/os/compression/compress_read.c
+++ b/os/compression/compress_read.c
@@ -39,8 +39,24 @@
  * Private Declarations
  ****************************************************************************/
 
-struct s_header compression_header;
-struct s_buffer buffers;
+static struct s_header compression_header;
+
+/* Number of blocks for caching */
+static unsigned int number_blocks_caching;
+
+/* Pointer to block_cache_t list to be used for holding uncompressed blocks */
+static block_cache_t *blockcache;
+
+/* Pointers for maintaining doubly linked list of blockcache */
+static block_cache_t *head;		/* Pointer to least priority block for caching */
+static block_cache_t *tail;		/* Pointer to highest priority block for caching */
+static block_cache_t *most_accessed;	/* Pointer to most accessed block for quick access */
+
+/* Number of requests for the most accessed block in blockcache list */
+static unsigned int max_accessed_count;
+
+/* Buffer to be used for reading compressed data from blockwise compressed binary */
+static unsigned char *compressed_data_buffer;
 
 /****************************************************************************
  * Private Functions
@@ -50,13 +66,13 @@ struct s_buffer buffers;
  * Name: compress_decompress_block
  *
  * Description:
- *   Decompress block in 'read_buffer' of readsize into 'out_buffer' of writesize
+ *   Decompress block in 'compressed_data_buffer' of readsize into 'out_buffer' of writesize
  *
  * Returned Value:
  *   Non-negative value on Success.
  *   Negative value on Failure.
  ****************************************************************************/
-static int compress_decompress_block(unsigned char *out_buffer, unsigned int *writesize, unsigned char *read_buffer, unsigned int *size, int index)
+static int compress_decompress_block(unsigned char *out_buffer, unsigned int *writesize, unsigned char *read_buf, unsigned int *size, int index)
 {
 	int ret = ERROR;
 
@@ -66,7 +82,7 @@ static int compress_decompress_block(unsigned char *out_buffer, unsigned int *wr
 		*writesize = compression_header.blocksize;
 		*size -= (LZMA_PROPS_SIZE);
 
-		ret = LzmaUncompress(&out_buffer[0], writesize, &read_buffer[LZMA_PROPS_SIZE], size, &read_buffer[0], LZMA_PROPS_SIZE);
+		ret = LzmaUncompress(&out_buffer[0], writesize, &read_buf[LZMA_PROPS_SIZE], size, &read_buf[0], LZMA_PROPS_SIZE);
 
 		if (ret == SZ_ERROR_FAIL) {
 			bmdbg("Failure to decompress with LZMAUncompress API\n");
@@ -213,10 +229,11 @@ static off_t compress_lseek_block(int filfd, uint16_t binary_header_size, int bl
  * Name: compress_read_block
  *
  * Description:
- *   Read 'block_number' block from compressed blocks section into read_buffer
+ *   Read 'block_number' block from compressed blocks section into
+ *   compressed_data_buffer.
  *
  * Returned Value:
- *   Number of bytes read into read_buffer on Success
+ *   Number of bytes read into compressed_data_buffer on Success
  *   Negative value on Failure
  ****************************************************************************/
 static off_t compress_read_block(int filfd, uint16_t binary_header_size, FAR uint8_t *buf, int block_number)
@@ -264,6 +281,180 @@ static off_t compress_read_block(int filfd, uint16_t binary_header_size, FAR uin
 }
 
 /****************************************************************************
+ * Name: compress_update_blockcache_list
+ *
+ * Description:
+ *   Update blockcache list based on whether 'block_number' block in
+ *   blockwise-compressed binary is already cached or not. Also, maintain
+ *   head, tail and most_accessed pointers. Decompress block if not cached.
+ *   tail = most recently cached block (highest priority block for keeping
+ *          cached)
+ *   head = oldest cached block (lowest priority for keeping it cached).
+ *          If a new block needs to be cached, cache to this blockcache element.
+ *   most_accessed = pointer to most accessed block in blockcache list.
+ *          Needed for easy access to most accessed block from comp. binary.
+ *
+ * Returned Value:
+ *   Index in blockcache list where 'block_number' block number from compressed
+ *   binary is cached in uncompressed form. Return Negative value on failure.
+ ****************************************************************************/
+static unsigned int compress_update_blockcache_list(int block_number, int filfd, uint16_t binary_header_size)
+{
+	unsigned int blockcache_index;	/* Which blockcache element has needed uncompressed data for read */
+	block_cache_t *ptr;		/* Pointer to element in blockcache list which will be updated */
+	block_cache_t *temp;		/* Used when updating blockcache list */
+	bool flag_for_caching;		/* 1 = Block needs to be cached, 0 = Block already cached */
+	bool update_most_accessed;	/* 1 = Most accessed block is being removed from blockcache.
+					 *     Need to update most accessed pointer from scratch */
+	unsigned int writesize;
+	int size;
+	int ret;
+
+	/* Initialize flags */
+	flag_for_caching = true;
+	update_most_accessed = false;
+
+	/* First check is with block_number at most_accessed pointer */
+	if (most_accessed->block_number == block_number) {
+		flag_for_caching = false;
+		blockcache_index = most_accessed->index_block_cache;
+	}
+
+	/* Start checking for if block is cached from the tail */
+	if (flag_for_caching == true) {
+		ptr = tail;
+		while (ptr != NULL) {
+			if (ptr->block_number == block_number) {
+				flag_for_caching = false;
+				blockcache_index = ptr->index_block_cache;
+				break;
+			} else {
+				ptr = ptr->prev;
+			}
+		}
+	}
+
+	/* If block_number block from compressed binary needs to be cached */
+	if (flag_for_caching == true) {
+
+		/* If most_accessed == head, need to update most_accessed */
+		if (head == most_accessed)
+			update_most_accessed = true;
+
+		/* Detach head, Reassign head to head->next */
+		ptr = head;
+		head = ptr->next;
+		head->prev = ptr->prev;
+
+		/* Read compressed 'block_number' block into compressed_data_buffer */
+		size = compress_read_block(filfd, binary_header_size, compressed_data_buffer, block_number);
+		if (size < 0) {
+			bmdbg("Read for compressed block %d failed\n", block_number);
+			return ERROR;
+		}
+
+		/* Decompress block in compressed_data_buffer to chosen blockcache element */
+		ret = compress_decompress_block(ptr->out_buffer, &writesize, compressed_data_buffer, &size, block_number);
+		if (ret == ERROR) {
+			bmdbg("Failed to decompress %d block of this binary\n", block_number);
+			return ret;
+		}
+
+		/* Update block_number, Number of requests */
+		ptr->block_number = block_number;
+		ptr->no_requests_for_block = 1;
+
+		/* Updating most_accessed pointer */
+		if (ptr->no_requests_for_block >= max_accessed_count) {
+			max_accessed_count = ptr->no_requests_for_block;
+			most_accessed = ptr;
+		}
+
+		/* Always attach ptr at tail */
+		temp = tail;
+		temp->next = ptr;
+		ptr->prev = temp;
+		ptr->next = NULL;
+		tail = ptr;
+
+		/* Update most_accessed from scratch, if needed */
+		if (update_most_accessed == true) {
+			max_accessed_count = 0;
+			temp = tail;
+			while (temp != NULL) {
+				if (temp->no_requests_for_block > max_accessed_count) {
+					max_accessed_count = temp->no_requests_for_block;
+					most_accessed = temp;
+				}
+				temp = temp->prev;
+			}
+		}
+
+		/* Update blockcache_index into which block is uncompressed */
+		blockcache_index = ptr->index_block_cache;
+
+	} else { /* If block is already cached */
+
+		/* If block is cached at head location */
+		if (head == &blockcache[blockcache_index]) {
+			/* Detach head, Reassign head to head->next */
+			ptr = head;
+			head = ptr->next;
+			head->prev = ptr->prev;
+
+			ptr->no_requests_for_block += 1;
+
+			/* Update most_accessed pointer */
+			if (ptr->no_requests_for_block >= max_accessed_count) {
+				max_accessed_count = ptr->no_requests_for_block;
+				most_accessed = ptr;
+			}
+
+			/* Always attach ptr at tail */
+			temp = tail;
+			temp->next = ptr;
+			ptr->prev = temp;
+			ptr->next = NULL;
+			tail = ptr;
+
+		} else if (tail == &blockcache[blockcache_index]) { /* Block is cached at tail location */
+			blockcache[blockcache_index].no_requests_for_block += 1;
+
+			/* Update most_accessed pointer */
+			ptr = tail;
+			if (ptr->no_requests_for_block >= max_accessed_count) {
+				max_accessed_count = ptr->no_requests_for_block;
+				most_accessed = ptr;
+			}
+		} else { /* Block is cached at some other index in blockcache list */
+
+			/* Detach blockcache element at blockcache_index */
+			ptr = &blockcache[blockcache_index];
+			ptr->prev->next = ptr->next;
+			ptr->next->prev = ptr->prev;
+
+			/* Update Number of requests for block */
+			ptr->no_requests_for_block += 1;
+
+			/* Update most accessed pointer */
+			if (ptr->no_requests_for_block >= max_accessed_count) {
+				max_accessed_count = ptr->no_requests_for_block;
+				most_accessed = ptr;
+			}
+
+			/* Always attach ptr at tail */
+			temp = tail;
+			temp->next = ptr;
+			ptr->prev = temp;
+			ptr->next = NULL;
+			tail = ptr;
+		}
+	}
+
+	return blockcache_index;
+}
+
+/****************************************************************************
  * Name: compress_read
  *
  * Description:
@@ -281,78 +472,68 @@ int compress_read(int filfd, uint16_t binary_header_size, FAR uint8_t *buffer, s
 	int first_block;
 	int last_block;
 	int no_blocks;
-	int index;
-	int ret;
-	int actual_offset;			/* Offset from start of uncompressed file */
+	int block_number;		/* Block number in compressed file */
+	int actual_offset;		/* Offset from start of uncompressed file */
 	int block_size_to_write;	/* Size to write into buffer from decompressed block */
-	int buffer_index;
-	int blocksize;
-	unsigned int writesize;
-	unsigned int size;
+	int buffer_pos;			/* Position in buffer to start writing from */
+	int blocksize;			/* Blocksize used for compressing the binary */
+	unsigned int blockcache_index;	/* Which blockcache element has needed uncompressed data for read */
 
 	/* Setting first block, end block and number of blocks to read and decompressed */
 	blocksize = compression_header.blocksize;
 	compress_blocks_to_read(&first_block, &last_block, &no_blocks, offset, readsize);
 	if (first_block < 0 || no_blocks < 0) {
 		bmdbg("Incorrect first_block, no_blocks info\n");
-		buffer_index = ERROR;
+		buffer_pos = ERROR;
 		goto error_compress_read;
 	}
 
-	index = first_block;
-	buffer_index = 0;
+	block_number = first_block;
+	buffer_pos = 0;
 	/* Actual Offset in uncompressed file is same as Offset passed to this function */
 	actual_offset = offset;
 
 	/* Reading and decompressing blocks from first_block to last_block. Then writing to buffer. */
-	for (; index < first_block + no_blocks; index++) {
-		/* Read compressed 'index' block into read_buffer */
-		size = compress_read_block(filfd, binary_header_size, buffers.read_buffer, index);
-		if (size < 0) {
-			bmdbg("Read for compressed block %d failed\n", index);
-			buffer_index = size;
+	for (; block_number < first_block + no_blocks; block_number++) {
+
+		/* Update blockcache list and get uncompressed data into one of the blockcache elements */
+		blockcache_index = compress_update_blockcache_list(block_number, filfd, binary_header_size);
+		if (blockcache_index >= number_blocks_caching) {
+			buffer_pos = ERROR;
 			goto error_compress_read;
 		}
 
-		/* Decompress block in read_buffer to out_buffer */
-		ret = compress_decompress_block(buffers.out_buffer, &writesize, buffers.read_buffer, &size, index);
-		if (ret == ERROR) {
-			bmdbg("Failed to decompress %d block of this binary\n", index);
-			buffer_index = ret;
-			goto error_compress_read;
-		}
-
-		if (index == first_block) {
+		if (block_number == first_block) {
 			/*
 			 * Read appropriate number of bytes to buffer from this block using readsize and offset info.
 			 * If start_offset + readsize < end_offset, write from start_offset to start_offset + readsize.
 			 * Otherwise, write from start_offset to end_offset into buffer.
 			 */
-			block_size_to_write = ((index + 1) * blocksize - 1 > actual_offset + readsize - 1 ? readsize : (index + 1) * blocksize - actual_offset);
-			memcpy(&buffer[buffer_index], &buffers.out_buffer[actual_offset - (index * blocksize)], block_size_to_write);
-			buffer_index += block_size_to_write;
-		} else if (index == last_block) {
+			block_size_to_write = ((block_number + 1) * blocksize - 1 > actual_offset + readsize - 1 ? readsize : (block_number + 1) * blocksize - actual_offset);
+			memcpy(&buffer[buffer_pos], &blockcache[blockcache_index].out_buffer[actual_offset - (block_number * blocksize)], block_size_to_write);
+			buffer_pos += block_size_to_write;
+		} else if (block_number == last_block) {
 			/*
 			 * Read appropriate number of bytes to buffer from this block using readsize and offset info.
 			 * Calculate end_offset (Offset of last byte to write from this block).
 			 * Write from start_offset to end_offset from this block into buffer.
 			 */
-			block_size_to_write = actual_offset + readsize - (index * blocksize);
-			memcpy(&buffer[buffer_index], &buffers.out_buffer[0], block_size_to_write);
-			buffer_index += block_size_to_write;
+			block_size_to_write = actual_offset + readsize - (block_number * blocksize);
+			memcpy(&buffer[buffer_pos], &blockcache[blockcache_index].out_buffer[0], block_size_to_write);
+			buffer_pos += block_size_to_write;
 		} else {
 			/*
 			 * This is not the first or last block. This is intermediary block.
 			 * So, write entire block into buffer.
 			 */
 			block_size_to_write = blocksize;
-			memcpy(&buffer[buffer_index], &buffers.out_buffer[0], block_size_to_write);
-			buffer_index += block_size_to_write;
+			memcpy(&buffer[buffer_pos], &blockcache[blockcache_index].out_buffer[0], block_size_to_write);
+			buffer_pos += block_size_to_write;
 		}
 	}
 
 error_compress_read:
-	return buffer_index;
+	return buffer_pos;
 }
 
 /****************************************************************************
@@ -363,7 +544,7 @@ error_compress_read:
  *
  * Returned value:
  *   OK (0) on Success
- *   ERROR (-1) on Failure
+ *   Negative value on Failure
  ****************************************************************************/
 int compress_init(int filfd, uint16_t offset, off_t *filelen)
 {
@@ -379,13 +560,57 @@ int compress_init(int filfd, uint16_t offset, off_t *filelen)
 	/* Assign file length as that of uncompressed file */
 	*filelen = compression_header.binary_size;
 
+	/* Set number of blocks to use for caching */
+	if (CONFIG_DECOMPRESSION_CACHE_BLOCKS < (CUTOFF_RATIO_CACHE_BLOCKS) * (compression_header.sections - 1))
+		number_blocks_caching = CONFIG_DECOMPRESSION_CACHE_BLOCKS;
+	else
+		number_blocks_caching = ((CUTOFF_RATIO_CACHE_BLOCKS) * (compression_header.sections - 1));
+
+	/* Initialize max_accesed_count to 0 */
+	max_accessed_count = 0;
+
 #if CONFIG_COMPRESSION_TYPE == 1
-	/* Allocating memory for read and out buffer to be used for LZMA decompression */
+	/* Allocating memory for compressed_data_buffer and blockcache list to be used for LZMA decompression */
 	if (compression_header.compression_format == COMPRESSION_TYPE_LZMA) {
-		buffers.read_buffer = (unsigned char *)kmm_malloc(compression_header.blocksize + 5);
-		buffers.out_buffer = (unsigned char *)kmm_malloc(compression_header.blocksize);
+
+		compressed_data_buffer = (unsigned char *)kmm_malloc(compression_header.blocksize + 5);
+		if (!compressed_data_buffer) {
+			bmdbg("Failed kmm_malloc for read buffer\n");
+			return -ENOMEM;
+		}
+
+		blockcache = (block_cache_t *)kmm_malloc(number_blocks_caching * sizeof(block_cache_t));
+		if (!blockcache) {
+			bmdbg("Failed kmm_malloc for blockcache\n");
+			compress_uninit();
+			return -ENOMEM;
+		}
+
+		/* Initialize blockcache list */
+		for (int i = 0; i < number_blocks_caching; i++) {
+			blockcache[i].out_buffer = (unsigned char *)kmm_malloc(compression_header.blocksize);
+			if (!blockcache[i].out_buffer) {
+				bmdbg("Failed kmm_malloc for blockcache's out_buffer\n");
+				compress_uninit();
+				return -ENOMEM;
+			}
+
+			blockcache[i].block_number = -1;
+			blockcache[i].no_requests_for_block = 0;
+			blockcache[i].index_block_cache = i;
+			blockcache[i].next = &blockcache[(i + 1) % number_blocks_caching];
+			blockcache[i].prev = &blockcache[(i - 1) % number_blocks_caching];
+		}
 	}
 #endif
+
+	/* Assign head, tail and most_accessed pointers */
+	head = &blockcache[0];
+	tail = &blockcache[number_blocks_caching - 1];
+	most_accessed = tail;
+
+	head->prev = NULL;
+	tail->next = NULL;
 
 error_compress_init:
 	return ret;
@@ -402,7 +627,21 @@ error_compress_init:
  ****************************************************************************/
 void compress_uninit(void)
 {
-	/* Freeing memory allocated to read_buffer and out_buffer for file decompression */
-	free(buffers.read_buffer);
-	free(buffers.out_buffer);
+	/* Freeing memory allocated to compressed_data_buffer and blockcache for file decompression */
+	if (compressed_data_buffer) {
+		kmm_free(compressed_data_buffer);
+		compressed_data_buffer = NULL;
+	}
+
+	for (int i = 0; i < number_blocks_caching; i++) {
+		if (blockcache[i].out_buffer) {
+			kmm_free(blockcache[i].out_buffer);
+			blockcache[i].out_buffer = NULL;
+		}
+	}
+
+	if (blockcache) {
+		kmm_free(blockcache);
+		blockcache = NULL;
+	}
 }

--- a/os/include/tinyara/binfmt/compression/compress_read.h
+++ b/os/include/tinyara/binfmt/compression/compress_read.h
@@ -28,15 +28,23 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
+#define CUTOFF_RATIO_CACHE_BLOCKS 0.1f	/* Max. Ratio of blocks to be used for caching
+					 * to total number of compressed blocks in binary */
+
 /****************************************************************************
  * Public Types
  ****************************************************************************/
 
-/* Struct for buffers to be used for read/decompression */
-struct s_buffer {
-	unsigned char *read_buffer;
-	unsigned char *out_buffer;
+/* Struct for output buffers to cache uncompressed blocks */
+struct block_cache_s {
+	unsigned char *out_buffer;			/* Buffer that is going to hold uncompressed data */
+	int block_number;			/* Block number in compressed file for the cached block */
+	unsigned int no_requests_for_block;	/* Number of requests for current block that is cached */
+	unsigned int index_block_cache;		/* Index of block cache in the array */
+	struct block_cache_s *next;		/* Pointer to next element in doubly linked list */
+	struct block_cache_s *prev;		/* Pointer to previous element in doubly linked list */
 };
+typedef struct block_cache_s block_cache_t;
 
 /****************************************************************************
  * Function Prototypes

--- a/os/tools/compression/Makefile
+++ b/os/tools/compression/Makefile
@@ -31,7 +31,7 @@ OBJDIR		=  obj
 DEPDIR		=  dep
 SRCDIR		=  src
 
-CC		=  $(CROSS_COMPILE)gcc
+CC		=  gcc
 LDFLAGS		+=  -g
 LIBFILES	+=  -lm -lpthread
 ifeq ($(RELEASE),)


### PR DESCRIPTION
This PR makes following changes:
- Implements block caching to reduce time for loading block-wise compressed binaries.
- Replace malloc with kmm_malloc for dynamic memory allocation in compress_read.c file.
- Remove CROSS_COMPILE from CC assignment in Makefile for building compression tool. Use host PC's gcc compiler.