### PR TITLE
os/mm: Add caller address to mm alloc fail API

### DIFF
--- a/os/drivers/memory/mminfo.c
+++ b/os/drivers/memory/mminfo.c
@@ -144,7 +144,11 @@ static int mminfo_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
 #ifdef CONFIG_APP_BINARY_SEPARATION
 	case MMINFOIOC_MNG_ALLOCFAIL:
 		/* There is a single heap for user. So start and end indexes of heap are always 0. */
-		mm_manage_alloc_fail(BASE_HEAP, 0, 0, (size_t)arg, USER_HEAP);
+		mm_manage_alloc_fail(BASE_HEAP, 0, 0, ((struct mm_alloc_fail_s *)arg)->size, USER_HEAP
+#if defined(CONFIG_DEBUG_MM_HEAPINFO)
+				, ((struct mm_alloc_fail_s *)arg)->caller
+#endif
+				);
 		break;
 #endif
 	default:

--- a/os/include/debug.h
+++ b/os/include/debug.h
@@ -1315,7 +1315,7 @@ int get_errno(void);
 #define mllvdbg     (void)
 #endif
 
-#if defined(CONFIG_MM_ASSERT_ON_FAIL) && defined(CONFIG_APP_BINARY_SEPARATION) && defined (__KERNEL__)
+#if defined(CONFIG_MM_ASSERT_ON_FAIL) && (defined(CONFIG_BUILD_FLAT) || (defined(CONFIG_APP_BINARY_SEPARATION) && defined (__KERNEL__)))
 #define mfdbg lldbg
 #else
 #define mfdbg dbg

--- a/os/include/tinyara/mm/mm.h
+++ b/os/include/tinyara/mm/mm.h
@@ -342,8 +342,8 @@ struct heapinfo_group_s {
 	int stack_size;
 	int heap_size;
 };
-#endif
 
+#endif
 #ifdef CONFIG_HEAPINFO_USER_GROUP
 extern int heapinfo_max_group;
 extern struct heapinfo_group_s heapinfo_group[HEAPINFO_USER_GROUP_NUM];
@@ -351,6 +351,12 @@ extern struct heapinfo_group_info_s group_info[HEAPINFO_THREAD_NUM];
 #endif
 
 #endif
+
+struct mm_alloc_fail_s {
+	uint32_t size;
+	uint32_t caller;
+};
+
 /* This describes one heap (possibly with multiple regions) */
 
 struct mm_heap_s {
@@ -729,6 +735,16 @@ int mm_check_heap_corruption(struct mm_heap_s *heap);
 
 /* Function to manage the memory allocation failure case. */
 #if defined(CONFIG_APP_BINARY_SEPARATION) && !defined(__KERNEL__)
+#ifdef CONFIG_DEBUG_MM_HEAPINFO
+void mm_ioctl_alloc_fail(size_t size, uint32_t caller);
+#define mm_manage_alloc_fail(h, b, e, s, t, c) 	do { \
+							(void)h; \
+							(void)b; \
+							(void)e; \
+							(void)t; \
+							mm_ioctl_alloc_fail(s, c); \
+						} while (0)
+#else
 void mm_ioctl_alloc_fail(size_t size);
 #define mm_manage_alloc_fail(h, b, e, s, t) 	do { \
 							(void)h; \
@@ -737,8 +753,13 @@ void mm_ioctl_alloc_fail(size_t size);
 							(void)t; \
 							mm_ioctl_alloc_fail(s); \
 						} while (0)
+#endif
 #else
-void mm_manage_alloc_fail(struct mm_heap_s *heap, int startidx, int endidx, size_t size, int heap_type);
+void mm_manage_alloc_fail(struct mm_heap_s *heap, int startidx, int endidx, size_t size, int heap_type
+#ifdef CONFIG_DEBUG_MM_HEAPINFO
+		, uint32_t caller
+#endif
+		);
 #endif
 
 #if CONFIG_KMM_NHEAPS > 1

