### PR TITLE
kernel/binary_manager : Change functions that not use return values t…

### DIFF
--- a/framework/src/task_manager/task_manager_core.c
+++ b/framework/src/task_manager/task_manager_core.c
@@ -1488,7 +1488,7 @@ static int taskmgr_init_task_manager(void)
 	}
 
 	g_tm_recv_mqfd = mq_open(TM_PUBLIC_MQ, O_RDONLY | O_CREAT, 0666, &attr);
-	if (g_tm_recv_mqfd < 0) {
+	if (g_tm_recv_mqfd == (mqd_t)ERROR) {
 		tmdbg("Failed to open task manager public queue.\n");
 		close(taskmgr_fd);
 		return ERROR;

--- a/os/kernel/binary_manager/binary_manager.c
+++ b/os/kernel/binary_manager/binary_manager.c
@@ -123,26 +123,26 @@ void binary_manager_register_partition(int part_num, int part_type, char *name, 
 }
 
 /* Update binary state to BINARY_RUNNING state */
-int binary_manager_update_running_state(int bin_id)
+void binary_manager_update_running_state(int bin_id)
 {
 	int bin_idx;
 
 	if (bin_id <= 0) {
 		bmdbg("Invalid parameter: bin id %d\n", bin_id);
-		return BINMGR_INVALID_PARAM;
+		return;
 	}
 
 	bin_idx = binary_manager_get_index_with_binid(bin_id);
 	if (bin_idx < 0) {
 		bmdbg("Failed to get index of binary %d\n", bin_id);
-		return BINMGR_NOT_FOUND;
+		return;
 	}
 
 	BIN_STATE(bin_idx) = BINARY_RUNNING;
 	bmvdbg("binary '%s' state is changed, state = %d.\n", BIN_NAME(bin_idx), BIN_STATE(bin_idx));
 
 	/* Notify that binary is started. */
-	return binary_manager_notify_state_changed(bin_idx, BINARY_STARTED);
+	binary_manager_notify_state_changed(bin_idx, BINARY_STARTED);
 }
 
 /****************************************************************************
@@ -194,7 +194,6 @@ int binary_manager(int argc, char *argv[])
 	}
 
 	while (1) {
-		ret = ERROR;
 		bmvdbg("Wait for message\n");
 
 		nbytes = mq_receive(g_binmgr_mq_fd, (char *)&request_msg, sizeof(binmgr_request_t), NULL);
@@ -211,10 +210,10 @@ int binary_manager(int argc, char *argv[])
 			break;
 #endif
 		case BINMGR_GET_INFO:
-			ret = binary_manager_get_info_with_name(request_msg.requester_pid, (char *)request_msg.data.bin_name);
+			binary_manager_get_info_with_name(request_msg.requester_pid, (char *)request_msg.data.bin_name);
 			break;
 		case BINMGR_GET_INFO_ALL:
-			ret = binary_manager_get_info_all(request_msg.requester_pid);
+			binary_manager_get_info_all(request_msg.requester_pid);
 			break;
 		case BINMGR_RELOAD:
 			memset(type_str, 0, 1);
@@ -222,16 +221,16 @@ int binary_manager(int argc, char *argv[])
 			loading_data[0] = itoa(LOADCMD_RELOAD, type_str, 10);
 			loading_data[1] = (char *)request_msg.data.bin_name;
 			loading_data[2] = NULL;
-			ret = binary_manager_loading(loading_data);
+			binary_manager_loading(loading_data);
 			break;
 		case BINMGR_NOTIFY_STARTED:
-			ret = binary_manager_update_running_state(request_msg.requester_pid);
+			binary_manager_update_running_state(request_msg.requester_pid);
 			break;
 		case BINMGR_REGISTER_STATECB:
-			ret = binary_manager_register_statecb(request_msg.requester_pid, (binmgr_cb_t *)request_msg.data.cb_info);
+			binary_manager_register_statecb(request_msg.requester_pid, (binmgr_cb_t *)request_msg.data.cb_info);
 			break;
 		case BINMGR_UNREGISTER_STATECB:
-			ret = binary_manager_unregister_statecb(request_msg.requester_pid);
+			binary_manager_unregister_statecb(request_msg.requester_pid);
 			break;
 		default:
 			break;

--- a/os/kernel/binary_manager/binary_manager.c
+++ b/os/kernel/binary_manager/binary_manager.c
@@ -176,7 +176,7 @@ int binary_manager(int argc, char *argv[])
 
 	/* Create binary manager message queue */
 	g_binmgr_mq_fd = mq_open(BINMGR_REQUEST_MQ, O_RDWR | O_CREAT, 0666, &attr);
-	if (g_binmgr_mq_fd < 0) {
+	if (g_binmgr_mq_fd == (mqd_t)ERROR) {
 		bmdbg("Failed to open message queue\n");
 		return 0;
 	}

--- a/os/kernel/binary_manager/binary_manager.h
+++ b/os/kernel/binary_manager/binary_manager.h
@@ -147,19 +147,19 @@ void binary_manager_recovery(int pid);
 mqd_t binary_manager_get_mqfd(void);
 #endif
 
-int binary_manager_register_statecb(int pid, binmgr_cb_t *cb_info);
-int binary_manager_unregister_statecb(int pid);
+void binary_manager_register_statecb(int pid, binmgr_cb_t *cb_info);
+void binary_manager_unregister_statecb(int pid);
 void binary_manager_clear_bin_statecb(int bin_idx);
 int binary_manager_send_statecb_msg(int recv_binidx, char *bin_name, uint8_t state, bool need_response);
-int binary_manager_notify_state_changed(int bin_idx, uint8_t state);
+void binary_manager_notify_state_changed(int bin_idx, uint8_t state);
 int binary_manager_load_binary(int bin_idx);
 int binary_manager_loading(char *loading_data[]);
 uint32_t binary_manager_get_binary_count(void);
 int binary_manager_get_index_with_binid(int bin_id);
-int binary_manager_get_info_with_name(int request_pid, char *bin_name);
-int binary_manager_get_info_all(int request_pid);
+void binary_manager_get_info_with_name(int request_pid, char *bin_name);
+void binary_manager_get_info_all(int request_pid);
 
-int binary_manager_send_response(char *q_name, void *response_msg, int msg_size);
+void binary_manager_send_response(char *q_name, void *response_msg, int msg_size);
 
 /****************************************************************************
  * Binary Manager Main Thread

--- a/os/kernel/binary_manager/binary_manager_callback.c
+++ b/os/kernel/binary_manager/binary_manager_callback.c
@@ -64,7 +64,7 @@ void binary_manager_clear_bin_statecb(int bin_idx)
  *   This function clears registered callback for the changes of binary state.
  *
  ****************************************************************************/
-int binary_manager_unregister_statecb(int pid)
+void binary_manager_unregister_statecb(int pid)
 {
 	int bin_idx;
 	struct tcb_s *tcb;
@@ -108,7 +108,7 @@ int binary_manager_unregister_statecb(int pid)
 
 send_result:
 	snprintf(q_name, BIN_PRIVMQ_LEN, "%s%d", BINMGR_RESPONSE_MQ_PREFIX, pid);
-	return binary_manager_send_response(q_name, &response_msg, sizeof(binmgr_statecb_response_t));
+	binary_manager_send_response(q_name, &response_msg, sizeof(binmgr_statecb_response_t));
 }
 
 /****************************************************************************
@@ -118,7 +118,7 @@ send_result:
  *   This function registers callback for the changes of binary state.
  *
  ****************************************************************************/
-int binary_manager_register_statecb(int pid, binmgr_cb_t *cb_info)
+void binary_manager_register_statecb(int pid, binmgr_cb_t *cb_info)
 {
 	int bin_idx;
 	struct tcb_s *tcb;
@@ -174,7 +174,7 @@ int binary_manager_register_statecb(int pid, binmgr_cb_t *cb_info)
 
 send_result:
 	snprintf(q_name, BIN_PRIVMQ_LEN, "%s%d", BINMGR_RESPONSE_MQ_PREFIX, pid);
-	return binary_manager_send_response(q_name, &response_msg, sizeof(binmgr_statecb_response_t));
+	binary_manager_send_response(q_name, &response_msg, sizeof(binmgr_statecb_response_t));
 }
 
 /****************************************************************************
@@ -282,7 +282,7 @@ errout:
  *   This function sends callback message to other binaries if registered callbacks exist.
  *
  ****************************************************************************/
-int binary_manager_notify_state_changed(int bin_idx, uint8_t state)
+void binary_manager_notify_state_changed(int bin_idx, uint8_t state)
 {
 	int ret;
 	int count;
@@ -291,7 +291,7 @@ int binary_manager_notify_state_changed(int bin_idx, uint8_t state)
 
 	if (bin_idx <= 0 || state >= BINARY_STATE_MAX) {
 		bmdbg("Invalid parameter: bin idx %d, state %d\n", bin_idx, state);
-		return BINMGR_INVALID_PARAM;
+		return;
 	}
 
 	count = binary_manager_get_binary_count();
@@ -309,8 +309,5 @@ int binary_manager_notify_state_changed(int bin_idx, uint8_t state)
 
 	if (fail_count > 0) {
 		bmdbg("Invalid parameter: bin idx %d, state %d\n", bin_idx, state);
-		return BINMGR_OPERATION_FAIL;
 	}
-
-	return BINMGR_OK;
 }

--- a/os/kernel/binary_manager/binary_manager_getinfo.c
+++ b/os/kernel/binary_manager/binary_manager_getinfo.c
@@ -86,7 +86,7 @@ int binary_manager_get_index_with_name(char *bin_name)
 }
 
 /* Get binary info with binary name */
-int binary_manager_get_info_with_name(int requester_pid, char *bin_name)
+void binary_manager_get_info_with_name(int requester_pid, char *bin_name)
 {
 	int bin_idx;
 	int bin_count;
@@ -95,7 +95,7 @@ int binary_manager_get_info_with_name(int requester_pid, char *bin_name)
 
 	if (requester_pid < 0 || bin_name == NULL) {
 		bmdbg("Invalid data pid %d name %s\n", requester_pid, bin_name);
-		return ERROR;
+		return;
 	}
 	snprintf(q_name, BIN_PRIVMQ_LEN, "%s%d", BINMGR_RESPONSE_MQ_PREFIX, requester_pid);
 
@@ -112,17 +112,16 @@ int binary_manager_get_info_with_name(int requester_pid, char *bin_name)
 			snprintf(response_msg.data.active_dev, BINMGR_DEVNAME_LEN, BINMGR_DEVNAME_FMT, BIN_PARTNUM(bin_idx, BIN_USEIDX(bin_idx)));
 			if (BIN_PARTNUM(bin_idx, (BIN_USEIDX(bin_idx) ^ 1)) != -1) {
 				snprintf(response_msg.data.inactive_dev, BINMGR_DEVNAME_LEN, BINMGR_DEVNAME_FMT, BIN_PARTNUM(bin_idx, (BIN_USEIDX(bin_idx) ^ 1)));
-
 			}
 			break;
 		}
 	}
 
-	return binary_manager_send_response(q_name, &response_msg, sizeof(binmgr_getinfo_response_t));
+	binary_manager_send_response(q_name, &response_msg, sizeof(binmgr_getinfo_response_t));
 }
 
 /* Get info of all registered binaries */
