### PR TITLE
os/binfmt: Modify loadable app memory regions to reduce memory wastage

### DIFF
--- a/os/arch/arm/src/armv7-m/up_svcall.c
+++ b/os/arch/arm/src/armv7-m/up_svcall.c
@@ -375,9 +375,9 @@ int up_svcall(int irq, FAR void *context, FAR void *arg)
 		* USERSPACE->task_startup method. Instead we pick the PC value
 		* from the app's userspace object stored in its tcb.
 		*
-		* Here, we check if this task is a loadable app (non-zero ram_start)
+		* Here, we check if this task is a loadable app (non-zero uspace)
 		*/
-		if (((struct tcb_s *)sched_self())->ram_start) {
+		if (((struct tcb_s *)sched_self())->uspace) {
 			regs[REG_PC] = (uint32_t)((struct userspace_s *)(((struct tcb_s *)sched_self())->uspace))->task_startup;
 		} else
 		/* If its a normal non-loadable user app, then follow the default method */
@@ -422,9 +422,9 @@ int up_svcall(int irq, FAR void *context, FAR void *arg)
 		* USERSPACE->task_startup method. Instead we pick the PC value
 		* from the app's userspace object stored in its tcb.
 		*
-		* Here, we check if this task is a loadable app (non-zero ram_start)
+		* Here, we check if this task is a loadable app (non-zero uspace)
 		*/
-		if (((struct tcb_s *)sched_self())->ram_start) {
+		if (((struct tcb_s *)sched_self())->uspace) {
 			regs[REG_PC] = (uint32_t)((struct userspace_s *)(((struct tcb_s *)sched_self())->uspace))->pthread_startup;
 		} else
 		/* If its a normal non-loadable user app, then follow the default method */
@@ -477,9 +477,9 @@ int up_svcall(int irq, FAR void *context, FAR void *arg)
 		* USERSPACE->task_startup method. Instead we pick the PC value
 		* from the app's userspace object stored in its tcb.
 		*
-		* Here, we check if this task is a loadable app (non-zero ram_start)
+		* Here, we check if this task is a loadable app (non-zero uspace)
 		*/
-		if (rtcb->ram_start) {
+		if (rtcb->uspace) {
 			regs[REG_PC] = (uint32_t)((struct userspace_s *)(rtcb->uspace))->signal_handler;
 		} else
 		/* If its a normal non-loadable user app, then follow the default method */

--- a/os/binfmt/binfmt_execmodule.c
+++ b/os/binfmt/binfmt_execmodule.c
@@ -178,7 +178,6 @@ int exec_module(FAR struct binary_s *binp)
 
 #ifdef CONFIG_APP_BINARY_SEPARATION
 	binp->uheap = (struct mm_heap_s *)binp->heapstart;
-	binp->uheap_size = binp->ramstart + binp->ramsize - binp->heapstart - sizeof(struct mm_heap_s);
 	mm_initialize(binp->uheap, binp->heapstart + sizeof(struct mm_heap_s), binp->uheap_size);
 #ifdef CONFIG_BINARY_MANAGER
 	mm_add_app_heap_list(binp->uheap, binp->bin_name);
@@ -194,12 +193,12 @@ int exec_module(FAR struct binary_s *binp)
 	/* Initialize the MPU registers in tcb with suitable protection values */
 #ifdef CONFIG_ARMV7M_MPU
 #ifdef CONFIG_OPTIMIZE_APP_RELOAD_TIME
-	/* Complete RAM partition will be configured as RW region */
-	mpu_configure_app_regs(&rtcb->mpu_regs[0], g_mpu_region_nr, (uintptr_t)binp->ramstart, binp->ramsize, false, false);
 	/* Configure text section as RO and executable region */
-	mpu_configure_app_regs(&rtcb->mpu_regs[3], g_mpu_region_nr + 1, (uintptr_t)binp->alloc[0], binp->textsize, true, true);
+	mpu_configure_app_regs(&rtcb->mpu_regs[3], g_mpu_region_nr, (uintptr_t)binp->alloc[0], binp->textsize, true, true);
 	/* Configure ro section as RO and non-executable region */
-	mpu_configure_app_regs(&rtcb->mpu_regs[6], g_mpu_region_nr + 2, (uintptr_t)binp->alloc[3], binp->rosize, true, false);
+	mpu_configure_app_regs(&rtcb->mpu_regs[6], g_mpu_region_nr + 1, (uintptr_t)binp->alloc[3], binp->rosize, true, false);
+	/* Complete RAM partition will be configured as RW region */
+	mpu_configure_app_regs(&rtcb->mpu_regs[0], g_mpu_region_nr + 2, (uintptr_t)binp->alloc[4], binp->ramsize, false, false);
 #else
 	/* Complete RAM partition will be configured as RW region */
 	mpu_configure_app_regs(&rtcb->mpu_regs[0], g_mpu_region_nr, (uintptr_t)binp->ramstart, binp->ramsize, false, true);

--- a/os/binfmt/binfmt_exit.c
+++ b/os/binfmt/binfmt_exit.c
@@ -129,11 +129,10 @@ int binfmt_exit(FAR struct binary_s *bin)
 		}
 		address = (FAR void *)sq_next((FAR sq_entry_t *)address);
 	}
-#ifdef CONFIG_OPTIMIZE_APP_RELOAD_TIME
-	if (!bin->reload)
+#ifndef CONFIG_OPTIMIZE_APP_RELOAD_TIME
+	/* Free the RAM partition into which this app was loaded */
+	kumm_free((void *)bin->ramstart);
 #endif
-		/* Free the RAM partition into which this app was loaded */
-		kumm_free((void *)bin->ramstart);
 #endif
 	/* Free the load structure */
 

--- a/os/binfmt/binfmt_unloadmodule.c
+++ b/os/binfmt/binfmt_unloadmodule.c
@@ -189,13 +189,19 @@ int unload_module(FAR struct binary_s *binp)
 
 		/* Free allocated address spaces */
 
-#ifndef CONFIG_APP_BINARY_SEPARATION
-		for (i = 0; i < BINFMT_NALLOC; i++) {
-			if (binp->alloc[i]) {
-				binfo("Freeing alloc[%d]: %p\n", i, binp->alloc[i]);
-				kumm_free((FAR void *)binp->alloc[i]);
+#if defined(CONFIG_OPTIMIZE_APP_RELOAD_TIME) || !defined(CONFIG_APP_BINARY_SEPARATION)
+#ifdef CONFIG_OPTIMIZE_APP_RELOAD_TIME
+		if (!binp->reload) {
+#endif
+			for (i = 0; i < BINFMT_NALLOC; i++) {
+				if (binp->alloc[i]) {
+					binfo("Freeing alloc[%d]: %p\n", i, binp->alloc[i]);
+					kumm_free((FAR void *)binp->alloc[i]);
+				}
 			}
+#ifdef CONFIG_OPTIMIZE_APP_RELOAD_TIME
 		}
+#endif
 #endif
 
 		/* Notice that the address environment is not destroyed.  This should

--- a/os/binfmt/elf.c
+++ b/os/binfmt/elf.c
@@ -306,7 +306,12 @@ static int elf_loadbinary(FAR struct binary_s *binp)
 	binp->alloc[4] = (FAR void *)loadinfo.dataalloc;
 	binp->textsize = loadinfo.textsize;
 	binp->rosize = loadinfo.rosize;
-	binp->datasize = loadinfo.datasize;
+	/* loadinfo.datasize includes the size of data and bss sections.
+	 * But, binp->datasize is used to backup the data section as
+	 * part of RO region. So, we subtract bss size from loadinfo.datasize
+	 * to obtain the size of just the data backup.
+	 */
+	binp->datasize = loadinfo.datasize - binp->bsssize;
 	binp->datastart = loadinfo.dataalloc;
 #endif
 

--- a/os/binfmt/libelf/libelf_load.c
+++ b/os/binfmt/libelf/libelf_load.c
@@ -137,6 +137,9 @@ static void elf_elfsize(struct elf_loadinfo_s *loadinfo)
 			if ((shdr->sh_flags & SHF_WRITE) != 0) {
 				datasize += ELF_ALIGNUP(shdr->sh_size);
 #ifdef CONFIG_OPTIMIZE_APP_RELOAD_TIME
+				if (shdr->sh_type == SHT_NOBITS) {
+					loadinfo->binp->bsssize = ELF_ALIGNUP(shdr->sh_size);
+				}
 			} else if ((shdr->sh_flags & SHF_EXECINSTR) != 0) {
 				textsize += ELF_ALIGNUP(shdr->sh_size);
 			} else {
@@ -242,7 +245,6 @@ static inline int elf_loadfile(FAR struct elf_loadinfo_s *loadinfo)
 		else {
 #ifdef CONFIG_OPTIMIZE_APP_RELOAD_TIME
 			loadinfo->binp->bssstart = *pptr;
-			loadinfo->binp->bsssize = shdr->sh_size;
 #endif
 			memset(*pptr, 0, shdr->sh_size);
 		}

--- a/os/tools/mkbinheader.py
+++ b/os/tools/mkbinheader.py
@@ -206,8 +206,12 @@ with open(file_path, 'rb') as fp:
         sys.exit(1)
 
     static_ram_size = get_static_ram_size(bin_type)
-    binary_ram_size = int(static_ram_size) + int(dynamic_ram_size)
-    binary_ram_size = roundup_power_two(binary_ram_size)
+    cfg_path = os.getenv('TOPDIR') + '/.config'
+    if check_optimize_config(cfg_path) == True:
+        binary_ram_size = int(dynamic_ram_size)
+    else:
+        binary_ram_size = int(static_ram_size) + int(dynamic_ram_size)
+        binary_ram_size = roundup_power_two(binary_ram_size)
 
     # based on comp_enabled, check if we need to compress binary.
     # If yes, assign to bin_comp value for compression algorithm to use.


### PR DESCRIPTION
If CONFIG_OPTIMIZE_APP_RELOAD_TIME is enabled, then we define 3 MPU regions
for loadable apps. The existing implementation for this is to allocate one large
memory region to cover text, ro, data and heap requirements of the applications.
This large memory region is configured as RW memory in the MPU. Additionally, we
define two MPU regions for text and ro areas which will overlap the large RW region.
Allocating memory regions in this way can sometimes result in wastage of memory
due to the address alignment and region size requirements of the MPU. Specifically,
memory wastage occurs due to resizing the large RW memory region according to the
MPU requirements.

In order to overcome this problem, we modify the memory regions as follows:
- Allocate 2 separate regions for text and ro
- Allocate a seprate memory region for data + heap and configure it as RW region
- All 3 regions will follow the size and address alignment requirements of the MPU

Signed-off-by: Kishore SN <kishore.sn@samsung.com>