### PR TITLE
kernel/clock: remove up_rtc_settime in clock_settime

### DIFF
--- a/os/kernel/clock/clock_settime.c
+++ b/os/kernel/clock/clock_settime.c
@@ -61,7 +61,6 @@
 #include <errno.h>
 #include <debug.h>
 
-#include <tinyara/arch.h>
 #include <arch/irq.h>
 
 #include "clock/clock.h"
@@ -153,13 +152,6 @@ int clock_settime(clockid_t clock_id, FAR const struct timespec *tp)
 		g_basetime.tv_nsec -= bias.tv_nsec;
 		g_basetime.tv_sec  -= bias.tv_sec;
 
-		/* Setup the RTC (lo- or high-res) */
-
-#ifdef CONFIG_RTC
-		if (g_rtc_enabled) {
-			up_rtc_settime(tp);
-		}
-#endif
 		irqrestore(flags);
 
 		svdbg("basetime=(%ld,%lu) bias=(%ld,%lu)\n", (long)g_basetime.tv_sec, (unsigned long)g_basetime.tv_nsec, (long)bias.tv_sec, (unsigned long)bias.tv_nsec);


### PR DESCRIPTION
Currently clock_settime calls up_rtc_settime with g_rtc_enabled conditional.
It means when we set the time, both system time and rtc time are set.
But there is no way to adjust system time alone. In our usage,
we get the time from server and then set the RTC time. Every few seconds,
we adjust system time using rtc time. But adjusting system time causes
rtc time re-setting. At that time, because of some additional code, rtc time
gets small time difference. It causes big time difference after few hours.
Let's make clock_settime to set system time only. When we want to set
RTC time, let's use RTC driver.

Signed-off-by: sunghan-chang <sh924.chang@samsung.com>