### PR TITLE
os/fs/smartfs: Remove redundant check for end of file sectors

### DIFF
--- a/os/fs/smartfs/smartfs_smart.c
+++ b/os/fs/smartfs/smartfs_smart.c
@@ -576,14 +576,6 @@ static ssize_t smartfs_read(FAR struct file *filep, char *buffer, size_t buflen)
 
 			sf->currsector = SMARTFS_NEXTSECTOR(header);
 			sf->curroffset = sizeof(struct smartfs_chain_header_s);
-
-			/* Test if at end of data */
-
-			if (sf->currsector == SMARTFS_ERASEDSTATE_16BIT) {
-				/* No more data!  Return what we have */
-
-				break;
-			}
 		}
 	}
 


### PR DESCRIPTION
- The check for the end of file sectors is done at the beginning of the
  while loop, don't need to check again at the end.

Signed-off-by: Amogh Hassija <a.hassija@samsung.com>