### PR TITLE
drivers/wireless, se: use kmm APIs

### DIFF
--- a/os/drivers/wireless/realtek/wifi_util_interface/wifi_util.c
+++ b/os/drivers/wireless/realtek/wifi_util_interface/wifi_util.c
@@ -205,7 +205,7 @@ int wext_set_key_ext(const char *ifname, __u16 alg, const __u8 *addr, int key_id
 		RTW_API_INFO("\n\rioctl[SIOCSIWENCODEEXT] set key fail");
 	}
 
-	free(ext);
+	kmm_free(ext);
 
 	return ret;
 }
@@ -1367,12 +1367,12 @@ int wext_deinit_mac_filter(void)
 	{
 		item = list_entry(iterator, rtw_mac_filter_list_t, node);
 		list_del(iterator);
-		free(item);
+		kmm_free(item);
 		item = NULL;
 		iterator = mf_list_head;
 	}
 
-	free(mf_list_head);
+	kmm_free(mf_list_head);
 	mf_list_head = NULL;
 	return 0;
 }
@@ -1408,7 +1408,7 @@ int wext_del_mac_filter(unsigned char *hwaddr)
 		item = list_entry(iterator, rtw_mac_filter_list_t, node);
 		if (memcmp(item->mac_addr, hwaddr, 6) == 0) {
 			list_del(iterator);
-			free(item);
+			kmm_free(item);
 			item = NULL;
 			return 0;
 		}

