### PR TITLE
tidyup of sched_yield

### DIFF
--- a/os/arch/arm/include/arch.h
+++ b/os/arch/arm/include/arch.h
@@ -114,7 +114,7 @@
 static inline uint32_t get_PSPLIM(void)
 {
 	uint32_t result;
-	__asm volatile ("MRS %0, psplim"  : "=r" (result) );
+	__asm volatile ("MRS %0, psplim"  : "=r" (result));
 	return result;
 }
 static inline void set_PSPLIM(uint32_t PSP_limit)

--- a/os/arch/arm/src/amebad/Make.defs
+++ b/os/arch/arm/src/amebad/Make.defs
@@ -113,6 +113,10 @@ CMN_ASRCS += up_fpu.S
 CMN_CSRCS += up_copyarmstate.c
 endif
 
+ifeq ($(CONFIG_SCHED_YIELD_OPTIMIZATION),y)
+CMN_CSRCS += up_schedyield.c
+endif
+
 ARCH_SRCDIR = $(TOPDIR)/arch/$(CONFIG_ARCH)/src/
 
 CFLAGS+= -mcmse

--- a/os/arch/arm/src/armv7-m/up_schedyield.c
+++ b/os/arch/arm/src/armv7-m/up_schedyield.c
@@ -20,6 +20,22 @@
  * Included Files
  ****************************************************************************/
 
+#include <tinyara/config.h>
+
+#ifdef CONFIG_TASK_MONITOR
+#include <sys/types.h>
+#endif
+#ifdef CONFIG_SUPPORT_COMMON_BINARY
+#include <stdint.h>
+#endif
+#include <tinyara/sched.h>
+#ifdef CONFIG_ARMV7M_MPU
+#include <tinyara/mpu.h>
+#endif
+#ifdef CONFIG_TASK_SCHED_HISTORY
+#include <tinyara/debug/sysdbg.h>
+#endif
+
 #include "sched/sched.h"
 #include "up_internal.h"
 
@@ -30,6 +46,10 @@
 /****************************************************************************
  * Private Data
  ****************************************************************************/
+
+#ifdef CONFIG_SUPPORT_COMMON_BINARY
+extern uint32_t g_umm_app_id;
+#endif
 
 /****************************************************************************
  * Private Functions
@@ -68,6 +88,38 @@ void up_schedyield(struct tcb_s *rtcb)
 		 */
 
 		rtcb = this_task();
+#ifdef CONFIG_TASK_SCHED_HISTORY
+		/* Save the task name which will be scheduled */
+
+		save_task_scheduling_status(rtcb);
+#endif
+
+		/* Restore the MPU registers in case we are switching to an application task */
+#ifdef CONFIG_ARMV7M_MPU
+		/* Condition check : Update MPU registers only if this is not a kernel thread. */
+
+		if ((rtcb->flags & TCB_FLAG_TTYPE_MASK) != TCB_FLAG_TTYPE_KERNEL) {
+#if defined(CONFIG_APP_BINARY_SEPARATION)
+			for (int i = 0; i < 3 * MPU_NUM_REGIONS; i += 3) {
+				up_mpu_set_register(&rtcb->mpu_regs[i]);
+			}
+#endif
+#ifdef CONFIG_MPU_STACK_OVERFLOW_PROTECTION
+			up_mpu_set_register(rtcb->stack_mpu_regs);
+#endif
+		}
+#endif
+
+#ifdef CONFIG_SUPPORT_COMMON_BINARY
+		if (g_umm_app_id) {
+			*g_umm_app_id = rtcb->app_id;
+		}
+#endif
+#ifdef CONFIG_TASK_MONITOR
+		/* Update rtcb active flag for monitoring. */
+
+		rtcb->is_active = true;
+#endif
 		/* Then switch contexts */
 
 		up_restorestate(rtcb->xcp.regs);
@@ -80,6 +132,11 @@ void up_schedyield(struct tcb_s *rtcb)
 		 */
 
 		struct tcb_s *nexttcb = this_task();
