### PR TITLE
kernel/binary_manager_load.c : Show the binary loading fail log

### DIFF
--- a/os/kernel/binary_manager/binary_manager_load.c
+++ b/os/kernel/binary_manager/binary_manager_load.c
@@ -200,7 +200,7 @@ static int binary_manager_load(int bin_idx)
 					BIN_USEIDX(bin_idx) ^= 1;
 					continue;
 				} else {
-					bmdbg("No valid binary %s file\n", BIN_NAME(bin_idx));
+					printf("Fail to load %s binary : No valid binary file\n", BIN_NAME(bin_idx));
 					break;
 				}
 			}


### PR DESCRIPTION
When fail to load binary because of invalid binary file, there was no logs if we don't enable the binary manager error log config.
In that case, there is no action after boot, so we cannot distinguish it is stucked or loaded fail.
So show the binary loading fail log always.

Signed-off-by: jeongchanKim <jc_.kim@samsung.com>