### PR TITLE
drivers: Store filep to distinguish fds of poll waiter slots

### DIFF
--- a/os/drivers/gpio/gpio.c
+++ b/os/drivers/gpio/gpio.c
@@ -515,6 +515,7 @@ static int gpio_poll(FAR struct file *filep, FAR struct pollfd *fds,
 				/* Bind the poll structure and this slot */
 				opriv->go_fds[i] = fds;
 				fds->priv = &opriv->go_fds[i];
+				fds->filep = (void *)filep;
 				break;
 			}
 		}
@@ -594,7 +595,7 @@ static int gpio_close(FAR struct file *filep)
 	 */
 	for (waiter_idx = 0; waiter_idx < CONFIG_GPIO_NPOLLWAITERS; waiter_idx++) {
 		struct pollfd *fds = opriv->go_fds[waiter_idx];
-		if (fds && fds->priv == (FAR void *)&opriv->go_fds[waiter_idx]) {
+		if (fds && (FAR struct file *)fds->filep == filep) {
 			opriv->go_fds[waiter_idx] = NULL;
 		}
 	}

--- a/os/drivers/lwnl/lwnl.c
+++ b/os/drivers/lwnl/lwnl.c
@@ -171,7 +171,7 @@ static int lwnl_close(struct file *filep)
 	 */
 	for (waiter_idx = 0; waiter_idx < LWNL_NPOLLWAITERS; waiter_idx++) {
 		struct pollfd *fds = ln_open->io_fds[waiter_idx];
-		if (fds && fds->priv == (FAR void *)&ln_open->io_fds[waiter_idx]) {
+		if (fds && (FAR struct file *)fds->filep == filep) {
 			ln_open->io_fds[waiter_idx] = NULL;
 		}
 	}
@@ -269,6 +269,7 @@ static int lwnl_poll(FAR struct file *filep, FAR struct pollfd *fds, bool setup)
 				/* Bind the poll structure and this slot */
 				ln_open->io_fds[i] = fds;
 				fds->priv = &ln_open->io_fds[i];
+				fds->filep = (void *)filep;
 				break;
 			}
 		}


### PR DESCRIPTION
Store filep when file is registered in a list of waiters for polling and check it when closing filep.