### PR TITLE
fs/driver/mtd: Fix wrong output from '/proc/partitions'

### DIFF
--- a/apps/examples/fs_test/procfs_test.c
+++ b/apps/examples/fs_test/procfs_test.c
@@ -200,7 +200,7 @@ static int read_pid_entry(FAR const char *dirpath, FAR struct dirent *entryp, FA
 #ifdef CONFIG_BUILD_KERNEL
 int main(int argc, FAR char *argv[])
 #else
-int proc_test_main(int argc, char *argv[])
+int procfs_test_main(int argc, char *argv[])
 #endif
 {
 	int ret;

--- a/os/arch/arm/src/amebad/amebad_flash.c
+++ b/os/arch/arm/src/amebad/amebad_flash.c
@@ -345,13 +345,16 @@ FAR struct mtd_dev_s *up_flashinitialize(void)
 		priv->mtd.bwrite = amebad_bwrite;
 		priv->mtd.read = amebad_read;
 		priv->mtd.ioctl = amebad_ioctl;
-
 #if defined(CONFIG_MTD_BYTE_WRITE)
 		priv->mtd.write = amebad_write;
 #endif
 		priv->nsectors = AMEBAD_NSECTORS;
+#ifdef CONFIG_MTD_REGISTRATION
+		priv->mtd.name = "ameba_flash";
+#endif
 		u8 chip_id[4];
 		flash_read_id(NULL, chip_id, 4);
+
 		printf("Manufacturer : %u memory type : %u capacity : %u\n", chip_id[0], chip_id[1], chip_id[2]);
 		return (FAR struct mtd_dev_s *)priv;
 	}

--- a/os/arch/arm/src/imxrt/imxrt_mtd_flash.c
+++ b/os/arch/arm/src/imxrt/imxrt_mtd_flash.c
@@ -642,6 +642,9 @@ FAR struct mtd_dev_s *imxrt_mtd_initialize(void)
 		priv->mtd.write = imxrt_write;
 #endif
 		priv->mtd.ioctl = imxrt_ioctl;
+#ifdef CONFIG_MTD_REGISTRATION
+		priv->mtd.name = "imxrt_flash";
+#endif
 
 		/* Identify the FLASH chip and get its capacity */
 

--- a/os/arch/arm/src/stm32l4/stm32l4_ospi.c
+++ b/os/arch/arm/src/stm32l4/stm32l4_ospi.c
@@ -1920,6 +1920,9 @@ FAR struct mtd_dev_s *up_flashinitialize(void)
     priv->bwrite = this_bwrite;
     priv->read = this_read;
     priv->ioctl = this_ioctl;
+#ifdef CONFIG_MTD_REGISTRATION
+    priv->mtd.name = "stm32l4_flash";
+#endif
   }
 
   return priv;

--- a/os/arch/xtensa/src/esp32/spi_flash/esp32_flash.c
+++ b/os/arch/xtensa/src/esp32/spi_flash/esp32_flash.c
@@ -316,6 +316,9 @@ FAR struct mtd_dev_s *up_flashinitialize(void)
 #if defined(CONFIG_MTD_BYTE_WRITE)
 		priv->mtd.write = esp32_write;
 #endif
+#ifdef CONFIG_MTD_REGISTRATION
+		priv->mtd.name = "esp32_flash";
+#endif
         priv->nsectors = ESP32_NSECTORS;
 		return (FAR struct mtd_dev_s *)priv;
     }

--- a/os/fs/driver/mtd/m25px/m25px.c
+++ b/os/fs/driver/mtd/m25px/m25px.c
@@ -1043,6 +1043,9 @@ FAR struct mtd_dev_s *m25p_initialize(FAR struct spi_dev_s *dev)
 		priv->mtd.write = m25p_write;
 #endif
 		priv->mtd.ioctl = m25p_ioctl;
+#ifdef CONFIG_MTD_REGISTRATION
+		priv->mtd.name = "m25px";
+#endif
 		priv->dev = dev;
 
 		/* Deselect the FLASH */

