### PR TITLE
external/webserver: Implement API for chunk transfer from webserver

### DIFF
--- a/external/include/protocols/webserver/http_server.h
+++ b/external/include/protocols/webserver/http_server.h
@@ -205,6 +205,12 @@ struct http_server_t {
 #endif
 };
 
+typedef enum {
+        FIRST_DATA = 0,
+        NEXT_DATA = 1,
+        LAST_DATA = 2,
+} data_type_e;
+
 /****************************************************************************
  * Public Function Prototypes
  ****************************************************************************/
@@ -309,6 +315,21 @@ int http_send_response(struct http_client_t *client, int status, const char *bod
  *         On failure, HTTP_ERROR(-1) is returned.
  */
 int http_send_response_with_status_msg(struct http_client_t *client, int status, const char* status_message, const char* body, struct http_keyvalue_list_t *headers);
+
+/**
+ * @brief http_send_response_chunk() sends the response in chunk form.
+ *
+ * @param[in] client a pointer of HTTP client.
+ * @param[in] status status code of a response.
+ * @param[in] status_message status message associated with status code.
+ * @param[in] body Response payload.
+ * @param[in] headers HTTP headers of a response.
+ * @param[in] data_type - FIRST_DATA, NEXT_DATA, LAST_DATA
+ * @return On success, HTTP_OK(0) is returned.
+ *         On failure, HTTP_ERROR(-1) is returned.
+ */
+int http_send_response_chunk(struct http_client_t *client, int status, const char* status_message,
+                        const char *body, struct http_keyvalue_list_t *headers, data_type_e data_type);
 
 #ifdef CONFIG_NET_SECURITY_TLS
 /**


### PR DESCRIPTION
API http_send_response_chunk sends response to client in chunk
format

Signed-off-by: Amit Purwar <amit.purwar@samsung.com>