### PR TITLE
rtl8721csm/bluetooth: fix ble assert issue

### DIFF
--- a/os/board/rtl8721csm/src/component/common/bluetooth/realtek/sdk/board/common/os/tizenrt/osif_tizenrt.c
+++ b/os/board/rtl8721csm/src/component/common/bluetooth/realtek/sdk/board/common/os/tizenrt/osif_tizenrt.c
@@ -514,7 +514,7 @@ bool osif_msg_send(void *p_handle, void *p_msg, uint32_t wait_ms)
 		return _FAIL;
 	}
 
-	if (wait_ms != 0xFFFFFFFF) {
+	if (wait_ms != 0xFFFFFFFF && up_interrupt_context() == false) {
 		struct timespec ts;
 		clock_gettime(CLOCK_REALTIME, &ts);
 		ts.tv_sec += wait_ms / 1000;

--- a/os/board/rtl8721csm/src/component/common/bluetooth/realtek/sdk/board/common/src/hci_adapter.c
+++ b/os/board/rtl8721csm/src/component/common/bluetooth/realtek/sdk/board/common/src/hci_adapter.c
@@ -34,7 +34,7 @@ extern bool hci_board_complete(void);
 /* ================================internal=========================== */
 bool hci_rtk_tx_cb(void)
 {
-    if (p_hci_rtk->tx_buf != NULL)
+    if (p_hci_rtk->tx_buf != NULL && up_interrupt_context() == false)
     {
         os_mem_free(p_hci_rtk->tx_buf);
         p_hci_rtk->tx_buf = NULL;


### PR DESCRIPTION
- prevent mm_free and mq_timedsend in interrupt context