### PR TITLE
socket: Define PF and AF after including LWIP

### DIFF
--- a/os/include/sys/sock_internal.h
+++ b/os/include/sys/sock_internal.h
@@ -69,40 +69,6 @@
  * Definitions
  ****************************************************************************/
 
-/* The socket()domain parameter specifies a communication domain; this selects
- * the protocol family which will be used for communication.
- */
-
-/* Protocol families */
-
-#define PF_UNSPEC       0		/* Protocol family unspecified */
-#define PF_UNIX         1		/* Local communication */
-#define PF_LOCAL        1		/* Local communication */
-#define PF_INET         2		/* IPv4 Internet protocols */
-#define PF_INET6        3		/* IPv6 Internet protocols */
-#define PF_IPX          4		/* IPX - Novell protocols */
-#define PF_NETLINK      5		/* Kernel user interface device */
-#define PF_X25          6		/* ITU-T X.25 / ISO-8208 protocol */
-#define PF_AX25         7		/* Amateur radio AX.25 protocol */
-#define PF_ATMPVC       8		/* Access to raw ATM PVCs */
-#define PF_APPLETALK    9		/* Appletalk */
-#define PF_PACKET      10		/* Low level packet interface */
-
-/* Address families */
-
-#define AF_UNSPEC      PF_UNSPEC
-#define AF_UNIX        PF_UNIX
-#define AF_LOCAL       PF_LOCAL
-#define AF_INET        PF_INET
-#define AF_INET6       PF_INET6
-#define AF_IPX         PF_IPX
-#define AF_NETLINK     PF_NETLINK
-#define AF_X25         PF_X25
-#define AF_AX25        PF_AX25
-#define AF_ATMPVC      PF_ATMPVC
-#define AF_APPLETALK   PF_APPLETALK
-#define AF_PACKET      PF_PACKET
-
 /* The socket created by socket() has the indicated type, which specifies
  * the communication semantics.
  */

--- a/os/include/sys/socket.h
+++ b/os/include/sys/socket.h
@@ -87,6 +87,58 @@ extern "C" {
 #endif
 
 /****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/* The socket()domain parameter specifies a communication domain; this selects
+ * the protocol family which will be used for communication.
+ */
+
+/* Supported Protocol Families */
+
+#ifndef PF_UNSPEC
+#define PF_UNSPEC 0 /* Protocol family unspecified */
+#endif
+#ifndef PF_UNIX
+#define PF_UNIX 1 /* Local communication */
+#endif
+#ifndef PF_LOCAL
+#define PF_LOCAL 1 /* Local communication */
+#endif
+#ifndef PF_INET
+#define PF_INET 2 /* IPv4 Internet protocols */
+#endif
+#ifndef PF_INET6
+#define PF_INET6 10 /* IPv6 Internet protocols */
+#endif
+#ifndef PF_PACKET
+#define PF_PACKET 17 /* Low level packet interface */
+#endif
+
+/* Supported Address Families. Opengroup.org requires only AF_UNSPEC,
+ * AF_UNIX, AF_INET and AF_INET6.
+ */
+
+#ifndef AF_UNSPEC
+#define AF_UNSPEC PF_UNSPEC
+#endif
+#ifndef AF_UNIX
+#define AF_UNIX PF_UNIX
+#endif
+#ifndef AF_LOCAL
+#define AF_LOCAL PF_LOCAL
+#endif
+#ifndef AF_INET
+#define AF_INET PF_INET
+#endif
+#ifndef AF_INET6
+#define AF_INET6 PF_INET6
+#endif
+#ifndef AF_PACKET
+#define AF_PACKET PF_PACKET
+#endif
+
+/****************************************************************************
  * Public Structure
  ****************************************************************************/
 

--- a/os/include/tinyara/lwnl/lwnl.h
+++ b/os/include/tinyara/lwnl/lwnl.h
@@ -45,7 +45,7 @@
 
 
 /* Light-weight netlink domain definition */
-#define AF_LWNL 1
+#define AF_LWNL 3
 
 /*	Event type */
 #define LWNL_ROUTE 1


### PR DESCRIPTION
After including LWIP, socket.h define address families and protocol
families which are not defined.