### PR TITLE
kernel/semaphore: Register user semaphores to release all holders of them

### DIFF
--- a/lib/libc/libc.csv
+++ b/lib/libc/libc.csv
@@ -153,7 +153,6 @@
 "sched_get_priority_max", "sched.h", "", "int", "int"
 "sched_get_priority_min", "sched.h", "", "int", "int"
 "sem_getvalue", "semaphore.h", "", "int", "FAR sem_t *", "FAR int *"
-"sem_init", "semaphore.h", "", "int", "FAR sem_t *", "int", "unsigned int"
 "sendfile", "sys/sendfile.h", "CONFIG_NSOCKET_DESCRIPTORS > 0 || CONFIG_NFILE_DESCRIPTORS > 0", "ssize_t", "int", "int", "off_t *", "size_t"
 "setlocale", "local.h", "", "FAR char *", "int", "FAR const char *"
 "setlogmask", "syslog.h", "", "int", "int"

--- a/lib/libc/semaphore/Make.defs
+++ b/lib/libc/semaphore/Make.defs
@@ -52,7 +52,7 @@
 
 # Add the semaphore C files to the build
 
-CSRCS += sem_init.c sem_getprotocol.c sem_getvalue.c
+CSRCS += sem_getprotocol.c sem_getvalue.c
 
 ifneq ($(CONFIG_PRIORITY_INHERITANCE),y)
 CSRCS += sem_setprotocol.c

--- a/os/include/sys/syscall.h
+++ b/os/include/sys/syscall.h
@@ -106,12 +106,13 @@
 #define SYS_sem_timedwait              (CONFIG_SYS_RESERVED + 16)
 #define SYS_sem_trywait                (CONFIG_SYS_RESERVED + 17)
 #define SYS_sem_wait                   (CONFIG_SYS_RESERVED + 18)
+#define SYS_sem_init                   (CONFIG_SYS_RESERVED + 19)
 
 #ifdef CONFIG_PRIORITY_INHERITANCE
-#define SYS_sem_setprotocol            (CONFIG_SYS_RESERVED + 19)
-#define __SYS_named_sem                (CONFIG_SYS_RESERVED + 20)
+#define SYS_sem_setprotocol            (CONFIG_SYS_RESERVED + 20)
+#define __SYS_named_sem                (CONFIG_SYS_RESERVED + 21)
 #else
-#define __SYS_named_sem                (CONFIG_SYS_RESERVED + 19)
+#define __SYS_named_sem                (CONFIG_SYS_RESERVED + 20)
 #endif
 
 /* Named semaphores */

