### PR TITLE
TRAP: Add functionality to dump a file from userfs partition on crash

### DIFF
--- a/tools/trap/HowToUseTrap.md
+++ b/tools/trap/HowToUseTrap.md
@@ -460,8 +460,11 @@ Choose from the following options:-
 2. Userfs Dump
 3. Both RAM and Userfs dumps
 4. External Userfs Partition Dump
-5. Exit TRAP Tool
-6. Reboot TARGET Device
+5. Dump specific file from target device
+r. Reboot TARGET Device
+x. Exit TRAP tool
+You may chose mutiple dump options together by entering the option numbers consectuively
+For Example - '14' to dump both RAM and External USERFS partition contents OR '35' to print RAM, USERFS and FILE contents
 1 (-> RAM Dump option chosen)
 ```
 5. If RAM Dump option is chosen, tool will prompt the user for the regions to be dumped on successful handshake
@@ -500,8 +503,11 @@ Choose from the following options:-
 2. Userfs Dump
 3. Both RAM and Userfs dumps
 4. External Userfs Partition Dump
-5. Exit TRAP Tool
-6. Reboot TARGET Device
+5. Dump specific file from target device
+r. Reboot TARGET Device
+x. Exit TRAP Tool
+You may chose mutiple dump options together by entering the option numbers consectuively
+For Example - '14' to dump both RAM and External USERFS partition contents OR '35' to print RAM, USERFS and FILE contents
 2 (-> Userfs Dump option chosen)
 ```
 8. If Userfs Dump option is chosen, tool will dump the region on successful handshake
@@ -525,8 +531,11 @@ Choose from the following options:-
 2. Userfs Dump
 3. Both RAM and Userfs dumps
 4. External Userfs Partition Dump
-5. Exit TRAP Tool
-6. Reboot TARGET Device
+5. Dump specific file from target device
+r. Reboot TARGET Device
+x. Exit TRAP Tool
+You may chose mutiple dump options together by entering the option numbers consectuively
+For Example - '14' to dump both RAM and External USERFS partition contents OR '35' to print RAM, USERFS and FILE contents
 4 (-> External Userfs Partition dump option chosen)
 ```
 10. If External Userfs Partition dump option is chosen, tool will dump the Userfs partition on the External Flash on successful handshake..
@@ -552,9 +561,12 @@ Choose from the following options:-
 2. Userfs Dump
 3. Both RAM and Userfs dumps
 4. External Userfs Partition Dump
-5. Exit TRAP Tool
-6. Reboot TARGET Device
-6 (-> Reboot TARGET Device option chosen)
+5. Dump specific file from target device
+r. Reboot TARGET Device
+x. Exit TRAP Tool
+You may chose mutiple dump options together by entering the option numbers consectuively
+For Example - '14' to dump both RAM and External USERFS partition contents OR '35' to print RAM, USERFS and FILE contents
+r (-> Reboot TARGET Device option chosen)
 ```
 12. If Reboot TARGET Device option is chosen, tool will send a Reboot signal string to the TARGET device and exit
 ```
@@ -562,7 +574,7 @@ CONFIG_BOARD_ASSERT_AUTORESET needs to be enabled to reboot TARGET Device after 
 do_handshake: Target Handshake successful
 Dump tool exits after successful operation
 ```
-13. The TRAP tool exits if user chooses Option 5.
+13. The TRAP tool exits if user chooses Option 'x'.
 ```
 Dump tool exits after successful operation
 ```

--- a/tools/trap/trap.c
+++ b/tools/trap/trap.c
@@ -367,10 +367,11 @@ int main(int argc, char *argv[])
 	char *dev_file;
 	char tty_path[TTYPATH_LEN] = {0, };
 	char tty_type[TTYTYPE_LEN] = {0, };
-	int choice;
+	char choice[4] = {'\0'};
 	char c;
 	char handshake_string[HANDSHAKE_STR_LEN_MAX];
 	int DUMP_FLAGS;
