### PR TITLE
wqueue : Modify to get hpwork, lpwork and usrwork from each getXXX APIs

### DIFF
--- a/os/wqueue/kwqueue/kwork_cancel.c
+++ b/os/wqueue/kwqueue/kwork_cancel.c
@@ -115,15 +115,15 @@ int work_cancel(int qid, FAR struct work_s *work)
 #ifdef CONFIG_SCHED_HPWORK
 	if (qid == HPWORK) {
 		/* Cancel high priority work */
-
-		return work_qcancel((FAR struct wqueue_s *)&g_hpwork, work);
+		struct hp_wqueue_s *hwq = get_hpwork();
+		return work_qcancel((FAR struct wqueue_s *)hwq, work);
 	} else
 #endif
 #ifdef CONFIG_SCHED_LPWORK
 		if (qid == LPWORK) {
 			/* Cancel low priority work */
-
-			return work_qcancel((FAR struct wqueue_s *)&g_lpwork, work);
+			struct lp_wqueue_s *lwq = get_lpwork();
+			return work_qcancel((FAR struct wqueue_s *)lwq, work);
 		} else
 #endif
 		{

--- a/os/wqueue/kwqueue/kwork_hpthread.c
+++ b/os/wqueue/kwqueue/kwork_hpthread.c
@@ -81,7 +81,7 @@
 
 /* The state of the kernel mode, high priority work queue. */
 
-struct hp_wqueue_s g_hpwork;
+static struct hp_wqueue_s g_hpwork;
 
 /****************************************************************************
  * Private Data
@@ -151,6 +151,11 @@ static int work_hpthread(int argc, char *argv[])
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
+
+struct hp_wqueue_s *get_hpwork(void)
+{
+	return &g_hpwork;
+}
 
 /****************************************************************************
  * Name: work_hpstart

--- a/os/wqueue/kwqueue/kwork_inherit.c
+++ b/os/wqueue/kwqueue/kwork_inherit.c
@@ -333,8 +333,9 @@ void lpwork_boostpriority(uint8_t reqprio)
 
 	/* Adjust the priority of every worker thread */
 
+	struct lp_wqueue_s *lwq = get_lpwork();
 	for (wndx = 0; wndx < CONFIG_SCHED_LPNTHREADS; wndx++) {
-		lpwork_boostworker(g_lpwork.worker[wndx].pid, reqprio);
+		lpwork_boostworker(lwq->worker[wndx].pid, reqprio);
 	}
 
 	sched_unlock();
@@ -377,8 +378,9 @@ void lpwork_restorepriority(uint8_t reqprio)
 
 	/* Adjust the priority of every worker thread */
 
+	struct lp_wqueue_s *lwq = get_lpwork();
 	for (wndx = 0; wndx < CONFIG_SCHED_LPNTHREADS; wndx++) {
-		lpwork_restoreworker(g_lpwork.worker[wndx].pid, reqprio);
+		lpwork_restoreworker(lwq->worker[wndx].pid, reqprio);
 	}
 
 	sched_unlock();

--- a/os/wqueue/kwqueue/kwork_queue.c
+++ b/os/wqueue/kwqueue/kwork_queue.c
@@ -130,7 +130,8 @@ int work_queue(int qid, FAR struct work_s *work, worker_t worker, FAR void *arg,
 	if (qid == HPWORK) {
 		/* Cancel high priority work */
 
-		result = work_qqueue((FAR struct wqueue_s *)&g_hpwork, work, worker, arg, delay);
+		struct hp_wqueue_s *hwq = get_hpwork();
+		result = work_qqueue((FAR struct wqueue_s *)hwq, work, worker, arg, delay);
 		if (result != OK) {
 			return result;
 		}
@@ -141,7 +142,8 @@ int work_queue(int qid, FAR struct work_s *work, worker_t worker, FAR void *arg,
 		if (qid == LPWORK) {
 			/* Cancel low priority work */
 
-			result = work_qqueue((FAR struct wqueue_s *)&g_lpwork, work, worker, arg, delay);
+			struct lp_wqueue_s *lwq = get_lpwork();
+			result = work_qqueue((FAR struct wqueue_s *)lwq, work, worker, arg, delay);
 			if (result != OK) {
 				return result;
 			}

--- a/os/wqueue/kwqueue/kwork_signal.c
+++ b/os/wqueue/kwqueue/kwork_signal.c
@@ -54,20 +54,22 @@ int work_signal(int qid)
 	/* Get the process ID of the worker thread */
 #ifdef CONFIG_SCHED_HPWORK
 	if (qid == HPWORK) {
-		pid = g_hpwork.worker[0].pid;
+		struct hp_wqueue_s *hwq = get_hpwork();
+		pid = hwq->worker[0].pid;
 	} else
 #endif
 #ifdef CONFIG_SCHED_LPWORK
 	if (qid == LPWORK) {
 		int wndx;
 		int i;
+		struct lp_wqueue_s *lwq = get_lpwork();
 
 		/* Find an IDLE worker thread */
 
 		for (wndx = 0, i = 0; i < CONFIG_SCHED_LPNTHREADS; i++) {
 			/* Is this worker thread busy? */
 
-			if (!g_lpwork.worker[i].busy) {
+			if (!lwq->worker[i].busy) {
 				/* No.. select this thread */
 
 				wndx = i;
@@ -79,7 +81,7 @@ int work_signal(int qid)
 			* thread 0 if all of the worker threads are busy).
 			*/
 
-		pid = g_lpwork.worker[wndx].pid;
+		pid = lwq->worker[wndx].pid;
 	} else
 #endif
 	{

--- a/os/wqueue/uwqueue/uwork_cancel.c
+++ b/os/wqueue/uwqueue/uwork_cancel.c
@@ -113,7 +113,8 @@
 int work_cancel(int qid, FAR struct work_s *work)
 {
 	if (qid == USRWORK) {
-		return work_qcancel(&g_usrwork, work);
+		struct wqueue_s *usrwq = get_usrwork();
+		return work_qcancel(usrwq, work);
 	} else {
 		return -EINVAL;
 	}

--- a/os/wqueue/uwqueue/uwork_lock.c
+++ b/os/wqueue/uwqueue/uwork_lock.c
@@ -109,13 +109,15 @@ int work_lock(void)
 {
 	int ret;
 #ifdef CONFIG_BUILD_PROTECTED
-	ret = sem_wait(&g_usrsem);
+	sem_t *usrsem = get_usrsem();
+	ret = sem_wait(usrsem);
 	if (ret < 0) {
 		DEBUGASSERT(errno == EINTR);
 		return -EINTR;
 	}
 #else
-	ret = pthread_mutex_lock(&g_usrmutex);
+	pthread_mutex_t *usrmutex = get_usrmutex();
+	ret = pthread_mutex_lock(usrmutex);
 	if (ret != 0) {
 		DEBUGASSERT(ret == EINTR);
 		return -EINTR;
@@ -141,8 +143,10 @@ int work_lock(void)
 void work_unlock(void)
 {
 #ifdef CONFIG_BUILD_PROTECTED
-	(void)sem_post(&g_usrsem);
+	sem_t *usrsem = get_usrsem();
+	(void)sem_post(usrsem);
 #else
-	(void)pthread_mutex_unlock(&g_usrmutex);
+	pthread_mutex_t *usrmutex = get_usrmutex();
+	(void)pthread_mutex_unlock(usrmutex);
 #endif
 }

--- a/os/wqueue/uwqueue/uwork_queue.c
+++ b/os/wqueue/uwqueue/uwork_queue.c
@@ -125,7 +125,8 @@ int work_queue(int qid, FAR struct work_s *work, worker_t worker, FAR void *arg,
 {
 	int ret;
 	if (qid == USRWORK) {
-		ret = work_qqueue(&g_usrwork, work, worker, arg, delay);
+		struct wqueue_s *usrwq = get_usrwork();
+		ret = work_qqueue(usrwq, work, worker, arg, delay);
 		if (ret != OK) {
 			return ret;
 		}

--- a/os/wqueue/uwqueue/uwork_signal.c
+++ b/os/wqueue/uwqueue/uwork_signal.c
@@ -55,7 +55,8 @@ int work_signal(int qid)
 	/* Get the process ID of the worker thread */
 
 	if (qid == USRWORK) {
-		pid = g_usrwork.worker[0].pid;
+		struct wqueue_s *usrwq = get_usrwork();
+		pid = usrwq->worker[0].pid;
 	} else {
 		return -EINVAL;
 	}

--- a/os/wqueue/wqueue.h
+++ b/os/wqueue/wqueue.h
@@ -123,26 +123,24 @@ struct lp_wqueue_s {
 
 /* The state of the user mode work queue */
 
-extern struct wqueue_s g_usrwork;
+struct wqueue_s *get_usrwork(void);
 
 #ifdef CONFIG_SCHED_HPWORK
-/* The state of the kernel mode, high priority work queue. */
-
-extern struct hp_wqueue_s g_hpwork;
+struct hp_wqueue_s *get_hpwork(void);
 #endif
 
 #ifdef CONFIG_SCHED_LPWORK
-/* The state of the kernel mode, low priority work queue(s). */
-
-extern struct lp_wqueue_s g_lpwork;
+struct lp_wqueue_s *get_lpwork(void); 
 #endif
 
 /* This semaphore/mutex supports exclusive access to the user-mode work queue */
 
+struct wqueue_s *get_usrwork(void);
+
 #ifdef CONFIG_BUILD_PROTECTED
-extern sem_t g_usrsem;
+sem_t *get_usrsem(void);
 #else
-extern pthread_mutex_t g_usrmutex;
+pthread_mutex_t *get_usrmutex(void);
 #endif
 
 /****************************************************************************


### PR DESCRIPTION
g_hpwork, g_lpwork, g_usrwork and g_usrsem/g_usrmutex are global variable, so it is not good to use directly.
So add getXXX APIs for each global variables.