### PR TITLE
os/tools/check_package_size.py : add used ratio of flash memory

### DIFF
--- a/os/tools/check_package_size.py
+++ b/os/tools/check_package_size.py
@@ -30,6 +30,7 @@ cfg_file = os_folder + '/.config'
 tool_folder = os_folder + '/tools'
 build_folder = os_folder + '/../build'
 output_folder = build_folder + '/output/bin'
+output_file_name = output_folder + '/tinyara_binarysize.txt'
 
 FAIL_TO_BUILD = False
 WARNING_RATIO = 95
@@ -59,14 +60,20 @@ def check_binary_size(bin_type, part_size):
         global FAIL_TO_BUILD
         FAIL_TO_BUILD = True
         check_result = "FAIL"
+        result_mark = ""
     elif used_ratio > WARNING_RATIO :
         check_result = "WARNING"
+        result_mark = ":warning:"
     else :
         check_result = "PASS"
+        result_mark = ":heavy_check_mark:"
 
     # Print each information
     print(" {:7}".format(bin_type) + " " + number_with_comma_align(BINARY_SIZE) + " bytes   " +
             number_with_comma_align(PARTITION_SIZE) + " bytes    " + "{:6}".format(used_ratio) + "%    " + check_result)
+    # File print each information
+    outfile.write(bin_type + " | " + number_with_comma(BINARY_SIZE) + " bytes | " +
+        number_with_comma(PARTITION_SIZE) + " bytes | " + str(used_ratio)+"%" + " | " + result_mark + check_result + "\n")
 
 def check_binary_header(bin_type):
     # Read the binary name from .bininfo
@@ -139,6 +146,12 @@ APP2_PARTITION_SIZE = int(SIZE_LIST[APP2_IDX]) * 1024
 print("\n========== Size Verification of built Binaries ==========")
 print("Type        Binary Size     Partition Size      used(%)")
 
+# File print init
+outfile = open(output_file_name, 'w')
+outfile.write("========== Size Verification of built Binaries ==========\n")
+outfile.write("Type | Binary Size | Partition Size | used(%) | result\n")
+outfile.write("-- | -- | -- | -- | --\n")
+
 fail_type_list = []
 check_binary_size("KERNEL", KERNEL_PARTITION_SIZE)
 if CONFIG_APP_BINARY_SEPARATION == "y" :
@@ -148,7 +161,7 @@ if CONFIG_APP_BINARY_SEPARATION == "y" :
         check_binary_size("APP2", APP2_PARTITION_SIZE)
     if CONFIG_SUPPORT_COMMON_BINARY == "y" :
         check_binary_size("COMMON", COMMON_PARTITION_SIZE)
-
+outfile.close()
 if FAIL_TO_BUILD == True :
     # Stop to build, because there is mismatched size problem.
     print("!!!!!!!! ERROR !!!!!!!")


### PR DESCRIPTION
This PR adds build log about the ratio of flash memory used for each partition.
The usaed ratio means (Binary Size)/(Partition Size) and is divided into PASS, WARNING, FAIL according to used ratio.
 - PASS: The used ratio is 95% or less.
 - WARNING: The used ratio exceeds 95%.
 - FAIL: Binary size is larger than partition size. It is build fail.

The printed build log examples are as below.

case1
```
========== Size Verification of built Binaries ==========
Type        Binary Size     Partition Size      used(%)
 KERNEL   1,110,848 bytes    1,835,008 bytes     60.54%    PASS
=> Size verification SUCCESS!! The size of all binaries are OK.
```
case2
```
========== Size Verification of built Binaries ==========
Type        Binary Size     Partition Size      used(%)
 KERNEL     795,456 bytes    1,835,008 bytes     43.35%    PASS
 APP1       624,288 bytes      524,288 bytes    119.07%    FAIL
 APP2     1,010,384 bytes    1,040,384 bytes     97.12%    WARNING
!!!!!!!! ERROR !!!!!!!
=> APP1 Binary will be deleted. Need to re-configure the partition using menuconfig and to re-build.
```


And This information printed with build/output/bin/tinyara_binarysize.txt
The printed contents are markdown format like below. This file is uesd in CI/CD.
```
========== Size Verification of built Binaries ==========
Type | Binary Size | Partition Size | used(%) | result
-- | -- | -- | -- | --
KERNEL | 795,456 bytes | 1,835,008 bytes | 43.35% | :heavy_check_mark:PASS
APP1 | 524,288 bytes | 524,288 bytes | 100.0% | :warning:WARNING
APP2 | 1,010,384 bytes | 1,040,384 bytes | 97.12% | :warning:WARNING
```
Type | Binary Size | Partition Size | used(%) | result
-- | -- | -- | -- | --
KERNEL | 795,456 bytes | 1,835,008 bytes | 43.35% | :heavy_check_mark:PASS
APP1 | 524,288 bytes | 524,288 bytes | 100.0% | :warning:WARNING
APP2 | 1,010,384 bytes | 1,040,384 bytes | 97.12% | :warning:WARNING