### PR TITLE
build/configs: Common download script for rtk, imxrt and artik

### DIFF
--- a/build/configs/artik053/STDK/Make.defs
+++ b/build/configs/artik053/STDK/Make.defs
@@ -150,7 +150,7 @@ HOSTCFLAGS = -Wall -Wstrict-prototypes -Wshadow -Wundef -g -pipe
 HOSTLDFLAGS =
 
 define DOWNLOAD
-  $(TOPDIR)/../build/configs/artik05x/artik05x_download.sh --board=artik053 $(1) $(2) $(3) $(4) $(5) $(6)
+  $(TOPDIR)/../build/configs/common_download.sh $(1) $(2) $(3) $(4) $(5) $(6)
 endef
 
 define OTA_IMG

--- a/build/configs/artik053/avs_test/Make.defs
+++ b/build/configs/artik053/avs_test/Make.defs
@@ -155,7 +155,7 @@ HOSTCFLAGS = -Wall -Wstrict-prototypes -Wshadow -Wundef -g -pipe
 HOSTLDFLAGS =
 
 define DOWNLOAD
-  $(TOPDIR)/../build/configs/artik05x/artik05x_download.sh --board=artik053 $(1) $(2) $(3) $(4) $(5) $(6)
+  $(TOPDIR)/../build/configs/common_download.sh $(1) $(2) $(3) $(4) $(5) $(6)
 endef
 
 define OTA_IMG

--- a/build/configs/artik053/cxxtest/Make.defs
+++ b/build/configs/artik053/cxxtest/Make.defs
@@ -159,7 +159,7 @@ HOSTCFLAGS = -Wall -Wstrict-prototypes -Wshadow -Wundef -g -pipe
 HOSTLDFLAGS =
 
 define DOWNLOAD
-  $(TOPDIR)/../build/configs/artik05x/artik05x_download.sh --board=artik053 $(1) $(2) $(3) $(4) $(5) $(6)
+  $(TOPDIR)/../build/configs/common_download.sh $(1) $(2) $(3) $(4) $(5) $(6)
 endef
 
 define OTA_IMG

--- a/build/configs/artik053/grpc/Make.defs
+++ b/build/configs/artik053/grpc/Make.defs
@@ -122,7 +122,7 @@ HOSTCFLAGS = -Wall -Wstrict-prototypes -Wshadow -Wundef -g -pipe
 HOSTLDFLAGS =
 
 define DOWNLOAD
-  $(TOPDIR)/../build/configs/artik05x/artik05x_download.sh --board=artik053 $(1) $(2) $(3) $(4) $(5) $(6)
+  $(TOPDIR)/../build/configs/common_download.sh $(1) $(2) $(3) $(4) $(5) $(6)
 endef
 
 define OTA_IMG

--- a/build/configs/artik053/hello/Make.defs
+++ b/build/configs/artik053/hello/Make.defs
@@ -150,7 +150,7 @@ HOSTCFLAGS = -Wall -Wstrict-prototypes -Wshadow -Wundef -g -pipe
 HOSTLDFLAGS =
 
 define DOWNLOAD
-  $(TOPDIR)/../build/configs/artik05x/artik05x_download.sh --board=artik053 $(1) $(2) $(3) $(4) $(5) $(6)
+  $(TOPDIR)/../build/configs/common_download.sh $(1) $(2) $(3) $(4) $(5) $(6)
 endef
 
 define OTA_IMG

--- a/build/configs/artik053/helloxx/Make.defs
+++ b/build/configs/artik053/helloxx/Make.defs
@@ -162,7 +162,7 @@ HOSTCFLAGS = -Wall -Wstrict-prototypes -Wshadow -Wundef -g -pipe
 HOSTLDFLAGS =
 
 define DOWNLOAD
-  $(TOPDIR)/../build/configs/artik05x/artik05x_download.sh --board=artik053 $(1) $(2) $(3) $(4) $(5) $(6)
+  $(TOPDIR)/../build/configs/common_download.sh $(1) $(2) $(3) $(4) $(5) $(6)
 endef
 
 define OTA_IMG

--- a/build/configs/artik053/iotivity/Make.defs
+++ b/build/configs/artik053/iotivity/Make.defs
@@ -150,7 +150,7 @@ HOSTCFLAGS = -Wall -Wstrict-prototypes -Wshadow -Wundef -g -pipe
 HOSTLDFLAGS =
 
 define DOWNLOAD
-  $(TOPDIR)/../build/configs/artik05x/artik05x_download.sh --board=artik053 $(1) $(2) $(3) $(4) $(5) $(6)
+  $(TOPDIR)/../build/configs/common_download.sh $(1) $(2) $(3) $(4) $(5) $(6)
 endef
 
 define OTA_IMG

--- a/build/configs/artik053/iotjs/Make.defs
+++ b/build/configs/artik053/iotjs/Make.defs
@@ -150,7 +150,7 @@ HOSTCFLAGS = -Wall -Wstrict-prototypes -Wshadow -Wundef -g -pipe
 HOSTLDFLAGS =
 
 define DOWNLOAD
-  $(TOPDIR)/../build/configs/artik05x/artik05x_download.sh --board=artik053 $(1) $(2) $(3) $(4) $(5) $(6)
+  $(TOPDIR)/../build/configs/common_download.sh $(1) $(2) $(3) $(4) $(5) $(6)
 endef
 
 define OTA_IMG

--- a/build/configs/artik053/kernel_sample/Make.defs
+++ b/build/configs/artik053/kernel_sample/Make.defs
@@ -150,7 +150,7 @@ HOSTCFLAGS = -Wall -Wstrict-prototypes -Wshadow -Wundef -g -pipe
 HOSTLDFLAGS =
 
 define DOWNLOAD
-  $(TOPDIR)/../build/configs/artik05x/artik05x_download.sh --board=artik053 $(1) $(2) $(3) $(4) $(5) $(6)
+  $(TOPDIR)/../build/configs/common_download.sh $(1) $(2) $(3) $(4) $(5) $(6)
 endef
 
 define OTA_IMG

--- a/build/configs/artik053/minimal/Make.defs
+++ b/build/configs/artik053/minimal/Make.defs
@@ -149,7 +149,7 @@ HOSTCFLAGS = -Wall -Wstrict-prototypes -Wshadow -Wundef -g -pipe
 HOSTLDFLAGS =
 
 define DOWNLOAD
-  $(TOPDIR)/../build/configs/artik05x/artik05x_download.sh --board=artik053 $(1) $(2) $(3) $(4) $(5) $(6)
+  $(TOPDIR)/../build/configs/common_download.sh $(1) $(2) $(3) $(4) $(5) $(6)
 endef
 
 define OTA_IMG

--- a/build/configs/artik053/netmgr/Make.defs
+++ b/build/configs/artik053/netmgr/Make.defs
@@ -149,7 +149,7 @@ HOSTCFLAGS = -Wall -Wstrict-prototypes -Wshadow -Wundef -g -pipe
 HOSTLDFLAGS =
 
 define DOWNLOAD
-  $(TOPDIR)/../build/configs/artik05x/artik05x_download.sh --board=artik053 $(1) $(2) $(3) $(4) $(5) $(6)
+  $(TOPDIR)/../build/configs/common_download.sh $(1) $(2) $(3) $(4) $(5) $(6)
 endef
 
 define OTA_IMG

--- a/build/configs/artik053/nettest/Make.defs
+++ b/build/configs/artik053/nettest/Make.defs
@@ -149,7 +149,7 @@ HOSTCFLAGS = -Wall -Wstrict-prototypes -Wshadow -Wundef -g -pipe
 HOSTLDFLAGS =
 
 define DOWNLOAD
-  $(TOPDIR)/../build/configs/artik05x/artik05x_download.sh --board=artik053 $(1) $(2) $(3) $(4) $(5) $(6)
+  $(TOPDIR)/../build/configs/common_download.sh $(1) $(2) $(3) $(4) $(5) $(6)
 endef
 
 define OTA_IMG

--- a/build/configs/artik053/rssi_report/Make.defs
+++ b/build/configs/artik053/rssi_report/Make.defs
@@ -115,7 +115,7 @@ HOSTCFLAGS = -Wall -Wstrict-prototypes -Wshadow -Wundef -g -pipe
 HOSTLDFLAGS =
 
 define DOWNLOAD
-  $(TOPDIR)/../build/configs/artik05x/artik05x_download.sh --board=artik053 $(1) $(2) $(3) $(4) $(5) $(6)
+  $(TOPDIR)/../build/configs/common_download.sh $(1) $(2) $(3) $(4) $(5) $(6)
 endef
 
 define OTA_IMG

--- a/build/configs/artik053/st_things/Make.defs
+++ b/build/configs/artik053/st_things/Make.defs
@@ -116,7 +116,7 @@ HOSTCFLAGS = -Wall -Wstrict-prototypes -Wshadow -Wundef -g -pipe
 HOSTLDFLAGS =
 
 define DOWNLOAD
-  $(TOPDIR)/../build/configs/artik05x/artik05x_download.sh --board=artik053 $(1) $(2) $(3) $(4) $(5) $(6)
+  $(TOPDIR)/../build/configs/common_download.sh $(1) $(2) $(3) $(4) $(5) $(6)
 endef
 
 define OTA_IMG

--- a/build/configs/artik053/tc/Make.defs
+++ b/build/configs/artik053/tc/Make.defs
@@ -150,7 +150,7 @@ HOSTCFLAGS = -Wall -Wstrict-prototypes -Wshadow -Wundef -g -pipe
 HOSTLDFLAGS =
 
 define DOWNLOAD
-  $(TOPDIR)/../build/configs/artik05x/artik05x_download.sh --board=artik053 $(1) $(2) $(3) $(4) $(5) $(6)
+  $(TOPDIR)/../build/configs/common_download.sh $(1) $(2) $(3) $(4) $(5) $(6)
 endef
 
 define OTA_IMG

--- a/build/configs/artik053/tc_libcxx/Make.defs
+++ b/build/configs/artik053/tc_libcxx/Make.defs
@@ -162,7 +162,7 @@ HOSTCFLAGS = -Wall -Wstrict-prototypes -Wshadow -Wundef -g -pipe
 HOSTLDFLAGS =
 
 define DOWNLOAD
-  $(TOPDIR)/../build/configs/artik05x/artik05x_download.sh --board=artik053 $(1) $(2) $(3) $(4) $(5) $(6)
+  $(TOPDIR)/../build/configs/common_download.sh $(1) $(2) $(3) $(4) $(5) $(6)
 endef
 
 define OTA_IMG

--- a/build/configs/artik053/tc_minimal_kernel/Make.defs
+++ b/build/configs/artik053/tc_minimal_kernel/Make.defs
@@ -149,7 +149,7 @@ HOSTCFLAGS = -Wall -Wstrict-prototypes -Wshadow -Wundef -g -pipe
 HOSTLDFLAGS =
 
 define DOWNLOAD
-  $(TOPDIR)/../build/configs/artik05x/artik05x_download.sh --board=artik053 $(1) $(2) $(3) $(4) $(5) $(6)
+  $(TOPDIR)/../build/configs/common_download.sh $(1) $(2) $(3) $(4) $(5) $(6)
 endef
 
 define OTA_IMG

--- a/build/configs/artik053s/iotjs/Make.defs
+++ b/build/configs/artik053s/iotjs/Make.defs
@@ -149,7 +149,7 @@ HOSTCFLAGS = -Wall -Wstrict-prototypes -Wshadow -Wundef -g -pipe
 HOSTLDFLAGS =
 
 define DOWNLOAD
-  $(TOPDIR)/../build/configs/artik05x/artik05x_download.sh --board=artik053s --secure $(1) $(2) $(3) $(4) $(5) $(6)
+  $(TOPDIR)/../build/configs/common_download.sh $(1) $(2) $(3) $(4) $(5) $(6)
 endef
 
 define OTA_IMG

--- a/build/configs/artik053s/nettest/Make.defs
+++ b/build/configs/artik053s/nettest/Make.defs
@@ -149,7 +149,7 @@ HOSTCFLAGS = -Wall -Wstrict-prototypes -Wshadow -Wundef -g -pipe
 HOSTLDFLAGS =
 
 define DOWNLOAD
-  $(TOPDIR)/../build/configs/artik05x/artik05x_download.sh --board=artik053s --secure $(1) $(2) $(3) $(4) $(5) $(6)
+  $(TOPDIR)/../build/configs/common_download.sh $(1) $(2) $(3) $(4) $(5) $(6)
 endef
 
 define OTA_IMG

--- a/build/configs/artik053s/st_things/Make.defs
+++ b/build/configs/artik053s/st_things/Make.defs
@@ -149,7 +149,7 @@ HOSTCFLAGS = -Wall -Wstrict-prototypes -Wshadow -Wundef -g -pipe
 HOSTLDFLAGS =
 
 define DOWNLOAD
