### PR TITLE
build/configs/artik05x: Fix the build break with non standard python path

### DIFF
--- a/build/configs/artik05x/artik05x_make_bin.sh
+++ b/build/configs/artik05x/artik05x_make_bin.sh
@@ -75,7 +75,7 @@ fi
 
 add_checksum() {
 	echo "ATTACHNS2: ${TIZENRT_BIN} --> ${SAMSUNG_NS2_BIN}"
-	${OS_DIR_PATH}/tools/s5jchksum.py ${OUTPUT_BINARY_PATH}/${TIZENRT_BIN} ${OUTPUT_BINARY_PATH}/${SAMSUNG_NS2_BIN}
+	python ${OS_DIR_PATH}/tools/s5jchksum.py ${OUTPUT_BINARY_PATH}/${TIZENRT_BIN} ${OUTPUT_BINARY_PATH}/${SAMSUNG_NS2_BIN}
 }
 
 signing() {


### PR DESCRIPTION
build/configs/artik05x: Fix the build break with non standard python path

Env:
Python installed in path other than /usr/bin/python

Test Configution:
./tools/configure.sh  artik053/hello
make

Issue:
TizenRT/os/../build/configs/artik05x/artik05x_make_bin.sh:
TizenRT/build/configs/artik05x/../../../os/tools/s5jchksum.py:
/usr/bin/python: bad interpreter: No such file or directory
Makefile.unix:494: recipe for target 'post' failed
make: *** [post] Error 126

Cause:
artik05x_make_bin.sh requires python to be installed at /usr/bin/python
but it is possible to install python in other path and export system wide.

Measure:
Invoke the script with python which avoids looking for /usr/bin/python

Signed-off-by: Manohara HK <manohara.hk@samsung.com>