### PR TITLE
libc/network: remove assert in freeaddrinfo()

### DIFF
--- a/lib/libc/netdb/lib_freeaddrinfo.c
+++ b/lib/libc/netdb/lib_freeaddrinfo.c
@@ -50,7 +50,10 @@
 #ifdef CONFIG_NET_LWIP_NETDB
 void freeaddrinfo(FAR struct addrinfo *ai)
 {
-	DEBUGASSERT(ai != NULL);
+	if (!ai) {
+		printf("ai is null\n");
+		return;
+	}
 
 	int ret = -1;
 	struct req_lwip_data req;


### PR DESCRIPTION
It's dangerous to call assert(). furthermore linux doens't make
crash when freeaddrinfo() receive null. so libc prints error log
instead of calling assert()