### PR TITLE
Load apps into single RAM region

### DIFF
--- a/os/arch/Kconfig
+++ b/os/arch/Kconfig
@@ -798,6 +798,16 @@ config RAM_KREGIONx_HEAP_INDEX
 		It means that its region can be handled to the index-th heap.
 		Index can be from 0 to (KMM_NHEAPS-1).
 
+config HEAP_INDEX_LOADED_APP
+	int "Heap index for allocating app elf sections and app heap"
+	default 0
+	depends on APP_BINARY_SEPARATION
+	---help---
+		This heap index is used for allocating elf sections and heap area
+		for loadable apps. This value must be set to point to a heap which
+		has sufficient size of contiguous memory to accomodate all the
+		app sections with their alignment requriements.
+
 config RAM_MALLOC_PRIOR_INDEX
 	int "prior region index(0 KMM_NHEAPS-1) of RAM used in malloc"
 	default 0

--- a/os/arch/arm/src/common/up_allocateheap.c
+++ b/os/arch/arm/src/common/up_allocateheap.c
@@ -161,6 +161,7 @@ void up_add_kregion(void)
 	kheap = kmm_get_heap();
 	for (region_cnt = 1; region_cnt < CONFIG_KMM_REGIONS; region_cnt++) {
 		if (kheap[kregionx_heap_idx[region_cnt]].mm_heapsize == 0) {
+			lldbg("Heap idx = %u start = 0x%x size = %d\n", kregionx_heap_idx[region_cnt], kregionx_start[region_cnt], kregionx_size[region_cnt]);
 			mm_initialize(&kheap[kregionx_heap_idx[region_cnt]], kregionx_start[region_cnt], kregionx_size[region_cnt]);
 			continue;
 		}

--- a/os/include/tinyara/mm/mm.h
+++ b/os/include/tinyara/mm/mm.h
@@ -723,22 +723,6 @@ typedef struct heapinfo_total_info_s heapinfo_total_info_t;
  * @cond
  * @internal
  */
-#ifdef CONFIG_MM_KERNEL_HEAP
-#if CONFIG_KMM_NHEAPS > 1
-void *kmm_malloc_at(int heap_index, size_t size);
-void *kmm_calloc_at(int heap_index, size_t n, size_t elem_size);
-void *kmm_memalign_at(int heap_index, size_t alignment, size_t size);
-void *kmm_realloc_at(int heap_index, void *oldmem, size_t size);
-void *kmm_zalloc_at(int heap_index, size_t size);
-#else
-#define kmm_malloc_at(heap_index, size)              kmm_malloc(size)
-#define kmm_calloc_at(heap_index, n, elem_size)      kmm_calloc(n, elem_size)
-#define kmm_memalign_at(heap_index, alignment, size) kmm_memalign(alignment, size)
-#define kmm_realloc_at(heap_index, oldmem, size)     kmm_realloc(oldmem, size)
-#define kmm_zalloc_at(heap_index, size)              kmm_zalloc(size)
-#endif
-#endif
-
 /**
  * @brief Allocate memory to the specific heap.
  * @details @b #include <tinyara/mm/mm.h>\n
@@ -813,6 +797,22 @@ void *zalloc_at(int heap_index, size_t size);
 /**
  * @endcond
  */
+
+#ifdef CONFIG_MM_KERNEL_HEAP
+#if CONFIG_KMM_NHEAPS > 1
+void *kmm_malloc_at(int heap_index, size_t size);
+void *kmm_calloc_at(int heap_index, size_t n, size_t elem_size);
+void *kmm_memalign_at(int heap_index, size_t alignment, size_t size);
+void *kmm_realloc_at(int heap_index, void *oldmem, size_t size);
+void *kmm_zalloc_at(int heap_index, size_t size);
+#else
+#define kmm_malloc_at(heap_index, size)              kmm_malloc(size)
+#define kmm_calloc_at(heap_index, n, elem_size)      kmm_calloc(n, elem_size)
+#define kmm_memalign_at(heap_index, alignment, size) kmm_memalign(alignment, size)
+#define kmm_realloc_at(heap_index, oldmem, size)     kmm_realloc(oldmem, size)
+#define kmm_zalloc_at(heap_index, size)              kmm_zalloc(size)
+#endif
+#endif
 
 static inline uint32_t mm_align_up_by_size(uint32_t address, uint32_t size)
 {


### PR DESCRIPTION
Load apps into single RAM region to make sure that all app sections are within 32MB address range.
Modify defconfig to use 2 heaps to allow the above change