### PR TITLE
wqueue: Fix build error in HP/LP worker thread's

### DIFF
--- a/os/wqueue/work_process.c
+++ b/os/wqueue/work_process.c
@@ -134,11 +134,12 @@ void work_process(FAR struct wqueue_s *wqueue, int wndx)
 	clock_t ctick;
 	clock_t next;
 
-#ifdef CONFIG_SCHED_WORKQUEUE_SORTING
+#if (defined(CONFIG_SCHED_LPWORK) && CONFIG_SCHED_LPNTHREADS > 0) || defined(CONFIG_SCHED_WORKQUEUE_SORTING)
 	sigset_t set;
 	sigemptyset(&set);
 	sigaddset(&set, SIGWORK);
-#else 
+#endif
+#ifndef CONFIG_SCHED_WORKQUEUE_SORTING
 	clock_t remaining;
 #endif
 

--- a/os/wqueue/work_queue.c
+++ b/os/wqueue/work_queue.c
@@ -122,7 +122,7 @@ int work_qqueue(FAR struct wqueue_s *wqueue, FAR struct work_s *work, worker_t w
 	DEBUGASSERT(work != NULL);
 
 #ifdef CONFIG_SCHED_WORKQUEUE_SORTING
-	struct work_s *next_work;
+	struct work_s *next_work = NULL;
 #endif
 	struct work_s *cur_work;
 
@@ -134,7 +134,6 @@ int work_qqueue(FAR struct wqueue_s *wqueue, FAR struct work_s *work, worker_t w
 #endif
 
 	/* check whether requested work is in queue list or not */
-	next_work = NULL;
 	cur_work = (struct work_s *)wqueue->q.head;
 	while (cur_work != NULL) {
 		if (cur_work == work) {


### PR DESCRIPTION
Build failed for "stm32" boards with below error 

configs:
stm32f429i-disco/hello
stm32f407-disc1/hello

CC:  work_queue.c
work_queue.c: In function 'work_qqueue':
work_queue.c:137:2: error: 'next_work' undeclared (first use in this function)
  next_work = NULL;
  ^~~~~~~~~
CC: work_process.c
work_process.c: In function 'work_process':
work_process.c:277:28: error: 'set' undeclared (first use in this function)
   DEBUGVERIFY(sigwaitinfo(&set, NULL));

CC: work_process.c: In function 'work_process':
work_process.c:257:4: error: 'remaining' undeclared (first use in this function)
    remaining = work->delay - elapsed;
    ^~~~~~~~~

Signed-off-by: Satheesh Kumar <satheesh.ks@samsung.com>