### PR TITLE
kernel/semaphore: Initialize kernel semaphores with sem_init instead of SEM_INITIALIZER

### DIFF
--- a/os/arch/arm/src/common/up_initialize.c
+++ b/os/arch/arm/src/common/up_initialize.c
@@ -214,6 +214,12 @@ void up_initialize(void)
 #endif
 #endif
 
+	/* Initialize pipe */
+
+#if defined(CONFIG_PIPES) && CONFIG_DEV_PIPE_SIZE > 0
+	pipe_initialize();
+#endif
+
 	/* Register devices */
 
 #if CONFIG_NFILE_DESCRIPTORS > 0

--- a/os/arch/arm/src/stm32/stm32_eth.c
+++ b/os/arch/arm/src/stm32/stm32_eth.c
@@ -81,6 +81,9 @@
 #if defined(CONFIG_NET_PKT)
 #include <tinyara/net/pkt.h>
 #endif
+#ifdef CONFIG_ARCH_PHY_INTERRUPT
+#include <tinyara/net/phy.h>
+#endif
 
 #include "up_internal.h"
 
@@ -3972,6 +3975,11 @@ int stm32_ethinitialize(int intf)
 	priv->txpoll = wd_create();	/* Create periodic poll timer */
 	priv->txtimeout = wd_create();	/* Create TX timeout timer */
 
+#ifdef CONFIG_ARCH_PHY_INTERRUPT
+	/* Initialize a semaphore for phy notification */
+
+	phy_notify_initialize();
+#endif
 	/* Configure GPIO pins to support Ethernet */
 
 	stm32_ethgpioconfig(priv);

--- a/os/arch/arm/src/tiva/tm4c_ethernet.c
+++ b/os/arch/arm/src/tiva/tm4c_ethernet.c
@@ -3947,6 +3947,12 @@ int tiva_ethinitialize(int intf)
 	priv->txpoll = wd_create();	/* Create periodic poll timer */
 	priv->txtimeout = wd_create();	/* Create TX timeout timer */
 
+#ifdef CONFIG_TIVA_PHY_INTERRUPTS
+	/* Initialize a semaphore for phy notification */
+
+	phy_notify_initialize();
+#endif
+
 #ifdef CONFIG_TIVA_BOARDMAC
 	/* If the board can provide us with a MAC address, get the address
 	 * from the board now.  The MAC will not be applied until tiva_ifup()

--- a/os/arch/xtensa/src/esp32/esp32_spi.c
+++ b/os/arch/xtensa/src/esp32/esp32_spi.c
@@ -506,7 +506,7 @@ static struct esp32_spidev_s g_spi3dev = {
 };
 
 static volatile spi_dma_claim_t g_spi_dma = {
-	.dma_lock = SEM_INITIALIZER(1),
+	.dma_lock = {0},
 	.chan_enabled = 0,
 };
 
@@ -1585,6 +1585,9 @@ struct spi_dev_s *up_spiinitialize(int port)
 #else
 		spi_select_device(priv, 0, &def_dev_config);
 #endif
+
+		/* Initialize a semaphore for spi dma */
+		sem_init(&g_spi_dma.dma_lock, 0, 1);
 		priv->initiallized = true;
 	}
 

--- a/os/drivers/net/phy_notify.c
+++ b/os/drivers/net/phy_notify.c
@@ -148,7 +148,7 @@ static int phy_handler_3(int irq, FAR void *context, FAR void *arg);
  ****************************************************************************/
 /* Serializes access to the g_notify_clients array */
 
-static sem_t g_notify_clients_sem = SEM_INITIALIZER(1);
+static sem_t g_notify_clients_sem;
 
 /* This is a array the hold information for each PHY notification client */
 
