### PR TITLE
os/wqueue : Refactor work queue

### DIFF
--- a/os/include/tinyara/wqueue.h
+++ b/os/include/tinyara/wqueue.h
@@ -387,7 +387,7 @@ int work_lpstart(void);
  *
  ****************************************************************************/
 
-int work_queue(int qid, FAR struct work_s *work, worker_t worker, FAR void *arg, uint32_t delay);
+int work_queue(int qid, FAR struct work_s *work, worker_t worker, FAR void *arg, clock_t delay);
 
 /****************************************************************************
  * Name: work_cancel

--- a/os/wqueue/kwqueue/kwork_queue.c
+++ b/os/wqueue/kwqueue/kwork_queue.c
@@ -56,6 +56,7 @@
 
 #include <tinyara/config.h>
 
+#include <sys/types.h>
 #include <stdint.h>
 #include <queue.h>
 #include <assert.h>
@@ -120,7 +121,7 @@
  *
  ****************************************************************************/
 
-int work_queue(int qid, FAR struct work_s *work, worker_t worker, FAR void *arg, uint32_t delay)
+int work_queue(int qid, FAR struct work_s *work, worker_t worker, FAR void *arg, clock_t delay)
 {
 #if defined(CONFIG_SCHED_HPWORK) || defined(CONFIG_SCHED_LPWORK)
 	int result;

--- a/os/wqueue/uwqueue/uwork_queue.c
+++ b/os/wqueue/uwqueue/uwork_queue.c
@@ -56,6 +56,7 @@
 
 #include <tinyara/config.h>
 
+#include <sys/types.h>
 #include <stdint.h>
 #include <signal.h>
 #include <assert.h>
@@ -120,7 +121,7 @@
  *
  ****************************************************************************/
 
-int work_queue(int qid, FAR struct work_s *work, worker_t worker, FAR void *arg, uint32_t delay)
+int work_queue(int qid, FAR struct work_s *work, worker_t worker, FAR void *arg, clock_t delay)
 {
 	int ret;
 	if (qid == USRWORK) {

--- a/os/wqueue/work_queue.c
+++ b/os/wqueue/work_queue.c
@@ -146,7 +146,7 @@ int work_qqueue(FAR struct wqueue_s *wqueue, FAR struct work_s *work, worker_t w
 
 		if (next_work == NULL) {
 			elapsed = ctick - cur_work->qtime;
-			if (cur_work->delay - elapsed > delay) {
+			if (cur_work->delay > elapsed && cur_work->delay - elapsed > delay) {
 				next_work = cur_work;
 			}
 		}

--- a/os/wqueue/work_queue.c
+++ b/os/wqueue/work_queue.c
@@ -55,6 +55,7 @@
 
 #include <tinyara/config.h>
 
+#include <sys/types.h>
 #include <stdint.h>
 #include <queue.h>
 #include <assert.h>
@@ -115,7 +116,7 @@
  *
  ****************************************************************************/
 
-int work_qqueue(FAR struct wqueue_s *wqueue, FAR struct work_s *work, worker_t worker, FAR void *arg, uint32_t delay)
+int work_qqueue(FAR struct wqueue_s *wqueue, FAR struct work_s *work, worker_t worker, FAR void *arg, clock_t delay)
 {
 	DEBUGASSERT(work != NULL);
 

--- a/os/wqueue/wqueue.h
+++ b/os/wqueue/wqueue.h
@@ -237,7 +237,7 @@ int work_qcancel(FAR struct wqueue_s *wqueue, FAR struct work_s *work);
  *
  ****************************************************************************/
 
-int work_qqueue(FAR struct wqueue_s *wqueue, FAR struct work_s *work, worker_t worker, FAR void *arg, uint32_t delay);
+int work_qqueue(FAR struct wqueue_s *wqueue, FAR struct work_s *work, worker_t worker, FAR void *arg, clock_t delay);
 
 /****************************************************************************
  * Name: work_process


### PR DESCRIPTION
os/wqueue : Check underflow in remaining time

If 'elapsed' is greater than 'cur_work->delay', there is an underflow.
So It must check.

os/wqueue : Modify the 'delay' type

Since the value of 'delay' uses clock, I changed the data type to clock_t.