### PR TITLE
os/tools: Validate packages after build

### DIFF
--- a/os/Makefile.unix
+++ b/os/Makefile.unix
@@ -545,7 +545,7 @@ endif
 	$(Q) python ./tools/set_bininfo.py $(BIN_EXT)
 	$(Q) $(call MAKE_SAMSUNG_HEADER, $(BIN_EXE), $(BIN_EXT))
 ifeq ($(CONFIG_FLASH_PARTITION),y)
-	$(Q) python ./tools/check_output_size.py
+	$(Q) python ./tools/validate_output.py
 endif
 	$(Q) $(call MAKE_BOOTPARAM)
 

--- a/os/tools/check_package_header.py
+++ b/os/tools/check_package_header.py
@@ -20,7 +20,7 @@
 # And verify the package by calculating the crc and comparing it with the value of the header.
 #
 # Usage :
-#   python check_package.py [package path]
+#   python check_package_header.py [package path]
 
 from __future__ import with_statement
 import struct
@@ -46,8 +46,8 @@ VERIFY_SUCCESS = True
 target = sys.argv[1]
 if target == "-h" or target == "--help" :
     print("Usage :")
-    print("\tpython check_package.py [package_path]")
-    print("\tex) python check_package.py ../../build/output/bin/kernel_XXX_YYMMDD.trpk")
+    print("\tpython check_package_header.py [package_path]")
+    print("\tex) python check_package_header.py ../../build/output/bin/kernel_XXX_YYMMDD.trpk")
     sys.exit(0)
 
 # Read the package header
@@ -56,7 +56,7 @@ with open(target, 'r') as f:
 
 check_signing = struct.unpack('H', data[4:6])
 
-if "kernel_" in target :
+if "kernel" in target :
     print("=== Kernel Package Header Information ===")
     print("< Cannot check the signing >")
     SIGNING_OFFSET = 0 #For kernel package, signing info is not added at the first. So we will not use the offset for kernel package case.
@@ -71,7 +71,7 @@ if "kernel_" in target :
     print("\tFile Size          : " + str(file_size[0]))
     print("\tSecure Header Size : " + str(secure_size[0]))
 
-elif "common_" in target :
+elif "common" in target :
     print("=== Common Package Header Information ===")
 
     if int(check_signing[0]) == COMMON_HEADER_SIZE :
@@ -89,7 +89,7 @@ elif "common_" in target :
     print("\tPackage Version : " + str(package_ver[0]))
     print("\tFile Size       : " + str(file_size[0]))
 
-elif "app_" in target :
+elif "app" in target :
     print("=== App Package Header Information ===")
 
     if int(check_signing[0]) == APP_HEADER_SIZE :
@@ -168,3 +168,6 @@ else :
 # Return exit(1) if there is a validation failure.
 if VERIFY_SUCCESS == False :
     sys.exit(1)
+    print("!!!!ERROR!!!! Binary is invalid. Please check the package.\n")
+else :
+    print("=> Header verification SUCCESS!!\n")

--- a/os/tools/check_package_size.py
+++ b/os/tools/check_package_size.py
@@ -17,9 +17,8 @@
 #
 ###########################################################################
 
-# This script is for checking if the kernel, common and user partitions are large enough to accommodate their respective binaries.
-# For this, get the partition size and binary size,
-# and check if the binary sizes are smaller than their respective partition sizes.
+# This script checks if the each partitions are large enough to accommodate their respective binaries.
+# It gets the partition size and binary size and check if the binary sizes are smaller than their respective partition sizes.
 
 import os
 import sys
@@ -28,6 +27,7 @@ import config_util as util
 
 os_folder = os.path.dirname(__file__) + '/..'
 cfg_file = os_folder + '/.config'
+tool_folder = os_folder + '/tools'
 build_folder = os_folder + '/../build'
 output_folder = build_folder + '/output/bin'
 
@@ -60,6 +60,16 @@ def check_binary_size(bin_type, part_size):
         print("   " + bin_type + " Binary will be deleted. Need to re-configure the partition using menuconfig and to re-build.")
         os.remove(output_path)
         FAIL_TO_BUILD = True
+
+def check_binary_header(bin_type):
+    # Read the binary name from .bininfo
+    bin_name = util.get_binname_from_bininfo(bin_type)
+    if bin_name == 'None' :
+        return
+    output_path = build_folder + '/output/bin/' + bin_name
+
+    # Run script for checking binary header
+    os.system('python ' + tool_folder + '/check_package.py ' + output_path)
 
 PARTITION_SIZE_LIST = util.get_value_from_file(cfg_file, "CONFIG_FLASH_PART_SIZE=")
 PARTITION_NAME_LIST = util.get_value_from_file(cfg_file, "CONFIG_FLASH_PART_NAME=")
@@ -133,4 +143,4 @@ if FAIL_TO_BUILD == True :
     # Stop to build, because there is mismatched size problem.
     sys.exit(1)
 else :
-    print("Size verification is done.")
+    print("=> Size verification SUCCESS!! The size of all binaries are OK.\n")

--- a/os/tools/validate_output.py
+++ b/os/tools/validate_output.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python
+###########################################################################
+#
+# Copyright 2022 Samsung Electronics All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+#
+###########################################################################
+
+# This script is for checking package validation : kernel, common, user.
+# 1. Check if the each partitions are large enough to accommodate their respective binaries.
+#    It gets the partition size and binary size and check if the binary sizes are smaller than their respective partition sizes.
+# 2. Check if the values of binary header are valid.
+#    It verifies the package by calculating the crc and comparing it with the value of the header.
+
+import os
+
+os_folder = os.path.dirname(__file__) + '/..'
+tool_folder = os_folder + '/tools/'
+output_folder = os_folder + '/../build/output/bin/'
+
+def check_package_size():
+    # Run script for checking binary sizes
+    os.system('python ' + tool_folder + '/check_package_size.py')
+
+def check_package_header():
+    # Run script for checking binary sizes
+    for file in os.listdir(output_folder):
+        if file.endswith('.trpk'):
+            os.system('python ' + tool_folder + '/check_package.py ' + output_folder + file)
+
+############################################################################
+# Validates packages
+############################################################################
+# 1. Validate the binary size with partition size
+check_package_size()
+
+# 2. Validate the header data of binaries
+check_package_header()


### PR DESCRIPTION
Call script for checking package validation after build.
It parses the package header information and show them.
And verify the package by calculating the crc and comparing it with the value of the header.