### PR TITLE
loadable_apps: remove including Make.defs of TOPDIR from loadable.mk

### DIFF
--- a/loadable_apps/loadable.mk
+++ b/loadable_apps/loadable.mk
@@ -16,7 +16,6 @@
 #
 ###########################################################################
 include $(TOPDIR)/.config
-include $(TOPDIR)/Make.defs
 
 LINKLIBS = $(patsubst $(LIBRARIES_DIR)/%, %, $(USERLIBS))
 LDLIBS = $(patsubst %.a, %, $(patsubst lib%,-l%,$(LINKLIBS)))


### PR DESCRIPTION
The loadable.mk is an util script to build loadable user binary so that
it should be called from each binary.
Each binary should include Make.defs of TOPDIR and should define each
CFLAGS in each Makefile.
With above, loadable.mk should not include Make.defs of TOPDIR.
This commit makes each Makefile take own CFLAGS.

Signed-off-by: sunghan-chang <sh924.chang@samsung.com>