### PR TITLE
arch/arm/common: Unify a function to restore context of tcb for context switching

### DIFF
--- a/os/arch/arm/src/amebad/Make.defs
+++ b/os/arch/arm/src/amebad/Make.defs
@@ -65,7 +65,7 @@ CMN_CSRCS += up_releasepending.c up_releasestack.c up_reprioritizertr.c
 CMN_CSRCS += up_schedulesigaction.c up_sigdeliver.c up_stackframe.c
 CMN_CSRCS += up_unblocktask.c up_usestack.c up_doirq.c up_hardfault.c
 CMN_CSRCS += up_svcall.c up_vfork.c up_trigger_irq.c up_systemreset.c
-CMN_CSRCS += up_unblocktask_withoutsavereg.c
+CMN_CSRCS += up_unblocktask_withoutsavereg.c up_restoretask.c
 
 ifeq ($(CONFIG_SYSTEM_REBOOT_REASON),y)
 CMN_CSRCS += up_reboot_reason.c

--- a/os/arch/arm/src/armv7-m/up_blocktask.c
+++ b/os/arch/arm/src/armv7-m/up_blocktask.c
@@ -69,15 +69,6 @@
 #include <tinyara/debug/sysdbg.h>
 #endif
 
-#ifdef CONFIG_TASK_MONITOR
-#include "task_monitor/task_monitor_internal.h"
-#endif
-
-#ifdef CONFIG_ARMV7M_MPU
-#include "mpu.h"
-#include <tinyara/mpu.h>
-#endif
-
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
@@ -85,9 +76,7 @@
 /****************************************************************************
  * Private Data
  ****************************************************************************/
-#ifdef CONFIG_SUPPORT_COMMON_BINARY
-extern uint32_t *g_umm_app_id;
-#endif
+
 /****************************************************************************
  * Private Functions
  ****************************************************************************/
@@ -164,39 +153,14 @@ void up_block_task(struct tcb_s *tcb, tstate_t task_state)
 
 			rtcb = this_task();
 
-#ifdef CONFIG_TASK_SCHED_HISTORY
-			/* Save the task name which will be scheduled */
-			save_task_scheduling_status(rtcb);
-#endif
+			/* Restore rtcb data for context switching */
 
-			/* Restore the MPU registers in case we are switching to an application task */
-#ifdef CONFIG_ARMV7M_MPU
-			/* Condition check : Update MPU registers only if this is not a kernel thread. */
-			if ((rtcb->flags & TCB_FLAG_TTYPE_MASK) != TCB_FLAG_TTYPE_KERNEL) {
-#if defined(CONFIG_APP_BINARY_SEPARATION)
-				for (int i = 0; i < MPU_REG_NUMBER * MPU_NUM_REGIONS; i += MPU_REG_NUMBER) {
-					up_mpu_set_register(&rtcb->mpu_regs[i]);
-				}
-#endif
-			}
-#ifdef CONFIG_MPU_STACK_OVERFLOW_PROTECTION
-			up_mpu_set_register(rtcb->stack_mpu_regs);
-#endif
-#endif
-
-#ifdef CONFIG_SUPPORT_COMMON_BINARY
-			if (g_umm_app_id) {
-				*g_umm_app_id = rtcb->app_id;
-			}
-#endif
-#ifdef CONFIG_TASK_MONITOR
-			/* Update rtcb active flag for monitoring. */
-			rtcb->is_active = true;
-#endif
+			up_restoretask(rtcb);
 
 			/* Then switch contexts */
 
 			up_restorestate(rtcb->xcp.regs);
+
 		}
 
 		/* No, then we will need to perform the user context switch */

--- a/os/arch/arm/src/armv7-m/up_releasepending.c
+++ b/os/arch/arm/src/armv7-m/up_releasepending.c
@@ -62,10 +62,6 @@
 
 #include "sched/sched.h"
 #include "up_internal.h"
-#ifdef CONFIG_ARMV7M_MPU
-#include "mpu.h"
-#include <tinyara/mpu.h>
-#endif
 
 #ifdef CONFIG_TASK_SCHED_HISTORY
 #include <tinyara/debug/sysdbg.h>
@@ -78,9 +74,7 @@
 /****************************************************************************
  * Private Data
  ****************************************************************************/
-#ifdef CONFIG_SUPPORT_COMMON_BINARY
-extern uint32_t *g_umm_app_id;
-#endif
+
 /****************************************************************************
  * Private Functions
  ****************************************************************************/
@@ -128,38 +122,14 @@ void up_release_pending(void)
 			rtcb = this_task();
 			sllvdbg("New Active Task TCB=%p\n", rtcb);
 
-#ifdef CONFIG_TASK_SCHED_HISTORY
-			/* Save the task name which will be scheduled */
-			save_task_scheduling_status(rtcb);
-#endif
+			/* Restore rtcb data for context switching */
 
-			/* Restore the MPU registers in case we are switching to an application task */
-#ifdef CONFIG_ARMV7M_MPU
-			/* Condition check : Update MPU registers only if this is not a kernel thread. */
-			if ((rtcb->flags & TCB_FLAG_TTYPE_MASK) != TCB_FLAG_TTYPE_KERNEL) {
-#if defined(CONFIG_APP_BINARY_SEPARATION)
-				for (int i = 0; i < MPU_REG_NUMBER * MPU_NUM_REGIONS; i += MPU_REG_NUMBER) {
-					up_mpu_set_register(&rtcb->mpu_regs[i]);
-				}
-#endif
-			}
-#ifdef CONFIG_MPU_STACK_OVERFLOW_PROTECTION
-			up_mpu_set_register(rtcb->stack_mpu_regs);
-#endif
-#endif
-
-#ifdef CONFIG_SUPPORT_COMMON_BINARY
-			if (g_umm_app_id) {
-				*g_umm_app_id = rtcb->app_id;
-			}
-#endif
-#ifdef CONFIG_TASK_MONITOR
-			/* Update rtcb active flag for monitoring. */
-			rtcb->is_active = true;
-#endif
+			up_restoretask(rtcb);
 
 			/* Then switch contexts */
