### PR TITLE
fixup! net/lwip: support window scale option

### DIFF
--- a/os/net/lwip/configs/tcp/Kconfig
+++ b/os/net/lwip/configs/tcp/Kconfig
@@ -20,7 +20,6 @@ config NET_TCP_WND
 
 config NET_WND_SCALE
 	bool "Window scale support"
-	range 0 14
 	default n
 	---help---
 		Set LWIP_WND_SCALE to 1 to enable window scaling.
@@ -30,6 +29,7 @@ if NET_WND_SCALE
 config NET_TCP_RCV_SCALE
 	int "Receive window scale support"
 	default 0
+	range 0 14
 	---help---
 		Set TCP_RCV_SCALE to the desired scaling factor (shift count in the range of [0..14]).
 		When LWIP_WND_SCALE is enabled but TCP_RCV_SCALE is 0, we can use a large


### PR DESCRIPTION
CONFIG_NET_WND_SCALE is a bool type so that it can't have a range syntax.
This causes menuconfig warnings as below:

net/lwip/configs/tcp/Kconfig:23:warning: range is only allowed for int or hex symbols
net/lwip/configs/tcp/Kconfig:23:warning: range is invalid

PR #5377 shows that range was for CONFIG_NET_TCP_RCV_SCALE. And description of that config
also says the same range.
This commit moves it to proper config to resolve the warning.

Signed-off-by: sunghan-chang <sh924.chang@samsung.com>