### PR TITLE
shell: tidyup semicolon and exclamation commands

### DIFF
--- a/apps/shell/tash_command.c
+++ b/apps/shell/tash_command.c
@@ -240,7 +240,7 @@ static int tash_history(int argc, char **args)
  * @return     The address of command buffer selected on success, null on failure
  */
 
-char *tash_get_cmd_from_history(int hist_idx)
+static char *tash_get_cmd_from_history(int hist_idx)
 {
 	int cmd_idx;
 
@@ -346,6 +346,50 @@ bool tash_search_cmd(char *cmd, int *pos, char status)
 		}
 	}
 	return true;
+}
+
+/**
+ * @brief     treat exclamation command
+ * @details   Find the exclamation command and replace it to real command into buffer
+ * @param[in] buff The pointer of user input string
+ * @return    OK on success, ERROR on failure
+ */
+
+int check_exclam_cmd(char *buff)
+{
+	int hist_idx;
+	int histcmd_size;
+	char *histcmd_ptr;
+	char *exclam_ptr;
+	int ret = OK;
+
+	/* Find the '!' in the input character */
+
+	while ((exclam_ptr = strchr(buff, ASCII_EXCLAM)) != NULL) {
+		/* Get the command from history according to the given index */
+
+		hist_idx = strtol(exclam_ptr + 1, &buff, 10);
+		histcmd_ptr = tash_get_cmd_from_history(hist_idx);
+		if (!histcmd_ptr) {
+			/* No command, Let's finish */
+
+			ret = ERROR;
+			break;
+		} else {
+			histcmd_size = strlen(histcmd_ptr);
+			if (histcmd_size != (int)(buff - exclam_ptr)) {
+				/* "!number" does not have the same size as the command from the history list.
+				 * Let's adjust the location of next string to replace "!number" to real command string.
+				 */
+
+				memmove(exclam_ptr + histcmd_size, buff, strlen(buff));
+			}
+			/* Replace "!number" to real command string in buff */
+
+			strncpy(exclam_ptr, histcmd_ptr, histcmd_size);
+		}
+	}
+	return ret;
 }
 #endif
 

--- a/apps/shell/tash_command.c
+++ b/apps/shell/tash_command.c
@@ -233,28 +233,45 @@ static int tash_history(int argc, char **args)
 	return 0;
 }
 
