### PR TITLE
os/binfmt: Fix memfault during Common binary Update test

### DIFF
--- a/os/binfmt/binfmt_loadbinary.c
+++ b/os/binfmt/binfmt_loadbinary.c
@@ -86,9 +86,6 @@ int load_binary(int binary_idx, FAR const char *filename, load_attr_t *load_attr
 	int pid;
 	int errcode;
 	int ret;
-#if (defined(CONFIG_SUPPORT_COMMON_BINARY) && (defined(CONFIG_ARMV7M_MPU) || defined(CONFIG_ARMV8M_MPU)))
-	uint32_t com_bin_mpu_regs[MPU_REG_NUMBER * MPU_NUM_REGIONS];	/* We need 3 register values to configure each MPU region */
-#endif
 
 	/* Sanity check */
 	if (load_attr && load_attr->bin_size <= 0) {
@@ -193,15 +190,15 @@ int load_binary(int binary_idx, FAR const char *filename, load_attr_t *load_attr
 		uint8_t nregion = mpu_get_nregion_info(MPU_REGION_COMMON_BIN);
 #ifdef CONFIG_OPTIMIZE_APP_RELOAD_TIME
 		/* Get MPU register values for MPU regions */
-		mpu_get_register_config_value(&com_bin_mpu_regs[0], nregion - 3, (uintptr_t)bin->alloc[ALLOC_TEXT], bin->textsize, true,  true);
-		mpu_get_register_config_value(&com_bin_mpu_regs[3], nregion - 2, (uintptr_t)bin->alloc[ALLOC_RO],   bin->rosize,   true,  false);
-		mpu_get_register_config_value(&com_bin_mpu_regs[6], nregion - 1, (uintptr_t)bin->alloc[ALLOC_DATA], bin->ramsize,  false, false);
+		mpu_get_register_config_value(&bin->cmn_mpu_regs[0], nregion - 3, (uintptr_t)bin->alloc[ALLOC_TEXT], bin->textsize, true,  true);
+		mpu_get_register_config_value(&bin->cmn_mpu_regs[3], nregion - 2, (uintptr_t)bin->alloc[ALLOC_RO],   bin->rosize,   true,  false);
+		mpu_get_register_config_value(&bin->cmn_mpu_regs[6], nregion - 1, (uintptr_t)bin->alloc[ALLOC_DATA], bin->ramsize,  false, false);
 #else
-		mpu_get_register_config_value(&com_bin_mpu_regs[0], nregion - 1, (uintptr_t)bin->ramstart,          bin->ramsize,  false, true);
+		mpu_get_register_config_value(&bin->cmn_mpu_regs[0], nregion - 1, (uintptr_t)bin->ramstart,          bin->ramsize,  false, true);
 #endif
 		/* Set MPU register values to real MPU h/w */
 		for (int i = 0; i < MPU_REG_NUMBER * MPU_NUM_REGIONS; i += MPU_REG_NUMBER) {
-			up_mpu_set_register(&com_bin_mpu_regs[i]);
+			up_mpu_set_register(&bin->cmn_mpu_regs[i]);
 		}
 #endif
 

--- a/os/include/tinyara/binfmt/binfmt.h
+++ b/os/include/tinyara/binfmt/binfmt.h
@@ -127,6 +127,9 @@ struct binary_s {
 #endif
 #ifdef CONFIG_SUPPORT_COMMON_BINARY
 	uint8_t islibrary;		/* Is this bin object containing a library */
+#ifdef CONFIG_ARM_MPU							/* MPU register values for common binary only */
+	uint32_t cmn_mpu_regs[MPU_REG_NUMBER * MPU_NUM_REGIONS];	/* Common binary MPU is configured during loading and disabled during unload_module */
+#endif
 #endif
 #if defined(CONFIG_ARCH_ADDRENV) && defined(CONFIG_BUILD_KERNEL)
 	FAR char *argbuffer;		/* Allocated argument list */

--- a/os/include/tinyara/sched.h
+++ b/os/include/tinyara/sched.h
@@ -622,14 +622,15 @@ struct tcb_s {
 #ifdef CONFIG_APP_BINARY_SEPARATION
 	uint32_t uspace;		/* User space object for app binary */
 
-#ifdef CONFIG_ARM_MPU
-	uint32_t mpu_regs[MPU_REG_NUMBER * MPU_NUM_REGIONS];	/* MPU register values for loading data */
+#ifdef CONFIG_ARM_MPU						/* MPU register values for loadable apps only */
+	uint32_t mpu_regs[MPU_REG_NUMBER * MPU_NUM_REGIONS];	/* MPU for apps is configured during loading and disabled in task_terminate */
 #endif
 #endif
 
-#if defined(CONFIG_MPU_STACK_OVERFLOW_PROTECTION)
-uint32_t stack_mpu_regs[MPU_REG_NUMBER]; /* MPU register values for stack protection */
+#if defined(CONFIG_MPU_STACK_OVERFLOW_PROTECTION)		/* MPU register values for stack protection */
+	uint32_t stack_mpu_regs[MPU_REG_NUMBER];		/* MPU for stack is configured during stack creation and disabled at stack release */
 #endif
+
 #ifdef CONFIG_SUPPORT_COMMON_BINARY
 	uint32_t app_id;			/* Indicates app id of the task and used to index into umm_heap_table */
 #endif


### PR DESCRIPTION
During update test, we try to unload and reload all binaries. In case
of app binary, we disbale the MPU regions based on the MPU regs stored
in the tcb of apps. But, in case of Common binary, the MPU regions are
not stored anywhere. As a result, the MPU for common binary is not
disabled. So, at the time of reloading common binary, there is a memfault
while trying to copy code from binary to the read-only area of the code
section.

Issue is fixed by storing the common binary MPU registers in the binary
data structure and disabling the regions at the time of unload module.

Signed-off-by: Kishore S N <kishore.sn@samsung.com>