+
 			up_restorestate(rtcb->xcp.regs);
+
 		}
 
 		/* No, then we will need to perform the user context switch */

--- a/os/arch/arm/src/armv7-m/up_reprioritizertr.c
+++ b/os/arch/arm/src/armv7-m/up_reprioritizertr.c
@@ -64,10 +64,6 @@
 
 #include "sched/sched.h"
 #include "up_internal.h"
-#ifdef CONFIG_ARMV7M_MPU
-#include "mpu.h"
-#include <tinyara/mpu.h>
-#endif
 
 #ifdef CONFIG_TASK_SCHED_HISTORY
 #include <tinyara/debug/sysdbg.h>
@@ -76,9 +72,7 @@
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
-#ifdef CONFIG_SUPPORT_COMMON_BINARY
-extern uint32_t *g_umm_app_id;
-#endif
+
 /****************************************************************************
  * Private Data
  ****************************************************************************/
@@ -180,37 +174,14 @@ void up_reprioritize_rtr(struct tcb_s *tcb, uint8_t priority)
 				rtcb = this_task();
 				sllvdbg("New Active Task TCB=%p\n", rtcb);
 
-#ifdef CONFIG_TASK_SCHED_HISTORY
-				/* Save the task name which will be scheduled */
-				save_task_scheduling_status(rtcb);
-#endif
-				/* Restore the MPU registers in case we are switching to an application task */
-#ifdef CONFIG_ARMV7M_MPU
-				/* Condition check : Update MPU registers only if this is not a kernel thread. */
-				if ((rtcb->flags & TCB_FLAG_TTYPE_MASK) != TCB_FLAG_TTYPE_KERNEL) {
-#if defined(CONFIG_APP_BINARY_SEPARATION)
-					for (int i = 0; i < MPU_REG_NUMBER * MPU_NUM_REGIONS; i += MPU_REG_NUMBER) {
-						up_mpu_set_register(&rtcb->mpu_regs[i]);
-					}
-#endif
-				}
-#ifdef CONFIG_MPU_STACK_OVERFLOW_PROTECTION
-				up_mpu_set_register(rtcb->stack_mpu_regs);
-#endif
-#endif
-
-#ifdef CONFIG_SUPPORT_COMMON_BINARY
-				if (g_umm_app_id) {
-					*g_umm_app_id = rtcb->app_id;
-				}
-#endif
-#ifdef CONFIG_TASK_MONITOR
-				/* Update rtcb active flag for monitoring. */
-				rtcb->is_active = true;
-#endif
-
+				/* Restore rtcb data for context switching */
+				
+				up_restoretask(rtcb);
+				
 				/* Then switch contexts */
+				
 				up_restorestate(rtcb->xcp.regs);
+
 			}
 
 			/* No, then we will need to perform the user context switch */

--- a/os/arch/arm/src/armv7-m/up_schedyield.c
+++ b/os/arch/arm/src/armv7-m/up_schedyield.c
@@ -25,19 +25,11 @@
 #include <sys/types.h>
 #include <debug.h>
 #include <queue.h>
-#ifdef CONFIG_SUPPORT_COMMON_BINARY
-#include <stdint.h>
-#endif
 
+#include <tinyara/arch.h>
 #include <tinyara/sched.h>
 #if CONFIG_RR_INTERVAL > 0
 #include <tinyara/clock.h>
-#endif
-#ifdef CONFIG_ARMV7M_MPU
-#include <tinyara/mpu.h>
-#endif
-#ifdef CONFIG_TASK_SCHED_HISTORY
-#include <tinyara/debug/sysdbg.h>
 #endif
 
 #include "sched/sched.h"
@@ -50,10 +42,6 @@
 /****************************************************************************
  * Private Data
  ****************************************************************************/
