### PR TITLE
stm32: Fix coding rule violation

### DIFF
--- a/os/arch/arm/src/stm32/stm32_eth.c
+++ b/os/arch/arm/src/stm32/stm32_eth.c
@@ -596,9 +596,9 @@
  */
 
 struct stm32_ethmac_s {
-	uint8_t ifup: 1;				/* true:ifup false:ifdown */
-	uint8_t mbps100: 1;			/* 100MBps operation (vs 10 MBps) */
-	uint8_t fduplex: 1;			/* Full (vs. half) duplex */
+	uint8_t ifup:1;				/* true:ifup false:ifdown */
+	uint8_t mbps100:1;			/* 100MBps operation (vs 10 MBps) */
+	uint8_t fduplex:1;			/* Full (vs. half) duplex */
 	WDOG_ID txpoll;				/* TX poll timer */
 	WDOG_ID txtimeout;			/* TX timeout timer */
 #ifdef CONFIG_NET_NOINTS


### PR DESCRIPTION
[SPC_M_OPR] spaces prohibited around that ':' (ctx:VxW)