### PR TITLE
arrh/arm/armv7,8-m: Show loading binary addresses after checking app heap corruption

### DIFF
--- a/os/arch/arm/src/armv7-m/up_assert.c
+++ b/os/arch/arm/src/armv7-m/up_assert.c
@@ -511,11 +511,11 @@ void up_assert(const uint8_t *filename, int lineno)
 	struct tcb_s *fault_tcb = this_task();
 
 	if (IS_FAULT_IN_USER_THREAD(fault_tcb)) {
-		elf_show_all_bin_addr();
 		lldbg("Checking current app heap for corruption...\n");
 		if (mm_check_heap_corruption((struct mm_heap_s *)(fault_tcb->uheap)) == OK) {
 			lldbg("No app heap corruption detected\n");
 		}
+		elf_show_all_bin_addr();
 	}
 #endif
 	lldbg("Assert location (PC) : %08x\n", asserted_location);

--- a/os/arch/arm/src/armv8-m/up_assert.c
+++ b/os/arch/arm/src/armv8-m/up_assert.c
@@ -527,11 +527,11 @@ void up_assert(const uint8_t *filename, int lineno)
 	struct tcb_s *fault_tcb = this_task();
 
 	if (IS_FAULT_IN_USER_THREAD(fault_tcb)) {
-		elf_show_all_bin_addr();
 		lldbg("Checking current app heap for corruption...\n");
 		if (mm_check_heap_corruption((struct mm_heap_s *)(fault_tcb->uheap)) == OK) {
 			lldbg("No app heap corruption detected\n");
 		}
+		elf_show_all_bin_addr();
 	}
 #endif
 	lldbg("Assert location (PC) : 0x%08x\n", asserted_location);


### PR DESCRIPTION
Show loading binary addresses after checking app heap corruption for readability.