### PR TITLE
board/rtl8721csm: Change key_id used for WEP shared key auth method to 0

### DIFF
--- a/os/board/rtl8721csm/src/component/common/api/wifi_interactive_mode.c
+++ b/os/board/rtl8721csm/src/component/common/api/wifi_interactive_mode.c
@@ -445,7 +445,7 @@ int8_t cmd_wifi_connect(trwifi_ap_config_s *ap_connect_config, void *arg)
 		password = ap_connect_config->passphrase;
 		ssid_len = strlen((const char *)ssid);
 		password_len = ap_connect_config->passphrase_length;
-		key_id = 1; //Foucus
+		key_id = 0;
 		if ((password_len != 5) && (password_len != 13)) {
 			ndbg("\n\rWrong WEP key length. Must be 5 or 13 ASCII characters.");
 			return -1;

--- a/os/board/rtl8721csm/src/component/common/api/wifi_interactive_mode.c
+++ b/os/board/rtl8721csm/src/component/common/api/wifi_interactive_mode.c
@@ -419,7 +419,7 @@ int8_t cmd_wifi_connect(trwifi_ap_config_s *ap_connect_config, void *arg)
 	char *password;
 	int ssid_len;
 	int password_len;
-	int key_id;
+	int key_id = 0;
 	void *semaphore;
 	int security_retry_count = 0;
 
@@ -437,7 +437,6 @@ int8_t cmd_wifi_connect(trwifi_ap_config_s *ap_connect_config, void *arg)
 		password = NULL;
 		ssid_len = strlen((const char *)ssid);
 		password_len = 0;
-		key_id = 0;
 		semaphore = NULL;
 		break;
 	case WIFI_UTILS_AUTH_WEP_SHARED:
@@ -445,7 +444,6 @@ int8_t cmd_wifi_connect(trwifi_ap_config_s *ap_connect_config, void *arg)
 		password = ap_connect_config->passphrase;
 		ssid_len = strlen((const char *)ssid);
 		password_len = ap_connect_config->passphrase_length;
-		key_id = 0;
 		if ((password_len != 5) && (password_len != 13)) {
 			ndbg("\n\rWrong WEP key length. Must be 5 or 13 ASCII characters.");
 			return -1;
@@ -457,7 +455,6 @@ int8_t cmd_wifi_connect(trwifi_ap_config_s *ap_connect_config, void *arg)
 		password = ap_connect_config->passphrase;
 		ssid_len = strlen((const char *)ssid);
 		password_len = ap_connect_config->passphrase_length;
-		key_id = 0;
 		semaphore = NULL;
 		break;
 	case WIFI_UTILS_AUTH_WPA3_PSK:
@@ -465,7 +462,6 @@ int8_t cmd_wifi_connect(trwifi_ap_config_s *ap_connect_config, void *arg)
 		password = ap_connect_config->passphrase;
 		ssid_len = strlen((const char *)ssid);
 		password_len = ap_connect_config->passphrase_length;
-		key_id = 0;
 		semaphore = NULL;
 		break;
 	default:
@@ -483,7 +479,6 @@ int8_t cmd_wifi_connect(trwifi_ap_config_s *ap_connect_config, void *arg)
 		password = ap_connect_config->passphrase;
 		ssid_len = strlen((const char *)ssid);
 		password_len = ap_connect_config->passphrase_length;
-		key_id = 0;
 		semaphore = NULL;
 		break;
 	}


### PR DESCRIPTION

Change key_id from 1 to 0 for WEP shared key auth method connection according to RTK default SDK setting, also to fix connection issue found in compatibility test.