-void tash_get_cmd_from_history(int num, char *cmd)
+/**
+ * @brief      Get the command in the history list
+ * @details    Return the address of command buffer which is selected by the index in history list
+ * @param[in]  hist_idx The index in the history list
+ * @return     The address of command buffer selected on success, null on failure
+ */
+
+char *tash_get_cmd_from_history(int hist_idx)
 {
-	if (num < 1 || num >= TASH_MAX_STORE) {
-		return;
+	int cmd_idx;
+
+	if (hist_idx < 0) {
+		printf("Not supported\n");
+		return NULL;
+	} else if (hist_idx == 0 || hist_idx >= TASH_MAX_STORE) {
+		printf("!%d: event not found\n", hist_idx);
+		return NULL;
 	}
 
-	int head_idx = cmd_head;
-	int pos = 0;
+	/* Get the command index by adding given number from first command index in ring buffer */
 
-	head_idx += (num - 1);
+	cmd_idx = cmd_head + (hist_idx - 1);
 
-	if (head_idx >= TASH_MAX_STORE) {
-		head_idx -= TASH_MAX_STORE;
-	}
-	if (head_idx >= cmd_tail) {
-		return;
+	/* Check overflow of buffer size */
+
+	if (cmd_idx >= TASH_MAX_STORE) {
+		cmd_idx -= TASH_MAX_STORE;
 	}
 
-	while (cmd_store[head_idx][pos] != 0) {
-		cmd[pos] = cmd_store[head_idx][pos];
-		pos++;
+	/* Check the given number is in a valid range */
+
+	if ((cmd_idx >= cmd_tail) && (cmd_head < cmd_tail)) {
+		printf("!%d: event not found\n", hist_idx);
+		return NULL;
 	}
+
+	/* Return the address of command buffer indexed */
+
+	return cmd_store[cmd_idx];
 }
 
 void tash_store_cmd(char *cmd)

--- a/apps/shell/tash_command.c
+++ b/apps/shell/tash_command.c
@@ -276,35 +276,51 @@ static char *tash_get_cmd_from_history(int hist_idx)
 
 void tash_store_cmd(char *cmd)
 {
+	#define HISTPTR_TO_LAST  (cmd_pos = cmd_tail)
+
 	/* Clear temporary buffer */
 
 	cmd_line[0] = ASCII_NUL;
 
-	/* If there is no command, it is not saved. */
 	if (cmd == NULL || cmd[0] == ASCII_NUL) {
+		/* No valid command */
+
 		return;
 	}
 
 	if (cmd_head != cmd_tail) {
-		/* If it is the same as the previous command, it is not saved. */
+		/* When there are saved commands in the history,
+		 * need to check whether this command is the same with the last command
+		 * to avoid duplicated saving.
+		 */
+
+		/* Get the last command index in the history  */
+
 		int prev = cmd_tail;
 		CMD_INDEX_DOWN(prev);
 
 		if (strncmp(cmd_store[prev], cmd, TASH_LINEBUFLEN) == 0) {
-			cmd_pos = cmd_tail;
+			/* This is the same with the last!! Let's move the history command pointer to the last and exit. */
+
+			HISTPTR_TO_LAST;
 			return;
 		}
 	}
 
-	/* Save current command. */
+	/* Save current command into the history list. */
+
 	strncpy(cmd_store[cmd_tail], cmd, TASH_LINEBUFLEN);
 	CMD_INDEX_UP(cmd_tail);
 
 	/* Move the head when the storage space is full. */
+
 	if (cmd_tail == cmd_head) {
 		CMD_INDEX_UP(cmd_head);
 	}
-	cmd_pos = cmd_tail;
+
+	/* Move the history command pointer to the last. */
+
+	HISTPTR_TO_LAST;
 }
 
 bool tash_search_cmd(char *cmd, int *cmd_char_ptr, char direction)

--- a/apps/shell/tash_internal.h
+++ b/apps/shell/tash_internal.h
@@ -67,7 +67,7 @@
 bool tash_do_autocomplete(char *cmd, int *pos, bool double_tab);
 
 #if TASH_MAX_STORE > 0
-void tash_get_cmd_from_history(int num, char *cmd);
+char *tash_get_cmd_from_history(int hist_idx);
 bool tash_search_cmd(char *cmd, int *pos, char status);
 void tash_store_line(char *line);
 void tash_store_cmd(char *cmd);

--- a/apps/shell/tash_internal.h
+++ b/apps/shell/tash_internal.h
@@ -67,7 +67,7 @@
 bool tash_do_autocomplete(char *cmd, int *pos, bool double_tab);
 
 #if TASH_MAX_STORE > 0
-char *tash_get_cmd_from_history(int hist_idx);
+int check_exclam_cmd(char *buff);
 bool tash_search_cmd(char *cmd, int *pos, char status);
 void tash_store_line(char *line);
 void tash_store_cmd(char *cmd);

--- a/apps/shell/tash_main.c
+++ b/apps/shell/tash_main.c
@@ -122,6 +122,7 @@ static char *tash_read_input_line(int fd)
 	bool prepare_direction_key = false;
 	bool is_direction_pressed = false;
 	char direction;
+	int prev_cmd_len = 0;
 #endif
 #if !defined(CONFIG_DISABLE_POLL)
 	fd_set tfd;
@@ -171,11 +172,13 @@ static char *tash_read_input_line(int fd)
 					}
 					is_tab_pressed = false;
 					is_esc_pressed = false;
+					prev_cmd_len = pos;
 				} else if (CURR_CHAR == ASCII_TAB) {
 					/* TAB key - Auto-complete the command functionality */
 
 					if (pos > 0 && tash_do_autocomplete(buffer, &pos, is_tab_pressed) == true) {
 						tash_print_cmd(fd, buffer, pos);
+						prev_cmd_len = pos;
 					}
 					is_tab_pressed = true;
 					is_esc_pressed = false;
@@ -254,15 +257,17 @@ static char *tash_read_input_line(int fd)
 					}
 					is_tab_pressed = false;
 					is_esc_pressed = false;
+					prev_cmd_len = pos;
 				}
 			}
 
 #if TASH_MAX_STORE > 0
 			if (is_direction_pressed) {
 				if (tash_search_cmd(buffer, &pos, direction) == true) {
-					tash_clear_line(fd, sizeof(TASH_PROMPT) + pos);
+					tash_clear_line(fd, sizeof(TASH_PROMPT) + prev_cmd_len);
 
 					tash_print_cmd(fd, buffer, pos);
+					prev_cmd_len = pos;
 				}
 				is_direction_pressed = false;
 			}

