### PR TITLE
apps/camera : Add USER_ENTRYPOINT when Enable ENTRY_CAMERATEST

### DIFF
--- a/apps/examples/camera/Kconfig
+++ b/apps/examples/camera/Kconfig
@@ -9,3 +9,7 @@ config EXAMPLES_CAMERATEST
 	depends on VIDEO_SOURCE
 	---help---
 		Enable the camera example
+
+config USER_ENTRYPOINT
+	string
+	default "camera_main" if ENTRY_CAMERATEST

--- a/apps/examples/camera/camera_main.c
+++ b/apps/examples/camera/camera_main.c
@@ -246,7 +246,7 @@ static void free_buffer(struct v_buffer *buffers, uint8_t bufnum)
  * Public Functions
  ****************************************************************************/
 #ifdef CONFIG_BUILD_KERNEL
-int camera_main(int argc, FAR char *argv[])
+int main(int argc, FAR char *argv[])
 #else
 int camera_main(int argc, char *argv[])
 #endif


### PR DESCRIPTION
When ENTRY_CAMERATEST is enabled, USER_ENTRYPOINT must be 'camera_main'.