### PR TITLE
[Realtek][RTL8721CSM] Add 'make download' Function and AmebaD Image Download Tool

### DIFF
--- a/os/dbuild.sh
+++ b/os/dbuild.sh
@@ -78,6 +78,8 @@ function FIND_BINFILE()
 		BINFILE="${BINDIR}/tinyara_head${EXTNAME}"
 	elif [[ "${CONFIG_ARCH_BOARD}" == "cy4390x" ]]; then
 		BINFILE="${BINDIR}/tinyara_master_strip"
+	elif [[ "${CONFIG_ARCH_BOARD}" == "rtl8721csm" ]]; then
+		BINFILE="${BINDIR}/km0_km4_image2${EXTNAME}"
 	else
 		BINFILE="${BINDIR}/tinyara${EXTNAME}"
 	fi


### PR DESCRIPTION
1. Added AmebaD image download tool.
2. Added 'make download' function for all configurations.
3. Parameter $(2) is set as serial port number. ttyUSB1 is the default value.
4. Tested build and download functions in both tz enabled and disabled modes.