### PR TITLE
framework/media/utils: Remove dependence on mpeg2ts demux module

### DIFF
--- a/framework/include/media/MediaUtils.h
+++ b/framework/include/media/MediaUtils.h
@@ -160,6 +160,17 @@ bool aac_header_parsing(unsigned char *header, unsigned int *channel, unsigned i
  * @endcond
  */
 bool wave_header_parsing(unsigned char *header, unsigned int *channel, unsigned int *sampleRate, audio_format_type_t *pcmFormat);
+/**
+ * @cond
+ * @internal
+ * @brief Check if the given data stream in buffer is MPEG2-TS format stream.
+ * @details @b #include <media/MediaUtils.h>
+ * @param[in] buffer: Pointer to the data stream buffer.
+ * @param[in] size: Size in bytes of data in the buffer.
+ * @return true - MPEG2-TS format. false - not MPEG2-TS format.
+ * @endcond
+ */
+bool isMpeg2Ts(const unsigned char *buffer, size_t size);
 } // namespace utils
 } // namespace media
 

--- a/framework/src/media/utils/MediaUtils.cpp
+++ b/framework/src/media/utils/MediaUtils.cpp
@@ -22,19 +22,124 @@
 #include <tinyara/config.h>
 #include <cstring>
 
-#ifdef CONFIG_CONTAINER_MPEG2TS
-#include "../demux/mpeg2ts/TSDemuxer.h"
-#endif
-
 namespace media {
 namespace utils {
 
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
 #ifdef __GNUC__
 #define POPCOUNT(x) __builtin_popcount(x)
 #else
 #define POPCOUNT(x) popcount(x)
 #endif
 
+#define IF_FAIL_RETURN_VAL(cond, val)           do { if (!(cond)) { return val; } } while (0)
+#define MINIMUM(x, y)                           (((x) < (y)) ? (x) : (y))
+
+#define TS_PACKET_SIZE                          188     // number of bytes of each transport packet
+#define TS_SYNC_BYTE                            0x47    // transport packet sync byte (0x47)
+#define TS_SYNC_COUNT                           3       // match Sync-Byte 3 times at least
+#define TS_HEAD_BYTES                           4       // 4 bytes header followed by payload
+#define TS_ADAPT_FIELD_LENGTH_BYTES             1       // adaptation-field-length takes 1 byte
+#define TS_CONTINUITY_COUNTER_MOD               16      // continuity counter's module value
+
+#define BITS_MASK(bits)                         ((1 << (bits)) - 1)
+#define TS_TRANSPORT_ERROR_INDICATOR(buffer)    ((buffer[1] >> 7) & BITS_MASK(1))
+#define TS_PAYLOAD_UNIT_START_INDICATOR(buffer) ((buffer[1] >> 6) & BITS_MASK(1))
+#define TS_PID(buffer)                          (((buffer[1] << 8) + buffer[2]) & BITS_MASK(13))
+#define TS_ADAPTION_FIELD_CONTROL(buffer)       ((buffer[3] >> 4) & BITS_MASK(2))
+#define TS_CONTINUITY_COUNTER(buffer)           ((buffer[3]) & BITS_MASK(4))
+#define TS_ADAPTION_FIELD_LENGTH(buffer)        (buffer[TS_HEAD_BYTES])
+
+#define SECTION_LENGTH(buffer)                  (((buffer[1] & 0x0F) << 8) + buffer[2])
+#define SECTION_HEAD_BYTES                      3       // table_id + ... + section_length
+#define PAT_PID                                 0x0000  // PID of Program Association Table
+#define NETWORK_PID_PN                          0x0000  // program number 0 specifies the network PID
+#define PMT_STREAMS_MAXIMUM                     10      // maximum number of streams in PMT
+#define PROGRAM_INFO_LENGTH(buffer)             (((buffer[10] << 8) + buffer[11]) & 0x0FFF)
+#define STREAM_INFO_HEAD_BYTES                  5       // each stream info head takes 5bytes
+#define ES_INFO_LENGTH(buffer)                  ((((buffer)[3] << 8) + (buffer)[4]) & 0x0FFF)
+#define CRC32_BYTES                             4       // CRC32 takes 4bytes
+
+// Supported audio stream types
+#define STREAM_TYPE_AUDIO_MPEG1                 0x03 // MPEG-1 audio (ISO/IEC 11172-3 audio)
+#define STREAM_TYPE_AUDIO_AAC                   0x0F // MPEG-2 lower bit-rate audio (ISO/IEC 13818-7 ADTS AAC)
+#define STREAM_TYPE_AUDIO_HE_AAC                0x11 // MPEG-4 LOAS multi-format framed audio (ISO/IEC 14496-3)
+
+#define PES_PACKET_HEAD_BYTES                   6   // packet_start_code_prefix + stream_id + PES_packet_length
+#define PES_STREAM_HEAD_BYTES                   3   // stream info + 7 flags + PES head data length fields
+#define PES_PACKET_START_CODE_PREFIX(buffer)    ((buffer[0] << 16) | (buffer[1] << 8) | buffer[2])
+#define PES_STREAM_ID(buffer)                   (buffer[3])
+#define PES_PACKET_LENGTH(buffer)               ((buffer[4] << 8) | buffer[5])
+#define PES_HEADER_DATA_LENGTH(buffer)          (buffer[PES_PACKET_HEAD_BYTES + 2])
+
+/****************************************************************************
+ * Private Declarations
+ ****************************************************************************/
+enum utils_error_e {
+	UTILS_ERROR_WANT_MORE_DATA = -6,
+	UTILS_ERROR_NOT_FOUND = -5,
+	UTILS_ERROR_NOT_SUPPORTED = -4,
+	UTILS_ERROR_NOT_AVAILABLE = -3,
+	UTILS_ERROR_BAD_PARAMETER = -2,
+	UTILS_ERROR_UNKNOWN = -1,
+	UTILS_ERROR_NONE = 0 // No Error
+};
+
+typedef struct {
+	uint16_t tsId;          // transport stream ID
+	uint16_t numOfPrgs;     // number of programs
+} psi_pat_info_t;
+
+typedef struct {
+	uint16_t prgNum;        // program number
+	uint16_t numOfStreams;  // number of streams
+} psi_pmt_info_t;
+
+typedef struct {
+	uint8_t type;           // stream type
+	uint16_t pid;           // elementary PID
+} psi_pmt_stream_info_t;
+
+typedef struct {
+	const uint8_t *data;    // section data buffer address
+	uint16_t size;          // size in bytes of section data
+} psi_section_t;
+
+/**
+ * Limitations:
+ * Most of time there's only one section in a PSI table (PAT especially),
+ * Therefore, now we simply support single section for both PAT and PMT,
+ * and this single section must be packaged in only one TS packet.
+ * If the limit is broken, ts_psi_process() returns UTILS_ERROR_NOT_SUPPORTED.
+ */
+typedef struct {
+	psi_section_t section;  // single section of PSI table
+} psi_table_t;
+
+typedef struct {
+	uint16_t pid;           // PID of PES
+	uint16_t packetLen;     // total length bytes of the PES packet
+	uint16_t present;       // present bytes unpacked from TS packets
+	uint16_t esOffset;      // consumed ES data offset from PES packet head
+	uint8_t  continuity;    // continuity counter of last unpacked TS packet
+} pes_packet_t;
+
+typedef struct {
+	uint8_t *buffer;        // user given mpeg2-ts data buffer
+	size_t buflen;          // length in bytes of data in the buffer
+	size_t offset;          // offset in bytes indicate how many data used in buffer
+	pes_packet_t pes;       // PES
+	psi_table_t pat;        // PAT
+	psi_table_t pmt;        // PMT
+	uint16_t numOfStreams;  // number of streams in PMT components
+	uint16_t streamOffset[PMT_STREAMS_MAXIMUM]; // stream info offset map
+} ts_demux_t;
+
+/****************************************************************************
+ * Private Variables
+ ****************************************************************************/
 // Mine-Type for audio stream
 static const std::string AAC_MIME_TYPE = "audio/aac";
 static const std::string AACP_MIME_TYPE = "audio/aacp";
@@ -42,6 +147,389 @@ static const std::string MPEG_MIME_TYPE = "audio/mpeg";
 static const std::string MP4_MIME_TYPE = "audio/mp4";
 static const std::string OPUS_MIME_TYPE = "audio/opus";
 static const std::string MP2T_MIME_TYPE = "video/MP2T";
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+#ifndef __GNUC__
+static int32_t popcount(uint32_t x)
+{
+	x -= (x >> 1) & 0x55555555;
+	x = (x & 0x33333333) + ((x >> 2) & 0x33333333);
+	x = (x + (x >> 4)) & 0x0F0F0F0F;
+	x += x >> 8;
+	x += x >> 16;
+	return x & 0x0000003F;
+}
+#endif
+
+// Locate 1st TS packet in the given buffer, resync header if necessary or required.
+static int findTsPacket(const uint8_t *buffer, size_t size, bool sync)
+{
+	size_t syncOffset = 0;
+	IF_FAIL_RETURN_VAL(size >= TS_PACKET_SIZE, UTILS_ERROR_WANT_MORE_DATA);
+
+	if (sync || (buffer[0] != TS_SYNC_BYTE)) {
+		for (syncOffset = 0; syncOffset < TS_PACKET_SIZE; syncOffset++) {
+			if (buffer[syncOffset] != TS_SYNC_BYTE) {
+				continue;
+			}
+			IF_FAIL_RETURN_VAL(size >= syncOffset + TS_SYNC_COUNT * TS_PACKET_SIZE, UTILS_ERROR_WANT_MORE_DATA);
+
+			int count;
+			for (count = 1; count < TS_SYNC_COUNT; count++) {
+				if (buffer[syncOffset + count * TS_PACKET_SIZE] != TS_SYNC_BYTE) {
+					break;
+				}
+			}
+			if (count == TS_SYNC_COUNT) {
+				break; // sync succeed
+			}
+		}
+		IF_FAIL_RETURN_VAL(syncOffset < TS_PACKET_SIZE, UTILS_ERROR_NOT_FOUND);
+	}
+
+	return (int)syncOffset;
+}
+
+// Abstract payload from the given TS packet
+static const uint8_t *getPayloadData(const uint8_t *packet, uint8_t *payloadDataLen)
+{
+	uint8_t lenPayload = TS_PACKET_SIZE - TS_HEAD_BYTES;
+	const uint8_t *payload = packet + TS_HEAD_BYTES;
+	if (TS_TRANSPORT_ERROR_INDICATOR(packet)) {
+		meddbg("Transport Error\n");
+		return nullptr;
+	}
+	if (TS_ADAPTION_FIELD_CONTROL(packet) == 0) { // 0 - reserved
+		medwdbg("adaptationFieldControl 0 is reserved\n");
+		return nullptr;
+	}
+	if (TS_ADAPTION_FIELD_CONTROL(packet) == 2) { // 2 - 183bytes adaptation field only
+		return nullptr; // no playload
+	}
+	if (TS_ADAPTION_FIELD_CONTROL(packet) == 3) { // 3 - 1~182bytes adaptation field + payload
+		lenPayload = TS_PACKET_SIZE - TS_HEAD_BYTES - (TS_ADAPT_FIELD_LENGTH_BYTES + TS_ADAPTION_FIELD_LENGTH(packet));
+		payload = packet + (TS_PACKET_SIZE - lenPayload);
+	} // else 1 - 184bytes playload
+	*payloadDataLen = lenPayload;
+	return payload;
+}
+
+// Unpack TS packet to abstract PSI section
+static int PSI_Unpack(const uint8_t *packet, const uint8_t **section, uint16_t *sectlen)
+{
+	uint8_t  lenPayload = 0;
+	const uint8_t *ptrPayload = getPayloadData(packet, &lenPayload);
+	if (!ptrPayload) {
+		// no payload
+		*section = NULL;
+		return UTILS_ERROR_NONE;
+	}
+
+	if (TS_PAYLOAD_UNIT_START_INDICATOR(packet)) {
+		// new section start, and the 1st byte in payload is the pointer field.
+		uint8_t u8PointerField = ptrPayload[0];
+		if (u8PointerField != 0) {
+			// prev section tail and next section head in this packet!
+			return UTILS_ERROR_NOT_SUPPORTED;
+		}
+		// handle new section
+		const uint8_t *ptrSection = ptrPayload + 1 + u8PointerField;
+		uint16_t lenSection = (SECTION_HEAD_BYTES + SECTION_LENGTH(ptrSection));
+		if (lenSection > (lenPayload - 1 - u8PointerField)) {
+			// portion of section in this packet
+			return UTILS_ERROR_NOT_SUPPORTED;
+		}
+		// TODO: check CRC32
+		// section complete (whole section contained in one TS packet)
+		*section = ptrSection;
+		*sectlen = lenSection;
+		return UTILS_ERROR_NONE;
+	}
+
+	// section appending
+	return UTILS_ERROR_NOT_SUPPORTED;
+}
+
+// Get the information (number of programs) in the PAT.
+static int ts_psi_get_pat_info(ts_demux_t *demux, psi_pat_info_t *info)
+{
+	psi_section_t *patSect = &demux->pat.section;
+	info->tsId = (patSect->data[3] << 8) + patSect->data[4];
+	// take off 8bytes header and 4bytes CRC, one program consists of 4bytes.
+	info->numOfPrgs = (patSect->size - 12) >> 2;
+	return UTILS_ERROR_NONE;
+}
+
+// Get the program number and PID from PAT at the given program index.
+static int ts_psi_get_program(ts_demux_t *demux, uint16_t index, uint16_t *prgNum, uint16_t *pmtPid)
+{
+	psi_section_t *patSect = &demux->pat.section;
+	IF_FAIL_RETURN_VAL(index < ((patSect->size - 12) >> 2), UTILS_ERROR_BAD_PARAMETER);
+	// 8bytes header + loop { 2bytes program number + 2bytes pmt pid }
+	const uint8_t *prgData = &patSect->data[8 + index * 4];
+	*prgNum = (prgData[0] << 8) + prgData[1];
+	*pmtPid = ((prgData[2] << 8) + prgData[3]) & 0x1FFF;
+	return UTILS_ERROR_NONE;
+}
+
+// Get the information (program number, number of streams, etc.) in the PMT.
+static int ts_psi_get_pmt_info(ts_demux_t *demux, psi_pmt_info_t *info)
+{
+	psi_section_t *pmtSect = &demux->pmt.section;
+	info->prgNum = (pmtSect->data[3] << 8) + pmtSect->data[4];
+	info->numOfStreams = demux->numOfStreams;
+	return UTILS_ERROR_NONE;
+}
+
+// Get the information (stream type, stream PID, etc.) of the PMT elementary stream.
+static int ts_psi_get_stream_info(ts_demux_t *demux, uint16_t index, psi_pmt_stream_info_t *info)
+{
+	psi_section_t *pmtSect = &demux->pmt.section;
+	IF_FAIL_RETURN_VAL(index < demux->numOfStreams, UTILS_ERROR_BAD_PARAMETER);
+	uint16_t offset = demux->streamOffset[index];
+	info->type = pmtSect->data[offset];
+	info->pid = ((pmtSect->data[offset + 1] << 8) + pmtSect->data[offset + 2]) & 0x1FFF;
+	return UTILS_ERROR_NONE;
+}
+
+// Calculate the number of streams in PMT and map each stream offset
+static void map_pmt_streams(ts_demux_t *demux)
+{
+	psi_section_t *pmtSect = &demux->pmt.section;
+	// 12bytes header + program info length + loop { stream info }
+	uint16_t offset = 12 + PROGRAM_INFO_LENGTH(pmtSect->data);
+	uint16_t next = offset + STREAM_INFO_HEAD_BYTES + ES_INFO_LENGTH(&pmtSect->data[offset]);
+	int count = 0;
+	// loop until next stream offset exceed the first CRC byte
+	while (next <= pmtSect->size - CRC32_BYTES) {
+		demux->streamOffset[count++] = offset;
+		if (count == PMT_STREAMS_MAXIMUM) {
+			// [rarely] there are too many streams, consider to increase PMT_STREAMS_MAXIMUM.
+			break;
+		}
+		offset = next;
+		next = offset + STREAM_INFO_HEAD_BYTES + ES_INFO_LENGTH(&pmtSect->data[offset]);
+	}
+	demux->numOfStreams = count;
+}
+
+// Initialize the TS demux
+static int ts_demux_init(ts_demux_t *demux, uint8_t *buffer, uint32_t size)
+{
+	IF_FAIL_RETURN_VAL(demux != NULL, UTILS_ERROR_BAD_PARAMETER);
+	IF_FAIL_RETURN_VAL(buffer != NULL && size >= TS_SYNC_COUNT * TS_PACKET_SIZE, UTILS_ERROR_BAD_PARAMETER);
+
+	memset(demux, 0x00, sizeof(ts_demux_t));
+	demux->buffer = buffer;
+	demux->buflen = size;
+	demux->offset = 0;
+	demux->numOfStreams = 0;
+	demux->pes.pid = 0x1FFF;
+	demux->pes.continuity = 0xff;
+	return UTILS_ERROR_NONE;
+}
+
+// Process demuxing to abstract PSI table (PAT or PMT) with the given PID.
+static int ts_psi_process(ts_demux_t *demux, uint16_t pid)
+{
+	while (1) {
+		// locate ts packet
+		int ret = findTsPacket(demux->buffer + demux->offset, demux->buflen - demux->offset, false);
+		IF_FAIL_RETURN_VAL(ret >= UTILS_ERROR_NONE, ret);
+		demux->offset += ret;
+		uint8_t *tsPacket = demux->buffer + demux->offset;
+		demux->offset += TS_PACKET_SIZE;
+		if (TS_PID(tsPacket) != pid) {
+			continue; // PID not match
+		}
+		// unpack ts packet to get section
+		uint16_t lenSection = 0;
+		const uint8_t *ptrSection = NULL;
+		ret = PSI_Unpack(tsPacket, &ptrSection, &lenSection);
+		IF_FAIL_RETURN_VAL(ret == UTILS_ERROR_NONE, ret);
+		if (ptrSection == NULL) {
+			continue; // no section
+		}
+		if (ptrSection[6] != 0 || ptrSection[7] != 0) {
+			// multi sections
+			return UTILS_ERROR_NOT_SUPPORTED;
+		}
+		// table complete (support only one section in the PAT/PMT)
+		psi_table_t *table = (pid == PAT_PID ? &demux->pat : &demux->pmt);
+		table->section.data = ptrSection;
+		table->section.size = lenSection;
+		if (pid != PAT_PID) {
+			// calculate streams offset once PMT received
+			map_pmt_streams(demux);
+		}
+		return UTILS_ERROR_NONE;
+	}
+}
+
+// Process demuxing to abstract PES/ES data with the given PID.
+static int ts_pes_process(ts_demux_t *demux, uint16_t pid, uint8_t *buffer, size_t size)
+{
+	pes_packet_t *pes = &demux->pes;
+	IF_FAIL_RETURN_VAL((pes->pid != pid), UTILS_ERROR_NOT_SUPPORTED);
+	pes->pid = pid;
+	pes->continuity = 0xff;
+
+	size_t total = 0;
+	while (total < size) {
+		// locate ts packet
+		int ret = findTsPacket(demux->buffer + demux->offset, demux->buflen - demux->offset, false);
+		IF_FAIL_RETURN_VAL(ret >= UTILS_ERROR_NONE, ret);
+		demux->offset += ret;
+		uint8_t *tsPacket = demux->buffer + demux->offset;
+		demux->offset += TS_PACKET_SIZE;
+		if (TS_PID(tsPacket) != pid) {
+			continue; // PID not match
+		}
+		// unpack ts packet to get ES data
+		uint8_t lenPayload = 0;
+		const uint8_t *ptrPayload = getPayloadData(tsPacket, &lenPayload);
+		if (!ptrPayload) {
+			continue; // no payload
+		}
+		if (TS_PAYLOAD_UNIT_START_INDICATOR(tsPacket)) {
+			// new PES packet start
+			if (PES_STREAM_ID(ptrPayload) < 0xc0 || PES_STREAM_ID(ptrPayload) > 0xdf) {
+				// not audio stream (stream id = 110xxxxx)
+				pes->continuity = 0xff;
+				continue;
+			}
+			pes->present = 0;
+			pes->packetLen = PES_PACKET_HEAD_BYTES + PES_PACKET_LENGTH(ptrPayload);
+			pes->esOffset = PES_PACKET_HEAD_BYTES + PES_STREAM_HEAD_BYTES + PES_HEADER_DATA_LENGTH(ptrPayload);
+		} else if (pes->continuity == 0xff) {
+			// waiting for new start indicator
+			continue;
+		} else if (TS_CONTINUITY_COUNTER(tsPacket) != ((pes->continuity + 1) % TS_CONTINUITY_COUNTER_MOD)) {
+			// continuity is broken
+			pes->continuity = 0xff;
+			total = 0; // drop copied ES data
+			continue;
+		}
+		// copy incoming ES data to output buffer
+		uint16_t header = (pes->present < pes->esOffset) ? pes->esOffset - pes->present : 0;
+		if (lenPayload > header) {
+			// ES data is available
+			uint16_t esLen = MINIMUM(pes->present + lenPayload, pes->packetLen) - pes->esOffset;
+			esLen = MINIMUM(size - total, esLen);
+			memcpy((void *)&buffer[total], (const void *)&ptrPayload[header], esLen);
+			total += esLen;
+			pes->esOffset += esLen;
+		} // else, no ES data in this ts packet
+		pes->continuity = TS_CONTINUITY_COUNTER(tsPacket);
+		pes->present += lenPayload;
+	}
+	return total;
+}
+
+/**
+ * @brief Parsing the mpeg2 transport stream data in buffer, to get audio stream codec type and other informations
+ * @param[in] buffer, buffer size, and audio type, channel, sample rate, pcm format adderss to receive.
+ * @return true - parsing success. false - parsing fail.
+ */
+static bool ts_parsing(unsigned char *buffer, unsigned int bufferSize, audio_type_t *audioType, unsigned int *channel, unsigned int *sampleRate, audio_format_type_t *pcmFormat)
+{
+	int ret;
+	ts_demux_t demux;
+
+	// init parser
+	ret = ts_demux_init(&demux, buffer, bufferSize);
+	if (ret < UTILS_ERROR_NONE) {
+		meddbg("Demux init failed, err %d\n", ret);
+		return false;
+	}
+
+	// parse and get PAT info
+	ret = ts_psi_process(&demux, PAT_PID);
+	if (ret < UTILS_ERROR_NONE) {
+		meddbg("PAT not found, err %d\n", ret);
+		return false;
+	}
+	psi_pat_info_t patInfo = {0};
+	ret = ts_psi_get_pat_info(&demux, &patInfo);
+	if (ret < UTILS_ERROR_NONE || patInfo.numOfPrgs < 1) {
+		meddbg("No program in PAT, err %d\n", ret);
+		return false;
+	}
+
+	// select the 1st program
+	uint16_t prgNum, pmtPid;
+	ret = ts_psi_get_program(&demux, 0, &prgNum, &pmtPid);
+	if (ret == UTILS_ERROR_NONE && prgNum == NETWORK_PID_PN) {
+		// skip network pn-pid, get next program
+		ret = ts_psi_get_program(&demux, 1, &prgNum, &pmtPid);
+	}
+	if (ret < UTILS_ERROR_NONE) {
+		meddbg("Select program failed, err %d\n", ret);
+		return false;
+	}
+
+	// parse and get PMT info
+	ret = ts_psi_process(&demux, pmtPid);
+	if (ret < UTILS_ERROR_NONE) {
+		meddbg("PMT not found, err %d\n", ret);
+		return false;
+	}
+	psi_pmt_info_t pmtInfo = {0};
+	ret = ts_psi_get_pmt_info(&demux, &pmtInfo);
+	if (ret < UTILS_ERROR_NONE || pmtInfo.numOfStreams < 1) {
+		meddbg("No elementary stream in PMT, err %d\n", ret);
+		return false;
+	}
+
+	// get supported audio stream info
+	psi_pmt_stream_info_t streamInfo = {0};
+	*audioType = AUDIO_TYPE_INVALID;
+	for (int i = 0; i < pmtInfo.numOfStreams; i++) {
+		ts_psi_get_stream_info(&demux, i, &streamInfo);
+		switch (streamInfo.type) {
+			case STREAM_TYPE_AUDIO_AAC:
+			case STREAM_TYPE_AUDIO_HE_AAC:
+				*audioType = AUDIO_TYPE_AAC;
+				break;
+			case STREAM_TYPE_AUDIO_MPEG1:
+				*audioType = AUDIO_TYPE_MP3;
+				break;
+			default:
+				medvdbg("Unsupported stream type %d\n", streamInfo.type);
+				break;
+		}
+		if (*audioType != AUDIO_TYPE_INVALID) {
+			break; // got supported audio stream
+		}
+	}
+	if (*audioType == AUDIO_TYPE_INVALID) {
+		meddbg("Audio stream (supported type) not found\n");
+		return false;
+	}
+
+	// get ES data
+	uint8_t audioES[64];
+	size_t audioESLen = sizeof(audioES);
+	ret = ts_pes_process(&demux, streamInfo.pid, audioES, audioESLen);
+	if (ret < UTILS_ERROR_NONE) {
+		meddbg("Get ES data failed, PID %u, err %d\n", streamInfo.pid, ret);
+		return false;
+	}
+	audioESLen = (size_t)ret;
+
+	// parse ES data and return result
+	if (pcmFormat) {
+		// set default value as same as the one in DataSource::DataSource()
+		*pcmFormat = AUDIO_FORMAT_TYPE_S16_LE;
+	}
+	return buffer_header_parsing(audioES, (unsigned int)audioESLen, *audioType, channel, sampleRate, pcmFormat);
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
 
 void toLowerString(std::string &str)
 {
@@ -314,62 +802,6 @@ bool wave_header_parsing(unsigned char *header, unsigned int *channel, unsigned 
 	return true;
 }
 
-#ifdef CONFIG_CONTAINER_MPEG2TS
-/**
- * @brief Parsing the mpeg2 transport stream data in buffer, to get audio stream codec type and other informations
- * @param[in] buffer, buffer size, and audio type, channel, sample rate, pcm format adderss to receive.
- * @return true - parsing success. false - parsing fail.
- */
-static bool ts_parsing(unsigned char *buffer, unsigned int bufferSize, audio_type_t *audioType, unsigned int *channel, unsigned int *sampleRate, audio_format_type_t *pcmFormat)
-{
-	// create temporary ts parser
-	auto tsDemuxer = media::TSDemuxer::create();
-	if (!tsDemuxer) {
-		meddbg("TSDemuxer::create failed\n");
-		return false;
-	}
-
-	// push the given (ts) data into demux buffer
-	size_t ret = tsDemuxer->pushData(buffer, bufferSize);
-	if (ret < bufferSize) {
-		medwdbg("TSDemuxer accept part of data %u/%u\n", ret, bufferSize);
-	}
-
-	// pre parse to get PSI
-	if (tsDemuxer->prepare() < 0) {
-		meddbg("TSDemuxer parse failed\n");
-		return false;
-	}
-
-	// get programs in ts, usually we select the 1th one as default.
-	std::vector<unsigned short> programs;
-	tsDemuxer->getPrograms(programs);
-	medvdbg("There's %lu programs in the given transport stream\n", programs.size());
-	if (programs.empty()) {
-		meddbg("TSDemuxer didn't find any program! Failed!\n");
-		return false;
-	}
-
-	// get audio type (from PMT component stream type field)
-	*audioType = tsDemuxer->getAudioType((void *)&programs[0]);
-
-	// get ES data (we expect the given ts data is enough to form a PES packet)
-	unsigned char audioES[64]; // 64 bytes should be enough for header parsing
-	ssize_t audioESLen = tsDemuxer->pullData(audioES, sizeof(audioES), (void *)&programs[0]);
-	if (audioESLen < 0) {
-		meddbg("TSDemuxer get ES data failed!\n");
-		return false;
-	}
-
-	if (pcmFormat) {
-		// Asign default value (same in DataSource)
-		*pcmFormat = AUDIO_FORMAT_TYPE_S16_LE;
-	}
-
-	return buffer_header_parsing(audioES, (unsigned int)audioESLen, *audioType, channel, sampleRate, pcmFormat);
-}
-#endif
-
 bool file_header_parsing(FILE *fp, audio_type_t audioType, unsigned int *channel, unsigned int *sampleRate, audio_format_type_t *pcmFormat)
 {
 	unsigned char *header = NULL;
@@ -468,7 +900,6 @@ bool file_header_parsing(FILE *fp, audio_type_t audioType, unsigned int *channel
 			return false;
 		}
 		break;
-#ifdef CONFIG_CONTAINER_MPEG2TS
 	case AUDIO_TYPE_MP2T: {
 		// has container, demux and parse stream data to get audio type
 		size_t bufferSize = CONFIG_DATASOURCE_PREPARSE_BUFFER_SIZE;
@@ -491,7 +922,6 @@ bool file_header_parsing(FILE *fp, audio_type_t audioType, unsigned int *channel
 			return false;
 		}
 	} break;
-#endif
 	default:
 		medvdbg("does not support header parsing\n");
 		return false;
@@ -592,14 +1022,12 @@ bool buffer_header_parsing(unsigned char *buffer, unsigned int bufferSize, audio
 			return false;
 		}
 		break;
-#ifdef CONFIG_CONTAINER_MPEG2TS
 	case AUDIO_TYPE_MP2T:
 		if (!ts_parsing(buffer, bufferSize, &audioType, channel, sampleRate, pcmFormat)) {
 			meddbg("ts_parsing failed, can not get audio information!\n");
 			return false;
 		}
 		break;
-#endif
 	default:
 		medvdbg("does not support header parsing\n");
 		return false;
@@ -726,18 +1154,6 @@ bool writeWavHeader(FILE *fp, unsigned int channel, unsigned int sampleRate, aud
 	return true;
 }
 
-#ifndef __GNUC__
-static int32_t popcount(uint32_t x)
-{
-	x -= (x >> 1) & 0x55555555;
-	x = (x & 0x33333333) + ((x >> 2) & 0x33333333);
-	x = (x + (x >> 4)) & 0x0F0F0F0F;
-	x += x >> 8;
-	x += x >> 16;
-	return x & 0x0000003F;
-}
-#endif
-
 unsigned int splitChannel(unsigned int layout, const signed short *stream, unsigned int frames, unsigned int channels, ...)
 {
 	uint32_t ret = 0;
@@ -848,6 +1264,22 @@ float getSignalToNoiseRatio(const short *buffer, size_t size, int windows, int *
 
 	va_end(ap);
 	return energyRatio;
+}
+
+bool isMpeg2Ts(const unsigned char *buffer, size_t size)
+{
+	if (!buffer) {
+		meddbg("Invalid param, buffer is null!\n");
+		return false;
+	}
+
+	int ret = findTsPacket(buffer, size, true);
+	if (ret < UTILS_ERROR_NONE) {
+		meddbg("Not found TS packets, err %d\n", ret);
+		return false;
+	}
+
+	return true;
 }
 
 } // namespace util


### PR DESCRIPTION
Implement simple MPEG2-TS demux inside media utils.
It's light-weighted, and has below limitations:
- Do not support multi sections in neither PAT nor PMT.
- Do not support one section packaged in multi TS packets.
- Do not support PSI table version detecting.

But it meets the requirement to abstract audio informations
from MPEG2-TS data stream.