### PR TITLE
kernel/sem_wait.c : Add comment about semcount increasing awakened by…

### DIFF
--- a/os/kernel/semaphore/sem_wait.c
+++ b/os/kernel/semaphore/sem_wait.c
@@ -221,9 +221,8 @@ int sem_wait(FAR sem_t *sem)
 			 * latter cases be examining the errno value.
 			 *
 			 * In the event that the semaphore wait was interrupted by a signal or
-			 * a timeout, certain semaphore clean-up operations have already been
-			 * performed (see sem_waitirq.c).  Specifically:
-			 *
+			 * a timeout, certain semaphore clean-up operations like semcount recovery
+			 * have already been performed (see sem_waitirq.c). Specifically:
 			 * - sem_canceled() was called to restore the priority of all threads
 			 *   that hold a reference to the semaphore,
 			 * - The semaphore count was decremented, and


### PR DESCRIPTION
… signal or timeout

If a semaphore is awakened by signal or timeout, its semcount was increased from sem_waitirq.
In the sem_wait code, there is no mention about semcount restore, so added the description about this.

Signed-off-by: jeongchanKim <jc_.kim@samsung.com>