### PR TITLE
os/mm/umm_mallinfo : Move param null checking

### DIFF
--- a/os/mm/kmm_heap/kmm_mallinfo.c
+++ b/os/mm/kmm_heap/kmm_mallinfo.c
@@ -113,11 +113,12 @@ int kmm_mallinfo(struct mallinfo *info)
 {
 	int kheap_idx;
 	struct mm_heap_s *kheap = kmm_get_heap();
+#if CONFIG_KMM_NHEAPS > 1
 	if (!info) {
 		mdbg("info is NULL\n");
 		return ERROR;
 	}
-#if CONFIG_KMM_NHEAPS > 1
+
 	info->arena = 0;
 	info->fordblks = 0;
 	info->mxordblk = 0;

--- a/os/mm/umm_heap/umm_mallinfo.c
+++ b/os/mm/umm_heap/umm_mallinfo.c
@@ -116,12 +116,12 @@ int mallinfo(struct mallinfo *info)
 	mm_mallinfo(&BASE_HEAP[0], info);
 #else
 	int heap_idx;
-
+#if CONFIG_KMM_NHEAPS > 1
 	if (!info) {
 		mdbg("info is NULL\n");
 		return ERROR;
 	}
-#if CONFIG_KMM_NHEAPS > 1
+
 	info->arena = 0;
 	info->fordblks = 0;
 	info->mxordblk = 0;


### PR DESCRIPTION
If passed 'info' is NULL, mallinfo cannot work properly.
But it is checked only when the build type is not binary separation.
So moved up for checking every cases.