### PR TITLE
Resolve build issue in config: security_hal_test_tz

### DIFF
--- a/apps/examples/security_test/seclink/sl_auth_test.c
+++ b/apps/examples/security_test/seclink/sl_auth_test.c
@@ -86,7 +86,7 @@ static hal_data g_rand = HAL_DATA_INITIALIZER;
 static hal_data g_cert_in = HAL_DATA_INITIALIZER;
 static hal_data g_cert_out = HAL_DATA_INITIALIZER;
 
-ST_SET_PACK(sl_auth);
+ST_SET_PACK_GLOBAL(sl_auth);
 
 START_TEST_F(gen_random)
 {

--- a/apps/examples/security_test/seclink/sl_crypto_test.c
+++ b/apps/examples/security_test/seclink/sl_crypto_test.c
@@ -27,7 +27,7 @@
 #include "sl_test.h"
 #include "sl_test_usage.h"
 
-ST_SET_PACK(sl_crypto);
+ST_SET_PACK_GLOBAL(sl_crypto);
 
 static char *g_command[] = {
 #ifdef SL_CRYPTO_TEST_POOL

--- a/apps/examples/security_test/seclink/sl_key_test.c
+++ b/apps/examples/security_test/seclink/sl_key_test.c
@@ -74,7 +74,7 @@ static hal_data g_ecc_pubkey_in = HAL_DATA_INITIALIZER;
 static hal_data g_ecc_prikey_in = HAL_DATA_INITIALIZER;
 static hal_data g_key_out = HAL_DATA_INITIALIZER;
 
-ST_SET_PACK(sl_key);
+ST_SET_PACK_GLOBAL(sl_key);
 
 TESTCASE_SETUP(sl_key_global)
 {

--- a/apps/examples/security_test/seclink/sl_mbed_test.c
+++ b/apps/examples/security_test/seclink/sl_mbed_test.c
@@ -60,7 +60,7 @@ typedef enum {
 	SL_MBED_TYPE_ERR = -1
 } sl_mbed_type_e;
 
-ST_SET_PACK(sl_mbed);
+ST_SET_PACK_GLOBAL(sl_mbed);
 /*
  * AES test vectors from:
  *

--- a/apps/examples/security_test/seclink/sl_ss_test.c
+++ b/apps/examples/security_test/seclink/sl_ss_test.c
@@ -72,7 +72,7 @@ static unsigned char *g_ss_data[SL_TEST_MAX_SLOT_INDEX] = {
 	NULL,
 };
 
-ST_SET_PACK(sl_ss);
+ST_SET_PACK_GLOBAL(sl_ss);
 
 /*
  * Desc: Write data in secure storage

--- a/external/include/stress_tool/st_perf.h
+++ b/external/include/stress_tool/st_perf.h
@@ -180,6 +180,7 @@ void perf_set_keeprunning(int enable);
 /*
  * Expect?
  */
+
 #define ST_EXPECT_EQ(val, exp)                                          \
 	do {                                                                \
 		if (exp != val) {                                               \
@@ -261,6 +262,13 @@ void perf_set_keeprunning(int enable);
 /*
  * Testcase definitions
  */
+
+/*
+ * Description: Define testsuite & do not set global configuration
+ */
+#define ST_SET_PACK_GLOBAL(testsuite)         \
+	static st_pack g_pack_##testsuite;
+
 /*
  * Description: Define testsuite
  */


### PR DESCRIPTION
Issue: security_test/seclink files use ST_SET_PACK in global scope.
perf_add_global function call fails at that scope.

Change: Add an alternate ST_SET_PACK_GLOBAL and use in seclink files.