### PR TITLE
libc/lib_strlen : Add NULL check for string

### DIFF
--- a/lib/libc/string/lib_strlen.c
+++ b/lib/libc/string/lib_strlen.c
@@ -66,6 +66,9 @@
 size_t strlen(const char *s)
 {
 	const char *sc;
+	if (s == NULL) {
+		return 0;
+	}
 	for (sc = s; *sc != '\0'; ++sc);
 	return sc - s;
 }


### PR DESCRIPTION
If passed param 's' is NULL, it cannot be calculated.
So add null checking.