### PR TITLE
tools/nxfuse: fix wrong conditional of vdbg

### DIFF
--- a/tools/nxfuse/src/tinyara_services.c
+++ b/tools/nxfuse/src/tinyara_services.c
@@ -290,7 +290,7 @@ int dbg(const char *fmt, ...)
  *
  ****************************************************************************/
 
-#ifdef CONFIG_DEBUG
+#ifdef CONFIG_DEBUG_VERBOSE
 int vdbg(const char *fmt, ...)
 {
 	va_list args;


### PR DESCRIPTION
The vdbg function is matched with CONFIG_DEBUG_VERBOSE, not
CONFIG_DEBUG.
This commit fixs above and resolves build break as below:
In file included from src/tinyara_services.c:68:0:
include/debug.h:1052:21: error: expected identifier or '(' before 'void'
 #define vdbg       (void)
                     ^
src/tinyara_services.c:294:5: note: in expansion of macro 'vdbg'
 int vdbg(const char *fmt, ...)
     ^
make[3]: *** [obj/tinyara_services.o] Error 1

Signed-off-by: sunghan-chang <sh924.chang@samsung.com>