### PR TITLE
mm/mm_heap: add DEBUG_SET_CALLER_ADDR() macro.

### DIFF
--- a/os/include/tinyara/mm/mm.h
+++ b/os/include/tinyara/mm/mm.h
@@ -249,6 +249,15 @@ typedef size_t mmsize_t;
 #error Unknown CONFIG_ARCH option, malloc debug feature wont work.
 #endif
 
+#ifdef CONFIG_DEBUG_MM_HEAPINFO
+/* This macro updates a caller return address in the 'mem' node.
+ * This will show the real owner of the 'mem' even it's allocated through wrapping APIs of malloc.
+ */
+#define DEBUG_SET_CALLER_ADDR(mem) heapinfo_set_caller_addr(mem, __builtin_return_address(0))
+#else
+#define DEBUG_SET_CALLER_ADDR(mem)
+#endif
+
 /* typedef is used for defining size of address space */
 
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
@@ -679,6 +688,7 @@ int mm_size2ndx(size_t size);
 void heapinfo_parse_heap(FAR struct mm_heap_s *heap, int mode, pid_t pid);
 /* Funciton to add memory allocation info */
 void heapinfo_update_node(FAR struct mm_allocnode_s *node, mmaddress_t caller_retaddr);
+void heapinfo_set_caller_addr(void *address, mmaddress_t caller_retaddr);
 
 void heapinfo_add_size(struct mm_heap_s *heap, pid_t pid, mmsize_t size);
 void heapinfo_subtract_size(struct mm_heap_s *heap, pid_t pid, mmsize_t size);

--- a/os/mm/mm_heap/mm_heapinfo_utils.c
+++ b/os/mm/mm_heap/mm_heapinfo_utils.c
@@ -129,6 +129,30 @@ void heapinfo_update_node(FAR struct mm_allocnode_s *node, mmaddress_t caller_re
 }
 
 /****************************************************************************
+ * Name: heapinfo_set_caller_addr
+ *
+ * Description:
+ * Set caller address of malloc API to mem chunk
+ * It is only called in DEBUG_SET_CALLER_ADDR macro
+ ****************************************************************************/
+void heapinfo_set_caller_addr(void *address, mmaddress_t caller_retaddr)
+{
+	struct mm_allocnode_s *node;
+	struct mm_heap_s *heap;
+
+	heap = mm_get_heap(address);
+	if (heap) {
+		node = (struct mm_allocnode_s *)((char *)address - SIZEOF_MM_ALLOCNODE);
+		mm_takesemaphore(heap);
+		heapinfo_update_node(node, caller_retaddr);
+		mm_givesemaphore(heap);
+	} else {
+		mdbg("Failed to set caller address, heap not found. addr:%x\n", address);
+	}
+
+}
+
+/****************************************************************************
  * Name: heapinfo_exclude_stacksize
  *
  * Description:


### PR DESCRIPTION
Malloc API caller address is saved in alloc_call_addr of chunk(alloc node). If wrapping malloc API, The caller address becames warpped function address.

This commit adds macro(DEBUG_SET_CALLER_ADDR), that recives allocated memory address and sets caller address of current funtion to alloc_call_addr of chunk.

When warpping malloc API, have to update caller address with this macro.

Signed-off-by: eunwoo.nam <eunwoo.nam@samsung.com>