### PR TITLE
apps/system/utils/Kconfig : Add dependency of PROCFS in StackMonitor

### DIFF
--- a/apps/system/utils/Kconfig
+++ b/apps/system/utils/Kconfig
@@ -181,7 +181,7 @@ config ENABLE_PS
 config ENABLE_STACKMONITOR
 	bool "Stack monitor"
 	default n
-	depends on !FS_PROCFS_EXCLUDE_PROCESS
+	depends on FS_PROCFS && !FS_PROCFS_EXCLUDE_PROCESS
 	select STACK_COLORATION
 	---help---
 		The stack monitor is a daemon that will periodically assess


### PR DESCRIPTION
StackMonitor only works when FS_PROCFS is enabled.

Signed-off-by: jeongchanKim <jc_.kim@samsung.com>