### PR TITLE
apps/examples/reboot_reason_test : Add reboot reason sample

### DIFF
--- a/apps/examples/reboot_reason_test/.gitignore
+++ b/apps/examples/reboot_reason_test/.gitignore
@@ -1,0 +1,11 @@
+/Make.dep
+/.depend
+/.built
+/*.asm
+/*.obj
+/*.rel
+/*.lst
+/*.sym
+/*.adb
+/*.lib
+/*.src

--- a/apps/examples/reboot_reason_test/Kconfig
+++ b/apps/examples/reboot_reason_test/Kconfig
@@ -1,0 +1,18 @@
+#
+# For a description of the syntax of this configuration file,
+# see kconfig-language at https://www.kernel.org/doc/Documentation/kbuild/kconfig-language.txt
+#
+
+config EXAMPLES_REBOOT_REASON
+	bool "\"Reboot Reason\" example"
+	default n
+	depends on SYSTEM_REBOOT_REASON
+	select MM_ASSERT_ON_FAIL
+	select WATCHDOG
+	---help---
+		TizenRT provides the functionality to know the reason of previous rebooting.
+		This example gives several options to check it.
+
+config USER_ENTRYPOINT
+	string
+	default "reboot_reason_main" if ENTRY_REBOOT_REASON

--- a/apps/examples/reboot_reason_test/Kconfig_ENTRY
+++ b/apps/examples/reboot_reason_test/Kconfig_ENTRY
@@ -1,0 +1,3 @@
+config ENTRY_REBOOT_REASON
+	bool "\"Reboot Reason\" example"
+	depends on EXAMPLES_REBOOT_REASON

--- a/apps/examples/reboot_reason_test/Make.defs
+++ b/apps/examples/reboot_reason_test/Make.defs
@@ -1,0 +1,56 @@
+###########################################################################
+#
+# Copyright 2021 Samsung Electronics All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+#
+###########################################################################
+############################################################################
+# apps/examples/reboot_reason_test/Make.defs
+# Adds selected applications to apps/ build
+#
+#   Copyright (C) 2015 Gregory Nutt. All rights reserved.
+#   Author: Gregory Nutt <gnutt@nuttx.org>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in
+#    the documentation and/or other materials provided with the
+#    distribution.
+# 3. Neither the name NuttX nor the names of its contributors may be
+#    used to endorse or promote products derived from this software
+#    without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+# OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+# AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+############################################################################
+
+ifeq ($(CONFIG_EXAMPLES_REBOOT_REASON),y)
+CONFIGURED_APPS += examples/reboot_reason_test
+endif

--- a/apps/examples/reboot_reason_test/Makefile
+++ b/apps/examples/reboot_reason_test/Makefile
@@ -1,0 +1,158 @@
+###########################################################################
+#
+# Copyright 2021 Samsung Electronics All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+#
+###########################################################################
+############################################################################
+# apps/examples/reboot_reason_test/Makefile
+#
+#   Copyright (C) 2008, 2010-2013 Gregory Nutt. All rights reserved.
+#   Author: Gregory Nutt <gnutt@nuttx.org>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in
+#    the documentation and/or other materials provided with the
+#    distribution.
+# 3. Neither the name NuttX nor the names of its contributors may be
+#    used to endorse or promote products derived from this software
+#    without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+# OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+# AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+############################################################################
+
+-include $(TOPDIR)/.config
+-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
+
+# Reboot Reason built-in application info
+
+APPNAME = reboot_reason
+FUNCNAME = $(APPNAME)_main
+THREADEXEC = TASH_EXECMD_SYNC
+
+# Reboot Reason Example
+
+ASRCS =
+CSRCS =
+MAINSRC = reboot_reason_main.c
+
+AOBJS = $(ASRCS:.S=$(OBJEXT))
+COBJS = $(CSRCS:.c=$(OBJEXT))
+MAINOBJ = $(MAINSRC:.c=$(OBJEXT))
+
+SRCS = $(ASRCS) $(CSRCS) $(MAINSRC)
+OBJS = $(AOBJS) $(COBJS)
+
+ifneq ($(CONFIG_BUILD_KERNEL),y)
+  OBJS += $(MAINOBJ)
+endif
+
+ifeq ($(CONFIG_WINDOWS_NATIVE),y)
+  BIN = ..\..\libapps$(LIBEXT)
+else
+ifeq ($(WINTOOL),y)
+  BIN = ..\\..\\libapps$(LIBEXT)
+else
+  BIN = ../../libapps$(LIBEXT)
+endif
+endif
+
+ifeq ($(WINTOOL),y)
+  INSTALL_DIR = "${shell cygpath -w $(BIN_DIR)}"
+else
+  INSTALL_DIR = $(BIN_DIR)
+endif
+
+CONFIG_EXAMPLES_REBOOT_REASON_PROGNAME ?= reboot_reason$(EXEEXT)
+PROGNAME = $(CONFIG_EXAMPLES_REBOOT_REASON_PROGNAME)
+
+ROOTDEPPATH = --dep-path .
+
+# Common build
+
+VPATH =
+
+all: .built
+.PHONY: clean depend distclean
+
+$(AOBJS): %$(OBJEXT): %.S
+	$(call ASSEMBLE, $<, $@)
+
+$(COBJS) $(MAINOBJ): %$(OBJEXT): %.c
+	$(call COMPILE, $<, $@)
+
+.built: $(OBJS)
+	$(call ARCHIVE, $(BIN), $(OBJS))
+	@touch .built
+
+ifeq ($(CONFIG_BUILD_KERNEL),y)
+$(BIN_DIR)$(DELIM)$(PROGNAME): $(OBJS) $(MAINOBJ)
+	@echo "LD: $(PROGNAME)"
+	$(Q) $(LD) $(LDELFFLAGS) $(LDLIBPATH) -o $(INSTALL_DIR)$(DELIM)$(PROGNAME) $(ARCHCRT0OBJ) $(MAINOBJ) $(LDLIBS)
+	$(Q) $(NM) -u  $(INSTALL_DIR)$(DELIM)$(PROGNAME)
+
+install: $(BIN_DIR)$(DELIM)$(PROGNAME)
+
+else
+install:
+
+endif
+
+ifeq ($(CONFIG_BUILTIN_APPS)$(CONFIG_EXAMPLES_REBOOT_REASON),yy)
+$(BUILTIN_REGISTRY)$(DELIM)$(FUNCNAME).bdat: $(DEPCONFIG) Makefile
+	$(Q) $(call REGISTER,$(APPNAME),$(FUNCNAME),$(THREADEXEC),$(PRIORITY),$(STACKSIZE))
+
+context: $(BUILTIN_REGISTRY)$(DELIM)$(FUNCNAME).bdat
+
+else
+context:
+
+endif
+
+.depend: Makefile $(SRCS)
+	@$(MKDEP) $(ROOTDEPPATH) "$(CC)" -- $(CFLAGS) -- $(SRCS) >Make.dep
+	@touch $@
+
+depend: .depend
+
+clean:
+	$(call DELFILE, .built)
+	$(call CLEAN)
+
+distclean: clean
+	$(call DELFILE, Make.dep)
+	$(call DELFILE, .depend)
+
+-include Make.dep
+.PHONY: preconfig
+preconfig:

--- a/apps/examples/reboot_reason_test/reboot_reason_main.c
+++ b/apps/examples/reboot_reason_test/reboot_reason_main.c
@@ -1,0 +1,229 @@
+/****************************************************************************
+ *
+ * Copyright 2021 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+/****************************************************************************
+ * examples/reboot_reason_test/reboot_reason_main.c
+ *
+ *   Copyright (C) 2008, 2011-2012 Gregory Nutt. All rights reserved.
+ *   Author: Gregory Nutt <gnutt@nuttx.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <tinyara/config.h>
+#include <stdio.h>
+#ifdef CONFIG_MM_ASSERT_ON_FAIL
+#include <stdlib.h>
+#endif
+#ifdef CONFIG_WATCHDOG
+#include <fcntl.h>
+#include <sys/ioctl.h>
+#include <tinyara/watchdog.h>
+#endif
+#ifdef CONFIG_LIB_BOARDCTL
+#include <sys/boardctl.h>
+#endif
+#include <sys/prctl.h>
+#include <tinyara/reboot_reason.h>
+
+#define REBOOT_REASON_TEST_VAL 123
+
+static void display_reboot_reason_option(void)
+{
+	printf("\nSelect Reboot Reason Test Option.\n");
+	printf("\t-Press H or h : HW Reset Test\n");
+#ifdef CONFIG_MM_ASSERT_ON_FAIL
+	printf("\t-Press M or m : Memory Allocation Fail Test\n");
+#endif
+#ifdef CONFIG_WATCHDOG
+	printf("\t-Press W or w : Watchdog Reset Test\n");
+#endif
+	printf("\t-Press V or v : Random Value Write-Read Test\n");
+	printf("\t-Press C or c : Clear reboot reason\n");
+	printf("\t-Press R or r : Check previous reboot reason\n");
+	printf("\t-Press X or x : Terminate Tests.\n");
+}
+#ifdef CONFIG_WATCHDOG
+static void watchdog_test(void)
+{
+	int fd;
+	int ret;
+
+	fd = open(CONFIG_WATCHDOG_DEVPATH, O_RDWR);
+	if (fd < 0) {
+		printf("ERROR: Fail to open %s\n", CONFIG_WATCHDOG_DEVPATH);
+		return;
+	}
+
+	ret = ioctl(fd, WDIOC_SETTIMEOUT, 1000);
+	if (ret != OK) {
+		printf("ERROR: Fail to set watchdog timeout.\n");
+		close(fd);
+		return;
+	}
+
+	ret = ioctl(fd, WDIOC_START, 0);
+	if (ret != OK) {
+		printf("ERROR: Fail to start watchdog.\n");
+		close(fd);
+		return;
+	}
+
+	/* Wait until watchdog timeout */
+	while (1);
+}
+#endif
+
+#ifdef CONFIG_MM_ASSERT_ON_FAIL
+static void memory_alloc_fail_test(void)
+{
+	struct mallinfo data;
+	int largest_size;
+	int *alloc_ptr;
+
+#ifdef CONFIG_CAN_PASS_STRUCTS
+	data = mallinfo();
+#else
+	mallinfo(&data);
+#endif
+	largest_size = data.mxordblk;
+	/* Try to allocate not available size. */
+	alloc_ptr = (int *)malloc(largest_size + 1);
+
+	/* This line cannot be reached,
+	 * because there will be assert on memory allocation failure from malloc.
+	 */
+	free(alloc_ptr);
+}
+#endif
+
+static void reboot_board(void)
+{
+#ifdef CONFIG_LIB_BOARDCTL
+	printf("Board will be reset automatically.\n");
+	boardctl(BOARDIOC_RESET, 0);
+#else
+	printf("Please reboot the board manually.\n");
+#endif
+}
+
+/****************************************************************************
+ * reboot_reason_main
+ ****************************************************************************/
+
+#ifdef CONFIG_BUILD_KERNEL
+int main(int argc, FAR char *argv[])
+#else
+int reboot_reason_main(int argc, char *argv[])
+#endif
+{
+	int ch;
+	bool is_testing = true;
+
+	printf("Reboot Reason Test Start!\n");
+
+	while (is_testing) {
+		display_reboot_reason_option();
+		ch = getchar();
+		switch (ch) {
+		case 'H':
+		case 'h':
+			printf("Expected reboot reason after hw reset is : %d\n", REBOOT_SYSTEM_HW_RESET);
+			printf("Press HW Reset Button.\n");
+			/* Wait for pressing the hw reset button. */
+			while (1);
+			break;
+#ifdef CONFIG_MM_ASSERT_ON_FAIL
+		case 'M':
+		case 'm':
+			/* Test for Memory Allocation Fail */
+			printf("After Memory Allocation Fail, Expected Reboot reason is %d\n", REBOOT_SYSTEM_MEMORYALLOCFAIL);
+			memory_alloc_fail_test();
+			break;
+#endif
+#ifdef CONFIG_WATCHDOG
+		case 'W':
+		case 'w':
+			/* Test for Watchdog Reset */
+			printf("After watchdog reset, Expected Reboot reason is %d\n", REBOOT_SYSTEM_WATCHDOG);
+			watchdog_test();
+			break;
+#endif
+		case 'V':
+		case 'v':
+			/* Test for Temp value write-read */
+			printf("Write Test Reboot Reason : %d\n", REBOOT_REASON_TEST_VAL);
+			prctl(PR_REBOOT_REASON_WRITE, REBOOT_REASON_TEST_VAL);
+			reboot_board();
+			break;
+		case 'C':
+		case 'c':
+			/* Clear the previous reboot reason with REBOOT_REASON_INITIALIZED(0) */
+			printf("Will write %d and then will clear.\n", REBOOT_REASON_TEST_VAL);
+			printf("Expected reboot reason after reset is %d, otherwise wrong operation.\n", REBOOT_UNKNOWN);
+			prctl(PR_REBOOT_REASON_WRITE, REBOOT_REASON_TEST_VAL);
+			prctl(PR_REBOOT_REASON_CLEAR);
+			reboot_board();
+			break;
+		case 'R':
+		case 'r':
+			/* Read the previous reboot reason */
+			printf("\nPrevious Reboot Reason is : %d\n", prctl(PR_REBOOT_REASON_READ));
+			break;
+		case 'X':
+		case 'x':
+			printf("Test will be finished.\n");
+			is_testing = false;
+			break;
+		default:
+			printf("Invalid Scenario.\n");
+			break;
+		}
+	}
+
+	return 0;
+}

