### PR TITLE
[Realtek][RTL8721CSM] net/netmgr/ : RTL8721CSM loadable apps config bus fault fix

### DIFF
--- a/os/arch/arm/src/amebad/amebad_enet.c
+++ b/os/arch/arm/src/amebad/amebad_enet.c
@@ -193,7 +193,6 @@ struct netdev* amebad_register_dev(int sizeof_priv)
 
 void up_netinitialize(void)
 {
-#ifndef CONFIG_APP_BINARY_SEPARATION
 	int alloc_size;
 	//struct netdev *dev = NULL;
 
@@ -209,5 +208,4 @@ void up_netinitialize(void)
 		DiagPrintf("Failed to register amebad netdev\n");
 	}
 #endif	
-#endif
 }

--- a/os/arch/arm/src/amebad/amebad_serial.c
+++ b/os/arch/arm/src/amebad/amebad_serial.c
@@ -85,6 +85,8 @@
 #include "mbed/targets/hal/rtl8721d/objects.h"
 #include "rtl8721d_uart.h"
 #include "tinyara/kmalloc.h"
+#include "osdep_service.h"
+
 /****************************************************************************
  * Preprocessor Definitions
  ****************************************************************************/

--- a/os/arch/arm/src/amebad/amebad_serial.c
+++ b/os/arch/arm/src/amebad/amebad_serial.c
@@ -412,7 +412,7 @@ static void rtl8721d_up_shutdown(struct uart_dev_s *dev)
 	DEBUGASSERT(priv);
 	DEBUGASSERT(sdrv[uart_index_get(priv->tx)]);
 	serial_free(sdrv[uart_index_get(priv->tx)]);
-	free(sdrv[uart_index_get(priv->tx)]);
+	rtw_free(sdrv[uart_index_get(priv->tx)]);
 	sdrv[uart_index_get(priv->tx)] = NULL;
 }
 

--- a/os/arch/arm/src/amebad/amebad_start.c
+++ b/os/arch/arm/src/amebad/amebad_start.c
@@ -69,7 +69,8 @@
 #include "nvic.h"
 #endif
 
