### PR TITLE
framework/wifi_manager: socket open fail check

### DIFF
--- a/framework/src/wifi_manager/wifi_manager.c
+++ b/framework/src/wifi_manager/wifi_manager.c
@@ -1248,9 +1248,8 @@ wifi_manager_result_e _handler_on_reconnect_state(_wifimgr_msg_s *msg)
 
 		struct sockaddr_in serveraddr;
 		int sd = socket(PF_INET, SOCK_DGRAM, 0);
-		if (sd < 0) {
-			ndbg("[WM] socket create fail\n");
-		}
+		DEBUGASSERT(sd >= 0);
+
 		bzero(&serveraddr, sizeof(serveraddr));
 		serveraddr.sin_family = AF_INET;
 		serveraddr.sin_addr.s_addr = inet_addr("127.0.0.1");


### PR DESCRIPTION
- Add a logic to check whether socket open is failed or not
Because socket open fail at this stage is very critical to the entire wifi manager's operation, it is better to use DEBUGASSERT.