### PR TITLE
framework/wifi_manager: Static declaration of global variables

### DIFF
--- a/framework/src/wifi_manager/wifi_manager.c
+++ b/framework/src/wifi_manager/wifi_manager.c
@@ -499,7 +499,7 @@ typedef wifi_manager_result_e (*wifimgr_handler)(_wifimgr_msg_s *msg);
 /*
  * g_handler should be matched to _wifimgr_state
  */
-const wifimgr_handler g_handler[] = {
+static const wifimgr_handler g_handler[] = {
 	_handler_on_uninitialized_state,
 	_handler_on_disconnected_state,
 	_handler_on_disconnecting_state,

--- a/framework/src/wifi_manager/wifi_utils_lwnl80211.c
+++ b/framework/src/wifi_manager/wifi_utils_lwnl80211.c
@@ -87,9 +87,9 @@
 
 static wifi_utils_cb_s g_cbk = {NULL, NULL, NULL, NULL, NULL};
 
-struct _wifi_utils_s g_lwnl_hnd = {"", -1};
+static struct _wifi_utils_s g_lwnl_hnd = {"", -1};
 
-sem_t g_lwnl_signal;
+static sem_t g_lwnl_signal;
 
 static void close_cb_handler(void)
 {


### PR DESCRIPTION
- g_lwnl_hnd and g_lwnl_signal in wifi_utils_lwnl80211.c
- g_handler in wifi_manager.c
