### PR TITLE
mm/check_heap_corruption,manage_allocfail : Change dbg to lldbg

### DIFF
--- a/os/drivers/memory/mminfo.c
+++ b/os/drivers/memory/mminfo.c
@@ -141,6 +141,12 @@ static int mminfo_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
 		ret = OK;
 		break;
 #endif
+#ifdef CONFIG_APP_BINARY_SEPARATION
+	case MMINFOIOC_MNG_ALLOCFAIL:
+		/* There is a single heap for user. So start and end indexes of heap are always 0. */
+		mm_manage_alloc_fail(BASE_HEAP, 0, 0, (size_t)arg, USER_HEAP);
+		break;
+#endif
 	default:
 		mdbg("Not supported\n");
 		break;

--- a/os/include/tinyara/fs/ioctl.h
+++ b/os/include/tinyara/fs/ioctl.h
@@ -431,6 +431,7 @@
 
 #define MMINFOIOC_HEAP              _MMINFOIOC(0x0001)
 #define MMINFOIOC_PARSE             _MMINFOIOC(0x0002)
+#define MMINFOIOC_MNG_ALLOCFAIL     _MMINFOIOC(0x0003)
 
 /* Cpuload driver ioctl definitions ************************/
 

--- a/os/include/tinyara/mm/mm.h
+++ b/os/include/tinyara/mm/mm.h
@@ -714,6 +714,9 @@ int mm_check_heap_corruption(struct mm_heap_s *heap);
 
 /* Function to manage the memory allocation failure case. */
 void mm_manage_alloc_fail(struct mm_heap_s *heap, int startidx, int endidx, size_t size, int heap_type);
