### PR TITLE
kernel/clock: introduce CONFIG_INIT_SYSTEM_TIME_WITH_MIDNIGHT

### DIFF
--- a/os/kernel/Kconfig
+++ b/os/kernel/Kconfig
@@ -193,6 +193,14 @@ config INIT_SYSTEM_TIME
 	---help---
 		Initialize the system time based on VERSION_BUILD_TIME.
 
+config INIT_SYSTEM_TIME_WITH_MIDNIGHT
+	bool "set system init time to midnight"
+	default n
+	depends on INIT_SYSTEM_TIME
+	---help---
+		When CONFIG_INIT_SYSTEM_TIME is enabled, this config allows to start
+		system time with midnight (0:0:0).
+
 if !RTC
 
 config START_YEAR

--- a/os/kernel/clock/clock_initialize.c
+++ b/os/kernel/clock/clock_initialize.c
@@ -212,20 +212,42 @@ static void clock_inittime(void)
  ****************************************************************************/
 
 #ifdef CONFIG_INIT_SYSTEM_TIME
+#ifdef CONFIG_INIT_SYSTEM_TIME_WITH_MIDNIGHT
+#define SYSTIME_INIT_TIME_FORMAT "%Y-%m-%d"
+#else
+#define SYSTIME_INIT_TIME_FORMAT "%Y-%m-%d %T"
+#endif
+
 static void initialize_system_time(void)
 {
 	struct tm init_time;
 	struct timespec ts;
 	char *ret;
 
-	memset(&init_time, 0, sizeof(struct tm));
-	ret = strptime(CONFIG_VERSION_BUILD_TIME, "%Y-%m-%d %T", &init_time);
+	/* Initialize the members not used in strptime */
+
+#ifdef CONFIG_INIT_SYSTEM_TIME_WITH_MIDNIGHT
+	init_time.tm_sec = 0;
+	init_time.tm_min = 0;
+	init_time.tm_hour = 0;
+#endif
+	init_time.tm_wday = 0;
+	init_time.tm_yday = 0;
+	init_time.tm_isdst = 0;
+
+	/* Get build date */
+
+	ret = strptime(CONFIG_VERSION_BUILD_TIME, SYSTIME_INIT_TIME_FORMAT, &init_time);
 	if (ret == NULL) {
 		return;
 	}
 
+	/* Convert struct tm to struct timespec */
+
 	ts.tv_sec = mktime(&init_time);
 	ts.tv_nsec = 0;
+
+	/* Set system init time for rtc */
 
 	(void)up_rtc_settime(&ts);
 }


### PR DESCRIPTION
New config - CONFIG_INIT_SYSTEM_TIME_WITH_MIDNIGHT - sets system init time
to midnight. It's the same day regardless of this new config.
This is available with CONFIG_INIT_SYSTEM_TIME enabled.

Signed-off-by: sunghan-chang <sh924.chang@samsung.com>