--- a/os/mm/kmm_heap/kmm_calloc.c
+++ b/os/mm/kmm_heap/kmm_calloc.c
@@ -74,17 +74,21 @@ static void *kheap_calloc(size_t n, size_t elem_size, size_t retaddr)
 	struct mm_heap_s *kheap = kmm_get_baseheap();
 
 	for (heap_idx = HEAP_START_IDX; heap_idx <= HEAP_END_IDX; heap_idx++) {
+		ret = mm_calloc(&kheap[heap_idx], n, elem_size
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
-		ret = mm_calloc(&kheap[heap_idx], n, elem_size, retaddr);
-#else
-		ret = mm_calloc(&kheap[heap_idx], n, elem_size);
+				, retaddr
 #endif
+				);
 		if (ret != NULL) {
 			return ret;
 		}
 	}
 
-	mm_manage_alloc_fail(kheap, HEAP_START_IDX, HEAP_END_IDX, n * elem_size, KERNEL_HEAP);
+	mm_manage_alloc_fail(kheap, HEAP_START_IDX, HEAP_END_IDX, n * elem_size, KERNEL_HEAP
+#ifdef CONFIG_DEBUG_MM_HEAPINFO
+			, retaddr
+#endif
+			);
 	return NULL;
 }
 
@@ -123,19 +127,19 @@ void *kmm_calloc_at(int heap_index, size_t n, size_t elem_size)
 	}
 
 	kheap = kmm_get_baseheap();
+	ret = mm_calloc(&kheap[heap_index], n, elem_size
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
-	ret = mm_calloc(&kheap[heap_index], n, elem_size, caller_retaddr);
-	if (ret == NULL) {
-		mm_manage_alloc_fail(&kheap[heap_index], heap_index, heap_index, n * elem_size, KERNEL_HEAP);
-	}
-	return ret;
-#else
-	ret = mm_calloc(&kheap[heap_index], n, elem_size);
-	if (ret == NULL) {
-		mm_manage_alloc_fail(&kheap[heap_index], heap_index, heap_index, n * elem_size, KERNEL_HEAP);
-	}
-	return ret;
+			, caller_retaddr
 #endif
+			);
+	if (ret == NULL) {
+		mm_manage_alloc_fail(&kheap[heap_index], heap_index, heap_index, n * elem_size, KERNEL_HEAP
+#ifdef CONFIG_DEBUG_MM_HEAPINFO
+				, caller_retaddr
+#endif
+				);
+	}
+	return ret;
 }
 #endif
 

--- a/os/mm/kmm_heap/kmm_malloc.c
+++ b/os/mm/kmm_heap/kmm_malloc.c
@@ -87,17 +87,21 @@ static void *kheap_malloc(size_t size, size_t caller_retaddr)
 	struct mm_heap_s *kheap = kmm_get_baseheap();
 
 	for (heap_idx = HEAP_START_IDX; heap_idx <= HEAP_END_IDX; heap_idx++) {
+		ret = mm_malloc(&kheap[heap_idx], size
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
-		ret = mm_malloc(&kheap[heap_idx], size, caller_retaddr);
-#else
-		ret = mm_malloc(&kheap[heap_idx], size);
+				, caller_retaddr
 #endif
+				);
 		if (ret != NULL) {
 			return ret;
 		}
 	}
 
-	mm_manage_alloc_fail(kheap, HEAP_START_IDX, HEAP_END_IDX, size, KERNEL_HEAP);
+	mm_manage_alloc_fail(kheap, HEAP_START_IDX, HEAP_END_IDX, size, KERNEL_HEAP
+#ifdef CONFIG_DEBUG_MM_HEAPINFO
+			, caller_retaddr
+#endif
+			);
 	return NULL;
 }
 
@@ -140,13 +144,17 @@ void *kmm_malloc_at(int heap_index, size_t size)
 	}
 
 	kheap = kmm_get_baseheap();
