### PR TITLE
Implement watchdog for irq

### DIFF
--- a/os/arch/arm/src/common/up_initialize.c
+++ b/os/arch/arm/src/common/up_initialize.c
@@ -75,6 +75,10 @@
 #include <tinyara/net/telnet.h>
 #endif
 
+#ifdef CONFIG_WATCHDOG_FOR_IRQ
+#include <tinyara/arch.h>
+#endif
+
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
@@ -201,6 +205,13 @@ void up_initialize(void)
 #if !defined(CONFIG_SUPPRESS_INTERRUPTS) && !defined(CONFIG_SUPPRESS_TIMER_INTS) && \
 	!defined(CONFIG_SYSTEMTICK_EXTCLK)
 	up_timer_initialize();
+
+#ifdef CONFIG_WATCHDOG_FOR_IRQ
+#if (CONFIG_WATCHDOG_FOR_IRQ_INTERVAL <= CONFIG_USEC_PER_TICK)
+#error "CONFIG_WATCHDOG_FOR_IRQ_INTERVAL should be greater than CONFIG_USEC_PER_TICK"
+#endif
+	up_wdog_init(CONFIG_WATCHDOG_FOR_IRQ_INTERVAL);
+#endif
 #endif
 
 	/* Register devices */

--- a/os/arch/arm/src/imxrt/imxrt_wdog.c
+++ b/os/arch/arm/src/imxrt/imxrt_wdog.c
@@ -349,3 +349,33 @@ int board_reset(int status)
 	return 0;
 }
 #endif
+#ifdef CONFIG_WATCHDOG_FOR_IRQ
+/****************************************************************************
+ * Name: up_wdog_init
+ *
+ * Description:
+ *   Initialize the watchdog for irq
+ *
+ ****************************************************************************/
+void up_wdog_init(uint16_t timeout)
+{
+	wdog_config_t config;
+
+	imxrt_wdog_getdefaultconfig(&config);
+	config.timeoutValue = timeout;
+
+	imxrt_wdog_init(WDOG1, &config);
+}
+
+/****************************************************************************
+ * Name: up_wdog_keepalive
+ *
+ * Description:
+ *   Reset the watchdog timer for preventing timeouts.
+ *
+ ****************************************************************************/
+void up_wdog_keepalive(void)
+{
+	imxrt_wdog_refresh(WDOG1);
+}
+#endif

--- a/os/drivers/Kconfig
+++ b/os/drivers/Kconfig
@@ -382,6 +382,24 @@ config WATCHDOG_DEVPATH
 	string "Watchdog Device Path"
 	default "/dev/watchdog0"
 
+config WATCHDOG_FOR_IRQ
+	bool "Enable watchdog for irq"
+	default n
+	depends on !SUPPRESS_INTERRUPTS && !SUPPRESS_TIMER_INTS && !SYSTEMTICK_EXTCLK
+	---help---
+		If there is no irq within interval, watchdog resets the system.
+
+if WATCHDOG_FOR_IRQ
+
+config WATCHDOG_FOR_IRQ_INTERVAL
+	int "Interval for resetting watchdog(us)"
+	default 20000
+	---help---
+		After this interval, watchdog for irq expires.
+		This value should be greater than USER_PER_TICK.
+
+endif # WATCHDOG_FOR_IRQ
+
 endif # WATCHDOG
 
 config TIMER

--- a/os/include/tinyara/arch.h
+++ b/os/include/tinyara/arch.h
@@ -2107,6 +2107,27 @@ int up_getc(void);
 
 void up_puts(FAR const char *str);
 
+#ifdef CONFIG_WATCHDOG_FOR_IRQ
+/****************************************************************************
+ * Name: up_wdog_init
+ *
+ * Description:
+ *   Initialize the watchdog for irq
+ *
+ ****************************************************************************/
+void up_wdog_init(uint16_t timeout);
+
+/****************************************************************************
+ * Name: up_wdog_keepalive
+ *
+ * Description:
+ *   Reset the watchdog timer for preventing timeouts.
+ *
+ ****************************************************************************/
+void up_wdog_keepalive(void);
+
+#endif
+
 #undef EXTERN
 #ifdef __cplusplus
 }

--- a/os/kernel/sched/sched_processtimer.c
+++ b/os/kernel/sched/sched_processtimer.c
@@ -193,6 +193,9 @@ static inline void sched_process_timeslice(void)
 
 void sched_process_timer(void)
 {
+#ifdef CONFIG_WATCHDOG_FOR_IRQ
+	up_wdog_keepalive();
+#endif
 	/* Increment the system time (if in the link) */
 
 #ifdef CONFIG_HAVE_WEAKFUNCTIONS


### PR DESCRIPTION
1. imxrt/watchdog : Implement watchdog for irq
If there is no irq within interval, watchdog resets the system.
2. kernel/sched/sched_processtimer : Add watchdog for irq on every system timer
On every system timer events, reset the watchdog for irq.
If not, watchdog resets the system.