### PR TITLE
Trap support on docker

### DIFF
--- a/docs/HowToDebug.md
+++ b/docs/HowToDebug.md
@@ -2,7 +2,7 @@
 
 There are several debug methods.
 
-- [How to use RAMDUMP](../tools/ramdump/HowToUseRamdump.md)  
+- [How to use TRAP tool](../tools/trap/HowToUseTrap.md)  
 - [How to use Shell Commands](../apps/system/utils/README.md)  
 - [How to use Logging System](HowToUseLoggingSystem.md)
 - [How to debug a crash](HowToDebugACrash.md)

--- a/os/dutils.sh
+++ b/os/dutils.sh
@@ -19,7 +19,10 @@
 # dutils.sh
 
 OSDIR=`test -d ${0%/*} && cd ${0%/*}; pwd`
+CONFIGFILE="${OSDIR}/.config"
 TOPDIR="${OSDIR}/.."
+BINDIR="${TOPDIR}/build/output/bin"
+TRAPDIR="${TOPDIR}/tools/trap"
 DOCKER_VERSION="1.5.5"
 
 
@@ -57,6 +60,63 @@ function FIND_DBGBINFILE()
 	KERNEL_DBG_BIN="tinyara$EXEEXT"
 }
 
+function TRAP_MENU()
+{
+	echo =============================================================================
+	echo "  \"Select binary to debug crash with TRAP tool\""
+	echo =============================================================================
+	echo "  \"1. Default binary from previous build at build/output/bin location\""
+	echo "  \"2. Custom binary at any location\""
+	echo "  \"x. Exit\""
+	echo =============================================================================
+
+	read SELECT_BIN
+	case ${SELECT_BIN,,} in
+		1|default)
+			if [ -z "$(ls -A $BINDIR)" ]; then
+				echo "No output file in $BINDIR, Build the code and run TRAP again."
+				return
+			fi
+			echo "Enter the crash log file name: (ex: ../tools/trap/testlogs)"
+			read LOG_FILE
+			if [ ! -f ${LOG_FILE} ]; then
+				echo "$LOG_FILE: No such file, try again"
+				return
+			fi
+			TRAP_RUN log $LOG_FILE
+			;;
+		2|manual)
+			echo "Enter the following wrt os directory"
+			echo ""
+			echo "Enter the binary folder name: (ex: ../../build/output/bin/)"
+			read EXT_BIN_DIR
+			if [ -z "$(ls -A $EXT_BIN_DIR)" ]; then
+				echo "$EXT_BIN_DIR Folder does not exit, try again"
+				return
+			fi
+
+			echo "Enter the configuration file name: (ex: .config)"
+			read CONFIG_FILE
+			if [ ! -f ${CONFIG_FILE} ]; then
+				echo "$CONFIG_FILE: No such file, try again"
+				return
+			fi
+
+			echo "Enter the crash log file name: (ex: testlogs)"
+			read LOG_FILE
+			if [ ! -f ${LOG_FILE} ]; then
+				echo "$LOG_FILE: No such file, try again"
+				return
+			fi
+
+			TRAP_RUN log $LOG_FILE $EXT_BIN_DIR $CONFIG_FILE
+			;;
+		x|exit)
+			exit 1
+			;;
+	esac
+
+}
 function TOOLCHAIN_MENU()
 {
 	FIND_DBGBINFILE
@@ -153,7 +213,8 @@ function MENU()
 			echo ======================================================
 			echo "  \"Select Option\""
 			echo ======================================================
-			echo "  \"1. Run Toolchain Command\""
+			echo "  \"1. Run TRAP Debug tool\""
+			echo "  \"2. Run Toolchain Command\""
 			echo "  \"h. Help\""
 			echo "  \"x. Exit\""
 			echo ======================================================
@@ -161,7 +222,10 @@ function MENU()
 		fi
 
 		case ${SELECTED_START,,} in
-		1|tool)
+		1|trap)
+			TRAP_MENU
+			;;
+		2|tool)
 			TOOLCHAIN_MENU
 			;;
 		h|help)
@@ -187,6 +251,30 @@ function TOOLCHAIN()
 	docker run --rm -v ${TOPDIR}:/root/tizenrt -w /root/tizenrt/os --privileged tizenrt/tizenrt:${DOCKER_VERSION} $ARGS
 }
 
