### PR TITLE
board/rtl8721dhp_app_start.c : Fix to make coloration for idle stack

### DIFF
--- a/os/board/rtl8721csm/src/component/soc/realtek/amebad/fwlib/ram_hp/rtl8721dhp_app_start.c
+++ b/os/board/rtl8721csm/src/component/soc/realtek/amebad/fwlib/ram_hp/rtl8721dhp_app_start.c
@@ -1393,7 +1393,7 @@ extern void __libc_init_array(void);
 #ifdef CONFIG_STACK_COLORATION
 	/* Set the IDLE stack to the coloration value and jump into os_start() */
 
-	go_os_start((FAR void *)&_ebss, CONFIG_IDLETHREAD_STACKSIZE);
+	go_os_start((FAR void *)g_idle_topstack - CONFIG_IDLETHREAD_STACKSIZE, CONFIG_IDLETHREAD_STACKSIZE);
 #else
 	/* Call os_start() */
 


### PR DESCRIPTION
Fix the idle stack start address for coloration

Signed-off-by: jeongchanKim <jc_.kim@samsung.com>