### PR TITLE
tools/ramdump: Fixed some possible incorrect comparison with null war…

### DIFF
--- a/tools/ramdump/Ramdump_windows.ps1
+++ b/tools/ramdump/Ramdump_windows.ps1
@@ -230,7 +230,7 @@ function ramdump_main {
 	catch [System.Exception] {
 		Write-Error ("Failed to connect : " + $_)
 		$error[0] | Format-List -Force
-		if ($port -ne $null) {
+		if ($null -ne $port) {
 			$port.Close()
 		}
 		exit 1
@@ -258,7 +258,7 @@ function ramdump_main {
 
 	Write-Output "`nRamdump received successfully..!"
 
-	if ($port -ne $null) {
+	if ($null -ne $port) {
 		$port.Close()
 	}
 }


### PR DESCRIPTION
To ensure that PowerShell performs comparisons correctly, the $null element should be on the left side of the operator.

There are a number of reasons why this should occur:

$null is a scalar. When the input (left side) to an operator is a scalar value, comparison operators return a Boolean value. When the input is a collection of values, the comparison operators return any matching values, or an empty array if there are no matches in the collection. The only way to reliably check if a value is $null is to place $null on the left side of the operator so that a scalar comparison is performed.
PowerShell will perform type casting left to right, resulting in incorrect comparisons when $null is cast to other scalar types.


Ref:
https://github.com/PowerShell/PSScriptAnalyzer/blob/development/RuleDocumentation/PossibleIncorrectComparisonWithNull.md
