### PR TITLE
apps/kernel_stability_test : Test kernel stability for many context switch

### DIFF
--- a/apps/examples/heavy_signal_message_test/.gitignore
+++ b/apps/examples/heavy_signal_message_test/.gitignore
@@ -1,0 +1,11 @@
+/Make.dep
+/.depend
+/.built
+/*.asm
+/*.obj
+/*.rel
+/*.lst
+/*.sym
+/*.adb
+/*.lib
+/*.src

--- a/apps/examples/heavy_signal_message_test/Kconfig
+++ b/apps/examples/heavy_signal_message_test/Kconfig
@@ -1,0 +1,16 @@
+#
+# For a description of the syntax of this configuration file,
+# see kconfig-language at https://www.kernel.org/doc/Documentation/kbuild/kconfig-language.txt
+#
+
+config EXAMPLES_HEAVY_SIGNAL_MESSAGE_TEST
+	bool "Heavy Signal Message Test Sample"
+	default n
+	depends on !DISABLE_MQUEUE && !DISABLE_SIGNALS && !DISABLE_PTHREAD
+	---help---
+		Aging test in case of heavy signal/message scenarios. Check whether 
+		signal and message work normally while many context switches occur.
+
+config USER_ENTRYPOINT
+	string
+	default "heavy_signal_message_test_main" if ENTRY_HEAVY_SIGNAL_MESSAGE_TEST

--- a/apps/examples/heavy_signal_message_test/Kconfig_ENTRY
+++ b/apps/examples/heavy_signal_message_test/Kconfig_ENTRY
@@ -1,0 +1,3 @@
+config ENTRY_HEAVY_SIGNAL_MESSAGE_TEST
+	bool "Heavy Signal Message Test Sample"
+	depends on EXAMPLES_HEAVY_SIGNAL_MESSAGE_TEST

--- a/apps/examples/heavy_signal_message_test/Make.defs
+++ b/apps/examples/heavy_signal_message_test/Make.defs
@@ -1,0 +1,55 @@
+###########################################################################
+#
+# Copyright 2019 Samsung Electronics All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+#
+###########################################################################
+############################################################################
+# apps/examples/heavy_signal_message_test/Make.defs
+#
+#   Copyright (C) 2015 Gregory Nutt. All rights reserved.
+#   Author: Gregory Nutt <gnutt@nuttx.org>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in
+#    the documentation and/or other materials provided with the
+#    distribution.
+# 3. Neither the name NuttX nor the names of its contributors may be
+#    used to endorse or promote products derived from this software
+#    without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+# OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+# AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+############################################################################
+
+ifeq ($(CONFIG_EXAMPLES_HEAVY_SIGNAL_MESSAGE_TEST),y)
+CONFIGURED_APPS += examples/heavy_signal_message_test
+endif

--- a/apps/examples/heavy_signal_message_test/Makefile
+++ b/apps/examples/heavy_signal_message_test/Makefile
@@ -1,0 +1,158 @@
+###########################################################################
+#
+# Copyright 2019 Samsung Electronics All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+#
+###########################################################################
+############################################################################
+# apps/examples/heavy_signal_message_test/Makefile
+#
+#   Copyright (C) 2008, 2010-2013 Gregory Nutt. All rights reserved.
+#   Author: Gregory Nutt <gnutt@nuttx.org>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in
+#    the documentation and/or other materials provided with the
+#    distribution.
+# 3. Neither the name NuttX nor the names of its contributors may be
+#    used to endorse or promote products derived from this software
+#    without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+# OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+# AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+############################################################################
+
+-include $(TOPDIR)/.config
+-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
+
+# kernel stability test application info
+
+APPNAME = heavy_signal_message_test
+FUNCNAME = $(APPNAME)_main
+THREADEXEC = TASH_EXECMD_ASYNC
+
+# kernel stability test
+
+ASRCS =
+CSRCS = heavy_signal_message_test_receiver.c heavy_signal_message_test_sender.c heavy_signal_message_test_stop.c
+MAINSRC = heavy_signal_message_test_main.c
+
+AOBJS = $(ASRCS:.S=$(OBJEXT))
+COBJS = $(CSRCS:.c=$(OBJEXT))
+MAINOBJ = $(MAINSRC:.c=$(OBJEXT))
+
+SRCS = $(ASRCS) $(CSRCS) $(MAINSRC)
+OBJS = $(AOBJS) $(COBJS)
+
+ifneq ($(CONFIG_BUILD_KERNEL),y)
+  OBJS += $(MAINOBJ)
+endif
+
+ifeq ($(CONFIG_WINDOWS_NATIVE),y)
+  BIN = ..\..\libapps$(LIBEXT)
+else
+ifeq ($(WINTOOL),y)
+  BIN = ..\\..\\libapps$(LIBEXT)
+else
+  BIN = ../../libapps$(LIBEXT)
+endif
+endif
+
+ifeq ($(WINTOOL),y)
+  INSTALL_DIR = "${shell cygpath -w $(BIN_DIR)}"
+else
+  INSTALL_DIR = $(BIN_DIR)
+endif
+
+CONFIG_EXAMPLES_HEAVY_SIGNAL_MESSAGE_TEST_PROGNAME ?= heavy_signal_message_test$(EXEEXT)
+PROGNAME = $(CONFIG_EXAMPLES_HEAVY_SIGNAL_MESSAGE_TEST_PROGNAME)
+
+ROOTDEPPATH = --dep-path .
+
+# Common build
+
+VPATH =
+
+all: .built
+.PHONY: clean depend distclean
+
+$(AOBJS): %$(OBJEXT): %.S
+	$(call ASSEMBLE, $<, $@)
+
+$(COBJS) $(MAINOBJ): %$(OBJEXT): %.c
+	$(call COMPILE, $<, $@)
+
+.built: $(OBJS)
+	$(call ARCHIVE, $(BIN), $(OBJS))
+	@touch .built
+
+ifeq ($(CONFIG_BUILD_KERNEL),y)
+$(BIN_DIR)$(DELIM)$(PROGNAME): $(OBJS) $(MAINOBJ)
+	@echo "LD: $(PROGNAME)"
+	$(Q) $(LD) $(LDELFFLAGS) $(LDLIBPATH) -o $(INSTALL_DIR)$(DELIM)$(PROGNAME) $(ARCHCRT0OBJ) $(MAINOBJ) $(LDLIBS)
+	$(Q) $(NM) -u  $(INSTALL_DIR)$(DELIM)$(PROGNAME)
+
+install: $(BIN_DIR)$(DELIM)$(PROGNAME)
+
+else
+install:
+
+endif
+
+ifeq ($(CONFIG_BUILTIN_APPS)$(CONFIG_EXAMPLES_HEAVY_SIGNAL_MESSAGE_TEST),yy)
+$(BUILTIN_REGISTRY)$(DELIM)$(FUNCNAME).bdat: $(DEPCONFIG) Makefile
+	$(Q) $(call REGISTER,$(APPNAME),$(FUNCNAME),$(THREADEXEC),$(PRIORITY),$(STACKSIZE))
+
+context: $(BUILTIN_REGISTRY)$(DELIM)$(FUNCNAME).bdat
+
+else
+context:
+
+endif
+
+.depend: Makefile $(SRCS)
+	@$(MKDEP) $(ROOTDEPPATH) "$(CC)" -- $(CFLAGS) -- $(SRCS) >Make.dep
+	@touch $@
+
+depend: .depend
+
+clean:
+	$(call DELFILE, .built)
+	$(call CLEAN)
+
+distclean: clean
+	$(call DELFILE, Make.dep)
+	$(call DELFILE, .depend)
+
+-include Make.dep
+.PHONY: preconfig
+preconfig:

--- a/apps/examples/heavy_signal_message_test/heavy_signal_message_test.h
+++ b/apps/examples/heavy_signal_message_test/heavy_signal_message_test.h
@@ -1,0 +1,45 @@
+/****************************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+#ifndef __EXAMPLES_HEAVY_SIGNAL_MESSAGE_TEST_HEAVY_SIGNAL_MESSAGE_TEST_H__
+#define __EXAMPLES_HEAVY_SIGNAL_MESSAGE_TEST_HEAVY_SIGNAL_MESSAGE_TEST_H__
+
+#include <tinyara/config.h>
+
+#define HEAVY_SIGNAL_MESSAGE_TEST_MQ                    "safe_mq"
+#define HEAVY_SIGNAL_MESSAGE_TEST_SIG_MQ                "safe_sig_mq"
+#define HEAVY_SIGNAL_MESSAGE_TEST_SEND_STOP_MQ          "send_stop_mq"
+#define HEAVY_SIGNAL_MESSAGE_TEST_RECEIVE_STOP_MQ       "receive_stop_mq"
+
+#define HEAVY_SIGNAL_MESSAGE_TEST_MAX_MSG               16
+#define HEAVY_SIGNAL_MESSAGE_TEST_MQ_NAME_MAX           16
+#define HEAVY_SIGNAL_MESSAGE_TEST_USLEEP                100000
+#define HEAVY_SIGNAL_MESSAGE_TEST_NSLEEP                (HEAVY_SIGNAL_MESSAGE_TEST_USLEEP * 1000)
+#define HEAVY_SIGNAL_MESSAGE_TEST_MAX_NSLEEP            1000000000
+#define HEAVY_SIGNAL_MESSAGE_TEST_SIG_WAIT_NO           1
+#define HEAVY_SIGNAL_MESSAGE_TEST_SIG_TIME_WAIT_NO      2
+#define HEAVY_SIGNAL_MESSAGE_TEST_BUFFER_SIZE           600
+
+#define HEAVY_SIGNAL_MESSAGE_TEST_TASK_NUM              (CONFIG_MAX_TASKS / 16)
+
+#define HEAVY_SIGNAL_MESSAGE_TEST_STOP                  0
+
+void heavy_signal_message_test_receiver(void);
+void heavy_signal_message_test_sender(void);
+void heavy_signal_message_test_stop(void);
+
+#endif /* __EXAMPLES_HEAVY_SIGNAL_MESSAGE_TEST_HEAVY_SIGNAL_MESSAGE_TEST_H__ */

