### PR TITLE
network/wifimanager: fix assert issue in wifi stress test

### DIFF
--- a/framework/src/wifi_manager/wifi_manager_msghandler.c
+++ b/framework/src/wifi_manager/wifi_manager_msghandler.c
@@ -67,7 +67,7 @@ static int _process_msg(int argc, char *argv[])
  */
 int wifimgr_run_msghandler(void)
 {
-	int tid = task_create("wifi msg handler", 100, 4096, (main_t)_process_msg, NULL);
+	int tid = task_create("wifi msg handler", 101, 4096, (main_t)_process_msg, NULL);
 	if (tid < 0) {
 		WM_ERR;
 		return -1;


### PR DESCRIPTION
Increase the priority of wifi msg handler thread from 100 to 101 to avoid the assert issue in wifi stress test.
Please note that this is a workaround for the assert issue in wifi stress test.