### PR TITLE
add RTC driver initialization in arch for artik05x, sidk_s5jt200, stm…

### DIFF
--- a/os/arch/arm/src/s5j/s5j_rtc.h
+++ b/os/arch/arm/src/s5j/s5j_rtc.h
@@ -87,29 +87,20 @@ typedef void (*alarmcb_t)(void);
  * Public Functions
  ****************************************************************************/
 /****************************************************************************
- * Name: s5j_rtc_lowerhalf
+ * Name: s5j_rtc_initialize
  *
  * Description:
- *   Instantiate the RTC lower half driver for the S5J.
- *   General usage:
- *
- *     #include <tinyara/rtc.h>
- *     #include "s5j_rtc.h"
- *
- *     struct rtc_lowerhalf_s *lower;
- *     lower = s5j_rtc_lowerhalf();
- *     rtc_initialize(0, lower);
+ *   Register the RTC driver to provide RTC functionality
  *
  * Input Parameters:
  *   None
  *
  * Returned Value:
- *   On success, a non-NULL RTC lower interface is returned. NULL is
- *   returned on any failure.
+ *   None
  *
  ****************************************************************************/
 #ifdef CONFIG_RTC_DRIVER
-FAR struct rtc_lowerhalf_s *s5j_rtc_lowerhalf(void);
+void s5j_rtc_initialize(void);
 #endif /* CONFIG_RTC_DRIVER */
 
 #undef EXTERN

--- a/os/arch/arm/src/s5j/s5j_rtc_lowerhalf.c
+++ b/os/arch/arm/src/s5j/s5j_rtc_lowerhalf.c
@@ -59,6 +59,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <errno.h>
+#include <debug.h>
 
 #include <tinyara/arch.h>
 #include <tinyara/rtc.h>
