### PR TITLE
os/drivers/scsc: Implement probe request to send target SSID

### DIFF
--- a/framework/src/dm/conn/wifi/slsi_dm_connectivity.c
+++ b/framework/src/dm/conn/wifi/slsi_dm_connectivity.c
@@ -473,7 +473,7 @@ int dm_conn_free_scan_result(dm_scan_info_t **result)
 
 int dm_conn_wifi_scan(void)
 {
-	if (WiFiScanNetwork() == SLSI_STATUS_SUCCESS) {
+	if (WiFiScanNetwork(NULL) == SLSI_STATUS_SUCCESS) {
 		WiFiFreeScanResults(&g_wifi_scan_result);
 		WiFiGetScanResults(&g_wifi_scan_result);
 		WiFiNetworkJoin((uint8_t *)CONFIG_DM_AP_SSID, strlen(CONFIG_DM_AP_SSID), \

--- a/os/drivers/wireless/scsc/slsi_drv.c
+++ b/os/drivers/wireless/scsc/slsi_drv.c
@@ -415,9 +415,11 @@ lwnl80211_result_e slsidrv_scan_ap(lwnl80211_ap_config_s *config)
 			scan_filter_result.result_list = NULL;
 		}
 		strncpy((char *)scan_filter_result.scan_ssid, (const char *)config->ssid, config->ssid_length + 1);
+		ret = WiFiScanNetwork((char *)scan_filter_result.scan_ssid);
+	} else {
+		ret = WiFiScanNetwork(NULL);
 	}
 
-	ret = WiFiScanNetwork();
 	if (ret != SLSI_STATUS_SUCCESS) {
 		vddbg("[ERR] WiFi scan fail(%d)\n", ret);
 		return result;

--- a/os/drivers/wireless/scsc/slsi_utils.c
+++ b/os/drivers/wireless/scsc/slsi_utils.c
@@ -363,9 +363,11 @@ wifi_utils_result_e wifi_utils_scan_ap(void *arg)
 			scan_filter_result.result_list = NULL;
 		}
 		strncpy((char *)scan_filter_result.scan_ssid, (const char *)ap_connect_config->ssid, ap_connect_config->ssid_length + 1);
+		ret = WiFiScanNetwork((char *)scan_filter_result.scan_ssid);
+	} else {
+		ret = WiFiScanNetwork(NULL);
 	}
 
-	ret = WiFiScanNetwork();
 	if (ret != SLSI_STATUS_SUCCESS) {
 		ndbg("[WU] [ERR] WiFi scan fail(%d)\n", ret);
 		return wuret;

--- a/os/include/tinyara/wifi/slsi/slsi_wifi_api.h
+++ b/os/include/tinyara/wifi/slsi/slsi_wifi_api.h
@@ -296,7 +296,7 @@ int8_t WiFiRegisterScanCallback(network_scan_result_handler_t scan_result_handle
 
 /**
  * Scan for Wi-Fi network
- *
+ * @ssid : SSID of target AP, if null, wildcard SSID will be used
  * Return: Scan initiated successfully or failed
  *
  * Start a scan for Wi-Fi AP in the surroundings.
@@ -305,7 +305,7 @@ int8_t WiFiRegisterScanCallback(network_scan_result_handler_t scan_result_handle
  * or Scan aborted.
  * The scan results are retrieved using WiFiGetScanResults().
  */
-int8_t WiFiScanNetwork(void);
+int8_t WiFiScanNetwork(char *ssid);
 
 /**
  * Return current scan results list


### PR DESCRIPTION
- Wildcard SSID in probe request forces for the surrounding APs to send probe response,
which is not efficient and makes it possible to miss the target AP's probe response when there are many near by AP with high traffic ratio.
This implementation inserts a specific SSID into probe requenst not wildcard SSID,
which reduces the scanning duration by an average value of 250 ms.