### PR TITLE
os/mm/mm_heap/mm_getheap.c : Fix string copy size

### DIFF
--- a/apps/system/utils/utils_heapinfo.c
+++ b/apps/system/utils/utils_heapinfo.c
@@ -229,7 +229,8 @@ int utils_heapinfo(int argc, char **args)
 #ifdef CONFIG_APP_BINARY_SEPARATION
 		case 'b':
 			options.heap_type = HEAPINFO_HEAP_TYPE_BINARY;
-			strncpy(options.app_name, optarg, BIN_NAME_MAX);
+			strncpy(options.app_name, optarg, BIN_NAME_MAX - 1);
+			options.app_name[BIN_NAME_MAX - 1] = '\0';
 			heap_name = options.app_name;
 			break;
 #endif

--- a/framework/src/binary_manager/binary_manager_interface.c
+++ b/framework/src/binary_manager/binary_manager_interface.c
@@ -54,7 +54,8 @@ binmgr_result_type_e binary_manager_set_request(binmgr_request_t *request_msg, i
 			return BINMGR_INVALID_PARAM;
 		}
 		binmgr_update_bin_t *data = (binmgr_update_bin_t *)arg;
-		strncpy(request_msg->data.update_bin.bin_name, data->bin_name, BIN_NAME_MAX);
+		strncpy(request_msg->data.update_bin.bin_name, data->bin_name, BIN_NAME_MAX - 1);
+		request_msg->data.update_bin.bin_name[BIN_NAME_MAX - 1] = '\0';
 		request_msg->data.update_bin.version = data->version;
 		break;
 	case BINMGR_REGISTER_STATECB:

