### PR TITLE
nettest/netlog: modify netlog TC

### DIFF
--- a/apps/examples/nettest/netlog_test.c
+++ b/apps/examples/nettest/netlog_test.c
@@ -36,65 +36,49 @@ static const char netlib_err_log[] = "netlib error\n";
 static const char netlib_info_log[] = "netlib info\n";
 static const char netlib_verb_log[] = "netlib verb\n";
 
-START_TEST_F(error_log)
-{
-	int res = netlog_reset();
-	ST_EXPECT_EQ(0, res);
-	res = netlog_set_level(NL_MOD_WIFI_MANAGER, NL_LEVEL_ERROR);
-	ST_EXPECT_EQ(0, res);
-	int len = NET_LOGE(NL_MOD_WIFI_MANAGER, wifimanager_err_log);
-	ST_EXPECT_EQ(19, len);
-	len = NET_LOGI(NL_MOD_WIFI_MANAGER, wifimanager_info_log);
-	ST_EXPECT_EQ(0, len); // this should be 0 because log level is error;
-	len = NET_LOGV(NL_MOD_WIFI_MANAGER, wifimanager_verb_log);
-	ST_EXPECT_EQ(0, len); // this should be 0 because log level is error;
-}
-END_TEST_F
-
 START_TEST_F(info_log)
 {
-	int res = netlog_reset();
-	ST_EXPECT_EQ(0, res);
-	res = netlog_set_level(NL_MOD_WIFI_MANAGER, NL_LEVEL_INFO);
-	ST_EXPECT_EQ(0, res);
-	int len = NET_LOGE(NL_MOD_WIFI_MANAGER, wifimanager_err_log);
-	ST_EXPECT_EQ(19, len);
-	len = NET_LOGI(NL_MOD_WIFI_MANAGER, wifimanager_info_log);
-	ST_EXPECT_EQ(18, len); // this should be 0 because log level is error;
-	len = NET_LOGV(NL_MOD_WIFI_MANAGER, wifimanager_verb_log);
-	ST_EXPECT_EQ(0, len); // this should be 0 because log level is error;
+	ST_EXPECT_EQ(0, netlog_reset());
+	ST_EXPECT_EQ(0, netlog_set_level(NL_MOD_WIFI_MANAGER, NL_LEVEL_INFO));
+	ST_EXPECT_EQ(31, NET_LOGE(NL_MOD_WIFI_MANAGER, wifimanager_err_log));
+	ST_EXPECT_EQ(24, NET_LOGI(NL_MOD_WIFI_MANAGER, wifimanager_info_log));
+	// this should be 0 because log level is error;
+	ST_EXPECT_EQ(0, NET_LOGV(NL_MOD_WIFI_MANAGER, wifimanager_verb_log));
 }
 END_TEST_F
 
 START_TEST_F(verb_log)
 {
-	int res = netlog_reset();
-	ST_EXPECT_EQ(0, res);
-	res = netlog_set_level(NL_MOD_WIFI_MANAGER, NL_LEVEL_VERB);
-	ST_EXPECT_EQ(0, res);
-	int len = NET_LOGE(NL_MOD_WIFI_MANAGER, wifimanager_err_log);
-	ST_EXPECT_EQ(19, len);
-	len = NET_LOGI(NL_MOD_WIFI_MANAGER, wifimanager_info_log);
-	ST_EXPECT_EQ(18, len); // this should be 0 because log level is error;
-	len = NET_LOGV(NL_MOD_WIFI_MANAGER, wifimanager_verb_log);
-	ST_EXPECT_EQ(18, len); // this should be 0 because log level is error;
+	ST_EXPECT_EQ(0, netlog_reset());
+	ST_EXPECT_EQ(0, netlog_set_level(NL_MOD_WIFI_MANAGER, NL_LEVEL_VERB));
+	ST_EXPECT_EQ(31, NET_LOGE(NL_MOD_WIFI_MANAGER, wifimanager_err_log));
+	// this should be 0 because log level is error;
+	ST_EXPECT_EQ(24, NET_LOGI(NL_MOD_WIFI_MANAGER, wifimanager_info_log));
+	// this should be 0 because log level is error;
+	ST_EXPECT_EQ(24, NET_LOGV(NL_MOD_WIFI_MANAGER, wifimanager_verb_log));
+}
+END_TEST_F
+
+START_TEST_F(error_log)
+{
+	ST_EXPECT_EQ(0, netlog_reset());
+	ST_EXPECT_EQ(0, netlog_set_level(NL_MOD_WIFI_MANAGER, NL_LEVEL_ERROR));
+	ST_EXPECT_EQ(31, NET_LOGE(NL_MOD_WIFI_MANAGER, wifimanager_err_log));
+	ST_EXPECT_EQ(0, NET_LOGI(NL_MOD_WIFI_MANAGER, wifimanager_info_log));
+	ST_EXPECT_EQ(0, NET_LOGV(NL_MOD_WIFI_MANAGER, wifimanager_verb_log));
 }
 END_TEST_F
 
 START_TEST_F(mode_log)
 {
-	int res = netlog_reset();
-	ST_EXPECT_EQ(0, res);
-	res = netlog_set_level(NL_MOD_NETLIB, NL_LEVEL_ERROR);
-	ST_EXPECT_EQ(0, res);
-	int len = NET_LOGE(NL_MOD_WIFI_MANAGER, wifimanager_err_log);
-	ST_EXPECT_EQ(0, len);
-	len = NET_LOGI(NL_MOD_WIFI_MANAGER, wifimanager_info_log);
-	ST_EXPECT_EQ(0, len); // this should be 0 because log level is error;
-	len = NET_LOGV(NL_MOD_WIFI_MANAGER, wifimanager_verb_log);
-	ST_EXPECT_EQ(0, len); // this should be 0 because log level is error;
-	len = NET_LOGE(NL_MOD_NETLIB, "%s", netlib_err_log);
-	ST_EXPECT_EQ(13, len);
+	ST_EXPECT_EQ(0, netlog_reset());
+	ST_EXPECT_EQ(0, netlog_set_level(NL_MOD_NETLIB, NL_LEVEL_ERROR));
+	ST_EXPECT_EQ(0, NET_LOGE(NL_MOD_WIFI_MANAGER, wifimanager_err_log));
+	// this should be 0 because log level is error;
+	ST_EXPECT_EQ(0, NET_LOGI(NL_MOD_WIFI_MANAGER, wifimanager_info_log));
+	// this should be 0 because log level is error;
+	ST_EXPECT_EQ(0, NET_LOGV(NL_MOD_WIFI_MANAGER, wifimanager_verb_log));
+	ST_EXPECT_EQ(25, NET_LOGE(NL_MOD_NETLIB, "%s", netlib_err_log));
 }
 END_TEST_F
 
