### PR TITLE
kernel/binary_manager: Return all results for requested binaries from binary_manager_set_bootparam

### DIFF
--- a/framework/include/binary_manager/binary_manager.h
+++ b/framework/include/binary_manager/binary_manager.h
@@ -135,7 +135,7 @@ binmgr_result_type_e binary_manager_get_state(char *binary_name, int *state);
  *         0 (BINMGR_OK) on success. On failure, negative value is returned.
  * @since TizenRT v3.1 PRE
  */
-binmgr_result_type_e binary_manager_set_bootparam(uint8_t type);
+binmgr_result_type_e binary_manager_set_bootparam(uint8_t type, binary_setbp_result_t *update_result);
 
 #endif
 /**

--- a/framework/src/binary_manager/binary_manager_update.c
+++ b/framework/src/binary_manager/binary_manager_update.c
@@ -41,9 +41,12 @@ binmgr_result_type_e binary_manager_set_bootparam(uint8_t type, binary_setbp_res
 		return BINMGR_INVALID_PARAM;
 	}
 
-	if (!BM_CHECK_GROUP(type, BINARY_KERNEL) && !BM_CHECK_GROUP(type, BINARY_USERAPP)
+	if (!BM_CHECK_GROUP(type, BINARY_KERNEL)
+#ifdef CONFIG_APP_BINARY_SEPARATION
+	&& !BM_CHECK_GROUP(type, BINARY_USERAPP)
 #ifdef CONFIG_SUPPORT_COMMON_BINARY
 	&& !BM_CHECK_GROUP(type, BINARY_COMMON)
+#endif
 #endif
 	) {
 		bmdbg("Invalid parameter %u\n", type);

--- a/loadable_apps/loadable_sample/wifiapp/binary_update.c
+++ b/loadable_apps/loadable_sample/wifiapp/binary_update.c
@@ -317,6 +317,7 @@ static int binary_update_same_version_test(void)
 {
 	int ret;
 	uint8_t type = 0;
+	binary_setbp_result_t result;
 	binary_update_info_t pre_bin_info;
 	binary_update_info_t cur_bin_info;
 
@@ -336,8 +337,14 @@ static int binary_update_same_version_test(void)
 	sleep(2);
 
 	BM_SET_GROUP(type, BINARY_USERAPP);
-	ret = binary_manager_set_bootparam(type);
+	ret = binary_manager_set_bootparam(type, &result);
 	if (ret != OK) {
+		if (ret == BINMGR_ALREADY_UPDATED) {
+			int idx;
+			for (idx = 0; idx < BINARY_TYPE_MAX; idx++) {
+				printf("[%d] result %d\n", idx, result.result[idx]);
+			}
+		}
 		return ret;
 	}
 
@@ -359,6 +366,7 @@ static int binary_update_new_version_test(char *bin_name)
 	int ret;
 	uint8_t type = 0;
 	char path[BINARY_PATH_LEN];
+	binary_setbp_result_t result;
 	binary_update_info_t pre_bin_info;
 	binary_update_info_t cur_bin_info;
 
@@ -383,8 +391,15 @@ static int binary_update_new_version_test(char *bin_name)
 	}
 
 	BM_SET_GROUP(type, BINARY_USERAPP);
-	ret = binary_manager_set_bootparam(type);
+	ret = binary_manager_set_bootparam(type, &result);
+	printf("binary_manager_set_bootparam %d\n", ret);
 	if (ret != OK) {
+		if (ret == BINMGR_ALREADY_UPDATED) {
+			int idx;
+			for (idx = 0; idx < BINARY_TYPE_MAX; idx++) {
+				printf("[%d] result %d\n", idx, result.result[idx]);
+			}
+		}
 		return ret;
 	}
 

--- a/os/include/tinyara/binary_manager.h
+++ b/os/include/tinyara/binary_manager.h
@@ -67,12 +67,12 @@
 /* The lenght of user or kernel partition path */
 #define BINARY_PATH_LEN                  16
 
