### PR TITLE
lib/libc/semaphore/sem_init : Register to sem list only if sem is fro…

### DIFF
--- a/lib/libc/semaphore/sem_init.c
+++ b/lib/libc/semaphore/sem_init.c
@@ -66,6 +66,9 @@
 #endif
 #if defined(CONFIG_BINMGR_RECOVERY) && defined(__KERNEL__)
 #include <tinyara/semaphore.h>
+#include <tinyara/arch.h>
+
+#define is_kernel_sem(a) is_kernel_space((void *)a)
 #endif
 
 /****************************************************************************
@@ -134,7 +137,8 @@ int sem_init(FAR sem_t *sem, int pshared, unsigned int value)
 
 #if defined(CONFIG_BINMGR_RECOVERY) && defined(__KERNEL__)
 		/* Register semaphore in kernel region for kernel resource management */
-		if (sem->semcount != 0) {
+		
+		if (sem->semcount != 0 && is_kernel_sem(sem)) {
 			sem_register(sem);
 		}
 #endif

--- a/os/arch/arm/src/armv7-m/up_assert.c
+++ b/os/arch/arm/src/armv7-m/up_assert.c
@@ -93,6 +93,7 @@
 #ifdef CONFIG_BINMGR_RECOVERY
 #include <unistd.h>
 #include <mqueue.h>
+#include <stdbool.h>
 #include "binary_manager/binary_manager.h"
 #endif
 #include "irq/irq.h"
@@ -515,10 +516,8 @@ void up_assert(const uint8_t *filename, int lineno)
 #endif
 
 #ifdef CONFIG_BINMGR_RECOVERY
-	uint32_t ksram_segment_end  = (uint32_t)__ksram_segment_start__  + (uint32_t)__ksram_segment_size__;
-	uint32_t kflash_segment_end = (uint32_t)__kflash_segment_start__ + (uint32_t)__kflash_segment_size__;
 	uint32_t assert_pc;
-	uint32_t is_kernel_assert   = false;
+	bool is_kernel_assert;
 
 	/* Extract the PC value of instruction which caused the abort/assert */
 
@@ -530,9 +529,8 @@ void up_assert(const uint8_t *filename, int lineno)
 
 	/* Is the assert in Kernel? */
 
-	if ((assert_pc >= (uint32_t)__ksram_segment_start__ && assert_pc <= ksram_segment_end) || (assert_pc >= (uint32_t)__kflash_segment_start__ && assert_pc < kflash_segment_end)) {
-		is_kernel_assert = true;
-	}
+	is_kernel_assert = is_kernel_space(assert_pc);
+
 #endif  /* CONFIG_BINMGR_RECOVERY */
 
 	up_dumpstate();

--- a/os/arch/arm/src/common/up_checkspace.c
+++ b/os/arch/arm/src/common/up_checkspace.c
@@ -1,0 +1,46 @@
+/****************************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <tinyara/config.h>
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "up_internal.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#ifdef CONFIG_BUILD_PROTECTED
+
+bool is_kernel_space(void *addr)
+{
+	uint32_t ksram_segment_end  = (uint32_t)__ksram_segment_start__  + (uint32_t)__ksram_segment_size__;
+	uint32_t kflash_segment_end = (uint32_t)__kflash_segment_start__ + (uint32_t)__kflash_segment_size__;
+
+	if ((addr >= (void *)__ksram_segment_start__ && addr <= (void *)ksram_segment_end) || (addr >= (void *)__kflash_segment_start__ && addr < (void *)kflash_segment_end)) {
+		return true;
+	}
+	return false;
+}
+
+#endif							/* CONFIG_BUILD_PROTECTED */

--- a/os/arch/arm/src/imxrt/Make.defs
+++ b/os/arch/arm/src/imxrt/Make.defs
@@ -85,7 +85,7 @@ CMN_CSRCS += up_ramvec_initialize.c up_ramvec_attach.c
 endif
 
 ifeq ($(CONFIG_BUILD_PROTECTED),y)
-CMN_CSRCS += up_mpu.c up_task_start.c up_pthread_start.c
+CMN_CSRCS += up_mpu.c up_task_start.c up_pthread_start.c up_checkspace.c
 ifneq ($(CONFIG_DISABLE_SIGNALS),y)
 CMN_CSRCS += up_signal_dispatch.c
 CMN_UASRCS += up_signal_handler.S

--- a/os/include/tinyara/arch.h
+++ b/os/include/tinyara/arch.h
@@ -2148,6 +2148,17 @@ void up_wdog_keepalive(void);
 
 #endif
 
+#ifdef CONFIG_BUILD_PROTECTED
+/****************************************************************************
+ * Name: is_kernel_space
+ *
+ * Description:
+ *   Check the address is in kernel space or not
+ *
+ ****************************************************************************/
+bool is_kernel_space(void *addr);
+#endif
+
 #undef EXTERN
 #ifdef __cplusplus
 }


### PR DESCRIPTION
…m kernel

check that sem is from kernel or not when register to the g_sem_list, because g_sem_list manages only the kernel sem.