### PR TITLE
board : Move crashdump build condition and build path of board/common

### DIFF
--- a/os/board/artik05x/src/Makefile
+++ b/os/board/artik05x/src/Makefile
@@ -80,13 +80,15 @@ ifeq ($(CONFIG_SCSC_WLAN),y)
 CSRCS += artik05x_wlan.c
 endif
 
-ifeq ($(CONFIG_FLASH_PARTITION),y)
+
 DEPPATH += --dep-path $(TOPDIR)/board/common
 VPATH += :$(TOPDIR)/board/common
+ifeq ($(CONFIG_FLASH_PARTITION),y)
 CSRCS += partitions.c
+endif
+
 ifeq ($(CONFIG_BOARD_CRASHDUMP),y)
 CSRCS += crashdump.c
-endif
 endif
 
 # boardctl support

--- a/os/board/imxrt1020-evk/src/Makefile
+++ b/os/board/imxrt1020-evk/src/Makefile
@@ -80,13 +80,15 @@ ifeq ($(CONFIG_IMXRT_ENET),y)
 CSRCS += imxrt_ethernet.c
 endif
 
-ifeq ($(CONFIG_FLASH_PARTITION),y)
 DEPPATH += --dep-path $(TOPDIR)/board/common
 VPATH += :$(TOPDIR)/board/common
+
+ifeq ($(CONFIG_FLASH_PARTITION),y)
 CSRCS += partitions.c
+endif
+
 ifeq ($(CONFIG_BOARD_CRASHDUMP),y)
 CSRCS += crashdump.c
-endif
 endif
 
 # boardctl support

--- a/os/board/imxrt1050-evk/src/Makefile
+++ b/os/board/imxrt1050-evk/src/Makefile
@@ -80,13 +80,15 @@ ifeq ($(CONFIG_IMXRT_ENET),y)
 CSRCS += imxrt_ethernet.c
 endif
 
-ifeq ($(CONFIG_FLASH_PARTITION),y)
 DEPPATH += --dep-path $(TOPDIR)/board/common
 VPATH += :$(TOPDIR)/board/common
+
+ifeq ($(CONFIG_FLASH_PARTITION),y)
 CSRCS += partitions.c
+endif
+
 ifeq ($(CONFIG_BOARD_CRASHDUMP),y)
 CSRCS += crashdump.c
-endif
 endif
 
 # boardctl support


### PR DESCRIPTION
crashdump.c and DEPPATH,VPATH for board/common do not need to bounded to CONFIG_FLASH_PARTITON config.