### PR TITLE
os/fs/smartfs : Add logic to get blockdriver's physical sector from b…

### DIFF
--- a/os/fs/driver/mtd/smart.c
+++ b/os/fs/driver/mtd/smart.c
@@ -4777,6 +4777,15 @@ static int smart_ioctl(FAR struct inode *inode, int cmd, unsigned long arg)
 		goto ok_out;
 #endif							/* CONFIG_FS_WRITABLE */
 
+	case BIOC_FIBMAP:
+
+#ifndef CONFIG_MTD_SMART_MINIMIZE_RAM
+		ret = (int)dev->sMap[(uint16_t)arg];
+#else
+		ret = (int)smart_cache_lookup(dev, (uint16_t)arg);
+#endif
+		goto ok_out;
+
 #if defined(CONFIG_FS_PROCFS) && !defined(CONFIG_FS_PROCFS_EXCLUDE_SMARTFS)
 	case BIOC_GETPROCFSD:
 

--- a/os/fs/smartfs/smartfs.h
+++ b/os/fs/smartfs/smartfs.h
@@ -400,6 +400,7 @@ uint16_t get_used_byte_count_from_end(uint8_t *buffer);
 int set_used_byte_count(uint8_t *used, uint16_t count);
 uint16_t get_used_byte_count(uint8_t *used);
 #endif
+int smartfs_sector_recovery(struct smartfs_mountpt_s *fs);
 
 struct file;					/* Forward references */
 struct inode;

--- a/os/fs/smartfs/smartfs_smart.c
+++ b/os/fs/smartfs/smartfs_smart.c
@@ -1490,6 +1490,11 @@ static int smartfs_bind(FAR struct inode *blkdriver, const void *data, void **ha
 	}
 
 	*handle = (void *)fs;
+	
+	ret = smartfs_sector_recovery(fs);
+	if (ret != 0) {
+		goto error_with_semaphore;
+	}
 
 	smartfs_semgive(fs);
 	return ret;

--- a/os/include/tinyara/fs/ioctl.h
+++ b/os/include/tinyara/fs/ioctl.h
@@ -236,7 +236,13 @@
 										 *      ProcFS data.
 										 * OUT: None (ioctl return value provides
 										 *      success/failure indication). */
-#define BIOC_DEBUGCMD   _BIOC(0x000B)	/* Send driver specific debug command /
+#define BIOC_FIBMAP     _BIOC(0x000B)	/* Reveal Physical sector number from bitmap
+										 * of block device.
+										 * IN:	Logical sector number which need
+										 *		to reveal physical sector.
+										 * OUT: Physical sector number align with
+										 *		logical sector number */
+#define BIOC_DEBUGCMD   _BIOC(0x00FF)	/* Send driver specific debug command /
 										 * data to the block device.
 										 * IN:  Pointer to a struct defined for
 										 *      the block with specific debug


### PR DESCRIPTION
…lock device.

To recover isolated sector due to power failure, FS should know which logical sector is
mapped to active physical sector