### PR TITLE
mm/mm_heap/mm_getheap : Modify return type of mm_get_app_heap_node

### DIFF
--- a/os/mm/mm_heap/mm_getheap.c
+++ b/os/mm/mm_heap/mm_getheap.c
@@ -105,7 +105,7 @@ void mm_remove_app_heap_list(struct mm_heap_s *heap)
 	}
 }
 
-static struct mm_heap_s *mm_get_app_heap_node(void *address)
+static app_heap_s *mm_get_app_heap_node(void *address)
 {
 	/* First, search the address in list of app heaps */
 	app_heap_s *node = (app_heap_s *)dq_peek(&app_heap_q);


### PR DESCRIPTION
mm_get_app_heap_node returns app_heap structure, but its return type was mm_heap_s.
For avoiding build error, change the return type to app_heap_s.