### PR TITLE
fs/vfs/fs_open.c:  Fix error in vopen() function

### DIFF
--- a/os/fs/vfs/fs_open.c
+++ b/os/fs/vfs/fs_open.c
@@ -131,9 +131,7 @@ int vopen(FAR const char *path, int oflags, va_list ap)
 	/* If the file is opened for creation, then get the mode bits */
 
 	if ((oflags & (O_WRONLY | O_CREAT)) != 0) {
-		va_start(ap, oflags);
 		mode = va_arg(ap, mode_t);
-		va_end(ap);
 	}
 #endif
 


### PR DESCRIPTION
'va_start' is used in function with fixed args.
'va_start'/'va_end' should not be used in vopen function,
because it has fixed arguments.