### PR TITLE
external/include/libcxx: Backport max_align_t type from LLVM. 

### DIFF
--- a/external/include/libcxx/cstddef
+++ b/external/include/libcxx/cstddef
@@ -97,6 +97,13 @@ namespace std
 #if __cplusplus >= 201103L
   using nullptr_t = decltype(nullptr);
 #endif
+#if defined(__CLANG_MAX_ALIGN_T_DEFINED) || defined(_GCC_MAX_ALIGN_T) || \
+    defined(__DEFINED_max_align_t) || defined(__NetBSD__)
+// Re-use the compiler's <stddef.h> max_align_t where possible.
+using ::max_align_t;
+#else
+typedef long double max_align_t;
+#endif
 }
 
 #endif // __INCLUDE_CXX_CSTDDEF


### PR DESCRIPTION
max_align_t will be needed for tflite framework.

test result -
============ Test ofstream ==============================
printf: Starting test_ostream
printf: Successfully opened /dev/console
cout: Successfully opened /dev/console
Writing this to /dev/console
============ Test iostream ==============================
Hello, this is only a test
Print an int: 190
Print a char: d
============ Test STL(Array) ============================
1 2 3 4
10 11 12 13

Signed-off-by: Sangamanatha <sangam.swami@samsung.com>