### PR TITLE
[TEST PENDING] Optimization of buffer size for reading/appending SmartFs files

### DIFF
--- a/apps/README.md
+++ b/apps/README.md
@@ -5,7 +5,8 @@
 In this file,  
 > [**General**](README.md#general)  
 > [**Directory Location**](README.md#directory-location)  
-> [**Application Configuration File**](README.md#application-configuration-file)
+> [**Application Configuration File**](README.md#application-configuration-file)  
+> [**Suggestion for Optimizing SmartFs Ops**](README.md#Suggestion-for-Optimizing-SmartFs-Ops)
 
 Outside this file,  
 > [**Built-In Applications**](builtin/README.md)  
@@ -65,3 +66,20 @@ CONFIGURED_APPS += examples/hello
 endif
 ```
 
+## Suggestion for optimizing SmartFs Ops
+
+Using just any buffer size for reading/appending to the contents of a SmartFs file in a
+back-to-back(looped) manner might cause repetitive reading of sectors and performance degradation.
+Hence, programmers are encouraged to use an optimal buffer size for reading/appending
+back-to-back to/from a SmartFs file.
+
+You can use the following to obtain the optimal buffer size: -
+```
+stat("\mnt", &st);
+buf_size = st.st_blksize;
+```
+
+Please refer to the "buffer_optimization" example (apps/examples/smartfs/buffer_optimization) for
+more details. The same will give you a demonstration of the improvement in read/append performance.
+
+NOTE: This suggestion is useful only when read/append requests are made contiguously, back-to-back.

--- a/apps/examples/smartfs/buffer_optimization/Kconfig
+++ b/apps/examples/smartfs/buffer_optimization/Kconfig
@@ -1,0 +1,11 @@
+#
+# For a description of the syntax of this configuration file,
+# see kconfig-language at https://www.kernel.org/doc/Documentation/kbuild/kconfig-language.txt
+#
+
+config EXAMPLES_SMARTFS_BUF_OPTIMIZATION
+	bool "SmartFs Buffer Optimization Example"
+	default n
+	depends on TIMER
+	---help---
+		Enable the SmartFs Buffer Optimization Example

--- a/apps/examples/smartfs/buffer_optimization/Make.defs
+++ b/apps/examples/smartfs/buffer_optimization/Make.defs
@@ -1,0 +1,27 @@
+###########################################################################
+#
+# Copyright 2022 Samsung Electronics All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+#
+###########################################################################
+############################################################################
+#
+# apps/examples/smartfs/buffer_optimization/Make.defs
+# Adds selected applications to apps/ build
+#
+############################################################################
+
+ifeq ($(CONFIG_EXAMPLES_SMARTFS_BUF_OPTIMIZATION),y)
+CONFIGURED_APPS += examples/smartfs/buffer_optimization
+endif

--- a/apps/examples/smartfs/buffer_optimization/Makefile
+++ b/apps/examples/smartfs/buffer_optimization/Makefile
@@ -1,0 +1,131 @@
+###########################################################################
+#
+# Copyright 2022 Samsung Electronics All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+#
+###########################################################################
+############################################################################
+#
+# apps/examples/smartfs/buffer_optimization/Makefile
+#
+############################################################################
+
+-include $(TOPDIR)/.config
+-include $(TOPDIR)/Make.defs
+include $(APPDIR)/Make.defs
+
+# Smartfs Buffer Optimization Example info
+
+APPNAME = smartfs_buf_opt
+FUNCNAME = buffer_optimization_main
+PRIORITY = SCHED_PRIORITY_DEFAULT
+STACKSIZE = 4096
+THREADEXEC = TASH_EXECMD_ASYNC
+
+# Smartfs Buffer Optimization Example
+
+ASRCS =
+CSRCS =
+MAINSRC = buffer_optimization_main.c
+
+AOBJS = $(ASRCS:.S=$(OBJEXT))
+COBJS = $(CSRCS:.c=$(OBJEXT))
+MAINOBJ = $(MAINSRC:.c=$(OBJEXT))
+
+SRCS = $(ASRCS) $(CSRCS) $(MAINSRC)
+OBJS = $(AOBJS) $(COBJS)
+
+ifneq ($(CONFIG_BUILD_KERNEL),y)
+  OBJS += $(MAINOBJ)
+endif
+
+ifeq ($(CONFIG_WINDOWS_NATIVE),y)
+  BIN = $(APPDIR)\libapps$(LIBEXT)
+else
+ifeq ($(WINTOOL),y)
+  BIN = $(APPDIR)\\libapps$(LIBEXT)
+else
+  BIN = $(APPDIR)/libapps$(LIBEXT)
+endif
+endif
+
+ifeq ($(WINTOOL),y)
+  INSTALL_DIR = "${shell cygpath -w $(BIN_DIR)}"
+else
+  INSTALL_DIR = $(BIN_DIR)
+endif
+
+CONFIG_EXAMPLES_SMARTFS_BUF_OPTIMIZATION_PROGNAME ?= smartfs_buf_opt(EXEEXT)
+PROGNAME = $(CONFIG_EXAMPLES_SMARTFS_BUF_OPTIMIZATION_PROGNAME)
+
+ROOTDEPPATH = --dep-path .
+
+# Common build
+
+VPATH =
+
+all: .built
+.PHONY: clean depend distclean
+
+$(AOBJS): %$(OBJEXT): %.S
+	$(call ASSEMBLE, $<, $@)
+
+$(COBJS) $(MAINOBJ): %$(OBJEXT): %.c
+	$(call COMPILE, $<, $@)
+
+.built: $(OBJS)
+	$(call ARCHIVE, $(BIN), $(OBJS))
+	@touch .built
+
+ifeq ($(CONFIG_BUILD_KERNEL),y)
+$(BIN_DIR)$(DELIM)$(PROGNAME): $(OBJS) $(MAINOBJ)
+	@echo "LD: $(PROGNAME)"
+	$(Q) $(LD) $(LDELFFLAGS) $(LDLIBPATH) -o $(INSTALL_DIR)$(DELIM)$(PROGNAME) $(ARCHCRT0OBJ) $(MAINOBJ) $(LDLIBS)
+	$(Q) $(NM) -u  $(INSTALL_DIR)$(DELIM)$(PROGNAME)
+
+install: $(BIN_DIR)$(DELIM)$(PROGNAME)
+
+else
+install:
+
+endif
+
+ifeq ($(CONFIG_BUILTIN_APPS)$(CONFIG_EXAMPLES_SMARTFS_BUF_OPTIMIZATION),yy)
+$(BUILTIN_REGISTRY)$(DELIM)$(FUNCNAME).bdat: $(DEPCONFIG) Makefile
+	$(Q) $(call REGISTER,$(APPNAME),$(FUNCNAME),$(THREADEXEC),$(PRIORITY),$(STACKSIZE))
+
+context: $(BUILTIN_REGISTRY)$(DELIM)$(FUNCNAME).bdat
+
+else
+context:
+
+endif
+
+.depend: Makefile $(SRCS)
+	@$(MKDEP) $(ROOTDEPPATH) "$(CC)" -- $(CFLAGS) -- $(SRCS) >Make.dep
+	@touch $@
+
+depend: .depend
+
+clean:
+	$(call DELFILE, .built)
+	$(call CLEAN)
+
+distclean: clean
+	$(call DELFILE, Make.dep)
+	$(call DELFILE, .depend)
+
+-include Make.dep
+.PHONY: preconfig
+preconfig:

--- a/apps/examples/smartfs/buffer_optimization/buffer_optimization_main.c
+++ b/apps/examples/smartfs/buffer_optimization/buffer_optimization_main.c
@@ -1,0 +1,492 @@
+/****************************************************************************
+ *
+ * Copyright 2022 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+/****************************************************************************
+ *
+ * apps/examples/smartfs/buffer_optimization/buffer_optimization_main.c
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <sys/stat.h>
+#include <sys/statfs.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <time.h>
+
+#include <tinyara/timer.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+#define SAMPLE_FILE "/mnt/sample_file"
+#define TIMER_DEVNAME "/dev/timer%d"
+#define READ_TEST_ITR 100	//No. of times file will be read for testing
+#define APPEND_TEST_ITR 1	//No. of times file will be appended for testing
+#define TOTAL_APPEND_SIZE 10240	//Amount of data to be appended during the test
+#define DEFAULT_BUF_SIZE_S 512	//Smaller default buffer size used for demonstration testng
+#define DEFAULT_BUF_SIZE_L 1024	//Larger default buffer size used for demonstration testing
+
+/****************************************************************************
+ * Private data
+ ****************************************************************************/
+char g_buf[DEFAULT_BUF_SIZE_L + 1];
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: print_test_result
+ *
+ * Description: Helper function to print the test results.
+ *
+ ****************************************************************************/
+
+void print_test_result(const char *name, int file_size, int itr, int buf_size, uint32_t time)
+{
+	printf("\n**************************************************************************************\n");
+	printf("Throughput while %s %dKb file %d time(s) with %dbyte buffer size = %.02fKbps\n",\
+			name, file_size, itr, buf_size, (float)(file_size * itr * 1000000) / time);
+	printf("\n**************************************************************************************\n");
+	return;
+}
+
+/****************************************************************************
+ * Name: create_test_file
+ *
+ * Description: Creates the test file with test data that we will use
+ *              to conduct the test.
+ *
+ ****************************************************************************/
+
+static int create_test_file(int sample_file_size)
+{
+	int fd;
+	int ret = OK;
+	int buflen;
+	memset(g_buf, DEFAULT_BUF_SIZE_L, '1');
+
+	fd = open(SAMPLE_FILE, O_WROK | O_CREAT);
+	if (fd < 0) {
+		printf("Unable to open Sample File: %s for testing, Error: %d\n", SAMPLE_FILE, errno);
+		return ERROR;
+	}
+
+	//Use larger default buffer size to create the sample file
+	while (sample_file_size > 0) {
+		if (sample_file_size >= DEFAULT_BUF_SIZE_L) {
+			buflen = DEFAULT_BUF_SIZE_L;
+		} else {
+			buflen = sample_file_size;
+		}
+		ret = write(fd, g_buf, buflen);
+		if (ret < 0) {
+			printf("Unable to write to Sample File %s, Error: %d\n", SAMPLE_FILE, errno);
+			ret = errno;
+			goto error_with_fd;
+		}
+		sample_file_size -= ret;
+	}
+	ret = OK;
+
+error_with_fd:
+	close(fd);
+	return ret;
+}
+
+/****************************************************************************
+ * Name: append_test_util
+ *
+ * Description: Perform appending of data to the file, buffer by buffer
+ *
+ ****************************************************************************/
+
+static int append_test_util(int buf_size)
+{
+	int ret = OK;
+	int fd;
+	int itr = 0;
+	int total = TOTAL_APPEND_SIZE;
+
+	while (itr < APPEND_TEST_ITR) {
+		fd = open(SAMPLE_FILE, O_WROK | O_APPEND);
+		if (fd < 0) {
+			printf("Unable to open sample file %s for appending, Error: %d\n", SAMPLE_FILE, errno);
+			return ERROR;
+		}
+
+		while (total > 0) {
+			if (total < buf_size) {
+				buf_size = total;
+			}
+			ret = write(fd, g_buf, buf_size);
+			if (ret < 0) {
+				printf("Unable to write to file %s, Error: %d\n", SAMPLE_FILE, errno);
+				ret = errno;
+				goto error_with_fd;
+			}
+			total -= ret;
+		}
+		close(fd);
+		itr += 1;
+	}
+
+	ret = OK;
+error_with_fd:
+	close(fd);
+	return ret;
+}
+
+/****************************************************************************
+ * Name: append_test
+ *
+ * Description: Set up the timer and run the append test for different
+ *              buffer sizes.
+ *
+ ****************************************************************************/
+
+static int append_test(int frt_fd, int file_size)
+{
+	int ret;
+	int buf_size;
+	struct timer_status_s time_1, time_2;
+	uint32_t time_append;
+	struct stat st;
+
+
+	ret = ioctl(frt_fd, TCIOC_GETSTATUS, (unsigned long)(uintptr_t)&time_1);
+	if (ret < 0) {
+		fprintf(stderr, "ERROR: Failed to get Free Run Timer status: %d\n", errno);
+		return ret;
+	}
+
+	ret = append_test_util(DEFAULT_BUF_SIZE_S);
+	if (ret != OK) {
+		printf("Appending with buffer size %d failed\n", DEFAULT_BUF_SIZE_S);
+		return ret;
+	}
+
+	ret = ioctl(frt_fd, TCIOC_GETSTATUS, (unsigned long)(uintptr_t)&time_2);
+	if (ret < 0) {
+		fprintf(stderr, "ERROR: Failed to get Free Run Timer status: %d\n", errno);
+		return ret;
+	}
+
+	time_append = time_2.timeleft - time_1.timeleft;
+	print_test_result("appending", TOTAL_APPEND_SIZE, APPEND_TEST_ITR, DEFAULT_BUF_SIZE_S, time_append);
+
+	unlink(SAMPLE_FILE);
+
+	ret = create_test_file(file_size * 1024);
+	if (ret != OK) {
+		printf("Unable to complete test\n");
+		return -1;
+	}
+
+	ret = ioctl(frt_fd, TCIOC_GETSTATUS, (unsigned long)(uintptr_t)&time_1);
+	if (ret < 0) {
+		fprintf(stderr, "ERROR: Failed to get Free Run Timer status: %d\n", errno);
+		return ret;
+	}
+
+	ret = append_test_util(DEFAULT_BUF_SIZE_L);
+	if (ret != OK) {
+		printf("Appending with buffer size %d failed\n", DEFAULT_BUF_SIZE_L);
+		return ret;
+	}
+
+	ret = ioctl(frt_fd, TCIOC_GETSTATUS, (unsigned long)(uintptr_t)&time_2);
+	if (ret < 0) {
+		fprintf(stderr, "ERROR: Failed to get Free Run Timer status: %d\n", errno);
+		return ret;
+	}
+
+	time_append = time_2.timeleft - time_1.timeleft;
+	print_test_result("appending", TOTAL_APPEND_SIZE, APPEND_TEST_ITR, DEFAULT_BUF_SIZE_L, time_append);
+
+	unlink(SAMPLE_FILE);
+
+	ret = create_test_file(file_size * 1024);
+	if (ret != OK) {
+		printf("Unable to complete test\n");
+		return -1;
+	}
+
+	ret = stat("/mnt", &st);
+	if (ret < 0) {
+		printf("Stat to get optimal read buffer size failed, Errno = %d\n", errno);
+		return -1;
+	}
+	buf_size = st.st_blksize;
+
+	ret = ioctl(frt_fd, TCIOC_GETSTATUS, (unsigned long)(uintptr_t)&time_1);
+	if (ret < 0) {
+		fprintf(stderr, "ERROR: Failed to get Free Run Timer status: %d\n", errno);
+		return ret;
+	}
+
+	ret = append_test_util(buf_size);
+	if (ret != OK) {
+		printf("Appending with buffer size %d failed\n", buf_size);
+		return ret;
+	}
+
+	ret = ioctl(frt_fd, TCIOC_GETSTATUS, (unsigned long)(uintptr_t)&time_2);
+	if (ret < 0) {
+		fprintf(stderr, "ERROR: Failed to get Free Run Timer status: %d\n", errno);
+		return ret;
+	}
+
+	time_append = time_2.timeleft - time_1.timeleft;
+	printf("TEST WITH OPTIMIZED BUFFER\n");
+	print_test_result("appending", TOTAL_APPEND_SIZE, APPEND_TEST_ITR, buf_size, time_append);
+
+	unlink(SAMPLE_FILE);
+
+	printf("================================= APPEND TESTS COMPLETE =================================\n\n");
+
+	return OK;
+}
+
+/****************************************************************************
+ * Name: read_test_util
+ *
+ * Description: Perform a back-to-back read of the entire file's contents,
+ *              multiple times.
+ *
+ ****************************************************************************/
+
+static int read_test_util(int buf_size)
+{
+	int fd;
+	int ret;
+	int itr = 0;
+
+	while (itr < READ_TEST_ITR) {
+		fd = open(SAMPLE_FILE, O_RDOK);
+		if (fd < 0) {
+			printf("Unable to open Sample File %s for reading, Errno = %d\n", SAMPLE_FILE, errno);
+			return ERROR;
+		}
+
+		do {
+			ret = read(fd, g_buf, buf_size);
+			if (ret < 0) {
+				printf("Unable to read File %s, Error: %d\n", SAMPLE_FILE, errno);
+				ret = errno;
+				goto errout_with_fd;
+			}
+		} while (ret == buf_size);
+
+		close(fd);
+		itr += 1;
+	}
+
+	ret = OK;
+errout_with_fd:
+	close(fd);
+	return ret;
+}
+
+/****************************************************************************
+ * Name: read_test
+ *
+ * Description: Set up the timer and run the read test with different
+ *              buffer sizes.
+ *
+ ****************************************************************************/
+
+static int read_test(int frt_fd, int file_size)
+{
+	int ret;
+	int buf_size;
+	struct timer_status_s time_1, time_2;
+	uint32_t time_read;
+	struct stat st;
+
+	ret = ioctl(frt_fd, TCIOC_GETSTATUS, (unsigned long)(uintptr_t)&time_1);
+	if (ret < 0) {
+		fprintf(stderr, "ERROR: Failed to get Free Run Timer status: %d\n", errno);
+		return ret;
+	}
+
+	ret = read_test_util(DEFAULT_BUF_SIZE_S);
+	if (ret != OK) {
+		printf("Reading with buffer size %d failed\n", DEFAULT_BUF_SIZE_S);
+		return ret;
+	}
+
+	ret = ioctl(frt_fd, TCIOC_GETSTATUS, (unsigned long)(uintptr_t)&time_2);
+	if (ret < 0) {
+		fprintf(stderr, "ERROR: Failed to get Free Run Timer status: %d\n", errno);
+		return ret;
+	}
+
+	time_read = time_2.timeleft - time_1.timeleft;
+	print_test_result("reading", file_size, READ_TEST_ITR, DEFAULT_BUF_SIZE_S, time_read);
+
+	ret = ioctl(frt_fd, TCIOC_GETSTATUS, (unsigned long)(uintptr_t)&time_1);
+	if (ret < 0) {
+		fprintf(stderr, "ERROR: Failed to get Free Run Timer status: %d\n", errno);
+		return ret;
+	}
+
+	ret = read_test_util(DEFAULT_BUF_SIZE_L);
+	if (ret != OK) {
+		printf("Reading with buffer size %d failed\n", DEFAULT_BUF_SIZE_L);
+		return ret;
+	}
+
+	ret = ioctl(frt_fd, TCIOC_GETSTATUS, (unsigned long)(uintptr_t)&time_2);
+	if (ret < 0) {
+		fprintf(stderr, "ERROR: Failed to get Free Run Timer status: %d\n", errno);
+		return ret;
+	}
+
+	time_read = time_2.timeleft - time_1.timeleft;
+	print_test_result("reading", file_size, READ_TEST_ITR, DEFAULT_BUF_SIZE_L, time_read);
+
+	ret = stat("/mnt", &st);
+	if (ret < 0) {
+		printf("Stat to get optimal read buffer size failed, Errno = %d\n", errno);
+		return -1;
+	}
+	buf_size = st.st_blksize;
+
+	ret = ioctl(frt_fd, TCIOC_GETSTATUS, (unsigned long)(uintptr_t)&time_1);
+	if (ret < 0) {
+		fprintf(stderr, "ERROR: Failed to get Free Run Timer status: %d\n", errno);
+		return ret;
+	}
+
+	ret = read_test_util(buf_size);
+	if (ret != OK) {
+		printf("Reading with buffer size %d failed\n", buf_size);
+		return ret;
+	}
+
+	ret = ioctl(frt_fd, TCIOC_GETSTATUS, (unsigned long)(uintptr_t)&time_2);
+	if (ret < 0) {
+		fprintf(stderr, "ERROR: Failed to get Free Run Timer status: %d\n", errno);
+		return ret;
+	}
+
+	time_read = time_2.timeleft - time_1.timeleft;
+	printf("TEST WITH OPTIMIZED BUFFER\n");
+	print_test_result("reading", file_size, READ_TEST_ITR, buf_size, time_read);
+
+	printf("================================== READ TESTS COMPLETE ==================================\n\n");
+
+	return OK;
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+#ifdef CONFIG_BUILD_KERNEL
+int main(int argc, char *argv[])
+#else
+int buffer_optimization_main(int argc, char *argv[])
+#endif
+{
+	int ret = OK;
+	int file_size = 8;
+	int frt_fd = -1;
+	int timer_devno = 0;
+	struct statfs buf;
+
+	ret = statfs("/mnt", &buf);
+	if (ret < 0) {
+		printf("Statfs Failed!!! ret: %d\n", ret);
+		return -1;
+	}
+	char timer_path[buf.f_namelen];
+
+	if (argc > 1) {
+		timer_devno = atoi(argv[1]);
+		if (argc == 3) {
+			file_size = atoi(argv[2]);
+		}
+	} else {
+		printf("\nCorrect test command usage is: smartfs_buf_opt <Timer Device No.> <File Size in Kb>\n");
+		printf("-> Read test example will read the file back to back, one buffer size at a time\n");
+		printf("-> Append test example will append 10Kb data to the file, one buffer size at a time\n");
+		return -1;
+	}
+
+	snprintf(timer_path, _POSIX_PATH_MAX, TIMER_DEVNAME, timer_devno);
+	printf("Timer path = %s\n", timer_path);
+
+	ret = create_test_file(file_size * 1024);
+	if (ret != OK) {
+		printf("Unable to create test file, ret: %d\n", ret);
+		return -1;
+	}
+
+	frt_fd = open(timer_path, O_RDONLY);
+	if (frt_fd < 0) {
+		fprintf(stderr, "ERROR: Failed to open Free Run Timer: %d\n", errno);
+		return -1;
+	}
+
+	if (ioctl(frt_fd, TCIOC_SETMODE, MODE_FREERUN) < 0) {
+		fprintf(stderr, "ERROR: Failed to set Free Run Timer: %d\n", errno);
+		ret = -1;
+		goto error_with_frt_fd;
+	}
+	if (ioctl(frt_fd, TCIOC_START, TRUE) < 0) {
+		fprintf(stderr, "ERROR: Failed to start Free Run Timer: %d\n", errno);
+		ret = -1;
+		goto error_with_frt_fd;
+	}
+
+	ret = read_test(frt_fd, file_size);
+	if (ret != OK) {
+		printf("Read test failed on file: %s, ret: %d\n", SAMPLE_FILE, ret);
+		ret = -1;
+		goto error_with_open_timer_dev;
+	}
+
+	ret = append_test(frt_fd, file_size);
+	if (ret != OK) {
+		printf("Append test failed on file: %s, ret: %d\n", SAMPLE_FILE, ret);
+		ret = -1;
+	}
+
+error_with_open_timer_dev:
+	if (ioctl(frt_fd, TCIOC_STOP, 0) < 0) {
+		fprintf(stderr, "ERROR: Failed to stop the Free Run Timer: %d\n", errno);
+		ret = -1;
+		goto error_with_frt_fd;
+	}
+	if (ret == OK) {
+		printf("Test Example Completed Successfully\n");
+	}
+
+error_with_frt_fd:
+	close(frt_fd);
+	printf("SmartFs Optimized Buffer Test Example Exits\n\n");
+	return ret;
+}


### PR DESCRIPTION
- Using just any buffer size for reading from SmartFs files causes
repetitive reading of the same sector and degrades performance.

- We suggest the use of an optimal buffer size for reading from
SmartFs files when the content is to be read back-to-back in a loop.