### PR TITLE
kernel/binary_manager: Remove unused variable and call functions to use static global variables

### DIFF
--- a/os/arch/arm/src/armv7-m/up_assert.c
+++ b/os/arch/arm/src/armv7-m/up_assert.c
@@ -104,7 +104,6 @@
 #ifdef CONFIG_BINMGR_RECOVERY
 bool abort_mode = false;
 extern uint32_t g_assertpc;
-extern mqd_t g_binmgr_mq_fd;
 #endif
 /****************************************************************************
  * Pre-processor Definitions
@@ -440,29 +439,38 @@ static void _up_assert(int errorcode)
 static void recovery_user_assert(void)
 {
 	int ret;
+	mqd_t mqfd;
 	binmgr_request_t request_msg;
 	struct tcb_s *tcb;
 
-	request_msg.cmd = BINMGR_FAULT;
-	request_msg.requester_pid = getpid();
-	if (current_regs) {
-		tcb = sched_self();
-		sched_removereadytorun(tcb);
+	/* Get mqfd for sending recovery mesage to binary manager */
+	mqfd = binary_manager_get_mqfd();
+	if (mqfd != NULL) {
+		request_msg.cmd = BINMGR_FAULT;
+		request_msg.requester_pid = getpid();
+		if (current_regs) {
+			tcb = sched_self();
+			sched_removereadytorun(tcb);
 #if CONFIG_RR_INTERVAL > 0
-		tcb->timeslice = 0;
+			tcb->timeslice = 0;
 #endif
-		tcb->sched_priority = SCHED_PRIORITY_MIN;
-		sched_addreadytorun(tcb);
-	}
+			tcb->sched_priority = SCHED_PRIORITY_MIN;
+			sched_addreadytorun(tcb);
+		}
 
-	/* Send a message to binary manager with pid of the faulty task */
-
-	ret = mq_send(g_binmgr_mq_fd, (const char *)&request_msg, sizeof(binmgr_request_t), BINMGR_FAULT_PRIO);
-	DEBUGASSERT(ret == 0);
-	if (current_regs) {
-		tcb = sched_self();
-		current_regs = tcb->xcp.regs;
+		/* Send a message to binary manager with pid of the faulty task */
+		ret = mq_send(mqfd, (const char *)&request_msg, sizeof(binmgr_request_t), BINMGR_FAULT_PRIO);
+		if (ret == OK) {
+			if (current_regs) {
+				tcb = sched_self();
+				current_regs = tcb->xcp.regs;
+			}
+			/* Requested recovery to binary manager successfully */
+			return;
+		}
 	}
+	/* Failed to request for recovery to binary manager */
+	_up_assert(EXIT_FAILURE);
 }
 #endif
 

--- a/os/board/common/partitions.c
+++ b/os/board/common/partitions.c
@@ -103,7 +103,7 @@ void configure_partitions(void)
 		|| !strncmp(types, "romfs,", 6)
 #endif
 #ifdef CONFIG_BINARY_MANAGER
-		|| !strncmp(types, "kernel,", 7) || !strncmp(types, "bin,", 4) || !strncmp(types, "loadparam,", 10)
+		|| !strncmp(types, "kernel,", 7) || !strncmp(types, "bin,", 4)
 #endif
 		) {
 			if (ftl_initialize(partno, mtd_part)) {
@@ -158,8 +158,6 @@ void configure_partitions(void)
 				binary_manager_register_partition(partno, BINMGR_PART_KERNEL, part_name, partsize);
 			} else if (!strncmp(types, "bin,", 4)) {
 				binary_manager_register_partition(partno, BINMGR_PART_USRBIN, part_name, partsize);
-			} else if (!strncmp(types, "loadparam,", 10)) {
-				binary_manager_register_partition(partno, BINMGR_PART_LOADPARAM, part_name, partsize);
 			}
 #endif
 		}

