### PR TITLE
tools/trap: Add below requirements

### DIFF
--- a/tools/debug/debugsymbolviewer.py
+++ b/tools/debug/debugsymbolviewer.py
@@ -140,7 +140,7 @@ def setup_symbol_table(map_file, is_app):
 		print('~~~~~~~~~~~~~~~~~~~~~~~~SYMBOL TABLE END   ~~~~~~~~~~~~~~~~~~~~~')
 
 
-# Function to search the search_addr present in the Address to Symbol mapping table and print its corresponding symbol
+# Function to search the search_addr present in the Address to Symbol mapping table and print its corresponding symbol and related information
 def print_symbol(stack_addr, search_addr, is_app_symbol):
 	addr = 0x00000000
 	next_addr = 0x00000000
@@ -239,7 +239,7 @@ def is_kernel_text_address(address):
 		return False
 
 
-# Function to Parse the i/p log file (which contains stackdump during assert) and to print stack values
+# Function to Parse the input log file (which contains stackdump during assert) and to print stack values
 def print_stack(log_file):
 	stack_addr = 0x00000000
 	stack_val = 0x00000000
@@ -285,7 +285,7 @@ def print_stack(log_file):
 						print_symbol(stack_addr, stack_val, is_app_symbol)
 
 
-# Function to Parse the i/p log file (which contains wrong stackdump during assert)
+# Function to Parse the input log file (which contains wrong stackdump during assert)
 def print_wrong_sp(log_file):
 	stack_addr = 0x00000000
 	format_print = True
@@ -326,7 +326,7 @@ def print_wrong_sp(log_file):
 						stack_val = stack_val - int(g_stext_app[is_app_symbol - 1])
 						print_symbol(stack_addr, stack_val, is_app_symbol)
 
-# Function to Parse the i/p log file (which contains heap corruption data) and to print owner of corrupted node
+# Function to Parse the input log file (which contains heap corruption data) and to print owner of corrupted node
 def print_heap_corruption_data(log_file):
 	# Parse the contents based on tokens in log file.
 	with open(log_file) as searchfile:

--- a/tools/trap/ramdumpParser.py
+++ b/tools/trap/ramdumpParser.py
@@ -226,8 +226,7 @@ class dumpParser:
 								pc = lr
 
 					continue
-				# Incase if log file already has this data, address to symbol mapping is
-				# enough to get the call stack.
+				# In case if log file already has this data, address to symbol mapping is enough to get the call stack.
 				if 'unwind_backtrace_with_fp:' in line:
 					word = line.split(':')
 					if word[1] == ' CallTrace_Start':
@@ -324,8 +323,8 @@ class dumpParser:
 			a = self.elf_file_fd.read(length)
 		return a
 
-	# returns a tuple of the result by reading address from the "specified format string"
-	# return None on failure
+	# Returns a tuple of the result by reading the address from the "specified format string"
+	# In case of failure, return None
 	def read_string(self, address, format_string, debug=False):
 		addr = address
 
@@ -335,10 +334,10 @@ class dumpParser:
 				print(('Failed to read address {0:x}'.format(addr)))
 			return None
 
-		# Unpack the string with proper format and return to calle.
+		# Unpack the string with proper format and return to caller
 		return struct.unpack(format_string, s)
 
-	# returns a word size (4 bytes = 32 bits) read from dump "<" means little endian format
+	# Returns a word size (4 bytes = 32 bits) read from dump "<" means little endian format
 	# I indicates word
 	def read_word(self, address, debug=False):
 		if debug:
@@ -350,7 +349,7 @@ class dumpParser:
 			return None
 		else:
 			return s[0]
-	# returns a single Byte read from given dump address "<" means little endian format
+        # Returns a single Byte read from given dump address "<" means little endian format
 	# H indicates Half word
 	def read_halfword(self, address, debug=False):
 		if debug:
@@ -363,7 +362,7 @@ class dumpParser:
 		else:
 			return s[0]
 
-	# returns a single Byte read from given dump address "<" means little endian format
+	# Returns a single Byte read from given dump address "<" means little endian format
 	# B indicates Byte, It's useful while reading a String from dump
 	def read_byte(self, address, debug=False):
 		if debug:
@@ -1119,7 +1118,7 @@ def main():
 		SIZE_OF_ALLOC_NODE = 16
 
 		max_tasks = 0
-		# get MAX_TASKS num
+		# Get MAX_TASKS num
 		if 'CONFIG_MAX_TASKS=' in data:
 			index = data.find('CONFIG_MAX_TASKS=')
 			index += len('CONFIG_MAX_TASKS=')


### PR DESCRIPTION
    
    1. Add the Assertion failed at log
    2. Add the running work function's corresponding symbol
    3. Refactor comments
    
```
2. Crash type               : code assertion by code ASSERT or PANIC
   Crash log                : up_assert: Assertion failed at file:mm_heap/mm_mallinfo.c line: 134 task: hpwork

3. Crash point (PC or LR)
	PC & LR values not in any text range! No probable crash point detected.

4. Call stack of last run thread

	- Current running work function is:	 0xe041e81

Current running work function		File_name
0xe041e81				/root/tizenrt/apps/da_module/da_common_event_pubsub/src/da_common_event_pubsub.c:162

	- Current stack pointer:		 0x10064780

Stack_address	 Symbol_address	 Symbol location  Symbol_name		File_name
0x10064798	 0x10013014	 kernel  	  sem_unblock_task	/root/tizenrt/os/kernel/semaphore/sem_post.c:96
0x100647c0	 0xe005d60	 kernel  	  mm_mallinfo	/root/tizenrt/os/include/tinyara/mm/mm.h:643
.
.
```

Signed-off-by: Vidisha Thapa <thapa.v@samsung.com>