### PR TITLE
framework/ble_manager: improve memcpy speed

### DIFF
--- a/framework/include/ble_manager/ble_client.h
+++ b/framework/include/ble_manager/ble_client.h
@@ -67,7 +67,7 @@ typedef struct {
 	uint8_t raw_data_length;
 	uint8_t resp_data[BLE_ADV_RESP_DATA_MAX_LEN];
 	uint8_t resp_data_length;
-} ble_scanned_device;
+} __attribute__((aligned(4), packed)) ble_scanned_device;
 
 typedef struct {
 	ble_conn_info conn_info;

--- a/os/include/tinyara/net/if/ble.h
+++ b/os/include/tinyara/net/if/ble.h
@@ -151,7 +151,7 @@ typedef struct {
 	uint8_t raw_data_length;
 	uint8_t resp_data[TRBLE_ADV_RESP_DATA_MAX_LEN];
 	uint8_t resp_data_length;
-} trble_scanned_device;
+} __attribute__((aligned(4), packed)) trble_scanned_device;
 
 typedef struct {
 	int size;

--- a/os/net/blemgr/bledev.c
+++ b/os/net/blemgr/bledev.c
@@ -57,7 +57,13 @@ int trble_scan_data_enque(trble_scanned_device *info)
 		*/
 		return -2;
 	}
-	memcpy(&g_scan_queue->queue[g_scan_queue->write_index], info, sizeof(trble_scanned_device));
+
+	int i;
+	uint32_t *u1 = (uint32_t *)info;
+	uint32_t *u2 = (uint32_t *)&g_scan_queue->queue[g_scan_queue->write_index];
+	for (i = 0; i < sizeof(trble_scanned_device) / sizeof(uint32_t); i++) {
+		*(u2 + i) = *(u1 + i);
+	}
 	g_scan_queue->write_index = write_index_next;
 
 	sem_post(&g_scan_queue->countsem);

--- a/os/net/blemgr/bledev_mgr_client.c
+++ b/os/net/blemgr/bledev_mgr_client.c
@@ -25,7 +25,7 @@
 
 #define BLE_DRV_TAG "[BLEDRV_CLIENT]"
 
-static void _reverse_mac(uint8_t *mac)
+static inline void _reverse_mac(uint8_t *mac)
 {
 	int i;
 	int j;


### PR DESCRIPTION
- Test 3 cases of memcpy
1. use 'memcpy'
2. copy 1 byte unit
3. copy 4 bytes unit

The size of source  : 84 bytes (trble_scanned_device)
The number of trial : 10000 times

- The results
Test#1 :  8.01 ms
Test#2 : 21.15 ms
Test#3 :  6.36 ms

The speed of memcpy increased 15% by using 4 bytes unit.