### PR TITLE
mm/mm_heap : Make assert on allocation failure when checking all heap…

### DIFF
--- a/os/include/tinyara/mm/mm.h
+++ b/os/include/tinyara/mm/mm.h
@@ -706,6 +706,12 @@ char *mm_get_app_heap_name(void *address);
 /* Function to check heap corruption */
 int mm_check_heap_corruption(struct mm_heap_s *heap);
 
+#define USER_HEAP   1
+#define KERNEL_HEAP 2
+
+/* Function to manage the memory allocation failure case. */
+void mm_manage_alloc_fail(struct mm_heap_s *heap, int heapidx, size_t size, int heap_type);
+
 #if CONFIG_KMM_NHEAPS > 1
 /**
  * @cond

--- a/os/mm/mm_heap/Make.defs
+++ b/os/mm/mm_heap/Make.defs
@@ -56,7 +56,7 @@ CSRCS += mm_initialize.c mm_sem.c mm_addfreechunk.c mm_size2ndx.c
 CSRCS += mm_shrinkchunk.c
 CSRCS += mm_brkaddr.c mm_calloc.c mm_extend.c mm_free.c mm_mallinfo.c
 CSRCS += mm_malloc.c mm_memalign.c mm_realloc.c mm_zalloc.c mm_heap_regioninfo.c mm_getheap.c
-CSRCS += mm_check_heap_corruption.c
+CSRCS += mm_check_heap_corruption.c mm_manage_allocfail.c
 
 ifeq ($(CONFIG_BUILD_KERNEL),y)
 CSRCS += mm_sbrk.c

--- a/os/mm/mm_heap/mm_malloc.c
+++ b/os/mm/mm_heap/mm_malloc.c
@@ -58,12 +58,6 @@
 
 #include <debug.h>
 
-#ifdef CONFIG_MM_ASSERT_ON_FAIL
-#include <assert.h>
-#ifdef CONFIG_SYSTEM_REBOOT_REASON
-#include <tinyara/reboot_reason.h>
-#endif
-#endif
 #include <tinyara/mm/mm.h>
 
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
@@ -235,19 +229,7 @@ FAR void *mm_malloc(FAR struct mm_heap_s *heap, size_t size)
 	 * to the SYSLOG.
 	 */
 
-	if (!ret) {
-#if defined(CONFIG_MM_ASSERT_ON_FAIL) && defined(CONFIG_SYSTEM_REBOOT_REASON)
-		WRITE_REBOOT_REASON(REBOOT_SYSTEM_MEMORYALLOCFAIL);
-#endif
-		mdbg("Allocation failed, size %u\n", size);
-#ifdef CONFIG_DEBUG_MM_HEAPINFO
-		heapinfo_parse_heap(heap, HEAPINFO_DETAIL_ALL, HEAPINFO_PID_ALL);
-#endif
-
-#ifdef CONFIG_MM_ASSERT_ON_FAIL
-		PANIC();
-#endif
-	} else {
+	if (ret) {
 		mvdbg("Allocated %p, size %u\n", ret, size);
 	}
 

--- a/os/mm/mm_heap/mm_manage_allocfail.c
+++ b/os/mm/mm_heap/mm_manage_allocfail.c
@@ -1,0 +1,90 @@
+/****************************************************************************
+ *
+ * Copyright 2021 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <tinyara/config.h>
+#include <debug.h>
+#include <string.h>
+#include <stdlib.h>
+#include <tinyara/mm/mm.h>
+#ifdef CONFIG_MM_ASSERT_ON_FAIL
+#include <assert.h>
+#ifdef CONFIG_SYSTEM_REBOOT_REASON
+#include <tinyara/reboot_reason.h>
+#endif
+#endif
+
+#ifdef CONFIG_MM_ASSERT_ON_FAIL
+#define mfdbg lldbg // When CONFIG_MM_ASSERT_ON_FAIL is enabled, we cannot use the buffer way like mdbg because of board assert.
+#else
+#define mfdbg mdbg
+#endif
+
+#define KERNEL_STR "kernel"
+#define USER_STR   "user"
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+/************************************************************************
+ * Name: mm_manage_alloc_fail
+ *
+ * Description:
+ *   Manage the allocation failure case.
+ *   If needed, write the reboot reason and show the heap status through heapinfo.
+ *   And if CONFIG_MM_ASSERT_ON_FAIL is enabled, make assert.
+ *
+ * Return Value: None
+ *
+ ************************************************************************/
+
+void mm_manage_alloc_fail(struct mm_heap_s *heap, int heapidx, size_t size, int heap_type)
+{
+	mfdbg("Allocation failed from %s heap.\n", (heap_type == KERNEL_HEAP) ? KERNEL_STR : USER_STR);
+	mfdbg(" - requested size %u\n", size);
+
+#ifdef CONFIG_MM_ASSERT_ON_FAIL
+	struct mallinfo info;
+	memset(&info, 0, sizeof(struct mallinfo));
+	for (int idx = 0; idx < heapidx; idx++) {
+		mm_mallinfo(&heap[idx], &info);
+	}
+	mfdbg(" - largest free size : %d\n", info.mxordblk);
+	mfdbg(" - total free size   : %d\n", info.fordblks);
+
+#ifdef CONFIG_SYSTEM_REBOOT_REASON
+	WRITE_REBOOT_REASON(REBOOT_SYSTEM_MEMORYALLOCFAIL);
+#endif
+#endif /* CONFIG_MM_ASSERT_ON_FAIL */
+
+#ifdef CONFIG_DEBUG_MM_HEAPINFO
+	for (int idx = 0; idx < heapidx; idx++) {
+		heapinfo_parse_heap(&heap[idx], HEAPINFO_DETAIL_ALL, HEAPINFO_PID_ALL);
+	}
+#endif
+
+#ifdef CONFIG_MM_ASSERT_ON_FAIL
+	PANIC();
+#endif
+}

--- a/os/mm/mm_heap/mm_memalign.c
+++ b/os/mm/mm_heap/mm_memalign.c
@@ -276,19 +276,7 @@ FAR void *mm_memalign(FAR struct mm_heap_s *heap, size_t alignment, size_t size)
 	 * to the SYSLOG.
 	 */
 
-	if (!ret) {
-#if defined(CONFIG_MM_ASSERT_ON_FAIL) && defined(CONFIG_SYSTEM_REBOOT_REASON)
-		WRITE_REBOOT_REASON(REBOOT_SYSTEM_MEMORYALLOCFAIL);
-#endif
-		mdbg("Allocation failed, size %u\n", size);
-#ifdef CONFIG_DEBUG_MM_HEAPINFO
-		heapinfo_parse_heap(heap, HEAPINFO_DETAIL_ALL, HEAPINFO_PID_ALL);
-#endif
-
-#ifdef CONFIG_MM_ASSERT_ON_FAIL
-		PANIC();
-#endif
-	} else {
+	if (ret) {
 		mvdbg("Allocated %p, size %u\n", ret, size);
 	}
 


### PR DESCRIPTION
… regions

If CONFIG_MM_ASSERT_ON_FAIL is enabled and there are more then 2 heap regions,
if fail to allocate the first heap, it makes assert even though we can allocate the memory into the other heap.
So changed to check all heaps and make assert if we cannot allocate anywhere.

Signed-off-by: jeongchanKim <jc_.kim@samsung.com>