### PR TITLE
kernel/allocateheap : Remove unnecessary heap initialization checking

### DIFF
--- a/os/arch/arm/src/common/up_allocateheap.c
+++ b/os/arch/arm/src/common/up_allocateheap.c
@@ -72,8 +72,6 @@
 #include <tinyara/kmalloc.h>
 #include <tinyara/mm/heap_regioninfo.h>
 
-bool heapx_is_init[CONFIG_MM_NHEAPS];
-
 #if defined(CONFIG_BUILD_PROTECTED) && defined(CONFIG_MM_KERNEL_HEAP)
 #include <string.h>
 #endif
@@ -220,9 +218,8 @@ void up_addregion(void)
 	int region_cnt;
 
 	for (region_cnt = 1; region_cnt < CONFIG_MM_REGIONS; region_cnt++) {
-		if (heapx_is_init[regionx_heap_idx[region_cnt]] != true) {
+		if (BASE_HEAP[regionx_heap_idx[region_cnt]].mm_heapsize == 0) {
 			mm_initialize(&BASE_HEAP[regionx_heap_idx[region_cnt]], regionx_start[region_cnt], regionx_size[region_cnt]);
-			heapx_is_init[regionx_heap_idx[region_cnt]] = true;
 			continue;
 		}
 		mm_addregion(&BASE_HEAP[regionx_heap_idx[region_cnt]], regionx_start[region_cnt], regionx_size[region_cnt]);

--- a/os/arch/xtensa/src/esp32/esp32_allocateheap.c
+++ b/os/arch/xtensa/src/esp32/esp32_allocateheap.c
@@ -70,8 +70,6 @@
 
 #include "xtensa.h"
 
-bool heapx_is_init[CONFIG_MM_NHEAPS];
-
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
@@ -115,9 +113,8 @@ void up_addregion(void)
 	int region_cnt;
 
 	for (region_cnt = 1; region_cnt < CONFIG_MM_REGIONS; region_cnt++) {
-		if (heapx_is_init[regionx_heap_idx[region_cnt]] != true) {
+		if (BASE_HEAP[regionx_heap_idx[region_cnt]].mm_heapsize == 0) {
 			mm_initialize(&g_mmheap[regionx_heap_idx[region_cnt]], regionx_start[region_cnt], regionx_size[region_cnt]);
-			heapx_is_init[regionx_heap_idx[region_cnt]] = true;
 			continue;
 		}
 		mm_addregion(&g_mmheap[regionx_heap_idx[region_cnt]], regionx_start[region_cnt], regionx_size[region_cnt]);

--- a/os/kernel/init/os_start.c
+++ b/os/kernel/init/os_start.c
@@ -98,7 +98,6 @@
 
 extern const uint32_t g_idle_topstack;
 #include <tinyara/mm/heap_regioninfo.h>
-extern bool heapx_is_init[CONFIG_MM_NHEAPS];
 
 /****************************************************************************
  * Pre-processor Definitions
@@ -397,7 +396,6 @@ void os_start(void)
 
 #if CONFIG_MM_REGIONS > 1
 		mm_initialize(&BASE_HEAP[regionx_heap_idx[0]], heap_start, heap_size);
-		heapx_is_init[regionx_heap_idx[0]] = true;
 		up_addregion();
 #else
 		kumm_initialize(heap_start, heap_size);


### PR DESCRIPTION
We can check that heap is initialized or not with heap size. Because, if it is initialized, the size of its heap will not be zero.
So we don't need to use heapx_is_init array anymore.