### PR TITLE
os/binfmt: Add missing macros for elf_dumpbuffer

### DIFF
--- a/os/binfmt/elf.c
+++ b/os/binfmt/elf.c
@@ -74,14 +74,6 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-/* CONFIG_DEBUG, CONFIG_DEBUG_INFO, and CONFIG_DEBUG_BINFMT have to be
- * defined or CONFIG_ELF_DUMPBUFFER does nothing.
- */
-
-#if !defined(CONFIG_DEBUG_INFO) || !defined(CONFIG_DEBUG_BINFMT)
-#undef CONFIG_ELF_DUMPBUFFER
-#endif
-
 #ifndef CONFIG_ELF_STACKSIZE
 #define CONFIG_ELF_STACKSIZE 2048
 #endif

--- a/os/binfmt/libelf/Kconfig
+++ b/os/binfmt/libelf/Kconfig
@@ -35,7 +35,7 @@ config ELF_BUFFERINCR
 config ELF_DUMPBUFFER
 	bool "Dump ELF buffers"
 	default n
-	depends on DEBUG_INFO
+	depends on DEBUG_BINFMT_INFO
 	---help---
 		Dump various ELF buffers for debug purposes
 

--- a/os/binfmt/libelf/libelf_bind.c
+++ b/os/binfmt/libelf/libelf_bind.c
@@ -73,14 +73,6 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-/* CONFIG_DEBUG_FEATURES, CONFIG_DEBUG_INFO, and CONFIG_DEBUG_BINFMT have to be
- * defined or CONFIG_ELF_DUMPBUFFER does nothing.
- */
-
-#if !defined(CONFIG_DEBUG_INFO) || !defined(CONFIG_DEBUG_BINFMT)
-#undef CONFIG_ELF_DUMPBUFFER
-#endif
-
 #ifdef CONFIG_ELF_DUMPBUFFER
 #define elf_dumpbuffer(m, b, n) binfodumpbuffer(m, b, n)
 #else

--- a/os/binfmt/libelf/libelf_init.c
+++ b/os/binfmt/libelf/libelf_init.c
@@ -77,14 +77,6 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-/* CONFIG_DEBUG_FEATURES, CONFIG_DEBUG_INFO, and CONFIG_DEBUG_BINFMT have to be
- * defined or CONFIG_ELF_DUMPBUFFER does nothing.
- */
-
-#if !defined(CONFIG_DEBUG_INFO) || !defined(CONFIG_DEBUG_BINFMT)
-#undef CONFIG_ELF_DUMPBUFFER
-#endif
-
 #ifdef CONFIG_ELF_DUMPBUFFER
 #define elf_dumpbuffer(m, b, n) binfodumpbuffer(m, b, n)
 #else

--- a/os/include/debug.h
+++ b/os/include/debug.h
@@ -1696,6 +1696,18 @@ int get_errno(void);
 #define vdbgdumpbuffer(m, b, n)
 #endif
 
+#ifdef CONFIG_DEBUG_ERROR
+#  define errdumpbuffer(m, b, n) lib_dumpbuffer(m, b, n)
+#  ifdef CONFIG_DEBUG_VERBOSE
+#    define infodumpbuffer(m, b, n) lib_dumpbuffer(m, b, n)
+#  else
+#   define infodumpbuffer(m, b, n)
+#  endif
+#else
+#  define errdumpbuffer(m, b, n)
+#  define infodumpbuffer(m, b, n)
+# endif
+
 /* Subsystem specific debug */
 
 #ifdef CONFIG_DEBUG_MM
@@ -1768,6 +1780,14 @@ int get_errno(void);
 #else
 #define gdbgdumpbuffer(m, b, n)
 #define gvdbgdumpbuffer(m, b, n)
+#endif
+
+#ifdef CONFIG_DEBUG_BINFMT
+#  define berrdumpbuffer(m, b, n)  errdumpbuffer(m, b, n)
+#  define binfodumpbuffer(m, b, n) infodumpbuffer(m, b, n)
+#else
+#  define berrdumpbuffer(m, b, n)
+#  define binfodumpbuffer(m, b, n)
 #endif
 
 #ifdef CONFIG_DEBUG_LIB


### PR DESCRIPTION
Add missing debug macros for CONFIG_ELF_DUMPBUFFER

Signed-off-by: Sangamanatha <sangam.swami@samsung.com>