### PR TITLE
apps/system/utils: tidyup

### DIFF
--- a/apps/examples/mpu/mpu_test.c
+++ b/apps/examples/mpu/mpu_test.c
@@ -56,7 +56,7 @@ int mpu_tc_main(int argc, char *argv[])
 
 		if (ch == 'A' || ch == 'a') {
 			obj.type = MPUTEST_APP_ADDR;
-			ret = ioctl(tc_fd, TESTIOC_MPUTEST, &obj);
+			ret = ioctl(tc_fd, TESTIOC_MPUTEST, (unsigned long)&obj);
 			if (ret < 0) {
 				printf("ERROR: Failed to fetch test address from kernel\n");
 				close(tc_fd);
@@ -86,7 +86,7 @@ int mpu_tc_main(int argc, char *argv[])
 			ch = getchar();
 			if (ch == 'C' || ch == 'c') {
 				obj.type = MPUTEST_KERNEL_CODE;
-				ret = ioctl(tc_fd, TESTIOC_MPUTEST, &obj);
+				ret = ioctl(tc_fd, TESTIOC_MPUTEST, (unsigned long)&obj);
 				if (ret < 0) {
 					printf("ERROR: Failed to fetch test address from kernel\n");
 					close(tc_fd);
@@ -108,7 +108,7 @@ int mpu_tc_main(int argc, char *argv[])
 				printf("ERROR: User Task made invalid access to Kernel code space\n");
 			} else if (ch == 'D' || ch == 'd') {
 				obj.type = MPUTEST_KERNEL_DATA;
-				ret = ioctl(tc_fd, TESTIOC_MPUTEST, &obj);
+				ret = ioctl(tc_fd, TESTIOC_MPUTEST, (unsigned long)&obj);
 				if (ret < 0) {
 					printf("ERROR: Failed to fetch test address from kernel\n");
 					close(tc_fd);
@@ -139,7 +139,7 @@ int mpu_tc_main(int argc, char *argv[])
 
 		if (ch == 'A' || ch == 'a') {
 			obj.type = MPUTEST_APP_ADDR;
-			ret = ioctl(tc_fd, TESTIOC_MPUTEST, &obj);
+			ret = ioctl(tc_fd, TESTIOC_MPUTEST, (unsigned long)&obj);
 			if (ret < 0) {
 				printf("ERROR: Failed to fetch test address from kernel\n");
 				close(tc_fd);
@@ -169,7 +169,7 @@ int mpu_tc_main(int argc, char *argv[])
 			ch = getchar();
 			if (ch == 'C' || ch == 'c') {
 				obj.type = MPUTEST_KERNEL_CODE;
-				ret = ioctl(tc_fd, TESTIOC_MPUTEST, &obj);
+				ret = ioctl(tc_fd, TESTIOC_MPUTEST, (unsigned long)&obj);
 				if (ret < 0) {
 					printf("ERROR: Failed to fetch test address from kernel\n");
 					close(tc_fd);
@@ -191,7 +191,7 @@ int mpu_tc_main(int argc, char *argv[])
 				printf("ERROR: User Task made invalid access to Kernel code space\n");
 			} else if (ch == 'D' || ch == 'd') {
 				obj.type = MPUTEST_KERNEL_DATA;
-				ret = ioctl(tc_fd, TESTIOC_MPUTEST, &obj);
+				ret = ioctl(tc_fd, TESTIOC_MPUTEST, (unsigned long)&obj);
 				if (ret < 0) {
 					printf("ERROR: Failed to fetch test address from kernel\n");
 					close(tc_fd);

--- a/apps/system/utils/utils_ps.c
+++ b/apps/system/utils/utils_ps.c
@@ -65,7 +65,7 @@
 
 #include "utils_proc.h"
 
-#define STATENAMES_ARRARY_SIZE (sizeof(utils_statenames) / sizeof(utils_statenames[0]))
+#define STATENAMES_ARRAY_SIZE (sizeof(utils_statenames) / sizeof(utils_statenames[0]))
 #define PS_BUFLEN 128
 
 static const char *utils_statenames[] = {
@@ -111,7 +111,7 @@ static void ps_print_values(char *buf)
 	}
 
 	state = atoi(stat_info[PROC_STAT_STATE]);
-	if (state <= 0 || STATENAMES_ARRARY_SIZE <= state) {
+	if (state <= 0 || STATENAMES_ARRAY_SIZE <= state) {
 		return;
 	}
 

--- a/loadable_apps/loadable_sample/wifiapp/recovery.c
+++ b/loadable_apps/loadable_sample/wifiapp/recovery.c
@@ -52,7 +52,7 @@ static void *assert_thread(void *index)
 	} else if (type == 1) {
 		/* Access kernel code */
 		obj.type = MPUTEST_KERNEL_CODE;
-		ret = ioctl(tc_fd, TESTIOC_MPUTEST, &obj);
+		ret = ioctl(tc_fd, TESTIOC_MPUTEST, (unsigned long)&obj);
 		if (ret < 0) {
 			printf("ERROR: Failed to obtain address from kernel\n");
 			close(tc_fd);
@@ -65,7 +65,7 @@ static void *assert_thread(void *index)
 	} else {
 		/* Access another binary 'micom' address */
 		obj.type = MPUTEST_APP_ADDR;
-		ret = ioctl(tc_fd, TESTIOC_MPUTEST, &obj);
+		ret = ioctl(tc_fd, TESTIOC_MPUTEST, (unsigned long)&obj);
 		if (ret < 0) {
 			printf("ERROR: Failed to obtain address from kernel\n");
 			close(tc_fd);


### PR DESCRIPTION
1. apps/system/utils: fix typo in utils_ps.c 
2. apps/system/utils/fscmd: tidyup tash_cat
    1. remove duplicated fscmd_free for src/dest_fullpath at end of function
    2. In redirection case, written size could be less than requested size.
       add while loop to write entire read data to destination