+#ifdef CONFIG_TASK_SCHED_HISTORY
+		/* Save the task name which will be scheduled */
+
+		save_task_scheduling_status(nexttcb);
+#endif
 		up_switchcontext(rtcb->xcp.regs, nexttcb->xcp.regs);
 
 		/* up_switchcontext forces a context switch to the task at the

--- a/os/arch/arm/src/armv7-m/up_schedyield.c
+++ b/os/arch/arm/src/armv7-m/up_schedyield.c
@@ -22,13 +22,17 @@
 
 #include <tinyara/config.h>
 
-#ifdef CONFIG_TASK_MONITOR
 #include <sys/types.h>
-#endif
+#include <debug.h>
+#include <queue.h>
 #ifdef CONFIG_SUPPORT_COMMON_BINARY
 #include <stdint.h>
 #endif
+
 #include <tinyara/sched.h>
+#if CONFIG_RR_INTERVAL > 0
+#include <tinyara/clock.h>
+#endif
 #ifdef CONFIG_ARMV7M_MPU
 #include <tinyara/mpu.h>
 #endif
@@ -69,80 +73,124 @@ extern uint32_t g_umm_app_id;
  *
  *   1) The priority of the currently running task is either equal or more than other ready to run task
  *
- * Inputs:
- *   tcb: The TCB of the task that has been reprioritized
- *
  ****************************************************************************/
 
