### PR TITLE
os/include: Add DEBUGASSERT_INFO macro for descriptive debug output in case of DEBUGASSERT

### DIFF
--- a/os/include/assert.h
+++ b/os/include/assert.h
@@ -103,6 +103,14 @@ extern char assert_info_str[CONFIG_STDIO_BUFFER_SIZE];
 
 #ifdef CONFIG_DEBUG
 
+#define DEBUGASSERT_INFO(f, fmt, ...) \
+	{ \
+		if (!(f)) { \
+			  snprintf(assert_info_str, CONFIG_STDIO_BUFFER_SIZE, fmt, ##__VA_ARGS__); \
+			  up_assert((const uint8_t *)__FILE__, (int)__LINE__); \
+		} \
+	}
+
 #define DEBUGASSERT(f) \
 	{ if (!(f)) up_assert((const uint8_t *)__FILE__, (int)__LINE__); }
 
@@ -114,6 +122,7 @@ extern char assert_info_str[CONFIG_STDIO_BUFFER_SIZE];
 
 #else
 
+#define DEBUGASSERT_INFO(f, fmt, ...)
 #define DEBUGASSERT(f)
 #define DEBUGVERIFY(f) ((void)(f))
 #define DEBUGPANIC()
@@ -157,6 +166,13 @@ extern char assert_info_str[CONFIG_STDIO_BUFFER_SIZE];
 
 #ifdef CONFIG_DEBUG
 
+#define DEBUGASSERT_INFO(f, fmt, ...) \
+	{ \
+		if (!(f)) { \
+			  snprintf(assert_info_str, CONFIG_STDIO_BUFFER_SIZE, fmt, ##__VA_ARGS__): \
+			  up_assert(); \
+		} \
+	}
 /**
  * @brief Like ASSERT, but only if CONFIG_DEBUG is defined
  *
@@ -186,6 +202,7 @@ extern char assert_info_str[CONFIG_STDIO_BUFFER_SIZE];
 
 #else
 
+#define DEBUGASSERT_INFO(f, fmt, ...)
 #define DEBUGASSERT(f)
 #define DEBUGVERIFY(f) ((void)(f))
 #define DEBUGPANIC()

--- a/os/include/assert.h
+++ b/os/include/assert.h
@@ -86,7 +86,8 @@ extern char assert_info_str[CONFIG_STDIO_BUFFER_SIZE];
 
 #ifdef CONFIG_HAVE_FILENAME
 #define ASSERT_INFO(f, fmt, ...) \
-	{ if (!(f))	{ \
+	{ \
+		if (!(f)) { \
 			  snprintf(assert_info_str, CONFIG_STDIO_BUFFER_SIZE, fmt, ##__VA_ARGS__); \
 			  up_assert((const uint8_t *)__FILE__, (int)__LINE__); \
 		} \
@@ -132,10 +133,11 @@ extern char assert_info_str[CONFIG_STDIO_BUFFER_SIZE];
 #else
 
 #define ASSERT_INFO(f, fmt, ...) \
-	{ if (!(f))	{ \
+	{ \
+		if (!(f)) { \
 			  snprintf(assert_info_str, CONFIG_STDIO_BUFFER_SIZE, fmt, ##__VA_ARGS__); \
 			  up_assert(); \
-			} \
+		} \
 	}
 /**
  * @brief Assert if the condition is not true


### PR DESCRIPTION
- DEBUGASSERT_INFO gives out a descriptive output similar to ASSERT_INFO in case of DEBUGASSERTs

Sample output: -
```
TASH>>Hello, World!!
up_assert: Assertion failed at file:hello_main.c line: 71 task: appmain
up_assert: This is DEBUGASSERT_INFO in hello
up_dumpstate: Code asserted in normal thread!
up_dumpstate: Current SP is User Thread SP: 20090758
```

Signed-off-by: Amogh Hassija <a.hassija@samsung.com>