### PR TITLE
kernel/binary_manager: add including reboot_reason.h to use reboot re…

### DIFF
--- a/os/kernel/binary_manager/binary_manager_load.c
+++ b/os/kernel/binary_manager/binary_manager_load.c
@@ -45,6 +45,9 @@
 #ifdef CONFIG_OPTIMIZE_APP_RELOAD_TIME
 #include <tinyara/binfmt/binfmt.h>
 #endif
+#ifdef CONFIG_SYSTEM_REBOOT_REASON
+#include <tinyara/reboot_reason.h>
+#endif
 
 #include "sched/sched.h"
 #include "task/task.h"


### PR DESCRIPTION
…ason

<tinyara/reboot_reason.h> header should be included to use reboot reason definition.
This commit fixes the error as shown below:

CC:  binary_manager/binary_manager_load.c
binary_manager/binary_manager_load.c: In function 'update_thread':
binary_manager/binary_manager_load.c:568:26: error: 'REBOOT_SYSTEM_BINARY_UPDATE' undeclared (first use in this function)
   up_reboot_reason_write(REBOOT_SYSTEM_BINARY_UPDATE);
                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~

Signed-off-by: sunghan-chang <sh924.chang@samsung.com>