### PR TITLE
network: add net_poll interface

### DIFF
--- a/os/fs/vfs/fs_poll.c
+++ b/os/fs/vfs/fs_poll.c
@@ -68,11 +68,7 @@
 #include <tinyara/cancelpt.h>
 #include <tinyara/semaphore.h>
 #include <tinyara/fs/fs.h>
-
-#ifdef CONFIG_NET_LWIP
-#include "lwip/sockets.h"
-#endif
-
+#include <tinyara/net/net.h>
 #include <arch/irq.h>
 
 #include "inode/inode.h"
@@ -131,9 +127,7 @@ static int poll_fdsetup(int fd, FAR struct pollfd *fds, bool setup)
 
 #if defined(CONFIG_NET) && CONFIG_NSOCKET_DESCRIPTORS > 0
 		if ((unsigned int)fd < (CONFIG_NFILE_DESCRIPTORS + CONFIG_NSOCKET_DESCRIPTORS)) {
-#ifdef CONFIG_NET_LWIP
-			return lwip_poll(fd, fds, setup);
-#endif
+			return net_poll(fd, fds, setup);
 		} else
 #endif
 		{

--- a/os/include/tinyara/net/net.h
+++ b/os/include/tinyara/net/net.h
@@ -340,6 +340,21 @@ void net_releaselist(FAR struct socketlist *list);
 int net_close(int sockfd);
 
 /****************************************************************************
+ * Function: net_poll
+ *
+ * Description:
+ *   poll() waits for one of a set of file descriptors to become ready to
+ *   perform I/O.
+ *
+  * Returned Value:
+ *   0 on success; -1 on error with errno set appropriately.
+ *
+ * Assumptions:
+ *
+ ****************************************************************************/
+int net_poll(int sd, struct pollfd *fds, bool setup);
+
+/****************************************************************************
  * Function: net_dupsd
  *
  * Description:

--- a/os/net/netmgr/net_vfs.c
+++ b/os/net/netmgr/net_vfs.c
@@ -123,10 +123,9 @@ int net_close(int sd)
  * Assumptions:
  *
  ****************************************************************************/
-int net_poll(int fd, struct pollfd *fds, bool setup)
+int net_poll(int sd, struct pollfd *fds, bool setup)
 {
-	// ToDo
-	return -1;
+	NETSTACK_CALL_BYFD(sd, poll, (sd, fds, setup));
 }
 
 /****************************************************************************

--- a/os/net/netmgr/netstack_lwip.c
+++ b/os/net/netmgr/netstack_lwip.c
@@ -206,28 +206,9 @@ static int lwip_ns_vfcntl(int sockfd, int cmd, va_list ap)
 }
 
 
-/****************************************************************************
- * Function: lwip_poll
- *
- * Description:
- *	 The standard poll() operation redirects operations on socket descriptors
- *	 to this function.
- *
- * Input Parameters:
- *	 sock - An instance of the lwip socket structure.
- *	 fds   - The structure describing the events to be monitored, OR NULL if
- *			 this is a request to stop monitoring events.
- *	 setup - true: Setup up the poll; false: Teardown the poll
- *
- * Returned Value:
- *	0: Success; Negated errno on failure
- *
- ****************************************************************************/
-
 static int lwip_ns_poll(int fd, struct pollfd *fds, bool setup)
 {
-	// ToDo
-	return 0;
+	return lwip_poll(fd, fds, setup);
 }
 
 

--- a/os/net/socket/Make.defs
+++ b/os/net/socket/Make.defs
@@ -57,6 +57,7 @@ ifeq ($(CONFIG_NET_SOCKET),y)
 SOCK_CSRCS += net_sockets.c net_close.c net_dupsd.c net_dupsd2.c
 SOCK_CSRCS += net_clone.c net_vfcntl.c bsd_socket_api.c
 SOCK_CSRCS += recvmsg.c sendmsg.c
+SOCK_CSRCS += net_poll.c
 endif
 
 # Support for network access using streams

--- a/os/net/socket/net_poll.c
+++ b/os/net/socket/net_poll.c
@@ -1,0 +1,46 @@
+/****************************************************************************
+ *
+ * Copyright 2020 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+#include <tinyara/config.h>
+#ifdef CONFIG_NET
+
+#include <tinyara/net/net.h>
+#ifdef CONFIG_NET_LWIP
+#include "lwip/sockets.h"
+#endif
+
+/****************************************************************************
+ * Function: net_poll
+ *
+ * Description:
+ *   poll() waits for one of a set of file descriptors to become ready to
+ *   perform I/O.
+ *
+  * Returned Value:
+ *   0 on success; -1 on error with errno set appropriately.
+ *
+ * Assumptions:
+ *
+ ****************************************************************************/
+
+int net_poll(int sd, struct pollfd *fds, bool setup)
+{
+	return lwip_poll(sd, fds, setup);
+}
+
+#endif // CONFIG_NET


### PR DESCRIPTION
poll() called lwip_poll directly before.
net_poll is added to hide lwip interface from TizenRT VFS.