### PR TITLE
board/rtl8721csm/i2c_api.c : Initialize local variable

### DIFF
--- a/os/board/rtl8721csm/src/component/common/bluetooth/realtek/sdk/board/common/os/tizenrt/osif_tizenrt.c
+++ b/os/board/rtl8721csm/src/component/common/bluetooth/realtek/sdk/board/common/os/tizenrt/osif_tizenrt.c
@@ -223,6 +223,10 @@ bool osif_task_priority_set(void *p_handle, uint16_t priority)
 	}
 
 	p_tcb = sched_gettcb(pid);
+	if (!p_tcb) {
+		printf("[osif_task_priority_set] pid %d tcb is NULL\r\n", pid);
+		return _FAIL;
+	}
 
 	priority = (priority + SCHED_PRIORITY_DEFAULT > SCHED_PRIORITY_MAX || priority + SCHED_PRIORITY_DEFAULT < SCHED_PRIORITY_MIN)? SCHED_PRIORITY_DEFAULT : priority + SCHED_PRIORITY_DEFAULT;
 

--- a/os/board/rtl8721csm/src/component/common/mbed/targets/hal/rtl8721d/i2c_api.c
+++ b/os/board/rtl8721csm/src/component/common/mbed/targets/hal/rtl8721d/i2c_api.c
@@ -669,7 +669,7 @@ void i2c_reset(i2c_t *obj)
   */
 void i2c_restart_enable(i2c_t *obj)
 {
-    uint32_t i2cen;
+	uint32_t i2cen = 0;
 
 	if (obj->I2Cx->IC_ENABLE & BIT_CTRL_IC_ENABLE) {
 		I2C_Cmd(obj->I2Cx, DISABLE);
@@ -692,7 +692,7 @@ void i2c_restart_enable(i2c_t *obj)
   */
 void i2c_restart_disable(i2c_t *obj)
 {
-    uint32_t i2cen;
+	uint32_t i2cen = 0;
 
 	if (obj->I2Cx->IC_ENABLE & BIT_CTRL_IC_ENABLE) {
 		I2C_Cmd(obj->I2Cx, DISABLE);


### PR DESCRIPTION
WID:12571040 Uninitialized data is read from local variable 'i2cen' at i2c_api.c:704.

Signed-off-by: jeongchanKim <jc_.kim@samsung.com>