### PR TITLE
kernel/preference: Support private preference by task group

### DIFF
--- a/framework/src/preference/preference_init.c
+++ b/framework/src/preference/preference_init.c
@@ -36,6 +36,7 @@ int preference_init(void)
 		prefdbg("mkdir fail, %d\n", errno);
 		return PREFERENCE_IO_ERROR;
 	}
+#if CONFIG_TASK_NAME_SIZE > 0
 
 	/* Make private preference directory */
 	ret = mkdir(PREF_PRIVATE_PATH, 0777);
@@ -43,6 +44,7 @@ int preference_init(void)
 		prefdbg("mkdir fail, %d\n", errno);
 		return PREFERENCE_IO_ERROR;
 	}
+#endif
 
 	/* Make shared preference directory */
 	ret = mkdir(PREF_SHARED_PATH, 0777);

--- a/os/include/tinyara/preference.h
+++ b/os/include/tinyara/preference.h
@@ -56,6 +56,7 @@ enum preference_result_error_e {
 	PREFERENCE_OPERATION_FAIL = -6,
 	PREFERENCE_NOT_REGISTERED = -7,
 	PREFERENCE_INVALID_DATA = -8,
+	PREFERENCE_NOT_SUPPORTED = -9,
 };
 
 #define PRIVATE_PREFERENCE     0
@@ -79,7 +80,7 @@ struct value_attr_s {
 typedef struct value_attr_s value_attr_t;
 
 struct preference_data_s {
-	char *key;
+	const char *key;
 	int type;
 	value_attr_t attr;
 	void *value;

--- a/os/include/tinyara/sched.h
+++ b/os/include/tinyara/sched.h
@@ -490,6 +490,14 @@ struct task_group_s {
 
 	struct group_shm_s tg_shm;	/* Task shared memory logic                 */
 #endif
+
+#if defined(CONFIG_PREFERENCE) && CONFIG_TASK_NAME_SIZE > 0
+	/* Preference **************************************************************** */
+	/* The values of private preference are managed by task group.
+	 * Each 'value' is saved in a file named 'key' and they are located in a directory /mnt/private/<tg_name>.
+	 */
+	char tg_name[CONFIG_TASK_NAME_SIZE + 1]; /* Group name (with NULL terminator)  */
+#endif
 };
 #endif
 

--- a/os/kernel/group/group_create.c
+++ b/os/kernel/group/group_create.c
@@ -60,6 +60,9 @@
 #include <assert.h>
 #include <errno.h>
 #include <debug.h>
+#if defined(CONFIG_PREFERENCE) && CONFIG_TASK_NAME_SIZE > 0
+#include <string.h>
+#endif
 
 #include <tinyara/kmalloc.h>
 
@@ -321,7 +324,13 @@ int group_initialize(FAR struct task_tcb_s *tcb)
 	irqrestore(flags);
 
 #endif
+#if defined(CONFIG_PREFERENCE) && CONFIG_TASK_NAME_SIZE > 0
+	/* The values of private preference are managed by task group.
+	 * Set a name of task group, tg_name for private preference. */
 
+	strncpy(group->tg_name, tcb->cmn.name, strlen(tcb->cmn.name) + 1);
+
+#endif
 	/* Save the ID of the main task within the group of threads.  This needed
 	 * for things like SIGCHILD.  It ID is also saved in the TCB of the main
 	 * task but is also retained in the group which may persist after the main


### PR DESCRIPTION
The values of private preference are managed by task group.
Each 'value' is saved in a file named 'key' and they are located in a directory /mnt/private/<tg_name>.