### PR TITLE
network: Add zerocopy feature in Network Manager.

### DIFF
--- a/os/drivers/wireless/scsc/netif.c
+++ b/os/drivers/wireless/scsc/netif.c
@@ -401,14 +401,14 @@ static void slsi_free_netdev(struct netdev *dev)
 	kmm_free(dev);
 }
 
-int slsi_linkoutput(struct netdev *dev, uint8_t *data, uint16_t dlen)
+int slsi_linkoutput(struct netdev *dev, void *buf, uint16_t dlen)
 {
 	struct netdev_vif *ndev_vif = netdev_priv(dev);
 	struct slsi_dev *sdev = ndev_vif->sdev;
 	struct max_buff *mbuf = NULL;
 	int ret = ERR_OK;
 	u8 *mbuf_data;
-
+	uint8_t *data = (uint8_t *)buf;
 	SLSI_INCR_DATA_PATH_STATS(sdev->dp_stats.tx_linkoutput_packets);
 
 	if (!ndev_vif->is_available) {

--- a/os/drivers/wireless/scsc/slsi_drv_netmgr.c
+++ b/os/drivers/wireless/scsc/slsi_drv_netmgr.c
@@ -116,7 +116,7 @@ void slsi_ethernetif_input(struct netdev *dev, u8_t *frame_ptr, u16_t len)
 	SLSI_MUTEX_LOCK(sdev->rx_data_mutex);
 
 	SLSI_INCR_DATA_PATH_STATS(sdev->dp_stats.rx_num_packets_given_to_lwip);
-	netdev_input(dev, frame_ptr, len);
+	netdev_input(dev, (void *)frame_ptr, len);
 
 	SLSI_MUTEX_UNLOCK(sdev->rx_data_mutex);
 }
@@ -819,7 +819,7 @@ trwifi_result_e slsidrv_set_autoconnect(struct netdev *dev, uint8_t check)
 	return result;
 }
 extern int slsi_set_multicast_list(struct netdev *dev, const struct in_addr *group, netdev_mac_filter_action action);
-extern int slsi_linkoutput(struct netdev *dev, uint8_t *data, uint16_t dlen);
+extern int slsi_linkoutput(struct netdev *dev, void *data, uint16_t dlen);
 
 struct netdev* slsidrv_register_dev(int sizeof_priv)
 {

--- a/os/include/tinyara/netmgr/netdev_mgr.h
+++ b/os/include/tinyara/netmgr/netdev_mgr.h
@@ -68,7 +68,18 @@ struct netdev {
 };
 
 struct nic_io_ops {
-	int (*linkoutput)(struct netdev *dev, uint8_t *data, uint16_t len);
+	/* DESC:
+	 * it is called when network stack has data to pass to wi-fi driver
+	 * if NET_NETMGR_ZEROCOPY is enabled then data is lwIP pbuf not to do memory copy.
+	 * PARAMETER
+	 * dev: network device which sends data.
+	 * data: data to send, if NET_NETMGR_ZEROCOPY is enabled then it's pbuf.
+	 * len: length of data, if NET_NETMGR_ZEROCOPY is enabled then it's 0.
+	 * RETURN
+	 * On success: return 0;
+	 * On error: return -1;
+	 */
+	int (*linkoutput)(struct netdev *dev, void *data, uint16_t len);
 	int (*igmp_mac_filter)(struct netdev *netif, const struct in_addr *group, netdev_mac_filter_action action);
 };
 
@@ -102,9 +113,19 @@ struct netdev_config {
  */
 struct netdev *netdev_register(struct netdev_config *config);
 /*
- * desc: NIC driver should call following fuction to pass the incoming data to network stack.
+ * DESC:
+ * NIC driver should call following fuction to pass the incoming data to network stack.
+ * if NET_NETMGR_ZEROCOPY is enabled then data is lwIP pbuf not to do memory copy.
+ * On NET_NETMGR_ZEROCOPY if netdev_input return error then the caller should free data by itself.
+ * PARAMETER
+ * dev: network device which send data to network stack
+ * data: data received, if NET_NETMGR_ZEROCOPY is enabled then it's pbuf.
+ * len: length of received data, if NET_NETMGR_ZEROCOPY is enabled then it's 0.
+ * RETURN
+ * On success: return 0
+ * On error: return -1;
  */
-int netdev_input(struct netdev *dev, uint8_t *data, uint16_t len);
+int netdev_input(struct netdev *dev, void *data, uint16_t len);
 /**
  * Configuration
  */
@@ -115,7 +136,7 @@ int netdev_get_mtu(struct netdev *dev, int *mtu);
 /*
  * Deprecate
  * return address of hwaddr
- * this function is provided to support slsi driver which is implemented before netmgr is appear.
+ * this function is provided to support slsi driver which is implemented before netmgr is implemented.
  * this function should not be used to new devices
  */
 uint8_t *netdev_get_hwaddr_ptr(struct netdev *dev);

--- a/os/net/netmgr/Kconfig
+++ b/os/net/netmgr/Kconfig
@@ -9,14 +9,22 @@ config NET_NETMGR
 	---help---
 		network refactoring
 
+if NET_NETMGR
+config NET_NETMGR_ZEROCOPY
+	bool "Enable zero-copy in Network Manager"
+	default n
+	---help---
+		Enable zero copy to have Wi-Fi driver handle pbuf directly and vice versa
+		this option should be handled carefully
+
 config NET_TASK_BIND
 	bool "Bind to the task"
 	depends on NSOCKET_DESCRIPTORS > 0
 	default n
 	---help---
 		Enable bind sockets to task
-		
-		
+endif
+
 menu "Network Device Operations"
 
 config NETDEV_PHY_IOCTL

--- a/os/net/netmgr/netdev_mgr.c
+++ b/os/net/netmgr/netdev_mgr.c
@@ -67,7 +67,7 @@ int netdev_get_hwaddr(struct netdev *dev, uint8_t *hwaddr, uint8_t *hwaddr_len)
 }
 
 
-int netdev_input(struct netdev *dev, uint8_t *data, uint16_t len)
+int netdev_input(struct netdev *dev, void *data, uint16_t len)
 {
 	return ND_NETOPS(dev, input)(dev, data, len);
 }

--- a/os/net/netmgr/netdev_mgr_internal.h
+++ b/os/net/netmgr/netdev_mgr_internal.h
@@ -67,8 +67,8 @@ struct netdev_ops {
 	int (*joingroup)(struct netdev *dev, struct in_addr *addr);
 	int (*leavegroup)(struct netdev *dev, struct in_addr *addr);
 
-	int (*input)(struct netdev *dev, uint8_t *data, uint16_t len);
-	int (*linkoutput)(struct netdev *dev, uint8_t *data, uint16_t len);
+	int (*input)(struct netdev *dev, void *data, uint16_t len);
+	int (*linkoutput)(struct netdev *dev, void *data, uint16_t len);
 	int (*igmp_mac_filter)(struct netdev *dev, const struct in_addr *group, netdev_mac_filter_action action);
 
 	/* statistics


### PR DESCRIPTION
To increase the performance, zerocopy feature is implemented.
it'll pass pbuf from lwIP to wi-Fi driver while it's sending data. so
the number of memory copy is reduced. On the contrary, the network manager
pass pbuf to lwIP directly when it receive data from Wi-Fi
driver. this feature is dependent to Wi-Fi driver. So it have to be
handled carefully