### PR TITLE
kernel/task_monitor : Support a variety of intervals to check the task

### DIFF
--- a/os/include/tinyara/task_monitor.h
+++ b/os/include/tinyara/task_monitor.h
@@ -25,7 +25,7 @@
 
 #ifdef CONFIG_TASK_MONITOR
 
-void task_monitor_register(void);
+int task_monitor_register(int interval);
 void task_monitor_update_status(void);
 
 #ifdef __cplusplus

--- a/os/kernel/task/task_prctl.c
+++ b/os/kernel/task/task_prctl.c
@@ -244,7 +244,13 @@ int prctl(int option, ...)
 #ifdef CONFIG_TASK_MONITOR
 	case PR_MONITOR_REGISTER:
 	{
-		task_monitor_update_list(getpid(), MONITORED);
+		int interval = va_arg(ap, int);
+		int ret;
+		ret = task_monitor_register_list(getpid(), interval);
+		if (ret < 0) {
+			err = ret;
+			goto errout;
+		}
 	}
 	break;
 	case PR_MONITOR_UPDATE:

--- a/os/kernel/task/task_terminate.c
+++ b/os/kernel/task/task_terminate.c
@@ -193,7 +193,7 @@ int task_terminate(pid_t pid, bool nonblocking)
 	dtcb->task_state = TSTATE_TASK_INVALID;
 #ifdef CONFIG_TASK_MONITOR
 	/* Unregister this pid from task monitor */
-	task_monitor_update_list(pid, NOT_MONITORED);
+	task_monitor_unregester_list(pid);
 #endif
 	irqrestore(saved_state);
 

--- a/os/kernel/task_monitor/Kconfig
+++ b/os/kernel/task_monitor/Kconfig
@@ -22,9 +22,20 @@ config TASK_MONITOR_PRIORITY
 
 config TASK_MONITOR_INTERVAL
 	int "Interval for checking alive(sec)"
-	default 10
+	default 5
 	---help---
 		Task Monitor checks the registered tasks/pthreads active status
-		every this interval.
+		every this interval. If TASK_MONITOR_INTERVAL set by 5, Interval
+		value can use as 5, 10, 15 .... and TASK_MONITOR_MAX_INTERVAL.
 
+config TASK_MONITOR_MAX_INTERVAL
+	int "Max interval for checking alive(sec)"
+	default 20
+	---help---
+		It is maximum interval for task check and should be set to 
+		a multiple of TASK_MONITOR_INTERVAL. If it is not a multiple
+		of TASK_MONITOR_INTERVAL, it is set to the previous multiple.
+		ex) If TASK_MONITOR_INTERVAL set by 5 and TASK_MONITOR_MAX_INTERVAL
+		set by 17, Interval value can use as 5, 10 and 15.
+		
 endif # TASK_MONITOR

--- a/os/kernel/task_monitor/task_monitor.c
+++ b/os/kernel/task_monitor/task_monitor.c
@@ -19,32 +19,117 @@
  * Included Files
  ****************************************************************************/
 #include <tinyara/config.h>
+
+#include <errno.h>
 #include <sched.h>
+#include <queue.h>
+#include <semaphore.h>
+
 #include <sys/boardctl.h>
 #include <tinyara/sched.h>
+
 #include "task_monitor_internal.h"
 
-static int monitored_tasks_list[CONFIG_MAX_TASKS];
+static task_monitor_node_t g_monitored_tasks_list[CONFIG_MAX_TASKS];
+static task_monitor_node_queue_t g_que_list[TASK_MONITOR_CHECK_TIME];
+static int g_monitor_cnt;
+static sem_t g_stop_sem;
 
