### PR TITLE
New method to debug heap corruption

### DIFF
--- a/os/arch/arm/src/armv7-m/up_assert.c
+++ b/os/arch/arm/src/armv7-m/up_assert.c
@@ -91,6 +91,8 @@
 #include <sys/boardctl.h>
 #endif
 
+#include <tinyara/mm/mm.h>
+
 #ifdef CONFIG_BINMGR_RECOVERY
 #include <stdbool.h>
 #include "binary_manager/binary_manager.h"
@@ -477,6 +479,19 @@ void up_assert(const uint8_t *filename, int lineno)
 #endif  /* CONFIG_APP_BINARY_SEPARATION */
 
 	up_dumpstate();
+
+	lldbg("Checking kernel heap for corruption...\n");
+	if (mm_check_heap_corruption(g_kmmheap) == OK) {
+		lldbg("No heap corruption detected\n");
+	}
+#ifdef CONFIG_APP_BINARY_SEPARATION
+	if (!is_kernel_fault) {
+		lldbg("Checking current app heap for corruption...\n");
+		if (mm_check_heap_corruption((struct mm_heap_s *)(this_task()->uheap)) == OK) {
+			lldbg("No heap corruption detected\n");
+		}
+	}
+#endif
 
 #if defined(CONFIG_BOARD_CRASHDUMP)
 	board_crashdump(up_getsp(), this_task(), (uint8_t *)filename, lineno);

--- a/os/arch/arm/src/armv7-m/up_assert.c
+++ b/os/arch/arm/src/armv7-m/up_assert.c
@@ -104,6 +104,8 @@
 
 #ifdef CONFIG_BINMGR_RECOVERY
 bool abort_mode = false;
+#endif
+#ifdef CONFIG_APP_BINARY_SEPARATION
 extern uint32_t g_assertpc;
 #endif
 
@@ -456,7 +458,7 @@ void up_assert(const uint8_t *filename, int lineno)
 	lldbg("Assertion failed at file:%s line: %d\n", filename, lineno);
 #endif
 
-#ifdef CONFIG_BINMGR_RECOVERY
+#ifdef CONFIG_APP_BINARY_SEPARATION
 	uint32_t assert_pc;
 	bool is_kernel_fault;
 
@@ -472,7 +474,7 @@ void up_assert(const uint8_t *filename, int lineno)
 
 	is_kernel_fault = is_kernel_space((void *)assert_pc);
 
-#endif  /* CONFIG_BINMGR_RECOVERY */
+#endif  /* CONFIG_APP_BINARY_SEPARATION */
 
 	up_dumpstate();
 

--- a/os/arch/arm/src/armv7-m/up_hardfault.c
+++ b/os/arch/arm/src/armv7-m/up_hardfault.c
@@ -84,7 +84,7 @@
 
 #define INSN_SVC0        0xdf00	/* insn: svc 0 */
 
-#ifdef CONFIG_BINMGR_RECOVERY
+#ifdef CONFIG_APP_BINARY_SEPARATION
 uint32_t g_assertpc;
 #endif
 /****************************************************************************
@@ -118,7 +118,7 @@ int up_hardfault(int irq, FAR void *context, FAR void *arg)
 	uint32_t *regs = (uint32_t *)context;
 #endif
 
-#ifdef CONFIG_BINMGR_RECOVERY
+#ifdef CONFIG_APP_BINARY_SEPARATION
 	g_assertpc = regs[REG_R15];
 #endif
 	/* Get the value of the program counter where the fault occurred */

--- a/os/arch/arm/src/armv7-m/up_svcall.c
+++ b/os/arch/arm/src/armv7-m/up_svcall.c
@@ -97,7 +97,7 @@
 #define svcdbg(...)
 #endif
 
-#ifdef CONFIG_BINMGR_RECOVERY
+#ifdef CONFIG_APP_BINARY_SEPARATION
 extern uint32_t g_assertpc;
 #endif
 #ifdef CONFIG_SUPPORT_COMMON_BINARY
@@ -194,7 +194,7 @@ int up_svcall(int irq, FAR void *context, FAR void *arg)
 	/* The SVCall software interrupt is called with R0 = system call command
 	 * and R1..R7 =  variable number of arguments depending on the system call.
 	 */
-#ifdef CONFIG_BINMGR_RECOVERY
+#ifdef CONFIG_APP_BINARY_SEPARATION
 	g_assertpc = regs[REG_R14];
 #endif
 

