### PR TITLE
apps/examples/security_test/hal : Add dependency for security hal tes…

### DIFF
--- a/apps/examples/security_test/hal/Kconfig
+++ b/apps/examples/security_test/hal/Kconfig
@@ -4,6 +4,8 @@
 #
 config EXAMPLES_SECURITY_HAL_TEST
 	bool "Security HAL Test"
+	depends on BUILD_FLAT
+	depends on SE
 	select STRESS_TOOL
 	default n
 


### PR DESCRIPTION
…t on Flat build

Security Hal Test can run only with flat build. It cannot run from Loadable apps.
So add dependency.