### PR TITLE
Add functionality to dump Userfs partition from External Flash

### DIFF
--- a/tools/dump_tool/HowToUseDumpTool.md
+++ b/tools/dump_tool/HowToUseDumpTool.md
@@ -35,6 +35,14 @@ NOTE: - For devices that use ARM Cortex M, backtracking of frame pointer is not 
 Hence, it is not possible to obtain exact call stack for the crash.
 Ramdump may not produce results as expected in such cases.
 ```
+6. Enable CONFIG_BOARD_ASSERT_AUTORESET to enable resetting of TARGET device after extracting dumps
+```
+Hardware Configuration > Board Selection -> Reset a board on assert status automatically
+```
+7. Enable CONFIG_BCH to enable Block-to-Character driver support for extracting External Userfs Partition Dump
+```
+Device Drivers -> Block-to-character(BCH) Support
+```
 
 ## How to upload RAMDUMP-or-UserfsDUMP
 ### In Linux
@@ -69,9 +77,10 @@ Target device locked and ready to DUMP!!!
 Choose from the following options:-
 1. RAM Dump
 2. Userfs Dump
-3. Both RAM and Userfs Dump
-4. Exit Dump Tool
-5. Reboot TARGET Device
+3. Both RAM and Userfs dumps
+4. External Userfs Partition Dump
+5. Exit Dump Tool
+6. Reboot TARGET Device
 1 (-> RAM Dump option chosen)
 ```
 5. If RAM Dump option is chosen, tool will prompt the user for the regions to be dumped on successful handshake
@@ -108,9 +117,10 @@ Ramdump received successfully..!
 Choose from the following options:-
 1. RAM Dump
 2. Userfs Dump
-3. Both RAM and Userfs Dump
-4. Exit Dump Tool
-5. Reboot TARGET Device
+3. Both RAM and Userfs dumps
+4. External Userfs Partition Dump
+5. Exit Dump Tool
+6. Reboot TARGET Device
 2 (-> Userfs Dump option chosen)
 ```
 8. If Userfs Dump option is chosen, tool will dump the region on successful handshake
@@ -132,22 +142,50 @@ Filesystem Dump received successfully
 Choose from the following options:-
 1. RAM Dump
 2. Userfs Dump
-3. Both RAM and Userfs Dump
-4. Exit Dump Tool
-5. Reboot TARGET Device
-5 (-> Reboot TARGET Device option chosen)
+3. Both RAM and Userfs dumps
+4. External Userfs Partition Dump
+5. Exit Dump Tool
+6. Reboot TARGET Device
+4 (-> External Userfs Partition dump option chosen)
 ```
-10. If Reboot TARGET Device option is chosen, tool will send a Reboot signal string to the TARGET device and exit
+10. If External Userfs Partition dump option is chosen, tool will dump the Userfs partition on the External Flash on successful handshake..
+```
+DUMPING EXTERNAL USERFS DUMP PARTITION
+do_handshake: Target Handshake successful
+
+=========================================================================
+External filesystem size = 03145728
+=========================================================================
+
+Receiving external file system dump.....
+[===================-========================================================================================
+=============================================================================================================
+=================>]
+
+External Userfs partition dump received successfully
+```
+11. The dump tool will again provide a list of options for the user to choose from
+```
+Choose from the following options:-
+1. RAM Dump
+2. Userfs Dump
+3. Both RAM and Userfs dumps
+4. External Userfs Partition Dump
+5. Exit Dump Tool
+6. Reboot TARGET Device
+6 (-> Reboot TARGET Device option chosen)
+```
+12. If Reboot TARGET Device option is chosen, tool will send a Reboot signal string to the TARGET device and exit
 ```
 CONFIG_BOARD_ASSERT_AUTORESET needs to be enabled to reboot TARGET Device after a crash
 do_handshake: Target Handshake successful
 Dump tool exits after successful operation
 ```
-11. The dump tool exits if user chooses Option 4.
+13. The dump tool exits if user chooses Option 5.
 ```
 Dump tool exits after successful operation
 ```
-12. NOTE: The device stays in a loop, waiting for the next handshake/reboot signal till the user sends the Reboot signal.
+14. NOTE: The device stays in a loop, waiting for the next handshake/reboot signal till the user sends the Reboot signal.
 
 ### In Windows
 With the RAMDUMP configured above, whenever the target board crashes because an assert condition, it enters PANIC mode, and displays the following message:  

