### PR TITLE
examples/bluetooth: Supplement bt_unit_test code

### DIFF
--- a/apps/examples/bluetooth/Kconfig
+++ b/apps/examples/bluetooth/Kconfig
@@ -6,7 +6,7 @@
 config EXAMPLES_BT_UNIT_TEST
 	bool "Enable bt_unit_test"
 	default n
-	depends on !BUILD_PROTECTED
+	depends on BLUETOOTH
 	---help---
 		Enable bt_unit_test
 

--- a/apps/examples/bluetooth/bt_unit_test.c
+++ b/apps/examples/bluetooth/bt_unit_test.c
@@ -111,15 +111,6 @@ static const char *__bt_get_error_message(bt_error_e err)
 	return err_str;
 }
 
-static void __state_changed_cb(int result, bt_adapter_state_e adapter_state, void *user_data)
-{
-	TC_PRT("__state_changed_cb\n");
-	TC_PRT("result: %s\n", __bt_get_error_message(result));
-	TC_PRT("state: %s\n", (adapter_state == BT_ADAPTER_ENABLED) ? "ENABLED" : "DISABLED");
-
-	adapter_enabled = ((adapter_state == BT_ADAPTER_ENABLED) ? true : false);
-}
-
 static void __discovery_state_changed_cb(int result, bt_adapter_device_discovery_state_e discovery_state, bt_adapter_device_discovery_info_s *discovery_info, void *user_data)
 {
 	int i;
@@ -265,6 +256,37 @@ static void __le_scan_result_cb(int result, bt_adapter_le_device_scan_result_inf
 	}
 }
 
+static void __state_changed_cb(int result, bt_adapter_state_e adapter_state, void *user_data)
+{
+	int ret;
+	char *name = NULL;
+
+	TC_PRT("__state_changed_cb\n");
+	TC_PRT("result: %s\n", __bt_get_error_message(result));
+	TC_PRT("state: %s\n", (adapter_state == BT_ADAPTER_ENABLED) ? "ENABLED" : "DISABLED");
+
+//	adapter_enabled = ((adapter_state == BT_ADAPTER_ENABLED) ? true : false);
+
+	if (!(adapter_state == true && result == BT_ERROR_NONE)) {
+		TC_PRT("Adapter is NOT enabled\n");
+		return;
+	}
+
+	ret = bt_adapter_get_name(&name);
+	TC_PRT("bt_adapter_get_name() returns %s\n", __bt_get_error_message(ret));
+	TC_PRT("name: [%s]\n", name);
+
+	ret = bt_adapter_set_name("Test Name");
+	TC_PRT("bt_adapter_set_name() returns %s\n", __bt_get_error_message(ret));
+
+	ret = bt_adapter_get_name(&name);
+	TC_PRT("bt_adapter_get_name() returns %s\n", __bt_get_error_message(ret));
+	TC_PRT("name: [%s]\n", name);
+
+	ret = bt_adapter_le_start_scan(__le_scan_result_cb, NULL);
+	TC_PRT("bt_adapter_le_start_scan() returns %s\n", __bt_get_error_message(ret));
+}
+
 #if 0
 static bool __check_adapter_enabled(void *data)
 {
@@ -282,18 +304,18 @@ int bt_unit_test_main(int argc, char **argv)
 	TC_PRT("Enter bt_unit_test_main()\n");
 
 	ret = bt_initialize();
-	TC_PRT("returns %s\n", __bt_get_error_message(ret));
+	TC_PRT("bt_initialize() returns %s\n", __bt_get_error_message(ret));
 
 	ret = bt_adapter_set_state_changed_cb(__state_changed_cb, NULL);
-	TC_PRT("returns %s\n", __bt_get_error_message(ret));
+	TC_PRT("bt_adapter_set_state_changed_cb() returns %s\n", __bt_get_error_message(ret));
 
 	ret = bt_adapter_enable();
-	TC_PRT("returns %s\n", __bt_get_error_message(ret));
+	TC_PRT("bt_adapter_enable() returns %s\n", __bt_get_error_message(ret));
 
 // TODO: temporarily block the code because if EVENTLOOP feature is enabled, can NOT enter TASH shell.
 //	eventloop_add_timer_async(1000, true, __check_adapter_enabled, NULL);
 //	eventloop_loop_run();
-
+/*
 	ret = bt_adapter_set_device_discovery_state_changed_cb(__discovery_state_changed_cb, NULL);
 	TC_PRT("returns %s\n", __bt_get_error_message(ret));
 
@@ -302,6 +324,6 @@ int bt_unit_test_main(int argc, char **argv)
 
 	ret = bt_adapter_le_start_scan(__le_scan_result_cb, NULL);
 	TC_PRT("returns %s\n", __bt_get_error_message(ret));
-
+*/
 	return 0;
 }

--- a/framework/src/bluetooth/adaptation/bt-adatation-adapter.c
+++ b/framework/src/bluetooth/adaptation/bt-adatation-adapter.c
@@ -73,17 +73,25 @@ int bt_adapt_get_local_name(char **name)
 {
 	BT_PRT("Enter\n");
 
-	name = bt_get_name();
+	*name = bt_get_name();
 
-	BT_PRT("name: %s\n", name);
+	BT_PRT("name: %s\n", *name);
 
 	return BT_ERROR_NONE;
 }
 
 int bt_adapt_set_local_name(const char *name)
 {
-	/* To be implemented */
-	return BT_ERROR_NONE;
+	int ret = BT_ERROR_NONE;
+
+	BT_PRT("Enter\n");
+
+	ret = bt_set_name(name);
+	if (ret != BT_ERROR_NONE) {
+		BT_ERR("%s(0x%08x)\n", _bt_convert_error_to_string(ret), ret);
+	}
+
+	return ret;
 }
 
 int bt_adapt_get_discoverable_mode(bt_adapter_visibility_mode_e *mode)


### PR DESCRIPTION
framework/bluetooth: Add set_local_name function, 