-  $(TOPDIR)/../build/configs/artik05x/artik05x_download.sh --board=artik053s --secure $(1) $(2) $(3) $(4) $(5) $(6)
+  $(TOPDIR)/../build/configs/common_download.sh $(1) $(2) $(3) $(4) $(5) $(6)
 endef
 
 define OTA_IMG

--- a/build/configs/artik055s/audio/Make.defs
+++ b/build/configs/artik055s/audio/Make.defs
@@ -156,7 +156,7 @@ HOSTCFLAGS = -Wall -Wstrict-prototypes -Wshadow -Wundef -g -pipe
 HOSTLDFLAGS =
 
 define DOWNLOAD
-  $(TOPDIR)/../build/configs/artik05x/artik05x_download.sh --board=artik055s --secure $(1) $(2) $(3) $(4) $(5) $(6)
+  $(TOPDIR)/../build/configs/common_download.sh $(1) $(2) $(3) $(4) $(5) $(6)
 endef
 
 define OTA_IMG

--- a/build/configs/artik055s/iotjs/Make.defs
+++ b/build/configs/artik055s/iotjs/Make.defs
@@ -149,7 +149,7 @@ HOSTCFLAGS = -Wall -Wstrict-prototypes -Wshadow -Wundef -g -pipe
 HOSTLDFLAGS =
 
 define DOWNLOAD
-  $(TOPDIR)/../build/configs/artik05x/artik05x_download.sh --board=artik055s --secure $(1) $(2) $(3) $(4) $(5) $(6)
+  $(TOPDIR)/../build/configs/common_download.sh $(1) $(2) $(3) $(4) $(5) $(6)
 endef
 
 define OTA_IMG

--- a/build/configs/artik055s/minimal/Make.defs
+++ b/build/configs/artik055s/minimal/Make.defs
@@ -150,7 +150,7 @@ HOSTCFLAGS = -Wall -Wstrict-prototypes -Wshadow -Wundef -g -pipe
 HOSTLDFLAGS =
 
 define DOWNLOAD
-  $(TOPDIR)/../build/configs/artik05x/artik05x_download.sh --board=artik055s --secure $(1) $(2) $(3) $(4) $(5) $(6)
+  $(TOPDIR)/../build/configs/common_download.sh $(1) $(2) $(3) $(4) $(5) $(6)
 endef
 
 define OTA_IMG

--- a/build/configs/artik055s/nettest/Make.defs
+++ b/build/configs/artik055s/nettest/Make.defs
@@ -149,7 +149,7 @@ HOSTCFLAGS = -Wall -Wstrict-prototypes -Wshadow -Wundef -g -pipe
 HOSTLDFLAGS =
 
 define DOWNLOAD
-  $(TOPDIR)/../build/configs/artik05x/artik05x_download.sh --board=artik055s --secure $(1) $(2) $(3) $(4) $(5) $(6)
+  $(TOPDIR)/../build/configs/common_download.sh $(1) $(2) $(3) $(4) $(5) $(6)
 endef
 
 define OTA_IMG

--- a/build/configs/artik055s/st_things/Make.defs
+++ b/build/configs/artik055s/st_things/Make.defs
@@ -149,7 +149,7 @@ HOSTCFLAGS = -Wall -Wstrict-prototypes -Wshadow -Wundef -g -pipe
 HOSTLDFLAGS =
 
 define DOWNLOAD
-  $(TOPDIR)/../build/configs/artik05x/artik05x_download.sh --board=artik055s --secure $(1) $(2) $(3) $(4) $(5) $(6)
+  $(TOPDIR)/../build/configs/common_download.sh $(1) $(2) $(3) $(4) $(5) $(6)
 endef
 
 define OTA_IMG

--- a/build/configs/artik05x/artik05x_download.sh
+++ b/build/configs/artik05x/artik05x_download.sh
@@ -20,29 +20,35 @@
 # File   : artik05x_download.sh
 # Description : Download script for ARTIK 05X
 
-THIS_PATH=`test -d ${0%/*} && cd ${0%/*}; pwd`
-
 # When location of this script is changed, only OS_DIR_PATH should be changed together!!!
-OS_DIR_PATH=${THIS_PATH}/../../../os
 
-source ${OS_DIR_PATH}/.config
-
-USBRULE_PATH=${THIS_PATH}/../usbrule.sh
-USBRULE_BOARD="artik"
-USBRULE_IDVENDOR="0403"
-USBRULE_IDPRODUCT="6010"
+USBRULE_PATH=${TOP_PATH}/build/configs/usbrule.sh
 
 PARTMAP_DIR_PATH=${THIS_PATH}
-PARTITION_KCONFIG=${OS_DIR_PATH}/board/common/Kconfig
-BUILD_DIR_PATH=${OS_DIR_PATH}/../build
-CONFIGS_DIR_PATH=${BUILD_DIR_PATH}/configs
-OUTPUT_BINARY_PATH=${BUILD_DIR_PATH}/output/bin
+PARTITION_KCONFIG=${OS_PATH}/board/common/Kconfig
+BUILD_DIR_PATH=${OS_PATH}/../build
+CONFIGS_DIR_PATH=${TOP_PATH}/build/configs
+OUTPUT_BINARY_PATH=${TOP_PATH}/build/output/bin
 ARTIK05X_DIR_PATH=${CONFIGS_DIR_PATH}/artik05x
 SCRIPTS_PATH=${ARTIK05X_DIR_PATH}/scripts
 
-TIZENRT_BIN=${OUTPUT_BINARY_PATH}/tinyara_head.bin
-TIZENRT_APPS_BIN=${OUTPUT_BINARY_PATH}/tinyara_user.bin
-SMARTFS_BIN=${OUTPUT_BINARY_PATH}/artik05x_smartfs.bin
+if [[ "${CONFIG_ARCH_BOARD_ARTIK053}" == "y" ]]; then
+	BOARD_NAME=artik053
+	SECURE=""
+fi
+
+if [[ "${CONFIG_ARCH_BOARD_ARTIK053S}" == "y" ]]; then
+	BOARD_NAME=artik053s
+	SECURE="-signed"
+fi
+
+if [[ "${CONFIG_ARCH_BOARD_ARTIK055S}" == "y" ]]; then
+	BOARD_NAME=artik055s
+	SECURE="-signed"
+fi
+
+BOARD_DIR_PATH=${BUILD_DIR_PATH}/configs/${BOARD_NAME}
+FW_DIR_PATH=${BOARD_DIR_PATH}/bin
 
 OPENOCD_DIR_PATH=${BUILD_DIR_PATH}/tools/openocd
 if [[ $OSTYPE == "darwin"* ]]; then
@@ -62,245 +68,60 @@ OPENOCD=${OPENOCD_BIN_PATH}/openocd
 
 CFG_FILE=artik05x.cfg
 
-usage() {
-	cat <<EOF
-USAGE: `basename $0` [OPTIONS]
-OPTIONS:
-	[--board[="<board-name>"]]
-	[--secure]
-	[ALL | ROMFS | BL1 | BL2 | SSSFW | WLANFW | USERFS]
-
-For examples:
-	`basename $0` --board=artik053 ALL
-	`basename $0` --board=artik053 OS ROMFS
-	`basename $0` --board=artik053s --verify
-	`basename $0` --board=artik055s --secure
-
-Options:
-	--board[="<board-name>"]      select target board-name
-	--secure                      choose secure mode
-	--verify                      verify downloaded image if you need
-	ALL                           write each firmware image into FLASH
-	ROMFS                         write ROM File System image into FLASH
-	BL1                           write Primary Bootloader image into FLASH
-	BL2                           write Secondary Bootloader image into FLASH
-	SSSFW                         write Secure Element Firmware image into FLASH
-	WLANFW                        write WiFi Firmware image into FLASH
-	USERFS                        write user FS to SMARTFS partition
-
-EOF
-}
-
-# Exit if the file is not there
-ensure_file()
-{
-	if [ ! -f "${1:?}" ]; then
-		echo "missing file $1"
-		exit 1
-	fi
-}
-
-# Check if the file is present
-is_file_present()
-{
-	if [ ! -f "${1:?}" ]; then
-	    return 0
-	fi
-	return 1
-}
-
-compute_ocd_commands_user()
-{
-	local commands=
-	ensure_file ${SMARTFS_BIN}
-	commands+="flash_write userfs ${SMARTFS_BIN} ${VERIFY}"
-	echo ${commands}
-}
-
-compute_ocd_commands()
-{
-	local commands=
-	for part in "$@"; do
-		case "${part}" in
-			bl1)
-				ensure_file ${FW_DIR_PATH}/${part}.bin
-				commands+="flash_protect off; flash_write bl1 ${FW_DIR_PATH}/bl1.bin ${VERIFY}; flash_protect on; "
-				;;
-			bl2|sssfw|wlanfw)
-				ensure_file ${FW_DIR_PATH}/${part}.bin
-				commands+="flash_write ${part} ${FW_DIR_PATH}/${part}.bin ${VERIFY}; "
-				;;
-			os)
-				ensure_file ${TIZENRT_BIN}
-				commands+="flash_write ${part} ${TIZENRT_BIN} ${VERIFY}; "
-				;;
-			apps)
-				ensure_file ${TIZENRT_APPS_BIN}
-				commands+="flash_write ${part} ${TIZENRT_APPS_BIN} ${VERIFY}; "
-				;;
-			ota)
-			        is_file_present ${OUTPUT_BINARY_PATH}/ota.bin
-			        if [[ $? -eq 1 ]]; then
-				    commands+="flash_write ${part} ${OUTPUT_BINARY_PATH}/ota.bin ${VERIFY}; "
-			         else
-				     echo "#NOTE: ${OUTPUT_BINARY_PATH}/ota.bin is NOT present";
-				fi
-				;;
-			rom)
-			         is_file_present ${OUTPUT_BINARY_PATH}/romfs.img
-				 if [[ $? -eq 1 ]]; then
-				     commands+="flash_write ${part} ${OUTPUT_BINARY_PATH}/romfs.img ${VERIFY}; "
-				 else
-				     echo "#NOTE: ${OUTPUT_BINARY_PATH}/romfs.img is NOT present";
-				 fi
-				;;
-			zoneinfo)
-			         is_file_present ${OUTPUT_BINARY_PATH}/zoneinfo.img
-				 if [[ $? -eq 1 ]]; then
-				     commands+="flash_write ${part} ${OUTPUT_BINARY_PATH}/zoneinfo.img ${VERIFY}; "
-				 else
-				     echo "#NOTE: ${OUTPUT_BINARY_PATH}/zoneinfo.img is NOT present";
-				 fi
-				;;
-			loadparam)
-			         is_file_present ${OUTPUT_BINARY_PATH}/loadparam
-				 if [[ $? -eq 1 ]]; then
-				     commands+="flash_write ${part} ${OUTPUT_BINARY_PATH}/loadparam ${VERIFY}; "
-				 else
-				     echo "#NOTE: ${OUTPUT_BINARY_PATH}/loadparam is NOT present";
-				 fi
-				;;
-			micom)
-			         is_file_present ${OUTPUT_BINARY_PATH}/micom
-				 if [[ $? -eq 1 ]]; then
-				     commands+="flash_write ${part} ${OUTPUT_BINARY_PATH}/micom ${VERIFY}; "
-				 else
-				     echo "#NOTE: ${OUTPUT_BINARY_PATH}/micom is NOT present";
-				 fi
-				;;
-			wifi)
-			         is_file_present ${OUTPUT_BINARY_PATH}/wifi
-				 if [[ $? -eq 1 ]]; then
-				     commands+="flash_write ${part} ${OUTPUT_BINARY_PATH}/wifi ${VERIFY}; "
-				 else
-				     echo "#NOTE: ${OUTPUT_BINARY_PATH}/wifi is NOT present";
-				 fi
-				;;
-			*)
-				echo "#NOTE#: No binary available for ${part}"
-
-				;;
-		esac
-	done
-	echo ${commands}
-}
-
-download()
-{
-	parts=$1;
-
-	if [[ -n $parts ]] && [[ "$parts" != "all" ]]
-	then
-		echo "##Download $parts"
-	else
-	        default_parts=`grep -A 2 'config FLASH_PART_NAME' ${PARTITION_KCONFIG} | sed -n 's/\tdefault "\(.*\)".*/\1/p'`
-		configured_parts=${CONFIG_FLASH_PART_NAME:=${default_parts}}
-		parts=`echo $configured_parts | sed "s/,/ /g"`
-	fi
-
-	# Make Openocd commands for parts
-	if [[ "$parts" == "userfs" ]]
-	then
-		commands=$(compute_ocd_commands_user)
-		echo "ocd command to run: ${commands}"
-	else
-	# Make Openocd commands for parts
-		commands=$(compute_ocd_commands ${parts})
-		echo "ocd command to run: ${commands}"
-	fi
-
-	# Generate Partition Map
+function pre_download(){
 	${SCRIPTS_PATH}/partition_gen.sh
+}
 
+function board_download()
+{
+	commands=""
+	case $5 in
+		bl1)
+			if [ ! -f ${FW_DIR_PATH}/$3 ];then
+				echo "#NOTE#: No binary available for $5"
+			else
+				commands+="flash_protect off; flash_write $5 ${FW_DIR_PATH}/$3; flash_protect on; "
+			fi
+			;;
+		bl2|sssfw|wlanfw)
+			if [ ! -f ${FW_DIR_PATH}/$3 ];then
+				echo "#NOTE#: No binary available for $5"
+			else
+				commands+="flash_write $5 ${FW_DIR_PATH}/$3 ${VERIFY}; "
+			fi
+			;;
+		os)
+			if [ ! -f ${BIN_PATH}/$3 ];then
+				echo "#NOTE#: No binary available for $5"
+			else
+				commands+="flash_write $5 ${BIN_PATH}/$3${SECURE} ${VERIFY}; "
+			fi
+			;;
+		ota|rom|zoneinfo|loadparam|micom|wifi|userfs)
+			if [ ! -f ${BIN_PATH}/$3 ];then
+				echo "#NOTE#: No binary available for $5"
+			else
+				commands+="flash_write $5 ${BIN_PATH}/$3 ${VERIFY}; "
+			fi
+			;;
+		*)
+			echo "#NOTE#: No binary available for $5"
+	esac
 	# Download all binaries using openocd script
