### PR TITLE
os/board/rtl8721csm/src/Makefile: Remove duplicate CFLAG

### DIFF
--- a/os/board/rtl8721csm/src/Makefile
+++ b/os/board/rtl8721csm/src/Makefile
@@ -191,17 +191,13 @@ OBJS = $(AOBJS) $(COBJS)
 
 ifeq ($(WINTOOL),y)
   CFLAGS += -I "${shell cygpath -w $(ARCH_SRCDIR)/chip}"
-  CFLAGS += -I "${shell cygpath -w $(ARCH_SRCDIR)/armv8-m}"
   CFLAGS += -I "${shell cygpath -w $(ARCH_SRCDIR)/common}"
-  CFLAGS += -I "${shell cygpath -w $(COMPONENT_DIR)/soc/realtek/amebad/cmsis}"
   CFLAGS += -I "${shell cygpath -w $(BOARD_SRCDIR)/common}"
   CFLAGS += -I "${shell cygpath -w $(BOARD_SRCDIR)/$(CONFIG_ARCH_BOARD)/src}"
 else
   CFLAGS += -I$(ARCH_SRCDIR)/chip
   CFLAGS += -I$(ARCH_SRCDIR)/common
-  CFLAGS += -I$(COMPONENT_DIR)/soc/realtek/amebad/cmsis
   CFLAGS += -I$(BOARD_SRCDIR)/common
-  CFLAGS += -I$(ARCH_SRCDIR)/armv8-m
   CFLAGS += -I$(BOARD_SRCDIR)/$(CONFIG_ARCH_BOARD)/src
 endif
 


### PR DESCRIPTION
The below lines add duplicate CFLAG.

152:      CFLAGS += -I$(TOPDIR)/arch/$(CONFIG_ARCH)/src/armv8-m
194,204:  CFLAGS += -I$(ARCH_SRCDIR)/armv8-m

154:      CFLAGS += -I$(COMPONENT_DIR)/soc/realtek/amebad/cmsis
196,202:  CFLAGS += -I$(COMPONENT_DIR)/soc/realtek/amebad/cmsis

If there are more duplicate CFLAG, we can get warning message like below line. 
ERROR: Path+file is too long [4107/4096]

It might be became potential error, This commit removes duplicate CFLAG.

Signed-off-by: eunwoo.nam <eunwoo.nam@samsung.com>