### PR TITLE
kernel/binary_manager: Release all kernel semaphores taken by all threads in binary when binary recovery

### DIFF
--- a/os/include/tinyara/semaphore.h
+++ b/os/include/tinyara/semaphore.h
@@ -215,6 +215,45 @@ int sem_getprotocol(FAR sem_t *sem, FAR int *protocol);
 
 int sem_setprotocol(FAR sem_t *sem, int protocol);
 
+#ifdef CONFIG_BINMGR_RECOVERY
+/****************************************************************************
+ * Name: sem_register
+ *
+ * Description:
+ *   Register semaphore to a list of kernel semaphores.
+ *
+ * Parameters:
+ *   sem - Semaphore descriptor
+ *
+ * Return Value:
+ *   None
+ *
+ * Assumptions:
+ *   This function may be called when semaphore in kernel region is initialized.
+ *
+ ****************************************************************************/
+void sem_register(FAR sem_t *sem);
+
+/****************************************************************************
+ * Name: sem_unregister
+ *
+ * Description:
+ *   Unegister semaphore from a list of kernel semaphores.
+ *
+ * Parameters:
+ *   sem - Semaphore descriptor
+ *
+ * Return Value:
+ *   None
+ *
+ * Assumptions:
+ *   This function may be called when semaphore in kernel region is destroyed.
+ *
+ ****************************************************************************/
+void sem_unregister(FAR sem_t *sem);
+#endif
+
+
 #undef EXTERN
 #ifdef __cplusplus
 }

--- a/os/kernel/binary_manager/binary_manager_recovery.c
+++ b/os/kernel/binary_manager/binary_manager_recovery.c
@@ -25,6 +25,7 @@
 #include <stdlib.h>
 #include <queue.h>
 #include <errno.h>
+#include <semaphore.h>
 #include <sys/types.h>
 #ifdef CONFIG_BOARDCTL_RESET
 #include <sys/boardctl.h>
@@ -40,6 +41,7 @@
 #include "binary_manager.h"
 
 extern bool abort_mode;
+extern sq_queue_t g_sem_list;
 
 /****************************************************************************
  * Pre-processor Definitions
@@ -60,6 +62,42 @@ static void binary_manager_board_reset(void)
 		up_mdelay(10000);
 	}
 #endif
+}
+
+static void recovery_release_binary_sem(int binid)
+{
+	sem_t *sem;
+	irqstate_t flags;
+	FAR struct semholder_s *holder;
+
+	flags = irqsave();
+
+	sem = (sem_t *)sq_peek(&g_sem_list);
+	while (sem) {
+#if CONFIG_SEM_PREALLOCHOLDERS > 0
+		for (holder = sem->hhead; holder; holder = holder->flink)
+#else
+		holder = &sem->holder;
+#endif
+		{
+			if (holder && holder->htcb && holder->htcb->group && holder->htcb->group->tg_loadtask == binid) {
+				/* No saved holder for semaphore used for signaling */
+				if ((sem->flags & FLAGS_SIGSEM) != 0) {
+#if CONFIG_SEM_PREALLOCHOLDERS > 0
+					break;
+#else
+					sem = sq_next(sem);
+					continue;
+#endif
+				}
+				/* Increase semcount and release itself from holder */
+				sem->semcount++;
+				sem_releaseholder(sem, holder->htcb);
+			}
+		}
+		sem = sq_next(sem);
+	}
+	irqrestore(flags);
 }
 
 static void recovery_exclude_scheduling_each(FAR struct tcb_s *tcb, FAR void *arg)
@@ -108,6 +146,9 @@ static int recovery_exclude_scheduling(int binid)
 
 	/* Exclude all tasks and pthreads created in a binary which has 'binid' from scheduling */
 	sched_foreach(recovery_exclude_scheduling_each, (FAR void *)binid);
+
+	/* Release all semaphores held by the threads in binary */
+	recovery_release_binary_sem(binid);
 
 	return OK;
 }

--- a/os/kernel/semaphore/Make.defs
+++ b/os/kernel/semaphore/Make.defs
@@ -57,6 +57,11 @@ CSRCS += sem_post.c sem_recover.c sem_reset.c sem_waitirq.c sem_tickwait.c
 
 ifeq ($(CONFIG_PRIORITY_INHERITANCE),y)
 CSRCS += sem_initialize.c sem_holder.c sem_setprotocol.c
