### PR TITLE
os/wqueue : Enable interrupts at the end of work process

### DIFF
--- a/os/wqueue/work_process.c
+++ b/os/wqueue/work_process.c
@@ -271,8 +271,6 @@ void work_process(FAR struct wqueue_s *wqueue, int wndx)
 		wqueue->delay = 0;
 #if defined(CONFIG_SCHED_USRWORK) && !defined(__KERNEL__)
 		work_unlock();
-#else
-		irqrestore(flags);
 #endif
 		/* Wait indefinitely until signalled with SIGWORK */
 		wqueue->worker[wndx].busy = false;
@@ -301,19 +299,19 @@ void work_process(FAR struct wqueue_s *wqueue, int wndx)
 			*/
 #if defined(CONFIG_SCHED_USRWORK) && !defined(__KERNEL__)
 		work_unlock();
-#else
-		irqrestore(flags);
 #endif
 		wqueue->worker[wndx].busy = false;
 		usleep(next * USEC_PER_TICK);
 		wqueue->worker[wndx].busy = true;
-	} else {
-#if defined(CONFIG_SCHED_USRWORK) && !defined(__KERNEL__)
-		work_unlock();
-#else
-		irqrestore(flags);
-#endif
 	}
+#if defined(CONFIG_SCHED_USRWORK) && !defined(__KERNEL__)
+	else {
+		work_unlock();
+	}
+#else
+	irqrestore(flags);
+#endif
+
 }
 
 #endif							/* CONFIG_SCHED_WORKQUEUE */


### PR DESCRIPTION
The irqrestore is not needed before sigwait or usleep because
the context switch occurs during sigwait or usleep.