### PR TITLE
os/tools: terminate build when binary size exceeds partition size

### DIFF
--- a/os/tools/check_package_size.py
+++ b/os/tools/check_package_size.py
@@ -59,6 +59,7 @@ def check_binary_size(bin_type, part_size):
         print("   Built " + bin_type + " (" + number_with_comma(BINARY_SIZE) + " bytes) is greater than its partition (" + number_with_comma(PARTITION_SIZE) + " bytes).")
         print("   " + bin_type + " Binary will be deleted. Need to re-configure the partition using menuconfig and to re-build.")
         os.remove(output_path)
+        global FAIL_TO_BUILD
         FAIL_TO_BUILD = True
 
 def check_binary_header(bin_type):

--- a/os/tools/validate_output.py
+++ b/os/tools/validate_output.py
@@ -24,6 +24,7 @@
 #    It verifies the package by calculating the crc and comparing it with the value of the header.
 
 import os
+import sys
 
 os_folder = os.path.dirname(__file__) + '/..'
 tool_folder = os_folder + '/tools/'
@@ -31,7 +32,9 @@ output_folder = os_folder + '/../build/output/bin/'
 
 def check_package_size():
     # Run script for checking binary sizes
-    os.system('python ' + tool_folder + 'check_package_size.py')
+    ret = os.system('python ' + tool_folder + 'check_package_size.py')
+    if ret != 0 :
+        sys.exit(1)
 
 def check_package_header():
     # Run script for checking binary sizes


### PR DESCRIPTION
When the binary size exceeds the partition size, the build should terminate, but instead the build continues. Fixed this by exiting the parent process.

current version :
```
========== Size Verification of built Binaries ==========
KERNEL	Binary Size :    795,456 bytes	Partition Size :  1,835,008 bytes
APP1	Binary Size :        824 bytes	Partition Size :    524,288 bytes
APP2	Binary Size :      4,495 bytes	Partition Size :  1,040,384 bytes
COMMON	Binary Size :    359,336 bytes	Partition Size :     16,384 bytes
   !!!!!!!! ERROR !!!!!!!
   Built COMMON (359,336 bytes) is greater than its partition (16,384 bytes).
   COMMON Binary will be deleted. Need to re-configure the partition using menuconfig and to re-build.
=> Size verification SUCCESS!! The size of all binaries are OK.

=== Kernel Package Header Information ===
< Cannot check the signing >
	Header Size        : 12
	Package Version    : 200204
	File Size          : 795440
	Secure Header Size : 32
	* Checksum verification Done.
	* Version Matched between filename and header.
=> Header verification SUCCESS!!

=== App Package Header Information ===
< Unsigned App Package >
	Header Size       : 41
	Package Type      : ELF(1)
	Main Priority     : 220
	Loading Priority  : LOADING_HIGH(3)
	File Size         : 779
	Package Name      : app
	Package Version   : 190412
	RAM Size          : 512000
	Stack Size        : 4096
	Kernel Version    : 200204
	* Checksum verification Done.
	* Version Matched between filename and header.
=> Header verification SUCCESS!!

=== App Package Header Information ===
< Unsigned App Package >
	Header Size       : 41
	Package Type      : ELF(1)
	Main Priority     : 180
	Loading Priority  : LOADING_LOW(1)
	File Size         : 4450
	Package Name      : app
	Package Version   : 190412
	RAM Size          : 512000
	Stack Size        : 8192
	Kernel Version    : 200204
	* Checksum verification Done.
	* Version Matched between filename and header.
=> Header verification SUCCESS!!

========== Start to make boot parameters ==========
######################################
##          Library Sizes           ##
######################################
	.data 	.bss 	.text 	 Total
	88212 	2404 	293408 	384024 	lib_wlan.a
	284 	86924 	74515 	161723 	libnet.a
	224 	4300 	45071 	49595 	libboard.a
	0 	3616 	38682 	42298 	libkernel.a
	0 	76 	36117 	36193 	libfs.a
	808 	6720 	15144 	22672 	libkarch.a
	0 	364 	14693 	15057 	libdrivers.a
	4 	4 	13776 	13784 	libkc.a
	36 	1804 	8514 	10354 	libkmm.a
	0 	0 	9664 	9664 	NOLIB
	352 	0 	8148 	8500 	lib_wps.a
	0 	12 	5982 	5994 	libcompression.a
	12 	112 	5226 	5350 	libbinfmt.a
	0 	0 	4808 	4808 	libgcc.a
	132 	36 	1802 	1970 	libse.a
	0 	0 	1940 	1940 	libstubs.a
	0 	24 	1092 	1116 	libkwque.a
======================================================
  "Select build Option"
======================================================
  "1. Build with Current Configurations"
  "2. Re-configure"
  "3. Menuconfig"
```

with new changes :
```
========== Size Verification of built Binaries ==========
KERNEL	Binary Size :    795,456 bytes	Partition Size :  1,835,008 bytes
APP1	Binary Size :        824 bytes	Partition Size :    524,288 bytes
APP2	Binary Size :      4,495 bytes	Partition Size :  1,040,384 bytes
COMMON	Binary Size :    359,335 bytes	Partition Size :     16,384 bytes
   !!!!!!!! ERROR !!!!!!!
   Built COMMON (359,335 bytes) is greater than its partition (16,384 bytes).
   COMMON Binary will be deleted. Need to re-configure the partition using menuconfig and to re-build.
Makefile.unix:520: recipe for target 'post' failed
make: *** [post] Error 1
======================================================
  "Select build Option"
======================================================
  "1. Build with Current Configurations"
  "2. Re-configure"
  "3. Menuconfig"
```

Signed-off-by: Abhishek Akkabathula <a.akkabathul@samsung.com>