### PR TITLE
tools: Add heap corruption log data to TRAP tool

### DIFF
--- a/tools/trap/ramdumpParser.py
+++ b/tools/trap/ramdumpParser.py
@@ -753,8 +753,30 @@ def find_crash_point(log_file, elf):
     os.system("python3 ../debug/debugsymbolviewer.py " + log_file + " " + str(g_app_idx) + " 0")
 
     print('\n4. Miscellaneous information:')
+    # Parse the contents based on tokens in log file for heap corruption
+    with open(log_file) as searchfile:
+        heap_corr = 0
+        for line in searchfile:
+            # Print the heap corruption data (if any)
+            if 'mm_check_heap_corruption:' in line:
+                if (heap_corr == 0):
+                    print("\n## Heap Corruption Data:\n")
+                    heap_corr = 1
+                print("\033[F", line)
+            if 'dump_node:' in line:
+                print("\033[F", line)
+    with open(log_file) as searchfile:
+        for line in searchfile:
+            if 'allocated by code at addr' in line:
+                print("## Code Location of possible corrupted node allocation:")
+                # It displays the debug symbols corresponding to the corrupted heap node
+                # The last argument to debugsymbolviewer specifies whether or not to check for corrupted heap node addresses (2)
+                print('Allocated by code at addr\t\tFile_name')
+                os.system("python3 ../debug/debugsymbolviewer.py " + log_file + " " + str(g_app_idx) + " 2")
+                break
+
     # It displays the debug symbols corresponding to all the wrong sp addresses (if any)
-    # The last argument to debugsymbolviewer specifies whether or not to check for wrong stack pointer addresses
+    # The last argument to debugsymbolviewer specifies whether or not to check for wrong stack pointer addresses (1)
     os.system("python3 ../debug/debugsymbolviewer.py " + log_file + " " + str(g_app_idx) + " 1")
     print('-----------------------------------------------------------------------------------------')
 


### PR DESCRIPTION
This patch adds heap corruption logs to TRAP tool and displays
the appropriate file location for possible corrupted node allocation.

Logs look like below:
$sudo python3 ramdumpParser.py -t 31

*************************************************************
dump_file                   : None
log_file                    : 31
Number of binary            : 1 [kernel]
"kernel" elf_file           : ../../build/output/bin/tinyara.axf
*************************************************************
.
.
.
4. Miscellaneous information:

 mm_check_heap_corruption: #######################################################################################
 mm_check_heap_corruption: ERROR: Heap node corruption detected.
 mm_check_heap_corruption: =======================================================================================
 mm_check_heap_corruption: Possible corruption scenario 1:
 dump_node: OVERFLOWED NODE: addr = 0x020569b0 size = 48 type = A
 dump_node: Node owner pid = 8 (tash), allocated by code at addr = 0x0e0a623b
 dump_node: CORRUPTED NODE: addr = 0x020569e0 size = 64 preceding size = 48
 dump_node: Node owner pid = 1 (hprk), allocated by code at addr = 0x0e041f43
 mm_check_heap_corruption: =======================================================================================

Allocated by code at addr		File_name
0xe0a623b				/root/tizenrt/os/include/sys/select.h:166
0xe041f43				/root/tizenrt/apps/examples/testcase/le_tc/kernel/tc_wqueue.c:123
-----------------------------------------------------------------------------------------

Signed-off-by: Vidisha Thapa <thapa.v@samsung.com>