### PR TITLE
arch/arm/armv8-m : Fix performance issue due to cache setting

### DIFF
--- a/os/arch/arm/src/armv8-m/up_mpu.c
+++ b/os/arch/arm/src/armv8-m/up_mpu.c
@@ -169,7 +169,11 @@ void mpu_get_register_config_value(uint32_t *regs, uint32_t region, uintptr_t ba
 	}
 
 	regs[2] = (base + size - 1) & MPU_RLAR_LIMIT_MASK;
+#ifdef CONFIG_ARMV8M_DCACHE
+	regs[2] |= MPU_MAIR_IDX(MPU_MEM_ATTR_IDX_WB_T_RWA);
+#else
 	regs[2] |= MPU_MAIR_IDX(MPU_MEM_ATTR_IDX_NC);
+#endif
 	regs[2] |= MPU_RLAR_ENABLE;
 }
 


### PR DESCRIPTION
The syscall performance is poor since we are using no cache setting
in MPU. Change this to write back cache setting to improve performance.

Below is the performance comparison for both cases:

Syscall performance

Syscall type	| No cache case	| With WB cache case
syscall 0	| 52 secs	| 2 secs
syscall 1	| 59 secs	| 2 secs
syscall 2	| 51 secs	| 2 secs
syscall 3	| 184 secs	| 37 secs
syscall 4	| 57 secs	| 8 secs
syscall 5	| 66 secs	| 8 secs
syscall 6	| 282 secs	| 23 secs


Average context switch time

No cache : 138 usecs
WB cache : 19 usecs

Signed-off-by: Kishore S N <kishore.sn@samsung.com>