+	ret = mm_malloc(&kheap[heap_index], size
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
-	ret = mm_malloc(&kheap[heap_index], size, caller_retaddr);
-#else
-	ret = mm_malloc(&kheap[heap_index], size);
+			, caller_retaddr
 #endif
+			);
 	if (ret == NULL) {
-		mm_manage_alloc_fail(&kheap[heap_index], heap_index, heap_index, size, KERNEL_HEAP);
+		mm_manage_alloc_fail(&kheap[heap_index], heap_index, heap_index, size, KERNEL_HEAP
+#ifdef CONFIG_DEBUG_MM_HEAPINFO
+				, caller_retaddr
+#endif
+				);
 	}
 	return ret;
 }

--- a/os/mm/kmm_heap/kmm_memalign.c
+++ b/os/mm/kmm_heap/kmm_memalign.c
@@ -106,13 +106,17 @@ void *kmm_memalign_at(int heap_index, size_t alignment, size_t size)
 	}
 
 	kheap = kmm_get_baseheap();
+	ret = mm_memalign(&kheap[heap_index], alignment, size
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
-	ret = mm_memalign(&kheap[heap_index], alignment, size, caller_retaddr);
-#else
-	ret = mm_memalign(&kheap[heap_index], alignment, size);
+			, caller_retaddr
 #endif
+			);
 	if (ret == NULL) {
-		mm_manage_alloc_fail(&kheap[heap_index], heap_index, heap_index, size, KERNEL_HEAP);
+		mm_manage_alloc_fail(&kheap[heap_index], heap_index, heap_index, size, KERNEL_HEAP
+#ifdef CONFIG_DEBUG_MM_HEAPINFO
+				, caller_retaddr
+#endif
+				);
 	}
 	return ret;
 }
@@ -147,17 +151,21 @@ FAR void *kmm_memalign(size_t alignment, size_t size)
 #endif
 	struct mm_heap_s *kheap = kmm_get_baseheap();
 	for (kheap_idx = HEAP_START_IDX; kheap_idx <= HEAP_END_IDX; kheap_idx++) {
+		ret = mm_memalign(&kheap[kheap_idx], alignment, size
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
-		ret = mm_memalign(&kheap[kheap_idx], alignment, size, caller_retaddr);
-#else
-		ret = mm_memalign(&kheap[kheap_idx], alignment, size);
+				, caller_retaddr
 #endif
+				);
 		if (ret != NULL) {
 			return ret;
 		}
 	}
 
-	mm_manage_alloc_fail(kheap, HEAP_START_IDX, HEAP_END_IDX, size, KERNEL_HEAP);
+	mm_manage_alloc_fail(kheap, HEAP_START_IDX, HEAP_END_IDX, size, KERNEL_HEAP
+#ifdef CONFIG_DEBUG_MM_HEAPINFO
+			, caller_retaddr
+#endif
+			);
 	return NULL;
 }
 

--- a/os/mm/kmm_heap/kmm_realloc.c
+++ b/os/mm/kmm_heap/kmm_realloc.c
@@ -105,13 +105,17 @@ void *kmm_realloc_at(int heap_index, void *oldmem, size_t size)
 		return NULL;
 	}
 
+	ret = mm_realloc(&kheap[heap_index], oldmem, size
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
-	ret = mm_realloc(&kheap[heap_index], oldmem, size, caller_retaddr);
-#else
-	ret = mm_realloc(&kheap[heap_index], oldmem, size);
+			, caller_retaddr
 #endif
+			);
 	if (ret == NULL) {
-		mm_manage_alloc_fail(&kheap[heap_index], heap_index, heap_index, size, KERNEL_HEAP);
+		mm_manage_alloc_fail(&kheap[heap_index], heap_index, heap_index, size, KERNEL_HEAP
+#ifdef CONFIG_DEBUG_MM_HEAPINFO
+				, caller_retaddr
+#endif
+				);
 	}
 	return ret;
 }
