### PR TITLE
rtl8720e: fix typo

### DIFF
--- a/build/configs/rtl8720e/loadable_apps/Make.defs
+++ b/build/configs/rtl8720e/loadable_apps/Make.defs
@@ -240,7 +240,7 @@ define MAKE_BOOTPARAM
 endef
 
 define MAKE_USER_SIGNING
-  $(TOPDIR)/../build/configs/rtl8721csm/rtl8721csm_signing.sh user
+  $(TOPDIR)/../build/configs/rtl8720e/rtl8720e_signing.sh user
 endef
 
 define DOWNLOAD

--- a/os/arch/arm/src/amebalite/Make.defs
+++ b/os/arch/arm/src/amebalite/Make.defs
@@ -192,7 +192,7 @@ ifeq ($(CONFIG_SYSTEM_REBOOT_REASON),y)
 #CMN_CSRCS += amebalite_reboot_reason.c #FIXME
 endif
 ifeq ($(CONFIG_BINARY_SIGNING),y)
-#CMN_CSRCS += amebalite_signature.c	#FIXME
+CMN_CSRCS += amebalite_signature.c
 endif
 ifeq ($(CONFIG_AMEBALITE_BLE),y)
 EXTRA_LIBS += ${TOPDIR}/board/rtl8720e/src/libs/lib_btgap.a


### PR DESCRIPTION
1. configs/rtl8720e/loadable_apps: fix typo, rtl8721csm -> rtl8720e
2. arch/arm/amebalite: add amebalite_signature.c in Make.defs