### PR TITLE
external/curl: fix logical build error.

### DIFF
--- a/external/curl/Kconfig
+++ b/external/curl/Kconfig
@@ -123,7 +123,7 @@ if SSL_SUPPORT
 config MBEDTLS
 	bool "Mbed TLS"
 	default y
-	depends on !NET_SECURITY_TLS
+	depends on NET_SECURITY_TLS
 
 endif #SSL_SUPPORT
 

--- a/external/curl/curl_setup.h
+++ b/external/curl/curl_setup.h
@@ -1,5 +1,6 @@
 #ifndef HEADER_CURL_SETUP_H
 #define HEADER_CURL_SETUP_H
+#include <tinyara/config.h>
 /***************************************************************************
  *                                  _   _ ____  _
  *  Project                     ___| | | |  _ \| |

--- a/external/curl/vtls/Make.defs
+++ b/external/curl/vtls/Make.defs
@@ -17,7 +17,7 @@
 ###########################################################################
 # TLS/SSL specific source files
 
-CSRCS+= vtls.c 
+CSRCS+= vtls.c
 CSRCS+= polarssl_threadlock.c
 
 ifeq ($(CONFIG_MBEDTLS),y)

--- a/external/include/mbedtls/config.h
+++ b/external/include/mbedtls/config.h
@@ -2701,9 +2701,9 @@
  *
  * This module is required for X.509 CRL parsing.
  */
-#if defined(MBEDTLS_OCF_PATCH)
+// #if defined(MBEDTLS_OCF_PATCH)
 #define MBEDTLS_X509_CRL_PARSE_C
-#endif
+// #endif
 
 /**
  * \def MBEDTLS_X509_CSR_PARSE_C
@@ -2882,7 +2882,7 @@
 #undef MBEDTLS_ERROR_STRERROR_DUMMY
 #undef MBEDTLS_GENPRIME
 
-#undef MBEDTLS_FS_IO
+// #undef MBEDTLS_FS_IO
 #undef MBEDTLS_MEMORY_DEBUG
 #undef MBEDTLS_HAVEGE_C
 


### PR DESCRIPTION
The curl has a dependency for mbedtls or openssl to use https protocols.
But the dependency was ignored.