### PR TITLE
os/board/rtl8720e: Correct the internal pull up/pull down option for PA_19, LogUART RX, to pull up.

### DIFF
--- a/os/board/rtl8720e/src/component/soc/amebalite/fwlib/usrcfg/ameba_pinmapcfg.c
+++ b/os/board/rtl8720e/src/component/soc/amebalite/fwlib/usrcfg/ameba_pinmapcfg.c
@@ -47,7 +47,7 @@ const PMAP_TypeDef pmap_func[] = {
 	{_PA_16,			GPIO_PuPd_DOWN,			GPIO_PuPd_DOWN},			 //
 	{_PA_17,			GPIO_PuPd_DOWN,			GPIO_PuPd_DOWN},			 //
 	{_PA_18,			GPIO_PuPd_UP,				GPIO_PuPd_DOWN},			 //
-	{_PA_19,			GPIO_PuPd_DOWN,			GPIO_PuPd_DOWN},			 //
+	{_PA_19,			GPIO_PuPd_UP,			GPIO_PuPd_UP},			 //
 	{_PA_20,			GPIO_PuPd_UP,				GPIO_PuPd_UP},			 	//log_TX sleep need pull up
 	{_PA_21,			GPIO_PuPd_DOWN,			GPIO_PuPd_DOWN},			 //
 	{_PA_22,			GPIO_PuPd_UP,				GPIO_PuPd_UP},			 	//swr_voltage_sel sleep


### PR DESCRIPTION
Change PA_19 from GPIO_PuPd_DOWN to GPIO_PuPd_UP, further changes might be made once the final defaul pulling table been settle done.