### PR TITLE
Makefile.unix : call check_output_size.py when CONFIG_FLASH_PARTITION is enabled

### DIFF
--- a/os/Makefile.unix
+++ b/os/Makefile.unix
@@ -494,7 +494,9 @@ post:
 	$(Q) echo "Start the Board Specific Work for Binary"
 	$(Q) $(call MAKE_BOARD_SPECIFIC_BIN, $(BIN_EXE), $(BIN_EXT))
 	$(Q) $(call MAKE_SAMSUNG_HEADER, $(BIN_EXE), $(BIN_EXT))
+ifeq ($(CONFIG_FLASH_PARTITION),y)
 	$(Q) python ./tools/check_output_size.py
+endif
 	$(Q) $(call MAKE_BOOTPARAM)
 
 ifeq ($(CONFIG_UBOOT_UIMAGE),y)


### PR DESCRIPTION
check_output_size.py only works when CONFIG_FLASH_PARTITION is enabled, because it uses FLASH_PART_NAME and FLASH_PART_SIZE.