### PR TITLE
kernel/binary_manager: Add tcb to a binary thread list after task activation in pthread_create

### DIFF
--- a/os/kernel/pthread/pthread_create.c
+++ b/os/kernel/pthread/pthread_create.c
@@ -451,6 +451,11 @@ int pthread_create(FAR pthread_t *thread, FAR const pthread_attr_t *attr, pthrea
 
 	sched_lock();
 	if (ret == OK) {
+#if defined(CONFIG_BINARY_MANAGER) && defined(CONFIG_APP_BINARY_SEPARATION)
+		/* Add tcb to binary thread list */
+
+		binary_manager_add_binlist(&ptcb->cmn);
+#endif
 		ret = task_activate((FAR struct tcb_s *)ptcb);
 	}
 
@@ -470,11 +475,6 @@ int pthread_create(FAR pthread_t *thread, FAR const pthread_attr_t *attr, pthrea
 		if (!pjoin->started) {
 			ret = EINVAL;
 		}
-
-#if defined(CONFIG_BINARY_MANAGER) && defined(CONFIG_APP_BINARY_SEPARATION)
-		/* Add tcb to binary thread list */
-		binary_manager_add_binlist(&ptcb->cmn);
-#endif
 		sched_unlock();
 		(void)sem_destroy(&pjoin->data_sem);
 	} else {


### PR DESCRIPTION
If a caller thread is blocked by pthread_sem_take, binary_manager_remove_binlist is called first by executing the new created thread before adding the tcb to a list by binary_manager_add_binlist.
So it should be added to a binary thread list after task_activate directly before pthread_sem_take.