### PR TITLE
os, libc : Change strXXX to strnXXX for safe

### DIFF
--- a/lib/libc/time/lib_localtime.c
+++ b/lib/libc/time/lib_localtime.c
@@ -453,7 +453,7 @@ static void settzname(void)
 		const struct ttinfo_s *const ttisp = &sp->ttis[i];
 		char *cp = &sp->chars[ttisp->tt_abbrind];
 
-		if (strlen(cp) > TZ_ABBR_MAX_LEN && strcmp(cp, GRANDPARENTED) != 0) {
+		if (strlen(cp) > TZ_ABBR_MAX_LEN && strncmp(cp, GRANDPARENTED, strlen(GRANDPARENTED) + 1) != 0) {
 			*(cp + TZ_ABBR_MAX_LEN) = '\0';
 		}
 	}
@@ -502,6 +502,8 @@ static int tzload(FAR const char *name, FAR struct state_s *const sp, const int 
 	u_t *up;
 	int doaccess;
 	union local_storage *lsp;
+	size_t p_len;
+	size_t name_len;
 
 	lsp = malloc(sizeof * lsp);
 	if (!lsp) {
@@ -521,16 +523,22 @@ static int tzload(FAR const char *name, FAR struct state_s *const sp, const int 
 		++name;
 	}
 
+	name_len = strlen(name);
+
 	doaccess = name[0] == '/';
 	if (!doaccess) {
 		p = TZDIR;
-		if (!p || sizeof lsp->fullname - 1 <= strlen(p) + strlen(name)) {
+		if (!p) {
+			goto oops;
+		}
+		p_len = strlen(p);
+		if (sizeof lsp->fullname - 1 <= p_len + name_len) {
 			goto oops;
 		}
 
-		strcpy(fullname, p);
-		strcat(fullname, "/");
-		strcat(fullname, name);
+		strncpy(fullname, p, p_len);
+		strncat(fullname, "/", strlen("/"));
+		strncat(fullname, name, name_len + 1);
 
 		/* Set doaccess if '.' (as in "../") shows up in name.  */
 
@@ -803,7 +811,7 @@ static int typesequiv(FAR const struct state_s *const sp, const int a, const int
 		const struct ttinfo_s *ap = &sp->ttis[a];
 		const struct ttinfo_s *bp = &sp->ttis[b];
 		result = ap->tt_gmtoff == bp->tt_gmtoff && ap->tt_isdst == bp->tt_isdst && ap->tt_ttisstd == bp->tt_ttisstd &&\
-				ap->tt_ttisgmt == bp->tt_ttisgmt && strcmp(&sp->chars[ap->tt_abbrind], &sp->chars[bp->tt_abbrind]) == 0;
+				ap->tt_ttisgmt == bp->tt_ttisgmt && strncmp(&sp->chars[ap->tt_abbrind], &sp->chars[bp->tt_abbrind], strlen(&sp->chars[bp->tt_abbrind]) + 1) == 0;
 	}
 
 	return result;
@@ -1397,6 +1405,7 @@ static void tzsetwall(void)
 void tzset(void)
 {
 	FAR const char *name;
+	size_t name_len;
 
 	name = getenv("TZ");
 	if (name == NULL) {
@@ -1404,13 +1413,15 @@ void tzset(void)
 		return;
 	}
 
-	if (g_lcl_isset > 0 && strcmp(g_lcl_tzname, name) == 0) {
+	name_len = strlen(name);
+
+	if (g_lcl_isset > 0 && strncmp(g_lcl_tzname, name, name_len + 1) == 0) {
 		return;
 	}
 
-	g_lcl_isset = strlen(name) < sizeof g_lcl_tzname;
+	g_lcl_isset = name_len < sizeof g_lcl_tzname;
 	if (g_lcl_isset) {
-		(void)strcpy(g_lcl_tzname, name);
+		(void)strncpy(g_lcl_tzname, name, name_len + 1);
 	}
 
 	if (lclptr == NULL) {
@@ -1430,7 +1441,7 @@ void tzset(void)
 		lclptr->ttis[0].tt_isdst = 0;
 		lclptr->ttis[0].tt_gmtoff = 0;
 		lclptr->ttis[0].tt_abbrind = 0;
-		(void)strcpy(lclptr->chars, GMT);
+		(void)strncpy(lclptr->chars, GMT, strlen(GMT) + 1);
 	} else if (tzload(name, lclptr, TRUE) != 0) {
 		if (name[0] == ':' || tzparse(name, lclptr, FALSE) != 0) {
 			(void)gmtload(lclptr);

--- a/lib/libc/unistd/lib_getcwd.c
+++ b/lib/libc/unistd/lib_getcwd.c
@@ -113,6 +113,7 @@
 FAR char *getcwd(FAR char *buf, size_t size)
 {
 	char *pwd;
+	size_t pwd_len;
 
 	/* Verify input parameters */
 
@@ -132,14 +133,15 @@ FAR char *getcwd(FAR char *buf, size_t size)
 
 	/* Verify that the cwd will fit into the user-provided buffer */
 
-	if (strlen(pwd) + 1 > size) {
+	pwd_len = strlen(pwd) + 1;
+	if (pwd_len > size) {
 		set_errno(ERANGE);
 		return NULL;
 	}
 
 	/* Copy the cwd to the user buffer */
 
-	strcpy(buf, pwd);
+	strncpy(buf, pwd, pwd_len);
 	sched_unlock();
 	return buf;
 }

--- a/os/kernel/task/task_setup.c
+++ b/os/kernel/task/task_setup.c
@@ -614,7 +614,7 @@ static inline int task_stackargsetup(FAR struct task_tcb_s *tcb, FAR char *const
 
 	stackargv[0] = str;
 	nbytes = strlen(name) + 1;
-	strcpy(str, name);
+	strncpy(str, name, nbytes);
 	str += nbytes;
 
 	/* Copy each argument */
@@ -627,7 +627,7 @@ static inline int task_stackargsetup(FAR struct task_tcb_s *tcb, FAR char *const
 
 		stackargv[i + 1] = str;
 		nbytes = strlen(argv[i]) + 1;
-		strcpy(str, argv[i]);
+		strncpy(str, argv[i], nbytes);
 		str += nbytes;
 	}
 


### PR DESCRIPTION
strcpy, strcmp, strcat are vulnerable functions, so changed to strncpy, strncmp, strncat.