### PR TITLE
os/kernel/debug: Remove wrong description of sysdbg_read function

### DIFF
--- a/os/kernel/debug/sysdbg.c
+++ b/os/kernel/debug/sysdbg.c
@@ -288,12 +288,10 @@ static int sysdbg_close(FAR struct file *filep)
  *   Read the saved debug data and display on console
  *
  * Inputs:
- *   file pointer
- *   buffer : User space buffer
- *   buflen : User space buffer length
+ *   None
  *
  * Return Value:
- *   total size of written buffer
+ *   None
  *
  * Assumptions:
  *   None


### PR DESCRIPTION
Remove wrong function description.

Signed-off-by: sangamanatha <sangam.swami@samsung.com>