### PR TITLE
binfmt: save binary section addresses in static memory for debugging

### DIFF
--- a/os/arch/arm/src/armv7-m/up_assert.c
+++ b/os/arch/arm/src/armv7-m/up_assert.c
@@ -478,7 +478,7 @@ void up_assert(const uint8_t *filename, int lineno)
 		if (mm_check_heap_corruption((struct mm_heap_s *)(fault_tcb->uheap)) == OK) {
 			lldbg("No app heap corruption detected\n");
 		}
-		elf_show_all_bin_addr();
+		elf_show_all_bin_section_addr();
 	}
 #endif
 	lldbg("Assert location (PC) : %08x\n", asserted_location);

--- a/os/arch/arm/src/armv8-m/up_assert.c
+++ b/os/arch/arm/src/armv8-m/up_assert.c
@@ -521,7 +521,7 @@ void up_assert(const uint8_t *filename, int lineno)
 		if (mm_check_heap_corruption((struct mm_heap_s *)(fault_tcb->uheap)) == OK) {
 			lldbg("No app heap corruption detected\n");
 		}
-		elf_show_all_bin_addr();
+		elf_show_all_bin_section_addr();
 	}
 #endif
 	lldbg("Assert location (PC) : 0x%08x\n", asserted_location);

--- a/os/binfmt/binfmt_exit.c
+++ b/os/binfmt/binfmt_exit.c
@@ -113,7 +113,7 @@ int binfmt_exit(FAR struct binary_s *bin)
 		berr("ERROR: unload_module() failed: %d\n", ret);
 	}
 
-	elf_delete_bin_section_addr(bin);
+	elf_delete_bin_section_addr(bin->binary_idx);
 
 	uheap_start = (uint32_t)bin->uheap;
 	uheap_end = uheap_start + bin->sizes[BIN_HEAP];

--- a/os/binfmt/binfmt_initialize.c
+++ b/os/binfmt/binfmt_initialize.c
@@ -60,9 +60,6 @@
 #include <tinyara/binfmt/builtin.h>
 #include <tinyara/binfmt/elf.h>
 
-#include <queue.h>
-sq_queue_t g_bin_addr_list;
-
 #ifdef CONFIG_BINFMT_ENABLE
 
 /****************************************************************************
@@ -107,10 +104,6 @@ void binfmt_initialize(void)
 	if (ret < 0) {
 		berr("ERROR: nxflat_initialize failed: %d\n", ret);
 	}
-#endif
-
-#ifdef CONFIG_SAVE_BIN_SECTION_ADDR
-	sq_init(&g_bin_addr_list);
 #endif
 
 	UNUSED(ret);

--- a/os/binfmt/binfmt_loadbinary.c
+++ b/os/binfmt/binfmt_loadbinary.c
@@ -199,7 +199,7 @@ int load_binary(int binary_idx, FAR const char *filename, load_attr_t *load_attr
 	if (pid < 0) {
 		errcode = pid;
 		berr("ERROR: Failed to execute program '%s': %d\n", filename, errcode);
-		elf_delete_bin_section_addr(bin);
+		elf_delete_bin_section_addr(bin->binary_idx);
 		goto errout_with_unload;
 	}
 

--- a/os/binfmt/libelf/libelf.h
+++ b/os/binfmt/libelf/libelf.h
@@ -418,9 +418,8 @@ int elf_cache_init(int filfd, uint16_t offset, off_t filelen);
 int elf_cache_read(int filfd, uint16_t binary_header_size, FAR uint8_t *buffer, size_t readsize, off_t offset);
 #endif
 
+#ifdef CONFIG_APP_BINARY_SEPARATION
 struct bin_addr_info_s {
-	struct bin_addr_info_s *flink;
-	int bin_idx;
 	uint32_t text_addr;
 	uint32_t text_size;
 #ifdef CONFIG_SAVE_BIN_SECTION_ADDR
@@ -433,12 +432,11 @@ struct bin_addr_info_s {
 };
 typedef struct bin_addr_info_s bin_addr_info_t;
 
-extern sq_queue_t g_bin_addr_list;
-
 void elf_save_bin_section_addr(struct binary_s *bin);
-void elf_delete_bin_section_addr(struct binary_s *bin);
+void elf_delete_bin_section_addr(uint8_t bin_idx);
 #ifdef CONFIG_BINFMT_SECTION_UNIFIED_MEMORY
 void *elf_find_start_section_addr(struct binary_s *binp);
 #endif
+#endif /* CONFIG_APP_BINARY_SEPARATION */
 
 #endif							/* __BINFMT_LIBELF_LIBELF_H */

--- a/os/include/tinyara/binfmt/elf.h
+++ b/os/include/tinyara/binfmt/elf.h
@@ -253,8 +253,10 @@ int elf_bind(FAR struct elf_loadinfo_s *loadinfo, FAR const struct symtab_s *exp
 
 int elf_unload(struct elf_loadinfo_s *loadinfo);
 
+#ifdef CONFIG_APP_BINARY_SEPARATION
 void *elf_find_text_section_addr(int bin_idx);
-void elf_show_all_bin_addr(void);
+void elf_show_all_bin_section_addr(void);
+#endif
 
 #undef EXTERN
 #if defined(__cplusplus)


### PR DESCRIPTION
save binary section address information, g_bin_addr_list in static memory for debugging when kernel heap corruption.