### PR TITLE
apps/examples/timer: Close fd before pthread exit to release used resources

### DIFF
--- a/apps/examples/timer/timer_main.c
+++ b/apps/examples/timer/timer_main.c
@@ -110,7 +110,7 @@ static pthread_addr_t timer_thread(pthread_addr_t arg)
 	int intval = pargs->intval;
 	int fd = pargs->fd;
 #ifdef CONFIG_EXAMPLES_TIMER_FRT_MEASUREMENT
-	int frt_fd;
+	int frt_fd = -1;
 	char path[_POSIX_PATH_MAX];
 	int frt_dev;
 	struct timer_status_s before;
@@ -215,10 +215,12 @@ static pthread_addr_t timer_thread(pthread_addr_t arg)
 	}
 #endif
 error:
-	pthread_exit(NULL);
 #ifdef CONFIG_EXAMPLES_TIMER_FRT_MEASUREMENT
-	close(frt_fd);
+	if (frt_fd > 0) {
+		close(frt_fd);
+	}
 #endif
+	pthread_exit(NULL);
 	return NULL;
 }
 


### PR DESCRIPTION
It should close fd before pthread_exit to release used resource.
If timer example runs continuously, an error occurs in 4 times.

TASH>>timer -n 10

Open /dev/timer0
Attach timer handler
Set timer interval to 1000000, repeat 10
Start the timer
FRT Open /dev/timer1
ERROR: Failed to open Free Run Timer: 24
Finished