@@ -103,20 +87,13 @@ END_TEST_F
  */
 START_TEST_F(color_log)
 {
-	int res = netlog_reset();
-  res = netlog_set_color(NL_MOD_WIFI_MANAGER, NL_COLOR_GREEN);
-  ST_EXPECT_EQ(0, res);
-  res = netlog_set_level(NL_MOD_WIFI_MANAGER, NL_LEVEL_VERB);
-  ST_EXPECT_EQ(0, res);
-  int len = NET_LOGV(NL_MOD_WIFI_MANAGER, wifimanager_verb_log);
-  ST_EXPECT_EQ(19, len);
-
-  res = netlog_set_color(NL_MOD_NETLIB, NL_COLOR_YELLOW);
-  ST_EXPECT_EQ(0, res);
-  res = netlog_set_level(NL_MOD_NETLIB, NL_LEVEL_VERB);
-  ST_EXPECT_EQ(0, res);
-  len = NET_LOGV(NL_MOD_NETLIB, netlib_verb_log);
-  ST_EXPECT_EQ(13, len);
+	ST_EXPECT_EQ(0, netlog_reset());
+	ST_EXPECT_EQ(0, netlog_set_color(NL_MOD_WIFI_MANAGER, NL_COLOR_GREEN));
+	ST_EXPECT_EQ(0, netlog_set_level(NL_MOD_WIFI_MANAGER, NL_LEVEL_VERB));
+	ST_EXPECT_EQ(28, NET_LOGV(NL_MOD_WIFI_MANAGER, wifimanager_verb_log));
+	ST_EXPECT_EQ(0, netlog_set_color(NL_MOD_NETLIB, NL_COLOR_YELLOW));
+	ST_EXPECT_EQ(0, netlog_set_level(NL_MOD_NETLIB, NL_LEVEL_VERB));
+	ST_EXPECT_EQ(22, NET_LOGV(NL_MOD_NETLIB, netlib_verb_log));
 }
 END_TEST_F
 