+	echo "${commands}"
 	pushd ${OPENOCD_DIR_PATH} > /dev/null
 	${OPENOCD} -f ${CFG_FILE} -s ${SCRIPTS_PATH} -c "${commands}" -c "init; reset; exit" || exit 1
 	popd > /dev/null
-
-	echo "Flash DONE"
 }
 
-erase()
+function board_erase()
 {
-	case $1 in
-		ota)
-			PART_NAME=ota
-			;;
-		userfs)
-			PART_NAME=userfs
-			;;
-		all)
-			PART_NAME=all
-			;;
-		*)
-			echo "${$1} is not supported"
-			exit 1
-			;;
-	esac
 
-	# Generate Partition Map
-	${SCRIPTS_PATH}/partition_gen.sh
-
-	# Download all binaries using openocd script
 	pushd ${OPENOCD_DIR_PATH} > /dev/null
-	${OPENOCD} -f ${CFG_FILE} -s ${SCRIPTS_PATH} -c "flash_erase_part ${PART_NAME};	exit" || exit 1
+	${OPENOCD} -f ${CFG_FILE} -s ${SCRIPTS_PATH} -c "flash_erase_part $4;	exit" || exit 1
 	popd > /dev/null
 }
 
-if test $# -eq 0; then
-	usage 1>&2
-	exit 1
-fi
-
-while test $# -gt 0; do
-	case "$1" in
-		-*=*) optarg=`echo "${1,,}" | sed 's/[-_a-zA-Z0-9]*=//'` ;;
-		*) optarg= ;;
-	esac
-
-	case ${1,,} in
-		--board*)
-			BOARD_NAME=$optarg
-			BOARD_DIR_PATH=${BUILD_DIR_PATH}/configs/${BOARD_NAME}
-			FW_DIR_PATH=${BOARD_DIR_PATH}/bin
-			if [ ! -d ${BOARD_DIR_PATH} ]; then
-				usage 1>&2
-				exit 1
-			fi
-			;;
-		--secure)
-			TIZENRT_BIN=${TIZENRT_BIN}-signed
-			;;
-		--verify)
-			VERIFY=verify
-			;;
-		all|os|apps|rom|bl1|bl2|sssfw|wlanfw|ota|micom|wifi|userfs|zoneinfo)
-			download ${1,,}
-			;;
-		usbrule)
-			${USBRULE_PATH} ${USBRULE_BOARD} ${USBRULE_IDVENDOR} ${USBRULE_IDPRODUCT} || exit 1
-			;;
-		erase)
-			while test $# -gt 1
-			do
-				erase ${2,,}
-				shift
-			done
-			;;
-		*)
-			usage 1>&2
-			exit 1
-			;;
-	esac
-	shift
-done
+function post_download(){
+	:;
+}

--- a/build/configs/artik05x/board_metadata.txt
+++ b/build/configs/artik05x/board_metadata.txt
@@ -1,0 +1,33 @@
+###########################################################################
+#
+# Copyright 2021 Samsung Electronics All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+#
+###########################################################################
+# board_metadata.txt
+
+BOARD="ARTIK05X_FAMILY"
+
+USBRULE_BOARD="artik"
+USBRULE_IDVENDOR="0403"
+USBRULE_IDPRODUCT="6010"
+
+BL1="bl1"
+BL2="bl2"
+KERNEL="tinyara_head"
+OTA="ota"
+
+DEFAULT_PORT=ttyUSB1
+
+FLASH_START_ADDR=0x04000000

--- a/build/configs/common_download.sh
+++ b/build/configs/common_download.sh
@@ -1,0 +1,470 @@
+#!/usr/bin/env bash
+###########################################################################
+#
+# Copyright 2021 Samsung Electronics All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+#
+###########################################################################
+# common_download.sh
+
+CURDIR=$(readlink -f "$0")
+CUR_PATH=$(dirname "$CURDIR")
+
+#When the location of this script is changed, only TOP_PATH needs to be changed.
+TOP_PATH=${CUR_PATH}/../..
+OS_PATH=${TOP_PATH}/os
+BIN_PATH=${TOP_PATH}/build/output/bin
+PARTITION_KCONFIG=${OS_PATH}/board/common/Kconfig
+
+CONFIG=${OS_PATH}/.config
+source ${CONFIG}
+SMARTFS_BIN_PATH=${BIN_PATH}/${CONFIG_ARCH_BOARD}_smartfs.bin
+
+BOARD_CONFIG=${TOP_PATH}/build/configs/${CONFIG_ARCH_BOARD}/board_metadata.txt
+BOARD_SPECIFIC_SCRIPT=${TOP_PATH}/build/configs/${CONFIG_ARCH_BOARD}/${CONFIG_ARCH_BOARD}_download.sh
+
+source ${BOARD_SPECIFIC_SCRIPT}
+source ${BOARD_CONFIG}
+
+## For manual port selection set any argument to port={port required}, eg. make download port=ttyUSB2 ALL or make download all port=ttyUSB3
+
+if [ "$1" == "port" ]; then
+	PORT="$2"
+	shift 2
+else
+	PORT=${DEFAULT_PORT}
+fi
+
+WARNING="\n Port $PORT is selected\n\n
+	############################################\n
+	WARNINGS:\n
+	1. Make sure the board is in DOWNLOAD MODE.\n
+	2. Make sure NO other application like putty,\n
+	is occupying $PORT.\n
+	############################################\n"
+
+
+TTYDEV="/dev/${PORT}"
+
+##Utility function for sanity check##
+function sanity_check()
+{
+	if [ ! -f ${CONFIG} ];then
+		echo "No .config file"
+		exit 1
+	fi
+
+	if [ ! -f ${BOARD_SPECIFIC_SCRIPT} ];then
+		echo "No ${CONFIG_ARCH_BOARD}_download.sh file"
+		exit 1
+	fi
+
+	if [ ! -f ${BOARD_CONFIG} ];then
+		echo "No board_metadata.txt file"
+		exit 1
+	fi
+
+	CHECK_BOARD=$(echo "CONFIG_ARCH_BOARD_${BOARD}")
+	if [[ "${!CHECK_BOARD}" != "y" ]];then
+		echo "Target is NOT ${BOARD}"
+		exit 1
+	fi
+
+	if fuser -s ${TTYDEV};then
+		echo "${TTYDEV} is used by another process, can't proceed"
+		exit 1
+	fi
+}
+
+##Utility function to match partition name to binary name##
+function get_executable_name()
+{
+	case $1 in
+		bl1)
+			if [[ ! -n "${BL1}" ]];then
+				echo "No Binary Match"
+			else
+				echo "${BL1}.bin"
+			fi;;
+		bl2)
+			if [[ ! -n "${BL2}" ]];then
+				echo "No Binary Match"
+			else
+				echo "${BL2}.bin"
+			fi;;
+		kernel|os) echo "${KERNEL}.bin";;
+		ota) echo "${OTA}.bin";;
+		micom|wifi|loadparam) echo "$1";;
+		zoneinfo) echo "zoneinfo.img";;
+		rom) echo "romfs.img";;
+		bootparam)
+			if [[ ! -n "${BOOTPARAM}" ]];then
+				echo "No Binary Match"
+			else
+				echo "${BOOTPARAM}.bin"
+			fi;;
+		userfs) echo "${CONFIG_ARCH_BOARD}_smartfs.bin";;
+		sssfw|wlanfw) echo "$1.bin";;
+		*) echo "No Binary Match"
+		exit 1
+	esac
+}
+
+flash_ota=false
+##Utility function to get partition index ##
+function get_partition_index()
+{
+	for idx in ${!parts[@]}; do
+		if [[ ${parts[$idx],,} == ${1,,} ]]; then
+			if [[ $flash_ota == true ]]; then
+				## In this case, try to find 2nd kernel partition for OTA
+				flash_ota=false
+				continue;
+			fi
+			echo $idx
+			exit 1
+		else
+			if [[ $flash_ota == true ]]; then
+				## Else check for the partition named OTA
+				if [[ ${parts[$idx]} == "ota" ]]; then
+					echo $idx
+					exit 1
+				fi
+			fi
+		fi
+	done
+	echo -1
+}
+
+##Help utility##
+function dwld_help()
+{
+	cat <<EOF
+	HELP:
+		make download ALL or [PARTITION(S)]
+		make download ERASE ALL or erase [PARTITION(S)]
+		make download ALL port=ttyUSB1
+		make download port=ttyUSB1 ALL
+
+	PARTITION(S):
+		[${uniq_parts[@]}]  NOTE:case sensitive
+
+	For examples:
+		make download ALL
+		make download ERASE ALL
+		make download kernel
+		make download erase kernel
+		make download ota
+		make download erase ota
+		make download kernel userfs
+		make download erase userfs
+		make download erase port=ttyUSB1 userfs
+EOF
+}
+
+##Utility function to read partitions from .config or Kconfig##
+function get_configured_partitions()
+{
+	local configured_parts
+	# Read Partitions
+	if [[ -z ${CONFIG_FLASH_PART_NAME} ]];then
+
+		configured_parts=`grep -A 2 'config FLASH_PART_NAME' ${PARTITION_KCONFIG} | sed -n 's/\tdefault "\(.*\)".*/\1/p'`
+	else
+		configured_parts=${CONFIG_FLASH_PART_NAME}
+	fi
+
+	echo $configured_parts
+}
+
+##Utility function to get the partition sizes from .config or Kconfig
+function get_partition_sizes()
+{
+	local sizes_str
+	#Read Partition Sizes
+	if [[ -z ${CONFIG_FLASH_PART_SIZE} ]]
+	then
+		sizes_str=`grep -A 2 'config FLASH_PART_SIZE' ${PARTITION_KCONFIG} | sed -n 's/\tdefault "\(.*\)".*/\1/p'`
+	else
+		sizes_str=${CONFIG_FLASH_PART_SIZE}
+	fi
+
+	echo $sizes_str
+}
+
+download_specific_partition()
+{
+	TARGET=$1
+	if [[ ${TARGET} == "ota" || ${TARGET} == "OTA" ]];then
+		TARGET="kernel"
+		flash_ota=true
+	fi
+	partidx=$(get_partition_index ${TARGET})
+	if [[ "${partidx}" < 0 ]];then
+		echo "partition ${TARGET} is not supported"
+		dwld_help
+		exit 1
+	fi
+
+	# Get a filename and Download a file
+	echo ""
+	echo "============================="
+	if [[ $1 == "ota" || $1 == "OTA" ]];then
+		echo "Downloading Kernel OTA binary"
+	else
+		echo "Downloading ${parts[$partidx]} binary"
+	fi
+	echo "============================="
+
+	exe_name=$(get_executable_name ${parts[$partidx]})
+	if [[ "No Binary Match" = "${exe_name}" ]];then
+		echo "No corresponding binary for the partition ${parts[$partidx]}"
+		echo "Download $exe_name FAILED!"
+	else
+		board_download $TTYDEV ${offsets[$partidx]} ${exe_name} ${sizes[partidx]} ${parts[$partidx]}
+		echo ""
+		echo "Download $exe_name COMPLETE!"
+	fi
+}
+
+download_all()
+{
+	echo "Starting Download..."
+	found_kernel=false
+	found_wifi=false
+	found_micom=false
+
+	for partidx in ${!parts[@]}; do
+
+		if [[ "${CONFIG_APP_BINARY_SEPARATION}" != "y" ]];then
+			if [[ "${parts[$partidx]}" == "userfs" ]];then
+				continue
+			fi
+		fi
+
+		if [[ "${parts[$partidx]}" == "kernel" ]];then
+			if [[ $found_kernel == true ]];then
+				continue
+			fi
+			found_kernel=true
+		fi
+
+		if [[ "${parts[$partidx]}" == "wifi" ]];then
+			if [[ $found_wifi == true ]];then
+				continue
+			fi
+			found_wifi=true
+		fi
+
+		if [[ "${parts[$partidx]}" == "micom" ]];then
+			if [[ $found_micom == true ]];then
+				continue
+			fi
+			found_micom=true
+		fi
+
+		if [[ "${parts[$partidx]}" == "ftl" ]];then
+			continue
+		fi
+
+		if [[ "${parts[$partidx]}" == "config" ]];then
+			continue
+		fi
+
+		exe_name=$(get_executable_name ${parts[$partidx]})
+		if [[ "No Binary Match" = "${exe_name}" ]];then
+			continue
+		fi
+
+		echo ""
+		echo "=========================="
+		echo "Downloading ${parts[$partidx]} binary"
+		echo "=========================="
+
+		board_download $TTYDEV ${offsets[$partidx]} ${exe_name} ${sizes[partidx]} ${parts[$partidx]}
+	done
+	echo ""
+	echo "Download COMPLETE!"
+}
+
+erase()
+{
+	echo "Starting Erase..."
+	if [[ $2 == "all" || $2 == "ALL" ]];then
+		echo ""
+		echo "=========================="
+		echo "      Erasing All"
+		echo "=========================="
+		for partidx in ${!parts[@]}; do
+			if [[ "${parts[$partidx]}" == "userfs" ]];then
+				continue
+			elif [[ "${parts[$partidx]}" == "ss" ]];then
+				continue
+			else
+				echo ""
+				echo "=========================="
+				echo "Erasing ${parts[$partidx]} partition"
+				echo "=========================="
+			fi
+
+			board_erase $TTYDEV ${offsets[$partidx]} ${sizes[partidx]} ${parts[$partidx]}
+		done
+	else
+		found_kernel=false
+		for partidx in ${!parts[@]}; do
+			if [[ $2 == "kernel" || $2 == "KERNEL" ]];then
+				if [[ "${parts[$partidx]}" != "kernel" ]];then
+					continue
+				elif [[ $found_kernel == false ]];then
+					found_kernel=true
+				else
+					continue
+				fi
+			elif [[ $2 == "ota" || $2 == "OTA" ]];then
+				if [[ "${parts[$partidx]}" == "ota" ]];then
+					flash_ota=false
+				elif [[ "${parts[$partidx]}" != "kernel" ]];then
+					continue
+				elif [[ $found_kernel == false ]];then
+					found_kernel=true
+					continue
+				else
+					flash_ota=false
+				fi
+			elif [[ $2 == "ss" || $2 == "SS" ]];then
+				if [[ "${parts[$partidx]}" != "ss" ]];then
+					continue
+				fi
+			elif [[ $2 == "userfs" || $2 == "USERFS" ]];then
+				if [[ "${parts[$partidx]}" != "userfs" ]];then
+					continue
+				fi
+			else
+				printf "\n## Invalid Option ##\n\n"
+				dwld_help
+				break
+			fi
+
+			echo ""
+			echo "=========================="
+			echo "Erasing ${parts[$partidx]} partition"
+			echo "=========================="
+			board_erase $TTYDEV ${offsets[$partidx]} ${sizes[partidx]} ${parts[$partidx]}
+		done
+	fi
+	echo ""
+	echo "Erase COMPLETE!"
+}
+
+# Start here
+
+echo -e $WARNING
+
+cmd_args=$(echo $@ | tr '[:upper:]' '[:lower:]')
+
+# Checking the USB rule first
+for i in ${cmd_args[@]};do
+	if [[ "${i}" == "usbrule" ]];then
+		${USBRULE_PATH} ${USBRULE_BOARD} ${USBRULE_IDVENDOR} ${USBRULE_IDPRODUCT} ${USBRULE_IDVENDOR2} ${USBRULE_IDPRODUCT2} || exit 1
+		exit 0
+	fi
+done
+
+sanity_check;
+
+parts=$(get_configured_partitions)
+IFS=',' read -ra parts <<< "$parts"
+
+sizes=$(get_partition_sizes)
+IFS=',' read -ra sizes <<< "$sizes"
+
+#Calculate Flash Offset
+num=${#sizes[@]}
+offsets[0]=`printf "0x%X" ${FLASH_START_ADDR}`
+
+for (( i=1; i<=$num-1; i++ ))
+do
+	val=$((sizes[$i-1] * 1024))
+	offsets[$i]=`printf "0x%X" $((offsets[$i-1] + ${val}))`
+done
+
+#Dump Info
+echo ""
+echo "================================ < Flash Partition Information > ================================"
+printf "\rNAME       :"
+printf '  %12s' "${parts[@]}"
+printf "\r\nSIZE(in KB):"
+printf '  %12s' "${sizes[@]}"
+printf "\r\nAddr       :"
+printf '  %12s' "${offsets[@]}"
+printf "\n"
+echo "================================================================================================="
+echo ""
+
+if test $# -eq 0; then
+	echo "FAIL!! NO Given partition. Refer \"PARTITION NAMES\" above."
+	dwld_help 1>&2
+	exit 1
+fi
+
+uniq_parts=($(printf "%s\n" "${parts[@]}" | sort -u));
+
+#Validate arguments
+for i in ${cmd_args[@]};do
+
+	if [[ "${i}" == "ALL" || "${i}" == "all" || "${i}" == "erase" || "${i}" == "ERASE" || "${i}" == "usbrule" || "${i}" == "USBrule" ]];then
+		continue;
+	fi
+
+	result=no
+	for j in ${uniq_parts[@]};do
+		if [[ "${i}" == "${j}" ]];then
+			result=yes
+		fi
+	done
+
+	if [[ "$result" != "yes" ]];then
+		echo "FAIL!! Given \"${i}\" partition is not available. Refer \"PARTITION NAMES\" above."
+		dwld_help
+		exit 1
+	fi
+done
+
+# Must be defined in each board specific download file.
+pre_download;
+
+case $1 in
+	all|ALL)
+		download_all
+		;;
+	erase|ERASE)
+		erase $1 $2
+		;;
+	kernel|KERNEL)
+		download_specific_partition $1
+		if [[ -n "${BOOTPARAM}" ]];then
+			download_specific_partition "bootparam"
+		fi
+		;;
+	*)
+		while test $# -gt 0
+		do
+			download_specific_partition $1
+			shift
+		done
+		;;
+esac
+
+# Must be defined in each board specific download file.
+post_download;

