### PR TITLE
testcase/arastorage, messaging: add "_main" postfix for main function…

### DIFF
--- a/apps/examples/testcase/le_tc/filesystem/tc_fs_mops.c
+++ b/apps/examples/testcase/le_tc/filesystem/tc_fs_mops.c
@@ -403,7 +403,7 @@ static void tc_fs_mops_umount(const char *filesystemtype)
 	TC_ASSERT_EQ("umount", ret, OK);
 }
 
-void tc_fs_mops_testcase(const char *filesystemtype)
+static void tc_fs_mops_test_main(const char *filesystemtype)
 {
 	DIR *dir = NULL;
 	int fd1 = -1;
@@ -428,37 +428,20 @@ void tc_fs_mops_testcase(const char *filesystemtype)
 	tc_fs_mops_statfs(filesystemtype);
 	tc_fs_mops_unlink(filesystemtype);
 	tc_fs_mops_umount(filesystemtype);
-}
-
-void tc_fs_mops_romfs(void)
-{
-	tc_fs_mops_testcase("romfs");
-	TC_SUCCESS_RESULT();
-}
-
-void tc_fs_mops_smartfs(void)
-{
-	tc_fs_mops_testcase("smartfs");
-	TC_SUCCESS_RESULT();
-}
-
-void tc_fs_mops_tmpfs(void)
-{
-	tc_fs_mops_testcase("tmpfs");
 	TC_SUCCESS_RESULT();
 }
 
 void tc_fs_mops_main(void)
 {
 #ifdef CONFIG_TC_FS_TMPFS_MOPS
-	tc_fs_mops_tmpfs();
+	tc_fs_mops_test_main("tmpfs");
 #endif
 #ifdef CONFIG_TC_FS_ROMFS_MOPS
 #ifndef CONFIG_BUILD_PROTECTED
-	tc_fs_mops_romfs();
+	tc_fs_mops_test_main("romfs");
 #endif
 #endif
 #ifdef CONFIG_TC_FS_SMARTFS_MOPS
-	tc_fs_mops_smartfs();
+	tc_fs_mops_test_main("smartfs");
 #endif
 }

--- a/apps/examples/testcase/ta_tc/arastorage/itc/itc_arastorage_main.c
+++ b/apps/examples/testcase/ta_tc/arastorage/itc/itc_arastorage_main.c
@@ -1735,8 +1735,16 @@ void itc_arastorage_db_cursor_free_n(void)
 	TC_SUCCESS_RESULT();
 }
 
-int itc_arastorage_launcher(int argc, FAR char *argv[])
+#ifdef CONFIG_BUILD_KERNEL
+int main(int argc, FAR char *argv[])
+#else
+int itc_arastorage_main(int argc, char *argv[])
+#endif
 {
+	if (tc_handler(TC_START, "Arastorage ITC") == ERROR) {
+		return ERROR;
+	}
+
 	itc_arastorage_startup_p();
 	//db_init being called once inside itc_arastorage_startup_p for below ITCs
 	itc_arastorage_db_query_p_create_remove_relation();
@@ -1798,21 +1806,6 @@ int itc_arastorage_launcher(int argc, FAR char *argv[])
 	itc_arastorage_db_init_deinit_p_multi_time();
 	itc_arastorage_db_print_tuple_n_after_deinit();
 	itc_arastorage_db_print_value_n_after_deinit();
-
-	return 0;
-}
-
-#ifdef CONFIG_BUILD_KERNEL
-int main(int argc, FAR char *argv[])
-#else
-int itc_arastorage_main(int argc, char *argv[])
-#endif
-{
-	if (tc_handler(TC_START, "Arastorage ITC") == ERROR) {
-		return ERROR;
-	}
-
-	itc_arastorage_launcher(argc, argv);
 
 	(void)tc_handler(TC_END, "Arastorage ITC");
 	return 0;

--- a/apps/examples/testcase/ta_tc/messaging/utc/tc_internal.h
+++ b/apps/examples/testcase/ta_tc/messaging/utc/tc_internal.h
@@ -16,33 +16,9 @@
  *
  ****************************************************************************/
 
-#include <tinyara/config.h>
-#include <stdio.h>
-#include <string.h>
-#include <stdlib.h>
-#include <unistd.h>
-#include <sys/types.h>
-#include <messaging/messaging.h>
-#include "tc_common.h"
-#include "tc_internal.h"
-
-#ifdef CONFIG_BUILD_KERNEL
-int main(int argc, FAR char *argv[])
-#else
-int utc_messaging_main(int argc, char *argv[])
+#ifndef __MESSAGING_TC_INTERNAL_H
+#define __MESSAGING_TC_INTERNAL_H
+void utc_messaging_recv_reply_and_cleanup_main(void);
+void utc_messaging_send_main(void);
+void utc_messaging_multicast_main(void);
 #endif
-{
-	if (tc_handler(TC_START, "Messaging UTC") == ERROR) {
-		return ERROR;
-	}
-
-	utc_messaging_recv_reply_and_cleanup_main();
-
-	utc_messaging_send_main();
-
-	utc_messaging_multicast_main();
-
-	(void)tc_handler(TC_END, "Messaging UTC");
-
-	return 0;
-}

--- a/apps/examples/testcase/ta_tc/messaging/utc/utc_messaging_multicast.c
+++ b/apps/examples/testcase/ta_tc/messaging/utc/utc_messaging_multicast.c
@@ -209,7 +209,7 @@ static void utc_messaging_multicast_p(void)
 	TC_SUCCESS_RESULT();
 }
 
-void utc_messaging_multicast(void)
+void utc_messaging_multicast_main(void)
 {
 	utc_messaging_multicast_n();
 	utc_messaging_multicast_p();

--- a/apps/examples/testcase/ta_tc/messaging/utc/utc_messaging_recv.c
+++ b/apps/examples/testcase/ta_tc/messaging/utc/utc_messaging_recv.c
@@ -345,7 +345,7 @@ static void utc_messaging_cleanup_p(void)
 	TC_SUCCESS_RESULT();
 }
 
-void utc_messaging_recv_reply_and_cleanup(void)
+void utc_messaging_recv_reply_and_cleanup_main(void)
 {
 	utc_messaging_recv_block_n();
 	utc_messaging_recv_block_p();

--- a/apps/examples/testcase/ta_tc/messaging/utc/utc_messaging_send.c
+++ b/apps/examples/testcase/ta_tc/messaging/utc/utc_messaging_send.c
@@ -440,7 +440,7 @@ static void utc_messaging_send_p(void)
 	TC_SUCCESS_RESULT();
 }
 
-void utc_messaging_send(void)
+void utc_messaging_send_main(void)
 {
 	utc_messaging_send_n();
 	utc_messaging_send_p();


### PR DESCRIPTION
… of each tc

The "_main" postfix shows it's the main function of each tc. It is not
a testcase, it calls real testcases so that it does not have TC_ASSERT_XX macro.

Signed-off-by: sunghan-chang <sh924.chang@samsung.com>