### PR TITLE
libc/time: Change malloc to lib_malloc for memory allocation

### DIFF
--- a/lib/libc/time/lib_localtime.c
+++ b/lib/libc/time/lib_localtime.c
@@ -77,6 +77,8 @@
 
 #include <tinyara/time.h>
 
+#include "lib_internal.h"
+
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
@@ -505,7 +507,7 @@ static int tzload(FAR const char *name, FAR struct state_s *const sp, const int 
 	size_t p_len;
 	size_t name_len;
 
-	lsp = malloc(sizeof * lsp);
+	lsp = lib_malloc(sizeof * lsp);
 	if (!lsp) {
 		return -1;
 	}
@@ -1384,7 +1386,7 @@ static void tzsetwall(void)
 	g_lcl_isset = -1;
 
 	if (lclptr == NULL) {
-		lclptr = malloc(sizeof * lclptr);
+		lclptr = lib_malloc(sizeof * lclptr);
 		if (lclptr == NULL) {
 			settzname();		/* all we can do */
 			return;
@@ -1421,7 +1423,7 @@ void tzset(void)
 	}
 
 	if (lclptr == NULL) {
-		lclptr = malloc(sizeof * lclptr);
+		lclptr = lib_malloc(sizeof * lclptr);
 		if (lclptr == NULL) {
 			settzname();		/* all we can do */
 			return;
@@ -1551,7 +1553,7 @@ static struct tm *localsub(FAR const time_t *const timep, const int_fast32_t off
 static struct tm *gmtsub(FAR const time_t *const timep, const int_fast32_t offset, struct tm *const tmp)
 {
 	if (!g_gmt_isset) {
-		gmtptr = malloc(sizeof * gmtptr);
+		gmtptr = lib_malloc(sizeof * gmtptr);
 		g_gmt_isset = gmtptr != NULL;
 		if (g_gmt_isset) {
 			gmtload(gmtptr);


### PR DESCRIPTION
A libc is used by kernel and user spaces.
So it should use lib_malloc for memory allocation instead of malloc.