### PR TITLE
apps: Restructure menuconfig options into sub-menus

### DIFF
--- a/apps/Directory.mk
+++ b/apps/Directory.mk
@@ -78,8 +78,8 @@ nothing:
 install:
 
 preconfig: $(foreach SDIR, $(SUBDIRS), $(SDIR)_preconfig)
-	$(Q) $(MKKCONFIG) -m $(MENUDESC) -maxdepth 3
-	$(Q) $(MKKCONFIG) -o Kconfig_ENTRY -maxdepth 3
+	$(Q) $(MKKCONFIG) -m $(MENUDESC)
+	$(Q) $(MKKCONFIG) -o Kconfig_ENTRY
 
 context: $(foreach SDIR, $(SUBDIRS), $(SDIR)_context)
 

--- a/apps/examples/board_specific_demo/Makefile
+++ b/apps/examples/board_specific_demo/Makefile
@@ -16,6 +16,10 @@
 #
 ###########################################################################
 
+MENUDESC = "Board Specific Demos"
+
+include $(APPDIR)/Make.defs
+
 SUBDIRS = $(dir $(wildcard */Makefile))
 
 all: nothing
@@ -38,6 +42,8 @@ nothing:
 install:
 
 preconfig: $(foreach SDIR, $(SUBDIRS), $(SDIR)_preconfig)
+	$(Q) $(MKKCONFIG) -m $(MENUDESC)
+	$(Q) $(MKKCONFIG) -o Kconfig_ENTRY
 
 context: $(foreach SDIR, $(SUBDIRS), $(SDIR)_context)
 

--- a/apps/examples/dtls/Makefile
+++ b/apps/examples/dtls/Makefile
@@ -16,6 +16,10 @@
 #
 ###########################################################################
 
+MENUDESC = "dTLS"
+
+include $(APPDIR)/Make.defs
+
 SUBDIRS = $(dir $(wildcard */Makefile))
 
 all: nothing
@@ -38,6 +42,8 @@ nothing:
 install:
 
 preconfig: $(foreach SDIR, $(SUBDIRS), $(SDIR)_preconfig)
+	$(Q) $(MKKCONFIG) -m $(MENUDESC)
+	$(Q) $(MKKCONFIG) -o Kconfig_ENTRY
 
 context: $(foreach SDIR, $(SUBDIRS), $(SDIR)_context)
 

--- a/apps/examples/grpc/Makefile
+++ b/apps/examples/grpc/Makefile
@@ -16,6 +16,10 @@
 #
 ###########################################################################
 
+MENUDESC = "gRPC"
+
+include $(APPDIR)/Make.defs
+
 SUBDIRS = $(dir $(wildcard */Makefile))
 
 all: nothing
@@ -38,6 +42,8 @@ nothing:
 install:
 
 preconfig: $(foreach SDIR, $(SUBDIRS), $(SDIR)_preconfig)
+	$(Q) $(MKKCONFIG) -m $(MENUDESC)
+	$(Q) $(MKKCONFIG) -o Kconfig_ENTRY
 
 context: $(foreach SDIR, $(SUBDIRS), $(SDIR)_context)
 

--- a/apps/examples/libcoap/Makefile
+++ b/apps/examples/libcoap/Makefile
@@ -16,6 +16,10 @@
 #
 ###########################################################################
 
+MENUDESC = "Libcoap"
+
+include $(APPDIR)/Make.defs
+
 SUBDIRS = $(dir $(wildcard */Makefile))
 
 all: nothing
@@ -38,6 +42,8 @@ nothing:
 install:
 
 preconfig: $(foreach SDIR, $(SUBDIRS), $(SDIR)_preconfig)
+	$(Q) $(MKKCONFIG) -m $(MENUDESC)
+	$(Q) $(MKKCONFIG) -o Kconfig_ENTRY
 
 context: $(foreach SDIR, $(SUBDIRS), $(SDIR)_context)
 

--- a/apps/examples/performance/Makefile
+++ b/apps/examples/performance/Makefile
@@ -51,4 +51,38 @@
 
 MENUDESC = "Performance"
 
-include $(APPDIR)/Directory.mk
+include $(APPDIR)/Make.defs
+
+SUBDIRS = $(dir $(wildcard */Makefile))
+
+all: nothing
+
+.PHONY: nothing context depend clean distclean
+
+define SDIR_template
+$(1)_$(2):
+	$(Q) $(MAKE) -C $(1) $(2) TOPDIR="$(TOPDIR)" APPDIR="$(APPDIR)" EXTDIR="$(EXTDIR)"
+endef
+
+$(foreach SDIR, $(SUBDIRS), $(eval $(call SDIR_template,$(SDIR),preconfig)))
+$(foreach SDIR, $(SUBDIRS), $(eval $(call SDIR_template,$(SDIR),context)))
+$(foreach SDIR, $(SUBDIRS), $(eval $(call SDIR_template,$(SDIR),depend)))
+$(foreach SDIR, $(SUBDIRS), $(eval $(call SDIR_template,$(SDIR),clean)))
+$(foreach SDIR, $(SUBDIRS), $(eval $(call SDIR_template,$(SDIR),distclean)))
+
+nothing:
+
+install:
+
+preconfig: $(foreach SDIR, $(SUBDIRS), $(SDIR)_preconfig)
+	$(Q) $(MKKCONFIG) -m $(MENUDESC)
+	$(Q) $(MKKCONFIG) -o Kconfig_ENTRY
+
+context: $(foreach SDIR, $(SUBDIRS), $(SDIR)_context)
+
+depend: $(foreach SDIR, $(SUBDIRS), $(SDIR)_depend)
+
+clean: $(foreach SDIR, $(SUBDIRS), $(SDIR)_clean)
+
+distclean: $(foreach SDIR, $(SUBDIRS), $(SDIR)_distclean)
+	$(call DELFILE, Kconfig*)

