### PR TITLE
dumparser: Adding line information to callstack

### DIFF
--- a/tools/ramdump/dumpParser.py
+++ b/tools/ramdump/dumpParser.py
@@ -442,7 +442,14 @@ class dumpParser:
 			else:
 				symname, offset = r # Update both symbol name and offset
 
-			pstring = (extra_str + '[<{0:x}>] {1}+0x{2:x}'.format(frame.pc, symname, offset))
+			address = '{0:x}'.format(frame.pc)
+			cmd = ['addr2line', '-e', self.elf, address]
+			fd_popen = subprocess.Popen(cmd, stdout=subprocess.PIPE).stdout
+			data = fd_popen.read()
+			temp = data.split('/')[-1]
+			line = temp.split(':')[-1].rstrip()
+			name = temp[:-len(line)-2]
+			pstring = (extra_str + '[<{0:x}>] {1}+0x{2:x} [Line {3} of {4}]'.format(frame.pc, symname, offset, line, name))
 
 			if output_file:
 				out_file.write(pstring + '\n')


### PR DESCRIPTION
This patch will add line and file information to callstack as
below

CALL STACK of Aborted task:
*******************************************************************
[<40c9990>] save_cpuctxt_regs+0x54 [Line 585 of arm_assert.c]
[<40c9cb4>] up_assert+0x250 [Line 374 of irq.h]
[<40d5674>] hello_main+0x18 [Line 77 of hello_main.c]
[<40cca6c>] task_start+0x50 [Line 166 of task_start.c]

Signed-off-by: Siju Cherian <siju.cherian@samsung.com>