### PR TITLE
os/board/rtl8721csm: Disable all rtl8721csm BLE debug function by default

### DIFF
--- a/os/arch/arm/src/amebad/Kconfig
+++ b/os/arch/arm/src/amebad/Kconfig
@@ -73,6 +73,10 @@ config FTL_ENABLED
 	bool "Enable FTL"
 	default n
 
+config AMEBAD_BLE_DEBUG
+	bool "Enable BLE Debug"
+	default n
+
 config AMEBAD_BLE_PERIPHERAL
 	bool "Enable Amebad BLE Peripheral"
 	default n

--- a/os/board/rtl8721csm/src/component/common/bluetooth/realtek/sdk/inc/bt_board.h
+++ b/os/board/rtl8721csm/src/component/common/bluetooth/realtek/sdk/inc/bt_board.h
@@ -79,7 +79,11 @@ extern "C" {
 #define EFUSE_SW_DRIVER_DEBUG_LOG    BIT6
 #define EFUSE_SW_RSVD2               BIT7
 
+#ifdef CONFIG_AMEBAD_BLE_DEBUG
 #define CHECK_SW(x)                  (HAL_READ32(SPI_FLASH_BASE, FLASH_SYSTEM_DATA_ADDR + 0x28) & x)
+#else
+#define CHECK_SW(x)                  1
+#endif
 
 extern uint8_t rltk_wlan_is_mp(void);
 


### PR DESCRIPTION
- Disable flash bit check to disable all BLE debug function