### PR TITLE
arch/arm/Kconfig : Disable MPU based stack protection if selected v8m…

### DIFF
--- a/os/arch/arm/Kconfig
+++ b/os/arch/arm/Kconfig
@@ -304,6 +304,7 @@ config MPU_STACK_OVERFLOW_PROTECTION
 	bool "MPU Stack Overflow Protection"
 	depends on BUILD_PROTECTED
 	depends on ARM_MPU
+	depends on !ARMV8M_MPU
 	---help---
 		Enables stack overflow protection.
 		It protects each task's stack overflow outside its max allocated stack memory.


### PR DESCRIPTION
… arch

ARMv8M MPU cannot permit to overlap the region.
So we cannot use MPU based stack protection on ARMv8M architecture.
We can refer to the belows:
https://developer.arm.com/documentation/100235/0100/The-Cortex-M33-Peripherals/Security-Attribution-and-Memory-Protection/Memory-Protection-Unit?lang=en
"When memory regions overlap, the processor generates a fault if a core access hits the overlapping regions."