### PR TITLE
os/binfmt: Fix crash issue when reload optimization is disabled

### DIFF
--- a/os/arch/arm/src/armv7-m/up_mpu.c
+++ b/os/arch/arm/src/armv7-m/up_mpu.c
@@ -343,7 +343,7 @@ void mpu_get_register_config_value(uint32_t *regs, uint32_t region, uintptr_t ba
 #endif
 			MPU_RASR_C;                 /* Cacheable     */
 	if (readonly) {
-		regval |= MPU_RASR_AP_RWRO;     /* P:RW   U:RO   */
+		regval |= MPU_RASR_AP_RORO;     /* P:RO   U:RO   */
 	} else {
 		regval |= MPU_RASR_AP_RWRW;     /* P:RW   U:RW   */
 	}

--- a/os/binfmt/binfmt_execmodule.c
+++ b/os/binfmt/binfmt_execmodule.c
@@ -181,7 +181,7 @@ int exec_module(FAR struct binary_s *binp)
 	/* The first 4 bytes of the text section of the application must contain a
 	pointer to the application's mm_heap object. Here we will store the mm_heap
 	pointer to the start of the text section */
-	*(uint32_t *)(binp->alloc[ALLOC_DATA]) = (uint32_t)binp->uheap;
+	*(uint32_t *)(binp->datastart) = (uint32_t)binp->uheap;
 	rtcb = (struct tcb_s *)sched_self();
 	rtcb->uheap = (uint32_t)binp->uheap;
 
@@ -189,11 +189,11 @@ int exec_module(FAR struct binary_s *binp)
 #ifdef CONFIG_ARM_MPU
 #ifdef CONFIG_OPTIMIZE_APP_RELOAD_TIME
 	/* Configure text section as RO and executable region */
-	mpu_get_register_config_value(&rtcb->mpu_regs[3], MPU_REG_NUM_APP_TXT, (uintptr_t)binp->alloc[ALLOC_TEXT], binp->textsize, true, true);
+	mpu_get_register_config_value(&rtcb->mpu_regs[0], MPU_REG_NUM_APP_TXT, (uintptr_t)binp->alloc[ALLOC_TEXT], binp->textsize, true, true);
 	/* Configure ro section as RO and non-executable region */
-	mpu_get_register_config_value(&rtcb->mpu_regs[6], MPU_REG_NUM_APP_RO, (uintptr_t)binp->alloc[ALLOC_RO], binp->rosize, true, false);
+	mpu_get_register_config_value(&rtcb->mpu_regs[3], MPU_REG_NUM_APP_RO, (uintptr_t)binp->alloc[ALLOC_RO], binp->rosize, true, false);
 	/* Complete RAM partition will be configured as RW region */
-	mpu_get_register_config_value(&rtcb->mpu_regs[0], MPU_REG_NUM_APP_DATA, (uintptr_t)binp->alloc[ALLOC_DATA], binp->ramsize, false, false);
+	mpu_get_register_config_value(&rtcb->mpu_regs[6], MPU_REG_NUM_APP_DATA, (uintptr_t)binp->alloc[ALLOC_DATA], binp->ramsize, false, false);
 #else
 	/* Complete RAM partition will be configured as RW region */
 	mpu_get_register_config_value(&rtcb->mpu_regs[0], MPU_REG_NUM_APP, (uintptr_t)binp->ramstart, binp->ramsize, false, true);

--- a/os/binfmt/binfmt_loadbinary.c
+++ b/os/binfmt/binfmt_loadbinary.c
@@ -176,7 +176,7 @@ int load_binary(int binary_idx, FAR const char *filename, load_attr_t *load_attr
 			mpu_get_register_config_value(&com_bin_mpu_regs[3], MPU_REG_NUM_COM_LIB_RO,   (uintptr_t)bin->alloc[ALLOC_RO],   bin->rosize,   true,  false);
 			mpu_get_register_config_value(&com_bin_mpu_regs[6], MPU_REG_NUM_COM_LIB_DATA, (uintptr_t)bin->alloc[ALLOC_DATA], bin->ramsize,  false, false);
 #else
-			mpu_get_register_config_value(&com_bin_mpu_regs[0], MPU_REG_NUM_COM_LIB,      (uintptr_t)bin->ramstart,          bin->ramsize,  false, false);
+			mpu_get_register_config_value(&com_bin_mpu_regs[0], MPU_REG_NUM_COM_LIB,      (uintptr_t)bin->ramstart,          bin->ramsize,  false, true);
 #endif
 			/* Set MPU register values to real MPU h/w */
 			for (int i = 0; i < 3 * MPU_NUM_REGIONS; i += 3) {
@@ -199,7 +199,7 @@ int load_binary(int binary_idx, FAR const char *filename, load_attr_t *load_attr
 
 #ifdef CONFIG_SUPPORT_COMMON_BINARY
 	if (bin->islibrary) {
-		g_umm_app_id = bin->alloc[ALLOC_DATA] + 4;
+		g_umm_app_id = (uint32_t *)(bin->datastart + 4);
 #ifdef CONFIG_SAVE_BIN_SECTION_ADDR
 		elf_save_bin_section_addr(bin);
 #endif
@@ -208,7 +208,7 @@ int load_binary(int binary_idx, FAR const char *filename, load_attr_t *load_attr
 	/* If we support common binary, then we need to place a pointer to the app's heap object
 	 * into the heap table which is present at the start of the common library data section
 	 */
-	uint32_t *heap_table = (uint32_t *)(g_lib_binp->alloc[ALLOC_DATA] + 8);
+	uint32_t *heap_table = (uint32_t *)(g_lib_binp->datastart + 8);
 	heap_table[binary_idx] = bin->heapstart;
 #endif
 

--- a/os/binfmt/elf.c
+++ b/os/binfmt/elf.c
@@ -306,8 +306,8 @@ static int elf_loadbinary(FAR struct binary_s *binp)
 	 * to obtain the size of just the data backup.
 	 */
 	binp->datasize = loadinfo.datasize - binp->bsssize;
-	binp->datastart = loadinfo.dataalloc;
 #endif
+	binp->datastart = loadinfo.dataalloc;
 
 #ifdef CONFIG_BINFMT_CONSTRUCTORS
 	/* Save information about constructors and destructors. */

--- a/os/include/tinyara/binfmt/binfmt.h
+++ b/os/include/tinyara/binfmt/binfmt.h
@@ -111,6 +111,7 @@ struct binary_s {
 	uint32_t ramstart;		/* Start address of ram partition */
 	uint32_t ramsize;		/* Size of the RAM paritition */
 	uint32_t heapstart;		/* Start address of app heap area */
+	uint32_t datastart;		/* Start address of data section */
 #endif
 
 #if defined(CONFIG_SUPPORT_COMMON_BINARY) || defined(CONFIG_OPTIMIZE_APP_RELOAD_TIME)
@@ -120,7 +121,6 @@ struct binary_s {
 	size_t rosize;			/* Size of ro section */
 	size_t datasize;		/* Size of data section */
 	uint32_t reload;		/* Indicate whether this binary will be reloaded */
-	uint32_t datastart;		/* Start address of data section */
 	uint32_t bssstart;		/* Start address of bss section */
 	size_t bsssize;			/* Size of bss section */
 	uint32_t data_backup;		/* Start address of copy of data section */


### PR DESCRIPTION
Commit 1:

    When reload optimization is disabled, a single chunk of memory is
    allocated for holding all elf sections in RAM. In this case, the
    alloc[] array in binary_s structure will contain a single entry for
    the whole binary and any access to bin->alloc[DATA] will be invalid.
    So, we change all such access to bin->datastart which will hold the
    start address of data section.

Commit 2:

    arch/armv7-m: Set MPU permission to RO-RO for read only region
    
    Armv7m allows setting of different permissions for previleged and
    user modes. So, previously we were setting RW(P)-RO(U) permission for
    read only region. But armv8-m does not allow setting different permissions
    based on the mode. So, we are forced to set RO-RO permission for all
    read only regions. This commit changes the permission for armv7m read only
    region to RO-RO, so that the behavior is uniform between armv7m and armv8m.
    This commit also fixes a memfault issue which occurs when RO-RO permission
    is set and Common binary is enabled.

Signed-off-by: Kishore S N <kishore.sn@samsung.com>