### PR TITLE
build/configs/rtl8721csm_download.sh : Skip to try download for SE

### DIFF
--- a/build/configs/rtl8721csm/rtl8721csm_download.sh
+++ b/build/configs/rtl8721csm/rtl8721csm_download.sh
@@ -238,6 +238,10 @@ download_all()
 
 	for partidx in ${!parts[@]}; do
 
+		if [[ "${parts[$partidx]}" == "none" ]];then
+			continue
+		fi
+
 		if [[ "${CONFIG_APP_BINARY_SEPARATION}" != "y" ]];then
 			if [[ "${parts[$partidx]}" == "userfs" ]];then
 				continue


### PR DESCRIPTION
There are SE partitions which have the type as none.
We don't need to download the none type, so skip them.