### PR TITLE
add araplayer service

### DIFF
--- a/apps/examples/araplayer/AraPlayer.cpp
+++ b/apps/examples/araplayer/AraPlayer.cpp
@@ -1,0 +1,262 @@
+/****************************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+#include "AraPlayer.h"
+#include "AudioHttpDownloader.h"
+#include "MediaPlayerWrapper.h"
+#include "AudioPDStream.h"
+#include "AudioHASStream.h"
+#include "AudioLocalStream.h"
+#include "AudioWorker.h"
+
+AraPlayer::AraPlayer() :
+	mCurrStream(nullptr)
+{
+}
+
+AraPlayer::~AraPlayer()
+{
+}
+
+void AraPlayer::initWorker()
+{
+	DEBUG_TRACE(LOG_INFO, "worker initialized");
+	return notifySync();
+}
+
+void AraPlayer::init()
+{
+	std::unique_lock<std::mutex> lock(mCmdMtx);
+	AudioWorker &aw = AudioWorker::getWorker();
+	Timer::getInstance();
+	initCurl();
+	aw.setCurl(mCurl);
+	aw.startWorker();
+	aw.enQueue(&AraPlayer::initWorker, shared_from_this());
+	mCv.wait(lock);
+}
+
+void AraPlayer::notifySync()
+{
+	std::unique_lock<std::mutex> lock(mCmdMtx);
+	mCv.notify_one();
+}
+
+void AraPlayer::initCurl()
+{
+	curl_global_init(CURL_GLOBAL_DEFAULT);
+	mCurl = (void *)curl_multi_init();
+	curl_multi_perform((CURLM *)mCurl, &running);
+}
+
+// TO-DO msg will be changed in MessagePort CB.
+AudioStream *AraPlayer::createStream(pid_t pid, ara_player_msg_t *msg)
+{
+	AudioStream *newStream = nullptr;
+	AudioWorker &aw = AudioWorker::getWorker();
+
+	switch (msg->streamType)
+	{
+	case STREAM_LOCAL:
+		newStream = new AudioLocalStream;
+		aw.disableCurl();
+		break;
+	case STREAM_HTTP_PROGRESSIVE:
+		newStream = new AudioPDStream;
+		aw.enableCurl();
+		break;
+	case STREAM_HTTP_HLS:
+		newStream = new AudioHASStream;
+		aw.enableCurl();
+		break;
+	default:
+		DEBUG_TRACE(LOG_ERR, "Stream Type Error!!![%d]", msg->streamType);
+		return NULL;
+	}
+
+	aw.setPlayer(shared_from_this());
+	newStream->setMainCurl(mCurl);
+	newStream->setState(msg);
+	newStream->setPid(pid);
+	newStream->getMediaPlayer()->setObserver(shared_from_this());
+	mStreamMap.insert(std::make_pair(pid, newStream));
+
+	return newStream;
+}
+
+void AraPlayer::execute(pid_t pid, ara_player_msg_t *msg)
+{
+	std::unique_lock<std::mutex> lock(mCmdMtx);
+
+	if (mCurrStream != nullptr && mCurrStream->getPriority() < msg->priority) {
+		std::cout << "The player using the current device has a higher priority than your player." << std::endl;
+		// TO-DO response to App.
+		return;
+	}
+
+	AudioWorker &aw = AudioWorker::getWorker();
+
+	switch (msg->cmdType)
+	{
+	case CMD_START:
+		aw.enQueue(&AraPlayer::start, shared_from_this(), pid, msg);
+		break;
+	case CMD_STOP:
+		aw.enQueue(&AraPlayer::stop, shared_from_this(), pid);
+		break;
+	case CMD_PAUSE:
+		aw.enQueue(&AraPlayer::pause, shared_from_this(), pid);
+		break;
+	case CMD_RESUME:
+		aw.enQueue(&AraPlayer::resume, shared_from_this(), pid);
+	default:
+		break;
+	}
+}
+
+void AraPlayer::start(pid_t pid, ara_player_msg_t *msg)
+{
+	AudioStream *nStream = nullptr;
+
+	mIter = mStreamMap.find(pid);
+	if (mIter == mStreamMap.end()) {
+		nStream = createStream(pid, msg);
+
+	} else {
+		nStream = (AudioStream *)mIter->second;
+		ara_player_stream_t prevStreamType = nStream->getStreamType();
+		ara_player_stream_t currStreamType = msg->streamType;
+		if (prevStreamType != currStreamType) {
+			if (prevStreamType == STREAM_HTTP_PROGRESSIVE) {
+				delete nStream;
+			}
+			mStreamMap.erase(pid);
+			nStream = createStream(pid, msg);
+		}
+
+		if (currStreamType == STREAM_HTTP_PROGRESSIVE) {
+			AudioWorker &aw = AudioWorker::getWorker();
+			aw.enableCurl();
+		}
+	}
+
+	mCurrStream = nStream;
+
+	if (nStream->getMediaPlayer()->getState() == MediaPlayerWrapper::State::None) {
+		nStream->setState(msg);
+		nStream->startStream();
+	}
+}
+
+void AraPlayer::stop(pid_t pid)
+{
+	mIter = mStreamMap.find(pid);
+	if (mIter != mStreamMap.end()) {
+		if (((AudioStream *)mIter->second)->getMediaPlayer()->getState() == MediaPlayerWrapper::State::Playing) {
+			AudioWorker &aw = AudioWorker::getWorker();
+			aw.disableCurl();
+			mIter->second->stopStream();
+		} else {
+			DEBUG_TRACE(LOG_DEBUG, "not playing\n");
+		}
+	} else {
+		DEBUG_TRACE(LOG_INFO, "The corresponding pid does not exist.");
+	}
+}
+
+void AraPlayer::pause(pid_t pid)
+{
+	mIter = mStreamMap.find(pid);
+	if (mIter != mStreamMap.end()) {
+		if (((AudioStream *)mIter->second)->getMediaPlayer()->getState() == MediaPlayerWrapper::State::Playing) {
+			AudioWorker &aw = AudioWorker::getWorker();
+			aw.disableCurl();
+			mIter->second->pauseStream();
+		} else {
+			DEBUG_TRACE(LOG_DEBUG, "not playing\n");
+		}
+	} else {
+		DEBUG_TRACE(LOG_INFO, "The corresponding pid does not exist.");
+	}
+}
+
+void AraPlayer::resume(pid_t pid)
+{
+	mIter = mStreamMap.find(pid);
+	if (mIter != mStreamMap.end()) {
+		if (((AudioStream *)mIter->second)->getMediaPlayer()->getState() == MediaPlayerWrapper::State::Paused) {
+			AudioWorker &aw = AudioWorker::getWorker();
+			aw.enableCurl();
+			mIter->second->resumeStream();
+		} else {
+			DEBUG_TRACE(LOG_DEBUG, "not playing\n");
+		}
+	} else {
+		DEBUG_TRACE(LOG_INFO, "The corresponding pid does not exist.");
+	}
+}
+
+std::map<pid_t, AudioStream *> &AraPlayer::getStreamMap()
+{
+	return mStreamMap;
+}
+
+void AraPlayer::onPlaybackStarted(MediaPlayer &mediaPlayer)
+{
+	DEBUG_TRACE(LOG_INFO, "onPlaybackStarted");
+}
+
+void AraPlayer::onPlaybackFinished(MediaPlayer &mediaPlayer)
+{
+	DEBUG_TRACE(LOG_INFO, "onPlaybackFinished");
+}
+
+void AraPlayer::onPlaybackError(MediaPlayer &mediaPlayer, player_error_t error)
+{
+	DEBUG_TRACE(LOG_INFO, "onPlaybackError");
+}
+
+void AraPlayer::onStartError(MediaPlayer &mediaPlayer, player_error_t error)
+{
+	DEBUG_TRACE(LOG_INFO, "onStartError");
+}
+
+void AraPlayer::onPauseError(MediaPlayer &mediaPlayer, player_error_t error)
+{
+	DEBUG_TRACE(LOG_INFO, "onPauseError");
+
+	//TO-DO compare the MediaPlayer ID
+	mCurrStream->getMediaPlayer()->stopPlay();
+}
+
+void AraPlayer::onPlaybackStopped(MediaPlayer &mediaPlayer)
+{
+	DEBUG_TRACE(LOG_INFO, "onPlaybackStopped");
+	//TO-DO compare the MediaPlayer ID
+	mCurrStream->getMediaPlayer()->deinit();
+}
+
+void AraPlayer::onStopError(MediaPlayer &mediaPlayer, player_error_t error)
+{
+	DEBUG_TRACE(LOG_INFO, "onStopError");
+}
+
+void AraPlayer::onPlaybackPaused(MediaPlayer &mediaPlayer)
+{
+	DEBUG_TRACE(LOG_INFO, "onPlaybackPaused");
+}

--- a/apps/examples/araplayer/AraPlayer.h
+++ b/apps/examples/araplayer/AraPlayer.h
@@ -1,0 +1,74 @@
+/****************************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __ARA_PLAYER_H__
+#define __ARA_PLAYER_H__
+
+#include <curl/curl.h>
+#include <list>
+#include <map>
+#include <mutex>
+#include <condition_variable>
+#include <queue>
+#include "MediaPlayerWrapper.h"
+#include "AudioUtils.h"
+#include "AudioQueue.h"
+#include "AudioStream.h"
+#include "AudioCommon.h"
+
+class AraPlayer : public MediaPlayerObserverInterface, public std::enable_shared_from_this<AraPlayer>
+{
+public:
+	AraPlayer();
+	virtual ~AraPlayer();
+
+	void init();
+	void start(pid_t, ara_player_msg_t *);
+	void stop(pid_t);
+	void pause(pid_t);
+	void resume(pid_t);
+	void execute(pid_t pid, ara_player_msg_t *msg);
+
+	virtual void onPlaybackStarted(MediaPlayer &mediaPlayer) override;
+	virtual void onPlaybackFinished(MediaPlayer &mediaPlayer) override;
+	virtual void onPlaybackStopped(MediaPlayer &mediaPlayer) override;
+	virtual void onPlaybackError(MediaPlayer &mediaPlayer, player_error_t error) override;
+	virtual void onStartError(MediaPlayer &mediaPlayer, player_error_t error) override;
+	virtual void onStopError(MediaPlayer &mediaPlayer, player_error_t error) override;
+	virtual void onPauseError(MediaPlayer &mediaPlayer, player_error_t error) override;
+	virtual void onPlaybackPaused(MediaPlayer &mediaPlayer) override;
+
+	std::map<pid_t, AudioStream *> &getStreamMap();
+
+private:
+	void initCurl();
+	void initWorker();
+	void notifySync();
+	AudioStream *createStream(pid_t, ara_player_msg_t *);
+
+private:
+	std::map<pid_t, AudioStream *> mStreamMap;
+	std::map<pid_t, AudioStream *>::iterator mIter;
+	std::condition_variable mCv;
+	std::mutex mCmdMtx;
+	AudioStream *mCurrStream;
+	AudioQueue mQueue;
+	void *mCurl;
+	int running;
+};
+#endif

--- a/apps/examples/araplayer/AraPlayerService.cpp
+++ b/apps/examples/araplayer/AraPlayerService.cpp
@@ -1,0 +1,289 @@
+/****************************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+//***************************************************************************
+// Included Files
+//***************************************************************************
+
+/* */
+
+#ifndef MPLINUX
+
+#include <tinyara/config.h>
+#include <tinyara/init.h>
+#include <tinyara/signal.h>
+
+#include <wifi_manager/wifi_manager.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <memory>
+#include <protocols/ntpclient.h>
+
+#include "AraPlayer.h"
+#include "AudioCommon.h"
+
+#define SSID "DENT_5G"
+#define PASSWORD "jonbeo1#"
+#define AUTH_TYPE WIFI_MANAGER_AUTH_WPA2_PSK
+#define CRYPTO_TYPE WIFI_MANAGER_CRYPTO_TKIP_AND_AES
+
+const char *radio_url = "http://111.119.28.213/stream/bbcmedia_radio2_mf_q?s=1555372806&e=1555387206&h=345be035221c0f70351b9c1f66617dfa";
+const char *local_url = "/rom/over_16000.mp3";
+const pid_t appPid = 1;
+
+/*
+ *Callback
+ */
+/* */ static bool g_wifi_connected = false;
+
+void __wm_sta_connected(wifi_manager_result_e res)
+{
+	printf(" T%d --> %s res(%d)\n", getpid(), __FUNCTION__, res);
+
+	g_wifi_connected = true;
+}
+
+void __wm_sta_disconnected(wifi_manager_disconnect_e disconn)
+{
+	printf(" T%d --> %s\n", getpid(), __FUNCTION__);
+
+	g_wifi_connected = false;
+}
+
+void __wm_softap_sta_join(void)
+{
+	printf(" T%d --> %s\n", getpid(), __FUNCTION__);
+}
+
+void __wm_softap_sta_leave(void)
+{
+	printf(" T%d --> %s\n", getpid(), __FUNCTION__);
+}
+
+static wifi_manager_cb_s multiroom_wifi_callbacks = {
+	__wm_sta_connected,
+	__wm_sta_disconnected,
+	__wm_softap_sta_join,
+	__wm_softap_sta_leave,
+	NULL,
+};
+
+void __wm_connect(void)
+{
+	wifi_manager_ap_config_s apconfig;
+	strncpy(apconfig.ssid, SSID, sizeof(SSID));
+	apconfig.ssid_length = strlen(apconfig.ssid);
+	apconfig.ap_auth_type = AUTH_TYPE;
+	if (apconfig.ap_auth_type != WIFI_MANAGER_AUTH_OPEN) {
+		strncpy(apconfig.passphrase, PASSWORD, sizeof(PASSWORD));
+		apconfig.passphrase_length = strlen(apconfig.passphrase);
+		apconfig.ap_crypto_type = CRYPTO_TYPE;
+	}
+
+	wifi_manager_result_e res = wifi_manager_connect_ap(&apconfig);
+	if (res != WIFI_MANAGER_SUCCESS) {
+		printf(" AP connect failed\n");
+		return;
+	}
+	/* Wait for DHCP connection */
+	printf(" wait join done [%s]\n", apconfig.ssid);
+}
+
+void __wm_sta_start(void)
+{
+	wifi_manager_result_e res = WIFI_MANAGER_SUCCESS;
+
+	res = wifi_manager_set_mode(STA_MODE, NULL);
+	if (res != WIFI_MANAGER_SUCCESS) {
+		printf(" Set STA mode Fail\n");
+		return;
+	}
+	printf(" Connecting to AP\n");
+}
+
+void wifi_start(void)
+{
+	wifi_manager_result_e res;
+
+	res = wifi_manager_init(&multiroom_wifi_callbacks);
+	if (res != WIFI_MANAGER_SUCCESS) {
+		printf(" wifi_manager_init fail\n");
+	}
+	__wm_sta_start();
+	__wm_connect();
+	while (g_wifi_connected == false) {
+		WAITMS(1000);
+	}
+
+	return;
+}
+
+void menu()
+{
+	std::cout << "=== BBC Radio ===" << std::endl;
+	std::cout << "1. play Radio" << std::endl;
+	std::cout << "2. pause Radio" << std::endl;
+	std::cout << "3. resume Radio" << std::endl;
+	std::cout << "4. stop Radio" << std::endl;
+
+	std::cout << "=== Local File ===" << std::endl;
+	std::cout << "5. play Local" << std::endl;
+	std::cout << "6. pause Local" << std::endl;
+	std::cout << "7. resume Local" << std::endl;
+	std::cout << "8. stop Local" << std::endl;
+
+	std::cout << "=== SBS Live Radio ===" << std::endl;
+	std::cout << "9. play Radio" << std::endl;
+	std::cout << "10. stop Radio" << std::endl;
+}
+
+int userInput(int min, int max)
+{
+	assert(min <= max);
+	int input = 0;
+
+	std::cin >> input;
+	std::cout << std::endl;
+
+	if (!std::cin.fail()) {
+		if (min <= input && input <= max) {
+			std::cout << "return input" << std::endl;
+			return input;
+		}
+	}
+
+	std::cin.clear();
+	std::cin.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
+
+	std::cout << "Invalid Input, please try again" << std::endl;
+
+	return input;
+}
+
+extern "C" {
+int AraPlayerService_main(int argc, char *argv[])
+{
+	int input = 0;
+	wifi_start();
+
+	auto instance = std::make_shared<AraPlayer>();
+	instance->init();
+	//TO-DO will change (example -> service(use binary manager))
+	while (1) {
+		menu();
+		input = userInput(1, 8);
+		printf("input = %d\n", input);
+		ara_player_msg_t *msg = new ara_player_msg_t;
+		switch (input) {
+		case 1: {
+			memset(msg, 0x00, sizeof(ara_player_msg_t));
+			msg->priority = PRIORITY_NORMAL;
+			msg->cmdType = CMD_START;
+			msg->streamType = STREAM_HTTP_PROGRESSIVE;
+			memcpy(msg->url, radio_url, strlen(radio_url) + 1);
+			instance->execute(appPid, msg);
+		}
+		break;
+		case 2: {
+			memset(msg, 0x00, sizeof(ara_player_msg_t));
+			msg->priority = PRIORITY_NORMAL;
+			msg->cmdType = CMD_PAUSE;
+			msg->streamType = STREAM_HTTP_PROGRESSIVE;
+			memcpy(msg->url, radio_url, strlen(radio_url) + 1);
+			instance->execute(appPid, msg);
+		}
+		break;
+		case 3: {
+			memset(msg, 0x00, sizeof(ara_player_msg_t));
+			msg->priority = PRIORITY_NORMAL;
+			msg->cmdType = CMD_RESUME;
+			msg->streamType = STREAM_HTTP_PROGRESSIVE;
+			memcpy(msg->url, radio_url, strlen(radio_url) + 1);
+			instance->execute(appPid, msg);
+		}
+		break;
+		case 4: {
+			memset(msg, 0x00, sizeof(ara_player_msg_t));
+			msg->priority = PRIORITY_NORMAL;
+			msg->cmdType = CMD_STOP;
+			msg->streamType = STREAM_HTTP_PROGRESSIVE;
+			memcpy(msg->url, radio_url, strlen(radio_url) + 1);
+			instance->execute(appPid, msg);
+		}
+		break;
+		case 5: {
+			msg->priority = PRIORITY_NORMAL;
+			msg->cmdType = CMD_START;
+			msg->streamType = STREAM_LOCAL;
+			memcpy(msg->url, local_url, strlen(local_url) + 1);
+			instance->execute(appPid, msg);
+		}
+		break;
+		case 6: {
+			msg->priority = PRIORITY_NORMAL;
+			msg->cmdType = CMD_PAUSE;
+			msg->streamType = STREAM_LOCAL;
+			memcpy(msg->url, local_url, strlen(local_url) + 1);
+			instance->execute(appPid, msg);
+		}
+		break;
+		case 7: {
+			msg->priority = PRIORITY_NORMAL;
+			msg->cmdType = CMD_RESUME;
+			msg->streamType = STREAM_LOCAL;
+			memcpy(msg->url, local_url, strlen(local_url) + 1);
+			instance->execute(appPid, msg);
+		}
+		break;
+		case 8: {
+			msg->priority = PRIORITY_NORMAL;
+			msg->cmdType = CMD_STOP;
+			msg->streamType = STREAM_LOCAL;
+			memcpy(msg->url, local_url, strlen(local_url) + 1);
+			instance->execute(appPid, msg);
+		}
+		break;
+		case 9: {
+			memset(msg, 0x00, sizeof(ara_player_msg_t));
+			msg->priority = PRIORITY_NORMAL;
+			msg->cmdType = CMD_START;
+			msg->streamType = STREAM_HTTP_HLS;
+			memcpy(msg->url, radio_url, strlen(radio_url) + 1);
+			instance->execute(appPid, msg);
+		}
+		break;
+		case 10: {
+			memset(msg, 0x00, sizeof(ara_player_msg_t));
+			msg->priority = PRIORITY_NORMAL;
+			msg->cmdType = CMD_STOP;
+			msg->streamType = STREAM_HTTP_HLS;
+			memcpy(msg->url, radio_url, strlen(radio_url) + 1);
+			instance->execute(appPid, msg);
+		}
+		break;
+		default:
+			break;
+		}
+	}
+
+	printf("exit\n");
+	return 0;
+}
+}
+#endif