@@ -125,15 +102,11 @@ END_TEST_F
  */
 START_TEST_F(timer_log)
 {
-	int res = netlog_reset();
-  res = netlog_set_color(NL_MOD_WIFI_MANAGER, NL_COLOR_GREEN);
-  ST_EXPECT_EQ(0, res);
-  res = netlog_set_level(NL_MOD_WIFI_MANAGER, NL_LEVEL_ERROR);
-  ST_EXPECT_EQ(0, res);
-  res = netlog_set_timer(NL_OPT_ENABLE);
-  ST_EXPECT_EQ(0, res);
-  int len = NET_LOGE(NL_MOD_WIFI_MANAGER, wifimanager_err_log);
-  ST_EXPECT_EQ(19, len);
+	ST_EXPECT_EQ(0, netlog_reset());
+	ST_EXPECT_EQ(0, netlog_set_color(NL_MOD_WIFI_MANAGER, NL_COLOR_GREEN));
+	ST_EXPECT_EQ(0, netlog_set_level(NL_MOD_WIFI_MANAGER, NL_LEVEL_ERROR));
+	ST_EXPECT_EQ(0, netlog_set_timer(NL_OPT_ENABLE));
+	ST_EXPECT_EQ(45, NET_LOGE(NL_MOD_WIFI_MANAGER, wifimanager_err_log));
 }
 END_TEST_F
 
@@ -142,16 +115,12 @@ END_TEST_F
  */
 START_TEST_F(add_option)
 {
-	int res = netlog_reset();
-  res = netlog_set_level(NL_MOD_WIFI_MANAGER, NL_LEVEL_VERB);
-  ST_EXPECT_EQ(0, res);
-  res = netlog_set_function(NL_OPT_ENABLE);
-  ST_EXPECT_EQ(0, res);
-  int len = NET_LOGV(NL_MOD_WIFI_MANAGER, wifimanager_verb_log);
-  ST_EXPECT_EQ(18, len);
-  res = netlog_set_file(NL_OPT_ENABLE);
-  len = NET_LOGV(NL_MOD_WIFI_MANAGER, wifimanager_verb_log);
-  ST_EXPECT_EQ(18, len);
+	ST_EXPECT_EQ(0, netlog_reset());
+	ST_EXPECT_EQ(0, netlog_set_level(NL_MOD_WIFI_MANAGER, NL_LEVEL_VERB));
+	ST_EXPECT_EQ(0, netlog_set_function(NL_OPT_ENABLE));
+	ST_EXPECT_EQ(39, NET_LOGV(NL_MOD_WIFI_MANAGER, wifimanager_verb_log));
+	ST_EXPECT_EQ(0, netlog_set_file(NL_OPT_ENABLE));
+	ST_EXPECT_EQ(105, NET_LOGV(NL_MOD_WIFI_MANAGER, wifimanager_verb_log));
 }
 END_TEST_F
 
