### PR TITLE
framework/media: Fix a bug in StreamHandler

### DIFF
--- a/framework/src/media/StreamHandler.cpp
+++ b/framework/src/media/StreamHandler.cpp
@@ -95,7 +95,7 @@ void StreamHandler::createWorker()
 	medvdbg("StreamHandler::createWorker()\n");
 	if (mStreamBuffer && !mIsWorkerAlive) {
 		resetWorker();
-		mStreamBuffer = nullptr;
+		mStreamBuffer->reset();
 		mIsWorkerAlive = true;
 
 		pthread_attr_t attr;


### PR DESCRIPTION
mStreamBuffer should be reset in createWorker.
@zhouxinhe found this bug.