--- a/os/kernel/binary_manager/binary_manager.h
+++ b/os/kernel/binary_manager/binary_manager.h
@@ -130,6 +130,9 @@ struct binmgr_uinfo_s {
 	struct tcb_s *rt_list;
 	struct tcb_s *nrt_list;
 	sq_queue_t cb_list; // list node type : statecb_node_t
+#ifdef CONFIG_BINMGR_RECOVERY
+	sq_queue_t sem_list;
+#endif
 #ifdef CONFIG_OPTIMIZE_APP_RELOAD_TIME
 	struct binary_s *binp;
 #endif
@@ -162,6 +165,9 @@ binmgr_uinfo_t *binary_manager_get_udata(uint32_t bin_idx);
 #define BIN_VER(bin_idx)                                binary_manager_get_udata(bin_idx)->bin_ver
 #define BIN_KERNEL_VER(bin_idx)                         binary_manager_get_udata(bin_idx)->kernel_ver
 #define BIN_CBLIST(bin_idx)                             binary_manager_get_udata(bin_idx)->cb_list
+#ifdef CONFIG_BINMGR_RECOVERY
+#define BIN_SEMLIST(bin_idx)                            binary_manager_get_udata(bin_idx)->sem_list
+#endif
 
 #define BIN_LOAD_ATTR(bin_idx)                          binary_manager_get_udata(bin_idx)->load_attr
 #define BIN_NAME(bin_idx)                               binary_manager_get_udata(bin_idx)->load_attr.bin_name

--- a/os/kernel/binary_manager/binary_manager_data.c
+++ b/os/kernel/binary_manager/binary_manager_data.c
@@ -129,6 +129,9 @@ int binary_manager_register_ubin(char *name)
 	BIN_STATE(g_bin_count) = BINARY_INACTIVE;
 	strncpy(BIN_NAME(g_bin_count), name, BIN_NAME_MAX);
 	sq_init(&BIN_CBLIST(g_bin_count));
+#ifdef CONFIG_BINMGR_RECOVERY
+	sq_init(&BIN_SEMLIST(g_bin_count));
+#endif
 
 	bmvdbg("[USER %d] %s\n", g_bin_count, BIN_NAME(g_bin_count));
 

--- a/os/kernel/semaphore/Make.defs
+++ b/os/kernel/semaphore/Make.defs
@@ -52,7 +52,7 @@
 
 # Add semaphore-related files to the build
 
-CSRCS += sem_destroy.c sem_wait.c sem_trywait.c sem_timedwait.c
+CSRCS += sem_destroy.c sem_wait.c sem_trywait.c sem_timedwait.c sem_init.c
 CSRCS += sem_post.c sem_recover.c sem_reset.c sem_waitirq.c sem_tickwait.c
 
 ifeq ($(CONFIG_PRIORITY_INHERITANCE),y)

--- a/os/kernel/semaphore/sem_init.c
+++ b/os/kernel/semaphore/sem_init.c
@@ -64,11 +64,8 @@
 #ifdef CONFIG_SEMAPHORE_HISTORY
 #include <tinyara/debug/sysdbg.h>
 #endif
-#if defined(CONFIG_BINMGR_RECOVERY) && defined(__KERNEL__)
+#if defined(CONFIG_BINMGR_RECOVERY)
 #include <tinyara/semaphore.h>
-#include <tinyara/arch.h>
-
-#define is_kernel_sem(a) is_kernel_space((void *)a)
 #endif
 
 /****************************************************************************
@@ -135,10 +132,9 @@ int sem_init(FAR sem_t *sem, int pshared, unsigned int value)
 		}
 #endif
 
-#if defined(CONFIG_BINMGR_RECOVERY) && defined(__KERNEL__)
-		/* Register semaphore in kernel region for kernel resource management */
-		
-		if (sem->semcount != 0 && is_kernel_sem(sem)) {
+#if defined(CONFIG_BINMGR_RECOVERY)
+		/* Register semaphores for kernel resource management */
+		if (sem->semcount != 0) {
 			sem_register(sem);
 		}
 #endif

--- a/os/syscall/syscall.csv
+++ b/os/syscall/syscall.csv
@@ -119,6 +119,7 @@
 "sem_trywait", "semaphore.h", "", "int", "FAR sem_t*"
 "sem_unlink", "semaphore.h", "defined(CONFIG_FS_NAMED_SEMAPHORES)", "int", "FAR const char*"
 "sem_wait", "semaphore.h", "", "int", "FAR sem_t*"
+"sem_init", "semaphore.h", "", "int", "FAR sem_t *", "int", "unsigned int"
 "send", "sys/socket.h", "CONFIG_NSOCKET_DESCRIPTORS > 0 && defined(CONFIG_NET)", "ssize_t", "int", "FAR const void*", "size_t", "int"
 "sendto", "sys/socket.h", "CONFIG_NSOCKET_DESCRIPTORS > 0 && defined(CONFIG_NET)", "ssize_t", "int", "FAR const void*", "size_t", "int", "FAR const struct sockaddr*", "socklen_t"
 "set_errno","errno.h","!defined(__DIRECT_ERRNO_ACCESS)","void","int"

--- a/os/syscall/syscall_lookup.h
+++ b/os/syscall/syscall_lookup.h
@@ -82,6 +82,7 @@ SYSCALL_LOOKUP(sem_post,                  1, STUB_sem_post)
 SYSCALL_LOOKUP(sem_timedwait,             2, STUB_sem_timedwait)
 SYSCALL_LOOKUP(sem_trywait,               1, STUB_sem_trywait)
 SYSCALL_LOOKUP(sem_wait,                  1, STUB_sem_wait)
+SYSCALL_LOOKUP(sem_init,			      3, STUB_sem_init)
 
 #ifdef CONFIG_PRIORITY_INHERITANCE
 SYSCALL_LOOKUP(sem_setprotocol,           2, STUB_sem_setprotocol)

--- a/os/syscall/syscall_stublookup.c
+++ b/os/syscall/syscall_stublookup.c
@@ -105,6 +105,7 @@ uintptr_t STUB_sem_timedwait(int nbr, uintptr_t parm1, uintptr_t parm2);
 uintptr_t STUB_sem_trywait(int nbr, uintptr_t parm1);
 uintptr_t STUB_sem_unlink(int nbr, uintptr_t parm1);
 uintptr_t STUB_sem_wait(int nbr, uintptr_t parm1);
+uintptr_t STUB_sem_init(int nbr, uintptr_t parm1, uintptr_t parm2, uintptr_t parm3);
 uintptr_t STUB_set_errno(int nbr, uintptr_t parm1);
 uintptr_t STUB_pgalloc(int nbr, uintptr_t parm1, uintptr_t parm2);
 uintptr_t STUB_task_create(int nbr, uintptr_t parm1, uintptr_t parm2,


### PR DESCRIPTION
In fault recovery, it is necessary to release all holders of it despite user sempahore.
That's because all holder data is in kernel region.