--- a/apps/examples/araplayer/AudioCircularBuffer.cpp
+++ b/apps/examples/araplayer/AudioCircularBuffer.cpp
@@ -1,0 +1,87 @@
+
+#include <string.h>
+#include <unistd.h>
+#include <assert.h>
+#include "AudioCircularBuffer.h"
+
+AudioCircularBuffer::AudioCircularBuffer(size_t capacity) :
+	mBegIdx(0), mEndIdx(0), mSize(0), mCapacity(capacity), mData(nullptr)
+{
+	mData = new unsigned char[capacity];
+	assert(mData);
+}
+
+AudioCircularBuffer::~AudioCircularBuffer()
+{
+	delete[] mData;
+}
+
+size_t AudioCircularBuffer::write(const unsigned char *data, size_t bytes)
+{
+	if (bytes == 0) {
+		return 0;
+	}
+
+	mMutex.lock();
+
+	size_t bytes_to_write = std::min(bytes, mCapacity - mSize);
+
+	if (bytes_to_write <= mCapacity - mEndIdx) {
+		memcpy(mData + mEndIdx, data, bytes_to_write);
+		mEndIdx += bytes_to_write;
+		if (mEndIdx == mCapacity) {
+			mEndIdx = 0;
+		}
+	} else {
+		size_t size_1 = mCapacity - mEndIdx;
+		memcpy(mData + mEndIdx, data, size_1);
+		size_t size_2 = bytes_to_write - size_1;
+		memcpy(mData, data + size_1, size_2);
+		mEndIdx = size_2;
+	}
+
+	mSize += bytes_to_write;
+
+	mMutex.unlock();
+	return bytes_to_write;
+}
+
+size_t AudioCircularBuffer::read(unsigned char *buf, size_t bytes)
+{
+	if (bytes == 0) {
+		return 0;
+	}
+
+	mMutex.lock();
+
+	size_t bytes_to_read = std::min(bytes, mSize);
+
+	if (bytes_to_read <= mCapacity - mBegIdx) {
+		memcpy(buf, mData + mBegIdx, bytes_to_read);
+		mBegIdx += bytes_to_read;
+		if (mBegIdx == mCapacity) {
+			mBegIdx = 0;
+		}
+	} else {
+		size_t size_1 = mCapacity - mBegIdx;
+		memcpy(buf, mData + mBegIdx, size_1);
+		size_t size_2 = bytes_to_read - size_1;
+		memcpy(buf + size_1, mData, size_2);
+		mBegIdx = size_2;
+	}
+
+	mSize -= bytes_to_read;
+
+	mMutex.unlock();
+	return bytes_to_read;
+}
+
+void AudioCircularBuffer::clear()
+{
+	mMutex.lock();
+
+	memset(mData, 0x00, mCapacity);
+	mBegIdx = mEndIdx = mSize = 0;
+
+	mMutex.unlock();
+}

--- a/apps/examples/araplayer/AudioCircularBuffer.h
+++ b/apps/examples/araplayer/AudioCircularBuffer.h
@@ -1,0 +1,52 @@
+/****************************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+#ifndef __AUDIO_CIRCULAR_BUFFER_H__
+#define __AUDIO_CIRCULAR_BUFFER_H__
+
+#include <mutex>
+#include <algorithm>
+
+class AudioCircularBuffer
+{
+public:
+	AudioCircularBuffer(size_t);
+	~AudioCircularBuffer();
+
+	size_t size() const
+	{
+		return mSize;
+	}
+	size_t capacity() const
+	{
+		return mCapacity;
+	}
+	size_t getAvailableSpace() const
+	{
+		return mCapacity - mSize;
+	}
+	size_t write(const unsigned char *data, size_t bytes);
+	size_t read(unsigned char *data, size_t bytes);
+	void clear();
+
+private:
+	size_t mBegIdx, mEndIdx, mSize, mCapacity;
+	unsigned char *mData;
+
+	std::mutex mMutex;
+};
+#endif //__AUDIO_CIRCULAR_BUFFER_H__

--- a/apps/examples/araplayer/AudioCommon.h
+++ b/apps/examples/araplayer/AudioCommon.h
@@ -1,0 +1,102 @@
+/****************************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __AUDIO_COMMON_H__
+#define __AUDIO_COMMON_H__
+
+#include <media/MediaTypes.h>
+
+#define DEFAULT_STACK_SIZE 4096
+#define HTTP_STREAM 0
+#define HTTP_HEADER 1
+
+#define CIRCULAR_BUFFER_SIZE 1024 * 1024 // 1 Mb
+#define BUFFERING_TIME_VALUE 5			 // 2 msec
+
+#define USED_CURL_TRACE 0
+
+using namespace media;
+
+struct msg_recv_buf_s {
+	char *buf;
+	int buflen;
+	pid_t sender_pid;
+};
+
+typedef struct msg_recv_buf_s msg_recv_buf_t;
+
+typedef enum ara_player_prio_s {
+	PRIORITY_NORMAL = 0,
+	PRIORITY_SYSTEM,
+	PRIORITY_EMERGENCY
+} ara_player_prio_t;
+
+typedef enum ara_player_cmd_s {
+	CMD_START = 0,
+	CMD_STOP,
+	CMD_PAUSE,
+	CMD_RESUME
+} ara_player_cmd_t;
+
+typedef enum ara_player_stream_s {
+	STREAM_LOCAL = 0,
+	STREAM_HTTP_PROGRESSIVE,
+	STREAM_HTTP_HLS,
+	STREAM_HTTP_DASH,
+	STREAM_HTTP_FILE
+} ara_player_stream_t;
+
+struct ara_player_msg_s {
+	ara_player_prio_t priority;
+	ara_player_stream_t streamType; // Local / Stream
+	ara_player_cmd_t cmdType;		// start, stop, pause, resume
+	char url[1024];
+
+	// use the values below.
+	audio_type_t audioType;
+	audio_format_type_t pcmFormat;
+	unsigned int channels;
+	unsigned int sampleRate;
+};
+
+typedef struct ara_player_msg_s ara_player_msg_t;
+typedef int (*StreamDataCB)(void *ptr, int type, size_t len, void *p);
+
+typedef enum http_state_s {
+	HTTP_DOWNLOAD_IDLE,
+	HTTP_DOWNLOADING,
+	HTTP_DOWNLOAD_PAUSE,
+	HTTP_DOWNLOAD_COMPLETE
+} http_state_t;
+
+typedef enum request_type_s {
+	HTTP_PROGRESSIVE = 0,
+	HTTP_HLS_MANIFEST,
+	HTTP_HLS_TS,
+	HTTP_DASH_MPD,
+	HTTP_DASH_SEGMENT
+} request_type_t;
+
+#if defined(MPLINUX)
+#define LOG_ERR 1
+#define LOG_WARNING 2
+#define LOG_DEBUG 3
+#define LOG_INFO 4
+#endif
+
+#endif

--- a/apps/examples/araplayer/AudioHASStream.cpp
+++ b/apps/examples/araplayer/AudioHASStream.cpp
@@ -1,0 +1,294 @@
+/****************************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+#include "AudioHASStream.h"
+#include "MediaPlayerWrapper.h"
+#include "HASParser.h"
+#include "AraPlayer.h"
+#include "AudioWorker.h"
+
+AudioHASStream::AudioHASStream()
+{
+	mRequestIdx = 0;
+	mRequestBandWidth = -1;
+	mTimer = NULL;
+	HASParser::getInstance()->setCallback_GetPlaylistInfo(this, playlistInfoCallback);
+}
+
+AudioHASStream::~AudioHASStream()
+{
+	removeMapAll();
+}
+
+int AudioHASStream::startStream()
+{
+	AudioHttpDownloader *pHttpDownloader;
+	int ret = -1;
+
+	pHttpDownloader = new AudioHttpDownloader();
+	if (pHttpDownloader == NULL) {
+		DEBUG_TRACE(LOG_ERR, "AudioHttpDownloader error!");
+		return -1;
+	}
+
+	pHttpDownloader->mRequestUrl = std::string(mState->url);
+
+	if (strstr(pHttpDownloader->mRequestUrl.c_str(), ".m3u8")) {
+		DEBUG_TRACE(LOG_INFO, "Manifest request");
+		pHttpDownloader->mRequestType = request_type_s::HTTP_HLS_MANIFEST;
+	} else if (strstr(pHttpDownloader->mRequestUrl.c_str(), ".ts")) {
+		DEBUG_TRACE(LOG_INFO, "TS request");
+		pHttpDownloader->mRequestType = request_type_s::HTTP_HLS_TS;
+	} else {
+		DEBUG_TRACE(LOG_INFO, "Unsupport Request Type");
+		return -1;
+	}
+
+	pHttpDownloader->mStream = this;
+	ret = pHttpDownloader->startHttpDownload(mDownloaderMap, (char *)pHttpDownloader->mRequestUrl.c_str(), parseHttpData);
+	if (ret < 0) {
+		DEBUG_TRACE(LOG_ERR, "startHttpDownload error!");
+		return -1;
+	}
+
+	return ret;
+}
+
+int AudioHASStream::pauseStream()
+{
+	int ret = -1;
+	AudioHttpDownloader *pHttpDownloader;
+
+	for (mIter = mDownloaderMap.begin(); mIter != mDownloaderMap.end(); mIter++) {
+		pHttpDownloader = (AudioHttpDownloader *)mIter->second;
+
+		ret = pHttpDownloader->pauseHttpDownload();
+		if (ret < 0) {
+			DEBUG_TRACE(LOG_ERR, "pauseHttpDownload error!");
+		}
+	}
+
+	ret = mPlayer->pausePlay();
+	if (ret < 0) {
+		DEBUG_TRACE(LOG_ERR, "pausePlay error!");
+		return ret;
+	}
+
+	return ret;
+}
+
+int AudioHASStream::resumeStream()
+{
+	int ret = -1;
+	AudioHttpDownloader *pHttpDownloader;
+
+	for (mIter = mDownloaderMap.begin(); mIter != mDownloaderMap.end(); mIter++) {
+		pHttpDownloader = (AudioHttpDownloader *)mIter->second;
+
+		ret = pHttpDownloader->resumeHttpDownload();
+		if (ret < 0) {
+			DEBUG_TRACE(LOG_ERR, "resumeHttpDownload error!");
+		}
+	}
+
+	return ret;
+}
+
+int AudioHASStream::stopStream()
+{
+	AudioHttpDownloader *pHttpDownloader;
+	int ret = -1;
+
+	for (mIter = mDownloaderMap.begin(); mIter != mDownloaderMap.end(); mIter++) {
+		pHttpDownloader = (AudioHttpDownloader *)mIter->second;
+
+		ret = pHttpDownloader->stopHttpDownload();
+		if (ret < 0) {
+			DEBUG_TRACE(LOG_ERR, "stopHttpDownload error!");
+		}
+	}
+
+	ret = mPlayer->stopPlay();
+	if (ret < 0) {
+		DEBUG_TRACE(LOG_ERR, "Media stopPlay error!");
+		return ret;
+	}
+
+	return ret;
+}
+
+int AudioHASStream::requestStream(std::string url, request_type_t type)
+{
+	AudioHttpDownloader *pHttpDownloader;
+	int ret = -1;
+
+	pHttpDownloader = new AudioHttpDownloader();
+	if (pHttpDownloader == NULL) {
+		DEBUG_TRACE(LOG_ERR, "AudioHttpDownloader error!");
+		return -1;
+	}
+
+	pHttpDownloader->mRequestUrl = std::string(url);
+	pHttpDownloader->mRequestType = type;
+
+	pHttpDownloader->mStream = this;
+	ret = pHttpDownloader->startHttpDownload(mDownloaderMap, (char *)pHttpDownloader->mRequestUrl.c_str(), parseHttpData);
+	if (ret < 0) {
+		DEBUG_TRACE(LOG_ERR, "startHttpDownload error!");
+		return -1;
+	}
+
+	if (type == request_type_s::HTTP_HLS_TS) {
+		mRequestIdx++;
+	}
+	return ret;
+}
+
+std::map<void *, AudioHttpDownloader *> &AudioHASStream::getDownloaderMap()
+{
+	return mDownloaderMap;
+}
+
+void AudioHASStream::removeMapAll()
+{
+	for (mIter = mDownloaderMap.begin(); mIter != mDownloaderMap.end(); mIter++) {
+		delete mIter->second;
+	}
+}
+
+int AudioHASStream::parseHttpData(void *ptr, int type, size_t len, void *p)
+{
+	AudioHttpDownloader *pHttpDownloader = static_cast<AudioHttpDownloader *>(p);
+	AudioStream *pStream = (AudioStream *)pHttpDownloader->mStream;
+	size_t ret = 0;
+
+	switch (type) {
+	case HTTP_HEADER:
+		DEBUG_TRACE(LOG_INFO, "\n%s", ptr);
+		pHttpDownloader->responseHeader();
+		break;
+	case HTTP_STREAM:
+		switch (pHttpDownloader->mRequestType) {
+		case request_type_s::HTTP_HLS_MANIFEST:
+			DEBUG_TRACE(LOG_INFO, "HTTP_HLS_MANIFEST : %s", pHttpDownloader->mRequestUrl.c_str());
+			HASParser::getInstance()->parsePlaylist(pHttpDownloader->mRequestUrl.c_str(), (char *)ptr, len);
+			break;
+		case request_type_s::HTTP_HLS_TS:
+			if (!pHttpDownloader->getIsHeader()) {
+				audio_type_t audioType = getAudioTypeFromMimeType(pHttpDownloader->getContentType());
+				unsigned int channels;
+				unsigned int sampleRate;
+				unsigned int samplePerFrame;
+				switch (audioType) {
+				case AUDIO_TYPE_MP3:
+				case AUDIO_TYPE_AAC: {
+					int headPoint = header_parsing((unsigned char *)ptr, len, audioType, &channels, &sampleRate, &samplePerFrame, NULL);
+
+					if (headPoint != -1) {
+						// Frame length (in ms) = (samples per frame / sample rate (in hz)) * 1000
+						size_t bufferSize = (((float)samplePerFrame / (float)sampleRate) * 1000000) * 10; //10 sec frame length
+						pHttpDownloader->createBuffer(bufferSize);
+
+						// TO DO : There is a crash issue when printing the log here.. do not know the exact cause yet..
+						((AudioStream *)pHttpDownloader->mStream)->setAudioInformation(audioType, AUDIO_FORMAT_TYPE_S16_LE, sampleRate, channels, pStream);
+
+						ret = pHttpDownloader->chunkWrite((unsigned char *)ptr + headPoint, len - headPoint);
+
+						pHttpDownloader->setIsHeader(true);
+					}
+				}
+				break;
+				default:
+				break;
+				}
+			} else {
+				if (pStream->getMediaPlayer()->getState() == MediaPlayerWrapper::State::Ready) {
+					if (pHttpDownloader->getChunkSize() > (pHttpDownloader->getBuffer()->capacity() / BUFFERING_TIME_VALUE)) {
+						if (0 > (ret = ((AudioHASStream *)pHttpDownloader->mStream)->getMediaPlayer()->startPlay())) {
+							DEBUG_TRACE(LOG_ERR, "RTMediaPlayerWrapper startPlay error!");
+							return ret;
+						}
+					}
+				} else if (pStream->getMediaPlayer()->getState() == MediaPlayerWrapper::State::Paused) {
+					if (pHttpDownloader->getChunkSize() > (pHttpDownloader->getBuffer()->capacity() / BUFFERING_TIME_VALUE)) {
+						if (0 > (ret = ((AudioHASStream *)pHttpDownloader->mStream)->getMediaPlayer()->resumePlay())) {
+							DEBUG_TRACE(LOG_ERR, "RTMediaPlayerWrapper resumePlay error!");
+							return ret;
+						}
+					}
+				}
+				ret = pHttpDownloader->chunkWrite((unsigned char *)ptr, len);
+			}
+			break;
+		default:
+			break;
+		}
+		break;
+	default:
+		break;
+	}
+
+	return len;
+}
+
+void AudioHASStream::playlistInfoCallback(void *p, const char *url, play_list_info_t &pInfo)
+{
+	AudioHASStream *pHasStream = static_cast<AudioHASStream *>(p);
+	AudioWorker &aw = AudioWorker::getWorker();
+	has_segment_info_t outSegInfo;
+	int ret;
+
+	switch (pInfo.hasType) {
+	case HLS_MANIFEST:
+		DEBUG_TRACE(LOG_INFO, "playlist : %d", pInfo.type);
+		switch (pInfo.type) {
+		case MASTER:
+			for (std::vector<int>::iterator iter = pInfo.bandWidthQuality.begin(); iter != pInfo.bandWidthQuality.end(); ++iter) {
+				ret = HASParser::getInstance()->getPlaylistInfo(pInfo.playlistUrl.c_str(), (*iter), &outSegInfo);
+				if (ret > 0) {
+					if (pHasStream->mRequestBandWidth < 0) {
+						pHasStream->mRequestBandWidth = (*iter);
+					}
+					pHasStream->mBandWidthMap.insert(std::make_pair((*iter), outSegInfo.url));
+					aw.enQueue(&AudioHASStream::requestStream, pHasStream, outSegInfo.url, request_type_s::HTTP_HLS_MANIFEST);
+				}
+			}
+			break;
+		case SINGLE:
+		case MEDIA:
+			DEBUG_TRACE(LOG_INFO, "playlist : %d", pInfo.type);
+			if (pHasStream->mRequestIdx == 0) {
+				ret = HASParser::getInstance()->getSegmentInfo(pInfo.playlistUrl.c_str(), pHasStream->mRequestIdx, pHasStream->mRequestBandWidth, &outSegInfo);
+				if (ret > 0) {
+					aw.enQueue(&AudioHASStream::requestStream, pHasStream, outSegInfo.url, request_type_s::HTTP_HLS_TS);
+				}
+			}
+			break;
+		default:
+			break;
+		}
+		break;
+	case DASH_MPD:
+	default:
+		DEBUG_TRACE(LOG_ERR, "Unsupport HAS Type");
+		break;
+	}
+
+	//DEBUG_TRACE(LOG_DEBUG, "%s", url);
+	return;
+}

--- a/apps/examples/araplayer/AudioHASStream.h
+++ b/apps/examples/araplayer/AudioHASStream.h
@@ -1,0 +1,55 @@
+/****************************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __AUDIO_HASSTREAM_H__
+#define __AUDIO_HASSTREAM_H__
+
+#include "AudioCircularBuffer.h"
+#include "AudioStream.h"
+#include "PlaylistInfo.h"
+#include "AudioCommon.h"
+
+class AudioHASStream : public AudioStream
+{
+public:
+	AudioHASStream();
+	virtual ~AudioHASStream();
+
+	virtual int startStream() override;
+	virtual int pauseStream() override;
+	virtual int resumeStream() override;
+	virtual int stopStream() override;
+
+	int requestStream(std::string url, request_type_t type);
+	static int parseHttpData(void *ptr, int type, size_t size, void *p);
+	std::map<void *, AudioHttpDownloader *> &getDownloaderMap();
+	void removeMapAll();
+
+	static void playlistInfoCallback(void *p, const char *url, play_list_info_t &pInfo);
+
+	std::map<int, std::string> mBandWidthMap;
+	int mRequestBandWidth;
+	int mRequestIdx;
+	void *mTimer;
+
+private:
+	std::map<void *, AudioHttpDownloader *> mDownloaderMap;
+	std::map<void *, AudioHttpDownloader *>::iterator mIter;
+};
+
+#endif

--- a/apps/examples/araplayer/AudioHttpDownloader.cpp
+++ b/apps/examples/araplayer/AudioHttpDownloader.cpp
@@ -1,0 +1,379 @@
+/****************************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+#include <curl/curl.h>
+#include "AudioHttpDownloader.h"
+#include "AudioUtils.h"
+#include "AudioCommon.h"
+#include "AraPlayer.h"
+
+AudioHttpDownloader::AudioHttpDownloader()
+{
+	mHandle = NULL;
+	mState = HTTP_DOWNLOAD_IDLE;
+	headerBuf = NULL;
+	response_code = 0;
+	mIsHeader = false;
+	mBuffer = nullptr;
+}
+
+AudioHttpDownloader::~AudioHttpDownloader()
+{
+	DEBUG_TRACE(LOG_INFO, "AudioHttpDownloader Free");
+	freeDownloader();
+	CLEAN(mBuffer);
+}
+
+void AudioHttpDownloader::setState(http_state_t state)
+{
+	mState = state;
+}
+
+http_state_t AudioHttpDownloader::getState()
+{
+	return mState;
+}
+
+#if USED_CURL_TRACE
+size_t AudioHttpDownloader::CurlStateTrace(void *handle, int type, char *data, size_t size, void *userp)
+{
+	switch (type) {
+	case CURLINFO_TEXT:
+	case CURLINFO_HEADER_IN:
+	case CURLINFO_HEADER_OUT:
+		DEBUG_TRACE(LOG_DEBUG, "%s", data);
+		break;
+	case CURLINFO_DATA_IN:
+	case CURLINFO_DATA_OUT:
+	case CURLINFO_SSL_DATA_IN:
+	case CURLINFO_SSL_DATA_OUT:
+	default:
+		break;
+	}
+
+	return 0;
+}
+#endif
+
+int AudioHttpDownloader::startHttpDownload(std::map<void *, AudioHttpDownloader *> &downloaderMap, char *url, StreamDataCB cb)
+{
+	if (url == NULL) {
+		DEBUG_TRACE(LOG_ERR, "url is NULL!");
+		return -1;
+	}
+
+	if (mHandle == NULL) {
+		if (NULL == (mHandle = curl_easy_init())) {
+			DEBUG_TRACE(LOG_ERR, "curl_easy_init() error!");
+			return -1;
+		}
+
+		downloaderMap.insert(std::make_pair(mHandle, this));
+	} else {
+		curl_easy_reset((CURL *)mHandle);
+	}
+
+#if USED_CURL_TRACE
+	curl_easy_setopt((CURL *)mHandle, CURLOPT_DEBUGFUNCTION, CurlStateTrace);
+	curl_easy_setopt((CURL *)mHandle, CURLOPT_DEBUGDATA, this);
+	curl_easy_setopt((CURL *)mHandle, CURLOPT_VERBOSE, 1L);
+#endif
+	curl_easy_setopt((CURL *)mHandle, CURLOPT_URL, url);
+
+	// Header Callback
+	curl_easy_setopt((CURL *)mHandle, CURLOPT_HEADERFUNCTION, headerFunction);
+	curl_easy_setopt((CURL *)mHandle, CURLOPT_HEADERDATA, this);
+
+	// Data Callback
+	curl_easy_setopt((CURL *)mHandle, CURLOPT_WRITEFUNCTION, dataFunction);
+	curl_easy_setopt((CURL *)mHandle, CURLOPT_WRITEDATA, this);
+
+	curl_easy_setopt((CURL *)mHandle, CURLOPT_BUFFERSIZE, 4096);
+	curl_easy_setopt((CURL *)mHandle, CURLOPT_FOLLOWLOCATION, 1L);
+
+	// HTTPS
+	curl_easy_setopt((CURL *)mHandle, CURLOPT_SSL_VERIFYPEER, 0L);
+	parseHttpDataCB = cb;
+
+	setState(HTTP_DOWNLOADING);
+	curl_multi_add_handle((CURLM *)((AudioStream *)mStream)->getMainCurl(), (CURL *)mHandle);
+
+	DEBUG_TRACE(LOG_INFO, "http request [%s]", url);
+	return 0;
+}
+
+int AudioHttpDownloader::pauseHttpDownload()
+{
+	int ret;
+	setState(HTTP_DOWNLOAD_PAUSE);
+
+	ret = curl_easy_pause((CURL *)mHandle, CURLPAUSE_ALL);
+	if (ret != CURLE_OK) {
+		DEBUG_TRACE(LOG_ERR, "curl pause errro!");
+	}
+
+	return ret;
+}
+
+int AudioHttpDownloader::resumeHttpDownload()
+{
+	int ret;
+	setState(HTTP_DOWNLOADING);
+
+	ret = curl_easy_pause((CURL *)mHandle, CURLPAUSE_CONT);
+	if (ret != CURLE_OK) {
+		DEBUG_TRACE(LOG_ERR, "curl pause errro!");
+	}
+
+	return 0;
+}
+
+int AudioHttpDownloader::stopHttpDownload()
+{
+	freeDownloader();
+	setState(HTTP_DOWNLOAD_IDLE);
+	mIsHeader = false;
+	return 0;
+}
+
+void AudioHttpDownloader::downloadComplete()
+{
+	if (mHandle && ((getState() != HTTP_DOWNLOAD_COMPLETE) && (getState() != HTTP_DOWNLOAD_IDLE))) {
+		downloadInformation();
+		curl_multi_remove_handle((CURLM *)((AudioStream *)mStream)->getMainCurl(), (CURL *)mHandle);
+		setState(HTTP_DOWNLOAD_COMPLETE);
+	}
+}
+
+void AudioHttpDownloader::freeDownloader()
+{
+	downloadComplete();
+	if (mHandle) {
+		curl_easy_cleanup((CURL *)mHandle);
+		mHandle = NULL;
+	}
+
+	remnantBufSize = 0;
+}
+
+double AudioHttpDownloader::getDownloadSize()
+{
+	double val = 0;
+	int ret;
+
+	if (mHandle) {
+		ret = curl_easy_getinfo((CURL *)mHandle, CURLINFO_SIZE_DOWNLOAD, &val);
+
+		if ((CURLE_OK == ret) && (val > 0)) {
+			DEBUG_TRACE(LOG_INFO, "download length : %0.0f bytes", val);
+		}
+	}
+
+	return val;
+}
+
+void AudioHttpDownloader::downloadInformation()
+{
+	double val;
+	int ret;
+
+	if (mHandle) {
+		ret = curl_easy_getinfo((CURL *)mHandle, CURLINFO_RESPONSE_CODE, &val);
+		if ((ret == CURLE_OK) && (val > 200 && val < 700)) {
+			DEBUG_TRACE(LOG_INFO, "Response Code: %lld", val);
+		}
+
+		ret = curl_easy_getinfo((CURL *)mHandle, CURLINFO_CONTENT_LENGTH_DOWNLOAD, &val);
+		if ((ret == CURLE_OK) && (val > 0)) {
+			DEBUG_TRACE(LOG_INFO, "Content Length: %0.0f bytes", val);
+		}
+
+		/* check for bytes downloaded */
+		ret = curl_easy_getinfo((CURL *)mHandle, CURLINFO_SIZE_DOWNLOAD, &val);
+		if ((ret == CURLE_OK) && (val > 0)) {
+			DEBUG_TRACE(LOG_INFO, "Data downloaded: %0.0f bytes", val);
+		}
+
+		/* check for total download time */
+		ret = curl_easy_getinfo((CURL *)mHandle, CURLINFO_TOTAL_TIME, &val);
+		if ((ret == CURLE_OK) && (val > 0)) {
+			DEBUG_TRACE(LOG_INFO, "Total download time: %0.3f sec", val);
+		}
+
+		/* check for average download speed */
+		ret = curl_easy_getinfo((CURL *)mHandle, CURLINFO_SPEED_DOWNLOAD, &val);
+		if ((ret == CURLE_OK) && (val > 0)) {
+			DEBUG_TRACE(LOG_INFO, "Average download speed: %0.3f Mbps", (val / 1024 / 1024) * 8);
+		}
+	}
+}
+
+size_t AudioHttpDownloader::headerFunction(void *ptr, size_t size, size_t nmemb, void *userp)
+{
+	AudioHttpDownloader *pHttpDownload = static_cast<AudioHttpDownloader *>(userp);
+	size_t length;
+
+	if (pHttpDownload == NULL) {
+		DEBUG_TRACE(LOG_DEBUG, "pHttpDownload is NULL");
+		return 0;
+	}
+
+	if (pHttpDownload->headerBuf == NULL) {
+		pHttpDownload->headerBufSize = 0;
+	}
+
+	length = size * nmemb;
+
+	pHttpDownload->headerBuf = (char *)realloc(pHttpDownload->headerBuf, pHttpDownload->headerBufSize + length + 1);
+	if (pHttpDownload->headerBuf == NULL) {
+		DEBUG_TRACE(LOG_ERR, "not enough memory (realloc returned NULL)");
+		return 0;
+	}
+
+	memcpy(&(pHttpDownload->headerBuf[pHttpDownload->headerBufSize]), static_cast<char *>(ptr), length);
+	pHttpDownload->headerBufSize += length;
+	pHttpDownload->headerBuf[pHttpDownload->headerBufSize] = 0;
+
+	if (strcmp(static_cast<char *>(ptr), "\r\n") == 0) {
+		curl_easy_getinfo((CURL *)pHttpDownload->mHandle, CURLINFO_RESPONSE_CODE, &(pHttpDownload->response_code));
+
+		switch (pHttpDownload->response_code) {
+		case 200:
+		case 206:
+			pHttpDownload->parseHttpDataCB((void *)pHttpDownload->headerBuf, HTTP_HEADER, (unsigned int)pHttpDownload->headerBufSize, pHttpDownload);
+			break;
+		default:
+			break;
+		}
+
+		CLEAN(pHttpDownload->headerBuf);
+	}
+
+	return (size * nmemb);
+}
+
+size_t AudioHttpDownloader::dataFunction(void *ptr, size_t size, size_t nmemb, void *userp)
+{
+	AudioHttpDownloader *pHttpDownload = static_cast<AudioHttpDownloader *>(userp);
+
+	if (pHttpDownload == NULL) {
+		DEBUG_TRACE(LOG_DEBUG, "pHttpDownload is NULL");
+		return 0;
+	}
+
+	//DEBUG_TRACE(LOG_DEBUG, "%d", size*nmemb);
+
+	switch (pHttpDownload->getState()) {
+	case HTTP_DOWNLOADING:
+		pHttpDownload->parseHttpDataCB(ptr, HTTP_STREAM, size * nmemb, pHttpDownload);
+		break;
+	case HTTP_DOWNLOAD_PAUSE:
+	case HTTP_DOWNLOAD_COMPLETE:
+	case HTTP_DOWNLOAD_IDLE:
+	default:
+		break;
+	}
+
+	return size * nmemb;
+}
+
+int AudioHttpDownloader::responseHeader()
+{
+	// TO-DO header parsing(MP3, AAC, ...)
+	char *contentStr = NULL;
+	double content_length = 0;
+	int ret;
+
+	if (mHandle) {
+		ret = curl_easy_getinfo((CURL *)mHandle, CURLINFO_CONTENT_TYPE, &contentStr);
+		if (ret == CURLE_OK) {
+			mContentType = contentStr;
+			DEBUG_TRACE(LOG_INFO, "content type : %s", mContentType.c_str());
+		}
+
+		ret = curl_easy_getinfo((CURL *)mHandle, CURLINFO_CONTENT_LENGTH_DOWNLOAD, &content_length);
+		if (ret == CURLE_OK) {
+			DEBUG_TRACE(LOG_INFO, "content length : %.0f", content_length);
+		}
+	}
+
+	return 0;
+}
+
+size_t AudioHttpDownloader::chunkWrite(unsigned char *ptr, size_t len)
+{
+	while (mBuffer->capacity() - mBuffer->size() < len) {
+		WAITNS(0);
+	}
+
+	return mBuffer->write(ptr, len);
+}
+
+void AudioHttpDownloader::chunkClear()
+{
+	mBuffer->clear();
+}
+
+void AudioHttpDownloader::chunkFree()
+{
+	CLEAN(mBuffer);
+}
+
+size_t AudioHttpDownloader::getChunkSize()
+{
+	if (mBuffer) {
+		return mBuffer->size();
+	}
+
+	return 0;
+}
+
+size_t AudioHttpDownloader::chunkRead(unsigned char *buf, size_t size)
+{
+	return mBuffer->read(buf, size);
+}
+
+bool AudioHttpDownloader::getIsHeader() const
+{
+	return mIsHeader;
+}
+
+void AudioHttpDownloader::setIsHeader(bool val)
+{
+	mIsHeader = val;
+}
+
+void AudioHttpDownloader::createBuffer(size_t buffSize)
+{
+	mBuffer = new AudioCircularBuffer(buffSize);
+}
+
+std::string &AudioHttpDownloader::getContentType()
+{
+	return mContentType;
+}
+
+void *AudioHttpDownloader::getCurlHandle()
+{
+	return mHandle;
+}
+
+AudioCircularBuffer *AudioHttpDownloader::getBuffer()
+{
+	return mBuffer;
+}

