### PR TITLE
os/binfmt: Fix build warning in binfmt

### DIFF
--- a/os/binfmt/binfmt_unloadmodule.c
+++ b/os/binfmt/binfmt_unloadmodule.c
@@ -66,6 +66,7 @@
 #include <tinyara/binfmt/binfmt.h>
 
 #include "binfmt.h"
+#include "libelf/libelf.h"
 
 #ifdef CONFIG_BINFMT_ENABLE
 

--- a/os/binfmt/libelf/libelf.h
+++ b/os/binfmt/libelf/libelf.h
@@ -477,9 +477,9 @@ extern sq_queue_t g_bin_addr_list;
 
 void elf_save_bin_section_addr(struct binary_s *bin);
 void elf_delete_bin_section_addr(struct binary_s *bin);
+#endif
 #ifdef CONFIG_BINFMT_SECTION_UNIFIED_MEMORY
 void *elf_find_start_section_addr(struct binary_s *binp);
-#endif
 #endif
 
 #endif							/* __BINFMT_LIBELF_LIBELF_H */


### PR DESCRIPTION
Fix following build warning in binfmt.

binfmt_unloadmodule.c: In function 'unload_module':
binfmt_unloadmodule.c:203:23: warning: initialization of 'void *' from 'int' makes pointer from integer without a cast [-Wint-conversion]
  203 |    void *start_addr = elf_find_start_section_addr(binp);
      |

Signed-off-by: Kishore S N <kishore.sn@samsung.com>