### PR TITLE
build/configs: Add meta files to support esp32 boards on RT IDE

### DIFF
--- a/build/configs/esp32_DevKitC/.buildSpec.xml
+++ b/build/configs/esp32_DevKitC/.buildSpec.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2019 Samsung Electronics All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ either express or implied. See the License for the specific
+ language governing permissions and limitations under the License.
+-->
+<!--
+    predefined macro values:
+    * BOARD - selected board name by UI
+    * BUILD_OPTION - selected build option by UI
+    * TOOLCHAIN_PATH - user defined toolchain path by UI
+-->
+<build name="esp32_DevKitC">
+    <!-- path attribute value must be relative path from project root -->
+    <!-- Don't touch command name. IDE use command with name -->
+    <commands>
+        <command name="config" command="./configure.sh" path="${PROJECT_PATH}/os/tools" shellcmd="true">
+            <param name="buildOption" value="${BOARD}/${BUILD_OPTION}"/>
+        </command>
+        <command name="build" command="make" path="${PROJECT_PATH}/os" shellcmd="true">
+            <param name="V" value="V=3"/>
+        </command>
+        <command name="buildWithToolchain" command=". ./setenv.sh ${TOOLCHAIN_PATH};make V=1" path="${PROJECT_PATH}/os" shellcmd="true" shell="/bin/bash"/>
+        <command name="clean" command="make clean" path="${PROJECT_PATH}/os" shellcmd="true">
+            <param name="clean" value="clean"/>
+        </command>
+        <command name="distclean" command="make distclean" path="${PROJECT_PATH}/os" shellcmd="true">
+            <param name="distclean" value="distclean"/>
+        </command>
+    </commands>
+    <executors> <!-- execute command sequentially on build -->
+        <executor name="linux default executor" os="linux" bit="all">
+            <commandref name="config"/>
+            <commandref name="build"/>
+        </executor>
+    </executors>
+</build>

--- a/build/configs/esp32_DevKitC/.flashSpec.xml
+++ b/build/configs/esp32_DevKitC/.flashSpec.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2019 Samsung Electronics All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ either express or implied. See the License for the specific
+ language governing permissions and limitations under the License.
+-->
+<flash name="esp32_DevKitC flash" virtual="false">
+    <!-- path attribute value must be relative path from project root -->
+    <executors>
+        <execute name="flash" path="${PROJECT_PATH}/os" command="make download" os="linux" bit="all"></execute>
+    </executors>
+    <options>
+        <option desc="Flash all binaries and images">ALL</option>
+        <option desc="Flash TizenRT binary">OS</option>
+        <option desc="Flash Bootloader binaries">BOOTLOADER</option>
+        <option desc="Flash ROMFS image">ROMFS</option>
+        <option desc="Erase all of partitions">ERASE_ALL</option>
+    </options>
+</flash>

--- a/build/configs/esp_wrover_kit/.buildSpec.xml
+++ b/build/configs/esp_wrover_kit/.buildSpec.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2019 Samsung Electronics All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ either express or implied. See the License for the specific
+ language governing permissions and limitations under the License.
+-->
+<!--
+    predefined macro values:
+    * BOARD - selected board name by UI
+    * BUILD_OPTION - selected build option by UI
+    * TOOLCHAIN_PATH - user defined toolchain path by UI
+-->
+<build name="esp_wrover_kit">
+    <!-- path attribute value must be relative path from project root -->
+    <!-- Don't touch command name. IDE use command with name -->
+    <commands>
+        <command name="config" command="./configure.sh" path="${PROJECT_PATH}/os/tools" shellcmd="true">
+            <param name="buildOption" value="${BOARD}/${BUILD_OPTION}"/>
+        </command>
+        <command name="build" command="make" path="${PROJECT_PATH}/os" shellcmd="true">
+            <param name="V" value="V=3"/>
+        </command>
+        <command name="buildWithToolchain" command=". ./setenv.sh ${TOOLCHAIN_PATH};make V=1" path="${PROJECT_PATH}/os" shellcmd="true" shell="/bin/bash"/>
+        <command name="clean" command="make clean" path="${PROJECT_PATH}/os" shellcmd="true">
+            <param name="clean" value="clean"/>
+        </command>
+        <command name="distclean" command="make distclean" path="${PROJECT_PATH}/os" shellcmd="true">
+            <param name="distclean" value="distclean"/>
+        </command>
+    </commands>
+    <executors> <!-- execute command sequentially on build -->
+        <executor name="linux default executor" os="linux" bit="all">
+            <commandref name="config"/>
+            <commandref name="build"/>
+        </executor>
+    </executors>
+</build>

--- a/build/configs/esp_wrover_kit/.flashSpec.xml
+++ b/build/configs/esp_wrover_kit/.flashSpec.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2019 Samsung Electronics All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ either express or implied. See the License for the specific
+ language governing permissions and limitations under the License.
+-->
+<flash name="esp_wrover_kit flash" virtual="false">
+    <!-- path attribute value must be relative path from project root -->
+    <executors>
+        <execute name="flash" path="${PROJECT_PATH}/os" command="make download" os="linux" bit="all"></execute>
+    </executors>
+    <options>
+        <option desc="Flash all binaries and images">ALL</option>
+        <option desc="Flash TizenRT binary">OS</option>
+        <option desc="Flash Bootloader binaries">BOOTLOADER</option>
+        <option desc="Flash ROMFS image">ROMFS</option>
+        <option desc="Erase all of partitions">ERASE_ALL</option>
+    </options>
+</flash>


### PR DESCRIPTION
To support build and flash project with Tizen Studio RT IDE on esp32 boards.
(co-work with PR #4023)
