### PR TITLE
kernel/pthread: make internal pthread_join function to remove duplication

### DIFF
--- a/apps/examples/testcase/le_tc/kernel/tc_pthread.c
+++ b/apps/examples/testcase/le_tc/kernel/tc_pthread.c
@@ -34,8 +34,11 @@
 #include <pthread.h>
 #include <errno.h>
 #include <sys/types.h>
-#include "../../../../../os/kernel/group/group.h"
 #include "tc_internal.h"
+
+/****************************************************************************
+ * Definitions
+ ****************************************************************************/
 
 #define SEC_1                   1
 #define SEC_2                   2
@@ -55,37 +58,40 @@
 #define NOSIG                   333
 #define INVALID_PID             (-1)
 
-struct mallinfo mem;
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
 
-pthread_t g_thread1;
-pthread_t g_thread2;
-pthread_t thread[PTHREAD_CNT];
+static pthread_t g_thread1;
+static pthread_t g_thread2;
 
-pthread_mutex_t g_mutex = PTHREAD_MUTEX_INITIALIZER;
-pthread_cond_t g_cond;
+static pthread_mutex_t g_mutex = PTHREAD_MUTEX_INITIALIZER;
+static pthread_cond_t g_cond;
 static pthread_once_t g_once;
 static bool g_bpthreadcallback = false;
 
 static int g_cnt;
-bool g_maskquitrecv;
-bool g_maskusrrecv;
 
-pthread_barrier_t g_pthread_barrier;
-int g_barrier_count_in = 0;
-int g_barrier_count_out = 0;
-int g_barrier_count_spare = 0;
+static pthread_barrier_t g_pthread_barrier;
+static int g_barrier_count_in = 0;
+static int g_barrier_count_out = 0;
+static int g_barrier_count_spare = 0;
 
 static pthread_mutex_t g_mutex_timedwait;
 static pthread_cond_t cond;
 static int g_mutex_cnt = 0;
 
-int g_cond_sig_val = 0;
+static int g_cond_sig_val = 0;
 
 static bool g_sig_handle = false;
 