+	int choice_index = 0;
 
 	ret = 1;
 
@@ -384,12 +385,10 @@ int main(int argc, char *argv[])
 	dev_file = argv[1];
 
 	/* Get the tty type  */
-	if (!strcmp(dev_file, "/dev/ttyUSB1")) {
-		strncpy(tty_type, "ttyUSB1", TTYTYPE_LEN);
-	} else if (!strcmp(dev_file, "/dev/ttyUSB0")) {
-		strncpy(tty_type, "ttyUSB0", TTYTYPE_LEN);
-	} else if (!strcmp(dev_file, "/dev/ttyACM0")) {
-		strncpy(tty_type, "ttyACM0", TTYTYPE_LEN);
+	if (!strncmp(dev_file, "/dev/ttyUSB", 11)) {
+		strncpy(tty_type, &dev_file[5], TTYTYPE_LEN);
+	} else if (!strncmp(dev_file, "/dev/ttyACM", 11)) {
+		strncpy(tty_type, &dev_file[5], TTYTYPE_LEN);
 	} else {
 		printf("Undefined tty %s\n", dev_file);
 		return -1;
@@ -421,38 +420,43 @@ int main(int argc, char *argv[])
 	printf("Target device locked and ready to DUMP!!!\n");
 
 	while (1) {
-		printf("Choose from the following options:-\n1. RAM Dump\n2. Userfs Dump\n3. Both RAM and Userfs dumps\n4. External Userfs Partition Dump\n5. Exit TRAP Tool\n6. Reboot TARGET Device\n7. Dump specific file from Target Device\n");
+		printf("\nChoose from the following options:-\n1. RAM Dump\n2. Userfs Dump\n3. Both RAM and Userfs dumps\n4. External Userfs Partition Dump\n5. Dump specific file from target device\nr. Reboot TARGET Device\nx. Exit TRAP tool\n");
+		printf("\nYou may chose mutiple dump options together by entering the option numbers consectuively\nFor Example - \'14\' to dump both RAM and External USERFS partition contents OR \'35\' to print RAM, USERFS and FILE contents\n");
 		fflush(stdout);
-		scanf("%d", &choice);
+		scanf("%s", choice);
 		getchar();
 
 		DUMP_FLAGS = CLEAR_DUMP_FLAGS;
 
-		switch (choice) {
-		case 1:
-			DUMP_FLAGS |= RAMDUMP_FLAG;
-			break;
-		case 2:
-			DUMP_FLAGS |= USERFSDUMP_FLAG;
-			break;
-		case 3:
-			DUMP_FLAGS |= RAMDUMP_FLAG;
-			DUMP_FLAGS |= USERFSDUMP_FLAG;
-			break;
-		case 4:
-			DUMP_FLAGS |= EXTUSERFS_DUMP_FLAG;
-			break;
-		case 5:
-			break;
-		case 6:
-			DUMP_FLAGS |= REBOOT_DEVICE_FLAG;
-			break;
-		case 7:
-			DUMP_FLAGS |= FILE_DUMP_FLAG;
-			break;
-		default:
-			printf("Invalid Input\n");
-			continue;
+		while (choice_index < 4 && choice[choice_index] != '\0') {
+			switch (choice[choice_index]) {
+			case '1':
+				DUMP_FLAGS |= RAMDUMP_FLAG;
+				break;
+			case '2':
+				DUMP_FLAGS |= USERFSDUMP_FLAG;
+				break;
+			case '3':
+				DUMP_FLAGS |= RAMDUMP_FLAG;
+				DUMP_FLAGS |= USERFSDUMP_FLAG;
+				break;
+			case '4':
+				DUMP_FLAGS |= EXTUSERFS_DUMP_FLAG;
+				break;
+			case '5':
+				DUMP_FLAGS |= FILE_DUMP_FLAG;
+				break;
+			case 'r':
+				DUMP_FLAGS |= REBOOT_DEVICE_FLAG;
+				break;
+			case 'x':
+				break;
+			default:
+				printf("Invalid Input\n");
+				continue;
+			}
+
+			choice_index++;
 		}
 
 		if (DUMP_FLAGS & REBOOT_DEVICE_FLAG) {

--- a/tools/trap/trap.h
+++ b/tools/trap/trap.h
@@ -34,9 +34,10 @@
  ****************************************************************************/
 
 #define RAMDUMP_HANDSHAKE_STRING        "TIZENRTRMDUMP"
-#define FSDUMP_HANDSHAKE_STRING         "TIZENRTFSDUMP"
-#define EXTFSDUMP_HANDSHAKE_STRING      "TIZENRTEXTFSD"
+#define FSDUMP_HANDSHAKE_STRING         "TIZENRTFSDUMP"	//Dump the entire userfs flash partition
+#define EXTFSDUMP_HANDSHAKE_STRING      "TIZENRTEXTFSD"	//Dump the entire userfs partition from external flash
 #define TARGET_REBOOT_STRING            "TIZENRTREBOOT"
+#define USERFS_FDUMP_HANDSHAKE_STRING   "TIZENRTFILDUM"	//Dump a particular file from Userfs
 #define HANDSHAKE_STR_LEN_MAX           (13)
 #define BINFILE_NAME_SIZE               (40)
 #define KB_CHECK_COUNT                  (16 * 1024)
@@ -49,6 +50,7 @@
 #define USERFSDUMP_FLAG         2
 #define REBOOT_DEVICE_FLAG      4
 #define EXTUSERFS_DUMP_FLAG     8
+#define FILE_DUMP_FLAG		16
 
 /****************************************************************************
  * Public Types


### PR DESCRIPTION
- This change allows dumping of a particular file by name/path from a crashed TizenRT device

Signed-off-by: Amogh Hassija <a.hassija@samsung.com>

USAGE: - After TizenRT device crashes

> 
> ************************************************************************************************
>                 Disconnect this serial terminal and run Dump Tool
> ************************************************************************************************
> 
> 

> /TizenRT/tools/trap$ sudo ./trap.sh 
> Please enter serial port adapter:
> For example: /dev/ttyUSB1 or /dev/ttyACM0
> Enter:
> /dev/ttyUSB1
> Target device locked and ready to DUMP!!!
> Choose from the following options:-
> 1. RAM Dump
> 2. Userfs Dump
> 3. Both RAM and Userfs dumps
> 4. External Userfs Partition Dump
> 5. Dump specific file from target device
> r. Reboot TARGET Device
> x. Exit TRAP tool
> You may chose mutiple dump options together by entering the option numbers consectuively
> For Example - '14' to dump both RAM and External USERFS partition contents OR '35' to print RAM, USERFS and FILE contents
> 5
> This utility will allow you to enter a file name that you want to be dumped from the device
> It is the responsibility of the user to ensure that the correct file name/path is provided
> do_handshake: Target Handshake successful
> Enter the absolute path of the file that you want to be dumped from the Filesystem: -/mnt/f1.txt
> Attempting to Dump File /mnt/f1.txt from Target Device
> 
> Receiving file /mnt/f1.txt of size 5522 from Target Device
> 
> [>]
> 
> Dumped file /mnt/f1.txt from filesystem successfully
> Choose from the following options:-
> 1. RAM Dump
> 2. Userfs Dump
> 3. Both RAM and Userfs dumps
> 4. External Userfs Partition Dump
> 5. Dump specific file from target device
> r. Reboot TARGET Device
> x. Exit TRAP tool
> You may chose mutiple dump options together by entering the option numbers consectuively
> For Example - '14' to dump both RAM and External USERFS partition contents OR '35' to print RAM, USERFS and FILE contents
> r
> NOTE: - CONFIG_BOARD_ASSERT_AUTORESET needs to be enabled to reboot TARGET Device after a crash
> Handsake for rebooting device may fail since device reboots before sending acknowledgement
> Wrong Target Handshake, ack = H
> Target Handshake Failed
> Dump tool exits after successful operation