### PR TITLE
os/arch/arm: Provide function for disabling MPU region for armv7-m/armv8-m

### DIFF
--- a/os/arch/arm/src/armv7-m/up_mpu.c
+++ b/os/arch/arm/src/armv7-m/up_mpu.c
@@ -58,9 +58,13 @@
 
 #include <stdint.h>
 #include <assert.h>
+#include <stdbool.h>
+
+#include <tinyara/mpu.h>
 
 #include "mpu.h"
 #include "up_internal.h"
+#include "up_arch.h"
 
 /****************************************************************************
  * Pre-processor Definitions
@@ -376,4 +380,39 @@ void up_mpu_set_register(uint32_t *mpu_regs)
 		putreg32(mpu_regs[REG_RBAR], MPU_RBAR);
 		putreg32(mpu_regs[REG_RASR], MPU_RASR);
 	}
+}
+
+/****************************************************************************
+ * Name: up_mpu_check_active
+ *
+ * Description:
+ *   Checks if mpu registers passed as argument are the ones set in
+ *   mpu h/w
+ *
+ ****************************************************************************/
+bool up_mpu_check_active(uint32_t *mpu_regs)
+{
+	/* Set MPU_RNR register before getting corresponding
+	 * MPU_RBAR and MPU_RASR values
+	 */
+	putreg32(mpu_regs[REG_RNR], MPU_RNR);
+
+	return (getreg32(MPU_RBAR) == mpu_regs[REG_RBAR] && getreg32(MPU_RASR) == mpu_regs[REG_RASR]);
+}
+
+/****************************************************************************
+ * Name: up_mpu_disable_region
+ *
+ * Description:
+ *   Update tcb's mpu register values to disable a mpu region
+ *   and set these new register values to mpu h/w as well.
+ *
+ ****************************************************************************/
+void up_mpu_disable_region(uint32_t *mpu_regs)
+{
+	/* Disable region's Enable bit in mpu register settings */
+	mpu_regs[REG_RASR] &= ~MPU_RASR_ENABLE;
+
+	/* Set updated mpu register values to mpu h/w */
+	up_mpu_set_register(mpu_regs);
 }

--- a/os/arch/arm/src/armv8-m/up_mpu.c
+++ b/os/arch/arm/src/armv8-m/up_mpu.c
@@ -58,9 +58,13 @@
 
 #include <stdint.h>
 #include <assert.h>
+#include <stdbool.h>
+
+#include <tinyara/mpu.h>
 
 #include "mpu.h"
 #include "up_internal.h"
+#include "up_arch.h"
 
 /****************************************************************************
  * Pre-processor Definitions
@@ -186,4 +190,39 @@ void up_mpu_set_register(uint32_t *mpu_regs)
 		putreg32(mpu_regs[REG_RBAR], MPU_RBAR);
 		putreg32(mpu_regs[REG_RASR], MPU_RLAR);
 	}
+}
+
+/****************************************************************************
+ * Name: up_mpu_check_active
+ *
+ * Description:
+ *   Checks if mpu registers passed as argument are the ones set in
+ *   mpu h/w
+ *
+ ****************************************************************************/
+bool up_mpu_check_active(uint32_t *mpu_regs)
+{
+	/* Set MPU_RNR register before getting corresponding
+	 * MPU_RBAR and MPU_RLAR values
+	 */
+	putreg32(mpu_regs[REG_RNR], MPU_RNR);
+
+	return (getreg32(MPU_RBAR) == mpu_regs[REG_RBAR] && getreg32(MPU_RLAR) == mpu_regs[REG_RASR]);
+}
+
+/****************************************************************************
+ * Name: up_mpu_disable_region
+ *
+ * Description:
+ *   Update tcb's mpu register values to disable a mpu region
+ *   and set these new register values to mpu h/w as well.
+ *
+ ****************************************************************************/
+void up_mpu_disable_region(uint32_t *mpu_regs)
+{
+	/* Disable region's Enable bit in mpu register settings */
+	mpu_regs[REG_RASR] &= ~MPU_RLAR_ENABLE;
+
+	/* Set updated mpu register values to mpu h/w */
+	up_mpu_set_register(mpu_regs);
 }

--- a/os/include/tinyara/mpu.h
+++ b/os/include/tinyara/mpu.h
@@ -97,4 +97,8 @@ void mpu_get_register_config_value(uint32_t *regs, uint32_t region, uintptr_t ba
 
 void up_mpu_set_register(uint32_t *mpu_regs);
 
+bool up_mpu_check_active(uint32_t *mpu_regs);
+
+void up_mpu_disable_region(uint32_t *mpu_regs);
+
 #endif


### PR DESCRIPTION
- **up_mpu_disable_region(..)** is provided in up_mpu.c files for **armv7-m/armv8-m**
- A tcb's mpu registers for a mpu region can be passed to disable the region's ENABLE bit in these registers.
- This feature is needed to fix crash during binary recovery when kernel is freeing stack resources for a stopped task. It is required (for armv8-m) to disable MPU region for stack protection so that kernel has full access to these resources before freeing them.
- While for armv7-m mpu, it is possible to give privileged code full RW permission for a mpu region while maintaining RO permission for unprivileged code, this is not possible for armv8-m mpu (inherent limitation). So, for armv8-m, if it is required for privileged code to have full RW access to a RO mpu region, we should disable the MPU region using up_mpu_disable_region(..).