### PR TITLE
kernel/binary_manager: Set OK value on success in binary_manager_execute_loader

### DIFF
--- a/os/kernel/binary_manager/binary_manager.c
+++ b/os/kernel/binary_manager/binary_manager.c
@@ -112,7 +112,7 @@ int binary_manager(int argc, char *argv[])
 
 	/* Execute loading thread for load all binaries */
 	ret = binary_manager_execute_loader(LOADCMD_LOAD_ALL, 0);
-	if (ret <= 0) {
+	if (ret != OK) {
 		bmdbg("Failed to create loading thread\n");
 		goto binary_manager_exit;
 	}

--- a/os/kernel/binary_manager/binary_manager_load.c
+++ b/os/kernel/binary_manager/binary_manager_load.c
@@ -421,7 +421,7 @@ static int loadingall_thread(int argc, char *argv[])
 	for (bin_idx = 1; bin_idx <= bin_count; bin_idx++) {
 		if (BIN_LOAD_PRIORITY(bin_idx, BIN_USEIDX(bin_idx)) < BINARY_LOADPRIO_HIGH) {
 			ret = binary_manager_execute_loader(LOADCMD_LOAD, bin_idx);
-			if (ret > 0) {
+			if (ret == OK) {
 				load_cnt++;
 			}
 		}
@@ -707,8 +707,9 @@ int binary_manager_execute_loader(int cmd, int bin_idx)
 	ret = kernel_thread(LOADER_NAME, loader_priority, LOADER_STACKSIZE, loader_func, (char * const *)loading_data);
 	if (ret > 0) {
 		bmvdbg("Execute loading thread with pid %d\n", ret);
+		ret = OK;
 	} else {
-		bmdbg("Loading Fail\n");
+		bmdbg("Loading Fail, errno %d\n", errno);
 	}
 
 	return ret;

--- a/os/kernel/binary_manager/binary_manager_recovery.c
+++ b/os/kernel/binary_manager/binary_manager_recovery.c
@@ -340,7 +340,7 @@ void binary_manager_recovery(int bin_idx)
 	/* Create loader to reload binary */
 	BIN_STATE(bin_idx) = BINARY_FAULT;
 	ret = binary_manager_execute_loader(LOADCMD_RELOAD, bin_idx);
-	if (ret > 0) {
+	if (ret == OK) {
 		abort_mode = false;
 		bmllvdbg("Loading thread with pid %d will reload binaries!\n", ret);
 		return;


### PR DESCRIPTION
Set OK value on success in binary_manager_execute_loader and fix condition for checking result returned from it.