### PR TITLE
board/esp32_devkit: fix build errors and warnings

### DIFF
--- a/os/board/esp32_devkit/src/spiram.c
+++ b/os/board/esp32_devkit/src/spiram.c
@@ -60,11 +60,11 @@ we add more types of external RAM memory, this can be made into a more intellige
 #ifdef CONFIG_SPIRAM_SUPPORT
 
 
-#if CONFIG_SPIRAM_SPEED_40M && CONFIG_ESPTOOLPY_FLASHFREQ_40M
+#if defined(CONFIG_SPIRAM_SPEED_40M) && defined(CONFIG_ESPTOOLPY_FLASHFREQ_40M)
 #define PSRAM_SPEED PSRAM_CACHE_F40M_S40M
-#elif CONFIG_SPIRAM_SPEED_40M && CONFIG_ESPTOOLPY_FLASHFREQ_80M
+#elif defined(CONFIG_SPIRAM_SPEED_40M) && defined(CONFIG_ESPTOOLPY_FLASHFREQ_80M)
 #define PSRAM_SPEED PSRAM_CACHE_F80M_S40M
-#elif CONFIG_SPIRAM_SPEED_80M && CONFIG_ESPTOOLPY_FLASHFREQ_80M
+#elif defined(CONFIG_SPIRAM_SPEED_80M) && defined(CONFIG_ESPTOOLPY_FLASHFREQ_80M)
 #define PSRAM_SPEED PSRAM_CACHE_F80M_S80M
 #else
 #error "FLASH speed can only be equal to or higher than SRAM speed while SRAM is enabled!"
@@ -72,7 +72,7 @@ we add more types of external RAM memory, this can be made into a more intellige
 
 //manually redefined this size config
 #if CONFIG_KMM_REGIONS > 1
-#define CONFIG_SPIRAM_SIZE regionx_size[1]
+#define CONFIG_SPIRAM_SIZE kregionx_size[1]
 #else
 #define CONFIG_SPIRAM_SIZE 4194304
 #endif

--- a/os/board/esp32_devkit/src/spiram_psram.c
+++ b/os/board/esp32_devkit/src/spiram_psram.c
@@ -109,7 +109,7 @@ const uint32_t GPIO_PIN_MUX_REG[GPIO_PIN_COUNT] = {
 #define PSRAM_SET_BURST_LEN     0xC0
 #define PSRAM_DEVICE_ID         0x9F
 
-#if CONFIG_SPIRAM_TYPE_ESPPSRAM32
+#ifdef CONFIG_SPIRAM_TYPE_ESPPSRAM32
 
 #define PSRAM_MFG_ID_M          0xff
 #define PSRAM_MFG_ID_S             8
@@ -622,7 +622,7 @@ esp_err_t IRAM_ATTR psram_enable(psram_cache_mode_t mode, psram_vaddr_mode_t vad
 		gpio_matrix_out(PSRAM_CLK_IO, SIG_IN_FUNC225_IDX, 0, 0);
 		break;
 	}
-#if CONFIG_BOOTLOADER_VDDSDIO_BOOST_1_9V
+#ifdef CONFIG_BOOTLOADER_VDDSDIO_BOOST_1_9V
 	// For flash 80Mhz, we must update ldo voltage in case older version of bootloader didn't do this.
 	rtc_vddsdio_config_t cfg = rtc_vddsdio_get_config();
 	if (cfg.enable == 1 && cfg.tieh == RTC_VDDSDIO_TIEH_1_8V) {    // VDDSDIO regulator is enabled @ 1.8V
@@ -642,7 +642,7 @@ esp_err_t IRAM_ATTR psram_enable(psram_cache_mode_t mode, psram_vaddr_mode_t vad
 
 	uint32_t flash_id = g_rom_flashchip.device_id;
 	if (flash_id == FLASH_ID_GD25LQ32C) {
-#if CONFIG_SPIRAM_TYPE_ESPPSRAM32
+#ifdef CONFIG_SPIRAM_TYPE_ESPPSRAM32
 		// Set drive ability for 1.8v flash in 80Mhz.
 		SET_PERI_REG_BITS(PERIPHS_IO_MUX_SD_DATA0_U, FUN_DRV, 3, FUN_DRV_S);
 		SET_PERI_REG_BITS(PERIPHS_IO_MUX_SD_DATA1_U, FUN_DRV, 3, FUN_DRV_S);


### PR DESCRIPTION
1. use #if defined instead of #if because it checks definition, not value

CC:  spiram_psram.c
spiram_psram.c: In function 'psram_enable':
spiram_psram.c:625:5: warning: "CONFIG_BOOTLOADER_VDDSDIO_BOOST_1_9V" is not defined [-Wundef]
 #if CONFIG_BOOTLOADER_VDDSDIO_BOOST_1_9V
     ^
CC:  spiram.c
spiram.c:63:5: warning: "CONFIG_SPIRAM_SPEED_40M" is not defined [-Wundef]
 #if CONFIG_SPIRAM_SPEED_40M && CONFIG_ESPTOOLPY_FLASHFREQ_40M
     ^
spiram.c:65:7: warning: "CONFIG_SPIRAM_SPEED_40M" is not defined [-Wundef]
 #elif CONFIG_SPIRAM_SPEED_40M && CONFIG_ESPTOOLPY_FLASHFREQ_80M
       ^

2. use kregionx_size instead of regionx_size because it was renamed previous commit

spiram.c: In function 'esp_spiram_test':
spiram.c:75:28: error: 'regionx_size' undeclared (first use in this function)
 #define CONFIG_SPIRAM_SIZE regionx_size[1]
                            ^
spiram.c:90:13: note: in expansion of macro 'CONFIG_SPIRAM_SIZE'
  size_t s = CONFIG_SPIRAM_SIZE;
             ^
spiram.c:75:28: note: each undeclared identifier is reported only once for each function it appears in
 #define CONFIG_SPIRAM_SIZE regionx_size[1]
                            ^
spiram.c:90:13: note: in expansion of macro 'CONFIG_SPIRAM_SIZE'
  size_t s = CONFIG_SPIRAM_SIZE;
             ^
spiram.c: In function 'esp_spiram_get_size':
spiram.c:75:28: error: 'regionx_size' undeclared (first use in this function)
 #define CONFIG_SPIRAM_SIZE regionx_size[1]
                            ^
spiram.c:157:9: note: in expansion of macro 'CONFIG_SPIRAM_SIZE'
  return CONFIG_SPIRAM_SIZE;
         ^
spiram.c:158:1: warning: control reaches end of non-void function [-Wreturn-type]
 }
 ^
make[2]: *** [spiram.o] Error 1

Signed-off-by: sunghan-chang <sh924.chang@samsung.com>