### PR TITLE
Support MPU Stack Overflow Protection

### DIFF
--- a/os/arch/arm/Kconfig
+++ b/os/arch/arm/Kconfig
@@ -271,6 +271,28 @@ config ARCH_DABORTSTACK
 		will be used during data abort handling. Recommended data abort stack
 		size is 1K.
 
+config MPU_STACK_OVERFLOW_PROTECTION
+	bool "MPU Stack Overflow Protection"
+	depends on BUILD_PROTECTED
+	depends on ARM_MPU
+	default n
+	---help---
+		Enables stack overflow protection.
+		It protects each task's stack overflow outside its max allocated stack memory.
+		This is applicable to user mode tasks created in protected build.
+
+if MPU_STACK_OVERFLOW_PROTECTION
+
+config MPU_STACK_GUARD_SIZE
+	int "Stack Guard size configuration range(32-1024)"
+	default 32
+	range 32 1024
+	---help---
+		Set size for the stack guard. It must be set with 32 byte aligned values.
+		The size can be set in the range of 32 to 1024 bytes.
+		Setting large stack guard size will be a wastage of memory.
+endif
+
 if ARCH_CORTEXM3 || ARCH_CORTEXM4 || ARCH_CORTEXM7
 source arch/arm/src/armv7-m/Kconfig
 endif

--- a/os/arch/arm/src/armv7-m/mpu.h
+++ b/os/arch/arm/src/armv7-m/mpu.h
@@ -687,6 +687,33 @@ static inline void up_set_mpu_app_configuration(struct tcb_s *rtcb)
 #define up_set_mpu_app_configuration(x)
 #endif
 
+/****************************************************************************
+ * Name: up_set_mpu_stack_guard
+ *
+ * Description:
+ *   Configure task's stack guard region
+ *
+ ****************************************************************************/
+
+#if defined(CONFIG_MPU_STACK_OVERFLOW_PROTECTION)
+static inline void up_set_mpu_stack_guard(struct tcb_s *rtcb)
+{
+	/* We update the MPU registers only if:
+	 * This is not a kernel thread AND
+	 * It has a non zero value of base address (This ensures valid MPU setting)
+	 */
+	if ((rtcb->flags & TCB_FLAG_TTYPE_MASK) == TCB_FLAG_TTYPE_KERNEL) {
+		return;
+	}
+
+	if (rtcb->stack_mpu_regs[REG_RBAR]) {
+		putreg32(rtcb->stack_mpu_regs[REG_RNR], MPU_RNR);
+		putreg32(rtcb->stack_mpu_regs[REG_RBAR], MPU_RBAR);
+		putreg32(rtcb->stack_mpu_regs[REG_RASR], MPU_RASR);
+	}
+}
+#endif
+
 #undef EXTERN
 #if defined(__cplusplus)
 }

--- a/os/arch/arm/src/armv7-m/up_blocktask.c
+++ b/os/arch/arm/src/armv7-m/up_blocktask.c
@@ -169,6 +169,9 @@ void up_block_task(struct tcb_s *tcb, tstate_t task_state)
 			/* Restore the MPU registers in case we are switching to an application task */
 #ifdef CONFIG_ARMV7M_MPU
 			up_set_mpu_app_configuration(rtcb);
+#ifdef CONFIG_MPU_STACK_OVERFLOW_PROTECTION
+			up_set_mpu_stack_guard(rtcb);
+#endif
 #endif
 #ifdef CONFIG_TASK_MONITOR
 			/* Update rtcb active flag for monitoring. */

--- a/os/arch/arm/src/armv7-m/up_mpu.c
+++ b/os/arch/arm/src/armv7-m/up_mpu.c
@@ -306,15 +306,15 @@ uint32_t mpu_subregion(uintptr_t base, size_t size, uint8_t l2size)
 }
 
 /****************************************************************************
- * Name: mpu_configure_app_regs
+ * Name: mpu_get_register_value
  *
  * Description:
  *   Configure the user application SRAM mpu settings into the tcb variables
  *
  ****************************************************************************/
 
