### PR TITLE
arch/arm/src/armv7,8-m/up_assert.c : Fix build warning

### DIFF
--- a/os/arch/arm/src/armv7-m/up_assert.c
+++ b/os/arch/arm/src/armv7-m/up_assert.c
@@ -126,7 +126,7 @@ extern uint32_t g_assertpc;
 #define CONFIG_BOARD_RESET_ON_ASSERT 0
 #endif
 
-#define IS_FAULT_IN_USER_THREAD  (fault_tcb->uheap != NULL)
+#define IS_FAULT_IN_USER_THREAD  ((void *)fault_tcb->uheap != NULL)
 #define IS_FAULT_IN_USER_SPACE   (is_kernel_space((void *)assert_pc) == false)
 
 /****************************************************************************

--- a/os/arch/arm/src/armv8-m/up_assert.c
+++ b/os/arch/arm/src/armv8-m/up_assert.c
@@ -137,7 +137,7 @@ extern uint32_t g_assertpc;
 #define CONFIG_BOARD_RESET_ON_ASSERT 0
 #endif
 
-#define IS_FAULT_IN_USER_THREAD  (fault_tcb->uheap != NULL)
+#define IS_FAULT_IN_USER_THREAD  ((void *)fault_tcb->uheap != NULL)
 #define IS_FAULT_IN_USER_SPACE   (is_kernel_space((void *)assert_pc) == false)
 
 /****************************************************************************


### PR DESCRIPTION
Fix build error for comparison of different data type
armv8-m/up_assert.c: In function 'up_assert':
armv8-m/up_assert.c:140:52: warning: comparison between pointer and integer
 #define IS_FAULT_IN_USER_THREAD  (fault_tcb->uheap != (void *)NULL)
                                                    ^
armv8-m/up_assert.c:504:6: note: in expansion of macro 'IS_FAULT_IN_USER_THREAD'
  if (IS_FAULT_IN_USER_THREAD) {
      ^~~~~~~~~~~~~~~~~~~~~~~

Signed-off-by: jeongchanKim <jc_.kim@samsung.com>