### PR TITLE
kernel/binary_manager: Free a semaphore holder directly when priority inheritance is disabled

### DIFF
--- a/os/kernel/binary_manager/binary_manager_load.c
+++ b/os/kernel/binary_manager/binary_manager_load.c
@@ -560,7 +560,7 @@ void binary_manager_release_binary_sem(int bin_idx)
 				if (holder && holder->htcb && holder->htcb->group && holder->htcb->group->tg_binidx == bin_idx) {
 					/* Increase semcount and release itself from holder */
 					sem->semcount++;
-					sem_freeholder(sem, holder);
+
 					/* And after releasing the kernel sem, there can be a task which waits that sem. So unblock the waiting task. */
 					sem_unblock_task(sem, holder->htcb);
 				}

--- a/os/kernel/semaphore/sem_holder.c
+++ b/os/kernel/semaphore/sem_holder.c
@@ -143,36 +143,6 @@ static inline FAR struct semholder_s *sem_allocholder(sem_t *sem)
 }
 
 /****************************************************************************
- * Name: sem_findholder
- ****************************************************************************/
-
-static FAR struct semholder_s *sem_findholder(sem_t *sem, FAR struct tcb_s *htcb)
-{
-	FAR struct semholder_s *pholder;
-
-	/* Try to find the holder in the list of holders associated with this
-	 * semaphore
-	 */
-
-#if CONFIG_SEM_PREALLOCHOLDERS > 0
-	for (pholder = sem->hhead; pholder; pholder = pholder->flink)
-#else
-	pholder = &sem->holder;
-#endif
-	{
-		if (pholder->htcb == htcb) {
-			/* Got it! */
-
-			return pholder;
-		}
-	}
-
-	/* The holder does not appear in the list */
-
-	return NULL;
-}
-
-/****************************************************************************
  * Name: sem_findorallocateholder
  ****************************************************************************/
 
@@ -796,6 +766,36 @@ void sem_destroyholder(FAR sem_t *sem)
 
 	sem->holder.htcb = NULL;
 #endif
+}
+
+/****************************************************************************
+ * Name: sem_findholder
+ ****************************************************************************/
+
+struct semholder_s *sem_findholder(sem_t *sem, FAR struct tcb_s *htcb)
+{
+	FAR struct semholder_s *pholder;
+
+	/* Try to find the holder in the list of holders associated with this
+	 * semaphore
+	 */
+
+#if CONFIG_SEM_PREALLOCHOLDERS > 0
+	for (pholder = sem->hhead; pholder; pholder = pholder->flink)
+#else
+	pholder = &sem->holder;
+#endif
+	{
+		if (pholder->htcb == htcb) {
+			/* Got it! */
+
+			return pholder;
+		}
+	}
+
+	/* The holder does not appear in the list */
+
+	return NULL;
 }
 
 /****************************************************************************

--- a/os/kernel/semaphore/sem_setprotocol.c
+++ b/os/kernel/semaphore/sem_setprotocol.c
@@ -116,9 +116,12 @@ int sem_setprotocol(FAR sem_t *sem, int protocol)
 
 			sem->flags |= PRIOINHERIT_FLAGS_DISABLE;
 
-			/* Remove any current holders */
+#ifndef CONFIG_BINMGR_RECOVERY
+			/* Remove any current holders if only fault recovery is disabled
+			 * because it is necessasary to keep a list of holders for fault recovery. */
 
 			sem_destroyholder(sem);
+#endif
 			return OK;
 
 		case SEM_PRIO_INHERIT:

--- a/os/kernel/semaphore/semaphore.h
+++ b/os/kernel/semaphore/semaphore.h
@@ -112,6 +112,7 @@ void sem_unblock_task(sem_t *sem, struct tcb_s *htcb);
 void sem_freeholder(sem_t *sem, FAR struct semholder_s *pholder);
 void sem_initholders(void);
 void sem_destroyholder(FAR sem_t *sem);
+struct semholder_s *sem_findholder(sem_t *sem, FAR struct tcb_s *htcb);
 void sem_addholder(FAR sem_t *sem);
 void sem_addholder_tcb(FAR struct tcb_s *tcb, FAR sem_t *sem);
 void sem_releaseholder(FAR sem_t *sem, FAR struct tcb_s *htcb);


### PR DESCRIPTION
All semphoare holders should be freed by binary_manager_release_binary_sem.
If priority inheritance is disabled, a holder is freed directly.
If not, it is freed after restoring priorities of threads holding semaphore in sem_restorebaseprio.