### PR TITLE
arch/arm/src/armv8-m: Fix build break with MPU Stack protection enabled.

### DIFF
--- a/os/arch/arm/src/armv8-m/up_svcall.c
+++ b/os/arch/arm/src/armv8-m/up_svcall.c
@@ -274,7 +274,7 @@ int up_svcall(int irq, FAR void *context, FAR void *arg)
 			}
 		}
 #ifdef CONFIG_MPU_STACK_OVERFLOW_PROTECTION
-		up_mpu_set_register(tcb->stack_mpu_regs);
+		up_mpu_set_register(rtcb->stack_mpu_regs);
 #endif
 #endif
 #ifdef CONFIG_SUPPORT_COMMON_BINARY


### PR DESCRIPTION
This patch fixes the following build break:
armv8-m/up_svcall.c: In function 'up_svcall':
armv8-m/up_svcall.c:277:23: error: 'tcb' undeclared (first use in this function)
   up_mpu_set_register(tcb->stack_mpu_regs);
                       ^~~

Signed-off-by: Vidisha <thapa.v@samsung.com>