### PR TITLE
os/binfmt: Add code to free the allocated elf sections

### DIFF
--- a/os/binfmt/libelf/libelf_addrenv.c
+++ b/os/binfmt/libelf/libelf_addrenv.c
@@ -286,4 +286,16 @@ int elf_addrenv_alloc(FAR struct elf_loadinfo_s *loadinfo)
 
 void elf_addrenv_free(FAR struct elf_loadinfo_s *loadinfo)
 {
+	if (loadinfo->binp->sections[BIN_TEXT]) {
+		kmm_free(loadinfo->binp->sections[BIN_TEXT]);
+		loadinfo->binp->sections[BIN_TEXT] = NULL;
+	}
+	if (loadinfo->binp->sections[BIN_DATA]) {
+		kmm_free(loadinfo->binp->sections[BIN_DATA]);
+		loadinfo->binp->sections[BIN_DATA] = NULL;
+	}
+	if (loadinfo->binp->sections[BIN_RO]) {
+		kmm_free(loadinfo->binp->sections[BIN_RO]);
+		loadinfo->binp->sections[BIN_RO] = NULL;
+	}
 }


### PR DESCRIPTION
The elf_addrenv_free() API is empty. Add code to free the allocated elf sections. This API will be called when there is any error during elf load and bind stage. So, if the elf sections have already been allocated, they need to be freed here.

Signed-off-by: Kishore S N <kishore.sn@samsung.com>