### PR TITLE
os/Makefile.unix: Moving all USERLIBS from app binary to common binary..

### DIFF
--- a/os/Makefile.unix
+++ b/os/Makefile.unix
@@ -442,7 +442,6 @@ include LibTargets.mk
 
 ifeq ($(CONFIG_SUPPORT_COMMON_BINARY),y)
 LIBGCC = "${shell "$(CC)" $(ARCHCPUFLAGS) -print-libgcc-file-name}"
-COMMONLIBS = -luarch -luc -lumm -lproxies
 endif
 
 pass1deps: pass1dep $(USERLIBS)
@@ -451,7 +450,7 @@ pass1: pass1deps
 ifeq ($(CONFIG_BUILD_2PASS),y)
 	$(Q) $(MAKE) -C $(LOADABLE_APPDIR) TOPDIR="$(TOPDIR)" LOADABLEDIR="${LOADABLE_APPDIR}" LIBRARIES_DIR="$(LIBRARIES_DIR)" USERLIBS="$(USERLIBS)" all KERNEL=n
 ifeq ($(CONFIG_SUPPORT_COMMON_BINARY),y)
-	$(Q) $(LD) -r -o $(OUTBIN_DIR)/$(CONFIG_COMMON_BINARY_NAME) -T $(TOPDIR)/userspace/userspace_apps.ld -L $(LIBRARIES_DIR) --start-group $(COMMONLIBS) $(LIBGCC) --end-group $$(cat $(OUTBIN_DIR)/lib_symbols.txt)
+	$(Q) $(LD) -r -o $(OUTBIN_DIR)/$(CONFIG_COMMON_BINARY_NAME) -T $(TOPDIR)/userspace/userspace_apps.ld -L $(LIBRARIES_DIR) --start-group $(USERLIBS) $(LIBGCC) --end-group $$(cat $(OUTBIN_DIR)/lib_symbols.txt)
 	$(Q) if [ "`nm -u $(OUTBIN_DIR)/$(CONFIG_COMMON_BINARY_NAME) | wc -l`" != "0" ]; then \
 		echo "Undefined Symbols in Common binary"; \
 		nm -u -l $(OUTBIN_DIR)/$(CONFIG_COMMON_BINARY_NAME); \


### PR DESCRIPTION
This patch removes all user libraries like framework, external etc from app
binary and includes it in the common library when
CONFIG_SUPPORT_COMMON_BINARY is enabled.

Signed-off-by: Vidisha Thapa <thapa.v@samsung.com>