### PR TITLE
arch/arm/amebad_reboot_reason : Move up_reboot_reason_init() into up_…

### DIFF
--- a/os/arch/arm/src/common/up_initialize.c
+++ b/os/arch/arm/src/common/up_initialize.c
@@ -68,6 +68,10 @@
 
 #include <arch/board/board.h>
 
+#ifdef CONFIG_SYSTEM_REBOOT_REASON
+#include <arch/reboot_reason.h>
+#endif
+
 #include "up_arch.h"
 #include "up_internal.h"
 
@@ -164,6 +168,11 @@ void up_initialize(void)
 	/* Initialize global variables */
 
 	current_regs = NULL;
+
+#ifdef CONFIG_SYSTEM_REBOOT_REASON
+	up_reboot_reason_init();
+	lldbg("[Reboot Reason] : %d\n", up_reboot_reason_read());
+#endif
 
 	/* Calibrate the timing loop */
 

--- a/os/board/rtl8721csm/src/rtl8721csm_boot.c
+++ b/os/board/rtl8721csm/src/rtl8721csm_boot.c
@@ -67,9 +67,6 @@
 #include <tinyara/fs/mtd.h>
 #endif
 #include <arch/board/board.h>
-#ifdef CONFIG_SYSTEM_REBOOT_REASON
-#include <arch/reboot_reason.h>
-#endif
 #include "gpio_api.h"
 #include "timer_api.h"
 #ifdef CONFIG_FLASH_PARTITION
@@ -233,10 +230,6 @@ void board_initialize(void)
 		wifi_config.wifi_app_ctrl_tdma == FALSE) {
 		SystemSetCpuClk(CLK_KM4_100M);
 	}
-
-#ifdef CONFIG_SYSTEM_REBOOT_REASON
-	up_reboot_reason_init();
-#endif
 
 	InterruptRegister(IPC_INTHandler, IPC_IRQ, (u32)IPCM0_DEV, 5);
 	InterruptEn(IPC_IRQ, 5);


### PR DESCRIPTION
…initialize()

1. Move up_reboot_reason_init() into up_initialize()
2. Add log about previous reboot reason
3. Change to update the previous reboot reason when initializing the reboot reason, not reading the reason.