### PR TITLE
binfmt: Fix bugs about location of variable definition

### DIFF
--- a/os/binfmt/binfmt_execmodule.c
+++ b/os/binfmt/binfmt_execmodule.c
@@ -187,9 +187,8 @@ int exec_module(FAR struct binary_s *binp)
 
 	/* Initialize the MPU registers in tcb with suitable protection values */
 #ifdef CONFIG_ARM_MPU
-#ifdef CONFIG_OPTIMIZE_APP_RELOAD_TIME
 	uint8_t nregion = mpu_get_nregion_info(MPU_REGION_APP_BIN);
-
+#ifdef CONFIG_OPTIMIZE_APP_RELOAD_TIME
 	/* Configure text section as RO and executable region */
 	mpu_get_register_config_value(&rtcb->mpu_regs[0], nregion - 3, (uintptr_t)binp->alloc[ALLOC_TEXT], binp->textsize, true, true);
 	/* Configure ro section as RO and non-executable region */

--- a/os/binfmt/binfmt_unloadmodule.c
+++ b/os/binfmt/binfmt_unloadmodule.c
@@ -153,7 +153,6 @@ static inline int exec_dtors(FAR struct binary_s *binp)
 int unload_module(FAR struct binary_s *binp)
 {
 	int ret;
-	int section_idx;
 
 	if (binp) {
 		/* Perform any format-specific unload operations */
@@ -207,6 +206,7 @@ int unload_module(FAR struct binary_s *binp)
 			/* Each loading section is allocated respectively.
 			 * They need to be freed each.
 			 */
+			int section_idx;
 			for (section_idx = 0; section_idx < ALLOC_MAX; section_idx++) {
 				if (binp->alloc[section_idx]) {
 					binfo("Freeing alloc[%d]: %p\n", section_idx, binp->alloc[section_idx]);


### PR DESCRIPTION
- Fix bugs about variable definition
- Build error/warning logs
binfmt_unloadmodule.c: In function 'unload_module':
binfmt_unloadmodule.c:156:6: warning: unused variable 'section_idx' [-Wunused-variable]
  int section_idx;
      ^~~~~~~~~~~
CC:  binfmt_execmodule.c
binfmt_execmodule.c: In function 'exec_module':
binfmt_execmodule.c:201:52: error: 'nregion' undeclared (first use in this function)
  mpu_get_register_config_value(&rtcb->mpu_regs[0], nregion - 1, (uintptr_t)binp->ramstart, binp->ramsize, false, true);