### PR TITLE
os/binfmt: Refractoring binary loader

### DIFF
--- a/os/binfmt/Kconfig
+++ b/os/binfmt/Kconfig
@@ -24,6 +24,7 @@ config PATH_INITIAL
 config BINFMT_LOADABLE
 	bool
 	default n
+	depends on APP_BINARY_SEPARATION
 	---help---
 		Automatically selected if a loadable binary format is selected.
 

--- a/os/binfmt/binfmt_copyargv.c
+++ b/os/binfmt/binfmt_copyargv.c
@@ -100,108 +100,10 @@
 
 int binfmt_copyargv(FAR struct binary_s *bin, FAR char *const *argv)
 {
-#if defined(CONFIG_ARCH_ADDRENV) && defined(CONFIG_BUILD_KERNEL)
-	FAR char *ptr;
-	size_t argvsize;
-	size_t argsize;
-	int nargs;
-	int i;
-
-	/* Get the number of arguments and the size of the argument list */
-
-	bin->argv = (FAR char **)NULL;
-	bin->argbuffer = (FAR char *)NULL;
-
-	if (argv) {
-		argsize = 0;
-		nargs = 0;
-
-		for (i = 0; argv[i]; i++) {
-			/* Increment the size of the allocation with the size of the next string */
-
-			argsize += (strlen(argv[i]) + 1);
-			nargs++;
-
-			/* This is a sanity check to prevent running away with an unterminated
-			 * argv[] list.  MAX_EXEC_ARGS should be sufficiently large that this
-			 * never happens in normal usage.
-			 */
-
-			if (nargs > MAX_EXEC_ARGS) {
-				berr("ERROR: Too many arguments: %lu\n", (unsigned long)argvsize);
-				return -E2BIG;
-			}
-		}
-
-		binfo("args=%d argsize=%lu\n", nargs, (unsigned long)argsize);
-
-		/* Allocate the argv array and an argument buffer */
-
-		if (argsize > 0) {
-			argvsize = (nargs + 1) * sizeof(FAR char *);
-			bin->argbuffer = (FAR char *)kmm_malloc(argvsize + argsize);
-			if (!bin->argbuffer) {
-				berr("ERROR: Failed to allocate the argument buffer\n");
-				return -ENOMEM;
-			}
-
-			/* Copy the argv list */
-
-			bin->argv = (FAR char **)bin->argbuffer;
-			ptr = bin->argbuffer + argvsize;
-			for (i = 0; argv[i]; i++) {
-				bin->argv[i] = ptr;
-				argsize = strlen(argv[i]) + 1;
-				memcpy(ptr, argv[i], argsize);
-				ptr += argsize;
-			}
-
-			/* Terminate the argv[] list */
-
-			bin->argv[i] = (FAR char *)NULL;
-		}
-	}
-
-	return OK;
-
-#else
 	/* Just save the caller's argv pointer */
 
 	bin->argv = argv;
 	return OK;
-#endif
 }
-
-/****************************************************************************
- * Name: binfmt_freeargv
- *
- * Description:
- *   Release the copied argv[] list.
- *
- * Input Parameters:
- *   binp - Load structure
- *
- * Returned Value:
- *   None
- *
- ****************************************************************************/
-
-#if defined(CONFIG_ARCH_ADDRENV) && defined(CONFIG_BUILD_KERNEL)
-void binfmt_freeargv(FAR struct binary_s *binp)
-{
-	/* Is there an allocated argument buffer */
-
-	if (binp->argbuffer) {
-		/* Free the argument buffer */
-
-		kmm_free(binp->argbuffer);
-	}
-
-	/* Nullify the allocated argv[] array and the argument buffer pointers */
-
-	binp->argbuffer = (FAR char *)NULL;
-	binp->argv = (FAR char **)NULL;
-}
-#endif
 
 #endif							/* CONFIG_BINFMT_ENABLE */

--- a/os/binfmt/binfmt_dumpmodule.c
+++ b/os/binfmt/binfmt_dumpmodule.c
@@ -90,21 +90,17 @@ int dump_module(FAR const struct binary_s *bin)
 		berr("  filename:  %s\n", bin->filename);
 		berr("  argv:      %p\n", bin->argv);
 		berr("  entrypt:   %p\n", bin->entrypt);
-		berr("  mapped:    %p size=%d\n", bin->mapped, bin->mapsize);
 #ifdef CONFIG_OPTIMIZE_APP_RELOAD_TIME
-		berr("  text alloc:     %p\n", bin->alloc[ALLOC_TEXT]);
-		berr("  ro alloc:     %p\n", bin->alloc[ALLOC_RO]);
-		berr("  data alloc:     %p\n", bin->alloc[ALLOC_DATA]);
+		berr("  text alloc:     %p\n", bin->sections[BIN_TEXT]);
+		berr("  ro alloc:     %p\n", bin->sections[BIN_RO]);
+		berr("  data alloc:     %p\n", bin->sections[BIN_DATA]);
 #else
