### PR TITLE
os: Fix build warnings

### DIFF
--- a/os/binfmt/libelf/libelf_addrenv.c
+++ b/os/binfmt/libelf/libelf_addrenv.c
@@ -105,10 +105,11 @@ static int allocateregions(FAR struct elf_loadinfo_s *loadinfo)
 		}
 	}
 
-	loadinfo->binp->ramstart = *allocs[0] = (uintptr_t)kmm_memalign(sizes[0], totalsize);
-	if (loadinfo->binp->ramstart == NULL) {
+	*allocs[0] = (uintptr_t)kmm_memalign(sizes[0], totalsize);
+	if (*allocs[0] == (uintptr_t)NULL) {
 		return -ENOMEM;
 	}
+	loadinfo->binp->ramstart = (uint32_t)*allocs[0];
 	*allocs[1] = *allocs[0] + sizes[0];
 	*allocs[2] = *allocs[1] + sizes[1];
 

--- a/os/drivers/testcase/testcase_drv.c
+++ b/os/drivers/testcase/testcase_drv.c
@@ -160,7 +160,7 @@ static int testcase_drv_ioctl(FAR struct file *filep, int cmd, unsigned long arg
 			if (binid == 0) {
 				binid++;
 			}
-			obj->addr = BIN_LOADINFO(binid)->uheap;
+			obj->addr = (volatile uint32_t *)BIN_LOADINFO(binid)->uheap;
 			break;
 		}
 		default:

--- a/os/kernel/binary_manager/binary_manager_binfile.c
+++ b/os/kernel/binary_manager/binary_manager_binfile.c
@@ -157,7 +157,7 @@ int binary_manager_scan_ubin(int bin_idx)
 	int latest_idx;
 	char *bin_name;
 	binary_header_t header_data;
-	char filepath[FILES_PER_BIN][CONFIG_PATH_MAX];
+	char filepath[CONFIG_PATH_MAX];
 
 	bmvdbg("Open a directory, %s\n", BINARY_DIR_PATH);
 


### PR DESCRIPTION
Fix build warnings because of wrong type definition or type casting.