### PR TITLE
Solved stress_test1_crash_during_exit_with_pr4888

### DIFF
--- a/external/stress_tool/st_perf.c
+++ b/external/stress_tool/st_perf.c
@@ -130,11 +130,15 @@ void _run_smoke(st_smoke *smoke)
 				// if teardown fails then remained testcase could be affected.
 				// so remained procedures could be useless
 				// so stopping running smoke would be better
-				continue;
+				//continue;
+				printf("%s cnt= %d tc_%s_setup returned %d\n",unit->tc_name, cnt, unit->tc_name , ret);
 			}
 		}
 		st_elapsed_time duration;
 		ret = unit->tc(&duration);
+		if(ret!=STRESS_TC_PASS){
+			printf("%s cnt= %d tc_%s returned %d\n",unit->tc_name, cnt, unit->tc_name , ret);
+		}
 		perf_result = _calc_performance(smoke->performance, &duration);
 		_calc_stability(smoke->stability, ret);
 


### PR DESCRIPTION
Changed code such that deinit is called also when there is error in setup part of test case. 