### PR TITLE
Fix Svace errors - FS

### DIFF
--- a/os/fs/driver/mtd/smart.c
+++ b/os/fs/driver/mtd/smart.c
@@ -941,9 +941,9 @@ static ssize_t smart_write(FAR struct inode *inode, FAR const unsigned char *buf
 
 	/* Convert SMART blocks into MTD blocks. */
 
-	mtdstartblock = start_sector * dev->mtdBlksPerSector;
-	mtdblockcount = nsectors * dev->mtdBlksPerSector;
-	mtdBlksPerErase = dev->mtdBlksPerSector * dev->sectorsPerBlk;
+	mtdstartblock = (off_t)start_sector * (off_t)dev->mtdBlksPerSector;
+	mtdblockcount = (off_t)nsectors * (off_t)dev->mtdBlksPerSector;
+	mtdBlksPerErase = (off_t)dev->mtdBlksPerSector * (off_t)dev->sectorsPerBlk;
 
 	fvdbg("mtdsector: %d mtdnsectors: %d\n", mtdstartblock, mtdblockcount);
 
@@ -1819,7 +1819,7 @@ static int smart_set_wear_level(FAR struct smart_struct_s *dev, uint16_t block, 
 static int smart_scan(FAR struct smart_struct_s *dev)
 {
 	int sector;
-	int ret;
+	int ret = OK;
 	uint16_t totalsectors;
 	uint16_t prerelease;
 	uint16_t logicalsector;
@@ -5019,7 +5019,7 @@ static int smart_journal_release_sector(FAR struct smart_struct_s *dev, uint16_t
 	struct smart_sect_header_s header;
 	size_t offset;
 
-	offset = psector * dev->sectorsize;
+	offset = (off_t)psector * (off_t)dev->sectorsize;
 	ret = MTD_READ(dev->mtd, offset, sizeof(struct smart_sect_header_s), (FAR uint8_t *)&header);
 	if (ret != sizeof(struct smart_sect_header_s)) {
 		fdbg("Read header failed psector : %d offset : %d\n", psector, offset);
@@ -5159,7 +5159,7 @@ static int smart_journal_process_transaction(FAR struct smart_struct_s *dev, jou
 	case SMART_JOURNAL_TYPE_COMMIT: {
 
 		/* Write given data in rwbuffer from users, except mtd header */
-		ret = MTD_WRITE(dev->mtd, psector * dev->sectorsize + mtd_size, dev->sectorsize - mtd_size, (FAR uint8_t *)&dev->rwbuffer[mtd_size]);
+		ret = MTD_WRITE(dev->mtd, ((off_t)psector * dev->sectorsize) + (off_t)mtd_size, dev->sectorsize - mtd_size, (FAR uint8_t *)&dev->rwbuffer[mtd_size]);
 		if (ret != dev->sectorsize - mtd_size) {
 			fdbg("write data failed ret : %d\n", ret);
 			return -EIO;

--- a/os/fs/smartfs/smartfs_smart.c
+++ b/os/fs/smartfs/smartfs_smart.c
@@ -561,7 +561,7 @@ static ssize_t smartfs_read(FAR struct file *filep, char *buffer, size_t buflen)
 #endif
 		/* Calculate the number of bytes to read into the buffer */
 
-		bytestoread = bytesinsector - (sf->curroffset - sizeof(struct smartfs_chain_header_s));
+		bytestoread = bytesinsector - (sf->curroffset - (uint16_t)sizeof(struct smartfs_chain_header_s));
 		if (bytestoread + bytesread > buflen) {
 			/* Truncate bytesto read based on buffer len */
 

--- a/os/fs/smartfs/smartfs_utils.c
+++ b/os/fs/smartfs/smartfs_utils.c
@@ -2509,7 +2509,7 @@ int smartfs_sector_recovery(struct smartfs_mountpt_s *fs)
 	int ret;
 	long sector;
 	struct sector_recover_info_s info = {0,};
-	size_t size = (fs->fs_llformat.nsectors >> 3) + 1;
+	size_t size = (size_t)(fs->fs_llformat.nsectors >> 3) + 1;
 	
 	/* Alloc Logical Map */
 	char *map = (char *)kmm_malloc(sizeof(uint8_t *) * size);

--- a/tools/nxfuse/src/filemtd.c
+++ b/tools/nxfuse/src/filemtd.c
@@ -474,7 +474,7 @@ static int file_ioctl(FAR struct mtd_dev_s *dev, int cmd, unsigned long arg)
  *
  ****************************************************************************/
 
-FAR struct mtd_dev_s *filemtd_initialize(FAR const char *path, size_t offset, int16_t sectsize, int32_t erasesize)
+FAR struct mtd_dev_s *filemtd_initialize(FAR const char *path, size_t offset, uint16_t sectsize, uint32_t erasesize)
 {
 	FAR struct file_dev_s *priv;
 	struct stat sb;
@@ -543,6 +543,7 @@ FAR struct mtd_dev_s *filemtd_initialize(FAR const char *path, size_t offset, in
 	nblocks = (filelen - offset) / priv->erasesize;
 	if (nblocks < 3) {
 		fdbg("Need to provide at least three full erase block\n");
+		close(priv->fd);
 		kmm_free(priv);
 		return NULL;
 	}

--- a/tools/nxfuse/src/main.c
+++ b/tools/nxfuse/src/main.c
@@ -99,19 +99,19 @@ extern struct fuse_operations nxfuse_oper;
 int main(int argc, char *argv[])
 {
 	int opt, ret;
-	int erasesize = 0;
-	int sectsize = 0;
+	uint32_t erasesize = 0;
+	uint16_t sectsize = 0;
 	int pagesize = 0;
 	int fuse_argc;
 	int confirm = 0;
 	char *generic = "";
 	int opt_mkfs = 0;
 	int no_mount = 0;
-	char **fuse_argv;
+	char **fuse_argv = NULL;
 	const char *filename;
 	char *mount_point;
 	struct inode *pinode;
-	struct nxfuse_state *nxfuse_data;
+	struct nxfuse_state *nxfuse_data = NULL;
 	const char *fs_type = "smartfs";
 	char fsname[128];
 
@@ -121,6 +121,10 @@ int main(int argc, char *argv[])
 
 	fuse_argc = 1;
 	fuse_argv = malloc(sizeof(char *));
+	if (fuse_argv == NULL) {
+		printf("Unable to allocate memory for \'fuse_argv\' pointer\n");
+		return -1;
+	}
 	fuse_argv[0] = argv[0];
 
 	/* Parse the options.  This includes our own custom options as well
@@ -134,6 +138,10 @@ int main(int argc, char *argv[])
 
 			fuse_argc++;
 			fuse_argv = realloc(fuse_argv, sizeof(char *) * fuse_argc);
+			if (fuse_argv == NULL) {
+				printf("Unable to reallocate memory for \'fuse_argv\' pointer\n");
+				return -1;
+			}
 			fuse_argv[fuse_argc - 1] = "-d";
 			break;
 
@@ -143,6 +151,10 @@ int main(int argc, char *argv[])
 			no_mount = 1;
 			fuse_argc++;
 			fuse_argv = realloc(fuse_argv, sizeof(char *) * fuse_argc);
+			if (fuse_argv == NULL) {
+				printf("Unable to reallocate memory for \'fuse_argv\' pointer\n");
+				return -1;
+			}
 			fuse_argv[fuse_argc - 1] = "-h";
 			break;
 
@@ -152,6 +164,10 @@ int main(int argc, char *argv[])
 			no_mount = 1;
 			fuse_argc++;
 			fuse_argv = realloc(fuse_argv, sizeof(char *) * fuse_argc);
+			if (fuse_argv == NULL) {
+				printf("Unable to reallocate memory for \'fuse_argv\' pointer\n");
+				return -1;
+			}
 			fuse_argv[fuse_argc - 1] = "-V";
 			break;
 
@@ -160,6 +176,10 @@ int main(int argc, char *argv[])
 
 			fuse_argc++;
 			fuse_argv = realloc(fuse_argv, sizeof(char *) * fuse_argc);
+			if (fuse_argv == NULL) {
+				printf("Unable to reallocate memory for \'fuse_argv\' pointer\n");
+				return -1;
+			}
 			fuse_argv[fuse_argc - 1] = "-s";
 			break;
 
@@ -168,6 +188,10 @@ int main(int argc, char *argv[])
 
 			fuse_argc++;
 			fuse_argv = realloc(fuse_argv, sizeof(char *) * fuse_argc);
+			if (fuse_argv == NULL) {
+				printf("Unable to reallocate memory for \'fuse_argv\' pointer\n");
+				return -1;
+			}
 			fuse_argv[fuse_argc - 1] = "-f";
 			break;
 
@@ -176,6 +200,10 @@ int main(int argc, char *argv[])
 
 			fuse_argc += 2;
 			fuse_argv = realloc(fuse_argv, sizeof(char *) * fuse_argc);
+			if (fuse_argv == NULL) {
+				printf("Unable to reallocate memory for \'fuse_argv\' pointer\n");
+				return -1;
+			}
 			fuse_argv[fuse_argc - 2] = "-o";
 			fuse_argv[fuse_argc - 1] = optarg;
 			break;
@@ -285,6 +313,10 @@ int main(int argc, char *argv[])
 
 	fuse_argc += 2;
 	fuse_argv = realloc(fuse_argv, sizeof(char *) * fuse_argc);
+	if (fuse_argv == NULL) {
+		printf("Unable to reallocate memory for \'fuse_argv\' pointer\n");
+		return -1;
+	}
 	fuse_argv[fuse_argc - 2] = "-o";
 	sprintf(fsname, "subtype=%s", fs_type);
 	fuse_argv[fuse_argc - 1] = fsname;
@@ -293,6 +325,10 @@ int main(int argc, char *argv[])
 
 	fuse_argc++;
 	fuse_argv = realloc(fuse_argv, sizeof(char *) * fuse_argc);
+	if (fuse_argv == NULL) {
+		printf("Unable to reallocate memory for \'fuse_argv\' pointer\n");
+		return -1;
+	}
 	fuse_argv[fuse_argc - 1] = mount_point;
 
 	/* Call fuse_main to start the FS */

--- a/tools/nxfuse/src/nxfuse.h
+++ b/tools/nxfuse/src/nxfuse.h
@@ -109,6 +109,6 @@ struct inode *vmount(const char *filename, const char *mount_point, const char *
  *   specified NuttX filesystem type.
  *
  ****************************************************************************/
-int mkfs(const char *filename, const char *fs_type, int erasesize, int sectsize, int pagesize, char *generic, int confirm);
+int mkfs(const char *filename, const char *fs_type, uint32_t erasesize, uint16_t sectsize, int pagesize, char *generic, int confirm);
 
 #endif							/* _SRC_NXFUSE_H */

--- a/tools/nxfuse/src/tinyara_services.c
+++ b/tools/nxfuse/src/tinyara_services.c
@@ -72,6 +72,7 @@
 #include <tinyara/fs/mtd.h>
 #include <tinyara/fs/smart.h>
 #include <tinyara/fs/ioctl.h>
+#include <limits.h>
 
 #include "nxfuse.h"
 
@@ -82,7 +83,7 @@
 struct fs_ops_s {
 	const char *fs_name;
 	void *(*vmount)(const char *datasource, const char *mount_point, int erasesize, int sectsize, int pagesize, char *generic);
-	int (*mkfs)(const char *datasource, int erasesize, int sectsize, int pagesize, char *, int confirm);
+	int (*mkfs)(const char *datasource, uint32_t erasesize, uint16_t sectsize, int pagesize, char *, int confirm);
 	const struct mountpt_operations *pops;
 };
 
@@ -101,8 +102,8 @@ extern FAR struct mtd_dev_s *filemtd_initialize(FAR const char *path, size_t off
  ****************************************************************************/
 
 #ifdef CONFIG_FS_SMARTFS
-static void *smartfs_vmount(const char *datasource, const char *mount_point, int erasesize, int sectsize, int pagesize, char *generic);
-static int smartfs_mkfs(const char *datasource, int erasesize, int sectsize, int pagesize, char *generic, int confirm);
+static void *smartfs_vmount(const char *datasource, const char *mount_point, uint32_t erasesize, uint16_t sectsize, int pagesize, char *generic);
+static int smartfs_mkfs(const char *datasource, uint32_t erasesize, uint16_t sectsize, int pagesize, char *generic, int confirm);
 #endif
 
 /****************************************************************************
@@ -183,12 +184,12 @@ int register_blockdriver(FAR const char *path, FAR const struct block_operations
 	struct inode *node;
 	int ret;
 
-	node = calloc(sizeof(struct inode) + strlen(path), 1);
+	node = calloc(sizeof(struct inode) + PATH_MAX, 1);
 	if (node == NULL) {
 		return -1;
 	}
 
-	strcpy(node->i_name, path);
+	strncpy(node->i_name, path, PATH_MAX);
 	node->i_crefs = 0;
 	node->i_peer = NULL;
 	node->i_child = NULL;
@@ -362,7 +363,7 @@ struct inode *vmount(const char *datasource, const char *mount_point, const char
  ****************************************************************************/
 
 #ifdef CONFIG_FS_SMARTFS
-void *smartfs_vmount(const char *datasource, const char *mount_point, int erasesize, int sectsize, int pagesize, char *generic)
+void *smartfs_vmount(const char *datasource, const char *mount_point, uint32_t erasesize, uint16_t sectsize, int pagesize, char *generic)
 {
 	int ret;
 	int offset = 0;
@@ -429,7 +430,7 @@ void *smartfs_vmount(const char *datasource, const char *mount_point, int erases
  *
  ****************************************************************************/
 
-int mkfs(const char *datasource, const char *fs_type, int erasesize, int sectsize, int pagesize, char *generic, int confirm)
+int mkfs(const char *datasource, const char *fs_type, uint32_t erasesize, uint16_t sectsize, int pagesize, char *generic, int confirm)
 {
 	int x;
 	int ret = -ENODEV;
@@ -501,13 +502,15 @@ static int smartfs_umount(struct inode *blkdriver, void *fshandle)
  *
  ****************************************************************************/
 
-static int smartfs_mkfs(const char *datasource, int erasesize, int sectsize, int pagesize, char *generic, int confirm)
+static int smartfs_mkfs(const char *datasource, uint32_t erasesize, uint16_t sectsize, int pagesize, char *generic, int confirm)
 {
-	int ret = OK, x;
+	int ret;
+	int x;
 	void *fshandle;
 	struct inode *blkdriver;
 	uint8_t type;
 	struct smart_read_write_s request;
+	uint64_t sectorsize;
 
 	/* Try to mount the device to see if there is a format already */
 
@@ -541,10 +544,11 @@ static int smartfs_mkfs(const char *datasource, int erasesize, int sectsize, int
 
 	/* Perform a low-level SMART format */
 
+	sectorsize = (uint64_t)(sectsize << 16);
 #ifdef CONFIG_SMARTFS_MULTI_ROOT_DIRS
-	ret = blkdriver->u.i_bops->ioctl(blkdriver, BIOC_LLFORMAT, (sectsize << 16) | atoi(generic));
+	ret = blkdriver->u.i_bops->ioctl(blkdriver, BIOC_LLFORMAT, sectorsize | atoi(generic));
 #else
-	ret = blkdriver->u.i_bops->ioctl(blkdriver, BIOC_LLFORMAT, sectsize << 16);
+	ret = blkdriver->u.i_bops->ioctl(blkdriver, BIOC_LLFORMAT, sectorsize);
 #endif
 	if (ret != OK) {
 		close_blockdriver(blkdriver);
@@ -596,11 +600,8 @@ static int smartfs_mkfs(const char *datasource, int erasesize, int sectsize, int
 		}
 	}
 
-	if (ret == OK) {
-		printf("Format successful\n");
-	} else {
-		printf("Error %d during format\n", ret);
-	}
+	printf("Format successful\n");
+
 	return ret;
 }
 #endif							/* CONFIG_FS_SMARTFS */


### PR DESCRIPTION
- Fix - possibly uninitialized variable 'nxfuse_data' passed to fuse_main()
- Fix - check possible NULL return value of recall before deferencing pointer
- Fix - file opened but not closed before returning in error case
- Fix - use 'strncpy' instead of 'strcpy' for safety
- Fix - possibly unreachable code
- Fix - result of mathematical operation subject to overflow
- Fix - Possible underflow of integer during unsigned subtraction
- Fix - Assignment of signed int to bigger unsigned int without proper casting (added explicit type casting)