### PR TITLE
system/utils/README: add missing closing code block syntax (```) for …

### DIFF
--- a/apps/system/utils/README.md
+++ b/apps/system/utils/README.md
@@ -334,7 +334,7 @@ Kernel Features -> Disable TinyAra interfaces -> [ ] Disable environment variabl
 - Set a value which is greater than zero on CONFIG_NFILE_DESCRIPTORS.
 ```
 Kernel Features -> Files and I/O -> Maximum number of file descriptors per task
-
+```
 
 ## free
 This command shows heap information.


### PR DESCRIPTION
…echo

In markdown, code block syntax requires two of "\```"s for opening and closing.
But commit 0576fa6 missed closing for description of echo part.
This commit fixes wrong usages of ```.

Signed-off-by: sunghan-chang <sh924.chang@samsung.com>