### PR TITLE
external/esp_idf_port: remove 2nd argument giving of netif_create_ip6…

### DIFF
--- a/external/esp_idf_port/tcpip_adapter/tcpip_adapter_lwip.c
+++ b/external/esp_idf_port/tcpip_adapter/tcpip_adapter_lwip.c
@@ -449,7 +449,7 @@ esp_err_t tcpip_adapter_create_ip6_linklocal(tcpip_adapter_if_t tcpip_if)
 	}
 	p_netif = esp_netif[tcpip_if];
 	if (p_netif != NULL && netif_is_up(p_netif)) {
-		netif_create_ip6_linklocal_address(p_netif, 1);
+		netif_create_ip6_linklocal_address(p_netif);
 		return ESP_OK;
 	} else {
 		return ESP_FAIL;


### PR DESCRIPTION
…_linklocal_address()

The netif_create_ip6_linklocal_address function does not support
2nd argument anymore by commit df89d45.
Let's follow new API usages for esp_idf_port/tcpip_adapter.

Signed-off-by: sunghan-chang <sh924.chang@samsung.com>