### PR TITLE
binfmt: Free app heap node when unloading binary

### DIFF
--- a/os/binfmt/binfmt_execmodule.c
+++ b/os/binfmt/binfmt_execmodule.c
@@ -68,10 +68,7 @@
 #include <tinyara/mm/shm.h>
 #include <tinyara/binfmt/binfmt.h>
 #include <tinyara/mpu.h>
-
-#ifdef CONFIG_DEBUG_MM_HEAPINFO
 #include <tinyara/mm/mm.h>
-#endif
 
 #ifdef CONFIG_BINARY_MANAGER
 #include <string.h>
@@ -176,9 +173,7 @@ int exec_module(FAR struct binary_s *binp)
 #ifdef CONFIG_APP_BINARY_SEPARATION
 	binp->uheap = (struct mm_heap_s *)binp->heapstart;
 	mm_initialize(binp->uheap, (void *)binp->heapstart + sizeof(struct mm_heap_s), binp->uheap_size);
-#ifdef CONFIG_BINARY_MANAGER
 	mm_add_app_heap_list(binp->uheap, binp->bin_name);
-#endif
 
 	/* The first 4 bytes of the text section of the application must contain a
 	pointer to the application's mm_heap object. Here we will store the mm_heap

--- a/os/binfmt/binfmt_exit.c
+++ b/os/binfmt/binfmt_exit.c
@@ -66,6 +66,7 @@
 #endif
 #endif
 
+#include <tinyara/mm/mm.h>
 #include <tinyara/kmalloc.h>
 #include <tinyara/binfmt/binfmt.h>
 
@@ -136,6 +137,7 @@ int binfmt_exit(FAR struct binary_s *bin)
 		}
 		address = (FAR void *)sq_next((FAR sq_entry_t *)address);
 	}
+	mm_remove_app_heap_list(bin->uheap);
 	/* Free the RAM partition into which this app was loaded */
 	kumm_free((void *)bin->ramstart);
 #endif


### PR DESCRIPTION
A node of app heap is created and added to a list of app heap when loading binary.
This node should be removed from the list and freed when unloading binary.