--- a/build/configs/imxrt1020-evk/SAM/Make.defs
+++ b/build/configs/imxrt1020-evk/SAM/Make.defs
@@ -170,6 +170,6 @@ HOSTCFLAGS = -Wall -Wstrict-prototypes -Wshadow -Wundef -g -pipe
 HOSTLDFLAGS =
 
 define DOWNLOAD
-  $(TOPDIR)/../build/configs/$(CONFIG_ARCH_BOARD)/$(CONFIG_ARCH_BOARD)_download.sh $(1) $(2) $(3) $(4) $(5) $(6)
+  $(TOPDIR)/../build/configs/common_download.sh $(1) $(2) $(3) $(4) $(5) $(6)
 endef
 

--- a/build/configs/imxrt1020-evk/ble/Make.defs
+++ b/build/configs/imxrt1020-evk/ble/Make.defs
@@ -130,6 +130,6 @@ HOSTCFLAGS = -Wall -Wstrict-prototypes -Wshadow -Wundef -g -pipe
 HOSTLDFLAGS =
 
 define DOWNLOAD
-  $(TOPDIR)/../build/configs/$(CONFIG_ARCH_BOARD)/$(CONFIG_ARCH_BOARD)_download.sh $(1) $(2) $(3) $(4) $(5) $(6)
+  $(TOPDIR)/../build/configs/common_download.sh $(1) $(2) $(3) $(4) $(5) $(6)
 endef
 

--- a/build/configs/imxrt1020-evk/board_metadata.txt
+++ b/build/configs/imxrt1020-evk/board_metadata.txt
@@ -1,0 +1,36 @@
+###########################################################################
+#
+# Copyright 2021 Samsung Electronics All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+#
+###########################################################################
+# board_metadata.txt
+
+USBRULE_BOARD="imxrt"
+USBRULE_IDVENDOR="0d28"
+USBRULE_IDPRODUCT="0204"
+USBRULE_IDVENDOR2="0403"
+USBRULE_IDPRODUCT2="6010"
+
+BOARD=IMXRT1020_EVK
+
+DEFAULT_PORT="ttyACM0"
+
+BL1=""
+BL2=""
+KERNEL="tinyara"
+OTA=""
+BOOTPARAM=""
+
+FLASH_START_ADDR=0x60000000

--- a/build/configs/imxrt1020-evk/bootstrap.sh
+++ b/build/configs/imxrt1020-evk/bootstrap.sh
@@ -4,9 +4,9 @@
 CURDIR=$(readlink -f "$0")
 CURDIR_PATH=$(dirname "$CURDIR")
 
-BINFILE=${CURDIR_PATH}/../../tools/nxp/imxrt1020/ivt_flashloader.bin
-SDPHOST=${CURDIR_PATH}/../../tools/nxp/imxrt1020/sdphost
-BLHOST=${CURDIR_PATH}/../../tools/nxp/imxrt1020/blhost
+BINFILE=${CURDIR_PATH}/../tools/nxp/imxrt1020/ivt_flashloader.bin
+SDPHOST=${CURDIR_PATH}/../tools/nxp/imxrt1020/sdphost
+BLHOST=${CURDIR_PATH}/../tools/nxp/imxrt1020/blhost
 
 BASEADDR=0x20208000
 IVTADDR=0x20208400

--- a/build/configs/imxrt1020-evk/hello/Make.defs
+++ b/build/configs/imxrt1020-evk/hello/Make.defs
@@ -130,6 +130,6 @@ HOSTCFLAGS = -Wall -Wstrict-prototypes -Wshadow -Wundef -g -pipe
 HOSTLDFLAGS =
 
 define DOWNLOAD
-  $(TOPDIR)/../build/configs/$(CONFIG_ARCH_BOARD)/$(CONFIG_ARCH_BOARD)_download.sh $(1) $(2) $(3) $(4) $(5) $(6)
+  $(TOPDIR)/../build/configs/common_download.sh $(1) $(2) $(3) $(4) $(5) $(6)
 endef
 

--- a/build/configs/imxrt1020-evk/helloxx/Make.defs
+++ b/build/configs/imxrt1020-evk/helloxx/Make.defs
@@ -179,5 +179,5 @@ HOSTCFLAGS = -Wall -Wstrict-prototypes -Wshadow -Wundef -g -pipe
 HOSTLDFLAGS =
 
 define DOWNLOAD
-  $(TOPDIR)/../build/configs/$(CONFIG_ARCH_BOARD)/$(CONFIG_ARCH_BOARD)_download.sh $(1) $(2) $(3) $(4) $(5) $(6)
+  $(TOPDIR)/../build/configs/common_download.sh $(1) $(2) $(3) $(4) $(5) $(6)
 endef

--- a/build/configs/imxrt1020-evk/imxrt1020-evk_download.sh
+++ b/build/configs/imxrt1020-evk/imxrt1020-evk_download.sh
@@ -18,64 +18,12 @@
 ###########################################################################
 # imxrt1020-evk_download.sh
 
-WARNING="\n########################################\n
-	WARNING:Make sure NO other application like \n
-	putty etc, is accessing ttyACM0. If download \n
-	fails, reset the board before next try!!\n
-	#################################################\n"
-
-echo -e $WARNING
-
-CURDIR=$(readlink -f "$0")
-CURDIR_PATH=$(dirname "$CURDIR")
-
-# When location of this script is changed, only TOP_PATH should be changed together!!!
-TOP_PATH=${CURDIR_PATH}/../../..
-
-USBRULE_PATH=${CURDIR_PATH}/../usbrule.sh
-USBRULE_BOARD="imxrt"
-USBRULE_IDVENDOR="0d28"
-USBRULE_IDPRODUCT="0204"
-USBRULE_IDVENDOR2="0403"
-USBRULE_IDPRODUCT2="6010"
-
-OS_PATH=${TOP_PATH}/os
-OUTBIN_PATH=${TOP_PATH}/build/output/bin
-TTYDEV="/dev/ttyACM0"
-TINYARA_BIN=${OUTBIN_PATH}/tinyara.bin
-CONFIG=${OS_PATH}/.config
-ZONEINFO=${OUTBIN_PATH}/zoneinfo.img
-FLASH_START_ADDR=0x60000000
-
-##Utility function for sanity check##
-function imxrt1020_sanity_check()
-{
-	if [ ! -f ${CONFIG} ];then
-		echo "No .config file"
-		exit 1
-	fi
-
-	source ${CONFIG}
-	if [[ "${CONFIG_ARCH_BOARD_IMXRT1020_EVK}" != "y" ]];then
-		echo "Target is NOT IMXRT1020_EVK"
-		exit 1
-	fi
-
-	if [ ! -f ${TINYARA_BIN} ]; then
-		echo "missing file ${TINYARA_BIN}"
-		exit 1
-	fi
-
-	if fuser -s ${TTYDEV};then
-		echo "${TTYDEV} is used by another process, can't proceed"
-		exit 1
-	fi
-}
+USBRULE_PATH=${TOP_PATH}/build/configs/usbrule.sh
 
 ##Utility Function to Bootstrap and configure memory##
 function imxrt1020_bootstrap()
 {
-	source ${CURDIR_PATH}/bootstrap.sh
+	source ${TOP_PATH}/build/configs/${CONFIG_ARCH_BOARD}/bootstrap.sh
 	${BLHOST} -p $TTYDEV -- fill-memory 0x2000 0x04 0xc0000006
 	${BLHOST} -p $TTYDEV -- configure-memory 0x09 0x2000
 }
