### PR TITLE
examples/wifi_manager_sample: apply wifi auth policy

### DIFF
--- a/apps/examples/wifi_manager_sample/wm_test.c
+++ b/apps/examples/wifi_manager_sample/wm_test.c
@@ -400,7 +400,7 @@ static wifi_manager_ap_auth_type_e get_auth_type(const char *method)
 		if ((strcmp(method, wifi_test_auth_method[i]) == 0) || (result[0] && (strcmp(result[0], wifi_test_auth_method[i]) == 0))) {
 			if (result[2] != NULL) {
 				if (strcmp(result[2], "ent") == 0) {
-					return auth_type_table[i + 3];
+					return WIFI_MANAGER_AUTH_UNKNOWN;
 				}
 			}
 			return auth_type_table[i];


### PR DESCRIPTION
- wm_test doesn't suuport enterprise auth.