### PR TITLE
configs/rtl8721csm: Enable debug configs for rtk

### DIFF
--- a/build/configs/rtl8721csm/hello/defconfig
+++ b/build/configs/rtl8721csm/hello/defconfig
@@ -947,7 +947,50 @@ CONFIG_SCHED_LPWORKSTACKSIZE=2048
 #
 # Debug Options
 #
-# CONFIG_DEBUG is not set
+CONFIG_DEBUG=y
+CONFIG_DEBUG_ERROR=y
+# CONFIG_DEBUG_WARN is not set
+# CONFIG_DEBUG_VERBOSE is not set
+
+#
+# Subsystem Debug Options
+#
+# CONFIG_DEBUG_BINFMT is not set
+# CONFIG_DEBUG_BINMGR is not set
+# CONFIG_DEBUG_FS is not set
+# CONFIG_DEBUG_LIB is not set
+# CONFIG_DEBUG_MM is not set
+# CONFIG_DEBUG_NET is not set
+# CONFIG_DEBUG_PM is not set
+# CONFIG_DEBUG_SCHED is not set
+# CONFIG_DEBUG_SYSCALL is not set
+# CONFIG_DEBUG_TASH is not set
+
+#
+# Framework Debug Options
+#
+# CONFIG_DEBUG_IOTBUS is not set
+
+#
+# OS Function Debug Options
+#
+CONFIG_ARCH_HAVE_HEAPCHECK=y
+# CONFIG_DEBUG_HEAP is not set
+# CONFIG_DEBUG_MM_HEAPINFO is not set
+# CONFIG_DEBUG_IRQ is not set
+
+#
+# Driver Debug Options
+#
+# CONFIG_DEBUG_ANALOG is not set
+# CONFIG_DEBUG_I2S is not set
+# CONFIG_DEBUG_SPI is not set
+# CONFIG_DEBUG_WATCHDOG is not set
+
+#
+# System Debug Options
+#
+# CONFIG_DEBUG_SYSTEM is not set
 
 #
 # Stack Debug Options

--- a/build/configs/rtl8721csm/loadable_apps/defconfig
+++ b/build/configs/rtl8721csm/loadable_apps/defconfig
@@ -990,7 +990,50 @@ CONFIG_SCHED_USRWORKSTACKSIZE=2048
 #
 # Debug Options
 #
-# CONFIG_DEBUG is not set
+CONFIG_DEBUG=y
+CONFIG_DEBUG_ERROR=y
+# CONFIG_DEBUG_WARN is not set
+# CONFIG_DEBUG_VERBOSE is not set
+
+#
+# Subsystem Debug Options
+#
+# CONFIG_DEBUG_BINFMT is not set
+# CONFIG_DEBUG_BINMGR is not set
+# CONFIG_DEBUG_FS is not set
+# CONFIG_DEBUG_LIB is not set
+# CONFIG_DEBUG_MM is not set
+# CONFIG_DEBUG_NET is not set
+# CONFIG_DEBUG_PM is not set
+# CONFIG_DEBUG_SCHED is not set
+# CONFIG_DEBUG_SYSCALL is not set
+# CONFIG_DEBUG_TASH is not set
+
+#
+# Framework Debug Options
+#
+# CONFIG_DEBUG_IOTBUS is not set
+
+#
+# OS Function Debug Options
+#
+CONFIG_ARCH_HAVE_HEAPCHECK=y
+# CONFIG_DEBUG_HEAP is not set
+# CONFIG_DEBUG_MM_HEAPINFO is not set
+# CONFIG_DEBUG_IRQ is not set
+
+#
+# Driver Debug Options
+#
+# CONFIG_DEBUG_ANALOG is not set
+# CONFIG_DEBUG_I2S is not set
+# CONFIG_DEBUG_SPI is not set
+# CONFIG_DEBUG_WATCHDOG is not set
+
+#
+# System Debug Options
+#
+# CONFIG_DEBUG_SYSTEM is not set
 
 #
 # Stack Debug Options


### PR DESCRIPTION
Enable CONFIG_DEBUG and CONFIG_DEBUG_ERROR for rtk defconfigs.
If this is not enabled, all the faults such as memfault, busfault,
etc are treated as unexpected irq and we dont get debug information
for them. These configs were previously disabled for wifi perf
issue, and since we found that wifi perf is not related to these
configs, we are re-enabling them.

Signed-off-by: Kishore S N <kishore.sn@samsung.com>