### PR TITLE
framework/media: Manage focus with stream policy

### DIFF
--- a/apps/examples/testcase/ta_tc/media/utc/utc_media_focusmanager.cpp
+++ b/apps/examples/testcase/ta_tc/media/utc/utc_media_focusmanager.cpp
@@ -66,7 +66,7 @@ static void utc_media_FocusManager_requestFocus_p(void)
 							.build();
 
 	stream_info_t *info2;
-	stream_info_create(STREAM_TYPE_MEDIA, &info2);
+	stream_info_create(STREAM_TYPE_EMERGENCY, &info2);
 	auto stream_info2 = std::shared_ptr<stream_info_t>(info2, deleter);
 	auto focusRequest2 = media::FocusRequest::Builder()
 							.setStreamInfo(stream_info2)
@@ -83,8 +83,13 @@ static void utc_media_FocusManager_requestFocus_p(void)
 	TC_ASSERT_EQ("utc_media_FocusManager_requestFocus", ret, media::FOCUS_REQUEST_SUCCESS);
 	TC_ASSERT_EQ("utc_media_FocusManager_requestFocus", gain_counter, 1);
 
-	/* reqestFocus with other focusRequest. focus change callback will be called */
+	/* reqestFocus with a high prio focusRequest. focus change callback will be called */
 	ret = focusManger.requestFocus(focusRequest2);
+	TC_ASSERT_EQ("utc_media_FocusManager_requestFocus", ret, media::FOCUS_REQUEST_SUCCESS);
+	TC_ASSERT_EQ("utc_media_FocusManager_requestFocus", gain_counter, 2);
+
+	/* requestFocus with a low prio focusRequest. focus change callback will not be called */
+	ret = focusManger.requestFocus(focusRequest);
 	TC_ASSERT_EQ("utc_media_FocusManager_requestFocus", ret, media::FOCUS_REQUEST_SUCCESS);
 	TC_ASSERT_EQ("utc_media_FocusManager_requestFocus", gain_counter, 2);
 

--- a/framework/include/media/FocusManager.h
+++ b/framework/include/media/FocusManager.h
@@ -82,8 +82,11 @@ private:
 		bool hasSameId(std::shared_ptr<FocusRequest> focusRequest);
 		void notify(int focusChange);
 
+		static bool compare(const FocusRequester a, const FocusRequester b);
+
 	private:
 		stream_info_id_t mId;
+		stream_policy_t mPolicy;
 		std::shared_ptr<FocusChangeListener> mListener;
 	};
 


### PR DESCRIPTION
FocusManager::requestFocus considers stream policy.
So if the requiring FocusRequest has lower priority, it will not gain focus.