### PR TITLE
To change SmartFs to jSmartFs

### DIFF
--- a/apps/examples/smartfs/Makefile
+++ b/apps/examples/smartfs/Makefile
@@ -16,7 +16,7 @@
 #
 ###########################################################################
 
-MENUDESC = "SmartFs Test Applications"
+MENUDESC = "jSmartFs Test Applications"
 
 include $(APPDIR)/Make.defs
 

--- a/apps/examples/smartfs/buffer_optimization/Kconfig
+++ b/apps/examples/smartfs/buffer_optimization/Kconfig
@@ -4,8 +4,8 @@
 #
 
 config EXAMPLES_SMARTFS_BUF_OPTIMIZATION
-	bool "SmartFs Buffer Optimization Example"
+	bool "jSmartFs Buffer Optimization Example"
 	default n
 	depends on TIMER
 	---help---
-		Enable the SmartFs Buffer Optimization Example
+		Enable the jSmartFs Buffer Optimization Example

--- a/apps/examples/smartfs/buffer_optimization/Kconfig_ENTRY
+++ b/apps/examples/smartfs/buffer_optimization/Kconfig_ENTRY
@@ -1,3 +1,3 @@
 config ENTRY_SMARTFS_BUF_OPTIMIZATION
-	bool "SmartFs Buffer Optimization example"
+	bool "jSmartFs Buffer Optimization example"
 	depends on EXAMPLES_SMARTFS_BUF_OPTIMIZATION

--- a/apps/examples/smartfs/buffer_optimization/Makefile
+++ b/apps/examples/smartfs/buffer_optimization/Makefile
@@ -27,7 +27,7 @@ include $(APPDIR)/Make.defs
 
 # Smartfs Buffer Optimization Example info
 
-APPNAME = smartfs_buf_opt
+APPNAME = jsmartfs_buf_opt
 FUNCNAME = buffer_optimization_main
 PRIORITY = SCHED_PRIORITY_DEFAULT
 STACKSIZE = 4096

--- a/apps/examples/smartfs/buffer_optimization/buffer_optimization_main.c
+++ b/apps/examples/smartfs/buffer_optimization/buffer_optimization_main.c
@@ -276,7 +276,7 @@ int buffer_optimization_main(int argc, char *argv[])
 			file_size = atoi(argv[2]);
 		}
 	} else {
-		printf("\nCorrect test command usage is: smartfs_buf_opt <Timer Device No.> <File Size in Kb>\n");
+		printf("\nCorrect test command usage is: jsmartfs_buf_opt <Timer Device No.> <File Size in Kb>\n");
 		printf("-> Read test example will read the file back to back, one buffer size at a time\n");
 		return -1;
 	}
@@ -324,6 +324,6 @@ int buffer_optimization_main(int argc, char *argv[])
 
 error_with_frt_fd:
 	close(frt_fd);
-	printf("SmartFs Optimized Buffer Test Example Exits\n\n");
+	printf("jSmartFs Optimized Buffer Test Example Exits\n\n");
 	return ret;
 }

--- a/apps/examples/smartfs/fs_performance/fs_performance_main.c
+++ b/apps/examples/smartfs/fs_performance/fs_performance_main.c
@@ -108,7 +108,7 @@ static int do_test(int option, int fsz, int bsz)
 	case TEST_FLAG_FILE_CREATION :
 		printf("\n****************************************************************************************\n");
 		printf("********************************  TEST FILE CREATION  **********************************\n\n");
-		printf("Testing jSmartfs File creation with File size: %d bytes\n", fsz);
+		printf("Testing jSmartFs File creation with File size: %d bytes\n", fsz);
 		printf("The test creates a file with buffer size equal to file size.\n\n");
 
 		ret = ioctl(frt_fd, TCIOC_GETSTATUS, (unsigned long)(uintptr_t)&before);
@@ -154,7 +154,7 @@ static int do_test(int option, int fsz, int bsz)
 	case TEST_FLAG_OVERWRITE :
 		printf("\n****************************************************************************************\n");
 		printf("**********************************  TEST OVERWRITE  ************************************\n\n");
-		printf("Testing jSmartfs overwrite with File size: %d bytes, Buffer size: %d bytes\n", fsz, bsz);
+		printf("Testing jSmartFs overwrite with File size: %d bytes, Buffer size: %d bytes\n", fsz, bsz);
 		printf("The test overwrites a file from start, one buffer size at a time.\n\n");
 
 		fd = open(g_file[0], O_WROK | O_CREAT);
@@ -228,7 +228,7 @@ static int do_test(int option, int fsz, int bsz)
 	case TEST_FLAG_APPEND :
 		printf("\n****************************************************************************************\n");
 		printf("************************************  TEST APPEND  *************************************\n\n");