-		berr("  start of alloc:     %p\n", bin->alloc[0]);
+		berr("  start of alloc:     %p\n", bin->sections[0]);
 #endif
 #ifdef CONFIG_BINFMT_CONSTRUCTORS
-		berr("  alloc:     %p %p\n", bin->alloc[ALLOC_CTOR], bin->alloc[ALLOC_DTOR]);
+		berr("  alloc:     %p %p\n", bin->sections[BIN_CTOR], bin->sections[BIN_DTOR]);
 		berr("  ctors:     %p nctors=%d\n", bin->ctors, bin->nctors);
 		berr("  dtors:     %p ndtors=%d\n", bin->dtors, bin->ndtors);
-#endif
-#ifdef CONFIG_ARCH_ADDRENV
-		berr("  addrenv:   %p\n", bin->addrenv);
 #endif
 		berr("  stacksize: %d\n", bin->stacksize);
 		berr("  unload:    %p\n", bin->unload);

--- a/os/binfmt/binfmt_exec.c
+++ b/os/binfmt/binfmt_exec.c
@@ -208,7 +208,7 @@ int exec(FAR const char *filename, FAR char *const *argv, FAR const struct symta
 	}
 
 #ifdef CONFIG_DEBUG
-	dbg("%s loaded @ 0x%08x and running with pid = %d\n", bin->filename, bin->alloc[ALLOC_TEXT], pid);
+	dbg("%s loaded @ 0x%08x and running with pid = %d\n", bin->filename, bin->sections[BIN_TEXT], pid);
 #endif
 
 	sched_unlock();

--- a/os/binfmt/elf.c
+++ b/os/binfmt/elf.c
@@ -121,10 +121,14 @@ static void elf_dumploadinfo(FAR struct elf_loadinfo_s *loadinfo)
 	int i;
 
 	binfo("LOAD_INFO:\n");
-	binfo("  textalloc:    %08lx\n", (long)loadinfo->textalloc);
-	binfo("  dataalloc:    %08lx\n", (long)loadinfo->dataalloc);
-	binfo("  textsize:     %ld\n", (long)loadinfo->textsize);
-	binfo("  datasize:     %ld\n", (long)loadinfo->datasize);
+	binfo("  textalloc:    %08lx\n", (long)loadinfo->binp->sections[BIN_TEXT]);
+	binfo("  textsize:     %ld\n", (long)loadinfo->binp->sizes[BIN_TEXT]);
+#ifdef CONFIG_OPTIMIZE_APP_RELOAD_TIME
+	binfo("  roalloc:      %08lx\n", (long)loadinfo->binp->sections[BIN_RO]);
+	binfo("  rosize:       %ld\n", (long)loadinfo->binp->sizes[BIN_RO]);
+#endif
+	binfo("  dataalloc:    %08lx\n", (long)loadinfo->binp->sections[BIN_DATA]);
+	binfo("  datasize:     %ld\n", (long)loadinfo->binp->sizes[BIN_DATA]);
 	binfo("  filelen:      %ld\n", (long)loadinfo->filelen);
 #ifdef CONFIG_BINFMT_CONSTRUCTORS
 	binfo("  ctoralloc:    %08lx\n", (long)loadinfo->ctoralloc);
@@ -182,31 +186,8 @@ static void elf_dumploadinfo(FAR struct elf_loadinfo_s *loadinfo)
 #ifdef CONFIG_ELF_DUMPBUFFER
 static void elf_dumpentrypt(FAR struct binary_s *binp, FAR struct elf_loadinfo_s *loadinfo)
 {
-#ifdef CONFIG_ARCH_ADDRENV
-	int ret;
+	elf_dumpbuffer("Entry code", (FAR const uint8_t *)binp->entrypt, MIN(loadinfo->sizes[BIN_TEXT] - loadinfo->ehdr.e_entry, 512));
 
-	/* If CONFIG_ARCH_ADDRENV=y, then the loaded ELF lies in a virtual address
-	 * space that may not be in place now.  elf_addrenv_select() will
-	 * temporarily instantiate that address space.
-	 */
-
-	ret = elf_addrenv_select(loadinfo);
-	if (ret < 0) {
-		berr("ERROR: elf_addrenv_select() failed: %d\n", ret);
-		return;
-	}
-#endif
-
-	elf_dumpbuffer("Entry code", (FAR const uint8_t *)binp->entrypt, MIN(loadinfo->textsize - loadinfo->ehdr.e_entry, 512));
-
-#ifdef CONFIG_ARCH_ADDRENV
-	/* Restore the original address environment */
-
-	ret = elf_addrenv_restore(loadinfo);
-	if (ret < 0) {
-		berr("ERROR: elf_addrenv_restore() failed: %d\n", ret);
-	}
-#endif
 }
 #else
 #define elf_dumpentrypt(b, l)
