### PR TITLE
external/mbedtls: Add key allocation logic in mbedTLS alt layer

### DIFF
--- a/apps/examples/security_test/security_api/Makefile
+++ b/apps/examples/security_test/security_api/Makefile
@@ -30,6 +30,7 @@ ASRCS =
 #CSRCS += security_api_auth_test.c  security_api_keymgr_test.c security_api_ss_test.c
 CSRCS += security_api_utils.c
 CSRCS += security_api_keymgr_test.c security_api_crypto_test.c security_api_ss_test.c
+CSRCS += seclink_keymgr_test.c
 MAINSRC = security_api_test.c
 
 AOBJS = $(ASRCS:.S=$(OBJEXT))

--- a/apps/examples/security_test/security_api/security_api_crypto_test.c
+++ b/apps/examples/security_test/security_api/security_api_crypto_test.c
@@ -75,7 +75,7 @@ test_crypto(void)
 	aes_param.iv = iv.data;
 	aes_param.iv_len = iv.length;
 
-	if (0 != crypto_aes_encryption(hnd, aes_param, AES128_KEY, &input, &aes_enc_data)) {
+	if (0 != crypto_aes_encryption(hnd, &aes_param, AES128_KEY, &input, &aes_enc_data)) {
 		printf("Fail\n	! crypto_aes_encryption\n");
 		goto exit;
 	}
@@ -85,7 +85,7 @@ test_crypto(void)
 
 	printf("  . SEC AES Decryption ...\n");
 	fflush(stdout);
-	if (0 != crypto_aes_decryption(hnd, aes_param, AES128_KEY, &aes_enc_data, &aes_dec_data)) {
+	if (0 != crypto_aes_decryption(hnd, &aes_param, AES128_KEY, &aes_enc_data, &aes_dec_data)) {
 		printf("Fail\n	! security_aes_decryption\n");
 		goto exit;
 	}
@@ -117,7 +117,7 @@ test_crypto(void)
 	rsa_param.mgf = 0;
 	rsa_param.salt_byte_len = 0;
 
-	if (0 != crypto_rsa_encryption(hnd, rsa_param, RSA1024_KEY, &input, &rsa_enc_data)) {
+	if (0 != crypto_rsa_encryption(hnd, &rsa_param, RSA1024_KEY, &input, &rsa_enc_data)) {
 		printf("Fail\n	! crypto_rsa_encryption\n");
 		goto exit;
 	}
@@ -127,7 +127,7 @@ test_crypto(void)
 
 	printf("  . SEC RSA Decryption ...\n");
 	fflush(stdout);
-	if (0 != crypto_rsa_decryption(hnd, rsa_param, RSA1024_KEY, &rsa_enc_data, &rsa_dec_data)) {
+	if (0 != crypto_rsa_decryption(hnd, &rsa_param, RSA1024_KEY, &rsa_enc_data, &rsa_dec_data)) {
 		printf("Fail\n	! crypto_rsa_decryption\n");
 		goto exit;
 	}

--- a/apps/examples/security_test/security_api/security_api_ss_test.c
+++ b/apps/examples/security_test/security_api/security_api_ss_test.c
@@ -30,10 +30,7 @@
 void
 test_securestorage(void)
 {
-	int i;
 	unsigned int storage_size;
-	unsigned int count;
-	security_storage_list list;
 	security_handle hnd;
 	security_data input = {NULL, 0};
 	security_data output = {NULL, 0};
@@ -75,18 +72,6 @@ test_securestorage(void)
 	printf("ok\n");
 	PrintBuffer(TEST_SS_PATH, output.data, output.length);
 
-	printf("  . SEC Get Secure Storage List ...\n");
-
-	if (0 != ss_get_list_secure_storage(hnd, &count, &list)) {
-		printf("Fail\n	! ss_get_list_secure_storage\n");
-		goto exit;
-	}
-	printf("ok\n");
-	printf("[%20s] [%8s]\n", "FILE NAME", "FILE ATTR");
-	for (i = 0; i < count; i++) {
-		printf("[%20s] [%08x]\n", list[i].name, list[i].attr);
-	}
-
 	printf("  . SEC Delete secure storage ...\n");
 
 	if (0 != ss_delete_secure_storage(hnd, TEST_SS_PATH)) {
@@ -97,8 +82,6 @@ test_securestorage(void)
 
 exit:
 	free_security_data(&output);
-	if (count > 0)
-		free(list);
 
 	printf("  . SEC Deinitialize ...\n");
 	security_deinit(hnd);

--- a/apps/examples/security_test/security_api/security_api_test.c
+++ b/apps/examples/security_test/security_api/security_api_test.c
@@ -33,7 +33,7 @@ extern void test_authenticate(void);
 extern void test_crypto(void);
 extern void test_keymgr(void);
 extern void test_securestorage(void);
-
+extern void test_seclink_key(void);
 
 
 #ifdef CONFIG_BUILD_KERNEL
@@ -59,6 +59,8 @@ int security_api_test_main(int argc, char *argv[])
 	test_crypto();
 	test_keymgr();
 	test_securestorage();
+
+	test_seclink_key();
 
 	return 0;
 }

--- a/os/drivers/seclink/seclink_drv_utils.h
+++ b/os/drivers/seclink/seclink_drv_utils.h
@@ -5,7 +5,7 @@
 #endif
 
 #ifndef LINUX
-#define SLDRV_LOG vdbg
+#define SLDRV_LOG printf
 #else
 #define SLDRV_LOG printf
 #endif

--- a/os/include/tinyara/seclink_drv.h
+++ b/os/include/tinyara/seclink_drv.h
@@ -8,6 +8,7 @@ struct sec_upperhalf_s {
 	struct sec_lowerhalf_s *lower;
 	char *path;
 	int32_t refcnt;
+	sem_t su_lock;
 };
 
 struct sec_ops_s;

--- a/os/se/sss/security_hal_wrapper.c
+++ b/os/se/sss/security_hal_wrapper.c
@@ -1007,7 +1007,7 @@ int sss_hal_ecdsa_sign_md(hal_ecdsa_mode mode, hal_data *hash, uint32_t key_idx,
 	case HAL_ECDSA_SEC_P384R1:
 		ecc_sign.sign_type |= OID_ECC_P384;
 		break;
-	case HAL_ECDSA_SEC_P512R1:
+	case HAL_ECDSA_SEC_P521R1:
 		ecc_sign.sign_type |= OID_ECC_P521;
 		break;
 	case HAL_ECDSA_BRAINPOOL_P256R1:
@@ -1129,7 +1129,7 @@ int sss_hal_ecdsa_verify_md(hal_ecdsa_mode mode, hal_data *hash, hal_data *sign,
 	case HAL_ECDSA_SEC_P384R1:
 		ecc_sign.sign_type |= OID_ECC_P384;
 		break;
-	case HAL_ECDSA_SEC_P512R1:
+	case HAL_ECDSA_SEC_P521R1:
 		ecc_sign.sign_type |= OID_ECC_P521;
 		break;
 	case HAL_ECDSA_BRAINPOOL_P256R1:
@@ -1280,7 +1280,7 @@ int sss_hal_ecdh_compute_shared_secret(hal_ecdh_data *ecdh_param, uint32_t key_i
 	case HAL_ECDSA_SEC_P384R1:
 		ecc_pub.curve |= OID_ECC_P384;
 		break;
-	case HAL_ECDSA_SEC_P512R1:
+	case HAL_ECDSA_SEC_P521R1:
 		ecc_pub.curve |= OID_ECC_P521;
 		break;
 	case HAL_ECDSA_UNKNOWN:
@@ -1373,7 +1373,7 @@ int sss_hal_get_factory_key(uint32_t key_idx, hal_data *key)
 		}
 	} else {
 		return HAL_NOT_SUPPORTED;
-}
+	}
 
 	return HAL_SUCCESS;
 }


### PR DESCRIPTION
Add key allocation logic in mbedTLS alternative layer. if the key slot
is used and there are available slots then mbedTLS will allocate next
slot.