### PR TITLE
fix build warnings

### DIFF
--- a/framework/src/st_things/things_stack/framework/things_data_manager.c
+++ b/framework/src/st_things/things_stack/framework/things_data_manager.c
@@ -21,7 +21,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include <json/cJSON.h>
-#include <hashmap.h>
+#include <tinyara/hashmap.h>
 
 #include "octypes.h"
 #include "ocpayload.h"

--- a/framework/src/st_things/things_stack/framework/things_req_handler.c
+++ b/framework/src/st_things/things_stack/framework/things_req_handler.c
@@ -25,7 +25,7 @@
 #include <unistd.h>
 #include <signal.h>
 #include <pthread.h>
-#include <hashmap.h>
+#include <tinyara/hashmap.h>
 
 #include "ocpayload.h"
 

--- a/lib/libc/misc/lib_hashmap.c
+++ b/lib/libc/misc/lib_hashmap.c
@@ -28,7 +28,10 @@
 
 static unsigned long is_prime(unsigned long val)
 {
-	int i = 0, p = 0, exp = 0, a = 0;
+	int i = 0;
+	int p = 0;
+	int exp = 0;
+	int a = 0;
 
 	for (i = 9; i--;) {
 		a = (rand() % (val - 4)) + 2;
@@ -69,13 +72,13 @@ static int find_prime_greater_than(int val)
 static void rehash(struct hashmap_s *hm)
 {
 	long size = hm->size;
-	h_entry_s *table = hm->table;
+	h_entry_t *table = hm->table;
 
 	hm->size = find_prime_greater_than(size << 1);
 #ifdef __KERNEL__
-	hm->table = (h_entry_s *) kmm_calloc(sizeof(h_entry_s), hm->size);
+	hm->table = (h_entry_t *)kmm_calloc(sizeof(h_entry_t), hm->size);
 #else
-	hm->table = (h_entry_s *) calloc(sizeof(h_entry_s), hm->size);
+	hm->table = (h_entry_t *)calloc(sizeof(h_entry_t), hm->size);
 #endif
 	hm->count = 0;
 
@@ -111,9 +114,9 @@ struct hashmap_s *hashmap_create(int startsize)
 	}
 
 #ifdef __KERNEL__
-	hm->table = (h_entry_s *) kmm_calloc(sizeof(h_entry_s), startsize);
+	hm->table = (h_entry_t *)kmm_calloc(sizeof(h_entry_t), startsize);
 #else
-	hm->table = (h_entry_s *) calloc(sizeof(h_entry_s), startsize);
+	hm->table = (h_entry_t *)calloc(sizeof(h_entry_t), startsize);
 #endif
 	hm->size = startsize;
 	hm->count = 0;
@@ -123,7 +126,9 @@ struct hashmap_s *hashmap_create(int startsize)
 
 void hashmap_insert(struct hashmap_s *hash, const void *data, unsigned long key)
 {
-	long index, i, step;
+	long index;
+	long i;
+	long step;
 
 	if (hash->size <= hash->count) {
 		rehash(hash);
@@ -159,7 +164,10 @@ void hashmap_insert(struct hashmap_s *hash, const void *data, unsigned long key)
 void *hashmap_get(struct hashmap_s *hash, unsigned long key)
 {
 	if (hash->count) {
-		long index = 0, i = 0, step = 0;
+		long index = 0;
+		long i = 0;
+		long step = 0;
+
 		index = key % hash->size;
 		step = (key % (hash->size - 2)) + 1;
 
@@ -182,15 +190,15 @@ void *hashmap_get(struct hashmap_s *hash, unsigned long key)
 
 unsigned long* hashmap_get_keyset(struct hashmap_s *hash)
 {
-	unsigned long* keyset = NULL;
+	unsigned long *keyset = NULL;
 
 	if (hash->count) {
 		int i = 0;
 		int idx = 0;
 #ifdef __KERNEL__
-		keyset = kmm_malloc(sizeof(unsigned long) * hash->count);
+		keyset = (unsigned long *)kmm_malloc(sizeof(unsigned long) * hash->count);
 #else
-		keyset = malloc(sizeof(unsigned long) * hash->count);
+		keyset = (unsigned long *)malloc(sizeof(unsigned long) * hash->count);
 #endif
 		if (keyset != NULL) {
 			for (i = 0; i < hash->size; i++) {

--- a/lib/libc/misc/lib_hashmap.c
+++ b/lib/libc/misc/lib_hashmap.c
@@ -19,7 +19,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <tinyara/mm/mm.h>
-#include <hashmap.h>
+#include <tinyara/hashmap.h>
 
 /* this should be prime */
 #define TABLE_STARTSIZE 1021

--- a/os/arch/arm/src/armv7-m/up_assert.c
+++ b/os/arch/arm/src/armv7-m/up_assert.c
@@ -455,7 +455,6 @@ static void _up_assert(int errorcode)
  ****************************************************************************/
 static void recovery_user_assert(uint32_t assert_pc)
 {
-	int ret;
 	int binid;
 	int bin_idx;
 	struct tcb_s *tcb;
@@ -550,7 +549,7 @@ void up_assert(const uint8_t *filename, int lineno)
 
 	/* Is the assert in Kernel? */
 
-	is_kernel_assert = is_kernel_space(assert_pc);
+	is_kernel_assert = is_kernel_space((void *)assert_pc);
 
 #endif  /* CONFIG_BINMGR_RECOVERY */
 

--- a/os/arch/arm/src/armv7-m/up_mpu.c
+++ b/os/arch/arm/src/armv7-m/up_mpu.c
@@ -312,13 +312,13 @@ uint32_t mpu_subregion(uintptr_t base, size_t size, uint8_t l2size)
  *   Configure the user application SRAM mpu settings into the tcb variables
  *
  * Params:
- * 	regs     : pointer to array in which to store the configured values
- * 		   If regs is NULL, then configure the mpu registers directly
- * 	region   : number of the region to be configured
- * 	base     : start address for the region
- * 	size     : size of the region in bytes
- * 	readonly : true indicates a readonly region
- *	execute  : true indicates that the region has execute permission
+ *  regs     : pointer to array in which to store the configured values
+ *             If regs is NULL, then configure the mpu registers directly
+ *  region   : number of the region to be configured
+ *  base     : start address for the region
+ *  size     : size of the region in bytes
+ *  readonly : true indicates a readonly region
+ *  execute  : true indicates that the region has execute permission
  ****************************************************************************/
 
 void mpu_get_register_value(uint32_t *regs, uint32_t region, uintptr_t base, size_t size, uint8_t readonly, uint8_t execute)
@@ -340,13 +340,13 @@ void mpu_get_register_value(uint32_t *regs, uint32_t region, uintptr_t base, siz
 			MPU_RASR_SIZE_LOG2((uint32_t)l2size) | /* Region size   */
 			((uint32_t)subregions << MPU_RASR_SRD_SHIFT) | /* Sub-regions   */
 #ifdef CONFIG_APPS_RAM_REGION_SHAREABLE
-			MPU_RASR_S |                   /* Shareable     */
+			MPU_RASR_S |                /* Shareable     */
 #endif
-			MPU_RASR_C;                   /* Cacheable     */
+			MPU_RASR_C;                 /* Cacheable     */
 	if (readonly) {
-		regval |= MPU_RASR_AP_RWRO;              /* P:RW   U:RO   */
+		regval |= MPU_RASR_AP_RWRO;     /* P:RW   U:RO   */
 	} else {
-		regval |= MPU_RASR_AP_RWRW;		/* P:RW   U:RW   */
+		regval |= MPU_RASR_AP_RWRW;     /* P:RW   U:RW   */
 	}
 
 	if (!execute) {

--- a/os/arch/arm/src/armv7-m/up_mpu.c
+++ b/os/arch/arm/src/armv7-m/up_mpu.c
@@ -321,7 +321,6 @@ uint32_t mpu_subregion(uintptr_t base, size_t size, uint8_t l2size)
  *	execute  : true indicates that the region has execute permission
  ****************************************************************************/
 
-#if (defined(CONFIG_ARM_MPU) && defined(CONFIG_APP_BINARY_SEPARATION)) || defined(CONFIG_MPU_STACK_OVERFLOW_PROTECTION)
 void mpu_get_register_value(uint32_t *regs, uint32_t region, uintptr_t base, size_t size, uint8_t readonly, uint8_t execute)
 {
 	uint32_t regval;
@@ -366,4 +365,3 @@ void mpu_get_register_value(uint32_t *regs, uint32_t region, uintptr_t base, siz
 #endif
 	}
 }
-#endif

--- a/os/arch/arm/src/armv8-m/up_assert.c
+++ b/os/arch/arm/src/armv8-m/up_assert.c
@@ -445,7 +445,6 @@ static void _up_assert(int errorcode)
  ****************************************************************************/
 static void recovery_user_assert(void)
 {
-	int ret;
 	int binid;
 	int bin_idx;
 	struct tcb_s *tcb;
@@ -530,7 +529,7 @@ void up_assert(const uint8_t *filename, int lineno)
 
 	/* Is the assert in Kernel? */
 
-	is_kernel_assert = is_kernel_space(assert_pc);
+	is_kernel_assert = is_kernel_space((void *)assert_pc);
 
 #endif  /* CONFIG_BINMGR_RECOVERY */
 

--- a/os/arch/arm/src/armv8-m/up_mpu.c
+++ b/os/arch/arm/src/armv8-m/up_mpu.c
@@ -313,7 +313,6 @@ uint32_t mpu_subregion(uintptr_t base, size_t size, uint8_t l2size)
  *
  ****************************************************************************/
 
-#if (defined(CONFIG_ARM_MPU) && defined(CONFIG_APP_BINARY_SEPARATION)) || defined(CONFIG_MPU_STACK_OVERFLOW_PROTECTION)
 void mpu_get_register_value(uint32_t *regs, uint32_t region, uintptr_t base, size_t size, uint8_t readonly, uint8_t execute)
 {
 	uint32_t regval;
@@ -354,4 +353,3 @@ void mpu_get_register_value(uint32_t *regs, uint32_t region, uintptr_t base, siz
 
 	regs[2] = regval;
 }
-#endif

--- a/os/binfmt/binfmt_exec.c
+++ b/os/binfmt/binfmt_exec.c
@@ -145,7 +145,6 @@ int exec(FAR const char *filename, FAR char *const *argv, FAR const struct symta
 	/* Allocate the RAM partition to load the app into */
 	uint32_t *start_addr;
 	uint32_t size = 0;
-	struct tcb_s *tcb;
 
 	start_addr = kumm_memalign(size, size);
 

--- a/os/binfmt/binfmt_execmodule.c
+++ b/os/binfmt/binfmt_execmodule.c
@@ -83,10 +83,6 @@
 
 #ifdef CONFIG_BINFMT_ENABLE
 
-#ifdef CONFIG_ARM_MPU
-void mpu_get_register_value(uint32_t *regs, uint32_t region, uintptr_t base, size_t size, uint8_t readonly, uint8_t execute);
-#endif
-
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/

--- a/os/binfmt/binfmt_execmodule.c
+++ b/os/binfmt/binfmt_execmodule.c
@@ -83,6 +83,10 @@
 
 #ifdef CONFIG_BINFMT_ENABLE
 
+#ifdef CONFIG_ARM_MPU
+void mpu_get_register_value(uint32_t *regs, uint32_t region, uintptr_t base, size_t size, uint8_t readonly, uint8_t execute);
+#endif
+
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
@@ -175,7 +179,7 @@ int exec_module(FAR struct binary_s *binp)
 
 #ifdef CONFIG_APP_BINARY_SEPARATION
 	binp->uheap = (struct mm_heap_s *)binp->heapstart;
-	mm_initialize(binp->uheap, binp->heapstart + sizeof(struct mm_heap_s), binp->uheap_size);
+	mm_initialize(binp->uheap, (void *)binp->heapstart + sizeof(struct mm_heap_s), binp->uheap_size);
 #ifdef CONFIG_BINARY_MANAGER
 	mm_add_app_heap_list(binp->uheap, binp->bin_name);
 #endif
@@ -339,7 +343,7 @@ int exec_module(FAR struct binary_s *binp)
 	/* Store the address of the applications userspace object in the tcb  */
 	/* The app's userspace object will be found at an offset of 4 bytes from the start of the binary */
 	tcb->cmn.uspace = (uint32_t)binp->alloc[ALLOC_TEXT] + 4;
-	tcb->cmn.uheap = binp->uheap;
+	tcb->cmn.uheap = (uint32_t)binp->uheap;
 	tcb->cmn.ram_start = (uint32_t)binp->ramstart;
 	tcb->cmn.ram_size = binp->ramsize;
 

--- a/os/binfmt/binfmt_loadbinary.c
+++ b/os/binfmt/binfmt_loadbinary.c
@@ -45,10 +45,6 @@
 #ifdef CONFIG_SUPPORT_COMMON_BINARY
 struct binary_s *g_lib_binp;
 uint32_t *g_umm_app_id;
-
-#ifdef CONFIG_ARMV7M_MPU
-void mpu_get_register_value(uint32_t *regs, uint32_t region, uintptr_t base, size_t size, uint8_t readonly, uint8_t execute);
-#endif
 #endif
 
 /****************************************************************************

--- a/os/binfmt/binfmt_loadbinary.c
+++ b/os/binfmt/binfmt_loadbinary.c
@@ -115,8 +115,8 @@ int load_binary(int binary_idx, FAR const char *filename, load_attr_t *load_attr
 			goto errout_with_bin;
 		}
 
-		memcpy(bin->datastart, bin->data_backup, bin->datasize);
-		memset(bin->bssstart, 0, bin->bsssize);
+		memcpy((void *)bin->datastart, (const void *)bin->data_backup, bin->datasize);
+		memset((void *)bin->bssstart, 0, bin->bsssize);
 		bin->reload = false;
 	} else {
 #endif
@@ -168,11 +168,11 @@ int load_binary(int binary_idx, FAR const char *filename, load_attr_t *load_attr
 		if (bin->islibrary) {
 #ifdef CONFIG_ARMV7M_MPU
 #ifdef CONFIG_OPTIMIZE_APP_RELOAD_TIME
-			mpu_get_register_value(NULL, MPU_REG_NUM_COM_LIB_TXT, bin->alloc[ALLOC_TEXT], bin->textsize, true, true);
-			mpu_get_register_value(NULL, MPU_REG_NUM_COM_LIB_RO, bin->alloc[ALLOC_RO], bin->rosize, true, false);
-			mpu_get_register_value(NULL, MPU_REG_NUM_COM_LIB_DATA, bin->alloc[ALLOC_DATA], bin->ramsize, false, false);
+			mpu_get_register_value(NULL, MPU_REG_NUM_COM_LIB_TXT,  (uintptr_t)bin->alloc[ALLOC_TEXT], bin->textsize, true,  true);
+			mpu_get_register_value(NULL, MPU_REG_NUM_COM_LIB_RO,   (uintptr_t)bin->alloc[ALLOC_RO],   bin->rosize,   true,  false);
+			mpu_get_register_value(NULL, MPU_REG_NUM_COM_LIB_DATA, (uintptr_t)bin->alloc[ALLOC_DATA], bin->ramsize,  false, false);
 #else
-			mpu_get_register_value(NULL, MPU_REG_NUM_COM_LIB, bin->ramstart, bin->ramsize, false, false);
+			mpu_get_register_value(NULL, MPU_REG_NUM_COM_LIB,      (uintptr_t)bin->ramstart,          bin->ramsize,  false, false);
 #endif
 #endif
 		}
@@ -185,7 +185,7 @@ int load_binary(int binary_idx, FAR const char *filename, load_attr_t *load_attr
 			goto errout_with_bin;
 		}
 
-		memcpy(bin->data_backup, bin->datastart, bin->datasize);
+		memcpy((void *)bin->data_backup, (const void *)bin->datastart, bin->datasize);
 	}
 #endif
 
@@ -196,7 +196,7 @@ int load_binary(int binary_idx, FAR const char *filename, load_attr_t *load_attr
 		/* If we support common binary, then we need to place a pointer to the app's heap object
 		 * into the heap table which is present at the start of the common library data section
 		 */
-		uint32_t *heap_table = (uint32_t)g_lib_binp->alloc[ALLOC_DATA] + 4;
+		uint32_t *heap_table = (uint32_t *)g_lib_binp->alloc[ALLOC_DATA] + 4;
 		heap_table[binary_idx] = bin->heapstart;
 #endif
 

--- a/os/binfmt/libelf/libelf.h
+++ b/os/binfmt/libelf/libelf.h
@@ -134,6 +134,19 @@ int elf_loadshdrs(FAR struct elf_loadinfo_s *loadinfo);
 int elf_findsection(FAR struct elf_loadinfo_s *loadinfo, FAR const char *sectname);
 
 /****************************************************************************
+ * Name: elf_readstrtab
+ *
+ * Description:
+ *   Read the ELF string table into memory.
+ *
+ * Input Parameters:
+ *   loadinfo - Load state information
+ *
+ ****************************************************************************/
+
+int elf_readstrtab(FAR struct elf_loadinfo_s *loadinfo);
+
+/****************************************************************************
  * Name: elf_findsymtab
  *
  * Description:
@@ -205,6 +218,24 @@ int elf_readsym(FAR struct elf_loadinfo_s *loadinfo, int index, FAR Elf32_Sym *s
  ****************************************************************************/
 
 int elf_symvalue(FAR struct elf_loadinfo_s *loadinfo, FAR Elf32_Sym *sym, FAR const struct symtab_s *exports, int nexports);
+
+/****************************************************************************
+ * Name: elf_symname
+ *
+ * Description:
+ *   Get the symbol name in loadinfo->iobuffer[].
+ *
+ * Returned Value:
+ *   0 (OK) is returned on success and a negated errno is returned on
+ *   failure.
+ *
+ *   EINVAL - There is something inconsistent in the symbol table (should only
+ *            happen if the file is corrupted).
+ *   ESRCH - Symbol has no name
+ *
+ ****************************************************************************/
+
+int elf_symname(FAR struct elf_loadinfo_s *loadinfo, FAR const Elf32_Sym *sym);
 
 /****************************************************************************
  * Name: elf_freebuffers

--- a/os/binfmt/libelf/libelf_addrenv.c
+++ b/os/binfmt/libelf/libelf_addrenv.c
@@ -168,9 +168,9 @@ int elf_addrenv_alloc(FAR struct elf_loadinfo_s *loadinfo, size_t textsize, size
 #endif
 
 #ifdef CONFIG_OPTIMIZE_APP_RELOAD_TIME
-	loadinfo->textalloc = kumm_memalign(loadinfo->textsize, loadinfo->textsize);
-	loadinfo->roalloc = kumm_memalign(loadinfo->rosize, loadinfo->rosize);
-	loadinfo->dataalloc = kumm_memalign(datamemsize, datamemsize);
+	loadinfo->textalloc = (uintptr_t)kumm_memalign(loadinfo->textsize, loadinfo->textsize);
+	loadinfo->roalloc = (uintptr_t)kumm_memalign(loadinfo->rosize, loadinfo->rosize);
+	loadinfo->dataalloc = (uintptr_t)kumm_memalign(datamemsize, datamemsize);
 
 	loadinfo->binp->data_backup = loadinfo->roalloc + rosize;
 	loadinfo->binp->uheap_size = datamemsize - loadinfo->datasize - sizeof(struct mm_heap_s);

--- a/os/binfmt/libelf/libelf_bind.c
+++ b/os/binfmt/libelf/libelf_bind.c
@@ -198,7 +198,7 @@ static int elf_relocate(FAR struct elf_loadinfo_s *loadinfo, int relidx, FAR con
 				ret = -EINVAL;
 				goto ret_err;
 			}
-			prel = loadinfo->reltab + sizeof(Elf32_Rel) * i;
+			prel = (Elf32_Rel *)(loadinfo->reltab + sizeof(Elf32_Rel) * i);
 		} else {
 			ret = elf_readrel(loadinfo, relsec, i, &rel);
 			if (ret < 0) {
@@ -221,7 +221,7 @@ static int elf_relocate(FAR struct elf_loadinfo_s *loadinfo, int relidx, FAR con
 				ret = -EINVAL;
 				goto ret_err;
 			}
-			psym = loadinfo->symtab + sizeof(Elf32_Sym) * symidx;
+			psym = (FAR Elf32_Sym *)(loadinfo->symtab + sizeof(Elf32_Sym) * symidx);
 		} else {
 			ret = elf_readsym(loadinfo, symidx, &sym);
 			if (ret < 0) {
@@ -271,8 +271,8 @@ static int elf_relocate(FAR struct elf_loadinfo_s *loadinfo, int relidx, FAR con
 	}
 
 ret_err:
-	kmm_free(loadinfo->reltab);
-	loadinfo->reltab = NULL;
+	kmm_free((void *)loadinfo->reltab);
+	loadinfo->reltab = (uintptr_t)NULL;
 	return ret;
 }
 
@@ -307,7 +307,7 @@ static int export_library_symtab(FAR struct elf_loadinfo_s *loadinfo)
 		Elf32_Sym *psym = &sym;
 
 		if (loadinfo->symtab) {
-			psym = loadinfo->symtab + sizeof(Elf32_Sym) * i;
+			psym = (Elf32_Sym *)(loadinfo->symtab + sizeof(Elf32_Sym) * i);
 		} else {
 			ret = elf_readsym(loadinfo, i, &sym);
 			if (ret < 0) {
@@ -482,10 +482,10 @@ int elf_bind(FAR struct elf_loadinfo_s *loadinfo, FAR const struct symtab_s *exp
 
 ret_err:
 	if (loadinfo->strtab) {
-		kmm_free(loadinfo->strtab);
-		loadinfo->strtab = NULL;
+		kmm_free((void *)loadinfo->strtab);
+		loadinfo->strtab = (uintptr_t)NULL;
 	}
-	kmm_free(loadinfo->symtab);
-	loadinfo->symtab = NULL;
+	kmm_free((void *)loadinfo->symtab);
+	loadinfo->symtab = (uintptr_t)NULL;
 	return ret;
 }

--- a/os/binfmt/libelf/libelf_bind.c
+++ b/os/binfmt/libelf/libelf_bind.c
@@ -95,7 +95,7 @@
  * Private Data
  ****************************************************************************/
 #ifdef CONFIG_SUPPORT_COMMON_BINARY
-#include <hashmap.h>
+#include <tinyara/hashmap.h>
 static struct hashmap_s *g_lib_symhash;
 static int g_num_lib_syms;
 #endif

--- a/os/binfmt/libelf/libelf_load.c
+++ b/os/binfmt/libelf/libelf_load.c
@@ -244,7 +244,7 @@ static inline int elf_loadfile(FAR struct elf_loadinfo_s *loadinfo)
 
 		else {
 #ifdef CONFIG_OPTIMIZE_APP_RELOAD_TIME
-			loadinfo->binp->bssstart = *pptr;
+			loadinfo->binp->bssstart = (uint32_t)*pptr;
 #endif
 			memset(*pptr, 0, shdr->sh_size);
 		}
@@ -253,7 +253,7 @@ static inline int elf_loadfile(FAR struct elf_loadinfo_s *loadinfo)
 
 		binfo("%d. %08lx->%08lx\n", i, (unsigned long)shdr->sh_addr, (unsigned long)*pptr);
 
-		shdr->sh_addr = (uintptr_t) * pptr;
+		shdr->sh_addr = (uintptr_t)*pptr;
 
 		/* Setup the memory pointer for the next time through the loop */
 

--- a/os/binfmt/libelf/libelf_symbols.c
+++ b/os/binfmt/libelf/libelf_symbols.c
@@ -61,7 +61,7 @@
 #include <errno.h>
 #include <debug.h>
 #ifdef CONFIG_SUPPORT_COMMON_BINARY
-#include <hashmap.h>
+#include <tinyara/hashmap.h>
 #endif
 
 #include <tinyara/binfmt/elf.h>

--- a/os/include/debug.h
+++ b/os/include/debug.h
@@ -1330,8 +1330,8 @@ int get_errno(void);
 #define medvdbg     vdbg
 #define medllvdbg   llvdbg
 #else
+#define medvdbg     (void)
 #define medllvdbg   (void)
-#define medllvdbg   (...)
 #endif
 
 #ifdef CONFIG_DEBUG_MESSAGE_IPC

--- a/os/include/hashmap.h
+++ b/os/include/hashmap.h
@@ -16,41 +16,43 @@
  *
  ****************************************************************************/
 
-#ifndef _HASHMAP_H
-#define _HASHMAP_H
+#ifndef __INCLUDE_HASHMAP_H
+#define __INCLUDE_HASHMAP_H
 
 /** Hashmap structure (forward declaration) */
-typedef struct {
+struct h_entry_s {
 	void *data;
 	int flags;
 	long key;
-} h_entry_s;
+};
+typedef struct h_entry_s h_entry_t;
 
-typedef struct hashmap_s {
-	h_entry_s *table;
-	long size, count;
-} hashmap_s;
+struct hashmap_s {
+	h_entry_t *table;
+	long size;
+	long count;
+};
 
 // struct s_hashmap;
 // typedef struct s_hashmap hashmap;
 
 /** Creates a new hashmap near the given size. */
-extern struct hashmap_s *hashmap_create(int startsize);
+struct hashmap_s *hashmap_create(int startsize);
 
 /** Inserts a new element into the hashmap. */
-extern void hashmap_insert(struct hashmap_s *, const void *data, unsigned long key);
+void hashmap_insert(struct hashmap_s *hash, const void *data, unsigned long key);
 
 /** Returns the element for the key. */
-extern void *hashmap_get(struct hashmap_s *, unsigned long key);
+void *hashmap_get(struct hashmap_s *hash, unsigned long key);
 
 /** Returns the number of saved elements. */
-extern long hashmap_count(struct hashmap_s *);
+long hashmap_count(struct hashmap_s *hash);
 
 /** Removes the hashmap structure. */
-extern void hashmap_delete(struct hashmap_s *);
+void hashmap_delete(struct hashmap_s *hash);
 
-extern unsigned long hashmap_get_hashval(unsigned char *str);
+unsigned long hashmap_get_hashval(unsigned char *str);
 
-extern unsigned long* hashmap_get_keyset(struct hashmap_s *);
+unsigned long *hashmap_get_keyset(struct hashmap_s *hash);
 
-#endif							//_HASHMAP_H
+#endif	//__INCLUDE_HASHMAP_H

--- a/os/include/tinyara/hashmap.h
+++ b/os/include/tinyara/hashmap.h
@@ -16,8 +16,8 @@
  *
  ****************************************************************************/
 
-#ifndef __INCLUDE_HASHMAP_H
-#define __INCLUDE_HASHMAP_H
+#ifndef __INCLUDE_TINYARA_HASHMAP_H
+#define __INCLUDE_TINYARA_HASHMAP_H
 
 /** Hashmap structure (forward declaration) */
 struct h_entry_s {
@@ -55,4 +55,4 @@ unsigned long hashmap_get_hashval(unsigned char *str);
 
 unsigned long *hashmap_get_keyset(struct hashmap_s *hash);
 
-#endif	//__INCLUDE_HASHMAP_H
+#endif	//__INCLUDE_TINYARA_HASHMAP_H

--- a/os/include/tinyara/mpu.h
+++ b/os/include/tinyara/mpu.h
@@ -33,7 +33,7 @@
 /********************************************************************************
  * Pre-processor Definitions
  ********************************************************************************/
-#if (defined(CONFIG_ARM_MPU) && defined(CONFIG_APP_BINARY_SEPARATION)) || defined(CONFIG_MPU_STACK_OVERFLOW_PROTECTION)
+
 enum {
 	REG_RNR,
 	REG_RBAR,
@@ -45,7 +45,6 @@ enum {
 #define MPU_NUM_REGIONS		3
 #else
 #define MPU_NUM_REGIONS		1
-#endif
 #endif
 
 /* Enum for MPU region numbers */

--- a/os/include/tinyara/mpu.h
+++ b/os/include/tinyara/mpu.h
@@ -27,6 +27,9 @@
 
 #include <tinyara/config.h>
 
+#include <sys/types.h>
+#include <stdint.h>
+
 /********************************************************************************
  * Pre-processor Definitions
  ********************************************************************************/
@@ -86,5 +89,12 @@ enum MPU_REG_NUM {
 #error "MPU region numbers exceeded !!"
 #endif
 #endif
+
+
+/********************************************************************************
+ * Public Function Prototypes
+ ********************************************************************************/
+
+void mpu_get_register_value(uint32_t *regs, uint32_t region, uintptr_t base, size_t size, uint8_t readonly, uint8_t execute);
 
 #endif

--- a/tools/nxfuse/src/nxfuse.h
+++ b/tools/nxfuse/src/nxfuse.h
@@ -56,10 +56,12 @@
 #define _SRC_NXFUSE_H
 
 #define FIOUTIME        _FIOC(0x0007)  /* IN:  None
-                                                                                * OUT: OK if successful, -ENOSYS if not
-                                                                                */
+                                        * OUT: OK if successful, -ENOSYS if not
+                                        */
 #define FIOCHMOD        _FIOC(0x0008)  /* IN:  New mode flags (int)
-                                                                                * OUT: OK if successful, -ENOSYS if not
+                                        * OUT: OK if successful, -ENOSYS if not
+                                        */
+
 /* The logical sector number of the root directory. */
 
 #define SMARTFS_ROOT_DIR_SECTOR   3

--- a/tools/nxfuse/src/tinyara_services.c
+++ b/tools/nxfuse/src/tinyara_services.c
@@ -93,6 +93,8 @@ struct fs_ops_s {
 #ifdef CONFIG_FS_SMARTFS
 extern const struct mountpt_operations smartfs_operations;
 #endif
+extern void filemtd_teardown(FAR struct mtd_dev_s *dev);
+extern FAR struct mtd_dev_s *filemtd_initialize(FAR const char *path, size_t offset, int16_t sectsize, int32_t erasesize);
 
 /****************************************************************************
  * Private Function Prototypes


### PR DESCRIPTION
1. include/debug.h: fix typo in media debug definition 
2. tools/nxfuse: fix build warnings
3. binfmt: fix build warnings
4. arch/arm: fix build warnings
5. include/mpu.h: add the prototype of mpu_get_register_value …
6. arch/mpu: remove unnecessary conditionals of mpu_get_register_value …
7. arch/armv7-m/up_mpu.c: fix violations of coding rules
8. hashmap: fix violations of coding rules
9. hashmap: move the location of header into os/include/tinyara