### PR TITLE
framework/wifi_manager: fix parameter validation in scan api

### DIFF
--- a/framework/include/wifi_manager/wifi_manager.h
+++ b/framework/include/wifi_manager/wifi_manager.h
@@ -40,6 +40,7 @@ extern "C" {
 #define WIFIMGR_MACADDR_LEN        6
 #define WIFIMGR_MACADDR_STR_LEN    17
 #define WIFIMGR_SSID_LEN           32
+#define WIFIMGR_2G_CHANNEL_MAX     14
 #define WIFIMGR_PASSPHRASE_LEN     64
 /**
  * @brief <b> wifi MAC/PHY standard types
@@ -386,7 +387,7 @@ wifi_manager_result_e wifi_manager_disconnect_ap(void);
  *     if both SSID and channel are not set in config then it'll return error.
  *     wifi_manager check whether SSID is set by ssid_length in config. In the same way
  *     not checking channel is 0, but checking channel is greater than 0 and less than 15 in 2.5GHz.
- *     So if both channel and ssid_length are 0 then wifi_manager return WIFI_MANAGER_INVALID_ARGS.
+ *     So if both channel and ssid_length are 0 then wifi_manager returns WIFI_MANAGER_INVALID_ARGS.
  *     To request full scan to wifi_manager, config which is assigned null be pass to wifi_manager.
  */
 wifi_manager_result_e wifi_manager_scan_ap(wifi_manager_scan_config_s *config);

--- a/framework/src/wifi_manager/wifi_manager_api.c
+++ b/framework/src/wifi_manager/wifi_manager_api.c
@@ -189,13 +189,12 @@ wifi_manager_result_e wifi_manager_scan_ap(wifi_manager_scan_config_s *config)
 {
 	NET_LOGI(TAG, "-->\n");
 	if (config) {
-		if (config->channel < 0 || config->channel > 14) {
+		if (config->channel > WIFIMGR_2G_CHANNEL_MAX) {
 			WIFIADD_ERR_RECORD(ERR_WIFIMGR_INVALID_ARGUMENTS);
 			NET_LOGE(TAG, "invalid channel range %d\n", config->channel);
 			return WIFI_MANAGER_INVALID_ARGS;
 		}
-		if (config->ssid_length > WIFIMGR_SSID_LEN
-			|| config->ssid_length < 0) {
+		if (config->ssid_length > WIFIMGR_SSID_LEN) {
 			WIFIADD_ERR_RECORD(ERR_WIFIMGR_INVALID_ARGUMENTS);
 			return WIFI_MANAGER_INVALID_ARGS;
 		}


### PR DESCRIPTION
Both channel and ssid_length are unsigned int. So they're never less
than zero.