--- a/apps/examples/heavy_signal_message_test/heavy_signal_message_test_main.c
+++ b/apps/examples/heavy_signal_message_test/heavy_signal_message_test_main.c
@@ -1,0 +1,114 @@
+/****************************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+/****************************************************************************
+ * apps/examples/heavy_signal_message_test/heavy_signal_message_test_main.c
+ *
+ *   Copyright (C) 2008, 2011-2012 Gregory Nutt. All rights reserved.
+ *   Author: Gregory Nutt <gnutt@nuttx.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <tinyara/config.h>
+#include <stdio.h>
+#include <string.h>
+
+#include <sys/types.h>
+
+#include "heavy_signal_message_test.h"
+
+static volatile bool is_running;
+
+#ifdef CONFIG_BUILD_KERNEL
+int main(int argc, FAR char *argv[])
+#else
+int heavy_signal_message_test_main(int argc, char *argv[])
+#endif
+{
+
+	int pid;
+	if (argc >= 3) {
+		printf("\nUsage : heavy_signal_message \n");
+		printf("     or   heavy_signal_message stop\n");
+		return ERROR;
+	}
+
+	/* Execute the heavy signal message test sample. */
+	if (argc == 1) {
+		if (is_running) {
+			printf("There is already running heavy signal message test Sample.\n");
+			printf("New sample can run after that previous sample is finished.\n");
+			return ERROR;
+		}
+		pid = task_create("heavy_signal_message_test_receiver", 100, 1024, (main_t)heavy_signal_message_test_receiver, (FAR char *const *)NULL);
+		if (pid < 0) {
+			printf("heavy_signal_message_test_receiver task create FAIL\n");
+			return ERROR;
+		}
+
+		pid = task_create("heavy_signal_message_test_sender", 100, 1024, (main_t)heavy_signal_message_test_sender, (FAR char *const *)NULL);
+		if (pid < 0) {
+			printf("heavy_signal_message_test_sender task create FAIL\n");
+			return ERROR;
+		}
+		is_running = true;
+	} else if (argc == 2 && strncmp(argv[1], "stop", strlen("stop") + 1) == 0) {
+		if (is_running == false) {
+			printf("There is no running heavy signal message test sample. Cannot stop the sample.\n");
+			return ERROR;
+		}
+		is_running = false;
+		heavy_signal_message_test_stop();
+	} else {
+		printf("\nUsage : heavy_signal_message \n");
+		printf("     or   heavy_signal_message stop\n");
+		return ERROR;
+	}
+
+	return 0;
+}

