### PR TITLE
src/armv7-m,armv8-m: Modify to get the correct assert pc

### DIFF
--- a/os/arch/arm/src/armv7-m/up_assert.c
+++ b/os/arch/arm/src/armv7-m/up_assert.c
@@ -109,9 +109,8 @@
 #include "mpu.h"
 
 bool abort_mode = false;
-#ifdef CONFIG_APP_BINARY_SEPARATION
-extern uint32_t g_assertpc;
-#endif
+extern uint32_t system_exception_location;
+extern uint32_t user_assert_location;
 
 /****************************************************************************
  * Pre-processor Definitions
@@ -127,7 +126,7 @@ extern uint32_t g_assertpc;
 #endif
 
 #define IS_FAULT_IN_USER_THREAD(fault_tcb)  ((void *)fault_tcb->uheap != NULL)
-#define IS_FAULT_IN_USER_SPACE(assert_pc)   (is_kernel_space((void *)assert_pc) == false)
+#define IS_FAULT_IN_USER_SPACE(asserted_location)   (is_kernel_space((void *)asserted_location) == false)
 
 /****************************************************************************
  * Private Data
@@ -453,9 +452,29 @@ void dump_all_stack(void)
 
 void up_assert(const uint8_t *filename, int lineno)
 {
+	/* ARCH_GET_RET_ADDRESS should always be
+	 * called at the start of the function */
+
+	size_t kernel_assert_location = 0;
+	ARCH_GET_RET_ADDRESS(kernel_assert_location)
+
 	board_led_on(LED_ASSERTION);
 
 	abort_mode = true;
+
+	uint32_t asserted_location;
+
+	/* Extract the PC value of instruction which caused the abort/assert */
+
+	if (system_exception_location) {
+		asserted_location = (uint32_t)system_exception_location;
+		system_exception_location = 0x0;	/* reset */
+	} else if (user_assert_location) {
+		asserted_location = (uint32_t)user_assert_location;
+		user_assert_location = 0x0;
+	} else {
+		asserted_location = (uint32_t)kernel_assert_location;
+	}
 
 #if CONFIG_TASK_NAME_SIZE > 0
 	lldbg("Assertion failed at file:%s line: %d task: %s\n", filename, lineno, this_task()->name);
@@ -482,25 +501,15 @@ void up_assert(const uint8_t *filename, int lineno)
 			lldbg("No heap corruption detected\n");
 		}
 	}
-	lldbg("Assert location (PC) : %08x\n", g_assertpc);
 #endif
+	lldbg("Assert location (PC) : %08x\n", asserted_location);
 
 #if defined(CONFIG_BOARD_CRASHDUMP)
 	board_crashdump(up_getsp(), this_task(), (uint8_t *)filename, lineno);
 #endif
 
 #ifdef CONFIG_BINMGR_RECOVERY
