### PR TITLE
os/mm: Fix memory leak issue due to mm_get_heap

### DIFF
--- a/os/binfmt/binfmt_execmodule.c
+++ b/os/binfmt/binfmt_execmodule.c
@@ -205,7 +205,8 @@ int exec_module(FAR struct binary_s *binp)
 
 	tcb = (FAR struct task_tcb_s *)kmm_zalloc(sizeof(struct task_tcb_s));
 	if (!tcb) {
-		return -ENOMEM;
+		ret = -ENOMEM;
+		goto errout_with_appheap;
 	}
 #if defined(CONFIG_ARCH_ADDRENV) && defined(CONFIG_BUILD_KERNEL)
 	/* Instantiate the address environment containing the user heap */
@@ -387,6 +388,10 @@ int exec_module(FAR struct binary_s *binp)
 
 	return (int)pid;
 
+errout_with_appheap:
+#ifdef CONFIG_APP_BINARY_SEPARATION
+	mm_remove_app_heap_list(binp->uheap);
+#endif
 errout_with_tcbinit:
 #ifdef CONFIG_BINARY_MANAGER
 	BIN_ID(binary_idx) = -1;

--- a/os/binfmt/binfmt_exit.c
+++ b/os/binfmt/binfmt_exit.c
@@ -137,13 +137,14 @@ int binfmt_exit(FAR struct binary_s *bin)
 		}
 		address = (FAR void *)sq_next((FAR sq_entry_t *)address);
 	}
-	mm_remove_app_heap_list(bin->uheap);
+	mm_disable_app_heap_list(bin->uheap);
 #endif
 	/* Free the load structure */
 
 #ifdef CONFIG_OPTIMIZE_APP_RELOAD_TIME
 	if (!bin->reload) {
 #endif
+		mm_remove_app_heap_list(bin->uheap);
 		/* Free the RAM partition into which this app was loaded */
 		kmm_free((void *)bin->ramstart);
 		kmm_free(bin);

--- a/os/include/tinyara/mm/mm.h
+++ b/os/include/tinyara/mm/mm.h
@@ -684,9 +684,10 @@ struct mm_heap_s *mm_get_heap_with_index(int index);
 int mm_get_heapindex(void *mem);
 
 #if defined(CONFIG_APP_BINARY_SEPARATION) && defined(__KERNEL__)
-void mm_initialize_app_heap(void);
+void mm_initialize_app_heap_q(void);
 void mm_add_app_heap_list(struct mm_heap_s *heap, char *app_name);
 void mm_remove_app_heap_list(struct mm_heap_s *heap);
+void mm_disable_app_heap_list(struct mm_heap_s *heap);
 struct mm_heap_s *mm_get_app_heap_with_name(char *app_name);
 char *mm_get_app_heap_name(void *address);
 #endif

--- a/os/kernel/init/os_start.c
+++ b/os/kernel/init/os_start.c
@@ -415,6 +415,10 @@ void os_start(void)
 
 	up_add_kregion();
 
+#ifdef CONFIG_APP_BINARY_SEPARATION
+	mm_initialize_app_heap_q();
+#endif
+
 #if defined(CONFIG_SCHED_HAVE_PARENT) && defined(CONFIG_SCHED_CHILD_STATUS)
 	/* Initialize tasking data structures */
 

--- a/os/mm/mm_heap/mm_getheap.c
+++ b/os/mm/mm_heap/mm_getheap.c
@@ -56,7 +56,7 @@ static dq_queue_t app_heap_q;
  * Public Functions
  ****************************************************************************/
 #if defined(CONFIG_APP_BINARY_SEPARATION) && defined(__KERNEL__)
-void mm_initialize_app_heap()
+void mm_initialize_app_heap_q()
 {
 	dq_init(&app_heap_q);
 }
@@ -98,6 +98,23 @@ void mm_remove_app_heap_list(struct mm_heap_s *heap)
 	while (node) {
 		if (node->heap == heap) {
 			/* Remove and free the matching node */
+			dq_rem((dq_entry_t *)node, &app_heap_q);
+			kmm_free(node);
+			return;
+		}
+
+		node = dq_next(node);
+	}
+}
+
+void mm_disable_app_heap_list(struct mm_heap_s *heap)
+{
+	app_heap_s *node = (app_heap_s *)dq_peek(&app_heap_q);
+
+	/* Search the heap node in the list */
+	while (node) {
+		if (node->heap == heap) {
+			/* Disable the matching node */
 			node->is_active = false;
 			return;
 		}

--- a/os/mm/mm_heap/mm_getheap.c
+++ b/os/mm/mm_heap/mm_getheap.c
@@ -82,6 +82,7 @@ void mm_add_app_heap_list(struct mm_heap_s *heap, char *app_name)
 		return;
 	}
 
+	node->is_active = true;
 	node->heap = heap;
 	strncpy(node->app_name, app_name, BIN_NAME_MAX);
 


### PR DESCRIPTION
We maintain a list of app heap objects in app_heap_list. When an
application is loaded for the first time, a new node is created and
added to this list. However, since the is_active variable in the node
is not set, it leads to a failure when searching the app_heap_list
for a heap corresponding to an address. In such case, the mm_free
operation fails to free the address, resulting in memory leak. The
issue is fixed by setting is_active to true when the app heap is being
added to the list.

Signed-off-by: Kishore S N <kishore.sn@samsung.com>