### PR TITLE
arch/arm/src/armv7-m: Add support for clean & invalidate api for a specific region of dcache

### DIFF
--- a/os/arch/arm/src/armv7-m/arch_clean_dcache_by_range_to_poc.c
+++ b/os/arch/arm/src/armv7-m/arch_clean_dcache_by_range_to_poc.c
@@ -1,0 +1,113 @@
+/****************************************************************************
+ *
+ * Copyright 2020 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+/****************************************************************************
+ * os/arch/arm/src/armv7-m/arch_clean_dcache_by_range_to_poc.c
+ *
+ *   Copyright (C) 2015 Gregory Nutt. All rights reserved.
+ *   Author: Gregory Nutt <gnutt@nuttx.org>
+ *
+ * Some logic in this header file derives from the ARM CMSIS core_cm7.h
+ * header file which has a compatible 3-clause BSD license:
+ *
+ *   Copyright (c) 2009 - 2014 ARM LIMITED.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name ARM, TinyARA nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <tinyara/config.h>
+
+#include "cache.h"
+
+#if defined(CONFIG_ARMV7M_DCACHE) && !defined(CONFIG_ARMV7M_DCACHE_WRITETHROUGH)
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: arch_clean_dcache_by_range_to_poc
+ *
+ * Description:
+ *   Clean data cache within the specified region region by flushing the
+ *   contents of data cache to memory.
+ *
+ * Input Parameters:
+ *   start - virtual start address of region
+ *   end   - virtual end address of region + 1
+ *
+ * Returned Value:
+ *   None
+ *
+ * Assumptions:
+ *   This operation is not atomic.  This function assumes that the caller
+ *   has exclusive access to the address range so that no harm is done if
+ *   the operation is pre-empted.
+ *
+ ****************************************************************************/
+void arch_clean_dcache_by_range_to_poc(uintptr_t start, uintptr_t end)
+{
+	uint32_t ccsidr = getreg32(NVIC_CCSIDR);
+	uint32_t sshift = CCSIDR_LSSHIFT(ccsidr) + 4; /* log2(cache-line-size-in-bytes) */
+	uint32_t ssize = (1 << sshift);				  /* in Cortex-M7 size of cache line is fixed to 8 words (32 bytes) */
+
+	start &= ~(ssize - 1);
+	ARM_DSB();
+
+	do {
+		putreg32(start, NVIC_DCCMVAC);
+		start += ssize;
+	} while (start < end);
+
+	ARM_DSB();
+	ARM_ISB();
+}
+
+#endif

--- a/os/arch/arm/src/armv7-m/arch_clean_invalidate_dcache_by_range_to_poc.c
+++ b/os/arch/arm/src/armv7-m/arch_clean_invalidate_dcache_by_range_to_poc.c
@@ -1,0 +1,115 @@
+/****************************************************************************
+ *
+ * Copyright 2020 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+/****************************************************************************
+ * os/arch/arm/src/armv7-m/arch_clean_invalidate_dcache_by_range_to_poc.c
+ *
+ *   Copyright (C) 2015 Gregory Nutt. All rights reserved.
+ *   Author: Gregory Nutt <gnutt@nuttx.org>
+ *
+ * Some logic in this header file derives from the ARM CMSIS core_cm7.h
+ * header file which has a compatible 3-clause BSD license:
+ *
+ *   Copyright (c) 2009 - 2014 ARM LIMITED.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name ARM, TinyARA nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <tinyara/config.h>
+
+#include "cache.h"
+
+#if defined(CONFIG_ARMV7M_DCACHE) && !defined(CONFIG_ARMV7M_DCACHE_WRITETHROUGH)
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: arch_clean_invalidate_dcache_by_range_to_poc
+ *
+ * Description:
+ *   Invalidate the data cache within the specified region; we will be
+ *   performing a DMA operation in this region and we want to purge old data
+ *   in the cache.
+ *
+ * Input Parameters:
+ *   start - virtual start address of region
+ *   end   - virtual end address of region + 1
+ *
+ * Returned Value:
+ *   None
+ *
+ * Assumptions:
+ *   This operation is not atomic.  This function assumes that the caller
+ *   has exclusive access to the address range so that no harm is done if
+ *   the operation is pre-empted.
+ *
+ ****************************************************************************/
+void arch_clean_invalidate_dcache_by_range_to_poc(uintptr_t start, uintptr_t end)	//JS
+{
+	uint32_t ccsidr = getreg32(NVIC_CCSIDR);
+	uint32_t sshift = CCSIDR_LSSHIFT(ccsidr) + 4; /* log2(cache-line-size-in-bytes) */
+	uint32_t ssize = (1 << sshift);				  /* in Cortex-M7 size of cache line is fixed to 8 words (32 bytes) */
+
+	start &= ~(ssize - 1);
+	ARM_DSB();
+
+	do {
+		putreg32(start, NVIC_DCCIMVAC);
+		start += ssize;
+	} while (start < end);
+
+	ARM_DSB();
+	ARM_ISB();
+}
+
+#endif							/* CONFIG_ARMV7M_DCACHE */

