### PR TITLE
apps/system/utils : Modify heapinfo explanation in README.md

### DIFF
--- a/apps/system/utils/README.md
+++ b/apps/system/utils/README.md
@@ -325,21 +325,27 @@ This command shows heap memory usages per thread. This has arguments which confi
 ```bash
 TASH>>heapinfo --help
 
-Usage: heapinfo [OPTIONS]
+Usage: heapinfo [-TARGET] [-OPTION]
 Display information of heap memory
 
 Options:
- -i           Initialize the heapinfo
- -a           Show the all allocation details
- -p PID       Show the specific PID allocation details
- -f           Show the free list
- -g           Show the User defined group allocation details
-              (for -g option, CONFIG_HEAPINFO_GROUP is needed)
- -e HEAP_IDX  Show the heap[HEAP_IDX] allocation details
-              (-e option is available when CONFIG_MM_NHEAPS is greater than 1)
- -r           Show the all region information
-              (-r option is available when CONFIG_MM_REGIONS is greater than 1)
- -k OPTION    Show the kernel heap memory allocation details based on above options
+[-TARGET]
+ -k             Kernel Heap
+                (-k target is available when CONFIG_BUILD_PROTECTED is enabled)
+ -u             User Heap
+                (-u target is available when CONFIG_BUILD_PROTECTED is enabled)
+ -b BIN_NAME    Heap for BIN_NAME binary
+                (-b target is available when CONFIG_APP_BINARY_SEPARATION is enabled)
+[-OPTION]
+ -a             Show the all allocation details
+ -p PID         Show the specific PID allocation details
+ -f             Show the free list
+ -g             Show the User defined group allocation details
+                (for -g option, CONFIG_HEAPINFO_GROUP is needed)
+ -e HEAP_IDX    Show the heap[HEAP_IDX] allocation details
+                (-e option is available when CONFIG_MM_NHEAPS is greater than 1)
+ -r             Show the all region information
+                (-r option is available when CONFIG_MM_REGIONS is greater than 1)
 
 TASH>>heapinfo
 

--- a/apps/system/utils/utils_heapinfo.c
+++ b/apps/system/utils/utils_heapinfo.c
@@ -311,12 +311,10 @@ int utils_heapinfo(int argc, char **args)
 	return OK;
 
 usage:
-	printf("\nUsage: heapinfo [-TARGET] [-OPTION] [ARG]\n");
+	printf("\nUsage: heapinfo [-TARGET] [-OPTION]\n");
 	printf("Display information of heap memory\n");
+#ifdef CONFIG_BUILD_PROTECTED
 	printf("\nTargets:\n");
-#ifndef CONFIG_BUILD_PROTECTED
-	printf(" (none)         Initialize the heapinfo\n");
-#else
 	printf(" -k             Kernel Heap\n");
 	printf(" -u             User Heap\n");
 #ifdef CONFIG_APP_BINARY_SEPARATION


### PR DESCRIPTION
1. apps/system/utils : Modify heapinfo explanation in README.md
    Heapinfo was expanded to show kernel, user and specific binary heap information.
    Add explanation about target for heapinfo.

2. apps/system/utils/heapinfo : Remove unnecessary description
  If CONFIG_BUILD_PROTECTED is not enabled, there is only total heap, not kernel or user.
