### PR TITLE
examples/board_specific_demo/ameba_*: fix typo of entry config

### DIFF
--- a/apps/examples/board_specific_demo/ameba_secure_storage_demo/Kconfig_ENTRY
+++ b/apps/examples/board_specific_demo/ameba_secure_storage_demo/Kconfig_ENTRY
@@ -1,3 +1,3 @@
-config EXAMPLES_SSTORAGE
+config ENTRY_SSTORAGE
 	bool "Secure Storage example"
 	depends on EXAMPLES_SSTORAGE

--- a/apps/examples/board_specific_demo/ameba_wifi_csi_demo/Kconfig_ENTRY
+++ b/apps/examples/board_specific_demo/ameba_wifi_csi_demo/Kconfig_ENTRY
@@ -1,3 +1,3 @@
-config EXAMPLES_WIFICSI
+config ENTRY_WIFICSI
 	bool "WIFI CSI example"
 	depends on EXAMPLES_WIFICSI


### PR DESCRIPTION
Kconfig_Entry should define a ENTRY_* config to provide entry point selection in menuconfig. But ameba_secure_storage_demo and ameba_wifi_csi_demo duplicate define EXAMPLES_* configs which are already defined in Kconfig.
This commit fixes the error on menuconfig as shown below.

/root/tizenrt/apps/examples/board_specific_demo/ameba_secure_storage_demo/Kconfig:7:warning: choice value used outside its choice group /root/tizenrt/apps/examples/board_specific_demo/ameba_secure_storage_demo/Kconfig:8:warning: defaults for choice values not supported /root/tizenrt/apps/examples/board_specific_demo/ameba_wifi_csi_demo/Kconfig:7:warning: choice value used outside its choice group /root/tizenrt/apps/examples/board_specific_demo/ameba_wifi_csi_demo/Kconfig:8:warning: defaults for choice values not supported /root/tizenrt/apps/apps_entry/Kconfig:8:error: recursive dependency detected! For a resolution refer to Documentation/kbuild/kconfig-language.txt subsection "Kconfig recursive dependency limitations" /root/tizenrt/apps/apps_entry/Kconfig:8:	choice <choice> contains symbol EXAMPLES_SSTORAGE For a resolution refer to Documentation/kbuild/kconfig-language.txt subsection "Kconfig recursive dependency limitations" /root/tizenrt/apps/examples/board_specific_demo/ameba_secure_storage_demo/Kconfig_ENTRY:1:	symbol EXAMPLES_SSTORAGE depends on EXAMPLES_SSTORAGE For a resolution refer to Documentation/kbuild/kconfig-language.txt subsection "Kconfig recursive dependency limitations"
/root/tizenrt/apps/examples/board_specific_demo/ameba_secure_storage_demo/Kconfig_ENTRY:1:	symbol EXAMPLES_SSTORAGE is part of choice <choice>

Signed-off-by: sunghan <sh924.chang@samsung.com>