### PR TITLE
mm/umm_heap : Allocate memory into single heap user

### DIFF
--- a/os/mm/umm_heap/umm_realloc.c
+++ b/os/mm/umm_heap/umm_realloc.c
@@ -70,6 +70,7 @@
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
+#ifndef CONFIG_APP_BINARY_SEPARATION
 /************************************************************************
  * Name: realloc_at
  *
@@ -114,6 +115,7 @@ void *realloc_at(int heap_index, void *oldmem, size_t size)
 	return ret;
 }
 #endif
+#endif
 /****************************************************************************
  * Name: realloc
  *
@@ -131,7 +133,6 @@ void *realloc_at(int heap_index, void *oldmem, size_t size)
 
 FAR void *realloc(FAR void *oldmem, size_t size)
 {
-	int heap_idx;
 	int prev_heap_idx;
 	void *ret;
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
@@ -140,6 +141,23 @@ FAR void *realloc(FAR void *oldmem, size_t size)
 	ARCH_GET_RET_ADDRESS(caller_retaddr)
 #endif
 
+#ifdef CONFIG_APP_BINARY_SEPARATION
+	if (size == 0) {
+		free(oldmem);
+		return NULL;
+	}	
+	/* User supports a single heap on app separation */
+#ifdef CONFIG_DEBUG_MM_HEAPINFO
+	ret = mm_realloc(BASE_HEAP, oldmem, size, caller_retaddr);
+#else
+	ret = mm_realloc(BASE_HEAP, oldmem, size);
+#endif
+	if (ret == NULL) {
+		mm_manage_alloc_fail(BASE_HEAP, HEAP_START_IDX, HEAP_END_IDX, size, USER_HEAP);
+	}
+
+#else /* CONFIG_APP_BINARY_SEPARATION */
+	int heap_idx;
 	heap_idx = mm_get_index_of_heap(oldmem);
 	if (heap_idx < HEAP_START_IDX) {
 		return NULL;
@@ -177,5 +195,8 @@ FAR void *realloc(FAR void *oldmem, size_t size)
 	}
 
 	mm_manage_alloc_fail(BASE_HEAP, HEAP_START_IDX, HEAP_END_IDX, size, USER_HEAP);
-	return NULL;
+
+#endif /* CONFIG_APP_BINARY_SEPARATION */
+
+	return ret;
 }


### PR DESCRIPTION
If app separated, user has single heap, not multi heap.
So when allocating the memory, we don't need to check the multi-region.

Signed-off-by: jeongchanKim <jc_.kim@samsung.com>

* User heap supports a single heap on app binary separation.