### PR TITLE
framework/araui: Apply partial display update to rotate and scale APIs.

### DIFF
--- a/framework/src/araui/core/ui_window.c
+++ b/framework/src/araui/core/ui_window.c
@@ -280,6 +280,13 @@ ui_error_t ui_window_add_redraw_list(ui_rect_t redraw_rect)
 	new_area->width = redraw_rect.width;
 	new_area->height = redraw_rect.height;
 
+	if (new_area->x + new_area->width >= CONFIG_UI_DISPLAY_WIDTH) {
+		new_area->width = CONFIG_UI_DISPLAY_WIDTH - new_area->x;
+	}
+	if (new_area->y + new_area->height >= CONFIG_UI_DISPLAY_HEIGHT) {
+		new_area->height = CONFIG_UI_DISPLAY_HEIGHT - new_area->y;
+	}
+
 	vec_foreach(&g_window_redraw_list, window, iter) {
 		// window is whole screen case
 		if ((window->x == 0) && (window->y == 0) &&
@@ -301,12 +308,6 @@ ui_error_t ui_window_add_redraw_list(ui_rect_t redraw_rect)
 		ret = ui_get_contain_rect(previous, *new_area);
 		new_area->x = ret.x;
 		new_area->y = ret.y;
-		if (ret.x + ret.width > CONFIG_UI_DISPLAY_WIDTH) {
-			ret.width = CONFIG_UI_DISPLAY_WIDTH - ret.x;
-		}
-		if (ret.y + ret.height > CONFIG_UI_DISPLAY_HEIGHT) {
-			ret.height = CONFIG_UI_DISPLAY_HEIGHT - ret.y;
-		}
 		new_area->width = ret.width;
 		new_area->height = ret.height;
 

--- a/framework/src/araui/include/ui_commons_internal.h
+++ b/framework/src/araui/include/ui_commons_internal.h
@@ -26,10 +26,8 @@
 #define UI_ABS(x)           ((x) < (0) ? (-(x)) : (x))
 #define UI_MAX(a, b)        ((a) > (b) ? (a) : (b))
 #define UI_MIN(a, b)        ((a) > (b) ? (b) : (a))
-#define UI_MAX4(a, b, c, d) (UI_MAX(UI_MAX(a, b), UI_MAX(c, d)))
-#define UI_MIN4(a, b, c, d) (UI_MIN(UI_MIN(a, b), UI_MIN(c, d)))
-
-typedef float ui_mat_t[3][3];
+#define UI_MAX4(a, b, c, d) (UI_MAX(UI_MAX((a), (b)), UI_MAX((c), (d))))
+#define UI_MIN4(a, b, c, d) (UI_MIN(UI_MIN((a), (b)), UI_MIN((c), (d))))
 
 #ifdef __cplusplus
 extern "C" {

--- a/framework/src/araui/include/ui_renderer.h
+++ b/framework/src/araui/include/ui_renderer.h
@@ -60,6 +60,7 @@ typedef struct {
  * @brief Graphics common functions
  */
 ui_vec3_t ui_mat3_vec3_multiply(ui_mat3_t *mat, ui_vec3_t *vec);
+ui_mat3_t ui_mat3_identity(void);
 ui_mat3_t ui_mat3_mat3_multiply(ui_mat3_t *left, ui_mat3_t *right);
 float ui_get_weighted_value(float from, float to, float weight);
 
@@ -69,9 +70,9 @@ float ui_get_weighted_value(float from, float to, float weight);
 void ui_renderer_push_matrix(void);
 void ui_renderer_pop_matrix(void);
 void ui_renderer_load_identity(void);
-void ui_renderer_translate(float x, float y);
-void ui_renderer_rotate(int32_t deg);
-void ui_renderer_scale(float x, float y);
+void ui_renderer_translate(ui_mat3_t *parent_mat, ui_mat3_t *mat, float x, float y);
+void ui_renderer_rotate(ui_mat3_t *mat, int32_t deg);
+void ui_renderer_scale(ui_mat3_t *mat, float x, float y);
 void ui_renderer_set_texture(uint8_t *bitmap, int32_t width, int32_t height, ui_pixel_format_t pf);
 
 /**
@@ -81,10 +82,10 @@ void ui_renderer_set_texture(uint8_t *bitmap, int32_t width, int32_t height, ui_
  * - ui_render_{geometry}_uv: Render geometry with texture uv.
  * - ui_render_{geometry}_col_uv: Render geometry with multiply of texture uv and color gradient.
  */
-void ui_render_triangle_uv(
+void ui_render_triangle_uv(ui_mat3_t *trans_mat,
 	ui_vec3_t v1, ui_vec3_t v2, ui_vec3_t v3,
 	ui_uv_t uv1, ui_uv_t uv2, ui_uv_t uv3);
-void ui_render_quad_uv(
+void ui_render_quad_uv(ui_mat3_t *trans_mat,
 	ui_vec3_t v1, ui_vec3_t v2, ui_vec3_t v3, ui_vec3_t v4,
 	ui_uv_t uv1, ui_uv_t uv2, ui_uv_t uv3, ui_uv_t uv4);
 

--- a/framework/src/araui/include/ui_widget_internal.h
+++ b/framework/src/araui/include/ui_widget_internal.h
@@ -95,6 +95,8 @@ struct ui_widget_body_s {
 	int32_t degree;
 	int32_t pivot_x;
 	int32_t pivot_y;
+	ui_mat3_t trans_mat;
+	bool update_flag;
 
 	struct ui_widget_body_s *parent;
 	vec_void_t children;
@@ -238,6 +240,7 @@ bool ui_widget_check_widget_type(ui_widget_t widget, ui_widget_type_t type);
 ui_error_t ui_widget_update_position_info(ui_widget_body_t *widget);
 void ui_widget_init(ui_widget_body_t *body, int32_t width, int32_t height);
 void ui_widget_deinit(ui_widget_body_t *body);
+void ui_widget_update_global_rect(ui_widget_body_t *widget);
 ui_error_t ui_widget_destroy_sync(ui_widget_body_t *body);
 
 ui_widget_body_t *ui_widget_search_by_coord(ui_widget_body_t *widget, ui_coord_t coord);

--- a/framework/src/araui/widgets/ui_image_widget.c
+++ b/framework/src/araui/widgets/ui_image_widget.c
@@ -104,7 +104,7 @@ static void _ui_image_widget_set_image_func(void *userdata)
 	info->body->uv[UV_BOTTOM_RIGHT] = (ui_uv_t){ .u = 1.0f, .v = 1.0f };
 	info->body->uv[UV_TOP_RIGHT] = (ui_uv_t){ .u = 1.0f, .v = 0.0f };
 
-	ui_window_add_redraw_list(info->body->base.global_rect);
+	info->body->base.update_flag = true;
 
 	UI_FREE(info);
 }
@@ -123,7 +123,6 @@ static void ui_image_widget_render_func(ui_widget_t widget, uint32_t dt)
 	}
 
 	body = (ui_image_widget_body_t *)widget;
-
 	if (body->image) {
 		ui_renderer_set_texture(body->image->buf, body->image->width, body->image->height, body->image->pixel_format);
 
@@ -148,7 +147,7 @@ static void ui_image_widget_render_func(ui_widget_t widget, uint32_t dt)
 			1.0f
 		};
 
-		ui_render_quad_uv(v1, v2, v3, v4, body->uv[0], body->uv[1], body->uv[2], body->uv[3]);
+		ui_render_quad_uv(&body->base.trans_mat, v1, v2, v3, v4, body->uv[0], body->uv[1], body->uv[2], body->uv[3]);
 
 		ui_renderer_set_texture(NULL, 0, 0, UI_PIXEL_FORMAT_UNKNOWN);
 	}

--- a/framework/src/araui/widgets/ui_text_widget.c
+++ b/framework/src/araui/widgets/ui_text_widget.c
@@ -329,12 +329,7 @@ static void _ui_text_widget_set_text_func(void *userdata)
 		return;
 	}
 
-	if (ui_window_add_redraw_list(body->base.global_rect) != UI_OK) {
-		UI_LOGE("error: failed to add to the redraw list!\n");
-		UI_FREE(info->text);
-		UI_FREE(info);
-		return;
-	}
+	body->base.update_flag = true;
 
 	UI_FREE(info->text);
 	UI_FREE(info);
@@ -382,11 +377,7 @@ static void _ui_text_widget_set_align_func(void *userdata)
 	info = (ui_set_align_info_t *)userdata;
 
 	info->body->align = info->align;
-	if (ui_window_add_redraw_list(info->body->base.global_rect) != UI_OK) {
-		UI_LOGE("error: failed to add to the redraw list!\n");
-		UI_FREE(info);
-		return;
-	}
+	info->body->base.update_flag = true;
 
 	UI_FREE(info);
 }
@@ -653,11 +644,7 @@ static void _ui_text_widget_set_word_wrap_func(void *userdata)
 	// According to the text wrap option, a line number of the text widget can be differ from the current one.
 	// Therefore, this value should be recalculated.
 	_ui_text_widget_calculate_line_num(body);
-	if (ui_window_add_redraw_list(info->body->base.global_rect) != UI_OK) {
-		UI_LOGE("error: failed to add to the redraw list!\n");
-		UI_FREE(info);
-		return;
-	}
+	body->base.update_flag = true;
 
 	UI_FREE(info);
 }
@@ -716,11 +703,7 @@ static void _ui_text_widget_set_font_size_func(void *userdata)
 	// According to the text wrap option, a line number of the text widget can be differ from the current one.
 	// Therefore, this value should be recalculated.
 	_ui_text_widget_calculate_line_num(body);
-	if (ui_window_add_redraw_list(info->body->base.global_rect) != UI_OK) {
-		UI_LOGE("error: failed to add to the redraw list!\n");
-		UI_FREE(info);
-		return;
-	}
+	body->base.update_flag = true;
 
 	UI_FREE(info);
 }

