### PR TITLE
framework/task_manager : Add NULL checking before deallocate in task_…

### DIFF
--- a/framework/src/task_manager/task_manager_core.c
+++ b/framework/src/task_manager/task_manager_core.c
@@ -1258,7 +1258,7 @@ static int taskmgr_register_task(tm_task_info_t *task_info, int permission, int 
 	}
 
 end_func:
-	if (task_info->name != NULL) {
+	if (task_info != NULL && task_info->name != NULL) {
 		taskmgr_dealloc_task_name(task_info->name);
 	}
 	return handle;
@@ -1336,7 +1336,7 @@ static int taskmgr_register_pthread(tm_pthread_info_t *pthread_info, int permiss
 	}
 
 end_func:
-	if (pthread_info->name != NULL) {
+	if (pthread_info != NULL && pthread_info->name != NULL) {
 		taskmgr_dealloc_task_name(pthread_info->name);
 	}
 	return handle;

--- a/os/binfmt/binfmt_exec.c
+++ b/os/binfmt/binfmt_exec.c
@@ -143,7 +143,7 @@ int exec(FAR const char *filename, FAR char *const *argv, FAR const struct symta
 {
 	FAR struct binary_s *bin;
 	int pid;
-	int errcode;
+	int errcode = OK;
 	int ret;
 
 #ifdef CONFIG_APP_BINARY_SEPARATION
@@ -230,6 +230,7 @@ int exec(FAR const char *filename, FAR char *const *argv, FAR const struct symta
 	tcb->ram_start = 0;
 	tcb = sched_gettcb(pid);
 	if (tcb == NULL) {
+		errcode = ESRCH;
 		goto errout_with_lock;
 	}
 	tcb->ram_start = (uint32_t)start_addr;

--- a/os/binfmt/binfmt_loadbinary.c
+++ b/os/binfmt/binfmt_loadbinary.c
@@ -166,6 +166,10 @@ int load_binary(FAR const char *filename, load_attr_t *load_attr)
 #ifdef CONFIG_APP_BINARY_SEPARATION
 	tcb->ram_start = 0;
 	tcb = sched_gettcb(pid);
+	if (tcb == NULL) {
+		errcode = ESRCH;
+		goto errout_with_lock;
+	}
 	tcb->ram_start = (uint32_t)start_addr;
 	tcb->ram_size = size;
 #endif


### PR DESCRIPTION
…manager_core

If not checking the task_info or pthread_info before deallocate the task/pthread info's name,
it can cause dereferencing.