### PR TITLE
arch/arm/src: Add IRQ debug logs during assertion and update TRAP tool accordingly

### DIFF
--- a/os/arch/arm/src/armv7-m/up_doirq.c
+++ b/os/arch/arm/src/armv7-m/up_doirq.c
@@ -76,6 +76,7 @@
 #ifdef CONFIG_ARCH_NESTED_INTERRUPT
 extern uint32_t g_nestlevel; /* Initial top of interrupt stack */
 #endif
+int g_irq_nums[2] = {0};
 /****************************************************************************
  * Private Data
  ****************************************************************************/
@@ -90,6 +91,10 @@ extern uint32_t g_nestlevel; /* Initial top of interrupt stack */
 
 uint32_t *up_doirq(int irq, uint32_t *regs)
 {
+	/* Store the last two interrupt numbers for reference during assert */
+	g_irq_nums[1] = g_irq_nums[0];
+	g_irq_nums[0] = irq;
+
 #ifdef CONFIG_ARCH_NESTED_INTERRUPT
 	irqstate_t flags;
 #endif
@@ -179,6 +184,10 @@ uint32_t *up_doirq(int irq, uint32_t *regs)
 	current_regs = savestate;
 #endif
 #endif
+	/* Reset the interrupt number values */
+	g_irq_nums[0] = g_irq_nums[1];
+	g_irq_nums[1] = 0;
+
 	board_led_off(LED_INIRQ);
 	return regs;
 }

--- a/os/arch/arm/src/armv8-m/up_doirq.c
+++ b/os/arch/arm/src/armv8-m/up_doirq.c
@@ -76,6 +76,7 @@
 #ifdef CONFIG_ARCH_NESTED_INTERRUPT
 extern uint32_t g_nestlevel; /* Initial top of interrupt stack */
 #endif
+int g_irq_nums[2] = {0};
 /****************************************************************************
  * Private Data
  ****************************************************************************/
@@ -90,6 +91,10 @@ extern uint32_t g_nestlevel; /* Initial top of interrupt stack */
 
 uint32_t *up_doirq(int irq, uint32_t *regs)
 {
+	/* Store the last two interrupt numbers for reference during assert */
+	g_irq_nums[1] = g_irq_nums[0];
+	g_irq_nums[0] = irq;
+
 #ifdef CONFIG_ARCH_NESTED_INTERRUPT
 	irqstate_t flags;
 #endif
@@ -179,6 +184,10 @@ uint32_t *up_doirq(int irq, uint32_t *regs)
 	current_regs = savestate;
 #endif
 #endif
+	/* Reset the interrupt number values */
+	g_irq_nums[0] = g_irq_nums[1];
+	g_irq_nums[1] = 0;
+
 	board_led_off(LED_INIRQ);
 	return regs;
 }

--- a/os/kernel/irq/irq.h
+++ b/os/kernel/irq/irq.h
@@ -84,6 +84,8 @@ struct irq {
 };
 
 extern struct irq g_irqvector[NR_IRQS];
