### PR TITLE
testcase/kernel: Remove dependency on DEBUG of kernel_tc

### DIFF
--- a/apps/examples/testcase/le_tc/kernel/Kconfig
+++ b/apps/examples/testcase/le_tc/kernel/Kconfig
@@ -95,9 +95,6 @@ config TC_KERNEL_LIBC_MATH
 config TC_KERNEL_LIBC_MISC
 	bool "Libc Misc"
 	default n
-	select DEBUG
-	select DEBUG_ERROR
-	select DEBUG_VERBOSE
 
 config TC_KERNEL_LIBC_PTHREAD
 	bool "Libc Pthread"
@@ -167,7 +164,6 @@ config TC_KERNEL_SCHED
 config TC_KERNEL_SEMAPHORE
 	bool "Semaphore"
 	default n
-	select DEBUG
 
 config TC_KERNEL_SIGNAL
 	bool "Signal"
@@ -233,7 +229,6 @@ config ITC_KERNEL_LIBC_SEMAPHORE
 config ITC_KERNEL_SEMAPHORE
 	bool "ITC Semaphore"
 	default n
-	select DEBUG
 if ITC_KERNEL_SEMAPHORE
 config ITC_KERN_SEM_LOOP_SIZE
 	int "Iterator Count"

--- a/apps/examples/testcase/le_tc/kernel/kernel_tc_main.c
+++ b/apps/examples/testcase/le_tc/kernel/kernel_tc_main.c
@@ -97,9 +97,6 @@ int tc_kernel_main(int argc, char *argv[])
 #endif
 
 #ifdef CONFIG_TC_KERNEL_LIBC_MISC
-#if !defined(CONFIG_DEBUG) || !defined(CONFIG_DEBUG_ERROR) || !defined(CONFIG_DEBUG_VERBOSE)
-#error CONFIG_DEBUG, CONFIG_DEBUG_ERROR and CONFIG_DEBUG_VERBOSE are needed for testing LIBC_MISC TC
-#endif
 	libc_misc_main();
 #endif
 

--- a/apps/examples/testcase/le_tc/kernel/tc_libc_misc.c
+++ b/apps/examples/testcase/le_tc/kernel/tc_libc_misc.c
@@ -227,6 +227,8 @@ static void tc_libc_misc_crc32part(void)
 	TC_SUCCESS_RESULT();
 }
 
+#ifdef CONFIG_DEBUG
+#ifdef CONFIG_DEBUG_ERROR
 /**
  * @fn                  :tc_libc_misc_dbg
  * @brief               :Outputs messages to the console similar to printf() except that the output is not buffered.
@@ -257,7 +259,52 @@ static void tc_libc_misc_dbg(void)
 	TC_SUCCESS_RESULT();
 }
 
+/**
+ * @fn                  :tc_libc_misc_lib_dumpbuffer
+ * @brief               :Do a pretty buffer dump
+ * @scenario            :Do a pretty buffer dump
+ * @API's covered       :lib_dumpbuffer
+ * @Preconditions       :None
+ * @Postconditions      :None
+ * @Return              :void
+ */
+static void tc_libc_misc_lib_dumpbuffer(void)
+{
+	const char *msg = "tc_libc_misc_lib_dumpbuffer";
+	unsigned char buffer[] = {'S', 'A', 'M', 'S', 'U', 'N', 'G', '-', 'T', 'i', 'z', 'e', 'n', 'R', 'T'};
+	unsigned char *buf = NULL;
+	int idx;
+
+	/* To guarantee flushing other printf messages before using lowsyslog */
+	usleep(10);
+
+	/**
+	 * As lib_dumpbuffer returns void, there in no way to check the success or failure case
+	 * we need to manually check the dump output
+	 * Case-1: output: 53414d53554e472d54697a656e5254 SAMSUNG-TizenRT
+	 * Case-2: output: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a ...............	(i.e, 256 "0a")
+	 */
+
+	/* Case-1 */
+	lib_dumpbuffer(msg, buffer, sizeof(buffer));
+
+	/* Case-2 */
+	buf = (unsigned char *)malloc(BUFF_SIZE);
+	TC_ASSERT_NEQ("malloc", buf, NULL);
+
+	for (idx = 0; idx < BUFF_SIZE; idx++) {
+		buf[idx] = 0xA;
+	}
+	lib_dumpbuffer(msg, buf, BUFF_SIZE);
+
+	free(buf);
+	buf = NULL;
+
+	TC_SUCCESS_RESULT();
+}
+
 #ifndef CONFIG_BUILD_PROTECTED
+#ifdef CONFIG_ARCH_LOWPUTC
 /**
  * @fn                  :tc_libc_misc_lldbg
  * @brief               :Identical to [a-z]dbg() except this is uses special interfaces provided by architecture-specific logic to \n
@@ -319,7 +366,10 @@ static void tc_libc_misc_llvdbg(void)
 	TC_SUCCESS_RESULT();
 }
 #endif
+#endif /* CONFIG_BUILD_PROTECTED */
+#endif /* CONFIG_DEBUG_ERROR */
 
+#ifdef CONFIG_DEBUG_VERBOSE
 /**
  * @fn                  :tc_libc_misc_vdbg
  * @brief               :This is intended for general debug output that is normally suppressed.
@@ -350,50 +400,8 @@ static void tc_libc_misc_vdbg(void)
 
 	TC_SUCCESS_RESULT();
 }
-
-/**
- * @fn                  :tc_libc_misc_lib_dumpbuffer
- * @brief               :Do a pretty buffer dump
- * @scenario            :Do a pretty buffer dump
- * @API's covered       :lib_dumpbuffer
- * @Preconditions       :None
- * @Postconditions      :None
- * @Return              :void
- */
-static void tc_libc_misc_lib_dumpbuffer(void)
-{
-	const char *msg = "tc_libc_misc_lib_dumpbuffer";
-	unsigned char buffer[] = { 'S', 'A', 'M', 'S', 'U', 'N', 'G', '-', 'T', 'i', 'z', 'e', 'n', 'R', 'T' };
-	unsigned char *buf = NULL;
-	int idx;
-
-	/* To guarantee flushing other printf messages before using lowsyslog */
-	usleep(10);
-
-	/**
-	 * As lib_dumpbuffer returns void, there in no way to check the success or failure case
-	 * we need to manually check the dump output
-	 * Case-1: output: 53414d53554e472d54697a656e5254 SAMSUNG-TizenRT
-	 * Case-2: output: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a ...............	(i.e, 256 "0a")
-	 */
-
-	/* Case-1 */
-	lib_dumpbuffer(msg, buffer, sizeof(buffer));
-
-	/* Case-2 */
-	buf = (unsigned char *)malloc(BUFF_SIZE);
-	TC_ASSERT_NEQ("malloc", buf, NULL);
-
-	for (idx = 0; idx < BUFF_SIZE; idx++) {
-		buf[idx] = 0xA;
-	}
-	lib_dumpbuffer(msg, buf, BUFF_SIZE);
-
-	free(buf);
-	buf = NULL;
-
-	TC_SUCCESS_RESULT();
-}
+#endif
+#endif /* CONFIG_DEBUG */
 
 /**
  * @fn                  :tc_libc_misc_match


### PR DESCRIPTION
- Remove select option of DEBUG and DEBUG_ERROR/VERVOSE in Kconfig
- Add ifdef depending on configuration of DEBUG and DEBUG_ERROR/VERVOSE