### PR TITLE
shell/Kconfig: add description in TASH_PASSWORD_SHA256

### DIFF
--- a/apps/shell/Kconfig
+++ b/apps/shell/Kconfig
@@ -58,17 +58,17 @@ config TASH_SCRIPT
 		See "sh" on TASH help command.
 
 config SECURED_TASH
-    bool "Enable Secure shell"
-    depends on NET_SECURITY_TLS
-    default n
+	bool "Enable Secure shell"
+	depends on NET_SECURITY_TLS
+	default n
 
 if SECURED_TASH
 
 config TASH_PASSWORD_SHA256
-    string "SHA256 encrypted password"
-    default "0000"
-    ---help---
-        Enable password to enter TASH.
+	string "SHA256 encrypted password"
+	default "0000"
+	---help---
+		Enable password to enter TASH.
 endif
 
 endif

--- a/apps/shell/Kconfig
+++ b/apps/shell/Kconfig
@@ -65,10 +65,12 @@ config SECURED_TASH
 if SECURED_TASH
 
 config TASH_PASSWORD_SHA256
-	string "SHA256 encrypted password"
-	default "0000"
+	string "SHA256 encrypted password (32 Bytes)"
+	default "436890f31fcd6b154a0e49df9f190bd8b1dcd4b917a7a80b2d928452c22901f7"
 	---help---
-		Enable password to enter TASH.
+		Enable password to enter TASH. The password is hashed by SHA256 so that
+		the length of this config should be 32 bytes (64 characters).
+		default : hash value of "TizenRT" (Password : TizenRT)
 endif
 
 endif

--- a/os/Kconfig
+++ b/os/Kconfig
@@ -273,9 +273,9 @@ config BINARY_VERSION
 	int "Binary Version(YYMMDD)"
 	default 200204
 	---help---
-	Binary version which has a "YYMMDD" format is included in binary header.
-	It is used by binary manager to check the latest binary version.
-	So it should be set to a higer value in the latest version.
+		Binary version which has a "YYMMDD" format is included in binary header.
+		It is used by binary manager to check the latest binary version.
+		So it should be set to a higer value in the latest version.
 
 endmenu # Build Configuration
 


### PR DESCRIPTION
The password which is given in the config is hashed by SHA256
so that it should be 32 bytes. This commit describes it in the
help tab.