### PR TITLE
board/rtl8721csm/rtc_api.c : Remove unused local variable

### DIFF
--- a/os/board/rtl8721csm/src/component/common/mbed/targets/hal/rtl8721d/rtc_api.c
+++ b/os/board/rtl8721csm/src/component/common/mbed/targets/hal/rtl8721d/rtc_api.c
@@ -125,7 +125,6 @@ static void rtc_calculate_wday(int year, int mon, int mday, int* wday)
   */
 static void rtc_restore_timeinfo(void)
 {
-	u32 value;
 	int days_in_year;
 	RRAM_TypeDef* RRAM = ((RRAM_TypeDef *) RRAM_BASE);
 


### PR DESCRIPTION
Build warning : component/common/mbed/targets/hal/rtl8721d/rtc_api.c:128:6: warning: unused variable 'value' [-Wunused-variable]
  u32 value;