### PR TITLE
configs/rtl8721csm/tc : Correct the path to common_download.sh.

### DIFF
--- a/build/configs/rtl8721csm/tc/Make.defs
+++ b/build/configs/rtl8721csm/tc/Make.defs
@@ -224,5 +224,5 @@ define MAKE_BOOTPARAM
 endef
 
 define DOWNLOAD
-  $(TOPDIR)/../build/configs/rtl8721csm/common_download.sh $(1) $(2) $(3) $(4) $(5) $(6)
+  $(TOPDIR)/../build/configs/common_download.sh $(1) $(2) $(3) $(4) $(5) $(6)
 endef


### PR DESCRIPTION
- Correct the path to common_download.sh in rtl8721csm/tc/Make.defs.

Signed-off-by: Abhishek Akkabathula <a.akkabathul@samsung.com>