### PR TITLE
include/tinyara/mminfo.h : Add conditions for BIN_NAME_MAX

### DIFF
--- a/os/include/tinyara/mminfo.h
+++ b/os/include/tinyara/mminfo.h
@@ -23,7 +23,9 @@
  * Included Files
  ****************************************************************************/
 #include <tinyara/config.h>
-
+#if defined(CONFIG_DEBUG_MM_HEAPINFO) && defined(CONFIG_APP_BINARY_SEPARATION)
+#include <tinyara/binary_manager.h>
+#endif
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/


### PR DESCRIPTION
BIN_NAME_MAX is declared in binary_manager.h, but there is no header include when DEBUG_MM_HEAPINFO and APP_BINARY_SEPARATION are enabled.