### PR TITLE
mm/mm_heapinfo : Remove unnecessary elf_sections_size exclusion

### DIFF
--- a/os/binfmt/libelf/libelf_load.c
+++ b/os/binfmt/libelf/libelf_load.c
@@ -383,17 +383,6 @@ int elf_load(FAR struct elf_loadinfo_s *loadinfo)
 		goto errout_with_buffers;
 	}
 #endif
-
-#if defined(CONFIG_DEBUG_MM_HEAPINFO) && defined(CONFIG_APP_BINARY_SEPARATION)
-	/* Save the text and data region size of new binary into its heap
-	 * for excluding those size when calculating the heap usage.
-	 */
-	loadinfo->uheap->elf_sections_size = loadinfo->textsize + loadinfo->datasize;
-
-	loadinfo->uheap->total_alloc_size = 0;
-	loadinfo->uheap->peak_alloc_size = 0;
-#endif
-
 	return OK;
 
 	/* Error exits */

--- a/os/include/tinyara/mm/mm.h
+++ b/os/include/tinyara/mm/mm.h
@@ -396,10 +396,6 @@ struct mm_heap_s {
 	int mm_nregions;
 #endif
 
-#ifdef CONFIG_APP_BINARY_SEPARATION
-	size_t elf_sections_size;
-#endif
-
 	/* All free nodes are maintained in a doubly linked list.  This
 	 * array provides some hooks into the list at various points to
 	 * speed searches for free nodes.

--- a/os/mm/mm_heap/mm_heapinfo.c
+++ b/os/mm/mm_heap/mm_heapinfo.c
@@ -219,9 +219,7 @@ void heapinfo_parse(FAR struct mm_heap_s *heap, int mode, pid_t pid)
 	printf("     Summary of Heap Usages (Size in Bytes)\n");
 	printf("****************************************************************\n");
 	heap_size = heap->mm_heapsize;
-#ifdef CONFIG_APP_BINARY_SEPARATION
-	heap_size -= heap->elf_sections_size;
-#endif
+
 	printf("Total                           : %u (100%%)\n", heap_size);
 	printf("  - Allocated (Current / Peak)  : %u (%d%%) / %u (%d%%)\n",\
 		heap->total_alloc_size, (size_t)((uint64_t)(heap->total_alloc_size) * 100 / heap_size),\


### PR DESCRIPTION
    The current user heap allocation logic is as follows:
    
    1. allocate partition for app using kumm_memalign API
    2. place the elf sections directly in this partition
    3. initialize the uheap (which is the application's heap) at the end of the data section
    So we don't need to exclude elf_sections_size anymore.