### PR TITLE
os/drivers: USBhost driver bug fix

### DIFF
--- a/os/drivers/usbhost/rtl8723d.c
+++ b/os/drivers/usbhost/rtl8723d.c
@@ -484,10 +484,6 @@ static FAR struct usbhost_class_s *usbhost_create(FAR struct usbhost_hubport_s *
 		return &priv->usbclass;
 	}
 
-	if (priv) {
-		usbhost_freeclass(priv);
-	}
-
 	return NULL;
 }
 

--- a/os/drivers/usbhost/usbhost_enumerate.c
+++ b/os/drivers/usbhost/usbhost_enumerate.c
@@ -124,7 +124,7 @@ static inline uint16_t usbhost_getle16(const uint8_t *val)
 
 static void usbhost_putle16(uint8_t *dest, uint16_t val)
 {
-	dest[0] = val & 0xff;		/* Little endian means LS byte first in byte stream */
+	dest[0] = val & 0xff; /* Little endian means LS byte first in byte stream */
 	dest[1] = val >> 8;
 }
 
@@ -191,7 +191,7 @@ static inline int usbhost_configdesc(const uint8_t *configdesc, int cfglen, stru
 
 	/* Loop while there are more descriptors to examine */
 
-	memset(id, 0, sizeof(FAR struct usb_desc_s));
+	memset(id, 0, sizeof(FAR struct usbhost_id_s));
 	while (remaining >= sizeof(struct usb_desc_s)) {
 		/* What is the next descriptor? Is it an interface descriptor? */
 
@@ -309,7 +309,7 @@ int usbhost_enumerate(FAR struct usbhost_hubport_s *hport, FAR struct usbhost_cl
 	unsigned int cfglen;
 	uint8_t maxpacketsize;
 	uint8_t descsize;
-	uint8_t funcaddr = 0;
+	int funcaddr = 0;
 	FAR uint8_t *buffer = NULL;
 	int ret;
 
@@ -434,7 +434,7 @@ int usbhost_enumerate(FAR struct usbhost_hubport_s *hport, FAR struct usbhost_cl
 	/* Assign the function address to the port */
 
 	DEBUGASSERT(hport->funcaddr == 0 && funcaddr != 0);
-	hport->funcaddr = funcaddr;
+	hport->funcaddr = (uint8_t)funcaddr;
 
 	/* And reconfigure EP0 with the correct address */
 


### PR DESCRIPTION
- Remove unreachable code
- Modify function address type to uint8_t to int, returend by usbhost_devaddr_create