### PR TITLE
configs/rtl8721csm/scripts: Add _sinit, _einit to support c++

### DIFF
--- a/build/configs/rtl8721csm/scripts/rlx8721d_img2_is.ld
+++ b/build/configs/rtl8721csm/scripts/rlx8721d_img2_is.ld
@@ -253,8 +253,10 @@ SECTIONS
 		__preinit_array_end = .;
 		. = ALIGN(4);
 		__init_array_start = .;
+		_sinit = ABSOLUTE(.);
 		KEEP(*(SORT(.init_array.*)))
 		KEEP(*(.init_array))
+		_einit = ABSOLUTE(.);
 		__init_array_end = .;
 		. = ALIGN(4);
 		__fini_array_start = .;

--- a/build/configs/rtl8721csm/scripts/rlx8721d_img2_ns.ld
+++ b/build/configs/rtl8721csm/scripts/rlx8721d_img2_ns.ld
@@ -327,8 +327,10 @@ SECTIONS
 		__preinit_array_end = .;
 		. = ALIGN(4);
 		__init_array_start = .;
+		_sinit = ABSOLUTE(.);
 		KEEP(*(SORT(.init_array.*)))
 		KEEP(*(.init_array))
+		_einit = ABSOLUTE(.);
 		__init_array_end = .;
 		. = ALIGN(4);
 		__fini_array_start = .;


### PR DESCRIPTION
To fix gnu_cxxinitialize.c build error, add _sinit, _einit to ld file.