### PR TITLE
os/compression/compress_read.c : Reduce loading time for compressed binary

### DIFF
--- a/os/compression/compress_read.c
+++ b/os/compression/compress_read.c
@@ -39,8 +39,8 @@
  * Private Declarations
  ****************************************************************************/
 
-struct s_header *compression_header;
-struct s_buffer buffers;
+static struct s_header *compression_header;
+static struct s_buffer buffers;
 
 /****************************************************************************
  * Private Functions


### PR DESCRIPTION
- Keep entire compression header, including block offsets, in memory when loading compressed binary.
- Overhead of time taken to get block's offset from file using seek is eliminated.
  This significantly reduces time taken for compressed binary loading.

Signed-off-by: Amandeep Chauhan <a.chauhan@samsung.com>