### PR TITLE
apps/examples : Add static for internal use variable in syscall_perf …

### DIFF
--- a/apps/examples/performance/syscall/syscall_performance_main.c
+++ b/apps/examples/performance/syscall/syscall_performance_main.c
@@ -35,7 +35,7 @@
 #define TEST_TIMEDSEND_NMSGS	3
 #define SIGEV_SIGNAL	1		/* Notify via signal */
 
-int sig_no = SIGRTMIN;
+static int sig_no = SIGRTMIN;
 
 /*
  * measure_performance : variadic macro for time measurements for function calls

--- a/apps/examples/testcase/le_tc/kernel/tc_timer.c
+++ b/apps/examples/testcase/le_tc/kernel/tc_timer.c
@@ -28,7 +28,7 @@
 
 #define USECINT 10000000
 
-int sig_no = SIGRTMIN;
+static int sig_no = SIGRTMIN;
 
 #ifndef CONFIG_BUILD_PROTECTED
 /**


### PR DESCRIPTION
…and tc_timer

There are same name global variable in syscall_performance and tc_timer.
Each global variable is used only for its own code, so add static.
If not add static, there can be build error when build them simultaneously.