### PR TITLE
arch/amebad: remove duplicated definition of type in Kconfig

### DIFF
--- a/os/arch/arm/src/amebad/Kconfig
+++ b/os/arch/arm/src/amebad/Kconfig
@@ -79,7 +79,6 @@ config AMEBAD_RDP
 		If unsure, do not enable this.
 
 config AMEBAD_RDP_KEY
-	prompt "Amebad RDP Key"
 	hex "Amebad RDP Key"
 	default 2473040ab47c48655a15aa431c4bbb8a
 	range 00000000000000000000000000000000 ffffffffffffffffffffffffffffffff


### PR DESCRIPTION
CONFIG_AMEBAD_RDP_KEY has prompt definition with hex type
so that separated prompt definition is unnecessary.

This commit fixes the mennuconfig warning as shown below:
arch/arm/src/amebad/Kconfig:83:warning: prompt redefined

Signed-off-by: sunghan-chang <sh924.chang@samsung.com>