### PR TITLE
tools/mkbootparam: Change a range of CRC checking to the whole bootparam region with 4Kbytes

### DIFF
--- a/os/tools/mkbootparam.py
+++ b/os/tools/mkbootparam.py
@@ -24,24 +24,31 @@ config_file_path = os.path.dirname(__file__) + '/../.config'
 bootparam_file_path = os.path.dirname(__file__) + '/../../build/output/bin/bootparam.bin'
 user_file_dir = os.path.dirname(__file__) + '/../../build/output/bin/user'
 
-SIZE_OF_BOOTPARAM_PART = 8192
+SIZE_OF_BPx = 4096
+
+# The partition size of dual BPs
+SIZE_OF_BP_PARTITION = SIZE_OF_BPx * 2
 
 ###########################################################################################
 #
-# This script generates Boot Parameters for kernel.
+# This script generates Boot Parameters.
 #
-# Boot Parameter information :
+# Boot Parameter works based on dual partition, BP1 and BP2.
+# It puts BP data to first BP, BP1 and clears second BP, BP2.
+# Then it makes a output with the name 'bootparam.bin' (8K) by concatenating BP1 and BP2.
+#  * A output, 'bootparam.bin' should be downloaded and be located at the end of a flash.
+#
+# Boot Parameter information (BPx) :
 #  - Boot Parameter Format Version 1 (bootparam_format_version = 1)
 #  - The data from 'App Count' depends on CONFIG_APP_SEPARATION.
 # +------------------------------------------------------------------------------------------
 # | Checksum | BP Version | BP Format Version | Active Idx | First Address | Second Address |
 # | (4bytes) |  (4bytes)  |      (4bytes)     |   (1byte)  |    (4bytes)   |    (4bytes)    |
 # +------------------------------------------------------------------------------------------
-# ----------------------------------------------------------------------------------------------------------------+
-# | App Count | App1 Name  | App1 Active Idx | App2 Name  | App2 Active Idx |     App# ...   |      Reserved      |
-# |  (1byte)  | (16 bytes) |   (1 bytes)     | (16 bytes) |    (1 bytes)    |  (## bytes)    |(8Kbytes - 21bytes) |
-# ----------------------------------------------------------------------------------------------------------------+
-#  * The Boot Parameters (8KB) should be downloaded and be located at the end of a flash.
+# ----------------------------------------------------------------------------------------------------------------------+
+# | App Count | App1 Name  | App1 Active Idx | App2 Name  | App2 Active Idx |     App# ...   |         Reserved         |
+# |  (1byte)  | (16 bytes) |   (1 bytes)     | (16 bytes) |    (1 bytes)    |  (## bytes)    |(4Kbytes - (21 + @)bytes) |
+# ----------------------------------------------------------------------------------------------------------------------+
 #  * The "Checksum" is crc32 value for data from "BP Version" to "Second Address".
 #  * The "BP Version" is a version to check the latest of boot parameters.
 #  * The "BP Format Version" is a version to manage the format of boot parameters.
@@ -60,16 +67,12 @@ SIZE_OF_BOOTPARAM_PART = 8192
 def get_config_value(file_name, config):
 	with open(file_name, 'r+') as fp:
 		lines = fp.readlines()
-		found = False
 		for line in lines:
 			if config in line:
 				value = (line.split("=")[1])
-				found = True
-				break
-	if found == False:
-		print ("FAIL!! No found config %s" %config)
-		sys.exit(1)
-	return value;
+				return value
+	print ("FAIL!! No found config %s" %config)
+	sys.exit(1)
 
 def make_bootparam():
 	print "========== Start to make boot parameters =========="
@@ -80,7 +83,7 @@ def make_bootparam():
 	SIZE_OF_KERNEL_FIRST_ADDR = 4
 	SIZE_OF_KERNEL_SECOND_ADDR = 4
 
-	bootparam_size = SIZE_OF_CHECKSUM + SIZE_OF_BP_VERSION + SIZE_OF_BP_VERSION + SIZE_OF_KERNEL_INDEX + SIZE_OF_KERNEL_FIRST_ADDR + SIZE_OF_KERNEL_SECOND_ADDR
+	kernel_data_size = SIZE_OF_CHECKSUM + SIZE_OF_BP_VERSION + SIZE_OF_BP_VERSION + SIZE_OF_KERNEL_INDEX + SIZE_OF_KERNEL_FIRST_ADDR + SIZE_OF_KERNEL_SECOND_ADDR
 
 	FLASH_START_ADDR = get_config_value(config_file_path, "CONFIG_FLASH_START_ADDR=")
 	FLASH_SIZE = get_config_value(config_file_path, "CONFIG_FLASH_SIZE=")
@@ -89,46 +92,34 @@ def make_bootparam():
 	names = filter(None, names)
 	sizes = filter(None, sizes)
 
