### PR TITLE
xtensa/src/esp32/spi_flash: Remove redundant assignment.

### DIFF
--- a/os/arch/xtensa/src/esp32/spi_flash/esp32_flash.c
+++ b/os/arch/xtensa/src/esp32/spi_flash/esp32_flash.c
@@ -81,7 +81,7 @@ static ssize_t esp32_erase_page(size_t page)
 {
     irqstate_t irqs;
     int32_t result = 0;
-    result = result;
+
     if (page > (ESP32_START_SECOTR + ESP32_NSECTORS)) {
         printf("Invalid page number\n");
         return -EFAULT;


### PR DESCRIPTION
This patch removes redundant assignment of a variable
'result' to itself.

Note: This patch solve SonarQube issue

Signed-off-by: Nilabh <n.shant@partner.samsung.com>