### PR TITLE
fixup! examples/testcase/kernel: refactor tc_umm_heap

### DIFF
--- a/apps/examples/testcase/le_tc/kernel/tc_umm_heap.c
+++ b/apps/examples/testcase/le_tc/kernel/tc_umm_heap.c
@@ -283,7 +283,7 @@ static void tc_umm_heap_realloc(void)
 
 	/* Relloc Free by size 0 */
 	mem_ptr[0] = (int *)malloc(alloc_size);
-	TC_ASSERT_NEQ("malloc", mem_ptr[1], NULL);
+	TC_ASSERT_NEQ("malloc", mem_ptr[0], NULL);
 	alloc_size /= 2;
 	mem_ptr[1] = (int *)realloc(mem_ptr[0], alloc_size);
 	TC_ASSERT_NEQ_CLEANUP("realloc", mem_ptr[1], NULL, free(mem_ptr[0]));


### PR DESCRIPTION
Line 286 checks operation of line 285. Line 285 saves allocated memory
address in mem_ptr[0], but line 286 checks mem_ptr[1].
It's typo of previous commit ad391bf.
This commit fixes above.

Signed-off-by: sunghan-chang <sh924.chang@samsung.com>