### PR TITLE
fs/tmpfs : Change wrong memory allocation usage

### DIFF
--- a/os/fs/tmpfs/fs_tmpfs.h
+++ b/os/fs/tmpfs/fs_tmpfs.h
@@ -81,9 +81,9 @@
 #undef  kmm_malloc
 #undef  kmm_zalloc
 #undef  kmm_realloc
-#define kmm_malloc(s)     malloc_at(CONFIG_FS_TMPFS_HEAP_INDEX, s)
-#define kmm_zalloc(s)     zalloc_at(CONFIG_FS_TMPFS_HEAP_INDEX, s)
-#define kmm_realloc(p, s) realloc_at(CONFIG_FS_TMPFS_HEAP_INDEX, p, s)
+#define kmm_malloc(s)     kmm_malloc_at(CONFIG_FS_TMPFS_HEAP_INDEX, s)
+#define kmm_zalloc(s)     kmm_zalloc_at(CONFIG_FS_TMPFS_HEAP_INDEX, s)
+#define kmm_realloc(p, s) kmm_realloc_at(CONFIG_FS_TMPFS_HEAP_INDEX, p, s)
 #endif
 
 /****************************************************************************


### PR DESCRIPTION
kmm_malloc can be matched with kmm_malloc_at, instead of malloc_at for allocating the memory into the kernel.