### PR TITLE
drivers/rtk_drv.c: fix build error for imxrt1020-evk/tc

### DIFF
--- a/os/drivers/wireless/realtek/wifi_util_interface/rtk_drv.c
+++ b/os/drivers/wireless/realtek/wifi_util_interface/rtk_drv.c
@@ -31,6 +31,9 @@
 #include <errno.h>
 #include <net/if.h>
 #include <tinyara/lwnl/lwnl.h>
+#ifdef CONFIG_NET_NETMGR
+#include <tinyara/netmgr/netdev_mgr.h>
+#endif
 #include <tinyara/net/if/wifi.h>
 #include "wifi_conf.h"
 


### PR DESCRIPTION
- to fix the build error, include netdev_mgr.h header file to provide the reference of netdev.

Signed-off-by: Deepak Sharma <deepak.sh@samsung.com>