### PR TITLE
apps/wm_test: fix wrong cmd hardfault

### DIFF
--- a/apps/examples/wifi_manager/wm_test/wm_test.c
+++ b/apps/examples/wifi_manager/wm_test/wm_test.c
@@ -686,6 +686,8 @@ int _wt_parse_join(struct wt_options *opt, int argc, char *argv[])
 		// AP is open mode
 		opt->auth_type = WIFI_MANAGER_AUTH_OPEN;
 		opt->crypto_type = WIFI_MANAGER_CRYPTO_NONE;
+	} else {
+		return -1;
 	}
 	opt->ssid = argv[2];
 


### PR DESCRIPTION
- Fix hardfault when it receives wrong command of wm_test