### PR TITLE
kernel/group: Always detach the group from the tcb if the tcb has a group

### DIFF
--- a/os/kernel/group/group_leave.c
+++ b/os/kernel/group/group_leave.c
@@ -418,13 +418,13 @@ void group_leave(FAR struct tcb_s *tcb)
 				binfmt_exit(((struct task_tcb_s *)tcb)->bininfo);
 			}
 #endif
-
-			/* In any event, we can detach the group from the TCB so that we won't
-			 * do this again.
-			 */
-
-			tcb->group = NULL;
 		}
+
+		/* In any event, we can detach the group from the TCB so that we won't
+		 * do this again.
+		 */
+
+		tcb->group = NULL;
 	}
 }
 
@@ -483,13 +483,13 @@ void group_leave(FAR struct tcb_s *tcb)
 				binfmt_exit(((struct task_tcb_s *)tcb)->bininfo);
 			}
 #endif
-
-			/* In any event, we can detach the group from the TCB so we won't do
-			 * this again.
-			 */
-
-			tcb->group = NULL;
 		}
+
+		/* In any event, we can detach the group from the TCB so we won't do
+		 * this again.
+		 */
+
+		tcb->group = NULL;
 	}
 }
 


### PR DESCRIPTION
A group_leave function is called when a task or thread exits.
It decrements the reference count of the group and frees all resources of group if the reference count is zero.
Then a group is detached from the tcb regardless of reference count to avoid doing this again.