### PR TITLE
apps/sysinfo: add Binary version in system information

### DIFF
--- a/apps/system/sysinfo/sysinfo.c
+++ b/apps/system/sysinfo/sysinfo.c
@@ -79,7 +79,13 @@ void sysinfo(void)
 
 	/* Print OS version and Build information */
 	/* just get values defined in version.h */
+#ifdef CONFIG_BINARY_VERSION
+	printf("\tVersion:\n");
+	printf("\t\tPlatform: " CONFIG_VERSION_STRING "\tBinary: %d\n", CONFIG_BINARY_VERSION);
+	printf("\tCommit Hash: %s\n", CONFIG_VERSION_BUILD);
+#else
 	printf("\tVersion: " CONFIG_VERSION_STRING "\n\tCommit Hash: %s\n", CONFIG_VERSION_BUILD);
+#endif
 	printf("\tBuild User: " CONFIG_VERSION_BUILD_USER "\n\tBuild Time: %s\n", CONFIG_VERSION_BUILD_TIME);
 
 	/* Get the current time as specific format in the buffer */


### PR DESCRIPTION
Recently CONFIG_BINARY_VERSION was added. Let's print it in system information.

Signed-off-by: sunghan-chang <sh924.chang@samsung.com>