### PR TITLE
mm : Add error return in mm_initialize

### DIFF
--- a/os/arch/arm/src/common/up_allocateheap.c
+++ b/os/arch/arm/src/common/up_allocateheap.c
@@ -162,7 +162,9 @@ void up_add_kregion(void)
 	for (region_cnt = 1; region_cnt < CONFIG_KMM_REGIONS; region_cnt++) {
 		if (kheap[kregionx_heap_idx[region_cnt]].mm_heapsize == 0) {
 			lldbg("Heap idx = %u start = 0x%x size = %d\n", kregionx_heap_idx[region_cnt], kregionx_start[region_cnt], kregionx_size[region_cnt]);
-			mm_initialize(&kheap[kregionx_heap_idx[region_cnt]], kregionx_start[region_cnt], kregionx_size[region_cnt]);
+			if (mm_initialize(&kheap[kregionx_heap_idx[region_cnt]], kregionx_start[region_cnt], kregionx_size[region_cnt]) != OK) {
+				return;
+			}
 			continue;
 		}
 

--- a/os/arch/xtensa/src/esp32/esp32_allocateheap.c
+++ b/os/arch/xtensa/src/esp32/esp32_allocateheap.c
@@ -104,7 +104,9 @@ void up_add_kregion(void)
 	kheap = kmm_get_heap();
 	for (region_cnt = 1; region_cnt < CONFIG_KMM_REGIONS; region_cnt++) {
 		if (kheap[kregionx_heap_idx[region_cnt]].mm_heapsize == 0) {
-			mm_initialize(&kheap[kregionx_heap_idx[region_cnt]], kregionx_start[region_cnt], kregionx_size[region_cnt]);
+			if (mm_initialize(&kheap[kregionx_heap_idx[region_cnt]], kregionx_start[region_cnt], kregionx_size[region_cnt]) != OK) {
+				return;
+			}
 			continue;
 		}
 		mm_addregion(&kheap[kregionx_heap_idx[region_cnt]], kregionx_start[region_cnt], kregionx_size[region_cnt]);

--- a/os/binfmt/binfmt_execmodule.c
+++ b/os/binfmt/binfmt_execmodule.c
@@ -176,7 +176,11 @@ int exec_module(FAR struct binary_s *binp)
 #ifdef CONFIG_APP_BINARY_SEPARATION
 	binary_idx = binp->binary_idx;
 	binp->uheap = (struct mm_heap_s *)binp->heapstart;
-	mm_initialize(binp->uheap, (void *)binp->heapstart + sizeof(struct mm_heap_s), binp->uheap_size);
+	ret = mm_initialize(binp->uheap, (void *)binp->heapstart + sizeof(struct mm_heap_s), binp->uheap_size);
+	if (ret != OK) {
+		berr("ERROR: mm_initialize() failed, %d.\n", ret);
+		return ret;
+	}
 	mm_add_app_heap_list(binp->uheap, binp->bin_name);
 
 	binfo("------------------------%s Binary Heap Information------------------------\n", binp->bin_name);

--- a/os/include/tinyara/mm/mm.h
+++ b/os/include/tinyara/mm/mm.h
@@ -441,8 +441,8 @@ extern uint32_t g_cur_app;
 
 /* Functions contained in mm_initialize.c ***********************************/
 
-void mm_initialize(FAR struct mm_heap_s *heap, FAR void *heap_start, size_t heap_size);
-void mm_addregion(FAR struct mm_heap_s *heap, FAR void *heapstart, size_t heapsize);
+int mm_initialize(FAR struct mm_heap_s *heap, FAR void *heap_start, size_t heap_size);
+int mm_addregion(FAR struct mm_heap_s *heap, FAR void *heapstart, size_t heapsize);
 
 /* Functions contained in umm_initialize.c **********************************/
 
@@ -450,20 +450,20 @@ void mm_addregion(FAR struct mm_heap_s *heap, FAR void *heapstart, size_t heapsi
 /* Functions contained in kmm_initialize.c **********************************/
 
 #ifdef CONFIG_MM_KERNEL_HEAP
-void kmm_initialize(FAR void *heap_start, size_t heap_size);
+int kmm_initialize(FAR void *heap_start, size_t heap_size);
 #endif
 
 /* Functions contained in umm_addregion.c ***********************************/
 
 #if !defined(CONFIG_BUILD_PROTECTED) || !defined(__KERNEL__)
-void umm_initialize(FAR void *heap_start, size_t heap_size);
-void umm_addregion(FAR void *heapstart, size_t heapsize);
+int umm_initialize(FAR void *heap_start, size_t heap_size);
+int umm_addregion(FAR void *heapstart, size_t heapsize);
 #endif
 
 /* Functions contained in kmm_addregion.c ***********************************/
 
 #ifdef CONFIG_MM_KERNEL_HEAP
-void kmm_addregion(FAR void *heapstart, size_t heapsize);
+int kmm_addregion(FAR void *heapstart, size_t heapsize);
 #endif
 
 /* Functions contained in mm_sem.c ******************************************/

--- a/os/kernel/init/os_start.c
+++ b/os/kernel/init/os_start.c
@@ -401,7 +401,10 @@ void os_start(void)
 		 */
 
 		up_allocate_kheap(&heap_start, &heap_size);
-		kmm_initialize(heap_start, heap_size);
+		if (kmm_initialize(heap_start, heap_size) != OK) {
+			sdbg("ERROR : heap initialization is failed. heap_start : %x, heap_size : %u\n", heap_start, heap_size);
+			PANIC();
+		}
 #endif
 
 #ifdef CONFIG_MM_PGALLOC

--- a/os/mm/kmm_heap/kmm_addregion.c
+++ b/os/mm/kmm_heap/kmm_addregion.c
@@ -91,11 +91,11 @@
  *   heap_size  - The size (in bytes) if the memory region.
  *
  * Return Value:
- *   None
+ *   OK on success, negative errno on failure.
  *
  ************************************************************************/
 
-void kmm_addregion(FAR void *heap_start, size_t heap_size)
+int kmm_addregion(FAR void *heap_start, size_t heap_size)
 {
 	return mm_addregion(kmm_get_heap(), heap_start, heap_size);
 }

--- a/os/mm/kmm_heap/kmm_initialize.c
+++ b/os/mm/kmm_heap/kmm_initialize.c
@@ -99,11 +99,11 @@ struct mm_heap_s *kmm_get_heap(void)
  *   heap_size  - The size (in bytes) if the (initial) memory region.
  *
  * Return Value:
- *   None
+ *   OK on success, negative errno on failure.
  *
  ************************************************************************/
 
-void kmm_initialize(FAR void *heap_start, size_t heap_size)
+int kmm_initialize(FAR void *heap_start, size_t heap_size)
 {
 	return mm_initialize(g_kmmheap, heap_start, heap_size);
 }

--- a/os/mm/umm_heap/umm_addregion.c
+++ b/os/mm/umm_heap/umm_addregion.c
@@ -90,11 +90,11 @@
  *   heap_size  - The size (in bytes) if the memory region.
  *
  * Return Value:
- *   None
+ *   OK on success, negative errno on failure.
  *
  ************************************************************************/
 
-void umm_addregion(FAR void *heap_start, size_t heap_size)
+int umm_addregion(FAR void *heap_start, size_t heap_size)
 {
-	mm_addregion(BASE_HEAP, heap_start, heap_size);
+	return mm_addregion(BASE_HEAP, heap_start, heap_size);
 }

--- a/os/mm/umm_heap/umm_initialize.c
+++ b/os/mm/umm_heap/umm_initialize.c
@@ -135,11 +135,11 @@ struct mm_heap_s *g_app_heap_table[CONFIG_NUM_APPS + 1] __attribute__((section("
  *   heap_size  - The size (in bytes) if the (initial) memory region.
  *
  * Return Value:
- *   None
+ *   OK on success, negative errno on failure.
  *
  ************************************************************************/
 
-void umm_initialize(FAR void *heap_start, size_t heap_size)
+int umm_initialize(FAR void *heap_start, size_t heap_size)
 {
-	mm_initialize(BASE_HEAP, heap_start, heap_size);
+	return mm_initialize(BASE_HEAP, heap_start, heap_size);
 }


### PR DESCRIPTION
If there is a failure on mm_initialize when os boot up, system should not be started, because heap cannot be used properly.