### PR TITLE
arch/arm/src/amebad: Fix build error for RDP config

### DIFF
--- a/os/arch/arm/src/amebad/Kconfig
+++ b/os/arch/arm/src/amebad/Kconfig
@@ -80,7 +80,7 @@ config AMEBAD_RDP
 
 config AMEBAD_RDP_KEY
 	hex "Amebad RDP Key"
-	default 2473040ab47c48655a15aa431c4bbb8a
+	default 0x2473040ab47c48655a15aa431c4bbb8a
 	range 00000000000000000000000000000000 ffffffffffffffffffffffffffffffff
 	depends on AMEBAD_RDP
 


### PR DESCRIPTION
RDP key value is not set properly resulting in below build error.
Set proper HEX value for RDP KEY.

========== Image manipulating start ==========
========== RDP Encryption ==========
*** Error in `./EncTool': munmap_chunk(): invalid pointer: 0x00007ffffa43eb30 ***
======= Backtrace: =========
/lib/x86_64-linux-gnu/libc.so.6(+0x777e5)[0x7ffa421057e5]
/lib/x86_64-linux-gnu/libc.so.6(cfree+0x1a8)[0x7ffa42112698]
./EncTool(+0x1483f)[0x5619b7cd183f]
./EncTool(+0x14956)[0x5619b7cd1956]
/lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0xf0)[0x7ffa420ae830]
./EncTool(+0xd8a)[0x5619b7cbdd8a]

Signed-off-by: Sangamanatha <sangam.swami@samsung.com>