### PR TITLE
board/common : Add conditional statement

### DIFF
--- a/os/board/common/partitions.c
+++ b/os/board/common/partitions.c
@@ -93,8 +93,11 @@ static void type_specific_initialize(FAR struct mtd_dev_s *mtd_part, int partno,
 
 			snprintf(partref, sizeof(partref), "p%d", partno);
 			smart_initialize(CONFIG_FLASH_MINOR, mtd_part, partref);
-		}
+		} else
 #endif
+		{
+
+		}
 }
 
 static void move_to_next_part(const char **par)


### PR DESCRIPTION
If MTD_SMART and FS_SMARTFS are not configure build error occurs.
So I added the parentheses and the else conditional statement.