### PR TITLE
net/netmgr: Add missed header

### DIFF
--- a/os/net/netmgr/netstack.h
+++ b/os/net/netmgr/netstack.h
@@ -19,6 +19,7 @@
 #ifndef _NETMGR_NETSTACK_H__
 #define _NETMGR_NETSTACK_H__
 
+#include <net/if.h>
 struct netstack_ops {
 	// start, stop
 	int (*init)(void *data);


### PR DESCRIPTION
struct netmon_sock is defined at net/if.h