### PR TITLE
os/Makefile: Enable binary compression for common binary

### DIFF
--- a/os/Makefile.unix
+++ b/os/Makefile.unix
@@ -464,6 +464,10 @@ ifeq ($(CONFIG_SUPPORT_COMMON_BINARY),y)
 		mkdir -p "$(TOPDIR)/../tools/fs/contents-smartfs/$(CONFIG_ARCH_BOARD)"; \
 		mkdir -p "$(TOPDIR)/../tools/fs/contents-smartfs/$(CONFIG_ARCH_BOARD)/base-files"; \
 	fi
+ifeq ($(CONFIG_COMPRESSED_BINARY),y)
+	$(Q) tools/compression/mkcompressimg $(CONFIG_COMPRESSION_BLOCK_SIZE) $(CONFIG_COMPRESSION_TYPE) $(OUTBIN_DIR)/$(CONFIG_COMMON_BINARY_NAME) $(OUTBIN_DIR)/$(CONFIG_COMMON_BINARY_NAME).comp
+	$(Q) mv $(OUTBIN_DIR)/$(CONFIG_COMMON_BINARY_NAME).comp $(OUTBIN_DIR)/$(CONFIG_COMMON_BINARY_NAME)
+endif
 	$(Q) cp $(OUTBIN_DIR)/$(CONFIG_COMMON_BINARY_NAME) $(TOPDIR)/../tools/fs/contents-smartfs/$(CONFIG_ARCH_BOARD)/base-files/
 	$(Q) $(MAKE) smartfs
 endif

