### PR TITLE
Add SPI driver build break fixes

### DIFF
--- a/apps/examples/testcase/ta_tc/systemio/itc/itc_internal.h
+++ b/apps/examples/testcase/ta_tc/systemio/itc/itc_internal.h
@@ -37,4 +37,6 @@
 **********************************************************/
 char *Expect_Value(int, int);
 
+int itc_spi_main(void);
+
 #endif /* __EXAMPLES_TESTCASE_SYSTEMIO_ITC_INTERNAL_H */

--- a/apps/examples/testcase/ta_tc/systemio/itc/itc_spi.c
+++ b/apps/examples/testcase/ta_tc/systemio/itc/itc_spi.c
@@ -208,14 +208,14 @@ static void itc_systemio_spi_open_close_n_invalid_frequecy(void)
 }
 
 /**
-* @testcase         itc_systemio_spi_write_recv_trasfer_p
+* @testcase         itc_systemio_spi_write_recv_transfer_p
 * @brief            reads and writes data over spi bus, and transfers rx and tx data over spi bus
 * @scenario         writes data over spi bus, reads data over spi bus and transfers rx and tx data over spi bus
 * @apicovered       iotbus_spi_write, iotbus_spi_recv, iotbus_spi_transfer_buf
 * @precondition     none
 * @postcondition    none
 */
-void itc_systemio_spi_write_recv_trasfer_p(void)
+void itc_systemio_spi_write_recv_transfer_p(void)
 {
 	unsigned char sz_txbuf[64] = { 0, };
 	unsigned char sz_rxbuf[64] = { 0, };
@@ -248,6 +248,6 @@ int itc_spi_main(void)
 	itc_systemio_spi_open_close_n_invalid_bus();
 	itc_systemio_spi_open_close_n_invalid_bpw();
 	itc_systemio_spi_open_close_n_invalid_frequecy();
-	itc_systemio_spi_write_recv_trasfer_p();
+	itc_systemio_spi_write_recv_transfer_p();
 	return 0;
 }

--- a/apps/examples/testcase/ta_tc/systemio/utc/utc_spi.c
+++ b/apps/examples/testcase/ta_tc/systemio/utc/utc_spi.c
@@ -29,7 +29,7 @@
 
 iotbus_spi_context_h spi;
 
-unsigned int bus = 1;
+static unsigned int bus = 0;
 
 unsigned char txbuf[64] = { 0, };
 unsigned char rxbuf[64] = { 0, };;
@@ -98,6 +98,7 @@ static void utc_systemio_spi_recv_n(void)
 	TC_SUCCESS_RESULT();
 }
 
+#ifdef CONFIG_SPI_EXCHANGE
 static void utc_systemio_spi_transfer_buf_p(void)
 {
 	int ret = iotbus_spi_transfer_buf(spi, txbuf, rxbuf, 16);
@@ -113,6 +114,7 @@ static void utc_systemio_spi_transfer_buf_n(void)
 	TC_ASSERT_EQ("iotbus_spi_transfer_buf", ret, IOTBUS_ERROR_INVALID_PARAMETER);
 	TC_SUCCESS_RESULT();
 }
+#endif
 
 static void utc_systemio_spi_close_p(void)
 {


### PR DESCRIPTION
#Patch 1
apps/examples/testcase/ta_tc/systemio: Fix build breaks when SPI driver TC's are enabled
This patch adds fix for:
1) Missing declarations of SPI driver itc:
	int itc_spi_main(void);
2) Config dependency for unused API's when CONFIG_SPI_EXCHANGE is disabled.
3) SPI bus for UTC to 0.

#Patch 2
apps/examples/testcase/ta_tc/systemio/itc: Rename API in SPI ITC
Fix typo SPI test case ITc and rename to itc_systemio_spi_write_recv_transfer_p