### PR TITLE
board/imxrt1050-evk: block peripheral initialization to support serial

### DIFF
--- a/os/board/imxrt1050-evk/src/imxrt_boot.c
+++ b/os/board/imxrt1050-evk/src/imxrt_boot.c
@@ -258,13 +258,13 @@ void board_initialize(void)
 	/* Perform board initialization */
 
 	(void)imxrt_bringup();
-
+#if 0	// FIXME block belows temporarily to see serial logs
 	imxrt_iotbus_initialize();
 
 	imxrt_pwm_initialize();
 
 	imxrt_spi_initialize();
-
+#endif
 #ifdef CONFIG_WATCHDOG
 	imxrt_wdog_initialize(CONFIG_WATCHDOG_DEVPATH, IMXRT_WDOG1);
 #endif


### PR DESCRIPTION
Current peripheral initialization is not working well. It blocks
seeing serial logs. Let's block them temporarily.

Signed-off-by: sunghan-chang <sh924.chang@samsung.com>