### PR TITLE
apps/performance/syscall : Add sched lock and unlock for every tests

### DIFF
--- a/apps/examples/performance/syscall/syscall_performance_main.c
+++ b/apps/examples/performance/syscall/syscall_performance_main.c
@@ -20,6 +20,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <sched.h>
 #include <errno.h>
 #include <time.h>
 #include <tinyara/time.h>
@@ -178,25 +179,39 @@ static void syscall_perf_timer_settime(void)
 int syscall_performance_main(void)
 {
 	/* System Call 0 */
+	sched_lock();
 	syscall_perf_clearenv();
+	sched_unlock();
 
 	/* System Call 1 */
+	sched_lock();
 	syscall_perf_unsetenv();
+	sched_unlock();
 
 	/* System Call 2 */
+	sched_lock();
 	syscall_perf_clock_getres();
+	sched_unlock();
 
 	/* System Call 3 */
+	sched_lock();
 	syscall_perf_setenv();
+	sched_unlock();
 
 	/* System Call 4 */
+	sched_lock();
 	syscall_perf_timer_settime();
+	sched_unlock();
 
 	/* System Call 5 */
+	sched_lock();
 	syscall_perf_mq_timedsend();
+	sched_unlock();
 
 	/* System Call 6 */
+	sched_lock();
 	syscall_perf_mq_open();
+	sched_unlock();
 
 	return 0;
 }


### PR DESCRIPTION
Each test can be interfered by another threads because of scheduling.
For precise performance measurement, lock the scheduling on every tests.