### PR TITLE
framework/wifi_manager: DHCP bug fix

### DIFF
--- a/framework/src/wifi_manager/wifi_manager.c
+++ b/framework/src/wifi_manager/wifi_manager.c
@@ -733,7 +733,7 @@ wifi_manager_result_e _wifimgr_run_softap(wifi_manager_softap_config_s *config)
 
 	WIFIMGR_CHECK_UTILRESULT(wifi_utils_start_softap(&softap_config), "[WM] Starting softap mode failed.", WIFI_MANAGER_FAIL);
 #ifndef CONFIG_WIFIMGR_DISABLE_DHCPS
-	WIFIMGR_CHECK_RESULT(dhcps_start((dhcp_sta_joined)_wifi_dhcps_event), "[WM] Starting DHCP server failed.\n", WIFI_MANAGER_FAIL);
+	WIFIMGR_CHECK_RESULT(wm_dhcps_start((dhcp_sta_joined)_wifi_dhcps_event), "[WM] Starting DHCP server failed.\n", WIFI_MANAGER_FAIL);
 #endif
 	/* update wifi_manager_info */
 	WIFIMGR_SET_SOFTAP_SSID(config->ssid);
@@ -750,7 +750,7 @@ wifi_manager_result_e _wifimgr_stop_softap(void)
 	WM_LOG_START;
 	WIFIMGR_CHECK_UTILRESULT(wifi_utils_stop_softap(), "[WM] Stoping softap failed", WIFI_MANAGER_FAIL);
 #ifndef CONFIG_WIFIMGR_DISABLE_DHCPS
-	WIFIMGR_CHECK_RESULT(dhcps_stop(), "[WM] Stoping softap DHCP server failed.", WIFI_MANAGER_FAIL);
+	WIFIMGR_CHECK_RESULT(wm_dhcps_stop(), "[WM] Stoping softap DHCP server failed.", WIFI_MANAGER_FAIL);
 #endif
 	return WIFI_MANAGER_SUCCESS;
 }

--- a/framework/src/wifi_manager/wifi_manager_dhcp_internal.c
+++ b/framework/src/wifi_manager/wifi_manager_dhcp_internal.c
@@ -93,7 +93,16 @@ uint8_t dhcps_get_num(void)
 }
 
 #ifndef CONFIG_WIFIMGR_DISABLE_DHCPS
-wifi_manager_result_e dhcps_start(dhcp_sta_joined cb)
+static void _dhcps_remove_list(void)
+{
+	//TODO: Currently only one client can be joined and left
+	g_dhcp_list.ipaddr = 0;
+	for (int i = 0; i < 6; i++) {
+		g_dhcp_list.macaddr[i] = 0;
+	}
+}
+
+wifi_manager_result_e wm_dhcps_start(dhcp_sta_joined cb)
 {
 	//Default IP addr for SoftAP; 192.168.47.1.
 	//Please refer to LWIP_DHCPS_SERVER_IP defined in external/dhcpd/Kconfig
@@ -113,7 +122,7 @@ wifi_manager_result_e dhcps_start(dhcp_sta_joined cb)
 	return WIFI_MANAGER_SUCCESS;
 }
 
-wifi_manager_result_e dhcps_stop(void)
+wifi_manager_result_e wm_dhcps_stop(void)
 {
 	struct in_addr in = { .s_addr = INADDR_NONE };
 	WIFIMGR_SET_IP4ADDR(WIFIMGR_SOFTAP_IFNAME, in, in, in);
@@ -153,15 +162,6 @@ dhcp_status_e dhcps_add_node(void *msg)
 }
 
 void dhcps_del_node(void)
-{
-	//TODO: Currently only one client can be joined and left
-	g_dhcp_list.ipaddr = 0;
-	for (int i = 0; i < 6; i++) {
-		g_dhcp_list.macaddr[i] = 0;
-	}
-}
-
-static void _dhcps_remove_list(void)
 {
 	//TODO: Currently only one client can be joined and left
 	g_dhcp_list.ipaddr = 0;

--- a/framework/src/wifi_manager/wifi_manager_dhcp_internal.h
+++ b/framework/src/wifi_manager/wifi_manager_dhcp_internal.h
@@ -47,15 +47,14 @@ void dhcps_reset_num(void);
 uint8_t dhcps_get_num(void);
 
 #ifndef CONFIG_WIFIMGR_DISABLE_DHCPS
-wifi_manager_result_e dhcps_start(dhcp_sta_joined cb);
-wifi_manager_result_e dhcps_stop(void);
+wifi_manager_result_e wm_dhcps_start(dhcp_sta_joined cb);
+wifi_manager_result_e wm_dhcps_stop(void);
 /* TODO: Currently, wifi manager stores only a single mac address of the associated node
  * while it is running as a softap mode. This might be modified later,
  * when a chipset needs to support multiple connections simultaneously.
  */
 dhcp_status_e dhcps_add_node(void *node);
 void dhcps_del_node(void);
-static void _dhcps_remove_list(void);
 #endif
 
 #ifndef CONFIG_WIFIMGR_DISABLE_DHCPC


### PR DESCRIPTION
- Rename dhcps_start/stop to solve conflict with lwip dhcp function names
- Remove static predef in header