### PR TITLE
os/fs/smartfs: Fix inconsistency while opening multiple files at once

### DIFF
--- a/os/fs/smartfs/smartfs.h
+++ b/os/fs/smartfs/smartfs.h
@@ -228,7 +228,6 @@
 #define SMARTFS_BFLAG_UNMOD       0x00	/* Set if there are no unsynced changes in sf->buffer */
 #define SMARTFS_BFLAG_DIRTY       0x01	/* Set if data changed in the sector */
 #define SMARTFS_BFLAG_NEWALLOC    0x02	/* Set if sector not written since alloc */
-#define SMARTFS_BFLAG_NEW_ENTRY   0x04	/* Set if the open file structure object corresponds to a new file entry yet to be written to MTD */
 
 #define SMARTFS_ERASEDSTATE_16BIT (uint16_t)((CONFIG_SMARTFS_ERASEDSTATE << 8) | \
 								  CONFIG_SMARTFS_ERASEDSTATE)

--- a/os/fs/smartfs/smartfs_smart.c
+++ b/os/fs/smartfs/smartfs_smart.c
@@ -288,28 +288,18 @@ static int smartfs_open(FAR struct file *filep, const char *relpath, int oflags,
 				goto errout_with_buffer;
 			}
 
-#if defined(CONFIG_SMARTFS_USE_SECTOR_BUFFER) && !defined(NXFUSE_HOST_BUILD)
-			/* If CRC is enabled, hold the entry for writing later */
-			/* Mark flags to indicate that the entry will be written to a new sector in the parent directory.
-			 * This sector will then be chained in the end.
-			 */
-			sf->bflags |= SMARTFS_BFLAG_NEW_ENTRY;
-			/* Save entry mode to write to MTD later */
 			sf->entry.flags = SMARTFS_ERASEDSTATE_16BIT;
 #ifdef CONFIG_SMARTFS_ALIGNED_ACCESS
 			smartfs_wrle16(&sf->entry.flags, (uint16_t)(mode & SMARTFS_DIRENT_MODE));
 #else
 			sf->entry.flags = (uint16_t)(mode & SMARTFS_DIRENT_MODE);
 #endif
-#else
-			/* If CRC is disabled, write the new file entry */
 			/* At this point, either an available entry was found or a new one has been created */
 			ret = smartfs_writeentry(fs, sf->entry, SMARTFS_DIRENT_TYPE_FILE, mode);
 			if (ret != OK) {
 				fdbg("Unable to write entry, ret : %d\n", ret);
 				goto errout_with_buffer;
 			}
-#endif
 		} else {
 			/* Trying to create in a directory that doesn't exist */
 

--- a/os/fs/smartfs/smartfs_utils.c
+++ b/os/fs/smartfs/smartfs_utils.c
@@ -706,15 +706,6 @@ int smartfs_sync_internal(struct smartfs_mountpt_s *fs, struct smartfs_ofile_s *
 		}
 
 		sf->byteswritten = 0;
-		/* File's data sector has been synced with MTD, now check if this is a new file entry and write the entry */
-		if (sf->bflags & SMARTFS_BFLAG_NEW_ENTRY) {
-			/* Flags for this entry have already been set and stored, so mode will not be used */
-			ret = smartfs_writeentry(fs, sf->entry, SMARTFS_DIRENT_TYPE_FILE, (sf->entry.flags & SMARTFS_DIRENT_MODE));
-			if (ret < 0) {
-				fdbg("Failed to write new file entry ot MTD\n");
-				goto errout;
-			}
-		}
 		sf->bflags = SMARTFS_BFLAG_UNMOD;
 	}
 #else							/* CONFIG_SMARTFS_USE_SECTOR_BUFFER */


### PR DESCRIPTION
- When multiple files are opened at once without writing anything,
  temporary buffer entry gets overwritten.
- Hence, only the last of new file entries is synced to MTD.
- Change method so that new file entries are written instantly to
  MTD without holding for smartfs_sync_internal().

Signed-off-by: Amogh Hassija <a.hassija@samsung.com>