### PR TITLE
network/netmgr: initialize allocated netif memory to 0

### DIFF
--- a/os/net/netmgr/netdev_lwip.c
+++ b/os/net/netmgr/netdev_lwip.c
@@ -782,7 +782,7 @@ static int lwip_init_nic(struct netdev *dev, struct nic_config *config)
 		return -1;
 	}
 
-	char *rnetif = (char *)kmm_malloc(sizeof(struct netif) + sizeof(struct netdev *));
+	char *rnetif = (char *)kmm_zalloc(sizeof(struct netif) + sizeof(struct netdev *));
 	if (!rnetif) {
 		return -1;
 	}


### PR DESCRIPTION
if it's not zero then some module(ex. dhcpc) can access invalid
address of netif which is not initialized.