### PR TITLE
fs/vfs:  Change the return value of fs_getfilep()

### DIFF
--- a/os/board/sidk_s5jt200/src/slip_if.c
+++ b/os/board/sidk_s5jt200/src/slip_if.c
@@ -61,15 +61,18 @@ typedef void *sio_fd_t;
 sio_fd_t sio_open(u8_t devnum)
 {
 	int fd;
+	struct file *filep = NULL;
 
 	fd = open("/dev/ttyDBG", O_RDWR, 0666);
 	if (fd < 3) {
 		fs_dupfd2(fd, 3);
 		close(fd);
-		return fs_getfilep(3);
+		fs_getfilep(3, &filep);
+		return filep;
 	}
 
-	return fs_getfilep(fd);
+	fs_getfilep(fd, &filep);
+	return filep;
 }
 
 /**

--- a/os/fs/aio/aioc_contain.c
+++ b/os/fs/aio/aioc_contain.c
@@ -121,16 +121,15 @@ FAR struct aio_container_s *aio_contain(FAR struct aiocb *aiocbp)
 #ifdef CONFIG_PRIORITY_INHERITANCE
 	struct sched_param param;
 #endif
+	int ret;
 
 #ifdef AIO_HAVE_FILEP
 	{
 		/* Get the file structure corresponding to the file descriptor. */
 
-		u.filep = fs_getfilep(aiocbp->aio_fildes);
-		if (!u.filep) {
-			/* The errno value has already been set */
-
-			return NULL;
+		ret = fs_getfilep(aiocbp->aio_fildes, &u.filep);
+		if (ret < 0) {
+			goto errout;
 		}
 	}
 #endif
@@ -160,6 +159,9 @@ FAR struct aio_container_s *aio_contain(FAR struct aiocb *aiocbp)
 	dq_addlast(&aioc->aioc_link, &g_aio_pending);
 	aio_unlock();
 	return aioc;
+errout:
+	set_errno(-ret);
+	return NULL;
 }
 
 /****************************************************************************

--- a/os/fs/inode/fs_files.c
+++ b/os/fs/inode/fs_files.c
@@ -226,6 +226,7 @@ int file_dup(FAR struct file *filep, int minfd)
 {
 	int fd2;
 	struct file *filep2;
+	int ret;
 
 	/* Verify that fd is a valid, open file descriptor */
 	if (!filep || !filep->f_inode) {
@@ -244,15 +245,14 @@ int file_dup(FAR struct file *filep, int minfd)
 		goto errout_with_inode;
 	}
 
