### PR TITLE
tools/ramdump: Enabled user input for different device ports.

### DIFF
--- a/os/arch/arm/src/armv7-m/up_assert.c
+++ b/os/arch/arm/src/armv7-m/up_assert.c
@@ -535,6 +535,10 @@ void up_assert(const uint8_t *filename, int lineno)
 
 	up_dumpstate();
 
+#if defined(CONFIG_BOARD_CRASHDUMP)
+	board_crashdump(up_getsp(), this_task(), (uint8_t *)filename, lineno);
+#endif
+
 #ifdef CONFIG_BINMGR_RECOVERY
 	if (is_kernel_assert == false) {
 		/* recovery user assert through binary manager */

--- a/tools/ramdump/HowToUseRamdump.md
+++ b/tools/ramdump/HowToUseRamdump.md
@@ -46,7 +46,33 @@ After you see this message, you can upload the ramdump by following the step bel
 cd $TIZENRT_BASEDIR/tools/ramdump/
 ./ramdump.sh
 ```
-3. Ramdump Tool receives the ram contents from target.
+3. Ramdump Tool will prompt for user's input for device adapter connected to the linux machine.
+```
+Please enter serial port adapter:
+For example: /dev/ttyUSB0 or /dev/ttyACM0
+Enter:
+/dev/ttyUSB0
+/dev/ttyUSB0 open failed!!
+Please enter correct device port
+Enter:
+```
+4. After entering device adapter information, tool will prompt for regions to be dumped
+```
+Enter:
+/dev/ttyUSB1
+Target Handshake successful do_handshake
+Target entered to ramdump mode
+
+=========================================================================
+Ramdump Region Options:
+1. ALL  ( Address: 02023800, Size: 968704 )
+
+=========================================================================
+Please enter desired ramdump option as below:
+        1 for ALL
+Please enter your input: 
+```
+5. Ramdump Tool receives the ram contents from target.
 ```
 Target Handshake successful do_handshake
 Target entered to ramdump mode

--- a/tools/ramdump/ramdump.sh
+++ b/tools/ramdump/ramdump.sh
@@ -29,7 +29,22 @@ gcc ramdump_tool.c -o ramdump
 RAMDUMP_FILE=./ramdump_0x*.bin
 rm -f ${RAMDUMP_FILE}
 ok=true
-sudo ./ramdump /dev/ttyUSB1 || ok=false
+
+# Take user input for device port
+echo Please enter serial port adapter:
+echo For example: /dev/ttyUSB1 or /dev/ttyACM0
+
+while [ $ok = true ]
+do
+echo Enter:
+read dev_port
+if sudo ./ramdump $dev_port;
+	then
+		ok=false
+	else
+		ok=true
+fi
+done
 
 if "$ok"; then
 echo "\nCopying..."


### PR DESCRIPTION
This patch adds support for the user to enter choice of the
device port connected to the linux machine. It will help to
take ramdumps for all kind of boards rather than only ttyUSB1.

Interface looks like:
********************************************************************
sh ramdump.sh
Please enter serial port adapter:
For example: /dev/ttyUSB0 or /dev/ttyACM0
Enter:
/dev/ttyUSB0
/dev/ttyUSB0 open failed!!
Please enter correct device port
Enter:
/dev/ttyUSB1
Target Handshake successful do_handshake
Target entered to ramdump mode
.
.
.
Ramdump received successfully..!
********************************************************************

Signed-off-by: Vidisha Thapa <thapa.v@samsung.com>