### PR TITLE
arch/arm/amebad : Fix invalid Kconfig grammar and source

### DIFF
--- a/os/arch/arm/Kconfig
+++ b/os/arch/arm/Kconfig
@@ -253,7 +253,7 @@ if ARCH_CORTEXM3 || ARCH_CORTEXM4 || ARCH_CORTEXM7
 source arch/arm/src/armv7-m/Kconfig
 endif
 if ARCH_CORTEXM33
-source os/board/rtl8721csm/src/component/soc/realtek/amebad/cmsis/Kconfig
+source arch/arm/src/armv8-m/Kconfig
 endif
 if ARCH_CORTEXR4
 source arch/arm/src/armv7-r/Kconfig

--- a/os/arch/arm/src/amebad/Kconfig
+++ b/os/arch/arm/src/amebad/Kconfig
@@ -394,7 +394,7 @@ endchoice
 	config WIFI_MODULE
 		bool
 		default n
-		depends WIFI_NORMAL
+		depends on WIFI_NORMAL
 
 	config WIFI_VERIFY
 		bool


### PR DESCRIPTION
1. arch/arm/Kconfig : There is no Kconfig in os/board/rtl8721csm/src/component/soc/realtek/amebad/cmsis,
so remove sourcing from arch/arm/Kconfig
2. fix "depends" to "depends on"