### PR TITLE
utils/kill: remove unnecessary BUILD_PROTECTED conditional

### DIFF
--- a/apps/system/utils/Kconfig
+++ b/apps/system/utils/Kconfig
@@ -158,7 +158,6 @@ config ENABLE_IRQINFO
 config ENABLE_KILL
 	bool "kill"
 	default y
-	depends on !BUILD_PROTECTED
 	---help---
 		Send a signal to processes or process groups.
 		When SIGKILL(9) is sent, a task/pthread which received signal will be terminated without any garbage collection.


### PR DESCRIPTION
The kill command supports protected build so that "depends on !BUILD_PROTECTED"
is unnecessary.

Signed-off-by: sunghan-chang <sh924.chang@samsung.com>