### PR TITLE
fixup! libc/stdio: support hh, h, int, long, long long modifier in ss…

### DIFF
--- a/lib/libc/stdio/lib_sscanf.c
+++ b/lib/libc/stdio/lib_sscanf.c
@@ -935,7 +935,6 @@ int vsscanf(FAR const char *buf, FAR const char *fmt, va_list ap)
 						break;
 					}
 				}
-				count++;
 			}
 
 			width = 0;


### PR DESCRIPTION
…canf

Becasue original commit have added the length modifiers,
count++ should not be added.

Signed-off-by: sunghan-chang <sh924.chang@samsung.com>