### PR TITLE
os/kernel/binary_manager: Fix missing fd release

### DIFF
--- a/os/kernel/binary_manager/binary_manager_bootparam.c
+++ b/os/kernel/binary_manager/binary_manager_bootparam.c
@@ -125,6 +125,7 @@ int binary_manager_scan_bootparam(binmgr_bpinfo_t *bp_info)
 	bootparam = (char *)kmm_malloc(BOOTPARAM_SIZE);
 	if (!bootparam) {
 		bmdbg("Failed to allocate memory to read bootparam\n");
+		close(fd);
 		return BINMGR_OUT_OF_MEMORY;
 	}
 


### PR DESCRIPTION
Add releasing fd at failure case.

Signed-off-by: sangamanatha <sangam.swami@samsung.com>