### PR TITLE
libc/time: Remove unnessasary conditions for time_t

### DIFF
--- a/os/include/time.h
+++ b/os/include/time.h
@@ -141,6 +141,8 @@
 /* tm_year of struct tm means years since 1900 */
 #define TM_YEAR_BASE       1900
 
+/* The maximum value of time as time_t type */
+#define TIME_VALUE_MAX     UINT32_MAX
 /********************************************************************************
  * Public Types
  ********************************************************************************/


### PR DESCRIPTION
TizenRT represent time_t internally as type uint32_t.