### PR TITLE
kernel/clock : Update the system init time based on build time

### DIFF
--- a/os/kernel/Kconfig
+++ b/os/kernel/Kconfig
@@ -186,6 +186,13 @@ config JULIAN_TIME
 	---help---
 		Enables Julian time conversions
 
+config INIT_SYSTEM_TIME
+	bool "Initialize System Time"
+	default y
+	depends on RTC
+	---help---
+		Initialize the system time based on VERSION_BUILD_TIME.
+
 if !RTC
 
 config START_YEAR

--- a/os/kernel/clock/clock_initialize.c
+++ b/os/kernel/clock/clock_initialize.c
@@ -70,6 +70,9 @@
 #include <tinyara/clock.h>
 #include <tinyara/time.h>
 #include <tinyara/rtc.h>
+#ifdef CONFIG_INIT_SYSTEM_TIME
+#include <tinyara/version.h>
+#endif
 
 #include "clock/clock.h"
 
@@ -200,6 +203,33 @@ static void clock_inittime(void)
 }
 
 /****************************************************************************
+ * Name: initialize_system_time
+ *
+ * Description:
+ *   Initialize the system time based on VERSION_BUILD_TIME.
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_INIT_SYSTEM_TIME
+static void initialize_system_time(void)
+{
+	struct tm init_time;
+	struct timespec ts;
+	char *ret;
+
+	ret = strptime(CONFIG_VERSION_BUILD_TIME, "%Y-%m-%d %T", &init_time);
+	if (ret == NULL) {
+		return;
+	}
+
+	ts.tv_sec = mktime(&init_time);
+	ts.tv_nsec = 0;
+
+	(void)up_rtc_settime(&ts);
+}
+#endif
+
+/****************************************************************************
  * Public Functions
  ****************************************************************************/
 
@@ -217,6 +247,9 @@ void clock_initialize(void)
 
 #if defined(CONFIG_RTC)
 	up_rtc_initialize();
+#ifdef CONFIG_INIT_SYSTEM_TIME
+	initialize_system_time();
+#endif
 #endif
 
 	/* Initialize the time value to match the RTC */


### PR DESCRIPTION
When boot up, set the system init time based on CONFIG_VERSION_BUILD_TIME.