### PR TITLE
dutils.sh: Add option to store output to a file

### DIFF
--- a/os/.gitignore
+++ b/os/.gitignore
@@ -18,3 +18,4 @@
 /tinyara_memstats.txt
 /.appSpec
 /.bininfo
+/dutils_output_*.txt


### PR DESCRIPTION
This patch adds an option to store the output of the commands to a file with the name of command and timestamp as below:
    >> Output is stored in dutils_output_addr2line_2023.01.12-18.21.24.txt
    >> Output is stored in dutils_output_trap_2023.01.12-18.20.20.txt
    >> Output is stored in dutils_output_nm_2023.01.12-18.22.39.txt

Signed-off-by: Vidisha Thapa <thapa.v@samsung.com>