@@ -290,29 +291,29 @@ static struct s5j_lowerhalf_s g_rtc_lowerhalf = {
  * Public Functions
  ****************************************************************************/
 /****************************************************************************
- * Name: s5j_rtc_lowerhalf
+ * Name: s5j_rtc_initialize
  *
  * Description:
- *   Instantiate the RTC lower half driver for the S5J.
- *   General usage:
- *
- *     #include <tinyara/rtc.h>
- *     #include "s5j_rtc.h"
- *
- *     struct rtc_lowerhalf_s *lower;
- *     lower = s5j_rtc_lowerhalf();
- *     rtc_initialize(0, lower);
+ *   Register the RTC driver to provide RTC functionality
  *
  * Input Parameters:
  *   None
  *
  * Returned Value:
- *   On success, a non-NULL RTC lower interface is returned. NULL is
- *   returned on any failure.
+ *   None
  *
  ****************************************************************************/
-FAR struct rtc_lowerhalf_s *s5j_rtc_lowerhalf(void)
+
+void s5j_rtc_initialize(void)
 {
-	return (FAR struct rtc_lowerhalf_s *)&g_rtc_lowerhalf;
+	struct rtc_lowerhalf_s *lower = (struct rtc_lowerhalf_s *)&g_rtc_lowerhalf;
+	int ret;
+
+	/* Bind the lower half driver and register the combined RTC driver as /dev/rtc0 */
+
+	ret = rtc_initialize(0, lower);
+	if (ret < 0) {
+		lldbg("Failed to register the RTC driver: %d\n", ret);
+	}
 }
 #endif /* CONFIG_RTC_DRIVER */

--- a/os/arch/arm/src/stm32l4/stm32l4_rtc.h
+++ b/os/arch/arm/src/stm32l4/stm32l4_rtc.h
@@ -296,30 +296,21 @@ int stm32l4_rtc_cancelperiodic(void);
 #endif /* CONFIG_RTC_PERIODIC */
 
 /****************************************************************************
- * Name: stm32l4_rtc_lowerhalf
+ * Name: stm32l4_rtc_initialize
  *
  * Description:
- *   Instantiate the RTC lower half driver for the STM32L4.  General usage:
- *
- *     #include <tinyara/timers/rtc.h>
- *     #include "stm32l4_rtc.h>
- *
- *     struct rtc_lowerhalf_s *lower;
- *     lower = stm32l4_rtc_lowerhalf();
- *     rtc_initialize(0, lower);
+ *   Register the RTC driver to provide RTC functionality
  *
  * Input Parameters:
  *   None
  *
  * Returned Value:
- *   On success, a non-NULL RTC lower interface is returned.  NULL is
- *   returned on any failure.
+ *   None
  *
  ****************************************************************************/
 
 #ifdef CONFIG_RTC_DRIVER
-struct rtc_lowerhalf_s;
-FAR struct rtc_lowerhalf_s *stm32l4_rtc_lowerhalf(void);
+void stm32l4_rtc_initialize(void);
 #endif
 
 #undef EXTERN

--- a/os/arch/arm/src/stm32l4/stm32l4_rtc_lowerhalf.c
+++ b/os/arch/arm/src/stm32l4/stm32l4_rtc_lowerhalf.c
@@ -44,9 +44,10 @@
 #include <stdbool.h>
 #include <string.h>
 #include <errno.h>
+#include <debug.h>
 
 #include <tinyara/arch.h>
-#include <tinyara/timers/rtc.h>
+#include <tinyara/rtc.h>
 
 #include "chip.h"
 #include "stm32l4_rtc.h"
@@ -697,32 +698,30 @@ static int stm32l4_cancelperiodic(FAR struct rtc_lowerhalf_s *lower, int id)
  ****************************************************************************/
 
 /****************************************************************************
- * Name: stm32l4_rtc_lowerhalf
+ * Name: stm32l4_rtc_initialize
  *
  * Description:
- *   Instantiate the RTC lower half driver for the STM32.  General usage:
- *
- *     #include <tinyara/timers/rtc.h>
- *     #include "stm32l4_rtc.h>
- *
- *     struct rtc_lowerhalf_s *lower;
- *     lower = stm32l4_rtc_lowerhalf();
- *     rtc_initialize(0, lower);
+ *   Register the RTC driver to provide RTC functionality
  *
  * Input Parameters:
  *   None
  *
  * Returned Value:
- *   On success, a non-NULL RTC lower interface is returned.  NULL is
- *   returned on any failure.
+ *   None
  *
  ****************************************************************************/
 
-FAR struct rtc_lowerhalf_s *stm32l4_rtc_lowerhalf(void)
+void stm32l4_rtc_initialize(void)
 {
-  nxsem_init(&g_rtc_lowerhalf.devsem, 0, 1);
+	struct rtc_lowerhalf_s *lower = (struct rtc_lowerhalf_s *)&g_rtc_lowerhalf;
+	int ret;
 
-  return (FAR struct rtc_lowerhalf_s *)&g_rtc_lowerhalf;
+	/* Bind the lower half driver and register the combined RTC driver as /dev/rtc0 */
+
+	ret = rtc_initialize(0, lower);
+	if (ret < 0) {
+		lldbg("Failed to register the RTC driver: %d\n", ret);
+	}
 }
 
 #endif /* CONFIG_RTC_DRIVER */

--- a/os/board/artik05x/src/artik05x_tash.c
+++ b/os/board/artik05x/src/artik05x_tash.c
@@ -68,7 +68,6 @@
 #include <tinyara/fs/mtd.h>
 #include <tinyara/fs/ioctl.h>
 #include <tinyara/fs/mksmartfs.h>
-#include <tinyara/rtc.h>
 #include <tinyara/analog/adc.h>
 #include <tinyara/configdata.h>
 #include <chip.h>
@@ -276,19 +275,9 @@ int board_app_initialize(void)
 #endif /* CONFIG_LIBC_ZONEINFO_ROMFS */
 #endif /* CONFIG_ARTIK05X_AUTOMOUNT */
 
-#if defined(CONFIG_RTC_DRIVER)
-	{
-		struct rtc_lowerhalf_s *rtclower;
-
-		rtclower = s5j_rtc_lowerhalf();
-		if (rtclower) {
-			ret = rtc_initialize(0, rtclower);
-			if (ret < 0) {
-				lldbg("Failed to register the RTC driver: %d\n", ret);
-			}
-		}
-	}
-#endif /* CONFIG_RTC_DRIVER */
+#ifdef CONFIG_RTC_DRIVER
+	s5j_rtc_initialize();
+#endif
 
 #ifdef CONFIG_TIMER
 	{

--- a/os/board/sidk_s5jt200/src/s5jt200_tash.c
+++ b/os/board/sidk_s5jt200/src/s5jt200_tash.c
@@ -61,7 +61,6 @@
 #include <errno.h>
 
 #include <tinyara/board.h>
-#include <tinyara/rtc.h>
 #include <time.h>
 #include <chip.h>
 
@@ -404,20 +403,9 @@ int board_app_initialize(void)
 		lldbg("Version Info :\n");
 		lldbg("tinyARA %s\n", __TIMESTAMP__);
 	}
-#if defined(CONFIG_RTC_DRIVER)
-	{
-		struct rtc_lowerhalf_s *rtclower;
-
-		rtclower = s5j_rtc_lowerhalf();
-		if (rtclower) {
-			ret = rtc_initialize(0, rtclower);
-			if (ret < 0) {
-				lldbg("Failed to register the RTC driver: %d\n",
-						ret);
-			}
-		}
-	}
-#endif /* CONFIG_RTC_DRIVER */
+#ifdef CONFIG_RTC_DRIVER
+	s5j_rtc_initialize();
+#endif
 #endif /* CONFIG_RTC */
 
 	sidk_s5jt200_adc_setup();

--- a/os/board/stm32l4r9ai-disco/src/stm32_appinit.c
+++ b/os/board/stm32l4r9ai-disco/src/stm32_appinit.c
@@ -69,8 +69,7 @@
  * stm32l4r9ai-disco.
  */
 
-#ifdef HAVE_RTC_DRIVER
-#  include <nuttx/timers/rtc.h>
+#ifdef CONFIG_RTC_DRIVER
 #  include "stm32l4_rtc.h"
 #endif
 
@@ -119,9 +118,6 @@ static struct i2c_master_s* g_i2c3;
 #ifdef CONFIG_LIB_BOARDCTL
 int board_app_initialize(uintptr_t arg)
 {
-#ifdef HAVE_RTC_DRIVER
-  FAR struct rtc_lowerhalf_s *rtclower;
-#endif
   int ret;
 
   (void)ret;
@@ -141,28 +137,8 @@ int board_app_initialize(uintptr_t arg)
     }
 #endif
 
-#ifdef HAVE_RTC_DRIVER
-  /* Instantiate the STM32 lower-half RTC driver */
-
-  rtclower = stm32l4_rtc_lowerhalf();
-  if (!rtclower)
-    {
-      serr("ERROR: Failed to instantiate the RTC lower-half driver\n");
-      return -ENOMEM;
-    }
-  else
-    {
-      /* Bind the lower half driver and register the combined RTC driver
-       * as /dev/rtc0
-       */
-
-      ret = rtc_initialize(0, rtclower);
-      if (ret < 0)
-        {
-          serr("ERROR: Failed to bind/register the RTC driver: %d\n", ret);
-          return ret;
-        }
-    }
+#ifdef CONFIG_RTC_DRIVER
+  stm32l4_rtc_initialize();
 #endif
 
 #ifdef CONFIG_I2C


### PR DESCRIPTION
…32l4r9ai-disco

RTC driver in board gets lowerhalf structure from arch and initializes
using driver function. But other drivers like timer, gpio and etc do it in arch
and board just calls it.
We don't need to deliver lowerhalf to board so that we had better do it as others.

Signed-off-by: sunghan-chang <sh924.chang@samsung.com>