### PR TITLE
mm/mm_sem : Add NULL check of heap for avoiding dereferencing

### DIFF
--- a/os/mm/kmm_heap/kmm_sem.c
+++ b/os/mm/kmm_heap/kmm_sem.c
@@ -55,6 +55,8 @@
  ************************************************************************/
 
 #include <tinyara/config.h>
+#include <debug.h>
+#include <errno.h>
 
 #include <tinyara/mm/mm.h>
 
@@ -96,7 +98,11 @@
 int kmm_trysemaphore(void *dummy_addr)
 {
 	struct mm_heap_s *kheap = mm_get_heap(dummy_addr);
-	return mm_trysemaphore(kheap);
+	if (kheap) {
+		return mm_trysemaphore(kheap);
+	}
+	mdbg("Invalid Heap address given, Fail to try to take sem.\n");
+	return -EFAULT;
 }
 
 /************************************************************************
@@ -115,7 +121,11 @@ int kmm_trysemaphore(void *dummy_addr)
 void kmm_givesemaphore(void *dummy_addr)
 {
 	struct mm_heap_s *kheap = mm_get_heap(dummy_addr);
-	return mm_givesemaphore(kheap);
+	if (kheap) {
+		mm_givesemaphore(kheap);
+	} else {
+		mdbg("Invalid Heap address given, Fail to give sem.\n");
+	}
 }
 
 #endif							/* CONFIG_MM_KERNEL_HEAP */

--- a/os/mm/kmm_heap/kmm_sem.c
+++ b/os/mm/kmm_heap/kmm_sem.c
@@ -114,9 +114,6 @@ int kmm_trysemaphore(void *dummy_addr)
  * Parameters:
  *   None
  *
- * Return Value:
- *   OK on success; a negated errno on failure
- *
  ************************************************************************/
 void kmm_givesemaphore(void *dummy_addr)
 {

--- a/os/mm/mm_heap/mm_sem.c
+++ b/os/mm/mm_heap/mm_sem.c
@@ -55,7 +55,7 @@
  ****************************************************************************/
 
 #include <tinyara/config.h>
-
+#include <debug.h>
 #include <unistd.h>
 #include <errno.h>
 #include <assert.h>
@@ -65,24 +65,6 @@
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
-
-/* Define the following to enable semaphore state monitoring */
-//#define MONITOR_MM_SEMAPHORE 1
-
-#ifdef MONITOR_MM_SEMAPHORE
-#ifdef CONFIG_DEBUG
-#include <debug.h>
-#define msemdbg dbg
-#else
-#define msemdbg printf
-#endif
-#else
-#ifdef CONFIG_CPP_HAVE_VARARGS
-#define msemdbg(...)
-#else
-#define msemdbg (void)
-#endif
-#endif
 
 /****************************************************************************
  * Private Data
@@ -171,7 +153,7 @@ void mm_takesemaphore(FAR struct mm_heap_s *heap)
 	} else {
 		/* Take the semaphore (perhaps waiting) */
 
-		msemdbg("PID=%d taking\n", my_pid);
+		mvdbg("PID=%d taking\n", my_pid);
 		while (sem_wait(&heap->mm_semaphore) != 0) {
 			/* The only case that an error should occur here is if
 			 * the wait was awakened by a signal.
@@ -186,7 +168,7 @@ void mm_takesemaphore(FAR struct mm_heap_s *heap)
 		heap->mm_counts_held = 1;
 	}
 
-	msemdbg("Holder=%d count=%d\n", heap->mm_holder, heap->mm_counts_held);
+	mvdbg("Holder=%d count=%d\n", heap->mm_holder, heap->mm_counts_held);
 }
 
 /****************************************************************************
@@ -213,12 +195,12 @@ void mm_givesemaphore(FAR struct mm_heap_s *heap)
 		/* Yes, just release one count and return */
 
 		heap->mm_counts_held--;
-		msemdbg("Holder=%d count=%d\n", heap->mm_holder, heap->mm_counts_held);
+		mvdbg("Holder=%d count=%d\n", heap->mm_holder, heap->mm_counts_held);
 	} else {
 		/* Nope, this is the last reference I have */
 
 #ifdef CONFIG_DEBUG
-		msemdbg("PID=%d giving\n", my_pid);
+		mvdbg("PID=%d giving\n", my_pid);
 #endif
 
 		heap->mm_holder      = -1;
@@ -240,7 +222,7 @@ void mm_is_sem_available(void *address)
 
 	heap = mm_get_heap(address);
 	if (heap == NULL) {
-		msemdbg("Fail to get heap.\n");
+		mdbg("Invalid Heap address given, Fail to check sem availability.\n");
 		return;
 	}
 	mm_takesemaphore(heap);

--- a/os/mm/mm_heap/mm_sem.c
+++ b/os/mm/mm_heap/mm_sem.c
@@ -120,7 +120,7 @@ int mm_trysemaphore(FAR struct mm_heap_s *heap)
 		/* Try to take the semaphore (perhaps waiting) */
 
 		if (sem_trywait(&heap->mm_semaphore) != 0) {
-			return ERROR;
+			return -get_errno();
 		}
 
 		/* We have it.  Claim the stak and return */

--- a/os/mm/umm_heap/umm_sem.c
+++ b/os/mm/umm_heap/umm_sem.c
@@ -55,6 +55,7 @@
  ************************************************************************/
 
 #include <tinyara/config.h>
+#include <debug.h>
 #include <errno.h>
 #include <tinyara/mm/mm.h>
 
@@ -101,8 +102,8 @@ int umm_trysemaphore(void *address)
 	if (heap) {
 		return mm_trysemaphore(heap);
 	}
-	set_errno(EFAULT);
-	return EFAULT;
+	mdbg("Invalid Heap address given, Fail to try to take sem.\n");
+	return -EFAULT;
 }
 
 /************************************************************************
@@ -116,9 +117,6 @@ int umm_trysemaphore(void *address)
  * Parameters:
  *   None
  *
- * Return Value:
- *   OK on success; a negated errno on failure
- *
  ************************************************************************/
 
 void umm_givesemaphore(void *address)
@@ -126,7 +124,7 @@ void umm_givesemaphore(void *address)
 	struct mm_heap_s *heap;
 	heap = mm_get_heap(address);
 	if (!heap) {
-		set_errno(EFAULT);
+		mdbg("Invalid Heap address given, Fail to give sem.\n");
 		return;
 	}
 	mm_givesemaphore(heap);


### PR DESCRIPTION
In mm APIs, heap pointer can be dereferencing sometimes.
To avoid dereferencing, add null checking.