### PR TITLE
os/arch/arm/src/amebad: Modify rtl8721d_up_txready function

### DIFF
--- a/os/arch/arm/src/amebad/amebad_serial.c
+++ b/os/arch/arm/src/amebad/amebad_serial.c
@@ -672,8 +672,7 @@ static bool rtl8721d_up_txready(struct uart_dev_s *dev)
 {
 	struct rtl8721d_up_dev_s *priv = (struct rtl8721d_up_dev_s *)dev->priv;
 	DEBUGASSERT(priv);
-	while (!serial_writable(sdrv[uart_index_get(priv->tx)])) ;
-	return true;
+	return (serial_writable(sdrv[uart_index_get(priv->tx)]));
 }
 
 /****************************************************************************


### PR DESCRIPTION
This modification is made to fix the uart data loss under the heavy load.