### PR TITLE
loadable_apps/loadable_sample: enable app info only in loadable config

### DIFF
--- a/loadable_apps/loadable_sample/Kconfig
+++ b/loadable_apps/loadable_sample/Kconfig
@@ -107,5 +107,7 @@ endif #EXAMPLES_MICOM_TIMER_TEST
 endif #EXAMPLES_LOADABLE_AUTOMATIC_TEST
 endif #EXAMPLES_LOADABLE
 
+if APP_BINARY_SEPARATION
 source "$LOADABLEDIR/loadable_sample/micomapp/Kconfig"
 source "$LOADABLEDIR/loadable_sample/wifiapp/Kconfig"
+endif #APP_BINARY_SEPARATION


### PR DESCRIPTION
Signed-off-by: Abhishek Akkabathula <a.akkabathul@samsung.com>