-void up_schedyield(struct tcb_s *rtcb)
+void up_schedyield(void)
 {
-	if (current_regs) {
-		/* Yes, then we have to do things differently.
-		 * Just copy the current_regs into the OLD rtcb.
+	struct tcb_s *rtcb = this_task();
+	struct tcb_s *ntcb = rtcb->flink;
+
+	if (ntcb == NULL) {
+		sdbg("Fail to yield, there is no next tcb. Current task : %d\n", rtcb->pid);
+		return;
+	}
+
+	/* Yielding the CPU resource to other tasks is possible only if other tasks
+	 * priority is either equal or greater than currently running task.
+	 * It's achieved by rescheduling the current task behind any other tasks at
+	 * same priority
+	 */
+
+	if (rtcb->sched_priority <= ntcb->sched_priority) {
+
+		/* Remove the TCB from the ready-to-run list */
+
+		dq_rem((FAR dq_entry_t *)rtcb, (FAR dq_queue_t *)&g_readytorun);
+
+		/* Add the task in the correct location in the prioritized
+		 * g_readytorun task list
 		 */
 
-		up_savestate(rtcb->xcp.regs);
+		sched_addprioritized(rtcb, (FAR dq_queue_t *)&g_readytorun);
 
-		/* Restore the exception context of the rtcb at the (new) head
-		 * of the g_readytorun task list.
+		/* The current tcb was added in the middle of the ready-to-run list */
+
+		rtcb->task_state = TSTATE_TASK_READYTORUN;
+
+		/* we are going to do a context switch, then now it's the right
+		 * time to add any pending tasks back into the ready-to-run task
+		 * list now
 		 */
 
-		rtcb = this_task();
+		if (g_pendingtasks.head) {
+			sched_mergepending();
+		}
+
+		/* Get new head of the list */
+
+		ntcb = this_task();
+
+#if CONFIG_RR_INTERVAL > 0
+		ntcb->timeslice = MSEC2TICK(CONFIG_RR_INTERVAL);
+#endif
+
+		/* A context switch will occur. */
+
+		ntcb->task_state = TSTATE_TASK_RUNNING;
+
 #ifdef CONFIG_TASK_SCHED_HISTORY
 		/* Save the task name which will be scheduled */
 
-		save_task_scheduling_status(rtcb);
+		save_task_scheduling_status(ntcb);
 #endif
 
-		/* Restore the MPU registers in case we are switching to an application task */
-#ifdef CONFIG_ARMV7M_MPU
-		/* Condition check : Update MPU registers only if this is not a kernel thread. */
+		/* Are we in an interrupt handler? */
 
-		if ((rtcb->flags & TCB_FLAG_TTYPE_MASK) != TCB_FLAG_TTYPE_KERNEL) {
+		if (current_regs) {
+
+			/* Yes, then we have to do things differently.
+			 * Just copy the current_regs into the OLD rtcb.
+			 */
+
+			up_savestate(rtcb->xcp.regs);
+
+			/* Restore the exception context of the ntcb at the (new) head
+			 * of the g_readytorun task list.
+			 */
+
+			/* Restore the MPU registers in case we are switching to an application task */
+#ifdef CONFIG_ARMV7M_MPU
+			/* Condition check : Update MPU registers only if this is not a kernel thread. */
+
+			if ((ntcb->flags & TCB_FLAG_TTYPE_MASK) != TCB_FLAG_TTYPE_KERNEL) {
 #if defined(CONFIG_APP_BINARY_SEPARATION)
-			for (int i = 0; i < 3 * MPU_NUM_REGIONS; i += 3) {
-				up_mpu_set_register(&rtcb->mpu_regs[i]);
-			}
+				for (int i = 0; i < 3 * MPU_NUM_REGIONS; i += 3) {
+					up_mpu_set_register(&ntcb->mpu_regs[i]);
+				}
 #endif
 #ifdef CONFIG_MPU_STACK_OVERFLOW_PROTECTION
-			up_mpu_set_register(rtcb->stack_mpu_regs);
+				up_mpu_set_register(ntcb->stack_mpu_regs);
 #endif
-		}
+			}
 #endif
 
 #ifdef CONFIG_SUPPORT_COMMON_BINARY
-		if (g_umm_app_id) {
-			*g_umm_app_id = rtcb->app_id;
-		}
+			if (g_umm_app_id) {
+				*g_umm_app_id = ntcb->app_id;
+			}
 #endif
+
 #ifdef CONFIG_TASK_MONITOR
-		/* Update rtcb active flag for monitoring. */
+			/* Update rtcb active flag for monitoring. */
 
-		rtcb->is_active = true;
+			ntcb->is_active = true;
 #endif
-		/* Then switch contexts */
 
-		up_restorestate(rtcb->xcp.regs);
-	}
-	/* No, then we will need to perform the user context switch */
+			/* Then switch contexts */
 
-	else {
-		/* Switch context to the context of the task at the head of the
-		 * ready to run list.
-		 */
+			up_restorestate(ntcb->xcp.regs);
+		}
 
-		struct tcb_s *nexttcb = this_task();
-#ifdef CONFIG_TASK_SCHED_HISTORY
-		/* Save the task name which will be scheduled */
+		/* No, then we will need to perform the user context switch */
 
-		save_task_scheduling_status(nexttcb);
-#endif
-		up_switchcontext(rtcb->xcp.regs, nexttcb->xcp.regs);
+		else {
+			up_switchcontext(rtcb->xcp.regs, ntcb->xcp.regs);
 
-		/* up_switchcontext forces a context switch to the task at the
-		 * head of the ready-to-run list.  It does not 'return' in the
-		 * normal sense.  When it does return, it is because the blocked
-		 * task is again ready to run and has execution priority.
-		 */
+			/* up_switchcontext forces a context switch to the task at the
+			 * head of the ready-to-run list.  It does not 'return' in the
+			 * normal sense.  When it does return, it is because the blocked
+			 * task is again ready to run and has execution priority.
+			 */
+		}
 	}
 }

--- a/os/arch/arm/src/armv7-m/up_schedyield.c
+++ b/os/arch/arm/src/armv7-m/up_schedyield.c
@@ -1,0 +1,91 @@
+/****************************************************************************
+ *
+ * Copyright 2020 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include "sched/sched.h"
+#include "up_internal.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: up_schedyield
+ *
+ * Description:
+ *   Called when current task is willing to
+ *   yield cpu resource to other ready-to-run task.
+ *   context switch would occur in below case:
+ *
+ *   1) The priority of the currently running task is either equal or more than other ready to run task
+ *
+ * Inputs:
+ *   tcb: The TCB of the task that has been reprioritized
+ *
+ ****************************************************************************/
+
+void up_schedyield(struct tcb_s *rtcb)
+{
+	if (current_regs) {
+		/* Yes, then we have to do things differently.
+		 * Just copy the current_regs into the OLD rtcb.
+		 */
+
+		up_savestate(rtcb->xcp.regs);
+
+		/* Restore the exception context of the rtcb at the (new) head
+		 * of the g_readytorun task list.
+		 */
+
+		rtcb = this_task();
+		/* Then switch contexts */
+
+		up_restorestate(rtcb->xcp.regs);
+	}
+	/* No, then we will need to perform the user context switch */
+
+	else {
+		/* Switch context to the context of the task at the head of the
+		 * ready to run list.
+		 */
+
+		struct tcb_s *nexttcb = this_task();
+		up_switchcontext(rtcb->xcp.regs, nexttcb->xcp.regs);
+
+		/* up_switchcontext forces a context switch to the task at the
+		 * head of the ready-to-run list.  It does not 'return' in the
+		 * normal sense.  When it does return, it is because the blocked
+		 * task is again ready to run and has execution priority.
+		 */
+	}
+}

--- a/os/arch/arm/src/armv7-r/arm_schedyield.c
+++ b/os/arch/arm/src/armv7-r/arm_schedyield.c
@@ -20,6 +20,16 @@
  * Included Files
  ****************************************************************************/
 
+#include <tinyara/config.h>
+
+#include <sys/types.h>
+
+#include <tinyara/sched.h>
+#include <tinyara/ttrace.h>
+#ifdef CONFIG_TASK_SCHED_HISTORY
+#include <tinyara/debug/sysdbg.h>
+#endif
+
 #include "sched/sched.h"
 #include "up_internal.h"
 
@@ -68,6 +78,13 @@ void up_schedyield(struct tcb_s *rtcb)
 		 */
 
 		rtcb = this_task();
+		trace_sched(NULL, rtcb);
+
+#ifdef CONFIG_TASK_SCHED_HISTORY
+		/* Save the task name which will be scheduled */
+
+		save_task_scheduling_status(rtcb);
+#endif
 		/* Then switch contexts.  Any necessary address environment
 		 * changes will be made when the interrupt returns.
 		 */
@@ -86,6 +103,13 @@ void up_schedyield(struct tcb_s *rtcb)
 		 */
 
 		rtcb = this_task();
+		trace_sched(NULL, rtcb);
+
+#ifdef CONFIG_TASK_SCHED_HISTORY
+		/* Save the task name which will be scheduled */
+
+		save_task_scheduling_status(rtcb);
+#endif
 		/* Then switch contexts */
 
 		up_fullcontextrestore(rtcb->xcp.regs);

--- a/os/arch/arm/src/armv7-r/arm_schedyield.c
+++ b/os/arch/arm/src/armv7-r/arm_schedyield.c
@@ -1,0 +1,93 @@
+/****************************************************************************
+ *
+ * Copyright 2016 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include "sched/sched.h"
+#include "up_internal.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: up_schedyield
+ *
+ * Description:
+ *   Called when current task is willing to
+ *   yield cpu resource to other ready-to-run task.
+ *   context switch would occur in below case:
+ *
+ *   1) The priority of the currently running task is either equal or more than other ready to run task
+ *
+ * Inputs:
+ *   tcb: The TCB of the task that has been reprioritized
+ *
+ ****************************************************************************/
+
+void up_schedyield(struct tcb_s *rtcb)
+{
+	if (current_regs) {
+		/* Yes, then we have to do things differently.
+		 * Just copy the current_regs into the OLD rtcb.
+		 * rtcb is the tcb of task which is yeilding the resource
+		 */
+
+		up_savestate(rtcb->xcp.regs);
+		/* Restore the exception context of the new changed rtcb from the head
+		 * of the g_readytorun task list.
+		 */
+
+		rtcb = this_task();
+		/* Then switch contexts.  Any necessary address environment
+		 * changes will be made when the interrupt returns.
+		 */
+
+		up_restorestate(rtcb->xcp.regs);
+	}
+	/* Copy the exception context into the TCB at the (old) head of the
+	 * g_readytorun Task list. if up_saveusercontext returns a non-zero
+	 * value, then this is really the previously running task restarting!
+	 * here, rtcb is the tcb of task which is yeilding the resource
+	 */
+
+	else if (!up_saveusercontext(rtcb->xcp.regs)) {
+		/* Restore the exception context of the (new) changed rtcb from the head
+		 * of the g_readytorun task list.
+		 */
+
+		rtcb = this_task();
+		/* Then switch contexts */
+
+		up_fullcontextrestore(rtcb->xcp.regs);
+	}
+}

--- a/os/arch/arm/src/armv7-r/arm_schedyield.c
+++ b/os/arch/arm/src/armv7-r/arm_schedyield.c
@@ -59,59 +59,113 @@
  *
  *   1) The priority of the currently running task is either equal or more than other ready to run task
  *