-void task_monitor_update_list(int pid, int status)
+int task_monitor_register_list(int pid, int interval)
 {
-	monitored_tasks_list[PIDHASH(pid)] = status;
+	if (interval < CONFIG_TASK_MONITOR_INTERVAL || CONFIG_TASK_MONITOR_MAX_INTERVAL < interval) {
+		dbg("Must be greater than %d and less than or equal to %d.\n", CONFIG_TASK_MONITOR_INTERVAL, CONFIG_TASK_MONITOR_MAX_INTERVAL);
+		return EINVAL;
+	}
+
+	int hash_pid = PIDHASH(pid);
+	if (g_monitored_tasks_list[hash_pid].interval != 0) {
+		dbg("Already registered.\n");
+		return EALREADY;
+	}
+
+	g_monitored_tasks_list[hash_pid].pid = pid;
+	if (interval % CONFIG_TASK_MONITOR_INTERVAL == 0) {
+		g_monitored_tasks_list[hash_pid].interval = interval / CONFIG_TASK_MONITOR_INTERVAL;
+	} else {
+		/* If a value that is not divided, it is rounded up. */
+		g_monitored_tasks_list[hash_pid].interval = (interval / CONFIG_TASK_MONITOR_INTERVAL) + 1;
+		if (g_monitored_tasks_list[hash_pid].interval > TASK_MONITOR_CHECK_TIME) {
+			g_monitored_tasks_list[hash_pid].interval--;
+		}
+	}
+
+	dq_addlast((FAR dq_entry_t *)&g_monitored_tasks_list[hash_pid], &g_que_list[interval - 1].q);
+
+	g_monitor_cnt++;
+	if (g_monitor_cnt == 1) {
+		sem_post(&g_stop_sem);
+	}
+	return OK;
 }
 
