### PR TITLE
os/board/rtl8721csm: Remove unneeded RTL mpu setting

### DIFF
--- a/os/board/rtl8721csm/src/component/soc/realtek/amebad/fwlib/ram_hp/rtl8721dhp_app_start.c
+++ b/os/board/rtl8721csm/src/component/soc/realtek/amebad/fwlib/ram_hp/rtl8721dhp_app_start.c
@@ -938,6 +938,10 @@ u32 app_mpu_nocache_init(void)
 	mpu_region_config mpu_cfg;
 	u32 mpu_entry = 0;
 
+	/* No cache init */
+	/* It is for wifi related buffer area, to prevent non-sync from happening.
+	*  Because DMA is involved, so it cannot be used together with cache.
+	*/
 	mpu_entry = mpu_entry_alloc();
 	if (wifi_config.km4_cache_enable) {
 		mpu_cfg.region_base = (uint32_t)__ram_nocache_start__;
@@ -953,6 +957,13 @@ u32 app_mpu_nocache_init(void)
 	if (mpu_cfg.region_size >= 32) {
 		mpu_region_cfg(mpu_entry, &mpu_cfg);
 	}
+
+#ifndef CONFIG_PLATFORM_TIZENRT_OS
+	/* The following 3 MPU settings are not in use for TizenRT
+	*  "close 216K irom_ns cache" and "close 80K drom_ns cache" are added to prevent ROM code accessing data through the Cache.
+	*  "set 1KB retention ram no-cache" is for Deep Sleep
+	*  There is no performance drop after removing these 3 MPU setting, Verified.
+	*/
 
 	/* close 216K irom_ns cache */
 	mpu_entry = mpu_entry_alloc();
@@ -982,6 +993,18 @@ u32 app_mpu_nocache_init(void)
 	mpu_cfg.ap = MPU_UN_PRIV_RW;
 	mpu_cfg.sh = MPU_NON_SHAREABLE;
 	mpu_cfg.attr_idx = MPU_MEM_ATTR_IDX_NC;
+	mpu_region_cfg(mpu_entry, &mpu_cfg);
+#endif
+
+	/* set PSRAM Memory Write-Back */
+	/* To prevent data confusion issue in PSRAM */
+	mpu_entry = mpu_entry_alloc();
+	mpu_cfg.region_base = 0x02000000;
+	mpu_cfg.region_size = 0x400000;
+	mpu_cfg.xn = MPU_EXEC_ALLOW;
+	mpu_cfg.ap = MPU_UN_PRIV_RW;
+	mpu_cfg.sh = MPU_NON_SHAREABLE;
+	mpu_cfg.attr_idx = MPU_MEM_ATTR_IDX_WB_T_RWA;
 	mpu_region_cfg(mpu_entry, &mpu_cfg);
 
 	return 0;


### PR DESCRIPTION
- Removed 3 mpu setting "close 216K irom_ns cache", "close 80K drom_ns cache" and "set 1KB retention ram no-cache"
- Added PSRAM mpu setting "set PSRAM Memory Write-Back", to prevent data confusion issue in PSRAM