+ifeq ($(CONFIG_BINMGR_RECOVERY),y)
+CSRCS += sem_list.c
+endif
+else ifeq ($(CONFIG_BINMGR_RECOVERY),y)
+CSRCS += sem_holder.c sem_list.c
 endif
 
 # Include semaphore build support

--- a/os/kernel/semaphore/sem_destroy.c
+++ b/os/kernel/semaphore/sem_destroy.c
@@ -65,6 +65,9 @@
 #include "sched/sched.h"
 #include <tinyara/debug/sysdbg.h>
 #endif
+#ifdef CONFIG_BINMGR_RECOVERY
+#include <tinyara/semaphore.h>
+#endif
 
 /****************************************************************************
  * Definitions
@@ -145,6 +148,9 @@ int sem_destroy(FAR sem_t *sem)
 
 		sem_destroyholder(sem);
 
+#ifdef CONFIG_BINMGR_RECOVERY
+		sem_unregister(sem);
+#endif
 		sem->flags &= ~FLAGS_INITIALIZED;
 		return OK;
 	} else {

--- a/os/kernel/semaphore/sem_holder.c
+++ b/os/kernel/semaphore/sem_holder.c
@@ -65,8 +65,6 @@
 #include "sched/sched.h"
 #include "semaphore/semaphore.h"
 
-#ifdef CONFIG_PRIORITY_INHERITANCE
-
 /****************************************************************************
  * Definitions
  ****************************************************************************/
@@ -273,6 +271,8 @@ static int sem_recoverholders(FAR struct semholder_s *pholder, FAR sem_t *sem, F
 }
 #endif
 
+#ifdef CONFIG_PRIORITY_INHERITANCE
+
 /****************************************************************************
  * Name: sem_boostholderprio
  ****************************************************************************/
@@ -362,7 +362,7 @@ static int sem_boostholderprio(FAR struct semholder_s *pholder, FAR sem_t *sem, 
 
 	return 0;
 }
-
+#endif
 /****************************************************************************
  * Name: sem_verifyholder
  ****************************************************************************/
@@ -402,6 +402,8 @@ static int sem_dumpholder(FAR struct semholder_s *pholder, FAR sem_t *sem, FAR v
 	return 0;
 }
 #endif
+
+#ifdef CONFIG_PRIORITY_INHERITANCE
 
 /****************************************************************************
  * Name: sem_restoreholderprio
@@ -715,6 +717,7 @@ static inline void sem_restorebaseprio_task(FAR struct tcb_s *stcb, FAR sem_t *s
 		}
 	}
 }
+#endif
 
 /****************************************************************************
  * Public Functions
@@ -818,13 +821,19 @@ void sem_addholder_tcb(FAR struct tcb_s *htcb, FAR sem_t *sem)
 {
 	FAR struct semholder_s *pholder;
 
+	/* No needs to save holder for semaphore used for signaling */
+	if ((sem->flags & FLAGS_SIGSEM) != 0) {
+		return;
+	}
+
+#if defined(CONFIG_PRIORITY_INHERITANCE) && !defined(CONFIG_BINMGR_RECOVERY)
 	/*
 	 * If priority inheritance is disabled for this thread, then do not
 	 * add the holder. If there are never holders of the semaphore,
 	 * the priority inheritance is effectively disabled.
 	 */
-
 	if ((sem->flags & PRIOINHERIT_FLAGS_DISABLE) == 0) {
+#endif
 		/* Find or allocate a container for this new holder */
 		pholder = sem_findorallocateholder(sem, htcb);
 		if (pholder != NULL) {
@@ -835,7 +844,9 @@ void sem_addholder_tcb(FAR struct tcb_s *htcb, FAR sem_t *sem)
 			pholder->htcb = htcb;
 			pholder->counts++;
 		}
+#if defined(CONFIG_PRIORITY_INHERITANCE) && !defined(CONFIG_BINMGR_RECOVERY)
 	}
