### PR TITLE
fs/smartfs : Add boundary check logic FIBMAP

### DIFF
--- a/os/fs/driver/mtd/smart.c
+++ b/os/fs/driver/mtd/smart.c
@@ -4808,6 +4808,9 @@ static int smart_ioctl(FAR struct inode *inode, int cmd, unsigned long arg)
 
 	case BIOC_FIBMAP:
 
+		if ((uint16_t)arg >= dev->totalsectors) {
+			return -EINVAL;
+		}
 #ifndef CONFIG_MTD_SMART_MINIMIZE_RAM
 		ret = (int)dev->sMap[(uint16_t)arg];
 #else


### PR DESCRIPTION
Currently we can request FIBMAP with EMTPY SECTOR(0xFFFF) in this case it is greater than
sMap, so error happened. Max size should be smaller than number of sectors in dev