### PR TITLE
os/kernel/binary_manager : Change lldbg to printf

### DIFF
--- a/os/kernel/binary_manager/binary_manager.c
+++ b/os/kernel/binary_manager/binary_manager.c
@@ -206,22 +206,22 @@ int binary_manager(int argc, char *argv[])
 	return 0;
 errout_with_nobinary:
 	while (1) {
-		lldbg("=============== !!ERROR!! ============== \n");
+		printf("=============== !!ERROR!! ============== \n");
 		if (!is_found_bootparam) {
-			lldbg("ERROR!! Not found user partitions because parsing a partition list is failed.\n");
-			lldbg("Please check whether the partition 'bootparam' exists in CONFIG_FLASH_PART_TYPE with 8192K size.\n");
+			printf("ERROR!! Not found user partitions because parsing a partition list is failed.\n");
+			printf("Please check whether the partition 'bootparam' exists in CONFIG_FLASH_PART_TYPE with 8192K size.\n");
 		}
 #ifdef CONFIG_APP_BINARY_SEPARATION
 		if (!is_found_ubin) {
-			lldbg("ERROR!! Not found user partitions because parsing a partition list is failed.\n");
-			lldbg("Please check logs from configure_mtd_partitions and whether the partition 'bin' exists in CONFIG_FLASH_PART_TYPE.\n");
+			printf("ERROR!! Not found user partitions because parsing a partition list is failed.\n");
+			printf("Please check logs from configure_mtd_partitions and whether the partition 'bin' exists in CONFIG_FLASH_PART_TYPE.\n");
 		}
 #endif
 		if (!is_found_kpart) {
-			lldbg("ERROR!! Not found kernel partitions because parsing a partition list is failed.\n");
-			lldbg("Please check logs from configure_mtd_partitions and whether the partition 'kernel' exists in CONFIG_FLASH_PART_TYPE.\n");
+			printf("ERROR!! Not found kernel partitions because parsing a partition list is failed.\n");
+			printf("Please check logs from configure_mtd_partitions and whether the partition 'kernel' exists in CONFIG_FLASH_PART_TYPE.\n");
 		}
-		lldbg("Enable CONFIG_DEBUG_BINMGR_ERROR if you want to know exact reason.\n\n");
+		printf("Enable CONFIG_DEBUG_BINMGR_ERROR if you want to know exact reason.\n\n");
 		sleep(10);
 	}
 }

--- a/os/kernel/binary_manager/binary_manager_load.c
+++ b/os/kernel/binary_manager/binary_manager_load.c
@@ -119,9 +119,9 @@ static int binary_manager_load_binary(int bin_idx, char *path, load_attr_t *load
 		ret = load_binary(bin_idx, path, load_attr);
 		if (ret >= 0) {
 			if (bin_idx == 0) {
-				lldbg("%s Load 'common'(%s) success!\n", BINARY_COMP_TYPE, path);
+				printf("%s Load 'common'(%s) success!\n", BINARY_COMP_TYPE, path);
 			} else {
-				lldbg("%s Load '%s'(%s) success! pid = %d\n", BINARY_COMP_TYPE, load_attr->bin_name, path, ret);
+				printf("%s Load '%s'(%s) success! pid = %d\n", BINARY_COMP_TYPE, load_attr->bin_name, path, ret);
 			}
 			/* Set the data in table from header */
 			BIN_LOAD_ATTR(bin_idx) = *load_attr;
@@ -132,7 +132,7 @@ static int binary_manager_load_binary(int bin_idx, char *path, load_attr_t *load
 			usleep(1000);
 		}
 		retry_count++;
-		lldbg("Load '%s' %dth fail, errno %d\n", BIN_NAME(bin_idx), retry_count, errno);
+		printf("Load '%s' %dth fail, errno %d\n", BIN_NAME(bin_idx), retry_count, errno);
 	}
 #ifdef CONFIG_OPTIMIZE_APP_RELOAD_TIME
 	struct binary_s *binp = load_attr->binp;
@@ -564,7 +564,7 @@ static int update_thread(int argc, char *argv[])
 #ifdef CONFIG_SYSTEM_REBOOT_REASON
 		up_reboot_reason_write(REBOOT_SYSTEM_BINARY_UPDATE);
 #endif
-		lldbg("==> [REBOOT] Board will be rebooted with new kernel binary");
+		printf("==> [REBOOT] Board will be rebooted with new kernel binary");
 		boardctl(BOARDIOC_RESET, EXIT_SUCCESS);
 	}
 


### PR DESCRIPTION
To show always to user, it is better to use printf instead of lldbg.
So change lldbg to printf in binary manager.

Signed-off-by: jeongchanKim <jc_.kim@samsung.com>