### PR TITLE
os/Makefile.unix: Make common changes for app build in all repos

### DIFF
--- a/os/Makefile.unix
+++ b/os/Makefile.unix
@@ -519,11 +519,19 @@ post:
 ifeq ($(CONFIG_APP_BINARY_SEPARATION),y)
 	$(Q) mkdir -p $(OUTBIN_DIR)/user
 ifneq ($(CONFIG_SUPPORT_COMMON_BINARY),y)
+ifeq ($(CONFIG_APP1_INFO),y)
 	$(Q) $(call VERIFY_APP,"app1") #When common binary is used, undefined symbols of app
+endif
+ifeq ($(CONFIG_APP2_INFO),y)
 	$(Q) $(call VERIFY_APP,"app2") #will be defined in common binary. So dont perform "verify" for apps
+endif
 endif 
+ifeq ($(CONFIG_APP1_INFO),y)
 	$(Q) $(call PREPARE_APP,"app1","user",$(CONFIG_APP1_BIN_TYPE),$(CONFIG_APP1_BIN_VER),$(CONFIG_APP1_BIN_DYN_RAMSIZE),$(CONFIG_APP1_MAIN_STACKSIZE),$(CONFIG_APP1_MAIN_PRIORITY),$(CONFIG_APP1_BIN_LOADING_PRIORITY))
+endif
+ifeq ($(CONFIG_APP2_INFO),y)
 	$(Q) $(call PREPARE_APP,"app2","user",$(CONFIG_APP2_BIN_TYPE),$(CONFIG_APP2_BIN_VER),$(CONFIG_APP2_BIN_DYN_RAMSIZE),$(CONFIG_APP2_MAIN_STACKSIZE),$(CONFIG_APP2_MAIN_PRIORITY),$(CONFIG_APP2_BIN_LOADING_PRIORITY))
+endif
 ifeq ($(CONFIG_SUPPORT_COMMON_BINARY),y)
 	$(Q) $(call VERIFY_APP,$(CONFIG_COMMON_BINARY_NAME))
 	$(Q) $(call PREPARE_APP,$(CONFIG_COMMON_BINARY_NAME),"common",$(CONFIG_COMMON_BINARY_VERSION))

--- a/os/tools/check_output_size.py
+++ b/os/tools/check_output_size.py
@@ -122,8 +122,10 @@ APP2_PARTITION_SIZE = int(SIZE_LIST[APP2_IDX]) * 1024
 print("\n========== Size Verification of built Binaries ==========")
 check_binary_size("KERNEL", KERNEL_PARTITION_SIZE)
 if CONFIG_APP_BINARY_SEPARATION == "y" :
-    check_binary_size("APP1", APP1_PARTITION_SIZE)
-    check_binary_size("APP2", APP2_PARTITION_SIZE)
+    if APP1_IDX != 0 :
+        check_binary_size("APP1", APP1_PARTITION_SIZE)
+    if APP2_IDX != 0 :
+        check_binary_size("APP2", APP2_PARTITION_SIZE)
     if CONFIG_SUPPORT_COMMON_BINARY == "y" :
         check_binary_size("COMMON", COMMON_PARTITION_SIZE)
 


### PR DESCRIPTION
Public and private repos use different number of apps. So, while
building the app binaries, check the corresponding config and
build only the required app binaries.

Signed-off-by: Kishore S N <kishore.sn@samsung.com>