### PR TITLE
os/kernel: Prevent task and pthread creation from kernel threads

### DIFF
--- a/os/arch/arm/src/common/up_createstack.c
+++ b/os/arch/arm/src/common/up_createstack.c
@@ -174,15 +174,6 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
 {
 	size_t stack_alloc_size = stack_size;
 
-	/* new thread does not have the uheap value yet, It's added in the task_
-	 * schedsetup function.
-	 * Parent and child threads must have the same uheap value, so we are
-	 * using the parent thread uheap
-	 */
-#if defined(HAVE_KERNEL_HEAP) || defined(CONFIG_MPU_STACK_OVERFLOW_PROTECTION)
-	uint32_t uheap = sched_self()->uheap;	/* User heap pointer */
-#endif
-
 	/* Is there already a stack allocated of a different size?  Because of
 	 * alignment issues, stack_size might erroneously appear to be of a
 	 * different size.  Fortunately, this is not a critical operation.
@@ -202,12 +193,7 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
 		 */
 
 #ifdef HAVE_KERNEL_HEAP
-		/* Use the kernel allocator if this is a task / pthread being created
-		 * to run only on kernel side. We verify this by checking the uheap
-		 * object in the tcb of current running task. uheap is always non-null
-		 * in user threads and null for kernel threads.
-		 */
-		if (!uheap || ttype == TCB_FLAG_TTYPE_KERNEL) {
+		if (ttype == TCB_FLAG_TTYPE_KERNEL) {
 #ifdef CONFIG_MPU_STACK_OVERFLOW_PROTECTION
 			stack_alloc_size = stack_alloc_size + CONFIG_MPU_STACK_GUARD_SIZE;
 			tcb->stack_alloc_ptr = (uint32_t *)kmm_memalign(STACK_PROTECTION_MPU_ALIGNMENT, stack_alloc_size);

--- a/os/binfmt/binfmt.h
+++ b/os/binfmt/binfmt.h
@@ -160,14 +160,13 @@ static inline void binfmt_set_mpu(struct binary_s *binp)
 
 #ifdef CONFIG_SUPPORT_COMMON_BINARY
 	if (binp->islibrary) {
-		regs = binp->cmn_mpu_regs;
 		nregion = mpu_get_nregion_info(MPU_REGION_COMMON_BIN);
 	} else
 #endif
 	{
-		regs = sched_self()->mpu_regs;
 		nregion = mpu_get_nregion_info(MPU_REGION_APP_BIN);
 	}
+	regs = binp->mpu_regs;
 
 #ifdef CONFIG_OPTIMIZE_APP_RELOAD_TIME
 	/* Configure text section as RO and executable region */

--- a/os/binfmt/binfmt_unloadmodule.c
+++ b/os/binfmt/binfmt_unloadmodule.c
@@ -201,10 +201,10 @@ int unload_module(FAR struct binary_s *binp)
 #if (defined(CONFIG_ARMV7M_MPU) || defined(CONFIG_ARMV8M_MPU))
 #ifdef CONFIG_OPTIMIZE_APP_RELOAD_TIME
 			for (int i = 0; i < MPU_REG_NUMBER * MPU_NUM_REGIONS; i += MPU_REG_NUMBER) {
-				up_mpu_disable_region(&binp->cmn_mpu_regs[i]);
+				up_mpu_disable_region(&binp->mpu_regs[i]);
 			}
 #else
-			up_mpu_disable_region(&binp->cmn_mpu_regs[0]);
+			up_mpu_disable_region(&binp->mpu_regs[0]);
 #endif
 #endif
 		}

--- a/os/include/tinyara/binfmt/binfmt.h
+++ b/os/include/tinyara/binfmt/binfmt.h
@@ -121,9 +121,9 @@ struct binary_s {
 #endif
 #ifdef CONFIG_SUPPORT_COMMON_BINARY
 	uint8_t islibrary;			/* Is this bin object containing a library */
-#ifdef CONFIG_ARM_MPU							/* MPU register values for common binary only */
-	uint32_t cmn_mpu_regs[MPU_REG_NUMBER * MPU_NUM_REGIONS];	/* Common binary MPU is configured during loading and disabled during unload_module */
 #endif
+#ifdef CONFIG_ARM_MPU
+	uint32_t mpu_regs[MPU_REG_NUMBER * MPU_NUM_REGIONS];	/* MPU register values for common and app binaries */
 #endif
 	FAR char *const *argv;			/* Argument list */
 	FAR const struct symtab_s *exports;	/* Table of exported symbols */

--- a/os/kernel/pthread/pthread_create.c
+++ b/os/kernel/pthread/pthread_create.c
@@ -258,6 +258,10 @@ int pthread_create(FAR pthread_t *thread, FAR const pthread_attr_t *attr, pthrea
 	bool group_joined = false;
 #endif
 
+#ifdef CONFIG_APP_BINARY_SEPARATION
+	ASSERT((sched_self()->flags & TCB_FLAG_TTYPE_MASK) != TCB_FLAG_TTYPE_KERNEL);
+#endif
+
 	trace_begin(TTRACE_TAG_TASK, "pthread_create");
 
 	/* Check whether we are allowed to create new pthread ? */

--- a/os/kernel/task/task_create.c
+++ b/os/kernel/task/task_create.c
@@ -288,6 +288,10 @@ errout:
 #ifndef CONFIG_BUILD_KERNEL
 int task_create(FAR const char *name, int priority, int stack_size, main_t entry, FAR char *const argv[])
 {
+#ifdef CONFIG_APP_BINARY_SEPARATION
+	ASSERT((sched_self()->flags & TCB_FLAG_TTYPE_MASK) != TCB_FLAG_TTYPE_KERNEL);
+#endif
+
 #if defined(CONFIG_BINARY_MANAGER) && defined(CONFIG_APP_BINARY_SEPARATION)
 	if (BM_PRIORITY_MIN - 1 < priority && priority < BM_PRIORITY_MAX + 1) {
 		sdbg("Invalid priority %d, it should be lower than %d or higher than %d\n", priority, BM_PRIORITY_MIN, BM_PRIORITY_MAX);


### PR DESCRIPTION
If app separation is enabled, then only apps must be allowed to create
task and pthreads. Kernel can only create kthreads. If kernel side code
tries to create task or pthread, it will result in an ASSERT.

Signed-off-by: Kishore S N <kishore.sn@samsung.com>