### PR TITLE
examples/media/utc: fix handle leak and check issues in utc functions

### DIFF
--- a/apps/examples/testcase/ta_tc/media/utc/utc_media_fileinputdatasource.cpp
+++ b/apps/examples/testcase/ta_tc/media/utc/utc_media_fileinputdatasource.cpp
@@ -151,10 +151,14 @@ static void utc_media_FileInputDataSource_open_n(void)
 	for (auto path : paths)
 	{
 		FILE *fp = fopen(path, "w");
-		fclose(fp);
-		media::stream::FileInputDataSource source(path);
-		TC_ASSERT_EQ_CLEANUP("utc_media_FileInputDataSource_open", source.open(), false, remove(path));
-		remove(path);
+		if (fp != NULL) {
+			fclose(fp);
+			media::stream::FileInputDataSource source(path);
+			TC_ASSERT_EQ_CLEANUP("utc_media_FileInputDataSource_open", source.open(), false, remove(path));
+			remove(path);
+		} else {
+			printf("fail to open %s, errno : %d\n", path, get_errno());
+		}
 	}
 
 	TC_SUCCESS_RESULT();

--- a/apps/examples/testcase/ta_tc/media/utc/utc_media_mediaplayer.cpp
+++ b/apps/examples/testcase/ta_tc/media/utc/utc_media_mediaplayer.cpp
@@ -83,12 +83,12 @@ void EmptyObserver::cvAsyncWait()
 
 static void SetUp(void)
 {
-	FILE *fp = fopen(dummyfilepath, "w");
 	char *dummyData = new char[4096];
 	if (!dummyData) {
 		printf("Not Enough Memory!\n");
 		return;
 	}
+	FILE *fp = fopen(dummyfilepath, "w");
 	if (fp != NULL) {
 		int ret = fwrite(dummyData, 4096, 1, fp);
 		if (ret != 4096) {
@@ -396,7 +396,7 @@ static void utc_media_MediaPlayer_start_p(void)
 	for (int i = 0; i < 2; ++i) {
 		media::MediaRecorder mr;
 		auto dataSource = std::unique_ptr<media::stream::FileOutputDataSource>(new media::stream::FileOutputDataSource( (i == 0 ? filePath_opus : filePath_wav) ));
-	
+
 		mr.create();
 		mr.setDataSource(std::move(dataSource));
 		mr.prepare();
@@ -645,7 +645,7 @@ static void utc_media_MediaPlayer_operator_equal_p(void)
 {
 	media::MediaPlayer mp;
 	bool isSame = mp == mp;
-	
+
 	TC_ASSERT("utc_media_MediaPlayer_operator_equal", isSame);
 	TC_SUCCESS_RESULT();
 }
@@ -654,8 +654,8 @@ static void utc_media_MediaPlayer_operator_equal_n(void)
 {
 	media::MediaPlayer mp1, mp2;
 	bool isSame = mp1 == mp2;
-	
-	TC_ASSERT("utc_media_MediaPlayer_operator_equal", !isSame);	
+
+	TC_ASSERT("utc_media_MediaPlayer_operator_equal", !isSame);
 	TC_SUCCESS_RESULT();
 }
 


### PR DESCRIPTION
Fixed issues:
- The handle 'fp' was created at utc_media_mediaplayer.cpp:86 by calling function 'fopen' and lost at utc_media_mediaplayer.cpp:90.
- Return value of a function 'fopen' is dereferenced at utc_media_fileinputdatasource.cpp:154 without checking, but it is usually checked for this function.