### PR TITLE
os/include/debug.h: Change the conditionals for mfdbg from dbg to lldbg

### DIFF
--- a/os/arch/xtensa/src/xtensa/xtensa_assert.c
+++ b/os/arch/xtensa/src/xtensa/xtensa_assert.c
@@ -72,6 +72,8 @@
 #include "sched/sched.h"
 #include "xtensa.h"
 
+bool abort_mode = false;
+
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
@@ -167,6 +169,8 @@ static void xtensa_assert(int errorcode)
 void up_assert(const uint8_t *filename, int lineno)
 {
 	board_autoled_on(LED_ASSERTION);
+
+	abort_mode = true;
 
 #if defined(CONFIG_DEBUG)
 #if CONFIG_TASK_NAME_SIZE > 0 && defined(CONFIG_DEBUG_ERROR)

--- a/os/include/debug.h
+++ b/os/include/debug.h
@@ -499,8 +499,11 @@ int get_errno(void);
 #define mllvdbg(...)
 #endif
 
-#if defined(CONFIG_MM_ASSERT_ON_FAIL) && defined(CONFIG_APP_BINARY_SEPARATION) && defined (__KERNEL__)
-#define mfdbg(format, ...) lldbg(format, ##__VA_ARGS__)
+#if defined(CONFIG_BUILD_FLAT) || defined(__KERNEL__)
+#define mfdbg(format, ...) if (abort_mode || up_interrupt_context()) \
+                                                             lldbg(format, ##__VA_ARGS__); \
+                                                        else \
+                                                             dbg(format, ##__VA_ARGS__);
 #else
 #define mfdbg(format, ...) dbg(format, ##__VA_ARGS__)
 #endif

--- a/os/mm/mm_heap/mm_check_heap_corruption.c
+++ b/os/mm/mm_heap/mm_check_heap_corruption.c
@@ -77,7 +77,7 @@ enum node_type_e {
 };
 typedef enum node_type_e node_type_t;
 
-#if defined(__KERNEL__)
+#if defined(CONFIG_BUILD_FLAT) || defined(__KERNEL__)
 extern bool abort_mode;
 #endif
 /****************************************************************************

--- a/os/mm/mm_heap/mm_manage_allocfail.c
+++ b/os/mm/mm_heap/mm_manage_allocfail.c
@@ -94,6 +94,11 @@ void mm_manage_alloc_fail(struct mm_heap_s *heap, int startidx, int endidx, size
 {
 	irqstate_t flags = irqsave();
 
+	extern bool abort_mode;
+#ifdef CONFIG_MM_ASSERT_ON_FAIL
+	abort_mode = true;
+#endif
+
 	mfdbg("Allocation failed from %s heap.\n", (heap_type == KERNEL_HEAP) ? KERNEL_STR : USER_STR);
 	mfdbg(" - requested size %u\n", size);
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
@@ -113,8 +118,6 @@ void mm_manage_alloc_fail(struct mm_heap_s *heap, int startidx, int endidx, size
 	WRITE_REBOOT_REASON(REBOOT_SYSTEM_MEMORYALLOCFAIL);
 #endif
 
-	extern bool abort_mode;
-	abort_mode = true;
 #endif /* CONFIG_MM_ASSERT_ON_FAIL */
 
 #ifdef CONFIG_DEBUG_MM_HEAPINFO


### PR DESCRIPTION
This patch is for change in mfdbg to use lldbg instead of dbg in flat build
The logs get stuck for flat build, when there is heap corruption.
Change the mfdbg to use lldbg.
With the change the logs are getting displayed correctly.

LOGS BEFORE 

System Information:
Version:
Platform: 3.1 up_assert: Assertion failed at file:hello_main.c line: 83 task: appmn
up_dumpstate: Code asserted in normal thread!
up_dumpstate: Current SP is User Thread SP: 1006e6c8
........
TASH>>
TASH>>Hello, World!!
mm_check_heap_corruption: ###########################################################################
mm_check_heap_corruption: ERROR: Heap n

LOGS AFTER CHANGE

up_assert: Assertion failed at file:hello_main.c line: 83 task: hello
.......
mm_check_heap_corruption: #########################################################################################
mm_check_heap_corruption: ERROR: Heap node corruption detected.
mm_check_heap_corruption: ==================================================================================
mm_check_heap_corruption: Possible corruption scenario 1:
mm_check_heap_corruption: ...........