### PR TITLE
Revert "os/binfmt: Refactor code for usage of uheap and mpu_regs from…

### DIFF
--- a/os/arch/arm/src/common/up_createstack.c
+++ b/os/arch/arm/src/common/up_createstack.c
@@ -174,6 +174,15 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
 {
 	size_t stack_alloc_size = stack_size;
 
+	/* new thread does not have the uheap value yet, It's added in the task_
+	 * schedsetup function.
+	 * Parent and child threads must have the same uheap value, so we are
+	 * using the parent thread uheap
+	 */
+#if defined(HAVE_KERNEL_HEAP) || defined(CONFIG_MPU_STACK_OVERFLOW_PROTECTION)
+	uint32_t uheap = sched_self()->uheap;	/* User heap pointer */
+#endif
+
 	/* Is there already a stack allocated of a different size?  Because of
 	 * alignment issues, stack_size might erroneously appear to be of a
 	 * different size.  Fortunately, this is not a critical operation.
@@ -193,7 +202,12 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
 		 */
 
 #ifdef HAVE_KERNEL_HEAP
-		if (ttype == TCB_FLAG_TTYPE_KERNEL) {
+		/* Use the kernel allocator if this is a task / pthread being created
+		 * to run only on kernel side. We verify this by checking the uheap
+		 * object in the tcb of current running task. uheap is always non-null
+		 * in user threads and null for kernel threads.
+		 */
+		if (!uheap || ttype == TCB_FLAG_TTYPE_KERNEL) {
 #ifdef CONFIG_MPU_STACK_OVERFLOW_PROTECTION
 			stack_alloc_size = stack_alloc_size + CONFIG_MPU_STACK_GUARD_SIZE;
 			tcb->stack_alloc_ptr = (uint32_t *)kmm_memalign(STACK_PROTECTION_MPU_ALIGNMENT, stack_alloc_size);

--- a/os/binfmt/binfmt.h
+++ b/os/binfmt/binfmt.h
@@ -160,13 +160,14 @@ static inline void binfmt_set_mpu(struct binary_s *binp)
 
 #ifdef CONFIG_SUPPORT_COMMON_BINARY
 	if (binp->islibrary) {
+		regs = binp->cmn_mpu_regs;
 		nregion = mpu_get_nregion_info(MPU_REGION_COMMON_BIN);
 	} else
 #endif
 	{
+		regs = sched_self()->mpu_regs;
 		nregion = mpu_get_nregion_info(MPU_REGION_APP_BIN);
 	}
-	regs = binp->mpu_regs;
 
 #ifdef CONFIG_OPTIMIZE_APP_RELOAD_TIME
 	/* Configure text section as RO and executable region */

--- a/os/binfmt/binfmt_execmodule.c
+++ b/os/binfmt/binfmt_execmodule.c
@@ -150,6 +150,7 @@ static void exec_ctors(FAR void *arg)
 int exec_module(FAR struct binary_s *binp)
 {
 	FAR struct task_tcb_s *newtcb;
+	FAR struct tcb_s *rtcb;
 	FAR uint32_t *stack;
 	pid_t pid;
 	int ret;
@@ -181,6 +182,8 @@ int exec_module(FAR struct binary_s *binp)
 	pointer to the application's mm_heap object. Here we will store the mm_heap
 	pointer to the start of the text section */
 	*(uint32_t *)(binp->sections[BIN_DATA]) = (uint32_t)binp->uheap;
+	rtcb = (struct tcb_s *)sched_self();
+	rtcb->uheap = (uint32_t)binp->uheap;
 
 	/* Allocate a TCB for the new task. */
 
@@ -269,23 +272,20 @@ int exec_module(FAR struct binary_s *binp)
 
 	pid = newtcb->cmn.pid;
 
+	/* Parent task rtcb was initialized with uheap and mpu_regs values.
+	 * These values are used for stack allocation and task_init and will
+	 * be passed on to all the child tasks of the user app. Since the user
+	 * app is now created, we will reset these values here
+	 */
+	rtcb->uheap = 0;
+#ifdef CONFIG_ARM_MPU
+	memset(rtcb->mpu_regs, 0, sizeof(rtcb->mpu_regs));
+#endif
+
 	/* Store the address of the applications userspace object in the newtcb  */
 	/* The app's userspace object will be found at an offset of 4 bytes from the start of the binary */
 	newtcb->cmn.uspace = binp->sections[BIN_TEXT] + 4;
 	newtcb->cmn.uheap = (uint32_t)binp->uheap;
-	/* Copy the MPU register values from parent to child task */
-#ifdef CONFIG_ARM_MPU
-	int i = 0;
-#ifdef CONFIG_OPTIMIZE_APP_RELOAD_TIME
-	for (; i < MPU_REG_NUMBER * MPU_NUM_REGIONS; i += MPU_REG_NUMBER)
-#endif
-	{
-		newtcb->cmn.mpu_regs[i + MPU_REG_RNR] = binp->mpu_regs[i + MPU_REG_RNR];
-		newtcb->cmn.mpu_regs[i + MPU_REG_RBAR] = binp->mpu_regs[i + MPU_REG_RBAR];
-		newtcb->cmn.mpu_regs[i + MPU_REG_RASR] = binp->mpu_regs[i + MPU_REG_RASR];
-	}
-#endif
-
 
 #ifdef CONFIG_BINARY_MANAGER
 #ifdef CONFIG_SUPPORT_COMMON_BINARY

--- a/os/binfmt/binfmt_unloadmodule.c
+++ b/os/binfmt/binfmt_unloadmodule.c
@@ -201,10 +201,10 @@ int unload_module(FAR struct binary_s *binp)
 #if (defined(CONFIG_ARMV7M_MPU) || defined(CONFIG_ARMV8M_MPU))
 #ifdef CONFIG_OPTIMIZE_APP_RELOAD_TIME
 			for (int i = 0; i < MPU_REG_NUMBER * MPU_NUM_REGIONS; i += MPU_REG_NUMBER) {
-				up_mpu_disable_region(&binp->mpu_regs[i]);
+				up_mpu_disable_region(&binp->cmn_mpu_regs[i]);
 			}
 #else
-			up_mpu_disable_region(&binp->mpu_regs[0]);
+			up_mpu_disable_region(&binp->cmn_mpu_regs[0]);
 #endif
 #endif
 		}

--- a/os/include/tinyara/binfmt/binfmt.h
+++ b/os/include/tinyara/binfmt/binfmt.h
@@ -121,9 +121,9 @@ struct binary_s {
 #endif
 #ifdef CONFIG_SUPPORT_COMMON_BINARY
 	uint8_t islibrary;			/* Is this bin object containing a library */
+#ifdef CONFIG_ARM_MPU							/* MPU register values for common binary only */
+	uint32_t cmn_mpu_regs[MPU_REG_NUMBER * MPU_NUM_REGIONS];	/* Common binary MPU is configured during loading and disabled during unload_module */
 #endif
-#ifdef CONFIG_ARM_MPU
-	uint32_t mpu_regs[MPU_REG_NUMBER * MPU_NUM_REGIONS];	/* MPU register values for common and app binaries */
 #endif
 	FAR char *const *argv;			/* Argument list */
 	FAR const struct symtab_s *exports;	/* Table of exported symbols */


### PR DESCRIPTION
… parent tcb"

This reverts commit 76b849324120dd4a91cd6145c7d7e4293c1a2325.