### PR TITLE
board/common : Merge timezone automount

### DIFF
--- a/os/board/artik05x/src/artik05x_tash.c
+++ b/os/board/artik05x/src/artik05x_tash.c
@@ -244,15 +244,6 @@ int board_app_initialize(void)
 		}
 	}
 #endif /* CONFIG_RAMMTD */
-#ifdef CONFIG_LIBC_ZONEINFO_ROMFS
-	ret = mount(CONFIG_ARTIK05X_AUTOMOUNT_TZDEVNAME,
-		CONFIG_LIBC_TZDIR, "romfs", MS_RDONLY, NULL);
-
-	if (ret != OK) {
-		lldbg("ROMFS ERROR: mounting failed");
-	}
-
-#endif /* CONFIG_LIBC_ZONEINFO_ROMFS */
 #endif /* CONFIG_AUTOMOUNT */
 #endif /* CONFIG_FLASH_PARTITION */
 

--- a/os/board/common/common.h
+++ b/os/board/common/common.h
@@ -39,6 +39,7 @@ struct partition_data_s {
 struct partition_info_s {
 	int smartfs_partno;
 	int romfs_partno;
+	int timezone_partno;
 };
 typedef struct partition_info_s partition_info_t;
 

--- a/os/board/imxrt1020-evk/Kconfig
+++ b/os/board/imxrt1020-evk/Kconfig
@@ -35,15 +35,6 @@ config IMXRT_AUTOMOUNT_SSSRW_MOUNTPOINT
 		Specifies the mount point where secure storage
 		will be mounted at.
 
-config IMXRT_AUTOMOUNT_TZDEVNAME
-	string "Device name of the partition for zoneinfo file system"
-	default "/dev/mtdblock10"
-	depends on LIBC_ZONEINFO_ROMFS
-	depends on IMXRT_AUTOMOUNT
-	---help---
-		Specifies the device name (/dev/mtdblock10) of the partition
-		for zoneinfo file system.
-
 config SVR_DB_SECURESTORAGE
 	bool "Enable storing SVR DB inside secure storage partition"
 	default n

--- a/os/board/imxrt1020-evk/src/imxrt_bringup.c
+++ b/os/board/imxrt1020-evk/src/imxrt_bringup.c
@@ -229,13 +229,6 @@ void imxrt_filesystem_initialize(void)
 		}
 	}
 #endif							/* CONFIG_RAMMTD */
-#ifdef CONFIG_LIBC_ZONEINFO_ROMFS
-	ret = mount(CONFIG_IMXRT_AUTOMOUNT_TZDEVNAME, CONFIG_LIBC_TZDIR, "romfs", MS_RDONLY, NULL);
-
-	if (ret != OK) {
-		IMXLOG("ROMFS ERROR: mounting failed");
-	}
-#endif							/* CONFIG_LIBC_ZONEINFO_ROMFS */
 #endif							/* CONFIG_AUTOMOUNT */
 #endif							/* CONFIG_FLASH_PARTITION */
 }

--- a/os/board/imxrt1050-evk/src/imxrt_bringup.c
+++ b/os/board/imxrt1050-evk/src/imxrt_bringup.c
@@ -193,13 +193,6 @@ void imxrt_filesystem_initialize(void)
 		}
 	}
 #endif							/* CONFIG_RAMMTD */
-#ifdef CONFIG_LIBC_ZONEINFO_ROMFS
-	ret = mount(CONFIG_IMXRT_AUTOMOUNT_TZDEVNAME, CONFIG_LIBC_TZDIR, "romfs", MS_RDONLY, NULL);
-
-	if (ret != OK) {
-		IMXLOG("ROMFS ERROR: mounting failed");
-	}
-#endif							/* CONFIG_LIBC_ZONEINFO_ROMFS */
 #endif							/* CONFIG_AUTOMOUNT */
 }
 


### PR DESCRIPTION
Timezone uses romfs, so romfs should be mounted before using.
There is automount_fs_partition(), so merge the timezone automount into that.