### PR TITLE
Handle secure context switch whenever context switches without SVC

### DIFF
--- a/os/arch/arm/include/arch.h
+++ b/os/arch/arm/include/arch.h
@@ -110,6 +110,22 @@
 
 #endif							/* CONFIG_PIC */
 
+#ifdef CONFIG_ARCH_CORTEXM33
+static inline uint32_t get_PSPLIM(void)
+{
+	uint32_t result;
+	__asm volatile ("MRS %0, psplim"  : "=r" (result) );
+	return result;
+}
+static inline void set_PSPLIM(uint32_t PSP_limit)
+{
+	__asm volatile ("MSR psplim, %0" : : "r" (PSP_limit));
+}
+#else
+#define get_PSPLIM(void)					(0)
+#define set_PSPLIM(PSP_limit)				(0)
+#endif
+
 #ifdef CONFIG_ARCH_ADDRENV
 #if CONFIG_MM_PGSIZE != 4096
 #error Only pages sizes of 4096 are currently supported (CONFIG_ARCH_ADDRENV)

--- a/os/arch/arm/src/armv8-m/up_blocktask.c
+++ b/os/arch/arm/src/armv8-m/up_blocktask.c
@@ -78,6 +78,10 @@
 #include <tinyara/mpu.h>
 #endif
 
+#ifdef CONFIG_ARMV8M_TRUSTZONE
+#include <tinyara/tz_context.h>
+#endif
+
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
@@ -155,6 +159,10 @@ void up_block_task(struct tcb_s *tcb, tstate_t task_state)
 			 */
 
 			up_savestate(rtcb->xcp.regs);
+#ifdef CONFIG_ARMV8M_TRUSTZONE
+			/* Store the secure context and PSPLIM of OLD rtcb */
+			tz_store_context(rtcb->xcp.regs);
+#endif
 
 			/* Restore the exception context of the rtcb at the (new) head
 			 * of the g_readytorun task list.
@@ -190,6 +198,11 @@ void up_block_task(struct tcb_s *tcb, tstate_t task_state)
 			/* Then switch contexts */
 
 			up_restorestate(rtcb->xcp.regs);
+#ifdef CONFIG_ARMV8M_TRUSTZONE
+			/* Load the secure context and PSPLIM of OLD rtcb */
+			tz_load_context(rtcb->xcp.regs);
+#endif
+
 		}
 
 		/* No, then we will need to perform the user context switch */

--- a/os/arch/arm/src/armv8-m/up_releasepending.c
+++ b/os/arch/arm/src/armv8-m/up_releasepending.c
@@ -71,6 +71,10 @@
 #include <tinyara/debug/sysdbg.h>
 #endif
 
+#ifdef CONFIG_ARMV8M_TRUSTZONE
+#include <tinyara/tz_context.h>
+#endif
+
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
@@ -118,6 +122,10 @@ void up_release_pending(void)
 			 */
 
 			up_savestate(rtcb->xcp.regs);
+#ifdef CONFIG_ARMV8M_TRUSTZONE
+			/* Store the secure context and PSPLIM of OLD rtcb */
+			tz_store_context(rtcb->xcp.regs);
+#endif
 
 			/* Restore the exception context of the rtcb at the (new) head
 			 * of the g_readytorun task list.
@@ -153,6 +161,11 @@ void up_release_pending(void)
 
 			/* Then switch contexts */
 			up_restorestate(rtcb->xcp.regs);
+#ifdef CONFIG_ARMV8M_TRUSTZONE
+			/* Load the secure context and PSPLIM of OLD rtcb */
+			tz_load_context(rtcb->xcp.regs);
+#endif
+
 		}
 
 		/* No, then we will need to perform the user context switch */

--- a/os/arch/arm/src/armv8-m/up_reprioritizertr.c
+++ b/os/arch/arm/src/armv8-m/up_reprioritizertr.c
@@ -73,6 +73,10 @@
 #include <tinyara/debug/sysdbg.h>
 #endif
 
+#ifdef CONFIG_ARMV8M_TRUSTZONE
+#include <tinyara/tz_context.h>
+#endif
+
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
@@ -170,6 +174,10 @@ void up_reprioritize_rtr(struct tcb_s *tcb, uint8_t priority)
 				 */
 
 				up_savestate(rtcb->xcp.regs);
+#ifdef CONFIG_ARMV8M_TRUSTZONE
+			/* Store the secure context and PSPLIM of OLD rtcb */
+				tz_store_context(rtcb->xcp.regs);
+#endif
 
 				/* Restore the exception context of the rtcb at the (new) head
 				 * of the g_readytorun task list.
@@ -204,6 +212,10 @@ void up_reprioritize_rtr(struct tcb_s *tcb, uint8_t priority)
 
 				/* Then switch contexts */
 				up_restorestate(rtcb->xcp.regs);
+#ifdef CONFIG_ARMV8M_TRUSTZONE
+				/* Load the secure context and PSPLIM of OLD rtcb */
+				tz_load_context(rtcb->xcp.regs);
+#endif
 			}
 
 			/* No, then we will need to perform the user context switch */

--- a/os/arch/arm/src/armv8-m/up_schedulesigaction.c
+++ b/os/arch/arm/src/armv8-m/up_schedulesigaction.c
@@ -195,6 +195,11 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 				 */
 
 				up_savestate(tcb->xcp.regs);
+#ifdef CONFIG_ARMV8M_TRUSTZONE
+				/* Store the secure context and PSPLIM of OLD rtcb */
+				tz_store_context(tcb->xcp.regs);
+#endif
+
 			}
 		}
 

