### PR TITLE
binfmt/libelf: Optimize elf loading by caching frequently accessed area

### DIFF
--- a/os/binfmt/libelf/Kconfig
+++ b/os/binfmt/libelf/Kconfig
@@ -60,7 +60,6 @@ config ELF_CACHE_READ
         bool "ELF cache read support"
         default n
         depends on BINFMT_ENABLE
-        depends on !COMPRESSED_BINARY
         ---help---
 		Enabling this config would increase the elf read performance by
 		manyfolds with its caching mechanism.
@@ -69,8 +68,6 @@ config ELF_CACHE_READ
 		same position multiple times, then there would be a considerable delay.
 		Enabling this config will cache/buffer the previously accessed data.
 
-		Note: If COMPRESSED_BINARY=y, then this config should be disabled, as
-		by default COMPRESSED_BINARY config would support caching inbuilt.
 
 if ELF_CACHE_READ
 
@@ -80,6 +77,10 @@ config ELF_CACHE_BLOCK_SIZE
         range 512 8192
         ---help---
                 Enter block size to use for caching the elf read.
+
+                Note: For compressed binaries, Make sure the cache block size, should be
+                      greater than or equal to compression block size. Which would
+                      yield good read performance during caching
 
 config ELF_CACHE_BLOCKS_COUNT
         int "Number of Blocks to be cached when reading elf"

--- a/os/binfmt/libelf/Kconfig
+++ b/os/binfmt/libelf/Kconfig
@@ -55,3 +55,37 @@ config ELF_EXCLUDE_SYMBOLS
 	---help---
 		If this option is enabled, then it excludes symbol information from the ELF
 		and results in a ELF of much smaller size.
+
+config ELF_CACHE_READ
+        bool "ELF cache read support"
+        default n
+        depends on BINFMT_ENABLE
+        depends on !COMPRESSED_BINARY
+        ---help---
+		Enabling this config would increase the elf read performance by
+		manyfolds with its caching mechanism.
+
+		If an elf_read taking more time and consistently trying to read the
+		same position multiple times, then there would be a considerable delay.
+		Enabling this config will cache/buffer the previously accessed data.
+
+		Note: If COMPRESSED_BINARY=y, then this config should be disabled, as
+		by default COMPRESSED_BINARY config would support caching inbuilt.
+
+if ELF_CACHE_READ
+
+config ELF_CACHE_BLOCK_SIZE
+        int "Block size for elf read caching"
+        default 2048
+        range 512 8192
+        ---help---
+                Enter block size to use for caching the elf read.
+
+config ELF_CACHE_BLOCKS_COUNT
+        int "Number of Blocks to be cached when reading elf"
+        default 60
+        range 2 100
+        ---help---
+                Enter the number of blocks(counts) to use for caching.
+
+endif # ELF_CACHE_READ

--- a/os/binfmt/libelf/Make.defs
+++ b/os/binfmt/libelf/Make.defs
@@ -66,6 +66,9 @@ ifeq ($(CONFIG_BINFMT_CONSTRUCTORS),y)
 BINFMT_CSRCS += libelf_ctors.c libelf_dtors.c
 endif
 
+ifeq ($(CONFIG_ELF_CACHE_READ),y)
+BINFMT_CSRCS += libelf_cache.c
+endif
 # Hook the libelf subdirectory into the build
 
 VPATH += libelf

