### PR TITLE
os: use kmm APIs

### DIFF
--- a/os/arch/arm/src/s5j/sss/sss_driver_io.c
+++ b/os/arch/arm/src/s5j/sss/sss_driver_io.c
@@ -80,7 +80,7 @@ int sss_ro_read(unsigned int start_offset, unsigned char *buf, unsigned int byte
 	}
 
 	/* Allocate temporary read buffer */
-	read_buf = (unsigned char *)malloc(nsector * geo.blocksize);
+	read_buf = (unsigned char *)kmm_malloc(nsector * geo.blocksize);
 	if (read_buf == NULL) {
 		fdbg("Fail to allocate memory\n");
 		ret = ERROR_SSTORAGE_SFS_FREAD;
@@ -104,7 +104,7 @@ read_out:
 	}
 
 	if (read_buf) {
-		free(read_buf);
+		kmm_free(read_buf);
 	}
 #endif
 	return ret;

--- a/os/arch/arm/src/s5j/sss/sssro_verify.c
+++ b/os/arch/arm/src/s5j/sss/sssro_verify.c
@@ -77,7 +77,7 @@ int read_sssro_check(unsigned char *buf, unsigned int byte_size)
 		goto read_out;
 	}
 
-	read_buf = (unsigned char *)malloc(geo.blocksize);
+	read_buf = (unsigned char *)kmm_malloc(geo.blocksize);
 	if (read_buf == NULL) {
 		fdbg("Fail to allocate memory\n");
 		ret = SSSRO_CHK_FAIL;
@@ -102,7 +102,7 @@ read_out:
 	}
 
 	if (read_buf) {
-		free(read_buf);
+		kmm_free(read_buf);
 	}
 
 	return ret;