--- a/apps/examples/heavy_signal_message_test/heavy_signal_message_test_receiver.c
+++ b/apps/examples/heavy_signal_message_test/heavy_signal_message_test_receiver.c
@@ -1,0 +1,360 @@
+/****************************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+/****************************************************************************
+ * apps/examples/heavy_signal_message_test/heavy_signal_message_test_receiver.c
+ *
+ *   Copyright (C) 2008, 2011-2012 Gregory Nutt. All rights reserved.
+ *   Author: Gregory Nutt <gnutt@nuttx.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <stdio.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <mqueue.h>
+#include <signal.h>
+#include <pthread.h>
+#include <time.h>
+#include <semaphore.h>
+
+#include <sys/types.h>
+
+#include "heavy_signal_message_test.h"
+
+static int sig_mq_num;
+static int mq_num;
+static bool running;
+static int total_cnt;
+static int succese_cnt;
+
+static void *heavy_signal_message_test_sig_timedwait(void)
+{
+	int pid;
+	sigset_t sig;
+	siginfo_t info;
+	struct timespec timeout;
+
+	total_cnt++;
+	pid = getpid();
+	printf("[%d] heavy_signal_message_test_sig_timedwait pthread\n", pid);
+
+	timeout.tv_sec  = 0;
+	timeout.tv_nsec = HEAVY_SIGNAL_MESSAGE_TEST_NSLEEP;
+
+	sigemptyset(&sig);
+	sigaddset(&sig, HEAVY_SIGNAL_MESSAGE_TEST_SIG_TIME_WAIT_NO);
+
+	while (running == true) {
+		sigtimedwait(&sig, &info, &timeout);
+		printf("[%d] sig timed wait \n", pid);
+	}
+
+	succese_cnt++;
+	printf("[%d] heavy_signal_message_test_sig_timedwait pthread stop\n", pid);
+	return 0;
+}
+
+static void *heavy_signal_message_test_sem_timedwait(void)
+{
+	int pid;
+	int ret;
+	struct timespec abstime;
+	sem_t sem;
+
+	total_cnt++;
+	pid = getpid();
+	printf("[%d] heavy_signal_message_test_sem_timedwait pthread\n", pid);
+
+	sem_init(&sem, 0, 1);
+
+	ret = clock_gettime(CLOCK_REALTIME, &abstime);
+	if (ret != OK) {
+		printf("Fail to clock_gettime");
+		return 0;
+	}
+	abstime.tv_nsec += HEAVY_SIGNAL_MESSAGE_TEST_NSLEEP;
+	/* If tv_nsec over 1000000000, It is not valid.
+	 * So it reduce to less than 1000000000.
+	 */
+	if (abstime.tv_nsec >= HEAVY_SIGNAL_MESSAGE_TEST_MAX_NSLEEP) {
+		abstime.tv_sec += 1;
+		abstime.tv_nsec -= HEAVY_SIGNAL_MESSAGE_TEST_MAX_NSLEEP;
+	}
+	while (running == true) {
+		sem_timedwait(&sem, &abstime);
+		printf("[%d] sem timed wait\n", pid);
+		ret = clock_gettime(CLOCK_REALTIME, &abstime);
+		if (ret != OK) {
+			printf("Fail to clock_gettime");
+			return 0;
+		}
+
+		abstime.tv_nsec += HEAVY_SIGNAL_MESSAGE_TEST_NSLEEP;
+		if (abstime.tv_nsec >= HEAVY_SIGNAL_MESSAGE_TEST_MAX_NSLEEP) {
+			abstime.tv_sec += 1;
+			abstime.tv_nsec -= HEAVY_SIGNAL_MESSAGE_TEST_MAX_NSLEEP;
+		}
+	}
+
+	succese_cnt++;
+	printf("[%d] heavy_signal_message_test_sem_timedwait pthread stop\n", pid);
+	return 0;
+}
+
+static void *heavy_signal_message_test_sig_receive(void)
+{
+	int ret;
+	int pid;
+	mqd_t fd;
+	sigset_t sig_set;
+	struct mq_attr attr;
+	char q_name[HEAVY_SIGNAL_MESSAGE_TEST_MQ_NAME_MAX];
+
+	total_cnt++;
+	pid = getpid();
+	printf("[%d] heavy_signal_message_test_sig_receive_pthread\n", pid);
+
+	attr.mq_maxmsg = HEAVY_SIGNAL_MESSAGE_TEST_MAX_MSG;
+	attr.mq_msgsize = sizeof(int);
+	attr.mq_flags = 0;
+	snprintf(q_name, HEAVY_SIGNAL_MESSAGE_TEST_MQ_NAME_MAX, "%s%d", HEAVY_SIGNAL_MESSAGE_TEST_SIG_MQ, sig_mq_num++);
+
+	fd = mq_open(q_name, O_RDWR | O_CREAT, 0666, &attr);
+	if (fd < 0) {
+		printf("Failed to open message queue\n");
+		return 0;
+	}
+
+	/* notify receiver's pid to sender. */
+	ret = mq_send(fd, (char *)&pid, sizeof(int), 100);
+	if (ret < 0) {
+		printf("Failed to send message\n");
+		mq_close(fd);
+		mq_unlink(q_name);
+		return 0;
+	}
+	mq_close(fd);
+	mq_unlink(q_name);
+
+	sigemptyset(&sig_set);
+	sigaddset(&sig_set, HEAVY_SIGNAL_MESSAGE_TEST_SIG_WAIT_NO);
+
+	pthread_sigmask(SIG_BLOCK, &sig_set, NULL);
+
+	while (running == true) {
+		sigwaitinfo(&sig_set, NULL);
+		printf("[%d] receive_signal\n", pid);
+		usleep(HEAVY_SIGNAL_MESSAGE_TEST_USLEEP);
+	}
+
+	succese_cnt++;
+	printf("[%d] heavy_signal_message_test_sig_receive_pthread stop\n", pid);
+	return 0;
+}
+
+static void *heavy_signal_message_test_mq_receive(void)
+{
+	int ret;
+	int pid;
+	mqd_t fd;
+	struct mq_attr attr;
+	char q_name[HEAVY_SIGNAL_MESSAGE_TEST_MQ_NAME_MAX];
+	char buffer[HEAVY_SIGNAL_MESSAGE_TEST_BUFFER_SIZE + 1];
+	char message_value;
+
+	total_cnt++;
+	pid = getpid();
+	printf("[%d] heavy_signal_message_test_mq_receive_pthread \n", pid);
+
+	attr.mq_maxmsg = HEAVY_SIGNAL_MESSAGE_TEST_MAX_MSG;
+	attr.mq_msgsize = HEAVY_SIGNAL_MESSAGE_TEST_BUFFER_SIZE;
+	attr.mq_flags = 0;
+
+	/* sender and receiver open the same mq. safe_mq1, safe_mq2 .... */
+	snprintf(q_name, HEAVY_SIGNAL_MESSAGE_TEST_MQ_NAME_MAX, "%s%d", HEAVY_SIGNAL_MESSAGE_TEST_MQ, mq_num++);
+
+	fd = mq_open(q_name, O_RDWR | O_CREAT, 0666, &attr);
+	if (fd < 0) {
+		printf("Failed to open message queue\n");
+		return 0;
+	}
+	message_value = 'a' + (char)mq_num;
+
+	while (running == true) {
+		ret = mq_receive(fd, (char *)&buffer, HEAVY_SIGNAL_MESSAGE_TEST_BUFFER_SIZE, NULL);
+		if (ret < 0) {
+			printf("Failed to receive\n");
+			mq_close(fd);
+			mq_unlink(q_name);
+			return 0;
+		}
+		printf("[%d] receive message\n", pid);
+		for (int i = 0; i < HEAVY_SIGNAL_MESSAGE_TEST_BUFFER_SIZE; i++) {
+			/* Check for the correct message. */
+			if (buffer[i] != message_value) {
+				printf("Failed to receive\n");
+				mq_close(fd);
+				mq_unlink(q_name);
+				return 0;
+			}
+			buffer[i] = 0;
+		}
+		usleep(HEAVY_SIGNAL_MESSAGE_TEST_USLEEP);
+	}
+
+	succese_cnt++;
+	printf("[%d] heavy_signal_message_test_mq_receive_pthread stop\n", pid);
+	mq_close(fd);
+	mq_unlink(q_name);
+	return 0;
+}
+
+void heavy_signal_message_test_receiver(void)
+{
+	int i;
+	int ret;
+	pthread_t pid;
+	mqd_t fd;
+	int command;
+	struct timespec start_time;
+	struct timespec end_time;
+	struct mq_attr attr;
+	bool is_stop = false;
+	char q_name[HEAVY_SIGNAL_MESSAGE_TEST_MQ_NAME_MAX];
+
+	total_cnt = 0;
+	succese_cnt = 0;
+	running = true;
+
+	ret = clock_gettime(CLOCK_REALTIME, &start_time);
+	if (ret != OK) {
+		printf("Fail to clock_gettime");
+		return;
+	}
+
+	for (i = 0; i < HEAVY_SIGNAL_MESSAGE_TEST_TASK_NUM; ++i) {
+		ret = pthread_create(&pid, NULL, (pthread_startroutine_t)heavy_signal_message_test_sig_timedwait, NULL);
+		if (ret < 0) {
+			printf("heavy_signal_message_test_sig_timedwait pthread create FAIL\n");
+			return;
+		}
+		pthread_setname_np(pid, "sig_timedwait");
+		pthread_detach(pid);
+
+		ret = pthread_create(&pid, NULL, (pthread_startroutine_t)heavy_signal_message_test_sem_timedwait, NULL);
+		if (ret < 0) {
+			printf("heavy_signal_message_test_sem_timedwait pthread create FAIL\n");
+			return;
+		}
+		pthread_setname_np(pid, "sem_timedwait");
+		pthread_detach(pid);
+
+		ret = pthread_create(&pid, NULL, (pthread_startroutine_t)heavy_signal_message_test_sig_receive, NULL);
+		if (ret < 0) {
+			printf("heavy_signal_message_test_sig_receive pthread create FAIL\n");
+			return;
+		}
+		pthread_setname_np(pid, "sig_receive");
+		pthread_detach(pid);
+
+		ret = pthread_create(&pid, NULL, (pthread_startroutine_t)heavy_signal_message_test_mq_receive, NULL);
+		if (ret < 0) {
+			printf("heavy_signal_message_test_mq_receive pthread create FAIL\n");
+			return;
+		}
+		pthread_setname_np(pid, "mq_receive");
+		pthread_detach(pid);
+	}
+
+	attr.mq_maxmsg = HEAVY_SIGNAL_MESSAGE_TEST_MAX_MSG;
+	attr.mq_msgsize = sizeof(int);
+	attr.mq_flags = 0;
+
+	strncpy(q_name, HEAVY_SIGNAL_MESSAGE_TEST_RECEIVE_STOP_MQ, HEAVY_SIGNAL_MESSAGE_TEST_MQ_NAME_MAX);
+
+	fd = mq_open(q_name, O_RDWR | O_CREAT, 0666, &attr);
+	if (fd < 0) {
+		printf("Failed to open message queue\n");
+		return;
+	}
+
+	while (is_stop != true) {
+		ret = mq_receive(fd, (char *)&command, sizeof(int), NULL);
+		if (ret < 0) {
+			printf("Failed to send message\n");
+			mq_close(fd);
+			mq_unlink(q_name);
+			return;
+		}
+
+		switch (command) {
+		case HEAVY_SIGNAL_MESSAGE_TEST_STOP:
+			running = false;
+			is_stop = true;
+			break;
+		default:
+			break;
+		}
+	}
+
+	ret = clock_gettime(CLOCK_REALTIME, &end_time);
+	if (ret != OK) {
+		printf("Fail to clock_gettime");
+		return;
+	}
+
+	/* Wait for pthread to exit. */
+	sleep(1);
+	printf("heavy_signal_message_test_receiver task stop\n");
+	printf("receiver test total task count = [%d], succese taks count = [%d]\n", total_cnt, succese_cnt);
+	printf("receiver running time = [%ds]\n", end_time.tv_sec - start_time.tv_sec);
+
+	mq_close(fd);
+	mq_unlink(q_name);
+}