-	# Calculate partition size of boot parameters
-	partition_size = 0
-	offset = 0
-	for index, name in enumerate(names):
-		if name == "bootparam":
-			partition_size = int(sizes[index]) * 1024
-			break
-		offset += int(sizes[index]) * 1024
-
-	if partition_size == 0:
-		print "FAIL!! No bootparam partition."
-		sys.exit(1)
-	elif partition_size != SIZE_OF_BOOTPARAM_PART:
-		print "FAIL!! Bootparam partition size should be 8K. Please re-configure."
-		sys.exit(1)
-	elif offset != int(FLASH_SIZE) - int(SIZE_OF_BOOTPARAM_PART):
-		print "FAIL!! Bootparam should be located at the end of flash with 8K. Please re-configure."
-		sys.exit(1)
-
-	# Get addresses of kernel partitions
+	# Check partitions of kernel and bootparam
 	kernel_address = []
 	offset = 0
-	for index, types in enumerate(names):
-		if types == "kernel":
+	bp_part_size = 0
+	for index, name in enumerate(names):
+		if name == "kernel":
+			# Get addresses of kernel partitions
 			address = hex(int(FLASH_START_ADDR, 16) + offset)
 			kernel_address.append(address)
+		if name == "bootparam":
+			# Get size of bootparam partition
+			bp_part_size = int(sizes[index]) * 1024
+			# Verify partition size and offset of boot parameters
+			if bp_part_size == 0:
+				print "FAIL!! No bootparam partition."
+				sys.exit(1)
+			elif bp_part_size != SIZE_OF_BP_PARTITION:
+				print "FAIL!! Bootparam partition size should be 8K. Please re-configure."
+				sys.exit(1)
+			elif offset != int(FLASH_SIZE) - int(SIZE_OF_BP_PARTITION):
+				print "FAIL!! Bootparam should be located at the end of flash with 8K. Please re-configure."
+				sys.exit(1)
 		offset += int(sizes[index]) * 1024
 
+	# Verify kernel partitions
 	if len(kernel_address) == 0 or len(kernel_address) > 2:
 		print "FAIL!! No found kernel partition"
 		sys.exit(1)
-
-	if os.path.exists(user_file_dir):
-		user_file_list = os.listdir(user_file_dir)
-	else:
-		user_file_list = []
-	user_app_count = len(user_file_list)
-	SIZE_OF_BINNAME = 16
-	SIZE_OF_BINIDX = 1
-	app_bootparam_size = (user_app_count * (SIZE_OF_BINNAME + SIZE_OF_BINIDX)) + 1
 
 	with open(bootparam_file_path, 'wb') as fp:
 		# Write Data
@@ -142,22 +133,40 @@ def make_bootparam():
 		for address in kernel_address:
 			fp.write(struct.pack('I', int(address, 16)))
 
-	# Add checksum
-	mkchecksum_path = os.path.dirname(__file__) + '/mkchecksum.py'
-	os.system('python %s %s' % (mkchecksum_path, bootparam_file_path))
+	# Get User data
+	if os.path.exists(user_file_dir):
+		user_file_list = os.listdir(user_file_dir)
+	else:
+		user_file_list = []
 
-	with open(bootparam_file_path, 'a') as fp:
-		# User Data
-		user_active_idx = 0
-		fp.write(struct.pack('B', user_app_count))
-		for user_file in user_file_list:
-			    fp.write('{:{}{}.{}}'.format(user_file, '<', SIZE_OF_BINNAME, SIZE_OF_BINNAME - 1).replace(' ','\0'))
-			    fp.write(struct.pack('B', user_active_idx))
+	app_data_size = 0
+	user_app_count = len(user_file_list)
+	if user_app_count > 0:
+		SIZE_OF_BINCOUNT = 1
+		SIZE_OF_BINNAME = 16
+		SIZE_OF_BINIDX = 1
+		app_data_size = SIZE_OF_BINCOUNT + (user_app_count * (SIZE_OF_BINNAME + SIZE_OF_BINIDX))
+
+		with open(bootparam_file_path, 'a') as fp:
+			# User Data
+			user_active_idx = 0
+			fp.write(struct.pack('B', user_app_count))
+			for user_file in user_file_list:
+				    fp.write('{:{}{}.{}}'.format(user_file, '<', SIZE_OF_BINNAME, SIZE_OF_BINNAME - 1).replace(' ','\0'))
+				    fp.write(struct.pack('B', user_active_idx))
 
 	# Fill remaining space with '0xff'
 	with open(bootparam_file_path, 'a') as fp:
-		remain_size = partition_size - bootparam_size - app_bootparam_size
+		remain_size = SIZE_OF_BPx - (kernel_data_size + app_data_size)
 		fp.write(b'\xff' * remain_size)
+
+	# Add checksum for BP1
+	mkchecksum_path = os.path.dirname(__file__) + '/mkchecksum.py'
+	os.system('python %s %s' % (mkchecksum_path, bootparam_file_path))
+
+	# Fill remaining space with '0xff' for BP2
+	with open(bootparam_file_path, 'a') as fp:
+		fp.write(b'\xff' * SIZE_OF_BPx)
 
 ###################################################
 # Generate boot parameters


### PR DESCRIPTION
Change a range of CRC checking to the whole bootparam region with 4Kbytes to remove dependency of build type.