@@ -235,13 +216,11 @@ static int elf_loadbinary(FAR struct binary_s *binp)
 	/* Initialize the ELF library to load the program binary. */
 	loadinfo.offset = binp->offset;
 	loadinfo.filelen = binp->filelen;
-#ifdef CONFIG_APP_BINARY_SEPARATION
 	loadinfo.binp = binp;
-#endif
 
 	ret = elf_init(binp->filename, &loadinfo);
-	elf_dumploadinfo(&loadinfo);
 	if (ret != 0) {
+		elf_dumploadinfo(&loadinfo);
 		berr("Failed to initialize for load of ELF program: %d\n", ret);
 		goto errout;
 	}
@@ -263,48 +242,16 @@ static int elf_loadbinary(FAR struct binary_s *binp)
 		goto errout_with_load;
 	}
 
-	/* Return the load information */
 
-	binp->entrypt = (main_t)(loadinfo.textalloc + loadinfo.ehdr.e_entry);
+	binp->entrypt = (main_t)((uint32_t)loadinfo.binp->sections[BIN_TEXT] + loadinfo.ehdr.e_entry);
 	if (binp->stacksize == 0) {
 		binp->stacksize = CONFIG_ELF_STACKSIZE;
 	}
 
-	/* Add the ELF allocation to the alloc[] only if there is no address
-	 * environment.  If there is an address environment, it will automatically
-	 * be freed when the function exits
-	 *
-	 * REVISIT:  If the module is loaded then unloaded, wouldn't this cause
-	 * a memory leak?
-	 */
-
-#ifdef CONFIG_ARCH_ADDRENV
-	/* Save the address environment in the binfmt structure.  This will be
-	 * needed when the module is executed.
-	 */
-
-	up_addrenv_clone(&loadinfo.addrenv, &binp->addrenv);
-#else
-	binp->alloc[ALLOC_TEXT] = (FAR void *)loadinfo.textalloc;
-	binp->textsize = loadinfo.textsize;
 #ifdef CONFIG_BINFMT_CONSTRUCTORS
-	binp->alloc[ALLOC_CTOR] = loadinfo.ctoralloc;
-	binp->alloc[ALLOC_DTOR] = loadinfo.dtoralloc;
+	binp->sections[BIN_CTOR] = loadinfo.ctoralloc;
+	binp->sections[BIN_DTOR] = loadinfo.dtoralloc;
 #endif
-#endif
-
-#ifdef CONFIG_OPTIMIZE_APP_RELOAD_TIME
-	binp->alloc[ALLOC_RO] = (FAR void *)loadinfo.roalloc;
-	binp->alloc[ALLOC_DATA] = (FAR void *)loadinfo.dataalloc;
-	binp->rosize = loadinfo.rosize;
-	/* loadinfo.datasize includes the size of data and bss sections.
-	 * But, binp->datasize is used to backup the data section as
-	 * part of RO region. So, we subtract bss size from loadinfo.datasize
-	 * to obtain the size of just the data backup.
-	 */
-	binp->datasize = loadinfo.datasize - binp->bsssize;
-#endif
-	binp->datastart = loadinfo.dataalloc;
 
 #ifdef CONFIG_BINFMT_CONSTRUCTORS
 	/* Save information about constructors and destructors. */

--- a/os/binfmt/libelf/libelf.h
+++ b/os/binfmt/libelf/libelf.h
@@ -336,55 +336,13 @@ int elf_loaddtors(FAR struct elf_loadinfo_s *loadinfo);
  *
  * Input Parameters:
  *   loadinfo - Load state information
- *   textsize - The size (in bytes) of the .text address environment needed
- *     for the ELF image (read/execute).
- *   datasize - The size (in bytes) of the .bss/.data address environment
- *     needed for the ELF image (read/write).
- *   heapsize - The initial size (in bytes) of the heap address environment
- *     needed by the task.  This region may be read/write only.
  *
  * Returned Value:
  *   Zero (OK) on success; a negated errno value on failure.
  *
  ****************************************************************************/
 
