### PR TITLE
drivers/lwnl: add data pointer copy mode in lwnl_postmsg

### DIFF
--- a/os/drivers/lwnl/lwnl.c
+++ b/os/drivers/lwnl/lwnl.c
@@ -364,7 +364,7 @@ int lwnl_unregister(struct lwnl_lowerhalf_s *dev)
 	return 0;
 }
 
-int lwnl_postmsg(lwnl_dev_type dev, uint32_t evt, void *buffer, uint32_t buf_len)
+int lwnl_postmsg(lwnl_dev_type dev, uint32_t evt, void *buffer, int32_t buf_len)
 {
 	if (!g_lwnl_upper) {
 		return -1;

--- a/os/drivers/lwnl/lwnl_evt_queue.h
+++ b/os/drivers/lwnl/lwnl_evt_queue.h
@@ -32,6 +32,6 @@ int lwnl_add_listener(struct file *filep, lwnl_dev_type type);
 int lwnl_remove_listener(struct file *filep);
 int lwnl_get_event(struct file *filep, char *buf, int len);
 int lwnl_check_queue(struct file *filep);
-int lwnl_add_event(lwnl_cb_status type, void *buffer, uint32_t buf_len);
+int lwnl_add_event(lwnl_cb_status type, void *buffer, int32_t buf_len);
 
 #endif // _LWNL_EVT_QUEUE_H__

--- a/os/include/tinyara/lwnl/lwnl.h
+++ b/os/include/tinyara/lwnl/lwnl.h
@@ -144,10 +144,7 @@ struct netdev {
 int lwnl_register(struct lwnl_lowerhalf_s *ldev);
 int lwnl_unregister(struct lwnl_lowerhalf_s *ldev);
 int lwnl_register_dev(struct netdev *dev);
-int lwnl_postmsg(lwnl_dev_type dev, uint32_t evt, void *buffer, uint32_t buf_len);
-
-#define LWNL_POST_BLEMSG(evt, buffer, buf_len) \
-	lwnl_postmsg(LWNL_DEV_BLE, evt, buffer, buf_len)
+int lwnl_postmsg(lwnl_dev_type dev, uint32_t evt, void *buffer, int32_t buf_len);
 
 #ifndef CONFIG_NET_NETMGR
 int lwnl_register_dev(struct netdev *dev);

--- a/os/include/tinyara/net/if/ble.h
+++ b/os/include/tinyara/net/if/ble.h
@@ -347,4 +347,4 @@ struct trble_ops {
 	trble_stop_adv stop_adv;
 };
 
-int trble_post_event(lwnl_cb_ble evt, void *buffer, uint32_t buf_len);
+int trble_post_event(lwnl_cb_ble evt, void *buffer, int32_t buf_len);

--- a/os/net/blemgr/bledev.c
+++ b/os/net/blemgr/bledev.c
@@ -466,7 +466,7 @@ int bledev_handle(struct bledev *dev, lwnl_req cmd, void *data, uint32_t data_le
 	return ret;
 }
 
-int trble_post_event(lwnl_cb_ble evt, void *buffer, uint32_t buf_len)
+int trble_post_event(lwnl_cb_ble evt, void *buffer, int32_t buf_len)
 {
 	BLE_LOGV(TRBLE_TAG, "trble post event : %d\n", evt);
 	return lwnl_postmsg(LWNL_DEV_BLE, (int)evt, buffer, buf_len);

--- a/os/net/blemgr/bledev_mgr_client.c
+++ b/os/net/blemgr/bledev_mgr_client.c
@@ -66,7 +66,7 @@ static void bledrv_device_connected_cb(trble_device_connected *dev)
 
 static void bledrv_operation_notification_cb(trble_operation_handle *handle, trble_data *read_result)
 {
-	uint32_t size = sizeof(trble_conn_handle) + sizeof(trble_attr_handle) + sizeof(read_result->length) + read_result->length;
+	int32_t size = sizeof(trble_conn_handle) + sizeof(trble_attr_handle) + sizeof(read_result->length) + read_result->length;
 	uint8_t *data = (uint8_t *)kmm_malloc(size);
 	if (data == NULL) {
 		BLE_LOGE(BLE_DRV_TAG, "out of memroy\n");
@@ -89,9 +89,8 @@ static void bledrv_operation_notification_cb(trble_operation_handle *handle, trb
 	// Copy read_result data
 	memcpy(ptr, read_result->data, read_result->length);
 
-	trble_post_event(LWNL_EVT_BLE_CLIENT_NOTI, data, size);
+	trble_post_event(LWNL_EVT_BLE_CLIENT_NOTI, data, -(size));
 
-	kmm_free(data);
 	return;
 }
 


### PR DESCRIPTION
- add data pointer mode in lwnl_postmsg
(if data_len is negative, a queue copies pointer of data.)