### PR TITLE
os/board: tidyup CONFIG_ARCH_USE_FLASH, CONFIG_ARCH_USE_SECOND_FLASH

### DIFF
--- a/os/arch/arm/src/s5j/Kconfig
+++ b/os/arch/arm/src/s5j/Kconfig
@@ -351,7 +351,6 @@ config S5J_WDT_DEFTIMEOUT
 config S5J_SFLASH
 	bool "SFLASH"
 	default y
-	select ARCH_USE_FLASH
 	depends on S5J_HAVE_SFLASH
 
 config S5J_SENSOR_PPD42NS

--- a/os/board/Kconfig
+++ b/os/board/Kconfig
@@ -16,6 +16,7 @@ config ARCH_BOARD_ARTIK053
 	bool "Samsung ARTIK-053 Starter Kit"
 	depends on ARCH_CHIP_S5JT200
 	select ARCH_BOARD_ARTIK05X_FAMILY
+	select ARCH_BOARD_HAVE_FLASH
 	---help---
 		Samsung ARTIK-053 Starter Kit based on S5JT200 IoT WiFi MCU
 
@@ -23,6 +24,7 @@ config ARCH_BOARD_ARTIK053S
 	bool "Samsung ARTIK-053S Starter Kit"
 	depends on ARCH_CHIP_S5JT200
 	select ARCH_BOARD_ARTIK05X_FAMILY
+	select ARCH_BOARD_HAVE_FLASH
 	---help---
 		Samsung ARTIK-053S Starter Kit based on S5JT200 IoT WiFi MCU
 
@@ -30,6 +32,7 @@ config ARCH_BOARD_ARTIK055S
 	bool "Samsung ARTIK-055S Starter Kit"
 	depends on ARCH_CHIP_S5JT200
 	select ARCH_BOARD_ARTIK05X_FAMILY
+	select ARCH_BOARD_HAVE_FLASH
 	---help---
 		Samsung ARTIK-055S Starter Kit based on S5JT200 IoT WiFi MCU
 
@@ -46,6 +49,7 @@ config ARCH_BOARD_SIDK_S5JT200
 	depends on ARCH_CHIP_S5JT200
 	select ARCH_HAVE_BUTTONS
 	select ARCH_HAVE_IRQBUTTONS
+	select ARCH_BOARD_HAVE_FLASH
 	---help---
 		Samsung S5JT200 IoT wifi MCU
 
@@ -77,6 +81,7 @@ config ARCH_BOARD_ESP32_DEVKITC
 	bool "Espressif ESP32-DevKitC board"
 	depends on ARCH_CHIP_ESP32
 	select ARCH_BOARD_ESP32_FAMILY
+	select ARCH_BOARD_HAVE_FLASH
 	---help---
 		Espressif esp32 WIFI/BLE MCU
 
@@ -84,6 +89,7 @@ config ARCH_BOARD_ESP_WROVER_KIT
 	bool "Espressif ESP-WROVER-KIT board"
 	depends on ARCH_CHIP_ESP32
 	select ARCH_BOARD_ESP32_FAMILY
+	select ARCH_BOARD_HAVE_FLASH
 	---help---
 		Espressif esp32 WIFI/BLE LCDs MCU
 		
@@ -94,6 +100,7 @@ config ARCH_BOARD_IMXRT1020_EVK
 	select ARCH_HAVE_BUTTONS
 	select ARCH_HAVE_IRQBUTTONS
 	select AUTOGEN_MEMORY_LDSCRIPT if BUILD_PROTECTED
+	select ARCH_BOARD_HAVE_FLASH
 	---help---
 		This is the board configuration for the port of TinyARA to the NXP i.MXRT
 		evaluation kit, MIMXRT1020-EVKB.  This board features the MIMXRT1021CAF4A MCU.
@@ -105,6 +112,7 @@ config ARCH_BOARD_IMXRT1050_EVK
 	select ARCH_HAVE_BUTTONS
 	select ARCH_HAVE_IRQBUTTONS
 	select AUTOGEN_MEMORY_LDSCRIPT if BUILD_PROTECTED
+	select ARCH_BOARD_HAVE_FLASH
 	---help---
 		This is the board configuration for the port of TinyARA to the NXP i.MXRT
 		evaluation kit, MIMXRT1050-EVKB.  This board features the MIMXRT1052DVL6A MCU.
@@ -115,6 +123,7 @@ config ARCH_BOARD_STM32L4R9AI_DISCO
 	select ARCH_HAVE_LEDS
 	select ARCH_HAVE_BUTTONS
 	select ARCH_HAVE_IRQBUTTONS
