### PR TITLE
os/Makefile : Move command for deleting the built-in registry file

### DIFF
--- a/os/Makefile.unix
+++ b/os/Makefile.unix
@@ -385,10 +385,10 @@ context: check_context include/tinyara/config.h include/tinyara/version.h includ
 		echo "Previous Build Outputs - $(OUTBIN_DIR) - are deleted"; \
 		rm -rf ${OUTBIN_DIR}/*; \
 	fi
+	$(call DELFILE, $(APPDIR)/builtin/registry/*.?dat)
 	$(Q) for dir in $(CONTEXTDIRS) ; do \
 		$(MAKE) -C $$dir TOPDIR="$(TOPDIR)" EXTDIR="$(EXTDIR)" context; \
 	done
-	$(call DELFILE, $(APPDIR)/builtin/registry/*.?dat)
 	$(Q) ./tools/mkldscript.sh
 
 # clean_context

--- a/os/Makefile.win
+++ b/os/Makefile.win
@@ -384,8 +384,8 @@ context: check_context include\tinyara\config.h include\tinyara\version.h includ
 		echo "Previous Build Outputs - $(OUTBIN_DIR) - are deleted"
 		$(call DELFILE, $(OUTBIN_DIR)\*.*)
 	)
-	$(Q) for %%G in ($(CONTEXTDIRS)) do ( $(MAKE) -C %%G TOPDIR="$(TOPDIR)" context )
 	$(call DELFILE, $(APPDIR)\builtin\registry\*.?dat)
+	$(Q) for %%G in ($(CONTEXTDIRS)) do ( $(MAKE) -C %%G TOPDIR="$(TOPDIR)" context )
 
 # clean_context
 #


### PR DESCRIPTION
For deleting the previous built *dat file in built-in registry, this command is needed.
But if it is in previous line, *dat files are deleted after generating from contextdir.