### PR TITLE
os/kernel/debug/memdbg : Add build condition when CONFIG_DEBUG_MM_WARN is enabled

### DIFF
--- a/os/kernel/debug/Make.defs
+++ b/os/kernel/debug/Make.defs
@@ -20,7 +20,10 @@ ifeq ($(CONFIG_DEBUG_SYSTEM),y)
 CSRCS += sysdbg.c
 endif
 
-CSRCS += memdbg.c dbg_termination_info.c
+CSRCS += dbg_termination_info.c
+ifeq ($(CONFIG_DEBUG_MM_WARN),y)
+CSRCS += memdbg.c
+endif
 
 ifeq ($(CONFIG_ENABLE_STACKMONITOR)$(CONFIG_DEBUG),yy)
 CSRCS += stackinfo_save_terminated.c

--- a/os/kernel/debug/memdbg.c
+++ b/os/kernel/debug/memdbg.c
@@ -96,7 +96,7 @@ void display_memory_information(void)
 
 	mllwdbg("------------------------------ Heap Settings ------------------------------\n");
 
-	/* Print RAM configuration */
+	/* Print HEAP configuration */
 
 	for (heap_idx = 0; heap_idx < CONFIG_KMM_NHEAPS; heap_idx++) {
 		mllwdbg("Heap[%d] : size = %u, number of regions = %d\n", heap_idx, kheap[heap_idx].mm_heapsize, kheap[heap_idx].mm_nregions);

--- a/os/kernel/init/os_start.c
+++ b/os/kernel/init/os_start.c
@@ -597,7 +597,9 @@ void os_start(void)
 	pm_stay(PM_IDLE_DOMAIN, PM_NORMAL);
 #endif
 
+#ifdef CONFIG_DEBUG_MM_WARN
 	display_memory_information();
+#endif
 
 	DEBUGVERIFY(os_bringup());
 


### PR DESCRIPTION
1) memdbg is only meaningful when CONFIG_DEBUG_MM_WARN is enabled.
2) Modify comment about heap configuration