### PR TITLE
tc,os/drivers/watchdog: fix tc for invalid result

### DIFF
--- a/apps/examples/testcase/le_tc/drivers/tc_watchdog.c
+++ b/apps/examples/testcase/le_tc/drivers/tc_watchdog.c
@@ -147,7 +147,7 @@ static void tc_driver_watchdog_ioctl(void)
 	TC_ASSERT_EQ_CLEANUP("watchdog_ioctl", ret, OK, close(fd));
 
 	ret = ioctl(fd, -1, 0UL);
-	TC_ASSERT_EQ_CLEANUP("watchdog_ioctl", ret, OK, close(fd));
+	TC_ASSERT_EQ_CLEANUP("watchdog_ioctl", ret, -EINVAL, close(fd));
 
 	close(fd);
 

--- a/os/drivers/watchdog.c
+++ b/os/drivers/watchdog.c
@@ -273,10 +273,14 @@ static int wdog_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
 	wdvdbg("cmd: %d arg: %ld\n", cmd, arg);
 	DEBUGASSERT(upper && lower);
 
-	/* Get exclusive access to the device structures */
+	if (cmd < 0) {
+		return -EINVAL;
+	}
 
+	/* Get exclusive access to the device structures */
 	ret = sem_wait(&upper->exclsem);
 	if (ret < 0) {
+		ret = -get_errno();
 		return ret;
 	}
 


### PR DESCRIPTION
1. The result of the test case for the wrong input value is incorrect.
2. The watchdog does not handle an exception.

Signed-off-by: jaesick.shin <jaesick.shin@samsung.com>