### PR TITLE
libc/symtab : Add config for symtab APIs

### DIFF
--- a/build/configs/imxrt1020-evk/SAM/defconfig
+++ b/build/configs/imxrt1020-evk/SAM/defconfig
@@ -1333,6 +1333,7 @@ CONFIG_LIBC_ARCH_ELF=y
 # Program Execution Options
 #
 CONFIG_LIBC_EXECFUNCS=y
+CONFIG_LIBC_SYMTAB=y
 
 #
 # Basic CXX Support

--- a/build/configs/imxrt1020-evk/loadable_elf_apps/defconfig
+++ b/build/configs/imxrt1020-evk/loadable_elf_apps/defconfig
@@ -1222,6 +1222,7 @@ CONFIG_LIBC_ARCH_ELF=y
 # Program Execution Options
 #
 CONFIG_LIBC_EXECFUNCS=y
+CONFIG_LIBC_SYMTAB=y
 
 #
 # Basic CXX Support

--- a/build/configs/imxrt1050-evk/loadable_elf_apps/defconfig
+++ b/build/configs/imxrt1050-evk/loadable_elf_apps/defconfig
@@ -837,6 +837,7 @@ CONFIG_LIBC_ARCH_ELF=y
 # Program Execution Options
 #
 CONFIG_LIBC_EXECFUNCS=y
+CONFIG_LIBC_SYMTAB=y
 
 #
 # Basic CXX Support

--- a/build/configs/imxrt1050-evk/wifi_loadable/defconfig
+++ b/build/configs/imxrt1050-evk/wifi_loadable/defconfig
@@ -1054,6 +1054,7 @@ CONFIG_LIBC_ARCH_ELF=y
 # Program Execution Options
 #
 CONFIG_LIBC_EXECFUNCS=y
+CONFIG_LIBC_SYMTAB=y
 
 #
 # Basic CXX Support

--- a/lib/libc/Kconfig
+++ b/lib/libc/Kconfig
@@ -455,3 +455,9 @@ config LIBC_EXECFUNCS
 		non-standard binfmt function 'exec', and then (2) exit(0).  Since
 		the new thread will be terminated by the exec[l|v] call, it really
 		served no purpose other than to suport Unix compatility.
+
+config LIBC_SYMTAB
+	bool "Enable symbol table library"
+	default n
+	---help---
+		Enable symbol table library. It can be used for getting symbol information.

--- a/lib/libc/symtab/Make.defs
+++ b/lib/libc/symtab/Make.defs
@@ -50,6 +50,8 @@
 #
 ############################################################################
 
+ifeq ($(CONFIG_LIBC_SYMTAB),y)
+
 # Symbol table source files
 
 CSRCS += symtab_findbyname.c symtab_findbyvalue.c
@@ -59,3 +61,5 @@ CSRCS += symtab_findorderedbyname.c symtab_sortbyname.c
 
 DEPPATH += --dep-path symtab
 VPATH += :symtab
+
+endif

--- a/os/binfmt/Kconfig
+++ b/os/binfmt/Kconfig
@@ -6,6 +6,7 @@
 config BINFMT_ENABLE
 	bool "Enable BINFMT support"
 	default n
+	select LIBC_SYMTAB
 	---help---
 		By default, support for loadable binary formats is disable.  This logic
 		may be build by defining this setting.


### PR DESCRIPTION
symtab APIs are used only when loader tries to load.
So add symtab config to enable/disable.