### PR TITLE
os/fs/smartfs: Fix mismatched type of jSmartFs entry timestamps

### DIFF
--- a/os/fs/smartfs/smartfs_utils.c
+++ b/os/fs/smartfs/smartfs_utils.c
@@ -161,7 +161,7 @@ struct sector_entry_queue_s {
 	uint16_t logsector;			/* Logical sector number */
 	uint16_t parentsector;		/* Logical sector which is chain with this */
 	uint16_t parentoffset;		/* Offset of parent entry in parent sector */
-	uint16_t time;				/* Timestamp of entry */
+	uint32_t time;				/* Timestamp of entry */
 };
 
 struct sector_recover_info_s {


### PR DESCRIPTION
- Entry timestamps of type uint32_t are mistakenly stored as type uint16_t for comparison checking
- They should be stored and compared as type uint32_t for effective functioning

Signed-off-by: Amogh Hassija <a.hassija@samsung.com>