### PR TITLE
arch/arm: Add dcache invalidation to imxrt1020 flash driver.

### DIFF
--- a/os/arch/arm/src/imxrt/imxrt_norflash.c
+++ b/os/arch/arm/src/imxrt/imxrt_norflash.c
@@ -774,6 +774,9 @@ status_t imxrt_flexspi_nor_flash_erase_sector(FLEXSPI_Type *base, uint32_t addre
 	}
 
 	status = imxrt_flexspi_nor_wait_bus_busy(base);
+
+	arch_invalidate_dcache(address + IMXRT_FLASH_BASE, address + IMXRT_FLASH_BASE + IMXRT_SECTOR_SIZE);
+
 	irqrestore(flags);
 
 	return status;


### PR DESCRIPTION
- By adding dcache invalidation when erasing flash, MTD_ERASE failures
  which occur rarely disappear.