### PR TITLE
loadable_apps/micomapp : Fix printf arg count mismatch

### DIFF
--- a/loadable_apps/loadable_sample/micomapp/micomapp.c
+++ b/loadable_apps/loadable_sample/micomapp/micomapp.c
@@ -53,7 +53,7 @@ int micomapp_main(int argc, char **argv)
 #ifdef CONFIG_BINARY_MANAGER
 	ret = binary_manager_notify_binary_started();
 	if (ret < 0) {
-		printf("MICOM notify 'START' state FAIL\n", ret);
+		printf("MICOM notify 'START' state FAIL with error : %d\n", ret);
 	}
 #endif
 


### PR DESCRIPTION
Fix printf arg count mismatch because there is a printf with an incorrect number of args in micomapp