### PR TITLE
loadable_apps/wifiapp : Change user input variable type from char to int

### DIFF
--- a/loadable_apps/loadable_sample/wifiapp/wifiapp.c
+++ b/loadable_apps/loadable_sample/wifiapp/wifiapp.c
@@ -59,7 +59,7 @@ int main(int argc, char **argv)
 int wifiapp_main(int argc, char **argv)
 #endif
 {
-	char ch;
+	int ch;
 	bool is_testing = true;
 
 #if defined(CONFIG_SYSTEM_PREAPP_INIT) && defined(CONFIG_APP_BINARY_SEPARATION)


### PR DESCRIPTION
 WID:10253106 Integer value received from 'fgetc' can't be safely converted to a character at wifiapp.c:89 without a test for EOF.