### PR TITLE
kernel/clock_initialize : Add initialization of init_time

### DIFF
--- a/os/kernel/clock/clock_initialize.c
+++ b/os/kernel/clock/clock_initialize.c
@@ -58,6 +58,7 @@
 #include <tinyara/compiler.h>
 
 #include <stdint.h>
+#include <string.h>
 #include <time.h>
 #include <errno.h>
 #include <debug.h>
@@ -217,6 +218,7 @@ static void initialize_system_time(void)
 	struct timespec ts;
 	char *ret;
 
+	memset(&init_time, 0, sizeof(struct tm));
 	ret = strptime(CONFIG_VERSION_BUILD_TIME, "%Y-%m-%d %T", &init_time);
 	if (ret == NULL) {
 		return;


### PR DESCRIPTION
tm_isdst in init_time variable is used from mktime when CONFIG_LIBC_LOCALTIME is enabled.
Without initialization, it can have trash variable, so it can make wrong calculation in mktime.