### PR TITLE
os/kernel/task/task_terminate_unloaded : Skip unloading thread's stac…

### DIFF
--- a/os/kernel/debug/Make.defs
+++ b/os/kernel/debug/Make.defs
@@ -20,7 +20,11 @@ ifeq ($(CONFIG_DEBUG_SYSTEM),y)
 CSRCS += sysdbg.c
 endif
 
-CSRCS += memdbg.c
+CSRCS += memdbg.c dbg_termination_info.c
+
+ifeq ($(CONFIG_ENABLE_STACKMONITOR)$(CONFIG_DEBUG),yy)
+CSRCS += stackinfo_save_terminated.c
+endif
 
 DEPPATH += --dep-path debug
 VPATH += :debug

--- a/os/kernel/debug/debug.h
+++ b/os/kernel/debug/debug.h
@@ -1,0 +1,39 @@
+/****************************************************************************
+ *
+ * Copyright 2020 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __SCHED_DEBUG_DEBUG_H
+#define __SCHED_DEBUG_DEBUG_H
+
+/********************************************************************************
+ * Included Files
+ ********************************************************************************/
+
+#include <tinyara/config.h>
+#include <tinyara/sched.h>
+#include <sys/types.h>
+
+/********************************************************************************
+ * Public Function Prototypes
+ ********************************************************************************/
+#if defined(CONFIG_ENABLE_STACKMONITOR) && defined(CONFIG_DEBUG)
+void stackinfo_save_terminated(struct tcb_s *tcb);
+#endif
+
+void dbg_save_termination_info(struct tcb_s *tcb);
+
+#endif							/* __SCHED_DEBUG_DEBUG_H */

--- a/os/kernel/debug/stackinfo_save_terminated.c
+++ b/os/kernel/debug/stackinfo_save_terminated.c
@@ -1,0 +1,152 @@
+/****************************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+/****************************************************************************
+ * kernel/debug/stackinfo_save_terminated.c
+ *
+ *   Copyright (C) 2007, 2009 Gregory Nutt. All rights reserved.
+ *   Author: Gregory Nutt <gnutt@nuttx.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <tinyara/config.h>
+#include <time.h>
+#include <sys/types.h>
+
+#include <tinyara/clock.h>
+#include <tinyara/sched.h>
+#ifdef CONFIG_DEBUG_MM_HEAPINFO
+#include <tinyara/mm/mm.h>
+#endif
+
+/****************************************************************************
+ * Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Type Declarations
+ ****************************************************************************/
+
+/****************************************************************************
+ * Global Variables
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Variables
+ ****************************************************************************/
+static struct stkmon_save_s terminated_thread_stkinfo[CONFIG_MAX_TASKS * 2];
+static int stkmon_chk_idx;
+
+/****************************************************************************
+ * Private Function Prototypes
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+/****************************************************************************
+ * Name: stkmon_copy_log
+ *
+ * Description:
+ *   This function copies the terminated task/pthread's information to
+ *  user buffer.
+ *
+ ****************************************************************************/
+void stkmon_copy_log(struct stkmon_save_s *dest_arr)
+{
+	int thread_idx;
+
+	for (thread_idx = 0; thread_idx < STKMON_MAX_LOGS; thread_idx++) {
+		if (terminated_thread_stkinfo[thread_idx].timestamp != 0) {
+			memcpy(&dest_arr[thread_idx], &terminated_thread_stkinfo[thread_idx], sizeof(struct stkmon_save_s));
+		}
+	}
+}
+
+/****************************************************************************
+ * Name: stackinfo_save_terminated
+ *
+ * Description:
+ *   This function saves the terminated task/pthread's information for
+ *  stack monitor.
+ *
+ ****************************************************************************/
+void stackinfo_save_terminated(struct tcb_s *tcb)
+{
+#if (CONFIG_TASK_NAME_SIZE > 0)
+	int name_idx;
+#endif
+#ifdef CONFIG_DEBUG_MM_HEAPINFO
+	struct mm_heap_s *heap;
+#endif
+	terminated_thread_stkinfo[stkmon_chk_idx % STKMON_MAX_LOGS].timestamp = clock();
+	terminated_thread_stkinfo[stkmon_chk_idx % STKMON_MAX_LOGS].chk_pid = tcb->pid;
+	terminated_thread_stkinfo[stkmon_chk_idx % STKMON_MAX_LOGS].chk_stksize = tcb->adj_stack_size;
+#ifdef CONFIG_STACK_COLORATION
+	terminated_thread_stkinfo[stkmon_chk_idx % STKMON_MAX_LOGS].chk_peaksize = up_check_tcbstack(tcb);
+#endif
+#ifdef CONFIG_DEBUG_MM_HEAPINFO
+	heap = mm_get_heap(tcb->stack_alloc_ptr);
+	if (heap == NULL) {
+		return;
+	}
+	terminated_thread_stkinfo[stkmon_chk_idx % STKMON_MAX_LOGS].chk_peakheap = heap->alloc_list[PIDHASH(tcb->pid)].peak_alloc_size;
+#endif
+#if (CONFIG_TASK_NAME_SIZE > 0)
+	for (name_idx = 0; name_idx < CONFIG_TASK_NAME_SIZE + 1; name_idx++) {
+		terminated_thread_stkinfo[stkmon_chk_idx % STKMON_MAX_LOGS].chk_name[name_idx] = tcb->name[name_idx];
+	}
+#endif
+	stkmon_chk_idx %= STKMON_MAX_LOGS;
+	stkmon_chk_idx++;
+}
+

