### PR TITLE
kernel/wdog/wd_start.c : Remove unnecessary code

### DIFF
--- a/os/kernel/wdog/wd_start.c
+++ b/os/kernel/wdog/wd_start.c
@@ -275,13 +275,12 @@ int wd_start(WDOG_ID wdog, int delay, wdentry_t wdentry, int argc, ...)
 #endif
 	va_end(ap);
 
-	/* Calculate delay+1, forcing the delay into a range that we can handle */
+	/* If the delay is zero then assign 1 to the delay */
 
-	if (delay <= 0) {
+	if (delay == 0) {
 		delay = 1;
-	} else if (++delay <= 0) {
-		delay--;
 	}
+
 #ifdef CONFIG_SCHED_TICKLESS
 	/* Cancel the interval timer that drives the timing events.  This will cause
 	 * wd_timer to be called which update the delay value for the first time


### PR DESCRIPTION
If delay value is negative then wd_start return ERROR.
so we don't have to consider negative case.
also in case that ++delay is positive, we must decrease the delay value by one because we already increased delay value.
However I think this overflow check logic is not necessary.
so I remove whole elseif line.