### PR TITLE
os/board/rtl8720e: Resolve SVACE warnings with WGID from 244015~244019.

### DIFF
--- a/os/board/rtl8720e/src/component/mbed/targets/hal/rtl8720e/i2s_api.c
+++ b/os/board/rtl8720e/src/component/mbed/targets/hal/rtl8720e/i2s_api.c
@@ -203,8 +203,6 @@ void i2s_init(i2s_t *obj, PinName sck, PinName ws, PinName sd_tx, PinName sd_rx,
 
 	assert_param(IS_SP_SEL_I2S(obj->i2s_idx));
 
-	u32 tmp;
-	u32 clock;
 	RCC_PeriphClockSource_SPORT(CKSL_I2S_XTAL40M);
 
 	if (obj->i2s_idx == I2S1) {
@@ -239,7 +237,6 @@ void i2s_init(i2s_t *obj, PinName sck, PinName ws, PinName sd_tx, PinName sd_rx,
 	SP_InitStruct.SP_SR = obj->sampling_rate;
 	SP_InitStruct.SP_SetMultiIO = SP_TX_MULTIIO_EN;
 	SP_InitStruct.SP_SetMultiIO = SP_RX_MULTIIO_EN;
-	SP_InitStruct.SP_SelClk = clock;
 	if (obj->direction == I2S_DIR_TX) {
 		AUDIO_SP_Init(obj->i2s_idx, SP_DIR_TX, &SP_InitStruct);
 	} else {

--- a/os/board/rtl8720e/src/component/soc/amebalite/fwlib/ram_common/ameba_sport.c
+++ b/os/board/rtl8720e/src/component/soc/amebalite/fwlib/ram_common/ameba_sport.c
@@ -211,8 +211,8 @@ u32 AUDIO_SP_GetRXChnLen(AUDIO_SPORT_TypeDef *SPORTx)
 void AUDIO_SP_SetTXClkDiv(u32 index, u32 clock, u32 sr, u32 tdm, u32 chn_len)
 {
 	u32 Tmp;
-	u32 MI;
-	u32 NI;
+	u32 MI = 0;
+	u32 NI = 0;
 	u32 Bclk_div;
 
 	AUDIO_SPORT_TypeDef *SPORTx = AUDIO_DEV_TABLE[index].SPORTx;
@@ -296,8 +296,8 @@ void AUDIO_SP_SetTXClkDiv(u32 index, u32 clock, u32 sr, u32 tdm, u32 chn_len)
 void AUDIO_SP_SetRXClkDiv(u32 index, u32 clock, u32 sr, u32 tdm, u32 chn_len)
 {
 	u32 Tmp;
-	u32 NI;
-	u32 MI;
+	u32 NI = 0;
+	u32 MI = 0;
 	u32 Bclk_div;
 
 	AUDIO_SPORT_TypeDef *SPORTx = AUDIO_DEV_TABLE[index].SPORTx;


### PR DESCRIPTION
Resolve SVACE warnings with WGID from 244015~244019.