### PR TITLE
os/fs/smartfs: Write nextsector to parent after writing new entry

### DIFF
--- a/os/fs/smartfs/smartfs.h
+++ b/os/fs/smartfs/smartfs.h
@@ -380,9 +380,9 @@ int smartfs_finddirentry(struct smartfs_mountpt_s *fs, struct smartfs_entry_s *d
 
 int smartfs_createentry(struct smartfs_mountpt_s *fs, uint16_t parentdirsector, struct smartfs_entry_s *direntry);
 
-int smartfs_find_availableentry(struct smartfs_mountpt_s *fs, uint16_t parentdirsector, struct smartfs_entry_s *direntry, bool *new_chain);
+int smartfs_find_availableentry(struct smartfs_mountpt_s *fs, uint16_t *parentdirsector, struct smartfs_entry_s *direntry);
 
-int smartfs_writeentry(struct smartfs_mountpt_s *fs, struct smartfs_entry_s new_entry, const char *filename, uint16_t type, mode_t mode, struct smartfs_entry_s *direntry, bool newchain);
+int smartfs_writeentry(struct smartfs_mountpt_s *fs, struct smartfs_entry_s new_entry, const char *filename, uint16_t type, mode_t mode, struct smartfs_entry_s *direntry, uint16_t parentdirsector);
 
 int smartfs_alloc_firstsector(struct smartfs_mountpt_s *fs, uint16_t *sector, uint16_t type, FAR struct smartfs_ofile_s *sf);
 


### PR DESCRIPTION
- write entry to new sector first, then write chainheader->nestsector
  for old parent sector.
- If a power off occurs before the last step, smartfs recovery will
  handle the new isolated sector.
- remove unnecessary sector read from smartfs_createentry().

Signed-off-by: Amogh Hassija <a.hassija@samsung.com>