@@ -334,7 +334,6 @@ static int phy_handler_3(int irq, FAR void *context, FAR void *arg)
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
-
 /****************************************************************************
  * Function: phy_notify_subscribe
  *
@@ -467,6 +466,27 @@ int phy_notify_unsubscribe(FAR const char *intf, pid_t pid)
 
 	phy_semgive();
 	return OK;
+}
+
+/****************************************************************************
+ * Function: phy_notify_initialize
+ *
+ * Description:
+ *   Initialize a semaphore for phy notification
+ *
+ * Parameters:
+ *   None
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+void phy_notify_initialize(void)
+{
+	/* Initialize a sempahore phy notification */
+
+	sem_init(&g_notify_clients_sem, 0, 1);
 }
 
 #endif							/* CONFIG_ARCH_PHY_INTERRUPT */

--- a/os/drivers/net/telnet.c
+++ b/os/drivers/net/telnet.c
@@ -211,7 +211,7 @@ static const struct file_operations g_factory_fops = {
 /* Global information shared amongst telnet driver instanaces. */
 
 static struct telnet_common_s g_telnet_common = {
-	SEM_INITIALIZER(1),
+	{0},
 	0
 };
 
@@ -890,6 +890,11 @@ static int common_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
 
 int telnet_initialize(void)
 {
+
+	/* Initialize a semaphore for telnet */
+
+	sem_init(&g_telnet_common.tc_exclsem, 0, 1);
+
 	return register_driver("/dev/telnet", &g_factory_fops, 0666, NULL);
 }
 

--- a/os/drivers/pipes/pipe.c
+++ b/os/drivers/pipes/pipe.c
@@ -105,7 +105,7 @@ static const struct file_operations pipe_fops = {
 	pipecommon_unlink			/* unlink */
 };
 
-static sem_t g_pipesem = SEM_INITIALIZER(1);
+static sem_t g_pipesem;
 static uint32_t g_pipeset = 0;
 static uint32_t g_pipecreated = 0;
 
@@ -293,4 +293,24 @@ errout:
 	return ERROR;
 }
 
+/****************************************************************************
+ * Name: pipe_initialize
+ *
+ * Description:
+ *   Initialize a sempahore for pipe
+ *
+ * Inputs:
+ *   None
+ *
+ * Return:
+ *   None
+ *
+ ****************************************************************************/
+
+void pipe_initialize(void)
+{
+	/* Initialize a semaphore for pipe */
+
+	sem_init(&g_pipesem, 0, 1);
+}
 #endif							/* CONFIG_DEV_PIPE_SIZE > 0 */

--- a/os/drivers/syslog/ramlog.c
+++ b/os/drivers/syslog/ramlog.c
@@ -686,6 +686,12 @@ int ramlog_consoleinit(void)
 #ifndef CONFIG_RAMLOG_NONBLOCKING
 	if ((priv->rl_waitsem.flags & FLAGS_INITIALIZED) == 0) {
 		sem_init(&priv->rl_waitsem, 0, 0);
+
+		/*
+		 * The rl_waitsem semaphore is used for signaling and, hence,
+		 * should not have priority inheritance enabled.
+		 */
+		sem_setprotocol(&priv->rl_waitsem, SEM_PRIO_NONE);
 	}
 #endif
 
@@ -718,6 +724,13 @@ int ramlog_sysloginit(void)
 #ifndef CONFIG_RAMLOG_NONBLOCKING
 	if ((g_sysdev.rl_waitsem.flags & FLAGS_INITIALIZED) == 0) {
 		sem_init(&g_sysdev.rl_waitsem, 0, 0);
+
+		/*
+		 * The rl_waitsem semaphore is used for signaling and, hence,
+		 * should not have priority inheritance enabled.
+		 */
+		sem_setprotocol(&g_sysdev.rl_waitsem, SEM_PRIO_NONE);
+
 	}
 #endif
 