--- a/os/binfmt/binfmt_loadbinary.c
+++ b/os/binfmt/binfmt_loadbinary.c
@@ -143,7 +143,6 @@ int load_binary(int binary_idx, FAR const char *filename, load_attr_t *load_attr
 			bin->offset = load_attr->offset;
 			bin->stacksize = load_attr->stack_size;
 			bin->priority = load_attr->priority;
-			bin->compression_type = load_attr->compression_type;
 			bin->binary_idx = binary_idx;
 			bin->bin_ver = load_attr->bin_ver;
 #ifdef CONFIG_OPTIMIZE_APP_RELOAD_TIME

--- a/os/binfmt/elf.c
+++ b/os/binfmt/elf.c
@@ -235,12 +235,6 @@ static int elf_loadbinary(FAR struct binary_s *binp)
 	/* Initialize the ELF library to load the program binary. */
 	loadinfo.offset = binp->offset;
 	loadinfo.filelen = binp->filelen;
-	loadinfo.compression_type = binp->compression_type;
-#ifdef CONFIG_COMPRESSED_BINARY
-	if (binp->islibrary) {
-		loadinfo.compression_type = CONFIG_COMPRESSION_TYPE;
-	}
-#endif
 #ifdef CONFIG_APP_BINARY_SEPARATION
 	loadinfo.binp = binp;
 #endif

--- a/os/binfmt/elf.c
+++ b/os/binfmt/elf.c
@@ -236,6 +236,11 @@ static int elf_loadbinary(FAR struct binary_s *binp)
 	loadinfo.offset = binp->offset;
 	loadinfo.filelen = binp->filelen;
 	loadinfo.compression_type = binp->compression_type;
+#ifdef CONFIG_COMPRESSED_BINARY
+	if (binp->islibrary) {
+		loadinfo.compression_type = CONFIG_COMPRESSION_TYPE;
+	}
+#endif
 #ifdef CONFIG_APP_BINARY_SEPARATION
 	loadinfo.binp = binp;
 #endif

--- a/os/binfmt/libelf/libelf.h
+++ b/os/binfmt/libelf/libelf.h
@@ -443,7 +443,7 @@ void elf_cache_uninit(void);
  *   OK (0) on Success
  *   ERROR (-1) on Failure
  ****************************************************************************/
-int elf_cache_init(int filfd, uint16_t offset, off_t filelen, uint8_t compression_type);
+int elf_cache_init(int filfd, uint16_t offset, off_t filelen);
 
 /****************************************************************************
  * Name: elf_cache_read

--- a/os/binfmt/libelf/libelf_init.c
+++ b/os/binfmt/libelf/libelf_init.c
@@ -177,21 +177,16 @@ int elf_init(FAR const char *filename, FAR struct elf_loadinfo_s *loadinfo)
 		return ret;
 	}
 
-	if (loadinfo->compression_type > COMPRESS_TYPE_NONE) {
 #ifdef CONFIG_COMPRESSED_BINARY
-		ret = compress_init(loadinfo->filfd, loadinfo->offset, &loadinfo->filelen);
-		if (ret != OK) {
-			berr("Failed to read header for compressed binary : %d\n", ret);
-			return ret;
-		}
-#else
-		berr("No support for reading compressed binary\n");
-		return ERROR;
-#endif
+	ret = compress_init(loadinfo->filfd, loadinfo->offset, &loadinfo->filelen);
+	if (ret != OK) {
+		berr("Failed to read header for compressed binary : %d\n", ret);
+		return ret;
 	}
+#endif
 
 #if defined(CONFIG_ELF_CACHE_READ)
-	ret = elf_cache_init(loadinfo->filfd, loadinfo->offset, loadinfo->filelen, loadinfo->compression_type);
+	ret = elf_cache_init(loadinfo->filfd, loadinfo->offset, loadinfo->filelen);
 	if (ret != OK) {
 		berr("Failed to init cache support: %d\n", ret);
 		return ret;

--- a/os/binfmt/libelf/libelf_read.c
+++ b/os/binfmt/libelf/libelf_read.c
@@ -139,22 +139,15 @@ int elf_read(FAR struct elf_loadinfo_s *loadinfo, FAR uint8_t *buffer, size_t re
 	/* Loop until all of the requested data has been read. */
 
 	while (readsize > 0) {
-		if (loadinfo->compression_type == COMPRESS_TYPE_NONE) {	/* Uncompressed binary */
 #if defined(CONFIG_ELF_CACHE_READ)
-			/* Cache only if readsize request <= cache block size */
-			if (readsize <= CONFIG_ELF_CACHE_BLOCK_SIZE) {
-				nbytes = elf_cache_read(loadinfo->filfd, loadinfo->offset, buffer, readsize, offset - loadinfo->offset);
-			} else {
-				rpos = lseek(loadinfo->filfd, offset, SEEK_SET);
-				if (rpos != offset) {
-					int errval = get_errno();
-					berr("Failed to seek to position %lu: %d\n", (unsigned long)offset, errval);
-					return -errval;
-				}
-
-				/* Read the file data at offset into the user buffer */
-				nbytes = read(loadinfo->filfd, buffer, readsize);
-			}
+		/* Cache only if readsize request <= cache block size */
+		if (readsize <= CONFIG_ELF_CACHE_BLOCK_SIZE) {
+			nbytes = elf_cache_read(loadinfo->filfd, loadinfo->offset, buffer, readsize, offset - loadinfo->offset);
+		} else
+#endif
+		{
+#ifdef CONFIG_COMPRESSED_BINARY
+			nbytes = compress_read(loadinfo->filfd, loadinfo->offset, buffer, readsize, offset - loadinfo->offset);
 #else
 			/* Seek to the next read position */
 
@@ -168,29 +161,8 @@ int elf_read(FAR struct elf_loadinfo_s *loadinfo, FAR uint8_t *buffer, size_t re
 			/* Read the file data at offset into the user buffer */
 			nbytes = read(loadinfo->filfd, buffer, readsize);
 #endif
-		} else if (loadinfo->compression_type > COMPRESS_TYPE_NONE) {	/* Compressed binary */
-#ifdef CONFIG_COMPRESSED_BINARY
-			if (loadinfo->compression_type == CONFIG_COMPRESSION_TYPE) {
-				/* Read readsize bytes from offset from uncompressed file into unser buffer */
-#if defined(CONFIG_ELF_CACHE_READ)
-				/* Cache only if readsize request <= cache block size */
-				if (readsize <= CONFIG_ELF_CACHE_BLOCK_SIZE) {
-					nbytes = elf_cache_read(loadinfo->filfd, loadinfo->offset, buffer, readsize, offset - loadinfo->offset);
-				} else {
-					nbytes = compress_read(loadinfo->filfd, loadinfo->offset, buffer, readsize, offset - loadinfo->offset);
-				}
-#else
-				nbytes = compress_read(loadinfo->filfd, loadinfo->offset, buffer, readsize, offset - loadinfo->offset);
-#endif
-			} else {
-				berr("No support for decompression of compression format %d of this binary\n", loadinfo->compression_type);
-				return ERROR;
-			}
-#else
-			berr("No support for reading compressed binaries\n");
-			return ERROR;
-#endif
 		}
+
 		if (nbytes < 0) {
 			/* EINTR just means that we received a signal */
 

--- a/os/binfmt/libelf/libelf_uninit.c
+++ b/os/binfmt/libelf/libelf_uninit.c
@@ -104,14 +104,9 @@ int elf_uninit(struct elf_loadinfo_s *loadinfo)
 	elf_freebuffers(loadinfo);
 
 	/* Free buffers used for decompression */
-	if (loadinfo->compression_type > COMPRESS_TYPE_NONE) {
 #ifdef CONFIG_COMPRESSED_BINARY
-		compress_uninit();
-#else
-		berr("No support for reading compressed binary\n");
-		return ERROR;
+	compress_uninit();
 #endif
-	}
 #if defined(CONFIG_ELF_CACHE_READ)
 	elf_cache_uninit();
 #endif

--- a/os/include/tinyara/binary_manager.h
+++ b/os/include/tinyara/binary_manager.h
@@ -138,7 +138,6 @@ struct user_binary_header_s {
 	uint32_t crc_hash;
 	uint16_t header_size;
 	uint8_t bin_type;
-	uint8_t compression_type;
 	uint8_t bin_priority;
 	uint8_t loading_priority;
 	uint32_t bin_size;
@@ -175,7 +174,6 @@ struct load_attr_s {
 	uint32_t stack_size;		/* Size of the stack allocated for binary */
 	uint16_t offset;			/* The offset from which ELF binary has to be read in MTD partition */
 	uint8_t priority;			/* Priority of the binary */
-	uint8_t compression_type;	/* Binary compression type */
 	uint32_t bin_ver;			/* version of binary */
 #ifdef CONFIG_OPTIMIZE_APP_RELOAD_TIME
 	void *binp;			/* Binary info pointer */

--- a/os/include/tinyara/binfmt/binfmt.h
+++ b/os/include/tinyara/binfmt/binfmt.h
@@ -176,7 +176,6 @@ struct binary_s {
 	size_t stacksize;			/* Size of the stack in bytes (unallocated) */
 	size_t filelen;                 /* Size of binary size, used only when underlying is MTD */
 	size_t offset;                  /* Offset of binary from partition start*/
-	uint8_t compression_type;		/* Binary Compression type */
 #ifdef CONFIG_BINARY_MANAGER
 	uint8_t binary_idx;             /* Index of binary in binary table */
 	uint32_t bin_ver;               /* version of binary */

--- a/os/include/tinyara/binfmt/elf.h
+++ b/os/include/tinyara/binfmt/elf.h
@@ -100,9 +100,6 @@
 #define LIBELF_NALLOC      1
 #endif
 
-/* Uncompressed elf representation */
-#define COMPRESS_TYPE_NONE 0
-
 /****************************************************************************
  * Public Types
  ****************************************************************************/
@@ -171,7 +168,6 @@ struct elf_loadinfo_s {
 	uint16_t buflen;			/* size of iobuffer[] */
 	int filfd;					/* Descriptor for the file being loaded */
 	uint16_t offset;             /* elf offset when binary header is included */
-	uint8_t compression_type;		/* Binary Compression type */
 	uintptr_t symtab;			/* Copy of symbol table */
 	uintptr_t reltab;			/* Copy of relocation table */
 	uintptr_t strtab;			/* Copy of string table */

--- a/os/kernel/binary_manager/binary_manager.h
+++ b/os/kernel/binary_manager/binary_manager.h
@@ -201,7 +201,6 @@ binmgr_uinfo_t *binary_manager_get_udata(uint32_t bin_idx);
 #define BIN_OFFSET(bin_idx)                             binary_manager_get_udata(bin_idx)->load_attr.offset
 #define BIN_STACKSIZE(bin_idx)                          binary_manager_get_udata(bin_idx)->load_attr.stack_size
 #define BIN_PRIORITY(bin_idx)                           binary_manager_get_udata(bin_idx)->load_attr.priority
-#define BIN_COMPRESSION_TYPE(bin_idx)                   binary_manager_get_udata(bin_idx)->load_attr.compression_type
 #ifdef CONFIG_OPTIMIZE_APP_RELOAD_TIME
 #define BIN_LOADINFO(bin_idx)                           binary_manager_get_udata(bin_idx)->binp
 #endif

--- a/os/kernel/binary_manager/binary_manager_load.c
+++ b/os/kernel/binary_manager/binary_manager_load.c
@@ -193,7 +193,6 @@ static int binary_manager_load(int bin_idx)
 			strncpy(load_attr.bin_name, header_data.bin_name, BIN_NAME_MAX - 1);
 			load_attr.bin_name[BIN_NAME_MAX - 1] = '\0';
 			load_attr.bin_size = header_data.bin_size;
-			load_attr.compression_type = header_data.compression_type;
 			load_attr.ram_size = header_data.bin_ramsize;
 			load_attr.stack_size = header_data.bin_stacksize;
 			load_attr.priority = header_data.bin_priority;

--- a/os/tools/mkbinheader.py
+++ b/os/tools/mkbinheader.py
@@ -168,11 +168,11 @@ def make_kernel_binary_header():
 #
 # User binary header information on APP_BINARY_SEPARTION
 #
-# total header size is 42bytes.
-# +--------------------------------------------------------------------------------
-# | Header size | Binary type | Compression  | Binary priority | Loading priority |
-# |   (2bytes)  |   (1byte)   |   (1byte)    |     (1byte)     |      (1bytes)    |
-# +--------------------------------------------------------------------------------
+# total header size is 41bytes.
+# +-----------------------------------------------------------------
+# | Header size | Binary type | Binary priority | Loading priority |
+# |   (2bytes)  |   (1byte)   |     (1byte)     |      (1bytes)    |
+# +-----------------------------------------------------------------
 # -------------------------------------------------------------------------------------
 # | Binary size |  Binary name | Binary version | Binary ram size | Binary stack size |
 # |  (4bytes)   |   (16bytes)  |    (4bytes)    |    (4bytes)     |     (4bytes)      |
@@ -216,7 +216,6 @@ def make_user_binary_header():
 
     SIZE_OF_HEADERSIZE = 2
     SIZE_OF_BINTYPE = 1
-    SIZE_OF_COMFLAG = 1
     SIZE_OF_MAINPRIORITY = 1
     SIZE_OF_LOADINGPRIORITY = 1
     SIZE_OF_BINSIZE = 4
@@ -226,7 +225,7 @@ def make_user_binary_header():
     SIZE_OF_MAINSTACKSIZE = 4
     SIZE_OF_KERNELVER = 4
 
-    header_size = SIZE_OF_HEADERSIZE + SIZE_OF_BINTYPE + SIZE_OF_COMFLAG + SIZE_OF_MAINPRIORITY + SIZE_OF_LOADINGPRIORITY + SIZE_OF_BINSIZE + SIZE_OF_BINNAME + SIZE_OF_BINVER + SIZE_OF_BINRAMSIZE + SIZE_OF_MAINSTACKSIZE + SIZE_OF_KERNELVER
+    header_size = SIZE_OF_HEADERSIZE + SIZE_OF_BINTYPE + SIZE_OF_MAINPRIORITY + SIZE_OF_LOADINGPRIORITY + SIZE_OF_BINSIZE + SIZE_OF_BINNAME + SIZE_OF_BINVER + SIZE_OF_BINRAMSIZE + SIZE_OF_MAINSTACKSIZE + SIZE_OF_KERNELVER
 
     COMP_NONE = 0
     COMP_LZMA = 1
@@ -328,7 +327,6 @@ def make_user_binary_header():
 
         fp.write(struct.pack('H', header_size))
         fp.write(struct.pack('B', bin_type))
-        fp.write(struct.pack('B', bin_comp))
         fp.write(struct.pack('B', main_priority))
         fp.write(struct.pack('B', loading_priority))
         fp.write(struct.pack('I', file_size))


### PR DESCRIPTION
Common binary will be compressed with CONFIG_COMPRESSION_TYPE and
CONFIG_COMPRESSION_BLOCK_SIZE, if CONFIG_COMPRESSED_BINARY is enabled.

Signed-off-by: Kishore S N <kishore.sn@samsung.com>