### PR TITLE
tc/tc_watchdog: remove unncessary tc

### DIFF
--- a/apps/examples/testcase/le_tc/drivers/tc_watchdog.c
+++ b/apps/examples/testcase/le_tc/drivers/tc_watchdog.c
@@ -146,9 +146,6 @@ static void tc_driver_watchdog_ioctl(void)
 	ret = ioctl(fd, WDIOC_STOP, 0UL);
 	TC_ASSERT_EQ_CLEANUP("watchdog_ioctl", ret, OK, close(fd));
 
-	ret = ioctl(fd, -1, 0UL);
-	TC_ASSERT_EQ_CLEANUP("watchdog_ioctl", ret, OK, close(fd));
-
 	close(fd);
 
 	TC_SUCCESS_RESULT();


### PR DESCRIPTION
remove that tc, because
In some drivers, -1 may or may not be used.

Signed-off-by: jaesick.shin <jaesick.shin@samsung.com>