### PR TITLE
net/bluetooth: Fix error handling in Bluetooth subsystem

### DIFF
--- a/os/net/bluetooth/bt_conn.c
+++ b/os/net/bluetooth/bt_conn.c
@@ -148,7 +148,7 @@ static int conn_tx_kthread(int argc, FAR char *argv[])
 
 		do {
 			ret = sem_wait(&g_btdev.le_pkts_sem);
-		} while (ret == -EINTR);
+		} while (errno == EINTR);
 
 		DEBUGASSERT(ret == OK);
 
@@ -560,7 +560,7 @@ void bt_conn_set_state(FAR struct bt_conn_s *conn, enum bt_conn_state_e state)
 
 		do {
 			ret = sem_wait(&g_conn_handoff.sync_sem);
-		} while (ret == -EINTR);
+		} while (errno == EINTR);
 
 		DEBUGASSERT(ret == OK);
 
@@ -577,7 +577,7 @@ void bt_conn_set_state(FAR struct bt_conn_s *conn, enum bt_conn_state_e state)
 
 		do {
 			ret = sem_wait(&g_conn_handoff.sync_sem);
-		} while (ret == -EINTR);
+		} while (errno == EINTR);
 
 		DEBUGASSERT(ret == OK);
 		sem_post(&g_conn_handoff.sync_sem);

--- a/os/net/bluetooth/bt_hcicore.c
+++ b/os/net/bluetooth/bt_hcicore.c
@@ -955,7 +955,7 @@ static int hci_tx_kthread(int argc, FAR char *argv[])
 
 		do {
 			ret = sem_wait(&g_btdev.ncmd_sem);
-		} while (ret == -EINTR);
+		} while (errno == EINTR);
 
 		DEBUGASSERT(ret >= 0);
 

--- a/os/net/bluetooth/bt_ioctl.c
+++ b/os/net/bluetooth/bt_ioctl.c
@@ -169,8 +169,8 @@ static void btnet_scan_callback(FAR const bt_addr_le_t *addr, int8_t rssi, uint8
 	/* Get exclusive access to the scan data */
 
 	while ((ret = sem_wait(&g_scanstate.bs_exclsem)) < 0) {
-		DEBUGASSERT(ret == -EINTR || ret == -ECANCELED);
-		if (ret != -EINTR) {
+		DEBUGASSERT(errno == EINTR || errno == ECANCELED);
+		if (errno != EINTR) {
 			return;
 		}
 	}
@@ -247,7 +247,7 @@ static int btnet_scan_result(FAR struct bt_scanresponse_s *result, uint8_t maxrs
 
 		ret = sem_wait(&g_scanstate.bs_exclsem);
 		if (ret < 0) {
-			DEBUGASSERT(ret == -EINTR || ret == -ECANCELED);
+			DEBUGASSERT(errno == EINTR || errno == ECANCELED);
 			return ret;
 		}
 	}
@@ -338,8 +338,8 @@ static uint8_t btnet_discover_func(FAR const struct bt_gatt_attr_s *attr, FAR vo
 	/* Get exclusive access to the discovered data */
 
 	while ((ret = sem_wait(&g_discoverstate.bd_exclsem)) < 0) {
-		DEBUGASSERT(ret == -EINTR || ret == -ECANCELED);
-		if (ret != -EINTR) {
+		DEBUGASSERT(errno == EINTR || errno == ECANCELED);
+		if (errno != EINTR) {
 			return BT_GATT_ITER_STOP;
 		}
 	}
@@ -443,7 +443,7 @@ static int btnet_discover_result(FAR struct bt_discresonse_s *result, uint8_t ma
 	if (discovering) {
 		ret = sem_wait(&g_discoverstate.bd_exclsem);
 		if (ret < 0) {
-			DEBUGASSERT(ret == -EINTR || ret == -ECANCELED);
+			DEBUGASSERT(errno == EINTR || errno == ECANCELED);
 			return ret;
 		}
 	}

--- a/os/net/bluetooth/iob/iob_alloc.c
+++ b/os/net/bluetooth/iob/iob_alloc.c
@@ -149,7 +149,7 @@ static FAR struct iob_s *iob_allocwait(bool throttled)
 			 * should be returned.
 			 */
 
-			if (ret == -EINTR) {
+			if (errno == EINTR) {
 				/* Force a success indication so that we will continue looping. */
 
 				ret = OK;

--- a/os/net/bluetooth/iob/iob_alloc_qentry.c
+++ b/os/net/bluetooth/iob/iob_alloc_qentry.c
@@ -139,7 +139,7 @@ static FAR struct iob_qentry_s *iob_allocwait_qentry(void)
 			 * the error should be returned.
 			 */
 
-			if (ret == -EINTR) {
+			if (errno == EINTR) {
 				/* Force a success indication so that we will continue looping. */
 
 				ret = OK;


### PR DESCRIPTION
sem_wait return values are not handled properly.
Fix the return value handling.

Signed-off-by: Sangamanatha <sangam.swami@samsung.com>