--- a/apps/examples/heavy_signal_message_test/heavy_signal_message_test_sender.c
+++ b/apps/examples/heavy_signal_message_test/heavy_signal_message_test_sender.c
@@ -1,0 +1,286 @@
+/****************************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+/****************************************************************************
+ * apps/examples/heavy_signal_message_test/heavy_signal_message_test_snder.c
+ *
+ *   Copyright (C) 2008, 2011-2012 Gregory Nutt. All rights reserved.
+ *   Author: Gregory Nutt <gnutt@nuttx.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <stdio.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <mqueue.h>
+#include <signal.h>
+#include <pthread.h>
+
+#include <sys/types.h>
+
+#include "heavy_signal_message_test.h"
+
+static int sig_mq_num;
+static int mq_num;
+static bool running;
+static int total_cnt;
+static int succese_cnt;
+
+static void *heavy_signal_message_test_sig_send(void)
+{
+	int ret;
+	int recv_pid;
+	int pid;
+	mqd_t fd;
+	struct mq_attr attr;
+	char q_name[HEAVY_SIGNAL_MESSAGE_TEST_MQ_NAME_MAX];
+	union sigval value;
+
+	total_cnt++;
+	pid = getpid();
+	printf("[%d] heavy_signal_message_test_sig_send pthread \n", pid);
+
+	attr.mq_maxmsg = HEAVY_SIGNAL_MESSAGE_TEST_MAX_MSG;
+	attr.mq_msgsize = sizeof(int);
+	attr.mq_flags = 0;
+
+	snprintf(q_name, HEAVY_SIGNAL_MESSAGE_TEST_MQ_NAME_MAX, "%s%d", HEAVY_SIGNAL_MESSAGE_TEST_SIG_MQ, sig_mq_num++);
+
+	fd = mq_open(q_name, O_RDWR | O_CREAT, 0666, &attr);
+	if (fd < 0) {
+		printf("Failed to open message queue\n");
+		return 0;
+	}
+
+	/* sender receive a receiver's pid. */
+	ret = mq_receive(fd, (char *)&recv_pid, sizeof(int), NULL);
+	if (ret < 0) {
+		printf("Failed to send message\n");
+		mq_close(fd);
+		mq_unlink(q_name);
+		return 0;
+	}
+	mq_close(fd);
+	mq_unlink(q_name);
+
+	while (running == true) {
+		(void)sigqueue(recv_pid, HEAVY_SIGNAL_MESSAGE_TEST_SIG_WAIT_NO, value);
+		printf("[%d] send signal to %d\n", pid, recv_pid);
+		usleep(HEAVY_SIGNAL_MESSAGE_TEST_USLEEP);
+	}
+
+	succese_cnt++;
+	printf("[%d] heavy_signal_message_test_sig_send pthread stop\n", pid);
+	return 0;
+}
+
+static void *heavy_signal_message_test_mq_send(void)
+{
+	int ret;
+	int pid;
+	mqd_t fd;
+	struct mq_attr attr;
+	char q_name[HEAVY_SIGNAL_MESSAGE_TEST_MQ_NAME_MAX];
+	char buffer[HEAVY_SIGNAL_MESSAGE_TEST_BUFFER_SIZE + 1];
+
+	total_cnt++;
+	pid = getpid();
+	printf("[%d] heavy_signal_message_test_mq_send pthread \n", pid);
+
+	attr.mq_maxmsg = HEAVY_SIGNAL_MESSAGE_TEST_MAX_MSG;
+	attr.mq_msgsize = HEAVY_SIGNAL_MESSAGE_TEST_BUFFER_SIZE;
+	attr.mq_flags = 0;
+
+	/* sender and receiver open the same mq. safe_mq1, safe_mq2 ....*/
+	snprintf(q_name, HEAVY_SIGNAL_MESSAGE_TEST_MQ_NAME_MAX, "%s%d", HEAVY_SIGNAL_MESSAGE_TEST_MQ, mq_num++);
+
+	fd = mq_open(q_name, O_RDWR | O_CREAT, 0666, &attr);
+	if (fd < 0) {
+		printf("Failed to open message queue\n");
+		return 0;
+	}
+
+	for (int i = 0; i < HEAVY_SIGNAL_MESSAGE_TEST_BUFFER_SIZE; ++i) {
+		buffer[i] = 'a' + (char)mq_num;
+	}
+	buffer[HEAVY_SIGNAL_MESSAGE_TEST_BUFFER_SIZE] = 0;
+
+	while (running == true) {
+		ret = mq_send(fd, (char *)&buffer, HEAVY_SIGNAL_MESSAGE_TEST_BUFFER_SIZE, 100);
+		if (ret < 0) {
+			printf("Failed to send\n");
+			mq_close(fd);
+			mq_unlink(q_name);
+			return 0;
+		}
+		printf("[%d] send message\n", pid);
+		usleep(HEAVY_SIGNAL_MESSAGE_TEST_USLEEP);
+	}
+
+	succese_cnt++;
+	printf("[%d] heavy_signal_message_test_mq_send pthread stop\n", pid);
+
+	mq_close(fd);
+	mq_unlink(q_name);
+	return 0;
+}
+
+static void *heavy_signal_message_test_usleep(void)
+{
+	int pid;
+
+	total_cnt++;
+	pid = getpid();
+	printf("[%d] heavy_signal_message_test_usleep_pthread \n", pid);
+
+	while (running == true) {
+		printf("[%d] usleep\n", pid);
+		usleep(HEAVY_SIGNAL_MESSAGE_TEST_USLEEP);
+	}
+
+	succese_cnt++;
+	printf("[%d] heavy_signal_message_test_usleep_pthread stop\n", pid);
+	return 0;
+}
+
+void heavy_signal_message_test_sender(void)
+{
+	int i;
+	int ret;
+	pthread_t pid;
+	mqd_t fd;
+	int command;
+	struct timespec start_time;
+	struct timespec end_time;
+	struct mq_attr attr;
+	bool is_stop = false;
+	char q_name[HEAVY_SIGNAL_MESSAGE_TEST_MQ_NAME_MAX];
+
+	total_cnt = 0;
+	succese_cnt = 0;
+	running = true;
+
+	ret = clock_gettime(CLOCK_REALTIME, &start_time);
+	if (ret != OK) {
+		printf("Fail to clock_gettime");
+		return;
+	}
+
+	for (i = 0; i < HEAVY_SIGNAL_MESSAGE_TEST_TASK_NUM; ++i) {
+		ret = pthread_create(&pid, NULL, (pthread_startroutine_t)heavy_signal_message_test_sig_send, NULL);
+		if (ret < 0) {
+			printf("heavy_signal_message_test_sig_send pthread create FAIL\n");
+			return;
+		}
+		pthread_setname_np(pid, "sig_send");
+		pthread_detach(pid);
+
+		ret = pthread_create(&pid, NULL, (pthread_startroutine_t)heavy_signal_message_test_mq_send, NULL);
+		if (ret < 0) {
+			printf("heavy_signal_message_test_mq_send pthread create FAIL\n");
+			return;
+		}
+		pthread_setname_np(pid, "mq_send");
+		pthread_detach(pid);
+
+		ret = pthread_create(&pid, NULL, (pthread_startroutine_t)heavy_signal_message_test_usleep, NULL);
+		if (ret < 0) {
+			printf("heavy_signal_message_test_usleep pthread create FAIL\n");
+			return;
+		}
+		pthread_setname_np(pid, "usleep");
+		pthread_detach(pid);
+	}
+
+	attr.mq_maxmsg = HEAVY_SIGNAL_MESSAGE_TEST_MAX_MSG;
+	attr.mq_msgsize = sizeof(int);
+	attr.mq_flags = 0;
+
+	strncpy(q_name, HEAVY_SIGNAL_MESSAGE_TEST_SEND_STOP_MQ, HEAVY_SIGNAL_MESSAGE_TEST_MQ_NAME_MAX);
+
+	fd = mq_open(q_name, O_RDWR | O_CREAT, 0666, &attr);
+	if (fd < 0) {
+		bmdbg("Failed to open message queue\n");
+		return;
+	}
+
+	while (is_stop != true) {
+		ret = mq_receive(fd, (char *)&command, sizeof(int), NULL);
+		if (ret < 0) {
+			printf("Failed to send message\n");
+			mq_close(fd);
+			mq_unlink(q_name);
+			return;
+		}
+
+		switch (command) {
+		case HEAVY_SIGNAL_MESSAGE_TEST_STOP:
+			running = false;
+			is_stop = true;
+			break;
+		default:
+			break;
+		}
+	}
+
+	ret = clock_gettime(CLOCK_REALTIME, &end_time);
+	if (ret != OK) {
+		printf("Fail to clock_gettime");
+		return;
+	}
+
+	/* Wait for pthread to exit. */
+	sleep(1);
+
+	printf("heavy_signal_message_test_sender task stop\n");
+	printf("sender test total task count = [%d], succese taks count = [%d]\n", total_cnt, succese_cnt);
+	printf("sender running time = [%ds]\n", end_time.tv_sec - start_time.tv_sec);
+
+	mq_close(fd);
+	mq_unlink(q_name);
+}