@@ -160,18 +164,22 @@ FAR void *kmm_realloc(FAR void *oldmem, size_t newsize)
 	/* Try to mm_malloc to another heap. */
 	kheap_new = kmm_get_baseheap();
 	for (kheap_idx = HEAP_START_IDX; kheap_idx <= HEAP_END_IDX; kheap_idx++) {
+		ret = mm_malloc(&kheap_new[kheap_idx], newsize
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
-		ret = mm_malloc(&kheap_new[kheap_idx], newsize, caller_retaddr);
-#else
-		ret = mm_malloc(&kheap_new[kheap_idx], newsize);
+				, caller_retaddr
 #endif
+				);
 		if (ret != NULL) {
 			kmm_free(oldmem);
 			return ret;
 		}
 	}
 
-	mm_manage_alloc_fail(kheap_new, HEAP_START_IDX, HEAP_END_IDX, newsize, KERNEL_HEAP);
+	mm_manage_alloc_fail(kheap_new, HEAP_START_IDX, HEAP_END_IDX, newsize, KERNEL_HEAP
+#ifdef CONFIG_DEBUG_MM_HEAPINFO
+			, caller_retaddr
+#endif
+			);
 	return NULL;
 }
 

--- a/os/mm/kmm_heap/kmm_zalloc.c
+++ b/os/mm/kmm_heap/kmm_zalloc.c
@@ -99,13 +99,17 @@ void *kmm_zalloc_at(int heap_index, size_t size)
 	}
 
 	kheap = kmm_get_baseheap();
+	ret = mm_zalloc(&kheap[heap_index], size
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
-	ret = mm_zalloc(&kheap[heap_index], size, caller_retaddr);
-#else
-	ret = mm_zalloc(&kheap[heap_index], size);
+			, caller_retaddr
 #endif
+			);
 	if (ret == NULL) {
-		mm_manage_alloc_fail(&kheap[heap_index], heap_index, heap_index, size, KERNEL_HEAP);
+		mm_manage_alloc_fail(&kheap[heap_index], heap_index, heap_index, size, KERNEL_HEAP
+#ifdef CONFIG_DEBUG_MM_HEAPINFO
+				, caller_retaddr
+#endif
+				);
 	}
 	return ret;
 }
@@ -140,16 +144,20 @@ FAR void *kmm_zalloc(size_t size)
 	struct mm_heap_s *kheap = kmm_get_baseheap();
 
 	for (kheap_idx = HEAP_START_IDX; kheap_idx <= HEAP_END_IDX; kheap_idx++) {
+		ret = mm_zalloc(&kheap[kheap_idx], size
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
-		ret = mm_zalloc(&kheap[kheap_idx], size, caller_retaddr);
-#else
-		ret = mm_zalloc(&kheap[kheap_idx], size);
+				, caller_retaddr
 #endif
+				);
 		if (ret != NULL) {
 			return ret;
 		}
 	}
-	mm_manage_alloc_fail(kheap, HEAP_START_IDX, HEAP_END_IDX, size, KERNEL_HEAP);
+	mm_manage_alloc_fail(kheap, HEAP_START_IDX, HEAP_END_IDX, size, KERNEL_HEAP
+#ifdef CONFIG_DEBUG_MM_HEAPINFO
+			, caller_retaddr
+#endif
+			);
 	return NULL;
 }
 

--- a/os/mm/umm_heap/umm_calloc.c
+++ b/os/mm/umm_heap/umm_calloc.c
@@ -96,13 +96,17 @@ void *calloc_at(int heap_index, size_t n, size_t elem_size)
 	if (n == 0 || elem_size == 0) {
 		return NULL;
 	}
+	ret = mm_calloc(&BASE_HEAP[heap_index], n, elem_size
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
-	ret = mm_calloc(&BASE_HEAP[heap_index], n, elem_size, caller_retaddr);
-#else
-	ret = mm_calloc(&BASE_HEAP[heap_index], n, elem_size);
+			, caller_retaddr
 #endif
+			);
 	if (ret == NULL) {
-		mm_manage_alloc_fail(&BASE_HEAP[heap_index], heap_index, heap_index, n * elem_size, USER_HEAP);
+		mm_manage_alloc_fail(&BASE_HEAP[heap_index], heap_index, heap_index, n * elem_size, USER_HEAP
+#ifdef CONFIG_DEBUG_MM_HEAPINFO
+				, caller_retaddr
+#endif
+				);
 	}
 	return ret;
 }
