### PR TITLE
fixup! arch/arm/common: Modify stack coloration size when stack overf…

### DIFF
--- a/os/arch/arm/src/common/up_allocateheap.c
+++ b/os/arch/arm/src/common/up_allocateheap.c
@@ -155,7 +155,7 @@ void up_add_kregion(void)
 {
 	int region_cnt;
 	struct mm_heap_s *kheap;
-	void *heap_start;
+	void *heap_start = NULL;
 	size_t heap_size;
 	void *stack_end = (void *)(g_idle_topstack & ~(0x7));
 	kheap = kmm_get_heap();

--- a/os/arch/arm/src/common/up_createstack.c
+++ b/os/arch/arm/src/common/up_createstack.c
@@ -267,11 +267,21 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
 		 */
 
 #ifdef CONFIG_STACK_COLORATION
-		/* If CONFIG_MPU_STACK_OVERFLOW_PROTECTION is enabled, stack is created with requested size + CONFIG_MPU_STACK_GUARD_SIZE.
-		 * In this case, we should make coloration from stack_alloc_ptr to adj_stack_ptr.
-		 * So we should re-calculate the coloration size with CONFIG_MPU_STACK_GUARD_SIZE.
-		 */
-		up_stack_color(tcb->stack_alloc_ptr, tcb->adj_stack_size + CONFIG_MPU_STACK_GUARD_SIZE);
+#ifdef CONFIG_MPU_STACK_OVERFLOW_PROTECTION
+		if (uheap) {
+			/* If CONFIG_MPU_STACK_OVERFLOW_PROTECTION is enabled, stack is created with requested size + CONFIG_MPU_STACK_GUARD_SIZE.
+			 * In this case, we should make coloration from stack_alloc_ptr to adj_stack_ptr.
+			 * So we should re-calculate the coloration size with CONFIG_MPU_STACK_GUARD_SIZE.
+			 */
+			up_stack_color(tcb->stack_alloc_ptr, tcb->adj_stack_size + CONFIG_MPU_STACK_GUARD_SIZE);
+		} else
+#endif
+		{
+			/* Currently kernel thread does not have a stack guard at front of stack so that
+			 * the size of coloration should be the tcb->adj_stack_size.
+			 */
+			up_stack_color(tcb->stack_alloc_ptr, tcb->adj_stack_size);
+		}
 #endif
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
 		heapinfo_exclude_stacksize(tcb->stack_alloc_ptr);


### PR DESCRIPTION
…low is enabled

Commit 74f82f3 added the coloration size with CONFIG_MPU_STACK_GUARD_SIZE always.
But currently TizenRT does not apply it for kernel thread so that there is no
stack guard at front of stack. If we color the region with CONFIG_MPU_STACK_GUARD_SIZE added,
it overwrites the coloration data out of stack region. (It corrupts the heap data which
is located at behind of stack)
This commit adds the uheap conditional and else statement.

Signed-off-by: sunghan-chang <sh924.chang@samsung.com>