### PR TITLE
network/lwip: fix ipv6 kconfig

### DIFF
--- a/os/net/lwip/configs/Kconfig
+++ b/os/net/lwip/configs/Kconfig
@@ -13,15 +13,31 @@ menuconfig NET_IPv4
 
 source "net/lwip/configs/ipv4/Kconfig"
 
-menuconfig NET_IPv6
-	bool "IPv6 support"
+menuconfig NET_ICMP
+	bool "ICMP Support"
+	depends on NET_IPv4
 	default n
 	---help---
-		Build in support for IPv6.
+		Enable minimal ICMP support. Includes built-in support
+		for sending replies to received ECHO (ping) requests.
 
-source "net/lwip/configs/ipv6/Kconfig"
+if NET_ICMP
+source "net/lwip/configs/icmp/Kconfig"
+endif
 
-source "net/lwip/configs/socket/Kconfig"
+menuconfig NET_LWIP_IGMP
+	bool "IGMP Support"
+	depends on NET_IPv4
+	default n
+
+if NET_LWIP_IGMP
+config NET_LWIP_MEMP_NUM_IGMP_GROUP
+	int "Maximum number of IGMP group"
+	default 8
+	---help---
+		Number of multicast groups whose network interfaces
+		can be members at the same time
+endif #NET_LWIP_IGMP
 
 menuconfig NET_ARP
 	bool "ARP Support"
@@ -41,7 +57,6 @@ menuconfig NET_UDP
 
 source "net/lwip/configs/udp/Kconfig"
 
-
 menuconfig NET_TCP
 	bool "TCP Support"
 	depends on NET_IPv4 || NET_IPv6
@@ -52,32 +67,13 @@ menuconfig NET_TCP
 source "net/lwip/configs/tcp/Kconfig"
 
 
-menuconfig NET_ICMP
-	bool "ICMP Support"
-	depends on NET_IPv4
+menuconfig NET_IPv6
+	bool "IPv6 support"
 	default n
 	---help---
-		Enable minimal ICMP support. Includes built-in support
-		for sending replies to received ECHO (ping) requests.
+		Build in support for IPv6.
 
-if NET_ICMP
-source "net/lwip/configs/icmp/Kconfig"
-endif
-
-menuconfig NET_LWIP_IGMP
-	bool "IGMP Support"
-	depends on NET_IPv4	
-	default n
-
-if NET_LWIP_IGMP
-
-config NET_LWIP_MEMP_NUM_IGMP_GROUP
-	int "Maximum number of IGMP group"
-	default 8
-	---help---
-		Number of multicast groups whose network interfaces
-		can be members at the same time
-endif #NET_LWIP_IGMP
+source "net/lwip/configs/ipv6/Kconfig"
 
 if NET_IPv6
 source "net/lwip/configs/nd/Kconfig"
@@ -100,7 +96,7 @@ config NET_IPv6_DHCP
 	---help---
 		Enable DHCPv6 stateful address autoconfiguration.
 
-
+source "net/lwip/configs/socket/Kconfig"
 source "net/lwip/configs/mbox/Kconfig"
 source "net/lwip/configs/mem/Kconfig"
 source "net/lwip/configs/sys/Kconfig"
@@ -125,9 +121,7 @@ config NET_LWIP_VLAN_CHECK_ID
 	default 1
 	depends on NET_LWIP_VLAN_CHECK
 
-
 ################# SLIP #######################
-
 menuconfig NET_LWIP_SLIP_INTERFACE
 	bool "Support serial line IP interface"
 	default n
@@ -148,9 +142,7 @@ config NET_LWIP_SLIPIF_THREAD_PRIO
 
 endif #NET_LWIP_SLIP_INTERFACE
 
-
 ################# PPP #######################
-
 menuconfig NET_LWIP_PPP_SUPPORT
 	bool "Enable PPP"
 	default n