@@ -130,16 +134,20 @@ static void *heap_calloc(size_t n, size_t elem_size, int s, int e, size_t caller
 	void *ret;
 
 	for (heap_idx = s; heap_idx <= e; heap_idx++) {
+		ret = mm_calloc(&BASE_HEAP[heap_idx], n, elem_size
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
-		ret = mm_calloc(&BASE_HEAP[heap_idx], n, elem_size, caller_retaddr);
-#else
-		ret = mm_calloc(&BASE_HEAP[heap_idx], n, elem_size);
+				, caller_retaddr
 #endif
+				);
 		if (ret != NULL) {
 			return ret;
 		}
 	}
-	mm_manage_alloc_fail(BASE_HEAP, s, e, n * elem_size, USER_HEAP);
+	mm_manage_alloc_fail(BASE_HEAP, s, e, n * elem_size, USER_HEAP
+#ifdef CONFIG_DEBUG_MM_HEAPINFO
+			, caller_retaddr
+#endif
+			);
 	return NULL;
 }
 #endif
@@ -167,13 +175,17 @@ FAR void *calloc(size_t n, size_t elem_size)
 
 #ifdef CONFIG_APP_BINARY_SEPARATION
 	/* User supports a single heap on app separation */
+	ret = mm_calloc(BASE_HEAP, n, elem_size
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
-	ret = mm_calloc(BASE_HEAP, n, elem_size, caller_retaddr);
-#else
-	ret = mm_calloc(BASE_HEAP, n, elem_size);
+			, caller_retaddr
 #endif
+			);
 	if (ret == NULL) {
-		mm_manage_alloc_fail(BASE_HEAP, HEAP_START_IDX, HEAP_END_IDX, n * elem_size, USER_HEAP);
+		mm_manage_alloc_fail(BASE_HEAP, HEAP_START_IDX, HEAP_END_IDX, n * elem_size, USER_HEAP
+#ifdef CONFIG_DEBUG_MM_HEAPINFO
+				, caller_retaddr
+#endif
+				);
 	}
 
 #else /* CONFIG_APP_BINARY_SEPARATION */

--- a/os/mm/umm_heap/umm_malloc.c
+++ b/os/mm/umm_heap/umm_malloc.c
@@ -117,13 +117,17 @@ void *malloc_at(int heap_index, size_t size)
 	if (size == 0) {
 		return NULL;
 	}
+	ret = mm_malloc(&BASE_HEAP[heap_index], size
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
-	ret = mm_malloc(&BASE_HEAP[heap_index], size, caller_retaddr);
-#else
-	ret = mm_malloc(&BASE_HEAP[heap_index], size);
+			, caller_retaddr
 #endif
+			);
 	if (ret == NULL) {
-		mm_manage_alloc_fail(&BASE_HEAP[heap_index], heap_index, heap_index, size, USER_HEAP);
+		mm_manage_alloc_fail(&BASE_HEAP[heap_index], heap_index, heap_index, size, USER_HEAP
+#ifdef CONFIG_DEBUG_MM_HEAPINFO
+				, caller_retaddr
+#endif
+				);
 	}
 	return ret;
 }
@@ -151,17 +155,21 @@ static void *heap_malloc(size_t size, int s, int e, size_t caller_retaddr)
 	void *ret;
 
 	for (heap_idx = s; heap_idx <= e; heap_idx++) {
+		ret = mm_malloc(&BASE_HEAP[heap_idx], size
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
-		ret = mm_malloc(&BASE_HEAP[heap_idx], size, caller_retaddr);
-#else
-		ret = mm_malloc(&BASE_HEAP[heap_idx], size);
+				, caller_retaddr
 #endif
+				);
 		if (ret != NULL) {
 			return ret;
 		}
 	}
 
