### PR TITLE
arm/src/up_doirq.c: move local variable definition into proper conditional

### DIFF
--- a/os/arch/arm/src/armv7-m/up_doirq.c
+++ b/os/arch/arm/src/armv7-m/up_doirq.c
@@ -92,7 +92,6 @@ uint32_t *up_doirq(int irq, uint32_t *regs)
 {
 #ifdef CONFIG_ARCH_NESTED_INTERRUPT
 	irqstate_t flags;
-	uint32_t stack_remain;
 #endif
 	board_led_on(LED_INIRQ);
 #ifdef CONFIG_SUPPRESS_INTERRUPTS
@@ -104,6 +103,7 @@ uint32_t *up_doirq(int irq, uint32_t *regs)
 #ifdef CONFIG_ARCH_NESTED_INTERRUPT_STACKCHECK
 
 	/* check remaining stack available, assert if stack overflows */
+	uint32_t stack_remain;
 
 	stack_remain = (CONFIG_ARCH_INTERRUPTSTACK & ~3) - up_check_intstack();
 	if (stack_remain < 8) {

--- a/os/arch/arm/src/armv8-m/up_doirq.c
+++ b/os/arch/arm/src/armv8-m/up_doirq.c
@@ -92,7 +92,6 @@ uint32_t *up_doirq(int irq, uint32_t *regs)
 {
 #ifdef CONFIG_ARCH_NESTED_INTERRUPT
 	irqstate_t flags;
-	uint32_t stack_remain;
 #endif
 	board_led_on(LED_INIRQ);
 #ifdef CONFIG_SUPPRESS_INTERRUPTS
@@ -104,6 +103,7 @@ uint32_t *up_doirq(int irq, uint32_t *regs)
 #ifdef CONFIG_ARCH_NESTED_INTERRUPT_STACKCHECK
 
 	/* check remaining stack available, assert if stack overflows */
+	uint32_t stack_remain;
 
 	stack_remain = (CONFIG_ARCH_INTERRUPTSTACK & ~3) - up_check_intstack();
 	if (stack_remain < 8) {


### PR DESCRIPTION
Fix the following build warnings:

CC: armv8-m/up_doirq.c
armv8-m/up_doirq.c: In function 'up_doirq':
armv8-m/up_doirq.c:95:11: warning: unused variable 'stack_remain' [-Wunused-variable]
uint32_t stack_remain;
^~~~~~~~~~~~
CC: armv7-m/up_doirq.c
armv7-m/up_doirq.c: In function 'up_doirq':
armv7-m/up_doirq.c:95:11: warning: unused variable 'stack_remain' [-Wunused-variable]
uint32_t stack_remain;
^~~~~~~~~~~~