### PR TITLE
Add framework and external to common binary 

### DIFF
--- a/apps/system/init/init.c
+++ b/apps/system/init/init.c
@@ -162,6 +162,12 @@ int preapp_start(int argc, char *argv[])
 		printf("Failed to create Task Manager\n");
 		return ret;
 	}
+
+	ret = task_manager_populate_builtin_list(builtin_list, get_builtin_list_cnt());
+	if (ret < 0) {
+		printf("Failed to initialize Task Manager\n");
+		return ret;
+	}
 #endif
 
 #ifdef CONFIG_EVENTLOOP

--- a/framework/include/task_manager/task_manager.h
+++ b/framework/include/task_manager/task_manager.h
@@ -32,6 +32,7 @@
 #include <sys/types.h>
 #include <signal.h>
 #include <pthread.h>
+#include <apps/builtin.h>
 
 /**
  * @brief Task State which managed by Task Manager
@@ -102,6 +103,22 @@ enum tm_defined_broadcast_msg {
 	TM_BROADCAST_MSG_MAX = TM_BROADCAST_SYSTEM_MSG_MAX,
 #endif
 };
+
+/**
+ * @brief Builtin Application Info Structure
+ */
+struct tm_builtin_info_s {
+	char name[CONFIG_TASK_NAME_SIZE];
+	TASK_CALLBACK entry;
+	int exectype;
+	int priority;
+	int stacksize;
+};
+typedef struct tm_builtin_info_s tm_builtin_info_t;
+
+extern tm_builtin_info_t *tm_builtin_list;
+extern int tm_builtin_list_cnt;
+
 /**
  * @brief Application Info Structure
  */
@@ -161,6 +178,14 @@ extern "C" {
  * @endcond
  */
 int task_manager(int argc, char *argv[]);
+/**
+ * @brief Initialize the variables tm_builtin_list and builtin_list_cnt
+ * @details @b #include <task_manager/task_manager.h>\n
+ * This API can initialize the variables tm_builtin_list and builtin_list_cnt.\n
+ * @param[in] builtin_list that contains information about the builtin apps
+ * @param[in] length of builtin_list
+ */
+int task_manager_populate_builtin_list(const builtin_info_t builtin_apps_list[], int length);
 /**
  * @brief Request to register a built-in task
  * @details @b #include <task_manager/task_manager.h>\n

--- a/framework/src/task_manager/task_manager_permission.c
+++ b/framework/src/task_manager/task_manager_permission.c
@@ -19,7 +19,6 @@
  * Included Files
  ****************************************************************************/
 #include <stdbool.h>
-#include <apps/builtin.h>
 #include <task_manager/task_manager.h>
 #include "task_manager_internal.h"
 
@@ -32,7 +31,7 @@ bool taskmgr_is_permitted(int handle, pid_t pid)
 	int builtin_cnt;
 	int permission = TM_PERMISSION(handle);
 
-	builtin_cnt = get_builtin_list_cnt();
+	builtin_cnt = tm_builtin_list_cnt;
 
 	if (permission == TM_APP_PERMISSION_ALL \
 		|| (permission == TM_APP_PERMISSION_DEDICATE && TM_GID(handle) == pid)) {

--- a/loadable_apps/loadable.mk
+++ b/loadable_apps/loadable.mk
@@ -32,6 +32,8 @@ LDLIBS := $(patsubst %-luarch,%,$(LDLIBS))
 LDLIBS := $(patsubst %-luc,%,$(LDLIBS))
 LDLIBS := $(patsubst %-lumm,%,$(LDLIBS))
 LDLIBS := $(patsubst %-lproxies,%,$(LDLIBS))
+LDLIBS := $(patsubst %-lframework,%,$(LDLIBS))
+LDLIBS := $(patsubst %-lexternal,%,$(LDLIBS))
 else
 
 LIBGCC = "${shell "$(CC)" $(ARCHCPUFLAGS) -print-libgcc-file-name}"

--- a/os/Makefile.unix
+++ b/os/Makefile.unix
@@ -442,7 +442,7 @@ include LibTargets.mk
 
 ifeq ($(CONFIG_SUPPORT_COMMON_BINARY),y)
 LIBGCC = "${shell "$(CC)" $(ARCHCPUFLAGS) -print-libgcc-file-name}"
-COMMONLIBS = -luarch -luc -lumm -lproxies
+COMMONLIBS = -luarch -luc -lumm -lproxies -lframework -lexternal
 endif
 
 pass1deps: pass1dep $(USERLIBS)


### PR DESCRIPTION
Added framework and external to common binary. Task Manager shares a variable with apps/builtin to register the builtin
apps information such as the entry point. With commit "Adding Framework and External to Common Binary", calls from Framework to Apps is not be possible. To resolve this issue, adding an API in Task Manager to initialize the above shared variables. This API is called just after the Task Manager is launched.
