### PR TITLE
os/drivers/usbhost: Add missing malloc result check

### DIFF
--- a/os/drivers/usbhost/rtl8723d.c
+++ b/os/drivers/usbhost/rtl8723d.c
@@ -163,6 +163,10 @@ static FAR struct usbhost_rtk_wifi_s *usbhost_allocclass(void)
 
 	DEBUGASSERT(!up_interrupt_context());
 	priv = (FAR struct usbhost_rtk_wifi_s *)kmm_malloc(sizeof(struct usbhost_rtk_wifi_s));
+	if (priv == NULL) {
+		udbg("Failed to malloc\n");
+		return NULL;
+	}
 
 	memset(priv, 0, sizeof(FAR struct usbhost_rtk_wifi_s));
 


### PR DESCRIPTION
- Check whether kmm_malloc for priv is set or not