### PR TITLE
arch/arm/src/armv7-r : Add task monitor functionality

### DIFF
--- a/os/arch/arm/src/armv7-r/arm_syscall.c
+++ b/os/arch/arm/src/armv7-r/arm_syscall.c
@@ -275,6 +275,9 @@ uint32_t *arm_syscall(uint32_t *regs)
 
 		regs = (uint32_t *)regs[REG_R1];
 		DEBUGASSERT(regs);
+#ifdef CONFIG_TASK_MONITOR
+		rtcb->is_active = true;
+#endif
 	}
 	break;
 #endif


### PR DESCRIPTION
Task monitor is kernel thread which monitor the tasks/pthreads.
It checks if registered tasks/pthreads are alive.
It was implemented in v7m and v8m, so implement to v7-r also.