--- a/apps/examples/araplayer/AudioHttpDownloader.h
+++ b/apps/examples/araplayer/AudioHttpDownloader.h
@@ -1,0 +1,92 @@
+/****************************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+#ifndef __AUDIO_HTTPDOWNLOADER_H__
+#define __AUDIO_HTTPDOWNLOADER_H__
+
+#define USED_CURL_TRACE 0
+#define PIECE_CHUNK_SIZE (1024 * 2)
+
+#include <iostream>
+#include <list>
+#include <map>
+#include "AudioCircularBuffer.h"
+#include "AudioCommon.h"
+
+class AudioHttpDownloader
+{
+public:
+	AudioHttpDownloader();
+	~AudioHttpDownloader();
+
+	void setState(http_state_t);
+	http_state_t getState();
+
+	int startHttpDownload(std::map<void *, AudioHttpDownloader *> &, char *url, StreamDataCB);
+	int pauseHttpDownload();
+	int resumeHttpDownload();
+	int stopHttpDownload();
+
+	void downloadComplete();
+	void freeDownloader();
+	int responseHeader();
+
+	double getDownloadSize();
+
+	void *mStream;
+	void *mHandle;
+	std::string mRequestUrl;
+	request_type_t mRequestType;
+
+	size_t getChunkSize();
+	size_t chunkRead(unsigned char *buf, size_t size);
+	bool getIsHeader() const;
+	void setIsHeader(bool);
+	void createBuffer(size_t buffSize);
+	std::string &getContentType();
+	size_t chunkWrite(unsigned char *ptr, size_t len);
+	void *getCurlHandle();
+	AudioCircularBuffer *getBuffer();
+
+private:
+	int remnantBufSize;
+	int headerBufSize;
+	long response_code;
+	std::string mContentType;
+
+	http_state_t mState;
+	char *headerBuf;
+
+	void downloadInformation();
+	void writePlayloadData(void *ptr, size_t len, void *userp);
+
+#if USED_CURL_TRACE
+	static size_t CurlStateTrace(void *handle, int type, char *data, size_t size, void *userp);
+#endif
+	static size_t headerFunction(void *ptr, size_t size, size_t nmemb, void *userp);
+	static size_t dataFunction(void *ptr, size_t size, size_t nmemb, void *userp);
+
+	void chunkClear();
+	void chunkFree();
+
+	StreamDataCB parseHttpDataCB;
+	AudioCircularBuffer *mBuffer;
+
+	bool mIsHeader;
+};
+
+#endif

--- a/apps/examples/araplayer/AudioLocalStream.cpp
+++ b/apps/examples/araplayer/AudioLocalStream.cpp
@@ -1,0 +1,76 @@
+/****************************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+#include "AudioLocalStream.h"
+#include "MediaPlayerWrapper.h"
+
+AudioLocalStream::AudioLocalStream()
+{
+}
+
+AudioLocalStream::~AudioLocalStream()
+{
+}
+
+int AudioLocalStream::startStream()
+{
+	int ret = -1;
+
+	ret = mPlayer->init(mState->url);
+	ret = mPlayer->startPlay();
+
+	return ret;
+}
+
+int AudioLocalStream::pauseStream()
+{
+	int ret = -1;
+
+	ret = mPlayer->pausePlay();
+	if (ret < 0) {
+		DEBUG_TRACE(LOG_ERR, "pausePlay error!");
+		return ret;
+	}
+
+	return ret;
+}
+
+int AudioLocalStream::resumeStream()
+{
+	int ret = -1;
+
+	ret = mPlayer->resumePlay();
+	if (ret < 0) {
+		DEBUG_TRACE(LOG_ERR, "resumePlay error!");
+		return ret;
+	}
+
+	return ret;
+}
+
+int AudioLocalStream::stopStream()
+{
+	int ret = -1;
+	ret = mPlayer->stopPlay();
+	if (ret < 0) {
+		DEBUG_TRACE(LOG_ERR, "Media stopPlay error!");
+		return ret;
+	}
+
+	return ret;
+}

--- a/apps/examples/araplayer/AudioLocalStream.h
+++ b/apps/examples/araplayer/AudioLocalStream.h
@@ -1,0 +1,41 @@
+/****************************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __AUDIO_LOCALSTREAM_H__
+#define __AUDIO_LOCALSTREAM_H__
+
+#include "AudioHttpDownloader.h"
+#include "MediaPlayerWrapper.h"
+#include "AudioCircularBuffer.h"
+#include "AudioUtils.h"
+#include "AudioStream.h"
+
+class AudioLocalStream : public AudioStream
+{
+public:
+	AudioLocalStream();
+	~AudioLocalStream();
+
+protected:
+	virtual int startStream();
+	virtual int pauseStream();
+	virtual int resumeStream();
+	virtual int stopStream();
+};
+
+#endif

--- a/apps/examples/araplayer/AudioPDStream.cpp
+++ b/apps/examples/araplayer/AudioPDStream.cpp
@@ -1,0 +1,192 @@
+/****************************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+#include "AudioPDStream.h"
+#include "MediaPlayerWrapper.h"
+
+AudioPDStream::AudioPDStream()
+{
+}
+
+AudioPDStream::~AudioPDStream()
+{
+	removeMapAll();
+}
+
+int AudioPDStream::startStream()
+{
+	AudioHttpDownloader *pHttpDownloader;
+	int ret = -1;
+
+	pHttpDownloader = new AudioHttpDownloader();
+	if (pHttpDownloader == NULL) {
+		DEBUG_TRACE(LOG_ERR, "MultiRoomHttpDownloader error!");
+		return -1;
+	}
+
+	pHttpDownloader->mStream = this;
+	ret = pHttpDownloader->startHttpDownload(mDownloaderMap, mState->url, parseHttpData);
+	if (ret < 0) {
+		DEBUG_TRACE(LOG_ERR, "startHttpDownload error!");
+		return -1;
+	}
+
+	return ret;
+}
+
+int AudioPDStream::pauseStream()
+{
+	AudioHttpDownloader *pHttpDownloader;
+	int ret = -1;
+
+	for (mIter = mDownloaderMap.begin(); mIter != mDownloaderMap.end(); mIter++) {
+		pHttpDownloader = (AudioHttpDownloader *)mIter->second;
+
+		ret = pHttpDownloader->pauseHttpDownload();
+		if (ret < 0) {
+			DEBUG_TRACE(LOG_ERR, "pauseHttpDownload error!");
+			return ret;
+		}
+	}
+
+	ret = mPlayer->pausePlay();
+	if (ret < 0) {
+		DEBUG_TRACE(LOG_ERR, "pausePlay error!");
+		return ret;
+	}
+
+	return ret;
+}
+
+int AudioPDStream::resumeStream()
+{
+	AudioHttpDownloader *pHttpDownloader;
+	int ret = -1;
+
+	for (mIter = mDownloaderMap.begin(); mIter != mDownloaderMap.end(); mIter++) {
+		pHttpDownloader = (AudioHttpDownloader *)mIter->second;
+
+		ret = pHttpDownloader->resumeHttpDownload();
+		if (ret < 0) {
+			DEBUG_TRACE(LOG_ERR, "resumeHttpDownload error!");
+			return ret;
+		}
+	}
+	return ret;
+}
+
+int AudioPDStream::stopStream()
+{
+	AudioHttpDownloader *pHttpDownloader;
+	int ret = -1;
+
+	for (mIter = mDownloaderMap.begin(); mIter != mDownloaderMap.end(); mIter++) {
+		pHttpDownloader = (AudioHttpDownloader *)mIter->second;
+
+		ret = pHttpDownloader->stopHttpDownload();
+		if (ret < 0) {
+			DEBUG_TRACE(LOG_ERR, "stopHttpDownload error!");
+			return ret;
+		}
+	}
+
+	ret = mPlayer->stopPlay();
+	if (ret < 0) {
+		DEBUG_TRACE(LOG_ERR, "Media stopPlay error!");
+		return ret;
+	}
+
+	return ret;
+}
+
+std::map<void *, AudioHttpDownloader *> &AudioPDStream::getDownloaderMap()
+{
+	return mDownloaderMap;
+}
+
+void AudioPDStream::removeMapAll()
+{
+	for (mIter = mDownloaderMap.begin(); mIter != mDownloaderMap.end(); mIter++) {
+		delete mIter->second;
+	}
+}
+
+int AudioPDStream::parseHttpData(void *ptr, int type, size_t len, void *p)
+{
+	AudioHttpDownloader *pDownloader = static_cast<AudioHttpDownloader *>(p);
+	AudioStream *pStream = (AudioStream *)pDownloader->mStream;
+	size_t ret = 0;
+
+	switch (type) {
+	case HTTP_HEADER:
+		ret = pDownloader->responseHeader();
+		break;
+	case HTTP_STREAM:
+		if (!pDownloader->getIsHeader()) {
+			audio_type_t audioType = getAudioTypeFromMimeType(pDownloader->getContentType());
+			unsigned int channels;
+			unsigned int sampleRate;
+			unsigned int samplePerFrame;
+			switch (audioType) {
+			case AUDIO_TYPE_MP3:
+			case AUDIO_TYPE_AAC: {
+				int headPoint = header_parsing((unsigned char *)ptr, len, audioType, &channels, &sampleRate, &samplePerFrame, NULL);
+
+				if (headPoint != -1) {
+					// Frame length (in ms) = (samples per frame / sample rate (in hz)) * 1000
+					size_t bufferSize = (((float)samplePerFrame / (float)sampleRate) * 1000000) * 10; //10 sec frame length
+					pDownloader->createBuffer(bufferSize);
+
+					// TO DO : There is a crash issue when printing the log here.. do not know the exact cause yet..
+					((AudioStream *)pDownloader->mStream)->setAudioInformation(audioType, AUDIO_FORMAT_TYPE_S16_LE, sampleRate, channels, pStream);
+
+					ret = pDownloader->chunkWrite((unsigned char *)ptr + headPoint, len - headPoint);
+
+					pDownloader->setIsHeader(true);
+				}
+			}
+			break;
+			default:
+			break;
+			}
+		} else {
+			if (pStream->getMediaPlayer()->getState() == MediaPlayerWrapper::State::Ready) {
+				if (pDownloader->getChunkSize() > (pDownloader->getBuffer()->capacity() / BUFFERING_TIME_VALUE)) {
+					if (0 > (ret = ((AudioPDStream *)pDownloader->mStream)->getMediaPlayer()->startPlay())) {
+						DEBUG_TRACE(LOG_ERR, "RTMediaPlayerWrapper startPlay error!");
+						return ret;
+					}
+				}
+			} else if (pStream->getMediaPlayer()->getState() == MediaPlayerWrapper::State::Paused) {
+				if (pDownloader->getChunkSize() > (pDownloader->getBuffer()->capacity() / BUFFERING_TIME_VALUE)) {
+					if (0 > (ret = ((AudioPDStream *)pDownloader->mStream)->getMediaPlayer()->resumePlay())) {
+						DEBUG_TRACE(LOG_ERR, "RTMediaPlayerWrapper resumePlay error!");
+						return ret;
+					}
+				}
+			}
+
+			ret = pDownloader->chunkWrite((unsigned char *)ptr, len);
+		}
+		break;
+	default:
+		break;
+	}
+
+	return len;
+}

--- a/apps/examples/araplayer/AudioPDStream.h
+++ b/apps/examples/araplayer/AudioPDStream.h
@@ -1,0 +1,44 @@
+/****************************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __AUDIO_PDSTREAM_H__
+#define __AUDIO_PDSTREAM_H__
+
+#include "AudioCircularBuffer.h"
+#include "AudioStream.h"
+class AudioPDStream : public AudioStream
+{
+public:
+	AudioPDStream();
+	virtual ~AudioPDStream();
+
+	virtual int startStream() override;
+	virtual int pauseStream() override;
+	virtual int resumeStream() override;
+	virtual int stopStream() override;
+
+	static int parseHttpData(void *ptr, int type, size_t size, void *p);
+	std::map<void *, AudioHttpDownloader *> &getDownloaderMap();
+	void removeMapAll();
+
+private:
+	std::map<void *, AudioHttpDownloader *> mDownloaderMap;
+	std::map<void *, AudioHttpDownloader *>::iterator mIter;
+};
+
+#endif

--- a/apps/examples/araplayer/AudioQueue.cpp
+++ b/apps/examples/araplayer/AudioQueue.cpp
@@ -1,0 +1,44 @@
+/* ****************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************/
+
+#include "AudioQueue.h"
+
+AudioQueue::AudioQueue()
+{
+}
+AudioQueue::~AudioQueue()
+{
+}
+
+std::function<void()> AudioQueue::deQueue()
+{
+	std::unique_lock<std::mutex> lock(mQueueMtx);
+	if (mQueueData.empty()) {
+		mQueueCv.wait(lock);
+	}
+
+	auto data = std::move(mQueueData.front());
+	mQueueData.pop();
+	return data;
+}
+
+bool AudioQueue::isEmpty()
+{
+	std::unique_lock<std::mutex> lock(mQueueMtx);
+	return mQueueData.empty();
+}

