### PR TITLE
loadable_sample/wifiapp : Remove unused variable

### DIFF
--- a/loadable_apps/loadable_sample/wifiapp/recovery.c
+++ b/loadable_apps/loadable_sample/wifiapp/recovery.c
@@ -33,7 +33,6 @@
 static void *assert_thread(void *index)
 {
 	int type;
-	volatile uint32_t *addr;
 	int tc_fd = open(TESTCASE_DRVPATH, O_WRONLY);
 	struct mputest_arg_s obj;
 	int ret;


### PR DESCRIPTION
Unused variable makes build warning. So remove it.