### PR TITLE
external/libcxx-test : Add include for 'test_macros.h'

### DIFF
--- a/external/libcxx-test/std/algorithms/alg.sorting/alg.min.max/max_element.pass.cpp
+++ b/external/libcxx-test/std/algorithms/alg.sorting/alg.min.max/max_element.pass.cpp
@@ -36,6 +36,7 @@
 #include <cassert>
 
 #include "test_iterators.h"
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 static std::mt19937 randomness;

--- a/external/libcxx-test/std/algorithms/alg.sorting/alg.min.max/min_element.pass.cpp
+++ b/external/libcxx-test/std/algorithms/alg.sorting/alg.min.max/min_element.pass.cpp
@@ -36,6 +36,7 @@
 #include <cassert>
 
 #include "test_iterators.h"
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 static std::mt19937 randomness;

--- a/external/libcxx-test/std/algorithms/alg.sorting/alg.min.max/minmax_element.pass.cpp
+++ b/external/libcxx-test/std/algorithms/alg.sorting/alg.min.max/minmax_element.pass.cpp
@@ -36,6 +36,7 @@
 #include <cassert>
 
 #include "test_iterators.h"
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 static std::mt19937 randomness;

--- a/external/libcxx-test/std/containers/associative/map/map.access/empty.pass.cpp
+++ b/external/libcxx-test/std/containers/associative/map/map.access/empty.pass.cpp
@@ -32,6 +32,7 @@
 
 #include <map>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 int tc_libcxx_containers_map_access_empty(void)

--- a/external/libcxx-test/std/containers/associative/map/map.access/size.pass.cpp
+++ b/external/libcxx-test/std/containers/associative/map/map.access/size.pass.cpp
@@ -32,6 +32,7 @@
 
 #include <map>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 

--- a/external/libcxx-test/std/containers/associative/map/map.cons/alloc.pass.cpp
+++ b/external/libcxx-test/std/containers/associative/map/map.cons/alloc.pass.cpp
@@ -34,6 +34,7 @@
 #include <cassert>
 #include "libcxx_tc_common.h"
 
+#include "test_macros.h"
 #include "test_allocator.h"
 
 int tc_libcxx_containers_map_cons_alloc(void)

--- a/external/libcxx-test/std/containers/associative/map/map.cons/compare.pass.cpp
+++ b/external/libcxx-test/std/containers/associative/map/map.cons/compare.pass.cpp
@@ -36,6 +36,7 @@
 #include <cassert>
 #include "libcxx_tc_common.h"
 
+#include "test_macros.h"
 #include "test_compare.h"
 
 int tc_libcxx_containers_map_cons_compare(void)

--- a/external/libcxx-test/std/containers/associative/map/map.cons/compare_alloc.pass.cpp
+++ b/external/libcxx-test/std/containers/associative/map/map.cons/compare_alloc.pass.cpp
@@ -34,6 +34,7 @@
 #include <cassert>
 #include "libcxx_tc_common.h"
 
+#include "test_macros.h"
 #include "test_compare.h"
 #include "test_allocator.h"
 

--- a/external/libcxx-test/std/containers/associative/map/map.cons/copy_alloc.pass.cpp
+++ b/external/libcxx-test/std/containers/associative/map/map.cons/copy_alloc.pass.cpp
@@ -34,6 +34,7 @@
 #include <cassert>
 #include "libcxx_tc_common.h"
 
+#include "test_macros.h"
 #include "test_compare.h"
 #include "test_allocator.h"
 

--- a/external/libcxx-test/std/containers/associative/map/map.cons/default.pass.cpp
+++ b/external/libcxx-test/std/containers/associative/map/map.cons/default.pass.cpp
@@ -32,6 +32,7 @@
 
 #include <map>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 

