### PR TITLE
framework/binary_manager.h : Move binary_manager_set_bootparam prototype

### DIFF
--- a/framework/include/binary_manager/binary_manager.h
+++ b/framework/include/binary_manager/binary_manager.h
@@ -126,6 +126,17 @@ binmgr_result_type_e binary_manager_get_download_path(char *binary_name, char *d
  */
 binmgr_result_type_e binary_manager_get_state(char *binary_name, int *state);
 
+/**
+ * @brief Set boot param
+ * @details @b #include <binary_manager/binary_manager.h>\n
+ *  It sends a message the binary manager to set boot param.
+ * @param[in] type Binary group type for bootparam
+ * @return A defined value of binmgr_result_type_e in <tinyara/binary_manager.h>
+ *         0 (BINMGR_OK) on success. On failure, negative value is returned.
+ * @since TizenRT v3.1 PRE
+ */
+binmgr_result_type_e binary_manager_set_bootparam(uint8_t type);
+
 #endif
 /**
  * @}

--- a/os/kernel/binary_manager/binary_manager.h
+++ b/os/kernel/binary_manager/binary_manager.h
@@ -279,6 +279,7 @@ int binary_manager_get_index_with_name(char *bin_name);
 int binary_manager_scan_bootparam(binmgr_bpinfo_t *bp_info);
 binmgr_bpdata_t *binary_manager_get_bpdata(void);
 int binary_manager_get_inactive_path(int requester_pid, char *bin_name);
+void binary_manager_update_bootparam(int requester_pid, uint8_t type);
 
 /****************************************************************************
  * Binary Manager Main Thread

--- a/os/kernel/binary_manager/binary_manager.h
+++ b/os/kernel/binary_manager/binary_manager.h
@@ -279,7 +279,6 @@ int binary_manager_get_index_with_name(char *bin_name);
 int binary_manager_scan_bootparam(binmgr_bpinfo_t *bp_info);
 binmgr_bpdata_t *binary_manager_get_bpdata(void);
 int binary_manager_get_inactive_path(int requester_pid, char *bin_name);
-int binary_manager_set_bootparam(int requester_pid, uint8_t type);
 
 /****************************************************************************
  * Binary Manager Main Thread


### PR DESCRIPTION
binary_manager_set_bootparam is user API which is in framework/binary_manager.
So to use this API, the prototype should be in framework/include/binary_manager.

Signed-off-by: jeongchanKim <jc_.kim@samsung.com>