### PR TITLE
kernel/binary_manager_load : Modify sem restore logic for fault case

### DIFF
--- a/os/kernel/binary_manager/binary_manager_load.c
+++ b/os/kernel/binary_manager/binary_manager_load.c
@@ -556,7 +556,9 @@ void binary_manager_release_binary_sem(int bin_idx)
 			if (holder && holder->htcb && holder->htcb->group && holder->htcb->group->tg_binidx == bin_idx) {
 				/* Increase semcount and release itself from holder */
 				sem->semcount++;
-				sem_releaseholder(sem, holder->htcb);
+				sem_freeholder(sem, holder);
+				/* And after releasing the kernel sem, there can be a task which waits that sem. So unblock the waiting task. */
+				sem_unblock_task(sem, holder->htcb);
 			}
 		}
 		sem = sq_next(sem);

--- a/os/kernel/semaphore/semaphore.h
+++ b/os/kernel/semaphore/semaphore.h
@@ -107,7 +107,9 @@ void sem_recover(FAR struct tcb_s *tcb);
  * holders of semaphores.
  */
 
+void sem_unblock_task(sem_t *sem, struct tcb_s *htcb);
 #ifdef SAVE_SEM_HOLDER
+void sem_freeholder(sem_t *sem, FAR struct semholder_s *pholder);
 void sem_initholders(void);
 void sem_destroyholder(FAR sem_t *sem);
 void sem_addholder(FAR sem_t *sem);
@@ -115,7 +117,7 @@ void sem_addholder_tcb(FAR struct tcb_s *tcb, FAR sem_t *sem);
 void sem_releaseholder(FAR sem_t *sem, FAR struct tcb_s *htcb);
 #if defined(CONFIG_PRIORITY_INHERITANCE)
 void sem_boostpriority(FAR sem_t *sem);
-void sem_restorebaseprio(FAR struct tcb_s *stcb, FAR sem_t *sem);
+void sem_restorebaseprio(FAR struct tcb_s *stcb, FAR struct tcb_s *htcb, FAR sem_t *sem);
 #endif
 #ifndef CONFIG_DISABLE_SIGNALS
 void sem_canceled(FAR struct tcb_s *stcb, FAR sem_t *sem);


### PR DESCRIPTION
If a task which occupied the kernel sem in fault binary, we should remove the sem holder from holder list.
So before calling the releaseholder, set the holder counts as 1.
And after releasing the kernel sem, there can be a task which waits that sem.
So call the sem_post instead of just calling sem_releaseholder.