### PR TITLE
apps/examples/testcase: Fix undefined symbols due to utc_adc testcase

### DIFF
--- a/apps/examples/testcase/ta_tc/systemio/utc/Kconfig
+++ b/apps/examples/testcase/ta_tc/systemio/utc/Kconfig
@@ -48,6 +48,7 @@ endif
 
 config SYSIO_UTC_ADC
 	bool "Sysio ADC TC"
+	depends on IOTBUS_ADC
 	default n
 endif
 

--- a/apps/examples/testcase/ta_tc/systemio/utc/utc_adc.c
+++ b/apps/examples/testcase/ta_tc/systemio/utc/utc_adc.c
@@ -20,10 +20,11 @@
 #include <stdlib.h>
 #include <iotbus/iotbus_adc.h>
 #include <iotbus/iotbus_error.h>
+#include "utc_internal.h"
 
 iotbus_adc_context_h adc;
 
-static void utc_systemio_adc_init_p(void)
+static void utc_systemio_iotbus_adc_init_p(void)
 {
 	iotbus_adc_context_h m_adc = iotbus_adc_init(0, 1);
 	TC_ASSERT_NEQ("iotbus_adc_init", m_adc, NULL);
@@ -31,7 +32,7 @@ static void utc_systemio_adc_init_p(void)
 	TC_SUCCESS_RESULT();
 }
 
-static void utc_systemio_adc_init_n(void)
+static void utc_systemio_iotbus_adc_init_n(void)
 {
 	iotbus_adc_context_h m_adc = iotbus_adc_init(-1, -1);
 	TC_ASSERT_EQ("iotbus_adc_init", m_adc, NULL);
@@ -110,15 +111,15 @@ static void utc_systemio_iotbus_adc_stop_n(void)
 	TC_SUCCESS_RESULT();
 }
 
-static void utc_systemio_adc_deinit_n(void)
+static void utc_systemio_iotbus_adc_deinit_n(void)
 {
 	TC_ASSERT_NEQ("iotbus_adc_deinit", iotbus_adc_deinit(NULL), 0);
 	TC_SUCCESS_RESULT();
 }
 
-static void utc_systemio_adc_deinit_p(void)
+static void utc_systemio_iotbus_adc_deinit_p(void)
 {
-	TC_ASSERT_EQ("iotbus_adc_deinit", iotbus_adc_deinit(adc));
+	TC_ASSERT_EQ("iotbus_adc_deinit", iotbus_adc_deinit(adc), 0);
 	TC_SUCCESS_RESULT();
 }
 


### PR DESCRIPTION
Following are appearing as undefined symbols in the libapps.a and are not getting resolved during final linking stage :
iotbus_adc_get_channel
iotbus_adc_get_state
iotbus_adc_set_channel
iotbus_adc_start
iotbus_adc_stop
TC_ASSERT_EQ
TC_ASSERT_GT
TC_ASSERT_LT
TC_ASSERT_NEQ
TC_SUCCESS_RESULT
utc_systemio_iotbus_adc_deinit_n
utc_systemio_iotbus_adc_deinit_p
utc_systemio_iotbus_adc_init_n
utc_systemio_iotbus_adc_init_p

Signed-off-by: Kishore SN <kishore.sn@samsung.com>