### PR TITLE
os/fs/smartfs: Modify flow for assigning new file/dir entry

### DIFF
--- a/os/fs/smartfs/smartfs.h
+++ b/os/fs/smartfs/smartfs.h
@@ -380,7 +380,7 @@ int smartfs_finddirentry(struct smartfs_mountpt_s *fs, struct smartfs_entry_s *d
 
 int smartfs_createentry(struct smartfs_mountpt_s *fs, uint16_t parentdirsector, struct smartfs_entry_s *direntry);
 
-int smartfs_find_availableentry(struct smartfs_mountpt_s *fs, uint16_t parentdirsector, struct smartfs_entry_s *direntry);
+int smartfs_find_availableentry(struct smartfs_mountpt_s *fs, uint16_t parentdirsector, struct smartfs_entry_s *direntry, bool *new_chain);
 
 int smartfs_writeentry(struct smartfs_mountpt_s *fs, struct smartfs_entry_s new_entry, const char *filename, uint16_t type, mode_t mode, struct smartfs_entry_s *direntry, bool newchain);
 


### PR DESCRIPTION
- smartfs_find_availableentry returns the final entry
  for writing to, not just an available entry.
- smartfs_createentry will be called internally from
  find_availableentry wihtout passing control back to
  upper fs layer API.
- Basically now, find_availableentry first looks for an
  availableentry and otherwise allocates space for a
  new one via createentry.

Signed-off-by: Amogh Hassija <a.hassija@samsung.com>