### PR TITLE
kernel/task_monitor : Implement task monitor for checking if register…

### DIFF
--- a/os/Kconfig
+++ b/os/Kconfig
@@ -607,6 +607,10 @@ menu "Binary manager"
 source kernel/binary_manager/Kconfig
 endmenu
 
+menu "Task Monitor"
+source kernel/task_monitor/Kconfig
+endmenu
+
 menu "Task manager"
 source "$FRAMEWORK_DIR/src/task_manager/Kconfig"
 endmenu

--- a/os/arch/arm/src/armv7-m/up_blocktask.c
+++ b/os/arch/arm/src/armv7-m/up_blocktask.c
@@ -69,6 +69,10 @@
 #include <tinyara/debug/sysdbg.h>
 #endif
 
+#ifdef CONFIG_TASK_MONITOR
+#include "task_monitor/task_monitor_internal.h"
+#endif
+
 #ifdef CONFIG_ARMV7M_MPU
 #include "mpu.h"
 #endif
@@ -165,6 +169,10 @@ void up_block_task(struct tcb_s *tcb, tstate_t task_state)
 			/* Restore the MPU registers in case we are switching to an application task */
 #ifdef CONFIG_ARMV7M_MPU
 			up_set_mpu_app_configuration(rtcb);
+#endif
+#ifdef CONFIG_TASK_MONITOR
+			/* Update rtcb active flag for monitoring. */
+			rtcb->is_active = true;
 #endif
 
 			/* Then switch contexts */

--- a/os/arch/arm/src/armv7-m/up_releasepending.c
+++ b/os/arch/arm/src/armv7-m/up_releasepending.c
@@ -134,6 +134,10 @@ void up_release_pending(void)
 #ifdef CONFIG_ARMV7M_MPU
 			up_set_mpu_app_configuration(rtcb);
 #endif
+#ifdef CONFIG_TASK_MONITOR
+			/* Update rtcb active flag for monitoring. */
+			rtcb->is_active = true;
+#endif
 
 			/* Then switch contexts */
 			up_restorestate(rtcb->xcp.regs);

--- a/os/arch/arm/src/armv7-m/up_reprioritizertr.c
+++ b/os/arch/arm/src/armv7-m/up_reprioritizertr.c
@@ -185,6 +185,10 @@ void up_reprioritize_rtr(struct tcb_s *tcb, uint8_t priority)
 #ifdef CONFIG_ARMV7M_MPU
 				up_set_mpu_app_configuration(rtcb);
 #endif
+#ifdef CONFIG_TASK_MONITOR
+				/* Update rtcb active flag for monitoring. */
+				rtcb->is_active = true;
+#endif
 
 				/* Then switch contexts */
 				up_restorestate(rtcb->xcp.regs);

--- a/os/arch/arm/src/armv7-m/up_svcall.c
+++ b/os/arch/arm/src/armv7-m/up_svcall.c
@@ -254,9 +254,16 @@ int up_svcall(int irq, FAR void *context, FAR void *arg)
 		DEBUGASSERT(regs[REG_R1] != 0);
 		current_regs = (uint32_t *)regs[REG_R1];
 
+#if defined(CONFIG_ARMV7M_MPU) || defined(CONFIG_TASK_MONITOR)
+		struct tcb_s *tcb = sched_self();
+#endif
 		/* Restore the MPU registers in case we are switching to an application task */
 #ifdef CONFIG_ARMV7M_MPU
-		up_set_mpu_app_configuration(sched_self());
+		up_set_mpu_app_configuration(tcb);
+#endif
+#ifdef CONFIG_TASK_MONITOR
+		/* Update tcb active flag for monitoring. */
+		tcb->is_active = true;
 #endif
 	}
 	break;
@@ -285,9 +292,16 @@ int up_svcall(int irq, FAR void *context, FAR void *arg)
 #endif
 		current_regs = (uint32_t *)regs[REG_R2];
 
