### PR TITLE
os/board/rtl8721csm : fix error_flag for wifi_get_ap_bssid API

### DIFF
--- a/os/board/rtl8721csm/src/component/common/api/wifi/wifi_conf.c
+++ b/os/board/rtl8721csm/src/component/common/api/wifi/wifi_conf.c
@@ -792,6 +792,7 @@ int wifi_connect(
 				rtw_memcpy(reason.ssid, join_result->network_info.ssid.val, 32);
 				reason.ssid_len = join_result->network_info.ssid.len;
 				reason.reason_code = RTK_STATUS_SUCCESS;
+				error_flag = RTW_NO_ERROR;
 
 				if (g_link_up) {
 					if (reason.reason_code) {


### PR DESCRIPTION
Update error_flag for successful wifi connection to get correct output of wifi_get_ap_bssid API