### PR TITLE
kernel/task/task_prctl.c : Change to get the TCB associated with the …

### DIFF
--- a/apps/examples/testcase/le_tc/kernel/tc_task.c
+++ b/apps/examples/testcase/le_tc/kernel/tc_task.c
@@ -377,45 +377,46 @@ static void tc_task_prctl(void)
 	char getname[CONFIG_TASK_NAME_SIZE + 1];
 	char oldname[CONFIG_TASK_NAME_SIZE + 1];
 	int ret_chk;
+	pid_t mypid = getpid();
 
 	/* unrecognized option case */
 
-	ret_chk = prctl(PR_INVALID, oldname, 0, 0, 0);
+	ret_chk = prctl(PR_INVALID, oldname, mypid);
 	TC_ASSERT_EQ("prctl", ret_chk, ERROR);
 	TC_ASSERT_EQ("prctl", get_errno(), EINVAL);
 
 	/* no such process case */
 
-	ret_chk = prctl(PR_GET_NAME, oldname, PID_INVALID, 0, 0);
+	ret_chk = prctl(PR_GET_NAME_BYPID, oldname, PID_INVALID);
 	TC_ASSERT_EQ("prctl", ret_chk, ERROR);
 	TC_ASSERT_EQ("prctl", get_errno(), ESRCH);
 
 	/* no name case */
 
-	ret_chk = prctl(PR_GET_NAME, NULL, 0, 0, 0);
+	ret_chk = prctl(PR_GET_NAME_BYPID, NULL, mypid);
 	TC_ASSERT_EQ("prctl", ret_chk, ERROR);
 	TC_ASSERT_EQ("prctl", get_errno(), EFAULT);
 
 	/* save taskname */
 
-	ret_chk = prctl(PR_GET_NAME, oldname, 0, 0, 0);
+	ret_chk = prctl(PR_GET_NAME_BYPID, oldname, mypid);
 	TC_ASSERT_EQ("prctl", ret_chk, OK);
 
 	/* set taskname */
 
-	ret_chk = prctl(PR_SET_NAME, setname, 0, 0, 0);
+	ret_chk = prctl(PR_SET_NAME_BYPID, setname, mypid);
 	TC_ASSERT_EQ("prctl", ret_chk, OK);
 
 	/* get taskname */
 
-	ret_chk = prctl(PR_GET_NAME, getname, 0, 0, 0);
-	TC_ASSERT_EQ_ERROR_CLEANUP("prctl", ret_chk, OK, get_errno(), prctl(PR_SET_NAME, oldname, 0, 0, 0));
+	ret_chk = prctl(PR_GET_NAME_BYPID, getname, mypid);
+	TC_ASSERT_EQ_ERROR_CLEANUP("prctl", ret_chk, OK, get_errno(), prctl(PR_SET_NAME_BYPID, oldname, mypid));
 
 	/* compare getname and setname */
 
-	TC_ASSERT_EQ_ERROR_CLEANUP("prctl", strncmp(getname, setname, CONFIG_TASK_NAME_SIZE), 0, get_errno(), prctl(PR_SET_NAME, oldname, 0, 0, 0));
+	TC_ASSERT_EQ_ERROR_CLEANUP("prctl", strncmp(getname, setname, CONFIG_TASK_NAME_SIZE), 0, get_errno(), prctl(PR_SET_NAME_BYPID, oldname, mypid));
 
-	prctl(PR_SET_NAME, oldname, 0, 0, 0);
+	prctl(PR_SET_NAME_BYPID, oldname, mypid);
 	TC_ASSERT_EQ("prctl", ret_chk, OK);
 
 #ifdef CONFIG_SYSTEM_REBOOT_REASON

--- a/os/include/pthread.h
+++ b/os/include/pthread.h
@@ -226,7 +226,7 @@
  * @since TizenRT v1.0
  */
 #define pthread_setname_np(thread, name) \
-	prctl((int)PR_SET_NAME, (char*)name, (int)thread)
+	prctl((int)PR_SET_NAME_BYPID, (char*)name, (int)thread)
 
 /**
  * @ingroup PTHREAD_KERNEL
@@ -238,7 +238,7 @@
  * @since TizenRT v1.0
  */
 #define pthread_getname_np(thread, name) \
-	prctl((int)PR_GET_NAME, (char*)name, (int)thread)
+	prctl((int)PR_GET_NAME_BYPID, (char*)name, (int)thread)
 
 /********************************************************************************
  * Global Type Declarations

--- a/os/include/sys/prctl.h
+++ b/os/include/sys/prctl.h
@@ -64,22 +64,38 @@
 /* Supported prctl() commands.
  *
  *  PR_SET_NAME
- *    Set the task (or thread) name for the thread whose ID is in required
- *    arg2 (int), using the value in the location pointed to by required arg1
- *    (char*).  The name can be up to CONFIG_TASK_NAME_SIZE long (including
+ *    Set the calling task (or thread) name, using the value in the location 
+ *    pointed to by required arg1(char*).
+ *    The name can be up to CONFIG_TASK_NAME_SIZE long (including
  *    any null termination).  The thread ID of 0 will set the name of the
  *    calling thread. As an example:
  *
- *      prctl(PR_SET_NAME, "MyName", 0);
+ *      prctl(PR_SET_NAME, "MyName");
+ *
+ *  PR_SET_NAME_BYPID
+ *    Set the task (or thread) name for the thread whose ID is in required
+ *    arg2 (int), using the value in the location pointed to by required arg1
+ *    (char*).  The name can be up to CONFIG_TASK_NAME_SIZE long (including
+ *    any null termination). As an example:
+ *
+ *      prctl(PR_SET_NAME_BYPID, "MyName", 0);
  *
  *  PR_GET_NAME
+ *    Return the calling task (or thread) name, in the buffer pointed to 
+ *    by optional arg1 (char *). The buffer must be CONFIG_TASK_NAME_SIZE long
+ *    (including any null termination). As an example:
+ *
+ *      char myname[CONFIG_TASK_NAME_SIZE];
+ *      prctl(PR_GET_NAME, myname);
+ *
+ *  PR_GET_NAME_BYPID
  *    Return the task (or thread) name for the for the thread whose ID is
  *    optional arg2 (int), in the buffer pointed to by optional arg1 (char *).
  *    The buffer must be CONFIG_TASK_NAME_SIZE long (including any null
  *    termination). As an example:
  *
  *      char myname[CONFIG_TASK_NAME_SIZE];
- *      prctl(PR_GET_NAME, myname, 0);
+ *      prctl(PR_GET_NAME_BYPID, myname, 0);
  */
 
 /**
@@ -88,7 +104,9 @@
  */
 enum prctl_type_e {
 	PR_SET_NAME = 0,
+	PR_SET_NAME_BYPID,
 	PR_GET_NAME,
+	PR_GET_NAME_BYPID,
 	PR_GET_STKLOG,
 	PR_MSG_SAVE,
 	PR_MSG_READ,


### PR DESCRIPTION
…PID for all cases

In previous PR_GET/SET_NAME, for pid 0, it gets the current running tcb.
In this case, we cannot get the Idle task's tcb.
So change to always get based on the pid.

Signed-off-by: jeongchanKim <jc_.kim@samsung.com>