### PR TITLE
os/arch/arm/amebad_reboot_reason : Add return of REBOOT_REASON_INITIA…

### DIFF
--- a/os/arch/arm/include/reboot_reason.h
+++ b/os/arch/arm/include/reboot_reason.h
@@ -18,6 +18,7 @@
 #ifndef __ARCH_ARM_INCLUDE_REBOOT_REASON_H
 #define __ARCH_ARM_INCLUDE_REBOOT_REASON_H
 
+#include <stdbool.h>
 #include <tinyara/reboot_reason.h>
 
 /****************************************************************************
@@ -29,5 +30,6 @@ reboot_reason_code_t up_reboot_reason_read(void);
 void up_reboot_reason_write(reboot_reason_code_t reason);
 void reboot_reason_write_user_intended(void);
 void up_reboot_reason_clear(void);
+bool up_reboot_reason_is_written(void);
 
 #endif	/* __ARCH_ARM_INCLUDE_REBOOT_REASON_H */

--- a/os/arch/arm/src/amebad/amebad_reboot_reason.c
+++ b/os/arch/arm/src/amebad/amebad_reboot_reason.c
@@ -55,6 +55,7 @@
 
 #include <tinyara/config.h>
 
+#include <stdbool.h>
 #include <tinyara/reboot_reason.h>
 #include "ameba_soc.h"
 /****************************************************************************
@@ -109,5 +110,14 @@ void up_reboot_reason_clear(void)
 	 */
 	up_reboot_reason_write(REBOOT_REASON_INITIALIZED);
 	backup_reg = REBOOT_REASON_INITIALIZED;
+}
+
+bool up_reboot_reason_is_written(void)
+{
+	if (BKUP_Read(BKUP_REG1) != REBOOT_REASON_INITIALIZED) {
+		return true;
+	}
+
+	return false;
 }
 #endif

--- a/os/arch/arm/src/common/up_reboot_reason.c
+++ b/os/arch/arm/src/common/up_reboot_reason.c
@@ -31,7 +31,7 @@
 void reboot_reason_write_user_intended(void)
 {
 	/* Write REBOOT_SYSTEM_USER_INTENDED only when there is no written reason before. */
-	if (up_reboot_reason_read() == REBOOT_REASON_INITIALIZED) {
+	if (!up_reboot_reason_is_written()) {
 		up_reboot_reason_write(REBOOT_SYSTEM_USER_INTENDED);
 	}
 }


### PR DESCRIPTION
…LIZED in up_reboot_reason_read()

If there is no written reboot reason and it is not hw reset or watchdog reset, then return REBOOT_REASON_INITIALIZED.