### PR TITLE
configs/rtl8721csm/download.sh: align partition information logs

### DIFF
--- a/build/configs/rtl8721csm/rtl8721csm_download.sh
+++ b/build/configs/rtl8721csm/rtl8721csm_download.sh
@@ -173,12 +173,15 @@ done
 
 #Dump Info
 echo ""
-echo "==================================================================================="
-printf '%b\t\t' "\rPARTITION NAMES: \t${parts[@]}\n"
-printf '%b\t\t' "\rPARTITION SIZES: \t${sizes[@]}\n"
-printf '%b\t' "\rPARTITION OFFSETS: \t${offsets[@]}\n"
-printf "\r"
-echo "==================================================================================="
+echo "================================ < Flash Partition Information > ================================"
+printf "\rNAME       :"
+printf '  %12s' "${parts[@]}"
+printf "\r\nSIZE(in KB):"
+printf '  %12s' "${sizes[@]}"
+printf "\r\nAddr       :"
+printf '  %12s' "${offsets[@]}"
+printf "\n"
+echo "================================================================================================="
 echo ""
 
 if test $# -eq 0; then


### PR DESCRIPTION
The logs of flash partition information was not aligned for each like below.
```
===================================================================================
PARTITION NAMES: 	km0_bl		km4_bl		reserved		ss		system_data		kernel		kernel		userfs
PARTITION SIZES: 	16		8		16		472		8		1792		1792		1048
PARTITION OFFSETS:  0x8000000  0x8004000  0x8006000  0x800A000  0x8080000  0x8082000  0x8242000  0x8402000
===================================================================================
```

This commit aligns the logs of each partition like below.
```
================================ < Flash Partition Information > ================================
NAME       :        km0_bl        km4_bl      reserved            ss   system_data        kernel        kernel        userfs
SIZE(in KB):            16             8            16           472             8          1792          1792          1048
Addr       :     0x8000000     0x8004000     0x8006000     0x800A000     0x8080000     0x8082000     0x8242000     0x8402000
=================================================================================================
```

Signed-off-by: sunghan-chang <sh924.chang@samsung.com>