### PR TITLE
kernel/semaphore : Remove unnecessary irqrestore

### DIFF
--- a/os/kernel/semaphore/sem_timedwait.c
+++ b/os/kernel/semaphore/sem_timedwait.c
@@ -227,8 +227,6 @@ int sem_timedwait(FAR sem_t *sem, FAR const struct timespec *abstime)
 	ret = sem_trywait(sem);
 	if (ret == OK) {
 		/* We got it! */
-
-		irqrestore(flags);
 		wd_delete(rtcb->waitdog);
 		rtcb->waitdog = NULL;
 		leave_cancellation_point();
@@ -311,7 +309,6 @@ int sem_timedwait(FAR sem_t *sem, FAR const struct timespec *abstime)
 	/* Error exits */
 
 errout_disabled:
-	irqrestore(flags);
 	wd_delete(rtcb->waitdog);
 	rtcb->waitdog = NULL;
 


### PR DESCRIPTION
In PR#4333, irqsave is moved from line 225 to line 270.
Between line 225 and line 270, there is irqrestore for error case. But we don't need this anymore.