### PR TITLE
os/board/rtl8720e/src/component/soc/amebalite/fwlib/ram_common: Workaround for A cut 131K calibration.

### DIFF
--- a/os/board/rtl8720e/src/component/soc/amebalite/fwlib/ram_common/ameba_clk.c
+++ b/os/board/rtl8720e/src/component/soc/amebalite/fwlib/ram_common/ameba_clk.c
@@ -93,7 +93,11 @@ VOID OSC131_R_Set(u32 setbit, u32 clearbit)
 	}
 
 	/* It takes 1ms to stable */
-	DelayMs(1);
+	if (SYSCFG_RLVersion() == SYSCFG_CUT_VERSION_A) {
+		DelayMs(2);
+	} else {
+		DelayMs(1);
+	}
 }
 
 /**


### PR DESCRIPTION

Workaround for 131k calibration issue in Acut, add more delay time to stable.