### PR TITLE
drivers/wireless, se: include kmalloc.h for kmm APIs

### DIFF
--- a/os/drivers/wireless/realtek/wifi_util_interface/wifi_util.c
+++ b/os/drivers/wireless/realtek/wifi_util_interface/wifi_util.c
@@ -18,6 +18,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdint.h>
+#include <tinyara/kmalloc.h>
 
 #include "wireless.h"
 #include "wlan_intf.h"

--- a/os/drivers/wireless/scsc/mib.c
+++ b/os/drivers/wireless/scsc/mib.c
@@ -19,6 +19,7 @@
 #include "mib.h"
 #include "debug_scsc.h"
 #include <sys/types.h>
+#include <tinyara/kmalloc.h>
 
 #define SLSI_MIB_MORE_MASK   0x80
 #define SLSI_MIB_SIGN_MASK   0x40

--- a/os/drivers/wireless/scsc/slsi_utils.c
+++ b/os/drivers/wireless/scsc/slsi_utils.c
@@ -24,6 +24,7 @@
 #include <string.h>
 #include <errno.h>
 #include <tinyara/wifi/slsi/slsi_wifi_api.h>
+#include <tinyara/kmalloc.h>
 
 #include <tinyara/wifi/wifi_utils.h>
 

--- a/os/se/konai/konai.c
+++ b/os/se/konai/konai.c
@@ -23,6 +23,7 @@
 #include <string.h>
 #include <tinyara/seclink_drv.h>
 #include <tinyara/security_hal.h>
+#include <tinyara/kmalloc.h>
 
 #define _IN_
 #define _OUT_

--- a/os/se/sss/security_hal_wrapper.c
+++ b/os/se/sss/security_hal_wrapper.c
@@ -44,6 +44,7 @@
 #include <tinyara/config.h>
 #include <tinyara/seclink_drv.h>
 #include <tinyara/security_hal.h>
+#include <tinyara/kmalloc.h>
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/os/se/virtual/hal_virtual.c
+++ b/os/se/virtual/hal_virtual.c
@@ -23,6 +23,7 @@
 #include <string.h>
 #include <tinyara/seclink_drv.h>
 #include <tinyara/security_hal.h>
+#include <tinyara/kmalloc.h>
 
 #define _IN_
 #define _OUT_


### PR DESCRIPTION
To use kmm APIs like kmm_malloc, kmm_free, <tinyara/kmalloc.h> should be
included.
This commit includes it on some files under os/wireless and os/se folders.

Signed-off-by: sunghan-chang <sh924.chang@samsung.com>