### PR TITLE
os/board/rtl8721csm: Modify do-while check in rtw_ble_server_start_adv(...) API

### DIFF
--- a/os/board/rtl8721csm/src/component/common/bluetooth/realtek/sdk/example/ble_peripheral/ble_tizenrt_server.c
+++ b/os/board/rtl8721csm/src/component/common/bluetooth/realtek/sdk/example/ble_peripheral/ble_tizenrt_server.c
@@ -24,6 +24,7 @@ uint16_t server_profile_count = 0;
 trble_server_init_config server_init_parm;
 bool (*ble_tizenrt_server_send_msg)(uint16_t sub_type, void *arg) = NULL;
 T_SEND_DATA_RESULT *send_indication_result = NULL;
+extern T_GAP_DEV_STATE ble_tizenrt_scatternet_gap_dev_state;
 
 trble_result_e rtw_ble_server_init(trble_server_init_config* init_parm)
 {
@@ -597,6 +598,11 @@ trble_result_e rtw_ble_server_start_adv(void)
     {   
         debug_print("Waiting for adv start \n");
         os_delay(100);
+        if (ble_tizenrt_scatternet_gap_dev_state.gap_adv_sub_state == GAP_ADV_TO_IDLE_CAUSE_CONN)
+        {
+            ble_tizenrt_scatternet_gap_dev_state.gap_adv_sub_state = GAP_ADV_TO_IDLE_CAUSE_STOP;
+            break;
+        }
         le_get_gap_param(GAP_PARAM_DEV_STATE , &new_state);
     } while(new_state.gap_adv_state != GAP_ADV_STATE_ADVERTISING);
 

--- a/os/board/rtl8721csm/src/component/common/bluetooth/realtek/sdk/example/ble_scatternet/ble_tizenrt_scatternet_app.c
+++ b/os/board/rtl8721csm/src/component/common/bluetooth/realtek/sdk/example/ble_scatternet/ble_tizenrt_scatternet_app.c
@@ -634,6 +634,7 @@ void ble_tizenrt_scatternet_app_handle_dev_state_evt(T_GAP_DEV_STATE new_state, 
                             bt_addr[1],
                             bt_addr[0]);
         }
+        ble_tizenrt_scatternet_gap_dev_state.gap_init_state = new_state.gap_init_state;
     }
 
     if (ble_tizenrt_scatternet_gap_dev_state.gap_adv_state != new_state.gap_adv_state)
@@ -648,11 +649,13 @@ void ble_tizenrt_scatternet_app_handle_dev_state_evt(T_GAP_DEV_STATE new_state, 
             {
                 dbg("GAP adv stopped \n");
             }
+            ble_tizenrt_scatternet_gap_dev_state.gap_adv_sub_state = new_state.gap_adv_sub_state;
         }
         else if (new_state.gap_adv_state == GAP_ADV_STATE_ADVERTISING)
         {
             dbg("GAP adv start \n");
         }
+        ble_tizenrt_scatternet_gap_dev_state.gap_adv_state = new_state.gap_adv_state;
     }
 
     if (ble_tizenrt_scatternet_gap_dev_state.gap_scan_state != new_state.gap_scan_state)
@@ -677,8 +680,8 @@ void ble_tizenrt_scatternet_app_handle_dev_state_evt(T_GAP_DEV_STATE new_state, 
                 debug_print("callback msg send fail \n");
             }
         }
+        ble_tizenrt_scatternet_gap_dev_state.gap_scan_state = new_state.gap_scan_state;
     }
-    ble_tizenrt_scatternet_gap_dev_state = new_state;
 }
 
 /**


### PR DESCRIPTION
The modification can handle the scenarios listed as below:

1. If there is no external operation over 100ms, adv start success.
nRF is able to scan the device.
2. If a master tries to connect TP1x within 100ms, connection built and new_state.gap_adv_state changed to idle. 
adv start success and build connection with other devices, so we think this adv_start operation success under such case. nRF will unable to see device after return success.
3. If a master tries to connect TP1x within 100ms, connection built but disconnect within 100ms as well. 
we think this adv_start operation success under such case. But nRF will unable to see TP1x in this case. Customers need to check log to debug.

Non-connectable cases:
1. start non-connectable adv as the first adv -> return success
2. start connectable adv as the first adv, then start non-connectable adv as the second adv -> return success
3. start connectable adv as the first adv, build the connection, then start non-connectable adv as the second adv -> return success
4. start connectable adv as the first adv, build the connection, then start connectable adv as the second adv -> return fail