--- a/external/libcxx-test/std/containers/associative/map/map.cons/default_recursive.pass.cpp
+++ b/external/libcxx-test/std/containers/associative/map/map.cons/default_recursive.pass.cpp
@@ -31,6 +31,7 @@
 // map();
 
 #include <map>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 struct X
 {

--- a/external/libcxx-test/std/containers/associative/map/map.cons/initializer_list.pass.cpp
+++ b/external/libcxx-test/std/containers/associative/map/map.cons/initializer_list.pass.cpp
@@ -34,6 +34,7 @@
 
 #include <map>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 int tc_libcxx_containers_map_cons_initializer_list(void)

--- a/external/libcxx-test/std/containers/associative/map/map.cons/initializer_list_compare.pass.cpp
+++ b/external/libcxx-test/std/containers/associative/map/map.cons/initializer_list_compare.pass.cpp
@@ -34,6 +34,7 @@
 
 #include <map>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 #include "test_compare.h"
 

--- a/external/libcxx-test/std/containers/associative/map/map.cons/initializer_list_compare_alloc.pass.cpp
+++ b/external/libcxx-test/std/containers/associative/map/map.cons/initializer_list_compare_alloc.pass.cpp
@@ -34,6 +34,7 @@
 
 #include <map>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 #include "test_compare.h"
 #include "test_allocator.h"

--- a/external/libcxx-test/std/containers/associative/map/map.cons/iter_iter.pass.cpp
+++ b/external/libcxx-test/std/containers/associative/map/map.cons/iter_iter.pass.cpp
@@ -33,6 +33,7 @@
 
 #include <map>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 

--- a/external/libcxx-test/std/containers/associative/map/map.cons/iter_iter_comp.pass.cpp
+++ b/external/libcxx-test/std/containers/associative/map/map.cons/iter_iter_comp.pass.cpp
@@ -33,6 +33,7 @@
 
 #include <map>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 #include "test_compare.h"

--- a/external/libcxx-test/std/containers/associative/map/map.cons/move.pass.cpp
+++ b/external/libcxx-test/std/containers/associative/map/map.cons/move.pass.cpp
@@ -34,6 +34,7 @@
 
 #include <map>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 #include "test_compare.h"

--- a/external/libcxx-test/std/containers/associative/map/map.cons/move_alloc.pass.cpp
+++ b/external/libcxx-test/std/containers/associative/map/map.cons/move_alloc.pass.cpp
@@ -34,6 +34,7 @@
 
 #include <map>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 #include "MoveOnly.h"

--- a/external/libcxx-test/std/containers/associative/map/map.cons/move_assign.pass.cpp
+++ b/external/libcxx-test/std/containers/associative/map/map.cons/move_assign.pass.cpp
@@ -34,6 +34,7 @@
 
 #include <map>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 #include "MoveOnly.h"

--- a/external/libcxx-test/std/containers/associative/map/map.modifiers/clear.pass.cpp
+++ b/external/libcxx-test/std/containers/associative/map/map.modifiers/clear.pass.cpp
@@ -32,6 +32,7 @@
 
 #include <map>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 

--- a/external/libcxx-test/std/containers/associative/map/map.modifiers/emplace.pass.cpp
+++ b/external/libcxx-test/std/containers/associative/map/map.modifiers/emplace.pass.cpp
@@ -35,6 +35,7 @@
 
 #include <map>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 #include <tuple>
 

--- a/external/libcxx-test/std/containers/associative/map/map.modifiers/emplace_hint.pass.cpp
+++ b/external/libcxx-test/std/containers/associative/map/map.modifiers/emplace_hint.pass.cpp
@@ -35,6 +35,7 @@
 
 #include <map>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 #include "Emplaceable.h"

--- a/external/libcxx-test/std/containers/associative/map/map.modifiers/erase_iter_iter.pass.cpp
+++ b/external/libcxx-test/std/containers/associative/map/map.modifiers/erase_iter_iter.pass.cpp
@@ -32,6 +32,7 @@
 
 #include <map>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 

--- a/external/libcxx-test/std/containers/associative/map/map.modifiers/erase_key.pass.cpp
+++ b/external/libcxx-test/std/containers/associative/map/map.modifiers/erase_key.pass.cpp
@@ -32,6 +32,7 @@
 
 #include <map>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 int tc_libcxx_containers_map_modifiers_erase_key(void)

--- a/external/libcxx-test/std/containers/associative/map/map.modifiers/insert_iter_iter.pass.cpp
+++ b/external/libcxx-test/std/containers/associative/map/map.modifiers/insert_iter_iter.pass.cpp
@@ -33,6 +33,7 @@
 
 #include <map>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 #include "test_iterators.h"

--- a/external/libcxx-test/std/containers/associative/map/types.pass.cpp
+++ b/external/libcxx-test/std/containers/associative/map/types.pass.cpp
@@ -48,6 +48,7 @@
 
 #include <map>
 #include <type_traits>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 int tc_libcxx_containers_map_types(void)

--- a/external/libcxx-test/std/containers/associative/multimap/multimap.cons/alloc.pass.cpp
+++ b/external/libcxx-test/std/containers/associative/multimap/multimap.cons/alloc.pass.cpp
@@ -32,6 +32,7 @@
 
 #include <map>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 #include "test_allocator.h"

--- a/external/libcxx-test/std/containers/associative/multimap/multimap.cons/assign_initializer_list.pass.cpp
+++ b/external/libcxx-test/std/containers/associative/multimap/multimap.cons/assign_initializer_list.pass.cpp
@@ -34,6 +34,7 @@
 
 #include <map>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 

--- a/external/libcxx-test/std/containers/associative/multimap/multimap.cons/compare.pass.cpp
+++ b/external/libcxx-test/std/containers/associative/multimap/multimap.cons/compare.pass.cpp
@@ -34,6 +34,7 @@
 
 #include <map>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 #include "test_compare.h"

--- a/external/libcxx-test/std/containers/associative/multimap/multimap.cons/compare_alloc.pass.cpp
+++ b/external/libcxx-test/std/containers/associative/multimap/multimap.cons/compare_alloc.pass.cpp
@@ -32,6 +32,7 @@
 
 #include <map>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 #include "test_compare.h"

--- a/external/libcxx-test/std/containers/associative/multimap/multimap.cons/copy_alloc.pass.cpp
+++ b/external/libcxx-test/std/containers/associative/multimap/multimap.cons/copy_alloc.pass.cpp
@@ -32,6 +32,7 @@
 
 #include <map>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 #include "test_compare.h"

--- a/external/libcxx-test/std/containers/associative/multimap/multimap.cons/copy_assign.pass.cpp
+++ b/external/libcxx-test/std/containers/associative/multimap/multimap.cons/copy_assign.pass.cpp
@@ -32,6 +32,7 @@
 
 #include <map>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 #include "test_compare.h"

--- a/external/libcxx-test/std/containers/associative/multimap/multimap.cons/initializer_list.pass.cpp
+++ b/external/libcxx-test/std/containers/associative/multimap/multimap.cons/initializer_list.pass.cpp
@@ -34,6 +34,7 @@
 
 #include <map>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 

--- a/external/libcxx-test/std/containers/associative/multimap/multimap.cons/initializer_list_compare.pass.cpp
+++ b/external/libcxx-test/std/containers/associative/multimap/multimap.cons/initializer_list_compare.pass.cpp
@@ -34,6 +34,7 @@
 
 #include <map>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 #include "test_compare.h"
 

--- a/external/libcxx-test/std/containers/associative/multimap/multimap.cons/initializer_list_compare_alloc.pass.cpp
+++ b/external/libcxx-test/std/containers/associative/multimap/multimap.cons/initializer_list_compare_alloc.pass.cpp
@@ -34,6 +34,7 @@
 
 #include <map>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 #include "test_compare.h"
 #include "test_allocator.h"

--- a/external/libcxx-test/std/containers/associative/multimap/multimap.cons/iter_iter_comp.pass.cpp
+++ b/external/libcxx-test/std/containers/associative/multimap/multimap.cons/iter_iter_comp.pass.cpp
@@ -34,6 +34,7 @@
 
 #include <map>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 #include "test_compare.h"

--- a/external/libcxx-test/std/containers/associative/multimap/multimap.cons/iter_iter_comp_alloc.pass.cpp
+++ b/external/libcxx-test/std/containers/associative/multimap/multimap.cons/iter_iter_comp_alloc.pass.cpp
@@ -34,6 +34,7 @@
 
 #include <map>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 #include "test_compare.h"

--- a/external/libcxx-test/std/containers/associative/multimap/multimap.cons/move_alloc.pass.cpp
+++ b/external/libcxx-test/std/containers/associative/multimap/multimap.cons/move_alloc.pass.cpp
@@ -34,6 +34,7 @@
 
 #include <map>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 #include "MoveOnly.h"

--- a/external/libcxx-test/std/containers/associative/multimap/multimap.cons/move_assign.pass.cpp
+++ b/external/libcxx-test/std/containers/associative/multimap/multimap.cons/move_assign.pass.cpp
@@ -34,6 +34,7 @@
 
 #include <map>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 #include "MoveOnly.h"

--- a/external/libcxx-test/std/containers/associative/multimap/multimap.modifiers/clear.pass.cpp
+++ b/external/libcxx-test/std/containers/associative/multimap/multimap.modifiers/clear.pass.cpp
@@ -32,6 +32,7 @@
 
 #include <map>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 int tc_libcxx_containers_multimap_modifiers_clear(void)

--- a/external/libcxx-test/std/containers/associative/multimap/multimap.modifiers/emplace.pass.cpp
+++ b/external/libcxx-test/std/containers/associative/multimap/multimap.modifiers/emplace.pass.cpp
@@ -35,6 +35,7 @@
 
 #include <map>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 #include "Emplaceable.h"

--- a/external/libcxx-test/std/containers/associative/multimap/multimap.modifiers/emplace_hint.pass.cpp
+++ b/external/libcxx-test/std/containers/associative/multimap/multimap.modifiers/emplace_hint.pass.cpp
@@ -35,6 +35,7 @@
 
 #include <map>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 #include "Emplaceable.h"

--- a/external/libcxx-test/std/containers/associative/multimap/multimap.modifiers/erase_iter_iter.pass.cpp
+++ b/external/libcxx-test/std/containers/associative/multimap/multimap.modifiers/erase_iter_iter.pass.cpp
@@ -32,6 +32,7 @@
 
 #include <map>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 int tc_libcxx_containers_multimap_modifiers_erase_iter_iter(void)

--- a/external/libcxx-test/std/containers/associative/multimap/multimap.modifiers/erase_key.pass.cpp
+++ b/external/libcxx-test/std/containers/associative/multimap/multimap.modifiers/erase_key.pass.cpp
@@ -32,6 +32,7 @@
 
 #include <map>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 

--- a/external/libcxx-test/std/containers/associative/multimap/multimap.modifiers/insert_initializer_list.pass.cpp
+++ b/external/libcxx-test/std/containers/associative/multimap/multimap.modifiers/insert_initializer_list.pass.cpp
@@ -34,6 +34,7 @@
 
 #include <map>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 int tc_libcxx_containers_multimap_modifiers_insert_initializer_list(void)

--- a/external/libcxx-test/std/containers/associative/multimap/multimap.modifiers/insert_iter_iter.pass.cpp
+++ b/external/libcxx-test/std/containers/associative/multimap/multimap.modifiers/insert_iter_iter.pass.cpp
@@ -33,6 +33,7 @@
 
 #include <map>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 #include "test_iterators.h"

--- a/external/libcxx-test/std/containers/associative/multimap/size.pass.cpp
+++ b/external/libcxx-test/std/containers/associative/multimap/size.pass.cpp
@@ -32,6 +32,7 @@
 
 #include <map>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 

--- a/external/libcxx-test/std/containers/associative/multimap/types.pass.cpp
+++ b/external/libcxx-test/std/containers/associative/multimap/types.pass.cpp
@@ -48,6 +48,7 @@
 
 #include <map>
 #include <type_traits>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 int tc_libcxx_containers_multimap_types(void)

--- a/external/libcxx-test/std/containers/sequences/forwardlist/forwardlist.access/front.pass.cpp
+++ b/external/libcxx-test/std/containers/sequences/forwardlist/forwardlist.access/front.pass.cpp
@@ -31,6 +31,7 @@
 
 #include <forward_list>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 #include <iterator>
 

--- a/external/libcxx-test/std/containers/sequences/forwardlist/forwardlist.cons/alloc.pass.cpp
+++ b/external/libcxx-test/std/containers/sequences/forwardlist/forwardlist.cons/alloc.pass.cpp
@@ -30,6 +30,7 @@
 
 #include <forward_list>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 #include "test_allocator.h"

--- a/external/libcxx-test/std/containers/sequences/forwardlist/forwardlist.cons/assign_copy.pass.cpp
+++ b/external/libcxx-test/std/containers/sequences/forwardlist/forwardlist.cons/assign_copy.pass.cpp
@@ -30,6 +30,7 @@
 
 #include <forward_list>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 #include <iterator>
 

--- a/external/libcxx-test/std/containers/sequences/forwardlist/forwardlist.cons/assign_init.pass.cpp
+++ b/external/libcxx-test/std/containers/sequences/forwardlist/forwardlist.cons/assign_init.pass.cpp
@@ -32,6 +32,7 @@
 
 #include <forward_list>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 #include <iterator>
 

--- a/external/libcxx-test/std/containers/sequences/forwardlist/forwardlist.cons/assign_move.pass.cpp
+++ b/external/libcxx-test/std/containers/sequences/forwardlist/forwardlist.cons/assign_move.pass.cpp
@@ -32,6 +32,7 @@
 
 #include <forward_list>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 #include <iterator>
 

--- a/external/libcxx-test/std/containers/sequences/forwardlist/forwardlist.cons/assign_op_init.pass.cpp
+++ b/external/libcxx-test/std/containers/sequences/forwardlist/forwardlist.cons/assign_op_init.pass.cpp
@@ -32,6 +32,7 @@
 
 #include <forward_list>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 #include <iterator>
 

--- a/external/libcxx-test/std/containers/sequences/forwardlist/forwardlist.cons/assign_range.pass.cpp
+++ b/external/libcxx-test/std/containers/sequences/forwardlist/forwardlist.cons/assign_range.pass.cpp
@@ -31,6 +31,7 @@
 
 #include <forward_list>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 #include <iterator>
 

--- a/external/libcxx-test/std/containers/sequences/forwardlist/forwardlist.cons/assign_size_value.pass.cpp
+++ b/external/libcxx-test/std/containers/sequences/forwardlist/forwardlist.cons/assign_size_value.pass.cpp
@@ -30,6 +30,7 @@
 
 #include <forward_list>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 #include <iterator>
 

--- a/external/libcxx-test/std/containers/sequences/forwardlist/forwardlist.cons/copy_alloc.pass.cpp
+++ b/external/libcxx-test/std/containers/sequences/forwardlist/forwardlist.cons/copy_alloc.pass.cpp
@@ -30,6 +30,7 @@
 
 #include <forward_list>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 #include <iterator>
 

--- a/external/libcxx-test/std/containers/sequences/forwardlist/forwardlist.cons/init.pass.cpp
+++ b/external/libcxx-test/std/containers/sequences/forwardlist/forwardlist.cons/init.pass.cpp
@@ -32,6 +32,7 @@
 
 #include <forward_list>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 

--- a/external/libcxx-test/std/containers/sequences/forwardlist/forwardlist.cons/init_alloc.pass.cpp
+++ b/external/libcxx-test/std/containers/sequences/forwardlist/forwardlist.cons/init_alloc.pass.cpp
@@ -32,6 +32,7 @@
 
 #include <forward_list>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 #include "test_allocator.h"

--- a/external/libcxx-test/std/containers/sequences/forwardlist/forwardlist.cons/move.pass.cpp
+++ b/external/libcxx-test/std/containers/sequences/forwardlist/forwardlist.cons/move.pass.cpp
@@ -32,6 +32,7 @@
 
 #include <forward_list>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 #include <iterator>
 

--- a/external/libcxx-test/std/containers/sequences/forwardlist/forwardlist.cons/move_alloc.pass.cpp
+++ b/external/libcxx-test/std/containers/sequences/forwardlist/forwardlist.cons/move_alloc.pass.cpp
@@ -32,6 +32,7 @@
 
 #include <forward_list>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 #include <iterator>
 

--- a/external/libcxx-test/std/containers/sequences/forwardlist/forwardlist.cons/range.pass.cpp
+++ b/external/libcxx-test/std/containers/sequences/forwardlist/forwardlist.cons/range.pass.cpp
@@ -31,6 +31,7 @@
 
 #include <forward_list>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 #include <iterator>
 

--- a/external/libcxx-test/std/containers/sequences/forwardlist/forwardlist.cons/range_alloc.pass.cpp
+++ b/external/libcxx-test/std/containers/sequences/forwardlist/forwardlist.cons/range_alloc.pass.cpp
@@ -32,6 +32,7 @@
 
 #include <forward_list>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 #include <iterator>
 

--- a/external/libcxx-test/std/containers/sequences/forwardlist/forwardlist.cons/size_value.pass.cpp
+++ b/external/libcxx-test/std/containers/sequences/forwardlist/forwardlist.cons/size_value.pass.cpp
@@ -30,6 +30,7 @@
 
 #include <forward_list>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 

--- a/external/libcxx-test/std/containers/sequences/forwardlist/forwardlist.cons/size_value_alloc.pass.cpp
+++ b/external/libcxx-test/std/containers/sequences/forwardlist/forwardlist.cons/size_value_alloc.pass.cpp
@@ -30,6 +30,7 @@
 
 #include <forward_list>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 #include "test_allocator.h"

--- a/external/libcxx-test/std/containers/sequences/forwardlist/forwardlist.iter/before_begin.pass.cpp
+++ b/external/libcxx-test/std/containers/sequences/forwardlist/forwardlist.iter/before_begin.pass.cpp
@@ -32,6 +32,7 @@
 
 #include <forward_list>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 #include <iterator>
 

--- a/external/libcxx-test/std/containers/sequences/forwardlist/forwardlist.modifiers/clear.pass.cpp
+++ b/external/libcxx-test/std/containers/sequences/forwardlist/forwardlist.modifiers/clear.pass.cpp
@@ -30,6 +30,7 @@
 
 #include <forward_list>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 #include "NotConstructible.h"

--- a/external/libcxx-test/std/containers/sequences/forwardlist/forwardlist.modifiers/emplace_after.pass.cpp
+++ b/external/libcxx-test/std/containers/sequences/forwardlist/forwardlist.modifiers/emplace_after.pass.cpp
@@ -33,6 +33,7 @@
 
 #include <forward_list>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 #include "Emplaceable.h"

--- a/external/libcxx-test/std/containers/sequences/forwardlist/forwardlist.modifiers/erase_after_many.pass.cpp
+++ b/external/libcxx-test/std/containers/sequences/forwardlist/forwardlist.modifiers/erase_after_many.pass.cpp
@@ -30,6 +30,7 @@
 
 #include <forward_list>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 

--- a/external/libcxx-test/std/containers/sequences/forwardlist/forwardlist.modifiers/erase_after_one.pass.cpp
+++ b/external/libcxx-test/std/containers/sequences/forwardlist/forwardlist.modifiers/erase_after_one.pass.cpp
@@ -30,6 +30,7 @@
 
 #include <forward_list>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 

--- a/external/libcxx-test/std/containers/sequences/forwardlist/forwardlist.modifiers/insert_after_const.pass.cpp
+++ b/external/libcxx-test/std/containers/sequences/forwardlist/forwardlist.modifiers/insert_after_const.pass.cpp
@@ -30,6 +30,7 @@
 
 #include <forward_list>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 

--- a/external/libcxx-test/std/containers/sequences/forwardlist/forwardlist.modifiers/insert_after_init.pass.cpp
+++ b/external/libcxx-test/std/containers/sequences/forwardlist/forwardlist.modifiers/insert_after_init.pass.cpp
@@ -32,6 +32,7 @@
 
 #include <forward_list>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 

--- a/external/libcxx-test/std/containers/sequences/forwardlist/forwardlist.modifiers/insert_after_range.pass.cpp
+++ b/external/libcxx-test/std/containers/sequences/forwardlist/forwardlist.modifiers/insert_after_range.pass.cpp
@@ -32,6 +32,7 @@
 
 #include <forward_list>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 #include "test_iterators.h"

--- a/external/libcxx-test/std/containers/sequences/forwardlist/forwardlist.modifiers/insert_after_rv.pass.cpp
+++ b/external/libcxx-test/std/containers/sequences/forwardlist/forwardlist.modifiers/insert_after_rv.pass.cpp
@@ -32,6 +32,7 @@
 
 #include <forward_list>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 #include "MoveOnly.h"

--- a/external/libcxx-test/std/containers/sequences/forwardlist/forwardlist.modifiers/insert_after_size_value.pass.cpp
+++ b/external/libcxx-test/std/containers/sequences/forwardlist/forwardlist.modifiers/insert_after_size_value.pass.cpp
@@ -30,6 +30,7 @@
 
 #include <forward_list>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 

--- a/external/libcxx-test/std/containers/sequences/forwardlist/forwardlist.modifiers/pop_front.pass.cpp
+++ b/external/libcxx-test/std/containers/sequences/forwardlist/forwardlist.modifiers/pop_front.pass.cpp
@@ -30,6 +30,7 @@
 
 #include <forward_list>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 #include "MoveOnly.h"

--- a/external/libcxx-test/std/containers/sequences/forwardlist/forwardlist.modifiers/push_front_const.pass.cpp
+++ b/external/libcxx-test/std/containers/sequences/forwardlist/forwardlist.modifiers/push_front_const.pass.cpp
@@ -30,6 +30,7 @@
 
 #include <forward_list>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 

--- a/external/libcxx-test/std/containers/sequences/forwardlist/forwardlist.modifiers/push_front_rv.pass.cpp
+++ b/external/libcxx-test/std/containers/sequences/forwardlist/forwardlist.modifiers/push_front_rv.pass.cpp
@@ -32,6 +32,7 @@
 
 #include <forward_list>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 #include "MoveOnly.h"

--- a/external/libcxx-test/std/containers/sequences/forwardlist/forwardlist.modifiers/resize_size.pass.cpp
+++ b/external/libcxx-test/std/containers/sequences/forwardlist/forwardlist.modifiers/resize_size.pass.cpp
@@ -30,6 +30,7 @@
 
 #include <forward_list>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 #include "DefaultOnly.h"

--- a/external/libcxx-test/std/containers/sequences/forwardlist/forwardlist.ops/merge.pass.cpp
+++ b/external/libcxx-test/std/containers/sequences/forwardlist/forwardlist.ops/merge.pass.cpp
@@ -31,6 +31,7 @@
 #include <forward_list>
 #include <iterator>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 

--- a/external/libcxx-test/std/containers/sequences/forwardlist/forwardlist.ops/merge_pred.pass.cpp
+++ b/external/libcxx-test/std/containers/sequences/forwardlist/forwardlist.ops/merge_pred.pass.cpp
@@ -32,6 +32,7 @@
 #include <iterator>
 #include <functional>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 

--- a/external/libcxx-test/std/containers/sequences/forwardlist/forwardlist.ops/remove.pass.cpp
+++ b/external/libcxx-test/std/containers/sequences/forwardlist/forwardlist.ops/remove.pass.cpp
@@ -31,6 +31,7 @@
 #include <forward_list>
 #include <iterator>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 

--- a/external/libcxx-test/std/containers/sequences/forwardlist/forwardlist.ops/remove_if.pass.cpp
+++ b/external/libcxx-test/std/containers/sequences/forwardlist/forwardlist.ops/remove_if.pass.cpp
@@ -31,6 +31,7 @@
 #include <forward_list>
 #include <iterator>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 #include <cstddef>
 

--- a/external/libcxx-test/std/containers/sequences/forwardlist/forwardlist.ops/reverse.pass.cpp
+++ b/external/libcxx-test/std/containers/sequences/forwardlist/forwardlist.ops/reverse.pass.cpp
@@ -32,6 +32,7 @@
 #include <iterator>
 #include <algorithm>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 

--- a/external/libcxx-test/std/containers/sequences/forwardlist/forwardlist.ops/sort.pass.cpp
+++ b/external/libcxx-test/std/containers/sequences/forwardlist/forwardlist.ops/sort.pass.cpp
@@ -34,6 +34,7 @@
 #include <vector>
 #include <random>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 

--- a/external/libcxx-test/std/containers/sequences/forwardlist/forwardlist.ops/sort_pred.pass.cpp
+++ b/external/libcxx-test/std/containers/sequences/forwardlist/forwardlist.ops/sort_pred.pass.cpp
@@ -35,6 +35,7 @@
 #include <functional>
 #include <random>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 

--- a/external/libcxx-test/std/containers/sequences/forwardlist/forwardlist.ops/splice_after_flist.pass.cpp
+++ b/external/libcxx-test/std/containers/sequences/forwardlist/forwardlist.ops/splice_after_flist.pass.cpp
@@ -30,6 +30,7 @@
 
 #include <forward_list>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 #include <iterator>
 #include <cstddef>

--- a/external/libcxx-test/std/containers/sequences/forwardlist/forwardlist.ops/splice_after_range.pass.cpp
+++ b/external/libcxx-test/std/containers/sequences/forwardlist/forwardlist.ops/splice_after_range.pass.cpp
@@ -31,6 +31,7 @@
 
 #include <forward_list>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 #include <iterator>
 

--- a/external/libcxx-test/std/containers/sequences/forwardlist/forwardlist.ops/unique.pass.cpp
+++ b/external/libcxx-test/std/containers/sequences/forwardlist/forwardlist.ops/unique.pass.cpp
@@ -31,6 +31,7 @@
 #include <forward_list>
 #include <iterator>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 

--- a/external/libcxx-test/std/containers/sequences/forwardlist/forwardlist.ops/unique_pred.pass.cpp
+++ b/external/libcxx-test/std/containers/sequences/forwardlist/forwardlist.ops/unique_pred.pass.cpp
@@ -31,6 +31,7 @@
 #include <forward_list>
 #include <iterator>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 

--- a/external/libcxx-test/std/containers/sequences/forwardlist/forwardlist.spec/member_swap.pass.cpp
+++ b/external/libcxx-test/std/containers/sequences/forwardlist/forwardlist.spec/member_swap.pass.cpp
@@ -30,6 +30,7 @@
 
 #include <forward_list>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 #include "test_allocator.h"

--- a/external/libcxx-test/std/containers/sequences/forwardlist/forwardlist.spec/non_member_swap.pass.cpp
+++ b/external/libcxx-test/std/containers/sequences/forwardlist/forwardlist.spec/non_member_swap.pass.cpp
@@ -31,6 +31,7 @@
 
 #include <forward_list>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 #include "test_allocator.h"

--- a/external/libcxx-test/std/containers/sequences/forwardlist/types.pass.cpp
+++ b/external/libcxx-test/std/containers/sequences/forwardlist/types.pass.cpp
@@ -44,6 +44,7 @@
 
 #include <forward_list>
 #include <type_traits>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 struct A { std::forward_list<A> v; }; // incomplete type support

--- a/external/libcxx-test/std/containers/sequences/list/list.capacity/resize_size.pass.cpp
+++ b/external/libcxx-test/std/containers/sequences/list/list.capacity/resize_size.pass.cpp
@@ -30,6 +30,7 @@
 
 #include <list>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 #include "DefaultOnly.h"
 

--- a/external/libcxx-test/std/containers/sequences/list/list.capacity/resize_size_value.pass.cpp
+++ b/external/libcxx-test/std/containers/sequences/list/list.capacity/resize_size_value.pass.cpp
@@ -30,6 +30,7 @@
 
 #include <list>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 #include "DefaultOnly.h"
 

--- a/external/libcxx-test/std/containers/sequences/list/list.cons/assign_copy.pass.cpp
+++ b/external/libcxx-test/std/containers/sequences/list/list.cons/assign_copy.pass.cpp
@@ -30,6 +30,7 @@
 
 #include <list>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 #include "test_allocator.h"
 

--- a/external/libcxx-test/std/containers/sequences/list/list.cons/assign_initializer_list.pass.cpp
+++ b/external/libcxx-test/std/containers/sequences/list/list.cons/assign_initializer_list.pass.cpp
@@ -32,6 +32,7 @@
 
 #include <list>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 

--- a/external/libcxx-test/std/containers/sequences/list/list.cons/assign_move.pass.cpp
+++ b/external/libcxx-test/std/containers/sequences/list/list.cons/assign_move.pass.cpp
@@ -32,6 +32,7 @@
 
 #include <list>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 #include "MoveOnly.h"
 #include "test_allocator.h"

--- a/external/libcxx-test/std/containers/sequences/list/list.cons/copy_alloc.pass.cpp
+++ b/external/libcxx-test/std/containers/sequences/list/list.cons/copy_alloc.pass.cpp
@@ -30,6 +30,7 @@
 
 #include <list>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 #include "DefaultOnly.h"
 #include "test_allocator.h"

--- a/external/libcxx-test/std/containers/sequences/list/list.cons/default_stack_alloc.pass.cpp
+++ b/external/libcxx-test/std/containers/sequences/list/list.cons/default_stack_alloc.pass.cpp
@@ -30,6 +30,7 @@
 
 #include <list>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 #include "test_allocator.h"
 

--- a/external/libcxx-test/std/containers/sequences/list/list.cons/initializer_list.pass.cpp
+++ b/external/libcxx-test/std/containers/sequences/list/list.cons/initializer_list.pass.cpp
@@ -32,6 +32,7 @@
 
 #include <list>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 

--- a/external/libcxx-test/std/containers/sequences/list/list.cons/initializer_list_alloc.pass.cpp
+++ b/external/libcxx-test/std/containers/sequences/list/list.cons/initializer_list_alloc.pass.cpp
@@ -32,6 +32,7 @@
 
 #include <list>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 #include "test_allocator.h"

--- a/external/libcxx-test/std/containers/sequences/list/list.cons/move.pass.cpp
+++ b/external/libcxx-test/std/containers/sequences/list/list.cons/move.pass.cpp
@@ -32,6 +32,7 @@
 
 #include <list>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 #include "MoveOnly.h"
 #include "test_allocator.h"

--- a/external/libcxx-test/std/containers/sequences/list/list.cons/move_alloc.pass.cpp
+++ b/external/libcxx-test/std/containers/sequences/list/list.cons/move_alloc.pass.cpp
@@ -32,6 +32,7 @@
 
 #include <list>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 #include "MoveOnly.h"
 #include "test_allocator.h"

--- a/external/libcxx-test/std/containers/sequences/list/list.cons/op_equal_initializer_list.pass.cpp
+++ b/external/libcxx-test/std/containers/sequences/list/list.cons/op_equal_initializer_list.pass.cpp
@@ -32,6 +32,7 @@
 
 #include <list>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 int tc_libcxx_containers_list_cons_op_equal_initializer_list(void)

--- a/external/libcxx-test/std/containers/sequences/list/list.cons/size_value_alloc.pass.cpp
+++ b/external/libcxx-test/std/containers/sequences/list/list.cons/size_value_alloc.pass.cpp
@@ -30,6 +30,7 @@
 
 #include <list>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 #include "DefaultOnly.h"
 #include "test_allocator.h"

--- a/external/libcxx-test/std/containers/sequences/list/list.modifiers/clear.pass.cpp
+++ b/external/libcxx-test/std/containers/sequences/list/list.modifiers/clear.pass.cpp
@@ -30,6 +30,7 @@
 
 #include <list>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 

--- a/external/libcxx-test/std/containers/sequences/list/list.modifiers/erase_iter.pass.cpp
+++ b/external/libcxx-test/std/containers/sequences/list/list.modifiers/erase_iter.pass.cpp
@@ -30,6 +30,7 @@
 
 #include <list>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 

--- a/external/libcxx-test/std/containers/sequences/list/list.modifiers/erase_iter_iter.pass.cpp
+++ b/external/libcxx-test/std/containers/sequences/list/list.modifiers/erase_iter_iter.pass.cpp
@@ -30,6 +30,7 @@
 
 #include <list>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 

--- a/external/libcxx-test/std/containers/sequences/list/list.modifiers/insert_iter_initializer_list.pass.cpp
+++ b/external/libcxx-test/std/containers/sequences/list/list.modifiers/insert_iter_initializer_list.pass.cpp
@@ -32,6 +32,7 @@
 
 #include <list>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 

--- a/external/libcxx-test/std/containers/sequences/list/list.modifiers/insert_iter_rvalue.pass.cpp
+++ b/external/libcxx-test/std/containers/sequences/list/list.modifiers/insert_iter_rvalue.pass.cpp
@@ -32,6 +32,7 @@
 
 #include <list>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 #include "MoveOnly.h"

--- a/external/libcxx-test/std/containers/sequences/list/list.modifiers/pop_front.pass.cpp
+++ b/external/libcxx-test/std/containers/sequences/list/list.modifiers/pop_front.pass.cpp
@@ -30,6 +30,7 @@
 
 #include <list>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 

--- a/external/libcxx-test/std/containers/sequences/list/list.modifiers/push_back.pass.cpp
+++ b/external/libcxx-test/std/containers/sequences/list/list.modifiers/push_back.pass.cpp
@@ -30,6 +30,7 @@
 
 #include <list>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 

--- a/external/libcxx-test/std/containers/sequences/list/list.modifiers/push_back_rvalue.pass.cpp
+++ b/external/libcxx-test/std/containers/sequences/list/list.modifiers/push_back_rvalue.pass.cpp
@@ -32,6 +32,7 @@
 
 #include <list>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 #include "MoveOnly.h"

--- a/external/libcxx-test/std/containers/sequences/list/list.modifiers/push_front.pass.cpp
+++ b/external/libcxx-test/std/containers/sequences/list/list.modifiers/push_front.pass.cpp
@@ -30,6 +30,7 @@
 
 #include <list>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 

--- a/external/libcxx-test/std/containers/sequences/list/list.modifiers/push_front_rvalue.pass.cpp
+++ b/external/libcxx-test/std/containers/sequences/list/list.modifiers/push_front_rvalue.pass.cpp
@@ -32,6 +32,7 @@
 
 #include <list>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 #include "MoveOnly.h"

--- a/external/libcxx-test/std/containers/sequences/list/list.ops/merge.pass.cpp
+++ b/external/libcxx-test/std/containers/sequences/list/list.ops/merge.pass.cpp
@@ -30,6 +30,7 @@
 
 #include <list>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 

--- a/external/libcxx-test/std/containers/sequences/list/list.ops/merge_comp.pass.cpp
+++ b/external/libcxx-test/std/containers/sequences/list/list.ops/merge_comp.pass.cpp
@@ -31,6 +31,7 @@
 #include <list>
 #include <functional>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 

--- a/external/libcxx-test/std/containers/sequences/list/list.ops/remove_if.pass.cpp
+++ b/external/libcxx-test/std/containers/sequences/list/list.ops/remove_if.pass.cpp
@@ -30,6 +30,7 @@
 
 #include <list>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 #include <functional>
 

--- a/external/libcxx-test/std/containers/sequences/list/list.ops/reverse.pass.cpp
+++ b/external/libcxx-test/std/containers/sequences/list/list.ops/reverse.pass.cpp
@@ -30,6 +30,7 @@
 
 #include <list>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 

--- a/external/libcxx-test/std/containers/sequences/list/list.ops/sort.pass.cpp
+++ b/external/libcxx-test/std/containers/sequences/list/list.ops/sort.pass.cpp
@@ -30,6 +30,7 @@
 
 #include <list>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 

--- a/external/libcxx-test/std/containers/sequences/list/list.ops/sort_comp.pass.cpp
+++ b/external/libcxx-test/std/containers/sequences/list/list.ops/sort_comp.pass.cpp
@@ -32,6 +32,7 @@
 #include <functional>
 #include <algorithm>  // for is_permutation
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 

--- a/external/libcxx-test/std/containers/sequences/list/list.ops/unique.pass.cpp
+++ b/external/libcxx-test/std/containers/sequences/list/list.ops/unique.pass.cpp
@@ -30,6 +30,7 @@
 
 #include <list>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 

--- a/external/libcxx-test/std/containers/sequences/list/list.ops/unique_pred.pass.cpp
+++ b/external/libcxx-test/std/containers/sequences/list/list.ops/unique_pred.pass.cpp
@@ -30,6 +30,7 @@
 
 #include <list>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 

--- a/external/libcxx-test/std/containers/sequences/list/list.special/swap.pass.cpp
+++ b/external/libcxx-test/std/containers/sequences/list/list.special/swap.pass.cpp
@@ -31,6 +31,7 @@
 
 #include <list>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 #include "test_allocator.h"
 

--- a/external/libcxx-test/std/containers/sequences/list/types.pass.cpp
+++ b/external/libcxx-test/std/containers/sequences/list/types.pass.cpp
@@ -41,6 +41,7 @@
 
 #include <list>
 #include <type_traits>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 struct A { std::list<A> v; }; // incomplete type support

--- a/external/libcxx-test/std/containers/sequences/vector.bool/assign_copy.pass.cpp
+++ b/external/libcxx-test/std/containers/sequences/vector.bool/assign_copy.pass.cpp
@@ -30,6 +30,7 @@
 
 #include <vector>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 #include "test_allocator.h"
 

--- a/external/libcxx-test/std/containers/sequences/vector.bool/assign_initializer_list.pass.cpp
+++ b/external/libcxx-test/std/containers/sequences/vector.bool/assign_initializer_list.pass.cpp
@@ -32,6 +32,7 @@
 
 #include <vector>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 

--- a/external/libcxx-test/std/containers/sequences/vector.bool/assign_move.pass.cpp
+++ b/external/libcxx-test/std/containers/sequences/vector.bool/assign_move.pass.cpp
@@ -32,6 +32,7 @@
 
 #include <vector>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 #include "test_allocator.h"
 

--- a/external/libcxx-test/std/containers/sequences/vector.bool/capacity.pass.cpp
+++ b/external/libcxx-test/std/containers/sequences/vector.bool/capacity.pass.cpp
@@ -31,6 +31,7 @@
 
 #include <vector>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 

--- a/external/libcxx-test/std/containers/sequences/vector.bool/erase_iter.pass.cpp
+++ b/external/libcxx-test/std/containers/sequences/vector.bool/erase_iter.pass.cpp
@@ -31,6 +31,7 @@
 
 #include <vector>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 

--- a/external/libcxx-test/std/containers/sequences/vector.bool/erase_iter_iter.pass.cpp
+++ b/external/libcxx-test/std/containers/sequences/vector.bool/erase_iter_iter.pass.cpp
@@ -31,6 +31,7 @@
 
 #include <vector>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 

--- a/external/libcxx-test/std/containers/sequences/vector.bool/initializer_list.pass.cpp
+++ b/external/libcxx-test/std/containers/sequences/vector.bool/initializer_list.pass.cpp
@@ -32,6 +32,7 @@
 
 #include <vector>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 

--- a/external/libcxx-test/std/containers/sequences/vector.bool/initializer_list_alloc.pass.cpp
+++ b/external/libcxx-test/std/containers/sequences/vector.bool/initializer_list_alloc.pass.cpp
@@ -32,6 +32,7 @@
 
 #include <vector>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 #include "test_allocator.h"

--- a/external/libcxx-test/std/containers/sequences/vector.bool/insert_iter_initializer_list.pass.cpp
+++ b/external/libcxx-test/std/containers/sequences/vector.bool/insert_iter_initializer_list.pass.cpp
@@ -32,6 +32,7 @@
 
 #include <vector>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 

--- a/external/libcxx-test/std/containers/sequences/vector.bool/insert_iter_size_value.pass.cpp
+++ b/external/libcxx-test/std/containers/sequences/vector.bool/insert_iter_size_value.pass.cpp
@@ -31,6 +31,7 @@
 
 #include <vector>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 #include <cstddef>
 

--- a/external/libcxx-test/std/containers/sequences/vector.bool/insert_iter_value.pass.cpp
+++ b/external/libcxx-test/std/containers/sequences/vector.bool/insert_iter_value.pass.cpp
@@ -31,6 +31,7 @@
 
 #include <vector>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 #include <cstddef>
 

--- a/external/libcxx-test/std/containers/sequences/vector.bool/move.pass.cpp
+++ b/external/libcxx-test/std/containers/sequences/vector.bool/move.pass.cpp
@@ -32,6 +32,7 @@
 
 #include <vector>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 #include "test_allocator.h"
 

--- a/external/libcxx-test/std/containers/sequences/vector.bool/move_alloc.pass.cpp
+++ b/external/libcxx-test/std/containers/sequences/vector.bool/move_alloc.pass.cpp
@@ -32,6 +32,7 @@
 
 #include <vector>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 #include "test_allocator.h"
 

--- a/external/libcxx-test/std/containers/sequences/vector.bool/op_equal_initializer_list.pass.cpp
+++ b/external/libcxx-test/std/containers/sequences/vector.bool/op_equal_initializer_list.pass.cpp
@@ -32,6 +32,7 @@
 
 #include <vector>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 int tc_libcxx_containers_vector_bool_op_equal_initializer_list(void)

--- a/external/libcxx-test/std/containers/sequences/vector.bool/push_back.pass.cpp
+++ b/external/libcxx-test/std/containers/sequences/vector.bool/push_back.pass.cpp
@@ -31,6 +31,7 @@
 
 #include <vector>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 #include <cstddef>
 

--- a/external/libcxx-test/std/containers/sequences/vector.bool/reserve.pass.cpp
+++ b/external/libcxx-test/std/containers/sequences/vector.bool/reserve.pass.cpp
@@ -31,6 +31,7 @@
 
 #include <vector>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 

--- a/external/libcxx-test/std/containers/sequences/vector.bool/resize_size.pass.cpp
+++ b/external/libcxx-test/std/containers/sequences/vector.bool/resize_size.pass.cpp
@@ -31,6 +31,7 @@
 
 #include <vector>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 

--- a/external/libcxx-test/std/containers/sequences/vector.bool/resize_size_value.pass.cpp
+++ b/external/libcxx-test/std/containers/sequences/vector.bool/resize_size_value.pass.cpp
@@ -31,6 +31,7 @@
 
 #include <vector>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 

--- a/external/libcxx-test/std/containers/sequences/vector.bool/shrink_to_fit.pass.cpp
+++ b/external/libcxx-test/std/containers/sequences/vector.bool/shrink_to_fit.pass.cpp
@@ -31,6 +31,7 @@
 
 #include <vector>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 

--- a/external/libcxx-test/std/containers/sequences/vector.bool/swap.pass.cpp
+++ b/external/libcxx-test/std/containers/sequences/vector.bool/swap.pass.cpp
@@ -31,6 +31,7 @@
 
 #include <vector>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 #include "test_allocator.h"
 

--- a/external/libcxx-test/std/containers/sequences/vector.bool/types.pass.cpp
+++ b/external/libcxx-test/std/containers/sequences/vector.bool/types.pass.cpp
@@ -47,6 +47,7 @@
 #include <vector>
 #include <iterator>
 #include <type_traits>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 #include "test_allocator.h"

--- a/external/libcxx-test/std/containers/sequences/vector/types.pass.cpp
+++ b/external/libcxx-test/std/containers/sequences/vector/types.pass.cpp
@@ -49,6 +49,7 @@
 #include <vector>
 #include <iterator>
 #include <type_traits>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 #include "test_allocator.h"
 #include "Copyable.h"

--- a/external/libcxx-test/std/containers/sequences/vector/vector.capacity/capacity.pass.cpp
+++ b/external/libcxx-test/std/containers/sequences/vector/vector.capacity/capacity.pass.cpp
@@ -30,6 +30,7 @@
 
 #include <vector>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 #include "asan_testing.h"

--- a/external/libcxx-test/std/containers/sequences/vector/vector.capacity/reserve.pass.cpp
+++ b/external/libcxx-test/std/containers/sequences/vector/vector.capacity/reserve.pass.cpp
@@ -30,6 +30,7 @@
 
 #include <vector>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 #include "test_allocator.h"
 #include "asan_testing.h"

--- a/external/libcxx-test/std/containers/sequences/vector/vector.capacity/resize_size_value.pass.cpp
+++ b/external/libcxx-test/std/containers/sequences/vector/vector.capacity/resize_size_value.pass.cpp
@@ -30,6 +30,7 @@
 
 #include <vector>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 #include "test_allocator.h"
 #include "asan_testing.h"

--- a/external/libcxx-test/std/containers/sequences/vector/vector.capacity/shrink_to_fit.pass.cpp
+++ b/external/libcxx-test/std/containers/sequences/vector/vector.capacity/shrink_to_fit.pass.cpp
@@ -30,6 +30,7 @@
 
 #include <vector>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 #include "test_allocator.h"
 #include "asan_testing.h"

--- a/external/libcxx-test/std/containers/sequences/vector/vector.capacity/swap.pass.cpp
+++ b/external/libcxx-test/std/containers/sequences/vector/vector.capacity/swap.pass.cpp
@@ -30,6 +30,7 @@
 
 #include <vector>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 #include "asan_testing.h"

--- a/external/libcxx-test/std/containers/sequences/vector/vector.cons/assign_copy.pass.cpp
+++ b/external/libcxx-test/std/containers/sequences/vector/vector.cons/assign_copy.pass.cpp
@@ -30,6 +30,7 @@
 
 #include <vector>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 #include "test_allocator.h"
 

--- a/external/libcxx-test/std/containers/sequences/vector/vector.cons/assign_initializer_list.pass.cpp
+++ b/external/libcxx-test/std/containers/sequences/vector/vector.cons/assign_initializer_list.pass.cpp
@@ -32,6 +32,7 @@
 
 #include <vector>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 #include "asan_testing.h"

--- a/external/libcxx-test/std/containers/sequences/vector/vector.cons/assign_move.pass.cpp
+++ b/external/libcxx-test/std/containers/sequences/vector/vector.cons/assign_move.pass.cpp
@@ -32,6 +32,7 @@
 
 #include <vector>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 #include "MoveOnly.h"
 #include "test_allocator.h"

--- a/external/libcxx-test/std/containers/sequences/vector/vector.cons/initializer_list.pass.cpp
+++ b/external/libcxx-test/std/containers/sequences/vector/vector.cons/initializer_list.pass.cpp
@@ -32,6 +32,7 @@
 
 #include <vector>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 #include "asan_testing.h"
 

--- a/external/libcxx-test/std/containers/sequences/vector/vector.cons/initializer_list_alloc.pass.cpp
+++ b/external/libcxx-test/std/containers/sequences/vector/vector.cons/initializer_list_alloc.pass.cpp
@@ -32,6 +32,7 @@
 
 #include <vector>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 #include "test_allocator.h"

--- a/external/libcxx-test/std/containers/sequences/vector/vector.cons/move.pass.cpp
+++ b/external/libcxx-test/std/containers/sequences/vector/vector.cons/move.pass.cpp
@@ -32,6 +32,7 @@
 
 #include <vector>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 #include "MoveOnly.h"
 #include "test_allocator.h"

--- a/external/libcxx-test/std/containers/sequences/vector/vector.cons/move_alloc.pass.cpp
+++ b/external/libcxx-test/std/containers/sequences/vector/vector.cons/move_alloc.pass.cpp
@@ -32,6 +32,7 @@
 
 #include <vector>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 #include "MoveOnly.h"
 #include "test_allocator.h"

--- a/external/libcxx-test/std/containers/sequences/vector/vector.cons/move_assign_noexcept.pass.cpp
+++ b/external/libcxx-test/std/containers/sequences/vector/vector.cons/move_assign_noexcept.pass.cpp
@@ -37,6 +37,7 @@
 
 #include <vector>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 #include "MoveOnly.h"

--- a/external/libcxx-test/std/containers/sequences/vector/vector.cons/move_noexcept.pass.cpp
+++ b/external/libcxx-test/std/containers/sequences/vector/vector.cons/move_noexcept.pass.cpp
@@ -35,6 +35,7 @@
 
 #include <vector>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 #include "MoveOnly.h"

--- a/external/libcxx-test/std/containers/sequences/vector/vector.cons/op_equal_initializer_list.pass.cpp
+++ b/external/libcxx-test/std/containers/sequences/vector/vector.cons/op_equal_initializer_list.pass.cpp
@@ -32,6 +32,7 @@
 
 #include <vector>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 #include "asan_testing.h"

--- a/external/libcxx-test/std/containers/sequences/vector/vector.data/data.pass.cpp
+++ b/external/libcxx-test/std/containers/sequences/vector/vector.data/data.pass.cpp
@@ -30,6 +30,7 @@
 
 #include <vector>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 #include "asan_testing.h"

--- a/external/libcxx-test/std/containers/sequences/vector/vector.data/data_const.pass.cpp
+++ b/external/libcxx-test/std/containers/sequences/vector/vector.data/data_const.pass.cpp
@@ -30,6 +30,7 @@
 
 #include <vector>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 #include "asan_testing.h"

--- a/external/libcxx-test/std/containers/sequences/vector/vector.modifiers/emplace_extra.pass.cpp
+++ b/external/libcxx-test/std/containers/sequences/vector/vector.modifiers/emplace_extra.pass.cpp
@@ -32,6 +32,7 @@
 
 #include <vector>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 #include "asan_testing.h"

--- a/external/libcxx-test/std/containers/sequences/vector/vector.modifiers/erase_iter.pass.cpp
+++ b/external/libcxx-test/std/containers/sequences/vector/vector.modifiers/erase_iter.pass.cpp
@@ -31,6 +31,7 @@
 #include <vector>
 #include <iterator>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 #include "asan_testing.h"

--- a/external/libcxx-test/std/containers/sequences/vector/vector.modifiers/erase_iter_iter.pass.cpp
+++ b/external/libcxx-test/std/containers/sequences/vector/vector.modifiers/erase_iter_iter.pass.cpp
@@ -31,6 +31,7 @@
 #include <vector>
 #include <iterator>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 #include "asan_testing.h"

--- a/external/libcxx-test/std/containers/sequences/vector/vector.modifiers/insert_iter_initializer_list.pass.cpp
+++ b/external/libcxx-test/std/containers/sequences/vector/vector.modifiers/insert_iter_initializer_list.pass.cpp
@@ -32,6 +32,7 @@
 
 #include <vector>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 #include "asan_testing.h"

--- a/external/libcxx-test/std/containers/sequences/vector/vector.modifiers/push_back.pass.cpp
+++ b/external/libcxx-test/std/containers/sequences/vector/vector.modifiers/push_back.pass.cpp
@@ -30,6 +30,7 @@
 
 #include <vector>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 #include <cstddef>
 #include "test_allocator.h"

--- a/external/libcxx-test/std/containers/sequences/vector/vector.modifiers/push_back_rvalue.pass.cpp
+++ b/external/libcxx-test/std/containers/sequences/vector/vector.modifiers/push_back_rvalue.pass.cpp
@@ -32,6 +32,7 @@
 
 #include <vector>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 #include <cstddef>
 #include "MoveOnly.h"

--- a/external/libcxx-test/std/containers/sequences/vector/vector.special/swap.pass.cpp
+++ b/external/libcxx-test/std/containers/sequences/vector/vector.special/swap.pass.cpp
@@ -32,6 +32,7 @@
 #include <vector>
 #include <iterator>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 #include "test_allocator.h"
 #include "asan_testing.h"

--- a/external/libcxx-test/std/containers/unord/unord.map/count.pass.cpp
+++ b/external/libcxx-test/std/containers/unord/unord.map/count.pass.cpp
@@ -35,6 +35,7 @@
 #include <unordered_map>
 #include <string>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 int tc_libcxx_containers_unord_map_count(void)

--- a/external/libcxx-test/std/containers/unord/unord.map/eq.pass.cpp
+++ b/external/libcxx-test/std/containers/unord/unord.map/eq.pass.cpp
@@ -39,6 +39,7 @@
 #include <unordered_map>
 #include <string>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 

--- a/external/libcxx-test/std/containers/unord/unord.map/equal_range_const.pass.cpp
+++ b/external/libcxx-test/std/containers/unord/unord.map/equal_range_const.pass.cpp
@@ -35,6 +35,7 @@
 #include <unordered_map>
 #include <string>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 

--- a/external/libcxx-test/std/containers/unord/unord.map/find_const.pass.cpp
+++ b/external/libcxx-test/std/containers/unord/unord.map/find_const.pass.cpp
@@ -35,6 +35,7 @@
 #include <unordered_map>
 #include <string>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 

--- a/external/libcxx-test/std/containers/unord/unord.map/find_non_const.pass.cpp
+++ b/external/libcxx-test/std/containers/unord/unord.map/find_non_const.pass.cpp
@@ -35,6 +35,7 @@
 #include <unordered_map>
 #include <string>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 int tc_libcxx_containers_unord_map_find_non_const(void)

--- a/external/libcxx-test/std/containers/unord/unord.map/local_iterators.pass.cpp
+++ b/external/libcxx-test/std/containers/unord/unord.map/local_iterators.pass.cpp
@@ -40,6 +40,7 @@
 #include <unordered_map>
 #include <string>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 int tc_libcxx_containers_unord_map_local_iterators(void)

--- a/external/libcxx-test/std/containers/unord/unord.map/types.pass.cpp
+++ b/external/libcxx-test/std/containers/unord/unord.map/types.pass.cpp
@@ -47,6 +47,7 @@
 
 #include <unordered_map>
 #include <type_traits>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 int tc_libcxx_containers_unord_map_types(void)

--- a/external/libcxx-test/std/containers/unord/unord.map/unord.map.cnstr/assign_init.pass.cpp
+++ b/external/libcxx-test/std/containers/unord/unord.map/unord.map.cnstr/assign_init.pass.cpp
@@ -37,6 +37,7 @@
 #include <unordered_map>
 #include <string>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 #include <cfloat>
 #include <cstddef>

--- a/external/libcxx-test/std/containers/unord/unord.map/unord.map.modifiers/clear.pass.cpp
+++ b/external/libcxx-test/std/containers/unord/unord.map/unord.map.modifiers/clear.pass.cpp
@@ -35,6 +35,7 @@
 #include <unordered_map>
 #include <string>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 

--- a/external/libcxx-test/std/containers/unord/unord.map/unord.map.modifiers/emplace.pass.cpp
+++ b/external/libcxx-test/std/containers/unord/unord.map/unord.map.modifiers/emplace.pass.cpp
@@ -37,6 +37,7 @@
 
 #include <unordered_map>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 #include "Emplaceable.h"

--- a/external/libcxx-test/std/containers/unord/unord.map/unord.map.modifiers/emplace_hint.pass.cpp
+++ b/external/libcxx-test/std/containers/unord/unord.map/unord.map.modifiers/emplace_hint.pass.cpp
@@ -38,6 +38,7 @@
 
 #include <unordered_map>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 #include "Emplaceable.h"

--- a/external/libcxx-test/std/containers/unord/unord.map/unord.map.modifiers/erase_range.pass.cpp
+++ b/external/libcxx-test/std/containers/unord/unord.map/unord.map.modifiers/erase_range.pass.cpp
@@ -35,6 +35,7 @@
 #include <unordered_map>
 #include <string>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 

--- a/external/libcxx-test/std/containers/unord/unord.map/unord.map.modifiers/insert_hint_const_lvalue.pass.cpp
+++ b/external/libcxx-test/std/containers/unord/unord.map/unord.map.modifiers/insert_hint_const_lvalue.pass.cpp
@@ -34,6 +34,7 @@
 
 #include <unordered_map>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 

--- a/external/libcxx-test/std/containers/unord/unord.map/unord.map.modifiers/insert_hint_rvalue.pass.cpp
+++ b/external/libcxx-test/std/containers/unord/unord.map/unord.map.modifiers/insert_hint_rvalue.pass.cpp
@@ -38,6 +38,7 @@
 
 #include <unordered_map>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 #include "MoveOnly.h"

--- a/external/libcxx-test/std/containers/unord/unord.map/unord.map.modifiers/insert_init.pass.cpp
+++ b/external/libcxx-test/std/containers/unord/unord.map/unord.map.modifiers/insert_init.pass.cpp
@@ -37,6 +37,7 @@
 #include <unordered_map>
 #include <string>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 #include "test_iterators.h"

--- a/external/libcxx-test/std/containers/unord/unord.map/unord.map.modifiers/insert_range.pass.cpp
+++ b/external/libcxx-test/std/containers/unord/unord.map/unord.map.modifiers/insert_range.pass.cpp
@@ -36,6 +36,7 @@
 #include <unordered_map>
 #include <string>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 #include "test_iterators.h"

--- a/external/libcxx-test/std/containers/unord/unord.map/unord.map.modifiers/insert_rvalue.pass.cpp
+++ b/external/libcxx-test/std/containers/unord/unord.map/unord.map.modifiers/insert_rvalue.pass.cpp
@@ -38,6 +38,7 @@
 
 #include <unordered_map>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 #include "MoveOnly.h"

--- a/external/libcxx-test/std/containers/unord/unord.multimap/count.pass.cpp
+++ b/external/libcxx-test/std/containers/unord/unord.multimap/count.pass.cpp
@@ -35,6 +35,7 @@
 #include <unordered_map>
 #include <string>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 int tc_libcxx_containers_unord_multimap_count(void)

--- a/external/libcxx-test/std/containers/unord/unord.multimap/eq.pass.cpp
+++ b/external/libcxx-test/std/containers/unord/unord.multimap/eq.pass.cpp
@@ -39,6 +39,7 @@
 #include <unordered_map>
 #include <string>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 

--- a/external/libcxx-test/std/containers/unord/unord.multimap/equal_range_const.pass.cpp
+++ b/external/libcxx-test/std/containers/unord/unord.multimap/equal_range_const.pass.cpp
@@ -35,6 +35,7 @@
 #include <unordered_map>
 #include <string>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 int tc_libcxx_containers_unord_multimap_equal_range_const(void)

--- a/external/libcxx-test/std/containers/unord/unord.multimap/equal_range_non_const.pass.cpp
+++ b/external/libcxx-test/std/containers/unord/unord.multimap/equal_range_non_const.pass.cpp
@@ -35,6 +35,7 @@
 #include <unordered_map>
 #include <string>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 

--- a/external/libcxx-test/std/containers/unord/unord.multimap/find_const.pass.cpp
+++ b/external/libcxx-test/std/containers/unord/unord.multimap/find_const.pass.cpp
@@ -35,6 +35,7 @@
 #include <unordered_map>
 #include <string>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 

--- a/external/libcxx-test/std/containers/unord/unord.multimap/find_non_const.pass.cpp
+++ b/external/libcxx-test/std/containers/unord/unord.multimap/find_non_const.pass.cpp
@@ -35,6 +35,7 @@
 #include <unordered_map>
 #include <string>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 int tc_libcxx_containers_unord_multimap_find_non_const(void)

--- a/external/libcxx-test/std/containers/unord/unord.multimap/load_factor.pass.cpp
+++ b/external/libcxx-test/std/containers/unord/unord.multimap/load_factor.pass.cpp
@@ -35,6 +35,7 @@
 #include <unordered_map>
 #include <string>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 #include <cfloat>
 #include <cmath>

--- a/external/libcxx-test/std/containers/unord/unord.multimap/local_iterators.pass.cpp
+++ b/external/libcxx-test/std/containers/unord/unord.multimap/local_iterators.pass.cpp
@@ -40,6 +40,7 @@
 #include <unordered_map>
 #include <string>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 

--- a/external/libcxx-test/std/containers/unord/unord.multimap/max_bucket_count.pass.cpp
+++ b/external/libcxx-test/std/containers/unord/unord.multimap/max_bucket_count.pass.cpp
@@ -35,6 +35,7 @@
 #include <unordered_map>
 #include <string>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 int tc_libcxx_containers_unord_multimap_max_bucket_count(void)

--- a/external/libcxx-test/std/containers/unord/unord.multimap/max_load_factor.pass.cpp
+++ b/external/libcxx-test/std/containers/unord/unord.multimap/max_load_factor.pass.cpp
@@ -36,6 +36,7 @@
 #include <unordered_map>
 #include <string>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 int tc_libcxx_containers_unord_multimap_max_load_factor(void)

--- a/external/libcxx-test/std/containers/unord/unord.multimap/types.pass.cpp
+++ b/external/libcxx-test/std/containers/unord/unord.multimap/types.pass.cpp
@@ -47,6 +47,7 @@
 
 #include <unordered_map>
 #include <type_traits>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 int tc_libcxx_containers_unord_multimap_types(void)

--- a/external/libcxx-test/std/containers/unord/unord.multimap/unord.multimap.cnstr/assign_init.pass.cpp
+++ b/external/libcxx-test/std/containers/unord/unord.multimap/unord.multimap.cnstr/assign_init.pass.cpp
@@ -37,6 +37,7 @@
 #include <unordered_map>
 #include <string>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 #include <cfloat>
 #include <cstddef>

--- a/external/libcxx-test/std/containers/unord/unord.multimap/unord.multimap.modifiers/clear.pass.cpp
+++ b/external/libcxx-test/std/containers/unord/unord.multimap/unord.multimap.modifiers/clear.pass.cpp
@@ -35,6 +35,7 @@
 #include <unordered_map>
 #include <string>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 

--- a/external/libcxx-test/std/containers/unord/unord.multimap/unord.multimap.modifiers/emplace.pass.cpp
+++ b/external/libcxx-test/std/containers/unord/unord.multimap/unord.multimap.modifiers/emplace.pass.cpp
@@ -37,6 +37,7 @@
 
 #include <unordered_map>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 #include "Emplaceable.h"

--- a/external/libcxx-test/std/containers/unord/unord.multimap/unord.multimap.modifiers/erase_range.pass.cpp
+++ b/external/libcxx-test/std/containers/unord/unord.multimap/unord.multimap.modifiers/erase_range.pass.cpp
@@ -35,6 +35,7 @@
 #include <unordered_map>
 #include <string>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 #include <cstddef>
 

--- a/external/libcxx-test/std/containers/unord/unord.multimap/unord.multimap.modifiers/insert_const_lvalue.pass.cpp
+++ b/external/libcxx-test/std/containers/unord/unord.multimap/unord.multimap.modifiers/insert_const_lvalue.pass.cpp
@@ -34,6 +34,7 @@
 
 #include <unordered_map>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 

--- a/external/libcxx-test/std/containers/unord/unord.multimap/unord.multimap.modifiers/insert_hint_const_lvalue.pass.cpp
+++ b/external/libcxx-test/std/containers/unord/unord.multimap/unord.multimap.modifiers/insert_hint_const_lvalue.pass.cpp
@@ -34,6 +34,7 @@
 
 #include <unordered_map>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 template<class Container>

--- a/external/libcxx-test/std/containers/unord/unord.multimap/unord.multimap.modifiers/insert_hint_rvalue.pass.cpp
+++ b/external/libcxx-test/std/containers/unord/unord.multimap/unord.multimap.modifiers/insert_hint_rvalue.pass.cpp
@@ -38,6 +38,7 @@
 
 #include <unordered_map>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 #include "MoveOnly.h"

--- a/external/libcxx-test/std/containers/unord/unord.multimap/unord.multimap.modifiers/insert_init.pass.cpp
+++ b/external/libcxx-test/std/containers/unord/unord.multimap/unord.multimap.modifiers/insert_init.pass.cpp
@@ -37,6 +37,7 @@
 #include <unordered_map>
 #include <string>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 #include <cstddef>
 

--- a/external/libcxx-test/std/containers/unord/unord.multimap/unord.multimap.modifiers/insert_range.pass.cpp
+++ b/external/libcxx-test/std/containers/unord/unord.multimap/unord.multimap.modifiers/insert_range.pass.cpp
@@ -36,6 +36,7 @@
 #include <unordered_map>
 #include <string>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 #include <cstddef>
 

--- a/external/libcxx-test/std/containers/unord/unord.multimap/unord.multimap.modifiers/insert_rvalue.pass.cpp
+++ b/external/libcxx-test/std/containers/unord/unord.multimap/unord.multimap.modifiers/insert_rvalue.pass.cpp
@@ -38,6 +38,7 @@
 
 #include <unordered_map>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 #include "MoveOnly.h"

--- a/external/libcxx-test/std/depr/depr.c.headers/stdbool_h.pass.cpp
+++ b/external/libcxx-test/std/depr/depr.c.headers/stdbool_h.pass.cpp
@@ -27,6 +27,7 @@
 // test <stdbool.h>
 
 #include <stdbool.h>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 #ifdef bool

--- a/external/libcxx-test/std/diagnostics/std.exceptions/domain.error/domain_error.pass.cpp
+++ b/external/libcxx-test/std/diagnostics/std.exceptions/domain.error/domain_error.pass.cpp
@@ -31,6 +31,7 @@
 #include <cstring>
 #include <string>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 int tc_libcxx_diagnostics_stdexcept_domain_error(void)

--- a/external/libcxx-test/std/diagnostics/std.exceptions/invalid.argument/invalid_argument.pass.cpp
+++ b/external/libcxx-test/std/diagnostics/std.exceptions/invalid.argument/invalid_argument.pass.cpp
@@ -31,6 +31,7 @@
 #include <cstring>
 #include <string>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 int tc_libcxx_diagnostics_stdexcept_invalid_argument(void)

--- a/external/libcxx-test/std/diagnostics/std.exceptions/length.error/length_error.pass.cpp
+++ b/external/libcxx-test/std/diagnostics/std.exceptions/length.error/length_error.pass.cpp
@@ -31,6 +31,7 @@
 #include <cstring>
 #include <string>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 int tc_libcxx_diagnostics_stdexcept_length_error(void)

--- a/external/libcxx-test/std/diagnostics/std.exceptions/logic.error/logic_error.pass.cpp
+++ b/external/libcxx-test/std/diagnostics/std.exceptions/logic.error/logic_error.pass.cpp
@@ -31,6 +31,7 @@
 #include <cstring>
 #include <string>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 int tc_libcxx_diagnostics_stdexcept_logic_error(void)

--- a/external/libcxx-test/std/diagnostics/std.exceptions/out.of.range/out_of_range.pass.cpp
+++ b/external/libcxx-test/std/diagnostics/std.exceptions/out.of.range/out_of_range.pass.cpp
@@ -31,6 +31,7 @@
 #include <cstring>
 #include <string>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 int tc_libcxx_diagnostics_stdexcept_out_of_range(void)

--- a/external/libcxx-test/std/diagnostics/std.exceptions/overflow.error/overflow_error.pass.cpp
+++ b/external/libcxx-test/std/diagnostics/std.exceptions/overflow.error/overflow_error.pass.cpp
@@ -31,6 +31,7 @@
 #include <cstring>
 #include <string>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 int tc_libcxx_diagnostics_stdexcept_overflow_error(void)

--- a/external/libcxx-test/std/diagnostics/std.exceptions/range.error/range_error.pass.cpp
+++ b/external/libcxx-test/std/diagnostics/std.exceptions/range.error/range_error.pass.cpp
@@ -31,6 +31,7 @@
 #include <cstring>
 #include <string>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 int tc_libcxx_diagnostics_stdexcept_range_error(void)

--- a/external/libcxx-test/std/diagnostics/std.exceptions/runtime.error/runtime_error.pass.cpp
+++ b/external/libcxx-test/std/diagnostics/std.exceptions/runtime.error/runtime_error.pass.cpp
@@ -31,6 +31,7 @@
 #include <cstring>
 #include <string>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 int tc_libcxx_diagnostics_stdexcept_runtime_error(void)

--- a/external/libcxx-test/std/diagnostics/std.exceptions/underflow.error/underflow_error.pass.cpp
+++ b/external/libcxx-test/std/diagnostics/std.exceptions/underflow.error/underflow_error.pass.cpp
@@ -31,6 +31,7 @@
 #include <cstring>
 #include <string>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 int tc_libcxx_diagnostics_stdexcept_underflow_error(void)

--- a/external/libcxx-test/std/iterators/iterator.primitives/iterator.basic/iterator.pass.cpp
+++ b/external/libcxx-test/std/iterators/iterator.primitives/iterator.basic/iterator.pass.cpp
@@ -39,6 +39,7 @@
 
 #include <iterator>
 #include <type_traits>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 struct A {};

--- a/external/libcxx-test/std/iterators/iterator.primitives/iterator.operations/advance.pass.cpp
+++ b/external/libcxx-test/std/iterators/iterator.primitives/iterator.operations/advance.pass.cpp
@@ -39,6 +39,7 @@
 
 #include <iterator>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 #include "test_iterators.h"

--- a/external/libcxx-test/std/iterators/iterator.primitives/iterator.operations/distance.pass.cpp
+++ b/external/libcxx-test/std/iterators/iterator.primitives/iterator.operations/distance.pass.cpp
@@ -36,6 +36,7 @@
 
 #include <iterator>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 #include "test_iterators.h"

--- a/external/libcxx-test/std/iterators/iterator.primitives/iterator.operations/next.pass.cpp
+++ b/external/libcxx-test/std/iterators/iterator.primitives/iterator.operations/next.pass.cpp
@@ -33,6 +33,7 @@
 
 #include <iterator>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 #include "test_iterators.h"

--- a/external/libcxx-test/std/iterators/iterator.primitives/iterator.operations/prev.pass.cpp
+++ b/external/libcxx-test/std/iterators/iterator.primitives/iterator.operations/prev.pass.cpp
@@ -31,6 +31,7 @@
 
 #include <iterator>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 #include "test_iterators.h"

--- a/external/libcxx-test/std/iterators/iterator.primitives/iterator.traits/const_pointer.pass.cpp
+++ b/external/libcxx-test/std/iterators/iterator.primitives/iterator.traits/const_pointer.pass.cpp
@@ -38,6 +38,7 @@
 
 #include <iterator>
 #include <type_traits>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 struct A {};

--- a/external/libcxx-test/std/iterators/iterator.primitives/iterator.traits/empty.pass.cpp
+++ b/external/libcxx-test/std/iterators/iterator.primitives/iterator.traits/empty.pass.cpp
@@ -32,6 +32,7 @@
 // };
 
 #include <iterator>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 struct not_an_iterator

--- a/external/libcxx-test/std/iterators/iterator.primitives/iterator.traits/iterator.pass.cpp
+++ b/external/libcxx-test/std/iterators/iterator.primitives/iterator.traits/iterator.pass.cpp
@@ -38,6 +38,7 @@
 
 #include <iterator>
 #include <type_traits>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 struct A {};

--- a/external/libcxx-test/std/iterators/iterator.primitives/iterator.traits/pointer.pass.cpp
+++ b/external/libcxx-test/std/iterators/iterator.primitives/iterator.traits/pointer.pass.cpp
@@ -38,6 +38,7 @@
 
 #include <iterator>
 #include <type_traits>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 struct A {};

--- a/external/libcxx-test/std/iterators/iterator.primitives/std.iterator.tags/bidirectional_iterator_tag.pass.cpp
+++ b/external/libcxx-test/std/iterators/iterator.primitives/std.iterator.tags/bidirectional_iterator_tag.pass.cpp
@@ -30,6 +30,7 @@
 
 #include <iterator>
 #include <type_traits>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 int tc_libcxx_iterators_std_iterator_tags_bidirectional_iterator_tag(void)

--- a/external/libcxx-test/std/iterators/iterator.primitives/std.iterator.tags/forward_iterator_tag.pass.cpp
+++ b/external/libcxx-test/std/iterators/iterator.primitives/std.iterator.tags/forward_iterator_tag.pass.cpp
@@ -30,6 +30,7 @@
 
 #include <iterator>
 #include <type_traits>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 int tc_libcxx_iterators_std_iterator_tags_forward_iterator_tag(void)

--- a/external/libcxx-test/std/iterators/iterator.primitives/std.iterator.tags/input_iterator_tag.pass.cpp
+++ b/external/libcxx-test/std/iterators/iterator.primitives/std.iterator.tags/input_iterator_tag.pass.cpp
@@ -30,6 +30,7 @@
 
 #include <iterator>
 #include <type_traits>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 int tc_libcxx_iterators_std_iterator_tags_input_iterator_tag(void)

--- a/external/libcxx-test/std/iterators/iterator.primitives/std.iterator.tags/output_iterator_tag.pass.cpp
+++ b/external/libcxx-test/std/iterators/iterator.primitives/std.iterator.tags/output_iterator_tag.pass.cpp
@@ -30,6 +30,7 @@
 
 #include <iterator>
 #include <type_traits>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 int tc_libcxx_iterators_std_iterator_tags_output_iterator_tag(void)

--- a/external/libcxx-test/std/iterators/iterator.primitives/std.iterator.tags/random_access_iterator_tag.pass.cpp
+++ b/external/libcxx-test/std/iterators/iterator.primitives/std.iterator.tags/random_access_iterator_tag.pass.cpp
@@ -30,6 +30,7 @@
 
 #include <iterator>
 #include <type_traits>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 

--- a/external/libcxx-test/std/iterators/predef.iterators/insert.iterators/back.insert.iter.ops/back.insert.iter.cons/container.pass.cpp
+++ b/external/libcxx-test/std/iterators/predef.iterators/insert.iterators/back.insert.iter.ops/back.insert.iter.cons/container.pass.cpp
@@ -33,6 +33,7 @@
 #include <iterator>
 #include <vector>
 #include "nasty_containers.hpp"
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 template <class C>

--- a/external/libcxx-test/std/iterators/predef.iterators/insert.iterators/back.insert.iter.ops/back.insert.iter.op++/post.pass.cpp
+++ b/external/libcxx-test/std/iterators/predef.iterators/insert.iterators/back.insert.iter.ops/back.insert.iter.op++/post.pass.cpp
@@ -33,6 +33,7 @@
 #include <iterator>
 #include <vector>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 #include "nasty_containers.hpp"
 

--- a/external/libcxx-test/std/iterators/predef.iterators/insert.iterators/back.insert.iter.ops/back.insert.iter.op++/pre.pass.cpp
+++ b/external/libcxx-test/std/iterators/predef.iterators/insert.iterators/back.insert.iter.ops/back.insert.iter.op++/pre.pass.cpp
@@ -33,6 +33,7 @@
 #include <iterator>
 #include <vector>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 #include "nasty_containers.hpp"
 

--- a/external/libcxx-test/std/iterators/predef.iterators/insert.iterators/back.insert.iter.ops/back.insert.iter.op=/lv_value.pass.cpp
+++ b/external/libcxx-test/std/iterators/predef.iterators/insert.iterators/back.insert.iter.ops/back.insert.iter.op=/lv_value.pass.cpp
@@ -35,6 +35,7 @@
 #include <iterator>
 #include <vector>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 template <class C>

--- a/external/libcxx-test/std/iterators/predef.iterators/insert.iterators/back.insert.iter.ops/back.insert.iter.op=/rv_value.pass.cpp
+++ b/external/libcxx-test/std/iterators/predef.iterators/insert.iterators/back.insert.iter.ops/back.insert.iter.op=/rv_value.pass.cpp
@@ -39,6 +39,7 @@
 #include <vector>
 #include <memory>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 template <class C>

--- a/external/libcxx-test/std/iterators/predef.iterators/insert.iterators/back.insert.iter.ops/back.insert.iter.op_astrk/test.pass.cpp
+++ b/external/libcxx-test/std/iterators/predef.iterators/insert.iterators/back.insert.iter.ops/back.insert.iter.op_astrk/test.pass.cpp
@@ -33,6 +33,7 @@
 #include <iterator>
 #include <vector>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 #include "nasty_containers.hpp"
 

--- a/external/libcxx-test/std/iterators/predef.iterators/insert.iterators/back.insert.iter.ops/back.inserter/test.pass.cpp
+++ b/external/libcxx-test/std/iterators/predef.iterators/insert.iterators/back.insert.iter.ops/back.inserter/test.pass.cpp
@@ -33,6 +33,7 @@
 #include <iterator>
 #include <vector>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 #include "nasty_containers.hpp"
 

--- a/external/libcxx-test/std/iterators/predef.iterators/insert.iterators/front.insert.iter.ops/front.insert.iter.cons/container.pass.cpp
+++ b/external/libcxx-test/std/iterators/predef.iterators/insert.iterators/front.insert.iter.ops/front.insert.iter.cons/container.pass.cpp
@@ -33,6 +33,7 @@
 #include <iterator>
 #include <list>
 #include "nasty_containers.hpp"
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 template <class C>

--- a/external/libcxx-test/std/iterators/predef.iterators/insert.iterators/front.insert.iter.ops/front.insert.iter.op++/post.pass.cpp
+++ b/external/libcxx-test/std/iterators/predef.iterators/insert.iterators/front.insert.iter.ops/front.insert.iter.op++/post.pass.cpp
@@ -33,6 +33,7 @@
 #include <iterator>
 #include <list>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 #include "nasty_containers.hpp"
 

--- a/external/libcxx-test/std/iterators/predef.iterators/insert.iterators/front.insert.iter.ops/front.insert.iter.op++/pre.pass.cpp
+++ b/external/libcxx-test/std/iterators/predef.iterators/insert.iterators/front.insert.iter.ops/front.insert.iter.op++/pre.pass.cpp
@@ -33,6 +33,7 @@
 #include <iterator>
 #include <list>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 #include "nasty_containers.hpp"
 

--- a/external/libcxx-test/std/iterators/predef.iterators/insert.iterators/front.insert.iter.ops/front.insert.iter.op=/lv_value.pass.cpp
+++ b/external/libcxx-test/std/iterators/predef.iterators/insert.iterators/front.insert.iter.ops/front.insert.iter.op=/lv_value.pass.cpp
@@ -34,6 +34,7 @@
 #include <iterator>
 #include <list>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 #include "nasty_containers.hpp"
 

--- a/external/libcxx-test/std/iterators/predef.iterators/insert.iterators/front.insert.iter.ops/front.insert.iter.op=/rv_value.pass.cpp
+++ b/external/libcxx-test/std/iterators/predef.iterators/insert.iterators/front.insert.iter.ops/front.insert.iter.op=/rv_value.pass.cpp
@@ -37,6 +37,7 @@
 #include <list>
 #include <memory>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 template <class C>

--- a/external/libcxx-test/std/iterators/predef.iterators/insert.iterators/front.insert.iter.ops/front.insert.iter.op_astrk/test.pass.cpp
+++ b/external/libcxx-test/std/iterators/predef.iterators/insert.iterators/front.insert.iter.ops/front.insert.iter.op_astrk/test.pass.cpp
@@ -33,6 +33,7 @@
 #include <iterator>
 #include <list>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 #include "nasty_containers.hpp"
 

--- a/external/libcxx-test/std/iterators/predef.iterators/insert.iterators/front.insert.iter.ops/front.inserter/test.pass.cpp
+++ b/external/libcxx-test/std/iterators/predef.iterators/insert.iterators/front.insert.iter.ops/front.inserter/test.pass.cpp
@@ -33,6 +33,7 @@
 #include <iterator>
 #include <list>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 #include "nasty_containers.hpp"
 

--- a/external/libcxx-test/std/iterators/predef.iterators/insert.iterators/insert.iter.ops/insert.iter.cons/test.pass.cpp
+++ b/external/libcxx-test/std/iterators/predef.iterators/insert.iterators/insert.iter.ops/insert.iter.cons/test.pass.cpp
@@ -33,6 +33,7 @@
 #include <iterator>
 #include <vector>
 #include "nasty_containers.hpp"
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 template <class C>

--- a/external/libcxx-test/std/iterators/predef.iterators/insert.iterators/insert.iter.ops/insert.iter.op++/post.pass.cpp
+++ b/external/libcxx-test/std/iterators/predef.iterators/insert.iterators/insert.iter.ops/insert.iter.op++/post.pass.cpp
@@ -33,6 +33,7 @@
 #include <iterator>
 #include <vector>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 #include "nasty_containers.hpp"
 

--- a/external/libcxx-test/std/iterators/predef.iterators/insert.iterators/insert.iter.ops/insert.iter.op++/pre.pass.cpp
+++ b/external/libcxx-test/std/iterators/predef.iterators/insert.iterators/insert.iter.ops/insert.iter.op++/pre.pass.cpp
@@ -33,6 +33,7 @@
 #include <iterator>
 #include <vector>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 #include "nasty_containers.hpp"
 

--- a/external/libcxx-test/std/iterators/predef.iterators/insert.iterators/insert.iter.ops/insert.iter.op=/lv_value.pass.cpp
+++ b/external/libcxx-test/std/iterators/predef.iterators/insert.iterators/insert.iter.ops/insert.iter.op=/lv_value.pass.cpp
@@ -35,6 +35,7 @@
 #include <iterator>
 #include <vector>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 #include "nasty_containers.hpp"
 

--- a/external/libcxx-test/std/iterators/predef.iterators/insert.iterators/insert.iter.ops/insert.iter.op=/rv_value.pass.cpp
+++ b/external/libcxx-test/std/iterators/predef.iterators/insert.iterators/insert.iter.ops/insert.iter.op=/rv_value.pass.cpp
@@ -40,6 +40,7 @@
 #include <vector>
 #include <memory>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 template <class C>

--- a/external/libcxx-test/std/iterators/predef.iterators/insert.iterators/insert.iter.ops/insert.iter.op_astrk/test.pass.cpp
+++ b/external/libcxx-test/std/iterators/predef.iterators/insert.iterators/insert.iter.ops/insert.iter.op_astrk/test.pass.cpp
@@ -33,6 +33,7 @@
 #include <iterator>
 #include <vector>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 #include "nasty_containers.hpp"
 

--- a/external/libcxx-test/std/iterators/predef.iterators/insert.iterators/insert.iter.ops/inserter/test.pass.cpp
+++ b/external/libcxx-test/std/iterators/predef.iterators/insert.iterators/insert.iter.ops/inserter/test.pass.cpp
@@ -33,6 +33,7 @@
 #include <iterator>
 #include <vector>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 #include "nasty_containers.hpp"
 

--- a/external/libcxx-test/std/iterators/predef.iterators/move.iterators/move.iter.ops/move.iter.op.conv/tested_elsewhere.pass.cpp
+++ b/external/libcxx-test/std/iterators/predef.iterators/move.iterators/move.iter.ops/move.iter.op.conv/tested_elsewhere.pass.cpp
@@ -24,6 +24,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 int tc_libcxx_iterators_move_iter_op_conv_tested_elsewhere(void)
 {

--- a/external/libcxx-test/std/iterators/predef.iterators/reverse.iterators/reverse.iter.ops/reverse.iter.conv/tested_elsewhere.pass.cpp
+++ b/external/libcxx-test/std/iterators/predef.iterators/reverse.iterators/reverse.iter.ops/reverse.iter.conv/tested_elsewhere.pass.cpp
@@ -23,6 +23,7 @@
 // Source Licenses. See LICENSE.TXT for details.
 //
 //===----------------------------------------------------------------------===//
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 int tc_libcxx_iterators_reverse_iter_conv_tested_elsewhere(void)

--- a/external/libcxx-test/std/iterators/predef.iterators/reverse.iterators/reverse.iter.requirements/nothing_to_do.pass.cpp
+++ b/external/libcxx-test/std/iterators/predef.iterators/reverse.iterators/reverse.iter.requirements/nothing_to_do.pass.cpp
@@ -23,6 +23,7 @@
 // Source Licenses. See LICENSE.TXT for details.
 //
 //===----------------------------------------------------------------------===//
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 int tc_libcxx_iterators_reverse_iter_requirements_nothing_to_do(void)

--- a/external/libcxx-test/std/iterators/stream.iterators/istream.iterator/istream.iterator.cons/istream.pass.cpp
+++ b/external/libcxx-test/std/iterators/stream.iterators/istream.iterator/istream.iterator.cons/istream.pass.cpp
@@ -33,6 +33,7 @@
 #include <iterator>
 #include <sstream>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 int tc_libcxx_iterators_istream_iterator_cons_istream(void)

--- a/external/libcxx-test/std/iterators/stream.iterators/istream.iterator/istream.iterator.ops/arrow.pass.cpp
+++ b/external/libcxx-test/std/iterators/stream.iterators/istream.iterator/istream.iterator.ops/arrow.pass.cpp
@@ -33,6 +33,7 @@
 #include <iterator>
 #include <sstream>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 struct A

--- a/external/libcxx-test/std/iterators/stream.iterators/istream.iterator/istream.iterator.ops/dereference.pass.cpp
+++ b/external/libcxx-test/std/iterators/stream.iterators/istream.iterator/istream.iterator.ops/dereference.pass.cpp
@@ -33,6 +33,7 @@
 #include <iterator>
 #include <sstream>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 int tc_libcxx_iterators_istream_iterator_ops_dereference(void)

--- a/external/libcxx-test/std/iterators/stream.iterators/istream.iterator/istream.iterator.ops/equal.pass.cpp
+++ b/external/libcxx-test/std/iterators/stream.iterators/istream.iterator/istream.iterator.ops/equal.pass.cpp
@@ -39,6 +39,7 @@
 #include <iterator>
 #include <sstream>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 int tc_libcxx_iterators_istream_iterator_ops_equal(void)

--- a/external/libcxx-test/std/iterators/stream.iterators/istream.iterator/istream.iterator.ops/post_increment.pass.cpp
+++ b/external/libcxx-test/std/iterators/stream.iterators/istream.iterator/istream.iterator.ops/post_increment.pass.cpp
@@ -33,6 +33,7 @@
 #include <iterator>
 #include <sstream>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 int tc_libcxx_iterators_istream_iterator_ops_post_increment(void)

--- a/external/libcxx-test/std/iterators/stream.iterators/istream.iterator/istream.iterator.ops/pre_increment.pass.cpp
+++ b/external/libcxx-test/std/iterators/stream.iterators/istream.iterator/istream.iterator.ops/pre_increment.pass.cpp
@@ -33,6 +33,7 @@
 #include <iterator>
 #include <sstream>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 int tc_libcxx_iterators_istream_iterator_ops_pre_increment(void)

--- a/external/libcxx-test/std/iterators/stream.iterators/istreambuf.iterator/istreambuf.iterator.cons/istream.pass.cpp
+++ b/external/libcxx-test/std/iterators/stream.iterators/istreambuf.iterator/istreambuf.iterator.cons/istream.pass.cpp
@@ -33,6 +33,7 @@
 #include <iterator>
 #include <sstream>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 int tc_libcxx_iterators_istreambuf_iterator_cons_istream(void)

--- a/external/libcxx-test/std/iterators/stream.iterators/istreambuf.iterator/istreambuf.iterator.cons/proxy.pass.cpp
+++ b/external/libcxx-test/std/iterators/stream.iterators/istreambuf.iterator/istreambuf.iterator.cons/proxy.pass.cpp
@@ -33,6 +33,7 @@
 #include <iterator>
 #include <sstream>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 int tc_libcxx_iterators_istreambuf_iterator_cons_proxy(void)

--- a/external/libcxx-test/std/iterators/stream.iterators/istreambuf.iterator/istreambuf.iterator.cons/streambuf.pass.cpp
+++ b/external/libcxx-test/std/iterators/stream.iterators/istreambuf.iterator/istreambuf.iterator.cons/streambuf.pass.cpp
@@ -33,6 +33,7 @@
 #include <iterator>
 #include <sstream>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 int tc_libcxx_iterators_istreambuf_iterator_cons_streambuf(void)

--- a/external/libcxx-test/std/iterators/stream.iterators/istreambuf.iterator/istreambuf.iterator_equal/equal.pass.cpp
+++ b/external/libcxx-test/std/iterators/stream.iterators/istreambuf.iterator/istreambuf.iterator_equal/equal.pass.cpp
@@ -33,6 +33,7 @@
 #include <iterator>
 #include <sstream>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 int tc_libcxx_iterators_istreambuf_iterator_equal_equal(void)

--- a/external/libcxx-test/std/iterators/stream.iterators/istreambuf.iterator/istreambuf.iterator_op!=/not_equal.pass.cpp
+++ b/external/libcxx-test/std/iterators/stream.iterators/istreambuf.iterator/istreambuf.iterator_op!=/not_equal.pass.cpp
@@ -35,6 +35,7 @@
 #include <iterator>
 #include <sstream>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 int tc_libcxx_iterators_istreambuf_iterator_op___not_equal(void)

--- a/external/libcxx-test/std/iterators/stream.iterators/istreambuf.iterator/istreambuf.iterator_op++/dereference.pass.cpp
+++ b/external/libcxx-test/std/iterators/stream.iterators/istreambuf.iterator/istreambuf.iterator_op++/dereference.pass.cpp
@@ -33,6 +33,7 @@
 #include <iterator>
 #include <sstream>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 int tc_libcxx_iterators_istreambuf_iterator_op___dereference(void)

--- a/external/libcxx-test/std/iterators/stream.iterators/istreambuf.iterator/istreambuf.iterator_op==/equal.pass.cpp
+++ b/external/libcxx-test/std/iterators/stream.iterators/istreambuf.iterator/istreambuf.iterator_op==/equal.pass.cpp
@@ -35,6 +35,7 @@
 #include <iterator>
 #include <sstream>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 int tc_libcxx_iterators_istreambuf_iterator_op___equal(void)

--- a/external/libcxx-test/std/iterators/stream.iterators/istreambuf.iterator/istreambuf.iterator_op_astrk/post_increment.pass.cpp
+++ b/external/libcxx-test/std/iterators/stream.iterators/istreambuf.iterator/istreambuf.iterator_op_astrk/post_increment.pass.cpp
@@ -33,6 +33,7 @@
 #include <iterator>
 #include <sstream>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 int tc_libcxx_iterators_istreambuf_iterator_op_astrk_post_increment(void)

--- a/external/libcxx-test/std/iterators/stream.iterators/istreambuf.iterator/istreambuf.iterator_op_astrk/pre_increment.pass.cpp
+++ b/external/libcxx-test/std/iterators/stream.iterators/istreambuf.iterator/istreambuf.iterator_op_astrk/pre_increment.pass.cpp
@@ -34,6 +34,7 @@
 #include <iterator>
 #include <sstream>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 int tc_libcxx_iterators_istreambuf_iterator_op_astrk_pre_increment(void)

--- a/external/libcxx-test/std/iterators/stream.iterators/istreambuf.iterator/istreambuf.iterator_proxy/proxy.pass.cpp
+++ b/external/libcxx-test/std/iterators/stream.iterators/istreambuf.iterator/istreambuf.iterator_proxy/proxy.pass.cpp
@@ -45,6 +45,7 @@
 #include <iterator>
 #include <sstream>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 int tc_libcxx_iterators_istreambuf_iterator_proxy_proxy(void)

--- a/external/libcxx-test/std/iterators/stream.iterators/iterator.range/begin_array.pass.cpp
+++ b/external/libcxx-test/std/iterators/stream.iterators/iterator.range/begin_array.pass.cpp
@@ -30,6 +30,7 @@
 
 #include <iterator>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 int tc_libcxx_iterators_iterator_range_begin_array(void)

--- a/external/libcxx-test/std/iterators/stream.iterators/iterator.range/begin_const.pass.cpp
+++ b/external/libcxx-test/std/iterators/stream.iterators/iterator.range/begin_const.pass.cpp
@@ -30,6 +30,7 @@
 
 #include <vector>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 int tc_libcxx_iterators_iterator_range_begin_const(void)

--- a/external/libcxx-test/std/iterators/stream.iterators/iterator.range/begin_non_const.pass.cpp
+++ b/external/libcxx-test/std/iterators/stream.iterators/iterator.range/begin_non_const.pass.cpp
@@ -30,6 +30,7 @@
 
 #include <vector>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 int tc_libcxx_iterators_iterator_range_begin_non_const(void)

--- a/external/libcxx-test/std/iterators/stream.iterators/iterator.range/end_array.pass.cpp
+++ b/external/libcxx-test/std/iterators/stream.iterators/iterator.range/end_array.pass.cpp
@@ -30,6 +30,7 @@
 
 #include <iterator>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 int tc_libcxx_iterators_iterator_range_end_array(void)

--- a/external/libcxx-test/std/iterators/stream.iterators/iterator.range/end_const.pass.cpp
+++ b/external/libcxx-test/std/iterators/stream.iterators/iterator.range/end_const.pass.cpp
@@ -30,6 +30,7 @@
 
 #include <vector>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 int tc_libcxx_iterators_iterator_range_end_const(void)

--- a/external/libcxx-test/std/iterators/stream.iterators/iterator.range/end_non_const.pass.cpp
+++ b/external/libcxx-test/std/iterators/stream.iterators/iterator.range/end_non_const.pass.cpp
@@ -30,6 +30,7 @@
 
 #include <vector>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 int tc_libcxx_iterators_iterator_range_end_non_const(void)

--- a/external/libcxx-test/std/iterators/stream.iterators/ostream.iterator/ostream.iterator.cons.des/copy.pass.cpp
+++ b/external/libcxx-test/std/iterators/stream.iterators/ostream.iterator/ostream.iterator.cons.des/copy.pass.cpp
@@ -33,6 +33,7 @@
 #include <iterator>
 #include <sstream>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 int tc_libcxx_iterators_ostream_iterator_cons_des_copy(void)

--- a/external/libcxx-test/std/iterators/stream.iterators/ostream.iterator/ostream.iterator.cons.des/ostream.pass.cpp
+++ b/external/libcxx-test/std/iterators/stream.iterators/ostream.iterator/ostream.iterator.cons.des/ostream.pass.cpp
@@ -33,6 +33,7 @@
 #include <iterator>
 #include <sstream>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 struct MyTraits : std::char_traits<char> {};

--- a/external/libcxx-test/std/iterators/stream.iterators/ostream.iterator/ostream.iterator.ops/dereference.pass.cpp
+++ b/external/libcxx-test/std/iterators/stream.iterators/ostream.iterator/ostream.iterator.ops/dereference.pass.cpp
@@ -33,6 +33,7 @@
 #include <iterator>
 #include <sstream>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 int tc_libcxx_iterators_ostream_iterator_ops_dereference(void)

--- a/external/libcxx-test/std/iterators/stream.iterators/ostream.iterator/ostream.iterator.ops/increment.pass.cpp
+++ b/external/libcxx-test/std/iterators/stream.iterators/ostream.iterator/ostream.iterator.ops/increment.pass.cpp
@@ -34,6 +34,7 @@
 #include <iterator>
 #include <sstream>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 int tc_libcxx_iterators_ostream_iterator_ops_increment(void)

--- a/external/libcxx-test/std/iterators/stream.iterators/ostreambuf.iterator/ostreambuf.iter.cons/ostream.pass.cpp
+++ b/external/libcxx-test/std/iterators/stream.iterators/ostreambuf.iterator/ostreambuf.iter.cons/ostream.pass.cpp
@@ -33,6 +33,7 @@
 #include <iterator>
 #include <sstream>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 int tc_libcxx_iterators_ostreambuf_iter_cons_ostream(void)

--- a/external/libcxx-test/std/iterators/stream.iterators/ostreambuf.iterator/ostreambuf.iter.cons/streambuf.pass.cpp
+++ b/external/libcxx-test/std/iterators/stream.iterators/ostreambuf.iterator/ostreambuf.iter.cons/streambuf.pass.cpp
@@ -33,6 +33,7 @@
 #include <iterator>
 #include <sstream>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 int tc_libcxx_iterators_ostreambuf_iter_cons_streambuf(void)

--- a/external/libcxx-test/std/iterators/stream.iterators/ostreambuf.iterator/ostreambuf.iter.ops/assign_c.pass.cpp
+++ b/external/libcxx-test/std/iterators/stream.iterators/ostreambuf.iterator/ostreambuf.iter.ops/assign_c.pass.cpp
@@ -34,6 +34,7 @@
 #include <iterator>
 #include <sstream>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 int tc_libcxx_iterators_ostreambuf_iter_ops_assign_c(void)

--- a/external/libcxx-test/std/iterators/stream.iterators/ostreambuf.iterator/ostreambuf.iter.ops/deref.pass.cpp
+++ b/external/libcxx-test/std/iterators/stream.iterators/ostreambuf.iterator/ostreambuf.iter.ops/deref.pass.cpp
@@ -33,6 +33,7 @@
 #include <iterator>
 #include <sstream>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 int tc_libcxx_iterators_ostreambuf_iter_ops_deref(void)

--- a/external/libcxx-test/std/iterators/stream.iterators/ostreambuf.iterator/ostreambuf.iter.ops/failed.pass.cpp
+++ b/external/libcxx-test/std/iterators/stream.iterators/ostreambuf.iterator/ostreambuf.iter.ops/failed.pass.cpp
@@ -33,6 +33,7 @@
 #include <iterator>
 #include <sstream>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 int tc_libcxx_iterators_ostreambuf_iter_ops_failed(void)

--- a/external/libcxx-test/std/iterators/stream.iterators/ostreambuf.iterator/ostreambuf.iter.ops/increment.pass.cpp
+++ b/external/libcxx-test/std/iterators/stream.iterators/ostreambuf.iterator/ostreambuf.iter.ops/increment.pass.cpp
@@ -34,6 +34,7 @@
 #include <iterator>
 #include <sstream>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 int tc_libcxx_iterators_ostreambuf_iter_ops_increment(void)

--- a/external/libcxx-test/std/language.support/support.runtime/cstdbool.pass.cpp
+++ b/external/libcxx-test/std/language.support/support.runtime/cstdbool.pass.cpp
@@ -27,6 +27,7 @@
 // test <cstdbool>
 
 #include <cstdbool>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 #ifdef bool

--- a/external/libcxx-test/std/numerics/rand/rand.device/entropy.pass.cpp
+++ b/external/libcxx-test/std/numerics/rand/rand.device/entropy.pass.cpp
@@ -32,6 +32,7 @@
 
 #include <random>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 int tc_numerics_rand_device_entropy(void)

--- a/external/libcxx-test/std/strings/basic.string/string.access/back.pass.cpp
+++ b/external/libcxx-test/std/strings/basic.string/string.access/back.pass.cpp
@@ -35,6 +35,7 @@
 
 #include <string>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 

--- a/external/libcxx-test/std/strings/basic.string/string.access/front.pass.cpp
+++ b/external/libcxx-test/std/strings/basic.string/string.access/front.pass.cpp
@@ -35,6 +35,7 @@
 
 #include <string>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 

--- a/external/libcxx-test/std/strings/basic.string/string.access/index.pass.cpp
+++ b/external/libcxx-test/std/strings/basic.string/string.access/index.pass.cpp
@@ -35,6 +35,7 @@
 
 #include <string>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 

--- a/external/libcxx-test/std/strings/basic.string/string.capacity/clear.pass.cpp
+++ b/external/libcxx-test/std/strings/basic.string/string.capacity/clear.pass.cpp
@@ -30,6 +30,7 @@
 
 #include <string>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 

--- a/external/libcxx-test/std/strings/basic.string/string.capacity/length.pass.cpp
+++ b/external/libcxx-test/std/strings/basic.string/string.capacity/length.pass.cpp
@@ -30,6 +30,7 @@
 
 #include <string>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 

--- a/external/libcxx-test/std/strings/basic.string/string.capacity/max_size.pass.cpp
+++ b/external/libcxx-test/std/strings/basic.string/string.capacity/max_size.pass.cpp
@@ -38,6 +38,7 @@
 
 #include <string>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 

--- a/external/libcxx-test/std/strings/basic.string/string.capacity/size.pass.cpp
+++ b/external/libcxx-test/std/strings/basic.string/string.capacity/size.pass.cpp
@@ -30,6 +30,7 @@
 
 #include <string>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 

--- a/external/libcxx-test/std/strings/basic.string/string.cons/initializer_list_assignment.pass.cpp
+++ b/external/libcxx-test/std/strings/basic.string/string.cons/initializer_list_assignment.pass.cpp
@@ -32,6 +32,7 @@
 
 #include <string>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 

--- a/external/libcxx-test/std/strings/basic.string/string.iterators/begin.pass.cpp
+++ b/external/libcxx-test/std/strings/basic.string/string.iterators/begin.pass.cpp
@@ -31,6 +31,7 @@
 
 #include <string>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 

--- a/external/libcxx-test/std/strings/basic.string/string.iterators/cbegin.pass.cpp
+++ b/external/libcxx-test/std/strings/basic.string/string.iterators/cbegin.pass.cpp
@@ -30,6 +30,7 @@
 
 #include <string>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 

--- a/external/libcxx-test/std/strings/basic.string/string.iterators/cend.pass.cpp
+++ b/external/libcxx-test/std/strings/basic.string/string.iterators/cend.pass.cpp
@@ -30,6 +30,7 @@
 
 #include <string>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 

--- a/external/libcxx-test/std/strings/basic.string/string.iterators/crbegin.pass.cpp
+++ b/external/libcxx-test/std/strings/basic.string/string.iterators/crbegin.pass.cpp
@@ -30,6 +30,7 @@
 
 #include <string>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 

--- a/external/libcxx-test/std/strings/basic.string/string.iterators/crend.pass.cpp
+++ b/external/libcxx-test/std/strings/basic.string/string.iterators/crend.pass.cpp
@@ -30,6 +30,7 @@
 
 #include <string>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 

--- a/external/libcxx-test/std/strings/basic.string/string.iterators/end.pass.cpp
+++ b/external/libcxx-test/std/strings/basic.string/string.iterators/end.pass.cpp
@@ -31,6 +31,7 @@
 
 #include <string>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 #include <cstddef>
 

--- a/external/libcxx-test/std/strings/basic.string/string.iterators/rbegin.pass.cpp
+++ b/external/libcxx-test/std/strings/basic.string/string.iterators/rbegin.pass.cpp
@@ -31,6 +31,7 @@
 
 #include <string>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 

--- a/external/libcxx-test/std/strings/basic.string/string.iterators/rend.pass.cpp
+++ b/external/libcxx-test/std/strings/basic.string/string.iterators/rend.pass.cpp
@@ -31,6 +31,7 @@
 
 #include <string>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 #include <cstddef>
 

--- a/external/libcxx-test/std/strings/basic.string/string.modifiers/string_append/iterator.pass.cpp
+++ b/external/libcxx-test/std/strings/basic.string/string.modifiers/string_append/iterator.pass.cpp
@@ -31,6 +31,7 @@
 
 #include <string>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 #include "test_iterators.h"

--- a/external/libcxx-test/std/strings/basic.string/string.modifiers/string_insert/iter_initializer_list.pass.cpp
+++ b/external/libcxx-test/std/strings/basic.string/string.modifiers/string_insert/iter_initializer_list.pass.cpp
@@ -33,6 +33,7 @@
 
 #include <string>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 

--- a/external/libcxx-test/std/strings/basic.string/string.modifiers/string_insert/iter_iter_iter.pass.cpp
+++ b/external/libcxx-test/std/strings/basic.string/string.modifiers/string_insert/iter_iter_iter.pass.cpp
@@ -31,6 +31,7 @@
 
 #include <string>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 #include "test_iterators.h"

--- a/external/libcxx-test/std/strings/basic.string/string.modifiers/string_op_plus_equal/initializer_list.pass.cpp
+++ b/external/libcxx-test/std/strings/basic.string/string.modifiers/string_op_plus_equal/initializer_list.pass.cpp
@@ -32,6 +32,7 @@
 
 #include <string>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 

--- a/external/libcxx-test/std/strings/basic.string/string.modifiers/string_replace/iter_iter_initializer_list.pass.cpp
+++ b/external/libcxx-test/std/strings/basic.string/string.modifiers/string_replace/iter_iter_initializer_list.pass.cpp
@@ -32,6 +32,7 @@
 
 #include <string>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 

--- a/external/libcxx-test/std/strings/basic.string/string.modifiers/string_replace/iter_iter_iter_iter.pass.cpp
+++ b/external/libcxx-test/std/strings/basic.string/string.modifiers/string_replace/iter_iter_iter_iter.pass.cpp
@@ -33,6 +33,7 @@
 #include <string>
 #include <iterator>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 #include "test_iterators.h"

--- a/external/libcxx-test/std/strings/basic.string/string.modifiers/string_replace/iter_iter_pointer.pass.cpp
+++ b/external/libcxx-test/std/strings/basic.string/string.modifiers/string_replace/iter_iter_pointer.pass.cpp
@@ -34,6 +34,7 @@
 #include <string>
 #include <algorithm>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 

--- a/external/libcxx-test/std/strings/basic.string/string.nonmembers/string.io/get_line_delim_rv.pass.cpp
+++ b/external/libcxx-test/std/strings/basic.string/string.nonmembers/string.io/get_line_delim_rv.pass.cpp
@@ -36,6 +36,7 @@
 #include <string>
 #include <sstream>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 

--- a/external/libcxx-test/std/strings/basic.string/string.nonmembers/string.io/get_line_rv.pass.cpp
+++ b/external/libcxx-test/std/strings/basic.string/string.nonmembers/string.io/get_line_rv.pass.cpp
@@ -36,6 +36,7 @@
 #include <string>
 #include <sstream>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 

--- a/external/libcxx-test/std/strings/basic.string/string.nonmembers/string_op!=/pointer_string.pass.cpp
+++ b/external/libcxx-test/std/strings/basic.string/string.nonmembers/string_op!=/pointer_string.pass.cpp
@@ -31,6 +31,7 @@
 
 #include <string>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 

--- a/external/libcxx-test/std/strings/basic.string/string.nonmembers/string_op!=/string_pointer.pass.cpp
+++ b/external/libcxx-test/std/strings/basic.string/string.nonmembers/string_op!=/string_pointer.pass.cpp
@@ -31,6 +31,7 @@
 
 #include <string>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 template <class S>

--- a/external/libcxx-test/std/strings/basic.string/string.nonmembers/string_op!=/string_string.pass.cpp
+++ b/external/libcxx-test/std/strings/basic.string/string.nonmembers/string_op!=/string_string.pass.cpp
@@ -32,6 +32,7 @@
 
 #include <string>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 template <class S>

--- a/external/libcxx-test/std/strings/basic.string/string.nonmembers/string_operator==/pointer_string.pass.cpp
+++ b/external/libcxx-test/std/strings/basic.string/string.nonmembers/string_operator==/pointer_string.pass.cpp
@@ -31,6 +31,7 @@
 
 #include <string>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 

--- a/external/libcxx-test/std/strings/basic.string/string.nonmembers/string_operator==/string_pointer.pass.cpp
+++ b/external/libcxx-test/std/strings/basic.string/string.nonmembers/string_operator==/string_pointer.pass.cpp
@@ -31,6 +31,7 @@
 
 #include <string>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 

--- a/external/libcxx-test/std/strings/basic.string/string.nonmembers/string_operator==/string_string.pass.cpp
+++ b/external/libcxx-test/std/strings/basic.string/string.nonmembers/string_operator==/string_string.pass.cpp
@@ -32,6 +32,7 @@
 
 #include <string>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 

--- a/external/libcxx-test/std/strings/basic.string/string.nonmembers/string_opgt/pointer_string.pass.cpp
+++ b/external/libcxx-test/std/strings/basic.string/string.nonmembers/string_opgt/pointer_string.pass.cpp
@@ -31,6 +31,7 @@
 
 #include <string>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 

--- a/external/libcxx-test/std/strings/basic.string/string.nonmembers/string_opgt/string_pointer.pass.cpp
+++ b/external/libcxx-test/std/strings/basic.string/string.nonmembers/string_opgt/string_pointer.pass.cpp
@@ -31,6 +31,7 @@
 
 #include <string>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 

--- a/external/libcxx-test/std/strings/basic.string/string.nonmembers/string_opgt/string_string.pass.cpp
+++ b/external/libcxx-test/std/strings/basic.string/string.nonmembers/string_opgt/string_string.pass.cpp
@@ -32,6 +32,7 @@
 
 #include <string>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 

--- a/external/libcxx-test/std/strings/basic.string/string.nonmembers/string_opgt=/pointer_string.pass.cpp
+++ b/external/libcxx-test/std/strings/basic.string/string.nonmembers/string_opgt=/pointer_string.pass.cpp
@@ -31,6 +31,7 @@
 
 #include <string>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 

--- a/external/libcxx-test/std/strings/basic.string/string.nonmembers/string_opgt=/string_pointer.pass.cpp
+++ b/external/libcxx-test/std/strings/basic.string/string.nonmembers/string_opgt=/string_pointer.pass.cpp
@@ -31,6 +31,7 @@
 
 #include <string>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 

--- a/external/libcxx-test/std/strings/basic.string/string.nonmembers/string_opgt=/string_string.pass.cpp
+++ b/external/libcxx-test/std/strings/basic.string/string.nonmembers/string_opgt=/string_string.pass.cpp
@@ -32,6 +32,7 @@
 
 #include <string>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 

--- a/external/libcxx-test/std/strings/basic.string/string.nonmembers/string_oplt/pointer_string.pass.cpp
+++ b/external/libcxx-test/std/strings/basic.string/string.nonmembers/string_oplt/pointer_string.pass.cpp
@@ -31,6 +31,7 @@
 
 #include <string>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 

--- a/external/libcxx-test/std/strings/basic.string/string.nonmembers/string_oplt/string_pointer.pass.cpp
+++ b/external/libcxx-test/std/strings/basic.string/string.nonmembers/string_oplt/string_pointer.pass.cpp
@@ -31,6 +31,7 @@
 
 #include <string>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 

--- a/external/libcxx-test/std/strings/basic.string/string.nonmembers/string_oplt/string_string.pass.cpp
+++ b/external/libcxx-test/std/strings/basic.string/string.nonmembers/string_oplt/string_string.pass.cpp
@@ -32,6 +32,7 @@
 
 #include <string>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 

--- a/external/libcxx-test/std/strings/basic.string/string.nonmembers/string_oplt=/pointer_string.pass.cpp
+++ b/external/libcxx-test/std/strings/basic.string/string.nonmembers/string_oplt=/pointer_string.pass.cpp
@@ -31,6 +31,7 @@
 
 #include <string>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 

--- a/external/libcxx-test/std/strings/basic.string/string.nonmembers/string_oplt=/string_pointer.pass.cpp
+++ b/external/libcxx-test/std/strings/basic.string/string.nonmembers/string_oplt=/string_pointer.pass.cpp
@@ -31,6 +31,7 @@
 
 #include <string>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 

--- a/external/libcxx-test/std/strings/basic.string/string.nonmembers/string_oplt=/string_string.pass.cpp
+++ b/external/libcxx-test/std/strings/basic.string/string.nonmembers/string_oplt=/string_string.pass.cpp
@@ -32,6 +32,7 @@
 
 #include <string>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 

--- a/external/libcxx-test/std/strings/basic.string/string.ops/string.accessors/c_str.pass.cpp
+++ b/external/libcxx-test/std/strings/basic.string/string.ops/string.accessors/c_str.pass.cpp
@@ -30,6 +30,7 @@
 
 #include <string>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 

--- a/external/libcxx-test/std/strings/basic.string/string.ops/string.accessors/get_allocator.pass.cpp
+++ b/external/libcxx-test/std/strings/basic.string/string.ops/string.accessors/get_allocator.pass.cpp
@@ -30,6 +30,7 @@
 
 #include <string>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 #include "test_allocator.h"

--- a/external/libcxx-test/std/strings/basic.string/string.ops/string_compare/pointer.pass.cpp
+++ b/external/libcxx-test/std/strings/basic.string/string.ops/string_compare/pointer.pass.cpp
@@ -30,6 +30,7 @@
 
 #include <string>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 

--- a/external/libcxx-test/std/strings/basic.string/string.ops/string_compare/string.pass.cpp
+++ b/external/libcxx-test/std/strings/basic.string/string.ops/string_compare/string.pass.cpp
@@ -30,6 +30,7 @@
 
 #include <string>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 

--- a/external/libcxx-test/std/strings/basic.string/string.ops/string_find.first.not.of/char_size.pass.cpp
+++ b/external/libcxx-test/std/strings/basic.string/string.ops/string_find.first.not.of/char_size.pass.cpp
@@ -30,6 +30,7 @@
 
 #include <string>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 

--- a/external/libcxx-test/std/strings/basic.string/string.ops/string_find.first.not.of/pointer_size.pass.cpp
+++ b/external/libcxx-test/std/strings/basic.string/string.ops/string_find.first.not.of/pointer_size.pass.cpp
@@ -30,6 +30,7 @@
 
 #include <string>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 

--- a/external/libcxx-test/std/strings/basic.string/string.ops/string_find.first.not.of/pointer_size_size.pass.cpp
+++ b/external/libcxx-test/std/strings/basic.string/string.ops/string_find.first.not.of/pointer_size_size.pass.cpp
@@ -30,6 +30,7 @@
 
 #include <string>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 

--- a/external/libcxx-test/std/strings/basic.string/string.ops/string_find.first.not.of/string_size.pass.cpp
+++ b/external/libcxx-test/std/strings/basic.string/string.ops/string_find.first.not.of/string_size.pass.cpp
@@ -30,6 +30,7 @@
 
 #include <string>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 

--- a/external/libcxx-test/std/strings/basic.string/string.ops/string_find.first.of/char_size.pass.cpp
+++ b/external/libcxx-test/std/strings/basic.string/string.ops/string_find.first.of/char_size.pass.cpp
@@ -30,6 +30,7 @@
 
 #include <string>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 

--- a/external/libcxx-test/std/strings/basic.string/string.ops/string_find.first.of/pointer_size.pass.cpp
+++ b/external/libcxx-test/std/strings/basic.string/string.ops/string_find.first.of/pointer_size.pass.cpp
@@ -30,6 +30,7 @@
 
 #include <string>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 

--- a/external/libcxx-test/std/strings/basic.string/string.ops/string_find.first.of/pointer_size_size.pass.cpp
+++ b/external/libcxx-test/std/strings/basic.string/string.ops/string_find.first.of/pointer_size_size.pass.cpp
@@ -30,6 +30,7 @@
 
 #include <string>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 

--- a/external/libcxx-test/std/strings/basic.string/string.ops/string_find.first.of/string_size.pass.cpp
+++ b/external/libcxx-test/std/strings/basic.string/string.ops/string_find.first.of/string_size.pass.cpp
@@ -30,6 +30,7 @@
 
 #include <string>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 

--- a/external/libcxx-test/std/strings/basic.string/string.ops/string_find.last.not.of/char_size.pass.cpp
+++ b/external/libcxx-test/std/strings/basic.string/string.ops/string_find.last.not.of/char_size.pass.cpp
@@ -30,6 +30,7 @@
 
 #include <string>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 

--- a/external/libcxx-test/std/strings/basic.string/string.ops/string_find.last.not.of/pointer_size.pass.cpp
+++ b/external/libcxx-test/std/strings/basic.string/string.ops/string_find.last.not.of/pointer_size.pass.cpp
@@ -30,6 +30,7 @@
 
 #include <string>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 

--- a/external/libcxx-test/std/strings/basic.string/string.ops/string_find.last.not.of/pointer_size_size.pass.cpp
+++ b/external/libcxx-test/std/strings/basic.string/string.ops/string_find.last.not.of/pointer_size_size.pass.cpp
@@ -30,6 +30,7 @@
 
 #include <string>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 

--- a/external/libcxx-test/std/strings/basic.string/string.ops/string_find.last.not.of/string_size.pass.cpp
+++ b/external/libcxx-test/std/strings/basic.string/string.ops/string_find.last.not.of/string_size.pass.cpp
@@ -30,6 +30,7 @@
 
 #include <string>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 

--- a/external/libcxx-test/std/strings/basic.string/string.ops/string_find.last.of/char_size.pass.cpp
+++ b/external/libcxx-test/std/strings/basic.string/string.ops/string_find.last.of/char_size.pass.cpp
@@ -30,6 +30,7 @@
 
 #include <string>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 

--- a/external/libcxx-test/std/strings/basic.string/string.ops/string_find.last.of/pointer_size.pass.cpp
+++ b/external/libcxx-test/std/strings/basic.string/string.ops/string_find.last.of/pointer_size.pass.cpp
@@ -30,6 +30,7 @@
 
 #include <string>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 

--- a/external/libcxx-test/std/strings/basic.string/string.ops/string_find.last.of/pointer_size_size.pass.cpp
+++ b/external/libcxx-test/std/strings/basic.string/string.ops/string_find.last.of/pointer_size_size.pass.cpp
@@ -30,6 +30,7 @@
 
 #include <string>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 

--- a/external/libcxx-test/std/strings/basic.string/string.ops/string_find.last.of/string_size.pass.cpp
+++ b/external/libcxx-test/std/strings/basic.string/string.ops/string_find.last.of/string_size.pass.cpp
@@ -30,6 +30,7 @@
 
 #include <string>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 

--- a/external/libcxx-test/std/strings/basic.string/string.ops/string_find/char_size.pass.cpp
+++ b/external/libcxx-test/std/strings/basic.string/string.ops/string_find/char_size.pass.cpp
@@ -30,6 +30,7 @@
 
 #include <string>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 

--- a/external/libcxx-test/std/strings/basic.string/string.ops/string_find/pointer_size.pass.cpp
+++ b/external/libcxx-test/std/strings/basic.string/string.ops/string_find/pointer_size.pass.cpp
@@ -30,6 +30,7 @@
 
 #include <string>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 

--- a/external/libcxx-test/std/strings/basic.string/string.ops/string_find/pointer_size_size.pass.cpp
+++ b/external/libcxx-test/std/strings/basic.string/string.ops/string_find/pointer_size_size.pass.cpp
@@ -30,6 +30,7 @@
 
 #include <string>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 

--- a/external/libcxx-test/std/strings/basic.string/string.ops/string_find/string_size.pass.cpp
+++ b/external/libcxx-test/std/strings/basic.string/string.ops/string_find/string_size.pass.cpp
@@ -30,6 +30,7 @@
 
 #include <string>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 

--- a/external/libcxx-test/std/strings/basic.string/string.ops/string_rfind/char_size.pass.cpp
+++ b/external/libcxx-test/std/strings/basic.string/string.ops/string_rfind/char_size.pass.cpp
@@ -30,6 +30,7 @@
 
 #include <string>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 

--- a/external/libcxx-test/std/strings/basic.string/string.ops/string_rfind/pointer_size.pass.cpp
+++ b/external/libcxx-test/std/strings/basic.string/string.ops/string_rfind/pointer_size.pass.cpp
@@ -30,6 +30,7 @@
 
 #include <string>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 

--- a/external/libcxx-test/std/strings/basic.string/string.ops/string_rfind/pointer_size_size.pass.cpp
+++ b/external/libcxx-test/std/strings/basic.string/string.ops/string_rfind/pointer_size_size.pass.cpp
@@ -30,6 +30,7 @@
 
 #include <string>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 

--- a/external/libcxx-test/std/strings/basic.string/string.ops/string_rfind/string_size.pass.cpp
+++ b/external/libcxx-test/std/strings/basic.string/string.ops/string_rfind/string_size.pass.cpp
@@ -30,6 +30,7 @@
 
 #include <string>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 

--- a/external/libcxx-test/std/strings/basic.string/types.pass.cpp
+++ b/external/libcxx-test/std/strings/basic.string/types.pass.cpp
@@ -52,6 +52,7 @@
 #include <string>
 #include <iterator>
 #include <type_traits>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 #include "test_traits.h"

--- a/external/libcxx-test/std/strings/c.strings/cctype.pass.cpp
+++ b/external/libcxx-test/std/strings/c.strings/cctype.pass.cpp
@@ -29,6 +29,7 @@
 #include <cctype>
 #include <type_traits>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 #ifdef isalnum

--- a/external/libcxx-test/std/strings/char.traits/char.traits.specializations/char.traits.specializations.char/assign3.pass.cpp
+++ b/external/libcxx-test/std/strings/char.traits/char.traits.specializations/char.traits.specializations.char/assign3.pass.cpp
@@ -32,6 +32,7 @@
 
 #include <string>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 int tc_libcxx_strings_char_traits_specializations_char_assign3(void)

--- a/external/libcxx-test/std/strings/char.traits/char.traits.specializations/char.traits.specializations.char/copy.pass.cpp
+++ b/external/libcxx-test/std/strings/char.traits/char.traits.specializations/char.traits.specializations.char/copy.pass.cpp
@@ -32,6 +32,7 @@
 
 #include <string>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 int tc_libcxx_strings_char_traits_specializations_char_copy(void)

--- a/external/libcxx-test/std/strings/char.traits/char.traits.specializations/char.traits.specializations.char/eof.pass.cpp
+++ b/external/libcxx-test/std/strings/char.traits/char.traits.specializations/char.traits.specializations.char/eof.pass.cpp
@@ -32,6 +32,7 @@
 
 #include <string>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 int tc_libcxx_strings_char_traits_specializations_char_eof(void)

--- a/external/libcxx-test/std/strings/char.traits/char.traits.specializations/char.traits.specializations.char/eq.pass.cpp
+++ b/external/libcxx-test/std/strings/char.traits/char.traits.specializations/char.traits.specializations.char/eq.pass.cpp
@@ -32,6 +32,7 @@
 
 #include <string>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 int tc_libcxx_strings_char_traits_specializations_char_eq(void)

--- a/external/libcxx-test/std/strings/char.traits/char.traits.specializations/char.traits.specializations.char/eq_int_type.pass.cpp
+++ b/external/libcxx-test/std/strings/char.traits/char.traits.specializations/char.traits.specializations.char/eq_int_type.pass.cpp
@@ -32,6 +32,7 @@
 
 #include <string>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 int tc_libcxx_strings_char_traits_specializations_char_eq_int_type(void)

--- a/external/libcxx-test/std/strings/char.traits/char.traits.specializations/char.traits.specializations.char/lt.pass.cpp
+++ b/external/libcxx-test/std/strings/char.traits/char.traits.specializations/char.traits.specializations.char/lt.pass.cpp
@@ -32,6 +32,7 @@
 
 #include <string>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 int tc_libcxx_strings_char_traits_specializations_char_lt(void)

--- a/external/libcxx-test/std/strings/char.traits/char.traits.specializations/char.traits.specializations.char/move.pass.cpp
+++ b/external/libcxx-test/std/strings/char.traits/char.traits.specializations/char.traits.specializations.char/move.pass.cpp
@@ -32,6 +32,7 @@
 
 #include <string>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 int tc_libcxx_strings_char_traits_specializations_char_move(void)

--- a/external/libcxx-test/std/strings/char.traits/char.traits.specializations/char.traits.specializations.char/not_eof.pass.cpp
+++ b/external/libcxx-test/std/strings/char.traits/char.traits.specializations/char.traits.specializations.char/not_eof.pass.cpp
@@ -32,6 +32,7 @@
 
 #include <string>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 int tc_libcxx_strings_char_traits_specializations_char_not_eof(void)

--- a/external/libcxx-test/std/strings/char.traits/char.traits.specializations/char.traits.specializations.char/to_char_type.pass.cpp
+++ b/external/libcxx-test/std/strings/char.traits/char.traits.specializations/char.traits.specializations.char/to_char_type.pass.cpp
@@ -32,6 +32,7 @@
 
 #include <string>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 int tc_libcxx_strings_char_traits_specializations_char_to_char_type(void)

--- a/external/libcxx-test/std/strings/char.traits/char.traits.specializations/char.traits.specializations.char/to_int_type.pass.cpp
+++ b/external/libcxx-test/std/strings/char.traits/char.traits.specializations/char.traits.specializations.char/to_int_type.pass.cpp
@@ -32,6 +32,7 @@
 
 #include <string>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 int tc_libcxx_strings_char_traits_specializations_char_to_int_type(void)

--- a/external/libcxx-test/std/strings/char.traits/char.traits.specializations/char.traits.specializations.char/types.pass.cpp
+++ b/external/libcxx-test/std/strings/char.traits/char.traits.specializations/char.traits.specializations.char/types.pass.cpp
@@ -36,6 +36,7 @@
 
 #include <string>
 #include <type_traits>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 int tc_libcxx_strings_char_traits_specializations_char_types(void)

--- a/external/libcxx-test/std/strings/char.traits/char.traits.specializations/char.traits.specializations.char16_t/assign3.pass.cpp
+++ b/external/libcxx-test/std/strings/char.traits/char.traits.specializations/char.traits.specializations.char16_t/assign3.pass.cpp
@@ -32,6 +32,7 @@
 
 #include <string>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 int tc_libcxx_strings_char_traits_specializations_char16_t_assign3(void)

--- a/external/libcxx-test/std/strings/char.traits/char.traits.specializations/char.traits.specializations.char16_t/copy.pass.cpp
+++ b/external/libcxx-test/std/strings/char.traits/char.traits.specializations/char.traits.specializations.char16_t/copy.pass.cpp
@@ -32,6 +32,7 @@
 
 #include <string>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 int tc_libcxx_strings_char_traits_specializations_char16_t_copy(void)

--- a/external/libcxx-test/std/strings/char.traits/char.traits.specializations/char.traits.specializations.char16_t/eof.pass.cpp
+++ b/external/libcxx-test/std/strings/char.traits/char.traits.specializations/char.traits.specializations.char16_t/eof.pass.cpp
@@ -32,6 +32,7 @@
 
 #include <string>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 int tc_libcxx_strings_char_traits_specializations_char16_t_eof(void)

--- a/external/libcxx-test/std/strings/char.traits/char.traits.specializations/char.traits.specializations.char16_t/move.pass.cpp
+++ b/external/libcxx-test/std/strings/char.traits/char.traits.specializations/char.traits.specializations.char16_t/move.pass.cpp
@@ -32,6 +32,7 @@
 
 #include <string>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 int tc_libcxx_strings_char_traits_specializations_char16_t_move(void)

--- a/external/libcxx-test/std/strings/char.traits/char.traits.specializations/char.traits.specializations.char16_t/types.pass.cpp
+++ b/external/libcxx-test/std/strings/char.traits/char.traits.specializations/char.traits.specializations.char16_t/types.pass.cpp
@@ -37,6 +37,7 @@
 #include <string>
 #include <type_traits>
 #include <cstdint>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 int tc_libcxx_strings_char_traits_specializations_char16_t_types(void)

--- a/external/libcxx-test/std/strings/char.traits/char.traits.specializations/char.traits.specializations.char32_t/assign3.pass.cpp
+++ b/external/libcxx-test/std/strings/char.traits/char.traits.specializations/char.traits.specializations.char32_t/assign3.pass.cpp
@@ -32,6 +32,7 @@
 
 #include <string>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 int tc_libcxx_strings_char_traits_specializations_char32_t_assign3(void)

--- a/external/libcxx-test/std/strings/char.traits/char.traits.specializations/char.traits.specializations.char32_t/copy.pass.cpp
+++ b/external/libcxx-test/std/strings/char.traits/char.traits.specializations/char.traits.specializations.char32_t/copy.pass.cpp
@@ -32,6 +32,7 @@
 
 #include <string>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 int tc_libcxx_strings_char_traits_specializations_char32_t_copy(void)

--- a/external/libcxx-test/std/strings/char.traits/char.traits.specializations/char.traits.specializations.char32_t/eof.pass.cpp
+++ b/external/libcxx-test/std/strings/char.traits/char.traits.specializations/char.traits.specializations.char32_t/eof.pass.cpp
@@ -32,6 +32,7 @@
 
 #include <string>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 int tc_libcxx_strings_char_traits_specializations_char32_t_eof(void)

--- a/external/libcxx-test/std/strings/char.traits/char.traits.specializations/char.traits.specializations.char32_t/move.pass.cpp
+++ b/external/libcxx-test/std/strings/char.traits/char.traits.specializations/char.traits.specializations.char32_t/move.pass.cpp
@@ -32,6 +32,7 @@
 
 #include <string>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 int tc_libcxx_strings_char_traits_specializations_char32_t_move(void)

--- a/external/libcxx-test/std/strings/char.traits/char.traits.specializations/char.traits.specializations.char32_t/types.pass.cpp
+++ b/external/libcxx-test/std/strings/char.traits/char.traits.specializations/char.traits.specializations.char32_t/types.pass.cpp
@@ -37,6 +37,7 @@
 #include <string>
 #include <type_traits>
 #include <cstdint>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 int tc_libcxx_strings_char_traits_specializations_char32_t_types(void)

--- a/external/libcxx-test/std/strings/char.traits/char.traits.specializations/char.traits.specializations.wchar.t/eof.pass.cpp
+++ b/external/libcxx-test/std/strings/char.traits/char.traits.specializations/char.traits.specializations.wchar.t/eof.pass.cpp
@@ -32,6 +32,7 @@
 
 #include <string>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 int tc_libcxx_strings_char_traits_specializations_wchar_t_eof(void)

--- a/external/libcxx-test/std/strings/char.traits/char.traits.specializations/char.traits.specializations.wchar.t/eq.pass.cpp
+++ b/external/libcxx-test/std/strings/char.traits/char.traits.specializations/char.traits.specializations.wchar.t/eq.pass.cpp
@@ -32,6 +32,7 @@
 
 #include <string>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 int tc_libcxx_strings_char_traits_specializations_wchar_t_eq(void)

--- a/external/libcxx-test/std/strings/char.traits/char.traits.specializations/char.traits.specializations.wchar.t/eq_int_type.pass.cpp
+++ b/external/libcxx-test/std/strings/char.traits/char.traits.specializations/char.traits.specializations.wchar.t/eq_int_type.pass.cpp
@@ -32,6 +32,7 @@
 
 #include <string>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 int tc_libcxx_strings_char_traits_specializations_wchar_t_eq_int_type(void)

--- a/external/libcxx-test/std/strings/char.traits/char.traits.specializations/char.traits.specializations.wchar.t/lt.pass.cpp
+++ b/external/libcxx-test/std/strings/char.traits/char.traits.specializations/char.traits.specializations.wchar.t/lt.pass.cpp
@@ -32,6 +32,7 @@
 
 #include <string>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 int tc_libcxx_strings_char_traits_specializations_wchar_t_lt(void)

--- a/external/libcxx-test/std/strings/char.traits/char.traits.specializations/char.traits.specializations.wchar.t/not_eof.pass.cpp
+++ b/external/libcxx-test/std/strings/char.traits/char.traits.specializations/char.traits.specializations.wchar.t/not_eof.pass.cpp
@@ -32,6 +32,7 @@
 
 #include <string>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 int tc_libcxx_strings_char_traits_specializations_wchar_t_not_eof(void)

--- a/external/libcxx-test/std/strings/char.traits/char.traits.specializations/char.traits.specializations.wchar.t/to_char_type.pass.cpp
+++ b/external/libcxx-test/std/strings/char.traits/char.traits.specializations/char.traits.specializations.wchar.t/to_char_type.pass.cpp
@@ -32,6 +32,7 @@
 
 #include <string>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 int tc_libcxx_strings_char_traits_specializations_wchar_t_to_char_type(void)

--- a/external/libcxx-test/std/strings/char.traits/char.traits.specializations/char.traits.specializations.wchar.t/to_int_type.pass.cpp
+++ b/external/libcxx-test/std/strings/char.traits/char.traits.specializations/char.traits.specializations.wchar.t/to_int_type.pass.cpp
@@ -32,6 +32,7 @@
 
 #include <string>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 int tc_libcxx_strings_char_traits_specializations_wchar_t_to_int_type(void)

--- a/external/libcxx-test/std/strings/char.traits/char.traits.specializations/char.traits.specializations.wchar.t/types.pass.cpp
+++ b/external/libcxx-test/std/strings/char.traits/char.traits.specializations/char.traits.specializations.wchar.t/types.pass.cpp
@@ -36,6 +36,7 @@
 
 #include <string>
 #include <type_traits>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 int tc_libcxx_strings_char_traits_specializations_wchar_t_types(void)

--- a/external/libcxx-test/std/thread/thread.mutex/thread.lock/thread.lock.guard/adopt_lock.pass.cpp
+++ b/external/libcxx-test/std/thread/thread.mutex/thread.lock/thread.lock.guard/adopt_lock.pass.cpp
@@ -20,6 +20,7 @@
 #include <cstdlib>
 #include <cassert>
 #include "libcxx_tc_common.h"
+#include "test_macros.h"
 
 static std::mutex m;
 

--- a/external/libcxx-test/std/thread/thread.mutex/thread.lock/thread.lock.guard/types.pass.cpp
+++ b/external/libcxx-test/std/thread/thread.mutex/thread.lock/thread.lock.guard/types.pass.cpp
@@ -22,6 +22,7 @@
 #include <mutex>
 #include <type_traits>
 #include "libcxx_tc_common.h"
+#include "test_macros.h"
 
 int tc_libcxx_thread_thread_lock_guard_types(void)
 {

--- a/external/libcxx-test/std/thread/thread.mutex/thread.lock/thread.lock.unique/thread.lock.unique.cons/default.pass.cpp
+++ b/external/libcxx-test/std/thread/thread.mutex/thread.lock/thread.lock.unique/thread.lock.unique.cons/default.pass.cpp
@@ -18,6 +18,7 @@
 #include <mutex>
 #include <cassert>
 #include "libcxx_tc_common.h"
+#include "test_macros.h"
 
 int tc_libcxx_thread_thread_lock_unique_cons_default(void)
 {

--- a/external/libcxx-test/std/thread/thread.mutex/thread.lock/thread.lock.unique/thread.lock.unique.cons/move_assign.pass.cpp
+++ b/external/libcxx-test/std/thread/thread.mutex/thread.lock/thread.lock.unique/thread.lock.unique.cons/move_assign.pass.cpp
@@ -19,6 +19,7 @@
 #include <cassert>
 #include "libcxx_tc_common.h"
 #include "nasty_containers.hpp"
+#include "test_macros.h"
 
 int tc_libcxx_thread_thread_lock_unique_cons_move_assign(void)
 {

--- a/external/libcxx-test/std/thread/thread.mutex/thread.lock/thread.lock.unique/thread.lock.unique.cons/move_ctor.pass.cpp
+++ b/external/libcxx-test/std/thread/thread.mutex/thread.lock/thread.lock.unique/thread.lock.unique.cons/move_ctor.pass.cpp
@@ -19,6 +19,7 @@
 #include <cassert>
 #include "libcxx_tc_common.h"
 #include "nasty_containers.hpp"
+#include "test_macros.h"
 
 int tc_libcxx_thread_thread_lock_unique_cons_move_ctor(void)
 {
@@ -27,6 +28,7 @@ int tc_libcxx_thread_thread_lock_unique_cons_move_ctor(void)
     M m;
     std::unique_lock<M> lk0(m);
     std::unique_lock<M> lk = std::move(lk0);
+//	printf("sangam dbg : cons_move_ctor1\n");
     TC_ASSERT_EXPR(lk.mutex() == std::addressof(m));
     TC_ASSERT_EXPR(lk.owns_lock() == true);
     TC_ASSERT_EXPR(lk0.mutex() == nullptr);
@@ -36,6 +38,7 @@ int tc_libcxx_thread_thread_lock_unique_cons_move_ctor(void)
     typedef nasty_mutex M;
     M m;
     std::unique_lock<M> lk0(m);
+//	printf("sangam dbg : cons_move_ctor2\n");
     std::unique_lock<M> lk = std::move(lk0);
     TC_ASSERT_EXPR(lk.mutex() == std::addressof(m));
     TC_ASSERT_EXPR(lk.owns_lock() == true);

--- a/external/libcxx-test/std/thread/thread.mutex/thread.lock/thread.lock.unique/thread.lock.unique.cons/mutex_adopt_lock.pass.cpp
+++ b/external/libcxx-test/std/thread/thread.mutex/thread.lock/thread.lock.unique/thread.lock.unique.cons/mutex_adopt_lock.pass.cpp
@@ -19,6 +19,7 @@
 #include <cassert>
 #include "libcxx_tc_common.h"
 #include "nasty_containers.hpp"
+#include "test_macros.h"
 
 int tc_libcxx_thread_thread_lock_unique_cons_mutex_adopt_lock(void)
 {

--- a/external/libcxx-test/std/thread/thread.mutex/thread.lock/thread.lock.unique/thread.lock.unique.cons/mutex_defer_lock.pass.cpp
+++ b/external/libcxx-test/std/thread/thread.mutex/thread.lock/thread.lock.unique/thread.lock.unique.cons/mutex_defer_lock.pass.cpp
@@ -19,6 +19,7 @@
 #include <cassert>
 #include "libcxx_tc_common.h"
 #include "nasty_containers.hpp"
+#include "test_macros.h"
 
 int tc_libcxx_thread_thread_lock_unique_cons_mutex_defer_lock(void)
 {

--- a/external/libcxx-test/std/thread/thread.mutex/thread.lock/thread.lock.unique/thread.lock.unique.cons/mutex_duration.pass.cpp
+++ b/external/libcxx-test/std/thread/thread.mutex/thread.lock/thread.lock.unique/thread.lock.unique.cons/mutex_duration.pass.cpp
@@ -23,6 +23,7 @@
 #include <cstdlib>
 #include <cassert>
 #include "libcxx_tc_common.h"
+#include "test_macros.h"
 
 static std::timed_mutex m;
 

--- a/external/libcxx-test/std/thread/thread.mutex/thread.lock/thread.lock.unique/thread.lock.unique.cons/mutex_time_point.pass.cpp
+++ b/external/libcxx-test/std/thread/thread.mutex/thread.lock/thread.lock.unique/thread.lock.unique.cons/mutex_time_point.pass.cpp
@@ -23,6 +23,7 @@
 #include <cstdlib>
 #include <cassert>
 #include "libcxx_tc_common.h"
+#include "test_macros.h"
 
 static std::timed_mutex m;
 

--- a/external/libcxx-test/std/thread/thread.mutex/thread.lock/thread.lock.unique/thread.lock.unique.cons/mutex_try_to_lock.pass.cpp
+++ b/external/libcxx-test/std/thread/thread.mutex/thread.lock/thread.lock.unique/thread.lock.unique.cons/mutex_try_to_lock.pass.cpp
@@ -19,6 +19,7 @@
 #include <thread>
 #include <cstdlib>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 static std::mutex m;

--- a/external/libcxx-test/std/thread/thread.mutex/thread.lock/thread.lock.unique/thread.lock.unique.mod/member_swap.pass.cpp
+++ b/external/libcxx-test/std/thread/thread.mutex/thread.lock/thread.lock.unique/thread.lock.unique.mod/member_swap.pass.cpp
@@ -18,6 +18,7 @@
 #include <mutex>
 #include <cassert>
 #include "libcxx_tc_common.h"
+#include "test_macros.h"
 
 struct mutex
 {

--- a/external/libcxx-test/std/thread/thread.mutex/thread.lock/thread.lock.unique/thread.lock.unique.mod/nonmember_swap.pass.cpp
+++ b/external/libcxx-test/std/thread/thread.mutex/thread.lock/thread.lock.unique/thread.lock.unique.mod/nonmember_swap.pass.cpp
@@ -19,6 +19,7 @@
 #include <mutex>
 #include <cassert>
 #include "libcxx_tc_common.h"
+#include "test_macros.h"
 
 struct mutex
 {

--- a/external/libcxx-test/std/thread/thread.mutex/thread.lock/thread.lock.unique/thread.lock.unique.mod/release.pass.cpp
+++ b/external/libcxx-test/std/thread/thread.mutex/thread.lock/thread.lock.unique/thread.lock.unique.mod/release.pass.cpp
@@ -18,6 +18,7 @@
 #include <mutex>
 #include <cassert>
 #include "libcxx_tc_common.h"
+#include "test_macros.h"
 
 struct mutex
 {

--- a/external/libcxx-test/std/thread/thread.mutex/thread.lock/thread.lock.unique/thread.lock.unique.obs/mutex.pass.cpp
+++ b/external/libcxx-test/std/thread/thread.mutex/thread.lock/thread.lock.unique/thread.lock.unique.obs/mutex.pass.cpp
@@ -18,6 +18,7 @@
 #include <mutex>
 #include <cassert>
 #include "libcxx_tc_common.h"
+#include "test_macros.h"
 
 static std::mutex m;
 

--- a/external/libcxx-test/std/thread/thread.mutex/thread.lock/thread.lock.unique/thread.lock.unique.obs/op_bool.pass.cpp
+++ b/external/libcxx-test/std/thread/thread.mutex/thread.lock/thread.lock.unique/thread.lock.unique.obs/op_bool.pass.cpp
@@ -18,6 +18,7 @@
 #include <mutex>
 #include <cassert>
 #include "libcxx_tc_common.h"
+#include "test_macros.h"
 
 static std::mutex m;
 

--- a/external/libcxx-test/std/thread/thread.mutex/thread.lock/thread.lock.unique/thread.lock.unique.obs/owns_lock.pass.cpp
+++ b/external/libcxx-test/std/thread/thread.mutex/thread.lock/thread.lock.unique/thread.lock.unique.obs/owns_lock.pass.cpp
@@ -18,6 +18,7 @@
 #include <mutex>
 #include <cassert>
 #include "libcxx_tc_common.h"
+#include "test_macros.h"
 
 static std::mutex m;
 

--- a/external/libcxx-test/std/thread/thread.mutex/thread.lock/thread.lock.unique/types.pass.cpp
+++ b/external/libcxx-test/std/thread/thread.mutex/thread.lock/thread.lock.unique/types.pass.cpp
@@ -22,6 +22,7 @@
 #include <mutex>
 #include <type_traits>
 #include "libcxx_tc_common.h"
+#include "test_macros.h"
 
 int tc_libcxx_thread_thread_lock_unique_types(void)
 {

--- a/external/libcxx-test/std/thread/thread.mutex/thread.lock/types.pass.cpp
+++ b/external/libcxx-test/std/thread/thread.mutex/thread.lock/types.pass.cpp
@@ -22,6 +22,7 @@
 #include <mutex>
 #include <type_traits>
 #include "libcxx_tc_common.h"
+#include "test_macros.h"
 
 int tc_libcxx_thread_thread_lock_types(void)
 {

--- a/external/libcxx-test/std/thread/thread.mutex/thread.mutex.requirements/thread.mutex.requirements.mutex/thread.mutex.class/default.pass.cpp
+++ b/external/libcxx-test/std/thread/thread.mutex/thread.mutex.requirements/thread.mutex.requirements.mutex/thread.mutex.class/default.pass.cpp
@@ -18,6 +18,7 @@
 #include <mutex>
 #include <type_traits>
 #include "libcxx_tc_common.h"
+#include "test_macros.h"
 
 int tc_libcxx_thread_thread_mutex_class_default(void)
 {

--- a/external/libcxx-test/std/thread/thread.mutex/thread.mutex.requirements/thread.mutex.requirements.mutex/thread.mutex.class/lock.pass.cpp
+++ b/external/libcxx-test/std/thread/thread.mutex/thread.mutex.requirements/thread.mutex.requirements.mutex/thread.mutex.class/lock.pass.cpp
@@ -20,6 +20,7 @@
 #include <cstdlib>
 #include <cassert>
 #include "libcxx_tc_common.h"
+#include "test_macros.h"
 
 #include <iostream>
 

--- a/external/libcxx-test/std/thread/thread.mutex/thread.mutex.requirements/thread.mutex.requirements.mutex/thread.mutex.class/try_lock.pass.cpp
+++ b/external/libcxx-test/std/thread/thread.mutex/thread.mutex.requirements/thread.mutex.requirements.mutex/thread.mutex.class/try_lock.pass.cpp
@@ -19,6 +19,7 @@
 #include <thread>
 #include <cstdlib>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 static std::mutex m;

--- a/external/libcxx-test/std/thread/thread.mutex/thread.mutex.requirements/thread.mutex.requirements.mutex/thread.mutex.recursive/default.pass.cpp
+++ b/external/libcxx-test/std/thread/thread.mutex/thread.mutex.requirements/thread.mutex.requirements.mutex/thread.mutex.recursive/default.pass.cpp
@@ -17,6 +17,7 @@
 
 #include <mutex>
 #include "libcxx_tc_common.h"
+#include "test_macros.h"
 
 int tc_libcxx_thread_thread_mutex_recursive_default(void)
 {

--- a/external/libcxx-test/std/thread/thread.mutex/thread.mutex.requirements/thread.mutex.requirements.mutex/thread.mutex.recursive/lock.pass.cpp
+++ b/external/libcxx-test/std/thread/thread.mutex/thread.mutex.requirements/thread.mutex.requirements.mutex/thread.mutex.recursive/lock.pass.cpp
@@ -20,6 +20,7 @@
 #include <cstdlib>
 #include <cassert>
 #include "libcxx_tc_common.h"
+#include "test_macros.h"
 
 #include <iostream>
 

--- a/external/libcxx-test/std/thread/thread.mutex/thread.mutex.requirements/thread.mutex.requirements.mutex/thread.mutex.recursive/try_lock.pass.cpp
+++ b/external/libcxx-test/std/thread/thread.mutex/thread.mutex.requirements/thread.mutex.requirements.mutex/thread.mutex.recursive/try_lock.pass.cpp
@@ -19,6 +19,7 @@
 #include <thread>
 #include <cstdlib>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 static std::recursive_mutex m;

--- a/external/libcxx-test/std/thread/thread.mutex/thread.mutex.requirements/thread.timedmutex.requirements/thread.timedmutex.class/default.pass.cpp
+++ b/external/libcxx-test/std/thread/thread.mutex/thread.mutex.requirements/thread.timedmutex.requirements/thread.timedmutex.class/default.pass.cpp
@@ -17,6 +17,7 @@
 
 #include <mutex>
 #include "libcxx_tc_common.h"
+#include "test_macros.h"
 
 int tc_libcxx_thread_thread_timedmutex_class_default(void)
 {

--- a/external/libcxx-test/std/thread/thread.mutex/thread.mutex.requirements/thread.timedmutex.requirements/thread.timedmutex.class/lock.pass.cpp
+++ b/external/libcxx-test/std/thread/thread.mutex/thread.mutex.requirements/thread.timedmutex.requirements/thread.timedmutex.class/lock.pass.cpp
@@ -20,6 +20,7 @@
 #include <cstdlib>
 #include <cassert>
 #include "libcxx_tc_common.h"
+#include "test_macros.h"
 
 #include <iostream>
 

--- a/external/libcxx-test/std/thread/thread.mutex/thread.mutex.requirements/thread.timedmutex.requirements/thread.timedmutex.class/try_lock.pass.cpp
+++ b/external/libcxx-test/std/thread/thread.mutex/thread.mutex.requirements/thread.timedmutex.requirements/thread.timedmutex.class/try_lock.pass.cpp
@@ -19,6 +19,7 @@
 #include <thread>
 #include <cstdlib>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 static std::timed_mutex m;

--- a/external/libcxx-test/std/thread/thread.mutex/thread.mutex.requirements/thread.timedmutex.requirements/thread.timedmutex.class/try_lock_for.pass.cpp
+++ b/external/libcxx-test/std/thread/thread.mutex/thread.mutex.requirements/thread.timedmutex.requirements/thread.timedmutex.class/try_lock_for.pass.cpp
@@ -21,6 +21,7 @@
 #include <cstdlib>
 #include <cassert>
 #include "libcxx_tc_common.h"
+#include "test_macros.h"
 
 static std::timed_mutex m;
 

--- a/external/libcxx-test/std/thread/thread.mutex/thread.mutex.requirements/thread.timedmutex.requirements/thread.timedmutex.class/try_lock_until.pass.cpp
+++ b/external/libcxx-test/std/thread/thread.mutex/thread.mutex.requirements/thread.timedmutex.requirements/thread.timedmutex.class/try_lock_until.pass.cpp
@@ -21,6 +21,7 @@
 #include <cstdlib>
 #include <cassert>
 #include "libcxx_tc_common.h"
+#include "test_macros.h"
 
 static std::timed_mutex m;
 

--- a/external/libcxx-test/std/thread/thread.mutex/thread.mutex.requirements/thread.timedmutex.requirements/thread.timedmutex.recursive/default.pass.cpp
+++ b/external/libcxx-test/std/thread/thread.mutex/thread.mutex.requirements/thread.timedmutex.requirements/thread.timedmutex.recursive/default.pass.cpp
@@ -17,6 +17,7 @@
 
 #include <mutex>
 #include "libcxx_tc_common.h"
+#include "test_macros.h"
 
 int tc_libcxx_thread_thread_timedmutex_recursive_default(void)
 {

--- a/external/libcxx-test/std/thread/thread.mutex/thread.mutex.requirements/thread.timedmutex.requirements/thread.timedmutex.recursive/lock.pass.cpp
+++ b/external/libcxx-test/std/thread/thread.mutex/thread.mutex.requirements/thread.timedmutex.requirements/thread.timedmutex.recursive/lock.pass.cpp
@@ -20,6 +20,7 @@
 #include <cstdlib>
 #include <cassert>
 #include "libcxx_tc_common.h"
+#include "test_macros.h"
 
 #include <iostream>
 

--- a/external/libcxx-test/std/thread/thread.mutex/thread.mutex.requirements/thread.timedmutex.requirements/thread.timedmutex.recursive/try_lock.pass.cpp
+++ b/external/libcxx-test/std/thread/thread.mutex/thread.mutex.requirements/thread.timedmutex.requirements/thread.timedmutex.recursive/try_lock.pass.cpp
@@ -19,6 +19,7 @@
 #include <thread>
 #include <cstdlib>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 static std::recursive_timed_mutex m;

--- a/external/libcxx-test/std/thread/thread.mutex/thread.mutex.requirements/thread.timedmutex.requirements/thread.timedmutex.recursive/try_lock_for.pass.cpp
+++ b/external/libcxx-test/std/thread/thread.mutex/thread.mutex.requirements/thread.timedmutex.requirements/thread.timedmutex.recursive/try_lock_for.pass.cpp
@@ -21,6 +21,7 @@
 #include <cstdlib>
 #include <cassert>
 #include "libcxx_tc_common.h"
+#include "test_macros.h"
 
 static std::recursive_timed_mutex m;
 

--- a/external/libcxx-test/std/thread/thread.mutex/thread.mutex.requirements/thread.timedmutex.requirements/thread.timedmutex.recursive/try_lock_until.pass.cpp
+++ b/external/libcxx-test/std/thread/thread.mutex/thread.mutex.requirements/thread.timedmutex.requirements/thread.timedmutex.recursive/try_lock_until.pass.cpp
@@ -21,6 +21,7 @@
 #include <cstdlib>
 #include <cassert>
 #include "libcxx_tc_common.h"
+#include "test_macros.h"
 
 static std::recursive_timed_mutex m;
 

--- a/external/libcxx-test/std/utilities/memory/util.smartptr/util.smartptr.shared/util.smartptr.shared.assign/auto_ptr_Y.pass.cpp
+++ b/external/libcxx-test/std/utilities/memory/util.smartptr/util.smartptr.shared/util.smartptr.shared.assign/auto_ptr_Y.pass.cpp
@@ -34,6 +34,7 @@
 #include <memory>
 #include <type_traits>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 #include "smartptr_shared_common.hpp"
 

--- a/external/libcxx-test/std/utilities/memory/util.smartptr/util.smartptr.shared/util.smartptr.shared.assign/shared_ptr.pass.cpp
+++ b/external/libcxx-test/std/utilities/memory/util.smartptr/util.smartptr.shared/util.smartptr.shared.assign/shared_ptr.pass.cpp
@@ -33,6 +33,7 @@
 #include <memory>
 #include <type_traits>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 #include "smartptr_shared_common.hpp"
 

--- a/external/libcxx-test/std/utilities/memory/util.smartptr/util.smartptr.shared/util.smartptr.shared.assign/shared_ptr_Y.pass.cpp
+++ b/external/libcxx-test/std/utilities/memory/util.smartptr/util.smartptr.shared/util.smartptr.shared.assign/shared_ptr_Y.pass.cpp
@@ -33,6 +33,7 @@
 #include <memory>
 #include <type_traits>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 #include "smartptr_shared_common.hpp"
 

--- a/external/libcxx-test/std/utilities/memory/util.smartptr/util.smartptr.shared/util.smartptr.shared.assign/shared_ptr_Y_rv.pass.cpp
+++ b/external/libcxx-test/std/utilities/memory/util.smartptr/util.smartptr.shared/util.smartptr.shared.assign/shared_ptr_Y_rv.pass.cpp
@@ -35,6 +35,7 @@
 #include <memory>
 #include <type_traits>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 #include "smartptr_shared_common.hpp"
 

--- a/external/libcxx-test/std/utilities/memory/util.smartptr/util.smartptr.shared/util.smartptr.shared.assign/shared_ptr_rv.pass.cpp
+++ b/external/libcxx-test/std/utilities/memory/util.smartptr/util.smartptr.shared/util.smartptr.shared.assign/shared_ptr_rv.pass.cpp
@@ -35,6 +35,7 @@
 #include <memory>
 #include <type_traits>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 #include "smartptr_shared_common.hpp"
 

--- a/external/libcxx-test/std/utilities/memory/util.smartptr/util.smartptr.shared/util.smartptr.shared.assign/unique_ptr_Y.pass.cpp
+++ b/external/libcxx-test/std/utilities/memory/util.smartptr/util.smartptr.shared/util.smartptr.shared.assign/unique_ptr_Y.pass.cpp
@@ -33,6 +33,7 @@
 #include <memory>
 #include <type_traits>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 #include "smartptr_shared_common.hpp"
 

--- a/external/libcxx-test/std/utilities/memory/util.smartptr/util.smartptr.shared/util.smartptr.shared.const/shared_ptr.pass.cpp
+++ b/external/libcxx-test/std/utilities/memory/util.smartptr/util.smartptr.shared/util.smartptr.shared.const/shared_ptr.pass.cpp
@@ -32,6 +32,7 @@
 
 #include <memory>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 #include "smartptr_shared_common.hpp"
 

--- a/external/libcxx-test/std/utilities/memory/util.smartptr/util.smartptr.shared/util.smartptr.shared.const/shared_ptr_Y.pass.cpp
+++ b/external/libcxx-test/std/utilities/memory/util.smartptr/util.smartptr.shared/util.smartptr.shared.const/shared_ptr_Y.pass.cpp
@@ -33,6 +33,7 @@
 #include <memory>
 #include <type_traits>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 #include "smartptr_shared_common.hpp"
 

--- a/external/libcxx-test/std/utilities/memory/util.smartptr/util.smartptr.shared/util.smartptr.shared.const/shared_ptr_pointer.pass.cpp
+++ b/external/libcxx-test/std/utilities/memory/util.smartptr/util.smartptr.shared/util.smartptr.shared.const/shared_ptr_pointer.pass.cpp
@@ -32,6 +32,7 @@
 
 #include <memory>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 #include "smartptr_shared_common.hpp"
 

--- a/external/libcxx-test/std/utilities/utility/pairs/pair.astuple/get_rv.pass.cpp
+++ b/external/libcxx-test/std/utilities/utility/pairs/pair.astuple/get_rv.pass.cpp
@@ -37,6 +37,7 @@
 #include <utility>
 #include <memory>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 int tc_libcxx_utilities_pair_astuple_get_rv(void)

--- a/external/libcxx-test/std/utilities/utility/pairs/pair.astuple/tuple_element.pass.cpp
+++ b/external/libcxx-test/std/utilities/utility/pairs/pair.astuple/tuple_element.pass.cpp
@@ -31,6 +31,7 @@
 // tuple_element<I, pair<T1, T2> >::type
 
 #include <utility>
+#include "test_macros.h"
  #include "libcxx_tc_common.h"
 
 template <class T1, class T2>

--- a/external/libcxx-test/std/utilities/utility/pairs/pair.astuple/tuple_size.pass.cpp
+++ b/external/libcxx-test/std/utilities/utility/pairs/pair.astuple/tuple_size.pass.cpp
@@ -31,6 +31,7 @@
 // tuple_size<pair<T1, T2> >::value
 
 #include <utility>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 int tc_libcxx_utilities_pair_astuple_tuple_size(void)

--- a/external/libcxx-test/std/utilities/utility/pairs/pair.piecewise/piecewise_construct.pass.cpp
+++ b/external/libcxx-test/std/utilities/utility/pairs/pair.piecewise/piecewise_construct.pass.cpp
@@ -36,6 +36,7 @@
 #include <utility>
 #include <tuple>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 class A

--- a/external/libcxx-test/std/utilities/utility/pairs/pairs.pair/U_V.pass.cpp
+++ b/external/libcxx-test/std/utilities/utility/pairs/pairs.pair/U_V.pass.cpp
@@ -36,6 +36,7 @@
 #include <utility>
 #include <memory>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 #include "archetypes.hpp"

--- a/external/libcxx-test/std/utilities/utility/pairs/pairs.pair/assign_rv_pair.pass.cpp
+++ b/external/libcxx-test/std/utilities/utility/pairs/pairs.pair/assign_rv_pair.pass.cpp
@@ -35,6 +35,7 @@
 #include <utility>
 #include <memory>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 

--- a/external/libcxx-test/std/utilities/utility/pairs/pairs.pair/assign_rv_pair_U_V.pass.cpp
+++ b/external/libcxx-test/std/utilities/utility/pairs/pairs.pair/assign_rv_pair_U_V.pass.cpp
@@ -35,6 +35,7 @@
 #include <utility>
 #include <memory>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 #include <archetypes.hpp>
 

--- a/external/libcxx-test/std/utilities/utility/pairs/pairs.pair/const_first_const_second.pass.cpp
+++ b/external/libcxx-test/std/utilities/utility/pairs/pairs.pair/const_first_const_second.pass.cpp
@@ -34,6 +34,7 @@
 
 #include <utility>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 #include "archetypes.hpp"

--- a/external/libcxx-test/std/utilities/utility/pairs/pairs.pair/const_pair_U_V.pass.cpp
+++ b/external/libcxx-test/std/utilities/utility/pairs/pairs.pair/const_pair_U_V.pass.cpp
@@ -34,6 +34,7 @@
 
 #include <utility>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 #include "archetypes.hpp"

--- a/external/libcxx-test/std/utilities/utility/pairs/pairs.pair/piecewise.pass.cpp
+++ b/external/libcxx-test/std/utilities/utility/pairs/pairs.pair/piecewise.pass.cpp
@@ -37,6 +37,7 @@
 #include <utility>
 #include <tuple>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 int tc_libcxx_utilities_pairs_pair_piecewise(void)

--- a/external/libcxx-test/std/utilities/utility/pairs/pairs.pair/rv_pair_U_V.pass.cpp
+++ b/external/libcxx-test/std/utilities/utility/pairs/pairs.pair/rv_pair_U_V.pass.cpp
@@ -35,6 +35,7 @@
 #include <utility>
 #include <memory>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 #include "archetypes.hpp"

--- a/external/libcxx-test/std/utilities/utility/pairs/pairs.pair/swap.pass.cpp
+++ b/external/libcxx-test/std/utilities/utility/pairs/pairs.pair/swap.pass.cpp
@@ -32,6 +32,7 @@
 
 #include <utility>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 struct S {

--- a/external/libcxx-test/std/utilities/utility/pairs/pairs.pair/types.pass.cpp
+++ b/external/libcxx-test/std/utilities/utility/pairs/pairs.pair/types.pass.cpp
@@ -34,6 +34,7 @@
 
 #include <utility>
 #include <type_traits>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 int tc_libcxx_utilities_pairs_pair_types(void)

--- a/external/libcxx-test/std/utilities/utility/pairs/pairs.spec/non_member_swap.pass.cpp
+++ b/external/libcxx-test/std/utilities/utility/pairs/pairs.spec/non_member_swap.pass.cpp
@@ -32,6 +32,7 @@
 
 #include <utility>
 #include <cassert>
+#include "test_macros.h"
 #include "libcxx_tc_common.h"
 
 int tc_libcxx_utilities_pairs_spec_non_member_swap(void)


### PR DESCRIPTION
Backport patch from llvm. Include 'test_macros.h' to all tests that were missing them.
It fix random hardfaults during utc tests.

Signed-off-by: Sangamanatha <sangam.swami@samsung.com>