### PR TITLE
testcase/filesystem: Add errno verification and fix expect value of dprintf negative case function

### DIFF
--- a/apps/examples/testcase/le_tc/filesystem/fs_main.c
+++ b/apps/examples/testcase/le_tc/filesystem/fs_main.c
@@ -3044,6 +3044,7 @@ static void tc_libc_stdio_dprintf_invalid_fd_n(void)
 	/* Testcase */
 	ret = dprintf(CONFIG_NFILE_DESCRIPTORS, "%s", str);
 	TC_ASSERT_EQ("dprintf", ret, ERROR);
+	TC_ASSERT_EQ("dprintf", errno, EBADF);
 
 	TC_SUCCESS_RESULT();
 }

--- a/apps/examples/testcase/le_tc/filesystem/fs_main.c
+++ b/apps/examples/testcase/le_tc/filesystem/fs_main.c
@@ -3043,7 +3043,7 @@ static void tc_libc_stdio_dprintf_invalid_fd_n(void)
 
 	/* Testcase */
 	ret = dprintf(CONFIG_NFILE_DESCRIPTORS, "%s", str);
-	TC_ASSERT_EQ("dprintf", ret, 0);
+	TC_ASSERT_EQ("dprintf", ret, ERROR);
 
 	TC_SUCCESS_RESULT();
 }


### PR DESCRIPTION
Add errno verification and fix expect value of the "tc_libc_stdio_dprintf_invalid_fd_n()" function.

#This PR works properly when PR #4211 is merge