### PR TITLE
board/rtl8721csm/src/component/os/tizenrt: Modification for easy setup example performance.

### DIFF
--- a/os/board/rtl8721csm/src/component/os/tizenrt/tizenrt_service.c
+++ b/os/board/rtl8721csm/src/component/os/tizenrt/tizenrt_service.c
@@ -497,12 +497,12 @@ static void _tizenrt_usleep_os(int us)
 
 static void _tizenrt_mdelay_os(int ms)
 {
-	usleep((unsigned long)ms * 1000);
+	up_mdelay((unsigned long)ms);
 }
 
 static void _tizenrt_udelay_os(int us)
 {
-	usleep((unsigned long)us);
+	up_udelay((unsigned long)us);
 }
 
 static void _tizenrt_yield_os(void)


### PR DESCRIPTION
Modification for easy setup example performance, revert the changes made for tizenrt os delay API usage in previous PR, change back to up_mdelay and up_udelay.

Signed-off-by: fengyunlai <1063072208@qq.com>