### PR TITLE
apps/example/ta_tc/messaging/utc : Fix coverity issues

### DIFF
--- a/apps/examples/testcase/ta_tc/messaging/utc/utc_messaging_recv.c
+++ b/apps/examples/testcase/ta_tc/messaging/utc/utc_messaging_recv.c
@@ -170,10 +170,10 @@ static void nonblock_callback(msg_reply_type_t msg_type, msg_recv_buf_t *recv_da
 		} else {
 			tc_reply_chk = TC_OK;
 		}
+		free(reply.msg);
 	} else {
 		tc_nonblock_chk = TC_FAIL;
 	}
-	free(reply.msg);
 }
 
 static void utc_messaging_recv_nonblock_n(void)

--- a/apps/examples/testcase/ta_tc/messaging/utc/utc_messaging_send.c
+++ b/apps/examples/testcase/ta_tc/messaging/utc/utc_messaging_send.c
@@ -271,7 +271,6 @@ static void reply_recv(int argc, FAR char *argv[])
 	}
 	if (ret != OK) {
 		tc_send_chk = TC_FAIL;
-		free(reply_data.msg);
 		goto cleanup_return;
 	}
 


### PR DESCRIPTION
Fix coverity issues that uninitialized pointer read in utc_messaging_send.c and double free in utc_messaging_recv.c