-
-#ifdef CONFIG_SUPPORT_COMMON_BINARY
-extern uint32_t g_umm_app_id;
-#endif
 
 /****************************************************************************
  * Private Functions
@@ -128,12 +116,6 @@ void up_schedyield(void)
 
 		ntcb->task_state = TSTATE_TASK_RUNNING;
 
-#ifdef CONFIG_TASK_SCHED_HISTORY
-		/* Save the task name which will be scheduled */
-
-		save_task_scheduling_status(ntcb);
-#endif
-
 		/* Are we in an interrupt handler? */
 
 		if (current_regs) {
@@ -144,37 +126,9 @@ void up_schedyield(void)
 
 			up_savestate(rtcb->xcp.regs);
 
-			/* Restore the exception context of the ntcb at the (new) head
-			 * of the g_readytorun task list.
-			 */
+			/* Restore ntcb data for context switching */
 
-			/* Restore the MPU registers in case we are switching to an application task */
-#ifdef CONFIG_ARMV7M_MPU
-			/* Condition check : Update MPU registers only if this is not a kernel thread. */
-
-			if ((ntcb->flags & TCB_FLAG_TTYPE_MASK) != TCB_FLAG_TTYPE_KERNEL) {
-#if defined(CONFIG_APP_BINARY_SEPARATION)
-				for (int i = 0; i < MPU_REG_NUMBER * MPU_NUM_REGIONS; i += MPU_REG_NUMBER) {
-					up_mpu_set_register(&ntcb->mpu_regs[i]);
-				}
-#endif
-			}
-#ifdef CONFIG_MPU_STACK_OVERFLOW_PROTECTION
-			up_mpu_set_register(ntcb->stack_mpu_regs);
-#endif
-#endif
-
-#ifdef CONFIG_SUPPORT_COMMON_BINARY
-			if (g_umm_app_id) {
-				*g_umm_app_id = ntcb->app_id;
-			}
-#endif
-
-#ifdef CONFIG_TASK_MONITOR
-			/* Update rtcb active flag for monitoring. */
-
-			ntcb->is_active = true;
-#endif
+			up_restoretask(ntcb);
 
 			/* Then switch contexts */
 

--- a/os/arch/arm/src/armv7-m/up_svcall.c
+++ b/os/arch/arm/src/armv7-m/up_svcall.c
@@ -62,6 +62,7 @@
 #include <debug.h>
 
 #include <arch/irq.h>
+#include <tinyara/arch.h>
 #include <tinyara/sched.h>
 #include <tinyara/userspace.h>
 
@@ -72,10 +73,6 @@
 #include "svcall.h"
 #include "exc_return.h"
 #include "up_internal.h"
-#ifdef CONFIG_ARMV7M_MPU
-#include "mpu.h"
-#include <tinyara/mpu.h>
-#endif
 
 #define INDEX_ERROR (-1)
 /****************************************************************************
@@ -183,9 +180,7 @@ static void dispatch_syscall(void)
 int up_svcall(int irq, FAR void *context, FAR void *arg)
 {
 	uint32_t *regs = (uint32_t *)context;
-#if defined(CONFIG_BUILD_PROTECTED)
 	struct tcb_s *rtcb = sched_self();
-#endif
 	uint32_t cmd;
 
 	DEBUGASSERT(regs && regs == current_regs);
@@ -263,31 +258,9 @@ int up_svcall(int irq, FAR void *context, FAR void *arg)
 		DEBUGASSERT(regs[REG_R1] != 0);
 		current_regs = (uint32_t *)regs[REG_R1];
 
-#if (defined(CONFIG_ARMV7M_MPU) && defined(CONFIG_APP_BINARY_SEPARATION)) || defined(CONFIG_TASK_MONITOR)
-		struct tcb_s *tcb = sched_self();
-#endif
-		/* Restore the MPU registers in case we are switching to an application task */
-#if (defined(CONFIG_ARMV7M_MPU) && defined(CONFIG_APP_BINARY_SEPARATION))
-		/* Condition check : Update MPU registers only if this is not a kernel thread. */
-		if ((tcb->flags & TCB_FLAG_TTYPE_MASK) != TCB_FLAG_TTYPE_KERNEL) {
-			for (int i = 0; i < MPU_REG_NUMBER * MPU_NUM_REGIONS; i += MPU_REG_NUMBER) {
-				up_mpu_set_register(&tcb->mpu_regs[i]);
-			}
-		}
-#ifdef CONFIG_MPU_STACK_OVERFLOW_PROTECTION
-		up_mpu_set_register(tcb->stack_mpu_regs);
-#endif
-#endif
+		/* Restore rtcb data for context switching */
 
-#ifdef CONFIG_SUPPORT_COMMON_BINARY
-		if (g_umm_app_id) {
-			*g_umm_app_id = tcb->app_id;
-		}
-#endif
-#ifdef CONFIG_TASK_MONITOR
-		/* Update tcb active flag for monitoring. */
-		tcb->is_active = true;
-#endif
+		up_restoretask(rtcb);
 	}
 	break;
 
@@ -315,31 +288,9 @@ int up_svcall(int irq, FAR void *context, FAR void *arg)
 #endif
 		current_regs = (uint32_t *)regs[REG_R2];
 
-#if (defined(CONFIG_ARMV7M_MPU) && defined(CONFIG_APP_BINARY_SEPARATION)) || defined(CONFIG_TASK_MONITOR)
-		struct tcb_s *tcb = sched_self();
-#endif
-		/* Restore the MPU registers in case we are switching to an application task */
-#if (defined(CONFIG_ARMV7M_MPU) && defined(CONFIG_APP_BINARY_SEPARATION))
-		/* Condition check : Update MPU registers only if this is not a kernel thread. */
-		if ((tcb->flags & TCB_FLAG_TTYPE_MASK) != TCB_FLAG_TTYPE_KERNEL) {
-			for (int i = 0; i < MPU_REG_NUMBER * MPU_NUM_REGIONS; i += MPU_REG_NUMBER) {
-				up_mpu_set_register(&tcb->mpu_regs[i]);
-			}
-		}
-#ifdef CONFIG_MPU_STACK_OVERFLOW_PROTECTION
-		up_mpu_set_register(tcb->stack_mpu_regs);
-#endif
-#endif
+		/* Restore rtcb data for context switching */
 
-#ifdef CONFIG_SUPPORT_COMMON_BINARY
-		if (g_umm_app_id) {
-			*g_umm_app_id = tcb->app_id;
-		}
-#endif
-#ifdef CONFIG_TASK_MONITOR
-		/* Update tcb active flag for monitoring. */
-		tcb->is_active = true;
-#endif
+		up_restoretask(rtcb);
 	}
 	break;
 

--- a/os/arch/arm/src/armv7-m/up_unblocktask.c
+++ b/os/arch/arm/src/armv7-m/up_unblocktask.c
@@ -63,10 +63,6 @@
 #include "sched/sched.h"
 #include "clock/clock.h"
 #include "up_internal.h"
-#ifdef CONFIG_ARMV7M_MPU
-#include "mpu.h"
-#include <tinyara/mpu.h>
-#endif
 
 #ifdef CONFIG_TASK_SCHED_HISTORY
 #include <tinyara/debug/sysdbg.h>
@@ -79,9 +75,7 @@
 /****************************************************************************
  * Private Data
  ****************************************************************************/
-#ifdef CONFIG_SUPPORT_COMMON_BINARY
-extern uint32_t *g_umm_app_id;
-#endif
+
 /****************************************************************************
  * Private Functions
  ****************************************************************************/