-const uintptr_t g_idle_topstack = (uintptr_t)&_ebss + CONFIG_IDLETHREAD_STACKSIZE;
+#define MSP_RAM_HP_NS		0x10004FFC
+const uintptr_t g_idle_topstack = MSP_RAM_HP_NS;
 
 /****************************************************************************
  * Name: _start

--- a/os/board/rtl8721csm/src/component/common/api/network/src/wlan_network.c
+++ b/os/board/rtl8721csm/src/component/common/api/network/src/wlan_network.c
@@ -141,7 +141,7 @@ static rtw_result_t app_scan_result_handler( rtw_scan_handler_result_t* malloced
 #if defined(CONFIG_INIC_CMD_RSP) && CONFIG_INIC_CMD_RSP
 		inic_c2h_msg("ATWS", RTW_SUCCESS, (char *)malloced_scan_result->user_data, ApNum*sizeof(rtw_scan_result_t));
 		if(malloced_scan_result->user_data)
-			free(malloced_scan_result->user_data);
+			rtw_free(malloced_scan_result->user_data);
 		inic_c2h_msg("ATWS", RTW_SUCCESS, NULL, 0);
 #endif
 #if (defined(CONFIG_EXAMPLE_UART_ATCMD) && CONFIG_EXAMPLE_UART_ATCMD) || (defined(CONFIG_EXAMPLE_SPI_ATCMD) && CONFIG_EXAMPLE_SPI_ATCMD)

--- a/os/board/rtl8721csm/src/component/common/api/wifi/rtw_wpa_supplicant/wpa_supplicant/wifi_wps_config.c
+++ b/os/board/rtl8721csm/src/component/common/api/wifi/rtw_wpa_supplicant/wpa_supplicant/wifi_wps_config.c
@@ -545,7 +545,7 @@ static void clean_discovered_ssids(void)
 
 	for(i = 0; i < DISCOVERED_SSIDS_NUM; i ++) {
 		if(discovered_ssids[i]) {
-			free(discovered_ssids[i]);
+			rtw_free(discovered_ssids[i]);
 			discovered_ssids[i] = NULL;
 		}
 	}
@@ -562,7 +562,7 @@ static void update_discovered_ssids(char *ssid)
 		}
 		else {
 			if(strlen(discovery_ssid) == 0) {
-				discovered_ssids[i] = malloc(strlen(ssid) + 1);
+				discovered_ssids[i] = rtw_malloc(strlen(ssid) + 1);
 				strcpy(discovered_ssids[i], ssid);
 				strcpy(discovery_ssid, ssid);
 				break;
@@ -732,7 +732,7 @@ static u8 wps_scan_cred_ssid(struct dev_credential *dev_cred)
 	scan_buf_arg scan_buf;
 
 	scan_buf.buf_len = 1000;
-	scan_buf.buf = malloc(scan_buf.buf_len);
+	scan_buf.buf = rtw_malloc(scan_buf.buf_len);
 
 	if(scan_buf.buf) {
 		memset(scan_buf.buf, 0, scan_buf.buf_len);
@@ -763,7 +763,7 @@ static u8 wps_scan_cred_ssid(struct dev_credential *dev_cred)
 			}
 		}
 
-		free(scan_buf.buf);
+		rtw_free(scan_buf.buf);
 	}
 	else {
 		// if cannot scan, suppose it can be found
@@ -776,7 +776,7 @@ static u8 wps_scan_cred_ssid(struct dev_credential *dev_cred)
 static void wps_filter_cred_by_scan(struct dev_credential *dev_cred, int cred_cnt)
 {
 	u8 ssid_found_count = 0;
-	u8 *ssid_found_flags = (u8 *) malloc(cred_cnt);
+	u8 *ssid_found_flags = (u8 *) rtw_malloc(cred_cnt);
 
 	if(ssid_found_flags) {
 		int i, times;
@@ -801,7 +801,7 @@ static void wps_filter_cred_by_scan(struct dev_credential *dev_cred, int cred_cn
 				memset(&dev_cred[i], 0, sizeof(struct dev_credential));
 		}
 
-		free(ssid_found_flags);
+		rtw_free(ssid_found_flags);
 	}
 }
 

--- a/os/board/rtl8721csm/src/component/common/api/wifi/wifi_util.c
+++ b/os/board/rtl8721csm/src/component/common/api/wifi/wifi_util.c
@@ -218,7 +218,7 @@ int wext_set_key_ext(const char *ifname, __u16 alg, const __u8 *addr, int key_id
 		RTW_API_INFO("\n\rioctl[SIOCSIWENCODEEXT] set key fail");
 	}
 
-	free(ext);
+	rtw_free(ext);
 
 	return ret;
 }
@@ -251,7 +251,7 @@ int wext_get_enc_ext(const char *ifname, __u16 *alg, __u8 *key_idx, __u8 *passph
 	}
 
 	if(ext != NULL)
-		free(ext);
+		rtw_free(ext);
 	
 	return ret;
 }
@@ -1496,12 +1496,12 @@ int wext_deinit_mac_filter(void)
 	list_for_each(iterator, mf_list_head) {
 		item = list_entry(iterator, rtw_mac_filter_list_t, node);
 		list_del(iterator);
-		free(item);
+		rtw_free(item);
 		item = NULL;
 		iterator = mf_list_head;
 	}
 
-	free(mf_list_head);
+	rtw_free(mf_list_head);
 	mf_list_head = NULL;
 	return 0;
 }
@@ -1536,7 +1536,7 @@ int wext_del_mac_filter(unsigned char* hwaddr)
 		item = list_entry(iterator, rtw_mac_filter_list_t, node);
 		if(memcmp(item->mac_addr,hwaddr,6) == 0){
 			list_del(iterator);
-			free(item);
+			rtw_free(item);
 			item = NULL;
 			return 0;
 		}

--- a/os/board/rtl8721csm/src/component/common/mbed/targets/hal/rtl8721d/sys_api.c
+++ b/os/board/rtl8721csm/src/component/common/mbed/targets/hal/rtl8721d/sys_api.c
@@ -133,7 +133,7 @@ void sys_recover_ota_signature(void)
 	}
 
 	/* Backup first 4KB of the old firmware */
-	buf = malloc(4096);
+	buf = rtw_malloc(4096);
 	ota_readstream_user(DstAddr, 4096, buf);
 
 	/* Modify signature */

--- a/os/net/netmgr/netdev_lwip.c
+++ b/os/net/netmgr/netdev_lwip.c
@@ -617,11 +617,13 @@ static err_t _netif_loopif_init(struct netif *netif)
 
 	netif->name[0] = 'l';
 	netif->name[1] = 'o';
+#if LWIP_HAVE_LOOPIF
 #if LWIP_IPV4
 	netif->output = _netif_loop_output_ipv4;
 #endif
 #if LWIP_IPV6
 	netif->output_ip6 = _netif_loop_output_ipv6;
+#endif
 #endif
 #if LWIP_LOOPIF_MULTICAST
 	netif->flags |= NETIF_FLAG_IGMP;


### PR DESCRIPTION
RTL8721CSM configs loopback disable. 1st commit for the modification of all defconfigs, fix netdev_lwip.c Macros, _netif_loop_output_ipv4 and _netif_loop_output_ipv6 are not defined if LWIP_HAVE_LOOPIF is 0.