### PR TITLE
remove env for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,9 +23,6 @@ matrix:
     - env: BUILD_CONFIG=artik055s/audio
     - env: BUILD_CONFIG=artik053/st_things
     - env: BUILD_CONFIG=artik053/tc
-    - env: BUILD_CONFIG=artik053/iotjs
-    - env: BUILD_CONFIG=artik053/minimal
-    - env: BUILD_CONFIG=qemu/tc_64k
     - env: BUILD_CONFIG=qemu/build_test
     - env: BUILD_CONFIG=esp_wrover_kit/hello_with_tash
     - env: BUILD_CONFIG=imxrt1020-evk/loadable_elf_apps


### PR DESCRIPTION
remove env for travis

remove list,
    - env: BUILD_CONFIG=artik053/iotjs	
    - env: BUILD_CONFIG=artik053/minimal	
    - env: BUILD_CONFIG=qemu/tc_64k

Signed-off-by: jaesick.shin <jaesick.shin@samsung.com>