### PR TITLE
net/lwip: Synchronize access to mbox between sending tasks

### DIFF
--- a/os/net/lwip/src/api/api_lib.c
+++ b/os/net/lwip/src/api/api_lib.c
@@ -145,6 +145,9 @@ struct netconn *netconn_new_with_proto_and_callback(enum netconn_type t, u8_t pr
 #if !LWIP_NETCONN_SEM_PER_THREAD
 			LWIP_ASSERT("conn has no op_completed", sys_sem_valid(&conn->op_completed));
 			sys_sem_free(&conn->op_completed);
+			sys_sem_set_invalid(&conn->op_completed);
+			sys_sem_free(&conn->op_sync);
+			sys_sem_set_invalid(&conn->op_sync);
 #endif							/* !LWIP_NETCONN_SEM_PER_THREAD */
 			sys_mbox_free(&conn->recvmbox);
 			memp_free(MEMP_NETCONN, conn);

--- a/os/net/lwip/src/include/lwip/api.h
+++ b/os/net/lwip/src/include/lwip/api.h
@@ -247,7 +247,10 @@ struct netconn {
 #if !LWIP_NETCONN_SEM_PER_THREAD
 	/* sem that is used to synchronously execute functions in the core context */
 	sys_sem_t op_completed;
+	/* sem that is used to synchroneously post messages on the netconn in tcpip_apimsg() */
+	sys_sem_t op_sync;
 #endif
+
 	/*
 	 * mbox where received packets are stored until they are fetched
 	 * by the netconn application thread (can grow quite big)


### PR DESCRIPTION
Synchronize access to mbox using a op-sync sempahore. In effect, this commit reinstates an earlier patch that was removed over time.