### PR TITLE
framework/task_manager : coverage enhancement

### DIFF
--- a/apps/examples/testcase/ta_tc/task_manager/utc/utc_taskmanager_main.c
+++ b/apps/examples/testcase/ta_tc/task_manager/utc/utc_taskmanager_main.c
@@ -107,6 +107,9 @@ static int not_builtin_task(int argc, char *argv[])
 
 static void *tm_pthread(void *param)
 {
+	while (1) {
+		usleep(1);
+	}	// This will be dead at utc_taskmanager_stop_p
 	return NULL;
 }
 
@@ -309,6 +312,9 @@ static void utc_taskmanager_start_n(void)
 static void utc_taskmanager_start_p(void)
 {
 	int ret;
+
+	ret = task_manager_start(tm_pthread_handle, TM_RESPONSE_WAIT_INF);
+	TC_ASSERT_EQ("task_manager_start", ret, OK);	
 
 	ret = task_manager_start(tm_sample_handle, TM_RESPONSE_WAIT_INF);
 	TC_ASSERT_EQ("task_manager_start", ret, OK);
@@ -768,6 +774,10 @@ static void utc_taskmanager_stop_p(void)
 
 	sleep(1);
 	cb_flag = false;
+
+	ret = task_manager_stop(tm_pthread_handle, TM_RESPONSE_WAIT_INF);
+	TC_ASSERT_EQ("task_manager_stop", ret, OK);
+
 	ret = task_manager_stop(tm_sample_handle, TM_RESPONSE_WAIT_INF);
 	TC_ASSERT_EQ("task_manager_stop", ret, OK);
 
@@ -906,7 +916,7 @@ static void utc_taskmanager_register_pthread_p(void)
 	pthread_attr_t attr;
 
 	pthread_attr_init(&attr);
-	tm_pthread_handle = task_manager_register_pthread("tm_pthread", &attr, tm_pthread, NULL, TM_APP_PERMISSION_DEDICATE, TM_RESPONSE_WAIT_INF);
+	tm_pthread_handle = task_manager_register_pthread("tm_pthread", &attr, tm_pthread, NULL, TM_APP_PERMISSION_GROUP, TM_RESPONSE_WAIT_INF);
 	TC_ASSERT_GEQ("task_manager_register_pthread", tm_pthread_handle, 0);
 
 	TC_SUCCESS_RESULT();

--- a/framework/src/task_manager/task_manager_broadcast.c
+++ b/framework/src/task_manager/task_manager_broadcast.c
@@ -29,7 +29,7 @@
  ****************************************************************************/
 int task_manager_broadcast(int msg, tm_msg_t *broadcast_data, int timeout)
 {
-	int status;
+	int status = TM_OUT_OF_MEMORY;
 	tm_request_t request_msg;
 	tm_response_t response_msg;
 
@@ -49,8 +49,7 @@ int task_manager_broadcast(int msg, tm_msg_t *broadcast_data, int timeout)
 	if (broadcast_data != NULL && broadcast_data->msg_size != 0) {
 		((tm_internal_msg_t *)request_msg.data)->msg = (void *)TM_ALLOC(broadcast_data->msg_size);
 		if (((tm_internal_msg_t *)request_msg.data)->msg == NULL) {
-			TM_FREE(request_msg.data);
-			return TM_OUT_OF_MEMORY;
+			goto errout_with_free_data;
 		}
 		memcpy(((tm_internal_msg_t *)request_msg.data)->msg, broadcast_data->msg, broadcast_data->msg_size);
 		((tm_internal_msg_t *)request_msg.data)->msg_size = broadcast_data->msg_size;
@@ -66,20 +65,16 @@ int task_manager_broadcast(int msg, tm_msg_t *broadcast_data, int timeout)
 	if (timeout != TM_NO_RESPONSE) {
 		TM_ASPRINTF(&request_msg.q_name, "%s%d", TM_PRIVATE_MQ, request_msg.caller_pid);
 		if (request_msg.q_name == NULL) {
-			TM_FREE(((tm_internal_msg_t *)request_msg.data)->msg);
-			TM_FREE(request_msg.data);
-			return TM_OUT_OF_MEMORY;
+			goto errout_with_free_msg;
 		}
 	}
 
 	status = taskmgr_send_request(&request_msg);
 	if (status < 0) {
-		TM_FREE(((tm_internal_msg_t *)request_msg.data)->msg);
-		TM_FREE(request_msg.data);
 		if (request_msg.q_name != NULL) {
 			TM_FREE(request_msg.q_name);
 		}
-		return status;
+		goto errout_with_free_msg;
 	}
 
 	if (timeout != TM_NO_RESPONSE) {
@@ -87,5 +82,11 @@ int task_manager_broadcast(int msg, tm_msg_t *broadcast_data, int timeout)
 		TM_FREE(request_msg.q_name);
 	}
 
+	return status;
+
+errout_with_free_msg:
+	TM_FREE(((tm_internal_msg_t *)request_msg.data)->msg);	
+errout_with_free_data:
+	TM_FREE(request_msg.data);
 	return status;
 }

--- a/framework/src/task_manager/task_manager_register.c
+++ b/framework/src/task_manager/task_manager_register.c
@@ -77,7 +77,7 @@ int task_manager_register_builtin(char *name, int permission, int timeout)
 
 int task_manager_register_task(char *name, int priority, int stack_size, main_t entry, char * argv[], int permission, int timeout)
 {
-	int status;
+	int status = TM_OUT_OF_MEMORY;
 	tm_request_t request_msg;
 	tm_response_t response_msg;
 
@@ -95,8 +95,7 @@ int task_manager_register_task(char *name, int priority, int stack_size, main_t 
 	}
 	((tm_task_info_t *)request_msg.data)->name = (char *)TM_ALLOC(strlen(name) + 1);
 	if (((tm_task_info_t *)request_msg.data)->name == NULL) {
-		TM_FREE(request_msg.data);
-		return TM_OUT_OF_MEMORY;
+		goto errout_with_free2;
 	}
 	strncpy(((tm_task_info_t *)request_msg.data)->name, name, strlen(name) + 1);
 	((tm_task_info_t *)request_msg.data)->priority = priority;
@@ -108,20 +107,16 @@ int task_manager_register_task(char *name, int priority, int stack_size, main_t 
 	if (timeout != TM_NO_RESPONSE) {
 		TM_ASPRINTF(&request_msg.q_name, "%s%d", TM_PRIVATE_MQ, request_msg.caller_pid);
 		if (request_msg.q_name == NULL) {
-			TM_FREE(((tm_task_info_t *)request_msg.data)->name);
-			TM_FREE(request_msg.data);
-			return TM_OUT_OF_MEMORY;
+			goto errout_with_free1;
 		}
 	}
 
 	status = taskmgr_send_request(&request_msg);
 	if (status < 0) {
 		TM_FREE(((tm_task_info_t *)request_msg.data)->name);
-		TM_FREE(request_msg.data);
 		if (request_msg.q_name != NULL) {
-			TM_FREE(request_msg.q_name);
+			goto errout_with_free1;
 		}
-		return status;
 	}
 
 	if (timeout != TM_NO_RESPONSE) {
@@ -130,12 +125,18 @@ int task_manager_register_task(char *name, int priority, int stack_size, main_t 
 	}
 
 	return status;
+
+errout_with_free1:
+	TM_FREE(request_msg.q_name);
+errout_with_free2:
+	TM_FREE(request_msg.data);
+	return status;
 }
 
 #ifndef CONFIG_DISABLE_PTHREAD
 int task_manager_register_pthread(char *name, pthread_attr_t *attr, pthread_startroutine_t start_routine, pthread_addr_t arg, int permission, int timeout)
 {
-	int status;
+	int status = TM_OUT_OF_MEMORY;
 	tm_request_t request_msg;
 	tm_response_t response_msg;
 
@@ -153,15 +154,12 @@ int task_manager_register_pthread(char *name, pthread_attr_t *attr, pthread_star
 	}
 	((tm_pthread_info_t *)request_msg.data)->name = (char *)TM_ALLOC(strlen(name) + 1);
 	if (((tm_pthread_info_t *)request_msg.data)->name == NULL) {
-		TM_FREE(request_msg.data);
-		return TM_OUT_OF_MEMORY;
+		goto errout_with_free3;
 	}
 	strncpy(((tm_pthread_info_t *)request_msg.data)->name, name, strlen(name) + 1);
 	((tm_pthread_info_t *)request_msg.data)->attr = (pthread_attr_t *)TM_ALLOC(sizeof(pthread_attr_t));
 	if (((tm_pthread_info_t *)request_msg.data)->attr == NULL) {
-		TM_FREE(((tm_pthread_info_t *)request_msg.data)->name);
-		TM_FREE(request_msg.data);
-		return TM_OUT_OF_MEMORY;
+		goto errout_with_free2;
 	}
 	memcpy(((tm_pthread_info_t *)request_msg.data)->attr, attr, sizeof(pthread_attr_t));
 	((tm_pthread_info_t *)request_msg.data)->entry = start_routine;
@@ -171,22 +169,16 @@ int task_manager_register_pthread(char *name, pthread_attr_t *attr, pthread_star
 	if (timeout != TM_NO_RESPONSE) {
 		TM_ASPRINTF(&request_msg.q_name, "%s%d", TM_PRIVATE_MQ, request_msg.caller_pid);
 		if (request_msg.q_name == NULL) {
-			TM_FREE(((tm_pthread_info_t *)request_msg.data)->attr);
-			TM_FREE(((tm_pthread_info_t *)request_msg.data)->name);
-			TM_FREE(request_msg.data);
-			return TM_OUT_OF_MEMORY;
+			goto errout_with_free1;
 		}
 	}
 
 	status = taskmgr_send_request(&request_msg);
 	if (status < 0) {
-		TM_FREE(((tm_pthread_info_t *)request_msg.data)->attr);
-		TM_FREE(((tm_pthread_info_t *)request_msg.data)->name);
-		TM_FREE(request_msg.data);
 		if (request_msg.q_name != NULL) {
 			TM_FREE(request_msg.q_name);
 		}
-		return status;
+		goto errout_with_free1;
 	}
 
 	if (timeout != TM_NO_RESPONSE) {
@@ -194,6 +186,14 @@ int task_manager_register_pthread(char *name, pthread_attr_t *attr, pthread_star
 		TM_FREE(request_msg.q_name);
 	}
 
+	return status;
+
+errout_with_free1:
+	TM_FREE(((tm_pthread_info_t *)request_msg.data)->attr);
+errout_with_free2:
+	TM_FREE(((tm_pthread_info_t *)request_msg.data)->name);
+errout_with_free3:
+	TM_FREE(request_msg.data);
 	return status;
 }
 #endif

--- a/framework/src/task_manager/task_manager_unicast.c
+++ b/framework/src/task_manager/task_manager_unicast.c
@@ -33,7 +33,7 @@
  ****************************************************************************/
 int task_manager_unicast(int handle, tm_msg_t *send_msg, tm_msg_t *reply_msg, int timeout)
 {
-	int status;
+	int status = TM_OUT_OF_MEMORY;
 	tm_request_t request_msg;
 	tm_response_t response_msg;
 
@@ -52,8 +52,7 @@ int task_manager_unicast(int handle, tm_msg_t *send_msg, tm_msg_t *reply_msg, in
 		}
 		((tm_internal_msg_t *)request_msg.data)->msg = (void *)TM_ALLOC(send_msg->msg_size);
 		if (((tm_internal_msg_t *)request_msg.data)->msg == NULL) {
-			TM_FREE(request_msg.data);
-			return TM_OUT_OF_MEMORY;
+			goto errout_with_free2;
 		}
 		memcpy(((tm_internal_msg_t *)request_msg.data)->msg, send_msg->msg, send_msg->msg_size);
 		((tm_internal_msg_t *)request_msg.data)->msg_size = send_msg->msg_size;
@@ -72,20 +71,16 @@ int task_manager_unicast(int handle, tm_msg_t *send_msg, tm_msg_t *reply_msg, in
 	if (timeout != TM_NO_RESPONSE) {
 		TM_ASPRINTF(&request_msg.q_name, "%s%d", TM_PRIVATE_MQ, request_msg.caller_pid);
 		if (request_msg.q_name == NULL) {
-			TM_FREE(((tm_internal_msg_t *)request_msg.data)->msg);
-			TM_FREE(request_msg.data);
-			return TM_OUT_OF_MEMORY;
+			goto errout_with_free1;
 		}
 	}
 
 	status = taskmgr_send_request(&request_msg);
 	if (status < 0) {
-		TM_FREE(((tm_internal_msg_t *)request_msg.data)->msg);
-		TM_FREE(request_msg.data);
 		if (request_msg.q_name != NULL) {
 			TM_FREE(request_msg.q_name);
 		}
-		return status;
+		goto errout_with_free1;
 	}
 
 	if (timeout != TM_NO_RESPONSE) {
@@ -95,16 +90,20 @@ int task_manager_unicast(int handle, tm_msg_t *send_msg, tm_msg_t *reply_msg, in
 			reply_msg->msg_size = ((tm_msg_t *)response_msg.data)->msg_size;
 			reply_msg->msg = TM_ALLOC(reply_msg->msg_size);
 			if (reply_msg->msg == NULL) {
-				TM_FREE(((tm_internal_msg_t *)request_msg.data)->msg);
-				TM_FREE(request_msg.data);
-				return TM_OUT_OF_MEMORY;
+				status = TM_OUT_OF_MEMORY;
+				goto errout_with_free1;
 			}
 			memcpy(reply_msg->msg, ((tm_msg_t *)response_msg.data)->msg, reply_msg->msg_size);
 			TM_FREE(((tm_msg_t *)response_msg.data)->msg);
 			TM_FREE(response_msg.data);
 		}
 	}
+	return status;
 
+errout_with_free1:
+	TM_FREE(((tm_internal_msg_t *)request_msg.data)->msg);
+errout_with_free2:
+	TM_FREE(request_msg.data);
 	return status;
 }
 


### PR DESCRIPTION
1.     framework/task_manager : Modify wrong cmd in set callback and Merge duplicated errout case
    
    . taskmgr_set_cb_common should set the cmd based on passed param
    . Freeing some data is duplicated for error case. Merged them.

2.     apps/testcase/task_manager : Expand utc for pthread to start and stop with group permission
    
    There was a utc for pthread, but only testing register and unregister.
    Expand to test task_manager_start and task_manager_stop with group permission.