@@ -84,222 +32,42 @@ function imxrt1020_bootstrap()
 #Input: Address and length
 function flash_erase()
 {
-	echo -e "\nFLASH_ERASE: ADDR:$1 LENGTH:$2 KB"
-	size_in_bytes=$(($2 * 1024))
-	${BLHOST} -p ${TTYDEV} -- flash-erase-region $1 $size_in_bytes
+	echo -e "\nFLASH_ERASE: ADDR:$2 LENGTH:$3 KB"
+	size_in_bytes=$(($3 * 1024))
+	${BLHOST} -p $1 -- flash-erase-region $2 $size_in_bytes
 }
 
 ##Utility function to write a binary on a flash partition##
 #Input: Address and filepath
 function flash_write()
 {
-	echo -e "\nFLASH_WRITE ADDR:$1 \nFILEPATH:$2 "
-	${BLHOST} -p ${TTYDEV} -- write-memory $1 $2
+	echo -e "\nFLASH_WRITE ADDR:$2 \nFILEPATH:$3 "
+	${BLHOST} -p $1 -- write-memory $2 $3
 	sleep 2
 }
 
-##Utility function to match partition name to binary name##
-function get_executable_name()
+function pre_download()
 {
-	case $1 in
-		kernel) echo "tinyara.bin";;
-		micom) echo "micom";;
-		wifi) echo "wifi";;
-		zoneinfo) echo "zoneinfo.img";;
-		userfs) echo "imxrt1020-evk_smartfs.bin";;
-		*) echo "No Binary Match"
-		exit 1
-	esac
+	imxrt1020_bootstrap
 }
 
-##Utility function to get partition index ##
-function get_partition_index()
+function post_download()
 {
-	case $1 in
-		kernel) echo "0";;
-		micom) echo "1";;
-		wifi) echo "3";;
-		zoneinfo)
-		for i in "${!parts[@]}"
-		do
-		   if [[ "${parts[$i]}" = "zoneinfo" ]]; then
-			echo $i
-		   fi
-		done
-		;;
-		userfs)
-		for i in "${!parts[@]}"
-		do
-		   if [[ "${parts[$i]}" = "userfs" ]]; then
-			echo $i
-		   fi
-		done
-		;;
-		*) echo "No Matching Partition"
-		exit 1
-	esac
+	:;
 }
 
-##Help utility##
-function imxrt1020_dwld_help()
+function board_download()
 {
-        cat <<EOF
-	HELP:
-		make download ERASE [PARTITION(S)]
-		make download ALL or [PARTITION(S)]
-	PARTITION(S):
-		 [${uniq_parts[@]}]  NOTE:case sensitive
-
-	For examples:
-		make download ALL
-	        make download kernel
-		make download ERASE kernel
-EOF
-}
-
-##Utility function to read paritions from .config or Kconfig##
-function get_configured_partitions()
-{
-	local configured_parts
-	# Read Partitions
-	if [[ -z ${CONFIG_FLASH_PART_NAME} ]];then
-
-		configured_parts=`grep -A 2 'config FLASH_PART_NAME' ${PARTITION_KCONFIG} | sed -n 's/\tdefault "\(.*\)".*/\1/p'`
+	if [ ! -f ${BIN_PATH}/$3 ];then
+		echo "${BIN_PATH}/$3 not found"
 	else
-		configured_parts=${CONFIG_FLASH_PART_NAME}
+		echo "${BIN_PATH}/$3"
+		flash_erase $1 $2 $4
+		flash_write $1 $2 ${BIN_PATH}/$3
 	fi
-
-	echo $configured_parts
 }
 
-##Utility function to get the partition sizes from .config or Kconfig
-function get_partition_sizes()
+function board_erase()
 {
-	local sizes_str
-	#Read Partition Sizes
-	if [[ -z ${CONFIG_FLASH_PART_SIZE} ]]
-	then
-		sizes_str=`grep -A 2 'config FLASH_PART_SIZE' ${PARTITION_KCONFIG} | sed -n 's/\tdefault "\(.*\)".*/\1/p'`
-	else
-		sizes_str=${CONFIG_FLASH_PART_SIZE}
-	fi
-
-	echo $sizes_str
+	flash_erase $1 $2 $3
 }
-
-# Start here
-
-cmd_args=$(echo $@ | tr '[:upper:]' '[:lower:]')
-
-# Treat adding the USB rule first
-for i in ${cmd_args[@]};do
-	if [[ "${i}" == "usbrule" ]];then
-		${USBRULE_PATH} ${USBRULE_BOARD} ${USBRULE_IDVENDOR} ${USBRULE_IDPRODUCT} ${USBRULE_IDVENDOR2} ${USBRULE_IDPRODUCT2} || exit 1
-		exit 0
-	fi
-done
-
-imxrt1020_sanity_check;
-
-parts=$(get_configured_partitions)
-IFS=',' read -ra parts <<< "$parts"
-
-sizes=$(get_partition_sizes)
-IFS=',' read -ra sizes <<< "$sizes"
-
-#Calculate Flash Offset
-num=${#sizes[@]}
-offsets[0]=`printf "0x%X" ${FLASH_START_ADDR}`
-
-for (( i=1; i<=$num-1; i++ ))
-do
-	val=$((sizes[$i-1] * 1024))
-	offsets[$i]=`printf "0x%X" $((offsets[$i-1] + ${val}))`
-done
-
-#Dump Info
-echo "PARTIION OFFSETS: ${offsets[@]}"
-echo "PARTITION SIZES: ${sizes[@]}"
-echo "PARTIION NAMES: ${parts[@]}"
-
-if test $# -eq 0; then
-	echo "FAIL!! NO Given partition. Refer \"PARTITION NAMES\" above."
-	imxrt1020_dwld_help 1>&2
-	exit 1
-fi
-
-uniq_parts=($(printf "%s\n" "${parts[@]}" | sort -u));
-
-#Validate arguments
-for i in ${cmd_args[@]};do
-
-	if [[ "${i}" == "erase" || "${i}" == "all" ]];then
-		continue;
-	fi
-
-	for j in ${uniq_parts[@]};do
-		if [[ "${i}" == "${j}" ]];then
-			result=yes
-		fi
-	done
-
-	if [[ "$result" != "yes" ]];then
-		echo "FAIL!! Given \"${i}\" partition is not available. Refer \"PARTITION NAMES\" above."
-		imxrt1020_dwld_help
-		exit 1
-	fi
-	result=no
-done
-
-imxrt1020_bootstrap;
-
-case ${1,,} in
-#Download ALL option
-all)
-	for part in ${uniq_parts[@]}; do
-		if [[ "${CONFIG_SUPPORT_COMMON_BINARY}" != "y" ]];then
-			if [[ "$part" == "userfs" ]];then
-				continue
-			fi
-		fi
-		if [[ "$part" == "ftl" ]];then
-			continue
-		fi
-		if [[ "$part" == "config" ]];then
-			continue
-		fi
-		gidx=$(get_partition_index $part)
-		flash_erase ${offsets[$gidx]} ${sizes[$gidx]}
-		exe_name=$(get_executable_name ${parts[$gidx]})
-		flash_write ${offsets[$gidx]} ${OUTBIN_PATH}/${exe_name}
-	done
-	;;
-#Download ERASE <list of partitions>
-erase)
-	while test $# -gt 1
-	do
-		chk=${2,,}
-		for i in "${!parts[@]}"; do
-		   if [[ "${parts[$i]}" = "${chk}" ]]; then
-			flash_erase ${offsets[${i}]} ${sizes[${i}]}
-		   fi
-		done
-		shift
-	done
-	;;
-#Download <list of partitions>
-*)
-	while test $# -gt 0
-	do
-		chk=${1,,}
-		for i in "${!uniq_parts[@]}"; do
-		   if [[ "${uniq_parts[$i]}" = "${chk}" ]]; then
-			gidx=$(get_partition_index ${chk})
-			flash_erase ${offsets[$gidx]} ${sizes[$gidx]}
-			exe_name=$(get_executable_name ${chk})
-			flash_write ${offsets[$gidx]} ${OUTBIN_PATH}/${exe_name}
-		   fi
-		done
-		shift
-	done
-esac

--- a/build/configs/imxrt1020-evk/loadable_elf_apps/Make.defs
+++ b/build/configs/imxrt1020-evk/loadable_elf_apps/Make.defs
@@ -168,6 +168,6 @@ HOSTCFLAGS = -Wall -Wstrict-prototypes -Wshadow -Wundef -g -pipe
 HOSTLDFLAGS =
 
 define DOWNLOAD
-  $(TOPDIR)/../build/configs/$(CONFIG_ARCH_BOARD)/$(CONFIG_ARCH_BOARD)_download.sh $(1) $(2) $(3) $(4) $(5) $(6)
+  $(TOPDIR)/../build/configs/common_download.sh $(1) $(2) $(3) $(4) $(5) $(6)
 endef
 

--- a/build/configs/imxrt1020-evk/reliability_test/Make.defs
+++ b/build/configs/imxrt1020-evk/reliability_test/Make.defs
@@ -168,6 +168,6 @@ HOSTCFLAGS = -Wall -Wstrict-prototypes -Wshadow -Wundef -g -pipe
 HOSTLDFLAGS =
 
 define DOWNLOAD
-  $(TOPDIR)/../build/configs/$(CONFIG_ARCH_BOARD)/$(CONFIG_ARCH_BOARD)_download.sh $(1) $(2) $(3) $(4) $(5) $(6)
+  $(TOPDIR)/../build/configs/common_download.sh $(1) $(2) $(3) $(4) $(5) $(6)
 endef
 

--- a/build/configs/imxrt1020-evk/tc/Make.defs
+++ b/build/configs/imxrt1020-evk/tc/Make.defs
@@ -171,6 +171,6 @@ HOSTCFLAGS = -Wall -Wstrict-prototypes -Wshadow -Wundef -g -pipe
 HOSTLDFLAGS =
 
 define DOWNLOAD
-  $(TOPDIR)/../build/configs/$(CONFIG_ARCH_BOARD)/$(CONFIG_ARCH_BOARD)_download.sh $(1) $(2) $(3) $(4) $(5) $(6)
+  $(TOPDIR)/../build/configs/common_download.sh $(1) $(2) $(3) $(4) $(5) $(6)
 endef
 

--- a/build/configs/imxrt1050-evk/board_metadata.txt
+++ b/build/configs/imxrt1050-evk/board_metadata.txt
@@ -1,0 +1,36 @@
+###########################################################################
+#
+# Copyright 2021 Samsung Electronics All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+#
+###########################################################################
+# board_metadata.txt
+
+USBRULE_BOARD="imxrt"
+USBRULE_IDVENDOR="0d28"
+USBRULE_IDPRODUCT="0204"
+USBRULE_IDVENDOR2="0403"
+USBRULE_IDPRODUCT2="6010"
+
+BOARD=IMXRT1050_EVK
+
+DEFAULT_PORT="ttyACM0"
+
+BL1=""
+BL2=""
+KERNEL="tinyara"
+OTA=""
+BOOTPARAM=""
+
+FLASH_START_ADDR=0x60000000

--- a/build/configs/imxrt1050-evk/bootstrap.sh
+++ b/build/configs/imxrt1050-evk/bootstrap.sh
@@ -3,7 +3,7 @@
 
 CURDIR=$(readlink -f "$0")
 CURDIR_PATH=$(dirname "$CURDIR")
-NXPTOOLS_PATH=${CURDIR_PATH}/../../tools/nxp/imxrt1050
+NXPTOOLS_PATH=${TOP_PATH}/build/tools/nxp/imxrt1050
 
 BINFILE=${NXPTOOLS_PATH}/ivt_flashloader.bin
 SDPHOST=${NXPTOOLS_PATH}/sdphost

--- a/build/configs/imxrt1050-evk/hello/Make.defs
+++ b/build/configs/imxrt1050-evk/hello/Make.defs
@@ -130,6 +130,6 @@ HOSTCFLAGS = -Wall -Wstrict-prototypes -Wshadow -Wundef -g -pipe
 HOSTLDFLAGS =
 
 define DOWNLOAD
