### PR TITLE
testcase/kernel/tc_libc_timer : Add CONFIG specific buffer check line

### DIFF
--- a/apps/examples/testcase/le_tc/kernel/tc_libc_timer.c
+++ b/apps/examples/testcase/le_tc/kernel/tc_libc_timer.c
@@ -321,6 +321,9 @@ static void tc_libc_timer_strftime(void)
 	st_time.tm_mday = 19;
 	st_time.tm_mon = 5;
 	st_time.tm_year = 2017 - TM_YEAR_BASE;
+#if defined(CONFIG_LIBC_LOCALTIME) || defined(CONFIG_TIME_EXTENDED)
+	st_time.tm_wday = 5;
+#endif
 
 	/* Verifying year and month filled in time structure.
 	 * time structure has month in range 0-11,
@@ -335,7 +338,18 @@ static void tc_libc_timer_strftime(void)
 
 	/* Check the full name for the day of the week */
 	strftime(buffer, BUFF_SIZE, "%a", &st_time);
+#if defined(CONFIG_LIBC_LOCALTIME) || defined(CONFIG_TIME_EXTENDED)
+	TC_ASSERT_EQ("strftime", strncmp(buffer, "Fri", strlen("Fri") + 1), 0);
+#else
 	TC_ASSERT_EQ("strftime", strncmp(buffer, "Day", strlen("Day") + 1), 0);
+#endif
+
+	strftime(buffer, BUFF_SIZE, "%A", &st_time);
+#if defined(CONFIG_LIBC_LOCALTIME) || defined(CONFIG_TIME_EXTENDED)
+	TC_ASSERT_EQ("strftime", strncmp(buffer, "Friday", strlen("Friday") + 1), 0);
+#else
+	TC_ASSERT_EQ("strftime", strncmp(buffer, "Day", strlen("Day") + 1), 0);
+#endif
 
 	/* Check the full month name */
 	strftime(buffer, BUFF_SIZE, "%B", &st_time);

--- a/lib/libc/time/lib_strftime.c
+++ b/lib/libc/time/lib_strftime.c
@@ -127,6 +127,8 @@ static const char *const g_monthname[12] = {
  *   ter,  and  terminated  by  a  conversion  specifier  character, and are
  *   replaced in s as follows:
  *
+ *   %a     A three-letter abbreviation for the day of the week.
+ *   %A     The full name for the day of the week.
  *   %b     The abbreviated month name according to the current locale.
  *   %B     The full month name according to the current locale.
  *   %C     The century number (year/100) as a 2-digit integer. (SU)


### PR DESCRIPTION
If CONFIG_LIBC_LOCALTIME or CONFIG_TIME_EXTENDED is turned on.
The strftime function that receives the %a and %A parameter stores the value associated with st_time.tm_wday in buffer instead of "Day".
So I added a #if line to handle this.