### PR TITLE
apps/examples: Fix a FS TC build error

### DIFF
--- a/apps/examples/testcase/le_tc/filesystem/fs_main.c
+++ b/apps/examples/testcase/le_tc/filesystem/fs_main.c
@@ -3702,7 +3702,7 @@ int tc_filesystem_main(int argc, char *argv[])
 	tc_driver_mtd_config_ops();
 #endif
 
-#if defined(CONFIG_MTD_FTL) && defined(CONFIG_BCH)
+#if defined(CONFIG_MTD_FTL) && defined(CONFIG_BCH) && defined(CONFIG_FLASH_PARTITION)
 	tc_driver_mtd_ftl_ops();
 #endif
 


### PR DESCRIPTION
- 'defined(CONFIG_FLASH_PARTITION)' is added to correct the build error of a ftl TC.