+function TRAP_RUN()
+{
+	TRAPCMD="ramdumpParser.py -t $2"
+
+	if [ ! -z "$3" ]; then
+		# Append the binary path
+		TRAPCMD+=" -b ../../os/"$3
+	fi
+	if [ ! -z "$4" ]; then
+		# Append the config path
+		TRAPCMD+=" -c ../../os/"$4
+	fi
+
+	# Parse kernel elf path
+	make -C "tools" -f Makefile.export TOPDIR=".." EXPORTDIR=".."
+	source "./makeinfo.sh"
+	rm -f "makeinfo.sh"
+	TRAPCMD+=" -e tinyara$EXEEXT"
+
+	echo "Executing: $TRAPCMD"
+	# execute TRAP script
+	docker run --rm ${DOCKER_OPT} -v ${TOPDIR}:/root/tizenrt -it -w /root/tizenrt/tools/trap --privileged tizenrt/tizenrt:1.5.6 python3.7 $TRAPCMD
+}
+
 function HELP()
 {
 	echo "Usage:	dutils.sh [menu] | [help] | [tool toolchain_cmd]"
@@ -195,6 +283,11 @@ function HELP()
 	echo "help	Display this help menu"
 	echo "tool	Enter toolchain command which will be executed in docker"
 	echo "	Ex: dutils.sh tool nm <relative path to binary file>"
+	echo "log	Enter custom log file which will be execute TRAP in docker"
+	echo "	Ex: dutils.sh log -t <relative path to log file>"
+	echo "    : dutils.sh log -t logs"
+	echo "	Ex: dutils.sh log -t <relative path to log file> -b <relative path to test binaries> -c <relative path to configuration file>"
+	echo "    : dutils.sh log -t logs -b ../../os/testbin/ -c ../../os/cfile"
 	echo ""
 }
 
@@ -209,6 +302,8 @@ elif [ "$1" == "tool" ]; then
 	else
 		TOOLCHAIN $@
 	fi
+elif [ "$1" == "log" ]; then
+	TRAP_RUN $@
 elif [ "$1" == "help" ]; then
 	HELP
 else

--- a/os/dutils.sh
+++ b/os/dutils.sh
@@ -154,6 +154,7 @@ function MENU()
 			echo "  \"Select Option\""
 			echo ======================================================
 			echo "  \"1. Run Toolchain Command\""
+			echo "  \"h. Help\""
 			echo "  \"x. Exit\""
 			echo ======================================================
 			read SELECTED_START
@@ -162,6 +163,9 @@ function MENU()
 		case ${SELECTED_START,,} in
 		1|tool)
 			TOOLCHAIN_MENU
+			;;
+		h|help)
+			HELP
 			;;
 		x|exit)
 			exit 1
@@ -190,7 +194,7 @@ function HELP()
 	echo "menu	Display interactive menu"
 	echo "help	Display this help menu"
 	echo "tool	Enter toolchain command which will be executed in docker"
-	echo "	Ex: dbuild.sh tool nm <relative path to binary file>"
+	echo "	Ex: dutils.sh tool nm <relative path to binary file>"
 	echo ""
 }
 

--- a/tools/trap/HowToUseTrap.md
+++ b/tools/trap/HowToUseTrap.md
@@ -58,7 +58,7 @@ TRAP Script provides two interfaces:
 
 ### TRAP using CUI
 