-	mm_manage_alloc_fail(BASE_HEAP, s, e, size, USER_HEAP);
+	mm_manage_alloc_fail(BASE_HEAP, s, e, size, USER_HEAP
+#ifdef CONFIG_DEBUG_MM_HEAPINFO
+			, caller_retaddr
+#endif
+			);
 	return NULL;
 }
 #endif
@@ -224,13 +232,17 @@ FAR void *malloc(size_t size)
 
 #ifdef CONFIG_APP_BINARY_SEPARATION
 	/* User supports a single heap on app separation */
+	ret = mm_malloc(BASE_HEAP, size
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
-	ret = mm_malloc(BASE_HEAP, size, caller_retaddr);
-#else
-	ret = mm_malloc(BASE_HEAP, size);
+			, caller_retaddr
 #endif
+			);
 	if (ret == NULL) {
-		mm_manage_alloc_fail(BASE_HEAP, HEAP_START_IDX, HEAP_END_IDX, size, USER_HEAP);
+		mm_manage_alloc_fail(BASE_HEAP, HEAP_START_IDX, HEAP_END_IDX, size, USER_HEAP
+#ifdef CONFIG_DEBUG_MM_HEAPINFO
+				, caller_retaddr
+#endif
+				);
 	}
 
 #else /* CONFIG_APP_BINARY_SEPARATION */

--- a/os/mm/umm_heap/umm_memalign.c
+++ b/os/mm/umm_heap/umm_memalign.c
@@ -101,13 +101,17 @@ void *memalign_at(int heap_index, size_t alignment, size_t size)
 		return NULL;
 	}
 
+	ret = mm_memalign(&BASE_HEAP[heap_index], alignment, size
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
-	ret = mm_memalign(&BASE_HEAP[heap_index], alignment, size, caller_retaddr);
-#else
-	ret = mm_memalign(&BASE_HEAP[heap_index], alignment, size);
+			, caller_retaddr
 #endif
+			);
 	if (ret == NULL) {
-		mm_manage_alloc_fail(&BASE_HEAP[heap_index], heap_index, heap_index, size, USER_HEAP);
+		mm_manage_alloc_fail(&BASE_HEAP[heap_index], heap_index, heap_index, size, USER_HEAP
+#ifdef CONFIG_DEBUG_MM_HEAPINFO
+				, caller_retaddr
+#endif
+				);
 	}
 	return ret;
 }
@@ -142,30 +146,38 @@ FAR void *memalign(size_t alignment, size_t size)
 #endif
 #ifdef CONFIG_APP_BINARY_SEPARATION
 	/* User supports a single heap on app separation */
+	ret = mm_memalign(BASE_HEAP, alignment, size
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
-	ret = mm_memalign(BASE_HEAP, alignment, size, caller_retaddr);
-#else
-	ret = mm_memalign(BASE_HEAP, alignment, size);
+			, caller_retaddr
 #endif
+			);
 	if (ret == NULL) {
-		mm_manage_alloc_fail(BASE_HEAP, HEAP_START_IDX, HEAP_END_IDX, size, USER_HEAP);
+		mm_manage_alloc_fail(BASE_HEAP, HEAP_START_IDX, HEAP_END_IDX, size, USER_HEAP
+#ifdef CONFIG_DEBUG_MM_HEAPINFO
+				, caller_retaddr
+#endif
+				);
 	}
 
 #else /* CONFIG_APP_BINARY_SEPARATION */
 
 	int heap_idx;
 	for (heap_idx = HEAP_START_IDX; heap_idx <= HEAP_END_IDX; heap_idx++) {
+		ret = mm_memalign(&BASE_HEAP[heap_idx], alignment, size
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
-		ret = mm_memalign(&BASE_HEAP[heap_idx], alignment, size, caller_retaddr);
-#else
-		ret = mm_memalign(&BASE_HEAP[heap_idx], alignment, size);
+				, caller_retaddr
 #endif
+				);
 		if (ret != NULL) {
 			return ret;
 		}
 	}
 
