### PR TITLE
framework/task_manager: Fix tm_msg_s description

### DIFF
--- a/framework/include/task_manager/task_manager.h
+++ b/framework/include/task_manager/task_manager.h
@@ -123,7 +123,7 @@ struct tm_appinfo_list_s {
 typedef struct tm_appinfo_list_s tm_appinfo_list_t;
 
 /**
- * @brief Unicast message Structure
+ * @brief Unicast/Broadcast message structure
  */
 struct tm_msg_s {
 	int msg_size;


### PR DESCRIPTION
tm_mgs_s is used for both unicast and broadcast