### PR TITLE
fs/fscmd : Fix df doesn't show 2nd mount point of file system

### DIFF
--- a/apps/system/utils/fscmd.c
+++ b/apps/system/utils/fscmd.c
@@ -796,7 +796,6 @@ static int mount_handler(FAR const char *mountpoint, FAR struct statfs *statbuf,
 static int search_mountpoints(const char *dirpath, foreach_mountpoint_t handler)
 {
 	int ret = OK;
-	struct statfs prev_buf = {0, };
 	DIR *dirp = opendir(dirpath);		/* Open the directory */
 	if (!dirp) {
 		/* Failed to open the directory */
@@ -825,11 +824,6 @@ static int search_mountpoints(const char *dirpath, foreach_mountpoint_t handler)
 		}
 
 		if ((buf.f_type == SMARTFS_MAGIC) || (buf.f_type == ROMFS_MAGIC) || (buf.f_type == PROCFS_MAGIC) || (buf.f_type == TMPFS_MAGIC)) {
-			if (prev_buf.f_type == buf.f_type) {	/* In this case, inode is not changed. */
-				continue;
-			}
-			prev_buf.f_type = buf.f_type;
-
 			ret = handler(fullpath, &buf, NULL);
 			if (ret != OK) {
 				FSCMD_OUTPUT("handler is failed at %s\n", fullpath);


### PR DESCRIPTION
If there are more than one same fs type of mountpoint, df show only first one.