### PR TITLE
log_dump.c: Fix hang issue in log dump module

### DIFF
--- a/os/include/tinyara/mm/mm.h
+++ b/os/include/tinyara/mm/mm.h
@@ -455,6 +455,9 @@ extern uint32_t g_cur_app;
 #define BASE_HEAP       g_kmmheap
 #endif
 
+// Check if the kernel heap has been locked by any process.
+#define IS_KMM_LOCKED()		(g_kmmheap->mm_counts_held > 0 ? 1 : 0)
+
 /****************************************************************************
  * Public Function Prototypes
  ****************************************************************************/

--- a/os/kernel/Kconfig
+++ b/os/kernel/Kconfig
@@ -1026,4 +1026,8 @@ config LOG_DUMP_MAX_FREE_HEAP
 	int "Maximum percent of memory occupied by logs compared to free heap"
 	default 20
 
+config LOG_DUMP_NUMBUFS
+	int "Number of buffers to reserve for log dump"
+	default 2
+
 endif # LOG_DUMP

--- a/os/kernel/Kconfig
+++ b/os/kernel/Kconfig
@@ -1004,6 +1004,11 @@ config LOG_DUMP
 
 if LOG_DUMP
 
+config LOG_DUMP_PRIO
+	int "Log dump comrpess thread priority"
+	range 0 250
+	default 200
+
 config LOG_DUMP_CHUNK_SIZE
 	int "Log dump chunk size in bytes"
 	range 0 LOG_DUMP_MAX_SIZE

--- a/os/kernel/init/os_bringup.c
+++ b/os/kernel/init/os_bringup.c
@@ -297,7 +297,7 @@ static inline void os_do_appstart(void)
 #ifdef CONFIG_LOG_DUMP
 	svdbg("Starting log_dump thread\n");
 
-	pid = kernel_thread(LOG_DUMP_NAME, 200, LOG_DUMP_STACKSIZE, log_dump, NULL);
+	pid = kernel_thread(LOG_DUMP_NAME, CONFIG_LOG_DUMP_PRIO, LOG_DUMP_STACKSIZE, log_dump, NULL);
 	if (pid < 0) {
 		sdbg("Failed to start log dump");
 	}

--- a/os/kernel/log_dump/log_dump.c
+++ b/os/kernel/log_dump/log_dump.c
@@ -56,6 +56,7 @@
 #define LOG_DUMP_MEM_FAIL		-1
 #define LOG_DUMP_COMPHEAD_OFFSET	-1
 #define LOG_DUMP_OPT_FAIL		-2
+#define LOG_DUMP_FAIL			-99
 #define LOG_DUMP_STRLEN_FREEHEAP		15	/* String size to display Free heap size */
 #define LOG_DUMP_COMPRESS_NODESZ	5	/* use 4 char to store compressed node size */
 
@@ -382,6 +383,14 @@ int log_dump_save(char ch)
 		 */
 		if (IS_KMM_LOCKED()) {
 			return LOG_DUMP_MEM_FAIL;
+		}
+
+		/* If the current thread priority is greater than the compress thread
+		 * priority, then there will be a lockup since both threads cannot proceed. 
+		 * So, in this case, we will return without performing the compression.
+		 */
+		if (sched_self()->sched_priority > CONFIG_LOG_DUMP_PRIO) {
+			return LOG_DUMP_FAIL;
 		}
 
 		/* compress the block, add it to the nodes, reset the uncomp_array */


### PR DESCRIPTION
If log dump is enabled, and we run heapinfo command, then there is a hang issue. This is because, the heapinfo command locks the kernel heap. But, at the same time heapinfo logs are sent to log dump module which tries to allocate buffer. Since, the heap is already locked by the heapinfo command, it results in a lock-up.

To overcome this issue, upon entering logdump api we will check if the kernel heap is locked before performing the log dump operations which require memory to be allocated or freed. The log dump operation will not be performed as long as the heap is locked. So, any logs printed during this time will not get included in the log dump.

Signed-off-by: Kishore S N <kishore.sn@samsung.com>