### PR TITLE
binfmt/binfmt_loadbinary.c : move elf_save_bin_section_addr to before…

### DIFF
--- a/os/binfmt/binfmt_loadbinary.c
+++ b/os/binfmt/binfmt_loadbinary.c
@@ -211,14 +211,15 @@ int load_binary(int binary_idx, FAR const char *filename, load_attr_t *load_attr
 	heap_table[binary_idx] = bin->heapstart;
 #endif
 
+	elf_save_bin_section_addr(bin);
 	/* Start the module */
 	pid = exec_module(bin);
 	if (pid < 0) {
 		errcode = pid;
 		berr("ERROR: Failed to execute program '%s': %d\n", filename, errcode);
+		elf_delete_bin_section_addr(bin);
 		goto errout_with_unload;
 	}
-	elf_save_bin_section_addr(bin);
 
 	/* Print Binary section address & size details */
 


### PR DESCRIPTION
… calling exec_module

if a higher priority app crashes on start, then elf_show_all_bin_addr() doesn't print the
details of the app as they are saved by elf_save_bin_section_addr after the app has started
executing. So moving elf_save_bin_section_addr to before calling exec_module.

Signed-off-by: Abhishek Akkabathula <a.akkabathul@samsung.com>