### PR TITLE
lib/libc: Fix testcase failure in tc_rtc

### DIFF
--- a/apps/examples/testcase/le_tc/drivers/tc_rtc.c
+++ b/apps/examples/testcase/le_tc/drivers/tc_rtc.c
@@ -20,6 +20,7 @@
 /// @brief Test Case Example for rtc driver
 #include <tinyara/config.h>
 #include <tinyara/rtc.h>
+#include <tinyara/time.h>
 #include <stdio.h>
 #include <fcntl.h>
 #include <sys/ioctl.h>
@@ -115,7 +116,15 @@ static void tc_driver_rtc_ioctl(void)
 	TC_ASSERT_EQ_CLEANUP("rtc_ioctl", rtctime_r.tm_sec, rtctime_s.tm_sec, close(fd));
 	TC_ASSERT_EQ_CLEANUP("rtc_ioctl", rtctime_r.tm_mday, rtctime_s.tm_mday, close(fd));
 	TC_ASSERT_EQ_CLEANUP("rtc_ioctl", rtctime_r.tm_mon, rtctime_s.tm_mon, close(fd));
-	TC_ASSERT_EQ_CLEANUP("rtc_ioctl", rtctime_r.tm_year, rtctime_s.tm_year, close(fd));
+
+	/* If the year according to the RTC's Epoch is less than 1970,
+	 *  it is assumed to be 100 years later, that is,between 2000 and 2069.
+	 *  Refer : https://man7.org/linux/man-pages/man4/rtc.4.html */
+	if (rtctime_s.tm_year < EPOCH_YEAR - TM_YEAR_BASE) {
+		TC_ASSERT_EQ_CLEANUP("rtc_ioctl", rtctime_r.tm_year, rtctime_s.tm_year + 100, close(fd));
+	} else {
+		TC_ASSERT_EQ_CLEANUP("rtc_ioctl", rtctime_r.tm_year, rtctime_s.tm_year, close(fd));
+	}
 
 	/* Negative test cases */
 	ret = ioctl(fd, -1, 0);

--- a/lib/libc/time/lib_calendar2utc.c
+++ b/lib/libc/time/lib_calendar2utc.c
@@ -193,6 +193,13 @@ time_t clock_calendar2utc(int year, int month, int day)
 {
 	time_t days;
 
+	/* If the year according to the RTC's Epoch is less than 1970,
+	 *  it is assumed to be 100 years later, that is,between 2000 and 2069.
+	 *  Refer : https://man7.org/linux/man-pages/man4/rtc.4.html */
+	if (year < EPOCH_YEAR) {
+		year += 100;
+	}
+
 	/* Years since epoch in units of days (ignoring leap years). */
 
 	days = (year - EPOCH_YEAR) * 365;


### PR DESCRIPTION
tc_rtc fails for settime and rdtime ioctl. This is because, we set
year value as 3. According to unix standard, this value is considered
as year 1903, which is in turn less than EPOCH year of 1970. In such
case, we need to follow unix standard and add 100 to the year value.
So, all year values from 1900 to 1969 will be converted to 2000 to
2069. We update the tc_rtc accordingly.

Signed-off-by: Kishore S N <kishore.sn@samsung.com>