### PR TITLE
os/arch: fix typo

### DIFF
--- a/os/arch/arm/src/tiva/tiva_allocateheap.c
+++ b/os/arch/arm/src/tiva/tiva_allocateheap.c
@@ -135,7 +135,7 @@ void up_allocate_heap(FAR void **heap_start, size_t *heap_size)
 	size_t usize = REGION_END - ubase;
 	int log2;
 
-	DEBUGASSERT(ubase < (uintptr_t)(REGION_END);
+	DEBUGASSERT(ubase < (uintptr_t)(REGION_END));
 
 	/* Adjust that size to account for MPU alignment requirements.
 	 * NOTE that there is an implicit assumption that the RAM_END(REGION_START + REGION_SIZE)

--- a/os/board/stm32l4r9ai-disco/src/stm32_spi.c
+++ b/os/board/stm32l4r9ai-disco/src/stm32_spi.c
@@ -190,7 +190,7 @@ uint8_t stm32l4_spi2status(FAR struct spi_dev_s *dev, uint32_t devid)
 #endif
 
 #ifdef CONFIG_STM32L4_SPI3
-void stm32l4_spi3select(FAR struct spi_dev_s *dev, uint32_t devid, bool selected)
+void stm32l4_spi3select(FAR struct spi_dev_s *dev, uint32_t devid, bool selected){
 
   spiinfo("devid: %d CS: %s\n", (int)devid, selected ? "assert" : "de-assert");
 }


### PR DESCRIPTION
I added ')' to tiva_allocateheap.c at line 138 and '{' to stm32_spi.c