-  $(TOPDIR)/../build/configs/$(CONFIG_ARCH_BOARD)/$(CONFIG_ARCH_BOARD)_download.sh $(1) $(2) $(3) $(4) $(5) $(6)
+  $(TOPDIR)/../build/configs/common_download.sh $(1) $(2) $(3) $(4) $(5) $(6)
 endef
 

--- a/build/configs/imxrt1050-evk/helloxx/Make.defs
+++ b/build/configs/imxrt1050-evk/helloxx/Make.defs
@@ -179,5 +179,5 @@ HOSTCFLAGS = -Wall -Wstrict-prototypes -Wshadow -Wundef -g -pipe
 HOSTLDFLAGS =
 
 define DOWNLOAD
-  $(TOPDIR)/../build/configs/$(CONFIG_ARCH_BOARD)/$(CONFIG_ARCH_BOARD)_download.sh $(1) $(2) $(3) $(4) $(5) $(6)
+  $(TOPDIR)/../build/configs/common_download.sh $(1) $(2) $(3) $(4) $(5) $(6)
 endef

--- a/build/configs/imxrt1050-evk/imxrt1050-evk_download.sh
+++ b/build/configs/imxrt1050-evk/imxrt1050-evk_download.sh
@@ -37,61 +37,9 @@
 ###########################################################################
 # imxrt1050-evk_download.sh
 
-WARNING="\n########################################\n
-	WARNING:If download fails, don't forget to replug\n
-	and reset the board before next try!!\n
-	#################################################\n"
+BOOTSTRAP_SCRIPT=${TOP_PATH}/build/configs/${CONFIG_ARCH_BOARD}/bootstrap.sh
 
-echo -e $WARNING
-
-THIS_PATH=`test -d ${0%/*} && cd ${0%/*}; pwd`
-
-# When location of this script is changed, only TOP_PATH should be changed together!!!
-TOP_PATH=${THIS_PATH}/../../..
-BOOTSTRAP_SCRIPT=${THIS_PATH}/bootstrap.sh
-
-USBRULE_PATH=${THIS_PATH}/../usbrule.sh
-USBRULE_BOARD="imxrt"
-USBRULE_IDVENDOR="0d28"
-USBRULE_IDPRODUCT="0204"
-USBRULE_IDVENDOR2="0403"
-USBRULE_IDPRODUCT2="6010"
-
-OS_PATH=${TOP_PATH}/os
-OUTBIN_PATH=${TOP_PATH}/build/output/bin
-TTYDEV="/dev/ttyACM0"
-
-# Following to read partition information
-PARTITION_KCONFIG=${OS_PATH}/board/common/Kconfig
-
-CONFIG=${OS_PATH}/.config
-FLASH_START_ADDR=0x60000000
-TINYARA_BIN=${OUTBIN_PATH}/tinyara.bin
-
-##Utility function for sanity check##
-function imxrt1050_sanity_check()
-{
-        if [ ! -f ${CONFIG} ];then
-                echo "No .config file"
-                exit 1
-        fi
-
-        source ${CONFIG}
-        if [[ "${CONFIG_ARCH_BOARD_IMXRT1050_EVK}" != "y" ]];then
-                echo "Target is NOT IMXRT1050_EVK"
-                exit 1
-        fi
-
-        if [ ! -f ${TINYARA_BIN} ]; then
-                echo "missing file ${TINYARA_BIN}"
-                exit 1
-        fi
-
-        if fuser -s ${TTYDEV};then
-                echo "${TTYDEV} is used by another process, can't proceed"
-                exit 1
-        fi
-}
+USBRULE_PATH=${TOP_PATH}/build/configs/usbrule.sh
 
 #Bootstrap to set communicaiton with blhost
 #Input: None
@@ -122,210 +70,28 @@ function flash_write()
 	sleep 2
 }
 
-#Utility function to match partition name to binary name
-#NOTE: Hard-coded for now
-function get_executable_name()
+function pre_download()
 {
-	case $1 in
-		kernel) echo "tinyara.bin";;
-		app) echo "tinyara_user.bin";;
-		micom) echo "micom";;
-		wifi) echo "wifi";;
-		zoneinfo) echo "zoneinfo.img";;
-		userfs) echo "imxrt1050-evk_smartfs.bin";;
-		*) echo "No Binary Match"
-		exit 1
-	esac
-}	
-
-##Utility function to get partition index ##
-function get_partition_index()
-{
-        case $1 in
-                kernel) echo "0";;
-                app) echo "1";;
-                micom) echo "2";;
-                wifi) echo "4";;
-                zoneinfo)
-                for i in "${!parts[@]}"
-                do
-                   if [[ "${parts[$i]}" = "zoneinfo" ]]; then
-                        echo $i
-                fi
-                done
-                ;;
-                userfs)
-                for i in "${!parts[@]}"
-                do
-                   if [[ "${parts[$i]}" = "userfs" ]]; then
-                        echo $i
-                fi
-                done
-                ;;
-                *) echo "No Matching Partition"
-                exit 1
-        esac
+	bootstrap
 }
 
-##Help utility##
-function imxrt1050_dwld_help()
+function post_download()
 {
-        cat <<EOF
-        HELP:
-                make download ERASE [PARTITION(S)]
-                make download ALL or [PARTITION(S)]
-        PARTITION(S):
-                 [${uniq_parts[@]}]  NOTE:case sensitive
-
-        For examples:
-                make download ALL
-                make download kernel app
-                make download app
-                make download ERASE kernel
-EOF
+	:;
 }
 
-
-##Utility function to read paritions from .config or Kconfig##
-function get_configured_partitions()
+function board_download()
 {
-        local configured_parts
-        # Read Partitions
-        if [[ -z ${CONFIG_FLASH_PART_NAME} ]];then
-
-                configured_parts=`grep -A 2 'config FLASH_PART_NAME' ${PARTITION_KCONFIG} | sed -n 's/\tdefault "\(.*\)".*/\1/p'`
-        else
-                configured_parts=${CONFIG_FLASH_PART_NAME}
-        fi
-
-        echo $configured_parts
-}
-
-##Utility function to get the partition sizes from .config or Kconfig
-function get_partition_sizes()
-{
-        local sizes_str
-        #Read Partition Sizes
-        if [[ -z ${CONFIG_FLASH_PART_SIZE} ]]
-        then
-                sizes_str=`grep -A 2 'config FLASH_PART_SIZE' ${PARTITION_KCONFIG} | sed -n 's/\tdefault "\(.*\)".*/\1/p'`
-        else
-                sizes_str=${CONFIG_FLASH_PART_SIZE}
-        fi
-
-        echo $sizes_str
-}
-
-# Start here
-
-cmd_args=$(echo $@ | tr '[:upper:]' '[:lower:]')
-
-# Treat adding the USB rule first
-for i in ${cmd_args[@]};do
-	if [[ "${i}" == "usbrule" ]];then
-		${USBRULE_PATH} ${USBRULE_BOARD} ${USBRULE_IDVENDOR} ${USBRULE_IDPRODUCT} ${USBRULE_IDVENDOR2} ${USBRULE_IDPRODUCT2} || exit 1
-		exit 0
+	if [ ! -f ${BIN_PATH}/$3 ];then
+		echo "${BIN_PATH}/$3 not found"
+	else
+		echo "${BIN_PATH}/$3"
+		flash_erase $2 $4
+		flash_write $2 ${BIN_PATH}/$3
 	fi
-done
+}
 
-#Sanity Check
-imxrt1050_sanity_check
-
-parts=$(get_configured_partitions)
-IFS=',' read -ra parts <<< "$parts"
-
-sizes=$(get_partition_sizes)
-IFS=',' read -ra sizes <<< "$sizes"
-
-
-#Calculate Flash Offset
-num=${#sizes[@]}
-offsets[0]=`printf "0x%X" ${FLASH_START_ADDR}`
-
-for (( i=1; i<=$num-1; i++ ))
-do
-	val=$((sizes[$i-1] * 1024))
-
-	offsets[$i]=`printf "0x%X" $((offsets[$i-1] + ${val}))`
-done
-
-#Dump Info
-echo "PARTIION OFFSETS: ${offsets[@]}"
-echo "PARTITION SIZES: ${sizes[@]}"
-echo "PARTIION NAMES: ${parts[@]}"
-
-if test $# -eq 0; then
-	echo "FAIL!! NO Given partition. Refer \"PARTITION NAMES\" above."
-	imxrt1050_dwld_help 1>&2
-	exit 1
-fi
-
-uniq_parts=($(printf "%s\n" "${parts[@]}" | sort -u));
-
-#Validate arguments
-for i in ${cmd_args[@]};do
-
-	if [[ "${i}" == "erase" || "${i}" == "all" ]];then
-		continue;
-	fi
-
-	for j in ${uniq_parts[@]};do
-		if [[ "${i}" == "${j}" ]];then
-			result=yes
-		fi
-	done
-
-	if [[ "$result" != "yes" ]];then
-		echo "FAIL!! Given \"${i}\" partition is not available. Refer \"PARTITION NAMES\" above."
-		imxrt1050_dwld_help
-		exit 1
-	fi
-	result=no
-done
-
-#bootstrap
-bootstrap
-
-case ${1,,} in
-#Download ALL option
-all)
-        for part in ${uniq_parts[@]}; do
-                if [[ "$part" == "userfs" ]];then
-                        continue
-                fi
-                gidx=$(get_partition_index $part)
-                flash_erase ${offsets[$gidx]} ${sizes[$gidx]}
-                exe_name=$(get_executable_name ${parts[$gidx]})
-                flash_write ${offsets[$gidx]} ${OUTBIN_PATH}/${exe_name}
-        done
-        ;;
-#Download ERASE <list of partitions>
-erase)
-        while test $# -gt 1
-        do
-                chk=${2,,}
-                for i in "${!parts[@]}"; do
-                   if [[ "${parts[$i]}" = "${chk}" ]]; then
-                        flash_erase ${offsets[${i}]} ${sizes[${i}]}
-                   fi
-                done
-                shift
-        done
-        ;;
-#Download <list of partitions>
-*)
-        while test $# -gt 0
-        do
-                chk=${1,,}
-                for i in "${!uniq_parts[@]}"; do
-                   if [[ "${uniq_parts[$i]}" = "${chk}" ]]; then
-                        gidx=$(get_partition_index ${chk})
-                        flash_erase ${offsets[$gidx]} ${sizes[$gidx]}
-                        exe_name=$(get_executable_name ${chk})
-                        flash_write ${offsets[$gidx]} ${OUTBIN_PATH}/${exe_name}
-                   fi
-                done
-                shift
-        done
-esac
-
+function board_erase()
+{
+	flash_erase $2 $3
+}

--- a/build/configs/imxrt1050-evk/loadable_elf_apps/Make.defs
+++ b/build/configs/imxrt1050-evk/loadable_elf_apps/Make.defs
@@ -168,6 +168,6 @@ HOSTCFLAGS = -Wall -Wstrict-prototypes -Wshadow -Wundef -g -pipe
 HOSTLDFLAGS =
 
 define DOWNLOAD
-  $(TOPDIR)/../build/configs/$(CONFIG_ARCH_BOARD)/$(CONFIG_ARCH_BOARD)_download.sh $(1) $(2) $(3) $(4) $(5) $(6)
+  $(TOPDIR)/../build/configs/common_download.sh $(1) $(2) $(3) $(4) $(5) $(6)
 endef
 

--- a/build/configs/imxrt1050-evk/tc/Make.defs
+++ b/build/configs/imxrt1050-evk/tc/Make.defs
@@ -107,6 +107,6 @@ HOSTCFLAGS = -Wall -Wstrict-prototypes -Wshadow -Wundef -g -pipe
 HOSTLDFLAGS =
 
 define DOWNLOAD
-  $(TOPDIR)/../build/configs/$(CONFIG_ARCH_BOARD)/$(CONFIG_ARCH_BOARD)_download.sh $(1) $(2) $(3) $(4) $(5) $(6)
+  $(TOPDIR)/../build/configs/common_download.sh $(1) $(2) $(3) $(4) $(5) $(6)
 endef
 

--- a/build/configs/rtl8721csm/.flashSpec.xml
+++ b/build/configs/rtl8721csm/.flashSpec.xml
@@ -21,8 +21,8 @@
     </executors>
     <options>
         <option desc="Flash all binaries and images">ALL</option>
-        <option desc="Flash TizenRT km0 bootloader">KM0_BL</option>
-        <option desc="Flash TizenRT km4 bootloader">KM4_BL</option>
+        <option desc="Flash TizenRT km0 bootloader">BL1</option>
+        <option desc="Flash TizenRT km4 bootloader">BL2</option>
         <option desc="Flash TizenRT kernel">KERNEL</option>
         <option desc="Flash TizenRT userfs">USERFS</option>
         <option desc="Flash TizenRT ota">OTA</option>

