### PR TITLE
arch/armv8-m: modify tz_context initialization value to 0 in up_svcall.c

### DIFF
--- a/os/arch/arm/src/armv8-m/up_svcall.c
+++ b/os/arch/arm/src/armv8-m/up_svcall.c
@@ -568,7 +568,7 @@ int up_svcall(int irq, FAR void *context, FAR void *arg)
 	case SYS_free_securecontext: {
 		/* Free the secure context. */
 		TZ_FreeModuleContext_S(rtcb->tz_context);
-		rtcb->tz_context = NULL;
+		rtcb->tz_context = 0;
 	}
 	break;
 #endif


### PR DESCRIPTION
The tz_context type is TZ_ModuleId_t which is the same as uint32_t.
So, null is not proper. This causes build warning as below:

CC:  armv8-m/up_svcall.c
armv8-m/up_svcall.c: In function 'up_svcall':
armv8-m/up_svcall.c:571:20: warning: assignment makes integer from pointer without a cast [-Wint-conversion]
   rtcb->tz_context = NULL;
                    ^

Let's change the value to 0 to resolve above.

Signed-off-by: sunghan-chang <sh924.chang@samsung.com>