### PR TITLE
wifi_manager: fix scan callback in stress test

### DIFF
--- a/apps/examples/wifi_manager_sample/wm_test.c
+++ b/apps/examples/wifi_manager_sample/wm_test.c
@@ -517,9 +517,10 @@ void wm_scan_done(wifi_manager_scan_info_s **scan_result, wifi_manager_scan_resu
 	}
 	wifi_manager_scan_info_s *wifi_scan_iter = *scan_result;
 	while (wifi_scan_iter != NULL) {
-		printf("[WT] WiFi AP SSID: %-25s, BSSID: %-20s, Rssi: %d, Auth: %d, Crypto: %d\n",
+		printf("[WT] WiFi AP SSID: %-25s, BSSID: %-20s, Rssi: %d, Auth: %s, Crypto: %s\n",
 			   wifi_scan_iter->ssid, wifi_scan_iter->bssid, wifi_scan_iter->rssi,
-			   wifi_scan_iter->ap_auth_type, wifi_scan_iter->ap_crypto_type);
+			   wifi_test_auth_method[wifi_scan_iter->ap_auth_type],
+			   wifi_test_crypto_method[wifi_scan_iter->ap_crypto_type]);
 		wifi_scan_iter = wifi_scan_iter->next;
 	}
 	WM_TEST_SIGNAL;

--- a/apps/examples/wifi_manager_sample/wm_test_stress_test1.c
+++ b/apps/examples/wifi_manager_sample/wm_test_stress_test1.c
@@ -56,17 +56,21 @@ static wifi_manager_ap_crypto_type_e WM_AP_CRYPTO;
  */
 static void wm_sta_connected(wifi_manager_result_e);
 static void wm_sta_disconnected(wifi_manager_disconnect_e);
-
+static void wm_softap_sta_joined(void);
+static void wm_softap_sta_left(void);
+static void wm_scan_ap_done(wifi_manager_scan_info_s **, wifi_manager_scan_result_e);
 /*
  * Global
  */
 static wifi_manager_cb_s g_wifi_callbacks = {
 	wm_sta_connected,
 	wm_sta_disconnected,
-	NULL, NULL, NULL
+	wm_softap_sta_joined,
+	wm_softap_sta_left,
+	wm_scan_ap_done
 };
 
