### PR TITLE
fix typo, the the, becasue, the life the task

### DIFF
--- a/apps/examples/i2schar/Kconfig
+++ b/apps/examples/i2schar/Kconfig
@@ -81,7 +81,7 @@ config EXAMPLES_I2SCHAR_DEVINIT
 	depends on !BUILD_PROTECTED && !BUILD_KERNEL
 	---help---
 		Define if architecture-specific I2S device initialize is available.
-		If defined, the the platform specific code must provide a function
+		If defined, the platform specific code must provide a function
 		i2schar_devinit() that will be called each time that this test
 		executes.  Not available in the kernel build mode.
 

--- a/apps/examples/kernel_sample/mqueue.c
+++ b/apps/examples/kernel_sample/mqueue.c
@@ -387,7 +387,7 @@ void mqueue_test(void)
 		printf("             ERROR Instead exited with nerrors=%d\n", (int)result);
 	}
 
-	/* Message queues are global resources and persist for the life the the
+	/* Message queues are global resources and persist for the life of the
 	 * task group.  The message queue opened by the sender_thread must be closed
 	 * since the sender pthread may have been canceled and may have left the
 	 * message queue open.

--- a/apps/examples/testcase/le_tc/kernel/tc_memory_safety.c
+++ b/apps/examples/testcase/le_tc/kernel/tc_memory_safety.c
@@ -374,7 +374,7 @@ static void tc_memory_safety_with_mqueue(void)
 	pthread_join(receiver, &result);
 	TC_ASSERT_EQ("pthread_join", result, expected);
 
-	/* Message queues are global resources and persist for the life the the
+	/* Message queues are global resources and persist for the life of the
 	 * task group.  The message queue opened by the sender_thread must be closed
 	 * since the sender pthread may have been canceled and may have left the
 	 * message queue open.

--- a/apps/examples/testcase/le_tc/kernel/tc_mqueue.c
+++ b/apps/examples/testcase/le_tc/kernel/tc_mqueue.c
@@ -643,7 +643,7 @@ static void tc_mqueue_mq_open_close_send_receive(void)
 	pthread_join(receiver, &result);
 	TC_ASSERT_EQ("pthread_join", result, expected);
 
-	/* Message queues are global resources and persist for the life the the
+	/* Message queues are global resources and persist for the life of the
 	 * task group.  The message queue opened by the sender_thread must be closed
 	 * since the sender pthread may have been canceled and may have left the
 	 * message queue open.

--- a/apps/system/inifile/inifile.c
+++ b/apps/system/inifile/inifile.c
@@ -422,7 +422,7 @@ static FAR char *inifile_find_section_variable(FAR struct inifile_state_s *priv,
 
 		inivdbg("varinfo.variable=\"%s\"\n", varinfo.variable);
 
-		/* Does the the variable name match the one we are looking for? */
+		/* Does the variable name match the one we are looking for? */
 
 		if (strcasecmp(varinfo.variable, variable) == 0) {
 			/* Yes... then we have it! */

--- a/apps/system/utils/Kconfig
+++ b/apps/system/utils/Kconfig
@@ -67,7 +67,7 @@ config CPULOADMONITOR_PRIORITY
 	int "CPU load monitor daemon priority"
 	default 100
 	---help---
-		The priority to use the the CPU load monitor daemon.  Default: 100
+		The priority to use the CPU load monitor daemon.  Default: 100
 
 config CPULOADMONITOR_INTERVAL
 	int "CPU load monitor frequency"
@@ -198,7 +198,7 @@ config STACKMONITOR_PRIORITY
 	int "Stack monitor daemon priority"
 	default 100
 	---help---
-		The priority to use the the stack monitor daemon.  Default: 100
+		The priority to use the stack monitor daemon.  Default: 100
 
 config STACKMONITOR_INTERVAL
 	int "Stack monitor dump frequency"

--- a/apps/system/utils/utils_stackmonitor.c
+++ b/apps/system/utils/utils_stackmonitor.c
@@ -288,7 +288,7 @@ static void stackmonitor_stop(void)
 
 	if (stkmon_started) {
 		/* Stop the stack monitor.  The next time the monitor wakes up,
-		 * it will see the the stop indication and will exist.
+		 * it will see the stop indication and will exist.
 		 */
 		printf(STKMON_PREFIX "Stopping, not stopped yet\n");
 		stkmon_started = FALSE;

--- a/apps/system/vi/vi.c
+++ b/apps/system/vi/vi.c
@@ -1462,7 +1462,7 @@ static void vi_scrollcheck(FAR struct vi_s *vi)
 		vi->hscroll -= TABSIZE;
 	}
 
-	/* If the the cursor column lies to the right of the display, then adjust
+	/* If the cursor column lies to the right of the display, then adjust
 	 * the horizontal scrolling position so that the cursor position does
 	 * lie on the display.
 	 */
@@ -2010,7 +2010,7 @@ static void vi_paste(FAR struct vi_s *vi)
  * Name: vi_gotoline
  *
  * Description:
- *   Position the the cursor at the line specified by vi->value.  If
+ *   Position the cursor at the line specified by vi->value.  If
  *   vi->value is zero, then the cursor is position at the end of the text
  *   buffer.
  *
@@ -2752,7 +2752,7 @@ static int vi_cmd_submode(FAR struct vi_s *vi)
  * Name: vi_findstring
  *
  * Description:
- *   Find the the string in the findstr buffer by searching for a matching
+ *   Find the string in the findstr buffer by searching for a matching
  *   sub-string in the text buffer, starting at the current cursor position.
  *
  ****************************************************************************/

--- a/build/configs/sidk_s5jt200/tools/openocd/scripts/board/at91sam9g20-ek.cfg
+++ b/build/configs/sidk_s5jt200/tools/openocd/scripts/board/at91sam9g20-ek.cfg
@@ -47,7 +47,7 @@ proc read_register {register} {
 
 proc at91sam9g20_reset_start { } {
 
-	# Make sure that the the jtag is running slow, since there are a number of different ways the board
+	# Make sure that the jtag is running slow, since there are a number of different ways the board
 	# can be configured coming into this state that can cause communication problems with the jtag
 	# adapter.  Also since this call can be made following a "reset init" where fast memory accesses
 	# are enabled, need to temporarily shut this down so that the RSTC_MR register can be written at slower
@@ -206,7 +206,7 @@ proc at91sam9g20_reset_init { } {
 	mww 0xffffea00 0x3
 	mww 0x20000000 0
 
-	# Signal normal mode using the SDRAMC_MR register and follow with a zero value write the the starting
+	# Signal normal mode using the SDRAMC_MR register and follow with a zero value write the starting
 	# memory location for the SDRAM.
 
 	mww 0xffffea00 0x0

--- a/build/configs/sidk_s5jt200/tools/openocd/scripts/board/icnova_sam9g45_sodimm.cfg
+++ b/build/configs/sidk_s5jt200/tools/openocd/scripts/board/icnova_sam9g45_sodimm.cfg
@@ -50,7 +50,7 @@ proc read_register {register} {
 
 proc at91sam9g45_start { } {
 
-	# Make sure that the the jtag is running slow, since there are a number of different ways the board
+	# Make sure that the jtag is running slow, since there are a number of different ways the board
 	# can be configured coming into this state that can cause communication problems with the jtag
 	# adapter.  Also since this call can be made following a "reset init" where fast memory accesses
 	# are enabled, need to temporarily shut this down so that the RSTC_MR register can be written at slower

--- a/build/configs/sidk_s5jt200/tools/openocd/scripts/target/icepick.cfg
+++ b/build/configs/sidk_s5jt200/tools/openocd/scripts/target/icepick.cfg
@@ -4,7 +4,7 @@
 #
 
 # Utilities for TI ICEpick-C/D used in most TI SoCs
-# Details about the ICEPick are available in the the TRM for each SoC
+# Details about the ICEPick are available in the TRM for each SoC
 # and http://processors.wiki.ti.com/index.php/ICEPICK
 
 # create "constants"

--- a/docs/TinyAra_Config_Variables.html
+++ b/docs/TinyAra_Config_Variables.html
@@ -12313,7 +12313,7 @@ expected, however.
 </li>
   <li><i>Kconfig file</i>: <code>./arch/arm/src/stm32/Kconfig</code>
 <p>
-  If you are using the the LTDC, then you must provide the address  of the start of the framebuffer.  This address will typically  be in the SRAM or SDRAM memory region of the FSMC.</p>
+  If you are using the LTDC, then you must provide the address  of the start of the framebuffer.  This address will typically  be in the SRAM or SDRAM memory region of the FSMC.</p>
 </ul>
 <h3><a name="CONFIG_STM32_LTDC_FB_SIZE">1.2.156.10 <code>CONFIG_STM32_LTDC_FB_SIZE</code>: Framebuffer memory size (bytes)</a></h3>
 <ul>
@@ -15427,7 +15427,7 @@ int up_prioritize_irq(int irq, int priority)
 <p>
   NOTE: ARCH_INTERRUPTSTACK must be set in kernel mode (BUILD_KERNEL).  In kernel mode without an interrupt stack, the interrupt handler  will set the MSP to the stack pointer of the interrupted thread.  If  the interrupted thread was a privileged thread, that will be the MSP  otherwise it will be the PSP.  If the PSP is used, then the value of  the MSP will be invalid when the interrupt handler returns because  it will be a pointer to an old position in the unprivileged stack.  Then when the high priority interrupt occurs and uses this stale MSP,  there will most likely be a system failure.</p>
 <p>
-  If the interrupt stack is selected, on the other hand, then the  interrupt handler will always set the the MSP to the interrupt  stack.  So when the high priority interrupt occurs, it will either  use the MSP of the last privileged thread to run or, in the case of  the nested interrupt, the interrupt stack if no privileged task has  run</p>
+  If the interrupt stack is selected, on the other hand, then the  interrupt handler will always set the MSP to the interrupt  stack.  So when the high priority interrupt occurs, it will either  use the MSP of the last privileged thread to run or, in the case of  the nested interrupt, the interrupt stack if no privileged task has  run</p>
 </ul>
 <h3><a name="CONFIG_ARCH_INT_DISABLEALL">1.2.242 <code>CONFIG_ARCH_INT_DISABLEALL</code>: Disable high priority interrupts</a></h3>
 <ul>
@@ -17420,9 +17420,9 @@ int up_prioritize_irq(int irq, int priority)
   </li>
   <li><i>Kconfig file</i>: <code>./kernel/Kconfig</code>
 <p>
-  In the &quot;normal&quot; configuration where system time is provided by a  periodic timer interrupt, the default system timer is expected to  run at 100Hz or USEC_PER_TICK=10000.  This setting must be defined  to inform of TinyAra the interval that the the processor hardware is  providing system timer interrupts to the OS.</p>
+  In the &quot;normal&quot; configuration where system time is provided by a  periodic timer interrupt, the default system timer is expected to  run at 100Hz or USEC_PER_TICK=10000.  This setting must be defined  to inform of TinyAra the interval that the processor hardware is  providing system timer interrupts to the OS.</p>
 <p>
-  If SCHED_TICKLESS is selected, then there are no system timer  interrupts.  In this case, USEC_PER_TICK does not control any timer  rates.  Rather, it only determines the resolution of time reported  by clock_systimer() and the resolution of times that can be set for  certain delays including watchdog timers and delayed work.  In this  case there is a trade-off:  It is better to have the USEC_PER_TICK as  low as possible for higher timing resolution.  However, the the time  is currently held in &apos;unsigned int&apos; on some systems, this may be  16-bits but on most contemporary systems it will be 32-bits.  In  either case, smaller values of USEC_PER_TICK will reduce the range  of values that delays that can be represented.  So the trade-off is  between range and resolution (you could also modify the code to use  a 64-bit value if you really want both).</p>
+  If SCHED_TICKLESS is selected, then there are no system timer  interrupts.  In this case, USEC_PER_TICK does not control any timer  rates.  Rather, it only determines the resolution of time reported  by clock_systimer() and the resolution of times that can be set for  certain delays including watchdog timers and delayed work.  In this  case there is a trade-off:  It is better to have the USEC_PER_TICK as  low as possible for higher timing resolution.  However, the time  is currently held in &apos;unsigned int&apos; on some systems, this may be  16-bits but on most contemporary systems it will be 32-bits.  In  either case, smaller values of USEC_PER_TICK will reduce the range  of values that delays that can be represented.  So the trade-off is  between range and resolution (you could also modify the code to use  a 64-bit value if you really want both).</p>
 <p>
   The default, 100 microseconds, will provide for a range of delays  up to 120 hours.</p>
 <p>
@@ -37301,7 +37301,7 @@ sizeof(FAR void *) == sizeof(unsigned long));
 </li>
   <li><i>Kconfig file</i>: <code>/home/sunghan/Work/TinyAra/Forked_TizenRT/apps/examples/i2schar/Kconfig</code>
 <p>
-  Define if architecture-specific I2S device initialize is available.  If defined, the the platform specific code must provide a function  i2schar_devinit() that will be called each time that this test  executes.  Not available in the kernel build mode.</p>
+  Define if architecture-specific I2S device initialize is available.  If defined, the platform specific code must provide a function  i2schar_devinit() that will be called each time that this test  executes.  Not available in the kernel build mode.</p>
 </ul>
 <h3><a name="CONFIG_EXAMPLES_IOTBUS_TEST">1.18.4.55 <code>CONFIG_EXAMPLES_IOTBUS_TEST</code>: Iotbus example</a></h3>
 <ul>
@@ -41488,7 +41488,7 @@ RAMMTD_ERASESIZE * EXAMPLES_SMART_NEBLOCKS
   <li><i>Dependencies</i>: <a href="#CONFIG_ENABLE_CPULOAD_MONITOR"><code>CONFIG_ENABLE_CPULOAD_MONITOR</code></a></li>
   <li><i>Kconfig file</i>: <code>/home/sunghan/Work/TinyAra/Forked_TizenRT/apps/system/utils/Kconfig</code>
 <p>
-  The priority to use the the CPU load monitor daemon.  Default: 100</p>
+  The priority to use the CPU load monitor daemon.  Default: 100</p>
 </ul>
 <h3><a name="CONFIG_CPULOADMONITOR_INTERVAL">1.18.7.47 <code>CONFIG_CPULOADMONITOR_INTERVAL</code>: CPU load monitor frequency</a></h3>
 <ul>
@@ -41665,7 +41665,7 @@ RAMMTD_ERASESIZE * EXAMPLES_SMART_NEBLOCKS
   <li><i>Dependencies</i>: <a href="#CONFIG_ENABLE_STACKMONITOR_CMD"><code>CONFIG_ENABLE_STACKMONITOR_CMD</code></a></li>
   <li><i>Kconfig file</i>: <code>/home/sunghan/Work/TinyAra/Forked_TizenRT/apps/system/utils/Kconfig</code>
 <p>
-  The priority to use the the stack monitor daemon.  Default: 100</p>
+  The priority to use the stack monitor daemon.  Default: 100</p>
 </ul>
 <h3><a name="CONFIG_STACKMONITOR_INTERVAL">1.18.7.63 <code>CONFIG_STACKMONITOR_INTERVAL</code>: Stack monitor dump frequency</a></h3>
 <ul>

--- a/framework/include/binary_manager/binary_manager.h
+++ b/framework/include/binary_manager/binary_manager.h
@@ -84,7 +84,7 @@ binmgr_result_type_e binary_manager_get_update_info_all(binary_update_info_list_
 binmgr_result_type_e binary_manager_notify_binary_started(void);
 
 /**
- * @brief Set the callback which will be called when the the states of binaries are changed
+ * @brief Set the callback which will be called when the states of binaries are changed
  * @details @b #include <binary_manager/binary_manager.h>\n
  *  It sets callback for the changes of binary state.
  * @return A defined value of binmgr_result_type_e in <tinyara/binary_manager.h>

--- a/framework/include/bluetooth/bluetooth.h
+++ b/framework/include/bluetooth/bluetooth.h
@@ -1318,7 +1318,7 @@ int bt_adapter_le_add_advertising_service_data(bt_advertiser_h advertiser,
 /**
  * @ingroup CAPI_NETWORK_BLUETOOTH_ADAPTER_LE_MODULE
  * @brief Sets the external appearance of this device to advertise or scan response data.
- *        Please refer to the adopted Bluetooth specification for the the appearance.
+ *        Please refer to the adopted Bluetooth specification for the appearance.
  * @since_tizen 2.3.1
  *
  * @param[in] advertiser The handle of advertiser
@@ -3516,7 +3516,7 @@ int bt_avrcp_control_set_equalizer_state(bt_avrcp_equalizer_state_e state);
 
 /**
  * @ingroup CAPI_NETWORK_BLUETOOTH_AVRCP_CONTROL_MODULE
- * @brief  Gets the the equalizer state of the remote device.
+ * @brief  Gets the equalizer state of the remote device.
  * @since_tizen 3.0
  * @param[out] state The equalizer state, one of: ON, OFF
  * @return  0 on success, otherwise a negative error value.

--- a/lib/libc/locale/lib_localeconv.c
+++ b/lib/libc/locale/lib_localeconv.c
@@ -79,7 +79,7 @@
 
 FAR struct lconv *localeconv(void)
 {
-	/* NULL indicates the the locale was not changed */
+	/* NULL indicates the locale was not changed */
 
 	return NULL;
 }

--- a/os/arch/Kconfig
+++ b/os/arch/Kconfig
@@ -673,7 +673,7 @@ config ARCH_HIPRI_INTERRUPT
 		there will most likely be a system failure.
 
 		If the interrupt stack is selected, on the other hand, then the
-		interrupt handler will always set the the MSP to the interrupt
+		interrupt handler will always set the MSP to the interrupt
 		stack.  So when the high priority interrupt occurs, it will either
 		use the MSP of the last privileged thread to run or, in the case of
 		the nested interrupt, the interrupt stack if no privileged task has

--- a/os/arch/arm/include/stm32/ltdc.h
+++ b/os/arch/arm/include/stm32/ltdc.h
@@ -412,7 +412,7 @@ struct ltdc_layer_s {
 	 *   On error - -EINVAL
 	 *
 	 * Procedure Information:
-	 *   If the srcxpos and srcypos unequal the the xpos and ypos of the coord
+	 *   If the srcxpos and srcypos unequal the xpos and ypos of the coord
 	 *   structure this acts like moving the visible area to another position on
 	 *   the screen during the next update operation.
 	 *

--- a/os/arch/arm/include/stm32l4/ltdc.h
+++ b/os/arch/arm/include/stm32l4/ltdc.h
@@ -412,7 +412,7 @@ struct ltdc_layer_s {
 	 *   On error - -EINVAL
 	 *
 	 * Procedure Information:
-	 *   If the srcxpos and srcypos unequal the the xpos and ypos of the coord
+	 *   If the srcxpos and srcypos unequal the xpos and ypos of the coord
 	 *   structure this acts like moving the visible area to another position on
 	 *   the screen during the next update operation.
 	 *

--- a/os/arch/arm/src/armv7-m/up_exception.S
+++ b/os/arch/arm/src/armv7-m/up_exception.S
@@ -77,7 +77,7 @@
    * stale MSP, there will most likely be a system failure.
    *
    * If the interrupt stack is selected, on the other hand, then the interrupt
-   * handler will always set the the MSP to the interrupt stack.  So when the high
+   * handler will always set the MSP to the interrupt stack.  So when the high
    * priority interrupt occurs, it will either use the MSP of the last privileged
    * thread to run or, in the case of the nested interrupt, the interrupt stack if
    * no privileged task has run.
@@ -87,7 +87,7 @@
 #    error Interrupt stack must be used with high priority interrupts in kernel mode
 #  endif
 
-  /* Use the the BASEPRI to control interrupts is required if nested, high
+  /* Use the BASEPRI to control interrupts is required if nested, high
    * priority interrupts are supported.
    */
 

--- a/os/arch/arm/src/armv7-r/arm_gicv2.c
+++ b/os/arch/arm/src/armv7-r/arm_gicv2.c
@@ -317,7 +317,7 @@ void arm_gic_initialize(void)
 #endif
 
 #if !defined(CONFIG_ARCH_HAVE_TRUSTZONE)
-	/* Enable the distributor by setting the the Enable bit in the enable
+	/* Enable the distributor by setting the Enable bit in the enable
 	 * register (no security extensions).
 	 */
 

--- a/os/arch/arm/src/armv8-m/up_exception.S
+++ b/os/arch/arm/src/armv8-m/up_exception.S
@@ -77,7 +77,7 @@
    * stale MSP, there will most likely be a system failure.
    *
    * If the interrupt stack is selected, on the other hand, then the interrupt
-   * handler will always set the the MSP to the interrupt stack.  So when the high
+   * handler will always set the MSP to the interrupt stack.  So when the high
    * priority interrupt occurs, it will either use the MSP of the last privileged
    * thread to run or, in the case of the nested interrupt, the interrupt stack if
    * no privileged task has run.
@@ -87,7 +87,7 @@
 #    error Interrupt stack must be used with high priority interrupts in kernel mode
 #  endif
 
-  /* Use the the BASEPRI to control interrupts is required if nested, high
+  /* Use the BASEPRI to control interrupts is required if nested, high
    * priority interrupts are supported.
    */
 

--- a/os/arch/arm/src/imxrt/chip/imxrt102x_config.h
+++ b/os/arch/arm/src/imxrt/chip/imxrt102x_config.h
@@ -19484,7 +19484,7 @@ typedef struct {
 #define LPI2C_MCFGR0_RDMO_SHIFT                  (9U)
 /*! RDMO - Receive Data Match Only
  *  0b0..Received data is stored in the receive FIFO
- *  0b1..Received data is discarded unless the the Data Match Flag (MSR[DMF]) is set
+ *  0b1..Received data is discarded unless the Data Match Flag (MSR[DMF]) is set
  */
 #define LPI2C_MCFGR0_RDMO(x)                     (((uint32_t)(((uint32_t)(x)) << LPI2C_MCFGR0_RDMO_SHIFT)) & LPI2C_MCFGR0_RDMO_MASK)
 /*! @} */

--- a/os/arch/arm/src/imxrt/chip/imxrt105x_config.h
+++ b/os/arch/arm/src/imxrt/chip/imxrt105x_config.h
@@ -22705,7 +22705,7 @@ typedef struct {
 #define LPI2C_MCFGR0_RDMO_SHIFT                  (9U)
 /*! RDMO - Receive Data Match Only
  *  0b0..Received data is stored in the receive FIFO
- *  0b1..Received data is discarded unless the the Data Match Flag (MSR[DMF]) is set
+ *  0b1..Received data is discarded unless the Data Match Flag (MSR[DMF]) is set
  */
 #define LPI2C_MCFGR0_RDMO(x)                     (((uint32_t)(((uint32_t)(x)) << LPI2C_MCFGR0_RDMO_SHIFT)) & LPI2C_MCFGR0_RDMO_MASK)
 /*! @} */

--- a/os/arch/arm/src/imxrt/imxrt_hprtc.c
+++ b/os/arch/arm/src/imxrt/imxrt_hprtc.c
@@ -377,7 +377,7 @@ int imxrt_hprtc_initialize(void)
 {
 	uint32_t regval;
 
-	/* Enable clocking to the the SNVS HP module.
+	/* Enable clocking to the SNVS HP module.
 	 * Clock is on in run mode, but off in WAIT and STOP modes.
 	 */
 

--- a/os/arch/arm/src/imxrt/imxrt_i2s.c
+++ b/os/arch/arm/src/imxrt/imxrt_i2s.c
@@ -942,7 +942,7 @@ void i2s_tx_init(I2S_Type *base, const sai_config_t *config)
 }
 
 /*!
- * @brief Initializes the the SAI Rx peripheral.
+ * @brief Initializes the SAI Rx peripheral.
  *
  * Ungates the SAI clock, resets the module, and configures the SAI Rx with a configuration structure.
  * The configuration structure can be custom filled or set with default values by
@@ -1600,7 +1600,7 @@ void i2s_transfer_abortsend(I2S_Type *base, sai_handle_t *handle)
 }
 
 /*!
- * @brief Aborts the the current IRQ receive.
+ * @brief Aborts the current IRQ receive.
  *
  * @note This API can be called when an interrupt non-blocking transfer initiates
  * to abort the transfer early.

--- a/os/arch/arm/src/imxrt/imxrt_i2s_edma.c
+++ b/os/arch/arm/src/imxrt/imxrt_i2s_edma.c
@@ -1503,7 +1503,7 @@ void i2s_tx_init(I2S_Type *base, const sai_config_t *config)
 }
 
 /*!
- * @brief Initializes the the SAI Rx peripheral.
+ * @brief Initializes the SAI Rx peripheral.
  *
  * Ungates the SAI clock, resets the module, and configures the SAI Rx with a configuration structure.
  * The configuration structure can be custom filled or set with default values by

--- a/os/arch/arm/src/imxrt/imxrt_lpsrtc.c
+++ b/os/arch/arm/src/imxrt/imxrt_lpsrtc.c
@@ -143,7 +143,7 @@ int imxrt_lpsrtc_initialize(void)
 
 	imxrt_hprtc_initialize();
 
-	/* Enable clocking to the the SNVS LP module.
+	/* Enable clocking to the SNVS LP module.
 	 * Clock is on during all modes, except STOP mode.
 	 */
 

--- a/os/arch/arm/src/stm32/Kconfig
+++ b/os/arch/arm/src/stm32/Kconfig
@@ -3688,7 +3688,7 @@ config STM32_LTDC_DITHER_BLUE
 config STM32_LTDC_FB_BASE
 	hex "Framebuffer memory start address"
 	---help---
-		If you are using the the LTDC, then you must provide the address
+		If you are using the LTDC, then you must provide the address
 		of the start of the framebuffer.  This address will typically
 		be in the SRAM or SDRAM memory region of the FSMC.
 

--- a/os/arch/arm/src/stm32/stm32_dma.h
+++ b/os/arch/arm/src/stm32/stm32_dma.h
@@ -108,7 +108,7 @@
 typedef FAR void *DMA_HANDLE;
 
 /* Description:
- *   This is the type of the callback that is used to inform the user of the the
+ *   This is the type of the callback that is used to inform the user of the
  *   completion of the DMA.
  *
  * Input Parameters:

--- a/os/arch/arm/src/stm32/stm32_eth.c
+++ b/os/arch/arm/src/stm32/stm32_eth.c
@@ -1522,7 +1522,7 @@ static int stm32_recvframe(FAR struct stm32_ethmac_s *priv)
 		else {
 			priv->segments++;
 
-			/* Check if the there is only one segment in the frame */
+			/* Check if there is only one segment in the frame */
 
 			if (priv->segments == 1) {
 				rxcurr = rxdesc;

--- a/os/arch/arm/src/stm32/stm32_ltdc.c
+++ b/os/arch/arm/src/stm32/stm32_ltdc.c
@@ -2610,7 +2610,7 @@ static int stm32_getblendmode(FAR struct ltdc_layer_s *layer, uint32_t *mode)
  *   On error - -EINVAL
  *
  * Procedure Information:
- *   If the srcxpos and srcypos unequal the the xpos and ypos of the area
+ *   If the srcxpos and srcypos unequal the xpos and ypos of the area
  *   structure this acts like moving the visible area to another position on
  *   the screen during the next update operation.
  *

--- a/os/arch/arm/src/stm32/stm32_otgfshost.c
+++ b/os/arch/arm/src/stm32/stm32_otgfshost.c
@@ -2069,7 +2069,7 @@ static ssize_t stm32_out_transfer(FAR struct stm32_usbhost_s *priv, int chidx, F
 			/* Check for a special case:  If (1) the transfer was NAKed and (2)
 			 * no Tx FIFO empty or Rx FIFO not-empty event occurred, then we
 			 * should be able to just flush the Rx and Tx FIFOs and try again.
-			 * We can detect this latter case becasue the then the transfer
+			 * We can detect this latter case because then the transfer
 			 * buffer pointer and buffer size will be unaltered.
 			 */
 

--- a/os/arch/arm/src/stm32/stm32_otghshost.c
+++ b/os/arch/arm/src/stm32/stm32_otghshost.c
@@ -1422,7 +1422,7 @@ static int stm32_in_transfer(FAR struct stm32_usbhost_s *priv, int chidx, FAR ui
 			/* Check for a special case:  If (1) the transfer was NAKed and (2)
 			 * no Tx FIFO empty or Rx FIFO not-empty event occurred, then we
 			 * should be able to just flush the Rx and Tx FIFOs and try again.
-			 * We can detect this latter case becasue the then the transfer
+			 * We can detect this latter case because then the transfer
 			 * buffer pointer and buffer size will be unaltered.
 			 */
 
@@ -1542,7 +1542,7 @@ static int stm32_out_transfer(FAR struct stm32_usbhost_s *priv, int chidx, FAR u
 			/* Check for a special case:  If (1) the transfer was NAKed and (2)
 			 * no Tx FIFO empty or Rx FIFO not-empty event occurred, then we
 			 * should be able to just flush the Rx and Tx FIFOs and try again.
-			 * We can detect this latter case becasue the then the transfer
+			 * We can detect this latter case because then the transfer
 			 * buffer pointer and buffer size will be unaltered.
 			 */
 

--- a/os/arch/arm/src/stm32/stm32_vectors.S
+++ b/os/arch/arm/src/stm32/stm32_vectors.S
@@ -81,7 +81,7 @@
    * stale MSP, there will most likely be a system failure.
    *
    * If the interrupt stack is selected, on the other hand, then the interrupt
-   * handler will always set the the MSP to the interrupt stack.  So when the high
+   * handler will always set the MSP to the interrupt stack.  So when the high
    * priority interrupt occurs, it will either use the MSP of the last privileged
    * thread to run or, in the case of the nested interrupt, the interrupt stack if
    * no privileged task has run.
@@ -91,7 +91,7 @@
 #    error Interrupt stack must be used with high priority interrupts in kernel mode
 #  endif
 
-  /* Use the the BASEPRI to control interrupts is required if nested, high
+  /* Use the BASEPRI to control interrupts is required if nested, high
    * priority interrupts are supported.
    */
 

--- a/os/arch/arm/src/stm32l4/Kconfig
+++ b/os/arch/arm/src/stm32l4/Kconfig
@@ -4587,7 +4587,7 @@ config STM32L4_LTDC_DITHER_BLUE
 config STM32L4_LTDC_FB_BASE
 	hex "Framebuffer memory start address"
 	---help---
-		If you are using the the LTDC, then you must provide the address
+		If you are using the LTDC, then you must provide the address
 		of the start of the framebuffer.  This address will typically
 		be in the SRAM or SDRAM memory region of the FSMC.
 

--- a/os/arch/arm/src/stm32l4/hal/stm32l4xx_hal_tim.c
+++ b/os/arch/arm/src/stm32l4/hal/stm32l4xx_hal_tim.c
@@ -4464,7 +4464,7 @@ HAL_StatusTypeDef HAL_TIM_ConfigOCrefClear(TIM_HandleTypeDef *htim,
   {
     case TIM_CLEARINPUTSOURCE_NONE:
     {
-      /* Clear the OCREF clear selection bit and the the ETR Bits */
+      /* Clear the OCREF clear selection bit and the ETR Bits */
       CLEAR_BIT(htim->Instance->SMCR, (TIM_SMCR_OCCS | TIM_SMCR_ETF | TIM_SMCR_ETPS | TIM_SMCR_ECE | TIM_SMCR_ETP));
       break;
     }

--- a/os/arch/arm/src/stm32l4/hal/stm32l4xx_ll_usb.c
+++ b/os/arch/arm/src/stm32l4/hal/stm32l4xx_ll_usb.c
@@ -1856,7 +1856,7 @@ HAL_StatusTypeDef USB_DisableGlobalInt(USB_TypeDef *USBx)
   * @brief  USB_SetCurrentMode : Set functional mode
   * @param  USBx : Selected device
   * @param  mode :  current core mode
-  *          This parameter can be one of the these values:
+  *          This parameter can be one of these values:
   *            @arg USB_DEVICE_MODE: Peripheral mode mode
   * @retval HAL status
   */

--- a/os/arch/arm/src/stm32l4/stm32l4_ltdc.c
+++ b/os/arch/arm/src/stm32l4/stm32l4_ltdc.c
@@ -2613,7 +2613,7 @@ static int stm32_getblendmode(FAR struct ltdc_layer_s *layer, uint32_t *mode)
  *   On error - -EINVAL
  *
  * Procedure Information:
- *   If the srcxpos and srcypos unequal the the xpos and ypos of the area
+ *   If the srcxpos and srcypos unequal the xpos and ypos of the area
  *   structure this acts like moving the visible area to another position on
  *   the screen during the next update operation.
  *

--- a/os/arch/arm/src/tiva/tiva_i2c.c
+++ b/os/arch/arm/src/tiva/tiva_i2c.c
@@ -1316,7 +1316,7 @@ static int tiva_i2c_interrupt(struct tiva_i2c_priv_s *priv, uint32_t status)
 						if ((priv->msgv->flags & I2C_M_NORESTART) != 0) {
 							/* Just continue transferring data.  In this case,
 							 * no STOP was sent at the end of the last message
-							 * and the there is no new address.
+							 * and there is no new address.
 							 *
 							 * REVISIT: In this case, the address or the
 							 * direction of the transfer cannot be permitted to
@@ -1710,7 +1710,7 @@ static int tiva_i2c_initialize(struct tiva_i2c_priv_s *priv, uint32_t frequency)
 #endif
 #endif
 
-	/* Configure the the initial I2C clock frequency. */
+	/* Configure the initial I2C clock frequency. */
 
 	(void)tiva_i2c_setclock(priv, frequency);
 

--- a/os/arch/arm/src/tiva/tiva_timer.h
+++ b/os/arch/arm/src/tiva/tiva_timer.h
@@ -621,7 +621,7 @@ uint32_t tiva_timer32_remaining(TIMER_HANDLE handle);
  * Description:
  *   This function may be called at any time to change the timer interval
  *   match value of a 32-bit timer.  This function sets the match register
- *   the the absolute value specified.
+ *   the absolute value specified.
  *
  * Input Parameters:
  *   handle   - The handle value returned  by tiva_gptm_configure()
@@ -645,7 +645,7 @@ static inline void tiva_timer32_absmatch(TIMER_HANDLE handle, uint32_t absmatch)
  * Description:
  *   This function may be called at any time to change the timer interval
  *   match value of a 16-bit timer.  This function sets the match register
- *   the the absolute value specified.
+ *   the absolute value specified.
  *
  * Input Parameters:
  *   handle   - The handle value returned  by tiva_gptm_configure()

--- a/os/arch/arm/src/tiva/tiva_timerlib.c
+++ b/os/arch/arm/src/tiva/tiva_timerlib.c
@@ -2527,7 +2527,7 @@ uint32_t tiva_timer32_remaining(TIMER_HANDLE handle)
 			 * the timeout event (0x0), the timer reloads its start value
 			 * from the GPTMTAILR register on the next cycle.
 			 *
-			 * The time remaining it then just the the value of the counter
+			 * The time remaining it then just the value of the counter
 			 * register.
 			 *
 			 * REVISIT: Or the counter value +1?

--- a/os/arch/arm/src/tiva/tiva_timerlow32.c
+++ b/os/arch/arm/src/tiva/tiva_timerlow32.c
@@ -434,7 +434,7 @@ static int tiva_settimeout(struct timer_lowerhalf_s *lower, uint32_t timeout)
 
 	timvdbg("Entry: timeout=%d\n", timeout);
 
-	/* Calculate the the new time settings */
+	/* Calculate the new time settings */
 
 	tiva_timeout(priv, timeout);
 

--- a/os/arch/arm/src/tiva/tiva_vectors.S
+++ b/os/arch/arm/src/tiva/tiva_vectors.S
@@ -80,7 +80,7 @@
    * stale MSP, there will most likely be a system failure.
    *
    * If the interrupt stack is selected, on the other hand, then the interrupt
-   * handler will always set the the MSP to the interrupt stack.  So when the high
+   * handler will always set the MSP to the interrupt stack.  So when the high
    * priority interrupt occurs, it will either use the MSP of the last privileged
    * thread to run or, in the case of the nested interrupt, the interrupt stack if
    * no privileged task has run.
@@ -90,7 +90,7 @@
 #    error Interrupt stack must be used with high priority interrupts in kernel mode
 #  endif
 
-  /* Use the the BASEPRI to control interrupts is required if nested, high
+  /* Use the BASEPRI to control interrupts is required if nested, high
    * priority interrupts are supported.
    */
 

--- a/os/arch/arm/src/tiva/tm4c_ethernet.c
+++ b/os/arch/arm/src/tiva/tm4c_ethernet.c
@@ -1548,7 +1548,7 @@ static int tiva_recvframe(FAR struct tiva_ethmac_s *priv)
 		else {
 			priv->segments++;
 
-			/* Check if the there is only one segment in the frame */
+			/* Check if there is only one segment in the frame */
 
 			if (priv->segments == 1) {
 				rxcurr = rxdesc;
@@ -4091,7 +4091,7 @@ void up_netinitialize(void)
  *      and SIOCSMIIREG ioctl calls** to communicate with the PHY,
  *      determine what network event took place (Link Up/Down?), and
  *      take the appropriate actions.
- *   d. It should then interact the the PHY to clear any pending
+ *   d. It should then interact the PHY to clear any pending
  *      interrupts, then re-enable the PHY interrupt.
  *
  *    * This is an OS internal interface and should not be used from

--- a/os/arch/boardctl.c
+++ b/os/arch/boardctl.c
@@ -107,7 +107,7 @@ int boardctl(unsigned int cmd, uintptr_t arg)
 	 *                board_app_initialize() implementation without modification.
 	 *                The argument has no meaning to NuttX; the meaning of the
 	 *                argument is a contract between the board-specific
-	 *                initalization logic and the the matching application logic.
+	 *                initalization logic and the matching application logic.
 	 *                The value cold be such things as a mode enumeration value,
 	 *                a set of DIP switch switch settings, a pointer to
 	 *                configuration data read from a file or serial FLASH, or

--- a/os/board/rtl8721csm/src/component/common/api/wifi/wifi_conf.h
+++ b/os/board/rtl8721csm/src/component/common/api/wifi/wifi_conf.h
@@ -743,7 +743,7 @@ int wifi_get_network_mode(rtw_network_mode_t *pmode);
  *                    - 4 means enable the promisc special for Broadcast/Multicast 802.11 frames.
  * @param[in]  callback: the callback function which will 
  *  			  receive and process the netowork data.
- * @param[in]  len_used: specify if the the promisc data length is used.
+ * @param[in]  len_used: specify if the promisc data length is used.
  *				If len_used set to 1, packet(frame data) length will be saved and transferred to callback function.
  *
  * @return  RTW_SUCCESS or RTW_ERROR

--- a/os/board/rtl8721csm/src/component/common/mbed/hal_ext/pcm_api.h
+++ b/os/board/rtl8721csm/src/component/common/mbed/hal_ext/pcm_api.h
@@ -375,7 +375,7 @@ u8 pcm_irq_get_channel(pcm_t *obj);
 u32 pcm_irq_get_buffer_size(pcm_t *obj);
 
 /**
-  * @brief  Get the the page number of the processing channel in the interrupt handler.
+  * @brief  Get the page number of the processing channel in the interrupt handler.
   *          This function needs in the interrupt handler.
   * @param  obj: PCM object define in application software.
   * @retval none

--- a/os/board/rtl8721csm/src/component/soc/realtek/amebad/fwlib/include/rtl8721d_ota.h
+++ b/os/board/rtl8721csm/src/component/soc/realtek/amebad/fwlib/include/rtl8721d_ota.h
@@ -79,7 +79,7 @@ typedef struct
 	u32	Checksum;	/*!< Specifies the OTA image checksum.
 	                         	This parameter is used to judge whether the image received is correct. */
 	u32  ImgLen;		/*!< Specifies the OTA image length. */
-	u32  Offset;		/*!< Specifies the the location in the total firmware file. */
+	u32  Offset;		/*!< Specifies the location in the total firmware file. */
 	u32  FlashAddr;    /*!< Specifies the flash offset address of the corresponding image. */
 }update_file_img_hdr;
 

--- a/os/board/rtl8721csm/src/component/soc/realtek/amebad/fwlib/ram_hp/rtl8721dhp_usi_uart.c
+++ b/os/board/rtl8721csm/src/component/soc/realtek/amebad/fwlib/ram_hp/rtl8721dhp_usi_uart.c
@@ -1154,7 +1154,7 @@ void USI_UARTLPRxStructInit(USI_LPUARTInitTypeDef* USI_LPUARTInitStruct)
 }
 
 /**
-  * @brief    Initializes the the UART Low Power RX path peripheral according to the specified
+  * @brief    Initializes the UART Low Power RX path peripheral according to the specified
   *              parameters in the USI_LPUARTInitStruct.
   * @param  USIx: where x can be 0.
   * @param  USI_LPUARTInitStruct: pointer to an USI_LPUARTInitTypeDef structure which has been configured.

--- a/os/drivers/usbhost/Kconfig
+++ b/os/drivers/usbhost/Kconfig
@@ -126,7 +126,7 @@ config USBHOST_CDCACM_REDUCED
 		status lines. This mode is useful if the number of available
 		endpoints is limited by hardware restrictions.
 
-		If the the CDC/ACM compliant protocol is selected, then the reduced
+		If the CDC/ACM compliant protocol is selected, then the reduced
 		protocol is supported for devices that provide not interrupt IN
 		endpoint.  This option is then most useful for testing purposes or
 		if there are insufficient resources to support the compliant

--- a/os/drivers/usbhost/usbhost_devaddr.c
+++ b/os/drivers/usbhost/usbhost_devaddr.c
@@ -273,7 +273,7 @@ void usbhost_devaddr_initialize(FAR struct usbhost_roothubport_s *rhport)
  *     newly connected and so is in need of a function address.
  *
  * Returned Value:
- *   On success, a new device function address in the the range 0x01 to 0x7f
+ *   On success, a new device function address in the range 0x01 to 0x7f
  *   is returned.  On failure, a negated errno value is returned.
  *
  ****************************************************************************/

--- a/os/drivers/usbhost/usbhost_trace.c
+++ b/os/drivers/usbhost/usbhost_trace.c
@@ -127,7 +127,7 @@ static int usbhost_trsyslog(uint32_t event, FAR void *arg)
 		syslog(LOG_INFO, fmt, (unsigned int)TRACE_DECODE_U23(event));
 	}
 
-	/* No, then it must the the two argument format first. */
+	/* No, then it must be the two argument format first. */
 
 	else {
 		fmt = usbhost_trformat2(id);

--- a/os/drivers/wireless/realtek/wifi_util_interface/wifi_conf.h
+++ b/os/drivers/wireless/realtek/wifi_util_interface/wifi_conf.h
@@ -845,7 +845,7 @@ int wifi_get_network_mode(rtw_network_mode_t *pmode);
  *Broadcast/Multicast 802.11 frames.
  * @param[in]  callback: the callback function which will
  *  			  receive and process the netowork data.
- * @param[in]  len_used: specify if the the promisc data length is used.
+ * @param[in]  len_used: specify if the promisc data length is used.
  *				If len_used set to 1, packet(frame data) length will
  *be saved and transferred to callback function.
  *

--- a/os/fs/driver/mtd/mtd_config.c
+++ b/os/fs/driver/mtd/mtd_config.c
@@ -270,7 +270,7 @@ static int mtdconfig_writebytes(FAR struct mtdconfig_struct_s *dev, int offset, 
 		off_t bytes_written = 0;
 
 		while (writelen) {
-			/* Read existing data from the the block into the buffer */
+			/* Read existing data from the block into the buffer */
 
 			block = offset / dev->blocksize;
 			ret = MTD_BREAD(dev->mtd, block, 1, dev->buffer);

--- a/os/fs/driver/mtd/smart.c
+++ b/os/fs/driver/mtd/smart.c
@@ -290,7 +290,7 @@ struct smart_struct_s {
 	uint8_t minwearlevel;		/* Min level in the wear level bits */
 	uint8_t maxwearlevel;		/* Max level in the wear level bits */
 	uint8_t *wearstatus;		/* Array of wear leveling bits */
-	uint32_t uneven_wearcount;	/* Number of times the the wear level has gone over max */
+	uint32_t uneven_wearcount;	/* Number of times the wear level has gone over max */
 #endif
 #ifdef CONFIG_MTD_SMART_ENABLE_CRC
 	FAR struct smart_allocsector_s *allocsector;	/* Pointer to first alloc sector */

--- a/os/include/sys/boardctl.h
+++ b/os/include/sys/boardctl.h
@@ -74,7 +74,7 @@
  *                board_app_initialize() implementation without modification.
  *                The argument has no meaning to NuttX; the meaning of the
  *                argument is a contract between the board-specific
- *                initalization logic and the the matching application logic.
+ *                initalization logic and the matching application logic.
  *                The value cold be such things as a mode enumeration value,
  *                a set of DIP switch switch settings, a pointer to
  *                configuration data read from a file or serial FLASH, or

--- a/os/include/tinyara/arch.h
+++ b/os/include/tinyara/arch.h
@@ -1509,7 +1509,7 @@ void up_timer_initialize(void);
  *   any failure.
  *
  * Assumptions:
- *   Called from the the normal tasking context.  The implementation must
+ *   Called from the normal tasking context.  The implementation must
  *   provide whatever mutual exclusion is necessary for correct operation.
  *   This can include disabling interrupts in order to assure atomic register
  *   operations.
@@ -2070,7 +2070,7 @@ xcpt_t board_button_irq(int id, xcpt_t irqhandler);
  *      and SIOCSMIIREG ioctl calls** to communicate with the PHY,
  *      determine what network event took place (Link Up/Down?), and
  *      take the appropriate actions.
- *   d. It should then interact the the PHY to clear any pending
+ *   d. It should then interact the PHY to clear any pending
  *      interrupts, then re-enable the PHY interrupt.
  *
  *    * This is an OS internal interface and should not be used from

--- a/os/include/tinyara/audio/tas5749.h
+++ b/os/include/tinyara/audio/tas5749.h
@@ -83,7 +83,7 @@
  *   thread.
  * CONFIG_TAS5749_BUFFER_SIZE - Preferred buffer size
  * CONFIG_TAS5749_NUM_BUFFERS - Preferred number of buffers
- * CONFIG_TAS5749_WORKER_STACKSIZE - Stack size to use when creating the the
+ * CONFIG_TAS5749_WORKER_STACKSIZE - Stack size to use when creating the
  *   TAS5749 worker thread.
  * CONFIG_TAS5749_REGDUMP - Enable logic to dump all TAS5749 registers to
  *   the SYSLOG device.

--- a/os/include/tinyara/bluetooth/conn.h
+++ b/os/include/tinyara/bluetooth/conn.h
@@ -201,7 +201,7 @@ int bt_conn_disconnect(struct bt_conn *conn, uint8_t reason);
 /** @brief Initiate an LE connection to a remote device.
  *
  *  Allows initiate new LE link to remote peer using its address.
- *  Returns a new reference that the the caller is responsible for managing.
+ *  Returns a new reference that the caller is responsible for managing.
  *
  *  @param peer  Remote address.
  *  @param param Initial connection parameters.
@@ -240,7 +240,7 @@ int bt_le_set_auto_conn(const bt_addr_le_t *addr, const struct bt_le_conn_param 
  *
  *  The advertising may be canceled with bt_conn_disconnect().
  *
- *  Returns a new reference that the the caller is responsible for managing.
+ *  Returns a new reference that the caller is responsible for managing.
  *
  *  @param peer  Remote address.
  *  @param param Directed advertising parameters.
@@ -755,7 +755,7 @@ struct bt_br_conn_param {
 /** @brief Initiate an BR/EDR connection to a remote device.
  *
  *  Allows initiate new BR/EDR link to remote peer using its address.
- *  Returns a new reference that the the caller is responsible for managing.
+ *  Returns a new reference that the caller is responsible for managing.
  *
  *  @param peer  Remote address.
  *  @param param Initial connection parameters.
@@ -767,7 +767,7 @@ struct bt_conn *bt_conn_create_br(const bt_addr_t *peer, const struct bt_br_conn
 /** @brief Initiate an SCO connection to a remote device.
  *
  *  Allows initiate new SCO link to remote peer using its address.
- *  Returns a new reference that the the caller is responsible for managing.
+ *  Returns a new reference that the caller is responsible for managing.
  *
  *  @param peer  Remote address.
  *

--- a/os/include/tinyara/board.h
+++ b/os/include/tinyara/board.h
@@ -63,7 +63,7 @@
  *    definitions provide the common interface between TinyAra and the
  *    architecture-specific implementation in arch/
  *
- *    These definitions are retained in the the header file tinyara/include/arch.h
+ *    These definitions are retained in the header file tinyara/include/arch.h
  *
  *    NOTE: up_ is supposed to stand for microprocessor; the u is like the
  *    Greek letter micron: µ. So it would be µP which is a common shortening

--- a/os/include/tinyara/net/netdev.h
+++ b/os/include/tinyara/net/netdev.h
@@ -155,7 +155,7 @@ struct net_driver_s {
 #endif
 
 	/* d_appdata points to the location where application data can be read from
-	 * or written to in the the packet buffer.
+	 * or written to in the packet buffer.
 	 */
 
 	uint8_t *d_appdata;

--- a/os/include/tinyara/power/battery_charger.h
+++ b/os/include/tinyara/power/battery_charger.h
@@ -84,7 +84,7 @@
  * around the lower-half battery charger driver that does all of the real work.
  * Since there is no real data transfer to/or from a battery, all of the
  * driver interaction is through IOCTL commands.  The IOCTL commands
- * supported by the upper-half driver simply provide calls into the the
+ * supported by the upper-half driver simply provide calls into the
  * lower half as summarized below:
  *
  * BATIOC_STATE - Return the current state of the battery (see

--- a/os/include/tinyara/power/battery_gauge.h
+++ b/os/include/tinyara/power/battery_gauge.h
@@ -85,7 +85,7 @@
  * real work.
  * Since there is no real data transfer to/or from a battery, all of the
  * driver interaction is through IOCTIL commands.  The IOCTL commands
- * supported by the upper-half driver simply provide calls into the the
+ * supported by the upper-half driver simply provide calls into the
  * lower half as summarized below:
  *
  * BATIOC_STATE - Return the current state of the battery (see

--- a/os/include/tinyara/sdio.h
+++ b/os/include/tinyara/sdio.h
@@ -85,7 +85,7 @@
  *   avoid potentially very long (600Ms+) busy waiting in the MMCSD driver.
  *
  *   To implement D0 Busy signalling, the underlying SDIO driver must be
- *   capable of switching the the D0 GPIO to be a rising edge sensitive
+ *   capable of switching the D0 GPIO to be a rising edge sensitive
  *   interrupt pin. It must then, condition that pin to detect the rising
  *   edge on receipt of SDWAIT_WRCOMPLETE in the SDIO_WAITENABLE call and
  *   return it back to regular SDIO mode, when either the ISR fires or pin

--- a/os/include/tinyara/usb/usbhost.h
+++ b/os/include/tinyara/usb/usbhost.h
@@ -648,7 +648,7 @@ struct usbhost_id_s {
 	uint16_t pid;				/* Product ID (for vendor/product specific devices) */
 };
 
-/* The struct usbhost_registry_s type describes information that is kept in the the
+/* The struct usbhost_registry_s type describes information that is kept in the
  * USB host registry.  USB host class implementations register this information so
  * that USB host drivers can later find the class that matches the device that is
  * connected to the USB port.

--- a/os/include/tinyara/usb/usbhost_devaddr.h
+++ b/os/include/tinyara/usb/usbhost_devaddr.h
@@ -135,7 +135,7 @@ void usbhost_devaddr_initialize(FAR struct usbhost_roothubport_s *rhport);
  *     newly connected and so is in need of a function address.
  *
  * Returned Value:
- *   On success, a new device function address in the the range 0x01 to 0x7f
+ *   On success, a new device function address in the range 0x01 to 0x7f
  *   is returned.  On failure, a negated errno value is returned.
  *
  ****************************************************************************/

--- a/os/kernel/Kconfig
+++ b/os/kernel/Kconfig
@@ -113,7 +113,7 @@ config USEC_PER_TICK
 		In the "normal" configuration where system time is provided by a
 		periodic timer interrupt, the default system timer is expected to
 		run at 100Hz or USEC_PER_TICK=10000.  This setting must be defined
-		to inform of TinyAra the interval that the the processor hardware is
+		to inform of TinyAra the interval that the processor hardware is
 		providing system timer interrupts to the OS.
 
 		If SCHED_TICKLESS is selected, then there are no system timer
@@ -122,7 +122,7 @@ config USEC_PER_TICK
 		by clock_systimer() and the resolution of times that can be set for
 		certain delays including watchdog timers and delayed work.  In this
 		case there is a trade-off:  It is better to have the USEC_PER_TICK as
-		low as possible for higher timing resolution.  However, the the time
+		low as possible for higher timing resolution.  However, the time
 		is currently held in 'unsigned int' on some systems, this may be
 		16-bits but on most contemporary systems it will be 32-bits.  In
 		either case, smaller values of USEC_PER_TICK will reduce the range

--- a/os/kernel/group/group_join.c
+++ b/os/kernel/group/group_join.c
@@ -177,7 +177,7 @@ static inline int group_addmember(FAR struct task_group_s *group, pid_t pid)
  *
  * Assumptions:
  * - The parent task from which the group will be inherited is the task at
- *   the thead of the ready to run list.
+ *   thead of the ready to run list.
  * - Called during thread creation in a safe context.  No special precautions
  *   are required here.
  *
@@ -218,7 +218,7 @@ int group_bind(FAR struct pthread_tcb_s *tcb)
  *
  * Assumptions:
  * - The parent task from which the group will be inherited is the task at
- *   the thead of the ready to run list.
+ *   thead of the ready to run list.
  * - Called during thread creation in a safe context.  No special precautions
  *   are required here.
  *

--- a/os/kernel/pthread/pthread_cleanup.c
+++ b/os/kernel/pthread/pthread_cleanup.c
@@ -142,7 +142,7 @@ static void pthread_cleanup_pop_tcb(FAR struct pthread_tcb_s *tcb, int execute)
  *   - The thread calls pthread_cleanup_pop() with a non-zero execute argument.
  *
  * Input Parameters:
- *   routine - The cleanup routine to be pushed on the the cleanup stack.
+ *   routine - The cleanup routine to be pushed on the cleanup stack.
  *   arg     - An argument that will accompany the callback.
  *   execute - Execute the popped cleanup function immediately.
  *

--- a/os/kernel/task/task_getpid.c
+++ b/os/kernel/task/task_getpid.c
@@ -97,7 +97,7 @@ pid_t getpid(void)
 {
 	FAR struct tcb_s *rtcb;
 
-	/* Get the the TCB at the head of the ready-to-run task list.  That
+	/* Get the TCB at the head of the ready-to-run task list.  That
 	 * will be the currently executing task.  There is an exception to
 	 * this:  Verify early in the start-up sequence, the g_readytorun
 	 * list may be empty!  This case, of course, the start-up/IDLE thread

--- a/os/kernel/wdog/wd_create.c
+++ b/os/kernel/wdog/wd_create.c
@@ -120,7 +120,7 @@ WDOG_ID wd_create(void)
 	state = irqsave();
 
 	/* If we are in an interrupt handler -OR- if the number of pre-allocated
-	 * timer structures exceeds the reserve, then take the the next timer from
+	 * timer structures exceeds the reserve, then take the next timer from
 	 * the head of the free list.
 	 */
 

--- a/os/kernel/wdog/wd_start.c
+++ b/os/kernel/wdog/wd_start.c
@@ -392,7 +392,7 @@ int wd_start(WDOG_ID wdog, int delay, wdentry_t wdentry, int argc, ...)
  *
  * Parameters:
  *   ticks - If CONFIG_SCHED_TICKLESS is defined then the number of ticks
- *     in the the interval that just expired is provided.  Otherwise,
+ *     in the interval that just expired is provided.  Otherwise,
  *     this function is called on each timer interrupt and a value of one
  *     is implicit.
  *

--- a/os/kernel/wdog/wdog.h
+++ b/os/kernel/wdog/wdog.h
@@ -140,7 +140,7 @@ void weak_function wd_initialize(void);
  *
  * Parameters:
  *   ticks - If CONFIG_SCHED_TICKLESS is defined then the number of ticks
- *     in the the interval that just expired is provided.  Otherwise,
+ *     in the interval that just expired is provided.  Otherwise,
  *     this function is called on each timer interrupt and a value of one
  *     is implicit.
  *

--- a/os/mm/shm/README.txt
+++ b/os/mm/shm/README.txt
@@ -79,7 +79,7 @@ Concepts
     int shmctl(int shmid, int cmd, struct shmid_ds *buf);
 
   In order for a process to make use of the memory region, it must be
-  "attached" the the process using:
+  "attached" the process using:
 
     FAR void *shmat(int shmid, FAR const void *shmaddr, int shmflg);
 

--- a/os/mm/shm/shmat.c
+++ b/os/mm/shm/shmat.c
@@ -203,7 +203,7 @@ FAR void *shmat(int shmid, FAR const void *shmaddr, int shmflg)
 
 	region->sr_ds.shm_nattch++;
 
-	/* Save the process ID of the the last operation */
+	/* Save the process ID of the last operation */
 
 	region->sr_ds.shm_lpid = tcb->pid;
 

--- a/os/mm/shm/shmctl.c
+++ b/os/mm/shm/shmctl.c
@@ -139,7 +139,7 @@
  *       to be stored in the structure pointed to by the buf argument.
  *
  * POSIX Deviations:
- *     - IPC_SET.  Does not set the the shm_perm.uid or shm_perm.gid
+ *     - IPC_SET.  Does not set the shm_perm.uid or shm_perm.gid
  *       members of the shmid_ds data structure associated with shmid
  *       because user and group IDs are not yet supported by TinyAra
  *     - IPC_SET.  Does not restrict the operation to processes with
@@ -220,7 +220,7 @@ int shmctl(int shmid, int cmd, struct shmid_ds *buf)
 		goto errout_with_semaphore;
 	}
 
-	/* Save the process ID of the the last operation */
+	/* Save the process ID of the last operation */
 
 	region = &g_shminfo.si_region[shmid];
 	region->sr_ds.shm_lpid = getpid();

--- a/os/mm/shm/shmdt.c
+++ b/os/mm/shm/shmdt.c
@@ -195,7 +195,7 @@ int shmdt(FAR const void *shmaddr)
 		region->sr_ds.shm_nattch--;
 	}
 
-	/* Save the process ID of the the last operation */
+	/* Save the process ID of the last operation */
 
 	region->sr_ds.shm_lpid = tcb->pid;
 

--- a/os/net/bluetooth/bt_conn.c
+++ b/os/net/bluetooth/bt_conn.c
@@ -1001,7 +1001,7 @@ int bt_conn_disconnect_internal(FAR struct bt_conn_s *conn, uint8_t reason)
  *
  * Description:
  *  Allows initiate new LE link to remote peer using its address.
- *  Returns a new reference that the the caller is responsible for managing.
+ *  Returns a new reference that the caller is responsible for managing.
  *
  * Input Parameters:
  *   peer - Remote address.

--- a/os/net/bluetooth/bt_conn.h
+++ b/os/net/bluetooth/bt_conn.h
@@ -404,7 +404,7 @@ int bt_conn_disconnect_internal(FAR struct bt_conn_s *conn, uint8_t reason);
  *
  * Description:
  *  Allows initiate new LE link to remote peer using its address.
- *  Returns a new reference that the the caller is responsible for managing.
+ *  Returns a new reference that the caller is responsible for managing.
  *
  * Input Parameters:
  *   peer - Remote address.

--- a/os/net/bluetooth/bt_hcicore.c
+++ b/os/net/bluetooth/bt_hcicore.c
@@ -990,7 +990,7 @@ static int hci_tx_kthread(int argc, FAR char *argv[])
  * Name: hci_rx_work
  *
  * Description:
- *   This work function may operate on either the the high priority work
+ *   This work function may operate on either the high priority work
  *   thread (using the high priority buffer queue), or on the low priority
  *   work queue (using the low priority buffer queue), depending upon the
  *   type of the incoming message

--- a/os/net/bluetooth/bt_hcicore.h
+++ b/os/net/bluetooth/bt_hcicore.h
@@ -102,7 +102,7 @@ struct bt_dev_le {
 	/* Controller buffer information */
 	uint16_t mtu;
 
-	/* Size of the the controller resolving list */
+	/* Size of the controller resolving list */
 	uint8_t rl_size;
 	/* Number of entries in the resolving list. rl_entries > rl_size
 	 * means that host-side resolving is used.

--- a/os/net/bluetooth/conn_internal.h
+++ b/os/net/bluetooth/conn_internal.h
@@ -171,7 +171,7 @@ struct bt_conn *bt_conn_lookup_handle(u16_t handle);
 /* Compare an address with bt_conn destination address */
 int bt_conn_addr_le_cmp(const struct bt_conn *conn, const bt_addr_le_t *peer);
 
-/* Helpers for identifying & looking up connections based on the the index to
+/* Helpers for identifying & looking up connections based on the index to
  * the connection list. This is useful for O(1) lookups, but can't be used
  * e.g. as the handle since that's assigned to us by the controller.
  */

--- a/os/net/lwip/src/core/ipv6/ethip6.c
+++ b/os/net/lwip/src/core/ipv6/ethip6.c
@@ -80,7 +80,7 @@
  * are selected and the packet is transmitted on the link.
  *
  * For unicast addresses, ask the ND6 module what to do. It will either let us
- * send the the packet right away, or queue the packet for later itself, unless
+ * send the packet right away, or queue the packet for later itself, unless
  * an error occurs.
  *
  * @todo anycast addresses

--- a/os/tools/Config.mk
+++ b/os/tools/Config.mk
@@ -173,7 +173,7 @@ endef
 # Example: $(call MOVEOBJ, prefix, directory)
 #
 # This is only used in directories that keep object files in sub-directories.
-# Certain compilers (ZDS-II) always place the resulting files in the the
+# Certain compilers (ZDS-II) always place the resulting files in the
 # directory where the compiler was invoked with not option to generate objects
 # in a different location.
 

--- a/os/tools/README.txt
+++ b/os/tools/README.txt
@@ -400,7 +400,7 @@ refresh.sh
   The steps to refresh the file are:
 
   1. Make tools/cmpconfig if it is not already built.
-  2. Copy the the defconfig file to the top-level TinyAra
+  2. Copy the defconfig file to the top-level TinyAra
      directory as .config (being careful to save any previous
      .config file that you might want to keep!).
   3. Execute 'make oldconfig' to update the configuration.


### PR DESCRIPTION
1. the the -> the
2. the life the task group -> the life of the task group
3. becasue -> because

Signed-off-by: sunghan-chang <sh924.chang@samsung.com>