### PR TITLE
arch/amebad/amebad_serial.c: fix wrong size of tx buffer for uart2

### DIFF
--- a/os/arch/arm/src/amebad/amebad_serial.c
+++ b/os/arch/arm/src/amebad/amebad_serial.c
@@ -353,7 +353,7 @@ static uart_dev_t g_uart2port = {
 		.buffer = g_uart2rxbuffer,
 	},
 	.xmit = {
-		.size = CONFIG_UART1_TXBUFSIZE,
+		.size = CONFIG_UART2_TXBUFSIZE,
 		.buffer = g_uart2txbuffer,
 	},
 	.ops = &g_uart_ops,


### PR DESCRIPTION
Uart2 uses tx buffer for g_uart2txbuffer global variable and
its definition is
static char g_uart2txbuffer[CONFIG_UART2_TXBUFSIZE];.
So, g_uart2port structure should have CONFIG_UART2_TXBUFSIZE in the .xmit->.size,
not CONFIG_UART1_TXBUFSIZE.
This commit fixes above.

Signed-off-by: sunghan-chang <sh924.chang@samsung.com>