### PR TITLE
libc/zoneinfo : Apply the config renamed to LIBC_OPTIMIZE_ZONEINFO_RULES 

### DIFF
--- a/lib/libc/zoneinfo/Makefile
+++ b/lib/libc/zoneinfo/Makefile
@@ -102,7 +102,7 @@ tzdb:
 
 .tzbuilt: tzbin .tzunpack
 	$(Q) $(MAKE) -C tzdb CFLAGS=-DSTD_INSPIRED TOPDIR=$(TZBIN_PATH) posix_only
-ifeq ($(CONFIG_LIBC_DELETE_ZONEINFO_RULES),y)
+ifeq ($(CONFIG_LIBC_OPTIMIZE_ZONEINFO_RULES),y)
 	$(Q) $(ZONEINFO_PATH)/mk_opt_tzrule.py
 endif
 	$(Q) touch $@


### PR DESCRIPTION
LIBC_DELETE_ZONEINFO_RULES was renamed to LIBC_OPTIMIZE_ZONEINFO_RULES with commit b2cb34d.
This commit applies that change in Makefile of libc/zoneinfo.
