### PR TITLE
mm/mm_heap/mm_heapinfo : Remove total_info

### DIFF
--- a/os/include/tinyara/mm/mm.h
+++ b/os/include/tinyara/mm/mm.h
@@ -350,9 +350,6 @@ extern struct heapinfo_group_s heapinfo_group[HEAPINFO_USER_GROUP_NUM];
 extern struct heapinfo_group_info_s group_info[HEAPINFO_THREAD_NUM];
 #endif
 
-#if CONFIG_KMM_NHEAPS > 1
-extern heapinfo_total_info_t total_info;
-#endif
 #endif
 /* This describes one heap (possibly with multiple regions) */
 
@@ -707,18 +704,6 @@ char *mm_get_app_heap_name(void *address);
 #endif
 
 #if CONFIG_KMM_NHEAPS > 1
-struct heapinfo_total_info_s {
-	int total_heap_size;
-	int cur_free;
-	int largest_free_size;
-	int cur_dead_thread;
-	int sum_of_stacks;
-	int sum_of_heaps;
-	int cur_alloc_size;
-	int peak_alloc_size;
-};
-typedef struct heapinfo_total_info_s heapinfo_total_info_t;
-
 /**
  * @cond
  * @internal

--- a/os/mm/mm_heap/mm_heapinfo_parse_heap.c
+++ b/os/mm/mm_heap/mm_heapinfo_parse_heap.c
@@ -64,10 +64,6 @@
 #define HEAPINFO_INT INT16_MAX
 #define HEAPINFO_NONSCHED (INT16_MAX - 1)
 
-#if CONFIG_KMM_NHEAPS > 1
-heapinfo_total_info_t total_info;
-#endif
-
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
@@ -189,20 +185,6 @@ void heapinfo_parse_heap(FAR struct mm_heap_s *heap, int mode, pid_t pid)
 	}
 #undef region
 
-#if CONFIG_KMM_NHEAPS > 1
-	total_info.total_heap_size += heap->mm_heapsize;
-	total_info.cur_free += fordblks;
-	if (total_info.largest_free_size < mxordblk) {
-		total_info.largest_free_size = mxordblk;
-	}
-	total_info.cur_dead_thread += nonsched_resource;
-	total_info.sum_of_stacks += stack_resource;
-	total_info.sum_of_heaps += heap_resource - (heap->mm_nregions * SIZEOF_MM_ALLOCNODE);
-
-	if (mode == HEAPINFO_SIMPLE) {
-		return;
-	}
-#endif
 	printf("\n****************************************************************\n");
 	printf("     Summary of Heap Usages (Size in Bytes)\n");
 	printf("****************************************************************\n");

--- a/os/mm/mm_heap/mm_heapinfo_utils.c
+++ b/os/mm/mm_heap/mm_heapinfo_utils.c
@@ -110,12 +110,6 @@ void heapinfo_update_total_size(struct mm_heap_s *heap, mmsize_t size, pid_t pid
 	if (heap->peak_alloc_size < heap->total_alloc_size) {
 		heap->peak_alloc_size = heap->total_alloc_size;
 	}
-#if CONFIG_KMM_NHEAPS > 1
-	total_info.cur_alloc_size += size;
-	if (total_info.peak_alloc_size < total_info.cur_alloc_size) {
-		total_info.peak_alloc_size = total_info.cur_alloc_size;
-	}
-#endif
 #ifdef CONFIG_HEAPINFO_USER_GROUP
 	heapinfo_update_group(size, pid);
 #endif


### PR DESCRIPTION
total_info indicates the whole heap information. But it is duplicated info with free commands, and it can be calculated from each heap info.
So removed it.