### PR TITLE
drivers/bluetooth/virtual_ble: remove duplicated config, VIRTUAL_BLE

### DIFF
--- a/os/drivers/bluetooth/virtual_ble/Kconfig
+++ b/os/drivers/bluetooth/virtual_ble/Kconfig
@@ -1,3 +1,0 @@
-config VIRTUAL_BLE
-	bool "Virtual BLE Driver"
-	default n


### PR DESCRIPTION
The Kconfig under os/drivers/bluetooth defines the config VIRTUAL_BLE already. But commit 3665952 duplicate defines it. That's why it makes the warning as below. This commit fixes it.

drivers/bluetooth/virtual_ble/Kconfig:2:warning: choice value used outside its choice group drivers/bluetooth/virtual_ble/Kconfig:3:warning: defaults for choice values not supported drivers/bluetooth/Kconfig:27:error: recursive dependency detected! For a resolution refer to Documentation/kbuild/kconfig-language.txt subsection "Kconfig recursive dependency limitations" drivers/bluetooth/Kconfig:27:	choice <choice> contains symbol VIRTUAL_BLE For a resolution refer to Documentation/kbuild/kconfig-language.txt subsection "Kconfig recursive dependency limitations" drivers/bluetooth/Kconfig:31:	symbol VIRTUAL_BLE depends on VIRTUAL_BLE For a resolution refer to Documentation/kbuild/kconfig-language.txt subsection "Kconfig recursive dependency limitations"
drivers/bluetooth/Kconfig:31:	symbol VIRTUAL_BLE is part of choice <choice>

Signed-off-by: sunghan <sh924.chang@samsung.com>