--- a/os/drivers/syslog/ramlog.c
+++ b/os/drivers/syslog/ramlog.c
@@ -163,9 +163,9 @@ static struct ramlog_dev_s g_sysdev = {
 #endif
 	0,							/* rl_head */
 	0,							/* rl_tail */
-	SEM_INITIALIZER(1),			/* rl_exclsem */
+	{0},						/* rl_exclsem */
 #ifndef CONFIG_RAMLOG_NONBLOCKING
-	SEM_INITIALIZER(0),			/* rl_waitsem */
+	{0},						/* rl_waitsem */
 #endif
 	CONFIG_RAMLOG_BUFSIZE,		/* rl_bufsize */
 	g_sysbuffer					/* rl_buffer */
@@ -678,6 +678,17 @@ int ramlog_consoleinit(void)
 {
 	FAR struct ramlog_dev_s *priv = &g_sysdev;
 
+	/* Initialize the non-zero values in the RAM logging device structure */
+
+	if ((priv->rl_exclsem.flags & FLAGS_INITIALIZED) == 0) {
+		sem_init(&priv->rl_exclsem, 0, 1);
+	}
+#ifndef CONFIG_RAMLOG_NONBLOCKING
+	if ((priv->rl_waitsem.flags & FLAGS_INITIALIZED) == 0) {
+		sem_init(&priv->rl_waitsem, 0, 0);
+	}
+#endif
+
 	/* Register the console character driver */
 
 	return register_driver("/dev/console", &g_ramlogfops, 0666, priv);
@@ -699,6 +710,17 @@ int ramlog_consoleinit(void)
 #ifdef CONFIG_RAMLOG_SYSLOG
 int ramlog_sysloginit(void)
 {
+	/* Initialize the non-zero values in the RAM logging device structure */
+
+	if ((g_sysdev.rl_exclsem.flags & FLAGS_INITIALIZED) == 0) {
+		sem_init(&g_sysdev.rl_exclsem, 0, 1);
+	}
+#ifndef CONFIG_RAMLOG_NONBLOCKING
+	if ((g_sysdev.rl_waitsem.flags & FLAGS_INITIALIZED) == 0) {
+		sem_init(&g_sysdev.rl_waitsem, 0, 0);
+	}
+#endif
+
 	/* Register the syslog character driver */
 
 	return register_driver(CONFIG_SYSLOG_DEVPATH, &g_ramlogfops, 0666, &g_sysdev);

--- a/os/fs/driver/Make.defs
+++ b/os/fs/driver/Make.defs
@@ -63,7 +63,9 @@ CSRCS_DRIVER += block/fs_registerblockdriver.c block/fs_unregisterblockdriver.c
 CSRCS_DRIVER += block/fs_findblockdriver.c block/fs_openblockdriver.c block/fs_closeblockdriver.c block/ramdisk.c
 
 ifneq ($(CONFIG_DISABLE_PSEUDOFS_OPERATIONS),y)
+ifeq ($(CONFIG_BCH),y)
 CSRCS_DRIVER += block/fs_blockproxy.c
+endif
 endif
 endif
 

--- a/os/fs/driver/block/driver.h
+++ b/os/fs/driver/block/driver.h
@@ -137,7 +137,7 @@ int find_blockdriver(FAR const char *pathname, int mountflags, FAR struct inode 
  *
  ****************************************************************************/
 #if !defined(CONFIG_DISABLE_PSEUDOFS_OPERATIONS) && \
-	!defined(CONFIG_DISABLE_MOUNTPOINT)
+	!defined(CONFIG_DISABLE_MOUNTPOINT) && defined(CONFIG_BCH)
 int block_proxy(FAR const char *blkdev, int oflags);
 #endif
 

--- a/os/fs/driver/block/fs_blockproxy.c
+++ b/os/fs/driver/block/fs_blockproxy.c
@@ -79,7 +79,7 @@
  ****************************************************************************/
 
 static uint32_t g_devno;
-static sem_t g_devno_sem = SEM_INITIALIZER(1);
+static sem_t g_devno_sem;
 
 /****************************************************************************
  * Private Functions
@@ -226,5 +226,25 @@ errout_with_bchdev:
 errout_with_chardev:
 	kmm_free(chardev);
 	return ret;
+}
+
+/****************************************************************************
+ * Name: unique_chardev_initialize
+ *
+ * Description:
+ *   Initialize a semphore for unique character device
+ *
+ * Input parameters:
+ *   None
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+void unique_chardev_initialize(void)
+{
+	/* Initialize a semphore for unique chardev */
+
+	sem_init(&g_devno_sem, 0, 1);
 }
 #endif /* !CONFIG_DISABLE_MOUNTPOINT && !CONFIG_DISABLE_PSEUDOFS_OPERATIONS */

--- a/os/fs/fs_initialize.c
+++ b/os/fs/fs_initialize.c
@@ -141,7 +141,8 @@ void fs_initialize(void)
 
 #endif
 
-#if !defined(CONFIG_DISABLE_PSEUDOFS_OPERATIONS) && !defined(CONFIG_DISABLE_MOUNTPOINT)
+#if !defined(CONFIG_DISABLE_PSEUDOFS_OPERATIONS) && \
+	!defined(CONFIG_DISABLE_MOUNTPOINT) && defined(CONFIG_BCH)
 	/* Initialize for unique character device used in  */
 
 	unique_chardev_initialize();

--- a/os/fs/fs_initialize.c
+++ b/os/fs/fs_initialize.c
@@ -140,4 +140,10 @@ void fs_initialize(void)
 	aio_initialize();
 
 #endif
+
+#if !defined(CONFIG_DISABLE_PSEUDOFS_OPERATIONS) && !defined(CONFIG_DISABLE_MOUNTPOINT)
+	/* Initialize for unique character device used in  */
+
+	unique_chardev_initialize();
+#endif
 }

--- a/os/include/semaphore.h
+++ b/os/include/semaphore.h
@@ -141,6 +141,11 @@ struct sem_s {
 typedef struct sem_s sem_t;
 
 /* Initializers */
+/* NOTE : It should NOT be used in kernel space because it doesn't call sem_init.
+ * In app separtion, all kernel semaphores are registered to a list in sem_init and recoverd when fault occurs.
+ * So they should be initialized by sem_init for recovery.
+*/
+
 /**
  * @ingroup SEMAPHORE_KERNEL
  * @brief Sem initializer

--- a/os/include/tinyara/fs/fs.h
+++ b/os/include/tinyara/fs/fs.h
@@ -846,6 +846,19 @@ int file_fsync(FAR struct file *filep);
 int file_vfcntl(FAR struct file *filep, int cmd, va_list ap);
 #endif
 
+/* fs/driver/block/fs_blockproxy.c ******************************************/
+/****************************************************************************
+ * Name: unique_chardev_initialize
+ *
+ * Description:
+ *  Initialize a semphore for unique character device.
+ *
+ ****************************************************************************/
+
+#if !defined(CONFIG_DISABLE_PSEUDOFS_OPERATIONS) && !defined(CONFIG_DISABLE_MOUNTPOINT)
+void unique_chardev_initialize(void);
+#endif
+
 /* drivers/dev_null.c *******************************************************/
 /****************************************************************************
  * Name: devnull_register
@@ -965,6 +978,17 @@ ssize_t bchlib_read(FAR void *handle, FAR char *buffer, size_t offset, size_t le
  ****************************************************************************/
 
 ssize_t bchlib_write(FAR void *handle, FAR const char *buffer, size_t offset, size_t len);
+
+/* drivers/pipes/pipe.c ***********************************************/
+/****************************************************************************
+ * Name: pipe_initialize
+ *
+ * Description:
+ *   Initialize a semaphore for pipe
+ *
+ ****************************************************************************/
+
+void pipe_initialize(void);
 
 #undef EXTERN
 #if defined(__cplusplus)

--- a/os/include/tinyara/net/phy.h
+++ b/os/include/tinyara/net/phy.h
@@ -156,6 +156,24 @@ int phy_notify_subscribe(FAR const char *intf, pid_t pid, int signo, FAR void *a
 int phy_notify_unsubscribe(FAR const char *intf, pid_t pid);
 #endif
 
+/****************************************************************************
+ * Function: phy_notify_initialize
+ *
+ * Description:
+ *   Initialize a semaphore for phy notification
+ *
+ * Parameters:
+ *   None
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_ARCH_PHY_INTERRUPT
+void phy_notify_initialize(void);
+#endif
+
 #undef EXTERN
 #ifdef __cplusplus
 }

--- a/os/kernel/init/os_bringup.c
+++ b/os/kernel/init/os_bringup.c
@@ -94,6 +94,9 @@
 #ifdef CONFIG_TASK_MONITOR
 #include "task_monitor/task_monitor_internal.h"
 #endif
+#ifdef CONFIG_MESSAGING_IPC
+#include "messaging/message_ctrl.h"
+#endif
 
 /****************************************************************************
  * Pre-processor Definitions
@@ -270,6 +273,10 @@ static inline void os_do_appstart(void)
 
 #ifdef CONFIG_TASK_MANAGER
 	task_manager_drv_register();
+#endif
+
+#ifdef CONFIG_MESSAGING_IPC
+	messaging_initialize();
 #endif
 
 #ifdef CONFIG_TASK_MONITOR

--- a/os/kernel/messaging/message_ctrl.h
+++ b/os/kernel/messaging/message_ctrl.h
@@ -62,4 +62,5 @@
 int messaging_save_receiver(char *port_name, pid_t recv_pid, int recv_prio);
 int messaging_read_list(char *port_name, int *recv_arr, int *total_cnt);
 int messaging_remove_list(char *port_name);
+void messaging_initialize(void);
 #endif							/* __KERNEL_MESSAGING_MESSAGE_CTRL_H */

--- a/os/kernel/messaging/messaging.c
+++ b/os/kernel/messaging/messaging.c
@@ -94,7 +94,7 @@ struct msg_recv_node_s {
 };
 typedef struct msg_recv_node_s msg_recv_node_t;
 
-static sem_t port_list_sem = SEM_INITIALIZER(1);
+static sem_t port_list_sem;
 
 /****************************************************************************
  * Public Variables
@@ -376,4 +376,11 @@ int messaging_remove_list(char *port_name)
 	}
 
 	return ret;
+}
+
+void messaging_initialize(void)
+{
+	/* Initialize a sempahore for port list */
+
+	sem_init(&port_list_sem, 0, 1);
 }

--- a/os/net/bluetooth/bluetooth.c
+++ b/os/net/bluetooth/bluetooth.c
@@ -304,6 +304,8 @@ static int bt_conn_init(void)
 		return err;
 	}
 
+	bt_conn_handoff_init();
+
 	return err;
 }
 

--- a/os/net/bluetooth/bt_conn.c
+++ b/os/net/bluetooth/bt_conn.c
@@ -85,7 +85,7 @@ struct bt_conn_handoff_s {
 
 static struct bt_conn_s g_conns[CONFIG_BLUETOOTH_MAX_CONN];
 static struct bt_conn_handoff_s g_conn_handoff = {
-	SEM_INITIALIZER(1),
+	{0},
 	NULL
 };
 
@@ -1131,4 +1131,11 @@ bool bt_le_conn_params_valid(const struct bt_le_conn_param *param)
 	}
 
 	return true;
+}
+
+void bt_conn_handoff_init(void)
+{
+	/* Initialize a semaphore for connection handoff */
+
+	sem_init(&g_conn_handoff.sync_sem, 0, 1);
 }

--- a/os/net/bluetooth/bt_conn.h
+++ b/os/net/bluetooth/bt_conn.h
@@ -471,4 +471,5 @@ struct bt_conn_s *bt_conn_relref(FAR struct bt_conn_s *conn);
 int bt_hci_connect_le_cancel(FAR struct bt_conn_s *conn);
 
 int bt_hci_disconnect(FAR struct bt_conn_s *conn, uint8_t reason);
+void bt_conn_handoff_init(void);
 #endif							/* __NET_BLUETOOTH_BT_CONN_H */


### PR DESCRIPTION
All kernel semaphores should be intialized by sem_init for recovery.
In App separation, they are registered to a list in sem_init and recovered when fault occurs.