### PR TITLE
os/include/tinyara/mm : Move heapinfo_total_info_t into mm_heapinfo_utils.c

### DIFF
--- a/os/include/tinyara/mm/mm.h
+++ b/os/include/tinyara/mm/mm.h
@@ -350,9 +350,6 @@ extern struct heapinfo_group_s heapinfo_group[HEAPINFO_USER_GROUP_NUM];
 extern struct heapinfo_group_info_s group_info[HEAPINFO_THREAD_NUM];
 #endif
 
-#if CONFIG_KMM_NHEAPS > 1
-extern heapinfo_total_info_t total_info;
-#endif
 #endif
 /* This describes one heap (possibly with multiple regions) */
 
@@ -688,6 +685,9 @@ void heapinfo_update_group(mmsize_t size, pid_t pid);
 void heapinfo_update_group_info(pid_t pid, int group, int type);
 void heapinfo_check_group_list(pid_t pid, char *name);
 #endif
+#if CONFIG_KMM_NHEAPS > 1
+void heapinfo_update_total_summary(struct mm_heap_s *heap, size_t noused_size, size_t used_size, size_t nonsched_resource, size_t stack_resource, size_t heap_resource);
+#endif
 #endif
 void mm_is_sem_available(void *address);
 
@@ -707,18 +707,6 @@ char *mm_get_app_heap_name(void *address);
 #endif
 
 #if CONFIG_KMM_NHEAPS > 1
-struct heapinfo_total_info_s {
-	int total_heap_size;
-	int cur_free;
-	int largest_free_size;
-	int cur_dead_thread;
-	int sum_of_stacks;
-	int sum_of_heaps;
-	int cur_alloc_size;
-	int peak_alloc_size;
-};
-typedef struct heapinfo_total_info_s heapinfo_total_info_t;
-
 /**
  * @cond
  * @internal

--- a/os/mm/mm_heap/mm_heapinfo_parse_heap.c
+++ b/os/mm/mm_heap/mm_heapinfo_parse_heap.c
@@ -64,10 +64,6 @@
 #define HEAPINFO_INT INT16_MAX
 #define HEAPINFO_NONSCHED (INT16_MAX - 1)
 
-#if CONFIG_KMM_NHEAPS > 1
-heapinfo_total_info_t total_info;
-#endif
-
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
@@ -190,14 +186,7 @@ void heapinfo_parse_heap(FAR struct mm_heap_s *heap, int mode, pid_t pid)
 #undef region
 
 #if CONFIG_KMM_NHEAPS > 1
-	total_info.total_heap_size += heap->mm_heapsize;
-	total_info.cur_free += fordblks;
-	if (total_info.largest_free_size < mxordblk) {
-		total_info.largest_free_size = mxordblk;
-	}
-	total_info.cur_dead_thread += nonsched_resource;
-	total_info.sum_of_stacks += stack_resource;
-	total_info.sum_of_heaps += heap_resource - (heap->mm_nregions * SIZEOF_MM_ALLOCNODE);
+	heapinfo_update_total_summary(heap, fordblks, mxordblk, nonsched_resource, stack_resource, heap_resource);
 
 	if (mode == HEAPINFO_SIMPLE) {
 		return;


### PR DESCRIPTION
heapinfo_total_info_t can be used only in mm_heapinfo_utils.c
so moved it.