### PR TITLE
os/mm: Add heap dump option to heapinfo cmd

### DIFF
--- a/os/drivers/memory/mminfo.c
+++ b/os/drivers/memory/mminfo.c
@@ -116,11 +116,16 @@ static int mminfo_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
 			heap = mm_get_app_heap_with_name(option->app_name);
 			break;
 #endif
+
 		default:
 			break;
 		}
 		if (heap == NULL) {
 			return -EINVAL;
+		}
+		if (option->mode == HEAPINFO_DUMP_HEAP) {
+			heapinfo_dump_heap(heap);
+			return OK;
 		}
 		if (option->mode == HEAPINFO_INIT_PEAK) {
 			heap->peak_alloc_size = 0;

--- a/os/include/tinyara/mm/mm.h
+++ b/os/include/tinyara/mm/mm.h
@@ -195,6 +195,7 @@
 #define HEAPINFO_DETAIL_FREE 4
 #define HEAPINFO_DETAIL_SPECIFIC_HEAP 5
 #define HEAPINFO_INIT_PEAK 6
+#define HEAPINFO_DUMP_HEAP 7
 #define HEAPINFO_PID_ALL -1
 
 #define HEAPINFO_INIT_INFO -1
@@ -214,6 +215,10 @@
 #define KREGION_START (size_t)kregionx_start[0]
 #define KREGION_SIZE  kregionx_size[0]
 #define KREGION_END (KREGION_START + KREGION_SIZE)
+#endif
+
+#if defined(CONFIG_BUILD_FLAT) || defined(__KERNEL__)
+extern bool abort_mode;
 #endif
 
 /* Determines the size of the chunk size/offset type */
@@ -683,6 +688,8 @@ void mm_addfreechunk(FAR struct mm_heap_s *heap, FAR struct mm_freenode_s *node)
 
 int mm_size2ndx(size_t size);
 
+void mm_dump_heap_region(uint32_t start, uint32_t end);
+int heap_dbg(const char *fmt, ...);
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
 /* Functions contained in kmm_mallinfo.c . Used to display memory allocation details */
 void heapinfo_parse_heap(FAR struct mm_heap_s *heap, int mode, pid_t pid);
@@ -696,6 +703,7 @@ void heapinfo_update_total_size(struct mm_heap_s *heap, mmsize_t size, pid_t pid
 void heapinfo_exclude_stacksize(void *stack_ptr);
 void heapinfo_peak_init(struct mm_heap_s *heap);
 void heapinfo_dealloc_tcbinfo(void *address, pid_t pid);
+void heapinfo_dump_heap(struct mm_heap_s *heap);
 #ifdef CONFIG_HEAPINFO_USER_GROUP
 void heapinfo_update_group(mmsize_t size, pid_t pid);
 void heapinfo_update_group_info(pid_t pid, int group, int type);

--- a/os/mm/mm_heap/Make.defs
+++ b/os/mm/mm_heap/Make.defs
@@ -56,7 +56,7 @@ CSRCS += mm_initialize.c mm_sem.c mm_addfreechunk.c mm_size2ndx.c
 CSRCS += mm_shrinkchunk.c
 CSRCS += mm_brkaddr.c mm_calloc.c mm_extend.c mm_free.c mm_mallinfo.c
 CSRCS += mm_malloc.c mm_memalign.c mm_realloc.c mm_zalloc.c mm_heap_regioninfo.c mm_getheap.c
-CSRCS += mm_check_heap_corruption.c mm_manage_allocfail.c mm_getsize.c
+CSRCS += mm_check_heap_corruption.c mm_manage_allocfail.c mm_getsize.c mm_heap_dbg.c
 
 ifeq ($(CONFIG_BUILD_KERNEL),y)
 CSRCS += mm_sbrk.c

--- a/os/mm/mm_heap/mm_check_heap_corruption.c
+++ b/os/mm/mm_heap/mm_check_heap_corruption.c
@@ -72,9 +72,6 @@
 /****************************************************************************
  * Public data
  ****************************************************************************/
-#if defined(CONFIG_BUILD_FLAT) || defined(__KERNEL__)
-extern bool abort_mode;
-#endif
 /****************************************************************************
  * Private Data
  ****************************************************************************/
@@ -117,19 +114,6 @@ static void dump_node(struct mm_allocnode_s *node, char *node_type)
 	mfdbg("%s owner pid = %d%s, allocated by code at addr = 0x%08x\n", node_type, node->pid, is_stack, node->alloc_call_addr);
 #endif
 #endif
-}
-
-static void dump_corrupt_heap_region(uint32_t start, uint32_t end)
-{
-	mfdbg("#########################################################################################\n");
-	mfdbg("Dump heap : 0x%08x - 0x%08x\n", start, end);
-	mfdbg("#########################################################################################\n");
-	for (; start < end; start += 32) {
-		uint32_t *ptr = (uint32_t *)start;
-		mfdbg("%08x: %08x %08x %08x %08x %08x %08x %08x %08x\n",
-			   start, ptr[0], ptr[1], ptr[2], ptr[3], ptr[4], ptr[5], ptr[6], ptr[7]);
-	}
-	mfdbg("#########################################################################################\n");
 }
 
 /****************************************************************************
@@ -270,10 +254,10 @@ int mm_check_heap_corruption(struct mm_heap_s *heap)
 		if (iscorrupt_f || iscorrupt_r) {
 #if defined(CONFIG_MM_DUMP_CORRPUTED_HEAP)
 			mfdbg("CONFIG_MM_DUMP_CORRPUTED_HEAP enabled. Dumping full heap!!\n");
-			dump_corrupt_heap_region(heap->mm_heapstart[region], (uint32_t)(heap->mm_heapend[region]) + SIZEOF_MM_ALLOCNODE);
+			heapinfo_dump_heap_region(heap->mm_heapstart[region], (uint32_t)(heap->mm_heapend[region]) + SIZEOF_MM_ALLOCNODE);
 #else
 			mfdbg("Dumping the corrupted heap area\n");
-			dump_corrupt_heap_region(start_corrupt, end_corrupt);
+			mm_dump_heap_region(start_corrupt, end_corrupt);
 #endif
 			return -1;
 		}

--- a/os/mm/mm_heap/mm_heap_dbg.c
+++ b/os/mm/mm_heap/mm_heap_dbg.c
@@ -1,0 +1,73 @@
+/****************************************************************************
+ *
+ * Copyright 2023 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+#include <tinyara/config.h>
+#include <unistd.h>
+#include <stdint.h>
+#include <sys/types.h>
+#include <tinyara/sched.h>
+#include <tinyara/mm/mm.h>
+
+/************************************************************************
+ * Name: heap_dbg
+ *
+ * Description: Dump heap info debug logs without adding function name to start of log.
+ ************************************************************************/
+int heap_dbg(const char *fmt, ...)
+{
+	va_list ap;
+	int ret;
+
+	va_start(ap, fmt);
+#if defined(CONFIG_BUILD_FLAT) || defined(__KERNEL__)
+	extern bool abort_mode;
+
+	if (abort_mode) {
+		ret = lowvsyslog(LOG_ERR, fmt, ap);
+	} else {
+		ret = vsyslog(LOG_ERR, fmt, ap);
+	}
+#else
+	ret = vsyslog(LOG_ERR, fmt, ap);
+#endif
+	va_end(ap);
+
+	return ret;
+}
+
+/************************************************************************
+ * Name: mm_dump_heap_region
+ *
+ * Description: Print the hex value contents of heap from start to end address.
+ ************************************************************************/
+void mm_dump_heap_region(uint32_t start, uint32_t end)
+{
+	heap_dbg("#########################################################################################\n");
+	heap_dbg("Dump heap: 0x%08x - 0x%08x\n", start, end);
+	heap_dbg("#########################################################################################\n");
+	for (; start < end; start += 32) {
+		uint32_t *ptr = (uint32_t *)start;
+		heap_dbg("%08x: %08x %08x %08x %08x %08x %08x %08x %08x\n",
+			   start, ptr[0], ptr[1], ptr[2], ptr[3], ptr[4], ptr[5], ptr[6], ptr[7]);
+	}
+	heap_dbg("#########################################################################################\n");
+}
+


### PR DESCRIPTION
Allow user to dump entire heap regions using heapinfo command. Add new option -d for dumping heap. The -d option may be followed by option "kernel" or the app name to indicate the heap to be dumped.

Signed-off-by: Kishore S N <kishore.sn@samsung.com>