### PR TITLE
mpu: tidy-up naming and comment

### DIFF
--- a/os/arch/arm/src/armv7-m/up_blocktask.c
+++ b/os/arch/arm/src/armv7-m/up_blocktask.c
@@ -174,7 +174,7 @@ void up_block_task(struct tcb_s *tcb, tstate_t task_state)
 			/* Condition check : Update MPU registers only if this is not a kernel thread. */
 			if ((rtcb->flags & TCB_FLAG_TTYPE_MASK) != TCB_FLAG_TTYPE_KERNEL) {
 #if defined(CONFIG_APP_BINARY_SEPARATION)
-				for (int i = 0; i < 3 * MPU_NUM_REGIONS; i += 3) {
+				for (int i = 0; i < MPU_REG_NUMBER * MPU_NUM_REGIONS; i += MPU_REG_NUMBER) {
 					up_mpu_set_register(&rtcb->mpu_regs[i]);
 				}
 #endif

--- a/os/arch/arm/src/armv7-m/up_mpu.c
+++ b/os/arch/arm/src/armv7-m/up_mpu.c
@@ -375,10 +375,10 @@ void up_mpu_set_register(uint32_t *mpu_regs)
 	/* We update MPU registers only if there is non zero value of
 	 * base address (This ensures valid MPU settings)
 	 */
-	if (mpu_regs[REG_RBAR]) {
-		putreg32(mpu_regs[REG_RNR], MPU_RNR);
-		putreg32(mpu_regs[REG_RBAR], MPU_RBAR);
-		putreg32(mpu_regs[REG_RASR], MPU_RASR);
+	if (mpu_regs[MPU_REG_RBAR]) {
+		putreg32(mpu_regs[MPU_REG_RNR], MPU_RNR);
+		putreg32(mpu_regs[MPU_REG_RBAR], MPU_RBAR);
+		putreg32(mpu_regs[MPU_REG_RASR], MPU_RASR);
 	}
 }
 
@@ -395,9 +395,9 @@ bool up_mpu_check_active(uint32_t *mpu_regs)
 	/* Set MPU_RNR register before getting corresponding
 	 * MPU_RBAR and MPU_RASR values
 	 */
-	putreg32(mpu_regs[REG_RNR], MPU_RNR);
+	putreg32(mpu_regs[MPU_REG_RNR], MPU_RNR);
 
-	return (getreg32(MPU_RBAR) == mpu_regs[REG_RBAR] && getreg32(MPU_RASR) == mpu_regs[REG_RASR]);
+	return (getreg32(MPU_RBAR) == mpu_regs[MPU_REG_RBAR] && getreg32(MPU_RASR) == mpu_regs[MPU_REG_RASR]);
 }
 
 /****************************************************************************
@@ -411,7 +411,7 @@ bool up_mpu_check_active(uint32_t *mpu_regs)
 void up_mpu_disable_region(uint32_t *mpu_regs)
 {
 	/* Disable region's Enable bit in mpu register settings */
-	mpu_regs[REG_RASR] &= ~MPU_RASR_ENABLE;
+	mpu_regs[MPU_REG_RASR] &= ~MPU_RASR_ENABLE;
 
 	/* Set updated mpu register values to mpu h/w */
 	up_mpu_set_register(mpu_regs);

--- a/os/arch/arm/src/armv7-m/up_releasepending.c
+++ b/os/arch/arm/src/armv7-m/up_releasepending.c
@@ -138,7 +138,7 @@ void up_release_pending(void)
 			/* Condition check : Update MPU registers only if this is not a kernel thread. */
 			if ((rtcb->flags & TCB_FLAG_TTYPE_MASK) != TCB_FLAG_TTYPE_KERNEL) {
 #if defined(CONFIG_APP_BINARY_SEPARATION)
-				for (int i = 0; i < 3 * MPU_NUM_REGIONS; i += 3) {
+				for (int i = 0; i < MPU_REG_NUMBER * MPU_NUM_REGIONS; i += MPU_REG_NUMBER) {
 					up_mpu_set_register(&rtcb->mpu_regs[i]);
 				}
 #endif

--- a/os/arch/arm/src/armv7-m/up_reprioritizertr.c
+++ b/os/arch/arm/src/armv7-m/up_reprioritizertr.c
@@ -189,7 +189,7 @@ void up_reprioritize_rtr(struct tcb_s *tcb, uint8_t priority)
 				/* Condition check : Update MPU registers only if this is not a kernel thread. */
 				if ((rtcb->flags & TCB_FLAG_TTYPE_MASK) != TCB_FLAG_TTYPE_KERNEL) {
 #if defined(CONFIG_APP_BINARY_SEPARATION)
-					for (int i = 0; i < 3 * MPU_NUM_REGIONS; i += 3) {
+					for (int i = 0; i < MPU_REG_NUMBER * MPU_NUM_REGIONS; i += MPU_REG_NUMBER) {
 						up_mpu_set_register(&rtcb->mpu_regs[i]);
 					}
 #endif

--- a/os/arch/arm/src/armv7-m/up_schedyield.c
+++ b/os/arch/arm/src/armv7-m/up_schedyield.c
@@ -154,7 +154,7 @@ void up_schedyield(void)
 
 			if ((ntcb->flags & TCB_FLAG_TTYPE_MASK) != TCB_FLAG_TTYPE_KERNEL) {
 #if defined(CONFIG_APP_BINARY_SEPARATION)
-				for (int i = 0; i < 3 * MPU_NUM_REGIONS; i += 3) {
+				for (int i = 0; i < MPU_REG_NUMBER * MPU_NUM_REGIONS; i += MPU_REG_NUMBER) {
 					up_mpu_set_register(&ntcb->mpu_regs[i]);
 				}
 #endif

--- a/os/arch/arm/src/armv7-m/up_svcall.c
+++ b/os/arch/arm/src/armv7-m/up_svcall.c
@@ -270,7 +270,7 @@ int up_svcall(int irq, FAR void *context, FAR void *arg)
 #if (defined(CONFIG_ARMV7M_MPU) && defined(CONFIG_APP_BINARY_SEPARATION))
 		/* Condition check : Update MPU registers only if this is not a kernel thread. */
 		if ((tcb->flags & TCB_FLAG_TTYPE_MASK) != TCB_FLAG_TTYPE_KERNEL) {
-			for (int i = 0; i < 3 * MPU_NUM_REGIONS; i += 3) {
+			for (int i = 0; i < MPU_REG_NUMBER * MPU_NUM_REGIONS; i += MPU_REG_NUMBER) {
 				up_mpu_set_register(&tcb->mpu_regs[i]);
 			}
 		}
@@ -322,7 +322,7 @@ int up_svcall(int irq, FAR void *context, FAR void *arg)
 #if (defined(CONFIG_ARMV7M_MPU) && defined(CONFIG_APP_BINARY_SEPARATION))
 		/* Condition check : Update MPU registers only if this is not a kernel thread. */
 		if ((tcb->flags & TCB_FLAG_TTYPE_MASK) != TCB_FLAG_TTYPE_KERNEL) {
-			for (int i = 0; i < 3 * MPU_NUM_REGIONS; i += 3) {
+			for (int i = 0; i < MPU_REG_NUMBER * MPU_NUM_REGIONS; i += MPU_REG_NUMBER) {
 				up_mpu_set_register(&tcb->mpu_regs[i]);
 			}
 		}

--- a/os/arch/arm/src/armv7-m/up_unblocktask.c
+++ b/os/arch/arm/src/armv7-m/up_unblocktask.c
@@ -160,7 +160,7 @@ void up_unblock_task(struct tcb_s *tcb)
 			/* Condition check : Update MPU registers only if this is not a kernel thread. */
 			if ((rtcb->flags & TCB_FLAG_TTYPE_MASK) != TCB_FLAG_TTYPE_KERNEL) {
 #if defined(CONFIG_APP_BINARY_SEPARATION)
-				for (int i = 0; i < 3 * MPU_NUM_REGIONS; i += 3) {
+				for (int i = 0; i < MPU_REG_NUMBER * MPU_NUM_REGIONS; i += MPU_REG_NUMBER) {
 					up_mpu_set_register(&rtcb->mpu_regs[i]);
 				}
 #endif

--- a/os/arch/arm/src/armv7-m/up_unblocktask_withoutsavereg.c
+++ b/os/arch/arm/src/armv7-m/up_unblocktask_withoutsavereg.c
@@ -160,7 +160,7 @@ void up_unblock_task_without_savereg(struct tcb_s *tcb)
 		/* Condition check : Update MPU registers only if this is not a kernel thread. */
 		if ((rtcb->flags & TCB_FLAG_TTYPE_MASK) != TCB_FLAG_TTYPE_KERNEL) {
 #if defined(CONFIG_APP_BINARY_SEPARATION)
-			for (int i = 0; i < 3 * MPU_NUM_REGIONS; i += 3) {
+			for (int i = 0; i < MPU_REG_NUMBER * MPU_NUM_REGIONS; i += MPU_REG_NUMBER) {
 				up_mpu_set_register(&rtcb->mpu_regs[i]);
 			}
 #endif

--- a/os/arch/arm/src/armv8-m/up_mpu.c
+++ b/os/arch/arm/src/armv8-m/up_mpu.c
@@ -189,10 +189,10 @@ void up_mpu_set_register(uint32_t *mpu_regs)
 	/* We update MPU registers only if there is non zero value of
 	 * base address (This ensures valid MPU settings)
 	 */
-	if (mpu_regs[REG_RBAR]) {
-		putreg32(mpu_regs[REG_RNR], MPU_RNR);
-		putreg32(mpu_regs[REG_RBAR], MPU_RBAR);
-		putreg32(mpu_regs[REG_RASR], MPU_RLAR);
+	if (mpu_regs[MPU_REG_RBAR]) {
+		putreg32(mpu_regs[MPU_REG_RNR], MPU_RNR);
+		putreg32(mpu_regs[MPU_REG_RBAR], MPU_RBAR);
+		putreg32(mpu_regs[MPU_REG_RASR], MPU_RLAR);
 	}
 }
 
@@ -209,9 +209,9 @@ bool up_mpu_check_active(uint32_t *mpu_regs)
 	/* Set MPU_RNR register before getting corresponding
 	 * MPU_RBAR and MPU_RLAR values
 	 */
-	putreg32(mpu_regs[REG_RNR], MPU_RNR);
+	putreg32(mpu_regs[MPU_REG_RNR], MPU_RNR);
 
-	return (getreg32(MPU_RBAR) == mpu_regs[REG_RBAR] && getreg32(MPU_RLAR) == mpu_regs[REG_RASR]);
+	return (getreg32(MPU_RBAR) == mpu_regs[MPU_REG_RBAR] && getreg32(MPU_RLAR) == mpu_regs[MPU_REG_RASR]);
 }
 
 /****************************************************************************
@@ -225,7 +225,7 @@ bool up_mpu_check_active(uint32_t *mpu_regs)
 void up_mpu_disable_region(uint32_t *mpu_regs)
 {
 	/* Disable region's Enable bit in mpu register settings */
-	mpu_regs[REG_RASR] &= ~MPU_RLAR_ENABLE;
+	mpu_regs[MPU_REG_RASR] &= ~MPU_RLAR_ENABLE;
 
 	/* Set updated mpu register values to mpu h/w */
 	up_mpu_set_register(mpu_regs);

--- a/os/arch/arm/src/armv8-m/up_releasepending.c
+++ b/os/arch/arm/src/armv8-m/up_releasepending.c
@@ -147,7 +147,7 @@ void up_release_pending(void)
 			/* Condition check : Update MPU registers only if this is not a kernel thread. */
 			if ((rtcb->flags & TCB_FLAG_TTYPE_MASK) != TCB_FLAG_TTYPE_KERNEL) {
 #if defined(CONFIG_APP_BINARY_SEPARATION)
-				for (int i = 0; i < 3 * MPU_NUM_REGIONS; i += 3) {
+				for (int i = 0; i < MPU_REG_NUMBER * MPU_NUM_REGIONS; i += MPU_REG_NUMBER) {
 					up_mpu_set_register(&rtcb->mpu_regs[i]);
 				}
 #endif

--- a/os/arch/arm/src/armv8-m/up_reprioritizertr.c
+++ b/os/arch/arm/src/armv8-m/up_reprioritizertr.c
@@ -198,7 +198,7 @@ void up_reprioritize_rtr(struct tcb_s *tcb, uint8_t priority)
 				/* Condition check : Update MPU registers only if this is not a kernel thread. */
 				if ((rtcb->flags & TCB_FLAG_TTYPE_MASK) != TCB_FLAG_TTYPE_KERNEL) {
 #if defined(CONFIG_APP_BINARY_SEPARATION)
-					for (int i = 0; i < 3 * MPU_NUM_REGIONS; i += 3) {
+					for (int i = 0; i < MPU_REG_NUMBER * MPU_NUM_REGIONS; i += MPU_REG_NUMBER) {
 						up_mpu_set_register(&rtcb->mpu_regs[i]);
 					}
 #endif

--- a/os/arch/arm/src/armv8-m/up_schedyield.c
+++ b/os/arch/arm/src/armv8-m/up_schedyield.c
@@ -160,7 +160,7 @@ void up_schedyield(void)
 
 			if ((ntcb->flags & TCB_FLAG_TTYPE_MASK) != TCB_FLAG_TTYPE_KERNEL) {
 #if defined(CONFIG_APP_BINARY_SEPARATION)
-				for (int i = 0; i < 3 * MPU_NUM_REGIONS; i += 3) {
+				for (int i = 0; i < MPU_REG_NUMBER * MPU_NUM_REGIONS; i += MPU_REG_NUMBER) {
 					up_mpu_set_register(&ntcb->mpu_regs[i]);
 				}
 #endif

--- a/os/arch/arm/src/armv8-m/up_svcall.c
+++ b/os/arch/arm/src/armv8-m/up_svcall.c
@@ -269,7 +269,7 @@ int up_svcall(int irq, FAR void *context, FAR void *arg)
 #if (defined(CONFIG_ARMV8M_MPU) && defined(CONFIG_APP_BINARY_SEPARATION))
 		/* Condition check : Update MPU registers only if this is not a kernel thread. */
 		if ((rtcb->flags & TCB_FLAG_TTYPE_MASK) != TCB_FLAG_TTYPE_KERNEL) {
-			for (int i = 0; i < 3 * MPU_NUM_REGIONS; i += 3) {
+			for (int i = 0; i < MPU_REG_NUMBER * MPU_NUM_REGIONS; i += MPU_REG_NUMBER) {
 				up_mpu_set_register(&rtcb->mpu_regs[i]);
 			}
 		}
@@ -318,7 +318,7 @@ int up_svcall(int irq, FAR void *context, FAR void *arg)
 #if (defined(CONFIG_ARMV8M_MPU) && defined(CONFIG_APP_BINARY_SEPARATION))
 		/* Condition check : Update MPU registers only if this is not a kernel thread. */
 		if ((rtcb->flags & TCB_FLAG_TTYPE_MASK) != TCB_FLAG_TTYPE_KERNEL) {
-			for (int i = 0; i < 3 * MPU_NUM_REGIONS; i += 3) {
+			for (int i = 0; i < MPU_REG_NUMBER * MPU_NUM_REGIONS; i += MPU_REG_NUMBER) {
 				up_mpu_set_register(&rtcb->mpu_regs[i]);
 			}
 		}

--- a/os/arch/arm/src/armv8-m/up_unblocktask.c
+++ b/os/arch/arm/src/armv8-m/up_unblocktask.c
@@ -167,7 +167,7 @@ void up_unblock_task(struct tcb_s *tcb)
 			/* Condition check : Update MPU registers only if this is not a kernel thread. */
 			if ((rtcb->flags & TCB_FLAG_TTYPE_MASK) != TCB_FLAG_TTYPE_KERNEL) {
 #if defined(CONFIG_APP_BINARY_SEPARATION)
-				for (int i = 0; i < 3 * MPU_NUM_REGIONS; i += 3) {
+				for (int i = 0; i < MPU_REG_NUMBER * MPU_NUM_REGIONS; i += MPU_REG_NUMBER) {
 					up_mpu_set_register(&rtcb->mpu_regs[i]);
 				}
 #endif

--- a/os/arch/arm/src/armv8-m/up_unblocktask_withoutsavereg.c
+++ b/os/arch/arm/src/armv8-m/up_unblocktask_withoutsavereg.c
@@ -163,7 +163,7 @@ void up_unblock_task_without_savereg(struct tcb_s *tcb)
 		/* Condition check : Update MPU registers only if this is not a kernel thread. */
 		if ((rtcb->flags & TCB_FLAG_TTYPE_MASK) != TCB_FLAG_TTYPE_KERNEL) {
 #if defined(CONFIG_APP_BINARY_SEPARATION)
-			for (int i = 0; i < 3 * MPU_NUM_REGIONS; i += 3) {
+			for (int i = 0; i < MPU_REG_NUMBER * MPU_NUM_REGIONS; i += MPU_REG_NUMBER) {
 				up_mpu_set_register(&rtcb->mpu_regs[i]);
 			}
 #endif

--- a/os/arch/arm/src/common/up_mpuinit.c
+++ b/os/arch/arm/src/common/up_mpuinit.c
@@ -38,6 +38,8 @@
  ****************************************************************************/
 
 #include <tinyara/config.h>
+
+#ifdef CONFIG_ARM_MPU
 #include <tinyara/mpu.h>
 
 #include <assert.h>
@@ -45,8 +47,6 @@
 #include "mpu.h"
 #include "up_mpuinit.h"
 #include "cache.h"
-
-#if defined(CONFIG_BUILD_PROTECTED) && defined(CONFIG_ARM_MPU)
 
 /****************************************************************************
  * Pre-processor Definitions
@@ -175,5 +175,4 @@ void up_mpuinitialize(void)
 	mpu_control(true, false, true);
 }
 
-#endif /* CONFIG_BUILD_PROTECTED && CONFIG_ARM_MPU */
-
+#endif // CONFIG_ARM_MPU

--- a/os/binfmt/binfmt_loadbinary.c
+++ b/os/binfmt/binfmt_loadbinary.c
@@ -87,7 +87,7 @@ int load_binary(int binary_idx, FAR const char *filename, load_attr_t *load_attr
 	int errcode;
 	int ret;
 #if (defined(CONFIG_SUPPORT_COMMON_BINARY) && (defined(CONFIG_ARMV7M_MPU) || defined(CONFIG_ARMV8M_MPU)))
-	uint32_t com_bin_mpu_regs[3 * MPU_NUM_REGIONS];	/* We need 3 register values to configure each MPU region */
+	uint32_t com_bin_mpu_regs[MPU_REG_NUMBER * MPU_NUM_REGIONS];	/* We need 3 register values to configure each MPU region */
 #endif
 
 	/* Sanity check */
@@ -196,7 +196,7 @@ int load_binary(int binary_idx, FAR const char *filename, load_attr_t *load_attr
 		mpu_get_register_config_value(&com_bin_mpu_regs[0], nregion - 1, (uintptr_t)bin->ramstart,          bin->ramsize,  false, true);
 #endif
 		/* Set MPU register values to real MPU h/w */
-		for (int i = 0; i < 3 * MPU_NUM_REGIONS; i += 3) {
+		for (int i = 0; i < MPU_REG_NUMBER * MPU_NUM_REGIONS; i += MPU_REG_NUMBER) {
 			up_mpu_set_register(&com_bin_mpu_regs[i]);
 		}
 #endif

--- a/os/board/rtl8721csm/src/component/soc/realtek/amebad/fwlib/ram_hp/rtl8721dhp_app_start.c
+++ b/os/board/rtl8721csm/src/component/soc/realtek/amebad/fwlib/ram_hp/rtl8721dhp_app_start.c
@@ -7,6 +7,9 @@
  *  possession or use of this module requires written permission of RealTek.
  */
 
+#include <tinyara/config.h>
+#include <tinyara/mpu.h>
+
 #include "ameba_soc.h"
 #include "rtl8721d_system.h"
 #include "psram_reserve.h"
@@ -1338,9 +1341,6 @@ extern void __libc_init_array(void);
 #ifdef CONFIG_PLATFORM_TIZENRT_OS
 	mpu_init();
 	app_mpu_nocache_init();
-
-	/* Initialize number of mpu regions for board specific purpose */
-	mpu_set_nregion_board_specific(1);
 #endif
 	app_vdd1833_detect();
 	memcpy_gdma_init();
@@ -1349,6 +1349,9 @@ extern void __libc_init_array(void);
 
 #ifdef CONFIG_PLATFORM_TIZENRT_OS
 #ifdef CONFIG_ARMV8M_MPU
+	/* Initialize number of mpu regions for board specific purpose */
+	mpu_set_nregion_board_specific(1);
+
 	up_mpuinitialize();
 #endif
 

--- a/os/include/tinyara/mpu.h
+++ b/os/include/tinyara/mpu.h
@@ -44,11 +44,11 @@ struct mpu_usages_s {
 	uint8_t max_nregion;
 };
 
-enum {
-	REG_RNR,
-	REG_RBAR,
-	REG_RASR,
-	REG_MAX
+enum mpu_register_type_e {
+	MPU_REG_RNR,
+	MPU_REG_RBAR,
+	MPU_REG_RASR,
+	MPU_REG_NUMBER
 };
 
 /* Enum to to get MPU region number info for MPU usages */
@@ -61,9 +61,11 @@ enum mpu_region_usages_e {
 };
 
 #ifdef CONFIG_OPTIMIZE_APP_RELOAD_TIME
-#define MPU_NUM_REGIONS		3
+/* Separate three MPU regions (text, ro and rw) to optimize reloading time */
+#define MPU_NUM_REGIONS     3
 #else
-#define MPU_NUM_REGIONS		1
+/* Just a MPU region for all of section data */
+#define MPU_NUM_REGIONS     1
 #endif
 
 #ifdef CONFIG_ARMV8M_MPU

--- a/os/include/tinyara/sched.h
+++ b/os/include/tinyara/sched.h
@@ -625,12 +625,12 @@ struct tcb_s {
 	uint32_t uspace;		/* User space object for app binary */
 
 #ifdef CONFIG_ARM_MPU
-	uint32_t mpu_regs[3 * MPU_NUM_REGIONS];	/* We need 3 register values to configure each MPU region */
+	uint32_t mpu_regs[MPU_REG_NUMBER * MPU_NUM_REGIONS];	/* MPU register values for loading data */
 #endif
 #endif
 
 #if defined(CONFIG_MPU_STACK_OVERFLOW_PROTECTION)
-uint32_t stack_mpu_regs[REG_MAX]; /* need 3 MPU registers to configure a region */
+uint32_t stack_mpu_regs[MPU_REG_NUMBER]; /* MPU register values for stack protection */
 #endif
 #ifdef CONFIG_SUPPORT_COMMON_BINARY
 	uint32_t app_id;			/* Indicates app id of the task and used to index into umm_heap_table */

--- a/os/kernel/task/task_setup.c
+++ b/os/kernel/task/task_setup.c
@@ -468,12 +468,12 @@ static int thread_schedsetup(FAR struct tcb_s *tcb, int priority, start_t start,
 #ifdef CONFIG_ARM_MPU
 		int i = 0;
 #ifdef CONFIG_OPTIMIZE_APP_RELOAD_TIME
-		for (; i < 3 * MPU_NUM_REGIONS; i += 3)
+		for (; i < MPU_REG_NUMBER * MPU_NUM_REGIONS; i += MPU_REG_NUMBER)
 #endif
 		{
-			tcb->mpu_regs[i + REG_RNR] = rtcb->mpu_regs[i + REG_RNR];
-			tcb->mpu_regs[i + REG_RBAR] = rtcb->mpu_regs[i + REG_RBAR];
-			tcb->mpu_regs[i + REG_RASR] = rtcb->mpu_regs[i + REG_RASR];
+			tcb->mpu_regs[i + MPU_REG_RNR] = rtcb->mpu_regs[i + MPU_REG_RNR];
+			tcb->mpu_regs[i + MPU_REG_RBAR] = rtcb->mpu_regs[i + MPU_REG_RBAR];
+			tcb->mpu_regs[i + MPU_REG_RASR] = rtcb->mpu_regs[i + MPU_REG_RASR];
 		}
 #endif
 

--- a/os/kernel/task/task_terminate.c
+++ b/os/kernel/task/task_terminate.c
@@ -189,7 +189,7 @@ int task_terminate(pid_t pid, bool nonblocking)
 	/* Disable mpu regions when the binary is unloaded if its own mpu registers are set in mpu h/w. */
 	if (IS_BINARY_MAINTASK(dtcb) && up_mpu_check_active(&dtcb->mpu_regs[0])) {
 #ifdef CONFIG_OPTIMIZE_APP_RELOAD_TIME
-		for (int i = 0; i < 3 * MPU_NUM_REGIONS; i += 3) {
+		for (int i = 0; i < MPU_REG_NUMBER * MPU_NUM_REGIONS; i += MPU_REG_NUMBER) {
 			up_mpu_disable_region(&dtcb->mpu_regs[i]);
 		}
 #else

--- a/os/kernel/task/task_terminate_unloaded.c
+++ b/os/kernel/task/task_terminate_unloaded.c
@@ -108,7 +108,7 @@ int task_terminate_unloaded(FAR struct tcb_s *tcb)
 	/* Disable mpu regions when the binary is unloaded if its own mpu registers are set in mpu h/w. */
 	if (IS_BINARY_MAINTASK(tcb) && up_mpu_check_active(&tcb->mpu_regs[0])) {
 #ifdef CONFIG_OPTIMIZE_APP_RELOAD_TIME
-		for (int i = 0; i < 3 * MPU_NUM_REGIONS; i += 3) {
+		for (int i = 0; i < MPU_REG_NUMBER * MPU_NUM_REGIONS; i += MPU_REG_NUMBER) {
 			up_mpu_disable_region(&tcb->mpu_regs[i]);
 		}
 #else


### PR DESCRIPTION
1. Rename the definitions
  REG_XXX -> MPU_REG_XXX
2. Use the definition instead of hard-coded value
  3 -> MPU_REG_NUMBER
3. Add and fix the comments

Signed-off-by: sunghan-chang <sh924.chang@samsung.com>