-		printf("Testing jSmartfs Append with file size: %d bytes, buffer size: %d bytes\n", fsz, bsz);
+		printf("Testing jSmartFs Append with file size: %d bytes, buffer size: %d bytes\n", fsz, bsz);
 		printf("The test append 64kb data to the end of the file given.\n\n");
 		for (i = 1; i <= ITR_APP; i++) {
 			fd = open(g_file[0], O_WROK | O_CREAT);
@@ -293,7 +293,7 @@ static int do_test(int option, int fsz, int bsz)
 	case TEST_FLAG_READ :
 		printf("\n****************************************************************************************\n");
 		printf("************************************  TEST READ  ***************************************\n\n");
-		printf("Testing jSmartfs Read with file size: %d bytes, buffer size: %d bytes\n", fsz, bsz);
+		printf("Testing jSmartFs Read with file size: %d bytes, buffer size: %d bytes\n", fsz, bsz);
 		printf("The test reads a given file size with the given buffer size %d times.\n\n", ITR_READ);
 		memset(g_read_buf, '1', MAX_RD_BUF_SIZE);
 
@@ -352,7 +352,7 @@ static int do_test(int option, int fsz, int bsz)
 	case TEST_FLAG_GC_EFFECT :
 		printf("\n****************************************************************************************\n");
 		printf("**************************  TEST GARBAGE COLLECTION EFFECT  ****************************\n\n");
-		printf("Testing jSmartfs Garbage collection with file size: %d bytes, buffer size: %d bytes\n", fsz, bsz);
+		printf("Testing jSmartFs Garbage collection with file size: %d bytes, buffer size: %d bytes\n", fsz, bsz);
 		printf("The test triggers Garbage Collection by repeatedly creating and unlinking a file.\n\n");
 		for (i = 1; i <= ITR_GC; i++) {
 			ret = ioctl(frt_fd, TCIOC_GETSTATUS, (unsigned long)(uintptr_t)&before);

--- a/apps/examples/smartfs/smart_test/smart_test.c
+++ b/apps/examples/smartfs/smart_test/smart_test.c
@@ -375,7 +375,7 @@ static int smart_seek_with_write_test(char *filename)
  *    In the test below, we use open / write, not fopen / fwrite.  If the
  *    fopen / fwrite routines were used instead, they would provide us with
  *    stream buffer management which we DO NOT WANT.  This will throw off
- *    the SMARTFS write sizes which will not generate the optimized wear
+ *    the jSmartFs write sizes which will not generate the optimized wear
  *    operations.
  *
  ****************************************************************************/
@@ -539,7 +539,7 @@ static void smart_usage(void)
 	fprintf(stderr, "usage: smart_test [-c COUNT] [-s SEEKCOUNT] [-w WRITECOUNT] smart_mounted_filename\n\n");
 
 	fprintf(stderr, "DESCRIPTION\n");
-	fprintf(stderr, "    Conducts various stress tests to validate SMARTFS operation.\n");
+	fprintf(stderr, "    Conducts various stress tests to validate jSmartFs operation.\n");
 	fprintf(stderr, "    Please choose one or more of -c, -s, or -w to conduct tests.\n\n");
 
 	fprintf(stderr, "OPTIONS\n");

--- a/apps/examples/smartfs/smartfs_powercut/Kconfig
+++ b/apps/examples/smartfs/smartfs_powercut/Kconfig
@@ -4,10 +4,10 @@
 #
 
 config EXAMPLES_SMARTFS_POWERCUT
-	bool "\"Smartfs Powercut Test\" example"
+	bool "\"jSmartFs Powercut Test\" example"
 	default n
 	---help---
-		Enable the \"Smartfs Powercut Test\" example
+		Enable the \"jSmartFs Powercut Test\" example
 
 config USER_ENTRYPOINT
 	string

--- a/apps/examples/smartfs/smartfs_powercut/Kconfig_ENTRY
+++ b/apps/examples/smartfs/smartfs_powercut/Kconfig_ENTRY
@@ -1,3 +1,3 @@
 config ENTRY_SMARTFS_POWERCUT
-	bool "Smartfs Powercut Test example"
+	bool "jSmartFs Powercut Test example"
 	depends on EXAMPLES_SMARTFS_POWERCUT

--- a/apps/examples/smartfs/smartfs_powercut/Makefile
+++ b/apps/examples/smartfs/smartfs_powercut/Makefile
@@ -54,15 +54,15 @@
 -include $(TOPDIR)/Make.defs
 include $(APPDIR)/Make.defs
 
-# smartfs powercut Test built-in application info
+# jSmartFs powercut Test built-in application info
 
-APPNAME = smartfs_powercut
+APPNAME = jsmartfs_powercut
 FUNCNAME = $(APPNAME)_main
 PRIORITY = SCHED_PRIORITY_DEFAULT
 STACKSIZE = 4096
 THREADEXEC = TASH_EXECMD_ASYNC
 
-# smartfs powercut Test Example
+# jSmartFs powercut Test Example
 
 ASRCS =
 CSRCS =

--- a/apps/examples/smartfs/smartfs_powercut/smartfs_powercut_main.c
+++ b/apps/examples/smartfs/smartfs_powercut/smartfs_powercut_main.c
@@ -730,7 +730,7 @@ static int do_test(char *src, char *backup, char *backupdir, int bufsize, file_t
 #ifdef CONFIG_BUILD_KERNEL
 int main(int argc, FAR char *argv[])
 #else
-int smartfs_powercut_main(int argc, char *argv[])
+int jsmartfs_powercut_main(int argc, char *argv[])
 #endif
 {
 	int ret;

--- a/apps/examples/testcase/le_tc/filesystem/fs_main.c
+++ b/apps/examples/testcase/le_tc/filesystem/fs_main.c
@@ -83,7 +83,7 @@ static char *TMP_MOUNT_DEV_DIR;
 #define MOUNT_DEV_DIR TMP_MOUNT_DEV_DIR
 #endif
 
-#define TARGET_FS_NAME "smartfs"
+#define TARGET_FS_NAME "jSmartFs"
 #else
 #define MOUNT_DEV_DIR "/dev/fs1"
 #define TARGET_FS_NAME "unknwon"
@@ -161,7 +161,7 @@ static char *TMP_MOUNT_DEV_DIR;
 #define ROOT_PATH "/"
 
 #define NONEFS_TYPE     "None FS"
-#define SMARTFS_TYPE    "smartfs"
+#define SMARTFS_TYPE    "jSmartFs"
 #define PROCFS_TYPE     "procfs"
 #define ROMFS_TYPE      "romfs"
 #define TMPFS_TYPE      "tmpfs"
@@ -346,7 +346,7 @@ static int make_long_file(void)
  * @brief            Mount file system
  * @scenario         Mount initialized file system
  * @apicovered       mount
- * @precondition     File system should be initialized. For smartfs, smart_initialize & mksmartfs should be excuted.
+ * @precondition     File system should be initialized. For jSmartFs, smart_initialize & mksmartfs should be excuted.
  * @postcondition    NA
  */
 static void tc_fs_vfs_mount_p(void)
@@ -377,7 +377,7 @@ static void tc_fs_vfs_mount_p(void)
  * @brief            Mount file system
  * @scenario         Mount file system on exist path
  * @apicovered       mount
- * @precondition     File system should be initialized. For smartfs, smart_initialize & mksmartfs should be excuted.
+ * @precondition     File system should be initialized. For jSmartFs, smart_initialize & mksmartfs should be excuted.
  * @postcondition    NA
  */
 static void tc_fs_vfs_mount_exist_path_n(void)
@@ -5487,7 +5487,7 @@ static void tc_libc_stdio_mktemp_p(void)
 #if defined(CONFIG_FS_TMPFS)
 	ret_check = mount(NULL, CONFIG_LIBC_TMPDIR, "tmpfs", 0, NULL);
 #elif defined(CONFIG_FS_SMARTFS)
-	ret_check = mount(MOUNT_DEV_DIR, CONFIG_LIBC_TMPDIR, "smartfs", 0, NULL);
+	ret_check = mount(MOUNT_DEV_DIR, CONFIG_LIBC_TMPDIR, "jSmartFs", 0, NULL);
 #endif
 	if (ret_check < 0) {
 		TC_ASSERT_EQ("mount", errno, EEXIST);
@@ -5548,7 +5548,7 @@ static void tc_libc_stdio_mktemp_invalid_path_n(void)
 #if defined(CONFIG_FS_TMPFS)
 	ret_check = mount(NULL, CONFIG_LIBC_TMPDIR, "tmpfs", 0, NULL);
 #elif defined(CONFIG_FS_SMARTFS)
-	ret_check = mount(MOUNT_DEV_DIR, CONFIG_LIBC_TMPDIR, "smartfs", 0, NULL);
+	ret_check = mount(MOUNT_DEV_DIR, CONFIG_LIBC_TMPDIR, "jSmartFs", 0, NULL);
 #endif
 	if (ret_check < 0) {
 		TC_ASSERT_EQ("mount", errno, EEXIST);
@@ -5602,7 +5602,7 @@ static void tc_libc_stdio_mkstemp_p(void)
 #if defined(CONFIG_FS_TMPFS)
 	ret_check = mount(NULL, CONFIG_LIBC_TMPDIR, "tmpfs", 0, NULL);
 #elif defined(CONFIG_FS_SMARTFS)
-	ret_check = mount(MOUNT_DEV_DIR, CONFIG_LIBC_TMPDIR, "smartfs", 0, NULL);
+	ret_check = mount(MOUNT_DEV_DIR, CONFIG_LIBC_TMPDIR, "jSmartFs", 0, NULL);
 #endif
 	if (ret_check < 0) {
 		TC_ASSERT_EQ("mount", errno, EEXIST);
@@ -5697,7 +5697,7 @@ static void tc_libc_stdio_tempnam_p(void)
 #if defined(CONFIG_FS_TMPFS)
 	ret_check = mount(NULL, CONFIG_LIBC_TMPDIR, "tmpfs", 0, NULL);
 #elif defined(CONFIG_FS_SMARTFS)
-	ret_check = mount(MOUNT_DEV_DIR, CONFIG_LIBC_TMPDIR, "smartfs", 0, NULL);
+	ret_check = mount(MOUNT_DEV_DIR, CONFIG_LIBC_TMPDIR, "jSmartFs", 0, NULL);
 #endif
 	if (ret_check < 0) {
 		TC_ASSERT_EQ("mount", errno, EEXIST);
@@ -5748,7 +5748,7 @@ static void tc_libc_stdio_tempnam_null_arg_n(void)
 #if defined(CONFIG_FS_TMPFS)
 	ret_check = mount(NULL, CONFIG_LIBC_TMPDIR, "tmpfs", 0, NULL);
 #elif defined(CONFIG_FS_SMARTFS)
-	ret_check = mount(MOUNT_DEV_DIR, CONFIG_LIBC_TMPDIR, "smartfs", 0, NULL);
+	ret_check = mount(MOUNT_DEV_DIR, CONFIG_LIBC_TMPDIR, "jSmartFs", 0, NULL);
 #endif
 	if (ret_check < 0) {
 		TC_ASSERT_EQ("mount", errno, EEXIST);
@@ -5800,7 +5800,7 @@ static void tc_libc_stdio_tmpnam_p(void)
 #if defined(CONFIG_FS_TMPFS)
 	ret_check = mount(NULL, CONFIG_LIBC_TMPDIR, "tmpfs", 0, NULL);
 #elif defined(CONFIG_FS_SMARTFS)
-	ret_check = mount(MOUNT_DEV_DIR, CONFIG_LIBC_TMPDIR, "smartfs", 0, NULL);
+	ret_check = mount(MOUNT_DEV_DIR, CONFIG_LIBC_TMPDIR, "jSmartFs", 0, NULL);
 #endif
 	if (ret_check < 0) {
 		TC_ASSERT_EQ("mount", errno, EEXIST);
@@ -5851,7 +5851,7 @@ static void tc_libc_stdio_tmpnam_null_string_n(void)
 #if defined(CONFIG_FS_TMPFS)
 	ret_check = mount(NULL, CONFIG_LIBC_TMPDIR, "tmpfs", 0, NULL);
 #elif defined(CONFIG_FS_SMARTFS)
-	ret_check = mount(MOUNT_DEV_DIR, CONFIG_LIBC_TMPDIR, "smartfs", 0, NULL);
+	ret_check = mount(MOUNT_DEV_DIR, CONFIG_LIBC_TMPDIR, "jSmartFs", 0, NULL);
 #endif
 	if (ret_check < 0) {
 		TC_ASSERT_EQ("mount", errno, EEXIST);

--- a/apps/examples/testcase/le_tc/filesystem/itc_fs.c
+++ b/apps/examples/testcase/le_tc/filesystem/itc_fs.c
@@ -51,7 +51,7 @@ static char *TMP_MOUNT_DEV_DIR;
 #define MOUNT_DEV_DIR TMP_MOUNT_DEV_DIR
 #endif
 
-#define FS_TYPE "smartfs"
+#define FS_TYPE "jSmartFs"
 #else
 #define MOUNT_DEV_DIR "/dev/fs1"
 #define FS_TYPE "unknwon"

--- a/apps/examples/testcase/le_tc/filesystem/tc_fs_mops.c
+++ b/apps/examples/testcase/le_tc/filesystem/tc_fs_mops.c
@@ -160,9 +160,9 @@ static void tc_fs_mops_mount(const char *filesystemtype)
 		ret = mount(ROMFS_MOUNT_DEV_DIR, ROMFS_TEST_MOUNTPOINT, "romfs", 1, NULL);
 
 #endif
-	} else if (strcmp(filesystemtype, "smartfs") == 0) {
+	} else if (strcmp(filesystemtype, "jSmartFs") == 0) {
 		ret = umount(SMARTFS_TEST_MOUNTPOINT);
-		ret = mount(SMARTFS_MOUNT_DEV_DIR, SMARTFS_TEST_MOUNTPOINT, "smartfs", 0, NULL);
+		ret = mount(SMARTFS_MOUNT_DEV_DIR, SMARTFS_TEST_MOUNTPOINT, "jSmartFs", 0, NULL);
 	}
 
 	TC_ASSERT_EQ("mount", ret, OK);	
@@ -174,7 +174,7 @@ static void tc_fs_mops_open(const char *filesystemtype, int *fd)
 		*fd = open(TMPFS_TEST_MOUNTPOINT"/test", O_RDWR | O_CREAT | O_TRUNC);
 	} else if (strcmp(filesystemtype, "romfs") == 0) {
 		*fd = open(ROMFS_TEST_FILEPATH, O_RDONLY);
-	} else if (strcmp(filesystemtype, "smartfs") == 0) {
+	} else if (strcmp(filesystemtype, "jSmartFs") == 0) {
 		*fd = open(SMARTFS_TEST_MOUNTPOINT"/test", O_RDWR | O_CREAT | O_TRUNC);
 	}
 
@@ -197,7 +197,7 @@ static void tc_fs_mops_write(const char *filesystemtype, int fd)
 static void tc_fs_mops_sync(const char *filesystemtype, int fd)
 {
 	int ret = -1;
-	if (strcmp(filesystemtype, "smartfs") == 0) {
+	if (strcmp(filesystemtype, "jSmartFs") == 0) {
 		ret = fsync(fd);
 		TC_ASSERT_EQ_CLEANUP("fsync", ret, OK, close(fd));	
 	}
@@ -236,7 +236,7 @@ static void tc_fs_mops_ioctl(const char *filesystemtype, int fd)
 
 	if (strcmp(filesystemtype, "tmpfs") == 0 || strcmp(filesystemtype, "romfs") == 0) {
 		ret = ioctl(fd, FIOC_MMAP, (unsigned long)&size);
-	} else if (strcmp(filesystemtype, "smartfs") == 0) {
+	} else if (strcmp(filesystemtype, "jSmartFs") == 0) {
 		return;
 	}
 
@@ -269,7 +269,7 @@ static void tc_fs_mops_opendir(const char *filesystemtype, DIR **dir)
 		*dir = opendir(TMPFS_TEST_MOUNTPOINT);
 	} else if (strcmp(filesystemtype, "romfs") == 0) {
 		*dir = opendir("/rom/init.d");
-	} else if (strcmp(filesystemtype, "smartfs") == 0) {
+	} else if (strcmp(filesystemtype, "jSmartFs") == 0) {
 		*dir = opendir(SMARTFS_TEST_MOUNTPOINT);
 	}
 
@@ -293,7 +293,7 @@ static void tc_fs_mops_closedir(const char *filesystemtype, DIR *dir)
 {
 	int ret = -1;
 
-	if (strcmp(filesystemtype, "romfs") == 0 || strcmp(filesystemtype, "smartfs") == 0) {
+	if (strcmp(filesystemtype, "romfs") == 0 || strcmp(filesystemtype, "jSmartFs") == 0) {
 		return;
 	}
 
@@ -309,7 +309,7 @@ static void tc_fs_mops_mkdir(const char *filesystemtype)
 		ret = mkdir(TMPFS_TEST_MOUNTPOINT"/dir", 0777);
 	} else if (strcmp(filesystemtype, "romfs") == 0) {
 		return;
-	} else if (strcmp(filesystemtype, "smartfs") == 0) {
+	} else if (strcmp(filesystemtype, "jSmartFs") == 0) {
 		ret = mkdir(SMARTFS_TEST_MOUNTPOINT"/dir", 0777);
 	}
 
@@ -324,7 +324,7 @@ static void tc_fs_mops_rmdir(const char *filesystemtype)
 		ret = rmdir(TMPFS_TEST_MOUNTPOINT"/dir");
 	} else if (strcmp(filesystemtype, "romfs") == 0) {
 		return;
-	} else if (strcmp(filesystemtype, "smartfs") == 0) {
+	} else if (strcmp(filesystemtype, "jSmartFs") == 0) {
 		ret = rmdir(SMARTFS_TEST_MOUNTPOINT"/dir");
 	}
 
@@ -341,7 +341,7 @@ static void tc_fs_mops_stat(const char *filesystemtype)
 		ret = stat(TMPFS_TEST_MOUNTPOINT"/test", &st);
 	} else if (strcmp(filesystemtype, "romfs") == 0) {
 		ret = stat(filename, &st);
-	} else if (strcmp(filesystemtype, "smartfs") == 0) {
+	} else if (strcmp(filesystemtype, "jSmartFs") == 0) {
 		ret = stat(SMARTFS_TEST_MOUNTPOINT"/test", &st);
 	}
 
@@ -356,7 +356,7 @@ static void tc_fs_mops_rename(const char *filesystemtype)
 		ret = rename(TMPFS_TEST_MOUNTPOINT"/test", TMPFS_TEST_MOUNTPOINT"/test_new");
 	} else if (strcmp(filesystemtype, "romfs") == 0) {
 		return;
-	} else if (strcmp(filesystemtype, "smartfs") == 0) {
+	} else if (strcmp(filesystemtype, "jSmartFs") == 0) {
 		ret = rename(SMARTFS_TEST_MOUNTPOINT"/test", SMARTFS_TEST_MOUNTPOINT"/test_new");
 	}
 
@@ -372,7 +372,7 @@ static void tc_fs_mops_statfs(const char *filesystemtype)
 		ret = statfs(TMPFS_TEST_MOUNTPOINT, &fs);
 	} else if (strcmp(filesystemtype, "romfs") == 0) {
 		ret = statfs("/rom", &fs);
-	} else if (strcmp(filesystemtype, "smartfs") == 0) {
+	} else if (strcmp(filesystemtype, "jSmartFs") == 0) {
 		ret = statfs(SMARTFS_TEST_MOUNTPOINT, &fs);
 	}
 
@@ -387,7 +387,7 @@ static void tc_fs_mops_unlink(const char *filesystemtype)
 		ret = unlink(TMPFS_TEST_MOUNTPOINT"/test_new");
 	} else if (strcmp(filesystemtype, "romfs") == 0) {
 		return;
-	} else if (strcmp(filesystemtype, "smartfs") == 0) {
+	} else if (strcmp(filesystemtype, "jSmartFs") == 0) {
 		ret = unlink(SMARTFS_TEST_MOUNTPOINT"/test_new");
 	}
 
@@ -402,7 +402,7 @@ static void tc_fs_mops_umount(const char *filesystemtype)
 		ret = umount(TMPFS_TEST_MOUNTPOINT);
 	} else if (strcmp(filesystemtype, "romfs") == 0) {
 		ret = umount("/rom");
-	} else if (strcmp(filesystemtype, "smartfs") == 0) {
+	} else if (strcmp(filesystemtype, "jSmartFs") == 0) {
 		ret = umount(SMARTFS_TEST_MOUNTPOINT);
 	}
 
@@ -451,6 +451,6 @@ void tc_fs_mops_main(void)
 #endif
 #endif
 #ifdef CONFIG_TC_FS_SMARTFS_MOPS
-	tc_fs_mops_test_main("smartfs");
+	tc_fs_mops_test_main("jSmartFs");
 #endif
 }

--- a/apps/system/utils/fscmd.c
+++ b/apps/system/utils/fscmd.c
@@ -104,7 +104,7 @@
 
 /** Define FS Type **/
 #define NONEFS_TYPE     "None FS"
-#define SMARTFS_TYPE    "smartfs"
+#define SMARTFS_TYPE    "jSmartFs"
 #define PROCFS_TYPE     "procfs"
 #define ROMFS_TYPE      "romfs"
 #define TMPFS_TYPE      "tmpfs"
@@ -1237,7 +1237,7 @@ static const char *get_fstype(FAR struct statfs *statbuf)
 
 #ifdef CONFIG_FS_SMARTFS
 	case SMARTFS_MAGIC:
-		fstype = "smartfs";
+		fstype = "jSmartFs";
 		break;
 #endif
 
@@ -1363,7 +1363,7 @@ static int format_filesystem(fs_minor_t minor)
 		if (fd < 0) {
 			continue;
 		}
-		/* TODO Multi root of smartfs should be considered when it enabled */
+		/* TODO Multi root of jSmartFs should be considered when it enabled */
 		ret = ioctl(fd, BIOC_BULKERASE, 0);
 		close(fd);
 		if (ret != OK) {

--- a/os/board/artik05x/src/artik05x_tash.c
+++ b/os/board/artik05x/src/artik05x_tash.c
@@ -201,7 +201,7 @@ int board_app_initialize(void)
 	} else {
 		ret = mount(CONFIG_ARTIK05X_AUTOMOUNT_SSSRW_DEVNAME,
 				CONFIG_ARTIK05X_AUTOMOUNT_SSSRW_MOUNTPOINT,
-				"smartfs", 0, NULL);
+				"jSmartFs", 0, NULL);
 		if (ret != OK) {
 			lldbg("ERROR: mounting '%s' failed\n",
 					CONFIG_ARTIK05X_AUTOMOUNT_SSSRW_DEVNAME);
@@ -234,7 +234,7 @@ int board_app_initialize(void)
 					lldbg("ERROR: mksmartfs on %s failed\n", CONFIG_ARTIK05X_RAMMTD_DEV_POINT);
 					kmm_free(rambuf);
 				} else {
-					ret = mount(CONFIG_ARTIK05X_RAMMTD_DEV_POINT, CONFIG_ARTIK05X_RAMMTD_MOUNT_POINT, "smartfs", 0, NULL);
+					ret = mount(CONFIG_ARTIK05X_RAMMTD_DEV_POINT, CONFIG_ARTIK05X_RAMMTD_MOUNT_POINT, "jSmartFs", 0, NULL);
 					if (ret < 0) {
 						lldbg("ERROR: Failed to mount the SMART volume: %d\n", errno);
 						kmm_free(rambuf);

--- a/os/board/common/partitions.c
+++ b/os/board/common/partitions.c
@@ -351,7 +351,7 @@ void automount_fs_partition(partition_info_t *partinfo)
 	if (ret != OK) {
 		printf("ERROR: mksmartfs on %s failed errno : %d\n", fs_devname, errno);
 	} else {
-		ret = mount(fs_devname, "/mnt", "smartfs", 0, NULL);
+		ret = mount(fs_devname, "/mnt", "jSmartFs", 0, NULL);
 		if (ret != OK) {
 			printf("ERROR: mounting '%s' failed, errno %d\n", fs_devname, get_errno());
 		} else {

--- a/os/board/imxrt1020-evk/src/imxrt_bringup.c
+++ b/os/board/imxrt1020-evk/src/imxrt_bringup.c
@@ -202,7 +202,7 @@ void imxrt_filesystem_initialize(void)
 					IMXLOG("SMARTFS ERROR: mksmartfs failed");
 					kmm_free(rambuf);
 				} else {
-					ret = mount(CONFIG_IMXRT_RAMMTD_DEV_POINT, CONFIG_IMXRT_RAMMTD_MOUNT_POINT, "smartfs", 0, NULL);
+					ret = mount(CONFIG_IMXRT_RAMMTD_DEV_POINT, CONFIG_IMXRT_RAMMTD_MOUNT_POINT, "jSmartFs", 0, NULL);
 					if (ret < 0) {
 						IMXLOG("SMARTFS ERROR: mount the SMART volume failed");
 						kmm_free(rambuf);

--- a/os/board/imxrt1050-evk/src/imxrt_bringup.c
+++ b/os/board/imxrt1050-evk/src/imxrt_bringup.c
@@ -166,7 +166,7 @@ void imxrt_filesystem_initialize(void)
 					IMXLOG("SMARTFS ERROR: mksmartfs failed");
 					kmm_free(rambuf);
 				} else {
-					ret = mount(CONFIG_IMXRT_RAMMTD_DEV_POINT, CONFIG_IMXRT_RAMMTD_MOUNT_POINT, "smartfs", 0, NULL);
+					ret = mount(CONFIG_IMXRT_RAMMTD_DEV_POINT, CONFIG_IMXRT_RAMMTD_MOUNT_POINT, "jSmartFs", 0, NULL);
 					if (ret < 0) {
 						IMXLOG("SMARTFS ERROR: mount the SMART volume failed");
 						kmm_free(rambuf);

--- a/os/board/lm3s6965-ek/src/up_boot.c
+++ b/os/board/lm3s6965-ek/src/up_boot.c
@@ -215,7 +215,7 @@ int board_initialize(void)
 	if (ret != OK) {
 		lldbg("ERROR: mksmartfs on %s failed, ret = %d\n", devname, ret);
 	} else {
-		ret = mount(devname, QEMU_SMARTFS_MOUNT_POINT, "smartfs", 0, NULL);
+		ret = mount(devname, QEMU_SMARTFS_MOUNT_POINT, "jSmartFs", 0, NULL);
 		if (ret != OK) {
 			lldbg("ERROR: mounting '%s' failed, ret = %d\n", devname, ret);
 		} else {

--- a/os/board/sidk_s5jt200/src/s5jt200_tash.c
+++ b/os/board/sidk_s5jt200/src/s5jt200_tash.c
@@ -329,7 +329,7 @@ int board_app_initialize(void)
 	} else {
 		ret = mount(SIDK_S5JT200_AUTOMOUNT_USERFS_DEVNAME,
 				CONFIG_SIDK_S5JT200_AUTOMOUNT_USERFS_MOUNTPOINT,
-				"smartfs", 0, NULL);
+				"jSmartFs", 0, NULL);
 		if (ret != OK)
 			lldbg("ERROR: mounting '%s' failed\n",
 				SIDK_S5JT200_AUTOMOUNT_USERFS_DEVNAME);
@@ -349,7 +349,7 @@ int board_app_initialize(void)
 	} else {
 		ret = mount(CONFIG_SIDK_S5JT200_AUTOMOUNT_SSSRW_DEVNAME,
 				CONFIG_SIDK_S5JT200_AUTOMOUNT_SSSRW_MOUNTPOINT,
-				"smartfs", 0, NULL);
+				"jSmartFs", 0, NULL);
 		if (ret != OK)
 			lldbg("ERROR: mounting '%s' failed\n",
 				CONFIG_SIDK_S5JT200_AUTOMOUNT_SSSRW_DEVNAME);
@@ -377,7 +377,7 @@ int board_app_initialize(void)
 				lldbg("ERROR: mksmartfs on %s failed", CONFIG_SIDK_S5JT200_RAMMTD_DEV_POINT);
 				kmm_free(rambuf);
 			} else {
-				ret = mount(CONFIG_SIDK_S5JT200_RAMMTD_DEV_POINT, CONFIG_SIDK_S5JT200_RAMMTD_MOUNT_POINT, "smartfs", 0, NULL);
+				ret = mount(CONFIG_SIDK_S5JT200_RAMMTD_DEV_POINT, CONFIG_SIDK_S5JT200_RAMMTD_MOUNT_POINT, "jSmartFs", 0, NULL);
 				if (ret < 0) {
 					lldbg("ERROR: Failed to mount the SMART volume: %d\n", errno);
 					kmm_free(rambuf);

--- a/os/fs/driver/mtd/smart.c
+++ b/os/fs/driver/mtd/smart.c
@@ -19,6 +19,7 @@
  * fs/driver/mtd/smart.c
  *
  * Sector Mapped Allocation for Really Tiny (SMART) Flash block driver.
+ * Journaling mechanism is added to the SMART layer itself and upgrades smartfs to jSmartFs.
  *
  *   Copyright (C) 2013-2014 Ken Pettit. All rights reserved.
  *   Author: Ken Pettit <pettitkd@gmail.com>

--- a/os/fs/mount/fs_mount.c
+++ b/os/fs/mount/fs_mount.c
@@ -133,7 +133,7 @@ static const struct fsmap_t g_bdfsmap[] = {
 	 * here. If no file system exists then you have to add { NULL, NULL }
 	 */
 #ifdef CONFIG_FS_SMARTFS
-	{"smartfs", &smartfs_operations},
+	{"jSmartFs", &smartfs_operations},
 #endif
 #ifdef CONFIG_FS_ROMFS
 	{"romfs", &romfs_operations},

--- a/os/fs/smartfs/README.txt
+++ b/os/fs/smartfs/README.txt
@@ -1,17 +1,20 @@
-SMARTFS README
-^^^^^^^^^^^^^^
+jSmartFs README
+^^^^^^^^^^^^^^^
 
 This README file contains information about the implemenation of the TinyAra
-Sector Mapped Allocation for Really Tiny (SMART) FLASH file system, SMARTFS.
+Journaling - Sector Mapped Allocation for Really Tiny FLASH file system, jSmartFs.
+Journaling tries to provide an assurance of file system integrity during system crash.
+By writing changes to a journal quickly, we can ensure that all changes to files
+are recorded and not lost during power shutdowns or crashes.
 
 Contents:
 
   Features
   General operation
-  SMARTFS organization
+  jSmartFs organization
   Headers
   Multiple mount points
-  SMARTFS Limitations
+  jSmartFs Limitations
   ioctls
   Things to Do
 
@@ -136,7 +139,7 @@ General operation
   at at time (which is typically 256 bytes).  For FLASH devices that support
   byte write mode, support for this config item can be added to the MTD
   driver.  Enabling and supporting this feature reduces the traffic on the
-  SPI bus considerably because SMARTFS performs many operations that affect
+  SPI bus considerably because jSmartFs performs many operations that affect
   only a few bytes on the device.  Without BYTE_WRITE, the code must
   perform a full page read-modify-write operation on a 256 or even 512
   byte page.
@@ -253,7 +256,7 @@ General operation
   as a chain or "linked list" of logical sectors.  Thus the actual physical
   sectors that a give file or directory uses does not need to be contiguous
   and in fact can (and will) move around over time.  To manage the sector
-  chains, the SMARTFS layer adds a "chain header" after the sector's "sector
+  chains, the jSmartFs layer adds a "chain header" after the sector's "sector
   header".  This is a 5-byte header which contains the chain type (file or
   directory), a "next logical sector" entry and the count of bytes actually
   used within the sector.
@@ -283,7 +286,7 @@ General operation
   existing data) or appending to a sector for regular files requires copying
   the file data to a new sector and releasing the old one.
 
-SMARTFS organization
+jSmartFs organization
 ====================
 
   The following example assumes 2 logical blocks per FLASH erase block.  The
@@ -393,11 +396,11 @@ Multiple Mount Points
   in the others).  Each directory structure is isolated from the others,
   they simply share the same physical media for storage.
 
-SMARTFS Limitations
+jSmartFs Limitations
 ===================
 
 This implementation has several limitations that you should be aware
-before opting to use SMARTFS:
+before opting to use jSmartFs:
 
 1. The implementation can support CRC-8 or CRC-16 error detection, and can
    relocate a failed write operation to a new sector.  However with no bad

--- a/os/fs/smartfs/smartfs.h
+++ b/os/fs/smartfs/smartfs.h
@@ -175,7 +175,7 @@
 #define INODE_STATE_FILE          (CONFIG_NXFFS_ERASEDSTATE ^ 0x22)
 #define INODE_STATE_DELETED       (CONFIG_NXFFS_ERASEDSTATE ^ 0xaa)
 
-/* Smartfs workbuffer maximum length */
+/* jSmartFs workbuffer maximum length */
 
 #define SMARTFS_MAX_WORKBUFFER_LEN 256
 
@@ -287,7 +287,7 @@ struct smartfs_entry_header_s {
 	char name[0];				/* inode name */
 };
 
-/* This structure describes the smartfs header at the start of each
+/* This structure describes the jSmartFs header at the start of each
  * sector.  It manages the sector chain and used bytes in the sector.
  */
 
@@ -317,7 +317,7 @@ struct smartfs_ofile_s {
 #endif
 	int16_t crefs;				/* Reference count */
 	mode_t oflags;				/* Open mode */
-	struct smartfs_entry_s entry;	/* Describes the SMARTFS inode entry */
+	struct smartfs_entry_s entry;	/* Describes the jSmartFs inode entry */
 	size_t filepos;				/* Current file position */
 	uint16_t currsector;		/* Current sector of filepos */
 	uint16_t curroffset;		/* Current offset in sector */
@@ -331,12 +331,12 @@ struct smartfs_ofile_s {
 
 /* This structure represents the overall mountpoint state.  An instance of this
  * structure is retained as inode private data on each mountpoint that is
- * mounted with a smartfs filesystem.
+ * mounted with a jSmartFs filesystem.
  */
 
 struct smartfs_mountpt_s {
 #if defined(CONFIG_SMARTFS_MULTI_ROOT_DIRS) || defined(CONFIG_FS_PROCFS)
-	struct smartfs_mountpt_s *fs_next;	/* Pointer to next SMART filesystem */
+	struct smartfs_mountpt_s *fs_next;	/* Pointer to next jSmartFs filesystem */
 #endif
 	FAR struct inode *fs_blkdriver;	/* Our underlying block device */
 	sem_t *fs_sem;				/* Used to assure thread-safe access */

--- a/os/fs/smartfs/smartfs_utils.c
+++ b/os/fs/smartfs/smartfs_utils.c
@@ -870,7 +870,7 @@ int smartfs_mount(struct smartfs_mountpt_s *fs, bool writeable)
 		fs->fs_workbuffer = (char *)kmm_malloc(256);
 	}
 
-	/* Now add ourselves to the linked list of SMART mounts */
+	/* Now add ourselves to the linked list of jSmartFs mounts */
 
 	fs->fs_next = g_mounthead;
 	g_mounthead = fs;
@@ -884,7 +884,7 @@ int smartfs_mount(struct smartfs_mountpt_s *fs, bool writeable)
 #endif							/* CONFIG_SMARTFS_MULTI_ROOT_DIRS */
 
 #if defined(CONFIG_FS_PROCFS) && !defined(CONFIG_FS_PROCFS_EXCLUDE_SMARTFS) && !defined(CONFIG_SMARTFS_MULTI_ROOT_DIRS)
-	/* Now add ourselves to the linked list of SMART mounts */
+	/* Now add ourselves to the linked list of jSmartFs mounts */
 
 	fs->fs_next = g_mounthead;
 	g_mounthead = fs;
@@ -1401,8 +1401,8 @@ errout:
  *   allocate a new entry. Then returns the 1st entry of the new sector.
  *
  * Input Parameters:
- *   fs - pointer to smartfs mountpoint structure.
- *   direntry - pointer to smartfs entry to return details of allocated
+ *   fs - pointer to jSmartFs mountpoint structure.
+ *   direntry - pointer to jSmartFs entry to return details of allocated
  *     entry.
  *
  * Returned Values:
@@ -1439,8 +1439,8 @@ int smartfs_createdirentry(struct smartfs_mountpt_s *fs, struct smartfs_entry_s 
  *   The first one to be found is used.
  *
  * Input Parameters:
- *   fs - pointer to smartfs mountpoint structure.
- *   direntry - pointer to smartfs entry structure for returning details
+ *   fs - pointer to jSmartFs mountpoint structure.
+ *   direntry - pointer to jSmartFs entry structure for returning details
  *     of the available entry found.
  *     If no available entry is found, it returns with the logical sector
  *     number of the last sector chained to parentdirsector.
@@ -1519,7 +1519,7 @@ int smartfs_find_availableentry(struct smartfs_mountpt_s *fs, struct smartfs_ent
  *   find_availableentry or createentry.
  *
  * Input Parameters:
- *   fs - pointer to smartfs mountpoint structure.
+ *   fs - pointer to jSmartFs mountpoint structure.
  *   new_entry - the details of the entry in MTD where new entry is to be
  *     written.
  *   type - type of new entry (file/dir).
@@ -1635,10 +1635,10 @@ errout:
  * Description: Allocate new data sector for a new file/directory entry.
  *
  * Input Parameters:
- *   fs - ponter to smartfs mountpoint structure.
+ *   fs - ponter to jSmartFs mountpoint structure.
  *   sector - pointer to return the sector number allocated.
  *   type - to set the type(file/dir) of the new sector allocated.
- *   sf - pointer to smartfs ofile structure in case a new file is being
+ *   sf - pointer to jSmartFs ofile structure in case a new file is being
  *     opened.
  *
  * Returned Values:
@@ -1702,7 +1702,7 @@ int smartfs_alloc_firstsector(struct smartfs_mountpt_s *fs, uint16_t *sector, ui
  * Description: Invalidates the smartfs entry passed as a parameter.
  *
  * Input Parameters:
- *  fs - pointer to smartfs mountpoint structure.
+ *  fs - pointer to jSmartFs mountpoint structure.
  *  parentdirsector - parent sector of entry to be marked invalid.
  *  offset - offset of entry in parent directory sector
  *
@@ -2257,7 +2257,7 @@ ssize_t smartfs_append_data(FAR struct smartfs_mountpt_s *fs, FAR struct smartfs
 /****************************************************************************
  * Name: smartfs_get_first_mount
  *
- * Description: Returns a pointer to the first mounted smartfs volume.
+ * Description: Returns a pointer to the first mounted jSmartFs volume.
  *
  ****************************************************************************/
 
@@ -2532,7 +2532,7 @@ errout:
 /****************************************************************************
  * Name: smartfs_sector_recovery
  *
- * Description: Recover Isolated sector that is not able to access in smartfs.
+ * Description: Recover Isolated sector that is not able to access in jSmartFs.
  *              Because of power off, Isolated sector can be exist.
  *              This works stand alone, but it works properly with journaling
  *

--- a/tools/nxfuse/src/main.c
+++ b/tools/nxfuse/src/main.c
@@ -112,7 +112,7 @@ int main(int argc, char *argv[])
 	char *mount_point;
 	struct inode *pinode;
 	struct nxfuse_state *nxfuse_data = NULL;
-	const char *fs_type = "smartfs";
+	const char *fs_type = "jSmartFs";
 	char fsname[128];
 
 	/* We will recreate the argv array for fuse_main with only those

--- a/tools/nxfuse/src/tinyara_services.c
+++ b/tools/nxfuse/src/tinyara_services.c
@@ -117,7 +117,7 @@ static int g_inode_count = 0;
 
 static struct fs_ops_s g_fs_ops[] = {
 #ifdef CONFIG_FS_SMARTFS
-	{"smartfs", smartfs_vmount, smartfs_mkfs, &smartfs_operations},
+	{"jSmartFs", smartfs_vmount, smartfs_mkfs, &smartfs_operations},
 #endif
 
 	{"", NULL, NULL}


### PR DESCRIPTION
- jSmartFs is an update to smartfs to ensure recovery and filesystem integrity.
- The core is the same while the entity is logically regarded as jSmartFs (journaling SmartFs).
- Name of smartfs is updated to jSmartFs, hence update the mount commands. 
- to mount the same user filesystem with the name as jSmartFs instead of smartfs.
- Logical name of user filesystem changed from smartfs to jSmartFs.
- Test applications (filesystem_tc) should invoke test cases with the same name.
- Standard examples (powercut, buffer optimization) should be updated for jSmartFs.
- TASH help commands (df -h) should also regard the entity as jSmartFs.
- While Nxfuse still works as a generic tool to mount a SMART filesystem, in our case, we use Nxfuse to mount our user Fs which is now named as jSmartFs
- Only change the name references, while others still say smartfs as Nxfuse continues to be a general tool.


