### PR TITLE
arch/arm/src: Update assert code to accomodate extra arguments for

### DIFF
--- a/os/arch/arm/src/armv7-m/up_assert.c
+++ b/os/arch/arm/src/armv7-m/up_assert.c
@@ -137,6 +137,11 @@ extern int g_irq_nums[3];
 #define IS_FAULT_IN_USER_SPACE(asserted_location)   (is_kernel_space((void *)asserted_location) == false)
 
 /****************************************************************************
+ * Public Variables
+ ****************************************************************************/
+char assert_info_str[CONFIG_STDIO_BUFFER_SIZE] = {'\0', };
+
+/****************************************************************************
  * Private Data
  ****************************************************************************/
 
@@ -477,6 +482,11 @@ void up_assert(const uint8_t *filename, int lineno)
 #else
 	lldbg("Assertion failed at file:%s line: %d\n", filename, lineno);
 #endif
+
+	/* Print the extra arguments (if any) from ASSERT_INFO macro */
+	if (assert_info_str[0]) {
+		lldbg("%s\n", assert_info_str);
+	}
 
 #if defined(CONFIG_DEBUG_WORKQUEUE)
 #if defined(CONFIG_BUILD_FLAT) || (defined(CONFIG_BUILD_PROTECTED) && defined(__KERNEL__))

--- a/os/arch/arm/src/armv7-r/arm_assert.c
+++ b/os/arch/arm/src/armv7-r/arm_assert.c
@@ -123,6 +123,11 @@ static bool recursive_abort = false;
 bool g_upassert = false;
 
 /****************************************************************************
+ * Public Variables
+ ****************************************************************************/
+char assert_info_str[CONFIG_STDIO_BUFFER_SIZE] = {'\0', };
+
+/****************************************************************************
  * Private Data
  ****************************************************************************/
 
@@ -920,6 +925,11 @@ void up_assert(const uint8_t *filename, int lineno)
 #else
 	lldbg("Assertion failed at file:%s line: %d\n", filename, lineno);
 #endif
+
+	/* Print the extra arguments (if any) from ASSERT_INFO macro */
+	if (assert_info_str[0]) {
+		lldbg("%s\n", assert_info_str);
+	}
 
 #if defined(CONFIG_DEBUG_WORKQUEUE)
 #if defined(CONFIG_BUILD_FLAT) || (defined(CONFIG_BUILD_PROTECTED) && defined(__KERNEL__))

--- a/os/arch/arm/src/armv8-m/up_assert.c
+++ b/os/arch/arm/src/armv8-m/up_assert.c
@@ -148,6 +148,11 @@ extern int g_irq_nums[3];
 #define IS_FAULT_IN_USER_SPACE(asserted_location)   (is_kernel_space((void *)asserted_location) == false)
 
 /****************************************************************************
+ * Public Variables
+ ****************************************************************************/
+char assert_info_str[CONFIG_STDIO_BUFFER_SIZE] = {'\0', };
+
+/****************************************************************************
  * Private Data
  ****************************************************************************/
 
@@ -511,6 +516,10 @@ void up_assert(const uint8_t *filename, int lineno)
 	lldbg("Assertion failed at file:%s line: %d\n", filename, lineno);
 #endif
 
+	/* Print the extra arguments (if any) from ASSERT_INFO macro */
+	if (assert_info_str[0]) {
+		lldbg("%s\n", assert_info_str);
+	}
 #if defined(CONFIG_DEBUG_WORKQUEUE)
 #if defined(CONFIG_BUILD_FLAT) || (defined(CONFIG_BUILD_PROTECTED) && defined(__KERNEL__))
 	if (IS_HPWORK || IS_LPWORK) {

--- a/os/arch/xtensa/src/xtensa/xtensa_assert.c
+++ b/os/arch/xtensa/src/xtensa/xtensa_assert.c
@@ -82,6 +82,11 @@
 #endif
 
 /****************************************************************************
+ * Public Variables
+ ****************************************************************************/
+char assert_info_str[CONFIG_STDIO_BUFFER_SIZE] = {'\0', };
+
+/****************************************************************************
  * Private Functions
  ****************************************************************************/
 
@@ -176,6 +181,11 @@ void up_assert(const uint8_t *filename, int lineno)
 	lldbg("Assertion failed at file:%s line: %d\n", filename, lineno);
 #endif
 #endif
+
+	/* Print the extra arguments (if any) from ASSERT_INFO macro */
+	if (assert_info_str[0]) {
+		lldbg("%s\n", assert_info_str);
+	}
 
 	xtensa_assert(EXIT_FAILURE);
 }