-#### To display Debug Symbols/Crash point using assert logs
+#### To display Debug Symbols/Crash point using default build binary
 1. Change the directory to trap
 ```
 cd $TIZENRT_BASEDIR/tools/trap/
@@ -278,6 +278,43 @@ Stack_address	 Symbol_address	 Symbol location  Symbol_name		File_name
 
 4. Miscellaneous information:
 -----------------------------------------------------------------------------------------
+```
+
+#### To display Debug Symbols/Crash point using binary other than default build binary
+1. Run Ramdump Parser Script and see the Output  
+    $ python3 ramdumpParser.py -t `<Log file path>` -b `<binary folder path>` -c `<configuration file path>`
+```
+vidisha@vidisha:~/tizenRT/tools/trap(trap)$ sudo python3 ramdumpParser.py -t logs -b ../../os/vidisha/bin/ -c ../../os/cfile
+
+
+*************************************************************
+dump_file                   : None
+log_file                    : logs
+Number of binary            : 1 [kernel]
+"kernel" elf_file           : ../../os/vidisha/bin/tinyara.axf
+*************************************************************
+
+-----------------------------------------------------------------------------------------
+1. Crash Binary             : kernel
+
+2. Crash type               : code assertion by code ASSERT or PANIC
+
+3. Crash point
+	-  up_assert: Assertion failed at file:init/os_start.c line: 621 task: Idle Task
+
+
+	- Code asserted in normal thread.
+
+4. Call stack of last run thread
+
+Stack_address	 Symbol_address	 Symbol location  Symbol_name		File_name
+ User stack
+0x10004fa0	 0xe00183c	 kernel  	  thread_create	/root/tizenrt/os/kernel/task/task_create.c:133
+0x10004fe0	 0x10010d90	 kernel  	  os_start	/root/tizenrt/os/include/tinyara/init.h:89
+
+x. Miscellaneous information:
+-----------------------------------------------------------------------------------------
+vidisha@vidisha:~/tizenRT/tools/trap(trap)$
 ```
 
 #### To get call stack using RAM dump

--- a/tools/trap/ramdumpParser.py
+++ b/tools/trap/ramdumpParser.py
@@ -954,6 +954,9 @@ def usage():
 	print('Following options are available')
 	print('\t-r, --dump_file                 RAM/FLASH dump_file along with path')
 	print('\t-t, --log_file                  Enter Logfile which contains stackdump during assert')
+	print('\t-b, --bin_path                  Enter binary folder path other than default binary')
+	print('\t-c, --config_Path               Enter configuration file path for above binary')
+	print('\t-e, --elf_path                  Enter kernel elf file name')
 	print('\t-h, --help                      Show help')
 	print('')
 	print('syntax :')
@@ -966,6 +969,10 @@ def usage():
 	print('Below example if you give simple assert log file as path: ')
 	print('---------------------------------------------------------')
 	print('python3 ramdumpParser.py -r log.txt ')
+	print('')
+	print('Below example if you give binary file other than default as path: ')
+	print('---------------------------------------------------------')
+	print('python3 ramdumpParser.py -r log.txt -b ../../os/vidisha/bin/ -c ../../os/cfile -e tinayara.axf')
 	print('')
 	print('')
 	print('Note:')
@@ -980,9 +987,12 @@ def usage():
 	sys.exit(1)
 
 def main():
+	global BIN_PATH
+	global CONFIG_PATH
 	dump_file = None
 	log_file = None
 	elf = None
+	elf_path = None
 	framePointer = 0
 	stackPointer = 0
 	programCounter = 0
@@ -990,7 +1000,7 @@ def main():
 	have_ram_kernel_text = False
 
 	try:
-		opts, args = GetOpt(sys.argv[1:],'r:t:h', ['dump_file=','log_file=','help'])
+            opts, args = GetOpt(sys.argv[1:],'r:t:b:c:e:h', ['dump_file=','log_file=','bin_path=','config_path=','elf_path=','help'])
 	except GetoptError as e:
 		print(' ')
 		print(' ')
@@ -1003,16 +1013,27 @@ def main():
 			dump_file = arg
 		elif opt in ('-t', '--log_file'):
 			log_file = arg
+		elif opt in ('-b', '--bin_path'):
+			bin_path = arg
+			BIN_PATH = bin_path
+		elif opt in ('-c', '--config_path'):
+			config_path = arg
+			CONFIG_PATH = config_path
+		elif opt in ('-e', '--elf_ext'):
+			elf_path = arg
 		elif opt in ('-h', '--help'):
 			usage()
 
-	# Read tinyara extension from Make.defs
-	with open(MAKEFILE_PATH, 'r') as fd:
-		lines = fd.readlines()
-		for line in lines:
-			if 'EXEEXT =' in line:
-				ext = (line.split("=")[1].strip())
-	elf = (BIN_PATH + 'tinyara' + ext)
+	if not elf_path:
+		# Read tinyara extension from Make.defs
+		with open(MAKEFILE_PATH, 'r') as fd:
+			lines = fd.readlines()
+			for line in lines:
+				if 'EXEEXT =' in line:
+					ext = (line.split("=")[1].strip())
+		elf = (BIN_PATH + 'tinyara' + ext)
+	else:
+		elf = BIN_PATH + elf_path
 
 	if not log_file and not dump_file:
 		print('Usage error: Must specify one of the -t or -e options. Plz find below for proper usage')


