### PR TITLE
external/esp_idf_port:remove redundant code

### DIFF
--- a/external/esp_idf_port/esp32/event_loop/event_default_handlers.c
+++ b/external/esp_idf_port/esp32/event_loop/event_default_handlers.c
@@ -45,12 +45,6 @@
 #include "lwip/dhcp.h"
 #include "lwip/prot/dhcp.h"
 #include "rom/ets_sys.h"
-#if 0
-#include "freertos/FreeRTOS.h"
-#include "freertos/task.h"
-#include "freertos/queue.h"
-#include "freertos/semphr.h"
-#endif
 #include "tcpip_adapter.h"
 #include "esp_log.h"
 

--- a/external/esp_idf_port/include/esp_intr.h
+++ b/external/esp_idf_port/include/esp_intr.h
@@ -34,7 +34,6 @@
 #define __ESP_INTR_H__
 
 #include "rom/ets_sys.h"
-#include "freertos/xtensa_api.h"
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
Remove unused code and unnecessary header file reference.