### PR TITLE
fs/fscmd : Fix memfault of echo

### DIFF
--- a/apps/system/utils/fscmd.c
+++ b/apps/system/utils/fscmd.c
@@ -159,6 +159,10 @@ static int tash_echo(int argc, char **args)
 	int n_opt = 1;
 	int ret = ERROR;
 
+	if (argc == 1) {
+		FSCMD_OUTPUT("\n");
+		return OK;
+	}
 	if (!strncmp(args[1], "--help", strlen("--help") + 1)) {
 		FSCMD_OUTPUT(FSCMD_ECHO_USAGE);
 		return OK;


### PR DESCRIPTION
If user type just 'echo' memfault happened because args[1] is null so fix it.