### PR TITLE
arch/arm/common/up_mpuinit.c : Fix type casting and Add ifdef conditi…

### DIFF
--- a/os/arch/arm/src/common/up_mpuinit.c
+++ b/os/arch/arm/src/common/up_mpuinit.c
@@ -73,7 +73,7 @@ static struct mpu_usages_s g_mpu_region_usages;
 
 void mpu_region_initialize(struct mpu_usages_s *mpu)
 {
-	uint8_t offset = (struct mpu_usages_s *)mpu->nregion_board_specific;
+	uint8_t offset = mpu->nregion_board_specific;
 
 #ifdef CONFIG_SUPPORT_COMMON_BINARY
 	offset += MPU_NUM_REGIONS;
@@ -149,7 +149,6 @@ void mpu_set_nregion_board_specific(uint8_t num)
  *   resources.
  *
  ****************************************************************************/
-
 void up_mpuinitialize(void)
 {
 	/* Initialize MPU register numbers information */

--- a/os/arch/arm/src/common/up_mpuinit.h
+++ b/os/arch/arm/src/common/up_mpuinit.h
@@ -54,11 +54,10 @@
  *   resources.
  *
  ****************************************************************************/
-
-#ifdef CONFIG_BUILD_PROTECTED
+#ifdef CONFIG_ARM_MPU  
 void up_mpuinitialize(void);
 #else
-#  define up_mpuinitialize()
+#define up_mpuinitialize()
 #endif
 
 #endif /* __ARCH_ARM_SRC_UP_MPUINIT_H */


### PR DESCRIPTION
…on for mpuinitialize

1) mpu->nregion_board_specific is uint8_t type, so don't need to type cating to struct mpu_usages_s *.
2) up_mpuinitialize is only working when CONFIG_BUILD_PROTECTED.