### PR TITLE
lib/libc: add additional log information

### DIFF
--- a/lib/libc/netdb/lib_freeaddrinfo.c
+++ b/lib/libc/netdb/lib_freeaddrinfo.c
@@ -61,7 +61,7 @@ void freeaddrinfo(FAR struct addrinfo *ai)
 
 	int sockfd = socket(AF_INET, SOCK_DGRAM, 0);
 	if (sockfd < 0) {
-		printf("socket() failed with errno: %d\n", errno);
+		printf("socket() failed with errno: %d\t%s\n", errno, __FUNCTION__);
 		return;
 	}
 
@@ -71,7 +71,7 @@ void freeaddrinfo(FAR struct addrinfo *ai)
 
 	ret = ioctl(sockfd, SIOCLWIP, (unsigned long)&req);
 	if (ret == ERROR) {
-		printf("ioctl() failed with errno: %d\n", errno);
+		printf("ioctl() failed with errno: %d\t%s\n", errno, __FUNCTION__);
 	}
 
 	close(sockfd);

--- a/lib/libc/netdb/lib_getaddrinfo.c
+++ b/lib/libc/netdb/lib_getaddrinfo.c
@@ -70,7 +70,7 @@ int getaddrinfo(FAR const char *hostname,
 
 	int sockfd = socket(AF_INET, SOCK_DGRAM, 0);
 	if (sockfd < 0) {
-		printf("socket() failed with errno: %d\n", errno);
+		printf("socket() failed with errno: %d\t%s\n", errno, __FUNCTION__);
 		return ret;
 	}
 
@@ -84,7 +84,7 @@ int getaddrinfo(FAR const char *hostname,
 	ret = ioctl(sockfd, SIOCLWIP, (unsigned long)&req);
 	close(sockfd);
 	if (ret == ERROR) {
-		printf("ioctl() failed with errno: %d\n", errno);
+		printf("ioctl() failed with errno: %d\t%s\n", errno, __FUNCTION__);
 		return ret;
 	}
 

--- a/lib/libc/netdb/lib_gethostbyname.c
+++ b/lib/libc/netdb/lib_gethostbyname.c
@@ -70,7 +70,7 @@ struct hostent *gethostbyname(const char *name)
 
 	int sockfd = socket(AF_INET, SOCK_DGRAM, 0);
 	if (sockfd < 0) {
-		printf("socket() failed with errno: %d\n", errno);
+		printf("socket() failed with errno: %d\t%s\n", errno, __FUNCTION__);
 		return NULL;
 	}
 
@@ -81,7 +81,7 @@ struct hostent *gethostbyname(const char *name)
 
 	int ret = ioctl(sockfd, SIOCLWIP, (unsigned long)&req);
 	if (ret == ERROR) {
-		printf("ioctl() failed with errno: %d\n", errno);
+		printf("ioctl() failed with errno: %d\t%s\n", errno, __FUNCTION__);
 		close(sockfd);
 		return NULL;
 	}

--- a/lib/libc/netdb/lib_getnameinfo.c
+++ b/lib/libc/netdb/lib_getnameinfo.c
@@ -70,7 +70,7 @@ int getnameinfo(const struct sockaddr *sa,
 
 	int sockfd = socket(AF_INET, SOCK_DGRAM, 0);
 	if (sockfd < 0) {
-		printf("socket() failed with errno: %d\n", errno);
+		printf("socket() failed with errno: %d\t%s\n", errno, __FUNCTION__);
 		return ret;
 	}
 
@@ -86,7 +86,7 @@ int getnameinfo(const struct sockaddr *sa,
 
 	ret = ioctl(sockfd, SIOCLWIP, (unsigned long)&req);
 	if (ret == ERROR) {
-		printf("ioctl() failed with errno: %d\n", errno);
+		printf("ioctl() failed with errno: %d\t%s\n", errno, __FUNCTION__);
 		close(sockfd);
 		return ret;
 	}


### PR DESCRIPTION
Those APIs freeaddrinfo, getaddrinfo printed same error log if ioctl
was failed. To distinguish the log add function information.