### PR TITLE
include/sys/un.h: Remove an incorrect comment

### DIFF
--- a/os/include/sys/un.h
+++ b/os/include/sys/un.h
@@ -18,7 +18,7 @@
 /****************************************************************************
  * include/sys/un.h
  *
- *   Copyright (C) 2015 Gregory Nutt. All rights reserved.
+ *   Copyright (C) 2015, 2020 Gregory Nutt. All rights reserved.
  *   Author: Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
@@ -56,10 +56,6 @@
 /****************************************************************************
  * Included Files
  ****************************************************************************/
-
-/* The sys/un.> header defines the type sa_family_t as described in
- * sys/socket.h.
- */
 
 #include <tinyara/config.h>
 #include <sys/socket.h>


### PR DESCRIPTION
This commit is taken from Nuttx.