### PR TITLE
tools/dump_tool: Update the tool to accomodate loadable_apps crash point detection

### DIFF
--- a/os/arch/arm/src/armv7-m/up_assert.c
+++ b/os/arch/arm/src/armv7-m/up_assert.c
@@ -478,6 +478,7 @@ void up_assert(const uint8_t *filename, int lineno)
 			lldbg("No heap corruption detected\n");
 		}
 	}
+	lldbg("Assert location (PC) : %08x\n", g_assertpc);
 #endif
 
 #if defined(CONFIG_BOARD_CRASHDUMP)

--- a/os/arch/arm/src/armv8-m/up_assert.c
+++ b/os/arch/arm/src/armv8-m/up_assert.c
@@ -495,6 +495,7 @@ void up_assert(const uint8_t *filename, int lineno)
 			lldbg("No heap corruption detected\n");
 		}
 	}
+	lldbg("Assert location (PC) : %08x\n", g_assertpc);
 #endif
 
 #if defined(CONFIG_BOARD_CRASHDUMP)

--- a/tools/debug/debugsymbolviewer.py
+++ b/tools/debug/debugsymbolviewer.py
@@ -89,7 +89,7 @@ def print_symbol(search_addr):
 	next_addr = 0x00000000
 	l = 0
 	h = len(symbol_lookup_table)
-	mid = (l + h) / 2
+	mid = (l + h) // 2
 
 	while (l <= h):
 		addr = symbol_lookup_table[mid - 1][0]
@@ -104,7 +104,7 @@ def print_symbol(search_addr):
 		else:
 			l = mid + 1
 
-		mid = (l + h) / 2
+		mid = (l + h) // 2
 
 	if (l > h):
 		if debug:
@@ -169,7 +169,7 @@ if (__name__ == '__main__'):
 
     setup_symbol_table(systemmap_path)
 
-    print('----------------------------------  DEBUG DISPLAY SYMBOLS -------------------------------')
+    print('------------------------------- DEBUG SYMBOLS IN TEXT RANGE -----------------------------')
     print('Dump_address\t Symbol_address\t  Symbol_name\tFile_name')
     parse_file(log_file)
     print('-----------------------------------------------------------------------------------------')

--- a/tools/dump_tool/HowToUseDumpTool.md
+++ b/tools/dump_tool/HowToUseDumpTool.md
@@ -308,7 +308,7 @@ binary_manager_send_request
 
 ----------------------------------------------------------
 
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  DEBUG DISPLAY SYMBOLS ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+------------------------------- DEBUG SYMBOLS IN TEXT RANGE -----------------------------
 Dump_address	 Symbol_address	  Symbol_name	File_name
 0xe0072f3	 0xe007290 	  up_assert	/root/tizenrt/os/include/assert.h:211
 0xe04f0bn	 0xe04f028 	  __FUNCTION__.6571
@@ -340,7 +340,7 @@ os_start
 
 ----------------------------------------------------------
 
---------------------------- DEBUG SYMBOLS IN KERNEL TEXT RANGE -------------------------
+------------------------------- DEBUG SYMBOLS IN TEXT RANGE -----------------------------
 Dump_address	 Symbol_address	  Symbol_name	File_name
 0xe0542b3	 0xe0542a3 	  __FUNCTION__.6620
 0xe0086cd	 0xe0086cc 	  lowoutstream_putc	/root/product/.tizenrt/lib/libc/stdio/lib_lowoutstream.c:76
@@ -379,7 +379,7 @@ sched_get_priority_max
 
 ----------------------------------------------------------
 
---------------------------- DEBUG SYMBOLS IN KERNEL TEXT RANGE -------------------------
+------------------------------- DEBUG SYMBOLS IN TEXT RANGE -----------------------------
 Dump_address	 Symbol_address	  Symbol_name	File_name
 0xe006337	 0xe006310 	  lowvsyslog	/root/product/.tizenrt/os/include/syslog.h:263
 0xe0060c1	 0xe0060c0 	  lib_noflush	/root/product/.tizenrt/os/include/tinyara/streams.h:605

--- a/tools/dump_tool/HowToUseDumpTool.md
+++ b/tools/dump_tool/HowToUseDumpTool.md
@@ -265,6 +265,8 @@ Ramdump received successfully..!
 DumpParser Script provides two interfaces: CUI and GUI
 
 ### DumpParser using CUI
