### PR TITLE
binfmt/libelf: Free memory if it is allocated memory

### DIFF
--- a/os/binfmt/libelf/libelf_bind.c
+++ b/os/binfmt/libelf/libelf_bind.c
@@ -271,8 +271,10 @@ static int elf_relocate(FAR struct elf_loadinfo_s *loadinfo, int relidx, FAR con
 	}
 
 ret_err:
-	kmm_free((void *)loadinfo->reltab);
-	loadinfo->reltab = (uintptr_t)NULL;
+	if (loadinfo->reltab) {
+		kmm_free((void *)loadinfo->reltab);
+		loadinfo->reltab = (uintptr_t)NULL;
+	}
 	return ret;
 }
 
@@ -485,7 +487,9 @@ ret_err:
 		kmm_free((void *)loadinfo->strtab);
 		loadinfo->strtab = (uintptr_t)NULL;
 	}
-	kmm_free((void *)loadinfo->symtab);
-	loadinfo->symtab = (uintptr_t)NULL;
+	if (loadinfo->symtab) {
+		kmm_free((void *)loadinfo->symtab);
+		loadinfo->symtab = (uintptr_t)NULL;
+	}
 	return ret;
 }

--- a/os/mm/kmm_heap/kmm_free.c
+++ b/os/mm/kmm_heap/kmm_free.c
@@ -92,8 +92,12 @@
 
 void kmm_free(FAR void *mem)
 {
-	struct mm_heap_s *kheap = mm_get_heap(mem);
-	DEBUGASSERT(kmm_heapmember(mem));
-	mm_free(kheap, mem);
+	struct mm_heap_s *kheap;
+
+	if (mem) {
+		DEBUGASSERT(kmm_heapmember(mem));
+		kheap = mm_get_heap(mem);
+		mm_free(kheap, mem);
+	}
 }
 #endif							/* CONFIG_MM_KERNEL_HEAP */


### PR DESCRIPTION
The memory should be freed when it is allocated.