--- a/tools/dump_tool/dump_tool.h
+++ b/tools/dump_tool/dump_tool.h
@@ -35,6 +35,7 @@
 
 #define RAMDUMP_HANDSHAKE_STRING        "TIZENRTRMDUMP"
 #define FSDUMP_HANDSHAKE_STRING         "TIZENRTFSDUMP"
+#define EXTFSDUMP_HANDSHAKE_STRING      "TIZENRTEXTFSD"
 #define TARGET_REBOOT_STRING            "TIZENRTREBOOT"
 #define HANDSHAKE_STR_LEN_MAX           (13)
 #define BINFILE_NAME_SIZE               (40)
@@ -47,7 +48,7 @@
 #define RAMDUMP_FLAG            1
 #define USERFSDUMP_FLAG         2
 #define REBOOT_DEVICE_FLAG      4
-#define EXIT_TOOL_FLAG          8
+#define EXTUSERFS_DUMP_FLAG     8
 
 /****************************************************************************
  * Public Types

--- a/tools/dump_tool/dump_tool.sh
+++ b/tools/dump_tool/dump_tool.sh
@@ -30,6 +30,8 @@ RAMDUMP_FILE=./ramdump_0x*.bin
 rm -f ${RAMDUMP_FILE}
 FSDUMP_FILE=./fsdump_0x*.bin
 rm -f ${FSDUMP_FILE}
+EXTFSDUMP_FILE=./ext_fsdump_*.bin
+rm -f ${EXTFSDUMP_FILE}
 ok=true
 
 # Take user input for device port

--- a/tools/dump_tool/dumping_protocol.txt
+++ b/tools/dump_tool/dumping_protocol.txt
@@ -30,7 +30,8 @@ HOST  <------------ TARGET
 4.  TARGET compares the handshake string against the following: -
 	RAMDUMP_HANDSHAKE_STRING, if matched, go to step 5
 	FSDUMP_HANDSHAKE_STRING, if matched, go to step 19
-	TARGET_REBOOT_STRING, if matched, go to step 27
+	EXTFSDUMP_HANDSHAKE_STRING, if matched, go to step 27
+	TARGET_REBOOT_STRING, if matched, go to step 33
 	else, send Negative Acknowledgement 'N', go to step 1
 5.  TARGET sends Acknowledgement 'A' to HOST.
 6.  TARGET will send 1 byte holding number of memory regions.
@@ -54,12 +55,19 @@ HOST  <------------ TARGET
 24. TARGET will send FSDUMP size bytes to the HOST.
 25. HOST will receive FSDUMP size bytes from the TARGET.
 26. goto step 1.
-27. TARGET sends Acknowledgement 'A' to HOST.
-28. If CONFIG_BOARD_ASSERT_AUTORESET is enabled, the device is reset.
-29. The dump function on the TARGET side exits.
+27. TARGET sends Acknowledgement 'A' to HOST
+28. TARGET will send 4 bytes holding the size of the Userfs partition in the External Flash.
+29. HOST will receive 4 bytes holding the siZe of the Userfs partition in the External Flash.
+30. TARGET will send EXTFSDUMP size bytes to the HOST.
+31. HOST will receive EXTFSDUMP size bytes from the TARGET.
+32. goto step 1.
+33. TARGET sends Acknowledgement 'A' to HOST.
+34. If CONFIG_BOARD_ASSERT_AUTORESET is enabled, the device is reset.
+35. The dump function on the HOST side exits.
 
 Note :
 Handshake string for dumping RAM contents is "TIZENRTRMDUMP".
 Handshake string for dumping Userfs contents is "TIZENRTFSDUMP".
-String for TARGET Reboot is "TIZENRTREBOOT".
+Handshake string for dumping External Userfs partition is "TIZENRTEXTFSD"
+Handshake string for TARGET Reboot is "TIZENRTREBOOT".
 


### PR DESCRIPTION
- Add smart MTD ioctl to retrieve all smartfs sectors for
  corresponding partition identifier.
- Add option to dump tool interface to dump external
  userfs partition.

Signed-off-by: Amogh Hassija <a.hassija@samsung.com>