### PR TITLE
kernel/semaphore : Save semaphore holders when binary manager is enabled

### DIFF
--- a/os/include/semaphore.h
+++ b/os/include/semaphore.h
@@ -73,8 +73,8 @@
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
-/* Save semaphore holder data when priority inheritance or binary manager recovery is enabled. */
-#if defined(CONFIG_PRIORITY_INHERITANCE) || defined(CONFIG_BINMGR_RECOVERY)
+/* Save semaphore holder data when priority inheritance or binary manager is enabled. */
+#if defined(CONFIG_PRIORITY_INHERITANCE) || defined(CONFIG_BINARY_MANAGER)
 #define SAVE_SEM_HOLDER 1
 #endif
 
@@ -119,7 +119,7 @@ struct semholder_s {
  * @brief Structure of generic semaphore
  */
 struct sem_s {
-#ifdef CONFIG_BINMGR_RECOVERY
+#ifdef CONFIG_BINARY_MANAGER
 	struct sem_s *flink;		/* Support for singly linked lists. */
 #endif
 	int16_t semcount;			/* >0 -> Num counts available */
@@ -151,13 +151,13 @@ typedef struct sem_s sem_t;
  * @brief Sem initializer
  */
 #ifdef SAVE_SEM_HOLDER
-#ifdef CONFIG_BINMGR_RECOVERY
+#ifdef CONFIG_BINARY_MANAGER
 #if CONFIG_SEM_PREALLOCHOLDERS > 0
 #define SEM_INITIALIZER(c) {NULL, (c), FLAGS_INITIALIZED, NULL} /* flink, semcount, flags, hhead */
 #else
 #define SEM_INITIALIZER(c) {NULL, (c), FLAGS_INITIALIZED, SEMHOLDER_INITIALIZER} /* flink, semcount, flags, holder */
 #endif
-#else // CONFIG_BINMGR_RECOVERY
+#else // CONFIG_BINARY_MANAGER
 #if CONFIG_SEM_PREALLOCHOLDERS > 0
 #define SEM_INITIALIZER(c) {(c), FLAGS_INITIALIZED, NULL} /* semcount, flags, hhead */
 #else

--- a/os/kernel/semaphore/Make.defs
+++ b/os/kernel/semaphore/Make.defs
@@ -57,13 +57,12 @@ CSRCS += sem_post.c sem_recover.c sem_reset.c sem_waitirq.c sem_tickwait.c
 
 ifeq ($(CONFIG_PRIORITY_INHERITANCE),y)
 CSRCS += sem_initialize.c sem_holder.c sem_setprotocol.c
-ifeq ($(CONFIG_BINMGR_RECOVERY),y)
+ifeq ($(CONFIG_BINARY_MANAGER),y)
 CSRCS += sem_list.c
 endif
-else ifeq ($(CONFIG_BINMGR_RECOVERY),y)
+else ifeq ($(CONFIG_BINARY_MANAGER),y)
 CSRCS += sem_holder.c sem_list.c
 endif
-
 # Include semaphore build support
 
 DEPPATH += --dep-path semaphore


### PR DESCRIPTION
Semaphore holders should be saved to be released when binary recovery or binary update.