### PR TITLE
kernel/binary_manager: Get path to download binary from binary_manager_open_new_entry

### DIFF
--- a/framework/include/binary_manager/binary_manager.h
+++ b/framework/include/binary_manager/binary_manager.h
@@ -111,7 +111,7 @@ int binary_manager_unregister_state_changed_callback(void);
  *  Otherwise, it creates empty file with version and returns a path of the file.
  * @param[in] binary_name The binary name to update
  * @param[in] version The binary version to update
- * @param[out] download_path The path to the download binary. The maximum length is CONFIG_PATH_MAX.
+ * @param[out] download_path The path to the download binary. The maximum length is BINARY_PATH_LEN.
  * @return A defined value of binmgr_response_result_type in <tinyara/binary_manager.h>
  *         0 (BINMGR_OK) on success. On failure, negative value is returned.
  * @since TizenRT v3.1 PRE

--- a/framework/include/binary_manager/binary_manager.h
+++ b/framework/include/binary_manager/binary_manager.h
@@ -43,11 +43,11 @@
  *  This function loads a new binary after downloading the binary.\n
  * It requests the binary manager to load the input binary name.
  * @param[in] binary_name The name of a new binary to be loaded
- * @return A defined value of binmgr_response_result_type in <tinyara/binary_manager.h>
+ * @return A defined value of binmgr_result_type_e in <tinyara/binary_manager.h>
  *         0 (BINMGR_OK) On success. On failure, negative value is returned.
  * @since TizenRT v3.0
  */
-int binary_manager_update_binary(char *binary_name);
+binmgr_result_type_e binary_manager_update_binary(char *binary_name);
 
 /**
  * @brief Get the binary information with name
@@ -55,53 +55,53 @@ int binary_manager_update_binary(char *binary_name);
  *  It requests the binary manager to get the binary information through input binary name.
  * @param[in] binary_name The binary name which to get
  * @param[out] binary_info The address value to receive the binary information
- * @return A defined value of binmgr_response_result_type in <tinyara/binary_manager.h>
+ * @return A defined value of binmgr_result_type_e in <tinyara/binary_manager.h>
  *         0 (BINMGR_OK) On success. On failure, negative value is returned.
  * @since TizenRT v3.0
  */
-int binary_manager_get_update_info(char *binary_name, binary_update_info_t *binary_info);
+binmgr_result_type_e binary_manager_get_update_info(char *binary_name, binary_update_info_t *binary_info);
 
 /**
  * @brief Get the all binaries information
  * @details @b #include <binary_manager/binary_manager.h>\n
  *  It requests the binary manager to get the all of binaries' information.
  * @param[out] binary_info_list The address value to receive the binary information list
- * @return A defined value of binmgr_response_result_type in <tinyara/binary_manager.h>
+ * @return A defined value of binmgr_result_type_e in <tinyara/binary_manager.h>
  *         0 (BINMGR_OK) On success. On failure, negative value is returned.
  * @since TizenRT v3.0
  */
-int binary_manager_get_update_info_all(binary_update_info_list_t *binary_info_list);
+binmgr_result_type_e binary_manager_get_update_info_all(binary_update_info_list_t *binary_info_list);
 #endif
 
 /**
  * @brief Notify that loaded binary is started to binary manager
  * @details @b #include <binary_manager/binary_manager.h>\n
  *  It sends a message the binary manager to notify that loaded binary is started well.
- * @return A defined value of binmgr_response_result_type in <tinyara/binary_manager.h>
+ * @return A defined value of binmgr_result_type_e in <tinyara/binary_manager.h>
  *         0 (BINMGR_OK) On success. On failure, negative value is returned.
  * @since TizenRT v3.0
  */
-int binary_manager_notify_binary_started(void);
+binmgr_result_type_e binary_manager_notify_binary_started(void);
 
 /**
  * @brief Set the callback which will be called when the the states of binaries are changed
  * @details @b #include <binary_manager/binary_manager.h>\n
  *  It sets callback for the changes of binary state.
- * @return A defined value of binmgr_response_result_type in <tinyara/binary_manager.h>
+ * @return A defined value of binmgr_result_type_e in <tinyara/binary_manager.h>
  *         0 (BINMGR_OK) On success. On failure, negative value is returned.
  * @since TizenRT v3.0
  */
-int binary_manager_register_state_changed_callback(binmgr_statecb_t handler, void *cb_data);
+binmgr_result_type_e binary_manager_register_state_changed_callback(binmgr_statecb_t handler, void *cb_data);
 
 /**
  * @brief Clear the registered callback for the changes of binary state.
  * @details @b #include <binary_manager/binary_manager.h>\n
  *  It clears registered callback for the changes of binary state.
- * @return A defined value of binmgr_response_result_type in <tinyara/binary_manager.h>
+ * @return A defined value of binmgr_result_type_e in <tinyara/binary_manager.h>
  *         0 (BINMGR_OK) On success. On failure, negative value is returned.
  * @since TizenRT v3.0
  */
-int binary_manager_unregister_state_changed_callback(void);
+binmgr_result_type_e binary_manager_unregister_state_changed_callback(void);
 
 /**
  * @brief Get the path to download binary with version.
@@ -112,11 +112,11 @@ int binary_manager_unregister_state_changed_callback(void);
  * @param[in] binary_name The binary name to update
  * @param[in] version The binary version to update
  * @param[out] download_path The path to the download binary. The maximum length is BINARY_PATH_LEN.
- * @return A defined value of binmgr_response_result_type in <tinyara/binary_manager.h>
+ * @return A defined value of binmgr_result_type_e in <tinyara/binary_manager.h>
  *         0 (BINMGR_OK) on success. On failure, negative value is returned.
  * @since TizenRT v3.1 PRE
  */
