### PR TITLE
[README.md] Fix blockquote in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ To check all pre-defined configurations, type as follows:
 ##### 1.1 Additional Configuration (optional)
 After basic configuration by [1. Configuration](#1-configuration), you can additionally modify your configuration with *menuconfig*.
 
-``bash
+```bash
 ./dbuild.sh menuconfig
 ```
 > **Note**


### PR DESCRIPTION
Blockquote in README.md misses a ` character. This commit fixes it.