--- a/apps/shell/tash_main.c
+++ b/apps/shell/tash_main.c
@@ -303,22 +303,14 @@ int tash_execute_cmdline(char *buff)
 	int ret = OK;
 
 #if TASH_MAX_STORE > 0
-	int hist_idx;
-	char *stored_cmd_ptr;
-	int stored_cmd_size;
+	/* Find, verify the exclamation command and replace it to real command */
 
-	if (buff[0] == '!') {
-		hist_idx = atoi(buff + 1);
-		stored_cmd_ptr = tash_get_cmd_from_history(hist_idx);
-		if (!stored_cmd_ptr) {
-			ret = ERROR;
-			*buff = ASCII_NUL;
-		}
-
-		stored_cmd_size = strlen(stored_cmd_ptr);
-		strncpy(buff, stored_cmd_ptr, stored_cmd_size);
-		buff[stored_cmd_size] = ASCII_NUL;
+	if (check_exclam_cmd(buff) == ERROR) {
+		*buff = ASCII_NUL;
+		return ERROR;
 	}
+
+	/* Save the input command into history command buffer */
 
 	tash_store_cmd(buff);
 #endif

--- a/apps/shell/tash_main.c
+++ b/apps/shell/tash_main.c
@@ -303,9 +303,21 @@ int tash_execute_cmdline(char *buff)
 	int ret = OK;
 
 #if TASH_MAX_STORE > 0
+	int hist_idx;
+	char *stored_cmd_ptr;
+	int stored_cmd_size;
+
 	if (buff[0] == '!') {
-		int cmd_number = atoi(buff + 1);
-		tash_get_cmd_from_history(cmd_number, buff);
+		hist_idx = atoi(buff + 1);
+		stored_cmd_ptr = tash_get_cmd_from_history(hist_idx);
+		if (!stored_cmd_ptr) {
+			ret = ERROR;
+			*buff = ASCII_NUL;
+		}
+
+		stored_cmd_size = strlen(stored_cmd_ptr);
+		strncpy(buff, stored_cmd_ptr, stored_cmd_size);
+		buff[stored_cmd_size] = ASCII_NUL;
 	}
 
 	tash_store_cmd(buff);

--- a/apps/system/utils/README.md
+++ b/apps/system/utils/README.md
@@ -505,7 +505,8 @@ Heap Allocation Information per User defined Group
 
 
 ## history
-This command shows the history you executed, and you can re-execute it by calling the number with `!`.
+This command shows the history you executed.  
+Using this functionality, you can re-execute the command by calling the number with `!` or by up and down keys.
 ```bash
 TASH>>history
          TASH command history
@@ -537,6 +538,10 @@ tm_sample_itc    tm_utc           umount           unsetenv
 uptime           wm_test
 TASH>>
 ```
+
+>**NOTE**
+>We provide the configuration, *CONFIG_TASH_MAX_STORE_COMMANDS*, to set the maximum number of commands due to memory limitations.
+>When the history has maximum number of commands stored, the oldest command will be removed to store the last command.
 
 ### How to Enable
 Set *CONFIG_TASH_MAX_STORE_COMMANDS* value to use this command on menuconfig as shown below:


### PR DESCRIPTION
1. refactoring the tash_get_cmd_from_history 
    1. Return the address of command according to history index given on success, return null on failure
    2. Rename the variables for readability
    3. Add code comments to explain the operation
    4. Add user feedback messages on failure case
    5. Fix the bug on checking index validation
2. tidyup treatement of semicolon 
    1. Add error feedback message on single semicolon
        When only semicolon is input without any command, Linux returns
        syntax error. Let's do the same.
    2. Rename the local variable, has_nextcmd
        It shows there is a next continouse command. When it is set,
        Main loop should check continousely. For this usages, 'has' is
        better to understand the meaning. Let's rename 'is_nextcmd' to 'has_nextcmd'.
3. add combination command with exclamation command support
    Currently TASH supports single an exclamation command like "!2".
    But it does not support combination commands like "!2;!3", "!1test", "test!3" and so on.
    This commit parses the exclamation mark and replaces it to real command.