### PR TITLE
os/wqueue/kwqueue: Change slldbg to sdbg in wqueue.

### DIFF
--- a/os/wqueue/kwqueue/kwork_hpthread.c
+++ b/os/wqueue/kwqueue/kwork_hpthread.c
@@ -191,7 +191,7 @@ int work_hpstart(void)
 		int errcode = errno;
 		DEBUGASSERT(errcode > 0);
 
-		slldbg("kernel_thread failed: %d\n", errcode);
+		sdbg("kernel_thread failed: %d\n", errcode);
 		return -errcode;
 	}
 

--- a/os/wqueue/kwqueue/kwork_lpthread.c
+++ b/os/wqueue/kwqueue/kwork_lpthread.c
@@ -235,7 +235,7 @@ int work_lpstart(void)
 			int errcode = errno;
 			DEBUGASSERT(errcode > 0);
 
-			slldbg("kernel_thread %d failed: %d\n", wndx, errcode);
+			sdbg("kernel_thread %d failed: %d\n", wndx, errcode);
 			sched_unlock();
 			return -errcode;
 		}


### PR DESCRIPTION
The lldbg have to used only when OS doesn't work normally, such as OS init or assert or other special cases. 
However, This case is OS normal operation. so This commit changes slldbg to sdbg.

Signed-off-by: eunwoo.nam <eunwoo.nam@samsung.com>