### PR TITLE
board: remove duplicated comment for partition

### DIFF
--- a/os/board/Kconfig
+++ b/os/board/Kconfig
@@ -329,8 +329,5 @@ endif
 if ARCH_BOARD_RTL8721CSM
 source board/rtl8721csm/Kconfig
 endif
-comment "Board-Partition Options"
 
 source board/common/Kconfig
-
-

--- a/os/board/rtl8721csm/src/rtl8721csm_boot.c
+++ b/os/board/rtl8721csm/src/rtl8721csm_boot.c
@@ -187,7 +187,7 @@ void amebad_mount_partions(void)
 	/* Configure mtd partitions */
 	ret = configure_mtd_partitions(mtd, &g_flash_part_data);
 	if (ret != OK) {
-		lldbg("ERROR: configure_mtd_partitions failed");
+		lldbg("ERROR: configure_mtd_partitions failed\n");
 		return;
 	}
 #ifdef CONFIG_AMEBAD_AUTOMOUNT
@@ -195,7 +195,7 @@ void amebad_mount_partions(void)
 	/* Initialize and mount user partition (if we have) */
 	ret = mksmartfs(CONFIG_AMEBAD_AUTOMOUNT_USERFS_DEVNAME, false);
 	if (ret != OK) {
-		lldbg("ERROR: mksmartfs on %s failed", CONFIG_AMEBAD_AUTOMOUNT_USERFS_DEVNAME);
+		lldbg("ERROR: mksmartfs on %s failed\n", CONFIG_AMEBAD_AUTOMOUNT_USERFS_DEVNAME);
 	} else {
 		ret = mount(CONFIG_AMEBAD_AUTOMOUNT_USERFS_DEVNAME, CONFIG_AMEBAD_AUTOMOUNT_USERFS_MOUNTPOINT, "smartfs", 0, NULL);
 		if (ret != OK) {


### PR DESCRIPTION
There are two comments for partition in os/board and os/board/common.
"Board-Partition Options"

Let's remove one.

Signed-off-by: sunghan-chang <sh924.chang@samsung.com>