### PR TITLE
os/mm: Fix issue in mm_manage_allocfail

### DIFF
--- a/os/mm/mm_heap/mm_manage_allocfail.c
+++ b/os/mm/mm_heap/mm_manage_allocfail.c
@@ -100,7 +100,6 @@ void mm_manage_alloc_fail(struct mm_heap_s *heap, int startidx, int endidx, size
 	mfdbg(" - caller address = 0x%08x\n", caller);
 #endif
 
-#ifdef CONFIG_MM_ASSERT_ON_FAIL
 	struct mallinfo info;
 	memset(&info, 0, sizeof(struct mallinfo));
 	for (int idx = startidx; idx <= endidx; idx++) {
@@ -109,6 +108,7 @@ void mm_manage_alloc_fail(struct mm_heap_s *heap, int startidx, int endidx, size
 	mfdbg(" - largest free size : %d\n", info.mxordblk);
 	mfdbg(" - total free size   : %d\n", info.fordblks);
 
+#ifdef CONFIG_MM_ASSERT_ON_FAIL
 #ifdef CONFIG_SYSTEM_REBOOT_REASON
 	WRITE_REBOOT_REASON(REBOOT_SYSTEM_MEMORYALLOCFAIL);
 #endif


### PR DESCRIPTION
When memory alloc is failed, we must always print largest free node and total free space in the heap.

Signed-off-by: Kishore S N <kishore.sn@samsung.com>