### PR TITLE
binfmt : Add debug for saving each sections addr of bi…

### DIFF
--- a/os/binfmt/Kconfig
+++ b/os/binfmt/Kconfig
@@ -90,4 +90,11 @@ config OPTIMIZE_APP_RELOAD_TIME
 		the MPU requirements. Hence, using this option can result in a steep increase in the memory
 		requirement for this application.
 
+config SAVE_BIN_SECTION_ADDR
+	bool "Save binary section address"
+	default n
+	depends on APP_BINARY_SEPARATION
+	---help---
+		For debugging binary symbol, save the each section address.
+
 endif # BINFMT_ENABLE

--- a/os/binfmt/binfmt_exit.c
+++ b/os/binfmt/binfmt_exit.c
@@ -61,6 +61,9 @@
 #include <debug.h>
 #ifdef CONFIG_APP_BINARY_SEPARATION
 #include <queue.h>
+#ifdef CONFIG_SAVE_BIN_SECTION_ADDR
+#include "libelf/libelf.h"
+#endif
 #endif
 
 #include <tinyara/kmalloc.h>
@@ -113,6 +116,10 @@ int binfmt_exit(FAR struct binary_s *bin)
 	if (ret < 0) {
 		berr("ERROR: unload_module() failed: %d\n", ret);
 	}
+
+#ifdef CONFIG_SAVE_BIN_SECTION_ADDR
+	elf_delete_bin_section_addr(bin);
+#endif
 
 #ifdef CONFIG_APP_BINARY_SEPARATION
 	uheap_start = (uint32_t)bin->uheap;

--- a/os/binfmt/binfmt_initialize.c
+++ b/os/binfmt/binfmt_initialize.c
@@ -60,6 +60,11 @@
 #include <tinyara/binfmt/builtin.h>
 #include <tinyara/binfmt/elf.h>
 
+#ifdef CONFIG_SAVE_BIN_SECTION_ADDR
+#include <queue.h>
+sq_queue_t g_bin_addr_list;
+#endif
+
 #ifdef CONFIG_BINFMT_ENABLE
 
 /****************************************************************************
@@ -104,6 +109,10 @@ void binfmt_initialize(void)
 	if (ret < 0) {
 		berr("ERROR: nxflat_initialize failed: %d\n", ret);
 	}
+#endif
+
+#ifdef CONFIG_SAVE_BIN_SECTION_ADDR
+	sq_init(&g_bin_addr_list);
 #endif
 
 	UNUSED(ret);

--- a/os/binfmt/libelf/libelf.h
+++ b/os/binfmt/libelf/libelf.h
@@ -64,6 +64,11 @@
 #include <tinyara/arch.h>
 #include <tinyara/binfmt/elf.h>
 
+#ifdef CONFIG_SAVE_BIN_SECTION_ADDR
+#include <queue.h>
+#include <tinyara/binary_manager.h>
+#endif
+
 /****************************************************************************
  * Public Function Prototypes
  ****************************************************************************/
@@ -453,6 +458,23 @@ int elf_cache_init(int filfd, uint16_t offset, off_t filelen, uint8_t compressio
  *   Negative value on failure
  ****************************************************************************/
 int elf_cache_read(int filfd, uint16_t binary_header_size, FAR uint8_t *buffer, size_t readsize, off_t offset);
+#endif
+
+#ifdef CONFIG_SAVE_BIN_SECTION_ADDR
+struct bin_addr_info_s {
+	struct bin_addr_info_s *flink;
+	char bin_name[BIN_NAME_MAX];
+	uint32_t text_addr;
+	uint32_t rodata_addr;
+	uint32_t data_addr;
+	uint32_t bss_addr;
+};
+typedef struct bin_addr_info_s bin_addr_info_t;
+
+extern sq_queue_t g_bin_addr_list;
+
+void elf_save_bin_section_addr(struct binary_s *bin);
+void elf_delete_bin_section_addr(struct binary_s *bin);
 #endif
 
 #endif							/* __BINFMT_LIBELF_LIBELF_H */


### PR DESCRIPTION
…nary

For finding/matching the symbols of user binary, saving each sections address is required.
So saving when loading, and releasing when unloading the address.