### PR TITLE
network/library: fix getifaddrs for Iotivity

### DIFF
--- a/lib/libc/netdb/Make.defs
+++ b/lib/libc/netdb/Make.defs
@@ -20,7 +20,7 @@ ifeq ($(CONFIG_NET_LWIP_NETDB),y)
 # Add the netdb C files to the build
 
 CSRCS += lib_freeaddrinfo.c lib_getaddrinfo.c lib_gethostbyname.c lib_getnameinfo.c
-
+CSRCS += lib_getifaddr.c
 # Add the netdb directory to the build
 
 DEPPATH += --dep-path netdb

--- a/lib/libc/netdb/lib_getifaddr.c
+++ b/lib/libc/netdb/lib_getifaddr.c
@@ -1,0 +1,101 @@
+/****************************************************************************
+ *
+ * Copyright 2020 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <tinyara/config.h>
+
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <sys/ioctl.h>
+#include <errno.h>
+#include <netdb.h>
+#include <net/if.h>
+#include <ifaddrs.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: getifaddrs
+ *
+ * Description:
+ *   Return active NIC information whereas linux implementation
+ *   returns all NIC information. it's temporary API for supporting Iotivity
+ *   It should be fixed later when requirements is changed.
+ *
+ * Input Parameters:
+ *   ifap - The list  consists of ifaddrs structures
+ *
+ * Returned Value:
+ *   0 on success, non-zero on failure
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: getifaddrs
+ ****************************************************************************/
+
+int getifaddrs(struct ifaddrs **ifap)
+{
+	// iotivity doesn't call freeifaddr, so it's defined to static
+	static struct ifaddrs ifa;
+	static struct sockaddr_in addr, netmask;
+	static char ifname[10] = {0,};
+	uint8_t flags;
+
+	// get interface name to fetch ip address
+	int sockfd = socket(AF_INET, SOCK_DGRAM, 0);
+	if (sockfd < 0) {
+		printf("socket() failed with errno: %d\n", errno);
+		return -1;
+	}
+
+	struct ifreq req;
+	memset(&req, 0, sizeof(req));
+
+	int ret = ioctl(sockfd, SIOCGIFNAME, (unsigned long)&req);
+	if (ret == ERROR) {
+		printf("ioctl() failed with errno: %d\n", errno);
+		close(sockfd);
+		return ret;
+	}
+	close(sockfd);
+	strncpy(ifname, req.ifr_name, IFNAMSIZ);
+
+	memset(&ifa, 0, sizeof(ifa));
+	memset(&addr, 0, sizeof(addr));
+	memset(&netmask, 0, sizeof(netmask));
+
+	netlib_get_ipv4addr(ifname, &addr.sin_addr);
+	netlib_get_dripv4addr(ifname, &netmask.sin_addr);
+	netlib_getifstatus(ifname, &flags);
+
+	ifa.ifa_next = NULL;
+	ifa.ifa_name = ifname;
+	ifa.ifa_flags = flags | IFF_RUNNING;
+	addr.sin_family = netmask.sin_family = AF_INET;
+	ifa.ifa_addr = (struct sockaddr *)&addr;
+	ifa.ifa_netmask = (struct sockaddr *)&netmask;
+
+	*ifap = &ifa;
+
+	return ret;
+}

--- a/os/include/ifaddrs.h
+++ b/os/include/ifaddrs.h
@@ -28,4 +28,6 @@ struct ifaddrs {
 	void *ifa_data;
 };
 
+int getifaddrs(struct ifaddrs **ifap);
+
 #endif

