### PR TITLE
os/board/rtl8720e: Resolve SVACE warnings with WGID 244021 and 244060

### DIFF
--- a/os/board/rtl8720e/src/component/wifi/driver/include/wifi_constants.h
+++ b/os/board/rtl8720e/src/component/wifi/driver/include/wifi_constants.h
@@ -202,7 +202,7 @@ enum {
 
 	RTW_SECURITY_FORCE_32_BIT   = 0x7fffffff                                        /**< Exists only to force rtw_security_t type to 32 bits */
 };
-typedef unsigned long rtw_security_t;
+typedef long rtw_security_t;
 
 /**
  * @brief The enumeration lists wpa mode

--- a/os/board/rtl8720e/src/component/wifi/wifi_interactive_mode.c
+++ b/os/board/rtl8720e/src/component/wifi/wifi_interactive_mode.c
@@ -441,7 +441,7 @@ int8_t cmd_wifi_connect(trwifi_ap_config_s *ap_connect_config, void *arg, uint32
 	int key_id = 0;
 	void *semaphore;
 	int security_retry_count = 0;
-	uint8_t pscan_config;
+	uint8_t pscan_config = 0;
 	rtw_network_info_t wifi_info = {0};
 
 	trwifi_ap_auth_type_e auth = ap_connect_config->ap_auth_type;


### PR DESCRIPTION
Resolve 244021 by initializing pscan_config to 0
Resolve 244060 by modifying rtw_security_t to long