### PR TITLE
os/arch/arm: Fix build errors due to nested irq stack

### DIFF
--- a/os/arch/Kconfig
+++ b/os/arch/Kconfig
@@ -587,7 +587,7 @@ config ARCH_INTERRUPTSTACK
 
 config ARCH_NESTED_IRQ_STACK_SIZE
 	int "Nested IRQ secondary stack size"
-	depends on ARCH_HAVE_INTERRUPTSTACK
+	depends on ARCH_HAVE_INTERRUPTSTACK && ARCH_ARMV8M_FAMILY
 	default 512
 	---help---
 		This is an additional stack which will be used only when nested irq

--- a/os/arch/arm/src/armv8-m/up_assert.c
+++ b/os/arch/arm/src/armv8-m/up_assert.c
@@ -266,19 +266,22 @@ static void up_dumpstate(void)
 	uint32_t istackbase;
 	uint32_t istacksize;
 #endif
+#ifdef CONFIG_ARCH_NESTED_IRQ_STACK_SIZE
 	uint32_t nestirqstkbase;
 	uint32_t nestirqstksize;
+#endif
 
 	/* Get the limits on the user stack memory */
 
 	ustackbase = (uint32_t)rtcb->adj_stack_ptr;
 	ustacksize = (uint32_t)rtcb->adj_stack_size;
+	lldbg("sp:     %08x\n", sp);
 
+#ifdef CONFIG_ARCH_NESTED_IRQ_STACK_SIZE
 	/* Get the limits on the nested irq stack */
 	nestirqstkbase = (uint32_t)&g_nestedirqstkbase;
 	nestirqstksize = (CONFIG_ARCH_NESTED_IRQ_STACK_SIZE & ~3);
 
-	lldbg("sp:     %08x\n", sp);
 	lldbg("Nested IRQ stack:\n");
 	lldbg("  base: %08x\n", nestirqstkbase);
 	lldbg("  size: %08x\n", nestirqstksize);
@@ -295,6 +298,7 @@ static void up_dumpstate(void)
 
 		up_stackdump(sp, nestirqstkbase);
 	}
+#endif
 
 	
 #if CONFIG_ARCH_INTERRUPTSTACK > 3

--- a/os/arch/arm/src/common/up_checkstack.c
+++ b/os/arch/arm/src/common/up_checkstack.c
@@ -196,6 +196,7 @@ ssize_t up_check_stack_remain(void)
 	return up_check_tcbstack_remain(this_task());
 }
 
+#ifdef CONFIG_ARCH_NESTED_IRQ_STACK_SIZE
 size_t up_check_nestirqstack(void)
 {
 	return do_stackcheck((uintptr_t)&g_nestedirqstkalloc, (CONFIG_ARCH_NESTED_IRQ_STACK_SIZE & ~3));
@@ -205,6 +206,7 @@ size_t up_check_nestirqstack_remain(void)
 {
 	return (CONFIG_ARCH_NESTED_IRQ_STACK_SIZE & ~3) - up_check_nestirqstack();
 }
+#endif
 
 #if CONFIG_ARCH_INTERRUPTSTACK > 3
 size_t up_check_intstack(void)

--- a/os/arch/arm/src/common/up_initialize.c
+++ b/os/arch/arm/src/common/up_initialize.c
@@ -142,6 +142,7 @@ static inline void up_color_intstack(void)
 #define up_color_intstack()
 #endif
 
+#ifdef CONFIG_ARCH_NESTED_IRQ_STACK_SIZE
 static inline void up_color_nestirqstack(void)
 {
 	uint32_t *ptr = (uint32_t *)&g_nestedirqstkalloc;
@@ -151,6 +152,9 @@ static inline void up_color_nestirqstack(void)
 		*ptr++ = INTSTACK_COLOR;
 	}
 }
+#else
+#define up_color_nestirqstack()
+#endif
 
 /****************************************************************************
  * Public Functions


### PR DESCRIPTION
Nested irq stack is defined only in ARMv8. So, it causes build errors
for other chipsets when used in common code. Fix by adding check for
definition of nested irq stack config.

Signed-off-by: Kishore S N <kishore.sn@samsung.com>