### PR TITLE
mm/mm_heap/mm_realloc : Add logic for checking overflow of size

### DIFF
--- a/os/mm/mm_heap/mm_initialize.c
+++ b/os/mm/mm_heap/mm_initialize.c
@@ -127,6 +127,20 @@ void mm_addregion(FAR struct mm_heap_s *heap, FAR void *heapstart, size_t heapsi
 
 	heapbase = MM_ALIGN_UP((uintptr_t)heapstart);
 	heapend  = MM_ALIGN_DOWN((uintptr_t)heapstart + (uintptr_t)heapsize);
+	if ((heapbase < (uintptr_t)heapstart)) {
+		/* heapbase cannot be smaller than heapstart.
+		 * If this happens, heapbase can be overflowed from alignment.
+		 */
+		return;
+	}
+
+	if (heapbase >= (uintptr_t)heapend) {
+		/* heapbase is aligned up from heapstart,
+		 * and heapend is the summation of heapstart and heapsize.
+		 * If heapsize is very small, align-up address can be equal to or greater than heapend.
+		 */
+		return;
+	}
 	heapsize = heapend - heapbase;
 
 	mlldbg("Region %d: base=%p size=%u\n", IDX + 1, heapstart, heapsize);

--- a/os/mm/mm_heap/mm_realloc.c
+++ b/os/mm/mm_heap/mm_realloc.c
@@ -136,6 +136,13 @@ FAR void *mm_realloc(FAR struct mm_heap_s *heap, FAR void *oldmem, size_t size)
 		return NULL;
 	}
 
+	if (size > MM_ALIGN_DOWN(MMSIZE_MAX) - SIZEOF_MM_ALLOCNODE) {
+		mdbg("Because of mm_allocnode, %u cannot be allocated. The maximum \
+			 allocable size is (MM_ALIGN_DOWN(MMSIZE_MAX) - SIZEOF_MM_ALLOCNODE) \
+			 : %u\n.", size, (MM_ALIGN_DOWN(MMSIZE_MAX) - SIZEOF_MM_ALLOCNODE));
+		return NULL;
+	}
+
 	/* Adjust the size to account for (1) the size of the allocated node and
 	 * (2) to make sure that it is an even multiple of our granule size.
 	 */


### PR DESCRIPTION
MM_ALIGN_UP do an unsafe calculation that can cause integer wrap-around.
For avoiding integer wrap-around, check the size whether it is smaller than possible allocation size.