### PR TITLE
Add new IRQ and refactor debug logs during assertion and update TRAP tool accordingly 

### DIFF
--- a/os/arch/arm/src/armv7-m/up_assert.c
+++ b/os/arch/arm/src/armv7-m/up_assert.c
@@ -114,11 +114,12 @@
 #include "up_arch.h"
 #include "up_internal.h"
 #include "mpu.h"
+#include "nvic.h"
 
 bool abort_mode = false;
 extern uint32_t system_exception_location;
 extern uint32_t user_assert_location;
-
+extern int g_irq_nums[3];
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
@@ -250,95 +251,118 @@ static void up_dumpstate(void)
 {
 	struct tcb_s *rtcb = this_task();
 	uint32_t sp = up_getsp();
-	uint32_t ustackbase;
-	uint32_t ustacksize;
+	uint32_t stackbase = 0;
+	uint32_t stacksize = 0;
 #if CONFIG_ARCH_INTERRUPTSTACK > 3
-	uint32_t istackbase;
-	uint32_t istacksize;
+	uint32_t istackbase = 0;
+	uint32_t istacksize = 0;
 #endif
+	uint8_t irq_num;
 
-	/* Get the limits on the user stack memory */
+	/* Get the limits for each type of stack */
 
-	ustackbase = (uint32_t)rtcb->adj_stack_ptr;
-	ustacksize = (uint32_t)rtcb->adj_stack_size;
-
+	stackbase = (uint32_t)rtcb->adj_stack_ptr;
+	stacksize = (uint32_t)rtcb->adj_stack_size;
 #if CONFIG_ARCH_INTERRUPTSTACK > 3
-	/* Get the limits on the interrupt stack memory */
-
 	istackbase = (uint32_t)&g_intstackbase;
 	istacksize = (CONFIG_ARCH_INTERRUPTSTACK & ~3);
-
-	/* Show interrupt stack info */
-
-	lldbg("sp:     %08x\n", sp);
-	lldbg("IRQ stack:\n");
-	lldbg("  base: %08x\n", istackbase);
-	lldbg("  size: %08x\n", istacksize);
-#ifdef CONFIG_STACK_COLORATION
-	lldbg("  used: %08x\n", up_check_intstack());
 #endif
+	bool is_irq_assert = false;
+	bool is_sp_corrupt = false;
 
-	/* Does the current stack pointer lie within the interrupt
-	 * stack?
+	/* Check if the assert location is in user thread or IRQ handler.
+	 * If the irq_num is lesser than NVIC_IRQ_USAGEFAULT, then it is
+	 * a fault and not an irq.
 	 */
-
-	if (sp <= istackbase && sp > istackbase - istacksize) {
-		/* Yes.. dump the interrupt stack */
-
-		up_stackdump(sp, istackbase);
+	if (g_irq_nums[2] && (g_irq_nums[0] <= NVIC_IRQ_USAGEFAULT)) {
+		/* Assert in nested irq */
+		irq_num = 1;
+		is_irq_assert = true;
+		lldbg("Code asserted in nested IRQ state!\n");
+	} else if (g_irq_nums[1] && (g_irq_nums[0] > NVIC_IRQ_USAGEFAULT)) {
+		/* Assert in nested irq */
+		irq_num = 0;
+		is_irq_assert = true;
+		lldbg("Code asserted in nested IRQ state!\n");
+	} else if (g_irq_nums[1] && (g_irq_nums[0] <= NVIC_IRQ_USAGEFAULT)) {
+		/* Assert in irq */
+		irq_num = 1;
+		is_irq_assert = true;
+		lldbg("Code asserted in IRQ state!\n");
+	} else if (g_irq_nums[0] > NVIC_IRQ_USAGEFAULT) {
+		/* Assert in irq */
+		irq_num = 0;
+		is_irq_assert = true;
+		lldbg("Code asserted in IRQ state!\n");
+	} else {
+		/* Assert in user thread */
+		lldbg("Code asserted in normal thread!\n");
+		if (current_regs) {
+			/* If assert is in user thread, but current_regs is not NULL,
+			 * it means that assert happened due to a fault. So, we want to
+			 * reset the sp to the value just before the fault happened
+			 */
+			sp = current_regs[REG_R13];
+		}
 	}
 
-	/* Extract the user stack pointer if we are in an interrupt handler.
-	 * If we are not in an interrupt handler.  Then sp is the user stack
-	 * pointer (and the above range check should have failed).
-	 */
+	/* Print IRQ handler details if required */
 
-	if (current_regs) {
-		sp = current_regs[REG_R13];
-		lldbg("sp:     %08x\n", sp);
-	}
-
-	lldbg("User stack:\n");
-	lldbg("  base: %08x\n", ustackbase);
-	lldbg("  size: %08x\n", ustacksize);
-#ifdef CONFIG_STACK_COLORATION
-	lldbg("  used: %08x\n", up_check_tcbstack(rtcb));
+	if (is_irq_assert) {
+		lldbg("IRQ num: %d\n", g_irq_nums[irq_num]);
+		lldbg("IRQ handler: %08x \n", g_irqvector[g_irq_nums[irq_num]].handler);
+#ifdef CONFIG_DEBUG_IRQ_INFO
+		lldbg("IRQ name: %s \n", g_irqvector[g_irq_nums[irq_num]].irq_name);
 #endif
-
-	/* Dump the user stack if the stack pointer lies within the allocated user
-	 * stack memory.
-	 */
-
-	if (sp <= ustackbase && sp > ustackbase - ustacksize) {
-		up_stackdump(sp, ustackbase);
-	}
+#if CONFIG_ARCH_INTERRUPTSTACK > 3
+		if ((sp <= istackbase) && (sp > (istackbase - istacksize))) {
+			stackbase = istackbase;
+			stacksize = istacksize;
+			lldbg("Current SP is IRQ SP: %08x\n", sp);
+			lldbg("IRQ stack:\n");
+		} else {
+			is_sp_corrupt = true;
+		}
 #else
-
-	/* Show user stack info */
-
-	lldbg("sp:         %08x\n", sp);
-	lldbg("stack base: %08x\n", ustackbase);
-	lldbg("stack size: %08x\n", ustacksize);
-#ifdef CONFIG_STACK_COLORATION
-	lldbg("stack used: %08x\n", up_check_tcbstack(rtcb));
+		if ((sp <= stackbase) && (sp > (stackbase - stacksize))) {
+			lldbg("Current SP is User Thread SP: %08x\n", sp);
+			lldbg("User stack:\n");
+		} else {
+			is_sp_corrupt = true;
+		}
 #endif
+	} else if ((sp <= stackbase) && (sp > (stackbase - stacksize))) {
+		lldbg("Current SP is User Thread SP: %08x\n", sp);
+		lldbg("User stack:\n");
+	} else {
+		is_sp_corrupt = true;
+	}
 
-	/* Dump the user stack if the stack pointer lies within the allocated user
-	 * stack memory.
-	 */
 
-	if (sp > ustackbase || sp <= ustackbase - ustacksize) {
-		lldbg("ERROR: Stack pointer is not within the allocated stack\n");
-		lldbg("Proper task stack dump:\n");
-		up_stackdump(ustackbase - ustacksize + 1, ustackbase);
+	if (is_sp_corrupt) {
+		lldbg("ERROR: Stack pointer is not within any of the allocated stack\n");
 		lldbg("Wrong Stack pointer %08x: %08x %08x %08x %08x %08x %08x %08x %08x\n",
 		sp, *((uint32_t *)sp + 0), *((uint32_t *)sp + 1), *((uint32_t *)sp + 2), ((uint32_t *)sp + 3),
 		*((uint32_t *)sp + 4), ((uint32_t *)sp + 5), ((uint32_t *)sp + 6), ((uint32_t *)sp + 7));
-	} else {
-		up_stackdump(sp, ustackbase);
-	}
 
+		/* Since SP is corrupted, we dont know which stack was being used.
+		 * So, dump all the available stacks.
+		 */
+#if CONFIG_ARCH_INTERRUPTSTACK > 3
+		lldbg("IRQ stack dump:\n");
+		up_stackdump(istackbase - istacksize + 1, istackbase);
 #endif
+		lldbg("User thread stack dump:\n");
+		up_stackdump(stackbase - stacksize + 1, stackbase);
+	} else {
+		/* Dump the stack region which contains the current stack pointer */
+		lldbg("  base: %08x\n", stackbase);
+		lldbg("  size: %08x\n", stacksize);
+#ifdef CONFIG_STACK_COLORATION
+		lldbg("  used: %08x\n", up_check_assertstack((uintptr_t)(stackbase - stacksize), stacksize));
+#endif
+		up_stackdump(sp, stackbase);
+	}
 
 	/* Then dump the registers (if available) */
 
@@ -457,6 +481,7 @@ void up_assert(const uint8_t *filename, int lineno)
 #if defined(CONFIG_DEBUG_WORKQUEUE)
 #if defined(CONFIG_BUILD_FLAT) || (defined(CONFIG_BUILD_PROTECTED) && defined(__KERNEL__))
 	if (IS_HPWORK || IS_LPWORK) {
+		lldbg("Code asserted in workqueue!\n");
 		lldbg("Running work function is %x.\n", work_get_current());
 	}
 #endif

--- a/os/arch/arm/src/armv7-m/up_doirq.c
+++ b/os/arch/arm/src/armv7-m/up_doirq.c
@@ -76,6 +76,7 @@
 #ifdef CONFIG_ARCH_NESTED_INTERRUPT
 extern uint32_t g_nestlevel; /* Initial top of interrupt stack */
 #endif
+int g_irq_nums[3] = {0}; /* Array to store the last three interrupt numbers */
 /****************************************************************************
  * Private Data
  ****************************************************************************/
@@ -90,6 +91,11 @@ extern uint32_t g_nestlevel; /* Initial top of interrupt stack */
 
 uint32_t *up_doirq(int irq, uint32_t *regs)
 {
+	/* Store the last three interrupt numbers for reference during assert */
+	g_irq_nums[2] = g_irq_nums[1];
+	g_irq_nums[1] = g_irq_nums[0];
+	g_irq_nums[0] = irq;
+
 #ifdef CONFIG_ARCH_NESTED_INTERRUPT
 	irqstate_t flags;
 #endif
@@ -179,6 +185,11 @@ uint32_t *up_doirq(int irq, uint32_t *regs)
 	current_regs = savestate;
 #endif
 #endif
+	/* Reset the interrupt number values */
+	g_irq_nums[0] = g_irq_nums[1];
+	g_irq_nums[1] = g_irq_nums[2];
+	g_irq_nums[2] = 0;
+
 	board_led_off(LED_INIRQ);
 	return regs;
 }

--- a/os/arch/arm/src/armv8-m/up_doirq.c
+++ b/os/arch/arm/src/armv8-m/up_doirq.c
@@ -76,6 +76,7 @@
 #ifdef CONFIG_ARCH_NESTED_INTERRUPT
 extern uint32_t g_nestlevel; /* Initial top of interrupt stack */
 #endif
+int g_irq_nums[3] = {0}; /* Array to store the last three interrupt numbers */
 /****************************************************************************
  * Private Data
  ****************************************************************************/
@@ -90,6 +91,11 @@ extern uint32_t g_nestlevel; /* Initial top of interrupt stack */
 
 uint32_t *up_doirq(int irq, uint32_t *regs)
 {
+	/* Store the last three interrupt numbers for reference during assert */
+	g_irq_nums[2] = g_irq_nums[1];
+	g_irq_nums[1] = g_irq_nums[0];
+	g_irq_nums[0] = irq;
+
 #ifdef CONFIG_ARCH_NESTED_INTERRUPT
 	irqstate_t flags;
 #endif
@@ -179,6 +185,11 @@ uint32_t *up_doirq(int irq, uint32_t *regs)
 	current_regs = savestate;
 #endif
 #endif
+	/* Reset the interrupt number values */
+	g_irq_nums[0] = g_irq_nums[1];
+	g_irq_nums[1] = g_irq_nums[2];
+	g_irq_nums[2] = 0;
+
 	board_led_off(LED_INIRQ);
 	return regs;
 }

--- a/os/arch/arm/src/common/up_checkstack.c
+++ b/os/arch/arm/src/common/up_checkstack.c
@@ -191,6 +191,11 @@ size_t up_check_stack(void)
 	return up_check_tcbstack(this_task());
 }
 
+size_t up_check_assertstack(uintptr_t alloc, size_t size)
+{
+	return do_stackcheck((uintptr_t)alloc, size);
+}
+
 ssize_t up_check_stack_remain(void)
 {
 	return up_check_tcbstack_remain(this_task());

--- a/os/include/tinyara/arch.h
+++ b/os/include/tinyara/arch.h
@@ -1867,6 +1867,7 @@ struct tcb_s;
 size_t up_check_tcbstack(FAR struct tcb_s *tcb);
 ssize_t up_check_tcbstack_remain(FAR struct tcb_s *tcb);
 size_t up_check_stack(void);
+size_t up_check_assertstack(uintptr_t alloc, size_t size);
 ssize_t up_check_stack_remain(void);
 #if CONFIG_ARCH_INTERRUPTSTACK > 3
 size_t up_check_intstack(void);

--- a/tools/debug/debugsymbolviewer.py
+++ b/tools/debug/debugsymbolviewer.py
@@ -228,6 +228,13 @@ def print_stack(log_file):
 						continue
 				continue
 
+			if 'stack:' in line:
+				word = line.split(':')
+				print(word[1])
+			if 'stack dump:' in line:
+				word = line.split(':')
+				print(word[1])
+
 			# Read the stack contents of aborted stack and check for valid addresses
 			if 'up_stackdump:' in line:
 				word = line.split(':')
@@ -317,6 +324,19 @@ def print_running_work_function(log_file):
                             node = int(wf[:-2], 16)
                             print_symbol(0x00000000, node, 0)
                             print_symbol(0x00000000, node, 1)
+
+# Function to Parse the input log file (which contains interrupt handler data) and to print its owner
+def print_interrupt_handler_data(log_file):
+	# Parse the contents based on tokens in log file.
+	with open(log_file) as searchfile:
+		for line in searchfile:
+			if 'IRQ handler' in line:
+                            word = line.split(' ')
+                            node = int(word[-1], 16)
+                            print_symbol(0x00000000, node, 0)
+                            print_symbol(0x00000000, node, 1)
+
+# Function to Parse the input log file (which contains current running work function) and to print its owner
 #Execution starts here
 if (__name__ == '__main__'):
 
@@ -353,3 +373,6 @@ if (__name__ == '__main__'):
         # 3 specifies to print the running work function information
 	elif (addr_type == 3):
 		print_running_work_function(log_file)
+        # 4 specifies to print the interrupt handler information (if any)
+	elif (addr_type == 4):
+		print_interrupt_handler_data(log_file)


### PR DESCRIPTION
This patch adds debug logs for IRQ during assert.

Sample logs are as follows:
up_hardfault: PANIC!!! Hard fault: 40000000
up_assert: Assertion failed at file:armv8-m/up_hardfault.c line: 204 task: tash
up_dumpstate: sp:     0218562c
up_dumpstate: Code asserted in nested IRQ state!
up_dumpstate: IRQ num: 4
up_dumpstate: IRQ handler: 0e008fd5
up_dumpstate: stack base: 02185878
up_dumpstate: stack size: 00000fec
up_dumpstate: stack used: 00000334
up_stackdump: 02185620: xxxxxxxx xxxxxxxx xxxxxxxx 000000cc 1007222c 00000001 00000330 00000018
up_stackdump: 02185640: 0e006a1b 00000003 0e00715d 0e00679d 0000002c 1002c1ec 1002c1ec 1002a9d0
up_stackdump: 02185660: 00000003 0218569c 0218570c 00000001 00000330 00000018 0e00940d 0e0093e5
up_stackdump: 02185680: 10012169 1002c1ec 1002a9d0 00000004 0218570c 00000000 10011e4b 021856f0
up_stackdump: 021856a0: 000000e0 1002c1ec 1002a9d0 00000004 0218570c 00000000 00000001 00000330
up_stackdump: 021856c0: 00000018 ffffffb0 02185740 00000000 00000004 0218570c 00000000 00000000
up_stackdump: 021856e0: 00000000 10012169 0e008fd8 41000204 10011e4b 00000004 00000000 00000022
up_stackdump: 02185700: 0217f348 0217f348 10011e4b 02185760 000000e0 00000004 00000000 00000022
up_stackdump: 02185720: 0217f348 0217f348 00000001 00000330 00000018 ffffffbc 00000000 02184890
up_stackdump: 02185740: 00000000 00000000 00000000 02100028 10026fa5 0220040b 02205612 61000000
up_stackdump: 02185760: 00000002 02100028 00000000 021857a8 00000000 022021cf 021857a8 00000001
up_stackdump: 02185780: 00000000 021858a8 00000001 00000000 00000001 00000000 00000000 00000000
up_stackdump: 021857a0: 00000000 02202829 021858a0 00000000 00000000 00000000 00000000 ffffffbc
up_stackdump: 021857c0: 00000000 02184890 00000001 100287a0 00000001 00000000 0e001eb3 02202679
up_stackdump: 021857e0: 0220030a 21000000 021858a0 02202679 02185820 02185848 000000e0 00000000
up_stackdump: 02185800: 0217fcd4 00000008 00000000 00000008 00000001 00000000 00000009 00000008
up_stackdump: 02185820: 00000006 00000000 00000007 00000003 0217fcd4 021858a0 022591cc 00000000
up_stackdump: 02185840: 00000000 00000000 00000000 022028a3 0218587c 02202831 00000001 0218587c
up_stackdump: 02185860: 00000000 0220043d 0218587c 0e001c83 00000000 00000000 deadbeef 02185884
up_registerdump: R0: 00000004 0218570c 00000000 00000000 1002c1ec 1002a9d0 00000004 0218570c
up_registerdump: R8: 00000000 00000001 00000330 00000018 00000000 021856f0 10012169 0e008fd8
up_registerdump: xPSR: 41000204 BASEPRI: 000000e0 CONTROL: 00000001
up_registerdump: EXC_RETURN: ffffffb0
