### PR TITLE
libc/time/lib_localtime : Change free to lib_free

### DIFF
--- a/lib/libc/lib_internal.h
+++ b/lib/libc/lib_internal.h
@@ -104,6 +104,7 @@
 /* Domain-specific allocations */
 
 #define lib_malloc(s)      kmm_malloc(s)
+#define lib_calloc(p, s)   kmm_calloc(p, s)
 #define lib_zalloc(s)      kmm_zalloc(s)
 #define lib_realloc(p, s)  kmm_realloc(p, s)
 #define lib_memalign(p, s) kmm_memalign(p, s)
@@ -122,6 +123,7 @@
 /* Domain-specific allocations */
 
 #define lib_malloc(s)      malloc(s)
+#define lib_calloc(p, s)   calloc(p, s)
 #define lib_zalloc(s)      zalloc(s)
 #define lib_realloc(p, s)  realloc(p, s)
 #define lib_free(p)        free(p)

--- a/lib/libc/misc/lib_hashmap.c
+++ b/lib/libc/misc/lib_hashmap.c
@@ -21,6 +21,8 @@
 #include <tinyara/mm/mm.h>
 #include <tinyara/hashmap.h>
 
+#include "lib_internal.h"
+
 /* this should be prime */
 #define TABLE_STARTSIZE 1021
 
@@ -75,11 +77,8 @@ static void rehash(struct hashmap_s *hm)
 	h_entry_t *table = hm->table;
 
 	hm->size = find_prime_greater_than(size << 1);
-#ifdef __KERNEL__
-	hm->table = (h_entry_t *)kmm_calloc(sizeof(h_entry_t), hm->size);
-#else
-	hm->table = (h_entry_t *)calloc(sizeof(h_entry_t), hm->size);
-#endif
+
+	hm->table = (h_entry_t *)lib_calloc(sizeof(h_entry_t), hm->size);
 	hm->count = 0;
 
 	while (--size >= 0) {
@@ -88,20 +87,12 @@ static void rehash(struct hashmap_s *hm)
 		}
 	}
 
-#ifdef __KERNEL__
-	kmm_free(table);
-#else
-	free(table);
-#endif
+	lib_free(table);
 }
 
 struct hashmap_s *hashmap_create(int startsize)
 {
-#ifdef __KERNEL__
-	struct hashmap_s *hm = (struct hashmap_s *)kmm_malloc(sizeof(struct hashmap_s));
-#else
-	struct hashmap_s *hm = (struct hashmap_s *)malloc(sizeof(struct hashmap_s));
-#endif
+	struct hashmap_s *hm = (struct hashmap_s *)lib_malloc(sizeof(struct hashmap_s));
 
 	if (hm == NULL) {
 		return NULL;
@@ -113,11 +104,7 @@ struct hashmap_s *hashmap_create(int startsize)
 		startsize = find_prime_greater_than(startsize - 2);
 	}
 
-#ifdef __KERNEL__
-	hm->table = (h_entry_t *)kmm_calloc(sizeof(h_entry_t), startsize);
-#else
-	hm->table = (h_entry_t *)calloc(sizeof(h_entry_t), startsize);
-#endif
+	hm->table = (h_entry_t *)lib_calloc(sizeof(h_entry_t), startsize);
 	hm->size = startsize;
 	hm->count = 0;
 
@@ -195,11 +182,8 @@ unsigned long* hashmap_get_keyset(struct hashmap_s *hash)
 	if (hash->count) {
 		int i = 0;
 		int idx = 0;
-#ifdef __KERNEL__
-		keyset = (unsigned long *)kmm_malloc(sizeof(unsigned long) * hash->count);
-#else
-		keyset = (unsigned long *)malloc(sizeof(unsigned long) * hash->count);
-#endif
+
+		keyset = (unsigned long *)lib_malloc(sizeof(unsigned long) * hash->count);
 		if (keyset != NULL) {
 			for (i = 0; i < hash->size; i++) {
 				if (hash->table[i].flags & ACTIVE) {
@@ -219,17 +203,10 @@ long hashmap_count(struct hashmap_s *hash)
 
 void hashmap_delete(struct hashmap_s *hash)
 {
-#ifdef __KERNEL__
 	if (hash != NULL) {
-		kmm_free(hash->table);
+		lib_free(hash->table);
 	}
-	kmm_free(hash);
-#else
-	if (hash != NULL) {
-		free(hash->table);
-	}
-	free(hash);
-#endif
+	lib_free(hash);
 }
 
 /*

--- a/lib/libc/time/lib_localtime.c
+++ b/lib/libc/time/lib_localtime.c
@@ -791,11 +791,11 @@ static int tzload(FAR const char *name, FAR struct state_s *const sp, const int 
 	}
 
 	sp->defaulttype = i;
-	free(up);
+	lib_free(up);
 	return 0;
 
 oops:
-	free(up);
+	lib_free(up);
 	return -1;
 }
 


### PR DESCRIPTION
In PR#4551, malloc is changed to lib_malloc, then we should change free to lib_free also.
Because lib can be used from kernel and user spaces.