### PR TITLE
arch/arm : Add reboot_reason_trywrite in up_assert

### DIFF
--- a/os/arch/arm/src/amebad/Make.defs
+++ b/os/arch/arm/src/amebad/Make.defs
@@ -67,6 +67,10 @@ CMN_CSRCS += up_unblocktask.c up_usestack.c up_doirq.c up_hardfault.c
 CMN_CSRCS += up_svcall.c up_vfork.c up_trigger_irq.c up_systemreset.c
 CMN_CSRCS += up_unblocktask_withoutsavereg.c
 
+ifeq ($(CONFIG_SYSTEM_REBOOT_REASON),y)
+CMN_CSRCS += up_reboot_reason.c
+endif
+
 ifeq ($(CONFIG_STACK_COLORATION),y)
 CMN_CSRCS += go_os_start.c
 endif

--- a/os/arch/arm/src/armv8-m/up_assert.c
+++ b/os/arch/arm/src/armv8-m/up_assert.c
@@ -88,6 +88,9 @@
 
 #include <tinyara/mm/mm.h>
 
+#ifdef CONFIG_SYSTEM_REBOOT_REASON
+#include <arch/reboot_reason.h>
+#endif
 #include "sched/sched.h"
 #ifdef CONFIG_BOARD_ASSERT_AUTORESET
 #include <sys/boardctl.h>
@@ -456,6 +459,10 @@ void dump_all_stack(void)
 void up_assert(const uint8_t *filename, int lineno)
 {
 	board_led_on(LED_ASSERTION);
+
+#ifdef CONFIG_SYSTEM_REBOOT_REASON
+	reboot_reason_write_user_intended();
+#endif
 
 #if defined(CONFIG_DEBUG_DISPLAY_SYMBOL) || defined(CONFIG_BINMGR_RECOVERY)
 	abort_mode = true;

--- a/os/arch/arm/src/common/up_reboot_reason.c
+++ b/os/arch/arm/src/common/up_reboot_reason.c
@@ -15,19 +15,24 @@
  * language governing permissions and limitations under the License.
  *
  ****************************************************************************/
-#ifndef __ARCH_ARM_INCLUDE_REBOOT_REASON_H
-#define __ARCH_ARM_INCLUDE_REBOOT_REASON_H
 
+#include <tinyara/config.h>
+#include <arch/reboot_reason.h>
 #include <tinyara/reboot_reason.h>
 
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
 
-void up_reboot_reason_init(void);
-reboot_reason_code_t up_reboot_reason_read(void);
-void up_reboot_reason_write(reboot_reason_code_t reason);
-void reboot_reason_write_user_intended(void);
-void up_reboot_reason_clear(void);
-
-#endif	/* __ARCH_ARM_INCLUDE_REBOOT_REASON_H */
+/****************************************************************************
+ * Name: reboot_reason_trywrite
+ ****************************************************************************/
+#ifdef CONFIG_SYSTEM_REBOOT_REASON
+void reboot_reason_write_user_intended(void)
+{
+	/* Write REBOOT_SYSTEM_USER_INTENDED only when there is no written reason before. */
+	if (up_reboot_reason_read() == REBOOT_REASON_INITIALIZED) {
+		up_reboot_reason_write(REBOOT_SYSTEM_USER_INTENDED);
+	}
+}
+#endif


### PR DESCRIPTION
1) reboot_reason_trywrite checks that there is already written reboot reason. If no, write REBOOT_SYSTEM_USER_INTENDED.
2) In up_assert, if there is user intended assert, not data abort or prefetch abort, calls reboot_reason_trywrite().