### PR TITLE
os/binfmt : Fix wrong RO section address

### DIFF
--- a/os/binfmt/binfmt_loadbinary.c
+++ b/os/binfmt/binfmt_loadbinary.c
@@ -226,7 +226,7 @@ int load_binary(int binary_idx, FAR const char *filename, load_attr_t *load_attr
 	/* Print Binary section address & size details */
 
 	binfo("[%s] text    start addr =  0x%x  size = %u\n", bin->bin_name, (uint32_t)bin->alloc[ALLOC_TEXT], bin->textsize);
-	binfo("[%s] rodata  start addr =  0x%x  size = %u\n", bin->bin_name, (uint32_t)bin->alloc[ALLOC_DATA], bin->rosize);
+	binfo("[%s] rodata  start addr =  0x%x  size = %u\n", bin->bin_name, (uint32_t)bin->alloc[ALLOC_RO], bin->rosize);
 	binfo("[%s] data    start addr =  0x%x  size = %u\n", bin->bin_name, (uint32_t)bin->datastart, bin->datasize);
 	binfo("[%s] bss     start addr =  0x%x  size = %u\n", bin->bin_name, (uint32_t)bin->bssstart, bin->bsssize);
 

--- a/os/binfmt/libelf/libelf_sections.c
+++ b/os/binfmt/libelf/libelf_sections.c
@@ -197,7 +197,7 @@ void elf_save_bin_section_addr(struct binary_s *bin)
 
 		binfo("[%s] text_addr : %x\n", bin_info->bin_name, bin_info->text_addr);
 #ifdef CONFIG_OPTIMIZE_APP_RELOAD_TIME
-		bin_info->rodata_addr = (uint32_t)bin->alloc[ALLOC_DATA];
+		bin_info->rodata_addr = (uint32_t)bin->alloc[ALLOC_RO];
 		bin_info->data_addr = (uint32_t)bin->datastart;
 		bin_info->bss_addr = (uint32_t)bin->bssstart;
 


### PR DESCRIPTION
RO section should be from ALLOC_RO, not from ALLOC_DATA.
There are two wrong settings, so fix them.