### PR TITLE
arch/arm/v7,8-m,r/up_assert.c : Show stack alloc address when asserted

### DIFF
--- a/os/arch/arm/src/armv7-m/up_assert.c
+++ b/os/arch/arm/src/armv7-m/up_assert.c
@@ -227,13 +227,13 @@ static void up_taskdump(FAR struct tcb_s *tcb, FAR void *arg)
 	/* Dump interesting properties of this task */
 
 #if CONFIG_TASK_NAME_SIZE > 0
-	lldbg("%*s | %5d | %4d | %7lu / %7lu\n", CONFIG_TASK_NAME_SIZE,
+	lldbg("%*s | %5d | %4d | %7lu / %7lu | %16p\n", CONFIG_TASK_NAME_SIZE,
 			tcb->name, tcb->pid, tcb->sched_priority,
-			(unsigned long)used_stack_size, (unsigned long)tcb->adj_stack_size);
+			(unsigned long)used_stack_size, (unsigned long)tcb->adj_stack_size, tcb->stack_alloc_ptr);
 #else
-	lldbg("%5d | %4d | %7lu / %7lu\n",
+	lldbg("%5d | %4d | %7lu / %7lu | %16p\n",
 			tcb->pid, tcb->sched_priority, (unsigned long)used_stack_size,
-			(unsigned long)tcb->adj_stack_size);
+			(unsigned long)tcb->adj_stack_size, tcb->stack_alloc_ptr);
 #endif
 
 	if (used_stack_size == tcb->adj_stack_size) {
@@ -255,11 +255,11 @@ static inline void up_showtasks(void)
 	lldbg("*******************************************\n");
 
 #if CONFIG_TASK_NAME_SIZE > 0
-	lldbg("%*s | %5s | %4s | %7s / %7s\n", CONFIG_TASK_NAME_SIZE, "NAME", "PID", "PRI", "USED", "TOTAL STACK");
-	lldbg("---------------------------------------------------------------------\n");
+	lldbg("%*s | %5s | %4s | %7s / %7s | %16s\n", CONFIG_TASK_NAME_SIZE, "NAME", "PID", "PRI", "USED", "TOTAL STACK", "STACK ALLOC ADDR");
+	lldbg("-----------------------------------------------------------------------------------------\n");
 #else
-	lldbg("%5s | %4s | %7s / %7s\n", "PID", "PRI", "USED", "TOTAL STACK");
-	lldbg("----------------------------------\n");
+	lldbg("%5s | %4s | %7s / %7s | %16s\n", "PID", "PRI", "USED", "TOTAL STACK", "STACK ALLOC ADDR");
+	lldbg("------------------------------------------------------\n");
 #endif
 
 	/* Dump interesting properties of each task in the crash environment */

--- a/os/arch/arm/src/armv7-r/arm_assert.c
+++ b/os/arch/arm/src/armv7-r/arm_assert.c
@@ -486,13 +486,13 @@ static void up_taskdump(FAR struct tcb_s *tcb, FAR void *arg)
 	/* Dump interesting properties of this task */
 
 #if CONFIG_TASK_NAME_SIZE > 0
-	lldbg("%10s | %5d | %4d | %7lu / %7lu\n",
+	lldbg("%10s | %5d | %4d | %7lu / %7lu | %16p\n",
 			tcb->name, tcb->pid, tcb->sched_priority,
-			(unsigned long)used_stack_size, (unsigned long)tcb->adj_stack_size);
+			(unsigned long)used_stack_size, (unsigned long)tcb->adj_stack_size, tcb->stack_alloc_ptr);
 #else
-	lldbg("%5d | %4d | %7lu / %7lu\n",
+	lldbg("%5d | %4d | %7lu / %7lu | %16p\n",
 			tcb->pid, tcb->sched_priority, (unsigned long)used_stack_size,
-			(unsigned long)tcb->adj_stack_size);
+			(unsigned long)tcb->adj_stack_size, tcb->stack_alloc_ptr);
 #endif
 
 	if (used_stack_size == tcb->adj_stack_size) {
@@ -513,11 +513,11 @@ static inline void up_showtasks(void)
 	lldbg("*******************************************\n");
 
 #if CONFIG_TASK_NAME_SIZE > 0
-	lldbg("   NAME   |  PID  |  PRI |    USED /  TOTAL STACK\n");
-	lldbg("--------------------------------------------------\n");
+	lldbg("   NAME   |  PID  |  PRI |    USED /  TOTAL STACK | STACK ALLOC ADDR\n");
+	lldbg("----------------------------------------------------------------------\n");
 #else
-	lldbg("  PID | PRI |   USED / TOTAL STACK\n");
-	lldbg("----------------------------------\n");
+	lldbg("  PID | PRI |   USED / TOTAL STACK | STACK ALLOC ADDR\n");
+	lldbg("------------------------------------------------------\n");
 #endif
 
 	/* Dump interesting properties of each task in the crash environment */

--- a/os/arch/arm/src/armv8-m/up_assert.c
+++ b/os/arch/arm/src/armv8-m/up_assert.c
@@ -237,13 +237,13 @@ static void up_taskdump(FAR struct tcb_s *tcb, FAR void *arg)
 	/* Dump interesting properties of this task */
 
 #if CONFIG_TASK_NAME_SIZE > 0
-	lldbg("%*s | %5d | %4d | %7lu / %7lu\n", CONFIG_TASK_NAME_SIZE,
+	lldbg("%*s | %5d | %4d | %7lu / %7lu | %16p\n", CONFIG_TASK_NAME_SIZE,
 			tcb->name, tcb->pid, tcb->sched_priority,
-			(unsigned long)used_stack_size, (unsigned long)tcb->adj_stack_size);
+			(unsigned long)used_stack_size, (unsigned long)tcb->adj_stack_size, tcb->stack_alloc_ptr);
 #else
-	lldbg("%5d | %4d | %7lu / %7lu\n",
+	lldbg("%5d | %4d | %7lu / %7lu | %16p\n",
 			tcb->pid, tcb->sched_priority, (unsigned long)used_stack_size,
-			(unsigned long)tcb->adj_stack_size);
+			(unsigned long)tcb->adj_stack_size, tcb->stack_alloc_ptr);
 #endif
 
 	if (used_stack_size == tcb->adj_stack_size) {
@@ -265,11 +265,11 @@ static inline void up_showtasks(void)
 	lldbg("*******************************************\n");
 
 #if CONFIG_TASK_NAME_SIZE > 0
-	lldbg("%*s | %5s | %4s | %7s / %7s\n", CONFIG_TASK_NAME_SIZE, "NAME", "PID", "PRI", "USED", "TOTAL STACK");
-	lldbg("---------------------------------------------------------------------\n");
+	lldbg("%*s | %5s | %4s | %7s / %7s | %16s\n", CONFIG_TASK_NAME_SIZE, "NAME", "PID", "PRI", "USED", "TOTAL STACK",  "STACK ALLOC ADDR");
+	lldbg("-----------------------------------------------------------------------------------------\n");
 #else
-	lldbg("%5s | %4s | %7s / %7s\n", "PID", "PRI", "USED", "TOTAL STACK");
-	lldbg("----------------------------------\n");
+	lldbg("%5s | %4s | %7s / %7s | %16s\n", "PID", "PRI", "USED", "TOTAL STACK", "STACK ALLOC ADDR");
+	lldbg("------------------------------------------------------\n");
 #endif
 
 	/* Dump interesting properties of each task in the crash environment */


### PR DESCRIPTION
With stack alloc addr, we can get more information if there is an stack overflow.
For example, if there is a heap node corruption, but there is no overflowed prev node, then we can check the next heap node is stack or not.
If next heap node is stack node, then we can make suspicion about stack overflow.

Signed-off-by: jeongchanKim <jc_.kim@samsung.com>