-	uint32_t assert_pc;
-
-	/* Extract the PC value of instruction which caused the abort/assert */
-
-	if (current_regs) {
-		assert_pc = current_regs[REG_R15];
-	} else {
-		assert_pc = (uint32_t)g_assertpc;
-	}
-
-	if (IS_FAULT_IN_USER_SPACE(assert_pc)) {
+	if (IS_FAULT_IN_USER_SPACE(asserted_location)) {
 		/* Recover user fault through binary manager */
 		binary_manager_recover_userfault();
 	} else

--- a/os/arch/arm/src/armv7-m/up_busfault.c
+++ b/os/arch/arm/src/armv7-m/up_busfault.c
@@ -44,6 +44,7 @@
 #include "nvic.h"
 #include "up_internal.h"
 
+extern uint32_t system_exception_location;
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
@@ -86,6 +87,8 @@ int up_busfault(int irq, FAR void *context, FAR void *arg)
 	uint32_t *regs = (uint32_t *)context;
 	uint32_t cfsr = getreg32(NVIC_CFAULTS);
 	uint32_t bfar = getreg32(NVIC_BFAULT_ADDR);
+	system_exception_location = regs[REG_R15];
+
 	lldbg("PANIC!!! Bus fault occurred while executing instruction at address : 0x%08x\n", regs[REG_R15]);
 	lldbg("CFAULTS: 0x%08x\n", cfsr);
 

--- a/os/arch/arm/src/armv7-m/up_hardfault.c
+++ b/os/arch/arm/src/armv7-m/up_hardfault.c
@@ -85,9 +85,7 @@
 
 #define INSN_SVC0        0xdf00	/* insn: svc 0 */
 
-#ifdef CONFIG_APP_BINARY_SEPARATION
-uint32_t g_assertpc;
-#endif
+uint32_t system_exception_location;
 /****************************************************************************
  * Private Data
  ****************************************************************************/
@@ -115,13 +113,8 @@ uint32_t g_assertpc;
 
 int up_hardfault(int irq, FAR void *context, FAR void *arg)
 {
-#if defined(CONFIG_DEBUG_HARDFAULT) || !defined(CONFIG_ARMV7M_USEBASEPRI) || defined(CONFIG_BINMGR_RECOVERY)
 	uint32_t *regs = (uint32_t *)context;
-#endif
-
-#ifdef CONFIG_APP_BINARY_SEPARATION
-	g_assertpc = regs[REG_R15];
-#endif
+	system_exception_location = regs[REG_R15];
 	/* Get the value of the program counter where the fault occurred */
 
 #ifndef CONFIG_ARMV7M_USEBASEPRI

--- a/os/arch/arm/src/armv7-m/up_memfault.c
+++ b/os/arch/arm/src/armv7-m/up_memfault.c
@@ -75,6 +75,7 @@
 #include "nvic.h"
 #include "up_internal.h"
 
+extern uint32_t system_exception_location;
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
@@ -121,6 +122,8 @@ int up_memfault(int irq, FAR void *context, FAR void *arg)
 	uint32_t *regs = (uint32_t *)context;
 	uint32_t cfsr = getreg32(NVIC_CFAULTS);
 	uint32_t mmfar = getreg32(NVIC_MEMMANAGE_ADDR);
+	system_exception_location = regs[REG_R15];
+
 	lldbg("PANIC!!! Memory Management Fault occurred while executing instruction at address : 0x%08x\n", regs[REG_R15]);
 	lldbg("CFAULTS: 0x%08x\n", cfsr);
 
@@ -134,6 +137,7 @@ int up_memfault(int irq, FAR void *context, FAR void *arg)
 		lldbg("Data access violation occurred.\n");
 	} else if (cfsr & IACCVIOL) {
 		lldbg("Instruction access violation occurred while fetching instruction from an Execute Never (XN) region.\n");
+		system_exception_location = regs[REG_R14];	/* The PC value might be invalid, so use LR */
 	} else if (cfsr & MSTKERR) {
 		lldbg("Error while stacking registers during exception entry.\n");
 	} else if (cfsr & MUNSTKERR) {

--- a/os/arch/arm/src/armv7-m/up_svcall.c
+++ b/os/arch/arm/src/armv7-m/up_svcall.c
@@ -94,9 +94,7 @@
 #define svcdbg(...)
 #endif
 
-#ifdef CONFIG_APP_BINARY_SEPARATION
-extern uint32_t g_assertpc;
-#endif
+uint32_t user_assert_location;
 #ifdef CONFIG_SUPPORT_COMMON_BINARY
 extern uint32_t *g_umm_app_id;
 #endif
@@ -189,9 +187,6 @@ int up_svcall(int irq, FAR void *context, FAR void *arg)
 	/* The SVCall software interrupt is called with R0 = system call command
 	 * and R1..R7 =  variable number of arguments depending on the system call.
 	 */
-#ifdef CONFIG_APP_BINARY_SEPARATION
-	g_assertpc = regs[REG_R14];
-#endif
 
 #if defined(CONFIG_DEBUG_SYSCALL) || defined(CONFIG_DEBUG_SVCALL)
 #ifndef CONFIG_DEBUG_SVCALL
@@ -513,6 +508,11 @@ int up_svcall(int irq, FAR void *context, FAR void *arg)
 		DEBUGASSERT(index < CONFIG_SYS_NNEST);
 		if (index >= CONFIG_SYS_NNEST) {
 			return INDEX_ERROR;
+		}
+
+		if (cmd == SYS_up_assert) {
+			/* get the user assert location from the LR value */
+			user_assert_location = regs[REG_R14];
 		}
 
 		/* Setup to return to dispatch_syscall in privileged mode. */

--- a/os/arch/arm/src/armv7-m/up_usagefault.c
+++ b/os/arch/arm/src/armv7-m/up_usagefault.c
@@ -44,6 +44,7 @@
 #include "nvic.h"
 #include "up_internal.h"
 
+extern uint32_t system_exception_location;
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
@@ -84,6 +85,8 @@ int up_usagefault(int irq, FAR void *context, FAR void *arg)
 	(void)irqsave();
 	uint32_t *regs = (uint32_t *)context;
 	uint32_t cfsr = getreg32(NVIC_CFAULTS);
+	system_exception_location = regs[REG_R15];
+
 	lldbg("PANIC!!! Usagefault occurred while executing instruction at address : 0x%08x\n", regs[REG_R15]);
 	lldbg("CFAULTS: 0x%08x\n", cfsr);
 
@@ -95,6 +98,9 @@ int up_usagefault(int irq, FAR void *context, FAR void *arg)
 		lldbg("A coprocessor error has occurred.\n");
 	} else if (cfsr & INVPC) {
 		lldbg("An integrity check error has occurred on EXC_RETURN. PC value might be invalid.\n");
+		/* As PC value might be invalid use LR value to determine if
+		 * the crash occured in the kernel space or in the user space */
+		system_exception_location = regs[REG_R14];
 	} else if (cfsr & INVSTATE) {
 		lldbg("Invalid state. Instruction executed with invalid EPSR.T or EPSR.IT field.\n");
 	} else if (cfsr & UNDEFINSTR) {

--- a/os/arch/arm/src/armv8-m/up_busfault.c
+++ b/os/arch/arm/src/armv8-m/up_busfault.c
@@ -44,6 +44,7 @@
 #include "nvic.h"
 #include "up_internal.h"
 
+extern uint32_t system_exception_location;
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
@@ -86,6 +87,8 @@ int up_busfault(int irq, FAR void *context, FAR void *arg)
 	uint32_t *regs = (uint32_t *)context;
 	uint32_t cfsr = getreg32(NVIC_CFAULTS);
 	uint32_t bfar = getreg32(NVIC_BFAULT_ADDR);
+	system_exception_location = regs[REG_R15];
+
 	lldbg("PANIC!!! Bus fault occurred while executing instruction at address : 0x%08x\n", regs[REG_R15]);
 	lldbg("CFAULTS: 0x%08x\n", cfsr);
 

--- a/os/arch/arm/src/armv8-m/up_hardfault.c
+++ b/os/arch/arm/src/armv8-m/up_hardfault.c
@@ -90,9 +90,7 @@
 
 #define INSN_SVC0        0xdf00	/* insn: svc 0 */
 
-#ifdef CONFIG_APP_BINARY_SEPARATION
-uint32_t g_assertpc;
-#endif
+uint32_t system_exception_location;
 /****************************************************************************
  * Private Data
  ****************************************************************************/
@@ -120,13 +118,8 @@ uint32_t g_assertpc;
 
 int up_hardfault(int irq, FAR void *context, FAR void *arg)
 {
-#if defined(CONFIG_DEBUG_HARDFAULT) || !defined(CONFIG_ARMV8M_USEBASEPRI) || defined(CONFIG_BINMGR_RECOVERY)
 	uint32_t *regs = (uint32_t *)context;
-#endif
-
-#ifdef CONFIG_APP_BINARY_SEPARATION
-	g_assertpc = regs[REG_R15];
-#endif
+	system_exception_location = regs[REG_R15];
 	/* Get the value of the program counter where the fault occurred */
 
 #ifndef CONFIG_ARMV8M_USEBASEPRI

--- a/os/arch/arm/src/armv8-m/up_memfault.c
+++ b/os/arch/arm/src/armv8-m/up_memfault.c
@@ -75,6 +75,7 @@
 #include "nvic.h"
 #include "up_internal.h"
 
+extern uint32_t system_exception_location;
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
@@ -121,6 +122,8 @@ int up_memfault(int irq, FAR void *context, FAR void *arg)
 	uint32_t *regs = (uint32_t *)context;
 	uint32_t cfsr = getreg32(NVIC_CFAULTS);
 	uint32_t mmfar = getreg32(NVIC_MEMMANAGE_ADDR);
+	system_exception_location = regs[REG_R15];
+
 	lldbg("PANIC!!! Memory Management Fault occurred while executing instruction at address : 0x%08x\n", regs[REG_R15]);
 	lldbg("CFAULTS: 0x%08x MMFAR: 0x%08x\n", cfsr, mmfar);
 
@@ -134,6 +137,7 @@ int up_memfault(int irq, FAR void *context, FAR void *arg)
 		lldbg("Data access violation occurred.\n");
 	} else if (cfsr & IACCVIOL) {
 		lldbg("Instruction access violation occurred while fetching instruction from an Execute Never (XN) region.\n");
+		system_exception_location = regs[REG_R14];	/* The PC value might be invalid, so use LR */
 	} else if (cfsr & MSTKERR) {
 		lldbg("Error while stacking registers during exception entry.\n");
 	} else if (cfsr & MUNSTKERR) {

--- a/os/arch/arm/src/armv8-m/up_svcall.c
+++ b/os/arch/arm/src/armv8-m/up_svcall.c
@@ -98,9 +98,7 @@
 #define svcdbg(...)
 #endif
 
-#ifdef CONFIG_APP_BINARY_SEPARATION
-extern uint32_t g_assertpc;
-#endif
+uint32_t user_assert_location;
 #ifdef CONFIG_SUPPORT_COMMON_BINARY
 extern uint32_t *g_umm_app_id;
 #endif
@@ -194,9 +192,6 @@ int up_svcall(int irq, FAR void *context, FAR void *arg)
 	/* The SVCall software interrupt is called with R0 = system call command
 	 * and R1..R7 =  variable number of arguments depending on the system call.
 	 */
-#ifdef CONFIG_APP_BINARY_SEPARATION
-	g_assertpc = regs[REG_R14];
-#endif
 
 #if defined(CONFIG_DEBUG_SYSCALL) || defined(CONFIG_DEBUG_SVCALL)
 #ifndef CONFIG_DEBUG_SVCALL
@@ -544,6 +539,11 @@ int up_svcall(int irq, FAR void *context, FAR void *arg)
 		DEBUGASSERT(index < CONFIG_SYS_NNEST);
 		if (index >= CONFIG_SYS_NNEST) {
 			return INDEX_ERROR;
+		}
+
+		if (cmd == SYS_up_assert) {
+			/* get the user assert location from the LR value */
+			user_assert_location = regs[REG_R14];
 		}
 
 		/* Setup to return to dispatch_syscall in privileged mode. */

--- a/os/arch/arm/src/armv8-m/up_usagefault.c
+++ b/os/arch/arm/src/armv8-m/up_usagefault.c
@@ -44,6 +44,7 @@
 #include "nvic.h"
 #include "up_internal.h"
 
+extern uint32_t system_exception_location;
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
@@ -85,6 +86,8 @@ int up_usagefault(int irq, FAR void *context, FAR void *arg)
 	(void)irqsave();
 	uint32_t *regs = (uint32_t *)context;
 	uint32_t cfsr = getreg32(NVIC_CFAULTS);
+	system_exception_location = regs[REG_R15];
+
 	lldbg("PANIC!!! Usagefault occurred while executing instruction at address : 0x%08x\n", regs[REG_R15]);
 	lldbg("CFAULTS: 0x%08x\n", cfsr);
 
@@ -98,6 +101,9 @@ int up_usagefault(int irq, FAR void *context, FAR void *arg)
 		lldbg("A coprocessor error has occurred.\n");
 	} else if (cfsr & INVPC) {
 		lldbg("An integrity check error has occurred on EXC_RETURN. PC value might be invalid.\n");
+		/* As PC value might be invalid use LR value to determine if
+		 * the crash occured in the kernel space or in the user space */
+		system_exception_location = regs[REG_R14];
 	} else if (cfsr & INVSTATE) {
 		lldbg("Invalid state. Instruction executed with invalid EPSR.T or EPSR.IT field.\n");
 	} else if (cfsr & UNDEFINSTR) {

--- a/os/include/tinyara/mm/mm.h
+++ b/os/include/tinyara/mm/mm.h
@@ -226,11 +226,6 @@ typedef size_t mmsize_t;
 #define MMSIZE_MAX SIZE_MAX
 #endif
 
-/* typedef is used for defining size of address space */
-
-#ifdef CONFIG_DEBUG_MM_HEAPINFO
-typedef size_t mmaddress_t;		/* 32 bit address space */
-
 #if defined(CONFIG_ARCH_MIPS)
 /* Macro gets return address of malloc API. */
 #define ARCH_GET_RET_ADDRESS(caller_retaddr) \
@@ -253,6 +248,11 @@ typedef size_t mmaddress_t;		/* 32 bit address space */
 #else
 #error Unknown CONFIG_ARCH option, malloc debug feature wont work.
 #endif
+
+/* typedef is used for defining size of address space */
+
+#ifdef CONFIG_DEBUG_MM_HEAPINFO
+typedef size_t mmaddress_t;             /* 32 bit address space */
 
 #define SIZEOF_MM_MALLOC_DEBUG_INFO \
 	(sizeof(mmaddress_t) + sizeof(pid_t) + sizeof(uint16_t))


### PR DESCRIPTION
During the faults and assert failure in app space, g_assert_location is set
to appropriate value to indicate the location of the crash and is used during
up_assert. In case of app SW assert, the crash location is obtained from
R14 of the interrupt context and in case of HW fault in app, it is obtained
from R15 of the interrupt context saved on the stack. In the case of kernel
asserts, we get the assert pc from the return address (current LR value) in
up_assert.

Moved ARCH_GET_RET_ADDRESS definition out of CONFIG_DEBUG_MM_HEAPINFO
as it is used in up_assert.

Signed-off-by: Abhishek Akkabathula <a.akkabathul@samsung.com>