+
+#### To get call stack using RAM dump
 1. Run Ramdump Parser Script
 ```
 cd $TIZENRT_BASEDIR/tools/dump_tool/
@@ -272,6 +274,125 @@ python dumpParser.py -r $TIZENRT_BASEDIR/build/output/bin/ramdump_0x02020000_0x0
 ```
 2. See the Output
 
+#### To display Debug Symbols/Crash point using assert logs
+1. Copy crash logs
+    First copy the crash logs to a file named log_file in tools/dump_tool/`<log_file>`
+2. Run Script in tools/dump_tool path
+    $ python3 ramdumpParser.py -e `<Elf path>` -t `<Log file path>`
+
+    ex)
+    $ python3 ramdumpParser.py -e ../../build/output/bin/wifi_dbg -t ./log_file
+
+Example Call Stack Output for App crash is as follows:
+```
+*************************************************************
+dump_file         : None
+log_file          : .log_file
+elf_file  : ../../../output/wifi_dbg
+*************************************************************
+
+Number of applicaions : 2
+App1 is : micom
+App2 is : wifi
+
+----------------------------------------------------------
+App Crash point is as follows:
+App name : wifi
+0x00001492
+main
+/root/tizenrt/loadable_apps/loadable_sample/wifiapp/wifiapp.c:85
+
+0x00003367
+binary_manager_send_request
+/root/tizenrt/framework/src/binary_manager/binary_manager_interface.c:97
+
+----------------------------------------------------------
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  DEBUG DISPLAY SYMBOLS ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Dump_address	 Symbol_address	  Symbol_name	File_name
+0xe0072f3	 0xe007290 	  up_assert	/root/tizenrt/os/include/assert.h:211
+0xe04f0bn	 0xe04f028 	  __FUNCTION__.6571
+0xe04f043	 0xe04f028 	  __FUNCTION__.6571
+0xe007733	 0xe0076e8 	  up_memfault	/root/tizenrt/os/arch/arm/src/armv8-m/up_memfault.c:116
+0x10012345	 0x1001232c 	  up_doirq	/root/tizenrt/os/arch/arm/src/armv8-m/up_doirq.c:91
+0x10012055	 0x10012014 	  exception_common	/root/tizenrt/os/arch/arm/src/armv8-m/up_exception.S:156
+0xe001e4f	 0xe001e4e 	  sem_freeholder	/root/tizenrt/os/kernel/semaphore/sem_holder.c:163
+
+PC_value	 Symbol_address	  Symbol_name	File_name
+0x218ec12	 0x2000000 	  __psram_image2_text_start__
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+```
+ex)
+$ python3 ramdumpParser.py -e ../../build/output/bin/tinyara -t ./log_file
+
+Example Call Stack Output for Kernel crash is as follows:
+```
+*************************************************************
+dump_file         : None
+log_file          : .log_file
+elf_file  : ../../build/output/bin/tinyara
+*************************************************************
+----------------------------------------------------------
+Kernel Crash point is as follows:
+0x10010f36
+os_start
+/root/product/.tizenrt/os/kernel/init/os_start.c:615
+
+----------------------------------------------------------
+
+--------------------------- DEBUG SYMBOLS IN KERNEL TEXT RANGE -------------------------
+Dump_address	 Symbol_address	  Symbol_name	File_name
+0xe0542b3	 0xe0542a3 	  __FUNCTION__.6620
+0xe0086cd	 0xe0086cc 	  lowoutstream_putc	/root/product/.tizenrt/lib/libc/stdio/lib_lowoutstream.c:76
+0x10012565	 0x1001254c 	  up_doirq	/root/product/.tizenrt/os/arch/arm/src/armv8-m/up_doirq.c:91
+0x10012275	 0x10012234 	  exception_common	/root/product/.tizenrt/os/arch/arm/src/armv8-m/up_exception.S:156
+0x10012809	 0x10012808 	  up_unblock_task	/root/product/.tizenrt/os/include/tinyara/arch.h:472
+0xe001c15	 0xe001be8 	  task_activate	/root/product/.tizenrt/os/include/sched.h:141
+0x10010f36	 0x10010d90 	  os_start	/root/product/.tizenrt/os/include/tinyara/init.h:89
+0xe000e6f	 0xe000d2c 	  app_start	/root/product/.tizenrt/os/board/rtl8721csm/src/component/soc/realtek/amebad/fwlib/ram_hp/rtl8721dhp_app_start.c:1318
+
+PC_value	 Symbol_address	  Symbol_name	File_name
+0x10010f36	 0x10010d90 	  os_start	/root/product/.tizenrt/os/include/tinyara/init.h:89
+-----------------------------------------------------------------------------------------
+```
+ex)
+$python3 ramdumpParser.py -e ../../build/output/bin/common_dbg -t ./log_file
+
+Example Call Stack Output for Common Binary crash is as follows:
+```
+*************************************************************
+dump_file         : None
+log_file          : ./log_file
+elf_file  : ../../build/output/bin/common_dbg
+*************************************************************
+
+Number of applicaions : 2
+App[1] is : common
+App[2] is : app
+
+----------------------------------------------------------
+App Crash point is as follows:
+App name : common
+0x0003cdf2
+sched_get_priority_max
+/root/product/.tizenrt/lib/libc/sched/sched_getprioritymax.c:113
+
+----------------------------------------------------------
+
+--------------------------- DEBUG SYMBOLS IN KERNEL TEXT RANGE -------------------------
+Dump_address	 Symbol_address	  Symbol_name	File_name
+0xe006337	 0xe006310 	  lowvsyslog	/root/product/.tizenrt/os/include/syslog.h:263
+0xe0060c1	 0xe0060c0 	  lib_noflush	/root/product/.tizenrt/os/include/tinyara/streams.h:605
+0xe009c59	 0xe009bf8 	  up_memfault	/root/product/.tizenrt/os/arch/arm/src/armv8-m/up_memfault.c:116
+0x10012565	 0x1001254c 	  up_doirq	/root/product/.tizenrt/os/arch/arm/src/armv8-m/up_doirq.c:91
+0x10012275	 0x10012234 	  exception_common	/root/product/.tizenrt/os/arch/arm/src/armv8-m/up_exception.S:156
+0xe001e8f	 0xe001e8e 	  sem_freeholder	/root/product/.tizenrt/os/kernel/semaphore/sem_holder.c:163
+0xe050791	 0xe050744 	  pthread_start	/root/product/.tizenrt/os/kernel/pthread/pthread_create.c:188
+
+PC_value	 Symbol_address	  Symbol_name	File_name
+0x213ce12	 0x2000000 	  __psram_image2_text_start__
+-----------------------------------------------------------------------------------------
+```
 ### DumpParser using GUI
 The UI configuration of DumpParser is as follows
 

