### PR TITLE
arch/arm/amebad_timer_lowerhalf.c : Remove wrong return of amebad_gpt_handler

### DIFF
--- a/os/arch/arm/src/amebad/amebad_timer_lowerhalf.c
+++ b/os/arch/arm/src/amebad/amebad_timer_lowerhalf.c
@@ -400,10 +400,8 @@ static int amebad_gpt_ioctl(struct timer_lowerhalf_s *lower, int cmd, unsigned l
 
 	switch (cmd) {
 	case TCIOC_SETDIV:
-		ret = -EINVAL;
 		break;
 	case TCIOC_GETDIV:
-		ret = -EINVAL;
 		break;
 	case TCIOC_SETMODE:
 		if ((timer_mode_t)arg == MODE_FREERUN) {
@@ -413,23 +411,18 @@ static int amebad_gpt_ioctl(struct timer_lowerhalf_s *lower, int cmd, unsigned l
 		} else if ((timer_mode_t)arg == MODE_ALARM) {
 			priv->freerunmode = false;
 			ret = OK;
-		} else {
-			ret = -EINVAL;
 		}
 		break;
 	case TCIOC_SETRESOLUTION:
 		if ((timer_resolution_t)arg == TIME_RESOLUTION_MS) {
 			// TBD
 			ret = OK;
-		} else {
-			ret = -EINVAL;
 		}
 		break;
 	case TCIOC_SETIRQPRIO:
 		ret = up_prioritize_irq(TIM_x[priv->obj.timer_id], arg);
 		break;
 	case TCIOC_SETCLKSRC:
-		ret = -EINVAL;
 		break;
 	default:
 		tmrdbg("Invalid cmd %d\n", cmd);

--- a/os/arch/arm/src/amebad/amebad_timer_lowerhalf.c
+++ b/os/arch/arm/src/amebad/amebad_timer_lowerhalf.c
@@ -143,7 +143,7 @@ static void amebad_gpt_handler(uint32_t data)
 	uint32_t next_interval_us = 0;
 	DEBUGASSERT(priv);
 	if (!priv) {
-		return -ENODEV;
+		return;
 	}
 
 	if (priv->freerunmode) {	/* Free Run Mode */


### PR DESCRIPTION
1)   The return type of amebad_gpt_handler() is void, so it cannot return -ENODEV.
2)  'ret' is initialized as -EINVAL, so it is not need to be reassigned for some cases.