### PR TITLE
os/net/lwip/src/api/sockets.c : fixed comment

### DIFF
--- a/os/net/lwip/src/api/sockets.c
+++ b/os/net/lwip/src/api/sockets.c
@@ -1824,7 +1824,7 @@ int lwip_poll(int fd, struct pollfd *fds, bool setup)
 
 /**
  * Callback registered in the netconn layer for each socket-netconn.
- * Processes recvevent (data available) and wakes up tasks waiting for select.
+ * Processes receive events (data available) and wakes up tasks waiting for select.
  */
 static void event_callback(struct netconn *conn, enum netconn_evt evt, u16_t len)
 {


### PR DESCRIPTION
`recvevent` -> `receive events`

I don't think it's appropriate in context. 
Is it right to explain `receive event`"?