-/* Binary Type */
+/* Binary Type : Kernel, Common, User app */
 enum binary_type_e {
-	BINARY_KERNEL = 1,
-	BINARY_COMMON = 2,
-	BINARY_USERAPP = 3,
-	BINARY_TYPE_MAX,
+	BINARY_KERNEL = 0,
+	BINARY_COMMON = 1,
+	BINARY_USERAPP = 2,
+	BINARY_TYPE_MAX = 3,
 };
 
 /* Macros for binary grouping used for request to set bootparam */
@@ -165,6 +165,12 @@ struct common_binary_header_s {
 typedef struct common_binary_header_s common_binary_header_t;
 
 /* The structure of binary update information for kernel or user binaries */
+struct binary_setbp_result_s {
+	int result[BINARY_TYPE_MAX];
+};
+typedef struct binary_setbp_result_s binary_setbp_result_t;
+
+/* The structure of binary update information for kernel or user binaries */
 struct binary_update_info_s {
 	int available_size;
 	char name[BIN_NAME_MAX];
@@ -223,6 +229,7 @@ typedef struct binmgr_request_s binmgr_request_t;
 
 struct binmgr_setbp_response_s {
 	binmgr_result_type_e result;
+	binary_setbp_result_t data;
 };
 typedef struct binmgr_setbp_response_s binmgr_setbp_response_t;
 

--- a/os/kernel/Kconfig
+++ b/os/kernel/Kconfig
@@ -966,7 +966,6 @@ config IDLETHREAD_STACKSIZE
 config USERMAIN_STACKSIZE
 	int "Main thread stack size"
 	default 2048
-	depends on !BINARY_MANAGER
 	---help---
 		The size of the stack to allocate for the user initialization thread
 		that is started as soon as the OS completes its initialization.

--- a/os/kernel/binary_manager/Make.defs
+++ b/os/kernel/binary_manager/Make.defs
@@ -21,7 +21,7 @@
 ifeq ($(CONFIG_BINARY_MANAGER),y)
 
 CSRCS += binary_manager.c binary_manager_getinfo.c binary_manager_response.c
-CSRCS += binary_manager_data.c binary_manager_bootparam.c
+CSRCS += binary_manager_data.c binary_manager_bootparam.c binary_manager_verify.c
 
 ifeq ($(CONFIG_APP_BINARY_SEPARATION),y)
 CSRCS += binary_manager_load.c binary_manager_callback.c binary_manager_deinit.c

--- a/os/kernel/binary_manager/binary_manager.h
+++ b/os/kernel/binary_manager/binary_manager.h
@@ -280,6 +280,8 @@ int binary_manager_scan_bootparam(binmgr_bpinfo_t *bp_info);
 binmgr_bpdata_t *binary_manager_get_bpdata(void);
 int binary_manager_get_inactive_path(int requester_pid, char *bin_name);
 void binary_manager_update_bootparam(int requester_pid, uint8_t type);
+void binary_manager_reset_board(int reboot_reason);
+int binary_manager_update_kernel_binary(void);
 
 /****************************************************************************
  * Binary Manager Main Thread

--- a/os/kernel/binary_manager/binary_manager_bootparam.c
+++ b/os/kernel/binary_manager/binary_manager_bootparam.c
@@ -253,13 +253,15 @@ errout_with_fd:
 void binary_manager_update_bootparam(int requester_pid, uint8_t type)
 {
 	int ret;
-	int bin_idx;
-	bool need_update;
 	bool is_all_updatable;
-	uint32_t bin_count;
 	char q_name[BIN_PRIVMQ_LEN];
 	binmgr_bpdata_t update_bp_data;
 	binmgr_setbp_response_t response_msg;
+#ifdef CONFIG_APP_BINARY_SEPARATION
+	int bin_idx;
+	bool need_update;
+	uint32_t bin_count;
+#endif
 
 	memset((void *)&response_msg, 0, sizeof(binmgr_setbp_response_t));
 
@@ -291,6 +293,7 @@ void binary_manager_update_bootparam(int requester_pid, uint8_t type)
 		}
 	}
 
+#ifdef CONFIG_APP_BINARY_SEPARATION
 	need_update = false;
 
 	if (BM_CHECK_GROUP(type, BINARY_USERAPP)) {
@@ -332,6 +335,7 @@ void binary_manager_update_bootparam(int requester_pid, uint8_t type)
 			goto send_response;
 		}
 	}
+#endif
 #endif
 
 	if (is_all_updatable) {

--- a/os/kernel/binary_manager/binary_manager_getinfo.c
+++ b/os/kernel/binary_manager/binary_manager_getinfo.c
@@ -214,11 +214,11 @@ void binary_manager_get_info_all(int requester_pid)
 		response_msg.data.bin_info[result_idx].version = BIN_VER(bin_idx, BIN_USEIDX(bin_idx));
 		result_idx++;
 	}
-
+#endif
 	if (response_msg.result == BINMGR_OK) {
 		response_msg.data.bin_count = result_idx;
 	}
-#endif
+
 	binary_manager_send_response(q_name, &response_msg, sizeof(binmgr_getinfo_all_response_t));
 }
 

--- a/os/kernel/binary_manager/binary_manager_load.c
+++ b/os/kernel/binary_manager/binary_manager_load.c
@@ -716,11 +716,11 @@ int binary_manager_read_header(int type, char *devpath, void *header_data, bool 
 	uint32_t crc_bufsize;
 	int header_size = 0;
 
-	if (type < BINARY_KERNEL || type >= BINARY_TYPE_MAX || !header_data) {
+	if (type < BINARY_KERNEL || type >= BINARY_TYPE_COUNT || !header_data) {
 		bmdbg("Invalid parameter\n");
 		return BINMGR_INVALID_PARAM;
 	}
-	
+
 	if (type == BINARY_KERNEL) {
 		header_size = sizeof(kernel_binary_header_t);
 	} else if (type == BINARY_USERAPP) {

--- a/os/kernel/binary_manager/binary_manager_verify.c
+++ b/os/kernel/binary_manager/binary_manager_verify.c
@@ -1,0 +1,200 @@
+/****************************************************************************
+ *
+ * Copyright 2021 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+#include <tinyara/config.h>
+#include <debug.h>
+#include <fcntl.h>
+#include <crc32.h>
+#include <stdlib.h>
+#include <errno.h>
+
+#include <tinyara/mm/mm.h>
+#include <tinyara/binary_manager.h>
+
+#include "binary_manager/binary_manager.h"
+
+/****************************************************************************
+ * Private Definitions
+ ****************************************************************************/
+/* The buffer size for checking crc of common library */
+#define CMNLIB_CRC_BUFSIZE    512000
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+/*********************************************************************************************
+ * Name: binary_manager_verify_header_data
+ *
+ * Description:
+ *  This function verifies header value according to type.
+ *
+ *********************************************************************************************/
+static int binary_manager_verify_header_data(int type, void *header_input)
+{
+	/* Verify header data */
+	if (type == BINARY_KERNEL) {
+		kernel_binary_header_t *header_data = (kernel_binary_header_t *)header_input;
+		if (header_data->header_size == 0 || header_data->binary_size == 0 \
+		|| header_data->version < KERNEL_BIN_VER_MIN || header_data->version > KERNEL_BIN_VER_MAX) {
+			bmdbg("Invalid kernel header data : headersize %u, version %u, binary size %u\n", header_data->header_size, header_data->version, header_data->binary_size);
+			return ERROR;
+		}		
+		bmvdbg("Kernel binary header : %u %u %u %u \n", header_data->header_size, header_data->binary_size, header_data->version, header_data->secure_header_size);
+	} else if (type == BINARY_USERAPP) {
+		user_binary_header_t *header_data = (user_binary_header_t *)header_input;
+		if (header_data->bin_type != BIN_TYPE_ELF || header_data->bin_ver == 0 \
+		|| header_data->loading_priority == 0 || header_data->loading_priority >= BINARY_LOADPRIO_MAX \
+		|| header_data->bin_ramsize == 0 || header_data->bin_size == 0) {
+			bmdbg("Invalid user header data : headersize %u, binsize %u, ramsize %u, bintype %u\n", header_data->header_size, header_data->bin_size, header_data->bin_ramsize, header_data->bin_type);
+			return ERROR;
+		}		
+		bmvdbg("User binary header : %u %u %u %u %s %u %u %u\n", header_data->header_size, header_data->bin_type, header_data->bin_size, header_data->loading_priority, header_data->bin_name, header_data->bin_ver, header_data->bin_ramsize, header_data->kernel_ver);
+	} else {
+		/* Verify header data */
+		common_binary_header_t *header_data = (common_binary_header_t *)header_input;
+		if (header_data->header_size == 0 || header_data->bin_size == 0 ||\
+			header_data->version < BM_VERSION_DATE_MIN || header_data->version > BM_VERSION_DATE_MAX) {
+			bmdbg("Invalid common header data : headersize %u, binsize %u, version %u\n", header_data->header_size, header_data->bin_size, header_data->version);
+			return ERROR;
+		}
+		bmvdbg("Common binary header : headersize %u, binsize %u, version %u\n", header_data->header_size, header_data->bin_size, header_data->version);
+	}
+
+	return OK;
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+/*****************************************************************************
+ * Name: binary_manager_read_header
+ *
+ * Description:
+ *  This function reads and verifies header value with CRC checking according to type.
+ *
+ *****************************************************************************/
+int binary_manager_read_header(int type, char *devpath, void *header_data, bool crc_check)
+{
+	int fd;
+	int ret;
+	uint32_t read_size;
+	uint32_t bin_size;
+	uint32_t calculate_crc = 0;
+	uint8_t *crc_buffer;
+	uint32_t crc_hash;
+	uint32_t crc_bufsize;
+	int header_size = 0;
+
+	if (type < BINARY_KERNEL || type >= BINARY_TYPE_MAX || !header_data) {
+		bmdbg("Invalid parameter\n");
+		return BINMGR_INVALID_PARAM;
+	}
+	
+	if (type == BINARY_KERNEL) {
+		header_size = sizeof(kernel_binary_header_t);
+	} else if (type == BINARY_USERAPP) {
+		header_size = sizeof(user_binary_header_t);
+	} else if (type == BINARY_COMMON) {
+		header_size = sizeof(common_binary_header_t);
+	}
+
+	memset(header_data, 0, header_size);
+	crc_buffer = NULL;
+
+	fd = open(devpath, O_RDONLY);
+	if (fd < 0) {
+		bmdbg("Failed to open %s: %d, errno %d\n", devpath, ret, errno);
+		return BINMGR_OPERATION_FAIL;
+	}
+
+	/* Read the binary header */
+	ret = read(fd, (FAR uint8_t *)header_data, header_size);
+	if (ret != header_size) {
+		bmdbg("Failed to read %s: %d, errno %d\n", devpath, ret, errno);
+		ret = BINMGR_OPERATION_FAIL;
+		goto errout_with_fd;
+	}
+
+	/* Verify header data */
+	ret = binary_manager_verify_header_data(type, header_data);
+	if (ret < 0) {
+		ret = BINMGR_NOT_FOUND;
+		goto errout_with_fd;
+	}
+
+	if (crc_check) {
+		if (type == BINARY_KERNEL) {
+			crc_bufsize = ((kernel_binary_header_t *)header_data)->binary_size;
+			bin_size = ((kernel_binary_header_t *)header_data)->binary_size;
+			crc_hash = ((kernel_binary_header_t *)header_data)->crc_hash;
+		} else if (type == BINARY_USERAPP) {
+			crc_bufsize = ((user_binary_header_t *)header_data)->bin_ramsize;
+			bin_size = ((user_binary_header_t *)header_data)->bin_size;
+			crc_hash = ((user_binary_header_t *)header_data)->crc_hash;
+		} else if (type == BINARY_COMMON) {
+			crc_bufsize = CMNLIB_CRC_BUFSIZE;
+			bin_size = ((common_binary_header_t *)header_data)->bin_size;
+			crc_hash = ((common_binary_header_t *)header_data)->crc_hash;
+		}
+		struct mallinfo mem;
+#ifdef CONFIG_CAN_PASS_STRUCTS
+		mem = kmm_mallinfo();
+#else
+		(void)kmm_mallinfo(&mem);
+#endif
+		crc_bufsize = crc_bufsize < (mem.mxordblk / 2) ? crc_bufsize : (mem.mxordblk / 2);
+		crc_buffer = (uint8_t *)kmm_malloc(crc_bufsize);
+		if (!crc_buffer) {
+			bmdbg("Failed to allocate buffer for checking crc, size %u\n", crc_bufsize);
+			ret = BINMGR_OUT_OF_MEMORY;
+			goto errout_with_fd;
+		}
+		/* Calculate checksum and Verify it */
+		calculate_crc = crc32part((uint8_t *)header_data + CHECKSUM_SIZE, header_size - CHECKSUM_SIZE, calculate_crc);
+		while (bin_size > 0) {
+			read_size = bin_size < crc_bufsize ? bin_size : crc_bufsize;
+			ret = read(fd, (void *)crc_buffer, read_size);
+			if (ret < 0 || ret != read_size) {
+				bmdbg("Failed to read : %d, errno %d\n", ret, errno);
+				ret = BINMGR_OPERATION_FAIL;
+				goto errout_with_fd;
+			}
+			calculate_crc = crc32part(crc_buffer, read_size, calculate_crc);
+			bin_size -= read_size;
+		}
+
+		if (calculate_crc != crc_hash) {
+			bmdbg("Failed to crc check : %u != %u\n", calculate_crc, crc_hash);
+			ret = BINMGR_NOT_FOUND;
+			goto errout_with_fd;
+		}
+		kmm_free(crc_buffer);
+	}
+	close(fd);
+
+	return BINMGR_OK;
+
+errout_with_fd:
+	close(fd);
+	if (crc_buffer) {
+		kmm_free(crc_buffer);
+	}
+	return ret;
+}

--- a/os/kernel/init/os_bringup.c
+++ b/os/kernel/init/os_bringup.c
@@ -315,7 +315,7 @@ static inline void os_do_appstart(void)
 	}
 #endif
 
-#if !defined(CONFIG_BINARY_MANAGER)
+#if !defined(CONFIG_APP_BINARY_SEPARATION)
 	/* Start the application initialization task.  In a flat build, this is
 	 * entrypoint is given by the definitions, CONFIG_USER_ENTRYPOINT.  In
 	 * the protected build, however, we must get the address of the
@@ -327,7 +327,7 @@ static inline void os_do_appstart(void)
 #if defined(CONFIG_USER_ENTRYPOINT)
 	pid = task_create("appmain", SCHED_PRIORITY_DEFAULT, CONFIG_USERMAIN_STACKSIZE, (main_t)CONFIG_USER_ENTRYPOINT, (FAR char *const *)NULL);
 #endif
-#endif // !CONFIG_BINARY_MANAGER
+#endif // !CONFIG_APP_BINARY_SEPARATION
 
 	ASSERT(pid > 0);
 }


### PR DESCRIPTION
The binary_manager_set_bootparam is called with binary group.
If one of them has no update, binary manager doesn't update bootparam and returns error.
For this case, return all results for requested group's binaries to know the reason of failure of bootparam update.