### PR TITLE
os/arch/arm: Prevent recursive abort due to heap check

### DIFF
--- a/os/arch/arm/src/armv7-m/up_assert.c
+++ b/os/arch/arm/src/armv7-m/up_assert.c
@@ -104,9 +104,7 @@
 #include "up_internal.h"
 #include "mpu.h"
 
-#ifdef CONFIG_BINMGR_RECOVERY
 bool abort_mode = false;
-#endif
 #ifdef CONFIG_APP_BINARY_SEPARATION
 extern uint32_t g_assertpc;
 #endif
@@ -450,9 +448,7 @@ void up_assert(const uint8_t *filename, int lineno)
 {
 	board_led_on(LED_ASSERTION);
 
-#if defined(CONFIG_DEBUG_DISPLAY_SYMBOL) || defined(CONFIG_BINMGR_RECOVERY)
 	abort_mode = true;
-#endif
 
 #if CONFIG_TASK_NAME_SIZE > 0
 	lldbg("Assertion failed at file:%s line: %d task: %s\n", filename, lineno, this_task()->name);

--- a/os/arch/arm/src/armv7-r/arm_assert.c
+++ b/os/arch/arm/src/armv7-r/arm_assert.c
@@ -95,9 +95,9 @@
 #include <sys/boardctl.h>
 #endif
 
+bool abort_mode = false;
 #if defined(CONFIG_DEBUG_DISPLAY_SYMBOL)
 #include <stdio.h>
-bool abort_mode = false;
 static bool recursive_abort = false;
 #endif
 
@@ -942,8 +942,8 @@ void up_assert(const uint8_t *filename, int lineno)
 	if (abort_mode) {
 		recursive_abort = true;
 	}
-	abort_mode = true;
 #endif
+	abort_mode = true;
 
 #if CONFIG_TASK_NAME_SIZE > 0
 	lldbg("Assertion failed at file:%s line: %d task: %s\n", filename, lineno, this_task()->name);

--- a/os/arch/arm/src/armv8-m/up_assert.c
+++ b/os/arch/arm/src/armv8-m/up_assert.c
@@ -109,8 +109,9 @@
 #include "up_internal.h"
 #include "mpu.h"
 
-#ifdef CONFIG_BINMGR_RECOVERY
 bool abort_mode = false;
+
+#ifdef CONFIG_BINMGR_RECOVERY
 extern struct tcb_s *g_faultmsg_sender;
 extern sq_queue_t g_faultmsg_list;
 extern sq_queue_t g_freemsg_list;
@@ -464,9 +465,7 @@ void up_assert(const uint8_t *filename, int lineno)
 	reboot_reason_write_user_intended();
 #endif
 
-#if defined(CONFIG_DEBUG_DISPLAY_SYMBOL) || defined(CONFIG_BINMGR_RECOVERY)
 	abort_mode = true;
-#endif
 
 #if CONFIG_TASK_NAME_SIZE > 0
 	lldbg("Assertion failed at file:%s line: %d task: %s\n", filename, lineno, this_task()->name);

--- a/os/mm/mm_heap/mm_check_heap_corruption.c
+++ b/os/mm/mm_heap/mm_check_heap_corruption.c
@@ -75,9 +75,9 @@ enum node_type_e {
 	TYPE_CORRUPTED,
 	TYPE_OVERFLOWED,
 };
-
 typedef enum node_type_e node_type_t;
 
+extern bool abort_mode;
 /****************************************************************************
  * Private Data
  ****************************************************************************/
@@ -143,10 +143,11 @@ int mm_check_heap_corruption(struct mm_heap_s *heap)
 		 * Retake the semaphore for each region to reduce latencies
 		 */
 
+		if (!abort_mode
 #if defined(CONFIG_BUILD_FLAT) || defined(__KERNEL__)
-		if (!up_interrupt_context())
+			&& !up_interrupt_context()
 #endif
-		{
+		) {
 			mm_takesemaphore(heap);
 		}
 
@@ -161,10 +162,11 @@ int mm_check_heap_corruption(struct mm_heap_s *heap)
 				dump_node(prev, TYPE_OVERFLOWED);
 				dump_node(node, TYPE_CORRUPTED);
 				dbg("#########################################################################################\n");
+				if (!abort_mode
 #if defined(CONFIG_BUILD_FLAT) || defined(__KERNEL__)
-				if (!up_interrupt_context())
+					&& !up_interrupt_context()
 #endif
-				{
+				) {
 					mm_givesemaphore(heap);
 				}
 				return -1;
@@ -182,10 +184,11 @@ int mm_check_heap_corruption(struct mm_heap_s *heap)
 				dump_node(node, TYPE_OVERFLOWED);
 				dump_node(next, TYPE_CORRUPTED);
 				dbg("#########################################################################################\n");
+				if (!abort_mode
 #if defined(CONFIG_BUILD_FLAT) || defined(__KERNEL__)
-				if (!up_interrupt_context())
+					&& !up_interrupt_context()
 #endif
-				{
+				) {
 					mm_givesemaphore(heap);
 				}
 				return -1;
@@ -198,10 +201,11 @@ int mm_check_heap_corruption(struct mm_heap_s *heap)
 					dbg("Corrupted node blink(0x%08x) and prev node flink(0x%08x) do not match\n", ((struct mm_freenode_s *)node)->blink,
 							((struct mm_freenode_s *)node)->blink->flink);
 					dbg("#########################################################################################\n");
+					if (!abort_mode
 #if defined(CONFIG_BUILD_FLAT) || defined(__KERNEL__)
-					if (!up_interrupt_context())
+						&& !up_interrupt_context()
 #endif
-					{
+					) {
 						mm_givesemaphore(heap);
 					}
 					return -1;
@@ -213,10 +217,11 @@ int mm_check_heap_corruption(struct mm_heap_s *heap)
 					dbg("Corrupted node flink(0x%08x) and next node blink(0x%08x) do not match\n", ((struct mm_freenode_s *)node)->flink,
 							((struct mm_freenode_s *)node)->flink->blink);
 					dbg("#########################################################################################\n");
+					if (!abort_mode
 #if defined(CONFIG_BUILD_FLAT) || defined(__KERNEL__)
-					if (!up_interrupt_context())
+						 && !up_interrupt_context()
 #endif
-					{
+					) {
 						mm_givesemaphore(heap);
 					}
 					return -1;
@@ -224,10 +229,11 @@ int mm_check_heap_corruption(struct mm_heap_s *heap)
 			}
 		}
 
+		if (!abort_mode
 #if defined(CONFIG_BUILD_FLAT) || defined(__KERNEL__)
-		if (!up_interrupt_context())
+			&& !up_interrupt_context()
 #endif
-		{
+		) {
 			mm_givesemaphore(heap);
 		}
 	}


### PR DESCRIPTION
Recursive abort issue happened since the first assertion was caused
due to invalid heap semaphore, and in assert handler we again try
to check heap corruption which will try to aquire the invalid heap
semaphore. Modify heap corruption check to NOT use semaphore during
abort_mode. Also, we would like heap check to run always in case of
assert, irrespective of whether somebody else is holding the sem.

Signed-off-by: Kishore S N <kishore.sn@samsung.com>