--- a/os/drivers/wireless/scsc/mib.c
+++ b/os/drivers/wireless/scsc/mib.c
@@ -482,7 +482,7 @@ u8 *slsi_mib_find(struct slsi_mib_data *buffer, const struct slsi_mib_get_entry 
 
 struct slsi_mib_value *slsi_mib_decode_get_list(struct slsi_mib_data *buffer, u16 psidsLength, const struct slsi_mib_get_entry *psids)
 {
-	struct slsi_mib_value *results = calloc((size_t)psidsLength, sizeof(struct slsi_mib_value));
+	struct slsi_mib_value *results = kmm_calloc((size_t)psidsLength, sizeof(struct slsi_mib_value));
 	size_t i;
 	int len;
 
@@ -502,7 +502,7 @@ struct slsi_mib_value *slsi_mib_decode_get_list(struct slsi_mib_data *buffer, u1
 			memcpy(value.index, psids[i].index, sizeof(value.index));
 			len = slsi_mib_decode(&data, &value);
 			if (len == 0) {
-				free(results);
+				kmm_free(results);
 				return NULL;
 			}
 

--- a/os/drivers/wireless/scsc/slsi_drv.c
+++ b/os/drivers/wireless/scsc/slsi_drv.c
@@ -133,7 +133,7 @@ free_scan_results(lwnl80211_scan_list_s *scan_list)
 	while (cur) {
 		prev = cur;
 		cur = cur->next;
-		free(prev);
+		kmm_free(prev);
 	}
 	scan_list = NULL;
 }
@@ -171,7 +171,7 @@ fetch_scan_results(lwnl80211_scan_list_s **scan_list, slsi_scan_info_t **slsi_sc
 				continue;
 			}
 
-			cur = (lwnl80211_scan_list_s *)malloc(sizeof(lwnl80211_scan_list_s));
+			cur = (lwnl80211_scan_list_s *)kmm_malloc(sizeof(lwnl80211_scan_list_s));
 			if (!cur) {
 				free_scan_results(*scan_list);
 				return result;
@@ -239,14 +239,14 @@ static int slsi_drv_callback_handler(void *arg)
 		break;
 	}
 
-	free(type);
+	kmm_free(type);
 
 	return 0;
 }
 
 static void linkup_handler(slsi_reason_t *reason)
 {
-	int *type = (int *)malloc(sizeof(int));
+	int *type = (int *)kmm_malloc(sizeof(int));
 	if (type == NULL) {
 		vddbg("malloc error\n");
 		return;
@@ -267,7 +267,7 @@ static void linkup_handler(slsi_reason_t *reason)
 	int ret = pthread_create(&tid, NULL, (pthread_startroutine_t)slsi_drv_callback_handler, (void *)type);
 	if (ret != 0) {
 		vddbg("pthread create fail(%d)\n", errno);
-		free(type);
+		kmm_free(type);
 		return;
 	}
 	pthread_setname_np(tid, "lwnl80211_cbk_handler");
@@ -277,7 +277,7 @@ static void linkup_handler(slsi_reason_t *reason)
 
 static void linkdown_handler(slsi_reason_t *reason)
 {
-	int *type = (int *)malloc(sizeof(int));
+	int *type = (int *)kmm_malloc(sizeof(int));
 	if (type == NULL) {
 		vddbg("malloc error linkdown\n");
 		return;
@@ -292,7 +292,7 @@ static void linkdown_handler(slsi_reason_t *reason)
 	int ret = pthread_create(&tid, NULL, (pthread_startroutine_t)slsi_drv_callback_handler, (void *)type);
 	if (ret != 0) {
 		vddbg("pthread create fail(%d)\n", errno);
-		free(type);
+		kmm_free(type);
 		return;
 	}
 	pthread_setname_np(tid, "lwnl80211_cbk_handler");
@@ -492,7 +492,7 @@ lwnl80211_result_e slsidrv_connect_ap(lwnl80211_ap_config_s *ap_connect_config, 
 			}
 		}
 
-		config = (slsi_security_config_t *)zalloc(sizeof(slsi_security_config_t));
+		config = (slsi_security_config_t *)kmm_zalloc(sizeof(slsi_security_config_t));
 		if (!config) {
 			vddbg("Memory allocation failed!\n");
 			goto connect_ap_fail;
@@ -563,7 +563,7 @@ lwnl80211_result_e slsidrv_connect_ap(lwnl80211_ap_config_s *ap_connect_config, 
 
 connect_ap_fail:
 	if (config) {
-		free(config);
+		kmm_free(config);
 		config = NULL;
 	}
 
@@ -631,7 +631,7 @@ lwnl80211_result_e slsidrv_start_softap(lwnl80211_softap_config_s *softap_config
 	slsi_ap_config_t *ap_config = NULL;
 	slsi_security_config_t *security_config = NULL;
 
-	ap_config = (slsi_ap_config_t *)zalloc(sizeof(slsi_ap_config_t));
+	ap_config = (slsi_ap_config_t *)kmm_zalloc(sizeof(slsi_ap_config_t));
 	if (!ap_config) {
 		vddbg("Memory allocation failed!\n");
 		return LWNL80211_FAIL;
@@ -659,7 +659,7 @@ lwnl80211_result_e slsidrv_start_softap(lwnl80211_softap_config_s *softap_config
 	if (softap_config->passphrase_length < 1) {
 		goto start_soft_ap_fail;
 	} else {
-		security_config = (slsi_security_config_t *)zalloc(sizeof(slsi_security_config_t));
+		security_config = (slsi_security_config_t *)kmm_zalloc(sizeof(slsi_security_config_t));
 		if (!security_config) {
 			vddbg("Memory allocation failed!\n");
 			goto start_soft_ap_fail;
@@ -708,11 +708,11 @@ lwnl80211_result_e slsidrv_start_softap(lwnl80211_softap_config_s *softap_config
 
 start_soft_ap_fail:
 	if (ap_config) {
-		free(ap_config);
+		kmm_free(ap_config);
 		ap_config = NULL;
 	}
 	if (security_config) {
-		free(security_config);
+		kmm_free(security_config);
 		security_config = NULL;
 	}
 	return ret;
@@ -782,7 +782,7 @@ struct lwnl80211_lowerhalf_s *slsi_drv_initialize(void)
 {
 	SLSIDRV_ENTER;
 	struct lwnl80211_lowerhalf_s *dev = NULL;
-	dev = (struct lwnl80211_lowerhalf_s *)malloc(sizeof(struct lwnl80211_lowerhalf_s));
+	dev = (struct lwnl80211_lowerhalf_s *)kmm_malloc(sizeof(struct lwnl80211_lowerhalf_s));
 	if (!dev) {
 		return NULL;
 	}

--- a/os/drivers/wireless/scsc/slsi_drv_lwnl.c
+++ b/os/drivers/wireless/scsc/slsi_drv_lwnl.c
@@ -156,7 +156,7 @@ free_scan_results(trwifi_scan_list_s *scan_list)
 	while (cur) {
 		prev = cur;
 		cur = cur->next;
-		free(prev);
+		kmm_free(prev);
 	}
 	scan_list = NULL;
 }
@@ -194,7 +194,7 @@ fetch_scan_results(trwifi_scan_list_s **scan_list, slsi_scan_info_t **slsi_scan_
 				continue;
 			}
 
-			cur = (trwifi_scan_list_s *)malloc(sizeof(trwifi_scan_list_s));
+			cur = (trwifi_scan_list_s *)kmm_malloc(sizeof(trwifi_scan_list_s));
 			if (!cur) {
 				free_scan_results(*scan_list);
 				return result;
@@ -262,14 +262,14 @@ static int slsi_drv_callback_handler(void *arg)
 		break;
 	}
 
-	free(type);
+	kmm_free(type);
 
 	return 0;
 }
 
 static void linkup_handler(slsi_reason_t *reason)
 {
-	int *type = (int *)malloc(sizeof(int));
+	int *type = (int *)kmm_malloc(sizeof(int));
 	if (type == NULL) {
 		vddbg("malloc error\n");
 		return;
@@ -290,7 +290,7 @@ static void linkup_handler(slsi_reason_t *reason)
 	int ret = pthread_create(&tid, NULL, (pthread_startroutine_t)slsi_drv_callback_handler, (void *)type);
 	if (ret != 0) {
 		vddbg("pthread create fail(%d)\n", errno);
-		free(type);
+		kmm_free(type);
 		return;
 	}
 	pthread_setname_np(tid, "trwifi_cbk_handler");
@@ -300,7 +300,7 @@ static void linkup_handler(slsi_reason_t *reason)
 
 static void linkdown_handler(slsi_reason_t *reason)
 {
-	int *type = (int *)malloc(sizeof(int));
+	int *type = (int *)kmm_malloc(sizeof(int));
 	if (type == NULL) {
 		vddbg("malloc error linkdown\n");
 		return;
@@ -315,7 +315,7 @@ static void linkdown_handler(slsi_reason_t *reason)
 	int ret = pthread_create(&tid, NULL, (pthread_startroutine_t)slsi_drv_callback_handler, (void *)type);
 	if (ret != 0) {
 		vddbg("pthread create fail(%d)\n", errno);
-		free(type);
+		kmm_free(type);
 		return;
 	}
 	pthread_setname_np(tid, "trwifi_cbk_handler");
@@ -515,7 +515,7 @@ trwifi_result_e slsidrv_connect_ap(struct netdev *dev, trwifi_ap_config_s *ap_co
 			}
 		}
 
-		config = (slsi_security_config_t *)zalloc(sizeof(slsi_security_config_t));
+		config = (slsi_security_config_t *)kmm_zalloc(sizeof(slsi_security_config_t));
 		if (!config) {
 			vddbg("Memory allocation failed!\n");
 			goto connect_ap_fail;
@@ -586,7 +586,7 @@ trwifi_result_e slsidrv_connect_ap(struct netdev *dev, trwifi_ap_config_s *ap_co
 
 connect_ap_fail:
 	if (config) {
-		free(config);
+		kmm_free(config);
 		config = NULL;
 	}
 
@@ -654,7 +654,7 @@ trwifi_result_e slsidrv_start_softap(struct netdev *dev, trwifi_softap_config_s 
 	slsi_ap_config_t *ap_config = NULL;
 	slsi_security_config_t *security_config = NULL;
 
-	ap_config = (slsi_ap_config_t *)zalloc(sizeof(slsi_ap_config_t));
+	ap_config = (slsi_ap_config_t *)kmm_zalloc(sizeof(slsi_ap_config_t));
 	if (!ap_config) {
 		vddbg("Memory allocation failed!\n");
 		return TRWIFI_FAIL;
@@ -682,7 +682,7 @@ trwifi_result_e slsidrv_start_softap(struct netdev *dev, trwifi_softap_config_s 
 	if (softap_config->passphrase_length < 1) {
 		goto start_soft_ap_fail;
 	} else {
-		security_config = (slsi_security_config_t *)zalloc(sizeof(slsi_security_config_t));
+		security_config = (slsi_security_config_t *)kmm_zalloc(sizeof(slsi_security_config_t));
 		if (!security_config) {
 			vddbg("Memory allocation failed!\n");
 			goto start_soft_ap_fail;
@@ -731,11 +731,11 @@ trwifi_result_e slsidrv_start_softap(struct netdev *dev, trwifi_softap_config_s 
 
 start_soft_ap_fail:
 	if (ap_config) {
-		free(ap_config);
+		kmm_free(ap_config);
 		ap_config = NULL;
 	}
 	if (security_config) {
-		free(security_config);
+		kmm_free(security_config);
 		security_config = NULL;
 	}
 	return ret;
@@ -805,7 +805,7 @@ int slsi_drv_initialize(void)
 {
 	SLSIDRV_ENTER;
 	struct netdev *dev = NULL;
-	dev = (struct netdev *)malloc(sizeof(struct netdev));
+	dev = (struct netdev *)kmm_malloc(sizeof(struct netdev));
 	if (!dev) {
 		return -1;
 	}
@@ -819,7 +819,7 @@ int slsi_drv_initialize(void)
 	int res = lwnl_register_dev(dev);
 	if (res < 0) {
 		vddbg("register dev to lwnl fail\n");
-		free(dev);
+		kmm_free(dev);
 		return -1;
 	}
 	return 0;

--- a/os/drivers/wireless/scsc/slsi_drv_netmgr.c
+++ b/os/drivers/wireless/scsc/slsi_drv_netmgr.c
@@ -174,7 +174,7 @@ free_scan_results(trwifi_scan_list_s *scan_list)
 	while (cur) {
 		prev = cur;
 		cur = cur->next;
-		free(prev);
+		kmm_free(prev);
 	}
 	scan_list = NULL;
 }
@@ -212,7 +212,7 @@ fetch_scan_results(trwifi_scan_list_s **scan_list, slsi_scan_info_t **slsi_scan_
 				continue;
 			}
 
-			cur = (trwifi_scan_list_s *)malloc(sizeof(trwifi_scan_list_s));
+			cur = (trwifi_scan_list_s *)kmm_malloc(sizeof(trwifi_scan_list_s));
 			if (!cur) {
 				free_scan_results(*scan_list);
 				return result;
@@ -280,14 +280,14 @@ static int slsi_drv_callback_handler(void *arg)
 		break;
 	}
 
-	free(type);
+	kmm_free(type);
 
 	return 0;
 }
 
 static void linkup_handler(slsi_reason_t *reason)
 {
-	int *type = (int *)malloc(sizeof(int));
+	int *type = (int *)kmm_malloc(sizeof(int));
 	if (type == NULL) {
 		vddbg("malloc error\n");
 		return;
@@ -308,7 +308,7 @@ static void linkup_handler(slsi_reason_t *reason)
 	int ret = pthread_create(&tid, NULL, (pthread_startroutine_t)slsi_drv_callback_handler, (void *)type);
 	if (ret != 0) {
 		vddbg("pthread create fail(%d)\n", errno);
-		free(type);
+		kmm_free(type);
 		return;
 	}
 	pthread_setname_np(tid, "trwifi_cbk_handler");
@@ -318,7 +318,7 @@ static void linkup_handler(slsi_reason_t *reason)
 
 static void linkdown_handler(slsi_reason_t *reason)
 {
-	int *type = (int *)malloc(sizeof(int));
+	int *type = (int *)kmm_malloc(sizeof(int));
 	if (type == NULL) {
 		vddbg("malloc error linkdown\n");
 		return;
@@ -333,7 +333,7 @@ static void linkdown_handler(slsi_reason_t *reason)
 	int ret = pthread_create(&tid, NULL, (pthread_startroutine_t)slsi_drv_callback_handler, (void *)type);
 	if (ret != 0) {
 		vddbg("pthread create fail(%d)\n", errno);
-		free(type);
+		kmm_free(type);
 		return;
 	}
 	pthread_setname_np(tid, "trwifi_cbk_handler");
@@ -533,7 +533,7 @@ trwifi_result_e slsidrv_connect_ap(struct netdev *dev, trwifi_ap_config_s *ap_co
 			}
 		}
 
-		config = (slsi_security_config_t *)zalloc(sizeof(slsi_security_config_t));
+		config = (slsi_security_config_t *)kmm_zalloc(sizeof(slsi_security_config_t));
 		if (!config) {
 			vddbg("Memory allocation failed!\n");
 			goto connect_ap_fail;
@@ -604,7 +604,7 @@ trwifi_result_e slsidrv_connect_ap(struct netdev *dev, trwifi_ap_config_s *ap_co
 
 connect_ap_fail:
 	if (config) {
-		free(config);
+		kmm_free(config);
 		config = NULL;
 	}
 
@@ -672,7 +672,7 @@ trwifi_result_e slsidrv_start_softap(struct netdev *dev, trwifi_softap_config_s 
 	slsi_ap_config_t *ap_config = NULL;
 	slsi_security_config_t *security_config = NULL;
 
-	ap_config = (slsi_ap_config_t *)zalloc(sizeof(slsi_ap_config_t));
+	ap_config = (slsi_ap_config_t *)kmm_zalloc(sizeof(slsi_ap_config_t));
 	if (!ap_config) {
 		vddbg("Memory allocation failed!\n");
 		return TRWIFI_FAIL;
@@ -700,7 +700,7 @@ trwifi_result_e slsidrv_start_softap(struct netdev *dev, trwifi_softap_config_s 
 	if (softap_config->passphrase_length < 1) {
 		goto start_soft_ap_fail;
 	} else {
-		security_config = (slsi_security_config_t *)zalloc(sizeof(slsi_security_config_t));
+		security_config = (slsi_security_config_t *)kmm_zalloc(sizeof(slsi_security_config_t));
 		if (!security_config) {
 			vddbg("Memory allocation failed!\n");
 			goto start_soft_ap_fail;
@@ -749,11 +749,11 @@ trwifi_result_e slsidrv_start_softap(struct netdev *dev, trwifi_softap_config_s 
 
 start_soft_ap_fail:
 	if (ap_config) {
-		free(ap_config);
+		kmm_free(ap_config);
 		ap_config = NULL;
 	}
 	if (security_config) {
-		free(security_config);
+		kmm_free(security_config);
 		security_config = NULL;
 	}
 	return ret;

--- a/os/drivers/wireless/scsc/slsi_utils.c
+++ b/os/drivers/wireless/scsc/slsi_utils.c
@@ -96,7 +96,7 @@ free_scan_results(wifi_utils_scan_list_s *scan_list)
 	while (cur) {
 		prev = cur;
 		cur = cur->next;
-		free(prev);
+		kmm_free(prev);
 	}
 	scan_list = NULL;
 }
@@ -133,7 +133,7 @@ fetch_scan_results(wifi_utils_scan_list_s **scan_list, slsi_scan_info_t **slsi_s
 				wifi_scan_iter = wifi_scan_iter->next;
 				continue;
 			}
-			cur = (wifi_utils_scan_list_s *)malloc(sizeof(wifi_utils_scan_list_s));
+			cur = (wifi_utils_scan_list_s *)kmm_malloc(sizeof(wifi_utils_scan_list_s));
 			if (!cur) {
 				free_scan_results(*scan_list);
 				return wuret;
@@ -190,13 +190,13 @@ static int callback_handler(void *arg)
 	} else if (*type == 5 && g_cbk.softap_sta_left) {
 		g_cbk.softap_sta_left(NULL);
 	}
-	free(type);
+	kmm_free(type);
 	return 0;
 }
 
 static void linkup_handler(slsi_reason_t *reason)
 {
-	int *type = (int *)malloc(sizeof(int));
+	int *type = (int *)kmm_malloc(sizeof(int));
 	if (type == NULL) {
 		ndbg("[WU] malloc error\n");
 		return;
@@ -215,7 +215,7 @@ static void linkup_handler(slsi_reason_t *reason)
 	int ret = pthread_create(&tid, NULL, (pthread_startroutine_t)callback_handler, (void *)type);
 	if (ret != 0) {
 		ndbg("[WU] pthread create fail(%d)\n", errno);
-		free(type);
+		kmm_free(type);
 		return;
 	}
 	pthread_setname_np(tid, "wifi_utils_cbk_handler");
@@ -224,7 +224,7 @@ static void linkup_handler(slsi_reason_t *reason)
 
 static void linkdown_handler(slsi_reason_t *reason)
 {
-	int *type = (int *)malloc(sizeof(int));
+	int *type = (int *)kmm_malloc(sizeof(int));
 	if (type == NULL) {
 		ndbg("[WU] malloc error linkdown\n");
 		return;
@@ -239,7 +239,7 @@ static void linkdown_handler(slsi_reason_t *reason)
 	int ret = pthread_create(&tid, NULL, (pthread_startroutine_t)callback_handler, (void *)type);
 	if (ret != 0) {
 		ndbg("[WU] pthread create fail(%d)\n", errno);
-		free(type);
+		kmm_free(type);
 		return;
 	}
 	pthread_setname_np(tid, "wifi_utils_cbk_handler");
@@ -451,7 +451,7 @@ wifi_utils_result_e wifi_utils_connect_ap(wifi_utils_ap_config_s *ap_connect_con
 			}
 		}
 
-		config = (slsi_security_config_t *)zalloc(sizeof(slsi_security_config_t));
+		config = (slsi_security_config_t *)kmm_zalloc(sizeof(slsi_security_config_t));
 		if (!config) {
 			ndbg("[WU] Memory allocation failed!\n");
 			goto connect_ap_fail;
@@ -522,7 +522,7 @@ wifi_utils_result_e wifi_utils_connect_ap(wifi_utils_ap_config_s *ap_connect_con
 
 connect_ap_fail:
 	if (config) {
-		free(config);
+		kmm_free(config);
 		config = NULL;
 	}
 
@@ -587,7 +587,7 @@ wifi_utils_result_e wifi_utils_start_softap(wifi_utils_softap_config_s *softap_c
 	slsi_ap_config_t *ap_config = NULL;
 	slsi_security_config_t *security_config = NULL;
 
-	ap_config = (slsi_ap_config_t *)zalloc(sizeof(slsi_ap_config_t));
+	ap_config = (slsi_ap_config_t *)kmm_zalloc(sizeof(slsi_ap_config_t));
 	if (!ap_config) {
 		ndbg("[WU] Memory allocation failed!\n");
 		return WIFI_UTILS_FAIL;
@@ -615,7 +615,7 @@ wifi_utils_result_e wifi_utils_start_softap(wifi_utils_softap_config_s *softap_c
 	if (softap_config->passphrase_length < 1) {
 		goto start_soft_ap_fail;
 	} else {
-		security_config = (slsi_security_config_t *)zalloc(sizeof(slsi_security_config_t));
+		security_config = (slsi_security_config_t *)kmm_zalloc(sizeof(slsi_security_config_t));
 		if (!security_config) {
 			ndbg("[WU] Memory allocation failed!\n");
 			goto start_soft_ap_fail;
@@ -664,11 +664,11 @@ wifi_utils_result_e wifi_utils_start_softap(wifi_utils_softap_config_s *softap_c
 
 start_soft_ap_fail:
 	if (ap_config) {
-		free(ap_config);
+		kmm_free(ap_config);
 		ap_config = NULL;
 	}
 	if (security_config) {
-		free(security_config);
+		kmm_free(security_config);
 		security_config = NULL;
 	}
 	return ret;

--- a/os/drivers/wireless/scsc/slsi_wifi_api.c
+++ b/os/drivers/wireless/scsc/slsi_wifi_api.c
@@ -408,7 +408,7 @@ static char *slsi_send_request(char *cmd, int8_t *success)
 		return NULL;
 	}
 
-	char *buf = (char *)zalloc(WPA_BUFFER_SIZE);
+	char *buf = (char *)kmm_zalloc(WPA_BUFFER_SIZE);
 	if (buf == NULL) {
 		return buf;
 	}
@@ -459,7 +459,7 @@ static void slsi_send_command_str_digit(char *string, int digit)
 	snprintf(command, WPA_COMMAND_MAX_SIZE, "%s%d", string, digit);
 	pbuf = slsi_send_request(command, NULL);
 	if (pbuf) {
-		free(pbuf);
+		kmm_free(pbuf);
 		pbuf = NULL;
 	}
 }
@@ -481,7 +481,7 @@ static void slsi_send_command_str_upto_4(char *one, char *two, char *three, char
 		pbuf = slsi_send_request(command, result);
 	}
 	if (pbuf) {
-		free(pbuf);
+		kmm_free(pbuf);
 		pbuf = NULL;
 	}
 }
@@ -492,7 +492,7 @@ static int8_t slsi_save_config(void)
 	char *pbuf = NULL;
 	pbuf = slsi_send_request(WPA_COMMAND_SAVE_CONFIG, &result);
 	if (pbuf) {
-		free(pbuf);
+		kmm_free(pbuf);
 		pbuf = NULL;
 	}
 	return result;
@@ -574,7 +574,7 @@ static bool slsi_get_security_from_flags(const char *flag_str, slsi_security_con
 		} else {
 			ret = TRUE;
 			*sec_count = mode_count;
-			*sec = zalloc(sizeof(slsi_security_config_t) * mode_count);
+			*sec = kmm_zalloc(sizeof(slsi_security_config_t) * mode_count);
 			if (*sec == NULL) {
 				EPRINT("could not allocate memory for security mode block\n");
 				ret = FALSE;
@@ -668,7 +668,7 @@ static uint8_t *slsi_hexstr_2_bytearray(char *str, size_t str_size, size_t *arra
 		return NULL;
 	}
 	array_len = str_len / 2;
-	byte_array = (uint8_t *)zalloc(array_len + 1);
+	byte_array = (uint8_t *)kmm_zalloc(array_len + 1);
 	if (byte_array) {
 		char a, b;
 		VPRINT("length=%d, bytes= ", array_len);
@@ -695,7 +695,7 @@ static uint8_t *slsi_hexstr_2_bytearray(char *str, size_t str_size, size_t *arra
 static uint8_t *slsi_bytearray_2_hexstr(const uint8_t *bytes, size_t size, size_t *stringlen)
 {
 
-	uint8_t *hexstr = zalloc((size * 2) + 1);	//need room for null termination
+	uint8_t *hexstr = kmm_zalloc((size * 2) + 1);	//need room for null termination
 	if (hexstr != NULL) {
 		uint8_t *ptr = hexstr;
 		size_t i = 0;
@@ -896,7 +896,7 @@ static bool slsi_get_bss_info(const char *bssid, slsi_scan_info_t *info)
 					}
 				}
 				if (bytes) {
-					free(bytes);
+					kmm_free(bytes);
 					bytes = NULL;
 				}
 			}
@@ -913,14 +913,14 @@ static bool slsi_get_bss_info(const char *bssid, slsi_scan_info_t *info)
 			goto errout;
 		}
 		*end = '\0';
-		char *tmpflags = zalloc(end - pos + 1);
+		char *tmpflags = kmm_zalloc(end - pos + 1);
 		if (tmpflags == NULL) {
 			goto errout;
 		}
 		strlcpy(tmpflags, pos, end - pos + 1);
 		bool device_supported = slsi_get_security_from_flags(tmpflags, &info->sec_modes, &info->num_sec_modes);
 		if (tmpflags) {
-			free(tmpflags);
+			kmm_free(tmpflags);
 			tmpflags = NULL;
 		}
 		if (!device_supported) {
@@ -943,13 +943,13 @@ static bool slsi_get_bss_info(const char *bssid, slsi_scan_info_t *info)
 
 	}
 	if (pbuf) {
-		free(pbuf);
+		kmm_free(pbuf);
 		pbuf = NULL;
 		return TRUE;
 	}
 errout:
 	if (pbuf) {
-		free(pbuf);
+		kmm_free(pbuf);
 		pbuf = NULL;
 	}
 	return FALSE;
@@ -1049,22 +1049,22 @@ static void slsi_clean_recover(void)
 	sem_post(&g_sem_recover);
 	// Free join_config security
 	if (g_recovery_data.security) {
-		free(g_recovery_data.security);
+		kmm_free(g_recovery_data.security);
 		g_recovery_data.security = NULL;
 	}
 	// Free ap_config security
 	slsi_ap_config_t *t_ap_config = &g_recovery_data.ap_config;
 	if (t_ap_config->security) {
-		free(t_ap_config->security);
+		kmm_free(t_ap_config->security);
 		t_ap_config->security = NULL;
 	}
 	// Free ap_config vsie
 	if (t_ap_config->vsie) {
 		if (t_ap_config->vsie->content) {
-			free(t_ap_config->vsie->content);
+			kmm_free(t_ap_config->vsie->content);
 			t_ap_config->vsie->content = NULL;
 		}
-		free(t_ap_config->vsie);
+		kmm_free(t_ap_config->vsie);
 		t_ap_config->vsie = NULL;
 	}
 	// Clean g_recovery_data
@@ -1171,7 +1171,7 @@ static void slsi_reinitiate_state(void)
 		/* Setup mode */
 		slsi_ap_config_t *pl_ap_config = slsi_get_ap_config();
 		res_api = slsi_api_start(g_recovery_data.old_interface_type, pl_ap_config);
-		free(pl_ap_config);
+		kmm_free(pl_ap_config);
 		DPRINT("WiFiStart 2 returned result=%d \n", res_api);
 		if (res_api != SLSI_STATUS_SUCCESS) {
 			EPRINT("Not able to start Wi-Fi 2! \n");
@@ -1271,7 +1271,7 @@ void slsi_monitor_thread_handler(void *param)
 			result = strchr(result, '>');
 			if (result == NULL) {
 				if (tmp) {
-					free(tmp);
+					kmm_free(tmp);
 					tmp = NULL;
 				}
 				continue;
@@ -1394,7 +1394,7 @@ void slsi_monitor_thread_handler(void *param)
 							g_state = SLSI_WIFIAPI_STATE_SUPPLICANT_RUNNING;
 							if (g_network_id) {
 								slsi_remove_network(g_network_id);
-								free(g_network_id);
+								kmm_free(g_network_id);
 								g_network_id = NULL;
 							}
 						}
@@ -1430,7 +1430,7 @@ void slsi_monitor_thread_handler(void *param)
 						}
 						if (g_network_id) {
 							slsi_remove_network(g_network_id);
-							free(g_network_id);
+							kmm_free(g_network_id);
 							g_network_id = NULL;
 						}
 						if (g_link_down) {
@@ -1494,7 +1494,7 @@ void slsi_monitor_thread_handler(void *param)
 				}
 			}
 			if (tmp) {
-				free(tmp);
+				kmm_free(tmp);
 				tmp = NULL;
 			}
 #ifdef CONFIG_SCSC_WLAN_AUTO_RECOVERY
@@ -1517,7 +1517,7 @@ static int8_t slsi_recv_pending(char **result)
 	}
 	while (wpa_ctrl_pending(g_ctrl_conn) > 0) {
 		size_t len = WPA_BUFFER_SIZE - 1;
-		char *buf = zalloc(len + 1);
+		char *buf = kmm_zalloc(len + 1);
 		if (buf == NULL) {
 			return 0;
 		} else {
@@ -1530,7 +1530,7 @@ static int8_t slsi_recv_pending(char **result)
 				EPRINT("SLSI_API Could not read pending message.\n");
 				UNUSED(buf);	//prevent lint warning
 				if (buf) {
-					free(buf);
+					kmm_free(buf);
 					// prevent lint warning so no buf = NULL;
 				}
 			}
@@ -1669,14 +1669,14 @@ static int8_t slsi_get_network(uint8_t *ssid, uint8_t ssid_len, char **network_i
 		}
 		result = SLSI_STATUS_SUCCESS;
 		if (pbuf) {
-			free(pbuf);
+			kmm_free(pbuf);
 			pbuf = NULL;
 		}
 	}
 	return result;
 errout:
 	if (pbuf) {
-		free(pbuf);
+		kmm_free(pbuf);
 		pbuf = NULL;
 	}
 	return result;
@@ -1735,7 +1735,7 @@ static int8_t slsi_check_status(uint8_t *ssid, int8_t *ssid_len, char *bssid)
 		}
 		result = SLSI_STATUS_SUCCESS;
 		if (pbuf) {
-			free(pbuf);
+			kmm_free(pbuf);
 			pbuf = NULL;
 		}
 	}
@@ -1743,7 +1743,7 @@ static int8_t slsi_check_status(uint8_t *ssid, int8_t *ssid_len, char *bssid)
 
 errout:
 	if (pbuf) {
-		free(pbuf);
+		kmm_free(pbuf);
 		pbuf = NULL;
 	}
 	return result;
@@ -1880,7 +1880,7 @@ static int8_t slsi_set_security(const slsi_security_config_t *sec_config, const 
 			}
 			char *pbuf = slsi_send_request(command, &result);
 			if (pbuf) {
-				free(pbuf);
+				kmm_free(pbuf);
 				pbuf = NULL;
 				if (result != SLSI_STATUS_SUCCESS) {
 					goto errout;
@@ -1900,7 +1900,7 @@ static slsi_ap_config_t *slsi_get_ap_config(void)
 {
 
 	// Clean up structure
-	slsi_ap_config_t *p_ap_config = zalloc(sizeof(slsi_ap_config_t));
+	slsi_ap_config_t *p_ap_config = kmm_zalloc(sizeof(slsi_ap_config_t));
 
 	if (p_ap_config == NULL) {
 		EPRINT("Memory allocation failed \n");
@@ -1909,7 +1909,7 @@ static slsi_ap_config_t *slsi_get_ap_config(void)
 		memcpy(p_ap_config, tmp_ap_config, sizeof(slsi_ap_config_t));
 
 		if (tmp_ap_config->security) {
-			p_ap_config->security = zalloc(sizeof(slsi_security_config_t));
+			p_ap_config->security = kmm_zalloc(sizeof(slsi_security_config_t));
 			if (p_ap_config->security == NULL) {
 				EPRINT("Memory allocation failed \n");
 			} else {
@@ -1917,13 +1917,13 @@ static slsi_ap_config_t *slsi_get_ap_config(void)
 			}
 		}
 		if (tmp_ap_config->vsie) {
-			p_ap_config->vsie = zalloc(sizeof(slsi_vendor_ie_t));
+			p_ap_config->vsie = kmm_zalloc(sizeof(slsi_vendor_ie_t));
 			if (p_ap_config->vsie == NULL) {
 				EPRINT("Memory allocation failed \n");
 			} else {
 				memcpy(p_ap_config->vsie, tmp_ap_config->vsie, sizeof(slsi_vendor_ie_t));
 			}
-			p_ap_config->vsie->content = zalloc(tmp_ap_config->vsie->content_length);
+			p_ap_config->vsie->content = kmm_zalloc(tmp_ap_config->vsie->content_length);
 			if (p_ap_config->vsie->content == NULL) {
 				EPRINT("Memory allocation failed \n");
 			} else {
@@ -1940,15 +1940,15 @@ static void slsi_save_ap_config(slsi_ap_config_t *ap_config)
 	// Clean up structure
 	slsi_ap_config_t *t_ap_config = &g_recovery_data.ap_config;
 	if (t_ap_config->security) {
-		free(t_ap_config->security);
+		kmm_free(t_ap_config->security);
 		t_ap_config->security = NULL;
 	}
 	if (t_ap_config->vsie) {
 		if (t_ap_config->vsie->content) {
-			free(t_ap_config->vsie->content);
+			kmm_free(t_ap_config->vsie->content);
 			t_ap_config->vsie->content = NULL;
 		}
-		free(t_ap_config->vsie);
+		kmm_free(t_ap_config->vsie);
 		t_ap_config->vsie = NULL;
 	}
 	memset(&g_recovery_data.ap_config, 0, sizeof(slsi_ap_config_t));
@@ -1956,7 +1956,7 @@ static void slsi_save_ap_config(slsi_ap_config_t *ap_config)
 	// Save new config
 	memcpy(&g_recovery_data.ap_config, ap_config, sizeof(slsi_ap_config_t));
 	if (ap_config->security) {
-		t_ap_config->security = zalloc(sizeof(slsi_security_config_t));
+		t_ap_config->security = kmm_zalloc(sizeof(slsi_security_config_t));
 		if (t_ap_config->security == NULL) {
 			EPRINT("Memory allocation failed \n");
 		} else {
@@ -1964,7 +1964,7 @@ static void slsi_save_ap_config(slsi_ap_config_t *ap_config)
 		}
 	}
 	if (ap_config->vsie) {
-		t_ap_config->vsie = zalloc(sizeof(slsi_vendor_ie_t));
+		t_ap_config->vsie = kmm_zalloc(sizeof(slsi_vendor_ie_t));
 		if (t_ap_config->vsie == NULL) {
 			EPRINT("Memory allocation failed \n");
 		} else {
@@ -1972,7 +1972,7 @@ static void slsi_save_ap_config(slsi_ap_config_t *ap_config)
 		}
 
 		if (ap_config->vsie->content) {
-			t_ap_config->vsie->content = zalloc(ap_config->vsie->content_length);
+			t_ap_config->vsie->content = kmm_zalloc(ap_config->vsie->content_length);
 			if (t_ap_config->vsie->content == NULL) {
 				EPRINT("Memory allocation failed \n");
 			} else {
@@ -1986,7 +1986,7 @@ static void slsi_save_join(uint8_t *ssid, int ssid_len, uint8_t *bssid, const sl
 {
 	// Clean up structure
 	if (g_recovery_data.security) {
-		free(g_recovery_data.security);
+		kmm_free(g_recovery_data.security);
 		g_recovery_data.security = NULL;
 	}
 	memset(&(g_recovery_data.ssid), 0, sizeof(g_recovery_data.ssid));
@@ -2005,7 +2005,7 @@ static void slsi_save_join(uint8_t *ssid, int ssid_len, uint8_t *bssid, const sl
 
 	if (sec_config) {
 		// TODO: security not saved!!!
-		g_recovery_data.security = zalloc(sizeof(slsi_security_config_t));
+		g_recovery_data.security = kmm_zalloc(sizeof(slsi_security_config_t));
 		if (g_recovery_data.security == NULL) {
 			EPRINT("Memory allocation failed \n");
 		} else {
@@ -2037,7 +2037,7 @@ static int8_t slsi_join_network(uint8_t *ssid, int ssid_len, uint8_t *bssid, con
 		if (pbuf) {
 			pbuf[strcspn(pbuf, "\r\n")] = '\0';
 			network_id = strdup(pbuf);
-			free(pbuf);
+			kmm_free(pbuf);
 			pbuf = NULL;
 		} else {
 			goto errout;
@@ -2049,7 +2049,7 @@ static int8_t slsi_join_network(uint8_t *ssid, int ssid_len, uint8_t *bssid, con
 		snprintf(command, WPA_COMMAND_MAX_SIZE, "%s%s %sP\"%s\"", WPA_COMMAND_SET_NETWORK, network_id, WPA_PARAM_SSID, ssid_formatted);
 		pbuf = slsi_send_request(command, &result);
 		if (pbuf) {
-			free(pbuf);
+			kmm_free(pbuf);
 			// removed to prevent lint warning pbuf = NULL;
 			if (result != SLSI_STATUS_SUCCESS) {
 				goto errout;
@@ -2060,7 +2060,7 @@ static int8_t slsi_join_network(uint8_t *ssid, int ssid_len, uint8_t *bssid, con
 		snprintf(command, WPA_COMMAND_MAX_SIZE, "%s%s %s%d", WPA_COMMAND_SET_NETWORK, network_id, WPA_PARAM_SCAN_SSID, 1);
 		pbuf = slsi_send_request(command, &result);
 		if (pbuf) {
-			free(pbuf);
+			kmm_free(pbuf);
 			// removed to prevent lint warning pbuf = NULL;
 			if (result != SLSI_STATUS_SUCCESS) {
 				goto errout;
@@ -2089,7 +2089,7 @@ static int8_t slsi_join_network(uint8_t *ssid, int ssid_len, uint8_t *bssid, con
 			goto errout;
 		}
 		if (g_network_id) {
-			free(g_network_id);
+			kmm_free(g_network_id);
 			g_network_id = NULL;
 		}
 		g_network_id = strdup(network_id);
@@ -2097,7 +2097,7 @@ static int8_t slsi_join_network(uint8_t *ssid, int ssid_len, uint8_t *bssid, con
 
 errout:
 	if (network_id) {
-		free(network_id);
+		kmm_free(network_id);
 		network_id = NULL;
 	}
 
@@ -2194,7 +2194,7 @@ static int8_t slsi_set_ap_network(slsi_ap_config_t *ap_config)
 			pbuf[strcspn(pbuf, "\r\n")] = '\0';
 			network_id = strdup(pbuf);
 			if (pbuf) {
-				free(pbuf);
+				kmm_free(pbuf);
 				//removed to prevent lint warning pbuf = NULL;
 			}
 		}
@@ -2219,7 +2219,7 @@ static int8_t slsi_set_ap_network(slsi_ap_config_t *ap_config)
 			snprintf(command, WPA_COMMAND_MAX_SIZE, "%s%s %sP\"%s\"", WPA_COMMAND_SET_NETWORK, network_id, WPA_PARAM_SSID, ssid_formated);
 			pbuf = slsi_send_request(command, &result);
 			if (pbuf) {
-				free(pbuf);
+				kmm_free(pbuf);
 				//removed to prevent lint warning pbuf = NULL;
 				if (result != SLSI_STATUS_SUCCESS) {
 					goto errout;
@@ -2269,7 +2269,7 @@ static int8_t slsi_set_ap_network(slsi_ap_config_t *ap_config)
 					snprintf(command, WPA_COMMAND_MAX_SIZE, "%s%s %s%d", WPA_COMMAND_SET_NETWORK, network_id, WPA_PARAM_FREQUENCY, localFreq);
 					pbuf = slsi_send_request(command, &result);
 					if (pbuf) {
-						free(pbuf);
+						kmm_free(pbuf);
 						// removed to prevent lint error pbuf = NULL;
 						if (result != SLSI_STATUS_SUCCESS) {
 							goto errout;
@@ -2291,7 +2291,7 @@ static int8_t slsi_set_ap_network(slsi_ap_config_t *ap_config)
 				snprintf(command, WPA_COMMAND_MAX_SIZE, "%s%s %s%d", WPA_COMMAND_SET_NETWORK, network_id, WPA_PARAM_BEACON_INT, ap_config->beacon_period);
 				pbuf = slsi_send_request(command, &result);
 				if (pbuf) {
-					free(pbuf);
+					kmm_free(pbuf);
 					// removed to prevent lint warning pbuf = NULL;
 					if (result != SLSI_STATUS_SUCCESS) {
 						goto errout;
@@ -2304,7 +2304,7 @@ static int8_t slsi_set_ap_network(slsi_ap_config_t *ap_config)
 				snprintf(command, WPA_COMMAND_MAX_SIZE, "%s%s %s%d", WPA_COMMAND_SET_NETWORK, network_id, WPA_PARAM_DTIM_PERIOD, ap_config->DTIM);
 				pbuf = slsi_send_request(command, &result);
 				if (pbuf) {
-					free(pbuf);
+					kmm_free(pbuf);
 					// removed to prevent lint warning pbuf = NULL;
 					if (result != SLSI_STATUS_SUCCESS) {
 						goto errout;
@@ -2315,14 +2315,14 @@ static int8_t slsi_set_ap_network(slsi_ap_config_t *ap_config)
 			if (ap_config->vsie != NULL) {
 				DPRINT("OUI: %02X%02X%02X\n", ap_config->vsie->oui[0], ap_config->vsie->oui[1], ap_config->vsie->oui[2]);
 				uint32_t cmdsize = ap_config->vsie->content_length * 3 + 30;
-				char *tcommand = zalloc(cmdsize);
+				char *tcommand = kmm_zalloc(cmdsize);
 				size_t slen = 0;
 
 				if (tcommand == NULL) {
 					goto errout;
 				}
 				if (ap_config->vsie->content_length > 253) {
-					free(tcommand);
+					kmm_free(tcommand);
 					result = SLSI_STATUS_PARAM_FAILED;
 					goto errout;
 				}
@@ -2333,13 +2333,13 @@ static int8_t slsi_set_ap_network(slsi_ap_config_t *ap_config)
 				snprintf(tcommand, cmdsize, "%s%s%02X%02X%02X %s", WPA_COMMAND_SET, WPA_PARAM_VSIE, ap_config->vsie->oui[0], ap_config->vsie->oui[1], ap_config->vsie->oui[2], iehex);
 				pbuf = slsi_send_request(tcommand, &result);
 				if (iehex != NULL) {
-					free(iehex);
+					kmm_free(iehex);
 				}
 				if (tcommand) {
-					free(tcommand);
+					kmm_free(tcommand);
 				}
 				if (pbuf) {
-					free(pbuf);
+					kmm_free(pbuf);
 					// removed to prevent lint warning pbuf = NULL;
 					if (result != SLSI_STATUS_SUCCESS) {
 						goto errout;
@@ -2396,7 +2396,7 @@ static int8_t slsi_set_ap_network(slsi_ap_config_t *ap_config)
 					snprintf(command, WPA_COMMAND_MAX_SIZE, "%s%s %s%x", WPA_COMMAND_SET_NETWORK, network_id, WPA_PARAM_HT_MCS, ap_config->ht_mode.mcs_index);
 					pbuf = slsi_send_request(command, &result);
 					if (pbuf) {
-						free(pbuf);
+						kmm_free(pbuf);
 						pbuf = NULL;
 						if (result != SLSI_STATUS_SUCCESS) {
 							goto errout;
@@ -2426,7 +2426,7 @@ static int8_t slsi_set_ap_network(slsi_ap_config_t *ap_config)
 					goto errout;
 				}
 				if (g_network_id) {
-					free(g_network_id);
+					kmm_free(g_network_id);
 					g_network_id = NULL;
 				}
 				g_network_id = strdup(network_id);
@@ -2446,7 +2446,7 @@ errout:
 			slsi_demo_app_sleep(1, "AP setup");
 		}
 		if (network_id) {
-			free(network_id);
+			kmm_free(network_id);
 			network_id = NULL;
 		}
 	}
@@ -2500,7 +2500,7 @@ slsi_scan_info_t *slsi_parse_scan_results(char *sr)
 		return results;
 	}
 
-	slsi_scan_info_t *local_scan_result = (slsi_scan_info_t *)zalloc((size_t)sizeof(slsi_scan_info_t));
+	slsi_scan_info_t *local_scan_result = (slsi_scan_info_t *)kmm_zalloc((size_t)sizeof(slsi_scan_info_t));
 	if (local_scan_result == NULL) {
 		return results;
 	}
@@ -2537,7 +2537,7 @@ slsi_scan_info_t *slsi_parse_scan_results(char *sr)
 			pos = end + 1;
 			if (*pos != '\0') {
 				local_prev = local_scan_result;
-				local_scan_result->next = zalloc(sizeof(slsi_scan_info_t));
+				local_scan_result->next = kmm_zalloc(sizeof(slsi_scan_info_t));
 				local_scan_result = local_scan_result->next;
 			} else {
 				local_scan_result->next = NULL;
@@ -2551,7 +2551,7 @@ slsi_scan_info_t *slsi_parse_scan_results(char *sr)
 	if (discarted) {
 		if (local_scan_result) {
 			VPRINT("Allocated one to many - set previous next to NULL\n");
-			free(local_scan_result);
+			kmm_free(local_scan_result);
 			local_scan_result = NULL;
 			if (local_prev) {
 				local_prev->next = NULL;
@@ -2571,7 +2571,7 @@ static int8_t slsi_get_api_scan_results(slsi_scan_info_t **result_handler)
 	pbuf = slsi_send_request(command, NULL);
 	if (pbuf) {
 		*result_handler = slsi_parse_scan_results(pbuf);
-		free(pbuf);
+		kmm_free(pbuf);
 		pbuf = NULL;
 		result = SLSI_STATUS_SUCCESS;
 	}
@@ -2598,7 +2598,7 @@ static int8_t slsi_get_bssid(char **bssid)
 		pos = strstr(pbuf, WPA_VALUE_BSSID);
 		if (pos == NULL) {
 			VPRINT("SLSI_API get bssid FAILED");
-			free(pbuf);
+			kmm_free(pbuf);
 			pbuf = NULL;
 			goto errout;
 		}
@@ -2606,14 +2606,14 @@ static int8_t slsi_get_bssid(char **bssid)
 		end = strchr(pos, '\n');
 		if (end == NULL) {
 			VPRINT("SLSI_API get bssid FAILED");
-			free(pbuf);
+			kmm_free(pbuf);
 			pbuf = NULL;
 			goto errout;
 		}
 		*end = '\0';
 		VPRINT("SLSI_API get_bssid bssid %s\n", pos);
 		memcpy(*bssid, pos, 18);
-		free(pbuf);
+		kmm_free(pbuf);
 		pbuf = NULL;
 		result = SLSI_STATUS_SUCCESS;
 	}
@@ -2633,7 +2633,7 @@ static int8_t slsi_get_country_code(char *country_code)
 		result = SLSI_STATUS_SUCCESS;
 	}
 	if (nvram) {
-		free(nvram);
+		kmm_free(nvram);
 		nvram = NULL;
 	}
 
@@ -2708,7 +2708,7 @@ static int8_t slsi_get_tx_power(uint8_t *dbm)
 		*dbm = strtol(pbuf, &end, 10);
 		VPRINT("dbm = %d\n", *dbm);
 		pos = end + 1;
-		free(pbuf);
+		kmm_free(pbuf);
 		pbuf = NULL;
 		result = SLSI_STATUS_SUCCESS;
 	} else {
@@ -2764,7 +2764,7 @@ static int8_t slsi_set_tx_power(uint8_t *dbm, bool write_to_nvram, bool write_to
 	if (g_state == SLSI_WIFIAPI_STATE_NOT_STARTED) {
 		// we need to cleanup nvram as it will only get cleaned on wifistop
 		if (nvram != NULL) {
-			free(nvram);
+			kmm_free(nvram);
 			nvram = NULL;
 		}
 	}
@@ -2789,7 +2789,7 @@ static int8_t slsi_get_rssi(int8_t *rssi_value)
 		pos = strstr(pbuf, WPA_VALUE_RSSI);
 		if (pos == NULL) {
 			VPRINT("SLSI_API get_rssi cannot find: %s\n", WPA_VALUE_RSSI);
-			free(pbuf);
+			kmm_free(pbuf);
 			pbuf = NULL;
 			goto errout;
 		}
@@ -2797,7 +2797,7 @@ static int8_t slsi_get_rssi(int8_t *rssi_value)
 		end = strchr(pos, '\n');
 		if (end == NULL) {
 			VPRINT("SLSI_API get_rssi failed \n");
-			free(pbuf);
+			kmm_free(pbuf);
 			pbuf = NULL;
 			goto errout;
 		}
@@ -2831,7 +2831,7 @@ static int8_t slsi_get_mac(uint8_t *mac)
 		}
 		if (pos == NULL) {
 			VPRINT("SLSI_API get_mac parameter missing WPA_VALUE_ADDRESS\n");
-			free(pbuf);
+			kmm_free(pbuf);
 			pbuf = NULL;
 			goto errout;
 		}
@@ -2839,7 +2839,7 @@ static int8_t slsi_get_mac(uint8_t *mac)
 		end = strchr(pos, '\n');
 		if (end == NULL) {
 			VPRINT("SLSI_API get_mac command 2 FAILED\n");
-			free(pbuf);
+			kmm_free(pbuf);
 			pbuf = NULL;
 			goto errout;
 		}
@@ -2849,7 +2849,7 @@ static int8_t slsi_get_mac(uint8_t *mac)
 			VPRINT("SLSI_API get_mac select: %02x\n", mac[i]);
 			pos += 3;
 		}
-		free(pbuf);
+		kmm_free(pbuf);
 		pbuf = NULL;
 		result = SLSI_STATUS_SUCCESS;
 	}
@@ -2871,14 +2871,14 @@ static int8_t slsi_get_channel(int8_t *channel)
 		pos = strstr(pbuf, WPA_VALUE_FREQ);
 		if (pos == NULL) {
 			VPRINT("SLSI_API get: %s FAILED \n", WPA_VALUE_FREQ);
-			free(pbuf);
+			kmm_free(pbuf);
 			pbuf = NULL;
 			goto errout;
 		}
 		pos += 5;
 		end = strchr(pos, '\n');
 		if (end == NULL) {
-			free(pbuf);
+			kmm_free(pbuf);
 			pbuf = NULL;
 			goto errout;
 		}
@@ -2887,7 +2887,7 @@ static int8_t slsi_get_channel(int8_t *channel)
 		VPRINT("SLSI_API channel: %d\n", *channel);
 		result = SLSI_STATUS_SUCCESS;
 		pos = end + 1;
-		free(pbuf);
+		kmm_free(pbuf);
 		pbuf = NULL;
 	}
 errout:
@@ -3051,7 +3051,7 @@ static void slsi_init_nvram(void)
 {
 
 	if (nvram == NULL) {
-		nvram = zalloc(4 * 1024);	// flash block size of 4k
+		nvram = kmm_zalloc(4 * 1024);	// flash block size of 4k
 		if (!nvram) {
 			return;
 		}
@@ -3106,28 +3106,28 @@ static int8_t slsi_init(WiFi_InterFace_ID_t interface_id, const slsi_ap_config_t
 		VPRINT("start ap_config available\n");
 		if (g_ap_config != NULL) {
 			if (g_ap_config->security) {
-				free(g_ap_config->security);	// We might have a sec. config to free
+				kmm_free(g_ap_config->security);	// We might have a sec. config to free
 				g_ap_config->security = NULL;
 			}
 			if (g_ap_config->vsie) {
 				if (g_ap_config->vsie->content) {
-					free(g_ap_config->vsie->content);
+					kmm_free(g_ap_config->vsie->content);
 					g_ap_config->vsie->content = NULL;
 				}
-				free(g_ap_config->vsie);	// We might have a vsie config to free
+				kmm_free(g_ap_config->vsie);	// We might have a vsie config to free
 				g_ap_config->vsie = NULL;
 			}
-			free(g_ap_config);	// Free app_config of needed
+			kmm_free(g_ap_config);	// Free app_config of needed
 			g_ap_config = NULL;
 		}
-		g_ap_config = zalloc(sizeof(slsi_ap_config_t));
+		g_ap_config = kmm_zalloc(sizeof(slsi_ap_config_t));
 		if (g_ap_config == NULL) {
 			goto errout;
 		}
 
 		*g_ap_config = *ap_config;
 		if (ap_config->security) {
-			g_ap_config->security = zalloc(sizeof(slsi_security_config_t));
+			g_ap_config->security = kmm_zalloc(sizeof(slsi_security_config_t));
 			if (g_ap_config->security == NULL) {
 				goto errout;
 			}
@@ -3136,12 +3136,12 @@ static int8_t slsi_init(WiFi_InterFace_ID_t interface_id, const slsi_ap_config_t
 			g_ap_config->security = NULL;
 		}
 		if (ap_config->vsie) {
-			g_ap_config->vsie = zalloc(sizeof(slsi_vendor_ie_t));
+			g_ap_config->vsie = kmm_zalloc(sizeof(slsi_vendor_ie_t));
 			if (g_ap_config->vsie == NULL) {
 				goto errout;
 			}
 			*(g_ap_config->vsie) = *(ap_config->vsie);
-			g_ap_config->vsie->content = zalloc(ap_config->vsie->content_length);
+			g_ap_config->vsie->content = kmm_zalloc(ap_config->vsie->content_length);
 			if (g_ap_config->vsie->content == NULL) {
 				goto errout;
 			}
@@ -3213,28 +3213,28 @@ static void slsi_deinit(void)
 	sem_destroy(&g_sem_api_block);
 
 	if (nvram != NULL) {
-		free(nvram);
+		kmm_free(nvram);
 		nvram = NULL;
 	}
 	if (g_ap_config != NULL) {
 		if (g_ap_config->security) {
-			free(g_ap_config->security);	// We might have a sec. config to free
+			kmm_free(g_ap_config->security);	// We might have a sec. config to free
 			g_ap_config->security = NULL;
 		}
 		if (g_ap_config->vsie) {
 			if (g_ap_config->vsie->content) {
-				free(g_ap_config->vsie->content);	// We might have a vsie config to free
+				kmm_free(g_ap_config->vsie->content);	// We might have a vsie config to free
 				g_ap_config->vsie->content = NULL;
 			}
-			free(g_ap_config->vsie);	// We might have a vsie config to free
+			kmm_free(g_ap_config->vsie);	// We might have a vsie config to free
 			g_ap_config->vsie = NULL;
 		}
 		// Free app_config of needed
-		free(g_ap_config);
+		kmm_free(g_ap_config);
 		g_ap_config = NULL;
 	}
 	if (g_network_id) {
-		free(g_network_id);
+		kmm_free(g_network_id);
 		g_network_id = NULL;
 	}
 }
@@ -3270,7 +3270,7 @@ static int8_t slsi_api_start(WiFi_InterFace_ID_t interface_id, const slsi_ap_con
 				// remove network
 				if (g_network_id) {
 					slsi_remove_network(g_network_id);
-					free(g_network_id);
+					kmm_free(g_network_id);
 					g_network_id = NULL;
 				}
 			}
@@ -3316,7 +3316,7 @@ static int8_t slsi_api_start(WiFi_InterFace_ID_t interface_id, const slsi_ap_con
 #endif
 		if (result != SLSI_STATUS_SUCCESS && (slsi_get_op_mode() == SLSI_WIFI_SOFT_AP_IF)) {
 			if (g_network_id) {
-				free(g_network_id);
+				kmm_free(g_network_id);
 				g_network_id = NULL;
 			}
 		}
@@ -3398,7 +3398,7 @@ int8_t WiFiStop(void)
 		// remove network
 		if (g_network_id) {
 			slsi_remove_network(g_network_id);
-			free(g_network_id);
+			kmm_free(g_network_id);
 			g_network_id = NULL;
 		}
 	} else {
@@ -3456,9 +3456,9 @@ int8_t WiFiFreeScanResults(slsi_scan_info_t **scan_results)
 	while (tmp_bss_list != NULL) {
 		tmp = tmp_bss_list;
 		tmp_bss_list = tmp_bss_list->next;
-		free(tmp->sec_modes);
+		kmm_free(tmp->sec_modes);
 		tmp->sec_modes = NULL;
-		free(tmp);
+		kmm_free(tmp);
 	}
 	tmp = NULL;
 	*scan_results = NULL;
@@ -3773,7 +3773,7 @@ slsi_security_config_t *getSecurityConfig(char *sec_type, char *psk, WiFi_InterF
 {
 	slsi_security_config_t *ret = NULL;
 	if (strncmp(SLSI_WIFI_SECURITY_OPEN, sec_type, sizeof(SLSI_WIFI_SECURITY_OPEN)) != 0) {
-		ret = (slsi_security_config_t *)zalloc(sizeof(slsi_security_config_t));
+		ret = (slsi_security_config_t *)kmm_zalloc(sizeof(slsi_security_config_t));
 		if (ret) {
 			if (strncmp(SLSI_WIFI_SECURITY_WEP_OPEN, sec_type, sizeof(SLSI_WIFI_SECURITY_WEP_OPEN)) == 0) {
 				ret->secmode = SLSI_SEC_MODE_WEP;
@@ -3798,7 +3798,7 @@ slsi_security_config_t *getSecurityConfig(char *sec_type, char *psk, WiFi_InterF
 			memcpy(ret->passphrase, psk, strlen(psk));
 		} else {
 			if (ret) {
-				free(ret);
+				kmm_free(ret);
 				ret = NULL;
 			}
 		}

--- a/os/se/konai/konai.c
+++ b/os/se/konai/konai.c
@@ -42,7 +42,7 @@ int konai_free_data(_IN_ hal_data *data)
 {
 	if (data) {
 		if (data->data) {
-			free(data->data);
+			kmm_free(data->data);
 		}
 	}
 	return 0;
@@ -177,7 +177,7 @@ int konai_set_certificate(_IN_ uint32_t cert_idx, _IN_ hal_data *cert_in)
 {
 	KN_ENTER;
 
-	cert_s.data = (unsigned char *)malloc(cert_in->data_len);
+	cert_s.data = (unsigned char *)kmm_malloc(cert_in->data_len);
 	memcpy(cert_s.data, cert_in->data, cert_in->data_len);
 	cert_s.data_len = cert_in->data_len;
 
@@ -188,7 +188,7 @@ int konai_get_certificate(_IN_ uint32_t cert_idx, _OUT_ hal_data *cert_out)
 {
 	KN_ENTER;
 
-	cert_out->data = (unsigned char *)malloc(cert_s.data_len);
+	cert_out->data = (unsigned char *)kmm_malloc(cert_s.data_len);
 	memcpy(cert_out->data, cert_s.data, cert_s.data_len);
 	cert_out->data_len = cert_s.data_len;
 
@@ -199,7 +199,7 @@ int konai_remove_certificate(_IN_ uint32_t cert_idx)
 {
 	KN_ENTER;
 
-	free(cert_s.data);
+	kmm_free(cert_s.data);
 	cert_s.data_len = 0;
 
 	return 0;
@@ -209,7 +209,7 @@ static hal_data factory_s = {"factory", 7, NULL};
 
 int konai_get_factory_key(_IN_ uint32_t key_idx, _IN_ hal_data *key)
 {
-	key->data = (unsigned char *)malloc(7);
+	key->data = (unsigned char *)kmm_malloc(7);
 	memcpy(key->data, factory_s.data, 7);
 
 	return 0;
@@ -219,7 +219,7 @@ int konai_get_factory_cert(_IN_ uint32_t cert_idx, _IN_ hal_data *cert)
 {
 	KN_ENTER;
 
-	cert->data = (unsigned char *)malloc(7);
+	cert->data = (unsigned char *)kmm_malloc(7);
 	memcpy(cert->data, factory_s.data, 7);
 
 	return 0;
@@ -229,7 +229,7 @@ int konai_get_factory_data(_IN_ uint32_t data_idx, _IN_ hal_data *data)
 {
 	KN_ENTER;
 
-	data->data = (unsigned char *)malloc(7);
+	data->data = (unsigned char *)kmm_malloc(7);
 	memcpy(data->data, factory_s.data, 7);
 
 	return 0;
@@ -242,7 +242,7 @@ int konai_aes_encrypt(_IN_ hal_data *dec_data, _IN_ hal_aes_param *aes_param, _I
 {
 	KN_ENTER;
 
-	enc_data->data = (unsigned char *)malloc(dec_data->data_len);
+	enc_data->data = (unsigned char *)kmm_malloc(dec_data->data_len);
 	memcpy(enc_data->data, dec_data->data, dec_data->data_len);
 	enc_data->data_len = dec_data->data_len;
 
@@ -253,7 +253,7 @@ int konai_aes_decrypt(_IN_ hal_data *enc_data, _IN_ hal_aes_param *aes_param, _I
 {
 	KN_ENTER;
 
-	dec_data->data = (unsigned char *)malloc(enc_data->data_len);
+	dec_data->data = (unsigned char *)kmm_malloc(enc_data->data_len);
 	memcpy(dec_data->data, enc_data->data, enc_data->data_len);
 	dec_data->data_len = enc_data->data_len;
 
@@ -264,7 +264,7 @@ int konai_rsa_encrypt(_IN_ hal_data *dec_data, _IN_ hal_rsa_mode *mode, _IN_ uin
 {
 	KN_ENTER;
 
-	enc_data->data = (unsigned char *)malloc(dec_data->data_len);
+	enc_data->data = (unsigned char *)kmm_malloc(dec_data->data_len);
 	memcpy(enc_data->data, dec_data->data, dec_data->data_len);
 	enc_data->data_len = dec_data->data_len;
 
@@ -274,7 +274,7 @@ int konai_rsa_decrypt(_IN_ hal_data *enc_data, _IN_ hal_rsa_mode *mode, _IN_ uin
 {
 	KN_ENTER;
 
-	dec_data->data = (unsigned char *)malloc(enc_data->data_len);
+	dec_data->data = (unsigned char *)kmm_malloc(enc_data->data_len);
 	memcpy(dec_data->data, enc_data->data, enc_data->data_len);
 	dec_data->data_len = enc_data->data_len;
 

--- a/os/se/sss/security_hal_wrapper.c
+++ b/os/se/sss/security_hal_wrapper.c
@@ -140,7 +140,7 @@ static void hal_mpi_free(hal_mpi *X)
 
 	if (X->p != NULL) {
 		hal_mpi_zeroize(X->p, X->n);
-		free(X->p);
+		kmm_free(X->p);
 	}
 
 	X->s = 1;
@@ -157,14 +157,14 @@ static int hal_mpi_grow(hal_mpi *X, uint32_t nblimbs)
 	}
 
 	if (X->n < nblimbs)	{
-		if ((p = (uint64_t *)calloc(nblimbs, ciL)) == NULL) {
+		if ((p = (uint64_t *)kmm_calloc(nblimbs, ciL)) == NULL) {
 			return HAL_ALLOC_FAIL;
 		}
 
 		if (X->p != NULL) {
 			memcpy(p, X->p, X->n * ciL);
 			hal_mpi_zeroize(X->p, X->n);
-			free(X->p);
+			kmm_free(X->p);
 		}
 
 		X->n = nblimbs;
@@ -494,10 +494,10 @@ int sss_hal_free_data(hal_data *data)
 	HWRAP_ENTER;
 	if (data) {
 		if (data->data) {
-			free(data->data);
+			kmm_free(data->data);
 		}
 		if (data->priv) {
-			free(data->priv);
+			kmm_free(data->priv);
 		}
 	}
 	return HAL_SUCCESS;
@@ -1090,12 +1090,12 @@ int sss_hal_ecdsa_verify_md(hal_ecdsa_mode mode, hal_data *hash, hal_data *sign,
 	ecc_sign.r_byte_len = hal_mpi_size(&r);
 	ecc_sign.s_byte_len = hal_mpi_size(&s);
 
-	ecc_sign.r = (unsigned char *)malloc(ecc_sign.r_byte_len);
+	ecc_sign.r = (unsigned char *)kmm_malloc(ecc_sign.r_byte_len);
 	if (ecc_sign.r == NULL) {
 		ret = HAL_ALLOC_FAIL;
 		goto cleanup;
 	}
-	ecc_sign.s = (unsigned char *)malloc(ecc_sign.s_byte_len);
+	ecc_sign.s = (unsigned char *)kmm_malloc(ecc_sign.s_byte_len);
 	if (ecc_sign.s == NULL) {
 		ret = HAL_ALLOC_FAIL;
 		goto cleanup;
@@ -1156,10 +1156,10 @@ cleanup:
 	hal_mpi_free(&s);
 
 	if (ecc_sign.r) {
-		free(ecc_sign.r);
+		kmm_free(ecc_sign.r);
 	}
 	if (ecc_sign.s) {
-		free(ecc_sign.s);
+		kmm_free(ecc_sign.s);
 	}
 
 	return ret;
@@ -1189,7 +1189,7 @@ int sss_hal_dh_generate_param(uint32_t dh_idx, hal_dh_data *dh_param)
 	d_param.generator_g_byte_len = dh_param->G->data_len;;
 	d_param.generator_g = dh_param->G->data;
 	//set output pubkey
-	d_param.publickey = (unsigned char *)malloc(pubkey_len);
+	d_param.publickey = (unsigned char *)kmm_malloc(pubkey_len);
 	if (d_param.publickey == NULL) {
 		return HAL_NOT_ENOUGH_MEMORY;
 	}
@@ -1205,13 +1205,13 @@ int sss_hal_dh_generate_param(uint32_t dh_idx, hal_dh_data *dh_param)
 	}
 
 	if (!dh_param->pubkey->data) {
-		free(d_param.publickey);
+		kmm_free(d_param.publickey);
 		return HAL_INVALID_ARGS;
 	}
 	memcpy(dh_param->pubkey->data, d_param.publickey, d_param.publickey_byte_len);
 	dh_param->pubkey->data_len = d_param.publickey_byte_len;
 
-	free(d_param.publickey);
+	kmm_free(d_param.publickey);
 
 	return HAL_SUCCESS;
 }

--- a/os/se/virtual/hal_virtual.c
+++ b/os/se/virtual/hal_virtual.c
@@ -136,7 +136,7 @@ int virtual_hal_free_data(_IN_ hal_data *data)
 {
 	if (data) {
 		if (data->data) {
-			free(data->data);
+			kmm_free(data->data);
 		}
 	}
 	return 0;
@@ -313,7 +313,7 @@ int virtual_hal_get_certificate(_IN_ uint32_t cert_idx, _OUT_ hal_data *cert_out
 	cert_s.data = (void *)cert_data;
 	cert_s.data_len = sizeof(cert_data);
 
-	//cert_out->data = (unsigned char *)malloc(cert_s.data_len);
+	//cert_out->data = (unsigned char *)kmm_malloc(cert_s.data_len);
 	memcpy(cert_out->data, cert_s.data, cert_s.data_len);
 	cert_out->data_len = cert_s.data_len;
 
@@ -333,7 +333,7 @@ int virtual_hal_get_factory_key(_IN_ uint32_t key_idx, _IN_ hal_data *key)
 
 	hal_data factory_s = {"factory", 7, NULL};
 
-	key->data = (unsigned char *)malloc(7);
+	key->data = (unsigned char *)kmm_malloc(7);
 	memcpy(key->data, factory_s.data, 7);
 
 	return 0;
@@ -345,7 +345,7 @@ int virtual_hal_get_factory_cert(_IN_ uint32_t cert_idx, _IN_ hal_data *cert)
 
 	hal_data factory_s = {"factory", 7, NULL};
 
-	cert->data = (unsigned char *)malloc(7);
+	cert->data = (unsigned char *)kmm_malloc(7);
 	memcpy(cert->data, factory_s.data, 7);
 
 	return 0;
@@ -357,7 +357,7 @@ int virtual_hal_get_factory_data(_IN_ uint32_t data_idx, _IN_ hal_data *data)
 
 	hal_data factory_s = {"factory", 7, NULL};
 
-	data->data = (unsigned char *)malloc(7);
+	data->data = (unsigned char *)kmm_malloc(7);
 	memcpy(data->data, factory_s.data, 7);
 
 	return 0;
@@ -370,7 +370,7 @@ int virtual_hal_aes_encrypt(_IN_ hal_data *dec_data, _IN_ hal_aes_param *aes_par
 {
 	VH_ENTER;
 
-	enc_data->data = (unsigned char *)malloc(dec_data->data_len);
+	enc_data->data = (unsigned char *)kmm_malloc(dec_data->data_len);
 	memcpy(enc_data->data, dec_data->data, dec_data->data_len);
 	enc_data->data_len = dec_data->data_len;
 
@@ -381,7 +381,7 @@ int virtual_hal_aes_decrypt(_IN_ hal_data *enc_data, _IN_ hal_aes_param *aes_par
 {
 	VH_ENTER;
 
-	dec_data->data = (unsigned char *)malloc(enc_data->data_len);
+	dec_data->data = (unsigned char *)kmm_malloc(enc_data->data_len);
 	memcpy(dec_data->data, enc_data->data, enc_data->data_len);
 	dec_data->data_len = enc_data->data_len;
 
@@ -392,7 +392,7 @@ int virtual_hal_rsa_encrypt(_IN_ hal_data *dec_data, _IN_ hal_rsa_mode *mode, _I
 {
 	VH_ENTER;
 
-	enc_data->data = (unsigned char *)malloc(dec_data->data_len);
+	enc_data->data = (unsigned char *)kmm_malloc(dec_data->data_len);
 	memcpy(enc_data->data, dec_data->data, dec_data->data_len);
 	enc_data->data_len = dec_data->data_len;
 
@@ -403,7 +403,7 @@ int virtual_hal_rsa_decrypt(_IN_ hal_data *enc_data, _IN_ hal_rsa_mode *mode, _I
 {
 	VH_ENTER;
 
-	dec_data->data = (unsigned char *)malloc(enc_data->data_len);
+	dec_data->data = (unsigned char *)kmm_malloc(enc_data->data_len);
 	memcpy(dec_data->data, enc_data->data, enc_data->data_len);
 	dec_data->data_len = enc_data->data_len;
 


### PR DESCRIPTION
Because se and drivers/wireless folders are parts of kernel binary, they should use kmm APIs like
kmm_malloc, kmm_free, kmm_calloc and etc instead of malloc, free and calloc.
This commits fix them.