### PR TITLE
fs/fscmd : Prevent overflow of fscmd_buffer

### DIFF
--- a/apps/system/utils/fscmd.c
+++ b/apps/system/utils/fscmd.c
@@ -211,7 +211,7 @@ static int tash_echo(int argc, char **args)
 		return ret;
 	 }
 
-	for (i = n_opt; i < direction.index; i++) {
+	for (i = n_opt; i < direction.index && len < FSCMD_BUFFER_LEN; i++) {
 		if (i != n_opt) {
 			memcpy(fscmd_buffer + len, " ", 1);
 			len += 1;


### PR DESCRIPTION
Check buffer size when memcpy to fscmd_buffer