### PR TITLE
kernel/semaphore: Remove unnecessary code for semaphore list

### DIFF
--- a/lib/libc/semaphore/sem_init.c
+++ b/lib/libc/semaphore/sem_init.c
@@ -134,7 +134,9 @@ int sem_init(FAR sem_t *sem, int pshared, unsigned int value)
 
 #if defined(CONFIG_BINMGR_RECOVERY) && defined(__KERNEL__)
 		/* Register semaphore in kernel region for kernel resource management */
-		sem_register(sem);
+		if (sem->semcount != 0) {
+			sem_register(sem);
+		}
 #endif
 		return OK;
 	} else {

--- a/os/fs/vfs/fs_fdopen.c
+++ b/os/fs/vfs/fs_fdopen.c
@@ -226,10 +226,6 @@ FAR struct file_struct *fs_fdopen(int fd, int oflags, FAR struct tcb_s *tcb)
 	for (i = 0; i < CONFIG_NFILE_STREAMS; i++) {
 		stream = &slist->sl_streams[i];
 		if (stream->fs_fd < 0) {
-			/* Zero the structure */
-
-			memset(stream, 0, sizeof(FILE));
-
 #if CONFIG_STDIO_BUFFER_SIZE > 0
 			/* Initialize the semaphore the manages access to the buffer */
 

--- a/os/kernel/binary_manager/binary_manager_recovery.c
+++ b/os/kernel/binary_manager/binary_manager_recovery.c
@@ -81,15 +81,6 @@ static void recovery_release_binary_sem(int binid)
 #endif
 		{
 			if (holder && holder->htcb && holder->htcb->group && holder->htcb->group->tg_loadtask == binid) {
-				/* No saved holder for semaphore used for signaling */
-				if ((sem->flags & FLAGS_SIGSEM) != 0) {
-#if CONFIG_SEM_PREALLOCHOLDERS > 0
-					break;
-#else
-					sem = sq_next(sem);
-					continue;
-#endif
-				}
 				/* Increase semcount and release itself from holder */
 				sem->semcount++;
 				sem_releaseholder(sem, holder->htcb);

--- a/os/kernel/semaphore/sem_destroy.c
+++ b/os/kernel/semaphore/sem_destroy.c
@@ -149,7 +149,9 @@ int sem_destroy(FAR sem_t *sem)
 		sem_destroyholder(sem);
 
 #ifdef CONFIG_BINMGR_RECOVERY
-		sem_unregister(sem);
+		if ((sem->flags & FLAGS_SIGSEM) == 0) {
+			sem_unregister(sem);
+		}
 #endif
 		sem->flags &= ~FLAGS_INITIALIZED;
 		return OK;


### PR DESCRIPTION
- fs/vfs: Remove duplicated code to initialize stream structure
- kernel/binary_manager: Exclude semaphore for signaling for a list of kernel semaphores