### PR TITLE
configs/imxrt10x0-evk: check adding USB rule command at start

### DIFF
--- a/build/configs/artik053/README.md
+++ b/build/configs/artik053/README.md
@@ -94,6 +94,57 @@ Please set TizenRT common environment, [quick start](https://github.com/Samsung/
 This is an optional environment.  
 But as ARTIK is connected through USB, some operation like programming of binary can't be worked without this configuration.
 
+#### By dbuild.sh script
+
+The *dbuild.sh* script with the *menu* option supports the *u. USBrule* option to add it.
+
+1. Select the *d. Download* option after building TizenRT
+```sh
+======================================================
+  "Select build Option"
+======================================================
+  "1. Build with Current Configurations"
+  "2. Re-configure"
+  "3. Menuconfig"
+  "4. Build Clean"
+  "5. Build Dist-Clean"
+  "6. Build SmartFS Image"
+  "d. Download"
+  "x. Exit"
+======================================================
+d
+```
+2. Select the *u. USBrule* option
+```sh
+==================================================
+  "Select download option"
+==================================================
+  "1. ALL"
+  "2. OS"
+  "4. APPS"
+  "5. OTA"
+  "6. ROM"
+  "7. MICOM"
+  "8. WIFI"
+  "9. LOADPARAM"
+  "10. BL1"
+  "11. BL2"
+  "12. SSSFW"
+  "13. WLANFW"
+  "14. ERASE OTA"
+  "15. ERASE USERFS"
+  "16. ERASE ALL"
+  "u. USBrule"
+  "x. Exit"
+==================================================
+u
+```
+
+>**NOTE**
+>It requires root permission.
+
+#### By manually
+
 1. Make a file named 99-\<anyname\>.rules.
 2. Add below contents at above file.
 ```

--- a/build/configs/artik053s/README.md
+++ b/build/configs/artik053s/README.md
@@ -95,6 +95,57 @@ Please set TizenRT common environment, [quick start](https://github.com/Samsung/
 This is an optional environment.  
 But as ARTIK is connected through USB, some operation like programming of binary can't be worked without this configuration.
 
+#### By dbuild.sh script
+
+The *dbuild.sh* script with the *menu* option supports the *u. USBrule* option to add it.
+
+1. Select the *d. Download* option after building TizenRT
+```sh
+======================================================
+  "Select build Option"
+======================================================
+  "1. Build with Current Configurations"
+  "2. Re-configure"
+  "3. Menuconfig"
+  "4. Build Clean"
+  "5. Build Dist-Clean"
+  "6. Build SmartFS Image"
+  "d. Download"
+  "x. Exit"
+======================================================
+d
+```
+2. Select the *u. USBrule* option
+```sh
+==================================================
+  "Select download option"
+==================================================
+  "1. ALL"
+  "2. OS"
+  "4. APPS"
+  "5. OTA"
+  "6. ROM"
+  "7. MICOM"
+  "8. WIFI"
+  "9. LOADPARAM"
+  "10. BL1"
+  "11. BL2"
+  "12. SSSFW"
+  "13. WLANFW"
+  "14. ERASE OTA"
+  "15. ERASE USERFS"
+  "16. ERASE ALL"
+  "u. USBrule"
+  "x. Exit"
+==================================================
+u
+```
+
+>**NOTE**
+>It requires root permission.
+
+#### By manually
+
 1. Make a file named 99-\<anyname\>.rules.
 2. Add below contents at above file.
 ```

--- a/build/configs/artik055s/README.md
+++ b/build/configs/artik055s/README.md
@@ -101,6 +101,57 @@ Please set TizenRT common environment, [quick start](https://github.com/Samsung/
 This is an optional environment.  
 But as ARTIK is connected through USB, some operation like programming of binary can't be worked without this configuration.
 
+#### By dbuild.sh script
+
+The *dbuild.sh* script with the *menu* option supports the *u. USBrule* option to add it.
+
+1. Select the *d. Download* option after building TizenRT
+```sh
+======================================================
+  "Select build Option"
+======================================================
+  "1. Build with Current Configurations"
+  "2. Re-configure"
+  "3. Menuconfig"
+  "4. Build Clean"
+  "5. Build Dist-Clean"
+  "6. Build SmartFS Image"
+  "d. Download"
+  "x. Exit"
+======================================================
+d
+```
+2. Select the *u. USBrule* option
+```sh
+==================================================
+  "Select download option"
+==================================================
+  "1. ALL"
+  "2. OS"
+  "4. APPS"
+  "5. OTA"
+  "6. ROM"
+  "7. MICOM"
+  "8. WIFI"
+  "9. LOADPARAM"
+  "10. BL1"
+  "11. BL2"
+  "12. SSSFW"
+  "13. WLANFW"
+  "14. ERASE OTA"
+  "15. ERASE USERFS"
+  "16. ERASE ALL"
+  "u. USBrule"
+  "x. Exit"
+==================================================
+u
+```
+
+>**NOTE**
+>It requires root permission.
+
+#### By manually
+
 1. Make a file named 99-\<anyname\>.rules.
 2. Add below contents at above file.
 ```

--- a/build/configs/imxrt1020-evk/README.md
+++ b/build/configs/imxrt1020-evk/README.md
@@ -13,6 +13,55 @@ Please refer NXP Semiconductors [homepage](https://www.nxp.com/support/developer
 This section covers board-specific environment set-up.  
 Please set TizenRT common environment, [quick start](https://github.com/Samsung/TizenRT#quick-start), first before doing below.
 
+### Add USB device rules
+
+This is an optional environment.  
+But as the device is connected through USB, some operation like programming of binary can't be worked without this configuration.
+
+The *dbuild.sh* script with the *menu* option supports the *u. USBrule* option to add it.
+
+1. Select the *d. Download* option after building TizenRT
+```sh
+======================================================
+  "Select build Option"
+======================================================
+  "1. Build with Current Configurations"
+  "2. Re-configure"
+  "3. Menuconfig"
+  "4. Build Clean"
+  "5. Build Dist-Clean"
+  "6. Build SmartFS Image"
+  "d. Download"
+  "x. Exit"
+======================================================
+d
+```
+2. Select the *u. USBrule* option
+```sh
+==================================================
+  "Select download option"
+==================================================
+  "1. ALL"
+  "2. KERNEL"
+  "3. APP"
+  "4. MICOM"
+  "5. WIFI"
+  "6. USERFS"
+  "8. ERASE KERNEL"
+  "9. ERASE APP"
+  "10. ERASE MICOM"
+  "11. ERASE WIFI"
+  "12. ERASE USERFS"
+  "13. ERASE ALL"
+  "u. USBrule"
+  "x. Exit"
+==================================================
+u
+```
+
+>**NOTE**
+>It requires root permission.
+
 ## How to program a binary
 After building TizenRT, execute below command at $TIZENRT_BASEDIR/os folder.  
 See [[Getting the sources]](https://github.com/Samsung/TizenRT#getting-the-sources) for how to set *TIZENRT_BASEDIR*.

--- a/build/configs/imxrt1020-evk/imxrt1020-evk_download.sh
+++ b/build/configs/imxrt1020-evk/imxrt1020-evk_download.sh
@@ -189,6 +189,17 @@ function get_partition_sizes()
 }
 
 # Start here
+
+cmd_args=$@
+
+# Treat adding the USB rule first
+for i in ${cmd_args[@]};do
+	if [[ "${i}" == "USBrule" || "${i}" == "usbrule" ]];then
+		${USBRULE_PATH} ${USBRULE_BOARD} ${USBRULE_IDVENDOR} ${USBRULE_IDPRODUCT} || exit 1
+		exit 0
+	fi
+done
+
 imxrt1020_sanity_check;
 
 parts=$(get_configured_partitions)
@@ -219,7 +230,6 @@ if test $# -eq 0; then
 fi
 
 uniq_parts=($(printf "%s\n" "${parts[@]}" | sort -u));
-cmd_args=$@
 
 #Validate arguments
 for i in ${cmd_args[@]};do
@@ -277,9 +287,6 @@ erase)
 		done
 		shift
 	done
-	;;
-usbrule)
-	${USBRULE_PATH} ${USBRULE_BOARD} ${USBRULE_IDVENDOR} ${USBRULE_IDPRODUCT} || exit 1
 	;;
 #Download <list of partitions>
 *)

--- a/build/configs/imxrt1050-evk/README.md
+++ b/build/configs/imxrt1050-evk/README.md
@@ -8,6 +8,57 @@
 ## Information
 Please refer NXP Semiconductors [homepage](https://www.nxp.com/support/developer-resources/software-development-tools/i.mx-developer-resources/i.mx-rt1050-evaluation-kit:MIMXRT1050-EVK).
 
+## Environment Set-up
+
+### Add USB device rules
+
+This is an optional environment.  
+But as the device is connected through USB, some operation like programming of binary can't be worked without this configuration.
+
+The *dbuild.sh* script with the *menu* option supports the *u. USBrule* option to add it.
+
+1. Select the *d. Download* option after building TizenRT
+```sh
+======================================================
+  "Select build Option"
+======================================================
+  "1. Build with Current Configurations"
+  "2. Re-configure"
+  "3. Menuconfig"
+  "4. Build Clean"
+  "5. Build Dist-Clean"
+  "6. Build SmartFS Image"
+  "d. Download"
+  "x. Exit"
+======================================================
+d
+```
+2. Select the *u. USBrule* option
+```sh
+==================================================
+  "Select download option"
+==================================================
+  "1. ALL"
+  "2. KERNEL"
+  "3. APP"
+  "4. MICOM"
+  "5. WIFI"
+  "6. USERFS"
+  "8. ERASE KERNEL"
+  "9. ERASE APP"
+  "10. ERASE MICOM"
+  "11. ERASE WIFI"
+  "12. ERASE USERFS"
+  "13. ERASE ALL"
+  "u. USBrule"
+  "x. Exit"
+==================================================
+u
+```
+
+>**NOTE**
+>It requires root permission.
+
 ## How to program a binary
 After building TizenRT, execute below command at $TIZENRT_BASEDIR/os folder.  
 See [[Getting the sources]](https://github.com/Samsung/TizenRT#getting-the-sources) for how to set *TIZENRT_BASEDIR*.

--- a/build/configs/imxrt1050-evk/imxrt1050-evk_download.sh
+++ b/build/configs/imxrt1050-evk/imxrt1050-evk_download.sh
@@ -217,6 +217,16 @@ function get_partition_sizes()
 
 # Start here
 
+cmd_args=$@
+
+# Treat adding the USB rule first
+for i in ${cmd_args[@]};do
+	if [[ "${i}" == "USBrule" || "${i}" == "usbrule" ]];then
+		${USBRULE_PATH} ${USBRULE_BOARD} ${USBRULE_IDVENDOR} ${USBRULE_IDPRODUCT} || exit 1
+		exit 0
+	fi
+done
+
 #Sanity Check
 imxrt1050_sanity_check
 
@@ -250,7 +260,6 @@ if test $# -eq 0; then
 fi
 
 uniq_parts=($(printf "%s\n" "${parts[@]}" | sort -u));
-cmd_args=$@
 
 #Validate arguments
 for i in ${cmd_args[@]};do
@@ -272,8 +281,6 @@ for i in ${cmd_args[@]};do
 	fi
 	result=no
 done
-
-
 
 #bootstrap
 bootstrap
@@ -304,9 +311,6 @@ erase)
                 shift
         done
         ;;
-usbrule)
-	${USBRULE_PATH} ${USBRULE_BOARD} ${USBRULE_IDVENDOR} ${USBRULE_IDPRODUCT} || exit 1
-	;;
 #Download <list of partitions>
 *)
         while test $# -gt 0


### PR DESCRIPTION
Adding the USB rule file is not related with image programming
in the flash so that it does not need to check others like
partition table, serial port and so on.
This commit moves the location of checking that command at
very first.

Signed-off-by: sunghan-chang <sh924.chang@samsung.com>