### PR TITLE
os/drivers: lwnl80211 bug fix

### DIFF
--- a/framework/src/wifi_manager/wifi_utils_lwnl80211.c
+++ b/framework/src/wifi_manager/wifi_utils_lwnl80211.c
@@ -240,12 +240,12 @@ int wifi_utils_callback_handler(int argc, char *argv[])
 		{
 			wifi_utils_scan_list_s *scan_list;
 			scan_list = (wifi_utils_scan_list_s *)malloc(sizeof(wifi_utils_scan_list_s));
-			scan_list->next = NULL;
 			if (!scan_list) {
 				free_scan_data(scan_list);
 				WU_ERR;
 				break;
 			}
+			scan_list->next = NULL;
 			memcpy(&(scan_list->ap_info), &(msg.u.ap_info), sizeof(wifi_utils_ap_scan_info_s));
 			if (msg.md) {
 				int ret = receive_scan_data(mqfd, scan_list);

--- a/os/drivers/lwnl/lwnl80211.c
+++ b/os/drivers/lwnl/lwnl80211.c
@@ -119,18 +119,12 @@ static int lwnl80211_close(struct file *filep)
 	struct lwnl80211_upperhalf_s *upper = inode->i_private;
 	int ret = OK;
 
-	if (ret < 0) {
-		ret = -errno;
-		goto errout;
-	}
-
 	if (upper->crefs > 0) {
 		upper->crefs--;
 	} else {
 		ret = -ENOSYS;
 	}
 
-errout:
 	LWNL80211_LEAVE;
 	return ret;
 }


### PR DESCRIPTION
- Assign NULL for scan_list->next if scan_list is well malloced
- Remove redundant code in lwnl80211_close