### PR TITLE
Add checking TCB state in kwork_signal when signal.

### DIFF
--- a/os/include/tinyara/sched.h
+++ b/os/include/tinyara/sched.h
@@ -824,6 +824,15 @@ void sched_foreach(sched_foreach_t handler, FAR void *arg);
  */
 FAR struct tcb_s *sched_gettcb(pid_t pid);
 
+/**
+ * @ingroup SCHED_KERNEL
+ * @brief Get the task state associated with the pid.
+ * @details @b #include <tinyara/sched.h>
+ * @param[in] pid Pid for tcb
+ * @return On success, returns task state. On error, less than zero is returned.
+ */
+uint8_t task_getstate(pid_t pid);
+
 /* File system helpers **********************************************************/
 /* These functions all extract lists from the group structure assocated with the
  * currently executing task.

--- a/os/kernel/sched/sched_setpriority.c
+++ b/os/kernel/sched/sched_setpriority.c
@@ -106,7 +106,7 @@
  *   sched_priority - The new task priority
  *
  * Return Value:
- *   On success, sched_setparam() returns 0 (OK). On error, -1 (ERROR) is
+ *   On success, sched_setpriority() returns 0 (OK). On error, -1 (ERROR) is
  *   returned, and errno is set appropriately.
  *
  *  EINVAL The parameter 'param' is invalid or does not make sense for the

--- a/os/kernel/task/Make.defs
+++ b/os/kernel/task/Make.defs
@@ -55,6 +55,7 @@ CSRCS += task_start.c task_delete.c task_exit.c task_exithook.c
 CSRCS += task_recover.c task_restart.c
 CSRCS += task_terminate.c task_getgroup.c task_prctl.c task_getpid.c
 CSRCS += exit.c task_setcancelstate.c task_dumptasks.c
+CSRCS += task_getstate.c
 
 ifeq ($(CONFIG_ARCH_HAVE_VFORK),y)
 ifeq ($(CONFIG_SCHED_WAITPID),y)

--- a/os/kernel/task/task_getstate.c
+++ b/os/kernel/task/task_getstate.c
@@ -1,0 +1,84 @@
+/****************************************************************************
+ *
+ * Copyright 2023 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+/************************************************************************
+ * Included Files
+ ************************************************************************/
+
+#include <errno.h>
+#include <sched.h>
+
+/************************************************************************
+ * Definitions
+ ************************************************************************/
+
+/************************************************************************
+ * Private Type Declarations
+ ************************************************************************/
+
+/************************************************************************
+ * Global Variables
+ ************************************************************************/
+
+/************************************************************************
+ * Private Variables
+ ************************************************************************/
+
+/************************************************************************
+ * Private Function Prototypes
+ ************************************************************************/
+
+/************************************************************************
+ * Private Functionss
+ ************************************************************************/
+
+/************************************************************************
+ * Public Functions
+ ************************************************************************/
+
+/************************************************************************
+ * Name:  task_getstate
+ *
+ * Description:
+ *   Get the task state associated with the pid.
+ *
+ * Inputs
+ *   pid - the task ID of the task to query.
+ *
+ * Return Value:
+ *   On success, task_getstate() returns task state. On error, less than
+ *   zero is returned.
+ *
+ *   ESRCH - The task whose ID is pid could not be found.
+ *
+ ************************************************************************/
+
+uint8_t task_getstate(pid_t pid)
+{
+	struct tcb_s *tcb;
+
+	/* Get the TCB associated with the pid */
+	tcb = sched_gettcb(pid);
+
+	if (!tcb) {
+		/* No task with this pid was found */
+		return -ESRCH;
+	}
+
+	return tcb->task_state;
+}


### PR DESCRIPTION
 Signal after adding to the wqueue for process the work queue now.
 but worker thread don't need to receive the signal when it is processing the work queue.
 This PR adds checking the thread state, when signal. It only signal when work thread state is TSTATE_WAIT_SIG.

for this, I add sched_is_sigwait(). This function checks if TCB state is TSTATE_WAIT_SIG and returns it.

and I correct wrong function name in description in sched_setpriority.c