### PR TITLE
Fix typo about semaphore

### DIFF
--- a/external/esp_idf_port/esp32/esp32_wifi_os_adapter.c
+++ b/external/esp_idf_port/esp32/esp32_wifi_os_adapter.c
@@ -74,7 +74,7 @@ extern void esp_dport_access_stall_other_cpu_end_wrap(void);
 extern int64_t get_instant_time(void);
 
 
-/*=================seamphore API=================*/
+/*=================semaphore API=================*/
 static void *IRAM_ATTR semphr_create_wrapper(uint32_t max, uint32_t init)
 {
 	if (max > SEM_VALUE_MAX || init > SEM_VALUE_MAX) {

--- a/lib/libc/semaphore/sem_init.c
+++ b/lib/libc/semaphore/sem_init.c
@@ -80,7 +80,7 @@
  *
  * Description:
  *   This function initializes the UNAMED semaphore sem. Following a
- *   successful call to sem_init(), the semaophore may be used in subsequent
+ *   successful call to sem_init(), the semaphore may be used in subsequent
  *   calls to sem_wait(), sem_post(), and sem_trywait().  The semaphore
  *   remains usable until it is destroyed.
  *
@@ -107,7 +107,7 @@ int sem_init(FAR sem_t *sem, int pshared, unsigned int value)
 	 */
 
 	if (sem && value <= SEM_VALUE_MAX) {
-		/* Initialize the seamphore count */
+		/* Initialize the semaphore count */
 
 		sem->semcount = (int16_t)value;
 #ifdef CONFIG_SEMAPHORE_HISTORY

--- a/os/arch/xtensa/src/esp32/esp32_i2c.c
+++ b/os/arch/xtensa/src/esp32/esp32_i2c.c
@@ -362,7 +362,7 @@ static int i2c_esp32_isr(int irq, FAR void *context, FAR void *arg)
 					break;
 				}
 
-				/* not need to give seamphore, do work in isr itself*/
+				/* not need to give semaphore, do work in isr itself */
 				if (priv->status == I2C_STATUS_READ) {
 					i2c_esp32_get_i2c_data(priv);
 					ret = i2c_esp32_send_read_cmd(priv, 0, 0);


### PR DESCRIPTION
Replace `seamahpore` with `semaphore`