### PR TITLE
lib/libc : Modify malloc to lib_malloc in stdio and unistd

### DIFF
--- a/lib/libc/stdio/lib_vasprintf.c
+++ b/lib/libc/stdio/lib_vasprintf.c
@@ -158,7 +158,7 @@ int vasprintf(FAR char **ptr, const char *fmt, va_list ap)
 	 * for the null terminator.
 	 */
 
-	buf = (FAR char *)malloc(nulloutstream.nput + 1);
+	buf = (FAR char *)lib_malloc(nulloutstream.nput + 1);
 	if (!buf) {
 		return ERROR;
 	}

--- a/lib/libc/unistd/lib_execl.c
+++ b/lib/libc/unistd/lib_execl.c
@@ -61,6 +61,8 @@
 #include <unistd.h>
 #include <errno.h>
 
+#include "lib_internal.h"
+
 #ifdef CONFIG_LIBC_EXECFUNCS
 
 /****************************************************************************
@@ -178,7 +180,7 @@ int execl(FAR const char *path, ...)
 	/* Allocate a temporary argv[] array */
 
 	if (nargs > 0) {
-		argv = (FAR char **)malloc((nargs + 1) * sizeof(FAR char *));
+		argv = (FAR char **)lib_malloc((nargs + 1) * sizeof(FAR char *));
 		if (argv == (FAR char **)NULL) {
 			set_errno(ENOMEM);
 			return ERROR;
@@ -202,7 +204,7 @@ int execl(FAR const char *path, ...)
 	/* Free the allocated argv[] list */
 
 	if (argv) {
-		free(argv);
+		lib_free(argv);
 	}
 
 	return ret;


### PR DESCRIPTION
libc can be used from kernel and user, so it should use lib_Xalloc instead of Xalloc.