--- a/build/configs/rtl8721csm/board_metadata.txt
+++ b/build/configs/rtl8721csm/board_metadata.txt
@@ -1,0 +1,30 @@
+###########################################################################
+#
+# Copyright 2021 Samsung Electronics All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+#
+###########################################################################
+# board_metadata.txt
+
+BOARD="RTL8721CSM"
+
+DEFAULT_PORT="ttyUSB1"
+
+BL1="km0_boot_all"
+BL2="km4_boot_all"
+KERNEL="km0_km4_image2"
+OTA="km0_km4_image2"
+BOOTPARAM="bootparam"
+
+FLASH_START_ADDR=0x08000000

--- a/build/configs/rtl8721csm/hello/Make.defs
+++ b/build/configs/rtl8721csm/hello/Make.defs
@@ -224,5 +224,5 @@ define MAKE_BOOTPARAM
 endef
 
 define DOWNLOAD
-  $(TOPDIR)/../build/configs/rtl8721csm/rtl8721csm_download.sh $(1) $(2) $(3) $(4) $(5) $(6)
+  $(TOPDIR)/../build/configs/common_download.sh $(1) $(2) $(3) $(4) $(5) $(6)
 endef

--- a/build/configs/rtl8721csm/hello/defconfig
+++ b/build/configs/rtl8721csm/hello/defconfig
@@ -245,7 +245,7 @@ CONFIG_ARCH_BOARD_HAVE_FLASH=y
 CONFIG_FLASH_PARTITION=y
 CONFIG_FLASH_PART_SIZE="16,8,16,472,8,1792,1792,4080,8,"
 CONFIG_FLASH_PART_TYPE="none,none,none,none,none,kernel,kernel,smartfs,bootparam,"
-CONFIG_FLASH_PART_NAME="km0_bl,km4_bl,reserved,ss,system_data,kernel,kernel,userfs,bootparam,"
+CONFIG_FLASH_PART_NAME="bl1,bl2,reserved,ss,system_data,kernel,kernel,userfs,bootparam,"
 # CONFIG_ARCH_BOARD_HAVE_SECOND_FLASH is not set
 CONFIG_AUTOMOUNT=y
 CONFIG_AUTOMOUNT_USERFS=y

--- a/build/configs/rtl8721csm/loadable_apps/Make.defs
+++ b/build/configs/rtl8721csm/loadable_apps/Make.defs
@@ -236,5 +236,5 @@ define MAKE_BOOTPARAM
 endef
 
 define DOWNLOAD
-  $(TOPDIR)/../build/configs/rtl8721csm/rtl8721csm_download.sh $(1) $(2) $(3) $(4) $(5) $(6)
+  $(TOPDIR)/../build/configs/common_download.sh $(1) $(2) $(3) $(4) $(5) $(6)
 endef

--- a/build/configs/rtl8721csm/loadable_apps/defconfig
+++ b/build/configs/rtl8721csm/loadable_apps/defconfig
@@ -250,7 +250,7 @@ CONFIG_ARCH_BOARD_HAVE_FLASH=y
 CONFIG_FLASH_PARTITION=y
 CONFIG_FLASH_PART_SIZE="16,8,16,472,8,1792,1792,4080,8,"
 CONFIG_FLASH_PART_TYPE="none,none,none,none,none,kernel,kernel,smartfs,bootparam,"
-CONFIG_FLASH_PART_NAME="km0_bl,km4_bl,reserved,ss,system_data,kernel,kernel,userfs,bootparam,"
+CONFIG_FLASH_PART_NAME="bl1,bl2,reserved,ss,system_data,kernel,kernel,userfs,bootparam,"
 # CONFIG_ARCH_BOARD_HAVE_SECOND_FLASH is not set
 CONFIG_AUTOMOUNT=y
 CONFIG_AUTOMOUNT_USERFS=y

--- a/build/configs/rtl8721csm/nettest/Make.defs
+++ b/build/configs/rtl8721csm/nettest/Make.defs
@@ -197,5 +197,5 @@ define MAKE_BOOTPARAM
 endef
 
 define DOWNLOAD
-  $(TOPDIR)/../build/configs/rtl8721csm/rtl8721csm_download.sh $(1) $(2) $(3) $(4) $(5) $(6)
+  $(TOPDIR)/../build/configs/common_download.sh $(1) $(2) $(3) $(4) $(5) $(6)
 endef

--- a/build/configs/rtl8721csm/nettest/defconfig
+++ b/build/configs/rtl8721csm/nettest/defconfig
@@ -241,7 +241,7 @@ CONFIG_ARCH_BOARD_HAVE_FLASH=y
 CONFIG_FLASH_PARTITION=y
 CONFIG_FLASH_PART_SIZE="16,8,16,472,8,1792,1792,4080,8,"
 CONFIG_FLASH_PART_TYPE="none,none,none,none,none,kernel,kernel,smartfs,bootparam,"
-CONFIG_FLASH_PART_NAME="km0_bl,km4_bl,reserved,ss,system_data,kernel,kernel,userfs,bootparam,"
+CONFIG_FLASH_PART_NAME="bl1,bl2,reserved,ss,system_data,kernel,kernel,userfs,bootparam,"
 # CONFIG_ARCH_BOARD_HAVE_SECOND_FLASH is not set
 CONFIG_AUTOMOUNT=y
 CONFIG_AUTOMOUNT_USERFS=y

--- a/build/configs/rtl8721csm/rdp/Make.defs
+++ b/build/configs/rtl8721csm/rdp/Make.defs
@@ -225,5 +225,5 @@ define MAKE_BOOTPARAM
 endef
 
 define DOWNLOAD
-  $(TOPDIR)/../build/configs/rtl8721csm/rtl8721csm_download.sh $(1) $(2) $(3) $(4) $(5) $(6)
+  $(TOPDIR)/../build/configs/common_download.sh $(1) $(2) $(3) $(4) $(5) $(6)
 endef

--- a/build/configs/rtl8721csm/rdp/defconfig
+++ b/build/configs/rtl8721csm/rdp/defconfig
@@ -241,7 +241,7 @@ CONFIG_ARCH_BOARD_HAVE_FLASH=y
 CONFIG_FLASH_PARTITION=y
 CONFIG_FLASH_PART_SIZE="16,8,16,472,8,1792,1792,4080,8,"
 CONFIG_FLASH_PART_TYPE="none,none,none,none,none,kernel,kernel,smartfs,bootparam,"
-CONFIG_FLASH_PART_NAME="km0_bl,km4_bl,reserved,ss,system_data,kernel,kernel,userfs,bootparam,"
+CONFIG_FLASH_PART_NAME="bl1,bl2,reserved,ss,system_data,kernel,kernel,userfs,bootparam,"
 # CONFIG_ARCH_BOARD_HAVE_SECOND_FLASH is not set
 CONFIG_AUTOMOUNT=y
 CONFIG_AUTOMOUNT_USERFS=y

--- a/build/configs/rtl8721csm/rtl8721csm_download.sh
+++ b/build/configs/rtl8721csm/rtl8721csm_download.sh
@@ -18,143 +18,11 @@
 ###########################################################################
 # rtl8721csm_download.sh
 
-## For manual port selection, set $3 as the portname, eg. make download ALL x ttyUSB2
-if [ -n "$3" ]; then
-	PORT="$3"
-else
-	PORT="ttyUSB1"
-fi
-
-WARNING="\n Port $PORT is selected\n\n
-	############################################\n
-	WARNINGS:\n
-	1. Make sure the board is in DOWNLOAD MODE.\n
-	2. Make sure NO other application like putty,\n
-	is occupying $PORT.\n
-	############################################\n"
-
-echo -e $WARNING
-
-CURDIR=$(readlink -f "$0")
-CUR_PATH=$(dirname "$CURDIR")
-TOOL_PATH=${CUR_PATH}/../../tools/amebad
+TOOL_PATH=${TOP_PATH}/build/tools/amebad
 IMG_TOOL_PATH=${TOOL_PATH}/image_tool
-BIN_PATH=${CUR_PATH}/../../output/bin
-TOP_PATH=${CUR_PATH}/../../..
-OS_PATH=${TOP_PATH}/os
-SMARTFS_BIN_PATH=${BIN_PATH}/rtl8721csm_smartfs.bin
-FLASH_START_ADDR=0x08000000
 
-TTYDEV="/dev/${PORT}"
-CONFIG=${OS_PATH}/.config
-source ${CONFIG}
-
-##Utility function for sanity check##
-function rtl8721csm_sanity_check()
+function pre_download()
 {
-	if [ ! -f ${CONFIG} ];then
-		echo "No .config file"
-		exit 1
-	fi
-
-	if [[ "${CONFIG_ARCH_BOARD_RTL8721CSM}" != "y" ]];then
-		echo "Target is NOT RTL8721CSM"
-		exit 1
-	fi
-
-	if fuser -s ${TTYDEV};then
-		echo "${TTYDEV} is used by another process, can't proceed"
-		exit 1
-	fi
-}
-
-##Utility function to match partition name to binary name##
-function get_executable_name()
-{
-	case $1 in
-		km0_bl) echo "km0_boot_all.bin";;
-		km4_bl) echo "km4_boot_all.bin";;
-		kernel|ota) echo "km0_km4_image2.bin";;
-		bootparam) echo "bootparam.bin";;
-		userfs) echo "rtl8721csm_smartfs.bin";;
-		*) echo "No Binary Match"
-		exit 1
-	esac
-}
-flash_ota=false
-##Utility function to get partition index ##
-function get_partition_index()
-{
-	for idx in ${!parts[@]}; do
-		if [[ ${parts[$idx],,} == ${1,,} ]]; then
-			if [[ $flash_ota == true ]]; then
-				## In this case, try to find 2nd kernel partition for OTA
-				flash_ota=false
-				continue;
-			fi
-			echo $idx
-			exit 1
-		fi
-	done
-	echo -1
-}
-
-##Help utility##
-function rtl8721csm_dwld_help()
-{
-        cat <<EOF
-	HELP:
-		make download ALL or [PARTITION(S)]
-		make download ERASE ALL or erase [PARTITION(S)]
-
-	PARTITION(S):
-		[${uniq_parts[@]}]  NOTE:case sensitive
-
-	For examples:
-		make download ALL
-		make download ERASE ALL
-		make download kernel
-		make download erase kernel
-		make download ota
-		make download erase ota
-		make download erase ss
-		make download smartfs
-		make download erase userfs
-EOF
-}
-
-##Utility function to read partitions from .config or Kconfig##
-function get_configured_partitions()
-{
-	local configured_parts
-	# Read Partitions
-	if [[ -z ${CONFIG_FLASH_PART_NAME} ]];then
-
-		configured_parts=`grep -A 2 'config FLASH_PART_NAME' ${PARTITION_KCONFIG} | sed -n 's/\tdefault "\(.*\)".*/\1/p'`
-	else
-		configured_parts=${CONFIG_FLASH_PART_NAME}
-	fi
-
-	echo $configured_parts
-}
-
-##Utility function to get the partition sizes from .config or Kconfig
-function get_partition_sizes()
-{
-	local sizes_str
-	#Read Partition Sizes
-	if [[ -z ${CONFIG_FLASH_PART_SIZE} ]]
-	then
-		sizes_str=`grep -A 2 'config FLASH_PART_SIZE' ${PARTITION_KCONFIG} | sed -n 's/\tdefault "\(.*\)".*/\1/p'`
-	else
-		sizes_str=${CONFIG_FLASH_PART_SIZE}
-	fi
-
-	echo $sizes_str
-}
-
-# Start here
-
 cp -p ${BIN_PATH}/km0_boot_all.bin ${IMG_TOOL_PATH}/km0_boot_all.bin
 cp -p ${BIN_PATH}/km4_boot_all.bin ${IMG_TOOL_PATH}/km4_boot_all.bin
 cp -p ${BIN_PATH}/km0_km4_image2.bin ${IMG_TOOL_PATH}/km0_km4_image2.bin
@@ -162,224 +30,34 @@ cp -p ${BIN_PATH}/bootparam.bin ${IMG_TOOL_PATH}/bootparam.bin
 if test -f "${SMARTFS_BIN_PATH}"; then
 	cp -p ${BIN_PATH}/rtl8721csm_smartfs.bin ${IMG_TOOL_PATH}/rtl8721csm_smartfs.bin
 fi
+cp -p ${BIN_PATH}/bootparam.bin ${IMG_TOOL_PATH}/bootparam.bin
+}
 
-rtl8721csm_sanity_check;
 
