### PR TITLE
fixup! arch/arm: make CONFIG_ARM_MPU invisible for user

### DIFF
--- a/os/arch/arm/Kconfig
+++ b/os/arch/arm/Kconfig
@@ -191,7 +191,7 @@ config ARM_HAVE_MPU_UNIFIED
 
 config ARM_MPU
 	bool
-	defaut n
+	default n
 
 config ARMV7M_MPU
 	bool "MPU support"


### PR DESCRIPTION
It had the Kconfig syntax error. defaut --> default
Github user @Boooooots raises the issue for this,
https://github.com/Samsung/TizenRT/issues/4243.

Signed-off-by: sunghan-chang <sh924.chang@samsung.com>