### PR TITLE
apps/shell/tash_security : Modify wrong comparison of write size

### DIFF
--- a/apps/shell/tash_security.c
+++ b/apps/shell/tash_security.c
@@ -42,7 +42,7 @@ void tash_check_security(int fd)
 
 	do {
 		nbytes = write(fd, passwd_prompt, sizeof(passwd_prompt));
-		if (nbytes <= sizeof(passwd_prompt)) {
+		if (nbytes < sizeof(passwd_prompt)) {
 			usleep(20);
 			continue;
 		}


### PR DESCRIPTION
If it writes passwd_prompt properly, it can be equal to sizeof(passwd_prompt).
So the return of write is equal to sizeof(passwd_prompt) for successful case.