### PR TITLE
mm_heap/mm_free : Remove DEBUG_DOUBLE_FREE config and merge allocatio…

### DIFF
--- a/os/Kconfig.debug
+++ b/os/Kconfig.debug
@@ -250,16 +250,6 @@ config DEBUG_MM_INFO
 	---help---
 		Enable memory management informational debug SYSLOG output.
 
-config DEBUG_DOUBLE_FREE
-	bool "Debug Double Free Attempt"
-	default n
-	---help---
-		This flag would help to debug following operations
-		Attempt to free Null pointer
-		Attempt to free an Unallocated pointer
-		Attempt to free an abruptly initialized pointer (Security exploitation)
-		Attempt to free an already released pointer ( double free detection )
-
 endif #DEBUG_MM
 
 config DEBUG_NET

--- a/os/mm/mm_heap/mm_free.c
+++ b/os/mm/mm_heap/mm_free.c
@@ -91,9 +91,6 @@ void mm_free(FAR struct mm_heap_s *heap, FAR void *mem)
 	FAR struct mm_freenode_s *node;
 	FAR struct mm_freenode_s *prev;
 	FAR struct mm_freenode_s *next;
-#ifdef CONFIG_DEBUG_MM_HEAPINFO
-	struct mm_allocnode_s *alloc_node;
-#endif
 
 	mvdbg("Freeing %p\n", mem);
 
@@ -135,9 +132,8 @@ void mm_free(FAR struct mm_heap_s *heap, FAR void *mem)
 		return;
 	}
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
-	alloc_node = (struct mm_allocnode_s *)node;
-	heapinfo_subtract_size(heap, alloc_node->pid, alloc_node->size);
-	heapinfo_update_total_size(heap, ((-1) * alloc_node->size), alloc_node->pid);
+	heapinfo_subtract_size(heap, ((struct mm_allocnode_s *)node)->pid, ((struct mm_allocnode_s *)node)->size);
+	heapinfo_update_total_size(heap, ((-1) * ((struct mm_allocnode_s *)node)->size), ((struct mm_allocnode_s *)node)->pid);
 #endif
 	node->preceding &= ~MM_ALLOC_BIT;
 

--- a/os/mm/mm_heap/mm_free.c
+++ b/os/mm/mm_heap/mm_free.c
@@ -100,7 +100,6 @@ void mm_free(FAR struct mm_heap_s *heap, FAR void *mem)
 	/* Protect against attempts to free a NULL reference */
 
 	if (!mem) {
-#ifdef CONFIG_DEBUG_DOUBLE_FREE
 		/* Though it's permitted to attempt for releasing a NULL
 		 * reference in C, it would be good to catch those cases
 		 * atleast in DEBUG MODE as there is no logical reason to
@@ -108,8 +107,7 @@ void mm_free(FAR struct mm_heap_s *heap, FAR void *mem)
 		 * It can be a logical bug in sw to make an attempt of double free!
 		 * free(ptr); ptr = NULL; free(ptr);
 		 */
-		dbg("Attempt to release a null pointer\n");
-#endif
+		mdbg("Attempt to release a null pointer\n");
 		return;
 	}
 
@@ -122,29 +120,24 @@ void mm_free(FAR struct mm_heap_s *heap, FAR void *mem)
 	/* Map the memory chunk into a free node */
 
 	node = (FAR struct mm_freenode_s *)((char *)mem - SIZEOF_MM_ALLOCNODE);
-#ifdef CONFIG_DEBUG_DOUBLE_FREE
-	/* Assert on following logical error scenarios
-	 * 1) Attempt to free an unallocated memory or
-	 * 2) Attempt to release some arbitrary memory or
-	 * 3) Attempt to release already released memory ( double free )
-	 * Catch this bug and report to USER in debug mode
-	 * 1st scenario: int *ptr; free(ptr);
-	 * 2nd scenario: int *ptr = (int*)0x02069f50; free(ptr);
-	 * 3rd scenario: ptr = malloc(100); free(ptr); if(ptr) { free(ptr); }
-	 */
+	
 	if ((node->preceding & MM_ALLOC_BIT) != MM_ALLOC_BIT) {
-		dbg("Attempt for double freeing a pointer or releasing an unallocated pointer\n");
-		PANIC();
+		/* There are 3 cases of logical error scenarios
+		 * 1) Attempt to free an unallocated memory or
+		 * 2) Attempt to release some arbitrary memory or
+		 * 3) Attempt to release already released memory ( double free )
+		 * Catch this bug and report to USER in debug mode
+		 * 1st scenario: int *ptr; free(ptr);
+		 * 2nd scenario: int *ptr = (int*)0x02069f50; free(ptr);
+		 * 3rd scenario: ptr = malloc(100); free(ptr); if(ptr) { free(ptr); }
+		 */
+		mdbg("Attempt for double freeing a pointer or releasing an unallocated pointer\n");
+		return;
 	}
-
-#endif
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
 	alloc_node = (struct mm_allocnode_s *)node;
-
-	if ((alloc_node->preceding & MM_ALLOC_BIT) != 0) {
-		heapinfo_subtract_size(heap, alloc_node->pid, alloc_node->size);
-		heapinfo_update_total_size(heap, ((-1) * alloc_node->size), alloc_node->pid);
-	}
+	heapinfo_subtract_size(heap, alloc_node->pid, alloc_node->size);
+	heapinfo_update_total_size(heap, ((-1) * alloc_node->size), alloc_node->pid);
 #endif
 	node->preceding &= ~MM_ALLOC_BIT;
 


### PR DESCRIPTION
…n checking

If there is invalid free request, we don't need to call panic, but just printing debug msg.
There are 3 cases for invalid free request.
Following 3 cases are logical error scenarios.
1) Attempt to free an unallocated memory or
2) Attempt to release some arbitrary memory or
3) Attempt to release already released memory ( double free )
 Catch this bug and report to USER in debug mode
 1st scenario: int *ptr; free(ptr);
 2nd scenario: int *ptr = (int*)0x02069f50; free(ptr);
 3rd scenario: ptr = malloc(100); free(ptr); if(ptr) { free(ptr); }

And there is a duplicated allcoation checking logic between double free and heapinfo, so merge them.