### PR TITLE
external/json/cJSON.c : Include stdbool.h for true and false

### DIFF
--- a/external/json/cJSON.c
+++ b/external/json/cJSON.c
@@ -59,6 +59,7 @@
 #include <limits.h>
 #include <ctype.h>
 #include <unistd.h>
+#include <stdbool.h>
 
 #include <json/cJSON.h>
 


### PR DESCRIPTION
Without including stdbool.h, there can be build error from true and false.
 error: ‘false’ undeclared (first use in this function); did you mean ‘pause’?
         return false;
                ^~~~~
                pause

Signed-off-by: jeongchanKim <jc_.kim@samsung.com>