### PR TITLE
arch/arm/src/amebad: Buffer fix for mixed uart logs.

### DIFF
--- a/os/arch/arm/src/amebad/amebad_serial.c
+++ b/os/arch/arm/src/amebad/amebad_serial.c
@@ -114,7 +114,7 @@
 #elif defined(CONFIG_UART1_SERIAL_CONSOLE)
 #define CONSOLE_DEV             g_uart1port             /* UART1 is console */
 #define TTYS0_DEV               g_uart1port             /* UART1 is ttyS0 */
-#define CONSOLE                 UART3_DEV
+#define CONSOLE                 UART1_DEV
 #define UART1_ASSIGNED  1
 #define HAVE_SERIAL_CONSOLE
 #elif defined(CONFIG_UART2_SERIAL_CONSOLE)
@@ -672,29 +672,7 @@ static bool rtl8721d_up_txready(struct uart_dev_s *dev)
 {
 	struct rtl8721d_up_dev_s *priv = (struct rtl8721d_up_dev_s *)dev->priv;
 	DEBUGASSERT(priv);
-
-#if defined(CONFIG_UART0_SERIAL_CONSOLE)
-	if (uart_index_get(priv->tx) == 0){
-		while (!serial_writable(sdrv[uart_index_get(priv->tx)]));
-		return true;
-	}
-	else
-#elif defined(CONFIG_UART1_SERIAL_CONSOLE)
-	if (uart_index_get(priv->tx) == 3){
-		while (!serial_writable(sdrv[uart_index_get(priv->tx)]));
-		return true;
-	}
-	else
-#elif defined(CONFIG_UART2_SERIAL_CONSOLE)
-	if (uart_index_get(priv->tx) == 2){
-		while (!serial_writable(sdrv[uart_index_get(priv->tx)]));
-		return true;
-	}
-	else
-#endif
-	{
-		return (serial_writable(sdrv[uart_index_get(priv->tx)]));
-	}
+	return (serial_writable(sdrv[uart_index_get(priv->tx)]));
 }
 
 /****************************************************************************


### PR DESCRIPTION
syslog(lldbg) logs are stored in a buffer until we reach end of the line and then the entire line is output by disabling uart interrupts to prevent mixed logs during application context.

example run:

[tc_libc_math_roundl] PASS
tc_libc_misc_lib_dumpbuffer (0x20083b4):

0000: 53414d53554e472d54697a656e5254                                    SAMSUNG-TizenRT
[t
tc_libc_misc_lib_dumpbuffer (0x20042d0):
c_li
0000: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a ................ ................
bc_m
0020: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a ................ ................
ath
0040: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a ................ ................
_sc
0060: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a ................ ................
alb
0080: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a ................ ................
n]
00a0: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a ................ ................
PAS
00c0: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a ................ ................
S
00e0: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a ................ ................

[tc_libc_math_scalbnf] PASS

[tc_libc_math_scalbnl] PASS
