### PR TITLE
apps/shell : Fix build warning

### DIFF
--- a/apps/shell/tash_command.c
+++ b/apps/shell/tash_command.c
@@ -54,9 +54,7 @@
 #endif
 #define TASH_CMDS_PER_LINE			(4)
 
-#if CONFIG_TASH_MAX_STORE_COMMANDS > 0
-#define TASH_MAX_STORE              (CONFIG_TASH_MAX_STORE_COMMANDS)
-
+#if TASH_MAX_STORE > 0
 #define CMD_INDEX_UP(x)                                   \
 	do {                                                  \
 		((x) == TASH_MAX_STORE - 1) ? (x) = 0 : (x)++;    \
@@ -100,7 +98,7 @@ static int tash_exit(int argc, char **args);
 #if defined(CONFIG_BOARDCTL_RESET)
 static int tash_reboot(int argc, char **argv);
 #endif
-#if CONFIG_TASH_MAX_STORE_COMMANDS   > 0
+#if TASH_MAX_STORE   > 0
 static int tash_history(int argc, char **argv);
 #endif
 
@@ -126,13 +124,13 @@ const static tash_cmdlist_t tash_basic_cmds[] = {
 #if defined(CONFIG_BOARDCTL_RESET)
 	{"reboot", tash_reboot, TASH_EXECMD_SYNC},
 #endif
-#if CONFIG_TASH_MAX_STORE_COMMANDS > 0
+#if TASH_MAX_STORE > 0
 	{"history", tash_history, TASH_EXECMD_SYNC},
 #endif
 	{NULL,    NULL,        0}
 };
 
-#if CONFIG_TASH_MAX_STORE_COMMANDS   > 0
+#if TASH_MAX_STORE   > 0
 static char cmd_store[TASH_MAX_STORE][TASH_LINEBUFLEN];
 static char cmd_line[TASH_LINEBUFLEN];
 static int cmd_pos;
@@ -207,7 +205,7 @@ static int tash_exit(int argc, char **args)
  *  @ingroup tash
  */
 
-#if CONFIG_TASH_MAX_STORE_COMMANDS > 0
+#if TASH_MAX_STORE > 0
 static int tash_history(int argc, char **args)
 {
 	int cmd_idx = 1;

--- a/apps/shell/tash_internal.h
+++ b/apps/shell/tash_internal.h
@@ -28,6 +28,12 @@
 #define tash_free(a)          free(a)
 #define TASH_LINEBUFLEN       (128)
 
+#ifdef CONFIG_TASH_MAX_STORE_COMMANDS
+#define TASH_MAX_STORE        (CONFIG_TASH_MAX_STORE_COMMANDS)
+#else
+#define TASH_MAX_STORE        (0)
+#endif  
+
 #ifdef CONFIG_CPP_HAVE_VARARGS
 #ifdef CONFIG_DEBUG_TASH
 #ifdef CONFIG_DEBUG_TASH_ERROR
@@ -60,7 +66,7 @@
 
 bool tash_do_autocomplete(char *cmd, int *pos, bool double_tab);
 
-#if CONFIG_TASH_MAX_STORE_COMMANDS > 0
+#if TASH_MAX_STORE > 0
 void tash_get_cmd_from_history(int num, char *cmd);
 bool tash_search_cmd(char *cmd, int *pos, char status);
 void tash_store_line(char *line);

--- a/apps/shell/tash_main.c
+++ b/apps/shell/tash_main.c
@@ -160,7 +160,7 @@ static char *tash_read_input_line(int fd)
 					}
 					is_tab_pressed = true;
 				}
-#if CONFIG_TASH_MAX_STORE_COMMANDS   > 0
+#if TASH_MAX_STORE   > 0
 				else if (buffer[pos] == ASCII_ESC && buffer[pos + 1] == ASCII_LBRACKET) {
 					/* ASCII_ESC + ASCII_LBRACKET + ASCII_A is up
 					 * ASCII_ESC + ASCII_LBRACKET + ASCII_B is down
@@ -300,7 +300,7 @@ int tash_execute_cmdline(char *buff)
 	bool is_nextcmd = false;
 	int ret = OK;
 
-#if CONFIG_TASH_MAX_STORE_COMMANDS > 0
+#if TASH_MAX_STORE > 0
 	if (buff[0] == '!') {
 		int cmd_number = atoi(buff + 1);
 		tash_get_cmd_from_history(cmd_number, buff);


### PR DESCRIPTION
If CONFIG_TASH_MAX_STORE_COMMANDS is not config,
'#if CONFIG_TASH_MAX_STORE_COMMANDS > 0 'is build warning.
So modified from '#if CONFIG_TASH_MAX_STORE_COMMANDS > 0' to
'#if TASH_MAX_STORE > 0'.