### PR TITLE
Update boot logs to get RAM configuration for debug purpose

### DIFF
--- a/os/binfmt/binfmt_execmodule.c
+++ b/os/binfmt/binfmt_execmodule.c
@@ -175,6 +175,9 @@ int exec_module(FAR struct binary_s *binp)
 	mm_initialize(binp->uheap, (void *)binp->heapstart + sizeof(struct mm_heap_s), binp->uheap_size);
 	mm_add_app_heap_list(binp->uheap, binp->bin_name);
 
+	binfo("------------------------%s Binary Heap Information------------------------\n", binp->bin_name);
+	binfo("Start addr = 0x%x, size = %u \n", (void *)binp->heapstart + sizeof(struct mm_heap_s), binp->uheap_size);
+
 	/* The first 4 bytes of the text section of the application must contain a
 	pointer to the application's mm_heap object. Here we will store the mm_heap
 	pointer to the start of the text section */

--- a/os/binfmt/binfmt_loadbinary.c
+++ b/os/binfmt/binfmt_loadbinary.c
@@ -224,6 +224,14 @@ int load_binary(int binary_idx, FAR const char *filename, load_attr_t *load_attr
 #ifdef CONFIG_SAVE_BIN_SECTION_ADDR
 	elf_save_bin_section_addr(bin);
 #endif
+
+	/* Print Binary section address & size details */
+
+	binfo("[%s] text    start addr =  0x%x  size = %u\n", bin->bin_name, (uint32_t)bin->alloc[ALLOC_TEXT], bin->textsize);
+	binfo("[%s] rodata  start addr =  0x%x  size = %u\n", bin->bin_name, (uint32_t)bin->alloc[ALLOC_DATA], bin->rosize);
+	binfo("[%s] data    start addr =  0x%x  size = %u\n", bin->bin_name, (uint32_t)bin->datastart, bin->datasize);
+	binfo("[%s] bss     start addr =  0x%x  size = %u\n", bin->bin_name, (uint32_t)bin->bssstart, bin->bsssize);
+
 	return pid;
 
 errout_with_unload:

--- a/os/kernel/debug/Make.defs
+++ b/os/kernel/debug/Make.defs
@@ -18,7 +18,9 @@
 
 ifeq ($(CONFIG_DEBUG_SYSTEM),y)
 CSRCS += sysdbg.c
+endif
+
+CSRCS += memdbg.c
 
 DEPPATH += --dep-path debug
 VPATH += :debug
-endif

--- a/os/kernel/debug/memdbg.c
+++ b/os/kernel/debug/memdbg.c
@@ -1,0 +1,99 @@
+/****************************************************************************
+ *
+ * Copyright 2020 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+/***************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <tinyara/config.h>
+
+#include <stdio.h>
+#include <stdint.h>
+#include <debug.h>
+
+#include <tinyara/arch.h>
+#include <tinyara/mm/mm.h>
+
+/***************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Function Prototypes
+ ****************************************************************************/
+
+/****************************************************************************
+ * Global Variables
+ ****************************************************************************/
+
+extern const uint32_t g_idle_topstack;
+
+/****************************************************************************
+ * Private Types
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private data
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: display_memory_information
+ *
+ * Description:
+ *   This function prints the memory information for debug such as
+ *   the RAM configuration, Idle stack configuration, Heap configuration.
+ *
+ * Inputs:
+ *   None
+ *
+ * Return Value:
+ *   None
+ *
+ * Assumptions:
+ *   None
+ *
+ ****************************************************************************/
+
+void display_memory_information(void)
+{
+	/* Print RAM configuration */
+
+	mllvdbg("-------------------RAM Configuration--------------------\n");
+#ifdef CONFIG_SRAM_START_ADDR
+	mllvdbg("Internal RAM   : start addr = 0x%x size = %u\n", CONFIG_SRAM_START_ADDR, (CONFIG_KSRAM_SIZE + CONFIG_USRAM_SIZE));
+#if (defined(CONFIG_KSRAM_SIZE) && defined(CONFIG_RAM_KREGIONx_START))
+	mllvdbg("Kernel   RAM   : start addr = 0x%x size = %u\n", kregionx_start[0], CONFIG_KSRAM_SIZE);
+#endif
+#if (defined(CONFIG_USRAM_SIZE) && defined(CONFIG_RAM_REGIONx_START))
+	mllvdbg("User     RAM   : start addr = 0x%x size = %u\n", regionx_start[0], CONFIG_USRAM_SIZE);
+#endif
+#endif
+
+	/* Print Idle Stack configuration */
+
+	mllvdbg("Idle stack     : base addr = 0x%x size = %u\n", g_idle_topstack, CONFIG_IDLETHREAD_STACKSIZE);
+	mllvdbg("-------------------RAM Configuration--------------------\n");
+}

--- a/os/kernel/debug/memdbg.h
+++ b/os/kernel/debug/memdbg.h
@@ -1,0 +1,54 @@
+/****************************************************************************
+ *
+ * Copyright 2020 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+/********************************************************************************
+ * Pre-processor Definitions
+ ********************************************************************************/
+
+/********************************************************************************
+ * Global Type Declarations
+ ********************************************************************************/
+
+/****************************************************************************
+ * Public Types
+ ****************************************************************************/
+
+/********************************************************************************
+ * Public Variables
+ ********************************************************************************/
+
+/****************************************************************************
+ * Inline Functions
+ ****************************************************************************/
+
+/********************************************************************************
+ * Public Function Prototypes
+ ********************************************************************************/
+
+/****************************************************************************
+ * Name: display_memory_information
+ *
+ * Description:
+ *   This function prints the memory information for debug such as
+ *   the RAM configuration, Idle stack configuration, Heap configuration.
+ ****************************************************************************/
+void display_memory_information(void);

--- a/os/kernel/init/os_start.c
+++ b/os/kernel/init/os_start.c
@@ -96,6 +96,7 @@
 #ifdef CONFIG_KERNEL_TEST_DRV
 #include <tinyara/testcase_drv.h>
 #endif
+#include  "debug/memdbg.h"
 
 extern const uint32_t g_idle_topstack;
 #include <tinyara/mm/heap_regioninfo.h>
@@ -599,6 +600,9 @@ void os_start(void)
 	/* We cannot enter low power state until boot complete */
 	pm_stay(PM_IDLE_DOMAIN, PM_NORMAL);
 #endif
+
+	display_memory_information();
+
 	DEBUGVERIFY(os_bringup());
 
 	/* The IDLE Loop **********************************************************/


### PR DESCRIPTION
This patch adds the following logs:

1) ram address /size
2) idle stack address / size
3) each section address / size per binary
4) heap address / size per binary

Signed-off-by: Vidisha <thapa.v@samsung.com>