### PR TITLE
Sdaiot 98 fix scan type missing issue

### DIFF
--- a/os/board/rtl8721csm/src/component/os/tizenrt/rtk_netmgr.c
+++ b/os/board/rtl8721csm/src/component/os/tizenrt/rtk_netmgr.c
@@ -207,7 +207,7 @@ rtw_result_t app_scan_result_handler(rtw_scan_handler_result_t *malloced_scan_re
 			scan_list->ap_info.ap_crypto_type = WIFI_UTILS_CRYPTO_AES;
 			break;
 		default:
-			scan_list->ap_info.ap_crypto_type = WIFI_UTILS_CRYPTO_AES;
+			scan_list->ap_info.ap_crypto_type = WIFI_UTILS_CRYPTO_UNKNOWN;
 			break;
 		}
 		if (g_scan_list == NULL) {

--- a/os/board/rtl8721csm/src/component/os/tizenrt/rtk_netmgr.c
+++ b/os/board/rtl8721csm/src/component/os/tizenrt/rtk_netmgr.c
@@ -119,11 +119,41 @@ rtw_result_t app_scan_result_handler(rtw_scan_handler_result_t *malloced_scan_re
 		case RTW_SECURITY_WEP_PSK:
 			scan_list->ap_info.ap_auth_type = WIFI_UTILS_AUTH_WPA_PSK;
 			break;
+		case RTW_SECURITY_WPA_TKIP_PSK:
+			scan_list->ap_info.ap_auth_type = WIFI_UTILS_AUTH_WPA_PSK;
+			break;
+		case RTW_SECURITY_WPA_AES_PSK:
+			scan_list->ap_info.ap_auth_type = WIFI_UTILS_AUTH_WPA_PSK;
+			break;
 		case RTW_SECURITY_WPA2_AES_PSK:
+			scan_list->ap_info.ap_auth_type = WIFI_UTILS_AUTH_WPA2_PSK;
+			break;
+		case RTW_SECURITY_WPA2_TKIP_PSK:
+			scan_list->ap_info.ap_auth_type = WIFI_UTILS_AUTH_WPA2_PSK;
+			break;
+		case RTW_SECURITY_WPA2_MIXED_PSK:
 			scan_list->ap_info.ap_auth_type = WIFI_UTILS_AUTH_WPA2_PSK;
 			break;
 		case RTW_SECURITY_WPA_WPA2_MIXED:
 			scan_list->ap_info.ap_auth_type = WIFI_UTILS_AUTH_WPA_AND_WPA2_PSK;
+			break;
+		case RTW_SECURITY_WPA2_AES_CMAC:
+			scan_list->ap_info.ap_auth_type = WIFI_UTILS_AUTH_WPA2_PSK;
+			break;
+		case RTW_SECURITY_WPA2_ENTERPRISE:
+			scan_list->ap_info.ap_auth_type = WIFI_UTILS_AUTH_WPA2_PSK_ENT;
+			break;
+		case RTW_SECURITY_WPA_WPA2_ENTERPRISE:
+			scan_list->ap_info.ap_auth_type = WIFI_UTILS_AUTH_WPA_AND_WPA2_PSK_ENT;
+			break;
+		case RTW_SECURITY_WPS_OPEN:
+			scan_list->ap_info.ap_auth_type = WIFI_UTILS_AUTH_WPS;
+			break;
+		case RTW_SECURITY_WPS_SECURE:
+			scan_list->ap_info.ap_auth_type = WIFI_UTILS_AUTH_WPS;
+			break;
+		case RTW_SECURITY_WPA3_AES_PSK:
+			scan_list->ap_info.ap_auth_type = WIFI_UTILS_AUTH_WPA3_PSK;
 			break;
 		default:
 			scan_list->ap_info.ap_auth_type = WIFI_UTILS_AUTH_UNKNOWN;
@@ -144,14 +174,40 @@ rtw_result_t app_scan_result_handler(rtw_scan_handler_result_t *malloced_scan_re
 			scan_list->ap_info.ap_crypto_type = WIFI_UTILS_CRYPTO_TKIP;
 			break;
 		case RTW_SECURITY_WPA_AES_PSK:
+			scan_list->ap_info.ap_crypto_type = WIFI_UTILS_CRYPTO_AES;
+			break;
 		case RTW_SECURITY_WPA2_AES_PSK:
 			scan_list->ap_info.ap_crypto_type = WIFI_UTILS_CRYPTO_AES;
+			break;
+		case RTW_SECURITY_WPA2_TKIP_PSK:
+			scan_list->ap_info.ap_crypto_type = WIFI_UTILS_CRYPTO_TKIP;
 			break;
 		case RTW_SECURITY_WPA2_MIXED_PSK:
 			scan_list->ap_info.ap_crypto_type = WIFI_UTILS_CRYPTO_TKIP_AND_AES;
 			break;
-		default:
+		case RTW_SECURITY_WPA_WPA2_MIXED:
+			scan_list->ap_info.ap_crypto_type = WIFI_UTILS_CRYPTO_AES;
+			break;
+		case RTW_SECURITY_WPA2_AES_CMAC:
 			scan_list->ap_info.ap_crypto_type = WIFI_UTILS_CRYPTO_UNKNOWN;
+			break;
+		case RTW_SECURITY_WPA2_ENTERPRISE:
+			scan_list->ap_info.ap_crypto_type = WIFI_UTILS_CRYPTO_AES_ENT;
+			break;
+		case RTW_SECURITY_WPA_WPA2_ENTERPRISE:
+			scan_list->ap_info.ap_crypto_type = WIFI_UTILS_CRYPTO_AES_ENT;
+			break;
+		case RTW_SECURITY_WPS_OPEN:
+			scan_list->ap_info.ap_crypto_type = WIFI_UTILS_CRYPTO_NONE;
+			break;
+		case RTW_SECURITY_WPS_SECURE:
+			scan_list->ap_info.ap_crypto_type = WIFI_UTILS_CRYPTO_AES;
+			break;
+		case RTW_SECURITY_WPA3_AES_PSK:
+			scan_list->ap_info.ap_crypto_type = WIFI_UTILS_CRYPTO_AES;
+			break;
+		default:
+			scan_list->ap_info.ap_crypto_type = WIFI_UTILS_CRYPTO_AES;
 			break;
 		}
 		if (g_scan_list == NULL) {


### PR DESCRIPTION
Fix the issue: Cannot type the password in Easy setup due to the incorrect AP scan result.
Add the missing security types in scan result handler.