### PR TITLE
apps/examples/stack_protection: Resolve warnings

### DIFF
--- a/apps/examples/stack_protection/stack_protection_main.c
+++ b/apps/examples/stack_protection/stack_protection_main.c
@@ -78,9 +78,11 @@ int stack_prot_main(int argc, char *argv[])
 #endif
 {
 	char ch;
-	char *ptr;
 	int i = 0;
+#if defined(CONFIG_MPU_STACK_OVERFLOW_PROTECTION)
+	char *ptr;
 	char array_normal[STACK_NORMAL_SIZE];
+#endif
 
 	printf("Stack Overflow Protection testcase!!\n");
 


### PR DESCRIPTION
This patch resolves unused variable warnings in stack protection test code.

Signed-off-by: Vidisha <thapa.v@samsung.com>