### PR TITLE
fs/recovery : remove unnecessary errno

### DIFF
--- a/os/fs/smartfs/smartfs_utils.c
+++ b/os/fs/smartfs/smartfs_utils.c
@@ -1762,7 +1762,6 @@ int smartfs_examine_sector(struct smartfs_mountpt_s *fs, char *validsectors, int
 			readwrite.count = fs->fs_llformat.availbytes;
 			ret = FS_IOCTL(fs, BIOC_READSECT, (unsigned long)&readwrite);
 			if (ret < 0) {
-				ret = -EINVAL_SECTOR;
 				fdbg("Error %d reading sector %d data\n", ret, logsector);
 				goto errout;
 			}

--- a/os/include/errno.h
+++ b/os/include/errno.h
@@ -407,8 +407,6 @@
 #define EMEDIUMTYPE_STR     "Wrong medium type"
 #define ECANCELED           125
 #define ECANCELED_STR       "Operation cancelled"
-#define EINVAL_SECTOR       126
-#define EINVAL_SECTOR_STR   "Invalid sector"
 #define EOWNERDEAD          142
 #define EOWNERDEAD_STR      "Previous owner died"
 


### PR DESCRIPTION
Remove EINVAL_SECTOR from errno which is not defined in linux