### PR TITLE
os/fs/smartfs : Adjust stat's st_blksize

### DIFF
--- a/os/fs/smartfs/smartfs_smart.c
+++ b/os/fs/smartfs/smartfs_smart.c
@@ -2057,7 +2057,7 @@ static void smartfs_stat_common(FAR struct smartfs_mountpt_s *fs,
 		}
 	}
 	buf->st_size = entry->datlen;
-	buf->st_blksize = fs->fs_llformat.availbytes;
+	buf->st_blksize = fs->fs_llformat.availbytes - sizeof(struct smartfs_chain_header_s);
 	buf->st_blocks = (buf->st_size + buf->st_blksize - 1) / buf->st_blksize;
 	buf->st_atime = 0;
 	buf->st_ctime = 0;


### PR DESCRIPTION
st_blksize represents blocksize of FileSystem I/O.
So user can use it size of buffer to use entire of sector.
But it include size of chainheader in sector, so reduce size of chainheader