### PR TITLE
arch/esp32: Type casting to sem_t * when passing an argument to sem_init

### DIFF
--- a/os/arch/xtensa/src/esp32/esp32_spi.c
+++ b/os/arch/xtensa/src/esp32/esp32_spi.c
@@ -1587,7 +1587,7 @@ struct spi_dev_s *up_spiinitialize(int port)
 #endif
 
 		/* Initialize a semaphore for spi dma */
-		sem_init(&g_spi_dma.dma_lock, 0, 1);
+		sem_init((sem_t *)&g_spi_dma.dma_lock, 0, 1);
 		priv->initiallized = true;
 	}
 


### PR DESCRIPTION
Fix build warning.

chip/esp32_spi.c: In function 'up_spiinitialize':
chip/esp32_spi.c:1590:12: warning: passing argument 1 of 'sem_init' discards 'volatile' qualifier from pointer target type [-Wdiscarded-qualifiers]
   sem_init(&g_spi_dma.dma_lock, 0, 1);
            ^
In file included from /root/tizenrt/os/include/sys/types.h:66:0,
                 from /root/tizenrt/os/include/stdio.h:76,
                 from chip/esp32_spi.c:24:
/root/tizenrt/os/include/semaphore.h:198:5: note: expected 'sem_t * {aka struct sem_s *}' but argument is of type 'volatile sem_t * {aka volatile struct sem_s *}'
 int sem_init(FAR sem_t *sem, int pshared, unsigned int value);