### PR TITLE
kernel/binary_manager_load.c : Fix to get binary count

### DIFF
--- a/os/kernel/binary_manager/binary_manager_load.c
+++ b/os/kernel/binary_manager/binary_manager_load.c
@@ -531,7 +531,7 @@ static int update_thread(int argc, char *argv[])
 {
 	int ret;
 	int bin_idx;
-	uint32_t bin_count;
+	uint32_t bin_count = binary_manager_get_ucount();
 	binmgr_bpinfo_t bp_info;
 
 	/* Get the latest bootparam */


### PR DESCRIPTION
To reload the all binaries, it iterates the all binary based on bin_count.
But bin_count is not set properly.

binary_manager/binary_manager_load.c:561:2: warning: 'bin_count' may be used uninitialized in this function [-Wmaybe-uninitialized]
  for (bin_idx = 1; bin_idx <= bin_count; bin_idx++) {
  ^~~

Signed-off-by: jeongchanKim <jc_.kim@samsung.com>