### PR TITLE
dbuild: Trim white-space from hostname

### DIFF
--- a/os/dbuild.sh
+++ b/os/dbuild.sh
@@ -413,7 +413,7 @@ function BUILD()
 		DOCKER_OPT="-i"
 	fi
 
-	HOSTNAME="-h=`git config user.name`" # set github username instead of hostname, "-h=`hostname`"
+	HOSTNAME="-h=`git config user.name | tr -d ' '`" # set github username instead of hostname, "-h=`hostname`"
 	LOCALTIME="-v /etc/localtime:/etc/localtime:ro"
 	
 	DOCKER_IMAGES=`docker images | grep tizenrt/tizenrt | awk '{print $2}'`


### PR DESCRIPTION
A username of github is used for hostname.
Trim white-space from hostname for a case with spaces in the username.