### PR TITLE
os/fs/smartfs : [BugFix] Add chainheader to new entry sector

### DIFF
--- a/os/fs/smartfs/smartfs_smart.c
+++ b/os/fs/smartfs/smartfs_smart.c
@@ -1372,7 +1372,7 @@ static int smartfs_readdir(struct inode *mountpt, struct fs_dirent_s *dir)
 			/* Now advance to the next entry */
 
 			dir->u.smartfs.fs_curroffset += entrysize;
-			if (dir->u.smartfs.fs_curroffset >= fs->fs_llformat.availbytes) {
+			if (dir->u.smartfs.fs_curroffset + entrysize >= fs->fs_llformat.availbytes) {
 				/* We advanced past the end of the sector.  Go to next sector */
 
 				dir->u.smartfs.fs_curroffset = sizeof(struct smartfs_chain_header_s);


### PR DESCRIPTION
When currennt entry sector is full, smartfs alloc new entry sector and chaining with
current sector. In this time there's no chain header in new entry sector, so error happened
when some of file operation called(c.f rmdir)