--- a/os/include/tinyara/binary_manager.h
+++ b/os/include/tinyara/binary_manager.h
@@ -76,7 +76,6 @@ enum binary_statecb_state_e {
 enum binmgr_partition_type {
 	BINMGR_PART_KERNEL = 0,
 	BINMGR_PART_USRBIN,
-	BINMGR_PART_LOADPARAM,
 	BINMGR_PART_MAX,
 };
 

--- a/os/kernel/binary_manager/binary_manager.c
+++ b/os/kernel/binary_manager/binary_manager.c
@@ -46,19 +46,31 @@
 #endif
 
 /* Binary table, the first data [0] is for kernel. */
-binmgr_bininfo_t bin_table[BINARY_COUNT];
-int g_bin_count;
-int g_loadparam_part;
-mqd_t g_binmgr_mq_fd;
+static binmgr_bininfo_t bin_table[BINARY_COUNT];
+static int g_bin_count;
+static mqd_t g_binmgr_mq_fd;
 
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
+#ifdef CONFIG_BINMGR_RECOVERY
+/* Get a mqfd of binary manager for binary recovery */
+mqd_t binary_manager_get_mqfd(void)
+{
+	return g_binmgr_mq_fd;
+}
+#endif
 
 /* Get the number of user binaries */
 int binary_manager_get_binary_count(void)
 {
 	return g_bin_count;
+}
+
+/* Get a row of binary table with bin_idx */
+binmgr_bininfo_t *binary_manager_get_binary_data(int bin_idx)
+{
+	return &bin_table[bin_idx];
 }
 
 /* Register partitions : kernel, loadparam, user binaries */
@@ -72,9 +84,7 @@ void binary_manager_register_partition(int part_num, int part_type, char *name, 
 	}
 
 	/* Check partition type and register it */
-	if (part_type == BINMGR_PART_LOADPARAM) {
-		g_loadparam_part = part_num;
-	} else if (part_type == BINMGR_PART_KERNEL) {
+	if (part_type == BINMGR_PART_KERNEL) {
 		if (BIN_PARTSIZE(KERNEL_IDX, 0) > 0) {
 			/* Already registered first kernel partition, register it as second partition. */
 			BIN_PARTSIZE(KERNEL_IDX, 1) = part_size;

--- a/os/kernel/binary_manager/binary_manager.h
+++ b/os/kernel/binary_manager/binary_manager.h
@@ -102,26 +102,25 @@ struct statecb_node_s {
 };
 typedef struct statecb_node_s statecb_node_t;
 
-#define BIN_ID(bin_idx)                                 bin_table[bin_idx].bin_id
-#define BIN_STATE(bin_idx)                              bin_table[bin_idx].state
-#define BIN_USEIDX(bin_idx)                             bin_table[bin_idx].inuse_idx
-#define BIN_PARTSIZE(bin_idx, part_idx)                 bin_table[bin_idx].part_info[part_idx].part_size
-#define BIN_PARTNUM(bin_idx, part_idx)                  bin_table[bin_idx].part_info[part_idx].part_num
+binmgr_bininfo_t *binary_manager_get_binary_data(int bin_idx);
+#define BIN_ID(bin_idx)                                 binary_manager_get_binary_data(bin_idx)->bin_id
+#define BIN_STATE(bin_idx)                              binary_manager_get_binary_data(bin_idx)->state
+#define BIN_USEIDX(bin_idx)                             binary_manager_get_binary_data(bin_idx)->inuse_idx
+#define BIN_PARTSIZE(bin_idx, part_idx)                 binary_manager_get_binary_data(bin_idx)->part_info[part_idx].part_size
+#define BIN_PARTNUM(bin_idx, part_idx)                  binary_manager_get_binary_data(bin_idx)->part_info[part_idx].part_num
 
-#define BIN_VER(bin_idx)                                bin_table[bin_idx].bin_ver
-#define BIN_KERNEL_VER(bin_idx)                         bin_table[bin_idx].kernel_ver
-#define BIN_CBLIST(bin_idx)                             bin_table[bin_idx].cb_list
+#define BIN_VER(bin_idx)                                binary_manager_get_binary_data(bin_idx)->bin_ver
+#define BIN_KERNEL_VER(bin_idx)                         binary_manager_get_binary_data(bin_idx)->kernel_ver
+#define BIN_CBLIST(bin_idx)                             binary_manager_get_binary_data(bin_idx)->cb_list
 
-#define BIN_LOAD_ATTR(bin_idx)                          bin_table[bin_idx].load_attr
-#define BIN_NAME(bin_idx)                               bin_table[bin_idx].load_attr.bin_name
-#define BIN_SIZE(bin_idx)                               bin_table[bin_idx].load_attr.bin_size
-#define BIN_RAMSIZE(bin_idx)                            bin_table[bin_idx].load_attr.ram_size
-#define BIN_OFFSET(bin_idx)                             bin_table[bin_idx].load_attr.offset
-#define BIN_STACKSIZE(bin_idx)                          bin_table[bin_idx].load_attr.stack_size
-#define BIN_PRIORITY(bin_idx)                           bin_table[bin_idx].load_attr.priority
-#define BIN_COMPRESSION_TYPE(bin_idx)                   bin_table[bin_idx].load_attr.compression_type
-
-extern binmgr_bininfo_t bin_table[BINARY_COUNT];
+#define BIN_LOAD_ATTR(bin_idx)                          binary_manager_get_binary_data(bin_idx)->load_attr
+#define BIN_NAME(bin_idx)                               binary_manager_get_binary_data(bin_idx)->load_attr.bin_name
+#define BIN_SIZE(bin_idx)                               binary_manager_get_binary_data(bin_idx)->load_attr.bin_size
+#define BIN_RAMSIZE(bin_idx)                            binary_manager_get_binary_data(bin_idx)->load_attr.ram_size
+#define BIN_OFFSET(bin_idx)                             binary_manager_get_binary_data(bin_idx)->load_attr.offset
+#define BIN_STACKSIZE(bin_idx)                          binary_manager_get_binary_data(bin_idx)->load_attr.stack_size
+#define BIN_PRIORITY(bin_idx)                           binary_manager_get_binary_data(bin_idx)->load_attr.priority
+#define BIN_COMPRESSION_TYPE(bin_idx)                   binary_manager_get_binary_data(bin_idx)->load_attr.compression_type
 
 /****************************************************************************
  * Function Prototypes
@@ -145,6 +144,7 @@ extern binmgr_bininfo_t bin_table[BINARY_COUNT];
  *
  ****************************************************************************/
 void binary_manager_recovery(int pid);
+mqd_t binary_manager_get_mqfd(void);
 #endif
 
 int binary_manager_register_statecb(int pid, binmgr_cb_t *cb_info);


### PR DESCRIPTION
- Remove unused variable for loadparam partition
- Call functions to use static gloable variables