### PR TITLE
os/arch: Move wifi library from rtk to imxrt makefile

### DIFF
--- a/os/arch/arm/src/amebad/Make.defs
+++ b/os/arch/arm/src/amebad/Make.defs
@@ -200,10 +200,6 @@ EXTRA_LIBS += ${TOPDIR}/board/rtl8721csm/src/libs/cmse_implib.a
 endif
 endif
 
-ifeq ($(CONFIG_RTK_WLAN),y)
-EXTRA_LIBS += $(TOPDIR)/drivers/wireless/realtek/librtl.a
-endif
-
 ifeq ($(CONFIG_AMEBAD_WIFI),y)
 ifeq ($(CONFIG_ARCH_FPU),y)
 EXTRA_LIBS += $(TOPDIR)/board/rtl8721csm/src/libs/lib_wlan_fpu.a

--- a/os/arch/arm/src/imxrt/Make.defs
+++ b/os/arch/arm/src/imxrt/Make.defs
@@ -244,3 +244,8 @@ else
 CHIP_CSRCS += imxrt_usbhost.c imxrt_ehci.c
 endif
 endif
+
+# Library for external RTK wifi chip
+ifeq ($(CONFIG_RTK_WLAN),y)
+EXTRA_LIBS += $(TOPDIR)/drivers/wireless/realtek/librtl.a
+endif


### PR DESCRIPTION
librtl.a is a library used for imxrt board which has an external
rtk wifi chip. This library is wrongly included in rtk board
Makefile. This commit moves it to the proper imxrt Makefile.

Signed-off-by: Kishore S N <kishore.sn@samsung.com>