### PR TITLE
os/tools/*.py : Integrate common util functions

### DIFF
--- a/os/tools/check_output_size.py
+++ b/os/tools/check_output_size.py
@@ -34,32 +34,32 @@ output_folder = build_folder + '/output/bin'
 FAIL_TO_BUILD = False
 
 def number_with_comma_align(number):
-	return ("{:10,}".format(number))
+    return ("{:10,}".format(number))
 
 def number_with_comma(number):
-	return ("{:,}".format(number))
+    return ("{:,}".format(number))
 
 def check_binary_size(bin_type, part_size):
-	# Read the binary name from .bininfo
-	bin_name = util.get_binname_from_bininfo(bin_type)
-	if bin_name == 'None' :
-		return
-	output_path = build_folder + '/output/bin/' + bin_name
+    # Read the binary name from .bininfo
+    bin_name = util.get_binname_from_bininfo(bin_type)
+    if bin_name == 'None' :
+        return
+    output_path = build_folder + '/output/bin/' + bin_name
 
-	# Get the partition and binary size
-	BINARY_SIZE=os.path.getsize(output_path)
-	PARTITION_SIZE = part_size
+    # Get the partition and binary size
+    BINARY_SIZE=os.path.getsize(output_path)
+    PARTITION_SIZE = part_size
 
-	# Print each information
-	print(bin_type + "\tBinary Size : " + number_with_comma_align(BINARY_SIZE) + " bytes" + "\tPartition Size : " + number_with_comma_align(PARTITION_SIZE) + " bytes")
+    # Print each information
+    print(bin_type + "\tBinary Size : " + number_with_comma_align(BINARY_SIZE) + " bytes" + "\tPartition Size : " + number_with_comma_align(PARTITION_SIZE) + " bytes")
 
-	# Compare the partition size and its binary size
-	if PARTITION_SIZE < int(BINARY_SIZE) :
-		print("   !!!!!!!! ERROR !!!!!!!")
-		print("   Built " + bin_type + " (" + number_with_comma(BINARY_SIZE) + " bytes) is greater than its partition (" + number_with_comma(PARTITION_SIZE) + " bytes).")
-		print("   " + bin_type + " Binary will be deleted. Need to re-configure the partition using menuconfig and to re-build.")
-		os.remove(output_path)
-		FAIL_TO_BUILD = True
+    # Compare the partition size and its binary size
+    if PARTITION_SIZE < int(BINARY_SIZE) :
+        print("   !!!!!!!! ERROR !!!!!!!")
+        print("   Built " + bin_type + " (" + number_with_comma(BINARY_SIZE) + " bytes) is greater than its partition (" + number_with_comma(PARTITION_SIZE) + " bytes).")
+        print("   " + bin_type + " Binary will be deleted. Need to re-configure the partition using menuconfig and to re-build.")
+        os.remove(output_path)
+        FAIL_TO_BUILD = True
 
 PARTITION_SIZE_LIST = util.get_value_from_file(cfg_file, "CONFIG_FLASH_PART_SIZE=")
 PARTITION_NAME_LIST = util.get_value_from_file(cfg_file, "CONFIG_FLASH_PART_NAME=")
@@ -68,7 +68,7 @@ CONFIG_APP_BINARY_SEPARATION = util.get_value_from_file(cfg_file, "CONFIG_APP_BI
 CONFIG_SUPPORT_COMMON_BINARY = util.get_value_from_file(cfg_file, "CONFIG_SUPPORT_COMMON_BINARY=").rstrip('\n')
 
 if PARTITION_SIZE_LIST == 'None' :
-	sys.exit(0)
+    sys.exit(0)
 
 NAME_LIST = PARTITION_NAME_LIST.replace('"','').split(",")
 SIZE_LIST = PARTITION_SIZE_LIST.replace('"','').split(",")
@@ -82,8 +82,8 @@ APP2_IDX = 0
 
 FLASH_SIZE = 0
 for part in SIZE_LIST :
-	if part.isdigit() == True :
-		FLASH_SIZE += int(part) * 1024
+    if part.isdigit() == True :
+        FLASH_SIZE += int(part) * 1024
 
 KERNEL_PART_TMP_SIZE = FLASH_SIZE
 COMMON_PART_TMP_SIZE = FLASH_SIZE
@@ -91,27 +91,27 @@ APP1_PART_TMP_SIZE = FLASH_SIZE
 APP2_PART_TMP_SIZE = FLASH_SIZE
 
 for name in NAME_LIST :
-	PART_IDX += 1
-	if name == "kernel" or name == "os" :
-		if KERNEL_PART_TMP_SIZE > (int(SIZE_LIST[PART_IDX]) * 1024) :
-			KERNEL_PART_TMP_SIZE = (int(SIZE_LIST[PART_IDX]) * 1024)
-			KERNEL_IDX = PART_IDX
-		continue
-	elif name == "app1" :
-		if APP1_PART_TMP_SIZE > (int(SIZE_LIST[PART_IDX]) * 1024) :
-			APP1_PART_TMP_SIZE = int(SIZE_LIST[PART_IDX]) * 1024
-			APP1_IDX = PART_IDX
-		continue
-	elif name == "app2" :
-		if APP2_PART_TMP_SIZE > (int(SIZE_LIST[PART_IDX]) * 1024) :
-			APP2_PART_TMP_SIZE = int(SIZE_LIST[PART_IDX]) * 1024
-			APP2_IDX = PART_IDX
-		continue
-	elif name == "common" :
-		if COMMON_PART_TMP_SIZE > (int(SIZE_LIST[PART_IDX]) * 1024) :
-			COMMON_PART_TMP_SIZE = int(SIZE_LIST[PART_IDX]) * 1024
-			COMMON_IDX = PART_IDX
-		continue
+    PART_IDX += 1
+    if name == "kernel" or name == "os" :
+        if KERNEL_PART_TMP_SIZE > (int(SIZE_LIST[PART_IDX]) * 1024) :
+            KERNEL_PART_TMP_SIZE = (int(SIZE_LIST[PART_IDX]) * 1024)
+            KERNEL_IDX = PART_IDX
+        continue
+    elif name == "app1" :
+        if APP1_PART_TMP_SIZE > (int(SIZE_LIST[PART_IDX]) * 1024) :
+            APP1_PART_TMP_SIZE = int(SIZE_LIST[PART_IDX]) * 1024
+            APP1_IDX = PART_IDX
+        continue
+    elif name == "app2" :
+        if APP2_PART_TMP_SIZE > (int(SIZE_LIST[PART_IDX]) * 1024) :
+            APP2_PART_TMP_SIZE = int(SIZE_LIST[PART_IDX]) * 1024
+            APP2_IDX = PART_IDX
+        continue
+    elif name == "common" :
+        if COMMON_PART_TMP_SIZE > (int(SIZE_LIST[PART_IDX]) * 1024) :
+            COMMON_PART_TMP_SIZE = int(SIZE_LIST[PART_IDX]) * 1024
+            COMMON_IDX = PART_IDX
+        continue
 
 KERNEL_PARTITION_SIZE = int(SIZE_LIST[KERNEL_IDX]) * 1024
 COMMON_PARTITION_SIZE = int(SIZE_LIST[COMMON_IDX]) * 1024
@@ -122,13 +122,13 @@ APP2_PARTITION_SIZE = int(SIZE_LIST[APP2_IDX]) * 1024
 print("\n========== Size Verification of built Binaries ==========")
 check_binary_size("KERNEL", KERNEL_PARTITION_SIZE)
 if CONFIG_APP_BINARY_SEPARATION == "y" :
-	check_binary_size("APP1", APP1_PARTITION_SIZE)
-	check_binary_size("APP2", APP2_PARTITION_SIZE)
-	if CONFIG_SUPPORT_COMMON_BINARY == "y" :
-		check_binary_size("COMMON", COMMON_PARTITION_SIZE)
+    check_binary_size("APP1", APP1_PARTITION_SIZE)
+    check_binary_size("APP2", APP2_PARTITION_SIZE)
+    if CONFIG_SUPPORT_COMMON_BINARY == "y" :
+        check_binary_size("COMMON", COMMON_PARTITION_SIZE)
 
 if FAIL_TO_BUILD == True :
-	# Stop to build, because there is mismatched size problem.
-	sys.exit(1)
+    # Stop to build, because there is mismatched size problem.
+    sys.exit(1)
 else :
-	print("Size verification is done.")
+    print("Size verification is done.")

--- a/os/tools/check_output_size.py
+++ b/os/tools/check_output_size.py
@@ -24,6 +24,7 @@
 import os
 import sys
 import string
+import config_util as util
 
 os_folder = os.path.dirname(__file__) + '/..'
 cfg_file = os_folder + '/.config'
@@ -38,20 +39,9 @@ def number_with_comma_align(number):
 def number_with_comma(number):
 	return ("{:,}".format(number))
 
-def get_value_from_file(file_name, target):
-	with open(file_name, 'r+') as f:
-		lines = f.readlines()
-		value = 'None'
-		for line in lines:
-			if target in line:
-				value = (line.split("=")[1])
-				break
-	return value;
-
 def check_binary_size(bin_type, part_size):
 	# Read the binary name from .bininfo
-	bininfo_file = os_folder + '/.bininfo'
-	bin_name = get_value_from_file(bininfo_file, bin_type + "_BIN_NAME=").replace('"','').rstrip('\n')
+	bin_name = util.get_binname_from_bininfo(bin_type)
 	if bin_name == 'None' :
 		return
 	output_path = build_folder + '/output/bin/' + bin_name
@@ -71,11 +61,11 @@ def check_binary_size(bin_type, part_size):
 		os.remove(output_path)
 		FAIL_TO_BUILD = True
 
-PARTITION_SIZE_LIST = get_value_from_file(cfg_file, "CONFIG_FLASH_PART_SIZE=")
-PARTITION_NAME_LIST = get_value_from_file(cfg_file, "CONFIG_FLASH_PART_NAME=")
+PARTITION_SIZE_LIST = util.get_value_from_file(cfg_file, "CONFIG_FLASH_PART_SIZE=")
+PARTITION_NAME_LIST = util.get_value_from_file(cfg_file, "CONFIG_FLASH_PART_NAME=")
 
-CONFIG_APP_BINARY_SEPARATION = get_value_from_file(cfg_file, "CONFIG_APP_BINARY_SEPARATION=").rstrip('\n')
-CONFIG_SUPPORT_COMMON_BINARY = get_value_from_file(cfg_file, "CONFIG_SUPPORT_COMMON_BINARY=").rstrip('\n')
+CONFIG_APP_BINARY_SEPARATION = util.get_value_from_file(cfg_file, "CONFIG_APP_BINARY_SEPARATION=").rstrip('\n')
+CONFIG_SUPPORT_COMMON_BINARY = util.get_value_from_file(cfg_file, "CONFIG_SUPPORT_COMMON_BINARY=").rstrip('\n')
 
 if PARTITION_SIZE_LIST == 'None' :
 	sys.exit(0)

--- a/os/tools/check_package.py
+++ b/os/tools/check_package.py
@@ -45,98 +45,98 @@ VERIFY_SUCCESS = True
 
 target = sys.argv[1]
 if target == "-h" or target == "--help" :
-	print("Usage :")
-	print("\tpython check_package.py [package_path]")
-	print("\tex) python check_package.py ../../build/output/bin/kernel_XXX_YYMMDD.trpk")
-	sys.exit(0)
+    print("Usage :")
+    print("\tpython check_package.py [package_path]")
+    print("\tex) python check_package.py ../../build/output/bin/kernel_XXX_YYMMDD.trpk")
+    sys.exit(0)
 
 # Read the package header
 with open(target, 'r') as f:
-	data = f.read()
+    data = f.read()
 
 check_signing = struct.unpack('H', data[4:6])
 
 if "kernel_" in target :
-	print("=== Kernel Package Header Information ===")
-	print("< Cannot check the signing >")
-	SIGNING_OFFSET = 0 #For kernel package, signing info is not added at the first. So we will not use the offset for kernel package case.
+    print("=== Kernel Package Header Information ===")
+    print("< Cannot check the signing >")
+    SIGNING_OFFSET = 0 #For kernel package, signing info is not added at the first. So we will not use the offset for kernel package case.
 
-	header_size = struct.unpack('H', data[4:6])
-	package_ver = struct.unpack('I', data[6:10])
-	file_size = struct.unpack('I', data[10:14])
-	secure_size = struct.unpack('H', data[14:16])
+    header_size = struct.unpack('H', data[4:6])
+    package_ver = struct.unpack('I', data[6:10])
+    file_size = struct.unpack('I', data[10:14])
+    secure_size = struct.unpack('H', data[14:16])
 
-	print("\tHeader Size        : " + str(header_size[0]))
-	print("\tPackage Version    : " + str(package_ver[0]))
-	print("\tFile Size          : " + str(file_size[0]))
-	print("\tSecure Header Size : " + str(secure_size[0]))
+    print("\tHeader Size        : " + str(header_size[0]))
+    print("\tPackage Version    : " + str(package_ver[0]))
+    print("\tFile Size          : " + str(file_size[0]))
+    print("\tSecure Header Size : " + str(secure_size[0]))
 
 elif "common_" in target :
-	print("=== Common Package Header Information ===")
+    print("=== Common Package Header Information ===")
 
-	if int(check_signing[0]) == COMMON_HEADER_SIZE :
-		print("< Unsigned Common Package >")
-		SIGNING_OFFSET = 0
-	else :
-		print("< Signed Common Package >")
-		SIGNING_OFFSET = SIGNING_SIZE
+    if int(check_signing[0]) == COMMON_HEADER_SIZE :
+        print("< Unsigned Common Package >")
+        SIGNING_OFFSET = 0
+    else :
+        print("< Signed Common Package >")
+        SIGNING_OFFSET = SIGNING_SIZE
 
-	header_size = struct.unpack('H', data[4 + SIGNING_OFFSET:6 + SIGNING_OFFSET])
-	package_ver = struct.unpack('I', data[6 + SIGNING_OFFSET:10 + SIGNING_OFFSET])
-	file_size = struct.unpack('I', data[10 + SIGNING_OFFSET:14 + SIGNING_OFFSET])
+    header_size = struct.unpack('H', data[4 + SIGNING_OFFSET:6 + SIGNING_OFFSET])
+    package_ver = struct.unpack('I', data[6 + SIGNING_OFFSET:10 + SIGNING_OFFSET])
+    file_size = struct.unpack('I', data[10 + SIGNING_OFFSET:14 + SIGNING_OFFSET])
 
-	print("\tHeader Size     : " + str(header_size[0]))
-	print("\tPackage Version : " + str(package_ver[0]))
-	print("\tFile Size       : " + str(file_size[0]))
+    print("\tHeader Size     : " + str(header_size[0]))
+    print("\tPackage Version : " + str(package_ver[0]))
+    print("\tFile Size       : " + str(file_size[0]))
 
 elif "app_" in target :
-	print("=== App Package Header Information ===")
+    print("=== App Package Header Information ===")
 
-	if int(check_signing[0]) == APP_HEADER_SIZE :
-		print("< Unsigned App Package >")
-		SIGNING_OFFSET = 0
-	else :
-		print("< Signed App Package >")
-		SIGNING_OFFSET = SIGNING_SIZE
+    if int(check_signing[0]) == APP_HEADER_SIZE :
+        print("< Unsigned App Package >")
+        SIGNING_OFFSET = 0
+    else :
+        print("< Signed App Package >")
+        SIGNING_OFFSET = SIGNING_SIZE
 
-	header_size = struct.unpack('H', data[4 + SIGNING_OFFSET:6 + SIGNING_OFFSET])
-	package_type = struct.unpack('B', data[6 + SIGNING_OFFSET:7 + SIGNING_OFFSET])
-	main_prio = struct.unpack('B', data[7 + SIGNING_OFFSET:8 + SIGNING_OFFSET])
-	loading_prio = struct.unpack('B', data[8 + SIGNING_OFFSET:9 + SIGNING_OFFSET])
-	file_size = struct.unpack('I', data[9 + SIGNING_OFFSET:13 + SIGNING_OFFSET])
-	package_name = struct.unpack('ccc', data[13 + SIGNING_OFFSET:16 + SIGNING_OFFSET])
-	package_ver = struct.unpack('I', data[29 + SIGNING_OFFSET:33 + SIGNING_OFFSET])
-	ram_size = struct.unpack('I', data[33 + SIGNING_OFFSET:37 + SIGNING_OFFSET])
-	stk_size = struct.unpack('I', data[37 + SIGNING_OFFSET:41 + SIGNING_OFFSET])
-	kernel_ver = struct.unpack('I', data[41 + SIGNING_OFFSET:45 + SIGNING_OFFSET])
+    header_size = struct.unpack('H', data[4 + SIGNING_OFFSET:6 + SIGNING_OFFSET])
+    package_type = struct.unpack('B', data[6 + SIGNING_OFFSET:7 + SIGNING_OFFSET])
+    main_prio = struct.unpack('B', data[7 + SIGNING_OFFSET:8 + SIGNING_OFFSET])
+    loading_prio = struct.unpack('B', data[8 + SIGNING_OFFSET:9 + SIGNING_OFFSET])
+    file_size = struct.unpack('I', data[9 + SIGNING_OFFSET:13 + SIGNING_OFFSET])
+    package_name = struct.unpack('ccc', data[13 + SIGNING_OFFSET:16 + SIGNING_OFFSET])
+    package_ver = struct.unpack('I', data[29 + SIGNING_OFFSET:33 + SIGNING_OFFSET])
+    ram_size = struct.unpack('I', data[33 + SIGNING_OFFSET:37 + SIGNING_OFFSET])
+    stk_size = struct.unpack('I', data[37 + SIGNING_OFFSET:41 + SIGNING_OFFSET])
+    kernel_ver = struct.unpack('I', data[41 + SIGNING_OFFSET:45 + SIGNING_OFFSET])
 
-	print("\tHeader Size       : " + str(header_size[0]))
-	if package_type[0] == PACKAGE_TYPE_ELF :
-		print("\tPackage Type      : ELF(%d)" %package_type[0])
-	else :
-		print("\tPackage Type Invalid : %d" %package_type[0])
-		VERIFY_SUCCESS = False
-	print("\tMain Priority     : " + str(main_prio[0]))
-	if loading_prio[0] == LOADING_LOW :
-		print("\tLoading Priority  : LOADING_LOW(%d)" %LOADING_LOW)
-	elif loading_prio[0] == LOADING_MID :
-		print("\tLoading Priority  : LOADING_MID(%d)" %LOADING_MID)
-	elif loading_prio[0] == LOADING_HIGH :
-		print("\tLoading Priority  : LOADING_HIGH(%d)" %LOADING_HIGH)
-	else :
-		print("\tLoading Priority : Invalid(%d)" %loading_prio[0])
-		VERIFY_SUCCESS = False
-	print("\tFile Size         : " + str(file_size[0]))
-	print("\tPackage Name      : " + str(package_name[0]) + str(package_name[1]) + str(package_name[2]))
-	print("\tPackage Version   : " + str(package_ver[0]))
-	print("\tRAM Size          : " + str(ram_size[0]))
-	print("\tStack Size        : " + str(stk_size[0]))
-	print("\tKernel Version    : " + str(kernel_ver[0]))
+    print("\tHeader Size       : " + str(header_size[0]))
+    if package_type[0] == PACKAGE_TYPE_ELF :
+        print("\tPackage Type      : ELF(%d)" %package_type[0])
+    else :
+        print("\tPackage Type Invalid : %d" %package_type[0])
+        VERIFY_SUCCESS = False
+    print("\tMain Priority     : " + str(main_prio[0]))
+    if loading_prio[0] == LOADING_LOW :
+        print("\tLoading Priority  : LOADING_LOW(%d)" %LOADING_LOW)
+    elif loading_prio[0] == LOADING_MID :
+        print("\tLoading Priority  : LOADING_MID(%d)" %LOADING_MID)
+    elif loading_prio[0] == LOADING_HIGH :
+        print("\tLoading Priority  : LOADING_HIGH(%d)" %LOADING_HIGH)
+    else :
+        print("\tLoading Priority : Invalid(%d)" %loading_prio[0])
+        VERIFY_SUCCESS = False
+    print("\tFile Size         : " + str(file_size[0]))
+    print("\tPackage Name      : " + str(package_name[0]) + str(package_name[1]) + str(package_name[2]))
+    print("\tPackage Version   : " + str(package_ver[0]))
+    print("\tRAM Size          : " + str(ram_size[0]))
+    print("\tStack Size        : " + str(stk_size[0]))
+    print("\tKernel Version    : " + str(kernel_ver[0]))
 
 else :
-	print("!!!Not Supported Package. Please Check the package!!!")
-	VERIFY_SUCCESS = False
-	sys.exit(1)
+    print("!!!Not Supported Package. Please Check the package!!!")
+    VERIFY_SUCCESS = False
+    sys.exit(1)
 
 # Verify the package by calculating the crc and comparing it with the value of the header.
 
@@ -150,21 +150,21 @@ checksum_calc = zlib.crc32(data[calc_start_idx:calc_end_idx]) & 0xFFFFFFFF
 checksum_header = struct.unpack('I', data[0 + SIGNING_OFFSET:4 + SIGNING_OFFSET])[0]
 
 if checksum_header == checksum_calc :
-	print("\t* Checksum verification Done.")
+    print("\t* Checksum verification Done.")
 else :
-	print("\t* Checksum is invalid, header : " + str(checksum_header) + ", calc : " + str(checksum_calc));
-	VERIFY_SUCCESS = False
+    print("\t* Checksum is invalid, header : " + str(checksum_header) + ", calc : " + str(checksum_calc));
+    VERIFY_SUCCESS = False
 
 
 # Verify the package version between header and the file name
 file_name_ver = os.path.basename(target).split("_")[2].split(".")[0]
 
 if package_ver[0] == int(file_name_ver) :
-	print("\t* Version Matched between filename and header.")
+    print("\t* Version Matched between filename and header.")
 else :
-	print("\t* Version NOT MATCHED!!! between filename(" + file_name_ver + ") and header(" + str(package_ver[0]) + ")")
-	VERIFY_SUCCESS = False
+    print("\t* Version NOT MATCHED!!! between filename(" + file_name_ver + ") and header(" + str(package_ver[0]) + ")")
+    VERIFY_SUCCESS = False
 
 # Return exit(1) if there is a validation failure.
 if VERIFY_SUCCESS == False :
-	sys.exit(1)
+    sys.exit(1)

--- a/os/tools/config_util.py
+++ b/os/tools/config_util.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python
+###########################################################################
+#
+# Copyright 2022 Samsung Electronics All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+#
+###########################################################################
+
+import os
+import sys
+
+os_folder = os.path.dirname(__file__) + '/..'
+
+# This function returns the value which starts with the "'target'=" from "file_name".
+# For example, if CONFIG_ACB=123 is in test.txt,
+# get_value_from_file("test.txt", "CONFIG_ABC=") returns 123.
+def get_value_from_file(file_name, target):
+    with open(file_name, 'r+') as f:
+        lines = f.readlines()
+        value = 'None'
+        for line in lines:
+            if target in line:
+                value = (line.split("=")[1])
+                break
+    return value
+
+# This function checks that 'config' is in 'file_name' or not.
+# The return type of this function is True or False.
+def check_config_existence(file_name, config):
+    with open(file_name, 'r+') as f:
+        lines = f.readlines()
+    
+    return any([True if config in line and not line.startswith('#') else False for line in lines ])
+
+# This function returns the binary name from .bininfo file.
+# For example, if kernel binary name is "KERNEL_BOARD_99991231",
+# get_binname_from_bininfo("KERNEL") returns "KERNEL_BOARD_99991231".
+def get_binname_from_bininfo(bin_type):
+    bininfo_file = os.path.dirname(__file__) + '/..' + '/.bininfo'
+    return get_value_from_file(bininfo_file, bin_type + "_BIN_NAME=").replace('"','').rstrip('\n')

--- a/os/tools/mkbinheader.py
+++ b/os/tools/mkbinheader.py
@@ -22,6 +22,7 @@ import os
 import sys
 import struct
 import string
+import config_util as util
 
 cfg_path = os.path.dirname(__file__) + '/../.config'
 
@@ -41,27 +42,6 @@ def roundup_power_two(size):
     size = size + 1
 
     return size
-
-def get_config_value(file_name, config):
-    with open(file_name, 'r+') as fp:
-        lines = fp.readlines()
-        found = False
-        for line in lines:
-            if config in line:
-                value = (line.split("=")[1])
-                value = value.replace('"','').replace('\n','')
-                found = True
-                break
-    if found == False:
-        print ("FAIL!! No found config %s" %config)
-        sys.exit(1)
-    return int(value);
-
-def check_optimize_config(file_name):
-    with open(file_name, 'r+') as f:
-        lines = f.readlines()
-    
-    return any([True if 'CONFIG_OPTIMIZE_APP_RELOAD_TIME=y' in line and not line.startswith('#') else False for line in lines ])
 
 def get_static_ram_size(bin_type):
     # Calculate static RAM size
@@ -94,7 +74,7 @@ def get_static_ram_size(bin_type):
         # If CONFIG_OPTIMIZE_APP_RELOAD_TIME is enabled, then we will make a copy
         # of the data section inside the ro section and it will be used in
         # reload time. So, we add datasize to rosize to make place for data section.
-        if check_optimize_config(cfg_path) == True:
+        if util.check_config_existence(cfg_path, 'CONFIG_OPTIMIZE_APP_RELOAD_TIME=y') == True:
             rosize = rosize + datasize;
             rosize = roundup_power_two(rosize)
             textsize = roundup_power_two(textsize)
@@ -139,11 +119,12 @@ def make_kernel_binary_header():
     header_size = SIZE_OF_HEADERSIZE + SIZE_OF_BINVER + SIZE_OF_BINSIZE + SIZE_OF_SECURE_HEADER_SIZE
 
     # Get binary version
-    bin_ver = get_config_value(cfg_path, "CONFIG_BOARD_BUILD_DATE=")
-    if bin_ver < 0 :
+    bin_ver = util.get_value_from_file(cfg_path, "CONFIG_BOARD_BUILD_DATE=").replace('"','').replace('\n','')
+    if bin_ver == 'None' :
         print("Error : Not Found config for version, CONFIG_BOARD_BUILD_DATE")
         sys.exit(1)
-    elif bin_ver < 101 or bin_ver > 991231 :
+    bin_ver = int(bin_ver)
+    if bin_ver < 101 or bin_ver > 991231 :
         print("Error : Invalid value. It has 'YYMMDD' format so it should be in (101, 991231)")
         sys.exit(1)
 
@@ -248,10 +229,10 @@ def make_user_binary_header():
         print("Dynamic ram size : %d, Main stack size : %d" %(int(dynamic_ram_size), int(main_stack_size)))
         sys.exit(1)
 
-    priority = get_config_value(cfg_path, "CONFIG_BM_PRIORITY_MAX=")
+    priority = int(util.get_value_from_file(cfg_path, "CONFIG_BM_PRIORITY_MAX=").replace('"','').replace('\n',''))
     if priority > 0 :
         BM_PRIORITY_MAX = priority
-    priority = get_config_value(cfg_path, "CONFIG_BM_PRIORITY_MIN=")
+    priority = int(util.get_value_from_file(cfg_path, "CONFIG_BM_PRIORITY_MIN=").replace('"','').replace('\n',''))
     if priority > 0 :
         BM_PRIORITY_MIN = priority
 
@@ -285,18 +266,19 @@ def make_user_binary_header():
             sys.exit(1)
 
         static_ram_size = get_static_ram_size(bin_type)
-        if check_optimize_config(cfg_path) == True:
+        if util.check_config_existence(cfg_path, 'CONFIG_OPTIMIZE_APP_RELOAD_TIME=y') == True:
             binary_ram_size = int(dynamic_ram_size)
         else:
             binary_ram_size = int(static_ram_size) + int(dynamic_ram_size)
             binary_ram_size = roundup_power_two(binary_ram_size)
 
         # Get kernel binary version
-        kernel_ver = get_config_value(cfg_path, "CONFIG_BOARD_BUILD_DATE=")
-        if kernel_ver < 0 :
+        kernel_ver = util.get_value_from_file(cfg_path, "CONFIG_BOARD_BUILD_DATE=").replace('"','').replace('\n','')
+        if kernel_ver == 'None' :
             print("Error : Not Found config for kernel version, CONFIG_BOARD_BUILD_DATE")
             sys.exit(1)
-        elif kernel_ver < 101 or kernel_ver > 991231 :
+    kernel_ver = int(kernel_ver)
+        if kernel_ver < 101 or kernel_ver > 991231 :
             print("Error : Invalid value. It has 'YYMMDD' format so it should be in (101, 991231)")
             sys.exit(1)
 
@@ -367,7 +349,7 @@ def make_common_binary_header():
     header_size = SIZE_OF_HEADERSIZE + SIZE_OF_BINVER + SIZE_OF_BINSIZE
 
     # Get binary version
-    bin_ver = get_config_value(cfg_path, "CONFIG_COMMON_BINARY_VERSION=")
+    bin_ver = util.get_value_from_file(cfg_path, "CONFIG_COMMON_BINARY_VERSION=").replace('"','').replace('\n','')
     if bin_ver < 0 :
         print("Error : Not Found config for version, CONFIG_COMMON_BINARY_VERSION")
         sys.exit(1)

--- a/os/tools/mkbootparam.py
+++ b/os/tools/mkbootparam.py
@@ -19,6 +19,7 @@
 import os
 import sys
 import struct
+import config_util as util
 
 config_file_path = os.path.dirname(__file__) + '/../.config'
 bootparam_file_path = os.path.dirname(__file__) + '/../../build/output/bin/bootparam.bin'
@@ -64,16 +65,6 @@ SIZE_OF_BP_PARTITION = SIZE_OF_BPx * 2
 #
 ###########################################################################################
 
-def get_config_value(file_name, config):
-	with open(file_name, 'r+') as fp:
-		lines = fp.readlines()
-		for line in lines:
-			if config in line:
-				value = (line.split("=")[1])
-				return value
-	print ("FAIL!! No found config %s" %config)
-	sys.exit(1)
-
 def make_bootparam():
 	print "========== Start to make boot parameters =========="
 	SIZE_OF_CHECKSUM = 4
@@ -85,10 +76,10 @@ def make_bootparam():
 
 	kernel_data_size = SIZE_OF_CHECKSUM + SIZE_OF_BP_VERSION + SIZE_OF_BP_VERSION + SIZE_OF_KERNEL_INDEX + SIZE_OF_KERNEL_FIRST_ADDR + SIZE_OF_KERNEL_SECOND_ADDR
 
-	FLASH_START_ADDR = get_config_value(config_file_path, "CONFIG_FLASH_START_ADDR=")
-	FLASH_SIZE = get_config_value(config_file_path, "CONFIG_FLASH_SIZE=")
-	names = get_config_value(config_file_path, "CONFIG_FLASH_PART_NAME=").replace('"','').replace('\n','').split(",")
-	sizes = get_config_value(config_file_path, "CONFIG_FLASH_PART_SIZE=").replace('"','').replace('\n','').split(",")
+	FLASH_START_ADDR = util.get_value_from_file(config_file_path, "CONFIG_FLASH_START_ADDR=")
+	FLASH_SIZE = util.get_value_from_file(config_file_path, "CONFIG_FLASH_SIZE=")
+	names = util.get_value_from_file(config_file_path, "CONFIG_FLASH_PART_NAME=").replace('"','').replace('\n','').split(",")
+	sizes = util.get_value_from_file(config_file_path, "CONFIG_FLASH_PART_SIZE=").replace('"','').replace('\n','').split(",")
 	names = filter(None, names)
 	sizes = filter(None, sizes)
 

--- a/os/tools/mkbootparam.py
+++ b/os/tools/mkbootparam.py
@@ -66,98 +66,98 @@ SIZE_OF_BP_PARTITION = SIZE_OF_BPx * 2
 ###########################################################################################
 
 def make_bootparam():
-	print "========== Start to make boot parameters =========="
-	SIZE_OF_CHECKSUM = 4
-	SIZE_OF_BP_VERSION = 4
-	SIZE_OF_BP_FORMAT_VERSION = 4
-	SIZE_OF_KERNEL_INDEX = 1
-	SIZE_OF_KERNEL_FIRST_ADDR = 4
-	SIZE_OF_KERNEL_SECOND_ADDR = 4
+    print "========== Start to make boot parameters =========="
+    SIZE_OF_CHECKSUM = 4
+    SIZE_OF_BP_VERSION = 4
+    SIZE_OF_BP_FORMAT_VERSION = 4
+    SIZE_OF_KERNEL_INDEX = 1
+    SIZE_OF_KERNEL_FIRST_ADDR = 4
+    SIZE_OF_KERNEL_SECOND_ADDR = 4
 
-	kernel_data_size = SIZE_OF_CHECKSUM + SIZE_OF_BP_VERSION + SIZE_OF_BP_VERSION + SIZE_OF_KERNEL_INDEX + SIZE_OF_KERNEL_FIRST_ADDR + SIZE_OF_KERNEL_SECOND_ADDR
+    kernel_data_size = SIZE_OF_CHECKSUM + SIZE_OF_BP_VERSION + SIZE_OF_BP_VERSION + SIZE_OF_KERNEL_INDEX + SIZE_OF_KERNEL_FIRST_ADDR + SIZE_OF_KERNEL_SECOND_ADDR
 
-	FLASH_START_ADDR = util.get_value_from_file(config_file_path, "CONFIG_FLASH_START_ADDR=")
-	FLASH_SIZE = util.get_value_from_file(config_file_path, "CONFIG_FLASH_SIZE=")
-	names = util.get_value_from_file(config_file_path, "CONFIG_FLASH_PART_NAME=").replace('"','').replace('\n','').split(",")
-	sizes = util.get_value_from_file(config_file_path, "CONFIG_FLASH_PART_SIZE=").replace('"','').replace('\n','').split(",")
-	names = filter(None, names)
-	sizes = filter(None, sizes)
+    FLASH_START_ADDR = util.get_value_from_file(config_file_path, "CONFIG_FLASH_START_ADDR=")
+    FLASH_SIZE = util.get_value_from_file(config_file_path, "CONFIG_FLASH_SIZE=")
+    names = util.get_value_from_file(config_file_path, "CONFIG_FLASH_PART_NAME=").replace('"','').replace('\n','').split(",")
+    sizes = util.get_value_from_file(config_file_path, "CONFIG_FLASH_PART_SIZE=").replace('"','').replace('\n','').split(",")
+    names = filter(None, names)
+    sizes = filter(None, sizes)
 
-	INITIAL_ACTIVE_IDX = 0
+    INITIAL_ACTIVE_IDX = 0
 
-	# Check partitions of kernel and bootparam
-	kernel_address = []
-	offset = 0
-	bp_part_size = 0
-	for index, name in enumerate(names):
-		if name == "kernel":
-			# Get addresses of kernel partitions
-			address = hex(int(FLASH_START_ADDR, 16) + offset)
-			kernel_address.append(address)
-		if name == "bootparam":
-			# Get size of bootparam partition
-			bp_part_size = int(sizes[index]) * 1024
-			# Verify partition size and offset of boot parameters
-			if bp_part_size == 0:
-				print "FAIL!! No bootparam partition."
-				sys.exit(1)
-			elif bp_part_size != SIZE_OF_BP_PARTITION:
-				print "FAIL!! Bootparam partition size should be 8K. Please re-configure."
-				sys.exit(1)
-			elif offset != int(FLASH_SIZE) - int(SIZE_OF_BP_PARTITION):
-				print "FAIL!! Bootparam should be located at the end of flash with 8K. Please re-configure."
-				sys.exit(1)
-		offset += int(sizes[index]) * 1024
+    # Check partitions of kernel and bootparam
+    kernel_address = []
+    offset = 0
+    bp_part_size = 0
+    for index, name in enumerate(names):
+        if name == "kernel":
+            # Get addresses of kernel partitions
+            address = hex(int(FLASH_START_ADDR, 16) + offset)
+            kernel_address.append(address)
+        if name == "bootparam":
+            # Get size of bootparam partition
+            bp_part_size = int(sizes[index]) * 1024
+            # Verify partition size and offset of boot parameters
+            if bp_part_size == 0:
+                print "FAIL!! No bootparam partition."
+                sys.exit(1)
+            elif bp_part_size != SIZE_OF_BP_PARTITION:
+                print "FAIL!! Bootparam partition size should be 8K. Please re-configure."
+                sys.exit(1)
+            elif offset != int(FLASH_SIZE) - int(SIZE_OF_BP_PARTITION):
+                print "FAIL!! Bootparam should be located at the end of flash with 8K. Please re-configure."
+                sys.exit(1)
+        offset += int(sizes[index]) * 1024
 
-	# Verify kernel partitions
-	if len(kernel_address) == 0 or len(kernel_address) > 2:
-		print "FAIL!! No found kernel partition"
-		sys.exit(1)
+    # Verify kernel partitions
+    if len(kernel_address) == 0 or len(kernel_address) > 2:
+        print "FAIL!! No found kernel partition"
+        sys.exit(1)
 
-	with open(bootparam_file_path, 'wb') as fp:
-		# Write Data
-		bootparam_version = 1
-		bootparam_format_version = 1
-		fp.write(struct.pack('I', bootparam_version))
-		fp.write(struct.pack('I', bootparam_format_version))
-		# Kernel data
-		fp.write(struct.pack('B', INITIAL_ACTIVE_IDX))
-		for address in kernel_address:
-			fp.write(struct.pack('I', int(address, 16)))
+    with open(bootparam_file_path, 'wb') as fp:
+        # Write Data
+        bootparam_version = 1
+        bootparam_format_version = 1
+        fp.write(struct.pack('I', bootparam_version))
+        fp.write(struct.pack('I', bootparam_format_version))
+        # Kernel data
+        fp.write(struct.pack('B', INITIAL_ACTIVE_IDX))
+        for address in kernel_address:
+            fp.write(struct.pack('I', int(address, 16)))
 
-	# Get User data
-	if os.path.exists(user_file_dir):
-		user_file_list = os.listdir(user_file_dir)
-	else:
-		user_file_list = []
+    # Get User data
+    if os.path.exists(user_file_dir):
+        user_file_list = os.listdir(user_file_dir)
+    else:
+        user_file_list = []
 
-	app_data_size = 0
-	user_app_count = len(user_file_list)
-	if user_app_count > 0:
-		SIZE_OF_BINCOUNT = 1
-		SIZE_OF_BINNAME = 16
-		SIZE_OF_BINIDX = 1
-		app_data_size = SIZE_OF_BINCOUNT + (user_app_count * (SIZE_OF_BINNAME + SIZE_OF_BINIDX))
+    app_data_size = 0
+    user_app_count = len(user_file_list)
+    if user_app_count > 0:
+        SIZE_OF_BINCOUNT = 1
+        SIZE_OF_BINNAME = 16
+        SIZE_OF_BINIDX = 1
+        app_data_size = SIZE_OF_BINCOUNT + (user_app_count * (SIZE_OF_BINNAME + SIZE_OF_BINIDX))
 
-		with open(bootparam_file_path, 'a') as fp:
-			# User Data
-			fp.write(struct.pack('B', user_app_count))
-			for user_file in user_file_list:
-				    fp.write('{:{}{}.{}}'.format(user_file, '<', SIZE_OF_BINNAME, SIZE_OF_BINNAME - 1).replace(' ','\0'))
-				    fp.write(struct.pack('B', INITIAL_ACTIVE_IDX))
+        with open(bootparam_file_path, 'a') as fp:
+            # User Data
+            fp.write(struct.pack('B', user_app_count))
+            for user_file in user_file_list:
+                    fp.write('{:{}{}.{}}'.format(user_file, '<', SIZE_OF_BINNAME, SIZE_OF_BINNAME - 1).replace(' ','\0'))
+                    fp.write(struct.pack('B', INITIAL_ACTIVE_IDX))
 
-	# Fill remaining space with '0xff'
-	with open(bootparam_file_path, 'a') as fp:
-		remain_size = SIZE_OF_BPx - (kernel_data_size + app_data_size)
-		fp.write(b'\xff' * remain_size)
+    # Fill remaining space with '0xff'
+    with open(bootparam_file_path, 'a') as fp:
+        remain_size = SIZE_OF_BPx - (kernel_data_size + app_data_size)
+        fp.write(b'\xff' * remain_size)
 
-	# Add checksum for BP1
-	mkchecksum_path = os.path.dirname(__file__) + '/mkchecksum.py'
-	os.system('python %s %s' % (mkchecksum_path, bootparam_file_path))
+    # Add checksum for BP1
+    mkchecksum_path = os.path.dirname(__file__) + '/mkchecksum.py'
+    os.system('python %s %s' % (mkchecksum_path, bootparam_file_path))
 
-	# Fill remaining space with '0xff' for BP2
-	with open(bootparam_file_path, 'a') as fp:
-		fp.write(b'\xff' * SIZE_OF_BPx)
+    # Fill remaining space with '0xff' for BP2
+    with open(bootparam_file_path, 'a') as fp:
+        fp.write(b'\xff' * SIZE_OF_BPx)
 
 ###################################################
 # Generate boot parameters

--- a/os/tools/mksamsungheader.py
+++ b/os/tools/mksamsungheader.py
@@ -18,19 +18,11 @@
 ############################################################################
 import os
 import sys
+import config_util as util
 
 OS_DIR = os.path.dirname(__file__) + '/..'
 TOOL_DIR = OS_DIR + '/tools/'
 
-def read_binpath():
-	with open(OS_DIR + '/.bininfo') as f:
-		info = f.readline()
-		while info :
-			if ("kernel" in info) :
-				binary_path = info.split('=')[1].rstrip('\n')
-				break
-			info = f.readline()
-	return binary_path
 ############################################################################
 #
 # This script generates samsung binary header for kernel.
@@ -52,7 +44,7 @@ def read_binpath():
 # argv[3] is a size of secure header which is board-specific.
 #
 ############################################################################
-binary_path = OS_DIR + '/../build/output/bin/' + read_binpath()
+binary_path = OS_DIR + '/../build/output/bin/' + util.get_binname_from_bininfo("KERNEL")
 binary_type = sys.argv[1]
 secure_header_size = sys.argv[2]
 

--- a/os/tools/set_bininfo.py
+++ b/os/tools/set_bininfo.py
@@ -34,19 +34,19 @@ build_folder = os_folder + '/../build'
 output_folder = build_folder + '/output/bin'
 
 def save_bininfo(bin_name) :
-	with open(os_folder + '/.bininfo', "a") as f :
-		if ("kernel" in bin_name) :
-			f.write('KERNEL_BIN_NAME=' + bin_name + '\n')
-		if ("app1" in bin_name) :
-			f.write('APP1_BIN_NAME=' + bin_name + '\n')
-		if ("app2" in bin_name) :
-			f.write('APP2_BIN_NAME=' + bin_name + '\n')
-		if ("common" in bin_name) :
-			f.write('COMMON_BIN_NAME=' + bin_name + '\n')
+    with open(os_folder + '/.bininfo', "a") as f :
+        if ("kernel" in bin_name) :
+            f.write('KERNEL_BIN_NAME=' + bin_name + '\n')
+        if ("app1" in bin_name) :
+            f.write('APP1_BIN_NAME=' + bin_name + '\n')
+        if ("app2" in bin_name) :
+            f.write('APP2_BIN_NAME=' + bin_name + '\n')
+        if ("common" in bin_name) :
+            f.write('COMMON_BIN_NAME=' + bin_name + '\n')
 
 # Delete previous .bininfo
 if os.path.isfile(os_folder + '/.bininfo') :
-	os.remove(os_folder + '/.bininfo')
+    os.remove(os_folder + '/.bininfo')
 
 # Check the board type. Because kernel binary name is different based on board type.
 BOARD_TYPE = util.get_value_from_file(cfg_file, "CONFIG_ARCH_BOARD=").replace('"', '').rstrip("\n")
@@ -55,35 +55,35 @@ BOARD_TYPE = util.get_value_from_file(cfg_file, "CONFIG_ARCH_BOARD=").replace('"
 CONFIG_CMN_BIN_NAME = util.get_value_from_file(cfg_file, "CONFIG_COMMON_BINARY_NAME=").replace('"', '').rstrip("\n")
 
 if util.check_config_existence(cfg_file, 'CONFIG_BOARD_BUILD_DATE') == True:
-	BIN_VERSION = util.get_value_from_file(cfg_file, "CONFIG_BOARD_BUILD_DATE=").replace('"', '').rstrip("\n")
-	BIN_NAME = 'kernel_' + BOARD_TYPE + '_' + BIN_VERSION
+    BIN_VERSION = util.get_value_from_file(cfg_file, "CONFIG_BOARD_BUILD_DATE=").replace('"', '').rstrip("\n")
+    BIN_NAME = 'kernel_' + BOARD_TYPE + '_' + BIN_VERSION
 else :
-	BIN_NAME = 'kernel_' + BOARD_TYPE
+    BIN_NAME = 'kernel_' + BOARD_TYPE
 
 # Read the kernel binary name from board_metadata.txt.
 metadata_file = build_folder + '/configs/' + BOARD_TYPE + '/board_metadata.txt'
 if os.path.isfile(metadata_file) :
-	kernel_bin_name = util.get_value_from_file(metadata_file, "KERNEL=").replace('"','').rstrip('\n')
-	for filename in os.listdir(output_folder) :
-		if (filename == kernel_bin_name + '.' + SOURCE_EXT_NAME) :
-			# Change the kernel bin name as "kernel_[board]_[version].extension"
-			os.rename(output_folder + '/' + filename, output_folder + '/' + BIN_NAME + '.' + TARGET_EXT_NAME)
-			save_bininfo(BIN_NAME + '.' + TARGET_EXT_NAME)
-			continue
-		# Change the user bin name as "[user_bin_name]_[board]_[version]"
-		if ("app1" == filename or "app2" == filename) :
-			APP_BIN_VER = util.get_value_from_file(cfg_file, "CONFIG_" + filename.upper() + "_BIN_VER").rstrip("\n")
-			USER_BIN_NAME = filename + '_' + BOARD_TYPE + '_' + APP_BIN_VER
-			os.rename(output_folder + '/' + filename, output_folder + '/' + USER_BIN_NAME + '.' + TARGET_EXT_NAME)
-			save_bininfo(USER_BIN_NAME + '.' + TARGET_EXT_NAME)
-			continue
-		# Change the common bin name as "common_[board]_[version]"
-		if (filename == CONFIG_CMN_BIN_NAME) :
-			COMMON_BIN_VER = util.get_value_from_file(cfg_file, "CONFIG_COMMON_BINARY_VERSION=").replace('"','').rstrip('\n')
-			COMMON_BIN_NAME = 'common_' + BOARD_TYPE + '_' + COMMON_BIN_VER
-			os.rename(output_folder + '/' + CONFIG_CMN_BIN_NAME, output_folder + '/' + COMMON_BIN_NAME + '.' + TARGET_EXT_NAME)
-			save_bininfo(COMMON_BIN_NAME + '.' + TARGET_EXT_NAME)
-			continue
+    kernel_bin_name = util.get_value_from_file(metadata_file, "KERNEL=").replace('"','').rstrip('\n')
+    for filename in os.listdir(output_folder) :
+        if (filename == kernel_bin_name + '.' + SOURCE_EXT_NAME) :
+            # Change the kernel bin name as "kernel_[board]_[version].extension"
+            os.rename(output_folder + '/' + filename, output_folder + '/' + BIN_NAME + '.' + TARGET_EXT_NAME)
+            save_bininfo(BIN_NAME + '.' + TARGET_EXT_NAME)
+            continue
+        # Change the user bin name as "[user_bin_name]_[board]_[version]"
+        if ("app1" == filename or "app2" == filename) :
+            APP_BIN_VER = util.get_value_from_file(cfg_file, "CONFIG_" + filename.upper() + "_BIN_VER").rstrip("\n")
+            USER_BIN_NAME = filename + '_' + BOARD_TYPE + '_' + APP_BIN_VER
+            os.rename(output_folder + '/' + filename, output_folder + '/' + USER_BIN_NAME + '.' + TARGET_EXT_NAME)
+            save_bininfo(USER_BIN_NAME + '.' + TARGET_EXT_NAME)
+            continue
+        # Change the common bin name as "common_[board]_[version]"
+        if (filename == CONFIG_CMN_BIN_NAME) :
+            COMMON_BIN_VER = util.get_value_from_file(cfg_file, "CONFIG_COMMON_BINARY_VERSION=").replace('"','').rstrip('\n')
+            COMMON_BIN_NAME = 'common_' + BOARD_TYPE + '_' + COMMON_BIN_VER
+            os.rename(output_folder + '/' + CONFIG_CMN_BIN_NAME, output_folder + '/' + COMMON_BIN_NAME + '.' + TARGET_EXT_NAME)
+            save_bininfo(COMMON_BIN_NAME + '.' + TARGET_EXT_NAME)
+            continue
 else :
-	save_bininfo("tinyara.bin")
+    save_bininfo("tinyara.bin")
 

--- a/os/tools/set_bininfo.py
+++ b/os/tools/set_bininfo.py
@@ -20,6 +20,7 @@
 import os
 import sys
 import string
+import config_util as util
 
 SOURCE_EXT_NAME = sys.argv[1]
 TARGET_EXT_NAME = "trpk" # TizenRT Package (TizenRT Header + output)
@@ -31,22 +32,6 @@ os_folder = os.path.dirname(__file__) + '/..'
 cfg_file = os_folder + '/.config'
 build_folder = os_folder + '/../build'
 output_folder = build_folder + '/output/bin'
-
-def get_value_from_file(file_name, target):
-	with open(file_name, 'r+') as f:
-		lines = f.readlines()
-		value = 'None'
-		for line in lines:
-			if target in line:
-				value = (line.split("=")[1])
-				break		
-	return value;
-
-def check_version_config(file_name):
-    with open(file_name, 'r+') as f:
-        lines = f.readlines()
-    
-    return any([True if 'CONFIG_BOARD_BUILD_DATE' in line and not line.startswith('#') else False for line in lines ])
 
 def save_bininfo(bin_name) :
 	with open(os_folder + '/.bininfo', "a") as f :
@@ -64,13 +49,13 @@ if os.path.isfile(os_folder + '/.bininfo') :
 	os.remove(os_folder + '/.bininfo')
 
 # Check the board type. Because kernel binary name is different based on board type.
-BOARD_TYPE = get_value_from_file(cfg_file, "CONFIG_ARCH_BOARD=").replace('"', '').rstrip("\n")
+BOARD_TYPE = util.get_value_from_file(cfg_file, "CONFIG_ARCH_BOARD=").replace('"', '').rstrip("\n")
 
 # Extract Common binary name
-CONFIG_CMN_BIN_NAME = get_value_from_file(cfg_file, "CONFIG_COMMON_BINARY_NAME=").replace('"', '').rstrip("\n")
+CONFIG_CMN_BIN_NAME = util.get_value_from_file(cfg_file, "CONFIG_COMMON_BINARY_NAME=").replace('"', '').rstrip("\n")
 
-if check_version_config(cfg_file) :
-	BIN_VERSION = get_value_from_file(cfg_file, "CONFIG_BOARD_BUILD_DATE=").replace('"', '').rstrip("\n")
+if util.check_config_existence(cfg_file, 'CONFIG_BOARD_BUILD_DATE') == True:
+	BIN_VERSION = util.get_value_from_file(cfg_file, "CONFIG_BOARD_BUILD_DATE=").replace('"', '').rstrip("\n")
 	BIN_NAME = 'kernel_' + BOARD_TYPE + '_' + BIN_VERSION
 else :
 	BIN_NAME = 'kernel_' + BOARD_TYPE
@@ -78,7 +63,7 @@ else :
 # Read the kernel binary name from board_metadata.txt.
 metadata_file = build_folder + '/configs/' + BOARD_TYPE + '/board_metadata.txt'
 if os.path.isfile(metadata_file) :
-	kernel_bin_name = get_value_from_file(metadata_file, "KERNEL=").replace('"','').rstrip('\n')
+	kernel_bin_name = util.get_value_from_file(metadata_file, "KERNEL=").replace('"','').rstrip('\n')
 	for filename in os.listdir(output_folder) :
 		if (filename == kernel_bin_name + '.' + SOURCE_EXT_NAME) :
 			# Change the kernel bin name as "kernel_[board]_[version].extension"
@@ -87,14 +72,14 @@ if os.path.isfile(metadata_file) :
 			continue
 		# Change the user bin name as "[user_bin_name]_[board]_[version]"
 		if ("app1" == filename or "app2" == filename) :
-			APP_BIN_VER = get_value_from_file(cfg_file, "CONFIG_" + filename.upper() + "_BIN_VER").rstrip("\n")
+			APP_BIN_VER = util.get_value_from_file(cfg_file, "CONFIG_" + filename.upper() + "_BIN_VER").rstrip("\n")
 			USER_BIN_NAME = filename + '_' + BOARD_TYPE + '_' + APP_BIN_VER
 			os.rename(output_folder + '/' + filename, output_folder + '/' + USER_BIN_NAME + '.' + TARGET_EXT_NAME)
 			save_bininfo(USER_BIN_NAME + '.' + TARGET_EXT_NAME)
 			continue
 		# Change the common bin name as "common_[board]_[version]"
 		if (filename == CONFIG_CMN_BIN_NAME) :
-			COMMON_BIN_VER = get_value_from_file(cfg_file, "CONFIG_COMMON_BINARY_VERSION=").replace('"','').rstrip('\n')
+			COMMON_BIN_VER = util.get_value_from_file(cfg_file, "CONFIG_COMMON_BINARY_VERSION=").replace('"','').rstrip('\n')
 			COMMON_BIN_NAME = 'common_' + BOARD_TYPE + '_' + COMMON_BIN_VER
 			os.rename(output_folder + '/' + CONFIG_CMN_BIN_NAME, output_folder + '/' + COMMON_BIN_NAME + '.' + TARGET_EXT_NAME)
 			save_bininfo(COMMON_BIN_NAME + '.' + TARGET_EXT_NAME)


### PR DESCRIPTION
1. There are many duplicated util functions. So integrated.
 1) get_value_from_file() checks that passed argument(target) is in the file or not, and returns the value if exist.
 2) check_config_existence() checks that passed argument(config) is in the file and not starts with '#'.
 3) get_binname_from_bininfo() returns the binary name read from .bininfo

2. Change indentation from tab to 4 spaces
 It is recommended to use Python Coding rule based on PEP 8.
 (PEP 8 : python.org/dev/peps/pep-0008)
 So change the indentations from tab to 4 spaces.

Signed-off-by: jeongchanKim <jc_.kim@samsung.com>