--- a/tools/dump_tool/HowToUseDumpTool.md
+++ b/tools/dump_tool/HowToUseDumpTool.md
@@ -281,46 +281,45 @@ python dumpParser.py -r $TIZENRT_BASEDIR/build/output/bin/ramdump_0x02020000_0x0
     $ python3 ramdumpParser.py -e `<Elf path>` -t `<Log file path>`
 
     ex)
-    $ python3 ramdumpParser.py -e ../../build/output/bin/wifi_dbg -t ./log_file
+    $ python3 ramdumpParser.py -e ../../build/output/bin/app2_dbg -t ./log_file
 
 Example Call Stack Output for App crash is as follows:
 ```
 *************************************************************
 dump_file         : None
 log_file          : .log_file
-elf_file  : ../../../output/wifi_dbg
+elf_file  : ../../../output/app2_dbg
 *************************************************************
 
 Number of applicaions : 2
-App1 is : micom
-App2 is : wifi
+App[1] is : app1
+App[2] is : app2
 
 ----------------------------------------------------------
 App Crash point is as follows:
-App name : wifi
-0x00001492
+[ Caller - return address (LR) - of the function which has caused the crash ]
+App name : app2
+symbol addr : 0x000014d6
 main
-/root/tizenrt/loadable_apps/loadable_sample/wifiapp/wifiapp.c:85
+/root/tizenrt/loadable_apps/loadable_sample/wifiapp/wifiapp.c:121
 
-0x00003367
-binary_manager_send_request
-/root/tizenrt/framework/src/binary_manager/binary_manager_interface.c:97
+[Probable crash point corresponding to the R15 register value (PC) might be -4 or -8 bytes]
+App name : app2
+0x000014e5
+function name : main
+file : /root/tizenrt/loadable_apps/loadable_sample/wifiapp/wifiapp.c:113
 
-----------------------------------------------------------
-
-------------------------------- DEBUG SYMBOLS IN TEXT RANGE -----------------------------
+-------------------------- DEBUG SYMBOLS IN APPLICATION TEXT RANGE -------------------------
 Dump_address	 Symbol_address	  Symbol_name	File_name
-0xe0072f3	 0xe007290 	  up_assert	/root/tizenrt/os/include/assert.h:211
-0xe04f0bn	 0xe04f028 	  __FUNCTION__.6571
-0xe04f043	 0xe04f028 	  __FUNCTION__.6571
-0xe007733	 0xe0076e8 	  up_memfault	/root/tizenrt/os/arch/arm/src/armv8-m/up_memfault.c:116
-0x10012345	 0x1001232c 	  up_doirq	/root/tizenrt/os/arch/arm/src/armv8-m/up_doirq.c:91
-0x10012055	 0x10012014 	  exception_common	/root/tizenrt/os/arch/arm/src/armv8-m/up_exception.S:156
-0xe001e4f	 0xe001e4e 	  sem_freeholder	/root/tizenrt/os/kernel/semaphore/sem_holder.c:163
+0x1dc5	 0x1db5 	  write	/root/tizenrt/os/include/unistd.h:310
+0x1dc5	 0x1db5 	  write	/root/tizenrt/os/include/unistd.h:310
+0x14e5	 0x1479 	  main	/root/tizenrt/loadable_apps/loadable_sample/wifiapp/wifiapp.c:57
+0x1479	 0x1479 	  main	/root/tizenrt/loadable_apps/loadable_sample/wifiapp/wifiapp.c:57
+0x1ef5	 0x1edd 	  task_startup	/root/tizenrt/os/include/tinyara/userspace.h:127
 
 PC_value	 Symbol_address	  Symbol_name	File_name
-0x218ec12	 0x2000000 	  __psram_image2_text_start__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+-----------------------------------------------------------------------------------------
+----------------------------------------------------------
 ```
 ex)
 $ python3 ramdumpParser.py -e ../../build/output/bin/tinyara -t ./log_file
