### PR TITLE
mm/mm_heap/mm_calloc : Check integer wrap-around

### DIFF
--- a/os/mm/mm_heap/mm_calloc.c
+++ b/os/mm/mm_heap/mm_calloc.c
@@ -82,13 +82,21 @@ FAR void *mm_calloc(FAR struct mm_heap_s *heap, size_t n, size_t elem_size)
 {
 	FAR void *ret = NULL;
 
-	if (n > 0 && elem_size > 0) {
-#ifdef CONFIG_DEBUG_MM_HEAPINFO
-		ret = mm_zalloc(heap, n * elem_size, caller_retaddr);
-#else
-		ret = mm_zalloc(heap, n * elem_size);
-#endif
+	if ((n == 0) || (elem_size == 0)) {
+		mdbg("Invalid Parameter, n : %u, elem_size : %u\n", n, elem_size);
+		return NULL;
 	}
+
+	if (n > (MMSIZE_MAX / elem_size)) {
+		mdbg("Parameter n(%u) should be smaller than (MMSIZE_MAX / elem_size)(%u), \
+			because multiplication of n and elem_size cannot overflow the size_t.\n", n, (MMSIZE_MAX / elem_size));
+		return NULL;
+	}
+#ifdef CONFIG_DEBUG_MM_HEAPINFO
+	ret = mm_zalloc(heap, n * elem_size, caller_retaddr);
+#else
+	ret = mm_zalloc(heap, n * elem_size);
+#endif
 
 	return ret;
 }


### PR DESCRIPTION
The size which is n * elem_size can be integer wrap-around.
In this case, mm_calloc tries to allocate wrong, small memory and user can access invalid memory.