### PR TITLE
os/arch: Refactor debug messages

### DIFF
--- a/os/arch/arm/src/armv7-m/up_busfault.c
+++ b/os/arch/arm/src/armv7-m/up_busfault.c
@@ -89,28 +89,31 @@ int up_busfault(int irq, FAR void *context, FAR void *arg)
 	uint32_t bfar = getreg32(NVIC_BFAULT_ADDR);
 	system_exception_location = regs[REG_R15];
 
-	lldbg("PANIC!!! Bus fault occurred while executing instruction at address : 0x%08x\n", regs[REG_R15]);
-	lldbg("CFAULTS: 0x%08x\n", cfsr);
-
-	if (cfsr & BFARVALID) {
-		lldbg("Fault occurred while accessing address (BFAR) : 0x%08x\n", bfar);
-	} else {
-		lldbg("Unable to determine fault address.\n");
-	}
+	lldbg("#########################################################################\n");
+	lldbg("PANIC!!! Bus fault at instruction: 0x%08x\n", regs[REG_R15]);
 
 	if (cfsr & PRECISERR) {
-		lldbg("Precise data access error occurred.\n");
+		lldbg("FAULT TYPE: PRECISERR (Precise data access error occurred).\n");
 	} else if (cfsr & IMPRECISERR) {
-		lldbg("Imprecise data access error occurred.\n");
+		lldbg("FAULT TYPE: IMPRECISERR (Imprecise data access error occurred).\n");
 	} else if (cfsr & STKERR) {
-		lldbg("Error while stacking registers during exception entry.\n");
+		lldbg("FAULT TYPE: STKERR (Error while stacking registers during exception entry).\n");
 	} else if (cfsr & UNSTKERR) {
-		lldbg("Error while unstacking registers during exception return.\n");
+		lldbg("FAULT TYPE: UNSTKERR (Error while unstacking registers during exception return).\n");
 	} else if (cfsr & LSPERR) {
-		lldbg("Error occurred during lazy state preservation of Floating Point unit registers.\n");
+		lldbg("FAULT TYPE: LSPERR (Error occurred during lazy state preservation of Floating Point unit registers).\n");
 	} else if (cfsr & IBUSERR) {
-		lldbg("Error on an instruction prefetch.\n");
+		lldbg("FAULT TYPE: IBUSERR (Error on an instruction prefetch).\n");
 	}
