### PR TITLE
framework/binary_manager: Fix build warning about type casting

### DIFF
--- a/framework/src/binary_manager/binary_manager_interface.c
+++ b/framework/src/binary_manager/binary_manager_interface.c
@@ -49,7 +49,7 @@ binmgr_result_type_e binary_manager_set_request(binmgr_request_t *request_msg, i
 		snprintf(request_msg->data.bin_name, BIN_NAME_MAX, "%s", (char *)arg);
 		break;
 	case BINMGR_SETBP:
-		request_msg->data.type = (uint8_t)arg;
+		request_msg->data.type = *(uint8_t *)arg;
 		break;
 	case BINMGR_REGISTER_STATECB:
 		if (arg == NULL) {

--- a/framework/src/binary_manager/binary_manager_update.c
+++ b/framework/src/binary_manager/binary_manager_update.c
@@ -45,7 +45,7 @@ binmgr_result_type_e binary_manager_set_bootparam(uint8_t type)
 		return BINMGR_INVALID_PARAM;
 	}
 
-	ret = binary_manager_set_request(&request_msg, BINMGR_SETBP, type);
+	ret = binary_manager_set_request(&request_msg, BINMGR_SETBP, &type);
 	if (ret != BINMGR_OK) {
 		return ret;
 	}


### PR DESCRIPTION
CC:  src/binary_manager/binary_manager_interface.c
src/binary_manager/binary_manager_interface.c: In function 'binary_manager_set_request':
src/binary_manager/binary_manager_interface.c:52:28: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
   request_msg->data.type = (uint8_t)arg;
                            ^
CC:  src/binary_manager/binary_manager_update.c
src/binary_manager/binary_manager_update.c: In function 'binary_manager_set_bootparam':
src/binary_manager/binary_manager_update.c:48:63: warning: passing argument 3 of 'binary_manager_set_request' makes pointer from integer without a cast [-Wint-conversion]
  ret = binary_manager_set_request(&request_msg, BINMGR_SETBP, type);
                                                               ^~~~
In file included from src/binary_manager/binary_manager_update.c:31:0:
src/binary_manager/binary_manager_internal.h:31:22: note: expected 'void *' but argument is of type 'uint8_t {aka unsigned char}'
 binmgr_result_type_e binary_manager_set_request(binmgr_request_t *request_msg, int cmd, void *arg);                      ^~~~~~~~~~~~~~~~~~~~~~~~~~