### PR TITLE
[Under Powercut] Optimize Opening time of files in jSmartFs

### DIFF
--- a/os/fs/smartfs/smartfs.h
+++ b/os/fs/smartfs/smartfs.h
@@ -191,8 +191,9 @@
 #define SMARTFS_DIRENT_TYPE_DIR   0x2000
 #define SMARTFS_DIRENT_TYPE_FILE  0x0000
 
-/* Number of bytes in the SMART magic sequences */
+#define SMARTFS_DIRENT_LEN_UNKWN  0xFFFFFFFF	/* Signifies that the length of the openend file is not calculated yet */
 
+/* Number of bytes in the SMART magic sequences */
 #define SMART_MAGICSIZE           4
 
 /* Quasi-standard definitions */

--- a/os/fs/smartfs/smartfs.h
+++ b/os/fs/smartfs/smartfs.h
@@ -378,6 +378,8 @@ int smartfs_mount(struct smartfs_mountpt_s *fs, bool writeable);
 
 int smartfs_unmount(struct smartfs_mountpt_s *fs);
 
+int smartfs_get_datalen(struct smartfs_mountpt_s *fs, uint16_t firstsector, uint32_t *datalen);
+
 int smartfs_finddirentry(struct smartfs_mountpt_s *fs, struct smartfs_entry_s *direntry, const char *relpath);
 
 int smartfs_createdirentry(struct smartfs_mountpt_s *fs, struct smartfs_entry_s *direntry);


### PR DESCRIPTION
1. Separate entry finding and length calculation functionalities of smartfs_finddirentry function into 2 separate functions
2. Invoke smartfs_get_datalen while opening the file only when length of the file is required to be known
3. Invoke smartfs_get_datalen if an operation requires the length of the file to be known but the length has not been calculated yet