@@ -150,35 +144,9 @@ void up_unblock_task(struct tcb_s *tcb)
 
 			rtcb = this_task();
 
-#ifdef CONFIG_TASK_SCHED_HISTORY
-			/* Save the task name which will be scheduled */
-			save_task_scheduling_status(rtcb);
-#endif
+			/* Restore rtcb data for context switching */
 
-			/* Restore the MPU registers in case we are switching to an application task */
-#ifdef CONFIG_ARMV7M_MPU
-			/* Condition check : Update MPU registers only if this is not a kernel thread. */
-			if ((rtcb->flags & TCB_FLAG_TTYPE_MASK) != TCB_FLAG_TTYPE_KERNEL) {
-#if defined(CONFIG_APP_BINARY_SEPARATION)
-				for (int i = 0; i < MPU_REG_NUMBER * MPU_NUM_REGIONS; i += MPU_REG_NUMBER) {
-					up_mpu_set_register(&rtcb->mpu_regs[i]);
-				}
-#endif
-			}
-#ifdef CONFIG_MPU_STACK_OVERFLOW_PROTECTION
-			up_mpu_set_register(rtcb->stack_mpu_regs);
-#endif
-#endif
-
-#ifdef CONFIG_SUPPORT_COMMON_BINARY
-			if (g_umm_app_id) {
-				*g_umm_app_id = rtcb->app_id;
-			}
-#endif
-#ifdef CONFIG_TASK_MONITOR
-			/* Update rtcb active flag for monitoring. */
-			rtcb->is_active = true;
-#endif
+			up_restoretask(rtcb);
 
 			/* Then switch contexts */
 

--- a/os/arch/arm/src/armv7-m/up_unblocktask_withoutsavereg.c
+++ b/os/arch/arm/src/armv7-m/up_unblocktask_withoutsavereg.c
@@ -62,10 +62,6 @@
 #include "sched/sched.h"
 #include "clock/clock.h"
 #include "up_internal.h"
-#ifdef CONFIG_ARMV7M_MPU
-#include "mpu.h"
-#include <tinyara/mpu.h>
-#endif
 
 #ifdef CONFIG_TASK_SCHED_HISTORY
 #include <tinyara/debug/sysdbg.h>
@@ -78,9 +74,7 @@
 /****************************************************************************
  * Private Data
  ****************************************************************************/
-#ifdef CONFIG_SUPPORT_COMMON_BINARY
-extern uint32_t *g_umm_app_id;
-#endif
+
 /****************************************************************************
  * Private Functions
  ****************************************************************************/
@@ -150,35 +144,9 @@ void up_unblock_task_without_savereg(struct tcb_s *tcb)
 
 		rtcb = this_task();
 
-#ifdef CONFIG_TASK_SCHED_HISTORY
-		/* Save the task name which will be scheduled */
-		save_task_scheduling_status(rtcb);
-#endif
+		/* Restore rtcb data for context switching */
 
-		/* Restore the MPU registers in case we are switching to an application task */
-#ifdef CONFIG_ARMV7M_MPU
-		/* Condition check : Update MPU registers only if this is not a kernel thread. */
-		if ((rtcb->flags & TCB_FLAG_TTYPE_MASK) != TCB_FLAG_TTYPE_KERNEL) {
-#if defined(CONFIG_APP_BINARY_SEPARATION)
-			for (int i = 0; i < MPU_REG_NUMBER * MPU_NUM_REGIONS; i += MPU_REG_NUMBER) {
-				up_mpu_set_register(&rtcb->mpu_regs[i]);
-			}
-#endif
-		}
-#ifdef CONFIG_MPU_STACK_OVERFLOW_PROTECTION
-		up_mpu_set_register(rtcb->stack_mpu_regs);
-#endif
-#endif
-
-#ifdef CONFIG_SUPPORT_COMMON_BINARY
-		if (g_umm_app_id) {
-			*g_umm_app_id = rtcb->app_id;
-		}
-#endif
-#ifdef CONFIG_TASK_MONITOR
-		/* Update rtcb active flag for monitoring. */
-		rtcb->is_active = true;
-#endif
+		up_restoretask(rtcb);
 
 		/* Then switch contexts */
 

--- a/os/arch/arm/src/armv7-r/arm_blocktask.c
+++ b/os/arch/arm/src/armv7-r/arm_blocktask.c
@@ -143,13 +143,9 @@ void up_block_task(struct tcb_s *tcb, tstate_t task_state)
 
 			rtcb = this_task();
 
-#ifdef CONFIG_TASK_SCHED_HISTORY
-			/* Save the task name which will be scheduled */
-			save_task_scheduling_status(rtcb);
-#endif
+			/* Switch context of rtcb */
 
-			/* Then switch contexts. */
-			up_restorestate(rtcb->xcp.regs);
+			up_restoretask(rtcb);
 		}
 
 		/* Copy the user C context into the TCB at the (old) head of the

--- a/os/arch/arm/src/armv7-r/arm_releasepending.c
+++ b/os/arch/arm/src/armv7-r/arm_releasepending.c
@@ -112,14 +112,12 @@ void up_release_pending(void)
 
 			rtcb = this_task();
 
-#ifdef CONFIG_TASK_SCHED_HISTORY
-			/* Save the task name which will be scheduled */
-			save_task_scheduling_status(rtcb);
-#endif
+			/* Restore rtcb data for context switching */
 
-			/* Then switch contexts.  Any necessary address environment
-			 * changes will be made when the interrupt returns.
-			 */
+			up_restoretask(rtcb);
+
+			/* Then switch contexts */
+
 			up_restorestate(rtcb->xcp.regs);
 		}
 

