### PR TITLE
net/netlog: add runtime log interface

### DIFF
--- a/external/netutils/Makefile
+++ b/external/netutils/Makefile
@@ -62,6 +62,7 @@ CSRCS += netlib_setifstatus.c \
 	netlib_getifstatus.c
 CSRCS += netlib_getifaddrs.c
 CSRCS += netlib_getstats.c
+CSRCS += netlib_netlog.c
 
 ifeq ($(CONFIG_NET_NETMON),y)
 CSRCS += netlib_netmon.c

--- a/external/netutils/netlib.c
+++ b/external/netutils/netlib.c
@@ -67,8 +67,6 @@
 #include <netutils/netlib.h>
 #include <tinyara/net/netlog.h>
 
-#define TAG "[NETLIB]"
-
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
@@ -114,7 +112,7 @@ bool netlib_hwmacconv(const char *hwstr, uint8_t *hw)
 	unsigned char j;
 
 	if (strlen(hwstr) != 17) {
-		NET_LOGE(TAG, "insufficient buffer\n");
+		NET_LOGE(NL_MOD_NETLIB, "insufficient buffer\n");
 		return false;
 	}
 
@@ -131,7 +129,7 @@ bool netlib_hwmacconv(const char *hwstr, uint8_t *hw)
 
 			if (c == ':' || c == 0) {
 				*hw = tmp;
-				NET_LOGV(TAG, "HWMAC[%d]%0.2X\n", i, tmp);
+				NET_LOGV(NL_MOD_NETLIB, "HWMAC[%d]%0.2X\n", i, tmp);
 				++hw;
 				tmp = 0;
 			} else if (c >= '0' && c <= '9') {

--- a/external/netutils/netlib_getifaddrs.c
+++ b/external/netutils/netlib_getifaddrs.c
@@ -35,18 +35,16 @@
 #include <tinyara/lwnl/lwnl.h>
 #include <tinyara/net/netlog.h>
 
-#define TAG "[NETLIB]"
-
 static inline int _send_msg(lwnl_msg *msg)
 {
 	int ret = 0;
 	int fd = socket(AF_LWNL, SOCK_RAW, LWNL_ROUTE);
 	if (fd < 0) {
-		NET_LOGE(TAG, "create socket %d\n", errno);
+		NET_LOGE(NL_MOD_NETLIB, "create socket %d\n", errno);
 		ret = -1;
 	} else {
 		if (write(fd, msg, sizeof(*msg)) < 0) {
-			NET_LOGE(TAG, "write %d\n", errno);
+			NET_LOGE(NL_MOD_NETLIB, "write %d\n", errno);
 			ret = -2;
 		}
 		close(fd);
@@ -61,7 +59,7 @@ int netlib_getifaddrs(struct ifaddrs **ifap)
 					sizeof(*ifap), NULL, (void *)&res};
 	int lres = _send_msg(&msg);
 	if (lres < 0) {
-		NET_LOGE(TAG, "send request msg fail %d %d\n", lres, res);
+		NET_LOGE(NL_MOD_NETLIB, "send request msg fail %d %d\n", lres, res);
 		return -1;
 	}
 	*ifap = (struct ifaddrs *)msg.data;

--- a/external/netutils/netlib_getmacaddr.c
+++ b/external/netutils/netlib_getmacaddr.c
@@ -68,7 +68,6 @@
 #include <netutils/netlib.h>
 #include <tinyara/net/netlog.h>
 
-#define TAG "[NETLIB]"
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
@@ -105,13 +104,13 @@ int netlib_getmacaddr(const char *ifname, uint8_t *macaddr)
 {
 	int ret = ERROR;
 	if (!ifname || !macaddr) {
-		NET_LOGE(TAG, "invalid parameter %p %p\n", ifname, macaddr);
+		NET_LOGE(NL_MOD_NETLIB, "invalid parameter %p %p\n", ifname, macaddr);
 	}
 	/* Get a socket (only so that we get access to the INET subsystem) */
 
 	int sockfd = socket(PF_INETX, NETLIB_SOCK_IOCTL, 0);
 	if (sockfd < 0) {
-		NET_LOGE(TAG, "create socket %d\n", errno);
+		NET_LOGE(NL_MOD_NETLIB, "create socket %d\n", errno);
 	}
 
 	struct ifreq req;
@@ -124,7 +123,7 @@ int netlib_getmacaddr(const char *ifname, uint8_t *macaddr)
 	ret = ioctl(sockfd, SIOCGIFHWADDR, (unsigned long)&req);
 	close(sockfd);
 	if (ret == -1) {
-		NET_LOGE(TAG, "ioctl fail %d\n", errno);
+		NET_LOGE(NL_MOD_NETLIB, "ioctl fail %d\n", errno);
 		return ERROR;
 	}
 	/* Return the MAC address */

--- a/external/netutils/netlib_getstats.c
+++ b/external/netutils/netlib_getstats.c
@@ -29,7 +29,6 @@
 #include <tinyara/netmgr/netctl.h>
 #include <tinyara/net/netlog.h>
 
-#define TAG "[NETLIB]"
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
@@ -65,7 +64,7 @@ int netlib_getstats(void *arg)
 
 	int sockfd = socket(AF_INET, SOCK_DGRAM, 0);
 	if (sockfd < 0) {
-		NET_LOGE(TAG, "socket() failed with errno: %d\n", errno);
+		NET_LOGE(NL_MOD_NETLIB, "socket() failed with errno: %d\n", errno);
 		return ret;
 	}
 
@@ -75,7 +74,7 @@ int netlib_getstats(void *arg)
 	ret = ioctl(sockfd, SIOCLWIP, (unsigned long)&req);
 	close(sockfd);
 	if (ret == ERROR) {
-		NET_LOGE(TAG, "ioctl() failed with errno: %d\n", errno);
+		NET_LOGE(NL_MOD_NETLIB, "ioctl() failed with errno: %d\n", errno);
 		return ret;
 	}
 	// req_req_res is always OK.

--- a/external/netutils/netlib_ipmsfilter.c
+++ b/external/netutils/netlib_ipmsfilter.c
@@ -69,8 +69,6 @@
 #include <netutils/ipmsfilter.h>
 #include <tinyara/net/netlog.h>
 
-#define TAG "[NETLIB]"
-
 #ifdef CONFIG_NET_IGMP
 
 /****************************************************************************
@@ -102,7 +100,7 @@ int ipmsfilter(FAR const char *ifname, FAR const struct in_addr *multiaddr, uint
 {
 	int ret = ERROR;
 
-	NET_LOGV(TAG, "ifname: %s muliaddr: %08x fmode: %ld\n", ifname, *multiaddr, fmode);
+	NET_LOGV(NL_MOD_NETLIB, "ifname: %s muliaddr: %08x fmode: %ld\n", ifname, *multiaddr, fmode);
 	if (ifname && multiaddr) {
 		/* Get a socket (only so that we get access to the INET subsystem) */
 

--- a/external/netutils/netlib_listenon.c
+++ b/external/netutils/netlib_listenon.c
@@ -68,7 +68,6 @@
 #include <netutils/netlib.h>
 #include <tinyara/net/netlog.h>
 
-#define TAG "[NETLIB]"
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
@@ -103,7 +102,7 @@ int netlib_listenon(uint16_t portno)
 
 	listensd = socket(PF_INET, SOCK_STREAM, 0);
 	if (listensd < 0) {
-		NET_LOGE(TAG, "socket failure: %d\n", errno);
+		NET_LOGE(NL_MOD_NETLIB, "socket failure: %d\n", errno);
 		return ERROR;
 	}
 
@@ -112,7 +111,7 @@ int netlib_listenon(uint16_t portno)
 #ifdef CONFIG_NET_HAVE_REUSEADDR
 	optval = 1;
 	if (setsockopt(listensd, SOL_SOCKET, SO_REUSEADDR, (void *)&optval, sizeof(int)) < 0) {
-		NET_LOGE(TAG, "setsockopt SO_REUSEADDR failure: %d\n", errno);
+		NET_LOGE(NL_MOD_NETLIB, "setsockopt SO_REUSEADDR failure: %d\n", errno);
 		goto errout_with_socket;
 	}
 #endif
@@ -124,20 +123,20 @@ int netlib_listenon(uint16_t portno)
 	myaddr.sin_addr.s_addr = INADDR_ANY;
 
 	if (bind(listensd, (struct sockaddr *)&myaddr, sizeof(struct sockaddr_in)) < 0) {
-		NET_LOGE(TAG, "bind failure: %d\n", errno);
+		NET_LOGE(NL_MOD_NETLIB, "bind failure: %d\n", errno);
 		goto errout_with_socket;
 	}
 
 	/* Listen for connections on the bound TCP socket */
 
 	if (listen(listensd, 5) < 0) {
-		NET_LOGE(TAG, "listen failure %d\n", errno);
+		NET_LOGE(NL_MOD_NETLIB, "listen failure %d\n", errno);
 		goto errout_with_socket;
 	}
 
 	/* Begin accepting connections */
 
-	NET_LOGV(TAG, "Accepting connections on port %d\n", ntohs(portno));
+	NET_LOGV(NL_MOD_NETLIB, "Accepting connections on port %d\n", ntohs(portno));
 	return listensd;
 
 errout_with_socket:

--- a/external/netutils/netlib_netlog.c
+++ b/external/netutils/netlib_netlog.c
@@ -15,7 +15,7 @@
  * language governing permissions and limitations under the License.
  *
  ****************************************************************************/
-
+#include <tinyara/config.h>
 #include <stdio.h>
 #include <stdarg.h>
 #include <time.h>
@@ -25,16 +25,17 @@
 #include <tinyara/net/netlog.h>
 #endif
 
+#ifdef CONFIG_NET_RUNTIME_LOG
 typedef struct {
 	netlog_log_level_e level;
 	nl_color_e color;
 } netlog_config_s;
 
 static netlog_config_s g_mod_config[4] = {
-	{NL_LEVEL_UNKNOWN, NL_COLOR_DEFAULT},
-	{NL_LEVEL_UNKNOWN, NL_COLOR_DEFAULT},
-	{NL_LEVEL_UNKNOWN, NL_COLOR_DEFAULT},
-	{NL_LEVEL_UNKNOWN, NL_COLOR_DEFAULT},
+		{NL_LEVEL_UNKNOWN, NL_COLOR_DEFAULT},
+		{NL_LEVEL_UNKNOWN, NL_COLOR_DEFAULT},
+		{NL_LEVEL_UNKNOWN, NL_COLOR_DEFAULT},
+		{NL_LEVEL_UNKNOWN, NL_COLOR_DEFAULT},
 };
 
 static nl_options g_nl_timer = NL_OPT_DISABLE;
@@ -71,11 +72,11 @@ static inline int _print_time(void)
 }
 
 int netlogger_print(netlog_module_e mod,
-					netlog_log_level_e level,
-					const char *func,
-					const char *file,
-					const int line,
-					const char *fmt, ...)
+										netlog_log_level_e level,
+										const char *func,
+										const char *file,
+										const int line,
+										const char *fmt, ...)
 {
 	if (mod == NL_MOD_UNKNOWN) {
 		return 0;
@@ -151,3 +152,46 @@ int netlog_reset(void)
 
 	return 0;
 }
+#else	 /*  CONFIG_NET_RUNTIME_LOG */
+int netlogger_print(netlog_module_e mod,
+										netlog_log_level_e level,
+										const char *func,
+										const char *file,
+										const int line,
+										const char *fmt, ...)
+{
+	/*  enable CONFIG_NET_RUNTIME_LOG */
+	return -1;
+}
+int netlog_set_level(netlog_module_e module, netlog_log_level_e level)
+{
+	/*  enable CONFIG_NET_RUNTIME_LOG */
+	return -1;
+}
+int netlog_set_color(netlog_module_e module, nl_color_e color)
+{
+	/*  enable CONFIG_NET_RUNTIME_LOG */
+	return -1;
+}
+int netlog_set_timer(nl_options opt)
+{
+	/*  enable CONFIG_NET_RUNTIME_LOG */
+	return -1;
+}
+int netlog_set_function(nl_options opt)
+{
+	/*  enable CONFIG_NET_RUNTIME_LOG */
+	return -1;
+}
+int netlog_set_file(nl_options opt)
+{
+	/*  enable CONFIG_NET_RUNTIME_LOG */
+	return -1;
+}
+
+int netlog_reset(void)
+{
+	/*  enable CONFIG_NET_RUNTIME_LOG */
+	return -1;
+}
+#endif /*  CONFIG_NET_RUNTIME_LOG */

--- a/external/netutils/netlib_netmon.c
+++ b/external/netutils/netlib_netmon.c
@@ -34,8 +34,6 @@
 #include <netutils/netlib.h>
 #include <tinyara/net/netlog.h>
 
-#define TAG "[NETLIB]"
-
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
@@ -62,7 +60,7 @@ int netlib_netmon_sock(void *arg)
 	struct req_lwip_data req;
 	int sockfd = socket(AF_INET, NETLIB_SOCK_IOCTL, 0);
 	if (sockfd == -1) {
-		NET_LOGE(TAG, "socket() failed with errno: %d\n", errno);
+		NET_LOGE(NL_MOD_NETLIB, "socket() failed with errno: %d\n", errno);
 		return -1;
 	}
 
@@ -72,7 +70,7 @@ int netlib_netmon_sock(void *arg)
 	ret = ioctl(sockfd, SIOCLWIP, (unsigned long)&req);
 	close(sockfd);
 	if (ret == ERROR) {
-		NET_LOGE(TAG, "ioctl() failed with errno: %d\n", errno);
+		NET_LOGE(NL_MOD_NETLIB, "ioctl() failed with errno: %d\n", errno);
 		return -1;
 	}
 	arg = (void *)req.msg.netmon.info;
@@ -105,7 +103,7 @@ int netlib_netmon_devstats(const char *ifname, void **arg)
 	struct req_lwip_data req;
 	int sockfd = socket(AF_INET, NETLIB_SOCK_IOCTL, 0);
 	if (sockfd == -1) {
-		NET_LOGE(TAG, "socket() failed with errno: %d\n", errno);
+		NET_LOGE(NL_MOD_NETLIB, "socket() failed with errno: %d\n", errno);
 		return -1;
 	}
 
@@ -116,7 +114,7 @@ int netlib_netmon_devstats(const char *ifname, void **arg)
 	ret = ioctl(sockfd, SIOCLWIP, (unsigned long)&req);
 	close(sockfd);
 	if (ret == ERROR) {
-		NET_LOGE(TAG, "ioctl() failed with errno: %d\n", errno);
+		NET_LOGE(NL_MOD_NETLIB, "ioctl() failed with errno: %d\n", errno);
 		return -1;
 	}
 	ret = req.req_res;

--- a/external/netutils/netlib_server.c
+++ b/external/netutils/netlib_server.c
@@ -67,7 +67,6 @@
 #include <netutils/netlib.h>
 #include <tinyara/net/netlog.h>
 
-#define TAG "[NETLIB]"
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
@@ -107,7 +106,7 @@ void netlib_server(uint16_t portno, pthread_startroutine_t handler, int stacksiz
 
 	listensd = netlib_listenon(portno);
 	if (listensd < 0) {
-		NET_LOGE(TAG, "create listen socket\n");
+		NET_LOGE(NL_MOD_NETLIB, "create listen socket\n");
 		return;
 	}
 
@@ -119,11 +118,11 @@ void netlib_server(uint16_t portno, pthread_startroutine_t handler, int stacksiz
 		addrlen = sizeof(struct sockaddr_in);
 		acceptsd = accept(listensd, (struct sockaddr *)&myaddr, &addrlen);
 		if (acceptsd < 0) {
-			NET_LOGE(TAG, "accept failure: %d\n", errno);
+			NET_LOGE(NL_MOD_NETLIB, "accept failure: %d\n", errno);
 			break;
 		}
 
-		NET_LOGV(TAG, "Connection accepted -- spawning sd=%d\n", acceptsd);
+		NET_LOGV(NL_MOD_NETLIB, "Connection accepted -- spawning sd=%d\n", acceptsd);
 
 		/* Create a thread to handle the connection.  The socket descriptor is
 		 * provided in as the single argument to the new thread.
@@ -137,7 +136,7 @@ void netlib_server(uint16_t portno, pthread_startroutine_t handler, int stacksiz
 			/* Close the connection */
 
 			close(acceptsd);
-			NET_LOGE(TAG, "pthread_create failed\n");
+			NET_LOGE(NL_MOD_NETLIB, "pthread_create failed\n");
 
 			if (ret == EAGAIN) {
 				/* Lacked resources to create a new thread. This is a temporary

--- a/external/netutils/netlib_setdnsserver.c
+++ b/external/netutils/netlib_setdnsserver.c
@@ -29,8 +29,6 @@
 #include <tinyara/netmgr/netctl.h>
 #include <tinyara/net/netlog.h>
 
-#define TAG "[NETLIB]"
-
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
@@ -75,7 +73,7 @@ int netlib_setdnsserver(struct sockaddr *addr, int index)
 
 	int sockfd = socket(AF_INET, SOCK_DGRAM, 0);
 	if (sockfd < 0) {
-		NET_LOGE(TAG, "socket() failed with errno: %d\n", errno);
+		NET_LOGE(NL_MOD_NETLIB, "socket() failed with errno: %d\n", errno);
 		return ret;
 	}
 
@@ -87,7 +85,7 @@ int netlib_setdnsserver(struct sockaddr *addr, int index)
 	ret = ioctl(sockfd, SIOCLWIP, (unsigned long)&req);
 	close(sockfd);
 	if (ret == ERROR) {
-		NET_LOGE(TAG, "ioctl() failed with errno: %d\n", errno);
+		NET_LOGE(NL_MOD_NETLIB, "ioctl() failed with errno: %d\n", errno);
 		return ret;
 	}
 	return req.req_res;

--- a/external/netutils/netlib_setmacaddr.c
+++ b/external/netutils/netlib_setmacaddr.c
@@ -70,7 +70,6 @@
 #include <netutils/netlib.h>
 #include <tinyara/net/netlog.h>
 
-#define TAG "[NETLIB]"
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
@@ -102,9 +101,9 @@ void print_mac_addr(const uint8_t *mac)
 	int i;
 	for (i = 0; i < IFHWADDRLEN; i++) {
 		if (i == IFHWADDRLEN - 1) {
-			NET_LOG(TAG, "%02x\t", mac[i]);
+			NET_LOG(NL_MOD_NETLIB, "%02x\t", mac[i]);
 		} else {
-			NET_LOG(TAG, "%02x:\t", mac[i]);
+			NET_LOG(NL_MOD_NETLIB, "%02x:\t", mac[i]);
 		}
 	}
 }
@@ -127,12 +126,12 @@ void print_mac_addr(const uint8_t *mac)
 int netlib_setmacaddr(const char *ifname, const uint8_t *macaddr)
 {
 	int ret = ERROR;
-	NET_LOGV(TAG, "Entry\n");
+	NET_LOGV(NL_MOD_NETLIB, "Entry\n");
 	if (ifname && macaddr) {
 		/* Get a socket (only so that we get access to the INET subsystem) */
 
 		int sockfd = socket(PF_INETX, NETLIB_SOCK_IOCTL, 0);
-		NET_LOGV(TAG, "sockfd = %d\n", sockfd);
+		NET_LOGV(NL_MOD_NETLIB, "sockfd = %d\n", sockfd);
 		if (sockfd >= 0) {
 			struct ifreq req;
 
@@ -140,7 +139,7 @@ int netlib_setmacaddr(const char *ifname, const uint8_t *macaddr)
 			strncpy(req.ifr_name, ifname, IFNAMSIZ);
 
 			/* Put the new MAC address into the request */
-			NET_LOG(TAG, "Setting Mac Addr to \n");
+			NET_LOG(NL_MOD_NETLIB, "Setting Mac Addr to \n");
 			print_mac_addr(macaddr);
 			req.ifr_hwaddr.sa_family = AF_INETX;
 			memcpy(&req.ifr_hwaddr.sa_data, macaddr, IFHWADDRLEN);
@@ -151,7 +150,7 @@ int netlib_setmacaddr(const char *ifname, const uint8_t *macaddr)
 			close(sockfd);
 		}
 	}
-	NET_LOGV(TAG, "Exit\n");
+	NET_LOGV(NL_MOD_NETLIB, "Exit\n");
 	return ret;
 }
 

--- a/framework/src/wifi_manager/wifi_manager_api.c
+++ b/framework/src/wifi_manager/wifi_manager_api.c
@@ -37,13 +37,13 @@
 #define WIFIMGR_CHECK_AP_CONFIG(config)                                                                                         \
 	do {                                                                                                                        \
 		if (config->ssid_length > WIFIMGR_SSID_LEN || strlen(config->ssid) > WIFIMGR_SSID_LEN) {                                \
-			NET_LOGE(TAG, "AP configuration fails: too long ssid\n");                                                           \
-			NET_LOGE(TAG, "Make sure that length of SSID < 33\n");                                                              \
+			NET_LOGE(NL_MOD_WIFI_MANAGER, "AP configuration fails: too long ssid\n");                                                           \
+			NET_LOGE(NL_MOD_WIFI_MANAGER, "Make sure that length of SSID < 33\n");                                                              \
 			WIFIADD_ERR_RECORD(ERR_WIFIMGR_INVALID_ARGUMENTS);                                                                  \
 			return WIFI_MANAGER_INVALID_ARGS;                                                                                   \
 		} else if (config->passphrase_length > WIFIMGR_PASSPHRASE_LEN || strlen(config->passphrase) > WIFIMGR_PASSPHRASE_LEN) { \
-			NET_LOGE(TAG, "AP configuration fails: too long passphrase\n");                                                     \
-			NET_LOGE(TAG, "Make sure that length of passphrase < 65\n");                                                        \
+			NET_LOGE(NL_MOD_WIFI_MANAGER, "AP configuration fails: too long passphrase\n");                                                     \
+			NET_LOGE(NL_MOD_WIFI_MANAGER, "Make sure that length of passphrase < 65\n");                                                        \
 			WIFIADD_ERR_RECORD(ERR_WIFIMGR_INVALID_ARGUMENTS);                                                                  \
 			return WIFI_MANAGER_INVALID_ARGS;                                                                                   \
 		}                                                                                                                       \
@@ -57,7 +57,6 @@
 			return msg.result;					\
 		}										\
 	} while (0)
-#define TAG "[WM]"
 
 static inline void _convert_state(wifimgr_state_e *state, connect_status_e *conn, wifi_manager_mode_e *mode)
 {
@@ -89,7 +88,7 @@ static inline void _convert_state(wifimgr_state_e *state, connect_status_e *conn
 	case WIFIMGR_UNINITIALIZED:
 		break;
 	default:
-		NET_LOGE(TAG, "invalid state\n");
+		NET_LOGE(NL_MOD_WIFI_MANAGER, "invalid state\n");
 		break;
 	}
 }
@@ -98,7 +97,7 @@ static inline void _convert_state(wifimgr_state_e *state, connect_status_e *conn
  */
 wifi_manager_result_e wifi_manager_init(wifi_manager_cb_s *wmcb)
 {
-	NET_LOGI(TAG, "--> %s %d\n", __FUNCTION__, __LINE__);
+	NET_LOGI(NL_MOD_WIFI_MANAGER, "--> %s %d\n", __FUNCTION__, __LINE__);
 	if (!wmcb) {
 		WIFIADD_ERR_RECORD(ERR_WIFIMGR_INVALID_ARGUMENTS);
 		return WIFI_MANAGER_INVALID_ARGS;
@@ -110,14 +109,14 @@ wifi_manager_result_e wifi_manager_init(wifi_manager_cb_s *wmcb)
 
 wifi_manager_result_e wifi_manager_deinit(void)
 {
-	NET_LOGI(TAG, "--> %s %d\n", __FUNCTION__, __LINE__);
+	NET_LOGI(NL_MOD_WIFI_MANAGER, "--> %s %d\n", __FUNCTION__, __LINE__);
 	sem_t signal;
 	sem_init(&signal, 0, 0);
 	wifimgr_msg_s msg = {WIFIMGR_CMD_DEINIT, WIFI_MANAGER_FAIL, NULL, &signal};
 
 	int res = wifimgr_post_message(&msg);
 	if (res < 0 || msg.result != WIFI_MANAGER_SUCCESS) {
-		NET_LOGE(TAG, "post message fail %d %d\n", res, msg.result);
+		NET_LOGE(NL_MOD_WIFI_MANAGER, "post message fail %d %d\n", res, msg.result);
 		sem_destroy(msg.signal);
 		if (res < 0) {
 			return WIFI_MANAGER_FAIL;
@@ -133,7 +132,7 @@ wifi_manager_result_e wifi_manager_deinit(void)
 
 wifi_manager_result_e wifi_manager_set_mode(wifi_manager_mode_e mode, wifi_manager_softap_config_s *config)
 {
-	NET_LOGI(TAG, "--> %s %d\n", __FUNCTION__, __LINE__);
+	NET_LOGI(NL_MOD_WIFI_MANAGER, "--> %s %d\n", __FUNCTION__, __LINE__);
 	if (mode != STA_MODE && mode != SOFTAP_MODE) {
 		WIFIADD_ERR_RECORD(ERR_WIFIMGR_INVALID_ARGUMENTS);
 		return WIFI_MANAGER_INVALID_ARGS;
@@ -169,7 +168,7 @@ wifi_manager_result_e wifi_manager_set_mode(wifi_manager_mode_e mode, wifi_manag
 
 wifi_manager_result_e wifi_manager_connect_ap(wifi_manager_ap_config_s *config)
 {
-	NET_LOGI(TAG, "--> %s %d\n", __FUNCTION__, __LINE__);
+	NET_LOGI(NL_MOD_WIFI_MANAGER, "--> %s %d\n", __FUNCTION__, __LINE__);
 	if (!config) {
 		WIFIADD_ERR_RECORD(ERR_WIFIMGR_INVALID_ARGUMENTS);
 		return WIFI_MANAGER_INVALID_ARGS;
@@ -183,18 +182,18 @@ wifi_manager_result_e wifi_manager_connect_ap(wifi_manager_ap_config_s *config)
 
 wifi_manager_result_e wifi_manager_disconnect_ap(void)
 {
-	NET_LOGI(TAG, "--> %s %d\n", __FUNCTION__, __LINE__);
+	NET_LOGI(NL_MOD_WIFI_MANAGER, "--> %s %d\n", __FUNCTION__, __LINE__);
 	wifimgr_msg_s msg = {WIFIMGR_CMD_DISCONNECT, WIFI_MANAGER_FAIL, NULL, NULL};
 	RETURN_RESULT(wifimgr_post_message(&msg), msg);
 }
 
 wifi_manager_result_e wifi_manager_scan_ap(wifi_manager_scan_config_s *config)
 {
-	NET_LOGI(TAG, "--> %s %d\n", __FUNCTION__, __LINE__);
+	NET_LOGI(NL_MOD_WIFI_MANAGER, "--> %s %d\n", __FUNCTION__, __LINE__);
 	if (config) {
 		if (config->channel > WIFIMGR_2G_CHANNEL_MAX) {
 			WIFIADD_ERR_RECORD(ERR_WIFIMGR_INVALID_ARGUMENTS);
-			NET_LOGE(TAG, "invalid channel range %d\n", config->channel);
+			NET_LOGE(NL_MOD_WIFI_MANAGER, "invalid channel range %d\n", config->channel);
 			return WIFI_MANAGER_INVALID_ARGS;
 		}
 		if (config->ssid_length > WIFIMGR_SSID_LEN) {
@@ -212,7 +211,7 @@ wifi_manager_result_e wifi_manager_scan_ap(wifi_manager_scan_config_s *config)
 
 wifi_manager_result_e wifi_manager_scan_specific_ap(wifi_manager_ap_config_s *config)
 {
-	NET_LOGI(TAG, "--> %s %d\n", __FUNCTION__, __LINE__);
+	NET_LOGI(NL_MOD_WIFI_MANAGER, "--> %s %d\n", __FUNCTION__, __LINE__);
 	return WIFI_MANAGER_NO_API;
 }
 
@@ -221,7 +220,7 @@ wifi_manager_result_e wifi_manager_scan_specific_ap(wifi_manager_ap_config_s *co
  */
 wifi_manager_result_e wifi_manager_get_info(wifi_manager_info_s *info)
 {
-	NET_LOGI(TAG, "--> %s %d\n", __FUNCTION__, __LINE__);
+	NET_LOGI(NL_MOD_WIFI_MANAGER, "--> %s %d\n", __FUNCTION__, __LINE__);
 	if (info == NULL) {
 		WIFIADD_ERR_RECORD(ERR_WIFIMGR_INVALID_ARGUMENTS);
 		return WIFI_MANAGER_INVALID_ARGS;
@@ -244,7 +243,7 @@ wifi_manager_result_e wifi_manager_get_info(wifi_manager_info_s *info)
 
 wifi_manager_result_e wifi_manager_get_stats(wifi_manager_stats_s *stats)
 {
-	NET_LOGI(TAG, "--> %s %d\n", __FUNCTION__, __LINE__);
+	NET_LOGI(NL_MOD_WIFI_MANAGER, "--> %s %d\n", __FUNCTION__, __LINE__);
 	if (!stats) {
 		WIFIADD_ERR_RECORD(ERR_WIFIMGR_INVALID_ARGUMENTS);
 		return WIFI_MANAGER_INVALID_ARGS;
@@ -258,7 +257,7 @@ wifi_manager_result_e wifi_manager_get_stats(wifi_manager_stats_s *stats)
 
 wifi_manager_result_e wifi_manager_set_powermode(wifi_manager_powermode_e mode)
 {
-	NET_LOGI(TAG, "--> %s %d\n", __FUNCTION__, __LINE__);
+	NET_LOGI(NL_MOD_WIFI_MANAGER, "--> %s %d\n", __FUNCTION__, __LINE__);
 	wifimgr_msg_s msg = {WIFIMGR_CMD_SETPOWER, WIFI_MANAGER_FAIL, (void *)&mode, 0};
 	RETURN_RESULT(wifimgr_post_message(&msg), msg);
 }
@@ -268,7 +267,7 @@ wifi_manager_result_e wifi_manager_set_powermode(wifi_manager_powermode_e mode)
  */
 wifi_manager_result_e wifi_manager_register_cb(wifi_manager_cb_s *wmcb)
 {
-	NET_LOGI(TAG, "--> %s %d\n", __FUNCTION__, __LINE__);
+	NET_LOGI(NL_MOD_WIFI_MANAGER, "--> %s %d\n", __FUNCTION__, __LINE__);
 	int res = wifimgr_register_cb(wmcb);
 	if (res < 0) {
 		return WIFI_MANAGER_FAIL;
@@ -278,7 +277,7 @@ wifi_manager_result_e wifi_manager_register_cb(wifi_manager_cb_s *wmcb)
 
 wifi_manager_result_e wifi_manager_unregister_cb(wifi_manager_cb_s *wmcb)
 {
-	NET_LOGI(TAG, "--> %s %d\n", __FUNCTION__, __LINE__);
+	NET_LOGI(NL_MOD_WIFI_MANAGER, "--> %s %d\n", __FUNCTION__, __LINE__);
 	if (!wmcb) {
 		return WIFI_MANAGER_INVALID_ARGS;
 	}
@@ -297,7 +296,7 @@ wifi_manager_result_e wifi_manager_unregister_cb(wifi_manager_cb_s *wmcb)
 #ifdef CONFIG_WIFI_MANAGER_SAVE_CONFIG
 wifi_manager_result_e wifi_manager_save_config(wifi_manager_ap_config_s *config)
 {
-	NET_LOGI(TAG, "--> %s %d\n", __FUNCTION__, __LINE__);
+	NET_LOGI(NL_MOD_WIFI_MANAGER, "--> %s %d\n", __FUNCTION__, __LINE__);
 	if (!config) {
 		WIFIADD_ERR_RECORD(ERR_WIFIMGR_INVALID_ARGUMENTS);
 	}
@@ -310,7 +309,7 @@ wifi_manager_result_e wifi_manager_save_config(wifi_manager_ap_config_s *config)
 
 wifi_manager_result_e wifi_manager_get_config(wifi_manager_ap_config_s *config)
 {
-	NET_LOGI(TAG, "--> %s %d\n", __FUNCTION__, __LINE__);
+	NET_LOGI(NL_MOD_WIFI_MANAGER, "--> %s %d\n", __FUNCTION__, __LINE__);
 	if (!config) {
 		WIFIADD_ERR_RECORD(ERR_WIFIMGR_INVALID_ARGUMENTS);
 	}
@@ -322,14 +321,14 @@ wifi_manager_result_e wifi_manager_get_config(wifi_manager_ap_config_s *config)
 
 wifi_manager_result_e wifi_manager_remove_config(void)
 {
-	NET_LOGI(TAG, "--> %s %d\n", __FUNCTION__, __LINE__);
+	NET_LOGI(NL_MOD_WIFI_MANAGER, "--> %s %d\n", __FUNCTION__, __LINE__);
 	WIFIMGR_CHECK_UTILRESULT(wifi_profile_reset(0), TAG, "wifimgr remove config fail");
 	return WIFI_MANAGER_SUCCESS;
 }
 
 wifi_manager_result_e wifi_manager_get_connected_config(wifi_manager_ap_config_s *config)
 {
-	NET_LOGI(TAG, "--> %s %d\n", __FUNCTION__, __LINE__);
+	NET_LOGI(NL_MOD_WIFI_MANAGER, "--> %s %d\n", __FUNCTION__, __LINE__);
 	if (!config) {
 		WIFIADD_ERR_RECORD(ERR_WIFIMGR_INVALID_ARGUMENTS);
 	}
@@ -340,25 +339,25 @@ wifi_manager_result_e wifi_manager_get_connected_config(wifi_manager_ap_config_s
 #else
 wifi_manager_result_e wifi_manager_save_config(wifi_manager_ap_config_s *config)
 {
-	NET_LOGI(TAG, "--> %s %d\n", __FUNCTION__, __LINE__);
+	NET_LOGI(NL_MOD_WIFI_MANAGER, "--> %s %d\n", __FUNCTION__, __LINE__);
 	return WIFI_MANAGER_NO_API;
 }
 
 wifi_manager_result_e wifi_manager_get_config(wifi_manager_ap_config_s *config)
 {
-	NET_LOGI(TAG, "--> %s %d\n", __FUNCTION__, __LINE__);
+	NET_LOGI(NL_MOD_WIFI_MANAGER, "--> %s %d\n", __FUNCTION__, __LINE__);
 	return WIFI_MANAGER_NO_API;
 }
 
 wifi_manager_result_e wifi_manager_remove_config(void)
 {
-	NET_LOGI(TAG, "--> %s %d\n", __FUNCTION__, __LINE__);
+	NET_LOGI(NL_MOD_WIFI_MANAGER, "--> %s %d\n", __FUNCTION__, __LINE__);
 	return WIFI_MANAGER_NO_API;
 }
 
 wifi_manager_result_e wifi_manager_get_connected_config(wifi_manager_ap_config_s *config)
 {
-	NET_LOGI(TAG, "--> %s %d\n", __FUNCTION__, __LINE__);
+	NET_LOGI(NL_MOD_WIFI_MANAGER, "--> %s %d\n", __FUNCTION__, __LINE__);
 	return WIFI_MANAGER_NO_API;
 }
 #endif // CONFIG_WIFI_MANAGER_SAVE_CONFIG

--- a/framework/src/wifi_manager/wifi_manager_cb.c
+++ b/framework/src/wifi_manager/wifi_manager_cb.c
@@ -34,8 +34,6 @@
 #define WIFIMGR_NUM_CALLBACKS 3
 #define LOCK_WIFICB pthread_mutex_lock(&g_cb_handler.lock)
 #define UNLOCK_WIFICB pthread_mutex_unlock(&g_cb_handler.lock)
-#define TAG "[WM]"
-
 /*  Handler */
 struct wifimgr_cb_handler {
 	wifi_manager_cb_s *cb[WIFIMGR_NUM_CALLBACKS];
@@ -109,7 +107,7 @@ static void _create_cb_msg(wifi_manager_cb_msg_s *msg,
 		trwifi_scan_list_s *list = (trwifi_scan_list_s *)arg;
 		wifi_manager_scan_info_s *info = NULL;
 		if (!list || WIFI_MANAGER_SUCCESS != _convert_scan_info(&info, list)) {
-			NET_LOGE(TAG, "convert scan error\n");
+			NET_LOGE(NL_MOD_WIFI_MANAGER, "convert scan error\n");
 			msg->res = WIFI_MANAGER_FAIL;
 		} else {
 			msg->scanlist = info;
@@ -145,44 +143,44 @@ static void _post_user_cb(_wifimgr_usr_cb_type_e evt,
 		}
 		switch (evt) {
 		case CB_STA_CONNECTED:
-			NET_LOGV(TAG, "call sta connect success event\n");
+			NET_LOGV(NL_MOD_WIFI_MANAGER, "call sta connect success event\n");
 			if (cbk->sta_connected) {
 				cbk->sta_connected(msg, NULL);
 			}
 			break;
 		case CB_STA_CONNECT_FAILED:
-			NET_LOGV(TAG, "call sta connect fail event\n");
+			NET_LOGV(NL_MOD_WIFI_MANAGER, "call sta connect fail event\n");
 			WIFIADD_ERR_RECORD(ERR_WIFIMGR_CONNECT_FAIL);
 			if (cbk->sta_connected) {
 				cbk->sta_connected(msg, NULL);
 			}
 			break;
 		case CB_STA_DISCONNECTED:
-			NET_LOGV(TAG, "call sta disconnect event\n");
+			NET_LOGV(NL_MOD_WIFI_MANAGER, "call sta disconnect event\n");
 			if (cbk->sta_disconnected) {
 				cbk->sta_disconnected(msg, NULL);
 			}
 			break;
 		case CB_STA_RECONNECTED:
-			NET_LOGV(TAG, "call sta reconnect event\n");
+			NET_LOGV(NL_MOD_WIFI_MANAGER, "call sta reconnect event\n");
 			if (cbk->sta_disconnected) {
 				cbk->sta_disconnected(msg, NULL);
 			}
 			break;
 		case CB_STA_JOINED:
-			NET_LOGV(TAG, "call sta join event\n");
+			NET_LOGV(NL_MOD_WIFI_MANAGER, "call sta join event\n");
 			if (cbk->softap_sta_joined) {
 				cbk->softap_sta_joined(msg, NULL);
 			}
 			break;
 		case CB_STA_LEFT:
-			NET_LOGV(TAG, "call sta leave event\n");
+			NET_LOGV(NL_MOD_WIFI_MANAGER, "call sta leave event\n");
 			if (cbk->softap_sta_left) {
 				cbk->softap_sta_left(msg, NULL);
 			}
 			break;
 		case CB_SCAN_DONE:
-			NET_LOGV(TAG, "call sta scan event\n");
+			NET_LOGV(NL_MOD_WIFI_MANAGER, "call sta scan event\n");
 			/* convert scan data.*/
 			if (cbk->scan_ap_done) {
 				cbk->scan_ap_done(msg, NULL);
@@ -190,7 +188,7 @@ static void _post_user_cb(_wifimgr_usr_cb_type_e evt,
 			break;
 		default:
 			WIFIADD_ERR_RECORD(ERR_WIFIMGR_INVALID_EVENT);
-			NET_LOGE(TAG, "Invalid State\n");
+			NET_LOGE(NL_MOD_WIFI_MANAGER, "Invalid State\n");
 		}
 	}
 }

--- a/framework/src/wifi_manager/wifi_manager_dhcp.h
+++ b/framework/src/wifi_manager/wifi_manager_dhcp.h
@@ -28,15 +28,15 @@
 		int res = -1;                                           \
 		res = netlib_set_ipv4addr(intf, &ip);                   \
 		if (res == -1) {                                        \
-			NET_LOGE(TAG, "set ipv4 addr error\n");                \
+			NET_LOGE(NL_MOD_WIFI_MANAGER, "set ipv4 addr error\n");                \
 		}                                                       \
 		res = netlib_set_ipv4netmask(intf, &netmask);           \
 		if (res == -1) {                                        \
-			NET_LOGE(TAG, "set netmask addr error\n");             \
+			NET_LOGE(NL_MOD_WIFI_MANAGER, "set netmask addr error\n");             \
 		}                                                       \
 		res = netlib_set_dripv4addr(intf, &gateway);            \
 		if (res == -1) {                                        \
-			NET_LOGE(TAG, "set route addr error\n");               \
+			NET_LOGE(NL_MOD_WIFI_MANAGER, "set route addr error\n");               \
 		}                                                       \
 	} while (0)
 

--- a/framework/src/wifi_manager/wifi_manager_dhcpc.c
+++ b/framework/src/wifi_manager/wifi_manager_dhcpc.c
@@ -30,8 +30,6 @@
 #include "wifi_manager_error.h"
 #include "wifi_manager_dhcp.h"
 
-#define TAG "[WM]"
-
 /**
  * Internal DHCP client APIs
  */
@@ -45,17 +43,17 @@ wifi_manager_result_e dhcpc_get_ipaddr(void)
 	ret = dhcp_client_start(WIFIMGR_STA_IFNAME);
 	if (ret != 0) {
 		WIFIADD_ERR_RECORD(ERR_WIFIMGR_CONNECT_DHCPC_FAIL);
-		NET_LOGE(TAG, "[DHCPC] get IP address fail\n");
+		NET_LOGE(NL_MOD_WIFI_MANAGER, "[DHCPC] get IP address fail\n");
 		return wret;
 	}
 
 	ret = netlib_get_ipv4addr(WIFIMGR_STA_IFNAME, &ip);
 	if (ret != 0) {
-		NET_LOGE(TAG, "[DHCPC] get IP address fail\n");
+		NET_LOGE(NL_MOD_WIFI_MANAGER, "[DHCPC] get IP address fail\n");
 		WIFIADD_ERR_RECORD(ERR_WIFIMGR_CONNECT_DHCPC_FAIL);
 		return wret;
 	}
-	NET_LOGV(TAG, "[DHCPC] get IP address %s\n", inet_ntoa(ip));
+	NET_LOGV(NL_MOD_WIFI_MANAGER, "[DHCPC] get IP address %s\n", inet_ntoa(ip));
 
 	return WIFI_MANAGER_SUCCESS;
 }
@@ -70,6 +68,6 @@ void dhcpc_close_ipaddr(void)
 	/* To-Do is it right to clear IP address in here */
 	struct in_addr in = { .s_addr = INADDR_NONE };
 	WIFIMGR_SET_IP4ADDR(WIFIMGR_SOFTAP_IFNAME, in, in, in);
-	NET_LOGV(TAG, "release IP address\n");
+	NET_LOGV(NL_MOD_WIFI_MANAGER, "release IP address\n");
 	return;
 }

--- a/framework/src/wifi_manager/wifi_manager_dhcps.c
+++ b/framework/src/wifi_manager/wifi_manager_dhcps.c
@@ -39,18 +39,17 @@
 		int res = -1;                                           \
 		res = netlib_set_ipv4addr(intf, &ip);                   \
 		if (res == -1) {                                        \
-			NET_LOGE(TAG, "set ipv4 addr error\n");                \
+			NET_LOGE(NL_MOD_WIFI_MANAGER, "set ipv4 addr error\n");                \
 		}                                                       \
 		res = netlib_set_ipv4netmask(intf, &netmask);           \
 		if (res == -1) {                                        \
-			NET_LOGE(TAG, "set netmask addr error\n");             \
+			NET_LOGE(NL_MOD_WIFI_MANAGER, "set netmask addr error\n");             \
 		}                                                       \
 		res = netlib_set_dripv4addr(intf, &gateway);            \
 		if (res == -1) {                                        \
-			NET_LOGE(TAG, "set route addr error\n");               \
+			NET_LOGE(NL_MOD_WIFI_MANAGER, "set route addr error\n");               \
 		}                                                       \
 	} while (0)
-#define TAG "[WM]"
 
 #ifndef CONFIG_WIFIMGR_DISABLE_DHCPS
 static dhcp_node_s g_dhcp_list = {WIFIMGR_IP4_ZERO, WIFIMGR_MAC_ZERO};
@@ -74,26 +73,26 @@ void _wifi_dhcps_event(dhcp_evt_type_e type, void *data)
 void dhcps_inc_num(void)
 {
 	if (num_sta == UINT8_MAX) {
-		NET_LOGE(TAG, "num_sta overflowed\n");
+		NET_LOGE(NL_MOD_WIFI_MANAGER, "num_sta overflowed\n");
 		return;
 	}
-	NET_LOGV(TAG, "increase num_sta by 1\n");
+	NET_LOGV(NL_MOD_WIFI_MANAGER, "increase num_sta by 1\n");
 	num_sta++;
 }
 
 void dhcps_dec_num(void)
 {
 	if (num_sta == 0) {
-		NET_LOGE(TAG, "num_sta underflowed\n");
+		NET_LOGE(NL_MOD_WIFI_MANAGER, "num_sta underflowed\n");
 		return;
 	}
-	NET_LOGV(TAG, "decrease num_sta by 1\n");
+	NET_LOGV(NL_MOD_WIFI_MANAGER, "decrease num_sta by 1\n");
 	num_sta--;
 }
 
 void dhcps_reset_num(void)
 {
-	NET_LOGV(TAG, "reset num_sta to 0\n");
+	NET_LOGV(NL_MOD_WIFI_MANAGER, "reset num_sta to 0\n");
 	num_sta = 0;
 }
 
@@ -116,17 +115,17 @@ dhcp_status_e dhcps_add_node(void *msg)
 {
 	dhcp_node_s *node = (dhcp_node_s *)msg;
 	if (node != NULL) {
-		NET_LOGV(TAG, "IP: %d:%d:%d:%d\n",
+		NET_LOGV(NL_MOD_WIFI_MANAGER, "IP: %d:%d:%d:%d\n",
 			  ((char *)&(node->ipaddr))[0],
 			  ((char *)&(node->ipaddr))[1],
 			  ((char *)&(node->ipaddr))[2],
 			  ((char *)&(node->ipaddr))[3]);
-		NET_LOGV(TAG, "MAC: %02x:%02x:%02x:%02x:%02x:%02x\n",
+		NET_LOGV(NL_MOD_WIFI_MANAGER, "MAC: %02x:%02x:%02x:%02x:%02x:%02x\n",
 			  node->macaddr[0], node->macaddr[1],
 			  node->macaddr[2], node->macaddr[3],
 			  node->macaddr[4], node->macaddr[5]);
 	} else {
-		NET_LOGE(TAG, "[DHCP] No DHCP node exists\n");
+		NET_LOGE(NL_MOD_WIFI_MANAGER, "[DHCP] No DHCP node exists\n");
 		return DHCP_ERR;
 	}
 
@@ -164,10 +163,10 @@ wifi_manager_result_e wm_dhcps_start(void)
 	WIFIMGR_SET_IP4ADDR(WIFIMGR_SOFTAP_IFNAME, ip, netmask, gw);
 
 	if (dhcp_server_start(WIFIMGR_SOFTAP_IFNAME, _wifi_dhcps_event) != 0) {
-		NET_LOGE(TAG, "[DHCP] DHCP Server - started fail\n");
+		NET_LOGE(NL_MOD_WIFI_MANAGER, "[DHCP] DHCP Server - started fail\n");
 		return WIFI_MANAGER_FAIL;
 	}
-	NET_LOGV(TAG, "DHCP Server - started successfully\n");
+	NET_LOGV(NL_MOD_WIFI_MANAGER, "DHCP Server - started successfully\n");
 
 	return WIFI_MANAGER_SUCCESS;
 }
@@ -178,10 +177,10 @@ wifi_manager_result_e wm_dhcps_stop(void)
 	WIFIMGR_SET_IP4ADDR(WIFIMGR_SOFTAP_IFNAME, in, in, in);
 
 	if (dhcp_server_stop(WIFIMGR_SOFTAP_IFNAME) != 0) {
-		NET_LOGE(TAG, "[DHCP] DHCP Server - stopped failed\n");
+		NET_LOGE(NL_MOD_WIFI_MANAGER, "[DHCP] DHCP Server - stopped failed\n");
 		return WIFI_MANAGER_FAIL;
 	}
-	NET_LOGV(TAG, "DHCP Server - stopped successfully\n");
+	NET_LOGV(NL_MOD_WIFI_MANAGER, "DHCP Server - stopped successfully\n");
 	return WIFI_MANAGER_SUCCESS;
 }
 

--- a/framework/src/wifi_manager/wifi_manager_error.h
+++ b/framework/src/wifi_manager/wifi_manager_error.h
@@ -15,7 +15,7 @@ static inline _set_error_code(wifi_manager_result_e res)
 		return;
 	}
 
-	NET_LOGE(TAG, "Wi-Fi manager fail: state error\n");
+	NET_LOGE(NL_MOD_WIFI_MANAGER, "Wi-Fi manager fail: state error\n");
 	error_code_wifi_manager_t wifi_err_code;
 	switch (msg->event) {
 	case WIFIMGR_CMD_INIT:

--- a/framework/src/wifi_manager/wifi_manager_event.c
+++ b/framework/src/wifi_manager/wifi_manager_event.c
@@ -27,8 +27,6 @@
 #include "wifi_manager_event.h"
 #include "wifi_manager_msghandler.h"
 
-#define TAG "[WM]"
-
 /*  wifimgr_evt_str should be mapped to enum _wifimgr_evt  */
 static char *wifimgr_evt_str[] = {
 #undef WIFIMGR_REQUEST_TABLE

--- a/framework/src/wifi_manager/wifi_manager_info.c
+++ b/framework/src/wifi_manager/wifi_manager_info.c
@@ -28,8 +28,6 @@
 #include "wifi_manager_info.h"
 #include "wifi_manager_lwnl.h"
 
-#define TAG "[WM]"
-
 struct _wifimgr_info {
 	char ssid[WIFIMGR_SSID_LEN + 1];		// SSID of Connected AP if mode is a station
 	char softap_ssid[WIFIMGR_SSID_LEN + 1]; // SoftAP SSID if mode is a soft ap

--- a/framework/src/wifi_manager/wifi_manager_lwnl.c
+++ b/framework/src/wifi_manager/wifi_manager_lwnl.c
@@ -31,20 +31,19 @@
 #include <tinyara/net/netlog.h>
 
 #define WU_INTF_NAME "wlan0"
-#define TAG "[WM]"
 
 static inline int _send_msg(lwnl_msg *msg)
 {
 	int fd = socket(AF_LWNL, SOCK_RAW, LWNL_ROUTE);
 	if (fd < 0) {
-		NET_LOGE(TAG, "send lwnl msg open error\n");
+		NET_LOGE(NL_MOD_WIFI_MANAGER, "send lwnl msg open error\n");
 		return -1;
 	}
 
 	int res = write(fd, msg, sizeof(*msg));
 	close(fd);
 	if (res < 0) {
-		NET_LOGE(TAG, "send lwnl msg write error\n");
+		NET_LOGE(NL_MOD_WIFI_MANAGER, "send lwnl msg write error\n");
 		return -2;
 	}
 	return 0;

--- a/framework/src/wifi_manager/wifi_manager_lwnl_listener.c
+++ b/framework/src/wifi_manager/wifi_manager_lwnl_listener.c
@@ -29,8 +29,6 @@
 #include <tinyara/net/netlog.h>
 #include "wifi_manager_message.h"
 
-#define TAG "[WM]"
-
 typedef struct {
 	wifimgr_evt_e wevt;
 	lwnl_cb_wifi levt;
@@ -66,7 +64,7 @@ static wifimgr_evt_e _lwnl_convert_levent(lwnl_cb_wifi levt)
 }
 static int _lwnl_convert_scan(trwifi_scan_list_s **scan_list, void *input, int len)
 {
-	NET_LOGV(TAG, "len(%d)\n", len);
+	NET_LOGV(NL_MOD_WIFI_MANAGER, "len(%d)\n", len);
 	int remain = len;
 	trwifi_scan_list_s *prev = NULL;
 
@@ -103,7 +101,7 @@ static trwifi_scan_list_s *_lwnl_handle_scan(int fd, int len)
 
 	int res = read(fd, buf, len);
 	if (res != len) {
-		NET_LOGE(TAG, "read error\n");
+		NET_LOGE(NL_MOD_WIFI_MANAGER, "read error\n");
 		free(buf);
 		return NULL;
 	}
@@ -140,7 +138,7 @@ static int _lwnl_generate_msg(int fd, lwnl_cb_status status, int len)
 		if (len == sizeof(trwifi_cbk_msg_s)) {
 			int res = read(fd, (void *)&g_cbk, len);
 			if (res == -1) {
-				NET_LOGE(TAG, "read lwnl msg error %d %d\n", status.evt, errno);
+				NET_LOGE(NL_MOD_WIFI_MANAGER, "read lwnl msg error %d %d\n", status.evt, errno);
 				assert(0);
 			}
 		} else if (len == 0){
@@ -153,7 +151,7 @@ static int _lwnl_generate_msg(int fd, lwnl_cb_status status, int len)
 		break;
 	}
 	default:
-		NET_LOGE(TAG, "Bad status received (%d)\n", status.evt);
+		NET_LOGE(NL_MOD_WIFI_MANAGER, "Bad status received (%d)\n", status.evt);
 		return -1;
 	}
 	return 0;
@@ -174,14 +172,14 @@ int lwnl_fetch_event(int fd, void *buf, int buflen)
 	 */
 	int nbytes = read(fd, (char *)type_buf, LWNL_CB_HEADER_LEN);
 	if (nbytes < 0) {
-		NET_LOGE(TAG, "Failed to receive (nbytes=%d)\n", nbytes);
+		NET_LOGE(NL_MOD_WIFI_MANAGER, "Failed to receive (nbytes=%d)\n", nbytes);
 		return -1;
 	}
 
 	memcpy(&status, type_buf, sizeof(lwnl_cb_status));
 	memcpy(&len, type_buf + sizeof(lwnl_cb_status), sizeof(uint32_t));
 
-	NET_LOGV(TAG, "receive state(%d) length(%d)\n", status.evt, len);
+	NET_LOGV(NL_MOD_WIFI_MANAGER, "receive state(%d) length(%d)\n", status.evt, len);
 	(void)_lwnl_generate_msg(fd, status, len);
 
 	hmsg->msg = &g_msg;

--- a/framework/src/wifi_manager/wifi_manager_message.c
+++ b/framework/src/wifi_manager/wifi_manager_message.c
@@ -38,7 +38,6 @@
 #else
 #define WIFIMGR_MSG_QUEUE_NAME "/tmp/wifimgr_msg"
 #endif
-#define TAG "[WM]"
 
 extern wifi_manager_result_e wifimgr_handle_request(wifimgr_msg_s *msg);
 
@@ -52,7 +51,7 @@ static inline int _send_message(int fd, void *buf, int buflen)
 			if (err_no == EAGAIN || err_no == EINTR) {
 				continue;
 			}
-			NET_LOGE(TAG, "write error %d\n", err_no);
+			NET_LOGE(NL_MOD_WIFI_MANAGER, "write error %d\n", err_no);
 			return -1;
 		}
 		sent += res;
@@ -73,7 +72,7 @@ static inline int _recv_message(int fd, void *buf, int buflen)
 			if (err_no == EAGAIN || err_no == EINTR) {
 				continue;
 			}
-			NET_LOGE(TAG, "read error %d\n", err_no);
+			NET_LOGE(NL_MOD_WIFI_MANAGER, "read error %d\n", err_no);
 			return -1;
 		}
 		received += res;
@@ -91,7 +90,7 @@ int wifimgr_message_in(handler_msg *msg, handler_queue *queue)
 {
 	int fd = open(WIFIMGR_MSG_QUEUE_NAME, O_WRONLY);
 	if (fd < 0) {
-		NET_LOGE(TAG, "open error %d\n", errno);
+		NET_LOGE(NL_MOD_WIFI_MANAGER, "open error %d\n", errno);
 		return -1;
 	}
 
@@ -115,13 +114,13 @@ int wifimgr_message_out(handler_msg *msg, handler_queue *queue)
 		if (err_no == EINTR) {
 			return 1;
 		}
-		NET_LOGE(TAG, "select error(%d)\n", err_no);
+		NET_LOGE(NL_MOD_WIFI_MANAGER, "select error(%d)\n", err_no);
 		return -1;
 	}
 	if (FD_ISSET(queue->fd, &rfds)) {
 		res = _recv_message(queue->fd, (void *)msg, sizeof(handler_msg));
 		if (res < 0) {
-			NET_LOGE(TAG, "critical error\n");
+			NET_LOGE(NL_MOD_WIFI_MANAGER, "critical error\n");
 		} else {
 			wifimgr_msg_s *wmsg = msg->msg;
 			wmsg->result = wifimgr_handle_request(wmsg);
@@ -134,7 +133,7 @@ int wifimgr_message_out(handler_msg *msg, handler_queue *queue)
 	if (FD_ISSET(queue->nd, &rfds)) {
 		res = lwnl_fetch_event(queue->nd, (void *)msg, sizeof(handler_msg));
 		if (res < 0) {
-			NET_LOGE(TAG, "critical error\n");
+			NET_LOGE(NL_MOD_WIFI_MANAGER, "critical error\n");
 		} else {
 			wifimgr_msg_s *wmsg = msg->msg;
 			if (wmsg) {
@@ -156,13 +155,13 @@ int wifimgr_create_msgqueue(handler_queue *queue)
 
 	int res = mkfifo(WIFIMGR_MSG_QUEUE_NAME, 0666);
 	if (res < 0 && res != -EEXIST) {
-		NET_LOGE(TAG, "create wifimgr msg queue fail %d\n", errno);
+		NET_LOGE(NL_MOD_WIFI_MANAGER, "create wifimgr msg queue fail %d\n", errno);
 		return -1;
 	}
 
 	queue->fd = open(WIFIMGR_MSG_QUEUE_NAME, O_RDWR);
 	if (queue->fd < 0) {
-		NET_LOGE(TAG, "open wifimgr msg queue fail %d\n", errno);
+		NET_LOGE(NL_MOD_WIFI_MANAGER, "open wifimgr msg queue fail %d\n", errno);
 		unlink(WIFIMGR_MSG_QUEUE_NAME);
 		return -1;
 	}
@@ -172,7 +171,7 @@ int wifimgr_create_msgqueue(handler_queue *queue)
 	queue->nd = socket(AF_LWNL, SOCK_RAW, LWNL_ROUTE);
 	if (queue->nd < 0) {
 		close(queue->fd);
-		NET_LOGE(TAG, "socket open fail %d\n", errno);
+		NET_LOGE(NL_MOD_WIFI_MANAGER, "socket open fail %d\n", errno);
 		return -1;
 	}
 
@@ -181,7 +180,7 @@ int wifimgr_create_msgqueue(handler_queue *queue)
 	if (res < 0) {
 		close(queue->fd);
 		close(queue->nd);
-		NET_LOGE(TAG, "bind fail %d\n", errno);
+		NET_LOGE(NL_MOD_WIFI_MANAGER, "bind fail %d\n", errno);
 		return -1;
 	}
 	FD_SET(queue->nd, &queue->rfds);

--- a/framework/src/wifi_manager/wifi_manager_msghandler.c
+++ b/framework/src/wifi_manager/wifi_manager_msghandler.c
@@ -32,8 +32,6 @@
 #include "wifi_manager_utils.h"
 #include "wifi_manager_lwnl_listener.h"
 
-#define TAG "[WM]"
-
 /*
  * Global variable
  */
@@ -56,7 +54,7 @@ static int _process_msg(int argc, char *argv[])
 		handler_msg hmsg;
 		int res = wifimgr_message_out(&hmsg, &g_wifi_message_queue);
 		if (res < 0) {
-			NET_LOGE(TAG, "wifimgr msg out fail %d\n", res);
+			NET_LOGE(NL_MOD_WIFI_MANAGER, "wifimgr msg out fail %d\n", res);
 			return -1;
 		} else if (res == 1) {
 			continue;
@@ -72,7 +70,7 @@ int wifimgr_run_msghandler(void)
 {
 	int tid = net_task_create("wifi msg handler", 100, 4096, (main_t)_process_msg, NULL);
 	if (tid == -1) {
-		NET_LOGE(TAG, "wifi msg handler task create %d\n", errno);
+		NET_LOGE(NL_MOD_WIFI_MANAGER, "wifi msg handler task create %d\n", errno);
 		return -1;
 	}
 
@@ -92,7 +90,7 @@ int wifimgr_post_message(wifimgr_msg_s *msg)
 
 	res = wifimgr_message_in(&hmsg, &g_wifi_message_queue);
 	if (res < 0) {
-		NET_LOGE(TAG, "wifimgr msg in fail %d\n", res);
+		NET_LOGE(NL_MOD_WIFI_MANAGER, "wifimgr msg in fail %d\n", res);
 		return -1;
 	}
 

--- a/framework/src/wifi_manager/wifi_manager_profile.c
+++ b/framework/src/wifi_manager/wifi_manager_profile.c
@@ -34,7 +34,6 @@
 #include "wifi_manager_profile.h"
 
 //#define WIFI_PROFILE_USE_ETC
-#define TAG "[WM]"
 
 #define WIFI_PROFILE_PATH "/mnt/"
 #define WIFI_PROFILE_FILENAME "wifi.conf"
@@ -146,13 +145,13 @@ static int _wifi_profile_store_file(char *buf, unsigned int buf_size, int intern
 	}
 
 	if (!fp) {
-		NET_LOGE(TAG, "file open error(%d)\n", errno);
+		NET_LOGE(NL_MOD_WIFI_MANAGER, "file open error(%d)\n", errno);
 		return -1;
 	}
 
 	int ret = fwrite(buf, 1, buf_size, fp);
 	if (ret < 0) {
-		NET_LOGE(TAG, "file write error(%d)\n", errno);
+		NET_LOGE(NL_MOD_WIFI_MANAGER, "file write error(%d)\n", errno);
 		fclose(fp);
 		return -1;
 	}
@@ -170,17 +169,17 @@ static int _wifi_profile_read_file(char *buf, unsigned int buf_size, int interna
 		fp = fopen(WIFI_PROFILE_PATH WIFI_PROFILE_FILENAME, "r");
 	}
 	if (!fp) {
-		NET_LOGE(TAG, "file open error(%d)\n", errno);
+		NET_LOGE(NL_MOD_WIFI_MANAGER, "file open error(%d)\n", errno);
 		return -1;
 	}
 
 	int ret = fread(buf, 1, buf_size, fp);
 	if (ret < 0) {
-		NET_LOGE(TAG, "fread fail\n");
+		NET_LOGE(NL_MOD_WIFI_MANAGER, "fread fail\n");
 		fclose(fp);
 		return -1;
 	} else if (ret > 107) {
-		NET_LOGE(TAG, "file is corrupted\n");
+		NET_LOGE(NL_MOD_WIFI_MANAGER, "file is corrupted\n");
 		fclose(fp);
 		return -1;
 	}
@@ -199,7 +198,7 @@ trwifi_result_e wifi_profile_init(void)
 #ifdef WIFI_PROFILE_USE_ETC
 	DIR *dir = opendir(WIFI_PROFILE_PATH);
 	if (!dir) {
-		NET_LOGE(TAG, "error reason (%d)\n", errno);
+		NET_LOGE(NL_MOD_WIFI_MANAGER, "error reason (%d)\n", errno);
 		if (errno == ENOENT || errno == ENOTDIR) {
 			ret = mkdir(WIFI_PROFILE_PATH, 0777);
 			if (ret < 0) {
@@ -223,7 +222,7 @@ trwifi_result_e wifi_profile_reset(int internal)
 	security_handle hnd;
 	security_error err = security_init(&hnd);
 	if (err != SECURITY_OK) {
-		NET_LOGE(TAG, "Reset wi-fi profile in SS fail\n", ret);
+		NET_LOGE(NL_MOD_WIFI_MANAGER, "Reset wi-fi profile in SS fail\n", ret);
 		return TRWIFI_FILE_ERROR;
 	}
 	security_data data = {&buf, 1};
@@ -248,7 +247,7 @@ trwifi_result_e wifi_profile_reset(int internal)
 		ret = unlink(WIFI_PROFILE_PATH WIFI_PROFILE_FILENAME);
 	}
 	if (ret < 0) {
-		NET_LOGE(TAG, "Delete Wi-Fi profile fail(%d)\n", errno);
+		NET_LOGE(NL_MOD_WIFI_MANAGER, "Delete Wi-Fi profile fail(%d)\n", errno);
 		return TRWIFI_FILE_ERROR;
 	}
 #endif
@@ -264,12 +263,12 @@ trwifi_result_e wifi_profile_write(wifi_manager_ap_config_s *config, int interna
 	if (len < 0) {
 		return TRWIFI_FAIL;
 	}
-	NET_LOGV(TAG, "store data to file: buffer len(%d)\n", len);
+	NET_LOGV(NL_MOD_WIFI_MANAGER, "store data to file: buffer len(%d)\n", len);
 #ifdef CONFIG_WIFI_PROFILE_SECURESTORAGE
 	security_handle hnd;
 	security_error err = security_init(&hnd);
 	if (err != SECURITY_OK) {
-		NET_LOGE(TAG, "Write Wi-Fi info in SS fail\n", ret);
+		NET_LOGE(NL_MOD_WIFI_MANAGER, "Write Wi-Fi info in SS fail\n", ret);
 		return TRWIFI_FILE_ERROR;
 	}
 	char ss_name[7] = {0,};
@@ -318,7 +317,7 @@ trwifi_result_e wifi_profile_read(wifi_manager_ap_config_s *config, int internal
 	security_handle hnd;
 	security_error err = security_init(&hnd);
 	if (err != SECURITY_OK) {
-		NET_LOGE(TAG, "Read Wi-Fi info in SS fail\n", ret);
+		NET_LOGE(NL_MOD_WIFI_MANAGER, "Read Wi-Fi info in SS fail\n", ret);
 		return TRWIFI_FILE_ERROR;
 	}
 
@@ -338,11 +337,11 @@ trwifi_result_e wifi_profile_read(wifi_manager_ap_config_s *config, int internal
 	}
 
 	if (data.length <= 0) {
-		NET_LOGE(TAG, "Read length is 0");
+		NET_LOGE(NL_MOD_WIFI_MANAGER, "Read length is 0");
 	}
 	security_deinit(hnd);
 
-	NET_LOGV(TAG, "read data len(%u)\n", data.length);
+	NET_LOGV(NL_MOD_WIFI_MANAGER, "read data len(%u)\n", data.length);
 
 #else
 	ret = _wifi_profile_read_file(buf, WIFI_PROFILE_BUFSIZE, internal);

--- a/framework/src/wifi_manager/wifi_manager_state.c
+++ b/framework/src/wifi_manager/wifi_manager_state.c
@@ -144,8 +144,6 @@ static char *wifimgr_state_str[] = {
 		wifimgr_set_info(WIFIMGR_STATE, &twmsg);         \
 	} while (0)
 
-#define TAG "[WM]"
-
 static inline void WIFIMGR_SET_STATE(wifimgr_state_e s)
 {
 	g_manager_info.state = s;
@@ -214,7 +212,7 @@ wifi_manager_result_e _wifimgr_save_connected_config(wifi_manager_ap_config_s *c
 #ifdef CONFIG_WIFI_MANAGER_SAVE_CONFIG
 	trwifi_result_e ret = wifi_profile_write(config, 1);
 	if (ret != TRWIFI_SUCCESS) {
-		NET_LOGE(TAG, "Failed to save the connected AP configuration in file system\n");
+		NET_LOGE(NL_MOD_WIFI_MANAGER, "Failed to save the connected AP configuration in file system\n");
 		return WIFI_MANAGER_FAIL;
 	}
 #endif
@@ -259,7 +257,7 @@ wifi_manager_result_e _wifimgr_disconnect_ap(void)
 wifi_manager_result_e _wifimgr_run_softap(wifi_manager_softap_config_s *config)
 {
 	if (strlen(config->ssid) > WIFIMGR_SSID_LEN || strlen(config->passphrase) > WIFIMGR_PASSPHRASE_LEN) {
-		NET_LOGE(TAG, "SSID or PASSPHRASE length invalid\n");
+		NET_LOGE(NL_MOD_WIFI_MANAGER, "SSID or PASSPHRASE length invalid\n");
 		return WIFI_MANAGER_FAIL;
 	}
 	trwifi_softap_config_s softap_config;
@@ -337,7 +335,7 @@ wifi_manager_result_e _handler_on_uninitialized_state(wifimgr_msg_s *msg)
 	wifi_manager_cb_s *cb = (wifi_manager_cb_s *)msg->param;
 	int res = wifimgr_register_cb(cb);
 	if (res < 0) {
-		NET_LOGE(TAG, "WIFIMGR REGISTER CB\n");
+		NET_LOGE(NL_MOD_WIFI_MANAGER, "WIFIMGR REGISTER CB\n");
 	}
 #ifdef CONFIG_DISABLE_EXTERNAL_AUTOCONNECT
 	WIFIMGR_CHECK_UTILRESULT(wifi_utils_set_autoconnect(0), TAG, "Set Autoconnect failed");
@@ -388,7 +386,7 @@ wifi_manager_result_e _handler_on_disconnecting_state(wifimgr_msg_s *msg)
 		&& msg->event != WIFIMGR_EVT_STA_CONNECT_FAILED
 		&& msg->event != WIFIMGR_EVT_SCAN_DONE) {
 		WIFIADD_ERR_RECORD(ERR_WIFIMGR_INVALID_EVENT);
-		NET_LOGE(TAG, "invalid param\n");
+		NET_LOGE(NL_MOD_WIFI_MANAGER, "invalid param\n");
 		return WIFI_MANAGER_BUSY;
 	}
 
@@ -421,7 +419,7 @@ wifi_manager_result_e _handler_on_disconnecting_state(wifimgr_msg_s *msg)
 		WIFIMGR_SET_STATE(WIFIMGR_STA_DISCONNECTED);
 		break;
 	default:
-		NET_LOGE(TAG, "invalid argument\n");
+		NET_LOGE(NL_MOD_WIFI_MANAGER, "invalid argument\n");
 		break;
 	}
 
@@ -598,7 +596,7 @@ wifi_manager_result_e wifimgr_handle_request(wifimgr_msg_s *msg)
 {
 	wifi_manager_result_e res = WIFI_MANAGER_FAIL;
 
-	NET_LOGI(TAG, "handle request state(%s) evt(%s)\n",
+	NET_LOGI(NL_MOD_WIFI_MANAGER, "handle request state(%s) evt(%s)\n",
 			 wifimgr_get_state_str(WIFIMGR_GET_STATE),
 			 wifimgr_get_evt_str(msg->event));
 	if (msg->event == WIFIMGR_CMD_GETSTATS) {
@@ -611,6 +609,6 @@ wifi_manager_result_e wifimgr_handle_request(wifimgr_msg_s *msg)
 #ifdef CONFIG_WIFIMGR_ERROR_REPORT
 	_set_error_code(res);
 #endif
-	NET_LOGV(TAG, "<-- _handle_request\n");
+	NET_LOGV(NL_MOD_WIFI_MANAGER, "<-- _handle_request\n");
 	return res;
 }

--- a/framework/src/wifi_manager/wifi_manager_utils.h
+++ b/framework/src/wifi_manager/wifi_manager_utils.h
@@ -66,7 +66,7 @@ int net_task_create(FAR const char *name, int priority, int stack_size,
 	do {												\
 		trwifi_result_e wmres = func;					\
 		if (wmres != TRWIFI_SUCCESS) {					\
-			NET_LOGE(TAG, msg " reason(%d)\n", wmres);	\
+			NET_LOGE(NL_MOD_WIFI_MANAGER, msg " reason(%d)\n", wmres);	\
 			WIFIADD_ERR_RECORD(ERR_WIFIMGR_UTILS_FAIL);	\
 			return wifimgr_convert2wifimgr_res(wmres);		\
 		}												\

--- a/os/net/Kconfig
+++ b/os/net/Kconfig
@@ -33,6 +33,12 @@ if NET_LWIP
 source net/lwip/configs/Kconfig
 endif #NET_LWIP
 
+config NET_RUNTIME_LOG
+	bool "Run-time logging"
+	default n
+	---help---
+		Enable runtime logging in network log
+
 menu "Driver buffer configuration"
 
 config NET_ETH_MTU


### PR DESCRIPTION
Network module has supported build time log only. So if you want to
turn on additional log to get more information, you have to build target
again and it waits your time. Unfortunately lack of performance of the
board, it's impossible to enable all logs in network stack especially
lwIP. So this commit is start point of runtime
logging. Interoperability to previous built time logging, it provides
new config NET_RUNTIME_LOG to enable it. If NET_RUNTIME_LOG is off
then network log work the same as before.