### PR TITLE
lwip, utils: fix Kconfig warnings

### DIFF
--- a/apps/system/utils/Kconfig
+++ b/apps/system/utils/Kconfig
@@ -150,8 +150,8 @@ config ENABLE_TZSELECT
 config ENABLE_IRQINFO
 	bool "irqinfo"
 	default n
-	depends on TASH && !FS_PROCFS_EXCLUDE_IRQS
-	select DEBUG_IRQ_INFO if DEBUG
+	depends on !FS_PROCFS_EXCLUDE_IRQS
+	depends on DEBUG_IRQ_INFO
 	---help---
 		List the registered interrupts, it's occurrence counts and corresponding isr.
 

--- a/os/net/lwip/configs/Kconfig
+++ b/os/net/lwip/configs/Kconfig
@@ -77,7 +77,7 @@ source "net/lwip/configs/ipv6/Kconfig"
 
 if NET_IPv6
 source "net/lwip/configs/nd/Kconfig"
-source "net/lwip/configs/icmp6/Kconfig""
+source "net/lwip/configs/icmp6/Kconfig"
 endif
 
 menuconfig NET_IPv6_MLD


### PR DESCRIPTION
1. net/lwip/config: remove typo in Kconfig
2. apps/system/utils: tidyup ENABLE_IRQINFO dependencies