### PR TITLE
os : Delete/Fix wrong comment

### DIFF
--- a/os/board/rtl8721csm/src/component/os/tizenrt/tizenrt_service.c
+++ b/os/board/rtl8721csm/src/component/os/tizenrt/tizenrt_service.c
@@ -720,8 +720,8 @@ err_exit:
 	if(strncmp(name, "rtw_xmit_tasklet", strlen("rtw_xmit_tasklet") + 1) == 0) priority = 105;
 	if(strncmp(name, "cmd_thread", strlen("cmd_thread") + 1) == 0) priority = 105;
 	if(strncmp(name, "tcp_server_handler", strlen("tcp_server_handler") + 1) == 0) priority = 105;
+
 	stack_size *= sizeof(uint32_t);
-	/* Execute loading thread for load all binaries */
 	func_addr = (int)func;
 	ctx_addr = (int)thctx;
 	task_info[0] = itoa(func_addr, str_func_addr, 16);

--- a/os/drivers/memory/mminfo.c
+++ b/os/drivers/memory/mminfo.c
@@ -70,7 +70,7 @@ static ssize_t mminfo_write(FAR struct file *filep, FAR const char *buffer, size
 /************************************************************************************
  * Name: mminfo_ioctl
  *
- * Description: The ioctl method for heapinfo.
+ * Description: The ioctl method for mminfo.
  *
  ************************************************************************************/
 static int mminfo_ioctl(FAR struct file *filep, int cmd, unsigned long arg)


### PR DESCRIPTION
1) tizenrt_service.c : Delete wrong comment
2) mminfo.c : ioctl is for mminfo, not heapinfo