### PR TITLE
os/board/rtl8721csm/src/Makefile : To use arch from board, add CFLAGS

### DIFF
--- a/os/board/rtl8721csm/src/Makefile
+++ b/os/board/rtl8721csm/src/Makefile
@@ -197,9 +197,12 @@ ifeq ($(WINTOOL),y)
   CFLAGS += -I "${shell cygpath -w $(BOARD_SRCDIR)/common}"
   CFLAGS += -I "${shell cygpath -w $(BOARD_SRCDIR)/$(CONFIG_ARCH_BOARD)/src}"
 else
+  CFLAGS += -I$(ARCH_SRCDIR)/chip
   CFLAGS += -I$(ARCH_SRCDIR)/common
+  CFLAGS += -I$(COMPONENT_DIR)/soc/realtek/amebad/cmsis
   CFLAGS += -I$(BOARD_SRCDIR)/common
   CFLAGS += -I$(ARCH_SRCDIR)/armv8-m
+  CFLAGS += -I$(BOARD_SRCDIR)/$(CONFIG_ARCH_BOARD)/src
 endif
 
 all: libboard$(LIBEXT)


### PR DESCRIPTION
There is a build error for header include. To fix this, add CFLAGS about arch
rtl8721csm_boot.c:76:24: fatal error: amebad_i2c.h: No such file or directory
 #include "amebad_i2c.h"
                        ^

Signed-off-by: jeongchanKim <jc_.kim@samsung.com>