### PR TITLE
kernel/task : Add Fast Interrupt Notification APIs

### DIFF
--- a/os/include/sys/syscall.h
+++ b/os/include/sys/syscall.h
@@ -480,10 +480,12 @@
 
 #if CONFIG_TASK_NAME_SIZE > 0
 #define SYS_prctl                      (SYS_nnetsocket + 0)
-#define SYS_maxsyscall                 (SYS_nnetsocket + 1)
+#define SYS_fin_wait                   (SYS_nnetsocket + 1)
 #else
-#define SYS_maxsyscall                 SYS_nnetsocket
+#define SYS_fin_wait                   SYS_nnetsocket
 #endif
+
+#define SYS_maxsyscall                 SYS_fin_wait
 
 /* Note that the reported number of system calls does *NOT* include the
  * architecture-specific system calls.  If the "real" total is required,

--- a/os/include/tinyara/irq.h
+++ b/os/include/tinyara/irq.h
@@ -60,6 +60,8 @@
 #include <assert.h>
 #endif
 
+#include <sys/types.h>
+
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
@@ -75,6 +77,8 @@
 #define irq_detach(irq) irq_attach(irq, NULL, NULL)
 #endif
 #endif
+
+#define NO_FIN_DATA -999
 /****************************************************************************
  * Public Types
  ****************************************************************************/
@@ -133,6 +137,23 @@ int irq_attach(int irq, xcpt_t isr, FAR void *arg);
 void irq_info(void);
 
 #endif
+
+/**
+ * @cond
+ * @internal
+ */
+int fin_notify(pid_t pid, int data);
+/**
+ * @endcond
+ */
+/**
+ * @brief wait for kenrel irq event
+ * @details @b #include <tinyara/irq.h> \n
+ * @return On success, OK is returned. On failure, ERROR will be returned.
+ * SYSTEM CALL API \n
+ * @since TizenRT v3.1 PRE
+ */
+int fin_wait(void);
 
 #undef EXTERN
 #ifdef __cplusplus