-	filep2 = fs_getfilep(fd2);
-	if (!filep2) {
+	ret = fs_getfilep(fd2, &filep2);
+	if (ret < 0) {
 		goto errout_with_inode;
 	}
 
 	DEBUGASSERT(filep->f_inode == filep2->f_inode);
 
 	if (filep->f_inode->u.i_ops && filep->f_inode->u.i_ops->open) {
-		int ret = 0;
 #ifndef CONFIG_DISABLE_MOUNTPOINT
 		if (INODE_IS_MOUNTPT(filep->f_inode)) {
 			/* Dup the open file on the in the new file structure */

--- a/os/fs/vfs/fs_dupfd.c
+++ b/os/fs/vfs/fs_dupfd.c
@@ -93,19 +93,29 @@
 int fs_dupfd(int fd, int minfd)
 {
 	FAR struct file *filep;
+	int ret;
 
 	/* Get the file structure corresponding to the file descriptor. */
 
-	filep = fs_getfilep(fd);
-	if (!filep) {
-		/* The errno value has already been set */
-
-		return ERROR;
+	ret = fs_getfilep(fd, &filep);
+	if (ret < 0) {
+		goto errout;
 	}
+
+	DEBUGASSERT(filep != NULL);
 
 	/* Let file_dup() do the real work */
 
-	return file_dup(filep, minfd);
+	ret = file_dup(filep, minfd);
+	if (ret < 0) {
+		goto errout;
+	}
+
+	return ret;
+
+errout:
+	set_errno(-ret);
+	return ERROR;
 }
 
 #endif							/* CONFIG_NFILE_DESCRIPTORS > 0 */

--- a/os/fs/vfs/fs_fdopen.c
+++ b/os/fs/vfs/fs_fdopen.c
@@ -84,16 +84,15 @@ static inline int fs_checkfd(FAR struct tcb_s *tcb, int fd, int oflags)
 {
 	FAR struct file *filep;
 	FAR struct inode *inode;
+	int ret;
 
 	DEBUGASSERT(tcb && tcb->group);
 
 	/* Get the file structure corresponding to the file descriptor. */
 
-	filep = fs_getfilep(fd);
-	if (!filep) {
-		/* The errno value has already been set */
-
-		return ERROR;
+	ret = fs_getfilep(fd, &filep);
+	if (ret < 0) {
+		return ret;
 	}
 
 	/* Get the inode associated with the file descriptor.  This should

--- a/os/fs/vfs/fs_fstat.c
+++ b/os/fs/vfs/fs_fstat.c
@@ -102,13 +102,14 @@ int fstat(int fd, FAR struct stat *buf)
 		return ERROR;
 	}
 
-	/* The descriptor is in a valid range to file descriptor... do the
-	 * read.	First, get the file structure.	Note that on failure,
-	 * fs_getfilep() will set the errno variable. */
-	filep = fs_getfilep(fd);
-	if (filep == NULL) {
-		/* The errno value has already been set */
-		return ERROR;
+	/* The descriptor is in a valid range for a file descriptor... do the
+	 * fstat.  First, get the file structure.  Note that on failure,
+	 * fs_getfilep() will set the errno variable.
+	 */
+
+	ret = fs_getfilep(fd, &filep);
+	if (ret < 0) {
+		goto errout;
 	}
 
 	/* Get the inode from the file structure */
@@ -141,4 +142,7 @@ int fstat(int fd, FAR struct stat *buf)
 
 	/* Successfully fstat'ed the file */
 	return OK;
+errout:
+	set_errno(-ret);
+	return ERROR;
 }

--- a/os/fs/vfs/fs_fstatfs.c
+++ b/os/fs/vfs/fs_fstatfs.c
@@ -92,14 +92,17 @@ int fstatfs(int fd, FAR struct statfs *buf)
 
 	DEBUGASSERT(buf != NULL);
 
-	/* First, get the file structure.
-     * Note that on failure, fs_getfilep() will set the errno variable.
+	/* The descriptor is in a valid range to file descriptor... do the
+	 * read.  First, get the file structure.  Note that on failure,
+	 * fs_getfilep() will set the errno variable.
 	 */
-	filep = fs_getfilep(fd);
-	if (filep == NULL) {
-		/* The errno value has already been set */
-		return ERROR;
+
+	ret = fs_getfilep(fd, &filep);
+	if (ret < 0) {
+		goto errout;
 	}
+
+	DEBUGASSERT(filep != NULL);
 
 	/* Get the inode from the file structure */
 	inode = filep->f_inode;
@@ -139,4 +142,7 @@ int fstatfs(int fd, FAR struct statfs *buf)
 
 	/* Successfully statfs'ed the file */
 	return OK;
+errout:
+	set_errno(-ret);
+	return ERROR;
 }

--- a/os/fs/vfs/fs_fsync.c
+++ b/os/fs/vfs/fs_fsync.c
@@ -154,19 +154,22 @@ int fsync(int fd)
 
 	/* Get the file structure corresponding to the file descriptor. */
 
-	filep = fs_getfilep(fd);
-	if (!filep) {
-		/* The errno value has already been set */
-
-		leave_cancellation_point();
-		return ERROR;
+	ret = fs_getfilep(fd, &filep);
+	if (ret < 0) {
+		goto errout;
 	}
+
+	DEBUGASSERT(filep != NULL);
 
 	/* Perform the fsync operation */
 
 	ret = file_fsync(filep);
 	leave_cancellation_point();
 	return ret;
+errout:
+	leave_cancellation_point();
+	set_errno(-ret);
+	return ERROR;
 }
 
 #endif							/* !CONFIG_DISABLE_MOUNTPOINT */

--- a/os/fs/vfs/fs_lseek.c
+++ b/os/fs/vfs/fs_lseek.c
@@ -188,19 +188,33 @@ errout:
 off_t lseek(int fd, off_t offset, int whence)
 {
 	FAR struct file *filep;
+	off_t newpos;
+	int errcode;
+	int ret;
 
 	/* Get the file structure corresponding to the file descriptor. */
 
-	filep = fs_getfilep(fd);
-	if (!filep) {
-		/* The errno value has already been set */
-
-		return (off_t)ERROR;
+	ret = fs_getfilep(fd, &filep);
+	if (ret < 0) {
+		errcode = -ret;
+		goto errout;
 	}
+
+	DEBUGASSERT(filep != NULL);
 
 	/* Then let file_seek do the real work */
 
-	return file_seek(filep, offset, whence);
+	newpos = file_seek(filep, offset, whence);
+	if (newpos < 0) {
+		errcode = (int)-newpos;
+		goto errout;
+	}
+
+	return newpos;
+
+errout:
+	set_errno(errcode);
+	return (off_t)ERROR;
 }
 
 #endif

--- a/os/fs/vfs/fs_open.c
+++ b/os/fs/vfs/fs_open.c
@@ -206,11 +206,9 @@ int open(const char *path, int oflags, ...)
 
 	/* Get the file structure corresponding to the file descriptor. */
 
-	filep = fs_getfilep(fd);
-	if (!filep) {
-		/* The errno value has already been set */
-		leave_cancellation_point();
-		return ERROR;
+	ret = fs_getfilep(fd, &filep);
+	if (ret < 0) {
+		goto errout_with_inode;
 	}
 
 	/* Perform the driver open operation.  NOTE that the open method may be

--- a/os/fs/vfs/fs_poll.c
+++ b/os/fs/vfs/fs_poll.c
@@ -149,11 +149,9 @@ static int poll_fdsetup(int fd, FAR struct pollfd *fds, bool setup)
 
 	/* Get the file pointer corresponding to this file descriptor */
 
-	filep = fs_getfilep(fd);
-	if (!filep) {
-		/* The errno value has already been set */
-
-		return ERROR;
+	ret = fs_getfilep(fd, &filep);
+	if (ret < 0) {
+		return ret;
 	}
 
 	inode = filep->f_inode;

--- a/os/fs/vfs/fs_read.c
+++ b/os/fs/vfs/fs_read.c
@@ -181,21 +181,18 @@ ssize_t read(int fd, FAR void *buf, size_t nbytes)
 		FAR struct file *filep;
 
 		/* The descriptor is in a valid range to file descriptor... do the
-		 * read.  First, get the file structure. Note that on failure,
+		 * read.  First, get the file structure.  Note that on failure,
 		 * fs_getfilep() will set the errno variable.
 		 */
 
-		filep = fs_getfilep(fd);
-		if (!filep) {
-			/* The errno value has already been set */
-
-			ret = ERROR;
-		} else {
-
-			/* Then let file_read do all of the work */
-
-			ret = file_read(filep, buf, nbytes);
+		ret = (ssize_t)fs_getfilep(fd, &filep);
+		if (ret < 0) {
+			return ret;
 		}
+
+		/* Then let file_read do all of the work. */
+
+		ret = file_read(filep, buf, nbytes);
 	}
 #endif
 

--- a/os/fs/vfs/fs_write.c
+++ b/os/fs/vfs/fs_write.c
@@ -198,18 +198,15 @@ ssize_t write(int fd, FAR const void *buf, size_t nbytes)
 	}
 #if CONFIG_NFILE_DESCRIPTORS > 0
 	else {
-		/* The descriptor is in the right range to be a file descriptor... write
-		 * to the file. Note that fs_getfilep() will set the errno on failure.
+		/* The descriptor is in the right range to be a file descriptor..
+		 * write to the file.  Note that fs_getfilep() will set the errno on
+		 * failure.
 		 */
 
-		filep = fs_getfilep(fd);
-		if (!filep) {
-			/* The errno value has already been set */
-
-			ret = ERROR;
-		} else {
-			/* Perform the write operation using the file descriptor as an index.
-			 * Note that file_write() will set the errno on failure.
+		ret = (ssize_t)fs_getfilep(fd, &filep);
+		if (ret >= 0) {
+			/* Perform the write operation using the file descriptor as an
+			 * index.  Note that file_write() will set the errno on failure.
 			 */
 
 			ret = file_write(filep, buf, nbytes);

--- a/os/include/tinyara/fs/fs.h
+++ b/os/include/tinyara/fs/fs.h
@@ -727,18 +727,18 @@ int lib_flushall(FAR struct streamlist *list);
  *   file.  NOTE that this function will currently fail if it is provided
  *   with a socket descriptor.
  *
- * Parameters:
- *   fd - The file descriptor
+ * Input Parameters:
+ *   fd    - The file descriptor
+ *   filep - The location to return the struct file instance
  *
- * Return:
- *   A point to the corresponding struct file instance is returned on
- *   success.  On failure,  NULL is returned and the errno value is
- *   set appropriately (EBADF).
+ * Returned Value:
+ *   Zero (OK) is returned on success; a negated errno value is returned on
+ *   any failure.
  *
  ****************************************************************************/
 
 #if CONFIG_NFILE_DESCRIPTORS > 0
-FAR struct file *fs_getfilep(int fd);
+int fs_getfilep(int fd, FAR struct file **filep);
 #endif
 
 /* fs/fs_read.c *************************************************************/


### PR DESCRIPTION
It no longer sets the errno variable but, rather, returns errors in the same manner as other internal OS functions.
This commit is taken from Nuttx.