### PR TITLE
arch/arm/src/armv7-m: Add support of nested interrupt in flat binary

### DIFF
--- a/os/arch/arm/src/armv7-m/up_doirq.c
+++ b/os/arch/arm/src/armv7-m/up_doirq.c
@@ -117,14 +117,6 @@ uint32_t *up_doirq(int irq, uint32_t *regs)
 	 * only be modified for outermost interrupt handler (when g_nestlevel == 0)
 	 */
 
-	flags = irqsave();
-
-	if (g_nestlevel == 0) {
-		current_regs = regs;
-	}
-
-	g_nestlevel++;
-
 	irqrestore(flags);
 #else
 	uint32_t *savestate;

--- a/os/arch/arm/src/armv7-m/up_doirq.c
+++ b/os/arch/arm/src/armv7-m/up_doirq.c
@@ -73,7 +73,7 @@
 /****************************************************************************
  * Public Data
  ****************************************************************************/
-#if CONFIG_ARCH_INTERRUPTSTACK > 7
+#ifdef CONFIG_ARCH_NESTED_INTERRUPT
 extern uint32_t g_nestlevel; /* Initial top of interrupt stack */
 #endif
 /****************************************************************************
@@ -90,7 +90,7 @@ extern uint32_t g_nestlevel; /* Initial top of interrupt stack */
 
 uint32_t *up_doirq(int irq, uint32_t *regs)
 {
-#if CONFIG_ARCH_INTERRUPTSTACK > 7
+#ifdef CONFIG_ARCH_NESTED_INTERRUPT
 	irqstate_t flags;
 	uint32_t stack_remain;
 #endif
@@ -99,7 +99,7 @@ uint32_t *up_doirq(int irq, uint32_t *regs)
 	PANIC();
 #else
 
-#if CONFIG_ARCH_INTERRUPTSTACK > 7
+#ifdef CONFIG_ARCH_NESTED_INTERRUPT
 
 #ifdef CONFIG_ARCH_NESTED_INTERRUPT_STACKCHECK
 
@@ -147,7 +147,7 @@ uint32_t *up_doirq(int irq, uint32_t *regs)
 
 	irq_dispatch(irq, regs);
 
-#if CONFIG_ARCH_INTERRUPTSTACK > 7
+#ifdef CONFIG_ARCH_NESTED_INTERRUPT
 	/* Context switches are indicated by the returned value of this function.
 	 * If a context switch occurred while processing the interrupt then
 	 * current_regs may have change value.  If we return any value different

--- a/os/arch/arm/src/armv7-m/up_lazyexception.S
+++ b/os/arch/arm/src/armv7-m/up_lazyexception.S
@@ -203,6 +203,7 @@ exception_common:
 	stmdb	sp!, {r2-r11,r14}		/* Save the remaining registers plus the SP value */
 #else
 	stmdb	sp!, {r2-r11}			/* Save the remaining registers plus the SP value */
+	mov	r7, r14				/* Save R14 value in r7 */
 #endif
 
 #if !defined(CONFIG_ARCH_HIPRI_INTERRUPT) && !defined(CONFIG_ARCH_NESTED_INTERRUPT)
@@ -245,11 +246,12 @@ exception_common:
 	/* If g_nestlevel is zero then behave as normal, switching from the user
 	 * to the interrupt stack; if g_nestlevel is greater than zero, then do
 	 * not switch stacks. In this latter case, we are already using the interrupt stack */
-
+#ifdef CONFIG_ARCH_NESTED_INTERRUPT
 	ldr		r5, =g_nestlevel
 	ldr		r6, [r5]
 	cmp		r6, #0
 	bne		9f
+#endif
 	ldr		sp, =g_intstackbase
 9:
 #else
@@ -265,6 +267,7 @@ exception_common:
 
 	bl		up_doirq				/* R0=IRQ, R1=register save (msp) */
 	mov		r1, r4					/* Recover R1=main stack pointer */
+	mov		r14, r7					/* Recover R14=R7 */
 
 	/* On return from up_doirq, R0 will hold a pointer to register context
 	 * array to use for the interrupt return.  If that return value is the same
@@ -307,6 +310,7 @@ exception_common:
 	ldmia	r0, {r2-r11,r14}		/* Recover R4-R11, r14 + 2 temp values */
 #else
 	ldmia	r0, {r2-r11}			/* Recover R4-R11 + 2 temp values */
+	ldr	r14, =EXC_RETURN_PRIVTHR	/* Load the special value */
 #endif
 	b		3f						/* Re-join common logic */
 
@@ -363,12 +367,6 @@ exception_common:
 	msr		control, r2				/* Save the updated control register */
 #else
 	msr		msp, r1					/* Recover the return MSP value */
-
-	/* Preload r14 with the special return value first (so that the return
-	 * actually occurs with interrupts still disabled).
-	 */
-
-	ldr		r14, =EXC_RETURN_PRIVTHR	/* Load the special value */
 #endif
 
 	/* Restore the interrupt state */
@@ -398,7 +396,7 @@ exception_common:
  *
  ************************************************************************************************/
 
-#if !defined(CONFIG_SMP) && CONFIG_ARCH_INTERRUPTSTACK > 7
+#if !defined(CONFIG_SMP) && CONFIG_ARCH_INTERRUPTSTACK > 3
 	.bss
 	.global	g_intstackalloc
 	.global	g_intstackbase

--- a/os/arch/arm/src/armv7-m/up_lazyexception.S
+++ b/os/arch/arm/src/armv7-m/up_lazyexception.S
@@ -229,6 +229,20 @@ exception_common:
 	msr		basepri, r2				/* Set the BASEPRI */
 #endif
 
+	/* Disable further interrupts until we get g_nestlevel
+	 * and current_regs=regs, If before storing above values, higher priority
+	 * interrupt comes then context will be corrupted.
+	 */
+
+#ifdef CONFIG_ARCH_NESTED_INTERRUPT
+#ifdef CONFIG_ARMV7M_USEBASEPRI
+	mov r1, #NVIC_SYSH_DISABLE_PRIORITY
+	msr basepri,r1						/* Set base priority */
+#else
+	cpsid	i
+#endif
+#endif
+
 	/* There are two arguments to up_doirq:
 	 *
 	 *   R0 = The IRQ number
@@ -246,14 +260,30 @@ exception_common:
 	/* If g_nestlevel is zero then behave as normal, switching from the user
 	 * to the interrupt stack; if g_nestlevel is greater than zero, then do
 	 * not switch stacks. In this latter case, we are already using the interrupt stack */
+
 #ifdef CONFIG_ARCH_NESTED_INTERRUPT
 	ldr		r5, =g_nestlevel
 	ldr		r6, [r5]
-	cmp		r6, #0
+	add		r6, r6, 1
+	str		r6, [r5]
+	cmp		r6, #1
 	bne		9f
+	ldr		r5, =current_regs
+	str		r1, [r5]
 #endif
 	ldr		sp, =g_intstackbase
 9:
+	/* Reenabling the interrupts before going into up_doirq
+	 * so that any higher priority interrupt can be served.
+	 */
+
+#ifdef CONFIG_ARCH_NESTED_INTERRUPT
+#ifdef CONFIG_ARMv7M_USEBASEPRI
+	msr		basepri, r3
+#else
+	cpsie	i
+#endif
+#endif
 #else
 	/* Otherwise, we will re-use the interrupted thread's stack.  That may
 	 * mean using either MSP or PSP stack for interrupt level processing (in


### PR DESCRIPTION
This patch adds support of nested interrupt in flat binary
as well as move logic of incrementing g_nestlevel and storing
current_regs value in critical area under exception_common function

Signed-off-by: Drashti Parikh <p.drashti@partner.samsung.com>