### PR TITLE
framework/wifi_manager: Add an API for scanning specific AP

### DIFF
--- a/framework/include/wifi_manager/wifi_manager.h
+++ b/framework/include/wifi_manager/wifi_manager.h
@@ -214,7 +214,7 @@ typedef struct {
 	int interval;
 	// max_interval: it is the maximum wait time if type is EXPONENTIAL
 	//             : it is not used if type is INTERVAL
-	int max_interval; // 
+	int max_interval;
 } wifi_manager_reconnect_config_s;
 
 /**
@@ -338,6 +338,15 @@ wifi_manager_result_e wifi_manager_disconnect_ap(void);
  * @since TizenRT v1.1
  */
 wifi_manager_result_e wifi_manager_scan_ap(void);
+
+/**
+ * @brief Scan nearby access points
+ * @details @b #include <wifi_manager/wifi_manager.h>
+ * @param[in] config Required AP configuration, which SSID should be given.
+ * @return On success, WIFI_MANAGER_SUCCESS (i.e., 0) is returned. On failure, non-zero value is returned.
+ * @since TizenRT v3.0
+ */
+wifi_manager_result_e wifi_manager_scan_specific_ap(wifi_manager_ap_config_s *config);
 
 /**
  * @brief Save the AP configuration at persistent storage

--- a/framework/src/wifi_manager/slsi_wifi_utils.c
+++ b/framework/src/wifi_manager/slsi_wifi_utils.c
@@ -351,12 +351,12 @@ wifi_utils_result_e wifi_utils_scan_ap(void *arg)
 
 	scan_filter_result.scan_flag = 0;
 	if (arg != NULL) {
+		wifi_utils_ap_config_s *ap_connect_config = (wifi_utils_ap_config_s *)arg;
 		scan_filter_result.scan_flag = 1;
 		if (scan_filter_result.result_list != NULL) {
 			free_scan_results(scan_filter_result.result_list);
 			scan_filter_result.result_list = NULL;
 		}
-		wifi_utils_ap_config_s *ap_connect_config = (wifi_utils_ap_config_s *)arg;
 		strncpy((char *)scan_filter_result.scan_ssid, (const char *)ap_connect_config->ssid, ap_connect_config->ssid_length);
 	}
 
@@ -638,7 +638,7 @@ wifi_utils_result_e wifi_utils_start_softap(wifi_utils_softap_config_s *softap_c
 	}
 	g_mode = SLSI_WIFI_SOFT_AP_IF;
 	nvdbg("[WU] SoftAP with SSID: %s has successfully started!\n", softap_config->ssid);
-	
+
 	ret = WiFiRegisterLinkCallback(&linkup_handler, &linkdown_handler);
 	if (ret != SLSI_STATUS_SUCCESS) {
 		ndbg("[WU] Link callback handles: register failed !\n");

--- a/framework/src/wifi_manager/wifi_manager.c
+++ b/framework/src/wifi_manager/wifi_manager.c
@@ -955,7 +955,6 @@ wifi_manager_result_e _wifimgr_scan(wifi_manager_ap_config_s *config)
 	if (!cbk->scan_ap_done) {
 		return WIFI_MANAGER_CALLBACK_NOT_REGISTERED;
 	}
-
 	if (config) {
 		strncpy(uconf.ssid, config->ssid, WIFIMGR_SSID_LEN);
 		uconf.ssid[WIFIMGR_SSID_LEN] = '\0';

--- a/framework/src/wifi_manager/wifi_utils_lwnl80211.c
+++ b/framework/src/wifi_manager/wifi_utils_lwnl80211.c
@@ -355,11 +355,17 @@ wifi_utils_result_e wifi_utils_deinit(void)
 wifi_utils_result_e wifi_utils_scan_ap(void *arg)
 {
 	WU_ENTER;
+	wifi_utils_ap_config_s *config = NULL;
+	uint32_t config_len = 0;
+	if (arg) {
+		config = (wifi_utils_ap_config_s *)arg;
+		config_len = sizeof(wifi_utils_ap_config_s);
+	}
 
 	int fd = open(LWNL80211_PATH, O_RDWR);
 	WU_CHECK_ERR(fd);
 
-	lwnl80211_data data_in = {NULL, 0, 0};
+	lwnl80211_data data_in = {(void *)config, config_len, 0};
 
 	WU_CALL(fd, LWNL80211_SCAN_AP, data_in);
 

--- a/os/drivers/lwnl/lwnl80211.c
+++ b/os/drivers/lwnl/lwnl80211.c
@@ -278,14 +278,14 @@ static int _ops_stop_softap(struct lwnl80211_lowerhalf_s *lower, lwnl80211_resul
 	return ret;
 }
 
-static int _ops_scan_ap(struct lwnl80211_lowerhalf_s *lower, lwnl80211_result_e *res)
+static int _ops_scan_ap(struct lwnl80211_lowerhalf_s *lower, lwnl80211_ap_config_s *config, lwnl80211_result_e *res)
 {
 	int ret = -ENOSYS;
 	if (lower->ops->scan_ap == NULL) {
 		return ret;
 	}
 
-	*res = lower->ops->scan_ap(NULL);
+	*res = lower->ops->scan_ap(config);
 	if (*res == LWNL80211_SUCCESS) {
 		ret = OK;
 	}
@@ -365,7 +365,7 @@ static int lwnl80211_ioctl(struct file *filep, int cmd, unsigned long arg)
 		ret = _ops_stop_softap(lower, res);
 		break;
 	case LWNL80211_SCAN_AP:
-		ret = _ops_scan_ap(lower, res);
+		ret = _ops_scan_ap(lower, (lwnl80211_ap_config_s *)data_in->data, res);
 		break;
 	default:
 		ret = _ops_drv_ioctl(lower, cmd, arg, res);

--- a/os/drivers/wireless/realtek/wifi_util_interface/rtk_drv_lwnl80211.c
+++ b/os/drivers/wireless/realtek/wifi_util_interface/rtk_drv_lwnl80211.c
@@ -226,7 +226,7 @@ lwnl80211_result_e rtkdrv_deinit(void)
 	return result;
 }
 
-lwnl80211_result_e rtkdrv_scan_ap(void *arg)
+lwnl80211_result_e rtkdrv_scan_ap(lwnl80211_ap_config_s *config)
 {
 	RTKDRV_ENTER;
 	lwnl80211_result_e result = LWNL80211_FAIL;

--- a/os/drivers/wireless/realtek/wifi_util_interface/rtk_drv_lwnl80211.h
+++ b/os/drivers/wireless/realtek/wifi_util_interface/rtk_drv_lwnl80211.h
@@ -127,7 +127,7 @@ int8_t WiFiRegisterLinkCallback(rtk_network_link_callback_t link_up, rtk_network
 
 lwnl80211_result_e rtkdrv_init(struct lwnl80211_lowerhalf_s *dev);
 lwnl80211_result_e rtkdrv_deinit(void);
-lwnl80211_result_e rtkdrv_scan_ap(void *arg);
+lwnl80211_result_e rtkdrv_scan_ap(lwnl80211_ap_config_s *config);
 lwnl80211_result_e rtkdrv_connect_ap(lwnl80211_ap_config_s *ap_connect_config, void *arg);
 lwnl80211_result_e rtkdrv_disconnect_ap(void *arg);
 lwnl80211_result_e rtkdrv_get_info(lwnl80211_info *wifi_info);

--- a/os/include/tinyara/lwnl/lwnl80211.h
+++ b/os/include/tinyara/lwnl/lwnl80211.h
@@ -217,7 +217,7 @@ struct lwnl80211_upperhalf_s;
 struct lwnl80211_ops_s {
 	CODE lwnl80211_result_e (*init)(struct lwnl80211_lowerhalf_s *dev);
 	CODE lwnl80211_result_e (*deinit)(void);
-	CODE lwnl80211_result_e (*scan_ap)(void *arg);
+	CODE lwnl80211_result_e (*scan_ap)(lwnl80211_ap_config_s *config);
 	CODE lwnl80211_result_e (*connect_ap)(lwnl80211_ap_config_s *config, void *arg);
 	CODE lwnl80211_result_e (*disconnect_ap)(void *arg);
 	CODE lwnl80211_result_e (*get_info)(lwnl80211_info *info);
@@ -240,7 +240,7 @@ typedef struct lwnl80211_lowerhalf_s {
 /* Driver OPSs */
 lwnl80211_result_e lwnl80211_init(struct lwnl80211_lowerhalf_s *dev);
 lwnl80211_result_e lwnl80211_deinit(void);
