### PR TITLE
arch/amebad/flash : Add function to verify erased page

### DIFF
--- a/os/arch/arm/src/amebad/amebad_flash.c
+++ b/os/arch/arm/src/amebad/amebad_flash.c
@@ -116,7 +116,8 @@ static ssize_t amebad_erase_page(size_t page)
 {
 	uint32_t address;
 	irqstate_t irqs;
-
+	ssize_t ret;
+	
 	if (page > (AMEBAD_START_SECOTR + AMEBAD_NSECTORS)) {
 		printf("Invalid page number\n");
 		return -EFAULT;
@@ -128,11 +129,13 @@ static ssize_t amebad_erase_page(size_t page)
 	/* do erase */
 	address = page * CONFIG_AMEBAD_FLASH_BLOCK_SIZE;
 	flash_erase_sector(NULL, address);
-
+	ret = flash_erase_verify(address);
 	/* Restore IRQs */
 	irqrestore(irqs);
-
-	return OK;
+	if (ret != OK) {
+		ret = -EIO;
+	}
+	return ret;
 }
 
 static int amebad_erase(FAR struct mtd_dev_s *dev, off_t startblock, size_t nblocks)

--- a/os/board/rtl8721csm/src/component/common/mbed/hal_ext/flash_api.h
+++ b/os/board/rtl8721csm/src/component/common/mbed/hal_ext/flash_api.h
@@ -51,6 +51,14 @@ void flash_erase_sector(flash_t *obj, uint32_t address);
   */
 void flash_erase_block(flash_t * obj, uint32_t address);
 
+
+/**
+  * @brief  Verify erased block
+  * @param address: address of target page
+  * @retval 0 : success or -1 : Failure.
+  */
+int flash_erase_verify(u32 address);
+
 /**
   * @brief  Read a word from specified address
   * @param  obj: Flash object define in application software.

--- a/os/board/rtl8721csm/src/component/common/mbed/targets/hal/rtl8721d/flash_api.c
+++ b/os/board/rtl8721csm/src/component/common/mbed/targets/hal/rtl8721d/flash_api.c
@@ -178,6 +178,25 @@ void flash_erase_chip(flash_t *obj)
 }
 
 /**
+  * @brief  Verify erased block
+  * @param address: address of target page
+  * @retval 0 : success or -1 : Failure.
+  */
+int flash_erase_verify(u32 address)
+{
+	int count = 0x1000; //4k, block size
+	while (count > 0) {
+		if (HAL_READ32(SPI_FLASH_BASE, address) != 0xffffffff) {
+			dbg("Not erased, address : %u value : %u\n", address, HAL_READ32(SPI_FLASH_BASE, address));
+			return -1;
+		}
+		address += sizeof(u32);
+		count -= sizeof(u32);
+	}
+	return 0;
+}
+
+/**
   * @brief  Read a word from specified address
   * @param  obj: Flash object define in application software.
   * @param  address: Specifies the address to read from.


### PR DESCRIPTION
If sudden power off happened during erase, sometimes target pages are not erased properly.
In product level, level of voltage can be increase for a while, then fs could treat it is correct.
To prevent this situation, verify logic must be added