### PR TITLE
kernel/binfmt/libelf_sections.c : Fix to get binary name

### DIFF
--- a/os/binfmt/libelf/libelf_sections.c
+++ b/os/binfmt/libelf/libelf_sections.c
@@ -226,7 +226,7 @@ void elf_save_bin_section_addr(struct binary_s *bin)
 		bin_info->bin_idx = bin->binary_idx;
 		bin_info->text_addr = (uint32_t)bin->alloc[ALLOC_TEXT];
 #ifdef CONFIG_SAVE_BIN_SECTION_ADDR
-		binfo("[%s] text_addr : %x\n", bin_info->bin_name, bin_info->text_addr);
+		binfo("[%s] text_addr : %x\n", bin->bin_name, bin_info->text_addr);
 #ifdef CONFIG_OPTIMIZE_APP_RELOAD_TIME
 		bin_info->rodata_addr = (uint32_t)bin->alloc[ALLOC_RO];
 		bin_info->data_addr = (uint32_t)bin->datastart;


### PR DESCRIPTION
The binary name is in binary_s, not in bin_addr_info_t.
(It was removed from bin_addr_info_t in previous commit.)

libelf/libelf_sections.c: In function 'elf_save_bin_section_addr':
libelf/libelf_sections.c:229:42: error: 'bin_addr_info_t {aka struct bin_addr_info_s}' has no member named 'bin_name'; did you mean 'bin_idx'?
   lldbg("[%s] text_addr : %x\n", bin_info->bin_name, bin_info->text_addr);

Signed-off-by: jeongchanKim <jc_.kim@samsung.com>