### PR TITLE
framework/messaging : Modify cleanup

### DIFF
--- a/apps/examples/testcase/ta_tc/messaging/utc/utc_messaging_multicast.c
+++ b/apps/examples/testcase/ta_tc/messaging/utc/utc_messaging_multicast.c
@@ -37,6 +37,7 @@
 
 static bool tc_multi_chk = TC_OK;
 static int tc_multi_count = 0;
+static bool tc_cleanup_chk = false;
 
 static sem_t multi_sem;
 
@@ -81,6 +82,11 @@ static int multi_recv_nonblock(int argc, FAR char *argv[])
 	sleep(5);
 
 	free(multi_data.buf);
+
+	ret = messaging_cleanup(TC_MULTI_PORT);
+	if (ret == OK) {
+		tc_cleanup_chk = true;
+	}
 	return OK;
 }
 
@@ -107,6 +113,7 @@ static int multi_recv_block(int argc, FAR char *argv[])
 
 	tc_multi_count++;
 	free(msg.buf);
+
 	return OK;
 errout:
 	free(msg.buf);
@@ -197,8 +204,7 @@ static void utc_messaging_multicast_p(void)
 
 	(void)sem_destroy(&multi_sem);
 
-	ret = messaging_cleanup(TC_MULTI_PORT);
-	TC_ASSERT_EQ("messging_multicast", ret, OK);
+	TC_ASSERT_EQ("messging_multicast", tc_cleanup_chk, true);
 
 	TC_SUCCESS_RESULT();
 }

--- a/apps/examples/testcase/ta_tc/messaging/utc/utc_messaging_recv.c
+++ b/apps/examples/testcase/ta_tc/messaging/utc/utc_messaging_recv.c
@@ -43,6 +43,7 @@ static sem_t recv_sem;
 static bool tc_block_chk = TC_OK;
 static bool tc_nonblock_chk = TC_OK;
 static bool tc_reply_chk = TC_OK;
+static bool tc_cleanup_chk = false;
 
 static void utc_messaging_recv_block_n(void)
 {
@@ -255,6 +256,8 @@ static void nonblock_recv(int argc, FAR char *argv[])
 	msg_callback_info_t cb_info;
 	cb_info.cb_func = nonblock_callback;
 
+	tc_cleanup_chk = false;
+
 	ret = sem_wait(&recv_sem);
 	if (ret != OK) {
 		tc_nonblock_chk = TC_FAIL;
@@ -281,6 +284,11 @@ static void nonblock_recv(int argc, FAR char *argv[])
 
 	/* wait not to finish before receiving message. */
 	sleep(2);
+
+	ret = messaging_cleanup(TC_NONBLOCK_PORT);
+	if (ret == OK) {
+		tc_cleanup_chk = true;
+	}
 }
 
 static void utc_messaging_recv_nonblock_p(void)
@@ -332,10 +340,7 @@ static void utc_messaging_cleanup_n(void)
 
 static void utc_messaging_cleanup_p(void)
 {
-	int ret;
-
-	ret = messaging_cleanup(TC_NONBLOCK_PORT);
-	TC_ASSERT_EQ("messaging_cleanup", ret, OK);
+	TC_ASSERT_EQ("messaging_cleanup", tc_cleanup_chk, true);
 
 	TC_SUCCESS_RESULT();
 }


### PR DESCRIPTION
1.  framework/messaging : Change empty check logic for cleanup
    
    If port_info reaches the end of the g_port_info_list, it also returns OK.
    For distinguishing the empty of g_port_info_list and no matched case, make boolean variable.

2. apps/testcase/messaging : Modify cleanup tc of recv and multicast
    
    messaginig_cleanup only works with port owner who registered the port.
    so calling cleanup in each receivers.
