### PR TITLE
os: Refine caching logic for improved loading time

### DIFF
--- a/os/binfmt/libelf/libelf_cache.c
+++ b/os/binfmt/libelf/libelf_cache.c
@@ -105,7 +105,6 @@ static off_t elf_cache_lseek_block(int filfd, uint16_t binary_header_size, int b
 
 	actual_offset = binary_header_size + block_number * cache_blocks_size;
 
-#ifndef CONFIG_COMPRESSED_BINARY
 	/* Seek to location of this block in actual ELF file */
 	rpos = lseek(filfd, actual_offset, SEEK_SET);
 
@@ -116,10 +115,6 @@ static off_t elf_cache_lseek_block(int filfd, uint16_t binary_header_size, int b
 		berr("Failed to seek to position %lu: %d\n", (unsigned long)actual_offset, errval);
 		return -errval;
 	}
-
-#else
-	rpos = actual_offset;
-#endif
 
 	return rpos;
 }
@@ -143,8 +138,21 @@ static off_t elf_cache_read_block(int filfd, uint16_t binary_header_size, FAR ui
 
 	binfo("filfd: %d block_number: %d binary_header_size: %d\n", filfd, block_number, binary_header_size);
 
-	/* Seek to location of 'block_number' block in elf file */
-	rpos = elf_cache_lseek_block(filfd, binary_header_size, block_number);
+	/* Seek to location of 'block_number' block in elf file for uncompressed elf */
+	if (elf_compress_type == COMPRESS_TYPE_NONE) {
+		rpos = elf_cache_lseek_block(filfd, binary_header_size, block_number);
+	}
+#ifdef CONFIG_COMPRESSED_BINARY
+	else {
+		if (elf_compress_type == CONFIG_COMPRESSION_TYPE) {
+			rpos = binary_header_size + (block_number * cache_blocks_size);
+		} else {
+			berr("No support for decompression of compression format %d of this binary\n", elf_compress_type);
+			return ERROR;
+		}
+	}
+#endif
+
 
 	if (rpos < 0) {
 		berr("Failed to seek to offset of block number %d\n", block_number);
@@ -169,6 +177,7 @@ static off_t elf_cache_read_block(int filfd, uint16_t binary_header_size, FAR ui
 			nbytes = compress_read(filfd, binary_header_size, buf, readsize, rpos - binary_header_size);
 		} else {
 			berr("No support for decompression of compression format %d of this binary\n", elf_compress_type);
+			return ERROR;
 		}
 	}
 #endif

--- a/os/binfmt/libelf/libelf_cache.c
+++ b/os/binfmt/libelf/libelf_cache.c
@@ -478,6 +478,11 @@ int elf_cache_init(int filfd, uint16_t offset, off_t filelen, uint8_t compressio
 		number_blocks_caching++;
 	}
 
+	/* Minimum 2 blocks needed for caching logic to work */
+	if (number_blocks_caching < 2) {
+		number_blocks_caching = 2;
+	}
+
 	/* Initialize max_accesed_count to 0 */
 	max_accessed_count = 0;
 

--- a/os/compression/compress_read.c
+++ b/os/compression/compress_read.c
@@ -95,7 +95,7 @@ static void compress_blocks_to_read(int *first_block, int *last_block, int *no_b
 	blocksize = compression_header->blocksize;
 
 	*first_block = offset / blocksize;
-	*last_block = (offset + readsize) / blocksize;
+	*last_block = (offset + readsize - 1) / blocksize;
 	*no_blocks = *last_block - *first_block + 1;
 }
 


### PR DESCRIPTION
This PR contains below changes:
- Removes caching of large readsize requests.
- Removes an unnecessary file seek from compressed elf loading
- Removes needless caching of one additional block for compressed elf loading
- Adds check for minimum number of blocks needed for caching.

Together, they significantly reduce loading time for uncompressed/compressed elfs.