@@ -160,40 +129,29 @@ END_TEST_F
  */
 START_TEST_F(remove_option)
 {
-	int res = netlog_reset();
-  res = netlog_set_level(NL_MOD_WIFI_MANAGER, NL_LEVEL_VERB);
-  ST_EXPECT_EQ(0, res);
-  res = netlog_set_function(NL_OPT_ENABLE);
-  ST_EXPECT_EQ(0, res);
-  int len = NET_LOGV(NL_MOD_WIFI_MANAGER, wifimanager_verb_log);
-  ST_EXPECT_EQ(18, len);
-  res = netlog_set_file(NL_OPT_ENABLE);
-  len = NET_LOGV(NL_MOD_WIFI_MANAGER, wifimanager_verb_log);
-  ST_EXPECT_EQ(18, len);
-
-  res = netlog_set_function(NL_OPT_DISABLE);
-  ST_EXPECT_EQ(0, res);
-  len = NET_LOGV(NL_MOD_WIFI_MANAGER, wifimanager_verb_log);
-  ST_EXPECT_EQ(18, len);
-
-  res = netlog_set_file(NL_OPT_DISABLE);
-  ST_EXPECT_EQ(0, res);
-  len = NET_LOGV(NL_MOD_WIFI_MANAGER, wifimanager_verb_log);
-  ST_EXPECT_EQ(18, len);
+	ST_EXPECT_EQ(0, netlog_reset());
+	ST_EXPECT_EQ(0, netlog_set_level(NL_MOD_WIFI_MANAGER, NL_LEVEL_VERB));
+	ST_EXPECT_EQ(0, netlog_set_function(NL_OPT_ENABLE));
+	ST_EXPECT_EQ(42, NET_LOGV(NL_MOD_WIFI_MANAGER, wifimanager_verb_log));
+	ST_EXPECT_EQ(0, netlog_set_file(NL_OPT_ENABLE));
+	ST_EXPECT_EQ(108, NET_LOGV(NL_MOD_WIFI_MANAGER, wifimanager_verb_log));
+	ST_EXPECT_EQ(0, netlog_set_function(NL_OPT_DISABLE));
+	ST_EXPECT_EQ(90, NET_LOGV(NL_MOD_WIFI_MANAGER, wifimanager_verb_log));
+	ST_EXPECT_EQ(0, netlog_set_file(NL_OPT_DISABLE));
+	ST_EXPECT_EQ(24, NET_LOGV(NL_MOD_WIFI_MANAGER, wifimanager_verb_log));
 }
 END_TEST_F
-
 
 void netlog_run_test(void)
 {
 	ST_SET_PACK(netlog);
 	ST_SET_SMOKE1(netlog, NT_TEST_TRIAL, ST_NO_TIMELIMIT, "turn on info", info_log);
 	ST_SET_SMOKE1(netlog, NT_TEST_TRIAL, ST_NO_TIMELIMIT, "turn on debug", verb_log);
-	ST_SET_SMOKE1(netlog, 3, ST_NO_TIMELIMIT, "turn on error", error_log);
+	ST_SET_SMOKE1(netlog, NT_TEST_TRIAL, ST_NO_TIMELIMIT, "turn on error", error_log);
 	ST_SET_SMOKE1(netlog, NT_TEST_TRIAL, ST_NO_TIMELIMIT, "log per mode", mode_log);
-  ST_SET_SMOKE1(netlog, NT_TEST_TRIAL, ST_NO_TIMELIMIT, "color log", color_log);
-  ST_SET_SMOKE1(netlog, NT_TEST_TRIAL, ST_NO_TIMELIMIT, "timer log", timer_log);
-  ST_SET_SMOKE1(netlog, NT_TEST_TRIAL, ST_NO_TIMELIMIT, "set additional info", add_option);
-  ST_SET_SMOKE1(netlog, NT_TEST_TRIAL, ST_NO_TIMELIMIT, "remove additional info", remove_option);
+	ST_SET_SMOKE1(netlog, NT_TEST_TRIAL, ST_NO_TIMELIMIT, "color log", color_log);
+	ST_SET_SMOKE1(netlog, NT_TEST_TRIAL, ST_NO_TIMELIMIT, "timer log", timer_log);
+	ST_SET_SMOKE1(netlog, NT_TEST_TRIAL, ST_NO_TIMELIMIT, "set additional info", add_option);
+	ST_SET_SMOKE1(netlog, NT_TEST_TRIAL, ST_NO_TIMELIMIT, "remove additional info", remove_option);
 	ST_RUN_TEST(netlog);
 }