+
+	if (cfsr & BFARVALID) {
+		lldbg("FAULT ADDRESS: 0x%08x\n", bfar);
+	} else {
+		lldbg("FAULT ADDRESS: Unable to determine fault address.\n");
+	}
+
+	lldbg("FAULT REGS: CFAULTS: 0x%08x BFAR: 0x%08x\n", cfsr, bfar);
+	lldbg("#########################################################################\n");
 
 #ifdef CONFIG_SYSTEM_REBOOT_REASON
 	if (cfsr & IBUSERR) {

--- a/os/arch/arm/src/armv7-m/up_memfault.c
+++ b/os/arch/arm/src/armv7-m/up_memfault.c
@@ -124,27 +124,30 @@ int up_memfault(int irq, FAR void *context, FAR void *arg)
 	uint32_t mmfar = getreg32(NVIC_MEMMANAGE_ADDR);
 	system_exception_location = regs[REG_R15];
 
-	lldbg("PANIC!!! Memory Management Fault occurred while executing instruction at address : 0x%08x\n", regs[REG_R15]);
-	lldbg("CFAULTS: 0x%08x\n", cfsr);
-
-	if (cfsr & MMARVALID) {
-		lldbg("Access violation occurred at address (MMFAR) : 0x%08x\n", mmfar);
-	} else {
-		lldbg("Unable to determine access violation address.\n");
-	}
+	lldbg("#########################################################################\n");
+	lldbg("PANIC!!! Memory Management Fault at instruction : 0x%08x\n", regs[REG_R15]);
 
 	if (cfsr & DACCVIOL) {
-		lldbg("Data access violation occurred.\n");
+		lldbg("FAULT TYPE: DACCVIOL (Data access violation occurred. Check MPU RW permissions).\n");
 	} else if (cfsr & IACCVIOL) {
-		lldbg("Instruction access violation occurred while fetching instruction from an Execute Never (XN) region.\n");
+		lldbg("FAULT TYPE: IACCVIOL (Instruction access violation occurred. Check MPU XN region).\n");
 		system_exception_location = regs[REG_R14];	/* The PC value might be invalid, so use LR */
 	} else if (cfsr & MSTKERR) {
-		lldbg("Error while stacking registers during exception entry.\n");
+		lldbg("FAULT TYPE: MSTKERR (Error while stacking registers during exception entry).\n");
 	} else if (cfsr & MUNSTKERR) {
-		lldbg("Error while unstacking registers during exception return.\n");
+		lldbg("FAULT TYPE: MUNSTKERR (Error while unstacking registers during exception return).\n");
 	} else if (cfsr & MLSPERR) {
-		lldbg("Error occurred during lazy state preservation of Floating Point unit registers.\n");
+		lldbg("FAULT TYPE: MLSPERR (Error occurred during lazy state preservation of Floating Point unit registers).\n");
 	}
+
+	if (cfsr & MMARVALID) {
+		lldbg("FAULT ADDRESS: 0x%08x\n", mmfar);
+	} else {
+		lldbg("FAULT ADDRESS: Unable to determine fault address.\n");
+	}
+
+	lldbg("FAULT REGS: CFAULTS: 0x%08x MMFAR: 0x%08x\n", cfsr, mmfar);
+	lldbg("#########################################################################\n\n\n");
 
 #ifdef CONFIG_SYSTEM_REBOOT_REASON
 	if (cfsr & IACCVIOL) {

--- a/os/arch/arm/src/armv7-m/up_usagefault.c
+++ b/os/arch/arm/src/armv7-m/up_usagefault.c
@@ -87,25 +87,28 @@ int up_usagefault(int irq, FAR void *context, FAR void *arg)
 	uint32_t cfsr = getreg32(NVIC_CFAULTS);
 	system_exception_location = regs[REG_R15];
 
-	lldbg("PANIC!!! Usagefault occurred while executing instruction at address : 0x%08x\n", regs[REG_R15]);
-	lldbg("CFAULTS: 0x%08x\n", cfsr);
+	lldbg("#########################################################################\n");
+	lldbg("PANIC!!! Usagefault at instruction: 0x%08x\n", regs[REG_R15]);
 
 	if (cfsr & DIVBYZERO) {
-		lldbg("Divide by zero error has occurred.\n");
+		lldbg("FAULT TYPE: DIVBYZERO (Divide by zero error has occurred).\n");
 	} else if (cfsr & UNALIGNED) {
-		lldbg("Unaligned access error has occurred.\n");
+		lldbg("FAULT TYPE: UNALIGNED (Unaligned access error has occurred).\n");
 	} else if (cfsr & NOCP) {
-		lldbg("A coprocessor error has occurred.\n");
+		lldbg("FAULT TYPE: NOCP (A coprocessor error has occurred).\n");
 	} else if (cfsr & INVPC) {
-		lldbg("An integrity check error has occurred on EXC_RETURN. PC value might be invalid.\n");
+		lldbg("FAULT TYPE: INVPC (Integrity check error during EXC_RETURN).\n");
 		/* As PC value might be invalid use LR value to determine if
 		 * the crash occurred in the kernel space or in the user space */
 		system_exception_location = regs[REG_R14];
 	} else if (cfsr & INVSTATE) {
-		lldbg("Invalid state. Instruction executed with invalid EPSR.T or EPSR.IT field.\n");
+		lldbg("FAULT TYPE: INVSTATE (Invalid state. Check EPSR T bit. XPSR = 0x%08x).\n", regs[REG_XPSR]);
 	} else if (cfsr & UNDEFINSTR) {
-		lldbg("Undefined instruction executed.\n");
+		lldbg("FAULT TYPE: UNDEFINSTR (Undefined instruction executed).\n");
 	}
+
+	lldbg("FAULT REGS: CFAULTS: 0x%08x\n", cfsr);
+	lldbg("#########################################################################\n");
 
 #ifdef CONFIG_SYSTEM_REBOOT_REASON
 	up_reboot_reason_write(REBOOT_SYSTEM_PREFETCHABORT);

--- a/os/arch/arm/src/armv8-m/mpu.h
+++ b/os/arch/arm/src/armv8-m/mpu.h
@@ -287,6 +287,30 @@ static inline void mpu_showtype(void)
 }
 
 /****************************************************************************
+ * Name: mpu_get_access_type_str
+ *
+ * Description:
+ *   Get the mpu region access type string
+ *
+ ****************************************************************************/
+
+static inline char *mpu_get_access_type_str(uint32_t rbar)
+{
+	uint32_t val = rbar & MPU_RBAR_AP_MASK;
+	if (val == MPU_RBAR_AP_RWNO) {
+		return "RW/NO";
+	} else if (val == MPU_RBAR_AP_RWRW) {
+		return "RW/RW";
+	} else if (val == MPU_RBAR_AP_RONO) {
+		return "RO/NO";
+	} else if (val == MPU_RBAR_AP_RORO) {
+		return "RO/RO";
+	} else {
+		return "XX/XX";
+	}
+}
+
+/****************************************************************************
  * Name: mpu_show_regioninfo
  *
  * Description:
@@ -303,22 +327,22 @@ static inline void mpu_show_regioninfo(void)
 	/* save the current region before printing the information */
 	temp = getreg32(MPU_RNR);
 
-	lldbg("*****************************************************************************\n");
-	lldbg("*REGION_NO.\tBASE_ADDRESS\t    SIZE\t   STATUS\t ACCESS\t   \tNO_EXECUTE*\n");
-	lldbg("*****************************************************************************\n");
+	lldbg("********************************************************************************************\n");
+	lldbg("%-12s\t%-12s\t%-12s\t%-12s\t%-12s\t%-12s\n", "REGION_NO.", "BASE_ADDRESS", "SIZE", "STATUS", "ACCESS (P/U)", "EXECUTE");
+	lldbg("********************************************************************************************\n");
 	for (idx = 0; idx < 8; idx++) {
 		putreg32(idx, MPU_RNR);
 		rbar = getreg32(MPU_RBAR);
 		rlar = getreg32(MPU_RLAR);
-		lldbg("%8d\t\t%8X\t%8X\t%8X\t%8X\t%8X\n",
+		lldbg("%-12d\t0x%-10X\t0x%-10X\t%-12s\t%-12s\t%-12s\n",
 			idx,
 			(rbar & MPU_RBAR_ADDR_MASK),
 			(((rlar & MPU_RLAR_LIMIT_MASK) - (rbar & MPU_RBAR_ADDR_MASK)) | 0x1f) + 1,
-			(rlar & MPU_RLAR_ENABLE) ? 1 : 0,
-			((rbar & MPU_RBAR_AP_MASK) >> MPU_RBAR_AP_SHIFT),
-			(rbar & MPU_RBAR_XN));
+			(rlar & MPU_RLAR_ENABLE) ? "ENABLED" : "DISABLED",
+			mpu_get_access_type_str(rbar),
+			(rbar & MPU_RBAR_XN) ? "XN" : "X");
 	}
-	lldbg("*****************************************************************************\n");
+	lldbg("********************************************************************************************\n");
 	/* restore the previous region */
 	putreg32(temp, MPU_RNR);
 #endif

--- a/os/arch/arm/src/armv8-m/up_busfault.c
+++ b/os/arch/arm/src/armv8-m/up_busfault.c
@@ -89,28 +89,31 @@ int up_busfault(int irq, FAR void *context, FAR void *arg)
 	uint32_t bfar = getreg32(NVIC_BFAULT_ADDR);
 	system_exception_location = regs[REG_R15];
 
-	lldbg("PANIC!!! Bus fault occurred while executing instruction at address : 0x%08x\n", regs[REG_R15]);
-	lldbg("CFAULTS: 0x%08x\n", cfsr);
-
-	if (cfsr & BFARVALID) {
-		lldbg("Fault occurred while accessing address (BFAR) : 0x%08x\n", bfar);
-	} else {
-		lldbg("Unable to determine fault address.\n");
-	}
+	lldbg("#########################################################################\n");
+	lldbg("PANIC!!! Bus fault at instruction: 0x%08x\n", regs[REG_R15]);
 
 	if (cfsr & PRECISERR) {
-		lldbg("Precise data access error occurred.\n");
+		lldbg("FAULT TYPE: PRECISERR (Precise data access error occurred).\n");
 	} else if (cfsr & IMPRECISERR) {
-		lldbg("Imprecise data access error occurred.\n");
+		lldbg("FAULT TYPE: IMPRECISERR (Imprecise data access error occurred).\n");
 	} else if (cfsr & STKERR) {
-		lldbg("Error while stacking registers during exception entry.\n");
+		lldbg("FAULT TYPE: STKERR (Error while stacking registers during exception entry).\n");
 	} else if (cfsr & UNSTKERR) {
-		lldbg("Error while unstacking registers during exception return.\n");
+		lldbg("FAULT TYPE: UNSTKERR (Error while unstacking registers during exception return).\n");
 	} else if (cfsr & LSPERR) {
-		lldbg("Error occurred during lazy state preservation of Floating Point unit registers.\n");
+		lldbg("FAULT TYPE: LSPERR (Error occurred during lazy state preservation of Floating Point unit registers).\n");
 	} else if (cfsr & IBUSERR) {
-		lldbg("Error on an instruction prefetch.\n");
+		lldbg("FAULT TYPE: IBUSERR (Error on an instruction prefetch).\n");
 	}
+
+	if (cfsr & BFARVALID) {
+		lldbg("FAULT ADDRESS: 0x%08x\n", bfar);
+	} else {
+		lldbg("FAULT ADDRESS: Unable to determine fault address.\n");
+	}
+
+	lldbg("FAULT REGS: CFAULTS: 0x%08x BFAR: 0x%08x\n", cfsr, bfar);
+	lldbg("#########################################################################\n");
 
 #ifdef CONFIG_SYSTEM_REBOOT_REASON
 	if (cfsr & IBUSERR) {

--- a/os/arch/arm/src/armv8-m/up_memfault.c
+++ b/os/arch/arm/src/armv8-m/up_memfault.c
@@ -124,27 +124,30 @@ int up_memfault(int irq, FAR void *context, FAR void *arg)
 	uint32_t mmfar = getreg32(NVIC_MEMMANAGE_ADDR);
 	system_exception_location = regs[REG_R15];
 
-	lldbg("PANIC!!! Memory Management Fault occurred while executing instruction at address : 0x%08x\n", regs[REG_R15]);
-	lldbg("CFAULTS: 0x%08x MMFAR: 0x%08x\n", cfsr, mmfar);
-
-	if (cfsr & MMARVALID) {
-		lldbg("Access violation occurred at address (MMFAR) : 0x%08x\n", mmfar);
-	} else {
-		lldbg("Unable to determine access violation address.\n");
-	}
+	lldbg("#########################################################################\n");
+	lldbg("PANIC!!! Memory Management Fault at instruction : 0x%08x\n", regs[REG_R15]);
 
 	if (cfsr & DACCVIOL) {
-		lldbg("Data access violation occurred.\n");
+		lldbg("FAULT TYPE: DACCVIOL (Data access violation occurred. Check MPU RW permissions).\n");
 	} else if (cfsr & IACCVIOL) {
-		lldbg("Instruction access violation occurred while fetching instruction from an Execute Never (XN) region.\n");
+		lldbg("FAULT TYPE: IACCVIOL (Instruction access violation occurred. Check MPU XN region).\n");
 		system_exception_location = regs[REG_R14];	/* The PC value might be invalid, so use LR */
 	} else if (cfsr & MSTKERR) {
-		lldbg("Error while stacking registers during exception entry.\n");
+		lldbg("FAULT TYPE: MSTKERR (Error while stacking registers during exception entry).\n");
 	} else if (cfsr & MUNSTKERR) {
-		lldbg("Error while unstacking registers during exception return.\n");
+		lldbg("FAULT TYPE: MUNSTKERR (Error while unstacking registers during exception return).\n");
 	} else if (cfsr & MLSPERR) {
-		lldbg("Error occurred during lazy state preservation of Floating Point unit registers.\n");
+		lldbg("FAULT TYPE: MLSPERR (Error occurred during lazy state preservation of Floating Point unit registers).\n");
 	}
+
+	if (cfsr & MMARVALID) {
+		lldbg("FAULT ADDRESS: 0x%08x\n", mmfar);
+	} else {
+		lldbg("FAULT ADDRESS: Unable to determine fault address.\n");
+	}
+
+	lldbg("FAULT REGS: CFAULTS: 0x%08x MMFAR: 0x%08x\n", cfsr, mmfar);
+	lldbg("#########################################################################\n\n\n");
 
 #ifdef CONFIG_SYSTEM_REBOOT_REASON
 	if (cfsr & IACCVIOL) {

--- a/os/arch/arm/src/armv8-m/up_usagefault.c
+++ b/os/arch/arm/src/armv8-m/up_usagefault.c
@@ -88,27 +88,30 @@ int up_usagefault(int irq, FAR void *context, FAR void *arg)
 	uint32_t cfsr = getreg32(NVIC_CFAULTS);
 	system_exception_location = regs[REG_R15];
 
-	lldbg("PANIC!!! Usagefault occurred while executing instruction at address : 0x%08x\n", regs[REG_R15]);
-	lldbg("CFAULTS: 0x%08x\n", cfsr);
+	lldbg("#########################################################################\n");
+	lldbg("PANIC!!! Usagefault at instruction: 0x%08x\n", regs[REG_R15]);
 
 	if (cfsr & DIVBYZERO) {
-		lldbg("Divide by zero error has occurred.\n");
+		lldbg("FAULT TYPE: DIVBYZERO (Divide by zero error has occurred).\n");
 	} else if (cfsr & UNALIGNED) {
-		lldbg("Unaligned access error has occurred.\n");
+		lldbg("FAULT TYPE: UNALIGNED (Unaligned access error has occurred).\n");
 	} else if (cfsr & STKOF) {
-		lldbg("Stack overflow error has occurred.\n");
+		lldbg("FAULT TYPE: STKOF (Stack overflow error has occurred).\n");
 	} else if (cfsr & NOCP) {
-		lldbg("A coprocessor error has occurred.\n");
+		lldbg("FAULT TYPE: NOCP (A coprocessor error has occurred).\n");
 	} else if (cfsr & INVPC) {
-		lldbg("An integrity check error has occurred on EXC_RETURN. PC value might be invalid.\n");
+		lldbg("FAULT TYPE: INVPC (Integrity check error during EXC_RETURN).\n");
 		/* As PC value might be invalid use LR value to determine if
 		 * the crash occurred in the kernel space or in the user space */
 		system_exception_location = regs[REG_R14];
 	} else if (cfsr & INVSTATE) {
-		lldbg("Invalid state. Instruction executed with invalid EPSR.T or EPSR.IT field.\n");
+		lldbg("FAULT TYPE: INVSTATE (Invalid state. Check EPSR T bit. XPSR = 0x%08x).\n", regs[REG_XPSR]);
 	} else if (cfsr & UNDEFINSTR) {
-		lldbg("Undefined instruction executed.\n");
+		lldbg("FAULT TYPE: UNDEFINSTR (Undefined instruction executed).\n");
 	}
+
+	lldbg("FAULT REGS: CFAULTS: 0x%08x\n", cfsr);
+	lldbg("#########################################################################\n");
 
 #ifdef CONFIG_SYSTEM_REBOOT_REASON
 	 up_reboot_reason_write(REBOOT_SYSTEM_PREFETCHABORT);


### PR DESCRIPTION
Refactor debug messages in fault hanlders and mpu code to provide
clear and accurate information.

Sample output after refactoring


```
up_memfault: #########################################################################
up_memfault: PANIC!!! Memory Management Fault at instruction : 0x02200196
up_memfault: FAULT TYPE: DACCVIOL (Data access violation occurred. Check MPU RW permissions).
up_memfault: FAULT ADDRESS: 0x0e000020
up_memfault: FAULT REGS: CFAULTS: 0x00000082 MMFAR: 0x0e000020
up_memfault: #########################################################################
```


```
mpu_show_regioninfo: ********************************************************************************************
mpu_show_regioninfo: REGION_NO.         BASE_ADDRESS    SIZE            STATUS          ACCESS (P/U)    EXECUTE
mpu_show_regioninfo: ********************************************************************************************
mpu_show_regioninfo: 0                  0x10042700      0x157A0         ENABLED         RW/RW           X
mpu_show_regioninfo: 1                  0x2000000       0x100020        ENABLED         RW/RW           X
mpu_show_regioninfo: 2                  0x21FE740       0x58400         ENABLED         RO/RO           X
mpu_show_regioninfo: 3                  0x2256B40       0x21660         ENABLED         RO/RO           XN
mpu_show_regioninfo: 4                  0x217F620       0x7F120         ENABLED         RW/RW           XN
mpu_show_regioninfo: 5                  0x0             0x20            DISABLED        RW/NO           X
mpu_show_regioninfo: 6                  0x0             0x20            DISABLED        RW/NO           X
mpu_show_regioninfo: 7                  0x0             0x20            DISABLED        RW/NO           X
mpu_show_regioninfo: ********************************************************************************************
```


Signed-off-by: Kishore S N <kishore.sn@samsung.com>