--- a/os/arch/arm/src/armv7-r/arm_reprioritizertr.c
+++ b/os/arch/arm/src/armv7-r/arm_reprioritizertr.c
@@ -161,13 +161,12 @@ void up_reprioritize_rtr(struct tcb_s *tcb, uint8_t priority)
 
 				rtcb = this_task();
 
-				/* Then switch contexts.  Any necessary address environment
-				 * changes will be made when the interrupt returns.
-				 */
-#ifdef CONFIG_TASK_SCHED_HISTORY
-				/* Save the task name which will be scheduled */
-				save_task_scheduling_status(rtcb);
-#endif
+				/* Restore rtcb data for context switching */
+				
+				up_restoretask(rtcb);
+				
+				/* Then switch contexts */
+				
 				up_restorestate(rtcb->xcp.regs);
 			}
 

--- a/os/arch/arm/src/armv7-r/arm_schedyield.c
+++ b/os/arch/arm/src/armv7-r/arm_schedyield.c
@@ -131,17 +131,14 @@ void up_schedyield(void)
 
 			trace_sched(NULL, ntcb);
 
-	#ifdef CONFIG_TASK_SCHED_HISTORY
-			/* Save the task name which will be scheduled */
+			/* Restore ntcb data for context switching */
 
-			save_task_scheduling_status(ntcb);
-	#endif
+			up_restoretask(ntcb);
 
-			/* Then switch contexts.  Any necessary address environment
-			 * changes will be made when the interrupt returns.
-			 */
+			/* Then switch contexts */
 
 			up_restorestate(ntcb->xcp.regs);
+
 		}
 
 		/* Copy the exception context into the TCB at the (old) head of the

--- a/os/arch/arm/src/armv7-r/arm_unblocktask.c
+++ b/os/arch/arm/src/armv7-r/arm_unblocktask.c
@@ -141,16 +141,14 @@ void up_unblock_task(struct tcb_s *tcb)
 
 			trace_sched(NULL, rtcb);
 
-#ifdef CONFIG_TASK_SCHED_HISTORY
-			/* Save the task name which will be scheduled */
-			save_task_scheduling_status(rtcb);
-#endif
+			/* Restore rtcb data for context switching */
 
-			/* Then switch contexts.  Any necessary address environment
-			 * changes will be made when the interrupt returns.
-			 */
+			up_restoretask(rtcb);
+
+			/* Then switch contexts */
 
 			up_restorestate(rtcb->xcp.regs);
+
 		}
 
 		/* We are not in an interrupt handler.  Copy the user C context

--- a/os/arch/arm/src/armv8-m/up_releasepending.c
+++ b/os/arch/arm/src/armv8-m/up_releasepending.c
@@ -62,10 +62,6 @@
 
 #include "sched/sched.h"
 #include "up_internal.h"
-#ifdef CONFIG_ARMV8M_MPU
-#include "mpu.h"
-#include <tinyara/mpu.h>
-#endif
 
 #ifdef CONFIG_TASK_SCHED_HISTORY
 #include <tinyara/debug/sysdbg.h>
@@ -82,9 +78,7 @@
 /****************************************************************************
  * Private Data
  ****************************************************************************/
-#ifdef CONFIG_SUPPORT_COMMON_BINARY
-extern uint32_t *g_umm_app_id;
-#endif
+
 /****************************************************************************
  * Private Functions
  ****************************************************************************/
@@ -137,42 +131,12 @@ void up_release_pending(void)
 			rtcb = this_task();
 			sllvdbg("New Active Task TCB=%p\n", rtcb);
 
-#ifdef CONFIG_TASK_SCHED_HISTORY
-			/* Save the task name which will be scheduled */
-			save_task_scheduling_status(rtcb);
-#endif
+			/* Restore rtcb data for context switching */
 
-			/* Restore the MPU registers in case we are switching to an application task */
-#ifdef CONFIG_ARMV8M_MPU
-			/* Condition check : Update MPU registers only if this is not a kernel thread. */
-			if ((rtcb->flags & TCB_FLAG_TTYPE_MASK) != TCB_FLAG_TTYPE_KERNEL) {
-#if defined(CONFIG_APP_BINARY_SEPARATION)
-				for (int i = 0; i < MPU_REG_NUMBER * MPU_NUM_REGIONS; i += MPU_REG_NUMBER) {
-					up_mpu_set_register(&rtcb->mpu_regs[i]);
-				}
-#endif
-			}
-#ifdef CONFIG_MPU_STACK_OVERFLOW_PROTECTION
-			up_mpu_set_register(rtcb->stack_mpu_regs);
-#endif
-#endif
+			up_restoretask(rtcb);
 
-#ifdef CONFIG_SUPPORT_COMMON_BINARY
-			if (g_umm_app_id) {
-				*g_umm_app_id = rtcb->app_id;
-			}
-#endif
-#ifdef CONFIG_TASK_MONITOR
-			/* Update rtcb active flag for monitoring. */
-			rtcb->is_active = true;
-#endif
-
-#ifdef CONFIG_ARMV8M_TRUSTZONE
-			if (rtcb->tz_context) {
-				TZ_LoadContext_S(rtcb->tz_context);
-			}
-#endif
 			/* Then switch contexts */
+
 			up_restorestate(rtcb->xcp.regs);
 
 		}

--- a/os/arch/arm/src/armv8-m/up_reprioritizertr.c
+++ b/os/arch/arm/src/armv8-m/up_reprioritizertr.c
@@ -64,10 +64,6 @@
 
 #include "sched/sched.h"
 #include "up_internal.h"
-#ifdef CONFIG_ARMV8M_MPU
-#include "mpu.h"
-#include <tinyara/mpu.h>
-#endif
 
 #ifdef CONFIG_TASK_SCHED_HISTORY
 #include <tinyara/debug/sysdbg.h>
@@ -84,9 +80,7 @@
 /****************************************************************************
  * Private Data
  ****************************************************************************/
