### PR TITLE
include/tinyara: Resolve build break for rtl8721csm/security_hal_test config

### DIFF
--- a/os/include/tinyara/seclink_drv.h
+++ b/os/include/tinyara/seclink_drv.h
@@ -2,6 +2,7 @@
 #define _SECLINK_DRV_H__
 
 #include <stdint.h>
+#include <semaphore.h>
 
 struct sec_lowerhalf_s;
 struct sec_upperhalf_s {


### PR DESCRIPTION
This patch resolves build break for rtl8721csm/security_hal_test configuration.

Signed-off-by: Vidisha <thapa.v@samsung.com>