### PR TITLE
tools/trap: Refactor TRAP tool

### DIFF
--- a/os/arch/arm/src/armv7-m/up_assert.c
+++ b/os/arch/arm/src/armv7-m/up_assert.c
@@ -147,10 +147,26 @@ extern uint32_t user_assert_location;
 #ifdef CONFIG_ARCH_STACKDUMP
 static void up_stackdump(uint32_t sp, uint32_t stack_base)
 {
-	uint32_t stack;
+	uint32_t stack = sp & ~0x1f;
+	uint32_t *ptr = (uint32_t *)stack;
+	uint8_t i;
 
-	for (stack = sp & ~0x1f; stack < stack_base; stack += 32) {
-		uint32_t *ptr = (uint32_t *)stack;
+	lldbg("%08x:", stack);
+	for (i = 0; i < 8; i++) {  // Print first 8 values for sp located
+		if (stack < sp) {
+			/* If stack pointer(sp) is aligned(sp & 0x1f) to an address outside allocated stack */
+			/* Then, for stack addresses outside allocated stack, print 'xxxxxxxx' */
+			lldbg_noarg(" xxxxxxxx");
+		} else {
+			/* For remaining stack addresses inside allocated stack, print proper stack address values */
+			lldbg_noarg(" %08x", ptr[i]);
+		}
+		stack += 4;
+	}
+	lldbg_noarg("\n");
+
+	for (; stack < stack_base; stack += 32) { // Print remaining stack values from 9th value to end
+		ptr = (uint32_t *)stack;
 		lldbg("%08x: %08x %08x %08x %08x %08x %08x %08x %08x\n",
 			   stack, ptr[0], ptr[1], ptr[2], ptr[3], ptr[4], ptr[5], ptr[6], ptr[7]);
 	}

--- a/os/arch/arm/src/armv8-m/up_assert.c
+++ b/os/arch/arm/src/armv8-m/up_assert.c
@@ -157,10 +157,26 @@ extern uint32_t user_assert_location;
 #ifdef CONFIG_ARCH_STACKDUMP
 static void up_stackdump(uint32_t sp, uint32_t stack_base)
 {
-	uint32_t stack;
+	uint32_t stack = sp & ~0x1f;
+	uint32_t *ptr = (uint32_t *)stack;
+	uint8_t i;
 
-	for (stack = sp & ~0x1f; stack < stack_base; stack += 32) {
-		uint32_t *ptr = (uint32_t *)stack;
+	lldbg("%08x:", stack);
+	for (i = 0; i < 8; i++) {  // Print first 8 values for sp located
+		if (stack < sp) {
+			/* If stack pointer(sp) is aligned(sp & 0x1f) to an address outside allocated stack */
+			/* Then, for stack addresses outside allocated stack, print 'xxxxxxxx' */
+			lldbg_noarg(" xxxxxxxx");
+		} else {
+			/* For remaining stack addresses inside allocated stack, print proper stack address values */
+			lldbg_noarg(" %08x", ptr[i]);
+		}
+		stack += 4;
+	}
+	lldbg_noarg("\n");
+
+	for (; stack < stack_base; stack += 32) { // Print remaining stack values from 9th value to end
+		ptr = (uint32_t *)stack;
 		lldbg("%08x: %08x %08x %08x %08x %08x %08x %08x %08x\n",
 			   stack, ptr[0], ptr[1], ptr[2], ptr[3], ptr[4], ptr[5], ptr[6], ptr[7]);
 	}

--- a/tools/debug/debugsymbolviewer.py
+++ b/tools/debug/debugsymbolviewer.py
@@ -18,47 +18,85 @@
 
 from __future__ import print_function
 from math import log
+from array import *
+import os
 import re
 import sys
 
 bin_path = '../../build/output/bin/'	# Output bin path
-symbol_lookup_table = []		# Lookup table created from contents of system map file
+ksymbol_lookup_table = []		# Lookup table created from contents of system map file for kernel symbols
+asymbol_lookup_table = [[]] * 10	# Lookup table created from contents of appX map files for application symbols
 debug = False				# Variable to print debug logs
 pc_value = 0x00000000			# Program counter value
+format_print = True
 
 # Kernel text start & end addresses
 ram_text_start_addr = 0x00000000
 ram_text_end_addr = 0x00000000
 flash_text_start_addr = 0x00000000
 flash_text_end_addr = 0x00000000
+g_stext_app = [0] * 10
+g_etext_app = [0] * 10
+app_name = []
 
 def bytes_needed(n):
     if n == 0:
         return 1
     return int(log(n, 256)) + 1
 
-# Function to setup the Address to Symbol mapping table from the System Map file
-def setup_symbol_table(sm_file):
+# Function to get the application binary names, text address and sizes
+def find_app_text_range(log_file):
+	global g_stext_app
+	global g_etext_app
+	g_stext_app = array('i', range(0, app_idx))
+	g_etext_app = array('i', range(0, app_idx))
+
+	idx = 0
+	with open(log_file) as searchfile:
+		for line in searchfile:
+			# Read the app text address and size
+			if 'elf_show_all_bin_addr:' in line:
+				word = line.split(':')
+				t = word[2].split(',') # word[2] is the App Start Text address
+				w = word[1].split(' ')
+				# w[1] denotes string '[<app_name>]'
+				start_idx = int(w[1].find('[')) + 1
+				end_idx = int(w[1].find(']'))
+				app_name.append(w[1][start_idx:end_idx])
+				g_stext_app[idx] = int(t[0], 16)
+				g_etext_app[idx] = g_stext_app[idx] + int(word[3], 10) # word[3] is text_size
+				idx = idx + 1
+
+	if debug:
+		# Printing the kernel text address ranges in ram and flash areas
+		for idx in range(app_idx):
+			print('~~~~~~~~~~~~~~~~~~~ APPLICATION TEXT ADDRESS RANGE ~~~~~~~~~~~~~~~~~~~~')
+			print('g_stext_app[{}]\t=\t{:8}'.format(idx, hex(g_stext_app[idx])))
+			print('g_etext_app[{}]\t=\t{:8}'.format(idx, hex(g_etext_app[idx])))
+		print('~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~')
+		print('')
+
+# Function to setup the kernel text addresses 
+def find_kernel_text_range(log_file):
 	global flash_text_start_addr
 	global flash_text_end_addr
 	global ram_text_start_addr
 	global ram_text_end_addr
 	is_ram_text = False
+
 	# Reading the System Map file and preparing the symbol map table
-	with open(sm_file) as searchfile:
+	with open(log_file) as searchfile:
 		for line in searchfile:
 			s = line.split(' ', 2)
 			if len(s) == 3:
 				if not '$' in s[2]:
 					# s[0] contains address and s[2] contains Symbol name
-					symbol_lookup_table.append((int(s[0], 16), s[2].rstrip()))
-
 					# Extract kernel text start & end addresses from the table
 					symbol = s[2].rstrip('\n')
 					if symbol == '_stext_flash':
-						flash_text_start_addr = hex(int(s[0], 16) + int(offset,16))
+						flash_text_start_addr = hex(int(s[0], 16))
 					if symbol == '_etext_flash':
-						flash_text_end_addr= hex(int(s[0], 16) + int(offset,16))
+						flash_text_end_addr= hex(int(s[0], 16))
 					if symbol == '_stext_ram':
 						is_ram_text = True
 						ram_text_start_addr = hex(int(s[0], 16))
@@ -66,14 +104,8 @@ def setup_symbol_table(sm_file):
 						ram_text_end_addr = hex(int(s[0], 16))
 
 	if debug:
-		# Printing the Created Symbol table
-		print('\n~~~~~~~~~~~~~~~~~~~~~~~~ SYMBOL TABLE START ~~~~~~~~~~~~~~~~~~~~~')
-		for line in symbol_lookup_table:
-			print("{0:x} {1}".format(line[0], line[1]))
-		print('~~~~~~~~~~~~~~~~~~~~~~~~SYMBOL TABLE END   ~~~~~~~~~~~~~~~~~~~~~')
-
 		# Printing the kernel text address ranges in ram and flash areas
-		print('~~~~~~~~~~~~~~~~~~~~~~~~~~  TEXT ADDRESS RANGE ~~~~~~~~~~~~~~~~~~~~~~~')
+		print('~~~~~~~~~~~~~~~~~~~~~ KERNEL TEXT ADDRESS RANGE ~~~~~~~~~~~~~~~~~~~~~~')
 		print('flash_text_start_addr\t=\t', flash_text_start_addr)
 		print('flash_text_end_addr\t=\t', flash_text_end_addr)
 		if (is_ram_text):
@@ -82,21 +114,57 @@ def setup_symbol_table(sm_file):
 		print('~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~')
 		print('')
 
+# Function to setup Address to Symbol mapping table from the System Map and appX map files for kernel and applications
+def setup_symbol_table(map_file, is_app):
+	if debug:
+		print('setup_symbol_table : '+ map_file, is_app)
+	# Reading the System Map file and preparing the symbol map table
+	with open(map_file) as searchfile:
+		for line in searchfile:
+			s = line.split(' ', 2)
+			if len(s) == 3:
+				if not '$' in s[2]:
+					# s[0] contains address and s[2] contains Symbol name
+					if(is_app):
+						asymbol_lookup_table[is_app].append((int(s[0], 16), s[2].rstrip()))
+					else:
+						ksymbol_lookup_table.append((int(s[0], 16), s[2].rstrip()))
+	if debug:
+		# Printing the Created Symbol table
+		print('\n~~~~~~~~~~~~~~~~~~~~~~~~ SYMBOL TABLE START ~~~~~~~~~~~~~~~~~~~~~')
+		if(is_app):
+			for line in asymbol_lookup_table[is_app]:
+				print("{0:x} {1}".format(line[0], line[1]))
+		else:
+			for line in ksymbol_lookup_table:
+				print("{0:x} {1}".format(line[0], line[1]))
+		print('~~~~~~~~~~~~~~~~~~~~~~~~SYMBOL TABLE END   ~~~~~~~~~~~~~~~~~~~~~')
 
-# Function to search the search_addr present in the System map file and print its corresponding symbol
-def print_symbol(search_addr):
+
+# Function to search the search_addr present in the Address to Symbol mapping table and print its corresponding symbol
+def print_symbol(stack_addr, search_addr, is_app_symbol):
 	addr = 0x00000000
 	next_addr = 0x00000000
 	l = 0
-	h = len(symbol_lookup_table) - 1
+	if (is_app_symbol):
+		h = len(asymbol_lookup_table[is_app_symbol]) - 1
+	else:
+		h = len(ksymbol_lookup_table) - 1
 	mid = (l + h) // 2
 
 	while (l <= h):
-		addr = symbol_lookup_table[mid - 1][0]
-		next_addr = symbol_lookup_table[mid][0]
+		if (is_app_symbol):
+			addr = asymbol_lookup_table[is_app_symbol][mid - 1][0]
+			next_addr = asymbol_lookup_table[is_app_symbol][mid][0]
+		else:
+			addr = ksymbol_lookup_table[mid - 1][0]
+			next_addr = ksymbol_lookup_table[mid][0]
 
 		if (search_addr >= addr and search_addr <= next_addr):
-			print("{0}\t {1} \t  {2}".format(hex(search_addr), hex(addr), symbol_lookup_table[mid - 1][1]))
+			if (is_app_symbol):
+				print("{:8}\t {:8}\t app{}    \t  {}".format(hex(stack_addr), hex(addr), is_app_symbol, asymbol_lookup_table[is_app_symbol][mid - 1][1]))
+			else:
+				print("{:8}\t {:8}\t kernel  \t  {}".format(hex(stack_addr), hex(addr), ksymbol_lookup_table[mid - 1][1]))
 			break
 
 		if (search_addr < addr):
@@ -111,78 +179,138 @@ def print_symbol(search_addr):
 			print('Symbol not found for address: {0} in map file'.format(hex(search_addr)))
 
 
-# Function to check if address lies in the kernel text address range
-def is_text_address(address):
+# Function to check if address lies in the applications' text address range
+def is_app_text_address(address):
+	idx = 0
+	# Check the application text address range
+	for idx in range(app_idx):
+		if (address >= hex(g_stext_app[idx]) and address < hex(g_etext_app[idx])):
+			return (idx + 1)
+	if (idx == app_idx):
+			return False
 
-	# Check the address
+# Function to check if address lies in the kernel text address range
+def is_kernel_text_address(address):
+
+	# Check the kernel text address range
 	if (address >= ram_text_start_addr and address < ram_text_end_addr) or (address >= flash_text_start_addr and address < flash_text_end_addr):
-		return True
+		return True 
 	else:
 		return False
 
 
-# Function to Parse the i/p log file (which contains stackdump during assert)
-def parse_file(log_file):
+# Function to Parse the i/p log file (which contains stackdump during assert) and to print stack values
+def print_stack(log_file):
 	stack_addr = 0x00000000
+	stack_val = 0x00000000
+	format_print = True
 	# Parse the contents based on tokens in log file.
 	with open(log_file) as searchfile:
 		for line in searchfile:
 			if 'up_registerdump:' in line:
 				word = line.split(':')
-
 				# word[1] contains the register name i.e R0 or R8
 				reg = word[1].split()
 
 				if reg[0] == 'R8':
 					t = word[2].split( )
-
 					# Check for corruption of PC value in logs
 					if (len(word[2].split( )) != 8):
 						print('\nAssert logs are corrupted, and we are not able to determine the value of PC.\n')
 						continue
-
-					# Last subword of word[2] contains the PC value
-					pc_value = int(t[-1],16)
-					print('\nPC_value\t Symbol_address\t  Symbol_name\tFile_name')
-					print_symbol(pc_value)
 				continue
 
 			# Read the stack contents of aborted stack and check for valid addresses
 			if 'up_stackdump:' in line:
 				word = line.split(':')
 				t = word[2].split( )
+				stack_addr = int(word[1], 16)
 				for sub_word in t:
+					stack_addr = stack_addr + 4
 					# Check for valid address, else move to the next sub_word
+					if (sub_word == 'xxxxxxxx'):
+						continue
 					if (bytes_needed(int(sub_word,16)) != 4):
 						continue
 
-					stack_addr = int(sub_word,16)
+					stack_val = int(sub_word,16)
 					# Check if the stack address lies in kernel text address range
-					if (is_text_address(hex(stack_addr))):
+					if (is_kernel_text_address(hex(stack_val))):
 						#If yes, print it's corresponding symbol
-                                                stack_addr = stack_addr - int(offset,16)
-                                                print_symbol(stack_addr)
+                                                print_symbol(stack_addr, stack_val, 0)
+					# Check if the stack address lies in application text address range
+					is_app_symbol = is_app_text_address(hex(stack_val))	# app index in case of application symbol
+					if (is_app_symbol):
+						#If yes, print it's corresponding symbol
+                                                stack_val = stack_val - int(g_stext_app[is_app_symbol - 1])
+                                                print_symbol(stack_addr, stack_val, is_app_symbol)
+
+# Function to Parse the i/p log file (which contains wrong stackdump during assert)
+def print_wrong_sp(log_file):
+	stack_addr = 0x00000000
+	format_print = True
+	# Parse the contents based on tokens in log file.
+	with open(log_file) as searchfile:
+		for line in searchfile:
+			# Read the stack contents of aborted stack and check for valid addresses
+			if 'Wrong Stack pointer' in line:
+				word = line.split(':')
+				t = word[2].split( )
+				s = word[1].split( )
+				stack_addr = int(s[-1], 16)
+				for sub_word in t:
+					stack_addr = stack_addr + 4
+					# Check for valid address, else move to the next sub_word
+					if (sub_word == 'xxxxxxxx'):
+						continue
+					if (bytes_needed(int(sub_word,16)) != 4):
+						continue
+
+					stack_val = int(sub_word,16)
+					# Check if the stack address lies in kernel text address range
+					if (is_kernel_text_address(hex(stack_val))):
+						if (format_print):
+							print('\t- SP is out of the stack range. Debug symbols corresponding to the wrong stack pointer addresses are given below:')
+							print('Stack_address\t Symbol_address\t Symbol location  Symbol_name\t\tFile_name')
+							format_print = False
+						#If yes, print it's corresponding symbol
+                                                print_symbol(stack_addr, stack_val, 0)
+					# Check if the stack address lies in application text address range
+					is_app_symbol = is_app_text_address(hex(stack_val))	# app index in case of application symbol
+					if (is_app_symbol):
+						if (format_print):
+							print('\t- SP is out of the stack range. Debug symbols corresponding to the wrong stack pointer addresses are given below:')
+							print('Stack_address\t Symbol_address\t Symbol location  Symbol_name\t\tFile_name')
+							format_print = False
+						#If yes, print it's corresponding symbol
+                                                stack_val = stack_val - int(g_stext_app[is_app_symbol - 1])
+                                                print_symbol(stack_addr, stack_val, is_app_symbol)
 
 
 #Execution starts here
 if (__name__ == '__main__'):
 
     # init
-    bin_path += sys.argv[1]
-    log_file = sys.argv[2]
-    offset = sys.argv[3]
-    is_kernel_crash = int(sys.argv[4])	# 1 if kernel crash, 0 in case of application crash
+    log_file = sys.argv[1]		# Log file containing crash logs
+    app_idx = int(sys.argv[2])		# Number of applications (g_app_idx)
+    is_wrong_sp = int(sys.argv[3])	# 1 if wrong SP information needs to be printed, 0 if no wrong sp in logs
 
     if debug:
-        if (is_kernel_crash):
-           print("Is kernel crash : yes")
-        else:
-           print("Is application crash : yes")
-        print("Map file : " + bin_path)
-        print("Offset (text range start) : " + offset)
-    setup_symbol_table(bin_path)
+        print("Log file : " + log_file)
+        print("Number of applications : ", app_idx)
+        print("is_wrong_sp : ", is_wrong_sp)
 
-    print('Dump_address\t Symbol_address\t  Symbol_name\tFile_name')
-    parse_file(log_file)
-    print('-----------------------------------------------------------------------------------------')
+    find_kernel_text_range(bin_path + "System.map")
+    if (app_idx > 0):
+        find_app_text_range(log_file)
+
+    setup_symbol_table(bin_path + "System.map", 0)
+    for idx in range(app_idx):
+        os.system("nm --defined-only -l --numeric-sort " + bin_path + app_name[idx] + "_dbg > " + bin_path + app_name[idx] + ".map")
+        setup_symbol_table(bin_path + app_name[idx] + ".map", idx + 1)
+
+    if (is_wrong_sp):
+        print_wrong_sp(log_file)
+    else:
+        print_stack(log_file)
 


### PR DESCRIPTION
    This patch:
    1) Adds debug display symbols for stack contents if sp is not within allocated
    stack memory range. (PR #5339)
    2) Adds symbol for addresses corresponding to (pc - 4) & (pc - 8).
    3) Adds symbol location for all the displayed stack values.
    4) Displays current stack values in ascending order.
    5) Modifies the format of the display logs.

Signed-off-by: Vidisha <thapa.v@samsung.com>