### PR TITLE
os/board/rtl8720e: Resolve SVACE i2c_api.c warnings with WGID from 191360~191361.

### DIFF
--- a/os/board/rtl8720e/src/component/mbed/targets/hal/rtl8720e/i2c_api.c
+++ b/os/board/rtl8720e/src/component/mbed/targets/hal/rtl8720e/i2c_api.c
@@ -465,7 +465,7 @@ void i2c_reset(i2c_t *obj)
   */
 void i2c_restart_enable(i2c_t *obj)
 {
-	uint32_t i2cen;
+	uint32_t i2cen = 0;
 
 	if (obj->I2Cx->IC_ENABLE & I2C_BIT_ENABLE) {
 		I2C_Cmd(obj->I2Cx, DISABLE);
@@ -488,7 +488,7 @@ void i2c_restart_enable(i2c_t *obj)
   */
 void i2c_restart_disable(i2c_t *obj)
 {
-	uint32_t i2cen;
+	uint32_t i2cen = 0;
 
 	if (obj->I2Cx->IC_ENABLE & I2C_BIT_ENABLE) {
 		I2C_Cmd(obj->I2Cx, DISABLE);


### PR DESCRIPTION


    Resolve SVACE i2c_api.c warnings with WGID from 191360~191361.