-#if defined(CONFIG_ARMV7M_MPU) && defined(CONFIG_APP_BINARY_SEPARATION)
-void mpu_configure_app_regs(uint32_t *regs, uint32_t region, uintptr_t base, size_t size, uint8_t readonly, uint8_t execute)
+#if (defined(CONFIG_ARM_MPU) && defined(CONFIG_APP_BINARY_SEPARATION)) || defined(CONFIG_MPU_STACK_OVERFLOW_PROTECTION)
+void mpu_get_register_value(uint32_t *regs, uint32_t region, uintptr_t base, size_t size, uint8_t readonly, uint8_t execute)
 {
 	uint32_t regval;
 	uint8_t l2size;

--- a/os/arch/arm/src/armv7-m/up_releasepending.c
+++ b/os/arch/arm/src/armv7-m/up_releasepending.c
@@ -133,6 +133,9 @@ void up_release_pending(void)
 			/* Restore the MPU registers in case we are switching to an application task */
 #ifdef CONFIG_ARMV7M_MPU
 			up_set_mpu_app_configuration(rtcb);
+#ifdef CONFIG_MPU_STACK_OVERFLOW_PROTECTION
+			up_set_mpu_stack_guard(rtcb);
+#endif
 #endif
 #ifdef CONFIG_TASK_MONITOR
 			/* Update rtcb active flag for monitoring. */

--- a/os/arch/arm/src/armv7-m/up_reprioritizertr.c
+++ b/os/arch/arm/src/armv7-m/up_reprioritizertr.c
@@ -184,6 +184,9 @@ void up_reprioritize_rtr(struct tcb_s *tcb, uint8_t priority)
 				/* Restore the MPU registers in case we are switching to an application task */
 #ifdef CONFIG_ARMV7M_MPU
 				up_set_mpu_app_configuration(rtcb);
+#ifdef CONFIG_MPU_STACK_OVERFLOW_PROTECTION
+				up_set_mpu_stack_guard(rtcb);
+#endif
 #endif
 #ifdef CONFIG_TASK_MONITOR
 				/* Update rtcb active flag for monitoring. */

--- a/os/arch/arm/src/armv7-m/up_svcall.c
+++ b/os/arch/arm/src/armv7-m/up_svcall.c
@@ -262,6 +262,9 @@ int up_svcall(int irq, FAR void *context, FAR void *arg)
 		/* Restore the MPU registers in case we are switching to an application task */
 #ifdef CONFIG_ARMV7M_MPU
 		up_set_mpu_app_configuration(tcb);
+#ifdef CONFIG_MPU_STACK_OVERFLOW_PROTECTION
+		up_set_mpu_stack_guard(tcb);
+#endif
 #endif
 #ifdef CONFIG_TASK_MONITOR
 		/* Update tcb active flag for monitoring. */
@@ -300,6 +303,9 @@ int up_svcall(int irq, FAR void *context, FAR void *arg)
 		/* Restore the MPU registers in case we are switching to an application task */
 #ifdef CONFIG_ARMV7M_MPU
 		up_set_mpu_app_configuration(tcb);
+#ifdef CONFIG_MPU_STACK_OVERFLOW_PROTECTION
+		up_set_mpu_stack_guard(tcb);
+#endif
 #endif
 #ifdef CONFIG_TASK_MONITOR
 		/* Update tcb active flag for monitoring. */

--- a/os/arch/arm/src/armv7-m/up_unblocktask.c
+++ b/os/arch/arm/src/armv7-m/up_unblocktask.c
@@ -155,6 +155,9 @@ void up_unblock_task(struct tcb_s *tcb)
 			/* Restore the MPU registers in case we are switching to an application task */
 #ifdef CONFIG_ARMV7M_MPU
 			up_set_mpu_app_configuration(rtcb);
+#ifdef CONFIG_MPU_STACK_OVERFLOW_PROTECTION
+			up_set_mpu_stack_guard(rtcb);
+#endif
 #endif
 #ifdef CONFIG_TASK_MONITOR
 			/* Update rtcb active flag for monitoring. */

--- a/os/arch/arm/src/armv8-m/mpu.h
+++ b/os/arch/arm/src/armv8-m/mpu.h
@@ -687,6 +687,34 @@ static inline void up_set_mpu_app_configuration(struct tcb_s *rtcb)
 #define up_set_mpu_app_configuration(x)
 #endif
 
+/****************************************************************************
+ * Name: up_set_mpu_stack_guard
+ *
+ * Description:
+ *   Configure task's stack guard region
+ *
+ ****************************************************************************/
+
+#if defined(CONFIG_MPU_STACK_OVERFLOW_PROTECTION)
+static inline void up_set_mpu_stack_guard(struct tcb_s *rtcb)
+{
+	/* We update the MPU registers only if:
+	 * This is not a kernel thread AND
+	 * It has a non zero value of base address (This ensures valid MPU setting)
+	 */
+	if ((rtcb->flags & TCB_FLAG_TTYPE_MASK) == TCB_FLAG_TTYPE_KERNEL) {
+		return;
+	}
+
+	if (rtcb->stack_mpu_regs[REG_RBAR]) {
+		putreg32(rtcb->stack_mpu_regs[REG_RNR], MPU_RNR);
+		putreg32(rtcb->stack_mpu_regs[REG_RBAR], MPU_RBAR);
+		putreg32(rtcb->stack_mpu_regs[REG_RASR], MPU_RASR);
+	}
+
+}
+#endif
+
 #undef EXTERN
 #if defined(__cplusplus)
 }

