### PR TITLE
mm/mm_heap/mm_check_heap_corruption : Move mm_givesemaphore for match…

### DIFF
--- a/os/mm/mm_heap/mm_check_heap_corruption.c
+++ b/os/mm/mm_heap/mm_check_heap_corruption.c
@@ -223,13 +223,13 @@ int mm_check_heap_corruption(struct mm_heap_s *heap)
 				}
 			}
 		}
-	}
 
 #if defined(CONFIG_BUILD_FLAT) || defined(__KERNEL__)
-	if (!up_interrupt_context())
+		if (!up_interrupt_context())
 #endif
-	{
-		mm_givesemaphore(heap);
+		{
+			mm_givesemaphore(heap);
+		}
 	}
 
 	return 0;


### PR DESCRIPTION
…ing mm_takesemaphore

mm_takesemaphore is in for loop about traversing heap region, but mm_givesemaphore is out of that for loop.
In this case, semaphore can not be matched, so moved it into for loop.