### PR TITLE
kernel/binary_manager : Fix typo

### DIFF
--- a/os/kernel/binary_manager/binary_manager.c
+++ b/os/kernel/binary_manager/binary_manager.c
@@ -125,7 +125,7 @@ int binary_manager(int argc, char *argv[])
 			continue;
 		}
 
-		bmvdbg("Recevied Request msg : cmd = %d\n", request_msg);
+		bmvdbg("Received Request msg : cmd = %d\n", request_msg);
 		switch (request_msg.cmd) {
 #ifdef CONFIG_BINMGR_RECOVERY
 		case BINMGR_FAULT:

--- a/os/kernel/binary_manager/binary_manager_binfile.c
+++ b/os/kernel/binary_manager/binary_manager_binfile.c
@@ -236,7 +236,7 @@ int binary_manager_create_entry(int requester_pid, char *bin_name, int version)
 		goto send_result;
 	}
 
-	/* If it is kernel, Return the devname of inacive kernel partition */
+	/* If it is kernel, Return the devname of inactive kernel partition */
 	if (!strncmp("kernel", bin_name, BIN_NAME_MAX)) {
 		kerinfo = binary_manager_get_kdata();
 		if (kerinfo->part_count > 1) {

--- a/os/kernel/binary_manager/binary_manager_callback.c
+++ b/os/kernel/binary_manager/binary_manager_callback.c
@@ -249,7 +249,7 @@ int binary_manager_send_statecb_msg(int recv_binidx, char *bin_name, uint8_t sta
 	}
 
 	if (need_response) {
-		bmvdbg("Wait repsonse count %d !\n", send_count);
+		bmvdbg("Wait response count %d !\n", send_count);
 		while (send_count > 0) {
 			ret = mq_receive(recv_mq, (char *)&response_msg, sizeof(binmgr_statecb_response_t), NULL);
 			if (ret == sizeof(binmgr_statecb_response_t)) {


### PR DESCRIPTION
Fix typo in binary_manager.c, binary_manager_binfile.c and binary_manager_callback.c