### PR TITLE
os/binfmt/libelf: Set cut-off ratio for no. of blocks for elf block caching

### DIFF
--- a/os/binfmt/libelf/libelf.h
+++ b/os/binfmt/libelf/libelf.h
@@ -359,6 +359,9 @@ void elf_addrenv_free(FAR struct elf_loadinfo_s *loadinfo);
 
 #ifdef CONFIG_ELF_CACHE_READ
 
+/* Cut-off ratio for number of blocks for caching */
+#define CUTOFF_RATIO_CACHE_BLOCKS 0.1f
+
 /* Struct for output buffers to cache uncompressed blocks */
 struct block_cache_s {
 	unsigned char *out_buffer;              /* Buffer that is going to hold uncompressed data */

--- a/os/binfmt/libelf/libelf_cache.c
+++ b/os/binfmt/libelf/libelf_cache.c
@@ -453,6 +453,13 @@ int elf_cache_init(int filfd, uint16_t offset, off_t filelen, uint8_t compressio
 	number_of_blocks = file_len / cache_blocks_size;
 	elf_compress_type = compression_type;
 
+	/* Set number of blocks to use for caching */
+	if (CONFIG_ELF_CACHE_BLOCKS_COUNT < (CUTOFF_RATIO_CACHE_BLOCKS) * (number_of_blocks)) {
+		number_blocks_caching = CONFIG_ELF_CACHE_BLOCKS_COUNT;
+	} else {
+		number_blocks_caching = ((CUTOFF_RATIO_CACHE_BLOCKS) * (number_of_blocks));
+	}
+
 	/* Extra unaligned data apart from blocksize */
 	if (file_len % cache_blocks_size)
 		number_of_blocks++;


### PR DESCRIPTION
- The logic for setting cut-off ratio for number of blocks to be used for elf block caching (when loading) was not merged in earlier pull request.
- In this PR, using CUTOFF_RATIO_CACHE_BLOCKS macro, we set number to blocks to use in elf caching inside elf_cache_init.

Signed-off-by: Nishtha97 <n.maloo@samsung.com>