### PR TITLE
kernel/binary_manager: Add deinit functions for binary reloading

### DIFF
--- a/os/include/tinyara/binary_manager.h
+++ b/os/include/tinyara/binary_manager.h
@@ -262,6 +262,7 @@ typedef struct binmgr_getinfo_all_response_s binmgr_getinfo_all_response_t;
 void binary_manager_register_kpart(int part_num, int part_size);
 void binary_manager_register_bppart(int part_num, int part_size);
 void binary_manager_register_upart(char *name, int part_num, int part_size);
+void binary_manager_deinit_modules(void);
 
 #ifdef __cplusplus
 #define EXTERN extern "C"

--- a/os/kernel/binary_manager/Make.defs
+++ b/os/kernel/binary_manager/Make.defs
@@ -24,7 +24,7 @@ CSRCS += binary_manager.c binary_manager_getinfo.c binary_manager_response.c
 CSRCS += binary_manager_data.c binary_manager_bootparam.c
 
 ifeq ($(CONFIG_APP_BINARY_SEPARATION),y)
-CSRCS += binary_manager_load.c binary_manager_callback.c
+CSRCS += binary_manager_load.c binary_manager_callback.c binary_manager_deinit.c
 ifeq ($(CONFIG_BINMGR_RECOVERY),y)
 CSRCS += binary_manager_recovery.c
 endif # CONFIG_BINMGR_RECOVERY

--- a/os/kernel/binary_manager/binary_manager_deinit.c
+++ b/os/kernel/binary_manager/binary_manager_deinit.c
@@ -1,0 +1,35 @@
+/****************************************************************************
+ *
+ * Copyright 2021 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+/*********************************************************************************************
+ * Name: binary_manager_deinit_modules
+ *
+ * Description:
+ *  This function calls deinit functions of modules which need to clear or reset used resources like device state
+ *  before loading again after binary unloading (i.e. network modules like LWIP)
+ *
+ *********************************************************************************************/
+void binary_manager_deinit_modules(void)
+{
+	/* Put calling deinit functions here */
+}

--- a/os/kernel/binary_manager/binary_manager_load.c
+++ b/os/kernel/binary_manager/binary_manager_load.c
@@ -393,44 +393,6 @@ static int binary_manager_terminate_binary(int bin_idx)
 	return OK;
 }
 
