### PR TITLE
wifi_manager: add dependency in wifi manager config

### DIFF
--- a/framework/src/wifi_manager/Kconfig
+++ b/framework/src/wifi_manager/Kconfig
@@ -7,6 +7,7 @@ config WIFI_MANAGER
     bool "Enable Wi-Fi Manager"
     default n
 	select DRIVERS_WIRELESS
+	select NETUTILS_NETLIB
     ---help---
         Easy APIs for applications to use and control Wi-Fi features
 


### PR DESCRIPTION
add netlib dependency to wifi manager configuration to prevent build
errors