### PR TITLE
os/arch/arm : Fix error in make menuconfig

### DIFF
--- a/os/arch/arm/Kconfig
+++ b/os/arch/arm/Kconfig
@@ -252,9 +252,6 @@ config ARCH_DABORTSTACK
 if ARCH_CORTEXM3 || ARCH_CORTEXM4 || ARCH_CORTEXM7
 source arch/arm/src/armv7-m/Kconfig
 endif
-if ARCH_CORTEXM33
-source os/board/rtl8721csm/src/component/soc/realtek/amebad/cmsis/Kconfig
-endif
 if ARCH_CORTEXR4
 source arch/arm/src/armv7-r/Kconfig
 endif

--- a/os/arch/arm/src/amebad/Kconfig
+++ b/os/arch/arm/src/amebad/Kconfig
@@ -394,7 +394,7 @@ endchoice
 	config WIFI_MODULE
 		bool
 		default n
-		depends WIFI_NORMAL
+		depends on WIFI_NORMAL
 
 	config WIFI_VERIFY
 		bool


### PR DESCRIPTION
arch/arm/Kconfig:256: can't open file "os/board/rtl8721csm/src/component/soc/realtek/amebad/cmsis/Kconfig"
Makefile.unix:567: recipe for target 'menuconfig' failed

Error is happening since the required Kconfig file is not present.
Hence, removed the code to include this file.

Signed-off-by: Kishore S N <kishore.sn@gmail.com>