-#ifdef CONFIG_BINMGR_RECOVERY
-/****************************************************************************
- * Name: binary_manager_reload
- *
- * Description:
- *   This function will terminate all the task/thread created by the binary
- *   i.e input binary id.
- *   It is called after all children are excluded from scheduling by fault recovery.
- *   It terminates its children, unloads binary and then it will load the binary.
- *
- * Input parameters:
- *   binid   -   The pid of binary to be reload
- *
- * Returned Value:
- *   None
- *
- ****************************************************************************/
-static int binary_manager_reload(int bin_idx)
-{
-	int ret;
-
-	/* Terminate binary */
-	ret = binary_manager_terminate_binary(bin_idx);
-	if (ret != OK) {
-		bmdbg("Failed to terminate binary %s\n", BIN_NAME(bin_idx));
-		return BINMGR_OPERATION_FAIL;
-	}
-
-	/* Load binary */
-	ret = binary_manager_execute_loader(LOADCMD_LOAD, bin_idx);
-	if (ret != OK) {
-		bmdbg("Failed to load binary, bin_idx %d\n", bin_idx);
-		return BINMGR_OPERATION_FAIL;
-	}
-	return BINMGR_OK;
-}
-#endif
-
 /****************************************************************************
  * Name: loading_thread
  *
@@ -512,18 +474,26 @@ static int loadingall_thread(int argc, char *argv[])
  * Name: reloading_thread
  *
  * Description:
- *   This thread reloads binary with binary index.
+ *   This function terminates all the task/thread created by the binary.
+ *   If common binary is enabled, it terminates all user binaries and common binary.
+ *   Otherwise, it terminates a faulty binary only.
+ *   It is called after all children are excluded from scheduling by fault recovery.
+ *   It terminates all children of binary, unloads binary and then it will load the binary.
  *
  ****************************************************************************/
 static int reloading_thread(int argc, char *argv[])
 {
+	int ret;
+	int load_cmd;
+
 	if (argc <= 1) {
 		bmdbg("Invalid arguments for reloading, argc %d\n", argc);
 		return ERROR;
 	}
 
+	/* argv[1] binary index for reloading */
+	int bin_idx = (int)atoi(argv[1]);
 #ifdef CONFIG_SUPPORT_COMMON_BINARY
-	int ret;
 	int bidx;
 	int bin_count = binary_manager_get_ucount();
 
@@ -533,9 +503,10 @@ static int reloading_thread(int argc, char *argv[])
 	 * So the common binary should be unloaded after termination of all user binaries
 	 * to clear used resources normally.
 	 */
+	load_cmd = LOADCMD_LOAD_ALL;
 
-	/* 1. Unload all user binaries */
-	for (bidx = 1; bidx <= bin_count; bidx++) {
+	/* Unload all user binaries and common binary */
+	for (bidx = 0; bidx <= bin_count; bidx++) {
 		ret = binary_manager_terminate_binary(bidx);
 		if (ret != OK) {
 			bmdbg("Failed to terminate binary %s\n", BIN_NAME(bidx));
@@ -543,28 +514,25 @@ static int reloading_thread(int argc, char *argv[])
 		}
 		bmdbg("Terminate binary %d\n", bidx);
 	}
+#else
+	load_cmd = LOADCMD_LOAD;
 
-	/* 2. Unload common binary */
-	ret = binary_manager_terminate_binary(BM_CMNLIB_IDX);
+	/* Unload the faulty binary */
+	ret = binary_manager_terminate_binary(bin_idx);
 	if (ret != OK) {
-		bmdbg("Failed to terminate common binary\n");
+		bmdbg("Failed to terminate binary %s\n", BIN_NAME(bin_idx));
 		return BINMGR_OPERATION_FAIL;
 	}
+#endif
 
-	/* 3. Load all binaries */
-	ret = binary_manager_execute_loader(LOADCMD_LOAD_ALL, 0);
+	/* Create a loader to reload binary */
+	ret = binary_manager_execute_loader(load_cmd, bin_idx);
 	if (ret != OK) {
-		bmdbg("Failed to execute loader to load all binaries\n");
+		bmdbg("Failed to execute loader to reload binary, %d\n", ret);
 		return BINMGR_OPERATION_FAIL;
 	}
 
 	return BINMGR_OK;
-#else
-	/* argv[1] binary index for reloading */
-	int bin_idx = (int)atoi(argv[1]);
-
-	return binary_manager_reload(bin_idx);
-#endif
 }
 #endif
 

--- a/os/kernel/binary_manager/binary_manager_load.c
+++ b/os/kernel/binary_manager/binary_manager_load.c
@@ -525,6 +525,9 @@ static int reloading_thread(int argc, char *argv[])
 	}
 #endif
 
+	/* Deinitialize modules in kernel */
+	binary_manager_deinit_modules();
+
 	/* Create a loader to reload binary */
 	ret = binary_manager_execute_loader(load_cmd, bin_idx);
 	if (ret != OK) {
@@ -594,6 +597,9 @@ static int update_thread(int argc, char *argv[])
 		return BINMGR_OPERATION_FAIL;
 	}
 #endif
+
+	/* Deinitialize modules in kernel */
+	binary_manager_deinit_modules();
 
 	/* Update boot parameter data */
 	binary_manager_set_bpidx(bp_info.inuse_idx);


### PR DESCRIPTION
Add binary_manager_deinit_modules function to call deinit functions of modules which need to clear or reset used resources like device state before loading again after binary unloading (i.e. network modules like LWIP)