### PR TITLE
kernel/wdog/wd_start : Remove unreachable condition

### DIFF
--- a/os/kernel/wdog/wd_start.c
+++ b/os/kernel/wdog/wd_start.c
@@ -279,8 +279,6 @@ int wd_start(WDOG_ID wdog, int delay, wdentry_t wdentry, int argc, ...)
 
 	if (delay <= 0) {
 		delay = 1;
-	} else if (++delay <= 0) {
-		delay--;
 	}
 #ifdef CONFIG_SCHED_TICKLESS
 	/* Cancel the interval timer that drives the timing events.  This will cause


### PR DESCRIPTION
if 'delay' is lower than equal to 0, it sets to 1 from line 281.