### PR TITLE
loadable_apps/wifiapp : Fix printf arg count mismatch

### DIFF
--- a/loadable_apps/loadable_sample/wifiapp/wifiapp.c
+++ b/loadable_apps/loadable_sample/wifiapp/wifiapp.c
@@ -69,7 +69,7 @@ int wifiapp_main(int argc, char **argv)
 	int ret;
 	ret = binary_manager_notify_binary_started();
 	if (ret < 0) {
-		printf("WIFI notify 'START' state FAIL\n", ret);
+		printf("WIFI notify 'START' state FAIL\n");
 	}
 #endif
 


### PR DESCRIPTION
Fix printf arg count mismatch because there is a printf with an incorrect number of args in wifiapp.c