### PR TITLE
configs/rtl8721csm: Remove checking filename according to trustzone in download script

### DIFF
--- a/build/configs/rtl8721csm/rtl8721csm_download.sh
+++ b/build/configs/rtl8721csm/rtl8721csm_download.sh
@@ -72,13 +72,7 @@ function get_executable_name()
 {
 	case $1 in
 		km0_bl) echo "km0_boot_all.bin";;
-		km4_bl)
-			if [[ "${CONFIG_AMEBAD_TRUSTZONE}" == "y" ]];then
-				echo "km4_boot_all_tz.bin"
-			else
-				echo "km4_boot_all.bin"
-			fi
-			;;
+		km4_bl) echo "km4_boot_all.bin";;
 		kernel) echo "km0_km4_image2.bin";;
 		userfs) echo "rtl8721csm_smartfs.bin";;
 		*) echo "No Binary Match"
@@ -148,11 +142,7 @@ function get_partition_sizes()
 # Start here
 
 cp -p ${BIN_PATH}/km0_boot_all.bin ${IMG_TOOL_PATH}/km0_boot_all.bin
-if [[ "${CONFIG_AMEBAD_TRUSTZONE}" == "y" ]];then
-	cp -p ${TOOL_PATH}/bootloader/km4_boot_all_tz.bin ${IMG_TOOL_PATH}/km4_boot_all_tz.bin
-else 
-	cp -p ${BIN_PATH}/km4_boot_all.bin ${IMG_TOOL_PATH}/km4_boot_all.bin
-fi
+cp -p ${BIN_PATH}/km4_boot_all.bin ${IMG_TOOL_PATH}/km4_boot_all.bin
 cp -p ${BIN_PATH}/km0_km4_image2.bin ${IMG_TOOL_PATH}/km0_km4_image2.bin
 if test -f "${SMARTFS_BIN_PATH}"; then
 	cp -p ${BIN_PATH}/rtl8721csm_smartfs.bin ${IMG_TOOL_PATH}/rtl8721csm_smartfs.bin


### PR DESCRIPTION
In build-time, the name of km4 image is set to km0_boot_all.bin regardless of trustzone in rtl8721csm_make_bin.sh.
Remove checking filename according to trustzone in download script.