### PR TITLE
os/fs/smartfs: Add missing 'endmenu' in Kconfig

### DIFF
--- a/os/fs/smartfs/Kconfig
+++ b/os/fs/smartfs/Kconfig
@@ -88,5 +88,7 @@ config SMARTFS_JOURNALING
                 of file descriptors allowed and sector size defined. Thus, to
                 minimize the area reserved for journaling, it is advised to keep
                 sector size small.
+
+endmenu
                 
 endif


### PR DESCRIPTION
- 'endmenu' statement mistakenly removed earlier
  causes make menuconfig to fail.
- Re-add statement.

Signed-off-by: Amogh Hassija <a.hassija@samsung.com>