### PR TITLE
os/fs/smartfs: Fix - Incorrect file size after shrinkfile()

### DIFF
--- a/os/fs/smartfs/smartfs_utils.c
+++ b/os/fs/smartfs/smartfs_utils.c
@@ -2012,7 +2012,7 @@ int smartfs_shrinkfile(FAR struct smartfs_mountpt_s *fs, FAR struct smartfs_ofil
 	chainheader = (struct smartfs_chain_header_s *)fs->fs_rwbuffer;
 	nextsector = SMARTFS_NEXTSECTOR(chainheader);
 	*(uint16_t *)chainheader->nextsector = SMARTFS_ERASEDSTATE_16BIT;
-	*(uint16_t *)chainheader->used = last_data;
+	*(uint16_t *)chainheader->used = SMARTFS_ERASEDSTATE_16BIT;
 
 	sf->byteswritten = last_data;
 	sf->entry.datalen = length;


### PR DESCRIPTION
- Fix improper used bytes in header so that retrieved file size is correct.

Signed-off-by: Amogh Hassija <a.hassija@samsung.com>