### PR TITLE
userspace: move including <tinyara/arch.h> to up_usersapce.c from use…

### DIFF
--- a/os/include/tinyara/userspace.h
+++ b/os/include/tinyara/userspace.h
@@ -63,8 +63,6 @@
 #include <signal.h>
 #include <pthread.h>
 
-#include <tinyara/arch.h>
-
 #ifdef CONFIG_BUILD_PROTECTED
 
 /****************************************************************************

--- a/os/userspace/up_userspace.c
+++ b/os/userspace/up_userspace.c
@@ -40,6 +40,7 @@
 #include <tinyara/config.h>
 #include <tinyara/userspace.h>
 #include <tinyara/init.h>
+#include <tinyara/arch.h>
 
 #if defined(CONFIG_BUILD_PROTECTED) && !defined(__KERNEL__)
 


### PR DESCRIPTION
…rspace.h

The up_userspace.c file needs <tinyara/arch.h> for up_signal_handler,
the userspace.h does not.
Let's move including the header from userspace.h to up_userspace.c.
It could also resolves recursive including.

Signed-off-by: sunghan-chang <sh924.chang@samsung.com>