### PR TITLE
Update ramdump as per latest TizenRT code

### DIFF
--- a/os/board/common/crashdump.c
+++ b/os/board/common/crashdump.c
@@ -103,72 +103,30 @@ static int ramdump_via_uart(void)
 	up_lowputc('A');
 
 	/* Send number of memory regions to HOST */
-	up_lowputc(CONFIG_MM_REGIONS);
-
-#if defined(CONFIG_MM_KERNEL_HEAP)
-	/* Send 1 to HOST if kernel heap exists */
-	up_lowputc('1');
-
-	/* Send number of memory regions to HOST */
 	up_lowputc(CONFIG_KMM_REGIONS);
 
-	/* Send number of memory regions to HOST */
-	up_lowputc((CONFIG_MM_REGIONS + CONFIG_KMM_REGIONS));
-
 	/* Send memory region address, size & heap index to HOST */
-	for (x = 0; x < (CONFIG_MM_REGIONS + CONFIG_KMM_REGIONS); x++) {
-#else
-	/* Send 1 to HOST if kernel heap exists */
-	up_lowputc('0');
+	for (x = 0; x < CONFIG_KMM_REGIONS; x++) {
 
-	/* Send memory region address, size & heap index to HOST */
-	for (x = 0; x < CONFIG_MM_REGIONS; x++) {
-#endif
-
-		if (x < CONFIG_MM_REGIONS) {
-
-			/* Send RAM address */
-			ptr = (uint8_t *)&regionx_start[x];
-			for (i = 0; i < sizeof(regionx_start[x]); i++) {
-				up_lowputc((uint8_t)*ptr);
-				ptr++;
-			}
-
-			/* Send RAM size */
-			ptr = (uint8_t *)&regionx_size[x];
-			for (i = 0; i < sizeof(regionx_size[x]); i++) {
-				up_lowputc((uint8_t)*ptr);
-				ptr++;
-			}
-
-			/* Send Heap Index */
-			up_lowputc(regionx_heap_idx[x]);
+		/* Send RAM address */
+		ptr = (uint8_t *)&kregionx_start[x];
+		for (i = 0; i < sizeof(kregionx_start[x]); i++) {
+			up_lowputc((uint8_t)*ptr);
+			ptr++;
 		}
-#if defined(CONFIG_MM_KERNEL_HEAP)
-		else if (x >= CONFIG_MM_REGIONS) {
-			int y =  x - CONFIG_MM_REGIONS;
 
-			/* Send Kernel region address */
-			ptr = (uint8_t *)&kregionx_start[y];
-			for (i = 0; i < sizeof(kregionx_start[y]); i++) {
-				up_lowputc((uint8_t)*ptr);
-				ptr++;
-			}
-
-			/* Send Kernel region size */
-			ptr = (uint8_t *)&kregionx_size[y];
-			for (i = 0; i < sizeof(kregionx_size[y]); i++) {
-				up_lowputc((uint8_t)*ptr);
-				ptr++;
-			}
-
-			/* Send Kernel Heap Index */
-			up_lowputc(regionx_kheap_idx[y]);
+		/* Send RAM size */
+		ptr = (uint8_t *)&kregionx_size[x];
+		for (i = 0; i < sizeof(kregionx_size[x]); i++) {
+			up_lowputc((uint8_t)*ptr);
+			ptr++;
 		}
-#endif
+
+		/* Send Heap Index */
+		up_lowputc(kregionx_heap_idx[x]);
 	}
 
-	/* Receive number of user memory regions to be dumped from HOST */
+	/* Receive number of memory regions to be dumped from HOST */
 	do {
 		if ((ch = up_getc()) != -1) {
 			host_reg[0] = ch;
@@ -189,32 +147,14 @@ static int ramdump_via_uart(void)
 
 		target_region = host_reg[0] - '0';
 
-		if (target_region < CONFIG_MM_REGIONS) {
-
-			/* Send User MM dump of size bytes */
-			ptr = (uint8_t *)regionx_start[target_region];
-			size = regionx_size[target_region];
-			while (size) {
-				up_lowputc((uint8_t)*ptr);
-				ptr++;
-				size--;
-			}
+		/* Send memory dump of size bytes */
+		ptr = (uint8_t *)kregionx_start[target_region];
+		size = kregionx_size[target_region];
+		while (size) {
+			up_lowputc((uint8_t)*ptr);
+			ptr++;
+			size--;
 		}
-#if defined(CONFIG_MM_KERNEL_HEAP)
-		else if (target_region >= CONFIG_MM_REGIONS) {
-			target_region =  target_region - CONFIG_MM_REGIONS;
-
-			/* Send Kernel MM dump of size bytes */
-			ptr = (uint8_t *)kregionx_start[target_region];
-			size = kregionx_size[target_region];
-			while (size) {
-				up_lowputc((uint8_t)*ptr);
-				ptr++;
-				size--;
-			}
-
-		}
-#endif
 	}
 
 	lldbg(" Successfull\n");


### PR DESCRIPTION
This PR removes the user space memory dependencies of ramdump
tool(CONFIG_RAM_REGIONx_xx) since protected build feature has
been removed TizenRT. Instead of supporting kernel & user heap dumps,
this tool now simply supports memory dump, the memory cofnigurations
for which are extracted using the following configs:
CONFIG_RAM_KREGIONx_xx

Signed-off-by: Vidisha <thapa.v@samsung.com>