### PR TITLE
os/wqueue : Fix build warning in work_process

### DIFF
--- a/os/wqueue/work_process.c
+++ b/os/wqueue/work_process.c
@@ -205,9 +205,9 @@ void work_process(FAR struct wqueue_s *wqueue, int wndx)
 				 */
 				
 #if defined(CONFIG_SCHED_USRWORK) && !defined(__KERNEL__)
-			work_unlock();
+				work_unlock();
 #else
-			irqrestore(flags);
+				irqrestore(flags);
 #endif
 				worker(arg);
 
@@ -217,9 +217,9 @@ void work_process(FAR struct wqueue_s *wqueue, int wndx)
 				 */
 
 #if defined(CONFIG_SCHED_USRWORK) && !defined(__KERNEL__)
-			while (work_lock() < 0);
+				while (work_lock() < 0);
 #else
-			flags = irqsave();
+				flags = irqsave();
 #endif
 				work = (FAR struct work_s *)wqueue->q.head;
 			} else {


### PR DESCRIPTION
I fixed build warning below.

work_process.c:220:4: warning: this 'while' clause does not guard... [-Wmisleading-indentation]
    while (work_lock() < 0);
    ^~~~~
work_process.c:224:5: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'while'
     work = (FAR struct work_s *)wqueue->q.head;
     ^~~~