### PR TITLE
os/binfmt: Read symbol table and relocation table into RAM

### DIFF
--- a/os/binfmt/libelf/libelf.h
+++ b/os/binfmt/libelf/libelf.h
@@ -148,6 +148,19 @@ int elf_findsection(FAR struct elf_loadinfo_s *loadinfo, FAR const char *sectnam
 int elf_findsymtab(FAR struct elf_loadinfo_s *loadinfo);
 
 /****************************************************************************
+ * Name: elf_readsymtab
+ *
+ * Description:
+ *   Read the ELF symbol table into memory.
+ *
+ * Input Parameters:
+ *   loadinfo - Load state information
+ *
+ ****************************************************************************/
+
+void elf_readsymtab(FAR struct elf_loadinfo_s *loadinfo);
+
+/****************************************************************************
  * Name: elf_readsym
  *
  * Description:

--- a/os/include/tinyara/binfmt/elf.h
+++ b/os/include/tinyara/binfmt/elf.h
@@ -167,6 +167,8 @@ struct elf_loadinfo_s {
 	int filfd;					/* Descriptor for the file being loaded */
 	uint16_t offset;             /* elf offset when binary header is included */
 	uint8_t compression_type;		/* Binary Compression type */
+	uintptr_t symtab;			/* Copy of symbol table */
+	uintptr_t reltab;			/* Copy of relocation table */
 };
 
 /****************************************************************************


### PR DESCRIPTION
Allocate memory from kernel heap for symbol table and reloc table.
Read complete symbol table and relocation table into RAM before
starting the relocation process. All accesses to the symbol and
relocation table will be done using the RAM instead of Flash. This
will reduce the relocation time.

Signed-off-by: Kishore SN <kishore.sn@samsung.com>