--- a/external/netutils/netlib_netlog.c
+++ b/external/netutils/netlib_netlog.c
@@ -54,7 +54,7 @@ static const char *get_color_code(nl_color_e color)
 	}
 }
 
-static inline void _print_time(void)
+static inline int _print_time(void)
 {
 	time_t time_info = time(NULL);
 	struct tm *tm = localtime(&time_info);
@@ -66,8 +66,8 @@ static inline void _print_time(void)
 	clock_gettime(CLOCK_REALTIME, &current_time);
 
 	unsigned int micro_sec = current_time.tv_nsec / 10000000;
-	printf(" [%02d:%02d:%02d.%02u]",
-		   tm->tm_hour, tm->tm_min, tm->tm_sec, micro_sec);
+	return printf(" [%02d:%02d:%02d.%02u]",
+								tm->tm_hour, tm->tm_min, tm->tm_sec, micro_sec);
 }
 
 int netlogger_print(netlog_module_e mod,
@@ -84,24 +84,25 @@ int netlogger_print(netlog_module_e mod,
 		return 0;
 	}
 
+	int len = 0;
 	va_list args;
 	va_start(args, fmt);
 	if (level == NL_LEVEL_ERROR) {
-		printf("\033[01;45m ");
+		len += printf("\033[01;45m ");
 	} else {
-		printf("%s", get_color_code(g_mod_config[mod].color));
+		len += printf("%s", get_color_code(g_mod_config[mod].color));
 	}
 	if (g_nl_timer == NL_OPT_ENABLE) {
-		_print_time();
+		len += _print_time();
 	}
 	if (g_nl_function == NL_OPT_ENABLE) {
-		printf("[%s]", func);
+		len += printf("[%s]", func);
 	}
 	if (g_nl_files == NL_OPT_ENABLE) {
-		printf("[%s:%d]", file, line);
+		len += printf("[%s:%d]", file, line);
 	}
-	int len = vprintf(fmt, args);
-	printf("\033[m"); // Resets the terminal to default.
+	len += vprintf(fmt, args);
+	len += printf("\033[m"); // Resets the terminal to default.
 	va_end(args);
 
 	return len;

--- a/external/stress_tool/st_perf.c
+++ b/external/stress_tool/st_perf.c
@@ -241,19 +241,19 @@ void perf_add_item(st_pack *pack, int repeat, char *tc_desc,
 				   st_unit_tc func_setup, st_unit_tc func_teardown, st_unit_tc func,
 				   unsigned int expect)
 {
-	st_performance *perf = (st_performance *)zalloc(sizeof(st_performance));
+	st_performance *perf = (st_performance *)calloc(sizeof(st_performance), 1);
 	if (!perf) {
 		PERF_ERR("perf alloc fail\n");
 		return;
 	}
-	st_stability *stab = (st_stability *)zalloc(sizeof(st_stability));
+	st_stability *stab = (st_stability *)calloc(sizeof(st_stability), 1);
 	if (!stab) {
 		PERF_ERR("stab alloc fail\n");
 		free(perf);
 		return;
 	}
 
-	st_func *sfunc = (st_func *)zalloc(sizeof(st_func));
+	st_func *sfunc = (st_func *)calloc(sizeof(st_func), 1);
 	if (!sfunc) {
 		PERF_ERR("func alloc fail\n");
 		free(perf);
@@ -269,7 +269,7 @@ void perf_add_item(st_pack *pack, int repeat, char *tc_desc,
 
 	perf->expect = expect;
 
-	st_smoke *smoke = (st_smoke *)zalloc(sizeof(st_smoke));
+	st_smoke *smoke = (st_smoke *)calloc(sizeof(st_smoke), 1);
 	if (!smoke) {
 		PERF_ERR("smoke alloc fail\n");
 		free(sfunc);

--- a/os/include/tinyara/net/netlog.h
+++ b/os/include/tinyara/net/netlog.h
@@ -43,6 +43,7 @@ typedef netmgr_logger *netmgr_logger_p;
 
 typedef enum {
 	NL_MOD_UNKNOWN,
+  NL_MODE_ALL,
 	/*  user level module */
 	NL_MOD_WIFI_MANAGER,
 	NL_MOD_NETLIB,
@@ -58,6 +59,41 @@ typedef enum {
 	NL_LEVEL_UNKNOWN,
 } netlog_log_level_e;
 
+typedef enum {
+	NL_LWIP_ETHARP,
+	NL_LWIP_NETIF,
+	NL_LWIP_PBUF,
+	NL_LWIP_API_LIB,
+	NL_LWIP_API_MSG,
+	NL_LWIP_SOCKETS,
+	NL_LWIP_ICMP,
+	NL_LWIP_IGMP,
+	NL_LWIP_INET,
+	NL_LWIP_IP,
+	NL_LWIP_IP_REASS,
+	NL_LWIP_RAW,
+	NL_LWIP_MEM,
+	NL_LWIP_MEMP,
+	NL_LWIP_SYS,
+	NL_LWIP_TIMERS,
+	NL_LWIP_TCP,
+	NL_LWIP_TCP_INPUT,
+	NL_LWIP_TCP_FR,
+	NL_LWIP_TCP_RTO,
+	NL_LWIP_TCP_CWND,
+	NL_LWIP_TCP_WND,
+	NL_LWIP_TCP_OUTPUT,
+	NL_LWIP_TCP_RST,
+	NL_LWIP_TCP_QLEN,
+	NL_LWIP_UDP,
+	NL_LWIP_TCPIP,
+	NL_LWIP_SLIP,
+	NL_LWIP_DHCP,
+	NL_LWIP_AUTOIP,
+	NL_LWIP_DNS,
+	NL_LWIP_IP6,
+	NL_LWIP_ND6,
+} netlog_lwip_sublevel_e;
 /*
  * DESCRIPTION: Initialize logger
  * RETURN: return 0 if succeed, else return negative if fail
@@ -151,13 +187,13 @@ int netlog_reset(void);
 /*  network log for user space */
 #ifdef __LINUX__
 #define NET_LOG(mod, fmt, args...) \
-	netlogger_print(mod, NL_LEVEL_UNKNOWN, __FUNCTION__, __FILE__, __LINE__, fmt, ##args);
+	netlogger_print(mod, NL_LEVEL_UNKNOWN, __FUNCTION__, __FILE__, __LINE__, fmt, ##args)
 #define NET_LOGE(mod, fmt, args...) \
-	netlogger_print(mod, NL_LEVEL_ERROR, __FUNCTION__, __FILE__, __LINE__, fmt, ##args);
+	netlogger_print(mod, NL_LEVEL_ERROR, __FUNCTION__, __FILE__, __LINE__, fmt, ##args)
 #define NET_LOGI(mod, fmt, args...) \
-	netlogger_print(mod, NL_LEVEL_INFO, __FUNCTION__, __FILE__, __LINE__, fmt, ##args);
+	netlogger_print(mod, NL_LEVEL_INFO, __FUNCTION__, __FILE__, __LINE__, fmt, ##args)
 #define NET_LOGV(mod, fmt, args...) \
-	netlogger_print(mod, NL_LEVEL_VERB, __FUNCTION__, __FILE__, __LINE__, fmt, ##args);
+	netlogger_print(mod, NL_LEVEL_VERB, __FUNCTION__, __FILE__, __LINE__, fmt, ##args)
 #else
 #define NET_LOG(mod, fmt, args...) \
 	printf(mod fmt, ##args);


### PR DESCRIPTION
TC pass was checked by returning value of NET_LOG API. However
previous API doesn't return correct value so TC couldn't check
validation of API. After modify APIs then change expected value of TC.