### PR TITLE
net/lwip/ipv6: fix coding rule violation

### DIFF
--- a/os/net/lwip/src/core/ipv6/nd6.c
+++ b/os/net/lwip/src/core/ipv6/nd6.c
@@ -2242,9 +2242,6 @@ static s8_t nd6_get_next_hop_entry(const ip6_addr_t *ip6addr, struct netif *neti
 					LWIP_DEBUGF(ND6_DEBUG, ("Failed to find router, need to NUD\n"));
 				}
 			}
-			else {
-
-			}
 		} else {
 			/* Not found. Create a new destination entry. */
 			i = nd6_new_destination_cache_entry();


### PR DESCRIPTION
This commit fixes violation of coding rule. The else conditional has no statement.
Let's remove it.

os/net/lwip/src/core/ipv6/nd6.c:2245: ERROR: [BRC_M_SMT] else should follow close brace '}'

Signed-off-by: sunghan-chang <sh924.chang@samsung.com>