--- a/framework/src/araui/widgets/ui_widget.c
+++ b/framework/src/araui/widgets/ui_widget.c
@@ -100,6 +100,19 @@ typedef struct {
 	ui_anim_t *anim;
 } ui_set_anim_info_t;
 
+/**
+ * @brief Matrix multiplication macros
+ */
+#define UI_GET_TRANS_X(widget, x, y) ( \
+	((widget)->trans_mat.m[0][0] * (x)) + \
+	((widget)->trans_mat.m[0][1] * (y)) + \
+	((widget)->trans_mat.m[0][2]))
+
+#define UI_GET_TRANS_Y(widget, x, y) ( \
+	((widget)->trans_mat.m[1][0] * (x)) + \
+	((widget)->trans_mat.m[1][1] * (y)) + \
+	((widget)->trans_mat.m[1][2]))
+
 static void _ui_widget_set_visible_func(void *userdata);
 static void _ui_widget_set_position_func(void *userdata);
 static void _ui_widget_set_size_func(void *userdata);
@@ -165,7 +178,7 @@ ui_error_t ui_widget_update_position_info(ui_widget_body_t *widget)
 
 	// Add update region to present newly located region
 	if (ui_window_add_redraw_list(widget->global_rect) != UI_OK) {
-		UI_LOGE("error: failed to add update list!\n");
+		UI_LOGE("error: failed to add redraw list!\n");
 		return UI_OPERATION_FAIL;
 	}
 
