### PR TITLE
binary_manager, micomapp and wifiapp: adjust the period of alert message

### DIFF
--- a/loadable_apps/loadable_sample/micomapp/micomapp.c
+++ b/loadable_apps/loadable_sample/micomapp/micomapp.c
@@ -63,7 +63,7 @@ int micomapp_main(int argc, char **argv)
 #endif /* CONFIG_EXAMPLES_MICOM_TIMER_TEST */
 
 	while (1) {
-		sleep(10);
+		sleep(300);
 		printf("[%d] MICOM ALIVE\n", getpid());
 	}
 

--- a/loadable_apps/loadable_sample/wifiapp/wifiapp.c
+++ b/loadable_apps/loadable_sample/wifiapp/wifiapp.c
@@ -120,7 +120,7 @@ int wifiapp_main(int argc, char **argv)
 
 #endif /* CONFIG_EXAMPLES_MICOM_TIMER_TEST */
 	while (1) {
-		sleep(10);
+		sleep(300);
 		printf("[%d] WIFI ALIVE\n", getpid());
 	}
 	return 0;

--- a/os/kernel/binary_manager/binary_manager_recovery.c
+++ b/os/kernel/binary_manager/binary_manager_recovery.c
@@ -87,7 +87,7 @@ static void binary_manager_reset_board(void)
 	sched_lock();
 	for (;;) {
 		lldbg("\nASSERT!! Push the reset button!\n");
-		up_mdelay(10000);
+		up_mdelay(300000);  // Print the message every 5 min
 	}
 #endif
 }


### PR DESCRIPTION
1. Every 10 sec, micom and wifi binaries prints the alive message.
It's not good to use TASH.
Let's adjust the period from 10 secs to 5 mins.
2. The binary_manager_reset_board() resets the board when CONFIG_BOARDCTL_RESET
is enabled, but it just waits after printing the message every 10 sec with
CONFIG_BOARDCTL_RESET disabled.
Message at every 10 sec disturbs checking the debug messages.
Let's increase the period from 10 secs to 5 mins.