### PR TITLE
compression : Change default compression algorithm to Miniz

### DIFF
--- a/os/compression/Kconfig
+++ b/os/compression/Kconfig
@@ -16,7 +16,7 @@ if COMPRESSED_BINARY
 
 config COMPRESSION_TYPE
 	int "Compression Algorithm Type"
-	default 1
+	default 2
 	range 1 2
 	---help---
 		Enter compression type.


### PR DESCRIPTION
Miniz has lower compression ratio, but has big advantage of decompressing compared with LZMA.
So select the default compression algorithm as Miniz.