### PR TITLE
drivers/timer : Modify timer interrupt notification method

### DIFF
--- a/docs/HowToUseTimer.md
+++ b/docs/HowToUseTimer.md
@@ -66,9 +66,8 @@ int fd = open(<TIMER_DEVICE_PATH>, O_RDONLY);
 2. Set the notification to get time expiration
 ```
 struct timer_notify_s notify;
-notify.arg   = NULL;                  /* An argument to pass with the signal */
-notify.pid   = (pid_t)getpid();       /* The ID of the task/thread to receive the signal */
-notify.signo = EXAMPLE_TIMER_SIGNO;   /* The signal number to use in the notification */
+notify.arg   = NULL;                  /* An argument to pass with the FIN */
+notify.pid   = (pid_t)getpid();       /* The ID of the task/thread to receive the FIN */
 
 ioctl(fd, TCIOC_NOTIFICATION, &notify);
 ```
@@ -80,14 +79,9 @@ ioctl(fd, TCIOC_SETTIMEOUT, time);
 ```
 ioctl(fd, TCIOC_START, 0);
 ```
-5. Wait the signal using *sigwaitinfo* or *sigaction*
+5. Wait the notification using *fin_wait*
 ```
-sigset_t sig_set;
-sigemptyset(&sig_set);
-sigaddset(&sig_set, EXAMPLE_TIMER_SIGNO);
-pthread_sigmask(SIG_BLOCK, &sig_set, NULL);
-
-sigwaitinfo(&sig_set, NULL);
+fin_wait();
 ```
 6. Stop the timer
 ```

--- a/os/drivers/timer.c
+++ b/os/drivers/timer.c
@@ -63,7 +63,6 @@
 #include <string.h>
 #include <semaphore.h>
 #include <fcntl.h>
-#include <signal.h>
 #include <assert.h>
 #include <errno.h>
 #include <debug.h>
@@ -87,7 +86,6 @@
 
 struct timer_upperhalf_s {
 	uint8_t   crefs; /* The number of times the device has been opened */
-	uint8_t   signo; /* The signal number to use in the notification */
 	pid_t     pid;   /* The ID of the task/thread to receive the signal */
 	FAR void *arg;   /* An argument to pass with the signal */
 	FAR char *path;  /* Registration path */
@@ -147,20 +145,10 @@ static const struct file_operations g_timerops = {
 static bool timer_notifier(FAR uint32_t *next_interval_us, FAR void *arg)
 {
 	FAR struct timer_upperhalf_s *upper = (FAR struct timer_upperhalf_s *)arg;
-#ifdef CONFIG_CAN_PASS_STRUCTS
-	union sigval value;
-#endif
-
 	DEBUGASSERT(upper != NULL);
 
-	/* Signal the waiter.. if there is one */
-
-#ifdef CONFIG_CAN_PASS_STRUCTS
-	value.sival_ptr = upper->arg;
-	(void)sigqueue(upper->pid, upper->signo, value);
-#else
-	(void)sigqueue(upper->pid, upper->signo, upper->arg);
-#endif
+	/* Send notification to the waiter.. */
+	fin_notify(upper->pid, (int)upper->arg);
 
 	return true;
 }
@@ -378,7 +366,6 @@ static int timer_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
 			(FAR struct timer_notify_s *)((uintptr_t)arg);
 
 		if (notify != NULL) {
-			upper->signo = notify->signo;
 			upper->pid   = notify->pid;
 			upper->arg   = notify->arg;
 

--- a/os/include/tinyara/timer.h
+++ b/os/include/tinyara/timer.h
@@ -179,7 +179,6 @@ struct timer_status_s {
 struct timer_notify_s {
 	FAR void *arg;   /* An argument to pass with the signal */
 	pid_t     pid;   /* The ID of the task/thread to receive the signal */
-	uint8_t   signo; /* The signal number to use in the notification */
 };
 
 /* This structure provides the "lower-half" driver operations available to


### PR DESCRIPTION
For notifying the timer interrupt, FIN(Fast Interrupt Notification) can be used, even it is faster than Signal.