- * Inputs:
- *   tcb: The TCB of the task that has been reprioritized
- *
  ****************************************************************************/
 
-void up_schedyield(struct tcb_s *rtcb)
+void up_schedyield(void)
 {
-	if (current_regs) {
-		/* Yes, then we have to do things differently.
-		 * Just copy the current_regs into the OLD rtcb.
-		 * rtcb is the tcb of task which is yeilding the resource
-		 */
+	struct tcb_s *rtcb = this_task();
+	struct tcb_s *ntcb = rtcb->flink;
 
-		up_savestate(rtcb->xcp.regs);
-		/* Restore the exception context of the new changed rtcb from the head
-		 * of the g_readytorun task list.
-		 */
-
-		rtcb = this_task();
-		trace_sched(NULL, rtcb);
-
-#ifdef CONFIG_TASK_SCHED_HISTORY
-		/* Save the task name which will be scheduled */
-
-		save_task_scheduling_status(rtcb);
-#endif
-		/* Then switch contexts.  Any necessary address environment
-		 * changes will be made when the interrupt returns.
-		 */
-
-		up_restorestate(rtcb->xcp.regs);
+	if (ntcb == NULL) {
+		sdbg("Fail to yield, there is no next tcb. Current task : %d\n", rtcb->pid);
+		return;
 	}
-	/* Copy the exception context into the TCB at the (old) head of the
-	 * g_readytorun Task list. if up_saveusercontext returns a non-zero
-	 * value, then this is really the previously running task restarting!
-	 * here, rtcb is the tcb of task which is yeilding the resource
+
+	/* Yielding the CPU resource to other tasks is possible only if other tasks
+	 * priority is either equal or greater than currently running task.
+	 * It's achieved by rescheduling the current task behind any other tasks at
+	 * same priority
 	 */
 
-	else if (!up_saveusercontext(rtcb->xcp.regs)) {
-		/* Restore the exception context of the (new) changed rtcb from the head
-		 * of the g_readytorun task list.
+	if (rtcb->sched_priority <= ntcb->sched_priority) {
+
+		/* Remove the TCB from the ready-to-run list */
+
+		dq_rem((FAR dq_entry_t *)rtcb, (FAR dq_queue_t *)&g_readytorun);
+
+		/* Add the task in the correct location in the prioritized
+		 * g_readytorun task list
 		 */
 
-		rtcb = this_task();
-		trace_sched(NULL, rtcb);
+		sched_addprioritized(rtcb, (FAR dq_queue_t *)&g_readytorun);
 
-#ifdef CONFIG_TASK_SCHED_HISTORY
-		/* Save the task name which will be scheduled */
+		/* The current tcb was added in the middle of the ready-to-run list */
 
-		save_task_scheduling_status(rtcb);
+		rtcb->task_state = TSTATE_TASK_READYTORUN;
+
+		/* we are going to do a context switch, then now it's the right
+		 * time to add any pending tasks back into the ready-to-run task
+		 * list now
+		 */
+
+		if (g_pendingtasks.head) {
+			sched_mergepending();
+		}
+
+		/* Get new head of the list */
+
+		ntcb = this_task();
+
+#if CONFIG_RR_INTERVAL > 0
+		ntcb->timeslice = MSEC2TICK(CONFIG_RR_INTERVAL);
 #endif
-		/* Then switch contexts */
 
-		up_fullcontextrestore(rtcb->xcp.regs);
+		/* A context switch will occur. */
+
+		ntcb->task_state = TSTATE_TASK_RUNNING;
+
+		/* Are we in an interrupt handler? */
+
+		if (current_regs) {
+
+			/* Yes, then we have to do things differently.
+			 * Just copy the current_regs into the OLD rtcb.
+			 * rtcb is the tcb of task which is yeilding the resource
+			 */
+
+			up_savestate(rtcb->xcp.regs);
+
+			/* Restore the exception context of the new changed ntcb from the head
+			 * of the g_readytorun task list.
+			 */
+
+			trace_sched(NULL, ntcb);
+
+	#ifdef CONFIG_TASK_SCHED_HISTORY
+			/* Save the task name which will be scheduled */
+
+			save_task_scheduling_status(ntcb);
+	#endif
+
+			/* Then switch contexts.  Any necessary address environment
+			 * changes will be made when the interrupt returns.
+			 */
+
+			up_restorestate(ntcb->xcp.regs);
+		}
+
+		/* Copy the exception context into the TCB at the (old) head of the
+		 * g_readytorun Task list. if up_saveusercontext returns a non-zero
+		 * value, then this is really the previously running task restarting!
+		 * here, rtcb is the tcb of task which is yeilding the resource
+		 */
+
+		else if (!up_saveusercontext(rtcb->xcp.regs)) {
+
+			/* Restore the exception context of the (new) changed rtcb from the head
+			 * of the g_readytorun task list.
+			 */
+
+			trace_sched(NULL, ntcb);
+
+	#ifdef CONFIG_TASK_SCHED_HISTORY
+			/* Save the task name which will be scheduled */
+
+			save_task_scheduling_status(ntcb);
+	#endif
+			/* Then switch contexts */
+
+			up_fullcontextrestore(ntcb->xcp.regs);
+		}
 	}
 }

--- a/os/arch/arm/src/armv8-m/up_schedyield.c
+++ b/os/arch/arm/src/armv8-m/up_schedyield.c
@@ -22,10 +22,14 @@
 
 #include <tinyara/config.h>
 
-#ifdef CONFIG_TASK_MONITOR
 #include <sys/types.h>
-#endif
+#include <debug.h>
+#include <queue.h>
+
 #include <tinyara/sched.h>
+#if CONFIG_RR_INTERVAL > 0
+#include <tinyara/clock.h>
+#endif
 #ifdef CONFIG_ARMV7M_MPU
 #include <tinyara/mpu.h>
 #endif
@@ -65,86 +69,126 @@
  *
  *   1) The priority of the currently running task is either equal or more than other ready to run task
  *