-int elf_addrenv_alloc(FAR struct elf_loadinfo_s *loadinfo, size_t textsize, size_t datasize, size_t heapsize);
-
-/****************************************************************************
- * Name: elf_addrenv_select
- *
- * Description:
- *   Temporarily select the task's address environment.
- *
- * Input Parameters:
- *   loadinfo - Load state information
- *
- * Returned Value:
- *   Zero (OK) on success; a negated errno value on failure.
- *
- ****************************************************************************/
-
-#ifdef CONFIG_ARCH_ADDRENV
-#define elf_addrenv_select(l) up_addrenv_select(&(l)->addrenv, &(l)->oldenv)
-#endif
-
-/****************************************************************************
- * Name: elf_addrenv_restore
- *
- * Description:
- *   Restore the address environment before elf_addrenv_select() was called..
- *
- * Input Parameters:
- *   loadinfo - Load state information
- *
- * Returned Value:
- *   Zero (OK) on success; a negated errno value on failure.
- *
- ****************************************************************************/
-
-#ifdef CONFIG_ARCH_ADDRENV
-#define elf_addrenv_restore(l) up_addrenv_restore(&(l)->oldenv)
-#endif
+int elf_addrenv_alloc(FAR struct elf_loadinfo_s *loadinfo);
 
 /****************************************************************************
  * Name: elf_addrenv_free

--- a/os/binfmt/libelf/libelf_addrenv.c
+++ b/os/binfmt/libelf/libelf_addrenv.c
@@ -61,9 +61,7 @@
 
 #include <tinyara/arch.h>
 #include <tinyara/kmalloc.h>
-#ifdef CONFIG_APP_BINARY_SEPARATION
 #include <tinyara/mm/mm.h>
-#endif
 #include <tinyara/mpu.h>
 #include "libelf.h"
 
@@ -88,8 +86,8 @@
 #ifdef CONFIG_OPTIMIZE_APP_RELOAD_TIME
 static int allocateregions(FAR struct elf_loadinfo_s *loadinfo)
 {
-	size_t sizes[MPU_NUM_REGIONS] = {loadinfo->textsize, loadinfo->rosize, loadinfo->binp->ramsize};
-	uintptr_t *allocs[MPU_NUM_REGIONS] = {&loadinfo->textalloc, &loadinfo->roalloc, &loadinfo->dataalloc};
+	size_t sizes[MPU_NUM_REGIONS] = {loadinfo->binp->sizes[BIN_TEXT], loadinfo->binp->sizes[BIN_RO], loadinfo->binp->ramsize};
+	uintptr_t *allocs[MPU_NUM_REGIONS] = {&loadinfo->binp->sections[BIN_TEXT], &loadinfo->binp->sections[BIN_RO], &loadinfo->binp->sections[BIN_DATA]};
 	int count = 0;
 	int i;
 	for (i = 0; i < CONFIG_KMM_REGIONS; i++) {
@@ -180,87 +178,29 @@ uint8_t mpu_log2regionceil(uintptr_t base, size_t size);
  * Name: elf_addrenv_alloc
  *
  * Description:
- *   Allocate memory for the ELF image (textalloc and dataalloc). If
- *   CONFIG_ARCH_ADDRENV=n, textalloc will be allocated using kmm_zalloc() and
- *   dataalloc will be a offset from textalloc.  If CONFIG_ARCH_ADDRENV-y, then
- *   textalloc and dataalloc will be allocated using up_addrenv_create().  In
- *   either case, there will be a unique instance of textalloc and dataalloc
- *   (and stack) for each instance of a process.
+ *   Allocate memory for the ELF sections.
  *
  * Input Parameters:
  *   loadinfo - Load state information
- *   textsize - The size (in bytes) of the .text address environment needed
- *     for the ELF image (read/execute).
- *   datasize - The size (in bytes) of the .bss/.data address environment
- *     needed for the ELF image (read/write).
- *   heapsize - The initial size (in bytes) of the heap address environment
- *     needed by the task.  This region may be read/write only.
  *
  * Returned Value:
  *   Zero (OK) on success; a negated errno value on failure.
  *
  ****************************************************************************/
 
