### PR TITLE
apps/examples: Add missing Kconfig_ENTRY files in sub-directories

### DIFF
--- a/apps/examples/board_specific_demo/cy4390x_demo/Kconfig_ENTRY
+++ b/apps/examples/board_specific_demo/cy4390x_demo/Kconfig_ENTRY
@@ -1,0 +1,3 @@
+config ENTRY_CY4390x_DEMO
+	bool "cy4390x Demo example"
+	depends on EXAMPLES_CY4390x_DEMO

--- a/apps/examples/board_specific_demo/esp32_wifi_demo/Kconfig_ENTRY
+++ b/apps/examples/board_specific_demo/esp32_wifi_demo/Kconfig_ENTRY
@@ -1,0 +1,3 @@
+config ENTRY_ESP32_WIFI_DEMO
+	bool "Esp32 wifi Demo example"
+	depends on EXAMPLES_ESP32WIFIDEMO

--- a/apps/examples/libcoap/client/Kconfig_ENTRY
+++ b/apps/examples/libcoap/client/Kconfig_ENTRY
@@ -1,0 +1,3 @@
+config ENTRY_LIBCOAP_CLIENT_TEST
+	bool "libcoap Client Test"
+	depends on EXAMPLES_LIBCOAP_CLIENT_TEST

--- a/apps/examples/libcoap/server/Kconfig_ENTRY
+++ b/apps/examples/libcoap/server/Kconfig_ENTRY
@@ -1,0 +1,3 @@
+config ENTRY_LIBCOAP_SERVER_TEST
+	bool "libcoap Server Test"
+	depends on EXAMPLES_LIBCOAP_SERVER_TEST

--- a/apps/examples/security_test/security_api/Kconfig_ENTRY
+++ b/apps/examples/security_test/security_api/Kconfig_ENTRY
@@ -1,0 +1,3 @@
+config ENTRY_SECURITY_API_TEST
+	bool "Security API Test"
+	depends on EXAMPLES_SECURITY_API_TEST

--- a/apps/examples/smartfs/buffer_optimization/Kconfig_ENTRY
+++ b/apps/examples/smartfs/buffer_optimization/Kconfig_ENTRY
@@ -1,0 +1,3 @@
+config ENTRY_SMARTFS_BUF_OPTIMIZATION
+	bool "SmartFs Buffer Optimization example"
+	depends on EXAMPLES_SMARTFS_BUF_OPTIMIZATION

--- a/apps/examples/smartfs/smart/Kconfig_ENTRY
+++ b/apps/examples/smartfs/smart/Kconfig_ENTRY
@@ -1,0 +1,3 @@
+config ENTRY_SMART
+	bool "SMART filesystem example"
+	depends on EXAMPLES_SMART

--- a/apps/examples/smartfs/smart_test/Kconfig_ENTRY
+++ b/apps/examples/smartfs/smart_test/Kconfig_ENTRY
@@ -1,0 +1,3 @@
+config ENTRY_SMART_TEST
+	bool "SMART filesystem test tool"
+	depends on EXAMPLES_SMART_TEST


### PR DESCRIPTION
- apps/examples: Add missing Kconfig_ENTRY files in sub-directories.