--- a/apps/examples/araplayer/AudioQueue.h
+++ b/apps/examples/araplayer/AudioQueue.h
@@ -1,0 +1,51 @@
+/* ****************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************/
+
+#ifndef __AUDIO_QUEUE_H__
+#define __AUDIO_QUEUE_H__
+
+#include <mutex>
+#include <condition_variable>
+#include <queue>
+#include <atomic>
+#include <iostream>
+#include <functional>
+
+class AudioQueue
+{
+public:
+	AudioQueue();
+	~AudioQueue();
+	template <typename _Callable, typename... _Args>
+	void enQueue(_Callable &&__f, _Args &&... __args)
+	{
+		std::unique_lock<std::mutex> lock(mQueueMtx);
+		std::function<void()> func = std::bind(std::forward<_Callable>(__f), std::forward<_Args>(__args)...);
+		mQueueData.push(func);
+		mQueueCv.notify_one();
+	}
+	std::function<void()> deQueue();
+	bool isEmpty();
+
+private:
+	std::queue<std::function<void()>> mQueueData;
+	std::condition_variable mQueueCv;
+	std::mutex mQueueMtx;
+};
+
+#endif

--- a/apps/examples/araplayer/AudioStream.cpp
+++ b/apps/examples/araplayer/AudioStream.cpp
@@ -1,0 +1,82 @@
+/****************************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+#include <iostream>
+#include <memory>
+#include "AudioStream.h"
+#include "MediaPlayerWrapper.h"
+
+AudioStream::AudioStream() :
+	mPid(-1)
+{
+	mPlayer = std::make_shared<MediaPlayerWrapper>();
+	mMainCurl = nullptr;
+}
+
+AudioStream::~AudioStream()
+{
+}
+
+void AudioStream::setState(ara_player_msg_t *state)
+{
+	mState = state;
+}
+
+void AudioStream::setMainCurl(void *curl)
+{
+	mMainCurl = curl;
+}
+
+void *AudioStream::getMainCurl()
+{
+	return mMainCurl;
+}
+
+void AudioStream::setPid(pid_t pid)
+{
+	mPid = pid;
+}
+
+ara_player_stream_t AudioStream::getStreamType()
+{
+	return mState->streamType;
+}
+
+uint8_t AudioStream::getPriority()
+{
+	return mState->priority;
+}
+
+std::string AudioStream::getUrl()
+{
+	return mState->url;
+}
+
+void AudioStream::setAudioInformation(audio_type_t audioType, audio_format_type_t format, unsigned int channels, unsigned int sample_rate, AudioStream *stream)
+{
+	mState->audioType = audioType;
+	mState->channels = channels;
+	mState->sampleRate = sample_rate;
+	mPlayer->init(audioType, format, channels, sample_rate, (void *)stream);
+	DEBUG_TRACE(LOG_INFO, "audioType:%d, SampleRate:%d, Channels:%d", (int)audioType, sample_rate, channels);
+}
+
+std::shared_ptr<MediaPlayerWrapper> AudioStream::getMediaPlayer()
+{
+	return mPlayer;
+}

--- a/apps/examples/araplayer/AudioStream.h
+++ b/apps/examples/araplayer/AudioStream.h
@@ -1,0 +1,60 @@
+/****************************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __AUDIO_STREAM_H__
+#define __AUDIO_STREAM_H__
+
+#include <iostream>
+#include "MediaPlayerWrapper.h"
+#include "AudioHttpDownloader.h"
+#include "AudioUtils.h"
+
+#define HTTP_STREAM 0
+#define HTTP_HEADER 1
+
+class AudioStream
+{
+public:
+	AudioStream();
+	virtual ~AudioStream();
+
+	virtual int startStream() = 0;
+	virtual int pauseStream() = 0;
+	virtual int resumeStream() = 0;
+	virtual int stopStream() = 0;
+
+	void setState(ara_player_msg_t *);
+	void setPid(pid_t);
+
+	ara_player_stream_t getStreamType();
+	uint8_t getPriority();
+	std::string getUrl();
+	void setMainCurl(void *curl);
+	void *getMainCurl();
+	void setAudioInformation(audio_type_t audioType, audio_format_type_t format, unsigned int channels, unsigned int sample_rate, AudioStream *stream);
+
+	std::shared_ptr<MediaPlayerWrapper> getMediaPlayer();
+
+protected:
+	pid_t mPid;
+	ara_player_msg_t *mState;
+	std::shared_ptr<MediaPlayerWrapper> mPlayer;
+	void *mMainCurl;
+};
+
+#endif //__AUDIO_STREAM_H__

--- a/apps/examples/araplayer/AudioUtils.cpp
+++ b/apps/examples/araplayer/AudioUtils.cpp
@@ -1,0 +1,992 @@
+/****************************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+#include <iostream>
+#include "AudioUtils.h"
+
+// Mine-Type for audio stream
+static const std::string AAC_MIME_TYPE = "audio/aac";
+static const std::string AACP_MIME_TYPE = "audio/aacp";
+static const std::string MPEG_MIME_TYPE = "audio/mpeg";
+static const std::string MP4_MIME_TYPE = "audio/mp4";
+static const std::string OPUS_MIME_TYPE = "audio/opus";
+
+// Sample Rate(in Hz) tables
+static const int sampleRateTable[3][3] = {
+	{44100, 48000, 32000},
+	{22050, 24000, 16000},
+	{11025, 12000, 8000},
+};
+// Bit Rate (in kbps) tables
+// V1 - MPEG 1, V2 - MPEG 2 and MPEG 2.5
+// L1 - Layer 1, L2 - Layer 2, L3 - Layer 3
+static const int bitRateTable[3][3][14] = {
+	{
+		{32, 64, 96, 128, 160, 192, 224, 256, 288, 320, 352, 384, 416, 448}, /* MPEG 1, Layer 1 */
+		{32, 48, 56, 64, 80, 96, 112, 128, 160, 192, 224, 256, 320, 384},	/* MPEG 1, Layer 2 */
+		{32, 40, 48, 56, 64, 80, 96, 112, 128, 160, 192, 224, 256, 320},	 /* MPEG 1, Layer 3 */
+	},
+	{
+		{32, 48, 56, 64, 80, 96, 112, 128, 144, 160, 176, 192, 224, 256}, /* MPEG 2, Layer 1 */
+		{8, 16, 24, 32, 40, 48, 56, 64, 80, 96, 112, 128, 144, 160},	  /* MPEG 2, Layer 2 */
+		{8, 16, 24, 32, 40, 48, 56, 64, 80, 96, 112, 128, 144, 160},	  /* MPEG 2, Layer 3 */
+	},
+	{
+		{32, 48, 56, 64, 80, 96, 112, 128, 144, 160, 176, 192, 224, 256}, /* MPEG 2.5, Layer 1 */
+		{8, 16, 24, 32, 40, 48, 56, 64, 80, 96, 112, 128, 144, 160},	  /* MPEG 2.5, Layer 2 */
+		{8, 16, 24, 32, 40, 48, 56, 64, 80, 96, 112, 128, 144, 160},	  /* MPEG 2.5, Layer 3 */
+	},
+};
+
+void ARAPS_LOG(int level, const char *filename, unsigned int line, const char *function, const char *pf_format, ...)
+{
+	int nBuf;
+	char szPrint[128];
+	char szBuffer[512];
+	va_list args;
+	struct timeval stCurTime;
+	struct tm stTime;
+
+	va_start(args, pf_format);
+
+	nBuf = vsprintf(szBuffer, pf_format, args);
+	if (nBuf < 0) {
+		std::cout << "DEBUG_TRACE ERROR..." << std::endl;
+		return;
+	}
+
+	va_end(args);
+
+	gettimeofday(&stCurTime, NULL);
+	localtime_r(&stCurTime.tv_sec, &stTime);
+
+	sprintf(szPrint, "[%02d:%02d:%02d.%03ld](%s:%d) >> ", stTime.tm_hour, stTime.tm_min, stTime.tm_sec, stCurTime.tv_usec / 1000, function, line);
+	std::cout << szPrint << szBuffer << std::endl;
+}
+
+void WAITMS(int msec)
+{
+#if USED_SLEEP_SELECT
+	struct timeval wait = {0, (msec * 1000)};
+	(void)select(0, NULL, NULL, NULL, &wait);
+#else
+	usleep(msec * 1000);
+#endif
+}
+
+void WAITNS(int nanosec)
+{
+#if USED_SLEEP_SELECT
+	struct timeval wait = {0, (nanosec)};
+	(void)select(0, NULL, NULL, NULL, &wait);
+#else
+	usleep(nanosec);
+#endif
+}
+
+void toLowerString(std::string &str)
+{
+	for (char &c : str) {
+		if ('A' <= c && c <= 'Z') {
+			c += ('a' - 'A');
+		}
+	}
+}
+
+void toUpperString(std::string &str)
+{
+	for (char &c : str) {
+		if ('a' <= c && c <= 'z') {
+			c -= ('a' - 'A');
+		}
+	}
+}
+
+audio_type_t getAudioTypeFromPath(std::string datapath)
+{
+	std::string basename = datapath.substr(datapath.find_last_of("/") + 1);
+	std::string extension;
+
+	if (basename.find(".") == std::string::npos) {
+		extension = "";
+	} else {
+		extension = basename.substr(basename.find_last_of(".") + 1);
+	}
+
+	toLowerString(extension);
+
+	if (extension.compare("mp3") == 0) {
+		medvdbg("audio type : mp3\n");
+		return AUDIO_TYPE_MP3;
+	} else if ((extension.compare("aac") == 0) || (extension.compare("mp4") == 0)) {
+		medvdbg("audio type : aac\n");
+		return AUDIO_TYPE_AAC;
+	} else if ((extension.compare("opus") == 0)) {
+		medvdbg("audio type : opus\n");
+		return AUDIO_TYPE_OPUS;
+	} else if ((extension.compare("flac") == 0)) {
+		medvdbg("audio type : flac\n");
+		return AUDIO_TYPE_FLAC;
+	} else if ((extension.compare("") == 0) || (extension.compare("pcm") == 0) || (extension.compare("raw") == 0)) {
+		medvdbg("audio type : pcm\n");
+		return AUDIO_TYPE_PCM;
+	} else if (extension.compare(AUDIO_EXT_TYPE_WAV) == 0) {
+		medvdbg("audio type : wav\n");
+		return AUDIO_TYPE_WAVE;
+	} else {
+		medvdbg("audio type : unknown\n");
+		return AUDIO_TYPE_INVALID;
+	}
+}
+
+audio_type_t getAudioTypeFromMimeType(std::string &mimeType)
+{
+	audio_type_t audioType;
+
+	if (mimeType.empty()) {
+		medwdbg("empty mime type!\n");
+		audioType = AUDIO_TYPE_UNKNOWN;
+	} else if ((mimeType.find(AAC_MIME_TYPE) != std::string::npos) ||
+			   (mimeType.find(AACP_MIME_TYPE) != std::string::npos)) {
+		audioType = AUDIO_TYPE_AAC;
+	} else if (mimeType.find(MPEG_MIME_TYPE) != std::string::npos) {
+		audioType = AUDIO_TYPE_MP3;
+	} else if (mimeType.find(MP4_MIME_TYPE) != std::string::npos) {
+		audioType = AUDIO_TYPE_AAC;
+	} else if (mimeType.find(OPUS_MIME_TYPE) != std::string::npos) {
+		audioType = AUDIO_TYPE_OPUS;
+	} else {
+		DEBUG_TRACE(LOG_DEBUG, "Unsupported mime type: %s\n", mimeType.c_str());
+		audioType = AUDIO_TYPE_UNKNOWN;
+	}
+
+	return audioType;
+}
+
+bool mp3_header_parsing(unsigned char *header, unsigned int *channel, unsigned int *sampleRate)
+{
+	/**
+*mp3_header is AAAAAAAA AAABBCCD EEEEFFGH IIJJKLMM
+*A - Frame sync
+*B - MPEG Audio version
+*...
+*F - Sampling rate frequency
+*.
+*I - Channel Mode
+*...
+*/
+	unsigned char bit;
+	unsigned int mpegVersion;
+
+	bit = header[1];
+	bit >>= 3;
+	bit &= (unsigned char)0x03;
+	/* we need B information so Shift header[1] three times to the right, and & 0x03 */
+	switch (bit) {
+	case 0:
+		mpegVersion = 2;
+		break;
+	case 2:
+		mpegVersion = 1;
+		break;
+	case 3:
+		mpegVersion = 0;
+		break;
+	default:
+		DEBUG_TRACE(LOG_DEBUG, "Not Supported Format mpeg version : %u\n", mpegVersion);
+		return false;
+	}
+
+	bit = header[2];
+	bit >>= 2;
+	bit &= 0x03;
+	/* we need F information so Shift header[1] two times to the right, and & 0x03 */
+	switch (bit) {
+	case 0:
+		*sampleRate = AUDIO_SAMPLE_RATE_44100;
+		break;
+	case 1:
+		*sampleRate = AUDIO_SAMPLE_RATE_48000;
+		break;
+	case 2:
+		*sampleRate = AUDIO_SAMPLE_RATE_32000;
+		break;
+	default:
+		DEBUG_TRACE(LOG_DEBUG, "Not Supported Format sample rate : %u\n", sampleRate);
+		return false;
+	}
+
+	*sampleRate >>= mpegVersion;
+
+	bit = header[3];
+	bit >>= 6;
+	/* we need I information so Shift header[3] six times to the right */
+	if (bit <= 2) {
+		*channel = 2;
+	} else {
+		*channel = 1;
+	}
+	return true;
+}
+
+bool aac_header_parsing(unsigned char *header, unsigned int *channel, unsigned int *sampleRate)
+{
+	/**
+*aac_header is AAAAAAAA AAAABCCD EEFFFFGH HHIJKLMM MMMMMMMM MMMOOOOO OOOOOOPP
+*A - syncword 0xFFF, all bits must be 1
+*....
+*F - Sampling rate frequency
+*..
+*H - Channel Mode
+*......
+*/
+	unsigned char bit;
+	bit = header[2];
+	bit >>= 2;
+	bit &= 0x0F;
+	/* we need F information so Shift header[2] two times to the right, and & 0x0F */
+	switch (bit) {
+	case 0:
+		*sampleRate = AUDIO_SAMPLE_RATE_96000;
+		break;
+	case 1:
+		*sampleRate = AUDIO_SAMPLE_RATE_88200;
+		break;
+	case 2:
+		*sampleRate = AUDIO_SAMPLE_RATE_64000;
+		break;
+	case 3:
+		*sampleRate = AUDIO_SAMPLE_RATE_48000;
+		break;
+	case 4:
+		*sampleRate = AUDIO_SAMPLE_RATE_44100;
+		break;
+	case 5:
+		*sampleRate = AUDIO_SAMPLE_RATE_32000;
+		break;
+	case 6:
+		*sampleRate = AUDIO_SAMPLE_RATE_24000;
+		break;
+	case 7:
+		*sampleRate = AUDIO_SAMPLE_RATE_22050;
+		break;
+	case 8:
+		*sampleRate = AUDIO_SAMPLE_RATE_16000;
+		break;
+	case 9:
+		*sampleRate = AUDIO_SAMPLE_RATE_12000;
+		break;
+	case 10:
+		*sampleRate = AUDIO_SAMPLE_RATE_11025;
+		break;
+	case 11:
+		*sampleRate = AUDIO_SAMPLE_RATE_8000;
+		break;
+	case 12:
+		*sampleRate = AUDIO_SAMPLE_RATE_7350;
+		break;
+	default:
+		DEBUG_TRACE(LOG_DEBUG, "Not Supported Format sample rate : %u\n", sampleRate);
+		return false;
+	}
+	bit = header[2];
+	bit <<= 2;
+	bit |= (header[3] >> 6);
+	bit &= 0x07;
+	/* we need H information so Shift header[3] six times to the right, and & 0x07 */
+	if (bit <= 0 || bit >= 8) {
+		DEBUG_TRACE(LOG_DEBUG, "Invalid value bit : %d\n", bit);
+		return false;
+	}
+
+	if (bit == 7) {
+		*channel = 8;
+	} else {
+		*channel = (unsigned int)bit;
+	}
+	return true;
+}
+
+bool wave_header_parsing(unsigned char *header, unsigned int *channel, unsigned int *sampleRate, audio_format_type_t *pcmFormat)
+{
+	/**
+*wave header is
+*Chunk ID    (4byte) / .... (4byte) /            .... (4byte)                /
+*.....       (4byte) / .... (4byte) / .. (2byte)   / NumChannels     (2byte) /
+*sample Rate (4byte) / .... (4byte) / .. (2byte)   / Bits Per sample (2byte) /
+*.....       (4byte) / .... (4byte)
+*/
+	unsigned short bitPerSample;
+	*channel = header[23];
+	*channel <<= 8;
+	*channel |= header[22];
+
+	*sampleRate = header[27];
+	*sampleRate <<= 8;
+	*sampleRate |= header[26];
+	*sampleRate <<= 8;
+	*sampleRate |= header[25];
+	*sampleRate <<= 8;
+	*sampleRate |= header[24];
+
+	bitPerSample = header[35];
+	bitPerSample <<= 8;
+	bitPerSample |= header[34];
+	/* wave header is Little Endian, so read from right byte */
+	switch (bitPerSample) {
+	case 8:
+		*pcmFormat = AUDIO_FORMAT_TYPE_S8;
+		break;
+	case 16:
+		*pcmFormat = AUDIO_FORMAT_TYPE_S16_LE;
+		break;
+	case 32:
+		*pcmFormat = AUDIO_FORMAT_TYPE_S32_LE;
+		break;
+	default:
+		DEBUG_TRACE(LOG_DEBUG, "Not Supported Format bit/sample : %u\n", bitPerSample);
+		return false;
+	}
+	return true;
+}
+
+bool header_parsing(FILE *fp, audio_type_t audioType, unsigned int *channel, unsigned int *sampleRate, audio_format_type_t *pcmFormat)
+{
+	unsigned char *header;
+	unsigned char tag[2];
+	bool isHeader;
+
+	switch (audioType) {
+	case AUDIO_TYPE_MP3:
+		isHeader = false;
+		while (fread(tag, sizeof(unsigned char), 1, fp) > 0) {
+			if (tag[0] == 0xFF) {
+				isHeader = true;
+				break;
+			}
+		}
+		if (isHeader) {
+			header = (unsigned char *)malloc(sizeof(unsigned char) * (MP3_HEADER_LENGTH + 1));
+			if (header == NULL) {
+				DEBUG_TRACE(LOG_DEBUG, "malloc failed error\n");
+				return false;
+			}
+			int ret;
+			ret = fseek(fp, -1, SEEK_CUR);
+			if (ret != OK) {
+				DEBUG_TRACE(LOG_DEBUG, "file seek failed errno : %d\n", errno);
+				free(header);
+				return false;
+			}
+
+			ret = fread(header, sizeof(unsigned char), MP3_HEADER_LENGTH, fp);
+			if (ret != MP3_HEADER_LENGTH) {
+				DEBUG_TRACE(LOG_DEBUG, "read failed ret : %d\n", ret);
+				free(header);
+				return false;
+			}
+
+			if (!mp3_header_parsing(header, channel, sampleRate)) {
+				DEBUG_TRACE(LOG_DEBUG, "Header parsing failed\n");
+				free(header);
+				return false;
+			}
+		} else {
+			medvdbg("no header\n");
+			return false;
+		}
+		break;
+	case AUDIO_TYPE_AAC:
+		isHeader = false;
+		while (fread(tag, sizeof(unsigned char), 1, fp) > 0) {
+			if (tag[0] == 0xFF) {
+				isHeader = true;
+				break;
+			}
+		}
+		if (isHeader) {
+			header = (unsigned char *)malloc(sizeof(unsigned char) * (AAC_HEADER_LENGTH + 1));
+			if (header == NULL) {
+				medvdbg("malloc failed error\n");
+				return false;
+			}
+
+			if (fseek(fp, -1, SEEK_CUR) != 0) {
+				DEBUG_TRACE(LOG_DEBUG, "file seek failed error\n");
+				free(header);
+				return false;
+			}
+
+			if ((fread(header, sizeof(unsigned char), AAC_HEADER_LENGTH, fp) != AAC_HEADER_LENGTH) || !aac_header_parsing(header, channel, sampleRate)) {
+				free(header);
+				return false;
+			}
+		} else {
+			medvdbg("no header\n");
+			return false;
+		}
+		break;
+	case AUDIO_TYPE_WAVE:
+		header = (unsigned char *)malloc(sizeof(unsigned char) * (WAVE_HEADER_LENGTH + 1));
+		if (header == NULL) {
+			medvdbg("malloc failed error\n");
+			return false;
+		}
+
+		if ((fread(header, sizeof(unsigned char), WAVE_HEADER_LENGTH, fp) != WAVE_HEADER_LENGTH) || !wave_header_parsing(header, channel, sampleRate, pcmFormat)) {
+			free(header);
+			return false;
+		}
+		break;
+	default:
+		medvdbg("does not support header parsing\n");
+		return false;
+	}
+
+	if (header != NULL) {
+		free(header);
+	}
+
+	if (fseek(fp, 0, SEEK_SET) != 0) {
+		DEBUG_TRACE(LOG_DEBUG, "file seek failed error\n");
+		return false;
+	}
+	return true;
+}
+
+int header_parsing(unsigned char *buffer, unsigned int bufferSize, audio_type_t audioType, unsigned int *channel, unsigned int *sampleRate, unsigned int *samplePerFrame, audio_format_type_t *pcmFormat)
+{
+	unsigned int headPoint;
+	unsigned char *header;
+	bool isHeader = false;
+	switch (audioType) {
+	case AUDIO_TYPE_MP3:
+		while (headPoint < bufferSize) {
+			if ((((buffer[headPoint] & 0xFF) << 8) | (buffer[headPoint + 1] & 0xF0)) == 0xFFF0) {
+				if (checkHeader(&buffer[headPoint], channel, sampleRate, samplePerFrame) == true) {
+					isHeader = true;
+					break;
+				}
+			}
+
+			headPoint++;
+		}
+
+		if (!isHeader) {
+			return -1;
+		}
+		break;
+	case AUDIO_TYPE_AAC:
+		if (AAC_HEADER_LENGTH > bufferSize) {
+			medvdbg("no header\n");
+			return -1;
+		}
+		isHeader = false;
+		headPoint = 0;
+		while (headPoint < bufferSize) {
+			if (buffer[headPoint] == 0xFF) {
+				isHeader = true;
+				break;
+			}
+			headPoint++;
+		}
+		if (isHeader && AAC_HEADER_LENGTH <= bufferSize - headPoint) {
+			header = (unsigned char *)malloc(sizeof(unsigned char) * (AAC_HEADER_LENGTH + 1));
+			if (header == NULL) {
+				medvdbg("malloc failed error\n");
+				return -1;
+			}
+			memcpy(header, buffer + headPoint, MP3_HEADER_LENGTH);
+			if (!aac_header_parsing(header, channel, sampleRate)) {
+				free(header);
+				return -1;
+			}
+		} else {
+			medvdbg("no header\n");
+			return -1;
+		}
+		break;
+	case AUDIO_TYPE_WAVE:
+		if (WAVE_HEADER_LENGTH <= bufferSize) {
+			header = (unsigned char *)malloc(sizeof(unsigned char) * (WAVE_HEADER_LENGTH + 1));
+			if (header == NULL) {
+				medvdbg("malloc failed error\n");
+				return -1;
+			}
+			memcpy(header, buffer, WAVE_HEADER_LENGTH);
+			if (!wave_header_parsing(header, channel, sampleRate, pcmFormat)) {
+				free(header);
+				return -1;
+			}
+		} else {
+			medvdbg("no header\n");
+			return -1;
+		}
+		break;
+	default:
+		medvdbg("does not support header parsing\n");
+		return -1;
+	}
+
+	if (header != NULL) {
+		free(header);
+	}
+	return headPoint;
+}
+
+bool checkHeader(unsigned char *buffer, unsigned int *channel, unsigned int *sampleRate, unsigned int *samplePerFrame)
+{
+	unsigned int header;
+	unsigned int bitrate;
+	unsigned int aau_size;
+	unsigned int version_index;
+	unsigned int layer_index;
+
+	unsigned char version;
+	unsigned char layer;
+	unsigned char bitrate_index;
+	unsigned char sample_rate_index;
+	unsigned char padding;
+	unsigned char channel_mode;
+
+	header = buffer[0] << 24 | buffer[1] << 16 | buffer[2] << 8 | buffer[3];
+
+	version = (header >> 19) & 0x3;
+	switch (version) {
+	case MPEG_1:
+		version_index = 0;
+		break;
+	case MPEG_2:
+		version_index = 1;
+		break;
+	case MPEG_2_5:
+		version_index = 2;
+		break;
+	default:
+		return false;
+	}
+
+	layer = (header >> 17) & 0x3;
+	switch (layer) {
+	case LAYER_1:
+		layer_index = 0;
+		break;
+	case LAYER_2:
+		layer_index = 1;
+		break;
+	case LAYER_3:
+		layer_index = 2;
+		break;
+	default:
+		return false;
+	}
+
+	bitrate_index = (header >> 12) & 0xf;
+	if ((bitrate_index == BITRATE_FREE) || bitrate_index == BITRATE_BAD) {
+		return false;
+	}
+
+	sample_rate_index = (header >> 10) & 0x3;
+	if (sample_rate_index == SAMPLE_RATE_UNDEFINED) {
+		return false;
+	}
+	padding = (header >> 9) & 0x1;
+
+	bitrate = bitRateTable[version_index][layer_index][bitrate_index - 1];
+	*sampleRate = sampleRateTable[version_index][sample_rate_index];
+
+	channel_mode = (header >> 8) & 0x3;
+	if (channel_mode <= 2) {
+		*channel = 2;
+	} else {
+		*channel = 1;
+	}
+
+	switch (layer) {
+	case LAYER_1:
+		aau_size = MPEG_LAYER1_AAU_SIZE(*sampleRate, bitrate, padding);
+		break;
+	case LAYER_2:
+		aau_size = MPEG_LAYER2_AAU_SIZE(*sampleRate, bitrate, padding);
+		break;
+	case LAYER_3:
+		if (version == MPEG_1) {
+			aau_size = MPEG1_LAYER3_AAU_SIZE(*sampleRate, bitrate, padding);
+		} else {
+			aau_size = MPEG2_LAYER3_AAU_SIZE(*sampleRate, bitrate, padding);
+		}
+		break;
+	}
+
+	if (aau_size > 0) {
+		*samplePerFrame = aau_size;
+	}
+
+	if (buffer[0] == buffer[aau_size] && buffer[1] == buffer[aau_size + 1]) {
+		DEBUG_TRACE(LOG_DEBUG, "aau_size : %d version : %d bitrate : %d samplerate : %d\n", aau_size, version, bitrate, *sampleRate);
+		return true;
+	}
+
+	return false;
+}
+
+struct wav_header_s {
+	char headerRiff[4]; //"RIFF"
+	uint32_t riffSize;
+	char headerWave[4]; //"wave"
+	char headerFmt[4];  //"fmt "
+	uint32_t fmtSize;   //16 for pcm
+	uint16_t format;	//1 for pcm
+	uint16_t channels;
+	uint32_t sampleRate;
+	uint32_t byteRate;
+	uint16_t blockAlign;
+	uint16_t bitPerSample;
+	char headerData[4]; //"data"
+	uint32_t dataSize;
+};
+
+bool createWavHeader(FILE *fp)
+{
+	struct wav_header_s *header;
+	header = (struct wav_header_s *)malloc(sizeof(struct wav_header_s));
+	if (!header) {
+		DEBUG_TRACE(LOG_DEBUG, "fail to malloc buffer\n");
+		return false;
+	}
+
+	memset(header, 0xff, WAVE_HEADER_LENGTH);
+	int ret;
+	ret = fwrite(header, sizeof(unsigned char), WAVE_HEADER_LENGTH, fp);
+	if (ret != WAVE_HEADER_LENGTH) {
+		DEBUG_TRACE(LOG_DEBUG, "file write failed error %d\n", errno);
+		free(header);
+		return false;
+	}
+	if (fseek(fp, WAVE_HEADER_LENGTH, SEEK_SET) != 0) {
+		DEBUG_TRACE(LOG_DEBUG, "file seek failed error\n");
+		free(header);
+		return false;
+	}
+
+	free(header);
+	return true;
+}
+
+bool writeWavHeader(FILE *fp, unsigned int channel, unsigned int sampleRate, audio_format_type_t pcmFormat, unsigned int fileSize)
+{
+	/**
+*wave header is
+*Chunk ID 'RIFF' (4byte) / Chunk Size (4byte) / Fomat 'WAVE' (4byte) /
+*Chunk ID 'fmt ' (4byte) / Chunk Size (4byte) / Audio Format (2byte) / NumChannels     (2byte) /
+*sample Rate     (4byte) / Byte Rate  (4byte) / Block Align  (2byte) / Bits Per sample (2byte) /
+*Chunk ID 'data' (4byte) / Chunk Size (4byte)
+*/
+	if (fseek(fp, 0, SEEK_SET) != 0) {
+		DEBUG_TRACE(LOG_DEBUG, "file seek failed error\n");
+		return false;
+	}
+
+	uint32_t byteRate = 0;
+	uint16_t bitPerSample = 0;
+	uint16_t blockAlign = 0;
+
+	switch (pcmFormat) {
+	case AUDIO_FORMAT_TYPE_S16_LE:
+		bitPerSample = 16;
+		break;
+	case AUDIO_FORMAT_TYPE_S32_LE:
+		bitPerSample = 32;
+		break;
+	default:
+		DEBUG_TRACE(LOG_DEBUG, "does not support audio format.\n");
+		return false;
+	}
+
+	blockAlign = channel * (bitPerSample >> 3);
+	byteRate = sampleRate * blockAlign;
+
+	struct wav_header_s *header;
+	header = (struct wav_header_s *)malloc(sizeof(struct wav_header_s));
+	if (header == NULL) {
+		DEBUG_TRACE(LOG_DEBUG, "malloc failed error\n");
+		return false;
+	}
+
+	strncpy(header->headerRiff, "RIFF", 4);
+
+	header->riffSize = fileSize - 8;
+
+	strncpy(header->headerWave, "WAVE", 4);
+	strncpy(header->headerFmt, "fmt ", 4);
+
+	header->fmtSize = 16;
+	header->format = 1;
+	header->channels = channel;
+	header->sampleRate = sampleRate;
+	header->byteRate = byteRate;
+	header->blockAlign = blockAlign;
+	header->bitPerSample = bitPerSample;
+
+	strncpy(header->headerData, "data", 4);
+
+	header->dataSize = fileSize - WAVE_HEADER_LENGTH;
+
+	int ret = 0;
+	ret = fwrite(header, sizeof(unsigned char), WAVE_HEADER_LENGTH, fp);
+
+	if (ret != WAVE_HEADER_LENGTH) {
+		DEBUG_TRACE(LOG_DEBUG, "file write failed error %d\n", errno);
+		free(header);
+		return false;
+	}
+
+	free(header);
+	return true;
+}
+
+Timer::Timer()
+{
+	int ret;
+	struct sched_param sparam;
+	pthread_attr_t attr;
+	pthread_attr_init(&attr);
+	pthread_attr_setstacksize(&attr, PTHREAD_STACK_DEFAULT);
+	sparam.sched_priority = 100;
+	pthread_attr_setschedparam(&attr, &sparam);
+
+	ret = pthread_create(&mTimerThread, &attr, timerThread, this);
+	if (ret != OK) {
+		DEBUG_TRACE(LOG_ERR, "Fail to create worker thread, return value : %d\n", ret);
+		mIsRunning = false;
+		return;
+	}
+	pthread_setname_np(mTimerThread, "Timer");
+
+	DEBUG_TRACE(LOG_INFO, "timer started\n");
+}
+
+Timer::~Timer()
+{
+	pthread_join(mTimerThread, NULL);
+	delete getInstance();
+}
+
+Timer *Timer::getInstance()
+{
+	static Timer *__mTimer;
+	if (!__mTimer) {
+		__mTimer = new Timer();
+	}
+	return __mTimer;
+}
+
+void Timer::timerClose()
+{
+	mIsRunning = false;
+}
+
+int Timer::newTimer(void **lphTmrElem)
+{
+	int ret = timerNewTimerElem(lphTmrElem);
+	if (ret < 0) {
+		DEBUG_TRACE(LOG_ERR, "TIMER : NewTimer(set time) Error!!!");
+		return -1;
+	}
+	return 0;
+}
+
+int Timer::setTimer(void *hAppTmrElem, void *hTmrElem, timerCallbackT cb, unsigned long msecTimeout, bool permanant)
+{
+	int ret = timerSetTimerElem(hAppTmrElem, hTmrElem, cb, msecTimeout, permanant);
+	if (ret < 0) {
+		DEBUG_TRACE(LOG_ERR, "TIMER : SetTimer(set time) Error!!!");
+		return -1;
+	}
+	return 0;
+}
+
+int Timer::resetTimer(void *hTmrElem)
+{
+	int ret = timerResetTimerElem(hTmrElem);
+	if (ret < 0) {
+		DEBUG_TRACE(LOG_ERR, "TIMER : ResetTimer(reset time) Error!!!");
+		return -1;
+	}
+	return 0;
+}
+
+void Timer::freeTimer(void *hTmrElem)
+{
+	int ret = timerFreeTimerElem(hTmrElem);
+	if (ret < 0) {
+		DEBUG_TRACE(LOG_ERR, "TIMER : FreeTimer(free time) Error!!!");
+	}
+}
+
+long Timer::getDurationTime(void *hTmrElem)
+{
+	return timerDurationElem(hTmrElem);
+}
+
+long Timer::getTick()
+{
+	struct timespec tp;
+	clock_gettime(CLOCK_REALTIME, &tp);
+	return (tp.tv_sec - mTimerClass.start_tv_sec) * (1000 / DEFAULT_TIME_MSEC) + (tp.tv_nsec / (1000000 * DEFAULT_TIME_MSEC));
+}
+
+void *Timer::timerThread(void *arg)
+{
+	Timer *timer = static_cast<Timer *>(arg);
+	struct timespec tp;
+	lTimerElem_t *elem;
+	long time = 0, rv = 0;
+
+	memset((char *)&(timer->mTimerClass), 0, sizeof(timer_s));
+	memset((char *)&(timer->mTimer), 0, sizeof(lTimerElem_t) * MAX_TIMER);
+
+	timer->mTimerClass.max = MAX_TIMER;
+	timer->mTimerClass.tick = DEFAULT_TIME_MSEC;
+	timer->mTimerClass.idx = 0;
+
+	clock_gettime(CLOCK_REALTIME, &tp);
+	timer->mTimerClass.start_tv_sec = tp.tv_sec;
+
+	timer->mIsRunning = true;
+
+	DEBUG_TRACE(LOG_INFO, "TIMER Therad Start");
+
+	while (timer->mIsRunning) {
+		for (int i = 0; i < timer->mTimerClass.max; i++) {
+			elem = &(timer->mTimer[i]);
+			if ((elem->used == true) && (elem->hAppTmr != NULL) && (elem->expires > 0)) {
+				time = timer->getTick();
+				rv = time - elem->timeout;
+				if (rv > 0 && (rv >= elem->expires)) {
+					if (elem->cb) {
+						if (elem->permant) {
+							elem->timeout = time;
+						}
+						if (elem->cb) {
+							elem->cb((void *)elem, elem->hAppTmr);
+						}
+					}
+				} else {
+					elem->current = rv;
+				}
+			}
+		}
+
+		WAITMS(DEFAULT_TIME_MSEC);
+	}
+
+	for (int j = 0; j < timer->mTimerClass.max; j++) {
+		timer->timerFreeTimerElem(&(timer->mTimer[j]));
+	}
+}
+
+int Timer::timerNewTimerElem(void **lphTmrElem)
+{
+	lTimerElem_t *elem;
+	int i = 0;
+
+	if (mTimerClass.idx >= mTimerClass.max) {
+		mTimerClass.idx = 0;
+	}
+
+	for (i = mTimerClass.idx; i < mTimerClass.max; i++) {
+		elem = &mTimer[i];
+		mTimerClass.idx++;
+		if (!elem->used) {
+			elem->used = true;
+			elem->idx = i;
+			elem->hAppTmr = NULL;
+			*lphTmrElem = (void *)elem;
+			return 0;
+		}
+	}
+
+	return -1;
+}
+
+int Timer::timerSetTimerElem(void *hAppTmrElem, void *hTmrElem, timerCallbackT cb, unsigned long msecTimeout, bool permant)
+{
+	struct timespec tp;
+	lTimerElem_t *elem = (lTimerElem_t *)hTmrElem;
+
+	if (!elem || !cb || !hAppTmrElem) {
+		return -1;
+	}
+
+	clock_gettime(CLOCK_REALTIME, &tp);
+
+	elem->hAppTmr = hAppTmrElem;
+	elem->cb = cb;
+	elem->timeout = (tp.tv_sec - mTimerClass.start_tv_sec) * (1000 / DEFAULT_TIME_MSEC) + (tp.tv_nsec / (1000000 * DEFAULT_TIME_MSEC));
+
+	elem->expires = msecTimeout;
+	elem->current = 0;
+	elem->permant = permant;
+
+	return 0;
+}
+
+int Timer::timerResetTimerElem(void *hTmrElem)
+{
+	lTimerElem_t *elem = (lTimerElem_t *)hTmrElem;
+	if (!elem) {
+		return 0;
+	}
+
+	elem->hAppTmr = NULL;
+	elem->permant = false;
+	elem->cb = NULL;
+	elem->timeout = 0;
+	elem->current = 0;
+	elem->expires = 0;
+	return 0;
+}
+
+int Timer::timerFreeTimerElem(void *hTmrElem)
+{
+	lTimerElem_t *elem = (lTimerElem_t *)hTmrElem;
+	if (!elem) {
+		return -1;
+	}
+
+	elem->hAppTmr = NULL;
+	elem->permant = false;
+	elem->cb = NULL;
+	elem->timeout = 0;
+	elem->current = 0;
+	elem->expires = 0;
+	elem->used = false;
+
+	return 0;
+}
+
+long Timer::timerDurationElem(void *hTmrElem)
+{
+	lTimerElem_t *elem = (lTimerElem_t *)hTmrElem;
+	if (!elem) {
+		return -1;
+	}
+
+	return elem->expires;
+}

