### PR TITLE
os/binfmt/libelf/libelf_read.c: Fix build warning

### DIFF
--- a/os/binfmt/libelf/libelf_read.c
+++ b/os/binfmt/libelf/libelf_read.c
@@ -184,6 +184,7 @@ int elf_read(FAR struct elf_loadinfo_s *loadinfo, FAR uint8_t *buffer, size_t re
 #endif
 			} else {
 				berr("No support for decompression of compression format %d of this binary\n", loadinfo->compression_type);
+				return ERROR;
 			}
 #else
 			berr("No support for reading compressed binaries\n");


### PR DESCRIPTION
- Add fix for below build warning:
-------------------------------------------------------
```
libelf/libelf_read.c: In function 'elf_read':
libelf/libelf_read.c:204:13: warning: 'nbytes' may be used uninitialized in this function [-Wmaybe-uninitialized]
    readsize -= nbytes;
```
-------------------------------------------------------

Signed-off-by: Amandeep Chauhan <a.chauhan@samsung.com>