--- a/os/arch/arm/src/armv8-m/up_assert.c
+++ b/os/arch/arm/src/armv8-m/up_assert.c
@@ -106,12 +106,14 @@
 
 #ifdef CONFIG_BINMGR_RECOVERY
 bool abort_mode = false;
-extern uint32_t g_assertpc;
 extern struct tcb_s *g_faultmsg_sender;
 extern sq_queue_t g_faultmsg_list;
 extern sq_queue_t g_freemsg_list;
 #endif
 
+#ifdef CONFIG_APP_BINARY_SEPARATION
+extern uint32_t g_assertpc;
+#endif
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
@@ -386,6 +388,7 @@ static void up_dumpstate(void)
 
 	(void)usbtrace_enumerate(assert_tracecallback, NULL);
 #endif
+
 }
 #else
 #define up_dumpstate()
@@ -462,7 +465,7 @@ void up_assert(const uint8_t *filename, int lineno)
 	lldbg("Assertion failed at file:%s line: %d\n", filename, lineno);
 #endif
 
-#ifdef CONFIG_BINMGR_RECOVERY
+#ifdef CONFIG_APP_BINARY_SEPARATION
 	uint32_t assert_pc;
 	bool is_kernel_fault;
 
@@ -478,7 +481,7 @@ void up_assert(const uint8_t *filename, int lineno)
 
 	is_kernel_fault = is_kernel_space((void *)assert_pc);
 
-#endif  /* CONFIG_BINMGR_RECOVERY */
+#endif  /* CONFIG_APP_BINARY_SEPARATION */
 
 	up_dumpstate();
 

--- a/os/arch/arm/src/armv8-m/up_assert.c
+++ b/os/arch/arm/src/armv8-m/up_assert.c
@@ -86,6 +86,8 @@
 #include <arch/board/board.h>
 #include <tinyara/sched.h>
 
+#include <tinyara/mm/mm.h>
+
 #include "sched/sched.h"
 #ifdef CONFIG_BOARD_ASSERT_AUTORESET
 #include <sys/boardctl.h>
@@ -484,6 +486,19 @@ void up_assert(const uint8_t *filename, int lineno)
 #endif  /* CONFIG_APP_BINARY_SEPARATION */
 
 	up_dumpstate();
+
+	lldbg("Checking kernel heap for corruption...\n");
+	if (mm_check_heap_corruption(g_kmmheap) == OK) {
+		lldbg("No heap corruption detected\n");
+	}
+#ifdef CONFIG_APP_BINARY_SEPARATION
+	if (!is_kernel_fault) {
+		lldbg("Checking current app heap for corruption...\n");
+		if (mm_check_heap_corruption((struct mm_heap_s *)(this_task()->uheap)) == OK) {
+			lldbg("No heap corruption detected\n");
+		}
+	}
+#endif
 
 #if defined(CONFIG_BOARD_CRASHDUMP)
 	board_crashdump(up_getsp(), this_task(), (uint8_t *)filename, lineno);

--- a/os/arch/arm/src/armv8-m/up_hardfault.c
+++ b/os/arch/arm/src/armv8-m/up_hardfault.c
@@ -89,7 +89,7 @@
 
 #define INSN_SVC0        0xdf00	/* insn: svc 0 */
 
-#ifdef CONFIG_BINMGR_RECOVERY
+#ifdef CONFIG_APP_BINARY_SEPARATION
 uint32_t g_assertpc;
 #endif
 /****************************************************************************
@@ -123,7 +123,7 @@ int up_hardfault(int irq, FAR void *context, FAR void *arg)
 	uint32_t *regs = (uint32_t *)context;
 #endif
 
-#ifdef CONFIG_BINMGR_RECOVERY
+#ifdef CONFIG_APP_BINARY_SEPARATION
 	g_assertpc = regs[REG_R15];
 #endif
 	/* Get the value of the program counter where the fault occurred */

--- a/os/arch/arm/src/armv8-m/up_svcall.c
+++ b/os/arch/arm/src/armv8-m/up_svcall.c
@@ -100,7 +100,7 @@
 #define svcdbg(...)
 #endif
 
-#ifdef CONFIG_BINMGR_RECOVERY
+#ifdef CONFIG_APP_BINARY_SEPARATION
 extern uint32_t g_assertpc;
 #endif
 #ifdef CONFIG_SUPPORT_COMMON_BINARY
@@ -196,7 +196,7 @@ int up_svcall(int irq, FAR void *context, FAR void *arg)
 	/* The SVCall software interrupt is called with R0 = system call command
 	 * and R1..R7 =  variable number of arguments depending on the system call.
 	 */
