### PR TITLE
debug/fs : fix build error when nxfusing run

### DIFF
--- a/os/include/debug.h
+++ b/os/include/debug.h
@@ -382,7 +382,6 @@ int get_errno(void);
 #else
 #define fdbg(...)
 #define flldbg(...)
-#define fsdbg(format, ...)
 #endif
 
 #ifdef CONFIG_DEBUG_FS_WARN
@@ -395,9 +394,11 @@ int get_errno(void);
 
 #ifdef CONFIG_DEBUG_FS_INFO
 #define fvdbg(format, ...)   vdbg(format, ##__VA_ARGS__)
+#define fsdbg(format, ...)   dbg_noarg(format, ##__VA_ARGS__)
 #define fllvdbg(format, ...) llvdbg(format, ##__VA_ARGS__)
 #else
 #define fvdbg(...)
+#define fsdbg(format, ...)
 #define fllvdbg(...)
 #endif
 
@@ -1154,11 +1155,10 @@ int get_errno(void);
 #ifdef CONFIG_DEBUG_FS_ERROR
 #define fdbg        dbg
 #define flldbg      lldbg
-#define fsdbg       dbg_noarg
+#define fsdbg       dbg
 #else
 #define fdbg        (void)
 #define flldbg      (void)
-#define fsdbg       (void)
 #endif
 
 #ifdef CONFIG_DEBUG_FS_WARN
@@ -1171,9 +1171,11 @@ int get_errno(void);
 
 #ifdef CONFIG_DEBUG_FS_INFO
 #define fvdbg       vdbg
+#define fsdbg       dbg
 #define fllvdbg     llvdbg
 #else
 #define fvdbg       (void)
+#define fsdbg       (void)
 #define fllvdbg     (void)
 #endif
 


### PR DESCRIPTION
can't find dbg_noarg when nxfusing, because config is different