### PR TITLE
loadable_apps/binary_update.c : Remove unused local variable

### DIFF
--- a/loadable_apps/loadable_sample/wifiapp/binary_update.c
+++ b/loadable_apps/loadable_sample/wifiapp/binary_update.c
@@ -317,7 +317,6 @@ static int binary_update_same_version_test(void)
 {
 	int ret;
 	uint8_t type = 0;
-	char path[BINARY_PATH_LEN];
 	binary_update_info_t pre_bin_info;
 	binary_update_info_t cur_bin_info;
 


### PR DESCRIPTION
binary_update.c:320:7: warning: unused variable 'path' [-Wunused-variable]
  char path[BINARY_PATH_LEN];
       ^~~~