### PR TITLE
kernel/init: Fix wrong include header file for mminfo

### DIFF
--- a/os/kernel/init/os_bringup.c
+++ b/os/kernel/init/os_bringup.c
@@ -78,8 +78,8 @@
 #ifdef CONFIG_SCHED_CPULOAD
 #include <tinyara/cpuload.h>
 #endif
-#ifdef CONFIG_ENABLE_HEAPINFO
-#include <tinyara/heapinfo_drv.h>
+#ifdef CONFIG_MMINFO
+#include <tinyara/mminfo.h>
 #endif
 #ifdef CONFIG_TASK_MANAGER
 #include <tinyara/task_manager_drv.h>


### PR DESCRIPTION
Changed heapinfo_drv.h to mminfo.h for mminfo_register.