-parts=$(get_configured_partitions)
-IFS=',' read -ra parts <<< "$parts"
-
-sizes=$(get_partition_sizes)
-IFS=',' read -ra sizes <<< "$sizes"
-
-#Calculate Flash Offset
-num=${#sizes[@]}
-offsets[0]=`printf "0x%X" ${FLASH_START_ADDR}`
-
-for (( i=1; i<=$num-1; i++ ))
-do
-	val=$((sizes[$i-1] * 1024))
-	offsets[$i]=`printf "0x%X" $((offsets[$i-1] + ${val}))`
-done
-
-#Dump Info
-echo ""
-echo "================================ < Flash Partition Information > ================================"
-printf "\rNAME       :"
-printf '  %12s' "${parts[@]}"
-printf "\r\nSIZE(in KB):"
-printf '  %12s' "${sizes[@]}"
-printf "\r\nAddr       :"
-printf '  %12s' "${offsets[@]}"
-printf "\n"
-echo "================================================================================================="
-echo ""
-
-if test $# -eq 0; then
-	echo "FAIL!! NO Given partition. Refer \"PARTITION NAMES\" above."
-	rtl8721csm_dwld_help 1>&2
-	exit 1
-fi
-
-uniq_parts=($(printf "%s\n" "${parts[@]}" | sort -u));
-
-#Validate arguments
-for i in ${cmd_args[@]};do
-
-	if [[ "${i}" == "ALL" ]];then
-		continue;
-	fi
-
-	for j in ${uniq_parts[@]};do
-		if [[ "${i}" == "${j}" ]];then
-			result=yes
-		fi
-	done
-
-	if [[ "$result" != "yes" ]];then
-		echo "FAIL!! Given \"${i}\" partition is not available. Refer \"PARTITION NAMES\" above."
-		rtl8721csm_dwld_help
-		exit 1
-	fi
-	result=no
-done
-
-download_specific_partition()
+function board_download()
 {
 	cd ${IMG_TOOL_PATH}
-	TARGET=$1
-	if [[ ${TARGET} == "ota" || ${TARGET} == "OTA" ]];then
-		TARGET="kernel"
-		flash_ota=true
-	fi
-	partidx=$(get_partition_index ${TARGET})
-	if [[ "${partidx}" < 0 ]];then
-		echo "Not supported"
-		rtl8721csm_dwld_help
-		exit 1
-	fi
-
-	# Get a filename and Download a file
-	echo ""
-	echo "============================="
-	if [[ $1 == "ota" || $1 == "OTA" ]];then
-		echo "Downloading Kernel OTA binary"
+	if [ ! -f ${IMG_TOOL_PATH}/$3 ];then
+		echo "$3 not present"
 	else
-		echo "Downloading ${parts[$partidx]} binary"
+		./amebad_image_tool "download" $1 1 $2 $3
 	fi
-	echo "============================="
-	exe_name=$(get_executable_name ${parts[$partidx]})
-	./amebad_image_tool "download" $TTYDEV 1 ${offsets[$partidx]} ${exe_name}
-
-	echo ""
-	echo "Download $exe_name COMPLETE!"
 }
 
-download_all()
+function board_erase()
 {
 	cd ${IMG_TOOL_PATH}
-	echo "Starting Download..."
-	found_kernel=false
-
-	for partidx in ${!parts[@]}; do
-
-		if [[ "${CONFIG_APP_BINARY_SEPARATION}" != "y" ]];then
-			if [[ "${parts[$partidx]}" == "userfs" ]];then
-				continue
-			fi
-		fi
-
-		if [[ "${parts[$partidx]}" == "kernel" ]];then
-			if [[ $found_kernel == true ]];then
-				continue
-			fi
-			found_kernel=true
-		fi
-
-		exe_name=$(get_executable_name ${parts[$partidx]})
-		[ "No Binary Match" = "${exe_name}" ] && continue
-
-		echo ""
-		echo "=========================="
-		echo "Downloading ${parts[$partidx]} binary"
-		echo "=========================="
-
-		./amebad_image_tool "download" $TTYDEV 1 ${offsets[$partidx]} ${exe_name}
-	done
-	echo ""
-	echo "Download COMPLETE!"
+	./amebad_image_tool "erase" $1 1 $2 0 $3
 }
 
-erase()
+function post_download()
 {
 	cd ${IMG_TOOL_PATH}
-	echo "Starting Erase..."
-	ota_addr=$(($FLASH_START_ADDR + $CONFIG_AMEBAD_FLASH_CAPACITY))
-	if [[ $2 == "all" || $2 == "ALL" ]];then
-		found_kernel=false
-		flash_ota=false
-		echo ""
-		echo "=========================="
-		echo "      Erasing All"
-		echo "=========================="
-		for partidx in ${!parts[@]}; do
-			if [[ "${parts[$partidx]}" == "userfs" ]];then
-				continue
-			elif [[ "${parts[$partidx]}" == "ss" ]];then
-				continue
-			else
-				echo ""
-				echo "=========================="
-				echo "Erasing ${parts[$partidx]} partition"
-				echo "=========================="
-			fi
-
-			./amebad_image_tool "erase" $TTYDEV 1 ${offsets[$partidx]} 0 ${sizes[partidx]}
-		done
-	else
-		for partidx in ${!parts[@]}; do
-			if [[ $2 == "kernel" || $2 == "KERNEL" ]];then
-				if [[ "${parts[$partidx]}" != "kernel" ]];then
-					continue
-				elif [[ ${offsets[$partidx]} -lt ${ota_addr} ]];then
-					ota_addr=0
-					found_kernel=false
-				else
-					continue
-				fi
-			elif [[ $2 == "ota" || $2 == "OTA" ]];then
-				if [[ "${parts[$partidx]}" != "kernel" ]];then
-					continue
-				elif [[ ${offsets[$partidx]} -lt ${ota_addr} ]];then
-					ota_addr=${offsets[$partidx]}
-					continue
-				else
-					flash_ota=false
-				fi
-			elif [[ $2 == "ss" || $2 == "SS" ]];then
-				if [[ "${parts[$partidx]}" != "ss" ]];then
-					continue
-				fi
-			elif [[ $2 == "userfs" || $2 == "USERFS" ]];then
-				if [[ "${parts[$partidx]}" != "userfs" ]];then
-					continue
-				fi
-			else
-				printf "\n## Invalid Option ##\n\n"
-				rtl8721csm_dwld_help
-				break
-			fi
-
-			echo ""
-			echo "=========================="
-			echo "Erasing ${parts[$partidx]} partition"
-			echo "=========================="
-			./amebad_image_tool "erase" $TTYDEV 1 ${offsets[$partidx]} 0 ${sizes[partidx]}
-		done
+	[ -e ${BL1}.bin ] && rm ${BL1}.bin
+	[ -e ${BL2}.bin ] && rm ${BL2}.bin
+	[ -e ${KERNEL}.bin ] && rm ${KERNEL}.bin
+	if test -f "${SMARTFS_BIN_PATH}"; then
+		[ -e ${CONFIG_ARCH_BOARD}_smartfs.bin ] && rm ${CONFIG_ARCH_BOARD}_smartfs.bin
 	fi
-	echo ""
-	echo "Erase COMPLETE!"
+	[ -e ${BOOTPARAM}.bin ] && rm ${BOOTPARAM}.bin
 }
-
-case $1 in
-	all|ALL)
-		download_all
-		;;
-	erase|ERASE)
-		erase $1 $2
-		;;
-	kernel|KERNEL)
-		download_specific_partition $1
-		download_specific_partition "bootparam"
-		;;
-	*)
-		download_specific_partition $1
-		;;
-esac
-
-[ -e km0_boot_all.bin ] && rm km0_boot_all.bin
-[ -e km4_boot_all.bin ] && rm km4_boot_all.bin
-[ -e km0_km4_image2.bin ] && rm km0_km4_image2.bin
-[ -e bootparam.bin ] && rm bootparam.bin
-if test -f "${SMARTFS_BIN_PATH}"; then
-	[ -e rtl8721csm_smartfs.bin ] && rm rtl8721csm_smartfs.bin
-fi

--- a/build/configs/rtl8721csm/security_hal_test_tz/Make.defs
+++ b/build/configs/rtl8721csm/security_hal_test_tz/Make.defs
@@ -165,5 +165,5 @@ define MAKE_BOOTPARAM
 endef
 
 define DOWNLOAD
-  $(TOPDIR)/../build/configs/rtl8721csm/rtl8721csm_download.sh $(1) $(2) $(3) $(4) $(5) $(6)
+  $(TOPDIR)/../build/configs/common_download.sh $(1) $(2) $(3) $(4) $(5) $(6)
 endef

--- a/build/configs/rtl8721csm/security_hal_test_tz/defconfig
+++ b/build/configs/rtl8721csm/security_hal_test_tz/defconfig
@@ -241,7 +241,7 @@ CONFIG_ARCH_BOARD_HAVE_FLASH=y
 CONFIG_FLASH_PARTITION=y
 CONFIG_FLASH_PART_SIZE="16,8,16,472,8,1792,1792,4080,8,"
 CONFIG_FLASH_PART_TYPE="none,none,none,none,none,kernel,kernel,smartfs,bootparam,"
-CONFIG_FLASH_PART_NAME="km0_bl,km4_bl,reserved,ss,system_data,kernel,kernel,userfs,bootparam,"
+CONFIG_FLASH_PART_NAME="bl1,bl2,reserved,ss,system_data,kernel,kernel,userfs,bootparam,"
 # CONFIG_ARCH_BOARD_HAVE_SECOND_FLASH is not set
 CONFIG_AUTOMOUNT=y
 CONFIG_AUTOMOUNT_USERFS=y

--- a/build/configs/rtl8721csm/tc/Make.defs
+++ b/build/configs/rtl8721csm/tc/Make.defs
@@ -224,5 +224,5 @@ define MAKE_BOOTPARAM
 endef
 
 define DOWNLOAD
-  $(TOPDIR)/../build/configs/rtl8721csm/rtl8721csm_download.sh $(1) $(2) $(3) $(4) $(5) $(6)
+  $(TOPDIR)/../build/configs/rtl8721csm/common_download.sh $(1) $(2) $(3) $(4) $(5) $(6)
 endef

--- a/build/configs/rtl8721csm/tc/defconfig
+++ b/build/configs/rtl8721csm/tc/defconfig
@@ -241,7 +241,7 @@ CONFIG_ARCH_BOARD_HAVE_FLASH=y
 CONFIG_FLASH_PARTITION=y
 CONFIG_FLASH_PART_SIZE="16,8,16,472,8,1792,1792,4080,8,"
 CONFIG_FLASH_PART_TYPE="none,none,none,none,none,kernel,kernel,smartfs,bootparam,"
-CONFIG_FLASH_PART_NAME="km0_bl,km4_bl,reserved,ss,system_data,kernel,kernel,userfs,bootparam,"
+CONFIG_FLASH_PART_NAME="bl1,bl2,reserved,ss,system_data,kernel,kernel,userfs,bootparam,"
 # CONFIG_ARCH_BOARD_HAVE_SECOND_FLASH is not set
 CONFIG_AUTOMOUNT=y
 CONFIG_AUTOMOUNT_USERFS=y

--- a/build/configs/rtl8721csm/tls_test/Make.defs
+++ b/build/configs/rtl8721csm/tls_test/Make.defs
@@ -224,5 +224,5 @@ define MAKE_BOOTPARAM
 endef
 
 define DOWNLOAD
-  $(TOPDIR)/../build/configs/rtl8721csm/rtl8721csm_download.sh $(1) $(2) $(3) $(4) $(5) $(6)
+  $(TOPDIR)/../build/configs/common_download.sh $(1) $(2) $(3) $(4) $(5) $(6)
 endef

--- a/build/configs/rtl8721csm/tls_test/defconfig
+++ b/build/configs/rtl8721csm/tls_test/defconfig
@@ -246,7 +246,7 @@ CONFIG_ARCH_BOARD_HAVE_FLASH=y
 CONFIG_FLASH_PARTITION=y
 CONFIG_FLASH_PART_SIZE="16,8,16,472,8,1792,1792,4080,8,"
 CONFIG_FLASH_PART_TYPE="none,none,none,none,none,kernel,kernel,smartfs,bootparam,"
-CONFIG_FLASH_PART_NAME="km0_bl,km4_bl,reserved,ss,system_data,kernel,kernel,userfs,bootparam,"
+CONFIG_FLASH_PART_NAME="bl1,bl2,reserved,ss,system_data,kernel,kernel,userfs,bootparam,"
 # CONFIG_ARCH_BOARD_HAVE_SECOND_FLASH is not set
 CONFIG_AUTOMOUNT=y
 CONFIG_AUTOMOUNT_USERFS=y

--- a/os/Makefile.unix
+++ b/os/Makefile.unix
@@ -543,7 +543,11 @@ ifeq (download,$(firstword $(MAKECMDGOALS)))
 endif
 
 download:
-	$(Q) $(call DOWNLOAD, $(DOWNLOAD_ARGS))
+	$(Q) if [ -z ${port} ]; then \
+		$(call DOWNLOAD, $(DOWNLOAD_ARGS)) ; \
+	else \
+		$(call DOWNLOAD, port ${port} $(DOWNLOAD_ARGS)) ; \
+	fi
 
 ota_img:
 	$(Q) $(call OTA_IMG)


### PR DESCRIPTION
- The download scripts have common code for parsing flash partitions, calculating offsets, parsing the arguments.
- Added common_download.sh under build/configs. The above mentioned common code is shifted to common_download.sh
- Under build/configs/board we have board specific functions like flash write, erase etc.