### PR TITLE
kernel/mqueue : Set errno when fail to get/allocate the msg

### DIFF
--- a/os/kernel/mqueue/mq_send.c
+++ b/os/kernel/mqueue/mq_send.c
@@ -128,6 +128,8 @@
  *   EMSGSIZE 'msglen' was greater than the maxmsgsize attribute of the
  *            message queue.
  *   EINTR    The call was interrupted by a signal handler.
+ *   EBUSY    Fail to get the msg from interrupt handler.
+ *   ENOMEM   Fail to allocate the msg from normal thread.
  *
  * Assumptions/restrictions:
  *

--- a/os/kernel/mqueue/mq_timedsend.c
+++ b/os/kernel/mqueue/mq_timedsend.c
@@ -192,7 +192,8 @@ static void mq_sndtimeout(int argc, uint32_t pid)
  *   EMSGSIZE 'msglen' was greater than the maxmsgsize attribute of the
  *            message queue.
  *   EINTR    The call was interrupted by a signal handler.
- *   ENOMEM    The system lacks sufficient memory resources for watchdog.
+ *   ENOMEM   The system lacks sufficient memory resources for watchdog.
+ *   EBUSY    Fail to get the msg from interrupt handler.
  *
  * Assumptions/restrictions:
  *


### PR DESCRIPTION
If fail to get the preallocated msg from interrupt handler, set errno as EBUSY.
If fail to allocat the msg from normal thread, set errno as ENOMEM.

Signed-off-by: jeongchanKim <jc_.kim@samsung.com>