### PR TITLE
board/common: Fix string comparison length for flash partition

### DIFF
--- a/os/board/common/partitions.c
+++ b/os/board/common/partitions.c
@@ -114,7 +114,7 @@ static int type_specific_initialize(FAR struct mtd_dev_s *mtd_part, int partno, 
 	}
 #endif
 #ifdef CONFIG_LIBC_ZONEINFO_ROMFS
-	else if (!strncmp(types, "timezone,", 10)) {
+	else if (!strncmp(types, "timezone,", 9)) {
 		do_ftlinit = true;
 		save_timezone_partno = true;
 	}


### PR DESCRIPTION
- "timezone," string of length 9 should be matched with incoming
  partition type string but strncmp checks for string of length 10.
- Hence, the partition types never match and timzeone romfs mounting
  never takes place.
- Change comparison length in strncmp for "timezone," from 10 to 9

Signed-off-by: Amogh Hassija <a.hassija@samsung.com>