### PR TITLE
external/dhcpd_lwip: Fix pthread_create return check in dhcps

### DIFF
--- a/external/dhcpd/dhcpd_lwip.c
+++ b/external/dhcpd/dhcpd_lwip.c
@@ -332,7 +332,7 @@ int dhcp_server_start(char *intf, dhcp_sta_joined_cb dhcp_join_cb)
 		return ERROR;
 	}
 	ret = pthread_create(&g_dhcpd_tid, &attr, _dhcpd_join_handler, (void *)data);
-	if (ret < 0) {
+	if (ret != OK) {
 		free(data->intf);
 		free(data);
 		ndbg("dhcps create dhcp handler fail(%d) errno %d\n", ret, errno);


### PR DESCRIPTION
Fix pthread_create return check in dhcps and add detach