### PR TITLE
kernel/binary_manager: Skip crc checking of binary files when system booting

### DIFF
--- a/os/kernel/binary_manager/binary_manager.h
+++ b/os/kernel/binary_manager/binary_manager.h
@@ -220,7 +220,7 @@ void binary_manager_get_info_all(int request_pid);
 void binary_manager_send_response(char *q_name, void *response_msg, int msg_size);
 int binary_manager_register_ubin(char *name);
 void binary_manager_scan_ubin(void);
-int binary_manager_read_header(char *path, binary_header_t *header_data);
+int binary_manager_read_header(char *path, binary_header_t *header_data, bool crc_check);
 int binary_manager_create_entry(int requester_pid, char *bin_name, int version);
 void binary_manager_release_binary_sem(int bin_idx);
 void binary_manager_update_running_state(int bin_id);

--- a/os/kernel/binary_manager/binary_manager_binfile.c
+++ b/os/kernel/binary_manager/binary_manager_binfile.c
@@ -112,7 +112,7 @@ void binary_manager_scan_ubin(void)
 			/* Remove binary file which is not running */
 			if (DIRENT_ISFILE(entryp->d_type)) {
 				snprintf(filepath, CONFIG_PATH_MAX, "%s/%s", BINARY_DIR_PATH, entryp->d_name);
-				ret = binary_manager_read_header(filepath, &header_data);
+				ret = binary_manager_read_header(filepath, &header_data, false);
 				if (ret < 0) {
 					continue;
 				}


### PR DESCRIPTION
Binary manager validates header values of binary file without checking crc when system boot.
That's because it takes a long time to read whole file for checking crc value.
And then it validates header values and crc value when loading binary.