### PR TITLE
arch/arm/src/imxrt: Support ramdump via uart support in imxrt board.

### DIFF
--- a/os/arch/arm/src/imxrt/Make.defs
+++ b/os/arch/arm/src/imxrt/Make.defs
@@ -60,7 +60,7 @@ CMN_ASRCS += up_fetchadd.S vfork.S
 
 CMN_CSRCS  = up_assert.c up_blocktask.c up_copyfullstate.c up_coherent_dcache.c
 CMN_CSRCS += up_createstack.c up_mdelay.c up_udelay.c up_exit.c
-CMN_CSRCS += up_initialize.c up_initialstate.c up_interruptcontext.c
+CMN_CSRCS += up_puts.c up_initialize.c up_initialstate.c up_interruptcontext.c
 CMN_CSRCS += up_memfault.c up_modifyreg8.c up_modifyreg16.c up_modifyreg32.c
 CMN_CSRCS += up_releasepending.c up_releasestack.c up_reprioritizertr.c
 CMN_CSRCS += up_schedulesigaction.c up_sigdeliver.c up_stackframe.c

--- a/os/arch/arm/src/imxrt/imxrt_lowputc.h
+++ b/os/arch/arm/src/imxrt/imxrt_lowputc.h
@@ -68,7 +68,17 @@
 #include "chip.h"
 #include "imxrt_config.h"
 
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+/* LPUART Data Register */
+#define LPUART_ALL_INTS (LPUART_CTRL_ORIE(1U) | LPUART_CTRL_NEIE(1U) | LPUART_CTRL_FEIE(1U) |  \
+			LPUART_CTRL_PEIE(1U) | LPUART_CTRL_TIE(1U)  | LPUART_CTRL_TCIE(1U) |  \
+			LPUART_CTRL_RIE(1U)  | LPUART_CTRL_ILIE(1U) | LPUART_CTRL_MA1IE(1U) | \
+			LPUART_CTRL_MA2IE(1U))
 
+#define LPUART_DATA_SHIFT              (0)	/* Bits 0-9: Data bits 0-9 */
+#define LPUART_DATA_MASK               (0x3ff << LPUART_DATA_SHIFT)
 /****************************************************************************
  * Public Types
  ****************************************************************************/
@@ -124,7 +134,8 @@ int imxrt_lpuart_configure(uint32_t base, FAR const struct uart_config_s *config
  ************************************************************************************/
 
 #if defined(HAVE_LPUART_DEVICE) && defined(CONFIG_DEBUG)
-void imxrt_lowputc(int ch);
+void imxrt_lowputc(char ch);
+uint8_t imxrt_lowgetc(void);
 #else
 #define imxrt_lowputc(ch)
 #endif


### PR DESCRIPTION
This patch add interface for TizenRT ramdump tool.

Find the below test logs :

Please enter serial port adapter:
For example: /dev/ttyUSB1 or /dev/ttyACM0
Enter:
/dev/ttyACM0
Target Handshake successful do_handshake
Target entered to ramdump mode

=========================================================================
Ramdump Region Options:
1. ALL  ( Address: 80000000, Size: 33554432 )

=========================================================================
Please enter desired ramdump option as below:
        1 for ALL
Please enter your input: 1

No. of Regions to be dumped received: ramdump_recv

Receiving ramdump......

=========================================================================
Dumping data, Address: 0x80000000, Size: 33554432bytes
=========================================================================
[========>

Ramdump received successfully..!

Signed-off-by: Sangamanatha <sangam.swami@samsung.com>