### PR TITLE
wqueue : Remove the condition of __KERNEL__

### DIFF
--- a/os/arch/arm/src/armv7-m/up_assert.c
+++ b/os/arch/arm/src/armv7-m/up_assert.c
@@ -102,8 +102,10 @@
 #include "binary_manager/binary_manager.h"
 #endif
 
-#if defined(CONFIG_DEBUG_WORKQUEUE) && defined(__KERNEL__)
+#if defined(CONFIG_DEBUG_WORKQUEUE)
+#if defined(CONFIG_BUILD_FLAT) || (defined(CONFIG_BUILD_PROTECTED) && defined(__KERNEL__))
 #include <tinyara/wqueue.h>
+#endif
 #endif
 
 #include "irq/irq.h"
@@ -507,11 +509,13 @@ void up_assert(const uint8_t *filename, int lineno)
 	lldbg("Assertion failed at file:%s line: %d\n", filename, lineno);
 #endif
 
-#if defined(CONFIG_DEBUG_WORKQUEUE) && defined(__KERNEL__)
+#if defined(CONFIG_DEBUG_WORKQUEUE)
+#if defined(CONFIG_BUILD_FLAT) || (defined(CONFIG_BUILD_PROTECTED) && defined(__KERNEL__))
 	if (IS_HPWORK || IS_LPWORK) {
 		lldbg("Running work function is %x.\n", work_get_current());
 	}
-#endif /* defined(CONFIG_DEBUG_WORKQUEUE) && defined(__KERNEL__) */
+#endif
+#endif /* defined(CONFIG_DEBUG_WORKQUEUE) */
 
 	up_dumpstate();
 

--- a/os/arch/arm/src/armv7-r/arm_assert.c
+++ b/os/arch/arm/src/armv7-r/arm_assert.c
@@ -77,8 +77,10 @@
 #include <string.h>
 #include <assert.h>
 #include <debug.h>
-#if defined(CONFIG_DEBUG_WORKQUEUE) && defined(__KERNEL__)
+#if defined(CONFIG_DEBUG_WORKQUEUE)
+#if defined(CONFIG_BUILD_FLAT) || (defined(CONFIG_BUILD_PROTECTED) && defined(__KERNEL__))
 #include <tinyara/wqueue.h>
+#endif
 #endif
 
 #include <tinyara/irq.h>
@@ -971,11 +973,13 @@ void up_assert(const uint8_t *filename, int lineno)
 	lldbg("Assertion failed at file:%s line: %d\n", filename, lineno);
 #endif
 
-#if defined(CONFIG_DEBUG_WORKQUEUE) && defined(__KERNEL__)
+#if defined(CONFIG_DEBUG_WORKQUEUE)
+#if defined(CONFIG_BUILD_FLAT) || (defined(CONFIG_BUILD_PROTECTED) && defined(__KERNEL__))
 	if (IS_HPWORK || IS_LPWORK) {
 		lldbg("Running work function is %x.\n", work_get_current());
 	}
-#endif /* defined(CONFIG_DEBUG_WORKQUEUE) && defined(__KERNEL__) */
+#endif
+#endif /* defined(CONFIG_DEBUG_WORKQUEUE) */
 
 	up_dumpstate();
 

--- a/os/arch/arm/src/armv8-m/up_assert.c
+++ b/os/arch/arm/src/armv8-m/up_assert.c
@@ -107,8 +107,10 @@
 #include "semaphore/semaphore.h"
 #include "binary_manager/binary_manager.h"
 #endif
-#if defined(CONFIG_DEBUG_WORKQUEUE) && defined(__KERNEL__)
+#if defined(CONFIG_DEBUG_WORKQUEUE)
+#if defined(CONFIG_BUILD_FLAT) || (defined(CONFIG_BUILD_PROTECTED) && defined(__KERNEL__))
 #include <tinyara/wqueue.h>
+#endif
 #endif
 #include "irq/irq.h"
 
@@ -523,11 +525,13 @@ void up_assert(const uint8_t *filename, int lineno)
 	lldbg("Assertion failed at file:%s line: %d\n", filename, lineno);
 #endif
 
-#if defined(CONFIG_DEBUG_WORKQUEUE) && defined(__KERNEL__)
+#if defined(CONFIG_DEBUG_WORKQUEUE)
+#if defined(CONFIG_BUILD_FLAT) || (defined(CONFIG_BUILD_PROTECTED) && defined(__KERNEL__))
 	if (IS_HPWORK || IS_LPWORK) {
 		lldbg("Running work function is %x.\n", work_get_current());
 	}
-#endif /* defined(CONFIG_DEBUG_WORKQUEUE) && defined(__KERNEL__) */
+#endif
+#endif /* defined(CONFIG_DEBUG_WORKQUEUE) */
 
 	up_dumpstate();
 

--- a/os/include/tinyara/wqueue.h
+++ b/os/include/tinyara/wqueue.h
@@ -497,7 +497,8 @@ void lpwork_restorepriority(uint8_t reqprio);
  * Description:
  *   Get the current running worker
  ****************************************************************************/
-#if defined(CONFIG_DEBUG_WORKQUEUE) && defined(__KERNEL__)
+#if defined(CONFIG_DEBUG_WORKQUEUE)
+#if defined(CONFIG_BUILD_FLAT) || (defined(CONFIG_BUILD_PROTECTED) && defined(__KERNEL__))
 worker_t work_get_current(void);
 
 #ifdef CONFIG_SCHED_HPWORK
@@ -510,6 +511,7 @@ worker_t work_get_current(void);
 #define IS_LPWORK (strncmp(this_task()->name, LPWORKNAME, sizeof(HPWORKNAME)) == 0)
 #else
 #define IS_LPWORK (false)
+#endif
 #endif
 #endif
 

--- a/os/wqueue/work_process.c
+++ b/os/wqueue/work_process.c
@@ -83,8 +83,10 @@
 /****************************************************************************
  * Private Data
  ****************************************************************************/
-#if defined(CONFIG_DEBUG_WORKQUEUE) && defined(__KERNEL__)
+#if defined(CONFIG_DEBUG_WORKQUEUE)
+#if defined(CONFIG_BUILD_FLAT) || (defined(CONFIG_BUILD_PROTECTED) && defined(__KERNEL__))
 static worker_t cur_worker;
+#endif
 #endif
 
 /****************************************************************************
@@ -94,11 +96,13 @@ static worker_t cur_worker;
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
-#if defined(CONFIG_DEBUG_WORKQUEUE) && defined(__KERNEL__)
+#if defined(CONFIG_DEBUG_WORKQUEUE)
+#if defined(CONFIG_BUILD_FLAT) || (defined(CONFIG_BUILD_PROTECTED) && defined(__KERNEL__))
 worker_t work_get_current(void)
 {
 	return cur_worker;
 }
+#endif
 #endif
 
 /****************************************************************************
@@ -191,8 +195,10 @@ void work_process(FAR struct wqueue_s *wqueue, int wndx)
 #else
 				irqrestore(flags);
 #endif
-#if defined(CONFIG_DEBUG_WORKQUEUE) && defined(__KERNEL__)
+#if defined(CONFIG_DEBUG_WORKQUEUE)
+#if defined(CONFIG_BUILD_FLAT) || (defined(CONFIG_BUILD_PROTECTED) && defined(__KERNEL__))
 				cur_worker = worker;
+#endif
 #endif
 				worker(arg);
 


### PR DESCRIPTION
To build the work queue debug log from flat build, remove #ifdef __KERNEL__.

Signed-off-by: jeongchanKim <jc_.kim@samsung.com>