--- a/os/arch/arm/src/amebad/amebad_reboot_reason.c
+++ b/os/arch/arm/src/amebad/amebad_reboot_reason.c
@@ -68,7 +68,7 @@ void up_reboot_reason_init(void)
 {
 	/* Read the same backup register for the boot reason */
 	backup_reg = BKUP_Read(BKUP_REG1);
-	BKUP_Write(BKUP_REG1, 0);
+	BKUP_Write(BKUP_REG1, REBOOT_REASON_INITIALIZED);
 
 }
 
@@ -76,7 +76,7 @@ reboot_reason_code_t up_reboot_reason_read(void)
 {
 	u32 boot_reason = 0;
 
-	if (backup_reg) {
+	if (backup_reg != REBOOT_REASON_INITIALIZED) {
 		return backup_reg;
 	} else {
 		/* Read AmebaD Boot Reason, WDT and HW reset supported */
@@ -104,9 +104,10 @@ void up_reboot_reason_write(reboot_reason_code_t reason)
 
 void up_reboot_reason_clear(void)
 {
-	/* Reboot Reason Clear API writes the REBOOT_UNKNOWN by default.
+	/* Reboot Reason Clear API writes the REBOOT_REASON_INITIALIZED by default.
 	 * If chip vendor needs another thing to do, please change the below.
 	 */
-	up_reboot_reason_write(REBOOT_UNKNOWN);
+	up_reboot_reason_write(REBOOT_REASON_INITIALIZED);
+	backup_reg = REBOOT_REASON_INITIALIZED;
 }
 #endif

--- a/os/include/tinyara/reboot_reason.h
+++ b/os/include/tinyara/reboot_reason.h
@@ -23,14 +23,15 @@
  ********************************************************************************************/
 
 typedef enum {
-	REBOOT_SYSTEM_WATCHDOG		= 0,	/* watchdog timeout */        
+	REBOOT_REASON_INITIALIZED	= 0,
 	REBOOT_SYSTEM_DATAABORT		= 1,	/* Data abort */
 	REBOOT_SYSTEM_PREFETCHABORT	= 2,	/* Prefetch abort */
 	REBOOT_SYSTEM_MEMORYALLOCFAIL	= 3,	/* Memory allocation failure */
-	REBOOT_SYSTEM_HW_RESET		= 4,	/* HW power reset */
+	REBOOT_SYSTEM_WATCHDOG		= 4,	/* Watchdog timeout */
+	REBOOT_SYSTEM_HW_RESET		= 5,	/* HW power reset */
 	REBOOT_SYSTEM_WIFICORE_WATCHDOG = 11,	/* Wi-Fi Core Watchdog Reset */
 	REBOOT_SYSTEM_WIFICORE_PANIC    = 12,	/* Wi-Fi Core Panic */
-	REBOOT_UNKNOWN 	 		= 32
+	REBOOT_UNKNOWN 	 		= 99,
 } reboot_reason_code_t;
 
 #endif					/* __INCLUDEREBOOT_REASON_H */


### PR DESCRIPTION
There are 5 options for testing reboot reason functionality.
1) hw reset
2) memory allocation fail
3) watchdog reset
4) temporary value write
5) clear the reboot reason