### PR TITLE
os/se/ameba: Added TP1E Samsung Key Address

### DIFF
--- a/os/se/ameba/security_ameba_wrapper_tz.c
+++ b/os/se/ameba/security_ameba_wrapper_tz.c
@@ -99,7 +99,12 @@
 #define SECTOR_SIZE 4096
 
 /* Secure efuse key location */
+#ifdef CONFIG_AMEBAD_TRUSTZONE
 #define SAMSUNG_KEY_ADDR 0x150
+#endif
+#ifdef CONFIG_AMEBALITE_TRUSTZONE
+#define SAMSUNG_KEY_ADDR 0x390
+#endif
 
 /* Non-Secure Data buff, 8K (2 Sector + Tag) */
 #define NS_BUF_LEN ((SECTOR_SIZE * 2) + 32)


### PR DESCRIPTION
Added TP1E Samsung Key Address with condition checking for the board type