### PR TITLE
arch/armv7-m, armv8-m: Print stack contents in out of range stack poi…

### DIFF
--- a/os/arch/arm/src/armv7-m/up_assert.c
+++ b/os/arch/arm/src/armv7-m/up_assert.c
@@ -364,6 +364,11 @@ static void up_dumpstate(void)
 
 	if (sp > ustackbase || sp <= ustackbase - ustacksize) {
 		lldbg("ERROR: Stack pointer is not within the allocated stack\n");
+		lldbg("Proper task stack dump:\n");
+		up_stackdump(ustackbase - ustacksize + 1, ustackbase);
+		lldbg("Wrong Stack pointer %08x: %08x %08x %08x %08x %08x %08x %08x %08x\n",
+		sp, *((uint32_t *)sp + 0), *((uint32_t *)sp + 1), *((uint32_t *)sp + 2), ((uint32_t *)sp + 3),
+		*((uint32_t *)sp + 4), ((uint32_t *)sp + 5), ((uint32_t *)sp + 6), ((uint32_t *)sp + 7));
 	} else {
 		up_stackdump(sp, ustackbase);
 	}

--- a/os/arch/arm/src/armv8-m/up_assert.c
+++ b/os/arch/arm/src/armv8-m/up_assert.c
@@ -375,6 +375,11 @@ static void up_dumpstate(void)
 
 	if (sp > ustackbase || sp <= ustackbase - ustacksize) {
 		lldbg("ERROR: Stack pointer is not within the allocated stack\n");
+		lldbg("Proper task stack dump:\n");
+		up_stackdump(ustackbase - ustacksize + 1, ustackbase);
+		lldbg("Wrong Stack pointer %08x: %08x %08x %08x %08x %08x %08x %08x %08x\n",
+		sp, *((uint32_t *)sp + 0), *((uint32_t *)sp + 1), *((uint32_t *)sp + 2), ((uint32_t *)sp + 3),
+		*((uint32_t *)sp + 4), ((uint32_t *)sp + 5), ((uint32_t *)sp + 6), ((uint32_t *)sp + 7));
 	} else {
 		up_stackdump(sp, ustackbase);
 	}


### PR DESCRIPTION
…nter case

Stack contents are not printed if sp is not within allocated stack memory range.
Printing process stack and current stack pointer helps in debugging.

Signed-off-by: sangamanatha <sangam.swami@samsung.com>