### PR TITLE
timer: change and add ioctl commands, TCIOC_SETMODE, TCIOC_SETRESOLUTION

### DIFF
--- a/apps/examples/timer/timer_main.c
+++ b/apps/examples/timer/timer_main.c
@@ -178,7 +178,7 @@ static pthread_addr_t timer_thread(pthread_addr_t arg)
 		fprintf(stderr, "ERROR: Failed to open Free Run Timer: %d\n", errno);
 		goto error;
 	}
-	if (ioctl(frt_fd, TCIOC_SETFREERUN, TRUE) < 0) {
+	if (ioctl(frt_fd, TCIOC_SETMODE, MODE_FREERUN) < 0) {
 		fprintf(stderr, "ERROR: Failed to set Free Run Timer: %d\n", errno);
 		goto error;
 	}

--- a/os/arch/arm/src/imxrt/imxrt_timer_lowerhalf.c
+++ b/os/arch/arm/src/imxrt/imxrt_timer_lowerhalf.c
@@ -408,13 +408,27 @@ static int imxrt_gpt_ioctl(struct timer_lowerhalf_s *lower, int cmd,
 			ret = (int)imxrt_gpt_getclockdivider(priv->gpt->base);
 		}
 		break;
-	case TCIOC_SETFREERUN:
-		if ((bool)arg == true) {
+	case TCIOC_SETMODE:
+		if ((timer_mode_t)arg == MODE_FREERUN) {
 			imxrt_gpt_setfreerunmode(priv->gpt->base);
-		} else {
+			ret = OK;
+		} else if ((timer_mode_t)arg == MODE_ALARM) {
 			imxrt_gpt_unsetfreerunmode(priv->gpt->base);
+			ret = OK;
+		} else {
+			ret = -EINVAL;
 		}
-		ret = OK;
+		break;
+	case TCIOC_SETRESOLUTION:
+		if ((timer_resolution_t)arg == TIME_RESOLUTION_US) {
+			// TO-DO develop
+			ret = OK;
+		} else if ((timer_resolution_t)arg == TIME_RESOLUTION_MS) {
+			// TO-DO develop
+			ret = OK;
+		} else {
+			ret = -EINVAL;
+		}
 		break;
 #ifdef CONFIG_ARCH_IRQPRIO
 	case TCIOC_SETIRQPRIO:

--- a/os/include/tinyara/timer.h
+++ b/os/include/tinyara/timer.h
@@ -104,19 +104,20 @@
  * range.
  */
 
-#define TCIOC_START		_TCIOC(0x0001)
-#define TCIOC_STOP		_TCIOC(0x0002)
-#define TCIOC_GETSTATUS		_TCIOC(0x0003)
-#define TCIOC_SETTIMEOUT	_TCIOC(0x0004)
-#define TCIOC_NOTIFICATION	_TCIOC(0x0005)
+#define TCIOC_START         _TCIOC(0x0001)
+#define TCIOC_STOP          _TCIOC(0x0002)
+#define TCIOC_GETSTATUS     _TCIOC(0x0003)
+#define TCIOC_SETTIMEOUT    _TCIOC(0x0004)
+#define TCIOC_NOTIFICATION  _TCIOC(0x0005)
 #define TCIOC_SETDIV        _TCIOC(0x0006)
 #define TCIOC_GETDIV        _TCIOC(0x0007)
-#define TCIOC_SETFREERUN    _TCIOC(0x0008)
+#define TCIOC_SETMODE       _TCIOC(0x0008)
+#define TCIOC_SETRESOLUTION _TCIOC(0x0009)
 #ifdef CONFIG_ARCH_IRQPRIO
-#define TCIOC_SETIRQPRIO    _TCIOC(0x0009)
+#define TCIOC_SETIRQPRIO    _TCIOC(0x000A)
 #endif
-#define TCIOC_SETCLKSRC     _TCIOC(0x000A)
-#define TCIOC_GETLIFETIME	_TCIOC(0x000B)
+#define TCIOC_SETCLKSRC     _TCIOC(0x000B)
+#define TCIOC_GETLIFETIME   _TCIOC(0x000C)
 
 /* Bit Settings *************************************************************/
 /* Bit settings for the struct timer_status_s flags field */
@@ -128,6 +129,29 @@
 /****************************************************************************
  * Public Types
  ****************************************************************************/
+
+/* This is the type of the argument passed to the TCIOC_SETMODE ioctl 
+ * Depending on the argument passed, 
+ * it is decided whether to operate as ALARM or Free running Timer.
+ */
+
+ enum timer_mode_e {
+	MODE_ALARM = 0x01,
+	MODE_FREERUN = 0x02
+};
+
+/* This is the type of the argument passed to the TCIOC_RESOLUTION ioctl 
+ * Whether or not Timer's resolution works as us or ms is determined, 
+ * and it is a unit of timer that the user is notified through the getstatus() function.
+ */
+
+enum timer_resolution_e {
+	TIME_RESOLUTION_US = 0x01,
+	TIME_RESOLUTION_MS = 0x02
+};
+
+typedef enum timer_mode_e timer_mode_t;
+typedef enum timer_resolution_e timer_resolution_t;
 
 /* Upper half callback prototype. Returns true to reload the timer, and the
  * function can modify the next interval if desired.


### PR DESCRIPTION
1. define the Timer mode as ALARAM and FRT(free run timer)
2. change SETFREERUN to SETMODE
 : The definition is different for each hal part,
   so it can be used for common use
3. add SETTIMEUNIT ioctl
 : this option to operate depending on whether the users
   sets the time unit to ms or us.

Signed-off-by: jaesick.shin <jaesick.shin@samsung.com>