--- a/apps/examples/araplayer/AudioUtils.h
+++ b/apps/examples/araplayer/AudioUtils.h
@@ -1,0 +1,160 @@
+/****************************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __AUDIO_UTILS_H__
+#define __AUDIO_UTILS_H__
+
+#include <iostream>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdarg.h>
+#include <pthread.h>
+#include <unistd.h>
+#include <time.h>
+#include <sys/time.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <media/MediaTypes.h>
+
+#include "AudioCommon.h"
+
+#define CLEAN(x)  \
+	if (x)        \
+		delete x; \
+	x = NULL;
+
+using namespace media;
+
+// MPEG version
+
+#define MPEG_1 3
+#define MPEG_2 2
+#define MPEG_UNDEFINED 1
+#define MPEG_2_5 0
+
+// MPEG layer
+#define LAYER_1 3
+#define LAYER_2 2
+#define LAYER_3 1
+#define LAYER_UNDEFINED 0
+
+// Bitrate index
+#define BITRATE_FREE 0x0 // Variable Bit Rate
+#define BITRATE_BAD 0xf  // Not allow
+
+// Sample Rate index
+#define SAMPLE_RATE_UNDEFINED 0x3
+
+// aau size = frame samples * (1 / sample rate) * bitrate / 8 + padding
+//            = frame samples * bitrate / 8 / sample rate + padding
+// Number of frame samples is constant value as below table:
+//        MPEG1  MPEG2(LSF)  MPEG2.5(LSF)
+// Layer1  384     384         384
+// Layer2  1152    1152        1152
+// Layer3  1152    576         576
+#define MPEG_LAYER1_AAU_SIZE(sr, br, pad) (384 * ((br)*1000) / 8 / (sr) + ((pad)*4))
+#define MPEG_LAYER2_AAU_SIZE(sr, br, pad) (1152 * ((br)*1000) / 8 / (sr) + (pad))
+#define MPEG1_LAYER3_AAU_SIZE(sr, br, pad) (1152 * ((br)*1000) / 8 / (sr) + (pad))
+#define MPEG2_LAYER3_AAU_SIZE(sr, br, pad) (576 * ((br)*1000) / 8 / (sr) + (pad))
+
+//***************************************************************************
+// Name: log
+//***************************************************************************/
+#define DEBUG_TRACE(lv, ...) ARAPS_LOG(lv, __FILE__, __LINE__, __FUNCTION__, __VA_ARGS__)
+
+void ARAPS_LOG(int level, const char *filename, unsigned int line, const char *function, const char *pf_format, ...);
+void WAITMS(int msec);
+void WAITNS(int nanosec);
+
+void toLowerString(std::string &str);
+void toUpperString(std::string &str);
+audio_type_t getAudioTypeFromPath(std::string path);
+audio_type_t getAudioTypeFromMimeType(std::string &mimeType);
+bool header_parsing(FILE *fp, audio_type_t AudioType, unsigned int *channel, unsigned int *sample_rate, audio_format_type_t *pcmFormat);
+int header_parsing(unsigned char *buffer, unsigned int bufferSize, audio_type_t audioType, unsigned int *channel, unsigned int *sampleRate, unsigned int *samplePerFrame, audio_format_type_t *pcmFormat);
+bool createWavHeader(FILE *fp);
+bool writeWavHeader(FILE *fp, unsigned int channel, unsigned int sampleRate, audio_format_type_t pcmFormat, unsigned int fileSize);
+bool checkHeader(unsigned char *buffer, unsigned int *channel, unsigned int *sampleRate, unsigned int *samplePerFrame);
+
+//***************************************************************************
+// Name: Timer
+//***************************************************************************/
+
+#define MAX_TIMER 5
+#define DEFAULT_TIME_MSEC 10
+
+typedef void (*timerCallbackT)(void *elem, void *appelem);
+
+class Timer
+{
+public:
+	Timer();
+	~Timer();
+
+	static Timer *getInstance();
+	void timerClose();
+	int newTimer(void **lphTmrElem);
+	int setTimer(void *hAppTmrElem, void *hTmrElem, timerCallbackT cb, unsigned long msecTimeout, bool permanant);
+	int resetTimer(void *hTmrElem);
+	void freeTimer(void *hTmrElem);
+	long getDurationTime(void *hTmrElem);
+	long getTick();
+
+private:
+	struct timer_s {
+		short count;
+		short max;
+		short idx;
+		long tick;
+		long start_tv_sec;
+		pthread_t tid;
+	};
+
+	typedef timer_s timer_t;
+
+	struct lTimerElem_s {
+		void *hAppTmr;
+		bool used;
+		bool permant;
+		short idx;
+		long timeout;
+		long current;
+		long expires;
+		timerCallbackT cb;
+	};
+
+	typedef lTimerElem_s lTimerElem_t;
+
+	bool mIsRunning;
+	timer_t mTimerClass;
+	lTimerElem_t mTimer[MAX_TIMER];
+
+	pthread_t mTimerThread;
+
+	int timerNewTimerElem(void **lphTmrElem);
+	int timerSetTimerElem(void *hAppTmrElem, void *hTmrElem, timerCallbackT cb, unsigned long msecTimeout, bool permant);
+	int timerResetTimerElem(void *hTmrElem);
+	int timerFreeTimerElem(void *hTmrElem);
+	long timerDurationElem(void *hTmrElem);
+
+protected:
+	static void *timerThread(void *);
+};
+#endif

