### PR TITLE
mm/*mm_heap : Move ARCH_GET_RET_ADDRESS at the first of the function

### DIFF
--- a/os/include/tinyara/mm/mm.h
+++ b/os/include/tinyara/mm/mm.h
@@ -232,12 +232,15 @@ typedef size_t mmsize_t;
 typedef size_t mmaddress_t;		/* 32 bit address space */
 
 #if defined(CONFIG_ARCH_MIPS)
-/* Macro gets return address of malloc API */
+/* Macro gets return address of malloc API. */
 #define ARCH_GET_RET_ADDRESS(caller_retaddr) \
 	do { \
 		asm volatile ("sw $ra, %0" : "=m" (caller_retaddr)); \
 	} while (0);
 #elif defined(CONFIG_ARCH_ARM)
+/* This macro should be placed at the first of the function.
+ * If no, it is better to use "__builtin_return_address(0)" instead.
+ */
 #define ARCH_GET_RET_ADDRESS(caller_retaddr) \
 	do { \
 		asm volatile ("mov %0,lr\n" : "=r" (caller_retaddr));\

--- a/os/mm/kmm_heap/kmm_calloc.c
+++ b/os/mm/kmm_heap/kmm_calloc.c
@@ -109,6 +109,10 @@ void *kmm_calloc_at(int heap_index, size_t n, size_t elem_size)
 {
 	void *ret;
 	struct mm_heap_s *kheap;
+#ifdef CONFIG_DEBUG_MM_HEAPINFO
+	size_t caller_retaddr = 0;
+	ARCH_GET_RET_ADDRESS(caller_retaddr)
+#endif
 	if (heap_index > HEAP_END_IDX || heap_index < HEAP_START_IDX) {
 		mdbg("kmm_calloc_at failed. Wrong heap index (%d) of (%d)\n", heap_index, HEAP_END_IDX);
 		return NULL;
@@ -120,8 +124,6 @@ void *kmm_calloc_at(int heap_index, size_t n, size_t elem_size)
 
 	kheap = kmm_get_heap();
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
-	size_t caller_retaddr = 0;
-	ARCH_GET_RET_ADDRESS(caller_retaddr)
 	ret = mm_calloc(&kheap[heap_index], n, elem_size, caller_retaddr);
 	if (ret == NULL) {
 		mm_manage_alloc_fail(&kheap[heap_index], heap_index, heap_index, n * elem_size, KERNEL_HEAP);
@@ -148,12 +150,12 @@ void *kmm_calloc_at(int heap_index, size_t n, size_t elem_size)
 FAR void *kmm_calloc(size_t n, size_t elem_size)
 {
 	size_t caller_retaddr = 0;
-#ifdef CONFIG_DEBUG_MM_HEAPINFO
-	ARCH_GET_RET_ADDRESS(caller_retaddr)
-#endif
 	if (n == 0 || elem_size == 0) {
 		return NULL;
 	}
+#ifdef CONFIG_DEBUG_MM_HEAPINFO
+	ARCH_GET_RET_ADDRESS(caller_retaddr)
+#endif
 	return kheap_calloc(n, elem_size, caller_retaddr);
 }
 

--- a/os/mm/kmm_heap/kmm_malloc.c
+++ b/os/mm/kmm_heap/kmm_malloc.c
@@ -126,6 +126,10 @@ void *kmm_malloc_at(int heap_index, size_t size)
 {
 	void *ret;
 	struct mm_heap_s *kheap;
+#ifdef CONFIG_DEBUG_MM_HEAPINFO
+	size_t caller_retaddr = 0;
+	ARCH_GET_RET_ADDRESS(caller_retaddr)
+#endif
 	if (heap_index > HEAP_END_IDX || heap_index < HEAP_START_IDX) {
 		mdbg("kmm_malloc_at failed. Wrong heap index (%d) of (%d)\n", heap_index, HEAP_END_IDX);
 		return NULL;
@@ -137,8 +141,6 @@ void *kmm_malloc_at(int heap_index, size_t size)
 
 	kheap = kmm_get_heap();
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
-	size_t caller_retaddr = 0;
-	ARCH_GET_RET_ADDRESS(caller_retaddr)
 	ret = mm_malloc(&kheap[heap_index], size, caller_retaddr);
 #else
 	ret = mm_malloc(&kheap[heap_index], size);

--- a/os/mm/kmm_heap/kmm_memalign.c
+++ b/os/mm/kmm_heap/kmm_memalign.c
@@ -92,6 +92,10 @@ void *kmm_memalign_at(int heap_index, size_t alignment, size_t size)
 {
 	void *ret;
 	struct mm_heap_s *kheap;
+#ifdef CONFIG_DEBUG_MM_HEAPINFO
+	size_t caller_retaddr = 0;
+	ARCH_GET_RET_ADDRESS(caller_retaddr)
+#endif
 	if (heap_index > HEAP_END_IDX || heap_index < HEAP_START_IDX) {
 		mdbg("kmm_memalign_at failed. Wrong heap index (%d) of (%d)\n", heap_index, HEAP_END_IDX);
 		return NULL;
@@ -103,8 +107,6 @@ void *kmm_memalign_at(int heap_index, size_t alignment, size_t size)
 
 	kheap = kmm_get_heap();
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
-	size_t caller_retaddr = 0;
-	ARCH_GET_RET_ADDRESS(caller_retaddr)
 	ret = mm_memalign(&kheap[heap_index], alignment, size, caller_retaddr);
 #else
 	ret = mm_memalign(&kheap[heap_index], alignment, size);
@@ -139,12 +141,13 @@ FAR void *kmm_memalign(size_t alignment, size_t size)
 	if (size == 0) {
 		return NULL;
 	}
-
+#ifdef CONFIG_DEBUG_MM_HEAPINFO
+	size_t caller_retaddr = 0;
+	ARCH_GET_RET_ADDRESS(caller_retaddr)
+#endif
 	struct mm_heap_s *kheap = kmm_get_heap();
 	for (kheap_idx = HEAP_START_IDX; kheap_idx <= HEAP_END_IDX; kheap_idx++) {
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
-		size_t caller_retaddr = 0;
-		ARCH_GET_RET_ADDRESS(caller_retaddr)
 		ret = mm_memalign(&kheap[kheap_idx], alignment, size, caller_retaddr);
 #else
 		ret = mm_memalign(&kheap[kheap_idx], alignment, size);

--- a/os/mm/kmm_heap/kmm_realloc.c
+++ b/os/mm/kmm_heap/kmm_realloc.c
@@ -89,6 +89,10 @@ void *kmm_realloc_at(int heap_index, void *oldmem, size_t size)
 {
 	void *ret;
 	struct mm_heap_s *kheap;
+#ifdef CONFIG_DEBUG_MM_HEAPINFO
+	size_t caller_retaddr = 0;
+	ARCH_GET_RET_ADDRESS(caller_retaddr)
+#endif
 	if (heap_index > HEAP_END_IDX || heap_index < HEAP_START_IDX) {
 		mdbg("kmm_realloc_at failed. Wrong heap index (%d) of (%d)\n", heap_index, HEAP_END_IDX);
 		return NULL;
@@ -100,8 +104,6 @@ void *kmm_realloc_at(int heap_index, void *oldmem, size_t size)
 
 	kheap = kmm_get_heap();
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
-	size_t caller_retaddr = 0;
-	ARCH_GET_RET_ADDRESS(caller_retaddr)
 	ret = mm_realloc(&kheap[heap_index], oldmem, size, caller_retaddr);
 #else
 	ret = mm_realloc(&kheap[heap_index], oldmem, size);
@@ -132,6 +134,10 @@ FAR void *kmm_realloc(FAR void *oldmem, size_t newsize)
 {
 	void *ret;
 	int kheap_idx;
+#ifdef CONFIG_DEBUG_MM_HEAPINFO
+	size_t caller_retaddr = 0;
+	ARCH_GET_RET_ADDRESS(caller_retaddr)
+#endif
 	struct mm_heap_s *kheap_origin = mm_get_heap(oldmem);
 	struct mm_heap_s *kheap_new;
 
@@ -139,8 +145,6 @@ FAR void *kmm_realloc(FAR void *oldmem, size_t newsize)
 		return NULL;
 	}
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
-	size_t caller_retaddr = 0;
-	ARCH_GET_RET_ADDRESS(caller_retaddr)
 	ret = mm_realloc(kheap_origin, oldmem, newsize, caller_retaddr);
 #else
 	ret = mm_realloc(kheap_origin, oldmem, newsize);
@@ -153,7 +157,6 @@ FAR void *kmm_realloc(FAR void *oldmem, size_t newsize)
 	kheap_new = kmm_get_heap();
 	for (kheap_idx = HEAP_START_IDX; kheap_idx <= HEAP_END_IDX; kheap_idx++) {
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
-		ARCH_GET_RET_ADDRESS(caller_retaddr)
 		ret = mm_malloc(&kheap_new[kheap_idx], newsize, caller_retaddr);
 #else
 		ret = mm_malloc(&kheap_new[kheap_idx], newsize);

--- a/os/mm/kmm_heap/kmm_zalloc.c
+++ b/os/mm/kmm_heap/kmm_zalloc.c
@@ -85,6 +85,10 @@ void *kmm_zalloc_at(int heap_index, size_t size)
 {
 	void *ret;
 	struct mm_heap_s *kheap;
+#ifdef CONFIG_DEBUG_MM_HEAPINFO
+	size_t caller_retaddr = 0;
+	ARCH_GET_RET_ADDRESS(caller_retaddr)
+#endif
 	if (heap_index > HEAP_END_IDX || heap_index < HEAP_START_IDX) {
 		mdbg("kmm_zalloc_at failed. Wrong heap index (%d) of (%d)\n", heap_index, HEAP_END_IDX);
 		return NULL;
@@ -96,8 +100,6 @@ void *kmm_zalloc_at(int heap_index, size_t size)
 
 	kheap = kmm_get_heap();
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
-	size_t caller_retaddr = 0;
-	ARCH_GET_RET_ADDRESS(caller_retaddr)
 	ret = mm_zalloc(&kheap[heap_index], size, caller_retaddr);
 #else
 	ret = mm_zalloc(&kheap[heap_index], size);
@@ -127,7 +129,10 @@ FAR void *kmm_zalloc(size_t size)
 {
 	void *ret;
 	int kheap_idx;
-
+#ifdef CONFIG_DEBUG_MM_HEAPINFO
+	size_t caller_retaddr = 0;
+	ARCH_GET_RET_ADDRESS(caller_retaddr)
+#endif
 	if (size == 0) {
 		return NULL;
 	}
@@ -136,8 +141,6 @@ FAR void *kmm_zalloc(size_t size)
 
 	for (kheap_idx = HEAP_START_IDX; kheap_idx <= HEAP_END_IDX; kheap_idx++) {
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
-		size_t caller_retaddr = 0;
-		ARCH_GET_RET_ADDRESS(caller_retaddr)
 		ret = mm_zalloc(&kheap[kheap_idx], size, caller_retaddr);
 #else
 		ret = mm_zalloc(&kheap[kheap_idx], size);

--- a/os/mm/umm_heap/umm_calloc.c
+++ b/os/mm/umm_heap/umm_calloc.c
@@ -83,6 +83,10 @@
 void *calloc_at(int heap_index, size_t n, size_t elem_size)
 {
 	void *ret;
+#ifdef CONFIG_DEBUG_MM_HEAPINFO
+	size_t caller_retaddr = 0;
+	ARCH_GET_RET_ADDRESS(caller_retaddr)
+#endif
 	if (heap_index > HEAP_END_IDX || heap_index < 0) {
 		mdbg("calloc_at failed. Wrong heap index (%d) of (%d)\n", heap_index, HEAP_END_IDX);
 		return NULL;
@@ -92,8 +96,6 @@ void *calloc_at(int heap_index, size_t n, size_t elem_size)
 		return NULL;
 	}
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
-	size_t caller_retaddr = 0;
-	ARCH_GET_RET_ADDRESS(caller_retaddr)
 	ret = mm_calloc(&BASE_HEAP[heap_index], n, elem_size, caller_retaddr);
 #else
 	ret = mm_calloc(&BASE_HEAP[heap_index], n, elem_size);

--- a/os/mm/umm_heap/umm_malloc.c
+++ b/os/mm/umm_heap/umm_malloc.c
@@ -105,6 +105,10 @@
 void *malloc_at(int heap_index, size_t size)
 {
 	void *ret;
+#ifdef CONFIG_DEBUG_MM_HEAPINFO
+	size_t caller_retaddr = 0;
+	ARCH_GET_RET_ADDRESS(caller_retaddr)
+#endif
 	if (heap_index > HEAP_END_IDX || heap_index < HEAP_START_IDX) {
 		mdbg("malloc_at failed. Wrong heap index (%d) of (%d)\n", heap_index, HEAP_END_IDX);
 		return NULL;
@@ -114,8 +118,6 @@ void *malloc_at(int heap_index, size_t size)
 		return NULL;
 	}
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
-	size_t caller_retaddr = 0;
-	ARCH_GET_RET_ADDRESS(caller_retaddr)
 	ret = mm_malloc(&BASE_HEAP[heap_index], size, caller_retaddr);
 #else
 	ret = mm_malloc(&BASE_HEAP[heap_index], size);

--- a/os/mm/umm_heap/umm_memalign.c
+++ b/os/mm/umm_heap/umm_memalign.c
@@ -87,6 +87,10 @@
 void *memalign_at(int heap_index, size_t alignment, size_t size)
 {
 	void *ret;
+#ifdef CONFIG_DEBUG_MM_HEAPINFO
+	size_t caller_retaddr = 0;
+	ARCH_GET_RET_ADDRESS(caller_retaddr)
+#endif
 	if (heap_index > HEAP_END_IDX || heap_index < HEAP_START_IDX) {
 		mdbg("memalign_at failed. Wrong heap index (%d) of (%d)\n", heap_index, HEAP_END_IDX);
 		return NULL;
@@ -97,8 +101,6 @@ void *memalign_at(int heap_index, size_t alignment, size_t size)
 	}
 
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
-	size_t caller_retaddr = 0;
-	ARCH_GET_RET_ADDRESS(caller_retaddr)
 	ret = mm_memalign(&BASE_HEAP[heap_index], alignment, size, caller_retaddr);
 #else
 	ret = mm_memalign(&BASE_HEAP[heap_index], alignment, size);

--- a/os/mm/umm_heap/umm_realloc.c
+++ b/os/mm/umm_heap/umm_realloc.c
@@ -87,6 +87,10 @@
 void *realloc_at(int heap_index, void *oldmem, size_t size)
 {
 	void *ret;
+#ifdef CONFIG_DEBUG_MM_HEAPINFO
+	size_t caller_retaddr = 0;
+	ARCH_GET_RET_ADDRESS(caller_retaddr)
+#endif
 	if (heap_index > HEAP_END_IDX || heap_index < HEAP_START_IDX) {
 		mdbg("realloc_at failed. Wrong heap index (%d) of (%d)\n", heap_index, HEAP_END_IDX);
 		return NULL;
@@ -97,8 +101,6 @@ void *realloc_at(int heap_index, void *oldmem, size_t size)
 	}
 
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
-	size_t caller_retaddr = 0;
-	ARCH_GET_RET_ADDRESS(caller_retaddr)
 	ret = mm_realloc(&BASE_HEAP[heap_index], oldmem, size, caller_retaddr);
 #else
 	ret = mm_realloc(&BASE_HEAP[heap_index], oldmem, size);

--- a/os/mm/umm_heap/umm_xalloc_user_at.c
+++ b/os/mm/umm_heap/umm_xalloc_user_at.c
@@ -115,13 +115,15 @@ void *malloc_user_at(struct mm_heap_s *heap, size_t size)
  ************************************************************************/
 void *realloc_user_at(struct mm_heap_s *heap, void *oldmem, size_t newsize)
 {
+#ifdef CONFIG_DEBUG_MM_HEAPINFO
+	size_t caller_retaddr = 0;
+	ARCH_GET_RET_ADDRESS(caller_retaddr)
+#endif
 	if (newsize == 0) {
 		free_user_at(heap, oldmem);
 		return NULL;
 	}
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
-	size_t caller_retaddr = 0;
-	ARCH_GET_RET_ADDRESS(caller_retaddr)	
 	return mm_realloc(heap, oldmem, newsize, caller_retaddr);
 #else
 	return mm_realloc(heap, oldmem, newsize);

--- a/os/mm/umm_heap/umm_zalloc.c
+++ b/os/mm/umm_heap/umm_zalloc.c
@@ -84,6 +84,10 @@
 void *zalloc_at(int heap_index, size_t size)
 {
 	void *ret;
+#ifdef CONFIG_DEBUG_MM_HEAPINFO
+	size_t caller_retaddr = 0;
+	ARCH_GET_RET_ADDRESS(caller_retaddr)
+#endif
 	if (heap_index > HEAP_END_IDX || heap_index < HEAP_START_IDX) {
 		mdbg("zalloc_at failed. Wrong heap index (%d) of (%d)\n", heap_index, HEAP_END_IDX);
 		return NULL;
@@ -93,8 +97,6 @@ void *zalloc_at(int heap_index, size_t size)
 		return NULL;
 	}
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
-	size_t caller_retaddr = 0;
-	ARCH_GET_RET_ADDRESS(caller_retaddr)
 	ret = mm_zalloc(&BASE_HEAP[heap_index], size, caller_retaddr);
 #else
 	ret = mm_zalloc(&BASE_HEAP[heap_index], size);


### PR DESCRIPTION
This macro should be placed at the first of the function.
If no, it is better to use "__builtin_return_address(0)" instead.

Signed-off-by: jeongchanKim <jc_.kim@samsung.com>