### PR TITLE
os/arch/arm/Kconfig : Remove unnecessary MPU select option

### DIFF
--- a/os/arch/arm/Kconfig
+++ b/os/arch/arm/Kconfig
@@ -69,7 +69,6 @@ config ARCH_CHIP_STM32L4
 config ARCH_CHIP_AMEBAD
 	bool "Realtek AMEBAD"
 	select ARCH_HAVE_MPU
-	select ARMV8M_MPU
 	select ARCH_HAVE_I2CRESET
 	select ARCH_HAVE_HEAPCHECK if DEBUG
 	---help---


### PR DESCRIPTION
ARCH_HAVE_MPU should be selected because amebad hw supports the mpu.
But ARMV8M_MPU is an optional config which can be enabled if needed.