### PR TITLE
os/binfmt: Fix compile error in binfmt log

### DIFF
--- a/os/binfmt/libelf/libelf_addrenv.c
+++ b/os/binfmt/libelf/libelf_addrenv.c
@@ -248,7 +248,7 @@ int elf_addrenv_alloc(FAR struct elf_loadinfo_s *loadinfo)
 	memset(loadinfo->binp->sections[BIN_BSS], 0, loadinfo->binp->sizes[BIN_BSS]);
 
 	if (!loadinfo->binp->sections[BIN_TEXT]) {
-		berr("ERROR: Failed to allocate text section (size = %u)\n", binp->sizes[BIN_TEXT]);
+		berr("ERROR: Failed to allocate text section (size = %u)\n", loadinfo->binp->sizes[BIN_TEXT]);
 		return -ENOMEM;
 	}
 


### PR DESCRIPTION
Fix build error due to missing loadinfo variable in log

Signed-off-by: Kishore S N <kishore.sn@samsung.com>