### PR TITLE
os, lib: Fix Svace issues

### DIFF
--- a/lib/libc/stdio/lib_sscanf.c
+++ b/lib/libc/stdio/lib_sscanf.c
@@ -689,9 +689,10 @@ int vsscanf(FAR const char *buf, FAR const char *fmt, va_list ap)
 					if (!width) {
 						/* No... Guess a field width using some heuristics */
 
-						int tmpwidth = findwidth(buf, fmt);
-						width = MIN(sizeof(tmp) - 1, tmpwidth);
+						width = findwidth(buf, fmt);
 					}
+
+					width = MIN(sizeof(tmp) - 1, width);
 
 					/* Copy the numeric string into a temporary working
 					 * buffer.
@@ -836,9 +837,10 @@ int vsscanf(FAR const char *buf, FAR const char *fmt, va_list ap)
 					if (!width) {
 						/* No... Guess a field width using some heuristics */
 
-						int tmpwidth = findwidth(buf, fmt);
-						width = MIN(sizeof(tmp) - 1, tmpwidth);
+						width = findwidth(buf, fmt);
 					}
+
+					width = MIN(sizeof(tmp) - 1, width);
 
 					/* Copy the real string into a temporary working buffer. */
 

--- a/lib/libc/string/lib_strdup.c
+++ b/lib/libc/string/lib_strdup.c
@@ -68,9 +68,10 @@ FAR char *strdup(const char *s)
 {
 	FAR char *news = NULL;
 	if (s) {
-		news = (FAR char *)lib_malloc(strlen(s) + 1);
+		size_t len = strlen(s) + 1;
+		news = (FAR char *)lib_malloc(len);
 		if (news) {
-			strcpy(news, s);
+			strncpy(news, s, len);
 		}
 	}
 

--- a/os/drivers/bch/bchdev_unregister.c
+++ b/os/drivers/bch/bchdev_unregister.c
@@ -83,7 +83,7 @@
  ****************************************************************************/
 int bchdev_unregister(FAR const char *chardev)
 {
-	FAR struct bchlib_s *bch;
+	FAR struct bchlib_s *bch = NULL;
 	int fd;
 	int ret;
 
@@ -108,7 +108,7 @@ int bchdev_unregister(FAR const char *chardev)
 	ret = ioctl(fd, DIOC_GETPRIV, (unsigned long)((uintptr_t)&bch));
 	(void)close(fd);
 
-	if (ret < 0) {
+	if (ret < 0 || !bch) {
 		fdbg("ERROR: ioctl failed: %d\n", errno);
 		return -errno;
 	}

--- a/os/drivers/bch/bchlib_read.c
+++ b/os/drivers/bch/bchlib_read.c
@@ -107,6 +107,11 @@ ssize_t bchlib_read(FAR void *handle, FAR char *buffer, size_t offset, size_t le
 		return 0;
 	}
 
+	if (bch->sectsize <= 0) {
+		fdbg("ERROR: Invalid sector size bch->sectsize = %d\n", bch->sectsize);
+		return -1;
+	}
+
 	/* Convert the file position into a sector number an offset. */
 	sector     = offset / bch->sectsize;
 	sectoffset = offset - sector * bch->sectsize;

--- a/os/drivers/bch/bchlib_write.c
+++ b/os/drivers/bch/bchlib_write.c
@@ -94,6 +94,11 @@ ssize_t bchlib_write(FAR void *handle, FAR const char *buffer, size_t offset, si
 		return 0;
 	}
 
+	if (bch->sectsize <= 0) {
+		fdbg("ERROR: Invalid sector size bch->sectsize = %d\n", bch->sectsize);
+		return -1;
+	}
+
 	/* Convert the file position into a sector number and offset. */
 	sector     = offset / bch->sectsize;
 	sectoffset = offset - sector * bch->sectsize;

--- a/os/mm/mm_heap/mm_check_heap_corruption.c
+++ b/os/mm/mm_heap/mm_check_heap_corruption.c
@@ -95,6 +95,11 @@ static void dump_node(struct mm_allocnode_s *node, node_type_t type)
 	char is_stack[9] = "'s stack";
 #endif
 
+	if (!node) {
+		mfdbg("Unable to dump NULL node\n");
+		return;
+	}
+
 	if (type == TYPE_CORRUPTED) {
 		mfdbg("CORRUPTED NODE: addr = 0x%08x size = %u preceding size = %u\n", node, node->size, MM_PREV_NODE_SIZE(node));
 	} else if (type == TYPE_OVERFLOWED) {


### PR DESCRIPTION
lib_strdup.c:73 - Use of vulnerable function 'strcpy' at lib_strdup.c:73. This function is unsafe, use strncpy instead. bchdev_unregister.c:124 - Uninitialized data is read from local variable 'bch' at bchdev_unregister.c:124. bchlib_write.c:139 - Division by zero
bchlib_read.c:152 - Division by zero
mm_check_heap_corruption.c:205 - After having been compared to NULL value at mm_check_heap_corruption.c:165, pointer 'prev' is passed as 1st parameter in call to function 'dump_node' at mm_check_heap_corruption.c:205, where it is dereferenced at mm_check_heap_corruption.c:104.

Signed-off-by: Kishore S N <kishore.sn@samsung.com>