### PR TITLE
Update up_disable_watchdog() dependency on CONFIG_WATCHDOG_FOR_IRQ in imxrt

### DIFF
--- a/os/arch/arm/src/imxrt/imxrt_wdog.c
+++ b/os/arch/arm/src/imxrt/imxrt_wdog.c
@@ -382,6 +382,7 @@ void up_wdog_keepalive(void)
 {
 	imxrt_wdog_refresh(WDOG1);
 }
+#endif
 
 /****************************************************************************
  * Name: up_watchdog_disable
@@ -397,4 +398,3 @@ void up_watchdog_disable(void)
 {
 	imxrt_wdog_disable_all();
 }
-#endif

--- a/os/board/common/crashdump.c
+++ b/os/board/common/crashdump.c
@@ -118,6 +118,9 @@ static int ramdump_via_uart(void)
 	/* Send memory region address, size & heap index to HOST */
 	for (x = 0; x < (CONFIG_MM_REGIONS + CONFIG_KMM_REGIONS); x++) {
 #else
+	/* Send 1 to HOST if kernel heap exists */
+	up_lowputc('0');
+
 	/* Send memory region address, size & heap index to HOST */
 	for (x = 0; x < CONFIG_MM_REGIONS; x++) {
 #endif


### PR DESCRIPTION
This dependency causes build break in imxrt when ramdump is enabled.
This patch updates that dependency
It also updates crashdump file to send no Kernel MM heap notification to the ramdump tool in case only USer MM regions are present.