### PR TITLE
os/dbuild.sh : fix build error

### DIFF
--- a/os/dbuild.sh
+++ b/os/dbuild.sh
@@ -436,7 +436,7 @@ else
 				ARG=$1
 			fi
 		else
-			ARG=$(echo $1 | tr '[:upper:]' '[:lower:]')
+			ARG=$1
 		fi
 		case ${STATUS} in
 		NOT_CONFIGURED)


### PR DESCRIPTION
In previous version, build error occured because the board name passed as an argument is changed to lowercase.
for example esp32_DevKitC is changed to esp32_devkitc.