--- a/os/binfmt/libelf/libelf.h
+++ b/os/binfmt/libelf/libelf.h
@@ -357,4 +357,55 @@ int elf_addrenv_alloc(FAR struct elf_loadinfo_s *loadinfo, size_t textsize, size
 
 void elf_addrenv_free(FAR struct elf_loadinfo_s *loadinfo);
 
+#ifdef CONFIG_ELF_CACHE_READ
+
+/* Struct for output buffers to cache uncompressed blocks */
+struct block_cache_s {
+	unsigned char *out_buffer;              /* Buffer that is going to hold uncompressed data */
+	int block_number;                       /* Block number in compressed file for the cached block */
+	unsigned int no_requests_for_block;     /* Number of requests for current block that is cached */
+	unsigned int index_block_cache;         /* Index of block cache in the array */
+	struct block_cache_s *next;             /* Pointer to next element in doubly linked list */
+	struct block_cache_s *prev;             /* Pointer to previous element in doubly linked list */
+};
+typedef struct block_cache_s block_cache_t;
+
+/****************************************************************************
+ * Name: elf_cache_uninit
+ *
+ * Description:
+ *   Release cache buffers initialized during elf_cache_init
+ *
+ * Returned Value:
+ *   None
+ ****************************************************************************/
+void elf_cache_uninit(void);
+
+/****************************************************************************
+ * Name: elf_cache_init
+ *
+ * Description:
+ *   Initialize the cache blocks
+ *
+ * Returned value:
+ *   OK (0) on Success
+ *   ERROR (-1) on Failure
+ ****************************************************************************/
+int elf_cache_init(int filfd, uint16_t offset, off_t *filelen);
+
+/****************************************************************************
+ * Name: elf_cache_read
+ *
+ * Description:
+ *   Read n-bytes from the elf file using 'offset' and 'readsize' info
+ *   The data is read into 'buffer' pointer. Offset value here is offset from
+ *   start of elf binary (excluding binary header).
+ *
+ * Returned Value:
+ *   Number of bytes read into buffer on Success
+ *   Negative value on failure
+ ****************************************************************************/
+int elf_cache_read(int filfd, uint16_t binary_header_size, FAR uint8_t *buffer, size_t readsize, off_t offset);
+#endif
+
 #endif							/* __BINFMT_LIBELF_LIBELF_H */

--- a/os/binfmt/libelf/libelf.h
+++ b/os/binfmt/libelf/libelf.h
@@ -391,7 +391,7 @@ void elf_cache_uninit(void);
  *   OK (0) on Success
  *   ERROR (-1) on Failure
  ****************************************************************************/
-int elf_cache_init(int filfd, uint16_t offset, off_t *filelen);
+int elf_cache_init(int filfd, uint16_t offset, off_t filelen, uint8_t compression_type);
 
 /****************************************************************************
  * Name: elf_cache_read

--- a/os/binfmt/libelf/libelf_cache.c
+++ b/os/binfmt/libelf/libelf_cache.c
@@ -1,0 +1,502 @@
+/****************************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+#include <tinyara/config.h>
+
+#include <sys/types.h>
+#include <stdint.h>
+#include <unistd.h>
+#include <string.h>
+#include <debug.h>
+#include <errno.h>
+
+#include <tinyara/fs/fs.h>
+#include "libelf.h"
+
+/****************************************************************************
+ * Private Declarations
+ ****************************************************************************/
+
+/* Number of blocks to be caching */
+static unsigned int number_blocks_caching;
+
+/* Size of each blocks for caching */
+static unsigned int cache_blocks_size;
+
+/* Length of file w/o binary header */
+static unsigned int file_len;
+
+/* Number of blocks for caching */
+static unsigned int number_of_blocks;
+
+/* Pointer to block_cache_t list to be used for holding ELF blocks */
+static block_cache_t *blockcache;
+
+/* Pointers for maintaining doubly linked list of blockcache */
+static block_cache_t *head;		/* Pointer to least priority block for caching */
+static block_cache_t *tail;		/* Pointer to highest priority block for caching */
+static block_cache_t *most_accessed;	/* Pointer to most accessed block for quick access */
+
+/* Number of requests for the most accessed block in blockcache list */
+static unsigned int max_accessed_count;
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: elf_cache_blocks_to_read
+ *
+ * Description:
+ *   Assign values to first_block, last_block and number of blocks to be read
+ *   from elf file in this particular call to elf_cache_read
+ *
+ * Returned Value:
+ *   None
+ ****************************************************************************/
+static void elf_cache_blocks_to_read(int *first_block, int *last_block, int *no_blocks, int offset, int readsize)
+{
+	int blocksize;
+
+	blocksize = cache_blocks_size;
+
+	*first_block = offset / blocksize;
+	*last_block = (offset + readsize) / blocksize;
+	*no_blocks = *last_block - *first_block + 1;
+}
+
+/****************************************************************************
+ * Name: elf_cache_lseek_block
+ *
+ * Description:
+ *   Seek to start of "block_number" block in elf blocks section
+ *
+ * Returned Value:
+ *   Starting offset (positive) of 'block_number' block in binary on Success
+ *   Negative value on Failure
+ ****************************************************************************/
+static off_t elf_cache_lseek_block(int filfd, uint16_t binary_header_size, int block_number)
+{
+	off_t rpos;
+	off_t actual_offset;
+
+	actual_offset = binary_header_size + block_number * cache_blocks_size;;
+
+	/* Seek to location of this block in actual ELF file */
+	rpos = lseek(filfd, actual_offset, SEEK_SET);
+
+	binfo("filfd: %d actual_offset: %d rpos: %d\n", filfd, actual_offset, rpos);
+
+	if (rpos != actual_offset) {
+		int errval = get_errno();
+		berr("Failed to seek to position %lu: %d\n", (unsigned long)actual_offset, errval);
+		return -errval;
+	}
+
+	return rpos;
+}
+
+/****************************************************************************
+ * Name: elf_cache_read_block
+ *
+ * Description:
+ *   Read 'block_number' block from elf blocks section into
+ *   provided respective block numbers 'out_buffer' variable.
+ *
+ * Returned Value:
+ *   Number of bytes read into out_buffer on Success
+ *   Negative value on Failure
+ ****************************************************************************/
+static off_t elf_cache_read_block(int filfd, uint16_t binary_header_size, FAR uint8_t *buf, int block_number)
+{
+	off_t rpos;
+	size_t readsize;
+	ssize_t nbytes;
+
+	binfo("filfd: %d block_number: %d binary_header_size: %d\n", filfd, block_number, binary_header_size);
+
+	/* Seek to location of 'block_number' block in elf file */
+	rpos = elf_cache_lseek_block(filfd, binary_header_size, block_number);
+
+	if (rpos < 0) {
+		berr("Failed to seek to offset of block number %d\n", block_number);
+		return rpos;
+	}
+
+	/* Last unaligned blocks to be read with its actual size and not with blocksize;*/
+	if (block_number == number_of_blocks - 1) {
+		readsize = file_len % cache_blocks_size;
+	} else {
+		readsize = cache_blocks_size;
+	}
+
+	/* Read actual data to 'block_number's buf */
+	nbytes = read(filfd, buf, readsize);
+
+	binfo("readsize: %d nbytes: %d rpos: %d\n", readsize, nbytes, rpos);
+
+	if (nbytes != readsize) {
+		int errval = get_errno();
+		berr("Read failed for size (%d) errno(%d)\n", readsize, errval);
+		return -errval;
+	}
+
+	return nbytes;
+}
+
+/****************************************************************************
+ * Name: elf_cache_update_blockcache_list
+ *
+ * Description:
+ *   Update blockcache list based on whether 'block_number' block in
+ *   blockwise-elf binary is already cached or not. Also, maintain
+ *   head, tail and most_accessed pointers.
+ *   tail = most recently cached block (highest priority block for keeping
+ *          cached)
+ *   head = oldest cached block (lowest priority for keeping it cached).
+ *          If a new block needs to be cached, cache to this blockcache element.
+ *   most_accessed = pointer to most accessed block in blockcache list.
+ *          Needed for easy access to most accessed block from comp. binary.
+ *
+ * Returned Value:
+ *   Index in blockcache list where 'block_number' from elf
+ *   binary is cached state. Return Negative value on failure.
+ ****************************************************************************/
+static unsigned int elf_cache_update_blockcache_list(int block_number, int filfd, uint16_t binary_header_size)
+{
+	unsigned int blockcache_index;		/* Which blockcache element has needed ELF data for read */
+	block_cache_t *ptr;					/* Pointer to element in blockcache list which will be updated */
+	block_cache_t *temp;				/* Used when updating blockcache list */
+	bool flag_for_caching;				/* 1 = Block needs to be cached, 0 = Block already cached */
+	bool update_most_accessed;			/* 1 = Most accessed block is being removed from blockcache.
+										 *     Need to update most accessed pointer from scratch */
+	int size;
+
+	binfo("filfd: %d block_number: %d\n", filfd, block_number);
+
+	/* Initialize flags */
+	flag_for_caching = true;
+	update_most_accessed = false;
+
+	/* First check is with block_number at most_accessed pointer */
+	if (most_accessed->block_number == block_number) {
+		flag_for_caching = false;
+		blockcache_index = most_accessed->index_block_cache;
+	}
+
+	/* Start checking for if block is cached from the tail */
+	if (flag_for_caching == true) {
+		ptr = tail;
+		while (ptr != NULL) {
+			if (ptr->block_number == block_number) {
+				flag_for_caching = false;
+				blockcache_index = ptr->index_block_cache;
+				break;
+			} else {
+				ptr = ptr->prev;
+			}
+		}
+	}
+
+	/* If block_number block from elf binary needs to be cached */
+	if (flag_for_caching == true) {
+
+		/* If most_accessed == head, need to update most_accessed */
+		if (head == most_accessed)
+			update_most_accessed = true;
+
+		/* Detach head, Reassign head to head->next */
+		ptr = head;
+		head = ptr->next;
+		head->prev = ptr->prev;
+
+		/* Read elf 'block_number' block into respective 'out_buffer' */
+		size = elf_cache_read_block(filfd, binary_header_size, ptr->out_buffer, block_number);
+		if (size < 0) {
+			berr("Read for block %d failed\n", block_number);
+			return ERROR;
+		}
+
+		/* Update block_number, Number of requests */
+		ptr->block_number = block_number;
+		ptr->no_requests_for_block = 1;
+
+		/* Updating most_accessed pointer */
+		if (ptr->no_requests_for_block >= max_accessed_count) {
+			max_accessed_count = ptr->no_requests_for_block;
+			most_accessed = ptr;
+		}
+
+		/* Always attach ptr at tail */
+		temp = tail;
+		temp->next = ptr;
+		ptr->prev = temp;
+		ptr->next = NULL;
+		tail = ptr;
+
+		/* Update most_accessed from scratch, if needed */
+		if (update_most_accessed == true) {
+			max_accessed_count = 0;
+			temp = tail;
+			while (temp != NULL) {
+				if (temp->no_requests_for_block > max_accessed_count) {
+					max_accessed_count = temp->no_requests_for_block;
+					most_accessed = temp;
+				}
+				temp = temp->prev;
+			}
+		}
+
+		/* Update blockcache_index into which block is cached */
+		blockcache_index = ptr->index_block_cache;
+
+	} else { /* If block is already cached */
+
+		/* If block is cached at head location */
+		if (head == &blockcache[blockcache_index]) {
+			/* Detach head, Reassign head to head->next */
+			ptr = head;
+			head = ptr->next;
+			head->prev = ptr->prev;
+
+			ptr->no_requests_for_block += 1;
+
+			/* Update most_accessed pointer */
+			if (ptr->no_requests_for_block >= max_accessed_count) {
+				max_accessed_count = ptr->no_requests_for_block;
+				most_accessed = ptr;
+			}
+
+			/* Always attach ptr at tail */
+			temp = tail;
+			temp->next = ptr;
+			ptr->prev = temp;
+			ptr->next = NULL;
+			tail = ptr;
+
+		} else if (tail == &blockcache[blockcache_index]) { /* Block is cached at tail location */
+			blockcache[blockcache_index].no_requests_for_block += 1;
+
+			/* Update most_accessed pointer */
+			ptr = tail;
+			if (ptr->no_requests_for_block >= max_accessed_count) {
+				max_accessed_count = ptr->no_requests_for_block;
+				most_accessed = ptr;
+			}
+		} else { /* Block is cached at some other index in blockcache list */
+
+			/* Detach blockcache element at blockcache_index */
+			ptr = &blockcache[blockcache_index];
+			ptr->prev->next = ptr->next;
+			ptr->next->prev = ptr->prev;
+
+			/* Update Number of requests for block */
+			ptr->no_requests_for_block += 1;
+
+			/* Update most accessed pointer */
+			if (ptr->no_requests_for_block >= max_accessed_count) {
+				max_accessed_count = ptr->no_requests_for_block;
+				most_accessed = ptr;
+			}
+
+			/* Always attach ptr at tail */
+			temp = tail;
+			temp->next = ptr;
+			ptr->prev = temp;
+			ptr->next = NULL;
+			tail = ptr;
+		}
+	}
+
+	return blockcache_index;
+}
+
+/****************************************************************************
+ * Name: elf_cache_read
+ *
+ * Description:
+ *   Read bytes from the elf file using 'offset' and 'readsize' info
+ *   provided for cached buffer.  The data is read into 'buffer'. Offset
+ *   value here is offset from start of elf binary (excluding binary
+ *   header).
+ *
+ * Returned Value:
+ *   Number of bytes read into buffer on Success
+ *   Negative value on failure
+ ****************************************************************************/
+int elf_cache_read(int filfd, uint16_t binary_header_size, FAR uint8_t *buffer, size_t readsize, off_t offset)
+{
+	int first_block;
+	int last_block;
+	int no_blocks;
+	int block_number;		/* Block number in an ELF file */
+	int actual_offset;		/* Offset from start of ELF file */
+	int block_size_to_write;	/* Size to write into buffer from cached block */
+	int buffer_pos;			/* Position in buffer to start writing from */
+	int blocksize;			/* Blocksize used for compressing the binary */
+	unsigned int blockcache_index;	/* Which blockcache element has needed ELF data for read */
+
+	binfo("filfd: %d readsize: %d offset: %d\n", filfd, readsize, offset);
+
+	/* Setting first block, end block and number of blocks to read */
+	blocksize = cache_blocks_size;
+	elf_cache_blocks_to_read(&first_block, &last_block, &no_blocks, offset, readsize);
+	if (first_block < 0 || no_blocks < 0) {
+		berr("Incorrect first_block, no_blocks info\n");
+		buffer_pos = ERROR;
+		goto error_cache_read;
+	}
+
+	block_number = first_block;
+	buffer_pos = 0;
+	/* Actual Offset in ELF file is same as Offset passed to this function */
+	actual_offset = offset;
+
+	/* Reading and decompressing blocks from first_block to last_block. Then writing to buffer. */
+	for (; block_number < first_block + no_blocks; block_number++) {
+
+		/* Update blockcache list and get data into one of the blockcache elements */
+		blockcache_index = elf_cache_update_blockcache_list(block_number, filfd, binary_header_size);
+		if (blockcache_index >= number_blocks_caching) {
+			buffer_pos = ERROR;
+			goto error_cache_read;
+		}
+
+		if (block_number == first_block) {
+			/*
+			 * Read appropriate number of bytes to buffer from this block using readsize and offset info.
+			 * If start_offset + readsize < end_offset, write from start_offset to start_offset + readsize.
+			 * Otherwise, write from start_offset to end_offset into buffer.
+			 */
+			block_size_to_write = (((block_number + 1) * blocksize - 1) > (actual_offset + readsize - 1)) ? readsize : ((block_number + 1) * blocksize - actual_offset);
+			memcpy(&buffer[buffer_pos], &blockcache[blockcache_index].out_buffer[actual_offset - (block_number * blocksize)], block_size_to_write);
+			buffer_pos += block_size_to_write;
+		} else if (block_number == last_block) {
+			/*
+			 * Read appropriate number of bytes to buffer from this block using readsize and offset info.
+			 * Calculate end_offset (Offset of last byte to write from this block).
+			 * Write from start_offset to end_offset from this block into buffer.
+			 */
+			block_size_to_write = actual_offset + readsize - (block_number * blocksize);
+			memcpy(&buffer[buffer_pos], &blockcache[blockcache_index].out_buffer[0], block_size_to_write);
+			buffer_pos += block_size_to_write;
+		} else {
+			/*
+			 * This is not the first or last block. This is intermediary block.
+			 * So, write entire block into buffer.
+			 */
+			block_size_to_write = blocksize;
+			memcpy(&buffer[buffer_pos], &blockcache[blockcache_index].out_buffer[0], block_size_to_write);
+			buffer_pos += block_size_to_write;
+		}
+	}
+
+error_cache_read:
+	return buffer_pos;
+}
+
+/****************************************************************************
+ * Name: elf_cache_init
+ *
+ * Description:
+ *   IInitialize the cache blocks
+ *
+ * Returned value:
+ *   OK (0) on Success
+ *   Negative value on Failure
+ ****************************************************************************/
+int elf_cache_init(int filfd, uint16_t offset, off_t *filelen)
+{
+	int ret = OK;
+
+	binfo("filfd: %d offset: %d filelen: %d\n", filfd, offset, *filelen);
+
+	/* Initialize the ELF params */
+	number_blocks_caching = CONFIG_ELF_CACHE_BLOCKS_COUNT;
+	cache_blocks_size = CONFIG_ELF_CACHE_BLOCK_SIZE;
+	file_len = *filelen;
+	number_of_blocks = file_len / cache_blocks_size;
+
+	/* Extra unaligned data apart from blocksize */
+	if (file_len % cache_blocks_size)
+		number_of_blocks++;
+
+	/* Initialize max_accesed_count to 0 */
+	max_accessed_count = 0;
+
+	blockcache = (block_cache_t *)kmm_malloc(number_blocks_caching * sizeof(block_cache_t));
+	if (!blockcache) {
+		berr("Failed kmm_malloc for blockcache\n");
+		elf_cache_uninit();
+		return -ENOMEM;
+	}
+
+	/* Initialize blockcache list */
+	for (int i = 0; i < number_blocks_caching; i++) {
+		blockcache[i].out_buffer = (unsigned char *)kmm_malloc(cache_blocks_size);
+
+		if (!blockcache[i].out_buffer) {
+			berr("Failed kmm_malloc for blockcache's out_buffer\n");
+			elf_cache_uninit();
+			return -ENOMEM;
+		}
+
+		blockcache[i].block_number = -1;
+		blockcache[i].no_requests_for_block = 0;
+		blockcache[i].index_block_cache = i;
+		blockcache[i].next = &blockcache[(i + 1) % number_blocks_caching];
+		blockcache[i].prev = &blockcache[(i - 1) % number_blocks_caching];
+	}
+
+	/* Assign head, tail and most_accessed pointers */
+	head = &blockcache[0];
+	tail = &blockcache[number_blocks_caching - 1];
+	most_accessed = tail;
+
+	head->prev = NULL;
+	tail->next = NULL;
+
+	return ret;
+}
+
+/****************************************************************************
+ * Name: elf_cache_uninit
+ *
+ * Description:
+ *   Release buffers initialized during elf_cache_init
+ *
+ * Returned Value:
+ *   None
+ ****************************************************************************/
+void elf_cache_uninit(void)
+{
+	for (int i = 0; i < number_blocks_caching; i++) {
+		if (blockcache[i].out_buffer) {
+			kmm_free(blockcache[i].out_buffer);
+			blockcache[i].out_buffer = NULL;
+		}
+	}
+
+	if (blockcache) {
+		kmm_free(blockcache);
+		blockcache = NULL;
+	}
+}

--- a/os/binfmt/libelf/libelf_init.c
+++ b/os/binfmt/libelf/libelf_init.c
@@ -185,6 +185,15 @@ int elf_init(FAR const char *filename, FAR struct elf_loadinfo_s *loadinfo)
 		return ret;
 	}
 
