### PR TITLE
apps/dns: Use ioctl to get IP addr instead of kernel API

### DIFF
--- a/apps/examples/dnsclient_test/dnsclient_main.c
+++ b/apps/examples/dnsclient_test/dnsclient_main.c
@@ -188,7 +188,7 @@ int dnsclient_main(int argc, FAR char *argv[])
 		return -1;
 	} else {
 		printf("DNS results\n");
-		printf("IP Address : %s\n", ip_ntoa((ip_addr_t *)shost->h_addr_list[0]));
+		printf("IP Address : %s\n", inet_ntoa(*((struct in_addr *)shost->h_addr_list[0])));
 	}
 
 	return 0;

--- a/apps/system/netdb/netdb_main.c
+++ b/apps/system/netdb/netdb_main.c
@@ -174,7 +174,7 @@ int netdb_main(int argc, char *argv[])
 
 		host = gethostbyaddr(&addr, sizeof(struct in_addr), AF_INET);
 		if (!host) {
-			fprintf(stderr, "ERROR -- gethostbyaddr failed.  h_errno=%d\n\n", h_errno);
+			fprintf(stderr, "ERROR -- gethostbyaddr failed.\n\n");
 			return EXIT_FAILURE;
 		}
 	}
@@ -197,7 +197,7 @@ int netdb_main(int argc, char *argv[])
 
 		host = gethostbyaddr(&addr, sizeof(struct in6_addr), AF_INET6);
 		if (!host) {
-			fprintf(stderr, "ERROR -- gethostbyaddr failed.  h_errno=%d\n\n", h_errno);
+			fprintf(stderr, "ERROR -- gethostbyaddr failed.\n\n");
 			return EXIT_FAILURE;
 		}
 	}
@@ -210,7 +210,7 @@ int netdb_main(int argc, char *argv[])
 
 		host = gethostbyname(argv[2]);
 		if (!host) {
-			fprintf(stderr, "ERROR -- gethostbyname failed.  h_errno=%d\n\n", h_errno);
+			fprintf(stderr, "ERROR -- gethostbyname failed. \n\n");
 			return EXIT_FAILURE;
 		}
 	}
@@ -232,7 +232,7 @@ int netdb_main(int argc, char *argv[])
 
 	if (host->h_addrtype == AF_INET) {
 		if (inet_ntop(AF_INET, host->h_addr, buffer, 48) == NULL) {
-			fprintf(stderr, "ERROR -- gethostbyname failed.  h_errno=%d\n\n", h_errno);
+			fprintf(stderr, "ERROR -- gethostbyname failed.\n\n");
 			return EXIT_FAILURE;
 		}
 
@@ -243,7 +243,7 @@ int netdb_main(int argc, char *argv[])
 
 	else if (host->h_addrtype == AF_INET6) {
 		if (inet_ntop(AF_INET6, host->h_addr, buffer, 48) == NULL) {
-			fprintf(stderr, "ERROR -- gethostbyname failed.  h_errno=%d\n\n", h_errno);
+			fprintf(stderr, "ERROR -- gethostbyname failed.\n\n");
 			return EXIT_FAILURE;
 		}
 

--- a/external/mdns/mdnsd.c
+++ b/external/mdns/mdnsd.c
@@ -1623,36 +1623,17 @@ done:
 static int mdnsd_set_host_info_by_netif(struct mdnsd *svr, const char *hostname, const char *netif_name)
 {
 	int result = -1;
-	uint32_t ipaddr = 0;;
-#ifdef CONFIG_NET_LWIP
-	struct netif *netif;
-#endif
+	struct in_addr ipaddr;
 
 	if (svr == NULL) {
 		ndbg("ERROR: mdnsd instance handle is null.\n");
 		goto done;
 	}
-#ifdef CONFIG_NET_LWIP
-	// find ip address with lwip netif_find() function
-	netif = netif_find(netif_name);
-	if (netif) {
-		ipaddr = ip4_addr_get_u32(ip_2_ip4(&netif->ip_addr));
-	} else {
-		ndbg("ERROR: mdnsd cannot find netif.(%s)\n", netif_name);
-		goto done;
+	result = netlib_get_ipv4addr(netif_name, &ipaddr);
+	if (result < 0) {
+		return result;
 	}
-
-	if (ipaddr == 0) {
-		ndbg("ERROR: mdnsd cannot set ip address.\n");
-		goto done;
-	}
-#else
-	/* if CONFIG_NET_LWIP is not set, it should be implemented to resolve ip address with netif_name */
-	ndbg("ERROR: cannot resolve ip address with netif_name.\n");
-	goto done;
-#endif
-
-	result = mdnsd_set_host_info(svr, hostname, ipaddr);
+	result = mdnsd_set_host_info(svr, hostname, ipaddr.s_addr);
 
 done:
 	return result;


### PR DESCRIPTION
- Remove h_errno, LwIP's DNS errno in kernel
- Use ioctl to get IP addr
- Use syscall to execute ntoa