### PR TITLE
build/configs/imxrt1050-evk: Add userfs flash provision in download.sh script for Imxrt1050-evk.

### DIFF
--- a/build/configs/imxrt1050-evk/imxrt1050-evk_download.sh
+++ b/build/configs/imxrt1050-evk/imxrt1050-evk_download.sh
@@ -130,7 +130,9 @@ function get_executable_name()
 		app) echo "tinyara_user.bin";;
 		micom) echo "micom";;
 		wifi) echo "wifi";;
+		userfs) echo "imxrt1050-evk_smartfs.bin";;
 		*) echo "No Binary Match"
+		exit 1
 	esac
 }	
 
@@ -142,6 +144,14 @@ function get_partition_index()
                 app | App | APP) echo "1";;
                 micom | Micom | MICOM) echo "2";;
                 wifi | Wifi | WIFI) echo "4";;
+                userfs | Userfs | USERFS)
+                for i in "${!parts[@]}"
+                do
+                   if [[ "${parts[$i]}" = "userfs" ]]; then
+                        echo $i
+                fi
+                done
+                ;;
                 *) echo "No Matching Partition"
                 exit 1
         esac


### PR DESCRIPTION
… script

-Added provision in download script to flash
 userfs (smartfs.bin) image to imxrt1050-evk board.
-Do a "sudo make download userfs" after
 "sudo make downlaod ALL" to flash smartfs.bin image.

Signed-off-by: Amogh Hassija <a.hassija@samsung.com>