### PR TITLE
arch/arm/imxrt/chip/imxrt_enet.h : Modify CONFIG_ARCH_FAMILY_IMXRT102…

### DIFF
--- a/os/arch/arm/src/imxrt/chip/imxrt_enet.h
+++ b/os/arch/arm/src/imxrt/chip/imxrt_enet.h
@@ -60,9 +60,9 @@
 #include <tinyara/config.h>
 
 #include "chip.h"
-#if defined(CONFIG_ARCH_FAMILY_IMXRT102x)
+#if defined(CONFIG_ARCH_CHIP_FAMILY_IMXRT102x)
 #include "chip/imxrt102x_config.h"
-#elif defined(CONFIG_ARCH_FAMILY_IMXRT105x)
+#elif defined(CONFIG_ARCH_CHIP_FAMILY_IMXRT105x)
 #include "chip/imxrt105x_config.h"
 #else
 #error Unrecognized i.MX RT architecture


### PR DESCRIPTION
…x to CONFIG_ARCH_CHIP_FAMILY_IMXRT102x

There is no definition of CONFIG_ARCH_FAMILY_IMXRT102x, but there is CONFIG_ARCH_CHIP_FAMILY_IMXRT102x.
So modified it.