-pthread_t self_pid;
-volatile uint8_t check_prio;
+static pthread_t self_pid;
+static volatile uint8_t check_prio;
 static int chk_val;
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
 
 static void *infinite_loop_thread(void *param)
 {
@@ -1517,7 +1523,7 @@ static void tc_pthread_pthread_testcancel(void)
 #endif
 
 /****************************************************************************
- * Name: pthread
+ * Name: pthread_main
  ****************************************************************************/
 
 int pthread_main(void)

--- a/apps/examples/testcase/le_tc/kernel/tc_pthread.c
+++ b/apps/examples/testcase/le_tc/kernel/tc_pthread.c
@@ -651,7 +651,7 @@ static void tc_pthread_pthread_tryjoin_np(void)
 	sleep(SEC_1);
 
 	ret_chk = pthread_tryjoin_np(pid, &pexit_value);
-	TC_ASSERT_EQ("pthread_tryjoin_np", ret_chk, ESRCH);
+	TC_ASSERT_EQ("pthread_tryjoin_np", ret_chk, OK);
 
 	ret_chk = pthread_create(&pid, NULL, pthread_exit_thread, NULL);
 	TC_ASSERT_EQ("pthread create", ret_chk, OK);

--- a/os/kernel/pthread/Make.defs
+++ b/os/kernel/pthread/Make.defs
@@ -53,7 +53,7 @@
 ifneq ($(CONFIG_DISABLE_PTHREAD),y)
 
 CSRCS += pthread_create.c pthread_exit.c pthread_join.c pthread_detach.c
-CSRCS += pthread_tryjoin_np.c
+CSRCS += pthread_tryjoin_np.c pthread_join_internal.c
 CSRCS += pthread_getschedparam.c pthread_setschedparam.c
 CSRCS += pthread_mutexinit.c pthread_mutexdestroy.c
 CSRCS += pthread_mutexlock.c pthread_mutextrylock.c pthread_mutexunlock.c

--- a/os/kernel/pthread/pthread.h
+++ b/os/kernel/pthread/pthread.h
@@ -120,6 +120,7 @@ void pthread_cleanup_popall(FAR struct pthread_tcb_s *tcb);
 int pthread_completejoin(pid_t pid, FAR void *exit_value);
 void pthread_destroyjoin(FAR struct task_group_s *group, FAR struct join_s *pjoin);
 FAR struct join_s *pthread_findjoininfo(FAR struct task_group_s *group, pid_t pid);
+int pthread_join_internal(pthread_t thread, FAR pthread_addr_t *pexit_value, bool blocking);
 void pthread_release(FAR struct task_group_s *group);
 int pthread_sem_take(sem_t *sem, bool intr);
 #ifdef CONFIG_PTHREAD_MUTEX_UNSAFE

--- a/os/kernel/pthread/pthread_join_internal.c
+++ b/os/kernel/pthread/pthread_join_internal.c
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- * Copyright 2016 Samsung Electronics All Rights Reserved.
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -65,6 +65,8 @@
 #include <tinyara/cancelpt.h>
 #include <tinyara/ttrace.h>
 
+#include "sched/sched.h"
+#include "group/group.h"
 #include "pthread/pthread.h"
 
 /****************************************************************************
@@ -92,7 +94,7 @@
  ****************************************************************************/
 
 /****************************************************************************
- * Name: pthread_join
+ * Name: pthread_join_internal
  *
  * Description:
  *    A thread can await termination of another thread and retrieve the
@@ -105,6 +107,7 @@
  * Parameters:
  *   thread
  *   pexit_value
+ *   blocking
  *
  * Return Value:
  *   0 if successful.  Otherwise, one of the following error codes:
@@ -115,27 +118,158 @@
  *           given thread ID.
  *   EDEADLK A deadlock was detected or the value of thread specifies the
  *           calling thread.
+ *   EBUSY   Thread is still alive even non-blocking is given.
  *
  * Assumptions:
  *
  ****************************************************************************/
 
-int pthread_join(pthread_t thread, FAR pthread_addr_t *pexit_value)
+int pthread_join_internal(pthread_t thread, FAR pthread_addr_t *pexit_value, bool blocking)
 {
+	FAR struct tcb_s *rtcb = this_task();
+	FAR struct task_group_s *group = rtcb->group;
+	FAR struct join_s *pjoin;
 	int ret;
 
-	trace_begin(TTRACE_TAG_TASK, "pthread_join");
+	svdbg("thread=%d group=%p\n", thread, group);
+	DEBUGASSERT(group);
 
-	/* pthread_join() is a cancellation point */
+	/* First make sure that this is not an attempt to join to
+	 * ourself.
+	 */
 
-	(void)enter_cancellation_point();
+	if ((pid_t)thread == getpid()) {
+		return EDEADLK;
+	}
 
-	/* Execute internal function with blocking */
+	/* Make sure no other task is mucking with the data structures
+	 * while we are performing the following operations.  NOTE:
+	 * we can be also sure that pthread_exit() will not execute
+	 * because it will also attempt to get this semaphore.
+	 */
 
-	ret = pthread_join_internal(thread, pexit_value, true);
+	(void)pthread_sem_take(&group->tg_joinsem, false);
 
-	svdbg("Returning %d\n", ret);
-	leave_cancellation_point();
-	trace_end(TTRACE_TAG_TASK);
+	/* Find the join information associated with this thread.
+	 * This can fail for one of three reasons:  (1) There is no
+	 * thread associated with 'thread,' (2) the thread is a task
+	 * and does not have join information, or (3) the thread
+	 * was detached and has exited.
+	 */
+
+	pjoin = pthread_findjoininfo(group, (pid_t)thread);
+	if (!pjoin) {
+		/* Determine what kind of error to return */
+
+		FAR struct tcb_s *tcb = sched_gettcb((pthread_t)thread);
+
+		sdbg("Could not find thread data\n");
+
+		/* Case (1) or (3) -- we can't tell which.  Assume (3) */
+
+		if (!tcb) {
+			ret = ESRCH;
+		}
+
+		/* The thread is still active but has no join info.  In that
+		 * case, it must be a task and not a pthread.
+		 */
+
+		else {
+			ret = EINVAL;
+		}
+
+		(void)pthread_sem_give(&group->tg_joinsem);
+	} else {
+		/* We found the join info structure.  Increment for the reference
+		 * to the join structure that we have.  This will keep things
+		 * stable for we have to do
+		 */
+
+		sched_lock();
+		pjoin->crefs++;
+
+		/* Check if the thread is still running.  If not, then things are
+		 * simpler.  There are still race conditions to be concerned with.
+		 * For example, there could be multiple threads executing in the
+		 * 'else' block below when we enter!
+		 */
+
+		if (pjoin->terminated) {
+			svdbg("Thread has terminated\n");
+
+			/* Get the thread exit value from the terminated thread. */
+
+			if (pexit_value) {
+				svdbg("exit_value=0x%p\n", pjoin->exit_value);
+				*pexit_value = pjoin->exit_value;
+			}
+		} else {
+			svdbg("Thread is still running\n");
+
+			if (blocking == true) {
+				/* Relinquish the data set semaphore.  Since pre-emption is
+				 * disabled, we can be certain that no task has the
+				 * opportunity to run between the time we relinquish the
+				 * join semaphore and the time that we wait on the thread exit
+				 * semaphore.
+				 */
+
+				(void)pthread_sem_give(&group->tg_joinsem);
+
+				/* Take the thread's thread exit semaphore.  We will sleep here
+				 * until the thread exits.  We need to exercise caution because
+				 * there could be multiple threads waiting here for the same
+				 * pthread to exit.
+				 */
+
+				(void)pthread_sem_take(&pjoin->exit_sem, false);
+
+				/* The thread has exited! Get the thread exit value */
+
+				if (pexit_value) {
+					*pexit_value = pjoin->exit_value;
+					svdbg("exit_value=0x%p\n", pjoin->exit_value);
+				}
+
+				/* Post the thread's data semaphore so that the exiting thread
+				 * will know that we have received the data.
+				 */
+
+				(void)pthread_sem_give(&pjoin->data_sem);
+
+				/* Retake the join semaphore, we need to hold this when
+				 * pthread_destroyjoin is called.
+				 */
+
+				(void)pthread_sem_take(&group->tg_joinsem, false);
+			} else {
+				sdbg("fail to get exit value\n");
+
+				sched_unlock();
+				pjoin->crefs--;
+				(void)pthread_sem_give(&group->tg_joinsem);
+				return EBUSY;
+			}
+		}
+
+		/* Pre-emption is okay now. The logic still cannot be re-entered
+		 * because we hold the join semaphore
+		 */
+
+		sched_unlock();
+
+		/* Release our reference to the join structure and, if the reference
+		 * count decrements to zero, deallocate the join structure.
+		 */
+
+		if (--pjoin->crefs <= 0) {
+			(void)pthread_destroyjoin(group, pjoin);
+		}
+
+		(void)pthread_sem_give(&group->tg_joinsem);
+		ret = OK;
+	}
+
 	return ret;
 }

--- a/os/kernel/pthread/pthread_join_internal.c
+++ b/os/kernel/pthread/pthread_join_internal.c
@@ -138,7 +138,7 @@ int pthread_join_internal(pthread_t thread, FAR pthread_addr_t *pexit_value, boo
 	 * ourself.
 	 */
 
-	if ((pid_t)thread == getpid()) {
+	if ((pid_t)thread == rtcb->pid) {
 		return EDEADLK;
 	}
 

--- a/os/kernel/pthread/pthread_tryjoin_np.c
+++ b/os/kernel/pthread/pthread_tryjoin_np.c
@@ -54,16 +54,14 @@
  ****************************************************************************/
 
 #include <sys/types.h>
+#include <stdbool.h>
 #include <unistd.h>
 #include <pthread.h>
 #include <errno.h>
 #include <debug.h>
 
-#include <tinyara/cancelpt.h>
 #include <tinyara/ttrace.h>
 
-#include "sched/sched.h"
-#include "group/group.h"
 #include "pthread/pthread.h"
 
 /****************************************************************************
@@ -115,6 +113,7 @@
  *   ESRCH   There is no given thread ID.
  *   EDEADLK A deadlock is detected or the value of thread specifies the
  *           calling thread.
+ *   EBUSY   Thread is still alive even non-blocking is given.
  *
  * Assumptions:
  *
@@ -122,117 +121,16 @@
 
 int pthread_tryjoin_np(pthread_t thread, FAR pthread_addr_t *pexit_value)
 {
-	FAR struct tcb_s *rtcb = this_task();
-	FAR struct task_group_s *group = rtcb->group;
-	FAR struct join_s *pjoin;
 	int ret;
 
 	trace_begin(TTRACE_TAG_TASK, "pthread_tryjoin_np");
-	svdbg("thread=%d group=%p\n", thread, group);
-	DEBUGASSERT(group);
 
-	/* pthread_tryjoin_np() is a cancellation point */
-	(void)enter_cancellation_point();
+	/* Execute internal function with non-blocking */
 
-	/* First make sure that this is not an attempt to join to
-	 * ourself.
-	 */
-
-	if ((pid_t)thread == getpid()) {
-		leave_cancellation_point();
-		trace_end(TTRACE_TAG_TASK);
-		return EDEADLK;
-	}
-
-	/* Make sure no other task is mucking with the data structures
-	 * while we are performing the following operations.  NOTE:
-	 * we can be also sure that pthread_exit() will not execute
-	 * because it will also attempt to get this semaphore.
-	 */
-
-	(void)pthread_sem_take(&group->tg_joinsem, false);
-
-	/* Find the join information associated with this thread.
-	 * This can fail for one of three reasons:  (1) There is no
-	 * thread associated with 'thread,' (2) the thread is a task
-	 * and does not have join information, or (3) the thread
-	 * was detached and has exited.
-	 */
-
-	pjoin = pthread_findjoininfo(group, (pid_t)thread);
-	if (!pjoin) {
-		/* Determine what kind of error to return */
-
-		FAR struct tcb_s *tcb = sched_gettcb((pthread_t)thread);
-
-		sdbg("Could not find thread data\n");
-
-		/* Case (1) or (3) -- we can't tell which.  Assume (3) */
-
-		if (!tcb) {
-			ret = ESRCH;
-		}
-
-		/* The thread is still active but has no join info.  In that
-		 * case, it must be a task and not a pthread.
-		 */
-
-		else {
-			ret = EINVAL;
-		}
-
-		(void)pthread_sem_give(&group->tg_joinsem);
-	} else {
-		/* We found the join info structure.  Increment for the reference
-		 * to the join structure that we have.  This will keep things
-		 * stable for we have to do
-		 */
-
-		sched_lock();
-		pjoin->crefs++;
-
-		/* Check if the thread is still running.  If not, then things are
-		 * simpler.  There are still race conditions to be concerned with.
-		 * For example, there could be multiple threads executing in the
-		 * 'else' block below when we enter!
-		 */
-
-		if (pjoin->terminated) {
-			svdbg("Thread has terminated\n");
-
-			/* Get the thread exit value from the terminated thread. */
-
-			if (pexit_value) {
-				svdbg("exit_value=0x%p\n", pjoin->exit_value);
-				*pexit_value = pjoin->exit_value;
-			}
-			ret = OK;
-		} else {
-			svdbg("Thread is still running, let's return an error\n");
-
-			ret = EBUSY;
-		}
-
-		/* Pre-emption is okay now. The logic still cannot be re-entered
-		 * because we hold the join semaphore
-		 */
-
-		sched_unlock();
-
-		/* Release our reference to the join structure and, if the reference
-		 * count decrements to zero, deallocate the join structure.
-		 */
-
-		if (--pjoin->crefs <= 0) {
-			(void)pthread_destroyjoin(group, pjoin);
-		}
-
-		(void)pthread_sem_give(&group->tg_joinsem);
-
-	}
+	ret = pthread_join_internal(thread, pexit_value, false);
 
 	svdbg("Returning %d\n", ret);
-	leave_cancellation_point();
+
 	trace_end(TTRACE_TAG_TASK);
 	return ret;
 }


### PR DESCRIPTION
The pthread_join and pthread_tryjoin_np are almost the same except
blocking. It causes many codes duplication.
This commit adds pthread_join_internal function and
pthread_join and pthread_tryjoin_np calls it with blocking option.

It already gets rtcb through this_task() so that it does not
need to call getpid for pid value.
Let's get it directly from rtcb structure.