--- a/apps/examples/araplayer/AudioWorker.cpp
+++ b/apps/examples/araplayer/AudioWorker.cpp
@@ -1,0 +1,268 @@
+/* ****************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************/
+
+#include <debug.h>
+#include <sched.h>
+#include <pthread.h>
+
+#include "AraPlayer.h"
+#include "AudioWorker.h"
+#include "AudioStream.h"
+#include "AudioPDStream.h"
+#include "AudioHASStream.h"
+
+AudioWorker::AudioWorker() :
+	mStacksize(PTHREAD_STACK_DEFAULT * 4),
+	mPriority(100),
+	mThreadName("AudioWorker"),
+	mIsRunning(false),
+	mRefCnt(0),
+	mWorkerThread(0),
+	mEnableCurl(false),
+	mMeasureCnt(0),
+	mBandwidth(0)
+{
+	medvdbg("AudioWorker::AudioWorker()\n");
+}
+
+AudioWorker::~AudioWorker()
+{
+	medvdbg("AudioWorker::~AudioWorker()\n");
+}
+
+AudioWorker &AudioWorker::getWorker()
+{
+	static AudioWorker worker;
+	return worker;
+}
+
+void AudioWorker::startWorker()
+{
+	std::unique_lock<std::mutex> lock(mRefMtx);
+	++mRefCnt;
+	DEBUG_TRACE(LOG_INFO, "%s::startWorker() - increase RefCnt : %d\n", mThreadName, mRefCnt);
+	if (mRefCnt == 1) {
+		int ret;
+		struct sched_param sparam;
+		pthread_attr_t attr;
+		pthread_attr_init(&attr);
+		pthread_attr_setstacksize(&attr, mStacksize);
+		sparam.sched_priority = mPriority;
+		pthread_attr_setschedparam(&attr, &sparam);
+		mIsRunning = true;
+		ret = pthread_create(&mWorkerThread, &attr, static_cast<pthread_startroutine_t>(AudioWorker::audioLooper), this);
+		if (ret != OK) {
+			DEBUG_TRACE(LOG_ERR, "Fail to create worker thread, return value : %d\n", ret);
+			--mRefCnt;
+			mIsRunning = false;
+			return;
+		}
+		pthread_setname_np(mWorkerThread, mThreadName);
+	}
+
+	DEBUG_TRACE(LOG_INFO, "worker started\n");
+}
+
+void AudioWorker::stopWorker()
+{
+	std::unique_lock<std::mutex> lock(mRefMtx);
+	if (mRefCnt > 0) {
+		--mRefCnt;
+	}
+	medvdbg("%s::stopWorker() - decrease RefCnt : %d\n", mThreadName, mRefCnt);
+	if (mRefCnt <= 0) {
+		std::atomic<bool> &refBool = mIsRunning;
+		mWorkerQueue.enQueue([&refBool]() {
+			refBool = false;
+		});
+		pthread_join(mWorkerThread, NULL);
+		medvdbg("%s::stopWorker() - mWorkerthread exited\n", mThreadName);
+	}
+}
+
+void AudioWorker::setCurl(void *curl)
+{
+	mCurl = curl;
+}
+
+void AudioWorker::setPlayer(std::shared_ptr<AraPlayer> player)
+{
+	mPlayer = player;
+}
+
+void AudioWorker::enableCurl()
+{
+	mEnableCurl = true;
+}
+
+void AudioWorker::disableCurl()
+{
+	mEnableCurl = false;
+}
+
+std::function<void()> AudioWorker::deQueue()
+{
+	return mWorkerQueue.deQueue();
+}
+
+AudioHttpDownloader *AudioWorker::findHttpDownloader(void *handle)
+{
+	std::map<pid_t, AudioStream *> sMap = mPlayer->getStreamMap();
+	std::map<pid_t, AudioStream *>::iterator sIter;
+	std::map<void *, AudioHttpDownloader *> dMap;
+	std::map<void *, AudioHttpDownloader *>::iterator dIter;
+
+	for (sIter = sMap.begin(); sIter != sMap.end(); sIter++) {
+		switch (((AudioStream *)sIter->second)->getStreamType()) {
+		case STREAM_HTTP_PROGRESSIVE:
+			dMap = ((AudioPDStream *)sIter->second)->getDownloaderMap();
+			break;
+		case STREAM_HTTP_HLS:
+		case STREAM_HTTP_DASH:
+			dMap = ((AudioHASStream *)sIter->second)->getDownloaderMap();
+			break;
+		default:
+			DEBUG_TRACE(LOG_INFO, "Unknow stream type [%d]", ((AudioStream *)sIter->second)->getStreamType());
+			continue;
+		}
+
+		dIter = dMap.find(handle);
+		if (dIter != dMap.end()) {
+			DEBUG_TRACE(LOG_INFO, "found handle\n");
+			return dIter->second;
+		}
+	}
+}
+
+void AudioWorker::measureBandwidth()
+{
+	std::map<pid_t, AudioStream *> sMap = mPlayer->getStreamMap();
+	std::map<pid_t, AudioStream *>::iterator sIter;
+	std::map<void *, AudioHttpDownloader *> dMap;
+	std::map<void *, AudioHttpDownloader *>::iterator dIter;
+
+	double val = 0;
+	double totalVal = 0;
+	int conns = 0;
+	int ret = 0;
+
+	if (mMeasureCnt % 5 == 0) {
+		for (sIter = sMap.begin(); sIter != sMap.end(); sIter++) {
+			switch (((AudioStream *)sIter->second)->getStreamType()) {
+			case STREAM_HTTP_PROGRESSIVE:
+				dMap = ((AudioPDStream *)sIter->second)->getDownloaderMap();
+				break;
+			case STREAM_HTTP_HLS:
+			case STREAM_HTTP_DASH:
+				dMap = ((AudioHASStream *)sIter->second)->getDownloaderMap();
+				break;
+			default:
+				DEBUG_TRACE(LOG_INFO, "Unknow stream type [%d]", ((AudioStream *)sIter->second)->getStreamType());
+				continue;
+			}
+
+			for (dIter = dMap.begin(); dIter != dMap.end(); dIter++) {
+				ret = curl_easy_getinfo((CURL *)dIter->first, CURLINFO_SPEED_DOWNLOAD, &val);
+				if ((ret == CURLE_OK) && (val > 0)) {
+					totalVal += val;
+					conns++;
+				}
+			}
+		}
+		mBandwidth = ((totalVal / 1024 / 1024) * 8) / conns;
+		//DEBUG_TRACE(LOG_INFO, "Currnet Download Speed : %0.3f Mbps, Connections(%d)", mBandwidth, conns);
+	}
+
+	mMeasureCnt++;
+}
+
+void AudioWorker::pollCurl(int msec)
+{
+	CURLMsg *msg;
+	CURLMcode mc;
+
+	int numfds, msgs_left, repeats = 0;
+
+	mc = curl_multi_perform((CURLM *)mCurl, &mCurlRunning);
+
+	if (mc == CURLM_OK)
+		mc = curl_multi_wait((CURLM *)mCurl, NULL, 0, msec, &numfds);
+
+	if (mc != CURLM_OK) {
+		//DEBUG_TRACE(LOG_ERR, "curl_multi_wait() failed, code %d", mc);
+		return;
+	}
+
+	if (!numfds) {
+		repeats++; /* count number of repeated zero numfds */
+		if (repeats > 1)
+			WAITMS(100); /* sleep 100 milliseconds */
+	} else
+		repeats = 0;
+
+	/* See how the transfers went */
+	while ((msg = curl_multi_info_read((CURLM *)mCurl, &msgs_left))) {
+		if (msg->msg == CURLMSG_DONE) {
+			AudioHttpDownloader *httpDownloader = static_cast<AudioHttpDownloader *>(findHttpDownloader((void *)msg->easy_handle));
+			if (httpDownloader) {
+				DEBUG_TRACE(LOG_INFO, "HTTP Downlaod Complete??? %d", mc);
+				httpDownloader->downloadComplete();
+			} else {
+				// error process...
+				DEBUG_TRACE(LOG_INFO, "curl_multi_remove_handle %d", mc);
+				curl_multi_remove_handle((CURLM *)mCurl, msg->easy_handle);
+			}
+		}
+	}
+	return;
+}
+
+bool AudioWorker::processLoop()
+{
+	if (mEnableCurl) {
+		pollCurl(100);
+		measureBandwidth();
+		return true;
+	}
+
+	return false;
+}
+
+void *AudioWorker::audioLooper(void *arg)
+{
+	auto worker = static_cast<AudioWorker *>(arg);
+	DEBUG_TRACE(LOG_INFO, "Start audioLooper\n");
+
+	while (worker->mIsRunning) {
+		while (worker->processLoop() && worker->mWorkerQueue.isEmpty()) {
+			WAITMS(1);
+		}
+
+		std::function<void()> run = worker->deQueue();
+		if (run != nullptr) {
+			run();
+		}
+	}
+	return NULL;
+}
+
+bool AudioWorker::isAlive()
+{
+	std::unique_lock<std::mutex> lock(mRefMtx);
+	return mRefCnt == 0 ? false : true;
+}

--- a/apps/examples/araplayer/AudioWorker.h
+++ b/apps/examples/araplayer/AudioWorker.h
@@ -1,0 +1,77 @@
+/* ****************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************/
+
+#ifndef __AUDIO_WORKER_H__
+#define __AUDIO_WORKER_H__
+
+#include <sys/types.h>
+#include <curl/curl.h>
+#include <atomic>
+#include <mutex>
+
+#include "AudioQueue.h"
+#include "AudioUtils.h"
+#include "AudioHttpDownloader.h"
+
+class AudioWorker
+{
+public:
+	AudioWorker();
+	virtual ~AudioWorker();
+
+	void startWorker();
+	void stopWorker();
+
+	template <typename _Callable, typename... _Args>
+	void enQueue(_Callable &&__f, _Args &&... __args)
+	{
+		mWorkerQueue.enQueue(__f, __args...);
+	}
+	std::function<void()> deQueue();
+	bool isAlive();
+
+	static AudioWorker &getWorker();
+	void setCurl(void *);
+	void enableCurl();
+	void disableCurl();
+	void setPlayer(std::shared_ptr<AraPlayer>);
+
+private:
+	bool processLoop();
+	static void *audioLooper(void *);
+	AudioHttpDownloader *findHttpDownloader(void *);
+	void pollCurl(int msec);
+	void measureBandwidth();
+
+private:
+	AudioQueue mWorkerQueue;
+	std::atomic<bool> mIsRunning;
+	int mRefCnt;
+	pthread_t mWorkerThread;
+	std::mutex mRefMtx;
+	void *mCurl;
+	int mCurlRunning;
+	bool mEnableCurl;
+	std::shared_ptr<AraPlayer> mPlayer;
+	long mStacksize;
+	int mPriority;
+	double mBandwidth;
+	unsigned int mMeasureCnt;
+	const char *mThreadName;
+};
+#endif

--- a/apps/examples/araplayer/Enumerator.h
+++ b/apps/examples/araplayer/Enumerator.h
@@ -1,0 +1,29 @@
+#pragma once
+
+/**
+ * @brief HLS Playlist type.
+ * @details
+ * @since TizenRT v3.0
+ */
+typedef enum play_list_type_s {
+	/** HLS Playlist type case */
+	NONE = -1,
+	/** HLS Playlist has a multi-tree structure */
+	MASTER = 0,
+	/** HLS Playlist has a single-tree structure */
+	SINGLE = 1,
+	/** HLS Playlist has a Media file */
+	MEDIA,
+} play_list_type_t;
+
+/**
+ * @brief Http Adaptive Streaming Type.
+ * @details
+ * @since TizenRT v3.0
+ */
+typedef enum has_type_s {
+	/** Http live streaming */
+	HLS_MANIFEST,
+	/** Mpeg Dash */
+	DASH_MPD
+} has_type_t;

--- a/apps/examples/araplayer/HASParser.cpp
+++ b/apps/examples/araplayer/HASParser.cpp
@@ -1,0 +1,110 @@
+/****************************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+#include <string.h>
+#include "HASParser.h"
+#include "HLSParser.h"
+#include "AudioUtils.h"
+
+HASParser::HASParser()
+{
+	mMapHasParser.insert(std::make_pair(".m3u8", new HLSParser));
+}
+
+HASParserInterface *HASParser::findParserWithPlaylistUrl(const char *url)
+{
+	int urlLen = strlen(url);
+	if (urlLen <= 5) {
+		DEBUG_TRACE(LOG_ERR, "url length <= 5");
+		return NULL;
+	}
+
+	int i;
+	for (i = urlLen - 1; i >= 0 && url[i] != '.'; --i);
+
+	if (i < 0) {
+		DEBUG_TRACE(LOG_ERR, "there is no extension");
+		return NULL;
+	}
+
+	ParserIter iter = mMapHasParser.find(url + i);
+	if (iter == mMapHasParser.end()) {
+		DEBUG_TRACE(LOG_ERR, "there is no appropriate parser");
+		return NULL;
+	}
+
+	return iter->second;
+}
+
+int HASParser::parsePlaylist(const char *url, const char *data, int size)
+{
+	HASParserInterface *parser = findParserWithPlaylistUrl(url);
+	if (parser == NULL) {
+		DEBUG_TRACE(LOG_ERR, "parser is null");
+		return -1;
+	}
+
+	return parser->parsePlaylist(url, data, size);
+}
+
+int HASParser::parseSegment(const char *url, const char *data, int size)
+{
+	for (ParserIter iter = mMapHasParser.begin(); iter != mMapHasParser.end(); ++iter) {
+		int ret = iter->second->parseSegment(url, data, size);
+		if (ret > 0) {
+			return 1;
+		}
+	}
+
+	DEBUG_TRACE(LOG_DEBUG, "segment index box parsing fail");
+	return 0;
+}
+
+int HASParser::getPlaylistInfo(const char *url, int bandwidth, has_segment_info_t *outSegInfo)
+{
+	if (bandwidth <= 0) {
+		DEBUG_TRACE(LOG_ERR, "GetSegmentUrlWithIndex, bandwidth is %d", bandwidth);
+		return -1;
+	}
+
+	HASParserInterface *parser = findParserWithPlaylistUrl(url);
+	return parser->getPlaylistInfo(url, bandwidth, outSegInfo);
+}
+
+int HASParser::getSegmentInfo(const char *url, unsigned int idx, int bandwidth, has_segment_info_t *outSegInfo)
+{
+	HASParserInterface *parser = findParserWithPlaylistUrl(url);
+	if (parser == nullptr) {
+		return -1;
+	}
+
+	return parser->getSegmentInfo(url, idx, bandwidth, outSegInfo);
+}
+
+void HASParser::setCallback_GetPlaylistInfo(void *callbackObj, HASParserInterface::Callback_GetPlaylistInfo cbGetPlaylistInfo)
+{
+	for (ParserIter iter = mMapHasParser.begin(); iter != mMapHasParser.end(); ++iter) {
+		iter->second->setCallback_GetPlaylistInfo(callbackObj, cbGetPlaylistInfo);
+	}
+}
+
+HASParser *HASParser::getInstance()
+{
+	static HASParser instance;
+	return &instance;
+}

--- a/apps/examples/araplayer/HASParser.h
+++ b/apps/examples/araplayer/HASParser.h
@@ -1,0 +1,98 @@
+/****************************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+ /**
+ * @file HASParser.h
+ * @brief Http Adaptive Streaming Parser APIS.
+ */
+
+#pragma once
+
+#include <map>
+#include <string>
+#include "HASParserInterface.h"
+
+#define DEBUG_LOG(X) DEBUG_TRACE(X)
+
+/**
+ * @class
+ * @brief This class is http adaptive streaming parser data structure
+ * @details @b #include <araplayer/HASParser.h>
+ * @since TizenRT v3.0
+ */
+
+class HASParser
+{
+public:
+	/**
+	 * @brief HASParser Constructs a new object provide
+	 * @details @b #include <araplayer/HASParser.h>
+	 * @since TizenRT v3.0
+	 */
+	HASParser();
+	/**
+	 * @brief Playlist parsing API
+	 * @details @b #include <araplayer/HASParser.h>
+	 * @param[in] url  requested playlist url
+	 * @param[in] data playlist data buffer point
+	 * @param[in] data playlist data size
+	 * @return True is Success, False is Fail
+	 * @since TizenRT v3.0
+	 */
+	int parsePlaylist(const char *url, const char *data, int size);
+	/**
+	 * @brief Get the Playlist Information
+	 * @details @b #include <araplayer/HASParser.h>
+	 * @param[in] url  requested playlist url
+	 * @param[in] bandwidth value of bandwith
+	 * @param[out] outSegInfo playlist info output data structure
+	 * @return True is Success, False is Fail
+	 * @since TizenRT v3.0
+	 */
+	int getPlaylistInfo(const char *url, int bandwidth, has_segment_info_t *outSegInfo);
+	/**
+	 * @brief Get the Segment Information
+	 * @details @b #include <araplayer/HASParser.h>
+	 * @param[in] url  requested playlist url
+	 * @param[in] inx  segment index
+	 * @param[in] bandwidth value of bandwith
+	 * @param[out] outSegInfo playlist info output data structure
+	 * @return True is Success, False is Fail
+	 * @since TizenRT v3.0
+	 */
+	int getSegmentInfo(const char *url, unsigned int idx, int bandwidth, has_segment_info_t *outSegInfo);
+	/**
+	 * @brief Sets the callback for Playlist parser data
+	 * @details @b #include <araplayer/HASParser.h>
+	 * @param[in] callbackObj the callback to be set for HASStream
+	 * @param[in] callbackFnc sets the callback function
+	 * @since TizenRT v3.0
+	 */
+	void setCallback_GetPlaylistInfo(void *callbackObj, HASParserInterface::Callback_GetPlaylistInfo cbGetPlaylistInfo);
+	
+	//TO-DO will remove
+	static HASParser *getInstance();
+	//TO-DO will remove
+	int parseSegment(const char *url, const char *data, int size);
+
+private:
+	HASParserInterface *findParserWithPlaylistUrl(const char *url);
+	HASParserInterface *findParserWithSegmentUrl(const char *url);
+	typedef std::map<std::string, HASParserInterface *>::iterator ParserIter;
+	std::map<std::string, HASParserInterface *> mMapHasParser;
+};

