### PR TITLE
Reserve MPU regions

### DIFF
--- a/os/arch/arm/src/common/up_createstack.c
+++ b/os/arch/arm/src/common/up_createstack.c
@@ -299,8 +299,9 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
 #endif
 		board_led_on(LED_STACKCREATED);
 #ifdef CONFIG_MPU_STACK_OVERFLOW_PROTECTION
+		uint8_t nregion = mpu_get_nregion_info(MPU_REGION_STACKOVF);
 		/* The smallest size that can be programmed for an MPU region is 32 bytes */
-		mpu_get_register_config_value(&tcb->stack_mpu_regs[0], MPU_REG_NUM_STK,
+		mpu_get_register_config_value(&tcb->stack_mpu_regs[0], nregion - 1,
 			(uint32_t)tcb->stack_alloc_ptr, CONFIG_MPU_STACK_GUARD_SIZE, true, false);
 #endif
 

--- a/os/arch/arm/src/common/up_mpuinit.c
+++ b/os/arch/arm/src/common/up_mpuinit.c
@@ -38,6 +38,7 @@
  ****************************************************************************/
 
 #include <tinyara/config.h>
+#include <tinyara/mpu.h>
 
 #include <assert.h>
 
@@ -50,10 +51,95 @@
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
+static struct mpu_usages_s g_mpu_region_usages;
+
+#ifdef CONFIG_ARMV7M_MPU
+#define MPU_MAX_NREGION		CONFIG_ARMV7M_MPU_NREGIONS
+#elif defined(CONFIG_ARMV8M_MPU)
+#define MPU_MAX_NREGION		CONFIG_ARMV8M_MPU_NREGIONS
+#endif
 
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
+
+/****************************************************************************
+ * Name: mpu_region_initialize
+ *
+ * Description:
+ *   Initialize the MPU region numbers.
+ *
+ ****************************************************************************/
+
+void mpu_region_initialize(struct mpu_usages_s *mpu)
+{
+	uint8_t offset = (struct mpu_usages_s *)mpu->nregion_board_specific;
+
+#ifdef CONFIG_SUPPORT_COMMON_BINARY
+	offset += MPU_NUM_REGIONS;
+	mpu->nregion_common_bin = offset;
+#endif
+
+#ifdef CONFIG_APP_BINARY_SEPARATION
+	offset += MPU_NUM_REGIONS;
+	mpu->nregion_app_bin = offset;
+#endif
+
+#ifdef CONFIG_MPU_STACK_OVERFLOW_PROTECTION
+	offset += 1;
+	mpu->nregion_stackovf = offset;
+#endif
+	mpu->max_nregion = offset;
+}
+
+/****************************************************************************
+ * Name: mpu_get_nregion_info
+ *
+ * Description:
+ *   Get the MPU region numbers.
+ *
+ ****************************************************************************/
+
+uint8_t mpu_get_nregion_info(enum mpu_region_usages_e usages)
+{
+	uint8_t nregion;
+	switch (usages) {
+	case MPU_REGION_BOARD_SPECIFIC:
+		nregion = g_mpu_region_usages.nregion_board_specific;
+		break;
+	case MPU_REGION_COMMON_BIN:
+		nregion = g_mpu_region_usages.nregion_common_bin;
+		break;
+	case MPU_REGION_APP_BIN:
+		nregion = g_mpu_region_usages.nregion_app_bin;
+		break;
+	case MPU_REGION_STACKOVF:
+		nregion = g_mpu_region_usages.nregion_stackovf;
+		break;
+	case MPU_REGION_MAX:
+		nregion = g_mpu_region_usages.max_nregion;
+		break;
+	default:
+		nregion = 0;
+		break;
+	}
+
+	return nregion;
+}
+
+/****************************************************************************
+ * Name: mpu_set_nregion_board_specific
+ *
+ * Description:
+ *   Initialize the number of MPU regions for board specific purpose
+ *
+ ****************************************************************************/
+
+void mpu_set_nregion_board_specific(uint8_t num)
+{
+	/* Initialize number of mpu regions for board-specific purpose */
+	g_mpu_region_usages.nregion_board_specific = num;
+}
 
 /****************************************************************************
  * Name: up_mpuinitialize
@@ -66,6 +152,12 @@
 
 void up_mpuinitialize(void)
 {
+	/* Initialize MPU register numbers information */
+	mpu_region_initialize(&g_mpu_region_usages);
+
+	/* Maximum MPU region number sanity check */
+	DEBUGASSERT(g_mpu_region_usages.max_nregion < MPU_MAX_NREGION);
+
 	/* Show MPU information */
 	mpu_showtype();
 

--- a/os/binfmt/binfmt_execmodule.c
+++ b/os/binfmt/binfmt_execmodule.c
@@ -188,15 +188,17 @@ int exec_module(FAR struct binary_s *binp)
 	/* Initialize the MPU registers in tcb with suitable protection values */
 #ifdef CONFIG_ARM_MPU
 #ifdef CONFIG_OPTIMIZE_APP_RELOAD_TIME
+	uint8_t nregion = mpu_get_nregion_info(MPU_REGION_APP_BIN);
+
 	/* Configure text section as RO and executable region */
-	mpu_get_register_config_value(&rtcb->mpu_regs[0], MPU_REG_NUM_APP_TXT, (uintptr_t)binp->alloc[ALLOC_TEXT], binp->textsize, true, true);
+	mpu_get_register_config_value(&rtcb->mpu_regs[0], nregion - 3, (uintptr_t)binp->alloc[ALLOC_TEXT], binp->textsize, true, true);
 	/* Configure ro section as RO and non-executable region */
-	mpu_get_register_config_value(&rtcb->mpu_regs[3], MPU_REG_NUM_APP_RO, (uintptr_t)binp->alloc[ALLOC_RO], binp->rosize, true, false);
+	mpu_get_register_config_value(&rtcb->mpu_regs[3], nregion - 2, (uintptr_t)binp->alloc[ALLOC_RO], binp->rosize, true, false);
 	/* Complete RAM partition will be configured as RW region */
-	mpu_get_register_config_value(&rtcb->mpu_regs[6], MPU_REG_NUM_APP_DATA, (uintptr_t)binp->alloc[ALLOC_DATA], binp->ramsize, false, false);
+	mpu_get_register_config_value(&rtcb->mpu_regs[6], nregion - 1, (uintptr_t)binp->alloc[ALLOC_DATA], binp->ramsize, false, false);
 #else
 	/* Complete RAM partition will be configured as RW region */
-	mpu_get_register_config_value(&rtcb->mpu_regs[0], MPU_REG_NUM_APP, (uintptr_t)binp->ramstart, binp->ramsize, false, true);
+	mpu_get_register_config_value(&rtcb->mpu_regs[0], nregion - 1, (uintptr_t)binp->ramstart, binp->ramsize, false, true);
 #endif
 #endif
 #endif /* CONFIG_APP_BINARY_SEPARATION */

--- a/os/binfmt/binfmt_loadbinary.c
+++ b/os/binfmt/binfmt_loadbinary.c
@@ -187,12 +187,13 @@ int load_binary(int binary_idx, FAR const char *filename, load_attr_t *load_attr
 
 #if (defined(CONFIG_ARMV7M_MPU) || defined(CONFIG_ARMV8M_MPU))
 #ifdef CONFIG_OPTIMIZE_APP_RELOAD_TIME
+		uint8_t nregion = mpu_get_nregion_info(MPU_REGION_COMMON_BIN);
 		/* Get MPU register values for MPU regions */
-		mpu_get_register_config_value(&com_bin_mpu_regs[0], MPU_REG_NUM_COM_LIB_TXT,  (uintptr_t)bin->alloc[ALLOC_TEXT], bin->textsize, true,  true);
-		mpu_get_register_config_value(&com_bin_mpu_regs[3], MPU_REG_NUM_COM_LIB_RO,   (uintptr_t)bin->alloc[ALLOC_RO],   bin->rosize,   true,  false);
-		mpu_get_register_config_value(&com_bin_mpu_regs[6], MPU_REG_NUM_COM_LIB_DATA, (uintptr_t)bin->alloc[ALLOC_DATA], bin->ramsize,  false, false);
+		mpu_get_register_config_value(&com_bin_mpu_regs[0], nregion - 3, (uintptr_t)bin->alloc[ALLOC_TEXT], bin->textsize, true,  true);
+		mpu_get_register_config_value(&com_bin_mpu_regs[3], nregion - 2, (uintptr_t)bin->alloc[ALLOC_RO],   bin->rosize,   true,  false);
+		mpu_get_register_config_value(&com_bin_mpu_regs[6], nregion - 1, (uintptr_t)bin->alloc[ALLOC_DATA], bin->ramsize,  false, false);
 #else
-		mpu_get_register_config_value(&com_bin_mpu_regs[0], MPU_REG_NUM_COM_LIB,      (uintptr_t)bin->ramstart,          bin->ramsize,  false, true);
+		mpu_get_register_config_value(&com_bin_mpu_regs[0], nregion - 1, (uintptr_t)bin->ramstart,          bin->ramsize,  false, true);
 #endif
 		/* Set MPU register values to real MPU h/w */
 		for (int i = 0; i < 3 * MPU_NUM_REGIONS; i += 3) {

--- a/os/board/rtl8721csm/src/component/soc/realtek/amebad/fwlib/ram_hp/rtl8721dhp_app_start.c
+++ b/os/board/rtl8721csm/src/component/soc/realtek/amebad/fwlib/ram_hp/rtl8721dhp_app_start.c
@@ -1338,6 +1338,9 @@ extern void __libc_init_array(void);
 #ifdef CONFIG_PLATFORM_TIZENRT_OS
 	mpu_init();
 	app_mpu_nocache_init();
+
+	/* Initialize number of mpu regions for board specific purpose */
+	mpu_set_nregion_board_specific(1);
 #endif
 	app_vdd1833_detect();
 	memcpy_gdma_init();

--- a/os/include/tinyara/mpu.h
+++ b/os/include/tinyara/mpu.h
@@ -34,11 +34,30 @@
  * Pre-processor Definitions
  ********************************************************************************/
 
+/* Structure for MPU region numbers */
+
+struct mpu_usages_s {
+	uint8_t nregion_board_specific;
+	uint8_t nregion_common_bin;
+	uint8_t nregion_app_bin;
+	uint8_t nregion_stackovf;
+	uint8_t max_nregion;
+};
+
 enum {
 	REG_RNR,
 	REG_RBAR,
 	REG_RASR,
 	REG_MAX
+};
+
+/* Enum to to get MPU region number info for MPU usages */
+enum mpu_region_usages_e {
+	MPU_REGION_BOARD_SPECIFIC,
+	MPU_REGION_COMMON_BIN,
+	MPU_REGION_APP_BIN,
+	MPU_REGION_STACKOVF,
+	MPU_REGION_MAX
 };
 
 #ifdef CONFIG_OPTIMIZE_APP_RELOAD_TIME
@@ -47,47 +66,10 @@ enum {
 #define MPU_NUM_REGIONS		1
 #endif
 
-/* Enum for MPU region numbers */
-
-enum MPU_REG_NUM {
-#ifdef CONFIG_APP_BINARY_SEPARATION
-#ifdef CONFIG_SUPPORT_COMMON_BINARY
-#ifdef CONFIG_OPTIMIZE_APP_RELOAD_TIME
-	MPU_REG_NUM_COM_LIB_TXT,	/* Common Binary */
-	MPU_REG_NUM_COM_LIB_RO,
-	MPU_REG_NUM_COM_LIB_DATA,
-#else
-	MPU_REG_NUM_COM_LIB,
+#ifdef CONFIG_ARMV8M_MPU
+#define MPU_ALIGNMENT_BYTES    32
+#define MPU_ALIGN_UP(a)                (((a) + MPU_ALIGNMENT_BYTES - 1) & ~(MPU_ALIGNMENT_BYTES - 1))
 #endif
-#endif
-#ifdef CONFIG_OPTIMIZE_APP_RELOAD_TIME
-	MPU_REG_NUM_APP_TXT,		/* Apps */
-	MPU_REG_NUM_APP_RO,
-	MPU_REG_NUM_APP_DATA,
-#else
-	MPU_REG_NUM_APP,
-#endif
-#endif
-#ifdef CONFIG_MPU_STACK_OVERFLOW_PROTECTION
-	MPU_REG_NUM_STK,		/* Stack */
-#endif
-	MPU_REG_NUM_MAX
-};
-
-#ifdef CONFIG_ARMV7M_MPU
-#define CUR_MPU_REG_NUM		CONFIG_ARMV7M_MPU_NREGIONS
-#elif defined(CONFIG_ARMV8M_MPU)
-#define CUR_MPU_REG_NUM		CONFIG_ARMV8M_MPU_NREGIONS
-#define MPU_ALIGNMENT_BYTES	32
-#define MPU_ALIGN_UP(a)		(((a) + MPU_ALIGNMENT_BYTES - 1) & ~(MPU_ALIGNMENT_BYTES - 1))
-#endif
-
-#if defined(CONFIG_ARMV7M_MPU) || defined(CONFIG_ARMV8M_MPU)
-#if (MPU_REG_NUM_MAX >= CUR_MPU_REG_NUM)
-#error "MPU region numbers exceeded !!"
-#endif
-#endif
-
 
 /********************************************************************************
  * Public Function Prototypes
@@ -100,5 +82,11 @@ void up_mpu_set_register(uint32_t *mpu_regs);
 bool up_mpu_check_active(uint32_t *mpu_regs);
 
 void up_mpu_disable_region(uint32_t *mpu_regs);
+
+void mpu_region_initialize(struct mpu_usages_s *mpu);
+
+void mpu_set_nregion_board_specific(uint8_t num);
+
+uint8_t mpu_get_nregion_info(enum mpu_region_usages_e usages);
 
 #endif


### PR DESCRIPTION
This PR adds support to reserve MPU regions by the vendor. (CONFIG_MPU_RESERVED)
In such a scenario, the TizenRT MPU configurations will be done past the reserved MPU regions.
It adds the following API's to mpuinit.c
mpu_get_region_info(), mpu_set_region_info(), mpu_regs_initialize()