-lwnl80211_result_e lwnl80211_scan_ap(void *arg);
+lwnl80211_result_e lwnl80211_scan_ap(lwnl80211_ap_config_s *config);
 lwnl80211_result_e lwnl80211_connect_ap(lwnl80211_ap_config_s *ap_connect_config, void *arg);
 lwnl80211_result_e lwnl80211_disconnect_ap(void *arg);
 lwnl80211_result_e lwnl80211_get_info(lwnl80211_info *wifi_info);

--- a/os/include/tinyara/lwnl/slsi_drv.h
+++ b/os/include/tinyara/lwnl/slsi_drv.h
@@ -54,7 +54,7 @@ struct slsi_drv_dev_s {
  ****************************************************************************/
 lwnl80211_result_e slsidrv_init(struct lwnl80211_lowerhalf_s *dev);
 lwnl80211_result_e slsidrv_deinit(void);
-lwnl80211_result_e slsidrv_scan_ap(void *arg);
+lwnl80211_result_e slsidrv_scan_ap(lwnl80211_ap_config_s *config);
 lwnl80211_result_e slsidrv_connect_ap(lwnl80211_ap_config_s *ap_connect_config, void *arg);
 lwnl80211_result_e slsidrv_disconnect_ap(void *arg);
 lwnl80211_result_e slsidrv_get_info(lwnl80211_info *wifi_info);


### PR DESCRIPTION
### commit fcb09b4 framework/wifi_manager: Specific scan API
Add an API of wifi_manager_scan_specific_ap for targetted scanning

### commit 31aaf1a os/drivers/lwnl: Modify scanning API for lwnl80211
- Modify the input type of internal scanning APIs
- Applied to slsi and rtk lwnl80211 drv
- Add UTC for newly added API