### PR TITLE
os/binfmt/libelf: fix build warning

### DIFF
--- a/os/binfmt/libelf/libelf_read.c
+++ b/os/binfmt/libelf/libelf_read.c
@@ -131,7 +131,9 @@ static inline void elf_dumpreaddata(FAR char *buffer, int buflen)
 int elf_read(FAR struct elf_loadinfo_s *loadinfo, FAR uint8_t *buffer, size_t readsize, off_t offset)
 {
 	ssize_t nbytes;				/* Number of bytes read */
+#if !defined(CONFIG_COMPRESSED_BINARY)
 	off_t rpos;					/* Position returned by lseek */
+#endif
 
 	/* Advance offset by binary header size, loadinfo->offset will be 0 in normal exec call */
 	offset += loadinfo->offset;


### PR DESCRIPTION
Add preprocessor condition to fix build warning as shown below

CC:  libelf/libelf_read.c
libelf/libelf_read.c: In function 'elf_read':
libelf/libelf_read.c:134:8: warning: unused variable 'rpos' [-Wunused-variable]
  off_t rpos;     /* Position returned by lseek */
        ^~~~

Signed-off-by: sunghan-chang <sh924.chang@samsung.com>