### PR TITLE
os/arch/arm/src : Move memfault, busfault and usagefault handlers out of CONFIG_DEBUG

### DIFF
--- a/os/arch/arm/src/imxrt/imxrt_lowputc.c
+++ b/os/arch/arm/src/imxrt/imxrt_lowputc.c
@@ -502,7 +502,7 @@ int imxrt_lpuart_configure(uint32_t base, FAR const struct uart_config_s *config
 }
 #endif							/* HAVE_LPUART_DEVICE */
 
-#if defined(HAVE_LPUART_DEVICE) && defined(CONFIG_DEBUG)
+#if defined(HAVE_LPUART_DEVICE)
 /****************************************************************************
  * Name: up_lowputc
  *

--- a/os/arch/arm/src/imxrt/imxrt_lowputc.h
+++ b/os/arch/arm/src/imxrt/imxrt_lowputc.h
@@ -133,7 +133,7 @@ int imxrt_lpuart_configure(uint32_t base, FAR const struct uart_config_s *config
  *
  ************************************************************************************/
 
-#if defined(HAVE_LPUART_DEVICE) && defined(CONFIG_DEBUG)
+#if defined(HAVE_LPUART_DEVICE)
 void imxrt_lowputc(char ch);
 uint8_t imxrt_lowgetc(void);
 #else

--- a/os/arch/arm/src/tiva/tiva_irq.c
+++ b/os/arch/arm/src/tiva/tiva_irq.c
@@ -175,15 +175,6 @@ static void tiva_dumpnvic(const char *msg, int irq)
  *
  ****************************************************************************/
 
-#ifdef CONFIG_DEBUG
-static int tiva_nmi(int irq, FAR void *context, FAR void *arg)
-{
-	(void)irqsave();
-	dbg("PANIC!!! NMI received\n");
-	PANIC();
-	return 0;
-}
-
 static int tiva_busfault(int irq, FAR void *context, FAR void *arg)
 {
 	(void)irqsave();
@@ -196,6 +187,15 @@ static int tiva_usagefault(int irq, FAR void *context, FAR void *arg)
 {
 	(void)irqsave();
 	dbg("PANIC!!! Usage fault received\n");
+	PANIC();
+	return 0;
+}
+
+#ifdef CONFIG_DEBUG
+static int tiva_nmi(int irq, FAR void *context, FAR void *arg)
+{
+	(void)irqsave();
+	dbg("PANIC!!! NMI received\n");
 	PANIC();
 	return 0;
 }
@@ -416,17 +416,16 @@ void up_irqinitialize(void)
 #ifdef CONFIG_ARMV7M_MPU
 	irq_attach(TIVA_IRQ_MEMFAULT, up_memfault, NULL);
 	up_enable_irq(TIVA_IRQ_MEMFAULT);
+#else
+	irq_attach(TIVA_IRQ_MEMFAULT, up_memfault, NULL);
 #endif
+	irq_attach(TIVA_IRQ_BUSFAULT, tiva_busfault, NULL);
+	irq_attach(TIVA_IRQ_USAGEFAULT, tiva_usagefault, NULL);
 
 	/* Attach all other processor exceptions (except reset and sys tick) */
 
 #ifdef CONFIG_DEBUG
 	irq_attach(TIVA_IRQ_NMI, tiva_nmi, NULL);
-#ifndef CONFIG_ARMV7M_MPU
-	irq_attach(TIVA_IRQ_MEMFAULT, up_memfault, NULL);
-#endif
-	irq_attach(TIVA_IRQ_BUSFAULT, tiva_busfault, NULL);
-	irq_attach(TIVA_IRQ_USAGEFAULT, tiva_usagefault, NULL);
 	irq_attach(TIVA_IRQ_PENDSV, tiva_pendsv, NULL);
 	irq_attach(TIVA_IRQ_DBGMONITOR, tiva_dbgmonitor, NULL);
 	irq_attach(TIVA_IRQ_RESERVED, tiva_reserved, NULL);


### PR DESCRIPTION
1. Enable lldbg logs during crash in imxrt without CONFIG_DEBUG
2. Move memfault, busfault and usagefault handlers out of CONFIG_DEBUG