+void task_monitor_unregester_list(int pid)
+{
+	int hash_pid;
+	int interval;
+	hash_pid = PIDHASH(pid);
+
+	if (g_monitored_tasks_list[hash_pid].interval == 0) {
+		/* Not registered. */
+		return;
+	}
+
+	g_monitored_tasks_list[hash_pid].pid = 0;
+	interval = g_monitored_tasks_list[hash_pid].interval;
+	g_monitored_tasks_list[hash_pid].interval = 0;
+
+	dq_rem((FAR dq_entry_t *)&g_monitored_tasks_list[hash_pid], &g_que_list[interval - 1].q);
+
+	g_monitor_cnt--;
+}
+
+static void task_monitor_init(void)
+{
+	int pid_idx;
+	int time_idx;
+
+	/* Initialize the dequeue list */
+	for (time_idx = 0; time_idx < TASK_MONITOR_CHECK_TIME; ++time_idx) {
+		g_que_list[time_idx].remaining_count = time_idx;
+		dq_init(&(g_que_list[time_idx].q));
+	}
+
+	/* Initialize the monitored tasks list */
+	for (pid_idx = 0; pid_idx < CONFIG_MAX_TASKS; pid_idx++) {
+		g_monitored_tasks_list[pid_idx].flink = NULL;
+		g_monitored_tasks_list[pid_idx].blink = NULL;
+		g_monitored_tasks_list[pid_idx].pid = 0;
+		g_monitored_tasks_list[pid_idx].interval = 0;
+	}
+
+	g_monitor_cnt = 0;
+	sem_init(&g_stop_sem, 0, 0);
+}
 /****************************************************************************
  * Main Function
  ****************************************************************************/
 int task_monitor(int argc, char *argv[])
 {
-	int pid_idx;
+	int time_idx;
 	struct tcb_s *tcb;
+	task_monitor_node_t *next_mon_node;
 
-	/* Initialize the monitored tasks list */
-	for (pid_idx = 0; pid_idx < CONFIG_MAX_TASKS; pid_idx++) {
-		monitored_tasks_list[pid_idx] = NOT_MONITORED;
-	}
+	task_monitor_init();
 
 	while (1) {
+
+		if (g_monitor_cnt == 0) {
+			/* if g_monitor_cnt is 0,
+			 * task_monitor is not working.
+			 */
+			while (sem_wait(&g_stop_sem) < 0);
+		}
+
 		if (sleep(CONFIG_TASK_MONITOR_INTERVAL) > 0) {
 			/* Wake up because of signal.
 			 * In this case, reset the interval again.
@@ -55,26 +140,36 @@ int task_monitor(int argc, char *argv[])
 		/* Check if registered tasks/pthread is alive or not.
 		 * If one of them is not alive, task monitor resets the system.
 		 */
-		for (pid_idx = 0; pid_idx < CONFIG_MAX_TASKS; pid_idx++) {
-			if (monitored_tasks_list[pid_idx] == MONITORED) {
-				tcb = sched_gettcb(pid_idx);
-				if (tcb == NULL) {
-					/* Invalid operation */
-					boardctl(BOARDIOC_RESET, 0);
-				}
+		for (time_idx = 0; time_idx < TASK_MONITOR_CHECK_TIME; ++time_idx) {
 
-				if (tcb->is_active == false) {
-					/* There is not alive task/pthread.
-					 * System will be reset.
-					 */
-					boardctl(BOARDIOC_RESET, 0);
-				} else {
-					/* Reset the registered task's/pthread's active flag. */
-					tcb->is_active = false;
+			if (g_que_list[time_idx].remaining_count == 0) {
+
+				next_mon_node = (task_monitor_node_t *)dq_peek(&g_que_list[time_idx - 1].q);
+
+				while (next_mon_node != NULL) {
+
+					tcb = sched_gettcb(next_mon_node->pid);
+
+					if (tcb == NULL || tcb->is_active == false) {
+						/* Invalid operation and
+						*  There is not alive task/pthread.
+						*  System will be reset.
+						*/
+						boardctl(BOARDIOC_RESET, 0);
+					} else {
+						/* Reset the registered task's/pthread's active flag. */
+						tcb->is_active = false;
+					}
+					next_mon_node = (task_monitor_node_t *)dq_prev(next_mon_node);
 				}
+				/* Restore the check time. */
+				g_que_list[time_idx].remaining_count = time_idx;
+			} else {
+				g_que_list[time_idx].remaining_count--;
 			}
 		}
 	}
 
+	(void)sem_destroy(&g_stop_sem);
 	return 0;
 }

--- a/os/kernel/task_monitor/task_monitor_internal.h
+++ b/os/kernel/task_monitor/task_monitor_internal.h
@@ -22,17 +22,33 @@
 /****************************************************************************
  * Included Files
  ****************************************************************************/
-
-#define NOT_MONITORED (-1)
-#define MONITORED     (0)
+#include <queue.h>
 
 #ifdef CONFIG_TASK_MONITOR
+
+#define TASK_MONITOR_CHECK_TIME    (CONFIG_TASK_MONITOR_MAX_INTERVAL / CONFIG_TASK_MONITOR_INTERVAL)
+
+struct task_monitor_node_s {
+	FAR struct task_monitor_node_s *flink;	/* Doubly linked list */
+	FAR struct task_monitor_node_s *blink;
+	int pid;				/* tcb's pid */
+	int interval;
+};
+
+typedef struct task_monitor_node_s task_monitor_node_t;
+
+struct task_monitor_node_queue_s {
+	dq_queue_t q;
+	int remaining_count;
+};
+
+typedef struct task_monitor_node_queue_s task_monitor_node_queue_t;
 
 /****************************************************************************
  * Function Prototypes
  ****************************************************************************/
 int task_monitor(int argc, char *argv[]);
-void task_monitor_update_list(int pid, int status);
-
+int task_monitor_register_list(int pid, int interval);
+void task_monitor_unregester_list(int pid);
 #endif							/* CONFIG_TASK_MONITOR */
 #endif							/* __SCHED_TASK_MONITOR_TASK_MONITOR_INTERNAL_H */

--- a/os/kernel/task_monitor/task_monitor_utils.c
+++ b/os/kernel/task_monitor/task_monitor_utils.c
@@ -21,9 +21,9 @@
 #include <sys/prctl.h>
 #include <sys/types.h>
 
-void task_monitor_register(void)
+int task_monitor_register(int interval)
 {
-	prctl(PR_MONITOR_REGISTER, NULL);
+	return prctl(PR_MONITOR_REGISTER, interval);
 }
 
 void task_monitor_update_status(void)


### PR DESCRIPTION
By setting the interval and the maximum interval,
It can check the task to the interval multiples.

If it config TASK_MONITOR_INTERVAL to 5 and TASK_MONITOR_MAX_INTERVAL to 20,
The available interval are 5, 10, 15 and 20.