### PR TITLE
os/include/tinyara/wqueue.h : Modify hpwork default priority description

### DIFF
--- a/os/include/tinyara/wqueue.h
+++ b/os/include/tinyara/wqueue.h
@@ -81,7 +81,7 @@
  *   if memory reclamation is of high priority).  If CONFIG_SCHED_HPWORK
  *   is enabled, then the following options can also be used:
  * CONFIG_SCHED_HPWORKPRIORITY - The execution priority of the high-
- *   priority worker thread.  Default: 224
+ *   priority worker thread.  Default: 201
  * CONFIG_SCHED_HPWORKSTACKSIZE - The stack size allocated for the worker
  *   thread.  Default: 2048.
  * CONFIG_SIG_SIGWORK - The signal number that will be used to wake-up


### PR DESCRIPTION
The priority of hpwork-queue should be less than binary manager.
So it was decreased to 201, but the description was not.
Fix the description.