--- a/apps/examples/heavy_signal_message_test/heavy_signal_message_test_stop.c
+++ b/apps/examples/heavy_signal_message_test/heavy_signal_message_test_stop.c
@@ -1,0 +1,103 @@
+/****************************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+/****************************************************************************
+ * apps/examples/heavy_signal_message_test/heavy_signal_message_test_stop.c
+ *
+ *   Copyright (C) 2008, 2011-2012 Gregory Nutt. All rights reserved.
+ *   Author: Gregory Nutt <gnutt@nuttx.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <tinyara/config.h>
+#include <stdlib.h>
+#include <fcntl.h>
+#include <mqueue.h>
+#include <string.h>
+
+#include "heavy_signal_message_test.h"
+
+void heavy_signal_message_test_stop(void)
+{
+	mqd_t send_fd;
+	mqd_t recv_fd;
+	int command;
+	struct mq_attr attr;
+	char send_q_name[HEAVY_SIGNAL_MESSAGE_TEST_MQ_NAME_MAX];
+	char recv_q_name[HEAVY_SIGNAL_MESSAGE_TEST_MQ_NAME_MAX];
+
+	attr.mq_maxmsg = HEAVY_SIGNAL_MESSAGE_TEST_MAX_MSG;
+	attr.mq_msgsize = sizeof(int);
+	attr.mq_flags = 0;
+
+	strncpy(send_q_name, HEAVY_SIGNAL_MESSAGE_TEST_SEND_STOP_MQ, HEAVY_SIGNAL_MESSAGE_TEST_MQ_NAME_MAX);
+	strncpy(recv_q_name, HEAVY_SIGNAL_MESSAGE_TEST_RECEIVE_STOP_MQ, HEAVY_SIGNAL_MESSAGE_TEST_MQ_NAME_MAX);
+
+	recv_fd = mq_open(recv_q_name, O_WRONLY | O_CREAT, 0666, &attr);
+	if (recv_fd < 0) {
+		printf("Failed to open message queue\n");
+		return;
+	}
+
+	send_fd = mq_open(send_q_name, O_WRONLY | O_CREAT, 0666, &attr);
+	if (send_fd < 0) {
+		printf("Failed to open message queue\n");
+		mq_close(recv_fd);
+		mq_unlink(recv_q_name);
+		return;
+	}
+
+	command = HEAVY_SIGNAL_MESSAGE_TEST_STOP;
+	mq_send(recv_fd, (char *)&command, sizeof(int), 100);
+	mq_send(send_fd, (char *)&command, sizeof(int), 100);
+
+	mq_close(send_fd);
+	mq_close(recv_fd);
+
+	return;
+}


### PR DESCRIPTION
Mary tasks work usleep, mq_receive, mq_send, sem_timedwait and so on.
It should work without dying while multiple context switches occur.