### PR TITLE
os/tools: Fix "No such file or directory: 'build/output/bin/user'" error

### DIFF
--- a/os/tools/mkbootparam.py
+++ b/os/tools/mkbootparam.py
@@ -119,7 +119,10 @@ def make_bootparam():
         print "FAIL!! No found kernel partition"
         sys.exit(1)
 
-    user_file_list = os.listdir(user_file_dir)
+    if os.path.exists(user_file_dir):
+        user_file_list = os.listdir(user_file_dir)
+    else:
+        user_file_list = []
     user_app_count = len(user_file_list)
     SIZE_OF_BINNAME = 16
     SIZE_OF_BINIDX = 1


### PR DESCRIPTION
========== Start to make boot parameters ==========
Traceback (most recent call last):
  File "/root/tizenrt/os/../os/tools/mkbootparam.py", line 161, in <module>
    make_bootparam()
  File "/root/tizenrt/os/../os/tools/mkbootparam.py", line 122, in make_bootparam
    user_file_list = os.listdir(user_file_dir)
OSError: [Errno 2] No such file or directory: '/root/tizenrt/os/../os/tools/../../build/output/bin/user'
make: *** [post] Error 1
Makefile.unix:494: recipe for target 'post' failed

Signed-off-by: Abhishek Akkabathula <a.akkabathul@samsung.com>