--- a/os/arch/xtensa/src/esp32/esp32_ledc.c
+++ b/os/arch/xtensa/src/esp32/esp32_ledc.c
@@ -123,7 +123,7 @@ static ledc_fade_t *s_ledc_fade_rec[LEDC_SPEED_MODE_MAX][LEDC_CHANNEL_MAX];
 static int ledc_fade_channel_init(ledc_mode_t speed_mode, ledc_channel_t channel)
 {
 	if (s_ledc_fade_rec[speed_mode][channel] == NULL) {
-		s_ledc_fade_rec[speed_mode][channel] = (ledc_fade_t *)calloc(1, sizeof(ledc_fade_t));
+		s_ledc_fade_rec[speed_mode][channel] = (ledc_fade_t *)kmm_calloc(1, sizeof(ledc_fade_t));
 	}
 	if (s_ledc_fade_rec[speed_mode][channel]) {
 
@@ -136,7 +136,7 @@ static int ledc_fade_channel_init(ledc_mode_t speed_mode, ledc_channel_t channel
 static int ledc_fade_channel_deinit(ledc_mode_t speed_mode, ledc_channel_t channel)
 {
 	if (s_ledc_fade_rec[speed_mode][channel]) {
-		free(s_ledc_fade_rec[speed_mode][channel]);
+		kmm_free(s_ledc_fade_rec[speed_mode][channel]);
 		s_ledc_fade_rec[speed_mode][channel] = NULL;
 	}
 	return OK;

--- a/os/arch/xtensa/src/esp32/esp32_rtc_module.c
+++ b/os/arch/xtensa/src/esp32/esp32_rtc_module.c
@@ -298,7 +298,7 @@ static inline void adc1_hall_enable(bool enable);
 
 SemaphoreHandle_t xSemaphoreCreateMutex(void)
 {
-	SemaphoreHandle_t x = malloc(sizeof(sem_t));
+	SemaphoreHandle_t x = kmm_malloc(sizeof(sem_t));
 	if (x != NULL) {
 		sem_init(x, 0, 1);
 		sem_setprotocol(x, SEM_PRIO_NONE);
@@ -1227,7 +1227,7 @@ esp_err_t touch_pad_filter_start(uint32_t filter_period_ms)
 	esp_err_t ret = ESP_OK;
 	xSemaphoreTake(rtc_touch_mux, portMAX_DELAY);
 	if (s_touch_pad_filter == NULL) {
-		s_touch_pad_filter = (touch_pad_filter_t *) calloc(1, sizeof(touch_pad_filter_t));
+		s_touch_pad_filter = (touch_pad_filter_t *)kmm_calloc(1, sizeof(touch_pad_filter_t));
 		if (s_touch_pad_filter == NULL) {
 			ret = ESP_ERR_NO_MEM;
 		}
@@ -1271,7 +1271,7 @@ esp_err_t touch_pad_filter_delete()
 			xTimerDelete(s_touch_pad_filter->timer, portMAX_DELAY);
 			s_touch_pad_filter->timer = NULL;
 		}
-		free(s_touch_pad_filter);
+		kmm_free(s_touch_pad_filter);
 		s_touch_pad_filter = NULL;
 	}
 	xSemaphoreGive(rtc_touch_mux);
@@ -2261,7 +2261,7 @@ esp_err_t rtc_isr_register(intr_handler_t handler, void *handler_arg, uint32_t r
 		return err;
 	}
 
-	rtc_isr_handler_t *item = malloc(sizeof(rtc_isr_handler_t));
+	rtc_isr_handler_t *item = kmm_malloc(sizeof(rtc_isr_handler_t));
 	if (item == NULL) {
 		return ESP_ERR_NO_MEM;
 	}
@@ -2296,7 +2296,7 @@ esp_err_t rtc_isr_deregister(intr_handler_t handler, void *handler_arg)
 				it->next = NULL;
 			}
 			found = true;
-			free(it);
+			kmm_free(it);
 			break;
 		}
 		prev = it;

--- a/os/arch/xtensa/src/esp32/spi_flash/flash_mmap.c
+++ b/os/arch/xtensa/src/esp32/spi_flash/flash_mmap.c
@@ -145,7 +145,7 @@ esp_err_t IRAM_ATTR spi_flash_mmap(size_t src_addr, size_t size, spi_flash_mmap_
 #ifdef CONFIG_SPIRAM_SUPPORT
 	int *pages = heap_caps_malloc(sizeof(int) * page_count, MALLOC_CAP_INTERNAL);
 #else
-	int *pages = (int *)malloc(sizeof(int) * page_count);
+	int *pages = (int *)kmm_malloc(sizeof(int) * page_count);
 #endif
 	if (pages == NULL) {
 		return ESP_ERR_NO_MEM;
@@ -154,7 +154,7 @@ esp_err_t IRAM_ATTR spi_flash_mmap(size_t src_addr, size_t size, spi_flash_mmap_
 		pages[i] = phys_page + i;
 	}
 	ret = spi_flash_mmap_pages(pages, page_count, memory, out_ptr, out_handle);
-	free(pages);
+	kmm_free(pages);
 	return ret;
 }
 
@@ -174,9 +174,9 @@ esp_err_t IRAM_ATTR spi_flash_mmap_pages(const int *pages, size_t page_count, sp
 		}
 	}
 #ifdef CONFIG_SPIRAM_SUPPORT
-	mmap_entry_t *new_entry = (mmap_entry_t *) heap_caps_malloc(sizeof(mmap_entry_t), MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT);
+	mmap_entry_t *new_entry = (mmap_entry_t *)heap_caps_malloc(sizeof(mmap_entry_t), MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT);
 #else
-	mmap_entry_t *new_entry = (mmap_entry_t *)malloc(sizeof(mmap_entry_t));
+	mmap_entry_t *new_entry = (mmap_entry_t *)kmm_malloc(sizeof(mmap_entry_t));
 #endif
 	if (new_entry == 0) {
 		return ESP_ERR_NO_MEM;
@@ -272,7 +272,7 @@ esp_err_t IRAM_ATTR spi_flash_mmap_pages(const int *pages, size_t page_count, sp
 
 	spi_flash_enable_interrupts_caches_and_other_cpu();
 	if (*out_ptr == NULL) {
-		free(new_entry);
+		kmm_free(new_entry);
 	}
 	return ret;
 }
@@ -302,7 +302,7 @@ void IRAM_ATTR spi_flash_munmap(spi_flash_mmap_handle_t handle)
 	if (it == NULL) {
 		assert(0 && "invalid handle, or handle already unmapped");
 	}
-	free(it);
+	kmm_free(it);
 }
 
 void spi_flash_mmap_dump(void)

--- a/os/arch/xtensa/src/esp32/spi_flash/partition.c
+++ b/os/arch/xtensa/src/esp32/spi_flash/partition.c
@@ -176,7 +176,7 @@ const esp_partition_t *esp_partition_find_first(esp_partition_type_t type, esp_p
 
 static esp_partition_iterator_opaque_t *iterator_create(esp_partition_type_t type, esp_partition_subtype_t subtype, const char *label)
 {
-	esp_partition_iterator_opaque_t *it = (esp_partition_iterator_opaque_t *)malloc(sizeof(esp_partition_iterator_opaque_t));
+	esp_partition_iterator_opaque_t *it = (esp_partition_iterator_opaque_t *)kmm_malloc(sizeof(esp_partition_iterator_opaque_t));
 	it->type = type;
 	it->subtype = subtype;
 	it->label = label;
@@ -208,7 +208,7 @@ static esp_err_t load_partitions(void)
 			break;
 		}
 		// allocate new linked list item and populate it with data from partition table
-		partition_list_item_t *item = (partition_list_item_t *)malloc(sizeof(partition_list_item_t));
+		partition_list_item_t *item = (partition_list_item_t *)kmm_malloc(sizeof(partition_list_item_t));
 		item->info.address = it->pos.offset;
 		item->info.size = it->pos.size;
 		item->info.type = it->type;
@@ -243,7 +243,7 @@ void esp_partition_initialize(void)
 void esp_partition_iterator_release(esp_partition_iterator_t iterator)
 {
 	// iterator == NULL is okay
-	free(iterator);
+	kmm_free(iterator);
 }
 
 const esp_partition_t *esp_partition_get(esp_partition_iterator_t iterator)

--- a/os/board/esp32_devkit/src/esp32_lcd.c
+++ b/os/board/esp32_devkit/src/esp32_lcd.c
@@ -111,9 +111,9 @@
 #define SWAPBYTES(i) ((i >> 8) | (i << 8))
 //when enabling spiram and use 80M VSPI, it's conflict to use spiram for LCD transmit buffer
 #if CONFIG_KMM_NHEAPS > 1
-#define LCD_MALLOC(size) malloc_at(0, (size))
+#define LCD_MALLOC(size) kmm_malloc_at(0, (size))
 #else
-#define LCD_MALLOC(size) malloc(size)
+#define LCD_MALLOC(size) kmm_malloc(size)
 #endif
 
 /****************************************************************************
@@ -440,7 +440,7 @@ static int esp32_ili9341_sendgram(FAR struct ili9341_lcd_s *lcd, const uint16_t 
 			trans_word -= dmasize;
 			buffidx += dmasize;
 		}
-		free(data_buf);
+		kmm_free(data_buf);
 		data_buf = NULL;
 	} else {
 		for (i = 0; i < nwords; i++) {

--- a/os/board/esp32_devkit/src/heap_caps.c
+++ b/os/board/esp32_devkit/src/heap_caps.c
@@ -34,6 +34,7 @@
 #include <assert.h>
 #include <stdio.h>
 #include <tinyara/mm/mm.h>
+#include <tinyara/kmalloc.h>
 
 #include "esp_attr.h"
 #include "esp_heap_caps.h"
@@ -69,7 +70,7 @@ IRAM_ATTR void *heap_caps_malloc(size_t size, uint32_t caps)
 		index = 0;
 	}
 
-	return malloc_at(index, size);;
+	return kmm_malloc_at(index, size);;
 }
 
 IRAM_ATTR void heap_caps_free(void *ptr)
@@ -78,7 +79,7 @@ IRAM_ATTR void heap_caps_free(void *ptr)
 		return;
 	}
 
-	free(ptr);
+	kmm_free(ptr);
 }
 
 IRAM_ATTR void *heap_caps_realloc(void *ptr, size_t size, int caps)
@@ -92,7 +93,7 @@ IRAM_ATTR void *heap_caps_realloc(void *ptr, size_t size, int caps)
 		return NULL;
 	}
 
-	return realloc(ptr, size);
+	return kmm_realloc(ptr, size);
 }
 
 IRAM_ATTR void *heap_caps_calloc(size_t n, size_t size, uint32_t caps)

--- a/os/crypto/blake2s.c
+++ b/os/crypto/blake2s.c
@@ -70,6 +70,7 @@
 #include <errno.h>
 
 #include <tinyara/crypto/blake2s.h>
+#include <tinyara/kmalloc.h>
 
 /****************************************************************************
  * Pre-processor Definitions
@@ -323,7 +324,7 @@ static int blake2s_selftest(void)
 	blake2s_state ctx;
 	int ret = -1;
 
-	in = malloc(1024);
+	in = kmm_malloc(1024);
 	if (!in) {
 		goto out;
 	}
@@ -361,7 +362,7 @@ static int blake2s_selftest(void)
 	ret = 0;
 
 out:
-	free(in);
+	kmm_free(in);
 	return ret;
 }
 #endif

--- a/os/drivers/lcd/lcd_framebuffer.c
+++ b/os/drivers/lcd/lcd_framebuffer.c
@@ -252,7 +252,7 @@ static int lcdfb_update(FAR struct lcdfb_dev_s *priv,
 			bytespl = (width * pinfo->bpp + 7) >> 3;
 			height = endy - starty + 1;
 			
-			dmabuff = (uint8_t *)malloc(height * bytespl);
+			dmabuff = (uint8_t *)kmm_malloc(height * bytespl);
 			if (dmabuff == NULL) {
 				gdbg("ERROR: out of memory \n");
 				return -ENOMEM;
@@ -280,7 +280,7 @@ static int lcdfb_update(FAR struct lcdfb_dev_s *priv,
 			}
 
 			ret = pinfo->putdma(starty, startx, endy, endx, dmabuff);
-			free(dmabuff);
+			kmm_free(dmabuff);
 		}
 
 		if (ret < 0) {
@@ -608,7 +608,7 @@ int up_fbinitialize(int display)
 	priv->stride = ((size_t)priv->xres * priv->pinfo.bpp + 7) >> 3;
 	priv->fblen  = priv->stride * priv->yres;
 
-	priv->fbmem  = (FAR uint8_t *)zalloc(priv->fblen);
+	priv->fbmem  = (FAR uint8_t *)kmm_zalloc(priv->fblen);
 	if (priv->fbmem == NULL) {
 		gdbg("ERROR: Failed to allocate frame buffer memory\n");
 		ret = -ENOMEM;

--- a/os/drivers/testcase/test_compress_decompress.c
+++ b/os/drivers/testcase/test_compress_decompress.c
@@ -26,6 +26,7 @@
 #include <string.h>
 #include <tinyara/testcase_drv.h>
 #include <tinyara/binfmt/compression/compress_read.h>
+#include <tinyara/kmalloc.h>
 #include <debug.h>
 #include <errno.h>
 #include <fcntl.h>
@@ -70,7 +71,7 @@ static int test_compress_decompress_function(unsigned long arg)
 
 	compression_header = get_compression_header();
 
-	dst_buffer = (uint8_t *)malloc(2048 * sizeof(uint8_t));
+	dst_buffer = (uint8_t *)kmm_malloc(2048 * sizeof(uint8_t));
 
 	if (dst_buffer == NULL) {
 		berr("Allocation of memory failed\n");
@@ -87,7 +88,7 @@ static int test_compress_decompress_function(unsigned long arg)
 	}
 
 	compress_uninit();
-	free(dst_buffer);
+	kmm_free(dst_buffer);
 
 	return OK;
 }

--- a/os/logm/logm_process.c
+++ b/os/logm/logm_process.c
@@ -23,6 +23,7 @@
 #include <arch/irq.h>
 #include <tinyara/logm.h>
 #include <tinyara/config.h>
+#include <tinyara/kmalloc.h>
 #include "logm.h"
 #ifdef CONFIG_LOGM_TEST
 #include "logm_test.h"
@@ -42,7 +43,7 @@ static int logm_change_bufsize(int buflen)
 	}
 
 	/* Realloc new buffer with new length */
-	char *new_g_logm_rsvbuf = (char *)realloc(g_logm_rsvbuf, buflen);
+	char *new_g_logm_rsvbuf = (char *)kmm_realloc(g_logm_rsvbuf, buflen);
 	if (new_g_logm_rsvbuf == NULL) {
 		wdbg("Realloc Fail\n");
 		return ERROR;
@@ -66,7 +67,7 @@ int logm_task(int argc, char *argv[])
 {
 	irqstate_t flags;
 
-	g_logm_rsvbuf = (char *)malloc(logm_bufsize);
+	g_logm_rsvbuf = (char *)kmm_malloc(logm_bufsize);
 	memset(g_logm_rsvbuf, 0, logm_bufsize);
 
 	/* Now logm is ready */
@@ -98,5 +99,7 @@ int logm_task(int argc, char *argv[])
 		}
 		usleep(logm_print_interval);
 	}
+
+	kmm_free(g_logm_rsvbuf);
 	return 0;					// Just to make compiler happy
 }


### PR DESCRIPTION
Kernel modules should allocate the memory in kernel space for internal usages.
Let's use kmm APIs instead of memory allocation APIs for user.
This commit includes the change in arch, board, crypto, drivers and logm.

Signed-off-by: sunghan-chang <sh924.chang@samsung.com>