### PR TITLE
Kernel Thread Stack Overflow Protection Testcase

### DIFF
--- a/apps/examples/stack_protection/Kconfig
+++ b/apps/examples/stack_protection/Kconfig
@@ -6,6 +6,7 @@
 config EXAMPLES_STACK_PROTECTION
 	bool "Stack Protection Test Example"
 	depends on (MPU_STACK_OVERFLOW_PROTECTION || REG_STACK_OVERFLOW_PROTECTION)
+	select DRIVERS_KERNEL_TEST
 	---help---
 		Enable the Stack Overflow Protection Test Example
 

--- a/os/drivers/kernel_test/Make.defs
+++ b/os/drivers/kernel_test/Make.defs
@@ -39,6 +39,10 @@ ifeq ($(CONFIG_ARMV8M_TRUSTZONE),y)
 CSRCS += test_tz.c
 endif
 
+ifeq ($(CONFIG_EXAMPLES_STACK_PROTECTION),y)
+CSRCS += test_kthread_stack_protection.c
+endif
+
 CFLAGS += -I$(TOPDIR)/kernel
 
 # Include kernel test driver support

--- a/os/drivers/kernel_test/kernel_test_drv.c
+++ b/os/drivers/kernel_test/kernel_test_drv.c
@@ -176,6 +176,11 @@ static int kernel_test_drv_ioctl(FAR struct file *filep, int cmd, unsigned long 
 		break;
 #endif
 
+#ifdef CONFIG_EXAMPLES_STACK_PROTECTION
+	case TESTIOC_KTHREAD_STACK_PROTECTION_TEST:
+		ret = test_kthread_stack_overflow_protection(cmd, arg);
+		break;
+#endif
 	default:
 		vdbg("Unrecognized cmd: %d arg: %ld\n", cmd, arg);
 		break;

--- a/os/drivers/kernel_test/kernel_test_proto.h
+++ b/os/drivers/kernel_test/kernel_test_proto.h
@@ -31,4 +31,7 @@ int test_compress_decompress(int cmd, unsigned long arg);
 #ifdef CONFIG_ARMV8M_TRUSTZONE
 int test_tz(void);
 #endif
+#ifdef CONFIG_EXAMPLES_STACK_PROTECTION
+int test_kthread_stack_overflow_protection(int cmd, unsigned long arg);
+#endif
 #endif

--- a/os/drivers/kernel_test/test_kthread_stack_protection.c
+++ b/os/drivers/kernel_test/test_kthread_stack_protection.c
@@ -1,0 +1,169 @@
+/****************************************************************************
+ *
+ * Copyright 2020 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <tinyara/config.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <tinyara/kernel_test_drv.h>
+#include <debug.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <semaphore.h>
+#include <tinyara/kthread.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+#define	KTHREAD_STACK_NORMAL_SIZE		300
+#define	KTHREAD_STACK_OVERFLOW_SIZE		4096
+
+/****************************************************************************
+ * Private Declarations
+ ****************************************************************************/
+
+static sem_t test_kthread_stack_sem;
+
+/****************************************************************************
+ * Private Function
+ ****************************************************************************/
+
+#if defined(CONFIG_REG_STACK_OVERFLOW_PROTECTION)
+static void kthread_stack_overflow_array(void)
+{
+	volatile char array_normal[KTHREAD_STACK_OVERFLOW_SIZE];
+
+	array_normal[0] = 'a';
+}
+
+static void kthread_stack_prot_inlimit(void)
+{
+	char array_normal[KTHREAD_STACK_NORMAL_SIZE];
+
+	array_normal[0] = 'a';
+}
+
+static void kthread_stack_overflow_func(int *val)
+{
+	char *ptr;
+	int i = 0;
+	volatile char array_normal[KTHREAD_STACK_NORMAL_SIZE];
+
+	ptr = &array_normal[KTHREAD_STACK_NORMAL_SIZE];
+	for (i = 0; i < KTHREAD_STACK_NORMAL_SIZE; i++) {
+		*ptr = 'a';
+		ptr = ptr - 1;
+	}
+
+	*val = *val + 1;
+	if (*val == (KTHREAD_STACK_OVERFLOW_SIZE / KTHREAD_STACK_NORMAL_SIZE)) {
+		return;
+	}
+	/* recursive call to create stack overflow condition */
+	kthread_stack_overflow_func(val);
+}
+#endif
+
+static int kernel_thread_stack_protection_test(int argc, FAR char *argv[])
+{
+	char ch = argv[1][0];
+	char *ptr;
+	int i = 0;
+	char array_normal[KTHREAD_STACK_NORMAL_SIZE];
+
+#if defined(CONFIG_MPU_STACK_OVERFLOW_PROTECTION)
+	if (ch == 'N' || ch == 'n') {
+		dbg("Test Stack access within range\n");
+		ptr = &array_normal[KTHREAD_STACK_NORMAL_SIZE];
+		for (i = 0; i < KTHREAD_STACK_NORMAL_SIZE; i++) {
+			*ptr = 'a';
+			ptr = ptr - 1;
+		}
+		dbg(" Test stack access within range - Passed !!\n");
+	} else if (ch == 'O' || ch == 'o') {
+		dbg("Test Stack access in overflow\n");
+		ptr = &array_normal[KTHREAD_STACK_NORMAL_SIZE];
+		for (i = 0; i < KTHREAD_STACK_OVERFLOW_SIZE; i++) {
+			*ptr = 'b';
+			ptr = ptr - 1;
+		}
+		dbg(" Test stack access in overflow - Failed !!\n");
+	}
+#elif defined(CONFIG_REG_STACK_OVERFLOW_PROTECTION)
+
+	if (ch == 'N' || ch == 'n') {
+		dbg("Test Stack access within range\n");
+		kthread_stack_prot_inlimit();
+		dbg(" Test stack access within range using array size - Passed !!\n");
+	} else if (ch == 'A' || ch == 'a') {
+		dbg("Test Overflow using array declaration\n");
+		kthread_stack_overflow_array();
+		dbg(" Test stack access in overflow - Failed !!\n");
+	} else if (ch == 'F' || ch == 'f') {
+		dbg("Test Overflow using recursive function\n");
+		kthread_stack_overflow_func(&i);
+		dbg(" Test stack access in overflow - Failed !!\n");
+	}
+#endif
+
+	(void)sem_post(&test_kthread_stack_sem);
+
+	return 0;
+}
+
+static int create_kernel_thread_for_stack_protection_test(unsigned long arg)
+{
+	int pid;
+	char *argv[2];
+	argv[1] = NULL;
+	argv[0] = (char *)arg;
+
+	sem_init(&test_kthread_stack_sem, 0, 0);
+
+	pid = kernel_thread("kthread_stack_prot_test", SCHED_PRIORITY_DEFAULT, 1024, kernel_thread_stack_protection_test, argv);
+	if (pid < 0) {
+		dbg("Failed to start kernel_thread_stack_protection_test thread\n");
+		sem_destroy(&test_kthread_stack_sem);
+		return -1;
+	}
+
+	sem_wait(&test_kthread_stack_sem);
+	sem_destroy(&test_kthread_stack_sem);
+
+	return 0;
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+int test_kthread_stack_overflow_protection(int cmd, unsigned long arg)
+{
+	int ret = -EINVAL;
+
+	switch (cmd) {
+	case TESTIOC_KTHREAD_STACK_PROTECTION_TEST:
+		ret = create_kernel_thread_for_stack_protection_test(arg);
+		break;
+	}
+	return ret;
+}

--- a/os/include/tinyara/kernel_test_drv.h
+++ b/os/include/tinyara/kernel_test_drv.h
@@ -78,6 +78,9 @@
 #ifdef CONFIG_ARMV8M_TRUSTZONE
 #define TESTIOC_TZ				_TESTIOC(21)
 #endif
+#ifdef CONFIG_EXAMPLES_STACK_PROTECTION
+#define TESTIOC_KTHREAD_STACK_PROTECTION_TEST	_TESTIOC(22)
+#endif
 
 #define KERNEL_TEST_DRVPATH                       "/dev/kernel_test"
 


### PR DESCRIPTION
- This PR adds testcase for verifying if Stack Overflow Protection feature works for Kernel thread as well.
- From Application, user is provided option for which feature of Stack Protection to test for Kernel thread.

- Application side code at -> apps/examples/stack_protection
- Testcase driver side code at -> os/drivers/testcase/

Result looks like below:
----------------------------------------------------
```
TASH>>stack_prot
Stack Overflow Protection testcase!!

Press U - Test Stack Protection for User Thread
Press K - Test Stack Protection for Kernel Thread
Press E - Exit the Test ..

Testing for Kernel Thread !!

Press M - Test Stack protection with MPU
Press E - Exit the Test ..

Press N - Test Stack access within range
Press O - Test Stack access in overflow
Press E - Exit the Test ..

kthread_stack_overflow_prot: Test Stack access within range
kthread_stack_overflow_prot:  Test stack access within range - Passed !!

Press M - Test Stack protection with MPU
Press E - Exit the Test ..
```
----------------------------------------------------

**### Note:**
**Pending Changes:** 
Will create a new PR to add missing condition check for NOR flash case in is_kernel_space.
Without this change, fault in kernel thread is not being identified as is_kernel_fault in up_assert for RTK.
These required changes are not related to testcase. This testcase is working as expected.