### PR TITLE
framework/media: fix invalid function call

### DIFF
--- a/framework/src/media/audio/audio_manager.c
+++ b/framework/src/media/audio/audio_manager.c
@@ -700,7 +700,7 @@ audio_manager_result_t set_audio_stream_in(unsigned int channels, unsigned int s
 
 	if (card_config->status == AUDIO_CARD_PAUSE) {
 		medvdbg("reset previous preparing\n");
-		reset_audio_stream_out();
+		reset_audio_stream_in();
 	}
 
 	pthread_mutex_lock(&(card->card_mutex));


### PR DESCRIPTION
The reset_audio_stream_in function should be called
but the reset_audio_stream_out function is called.

Signed-off-by: jsdosa <jsdosa@gmail.com>