### PR TITLE
os/kernel/binary_manager: Add NULL check in binary_manager_add_binlist

### DIFF
--- a/os/kernel/binary_manager/binary_manager_data.c
+++ b/os/kernel/binary_manager/binary_manager_data.c
@@ -191,6 +191,21 @@ void binary_manager_add_binlist(FAR struct tcb_s *tcb)
 {
 	int bin_idx;
 
+	if (!tcb) {
+		bmdbg("ERROR: tcb parameter is NULL\n");
+		return;
+	}
+
+	if (!tcb->group) {
+		/* It is possible that the task / pthread has already exited at the time of calling this function.
+		 * In this case, the group member will be NULL and will cause an exception if we try to dereference
+		 * the pointer. So, perform a null check here. If group is null, it is ok to not add the tcb to our
+		 * list because, task has already exited.
+		 */
+		bmdbg("Failed to add pid %d to binlist. This task has already exited and group is NULL\n", tcb->pid);
+		return;
+	}
+
 	bin_idx = tcb->group->tg_binidx;
 
 	/* A binary index, bin_idx is greater than 0 only if tcb is a thread of user binary.


### PR DESCRIPTION
This commit is for crash issue in network_tc pthread. It is observed that
there is a busfault while running net_sendto_main(). This API creates some
pthreads. If we add some print statements in the pthread, then crash is not
reproduced. It is found from analysis that the crash is happening due to
NULL pointer access in binary_manager_add_binlist. This is because, the pthread
seems to have exited before the binary_manager_add_binlist() is called, and
hence the tcb->group member is NULL.

In order to fix this issue, we perform NULL check in binary_manager_add_binlist
and if group member in tcb is null, then we do not need to add the tcb to the
app's thread list.

Signed-off-by: Kishore S N <kishore.sn@samsung.com>