### PR TITLE
board/rtl8721csm/app_start.c : Disable PSRAM MPU setting

### DIFF
--- a/os/board/rtl8721csm/src/component/soc/realtek/amebad/fwlib/ram_hp/rtl8721dhp_app_start.c
+++ b/os/board/rtl8721csm/src/component/soc/realtek/amebad/fwlib/ram_hp/rtl8721dhp_app_start.c
@@ -996,6 +996,7 @@ u32 app_mpu_nocache_init(void)
 	mpu_region_cfg(mpu_entry, &mpu_cfg);
 #endif
 
+#if 0 //fix me!
 	/* set PSRAM Memory Write-Back */
 	/* To prevent data confusion issue in PSRAM */
 	mpu_entry = mpu_entry_alloc();
@@ -1006,6 +1007,7 @@ u32 app_mpu_nocache_init(void)
 	mpu_cfg.sh = MPU_NON_SHAREABLE;
 	mpu_cfg.attr_idx = MPU_MEM_ATTR_IDX_WB_T_RWA;
 	mpu_region_cfg(mpu_entry, &mpu_cfg);
+#endif
 
 	return 0;
 }


### PR DESCRIPTION
With PSRAM MPU setting, binary manager cannot load the user binary.
So temporarily disable PSRAM MPU setting.