### PR TITLE
os/fs/smartfs: Modify sequence for writing new file entry/data with CRC enabled

### DIFF
--- a/os/fs/smartfs/smartfs.h
+++ b/os/fs/smartfs/smartfs.h
@@ -175,6 +175,10 @@
 #define INODE_STATE_FILE          (CONFIG_NXFFS_ERASEDSTATE ^ 0x22)
 #define INODE_STATE_DELETED       (CONFIG_NXFFS_ERASEDSTATE ^ 0xaa)
 
+/* Smartfs worbuffer maxuimum length */
+
+#define SMARTFS_MAX_WORKBUFFER_LEN 256
+
 /* Directory entry flag definitions */
 
 #define SMARTFS_DIRENT_EMPTY      0x8000	/* Set to non-erase state when entry used */
@@ -262,6 +266,7 @@ struct smartfs_entry_s {
 	FAR char *name;				/* inode name */
 	uint32_t utc;				/* Time stamp */
 	uint32_t datlen;			/* Length of inode data */
+	uint16_t prev_parent;		/* To track the processed directory sector to find parent for entry. Holds last sctive sector in parent chain if new sector has tobe chained */
 };
 
 /* This is an on-device representation of the SMART inode which exists on
@@ -376,13 +381,13 @@ int smartfs_mount(struct smartfs_mountpt_s *fs, bool writeable);
 
 int smartfs_unmount(struct smartfs_mountpt_s *fs);
 
-int smartfs_finddirentry(struct smartfs_mountpt_s *fs, struct smartfs_entry_s *direntry, const char *relpath, uint16_t *parentdirsector, const char **filename);
+int smartfs_finddirentry(struct smartfs_mountpt_s *fs, struct smartfs_entry_s *direntry, const char *relpath, const char **filename);
 
-int smartfs_createentry(struct smartfs_mountpt_s *fs, uint16_t parentdirsector, struct smartfs_entry_s *direntry);
+int smartfs_createdirentry(struct smartfs_mountpt_s *fs, struct smartfs_entry_s *direntry);
 
-int smartfs_find_availableentry(struct smartfs_mountpt_s *fs, uint16_t *parentdirsector, struct smartfs_entry_s *direntry);
+int smartfs_find_availableentry(struct smartfs_mountpt_s *fs, struct smartfs_entry_s *direntry);
 
-int smartfs_writeentry(struct smartfs_mountpt_s *fs, struct smartfs_entry_s new_entry, const char *filename, uint16_t type, mode_t mode, struct smartfs_entry_s *direntry, uint16_t parentdirsector);
+int smartfs_writeentry(struct smartfs_mountpt_s *fs, struct smartfs_entry_s new_entry, const char *filename, uint16_t type, mode_t mode, struct smartfs_entry_s *direntry);
 
 int smartfs_alloc_firstsector(struct smartfs_mountpt_s *fs, uint16_t *sector, uint16_t type, FAR struct smartfs_ofile_s *sf);
 

--- a/os/fs/smartfs/smartfs.h
+++ b/os/fs/smartfs/smartfs.h
@@ -225,8 +225,10 @@
 
 /* Buffer flags (when CRC enabled) */
 
+#define SMARTFS_BFLAG_UNMOD       0x00	/* Set if there are no unsynced changes in sf->buffer */
 #define SMARTFS_BFLAG_DIRTY       0x01	/* Set if data changed in the sector */
 #define SMARTFS_BFLAG_NEWALLOC    0x02	/* Set if sector not written since alloc */
+#define SMARTFS_BFLAG_NEW_ENTRY   0x04	/* Set if the open file structure object corresponds to a new file entry yet to be written to MTD */
 
 #define SMARTFS_ERASEDSTATE_16BIT (uint16_t)((CONFIG_SMARTFS_ERASEDSTATE << 8) | \
 								  CONFIG_SMARTFS_ERASEDSTATE)
@@ -398,9 +400,14 @@ int smartfs_deleteentry(struct smartfs_mountpt_s *fs, struct smartfs_entry_s *en
 int smartfs_countdirentries(struct smartfs_mountpt_s *fs, struct smartfs_entry_s *entry);
 
 int smartfs_truncatefile(struct smartfs_mountpt_s *fs, struct smartfs_entry_s *entry, FAR struct smartfs_ofile_s *sf);
+
 int smartfs_shrinkfile(FAR struct smartfs_mountpt_s *fs, FAR struct smartfs_ofile_s *sf, off_t length);
+
 int smartfs_extendfile(FAR struct smartfs_mountpt_s *fs, FAR struct smartfs_ofile_s *sf, off_t length);
+
 void smartfs_setbuffer(struct smart_read_write_s *rw, uint16_t logsector, uint16_t offset, uint16_t count, uint8_t *buffer);
+
+void smartfs_set_entry_flags(struct smartfs_entry_s *new_entry, mode_t mode, uint16_t type);
 
 uint16_t smartfs_rdle16(FAR const void *val);
 

--- a/os/fs/smartfs/smartfs_utils.c
+++ b/os/fs/smartfs/smartfs_utils.c
@@ -1284,12 +1284,12 @@ int smartfs_writeentry(struct smartfs_mountpt_s *fs, struct smartfs_entry_s new_
 		   Chainheader is written along with the 1st entry.
 		   So currently, smart_readsector will fail to invalidate CRC on empty sector
 		 */
-		tmp_buf = (char *)kmm_malloc(entrysize + sizeof(struct smartfs_entry_header_s));
+		tmp_buf = (char *)kmm_malloc(entrysize + sizeof(struct smartfs_chain_header_s));
 		if (tmp_buf == NULL) {
 			fdbg("Unable to allocate memory\n");
 			return -ENOMEM;
 		}
-		memset(tmp_buf, CONFIG_SMARTFS_ERASEDSTATE, entrysize + sizeof(struct smartfs_entry_header_s));
+		memset(tmp_buf, CONFIG_SMARTFS_ERASEDSTATE, entrysize + sizeof(struct smartfs_chain_header_s));
 		entry = (struct smartfs_entry_header_s *)&tmp_buf[sizeof(struct smartfs_chain_header_s)];
 		chainheader = (struct smartfs_chain_header_s *)&tmp_buf[0];
 		chainheader->type = SMARTFS_SECTOR_TYPE_DIR;
@@ -1483,7 +1483,7 @@ int smartfs_invalidateentry(struct smartfs_mountpt_s *fs, uint16_t parentdirsect
 
 	entry_flags = (uint8_t *)&fs->fs_rwbuffer[0];
 #if CONFIG_SMARTFS_ERASEDSTATE == 0xFF
-#if CONFIG_SMARTFS_ALIGNED_ACCESS
+#ifdef CONFIG_SMARTFS_ALIGNED_ACCESS
 	smartfs_wrle16(entry_flags, smartfs_rdle16(entry_flags) & ~SMARTFS_DIRENT_ACTIVE);
 #else
 	*entry_flags &= ~SMARTFS_DIRENT_ACTIVE;


### PR DESCRIPTION
- When CRC is enabled
- Sync file data with MTD first.
- Then write the new file entry ot MTD.
- If the entry was written to a new sector on the parent directory,
  Chain the new sector to the parent directory now.

Signed-off-by: Amogh Hassija <a.hassija@samsung.com>