### PR TITLE
board/rtl8721csm/flash: Add flow control mechanism for 256BWrite

### DIFF
--- a/os/board/rtl8721csm/src/component/common/mbed/targets/hal/rtl8721d/flash_api.c
+++ b/os/board/rtl8721csm/src/component/common/mbed/targets/hal/rtl8721d/flash_api.c
@@ -395,7 +395,7 @@ int  flash_stream_write(flash_t *obj, u32 address, u32 len, u8 * data)
 
 		addr_begin = (((addr_begin-1) >> 2) + 1) << 2;
 		for(;size >= 256 ;size -= 256){
-			FLASH_TxData256B(addr_begin, 256, data);
+			FLASH_TxData256B_RAM(addr_begin, 256, data);
 #ifdef MICRON_N25Q00AA
 			FLASH_ReadFlagStatusReg();
 #endif


### PR DESCRIPTION
1. Add flow control mechanism on 256BWrite function 
2. Move the new 256BWrite function to RAM 
3. Use the updated function instead of FLASH_TxData256B in flash_stream_write