### PR TITLE
fixup! mm/*mm_heap : Return NULL if requested size is 0

### DIFF
--- a/os/mm/kmm_heap/kmm_realloc.c
+++ b/os/mm/kmm_heap/kmm_realloc.c
@@ -99,6 +99,7 @@ void *kmm_realloc_at(int heap_index, void *oldmem, size_t size)
 	}
 
 	if (size == 0) {
+		mm_free(&kheap[heap_index], oldmem);
 		return NULL;
 	}
 
@@ -142,8 +143,10 @@ FAR void *kmm_realloc(FAR void *oldmem, size_t newsize)
 	struct mm_heap_s *kheap_new;
 
 	if (newsize == 0) {
+		mm_free(kheap_origin, oldmem);
 		return NULL;
 	}
+
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
 	ret = mm_realloc(kheap_origin, oldmem, newsize, caller_retaddr);
 #else

--- a/os/mm/umm_heap/umm_realloc.c
+++ b/os/mm/umm_heap/umm_realloc.c
@@ -89,14 +89,17 @@ void *realloc_at(int heap_index, void *oldmem, size_t size)
 	void *ret;
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
 	size_t caller_retaddr = 0;
+
 	ARCH_GET_RET_ADDRESS(caller_retaddr)
 #endif
+
 	if (heap_index > HEAP_END_IDX || heap_index < HEAP_START_IDX) {
 		mdbg("realloc_at failed. Wrong heap index (%d) of (%d)\n", heap_index, HEAP_END_IDX);
 		return NULL;
 	}
 
 	if (size == 0) {
+		mm_free(&BASE_HEAP[heap_index], oldmem);
 		return NULL;
 	}
 
@@ -131,19 +134,24 @@ FAR void *realloc(FAR void *oldmem, size_t size)
 	int heap_idx;
 	int prev_heap_idx;
 	void *ret;
-
-	if (size == 0) {
-		return NULL;
-	}
-
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
 	size_t caller_retaddr = 0;
+
 	ARCH_GET_RET_ADDRESS(caller_retaddr)
 #endif
+
 	heap_idx = mm_get_heapindex(oldmem);
 	if (heap_idx < HEAP_START_IDX) {
 		return NULL;
 	}
+
+	if (size == 0) {
+		mm_free(&BASE_HEAP[heap_idx], oldmem);
+		return NULL;
+	}
+
+	/* Try to realloc in previous allocated heap */
+
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
 	ret = mm_realloc(&BASE_HEAP[heap_idx], oldmem, size, caller_retaddr);
 #else
@@ -152,8 +160,9 @@ FAR void *realloc(FAR void *oldmem, size_t size)
 	if (ret != NULL) {
 		return ret;
 	}
+
 	/* Try to mm_malloc to another heap */
-	mdbg("After realloc, memory can be allocated to another heap which is not as same as previous.\n");
+
 	prev_heap_idx = heap_idx;
 	for (heap_idx = HEAP_START_IDX; heap_idx <= HEAP_END_IDX; heap_idx++) {
 #ifdef CONFIG_DEBUG_MM_HEAPINFO


### PR DESCRIPTION
When realloc is executed with size 0, it should try to free previous
allocated memory. But commit fad7c48 returns NULL without freeing.
This commit fixes wrong modification of commit fad7c48.

Signed-off-by: sunghan-chang <sh924.chang@samsung.com>