### PR TITLE
os: Add missing .PHONY definitions

### DIFF
--- a/os/crypto/Makefile
+++ b/os/crypto/Makefile
@@ -51,6 +51,7 @@ OBJS = $(AOBJS) $(COBJS)
 BIN = libcrypto$(LIBEXT)
 
 all: $(BIN)
+.PHONY: depend clean distclean
 
 $(AOBJS): %$(OBJEXT): %.S
 	$(call ASSEMBLE, $<, $@)

--- a/os/drivers/Makefile
+++ b/os/drivers/Makefile
@@ -146,6 +146,7 @@ OBJS = $(AOBJS) $(COBJS)
 BIN = libdrivers$(LIBEXT)
 
 all: $(BIN)
+.PHONY: depend clean distclean
 
 $(AOBJS): %$(OBJEXT): %.S
 	$(call ASSEMBLE, $<, $@)

--- a/os/fs/Makefile
+++ b/os/fs/Makefile
@@ -95,6 +95,7 @@ BIN = libfs$(LIBEXT)
 
 
 all: $(BIN)
+.PHONY: depend clean distclean
 
 $(AOBJS): %$(OBJEXT): %.S
 	$(call ASSEMBLE, $<, $@)

--- a/os/logm/Makefile
+++ b/os/logm/Makefile
@@ -42,6 +42,7 @@ OBJS = $(AOBJS) $(COBJS)
 BIN = liblogm$(LIBEXT)
 
 all: $(BIN)
+.PHONY: depend clean distclean
 
 $(AOBJS): %$(OBJEXT): %.S
 	$(call ASSEMBLE, $<, $(notdir $@))

--- a/os/net/Makefile
+++ b/os/net/Makefile
@@ -134,6 +134,7 @@ OBJS		= $(AOBJS) $(COBJS)
 BIN		= libnet$(LIBEXT)
 
 all:	$(BIN)
+.PHONY: depend clean distclean
 
 $(AOBJS): %$(OBJEXT): %.S
 	$(call ASSEMBLE, $<, $@)

--- a/os/pm/Makefile
+++ b/os/pm/Makefile
@@ -59,6 +59,7 @@ BIN = libpm$(LIBEXT)
 
 
 all: $(BIN)
+.PHONY: depend clean distclean
 
 $(AOBJS): %$(OBJEXT): %.S
 	$(call ASSEMBLE, $<, $@)


### PR DESCRIPTION
Add .PHONY definitions to prevent 'clean up to date' message weirdness when 'make clean' is done with no .config or
Make.defs file.

Signed-off-by: Sangamanatha <sangam.swami@samsung.com>