### PR TITLE
kernel/semaphore: Initialize semaphore with sem_init instead of SEM_INITIALIZER

### DIFF
--- a/os/arch/arm/src/stm32l4/stm32l4_flash.c
+++ b/os/arch/arm/src/stm32l4/stm32l4_flash.c
@@ -111,7 +111,7 @@
  * Private Data
  ************************************************************************************/
 
-static sem_t g_sem = SEM_INITIALIZER(1);
+static sem_t g_sem;
 static uint32_t g_page_buffer[FLASH_PAGE_WORDS];
 
 /************************************************************************************
@@ -204,6 +204,11 @@ static inline void flash_erase(size_t page)
 /************************************************************************************
  * Public Functions
  ************************************************************************************/
+void stm32l4_flash_initialize(void)
+{
+	/* Initialize a semaphore to access flash */
+	sem_init(&g_sem, 0, 1);
+}
 
 void stm32l4_flash_unlock(void)
 {

--- a/os/arch/xtensa/src/esp32/spi_flash/include/esp_partition.h
+++ b/os/arch/xtensa/src/esp32/spi_flash/include/esp_partition.h
@@ -175,6 +175,11 @@ const esp_partition_t *esp_partition_get(esp_partition_iterator_t iterator);
 esp_partition_iterator_t esp_partition_next(esp_partition_iterator_t iterator);
 
 /**
+ * @brief Initialize a mutex for partition access
+ */
+void esp_partition_initialize(void);
+
+/**
  * @brief Release partition iterator
  *
  * @param iterator Iterator obtained using esp_partition_find. Must be non-NULL.

--- a/os/arch/xtensa/src/esp32/spi_flash/include/esp_partition.h
+++ b/os/arch/xtensa/src/esp32/spi_flash/include/esp_partition.h
@@ -175,7 +175,7 @@ const esp_partition_t *esp_partition_get(esp_partition_iterator_t iterator);
 esp_partition_iterator_t esp_partition_next(esp_partition_iterator_t iterator);
 
 /**
- * @brief Initialize a mutex for partition access
+ * @brief Initialize a semaphore for partition access
  */
 void esp_partition_initialize(void);
 

--- a/os/arch/xtensa/src/esp32/spi_flash/partition.c
+++ b/os/arch/xtensa/src/esp32/spi_flash/partition.c
@@ -75,6 +75,8 @@
 #include <stdio.h>
 #include <pthread.h>
 
+#include <tinyara/sched.h>
+
 #include "esp_flash_partitions.h"
 #include "esp_attr.h"
 #include "esp_flash_data_types.h"
@@ -105,7 +107,7 @@ static esp_partition_iterator_opaque_t *iterator_create(esp_partition_type_t typ
 static esp_err_t load_partitions(void);
 
 static SLIST_HEAD(partition_list_head_, partition_list_item_) s_partition_list = SLIST_HEAD_INITIALIZER(s_partition_list);
-static pthread_mutex_t s_partition_list_lock = PTHREAD_MUTEX_INITIALIZER;
+static pthread_mutex_t s_partition_list_lock;
 
 esp_partition_iterator_t esp_partition_find(esp_partition_type_t type, esp_partition_subtype_t subtype, const char *label)
 {
@@ -232,6 +234,13 @@ static esp_err_t load_partitions(void)
 	}
 	spi_flash_munmap(handle);
 	return ESP_OK;
+}
+
+void esp_partition_initialize(void)
+{
+	/* Initialize a mutex for partition access */
+	sem_init(&s_partition_list_lock.sem, 0, 1);
+	s_partition_list_lock.pid = INVALID_PROCESS_ID;
 }
 
 void esp_partition_iterator_release(esp_partition_iterator_t iterator)

--- a/os/arch/xtensa/src/esp32/spi_flash/partition.c
+++ b/os/arch/xtensa/src/esp32/spi_flash/partition.c
@@ -73,9 +73,7 @@
 #include <assert.h>
 #include <string.h>
 #include <stdio.h>
-#include <pthread.h>
-
-#include <tinyara/sched.h>
+#include <semaphore.h>
 
 #include "esp_flash_partitions.h"
 #include "esp_attr.h"
@@ -107,18 +105,18 @@ static esp_partition_iterator_opaque_t *iterator_create(esp_partition_type_t typ
 static esp_err_t load_partitions(void);
 
 static SLIST_HEAD(partition_list_head_, partition_list_item_) s_partition_list = SLIST_HEAD_INITIALIZER(s_partition_list);
-static pthread_mutex_t s_partition_list_lock;
+static sem_t s_partition_list_lock;
 
 esp_partition_iterator_t esp_partition_find(esp_partition_type_t type, esp_partition_subtype_t subtype, const char *label)
 {
 	if (SLIST_EMPTY(&s_partition_list)) {
 		// only lock if list is empty (and check again after acquiring lock)
-		pthread_mutex_lock(&s_partition_list_lock);
+		sem_wait(&s_partition_list_lock);
 		esp_err_t err = ESP_OK;
 		if (SLIST_EMPTY(&s_partition_list)) {
 			err = load_partitions();
 		}
-		pthread_mutex_unlock(&s_partition_list_lock);
+		sem_post(&s_partition_list_lock);
 		if (err != ESP_OK) {
 			return NULL;
 		}
@@ -140,7 +138,7 @@ esp_partition_iterator_t esp_partition_next(esp_partition_iterator_t it)
 		esp_partition_iterator_release(it);
 		return NULL;
 	}
-	pthread_mutex_lock(&s_partition_list_lock);
+	sem_wait(&s_partition_list_lock);
 	for (; it->next_item != NULL; it->next_item = SLIST_NEXT(it->next_item, next)) {
 		esp_partition_t *p = &it->next_item->info;
 		if (it->type != p->type) {
@@ -155,7 +153,7 @@ esp_partition_iterator_t esp_partition_next(esp_partition_iterator_t it)
 		// all constraints match, bail out
 		break;
 	}
-	pthread_mutex_unlock(&s_partition_list_lock);
+	sem_post(&s_partition_list_lock);
 	if (it->next_item == NULL) {
 		esp_partition_iterator_release(it);
 		return NULL;
@@ -238,9 +236,8 @@ static esp_err_t load_partitions(void)
 
 void esp_partition_initialize(void)
 {
-	/* Initialize a mutex for partition access */
-	sem_init(&s_partition_list_lock.sem, 0, 1);
-	s_partition_list_lock.pid = INVALID_PROCESS_ID;
+	/* Initialize a semaphore for partition access */
+	sem_init(&s_partition_list_lock, 0, 1);
 }
 
 void esp_partition_iterator_release(esp_partition_iterator_t iterator)

--- a/os/board/esp32_devkit/src/esp32_boot.c
+++ b/os/board/esp32_devkit/src/esp32_boot.c
@@ -76,6 +76,9 @@
 #include "esp32_adc.h"
 #include <tinyara/analog/adc.h>
 #endif
+#if defined(CONFIG_ESP32_SPIFLASH)
+extern void esp_partition_initialize();
+#endif
 #ifdef CONFIG_SPIRAM_SUPPORT
 extern void esp_spiram_init_cache();
 extern int esp_spiram_init();
@@ -234,6 +237,9 @@ void board_initialize(void)
 {
 	/* Perform board-specific initialization */
 	(void)esp32_bringup();
+#ifdef CONFIG_ESP32_SPIFLASH
+	esp_partition_initialize();
+#endif
 	configure_partitions();
 	esp32_devKit_mount_partions();
 	board_gpio_initialize();

--- a/os/board/stm32l4r9ai-disco/include/stm32l4r9i_discovery.h
+++ b/os/board/stm32l4r9ai-disco/include/stm32l4r9i_discovery.h
@@ -359,6 +359,8 @@ extern void stm32_touch_printf_coord(void);
 
 extern void stm32_dsi_refresh(void);
 extern void up_hal_timer_initialize(void);
+
+extern void stm32l4_flash_initialize(void);
 /**
   * @}
   */

--- a/os/board/stm32l4r9ai-disco/src/stm32_boot.c
+++ b/os/board/stm32l4r9ai-disco/src/stm32_boot.c
@@ -81,6 +81,9 @@ void board_initialize(void)
     stm32_spiinitialize();
 #endif
 
+	/* Initialize for flash access */
+	stm32l4_flash_initialize();
+
 #ifdef CONFIG_STM32L4_OTGFS
   /* Initialize USB if the 1) OTG FS controller is in the configuration and 2)
    * disabled, and 3) the weak function stm32_usbinitialize() has been brought

--- a/os/net/netmgr/netdev_mgr_internal.c
+++ b/os/net/netmgr/netdev_mgr_internal.c
@@ -46,7 +46,7 @@ static int g_eth_idx = 0;
  * and application doesn't require write operation to netdev
  * so if there is no write operation then protection wouldn't be required
  */
-sem_t g_netdev_lock = SEM_INITIALIZER(1);
+static sem_t g_netdev_lock;
 
 #define NETDEV_LOCK								\
 	do {										\
@@ -259,4 +259,6 @@ void nm_init(void)
 		g_netdev[i].ops = NULL;
 		g_netdev[i].type = NM_UNKNOWN;
 	}
+
+	sem_init(&g_netdev_lock, 0, 1);
 }

--- a/os/pm/pm_initialize.c
+++ b/os/pm/pm_initialize.c
@@ -78,7 +78,7 @@
  * data structure here.
  */
 
-struct pm_global_s g_pmglobals = { SEM_INITIALIZER(1) };
+struct pm_global_s g_pmglobals;
 
 /****************************************************************************
  * Public Functions
@@ -106,6 +106,8 @@ void pm_initialize(void)
 {
 	FAR struct pm_domain_s *pdom;
 	int i;
+
+	sem_init(&g_pmglobals.regsem, 0, 1);
 
 	for (i = 0; i < CONFIG_PM_NDOMAINS; i++) {
 		pdom = &g_pmglobals.domain[i];


### PR DESCRIPTION
All kernel semaphores are registered to a list of kernel semaphores, g_sem_list for fault recovery.
So they should call sem_register by calling sem_init instead of SEM_INITIALIZER.