### PR TITLE
[DO NOT MERGE] Fix "rm -r" function and normalize path string with extra '/' characters.

### DIFF
--- a/os/fs/smartfs/smartfs_utils.c
+++ b/os/fs/smartfs/smartfs_utils.c
@@ -1199,7 +1199,7 @@ int smartfs_finddirentry(struct smartfs_mountpt_s *fs, struct smartfs_entry_s *d
 						 * open it and continue searching.
 						 */
 
-						if (*ptr == '\0') {
+						if (*ptr == '\0' || (*ptr == '/' && *(ptr + 1) == '\0')) {
 							/* We are at the last segment.  Report the entry */
 
 							/* Fill in the entry */
@@ -1334,7 +1334,7 @@ int smartfs_finddirentry(struct smartfs_mountpt_s *fs, struct smartfs_entry_s *d
 			 * segment, then report the parent directory sector.
 			 */
 
-			if (*ptr == '\0') {
+			if (*ptr == '\0' || (*ptr == '/' && *(ptr + 1) == '\0')) {
 				direntry->dsector = dirstack[depth];
 				strncpy(direntry->name, segment, seglen);
 			} else {

--- a/os/fs/vfs/Make.defs
+++ b/os/fs/vfs/Make.defs
@@ -81,6 +81,7 @@ CSRCS += fs_close.c fs_dup.c fs_dup2.c fs_fcntl.c fs_dupfd.c fs_dupfd2.c
 CSRCS += fs_fstat.c fs_fstatfs.c fs_getfilep.c fs_ioctl.c fs_lseek.c
 CSRCS += fs_mkdir.c fs_open.c fs_poll.c fs_read.c fs_rename.c fs_rmdir.c
 CSRCS += fs_stat.c fs_statfs.c fs_select.c fs_unlink.c fs_write.c
+CSRCS += fs_norm_path.c
 
 # Certain interfaces are not available if there is no mountpoint support
 

--- a/os/fs/vfs/fs_norm_path.c
+++ b/os/fs/vfs/fs_norm_path.c
@@ -1,0 +1,74 @@
+/****************************************************************************
+ *
+ * Copyright 2021 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <tinyara/fs/fs.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Variables
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Variables
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: normalize_path
+ *
+ * Description: Normalize the path if it has extra '/' characters in the
+ *  middle or at the end.
+ *
+ ****************************************************************************/
+
+void normalize_path(const char *path, char **ret_path)
+{
+	int i;
+	int j = 1;
+	char *tmp = *ret_path;
+
+	/* Copy the first character anyways */
+	tmp[0] = path[0];
+
+	for (i = 1; path[i] != '\0'; i++) {
+		/* If the current and previous characters are both '/' then skip the current one */
+		if ((path[i] == path[i - 1]) && (path[i] == '/')) {
+			continue;
+		}
+		tmp[j] = path[i];
+		j++;
+	}
+	tmp[j] = '\0';
+
+	return;
+}
+

--- a/os/include/tinyara/fs/fs.h
+++ b/os/include/tinyara/fs/fs.h
@@ -1164,6 +1164,8 @@ ssize_t bchlib_write(FAR void *handle, FAR const char *buffer, size_t offset, si
 
 void pipe_initialize(void);
 
+void normalize_path(const char *path, char **ret_path);
+
 #undef EXTERN
 #if defined(__cplusplus)
 }


### PR DESCRIPTION
- Fix smartfs_finddirentry() returns number of bytes read from flash when path ends in extra '/' character due to retention of last
  assigned value to return variable.
- Repeated '/' in path should be ignored to align with POSIX standard.
- For Eg: A) paths = "/mnt/test1" and = "/mnt/test1/" and B )paths = "/mnt/test1" and "/mnt//test1" should be considered
  same while looking for the entry respectively..
- Fix behavior of "rm -r", should only delete directory paths

Signed-off-by: Amogh Hassija <a.hassija@samsung.com>