### PR TITLE
external/webserver: Increase timeout for keep-alive connections

### DIFF
--- a/external/include/protocols/webserver/http_server.h
+++ b/external/include/protocols/webserver/http_server.h
@@ -93,6 +93,7 @@
 #define HTTP_CONF_CLIENT_STACKSIZE              8192
 #define HTTP_CONF_MIN_TLS_MEMORY                80000
 #define HTTP_CONF_SOCKET_TIMEOUT_MSEC           50000
+#define HTTP_CONF_KEEP_ALIVE_MSEC               300000
 #define HTTP_CONF_SERVER_MQ_MAX_MSG             10
 #define HTTP_CONF_SERVER_MQ_PRIO                50
 #define HTTP_CONF_SERVER_SIGWAKEUP              18

--- a/external/webserver/http_client.c
+++ b/external/webserver/http_client.c
@@ -582,6 +582,15 @@ int http_recv_and_handle_request(struct http_client_t *client, struct http_keyva
 	conn_type = http_keyvalue_list_find(request_params, "Connection");
 	if (!strncasecmp(conn_type, "Keep-Alive", strlen("Keep-Alive")+1)) {
 		client->keep_alive = 1;
+		struct timeval tv;
+		tv.tv_sec = HTTP_CONF_KEEP_ALIVE_MSEC / 1000;
+		tv.tv_usec = (HTTP_CONF_KEEP_ALIVE_MSEC % 1000) * 1000;
+		HTTP_LOGD("Keep-alive case, change timeout to (%u.%d)sec\n", tv.tv_sec, tv.tv_usec);
+		if (setsockopt(client->client_fd, SOL_SOCKET, SO_RCVTIMEO, (struct timeval *)&tv, sizeof(struct timeval)) < 0) {
+			HTTP_LOGE("Error: Fail to setsockopt\n");
+		} else {
+			HTTP_LOGD("Timeout modified done\n");
+		}
 	} else {
 		client->keep_alive = 0;
 	}


### PR DESCRIPTION
Current timeout for read operation is 50 seconds.
Increase timeout to 300 seconds for keep-alive connection requests.