### PR TITLE
binfmt : Move user binary heap initialization for heap usage

### DIFF
--- a/os/binfmt/binfmt_execmodule.c
+++ b/os/binfmt/binfmt_execmodule.c
@@ -213,9 +213,14 @@ int exec_module(FAR const struct binary_s *binp)
 	 * for calculating the heap usage per threads.
 	 */
 	int hashpid = PIDHASH(getpid());
+	struct mm_allocnode_s *node;
+
 	binp->uheap->alloc_list[hashpid].pid = HEAPINFO_INIT_INFO;
 	binp->uheap->alloc_list[hashpid].curr_alloc_size = 0;
 	binp->uheap->alloc_list[hashpid].num_alloc_free = 0;
+
+	node = (struct mm_allocnode_s *)((void *)stack - SIZEOF_MM_ALLOCNODE);
+	node->pid = (-1) * (tcb->cmn.pid);
 #endif
 
 	/* We can free the argument buffer now.

--- a/os/binfmt/binfmt_execmodule.c
+++ b/os/binfmt/binfmt_execmodule.c
@@ -205,6 +205,19 @@ int exec_module(FAR const struct binary_s *binp)
 		goto errout_with_addrenv;
 	}
 
+#if defined(CONFIG_DEBUG_MM_HEAPINFO) && defined(CONFIG_APP_BINARY_SEPARATION)
+	/* Re-initialize the binary heap alloc list information.
+	 * Loading thread uses the binary's heap for loading,
+	 * so it saves the alloc data in binary's heap.
+	 * But loading thread is not in its binary, exclude those data
+	 * for calculating the heap usage per threads.
+	 */
+	int hashpid = PIDHASH(getpid());
+	binp->uheap->alloc_list[hashpid].pid = HEAPINFO_INIT_INFO;
+	binp->uheap->alloc_list[hashpid].curr_alloc_size = 0;
+	binp->uheap->alloc_list[hashpid].num_alloc_free = 0;
+#endif
+
 	/* We can free the argument buffer now.
 	 * REVISIT:  It is good to free up memory as soon as possible, but
 	 * unfortunately here 'binp' is 'const'.  So to do this properly, we will

--- a/os/binfmt/libelf/libelf_load.c
+++ b/os/binfmt/libelf/libelf_load.c
@@ -353,17 +353,10 @@ int elf_load(FAR struct elf_loadinfo_s *loadinfo)
 #endif
 
 #if defined(CONFIG_DEBUG_MM_HEAPINFO) && defined(CONFIG_APP_BINARY_SEPARATION)
-	/* Re-initialize the binary heap information.
-	 * Because, binary heap contains text and data region size,
-	 * but those should not be calculated for heap usage.
+	/* Save the text and data region size of new binary into its heap
+	 * for excluding those size when calculating the heap usage.
 	 */
-	pid_t pid = getpid();
-	pid_t hashpid = PIDHASH(pid);
-
 	loadinfo->uheap->elf_sections_size = loadinfo->textsize + loadinfo->datasize;
-
-	loadinfo->uheap->alloc_list[hashpid].curr_alloc_size = 0;
-	loadinfo->uheap->alloc_list[hashpid].num_alloc_free = 0;
 
 	loadinfo->uheap->total_alloc_size = 0;
 	loadinfo->uheap->peak_alloc_size = 0;


### PR DESCRIPTION
Loading thread uses the binary's heap for loading, so it saves the alloc data in binary's heap.
But loading thread is not in its binary, exclude those data for calculating the heap usage per threads.