+#if defined(CONFIG_ARMV7M_MPU) || defined(CONFIG_TASK_MONITOR)
+		struct tcb_s *tcb = sched_self();
+#endif
 		/* Restore the MPU registers in case we are switching to an application task */
 #ifdef CONFIG_ARMV7M_MPU
-		up_set_mpu_app_configuration(sched_self());
+		up_set_mpu_app_configuration(tcb);
+#endif
+#ifdef CONFIG_TASK_MONITOR
+		/* Update tcb active flag for monitoring. */
+		tcb->is_active = true;
 #endif
 	}
 	break;

--- a/os/arch/arm/src/armv7-m/up_unblocktask.c
+++ b/os/arch/arm/src/armv7-m/up_unblocktask.c
@@ -156,6 +156,10 @@ void up_unblock_task(struct tcb_s *tcb)
 #ifdef CONFIG_ARMV7M_MPU
 			up_set_mpu_app_configuration(rtcb);
 #endif
+#ifdef CONFIG_TASK_MONITOR
+			/* Update rtcb active flag for monitoring. */
+			rtcb->is_active = true;
+#endif
 
 			/* Then switch contexts */
 

--- a/os/include/sys/prctl.h
+++ b/os/include/sys/prctl.h
@@ -93,6 +93,8 @@ enum prctl_type_e {
 	PR_MSG_SAVE = 4,
 	PR_MSG_READ = 5,
 	PR_MSG_REMOVE = 6,
+	PR_MONITOR_REGISTER = 7,
+	PR_MONITOR_UPDATE = 8,
 };
 
 /****************************************************************************

--- a/os/include/tinyara/sched.h
+++ b/os/include/tinyara/sched.h
@@ -624,6 +624,9 @@ struct tcb_s {
 #if CONFIG_TASK_NAME_SIZE > 0
 	char name[CONFIG_TASK_NAME_SIZE + 1];	/* Task name (with NUL terminator)     */
 #endif
+#ifdef CONFIG_TASK_MONITOR
+	bool is_active;
+#endif
 };
 
 /* struct task_tcb_s *************************************************************/

--- a/os/include/tinyara/task_monitor.h
+++ b/os/include/tinyara/task_monitor.h
@@ -1,0 +1,44 @@
+/****************************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __INCLUDE_TINYARA_TASK_MONITOR_H
+#define __INCLUDE_TINYARA_TASK_MONITOR_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#ifdef CONFIG_TASK_MONITOR
+
+void task_monitor_register(void);
+void task_monitor_update_status(void);
+
+#ifdef __cplusplus
+#define EXTERN extern "C"
+extern "C" {
+#else
+#define EXTERN extern
+#endif
+
+#undef EXTERN
+#ifdef __cplusplus
+}
+#endif
+
+#endif							/* CONFIG_TASK_MONITOR */
+#endif							/* __INCLUDE_TINYARA_TASK_MONITOR_H */

--- a/os/kernel/Makefile
+++ b/os/kernel/Makefile
@@ -77,6 +77,7 @@ include timer/Make.defs
 include environ/Make.defs
 include wqueue/Make.defs
 include debug/Make.defs
+include task_monitor/Make.defs
 
 AOBJS = $(ASRCS:.S=$(OBJEXT))
 COBJS = $(CSRCS:.c=$(OBJEXT))

--- a/os/kernel/init/os_bringup.c
+++ b/os/kernel/init/os_bringup.c
@@ -86,6 +86,9 @@
 #ifdef CONFIG_BINARY_MANAGER
 #include "binary_manager/binary_manager.h"
 #endif
