### PR TITLE
kernel : Optimize non-preemption-lock range

### DIFF
--- a/os/arch/arm/src/common/up_exit.c
+++ b/os/arch/arm/src/common/up_exit.c
@@ -157,15 +157,14 @@ void _exit(int status)
 	/* Disable interrupts.  They will be restored when the next
 	 * task is started.
 	 */
-
-	(void)irqsave();
-
 	sllvdbg("TCB=%p exiting\n", this_task());
 
 #if defined(CONFIG_DUMP_ON_EXIT) && defined(CONFIG_DEBUG)
 	sllvdbg("Other tasks:\n");
 	sched_foreach(_up_dumponexit, NULL);
 #endif
+
+	(void)irqsave();
 
 	/* Destroy the task at the head of the ready to run list. */
 

--- a/os/kernel/mqueue/mq_receive.c
+++ b/os/kernel/mqueue/mq_receive.c
@@ -177,11 +177,12 @@ ssize_t mq_receive(mqd_t mqdes, FAR char *msg, size_t msglen, FAR int *prio)
 	 * - The wait was interrupted by a signal
 	 */
 
+	sched_unlock();
+
 	if (mqmsg) {
 		ret = mq_doreceive(mqdes, mqmsg, msg, prio);
 	}
 
-	sched_unlock();
 	leave_cancellation_point();
 	return ret;
 }

--- a/os/kernel/mqueue/mq_send.c
+++ b/os/kernel/mqueue/mq_send.c
@@ -154,7 +154,6 @@ int mq_send(mqd_t mqdes, FAR const char *msg, size_t msglen, int prio)
 
 	/* Get a pointer to the message queue */
 
-	sched_lock();
 	msgq = mqdes->msgq;
 
 	/* Allocate a message structure:
@@ -182,6 +181,8 @@ int mq_send(mqd_t mqdes, FAR const char *msg, size_t msglen, int prio)
 
 		irqrestore(saved_state);
 	}
+
+	sched_lock();
 
 	/* Check if we were able to get a message structure -- this can fail
 	 * either because we cannot send the message (and didn't bother trying

--- a/os/kernel/mqueue/mq_timedreceive.c
+++ b/os/kernel/mqueue/mq_timedreceive.c
@@ -309,12 +309,12 @@ ssize_t mq_timedreceive(mqd_t mqdes, FAR char *msg, size_t msglen, FAR int *prio
 	 * - The wait was interrupted by a signal
 	 * - The watchdog timeout expired
 	 */
+	sched_unlock();
 
 	if (mqmsg) {
 		ret = mq_doreceive(mqdes, mqmsg, msg, prio);
 	}
 
-	sched_unlock();
 	wd_delete(rtcb->waitdog);
 	rtcb->waitdog = NULL;
 	leave_cancellation_point();

--- a/os/kernel/semaphore/sem_timedwait.c
+++ b/os/kernel/semaphore/sem_timedwait.c
@@ -222,8 +222,6 @@ int sem_timedwait(FAR sem_t *sem, FAR const struct timespec *abstime)
 	 * enabled while we are blocked waiting for the semaphore.
 	 */
 
-	flags = irqsave();
-
 	/* Try to take the semaphore without waiting. */
 
 	ret = sem_trywait(sem);
@@ -268,6 +266,9 @@ int sem_timedwait(FAR sem_t *sem, FAR const struct timespec *abstime)
 	/* Start the watchdog */
 
 	errcode = OK;
+
+	flags = irqsave();
+
 	wd_start(rtcb->waitdog, ticks, (wdentry_t)sem_timeout, 1, getpid());
 
 	/* Now perform the blocking wait */

--- a/os/kernel/signal/sig_timedwait.c
+++ b/os/kernel/signal/sig_timedwait.c
@@ -201,8 +201,6 @@ int sigtimedwait(FAR const sigset_t *set, FAR struct siginfo *info, FAR const st
 	/* sigtimedwait() is a cancellation point */
 	(void)enter_cancellation_point();
 
-	sched_lock();				/* Not necessary */
-
 	/* Several operations must be performed below:  We must determine if any
 	 * signal is pending and, if not, wait for the signal.  Since signals can
 	 * be posted from the interrupt level, there is a race condition that
@@ -353,7 +351,6 @@ int sigtimedwait(FAR const sigset_t *set, FAR struct siginfo *info, FAR const st
 		irqrestore(saved_state);
 	}
 
-	sched_unlock();
 	leave_cancellation_point();
 	return ret;
 }


### PR DESCRIPTION
mqueue : only protect with sched_lock about accessing and modifying the mqdes
semaphore : don't need to protect time calculation before start the watchdog
signal : remove not-necessary sched_lock