### PR TITLE
os/fs/smartfs: Update variable names and add macros for frequently used long strings

### DIFF
--- a/os/fs/smartfs/smartfs.h
+++ b/os/fs/smartfs/smartfs.h
@@ -295,12 +295,6 @@ struct smartfs_chain_header_s {
 	uint8_t used[4];			/* Number of bytes used in this sector */
 	uint8_t type;				/* Type of sector entry (file or dir) */
 };
-#elif defined(CONFIG_MTD_SMART_ENABLE_CRC) && defined(CONFIG_SMART_CRC_16)
-struct smartfs_chain_header_s {
-	uint8_t type;				/* Type of sector entry (file or dir) */
-	uint8_t nextsector[2];		/* Next logical sector in the chain */
-	uint8_t used[2];			/* Number of bytes used in this sector */
-};
 #else
 struct smartfs_chain_header_s {
 	uint8_t type;				/* Type of sector entry (file or dir) */

--- a/os/fs/smartfs/smartfs.h
+++ b/os/fs/smartfs/smartfs.h
@@ -249,6 +249,8 @@
 #undef  CONFIG_SMARTFS_DYNAMIC_HEADER
 #endif
 
+#define SMARTFS_AVAIL_DATABYTES(f) f->fs_llformat.availbytes - sizeof(struct smartfs_chain_header_s)
+
 /****************************************************************************
  * Public Types
  ****************************************************************************/

--- a/os/fs/smartfs/smartfs_smart.c
+++ b/os/fs/smartfs/smartfs_smart.c
@@ -1700,7 +1700,7 @@ static void smartfs_stat_common(FAR struct smartfs_mountpt_s *fs,
 		}
 	}
 	buf->st_size = entry->datalen;
-	buf->st_blksize = fs->fs_llformat.availbytes - sizeof(struct smartfs_chain_header_s);
+	buf->st_blksize = SMARTFS_AVAIL_DATABYTES(fs);
 	buf->st_blocks = (buf->st_size + buf->st_blksize - 1) / buf->st_blksize;
 	buf->st_atime = 0;
 	buf->st_ctime = 0;

--- a/os/fs/smartfs/smartfs_utils.c
+++ b/os/fs/smartfs/smartfs_utils.c
@@ -167,7 +167,7 @@ struct sector_entry_queue_s {
 struct sector_recover_info_s {
 	uint16_t totalsector;
 	uint16_t isolatedsector;
-	uint16_t cleanentries;
+	uint16_t cleanedentries;
 };
 
 /****************************************************************************
@@ -2276,12 +2276,12 @@ int smartfs_invalidate_old_entry(struct smartfs_mountpt_s *fs, uint16_t logsecto
 		if (firstparent->time > secondparent->time) {
 			ret = smartfs_invalidateentry(fs, secondparent->parentsector, secondparent->parentoffset);
 			if (ret == OK) {
-				info->cleanentries++;
+				info->cleanedentries++;
 			}
 		} else {
 			ret = smartfs_invalidateentry(fs, firstparent->parentsector, firstparent->parentoffset); 
 			if (ret == OK) {
-				info->cleanentries++;
+				info->cleanedentries++;
 			}
 		}
 	}
@@ -2427,7 +2427,7 @@ int smartfs_scan_entry(struct smartfs_mountpt_s *fs, char *map, struct sector_re
 							fdbg("Unable to mark entry inactive at sector %d, ret : %d\n", logsector, ret);
 							goto errout;
 						}
-						info->cleanentries++;
+						info->cleanedentries++;
 
 					} else {
 						/* Make New node of Entry's first sector and put it to queue */
@@ -2473,7 +2473,7 @@ int smartfs_scan_entry(struct smartfs_mountpt_s *fs, char *map, struct sector_re
 						goto errout;
 					}
 					
-					info->cleanentries++;
+					info->cleanedentries++;
 					break;
 				}
 			}
@@ -2564,7 +2564,7 @@ int smartfs_sector_recovery(struct smartfs_mountpt_s *fs)
 	fdbg("###############################\n");
 	fdbg("Total of active sectors : %d\n", info.totalsector);
 	fdbg("Recovered Isolated Sectors : %d\n", info.isolatedsector);
-	fdbg("Cleaned Entries : %d\n\n", info.cleanentries);
+	fdbg("Cleaned Entries : %d\n\n", info.cleanedentries);
 
 error_with_map:
 	if (map) {


### PR DESCRIPTION
os/fs/smartfs: Modify name of recovery info structure attribute

- Current name 'cleanentries' misguides the reader to believe
  that it is the count of clean entries.
- Change the bame to 'cleanedentries' which identifies as the
  count of entries cleaned during the recovery process.

Signed-off-by: Amogh Hassija <a.hassija@samsung.com>