### PR TITLE
os/fs/smartfs: Optimize number of loop iterations in smartfs_deleteentry()

### DIFF
--- a/os/fs/smartfs/smartfs_utils.c
+++ b/os/fs/smartfs/smartfs_utils.c
@@ -1579,6 +1579,10 @@ int smartfs_deleteentry(struct smartfs_mountpt_s *fs, struct smartfs_entry_s *en
 			if (ENTRY_VALID(direntry)) {
 				/* Count this entry */
 				count++;
+				if (count == 2) {
+					/* If valid entry count exceeds 1, we know we cannot release the sector */
+					break;
+				}
 			}
 
 			/* Advance to next entry */


### PR DESCRIPTION
- Exit the loop for counting entries when count>1.
- If count>1, we know that sector can't be released.

Signed-off-by: Amogh Hassija <a.hassija@samsung.com>