### PR TITLE
os/fs/smartfs : Fix truncate issues

### DIFF
--- a/apps/examples/testcase/le_tc/filesystem/fs_main.c
+++ b/apps/examples/testcase/le_tc/filesystem/fs_main.c
@@ -5109,9 +5109,11 @@ static void tc_libc_stdio_stdinstream_invalid_permission_n(void)
 	vfs_mount();
 	stream = fopen(VFS_FILE_PATH, "w+");
 	TC_ASSERT_NEQ_CLEANUP("fopen", stream, NULL, vfs_unmount());
+	fclose(stream);
 
 	/* Testcase */
 	/* Negative case, file opened with inappropriate permission */
+	stream = fopen(VFS_FILE_PATH, "w+");
 	lib_stdinstream((FAR struct lib_stdinstream_s *)&stdinstream, stream);
 	TC_ASSERT_EQ_CLEANUP("lib_stdinstream", stdinstream.stream, stream, fclose(stream); vfs_unmount());
 
@@ -5279,9 +5281,11 @@ static void tc_libc_stdio_stdsistream_invalid_permission_n(void)
 	vfs_mount();
 	stream = fopen(VFS_FILE_PATH, "w+");
 	TC_ASSERT_NEQ_CLEANUP("fopen", stream, NULL, vfs_unmount());
+	fclose(stream);
 
 	/* Testcase */
 	/* Negative case, file opened with inappropriate permission */
+	stream = fopen(VFS_FILE_PATH, "w+");
 	lib_stdsistream((FAR struct lib_stdsistream_s *)&stdsistream, stream);
 	TC_ASSERT_EQ_CLEANUP("lib_stdsistream", stdsistream.stream, stream, fclose(stream); vfs_unmount());
 

--- a/os/fs/smartfs/smartfs_smart.c
+++ b/os/fs/smartfs/smartfs_smart.c
@@ -331,11 +331,14 @@ static int smartfs_open(FAR struct file *filep, const char *relpath, int oflags,
 		 */
 
 		if (sf->currsector != SMARTFS_ERASEDSTATE_16BIT) {
-			smartfs_setbuffer(&readwrite, sf->currsector, 0, fs->fs_llformat.availbytes, (uint8_t *)sf->buffer);
-			ret = FS_IOCTL(fs, BIOC_READSECT, (unsigned long) &readwrite);
-			if (ret < 0) {
-				fdbg("ERROR: Error %d reading sector %d header\n", ret, sf->currsector);
-				goto errout_with_buffer;
+			/* For truncate, we already read header and set data in sf->buffer */
+			if (((oflags & (O_CREAT | O_TRUNC)) == 0) || (oflags & O_APPEND)) {
+				smartfs_setbuffer(&readwrite, sf->currsector, 0, fs->fs_llformat.availbytes, (uint8_t *)sf->buffer);
+				ret = FS_IOCTL(fs, BIOC_READSECT, (unsigned long) &readwrite);
+				if (ret < 0) {
+					fdbg("ERROR: Error %d reading sector %d header\n", ret, sf->currsector);
+					goto errout_with_buffer;
+				}
 			}
 		}
 	}


### PR DESCRIPTION
1. If user open with flag O_TRUNCATE but do not close, then it never update flash
   if sector buffer is enabled.
2. If O_TRUNCATE is set when open, do not read whole of sector because it already
   read by smartfs_truncatefile