### PR TITLE
kernel/binary_manager: Support binary update when new binary is downloaded

### DIFF
--- a/framework/include/binary_manager/binary_manager.h
+++ b/framework/include/binary_manager/binary_manager.h
@@ -38,16 +38,14 @@
  ****************************************************************************/
 #ifdef CONFIG_BINMGR_UPDATE
 /**
- * @brief Loads the binary after downloading a new binary
+ * @brief Loads the new binaries after downloading them
  * @details @b #include <binary_manager/binary_manager.h>\n
- *  This function loads a new binary after downloading the binary.\n
- * It requests the binary manager to load the input binary name.
- * @param[in] binary_name The name of a new binary to be loaded
+ *  This function loads the new binaries after downloading them.\n
  * @return A defined value of binmgr_result_type_e in <tinyara/binary_manager.h>
  *         0 (BINMGR_OK) On success. On failure, negative value is returned.
  * @since TizenRT v3.0
  */
-binmgr_result_type_e binary_manager_update_binary(char *binary_name);
+binmgr_result_type_e binary_manager_update_binary(void);
 
 /**
  * @brief Get the binary information with name

--- a/framework/src/binary_manager/binary_manager_interface.c
+++ b/framework/src/binary_manager/binary_manager_interface.c
@@ -41,7 +41,6 @@ binmgr_result_type_e binary_manager_set_request(binmgr_request_t *request_msg, i
 	case BINMGR_GET_STATE:
 	case BINMGR_GET_INFO:
 	case BINMGR_NOTIFY_STARTED:
-	case BINMGR_UPDATE:
 		if (arg == NULL) {
 			bmdbg("Invalid param, cmd : %d\n", cmd);
 			return BINMGR_INVALID_PARAM;
@@ -64,6 +63,7 @@ binmgr_result_type_e binary_manager_set_request(binmgr_request_t *request_msg, i
 		}
 		request_msg->data.cb_info = (binmgr_cb_t *)arg;
 		break;
+	case BINMGR_UPDATE:
 	default:
 		break;
 	}

--- a/framework/src/binary_manager/binary_manager_update.c
+++ b/framework/src/binary_manager/binary_manager_update.c
@@ -30,6 +30,39 @@
 #include <binary_manager/binary_manager.h>
 #include "binary_manager_internal.h"
 
+binmgr_result_type_e binary_manager_set_bootparam(void)
+{
+	binmgr_result_type_e ret;
+	binmgr_request_t request_msg;
+	binmgr_setbp_response_t response_msg;
+
+	ret = binary_manager_set_request(&request_msg, BINMGR_SETBP, NULL);
+	if (ret != BINMGR_OK) {
+		return ret;
+	}
+
+	ret = binary_manager_send_request(&request_msg);
+	if (ret != BINMGR_OK) {
+		return ret;
+	}
+
+	ret = binary_manager_receive_response(&response_msg, sizeof(binmgr_setbp_response_t));
+	if (ret != BINMGR_OK) {
+		return ret;
+	}
+
+	if (response_msg.result == BINMGR_OK) {
+		/* Copy binary info data */
+		is_updated
+	} else {
+		bmdbg("Binary manager set BOOTPARAM FAIL %d\n", response_msg.result);
+	}
+
+	return response_msg.result;
+
+}
+
+
 binmgr_result_type_e binary_manager_update_binary(void)
 {
 	binmgr_result_type_e ret;

--- a/framework/src/binary_manager/binary_manager_update.c
+++ b/framework/src/binary_manager/binary_manager_update.c
@@ -30,17 +30,12 @@
 #include <binary_manager/binary_manager.h>
 #include "binary_manager_internal.h"
 
-binmgr_result_type_e binary_manager_update_binary(char *binary_name)
+binmgr_result_type_e binary_manager_update_binary(void)
 {
 	binmgr_result_type_e ret;
 	binmgr_request_t request_msg;
 
-	if (binary_name == NULL || strlen(binary_name) > BIN_NAME_MAX - 1) {
-		bmdbg("load_new_binary failed : invalid binary name\n");
-		return BINMGR_INVALID_PARAM;
-	}
-
-	ret = binary_manager_set_request(&request_msg, BINMGR_UPDATE, binary_name);
+	ret = binary_manager_set_request(&request_msg, BINMGR_UPDATE, NULL);
 	if (ret != BINMGR_OK) {
 		return ret;
 	}

--- a/loadable_apps/loadable_sample/wifiapp/binary_update.c
+++ b/loadable_apps/loadable_sample/wifiapp/binary_update.c
@@ -408,7 +408,7 @@ static int binary_update_reload(char *name)
 	int ret;
 
 	printf("\n** Binary Update RELOAD [%s] test.\n", name);
-	ret = binary_manager_update_binary(name);
+	ret = binary_manager_update_binary();
 	if (ret == OK) {
 		printf("RELOAD [%s] SUCCESS\n", name);
 	} else {

--- a/os/include/tinyara/binary_manager.h
+++ b/os/include/tinyara/binary_manager.h
@@ -106,6 +106,7 @@ typedef enum binary_state binary_state_e;
 enum binmgr_request_msg_type {
 	BINMGR_GET_INFO,
 	BINMGR_GET_INFO_ALL,
+	BINMGR_SETBP,
 	BINMGR_UPDATE,
 	BINMGR_GET_STATE,
 	BINMGR_CREATE_BIN,
@@ -229,6 +230,12 @@ struct binmgr_createbin_response_s {
 	char binpath[BINARY_PATH_LEN];
 };
 typedef struct binmgr_createbin_response_s binmgr_createbin_response_t;
+
+struct binmgr_setbp_response_s {
+	binmgr_result_type_e result;
+	bool is_updated;
+};
+typedef struct binmgr_setbp_response_s binmgr_setbp_response_t;
 
 struct binmgr_getstate_response_s {
 	binmgr_result_type_e result;

--- a/os/kernel/binary_manager/binary_manager.c
+++ b/os/kernel/binary_manager/binary_manager.c
@@ -28,16 +28,10 @@
 #include <string.h>
 #include <signal.h>
 #include <stdlib.h>
-#include <sys/boardctl.h>
 
 #include <tinyara/binary_manager.h>
 #ifdef CONFIG_BINMGR_RECOVERY
 #include <tinyara/kthread.h>
-#endif
-
-#ifdef CONFIG_SYSTEM_REBOOT_REASON
-#include <tinyara/reboot_reason.h>
-#include <arch/reboot_reason.h>
 #endif
 
 #include "sched/sched.h"
@@ -173,15 +167,8 @@ int binary_manager(int argc, char *argv[])
 			binary_manager_create_entry(request_msg.requester_pid, request_msg.data.update_bin.bin_name, request_msg.data.update_bin.version);
 			break;
 		case BINMGR_UPDATE:
-			if (!strncmp("kernel", request_msg.data.bin_name, BIN_NAME_MAX)) {
-#ifdef CONFIG_SYSTEM_REBOOT_REASON
-				up_reboot_reason_write(REBOOT_SYSTEM_BINARY_UPDATE);
-#endif
-				boardctl(BOARDIOC_RESET, EXIT_SUCCESS);
-				break;
-			}
 #ifdef CONFIG_APP_BINARY_SEPARATION
-			binary_manager_execute_loader(LOADCMD_UPDATE, binary_manager_get_index_with_name(request_msg.data.bin_name));
+			binary_manager_execute_loader(LOADCMD_UPDATE, 0);
 #endif
 			break;
 #ifdef CONFIG_APP_BINARY_SEPARATION

--- a/os/kernel/binary_manager/binary_manager.c
+++ b/os/kernel/binary_manager/binary_manager.c
@@ -166,6 +166,9 @@ int binary_manager(int argc, char *argv[])
 		case BINMGR_CREATE_BIN:
 			binary_manager_create_entry(request_msg.requester_pid, request_msg.data.update_bin.bin_name, request_msg.data.update_bin.version);
 			break;
+		case BINMGR_SETBP:
+			binary_manager_update_bootparam(request_msg.requester_pid);
+			break;
 		case BINMGR_UPDATE:
 #ifdef CONFIG_APP_BINARY_SEPARATION
 			binary_manager_execute_loader(LOADCMD_UPDATE, 0);

--- a/os/kernel/binary_manager/binary_manager.h
+++ b/os/kernel/binary_manager/binary_manager.h
@@ -253,14 +253,16 @@ void binary_manager_get_state_with_name(int request_pid, char *bin_name);
 void binary_manager_send_response(char *q_name, void *response_msg, int msg_size);
 int binary_manager_register_ubin(char *name, uint32_t version, uint8_t load_priority);
 void binary_manager_scan_ubin_all(void);
-int binary_manager_scan_ubin(int bin_idx);
+int binary_manager_scan_ubin(int bin_idx, bool *need_update);
 int binary_manager_read_header(char *path, user_binary_header_t *header_data, bool crc_check);
 int binary_manager_create_entry(int requester_pid, char *bin_name, int version);
 void binary_manager_release_binary_sem(int bin_idx);
 void binary_manager_update_running_state(int bin_id);
 int binary_manager_get_index_with_name(char *bin_name);
-int binary_manager_scan_bootparam(void);
+int binary_manager_scan_bootparam(binmgr_bpinfo_t *bp_info);
+int binary_manager_update_bpinfo(void);
 binmgr_bpdata_t *binary_manager_get_bpdata(void);
+int binary_manager_update_bootparam(void);
 
 /****************************************************************************
  * Binary Manager Main Thread

--- a/os/kernel/binary_manager/binary_manager.h
+++ b/os/kernel/binary_manager/binary_manager.h
@@ -262,7 +262,7 @@ int binary_manager_get_index_with_name(char *bin_name);
 int binary_manager_scan_bootparam(binmgr_bpinfo_t *bp_info);
 int binary_manager_update_bpinfo(void);
 binmgr_bpdata_t *binary_manager_get_bpdata(void);
-int binary_manager_update_bootparam(void);
+int binary_manager_update_bootparam(int requester_pid);
 
 /****************************************************************************
  * Binary Manager Main Thread

--- a/os/kernel/binary_manager/binary_manager_binfile.c
+++ b/os/kernel/binary_manager/binary_manager_binfile.c
@@ -151,14 +151,15 @@ void binary_manager_scan_ubin_all(void)
  *	 This function scans binary files of binary with specific index.
  *
  ****************************************************************************/
-int binary_manager_scan_ubin(int bin_idx)
+int binary_manager_scan_ubin(int bin_idx, bool *need_update)
 {
 	int ret;
 	DIR *dirp;
 	int file_idx;
 	int name_len;
-	int latest_ver;
 	int latest_idx;
+	uint32_t latest_ver;
+	uint32_t running_ver;
 	char *bin_name;
 	user_binary_header_t header_data;
 	char filepath[BINARY_PATH_LEN];
@@ -175,6 +176,8 @@ int binary_manager_scan_ubin(int bin_idx)
 	file_idx = 0;
 	latest_ver = 0;
 	latest_idx = -1;
+	*need_update = false;
+	running_ver = BIN_VER(bin_idx, BIN_USEIDX(bin_idx));
 	bin_name = BIN_NAME(bin_idx);
 	name_len = strlen(bin_name);
 
@@ -201,7 +204,10 @@ int binary_manager_scan_ubin(int bin_idx)
 					latest_ver = header_data.bin_ver;
 					latest_idx = file_idx;
 					BIN_USEIDX(bin_idx) = latest_idx;
-					bmvdbg("Latest version %d, idx %d\n", latest_ver, latest_idx);
+					if (running_ver != latest_ver) {
+						*need_update = true;
+					}
+					bmvdbg("Latest version %u, idx %d\n", latest_ver, latest_idx);
 				}
 			}
 			file_idx++;


### PR DESCRIPTION
- Support binary update when new binary is downloaded
  - Binary manager scans all binaries and checks versions when update request
  - It reloads the binaries that new binary exists
- Change binary_manager_update_binary(char *name) to binary_manager_update_binary
  : User doesn't need to call binary_manager_update_binary with name because binary manager checks all binaries
- Update bootparam when new kernel binary exist and Reboot