### PR TITLE
apps,external,framework : Include stdlib.h to use mm APIs

### DIFF
--- a/apps/system/utils/netcmd_netmon.c
+++ b/apps/system/utils/netcmd_netmon.c
@@ -26,6 +26,7 @@
 #include <stdio.h>
 #include <errno.h>
 #include <stdint.h>
+#include <stdlib.h>
 #include <unistd.h>
 #include <string.h>
 #include <queue.h>

--- a/external/dhcpd/dhcpd_lwip.c
+++ b/external/dhcpd/dhcpd_lwip.c
@@ -59,6 +59,7 @@
 #include <tinyara/config.h>		/* TinyAra configuration */
 #include <stdio.h>
 #include <stdint.h>
+#include <stdlib.h>
 #include <stdbool.h>
 #include <string.h>
 #include <unistd.h>

--- a/framework/src/ble_manager/ble_manager_state.c
+++ b/framework/src/ble_manager/ble_manager_state.c
@@ -17,6 +17,7 @@
  ****************************************************************************/
 #include <tinyara/config.h>
 #include <string.h>
+#include <stdlib.h>
 #include <mqueue.h>
 #include <errno.h>
 #include <unistd.h>

--- a/framework/src/ble_manager/ble_queue.c
+++ b/framework/src/ble_manager/ble_queue.c
@@ -16,6 +16,7 @@
  *
  ****************************************************************************/
 #include <tinyara/config.h>
+#include <stdlib.h>
 #include <errno.h>
 #include "ble_queue.h"
 

--- a/framework/src/wifi_manager/wifi_manager_lwnl_listener.c
+++ b/framework/src/wifi_manager/wifi_manager_lwnl_listener.c
@@ -16,6 +16,7 @@
  *
  ****************************************************************************/
 #include <tinyara/config.h>
+#include <stdlib.h>
 #include <sys/socket.h>
 #include <sys/types.h>
 #include <errno.h>


### PR DESCRIPTION
To use mm APIs like malloc, free and so on, include stdlib.h

Signed-off-by: jeongchanKim <jc_.kim@samsung.com>