### PR TITLE
apps/system/utils: Fix build error of killall command about functions in utils_proc.c

### DIFF
--- a/apps/system/utils/Makefile
+++ b/apps/system/utils/Makefile
@@ -165,6 +165,8 @@ else ifeq ($(CONFIG_ENABLE_STACKMONITOR),y)
 CSRCS += utils_proc.c
 else ifeq ($(CONFIG_ENABLE_HEAPINFO),y)
 CSRCS += utils_proc.c
+else ifeq ($(CONFIG_ENABLE_KILLALL),y)
+CSRCS += utils_proc.c
 endif
 
 AOBJS = $(ASRCS:.S=$(OBJEXT))


### PR DESCRIPTION
A killall command uses proc data with utils in utils_proc.c
So build utils_proc.c if a killall command is enabled.