+#endif
 }
 
 /****************************************************************************
@@ -862,6 +873,51 @@ void sem_addholder(FAR sem_t *sem)
 }
 
 /****************************************************************************
+ * Name: sem_releaseholder
+ *
+ * Description:
+ *   Called from sem_post() after a thread releases one count on the
+ *   semaphore.
+ *
+ * Parameters:
+ *   sem - A reference to the semaphore being posted
+ *
+ * Return Value:
+ *   None
+ *
+ * Assumptions:
+ *
+ ****************************************************************************/
+
+void sem_releaseholder(FAR sem_t *sem, FAR struct tcb_s *rtcb)
+{
+	FAR struct semholder_s *pholder;
+
+	if ((sem->flags & FLAGS_SIGSEM) != 0) {
+		/* No saved holder for semaphore used for signaling */
+		return;
+	}
+
+	/* Find the container for this holder */
+
+	pholder = sem_findholder(sem, rtcb);
+
+	if (pholder && pholder->counts > 0) {
+		/* Decrement the counts on this holder -- the holder will be freed
+		 * later in sem_restorebaseprio.
+		 */
+		pholder->counts--;
+
+#ifndef CONFIG_PRIORITY_INHERITANCE
+		if (pholder->counts <= 0) {
+			sem_freeholder(sem, pholder);
+		}
+#endif
+	}
+}
+
+#ifdef CONFIG_PRIORITY_INHERITANCE
+/****************************************************************************
  * Name: void sem_boostpriority(sem_t *sem)
  *
  * Description:
@@ -887,40 +943,6 @@ void sem_boostpriority(FAR sem_t *sem)
 	 */
 
 	(void)sem_foreachholder(sem, sem_boostholderprio, rtcb);
-}
-
-/****************************************************************************
- * Name: sem_releaseholder
- *
- * Description:
- *   Called from sem_post() after a thread releases one count on the
- *   semaphore.
- *
- * Parameters:
- *   sem - A reference to the semaphore being posted
- *
- * Return Value:
- *   None
- *
- * Assumptions:
- *
- ****************************************************************************/
-
-void sem_releaseholder(FAR sem_t *sem)
-{
-	FAR struct tcb_s *rtcb = this_task();
-	FAR struct semholder_s *pholder;
-
-	/* Find the container for this holder */
-
-	pholder = sem_findholder(sem, rtcb);
-	if (pholder && pholder->counts > 0) {
-		/* Decrement the counts on this holder -- the holder will be freed
-		 * later in sem_restorebaseprio.
-		 */
-
-		pholder->counts--;
-	}
 }
 
 /****************************************************************************
@@ -976,7 +998,7 @@ void sem_restorebaseprio(FAR struct tcb_s *stcb, FAR sem_t *sem)
 		sem_restorebaseprio_task(stcb, sem);
 	}
 }
-
+#endif
 /****************************************************************************
  * Name: sem_canceled
  *
@@ -1004,8 +1026,11 @@ void sem_canceled(FAR struct tcb_s *stcb, FAR sem_t *sem)
 	DEBUGASSERT(sem->semcount <= 0);
 
 	/* Adjust the priority of every holder as necessary */
-
-	(void)sem_foreachholder(sem, sem_restoreholderprio, stcb);
+#ifdef CONFIG_PRIORITY_INHERITANCE
+	if ((sem->flags & PRIOINHERIT_FLAGS_DISABLE) == 0) {
+		(void)sem_foreachholder(sem, sem_restoreholderprio, stcb);
+	}
+#endif
 }
 #endif
 
@@ -1065,5 +1090,3 @@ int sem_nfreeholders(void)
 #endif
 }
 #endif
-
-#endif							/* CONFIG_PRIORITY_INHERITANCE */

