### PR TITLE
Fix mm_alloc_fail mixed logs

### DIFF
--- a/lib/libc/syslog/lib_lowsyslog.c
+++ b/lib/libc/syslog/lib_lowsyslog.c
@@ -150,7 +150,9 @@ int lowvsyslog(int priority, FAR const char *fmt, va_list ap)
 #if defined(CONFIG_LOGM) && defined(CONFIG_SYSLOG2LOGM)
 		ret = logm_internal(LOGM_LOWPUT, LOGM_UNKNOWN, priority, fmt, ap);
 #else
+		irqstate_t flags = irqsave();
 		ret = lowvsyslog_internal(fmt, ap);
+		irqrestore(flags);
 #endif
 	}
 	return ret;

--- a/os/arch/arm/src/armv7-m/up_assert.c
+++ b/os/arch/arm/src/armv7-m/up_assert.c
@@ -447,6 +447,7 @@ void up_assert(const uint8_t *filename, int lineno)
 		asserted_location = (uint32_t)kernel_assert_location;
 	}
 
+	irqstate_t flags = irqsave();
 #if CONFIG_TASK_NAME_SIZE > 0
 	lldbg("Assertion failed at file:%s line: %d task: %s\n", filename, lineno, fault_tcb->name);
 #else
@@ -492,6 +493,8 @@ void up_assert(const uint8_t *filename, int lineno)
 #if defined(CONFIG_BOARD_CRASHDUMP)
 	board_crashdump(up_getsp(), fault_tcb, (uint8_t *)filename, lineno);
 #endif
+
+	irqrestore(flags);
 
 #ifdef CONFIG_BINMGR_RECOVERY
 	if (IS_FAULT_IN_USER_SPACE(asserted_location)) {

--- a/os/arch/arm/src/armv8-m/up_assert.c
+++ b/os/arch/arm/src/armv8-m/up_assert.c
@@ -490,6 +490,7 @@ void up_assert(const uint8_t *filename, int lineno)
 		asserted_location = (uint32_t)kernel_assert_location;
 	}
 
+	irqstate_t flags = irqsave();
 #if CONFIG_TASK_NAME_SIZE > 0
 	lldbg("Assertion failed at file:%s line: %d task: %s\n", filename, lineno, fault_tcb->name);
 #else
@@ -535,6 +536,8 @@ void up_assert(const uint8_t *filename, int lineno)
 #if defined(CONFIG_BOARD_CRASHDUMP)
 	board_crashdump(up_getsp(), fault_tcb, (uint8_t *)filename, lineno);
 #endif
+
+	irqrestore(flags);
 
 #ifdef CONFIG_BINMGR_RECOVERY
 	if (IS_FAULT_IN_USER_SPACE(asserted_location)) {

--- a/os/drivers/memory/mminfo.c
+++ b/os/drivers/memory/mminfo.c
@@ -141,6 +141,12 @@ static int mminfo_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
 		ret = OK;
 		break;
 #endif
+#ifdef CONFIG_APP_BINARY_SEPARATION
+	case MMINFOIOC_MNG_ALLOCFAIL:
+		/* There is a single heap for user. So start and end indexes of heap are always 0. */
+		mm_manage_alloc_fail(BASE_HEAP, 0, 0, (size_t)arg, USER_HEAP);
+		break;
+#endif
 	default:
 		mdbg("Not supported\n");
 		break;

--- a/os/include/debug.h
+++ b/os/include/debug.h
@@ -499,6 +499,12 @@ int get_errno(void);
 #define mllvdbg(...)
 #endif
 
+#if defined(CONFIG_MM_ASSERT_ON_FAIL) && defined(CONFIG_APP_BINARY_SEPARATION) && defined (__KERNEL__)
+#define mfdbg(format, ...) lldbg(format, ##__VA_ARGS__)
+#else
+#define mfdbg(format, ...) dbg(format, ##__VA_ARGS__)
+#endif
+
 #ifdef CONFIG_DEBUG_NET_ERROR
 #define ndbg(format, ...)    dbg_noarg(format, ##__VA_ARGS__)
 #define nlldbg(format, ...)  lldbg_noarg(format, ##__VA_ARGS__)
@@ -1307,6 +1313,12 @@ int get_errno(void);
 #else
 #define mvdbg       (void)
 #define mllvdbg     (void)
+#endif
+
+#if defined(CONFIG_MM_ASSERT_ON_FAIL) && defined(CONFIG_APP_BINARY_SEPARATION) && defined (__KERNEL__)
+#define mfdbg lldbg
+#else
+#define mfdbg dbg
 #endif
 
 #ifdef CONFIG_DEBUG_NET_ERROR

--- a/os/include/tinyara/fs/ioctl.h
+++ b/os/include/tinyara/fs/ioctl.h
@@ -431,6 +431,7 @@
 
 #define MMINFOIOC_HEAP              _MMINFOIOC(0x0001)
 #define MMINFOIOC_PARSE             _MMINFOIOC(0x0002)
+#define MMINFOIOC_MNG_ALLOCFAIL     _MMINFOIOC(0x0003)
 
 /* Cpuload driver ioctl definitions ************************/
 

--- a/os/include/tinyara/mm/mm.h
+++ b/os/include/tinyara/mm/mm.h
@@ -713,7 +713,18 @@ int mm_check_heap_corruption(struct mm_heap_s *heap);
 #define HEAP_END_IDX   (CONFIG_KMM_NHEAPS - 1)
 
 /* Function to manage the memory allocation failure case. */
+#if defined(CONFIG_APP_BINARY_SEPARATION) && !defined(__KERNEL__)
+void mm_ioctl_alloc_fail(size_t size);
+#define mm_manage_alloc_fail(h, b, e, s, t) 	do { \
+							(void)h; \
+							(void)b; \
+							(void)e; \
+							(void)t; \
+							mm_ioctl_alloc_fail(s); \
+						} while (0)
+#else
 void mm_manage_alloc_fail(struct mm_heap_s *heap, int startidx, int endidx, size_t size, int heap_type);
