### PR TITLE
configs/rtl8721csm: set secure storage partition name and skip that at download

### DIFF
--- a/build/configs/rtl8721csm/hello/defconfig
+++ b/build/configs/rtl8721csm/hello/defconfig
@@ -243,7 +243,7 @@ CONFIG_FLASH_PARTITION=y
 CONFIG_FLASH_MINOR=0
 CONFIG_FLASH_PART_SIZE="16,8,16,472,1512,1048,"
 CONFIG_FLASH_PART_TYPE="none,none,none,none,kernel,smartfs,"
-CONFIG_FLASH_PART_NAME="km0_bl,km4_bl,none,none,kernel,userfs,"
+CONFIG_FLASH_PART_NAME="km0_bl,km4_bl,reserved,ss,kernel,userfs,"
 # CONFIG_ARCH_BOARD_HAVE_SECOND_FLASH is not set
 
 #

--- a/build/configs/rtl8721csm/loadable_apps/defconfig
+++ b/build/configs/rtl8721csm/loadable_apps/defconfig
@@ -253,7 +253,7 @@ CONFIG_FLASH_PARTITION=y
 CONFIG_FLASH_MINOR=0
 CONFIG_FLASH_PART_SIZE="16,8,16,472,1024,1024,5440,"
 CONFIG_FLASH_PART_TYPE="none,none,none,none,kernel,kernel,smartfs,"
-CONFIG_FLASH_PART_NAME="km0_bl,km4_bl,none,none,kernel,kernel,userfs,"
+CONFIG_FLASH_PART_NAME="km0_bl,km4_bl,reserved,ss,kernel,kernel,userfs,"
 # CONFIG_ARCH_BOARD_HAVE_SECOND_FLASH is not set
 
 #

--- a/build/configs/rtl8721csm/rdp/defconfig
+++ b/build/configs/rtl8721csm/rdp/defconfig
@@ -244,7 +244,7 @@ CONFIG_FLASH_PARTITION=y
 CONFIG_FLASH_MINOR=0
 CONFIG_FLASH_PART_SIZE="16,8,16,472,1512,1048,"
 CONFIG_FLASH_PART_TYPE="none,none,none,none,kernel,smartfs,"
-CONFIG_FLASH_PART_NAME="km0_bl,km4_bl,none,none,kernel,userfs,"
+CONFIG_FLASH_PART_NAME="km0_bl,km4_bl,reserved,ss,kernel,userfs,"
 # CONFIG_ARCH_BOARD_HAVE_SECOND_FLASH is not set
 
 #

--- a/build/configs/rtl8721csm/rtl8721csm_download.sh
+++ b/build/configs/rtl8721csm/rtl8721csm_download.sh
@@ -238,10 +238,6 @@ download_all()
 
 	for partidx in ${!parts[@]}; do
 
-		if [[ "${parts[$partidx]}" == "none" ]];then
-			continue
-		fi
-
 		if [[ "${CONFIG_APP_BINARY_SEPARATION}" != "y" ]];then
 			if [[ "${parts[$partidx]}" == "userfs" ]];then
 				continue
@@ -255,15 +251,16 @@ download_all()
 			found_kernel=true
 		fi
 
+		exe_name=$(get_executable_name ${parts[$partidx]})
+		[ "No Binary Match" = "${exe_name}" ] && continue
+
 		echo ""
 		echo "=========================="
 		echo "Downloading ${parts[$partidx]} binary"
 		echo "=========================="
 
-		exe_name=$(get_executable_name ${parts[$partidx]})
-
 		./amebad_image_tool $TTYDEV 1 ${offsets[$partidx]} ${exe_name}
-		[ -e ${exe_name} ] && rm ${exe_name}
+		rm ${exe_name}
 
 	done
 	echo ""

--- a/build/configs/rtl8721csm/security_hal_test_tz/defconfig
+++ b/build/configs/rtl8721csm/security_hal_test_tz/defconfig
@@ -244,7 +244,7 @@ CONFIG_FLASH_PARTITION=y
 CONFIG_FLASH_MINOR=0
 CONFIG_FLASH_PART_SIZE="16,8,16,472,1512,1048,"
 CONFIG_FLASH_PART_TYPE="none,none,none,none,kernel,smartfs,"
-CONFIG_FLASH_PART_NAME="km0_bl,km4_bl,none,none,kernel,userfs,"
+CONFIG_FLASH_PART_NAME="km0_bl,km4_bl,reserved,ss,kernel,userfs,"
 # CONFIG_ARCH_BOARD_HAVE_SECOND_FLASH is not set
 
 #

--- a/build/configs/rtl8721csm/tc/defconfig
+++ b/build/configs/rtl8721csm/tc/defconfig
@@ -243,7 +243,7 @@ CONFIG_FLASH_PARTITION=y
 CONFIG_FLASH_MINOR=0
 CONFIG_FLASH_PART_SIZE="16,8,16,472,1512,1048,"
 CONFIG_FLASH_PART_TYPE="none,none,none,none,kernel,smartfs,"
-CONFIG_FLASH_PART_NAME="km0_bl,km4_bl,none,none,kernel,userfs,"
+CONFIG_FLASH_PART_NAME="km0_bl,km4_bl,reserved,ss,kernel,userfs,"
 # CONFIG_ARCH_BOARD_HAVE_SECOND_FLASH is not set
 
 #


### PR DESCRIPTION
1. config/rtl8721csm/download.sh: skip non-binary partition 
2. configs/rtl8721csm/*: set partition name for secure storage