### PR TITLE
net/lwip: Synchronize access to mbox between sending tasks

### DIFF
--- a/os/net/lwip/src/api/api_lib.c
+++ b/os/net/lwip/src/api/api_lib.c
@@ -145,6 +145,9 @@ struct netconn *netconn_new_with_proto_and_callback(enum netconn_type t, u8_t pr
 #if !LWIP_NETCONN_SEM_PER_THREAD
 			LWIP_ASSERT("conn has no op_completed", sys_sem_valid(&conn->op_completed));
 			sys_sem_free(&conn->op_completed);
+			sys_sem_set_invalid(&conn->op_completed);
+			sys_sem_free(&conn->op_sync);
+			sys_sem_set_invalid(&conn->op_sync);
 #endif							/* !LWIP_NETCONN_SEM_PER_THREAD */
 			sys_mbox_free(&conn->recvmbox);
 			memp_free(MEMP_NETCONN, conn);

--- a/os/net/lwip/src/api/tcpip.c
+++ b/os/net/lwip/src/api/tcpip.c
@@ -67,6 +67,8 @@
 #include "lwip/netif/etharp.h"
 #include "lwip/netif/ethernet.h"
 #include "lwip/netif/ppp_oe.h"
+#include "lwip/api.h"
+#include "lwip/priv/api_msg.h"
 
 #define TCPIP_MSG_VAR_REF(name)     API_VAR_REF(name)
 #define TCPIP_MSG_VAR_DECLARE(name) API_VAR_DECLARE(struct tcpip_msg, name)
@@ -351,10 +353,11 @@ err_t tcpip_send_msg_wait_sem(tcpip_callback_fn fn, void *apimsg, sys_sem_t *sem
 	return ERR_OK;
 #else							/* LWIP_TCPIP_CORE_LOCKING */
 	TCPIP_MSG_VAR_DECLARE(msg);
+	struct api_msg *p_apimsg = (struct api_msg *)apimsg;
 
 	LWIP_ASSERT("semaphore not initialized", sys_sem_valid(sem));
 	LWIP_ASSERT("Invalid mbox", sys_mbox_valid_val(mbox));
-
+	sys_arch_sem_wait(&p_apimsg->conn->op_sync, 0);
 	TCPIP_MSG_VAR_ALLOC(msg);
 	TCPIP_MSG_VAR_REF(msg).type = TCPIP_MSG_API;
 	TCPIP_MSG_VAR_REF(msg).msg.api_msg.function = fn;
@@ -362,6 +365,7 @@ err_t tcpip_send_msg_wait_sem(tcpip_callback_fn fn, void *apimsg, sys_sem_t *sem
 	sys_mbox_post(&mbox, &TCPIP_MSG_VAR_REF(msg));
 	sys_arch_sem_wait(sem, 0);
 	TCPIP_MSG_VAR_FREE(msg);
+	sys_sem_signal(&p_apimsg->conn->op_sync);
 	return ERR_OK;
 #endif							/* LWIP_TCPIP_CORE_LOCKING */
 }

--- a/os/net/lwip/src/include/lwip/api.h
+++ b/os/net/lwip/src/include/lwip/api.h
@@ -247,7 +247,10 @@ struct netconn {
 #if !LWIP_NETCONN_SEM_PER_THREAD
 	/* sem that is used to synchronously execute functions in the core context */
 	sys_sem_t op_completed;
+	/* sem that is used to synchroneously post messages on the netconn in tcpip_apimsg() */
+	sys_sem_t op_sync;
 #endif
+
 	/*
 	 * mbox where received packets are stored until they are fetched
 	 * by the netconn application thread (can grow quite big)


### PR DESCRIPTION
Synchronize access to mbox using a `op-sync` sempahore. In effect, this commit reinstates an earlier [patch](https://github.com/Samsung/TizenRT/commit/19d2dc6e33df7fece97ac5d6df8ca66dccd60ac2#diff-a9481755452c015da55b0766857a43dc) that was removed over time.