-#ifdef CONFIG_SUPPORT_COMMON_BINARY
-extern uint32_t *g_umm_app_id;
-#endif
+
 /****************************************************************************
  * Private Functions
  ****************************************************************************/
@@ -189,42 +183,14 @@ void up_reprioritize_rtr(struct tcb_s *tcb, uint8_t priority)
 				rtcb = this_task();
 				sllvdbg("New Active Task TCB=%p\n", rtcb);
 
-#ifdef CONFIG_TASK_SCHED_HISTORY
-				/* Save the task name which will be scheduled */
-				save_task_scheduling_status(rtcb);
-#endif
-				/* Restore the MPU registers in case we are switching to an application task */
-#ifdef CONFIG_ARMV8M_MPU
-				/* Condition check : Update MPU registers only if this is not a kernel thread. */
-				if ((rtcb->flags & TCB_FLAG_TTYPE_MASK) != TCB_FLAG_TTYPE_KERNEL) {
-#if defined(CONFIG_APP_BINARY_SEPARATION)
-					for (int i = 0; i < MPU_REG_NUMBER * MPU_NUM_REGIONS; i += MPU_REG_NUMBER) {
-						up_mpu_set_register(&rtcb->mpu_regs[i]);
-					}
-#endif
-				}
-#ifdef CONFIG_MPU_STACK_OVERFLOW_PROTECTION
-				up_mpu_set_register(rtcb->stack_mpu_regs);
-#endif
-#endif
-#ifdef CONFIG_SUPPORT_COMMON_BINARY
-			if (g_umm_app_id) {
-				*g_umm_app_id = rtcb->app_id;
-			}
-#endif
-
-#ifdef CONFIG_TASK_MONITOR
-				/* Update rtcb active flag for monitoring. */
-				rtcb->is_active = true;
-#endif
-
-#ifdef CONFIG_ARMV8M_TRUSTZONE
-				if (rtcb->tz_context) {
-					TZ_LoadContext_S(rtcb->tz_context);
-				}
-#endif
+				/* Restore rtcb data for context switching */
+				
+				up_restoretask(rtcb);
+				
 				/* Then switch contexts */
+				
 				up_restorestate(rtcb->xcp.regs);
+
 			}
 
 			/* No, then we will need to perform the user context switch */

--- a/os/arch/arm/src/armv8-m/up_unblocktask.c
+++ b/os/arch/arm/src/armv8-m/up_unblocktask.c
@@ -63,10 +63,6 @@
 #include "sched/sched.h"
 #include "clock/clock.h"
 #include "up_internal.h"
-#ifdef CONFIG_ARMV8M_MPU
-#include "mpu.h"
-#include <tinyara/mpu.h>
-#endif
 
 #ifdef CONFIG_TASK_SCHED_HISTORY
 #include <tinyara/debug/sysdbg.h>
@@ -82,9 +78,7 @@
 /****************************************************************************
  * Private Data
  ****************************************************************************/
-#ifdef CONFIG_SUPPORT_COMMON_BINARY
-extern uint32_t *g_umm_app_id;
-#endif
+
 /****************************************************************************
  * Private Functions
  ****************************************************************************/
@@ -151,51 +145,20 @@ void up_unblock_task(struct tcb_s *tcb)
 			 */
 
 			up_savestate(rtcb->xcp.regs);
+
 			/* Restore the exception context of the rtcb at the (new) head
 			 * of the g_readytorun task list.
 			 */
 
 			rtcb = this_task();
 
-#ifdef CONFIG_TASK_SCHED_HISTORY
-			/* Save the task name which will be scheduled */
-			save_task_scheduling_status(rtcb);
-#endif
+			/* Restore rtcb data for context switching */
 
-			/* Restore the MPU registers in case we are switching to an application task */
-#ifdef CONFIG_ARMV8M_MPU
-			/* Condition check : Update MPU registers only if this is not a kernel thread. */
-			if ((rtcb->flags & TCB_FLAG_TTYPE_MASK) != TCB_FLAG_TTYPE_KERNEL) {
-#if defined(CONFIG_APP_BINARY_SEPARATION)
-				for (int i = 0; i < MPU_REG_NUMBER * MPU_NUM_REGIONS; i += MPU_REG_NUMBER) {
-					up_mpu_set_register(&rtcb->mpu_regs[i]);
-				}
-#endif
-			}
-#ifdef CONFIG_MPU_STACK_OVERFLOW_PROTECTION
-			up_mpu_set_register(rtcb->stack_mpu_regs);
-#endif
-#endif
-#ifdef CONFIG_SUPPORT_COMMON_BINARY
-			if (g_umm_app_id) {
-				*g_umm_app_id = rtcb->app_id;
-			}
-#endif
+			up_restoretask(rtcb);
 
-#ifdef CONFIG_TASK_MONITOR
-			/* Update rtcb active flag for monitoring. */
-			rtcb->is_active = true;
-#endif
-
-#ifdef CONFIG_ARMV8M_TRUSTZONE
-			if (rtcb->tz_context) {
-				TZ_LoadContext_S(rtcb->tz_context);
-			}
-#endif
 			/* Then switch contexts */
 
 			up_restorestate(rtcb->xcp.regs);
-
 		}
 
 		/* No, then we will need to perform the user context switch */

--- a/os/arch/arm/src/armv8-m/up_unblocktask_withoutsavereg.c
+++ b/os/arch/arm/src/armv8-m/up_unblocktask_withoutsavereg.c
@@ -62,18 +62,11 @@
 #include "sched/sched.h"
 #include "clock/clock.h"
 #include "up_internal.h"
-#ifdef CONFIG_ARMV8M_MPU
-#include "mpu.h"
-#include <tinyara/mpu.h>
-#endif
 
 #ifdef CONFIG_TASK_SCHED_HISTORY
 #include <tinyara/debug/sysdbg.h>
 #endif
 
