### PR TITLE
apps/examples/smartfs: Fix wrong path in Make.defs

### DIFF
--- a/apps/examples/smartfs/smartfs_powercut/Make.defs
+++ b/apps/examples/smartfs/smartfs_powercut/Make.defs
@@ -52,5 +52,5 @@
 ############################################################################
 
 ifeq ($(CONFIG_EXAMPLES_SMARTFS_POWERCUT),y)
-CONFIGURED_APPS += examples/smartfs_powercut
+CONFIGURED_APPS += examples/smartfs/smartfs_powercut
 endif


### PR DESCRIPTION
Fix wrong path in smartfs_powercut/Make.defs