### PR TITLE
kernel/binary_manager: Deactivate RT threads of all binaries in fault handler

### DIFF
--- a/os/arch/arm/src/common/up_checkspace.c
+++ b/os/arch/arm/src/common/up_checkspace.c
@@ -23,6 +23,9 @@
 #include <tinyara/config.h>
 #include <stdbool.h>
 #include <stdint.h>
+#ifdef CONFIG_SUPPORT_COMMON_BINARY
+#include <tinyara/binfmt/binfmt.h>
+#endif
 
 #include "up_internal.h"
 
@@ -45,4 +48,13 @@ bool is_kernel_space(void *addr)
 	return false;
 }
 
+#ifdef CONFIG_SUPPORT_COMMON_BINARY
+bool is_common_library_space(void *addr)
+{
+	if (g_lib_binp && addr >= (void *)g_lib_binp->alloc[ALLOC_TEXT] && addr <= (void *)(g_lib_binp->alloc[ALLOC_TEXT] + g_lib_binp->textsize)) {
+		return true;
+	}
+	return false;
+}
+#endif							/* CONFIG_SUPPORT_COMMON_BINARY */
 #endif							/* CONFIG_BUILD_PROTECTED */

--- a/os/include/tinyara/arch.h
+++ b/os/include/tinyara/arch.h
@@ -2188,6 +2188,18 @@ void up_wdog_keepalive(void);
  *
  ****************************************************************************/
 bool is_kernel_space(void *addr);
+
+#ifdef CONFIG_SUPPORT_COMMON_BINARY
+/****************************************************************************
+ * Name: is_common_library_space
+ *
+ * Description:
+ *   Check the address is in common library space or not
+ *
+ ****************************************************************************/
+bool is_common_library_space(void *addr);
+
+#endif
 #endif
 
 #undef EXTERN

--- a/os/include/tinyara/binfmt/binfmt.h
+++ b/os/include/tinyara/binfmt/binfmt.h
@@ -210,6 +210,11 @@ struct binfmt_s {
  * Public Data
  ****************************************************************************/
 
+#ifdef CONFIG_SUPPORT_COMMON_BINARY
+/* A binary data of common library */
+extern struct binary_s *g_lib_binp;
+#endif
+
 #if defined(__cplusplus)
 extern "C" {
 #endif

--- a/os/kernel/binary_manager/binary_manager.h
+++ b/os/kernel/binary_manager/binary_manager.h
@@ -77,13 +77,8 @@
 #define CHECKSUM_SIZE              4
 #define CRC_BUFFER_SIZE            512
 
-#ifdef CONFIG_SUPPORT_COMMON_BINARY
-/* bin id value of zero will indicate the library */
-#define BM_BINID_LIBRARY	0
-#endif
-
 /* Index of 'Common Library' data in binary table. */
-#define COMMLIB_IDX                0
+#define BM_CMNLIB_IDX              0
 
 /* The number of arguments for loader */
 #define LOADER_ARGC               1

--- a/os/kernel/binary_manager/binary_manager_load.c
+++ b/os/kernel/binary_manager/binary_manager_load.c
@@ -397,7 +397,7 @@ static int loadingall_thread(int argc, char *argv[])
 #ifdef CONFIG_SUPPORT_COMMON_BINARY
 	char libname[CONFIG_NAME_MAX];
 	snprintf(libname, CONFIG_NAME_MAX, "%s%s", CONFIG_COMMON_BINARY_PATH, CONFIG_COMMON_BINARY_NAME);
-	ret = load_binary(COMMLIB_IDX, libname, NULL);
+	ret = load_binary(BM_CMNLIB_IDX, libname, NULL);
 	if (ret < 0) {
 		return BINMGR_OPERATION_FAIL;
 	}
@@ -452,13 +452,13 @@ static int reloading_thread(int argc, char *argv[])
 	/* argv[1] binary index for reloading */
 	int bin_idx = (int)atoi(argv[1]);
 #ifdef CONFIG_SUPPORT_COMMON_BINARY
-	if (bin_idx == BM_BINID_LIBRARY) {
+	if (bin_idx == BM_CMNLIB_IDX) {
 		int ret;
 
 		/* Reload common library and all binaries */
 		char libname[CONFIG_NAME_MAX];
 		snprintf(libname, CONFIG_NAME_MAX, "%s%s", CONFIG_COMMON_BINARY_PATH, CONFIG_COMMON_BINARY_NAME);
-		ret = load_binary(COMMLIB_IDX, libname, NULL);
+		ret = load_binary(BM_CMNLIB_IDX, libname, NULL);
 		if (ret < 0) {
 			return BINMGR_OPERATION_FAIL;
 		}


### PR DESCRIPTION
If a fault happens in common library, All user binaries and library are reloaded.
So all RT threads of all binaries should be deactivated in fault handler.