### PR TITLE
arch/arm/src: Move the loading binary addresses before app heap corru…

### DIFF
--- a/os/arch/arm/src/armv7-m/up_assert.c
+++ b/os/arch/arm/src/armv7-m/up_assert.c
@@ -464,6 +464,10 @@ void up_assert(const uint8_t *filename, int lineno)
 
 	up_dumpstate();
 
+#ifdef CONFIG_APP_BINARY_SEPARATION
+	elf_show_all_bin_section_addr();
+#endif
+
 	lldbg("Checking kernel heap for corruption...\n");
 	if (mm_check_heap_corruption(g_kmmheap) == OK) {
 		lldbg("No kernel heap corruption detected\n");
@@ -478,7 +482,6 @@ void up_assert(const uint8_t *filename, int lineno)
 		if (mm_check_heap_corruption((struct mm_heap_s *)(fault_tcb->uheap)) == OK) {
 			lldbg("No app heap corruption detected\n");
 		}
-		elf_show_all_bin_section_addr();
 	}
 #endif
 	lldbg("Assert location (PC) : %08x\n", asserted_location);

--- a/os/arch/arm/src/armv8-m/up_assert.c
+++ b/os/arch/arm/src/armv8-m/up_assert.c
@@ -507,6 +507,10 @@ void up_assert(const uint8_t *filename, int lineno)
 
 	up_dumpstate();
 
+#ifdef CONFIG_APP_BINARY_SEPARATION
+	elf_show_all_bin_section_addr();
+#endif
+
 	lldbg("Checking kernel heap for corruption...\n");
 	if (mm_check_heap_corruption(g_kmmheap) == OK) {
 		lldbg("No kernel heap corruption detected\n");
@@ -521,7 +525,6 @@ void up_assert(const uint8_t *filename, int lineno)
 		if (mm_check_heap_corruption((struct mm_heap_s *)(fault_tcb->uheap)) == OK) {
 			lldbg("No app heap corruption detected\n");
 		}
-		elf_show_all_bin_section_addr();
 	}
 #endif
 	lldbg("Assert location (PC) : 0x%08x\n", asserted_location);


### PR DESCRIPTION
…ption check

This patch moves the elf_show_all_bin_addr() API call to before the app
heap corruption check in order to retrieve the loading binary addresses
for debug purposes if the device resets during heap corruption.

Signed-off-by: Vidisha Thapa <thapa.v@samsung.com>