### PR TITLE
arch/amebad/flash : Add log about flash chip id

### DIFF
--- a/os/arch/arm/src/amebad/amebad_flash.c
+++ b/os/arch/arm/src/amebad/amebad_flash.c
@@ -350,6 +350,9 @@ FAR struct mtd_dev_s *up_flashinitialize(void)
 		priv->mtd.write = amebad_write;
 #endif
 		priv->nsectors = AMEBAD_NSECTORS;
+		u8 chip_id[4];
+		flash_read_id(NULL, chip_id, 4);
+		lldbg("Manufacturer : %u memory type : %u capacity : %u\n", chip_id[0], chip_id[1], chip_id[2]);
 		return (FAR struct mtd_dev_s *)priv;
 	}
 	return NULL;


### PR DESCRIPTION
During flash initialize, chip id is printed.
It will be helpful for developer.

ex) #up_flashinitialize: Manufacturer : 161 memory type : 64 capacity : 23