### PR TITLE
os/kernel/binary_manager_verify.c : Modify the duplicated max bufsize…

### DIFF
--- a/os/kernel/binary_manager/binary_manager_verify.c
+++ b/os/kernel/binary_manager/binary_manager_verify.c
@@ -167,8 +167,8 @@ int binary_manager_read_header(int type, char *devpath, void *header_data, bool 
 			bin_size = ((common_binary_header_t *)header_data)->bin_size;
 			crc_hash = ((common_binary_header_t *)header_data)->crc_hash;
 		}
-		size_t largest_size = mm_get_largest_freenode_size();
-		crc_bufsize = crc_bufsize < (largest_size / 2) ? crc_bufsize : (largest_size / 2);
+		size_t max_bufsize = mm_get_largest_freenode_size() / 2;
+		crc_bufsize = crc_bufsize < max_bufsize ? crc_bufsize : max_bufsize;
 		crc_buffer = (uint8_t *)kmm_malloc(crc_bufsize);
 		if (!crc_buffer) {
 			bmdbg("Fail to malloc buffer for checking crc, size %u\n", crc_bufsize);


### PR DESCRIPTION
… calculation

There were duplicated max bufsize calculation, so removed the duplication to calculate once.

Signed-off-by: jeongchanKim <jc_.kim@samsung.com>