### PR TITLE
loadable_apps: pass loadable_apps' path

### DIFF
--- a/loadable_apps/Makefile
+++ b/loadable_apps/Makefile
@@ -63,7 +63,7 @@ $(foreach BDIR, $(BUILDIRS), $(eval $(call ADD_APPS,$(BDIR))))
 
 define DIR_template
 $(1)_$(2):
-	$(Q) $(MAKE) -C $(1) $(2) TOPDIR="$(TOPDIR)" USER_BIN_DIR="$(OUTPUT_BIN_DIR)" CROSSDEV=$(CROSSDEV)
+	$(Q) $(MAKE) -C $(1) $(2) TOPDIR="$(TOPDIR)" LOADABLEDIR="${LOADABLEDIR}" USER_BIN_DIR="$(OUTPUT_BIN_DIR)" CROSSDEV=$(CROSSDEV)
 endef
 $(foreach BDIR, $(CONFIGURED), $(eval $(call DIR_template,$(BDIR),context)))
 $(foreach BDIR, $(CONFIGURED), $(eval $(call DIR_template,$(BDIR),all)))

--- a/loadable_apps/loadable_sample/Makefile
+++ b/loadable_apps/loadable_sample/Makefile
@@ -61,7 +61,7 @@ all: nothing
 
 define SDIR_template
 $(1)_$(2):
-	$(Q) $(MAKE) -C $(1) $(2) TOPDIR="$(TOPDIR)"
+	$(Q) $(MAKE) -C $(1) $(2) TOPDIR="$(TOPDIR)" LOADABLEDIR="$(LOADABLEDIR)"
 endef
 
 $(foreach SDIR, $(SUBDIRS), $(eval $(call SDIR_template,$(SDIR),preconfig)))

--- a/loadable_apps/loadable_sample/micomapp/Makefile
+++ b/loadable_apps/loadable_sample/micomapp/Makefile
@@ -76,7 +76,7 @@ KERNEL_VER = 2.0
 STACKSIZE = 4096
 PRIORITY = 220
 
-include $(TOPDIR)/../loadable_apps/loadable.mk
+include $(TOPDIR)/$(LOADABLEDIR)/loadable.mk
 
 ###################################
 # Cases of Flat and Protected build

--- a/loadable_apps/loadable_sample/wifiapp/Makefile
+++ b/loadable_apps/loadable_sample/wifiapp/Makefile
@@ -75,7 +75,7 @@ KERNEL_VER = 2.0
 STACKSIZE = 8192
 PRIORITY = 180
 
-include $(TOPDIR)/../loadable_apps/loadable.mk
+include $(TOPDIR)/$(LOADABLEDIR)/loadable.mk
 
 ###################################
 # Cases of Flat and Protected build

--- a/os/Makefile.unix
+++ b/os/Makefile.unix
@@ -457,7 +457,7 @@ ifeq ($(CONFIG_BUILD_2PASS),y)
 	fi
 	$(call DELFILE, $(PASS1_BUILDIR)/up_userspace.o)
 	$(Q) $(MAKE) -C $(PASS1_BUILDIR) TOPDIR="$(TOPDIR)" LINKLIBS="$(LINKLIBS)" USERLIBS="$(USERLIBS)" "$(CONFIG_PASS1_TARGET)"
-	$(Q) $(MAKE) -C $(LOADABLE_APPDIR) TOPDIR="$(TOPDIR)" EXTDIR="$(EXTDIR)" LIBRARIES_DIR="$(LIBRARIES_DIR)" USERLIBS="$(USERLIBS)" all KERNEL=n
+	$(Q) $(MAKE) -C $(LOADABLE_APPDIR) TOPDIR="$(TOPDIR)" LOADABLEDIR="${LOADABLE_APPDIR}" LIBRARIES_DIR="$(LIBRARIES_DIR)" USERLIBS="$(USERLIBS)" all KERNEL=n
 endif
 
 pass2deps: pass2dep $(TINYARALIBS)
@@ -600,12 +600,12 @@ depend: pass1dep pass2dep
 subdir_clean:
 	$(Q) for dir in $(CLEANDIRS) ; do \
 		if [ -e $$dir/Makefile ]; then \
-			$(MAKE) -C $$dir TOPDIR="$(TOPDIR)" EXTDIR="$(EXTDIR)" clean ; \
+			$(MAKE) -C $$dir TOPDIR="$(TOPDIR)" EXTDIR="$(EXTDIR)" LOADABLEDIR="${LOADABLE_APPDIR}" clean ; \
 		fi \
 	done
 	$(Q) $(MAKE) -C tools -f Makefile.host TOPDIR="$(TOPDIR)" clean
 ifeq ($(CONFIG_BUILD_2PASS),y)
-	$(Q) $(MAKE) -C $(PASS1_BUILDIR) TOPDIR="$(TOPDIR)" EXTDIR="$(EXTDIR)" clean
+	$(Q) $(MAKE) -C $(PASS1_BUILDIR) TOPDIR="$(TOPDIR)" EXTDIR="$(EXTDIR)" LOADABLEDIR="${LOADABLE_APPDIR}" clean
 endif
 
 clean: subdir_clean
@@ -619,7 +619,7 @@ clean: subdir_clean
 subdir_distclean:
 	$(Q) for dir in $(CLEANDIRS) ; do \
 		if [ -e $$dir/Makefile ]; then \
-			$(MAKE) -C $$dir TOPDIR="$(TOPDIR)" EXTDIR="$(EXTDIR)" distclean ; \
+			$(MAKE) -C $$dir TOPDIR="$(TOPDIR)" EXTDIR="$(EXTDIR)" LOADABLEDIR="${LOADABLE_APPDIR}" distclean ; \
 		fi \
 	done
 


### PR DESCRIPTION
External folder path is not used and loadable_apps' path is necessary.
This commit passes the loadable_apps folder path instead of EXTDIR.

Signed-off-by: sunghan-chang <sh924.chang@samsung.com>