--- a/os/kernel/sched/Make.defs
+++ b/os/kernel/sched/Make.defs
@@ -60,10 +60,6 @@ CSRCS += sched_setscheduler.c sched_getscheduler.c
 CSRCS += sched_yield.c sched_rrgetinterval.c sched_foreach.c
 CSRCS += sched_lock.c sched_unlock.c sched_lockcount.c sched_self.c
 
-ifeq ($(CONFIG_ENABLE_STACKMONITOR)$(CONFIG_DEBUG),yy)
-CSRCS += sched_save_terminated_stackinfo.c
-endif
-
 ifeq ($(CONFIG_PRIORITY_INHERITANCE),y)
 CSRCS += sched_reprioritize.c
 endif

--- a/os/kernel/sched/sched_releasetcb.c
+++ b/os/kernel/sched/sched_releasetcb.c
@@ -138,18 +138,6 @@ int sched_releasetcb(FAR struct tcb_s *tcb, uint8_t ttype)
 		 * the process ID was never allocated to this TCB.
 		 */
 		if (tcb->pid) {
-#if defined(CONFIG_ENABLE_STACKMONITOR) && defined(CONFIG_DEBUG)
-			sched_save_terminated_stackinfo(tcb);
-#endif
-
-#ifdef CONFIG_DEBUG_MM_HEAPINFO
-			/* Deallocate heapinfo tcb infos in heap */
-			heapinfo_dealloc_tcbinfo(tcb->stack_alloc_ptr, tcb->pid);
-#ifdef CONFIG_HEAPINFO_USER_GROUP
-			heapinfo_update_group_info(tcb->pid, -1, HEAPINFO_DEL_INFO);
-#endif
-#endif
-
 #ifndef CONFIG_DISABLE_POSIX_TIMERS
 			/* Release any timers that the task might hold.  We do this
 			 * before release the PID because it may still be trying to

--- a/os/kernel/task/task_exithook.c
+++ b/os/kernel/task/task_exithook.c
@@ -69,6 +69,7 @@
 #include "group/group.h"
 #include "signal/signal.h"
 #include "task/task.h"
+#include "debug/debug.h"
 #ifdef CONFIG_BINARY_MANAGER
 #include "binary_manager/binary_manager.h"
 #endif
@@ -555,6 +556,11 @@ void task_exithook(FAR struct tcb_s *tcb, int status, bool nonblocking)
 	if ((tcb->flags & TCB_FLAG_EXIT_PROCESSING) != 0) {
 		return;
 	}
+
+#ifdef CONFIG_DEBUG
+	/* Save the terminated task/pthread's information for stack monitor and heapinfo. */
+	dbg_save_termination_info(tcb);
+#endif
 
 #ifdef CONFIG_CANCELLATION_POINTS
 	/* Mark the task as non-cancelable to avoid additional calls to exit()

--- a/os/kernel/task/task_terminate_unloaded.c
+++ b/os/kernel/task/task_terminate_unloaded.c
@@ -123,6 +123,12 @@ int task_terminate_unloaded(FAR struct tcb_s *tcb)
 #endif
 	tcb->flags |= TCB_FLAG_EXIT_PROCESSING;
 
+	/* No need to release the unloading thread's stack,
+	 * because whole heap memory will be released at one go.
+	 * So marking alloc pointer to NULL for skipping to release.
+	 */
+	tcb->stack_alloc_ptr = NULL;
+
 	/* Deallocate its TCB */
 
 	return sched_releasetcb(tcb, tcb->flags & TCB_FLAG_TTYPE_MASK);


### PR DESCRIPTION
…k release

We don't need to release the unloading thread's stack, because whole heap memory will be released at one go.
So marking alloc pointer to NULL for skipping to release.