-#ifdef CONFIG_BINMGR_RECOVERY
+#ifdef CONFIG_APP_BINARY_SEPARATION
 	g_assertpc = regs[REG_R14];
 #endif
 

--- a/os/include/tinyara/mm/mm.h
+++ b/os/include/tinyara/mm/mm.h
@@ -703,6 +703,9 @@ struct mm_heap_s *mm_get_app_heap_with_name(char *app_name);
 char *mm_get_app_heap_name(void *address);
 #endif
 
+/* Function to check heap corruption */
+int mm_check_heap_corruption(struct mm_heap_s *heap);
+
 #if CONFIG_KMM_NHEAPS > 1
 /**
  * @cond

--- a/os/mm/mm_heap/Make.defs
+++ b/os/mm/mm_heap/Make.defs
@@ -56,6 +56,7 @@ CSRCS += mm_initialize.c mm_sem.c mm_addfreechunk.c mm_size2ndx.c
 CSRCS += mm_shrinkchunk.c
 CSRCS += mm_brkaddr.c mm_calloc.c mm_extend.c mm_free.c mm_mallinfo.c
 CSRCS += mm_malloc.c mm_memalign.c mm_realloc.c mm_zalloc.c mm_heap_regioninfo.c mm_getheap.c
+CSRCS += mm_check_heap_corruption.c
 
 ifeq ($(CONFIG_BUILD_KERNEL),y)
 CSRCS += mm_sbrk.c

--- a/os/mm/mm_heap/mm_check_heap_corruption.c
+++ b/os/mm/mm_heap/mm_check_heap_corruption.c
@@ -1,0 +1,189 @@
+/****************************************************************************
+ *
+ * Copyright 2021 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+/****************************************************************************
+ * mm/mm_heap/mm_check_heap_corruption.c
+ *
+ *   Copyright (C) 2007, 2009, 2013-2014 Gregory Nutt. All rights reserved.
+ *   Author: Gregory Nutt <gnutt@nuttx.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+#include <tinyara/config.h>
+#include <debug.h>
+#include <tinyara/mm/mm.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+#define MM_PREV_NODE_SIZE(x)		((x)->preceding & ~MM_ALLOC_BIT)
+#define IS_ALLOCATED_NODE(x)		((x)->preceding & MM_ALLOC_BIT)
+#define IS_FREE_NODE(x)			(!IS_ALLOCATED_NODE(x))
+
+/****************************************************************************
+ * Public data
+ ****************************************************************************/
+enum node_type_e {
+	TYPE_CORRUPTED,
+	TYPE_OVERFLOWED,
+};
+
+typedef enum node_type_e node_type_t;
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+static void dump_node(struct mm_allocnode_s *node, node_type_t type)
+{
+	if (type == TYPE_CORRUPTED) {
+		dbg("CORRUPTED NODE: addr = 0x%08x size = %u preceding size = %u\n", node, node->size, MM_PREV_NODE_SIZE(node));
+	} else if (type == TYPE_OVERFLOWED) {
+		dbg("OVERFLOWED NODE: addr = 0x%08x size = %u type = %c\n", node, node->size, IS_ALLOCATED_NODE(node) ? 'A' : 'F');
+	}
+#ifdef CONFIG_DEBUG_MM_HEAPINFO
+	dbg("Node owner pid = %u, allocated by code at addr = 0x%08x\n", node->pid, node->alloc_call_addr);
+#endif
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: mm_check_heap_corruption
+ *
+ * Description:
+ *   This function walk through heap and prints information about corrupt node.
+ ****************************************************************************/
+int mm_check_heap_corruption(struct mm_heap_s *heap)
+{
+	struct mm_allocnode_s *node;
+	struct mm_allocnode_s *prev;
+	struct mm_allocnode_s *next;
+#if CONFIG_KMM_REGIONS > 1
+	int region;
+#else
+#define region 0
+#endif
+
+	DEBUGASSERT(heap);
+
+	/* Visit each region */
+
+#if CONFIG_KMM_REGIONS > 1
+	for (region = 0; region < heap->mm_nregions; region++)
+#endif
+	{
+		/* Visit each node in the region
+		 * Retake the semaphore for each region to reduce latencies
+		 */
+
+		mm_takesemaphore(heap);
+
+		prev = NULL;
+		node = heap->mm_heapstart[region];
+		next = (struct mm_allocnode_s *)((char *)node + node->size);
+
+		for (; node < heap->mm_heapend[region]; prev = node, node = next, next = (struct mm_allocnode_s *)((char *)next + next->size)) {
+			if (prev && prev->size != MM_PREV_NODE_SIZE(node)) {
+				dbg("#########################################################################################\n");
+				dbg("ERROR: Heap node corruption detected\n");
+				dump_node(prev, TYPE_OVERFLOWED);
+				dump_node(node, TYPE_CORRUPTED);
+				dbg("#########################################################################################\n");
+				mm_givesemaphore(heap);
+				return -1;
+			} else if (node->size != MM_PREV_NODE_SIZE(next)) {
+				dbg("#########################################################################################\n");
+				dbg("ERROR: Heap node corruption detected.\n");
+				dbg("=========================================================================================\n");
+				dbg("Possible corruption scenario 1:\n");
+				dbg("=========================================================================================\n");
+				dump_node(prev, TYPE_OVERFLOWED);
+				dump_node(node, TYPE_CORRUPTED);
+				dbg("=========================================================================================\n");
+				dbg("Possible corruption scenario 2:\n");
+				dbg("=========================================================================================\n");
+				dump_node(node, TYPE_OVERFLOWED);
+				dump_node(next, TYPE_CORRUPTED);
+				dbg("#########################################################################################\n");
+				mm_givesemaphore(heap);
+				return -1;
+			} else if (IS_FREE_NODE(node)) {
+				if ((((struct mm_freenode_s *)node)->blink && ((struct mm_freenode_s *)node)->blink->flink != ((struct mm_freenode_s *)node))) {
+					dbg("#########################################################################################\n");
+					dbg("ERROR: Heap node corruption detected in free node list\n");
+					dump_node(prev, TYPE_OVERFLOWED);
+					dump_node(node, TYPE_CORRUPTED);
+					dbg("Corrupted node blink(0x%08x) and prev node flink(0x%08x) do not match\n", ((struct mm_freenode_s *)node)->blink,
+							((struct mm_freenode_s *)node)->blink->flink);
+					dbg("#########################################################################################\n");
+					mm_givesemaphore(heap);
+					return -1;
+				} else if (((struct mm_freenode_s *)node)->flink && ((struct mm_freenode_s *)node)->flink->blink != ((struct mm_freenode_s *)node)) {
+					dbg("#########################################################################################\n");
+					dbg("ERROR: Heap node corruption detected in free node list\n");
+					dump_node(prev, TYPE_OVERFLOWED);
+					dump_node(node, TYPE_CORRUPTED);
+					dbg("Corrupted node flink(0x%08x) and next node blink(0x%08x) do not match\n", ((struct mm_freenode_s *)node)->flink,
+							((struct mm_freenode_s *)node)->flink->blink);
+					dbg("#########################################################################################\n");
+					mm_givesemaphore(heap);
+					return -1;
+				}
+			}
+		}
+	}
+
+	mm_givesemaphore(heap);
+	return 0;
+}

--- a/os/mm/mm_heap/mm_heapinfo_parse_heap.c
+++ b/os/mm/mm_heap/mm_heapinfo_parse_heap.c
@@ -69,6 +69,7 @@
  ****************************************************************************/
 
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
+
 /****************************************************************************
  * Name: heapinfo_parse
  *
@@ -104,6 +105,8 @@ void heapinfo_parse_heap(FAR struct mm_heap_s *heap, int mode, pid_t pid)
 	size_t nodelist_size[MM_NNODES] = {0, };
 	FAR struct mm_freenode_s *fnode;
 #endif
+
+	ASSERT(mm_check_heap_corruption(heap) == OK);
 
 	/* initialize the heap, stack and nonsched resource */
 	nonsched_resource = 0;


### PR DESCRIPTION
Heap corruption can happen when a node overflows into next node
in the heap list. However, even when heap is corrupted, the system
can run properly for some time. So, we provide heap corruption check
in following ways:

- Add heap corruption check api as part of heapinfo
- If heapinfo is not enabled, then we dont have any information about
the owner process of the heap node which caused the corruption.
- When user calls heapinfo for any app or kernel, the corresponding
heap is checked for corruption. All details about corruption are printed.
- When mallinfo api is called, heap corruption is checked and printed.
- In both cases, we will not ASSERT because, even with heap corruption,
the system can continue to operate unless the corrupted node is accessed.
- However, if the system gets ASSERT due to any other reason, we check
and print the heap corruption details for the corresponding heap.

Signed-off-by: Kishore S N <kishore.sn@samsung.com>