### PR TITLE
tools: Update new API name while parsing logs

### DIFF
--- a/tools/debug/debugsymbolviewer.py
+++ b/tools/debug/debugsymbolviewer.py
@@ -54,7 +54,7 @@ def find_app_text_range(log_file):
 	with open(log_file) as searchfile:
 		for line in searchfile:
 			# Read the app text address and size
-			if 'elf_show_all_bin_addr:' in line:
+			if 'elf_show_all_bin_section_addr:' in line:
 				word = line.split(':')
 				t = word[2].split(',') # word[2] is the App Start Text address
 				w = word[1].split(' ')

--- a/tools/trap/HowToUseTrap.md
+++ b/tools/trap/HowToUseTrap.md
@@ -83,8 +83,8 @@ up_assert: Checking kernel heap for corruption...
 up_assert: No kernel heap corruption detected
 up_assert: Checking current app heap for corruption...
 up_assert: No app heap corruption detected
-elf_show_all_bin_addr: [common] Text Addr : 0x2100020, Text Size : 672480
-elf_show_all_bin_addr: [app] Text Addr : 0x232d2c0, Text Size : 179616
+elf_show_all_bin_section_addr: [common] Text Addr : 0x2100020, Text Size : 672480
+elf_show_all_bin_section_addr: [app] Text Addr : 0x232d2c0, Text Size : 179616
 up_assert: Assert location (PC) : 0x02100025
 ```
 3. In the scenario where log file format is not supported, you will see a prompt as below:

--- a/tools/trap/ramdumpParser.py
+++ b/tools/trap/ramdumpParser.py
@@ -55,7 +55,7 @@ BIN_PATH = '../../build/output/bin/'
 CONFIG_PATH = '../../os/.config'
 MAKEFILE_PATH = '../../os/Make.defs'
 HEAPINFO_PATH = '../../os/include/tinyara/mm/heapinfo_internal.h'
-BIN_ADDR_FXN = 'elf_show_all_bin_addr'
+BIN_ADDR_FXN = 'elf_show_all_bin_section_addr'
 debug_cmd = 'addr2line'
 file_data = 'HeapInfo'
 


### PR DESCRIPTION
In previous commit id 24f18d12108e8260703f8ee8b035d80841d53fca, the API
name is changed from elf_show_all_bin_addr to elf_show_all_bin_section_addr.
So, we need to update in the script files to search the new name to find
the proper address of app text section.

Signed-off-by: Kishore S N <kishore.sn@samsung.com>