--- a/apps/examples/araplayer/HASParserInterface.h
+++ b/apps/examples/araplayer/HASParserInterface.h
@@ -1,0 +1,77 @@
+/****************************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+/**
+ * @file HASParserInterface.h
+ * @brief HASParserInterface APIS.
+ */
+
+#pragma once
+
+#include "PlaylistInfo.h"
+
+/**
+ * @class
+ * @brief This class provides an interface to the user.
+ * @details @b #include <araplay/HASParserInterface.h>
+ * This class informs the user of the parser apis.
+ * @since TizenRT v3.0
+ */
+
+class HASParserInterface
+{
+public:
+	/**
+	 * callback function type.
+	 * size_t callback(void *callbackObj, const char *url, play_list_info_t &out_pInfo)
+	 * The callbacks CANNOT be non-static class member functions.
+	 */
+	typedef void (*Callback_GetPlaylistInfo)(void *callbackObj, const char *url, play_list_info_t &out_pInfo);
+
+	virtual int parsePlaylist(const char *url, const char *data, int size)
+	{
+		return 0;
+	}
+
+	virtual int parseSegment(const char *url, const char *data, int size)
+	{
+		return 0;
+	}
+
+	virtual int getPlaylistInfo(const char *url, int bandwidth, has_segment_info_t *outSegInfo)
+	{
+		return 0;
+	}
+
+	virtual int getSegmentInfo(const char *url, int idx, int bandwidth, has_segment_info_t *outSegInfo)
+	{
+		return 0;
+	}
+
+	virtual void setCallback_GetPlaylistInfo(void *callbackObj, Callback_GetPlaylistInfo cbGetPlaylistInfo)
+	{
+	}
+
+protected:
+	void *mCallbackObject;
+
+	HASParserInterface() :
+		mCallbackObject(0)
+	{
+	}
+};

--- a/apps/examples/araplayer/HASType.h
+++ b/apps/examples/araplayer/HASType.h
@@ -1,0 +1,17 @@
+#pragma once
+
+typedef long long int64;
+
+typedef unsigned char uint8;
+typedef unsigned short uint16;
+typedef unsigned int uint32;
+typedef unsigned long long uint64;
+
+//TO-DO will remove
+struct range_s {
+	int64 start;
+	int64 end;
+};
+
+//TO-DO will remove
+typedef range_s range_t;

--- a/apps/examples/araplayer/HLSParser.cpp
+++ b/apps/examples/araplayer/HLSParser.cpp
@@ -1,0 +1,301 @@
+/****************************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+#include "HLSParser.h"
+#include <algorithm>
+#include <vector>
+#include <map>
+
+#include "AudioUtils.h"
+
+const char *HLSParser::PLAYLIST_EXT = ".m3u8";
+const char *HLSParser::SEGMENT_EXT = ".ts";
+const char *HLSParser::TARGET_DURATION = "#EXT-X-TARGETDURATION";
+const char *HLSParser::BEGIN_PLAYLIST_URL = "#EXT-X-STREAM-INF";
+const char *HLSParser::BEGIN_SEGMENT_URL = "#EXTINF";
+const char *HLSParser::BANDWIDTH = "BANDWIDTH";
+
+HLSParser::hls_play_list_t *HLSParser::findPlaylist(const char *url)
+{
+	for (std::map<std::string, hls_play_list_t *>::iterator iter = mMapMasterPlaylist.begin(); iter != mMapMasterPlaylist.end(); ++iter) {
+		if (iter->first.compare(url) == 0) {
+			return iter->second;
+		}
+
+		std::map<std::string, hls_play_list_t *> mapMediaPlaylist = iter->second->mapMediaPlaylist;
+		for (std::map<std::string, hls_play_list_t *>::iterator iterMedia = mapMediaPlaylist.begin(); iterMedia != mapMediaPlaylist.end(); ++iterMedia) {
+			if (iterMedia->first.compare(url) == 0) {
+				return iterMedia->second;
+			}
+		}
+	}
+	return NULL;
+}
+
+bool HLSParser::isFirstParsedMediaPlaylist(hls_play_list_t *mediaPlaylist)
+{
+    hls_play_list_t *masterPlaylist = mediaPlaylist->parent;
+    bool ret = false;
+
+    if (masterPlaylist == NULL) {
+        return ret;
+    }
+
+    for (auto iter = masterPlaylist->mapMediaPlaylist.begin(); iter != masterPlaylist->mapMediaPlaylist.end(); ++iter) {
+        if (masterPlaylist->parsingCnt == iter->second->parsingCnt) {
+            ret = true;
+        }
+    }
+
+    return ret;
+
+}
+
+int HLSParser::parsePlaylist(const char *url, const char *data, int size)
+{
+	hls_play_list_t *playlist = findPlaylist(url);
+	play_list_info_t pInfo;
+	int idx;
+
+	if (playlist == NULL) {
+		playlist = new hls_play_list_t;
+		playlist->url = std::string(url);
+		DEBUG_TRACE(LOG_DEBUG, "new playlist (cannot find playlist)");
+	}
+
+	if (playlist->parsingCnt > 0) {
+		playlist->parsingCnt++;
+		if (playlist->type == play_list_type_t::MASTER) {
+			DEBUG_TRACE(LOG_DEBUG, "");
+			for (std::map<std::string, hls_play_list_t *>::iterator iter = playlist->mapMediaPlaylist.begin(); iter != playlist->mapMediaPlaylist.end(); ++iter) {
+				iter->second->parsingCnt = 0;
+			}
+			playlist->parsingCnt = 1;
+		} else if ((playlist->type == play_list_type_t::MEDIA) && (mCallbackObject != NULL) && (mCBGetPlaylistInfo != NULL) && (isFirstParsedMediaPlaylist(playlist))) {
+			DEBUG_TRACE(LOG_DEBUG, "Execute GetPlaylistInfo Callback from Adaptor");
+			getMediaPlaylistInfo(playlist, pInfo);
+			mCBGetPlaylistInfo(mCallbackObject, url, pInfo);
+		}
+		return 1;
+	}
+
+	char segUrl[1024];
+	while (true) {
+		while (*data != '#' && *data != 0) {
+			++data;
+		}
+
+		if (*data == 0) {
+			break;
+		}
+
+		if (strncmp(TARGET_DURATION, data, mTargetDurationLen) == 0) {
+			int target_duration = 0;
+			data += mTargetDurationLen + 1;
+			while (*data >= '0' && *data <= '9') {
+				target_duration = target_duration * 10 + (*data - '0');
+				++data;
+			}
+			playlist->targetDuration = target_duration;
+		} else if (strncmp(BEGIN_PLAYLIST_URL, data, mBeginPlaylistUrlLen) == 0) {
+			if (playlist->type == play_list_type_t::NONE) {
+				playlist->type = play_list_type_t::MASTER;
+				mMapMasterPlaylist.insert(make_pair(std::string(url), playlist));
+			}
+
+			while (strncmp(BANDWIDTH, data, mBandwidthLen) != 0) {
+				++data;
+			}
+			data += mBandwidthLen + 1;
+
+			int bandwidth = 0;
+			while (*data >= '0' && *data <= '9') {
+				bandwidth = bandwidth * 10 + (*data - '0');
+				++data;
+			}
+
+			while (*data != '\n') {
+				++data;
+			}
+			++data;
+
+			idx = 0;
+			while (*data != '\r' && *data != '\n') {
+				segUrl[idx++] = *data++;
+			}
+
+			segUrl[idx] = 0;
+
+			hls_play_list_t *mediaPlaylist = new hls_play_list_t;
+			mediaPlaylist->url = std::string(segUrl);
+			mediaPlaylist->type = play_list_type_t::MEDIA;
+			mediaPlaylist->bandwidth = bandwidth;
+			mediaPlaylist->parent = playlist;
+
+			playlist->vecUrl.push_back(mediaPlaylist->url);
+			playlist->mapMediaPlaylist.insert(make_pair(mediaPlaylist->url, mediaPlaylist));
+		} else if (strncmp(BEGIN_SEGMENT_URL, data, mBeginSegmentUrlLen) == 0) {
+			if (playlist->type == play_list_type_t::NONE) {
+				playlist->type = play_list_type_t::SINGLE;
+				if (playlist->parent == NULL) {
+					DEBUG_TRACE(LOG_DEBUG, "Single Media Playlist [%s]", url);
+					mMapMasterPlaylist.insert(make_pair(std::string(url), playlist));
+				}
+			}
+
+			data += mBeginSegmentUrlLen + 1;
+			int point = 0;
+			double duration = 0;
+			while (*data != ',') {
+				duration = duration * 10 + (*data - '0');
+				point *= 10;
+				if (*data == '.') {
+					point = 1;
+				}
+				++data;
+			}
+
+			if (point) {
+				duration /= point;
+			}
+
+			++data;
+			while (*data == '\r' || *data == '\n') {
+				++data;
+			}
+
+			idx = 0;
+			while (*data != '\r' && *data != '\n') {
+				segUrl[idx++] = *data++;
+			}
+
+			segUrl[idx] = 0;
+			playlist->vecUrl.push_back(std::string(segUrl));
+		} else {
+			++data;
+		}
+	}
+
+	playlist->parsingCnt++;
+	if (mCallbackObject != NULL && mCBGetPlaylistInfo != NULL) {
+		if (isFirstParsedMediaPlaylist(playlist)) {
+			pInfo.playlistUrl = playlist->parent->url;
+		} else {
+			pInfo.playlistUrl = url;
+		}
+
+		getMediaPlaylistInfo(playlist, pInfo);
+		mCBGetPlaylistInfo(mCallbackObject, pInfo.playlistUrl.c_str(), pInfo);
+	}
+
+	return 1;
+}
+
+int HLSParser::getPlaylistInfo(const char *url, int bandwidth, has_segment_info_t *outSegInfo)
+{
+	int ret = 0;
+	PlaylistIter iter = mMapMasterPlaylist.find(url);
+	if (iter->second->parsingCnt <= 0 || iter == mMapMasterPlaylist.end()) {
+		DEBUG_TRACE(LOG_ERR, "there is no appropriate playlist with url: %s", url);
+		return -1;
+	}
+
+	std::map<std::string, hls_play_list_t *> &mapMediaPlaylist = iter->second->mapMediaPlaylist;
+	for (iter = mapMediaPlaylist.begin(); iter != mapMediaPlaylist.end(); ++iter) {
+		hls_play_list_t *playlist = iter->second;
+		if (playlist->bandwidth <= bandwidth) {
+			outSegInfo->url = std::string(playlist->url);
+			outSegInfo->bandwidth = bandwidth;
+			ret = 1;
+		}
+	}
+
+	return ret;
+}
+
+int HLSParser::getSegmentInfo(const char *url, int idx, int bandwidth, has_segment_info_t *outSegInfo)
+{
+	PlaylistIter iter = mMapMasterPlaylist.find(url);
+	hls_play_list_t *playlist;
+
+	if (iter == mMapMasterPlaylist.end()) {
+		DEBUG_TRACE(LOG_ERR, "there is no appropriate playlist with url: %s", url);
+		return -1;
+	}
+
+	std::map<std::string, hls_play_list_t *> &mapMediaPlaylist = iter->second->mapMediaPlaylist;
+	if (mapMediaPlaylist.size() > 0) {
+		for (iter = mapMediaPlaylist.begin(); iter != mapMediaPlaylist.end(); ++iter) {
+			playlist = iter->second;
+			if (playlist->bandwidth == bandwidth) {
+				if (idx >= (int)playlist->vecUrl.size()) {
+					DEBUG_TRACE(LOG_ERR, "index is larger than media playlist vector size, idx: %d, bandwidth: %d", idx, bandwidth);
+					return -1;
+				}
+				outSegInfo->url = std::string(playlist->vecUrl.at(idx));
+				outSegInfo->strRange = "";
+				outSegInfo->bandwidth = bandwidth;
+				return 1;
+			}
+		}
+	} else {
+		playlist = iter->second;
+		if (idx >= (int)playlist->vecUrl.size()) {
+			DEBUG_TRACE(LOG_ERR, "index is larger than media playlist vector size, idx: %d, bandwidth: %d", idx, bandwidth);
+			return -1;
+		}
+
+		outSegInfo->url = std::string(playlist->vecUrl.at(idx));
+		outSegInfo->strRange = "";
+		outSegInfo->bandwidth = bandwidth;
+		return 1;
+	}
+
+	DEBUG_TRACE(LOG_DEBUG, "there is no appropriate media playlist, idx: %d, bandwidth: %d, url: %s", idx, bandwidth, url);
+	return 0;
+}
+
+int HLSParser::getMediaPlaylistInfo(hls_play_list_t *playlist, play_list_info_t &pInfo)
+{
+	std::map<std::string, hls_play_list_t *> mapMediaPlaylist;
+	std::vector<int> &bandWidthQuality = pInfo.bandWidthQuality;
+	bandWidthQuality.clear();
+
+	pInfo.duration = playlist->targetDuration;
+	pInfo.hasType = HLS_MANIFEST;
+	pInfo.type = playlist->type;
+
+	if (playlist->parent == NULL) {
+		mapMediaPlaylist = playlist->mapMediaPlaylist;
+	} else {
+		mapMediaPlaylist = playlist->parent->mapMediaPlaylist;
+	}
+
+	for (std::map<std::string, hls_play_list_t *>::iterator iter = mapMediaPlaylist.begin(); iter != mapMediaPlaylist.end(); ++iter) {
+		bandWidthQuality.push_back(iter->second->bandwidth);
+	}
+
+	std::sort(bandWidthQuality.begin(), bandWidthQuality.end());
+	return 1;
+}
+
+void HLSParser::setCallback_GetPlaylistInfo(void *callbackObj, Callback_GetPlaylistInfo cbGetPlaylistInfo)
+{
+	mCallbackObject = callbackObj;
+	mCBGetPlaylistInfo = cbGetPlaylistInfo;
+}

--- a/apps/examples/araplayer/HLSParser.h
+++ b/apps/examples/araplayer/HLSParser.h
@@ -1,0 +1,125 @@
+/****************************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+/**
+ * @file HLSParser.h
+ * @brief Http Live Streaming Parser APIS.
+ */
+
+#pragma once
+
+#include <string>
+#include <vector>
+#include <map>
+#include <string.h>
+
+#include "HASParserInterface.h"
+#include "Enumerator.h"
+
+class HLSParser : public HASParserInterface
+{
+public:
+	/**
+	 * @brief HLSParser Constructs a new object provide
+	 * @details @b #include <araplayer/HASParser.h>
+	 * @since TizenRT v3.0
+	 */
+	HLSParser() :
+		mTargetDurationLen(strlen(TARGET_DURATION)), mBeginPlaylistUrlLen(strlen(BEGIN_PLAYLIST_URL)), mBeginSegmentUrlLen(strlen(BEGIN_SEGMENT_URL)), mBandwidthLen(strlen(BANDWIDTH)), mCBGetPlaylistInfo(NULL)
+	{
+	}
+
+	/**
+	 * @brief HLS Playlist(m3u8) data parsing API
+	 * @details @b #include <araplayer/HASParser.h>
+	 * @param[in] url  requested playlist url
+	 * @param[in] data playlist data buffer point
+	 * @param[in] data playlist data size
+	 * @return True is Success, False is Fail
+	 * @since TizenRT v3.0
+	 */
+	int parsePlaylist(const char *url, const char *data, int size);
+	/**
+	 * @brief Get the Playlist(m3u8)Information
+	 * @details @b #include <araplayer/HASParser.h>
+	 * @param[in] url requested playlist url
+	 * @param[in] bandwidth value of bandwith
+	 * @param[out] outSegInfo playlist info output data structure
+	 * @return True is Success, False is Fail
+	 * @since TizenRT v3.0
+	 */
+	int getPlaylistInfo(const char *url, int bandwidth, has_segment_info_t *outSegInfo);
+	/**
+	 * @brief Get the Segment Information
+	 * @details @b #include <araplayer/HASParser.h>
+	 * @param[in] url  requested playlist url
+	 * @param[in] inx  segment index
+	 * @param[in] bandwidth value of bandwith
+	 * @param[out] outSegInfo playlist info output data structure
+	 * @return True is Success, False is Fail
+	 * @since TizenRT v3.0
+	 */
+	int getSegmentInfo(const char *url, int idx, int bandwidth, has_segment_info_t *outSegInfo);
+	/**
+	 * @brief Sets the callback for Playlist parser data
+	 * @details @b #include <araplayer/HASParser.h>
+	 * @param[in] callbackObj the callback to be set for HASStream
+	 * @param[in] callbackFnc sets the callback function
+	 * @since TizenRT v3.0
+	 */
+	void setCallback_GetPlaylistInfo(void *callbackObj, Callback_GetPlaylistInfo cbGetPlaylistInfo);
+
+private:
+	struct hls_play_list_s {
+		int parsingCnt;
+		int bandwidth;
+		int targetDuration;
+		play_list_type_t type;
+		hls_play_list_s *parent;
+		std::string url;
+		std::vector<std::string> vecUrl;
+		std::map<std::string, hls_play_list_s *> mapMediaPlaylist;
+
+		hls_play_list_s() :
+			parsingCnt(0), bandwidth(0), type(play_list_type_t::NONE), parent(NULL)
+		{
+		}
+	};
+
+	typedef hls_play_list_s hls_play_list_t;
+	typedef std::map<std::string, hls_play_list_t *>::iterator PlaylistIter;
+
+	static const char *PLAYLIST_EXT;
+	static const char *SEGMENT_EXT;
+	static const char *TARGET_DURATION;
+	static const char *BEGIN_PLAYLIST_URL;
+	static const char *BEGIN_SEGMENT_URL;
+	static const char *BANDWIDTH;
+
+	int mTargetDurationLen;
+	int mBeginPlaylistUrlLen;
+	int mBeginSegmentUrlLen;
+	int mBandwidthLen;
+
+	std::map<std::string, hls_play_list_t *> mMapMasterPlaylist;
+	Callback_GetPlaylistInfo mCBGetPlaylistInfo;
+
+	hls_play_list_t *findPlaylist(const char *url);
+	int getMediaPlaylistInfo(hls_play_list_t *playlist, play_list_info_t &pInfo);
+	bool isFirstParsedMediaPlaylist(hls_play_list_t *playlist);
+};

--- a/apps/examples/araplayer/Kconfig
+++ b/apps/examples/araplayer/Kconfig
@@ -1,0 +1,15 @@
+#
+# For a description of the syntax of this configuration file,
+# see kconfig-language at https://www.kernel.org/doc/Documentation/kbuild/kconfig-language.txt
+#
+
+config EXAMPLES_ARAPLAYER
+	bool "AraPlayer example"
+	default n
+	depends on HAVE_CXX && HAVE_CXXINITIALIZE && MEDIA
+	---help---
+		Enable the AraPlayer example
+
+config USER_ENTRYPOINT
+	string
+	default "AraPlayerService_main" if ENTRY_ARAPLAYER

--- a/apps/examples/araplayer/Kconfig_ENTRY
+++ b/apps/examples/araplayer/Kconfig_ENTRY
@@ -1,0 +1,3 @@
+config ENTRY_ARAPLAYER
+	bool "AraPlayer example"
+	depends on EXAMPLES_ARAPLAYER