+#if defined(CONFIG_ELF_CACHE_READ) && !defined(CONFIG_COMPRESSED_BINARY)
+	if (loadinfo->compression_type == COMPRESS_TYPE_NONE) {
+		ret = elf_cache_init(loadinfo->filfd, loadinfo->offset, &loadinfo->filelen);
+		if (ret != OK) {
+			berr("Failed to init cache support: %d\n", ret);
+			return ret;
+		}
+	} else
+#endif
 	if (loadinfo->compression_type > COMPRESS_TYPE_NONE) {
 #ifdef CONFIG_COMPRESSED_BINARY
 		ret = compress_init(loadinfo->filfd, loadinfo->offset, &loadinfo->filelen);

--- a/os/binfmt/libelf/libelf_init.c
+++ b/os/binfmt/libelf/libelf_init.c
@@ -185,15 +185,6 @@ int elf_init(FAR const char *filename, FAR struct elf_loadinfo_s *loadinfo)
 		return ret;
 	}
 
-#if defined(CONFIG_ELF_CACHE_READ) && !defined(CONFIG_COMPRESSED_BINARY)
-	if (loadinfo->compression_type == COMPRESS_TYPE_NONE) {
-		ret = elf_cache_init(loadinfo->filfd, loadinfo->offset, &loadinfo->filelen);
-		if (ret != OK) {
-			berr("Failed to init cache support: %d\n", ret);
-			return ret;
-		}
-	} else
-#endif
 	if (loadinfo->compression_type > COMPRESS_TYPE_NONE) {
 #ifdef CONFIG_COMPRESSED_BINARY
 		ret = compress_init(loadinfo->filfd, loadinfo->offset, &loadinfo->filelen);
@@ -207,8 +198,15 @@ int elf_init(FAR const char *filename, FAR struct elf_loadinfo_s *loadinfo)
 #endif
 	}
 
