### PR TITLE
os/drivers/video: Add NULL Driver help for supported options

### DIFF
--- a/os/drivers/video/Kconfig
+++ b/os/drivers/video/Kconfig
@@ -30,3 +30,89 @@ config VIDEO_NULL
 	bool "Driver for Dummy Video lowerhalf"
 	depends on VIDEO_SOURCE
 	default n
+
+if VIDEO_NULL
+
+	comment "Select from the following supported options"
+
+choice
+	prompt   "Supported video-frame format options (-L)"
+
+config NULL_VIDEO_FORMAT_MJPEG
+	bool "MJPEG Video Format"
+	depends on !NULL_VIDEO_FORMAT_YUY2
+	default n
+
+config NULL_VIDEO_FORMAT_YUY2
+	bool "YUY2 Video Format"
+	depends on !NULL_VIDEO_FORMAT_MJPEG
+	default n
+
+endchoice
+
+choice
+	prompt   "Supported frame resolutions (-U)"
+
+config NULL_QVGA
+	bool "(0)QVGA (320x240)"
+	default n
+
+config NULL_VGA
+	bool "(1)VGA (640x480)"
+	default n
+
+config NULL_QUADVGA
+	bool "(2)QUADVGA (1280x960)"
+	default n
+
+config NULL_HD
+	bool "(3)HD (1280x720)"
+	default n
+
+comment "Higher frame resolutions may not be supported"
+comment " due to device memory restrictions"
+
+config NULL_FHD
+	bool "(4)FHD (1920x1080)"
+	default n
+
+config NULL_5M
+	bool "(5)5M (2560x1920)"
+	default n
+
+config NULL_3M
+	bool "(6)3M (2048x1536)"
+	default n
+
+endchoice
+
+choice
+	prompt   "Supported frame rates (-K)"
+
+config NULL_FR_30
+	bool "(0)1/30"
+	default n
+
+config NULL_FR_20
+	bool "(1)1/20"
+	default n
+
+config NULL_FR_15
+	bool "(2)1/15"
+	default n
+
+config NULL_FR_10
+	bool "(3)1/10"
+	default n
+
+endchoice
+
+config NULL_NUM_FRAMES
+	int "No. of frames to be rendered"
+	default 10
+
+comment "The options displayed are only to provide help to the user"
+comment "Actual option selection is to be done at runtime only using the commands and option numbers"
+comment "For eg. - camera -L 0 -U 1 -K 2 -n 2"
+
+endif


### PR DESCRIPTION
- Include supported options list in menuconfig
  for NULL driver.
- Options are only for display help, not for
  final selection.
- Options supported by the actual camera
  hardware may vary.