### PR TITLE
travis: modify the branch name, protection -> fs_journal

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ services:
 branches:
   only:
   - master
-  - protection
+  - fs_journal
 
 env:
   global:


### PR DESCRIPTION
There is no protection branch anymore, and there is fs_journal branch now.
Let's do travis-ci for fs_journal branch.

Signed-off-by: sunghan-chang <sh924.chang@samsung.com>