--- a/os/fs/driver/mtd/mtd_partition.c
+++ b/os/fs/driver/mtd/mtd_partition.c
@@ -104,7 +104,8 @@ struct mtd_partition_s {
 								 * sub-region */
 	off_t blocksize;			/* The size of one read/write block */
 	uint16_t blkpererase;		/* Number of R/W blocks in one erase block */
-	uint16_t tagnumber;			/* Number of tag to classify each MTD driver */
+	uint16_t partno;		     	/* Partition number */
+	uint16_t tagno;		     	/* Number of tag to classify each MTD driver */
 	struct mtd_partition_s *pnext;	/* Pointer to next partition struct */
 #ifdef CONFIG_MTD_PARTITION_NAMES
 	char name[MTD_PARTNAME_LEN + 1];   /* Name of the partition */
@@ -529,9 +530,9 @@ static ssize_t part_procfs_read(FAR struct file *filep, FAR char *buffer, size_t
 	/* Output a header before the first entry */
 	if (filep->f_pos == 0) {
 #ifdef CONFIG_MTD_PARTITION_NAMES
-		total = snprintf(buffer, buflen, " %-*s  Start    Size", MTD_PARTNAME_LEN, "Name");
+		total = snprintf(buffer, buflen, " %-*s  Start    Size   Tag", MTD_PARTNAME_LEN, "Name");
 #else
-		total = snprintf(buffer, buflen, "  Start    Size");
+		total = snprintf(buffer, buflen, "  Start    Size   Tag");
 #endif
 
 #ifndef CONFIG_FS_PROCFS_EXCLUDE_MTD
@@ -561,9 +562,9 @@ static ssize_t part_procfs_read(FAR struct file *filep, FAR char *buffer, size_t
 
 		/* Copy data from the next known partition */
 #ifdef CONFIG_MTD_PARTITION_NAMES
-		ret = snprintf(&buffer[total], buflen - total, "%15s %7d %7d", attr->nextpart->name, attr->nextpart->firstblock / blkpererase, attr->nextpart->neraseblocks);
+		ret = snprintf(&buffer[total], buflen - total, "%15s %7d %7d %4d", attr->nextpart->name, attr->nextpart->firstblock / blkpererase, attr->nextpart->neraseblocks, attr->nextpart->tagno);
 #else
-		ret = snprintf(&buffer[total], buflen - total, "%7d %7d", attr->nextpart->firstblock / blkpererase, attr->nextpart->neraseblocks);
+		ret = snprintf(&buffer[total], buflen - total, "%7d %7d %4d", attr->nextpart->firstblock / blkpererase, attr->nextpart->neraseblocks, attr->nextpart->tagno);
 #endif
 
 #ifndef CONFIG_FS_PROCFS_EXCLUDE_MTD
@@ -682,6 +683,7 @@ static int part_procfs_stat(const char *relpath, struct stat *buf)
  *   mtd        - The MTD device to be partitioned
  *   firstblock - The offset in bytes to the first block
  *   nblocks    - The number of blocks in the partition
+ *   partno     - Partition number
  *
  * Returned Value:
  *   On success, another MTD device representing the partition is returned.
@@ -689,7 +691,7 @@ static int part_procfs_stat(const char *relpath, struct stat *buf)
  *
  ****************************************************************************/
 
-FAR struct mtd_dev_s *mtd_partition(FAR struct mtd_dev_s *mtd, off_t firstblock, off_t nblocks, uint16_t tagno)
+FAR struct mtd_dev_s *mtd_partition(FAR struct mtd_dev_s *mtd, off_t firstblock, off_t nblocks, uint16_t partno)
 {
 	FAR struct mtd_partition_s *part;
 	FAR struct mtd_geometry_s geo;
@@ -764,7 +766,8 @@ FAR struct mtd_dev_s *mtd_partition(FAR struct mtd_dev_s *mtd, off_t firstblock,
 	part->neraseblocks = eraseend - erasestart;
 	part->blocksize = geo.blocksize;
 	part->blkpererase = blkpererase;
-	part->tagnumber = tagno;
+	part->partno = partno;
+	part->tagno = MTD_NONE;
 
 #ifdef CONFIG_MTD_PARTITION_NAMES
 	strncpy(part->name, "(noname)", MTD_PARTNAME_LEN);
@@ -812,12 +815,33 @@ FAR struct mtd_dev_s *get_mtd_partition(uint16_t tagno)
 	part = g_pfirstpartition;
 
 	do {
-		if (part->tagnumber == tagno) {
+		if (part->tagno == tagno) {
 			return (FAR struct mtd_dev_s *)part;
 		}
 		part = part->pnext;
 	} while (part);
 	return NULL;
+}
+
+/****************************************************************************
+ * Name: mtd_setpartitiontagno
+ *
+ * Description:
+ *   Sets the tag number of the specified partition.
+ *
+ ****************************************************************************/
+
+int mtd_setpartitiontagno(FAR struct mtd_dev_s *mtd, uint16_t tagno)
+{
+	FAR struct mtd_partition_s *priv = (FAR struct mtd_partition_s *)mtd;
+
+	if (priv == NULL || tagno >= MTD_TAG_MAX) {
+		return -EINVAL;
+	}
+
+	/* Set tag number */
+	priv->tagno = tagno;
+	return OK;
 }
 
 /****************************************************************************

--- a/os/include/tinyara/fs/mtd.h
+++ b/os/include/tinyara/fs/mtd.h
@@ -170,11 +170,13 @@ struct mtd_dev_s {
 };
 
 enum mtd_partition_tag_s {
-	MTD_MASTER = 0,
-	MTD_FS = 1,
-	MTD_NV = 2,
-	MTD_OTA = 3,
-	MTD_ROMFS = 4
+	MTD_NONE = 0,  /* None */
+	MTD_FS = 1,    /* File System */
+	MTD_NV = 2,    /* Non-Volatile */
+	MTD_OTA = 3,   /* OTA */
+	MTD_ROMFS = 4, /* ROM FS */
+	MTD_FTL = 5,   /* Directly use FTL as a block driver (ex. BCH) */
+	MTD_TAG_MAX,
 };
 
 struct spi_dev_s;
@@ -218,7 +220,7 @@ extern "C" {
  *       mtd            - The MTD device to be partitioned
  *       firstblock - The offset in bytes to the first block
  *       nblocks        - The number of blocks in the partition
- *       tagno           - The number of each mtd's tag to classify
+ *       partno           - Partition number
  *
  * Returned Value:
  *       On success, another MTD device representing the partition is returned.
@@ -226,7 +228,7 @@ extern "C" {
  *
  ****************************************************************************/
 
-FAR struct mtd_dev_s *mtd_partition(FAR struct mtd_dev_s *mtd, off_t firstblock, off_t nblocks, uint16_t tagno);
+FAR struct mtd_dev_s *mtd_partition(FAR struct mtd_dev_s *mtd, off_t firstblock, off_t nblocks, uint16_t partno);
 
 /****************************************************************************
  * Name: get_mtd_partition
@@ -236,6 +238,16 @@ FAR struct mtd_dev_s *mtd_partition(FAR struct mtd_dev_s *mtd, off_t firstblock,
  *
  ****************************************************************************/
 FAR struct mtd_dev_s *get_mtd_partition(uint16_t tagno);
+
+/****************************************************************************
+ * Name: mtd_setpartitiontagno
+ *
+ * Description:
+ *   Sets the tag number of the specified partition.
+ *
+ ****************************************************************************/
+
+int mtd_setpartitiontagno(FAR struct mtd_dev_s *mtd, uint16_t tagno);
 
 /****************************************************************************
  * Name: mtd_setpartitionname


### PR DESCRIPTION
- Fix wrong entry function name to 'procfs_test_main'
- Set the name of mtd devices in when device initialization
- fs/driver/mtd: Fix wrong output from '/proc/partitions'
  - Ex) cat /proc/partitions
 Name             Start    Size   MTD
            bl1       0       4    ameba_flash
            bl2       4       2    ameba_flash
       reserved       6       4    ameba_flash
             ss      10     118    ameba_flash
    system_data     128       2    ameba_flash
         kernel     130     448    ameba_flash
         kernel     578     448    ameba_flash
         userfs    1026    1020    ameba_flash
      bootparam    2046       2    ameba_flash