### PR TITLE
kernel/binary_manager: Reload all binaries when a fault happens in common or user binaries

### DIFF
--- a/os/arch/arm/src/armv7-m/up_assert.c
+++ b/os/arch/arm/src/armv7-m/up_assert.c
@@ -500,7 +500,7 @@ void up_assert(const uint8_t *filename, int lineno)
 #ifdef CONFIG_BINMGR_RECOVERY
 	if (IS_FAULT_IN_USER_SPACE) {
 		/* Recover user fault through binary manager */
-		binary_manager_recover_userfault(assert_pc);
+		binary_manager_recover_userfault();
 	} else
 #endif
 	{

--- a/os/arch/arm/src/armv8-m/up_assert.c
+++ b/os/arch/arm/src/armv8-m/up_assert.c
@@ -137,8 +137,8 @@ extern uint32_t g_assertpc;
 #define CONFIG_BOARD_RESET_ON_ASSERT 0
 #endif
 
-#define IS_FAULT_IN_USER_THREAD  ((void *)fault_tcb->uheap != NULL)
-#define IS_FAULT_IN_USER_SPACE   (is_kernel_space((void *)assert_pc) == false)
+#define IS_FAULT_IN_USER_THREAD(fault_tcb)  ((void *)fault_tcb->uheap != NULL)
+#define IS_FAULT_IN_USER_SPACE(assert_pc)   (is_kernel_space((void *)assert_pc) == false)
 
 /****************************************************************************
  * Private Data
@@ -479,21 +479,6 @@ void up_assert(const uint8_t *filename, int lineno)
 #else
 	lldbg("Assertion failed at file:%s line: %d\n", filename, lineno);
 #endif
-
-#ifdef CONFIG_APP_BINARY_SEPARATION
-	uint32_t assert_pc;
-	struct tcb_s *fault_tcb = this_task();
-
-	/* Extract the PC value of instruction which caused the abort/assert */
-
-	if (current_regs) {
-		assert_pc = current_regs[REG_R15];
-	} else {
-		assert_pc = (uint32_t)g_assertpc;
-	}
-
-#endif  /* CONFIG_APP_BINARY_SEPARATION */
-
 	up_dumpstate();
 
 	lldbg("Checking kernel heap for corruption...\n");
@@ -501,7 +486,9 @@ void up_assert(const uint8_t *filename, int lineno)
 		lldbg("No heap corruption detected\n");
 	}
 #ifdef CONFIG_APP_BINARY_SEPARATION
-	if (IS_FAULT_IN_USER_THREAD) {
+	struct tcb_s *fault_tcb = this_task();
+
+	if (IS_FAULT_IN_USER_THREAD(fault_tcb)) {
 		elf_show_all_bin_addr();
 		lldbg("Checking current app heap for corruption...\n");
 		if (mm_check_heap_corruption((struct mm_heap_s *)(fault_tcb->uheap)) == OK) {
@@ -515,7 +502,17 @@ void up_assert(const uint8_t *filename, int lineno)
 #endif
 
 #ifdef CONFIG_BINMGR_RECOVERY
-	if (IS_FAULT_IN_USER_SPACE) {
+	uint32_t assert_pc;
+
+	/* Extract the PC value of instruction which caused the abort/assert */
+
+	if (current_regs) {
+		assert_pc = current_regs[REG_R15];
+	} else {
+		assert_pc = (uint32_t)g_assertpc;
+	}
+
+	if (IS_FAULT_IN_USER_SPACE(assert_pc)) {
 		/* Recover user fault through binary manager */
 		binary_manager_recover_userfault();
 	} else

--- a/os/arch/arm/src/armv8-m/up_assert.c
+++ b/os/arch/arm/src/armv8-m/up_assert.c
@@ -517,7 +517,7 @@ void up_assert(const uint8_t *filename, int lineno)
 #ifdef CONFIG_BINMGR_RECOVERY
 	if (IS_FAULT_IN_USER_SPACE) {
 		/* Recover user fault through binary manager */
-		binary_manager_recover_userfault(assert_pc);
+		binary_manager_recover_userfault();
 	} else
 #endif
 	{

--- a/os/arch/arm/src/common/up_checkspace.c
+++ b/os/arch/arm/src/common/up_checkspace.c
@@ -73,14 +73,4 @@ bool is_kernel_space(void *addr)
 	}
 	return false;
 }
-
-#ifdef CONFIG_SUPPORT_COMMON_BINARY
-bool is_common_library_space(void *addr)
-{
-	if (g_lib_binp && addr >= (void *)g_lib_binp->alloc[ALLOC_TEXT] && addr <= (void *)(g_lib_binp->alloc[ALLOC_TEXT] + g_lib_binp->textsize)) {
-		return true;
-	}
-	return false;
-}
-#endif							/* CONFIG_SUPPORT_COMMON_BINARY */
 #endif							/* CONFIG_BUILD_PROTECTED */

--- a/os/include/tinyara/arch.h
+++ b/os/include/tinyara/arch.h
@@ -2224,17 +2224,6 @@ bool is_kernel_data_space(void *addr);
  ****************************************************************************/
 bool is_kernel_space(void *addr);
 
-#ifdef CONFIG_SUPPORT_COMMON_BINARY
-/****************************************************************************
- * Name: is_common_library_space
- *
- * Description:
- *   Check the address is in common library space or not
- *
- ****************************************************************************/
-bool is_common_library_space(void *addr);
-
-#endif
 #endif
 
 #undef EXTERN

--- a/os/kernel/binary_manager/binary_manager.h
+++ b/os/kernel/binary_manager/binary_manager.h
@@ -252,7 +252,7 @@ void binary_manager_deactivate_rtthreads(int bin_idx);
 void binary_manager_set_faultmsg_sender(pid_t pid);
 int binary_manager_faultmsg_sender(int argc, char *argv[]);
 mqd_t binary_manager_get_mqfd(void);
-void binary_manager_recover_userfault(uint32_t assert_pc);
+void binary_manager_recover_userfault(void);
 #endif
 
 void binary_manager_add_binlist(FAR struct tcb_s *tcb);


### PR DESCRIPTION
Binary manager should reload all binaries if a fault happens in common library or user binaries
That's because common binary is loaded in memory space of app binaries.