@@ -195,9 +187,7 @@ config NET_LWIP_PPP_THREAD_PRIO
 
 endif #NET_LWIP_PPP_SUPPORT
 
-
 ################# SNMP #######################
-
 menuconfig NET_LWIP_SNMP
 	bool "Enable SNMP"
 	default n

--- a/os/net/lwip/configs/icmp6/Kconfig
+++ b/os/net/lwip/configs/icmp6/Kconfig
@@ -3,9 +3,10 @@
 # see kconfig-language at https://www.kernel.org/doc/Documentation/kbuild/kconfig-language.txt
 #
 
-menu "ICMP6 Support"
+menu "ICMPv6 (RFC 4443)"
 
 config NET_IPv6_ICMP
+	bool
 	depends on NET_IPv6
 	default y
 	---help---

--- a/os/net/lwip/configs/nd/Kconfig
+++ b/os/net/lwip/configs/nd/Kconfig
@@ -3,9 +3,10 @@
 # see kconfig-language at https://www.kernel.org/doc/Documentation/kbuild/kconfig-language.txt
 #
 
-menu "ND Support"
+menu "Neighbor Discovery (RFC 4861)"
 
 config NET_IPv6_ND
+	bool
 	depends on NET_IPv6
 	default y
 	---help---
@@ -15,48 +16,48 @@ config NET_IPv6_ND_QUEUEING
 	bool "Enable queue outgoing IPv6 packets while MAC address"
 	default y
 	---help---
-		Enable queue outgoing IPv6 packets while MAC address.	
+		Enable queue outgoing IPv6 packets while MAC address.
 
 
 config NET_IPv6_ND_QUEUE
 	int "Max number of IPv6 packets to queue during MAC resolution"
 	default 20
 	---help---
-		Max number of IPv6 packets to queue during MAC resolution.	
+		Max number of IPv6 packets to queue during MAC resolution.
 
 config NET_IPv6_ND_NUM_NEIGHBORS
 	int "Number of entries in IPv6 neighbor cache"
 	default 10
 	---help---
-		Number of entries in IPv6 neighbor cache.	
+		Number of entries in IPv6 neighbor cache.
 
 config NET_IPv6_ND_NUM_DESTINATIONS
 	int "Number of entries in IPv6 destination cache"
 	default 10
 	---help---
-		Number of entries in IPv6 destination cache.	
+		Number of entries in IPv6 destination cache.
 
 config NET_IPv6_ND_NUM_PREFIXES
 	int "Number of entries in IPv6 on-link prefixes cache"
-	default 5 
+	default 5
 	---help---
-		Number of entries in IPv6 on-link prefixes cache.	
+		Number of entries in IPv6 on-link prefixes cache.
 
 config NET_IPv6_ND_NUM_ROUTERS
 	int "Number of entries in IPv6 default router cache"
-	default 3 
+	default 3
 	---help---
-		Number of entries in IPv6 default router cache.	
+		Number of entries in IPv6 default router cache.
 
 config NET_IPv6_ND_MAX_MULTICAST_SOLICIT
 	int "Max number of multicast solicit messages to send"
-	default 3 
+	default 3
 	---help---
-		Max number of multicast solicit messages to send.	
+		Max number of multicast solicit messages to send.
 
 config NET_IPv6_ND_MAX_UNICAST_SOLICIT
 	int "Max number of unicast neighbor solicitation messages"
-	default 3 
+	default 3
 	---help---
 		Max number of unicast neighbor solicitation messages
 		to send during neighbor reachability detection.
@@ -86,7 +87,7 @@ config NET_IPv6_ND_DELAY_FIRST_PROBE_TIME
 	---help---
 		Delay before first unicast neighbor solicitation
 		message is sent, during neighbor reachability detection.
-	
+
 config NET_IPv6_ND_ALLOW_RA_UPDATES
 	bool "Allow Router Advertisement messages to update"
 	default y


### PR DESCRIPTION
ICMPv6 and neighbor discovery don't have type. so it was removed after
menuconfig.