### PR TITLE
framework/wifi_manager: Fix wrong event when mobile connect to softap

### DIFF
--- a/framework/src/wifi_manager/wifi_manager_event.c
+++ b/framework/src/wifi_manager/wifi_manager_event.c
@@ -41,9 +41,8 @@ static char *wifimgr_evt_str[] = {
 	"EVT_STA_DISCONNECTED",
 #ifndef CONFIG_WIFIMGR_DISABLE_DHCPS
 	"EVT_DHCPS_ASSIGN_IP",
-#else
-	"EVT_JOINED",
 #endif
+	"EVT_JOINED",
 	"EVT_LEFT",
 	"EVT_SCAN_DONE",
 	"EVT_NONE",
@@ -94,11 +93,9 @@ void _wifi_utils_disconnect_event(void *arg)
 
 void _wifi_utils_join_event(void *arg)
 {
-#ifdef CONFIG_WIFIMGR_DISABLE_DHCPS
 	WM_ENTER;
 	wifimgr_msg_s msg = {EVT_JOINED, WIFI_MANAGER_FAIL, NULL, NULL};
 	WIFIMGR_CHECK_RESULT_NORET(wifimgr_post_message(&msg), "[WM] handle join event fail\n");
-#endif
 	return;
 }
 

--- a/framework/src/wifi_manager/wifi_manager_event.h
+++ b/framework/src/wifi_manager/wifi_manager_event.h
@@ -36,9 +36,8 @@ enum _wifimgr_evt {
 	EVT_STA_DISCONNECTED,   // Event that external STA disconnected from WiFi AP
 #ifndef CONFIG_WIFIMGR_DISABLE_DHCPS
 	EVT_DHCPS_ASSIGN_IP,	// Event that SoftAP got IP address
-#else
-	EVT_JOINED,				// Event that new STA joined softAP
 #endif
+	EVT_JOINED,				// Event that new STA joined softAP
 	EVT_LEFT,				// Event that external STA device left softAP
 	EVT_SCAN_DONE,			// Event that WiFi scanning over WLAN channels is done
 	EVT_NONE,

--- a/framework/src/wifi_manager/wifi_manager_lwnl_listener.c
+++ b/framework/src/wifi_manager/wifi_manager_lwnl_listener.c
@@ -108,9 +108,7 @@ static int _lwnl_call_event(int fd, lwnl_cb_status status, int len)
 		LWNL_SET_MSG(&g_msg, EVT_STA_DISCONNECTED, WIFI_MANAGER_FAIL, NULL, NULL);
 		break;
 	case LWNL_SOFTAP_STA_JOINED:
-#ifdef CONFIG_WIFIMGR_DISABLE_DHCPS
 		LWNL_SET_MSG(&g_msg, EVT_JOINED, WIFI_MANAGER_FAIL, NULL, NULL);
-#endif
 		break;
 	case LWNL_SOFTAP_STA_LEFT:
 		LWNL_SET_MSG(&g_msg, EVT_LEFT, WIFI_MANAGER_FAIL, NULL, NULL);

--- a/framework/src/wifi_manager/wifi_manager_state.c
+++ b/framework/src/wifi_manager/wifi_manager_state.c
@@ -635,9 +635,8 @@ wifi_manager_result_e _handler_on_softap_state(wifimgr_msg_s *msg)
 		WIFIMGR_CHECK_RESULT(_wifimgr_scan((wifi_manager_ap_config_s *)msg->param), "fail scan", WIFI_MANAGER_FAIL);
 		WIFIMGR_STORE_PREV_STATE;
 		WIFIMGR_SET_STATE(WIFIMGR_SCANNING);
-#ifdef CONFIG_WIFIMGR_DISABLE_DHCPS
 	} else if (msg->event == EVT_JOINED) {
-#else
+#ifndef CONFIG_WIFIMGR_DISABLE_DHCPS
 	/* wifi manager passes the callback after the dhcp server gives a station an IP address*/
 	} else if (msg->event == EVT_DHCPS_ASSIGN_IP) {
 		if (dhcps_add_node((dhcp_node_s *)msg->param) == DHCP_EXIST) {


### PR DESCRIPTION
If CONFIG_WIFIMGR_DISABLE_DHCPS is not set, g_msg is not set with LWNL_SOFTAP_STA_JOINED.

Even though g_msg is not set and value of g_msg is previous one, wifimgr_message_out call wifimgr_handle_request.

It makes wrong event like EVT_STA_DISCONNECTED or EVT_LEFT when mobile connect to SoftAP.

By using EVT_JOINED regardless of CONFIG_WIFIMGR_DISABLE_DHCPS, it can be fixed.