-#ifdef CONFIG_ARMV8M_TRUSTZONE
-#include <tinyara/tz_context.h>
-#endif
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
@@ -81,9 +74,7 @@
 /****************************************************************************
  * Private Data
  ****************************************************************************/
-#ifdef CONFIG_SUPPORT_COMMON_BINARY
-extern uint32_t *g_umm_app_id;
-#endif
+
 /****************************************************************************
  * Private Functions
  ****************************************************************************/
@@ -153,41 +144,10 @@ void up_unblock_task_without_savereg(struct tcb_s *tcb)
 
 		rtcb = this_task();
 
-#ifdef CONFIG_TASK_SCHED_HISTORY
-		/* Save the task name which will be scheduled */
-		save_task_scheduling_status(rtcb);
-#endif
+		/* Restore rtcb data for context switching */
 
-		/* Restore the MPU registers in case we are switching to an application task */
-#ifdef CONFIG_ARMV8M_MPU
-		/* Condition check : Update MPU registers only if this is not a kernel thread. */
-		if ((rtcb->flags & TCB_FLAG_TTYPE_MASK) != TCB_FLAG_TTYPE_KERNEL) {
-#if defined(CONFIG_APP_BINARY_SEPARATION)
-			for (int i = 0; i < MPU_REG_NUMBER * MPU_NUM_REGIONS; i += MPU_REG_NUMBER) {
-				up_mpu_set_register(&rtcb->mpu_regs[i]);
-			}
-#endif
-		}
-#ifdef CONFIG_MPU_STACK_OVERFLOW_PROTECTION
-		up_mpu_set_register(rtcb->stack_mpu_regs);
-#endif
-#endif
+		up_restoretask(rtcb);
 
-#ifdef CONFIG_SUPPORT_COMMON_BINARY
-		if (g_umm_app_id) {
-			*g_umm_app_id = rtcb->app_id;
-		}
-#endif
-#ifdef CONFIG_TASK_MONITOR
-		/* Update rtcb active flag for monitoring. */
-		rtcb->is_active = true;
-#endif
-
-#ifdef CONFIG_ARMV8M_TRUSTZONE
-		if (rtcb->tz_context) {
-			TZ_LoadContext_S(rtcb->tz_context);
-		}
-#endif
 		/* Then switch contexts */
 
 		up_restorestate(rtcb->xcp.regs);

--- a/os/arch/arm/src/bcm4390x/Make.defs
+++ b/os/arch/arm/src/bcm4390x/Make.defs
@@ -49,7 +49,7 @@ endif
 CMN_CSRCS  = up_allocateheap.c up_initialize.c up_idle.c up_interruptcontext.c
 CMN_CSRCS += up_exit.c up_createstack.c up_releasestack.c up_usestack.c
 CMN_CSRCS += up_vfork.c up_puts.c up_mdelay.c up_stackframe.c up_udelay.c
-CMN_CSRCS += up_modifyreg8.c up_modifyreg16.c up_modifyreg32.c
+CMN_CSRCS += up_modifyreg8.c up_modifyreg16.c up_modifyreg32.c up_restoretask.c
 ifeq ($(CONFIG_LATENCY_MEASURE),y)
 CMN_CSRCS += up_getclocks.c
 endif

--- a/os/arch/arm/src/common/up_restoretask.c
+++ b/os/arch/arm/src/common/up_restoretask.c
@@ -1,0 +1,106 @@
+/****************************************************************************
+ *
+ * Copyright 2021 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+#include <tinyara/config.h>
+#include <sched.h>
+#ifdef CONFIG_SUPPORT_COMMON_BINARY
+#include <stdint.h>
+#endif
+#ifdef CONFIG_TASK_MONITOR
+#include <stdbool.h>
+#endif
+#ifdef CONFIG_TASK_SCHED_HISTORY
+#include <tinyara/debug/sysdbg.h>
+#endif
+#ifdef CONFIG_ARMV8M_TRUSTZONE
+#include <tinyara/tz_context.h>
+#endif
+#ifdef CONFIG_ARM_MPU
+#include <tinyara/mpu.h>
+#include "mpu.h"
+#endif
+#include <tinyara/arch.h>
+
+#include "up_internal.h"
+#include "sched/sched.h"
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+#ifdef CONFIG_SUPPORT_COMMON_BINARY
+extern uint32_t *g_umm_app_id;
+#endif
+
+/************************************************************************************
+ * Name: up_restoretask
+ *
+ * Description:
+ *   Restore and set data needed for context switching from tcb before context switching.
+ *
+ *   This function is called only from the TinyAra scheduling
+ *   logic.
+ *
+ * Inputs:
+ *   tcb: Refers to the tcb which will be scheduled.
+ *     This tcb is at the head of the g_readytorun task lists.
+ *
+ ************************************************************************************/
+void up_restoretask(struct tcb_s *tcb)
+{
+	if (tcb) {
+#ifdef CONFIG_TASK_SCHED_HISTORY
+		/* Save the task name which will be scheduled */
+		save_task_scheduling_status(tcb);
+#endif
+
+		/* Restore the MPU registers in case we are switching to an application task */
+#ifdef CONFIG_ARM_MPU
+#ifdef CONFIG_APP_BINARY_SEPARATION
+		/* Condition check : Update MPU registers only if this is not a kernel thread. */
+
+		if ((tcb->flags & TCB_FLAG_TTYPE_MASK) != TCB_FLAG_TTYPE_KERNEL) {
+			for (int i = 0; i < MPU_REG_NUMBER * MPU_NUM_REGIONS; i += MPU_REG_NUMBER) {
+				up_mpu_set_register(&tcb->mpu_regs[i]);
+			}
+		}
+
+#ifdef CONFIG_SUPPORT_COMMON_BINARY
+		if (g_umm_app_id) {
+			*g_umm_app_id = tcb->app_id;
+		}
+#endif
+#endif
+#ifdef CONFIG_MPU_STACK_OVERFLOW_PROTECTION
+		up_mpu_set_register(tcb->stack_mpu_regs);
+#endif
+#endif
+
+#ifdef CONFIG_TASK_MONITOR
+		/* Update rtcb active flag for monitoring. */
+		tcb->is_active = true;
+#endif
+
+#ifdef CONFIG_ARMV8M_TRUSTZONE
+		if (tcb->tz_context) {
+			TZ_LoadContext_S(tcb->tz_context);
+		}
+#endif
+	}
+}

