### PR TITLE
testcase: rename tc_handler to testcase_state_handler

### DIFF
--- a/apps/examples/testcase/le_tc/drivers/drivers_tc_main.c
+++ b/apps/examples/testcase/le_tc/drivers/drivers_tc_main.c
@@ -31,7 +31,7 @@ int main(int argc, FAR char *argv[])
 int tc_drivers_main(int argc, char *argv[])
 #endif
 {
-	if (tc_handler(TC_START, "Drivers TC") == ERROR) {
+	if (testcase_state_handler(TC_START, "Drivers TC") == ERROR) {
 		return ERROR;
 	}
 #ifdef CONFIG_TC_DRIVERS_NULL
@@ -70,7 +70,7 @@ int tc_drivers_main(int argc, char *argv[])
 	i2c_main();
 #endif
 
-	(void)tc_handler(TC_END, "Drivers TC");
+	(void)testcase_state_handler(TC_END, "Drivers TC");
 
 	return 0;
 }

--- a/apps/examples/testcase/le_tc/filesystem/fs_main.c
+++ b/apps/examples/testcase/le_tc/filesystem/fs_main.c
@@ -3647,7 +3647,7 @@ int main(int argc, FAR char *argv[])
 int tc_filesystem_main(int argc, char *argv[])
 #endif
 {
-	if (tc_handler(TC_START, "FileSystem TC") == ERROR) {
+	if (testcase_state_handler(TC_START, "FileSystem TC") == ERROR) {
 		return ERROR;
 	}
 
@@ -3770,7 +3770,7 @@ int tc_filesystem_main(int argc, char *argv[])
 #if defined(CONFIG_TC_FS_PROCFS) && defined(CONFIG_FS_SMARTFS) && !defined(CONFIG_SMARTFS_MULTI_ROOT_DIRS) && !defined(CONFIG_BUILD_PROTECTED)
 	tc_fs_smartfs_mksmartfs();
 #endif
-	(void)tc_handler(TC_END, "FileSystem TC");
+	(void)testcase_state_handler(TC_END, "FileSystem TC");
 
 	return 0;
 }

--- a/apps/examples/testcase/le_tc/kernel/kernel_tc_main.c
+++ b/apps/examples/testcase/le_tc/kernel/kernel_tc_main.c
@@ -43,7 +43,7 @@ int main(int argc, FAR char *argv[])
 int tc_kernel_main(int argc, char *argv[])
 #endif
 {
-	if (tc_handler(TC_START, "Kernel TC") == ERROR) {
+	if (testcase_state_handler(TC_START, "Kernel TC") == ERROR) {
 		return ERROR;
 	}
 
@@ -229,7 +229,7 @@ int tc_kernel_main(int argc, char *argv[])
 	close(g_tc_fd);
 	g_tc_fd = -1;
 
-	(void)tc_handler(TC_END, "Kernel TC");
+	(void)testcase_state_handler(TC_END, "Kernel TC");
 
 	return 0;
 }

--- a/apps/examples/testcase/le_tc/network/network_tc_main.c
+++ b/apps/examples/testcase/le_tc/network/network_tc_main.c
@@ -33,7 +33,7 @@ int main(int argc, FAR char *argv[])
 int tc_network_main(int argc, char *argv[])
 #endif
 {
-	if (tc_handler(TC_START, "Network TC") == ERROR) {
+	if (testcase_state_handler(TC_START, "Network TC") == ERROR) {
 		return ERROR;
 	}
 
@@ -133,7 +133,7 @@ int tc_network_main(int argc, char *argv[])
 #ifdef CONFIG_ITC_NET_CONNECT
 	itc_net_connect_main();
 #endif
-	(void)tc_handler(TC_END, "Network TC");
+	(void)testcase_state_handler(TC_END, "Network TC");
 
 	return 0;
 }

--- a/apps/examples/testcase/le_tc/tcp_tls/tcp_tls_stress.c
+++ b/apps/examples/testcase/le_tc/tcp_tls/tcp_tls_stress.c
@@ -713,7 +713,7 @@ int main(int argc, FAR char *argv[])
 int tc_tcp_tls_main(int argc, char *argv[])
 #endif
 {
-	if (tc_handler(TC_START, "TCPTLS STRESS TC") == ERROR) {
+	if (testcase_state_handler(TC_START, "TCPTLS STRESS TC") == ERROR) {
 		return ERROR;
 	}
 	int res = tcp_tls_signal_init();
@@ -767,6 +767,6 @@ int tc_tcp_tls_main(int argc, char *argv[])
 	}
 
 	tcp_tls_signal_deinit();
-	(void)tc_handler(TC_END, "TCPTLS STRESS TC");
+	(void)testcase_state_handler(TC_END, "TCPTLS STRESS TC");
 	return 0;
 }

--- a/apps/examples/testcase/le_tc/ttrace/ttrace_tc_main.c
+++ b/apps/examples/testcase/le_tc/ttrace/ttrace_tc_main.c
@@ -141,7 +141,7 @@ int main(int argc, FAR char *argv[])
 int tc_ttrace_main(int argc, char *argv[])
 #endif
 {
-	if (tc_handler(TC_START, "TTRACE TC") == ERROR) {
+	if (testcase_state_handler(TC_START, "TTRACE TC") == ERROR) {
 		return ERROR;
 	}
 
@@ -151,7 +151,7 @@ int tc_ttrace_main(int argc, char *argv[])
 	tc_libc_trace_end_uid();
 	tc_libc_trace_sched();
 
-	(void)tc_handler(TC_END, "TTRACE TC");
+	(void)testcase_state_handler(TC_END, "TTRACE TC");
 
 	return 0;
 }

--- a/apps/examples/testcase/ta_tc/arastorage/itc/itc_arastorage_main.c
+++ b/apps/examples/testcase/ta_tc/arastorage/itc/itc_arastorage_main.c
@@ -1741,7 +1741,7 @@ int main(int argc, FAR char *argv[])
 int itc_arastorage_main(int argc, char *argv[])
 #endif
 {
-	if (tc_handler(TC_START, "Arastorage ITC") == ERROR) {
+	if (testcase_state_handler(TC_START, "Arastorage ITC") == ERROR) {
 		return ERROR;
 	}
 
@@ -1807,6 +1807,6 @@ int itc_arastorage_main(int argc, char *argv[])
 	itc_arastorage_db_print_tuple_n_after_deinit();
 	itc_arastorage_db_print_value_n_after_deinit();
 
-	(void)tc_handler(TC_END, "Arastorage ITC");
+	(void)testcase_state_handler(TC_END, "Arastorage ITC");
 	return 0;
 }

--- a/apps/examples/testcase/ta_tc/arastorage/utc/utc_arastorage_main.c
+++ b/apps/examples/testcase/ta_tc/arastorage/utc/utc_arastorage_main.c
@@ -1519,7 +1519,7 @@ int main(int argc, FAR char *argv[])
 int utc_arastorage_main(int argc, char *argv[])
 #endif
 {
-	if (tc_handler(TC_START, "Arastorage UTC") == ERROR) {
+	if (testcase_state_handler(TC_START, "Arastorage UTC") == ERROR) {
 		return ERROR;
 	}
 
@@ -1583,7 +1583,7 @@ int utc_arastorage_main(int argc, char *argv[])
 	cleanup();
 	db_deinit();
 
-	(void)tc_handler(TC_END, "Arastorage UTC");
+	(void)testcase_state_handler(TC_END, "Arastorage UTC");
 
 	return 0;
 }

--- a/apps/examples/testcase/ta_tc/audio/itc/itc_audio_main.c
+++ b/apps/examples/testcase/ta_tc/audio/itc/itc_audio_main.c
@@ -1138,7 +1138,7 @@ int main(int argc, FAR char *argv[])
 int itc_audio_main(int argc, char *argv[])
 #endif
 {
-	if (tc_handler(TC_START, "Audio ITC") == ERROR) {
+	if (testcase_state_handler(TC_START, "Audio ITC") == ERROR) {
 		return ERROR;
 	}
 
@@ -1195,7 +1195,7 @@ int itc_audio_main(int argc, char *argv[])
 	/* after test, unlink the file */
 	unlink(AUDIO_TEST_FILE);
 
-	(void)tc_handler(TC_END, "Audio ITC");
+	(void)testcase_state_handler(TC_END, "Audio ITC");
 
 	return 0;
 }

--- a/apps/examples/testcase/ta_tc/audio/utc/utc_audio_main.c
+++ b/apps/examples/testcase/ta_tc/audio/utc/utc_audio_main.c
@@ -1460,7 +1460,7 @@ int main(int argc, FAR char *argv[])
 int utc_audio_main(int argc, char *argv[])
 #endif
 {
-	if (tc_handler(TC_START, "Audio UTC") == ERROR) {
+	if (testcase_state_handler(TC_START, "Audio UTC") == ERROR) {
 		return ERROR;
 	}
 
@@ -1528,7 +1528,7 @@ int utc_audio_main(int argc, char *argv[])
 	/* after test, unlink the file */
 	unlink(AUDIO_TEST_FILE);
 
-	(void)tc_handler(TC_END, "Audio UTC");
+	(void)testcase_state_handler(TC_END, "Audio UTC");
 
 	return 0;
 }

--- a/apps/examples/testcase/ta_tc/device_management/itc/itc_dm_main.c
+++ b/apps/examples/testcase/ta_tc/device_management/itc/itc_dm_main.c
@@ -154,7 +154,7 @@ int main(int argc, FAR char *argv[])
 int itc_dm_main(int argc, char *argv[])
 #endif
 {
-	if (tc_handler(TC_START, "DeviceManagement ITC") == ERROR) {
+	if (testcase_state_handler(TC_START, "DeviceManagement ITC") == ERROR) {
 		return ERROR;
 	}
 
@@ -195,7 +195,7 @@ int itc_dm_main(int argc, char *argv[])
 		wifiAutoConnectDeInit_itc();
 	}
 
-	(void)tc_handler(TC_END, "DeviceManagement ITC");
+	(void)testcase_state_handler(TC_END, "DeviceManagement ITC");
 
 	return 0;
 }

--- a/apps/examples/testcase/ta_tc/device_management/utc/utc_dm_main.c
+++ b/apps/examples/testcase/ta_tc/device_management/utc/utc_dm_main.c
@@ -141,7 +141,7 @@ int main(int argc, FAR char *argv[])
 int utc_dm_main(int argc, char *argv[])
 #endif
 {
-	if (tc_handler(TC_START, "DeviceManagement UTC") == ERROR) {
+	if (testcase_state_handler(TC_START, "DeviceManagement UTC") == ERROR) {
 		return ERROR;
 	}
 
@@ -184,7 +184,7 @@ int utc_dm_main(int argc, char *argv[])
 		wifiAutoConnectDeInit();
 	}
 
-	(void)tc_handler(TC_END, "DeviceManagement UTC");
+	(void)testcase_state_handler(TC_END, "DeviceManagement UTC");
 
 	return 0;
 }

--- a/apps/examples/testcase/ta_tc/eventloop/utc/utc_eventloop_main.c
+++ b/apps/examples/testcase/ta_tc/eventloop/utc/utc_eventloop_main.c
@@ -458,7 +458,7 @@ int main(int argc, FAR char *argv[])
 int utc_eventloop_main(int argc, char *argv[])
 #endif
 {
-	if (tc_handler(TC_START, "Eventloop UTC") == ERROR) {
+	if (testcase_state_handler(TC_START, "Eventloop UTC") == ERROR) {
 		return ERROR;
 	}
 
@@ -487,7 +487,7 @@ int utc_eventloop_main(int argc, char *argv[])
 
 	utc_eventloop_loop_stop_p();
 
-	(void)tc_handler(TC_END, "Eventloop UTC");
+	(void)testcase_state_handler(TC_END, "Eventloop UTC");
 
 	return 0;
 }

--- a/apps/examples/testcase/ta_tc/media/itc/itc_media_main.cpp
+++ b/apps/examples/testcase/ta_tc/media/itc/itc_media_main.cpp
@@ -46,7 +46,7 @@ int main(int argc, FAR char *argv[])
 int itc_media_main(int argc, char *argv[])
 #endif
 {
-	if (tc_handler(TC_START, "Media ITC") == -1) {
+	if (testcase_state_handler(TC_START, "Media ITC") == -1) {
 		return -1;
 	}
 
@@ -62,7 +62,7 @@ int itc_media_main(int argc, char *argv[])
 	itc_media_bufferoutputdatasource_main();
 #endif
 
-	(void)tc_handler(TC_END, "Media ITC");
+	(void)testcase_state_handler(TC_END, "Media ITC");
 	return 0;
 }
 }

--- a/apps/examples/testcase/ta_tc/media/utc/utc_media_main.cpp
+++ b/apps/examples/testcase/ta_tc/media/utc/utc_media_main.cpp
@@ -65,7 +65,7 @@ int main(int argc, FAR char *argv[])
 int utc_media_main(int argc, char *argv[])
 #endif
 {
-	if (tc_handler(TC_START, "Media UTC") == -1) {
+	if (testcase_state_handler(TC_START, "Media UTC") == -1) {
 		return -1;
 	}
 
@@ -89,7 +89,7 @@ int utc_media_main(int argc, char *argv[])
 #endif
 #endif
 
-	(void)tc_handler(TC_END, "Media UTC");
+	(void)testcase_state_handler(TC_END, "Media UTC");
 	return 0;
 }
 }

--- a/apps/examples/testcase/ta_tc/messaging/utc/utc_messaging_main.c
+++ b/apps/examples/testcase/ta_tc/messaging/utc/utc_messaging_main.c
@@ -32,7 +32,7 @@ int main(int argc, FAR char *argv[])
 int utc_messaging_main(int argc, char *argv[])
 #endif
 {
-	if (tc_handler(TC_START, "Messaging UTC") == ERROR) {
+	if (testcase_state_handler(TC_START, "Messaging UTC") == ERROR) {
 		return ERROR;
 	}
 
@@ -42,7 +42,7 @@ int utc_messaging_main(int argc, char *argv[])
 
 	utc_messaging_multicast_main();
 
-	(void)tc_handler(TC_END, "Messaging UTC");
+	(void)testcase_state_handler(TC_END, "Messaging UTC");
 
 	return 0;
 }

--- a/apps/examples/testcase/ta_tc/mqtt/itc/itc_mqtt_main.c
+++ b/apps/examples/testcase/ta_tc/mqtt/itc/itc_mqtt_main.c
@@ -822,7 +822,7 @@ int main(int argc, FAR char *argv[])
 int itc_mqtt_main(int argc, char *argv[])
 #endif
 {
-	if (tc_handler(TC_START, "MQTT ITC") == ERROR) {
+	if (testcase_state_handler(TC_START, "MQTT ITC") == ERROR) {
 		return ERROR;
 	}
 
@@ -850,7 +850,7 @@ int itc_mqtt_main(int argc, char *argv[])
 		_itc_mqtt_deinit();
 	}
 
-	(void)tc_handler(TC_END, "MQTT ITC");
+	(void)testcase_state_handler(TC_END, "MQTT ITC");
 
 	return 0;
 }

--- a/apps/examples/testcase/ta_tc/mqtt/utc/utc_mqtt_main.c
+++ b/apps/examples/testcase/ta_tc/mqtt/utc/utc_mqtt_main.c
@@ -418,7 +418,7 @@ int main(int argc, FAR char *argv[])
 int utc_mqtt_main(int argc, char *argv[])
 #endif
 {
-	if (tc_handler(TC_START, "MQTT UTC") == ERROR) {
+	if (testcase_state_handler(TC_START, "MQTT UTC") == ERROR) {
 		return ERROR;
 	}
 
@@ -444,7 +444,7 @@ int utc_mqtt_main(int argc, char *argv[])
 
 	_utc_mqtt_deinit();
 exit:
-	(void)tc_handler(TC_END, "MQTT UTC");
+	(void)testcase_state_handler(TC_END, "MQTT UTC");
 
 	return 0;
 }

--- a/apps/examples/testcase/ta_tc/security/utc/utc_security_main.c
+++ b/apps/examples/testcase/ta_tc/security/utc/utc_security_main.c
@@ -50,7 +50,7 @@ int main(int argc, FAR char *argv[])
 int utc_security_main(int argc, char *argv[])
 #endif
 {
-	if (tc_handler(TC_START, "Security UTC") == ERROR) {
+	if (testcase_state_handler(TC_START, "Security UTC") == ERROR) {
 		return ERROR;
 	}
 	
@@ -71,7 +71,7 @@ int utc_security_main(int argc, char *argv[])
 	utc_ss_main();
 #endif
 
-	(void)tc_handler(TC_END, "Security UTC");
+	(void)testcase_state_handler(TC_END, "Security UTC");
 
 	return 0;
 }

--- a/apps/examples/testcase/ta_tc/systemio/itc/itc_sysio_main.c
+++ b/apps/examples/testcase/ta_tc/systemio/itc/itc_sysio_main.c
@@ -48,7 +48,7 @@ int main(int argc, FAR char *argv[])
 int itc_sysio_main(int argc, char *argv[])
 #endif
 {
-	if (tc_handler(TC_START, "SystemIO ITC") == ERROR) {
+	if (testcase_state_handler(TC_START, "SystemIO ITC") == ERROR) {
 		return ERROR;
 	}
 
@@ -72,7 +72,7 @@ int itc_sysio_main(int argc, char *argv[])
 	itc_gpio_main();
 #endif
 
-	(void)tc_handler(TC_END, "SystemIO ITC");
+	(void)testcase_state_handler(TC_END, "SystemIO ITC");
 
 	return 0;
 }

--- a/apps/examples/testcase/ta_tc/systemio/utc/utc_sysio_main.c
+++ b/apps/examples/testcase/ta_tc/systemio/utc/utc_sysio_main.c
@@ -50,7 +50,7 @@ int main(int argc, FAR char *argv[])
 int utc_sysio_main(int argc, char *argv[])
 #endif
 {
-	if (tc_handler(TC_START, "SystemIO UTC") == ERROR) {
+	if (testcase_state_handler(TC_START, "SystemIO UTC") == ERROR) {
 		return ERROR;
 	}
 
@@ -74,7 +74,7 @@ int utc_sysio_main(int argc, char *argv[])
 	utc_uart_main();
 #endif
 
-	(void)tc_handler(TC_END, "SystemIO UTC");
+	(void)testcase_state_handler(TC_END, "SystemIO UTC");
 
 	return 0;
 }

--- a/apps/examples/testcase/ta_tc/task_manager/itc/itc_taskmanager_main.c
+++ b/apps/examples/testcase/ta_tc/task_manager/itc/itc_taskmanager_main.c
@@ -986,7 +986,7 @@ int itc_taskmanager_main(int argc, char *argv[])
 {
 	int status;
 
-	if (tc_handler(TC_START, "TaskManager ITC") == ERROR) {
+	if (testcase_state_handler(TC_START, "TaskManager ITC") == ERROR) {
 		return ERROR;
 	}
 
@@ -998,7 +998,7 @@ int itc_taskmanager_main(int argc, char *argv[])
 
 	(void)task_manager_unregister(handle_tm_itc, TM_NO_RESPONSE);
 
-	(void)tc_handler(TC_END, "TaskManager itc");
+	(void)testcase_state_handler(TC_END, "TaskManager itc");
 
 	return 0;
 }

--- a/apps/examples/testcase/ta_tc/task_manager/utc/utc_taskmanager_main.c
+++ b/apps/examples/testcase/ta_tc/task_manager/utc/utc_taskmanager_main.c
@@ -1080,7 +1080,7 @@ int utc_taskmanager_main(int argc, char *argv[])
 {
 	int status;
 
-	if (tc_handler(TC_START, "TaskManager UTC") == ERROR) {
+	if (testcase_state_handler(TC_START, "TaskManager UTC") == ERROR) {
 		return ERROR;
 	}
 
@@ -1093,7 +1093,7 @@ int utc_taskmanager_main(int argc, char *argv[])
 	(void)task_manager_unregister(handle_tm_utc, TM_NO_RESPONSE);
 
 	sleep(1);
-	(void)tc_handler(TC_END, "TaskManager UTC");
+	(void)testcase_state_handler(TC_END, "TaskManager UTC");
 
 	return 0;
 }

--- a/apps/examples/testcase/ta_tc/wifi_manager/itc/itc_wifimanager_main.c
+++ b/apps/examples/testcase/ta_tc/wifi_manager/itc/itc_wifimanager_main.c
@@ -1140,7 +1140,7 @@ static void itc_wifimanager_get_connected_config_n(void)
 
 int wifi_manager_itc(int argc, FAR char *argv[])
 {
-	if (tc_handler(TC_START, "WiFiManager ITC") == ERROR) {
+	if (testcase_state_handler(TC_START, "WiFiManager ITC") == ERROR) {
 		return ERROR;
 	}
 
@@ -1196,7 +1196,7 @@ int wifi_manager_itc(int argc, FAR char *argv[])
 
 	itc_wifimanager_reconnect_p(); // System is crashing tested manually
 
-	(void)tc_handler(TC_END, "WiFiManager ITC");
+	(void)testcase_state_handler(TC_END, "WiFiManager ITC");
 
 	return 0;
 }

--- a/apps/examples/testcase/ta_tc/wifi_manager/utc/utc_wifimanager_main.c
+++ b/apps/examples/testcase/ta_tc/wifi_manager/utc/utc_wifimanager_main.c
@@ -561,7 +561,7 @@ static void utc_wifimanager_unregister_cb_p(void)
 
 int wifi_manager_utc(int argc, FAR char *argv[])
 {
-	if (tc_handler(TC_START, "WiFiManager UTC") == ERROR) {
+	if (testcase_state_handler(TC_START, "WiFiManager UTC") == ERROR) {
 		return ERROR;
 	}
 
@@ -619,7 +619,7 @@ int wifi_manager_utc(int argc, FAR char *argv[])
 
 	utc_wifimanager_deinit_p(); // End of UTC
 
-	(void)tc_handler(TC_END, "WiFiManager UTC");
+	(void)testcase_state_handler(TC_END, "WiFiManager UTC");
 
 	return 0;
 }

--- a/apps/examples/testcase/tc_common.h
+++ b/apps/examples/testcase/tc_common.h
@@ -153,7 +153,7 @@ extern int total_fail;
 extern "C" {
 #endif
 
-int tc_handler(tc_op_type_t type, const char *tc_name);
+int testcase_state_handler(tc_op_type_t type, const char *tc_name);
 
 #ifdef __cplusplus
 }

--- a/apps/examples/testcase/tc_main.c
+++ b/apps/examples/testcase/tc_main.c
@@ -207,7 +207,7 @@ static const tash_cmdlist_t tc_cmds[] = {
 #ifdef __cplusplus
 extern "C" {
 #endif
-int tc_handler(tc_op_type_t type, const char *tc_name)
+int testcase_state_handler(tc_op_type_t type, const char *tc_name)
 {
 	switch (type) {
 	case TC_START:

--- a/external/libcxx-test/utc_libcxx.c
+++ b/external/libcxx-test/utc_libcxx.c
@@ -20,7 +20,7 @@
 
 int utc_libcxx_main(int argc, char *argv[])
 {
-	if (tc_handler(TC_START, "Libc++ TC") == ERROR) {
+	if (testcase_state_handler(TC_START, "Libc++ TC") == ERROR) {
 		return ERROR;
 	}
 
@@ -62,7 +62,7 @@ int utc_libcxx_main(int argc, char *argv[])
 #endif
 
 
-	tc_handler(TC_END, "Libc++ TC");
+	testcase_state_handler(TC_END, "Libc++ TC");
 
 	return OK;
 }


### PR DESCRIPTION
It is difficult to know what it is from the function name and
is not a testcase function to test something.
So, this commit renames it as testcase_state_handler.

Signed-off-by: sunghan-chang <sh924.chang@samsung.com>