### PR TITLE
os/kernel/mqueue: increase NUM_INTERRUPT_MSGS

### DIFF
--- a/os/kernel/mqueue/mqueue.h
+++ b/os/kernel/mqueue/mqueue.h
@@ -90,7 +90,7 @@
  * interrupt handlers
  */
 
-#define NUM_INTERRUPT_MSGS   8
+#define NUM_INTERRUPT_MSGS   32
 
 /****************************************************************************
  * Public Type Definitions


### PR DESCRIPTION
- Because BLE is enabled, the number of interrupt is increased.