### PR TITLE
Make crashdump for common

### DIFF
--- a/os/arch/arm/src/common/up_watchdog.h
+++ b/os/arch/arm/src/common/up_watchdog.h
@@ -1,0 +1,42 @@
+/****************************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __ARCH_ARM_SRC_ARM_WATCHDOG_H
+#define __ARCH_ARM_SRC_ARM_WATCHDOG_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: up_watchdog_disable
+ *
+ * Description:
+ *   Disable board specific watchdog
+ *
+ * Cautions:
+ *   This can be only used if we cannot use driver structure like assert.
+ *
+ ****************************************************************************/
+void up_watchdog_disable(void);
+
+#endif							/* __ARCH_ARM_SRC_ARM_WATCHDOG_H */

--- a/os/arch/arm/src/imxrt/imxrt_wdog.c
+++ b/os/arch/arm/src/imxrt/imxrt_wdog.c
@@ -382,4 +382,19 @@ void up_wdog_keepalive(void)
 {
 	imxrt_wdog_refresh(WDOG1);
 }
+
+/****************************************************************************
+ * Name: up_watchdog_disable
+ *
+ * Description:
+ *   Disable board specific watchdog
+ *
+ * Cautions:
+ *   This can be only used if we cannot use driver structure like assert.
+ *
+ ****************************************************************************/
+void up_watchdog_disable(void)
+{
+	imxrt_wdog_disable_all();
+}
 #endif

--- a/os/arch/arm/src/s5j/s5j_watchdog.c
+++ b/os/arch/arm/src/s5j/s5j_watchdog.c
@@ -249,3 +249,18 @@ void s5j_watchdog_clear_int(void)
 {
 	putreg32(0xffffffff, S5J_WDT_WTCLRINT);
 }
+
+/****************************************************************************
+ * Name: up_watchdog_disable
+ *
+ * Description:
+ *   Disable board specific watchdog
+ *
+ * Cautions:
+ *   This can be only used if we cannot use driver structure like assert.
+ *
+ ****************************************************************************/
+void up_watchdog_disable(void)
+{
+	s5j_watchdog_disable();
+}

--- a/os/board/artik05x/src/Makefile
+++ b/os/board/artik05x/src/Makefile
@@ -72,10 +72,6 @@ else ifeq ($(CONFIG_AUDIO_ALC5658CHAR),y)
 CSRCS += artik055_alc5658char.c
 endif
 
-ifeq ($(CONFIG_BOARD_CRASHDUMP),y)
-CSRCS += artik05x_crashdump.c
-endif
-
 ifeq ($(CONFIG_MTD_PROGMEM),y)
 CSRCS += artik05x_progmem.c
 endif
@@ -88,6 +84,9 @@ ifeq ($(CONFIG_FLASH_PARTITION),y)
 DEPPATH += --dep-path $(TOPDIR)/board/common
 VPATH += :$(TOPDIR)/board/common
 CSRCS += partitions.c
+ifeq ($(CONFIG_BOARD_CRASHDUMP),y)
+CSRCS += crashdump.c
+endif
 endif
 
 # boardctl support

--- a/os/board/common/crashdump.c
+++ b/os/board/common/crashdump.c
@@ -29,6 +29,7 @@
 #include <chip.h>
 #include <arch/board/board.h>
 #include "up_internal.h"
+#include "up_watchdog.h"
 
 #include <tinyara/mm/heap_regioninfo.h>
 #include <tinyara/mm/mm.h>
@@ -195,12 +196,12 @@ void board_crashdump(uint32_t cur_sp, void *tcb, uint8_t *filename, int lineno)
 {
 	int ret = OK;
 
-#if defined(CONFIG_S5J_WATCHDOG)
+#if defined(CONFIG_WATCHDOG)
 	/* system under panic and we are dumping system state.
 	 * watchdog reset might stall the system, causing crashdump hang.
 	 * Hence let's disable watchdog reset during crashdump process.
 	 */
-	s5j_watchdog_disable();
+	up_watchdog_disable();
 #endif
 
 #if defined(CONFIG_BOARD_RAMDUMP_UART)

--- a/os/board/imxrt1020-evk/src/Makefile
+++ b/os/board/imxrt1020-evk/src/Makefile
@@ -84,6 +84,9 @@ ifeq ($(CONFIG_FLASH_PARTITION),y)
 DEPPATH += --dep-path $(TOPDIR)/board/common
 VPATH += :$(TOPDIR)/board/common
 CSRCS += partitions.c
+ifeq ($(CONFIG_BOARD_CRASHDUMP),y)
+CSRCS += crashdump.c
+endif
 endif
 
 # boardctl support

--- a/os/board/imxrt1050-evk/src/Makefile
+++ b/os/board/imxrt1050-evk/src/Makefile
@@ -84,6 +84,9 @@ ifeq ($(CONFIG_FLASH_PARTITION),y)
 DEPPATH += --dep-path $(TOPDIR)/board/common
 VPATH += :$(TOPDIR)/board/common
 CSRCS += partitions.c
+ifeq ($(CONFIG_BOARD_CRASHDUMP),y)
+CSRCS += crashdump.c
+endif
 endif
 
 # boardctl support


### PR DESCRIPTION
1.    arch/arm/src : Add up_watchdog_disable
    up_watchdog_disable calls board specific watchdog disable function.

2.     board/crashdump : Make crashdump.c for common
    For using crashdump with another board, make crashdump.c in board/common, and remove artik specific crashdump.c
