### PR TITLE
libc/math : Add float_t data type

### DIFF
--- a/os/include/tinyara/math.h
+++ b/os/include/tinyara/math.h
@@ -172,6 +172,17 @@ static __inline unsigned long long __DOUBLE_BITS(double __f)
 #define M_2_SQRTPI 1.1283791670955125738961589031215452
 
 /****************************************************************************
+ * Public Type Definitions
+ ****************************************************************************/
+typedef float float_t;
+
+#ifdef CONFIG_HAVE_DOUBLE
+typedef double double_t;
+#else
+typedef float double_t;
+#endif
+
+/****************************************************************************
  * Public Function Prototypes
  ****************************************************************************/
 


### PR DESCRIPTION
Include type definition of float math.h doesn't include type definition of float_t, so add it.
It is required as per posix standard.