### PR TITLE
apps/examples/wifi_manager_sample/wm_test.c: Fix auth type specified wm_test join issues.

### DIFF
--- a/apps/examples/wifi_manager_sample/wm_test.c
+++ b/apps/examples/wifi_manager_sample/wm_test.c
@@ -1036,9 +1036,9 @@ static int _wm_test_join(struct options *opt, int argc, char *argv[])
 	}
 
 	if (opt->auth_type == WIFI_MANAGER_AUTH_WEP_SHARED) {
-		if (strlen(argv[5]) == 13) {
+		if ((strlen(argv[5]) == 13) || (strlen(argv[5]) == 26)) {
 			opt->crypto_type = WIFI_MANAGER_CRYPTO_WEP_128;
-		} else if (strlen(argv[5]) == 5) {
+		} else if ((strlen(argv[5]) == 5) || (strlen(argv[5]) == 10)) {
 			opt->crypto_type = WIFI_MANAGER_CRYPTO_WEP_64;
 		} else {
 			return -1;
@@ -1070,9 +1070,9 @@ static int _wm_test_set(struct options *opt, int argc, char *argv[])
 	}
 
 	if (opt->auth_type == WIFI_MANAGER_AUTH_WEP_SHARED) {
-		if (strlen(argv[5]) == 13) {
+		if ((strlen(argv[5]) == 13) || (strlen(argv[5]) == 26)) {
 			opt->crypto_type = WIFI_MANAGER_CRYPTO_WEP_128;
-		} else if (strlen(argv[5]) == 5) {
+		} else if ((strlen(argv[5]) == 5) || (strlen(argv[5]) == 10)) {
 			opt->crypto_type = WIFI_MANAGER_CRYPTO_WEP_64;
 		} else {
 			return -1;

--- a/os/board/rtl8721csm/src/component/common/api/wifi_interactive_mode.c
+++ b/os/board/rtl8721csm/src/component/common/api/wifi_interactive_mode.c
@@ -425,11 +425,6 @@ int8_t cmd_wifi_connect(trwifi_ap_config_s *ap_connect_config, void *arg)
 
 	wifi_utils_ap_auth_type_e auth = ap_connect_config->ap_auth_type;
 	wifi_utils_ap_crypto_type_e crypto = ap_connect_config->ap_crypto_type;
-	/* WIFI_MANAGER_CRYPTO_AES: 3 */
-	if (crypto == 3 && ((auth != WIFI_UTILS_AUTH_WPA2_PSK) && (auth != WIFI_UTILS_AUTH_WPA3_PSK))) {
-		ndbg("\r\nInvalid crypto/auth match\n");
-		return -1;
-	}
 	ssid = ap_connect_config->ssid;
 	switch (auth) {
 	case WIFI_UTILS_AUTH_OPEN:
@@ -444,8 +439,8 @@ int8_t cmd_wifi_connect(trwifi_ap_config_s *ap_connect_config, void *arg)
 		password = ap_connect_config->passphrase;
 		ssid_len = strlen((const char *)ssid);
 		password_len = ap_connect_config->passphrase_length;
-		if ((password_len != 5) && (password_len != 13)) {
-			ndbg("\n\rWrong WEP key length. Must be 5 or 13 ASCII characters.");
+		if ((password_len != 5) && (password_len != 13) && (password_len != 10) && (password_len != 26)) {
+			ndbg("\n\rWrong WEP key length. Must be 5 or 13 ASCII characters, or 10 or 26 for HEX password.");
 			return -1;
 		}
 		semaphore = NULL;


### PR DESCRIPTION
Fix 2 parts: 1. wep_shared key not only support ASCII password, but also HEX password, while checking password length, add conditions.
                  2. In wifi_interactive_mode.c, cmd_wifi_connect() checked AES and auth type match. It is okay to skip, delete it to keep it same as RTK default wifi_interactive_mode.c, if keep this check, need to add for wpa, wpa12, wps for all cases.