### PR TITLE
os/tools: add build_test path in .gitignore

### DIFF
--- a/os/tools/.gitignore
+++ b/os/tools/.gitignore
@@ -11,3 +11,4 @@
 /*.dSYM
 /.k2h-body.dat
 /.k2h-apndx.dat
+/build_test/


### PR DESCRIPTION
When build test script meets build error, it leaves build logs in build_test folder.
Because it should not be a modification in git, this commit adds build_test path
in .gitignore.
This will remove untracked files in git status like below.

Untracked files:
  (use "git add <file>..." to include in what will be committed)

	tools/build_test/

Signed-off-by: sunghan-chang <sh924.chang@samsung.com>