### PR TITLE
arch/armv7-m, armv8-m: do board reset with kernel heap corruption

### DIFF
--- a/os/arch/arm/src/armv7-m/up_assert.c
+++ b/os/arch/arm/src/armv7-m/up_assert.c
@@ -467,6 +467,10 @@ void up_assert(const uint8_t *filename, int lineno)
 	lldbg("Checking kernel heap for corruption...\n");
 	if (mm_check_heap_corruption(g_kmmheap) == OK) {
 		lldbg("No heap corruption detected\n");
+	} else {
+		/* treat kernel fault */
+
+		_up_assert(EXIT_FAILURE);
 	}
 #ifdef CONFIG_APP_BINARY_SEPARATION
 	struct tcb_s *fault_tcb = this_task();

--- a/os/arch/arm/src/armv8-m/up_assert.c
+++ b/os/arch/arm/src/armv8-m/up_assert.c
@@ -484,6 +484,10 @@ void up_assert(const uint8_t *filename, int lineno)
 	lldbg("Checking kernel heap for corruption...\n");
 	if (mm_check_heap_corruption(g_kmmheap) == OK) {
 		lldbg("No heap corruption detected\n");
+	} else {
+		/* treat kernel fault */
+
+		_up_assert(EXIT_FAILURE);
 	}
 #ifdef CONFIG_APP_BINARY_SEPARATION
 	struct tcb_s *fault_tcb = this_task();


### PR DESCRIPTION
When kernel heap corruption is detected in assert, we can't keep kernel alive.
Currently it keeps and tries to reload user binary. Finally it causes kernel assert again.
This commit resets the board with kernel heap corruption in assert.

Signed-off-by: sunghan-chang <sh924.chang@samsung.com>