### PR TITLE
os/board/rtl8721csm : Enable driver to send deauth before auth packet

### DIFF
--- a/os/board/rtl8721csm/src/component/common/api/wifi/wifi_conf.c
+++ b/os/board/rtl8721csm/src/component/common/api/wifi/wifi_conf.c
@@ -1272,6 +1272,11 @@ _WEAK void wifi_set_mib(void)
 	wext_set_adaptivity(RTW_ADAPTIVITY_DISABLE);
 	//trp tis
 	wext_set_trp_tis(DISABLE);
+
+#if defined(CONFIG_PLATFORM_TIZENRT_OS)
+	//send deauth before auth to disconnect from AP to resolve AP compatibility issue
+	rltk_wlan_enable_issue_deauth(ENABLE);
+#endif
 }
 
 //----------------------------------------------------------------------------//


### PR DESCRIPTION
Some AP requires board to be disconnected first before trying to connect to same AP