--- a/os/include/tinyara/sched.h
+++ b/os/include/tinyara/sched.h
@@ -230,7 +230,7 @@ enum tstate_e {
 
 	TSTATE_TASK_INACTIVE,		/* BLOCKED      - Initialized but not yet activated */
 	TSTATE_WAIT_SEM,			/* BLOCKED      - Waiting for a semaphore */
-	TSTATE_WAIT_UNBLOCK,		/* BLOCKED		- Waiting to be unblocked by another task */
+	TSTATE_WAIT_FIN,		/* BLOCKED		- Waiting to be unblocked by fin */
 #ifndef CONFIG_DISABLE_SIGNALS
 	TSTATE_WAIT_SIG,			/* BLOCKED      - Waiting for a signal */
 #endif
@@ -643,6 +643,9 @@ struct tcb_s {
 #ifdef CONFIG_TASK_MONITOR
 	bool is_active;
 #endif
+
+	int fin_data;			/* Irq notification Data to be handled */
+	int pending_fin_data;		/* Pended irq notification data */
 };
 
 /* struct task_tcb_s *************************************************************/

--- a/os/kernel/binary_manager/binary_manager_recovery.c
+++ b/os/kernel/binary_manager/binary_manager_recovery.c
@@ -264,7 +264,7 @@ int binary_manager_faultmsg_sender(int argc, char *argv[])
 
 	while (1) {
 		/* Wait for fault messages and handle it */
-		up_block_task(this_task(), TSTATE_WAIT_UNBLOCK);
+		up_block_task(this_task(), TSTATE_WAIT_FIN);
 		while (!sq_empty(&g_faultmsg_list)) {
 			msg = (struct faultmsg_s *)sq_remfirst(&g_faultmsg_list);
 			request_msg.cmd = BINMGR_FAULT;

--- a/os/kernel/init/os_start.c
+++ b/os/kernel/init/os_start.c
@@ -170,7 +170,7 @@ volatile dq_queue_t g_waitingforfill;
 
 /* This is the list of all tasks that are blocking waiting to be unblocked another threads */
 
-volatile dq_queue_t g_waitingforunblock;
+volatile dq_queue_t g_waitingforfin;
 
 /* This the list of all tasks that have been initialized, but not yet
  * activated. NOTE:  This is the only list that is not prioritized.
@@ -227,7 +227,7 @@ const struct tasklist_s g_tasklisttable[NUM_TASK_STATES] = {
 	{&g_readytorun,           true },	/* TSTATE_TASK_RUNNING */
 	{&g_inactivetasks,        false},	/* TSTATE_TASK_INACTIVE */
 	{&g_waitingforsemaphore,  true },	/* TSTATE_WAIT_SEM */
-	{&g_waitingforunblock,    true }	/* TSTATE_WAIT_UNBLOCK */
+	{&g_waitingforfin,    true }		/* TSTATE_WAIT_FIN */
 #ifndef CONFIG_DISABLE_SIGNALS
 	,
 	{&g_waitingforsignal,     false}	/* TSTATE_WAIT_SIG */

--- a/os/kernel/irq/Make.defs
+++ b/os/kernel/irq/Make.defs
@@ -51,6 +51,7 @@
 ############################################################################
 
 CSRCS += irq_initialize.c irq_attach.c irq_dispatch.c irq_unexpectedisr.c
+CSRCS += fin_wait.c fin_notify.c
 
 ifeq ($(CONFIG_DEBUG_IRQ_INFO),y)
 CSRCS += irq_procfs.c

--- a/os/kernel/irq/fin_notify.c
+++ b/os/kernel/irq/fin_notify.c
@@ -1,0 +1,79 @@
+/****************************************************************************
+ *
+ * Copyright 2020 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <stdbool.h>
+#include <arch/irq.h>
+#include <sys/types.h>
+#include <tinyara/arch.h>
+#include <tinyara/irq.h>
+#include <tinyara/sched.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: fin_notify
+ *
+ * Description:
+ *   This function sends an irq event to specific pid task.
+ *   If that task was waiting FIN, it will be unblocked when receiving irq event.
+ *   But if that task was waiting another object, such as semaphore, this will update
+ *  the data only into the specific pid task's tcb, not make it be unblocked.
+ *
+ * Inputs:
+ *   pid - The task ID of the task to receive the irq event.
+ *   data - The data which passed to user.
+ *
+ * Return Value:
+ *   OK on success; or ERROR on failure
+ *
+ ****************************************************************************/
+
+int fin_notify(pid_t pid, int data)
+{
+	int saved_state;
+	struct tcb_s *tcb;
+
+	saved_state = irqsave();
+
+	tcb = sched_gettcb(pid);
+	if (tcb == NULL) {
+		return ERROR;
+	}
+
+	if (tcb->fin_data == NO_FIN_DATA) {
+		/* If this is the first irq, save the data in the first. */
+		tcb->fin_data = data;
+	} else {
+		/* If there is already pending irq, queueing new data. */
+		tcb->pending_fin_data = data;
+	}
+
+	if (tcb->task_state == TSTATE_WAIT_FIN) {
+		up_unblock_task(tcb);
+	}
+
+	irqrestore(saved_state);
+
+	return OK;
+}

--- a/os/kernel/irq/fin_wait.c
+++ b/os/kernel/irq/fin_wait.c
@@ -1,0 +1,97 @@
+/****************************************************************************
+ *
+ * Copyright 2020 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <assert.h>
+#include <stdbool.h>
+#include <string.h>
+#include <arch/irq.h>
+#include <sys/types.h>
+#include <tinyara/arch.h>
+#include <tinyara/irq.h>
+#include <tinyara/sched.h>
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+static void update_fin_queue(struct tcb_s *tcb)
+{
+	if (tcb->pending_fin_data != NO_FIN_DATA) {
+		tcb->fin_data = tcb->pending_fin_data;
+		tcb->pending_fin_data = NO_FIN_DATA;
+	} else {
+		tcb->fin_data = NO_FIN_DATA;
+	}	
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: fin_wait
+ *
+ * Description:
+ *   This function is for waiting kernel irq event.
+ *   If a task calls this function, it will be blocked until receiving irq event.
+ *
+ * Inputs:
+ *   None.
+ *
+ * Return Value:
+ *   On success, received data will be returned.
+ *   On failure, NO_FIN_DATA(-999) will be returned.
+ *
+ ****************************************************************************/
+
+int fin_wait(void)
+{
+	int ret = NO_FIN_DATA;
+	int saved_state;
+	struct tcb_s *tcb;
+
+	saved_state = irqsave();
+
+	tcb = sched_self();
+	DEBUGASSERT(tcb);
+
+	if (tcb->fin_data != NO_FIN_DATA) {
+		/* If there is already pending irq, return saved irq data. */
+		ret = tcb->fin_data;
+
+		/* If there is second pending irq, update the irq data. */
+		update_fin_queue(tcb);
+		irqrestore(saved_state);
+		return ret;
+	}
+
+	up_block_task(tcb, TSTATE_WAIT_FIN);
+
+	if (tcb->fin_data != NO_FIN_DATA) {
+		ret = tcb->fin_data;
+	}
+	/* If there is pending irq, update the irq data array. */
+	update_fin_queue(tcb);
+
+	irqrestore(saved_state);
+
+	return ret;
+}

--- a/os/kernel/task/task_setup.c
+++ b/os/kernel/task/task_setup.c
@@ -65,6 +65,7 @@
 
 #include <tinyara/arch.h>
 #include <tinyara/ttrace.h>
+#include <tinyara/irq.h>
 #ifdef CONFIG_SCHED_CPULOAD
 #include <tinyara/clock.h>
 #endif
@@ -474,6 +475,7 @@ static int thread_schedsetup(FAR struct tcb_s *tcb, int priority, start_t start,
 #endif
 
 #endif
+		tcb->fin_data = NO_FIN_DATA;
 
 		/* Add the task to the inactive task list */
 

--- a/os/syscall/syscall.csv
+++ b/os/syscall/syscall.csv
@@ -21,6 +21,7 @@
 "execv","unistd.h","defined(CONFIG_LIBC_EXECFUNCS)","int","FAR const char *","FAR char *const []|FAR char *const *"
 "exit", "stdlib.h", "", "void", "int"
 "fcntl", "fcntl.h", "CONFIG_NFILE_DESCRIPTORS > 0", "int", "int", "int", "..."
+"fin_wait", "tinyara/irq.h", "", "int"
 "fs_fdopen", "tinyara/fs/fs.h", "CONFIG_NFILE_DESCRIPTORS > 0 && CONFIG_NFILE_STREAMS > 0", "FAR struct file_struct*", "int", "int", "FAR struct tcb_s*"
 "fs_ioctl", "tinyara/fs/fs.h", "defined(CONFIG_LIBC_IOCTL_VARIADIC) && (CONFIG_NSOCKET_DESCRIPTORS > 0 || CONFIG_NFILE_DESCRIPTORS > 0)", "int", "int", "int", "unsigned long"
 "fstat","sys/stat.h","CONFIG_NFILE_DESCRIPTORS > 0","int","int","FAR struct stat*"

--- a/os/syscall/syscall_lookup.h
+++ b/os/syscall/syscall_lookup.h
@@ -351,6 +351,8 @@ SYSCALL_LOOKUP(socket,                  3, STUB_socket)
 SYSCALL_LOOKUP(prctl,                   5, STUB_prctl)
 #endif
 
+SYSCALL_LOOKUP(fin_wait,           	0, STUB_fin_wait)
+
 /****************************************************************************
  * Private Functions
  ****************************************************************************/

--- a/os/syscall/syscall_stublookup.c
+++ b/os/syscall/syscall_stublookup.c
@@ -367,6 +367,8 @@ uintptr_t STUB_socket(int nbr, uintptr_t parm1, uintptr_t parm2,
 uintptr_t STUB_prctl(int nbr, uintptr_t parm1, uintptr_t parm2,
 					 uintptr_t parm3, uintptr_t parm4, uintptr_t parm5);
 
+uintptr_t STUB_fin_wait(int nbr);
+
 /****************************************************************************
  * Public Data
  ****************************************************************************/


### PR DESCRIPTION
Fast Interrupt Notification(FIN) is for event from kernel to user.
It has advantages of speed and RAM usage.

There is 1 public API which anyone can use, and 1 internal API which kernel only can use.
[public] fin_wait : wait to receive kernel irq event
[internal] fin_notify : send event to specific pid