### PR TITLE
Fix Wifi stress test crash issues

### DIFF
--- a/external/stress_tool/st_perf.c
+++ b/external/stress_tool/st_perf.c
@@ -191,6 +191,7 @@ void _perf_free_pack(st_pack *pack)
 			free(smoke->func);
 		}
 		sq_entry_t *entry = smoke->entry.flink;
+		sq_rem(&smoke->entry, &pack->queue);
 		free(smoke);
 
 		if (!entry) {

--- a/os/arch/arm/src/armv7-m/up_schedulesigaction.c
+++ b/os/arch/arm/src/armv7-m/up_schedulesigaction.c
@@ -186,7 +186,6 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 #else
 				current_regs[REG_PRIMASK] = 1;
 #endif
-				current_regs[REG_XPSR] = ARMV7M_XPSR_T;
 #ifdef CONFIG_BUILD_PROTECTED
 				current_regs[REG_LR] = EXC_RETURN_PRIVTHR;
 #endif
@@ -231,7 +230,6 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 #else
 			tcb->xcp.regs[REG_PRIMASK] = 1;
 #endif
-			tcb->xcp.regs[REG_XPSR] = ARMV7M_XPSR_T;
 #ifdef CONFIG_BUILD_PROTECTED
 			tcb->xcp.regs[REG_LR] = EXC_RETURN_PRIVTHR;
 #endif

--- a/os/arch/arm/src/armv8-m/up_schedulesigaction.c
+++ b/os/arch/arm/src/armv8-m/up_schedulesigaction.c
@@ -186,7 +186,6 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 #else
 				current_regs[REG_PRIMASK] = 1;
 #endif
-				current_regs[REG_XPSR] = ARMV8M_XPSR_T;
 #ifdef CONFIG_BUILD_PROTECTED
 				current_regs[REG_LR] = EXC_RETURN_PRIVTHR;
 #endif
@@ -232,7 +231,6 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 #else
 			tcb->xcp.regs[REG_PRIMASK] = 1;
 #endif
-			tcb->xcp.regs[REG_XPSR] = ARMV8M_XPSR_T;
 #ifdef CONFIG_BUILD_PROTECTED
 			tcb->xcp.regs[REG_LR] = EXC_RETURN_PRIVTHR;
 #endif


### PR DESCRIPTION
Two crash issues are found during wifi stress test and fixed in this PR. 

1. Usage fault (INVPC) while running any stress test
2. Usage fault (INVSTATE) or busfault while running "stress 1" command multiple times.