-int elf_addrenv_alloc(FAR struct elf_loadinfo_s *loadinfo, size_t textsize, size_t datasize, size_t heapsize)
+int elf_addrenv_alloc(FAR struct elf_loadinfo_s *loadinfo)
 {
-#ifdef CONFIG_ARCH_ADDRENV
-	FAR void *vtext;
-	FAR void *vdata;
-	int ret;
-
-	/* Create an address environment for the new ELF task */
-
-	ret = up_addrenv_create(textsize, datasize, heapsize, &loadinfo->addrenv);
-	if (ret < 0) {
-		berr("ERROR: up_addrenv_create failed: %d\n", ret);
-		return ret;
-	}
-
-	/* Get the virtual address associated with the start of the address
-	 * environment.  This is the base address that we will need to use to
-	 * access the ELF image (but only if the address environment has been
-	 * selected.
-	 */
-
-	ret = up_addrenv_vtext(&loadinfo->addrenv, &vtext);
-	if (ret < 0) {
-		berr("ERROR: up_addrenv_vtext failed: %d\n", ret);
-		return ret;
-	}
-
-	ret = up_addrenv_vdata(&loadinfo->addrenv, textsize, &vdata);
-	if (ret < 0) {
-		berr("ERROR: up_addrenv_vdata failed: %d\n", ret);
-		return ret;
-	}
-
-	loadinfo->textalloc = (uintptr_t) vtext;
-	loadinfo->dataalloc = (uintptr_t) vdata;
-	return OK;
-#else
 	/* Allocate memory to hold the ELF image */
 
-#ifdef CONFIG_APP_BINARY_SEPARATION
 #ifdef CONFIG_OPTIMIZE_APP_RELOAD_TIME
-	uint32_t datamemsize = loadinfo->datasize + loadinfo->binp->ramsize;
-	uint32_t rosize = loadinfo->rosize;
+	/* Total size allocated for data section should include data, bss and heap */
+	uint32_t datamemsize = loadinfo->binp->sizes[BIN_DATA] + loadinfo->binp->sizes[BIN_BSS] + loadinfo->binp->ramsize;
+	uint32_t rosize = loadinfo->binp->sizes[BIN_RO];
+	loadinfo->binp->sizes[BIN_RO] += loadinfo->binp->sizes[BIN_DATA];
 
-	/* loadinfo->datasize contains the size of both data and bss sections.
-	 * But we need to backup only the data section in the RO region. So,
-	 * we need to extend the rosize by just the data section size only. Hence,
-	 * we are subtracting bsssize from loadinfo->datasize.
-	 */
-	loadinfo->rosize += loadinfo->datasize - loadinfo->binp->bsssize;
-
-#ifdef CONFIG_ARMV7M_MPU
-	/* ARMV7M requires MPU region size to be a power of two */
-	loadinfo->textsize = 1 << mpu_log2regionceil(0, loadinfo->textsize);
-	loadinfo->rosize = 1 << mpu_log2regionceil(0, loadinfo->rosize);
-	datamemsize = 1 << mpu_log2regionceil(0, datamemsize);
-	loadinfo->binp->ramsize = datamemsize;
-#elif CONFIG_ARMV8M_MPU
-	loadinfo->textsize = MPU_ALIGN_UP(loadinfo->textsize);
-	loadinfo->rosize = MPU_ALIGN_UP(loadinfo->rosize);
+#if defined(CONFIG_ARMV7M_MPU) || defined(CONFIG_ARMV8M_MPU)
+	loadinfo->binp->sizes[BIN_TEXT] = MPU_ALIGN_UP(loadinfo->binp->sizes[BIN_TEXT]);
+	loadinfo->binp->sizes[BIN_RO] = MPU_ALIGN_UP(loadinfo->binp->sizes[BIN_RO]);
 	datamemsize = MPU_ALIGN_UP(datamemsize);
 	loadinfo->binp->ramsize = datamemsize;
 #else
@@ -272,12 +212,13 @@ int elf_addrenv_alloc(FAR struct elf_loadinfo_s *loadinfo, size_t textsize, size
 		return -ENOMEM;
 	}
 
-	loadinfo->binp->data_backup = loadinfo->roalloc + rosize;
-	loadinfo->binp->uheap_size = datamemsize - loadinfo->datasize - sizeof(struct mm_heap_s);
+	/* Data section back up will be stored at the end of RO section. Adjust the size accordingly */
+	loadinfo->binp->data_backup = loadinfo->binp->sections[BIN_RO] + rosize;
+	loadinfo->binp->sizes[BIN_HEAP] = datamemsize - loadinfo->binp->sizes[BIN_DATA] - loadinfo->binp->sizes[BIN_BSS] - sizeof(struct mm_heap_s);
 #else
 	/* ramsize may be zero in case of loading library since we dont have header for library */
 	if (loadinfo->binp->ramsize == 0) {
-		loadinfo->binp->ramsize = loadinfo->textsize + loadinfo->datasize;
+		loadinfo->binp->ramsize = loadinfo->binp->sizes[BIN_TEXT] + loadinfo->binp->sizes[BIN_DATA] + loadinfo->binp->sizes[BIN_BSS];
 	}
 
 	/* Allocate the RAM partition to load the app into */
@@ -285,7 +226,7 @@ int elf_addrenv_alloc(FAR struct elf_loadinfo_s *loadinfo, size_t textsize, size
 	loadinfo->binp->ramstart = kmm_memalign_at(CONFIG_HEAP_INDEX_LOADED_APP, loadinfo->binp->ramsize, loadinfo->binp->ramsize);
 #elif CONFIG_ARMV8M_MPU
 	loadinfo->binp->ramsize = MPU_ALIGN_UP(loadinfo->binp->ramsize);
-	loadinfo->binp->ramstart = kmm_memalign_at(CONFIG_HEAP_INDEX_LOADED_APP, MPU_ALIGNMENT_BYTES, loadinfo->binp->ramsize);
+	loadinfo->binp->ramstart = (uint32_t)kmm_memalign_at(CONFIG_HEAP_INDEX_LOADED_APP, MPU_ALIGNMENT_BYTES, loadinfo->binp->ramsize);
 #else
 #error "Unknown MPU version. Expected either ARMV7M or ARMV8M"
 #endif
@@ -295,34 +236,34 @@ int elf_addrenv_alloc(FAR struct elf_loadinfo_s *loadinfo, size_t textsize, size
 		return -ENOMEM;
 	}
 
-	loadinfo->textalloc = loadinfo->binp->ramstart;
-	loadinfo->dataalloc = loadinfo->textalloc + loadinfo->textsize;
-	loadinfo->binp->uheap_size = loadinfo->binp->ramsize - (loadinfo->textsize + loadinfo->datasize) - sizeof(struct mm_heap_s);
+	loadinfo->binp->sections[BIN_TEXT] = loadinfo->binp->ramstart;
+	loadinfo->binp->sections[BIN_DATA] = loadinfo->binp->sections[BIN_TEXT] + loadinfo->binp->sizes[BIN_TEXT];
+	loadinfo->binp->sizes[BIN_HEAP] = loadinfo->binp->ramsize 
+					- (loadinfo->binp->sizes[BIN_TEXT] + loadinfo->binp->sizes[BIN_DATA] + loadinfo->binp->sizes[BIN_BSS]) 
+					- sizeof(struct mm_heap_s);
 #endif
-	loadinfo->binp->heapstart = loadinfo->dataalloc + loadinfo->datasize;
-#else
-	loadinfo->textalloc = (uintptr_t)kumm_malloc(textsize + datasize);
-#endif
-	if (!loadinfo->textalloc) {
-		berr("ERROR: Failed to allocate text section (size = %u)\n", textsize);
+	loadinfo->binp->sections[BIN_HEAP] = loadinfo->binp->sections[BIN_DATA] + loadinfo->binp->sizes[BIN_DATA] + loadinfo->binp->sizes[BIN_BSS];
+
+	loadinfo->binp->sections[BIN_BSS] = loadinfo->binp->sections[BIN_DATA] + loadinfo->binp->sizes[BIN_DATA];
+	memset(loadinfo->binp->sections[BIN_BSS], 0, loadinfo->binp->sizes[BIN_BSS]);
+
+	if (!loadinfo->binp->sections[BIN_TEXT]) {
+		berr("ERROR: Failed to allocate text section (size = %u)\n", binp->sizes[BIN_TEXT]);
 		return -ENOMEM;
 	}
 
-#ifdef CONFIG_APP_BINARY_SEPARATION
-	if (!loadinfo->dataalloc) {
-		berr("ERROR: Failed to allocate data section (size = %u)\n", datasize);
+	if (!loadinfo->binp->sections[BIN_DATA]) {
+		berr("ERROR: Failed to allocate data section (size = %u)\n", loadinfo->binp->ramsize);
 		return -ENOMEM;
 	}
 
 #ifdef CONFIG_OPTIMIZE_APP_RELOAD_TIME
-	if (!loadinfo->roalloc) {
-		berr("ERROR: Failed to allocate ro section (size = %u)\n", loadinfo->rosize);
+	if (!loadinfo->binp->sections[BIN_RO]) {
+		berr("ERROR: Failed to allocate ro section (size = %u)\n", loadinfo->binp->sizes[BIN_RO]);
 		return -ENOMEM;
 	}
 #endif
-#endif
 	return OK;
-#endif
 }
 
 /****************************************************************************
@@ -345,29 +286,4 @@ int elf_addrenv_alloc(FAR struct elf_loadinfo_s *loadinfo, size_t textsize, size
 
 void elf_addrenv_free(FAR struct elf_loadinfo_s *loadinfo)
 {
-#ifdef CONFIG_ARCH_ADDRENV
-	int ret;
-
-	/* Free the address environment */
-
-	ret = up_addrenv_destroy(&loadinfo->addrenv);
-	if (ret < 0) {
-		berr("ERROR: up_addrenv_destroy failed: %d\n", ret);
-	}
-#else
-	/* If there is an allocation for the ELF image, free it */
-
-#ifndef CONFIG_APP_BINARY_SEPARATION
-	if (loadinfo->textalloc != 0) {
-		kumm_free((FAR void *)loadinfo->textalloc);
-	}
-#endif
-#endif
-
-	/* Clear out all indications of the allocated address environment */
-
-	loadinfo->textalloc = 0;
-	loadinfo->dataalloc = 0;
-	loadinfo->textsize = 0;
-	loadinfo->datasize = 0;
 }

--- a/os/binfmt/libelf/libelf_read.c
+++ b/os/binfmt/libelf/libelf_read.c
@@ -117,10 +117,7 @@ static inline void elf_dumpreaddata(FAR char *buffer, int buflen)
  *
  * Description:
  *   Read 'readsize' bytes from the object file at 'offset'.  The data is
- *   read into 'buffer.' If 'buffer' is part of the ELF address environment,
- *   then the caller is responsibile for assuring that that address
- *   environment is in place before calling this function (i.e., that
- *   elf_addrenv_select() has been called if CONFIG_ARCH_ADDRENV=y).
+ *   read into 'buffer'.
  *
  * Returned Value:
  *   0 (OK) is returned on success and a negated errno is returned on

--- a/os/binfmt/libelf/libelf_sections.c
+++ b/os/binfmt/libelf/libelf_sections.c
@@ -188,9 +188,9 @@ static inline int elf_sectname(FAR struct elf_loadinfo_s *loadinfo, FAR const El
 #ifdef CONFIG_BINFMT_SECTION_UNIFIED_MEMORY
 void *elf_find_start_section_addr(struct binary_s *binp)
 {
-	int text_addr = (int)binp->alloc[ALLOC_TEXT];
-	int ro_addr = (int)binp->alloc[ALLOC_DATA];
-	int data_addr = (int)binp->alloc[ALLOC_DATA];
+	int text_addr = (int)binp->sections[BIN_TEXT];
+	int ro_addr = (int)binp->sections[BIN_RO];
+	int data_addr = (int)binp->sections[BIN_DATA];
 
 	if (text_addr <= ro_addr) {
 		if (text_addr <= data_addr) {
@@ -225,14 +225,14 @@ void elf_save_bin_section_addr(struct binary_s *bin)
 	bin_info = (bin_addr_info_t *)kmm_malloc(sizeof(bin_addr_info_t));
 	if (bin_info != NULL) {
 		bin_info->bin_idx = bin->binary_idx;
-		bin_info->text_addr = (uint32_t)bin->alloc[ALLOC_TEXT];
-		bin_info->text_size = bin->textsize;
+		bin_info->text_addr = bin->sections[BIN_TEXT];
+		bin_info->text_size = bin->sizes[BIN_TEXT];
 #ifdef CONFIG_SAVE_BIN_SECTION_ADDR
 		binfo("[%s] text_addr : %x\n", bin->bin_name, bin_info->text_addr);
 #ifdef CONFIG_OPTIMIZE_APP_RELOAD_TIME
-		bin_info->rodata_addr = (uint32_t)bin->alloc[ALLOC_RO];
-		bin_info->data_addr = (uint32_t)bin->datastart;
-		bin_info->bss_addr = (uint32_t)bin->bssstart;
+		bin_info->rodata_addr = bin->sections[BIN_RO];
+		bin_info->data_addr = bin->sections[BIN_DATA];
+		bin_info->bss_addr = bin->sections[BIN_BSS];
 
 		binfo("   rodata_addr : %x\n", bin_info->rodata_addr);
 		binfo("   data_addr   : %x\n", bin_info->data_addr);

--- a/os/binfmt/libelf/libelf_unload.c
+++ b/os/binfmt/libelf/libelf_unload.c
@@ -107,22 +107,12 @@ int elf_unload(struct elf_loadinfo_s *loadinfo)
 	/* Release memory used to hold static constructors and destructors */
 
 #ifdef CONFIG_BINFMT_CONSTRUCTORS
-#ifndef CONFIG_ARCH_ADDRENV
 	if (loadinfo->ctoralloc != 0) {
-#ifdef CONFIG_APP_BINARY_SEPARATION
-		mm_free(loadinfo->uheap, loadinfo->ctoralloc);
-#else
 		kumm_free(loadinfo->ctoralloc);
-#endif
 	}
 	if (loadinfo->dtoralloc != 0) {
-#ifdef CONFIG_APP_BINARY_SEPARATION
-		mm_free(loadinfo->uheap, loadinfo->dtoralloc);
-#else
 		kumm_free(loadinfo->dtoralloc);
-#endif
 	}
-#endif
 
 	loadinfo->ctoralloc = NULL;
 	loadinfo->ctors = NULL;

--- a/os/include/tinyara/binfmt/elf.h
+++ b/os/include/tinyara/binfmt/elf.h
@@ -109,68 +109,28 @@
  */
 
 struct elf_loadinfo_s {
-	/* elfalloc is the base address of the memory that is allocated to hold the
-	 * ELF program image.
-	 *
-	 * If CONFIG_ARCH_ADDRENV=n, elfalloc will be allocated using kmm_malloc() (or
-	 * kmm_zalloc()).  If CONFIG_ARCH_ADDRENV-y, then elfalloc will be allocated using
-	 * up_addrenv_create().  In either case, there will be a unique instance
-	 * of elfalloc (and stack) for each instance of a process.
-	 *
-	 * The alloc[] array in struct binary_s will hold memory that persists after
-	 * the ELF module has been loaded.
-	 */
-
-	uintptr_t textalloc;		/* .text memory allocated when ELF file was loaded */
-	uintptr_t dataalloc;		/* .bss/.data memory allocated when ELF file was loaded */
-	size_t textsize;			/* Size of the ELF .text memory allocation */
-	size_t datasize;			/* Size of the ELF .bss/.data memory allocation */
+	int filfd;				/* Descriptor for the file being loaded */
 	off_t filelen;				/* Length of the entire ELF file */
+	uint16_t offset;    		        /* elf offset when binary header is included */
 	Elf32_Ehdr ehdr;			/* Buffered ELF file header */
-	FAR Elf32_Shdr *shdr;		/* Buffered ELF section headers */
+	FAR Elf32_Shdr *shdr;			/* Buffered ELF section headers */
 	uint8_t *iobuffer;			/* File I/O buffer */
 
-	/* Constructors and destructors */
-
 #ifdef CONFIG_BINFMT_CONSTRUCTORS
-	FAR void *ctoralloc;		/* Memory allocated for ctors */
-	FAR void *dtoralloc;		/* Memory allocated dtors */
-	FAR binfmt_ctor_t *ctors;	/* Pointer to a list of constructors */
-	FAR binfmt_dtor_t *dtors;	/* Pointer to a list of destructors */
+	FAR binfmt_ctor_t *ctors;		/* Pointer to a list of constructors */
+	FAR binfmt_dtor_t *dtors;		/* Pointer to a list of destructors */
 	uint16_t nctors;			/* Number of constructors */
 	uint16_t ndtors;			/* Number of destructors */
 #endif
 
-	/* Address environment.
-	 *
-	 * addrenv - This is the handle created by up_addrenv_create() that can be
-	 *   used to manage the tasks address space.
-	 * oldenv  - This is a value returned by up_addrenv_select() that must be
-	 *   used to restore the current address environment.
-	 */
-
-#ifdef CONFIG_ARCH_ADDRENV
-	group_addrenv_t addrenv;	/* Task group address environment */
-	save_addrenv_t oldenv;		/* Saved address environment */
-#endif
-
-#ifdef CONFIG_APP_BINARY_SEPARATION
-	struct binary_s *binp;				/* Back pointer to binary object */
-#endif
-
-#ifdef CONFIG_OPTIMIZE_APP_RELOAD_TIME
-	uintptr_t roalloc;			/* Allocation start for ro section */
-	size_t rosize;				/* Allocation size for ro section */
-#endif
-
-	uint16_t symtabidx;			/* Symbol table section index */
-	uint16_t strtabidx;			/* String table section index */
-	uint16_t buflen;			/* size of iobuffer[] */
-	int filfd;					/* Descriptor for the file being loaded */
-	uint16_t offset;             /* elf offset when binary header is included */
 	uintptr_t symtab;			/* Copy of symbol table */
 	uintptr_t reltab;			/* Copy of relocation table */
 	uintptr_t strtab;			/* Copy of string table */
+	uint16_t symtabidx;			/* Symbol table section index */
+	uint16_t strtabidx;			/* String table section index */
+	uint16_t buflen;			/* size of iobuffer[] */
+
+	struct binary_s *binp;			/* Back pointer to binary object */
 };
 
 /****************************************************************************

--- a/os/include/tinyara/mpu.h
+++ b/os/include/tinyara/mpu.h
@@ -68,9 +68,11 @@ enum mpu_region_usages_e {
 #define MPU_NUM_REGIONS     1
 #endif
 
-#ifdef CONFIG_ARMV8M_MPU
-#define MPU_ALIGNMENT_BYTES    32
-#define MPU_ALIGN_UP(a)                (((a) + MPU_ALIGNMENT_BYTES - 1) & ~(MPU_ALIGNMENT_BYTES - 1))
+#ifdef CONFIG_ARMV7M_MPU
+#define MPU_ALIGN_UP(a)			(1 << mpu_log2regionceil(0, a))
+#elif CONFIG_ARMV8M_MPU
+#define MPU_ALIGNMENT_BYTES		32
+#define MPU_ALIGN_UP(a)			(((a) + MPU_ALIGNMENT_BYTES - 1) & ~(MPU_ALIGNMENT_BYTES - 1))
 #endif
 
 /********************************************************************************

--- a/os/kernel/binary_manager/binary_manager_load.c
+++ b/os/kernel/binary_manager/binary_manager_load.c
@@ -345,12 +345,13 @@ static int binary_manager_terminate_binary(int bin_idx)
 			return BINMGR_OPERATION_FAIL;
 		}
 #ifdef CONFIG_OPTIMIZE_APP_RELOAD_TIME
-		if (binp == NULL || binp->reload != true)
-#endif
-		{
+		if (binp == NULL || binp->reload != true) {
 			g_lib_binp = NULL;
 			BIN_LOADINFO(bin_idx) = NULL;
 		}
+#else
+		g_lib_binp = NULL;
+#endif
 		BIN_STATE(bin_idx) = BINARY_INACTIVE;
 		bmvdbg("Unload common binary Done!!\n");
 		return BINMGR_OK;


### PR DESCRIPTION
- Remove unused and unnecessary variables
- Make changes to mpu and section allocations
- Remove addrenv since we dont use it
- Some more cleanup

Signed-off-by: Kishore S N <kishore.sn@samsung.com>