@@ -329,21 +328,24 @@ Example Call Stack Output for Kernel crash is as follows:
 ```
 *************************************************************
 dump_file         : None
-log_file          : .log_file
-elf_file  : ../../build/output/bin/tinyara
+log_file          : ./log_file
+elf_file  : ../../build/output/bin/tinyara.axf
 *************************************************************
+
+
 ----------------------------------------------------------
 Kernel Crash point is as follows:
-0x10010f36
-os_start
-/root/product/.tizenrt/os/kernel/init/os_start.c:615
+[ Caller - return address (LR) - of the function which has caused the crash ]
+symbol addr : 0x10010f36
+function name : os_start
+file : /root/product/.tizenrt/os/kernel/init/os_start.c:615
 
-----------------------------------------------------------
-
-------------------------------- DEBUG SYMBOLS IN TEXT RANGE -----------------------------
+--------------------------- DEBUG SYMBOLS IN KERNEL TEXT RANGE --------------------------
 Dump_address	 Symbol_address	  Symbol_name	File_name
-0xe0542b3	 0xe0542a3 	  __FUNCTION__.6620
-0xe0086cd	 0xe0086cc 	  lowoutstream_putc	/root/product/.tizenrt/lib/libc/stdio/lib_lowoutstream.c:76
+0xe0558ab	 0xe05589b 	  __FUNCTION__.6623
+0xe006337	 0xe006310 	  lowvsyslog	/root/product/.tizenrt/os/include/syslog.h:263
+0xe0087dd	 0xe0087dc 	  lowoutstream_putc	/root/product/.tizenrt/lib/libc/stdio/lib_lowoutstream.c:76
+0xe009df5	 0xe009db0 	  up_usagefault	/root/product/.tizenrt/os/arch/arm/src/armv8-m/up_usagefault.c:83
 0x10012565	 0x1001254c 	  up_doirq	/root/product/.tizenrt/os/arch/arm/src/armv8-m/up_doirq.c:91
 0x10012275	 0x10012234 	  exception_common	/root/product/.tizenrt/os/arch/arm/src/armv8-m/up_exception.S:156
 0x10012809	 0x10012808 	  up_unblock_task	/root/product/.tizenrt/os/include/tinyara/arch.h:472
@@ -354,6 +356,7 @@ Dump_address	 Symbol_address	  Symbol_name	File_name
 PC_value	 Symbol_address	  Symbol_name	File_name
 0x10010f36	 0x10010d90 	  os_start	/root/product/.tizenrt/os/include/tinyara/init.h:89
 -----------------------------------------------------------------------------------------
+----------------------------------------------------------
 ```
 ex)
 $python3 ramdumpParser.py -e ../../build/output/bin/common_dbg -t ./log_file
