### PR TITLE
os/board/rtl8721csm: Fix uart data loss while flash write

### DIFF
--- a/os/arch/arm/src/amebad/amebad_serial.c
+++ b/os/arch/arm/src/amebad/amebad_serial.c
@@ -162,6 +162,7 @@
 #define UART2_ASSIGNED  1
 #endif
 #define CHAR_TIMEOUT 6540
+#define TX_FIFO_MAX 16
 
 /****************************************************************************
  * Private Types
@@ -195,6 +196,7 @@ struct rtl8721d_up_dev_s {
 #ifdef CONFIG_SERIAL_OFLOWCONTROL
 	uint8_t oflow:1;			/* output flow control (CTS) enabled */
 #endif
+	uint8_t tx_level;
 };
 
 /****************************************************************************
@@ -418,7 +420,6 @@ static int rtl8721d_up_setup(struct uart_dev_s *dev)
 	serial_baud(sdrv[uart_index_get(priv->tx)], priv->baud);
 	serial_format(sdrv[uart_index_get(priv->tx)], priv->bits, priv->parity, priv->stopbit);
 	serial_set_flow_control(sdrv[uart_index_get(priv->tx)], priv->FlowControl, priv->rts, priv->cts);
-
 	return OK;
 }
 
@@ -456,15 +457,17 @@ static void rtl8721d_up_shutdown(struct uart_dev_s *dev)
  *
  ****************************************************************************/
 
-//extern uint32_t uart_irqhandler(void *data);
 void rtl8721d_uart_irq(uint32_t id, SerialIrq event)
 {
 	struct uart_dev_s *dev = (struct uart_dev_s *)id;
+	struct rtl8721d_up_dev_s *priv = (struct rtl8721d_up_dev_s *)dev->priv;
 	if (event == RxIrq) {
 		uart_recvchars(dev);
 	}
 	if (event == TxIrq) {
+		priv->tx_level = TX_FIFO_MAX;
 		uart_xmitchars(dev);
+		priv->tx_level = 0;
 	}
 }
 static int rtl8721d_up_attach(struct uart_dev_s *dev)
@@ -647,6 +650,7 @@ static void rtl8721d_up_send(struct uart_dev_s *dev, int ch)
 	DEBUGASSERT(priv);
 	/*write one byte to tx fifo*/
 	serial_putc(sdrv[uart_index_get(priv->tx)], ch);
+	priv->tx_level--;
 }
 
 /****************************************************************************
@@ -680,7 +684,7 @@ static bool rtl8721d_up_txready(struct uart_dev_s *dev)
 	struct rtl8721d_up_dev_s *priv = (struct rtl8721d_up_dev_s *)dev->priv;
 	DEBUGASSERT(priv);
 
-	return (serial_writable(sdrv[uart_index_get(priv->tx)]));
+	return priv->tx_level;
 }
 
 /****************************************************************************
@@ -695,8 +699,7 @@ static bool rtl8721d_up_txempty(struct uart_dev_s *dev)
 {
 	struct rtl8721d_up_dev_s *priv = (struct rtl8721d_up_dev_s *)dev->priv;
 	DEBUGASSERT(priv);
-	while (!serial_writable(sdrv[uart_index_get(priv->tx)])) ;
-	return true;
+	return (serial_tx_empty(sdrv[uart_index_get(priv->tx)]));
 }
 
 /****************************************************************************

--- a/os/board/rtl8721csm/src/component/common/mbed/hal/serial_api.h
+++ b/os/board/rtl8721csm/src/component/common/mbed/hal/serial_api.h
@@ -188,6 +188,14 @@ int  serial_readable(serial_t *obj);
 int  serial_writable(serial_t *obj);
 
 /**
+  * @brief  check if transmit fifo is empty
+  * @param  obj: uart object define in application software.
+  * @retval 1: TRUE
+  * @retval 0: FALSE
+  */
+int serial_tx_empty(serial_t *obj);
+
+/**
   * @brief  Clear Rx fifo.
   * @param  obj: uart object define in application software.
   * @retval none

--- a/os/board/rtl8721csm/src/component/common/mbed/targets/hal/rtl8721d/flash_api.c
+++ b/os/board/rtl8721csm/src/component/common/mbed/targets/hal/rtl8721d/flash_api.c
@@ -374,7 +374,6 @@ int  flash_stream_write(flash_t *obj, u32 address, u32 len, u8 * data)
 	u32 read_word;
 	u32 i;
 
-	FLASH_Write_Lock();
 	while(page_cnt){
 		offset_to_align = addr_begin & 0x3;
 
@@ -387,36 +386,44 @@ int  flash_stream_write(flash_t *obj, u32 address, u32 len, u8 * data)
 				if(size == 0)
 					break;
 			}
+			FLASH_Write_Lock();
 			FLASH_TxData12B(addr_begin - offset_to_align, 4, (u8*)&read_word);
 #ifdef MICRON_N25Q00AA
 			FLASH_ReadFlagStatusReg();
 #endif
+			FLASH_Write_Unlock();
 		}
 
 		addr_begin = (((addr_begin-1) >> 2) + 1) << 2;
 		for(;size >= 256 ;size -= 256){
+			FLASH_Write_Lock();
 			FLASH_TxData256B_RAM(addr_begin, 256, data);
 #ifdef MICRON_N25Q00AA
 			FLASH_ReadFlagStatusReg();
 #endif
+			FLASH_Write_Unlock();
 			data += 256;
 			addr_begin += 256;
 		}
 
 		for(;size >= 12 ;size -= 12){
+			FLASH_Write_Lock();
 			FLASH_TxData12B(addr_begin, 12, data);
 #ifdef MICRON_N25Q00AA
 			FLASH_ReadFlagStatusReg();
 #endif
+			FLASH_Write_Unlock();
 			data += 12;
 			addr_begin += 12;
 		}
 
 		for(;size >= 4; size -=4){
+			FLASH_Write_Lock();
 			FLASH_TxData12B(addr_begin, 4, data);
 #ifdef MICRON_N25Q00AA
 			FLASH_ReadFlagStatusReg();
 #endif
+			FLASH_Write_Unlock();
 			data += 4;
 			addr_begin += 4;
 		}
@@ -427,10 +434,12 @@ int  flash_stream_write(flash_t *obj, u32 address, u32 len, u8 * data)
 				read_word = (read_word & (~(0xff << (8*i)))) | ((*data) <<(8*i));
 				data++;
 			}
-			FLASH_TxData12B(addr_begin, 4, (u8*)&read_word); 
+			FLASH_Write_Lock();
+			FLASH_TxData12B(addr_begin, 4, (u8*)&read_word);
 #ifdef MICRON_N25Q00AA
 			FLASH_ReadFlagStatusReg();
 #endif
+			FLASH_Write_Unlock();
 		}
 		page_cnt--;
 		addr_begin = addr_end;
@@ -439,7 +448,6 @@ int  flash_stream_write(flash_t *obj, u32 address, u32 len, u8 * data)
 	}
 
 	DCache_Invalidate(SPI_FLASH_BASE + address, len);
-	FLASH_Write_Unlock();
 
 	return size;
 }


### PR DESCRIPTION
This PR contains modifications on uart api and flash api.

For the uart api update:
- **tx_level** is added to ensure 16 bytes of data is transmitted for each uart tx interrupt. In this way, the total number of interrupts can be reduced as well as the time used for the transmission.

For the flash api update:
- **FLASH_Write_Lock** is applied only before and after the flash write functions to reduce the overall period of FLASH_Write_Lock.