### PR TITLE
kernel/binary_manager: Add only user threads to a thread list of binary

### DIFF
--- a/os/kernel/pthread/pthread_create.c
+++ b/os/kernel/pthread/pthread_create.c
@@ -453,8 +453,9 @@ int pthread_create(FAR pthread_t *thread, FAR const pthread_attr_t *attr, pthrea
 	if (ret == OK) {
 #if defined(CONFIG_BINARY_MANAGER) && defined(CONFIG_APP_BINARY_SEPARATION)
 		/* Add tcb to binary thread list */
-
-		binary_manager_add_binlist(&ptcb->cmn);
+		if ((ptcb->cmn.flags & TCB_FLAG_TTYPE_MASK) != TCB_FLAG_TTYPE_KERNEL) {
+			binary_manager_add_binlist(&ptcb->cmn);
+		}
 #endif
 		ret = task_activate((FAR struct tcb_s *)ptcb);
 	}

--- a/os/kernel/task/task_create.c
+++ b/os/kernel/task/task_create.c
@@ -219,10 +219,12 @@ static int thread_create(FAR const char *name, uint8_t ttype, int priority, int 
 	pid = (int)tcb->cmn.pid;
 
 #if defined(CONFIG_BINARY_MANAGER) && defined(CONFIG_APP_BINARY_SEPARATION)
-	FAR struct tcb_s *rtcb = this_task();
-	tcb->cmn.group->tg_binidx = rtcb->group->tg_binidx;
-	/* Add tcb to binary thread list */
-	binary_manager_add_binlist(&tcb->cmn);
+	if ((tcb->cmn.flags & TCB_FLAG_TTYPE_MASK) != TCB_FLAG_TTYPE_KERNEL) {
+		FAR struct tcb_s *rtcb = this_task();
+		tcb->cmn.group->tg_binidx = rtcb->group->tg_binidx;
+		/* Add tcb to binary thread list */
+		binary_manager_add_binlist(&tcb->cmn);
+	}
 #endif
 
 #ifdef CONFIG_HEAPINFO_USER_GROUP


### PR DESCRIPTION
Each binary's thread list is used for  binary reloading.
When binary reloading, binary manager terminates all user threads and loads user binary again.
So add only user threads to a thread list of binary in task_create and pthread_create.