--- a/os/arch/arm/src/armv7-m/cache.h
+++ b/os/arch/arm/src/armv7-m/cache.h
@@ -340,7 +340,7 @@ void arch_disable_dcache(void);
 #ifdef CONFIG_ARMV7M_DCACHE
 void arch_invalidate_dcache(uintptr_t start, uintptr_t end);
 #else
-#define arch_invalidate_dcache(s,e)
+#define arch_invalidate_dcache(s, e)
 #endif
 
 /****************************************************************************
@@ -390,7 +390,7 @@ void arch_invalidate_dcache_all(void);
 #if defined(CONFIG_ARMV7M_DCACHE) && !defined(CONFIG_ARMV7M_DCACHE_WRITETHROUGH)
 void arch_clean_dcache(uintptr_t start, uintptr_t end);
 #else
-#define arch_clean_dcache(s,e)
+#define arch_clean_dcache(s, e)
 #endif
 
 /****************************************************************************
@@ -448,12 +448,12 @@ void arch_clean_dcache_all(void);
 
 #ifdef CONFIG_ARMV7M_DCACHE
 #ifdef CONFIG_ARMV7M_DCACHE_WRITETHROUGH
-#define arch_flush_dcache(s,e) arch_invalidate_dcache(s,e)
+#define arch_flush_dcache(s, e) arch_invalidate_dcache(s, e)
 #else
 void arch_flush_dcache(uintptr_t start, uintptr_t end);
 #endif
 #else
-#define arch_flush_dcache(s,e)
+#define arch_flush_dcache(s, e)
 #endif
 
 /****************************************************************************
@@ -486,6 +486,24 @@ void arch_flush_dcache_all(void);
 #endif
 #else
 #define arch_flush_dcache_all()
+#endif
+
+#if defined(CONFIG_ARMV7M_DCACHE)
+
+#ifdef CONFIG_ARMV7M_DCACHE_WRITETHROUGH
+	#define arch_clean_invalidate_dcache_by_range_to_poc(s, e) arch_invalidate_dcache(s, e)
+#else
+	void arch_clean_invalidate_dcache_by_range_to_poc(uintptr_t start, uintptr_t end);
+#endif
+
+#else
+	#define arch_clean_invalidate_dcache_by_range_to_poc(s, e)
+#endif
+
+#if defined(CONFIG_ARMV7M_DCACHE) && !defined(CONFIG_ARMV7M_DCACHE_WRITETHROUGH)
+	void arch_clean_dcache_by_range_to_poc(uintptr_t start, uintptr_t end);
+#else
+	#define arch_clean_dcache_by_range_to_poc(s, e)
 #endif
 
 #undef EXTERN


### PR DESCRIPTION
-IMXRT USB Host driver requires to flush and invalid the dcache specific region, added
two api to handle this requirement as currently this is not supported.

This requirement is from NXP to support USB Host driver, and is part of the release from NXP
