### PR TITLE
binfmt/libelf/libelf_sections.c : Fix build warning for return

### DIFF
--- a/os/binfmt/libelf/libelf_sections.c
+++ b/os/binfmt/libelf/libelf_sections.c
@@ -215,6 +215,7 @@ void *elf_find_text_section_addr(int bin_idx)
 		}
 		info = (FAR void *)sq_next((FAR sq_entry_t *)info);
 	}
+	return NULL;
 }
 
 void elf_save_bin_section_addr(struct binary_s *bin)


### PR DESCRIPTION
/root/tizenrt/os/include/tinyara/binfmt/elf.h: In function 'elf_find_text_section_addr':
libelf/libelf_sections.c:218:1: warning: control reaches end of non-void function [-Wreturn-type]
 }
 ^

Signed-off-by: jeongchanKim <jc_.kim@samsung.com>