### PR TITLE
kernel/log_dump.c : Fix build error and warning

### DIFF
--- a/os/kernel/log_dump/log_dump.c
+++ b/os/kernel/log_dump/log_dump.c
@@ -25,6 +25,7 @@
 #include <tinyara/sched.h>
 
 #include <stdint.h>
+#include <stdlib.h>
 #include <unistd.h>
 #include <string.h>
 #include <errno.h>
@@ -56,7 +57,7 @@
  * Private Type Declarations
  ****************************************************************************/
 
-static struct log_dump_chunk_s {
+struct log_dump_chunk_s {
 	struct log_dump_chunk_s *flink;
 	char arr[CONFIG_LOG_DUMP_CHUNK_SIZE];
 };


### PR DESCRIPTION
1. Build Error
log_dump/log_dump.c: In function 'log_dump_save':
log_dump/log_dump.c:135:18: error: storage size of 'mem' isn't known
  struct mallinfo mem;

2. Build Warning
log_dump/log_dump.c:63:1: warning: useless storage class specifier in empty declaration
 };

Signed-off-by: jeongchanKim <jc_.kim@samsung.com>