### PR TITLE
examples/nanopb_simple: Modify Makefile

### DIFF
--- a/apps/examples/nanopb_simple/Makefile
+++ b/apps/examples/nanopb_simple/Makefile
@@ -53,7 +53,7 @@
 -include $(TOPDIR)/.config
 -include $(TOPDIR)/Make.defs
 include $(APPDIR)/Make.defs
-include $(TOPDIR)/../external/nanopb/nanopb/extra/nanopb.mk
+-include $(TOPDIR)/../external/nanopb/nanopb/extra/nanopb.mk
 
 APPNAME = nanopb_simple
 FUNCNAME = $(APPNAME)_main


### PR DESCRIPTION
NanoPb submodule could not be updated.
In this case, Makefile of nanopb_simple can't include
nanopb/extra/nanopb.mk