--- a/apps/examples/protobuf/Makefile
+++ b/apps/examples/protobuf/Makefile
@@ -16,6 +16,10 @@
 #
 ###########################################################################
 
+MENUDESC = "Protocol Buffer"
+
+include $(APPDIR)/Make.defs
+
 SUBDIRS = $(dir $(wildcard */Makefile))
 
 all: nothing
@@ -38,6 +42,8 @@ nothing:
 install:
 
 preconfig: $(foreach SDIR, $(SUBDIRS), $(SDIR)_preconfig)
+	$(Q) $(MKKCONFIG) -m $(MENUDESC)
+	$(Q) $(MKKCONFIG) -o Kconfig_ENTRY
 
 context: $(foreach SDIR, $(SUBDIRS), $(SDIR)_context)
 

--- a/apps/examples/security_test/Makefile
+++ b/apps/examples/security_test/Makefile
@@ -16,6 +16,10 @@
 #
 ###########################################################################
 
+MENUDESC = "Security Test"
+
+include $(APPDIR)/Make.defs
+
 SUBDIRS = $(dir $(wildcard */Makefile))
 
 all: nothing
@@ -38,6 +42,8 @@ nothing:
 install:
 
 preconfig: $(foreach SDIR, $(SUBDIRS), $(SDIR)_preconfig)
+	$(Q) $(MKKCONFIG) -m $(MENUDESC)
+	$(Q) $(MKKCONFIG) -o Kconfig_ENTRY
 
 context: $(foreach SDIR, $(SUBDIRS), $(SDIR)_context)
 

--- a/apps/examples/smartfs/Makefile
+++ b/apps/examples/smartfs/Makefile
@@ -16,6 +16,10 @@
 #
 ###########################################################################
 
+MENUDESC = "SmartFs Test Applications"
+
+include $(APPDIR)/Make.defs
+
 SUBDIRS = $(dir $(wildcard */Makefile))
 
 all: nothing
@@ -38,6 +42,8 @@ nothing:
 install:
 
 preconfig: $(foreach SDIR, $(SUBDIRS), $(SDIR)_preconfig)
+	$(Q) $(MKKCONFIG) -m $(MENUDESC)
+	$(Q) $(MKKCONFIG) -o Kconfig_ENTRY
 
 context: $(foreach SDIR, $(SUBDIRS), $(SDIR)_context)
 

--- a/apps/examples/tls/Makefile
+++ b/apps/examples/tls/Makefile
@@ -16,6 +16,10 @@
 #
 ###########################################################################
 
+MENUDESC = "TLS"
+
+include $(APPDIR)/Make.defs
+
 SUBDIRS = $(dir $(wildcard */Makefile))
 
 all: nothing
@@ -38,6 +42,8 @@ nothing:
 install:
 
 preconfig: $(foreach SDIR, $(SUBDIRS), $(SDIR)_preconfig)
+	$(Q) $(MKKCONFIG) -m $(MENUDESC)
+	$(Q) $(MKKCONFIG) -o Kconfig_ENTRY
 
 context: $(foreach SDIR, $(SUBDIRS), $(SDIR)_context)
 

--- a/apps/examples/wifi_manager/Makefile
+++ b/apps/examples/wifi_manager/Makefile
@@ -16,6 +16,10 @@
 #
 ###########################################################################
 
+MENUDESC = "Wifi Manager"
+
+include $(APPDIR)/Make.defs
+
 SUBDIRS = $(dir $(wildcard */Makefile))
 
 all: nothing
@@ -38,6 +42,8 @@ nothing:
 install:
 
 preconfig: $(foreach SDIR, $(SUBDIRS), $(SDIR)_preconfig)
+	$(Q) $(MKKCONFIG) -m $(MENUDESC)
+	$(Q) $(MKKCONFIG) -o Kconfig_ENTRY
 
 context: $(foreach SDIR, $(SUBDIRS), $(SDIR)_context)
 


### PR DESCRIPTION
- Multiple applications of the same domain will be presented in a separate sub-menu
 under the "Application Configuration" menuconfig tab.
- Added MENUDESC option in Makefiles of subfolders to initiate presentation of
 applications as a separate sub-menu
- Added preconfig options in Makefiles for subfolders to include dependant
 applications in this separate sub-menu.

Signed-off-by: Amogh Hassija <a.hassija@samsung.com>