### PR TITLE
os/binfmt/libelf: Correctly assign number of blocks for caching

### DIFF
--- a/os/binfmt/libelf/libelf_cache.c
+++ b/os/binfmt/libelf/libelf_cache.c
@@ -454,15 +454,15 @@ int elf_cache_init(int filfd, uint16_t offset, off_t filelen, uint8_t compressio
 	elf_compress_type = compression_type;
 
 	/* Set number of blocks to use for caching */
-	if (CONFIG_ELF_CACHE_BLOCKS_COUNT < (CUTOFF_RATIO_CACHE_BLOCKS) * (number_of_blocks)) {
-		number_blocks_caching = CONFIG_ELF_CACHE_BLOCKS_COUNT;
-	} else {
-		number_blocks_caching = ((CUTOFF_RATIO_CACHE_BLOCKS) * (number_of_blocks));
+	if (CONFIG_ELF_CACHE_BLOCKS_COUNT > (CUTOFF_RATIO_CACHE_BLOCKS) * (number_of_blocks)) {
+		number_blocks_caching = (CUTOFF_RATIO_CACHE_BLOCKS) * (number_of_blocks);
 	}
 
 	/* Extra unaligned data apart from blocksize */
-	if (file_len % cache_blocks_size)
+	if (file_len % cache_blocks_size) {
 		number_of_blocks++;
+		number_blocks_caching++;
+	}
 
 	/* Initialize max_accesed_count to 0 */
 	max_accessed_count = 0;

--- a/os/binfmt/libelf/libelf_cache.c
+++ b/os/binfmt/libelf/libelf_cache.c
@@ -105,6 +105,7 @@ static off_t elf_cache_lseek_block(int filfd, uint16_t binary_header_size, int b
 
 	actual_offset = binary_header_size + block_number * cache_blocks_size;
 
+#ifndef CONFIG_COMPRESSED_BINARY
 	/* Seek to location of this block in actual ELF file */
 	rpos = lseek(filfd, actual_offset, SEEK_SET);
 
@@ -115,6 +116,10 @@ static off_t elf_cache_lseek_block(int filfd, uint16_t binary_header_size, int b
 		berr("Failed to seek to position %lu: %d\n", (unsigned long)actual_offset, errval);
 		return -errval;
 	}
+
+#else
+	rpos = actual_offset;
+#endif
 
 	return rpos;
 }


### PR DESCRIPTION
-Assign no. of blocks for caching based on correctly updated number of blocks in file

Signed-off-by: Nishtha97 <n.maloo@samsung.com>