### PR TITLE
app/testcase: Modify network tc

### DIFF
--- a/apps/examples/testcase/le_tc/network/itc_net_inet.c
+++ b/apps/examples/testcase/le_tc/network/itc_net_inet.c
@@ -55,8 +55,8 @@ static void itc_net_inet_addr_n(void)
 static void itc_net_inet_aton_n(void)
 {
 	unsigned long ret;
-
-	ret = inet_aton(NULL, NULL);
+	const char *msg = "-1";
+	ret = inet_aton(msg, NULL);
 
 	TC_ASSERT_EQ("inet", ret, 0);
 	TC_SUCCESS_RESULT();

--- a/apps/examples/testcase/le_tc/network/itc_net_send.c
+++ b/apps/examples/testcase/le_tc/network/itc_net_send.c
@@ -48,19 +48,19 @@ static void itc_net_send_n_fd(void)
 }
 
 /**
-* @testcase            :itc_net_send_n_msg
+* @testcase            :itc_net_send_p_msg
 * @brief               :used to transmit a message to another socket
 * @scenario            :sending NULL msg
 * @apicovered          :send()
 * @precondition        :None
 * @postcondition       :None
 */
-static void itc_net_send_n_msg(int client_socket)
+static void itc_net_send_p_msg(int client_socket)
 {
 	char *msg = NULL;
-	int ret = send(client_socket, msg, strlen(msg), 0);
+	int ret = send(client_socket, msg, 0, 0);
 
-	TC_ASSERT_EQ("send", ret, -1);
+	TC_ASSERT_EQ("send", ret, 0);
 	TC_SUCCESS_RESULT();
 }
 
@@ -118,7 +118,7 @@ static void *server(void *args)
 	}
 
 	itc_net_send_n_fd();
-	itc_net_send_n_msg(client_socket);
+	itc_net_send_p_msg(client_socket);
 
 	ret = close(client_socket);
 	if (ret == -1) {


### PR DESCRIPTION
- The first input of inet_aton should not be NULL, because it will cause a crash. Instead, Change it to '-1' which is never used for network addr.
- Send socket operation is able to send NULL msg to the target socket. Therefore, itc_net_send_n_msg is actually, positive case, expecting return 0, not -1.
- strlen(NULL) is not allowed