### PR TITLE
heapinfo, messaging : Fix copy size and add '\0' to the end of string array

### DIFF
--- a/apps/system/utils/utils_heapinfo.c
+++ b/apps/system/utils/utils_heapinfo.c
@@ -229,7 +229,8 @@ int utils_heapinfo(int argc, char **args)
 #ifdef CONFIG_APP_BINARY_SEPARATION
 		case 'b':
 			options.heap_type = HEAPINFO_HEAP_TYPE_BINARY;
-			strncpy(options.app_name, optarg, BIN_NAME_MAX);
+			strncpy(options.app_name, optarg, BIN_NAME_MAX - 1);
+			options.app_name[BIN_NAME_MAX - 1] = '\0';
 			heap_name = options.app_name;
 			break;
 #endif

--- a/apps/system/utils/utils_kill.c
+++ b/apps/system/utils/utils_kill.c
@@ -293,6 +293,7 @@ int utils_killall(int argc, char **args)
 
 	arg.signo = signo;
 	strncpy(arg.name, ptr, CONFIG_TASK_NAME_SIZE);
+	arg.name[CONFIG_TASK_NAME_SIZE] = '\0';
 	arg.count = 0;
 	arg.ret = OK;
 

--- a/os/kernel/messaging/messaging.c
+++ b/os/kernel/messaging/messaging.c
@@ -217,7 +217,8 @@ int messaging_save_receiver(char *port_name, pid_t recv_pid, int recv_prio)
 	}
 
 	/* Fill the port node information except sender_pid. */
-	strncpy(port_node->port_name, port_name, strlen(port_name) + 1);
+	strncpy(port_node->port_name, port_name, MSG_MAX_PORT_NAME - 1);
+	port_node->port_name[MSG_MAX_PORT_NAME - 1] = '\0';
 	port_node->sender_pid = MSG_SENDER_UNDEFINED;
 	port_node->nreceiver = 1;
 	sem_init(&port_node->port_sem, 0, 1);


### PR DESCRIPTION
Fix string copy size and add '\0' to the end of string array for security issue.