### PR TITLE
reboot_reason: Remove wrong '\' at the end of macro definition

### DIFF
--- a/os/include/tinyara/reboot_reason.h
+++ b/os/include/tinyara/reboot_reason.h
@@ -40,10 +40,10 @@ typedef enum {
 
 #define WRITE_REBOOT_REASON(x) do {                                       \
 					prctl(PR_REBOOT_REASON_WRITE, x); \
-				} while (0)                               \
+				} while (0)
 #define READ_REBOOT_REASON() prctl(PR_REBOOT_REASON_READ)
 #define CLEAR_REBOOT_REASON() do {                                     \
 					prctl(PR_REBOOT_REASON_CLEAR); \
-				} while (0)                            \
+				} while (0)
 
 #endif					/* __INCLUDEREBOOT_REASON_H */


### PR DESCRIPTION
Remove wrong '\' at the end of macro definition.

Build error:
In file included from /TizenRT_washer/os/include/arch/reboot_reason.h:22:0,
                 from task/task_prctl.c:86:
/TizenRT_washer/os/include/tinyara/reboot_reason.h:49:30: error: '#' is not followed by a macro parameter
 #define WRITE_REBOOT_REASON(x) do {                                       \
                              ^
Makefile:97: recipe for target 'task_prctl.o' failed