### PR TITLE
apps/system: do cxxinitialize from preapp task

### DIFF
--- a/apps/platform/gnu/Kconfig
+++ b/apps/platform/gnu/Kconfig
@@ -7,6 +7,7 @@ config HAVE_CXXINITIALIZE
 	bool "Have C++ initialization"
 	default n
 	depends on HAVE_CXX
+	select SYSTEM_PREAPP_INIT
 	---help---
 		The platform-specific logic includes support for initialization
 		of static C++ instances for this architecture and for the selected

--- a/os/kernel/init/os_bringup.c
+++ b/os/kernel/init/os_bringup.c
@@ -462,10 +462,6 @@ int os_bringup(void)
 	logm_start();
 #endif
 
-#if !defined(CONFIG_BUILD_KERNEL) && defined(CONFIG_HAVE_CXXINITIALIZE)
-	up_cxxinitialize();
-#endif
-
 	/* Once the operating system has been initialized, the system must be
 	 * started by spawning the user initialization thread of execution.  This
 	 * will be the first user-mode thread.


### PR DESCRIPTION
The cxxinitialize function is in application context, not kernel context.
So, let's do it in preapp task which is running on application context.
Additionally let's make a dependancy between HAVE_CXXINITIALIZE and
SYSTEM_PREAPP_INIT to run preapp task automatically when cxx is enabled.

Signed-off-by: Sangamanatha <sangam.swami@samsung.com>