+#ifdef CONFIG_APP_BINARY_SEPARATION
+void mm_ioctl_alloc_fail(size_t size);
+#endif
 
 #if CONFIG_KMM_NHEAPS > 1
 /**

--- a/os/mm/mm_heap/mm_check_heap_corruption.c
+++ b/os/mm/mm_heap/mm_check_heap_corruption.c
@@ -96,9 +96,9 @@ static void dump_node(struct mm_allocnode_s *node, node_type_t type)
 #endif
 
 	if (type == TYPE_CORRUPTED) {
-		dbg("CORRUPTED NODE: addr = 0x%08x size = %u preceding size = %u\n", node, node->size, MM_PREV_NODE_SIZE(node));
+		lldbg("CORRUPTED NODE: addr = 0x%08x size = %u preceding size = %u\n", node, node->size, MM_PREV_NODE_SIZE(node));
 	} else if (type == TYPE_OVERFLOWED) {
-		dbg("OVERFLOWED NODE: addr = 0x%08x size = %u type = %c\n", node, node->size, IS_ALLOCATED_NODE(node) ? 'A' : 'F');
+		lldbg("OVERFLOWED NODE: addr = 0x%08x size = %u type = %c\n", node, node->size, IS_ALLOCATED_NODE(node) ? 'A' : 'F');
 	}
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
 	pid_t pid = node->pid;
@@ -112,12 +112,12 @@ static void dump_node(struct mm_allocnode_s *node, node_type_t type)
 	}
 #if CONFIG_TASK_NAME_SIZE > 0
 	if (prctl(PR_GET_NAME_BYPID, myname, pid) == OK) {
-		dbg("Node owner pid = %d (%s%s), allocated by code at addr = 0x%08x\n", node->pid, myname, is_stack, node->alloc_call_addr);
+		lldbg("Node owner pid = %d (%s%s), allocated by code at addr = 0x%08x\n", node->pid, myname, is_stack, node->alloc_call_addr);
 	} else {
-		dbg("Node owner pid = %d (Exited Task%s), allocated by code at addr = 0x%08x\n", node->pid, is_stack, node->alloc_call_addr);
+		lldbg("Node owner pid = %d (Exited Task%s), allocated by code at addr = 0x%08x\n", node->pid, is_stack, node->alloc_call_addr);
 	}
 #else
-	dbg("Node owner pid = %d%s, allocated by code at addr = 0x%08x\n", node->pid, is_stack, node->alloc_call_addr);
+	lldbg("Node owner pid = %d%s, allocated by code at addr = 0x%08x\n", node->pid, is_stack, node->alloc_call_addr);
 #endif
 #endif
 }
@@ -173,11 +173,11 @@ int mm_check_heap_corruption(struct mm_heap_s *heap)
 
 		for (; node < heap->mm_heapend[region]; prev = node, node = next, next = (struct mm_allocnode_s *)((char *)next + next->size)) {
 			if (prev && prev->size != MM_PREV_NODE_SIZE(node)) {
-				dbg("#########################################################################################\n");
-				dbg("ERROR: Heap node corruption detected\n");
+				lldbg("#########################################################################################\n");
+				lldbg("ERROR: Heap node corruption detected\n");
 				dump_node(prev, TYPE_OVERFLOWED);
 				dump_node(node, TYPE_CORRUPTED);
-				dbg("#########################################################################################\n");
+				lldbg("#########################################################################################\n");
 				if (!aborted
 #if defined(CONFIG_BUILD_FLAT) || defined(__KERNEL__)
 					&& !up_interrupt_context()
@@ -187,19 +187,19 @@ int mm_check_heap_corruption(struct mm_heap_s *heap)
 				}
 				return -1;
 			} else if (node->size != MM_PREV_NODE_SIZE(next)) {
-				dbg("#########################################################################################\n");
-				dbg("ERROR: Heap node corruption detected.\n");
-				dbg("=========================================================================================\n");
-				dbg("Possible corruption scenario 1:\n");
-				dbg("=========================================================================================\n");
+				lldbg("#########################################################################################\n");
+				lldbg("ERROR: Heap node corruption detected.\n");
+				lldbg("=========================================================================================\n");
+				lldbg("Possible corruption scenario 1:\n");
+				lldbg("=========================================================================================\n");
 				dump_node(prev, TYPE_OVERFLOWED);
 				dump_node(node, TYPE_CORRUPTED);
-				dbg("=========================================================================================\n");
-				dbg("Possible corruption scenario 2:\n");
-				dbg("=========================================================================================\n");
+				lldbg("=========================================================================================\n");
+				lldbg("Possible corruption scenario 2:\n");
+				lldbg("=========================================================================================\n");
 				dump_node(node, TYPE_OVERFLOWED);
 				dump_node(next, TYPE_CORRUPTED);
-				dbg("#########################################################################################\n");
+				lldbg("#########################################################################################\n");
 				if (!aborted
 #if defined(CONFIG_BUILD_FLAT) || defined(__KERNEL__)
 					&& !up_interrupt_context()
@@ -210,13 +210,13 @@ int mm_check_heap_corruption(struct mm_heap_s *heap)
 				return -1;
 			} else if (IS_FREE_NODE(node)) {
 				if ((((struct mm_freenode_s *)node)->blink && ((struct mm_freenode_s *)node)->blink->flink != ((struct mm_freenode_s *)node))) {
-					dbg("#########################################################################################\n");
-					dbg("ERROR: Heap node corruption detected in free node list\n");
+					lldbg("#########################################################################################\n");
+					lldbg("ERROR: Heap node corruption detected in free node list\n");
 					dump_node(prev, TYPE_OVERFLOWED);
 					dump_node(node, TYPE_CORRUPTED);
-					dbg("Corrupted node blink(0x%08x) and prev node flink(0x%08x) do not match\n", ((struct mm_freenode_s *)node)->blink,
+					lldbg("Corrupted node blink(0x%08x) and prev node flink(0x%08x) do not match\n", ((struct mm_freenode_s *)node)->blink,
 							((struct mm_freenode_s *)node)->blink->flink);
-					dbg("#########################################################################################\n");
+					lldbg("#########################################################################################\n");
 					if (!aborted
 #if defined(CONFIG_BUILD_FLAT) || defined(__KERNEL__)
 						&& !up_interrupt_context()
@@ -226,13 +226,13 @@ int mm_check_heap_corruption(struct mm_heap_s *heap)
 					}
 					return -1;
 				} else if (((struct mm_freenode_s *)node)->flink && ((struct mm_freenode_s *)node)->flink->blink != ((struct mm_freenode_s *)node)) {
-					dbg("#########################################################################################\n");
-					dbg("ERROR: Heap node corruption detected in free node list\n");
+					lldbg("#########################################################################################\n");
+					lldbg("ERROR: Heap node corruption detected in free node list\n");
 					dump_node(prev, TYPE_OVERFLOWED);
 					dump_node(node, TYPE_CORRUPTED);
-					dbg("Corrupted node flink(0x%08x) and next node blink(0x%08x) do not match\n", ((struct mm_freenode_s *)node)->flink,
+					lldbg("Corrupted node flink(0x%08x) and next node blink(0x%08x) do not match\n", ((struct mm_freenode_s *)node)->flink,
 							((struct mm_freenode_s *)node)->flink->blink);
-					dbg("#########################################################################################\n");
+					lldbg("#########################################################################################\n");
 					if (!aborted
 #if defined(CONFIG_BUILD_FLAT) || defined(__KERNEL__)
 						 && !up_interrupt_context()

--- a/os/mm/umm_heap/umm_calloc.c
+++ b/os/mm/umm_heap/umm_calloc.c
@@ -138,7 +138,11 @@ static void *heap_calloc(size_t n, size_t elem_size, int s, int e, size_t caller
 			return ret;
 		}
 	}
+#ifdef CONFIG_APP_BINARY_SEPARATION
+	mm_ioctl_alloc_fail(n * elem_size);
+#else
 	mm_manage_alloc_fail(BASE_HEAP, s, e, n * elem_size, USER_HEAP);
+#endif
 	return NULL;
 }
 

--- a/os/mm/umm_heap/umm_malloc.c
+++ b/os/mm/umm_heap/umm_malloc.c
@@ -160,8 +160,11 @@ static void *heap_malloc(size_t size, int s, int e, size_t caller_retaddr)
 			return ret;
 		}
 	}
-
+#ifdef CONFIG_APP_BINARY_SEPARATION
+	mm_ioctl_alloc_fail(size);
+#else
 	mm_manage_alloc_fail(BASE_HEAP, s, e, size, USER_HEAP);
+#endif
 	return NULL;
 }
 #endif

--- a/os/mm/umm_heap/umm_memalign.c
+++ b/os/mm/umm_heap/umm_memalign.c
@@ -150,7 +150,11 @@ FAR void *memalign(size_t alignment, size_t size)
 		}
 	}
 
+#ifdef CONFIG_APP_BINARY_SEPARATION
+	mm_ioctl_alloc_fail(size);
+#else
 	mm_manage_alloc_fail(BASE_HEAP, HEAP_START_IDX, HEAP_END_IDX, size, USER_HEAP);
+#endif
 	return NULL;
 }
 

--- a/os/mm/umm_heap/umm_realloc.c
+++ b/os/mm/umm_heap/umm_realloc.c
@@ -176,6 +176,10 @@ FAR void *realloc(FAR void *oldmem, size_t size)
 		}
 	}
 
+#ifdef CONFIG_APP_BINARY_SEPARATION
+	mm_ioctl_alloc_fail(size);
+#else
 	mm_manage_alloc_fail(BASE_HEAP, HEAP_START_IDX, HEAP_END_IDX, size, USER_HEAP);
+#endif
 	return NULL;
 }

--- a/os/mm/umm_heap/umm_zalloc.c
+++ b/os/mm/umm_heap/umm_zalloc.c
@@ -140,7 +140,11 @@ static void *heap_zalloc(size_t size, int s, int e, size_t caller_retaddr)
 		}
 	}
 
+#ifdef CONFIG_APP_BINARY_SEPARATION
+	mm_ioctl_alloc_fail(size);
+#else
 	mm_manage_alloc_fail(BASE_HEAP, s, e, size, USER_HEAP);
+#endif
 	return NULL;
 }
 #endif


### PR DESCRIPTION
In mm_check_heap_corruption,mm_manage_allocfail, information is printed through dbg. So if called from up_assert, logs can be mixed.

Signed-off-by: jeongchanKim <jc_.kim@samsung.com>