### PR TITLE
arch/arm/src/amebad/: Override secure hardfault handler to make it able to print PC/LR from NS

### DIFF
--- a/os/arch/arm/src/amebad/amebad_reboot_reason.h
+++ b/os/arch/arm/src/amebad/amebad_reboot_reason.h
@@ -25,6 +25,7 @@ enum {
 	REBOOT_SYSTEM_DSLP_RESET     = REBOOT_BOARD_SPECIFIC1, /* System wake up from deep sleep */
 	REBOOT_SYSTEM_SYS_RESET_CORE = REBOOT_BOARD_SPECIFIC2, /* System reset by Core */
 	REBOOT_SYSTEM_BOD_RESET      = REBOOT_BOARD_SPECIFIC3, /* Brownout reset */
+	REBOOT_SYSTEM_TZWD_RESET     = REBOOT_BOARD_SPECIFIC4, /* TrustZone Watch dog */
 };
 
 #endif /* __AMEBAD_REBOOT_REASON_H__ */

--- a/os/board/rtl8721csm/src/component/soc/realtek/amebad/fwlib/ram_hp/rtl8721dhp_app_start.c
+++ b/os/board/rtl8721csm/src/component/soc/realtek/amebad/fwlib/ram_hp/rtl8721dhp_app_start.c
@@ -14,6 +14,7 @@
 #include "ameba_soc.h"
 #include "rtl8721d_system.h"
 #include "psram_reserve.h"
+#include "amebad_reboot_reason.h"
 #ifdef CONFIG_ARMV8M_MPU
 #include "up_mpuinit.h"
 #endif
@@ -1047,6 +1048,14 @@ void app_mpu_s_nocache_init(void)
 #endif
 }
 
+#ifdef CONFIG_AMEBAD_TRUSTZONE
+void app_hardfualt_s_prehanlder(uint32_t fault_id)
+{
+	//write reboot reason, TrustZone watchdog
+	BKUP_Write(BKUP_REG1, REBOOT_SYSTEM_TZWD_RESET);
+}
+#endif
+
 VOID app_vdd1833_detect(VOID)
 {
 	u32 temp;
@@ -1376,6 +1385,10 @@ extern void __libc_init_array(void);
 	mpu_init();
 	app_mpu_nocache_init();
 	app_mpu_s_nocache_init();
+
+#ifdef CONFIG_AMEBAD_TRUSTZONE
+	Secure_VectorTableOverride(app_hardfualt_s_prehanlder);
+#endif
 #endif
 	app_vdd1833_detect();
 	memcpy_gdma_init();
@@ -1430,4 +1443,5 @@ RAM_START_FUNCTION Img2EntryFun0 = {
 	NULL,//BOOT_RAM_WakeFromPG,
 	(u32)NewVectorTable
 };
+
 


### PR DESCRIPTION

Override secure hardfault handler to 1. print PC/LR from NS 2. watchdog reset with reset reason
 - Commit information
   - https://github.com/Samsung/TizenRT/pull/5372