### PR TITLE
tools/fs/contents-smartfs: add .gitignore to blind the change

### DIFF
--- a/tools/fs/contents-smartfs/.gitignore
+++ b/tools/fs/contents-smartfs/.gitignore
@@ -1,0 +1,2 @@
+/*
+!/.gitignore


### PR DESCRIPTION
The tools/fs/contents-smartfs folder could include some files
but they are not contents for remote repository.
This commit adds .gitignore to blind the change of this folder for git.

Untracked files:
  (use "git add <file>..." to include in what will be committed)

	/tools/fs/contents-smartfs/

Signed-off-by: sunghan-chang <sh924.chang@samsung.com>