### PR TITLE
os/kernel/log_dump.c : Add start and stop functionality

### DIFF
--- a/os/drivers/serial/serial.c
+++ b/os/drivers/serial/serial.c
@@ -73,7 +73,7 @@
 #include <tinyara/serial/serial.h>
 #include <tinyara/fs/ioctl.h>
 #ifdef CONFIG_LOG_DUMP
-#include <tinyara/log_dump/log_dump.h>
+#include <tinyara/log_dump/log_dump_internal.h>
 #endif
 
 /************************************************************************************

--- a/os/fs/procfs/fs_procfslogsave.c
+++ b/os/fs/procfs/fs_procfslogsave.c
@@ -43,6 +43,8 @@
 #include <tinyara/fs/procfs.h>
 #include <tinyara/log_dump/log_dump.h>
 
+#include <tinyara/log_dump/log_dump_internal.h>
+
 #if !defined(CONFIG_DISABLE_MOUNTPOINT) && defined(CONFIG_FS_PROCFS)
 #if defined(CONFIG_LOG_DUMP)
 
@@ -74,6 +76,7 @@ struct logsave_file_s {
 static int logsave_open(FAR struct file *filep, FAR const char *relpath, int oflags, mode_t mode);
 static int logsave_close(FAR struct file *filep);
 static ssize_t logsave_read(FAR struct file *filep, FAR char *buffer, size_t buflen);
+static ssize_t logsave_write(FAR struct file *filep, FAR const char *buffer, size_t buflen);
 static int logsave_dup(FAR const struct file *oldp, FAR struct file *newp);
 static int logsave_stat(FAR const char *relpath, FAR struct stat *buf);
 
@@ -94,7 +97,7 @@ const struct procfs_operations logsave_operations = {
 	logsave_open,				/* open */
 	logsave_close,				/* close */
 	logsave_read,				/* read */
-	NULL,					/* write */
+	logsave_write,				/* write */
 
 	logsave_dup,				/* dup */
 
@@ -139,6 +142,15 @@ static int logsave_close(FAR struct file *filep)
 static ssize_t logsave_read(FAR struct file *filep, FAR char *buffer, size_t buflen)
 {
 	return log_dump_read(buffer, buflen);
+}
+
+/****************************************************************************
+ * Name: logsave_write
+ ****************************************************************************/
+
+static ssize_t logsave_write(FAR struct file *filep, FAR const char *buffer, size_t buflen)
+{
+	return log_dump_set(buffer, buflen);
 }
 
 /****************************************************************************

--- a/os/include/tinyara/log_dump/log_dump.h
+++ b/os/include/tinyara/log_dump/log_dump.h
@@ -19,10 +19,15 @@
 /****************************************************************************
  * Included Files
  ****************************************************************************/
+#include <stdio.h>
+#include <fcntl.h>
 
 /********************************************************************************
  * Definitions
  ********************************************************************************/
+
+ #define LOGDUMP_SAVE_START	"1"
+ #define LOGDUMP_SAVE_STOP	"2"
 
 /********************************************************************************
  * Public Types
@@ -32,10 +37,8 @@
  * Public Functions
  ********************************************************************************/
 
-int log_dump_init(void);
-
-void log_dump_read_init(void);
-
-int log_dump_save(char ch);
-
-size_t log_dump_read(FAR char *buffer, size_t buflen);
+#define OPEN_LOGDUMP()			open("/proc/logsave", O_RDWR)
+#define START_LOGDUMP_SAVE(fd)		write(fd, LOGDUMP_SAVE_START, strlen(LOGDUMP_SAVE_START) + 1)
+#define STOP_LOGDUMP_SAVE(fd)		write(fd, LOGDUMP_SAVE_STOP, strlen(LOGDUMP_SAVE_STOP) + 1)
+#define READ_LOGDUMP(fd, buf, bufsize)	read(fd, buf, bufsize)
+#define CLOSE_LOGDUMP(fd)		close(fd)

--- a/os/include/tinyara/log_dump/log_dump_internal.h
+++ b/os/include/tinyara/log_dump/log_dump_internal.h
@@ -1,0 +1,36 @@
+/****************************************************************************
+ *
+ * Copyright 2022 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __LOG_DUMP_INTERNAL_H
+#define __LOG_DUMP_INTERNAL_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+int log_dump_init(void);
+
+void log_dump_read_init(void);
+
+int log_dump_save(char ch);
+
+size_t log_dump_read(FAR char *buffer, size_t buflen);
+
+int log_dump_set(FAR const char *buffer, size_t buflen);
+
+#endif							/* __LOG_DUMP_INTERNAL_H */

--- a/os/kernel/init/os_start.c
+++ b/os/kernel/init/os_start.c
@@ -99,7 +99,7 @@
 #include  "init/init.h"
 #include  "debug/memdbg.h"
 #ifdef CONFIG_LOG_DUMP
-#include <tinyara/log_dump/log_dump.h>
+#include <tinyara/log_dump/log_dump_internal.h>
 #endif
 
 extern const uint32_t g_idle_topstack;


### PR DESCRIPTION
To control the log saving, add start and stop functionality.
Log will be saved by default if log dump config is enabled.

Usage:
  #include <tinyara/log_dump/log_dump.h>
  START_LOGDUMP_SAVE(fd); //To start the log saving
  STOP_LOGDUMP_SAVE(fd);  //To stop the log saving

Example:
TASH>>log_dump

TASH>>This Log Should NOT be saved!!!

log_dump_main: 

*********************   LOG DUMP START  *********************

This Log Should be saved!!!

System Information:

	Version:

		Platform: 3.1	Binary: 200204

	Commit Hash: b008e5f

	Build User: root@jeongchanKim

	Build Time: 2022-03-28 09:50:21 KST

	System Time: 06 Dec 2011, 00:00:00 [s] UTC 

TASH>>Hello, World!!



TASH>>

TASH>>

TASH>>log_dump

TASH>>This Log Should be saved!!!

log_dump_main: 

*********************   LOG DUMP END  ***********************



Signed-off-by: jeongchanKim <jc_.kim@samsung.com>