### PR TITLE
mm_check_heap_corruption.c : update the conditionals for the use of a…

### DIFF
--- a/os/mm/mm_heap/mm_check_heap_corruption.c
+++ b/os/mm/mm_heap/mm_check_heap_corruption.c
@@ -143,7 +143,7 @@ int mm_check_heap_corruption(struct mm_heap_s *heap)
 	struct mm_allocnode_s *prev;
 	struct mm_allocnode_s *next;
 	bool aborted = false;
-#if defined(__KERNEL__)
+#if defined(CONFIG_BUILD_FLAT) || defined(__KERNEL__)
 	aborted = abort_mode;
 #endif
 #if CONFIG_KMM_REGIONS > 1


### PR DESCRIPTION
mm_check_heap_corruption.c : update the conditionals for the use of abort mode

This PR is for addressing the  [comment](https://github.com/Samsung/TizenRT/pull/5705#discussion_r1041081790) in PR #5705. The abort mode flag is used in case of board crash. This flag is used in the mfdbg definition in os/include/debug.h for mfdbg conditionals. So changing the conditional for assignment of the board status for printing the heap information.