### PR TITLE
os/board/rtl8721csm: Fix compile error when TrustZone not enable

### DIFF
--- a/os/board/rtl8721csm/src/component/soc/realtek/amebad/fwlib/ram_hp/rtl8721dhp_app_start.c
+++ b/os/board/rtl8721csm/src/component/soc/realtek/amebad/fwlib/ram_hp/rtl8721dhp_app_start.c
@@ -1019,7 +1019,9 @@ u32 app_mpu_nocache_init(void)
 
 u32 app_mpu_s_nocache_init(void)
 {
+#ifdef CONFIG_AMEBAD_TRUSTZONE
 	mpu_s_no_cache_init();
+#endif
 }
 
 VOID app_vdd1833_detect(VOID)


### PR DESCRIPTION
Fix compile error when TrustZone not enable, do not call mpu_s_no_cache_init() when TrustZone is not enable.
mpu_s_no_cache_init() only exist in TrustZone