### PR TITLE
tools/memstats: Fix memstat for various section names and symbols

### DIFF
--- a/os/tools/memstats_gnueabil.py
+++ b/os/tools/memstats_gnueabil.py
@@ -112,10 +112,14 @@ def getListfromString(s):
 
 
 def PLO(size, libObj, currSym, subSym):
-    if currSym not in list(Required.keys()):
+    found = False
+    for key in list(Required.keys()):
+        if currSym.find(key) != -1:
+            found = True
+            if subSym not in Required[key]:
+                Required[key].append(subSym)
+    if found == False:
         return
-    if subSym not in Required[currSym]:
-        Required[currSym].append(subSym)
 
     libObj = libObj.strip().split('/')
     libObj = libObj[len(libObj)-1]
@@ -286,7 +290,7 @@ for line in infile:
             level1[currentSymbol] = {}
             continue
         else:
-            if re.search('\*\(.*\)', line.strip()) != None:
+            if re.search('\*\(.*\)', line.strip()) != None or re.search('\**.o\(', lsplit[0]) != None:
                 level2string = getListfromString(line.strip())
                 for l2strs in level2string:
                     if l2strs in list(level1[currentSymbol].keys()):
@@ -324,7 +328,6 @@ for line in infile:
                         level1[currentSymbol][subSymbol] += int(lsplit[2], 16)
                         PLO(int(lsplit[2], 16), libObject,
                             currentSymbol, subSymbol)
-
 infile.close()
 if options.all:
     options.totsize = options.libsize = options.details = True


### PR DESCRIPTION
- Support various section names
  - Each section has specific names like XXXX.text/bss/data, not .text/bss/data
  - For examples, in case of rtl8721csm, xip_image2.text, ram_image2.text for .text and ram_image2.bss.

- Support *function.o(.text/bss/data*) in tinyara.map
  - These are fixed in specific spaces defined by ld file.
  - For examples, *os_start.o and *up_exception.o in .ram_image2.text section.

- Result (rtl8721csm/hello)
  - Build result
 ######################################
	.data 	.bss 	.text 	 Total
	88212 	2404 	293068 	383684 	lib_wlan.a
	284 	86924 	74515 	161723 	libnet.a
	224 	4300 	45064 	49588 	libboard.a
	0 	3616 	38173 	41789 	libkernel.a
	0 	76 	36129 	36205 	libfs.a
	796 	6708 	14724 	22228 	libkarch.a
	0 	364 	14689 	15053 	libdrivers.a
	4 	4 	13375 	13383 	libkc.a
	36 	1804 	8657 	10497 	libkmm.a
	0 	0 	9600 	9600 	NOLIB
	364 	0 	8148 	8512 	lib_wps.a
	0 	12 	5974 	5986 	libcompression.a
	12 	96 	4788 	4896 	libbinfmt.a
	0 	0 	4808 	4808 	libgcc.a
	132 	36 	1774 	1942 	libse.a
	0 	0 	1940 	1940 	libstubs.a
	0 	24 	1092 	1116 	libkwque.a

  - In tinyara_memstat.txt
libgcc.a	4808
	.data 	.bss 	.text 	 Total
	0 	0 	1060 	1060 	_arm_muldivdf3.o
	0 	0 	880 	880 	_arm_addsubdf3.o
	0 	0 	712 	712 	_udivmoddi4.o
	0 	0 	672 	672 	_arm_muldivsf3.o
	0 	0 	540 	540 	_arm_addsubsf3.o
	0 	0 	272 	272 	_arm_cmpdf2.o
	0 	0 	236 	236 	_arm_cmpsf2.o
	0 	0 	160 	160 	_aeabi_ldivmod.o
	0 	0 	72 	72 	_fixunsdfdi.o
	0 	0 	64 	64 	_arm_fixunsdfsi.o
	0 	0 	64 	64 	_arm_fixunssfsi.o
	0 	0 	48 	48 	_aeabi_uldivmod.o
	0 	0 	24 	24 	_ashldi3.o
	0 	0 	4 	4 	_dvmd_tls.o
libboard.a	49588
	.data 	.bss 	.text 	 Total
	4 	68 	7128 	7200 	rtl8721dhp_app_start.o
	8 	92 	6347 	6447 	wifi_conf.o
	96 	0 	4340 	4436 	monitor_rom.o
	0 	1348 	2085 	3433 	serial_api.o
	0 	0 	3412 	3412 	wifi_util.o
        ....