### PR TITLE
os/Makefile.unix: use -f option to delete output bin folder 

### DIFF
--- a/os/Makefile.unix
+++ b/os/Makefile.unix
@@ -626,7 +626,7 @@ subdir_clean:
 	$(Q) $(MAKE) -C tools -f Makefile.host TOPDIR="$(TOPDIR)" clean
 
 clean: subdir_clean
-	$(call DELFILE, $(OUTBIN_DIR)/*)
+	$(call DELDIR, $(OUTBIN_DIR)/*)
 	$(call DELFILE, _SAVED_APPS_config)
 	$(call DELFILE, tinyara-export*)
 	$(call DELFILE, tinyara_user*)


### PR DESCRIPTION
When loadable build configuration is built, the user folder under output/bin is newly created and
it should be deleted with clean command. But DELFILE definition can do only files, can't do folders.
It causes the error as below:

rm: cannot remove '../build/output/bin/user': Is a directory
Makefile.unix:629: recipe for target 'clean' failed
make: *** [clean] Error 1

This commit changes the command to delete output bin folder from DELFILE to DELDIR to resolve above.