+#endif
 
 #if CONFIG_KMM_NHEAPS > 1
 /**

--- a/os/mm/Kconfig
+++ b/os/mm/Kconfig
@@ -150,6 +150,7 @@ config MM_SHM
 config MM_ASSERT_ON_FAIL
 	bool "Assertion when Memory allocation fail"
 	default y
+	select MMINFO if APP_BINARY_SEPARATION
 	---help---
 		When memory allocation fails, make assertion.
 		From the application binary with loadable build, it will be reloaded.

--- a/os/mm/mm_heap/mm_check_heap_corruption.c
+++ b/os/mm/mm_heap/mm_check_heap_corruption.c
@@ -96,9 +96,9 @@ static void dump_node(struct mm_allocnode_s *node, node_type_t type)
 #endif
 
 	if (type == TYPE_CORRUPTED) {
-		dbg("CORRUPTED NODE: addr = 0x%08x size = %u preceding size = %u\n", node, node->size, MM_PREV_NODE_SIZE(node));
+		mfdbg("CORRUPTED NODE: addr = 0x%08x size = %u preceding size = %u\n", node, node->size, MM_PREV_NODE_SIZE(node));
 	} else if (type == TYPE_OVERFLOWED) {
-		dbg("OVERFLOWED NODE: addr = 0x%08x size = %u type = %c\n", node, node->size, IS_ALLOCATED_NODE(node) ? 'A' : 'F');
+		mfdbg("OVERFLOWED NODE: addr = 0x%08x size = %u type = %c\n", node, node->size, IS_ALLOCATED_NODE(node) ? 'A' : 'F');
 	}
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
 	pid_t pid = node->pid;
@@ -112,12 +112,12 @@ static void dump_node(struct mm_allocnode_s *node, node_type_t type)
 	}
 #if CONFIG_TASK_NAME_SIZE > 0
 	if (prctl(PR_GET_NAME_BYPID, myname, pid) == OK) {
-		dbg("Node owner pid = %d (%s%s), allocated by code at addr = 0x%08x\n", node->pid, myname, is_stack, node->alloc_call_addr);
+		mfdbg("Node owner pid = %d (%s%s), allocated by code at addr = 0x%08x\n", node->pid, myname, is_stack, node->alloc_call_addr);
 	} else {
-		dbg("Node owner pid = %d (Exited Task%s), allocated by code at addr = 0x%08x\n", node->pid, is_stack, node->alloc_call_addr);
+		mfdbg("Node owner pid = %d (Exited Task%s), allocated by code at addr = 0x%08x\n", node->pid, is_stack, node->alloc_call_addr);
 	}
 #else
-	dbg("Node owner pid = %d%s, allocated by code at addr = 0x%08x\n", node->pid, is_stack, node->alloc_call_addr);
+	mfdbg("Node owner pid = %d%s, allocated by code at addr = 0x%08x\n", node->pid, is_stack, node->alloc_call_addr);
 #endif
 #endif
 }
@@ -173,11 +173,11 @@ int mm_check_heap_corruption(struct mm_heap_s *heap)
 
 		for (; node < heap->mm_heapend[region]; prev = node, node = next, next = (struct mm_allocnode_s *)((char *)next + next->size)) {
 			if (prev && prev->size != MM_PREV_NODE_SIZE(node)) {
-				dbg("#########################################################################################\n");
-				dbg("ERROR: Heap node corruption detected\n");
+				mfdbg("#########################################################################################\n");
+				mfdbg("ERROR: Heap node corruption detected\n");
 				dump_node(prev, TYPE_OVERFLOWED);
 				dump_node(node, TYPE_CORRUPTED);
-				dbg("#########################################################################################\n");
+				mfdbg("#########################################################################################\n");
 				if (!aborted
 #if defined(CONFIG_BUILD_FLAT) || defined(__KERNEL__)
 					&& !up_interrupt_context()
@@ -187,19 +187,19 @@ int mm_check_heap_corruption(struct mm_heap_s *heap)
 				}
 				return -1;
 			} else if (node->size != MM_PREV_NODE_SIZE(next)) {
-				dbg("#########################################################################################\n");
-				dbg("ERROR: Heap node corruption detected.\n");
-				dbg("=========================================================================================\n");
-				dbg("Possible corruption scenario 1:\n");
-				dbg("=========================================================================================\n");
+				mfdbg("#########################################################################################\n");
+				mfdbg("ERROR: Heap node corruption detected.\n");
+				mfdbg("=========================================================================================\n");
+				mfdbg("Possible corruption scenario 1:\n");
+				mfdbg("=========================================================================================\n");
 				dump_node(prev, TYPE_OVERFLOWED);
 				dump_node(node, TYPE_CORRUPTED);
-				dbg("=========================================================================================\n");
-				dbg("Possible corruption scenario 2:\n");
-				dbg("=========================================================================================\n");
+				mfdbg("=========================================================================================\n");
+				mfdbg("Possible corruption scenario 2:\n");
+				mfdbg("=========================================================================================\n");
 				dump_node(node, TYPE_OVERFLOWED);
 				dump_node(next, TYPE_CORRUPTED);
-				dbg("#########################################################################################\n");
+				mfdbg("#########################################################################################\n");
 				if (!aborted
 #if defined(CONFIG_BUILD_FLAT) || defined(__KERNEL__)
 					&& !up_interrupt_context()
@@ -210,13 +210,13 @@ int mm_check_heap_corruption(struct mm_heap_s *heap)
 				return -1;
 			} else if (IS_FREE_NODE(node)) {
 				if ((((struct mm_freenode_s *)node)->blink && ((struct mm_freenode_s *)node)->blink->flink != ((struct mm_freenode_s *)node))) {
-					dbg("#########################################################################################\n");
-					dbg("ERROR: Heap node corruption detected in free node list\n");
+					mfdbg("#########################################################################################\n");
+					mfdbg("ERROR: Heap node corruption detected in free node list\n");
 					dump_node(prev, TYPE_OVERFLOWED);
 					dump_node(node, TYPE_CORRUPTED);
-					dbg("Corrupted node blink(0x%08x) and prev node flink(0x%08x) do not match\n", ((struct mm_freenode_s *)node)->blink,
+					mfdbg("Corrupted node blink(0x%08x) and prev node flink(0x%08x) do not match\n", ((struct mm_freenode_s *)node)->blink,
 							((struct mm_freenode_s *)node)->blink->flink);
-					dbg("#########################################################################################\n");
+					mfdbg("#########################################################################################\n");
 					if (!aborted
 #if defined(CONFIG_BUILD_FLAT) || defined(__KERNEL__)
 						&& !up_interrupt_context()
@@ -226,13 +226,13 @@ int mm_check_heap_corruption(struct mm_heap_s *heap)
 					}
 					return -1;
 				} else if (((struct mm_freenode_s *)node)->flink && ((struct mm_freenode_s *)node)->flink->blink != ((struct mm_freenode_s *)node)) {
-					dbg("#########################################################################################\n");
-					dbg("ERROR: Heap node corruption detected in free node list\n");
+					mfdbg("#########################################################################################\n");
+					mfdbg("ERROR: Heap node corruption detected in free node list\n");
 					dump_node(prev, TYPE_OVERFLOWED);
 					dump_node(node, TYPE_CORRUPTED);
-					dbg("Corrupted node flink(0x%08x) and next node blink(0x%08x) do not match\n", ((struct mm_freenode_s *)node)->flink,
+					mfdbg("Corrupted node flink(0x%08x) and next node blink(0x%08x) do not match\n", ((struct mm_freenode_s *)node)->flink,
 							((struct mm_freenode_s *)node)->flink->blink);
-					dbg("#########################################################################################\n");
+					mfdbg("#########################################################################################\n");
 					if (!aborted
 #if defined(CONFIG_BUILD_FLAT) || defined(__KERNEL__)
 						 && !up_interrupt_context()


### PR DESCRIPTION
    - Add ioctl call for mm_alloc_fail in app separation
    - Change some logs from dbg to lldbg
    - Disable irq during mm_alloc_fail
    - Disable irq during assert handler
    Disable irq during lldbg to avoid mixed logs. When irq is disabled,
    then printf and dbg logs will not get printed.