+#ifdef CONFIG_TASK_MONITOR
+#include "task_monitor/task_monitor_internal.h"
+#endif
 
 /****************************************************************************
  * Pre-processor Definitions
@@ -258,6 +261,13 @@ static inline void os_do_appstart(void)
 
 #ifdef CONFIG_TASK_MANAGER
 	task_manager_drv_register();
+#endif
+
+#ifdef CONFIG_TASK_MONITOR
+	pid = kernel_thread("taskmonitor", CONFIG_TASK_MONITOR_PRIORITY, 1024, task_monitor, (FAR char *const *)NULL);
+	if (pid < 0) {
+		sdbg("Failed to start task monitor\n");
+	}
 #endif
 
 #if defined(CONFIG_SYSTEM_PREAPP_INIT) && !defined(CONFIG_APP_BINARY_SEPARATION)

--- a/os/kernel/task/task_prctl.c
+++ b/os/kernel/task/task_prctl.c
@@ -73,6 +73,10 @@
 #include "sched/sched.h"
 #include "task/task.h"
 
+#ifdef CONFIG_TASK_MONITOR
+#include "task_monitor/task_monitor_internal.h"
+#endif
+
 /************************************************************************
  * Private Functions
  ************************************************************************/
@@ -237,6 +241,24 @@ int prctl(int option, ...)
 #endif
 	}
 	break;
+#ifdef CONFIG_TASK_MONITOR
+	case PR_MONITOR_REGISTER:
+	{
+		task_monitor_update_list(getpid(), MONITORED);
+	}
+	break;
+	case PR_MONITOR_UPDATE:
+	{
+		struct tcb_s *tcb;
+		tcb = sched_gettcb(getpid());
+		if (tcb == NULL) {
+			sdbg("Fail to update the status in task monitor.\n");
+			goto errout;
+		}
+		tcb->is_active = true;
+	}
+	break;
+#endif
 	default:
 		sdbg("Unrecognized option: %d\n", option);
 		err = EINVAL;

--- a/os/kernel/task/task_terminate.c
+++ b/os/kernel/task/task_terminate.c
@@ -72,6 +72,9 @@
 #endif
 #include "task/task.h"
 
+#ifdef CONFIG_TASK_MONITOR
+#include "task_monitor/task_monitor_internal.h"
+#endif
 /****************************************************************************
  * Definitions
  ****************************************************************************/
@@ -188,6 +191,10 @@ int task_terminate(pid_t pid, bool nonblocking)
 	saved_state = irqsave();
 	dq_rem((FAR dq_entry_t *)dtcb, (dq_queue_t *)g_tasklisttable[dtcb->task_state].list);
 	dtcb->task_state = TSTATE_TASK_INVALID;
+#ifdef CONFIG_TASK_MONITOR
+	/* Unregister this pid from task monitor */
+	task_monitor_update_list(pid, NOT_MONITORED);
+#endif
 	irqrestore(saved_state);
 
 	/* At this point, the TCB should no longer be accessible to the system */

--- a/os/kernel/task_monitor/Kconfig
+++ b/os/kernel/task_monitor/Kconfig
@@ -1,0 +1,30 @@
+#
+# For a description of the syntax of this configuration file,
+# see kconfig-language at https://www.kernel.org/doc/Documentation/kbuild/kconfig-language.txt
+#
+
+config TASK_MONITOR
+	bool "Enable Task Monitor"
+	default n
+	depends on LIB_BOARDCTL
+	depends on BOARDCTL_RESET
+	---help---
+		This is kernel thread which monitor the tasks/pthreads.
+		It checks if registered tasks/pthreads are alive.
+
+if TASK_MONITOR
+
+config TASK_MONITOR_PRIORITY
+	int "Priority of Task Monitor"
+	default 200
+	---help---
+		Set the Task Monitor priority.
+
+config TASK_MONITOR_INTERVAL
+	int "Interval for checking alive(sec)"
+	default 10
+	---help---
+		Task Monitor checks the registered tasks/pthreads active status
+		every this interval.
+
+endif # TASK_MONITOR

--- a/os/kernel/task_monitor/Make.defs
+++ b/os/kernel/task_monitor/Make.defs
@@ -1,0 +1,30 @@
+###########################################################################
+#
+# Copyright 2019 Samsung Electronics All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+#
+###########################################################################
+
+# Add task monitor files
+
+ifeq ($(CONFIG_TASK_MONITOR),y)
+
+CSRCS += task_monitor.c task_monitor_utils.c
+
+# Include task monitor build support
+
+DEPPATH += --dep-path task_monitor
+VPATH += :task_monitor
+
+endif # CONFIG_TASK_MONITOR

