### PR TITLE
tools/symbolviewer: Support printing call stack information.

### DIFF
--- a/tools/symbolview/README.md
+++ b/tools/symbolview/README.md
@@ -1,0 +1,42 @@
+# SymbolViewer
+
+The Symbol viewer will help developer when they faced a error.
+It will show some call stack information
+when the application has been faced any abort.
+
+### Prerequisites
+Install python2.7, pyserial(at pip)
+
+### How to USE
+
+1. Enable Debug Options.
+    Debug Options
+      -> [*] Enable backtracking using Frame pointer register
+2. Run Script
+    $ python cmdautotest.py serial_port
+
+    ex)
+    $ python symbolviewer.py /dev/ttyUSB1
+
+```
+...
+unwind_backtrace_with_fp: Task: [appmain], Pid: [6], TaskAddr: [0x206b7d0] and [Current : appmain]
+unwind_backtrace_with_fp: stack size 0x27ec
+unwind_backtrace_with_fp: Registers are Valid, We may be either Interrupt context/exception context
+unwind_backtrace_with_fp: fp:0x2070bbc , sp:0x2070b90 , pc:0x412ba30
+unwind_backtrace_with_fp: [<0x412ba30>]
+ 	: /root/tizenrt/framework/src/st_things/things_stack/framework/things_security_manager.c:702
+unwind_backtrace_with_fp: [<0x412bc4c>]
+ 	: /root/tizenrt/framework/src/st_things/things_stack/framework/things_security_manager.c:678
+unwind_backtrace_with_fp: [<0x4121e24>]
+ 	: /root/tizenrt/framework/src/st_things/things_stack/things_stack.c:317
+unwind_backtrace_with_fp: [<0x411dc74>]
+ 	: /root/tizenrt/framework/src/st_things/st_things.c:372
+unwind_backtrace_with_fp: [<0x40d71b8>]
+ 	: /root/tizenrt/apps/examples/st_things/light/sample_light_things.c:142
+unwind_backtrace_with_fp: [<0x40d6dcc>]
+ 	: /root/tizenrt/apps/examples/st_things/st_things_sample_main.c:35
+unwind_backtrace_with_fp: [<0x40cc990>]
+ 	: /root/tizenrt/os/kernel/task/task_start.c:180
+unwind_frame_with_fp: End of Callstack
+```

--- a/tools/symbolview/symbolviewer.py
+++ b/tools/symbolview/symbolviewer.py
@@ -1,0 +1,104 @@
+###########################################################################
+#
+# Copyright 2019 Samsung Electronics All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+#
+###########################################################################
+
+from collections import OrderedDict
+from operator import eq
+
+import subprocess
+import serial
+import threading
+import time
+import sys
+
+isExit = False
+
+def rxfromUART(port):
+    global isExit
+    isStackInfo = False
+    length = len("unwind_backtrace_with_fp: [<")
+
+    while(isExit == False):
+        time.sleep(0.01)
+
+        lines = port.readlines()
+
+        if lines == None:
+            continue
+
+        for line in lines:
+
+            if line.find("unwind_backtrace_with_fp: Call Stack:") != -1:
+                isStackInfo = True
+            elif line.find("unwind_frame_with_fp: End of Callstack") != -1:
+                isStackInfo = False
+
+            if isStackInfo == True:
+                if line.find("unwind_backtrace_with_fp: [<") != -1:
+                             #unwind_backtrace_with_fp: [<
+                    addr = line[length: length + 10]
+
+                    proc = subprocess.Popen(["addr2line" ,
+                                    "-e" ,
+                                    "../../build/output/bin/tinyara",
+                                    addr], stdout=subprocess.PIPE)
+                    ouput, err = proc.communicate()
+                    time.sleep(0.01)
+
+                    sys.stdout.write( "%s \t: %s" % ((line),  ouput.decode('utf-8')))
+
+            else:
+                sys.stdout.write( "%s" % (line))
+
+def txtoUART(port, send):
+    if send.find("\n") != -1:
+        PORT.write((send).encode())
+    else:
+        PORT.write((send+"\n").encode())
+
+def wait2commnad(port):
+    global isExit
+    cmd = ""
+    while(isExit == False):
+        time.sleep(0.1)
+        cmd = sys.stdin.readline()
+        cmd.strip()
+        if eq(cmd, "exit\n"):
+            isExit = True
+            break
+        txtoUART(port, cmd)
+
+
+if (__name__ == '__main__'):
+    # init
+
+    PORT = serial.Serial(sys.argv[1], baudrate=115200, timeout=0.1)
+
+    rxthread = threading.Thread(target=rxfromUART,args=(PORT,))
+    rxthread.daemon = True
+    rxthread.start()
+
+    txthread = threading.Thread(target=wait2commnad, args=(PORT,))
+    txthread.daemon = True
+    txthread.start()
+
+    while(isExit == False):
+        time.sleep(0.1)
+
+    if (isExit == True):
+        txthread.join()
+        rxthread.join()


### PR DESCRIPTION
It will support developer to follow call stack to improve aborted application.

1. Enable Debug Options.
    Debug Options
      -> [*] Enable backtracking using Frame pointer register
2. Run logassist.
    [TizenRT]/tools$ python symbolviewer.py /dev/ttyUSB1

example:
print_callstack: *******************************************************************************
unwind_backtrace_with_fp: Task: [appmain], Pid: [6], TaskAddr: [0x206b7d0] and [Current : appmain]
unwind_backtrace_with_fp: stack size 0x27ec
unwind_backtrace_with_fp: Registers are Valid, We may be either Interrupt context/exception context
unwind_backtrace_with_fp: fp:0x2070bbc , sp:0x2070b90 , pc:0x412ba30
unwind_backtrace_with_fp: [<0x412ba30>]
 	: /root/tizenrt/framework/src/st_things/things_stack/framework/things_security_manager.c:702
unwind_backtrace_with_fp: [<0x412bc4c>]
 	: /root/tizenrt/framework/src/st_things/things_stack/framework/things_security_manager.c:678
unwind_backtrace_with_fp: [<0x4121e24>]
 	: /root/tizenrt/framework/src/st_things/things_stack/things_stack.c:317
unwind_backtrace_with_fp: [<0x411dc74>]
 	: /root/tizenrt/framework/src/st_things/st_things.c:372
unwind_backtrace_with_fp: [<0x40d71b8>]
 	: /root/tizenrt/apps/examples/st_things/light/sample_light_things.c:142
unwind_backtrace_with_fp: [<0x40d6dcc>]
 	: /root/tizenrt/apps/examples/st_things/st_things_sample_main.c:35
unwind_backtrace_with_fp: [<0x40cc990>]
 	: /root/tizenrt/os/kernel/task/task_start.c:180
unwind_frame_with_fp: End of Callstack