### PR TITLE
apps/examples: add lwnl sample

### DIFF
--- a/apps/examples/lwnl_sample/.gitignore
+++ b/apps/examples/lwnl_sample/.gitignore
@@ -1,0 +1,11 @@
+/Make.dep
+/.depend
+/.built
+/*.asm
+/*.obj
+/*.rel
+/*.lst
+/*.sym
+/*.adb
+/*.lib
+/*.src

--- a/apps/examples/lwnl_sample/Kconfig
+++ b/apps/examples/lwnl_sample/Kconfig
@@ -1,0 +1,14 @@
+#
+# For a description of the syntax of this configuration file,
+# see kconfig-language at https://www.kernel.org/doc/Documentation/kbuild/kconfig-language.txt
+#
+
+config EXAMPLES_LWNL_SAMPLE
+	bool "lwnl example"
+	default n
+	---help---
+		Enable the lwnl example
+
+config USER_ENTRYPOINT
+	string
+	default "lwnl_sample_main" if ENTRY_LWNL_SAMPLE

--- a/apps/examples/lwnl_sample/Kconfig_ENTRY
+++ b/apps/examples/lwnl_sample/Kconfig_ENTRY
@@ -1,0 +1,3 @@
+config ENTRY_LWNL_SAMPLE
+	bool "lwnl example"
+	depends on EXAMPLES_LWNL_SAMPLE

--- a/apps/examples/lwnl_sample/Make.defs
+++ b/apps/examples/lwnl_sample/Make.defs
@@ -1,0 +1,21 @@
+###########################################################################
+#
+# Copyright 2021 Samsung Electronics All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+#
+###########################################################################
+
+ifeq ($(CONFIG_EXAMPLES_LWNL_SAMPLE),y)
+CONFIGURED_APPS += examples/lwnl_sample/
+endif

--- a/apps/examples/lwnl_sample/Makefile
+++ b/apps/examples/lwnl_sample/Makefile
@@ -1,0 +1,120 @@
+###########################################################################
+#
+# Copyright 2021 Samsung Electronics All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+#
+###########################################################################
+
+-include $(TOPDIR)/.config
+-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
+
+APPNAME = lwnl_sample
+FUNCNAME = $(APPNAME)_main
+THREADEXEC = TASH_EXECMD_ASYNC
+
+ASRCS =
+CSRCS =
+MAINSRC = lwnl_sample.c
+
+AOBJS = $(ASRCS:.S=$(OBJEXT))
+COBJS = $(CSRCS:.c=$(OBJEXT))
+MAINOBJ = $(MAINSRC:.c=$(OBJEXT))
+
+SRCS = $(ASRCS) $(CSRCS) $(MAINSRC)
+OBJS = $(AOBJS) $(COBJS)
+
+ifneq ($(CONFIG_BUILD_KERNEL),y)
+  OBJS += $(MAINOBJ)
+endif
+
+ifeq ($(CONFIG_WINDOWS_NATIVE),y)
+  BIN = ..\..\libapps$(LIBEXT)
+else
+ifeq ($(WINTOOL),y)
+  BIN = ..\\..\\libapps$(LIBEXT)
+else
+  BIN = ../../libapps$(LIBEXT)
+endif
+endif
+
+ifeq ($(WINTOOL),y)
+  INSTALL_DIR = "${shell cygpath -w $(BIN_DIR)}"
+else
+  INSTALL_DIR = $(BIN_DIR)
+endif
+
+CONFIG_EXAMPLES_LWNL_SAMPLE_PROGNAME ?= lwnl_sample$(EXEEXT)
+PROGNAME = $(CONFIG_EXAMPLES_LWNL_SAMPLE_PROGNAME)
+
+ROOTDEPPATH = --dep-path .
+
+# Common build
+
+VPATH =
+
+all: .built
+.PHONY: clean depend distclean
+
+$(AOBJS): %$(OBJEXT): %.S
+	$(call ASSEMBLE, $<, $@)
+
+$(COBJS) $(MAINOBJ): %$(OBJEXT): %.c
+	$(call COMPILE, $<, $@)
+
+.built: $(OBJS)
+	$(call ARCHIVE, $(BIN), $(OBJS))
+	@touch .built
+
+ifeq ($(CONFIG_BUILD_KERNEL),y)
+$(BIN_DIR)$(DELIM)$(PROGNAME): $(OBJS) $(MAINOBJ)
+	@echo "LD: $(PROGNAME)"
+	$(Q) $(LD) $(LDELFFLAGS) $(LDLIBPATH) -o $(INSTALL_DIR)$(DELIM)$(PROGNAME) $(ARCHCRT0OBJ) $(MAINOBJ) $(LDLIBS)
+	$(Q) $(NM) -u  $(INSTALL_DIR)$(DELIM)$(PROGNAME)
+
+install: $(BIN_DIR)$(DELIM)$(PROGNAME)
+
+else
+install:
+
+endif
+
+ifeq ($(CONFIG_BUILTIN_APPS)$(CONFIG_EXAMPLES_LWNL_SAMPLE),yy)
+$(BUILTIN_REGISTRY)$(DELIM)$(FUNCNAME).bdat: $(DEPCONFIG) Makefile
+	$(Q) $(call REGISTER,$(APPNAME),$(FUNCNAME),$(THREADEXEC),$(PRIORITY),$(STACKSIZE))
+
+context: $(BUILTIN_REGISTRY)$(DELIM)$(FUNCNAME).bdat
+
+else
+context:
+
+endif
+
+.depend: Makefile $(SRCS)
+	@$(MKDEP) $(ROOTDEPPATH) "$(CC)" -- $(CFLAGS) -- $(SRCS) >Make.dep
+	@touch $@
+
+depend: .depend
+
+clean:
+	$(call DELFILE, .built)
+	$(call CLEAN)
+
+distclean: clean
+	$(call DELFILE, Make.dep)
+	$(call DELFILE, .depend)
+
+-include Make.dep
+.PHONY: preconfig
+preconfig:

--- a/apps/examples/lwnl_sample/lwnl_sample.c
+++ b/apps/examples/lwnl_sample/lwnl_sample.c
@@ -1,0 +1,124 @@
+/****************************************************************************
+ *
+ * Copyright 2021 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <tinyara/config.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <net/if.h>
+#include <errno.h>
+#include <sys/select.h>
+#include <sys/socket.h>
+#include <tinyara/lwnl/lwnl.h>
+
+/*
+ * it's test code so it doesn't perform error handling strictly.
+ */
+static void *event_listener(void *arg)
+{
+	int res = 0;
+	int idx = *((int *)arg);
+	printf("[%d] run event listener\n", idx);
+	int fd = socket(AF_LWNL, SOCK_RAW, LWNL_ROUTE);
+	if (fd < 0) {
+		printf("[%d] fail to create socket\n", idx);
+		return NULL;
+	}
+
+	res = bind(fd, NULL, 0);
+	if (res < 0) {
+		printf("[%d] bind fail errno(%d)\n", idx, errno);
+		close(fd);
+		return NULL;
+	}
+
+	fd_set rfds, ofds;
+	FD_ZERO(&ofds);
+	FD_SET(fd, &ofds);
+
+	printf("[%d] run event loop\n", idx);
+	for (;;) {
+		rfds = ofds;
+		res = select(fd + 1, &rfds, NULL, NULL, 0);
+		if (res <= 0) {
+			printf("[%d] select error res(%d) errno(%d))\n", idx, res, errno);
+			return NULL;
+		}
+
+		if (FD_ISSET(fd, &rfds)) {
+			char buf[8] = {0, };
+			lwnl_cb_status status;
+			uint32_t len;
+			int nbytes = read(fd, (char *)buf, 8);
+			if (nbytes < 0) {
+				printf("[%d] read error bytes(%d) errno(%d))\n", idx, nbytes, errno);
+				return NULL;
+			}
+			memcpy(&status, buf, sizeof(lwnl_cb_status));
+			memcpy(&len, buf + sizeof(lwnl_cb_status), sizeof(uint32_t));
+			printf("[%d] status (%d) len(%d)\n", idx, status, len);
+
+			// flush the event queue
+			if (len > 0) {
+				char *tmp = (char *)malloc(len);
+				read(fd, tmp, len);
+				free(tmp);
+			}
+		}
+	}
+}
+
+#ifdef CONFIG_BUILD_KERNEL
+int main(int argc, FAR char *argv[])
+#else
+	int lwnl_sample_main(int argc, char *argv[])
+#endif
+{
+	pthread_t *pid = NULL;
+	int num_threads = 3;
+	if (argc == 2) {
+		/* the number of listener is dependent to lwnl queue size.
+		 * please check LWNL_NPOLLWAITERS in lwnl_evt_queue.h.
+		 */
+		num_threads = atoi(argv[1]);
+		pid = (pthread_t *)malloc(sizeof(pthread_t) * num_threads);
+		if (!pid) {
+			printf("allocate thread pid array fail\n");
+			return -1;
+		}
+	} else if (argc != 1) {
+		printf("invalid usage\n");
+		printf("usage: lwnl_sample [number of threads]\n");
+	}
+
+	/*  run event listener thread */
+	printf("Run %d listener threads\n", num_threads);
+	for (int i = 0; i < num_threads; i++) {
+		pthread_create((pid + i), NULL, event_listener, (void *)&i);
+	}
+
+	printf("Run wi-fi manager to generate events\n");
+	/*  it's test program so it doesn't consider termination */
+	free(pid);
+
+	return 0;
+}


### PR DESCRIPTION
add lwnl sample. it creates 3 wi-fi event listener threads by lwnl and
it prints the type of event immediately.
1) run lwnl sample
   TASH> lwnl_sample
2) generate wi-fi manager event by wm_test
   TASH> wm_test start
   TASH> wm_test join ...
3) check that lwnl sample receive events
   [0] status (5) len(3268)␍␊
   [1] status (5) len(3268)␍␊
   [2] status (5) len(3268)