### PR TITLE
board/rtl8721csm/src/component/os/tizenrt: Fix wifi_netmgr_utils_init(), gmode should not be set to RTK_WIFI_NONE at the start of this function.

### DIFF
--- a/os/board/rtl8721csm/src/component/os/tizenrt/rtk_netmgr.c
+++ b/os/board/rtl8721csm/src/component/os/tizenrt/rtk_netmgr.c
@@ -341,7 +341,6 @@ static void linkdown_handler(rtk_reason_t *reason)
 trwifi_result_e wifi_netmgr_utils_init(struct netdev *dev)
 {
 	trwifi_result_e wuret = TRWIFI_FAIL;
-g_mode = RTK_WIFI_NONE;
 	if (g_mode == RTK_WIFI_NONE) {
 		int ret = RTK_STATUS_SUCCESS;
 		


### PR DESCRIPTION


Fix wifi_netmgr_utils_init() on gmode set value.