+	select ARCH_BOARD_HAVE_FLASH
 	---help---
 		STMicro STM32L4R9AI-Discovery board based on the STMicro STM32L4R9AI MCU.
 
@@ -123,6 +132,7 @@ config ARCH_BOARD_RTL8721CSM
 	depends on ARCH_CHIP_RTL8721CSM
 	select ARCH_HAVE_BUTTONS
 	select ARCH_HAVE_IRQBUTTONS
+	select ARCH_BOARD_HAVE_FLASH
 	---help---
 		Realtek RTL8721CSM-Discovery board based on the Realtek RTL8721CSM MCU.		
 endchoice

--- a/os/board/common/Kconfig
+++ b/os/board/common/Kconfig
@@ -3,13 +3,14 @@
 # see kconfig-language at https://www.kernel.org/doc/Documentation/kbuild/kconfig-language.txt
 #
 
-config ARCH_USE_FLASH
-	bool "Enable/Disable FLASH usage for user"
+config ARCH_BOARD_HAVE_FLASH
+	bool
 	default n
 	---help---
-		This shows that user enables FLASH to use.
+		This shows the board has the flash and enables to use.
+		This is enabled by board config.
 
-if ARCH_USE_FLASH && (NFILE_DESCRIPTORS != 0)
+if ARCH_BOARD_HAVE_FLASH && (NFILE_DESCRIPTORS != 0)
 comment "Board-Partition Options"
 
 config FLASH_PARTITION
@@ -53,16 +54,16 @@ config FLASH_PART_NAME
 		Comma separated list of partition names.
 
 endif # FLASH_PARTITION
-endif # ARCH_USE_FLASH && (NFILE_DESCRIPTORS != 0)
+endif # ARCH_BOARD_HAVE_FLASH && (NFILE_DESCRIPTORS != 0)
 
-config ARCH_USE_SECOND_FLASH
+config ARCH_BOARD_HAVE_SECOND_FLASH
 	bool
 	default n
 	---help---
-		This enables Second FLASH to use.
-		It is selected by chip config.
+		This shows the board has the second flash and enables to use.
+		This is enabled by board config.
 
-if ARCH_USE_SECOND_FLASH && (NFILE_DESCRIPTORS != 0)
+if ARCH_BOARD_HAVE_SECOND_FLASH && (NFILE_DESCRIPTORS != 0)
 comment "Second Flash Partition Options"
 
 config SECOND_FLASH_PARTITION
@@ -104,4 +105,4 @@ config SECOND_FLASH_PART_NAME
 		Comma separated list of partition names.
 
 endif # SECOND_FLASH_PARTITION
-endif # ARCH_USE_SECOND_FLASH && (NFILE_DESCRIPTORS != 0)
+endif # ARCH_BOARD_HAVE_SECOND_FLASH && (NFILE_DESCRIPTORS != 0)

--- a/os/board/imxrt1020-evk/Kconfig
+++ b/os/board/imxrt1020-evk/Kconfig
@@ -8,7 +8,6 @@ if ARCH_BOARD_IMXRT1020_EVK
 config IMXRT_NORFLASH
 	bool "Enable Norflash"
 	default y
-	select ARCH_USE_FLASH
 	---help---
 		Enables Norflash
 

--- a/os/board/imxrt1050-evk/Kconfig
+++ b/os/board/imxrt1050-evk/Kconfig
@@ -22,14 +22,12 @@ endchoice # Boot Flash
 config IMXRT_HYPERFLASH
 	bool "Enable Hyperflash"
 	default n
-	select ARCH_USE_FLASH
 	---help---
 		Enables Hyperflash
 
 config IMXRT_NORFLASH
 	bool "Enable Norflash"
 	default n
-	select ARCH_USE_FLASH
 	---help---
 		Enables Norflash
 


### PR DESCRIPTION
1. remove the prompt to hide from user
  They show the board has the flash, they are not the way to enable flash.
  CONFIG_FLASH_PARTITION and CONFIG_SECOND_FLASH_PARTITION are for that.
  So, user should not control them.

2. make a dependency with board config, not with chip config
  Ususally flash has a dependency with board, not with chip.
  Let's move the selection them under board config in Kconfig.

3. rename it to CONFIG_ARCH_BOARD_HAVE_FLASH
  By 2nd modification, it had better have BOARD prefix.
  And by 1st, it had better have HAVE prefix instead of USE.

Signed-off-by: sunghan-chang <sh924.chang@samsung.com>