### PR TITLE
Heapinfo modification for binary separation

### DIFF
--- a/os/arch/arm/src/common/up_createstack.c
+++ b/os/arch/arm/src/common/up_createstack.c
@@ -62,6 +62,9 @@
 #include <debug.h>
 #include <errno.h>
 
+#ifdef CONFIG_DEBUG_MM_HEAPINFO
+#include <tinyara/mm/mm.h>
+#endif
 #include <tinyara/kmalloc.h>
 #include <tinyara/arch.h>
 #include <arch/board/board.h>

--- a/os/binfmt/binfmt_exec.c
+++ b/os/binfmt/binfmt_exec.c
@@ -152,7 +152,7 @@ int exec(FAR const char *filename, FAR char *const *argv, FAR const struct symta
 	uint32_t size = 0;
 	struct tcb_s *tcb;
 
-	if (mm_allocate_ram_partition(&start_addr, &size) < 0) {
+	if (mm_allocate_ram_partition(&start_addr, &size, NULL) < 0) {
 		berr("ERROR: Failed to allocate RAM partition\n");
 		errcode = ENOMEM;
 		goto errout;

--- a/os/binfmt/binfmt_loadbinary.c
+++ b/os/binfmt/binfmt_loadbinary.c
@@ -93,7 +93,7 @@ int load_binary(FAR const char *filename, load_attr_t *load_attr)
 	uint32_t size = load_attr->ram_size;
 	struct tcb_s *tcb;
 
-	if (mm_allocate_ram_partition(&start_addr, &size) < 0) {
+	if (mm_allocate_ram_partition(&start_addr, &size, load_attr->bin_name) < 0) {
 		berr("ERROR: Failed to allocate RAM partition\n");
 		errcode = ENOMEM;
 		goto errout;

--- a/os/include/tinyara/binary_manager.h
+++ b/os/include/tinyara/binary_manager.h
@@ -125,6 +125,7 @@ typedef struct part_info_s part_info_t;
 
 /* The structure of load attr configuration */
 struct load_attr_s {
+	char bin_name[BIN_NAME_MAX];
 	uint32_t bin_size;			/* The size of ELF binary to be loaded */
 	uint32_t ram_size;			/* The size of RAM partition required by binary */
 	uint32_t stack_size;		/* Size of the stack allocated for binary */

--- a/os/include/tinyara/heapinfo_drv.h
+++ b/os/include/tinyara/heapinfo_drv.h
@@ -23,6 +23,9 @@
  * Included Files
  ****************************************************************************/
 #include <tinyara/config.h>
+#ifdef CONFIG_APP_BINARY_SEPARATION
+#include <tinyara/binary_manager.h>
+#endif
 
 /****************************************************************************
  * Pre-processor Definitions
@@ -30,8 +33,12 @@
 #define HEAPINFO_DRVPATH     "/dev/heapinfo"
 
 struct heapinfo_option_s {
+	int heap_type;
 	int mode;
 	int pid;
+#ifdef CONFIG_APP_BINARY_SEPARATION
+	char app_name[BIN_NAME_MAX];
+#endif
 };
 typedef struct heapinfo_option_s heapinfo_option_t;
 

--- a/os/include/tinyara/mm/mm.h
+++ b/os/include/tinyara/mm/mm.h
@@ -702,8 +702,9 @@ int mm_get_heapindex(void *mem);
 
 #if defined(CONFIG_APP_BINARY_SEPARATION) && defined(__KERNEL__)
 void mm_initialize_app_heap(void);
-void mm_add_app_heap_list(struct mm_heap_s *heap);
+void mm_add_app_heap_list(struct mm_heap_s *heap, char *app_name);
 void mm_remove_app_heap_list(struct mm_heap_s *heap);
+struct mm_heap_s *mm_get_app_heap_with_name(char *app_name);
 #endif
 
 #if CONFIG_MM_NHEAPS > 1
@@ -812,7 +813,7 @@ struct mm_ram_partition_s {
 
 /* Functions contained in mm_partition_mgr.c **************************************/
 void mm_initialize_ram_partitions(void);
-int8_t mm_allocate_ram_partition(uint32_t **start_addr, uint32_t *size);
+int8_t mm_allocate_ram_partition(uint32_t **start_addr, uint32_t *size, char *name);
 void mm_free_ram_partition(uint32_t address);
 
 #endif		/* defined(CONFIG_APP_BINARY_SEPARATION) && defined(__KERNEL__) */

--- a/os/include/tinyara/mm/mm.h
+++ b/os/include/tinyara/mm/mm.h
@@ -221,6 +221,14 @@
 #define HEAPINFO_ADD_INFO 1
 #define HEAPINFO_DEL_INFO 2
 
+#define HEAPINFO_HEAP_TYPE_KERNEL 1
+#ifdef CONFIG_BUILD_PROTECTED
+#define HEAPINFO_HEAP_TYPE_USER   2
+#ifdef CONFIG_APP_BINARY_SEPARATION
+#define HEAPINFO_HEAP_TYPE_BINARY    3
+#endif
+#endif
+
 #define REGION_START (size_t)regionx_start[0]
 #define REGION_SIZE  regionx_size[0]
 #define REGION_END (REGION_START + REGION_SIZE)

--- a/os/kernel/binary_manager/binary_manager.h
+++ b/os/kernel/binary_manager/binary_manager.h
@@ -89,7 +89,6 @@ struct binmgr_bininfo_s {
 	uint8_t inuse_idx;
 	load_attr_t load_attr;
 	part_info_t part_info[PARTS_PER_BIN];
-	char name[BIN_NAME_MAX];
 	char bin_ver[BIN_VER_MAX];
 	char kernel_ver[KERNEL_VER_MAX];
 	sq_queue_t cb_list; // list node type : statecb_node_t
@@ -109,12 +108,12 @@ typedef struct statecb_node_s statecb_node_t;
 #define BIN_PARTSIZE(bin_idx, part_idx)                 bin_table[bin_idx].part_info[part_idx].part_size
 #define BIN_PARTNUM(bin_idx, part_idx)                  bin_table[bin_idx].part_info[part_idx].part_num
 
-#define BIN_NAME(bin_idx)                               bin_table[bin_idx].name
 #define BIN_VER(bin_idx)                                bin_table[bin_idx].bin_ver
 #define BIN_KERNEL_VER(bin_idx)                         bin_table[bin_idx].kernel_ver
 #define BIN_CBLIST(bin_idx)                             bin_table[bin_idx].cb_list
 
 #define BIN_LOAD_ATTR(bin_idx)                          bin_table[bin_idx].load_attr
+#define BIN_NAME(bin_idx)                               bin_table[bin_idx].load_attr.bin_name
 #define BIN_SIZE(bin_idx)                               bin_table[bin_idx].load_attr.bin_size
 #define BIN_RAMSIZE(bin_idx)                            bin_table[bin_idx].load_attr.ram_size
 #define BIN_OFFSET(bin_idx)                             bin_table[bin_idx].load_attr.offset

--- a/os/kernel/binary_manager/binary_manager_load.c
+++ b/os/kernel/binary_manager/binary_manager_load.c
@@ -28,6 +28,7 @@
 #include <unistd.h>
 #include <fcntl.h>
 #include <sched.h>
+#include <string.h>
 #include <sys/types.h>
 
 #include <tinyara/mm/mm.h>
@@ -198,6 +199,7 @@ int binary_manager_load_binary(int bin_idx)
 	/* Load binary */
 	do {
 		if (is_new_bin == false) {
+			strncpy(load_attr.bin_name, header_data[latest_idx].bin_name, BIN_NAME_MAX);
 			snprintf(devname, BINMGR_DEVNAME_LEN, BINMGR_DEVNAME_FMT, BIN_PARTNUM(bin_idx, latest_idx));
 			load_attr.bin_size = header_data[latest_idx].bin_size;
 			load_attr.compression_type = header_data[latest_idx].compression_type;

--- a/os/mm/mm_heap/mm_partition_mgr.c
+++ b/os/mm/mm_heap/mm_partition_mgr.c
@@ -152,7 +152,7 @@ void mm_initialize_ram_partitions(void)
  *
  ****************************************************************************/
 
-int8_t mm_allocate_ram_partition(uint32_t **start_addr, uint32_t *size)
+int8_t mm_allocate_ram_partition(uint32_t **start_addr, uint32_t *size, char *name)
 {
 	if (*size == 0) {
 		*size = g_default_size;
@@ -189,7 +189,7 @@ int8_t mm_allocate_ram_partition(uint32_t **start_addr, uint32_t *size)
 
 	/* struct mm_heap_s will be situated at start of partition and heap will be initialized after this */
 	mm_initialize((struct mm_heap_s *)*start_addr, (uint8_t *)*start_addr + sizeof(struct mm_heap_s), *size);
-	mm_add_app_heap_list((struct mm_heap_s *)*start_addr);
+	mm_add_app_heap_list((struct mm_heap_s *)*start_addr, name);
 
 	mvdbg("Allocated RAM partition with start = 0x%x size = %u\n", *start_addr, *size);
 	return OK;


### PR DESCRIPTION
- arch/arm/up_createstack : Add missing header include
- kernel/binary_manager : Add app name in each app heap structure
- apps/system/utils : Support heapinfo for binary separation 
Changed heapinfo options are like below.
1. which heap to check
: k - normal heap / kernel_heap when protected build
: u - user heap when protected build
: b - binary(app) heap when binary separation
2. heapinfo mode
: a - allocation details per task/pthread
: f - free details per task/pthread
: p [pid] - allocation/free details of specific(pid) task/pthread