--- a/os/kernel/semaphore/sem_list.c
+++ b/os/kernel/semaphore/sem_list.c
@@ -1,0 +1,113 @@
+/****************************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+#include <queue.h>
+#include <semaphore.h>
+
+#include <tinyara/arch.h>
+
+/****************************************************************************
+ * Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Type Declarations
+ ****************************************************************************/
+
+/****************************************************************************
+ * Global Variables
+ ****************************************************************************/
+sq_queue_t g_sem_list;
+
+/****************************************************************************
+ * Private Variables
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: sem_register
+ *
+ * Description:
+ *   Register semaphore to a list of kernel semaphores.
+ *
+ * Parameters:
+ *   sem - Semaphore descriptor
+ *
+ * Return Value:
+ *   None
+ *
+ * Assumptions:
+ *   This function may be called when semaphore in kernel region is initialized.
+ *
+ ****************************************************************************/
+void sem_register(FAR sem_t *sem)
+{
+	sem_t *sem_ptr;
+	irqstate_t flags;
+
+	flags = irqsave();
+	sem_ptr = (sem_t *)sq_peek(&g_sem_list);
+	while (sem_ptr) {
+		if (sem_ptr == sem) {
+			/* Already registered */
+			irqrestore(flags);
+			return;
+		}
+		sem_ptr = sq_next(sem_ptr);
+	}
+	/* Add semaphore to a list of kernel semaphore, g_sem_list */
+	sq_addlast((FAR sq_entry_t *)sem, &g_sem_list);
+	irqrestore(flags);
+}
+
+/****************************************************************************
+ * Name: sem_unregister
+ *
+ * Description:
+ *   Unegister semaphore from a list of kernel semaphores.
+ *
+ * Parameters:
+ *   sem - Semaphore descriptor
+ *
+ * Return Value:
+ *   None
+ *
+ * Assumptions:
+ *   This function may be called when semaphore in kernel region is destroyed.
+ *
+ ****************************************************************************/
+void sem_unregister(FAR sem_t *sem)
+{
+	irqstate_t flags;
+
+	flags = irqsave();
+
+	/* Remove semaphore from a list of kernel semaphore */
+	sq_rem((FAR sq_entry_t *)sem, &g_sem_list);
+
+	irqrestore(flags);
+}

--- a/os/kernel/semaphore/sem_wait.c
+++ b/os/kernel/semaphore/sem_wait.c
@@ -203,11 +203,12 @@ int sem_wait(FAR sem_t *sem)
 
 			sched_lock();
 
-			/* Boost the priority of any threads holding a count on the
-			 * semaphore.
-			 */
-
-			sem_boostpriority(sem);
+			if ((sem->flags & PRIOINHERIT_FLAGS_DISABLE) == 0) {
+				/* Boost the priority of any threads holding a count on the
+				 * semaphore.
+				 */
+				sem_boostpriority(sem);
+			}
 #endif
 			/* Add the TCB to the prioritized semaphore wait queue */
 

--- a/os/kernel/semaphore/semaphore.h
+++ b/os/kernel/semaphore/semaphore.h
@@ -107,14 +107,16 @@ void sem_recover(FAR struct tcb_s *tcb);
  * holders of semaphores.
  */
 
-#ifdef CONFIG_PRIORITY_INHERITANCE
+#ifdef SAVE_SEM_HOLDER
 void sem_initholders(void);
 void sem_destroyholder(FAR sem_t *sem);
 void sem_addholder(FAR sem_t *sem);
 void sem_addholder_tcb(FAR struct tcb_s *tcb, FAR sem_t *sem);
+void sem_releaseholder(FAR sem_t *sem, FAR struct tcb_s *htcb);
+#if defined(CONFIG_PRIORITY_INHERITANCE)
 void sem_boostpriority(FAR sem_t *sem);
-void sem_releaseholder(FAR sem_t *sem);
 void sem_restorebaseprio(FAR struct tcb_s *stcb, FAR sem_t *sem);
+#endif
 #ifndef CONFIG_DISABLE_SIGNALS
 void sem_canceled(FAR struct tcb_s *stcb, FAR sem_t *sem);
 #else
@@ -126,7 +128,7 @@ void sem_canceled(FAR struct tcb_s *stcb, FAR sem_t *sem);
 #define sem_addholder(sem)
 #define sem_addholder_tcb(tcb, sem)
 #define sem_boostpriority(sem)
-#define sem_releaseholder(sem)
+#define sem_releaseholder(sem, htcb)
 #define sem_restorebaseprio(stcb, sem)
 #define sem_canceled(stcb, sem)
 #endif


### PR DESCRIPTION
- Manage the list of semaphore holder with enabling binary manager recovery
- Release all kernel semaphores taken by all task/pthreads when binary is reloaded by searching a list