### PR TITLE
mm/umm_mallinfo : Use First heap only when binary separation

### DIFF
--- a/os/mm/umm_heap/umm_mallinfo.c
+++ b/os/mm/umm_heap/umm_mallinfo.c
@@ -87,14 +87,19 @@
 
 struct mallinfo mallinfo(void)
 {
-	int heap_idx;
 	struct mallinfo info;
 #if CONFIG_KMM_NHEAPS > 1
 	memset(&info, 0, sizeof(struct mallinfo));
 #endif
+#ifdef CONFIG_APP_BINARY_SEPARATION
+	/* When CONFIG_APP_BINARY_SEPARATION, user heap only can be single heap. */
+	mm_mallinfo(&BASE_HEAP[0], &info);
+#else
+	int heap_idx;
 	for (heap_idx = 0; heap_idx < CONFIG_KMM_NHEAPS; heap_idx++) {
 		mm_mallinfo(&BASE_HEAP[heap_idx], &info);
 	}
+#endif
 	return info;
 }
 
@@ -102,10 +107,15 @@ struct mallinfo mallinfo(void)
 
 int mallinfo(struct mallinfo *info)
 {
+#ifdef CONFIG_APP_BINARY_SEPARATION
+	/* When CONFIG_APP_BINARY_SEPARATION, user heap only can be single heap. */
+	mm_mallinfo(&BASE_HEAP[0], info);
+#else
 	int heap_idx;
 	for (heap_idx = 0; heap_idx < CONFIG_KMM_NHEAPS; heap_idx++) {
 		mm_mallinfo(&BASE_HEAP[heap_idx], info);
 	}
+#endif
 	return OK;
 }
 


### PR DESCRIPTION
When CONFIG_APP_BINARY_SEPARATION, user heap only can be single heap.