### PR TITLE
docs/ProtectedBuildGuide: add the Available APIs tab

### DIFF
--- a/docs/ProtectedBuildGuide.md
+++ b/docs/ProtectedBuildGuide.md
@@ -3,7 +3,7 @@
 ## Contents
 - [Overview of Flat Build](#overview-of-flat-build)
 - [Overview of Protected Build](#overview-of-protected-build)
-- [Steps for suporting protected build in a new chipset](#steps-for-supporting-protected-build-in-a-new-chipset)
+- [Steps for supporting protected build in a new chipset](#steps-for-supporting-protected-build-in-a-new-chipset)
 	- [Make.defs](#makedefs)
 	- [Linker scripts](#linker-scripts)
 	- [Userspace Initialization](#userspace-initialization)
@@ -92,7 +92,7 @@ The following sections give detailed explanation regarding some of the steps / c
 
 ```
 
-- It is mandatory to define __uflash_segment_start__ linker variable. This will be used in the code to obtain the address of the uerspace object.
+- It is mandatory to define __uflash_segment_start__ linker variable. This will be used in the code to obtain the address of the userspace object.
 - The user can also enable the CONFIG_AUTOGEN_MEMORY_LDSCRIPT config, which will auto-generate the memory.ld file based on the Flash partition information in CONFIG_FLASH_PART_XXXX configs.
 
 #### user-space.ld
@@ -118,7 +118,7 @@ The following sections give detailed explanation regarding some of the steps / c
 
 ### Userspace Initialization
 - Userspace initialization is performed during the boot up stage to initialize the  user space data and bss memory regions.
-- The userpsace data section is copied from the flash memory to the designated RAM memory region.
+- The userspace data section is copied from the flash memory to the designated RAM memory region.
 - The bss section is initialized with zeros.
 - If the flash does not support XIP, then the code section also needs to be copied from the flash to the designated area of RAM.
 - The start address and sizes of the code, data and bss sections can be found either in the USERSPACE object.

--- a/docs/ProtectedBuildGuide.md
+++ b/docs/ProtectedBuildGuide.md
@@ -9,6 +9,7 @@
 	- [Userspace Initialization](#userspace-initialization)
 	- [MPU Initialization](#mpu-initialization)
 	- [Allocation of kernel and user heaps](#allocation-of-kernel-and-user-heaps)
+- [Available APIs](#available-apis)
 
 
 ## Overview of Flat Build
@@ -139,3 +140,14 @@ The following sections give detailed explanation regarding some of the steps / c
 - The user heap starts at the end of the user bss section and spans the entire remaining space in the user ram region.
 - However, if the chipset has a memory configuration that is different from the default one or if the vendor would like to initialize the kernel and user heaps at different locations or sizes, then the vendor can implement new versions of the APIs in a chipset specific file such as CHIPSET_allocateheap.c and build this new file instead of up_allocate.c file.
 - The vendor needs to take care that the prototypes of the APIs are not changed in their new implementation.
+
+## Available APIs
+Because the main purpose of Protected build is kernel protection from user by separation, user application can't use some Kernel APIs which manage kernel internal operation like sched_gettcb API.
+The platform APIs user can use with protected build are defined in syscall, libc, framework and external folders.  
+Please find the lists to check whether API is available or not on Protected build.
+
+- [List of libc APIs](https://github.com/Samsung/TizenRT/blob/master/lib/libc/libc.csv)
+- [List of Math APIs](https://github.com/Samsung/TizenRT/blob/master/lib/libc/math.csv)
+- [List of syscall APIs](https://github.com/Samsung/TizenRT/blob/master/os/syscall/syscall.csv)
+- [Headers of framework](https://github.com/Samsung/TizenRT/tree/master/framework/include)
+- [Headers of external](https://github.com/Samsung/TizenRT/tree/master/external/include)


### PR DESCRIPTION
There are APIs which can be used on Protected build.
This commit adds the tab in the documentation of protected build guide
to say the API lists.

Signed-off-by: sunghan-chang <sh924.chang@samsung.com>