### PR TITLE
network/wifi: remove mac address field in wifi manager

### DIFF
--- a/framework/src/wifi_manager/wifi_manager_api.c
+++ b/framework/src/wifi_manager/wifi_manager_api.c
@@ -223,7 +223,7 @@ wifi_manager_result_e wifi_manager_get_info(wifi_manager_info_s *info)
 
 	char softap_ssid[WIFIMGR_SSID_LEN + 1];
 	wifimgr_info_msg_s winfo = {info->ssid, softap_ssid,
-								info->mac_address, 0, WIFIMGR_UNINITIALIZED};
+								0, WIFIMGR_UNINITIALIZED};
 
 	wifimgr_get_info(WIFIMGR_ALL_INFO, &winfo);
 	info->rssi = winfo.rssi;

--- a/framework/src/wifi_manager/wifi_manager_info.c
+++ b/framework/src/wifi_manager/wifi_manager_info.c
@@ -30,15 +30,13 @@
 struct _wifimgr_info {
 	char ssid[WIFIMGR_SSID_LEN + 1];             // SSID of Connected AP if mode is a station
 	char softap_ssid[WIFIMGR_SSID_LEN + 1];      // SoftAP SSID if mode is a soft ap
-	char mac_address[WIFIMGR_MACADDR_LEN];	   // MAC address of wifi interface
 	int rssi;                  // It is only used for a station mode
 	wifimgr_state_e state;
 	wifimgr_state_e prev_state;
 };
 typedef struct _wifimgr_info _wifimgr_info_s;
 
-static _wifimgr_info_s g_manager_info = {{0}, {0}, {0}, 0};
-
+static _wifimgr_info_s g_manager_info = {{0}, {0}, 0, WIFIMGR_NONE, WIFIMGR_NONE};
 
 int wifimgr_get_info(int flag, wifimgr_info_msg_s *info)
 {
@@ -50,10 +48,6 @@ int wifimgr_get_info(int flag, wifimgr_info_msg_s *info)
 	if ((flag & WIFIMGR_SOFTAP_SSID) != 0) {
 		strncpy(info->softap_ssid, g_manager_info.softap_ssid, WIFIMGR_SSID_LEN);
 		info->softap_ssid[WIFIMGR_SSID_LEN] = '\0';
-	}
-
-	if ((flag & WIFIMGR_MACADDR) != 0) {
-		memcpy(info->mac_addr, g_manager_info.mac_address, WIFIMGR_MACADDR_LEN);
 	}
 
 	if ((flag & WIFIMGR_RSSI) != 0) {
@@ -87,10 +81,6 @@ int wifimgr_set_info(int flag, wifimgr_info_msg_s *info)
 	if ((flag & WIFIMGR_SOFTAP_SSID) != 0) {
 		strncpy(g_manager_info.softap_ssid, info->softap_ssid, WIFIMGR_SSID_LEN);
 		g_manager_info.softap_ssid[WIFIMGR_SSID_LEN] = '\0';
-	}
-
-	if ((flag & WIFIMGR_MACADDR) != 0) {
-		memcpy(g_manager_info.mac_address, info->mac_addr, WIFIMGR_MACADDR_LEN);
 	}
 
 	if ((flag & WIFIMGR_RSSI) != 0) {

--- a/framework/src/wifi_manager/wifi_manager_info.h
+++ b/framework/src/wifi_manager/wifi_manager_info.h
@@ -29,7 +29,6 @@
 struct wifimgr_info_msg {
 	char *ssid;
 	char *softap_ssid;
-	char *mac_addr;
 	int rssi;
 	wifimgr_state_e state;
 };


### PR DESCRIPTION
remove mac address field in wifi manager.
netlib_getmacaddr() return mac address of NIC.