-int binary_manager_get_download_path(char *binary_name, uint32_t version, char *download_path);
+binmgr_result_type_e binary_manager_get_download_path(char *binary_name, uint32_t version, char *download_path);
 
 /**
  * @brief Get a state of binary
@@ -124,11 +124,11 @@ int binary_manager_get_download_path(char *binary_name, uint32_t version, char *
  *  It sends a message the binary manager to get a state of binary with binary name.
  * @param[in] binary_name The binary name to get state
  * @param[out] state The state of binary with binary_name
- * @return A defined value of binmgr_response_result_type in <tinyara/binary_manager.h>
+ * @return A defined value of binmgr_result_type_e in <tinyara/binary_manager.h>
  *         0 (BINMGR_OK) on success. On failure, negative value is returned.
  * @since TizenRT v3.1 PRE
  */
-int binary_manager_get_state(char *binary_name, int *state);
+binmgr_result_type_e binary_manager_get_state(char *binary_name, int *state);
 
 #endif
 /**

--- a/framework/include/binary_manager/binary_manager.h
+++ b/framework/include/binary_manager/binary_manager.h
@@ -104,15 +104,19 @@ int binary_manager_register_state_changed_callback(binmgr_statecb_t handler, voi
 int binary_manager_unregister_state_changed_callback(void);
 
 /**
- * @brief Create a empty file where to be downloaded with version.
+ * @brief Get the path to download binary with version.
  * @details @b #include <binary_manager/binary_manager.h>\n
- *  It creates and opens a empty file where to be downloaded binary with version.
- *  User can perform file operations with returned fd : read, write, lseek, close.
+ *  User can perform file operations with returned filepath : open, read, write, lseek, close.
+ *  In case of kernel binary, it returns a path of inactive kernel partition.
+ *  Otherwise, it creates empty file with version and returns a path of the file.
+ * @param[in] binary_name The binary name to update
+ * @param[in] version The binary version to update
+ * @param[out] download_path The path to the download binary. The maximum length is CONFIG_PATH_MAX.
  * @return A defined value of binmgr_response_result_type in <tinyara/binary_manager.h>
- *         fd of a created file on success. On failure, negative value is returned.
+ *         0 (BINMGR_OK) on success. On failure, negative value is returned.
  * @since TizenRT v3.1 PRE
  */
-int binary_manager_open_new_entry(char *binary_name, uint32_t version);
+int binary_manager_get_download_path(char *binary_name, uint32_t version, char *download_path);
 
 #endif
 /**

--- a/framework/include/binary_manager/binary_manager.h
+++ b/framework/include/binary_manager/binary_manager.h
@@ -118,6 +118,18 @@ int binary_manager_unregister_state_changed_callback(void);
  */
 int binary_manager_get_download_path(char *binary_name, uint32_t version, char *download_path);
 
+/**
+ * @brief Get a state of binary
+ * @details @b #include <binary_manager/binary_manager.h>\n
+ *  It sends a message the binary manager to get a state of binary with binary name.
+ * @param[in] binary_name The binary name to get state
+ * @param[out] state The state of binary with binary_name
+ * @return A defined value of binmgr_response_result_type in <tinyara/binary_manager.h>
+ *         0 (BINMGR_OK) on success. On failure, negative value is returned.
+ * @since TizenRT v3.1 PRE
+ */
+int binary_manager_get_state(char *binary_name, int *state);
+
 #endif
 /**
  * @}

--- a/framework/src/binary_manager/Make.defs
+++ b/framework/src/binary_manager/Make.defs
@@ -17,7 +17,7 @@
 ###########################################################################
 
 ifeq ($(CONFIG_BINARY_MANAGER),y)
-CSRCS += binary_manager_interface.c binary_manager_notify.c binary_manager_register_callback.c
+CSRCS += binary_manager_interface.c binary_manager_notify.c binary_manager_register_callback.c binary_manager_get_state.c
 
 ifeq ($(CONFIG_BINMGR_UPDATE),y)
 CSRCS += binary_manager_update.c

--- a/framework/src/binary_manager/binary_manager_get_state.c
+++ b/framework/src/binary_manager/binary_manager_get_state.c
@@ -1,0 +1,64 @@
+/****************************************************************************
+ *
+ * Copyright 2020 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+/***************************************************************************
+ * Included Files
+ ***************************************************************************/
+
+#include <debug.h>
+#include <string.h>
+#include <tinyara/binary_manager.h>
+#include <binary_manager/binary_manager.h>
+#include "binary_manager_internal.h"
+
+int binary_manager_get_state(char *binary_name, int *state)
+{
+	int ret;
+	binmgr_request_t request_msg;
+	binmgr_getstate_response_t response_msg;
+
+	if (binary_name == NULL || strlen(binary_name) > BIN_NAME_MAX - 1) {
+		bmdbg("get_binary_info failed : invalid param.\n");
+		return BINMGR_INVALID_PARAM;
+	}
+
+	ret = binary_manager_set_request(&request_msg, BINMGR_GET_STATE, binary_name);
+	if (ret < 0) {
+		return BINMGR_COMMUNICATION_FAIL;
+	}
+
+	ret = binary_manager_send_request(&request_msg);
+	if (ret < 0) {
+		bmdbg("Failed to send request msg %d\n", ret);
+		return BINMGR_COMMUNICATION_FAIL;
+	}
+
+	ret = binary_manager_receive_response(&response_msg, sizeof(binmgr_getstate_response_t));
+	if (ret < 0) {
+		bmdbg("Failed to receive response msg %d\n", ret);
+		return BINMGR_COMMUNICATION_FAIL;
+	}
+
+	if (response_msg.result == BINMGR_OK) {
+		*state = response_msg.state;
+	} else {
+		bmdbg("Binary manager getstate FAIL %d\n", response_msg.result);
+	}
+
+	return response_msg.result;
+}