--- a/os/arch/arm/src/imxrt/Make.defs
+++ b/os/arch/arm/src/imxrt/Make.defs
@@ -66,7 +66,7 @@ CMN_CSRCS += up_releasepending.c up_releasestack.c up_reprioritizertr.c
 CMN_CSRCS += up_schedulesigaction.c up_sigdeliver.c up_stackframe.c
 CMN_CSRCS += up_unblocktask.c up_usestack.c up_doirq.c up_hardfault.c
 CMN_CSRCS += up_svcall.c up_vfork.c up_trigger_irq.c up_systemreset.c
-CMN_CSRCS += up_unblocktask_withoutsavereg.c
+CMN_CSRCS += up_unblocktask_withoutsavereg.c up_restoretask.c
 
 ifeq ($(CONFIG_STACK_COLORATION),y)
 CMN_CSRCS += go_os_start.c

--- a/os/arch/arm/src/s5j/Make.defs
+++ b/os/arch/arm/src/s5j/Make.defs
@@ -94,7 +94,7 @@ CMN_CSRCS += arm_releasepending.c arm_reprioritizertr.c
 CMN_CSRCS += arm_schedulesigaction.c arm_sigdeliver.c arm_syscall.c
 CMN_CSRCS += arm_unblocktask.c arm_undefinedinsn.c
 CMN_CSRCS += arm_copyarmstate.c
-CMN_CSRCS += up_checkstack.c
+CMN_CSRCS += up_checkstack.c up_restoretask.c
 
 ifeq ($(CONFIG_STACK_COLORATION),y)
 CMN_CSRCS += go_os_start.c

--- a/os/arch/arm/src/stm32/Make.defs
+++ b/os/arch/arm/src/stm32/Make.defs
@@ -69,7 +69,7 @@ CMN_CSRCS += up_memfault.c up_busfault.c up_usagefault.c up_modifyreg8.c up_modi
 CMN_CSRCS += up_releasepending.c up_releasestack.c up_reprioritizertr.c
 CMN_CSRCS += up_schedulesigaction.c up_sigdeliver.c up_stackframe.c
 CMN_CSRCS += up_systemreset.c up_unblocktask.c up_usestack.c up_doirq.c
-CMN_CSRCS += up_hardfault.c up_svcall.c up_vfork.c
+CMN_CSRCS += up_hardfault.c up_svcall.c up_vfork.c up_restoretask.c
 
 ifeq ($(CONFIG_STACK_COLORATION),y)
 CMN_CSRCS += go_os_start.c

--- a/os/arch/arm/src/stm32l4/Make.defs
+++ b/os/arch/arm/src/stm32l4/Make.defs
@@ -55,7 +55,7 @@ CMN_CSRCS += up_releasepending.c up_releasestack.c up_reprioritizertr.c
 CMN_CSRCS += up_schedulesigaction.c up_sigdeliver.c up_stackframe.c
 CMN_CSRCS += up_svcall.c up_systemreset.c up_trigger_irq.c up_udelay.c
 CMN_CSRCS += up_unblocktask.c up_usestack.c up_vfork.c
-CMN_CSRCS += up_puts.c
+CMN_CSRCS += up_puts.c up_restoretask.c
 
 ifeq ($(CONFIG_STACK_COLORATION),y)
 CMN_CSRCS += go_os_start.c

--- a/os/arch/arm/src/tiva/Make.defs
+++ b/os/arch/arm/src/tiva/Make.defs
@@ -62,7 +62,7 @@ CMN_CSRCS += up_modifyreg8.c up_modifyreg16.c up_modifyreg32.c
 CMN_CSRCS += up_releasepending.c up_releasestack.c up_reprioritizertr.c
 CMN_CSRCS += up_schedulesigaction.c up_sigdeliver.c up_stackframe.c
 CMN_CSRCS += up_unblocktask.c up_usestack.c up_doirq.c up_hardfault.c
-CMN_CSRCS += up_svcall.c up_vfork.c up_checkspace.c
+CMN_CSRCS += up_svcall.c up_vfork.c up_checkspace.c up_restoretask.c
 
 ifeq ($(CONFIG_SCHED_YIELD_OPTIMIZATION),y)
 CMN_CSRCS += up_schedyield.c

--- a/os/include/tinyara/arch.h
+++ b/os/include/tinyara/arch.h
@@ -432,6 +432,23 @@ void up_allocate_secure_context(TZ_ModuleId_t size);
 void up_free_secure_context();
 #endif
 
+/************************************************************************************
+ * Name: up_restoretask
+ *
+ * Description:
+ *   Restore and set data needed for context switching from tcb before context switching.
+ *
+ *   This function is called only from the TinyAra scheduling
+ *   logic.
+ *
+ * Inputs:
+ *   tcb: Refers to the tcb which will be scheduled.
+ *     This tcb is at the head of the g_readytorun task lists.
+ *
+ ************************************************************************************/
+
+void up_restoretask(struct tcb_s *tcb);
+
 /****************************************************************************
  * Name: up_unblock_task
  *


### PR DESCRIPTION
- Unify same operations for context switching in each functions.
- It can help to avoid missing and you don't need to modify all files when some operations or values are changed.