### PR TITLE
mm/mm_heap/mm_heapinfo : Exclude static RAM usage in binary heap

### DIFF
--- a/os/binfmt/libelf/libelf_load.c
+++ b/os/binfmt/libelf/libelf_load.c
@@ -352,6 +352,23 @@ int elf_load(FAR struct elf_loadinfo_s *loadinfo)
 	}
 #endif
 
+#if defined(CONFIG_DEBUG_MM_HEAPINFO) && defined(CONFIG_APP_BINARY_SEPARATION)
+	/* Re-initialize the binary heap information.
+	 * Because, binary heap contains text and data region size,
+	 * but those should not be calculated for heap usage.
+	 */
+	pid_t pid = getpid();
+	pid_t hashpid = PIDHASH(pid);
+
+	loadinfo->uheap->elf_sections_size = loadinfo->textsize + loadinfo->datasize;
+
+	loadinfo->uheap->alloc_list[hashpid].curr_alloc_size = 0;
+	loadinfo->uheap->alloc_list[hashpid].num_alloc_free = 0;
+
+	loadinfo->uheap->total_alloc_size = 0;
+	loadinfo->uheap->peak_alloc_size = 0;
+#endif
+
 	return OK;
 
 	/* Error exits */

--- a/os/include/tinyara/mm/mm.h
+++ b/os/include/tinyara/mm/mm.h
@@ -396,6 +396,10 @@ struct mm_heap_s {
 	int mm_nregions;
 #endif
 
+#ifdef CONFIG_APP_BINARY_SEPARATION
+	size_t elf_sections_size;
+#endif
+
 	/* All free nodes are maintained in a doubly linked list.  This
 	 * array provides some hooks into the list at various points to
 	 * speed searches for free nodes.

--- a/os/mm/mm_heap/mm_heapinfo.c
+++ b/os/mm/mm_heap/mm_heapinfo.c
@@ -102,6 +102,7 @@ void heapinfo_parse(FAR struct mm_heap_s *heap, int mode, pid_t pid)
 	size_t nonsched_resource;
 	int nonsched_idx;
 	struct sched_param sched_data;
+	size_t heap_size;
 
 	/* This nonsched can be 3 types : group resources, freed when child task finished, leak */
 	pid_t nonsched_list[CONFIG_MAX_TASKS];
@@ -217,11 +218,15 @@ void heapinfo_parse(FAR struct mm_heap_s *heap, int mode, pid_t pid)
 	printf("\n****************************************************************\n");
 	printf("     Summary of Heap Usages (Size in Bytes)\n");
 	printf("****************************************************************\n");
-	printf("Total                           : %u (100%%)\n", heap->mm_heapsize);
+	heap_size = heap->mm_heapsize;
+#ifdef CONFIG_APP_BINARY_SEPARATION
+	heap_size -= heap->elf_sections_size;
+#endif
+	printf("Total                           : %u (100%%)\n", heap_size);
 	printf("  - Allocated (Current / Peak)  : %u (%d%%) / %u (%d%%)\n",\
-		heap->total_alloc_size, (size_t)((uint64_t)(heap->total_alloc_size) * 100 / heap->mm_heapsize),\
-		heap->peak_alloc_size,  (size_t)((uint64_t)(heap->peak_alloc_size) * 100 / heap->mm_heapsize));
-	printf("  - Free (Current)              : %u (%d%%)\n", fordblks, (size_t)((uint64_t)fordblks * 100 / heap->mm_heapsize));
+		heap->total_alloc_size, (size_t)((uint64_t)(heap->total_alloc_size) * 100 / heap_size),\
+		heap->peak_alloc_size,  (size_t)((uint64_t)(heap->peak_alloc_size) * 100 / heap_size));
+	printf("  - Free (Current)              : %u (%d%%)\n", fordblks, (size_t)((uint64_t)fordblks * 100 / heap_size));
 	printf("  - Reserved                    : %u\n", SIZEOF_MM_ALLOCNODE * 2);
 
 	printf("\n****************************************************************\n");


### PR DESCRIPTION
Because, binary heap contains text and data region size,
but those should not be calculated for heap usage.