### PR TITLE
os/board/rtl8720e: Result value typecasting for us ticks

### DIFF
--- a/os/board/rtl8720e/src/component/mbed/targets/hal/rtl8720e/us_ticker.c
+++ b/os/board/rtl8720e/src/component/mbed/targets/hal/rtl8720e/us_ticker.c
@@ -63,7 +63,7 @@ uint32_t us_ticker_read(void)
 	uint64_t us_tick;
 
 	tick_cnt = SYSTIMER_TickGet(); //up counter
-	us_tick = tick_cnt * (1000000 / 32768);
+	us_tick = (uint64_t)(tick_cnt * (1000000 / 32768));
 
 	return ((uint32_t)us_tick);
 }


### PR DESCRIPTION
The value of an arithmetic expression tick_cnt * (1000000 / 32768) is subject to overflow due to a failure to cast operands to a larger data type before perfoming arithmetic