### PR TITLE
kernel/binary_manager: Optimize buffer size for crc checking

### DIFF
--- a/os/kernel/binary_manager/binary_manager_load.c
+++ b/os/kernel/binary_manager/binary_manager_load.c
@@ -746,6 +746,13 @@ int binary_manager_read_header(int type, char *devpath, void *header_data, bool 
 			bin_size = ((common_binary_header_t *)header_data)->bin_size;
 			crc_hash = ((common_binary_header_t *)header_data)->crc_hash;
 		}
+		struct mallinfo mem;
+#ifdef CONFIG_CAN_PASS_STRUCTS
+		mem = kmm_mallinfo();
+#else
+		(void)kmm_mallinfo(&mem);
+#endif
+		crc_bufsize = crc_bufsize < (mem.mxordblk / 2) ? crc_bufsize : (mem.mxordblk / 2);
 		crc_buffer = (uint8_t *)kmm_malloc(crc_bufsize);
 		if (!crc_buffer) {
 			bmdbg("Failed to allocate buffer for checking crc, size %u\n", crc_bufsize);


### PR DESCRIPTION
Binary manager allocates buffer with binary RAM size for binary crc checking.
But the space with this size can be not enough after some binaries are loaded.
So if this size is larger than the largest free size, set buffer size to (the largest free size / 2).