--- a/apps/examples/araplayer/Make.defs
+++ b/apps/examples/araplayer/Make.defs
@@ -1,0 +1,56 @@
+###########################################################################
+#
+# Copyright 2019 Samsung Electronics All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+#
+###########################################################################
+############################################################################
+# apps/examples/mediarecorder/Make.defs
+# Adds selected applications to apps/ build
+#
+#   Copyright (C) 2015 Gregory Nutt. All rights reserved.
+#   Author: Gregory Nutt <gnutt@nuttx.org>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in
+#    the documentation and/or other materials provided with the
+#    distribution.
+# 3. Neither the name NuttX nor the names of its contributors may be
+#    used to endorse or promote products derived from this software
+#    without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+# OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+# AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+############################################################################
+
+ifeq ($(CONFIG_EXAMPLES_ARAPLAYER),y)
+CONFIGURED_APPS += examples/araplayer
+endif

--- a/apps/examples/araplayer/Makefile
+++ b/apps/examples/araplayer/Makefile
@@ -1,0 +1,186 @@
+###########################################################################
+#
+# Copyright 2019 Samsung Electronics All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+#
+###########################################################################
+############################################################################
+# apps/examples/araplayer/Makefile
+#
+#   Copyright (C) 2009-2012 Gregory Nutt. All rights reserved.
+#   Author: Gregory Nutt <gnutt@nuttx.org>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in
+#    the documentation and/or other materials provided with the
+#    distribution.
+# 3. Neither the name NuttX nor the names of its contributors may be
+#    used to endorse or promote products derived from this software
+#    without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+# OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+# AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+############################################################################
+-include $(TOPDIR)/.config
+-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
+
+CPPEXT ?= .cpp
+# C++ Test Example
+
+APPNAME = AraPlayerService
+FUNCNAME = $(APPNAME)_main
+THREADEXEC = TASH_EXECMD_ASYNC
+
+# C++ Test Example
+ASRCS		=
+CSRCS		=
+CPPSRCS		= AudioHttpDownloader.cpp \
+			  MediaBufferInputDataSource.cpp \
+			  MediaPlayerWrapper.cpp \
+			  AudioCircularBuffer.cpp \
+			  AraPlayer.cpp \
+			  AudioStream.cpp \
+			  AudioPDStream.cpp \
+			  AudioHASStream.cpp \
+			  AudioLocalStream.cpp \
+			  AudioQueue.cpp \
+			  AudioWorker.cpp \
+			  AudioUtils.cpp \
+			  HASParser.cpp \
+			  HLSParser.cpp
+
+MAINSRC		= $(APPNAME).cpp
+
+AOBJS		= $(ASRCS:.S=$(OBJEXT))
+COBJS		= $(CSRCS:.c=$(OBJEXT))
+CPPOBJS		= $(CPPSRCS:$(CPPEXT)=$(OBJEXT))
+ifeq ($(suffix $(MAINSRC)),$(CPPEXT))
+MAINOBJ 	= $(MAINSRC:$(CPPEXT)=$(OBJEXT))
+else
+MAINOBJ 	= $(MAINSRC:.c=$(OBJEXT))
+endif
+
+SRCS		= $(ASRCS) $(CSRCS) $(CPPSRCS) $(MAINSRC)
+OBJS		= $(AOBJS) $(COBJS) $(CPPOBJS)
+
+ifneq ($(CONFIG_BUILD_KERNEL),y)
+OBJS		+= $(MAINOBJ)
+endif
+
+ifeq ($(CONFIG_WINDOWS_NATIVE),y)
+BIN		= ..\..\libapps$(LIBEXT)
+else
+ifeq ($(WINTOOL),y)
+  BIN		= ..\\..\\libapps$(LIBEXT)
+else
+  BIN		= ../../libapps$(LIBEXT)
+endif
+endif
+
+CONFIG_EXAMPLES_ARAPLAYER_PROGNAME ?= Araplayer$(EXEEXT)
+PROGNAME	= $(CONFIG_EXAMPLES_ARAPLAYER_PROGNAME)
+
+ROOTDEPPATH	= --dep-path .
+
+# Common build
+
+VPATH		=
+
+all: .built
+.PHONY:	clean depend distclean
+
+$(AOBJS): %$(OBJEXT): %.S
+	$(call ASSEMBLE, $<, $@)
+
+$(COBJS): %$(OBJEXT): %.c
+	$(call COMPILE, $<, $@)
+
+$(CPPOBJS): %$(OBJEXT): %$(CPPEXT)
+	$(call COMPILEXX, $<, $@)
+
+ifeq ($(suffix $(MAINSRC)),$(CPPEXT))
+$(MAINOBJ): %$(OBJEXT): %$(CPPEXT)
+	$(call COMPILEXX, $<, $@)
+else
+$(MAINOBJ): %$(OBJEXT): %.c
+	$(call COMPILE, $<, $@)
+endif
+
+.built: $(OBJS)
+	$(call ARCHIVE, $(BIN), $(OBJS))
+	@touch .built
+
+ifeq ($(CONFIG_BUILD_KERNEL),y)
+$(BIN_DIR)$(DELIM)$(PROGNAME): $(OBJS) $(MAINOBJ)
+	@echo "LD: $(PROGNAME)"
+	$(Q) $(LD) $(LDELFFLAGS) $(LDLIBPATH) -o $(INSTALL_DIR)$(DELIM)$(PROGNAME) $(ARCHCRT0OBJ) $(MAINOBJ) $(LDLIBS)
+	$(Q) $(NM) -u  $(INSTALL_DIR)$(DELIM)$(PROGNAME)
+
+install: $(BIN_DIR)$(DELIM)$(PROGNAME)
+
+else
+install:
+
+endif
+
+ifeq ($(CONFIG_BUILTIN_APPS)$(CONFIG_EXAMPLES_ARAPLAYER),yy)
+$(BUILTIN_REGISTRY)$(DELIM)$(FUNCNAME).bdat: $(DEPCONFIG) Makefile
+	$(Q) $(call REGISTER,$(APPNAME),$(FUNCNAME),$(THREADEXEC),$(PRIORITY),$(STACKSIZE))
+
+context: $(BUILTIN_REGISTRY)$(DELIM)$(FUNCNAME).bdat
+
+else
+context:
+
+endif
+
+.depend: Makefile $(SRCS)
+ifeq ($(filter %$(CPPEXT),$(SRCS)),)
+	@$(MKDEP) $(ROOTDEPPATH) "$(CC)" -- $(CFLAGS) -- $(SRCS) >Make.dep
+else
+	@$(MKDEP) $(ROOTDEPPATH) "$(CPP)" -- $(CPPFLAGS) -- $(SRCS) >Make.dep
+endif
+	@touch $@
+
+depend: .depend
+
+clean:
+	$(call DELFILE, .built)
+	$(call CLEAN)
+
+distclean: clean
+	$(call DELFILE, Make.dep)
+	$(call DELFILE, .depend)
+
+-include Make.dep
+.PHONY: preconfig
+preconfig:

--- a/apps/examples/araplayer/MediaBufferInputDataSource.cpp
+++ b/apps/examples/araplayer/MediaBufferInputDataSource.cpp
@@ -1,0 +1,117 @@
+/****************************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+#include <media/MediaTypes.h>
+#include "MediaBufferInputDataSource.h"
+#include "AudioStream.h"
+#include "AudioPDStream.h"
+#include "AudioHASStream.h"
+#include "AudioUtils.h"
+
+MediaBufferInputDataSource::MediaBufferInputDataSource() :
+	mIsOpened(false)
+{
+	memset(mBuf, 0x00, 4096);
+}
+
+MediaBufferInputDataSource::MediaBufferInputDataSource(audio_type_t audioType, audio_format_type_t format, unsigned int rate, unsigned int chan, void *stream)
+{
+	setChannels(chan);
+	setSampleRate(rate);
+	setPcmFormat(format);
+	setAudioType(audioType);
+	mStream = stream;
+}
+
+MediaBufferInputDataSource::~MediaBufferInputDataSource()
+{
+	if (isPrepared()) {
+		close();
+	}
+}
+
+bool MediaBufferInputDataSource::isPrepared()
+{
+	return mIsOpened;
+}
+
+bool MediaBufferInputDataSource::open()
+{
+	if (mIsOpened == false) {
+		mIsOpened = true;
+		return true;
+	}
+	
+	return false;
+}
+
+bool MediaBufferInputDataSource::close()
+{
+	if (mIsOpened) {
+		mIsOpened = false;
+		return true;
+	}
+
+	return false;
+}
+
+ssize_t MediaBufferInputDataSource::read(unsigned char *buf, size_t size)
+{
+	AudioStream *pStream = (AudioStream *)mStream;
+	AudioHttpDownloader *pDownloader = NULL;
+	std::map<void *, AudioHttpDownloader *> dMap;
+	std::map<void *, AudioHttpDownloader *>::iterator dIter;
+
+	ssize_t used = 0;
+
+	if (!isPrepared()) {
+		return EOF;
+	}
+
+	switch (pStream->getStreamType()) {
+	case STREAM_HTTP_PROGRESSIVE:
+		dMap = ((AudioPDStream *)mStream)->getDownloaderMap();
+		pDownloader = (AudioHttpDownloader *)(dMap.begin()->second);
+		break;
+	case STREAM_HTTP_HLS:
+		dMap = ((AudioHASStream *)mStream)->getDownloaderMap();
+		for (dIter = dMap.begin(); dIter != dMap.end(); dIter++) {
+			pDownloader = (AudioHttpDownloader *)(dIter->second);
+			if (pDownloader->mRequestType == request_type_t::HTTP_HLS_TS) {
+				break;
+			} else {
+				pDownloader = NULL;
+			}
+		}
+		break;
+	default:
+		DEBUG_TRACE(LOG_ERR, "Unknow type : %d", pStream->getStreamType());
+		return 0;
+	}
+
+	if (pDownloader) {
+		//DEBUG_TRACE(LOG_DEBUG, "size :%d , getChunkSize : %d", size, pDownloader->getChunkSize());
+		if (pDownloader->getChunkSize() >= size) {
+			used = pDownloader->chunkRead(buf, size);
+		} else {
+			memcpy(buf, mBuf, size);
+			used = size;
+		}
+	}
+	return used;
+}

--- a/apps/examples/araplayer/MediaBufferInputDataSource.h
+++ b/apps/examples/araplayer/MediaBufferInputDataSource.h
@@ -1,0 +1,47 @@
+/****************************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __MEDIA_BUFFERINPUTDATASOURCE_H__
+#define __MEDIA_BUFFERINPUTDATASOURCE_H__
+
+#include <media/InputDataSource.h>
+#include <media/MediaTypes.h>
+
+using namespace media;
+using namespace media::stream;
+
+class MediaBufferInputDataSource : public media::stream::InputDataSource
+{
+public:
+	MediaBufferInputDataSource();
+	virtual ~MediaBufferInputDataSource();
+
+	MediaBufferInputDataSource(audio_type_t audioType, audio_format_type_t format, unsigned int rate, unsigned int chan, void *stream);
+
+	bool isPrepared() override;
+	bool open() override;
+	bool close() override;
+	ssize_t read(unsigned char *buf, size_t size) override;
+
+	void *mStream;
+
+private:
+	unsigned char mBuf[4096];
+	bool mIsOpened;
+};
+#endif

--- a/apps/examples/araplayer/MediaPlayerWrapper.cpp
+++ b/apps/examples/araplayer/MediaPlayerWrapper.cpp
@@ -1,0 +1,221 @@
+/****************************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+#include "MediaPlayerWrapper.h"
+#include "AraPlayer.h"
+
+MediaPlayerWrapper::MediaPlayerWrapper() :
+	isSourceSet(false)
+{
+	mState = None;
+	readBufferSize = 4096;
+}
+
+void MediaPlayerWrapper::setObserver(std::shared_ptr<MediaPlayerObserverInterface> observer)
+{
+	mObserver = observer;
+}
+
+int MediaPlayerWrapper::setDataSource(std::unique_ptr<stream::InputDataSource> source)
+{
+	player_result_t ret = PLAYER_ERROR_NONE;
+
+	if (isSourceSet == false) {
+		ret = mp.create();
+		if (ret != PLAYER_ERROR_NONE) {
+			DEBUG_TRACE(LOG_ERR, "Mediaplayer create failed");
+		}
+
+		ret = mp.setDataSource(std::move(source));
+		if (ret != PLAYER_ERROR_NONE) {
+			DEBUG_TRACE(LOG_ERR, "Mediaplayer setDataSource failed");
+			mp.destroy();
+			return -1;
+		}
+
+		ret = mp.setObserver(mObserver);
+		if (ret != PLAYER_ERROR_NONE) {
+			DEBUG_TRACE(LOG_ERR, "Mediaplayer setObserver failed");
+			mp.destroy();
+			return -1;
+		}
+
+		isSourceSet = true;
+	}
+
+	mState = Ready;
+
+	return ret;
+}
+
+int MediaPlayerWrapper::init(audio_type_t type, audio_format_type_t format, unsigned int rate, unsigned int chan, void *stream)
+{
+	return setDataSource(std::move(std::unique_ptr<MediaBufferInputDataSource>(new MediaBufferInputDataSource(type, format, rate, chan, stream))));
+}
+
+int MediaPlayerWrapper::init(const char *url)
+{
+	auto source = std::move(std::unique_ptr<FileInputDataSource>(new FileInputDataSource(url)));
+	source->setPcmFormat(AUDIO_FORMAT_TYPE_S16_LE);
+	return setDataSource(std::move(source));
+}
+
+int MediaPlayerWrapper::deinit()
+{
+	player_result_t ret = PLAYER_ERROR_NONE;
+
+	if (mState == None) {
+		DEBUG_TRACE(LOG_ERR, "media player deinit invalid state[%d]", mState);
+		return -1;
+	}
+
+	if (mState == Stop) {
+		ret = mp.unprepare();
+		if (ret != PLAYER_ERROR_NONE) {
+			DEBUG_TRACE(LOG_ERR, "Mediaplayer unprepare failed");
+		}
+	}
+
+	ret = mp.destroy();
+	if (ret != PLAYER_ERROR_NONE) {
+		DEBUG_TRACE(LOG_ERR, "Mediaplayer destroy failed");
+	}
+
+	mState = None;
+	isSourceSet = false;
+
+	return 0;
+}
+
+int MediaPlayerWrapper::startPlay()
+{
+	player_result_t ret = PLAYER_ERROR_NONE;
+
+	if (mState != Ready) {
+		DEBUG_TRACE(LOG_ERR, "media player start invalid state[%d]", mState);
+		return -1;
+	}
+
+	ret = mp.prepare();
+	if (ret != PLAYER_ERROR_NONE) {
+		DEBUG_TRACE(LOG_ERR, "Mediaplayer prepare failed");
+		mp.destroy();
+		mState = None;
+		return -1;
+	}
+
+	ret = mp.start();
+	if (ret != PLAYER_ERROR_NONE) {
+		DEBUG_TRACE(LOG_ERR, "Mediaplayer prepare failed");
+		mp.unprepare();
+		mp.destroy();
+		mState = None;
+		return -1;
+	}
+
+	mState = Playing;
+
+	return 0;
+}
+
+int MediaPlayerWrapper::stopPlay()
+{
+	player_result_t ret = PLAYER_ERROR_NONE;
+
+	if (mState < Playing) {
+		DEBUG_TRACE(LOG_ERR, "media player stop invalid state[%d]", mState);
+		return -1;
+	}
+
+	ret = mp.stop();
+	if (ret != PLAYER_ERROR_NONE) {
+		DEBUG_TRACE(LOG_ERR, "Mediaplayer stop failed");
+		mp.unprepare();
+		mp.destroy();
+		mState = None;
+		return -1;
+	}
+
+	mState = Stop;
+	return 0;
+}
+
+int MediaPlayerWrapper::pausePlay()
+{
+	player_result_t ret = PLAYER_ERROR_NONE;
+
+	if (mState != Playing) {
+		DEBUG_TRACE(LOG_ERR, "media player pause invalid state[%d]", mState);
+		return -1;
+	}
+
+	ret = mp.pause();
+	if (ret != PLAYER_ERROR_NONE) {
+		DEBUG_TRACE(LOG_ERR, "Mediaplayer pause failed");
+		return -1;
+	}
+
+	mState = Paused;
+	return 0;
+}
+
+int MediaPlayerWrapper::resumePlay()
+{
+	player_result_t ret = PLAYER_ERROR_NONE;
+
+	DEBUG_TRACE(LOG_INFO, "");
+
+	if (mState != Paused) {
+		DEBUG_TRACE(LOG_ERR, "media player resume invalid state[%d]", mState);
+		return -1;
+	}
+
+	ret = mp.start();
+	if (ret != PLAYER_ERROR_NONE) {
+		DEBUG_TRACE(LOG_ERR, "Mediaplayer start failed");
+		return -1;
+	}
+
+	mState = Playing;
+	return 0;
+}
+
+int MediaPlayerWrapper::setVolume(int volume)
+{
+	uint8_t vol = 0;
+	DEBUG_TRACE(LOG_INFO, "setVolume is %d", volume);
+
+	if (mp.getVolume(&vol) != PLAYER_ERROR_NONE) {
+		DEBUG_TRACE(LOG_ERR, "MediaPlayer::getVolume failed");
+	} else {
+		DEBUG_TRACE(LOG_INFO, "Volume was %d", vol);
+	}
+
+	if (mp.setVolume(volume) != PLAYER_ERROR_NONE) {
+		DEBUG_TRACE(LOG_ERR, "MediaPlayer::setVolume failed");
+	}
+
+	vol = 0;
+	if (mp.getVolume(&vol) != PLAYER_ERROR_NONE) {
+		DEBUG_TRACE(LOG_ERR, "MediaPlayer::getVolume failed");
+	} else {
+		DEBUG_TRACE(LOG_INFO, "Now, Volume is %d", vol);
+	}
+
+	return 0;
+}

--- a/apps/examples/araplayer/MediaPlayerWrapper.h
+++ b/apps/examples/araplayer/MediaPlayerWrapper.h
@@ -1,0 +1,80 @@
+/****************************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __MEDIA_PLAYER_WRAPPER_H__
+#define __MEDIA_PLAYER_WRAPPER_H__
+
+#include <iostream>
+#include <functional>
+#include <memory>
+
+#include <media/MediaPlayer.h>
+#include <media/MediaTypes.h>
+#include <media/MediaPlayerObserverInterface.h>
+#include <media/FileInputDataSource.h>
+#include <media/InputDataSource.h>
+#include "MediaBufferInputDataSource.h"
+
+class MediaPlayerWrapper
+{
+public:
+	enum State {
+		None = 0,
+		Ready,
+		Playing,
+		Stop,
+		Paused
+	};
+
+	MediaPlayerWrapper();
+	virtual ~MediaPlayerWrapper() = default;
+
+	void setState(State state)
+	{
+		mState = state;
+	}
+	State getState()
+	{
+		return mState;
+	}
+
+	unsigned int getReadBufferSize()
+	{
+		return readBufferSize;
+	}
+
+	int init(media::audio_type_t type, media::audio_format_type_t format, unsigned int rate, unsigned int chan, void *stream);
+	int init(const char *);
+	int deinit();
+	int startPlay();
+	int stopPlay();
+	int pausePlay();
+	int resumePlay();
+	int setVolume(int volume);
+	int setDataSource(std::unique_ptr<stream::InputDataSource> source);
+	void setObserver(std::shared_ptr<MediaPlayerObserverInterface> observer);
+
+private:
+	std::shared_ptr<MediaPlayerObserverInterface> mObserver;
+	unsigned int readBufferSize;
+	State mState;
+	media::MediaPlayer mp;
+	bool isSourceSet;
+};
+
+#endif

--- a/apps/examples/araplayer/PlaylistInfo.h
+++ b/apps/examples/araplayer/PlaylistInfo.h
@@ -1,0 +1,61 @@
+/****************************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+#pragma once
+
+#include <vector>
+#include <string>
+#include "Enumerator.h"
+#include "HASType.h"
+
+/**
+ * @struct  play_list_info_s
+ * @brief   Define Playlist output structure, inludes url, streaming type, playlist type,
+ *          and duration, bandwith
+ */
+struct play_list_info_s {
+	/* playlist request url */
+	std::string playlistUrl;
+	/* http adaptive streaming type (hls/dash) */
+	has_type_t hasType;
+	/* playlist type (master/single/media) */
+	play_list_type_t type;
+	/* media file play duration time */
+	int duration;
+	/* bandwith level list (bps)*/
+	std::vector<int> bandWidthQuality;
+	
+	//TO-DO will remove
+	int bufferSize;
+};
+
+/**
+ * @struct  has_segment_info_s
+ * @brief   Define Segment output structure, includes url, bandwith
+ */
+struct has_segment_info_s {
+	std::string url;
+	int bandwidth;
+	//TO-DO will remove
+	std::string strRange;
+	//TO-DO will remove
+	range_t range;
+};
+
+typedef play_list_info_s play_list_info_t;
+typedef has_segment_info_s has_segment_info_t;


### PR DESCRIPTION
1. Currently added to example, but will be changed to service later.
2. AraPlayer service supports streams such as Local, PD, and HLS.
3. Each application communicates with the araplayer service via IPC.

Signed-off-by: jsdosa <jsdosa@gmail.com>