--- a/framework/src/binary_manager/binary_manager_get_state.c
+++ b/framework/src/binary_manager/binary_manager_get_state.c
@@ -26,9 +26,9 @@
 #include <binary_manager/binary_manager.h>
 #include "binary_manager_internal.h"
 
-int binary_manager_get_state(char *binary_name, int *state)
+binmgr_result_type_e binary_manager_get_state(char *binary_name, int *state)
 {
-	int ret;
+	binmgr_result_type_e ret;
 	binmgr_request_t request_msg;
 	binmgr_getstate_response_t response_msg;
 
@@ -38,20 +38,20 @@ int binary_manager_get_state(char *binary_name, int *state)
 	}
 
 	ret = binary_manager_set_request(&request_msg, BINMGR_GET_STATE, binary_name);
-	if (ret < 0) {
-		return BINMGR_COMMUNICATION_FAIL;
+	if (ret != BINMGR_OK) {
+		return ret;
 	}
 
 	ret = binary_manager_send_request(&request_msg);
-	if (ret < 0) {
+	if (ret != BINMGR_OK) {
 		bmdbg("Failed to send request msg %d\n", ret);
-		return BINMGR_COMMUNICATION_FAIL;
+		return ret;
 	}
 
 	ret = binary_manager_receive_response(&response_msg, sizeof(binmgr_getstate_response_t));
-	if (ret < 0) {
+	if (ret != BINMGR_OK) {
 		bmdbg("Failed to receive response msg %d\n", ret);
-		return BINMGR_COMMUNICATION_FAIL;
+		return ret;
 	}
 
 	if (response_msg.result == BINMGR_OK) {

--- a/framework/src/binary_manager/binary_manager_interface.c
+++ b/framework/src/binary_manager/binary_manager_interface.c
@@ -30,11 +30,11 @@
 #include <mqueue.h>
 #include <tinyara/binary_manager.h>
 
-int binary_manager_set_request(binmgr_request_t *request_msg, int cmd, void *arg)
+binmgr_result_type_e binary_manager_set_request(binmgr_request_t *request_msg, int cmd, void *arg)
 {
 	if (request_msg == NULL) {
 		bmdbg("Invalid param\n");
-		return ERROR;
+		return BINMGR_INVALID_PARAM;
 	}
 
 	switch (cmd) {
@@ -44,14 +44,14 @@ int binary_manager_set_request(binmgr_request_t *request_msg, int cmd, void *arg
 	case BINMGR_UPDATE:
 		if (arg == NULL) {
 			bmdbg("Invalid param, cmd : %d\n", cmd);
-			return ERROR;
+			return BINMGR_INVALID_PARAM;
 		}
 		snprintf(request_msg->data.bin_name, BIN_NAME_MAX, "%s", (char *)arg);
 		break;
 	case BINMGR_CREATE_BIN:
 		if (arg == NULL) {
 			bmdbg("Invalid param, cmd : %d\n", cmd);
-			return ERROR;
+			return BINMGR_INVALID_PARAM;
 		}
 		binmgr_update_bin_t *data = (binmgr_update_bin_t *)arg;
 		strncpy(request_msg->data.update_bin.bin_name, data->bin_name, BIN_NAME_MAX);
@@ -60,7 +60,7 @@ int binary_manager_set_request(binmgr_request_t *request_msg, int cmd, void *arg
 	case BINMGR_REGISTER_STATECB:
 		if (arg == NULL) {
 			bmdbg("Invalid param, cmd : %d\n", cmd);
-			return ERROR;
+			return BINMGR_INVALID_PARAM;
 		}
 		request_msg->data.cb_info = (binmgr_cb_t *)arg;
 		break;
@@ -71,10 +71,10 @@ int binary_manager_set_request(binmgr_request_t *request_msg, int cmd, void *arg
 	request_msg->cmd = cmd;
 	request_msg->requester_pid = getpid();
 
-	return OK;
+	return BINMGR_OK;
 }
 
-int binary_manager_send_request(binmgr_request_t *request_msg)
+binmgr_result_type_e binary_manager_send_request(binmgr_request_t *request_msg)
 {
 	int ret;
 	mqd_t binmgr_mq;
@@ -87,22 +87,22 @@ int binary_manager_send_request(binmgr_request_t *request_msg)
 	binmgr_mq = mq_open(BINMGR_REQUEST_MQ, O_WRONLY, 0666, 0);
 	if (binmgr_mq == (mqd_t)ERROR) {
 		bmdbg("mq open ERROR failed, errno %d\n", errno);
-		return ERROR;
+		return BINMGR_COMMUNICATION_FAIL;
 	}
 
 	ret = mq_send(binmgr_mq, (const char *)request_msg, sizeof(binmgr_request_t), BINMGR_NORMAL_PRIO);
 	if (ret < 0) {
 		bmdbg("send ERROR %d, errno %d\n", errno);
 		mq_close(binmgr_mq);
-		return ERROR;
+		return BINMGR_COMMUNICATION_FAIL;
 	}
 
 	mq_close(binmgr_mq);
 
-	return OK;
+	return BINMGR_OK;
 }
 
-int binary_manager_receive_response(void *response_msg, int msg_size)
+binmgr_result_type_e binary_manager_receive_response(void *response_msg, int msg_size)
 {
 	int nbytes;
 	struct mq_attr attr;
@@ -111,7 +111,7 @@ int binary_manager_receive_response(void *response_msg, int msg_size)
 
 	if (response_msg == NULL || msg_size < 0) {
 		bmdbg("Invalid param\n");
-		return ERROR;
+		return BINMGR_INVALID_PARAM;
 	}
 
 	attr.mq_maxmsg = BINMGR_MAX_MSG;
@@ -123,7 +123,7 @@ int binary_manager_receive_response(void *response_msg, int msg_size)
 	private_mq = mq_open(q_name, O_RDONLY | O_CREAT, 0666, &attr);
 	if (private_mq == (mqd_t)ERROR) {
 		bmdbg("mq open ERROR failed, errno %d\n", errno);
-		return ERROR;
+		return BINMGR_COMMUNICATION_FAIL;
 	}
 
 	nbytes = mq_receive(private_mq, (char *)response_msg, msg_size, NULL);
@@ -131,11 +131,11 @@ int binary_manager_receive_response(void *response_msg, int msg_size)
 		bmdbg("receive ERROR %d, errno %d\n", nbytes, errno);
 		mq_close(private_mq);
 		mq_unlink(q_name);
-		return ERROR;
+		return BINMGR_COMMUNICATION_FAIL;
 	}
 
 	mq_close(private_mq);
 	mq_unlink(q_name);
 
-	return OK;
+	return BINMGR_OK;
 }

--- a/framework/src/binary_manager/binary_manager_interface.c
+++ b/framework/src/binary_manager/binary_manager_interface.c
@@ -38,6 +38,7 @@ int binary_manager_set_request(binmgr_request_t *request_msg, int cmd, void *arg
 	}
 
 	switch (cmd) {
+	case BINMGR_GET_STATE:
 	case BINMGR_GET_INFO:
 	case BINMGR_NOTIFY_STARTED:
 	case BINMGR_UPDATE:

--- a/framework/src/binary_manager/binary_manager_internal.h
+++ b/framework/src/binary_manager/binary_manager_internal.h
@@ -28,8 +28,8 @@
 /****************************************************************************
  * Public Function Prototypes
  ****************************************************************************/
-int binary_manager_set_request(binmgr_request_t *request_msg, int cmd, void *arg);
-int binary_manager_send_request(binmgr_request_t *request_msg);
-int binary_manager_receive_response(void *response_msg, int msg_size);
+binmgr_result_type_e binary_manager_set_request(binmgr_request_t *request_msg, int cmd, void *arg);
+binmgr_result_type_e binary_manager_send_request(binmgr_request_t *request_msg);
+binmgr_result_type_e binary_manager_receive_response(void *response_msg, int msg_size);
 
 #endif							/* __BINARY_MANAGER_INTERNAL_H */

--- a/framework/src/binary_manager/binary_manager_notify.c
+++ b/framework/src/binary_manager/binary_manager_notify.c
@@ -27,20 +27,20 @@
 #include <binary_manager/binary_manager.h>
 #include "binary_manager_internal.h"
 
-int binary_manager_notify_binary_started(void)
+binmgr_result_type_e binary_manager_notify_binary_started(void)
 {
-	int ret;
+	binmgr_result_type_e ret;
 	binmgr_request_t request_msg;
 
 	ret = binary_manager_set_request(&request_msg, BINMGR_NOTIFY_STARTED, BINMGR_REQUEST_MQ);
-	if (ret < 0) {
-		return BINMGR_COMMUNICATION_FAIL;
+	if (ret != BINMGR_OK) {
+		return ret;
 	}
 
 	ret = binary_manager_send_request(&request_msg);
-	if (ret < 0) {
+	if (ret != BINMGR_OK) {
 		bmdbg("Failed to send request msg %d\n", ret);
-		return BINMGR_COMMUNICATION_FAIL;
+		return ret;
 	}
 
 	return BINMGR_OK;

--- a/framework/src/binary_manager/binary_manager_update.c
+++ b/framework/src/binary_manager/binary_manager_update.c
@@ -30,9 +30,9 @@
 #include <binary_manager/binary_manager.h>
 #include "binary_manager_internal.h"
 
-int binary_manager_update_binary(char *binary_name)
+binmgr_result_type_e binary_manager_update_binary(char *binary_name)
 {
-	int ret;
+	binmgr_result_type_e ret;
 	binmgr_request_t request_msg;
 
 	if (binary_name == NULL || strlen(binary_name) > BIN_NAME_MAX - 1) {
@@ -41,22 +41,21 @@ int binary_manager_update_binary(char *binary_name)
 	}
 
 	ret = binary_manager_set_request(&request_msg, BINMGR_UPDATE, binary_name);
-	if (ret < 0) {
-		return BINMGR_COMMUNICATION_FAIL;
+	if (ret != BINMGR_OK) {
+		return ret;
 	}
 
 	ret = binary_manager_send_request(&request_msg);
-	if (ret < 0) {
-		bmdbg("Failed to send request msg %d\n", ret);
-		return BINMGR_COMMUNICATION_FAIL;
+	if (ret != BINMGR_OK) {
+		return ret;
 	}
 
 	return BINMGR_OK;
 }
 
-int binary_manager_get_update_info(char *binary_name, binary_update_info_t *binary_info)
+binmgr_result_type_e binary_manager_get_update_info(char *binary_name, binary_update_info_t *binary_info)
 {
-	int ret;
+	binmgr_result_type_e ret;
 	binmgr_request_t request_msg;
 	binmgr_getinfo_response_t response_msg;
 
@@ -66,20 +65,18 @@ int binary_manager_get_update_info(char *binary_name, binary_update_info_t *bina
 	}
 
 	ret = binary_manager_set_request(&request_msg, BINMGR_GET_INFO, binary_name);
-	if (ret < 0) {
-		return BINMGR_COMMUNICATION_FAIL;
+	if (ret != BINMGR_OK) {
+		return ret;
 	}
 
 	ret = binary_manager_send_request(&request_msg);
-	if (ret < 0) {
-		bmdbg("Failed to send request msg %d\n", ret);
-		return BINMGR_COMMUNICATION_FAIL;
+	if (ret != BINMGR_OK) {
+		return ret;
 	}
 
 	ret = binary_manager_receive_response(&response_msg, sizeof(binmgr_getinfo_response_t));
-	if (ret < 0) {
-		bmdbg("Failed to receive response msg %d\n", ret);
-		return BINMGR_COMMUNICATION_FAIL;
+	if (ret != BINMGR_OK) {
+		return ret;
 	}
 
 	if (response_msg.result == BINMGR_OK) {
@@ -93,27 +90,25 @@ int binary_manager_get_update_info(char *binary_name, binary_update_info_t *bina
 	return response_msg.result;
 }
 
-int binary_manager_get_update_info_all(binary_update_info_list_t *binary_info_list)
+binmgr_result_type_e binary_manager_get_update_info_all(binary_update_info_list_t *binary_info_list)
 {
-	int ret;
+	binmgr_result_type_e ret;
 	binmgr_request_t request_msg;
 	binmgr_getinfo_all_response_t response_msg;
 
 	ret = binary_manager_set_request(&request_msg, BINMGR_GET_INFO_ALL, NULL);
-	if (ret < 0) {
-		return BINMGR_COMMUNICATION_FAIL;
+	if (ret != BINMGR_OK) {
+		return ret;
 	}
 
 	ret = binary_manager_send_request(&request_msg);
-	if (ret < 0) {
-		bmdbg("Failed to send request msg %d\n", ret);
-		return BINMGR_COMMUNICATION_FAIL;
+	if (ret != BINMGR_OK) {
+		return ret;
 	}
 
 	ret = binary_manager_receive_response(&response_msg, sizeof(binmgr_getinfo_all_response_t));
-	if (ret < 0) {
-		bmdbg("Failed to receive response msg %d\n", ret);
-		return BINMGR_COMMUNICATION_FAIL;
+	if (ret != BINMGR_OK) {
+		return ret;
 	}
 
 	if (response_msg.result == BINMGR_OK) {
@@ -127,9 +122,9 @@ int binary_manager_get_update_info_all(binary_update_info_list_t *binary_info_li
 	return response_msg.result;
 }
 
-int binary_manager_get_download_path(char *binary_name, uint32_t version, char *download_path)
+binmgr_result_type_e binary_manager_get_download_path(char *binary_name, uint32_t version, char *download_path)
 {
-	int ret;
+	binmgr_result_type_e ret;
 	binmgr_update_bin_t data;
 	binmgr_request_t request_msg;
 	binmgr_createbin_response_t response_msg;
@@ -143,20 +138,18 @@ int binary_manager_get_download_path(char *binary_name, uint32_t version, char *
 	data.version = version;
 
 	ret = binary_manager_set_request(&request_msg, BINMGR_CREATE_BIN, &data);
-	if (ret < 0) {
-		return BINMGR_COMMUNICATION_FAIL;
+	if (ret != BINMGR_OK) {
+		return ret;
 	}
-		
+
 	ret = binary_manager_send_request(&request_msg);
-	if (ret < 0) {
-		bmdbg("Failed to send request msg %d\n", ret);
-		return BINMGR_COMMUNICATION_FAIL;
+	if (ret != BINMGR_OK) {
+		return ret;
 	}
 
 	ret = binary_manager_receive_response(&response_msg, sizeof(binmgr_createbin_response_t));
-	if (ret < 0) {
-		bmdbg("Failed to receive response msg %d\n", ret);
-		return BINMGR_COMMUNICATION_FAIL;
+	if (ret != BINMGR_OK) {
+		return ret;
 	}
 
 	if (response_msg.result == BINMGR_OK) {

--- a/framework/src/binary_manager/binary_manager_update.c
+++ b/framework/src/binary_manager/binary_manager_update.c
@@ -127,9 +127,8 @@ int binary_manager_get_update_info_all(binary_update_info_list_t *binary_info_li
 	return response_msg.result;
 }
 
-int binary_manager_open_new_entry(char *binary_name, uint32_t version)
+int binary_manager_get_download_path(char *binary_name, uint32_t version, char *download_path)
 {
-	int fd;
 	int ret;
 	binmgr_update_bin_t data;
 	binmgr_request_t request_msg;
@@ -161,12 +160,8 @@ int binary_manager_open_new_entry(char *binary_name, uint32_t version)
 	}
 
 	if (response_msg.result == BINMGR_OK) {
-		fd = open(response_msg.binpath, O_RDWR | O_CREAT, 0666);
-		if (fd < 0) {
-			bmdbg("Failed to open file %s : %d\n", response_msg.binpath, errno);
-			return BINMGR_OPERATION_FAIL;
-		}
-		return fd;
+		bmvdbg("Create file path : %s\n", response_msg.binpath);
+		strncpy(download_path, response_msg.binpath, strlen(response_msg.binpath) + 1);
 	}
 
 	return response_msg.result;

--- a/loadable_apps/loadable_sample/wifiapp/binary_update.c
+++ b/loadable_apps/loadable_sample/wifiapp/binary_update.c
@@ -71,10 +71,10 @@ static int binary_update_download_binary(binary_update_info_t *binary_info, int 
 	uint32_t crc_hash = 0;
 	uint8_t buffer[BUFFER_SIZE];
 	binary_header_t header_data;
-	char filepath[CONFIG_PATH_MAX];
-	char new_filepath[CONFIG_PATH_MAX];
+	char filepath[BINARY_PATH_LEN];
+	char new_filepath[BINARY_PATH_LEN];
 
-	snprintf(filepath, CONFIG_PATH_MAX, "%s/%s_%u", BINARY_DIR_PATH, APP_NAME, (uint32_t)binary_info->version);
+	snprintf(filepath, BINARY_PATH_LEN, "%s/%s_%u", BINARY_DIR_PATH, APP_NAME, (uint32_t)binary_info->version);
 	read_fd = open(filepath, O_RDONLY);
 	if (read_fd < 0) {
 		fail_cnt++;
@@ -181,15 +181,15 @@ static int binary_update_download_new_binary(void)
 	uint8_t buffer[BUFFER_SIZE];
 	binary_header_t header_data;
 	binary_update_info_t bin_info;
-	char filepath[CONFIG_PATH_MAX];
-	char new_filepath[CONFIG_PATH_MAX];
+	char filepath[BINARY_PATH_LEN];
+	char new_filepath[BINARY_PATH_LEN];
 	int filesize;
 	FILE *fp;
 
 	/* Get 'micom' binary info */
 	binary_manager_get_update_info(APP_NAME, &bin_info);
 
-	snprintf(filepath, CONFIG_PATH_MAX, "%s/%s_%u", BINARY_DIR_PATH, APP_NAME, (uint32_t)bin_info.version);
+	snprintf(filepath, BINARY_PATH_LEN, "%s/%s_%u", BINARY_DIR_PATH, APP_NAME, (uint32_t)bin_info.version);
 
 	/* Get 'micom' binary file size */
 	fp = fopen(filepath, "r");
@@ -435,7 +435,7 @@ static int binary_update_unregister_state_changed_callback(void)
 static void binary_update_same_version_test(void)
 {
 	int ret;	
-	char filepath[CONFIG_PATH_MAX];
+	char filepath[BINARY_PATH_LEN];
 	binary_update_info_t bin_info;
 
 	ret = binary_update_getinfo(APP_NAME, &bin_info);
@@ -455,7 +455,7 @@ static void binary_update_same_version_test(void)
 static void binary_update_new_version_test(void)
 {
 	int ret;
-	char filepath[CONFIG_PATH_MAX];
+	char filepath[BINARY_PATH_LEN];
 	binary_update_info_t pre_bin_info;
 	binary_update_info_t cur_bin_info;
 
@@ -485,7 +485,7 @@ static void binary_update_new_version_test(void)
 	ret = binary_update_check_test_result(&pre_bin_info, &cur_bin_info, DOWNLOAD_VALID_BIN);
 	if (ret == OK) {
 		/* Unlink binary file with old version */
-		snprintf(filepath, CONFIG_PATH_MAX, "%s/%s_%u", BINARY_DIR_PATH, APP_NAME, (uint32_t)pre_bin_info.version);
+		snprintf(filepath, BINARY_PATH_LEN, "%s/%s_%u", BINARY_DIR_PATH, APP_NAME, (uint32_t)pre_bin_info.version);
 		unlink(filepath);
 	}
 }
@@ -525,7 +525,7 @@ static void binary_update_invalid_binary_test(void)
 static void binary_update_new_binary_test(void)
 {
 	int ret;
-	char filepath[CONFIG_PATH_MAX];
+	char filepath[BINARY_PATH_LEN];
 	binary_update_info_t bin_info;
 
 	/* Copy current binary and update version. */
@@ -553,7 +553,7 @@ static void binary_update_new_binary_test(void)
 	}
 
 	/* Unlink binary file */
-	snprintf(filepath, CONFIG_PATH_MAX, "%s/%s_%u", BINARY_DIR_PATH, NEW_APP_NAME, NEW_APP_VERSION);
+	snprintf(filepath, BINARY_PATH_LEN, "%s/%s_%u", BINARY_DIR_PATH, NEW_APP_NAME, NEW_APP_VERSION);
 	unlink(filepath);
 }
 

--- a/os/binfmt/binfmt_execmodule.c
+++ b/os/binfmt/binfmt_execmodule.c
@@ -349,7 +349,7 @@ int exec_module(FAR struct binary_s *binp)
 
 	/* Update id and state in binary table */
 	BIN_ID(binary_idx) = pid;
-	BIN_STATE(binary_idx) = BINARY_LOADING_DONE;
+	BIN_STATE(binary_idx) = BINARY_LOADED;
 	BIN_LOADVER(binary_idx) = binp->bin_ver;
 #ifdef CONFIG_OPTIMIZE_APP_RELOAD_TIME
 	BIN_LOADINFO(binary_idx) = binp;

--- a/os/include/tinyara/binary_manager.h
+++ b/os/include/tinyara/binary_manager.h
@@ -114,7 +114,7 @@ enum binmgr_request_msg_type {
 };
 
 /* Result values of returned from binary manager. */
-enum binmgr_response_result_type {
+enum binmgr_result_type {
 	BINMGR_OK = 0,
 	BINMGR_COMMUNICATION_FAIL = -1,
 	BINMGR_OPERATION_FAIL = -2,
@@ -124,6 +124,7 @@ enum binmgr_response_result_type {
 	BINMGR_ALREADY_REGISTERED = -6,
 	BINMGR_ALREADY_UPDATED = -7,
 };
+typedef enum binmgr_result_type binmgr_result_type_e;
 
 /****************************************************************************
  * Public Data
@@ -226,25 +227,25 @@ struct binmgr_createbin_response_s {
 typedef struct binmgr_createbin_response_s binmgr_createbin_response_t;
 
 struct binmgr_getstate_response_s {
-	int result;
+	binmgr_result_type_e result;
 	binary_state_e state;
 };
 typedef struct binmgr_getstate_response_s binmgr_getstate_response_t;
 
 struct binmgr_statecb_response_s {
-	int result;
+	binmgr_result_type_e result;
 	binmgr_cb_t *cb_info;
 };
 typedef struct binmgr_statecb_response_s binmgr_statecb_response_t;
 
 struct binmgr_getinfo_response_s {
-	int result;
+	binmgr_result_type_e result;
 	binary_update_info_t data;
 };
 typedef struct binmgr_getinfo_response_s binmgr_getinfo_response_t;
 
 struct binmgr_getinfo_all_response_s {
-	int result;
+	binmgr_result_type_e result;
 	binary_update_info_list_t data;
 };
 typedef struct binmgr_getinfo_all_response_s binmgr_getinfo_all_response_t;

--- a/os/include/tinyara/binary_manager.h
+++ b/os/include/tinyara/binary_manager.h
@@ -86,11 +86,24 @@ enum binary_statecb_state_e {
 	BINARY_READYTOUNLOAD = 2,     /* Binary will be unloaded */
 };
 
+/* States for user binary */
+enum binary_state {
+	BINARY_UNREGISTERED = 0,     /* File is not existing */
+	BINARY_INACTIVE = 1,         /* File is existing but binary is not loaded yet */
+	BINARY_LOADED = 2,           /* Loading binary is done */
+	BINARY_RUNNING = 3,          /* Loaded binary gets scheduling */
+	BINARY_UNLOADING = 4,        /* Loaded binary would be unloaded */
+	BINARY_FAULT = 5,            /* Binary is excluded from scheduling and would be reloaded */
+	BINARY_STATE_MAX,
+};
+typedef enum binary_state binary_state_e;
+
 /* Message type for binary manager */
 enum binmgr_request_msg_type {
 	BINMGR_GET_INFO,
 	BINMGR_GET_INFO_ALL,
 	BINMGR_UPDATE,
+	BINMGR_GET_STATE,
 	BINMGR_CREATE_BIN,
 	BINMGR_NOTIFY_STARTED,
 	BINMGR_REGISTER_STATECB,
@@ -211,6 +224,12 @@ struct binmgr_createbin_response_s {
 	char binpath[BINARY_PATH_LEN];
 };
 typedef struct binmgr_createbin_response_s binmgr_createbin_response_t;
+
+struct binmgr_getstate_response_s {
+	int result;
+	binary_state_e state;
+};
+typedef struct binmgr_getstate_response_s binmgr_getstate_response_t;
 
 struct binmgr_statecb_response_s {
 	int result;

--- a/os/include/tinyara/binary_manager.h
+++ b/os/include/tinyara/binary_manager.h
@@ -130,9 +130,6 @@ struct binary_update_info_s {
 	char name[BIN_NAME_MAX];
 	/* A double type to cover kernel version as float type and user binary version as uint32_t type */
 	double version;
-#if KERNEL_BIN_COUNT > 1
-	char inactive_dev[BINMGR_DEVNAME_LEN];
-#endif
 };
 typedef struct binary_update_info_s binary_update_info_t;
 

--- a/os/include/tinyara/binary_manager.h
+++ b/os/include/tinyara/binary_manager.h
@@ -70,6 +70,15 @@
 /* Mount point for User binaries */
 #define BINARY_DIR_PATH                  CONFIG_MOUNT_POINT"bins"
 
+/* The length of binary file or kernel partition path.
+ * A path is same like below:
+ *  - User filepath : "/<mount_path>/<binary_name>_<binary_version>"
+ *         length : CONFIG_NAME_MAX + BIN_NAME_MAX + binary_version (32) + /,_(3) + '\0'(1)
+ *  - Kernel partpath : "/dev/mtdblock#" defined as BINMGR_DEVNAME_FMT
+ * So define binary path length as (CONFIG_NAME_MAX + BIN_NAME_MAX + 40) with some extra.
+ */
+#define BINARY_PATH_LEN                  (CONFIG_NAME_MAX + BIN_NAME_MAX + 40)
+
 /* Binary states used in state callback */
 enum binary_statecb_state_e {
 	BINARY_STARTED = 0,           /* Binary is started */
@@ -199,7 +208,7 @@ typedef struct binmgr_request_s binmgr_request_t;
 
 struct binmgr_createbin_response_s {
 	int result;
-	char binpath[CONFIG_PATH_MAX];
+	char binpath[BINARY_PATH_LEN];
 };
 typedef struct binmgr_createbin_response_s binmgr_createbin_response_t;
 

--- a/os/kernel/binary_manager/binary_manager.c
+++ b/os/kernel/binary_manager/binary_manager.c
@@ -138,6 +138,9 @@ int binary_manager(int argc, char *argv[])
 		case BINMGR_GET_INFO_ALL:
 			binary_manager_get_info_all(request_msg.requester_pid);
 			break;
+		case BINMGR_GET_STATE:
+			binary_manager_get_state_with_name(request_msg.requester_pid, (char *)request_msg.data.bin_name);
+			break;
 		case BINMGR_UPDATE:
 			binary_manager_execute_loader(LOADCMD_UPDATE, binary_manager_get_index_with_name(request_msg.data.bin_name));
 			break;

--- a/os/kernel/binary_manager/binary_manager.h
+++ b/os/kernel/binary_manager/binary_manager.h
@@ -106,17 +106,6 @@ enum loading_thread_cmd {
 	LOADCMD_LOAD_MAX,
 };
 
-/* Binary states */
-enum binary_state_e {
-	BINARY_UNREGISTERED = 0,     /* Partition is unregistered */
-	BINARY_INACTIVE = 1,         /* Partition is registered, but binary is not loaded yet */
-	BINARY_LOADING_DONE = 2,     /* Loading binary is done */
-	BINARY_RUNNING = 3,          /* Loaded binary gets scheduling */
-	BINARY_WAITUNLOAD = 4,       /* Loaded binary would be unloaded */
-	BINARY_FAULT = 5,            /* Binary is excluded from scheduling and would be reloaded */
-	BINARY_STATE_MAX,
-};
-
 /* Binary types */
 enum binary_type_e {
 	BINARY_TYPE_REALTIME = 0,
@@ -244,6 +233,7 @@ uint32_t binary_manager_get_kcount(void);
 binmgr_kinfo_t *binary_manager_get_kdata(void);
 void binary_manager_get_info_with_name(int request_pid, char *bin_name);
 void binary_manager_get_info_all(int request_pid);
+void binary_manager_get_state_with_name(int request_pid, char *bin_name);
 void binary_manager_send_response(char *q_name, void *response_msg, int msg_size);
 int binary_manager_register_ubin(char *name, uint32_t version, uint8_t load_priority);
 void binary_manager_scan_ubin_all(void);

--- a/os/kernel/binary_manager/binary_manager_getinfo.c
+++ b/os/kernel/binary_manager/binary_manager_getinfo.c
@@ -82,7 +82,7 @@ int binary_manager_get_available_size(int bin_idx)
 	char *bin_name;
 	struct stat file_buf;
 	struct statfs fs_buf;
-	char filepath[CONFIG_PATH_MAX];
+	char filepath[BINARY_PATH_LEN];
 	char running_file[NAME_MAX];
 
 	snprintf(running_file, NAME_MAX, "%s_%d", BIN_NAME(bin_idx), BIN_LOADVER(bin_idx));
@@ -118,7 +118,7 @@ int binary_manager_get_available_size(int bin_idx)
 			/* Calculate size of old binary files to be removed when creating new file */
 			if (DIRENT_ISFILE(entryp->d_type) && !strncmp(entryp->d_name, bin_name, name_len) \
 				&& entryp->d_name[name_len] == '_' && strncmp(entryp->d_name, running_file, strlen(running_file))) {
-				snprintf(filepath, CONFIG_PATH_MAX, "%s/%s", BINARY_DIR_PATH, entryp->d_name);
+				snprintf(filepath, BINARY_PATH_LEN, "%s/%s", BINARY_DIR_PATH, entryp->d_name);
 				if (stat(filepath, &file_buf) == OK) {
 					bmvdbg("filepath %s size %d\n", filepath, file_buf.st_size);
 					size += file_buf.st_size;

--- a/os/kernel/binary_manager/binary_manager_getinfo.c
+++ b/os/kernel/binary_manager/binary_manager_getinfo.c
@@ -211,7 +211,6 @@ void binary_manager_get_info_all(int requester_pid)
 	response_msg.data.bin_info[result_idx].version = kerinfo->version;
 	if (kerinfo->part_count > 1) {
 		response_msg.data.bin_info[result_idx].available_size = kerinfo->part_info[kerinfo->inuse_idx ^ 1].part_size;
-		snprintf(response_msg.data.bin_info[result_idx].inactive_dev, BINMGR_DEVNAME_LEN, BINMGR_DEVNAME_FMT, kerinfo->part_info[kerinfo->inuse_idx ^ 1].part_num);
 	}
 	result_idx++;
 

--- a/os/kernel/binary_manager/binary_manager_getinfo.c
+++ b/os/kernel/binary_manager/binary_manager_getinfo.c
@@ -136,6 +136,41 @@ int binary_manager_get_available_size(int bin_idx)
 }
 
 /****************************************************************************
+ * Name: binary_manager_get_state_with_name
+ *
+ * Description:
+ *	 This function gets binary state with binary name.
+ *
+ ****************************************************************************/
+void binary_manager_get_state_with_name(int requester_pid, char *bin_name)
+{
+	int bin_idx;
+	uint32_t bin_count;
+	char q_name[BIN_PRIVMQ_LEN];
+	binmgr_getstate_response_t response_msg;
+
+	if (requester_pid < 0 || bin_name == NULL) {
+		bmdbg("Invalid data pid %d name %s\n", requester_pid, bin_name);
+		return;
+	}
+	snprintf(q_name, BIN_PRIVMQ_LEN, "%s%d", BINMGR_RESPONSE_MQ_PREFIX, requester_pid);
+
+	memset((void *)&response_msg, 0, sizeof(binmgr_getstate_response_t));
+	response_msg.result = BINMGR_NOT_FOUND;
+
+	bin_count = binary_manager_get_ucount();
+	for (bin_idx = 1; bin_idx <= bin_count; bin_idx++) {
+		if (!strncmp(BIN_NAME(bin_idx), bin_name, strlen(bin_name) + 1)) {
+			response_msg.result = BINMGR_OK;
+			response_msg.state = BIN_STATE(bin_idx);
+			break;
+		}
+	}
+
+	binary_manager_send_response(q_name, &response_msg, sizeof(binmgr_getstate_response_t));
+}
+
+/****************************************************************************
  * Name: binary_manager_get_info_with_name
  *
  * Description:

--- a/os/kernel/binary_manager/binary_manager_load.c
+++ b/os/kernel/binary_manager/binary_manager_load.c
@@ -110,6 +110,7 @@ static int binary_manager_load_binary(int bin_idx, char *path, load_attr_t *load
 			bmvdbg("Load '%s' success! pid = %d\n", path, ret);
 			/* Set the data in table from header */
 			BIN_LOAD_ATTR(bin_idx) = *load_attr;
+			strncpy(BIN_NAME(bin_idx), load_attr->bin_name, BIN_NAME_MAX);
 			bmvdbg("BIN TABLE[%d] %d %d %d %.1f %s\n", bin_idx, BIN_SIZE(bin_idx), BIN_RAMSIZE(bin_idx), BIN_LOADVER(bin_idx), BIN_KERNEL_VER(bin_idx), BIN_NAME(bin_idx));
 			return OK;
 		} else if (errno == ENOMEM) {
@@ -207,7 +208,6 @@ static int binary_manager_load(int bin_idx)
 		ret = binary_manager_load_binary(bin_idx, filepath, &load_attr);
 		if (ret == OK) {
 			BIN_KERNEL_VER(bin_idx) = header_data.kernel_ver;
-			strncpy(BIN_NAME(bin_idx), header_data.bin_name, BIN_NAME_MAX);
 			return BINMGR_OK;
 		}
 		if (--bin_count > 0) {


### PR DESCRIPTION
User can get a path download binary instead of opened fd from binary_manager_open_new_entry.
And then user can perform file operations like open, read, write.