### PR TITLE
framework/iotbus: adjust TC coding rule.

### DIFF
--- a/apps/examples/testcase/ta_tc/systemio/utc/utc_gpio.c
+++ b/apps/examples/testcase/ta_tc/systemio/utc/utc_gpio.c
@@ -40,16 +40,6 @@ static iotbus_gpio_context_h gpio;
 static iotbus_gpio_context_h gpio2;
 static int gpio_callback_flag = 0;
 
-static int utc_systemio_gpio_open2(int gpiopin)
-{
-	iotbus_gpio_context_h m_gpio = iotbus_gpio_open(gpiopin);
-	if (!m_gpio) {
-		return 0;
-	}
-	gpio2 = m_gpio;
-	return 1;
-}
-
 static void utc_systemio_gpio_open_p(void)
 {
 	iotbus_gpio_context_h m_gpio = iotbus_gpio_open(TEST_GPIO_1ST);
@@ -304,7 +294,7 @@ int utc_gpio_main(void)
 	utc_systemio_gpio_open_p();
 	utc_systemio_gpio_open_n();
 
-	utc_systemio_gpio_open2(TEST_GPIO_2ND);
+	gpio2 = iotbus_gpio_open(TEST_GPIO_2ND);
 
 	utc_systemio_gpio_set_direction_p_IOTBUS_GPIO_DIRECTION_NONE();
 	utc_systemio_gpio_set_direction_p_IOTBUS_GPIO_DIRECTION_OUT();

--- a/apps/examples/testcase/ta_tc/systemio/utc/utc_spi.c
+++ b/apps/examples/testcase/ta_tc/systemio/utc/utc_spi.c
@@ -84,22 +84,11 @@ static void utc_systemio_spi_recv_n(void)
 	TC_SUCCESS_RESULT();
 }
 
-static void utc_systemio_spi_transfer_p(void)
-{
-	//TO DO
-}
-
-static void utc_systemio_spi_transfer_n(void)
-{
-	//TO DO
-}
-
 static void utc_systemio_spi_close_p(void)
 {
 	int ret = iotbus_spi_close(spi);
 	TC_ASSERT_EQ("iotbus_spi_close", ret, IOTBUS_ERROR_NONE);
 	TC_SUCCESS_RESULT();
-
 }
 
 static void utc_systemio_spi_close_n(void)
@@ -118,8 +107,6 @@ int utc_spi_main(void)
 	utc_systemio_spi_write_n();
 	utc_systemio_spi_recv_p();
 	utc_systemio_spi_recv_n();
-	utc_systemio_spi_transfer_p();
-	utc_systemio_spi_transfer_n();
 	utc_systemio_spi_close_n();
 	utc_systemio_spi_close_p();	
 

--- a/apps/examples/testcase/ta_tc/systemio/utc/utc_uart.c
+++ b/apps/examples/testcase/ta_tc/systemio/utc/utc_uart.c
@@ -70,7 +70,7 @@ static void utc_systemio_uart_set_baudrate_n(void)
 	TC_SUCCESS_RESULT();
 }
 
-static void utc_systemio_uart_set_mode_P_IOTBUS_UART_PARITY_NONE(void)
+static void utc_systemio_uart_set_mode_p_IOTBUS_UART_PARITY_NONE(void)
 {
 	TC_ASSERT_EQ("iotbus_uart_set_mode", iotbus_uart_set_mode(uart, 8, IOTBUS_UART_PARITY_NONE, 1), IOTBUS_ERROR_NONE);
 	TC_SUCCESS_RESULT();
@@ -173,7 +173,7 @@ int utc_uart_main(void)
 #ifdef CONFIG_SERIAL_TERMIOS
 	utc_systemio_uart_set_baudrate_p();
 	utc_systemio_uart_set_baudrate_n();	
-	utc_systemio_uart_set_mode_P_IOTBUS_UART_PARITY_NONE();
+	utc_systemio_uart_set_mode_p_IOTBUS_UART_PARITY_NONE();
 	utc_systemio_uart_set_mode_p_IOTBUS_UART_PARITY_EVEN();
 	utc_systemio_uart_set_mode_p_IOTBUS_UART_PARITY_ODD();
 	utc_systemio_uart_set_mode_n();


### PR DESCRIPTION
- remove unused utc funtion.
- modify typing errors of function name.