+/* Array to store the last two interrupt numbers */
+//extern int g_irq_nums[2];
 
 /****************************************************************************
  * Public Variables

--- a/tools/debug/debugsymbolviewer.py
+++ b/tools/debug/debugsymbolviewer.py
@@ -228,6 +228,13 @@ def print_stack(log_file):
 						continue
 				continue
 
+			if 'Code asserted in IRQ state!' in line:
+				print('[Interrupt Stack]')
+			if 'Code asserted in nested IRQ state!' in line:
+				print('[Interrupt Stack]')
+			if 'User stack:' in line:
+				print('[User stack]')
+
 			# Read the stack contents of aborted stack and check for valid addresses
 			if 'up_stackdump:' in line:
 				word = line.split(':')
@@ -317,6 +324,19 @@ def print_running_work_function(log_file):
                             node = int(wf[:-2], 16)
                             print_symbol(0x00000000, node, 0)
                             print_symbol(0x00000000, node, 1)
+
+# Function to Parse the input log file (which contains interrupt handler data) and to print its owner
+def print_interrupt_handler_data(log_file):
+	# Parse the contents based on tokens in log file.
+	with open(log_file) as searchfile:
+		for line in searchfile:
+			if 'IRQ handler' in line:
+                            word = line.split(' ')
+                            node = int(word[-1], 16)
+                            print_symbol(0x00000000, node, 0)
+                            print_symbol(0x00000000, node, 1)
+
+# Function to Parse the input log file (which contains current running work function) and to print its owner
 #Execution starts here
 if (__name__ == '__main__'):
 
@@ -353,3 +373,6 @@ if (__name__ == '__main__'):
         # 3 specifies to print the running work function information
 	elif (addr_type == 3):
 		print_running_work_function(log_file)
+        # 4 specifies to print the interrupt handler information (if any)
+	elif (addr_type == 4):
+		print_interrupt_handler_data(log_file)

--- a/tools/trap/ramdumpParser.py
+++ b/tools/trap/ramdumpParser.py
@@ -528,9 +528,9 @@ def print_crash_type(string):
     else:
         print('\n2. Crash type               : etc')
     if (crash_type_assert == True):
-        print('\n3. Crash point              :', string)
+        print('\n3. Crash point\n\t- ', string)
     else:
-        print('   Crash log                :', string)
+        print('   Crash log\n\t-', string)
 
 # Function to get the number of application binaries, names, text address and sizes
 def find_number_of_binaries(log_file):
@@ -572,11 +572,13 @@ def find_crash_point(log_file, elf):
     global g_assertpc
     global g_stext_app
     global g_etext_app
+    global crash_type_assert
     app_idx = 0
     pc_value = 0
     lr_value = 0
     is_app_crash = 0
     is_kernel_crash = 0
+    is_interrupt_mode = 0
     assertline = ""
 
     # Parse the contents based on tokens in log file.
@@ -775,9 +777,57 @@ def find_crash_point(log_file, elf):
                     # If PC value is invalid, show invalid PC
                     if 'PC value might be invalid' in line:
                         print('\tPC value might be invalid.')
-            print('\tPC & LR values not in any text range! No probable crash point detected.')
+            print('\t-  PC & LR values not in any text range! No probable crash point detected.')
 
-    print('\n4. Call stack of last run thread\n')
+    # Parse the contents based on tokens in log file to determine point of assertion in details
+    with open(log_file) as searchfile:
+        found_type = 0
+        for line in searchfile:
+            if 'Nested IRQ stack:' in line:
+                found_type = 1
+                print('\n\t- Code asserted in Nested IRQ state.')
+                break
+            elif 'IRQ stack:' in line:
+                found_type = 1
+                print('\n\t- Code asserted in IRQ state.')
+                break
+            elif 'Running work function is' in line:
+                found_type = 1
+                print('\n\t- Code asserted in workqueue.')
+                break
+        if (found_type == 0):
+                print('\n\t- Code asserted in normal thread.')
+
+    # Parse the contents based on tokens in log file for assert during interrupt context
+    with open(log_file) as searchfile:
+        for line in searchfile:
+            # Print the interrupt data during crash (if crashed during interrupt context)
+            if 'IRQ num:' in line:
+                word = line.split(' ')
+                # Last word[-1] contains the interrupt number
+                irq_num = word[-1]
+                print('\n\t- Interrupt number\t\t:',irq_num)
+            if 'Code asserted in IRQ state!' in line:
+                is_interrupt_mode = 1
+                # It displays the interrupt handler information corresponding to the Interrupt
+                # The last argument to debugsymbolviewer specifies whether or not to check for interrupt handler address (4)
+                print("\n4. Assertion Data during interrupt mode:\n")
+                print('- Interrupt handler at addr\t\tSymbol_name')
+                os.system("python3 ../debug/debugsymbolviewer.py " + log_file + " " + str(g_app_idx) + " 4")
+    with open(log_file) as searchfile:
+        for line in searchfile:
+            if 'Nested IRQ stack:' in line:
+                is_interrupt_mode = 2
+                print("- IRQ Stack information:\n")
+            if (is_interrupt_mode >= 2 and is_interrupt_mode < 9):
+                is_interrupt_mode = is_interrupt_mode + 1
+                print("\033[F", line)
+
+    if (is_interrupt_mode):
+        print('\n5. Call stack of last run thread\n')
+    else:
+        print('\n4. Call stack of last run thread\n')
+
     # Parse the contents based on tokens in log file.
     with open(log_file) as searchfile:
         for line in searchfile:
@@ -803,9 +853,10 @@ def find_crash_point(log_file, elf):
     print('\nStack_address\t Symbol_address\t Symbol location  Symbol_name\t\tFile_name')
     os.system("python3 ../debug/debugsymbolviewer.py " + log_file + " " + str(g_app_idx) + " 0")
 
-    print('\n5. Miscellaneous information:')
-    # Parse the contents based on tokens in log file for heap corruption
+    print('\nx. Miscellaneous information:')
+
     with open(log_file) as searchfile:
+    # Parse the contents based on tokens in log file for heap corruption
         heap_corr = 0
         for line in searchfile:
             # Print the heap corruption data (if any)


### PR DESCRIPTION
This patch adds debug logs for IRQ during assert.

Sample logs are as follows:
```
up_assert: Assertion failed at file:chip/amebalite_serial.c line: 679 task: Idle Task
up_dumpstate: sp:     200153e4
up_dumpstate: Code asserted in nested IRQ state!
up_dumpstate: IRQ num: 51
up_dumpstate: IRQ handler: 0e0017c5
up_dumpstate: Nested IRQ stack:
up_dumpstate:   base: 200156a0
up_dumpstate:   size: 00000200
up_dumpstate:   used: 00000000
up_dumpstate: IRQ stack:
up_dumpstate:   base: 20015490
up_dumpstate:   size: 00000400
up_dumpstate:   used: 00000190
up_stackdump: 200153e0: xxxxxxxx 000002a7 20013924 deadbeef deadbeef deadbeef deadbeef deadbeef
up_stackdump: 20015400: deadbeef 20098120 000000a0 20098120 20015448 200121e0 00000000 2001213c
up_stackdump: 20015420: 00000000 00000000 00000000 00000000 0e00babb 0e00baa9 00000001 00000000
up_stackdump: 20015440: 0e02322f 2001213c 2001368c 00000008 20003f38 00000000 00000033 00000000
up_stackdump: 20015460: 0e00b3fd 0e00b3f5 0e0017ed 200156a0 0e00c8bd 000000a0 200137fc 00000000
up_stackdump: 20015480: 20013924 00000000 0e00b177 20003f38 00000000 00000000 00000000 00000000
up_dumpstate: User stack:
up_dumpstate:   base: 20003ff8
up_dumpstate:   size: 00000400
up_dumpstate:   used: 000002ac
up_registerdump: R0: 00000000 200138a4 2009b008 00000000 200137fc 00000000 20013924 00000000
up_registerdump: R8: 00000000 00000000 00000000 00000000 2001396c 20003f88 0e001c53 0e001c52
up_registerdump: xPSR: 69010000 BASEPRI: 000000a0 CONTROL: 00000000
```

Signed-off-by: Vidisha Thapa <thapa.v@samsung.com>