### PR TITLE
fs/procfs/fs_procfsproc : Fix missing change about getting kernel heap

### DIFF
--- a/os/fs/procfs/fs_procfsproc.c
+++ b/os/fs/procfs/fs_procfsproc.c
@@ -389,7 +389,7 @@ static ssize_t proc_entry_stat(FAR struct proc_file_s *procfile, FAR struct tcb_
 #ifndef CONFIG_BUILD_PROTECTED
 		heap = mm_get_heap_with_index(0);
 #else
-		heap = &g_kmmheap;
+		heap = kmm_get_heap();
 #endif
 	} else {
 		heap = mm_get_heap(tcb->stack_alloc_ptr);


### PR DESCRIPTION
There is a missing change about getting kernel heap(commit 0be6d2a5e3e16f)
Change to get the kernel heap with kmm_get_heap API instead of direct access