### PR TITLE
os/mm/Kconfig : Change default value of MM_ASSERT_ON_FAIL as y

### DIFF
--- a/os/mm/Kconfig
+++ b/os/mm/Kconfig
@@ -149,7 +149,7 @@ config MM_SHM
 
 config MM_ASSERT_ON_FAIL
 	bool "Assertion when Memory allocation fail"
-	default n
+	default y
 	---help---
 		When memory allocation fails, make assertion.
 		From the application binary with loadable build, it will be reloaded.


### PR DESCRIPTION
When fail to allocate the memory, it makes assertion by default.

Signed-off-by: jeongchanKim <jc_.kim@samsung.com>