--- a/os/include/assert.h
+++ b/os/include/assert.h
@@ -68,8 +68,10 @@
  ****************************************************************************/
 
 #include <tinyara/compiler.h>
+#include <tinyara/config.h>
 #include <stdint.h>
 
+extern char assert_info_str[CONFIG_STDIO_BUFFER_SIZE];
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
@@ -83,6 +85,12 @@
 #undef PANIC					/* Unconditional abort */
 
 #ifdef CONFIG_HAVE_FILENAME
+#define ASSERT_INFO(f, fmt, ...) \
+	{ if (!(f))	{ \
+			  snprintf(assert_info_str, CONFIG_STDIO_BUFFER_SIZE, fmt, ##__VA_ARGS__); \
+			  up_assert((const uint8_t *)__FILE__, (int)__LINE__); \
+		} \
+	}
 
 #define ASSERT(f) \
 	{ if (!(f)) up_assert((const uint8_t *)__FILE__, (int)__LINE__); }
@@ -114,6 +122,12 @@
 
 #else
 
+#define ASSERT_INFO(f, fmt, ...) \
+	{ if (!(f))	{ \
+			  snprintf(assert_info_str, CONFIG_STDIO_BUFFER_SIZE, fmt, ##__VA_ARGS__); \
+			  up_assert(); \
+			} \
+	}
 /**
  * @brief Assert if the condition is not true
  *

--- a/os/kernel/semaphore/sem_post.c
+++ b/os/kernel/semaphore/sem_post.c
@@ -62,6 +62,7 @@
 #include <sched.h>
 #include <tinyara/arch.h>
 #include <tinyara/sched.h>
+#include <tinyara/mm/mm.h>
 
 #include "sched/sched.h"
 #include "semaphore/semaphore.h"
@@ -199,6 +200,8 @@ int sem_post(FAR sem_t *sem)
 {
 	irqstate_t saved_state;
 	int ret = ERROR;
+	size_t caller_retaddr = 0;
+	ARCH_GET_RET_ADDRESS(caller_retaddr);
 
 	/* Make sure we were supplied with a valid semaphore. */
 
@@ -211,6 +214,7 @@ int sem_post(FAR sem_t *sem)
 		saved_state = irqsave();
 
 		/* Perform the semaphore unlock operation. */
+		ASSERT_INFO(sem->semcount < SEM_VALUE_MAX, "sem = 0x%x, caller address = 0x%x", sem, caller_retaddr);
 		ASSERT(sem->semcount < SEM_VALUE_MAX);
 		sem_releaseholder(sem, this_task());
 		sem->semcount++;


### PR DESCRIPTION
debugging

THis patch updates the up_assert() API with an extra argument to print information useful for debugging.

Sample assert logs are as below:

TASH>>binary_manager_load_binary: Load success! [Name: app2] [Version: 190412] [Partition: A] [Compressed Binary] Test will be finished
nup_assert: Assertion failed at file:wifiapp.c line: 128 task: app2 assertInfo = TESTSTRING
up_dumpstate: sp:     021837b4
up_dumpstate: Nested IRQ stack:
up_dumpstate:   base: 1002a9b0
up_dumpstate:   size: 00000200
up_dumpstate:   used: 00000000
up_dumpstate: stack base: 02183860
up_dumpstate: stack size: 00001fe4
up_dumpstate: stack used: 00000278
up_stackdump: 021837a0: xxxxxxxx xxxxxxxx xxxxxxxx xxxxxxxx xxxxxxxx 00000080 100718ac 02257a88
up_stackdump: 021837c0: 02200343 022579cc 022579e4 02257a04 10011e4b 02183828 000000e0 02200343
up_stackdump: 021837e0: 0218380c 02200343 022579cc 022579e4 02257a04 00000000 00000000 00000000
up_stackdump: 02183800: 00000000 0e041b73 00000080 00000080 02200325 02200325 10011ecf 02200343
up_stackdump: 02183820: 022579cc 022579e4 021ff9bf 00000080 02257a88 02200325 02183864 021ff959
up_stackdump: 02183840: 00000001 02183864 00000000 02200471 02183864 0e001c83 00000000 00000000

Signed-off-by: Vidisha Thapa <thapa.v@samsung.com>