### PR TITLE
os/binfmt/libelf : Fix wrong condition for MPU-related defines and codes

### DIFF
--- a/os/include/tinyara/mpu.h
+++ b/os/include/tinyara/mpu.h
@@ -68,7 +68,7 @@ enum mpu_region_usages_e {
 #define MPU_NUM_REGIONS     1
 #endif
 
-#ifdef CONFIG_APP_BINARY_SEPARATION
+#ifdef CONFIG_ARMV8M_MPU
 #define MPU_ALIGNMENT_BYTES    32
 #define MPU_ALIGN_UP(a)                (((a) + MPU_ALIGNMENT_BYTES - 1) & ~(MPU_ALIGNMENT_BYTES - 1))
 #endif


### PR DESCRIPTION
1) MPU_ALIGNMENT_BYTES and MPU_ALIGN_UP are used only with armv8m mpu.
2) Calculation of each section size has dependency with architecture, but the allocation for those section has dependency with CONFIG_BINFMT_SECTION_UNIFIED_MEMORY.