### PR TITLE
arch/xtensa/include: add .gitignore to blind the chip and board folders

### DIFF
--- a/os/arch/xtensa/include/.gitignore
+++ b/os/arch/xtensa/include/.gitignore
@@ -1,0 +1,3 @@
+/board
+/chip
+


### PR DESCRIPTION
The build system makes the chip and board folders link at build time using
selected chip and board configuration. So it should not be shown at Git.
This commit adds .gitignore to blind them from git.

===================================================================
TizenRT$ git status
On branch master
Your branch is ahead of 'origin/master' by 44 commits.
  (use "git push" to publish your local commits)

Untracked files:
  (use "git add <file>..." to include in what will be committed)

	os/arch/xtensa/include/board
	os/arch/xtensa/include/chip

==================================================================

Signed-off-by: sunghan-chang <sh924.chang@samsung.com>