### PR TITLE
fs/smartfs/nxfuse : Fix error nxfuse with new journaling

### DIFF
--- a/tools/nxfuse/Makefile
+++ b/tools/nxfuse/Makefile
@@ -75,6 +75,7 @@ SOURCES		=  $(wildcard $(SRCDIR)/*.c)
 
 ifeq ($(CONFIG_FS_SMARTFS),y)
 SOURCES		+= $(wildcard $(SRCDIR)/smartfs/*.c)
+SOURCES 	+= $(wildcard $(SRCDIR)/queue/*.c)
 endif
 
 SRCTMP		=  $(patsubst $(SRCDIR)/%,%,$(SOURCES))
@@ -90,6 +91,8 @@ all: init $(APPNAME)
 init:
 	@mkdir -p $(OBJDIR)/smartfs
 	@mkdir -p $(DEPDIR)/smartfs
+	@mkdir -p $(OBJDIR)/queue
+	@mkdir -p $(DEPDIR)/queue
 
 #Include our built dependencies
 -include $(DEPS)

--- a/tools/nxfuse/mknxfuse.sh
+++ b/tools/nxfuse/mknxfuse.sh
@@ -43,6 +43,7 @@ ln -sf $SMARTFSDIR/smartfs.h $SMARTFS_TMPDIR/smartfs.h
 ln -sf $SMARTFSDIR/smartfs_utils.c $SMARTFS_TMPDIR/smartfs_utils.c
 ln -sf $SMARTFSDIR/smartfs_smart.c $SMARTFS_TMPDIR/smartfs_smart.c
 ln -sf $SMARTFSDIR/../driver/mtd/smart.c $SMARTFS_TMPDIR/smart.c
+ln -svf $BASE_DIR/lib/libc/queue $SRCDIR/
 
 #Header Files
 ln -sf $BASE_INCLUDE_DIR/crc16.h $DEST_INLCUDE_DIR/crc16.h
@@ -68,10 +69,6 @@ ln -sf $BASE_INCLUDE_DIR/tinyara/fs/fs.h $DEST_INLCUDE_DIR/tinyara/fs/fs.h
 ln -sf $BASE_DIR/lib/libc/misc/lib_crc16.c $SRCDIR/lib_crc16.c
 ln -sf $BASE_DIR/lib/libc/misc/lib_crc32.c $SRCDIR/lib_crc32.c
 ln -sf $BASE_DIR/lib/libc/misc/lib_crc8.c $SRCDIR/lib_crc8.c
-ln -sf $BASE_DIR/lib/libc/queue/sq_rem.c $SRCDIR/sq_rem.c
-ln -sf $BASE_DIR/lib/libc/queue/sq_addlast.c $SRCDIR/sq_addlast.c
-ln -sf $BASE_DIR/lib/libc/queue/sq_remfirst.c $SRCDIR/sq_remfirst.c
-ln -sf $BASE_DIR/lib/libc/queue/sq_remafter.c $SRCDIR/sq_remafter.c
 
 echo "Copying Done"
 
@@ -103,6 +100,7 @@ rm -rf $DEST_INLCUDE_DIR/tinyara/fs/ioctl.h
 rm -rf $DEST_INLCUDE_DIR/sys
 rm -rf $DEST_INLCUDE_DIR/tinyara/fs
 rm -rf $SMARTFS_TMPDIR
+rm -rf $SRCDIR/queue
 rm -rf $DEPDIR
 rm -rf $OBJDIR
 

--- a/tools/nxfuse/mksmartfsimg.sh
+++ b/tools/nxfuse/mksmartfsimg.sh
@@ -67,22 +67,32 @@ mkdir $CONTENTSDIR/$BOARDNAME/mnt/bins
 fi
 fi
 
+echo "make a dummy"
 #Make a dummy .bin file
 touch $BINDIR/$BINNAME
 
+echo "make image file"
 # Making image file
-dd if=/dev/zero of=$BINDIR/$BINNAME bs=$blksize count=$blkcount
+if [ "${CONFIG_SMARTFS_ERASEDSTATE}" == 0xff ]; then
+	dd if=/dev/zero bs=$blksize count=$blkcount | tr "\000" "\377" > $BINDIR/$BINNAME
+else
+	dd if=/dev/zero of=$BINDIR/$BINNAME bs=$blksize count=$blkcount
+fi
 
+echo "copy the nxfuse"
 #Copying the nxfuse
 cp $NXFUSEDIR/nxfuse .
 
 
+echo "Now format image"
 # Formatting
 ./nxfuse -p $pagesize -e $erasesize -l $blksize -t smartfs -m $BINDIR/$BINNAME || exit 1
 
+echo "mount binary"
 # Mounting mnt
 ./nxfuse -o nonempty -p $pagesize -e $erasesize -l $blksize -t smartfs $CONTENTSDIR/$BOARDNAME/mnt $BINDIR/$BINNAME || exit 1
 
+echo "Copy files"
 # Copying files to smartfs file system
 cp -rf $CONTENTSDIR/$BOARDNAME/base-files/* $CONTENTSDIR/$BOARDNAME/mnt/
 


### PR DESCRIPTION
New journaling initialized before smart_scan, so if write journal data failed, fusing also failed
1. Fix unnecessary reset of journal state when checkout
2. Set 0xFF when fuse make image
3. Improve logic of filemtd_write