### PR TITLE
[Realtek][RTL8721CSM]Add General Purpose Timer Peripheral

### DIFF
--- a/os/arch/arm/src/amebad/Make.defs
+++ b/os/arch/arm/src/amebad/Make.defs
@@ -146,6 +146,7 @@ CHIP_CSRCS += amebad_timerisr.c
 CHIP_CSRCS += amebad_serial.c
 CHIP_CSRCS += amebad_lowerhalf.c
 CHIP_CSRCS += amebad_enet.c
+CHIP_CSRCS += amebad_timer_lowerhalf.c
 
 ifeq ($(CONFIG_AMEBAD_TRUSTZONE),y)
 CHIP_CSRCS += amebad_nsc.c

--- a/os/arch/arm/src/amebad/amebad_timer_lowerhalf.c
+++ b/os/arch/arm/src/amebad/amebad_timer_lowerhalf.c
@@ -142,6 +142,8 @@ static struct amebad_gpt_lowerhalf_s g_gpt3_lowerhalf = {
 static void amebad_timout_handler(uint32_t data)
 {
 	struct amebad_gpt_lowerhalf_s *priv = (struct amebad_gpt_lowerhalf_s *)data;
+	DEBUGASSERT(priv);
+
 	uint32_t next_interval_us = 0;
 
 	if (priv->callback(&next_interval_us, priv->arg)) {
@@ -179,7 +181,7 @@ static int amebad_gpt_start(struct timer_lowerhalf_s *lower)
 		}
 		gtimer_start_periodical(&priv->obj, priv->gpt_timeout, (void *)amebad_timout_handler, priv);
 		priv->started = true;
-		gtimer_reload(&priv->obj, 1000000);
+
 		tmrvdbg("Timer %d is started, callback %s\n", priv->obj.timer_id, priv->callback == NULL ? "none" : "set");
 		return OK;
 	}
@@ -206,6 +208,7 @@ static int amebad_gpt_start(struct timer_lowerhalf_s *lower)
 static int amebad_gpt_stop(struct timer_lowerhalf_s *lower)
 {
 	struct amebad_gpt_lowerhalf_s *priv = (struct amebad_gpt_lowerhalf_s *)lower;
+	DEBUGASSERT(priv);
 
 	if (priv->started) {
 		gtimer_deinit(&priv->obj);
@@ -238,6 +241,7 @@ static int amebad_gpt_stop(struct timer_lowerhalf_s *lower)
 static int amebad_gpt_settimeout(struct timer_lowerhalf_s *lower, uint32_t timeout)
 {
 	struct amebad_gpt_lowerhalf_s *priv = (struct amebad_gpt_lowerhalf_s *)lower;
+	DEBUGASSERT(priv);
 
 	if (priv->started) {
 		return -EPERM;
@@ -253,7 +257,7 @@ static int amebad_gpt_settimeout(struct timer_lowerhalf_s *lower, uint32_t timeo
  * Name: amebad_gpt_setcallback
  *
  * Description:
- *   Call this user provided timeout callback.
+ *   Set the user provided timeout callback.
  *
  * Input Parameters:
  *   lower    - A pointer the publicly visible representation of the
@@ -271,6 +275,8 @@ static int amebad_gpt_settimeout(struct timer_lowerhalf_s *lower, uint32_t timeo
 static void amebad_gpt_setcallback(struct timer_lowerhalf_s *lower, tccb_t callback, void *arg)
 {
 	struct amebad_gpt_lowerhalf_s *priv = (struct amebad_gpt_lowerhalf_s *)lower;
+	DEBUGASSERT(priv);
+
 	irqstate_t flags = irqsave();
 
 	/* Save the new callback */
@@ -307,15 +313,17 @@ int amebad_timer_initialize(const char *devpath, int timer)
 		break;
 
 	case TIMER2:
-		printf("Timer2\n");
 		priv = &g_gpt2_lowerhalf;
 		priv->obj.timer_id = TIMER2;
 		break;
 
 	case TIMER3:
-		printf("Timer3\n");
 		priv = &g_gpt3_lowerhalf;
 		priv->obj.timer_id = TIMER3;
+		break;
+
+	default: 
+		priv = NULL;
 		break;
 	}
 

--- a/os/arch/arm/src/amebad/amebad_timer_lowerhalf.c
+++ b/os/arch/arm/src/amebad/amebad_timer_lowerhalf.c
@@ -1,0 +1,348 @@
+/****************************************************************************
+ *
+ * Copyright 2020 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ****************************************************************************/
+/****************************************************************************
+ *
+ *   Copyright (C) 2020 Gregory Nutt. All rights reserved.
+ *   Author: Gregory Nutt <gnutt@nuttx.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+#include <tinyara/config.h>
+
+#include <sys/types.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <string.h>
+#include <errno.h>
+#include <debug.h>
+
+#include <tinyara/kmalloc.h>
+#include <tinyara/timer.h>
+#include <tinyara/irq.h>
+#include "timer_api.h"
+
+#ifdef CONFIG_TIMER
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Types
+ ****************************************************************************/
+
+struct amebad_gpt_lowerhalf_s {
+	const struct timer_ops_s *ops;	/* Lowerhalf operations */
+	gtimer_t obj;
+	uint8_t irq_id;
+	bool started;				/* True: Timer is started */
+	tccb_t callback;
+	void *arg;					/* Argument passed to upper half callback */
+	uint32_t gpt_timeout;
+};
+
+/****************************************************************************
+ * Private Function Prototypes
+ ****************************************************************************/
+static int amebad_gpt_start(struct timer_lowerhalf_s *lower);
+static int amebad_gpt_stop(struct timer_lowerhalf_s *lower);
+static int amebad_gpt_getstatus(struct timer_lowerhalf_s *lower, struct timer_status_s *status);
+static int amebad_gpt_settimeout(struct timer_lowerhalf_s *lower, uint32_t timeout);
+static void amebad_gpt_setcallback(struct timer_lowerhalf_s *lower, CODE tccb_t callback, void *arg);
+static int amebad_gpt_ioctl(struct timer_lowerhalf_s *lower, int cmd, unsigned long arg);
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+static const struct timer_ops_s g_timer_ops = {
+	.start = amebad_gpt_start,
+	.stop = amebad_gpt_stop,
+	.getstatus = NULL,
+	.settimeout = amebad_gpt_settimeout,
+	.setcallback = amebad_gpt_setcallback,
+	.ioctl = NULL,
+};
+
+static struct amebad_gpt_lowerhalf_s g_gpt0_lowerhalf = {
+	.ops = &g_timer_ops,
+};
+
+static struct amebad_gpt_lowerhalf_s g_gpt1_lowerhalf = {
+	.ops = &g_timer_ops,
+};
+
+static struct amebad_gpt_lowerhalf_s g_gpt2_lowerhalf = {
+	.ops = &g_timer_ops,
+};
+
+static struct amebad_gpt_lowerhalf_s g_gpt3_lowerhalf = {
+	.ops = &g_timer_ops,
+};
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+/****************************************************************************
+ * Name: amebad_gpt_handler
+ *
+ * Description:
+ *   timer interrupt handler
+ *
+ * Input Parameters:
+ *
+ * Returned Values:
+ *
+ ****************************************************************************/
+
+static void amebad_timout_handler(uint32_t data)
+{
+	struct amebad_gpt_lowerhalf_s *priv = (struct amebad_gpt_lowerhalf_s *)data;
+	uint32_t next_interval_us = 0;
+
+	if (priv->callback(&next_interval_us, priv->arg)) {
+		if (next_interval_us > 0) {
+			priv->gpt_timeout = next_interval_us;
+			gtimer_reload(&priv->obj, priv->gpt_timeout);
+		}
+	} else {
+		amebad_gpt_stop((struct timer_lowerhalf_s *)priv);
+	}
+}
+
+/****************************************************************************
+ * Name: amebad_gpt_start
+ *
+ * Description:
+ *   Start the timer, resetting the time to the current timeout,
+ *
+ * Input Parameters:
+ *   lower - A pointer the publicly visible representation of the "lower-half"
+ *           driver state structure.
+ *
+ * Returned Values:
+ *   Zero on success; a negated errno value on failure.
+ *
+ ****************************************************************************/
+static int amebad_gpt_start(struct timer_lowerhalf_s *lower)
+{
+	struct amebad_gpt_lowerhalf_s *priv = (struct amebad_gpt_lowerhalf_s *)lower;
+	DEBUGASSERT(priv);
+
+	if (!priv->started) {
+		if (priv->callback != NULL) {
+			gtimer_init(&priv->obj, priv->obj.timer_id);
+		}
+		gtimer_start_periodical(&priv->obj, priv->gpt_timeout, (void *)amebad_timout_handler, priv);
+		priv->started = true;
+		gtimer_reload(&priv->obj, 1000000);
+		tmrvdbg("Timer %d is started, callback %s\n", priv->obj.timer_id, priv->callback == NULL ? "none" : "set");
+		return OK;
+	}
+
+	/* Return EBUSY to indicate that the timer was already running */
+	tmrdbg("Error!! Timer %d was already running\n", priv->obj.timer_id);
+	return -EBUSY;
+}
+
+/****************************************************************************
+ * Name: amebad_gpt_stop
+ *
+ * Description:
+ *   Stop the timer
+ *
+ * Input Parameters:
+ *   lower - A pointer the publicly visible representation of the "lower-half"
+ *           driver state structure.
+ *
+ * Returned Values:
+ *   Zero on success; a negated errno value on failure.
+ *
+ ****************************************************************************/
+static int amebad_gpt_stop(struct timer_lowerhalf_s *lower)
+{
+	struct amebad_gpt_lowerhalf_s *priv = (struct amebad_gpt_lowerhalf_s *)lower;
+
+	if (priv->started) {
+		gtimer_deinit(&priv->obj);
+		priv->started = false;
+
+		tmrvdbg("Timer %d is stopped\n", priv->obj.timer_id);
+		return OK;
+	}
+
+	/* Return ENODEV to indicate that the timer was not running */
+	tmrdbg("Error!! Timer %d is not running\n", priv->obj.timer_id);
+	return -ENODEV;
+}
+
+/****************************************************************************
+ * Name: amebad_gpt_settimeout
+ *
+ * Description:
+ *   Set a new timeout value (and reset the timer)
+ *
+ * Input Parameters:
+ *   lower   - A pointer the publicly visible representation of the
+ *             "lower-half" driver state structure.
+ *   timeout - The new timeout value in microseconds.
+ *
+ * Returned Values:
+ *   Zero on success; a negated errno value on failure.
+ *
+ ****************************************************************************/
+static int amebad_gpt_settimeout(struct timer_lowerhalf_s *lower, uint32_t timeout)
+{
+	struct amebad_gpt_lowerhalf_s *priv = (struct amebad_gpt_lowerhalf_s *)lower;
+
+	if (priv->started) {
+		return -EPERM;
+	}
+
+	gtimer_reload(&priv->obj, timeout);
+	priv->gpt_timeout = timeout;
+
+	return OK;
+}
+
+/****************************************************************************
+ * Name: amebad_gpt_setcallback
+ *
+ * Description:
+ *   Call this user provided timeout callback.
+ *
+ * Input Parameters:
+ *   lower    - A pointer the publicly visible representation of the
+ *              "lower-half" driver state structure.
+ *   callback - The new timer expiration function pointer. If this
+ *              function pointer is NULL, then the reset-on-expiration
+ *              behavior is restored,
+ *  arg       - Argument that will be provided in the callback
+ *
+ * Returned Values:
+ *   The previous timer expiration function pointer or NULL is there was
+ *   no previous function pointer.
+ *
+ ****************************************************************************/
+static void amebad_gpt_setcallback(struct timer_lowerhalf_s *lower, tccb_t callback, void *arg)
+{
+	struct amebad_gpt_lowerhalf_s *priv = (struct amebad_gpt_lowerhalf_s *)lower;
+	irqstate_t flags = irqsave();
+
+	/* Save the new callback */
+	priv->callback = callback;
+	priv->arg = arg;
+
+	/* If no callback is attached, the timer stop at the first interrupt */
+	if (callback != NULL && priv->started) {
+		priv->obj.handler = (void *)amebad_timout_handler;
+		gtimer_init(&priv->obj, priv->obj.timer_id);
+	} else {
+		gtimer_deinit(&priv->obj);
+	}
+
+	irqrestore(flags);
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+int amebad_timer_initialize(const char *devpath, int timer)
+{
+	struct amebad_gpt_lowerhalf_s *priv = NULL;
+
+	switch (timer) {
+	case TIMER0:
+		priv = &g_gpt0_lowerhalf;
+		priv->obj.timer_id = TIMER0;
+		break;
+
+	case TIMER1:
+		priv = &g_gpt1_lowerhalf;
+		priv->obj.timer_id = TIMER1;
+		break;
+
+	case TIMER2:
+		printf("Timer2\n");
+		priv = &g_gpt2_lowerhalf;
+		priv->obj.timer_id = TIMER2;
+		break;
+
+	case TIMER3:
+		printf("Timer3\n");
+		priv = &g_gpt3_lowerhalf;
+		priv->obj.timer_id = TIMER3;
+		break;
+	}
+
+	if (!priv) {
+		return -ENODEV;
+	}
+
+	/* Initialize the elements of lower half state structure */
+	priv->started = false;
+	priv->callback = NULL;
+
+	/*
+	 * Register the timer driver as /dev/timerX.  The returned value from
+	 * timer_register is a handle that could be used with timer_unregister().
+	 * REVISIT: The returned handle is discard here.
+	 */
+
+	if (!timer_register(devpath, (struct timer_lowerhalf_s *)priv)) {
+		/*
+		 * The actual cause of the failure may have been a failure to allocate
+		 * perhaps a failure to register the timer driver (such as if the
+		 * 'depath' were not unique).  We know here but we return EEXIST to
+		 * indicate the failure (implying the non-unique devpath).
+		 */
+		return -EEXIST;
+	}
+	return OK;
+}
+
+#endif							/* CONFIG_TIMER */

--- a/os/board/rtl8721csm/src/component/common/mbed/targets/hal/rtl8721d/timer_api.c
+++ b/os/board/rtl8721csm/src/component/common/mbed/targets/hal/rtl8721d/timer_api.c
@@ -79,8 +79,14 @@ void gtimer_init (gtimer_t *obj, uint32_t tid)
 	TIM_InitStruct.TIM_UpdateEvent = ENABLE; /* UEV enable */
 	TIM_InitStruct.TIM_UpdateSource = TIM_UpdateSource_Overflow;
 	TIM_InitStruct.TIM_ARRProtection = ENABLE;
-	
+#ifndef CONFIG_PLATFORM_TIZENRT_OS
 	RTIM_TimeBaseInit(TIM_x[tid], &TIM_InitStruct, TIMx_irq[tid], (IRQ_FUN) gtimer_timeout_handler, (u32)obj);
+#else
+	RTIM_TimeBaseInit(TIM_x[tid], &TIM_InitStruct, TIMx_irq[tid], NULL, NULL);
+	InterruptDis(TIMx_irq[tid]);
+	InterruptRegister((IRQ_FUN) gtimer_timeout_handler, TIMx_irq[tid], (u32)obj, 14);
+	InterruptEn(TIMx_irq[tid], 14);
+#endif
 }
 
 /**

--- a/os/board/rtl8721csm/src/rtl8721csm_boot.c
+++ b/os/board/rtl8721csm/src/rtl8721csm_boot.c
@@ -65,6 +65,7 @@
 #include <tinyara/board.h>
 #include <arch/board/board.h>
 #include "gpio_api.h"
+#include "timer_api.h"
 
 /************************************************************************************
  * Pre-processor Definitions
@@ -90,70 +91,77 @@ void board_gpio_initialize(void)
 		u32 pinmode;
 		u32 pinpull;
 	} pins[] = {
-		{PA_0, PIN_OUTPUT, PullNone}, 
-		{PA_1, PIN_OUTPUT, PullNone},
-		{PA_2, PIN_OUTPUT, PullNone},
-		{PA_3, PIN_OUTPUT, PullNone}, 
-		{PB_5, PIN_OUTPUT, PullNone},
-		{PA_12, PIN_INPUT, PullDown},
-/*		{PA_6, PIN_OUTPUT, PullNone}, 
-		{PA_7, PIN_OUTPUT, PullNone},
-		{PA_8, PIN_OUTPUT, PullNone},
-		{PA_9, PIN_OUTPUT, PullNone}, 
-		{PA_10, PIN_OUTPUT, PullNone},
-		{PA_11, PIN_OUTPUT, PullNone},
-		{PA_12, PIN_OUTPUT, PullNone}, 
-		{PA_13, PIN_OUTPUT, PullNone},
-		{PA_14, PIN_OUTPUT, PullNone},
-		{PA_15, PIN_OUTPUT, PullNone}, 
-		{PA_16, PIN_OUTPUT, PullNone},
-		{PA_17, PIN_OUTPUT, PullNone},
-		{PA_18, PIN_OUTPUT, PullNone}, 
-		{PA_19, PIN_OUTPUT, PullNone},
-		{PA_20, PIN_OUTPUT, PullNone},
-		{PA_21, PIN_OUTPUT, PullNone}, 
-		{PA_22, PIN_OUTPUT, PullNone},
-		{PA_23, PIN_OUTPUT, PullNone},
-		{PA_24, PIN_OUTPUT, PullNone}, 
-		{PA_25, PIN_OUTPUT, PullNone},
-		{PA_26, PIN_OUTPUT, PullNone},
-		{PB_27, PIN_OUTPUT, PullNone}, 
-		{PA_28, PIN_OUTPUT, PullNone},
-		{PA_29, PIN_OUTPUT, PullNone},
-		{PA_30, PIN_OUTPUT, PullNone}, 
-		{PA_31, PIN_OUTPUT, PullNone},
-		{PB_0, PIN_OUTPUT, PullNone}, 
-		{PB_1, PIN_OUTPUT, PullNone},
-		{PB_2, PIN_OUTPUT, PullNone},
-		{PB_3, PIN_OUTPUT, PullNone}, 
-		{PB_4, PIN_OUTPUT, PullNone},
-		{PB_5, PIN_OUTPUT, PullNone},
-		{PB_6, PIN_OUTPUT, PullNone}, 
-		{PB_7, PIN_OUTPUT, PullNone},
-		{PB_8, PIN_OUTPUT, PullNone},
-		{PB_9, PIN_OUTPUT, PullNone}, 
-		{PB_10, PIN_OUTPUT, PullNone},
-		{PB_11, PIN_OUTPUT, PullNone},
-		{PB_12, PIN_OUTPUT, PullNone}, 
-		{PB_13, PIN_OUTPUT, PullNone},
-		{PB_14, PIN_OUTPUT, PullNone},
-		{PB_15, PIN_OUTPUT, PullNone}, 
-		{PB_16, PIN_OUTPUT, PullNone},
-		{PB_17, PIN_OUTPUT, PullNone},
-		{PB_18, PIN_OUTPUT, PullNone}, 
-		{PB_19, PIN_OUTPUT, PullNone},
-		{PB_20, PIN_OUTPUT, PullNone},
-		{PB_21, PIN_OUTPUT, PullNone}, 
-		{PB_22, PIN_OUTPUT, PullNone},
-		{PB_23, PIN_OUTPUT, PullNone},
-		{PB_24, PIN_OUTPUT, PullNone}, 
-		{PB_25, PIN_OUTPUT, PullNone},
-		{PB_26, PIN_OUTPUT, PullNone},
-		{PB_27, PIN_OUTPUT, PullNone}, 
-		{PB_28, PIN_OUTPUT, PullNone},
-		{PB_29, PIN_OUTPUT, PullNone},
-		{PB_30, PIN_OUTPUT, PullNone}, 
-		{PB_31, PIN_OUTPUT, PullNone}, */
+		{
+			PA_0, PIN_OUTPUT, PullNone
+		}, {
+			PA_1, PIN_OUTPUT, PullNone
+		}, {
+			PA_2, PIN_OUTPUT, PullNone
+		}, {
+			PA_3, PIN_OUTPUT, PullNone
+		}, {
+			PB_5, PIN_OUTPUT, PullNone
+		}, {
+			PA_12, PIN_INPUT, PullDown
+		},
+		/*		{PA_6, PIN_OUTPUT, PullNone},
+				{PA_7, PIN_OUTPUT, PullNone},
+				{PA_8, PIN_OUTPUT, PullNone},
+				{PA_9, PIN_OUTPUT, PullNone},
+				{PA_10, PIN_OUTPUT, PullNone},
+				{PA_11, PIN_OUTPUT, PullNone},
+				{PA_12, PIN_OUTPUT, PullNone},
+				{PA_13, PIN_OUTPUT, PullNone},
+				{PA_14, PIN_OUTPUT, PullNone},
+				{PA_15, PIN_OUTPUT, PullNone},
+				{PA_16, PIN_OUTPUT, PullNone},
+				{PA_17, PIN_OUTPUT, PullNone},
+				{PA_18, PIN_OUTPUT, PullNone},
+				{PA_19, PIN_OUTPUT, PullNone},
+				{PA_20, PIN_OUTPUT, PullNone},
+				{PA_21, PIN_OUTPUT, PullNone},
+				{PA_22, PIN_OUTPUT, PullNone},
+				{PA_23, PIN_OUTPUT, PullNone},
+				{PA_24, PIN_OUTPUT, PullNone},
+				{PA_25, PIN_OUTPUT, PullNone},
+				{PA_26, PIN_OUTPUT, PullNone},
+				{PB_27, PIN_OUTPUT, PullNone},
+				{PA_28, PIN_OUTPUT, PullNone},
+				{PA_29, PIN_OUTPUT, PullNone},
+				{PA_30, PIN_OUTPUT, PullNone},
+				{PA_31, PIN_OUTPUT, PullNone},
+				{PB_0, PIN_OUTPUT, PullNone},
+				{PB_1, PIN_OUTPUT, PullNone},
+				{PB_2, PIN_OUTPUT, PullNone},
+				{PB_3, PIN_OUTPUT, PullNone},
+				{PB_4, PIN_OUTPUT, PullNone},
+				{PB_5, PIN_OUTPUT, PullNone},
+				{PB_6, PIN_OUTPUT, PullNone},
+				{PB_7, PIN_OUTPUT, PullNone},
+				{PB_8, PIN_OUTPUT, PullNone},
+				{PB_9, PIN_OUTPUT, PullNone},
+				{PB_10, PIN_OUTPUT, PullNone},
+				{PB_11, PIN_OUTPUT, PullNone},
+				{PB_12, PIN_OUTPUT, PullNone},
+				{PB_13, PIN_OUTPUT, PullNone},
+				{PB_14, PIN_OUTPUT, PullNone},
+				{PB_15, PIN_OUTPUT, PullNone},
+				{PB_16, PIN_OUTPUT, PullNone},
+				{PB_17, PIN_OUTPUT, PullNone},
+				{PB_18, PIN_OUTPUT, PullNone},
+				{PB_19, PIN_OUTPUT, PullNone},
+				{PB_20, PIN_OUTPUT, PullNone},
+				{PB_21, PIN_OUTPUT, PullNone},
+				{PB_22, PIN_OUTPUT, PullNone},
+				{PB_23, PIN_OUTPUT, PullNone},
+				{PB_24, PIN_OUTPUT, PullNone},
+				{PB_25, PIN_OUTPUT, PullNone},
+				{PB_26, PIN_OUTPUT, PullNone},
+				{PB_27, PIN_OUTPUT, PullNone},
+				{PB_28, PIN_OUTPUT, PullNone},
+				{PB_29, PIN_OUTPUT, PullNone},
+				{PB_30, PIN_OUTPUT, PullNone},
+				{PB_31, PIN_OUTPUT, PullNone}, */
 	};
 
 	for (i = 0; i < sizeof(pins) / sizeof(*pins); i++) {
@@ -190,7 +198,6 @@ void amebad_mount_partions(void)
 #endif
 }
 
-
 /****************************************************************************
  * Name: board_initialize
  *
@@ -210,5 +217,13 @@ void board_initialize(void)
 	configure_partitions();
 	amebad_mount_partions();
 	board_gpio_initialize();
+#ifdef CONFIG_TIMER
+	int i;
+	char path[CONFIG_PATH_MAX];
+	for (i = 0; i < GTIMER_MAX; i++) {
+		snprintf(path, sizeof(path), "/dev/timer%d", i);
+		amebad_timer_initialize(path, i);
+	}
+#endif
 }
 #endif


### PR DESCRIPTION
1) The timer peripheral is now supported.
2) It is tested by the timer example (timer_main.c).
3) Currently, the 'getstatus' and 'ioctl' functions are not supported.