### PR TITLE
kernel/mqueue: Match types of variable between structures.

### DIFF
--- a/os/include/mqueue.h
+++ b/os/include/mqueue.h
@@ -85,10 +85,10 @@
 
 /** @brief sturcutre of mqueue attritube */
 struct mq_attr {
-	size_t mq_maxmsg;			/* Max number of messages in queue */
+	uint16_t mq_maxmsg;			/* Max number of messages in queue */
 	size_t mq_msgsize;			/* Max message size */
 	unsigned mq_flags;			/* Queue flags */
-	size_t mq_curmsgs;			/* Number of messages currently in queue */
+	uint16_t mq_curmsgs;			/* Number of messages currently in queue */
 };
 
 /* Message queue descriptor */

--- a/os/include/tinyara/mqueue.h
+++ b/os/include/tinyara/mqueue.h
@@ -85,15 +85,11 @@ struct mq_des;					/* forward reference */
 struct mqueue_inode_s {
 	FAR struct inode *inode;	/* Containing inode */
 	sq_queue_t msglist;			/* Prioritized message list */
-	int16_t maxmsgs;			/* Maximum number of messages in the queue */
-	int16_t nmsgs;				/* Number of message in the queue */
+	uint16_t maxmsgs;			/* Maximum number of messages in the queue */
+	uint16_t nmsgs;				/* Number of message in the queue */
 	int16_t nwaitnotfull;		/* Number tasks waiting for not full */
 	int16_t nwaitnotempty;		/* Number tasks waiting for not empty */
-#if CONFIG_MQ_MAXMSGSIZE < 256
-	uint8_t maxmsgsize;			/* Max size of message in message queue */
-#else
-	uint16_t maxmsgsize;		/* Max size of message in message queue */
-#endif
+	size_t maxmsgsize;			/* Max size of message in message queue */
 #ifndef CONFIG_DISABLE_SIGNALS
 	FAR struct mq_des *ntmqdes;	/* Notification: Owning mqdes (NULL if none) */
 	pid_t ntpid;				/* Notification: Receiving Task's PID */

--- a/os/kernel/mqueue/mq_getattr.c
+++ b/os/kernel/mqueue/mq_getattr.c
@@ -111,7 +111,7 @@ int mq_getattr(mqd_t mqdes, struct mq_attr *mq_stat)
 		mq_stat->mq_maxmsg = mqdes->msgq->maxmsgs;
 		mq_stat->mq_msgsize = mqdes->msgq->maxmsgsize;
 		mq_stat->mq_flags = mqdes->oflags;
-		mq_stat->mq_curmsgs = (size_t)mqdes->msgq->nmsgs;
+		mq_stat->mq_curmsgs = mqdes->msgq->nmsgs;
 
 		ret = OK;
 	}

--- a/os/kernel/mqueue/mq_msgqalloc.c
+++ b/os/kernel/mqueue/mq_msgqalloc.c
@@ -131,8 +131,8 @@ FAR struct mqueue_inode_s *mq_msgqalloc(mode_t mode, FAR struct mq_attr *attr)
 
 		sq_init(&msgq->msglist);
 		if (attr) {
-			msgq->maxmsgs    = (int16_t)attr->mq_maxmsg;
-			msgq->maxmsgsize = (int16_t)attr->mq_msgsize;
+			msgq->maxmsgs    = attr->mq_maxmsg;
+			msgq->maxmsgsize = attr->mq_msgsize;
 		} else {
 			msgq->maxmsgs    = MQ_MAX_MSGS;
 			msgq->maxmsgsize = MQ_MAX_BYTES;

--- a/os/kernel/mqueue/mq_rcvinternal.c
+++ b/os/kernel/mqueue/mq_rcvinternal.c
@@ -136,7 +136,7 @@ int mq_verifyreceive(mqd_t mqdes, FAR char *msg, size_t msglen)
 		return ERROR;
 	}
 
-	if (msglen < (size_t)mqdes->msgq->maxmsgsize) {
+	if (msglen < mqdes->msgq->maxmsgsize) {
 		set_errno(EMSGSIZE);
 		return ERROR;
 	}

--- a/os/kernel/mqueue/mq_sndinternal.c
+++ b/os/kernel/mqueue/mq_sndinternal.c
@@ -141,7 +141,7 @@ int mq_verifysend(mqd_t mqdes, FAR const char *msg, size_t msglen, int prio)
 		return ERROR;
 	}
 
-	if (msglen > (size_t)mqdes->msgq->maxmsgsize) {
+	if (msglen > mqdes->msgq->maxmsgsize) {
 		set_errno(EMSGSIZE);
 		return ERROR;
 	}

--- a/os/kernel/mqueue/mqueue.h
+++ b/os/kernel/mqueue/mqueue.h
@@ -108,11 +108,7 @@ struct mqueue_msg_s {
 	FAR struct mqueue_msg_s *next;	/* Forward link to next message */
 	uint8_t type;					/* (Used to manage allocations) */
 	uint8_t priority;				/* priority of message */
-#if MQ_MAX_BYTES < 256
-	uint8_t msglen;					/* Message data length */
-#else
-	uint16_t msglen;				/* Message data length */
-#endif
+	size_t msglen;					/* Message data length */
 	char mail[MQ_MAX_BYTES];		/* Message data */
 };
 


### PR DESCRIPTION
- Type of variables about message length, 'size_t'
   . maxmsgsize in mqueue_inode_s
   . msglen in mqueue_msg_s
   . msglen parameters of MQ functions.

- Type of variables about message count, 'size_t'
   . maxmsgs, nmsgs in mqueue_inode_s
   . mq_maxmsg, mq_msgsize in mq_attr.