### PR TITLE
os/tools: reformatting output of check_output_size.py

### DIFF
--- a/os/tools/check_output_size.py
+++ b/os/tools/check_output_size.py
@@ -32,6 +32,12 @@ output_folder = build_folder + '/output/bin'
 
 FAIL_TO_BUILD = False
 
+def number_with_comma_align(number):
+	return ("{:10,}".format(number))
+
+def number_with_comma(number):
+	return ("{:,}".format(number))
+
 def get_value_from_file(file_name, target):
 	with open(file_name, 'r+') as f:
 		lines = f.readlines()
@@ -54,15 +60,16 @@ def check_binary_size(bin_type, part_size):
 	BINARY_SIZE=os.path.getsize(output_path)
 	PARTITION_SIZE = part_size
 
+	# Print each information
+	print(bin_type + "\tBinary Size : " + number_with_comma_align(BINARY_SIZE) + " bytes" + "\tPartition Size : " + number_with_comma_align(PARTITION_SIZE) + " bytes")
+
 	# Compare the partition size and its binary size
 	if PARTITION_SIZE < int(BINARY_SIZE) :
-		print("!!!!!!!! ERROR !!!!!!!")
-		print(bin_type + " Binary size(" + str(BINARY_SIZE) + " bytes) is greater than its partition size(" + str(PARTITION_SIZE) + " bytes).")
-		print(bin_type + " Binary will be removed.")
+		print("   !!!!!!!! ERROR !!!!!!!")
+		print("   Built " + bin_type + " (" + number_with_comma(BINARY_SIZE) + " bytes) is greater than its partition (" + number_with_comma(PARTITION_SIZE) + " bytes).")
+		print("   " + bin_type + " Binary will be deleted. Need to re-configure the partition using menuconfig and to re-build.")
 		os.remove(output_path)
 		FAIL_TO_BUILD = True
-
-	print(bin_type + " Partition Size : " + str(PARTITION_SIZE) + " bytes, Binary Size : " + str(BINARY_SIZE) + " bytes")
 
 PARTITION_SIZE_LIST = get_value_from_file(cfg_file, "CONFIG_FLASH_PART_SIZE=")
 PARTITION_NAME_LIST = get_value_from_file(cfg_file, "CONFIG_FLASH_PART_NAME=")
@@ -122,7 +129,7 @@ APP1_PARTITION_SIZE = int(SIZE_LIST[APP1_IDX]) * 1024
 APP2_PARTITION_SIZE = int(SIZE_LIST[APP2_IDX]) * 1024
 
 # Check if the binary size is smaller than its partition size
-print("=== Verification of Binary sizes and Partition sizes ===")
+print("\n========== Size Verification of built Binaries ==========")
 check_binary_size("KERNEL", KERNEL_PARTITION_SIZE)
 if CONFIG_APP_BINARY_SEPARATION == "y" :
 	check_binary_size("APP1", APP1_PARTITION_SIZE)
@@ -133,3 +140,5 @@ if CONFIG_APP_BINARY_SEPARATION == "y" :
 if FAIL_TO_BUILD == True :
 	# Stop to build, because there is mismatched size problem.
 	sys.exit(1)
+else :
+	print("Size verification is done.")


### PR DESCRIPTION
1. change the title to show which point is the target of verification
2. change the message format as below:
   1) make a tab between the items
   2) add comma at the number and make align
   3) show binary size first
3. add done message
4. modify the message of failure

Success case
```
========== Size Verification of built Binaries ==========
KERNEL	Binary Size :    774,112 bytes	Partition Size :  1,835,008 bytes
APP1	Binary Size :      8,822 bytes	Partition Size :    524,288 bytes
APP2	Binary Size :    344,858 bytes	Partition Size :  1,040,384 bytes
Size verification is done.
```

Failure case
```
========== Size Verification of built Binaries ==========
KERNEL	Binary Size :    774,112 bytes	Partition Size :  1,835,008 bytes
APP1	Binary Size :      8,822 bytes	Partition Size :     16,384 bytes
APP2	Binary Size :    344,860 bytes	Partition Size :     16,384 bytes
   !!!!!!!! ERROR !!!!!!!
   Built APP2 (344,860 bytes) is greater than its partition (16,384 bytes).
   APP2 Binary will be deleted. Need to re-configure the partition using menuconfig and to re-build.
Size verification is done.
```