### PR DESCRIPTION
Sample execution logs are as below:
For default build binary >
```
 ======================================================
      "Select Option"
    ======================================================
      "1. Run Toolchain Command"
      "2. Run TRAP Debug tool"
      "h. Help"
      "x. Exit"
    ======================================================
    2
    ======================================================
      "Run TRAP tool for"
    ======================================================
      "1. Default binary from previous build at build/output/bin location"
      "2. Custom binary at any location"
      "x. Exit"
    ======================================================
    1
    Enter the crash log file name: (ex: ../tools/trap/testlogs)
    logs
    Executing: ramdumpParser.py -t logs
    
    *************************************************************
    dump_file                   : None
    log_file                    : logs
    Number of binary            : 1 [kernel]
    "kernel" elf_file           : ../../build/output/bin/tinyara.axf
    *************************************************************
    
    -----------------------------------------------------------------------------------------
    1. Crash Binary             : kernel
    
    2. Crash type               : code assertion by code ASSERT or PANIC
    
    3. Crash point
            -  up_assert: Assertion failed at file:init/os_start.c line: 621 task: Idle Task
    
            - Code asserted in normal thread.
    
    4. Call stack of last run thread
    
    Stack_address    Symbol_address  Symbol location  Symbol_name           File_name
     User stack
    0x10004fa0       0xe00183c       kernel           thread_create /root/tizenrt/os/kernel/task/task_create.c:133
    0x10004fe0       0x10010d90      kernel           os_start      /root/tizenrt/os/include/tinyara/init.h:89
    
    x. Miscellaneous information:
    -----------------------------------------------------------------------------------------
```

For binary provided by the user > 
```
    ======================================================
      "Select Option"
    ======================================================
      "1. Run Toolchain Command"
      "2. Run TRAP Debug tool"
      "h. Help"
      "x. Exit"
    ======================================================
    2
    =============================================================================
      "Select binary to debug crash with TRAP tool"
    =============================================================================
      "1. Default binary from previous build at build/output/bin location"
      "2. Custom binary at any location"
      "x. Exit"
    =============================================================================
    2
    Enter the following wrt os directory
    
    Enter the binary folder name: (ex: ../../build/output/bin/)
    test
    ls: cannot access 'test': No such file or directory
    decwec Folder does not exit, try again
    vidisha/bin/
    Enter the configuration file name: (ex: .config)
    cc
    cc: No such file, try again
    cfile
    Enter the crash log file name: (ex: testlogs)
    dd
    dd: No such file, try again
    logs
    make: Entering directory '/home/vidisha/testTizen/os/tools'
    chmod 755 ../makeinfo.sh
    make: Leaving directory '/home/vidisha/testTizen/os/tools'
    Executing: ramdumpParser.py -t logs -b ../../os/vidisha/bin/ -c ../../os/cfile -e tinyara.axf
    
    *************************************************************
    dump_file                   : None
    log_file                    : logs
    Number of binary            : 1 [kernel]
    "kernel" elf_file           : ../../build/output/bin/tinyara.axf
    *************************************************************
    
    -----------------------------------------------------------------------------------------
    1. Crash Binary             : kernel
    
    2. Crash type               : code assertion by code ASSERT or PANIC
    
    3. Crash point
            -  up_assert: Assertion failed at file:init/os_start.c line: 621 task: Idle Task
    
            - Code asserted in normal thread.
    
    4. Call stack of last run thread
    
    Stack_address    Symbol_address  Symbol location  Symbol_name           File_name
     User stack
    0x10004fa0       0xe00183c       kernel           thread_create /root/tizenrt/os/kernel/task/task_create.c:133
    0x10004fe0       0x10010d90      kernel           os_start      /root/tizenrt/os/include/tinyara/init.h:89
    
    x. Miscellaneous information:
    -----------------------------------------------------------------------------------------
    ======================================================
      "Select Option"
    ======================================================
      "1. Run Toolchain Command"
      "2. Run TRAP Debug tool"
      "h. Help"
      "x. Exit"
    ======================================================
```