-static pthread_mutex_t g_wm_mutex = PTHREAD_MUTEX_INITIALIZER;;
+static pthread_mutex_t g_wm_mutex = PTHREAD_MUTEX_INITIALIZER;
 static pthread_cond_t g_wm_cond = PTHREAD_COND_INITIALIZER;
 
 /*
@@ -82,6 +86,22 @@ void wm_sta_disconnected(wifi_manager_disconnect_e disconn)
 {
 	printf(" T%d --> %s\n", getpid(), __FUNCTION__);
 	WM_TEST_SIGNAL;
+}
+
+void wm_softap_sta_joined(void)
+{
+	printf(" T%d --> %s\n", getpid(), __FUNCTION__);
+}
+
+void wm_softap_sta_left(void)
+{
+	printf(" T%d --> %s\n", getpid(), __FUNCTION__);
+}
+
+void wm_scan_ap_done(wifi_manager_scan_info_s **info, wifi_manager_scan_result_e res)
+{
+	printf(" T%d --> %s\n", getpid(), __FUNCTION__);
+	printf(" result (%d) info pointer(%p)\n", res, *info);
 }
 
 static void wm_get_apinfo(wifi_manager_ap_config_s *apconfig)

--- a/framework/src/wifi_manager/wifi_manager_cb.c
+++ b/framework/src/wifi_manager/wifi_manager_cb.c
@@ -66,7 +66,7 @@ static void _free_scan_info(wifi_manager_scan_info_s *scan_list)
 }
 
 static wifi_manager_result_e _convert_scan_info(wifi_manager_scan_info_s **wm_scan_list,
-										 wifi_utils_scan_list_s *wu_scan_list)
+												wifi_utils_scan_list_s *wu_scan_list)
 {
 	wifi_manager_scan_info_s *cur = NULL, *prev = NULL;
 	wifi_utils_scan_list_s *iter = wu_scan_list;
@@ -110,28 +110,40 @@ void _handle_user_cb(_wifimgr_usr_cb_type_e evt, void *arg)
 		switch (evt) {
 		case CB_STA_CONNECTED:
 			WM_LOG_INFO("[WM] call sta connect success event\n");
-			cbk->sta_connected(WIFI_MANAGER_SUCCESS);
+			if (cbk->sta_connected) {
+				cbk->sta_connected(WIFI_MANAGER_SUCCESS);
+			}
 			break;
 		case CB_STA_CONNECT_FAILED:
 			WM_LOG_INFO("[WM] call sta connect fail event\n");
 			WIFIADD_ERR_RECORD(ERR_WIFIMGR_CONNECT_FAIL);
-			cbk->sta_connected(WIFI_MANAGER_FAIL);
+			if (cbk->sta_connected) {
+				cbk->sta_connected(WIFI_MANAGER_FAIL);
+			}
 			break;
 		case CB_STA_DISCONNECTED:
 			WM_LOG_INFO("[WM] call sta disconnect event\n");
-			cbk->sta_disconnected(WIFI_MANAGER_DISCONNECT);
+			if (cbk->sta_disconnected) {
+				cbk->sta_disconnected(WIFI_MANAGER_DISCONNECT);
+			}
 			break;
 		case CB_STA_RECONNECTED:
 			WM_LOG_INFO("[WM] call sta reconnect event\n");
-			cbk->sta_disconnected(WIFI_MANAGER_RECONNECT);
+			if (cbk->sta_disconnected) {
+				cbk->sta_disconnected(WIFI_MANAGER_RECONNECT);
+			}
 			break;
 		case CB_STA_JOINED:
 			WM_LOG_INFO("[WM] call sta join event\n");
-			cbk->softap_sta_joined();
+			if (cbk->softap_sta_joined) {
+				cbk->softap_sta_joined();
+			}
 			break;
 		case CB_STA_LEFT:
 			WM_LOG_INFO("[WM] call sta leave event\n");
-			cbk->softap_sta_left();
+			if (cbk->softap_sta_left) {
+				cbk->softap_sta_left();
+			}
 			break;
 		case CB_SCAN_DONE:
 			WM_LOG_INFO("[WM] call sta scan event\n");
@@ -139,11 +151,17 @@ void _handle_user_cb(_wifimgr_usr_cb_type_e evt, void *arg)
 			wifi_manager_scan_info_s *info = NULL;
 			wifi_utils_scan_list_s *list = (wifi_utils_scan_list_s *)arg;
 			if (list) {
-				WIFIMGR_CHECK_RESULT_CLEANUP(
-					_convert_scan_info(&info, (wifi_utils_scan_list_s *)arg),
-					"parse error", , cbk->scan_ap_done(NULL, WIFI_SCAN_FAIL));
-				cbk->scan_ap_done(&info, WIFI_SCAN_SUCCESS);
-				_free_scan_info(info);
+				if (WIFI_MANAGER_SUCCESS != _convert_scan_info(&info, (wifi_utils_scan_list_s *)arg)) {
+					WM_LOG_ERROR("[WM] parse error\n");
+					if (cbk->scan_ap_done) {
+						cbk->scan_ap_done(NULL, WIFI_SCAN_FAIL);
+					}
+				} else {
+					if (cbk->scan_ap_done) {
+						cbk->scan_ap_done(&info, WIFI_SCAN_SUCCESS);
+					}
+					_free_scan_info(info);
+				}
 			} else {
 				WIFIADD_ERR_RECORD(ERR_WIFIMGR_SCAN_FAIL);
 				cbk->scan_ap_done(NULL, WIFI_SCAN_FAIL);


### PR DESCRIPTION
stress test 1 doesn't define scan callback. so it caused crash while
scan stress test.
And add callback function checking in wi-fi manager callback function
for safety.