### PR TITLE
os/fs/smartfs: Fix improper start address of buffer passed to append_data

### DIFF
--- a/os/fs/smartfs/smartfs_smart.c
+++ b/os/fs/smartfs/smartfs_smart.c
@@ -756,7 +756,7 @@ static ssize_t smartfs_write(FAR struct file *filep, const char *buffer, size_t 
 
 	/* Now append data to end of the file. */
 	if (buflen > 0) {
-		byteswritten = smartfs_append_data(fs, sf, &buffer[byteswritten], byteswritten, buflen);
+		byteswritten = smartfs_append_data(fs, sf, buffer, byteswritten, buflen);
 	}
 	ret = byteswritten;
 


### PR DESCRIPTION
- Pass buffer with 0 offset to smartfs_append_data().
- 'byteswritten' parameter takes care of offset internally.

Signed-off-by: Amogh Hassija <a.hassija@samsung.com>