--- a/os/arch/arm/src/armv8-m/up_svcall.c
+++ b/os/arch/arm/src/armv8-m/up_svcall.c
@@ -571,6 +571,7 @@ int up_svcall(int irq, FAR void *context, FAR void *arg)
 
 		/* Allocate and load a context for the secure task. */
 		tz_memory = TZ_AllocModuleContext_S(ulR1);
+		regs[REG_R8] = tz_memory;
 
 		ASSERT(tz_memory != 0);
 		TZ_LoadContext_S(tz_memory);

--- a/os/arch/arm/src/armv8-m/up_unblocktask.c
+++ b/os/arch/arm/src/armv8-m/up_unblocktask.c
@@ -72,6 +72,10 @@
 #include <tinyara/debug/sysdbg.h>
 #endif
 
+#ifdef CONFIG_ARMV8M_TRUSTZONE
+#include <tinyara/tz_context.h>
+#endif
+
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
@@ -141,7 +145,10 @@ void up_unblock_task(struct tcb_s *tcb)
 			 */
 
 			up_savestate(rtcb->xcp.regs);
-
+#ifdef CONFIG_ARMV8M_TRUSTZONE
+			/* Store the secure context and PSPLIM of OLD rtcb */
+			tz_store_context(rtcb->xcp.regs);
+#endif
 			/* Restore the exception context of the rtcb at the (new) head
 			 * of the g_readytorun task list.
 			 */
@@ -176,6 +183,11 @@ void up_unblock_task(struct tcb_s *tcb)
 			/* Then switch contexts */
 
 			up_restorestate(rtcb->xcp.regs);
+
+#ifdef CONFIG_ARMV8M_TRUSTZONE
+			/* Load the secure context and PSPLIM of OLD rtcb */
+			tz_load_context(rtcb->xcp.regs);
+#endif
 		}
 
 		/* No, then we will need to perform the user context switch */

--- a/os/arch/arm/src/common/up_schedyield.c
+++ b/os/arch/arm/src/common/up_schedyield.c
@@ -23,6 +23,10 @@
 #include "sched/sched.h"
 #include "up_internal.h"
 
+#ifdef CONFIG_ARMV8M_TRUSTZONE
+#include <tinyara/tz_context.h>
+#endif
+
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
@@ -62,6 +66,10 @@ void up_schedyield(struct tcb_s *rtcb)
 		 * rtcb is the tcb of task which is yeilding the resource
 		 */
 		up_savestate(rtcb->xcp.regs);
+#ifdef CONFIG_ARMV8M_TRUSTZONE
+		/* Store the secure context and PSPLIM of OLD rtcb */
+		tz_store_context(tcb->xcp.regs);
+#endif
 
 		/* Restore the exception context of the new changed rtcb from the head
 		 * of the g_readytorun task list.
@@ -73,6 +81,11 @@ void up_schedyield(struct tcb_s *rtcb)
 		 */
 
 		up_restorestate(rtcb->xcp.regs);
+#ifdef CONFIG_ARMV8M_TRUSTZONE
+		/* Load the secure context and PSPLIM of OLD rtcb */
+		tz_load_context(rtcb->xcp.regs);
+#endif
+
 	}
 	/* Copy the exception context into the TCB at the (old) head of the
 	 * g_readytorun Task list. if up_saveusercontext returns a non-zero

--- a/os/include/tinyara/tz_context.h
+++ b/os/include/tinyara/tz_context.h
@@ -56,6 +56,7 @@
 #define TZ_CONTEXT_H
 
 #include <stdint.h>
+#include <arch/irq.h>
 
 /****************************************************************************
  * Public Type Declarations
@@ -70,10 +71,11 @@ typedef uint32_t TZ_ModuleId_t;
 /* Details TZ Memory ID identifies an allocated memory slot. */
 typedef uint32_t TZ_MemoryId_t;
 
+extern volatile TZ_MemoryId_t tz_memory;
+
 /****************************************************************************
  * Public Function Prototypes
  ****************************************************************************/
-
 /**
  * Initialize secure context memory system
  * return execution status (1: success, 0: error)
@@ -109,4 +111,40 @@ uint32_t TZ_LoadContext_S (TZ_MemoryId_t id);
  */
 uint32_t TZ_StoreContext_S (TZ_MemoryId_t id);
 
+/****************************************************************************
+ * Inline Functions
+ ****************************************************************************/
+
+/**
+/* Load the secure context and PSPLIM of OLD rtcb
+*/
+static inline void tz_load_context(uint32_t *reg)
+{
+	reg += REG_R8;
+	tz_memory = *reg;
+	uint32_t result = *(++reg);
+	set_PSPLIM(result);
+
+	/* If there is associated secure context
+	 * with the current active task, then load the secure context
+	 */
+	if (tz_memory) {
+		TZ_LoadContext_S(tz_memory);
+	}
+}
+
+/**
+ * Store the secure context and PSPLIM of OLD rtcb
+ */
+static inline void tz_store_context(uint32_t *reg)
+{
+	if (tz_memory) {
+		TZ_StoreContext_S(tz_memory);
+	}
+
+	reg += REG_R8;
+	*reg = tz_memory;
+	*(++reg) = get_PSPLIM();
+	tz_memory = 0;
+}
 #endif						/* TZ_CONTEXT_H */


### PR DESCRIPTION
This patch adds secure context handling when non-secure context switches without involving SVC
i.e when context switch/restore is done via up_savestate/up_restorestate

Signed-off-by: Nitish Ambastha <nitish.a@samsung.com>