### PR TITLE
apps/system/utils_kill.c : Fix build warning

### DIFF
--- a/apps/system/utils/utils_kill.c
+++ b/apps/system/utils/utils_kill.c
@@ -58,6 +58,9 @@
 #include <signal.h>
 #include <sched.h>
 #include <pthread.h>
+#if !defined(CONFIG_FS_AUTOMOUNT_PROCFS)
+#include <sys/mount.h>
+#endif
 #ifdef CONFIG_ENABLE_KILLALL
 #include "utils_proc.h"
 #define KILLALL_BUFLEN 128


### PR DESCRIPTION
utils_kill.c: In function 'utils_killall':
utils_kill.c:336:8: warning: implicit declaration of function 'mount' [-Wimplicit-function-declaration]
  ret = mount(NULL, PROCFS_MOUNT_POINT, PROCFS_FSTYPE, 0, NULL);
        ^
utils_kill.c:358:9: warning: implicit declaration of function 'umount' [-Wimplicit-function-declaration]
   (void)umount(PROCFS_MOUNT_POINT);

Signed-off-by: jeongchanKim <jc_.kim@samsung.com>