-	mm_manage_alloc_fail(BASE_HEAP, HEAP_START_IDX, HEAP_END_IDX, size, USER_HEAP);
+	mm_manage_alloc_fail(BASE_HEAP, HEAP_START_IDX, HEAP_END_IDX, size, USER_HEAP
+#ifdef CONFIG_DEBUG_MM_HEAPINFO
+			, caller_retaddr
+#endif
+			);
 #endif /* CONFIG_APP_BINARY_SEPARATION */
 	return ret;
 }

--- a/os/mm/umm_heap/umm_realloc.c
+++ b/os/mm/umm_heap/umm_realloc.c
@@ -104,13 +104,17 @@ void *realloc_at(int heap_index, void *oldmem, size_t size)
 		return NULL;
 	}
 
+	ret = mm_realloc(&BASE_HEAP[heap_index], oldmem, size
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
-	ret = mm_realloc(&BASE_HEAP[heap_index], oldmem, size, caller_retaddr);
-#else
-	ret = mm_realloc(&BASE_HEAP[heap_index], oldmem, size);
+			, caller_retaddr
 #endif
+			);
 	if (ret == NULL) {
-		mm_manage_alloc_fail(&BASE_HEAP[heap_index], heap_index, heap_index, size, USER_HEAP);
+		mm_manage_alloc_fail(&BASE_HEAP[heap_index], heap_index, heap_index, size, USER_HEAP
+#ifdef CONFIG_DEBUG_MM_HEAPINFO
+				, caller_retaddr
+#endif
+				);
 	}
 	return ret;
 }
@@ -147,13 +151,17 @@ FAR void *realloc(FAR void *oldmem, size_t size)
 		return NULL;
 	}	
 	/* User supports a single heap on app separation */
+	ret = mm_realloc(BASE_HEAP, oldmem, size
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
-	ret = mm_realloc(BASE_HEAP, oldmem, size, caller_retaddr);
-#else
-	ret = mm_realloc(BASE_HEAP, oldmem, size);
+			, caller_retaddr
 #endif
+			);
 	if (ret == NULL) {
-		mm_manage_alloc_fail(BASE_HEAP, HEAP_START_IDX, HEAP_END_IDX, size, USER_HEAP);
+		mm_manage_alloc_fail(BASE_HEAP, HEAP_START_IDX, HEAP_END_IDX, size, USER_HEAP
+#ifdef CONFIG_DEBUG_MM_HEAPINFO
+				, caller_retaddr
+#endif
+				);
 	}
 
 #else /* CONFIG_APP_BINARY_SEPARATION */
@@ -183,18 +191,22 @@ FAR void *realloc(FAR void *oldmem, size_t size)
 
 	prev_heap_idx = heap_idx;
 	for (heap_idx = HEAP_START_IDX; heap_idx <= HEAP_END_IDX; heap_idx++) {
+		ret = mm_malloc(&BASE_HEAP[heap_idx], size
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
-		ret = mm_malloc(&BASE_HEAP[heap_idx], size, caller_retaddr);
-#else
-		ret = mm_malloc(&BASE_HEAP[heap_idx], size);
+				, caller_retaddr
 #endif
+				);
 		if (ret != NULL) {
 			mm_free(&BASE_HEAP[prev_heap_idx], oldmem);
 			return ret;
 		}
 	}
 
-	mm_manage_alloc_fail(BASE_HEAP, HEAP_START_IDX, HEAP_END_IDX, size, USER_HEAP);
+	mm_manage_alloc_fail(BASE_HEAP, HEAP_START_IDX, HEAP_END_IDX, size, USER_HEAP
+#ifdef CONFIG_DEBUG_MM_HEAPINFO
+			, caller_retaddr
+#endif
+			);
 
 #endif /* CONFIG_APP_BINARY_SEPARATION */
 


### PR DESCRIPTION
When we print information about memory alloc failure, it is good to print the caller address so that during debugging we can immediately find out where the memory request was made. Add the caller address information to all memory failure cases.

Also, use lldbg instead of dbg to print mm fail logs in flat build.

Signed-off-by: Kishore S N <kishore.sn@samsung.com>