### PR TITLE
libc/string: fix typo, CONFIGC_ARCH_STPNCPY

### DIFF
--- a/lib/libc/string/lib_stpncpy.c
+++ b/lib/libc/string/lib_stpncpy.c
@@ -85,7 +85,7 @@
  *
  ****************************************************************************/
 
-#ifndef CONFIGC_ARCH_STPNCPY
+#ifndef CONFIG_ARCH_STPNCPY
 FAR char *stpncpy(FAR char *dest, FAR const char *src, size_t n)
 {
 	FAR char *end = dest + n;		/* End of dest buffer + 1 byte */


### PR DESCRIPTION
CONFIG'C'_ is a typo, let's remove 'C'.

Signed-off-by: sunghan-chang <sh924.chang@samsung.com>