### PR TITLE
kernel : Remove unnecessary variable in tcb - ram_start

### DIFF
--- a/os/binfmt/binfmt_execmodule.c
+++ b/os/binfmt/binfmt_execmodule.c
@@ -333,8 +333,6 @@ int exec_module(FAR struct binary_s *binp)
 	/* The app's userspace object will be found at an offset of 4 bytes from the start of the binary */
 	tcb->cmn.uspace = (uint32_t)binp->alloc[ALLOC_TEXT] + 4;
 	tcb->cmn.uheap = (uint32_t)binp->uheap;
-	tcb->cmn.ram_start = (uint32_t)binp->ramstart;
-	tcb->cmn.ram_size = binp->ramsize;
 
 #ifdef CONFIG_BINARY_MANAGER
 #ifdef CONFIG_SUPPORT_COMMON_BINARY

--- a/os/include/tinyara/sched.h
+++ b/os/include/tinyara/sched.h
@@ -620,8 +620,6 @@ struct tcb_s {
 
 	uint32_t uheap;			/* User heap object pointer */
 #ifdef CONFIG_APP_BINARY_SEPARATION
-	uint32_t ram_start;		/* Start address of RAM partition for this app */
-	uint32_t ram_size;		/* Size of RAM partition for this app */
 	uint32_t uspace;		/* User space object for app binary */
 
 #ifdef CONFIG_ARM_MPU

--- a/os/kernel/task/task_setup.c
+++ b/os/kernel/task/task_setup.c
@@ -456,8 +456,6 @@ static int thread_schedsetup(FAR struct tcb_s *tcb, int priority, start_t start,
 #ifdef CONFIG_APP_BINARY_SEPARATION
 		/* Copy the parent task ram details to this task */
 		rtcb = this_task();
-		tcb->ram_start = rtcb->ram_start;
-		tcb->ram_size = rtcb->ram_size;
 		tcb->uspace = rtcb->uspace;
 		tcb->uheap = rtcb->uheap;
 #ifdef CONFIG_SUPPORT_COMMON_BINARY


### PR DESCRIPTION
ram_start in tcb is not needed anymore, because we allocate the loading app with its own way.