### PR TITLE
lib/libc/sempahore/sem_init : Add NULL initialization of sem->flink

### DIFF
--- a/lib/libc/semaphore/sem_init.c
+++ b/lib/libc/semaphore/sem_init.c
@@ -135,6 +135,7 @@ int sem_init(FAR sem_t *sem, int pshared, unsigned int value)
 #if defined(CONFIG_BINMGR_RECOVERY) && defined(__KERNEL__)
 		/* Register semaphore in kernel region for kernel resource management */
 		if (sem->semcount != 0) {
+			sem->flink = NULL;
 			sem_register(sem);
 		}
 #endif

--- a/os/kernel/semaphore/sem_list.c
+++ b/os/kernel/semaphore/sem_list.c
@@ -77,7 +77,7 @@ void sem_register(FAR sem_t *sem)
 			irqrestore(flags);
 			return;
 		}
-		sem_ptr = sq_next(sem_ptr);
+		sem_ptr = (sem_t *)sq_next(sem_ptr);
 	}
 	/* Add semaphore to a list of kernel semaphore, g_sem_list */
 	sq_addlast((FAR sq_entry_t *)sem, &g_sem_list);


### PR DESCRIPTION
If sem is local variable, flink sometimes has trash value.
For appending at the end of the g_sem_list, flink should be set to NULL.