### PR TITLE
os/include/tinyara: Move wifi_common.h from framework to tinyara

### DIFF
--- a/external/esp_idf_port/esp32/esp32_wifi_utils.c
+++ b/external/esp_idf_port/esp32/esp32_wifi_utils.c
@@ -36,8 +36,8 @@
 #include <tinyara/wdog.h>
 #include <tinyara/arch.h>
 #include <tinyara/cancelpt.h>
+#include <tinyara/wifi/wifi_common.h>
 
-#include "wifi_common.h"
 #include "wifi_utils.h"
 
 #include "esp_attr.h"

--- a/external/rtk_wifi/include/rtk_wifi_utils.h
+++ b/external/rtk_wifi/include/rtk_wifi_utils.h
@@ -19,17 +19,17 @@
   * @file    rtk_wifi_utils.h
   * @author
   * @version
-  * @brief   This file provides user interface for Wi-Fi station and AP mode configuration 
+  * @brief   This file provides user interface for Wi-Fi station and AP mode configuration
   *             base on the functionalities provided by Realtek Wi-Fi driver.
   ******************************************************************************
   */
 #ifndef __RTK_WIFI_UTILS_H
 #define __RTK_WIFI_UTILS_H
 
-#include "wifi_common.h"
+#include <sys/types.h>
+#include <tinyara/wifi/wifi_common.h>
 #include "wifi_constants.h"
 #include "wifi_structures.h"
-#include <sys/types.h>
 
 /* rtk return values */
 #define RTK_STATUS_SUCCESS                             0	// Successfully completed

--- a/framework/src/wifi_manager/wifi_profile.c
+++ b/framework/src/wifi_manager/wifi_profile.c
@@ -27,9 +27,10 @@
 #include <sys/types.h>
 #include <errno.h>
 #include <fcntl.h>
+#include <tinyara/wifi/wifi_common.h>
+
 #include <wifi_manager/wifi_manager.h>
 #include <security/security_api.h>
-#include "wifi_common.h"
 #include "wifi_profile.h"
 
 //#define WIFI_PROFILE_USE_ETC

--- a/framework/src/wifi_manager/wifi_utils.h
+++ b/framework/src/wifi_manager/wifi_utils.h
@@ -24,7 +24,7 @@
 #include <mqueue.h>
 #include <pthread.h>
 
-#include "wifi_common.h"
+#include <tinyara/wifi/wifi_common.h>
 
 #ifdef CONFIG_LWNL80211
 struct _wifi_utils_s {

--- a/os/drivers/wireless/realtek/wifi_util_interface/rtk_drv_lwnl80211.h
+++ b/os/drivers/wireless/realtek/wifi_util_interface/rtk_drv_lwnl80211.h
@@ -25,6 +25,8 @@
 #include <tinyara/fs/fs.h>
 #include <tinyara/sched.h>
 
+#include <tinyara/wifi/wifi_common.h>
+
 #include <sys/types.h>
 #include <stdint.h>
 #include <stdbool.h>
@@ -36,7 +38,6 @@
 #include "../rtk/include/wifi_constants.h"
 #include "../rtk/include/wifi_structures.h"
 
-#include "wifi_common.h"
 #include "wifi_conf.h"
 #include "rtk_lwip_netconf.h"
 

--- a/os/drivers/wireless/realtek/wifi_util_interface/wifi_interactive_mode.c
+++ b/os/drivers/wireless/realtek/wifi_util_interface/wifi_interactive_mode.c
@@ -1,4 +1,5 @@
 #include <tinyara/config.h>
+#include <tinyara/wifi/wifi_common.h>
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -14,11 +15,8 @@
 #include "rtk_lwip_netconf.h"
 #include "net/lwip/ip_addr.h"
 #include "net/lwip/ip4_addr.h"
-#include "wifi_common.h"
 #include "rtk_wifi_utils.h"
 #include "net/lwip/tcpip.h"
-
-#include <../../framework/src/wifi_manager/wifi_common.h>
 
 #define vTaskDelay(t) usleep(t)
 

--- a/os/include/tinyara/wifi/wifi_common.h
+++ b/os/include/tinyara/wifi/wifi_common.h
@@ -19,13 +19,24 @@
 #ifndef __WIFI_COMMON_H__
 #define __WIFI_COMMON_H__
 
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+#include <tinyara/config.h>
 
-/* Length defines */
+#include <stdint.h>
+
+/****************************************************************************
+ * Definitions
+ ****************************************************************************/
 #define WIFI_UTILS_MACADDR_LEN        6
 #define WIFI_UTILS_MACADDR_STR_LEN    17
 #define WIFI_UTILS_SSID_LEN           32
 #define WIFI_UTILS_PASSPHRASE_LEN     64
 
+/****************************************************************************
+ * Enums
+ ****************************************************************************/
 /**
  * @brief time out option (used by message queue, uart, semaphore, mutex)
  *
@@ -37,7 +48,7 @@ typedef enum {
 
 /**
  * @brief <b> wifi result type FAIL, SUCCESS, INVALID ARGS</b>
- */ 
+ */
 typedef enum {
 	WIFI_UTILS_FAIL = -1,
 	WIFI_UTILS_SUCCESS,
@@ -103,6 +114,10 @@ typedef enum {
 	WIFI_UTILS_SOFTAP_MODE,                  /**<  soft ap mode          */
 } wifi_utils_status_e;
 
+
+/****************************************************************************
+ * Structures
+ ****************************************************************************/
 /**
  * @brief wifi access point information
  */


### PR DESCRIPTION
- wifi_common.h is widely used from kernel to user space
- Prevent WiFi kernel driver from reffering to the header defined in the framework