### PR TITLE
tools/build_test: Print a summary of build test results

### DIFF
--- a/os/tools/build_test.sh
+++ b/os/tools/build_test.sh
@@ -20,23 +20,33 @@
 
 TOOLDIR=`test -d ${0%/*} && cd ${0%/*}; pwd`
 OSDIR="${TOOLDIR}/.."
+OUTPUT_DIR="${TOOLDIR}/build_test/"
 
 BUILD_CMD=make
 CLEAN_CMD="${BUILD_CMD} distclean"
 
-build_targets="artik055s/audio
-               artik053/st_things
-               artik053/tc
-               qemu/build_test
-               esp_wrover_kit/hello_with_tash
-               imxrt1020-evk/loadable_elf_apps
-               rtl8721csm/loadable_apps"
+build_targets=(
+	"artik055s/audio"
+	"artik053/st_things"
+	"artik053/tc"
+	"qemu/build_test"
+	"esp_wrover_kit/hello_with_tash"
+	"imxrt1020-evk/loadable_elf_apps"
+	"rtl8721csm/loadable_apps"
+)
+
+is_failed=false
+
+if [ -d ${OUTPUT_DIR} ]; then
+	rm -rf ${OUTPUT_DIR}
+fi
+mkdir ${OUTPUT_DIR}
 
 echo "===================================="
 echo "========= Build Test START ========="
 echo "===================================="
 
-for target in ${build_targets[@]}; do
+for index in ${!build_targets[@]}; do
 	# verify build clean
 	echo "===================================="
 	echo "======= Clean Previous build ======="
@@ -45,19 +55,30 @@ for target in ${build_targets[@]}; do
 
 	# configure
 	echo "===================================="
-	echo "====== Configure \"${target}\" ======"
+	echo "====== Configure \"${build_targets[$index]}\" ======"
 	echo "===================================="	
-	cd ${TOOLDIR}; ./configure.sh ${target}
+	cd ${TOOLDIR}; ./configure.sh ${build_targets[$index]}
 
 	# build
 	echo "===================================="
-	echo "======== Build \"${target}\" ========"
+	echo "======== Build \"${build_targets[$index]}\" ========"
 	echo "===================================="	
-	cd ${OSDIR}; ${BUILD_CMD} || { echo "\"${target}\" ERROR!!!"; exit 1; }
-
-	echo "===================================="
-	echo "======== \"${target}\" Built ========"
-	echo "===================================="	
+	cd ${OSDIR};
+	OUTPUT_PATH=${OUTPUT_DIR}"`echo ${build_targets[$index]} | sed -e "s/\//\./g"`"
+	set -o pipefail;
+	${BUILD_CMD} |& tee ${OUTPUT_PATH}
+	if [ $? -eq 0 ]; then
+		echo "===================================="
+		echo "======== \"${build_targets[$index]}\" Built ========"
+		echo "===================================="
+		build_results[${index}]="SUCCESS"
+	else
+		is_failed=true
+		build_results[${index}]="FAIL"
+		echo "===================================="
+		echo "======== \"${build_targets[$index]}\" ERROR!!! ========"
+		echo "===================================="
+	fi
 done
 
 echo "===================================="
@@ -65,6 +86,17 @@ echo "======== Clean build output ========"
 echo "===================================="
 cd ${OSDIR}; ${CLEAN_CMD}
 
-echo "===================================="
-echo "====== Build Test All SUCCESS ======"
-echo "===================================="
+echo "=========================================="
+echo "=========== Build Test Result ==========="
+echo "=========================================="
+for index in ${!build_targets[@]}; do
+	printf "%30s ------ %s\n" ${build_targets[$index]} ${build_results[$index]}
+done
+echo "=========================================="
+
+if ${is_failed}; then
+	echo "Some builds are FAILED!! Please find build results in ${OUTPUT_DIR}"
+	exit 1
+else
+	rm -rf ${OUTPUT_DIR}
+fi


### PR DESCRIPTION
- Print a summary of build test results like travis CI
- All build test works without break although some builds are failed
- Support result file for failed test to help users find problems

[Print Logs]
1. All success
==========================================
=========== Build Test Result ===========
==========================================
               artik055s/audio ------ SUCCESS
            artik053/st_things ------ SUCCESS
                   artik053/tc ------ SUCCESS
               qemu/build_test ------ SUCCESS
esp_wrover_kit/hello_with_tash ------ SUCCESS
imxrt1020-evk/loadable_elf_apps ------ SUCCESS
      rtl8721csm/loadable_apps ------ SUCCESS
==========================================

2. Some failures
==========================================
=========== Build Test Result ===========
==========================================
               artik055s/audio ------ SUCCESS
            artik053/st_things ------ SUCCESS
                   artik053/tc ------ SUCCESS
               qemu/build_test ------ SUCCESS
esp_wrover_kit/hello_with_tash ------ SUCCESS
imxrt1020-evk/loadable_elf_apps ------ FAIL
      rtl8721csm/loadable_apps ------ FAIL
==========================================
Some builds are FAILED!! Please find build results in /root/tizenrt/os/tools/build_test/