### PR TITLE
kernel/binary_manager: Update booted kernel information from bootparam

### DIFF
--- a/os/board/common/partitions.c
+++ b/os/board/common/partitions.c
@@ -105,6 +105,7 @@ static int type_specific_initialize(int minor, FAR struct mtd_dev_s *mtd_part, i
 	if (!strncmp(types, "ftl,", 4)
 #ifdef CONFIG_BINARY_MANAGER
 	|| !strncmp(types, "kernel,", 7)
+	|| !strncmp(types, "bootparam,", 10)
 #endif
 	) {
 		do_ftlinit = true;
@@ -285,6 +286,8 @@ int configure_mtd_partitions(struct mtd_dev_s *mtd, struct partition_data_s *par
 #ifdef CONFIG_BINARY_MANAGER
 		if (!strncmp(types, "kernel,", 7)) {
 			binary_manager_register_kpart(partno, partsize);
+		} else if (!strncmp(types, "bootparam,", 10)) {
+			binary_manager_register_bppart(partno, partsize);
 		}
 #endif
 #ifdef CONFIG_MTD_PARTITION_NAMES

--- a/os/include/tinyara/binary_manager.h
+++ b/os/include/tinyara/binary_manager.h
@@ -258,6 +258,7 @@ typedef struct binmgr_getinfo_all_response_s binmgr_getinfo_all_response_t;
  * Public Function Prototypes
  ****************************************************************************/
 void binary_manager_register_kpart(int part_num, int part_size);
+void binary_manager_register_bppart(int part_num, int part_size);
 
 #ifdef __cplusplus
 #define EXTERN extern "C"

--- a/os/kernel/binary_manager/Make.defs
+++ b/os/kernel/binary_manager/Make.defs
@@ -21,7 +21,7 @@
 ifeq ($(CONFIG_BINARY_MANAGER),y)
 
 CSRCS += binary_manager.c binary_manager_getinfo.c binary_manager_response.c
-CSRCS += binary_manager_data.c binary_manager_binfile.c
+CSRCS += binary_manager_data.c binary_manager_binfile.c binary_manager_bootparam.c
 
 ifeq ($(CONFIG_APP_BINARY_SEPARATION),y)
 CSRCS += binary_manager_load.c binary_manager_callback.c

--- a/os/kernel/binary_manager/binary_manager.h
+++ b/os/kernel/binary_manager/binary_manager.h
@@ -74,6 +74,10 @@
 
 #define FILES_PER_BIN              2                          /* The number of files per binary */
 
+/* Bootparam information */
+#define BOOTPARAM_COUNT            2                          /* The number of boot parameters */
+#define BOOTPARAM_PARTSIZE         (8 * 1024)                 /* The size of partition for boot param binary : 8K */
+
 #define CHECKSUM_SIZE              4
 
 /* Index of 'Common Library' data in binary table. */
@@ -151,6 +155,23 @@ struct binmgr_kinfo_s {
 	uint32_t version;
 };
 typedef struct binmgr_kinfo_s binmgr_kinfo_t;
+
+/* Boot parameter data */
+struct binmgr_bpdata_s {
+	uint32_t crc_hash;
+	uint32_t version;
+	uint32_t format_ver;
+	uint8_t active_idx;
+	uint32_t address[BOOTPARAM_COUNT];
+} __attribute__((__packed__));
+typedef struct binmgr_bpdata_s binmgr_bpdata_t;
+
+struct binmgr_bpinfo_s {
+	uint8_t inuse_idx;
+	int part_num;
+	binmgr_bpdata_t bp_data;
+};
+typedef struct binmgr_bpinfo_s binmgr_bpinfo_t;
 
 struct statecb_node_s {
 	struct statecb_node_s *flink;
@@ -238,6 +259,8 @@ int binary_manager_create_entry(int requester_pid, char *bin_name, int version);
 void binary_manager_release_binary_sem(int bin_idx);
 void binary_manager_update_running_state(int bin_id);
 int binary_manager_get_index_with_name(char *bin_name);
+int binary_manager_scan_bootparam(void);
+binmgr_bpdata_t *binary_manager_get_bpdata(void);
 
 /****************************************************************************
  * Binary Manager Main Thread

--- a/os/kernel/binary_manager/binary_manager_bootparam.c
+++ b/os/kernel/binary_manager/binary_manager_bootparam.c
@@ -1,0 +1,152 @@
+/****************************************************************************
+ *
+ * Copyright 2021 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+#include <tinyara/config.h>
+#include <debug.h>
+#include <stdio.h>
+#include <string.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <stdbool.h>
+
+#include <tinyara/binary_manager.h>
+
+#include "binary_manager.h"
+
+/* Data for Boot parameters */
+static binmgr_bpinfo_t bp_info;
+
+#define BP_SEEK_OFFSET(index)   (index == 0 ? 0 : BOOTPARAM_PARTSIZE / 2)
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+/****************************************************************************
+ * Name: binary_manager_register_bppart
+ *
+ * Description:
+ *	 This function registers the partition of boot parameters.
+ *
+ ****************************************************************************/
+void binary_manager_register_bppart(int part_num, int part_size)
+{
+	if (part_num < 0 || part_size != BOOTPARAM_PARTSIZE) {
+		bmdbg("ERROR: Invalid part info : num %d, size %d\n", part_num, part_size);
+		return;
+	}
+
+	bp_info.part_num = part_num;
+
+	bmvdbg("[BOOTPARAM] part num %d\n", part_num);
+}
+
+bool is_valid_bootparam(binmgr_bpdata_t *bp_data)
+{
+	if (!bp_data) {
+		bmdbg("Boot param is NULL\n");
+		return false;
+	} else if (bp_data->format_ver == 0 || bp_data->active_idx >= binary_manager_get_kdata()->part_count) {
+		bmdbg("Invalid data. ver: %u, active index: %u, addresses: %x, %x\n", bp_data->version, bp_data->active_idx, bp_data->address[0], bp_data->address[1]);
+		return false;
+	} else if (bp_data->crc_hash != crc32((uint8_t *)bp_data + CHECKSUM_SIZE, sizeof(binmgr_bpdata_t) - CHECKSUM_SIZE)) {
+		bmdbg("Invalid crc32 value, crc32 %u, ver: %u, active index: %u, addresses: %x, %x\n", bp_data->crc_hash, bp_data->version, bp_data->active_idx, bp_data->address[0], bp_data->address[1]);
+		return false;
+	}
+
+	return true;
+}
+
+/*****************************************************************************************************
+ * Name: binary_manager_scan_bootparam
+ *
+ * Description:
+ *	 This function updates the latest boot parameter information by scanning all boot parameters.
+ *
+ *****************************************************************************************************/
+int binary_manager_scan_bootparam(void)
+{
+	int fd;
+	int ret;
+	int bp_idx;
+	int latest_idx = -1;
+	uint32_t latest_ver = 0;
+	binmgr_bpdata_t bp_data[BOOTPARAM_COUNT];
+	char bp_devpath[BINARY_PATH_LEN];
+
+	if (bp_info.part_num < 0) {
+		bmdbg("Invalid Bootparam partition Num : %d\n", bp_info.part_num);
+		return BINMGR_INVALID_PARAM;
+	}
+
+	/* Open dev to access boot parameters */
+	snprintf(bp_devpath, BINARY_PATH_LEN, BINMGR_DEVNAME_FMT, bp_info.part_num);
+	fd = open(bp_devpath, O_RDWR, 0666);
+	if (fd < 0) {
+		bmdbg("ERROR: Get a fd of bootparam, errno %d\n", errno);
+		return BINMGR_OPERATION_FAIL;
+	}
+
+	for (bp_idx = 0; bp_idx < BOOTPARAM_COUNT; bp_idx++) {
+		ret = lseek(fd, BP_SEEK_OFFSET(bp_idx), SEEK_SET);
+		if (ret < 0) {
+			bmdbg("ERROR: Seek Failed, errno %d\n", errno);
+			close(fd);
+			return BINMGR_OPERATION_FAIL;
+		}
+		/* Read bootparam data */
+		ret = read(fd, (FAR uint8_t *)&bp_data[bp_idx], sizeof(binmgr_bpdata_t));
+		if (ret != sizeof(binmgr_bpdata_t)) {
+			continue;
+		} else if (!is_valid_bootparam(&bp_data[bp_idx])) {
+			continue;
+		}
+
+		/* Update the latest version and index */
+		if (latest_ver < bp_data->version) {
+			latest_ver = bp_data->version;
+			latest_idx = bp_idx;
+			bmvdbg("Latest Version %d, index %d\n", latest_ver, latest_idx);
+		}
+	}
+	close(fd);
+
+	if (latest_ver == 0 || latest_idx < 0) {
+		bmdbg("Failed to find valid bootparam\n");
+		return BINMGR_NOT_FOUND;
+	}
+
+	bp_info.inuse_idx = latest_idx;
+	bp_info.bp_data = bp_data[latest_idx];
+	bmvdbg("Bootparam[%d] ver: %u, active index: %u, addresses: %x, %x\n", latest_idx, bp_info.bp_data.version, bp_info.bp_data.active_idx, bp_info.bp_data.address[0], bp_info.bp_data.address[1]);
+
+	return BINMGR_OK;
+}
+
+/****************************************************************************
+ * Name: binary_manager_get_bpdata
+ *
+ * Description:
+ *	 This function gets boot parameter data.
+ *
+ ****************************************************************************/
+binmgr_bpdata_t *binary_manager_get_bpdata(void)
+{
+	return &bp_info.bp_data;
+}


### PR DESCRIPTION
Update booted kernel binary information from boot parameter data without scanning all kernel binaries.

This PR will be updated with commits about boot parameter recovery, #5008 soon.