--- a/os/include/netdb.h
+++ b/os/include/netdb.h
@@ -125,7 +125,6 @@ struct servent_data {
 
 #if CONFIG_NET_LWIP
 
-//#ifndef CONFIG_NET_NETMGR
 typedef enum {
 	GETADDRINFO,
 	FREEADDRINFO,
@@ -158,7 +157,7 @@ struct req_lwip_data {
 	u8_t num_dns;
 	ip_addr_t *dns_server;
 };
-//#endif // CONFIG_NET_NETMGR
+
 #endif
 
 /****************************************************************************

--- a/os/include/tinyara/net/ioctl.h
+++ b/os/include/tinyara/net/ioctl.h
@@ -204,6 +204,10 @@
 /* lwip *********************************************************************/
 #define SIOCLWIP	     _SIOC(0x0055)  /* Call lwip API */
 
+/* Get active NIC name it's similar to Linux but it's not exactly same
+ * it's provided to running iotivity app on binary protection env */
+#define SIOCGIFNAME      _SIOC(0x0056)  /* get active NIC name. */
+
 /****************************************************************************
  * Type Definitions
  ****************************************************************************/

--- a/os/net/netdev/Make.defs
+++ b/os/net/netdev/Make.defs
@@ -58,6 +58,7 @@ NETDEV_CSRCS += netdev_count.c
 NETDEV_CSRCS += netdev_foreach.c
 NETDEV_CSRCS += netdev_sem.c
 NETDEV_CSRCS += netdev_getstats.c
+NETDEV_CSRCS += netdev_ifname.c
 ifeq ($(CONFIG_NET_LWIP_DHCP),y)
 ifeq ($(CONFIG_LWIP_DHCPC),y)
 NETDEV_CSRCS += netdev_dhcpc.c

--- a/os/net/netdev/netdev_ifname.c
+++ b/os/net/netdev/netdev_ifname.c
@@ -1,0 +1,83 @@
+/****************************************************************************
+ *
+ * Copyright 2020 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <tinyara/config.h>
+#if defined(CONFIG_NET) && CONFIG_NSOCKET_DESCRIPTORS > 0
+
+#include <string.h>
+#include <errno.h>
+
+#include "lwip/netif.h"
+#include "netdev/netdev.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Types
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Function: netdev_getifname
+ *
+ * Description:
+ *   Return active NIC name
+ *
+ * Parameters:
+ *   ifname - a user buffer to receive NIC name.
+ *
+ * Returned Value:
+ *  0 on success, non-zero on failure
+ *
+ ****************************************************************************/
+extern struct netif *g_netdevices;
+
+int netdev_getifname(char *ifname)
+{
+	struct netif *dev = NULL;
+	for (dev = g_netdevices; dev; dev = dev->next) {
+		if (dev->flags & NETIF_FLAG_LINK_UP) {
+			sprintf(ifname, "%c%c%d", dev->name[0], dev->name[1], dev->num);
+			return 0;
+		}
+	}
+
+	return -1;
+}
+#endif // (CONFIG_NET) && CONFIG_NSOCKET_DESCRIPTORS > 0

--- a/os/net/netdev/netdev_ioctl.c
+++ b/os/net/netdev/netdev_ioctl.c
@@ -867,6 +867,11 @@ static int netdev_ifrioctl(int cmd, FAR struct ifreq *req)
 	case SIOCGIFCONF:
 		ret = ioctl_siocgifconf((FAR struct ifconf *)req);
 		break;
+	case SIOCGIFNAME: {
+		ret = netdev_getifname(req->ifr_name);
+	}
+	break;
+
 	default: {
 		ret = -ENOTTY;
 	}
@@ -1271,7 +1276,7 @@ int lwip_func_ioctl(int s, int cmd, void *arg)
 			ret = OK;
 		}
 		break;
-#endif
+#endif // LWIP_DNS
 #if defined(CONFIG_NET_LWIP_DHCP)
 #if defined(CONFIG_LWIP_DHCPC)
 	case DHCPCSTART:
@@ -1312,13 +1317,13 @@ int lwip_func_ioctl(int s, int cmd, void *arg)
 		in_arg->req_res = netdev_dhcp_server_status((char *)in_arg->intf);
 		if (in_arg->req_res != 0) {
 			ret = -EINVAL;
-			ndbg("stop dhcpd fail\n");
+			ndbg("stop dhcp fail\n");
 		} else {
 			ret = OK;
 		}
 		break;
 #endif
-#endif
+#endif // CONFIG_NET_LWIP_DHCP
 	default:
 		ndbg("Wrong request type: %d\n", in_arg->type);
 		break;

--- a/os/net/netmgr/net_vfs.c
+++ b/os/net/netmgr/net_vfs.c
@@ -401,7 +401,9 @@ errout:
 void net_initlist(FAR struct socketlist *list)
 {
 	struct netstack *stk = get_netstack(TR_UDS);
-	stk->ops->initlist(list);
+	if (stk) {
+		stk->ops->initlist(list);
+	}
 }
 
 /****************************************************************************
@@ -421,5 +423,7 @@ void net_initlist(FAR struct socketlist *list)
 void net_releaselist(FAR struct socketlist *list)
 {
 	struct netstack *stk = get_netstack(TR_UDS);
-	stk->ops->releaselist((void *)list);
+	if (stk) {
+		stk->ops->releaselist((void *)list);
+	}
 }

--- a/os/net/netmgr/netdev_mgr_internal.c
+++ b/os/net/netmgr/netdev_mgr_internal.c
@@ -97,6 +97,7 @@ int nm_foreach(tr_netdev_callback_t callback, void *arg)
 	return ret;
 }
 
+
 int _nm_register_loop(struct netdev *dev, struct netdev_config *config)
 {
 	struct nic_config nconfig;
@@ -232,10 +233,18 @@ int nm_ifdown(struct netdev *dev)
 		return -1;
 	}
 
-	ret = dev->t_ops.wl->deinit(dev);
-	if (ret < 0) {
-		ndbg("fail to down driver interface\n");
-		return -2;
+	if (dev->type == NM_WIFI) {
+		ret = dev->t_ops.wl->deinit(dev);
+		if (ret < 0) {
+			ndbg("fail to down driver interface\n");
+			return -2;
+		}
+	} else if (dev->type == NM_ETHERNET) {
+		ret = dev->t_ops.eth->deinit(dev);
+		if (ret < 0) {
+			ndbg("fail to deinit etherent driver\n");
+			return -1;
+		}
 	}
 
 	return 0;

--- a/os/net/netmgr/netmgr_ioctl_lwip.c
+++ b/os/net/netmgr/netmgr_ioctl_lwip.c
@@ -37,6 +37,7 @@
 
 #if defined(CONFIG_NET_LWIP_DHCP)
 #define GET_NETIF_FROM_NETDEV(dev) (struct netif *)(((struct netdev_ops *)(dev)->ops)->nic)
+
 static struct netif *_netdev_dhcp_dev(FAR const char *intf)
 {
 	struct netif *cnif;


### PR DESCRIPTION
getifaddrs is tempolary implementation to run Iotivity. it doesn't run
on TizenRT 3.0 loadable environment because it accesses to
g_netdevices which is defined in kernel layer to get a running NIC
name. So this commit adds new ioctl command(SIOCGIFNAME) to access interface name
from app layer. however this operation is not same to linux. so you'd
better to use it carefully.