### PR TITLE
os/tools/build_test.sh : Add error check when build fail

### DIFF
--- a/os/tools/build_test.sh
+++ b/os/tools/build_test.sh
@@ -49,7 +49,7 @@ for target in ${build_targets[@]}; do
 	echo "===================================="
 	echo "======== Build \"${target}\" ========"
 	echo "===================================="	
-	cd ${OSDIR}; ${BUILD_CMD}
+	cd ${OSDIR}; ${BUILD_CMD} || { echo "\"${target}\" ERROR!!!"; exit 1; }
 
 	echo "===================================="
 	echo "======== \"${target}\" Built ========"


### PR DESCRIPTION
Current build script tries to build many configurations automatically.
But when there is a fail, build is not stopped and continue to the next.
So when there is a fail, stop the build and show where the build error is come from.