### PR TITLE
drivers/task_manager : Add NULL checking after sched_gettcb

### DIFF
--- a/os/drivers/task_manager/task_manager_drv.c
+++ b/os/drivers/task_manager/task_manager_drv.c
@@ -130,6 +130,10 @@ static int taskmgr_pthread_group_join(pid_t parent_pid, pid_t child_pid)
 
 	parent_group = taskmgr_get_group_struct(parent_pid);
 	child_tcb = (struct pthread_tcb_s *)sched_gettcb(child_pid);
+	if (child_tcb == NULL) {
+		tmdbg("[TM] Cannot find Child TCB.\n");
+		return ERROR;
+	}
 	ret = taskmgr_group_bind(parent_group, child_tcb);
 	if (ret != OK) {
 		tmdbg("[TM] Group bind is failed.\n");

--- a/os/include/tinyara/binary_manager.h
+++ b/os/include/tinyara/binary_manager.h
@@ -24,6 +24,7 @@
  ****************************************************************************/
 
 #include <tinyara/config.h>
+#include <stdint.h>
 
 #ifdef CONFIG_BINARY_MANAGER
 
@@ -137,7 +138,7 @@ typedef struct load_attr_s load_attr_t;
 
 /* The structure of binaries' information list */
 struct binary_update_info_list_s {
-	int bin_count;
+	uint32_t bin_count;
 	binary_update_info_t bin_info[BINARY_COUNT];
 };
 typedef struct binary_update_info_list_s binary_update_info_list_t;

--- a/os/kernel/binary_manager/binary_manager_getinfo.c
+++ b/os/kernel/binary_manager/binary_manager_getinfo.c
@@ -27,6 +27,7 @@
 #include <fcntl.h>
 #include <string.h>
 #include <stdlib.h>
+#include <stdint.h>
 
 #include <tinyara/binary_manager.h>
 
@@ -43,7 +44,7 @@
 int binary_manager_get_index_with_binid(int bin_id)
 {
 	int bin_idx;
-	int bin_count;
+	uint32_t bin_count;
 
 	if (bin_id <= 0) {
 		bmdbg("Invalid bin_id %d\n", bin_id);
@@ -66,7 +67,7 @@ int binary_manager_get_index_with_binid(int bin_id)
 int binary_manager_get_index_with_name(char *bin_name)
 {
 	int bin_idx;
-	int bin_count;
+	uint32_t bin_count;
 
 	if (bin_name == NULL) {
 		bmdbg("Invalid binary name, NULL\n");
@@ -89,7 +90,7 @@ int binary_manager_get_index_with_name(char *bin_name)
 void binary_manager_get_info_with_name(int requester_pid, char *bin_name)
 {
 	int bin_idx;
-	int bin_count;
+	uint32_t bin_count;
 	char q_name[BIN_PRIVMQ_LEN];
 	binmgr_getinfo_response_t response_msg;
 
@@ -124,7 +125,7 @@ void binary_manager_get_info_with_name(int requester_pid, char *bin_name)
 void binary_manager_get_info_all(int requester_pid)
 {
 	int bin_idx;
-	int bin_count;
+	uint32_t bin_count;
 	char q_name[BIN_PRIVMQ_LEN];
 	binmgr_getinfo_all_response_t response_msg;
 

--- a/os/kernel/binary_manager/binary_manager_load.c
+++ b/os/kernel/binary_manager/binary_manager_load.c
@@ -28,6 +28,7 @@
 #include <unistd.h>
 #include <fcntl.h>
 #include <sched.h>
+#include <stdint.h>
 #include <string.h>
 #include <sys/types.h>
 
@@ -145,7 +146,7 @@ int binary_manager_load_binary(int bin_idx)
 #if (defined(CONFIG_BUILD_PROTECTED) || defined(CONFIG_BUILD_KERNEL)) && defined(CONFIG_MM_KERNEL_HEAP)
 	int wait_count;
 #endif
-	int valid_bin_count;
+	uint32_t valid_bin_count;
 	bool loadable;
 	bool is_new_bin;
 	bool is_sched_locked;
@@ -281,7 +282,7 @@ static int binary_manager_load_all(void)
 	int ret;
 	int bin_idx;
 	int load_cnt;
-	int bin_count;
+	uint32_t bin_count;
 
 	load_cnt = 0;
 	bin_count = binary_manager_get_binary_count();


### PR DESCRIPTION
sched_gettcb can return NULL when cannot find the tcb.
In this case, we should not use the tcb in the below.