--- a/os/binfmt/binfmt_loadbinary.c
+++ b/os/binfmt/binfmt_loadbinary.c
@@ -147,7 +147,8 @@ int load_binary(int binary_idx, FAR const char *filename, load_attr_t *load_attr
 			bin->binary_idx = binary_idx;
 			bin->bin_ver = load_attr->bin_ver;
 #ifdef CONFIG_OPTIMIZE_APP_RELOAD_TIME
-			strncpy(bin->bin_name, load_attr->bin_name, BIN_NAME_MAX);
+			strncpy(bin->bin_name, load_attr->bin_name, BIN_NAME_MAX - 1);
+			bin->bin_name[BIN_NAME_MAX - 1] = '\0';
 #else
 			bin->bin_name = load_attr->bin_name;
 #endif

--- a/os/binfmt/libelf/libelf_sections.c
+++ b/os/binfmt/libelf/libelf_sections.c
@@ -213,7 +213,8 @@ void elf_save_bin_section_addr(struct binary_s *bin)
 	bin_addr_info_t *bin_info;
 	bin_info = (bin_addr_info_t *)kmm_malloc(sizeof(bin_addr_info_t));
 	if (bin_info != NULL) {
-		strncpy(bin_info->bin_name, bin->bin_name, BIN_NAME_MAX);
+		strncpy(bin_info->bin_name, bin->bin_name, BIN_NAME_MAX - 1);
+		bin_info->bin_name[BIN_NAME_MAX - 1] = '\0';
 		bin_info->text_addr = (uint32_t)bin->alloc[ALLOC_TEXT];
 
 		binfo("[%s] text_addr : %x\n", bin_info->bin_name, bin_info->text_addr);

--- a/os/kernel/binary_manager/binary_manager_callback.c
+++ b/os/kernel/binary_manager/binary_manager_callback.c
@@ -212,7 +212,8 @@ int binary_manager_send_statecb_msg(int recv_binidx, char *bin_name, uint8_t sta
 
 	state_data.need_response = need_response;
 	state_data.state = state;
-	strncpy(state_data.bin_name, bin_name, BIN_NAME_MAX);
+	strncpy(state_data.bin_name, bin_name, BIN_NAME_MAX - 1);
+	state_data.bin_name[BIN_NAME_MAX - 1] = '\0';
 
 	send_count = 0;
 	cb_node = (statecb_node_t *)sq_peek(&BIN_CBLIST(recv_binidx));

--- a/os/kernel/binary_manager/binary_manager_getinfo.c
+++ b/os/kernel/binary_manager/binary_manager_getinfo.c
@@ -203,7 +203,8 @@ void binary_manager_get_info_with_name(int requester_pid, char *bin_name)
 			} else {
 				response_msg.result = BINMGR_OK;
 				response_msg.data.available_size = size;
-				strncpy(response_msg.data.name, BIN_NAME(bin_idx) , BIN_NAME_MAX);
+				strncpy(response_msg.data.name, BIN_NAME(bin_idx) , BIN_NAME_MAX - 1);
+				response_msg.data.name[BIN_NAME_MAX - 1] = '\0';
 				response_msg.data.version = (double)BIN_LOADVER(bin_idx);
 			}
 			break;
@@ -242,7 +243,8 @@ void binary_manager_get_info_all(int requester_pid)
 
 	/* Kernel data */
 	kerinfo = binary_manager_get_kdata();
-	strncpy(response_msg.data.bin_info[result_idx].name, kerinfo->name , BIN_NAME_MAX);
+	strncpy(response_msg.data.bin_info[result_idx].name, kerinfo->name , BIN_NAME_MAX - 1);
+	response_msg.data.bin_info[result_idx].name[BIN_NAME_MAX - 1] = '\0';
 	response_msg.data.bin_info[result_idx].version = kerinfo->version;
 	if (kerinfo->part_count > 1) {
 		response_msg.data.bin_info[result_idx].available_size = kerinfo->part_info[kerinfo->inuse_idx ^ 1].part_size;
@@ -260,7 +262,8 @@ void binary_manager_get_info_all(int requester_pid)
 			}
 			response_msg.result = BINMGR_OK;
 			response_msg.data.bin_info[result_idx].available_size = size;
-			strncpy(response_msg.data.bin_info[result_idx].name, BIN_NAME(bin_idx) , BIN_NAME_MAX);
+			strncpy(response_msg.data.bin_info[result_idx].name, BIN_NAME(bin_idx) , BIN_NAME_MAX - 1);
+			response_msg.data.bin_info[result_idx].name[BIN_NAME_MAX - 1] = '\0';
 			response_msg.data.bin_info[result_idx].version = (double)BIN_LOADVER(bin_idx);
 			result_idx++;
 		}

--- a/os/kernel/binary_manager/binary_manager_load.c
+++ b/os/kernel/binary_manager/binary_manager_load.c
@@ -111,6 +111,7 @@ static int binary_manager_load_binary(int bin_idx, char *path, load_attr_t *load
 			/* Set the data in table from header */
 			BIN_LOAD_ATTR(bin_idx) = *load_attr;
 			strncpy(BIN_NAME(bin_idx), load_attr->bin_name, BIN_NAME_MAX);
+			BIN_NAME(bin_idx)[BIN_NAME_MAX - 1] = '\0';
 			bmvdbg("BIN TABLE[%d] %d %d %d %.1f %s\n", bin_idx, BIN_SIZE(bin_idx), BIN_RAMSIZE(bin_idx), BIN_LOADVER(bin_idx), BIN_KERNEL_VER(bin_idx), BIN_NAME(bin_idx));
 			return OK;
 		} else if (errno == ENOMEM) {

--- a/os/mm/mm_heap/mm_getheap.c
+++ b/os/mm/mm_heap/mm_getheap.c
@@ -84,7 +84,8 @@ void mm_add_app_heap_list(struct mm_heap_s *heap, char *app_name)
 
 	node->is_active = true;
 	node->heap = heap;
-	strncpy(node->app_name, app_name, BIN_NAME_MAX);
+	strncpy(node->app_name, app_name, BIN_NAME_MAX - 1);
+	node->app_name[BIN_NAME_MAX - 1] = '\0';
 
 	/* Add the new heap node to the head of the list*/
 	dq_addfirst((dq_entry_t *)node, &app_heap_q);


### PR DESCRIPTION
For security issue, it is better to copy the string based on its size.