### PR TITLE
rtl8721csm/download : Erase partitions except for userfs and ss in ERASE ALL command

### DIFF
--- a/build/configs/rtl8721csm/.flashSpec.xml
+++ b/build/configs/rtl8721csm/.flashSpec.xml
@@ -28,6 +28,7 @@
         <option desc="Flash TizenRT ota">OTA</option>
         <option desc="Erase TizenRT kernel">ERASE KERNEL</option>
         <option desc="Erase TizenRT ota">ERASE OTA</option>
+        <option desc="Erase TizenRT Secure Storage">ERASE SS</option>
         <option desc="Erase TizenRT userfs">ERASE USERFS</option>
         <option desc="Erase all binaries and images">ERASE ALL</option>
     </options>

--- a/build/configs/rtl8721csm/rtl8721csm_download.sh
+++ b/build/configs/rtl8721csm/rtl8721csm_download.sh
@@ -346,14 +346,12 @@ erase()
 				rtl8721csm_dwld_help
 				break
 			fi
-			exe_name=$(get_executable_name ${parts[$partidx]})
-			[ "No Binary Match" = "${exe_name}" ] && continue
 
 			echo ""
 			echo "=========================="
 			echo "Erasing ${parts[$partidx]} partition"
 			echo "=========================="
-			./amebad_image_tool "erase" $TTYDEV 1 ${offsets[$partidx]} ${exe_name} ${sizes[partidx]}
+			./amebad_image_tool "erase" $TTYDEV 1 ${offsets[$partidx]} 0 ${sizes[partidx]}
 		done
 	fi
 	echo ""

--- a/build/configs/rtl8721csm/rtl8721csm_download.sh
+++ b/build/configs/rtl8721csm/rtl8721csm_download.sh
@@ -116,6 +116,7 @@ function rtl8721csm_dwld_help()
 		make download erase kernel
 		make download ota
 		make download erase ota
+		make download erase ss
 		make download smartfs
 		make download erase userfs
 EOF
@@ -298,7 +299,20 @@ erase()
 		echo "=========================="
 		echo "      Erasing All"
 		echo "=========================="
-		./amebad_image_tool "erase" $TTYDEV 1 $FLASH_START_ADDR 0 $(($CONFIG_AMEBAD_FLASH_CAPACITY>>10))
+		for partidx in ${!parts[@]}; do
+			if [[ "${parts[$partidx]}" == "userfs" ]];then
+				continue
+			elif [[ "${parts[$partidx]}" == "ss" ]];then
+				continue
+			else
+				echo ""
+				echo "=========================="
+				echo "Erasing ${parts[$partidx]} partition"
+				echo "=========================="
+			fi
+
+			./amebad_image_tool "erase" $TTYDEV 1 ${offsets[$partidx]} 0 ${sizes[partidx]}
+		done
 	else
 		for partidx in ${!parts[@]}; do
 			if [[ $2 == "kernel" || $2 == "KERNEL" ]];then
@@ -318,6 +332,10 @@ erase()
 					continue
 				else
 					flash_ota=false
+				fi
+			elif [[ $2 == "ss" || $2 == "SS" ]];then
+				if [[ "${parts[$partidx]}" != "ss" ]];then
+					continue
 				fi
 			elif [[ $2 == "userfs" || $2 == "USERFS" ]];then
 				if [[ "${parts[$partidx]}" != "userfs" ]];then


### PR DESCRIPTION
The secure storage and userfs partitions should be kept when erasing all partitions.
That's why some data not to be erased could be written in these partition.
So except for userfs and ss and add command 'download erase ss' for erasing ss.