### PR TITLE
mm: Modify heap region dump API

### DIFF
--- a/os/mm/mm_heap/mm_check_heap_corruption.c
+++ b/os/mm/mm_heap/mm_check_heap_corruption.c
@@ -254,7 +254,7 @@ int mm_check_heap_corruption(struct mm_heap_s *heap)
 		if (iscorrupt_f || iscorrupt_r) {
 #if defined(CONFIG_MM_DUMP_CORRPUTED_HEAP)
 			mfdbg("CONFIG_MM_DUMP_CORRPUTED_HEAP enabled. Dumping full heap!!\n");
-			heapinfo_dump_heap_region(heap->mm_heapstart[region], (uint32_t)(heap->mm_heapend[region]) + SIZEOF_MM_ALLOCNODE);
+			mm_dump_heap_region(heap->mm_heapstart[region], (uint32_t)(heap->mm_heapend[region]) + SIZEOF_MM_ALLOCNODE);
 #else
 			mfdbg("Dumping the corrupted heap area\n");
 			mm_dump_heap_region(start_corrupt, end_corrupt);


### PR DESCRIPTION
Modify the heap region dump api to mm_dump_heap_region in the heap corruption code. This change was missed out in previous commit when the API was changed from heapinfo_dump_heap_region to mm_dump_heap_region.