@@ -372,26 +375,36 @@ App[2] is : app
 
 ----------------------------------------------------------
 App Crash point is as follows:
+[Probable crash point corresponding to the R15 register value (PC) might be -4 or -8 bytes]
+[ Current location (PC) of assert ]
+ - Exact crash point might be -4 or -8 bytes from the PC.
 App name : common
-0x0003cdf2
-sched_get_priority_max
-/root/product/.tizenrt/lib/libc/sched/sched_getprioritymax.c:113
+symbol addr : 0x0003cdea
+function name : sched_get_priority_max
+/root/product/.tizenrt/lib/libc/sched/sched_getprioritymax.c:110
 
-----------------------------------------------------------
+[ Caller - return address (LR) - of the function which has caused the crash ]
+App name : app
+symbol addr : 0x00000551
+function name : set_app_main_task
+file : /root/product/main/set_app_main/src/set_app_main.c:380 (discriminator 1)
 
-------------------------------- DEBUG SYMBOLS IN TEXT RANGE -----------------------------
+-------------------------- DEBUG SYMBOLS IN APPLICATION TEXT RANGE -------------------------
 Dump_address	 Symbol_address	  Symbol_name	File_name
-0xe006337	 0xe006310 	  lowvsyslog	/root/product/.tizenrt/os/include/syslog.h:263
-0xe0060c1	 0xe0060c0 	  lib_noflush	/root/product/.tizenrt/os/include/tinyara/streams.h:605
-0xe009c59	 0xe009bf8 	  up_memfault	/root/product/.tizenrt/os/arch/arm/src/armv8-m/up_memfault.c:116
-0x10012565	 0x1001254c 	  up_doirq	/root/product/.tizenrt/os/arch/arm/src/armv8-m/up_doirq.c:91
-0x10012275	 0x10012234 	  exception_common	/root/product/.tizenrt/os/arch/arm/src/armv8-m/up_exception.S:156
-0xe001e8f	 0xe001e8e 	  sem_freeholder	/root/product/.tizenrt/os/kernel/semaphore/sem_holder.c:163
-0xe050791	 0xe050744 	  pthread_start	/root/product/.tizenrt/os/kernel/pthread/pthread_create.c:188
+0x551	 0x3e2 	  gstSupportCourseInfo	/root/product/main/set_app_main/src/set_app_main.c:312
+0x3011	 0x3011 	  wm_easysetup_event_handler	/root/product/main/fill_ocf/src/fill_ocf.c:80
+0x57a1	 0x5729 	  process_operation_uri_from_bixby
+0x2eb9	 0x2e11 	  device_publish_resource_list_getter	/root/product/main/fill_ocf/src/fill_ocf.c:204
+0x2e11	 0x2df7 	  init_product_resources	/root/product/main/fill_ocf/src/fill_ocf.c:228
+0x1e49	 0x1e41 	  otn_wifi_apporve_update	/root/product/apps/otn/wifi_updater/src/otn_wifi_update.c:159
+0x2df7	 0x2df7 	  init_product_resources	/root/product/main/fill_ocf/src/fill_ocf.c:228
+0x105	 0x105 	  set_app_main_task	/root/product/main/set_app_main/src/set_app_main.c:128
+0x105	 0x105 	  set_app_main_task	/root/product/main/set_app_main/src/set_app_main.c:128
 
 PC_value	 Symbol_address	  Symbol_name	File_name
-0x213ce12	 0x2000000 	  __psram_image2_text_start__
 -----------------------------------------------------------------------------------------
+----------------------------------------------------------
+
 ```
 ### DumpParser using GUI
 The UI configuration of DumpParser is as follows


### PR DESCRIPTION
This patch adds the functionality where the crash logs are scanned for
address in the range of application text address range in addition to the
kernel crashes. If yes, it displays the point of crash for the respective
apps.

Signed-off-by: Vidisha Thapa <thapa.v@samsung.com>