### PR TITLE
os/binfmt/libelf_sections.c : Save text region size

### DIFF
--- a/os/binfmt/elf.c
+++ b/os/binfmt/elf.c
@@ -286,9 +286,7 @@ static int elf_loadbinary(FAR struct binary_s *binp)
 	up_addrenv_clone(&loadinfo.addrenv, &binp->addrenv);
 #else
 	binp->alloc[ALLOC_TEXT] = (FAR void *)loadinfo.textalloc;
-#if defined(CONFIG_SUPPORT_COMMON_BINARY) || defined(CONFIG_OPTIMIZE_APP_RELOAD_TIME)
 	binp->textsize = loadinfo.textsize;
-#endif
 #ifdef CONFIG_BINFMT_CONSTRUCTORS
 	binp->alloc[ALLOC_CTOR] = loadinfo.ctoralloc;
 	binp->alloc[ALLOC_DTOR] = loadinfo.dtoralloc;

--- a/os/binfmt/libelf/libelf.h
+++ b/os/binfmt/libelf/libelf.h
@@ -464,6 +464,7 @@ struct bin_addr_info_s {
 	struct bin_addr_info_s *flink;
 	int bin_idx;
 	uint32_t text_addr;
+	uint32_t text_size;
 #ifdef CONFIG_SAVE_BIN_SECTION_ADDR
 #ifdef CONFIG_OPTIMIZE_APP_RELOAD_TIME
 	uint32_t rodata_addr;

--- a/os/binfmt/libelf/libelf_sections.c
+++ b/os/binfmt/libelf/libelf_sections.c
@@ -226,6 +226,7 @@ void elf_save_bin_section_addr(struct binary_s *bin)
 	if (bin_info != NULL) {
 		bin_info->bin_idx = bin->binary_idx;
 		bin_info->text_addr = (uint32_t)bin->alloc[ALLOC_TEXT];
+		bin_info->text_size = bin->textsize;
 #ifdef CONFIG_SAVE_BIN_SECTION_ADDR
 		binfo("[%s] text_addr : %x\n", bin->bin_name, bin_info->text_addr);
 #ifdef CONFIG_OPTIMIZE_APP_RELOAD_TIME
@@ -263,7 +264,7 @@ void elf_show_all_bin_addr(void)
 	bin_addr_info_t *info;
 	info = (bin_addr_info_t *)sq_peek(&g_bin_addr_list);
 	while (info) {
-		lldbg("[%s] Text Addr : %p\n", BIN_NAME(info->bin_idx), info->text_addr);
+		lldbg("[%s] Text Addr : %p, Text Size : %u\n", BIN_NAME(info->bin_idx), info->text_addr, info->text_size);
 		info = (FAR void *)sq_next((FAR sq_entry_t *)info);
 	}
 }

--- a/os/include/tinyara/binfmt/binfmt.h
+++ b/os/include/tinyara/binfmt/binfmt.h
@@ -116,9 +116,7 @@ struct binary_s {
 	uint32_t datastart;		/* Start address of data section */
 #endif
 
-#if defined(CONFIG_SUPPORT_COMMON_BINARY) || defined(CONFIG_OPTIMIZE_APP_RELOAD_TIME)
 	size_t textsize;		/* Size of text section */
-#endif
 #ifdef CONFIG_OPTIMIZE_APP_RELOAD_TIME
 	size_t rosize;			/* Size of ro section */
 	size_t datasize;		/* Size of data section */


### PR DESCRIPTION
To use the user binary's text region size for debugging, save the text region size and show it when asserted.

Signed-off-by: jeongchanKim <jc_.kim@samsung.com>