### PR TITLE
se/ameba: Resolve compile error, and index problem for SE non-secure

### DIFF
--- a/os/se/ameba/rtl_security_api_wrapper.c
+++ b/os/se/ameba/rtl_security_api_wrapper.c
@@ -16,10 +16,10 @@
 *
 ***************************************************************************************************/
 
-#include <stdint.h>
-#include <stdio.h>
+#include <sys/types.h>
 #include <stdlib.h>
 #include <string.h>
+#include <stdint.h>
 #include <tinyara/kmalloc.h>
 
 #include "flash_api.h"
@@ -79,7 +79,7 @@ static uint8_t crypto_inited = 0;
 /**
  * Read secure efuse
  */
-static void rtl_ReadEfuse(u32 addr, u8 size, u8* key)
+static void rtl_ReadEfuse(uint32_t addr, uint8_t size, uint8_t *key)
 {
 	uint32_t Idx = 0;
 	uint32_t CtrlSetting = HAL_READ32(SYSTEM_CTRL_BASE, REG_HS_EFUSE_CTRL1_S);
@@ -119,7 +119,7 @@ uint32_t rtl_cryptoEngine_init_wrapper(void)
 /**
  * AES Crpyto Wrapper
  */
-uint32_t rtl_cryptoAES_ecb_wrapper(uint8_t* key, uint32_t keylen, unsigned char* message, uint32_t msglen, unsigned char* pResult, uint8_t mode)
+uint32_t rtl_cryptoAES_ecb_wrapper(uint8_t *key, uint32_t keylen, unsigned char *message, uint32_t msglen, unsigned char *pResult, uint8_t mode)
 {
 	uint32_t ret = RTL_HAL_SUCCESS;
 
@@ -145,7 +145,7 @@ uint32_t rtl_cryptoAES_ecb_wrapper(uint8_t* key, uint32_t keylen, unsigned char*
 	return ret;
 }
 
-uint32_t rtl_cryptoAES_cbc_wrapper(uint8_t* key, uint32_t keylen, unsigned char* message, uint32_t msglen, unsigned char* pResult, uint8_t mode)
+uint32_t rtl_cryptoAES_cbc_wrapper(uint8_t *key, uint32_t keylen, unsigned char *message, uint32_t msglen, unsigned char *pResult, uint8_t mode)
 {
 	uint32_t ret = RTL_HAL_SUCCESS;
 	unsigned char iv[16];
@@ -172,7 +172,7 @@ uint32_t rtl_cryptoAES_cbc_wrapper(uint8_t* key, uint32_t keylen, unsigned char*
 	return ret;
 }
 
-uint32_t rtl_cryptoAES_ctr_wrapper(uint8_t* key, uint32_t keylen, unsigned char* message, uint32_t msglen, unsigned char* pResult, uint8_t mode)
+uint32_t rtl_cryptoAES_ctr_wrapper(uint8_t *key, uint32_t keylen, unsigned char *message, uint32_t msglen, unsigned char *pResult, uint8_t mode)
 {
 	uint32_t ret = RTL_HAL_SUCCESS;
 	unsigned char iv[16];

--- a/os/se/ameba/rtl_security_api_wrapper.c
+++ b/os/se/ameba/rtl_security_api_wrapper.c
@@ -239,6 +239,37 @@ uint32_t rtl_read_factory_cert_wrapper(hal_data *data)
 	return ret;
 }
 
+uint32_t rtl_write_factory_cert_wrapper(hal_data *data)
+{
+	uint32_t ret;
+	uint8_t buf_length[4];
+	flash_t flash;
+	uint32_t data_len = data->data_len;
+
+	uint8_t	*buf_flash = (uint8_t *) malloc(data_len + 4);
+
+	if (buf_flash) {
+		itoa(data_len, buf_length, 10);
+		memcpy(buf_flash, buf_length, 4);
+		memcpy(buf_flash + 4, data->data, data->data_len);
+
+		device_mutex_lock(RT_DEV_LOCK_FLASH);
+		flash_erase_sector(&flash, FACTORY_CERT_ADDR);
+		flash_stream_write(&flash, FACTORY_CERT_ADDR, data_len + 4, buf_flash);
+		device_mutex_unlock(RT_DEV_LOCK_FLASH);
+
+		ret = RTL_HAL_SUCCESS;
+	} else {
+		ret = RTL_HAL_FAIL;
+	}
+
+	if (buf_flash != NULL) {
+		free(buf_flash);
+	}
+
+	return ret;
+}
+
 uint32_t rtl_read_factory_key_wrapper(hal_data *data)
 {
 	uint32_t ret;

--- a/os/se/ameba/rtl_security_api_wrapper.c
+++ b/os/se/ameba/rtl_security_api_wrapper.c
@@ -20,6 +20,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <tinyara/kmalloc.h>
 
 #include "flash_api.h"
 #include "device_lock.h"
@@ -215,7 +216,7 @@ uint32_t rtl_read_factory_cert_wrapper(hal_data *data)
 
 	data_len = atoi(buf_length);	/* Cert Length */
 
-	buf_flash = (uint8_t *) malloc(data_len + 4);	/* Allocate buff */
+	buf_flash = (uint8_t *)kmm_malloc(data_len + 4);	/* Allocate buff */
 
 	if (buf_flash) {
 		memset(buf_flash, 0, data_len + 4);
@@ -233,7 +234,7 @@ uint32_t rtl_read_factory_cert_wrapper(hal_data *data)
 	}
 
 	if (buf_flash != NULL) {
-		free(buf_flash);
+		kmm_free(buf_flash);
 	}
 
 	return ret;
@@ -246,7 +247,7 @@ uint32_t rtl_write_factory_cert_wrapper(hal_data *data)
 	flash_t flash;
 	uint32_t data_len = data->data_len;
 
-	uint8_t	*buf_flash = (uint8_t *) malloc(data_len + 4);
+	uint8_t	*buf_flash = (uint8_t *)kmm_malloc(data_len + 4);
 
 	if (buf_flash) {
 		itoa(data_len, buf_length, 10);
@@ -259,12 +260,9 @@ uint32_t rtl_write_factory_cert_wrapper(hal_data *data)
 		device_mutex_unlock(RT_DEV_LOCK_FLASH);
 
 		ret = RTL_HAL_SUCCESS;
+		kmm_free(buf_flash);
 	} else {
 		ret = RTL_HAL_FAIL;
-	}
-
-	if (buf_flash != NULL) {
-		free(buf_flash);
 	}
 
 	return ret;
@@ -288,9 +286,9 @@ uint32_t rtl_read_factory_key_wrapper(hal_data *data)
 	data_len = atoi(buf_length);	/* Key Length */
 
 	/* Allocate buff */
-	buf_flash = (uint8_t *) malloc(data_len + 4);
-	buf_crypt = (uint8_t *) malloc(data_len);
-	buf_plain = (uint8_t *) malloc(data_len);
+	buf_flash = (uint8_t *)kmm_malloc(data_len + 4);
+	buf_crypt = (uint8_t *)kmm_malloc(data_len);
+	buf_plain = (uint8_t *)kmm_malloc(data_len);
 
 	if (buf_plain && buf_crypt && buf_flash) {
 		memset(buf_flash, 0, data_len + 4);
@@ -314,13 +312,70 @@ uint32_t rtl_read_factory_key_wrapper(hal_data *data)
 	}
 
 	if (buf_flash != NULL) {
-		free(buf_flash);
+		kmm_free(buf_flash);
 	}
 	if (buf_plain != NULL) {
-		free(buf_plain);
+		kmm_free(buf_plain);
 	}
 	if (buf_crypt != NULL) {
-		free(buf_crypt);
+		kmm_free(buf_crypt);
+	}
+
+	return ret;
+}
+
+uint32_t rtl_write_factory_key_wrapper(hal_data *data)
+{
+	uint32_t ret;
+	uint8_t buf_length[4];
+	uint8_t	*buf_crypt = NULL;
+	uint8_t	*buf_flash = NULL;
+	uint8_t	*buf_plain = NULL;
+	unsigned char aes_key[32] __attribute__((aligned(4)));
+	flash_t flash;
+	uint32_t data_len = (data->data_len + 15) / 16 * 16;	/* AES blocks */
+
+	buf_crypt = (uint8_t *)kmm_malloc(data_len);
+	buf_flash = (uint8_t *)kmm_malloc(data_len + 4);
+	buf_plain = (uint8_t *)kmm_malloc(data_len);
+
+	if (buf_crypt && buf_flash && buf_plain) {
+		memset(buf_crypt, 0, data_len);
+		memset(buf_flash, 0, data_len + 4);
+		memset(buf_plain, 0, data_len);
+		memcpy(buf_plain, data->data, data->data_len);
+
+		memset(aes_key, 0, SAMSUNG_KEY_SIZE);
+		memcpy(aes_key, samsung_key, SAMSUNG_KEY_SIZE);
+
+		ret = rtl_cryptoAES_ecb_wrapper(aes_key, SAMSUNG_KEY_SIZE, buf_crypt, data_len, buf_plain, RTL_ENCRYPT);
+
+		if (ret != 0) {
+			goto exit;
+		}
+		itoa(data_len, buf_length, 10);
+		memcpy(buf_flash, buf_length, 4);
+		memcpy(buf_flash + 4, buf_crypt, data_len);
+
+		device_mutex_lock(RT_DEV_LOCK_FLASH);
+		flash_erase_sector(&flash, FACTORY_KEY_ADDR);
+		flash_stream_write(&flash, FACTORY_KEY_ADDR, data_len + 4, buf_flash);
+		device_mutex_unlock(RT_DEV_LOCK_FLASH);
+
+		ret = RTL_HAL_SUCCESS;
+	} else {
+		ret = RTL_HAL_FAIL;
+	}
+
+exit:
+	if (buf_crypt != NULL) {
+		kmm_free(buf_crypt);
+	}
+	if (buf_flash != NULL) {
+		kmm_free(buf_flash);
+	}
+	if (buf_plain != NULL) {
+		kmm_free(buf_plain);
 	}
 
 	return ret;
@@ -334,15 +389,15 @@ uint32_t rtl_write_storage_wrapper(uint32_t ss_idx, hal_data *data)
 	uint32_t ret;
 	uint8_t tmpbuf[64];
 	uint8_t buf_length[4];
-	uint8_t *key = (uint8_t*)(((uint32_t) tmpbuf + 31) & (~31));	/* align to 32byte */
+	uint8_t *key = (uint8_t*)(((uint32_t)tmpbuf + 31) & (~31));	/* align to 32byte */
 	flash_t flash;
 	uint32_t data_len = (data->data_len + 15) / 16 * 16;	/* AES blocks */
 	const uint8_t aes_gcm_iv[12];
 	const uint8_t aes_gcm_aad[20];
 
-	uint8_t	*buf = (uint8_t *) malloc(data_len + TAG_LENGTH);
-	uint8_t	*buf_flash = (uint8_t *) malloc(data_len + TAG_LENGTH + 4);
-	uint8_t	*data_plain = (uint8_t *) malloc(data_len);
+	uint8_t	*buf = (uint8_t *)kmm_malloc(data_len + TAG_LENGTH);
+	uint8_t	*buf_flash = (uint8_t *)kmm_malloc(data_len + TAG_LENGTH + 4);
+	uint8_t	*data_plain = (uint8_t *)kmm_malloc(data_len);
 	uint8_t	*tag = buf + data_len;
 
 	memcpy(aes_gcm_iv, aes_test_iv_gcm, sizeof(aes_test_iv_gcm));
@@ -400,13 +455,13 @@ uint32_t rtl_write_storage_wrapper(uint32_t ss_idx, hal_data *data)
 
 exit:
 	if (buf != NULL) {
-		free(buf);
+		kmm_free(buf);
 	}
 	if (buf_flash != NULL) {
-		free(buf_flash);
+		kmm_free(buf_flash);
 	}
 	if (data_plain != NULL) {
-		free(data_plain);
+		kmm_free(data_plain);
 	}
 
 	return ret;
@@ -419,7 +474,7 @@ uint32_t rtl_read_storage_wrapper(uint32_t ss_idx, hal_data *data)
 	uint8_t dec_tag[16];
 	uint8_t tmpbuf[64];
 	uint8_t buf_length[4];
-	uint8_t *key = (uint8_t*)(((uint32_t) tmpbuf + 31) & (~31));	/* align to 32byte */
+	uint8_t *key = (uint8_t*)(((uint32_t)tmpbuf + 31) & (~31));	/* align to 32byte */
 	flash_t flash;
 	const uint8_t aes_gcm_iv[12];
 	const uint8_t aes_gcm_aad[20];
@@ -430,9 +485,9 @@ uint32_t rtl_read_storage_wrapper(uint32_t ss_idx, hal_data *data)
 
 	data_len = atoi(buf_length);
 
-	uint8_t *buf = (uint8_t *) malloc(data_len + TAG_LENGTH);
-	uint8_t *buf_flash = (uint8_t *) malloc(data_len + TAG_LENGTH + 4);
-	uint8_t *data_plain = (uint8_t *) malloc(data_len);
+	uint8_t *buf = (uint8_t *)kmm_malloc(data_len + TAG_LENGTH);
+	uint8_t *buf_flash = (uint8_t *)kmm_malloc(data_len + TAG_LENGTH + 4);
+	uint8_t *data_plain = (uint8_t *)kmm_malloc(data_len);
 	uint8_t *tag = buf + data_len;
 
 	memcpy(aes_gcm_iv, aes_test_iv_gcm, sizeof(aes_test_iv_gcm));
@@ -494,13 +549,13 @@ uint32_t rtl_read_storage_wrapper(uint32_t ss_idx, hal_data *data)
 
 exit:
 	if (buf != NULL) {
-		free(buf);
+		kmm_free(buf);
 	}
 	if (buf_flash != NULL) {
-		free(buf_flash);
+		kmm_free(buf_flash);
 	}
 	if (data_plain != NULL) {
-		free(data_plain);
+		kmm_free(data_plain);
 	}
 
 	return ret;

--- a/os/se/ameba/security_ameba_wrapper.c
+++ b/os/se/ameba/security_ameba_wrapper.c
@@ -16,24 +16,22 @@
 *
 ***************************************************************************************************/
 
+#include <sys/types.h>
+#include <string.h>
+#include <stdint.h>
+
 #include <tinyara/config.h>
 #include <semaphore.h>
 #include <tinyara/seclink_drv.h>
 #include <tinyara/security_hal.h>
 #include <tinyara/kmalloc.h>
 
-#include <stdint.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-
 #include <rom_ssl_ram_map.h>
 
 #define AWRAP_TAG "[AMEBA_WRAPPER]"
-
-#define AWRAP_ENTER                                                                 \
-	do {                                                                             \
-		sedbg(AWRAP_TAG"[INFO] %s %s:%d\n", __FUNCTION__, __FILE__, __LINE__);       \
+#define AWRAP_ENTER                                     \
+	do {                                                \
+		sedbg(AWRAP_TAG"%s:%d\n", __FILE__, __LINE__);  \
 	} while (0)
 
 #define HAL_COPY_DATA(in, out, len)                     \
@@ -240,9 +238,9 @@ extern uint32_t rtl_cryptoEngine_init_wrapper(void);
 extern uint32_t rtl_write_storage_wrapper(uint32_t ss_idx, hal_data *data);
 extern uint32_t rtl_read_storage_wrapper(uint32_t ss_idx, hal_data *data);
 extern uint32_t rtl_delete_storage_wrapper(uint32_t ss_idx);
-extern uint32_t rtl_cryptoAES_ecb_wrapper(uint8_t* key, uint32_t keylen, unsigned char* message, uint32_t msglen, unsigned char* pResult, uint8_t mode);
-extern uint32_t rtl_cryptoAES_cbc_wrapper(uint8_t* key, uint32_t keylen, unsigned char* message, uint32_t msglen, unsigned char* pResult, uint8_t mode);
-extern uint32_t rtl_cryptoAES_ctr_wrapper(uint8_t* key, uint32_t keylen, unsigned char* message, uint32_t msglen, unsigned char* pResult, uint8_t mode);
+extern uint32_t rtl_cryptoAES_ecb_wrapper(uint8_t *key, uint32_t keylen, unsigned char *message, uint32_t msglen, unsigned char *pResult, uint8_t mode);
+extern uint32_t rtl_cryptoAES_cbc_wrapper(uint8_t *key, uint32_t keylen, unsigned char *message, uint32_t msglen, unsigned char *pResult, uint8_t mode);
+extern uint32_t rtl_cryptoAES_ctr_wrapper(uint8_t *key, uint32_t keylen, unsigned char *message, uint32_t msglen, unsigned char *pResult, uint8_t mode);
 extern uint32_t rtl_read_factory_key_wrapper(hal_data *data);
 extern uint32_t rtl_read_factory_cert_wrapper(hal_data *data);
 
@@ -258,7 +256,7 @@ static int rtl_chk_stat(void)
 	return HAL_SUCCESS;
 }
 
-static void* my_calloc(size_t nelements, size_t elementSize)
+static void *my_calloc(size_t nelements, size_t elementSize)
 {
 	size_t size;
 	void *ptr = NULL;
@@ -272,7 +270,7 @@ static void* my_calloc(size_t nelements, size_t elementSize)
 	return ptr;
 }
 
-static void my_free(void* ptr)
+static void my_free(void *ptr)
 {
 	kmm_free(ptr);
 }


### PR DESCRIPTION
1. Resolve compile error by adding include semaphore.h
2. Fix key index convert, array index start from 0, key index start from 1
3. Added rtl_write_factory_cert_wrapper() API for future reference