### PR TITLE
os/se/ameba: Fix hardfault caused by device lock calling from Secure

### DIFF
--- a/os/se/ameba/rtl_security_api_wrapper_tz.c
+++ b/os/se/ameba/rtl_security_api_wrapper_tz.c
@@ -43,9 +43,7 @@ static void ns_flash_erase(uint32_t address)
 {
 	flash_t flash;
 
-	device_mutex_lock(RT_DEV_LOCK_FLASH);
 	flash_erase_sector(&flash, address);
-	device_mutex_unlock(RT_DEV_LOCK_FLASH);
 }
 
 static int ns_flash_read(uint32_t address, uint32_t len, uint8_t *data)
@@ -53,9 +51,7 @@ static int ns_flash_read(uint32_t address, uint32_t len, uint8_t *data)
 	int ret;
 	flash_t flash;
 
-	device_mutex_lock(RT_DEV_LOCK_FLASH);
 	ret = flash_stream_read(&flash, address, len, data);
-	device_mutex_unlock(RT_DEV_LOCK_FLASH);
 
 	return ret;
 }
@@ -65,20 +61,16 @@ static int ns_flash_write(uint32_t address, uint32_t len, uint8_t *data)
 	int ret;
 	flash_t flash;
 
-	device_mutex_lock(RT_DEV_LOCK_FLASH);
 	ret = flash_stream_write(&flash, address, len, data);
-	device_mutex_unlock(RT_DEV_LOCK_FLASH);
 
 	return ret;
 }
 
 static void ns_setstatusbits(u32 NewState)
 {
-	device_mutex_lock(RT_DEV_LOCK_FLASH);
 	FLASH_Write_Lock();
 	FLASH_SetStatusBits(FLASH_STATUS_BITS, NewState);
 	FLASH_Write_Unlock();
-	device_mutex_unlock(RT_DEV_LOCK_FLASH);
 }
 
 static void ns_printf(const char *input)

--- a/os/se/ameba/security_ameba_wrapper_tz.c
+++ b/os/se/ameba/security_ameba_wrapper_tz.c
@@ -27,6 +27,7 @@
 #include <tinyara/kmalloc.h>
 
 #include <arch/chip/amebad_nsc.h>
+#include <device_lock.h>
 
 #define AWRAP_TAG "[AMEBA_WRAPPER]"
 #define AWRAP_ENTER                                     \
@@ -167,9 +168,11 @@ int se_ameba_hal_init(hal_init_param *params)
 	/* Secure Storage Key Address (efuse) */
 	input_data.samsung_key_addr = SAMSUNG_KEY_ADDR;
 
+	device_mutex_lock(RT_DEV_LOCK_FLASH);
 	up_allocate_secure_context(CONFIG_SE_SECURE_CONTEXT_SIZE);
 	ret = ameba_hal_init(params, &input_data, &ns_passin);
 	up_free_secure_context();
+	device_mutex_unlock(RT_DEV_LOCK_FLASH);
 
 exit:
 	if (ret != HAL_SUCCESS) {
@@ -589,9 +592,11 @@ int se_ameba_hal_get_factory_key(uint32_t key_idx, hal_data *key)
 	AWRAP_ENTER;
 	int ret = HAL_SUCCESS;
 
+	device_mutex_lock(RT_DEV_LOCK_FLASH);
 	up_allocate_secure_context(CONFIG_SE_SECURE_CONTEXT_SIZE);
 	ret = ameba_hal_get_factory_key(key_idx, key);
 	up_free_secure_context();
+	device_mutex_unlock(RT_DEV_LOCK_FLASH);
 
 	if (ret != HAL_SUCCESS) {
 		sedbg("RTL SE failed (%zu)\n", ret);
@@ -604,9 +609,11 @@ int se_ameba_hal_get_factory_cert(uint32_t cert_idx, hal_data *cert)
 	AWRAP_ENTER;
 	int ret = HAL_SUCCESS;
 
+	device_mutex_lock(RT_DEV_LOCK_FLASH);
 	up_allocate_secure_context(CONFIG_SE_SECURE_CONTEXT_SIZE);
 	ret = ameba_hal_get_factory_cert(cert_idx, cert);
 	up_free_secure_context();
+	device_mutex_unlock(RT_DEV_LOCK_FLASH);
 
 	if (ret != HAL_SUCCESS) {
 		sedbg("RTL SE failed (%zu)\n", ret);
@@ -619,9 +626,11 @@ int se_ameba_hal_get_factory_data(uint32_t data_idx, hal_data *data)
 	AWRAP_ENTER;
 	int ret = HAL_SUCCESS;
 
+	device_mutex_lock(RT_DEV_LOCK_FLASH);
 	up_allocate_secure_context(CONFIG_SE_SECURE_CONTEXT_SIZE);
 	ret = ameba_hal_get_factory_data(data_idx, data);
 	up_free_secure_context();
+	device_mutex_unlock(RT_DEV_LOCK_FLASH);
 
 	if (ret != HAL_SUCCESS) {
 		sedbg("RTL SE failed (%zu)\n", ret);
@@ -748,9 +757,11 @@ int se_ameba_hal_write_storage(uint32_t ss_idx, hal_data *data)
 		}
 	}
 
+	device_mutex_lock(RT_DEV_LOCK_FLASH);
 	up_allocate_secure_context(CONFIG_SE_SECURE_CONTEXT_SIZE);
 	ret = ameba_hal_write_storage(ss_idx, data);
 	up_free_secure_context();
+	device_mutex_unlock(RT_DEV_LOCK_FLASH);
 
 	if (ret != HAL_SUCCESS) {
 		sedbg("RTL SE failed (%zu)\n", ret);
@@ -767,10 +778,12 @@ int se_ameba_hal_read_storage(uint32_t ss_idx, hal_data *data)
 		return HAL_INVALID_SLOT_RANGE;
 	}
 
+	device_mutex_lock(RT_DEV_LOCK_FLASH);
 	ss_idx = ss_idx + 1;	/* Change Range to Slot 1-33 */
 	up_allocate_secure_context(CONFIG_SE_SECURE_CONTEXT_SIZE);
 	ret = ameba_hal_read_storage(ss_idx, data);
 	up_free_secure_context();
+	device_mutex_unlock(RT_DEV_LOCK_FLASH);
 
 	if (ret != HAL_SUCCESS) {
 		sedbg("RTL SE failed (%zu)\n", ret);
@@ -787,10 +800,12 @@ int se_ameba_hal_delete_storage(uint32_t ss_idx)
 		return HAL_INVALID_SLOT_RANGE;
 	}
 
+	device_mutex_lock(RT_DEV_LOCK_FLASH);
 	ss_idx = ss_idx + 1;	/* Change Range to Slot 1-33 */
 	up_allocate_secure_context(CONFIG_SE_SECURE_CONTEXT_SIZE);
 	ret = ameba_hal_delete_storage(ss_idx);
 	up_free_secure_context();
+	device_mutex_unlock(RT_DEV_LOCK_FLASH);
 
 	if (ret != HAL_SUCCESS) {
 		sedbg("RTL SE failed (%zu)\n", ret);


### PR DESCRIPTION
Remove calling device lock from Secure
Protect SE Secure API with Flash operation with device lock