### PR TITLE
kernel/binary_manager: Deactivate faulty thread if it is RT thread

### DIFF
--- a/os/kernel/binary_manager/binary_manager.h
+++ b/os/kernel/binary_manager/binary_manager.h
@@ -197,10 +197,11 @@ binmgr_uinfo_t *binary_manager_get_udata(uint32_t bin_idx);
  *
  ****************************************************************************/
 void binary_manager_recovery(int pid);
-void binary_manager_exclude_rtthreads(struct tcb_s *tcb);
+void binary_manager_deactivate_rtthreads(struct tcb_s *tcb);
 void binary_manager_set_faultmsg_sender(pid_t pid);
 int binary_manager_faultmsg_sender(int argc, char *argv[]);
 mqd_t binary_manager_get_mqfd(void);
+void binary_manager_recover_userfault(uint32_t assert_pc);
 #endif
 
 void binary_manager_add_binlist(FAR struct tcb_s *tcb);
@@ -222,6 +223,7 @@ int binary_manager_register_ubin(char *name);
 void binary_manager_scan_ubin(void);
 int binary_manager_read_header(char *path, binary_header_t *header_data);
 int binary_manager_create_entry(int requester_pid, char *bin_name, int version);
+void binary_manager_release_binary_sem(int binid);
 
 /****************************************************************************
  * Binary Manager Main Thread

--- a/os/kernel/binary_manager/binary_manager_recovery.c
+++ b/os/kernel/binary_manager/binary_manager_recovery.c
@@ -207,6 +207,15 @@ void binary_manager_exclude_rtthreads(struct tcb_s *tcb)
 	prev = tcb->bin_blink;
 	next = tcb->bin_flink;
 
+	if (tcb->sched_priority > BM_PRIORITY_MAX) {
+		if (tcb->waitdog) {
+			(void)wd_delete(tcb->waitdog);
+			tcb->waitdog = NULL;
+		}
+		/* Remove the TCB from the task list associated with the state */
+		BM_EXCLUDE_SCHEDULING(tcb);
+	}
+
 	while (prev) {
 		if (prev->sched_priority > BM_PRIORITY_MAX) {
 			/* Recover semaphores, message queue, and watchdog timer resources.*/


### PR DESCRIPTION
No needs to do something if fault thread is NRT thread.
That is because binary manager deactivates it before it is unblocked.
So fault handler deactivates it if faulty thread is RT thread only.