-	/* Read the ELF ehdr from offset 0 */
+#if defined(CONFIG_ELF_CACHE_READ)
+	ret = elf_cache_init(loadinfo->filfd, loadinfo->offset, loadinfo->filelen, loadinfo->compression_type);
+	if (ret != OK) {
+		berr("Failed to init cache support: %d\n", ret);
+		return ret;
+	}
+#endif
 
+	/* Read the ELF ehdr from offset 0 */
 	ret = elf_read(loadinfo, (FAR uint8_t *)&loadinfo->ehdr, sizeof(Elf32_Ehdr), 0);
 	if (ret < 0) {
 		berr("Failed to read ELF header: %d\n", ret);

--- a/os/binfmt/libelf/libelf_read.c
+++ b/os/binfmt/libelf/libelf_read.c
@@ -140,7 +140,7 @@ int elf_read(FAR struct elf_loadinfo_s *loadinfo, FAR uint8_t *buffer, size_t re
 
 	while (readsize > 0) {
 		if (loadinfo->compression_type == COMPRESS_TYPE_NONE) {	/* Uncompressed binary */
-#if defined(CONFIG_ELF_CACHE_READ) && !defined(CONFIG_COMPRESSED_BINARY)
+#if defined(CONFIG_ELF_CACHE_READ)
 			nbytes = elf_cache_read(loadinfo->filfd, loadinfo->offset, buffer, readsize, offset - loadinfo->offset);
 #else
 			/* Seek to the next read position */
@@ -153,15 +153,17 @@ int elf_read(FAR struct elf_loadinfo_s *loadinfo, FAR uint8_t *buffer, size_t re
 			}
 
 			/* Read the file data at offset into the user buffer */
-
 			nbytes = read(loadinfo->filfd, buffer, readsize);
 #endif
 		} else if (loadinfo->compression_type > COMPRESS_TYPE_NONE) {	/* Compressed binary */
 #ifdef CONFIG_COMPRESSED_BINARY
 			if (loadinfo->compression_type == CONFIG_COMPRESSION_TYPE) {
 				/* Read readsize bytes from offset from uncompressed file into unser buffer */
-
+#if defined(CONFIG_ELF_CACHE_READ)
+				nbytes = elf_cache_read(loadinfo->filfd, loadinfo->offset, buffer, readsize, offset - loadinfo->offset);
+#else
 				nbytes = compress_read(loadinfo->filfd, loadinfo->offset, buffer, readsize, offset - loadinfo->offset);
+#endif
 			} else {
 				berr("No support for decompression of compression format %d of this binary\n", loadinfo->compression_type);
 			}

--- a/os/binfmt/libelf/libelf_read.c
+++ b/os/binfmt/libelf/libelf_read.c
@@ -140,6 +140,9 @@ int elf_read(FAR struct elf_loadinfo_s *loadinfo, FAR uint8_t *buffer, size_t re
 
 	while (readsize > 0) {
 		if (loadinfo->compression_type == COMPRESS_TYPE_NONE) {	/* Uncompressed binary */
+#if defined(CONFIG_ELF_CACHE_READ) && !defined(CONFIG_COMPRESSED_BINARY)
+			nbytes = elf_cache_read(loadinfo->filfd, loadinfo->offset, buffer, readsize, offset - loadinfo->offset);
+#else
 			/* Seek to the next read position */
 
 			rpos = lseek(loadinfo->filfd, offset, SEEK_SET);
@@ -152,6 +155,7 @@ int elf_read(FAR struct elf_loadinfo_s *loadinfo, FAR uint8_t *buffer, size_t re
 			/* Read the file data at offset into the user buffer */
 
 			nbytes = read(loadinfo->filfd, buffer, readsize);
+#endif
 		} else if (loadinfo->compression_type > COMPRESS_TYPE_NONE) {	/* Compressed binary */
 #ifdef CONFIG_COMPRESSED_BINARY
 			if (loadinfo->compression_type == CONFIG_COMPRESSION_TYPE) {

--- a/os/binfmt/libelf/libelf_uninit.c
+++ b/os/binfmt/libelf/libelf_uninit.c
@@ -112,10 +112,8 @@ int elf_uninit(struct elf_loadinfo_s *loadinfo)
 		return ERROR;
 #endif
 	}
-#if defined(CONFIG_ELF_CACHE_READ) && !defined(CONFIG_COMPRESSED_BINARY)
-	else if (loadinfo->compression_type == COMPRESS_TYPE_NONE) {
-		elf_cache_uninit();
-	}
+#if defined(CONFIG_ELF_CACHE_READ)
+	elf_cache_uninit();
 #endif
 
 	/* Close the ELF file */

--- a/os/binfmt/libelf/libelf_uninit.c
+++ b/os/binfmt/libelf/libelf_uninit.c
@@ -107,8 +107,16 @@ int elf_uninit(struct elf_loadinfo_s *loadinfo)
 	if (loadinfo->compression_type > COMPRESS_TYPE_NONE) {
 #ifdef CONFIG_COMPRESSED_BINARY
 		compress_uninit();
+#else
+		berr("No support for reading compressed binary\n");
+		return ERROR;
 #endif
 	}
+#if defined(CONFIG_ELF_CACHE_READ) && !defined(CONFIG_COMPRESSED_BINARY)
+	else if (loadinfo->compression_type == COMPRESS_TYPE_NONE) {
+		elf_cache_uninit();
+	}
+#endif
 
 	/* Close the ELF file */
 

--- a/os/compression/Kconfig
+++ b/os/compression/Kconfig
@@ -29,12 +29,4 @@ config COMPRESSION_BLOCK_SIZE
 	---help---
 		Enter block size to use for compression of binary.
 
-config DECOMPRESSION_CACHE_BLOCKS
-	int "Blocks for caching when loading binary"
-	default 60
-	range 2 100
-	---help---
-		Enter number of blocks to use for caching decompressed
-		blocks from block-wise compressed binary when loading
-
 endif # COMPRESSED_BINARY

--- a/os/compression/compress_read.c
+++ b/os/compression/compress_read.c
@@ -39,24 +39,8 @@
  * Private Declarations
  ****************************************************************************/
 
-static struct s_header compression_header;
-
-/* Number of blocks for caching */
-static unsigned int number_blocks_caching;
-
-/* Pointer to block_cache_t list to be used for holding uncompressed blocks */
-static block_cache_t *blockcache;
-
-/* Pointers for maintaining doubly linked list of blockcache */
-static block_cache_t *head;		/* Pointer to least priority block for caching */
-static block_cache_t *tail;		/* Pointer to highest priority block for caching */
-static block_cache_t *most_accessed;	/* Pointer to most accessed block for quick access */
-
-/* Number of requests for the most accessed block in blockcache list */
-static unsigned int max_accessed_count;
-
-/* Buffer to be used for reading compressed data from blockwise compressed binary */
-static unsigned char *compressed_data_buffer;
+struct s_header compression_header;
+struct s_buffer buffers;
 
 /****************************************************************************
  * Private Functions
@@ -66,13 +50,13 @@ static unsigned char *compressed_data_buffer;
  * Name: compress_decompress_block
  *
  * Description:
- *   Decompress block in 'compressed_data_buffer' of readsize into 'out_buffer' of writesize
+ *   Decompress block in 'read_buffer' of readsize into 'out_buffer' of writesize
  *
  * Returned Value:
  *   Non-negative value on Success.
  *   Negative value on Failure.
  ****************************************************************************/
-static int compress_decompress_block(unsigned char *out_buffer, unsigned int *writesize, unsigned char *read_buf, unsigned int *size, int index)
+static int compress_decompress_block(unsigned char *out_buffer, unsigned int *writesize, unsigned char *read_buffer, unsigned int *size, int index)
 {
 	int ret = ERROR;
 
@@ -82,7 +66,7 @@ static int compress_decompress_block(unsigned char *out_buffer, unsigned int *wr
 		*writesize = compression_header.blocksize;
 		*size -= (LZMA_PROPS_SIZE);
 
-		ret = LzmaUncompress(&out_buffer[0], writesize, &read_buf[LZMA_PROPS_SIZE], size, &read_buf[0], LZMA_PROPS_SIZE);
+		ret = LzmaUncompress(&out_buffer[0], writesize, &read_buffer[LZMA_PROPS_SIZE], size, &read_buffer[0], LZMA_PROPS_SIZE);
 
 		if (ret == SZ_ERROR_FAIL) {
 			bmdbg("Failure to decompress with LZMAUncompress API\n");
@@ -229,11 +213,10 @@ static off_t compress_lseek_block(int filfd, uint16_t binary_header_size, int bl
  * Name: compress_read_block
  *
  * Description:
- *   Read 'block_number' block from compressed blocks section into
- *   compressed_data_buffer.
+ *   Read 'block_number' block from compressed blocks section into read_buffer
  *
  * Returned Value:
- *   Number of bytes read into compressed_data_buffer on Success
+ *   Number of bytes read into read_buffer on Success
  *   Negative value on Failure
  ****************************************************************************/
 static off_t compress_read_block(int filfd, uint16_t binary_header_size, FAR uint8_t *buf, int block_number)
@@ -281,180 +264,6 @@ static off_t compress_read_block(int filfd, uint16_t binary_header_size, FAR uin
 }
 
 /****************************************************************************
- * Name: compress_update_blockcache_list
- *
- * Description:
- *   Update blockcache list based on whether 'block_number' block in
- *   blockwise-compressed binary is already cached or not. Also, maintain
- *   head, tail and most_accessed pointers. Decompress block if not cached.
- *   tail = most recently cached block (highest priority block for keeping
- *          cached)
- *   head = oldest cached block (lowest priority for keeping it cached).
- *          If a new block needs to be cached, cache to this blockcache element.
- *   most_accessed = pointer to most accessed block in blockcache list.
- *          Needed for easy access to most accessed block from comp. binary.
- *
- * Returned Value:
- *   Index in blockcache list where 'block_number' block number from compressed
- *   binary is cached in uncompressed form. Return Negative value on failure.
- ****************************************************************************/
-static unsigned int compress_update_blockcache_list(int block_number, int filfd, uint16_t binary_header_size)
-{
-	unsigned int blockcache_index;	/* Which blockcache element has needed uncompressed data for read */
-	block_cache_t *ptr;		/* Pointer to element in blockcache list which will be updated */
-	block_cache_t *temp;		/* Used when updating blockcache list */
-	bool flag_for_caching;		/* 1 = Block needs to be cached, 0 = Block already cached */
-	bool update_most_accessed;	/* 1 = Most accessed block is being removed from blockcache.
-					 *     Need to update most accessed pointer from scratch */
-	unsigned int writesize;
-	int size;
-	int ret;
-
-	/* Initialize flags */
-	flag_for_caching = true;
-	update_most_accessed = false;
-
-	/* First check is with block_number at most_accessed pointer */
-	if (most_accessed->block_number == block_number) {
-		flag_for_caching = false;
-		blockcache_index = most_accessed->index_block_cache;
-	}
-
-	/* Start checking for if block is cached from the tail */
-	if (flag_for_caching == true) {
-		ptr = tail;
-		while (ptr != NULL) {
-			if (ptr->block_number == block_number) {
-				flag_for_caching = false;
-				blockcache_index = ptr->index_block_cache;
-				break;
-			} else {
-				ptr = ptr->prev;
-			}
-		}
-	}
-
-	/* If block_number block from compressed binary needs to be cached */
-	if (flag_for_caching == true) {
-
-		/* If most_accessed == head, need to update most_accessed */
-		if (head == most_accessed)
-			update_most_accessed = true;
-
-		/* Detach head, Reassign head to head->next */
-		ptr = head;
-		head = ptr->next;
-		head->prev = ptr->prev;
-
-		/* Read compressed 'block_number' block into compressed_data_buffer */
-		size = compress_read_block(filfd, binary_header_size, compressed_data_buffer, block_number);
-		if (size < 0) {
-			bmdbg("Read for compressed block %d failed\n", block_number);
-			return ERROR;
-		}
-
-		/* Decompress block in compressed_data_buffer to chosen blockcache element */
-		ret = compress_decompress_block(ptr->out_buffer, &writesize, compressed_data_buffer, &size, block_number);
-		if (ret == ERROR) {
-			bmdbg("Failed to decompress %d block of this binary\n", block_number);
-			return ret;
-		}
-
-		/* Update block_number, Number of requests */
-		ptr->block_number = block_number;
-		ptr->no_requests_for_block = 1;
-
-		/* Updating most_accessed pointer */
-		if (ptr->no_requests_for_block >= max_accessed_count) {
-			max_accessed_count = ptr->no_requests_for_block;
-			most_accessed = ptr;
-		}
-
-		/* Always attach ptr at tail */
-		temp = tail;
-		temp->next = ptr;
-		ptr->prev = temp;
-		ptr->next = NULL;
-		tail = ptr;
-
-		/* Update most_accessed from scratch, if needed */
-		if (update_most_accessed == true) {
-			max_accessed_count = 0;
-			temp = tail;
-			while (temp != NULL) {
-				if (temp->no_requests_for_block > max_accessed_count) {
-					max_accessed_count = temp->no_requests_for_block;
-					most_accessed = temp;
-				}
-				temp = temp->prev;
-			}
-		}
-
-		/* Update blockcache_index into which block is uncompressed */
-		blockcache_index = ptr->index_block_cache;
-
-	} else { /* If block is already cached */
-
-		/* If block is cached at head location */
-		if (head == &blockcache[blockcache_index]) {
-			/* Detach head, Reassign head to head->next */
-			ptr = head;
-			head = ptr->next;
-			head->prev = ptr->prev;
-
-			ptr->no_requests_for_block += 1;
-
-			/* Update most_accessed pointer */
-			if (ptr->no_requests_for_block >= max_accessed_count) {
-				max_accessed_count = ptr->no_requests_for_block;
-				most_accessed = ptr;
-			}
-
-			/* Always attach ptr at tail */
-			temp = tail;
-			temp->next = ptr;
-			ptr->prev = temp;
-			ptr->next = NULL;
-			tail = ptr;
-
-		} else if (tail == &blockcache[blockcache_index]) { /* Block is cached at tail location */
-			blockcache[blockcache_index].no_requests_for_block += 1;
-
-			/* Update most_accessed pointer */
-			ptr = tail;
-			if (ptr->no_requests_for_block >= max_accessed_count) {
-				max_accessed_count = ptr->no_requests_for_block;
-				most_accessed = ptr;
-			}
-		} else { /* Block is cached at some other index in blockcache list */
-
-			/* Detach blockcache element at blockcache_index */
-			ptr = &blockcache[blockcache_index];
-			ptr->prev->next = ptr->next;
-			ptr->next->prev = ptr->prev;
-
-			/* Update Number of requests for block */
-			ptr->no_requests_for_block += 1;
-
-			/* Update most accessed pointer */
-			if (ptr->no_requests_for_block >= max_accessed_count) {
-				max_accessed_count = ptr->no_requests_for_block;
-				most_accessed = ptr;
-			}
-
-			/* Always attach ptr at tail */
-			temp = tail;
-			temp->next = ptr;
-			ptr->prev = temp;
-			ptr->next = NULL;
-			tail = ptr;
-		}
-	}
-
-	return blockcache_index;
-}
-
-/****************************************************************************
  * Name: compress_read
  *
  * Description:
@@ -472,68 +281,78 @@ int compress_read(int filfd, uint16_t binary_header_size, FAR uint8_t *buffer, s
 	int first_block;
 	int last_block;
 	int no_blocks;
-	int block_number;		/* Block number in compressed file */
-	int actual_offset;		/* Offset from start of uncompressed file */
+	int index;
+	int ret;
+	int actual_offset;			/* Offset from start of uncompressed file */
 	int block_size_to_write;	/* Size to write into buffer from decompressed block */
-	int buffer_pos;			/* Position in buffer to start writing from */
-	int blocksize;			/* Blocksize used for compressing the binary */
-	unsigned int blockcache_index;	/* Which blockcache element has needed uncompressed data for read */
+	int buffer_index;
+	int blocksize;
+	unsigned int writesize;
+	unsigned int size;
 
 	/* Setting first block, end block and number of blocks to read and decompressed */
 	blocksize = compression_header.blocksize;
 	compress_blocks_to_read(&first_block, &last_block, &no_blocks, offset, readsize);
 	if (first_block < 0 || no_blocks < 0) {
 		bmdbg("Incorrect first_block, no_blocks info\n");
-		buffer_pos = ERROR;
+		buffer_index = ERROR;
 		goto error_compress_read;
 	}
 
-	block_number = first_block;
-	buffer_pos = 0;
+	index = first_block;
+	buffer_index = 0;
 	/* Actual Offset in uncompressed file is same as Offset passed to this function */
 	actual_offset = offset;
 
 	/* Reading and decompressing blocks from first_block to last_block. Then writing to buffer. */
-	for (; block_number < first_block + no_blocks; block_number++) {
-
-		/* Update blockcache list and get uncompressed data into one of the blockcache elements */
-		blockcache_index = compress_update_blockcache_list(block_number, filfd, binary_header_size);
-		if (blockcache_index >= number_blocks_caching) {
-			buffer_pos = ERROR;
+	for (; index < first_block + no_blocks; index++) {
+		/* Read compressed 'index' block into read_buffer */
+		size = compress_read_block(filfd, binary_header_size, buffers.read_buffer, index);
+		if (size < 0) {
+			bmdbg("Read for compressed block %d failed\n", index);
+			buffer_index = size;
 			goto error_compress_read;
 		}
 
-		if (block_number == first_block) {
+		/* Decompress block in read_buffer to out_buffer */
+		ret = compress_decompress_block(buffers.out_buffer, &writesize, buffers.read_buffer, &size, index);
+		if (ret == ERROR) {
+			bmdbg("Failed to decompress %d block of this binary\n", index);
+			buffer_index = ret;
+			goto error_compress_read;
+		}
+
+		if (index == first_block) {
 			/*
 			 * Read appropriate number of bytes to buffer from this block using readsize and offset info.
 			 * If start_offset + readsize < end_offset, write from start_offset to start_offset + readsize.
 			 * Otherwise, write from start_offset to end_offset into buffer.
 			 */
-			block_size_to_write = ((block_number + 1) * blocksize - 1 > actual_offset + readsize - 1 ? readsize : (block_number + 1) * blocksize - actual_offset);
-			memcpy(&buffer[buffer_pos], &blockcache[blockcache_index].out_buffer[actual_offset - (block_number * blocksize)], block_size_to_write);
-			buffer_pos += block_size_to_write;
-		} else if (block_number == last_block) {
+			block_size_to_write = ((index + 1) * blocksize - 1 > actual_offset + readsize - 1 ? readsize : (index + 1) * blocksize - actual_offset);
+			memcpy(&buffer[buffer_index], &buffers.out_buffer[actual_offset - (index * blocksize)], block_size_to_write);
+			buffer_index += block_size_to_write;
+		} else if (index == last_block) {
 			/*
 			 * Read appropriate number of bytes to buffer from this block using readsize and offset info.
 			 * Calculate end_offset (Offset of last byte to write from this block).
 			 * Write from start_offset to end_offset from this block into buffer.
 			 */
-			block_size_to_write = actual_offset + readsize - (block_number * blocksize);
-			memcpy(&buffer[buffer_pos], &blockcache[blockcache_index].out_buffer[0], block_size_to_write);
-			buffer_pos += block_size_to_write;
+			block_size_to_write = actual_offset + readsize - (index * blocksize);
+			memcpy(&buffer[buffer_index], &buffers.out_buffer[0], block_size_to_write);
+			buffer_index += block_size_to_write;
 		} else {
 			/*
 			 * This is not the first or last block. This is intermediary block.
 			 * So, write entire block into buffer.
 			 */
 			block_size_to_write = blocksize;
-			memcpy(&buffer[buffer_pos], &blockcache[blockcache_index].out_buffer[0], block_size_to_write);
-			buffer_pos += block_size_to_write;
+			memcpy(&buffer[buffer_index], &buffers.out_buffer[0], block_size_to_write);
+			buffer_index += block_size_to_write;
 		}
 	}
 
 error_compress_read:
-	return buffer_pos;
+	return buffer_index;
 }
 
 /****************************************************************************
@@ -544,7 +363,7 @@ error_compress_read:
  *
  * Returned value:
  *   OK (0) on Success
- *   Negative value on Failure
+ *   ERROR (-1) on Failure
  ****************************************************************************/
 int compress_init(int filfd, uint16_t offset, off_t *filelen)
 {
@@ -560,57 +379,13 @@ int compress_init(int filfd, uint16_t offset, off_t *filelen)
 	/* Assign file length as that of uncompressed file */
 	*filelen = compression_header.binary_size;
 
-	/* Set number of blocks to use for caching */
-	if (CONFIG_DECOMPRESSION_CACHE_BLOCKS < (CUTOFF_RATIO_CACHE_BLOCKS) * (compression_header.sections - 1))
-		number_blocks_caching = CONFIG_DECOMPRESSION_CACHE_BLOCKS;
-	else
-		number_blocks_caching = ((CUTOFF_RATIO_CACHE_BLOCKS) * (compression_header.sections - 1));
-
-	/* Initialize max_accesed_count to 0 */
-	max_accessed_count = 0;
-
 #if CONFIG_COMPRESSION_TYPE == 1
-	/* Allocating memory for compressed_data_buffer and blockcache list to be used for LZMA decompression */
+	/* Allocating memory for read and out buffer to be used for LZMA decompression */
 	if (compression_header.compression_format == COMPRESSION_TYPE_LZMA) {
-
-		compressed_data_buffer = (unsigned char *)kmm_malloc(compression_header.blocksize + 5);
-		if (!compressed_data_buffer) {
-			bmdbg("Failed kmm_malloc for read buffer\n");
-			return -ENOMEM;
-		}
-
-		blockcache = (block_cache_t *)kmm_malloc(number_blocks_caching * sizeof(block_cache_t));
-		if (!blockcache) {
-			bmdbg("Failed kmm_malloc for blockcache\n");
-			compress_uninit();
-			return -ENOMEM;
-		}
-
-		/* Initialize blockcache list */
-		for (int i = 0; i < number_blocks_caching; i++) {
-			blockcache[i].out_buffer = (unsigned char *)kmm_malloc(compression_header.blocksize);
-			if (!blockcache[i].out_buffer) {
-				bmdbg("Failed kmm_malloc for blockcache's out_buffer\n");
-				compress_uninit();
-				return -ENOMEM;
-			}
-
-			blockcache[i].block_number = -1;
-			blockcache[i].no_requests_for_block = 0;
-			blockcache[i].index_block_cache = i;
-			blockcache[i].next = &blockcache[(i + 1) % number_blocks_caching];
-			blockcache[i].prev = &blockcache[(i - 1) % number_blocks_caching];
-		}
+		buffers.read_buffer = (unsigned char *)kmm_malloc(compression_header.blocksize + 5);
+		buffers.out_buffer = (unsigned char *)kmm_malloc(compression_header.blocksize);
 	}
 #endif
-
-	/* Assign head, tail and most_accessed pointers */
-	head = &blockcache[0];
-	tail = &blockcache[number_blocks_caching - 1];
-	most_accessed = tail;
-
-	head->prev = NULL;
-	tail->next = NULL;
 
 error_compress_init:
 	return ret;
@@ -627,21 +402,7 @@ error_compress_init:
  ****************************************************************************/
 void compress_uninit(void)
 {
-	/* Freeing memory allocated to compressed_data_buffer and blockcache for file decompression */
-	if (compressed_data_buffer) {
-		kmm_free(compressed_data_buffer);
-		compressed_data_buffer = NULL;
-	}
-
-	for (int i = 0; i < number_blocks_caching; i++) {
-		if (blockcache[i].out_buffer) {
-			kmm_free(blockcache[i].out_buffer);
-			blockcache[i].out_buffer = NULL;
-		}
-	}
-
-	if (blockcache) {
-		kmm_free(blockcache);
-		blockcache = NULL;
-	}
+	/* Freeing memory allocated to read_buffer and out_buffer for file decompression */
+	free(buffers.read_buffer);
+	free(buffers.out_buffer);
 }

--- a/os/compression/compress_read.c
+++ b/os/compression/compress_read.c
@@ -402,7 +402,11 @@ error_compress_init:
  ****************************************************************************/
 void compress_uninit(void)
 {
+#if CONFIG_COMPRESSION_TYPE == 1
 	/* Freeing memory allocated to read_buffer and out_buffer for file decompression */
-	free(buffers.read_buffer);
-	free(buffers.out_buffer);
+	if (compression_header.compression_format == COMPRESSION_TYPE_LZMA) {
+		kmm_free(buffers.read_buffer);
+		kmm_free(buffers.out_buffer);
+	}
+#endif
 }

--- a/os/include/tinyara/binfmt/compression/compress_read.h
+++ b/os/include/tinyara/binfmt/compression/compress_read.h
@@ -28,23 +28,15 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-#define CUTOFF_RATIO_CACHE_BLOCKS 0.1f	/* Max. Ratio of blocks to be used for caching
-					 * to total number of compressed blocks in binary */
-
 /****************************************************************************
  * Public Types
  ****************************************************************************/
 
-/* Struct for output buffers to cache uncompressed blocks */
-struct block_cache_s {
-	unsigned char *out_buffer;			/* Buffer that is going to hold uncompressed data */
-	int block_number;			/* Block number in compressed file for the cached block */
-	unsigned int no_requests_for_block;	/* Number of requests for current block that is cached */
-	unsigned int index_block_cache;		/* Index of block cache in the array */
-	struct block_cache_s *next;		/* Pointer to next element in doubly linked list */
-	struct block_cache_s *prev;		/* Pointer to previous element in doubly linked list */
+/* Struct for buffers to be used for read/decompression */
+struct s_buffer {
+	unsigned char *read_buffer;
+	unsigned char *out_buffer;
 };
-typedef struct block_cache_s block_cache_t;
 
 /****************************************************************************
  * Function Prototypes


### PR DESCRIPTION
This patch will reduce the elf_load time performance

Issues:
1) ELF loading time quite high, when we are testing with smartfs
2) Specifically wifi app took ~29sec to load a 182KB file

Fix:
1) ELF_read is trying to access the same location a file/location multiple times, which in turn makes smartFS read overhead. So using the cache memory, we store the copies of data which are frequently used smarfFS file location.
2) Now the time has been reduced to 12ms for the same 182KB wifi file