### PR TITLE
os/board/rtl8721csm: add wifi auth type in connection

### DIFF
--- a/os/board/rtl8721csm/src/component/common/api/wifi_interactive_mode.c
+++ b/os/board/rtl8721csm/src/component/common/api/wifi_interactive_mode.c
@@ -463,6 +463,17 @@ int8_t cmd_wifi_connect(trwifi_ap_config_s *ap_connect_config, void *arg)
 		password_len = ap_connect_config->passphrase_length;
 		semaphore = NULL;
 		break;
+	case WIFI_UTILS_AUTH_WPA_PSK:
+		if (ap_connect_config->ap_crypto_type == WIFI_UTILS_CRYPTO_AES) {
+			security_type = RTW_SECURITY_WPA_AES_PSK;
+		} else {
+			security_type = RTW_SECURITY_WPA_TKIP_PSK;
+		}
+		password = ap_connect_config->passphrase;
+		ssid_len = strlen((const char *)ssid);
+		password_len = ap_connect_config->passphrase_length;
+		semaphore = NULL;
+		break;
 	default:
 		while (1) {
 			security_type = (_get_ap_security_mode((char*)ssid));


### PR DESCRIPTION
- add WPA_PSK auth type in rtl wifi connection