### PR TITLE
apps/examples/le_tc/kernel/tc_mqueue.c : Add missing return statement

### DIFF
--- a/apps/examples/testcase/le_tc/kernel/tc_mqueue.c
+++ b/apps/examples/testcase/le_tc/kernel/tc_mqueue.c
@@ -846,7 +846,11 @@ static void tc_mqueue_mq_timedsend_timedreceive_failurechecks(void)
 	TC_ASSERT_GEQ_CLEANUP("timedreceive_test", mq_close(g_timedrecv_mqfd), 0, goto cleanup1);
 	TC_ASSERT_GEQ("timedsend_test", mq_close(g_timedsend_mqfd), 0);
 
+	/* Unlink all mqueues related to this tc. */
+	mq_unlink("t_mqueuer");
+	mq_unlink("t_mqueues");
 	TC_SUCCESS_RESULT();
+	return;
 
 cleanup2:
 	mq_close(g_timedrecv_mqfd);


### PR DESCRIPTION
In tc_mqueue_mq_timedsend_timedreceive_failurechecks, return statement is missed.
So duplicated mq_close prints the below ERRORs.
mq_close_group: ERROR: mqdes(xxxxx) is not in this thread's group.

Signed-off-by: jeongchanKim <jc_.kim@samsung.com>