### PR TITLE
drivers/seclink: remove redundant " in Kconfig

### DIFF
--- a/os/drivers/seclink/Kconfig
+++ b/os/drivers/seclink/Kconfig
@@ -15,7 +15,7 @@ if SECURITY_LINK_DRV
 source "$FRAMEWORK_DIR/src/seclink/Kconfig"
 
 config SECURITY_LINK_DRV_PROFILE
-	bool "Display security driver performance""
+	bool "Display security driver performance"
 	depends on TIMER
 	default n
 	---help---


### PR DESCRIPTION
There is a typo in seclink Kconfig, three " in a line.
This makes the warning as below:

drivers/seclink/Kconfig:18:warning: multi-line strings not supported

This commit removes redundant ".

Signed-off-by: sunghan-chang <sh924.chang@samsung.com>