### PR TITLE
kernel/binary_manager: Support to retry loading in a failure and Remove unnessasary sched_lock/unlock

### DIFF
--- a/os/binfmt/binfmt_loadbinary.c
+++ b/os/binfmt/binfmt_loadbinary.c
@@ -32,10 +32,10 @@
 #include <tinyara/kmalloc.h>
 #include <tinyara/sched.h>
 #include <tinyara/binfmt/binfmt.h>
-#ifdef CONFIG_BINARY_MANAGER
 #include <tinyara/binary_manager.h>
-#endif
+
 #include "binfmt.h"
+#include "binary_manager/binary_manager.h"
 
 #ifdef CONFIG_BINFMT_ENABLE
 
@@ -73,7 +73,7 @@ extern void mpu_user_extsram_context(uint32_t region, uintptr_t base, size_t siz
  *
  ****************************************************************************/
 #ifdef CONFIG_BINARY_MANAGER
-int load_binary(FAR const char *filename, load_attr_t *load_attr)
+int load_binary(int binary_idx, FAR const char *filename, load_attr_t *load_attr)
 {
 	FAR struct binary_s *bin;
 	int pid;
@@ -198,6 +198,11 @@ int load_binary(FAR const char *filename, load_attr_t *load_attr)
 #endif
 
 	binfo("%s loaded @ 0x%08x and running with pid = %d\n", bin->filename, bin->alloc[0], pid);
+
+	/* Update binary id and state for fault handling before unlocking scheduling */
+
+	BIN_ID(binary_idx) = pid;
+	BIN_STATE(binary_idx) = BINARY_LOADING_DONE;
 
 	sched_unlock();
 	return pid;

--- a/os/include/tinyara/binfmt/binfmt.h
+++ b/os/include/tinyara/binfmt/binfmt.h
@@ -385,7 +385,7 @@ int binfmt_exit(FAR struct binary_s *bin);
  *
  ****************************************************************************/
 #ifdef CONFIG_BINARY_MANAGER
-int load_binary(FAR const char *filename, load_attr_t *load_attr);
+int load_binary(int binary_idx, FAR const char *filename, load_attr_t *load_attr);
 #endif
 
 #undef EXTERN

--- a/os/kernel/binary_manager/binary_manager.h
+++ b/os/kernel/binary_manager/binary_manager.h
@@ -62,6 +62,7 @@
 #if (defined(CONFIG_BUILD_PROTECTED) || defined(CONFIG_BUILD_KERNEL)) && defined(CONFIG_MM_KERNEL_HEAP)
 #define MAX_WAIT_COUNT             3                          /* The maximum number of times you can wait to process a delayed free */
 #endif
+#define BINMGR_LOADING_TRYCNT      2
 
 /* Loading thread cmd types */
 enum loading_thread_cmd {

--- a/os/kernel/binary_manager/binary_manager_load.c
+++ b/os/kernel/binary_manager/binary_manager_load.c
@@ -39,10 +39,6 @@
 #include "task/task.h"
 #include "binary_manager.h"
 
-#if (defined(CONFIG_BUILD_PROTECTED) || defined(CONFIG_BUILD_KERNEL)) && defined(CONFIG_MM_KERNEL_HEAP)
-extern volatile sq_queue_t g_delayed_kfree;
-#endif
-
 /****************************************************************************
  * Private Definitions
  ****************************************************************************/
@@ -143,13 +139,8 @@ int binary_manager_load_binary(int bin_idx)
 	int part_idx;
 	int latest_ver;
 	int latest_idx;
-#if (defined(CONFIG_BUILD_PROTECTED) || defined(CONFIG_BUILD_KERNEL)) && defined(CONFIG_MM_KERNEL_HEAP)
-	int wait_count;
-#endif
-	uint32_t valid_bin_count;
-	bool loadable;
-	bool is_new_bin;
-	bool is_sched_locked;
+	int retry_count;
+	int valid_bin_count;
 	load_attr_t load_attr;
 	char devname[BINMGR_DEVNAME_LEN];
 	binary_header_t header_data[PARTS_PER_BIN];
@@ -157,9 +148,6 @@ int binary_manager_load_binary(int bin_idx)
 	latest_ver = -1;
 	latest_idx = -1;
 	valid_bin_count = 0;
-	loadable = false;
-	is_new_bin = false;
-	is_sched_locked = false;
 
 	if (bin_idx < 0) {
 		bmdbg("Invalid bin idx %d\n", bin_idx);
@@ -179,7 +167,6 @@ int binary_manager_load_binary(int bin_idx)
 		}
 		ret = binary_manager_read_header(bin_idx, part_idx, &header_data[part_idx]);
 		if (ret == OK) {
-			loadable = true;
 			valid_bin_count++;
 			version = (int)atoi(header_data[part_idx].bin_ver);
 			bmvdbg("Found valid header in part %d, version %d\n", part_idx, version);
@@ -190,91 +177,53 @@ int binary_manager_load_binary(int bin_idx)
 		}
 	}
 
-	/* Failed to find valid binary */
-	if (loadable == false) {
-		bmdbg("Failed to find loadable binary %d\n", bin_idx);
+	if (valid_bin_count == 0) {
+		bmdbg("Failed to find valid header of binary %s\n", BIN_NAME(bin_idx));
 		return ERROR;
 	}
 
 	/* Load binary */
 	do {
-		if (is_new_bin == false) {
-			strncpy(load_attr.bin_name, header_data[latest_idx].bin_name, BIN_NAME_MAX);
-			snprintf(devname, BINMGR_DEVNAME_LEN, BINMGR_DEVNAME_FMT, BIN_PARTNUM(bin_idx, latest_idx));
-			load_attr.bin_size = header_data[latest_idx].bin_size;
-			load_attr.compression_type = header_data[latest_idx].compression_type;
-			load_attr.ram_size = header_data[latest_idx].bin_ramsize;
-			load_attr.stack_size = header_data[latest_idx].bin_stacksize;
-			load_attr.priority = header_data[latest_idx].bin_priority;
-			load_attr.offset = CHECKSUM_SIZE + header_data[latest_idx].header_size;		
-			is_new_bin = true;
-		}
+		strncpy(load_attr.bin_name, header_data[latest_idx].bin_name, BIN_NAME_MAX);
+		snprintf(devname, BINMGR_DEVNAME_LEN, BINMGR_DEVNAME_FMT, BIN_PARTNUM(bin_idx, latest_idx));
+		load_attr.bin_size = header_data[latest_idx].bin_size;
+		load_attr.compression_type = header_data[latest_idx].compression_type;
+		load_attr.ram_size = header_data[latest_idx].bin_ramsize;
+		load_attr.stack_size = header_data[latest_idx].bin_stacksize;
+		load_attr.priority = header_data[latest_idx].bin_priority;
+		load_attr.offset = CHECKSUM_SIZE + header_data[latest_idx].header_size;
+
 		bmvdbg("BIN[%d] %s %d %d\n", bin_idx, devname, load_attr.bin_size, load_attr.offset);
 
-		/* If a priority of loaded task is higher than priority of loading thread,
-		 * we need to lock scheduling until updating loading info in binary table. */
-		if (load_attr.priority >= LOADINGTHD_PRIORITY) {
-			sched_lock();
-			is_sched_locked = true;
-		}
-
-		ret = load_binary(devname, &load_attr);
-		if (ret > 0) {
-			bin_pid = (pid_t)ret;
-			bmvdbg("Load '%s' success! pid = %d\n", devname, bin_pid);
-			break;
-		} 
-#if (defined(CONFIG_BUILD_PROTECTED) || defined(CONFIG_BUILD_KERNEL)) && defined(CONFIG_MM_KERNEL_HEAP)
-		else if (errno == ENOMEM) {
-			if (is_sched_locked) {
-				sched_unlock();
-				is_sched_locked = false;
+		retry_count = 0;
+		
+		while (retry_count < BINMGR_LOADING_TRYCNT) {
+			ret = load_binary(bin_idx, devname, &load_attr);
+			if (ret > 0) {
+				bmvdbg("Load '%s' success! pid = %d\n", devname, ret);
+				/* Set the data in table from header */
+				BIN_USEIDX(bin_idx) = latest_idx;
+				BIN_LOAD_ATTR(bin_idx) = load_attr;
+				strncpy(BIN_VER(bin_idx), header_data[latest_idx].bin_ver, BIN_VER_MAX);
+				strncpy(BIN_KERNEL_VER(bin_idx), header_data[latest_idx].kernel_ver, KERNEL_VER_MAX);
+				strncpy(BIN_NAME(bin_idx), header_data[latest_idx].bin_name, BIN_NAME_MAX);
+				bmvdbg("BIN TABLE[%d] %d %d %s %s %s\n", bin_idx, BIN_SIZE(bin_idx), BIN_RAMSIZE(bin_idx), BIN_VER(bin_idx), BIN_KERNEL_VER(bin_idx), BIN_NAME(bin_idx));
+				return OK;
+			} else if (errno == ENOMEM) {
+				/* Sleep for a moment to get available memory */
+				usleep(1000);
 			}
-			if (g_delayed_kfree.head) {
-				wait_count = 0;
-				/* wait until delayed free list is empty */
-				while (g_delayed_kfree.head && wait_count < MAX_WAIT_COUNT) {
-					usleep(500);
-					wait_count++;
-				}
-				/* If delayed free list is empty, try to load binary again */
-				if (g_delayed_kfree.head == NULL) {
-					continue;
-				}
-			}
-		}
-#endif
-		if (is_sched_locked) {
-			sched_unlock();
-			is_sched_locked = false;
+			retry_count++;
+			bmdbg("Load '%s' %dth fail, errno %d\n", BIN_NAME(bin_idx), retry_count, errno);
 		}
 
-		if (valid_bin_count == 1) {
-			bmdbg("Load '%s' fail, errno %d\n", BIN_NAME(bin_idx), errno);
-			return ERROR;
+		if (--valid_bin_count > 0) {
+			/* Change index 0 to 1 and 1 to 0. */
+			latest_idx ^= 1;
 		}
-		is_new_bin = false;
-		valid_bin_count--;
-		/* Change index 0 to 1 and 1 to 0. */
-		latest_idx ^= 1;
-	} while (loadable);
+	} while (valid_bin_count > 0);
 
-	/* Set the data in table from header */
-	BIN_ID(bin_idx) = bin_pid;
-	BIN_STATE(bin_idx) = BINARY_LOADING_DONE;
-	BIN_USEIDX(bin_idx) = latest_idx;
-	BIN_LOAD_ATTR(bin_idx) = load_attr;
-	strncpy(BIN_VER(bin_idx), header_data[latest_idx].bin_ver, BIN_VER_MAX);
-	strncpy(BIN_KERNEL_VER(bin_idx), header_data[latest_idx].kernel_ver, KERNEL_VER_MAX);
-	strncpy(BIN_NAME(bin_idx), header_data[latest_idx].bin_name, BIN_NAME_MAX);
-
-	bmvdbg("BIN TABLE[%d] %d %d %s %s %s\n", bin_idx, BIN_SIZE(bin_idx), BIN_RAMSIZE(bin_idx), BIN_VER(bin_idx), BIN_KERNEL_VER(bin_idx), BIN_NAME(bin_idx));
-
-	if (is_sched_locked) {
-		sched_unlock();
-	}
-
-	return OK;
+	return ERROR;
 }
 
 static int binary_manager_load_all(void)


### PR DESCRIPTION
- Retry binary loading in a failure
- Remove unnessasary locking scheduling when binary loading