--- a/os/arch/arm/src/armv8-m/up_blocktask.c
+++ b/os/arch/arm/src/armv8-m/up_blocktask.c
@@ -169,6 +169,9 @@ void up_block_task(struct tcb_s *tcb, tstate_t task_state)
 			/* Restore the MPU registers in case we are switching to an application task */
 #ifdef CONFIG_ARMV8M_MPU
 			up_set_mpu_app_configuration(rtcb);
+#ifdef CONFIG_MPU_STACK_OVERFLOW_PROTECTION
+			up_set_mpu_stack_guard(rtcb);
+#endif
 #endif
 #ifdef CONFIG_TASK_MONITOR
 			/* Update rtcb active flag for monitoring. */

--- a/os/arch/arm/src/armv8-m/up_mpu.c
+++ b/os/arch/arm/src/armv8-m/up_mpu.c
@@ -306,15 +306,15 @@ uint32_t mpu_subregion(uintptr_t base, size_t size, uint8_t l2size)
 }
 
 /****************************************************************************
- * Name: mpu_configure_app_regs
+ * Name: mpu_get_register_value
  *
  * Description:
  *   Configure the user application SRAM mpu settings into the tcb variables
  *
  ****************************************************************************/
 
-#if defined(CONFIG_ARMV8M_MPU) && defined(CONFIG_APP_BINARY_SEPARATION)
-void mpu_configure_app_regs(uint32_t *regs, uint32_t region, uintptr_t base, size_t size, uint8_t readonly, uint8_t execute)
+#if (defined(CONFIG_ARM_MPU) && defined(CONFIG_APP_BINARY_SEPARATION)) || defined(CONFIG_MPU_STACK_OVERFLOW_PROTECTION)
+void mpu_get_register_value(uint32_t *regs, uint32_t region, uintptr_t base, size_t size, uint8_t readonly, uint8_t execute)
 {
 	uint32_t regval;
 	uint8_t l2size;

--- a/os/arch/arm/src/armv8-m/up_releasepending.c
+++ b/os/arch/arm/src/armv8-m/up_releasepending.c
@@ -133,6 +133,9 @@ void up_release_pending(void)
 			/* Restore the MPU registers in case we are switching to an application task */
 #ifdef CONFIG_ARMV8M_MPU
 			up_set_mpu_app_configuration(rtcb);
+#ifdef CONFIG_MPU_STACK_OVERFLOW_PROTECTION
+			up_set_mpu_stack_guard(rtcb);
+#endif
 #endif
 #ifdef CONFIG_TASK_MONITOR
 			/* Update rtcb active flag for monitoring. */

--- a/os/arch/arm/src/armv8-m/up_reprioritizertr.c
+++ b/os/arch/arm/src/armv8-m/up_reprioritizertr.c
@@ -184,6 +184,9 @@ void up_reprioritize_rtr(struct tcb_s *tcb, uint8_t priority)
 				/* Restore the MPU registers in case we are switching to an application task */
 #ifdef CONFIG_ARMV8M_MPU
 				up_set_mpu_app_configuration(rtcb);
+#ifdef CONFIG_MPU_STACK_OVERFLOW_PROTECTION
+				up_set_mpu_stack_guard(rtcb);
+#endif
 #endif
 #ifdef CONFIG_TASK_MONITOR
 				/* Update rtcb active flag for monitoring. */

--- a/os/arch/arm/src/armv8-m/up_svcall.c
+++ b/os/arch/arm/src/armv8-m/up_svcall.c
@@ -262,6 +262,9 @@ int up_svcall(int irq, FAR void *context, FAR void *arg)
 		/* Restore the MPU registers in case we are switching to an application task */
 #ifdef CONFIG_ARMV8M_MPU
 		up_set_mpu_app_configuration(tcb);
+#ifdef CONFIG_MPU_STACK_OVERFLOW_PROTECTION
+		up_set_mpu_stack_guard(tcb);
+#endif
 #endif
 #ifdef CONFIG_TASK_MONITOR
 		/* Update tcb active flag for monitoring. */
@@ -300,6 +303,9 @@ int up_svcall(int irq, FAR void *context, FAR void *arg)
 		/* Restore the MPU registers in case we are switching to an application task */
 #ifdef CONFIG_ARMV8M_MPU
 		up_set_mpu_app_configuration(tcb);
+#ifdef CONFIG_MPU_STACK_OVERFLOW_PROTECTION
+		up_set_mpu_stack_guard(tcb);
+#endif
 #endif
 #ifdef CONFIG_TASK_MONITOR
 		/* Update tcb active flag for monitoring. */

--- a/os/arch/arm/src/armv8-m/up_unblocktask.c
+++ b/os/arch/arm/src/armv8-m/up_unblocktask.c
@@ -155,6 +155,9 @@ void up_unblock_task(struct tcb_s *tcb)
 			/* Restore the MPU registers in case we are switching to an application task */
 #ifdef CONFIG_ARMV8M_MPU
 			up_set_mpu_app_configuration(rtcb);
+#ifdef CONFIG_MPU_STACK_OVERFLOW_PROTECTION
+			up_set_mpu_stack_guard(rtcb);
+#endif
 #endif
 #ifdef CONFIG_TASK_MONITOR
 			/* Update rtcb active flag for monitoring. */

--- a/os/binfmt/binfmt_execmodule.c
+++ b/os/binfmt/binfmt_execmodule.c
@@ -83,7 +83,6 @@
 
 #ifdef CONFIG_ARM_MPU
 extern uint32_t g_mpu_region_nr;
-void mpu_configure_app_regs(uint32_t *regs, uint32_t region, uintptr_t base, size_t size, uint8_t readonly, uint8_t execute);
 #endif
 
 /****************************************************************************
@@ -194,14 +193,14 @@ int exec_module(FAR struct binary_s *binp)
 #ifdef CONFIG_ARM_MPU
 #ifdef CONFIG_OPTIMIZE_APP_RELOAD_TIME
 	/* Configure text section as RO and executable region */
-	mpu_configure_app_regs(&rtcb->mpu_regs[3], g_mpu_region_nr, (uintptr_t)binp->alloc[0], binp->textsize, true, true);
+	mpu_get_register_value(&rtcb->mpu_regs[3], g_mpu_region_nr, (uintptr_t)binp->alloc[0], binp->textsize, true, true);
 	/* Configure ro section as RO and non-executable region */
-	mpu_configure_app_regs(&rtcb->mpu_regs[6], g_mpu_region_nr + 1, (uintptr_t)binp->alloc[3], binp->rosize, true, false);
+	mpu_get_register_value(&rtcb->mpu_regs[6], g_mpu_region_nr + 1, (uintptr_t)binp->alloc[3], binp->rosize, true, false);
 	/* Complete RAM partition will be configured as RW region */
-	mpu_configure_app_regs(&rtcb->mpu_regs[0], g_mpu_region_nr + 2, (uintptr_t)binp->alloc[4], binp->ramsize, false, false);
+	mpu_get_register_value(&rtcb->mpu_regs[0], g_mpu_region_nr + 2, (uintptr_t)binp->alloc[4], binp->ramsize, false, false);
 #else
 	/* Complete RAM partition will be configured as RW region */
-	mpu_configure_app_regs(&rtcb->mpu_regs[0], g_mpu_region_nr, (uintptr_t)binp->ramstart, binp->ramsize, false, true);
+	mpu_get_register_value(&rtcb->mpu_regs[0], g_mpu_region_nr, (uintptr_t)binp->ramstart, binp->ramsize, false, true);
 #endif
 #endif
 #endif /* CONFIG_APP_BINARY_SEPARATION */

--- a/os/include/tinyara/mpu.h
+++ b/os/include/tinyara/mpu.h
@@ -1,0 +1,52 @@
+/****************************************************************************
+ *
+ * Copyright 2020 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+///@file tinyara/mpu.h
+
+#ifndef __INCLUDE_TINYARA_MPU_H
+#define __INCLUDE_TINYARA_MPU_H
+
+/********************************************************************************
+ * Included Files
+ ********************************************************************************/
+
+#include <tinyara/config.h>
+
+/********************************************************************************
+ * Pre-processor Definitions
+ ********************************************************************************/
+#if (defined(CONFIG_ARM_MPU) && defined(CONFIG_APP_BINARY_SEPARATION)) || defined(CONFIG_MPU_STACK_OVERFLOW_PROTECTION)
+enum {
+	REG_RNR,
+	REG_RBAR,
+	REG_RASR,
+	REG_MAX
+};
+
+#ifdef CONFIG_OPTIMIZE_APP_RELOAD_TIME
+#define MPU_NUM_REGIONS		3
+#else
+#define MPU_NUM_REGIONS		1
+#endif
+#endif
+
+#ifdef CONFIG_MPU_STACK_OVERFLOW_PROTECTION
+#define STACKGUARD_MPU_REGION_NUM		3	/* Region number 3 is reserved for stack protection */
+#endif
+
+#endif

--- a/os/include/tinyara/sched.h
+++ b/os/include/tinyara/sched.h
@@ -80,25 +80,10 @@
 #include <tinyara/mm/shm.h>
 #include <tinyara/fs/fs.h>
 #include <tinyara/net/net.h>
+#include <tinyara/mpu.h>
 
 #include <arch/arch.h>
 
-/********************************************************************************
- * Pre-processor Definitions
- ********************************************************************************/
-#if defined(CONFIG_APP_BINARY_SEPARATION) && defined(CONFIG_ARM_MPU)
-enum {
-	REG_RNR,
-	REG_RBAR,
-	REG_RASR
-};
-
-#ifdef CONFIG_OPTIMIZE_APP_RELOAD_TIME
-#define MPU_NUM_REGIONS		3
-#else
-#define MPU_NUM_REGIONS		1
-#endif
-#endif
 /* Configuration ****************************************************************/
 /* Task groups currently only supported for retention of child status */
 
@@ -635,6 +620,10 @@ struct tcb_s {
 #ifdef CONFIG_ARM_MPU
 	uint32_t mpu_regs[3 * MPU_NUM_REGIONS];	/* We need 3 register values to configure each MPU region */
 #endif
+#endif
+
+#if defined(CONFIG_MPU_STACK_OVERFLOW_PROTECTION)
+uint32_t stack_mpu_regs[REG_MAX]; /* need 3 MPU registers to configure a region */
 #endif
 
 #if CONFIG_TASK_NAME_SIZE > 0

--- a/os/tools/mkconfig.c
+++ b/os/tools/mkconfig.c
@@ -305,6 +305,16 @@ int main(int argc, char **argv, char **envp)
 	printf("# undef CONFIG_DEBUG_SPI\n");
 	printf("# undef CONFIG_DEBUG_HEAP\n");
 	printf("#endif\n\n");
+	printf("#if defined(CONFIG_MPU_STACK_OVERFLOW_PROTECTION)\n");
+	printf("# if (CONFIG_MPU_STACK_GUARD_SIZE != 32) && \\\n");
+	printf("    (CONFIG_MPU_STACK_GUARD_SIZE != 64) && \\\n");
+	printf("    (CONFIG_MPU_STACK_GUARD_SIZE != 128) && \\\n");
+	printf("    (CONFIG_MPU_STACK_GUARD_SIZE != 256) && \\\n");
+	printf("    (CONFIG_MPU_STACK_GUARD_SIZE != 512) && \\\n");
+	printf("    (CONFIG_MPU_STACK_GUARD_SIZE != 1024) \n");
+	printf("#  define CONFIG_MPU_STACK_GUARD_SIZE 32\n");
+	printf("# endif\n");
+	printf("#endif\n\n");
 	printf("#endif /* __INCLUDE_CONFIG_H */\n");
 	fclose(stream);
 


### PR DESCRIPTION
Implement task's stack overflow protection with MPU support.
Stack guard memory(min of 32 bytes) will be reserved at the end of
each task's stack memory. The Stack guard memory will be marked as RO,
so that stack access above the permissible limit will result into
memory fault with MPU.

Signed-off-by: Sangamanatha <sangam.swami@samsung.com>