### PR TITLE
fixup! framework/messaging : Unify the error return case as goto

### DIFF
--- a/framework/src/messaging/messaging_common.c
+++ b/framework/src/messaging/messaging_common.c
@@ -256,6 +256,7 @@ void messaging_run_callback(int signo, siginfo_t *data)
 			break;
 		}
 	}
+	return;
 
 errout_with_recv_packet:
 	MSG_FREE(recv_packet);
@@ -263,5 +264,4 @@ errout_with_mq_close:
 	mq_close(recv_info->mqdes);
 errout_with_recv_info:
 	MSG_FREE(recv_info);
-	return;
 }


### PR DESCRIPTION
Commit e7f8067 unified the error return case using goto.
If there is no error, it has to finish without freeing memory allocated.
So, return should be located before goto.
This commit fixes the wrong location of return.

Signed-off-by: sunghan-chang <sh924.chang@samsung.com>