### PR TITLE
external/include/miniz: disable optional unused miniz APIs

### DIFF
--- a/external/include/miniz/miniz.h
+++ b/external/include/miniz/miniz.h
@@ -146,7 +146,7 @@
 /*#define MINIZ_NO_TIME */
 
 /* Define MINIZ_NO_ARCHIVE_APIS to disable all ZIP archive API's. */
-/*#define MINIZ_NO_ARCHIVE_APIS */
+#define MINIZ_NO_ARCHIVE_APIS
 
 /* Define MINIZ_NO_ARCHIVE_WRITING_APIS to disable all writing related ZIP archive API's. */
 /*#define MINIZ_NO_ARCHIVE_WRITING_APIS */


### PR DESCRIPTION
Disable optional miniz APIs that are not being used

https://github.com/Samsung/TizenRT/blob/6c94db748e7e50a7d9a0e3e75df533ddf730f961/external/include/miniz/miniz.h#L24-L25

Signed-off-by: Abhishek Akkabathula <a.akkabathul@samsung.com>