### PR TITLE
testcase/kernel: Move user entry function for task_init to userspace

### DIFF
--- a/apps/examples/testcase/le_tc/kernel/tc_task.c
+++ b/apps/examples/testcase/le_tc/kernel/tc_task.c
@@ -32,6 +32,7 @@
 #include <sys/wait.h>
 #include <sys/ioctl.h>
 #include <unistd.h>
+#include <stdbool.h>
 #include <tinyara/sched.h>
 #include <tinyara/testcase_drv.h>
 #include "tc_internal.h"
@@ -55,6 +56,7 @@ static int main_pid;
 static volatile int task_cnt;
 static volatile pid_t ppid;
 #endif
+static bool task_init_flag;
 
 /**
 * @fn                   :create_task
@@ -173,6 +175,19 @@ static int onexit_task(int argc, char *argv[])
 static int getpid_task(int argc, char *argv[])
 {
 	g_callback = (int)getpid();
+	return OK;
+}
+
+/**
+* @fn                   :test_task_entry
+* @brief                :utility function for tc_task_task_init
+* @return               :int
+*/
+static int test_task_entry(int argc, char *argv[])
+{
+	printf("test task entry\n");
+	task_init_flag = true;
+
 	return OK;
 }
 
@@ -473,9 +488,25 @@ static void tc_task_task_reparent(void)
 }
 #endif
 
+/**
+* @fn                   :tc_task_task_init
+* @brief                :Initialize a Task Control Block (TCB)
+* @Scenario             :Create and Initialize a Task Control Block (TCB)
+* API's covered         :task_init
+* Preconditions         :none
+* Postconditions        :none
+* @return               :void
+*/
 static void tc_task_task_init(void)
 {
-	TC_ASSERT_EQ("task_init", ioctl(tc_get_drvfd(), TESTIOC_TASK_INIT_TEST, 0), OK);
+	task_init_flag = false;
+
+	TC_ASSERT_EQ("task_init", ioctl(tc_get_drvfd(), TESTIOC_TASK_INIT_TEST, (unsigned long)test_task_entry), OK);
+
+	usleep(1);
+
+	TC_ASSERT_EQ("task_init", task_init_flag, true);
+
 	TC_SUCCESS_RESULT();
 }
 

--- a/os/drivers/testcase/kernel_test_proto.h
+++ b/os/drivers/testcase/kernel_test_proto.h
@@ -18,5 +18,5 @@
 
 #ifndef __DRIVERS_TESTCASE_KERNEL_TEST_PROTO_H
 #define __DRIVERS_TESTCASE_KERNEL_TEST_PROTO_H
-int test_task_init(void);
+int test_task_init(main_t entry);
 #endif

--- a/os/drivers/testcase/kernel_testcase_drv.c
+++ b/os/drivers/testcase/kernel_testcase_drv.c
@@ -673,7 +673,7 @@ static int kernel_test_drv_ioctl(FAR struct file *filep, int cmd, unsigned long 
 	break;
 
 	case TESTIOC_TASK_INIT_TEST: {
-		ret = test_task_init();
+		ret = test_task_init((main_t)arg);
 	}
 	break;
 

--- a/os/drivers/testcase/test_task_init.c
+++ b/os/drivers/testcase/test_task_init.c
@@ -45,25 +45,15 @@
  * Global Variables
  ****************************************************************************/
 
-static int is_done;
-
 /****************************************************************************
  * Private Functions
  ****************************************************************************/
-
-static int test_task_entry(int argc, char *argv[])
-{
-	printf("test task entry\n");
-	is_done = true;
-
-	return OK;
-}
 
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
 
-int test_task_init(void)
+int test_task_init(main_t entry)
 {
 	struct task_tcb_s *tcb;
 	uint32_t *stack;
@@ -84,7 +74,7 @@ int test_task_init(void)
 
 	/* positive test */
 
-	ret = task_init((struct tcb_s *)tcb, (const char *)TEST_TASK_NAME, (int)TEST_PRIORITY, stack, TEST_STACK_SIZE, test_task_entry, NULL);
+	ret = task_init((struct tcb_s *)tcb, (const char *)TEST_TASK_NAME, (int)TEST_PRIORITY, stack, TEST_STACK_SIZE, entry, NULL);
 	if (ret < 0) {
 		berr("Failed: task_init %d\n", ret);
 		ret = -get_errno();
@@ -93,7 +83,7 @@ int test_task_init(void)
 
 	/* Check the TCB values */
 
-	if ((tcb->cmn.sched_priority != TEST_PRIORITY) || (tcb->cmn.stack_alloc_ptr != stack) || (tcb->cmn.entry.main != test_task_entry)) {
+	if ((tcb->cmn.sched_priority != TEST_PRIORITY) || (tcb->cmn.stack_alloc_ptr != stack) || (tcb->cmn.entry.main != entry)) {
 		berr("Failed: set values, %d, %x, %x %d\n", tcb->cmn.pid, tcb->cmn.stack_alloc_ptr, tcb->cmn.entry.main);
 		ret = -ENXIO;
 		goto errout_with_task;
@@ -104,12 +94,6 @@ int test_task_init(void)
 		berr("Failed : task_activate() %d\n", ret);
 		ret = -get_errno();
 		goto errout_with_task;
-	}
-
-	usleep(1);
-
-	if (is_done == false) {
-		ret = ERROR;
 	}
 
 	return ret;


### PR DESCRIPTION
User entry function should be located in userspace because user can't access kernel region.