### PR TITLE
Add ramdump support for stm32l4

### DIFF
--- a/os/arch/arm/src/stm32l4/Make.defs
+++ b/os/arch/arm/src/stm32l4/Make.defs
@@ -55,6 +55,7 @@ CMN_CSRCS += up_releasepending.c up_releasestack.c up_reprioritizertr.c
 CMN_CSRCS += up_schedulesigaction.c up_sigdeliver.c up_stackframe.c
 CMN_CSRCS += up_svcall.c up_systemreset.c up_trigger_irq.c up_udelay.c
 CMN_CSRCS += up_unblocktask.c up_usestack.c up_vfork.c
+CMN_CSRCS += up_puts.c
 
 # Configuration-dependent common files
 

--- a/os/arch/arm/src/stm32l4/hal/stm32l4xx_hal_interface.c
+++ b/os/arch/arm/src/stm32l4/hal/stm32l4xx_hal_interface.c
@@ -46,8 +46,6 @@
 
 void ST_USART2_UART_Init(void);
 void SystemClock_Config(void);
-void lowputc(char ch);
-char lowgetc(void);
 void debuggpio_init(void);
 void gpio_reset(void);
 void gpio_set(void);
@@ -151,34 +149,6 @@ void ST_USART2_UART_Init(void)
   LL_USART_DisableFIFO(USART2);
   LL_USART_ConfigAsyncMode(USART2);
   LL_USART_Enable(USART2);
-}
-
-void lowputc(char ch)
-{
-#if 1
-    while(!LL_USART_IsActiveFlag_TXE(USART2)){}
-    LL_USART_TransmitData8(USART2, (uint8_t)(ch & 0xFFU));
-    while(!LL_USART_IsActiveFlag_TC(USART2)){}
-#else
-    //while(__HAL_UART_GET_FLAG(&huart2, UART_FLAG_TXE) == 0);
-    //huart2.Instance->TDR = (uint8_t)(ch & 0xFFU);
-    USART2->TDR = (uint8_t)(ch & 0xFFU);                
-    //while(__HAL_UART_GET_FLAG(&huart2, UART_FLAG_TC) == 0);
-#endif
-}
-
-char lowgetc(void)
-{
-    char ch;
-    if(LL_USART_IsActiveFlag_ORE(USART2)){
-        LL_USART_ClearFlag_ORE(USART2);
-    }
-
-    while(!LL_USART_IsActiveFlag_RXNE(USART2)){
-    }
-
-    ch = LL_USART_ReceiveData8(USART2);
-    return ch;
 }
 
 void debuggpio_init(void)

--- a/os/arch/arm/src/stm32l4/stm32l4_start.c
+++ b/os/arch/arm/src/stm32l4/stm32l4_start.c
@@ -118,7 +118,7 @@ static void go_nx_start(void *pv, unsigned int nbytes)
  ****************************************************************************/
 
 #ifdef CONFIG_DEBUG
-#  define showprogress(c) lowputc(c)//up_lowputc(c)
+#  define showprogress(c) up_lowputc(c)
 #else
 #  define showprogress(c)
 #endif

--- a/os/board/stm32l4r9ai-disco/src/Makefile
+++ b/os/board/stm32l4r9ai-disco/src/Makefile
@@ -89,6 +89,13 @@ VPATH += :$(TOPDIR)/board/common
 CSRCS += partitions.c
 endif
 
+DEPPATH += --dep-path $(TOPDIR)/board/common
+VPATH += :$(TOPDIR)/board/common
+
+ifeq ($(CONFIG_BOARD_CRASHDUMP),y)
+CSRCS += crashdump.c
+endif
+
 CSRCS += stm32l4r9i_discovery.c
 CSRCS += stm32l4r9i_discovery_io.c
 CSRCS += stm32l4r9i_discovery_ts.c


### PR DESCRIPTION
This patch enables ramdump support using TizenRT ramdump tool for stm32l4 board.

#### RESULT is as follows:

Please enter serial port adapter:
For example: /dev/ttyUSB1 or /dev/ttyACM0
Enter:
/dev/ttyACM0
[sudo] password for vidisha:
Target Handshake successful do_handshake
Target entered to ramdump mode

=========================================================================
Ramdump Region Options:
1. ALL
2. Region 0:    ( Address: 0x20000000, Size: 196608 )    [Heap index = 0]
3. Region 1:    ( Address: 0x20030000, Size: 65536 )     [Heap index = 0]
4. Region 2:    ( Address: 0x20040000, Size: 393216 )    [Heap index = 0]
=========================================================================
Please enter desired ramdump option as below:
        1 for ALL
        2 for Region 0
        25 for Region 0 & 3 ...
Please enter your input: 1

No. of Regions to be dumped received: ramdump_recv

Receiving ramdump......

********************************************************************************
Dumping Region: 0, Address: 0x20000000, Size: 196608bytes
********************************************************************************
[============>]
********************************************************************************
Dumping Region: 1, Address: 0x20030000, Size: 65536bytes
********************************************************************************
[====>]
********************************************************************************
Dumping Region: 2, Address: 0x20040000, Size: 393216bytes
********************************************************************************[========================>]
Ramdump received successfully..!