-int binary_manager_get_info_all(int requester_pid)
+void binary_manager_get_info_all(int requester_pid)
 {
 	int bin_idx;
 	int bin_count;
@@ -131,7 +130,7 @@ int binary_manager_get_info_all(int requester_pid)
 
 	if (requester_pid < 0) {
 		bmdbg("Invalid requester pid %d\n", requester_pid);
-		return ERROR;
+		return;
 	}
 	snprintf(q_name, BIN_PRIVMQ_LEN, "%s%d", BINMGR_RESPONSE_MQ_PREFIX, requester_pid);
 
@@ -154,5 +153,5 @@ int binary_manager_get_info_all(int requester_pid)
 		response_msg.result = BINMGR_NOT_FOUND;
 	}
 
-	return binary_manager_send_response(q_name, &response_msg, sizeof(binmgr_getinfo_all_response_t));
+	binary_manager_send_response(q_name, &response_msg, sizeof(binmgr_getinfo_all_response_t));
 }

--- a/os/kernel/binary_manager/binary_manager_response.c
+++ b/os/kernel/binary_manager/binary_manager_response.c
@@ -32,7 +32,7 @@
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
-int binary_manager_send_response(char *q_name, void *response_msg, int msg_size)
+void binary_manager_send_response(char *q_name, void *response_msg, int msg_size)
 {
 	int ret;
 	mqd_t mqfd;
@@ -40,7 +40,7 @@ int binary_manager_send_response(char *q_name, void *response_msg, int msg_size)
 
 	if (q_name == NULL || response_msg == NULL || msg_size < 0) {
 		bmdbg("Invalid param\n");
-		return ERROR;
+		return;
 	}
 
 	attr.mq_maxmsg = BINMGR_MAX_MSG;
@@ -50,17 +50,15 @@ int binary_manager_send_response(char *q_name, void *response_msg, int msg_size)
 	mqfd = mq_open(q_name, O_WRONLY | O_CREAT, 0666, &attr);
 	if (mqfd == (mqd_t)ERROR) {
 		bmdbg("mq_open failed!\n");
-		return ERROR;
+		return;
 	}
 
 	ret = mq_send(mqfd, (char *)response_msg, msg_size, BINMGR_NORMAL_PRIO);
 	if (ret < 0) {
 		bmdbg("mq_send failed! %d\n", errno);
 		mq_close(mqfd);
-		return ERROR;
+		return;
 	}
 
 	mq_close(mqfd);
-
-	return OK;
 }


### PR DESCRIPTION
…o void types

Binary manager always runs even with a request failure.
So we don't need to get return value from request.