### PR TITLE
board/imxrt1050-evk/imxrt_boot.c : Add watchdog initialization

### DIFF
--- a/os/board/imxrt1050-evk/src/imxrt_boot.c
+++ b/os/board/imxrt1050-evk/src/imxrt_boot.c
@@ -85,6 +85,11 @@
 #include "imxrt_semc_sdram.h"
 #endif
 
+#ifdef CONFIG_WATCHDOG
+#include <tinyara/watchdog.h>
+#include "imxrt_wdog.h"
+#endif
+
 #ifdef CONFIG_ANALOG
 #include "imxrt_adc.h"
 #endif
@@ -259,6 +264,10 @@ void board_initialize(void)
 	imxrt_pwm_initialize();
 
 	imxrt_spi_initialize();
+
+#ifdef CONFIG_WATCHDOG
+	imxrt_wdog_initialize(CONFIG_WATCHDOG_DEVPATH, IMXRT_WDOG1);
+#endif
 
 	#ifdef CONFIG_IMXRT_TIMER_INTERFACE
 	{

--- a/os/include/tinyara/watchdog.h
+++ b/os/include/tinyara/watchdog.h
@@ -273,27 +273,6 @@ void watchdog_unregister(FAR void *handle);
  * Architecture-specific Application Interfaces
  ****************************************************************************/
 
-/****************************************************************************
- * Name: up_wdginitialize()
- *
- * Description:
- *   Perform architecture-specific initialization of the Watchdog hardware.
- *   This interface should be provided by all configurations using
- *   to avoid exposed platform-dependent logic.
- *
- *   At a minimum, this function should call watchdog_register() which is
- *   described above.
- *
- * Input parameters:
- *   None
- *
- * Returned Value:
- *   Zero on success; a negated errno value on failure.
- *
- ****************************************************************************/
-
-int up_wdginitialize(void);
-
 #undef EXTERN
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Add imxrt 1050 watchdog initialization in boot code.
There are two watchdogs in imxrt1050, but now we use only one temporarily.(WDOG1)