### PR TITLE
arch/arm: set the default value of FPU config as n

### DIFF
--- a/os/arch/arm/Kconfig
+++ b/os/arch/arm/Kconfig
@@ -184,7 +184,7 @@ config ARCH_HAVE_LAZYFPU
 
 config ARCH_FPU
 	bool "FPU support"
-	default y
+	default n
 	depends on ARCH_HAVE_FPU
 	---help---
 		Build in support for the ARM Cortex-M4 Floating Point Unit (FPU).


### PR DESCRIPTION
Even a board supports FPU, it's not mandatory feature.
It might cause performance degradation so that it should be
defaultly disabled. When it needs, we can enable.

Signed-off-by: sunghan-chang <sh924.chang@samsung.com>