### PR TITLE
apps/system/utils : Add missing conditional and close fd on error

### DIFF
--- a/apps/system/utils/utils_heapinfo.c
+++ b/apps/system/utils/utils_heapinfo.c
@@ -291,6 +291,7 @@ int utils_heapinfo(int argc, char **args)
 	ret = ioctl(heapinfo_fd, HEAPINFOIOC_PARSE, (int)&options);
 	if (ret == ERROR) {
 		printf("Heapinfo Fail, %d.\n", get_errno());
+		close(heapinfo_fd);
 		return ERROR;		
 	}
 	close(heapinfo_fd);

--- a/apps/system/utils/utils_ps.c
+++ b/apps/system/utils/utils_ps.c
@@ -65,6 +65,7 @@
 
 #include "utils_proc.h"
 
+#define STATENAMES_ARRARY_SIZE (sizeof(utils_statenames) / sizeof(utils_statenames[0]))
 #define PS_BUFLEN 128
 
 static const char *utils_statenames[] = {
@@ -109,7 +110,7 @@ static void ps_print_values(char *buf)
 	}
 
 	state = atoi(stat_info[PROC_STAT_STATE]);
-	if (state <= 0) {
+	if (state <= 0 || STATENAMES_ARRARY_SIZE <= state) {
 		return;
 	}
 


### PR DESCRIPTION
I fixed svace issue below.

WID:1355883 Tainted integer 'state' obtained at utils_ps.c:111
that may have values in [9, +inf] is used as an index, which can
lead to buffer overflow at utils_ps.c:119; make sure this value
is within bounds.

WID:1355930 The handle 'heapinfo_fd' was created at utils_heapinfo.c:286
 by calling function 'open' and lost at utils_heapinfo.c:294.