### PR TITLE
framework/task_manager : Remove 'select workqueue config' in Kconfig

### DIFF
--- a/framework/src/task_manager/Kconfig
+++ b/framework/src/task_manager/Kconfig
@@ -7,8 +7,6 @@ config TASK_MANAGER
 	bool "Enable Task Manager"
 	default n
 	select SCHED_ATEXIT
-	select SCHED_WORKQUEUE if !BUILD_PROTECTED
-	select SCHED_USRWORK if BUILD_PROTECTED
 	depends on !DISABLE_SIGNALS && !DISABLE_MQUEUE && TASK_NAME_SIZE != 0
 	---help---
 		Enables Task Manager.


### PR DESCRIPTION
Since task_manager does not use workqueue,
there is no need to select work queue config.