### PR TITLE
Update Dump Tool (Realtek - rtl8721csm)

### DIFF
--- a/build/configs/rtl8721csm/hello/Make.defs
+++ b/build/configs/rtl8721csm/hello/Make.defs
@@ -121,7 +121,7 @@ ifneq ($(CONFIG_DEBUG_NOOPT),y)
 endif
 
 ifeq ($(CONFIG_FRAME_POINTER),y)
-  ARCHOPTIMIZATION += -fno-omit-frame-pointer -mapcs -mno-sched-prolog
+  ARCHOPTIMIZATION += -fomit-frame-pointer -mapcs -mno-sched-prolog
 endif
 
 ARCHCFLAGS = -fno-builtin -mcpu=cortex-m33 -mfpu=fpv5-sp-d16

--- a/build/configs/rtl8721csm/loadable_apps/Make.defs
+++ b/build/configs/rtl8721csm/loadable_apps/Make.defs
@@ -121,7 +121,7 @@ ifneq ($(CONFIG_DEBUG_NOOPT),y)
 endif
 
 ifeq ($(CONFIG_FRAME_POINTER),y)
-  ARCHOPTIMIZATION += -fno-omit-frame-pointer -mapcs -mno-sched-prolog
+  ARCHOPTIMIZATION += -fomit-frame-pointer -mapcs -mno-sched-prolog
 endif
 
 ARCHCFLAGS = -fno-builtin -mcpu=cortex-m33 -mfpu=fpv5-sp-d16 -fno-common

--- a/build/configs/rtl8721csm/rdp/Make.defs
+++ b/build/configs/rtl8721csm/rdp/Make.defs
@@ -122,7 +122,7 @@ ifneq ($(CONFIG_DEBUG_NOOPT),y)
 endif
 
 ifeq ($(CONFIG_FRAME_POINTER),y)
-  ARCHOPTIMIZATION += -fno-omit-frame-pointer -mapcs -mno-sched-prolog
+  ARCHOPTIMIZATION += -fomit-frame-pointer -mapcs -mno-sched-prolog
 endif
 
 ARCHCFLAGS = -fno-builtin -mcpu=cortex-m33 -mfpu=fpv5-sp-d16

--- a/build/configs/rtl8721csm/security_hal_test_tz/Make.defs
+++ b/build/configs/rtl8721csm/security_hal_test_tz/Make.defs
@@ -88,7 +88,7 @@ ifneq ($(CONFIG_DEBUG_NOOPT),y)
 endif
 
 ifeq ($(CONFIG_FRAME_POINTER),y)
-  ARCHOPTIMIZATION += -fno-omit-frame-pointer -mapcs -mno-sched-prolog
+  ARCHOPTIMIZATION += -fomit-frame-pointer -mapcs -mno-sched-prolog
 endif
 
 ARCHCFLAGS = -fno-builtin -mcpu=cortex-m33 -mfpu=fpv5-sp-d16

--- a/build/configs/rtl8721csm/tc/Make.defs
+++ b/build/configs/rtl8721csm/tc/Make.defs
@@ -121,7 +121,7 @@ ifneq ($(CONFIG_DEBUG_NOOPT),y)
 endif
 
 ifeq ($(CONFIG_FRAME_POINTER),y)
-  ARCHOPTIMIZATION += -fno-omit-frame-pointer -mapcs -mno-sched-prolog
+  ARCHOPTIMIZATION += -fomit-frame-pointer -mapcs -mno-sched-prolog
 endif
 
 ARCHCFLAGS = -fno-builtin -mcpu=cortex-m33 -mfpu=fpv5-sp-d16

--- a/os/tools/mkconfig.c
+++ b/os/tools/mkconfig.c
@@ -188,7 +188,7 @@ int main(int argc, char **argv, char **envp)
 	printf("# elif CONFIG_ARCH_BOARD_ESP32_FAMILY == 1\n");
 	printf("#  define CONFIG_FLASH_START_ADDR 0x300000\n");
 	printf("# elif CONFIG_ARCH_BOARD_RTL8721CSM == 1\n");
-	printf("#  define CONFIG_FLASH_START_ADDR 0x0\n");
+	printf("#  define CONFIG_FLASH_START_ADDR 0x8000000\n");
 	printf("# elif CONFIG_ARCH_BOARD_SIDK_S5JT200 == 1\n");
 	printf("#  define CONFIG_FLASH_START_ADDR 0x040C8000\n");
 	printf("# elif (CONFIG_ARCH_BOARD_STM32F407_DISC1 == 1 || CONFIG_ARCH_BOARD_STM32F429I_DISCO == 1 || CONFIG_ARCH_BOARD_STM32L4R9AI_DISCO == 1)\n");

--- a/tools/dump_tool/HowToUseDumpTool.md
+++ b/tools/dump_tool/HowToUseDumpTool.md
@@ -30,6 +30,11 @@ Debug Options -> Enable Debug Output Features to y
 ```
 Debug Options -> Enable backtracking using Frame pointer register  to y
 ```
+```
+NOTE: - For devices that use ARM Cortex M, backtracking of frame pointer is not supported.
+Hence, it is not possible to obtain exact call stack for the crash.
+Ramdump may not produce results as expected in such cases.
+```
 
 ## How to upload RAMDUMP-or-UserfsDUMP
 ### In Linux

--- a/tools/dump_tool/dump_tool.c
+++ b/tools/dump_tool/dump_tool.c
@@ -220,7 +220,7 @@ static int fsdump_recv(int dev_fd)
 	}
 
 	printf("\n=========================================================================\n");
-	printf("Filesystem start address = %x, filesystem size = %d\n", smartfs_addr, smartfs_size);
+	printf("Filesystem start address = %08x, filesystem size = %d\n", smartfs_addr, smartfs_size);
 	printf("=========================================================================\n");
 
 	/* Create filesystem dump binary file name */


### PR DESCRIPTION
- ARM Cortex M devices do not support register for frame pointer backtracking.
  Hence, build fails when CONFIG_FRAME_POINTER is selected.
  Add flag to omit frame pointer while building for rtl8721csm.
- For such cases, it is not possible to obtain exact call stack for the crash.
- Modify flash base address of rtl8721csm to proper value.
- Add NOTE to "How-To" file for dumps to declare limitation for ARM Cortex M devices.
- Modify formatting of filesystem start address print output to console.