### PR TITLE
binfmt: fix missing of freeing stack allocated and tidyup

### DIFF
--- a/os/binfmt/binfmt_execmodule.c
+++ b/os/binfmt/binfmt_execmodule.c
@@ -202,7 +202,7 @@ int exec_module(FAR const struct binary_s *binp)
 	if (ret < 0) {
 		ret = -get_errno();
 		berr("task_init() failed: %d\n", ret);
-		goto errout_with_addrenv;
+		goto errout_with_stack;
 	}
 
 #if defined(CONFIG_DEBUG_MM_HEAPINFO) && defined(CONFIG_APP_BINARY_SEPARATION)
@@ -324,14 +324,11 @@ int exec_module(FAR const struct binary_s *binp)
 	return (int)pid;
 
 errout_with_tcbinit:
-	tcb->cmn.stack_alloc_ptr = NULL;
 	sched_releasetcb(&tcb->cmn, TCB_FLAG_TTYPE_TASK);
-#ifdef CONFIG_APP_BINARY_SEPARATION
-	mm_free(binp->uheap, stack);
-#else
-	kumm_free(stack);
-#endif
 	return ret;
+
+errout_with_stack:
+	kumm_free(stack);
 
 errout_with_addrenv:
 #if defined(CONFIG_ARCH_ADDRENV) && defined(CONFIG_BUILD_KERNEL)

--- a/os/kernel/task/task_init.c
+++ b/os/kernel/task/task_init.c
@@ -181,10 +181,15 @@ int task_init(FAR struct tcb_s *tcb, const char *name, int priority, FAR uint32_
 	ret = group_initialize(ttcb);
 	if (ret < 0) {
 		errcode = -ret;
-		goto errout_with_group;
+		goto errout_with_setup;
 	}
 #endif
 	return OK;
+
+#ifdef HAVE_TASK_GROUP
+errout_with_setup:
+	sched_removeblocked((struct tcb_s *)ttcb);
+#endif
 
 errout_with_group:
 #ifdef HAVE_TASK_GROUP


### PR DESCRIPTION
1. When execution of task_init() is failed, it should free
   the stack allocated before. But it doesn't.
   This commit adds the "errout_with_stack" tab to do it.
2. kumm_free(stack) and mm_free(binp->uheap, stack) are the same.
   Let's remove duplicated code with CONFIG_APP_BINARY_SEPARATION.
3. Making "tcb->cmn.stack_alloc_ptr" null is done by sched_realeasetcb().
   Let's remove duplication.

Signed-off-by: sunghan-chang <sh924.chang@samsung.com>