@@ -218,9 +231,7 @@ static void _ui_widget_set_visible_func(void *userdata)
 	body = (ui_widget_body_t *)info->body;
 	body->visible = info->visible;
 
-	if (ui_window_add_redraw_list(body->global_rect) != UI_OK) {
-		UI_LOGE("error: failed to add to the update list!\n");
-	}
+	body->update_flag = true;
 
 	UI_FREE(info);
 }
@@ -269,7 +280,7 @@ static void _ui_widget_set_position_func(void *userdata)
 	body->local_rect.x = info->coord.x;
 	body->local_rect.y = info->coord.y;
 
-	ui_widget_update_position_info(body);
+	body->update_flag = true;
 
 	UI_FREE(info);
 }
@@ -831,6 +842,7 @@ void ui_widget_init(ui_widget_body_t *body, int32_t width, int32_t height)
 	body->local_rect.height = height;
 	body->scale_x = 1.0f;
 	body->scale_y = 1.0f;
+	body->trans_mat = ui_mat3_identity();
 
 	vec_init(&body->children);
 }
@@ -978,8 +990,7 @@ static void _ui_widget_set_rotation_func(void *userdata)
 
 	info->body->degree = info->degree;
 
-	// todo: Add redraw list
-	ui_window_add_redraw_list((ui_rect_t){ 0, 0, 360, 360 });
+	info->body->update_flag = true;
 
 	UI_FREE(info);
 }