--- a/os/kernel/task_monitor/task_monitor.c
+++ b/os/kernel/task_monitor/task_monitor.c
@@ -1,0 +1,80 @@
+/****************************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+#include <tinyara/config.h>
+#include <sched.h>
+#include <sys/boardctl.h>
+#include <tinyara/sched.h>
+#include "task_monitor_internal.h"
+
+static int monitored_tasks_list[CONFIG_MAX_TASKS];
+
+void task_monitor_update_list(int pid, int status)
+{
+	monitored_tasks_list[PIDHASH(pid)] = status;
+}
+
+/****************************************************************************
+ * Main Function
+ ****************************************************************************/
+int task_monitor(int argc, char *argv[])
+{
+	int pid_idx;
+	struct tcb_s *tcb;
+
+	/* Initialize the monitored tasks list */
+	for (pid_idx = 0; pid_idx < CONFIG_MAX_TASKS; pid_idx++) {
+		monitored_tasks_list[pid_idx] = NOT_MONITORED;
+	}
+
+	while (1) {
+		if (sleep(CONFIG_TASK_MONITOR_INTERVAL) > 0) {
+			/* Wake up because of signal.
+			 * In this case, reset the interval again.
+			 */
+			continue;
+		}
+
+		/* Check if registered tasks/pthread is alive or not.
+		 * If one of them is not alive, task monitor resets the system.
+		 */
+		for (pid_idx = 0; pid_idx < CONFIG_MAX_TASKS; pid_idx++) {
+			if (monitored_tasks_list[pid_idx] == MONITORED) {
+				tcb = sched_gettcb(pid_idx);
+				if (tcb == NULL) {
+					/* Invalid operation */
+					boardctl(BOARDIOC_RESET, 0);
+				}
+
+				if (tcb->is_active == false) {
+					/* There is not alive task/pthread.
+					 * System will be reset.
+					 */
+					boardctl(BOARDIOC_RESET, 0);
+				} else {
+					/* Reset the registered task's/pthread's active flag. */
+					tcb->is_active = false;
+				}
+			}
+		}
+	}
+
+	return 0;
+}

--- a/os/kernel/task_monitor/task_monitor_internal.h
+++ b/os/kernel/task_monitor/task_monitor_internal.h
@@ -1,0 +1,38 @@
+/****************************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __SCHED_TASK_MONITOR_TASK_MONITOR_INTERNAL_H
+#define __SCHED_TASK_MONITOR_TASK_MONITOR_INTERNAL_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#define NOT_MONITORED (-1)
+#define MONITORED     (0)
+
+#ifdef CONFIG_TASK_MONITOR
+
+/****************************************************************************
+ * Function Prototypes
+ ****************************************************************************/
+int task_monitor(int argc, char *argv[]);
+void task_monitor_update_list(int pid, int status);
+
+#endif							/* CONFIG_TASK_MONITOR */
+#endif							/* __SCHED_TASK_MONITOR_TASK_MONITOR_INTERNAL_H */

--- a/os/kernel/task_monitor/task_monitor_utils.c
+++ b/os/kernel/task_monitor/task_monitor_utils.c
@@ -1,0 +1,32 @@
+/****************************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+#include <sys/prctl.h>
+#include <sys/types.h>
+
+void task_monitor_register(void)
+{
+	prctl(PR_MONITOR_REGISTER, NULL);
+}
+
+void task_monitor_update_status(void)
+{
+	prctl(PR_MONITOR_UPDATE, NULL);
+}


### PR DESCRIPTION
…ed tasks/pthreads is alive

Task Monitor checks registered tasks/pthreads alive flag on every interval.
If there is an inactive task/pthread, task monitor resets the system.
Alive flag can be updated through context switching or user api(task_monitor_update_status), and
it will be reset on every interval.

User API
1) void task_monitor_register(void) : Register to task monitor, Task monitor only checks registered one.
2) void task_monitor_update_status(void) : Update the alive flag