### PR TITLE
arch/armv8-m : Fix Security test hang issue

### DIFF
--- a/os/arch/arm/src/armv8-m/up_unblocktask.c
+++ b/os/arch/arm/src/armv8-m/up_unblocktask.c
@@ -135,8 +135,8 @@ void up_unblock_task(struct tcb_s *tcb)
 
 	if (sched_addreadytorun(tcb)) {
 #ifdef CONFIG_ARMV8M_TRUSTZONE
-		if (tcb->tz_context) {
-			TZ_StoreContext_S(tcb->tz_context);
+		if (rtcb->tz_context) {
+			TZ_StoreContext_S(rtcb->tz_context);
 		}
 #endif
 		/* The currently active task has changed! We need to do

--- a/os/arch/arm/src/armv8-m/up_unblocktask_withoutsavereg.c
+++ b/os/arch/arm/src/armv8-m/up_unblocktask_withoutsavereg.c
@@ -136,11 +136,6 @@ void up_unblock_task_without_savereg(struct tcb_s *tcb)
 		tcb->task_state = TSTATE_TASK_RUNNING;
 		tcb->flink->task_state = TSTATE_TASK_READYTORUN;
 
-#ifdef CONFIG_ARMV8M_TRUSTZONE
-		if (tcb->tz_context) {
-			TZ_StoreContext_S(tcb->tz_context);
-		}
-#endif
 	} else {
 		/* The new btcb was added in the middle of the ready-to-run list */
 


### PR DESCRIPTION
During context switch, the secure context store is not happening sometimes.
Load secure context is getting called repeatedly without corresponding calls
to score secure context. This is resulting in corruption of secure area PSP.
The issue is fixed by making sure that secure context is stored for each
task which is switched OUT during a context switch.

Signed-off-by: Kishore S N <kishore.sn@samsung.com>