@@ -1100,3 +1111,23 @@ static void _ui_widget_resume_anim(void *userdata)
 {
 
 }
+
+void ui_widget_update_global_rect(ui_widget_body_t *widget)
+{
+	ui_vec3_t vertex[4];
+
+	vertex[0].x = UI_GET_TRANS_X(widget, - widget->pivot_x, - widget->pivot_y);
+	vertex[0].y = UI_GET_TRANS_Y(widget, - widget->pivot_x, - widget->pivot_y);
+	vertex[1].x = UI_GET_TRANS_X(widget, - widget->pivot_x + widget->local_rect.width, - widget->pivot_y);
+	vertex[1].y = UI_GET_TRANS_Y(widget, - widget->pivot_x + widget->local_rect.width, - widget->pivot_y);
+	vertex[2].x = UI_GET_TRANS_X(widget, - widget->pivot_x, - widget->pivot_y + widget->local_rect.height);
+	vertex[2].y = UI_GET_TRANS_Y(widget, - widget->pivot_x, - widget->pivot_y + widget->local_rect.height);
+	vertex[3].x = UI_GET_TRANS_X(widget, - widget->pivot_x + widget->local_rect.width, - widget->pivot_y + widget->local_rect.height);
+	vertex[3].y = UI_GET_TRANS_Y(widget, - widget->pivot_x + widget->local_rect.width, - widget->pivot_y + widget->local_rect.height);
+
+	widget->global_rect.x = (int32_t)UI_MIN4(vertex[0].x, vertex[1].x, vertex[2].x, vertex[3].x);
+	widget->global_rect.y = (int32_t)UI_MIN4(vertex[0].y, vertex[1].y, vertex[2].y, vertex[3].y);
+	widget->global_rect.width = (int32_t)UI_MAX4(vertex[0].x, vertex[1].x, vertex[2].x, vertex[3].x) - widget->global_rect.x;
+	widget->global_rect.height = (int32_t)UI_MAX4(vertex[0].y, vertex[1].y, vertex[2].y, vertex[3].y) - widget->global_rect.y;
+}
+


### PR DESCRIPTION
Previously, partial display update algorithm was not applied to the rotate and scale APIs.
(ui_widget_set_rotation(), ui_widget_set_scale())

From now on, partial display update algorithm is usable when rotate and scale APIs are called.

In order to provide this feature, the below modifications are applied.
1. transformation matrix is stored to the widget.
2. update transform matrix step is added before rendering widgets.
3. ui_window_add_redraw_list() is only called at the core.
(except ui_widget_set_position(). For this case, the previous location also needed to be update.)