- * Inputs:
- *   tcb: The TCB of the task that has been reprioritized
- *
  ****************************************************************************/
 
-void up_schedyield(struct tcb_s *rtcb)
+void up_schedyield(void)
 {
-	if (current_regs) {
-		/* Yes, then we have to do things differently.
-		 * Just copy the current_regs into the OLD rtcb.
+	struct tcb_s *rtcb = this_task();
+	struct tcb_s *ntcb = rtcb->flink;
+
+	if (ntcb == NULL) {
+		sdbg("Fail to yield, there is no next tcb. Current task : %d\n", rtcb->pid);
+		return;
+	}
+
+	/* Yielding the CPU resource to other tasks is possible only if other tasks
+	 * priority is either equal or greater than currently running task.
+	 * It's achieved by rescheduling the current task behind any other tasks at
+	 * same priority
+	 */
+
+	if (rtcb->sched_priority <= ntcb->sched_priority) {
+
+		/* Remove the TCB from the ready-to-run list */
+
+		dq_rem((FAR dq_entry_t *)rtcb, (FAR dq_queue_t *)&g_readytorun);
+
+		/* Add the task in the correct location in the prioritized
+		 * g_readytorun task list
 		 */
 
-		up_savestate(rtcb->xcp.regs);
-#ifdef CONFIG_ARMV8M_TRUSTZONE
-		/* Store the secure context and PSPLIM of OLD rtcb */
+		sched_addprioritized(rtcb, (FAR dq_queue_t *)&g_readytorun);
 
-		tz_store_context(rtcb->xcp.regs);
+		/* The current tcb was added in the middle of the ready-to-run list */
+
+		rtcb->task_state = TSTATE_TASK_READYTORUN;
+
+		/* we are going to do a context switch, then now it's the right
+		 * time to add any pending tasks back into the ready-to-run task
+		 * list now
+		 */
+
+		if (g_pendingtasks.head) {
+			sched_mergepending();
+		}
+
+		/* Get new head of the list */
+
+		ntcb = this_task();
+
+#if CONFIG_RR_INTERVAL > 0
+		ntcb->timeslice = MSEC2TICK(CONFIG_RR_INTERVAL);
 #endif
 
-		/* Restore the exception context of the rtcb at the (new) head
-		 * of the g_readytorun task list.
-		 */
+		/* A context switch will occur. */
 
-		rtcb = this_task();
+		ntcb->task_state = TSTATE_TASK_RUNNING;
+
 #ifdef CONFIG_TASK_SCHED_HISTORY
 		/* Save the task name which will be scheduled */
 
-		save_task_scheduling_status(rtcb);
+		save_task_scheduling_status(ntcb);
 #endif
 
-		/* Restore the MPU registers in case we are switching to an application task */
-#ifdef CONFIG_ARMV8M_MPU
-		/* Condition check : Update MPU registers only if this is not a kernel thread. */
+		/* Are we in an interrupt handler? */
 
-		if ((rtcb->flags & TCB_FLAG_TTYPE_MASK) != TCB_FLAG_TTYPE_KERNEL) {
+		if (current_regs) {
+			/* Yes, then we have to do things differently.
+			 * Just copy the current_regs into the OLD rtcb.
+			 */
+
+			up_savestate(rtcb->xcp.regs);
+#ifdef CONFIG_ARMV8M_TRUSTZONE
+			/* Store the secure context and PSPLIM of OLD rtcb */
+
+			tz_store_context(rtcb->xcp.regs);
+#endif
+
+			/* Restore the exception context of the ntcb at the (new) head
+			 * of the g_readytorun task list.
+			 */
+
+			/* Restore the MPU registers in case we are switching to an application task */
+#ifdef CONFIG_ARMV8M_MPU
+			/* Condition check : Update MPU registers only if this is not a kernel thread. */
+
+			if ((ntcb->flags & TCB_FLAG_TTYPE_MASK) != TCB_FLAG_TTYPE_KERNEL) {
 #if defined(CONFIG_APP_BINARY_SEPARATION)
-			for (int i = 0; i < 3 * MPU_NUM_REGIONS; i += 3) {
-				up_mpu_set_register(&rtcb->mpu_regs[i]);
-			}
+				for (int i = 0; i < 3 * MPU_NUM_REGIONS; i += 3) {
+					up_mpu_set_register(&ntcb->mpu_regs[i]);
+				}
 #endif
 #ifdef CONFIG_MPU_STACK_OVERFLOW_PROTECTION
-			up_mpu_set_register(rtcb->stack_mpu_regs);
+				up_mpu_set_register(ntcb->stack_mpu_regs);
 #endif
-		}
+			}
 #endif
 
 #ifdef CONFIG_TASK_MONITOR
-		/* Update rtcb active flag for monitoring. */
+			/* Update rtcb active flag for monitoring. */
 
-		rtcb->is_active = true;
+			ntcb->is_active = true;
 #endif
-		/* Then switch contexts */
+			/* Then switch contexts */
 
-		up_restorestate(rtcb->xcp.regs);
+			up_restorestate(ntcb->xcp.regs);
 #ifdef CONFIG_ARMV8M_TRUSTZONE
-		/* Load the secure context and PSPLIM of OLD rtcb */
+			/* Load the secure context and PSPLIM of OLD rtcb */
 
-		tz_load_context(rtcb->xcp.regs);
+			tz_load_context(ntcb->xcp.regs);
 #endif
 
-	}
-	/* No, then we will need to perform the user context switch */
+		}
+		/* No, then we will need to perform the user context switch */
 
-	else {
-		/* Switch context to the context of the task at the head of the
-		 * ready to run list.
-		 */
+		else {
+			up_switchcontext(rtcb->xcp.regs, ntcb->xcp.regs);
 
-		struct tcb_s *nexttcb = this_task();
-#ifdef CONFIG_TASK_SCHED_HISTORY
-		/* Save the task name which will be scheduled */
-
-		save_task_scheduling_status(nexttcb);
-#endif
-		up_switchcontext(rtcb->xcp.regs, nexttcb->xcp.regs);
-
-		/* up_switchcontext forces a context switch to the task at the
-		 * head of the ready-to-run list.  It does not 'return' in the
-		 * normal sense.  When it does return, it is because the blocked
-		 * task is again ready to run and has execution priority.
-		 */
+			/* up_switchcontext forces a context switch to the task at the
+			 * head of the ready-to-run list.  It does not 'return' in the
+			 * normal sense.  When it does return, it is because the blocked
+			 * task is again ready to run and has execution priority.
+			 */
+		}
 	}
 }

--- a/os/arch/arm/src/imxrt/Make.defs
+++ b/os/arch/arm/src/imxrt/Make.defs
@@ -111,6 +111,10 @@ CMN_ASRCS += up_fpu.S
 CMN_CSRCS += up_copyarmstate.c
 endif
 
+ifeq ($(CONFIG_SCHED_YIELD_OPTIMIZATION),y)
+CMN_CSRCS += up_schedyield.c
+endif
+
 # Required i.MX RT files
 
 CHIP_ASRCS  =

--- a/os/arch/arm/src/s5j/Make.defs
+++ b/os/arch/arm/src/s5j/Make.defs
@@ -102,7 +102,7 @@ CMN_CSRCS += arm_mpu.c
 endif
 
 ifeq ($(CONFIG_SCHED_YIELD_OPTIMIZATION),y)
-CMN_CSRCS += up_schedyield.c
+CMN_CSRCS += arm_schedyield.c
 endif
 
 ifeq ($(CONFIG_BUILD_KERNEL),y)

--- a/os/arch/arm/src/stm32l4/Make.defs
+++ b/os/arch/arm/src/stm32l4/Make.defs
@@ -89,6 +89,10 @@ ifeq ($(CONFIG_STACK_COLORATION),y)
 CMN_CSRCS += up_checkstack.c
 endif
 
+ifeq ($(CONFIG_SCHED_YIELD_OPTIMIZATION),y)
+CMN_CSRCS += up_schedyield.c
+endif
+
 # Required STM32L4 files
 
 CHIP_ASRCS  =

--- a/os/arch/arm/src/tiva/Make.defs
+++ b/os/arch/arm/src/tiva/Make.defs
@@ -62,7 +62,11 @@ CMN_CSRCS += up_modifyreg8.c up_modifyreg16.c up_modifyreg32.c
 CMN_CSRCS += up_releasepending.c up_releasestack.c up_reprioritizertr.c
 CMN_CSRCS += up_schedulesigaction.c up_sigdeliver.c up_stackframe.c
 CMN_CSRCS += up_unblocktask.c up_usestack.c up_doirq.c up_hardfault.c
-CMN_CSRCS += up_svcall.c up_vfork.c up_schedyield.c
+CMN_CSRCS += up_svcall.c up_vfork.c
+
+ifeq ($(CONFIG_SCHED_YIELD_OPTIMIZATION),y)
+CMN_CSRCS += up_schedyield.c
+endif
 
 ifeq ($(CONFIG_ARCH_RAMVECTORS),y)
 CMN_CSRCS += up_ramvec_initialize.c up_ramvec_attach.c

--- a/os/include/tinyara/arch.h
+++ b/os/include/tinyara/arch.h
@@ -558,13 +558,10 @@ void up_reprioritize_rtr(FAR struct tcb_s *tcb, uint8_t priority);
  *   logic.  Interrupts will always be disabled when this
  *   function is called.
  *
- * Inputs:
- *   tcb: The TCB of the task that is yielding the resource
- *
  ****************************************************************************/
 
 #ifdef CONFIG_SCHED_YIELD_OPTIMIZATION
-void up_schedyield(FAR struct tcb_s *rtcb);
+void up_schedyield(void);
 #endif
 
 /****************************************************************************

--- a/os/include/tinyara/tz_context.h
+++ b/os/include/tinyara/tz_context.h
@@ -46,9 +46,9 @@
  * @ingroup KERNEL
  */
 
-#if   defined ( __ICCARM__ )
+#if defined(__ICCARM__)
   #pragma system_include         /* treat file as system include file for MISRA check */
-#elif defined (__clang__)
+#elif defined(__clang__)
   #pragma clang system_header   /* treat file as system include file */
 #endif
 
@@ -80,7 +80,7 @@ extern volatile TZ_MemoryId_t tz_memory;
  * Initialize secure context memory system
  * return execution status (1: success, 0: error)
  */
-uint32_t TZ_InitContextSystem_S (void);
+uint32_t TZ_InitContextSystem_S(void);
 
 /**
  * Allocate context memory for calling secure software modules in TrustZone
@@ -88,28 +88,28 @@ uint32_t TZ_InitContextSystem_S (void);
  * return value != 0 id TrustZone memory slot identifier
  * return value 0    no memory available or internal error
  */
-TZ_MemoryId_t TZ_AllocModuleContext_S (TZ_ModuleId_t module);
+TZ_MemoryId_t TZ_AllocModuleContext_S(TZ_ModuleId_t module);
 
 /**
  * Free context memory that was previously allocated with \ref TZ_AllocModuleContext_S
  * param[in]  id  TrustZone memory slot identifier
  * return execution status (1: success, 0: error)
  */
-uint32_t TZ_FreeModuleContext_S (TZ_MemoryId_t id);
+uint32_t TZ_FreeModuleContext_S(TZ_MemoryId_t id);
 
 /**
  * Load secure context (called on RTOS thread context switch)
  * param[in]  id  TrustZone memory slot identifier
  * return execution status (1: success, 0: error)
  */
-uint32_t TZ_LoadContext_S (TZ_MemoryId_t id);
+uint32_t TZ_LoadContext_S(TZ_MemoryId_t id);
 
 /**
  * Store secure context (called on RTOS thread context switch)
  * param[in]  id  TrustZone memory slot identifier
  * return execution status (1: success, 0: error)
  */
-uint32_t TZ_StoreContext_S (TZ_MemoryId_t id);
+uint32_t TZ_StoreContext_S(TZ_MemoryId_t id);
 
 /****************************************************************************
  * Inline Functions


### PR DESCRIPTION
1. arch/arm: move up_schedyield to each architecture
2. arch/arm: add missing codes in schedyield.c 
3. kernel/sched: optimize sched_yield with CONFIG_SCHED_YIELD_OPTIMIZATION 
4. arch/arm, kernel/sched: move yield functionality into arch for optimization