### PR TITLE
os: Modify dbuild.sh to work around on centos linux

### DIFF
--- a/os/dbuild.sh
+++ b/os/dbuild.sh
@@ -431,7 +431,7 @@ function BUILD()
 		fi
 	fi
 	echo "Docker Image Version : ${DOCKER_VERSION}"
-	docker run --rm ${DOCKER_OPT} -v ${TOPDIR}:/root/tizenrt -w /root/tizenrt/os tizenrt/tizenrt:${DOCKER_VERSION} ${BUILD_CMD} $1 2>&1 | tee build.log
+	docker run --rm ${DOCKER_OPT} -v ${TOPDIR}:/root/tizenrt -w /root/tizenrt/os --privileged tizenrt/tizenrt:${DOCKER_VERSION} ${BUILD_CMD} $1 2>&1 | tee build.log
 
 	UPDATE_STATUS
 }


### PR DESCRIPTION
dbuild.sh doesn't work out on centos linux with permission problem.
Add --privileged option to fix it