### PR TITLE
network/tls: fix ecdsa HW acceleration

### DIFF
--- a/external/mbedtls/alt/pk_wrap_alt.c
+++ b/external/mbedtls/alt/pk_wrap_alt.c
@@ -863,7 +863,7 @@ int eckey_sign_wrap(void *ctx, mbedtls_md_type_t md_alg, const unsigned char *ha
 	mbedtls_ecdsa_init(&ecdsa);
 
 	if ((ret = mbedtls_ecdsa_from_keypair(&ecdsa, ctx)) == 0) {
-		unsigned int key_idx = (((mbedtls_ecp_keypair *) ctx)->grp).key_index;
+		unsigned int key_idx = (((mbedtls_ecp_keypair *) ctx)->grp).key_index = (((mbedtls_ecp_keypair *) ctx)->key_index);
 		unsigned int curve = ecdsa.grp.id;
 
 		hal_data t_hash = {0,};


### PR DESCRIPTION
there're two location to set key index in ecp_keypair. this should be
fixed later.