### PR TITLE
os/board/rtl8720e: Fix wlan idx selection

### DIFF
--- a/os/board/rtl8720e/src/component/os/tizenrt/ethernetif_tizenrt.c
+++ b/os/board/rtl8720e/src/component/os/tizenrt/ethernetif_tizenrt.c
@@ -97,6 +97,9 @@
 #define IF2NAME1 '2'
 #endif
 
+/* Check if current mode is softap */
+extern int softap_flag;
+
 static void arp_timer(void *arg);
 
 #if 0
@@ -155,6 +158,7 @@ err_t low_level_output(struct netdev *dev, uint8_t *data, uint16_t dlen)
 	struct eth_drv_sg sg_list[MAX_ETH_DRV_SG];
 	int sg_len = 0;
 	int ret = 0;
+	int idx = 0;
 
 #if CONFIG_WLAN
 /*
@@ -170,7 +174,11 @@ err_t low_level_output(struct netdev *dev, uint8_t *data, uint16_t dlen)
 	if (sg_len) {
 #if CONFIG_WLAN
 #if defined(CONFIG_AS_INIC_AP)
-		ret = inic_ipc_host_send(get_idx_from_dev(dev), sg_list, sg_len, dlen);
+		/* Currently TizenRT only uses idx 0 on application layer, but KR4 splits STA and SOFTAP into idx 0 and idx 1, need to check which idx to send to */
+		if (softap_flag == 1) {
+			idx = 1;
+		}
+		ret = inic_ipc_host_send(idx, sg_list, sg_len, dlen);
 		if (ret == ERR_IF) {
 			return ret;
 		}

--- a/os/board/rtl8720e/src/component/os/tizenrt/rtk_netmgr.c
+++ b/os/board/rtl8720e/src/component/os/tizenrt/rtk_netmgr.c
@@ -85,6 +85,7 @@ static trwifi_scan_list_s *g_scan_list;
 static int g_scan_num;
 extern struct netdev *ameba_nm_dev_wlan0;
 rtw_result_t app_scan_result_handler_legacy(rtw_scan_handler_result_t *malloced_scan_result);
+int softap_flag = 0;
 
 
 #define SCAN_TIMER_DURATION 180000
@@ -364,6 +365,7 @@ trwifi_result_e wifi_netmgr_utils_init(struct netdev *dev)
 		/*extern const char lib_wlan_rev[];
 		RTW_API_INFO("\n\rwlan_version %s\n", lib_wlan_rev);*/
 		wuret = TRWIFI_SUCCESS;
+		softap_flag = 0;
 		rtw_mutex_init(&scanlistbusy);
 	} else {
 		ndbg("Already %d\n", g_mode);
@@ -589,7 +591,7 @@ trwifi_result_e wifi_netmgr_utils_start_softap(struct netdev *dev, trwifi_softap
 	}
 	g_mode = RTK_WIFI_SOFT_AP_IF;
 	nvdbg("[RTK] SoftAP with SSID: %s has successfully started!\n", softap_config->ssid);
-
+	softap_flag = 1;
 	ret = TRWIFI_SUCCESS;
 
 	return ret;
@@ -617,6 +619,7 @@ trwifi_result_e wifi_netmgr_utils_start_sta(struct netdev *dev)
 	if (ret == RTK_STATUS_SUCCESS) {
 		g_mode = RTK_WIFI_STATION_IF;
 		wuret = TRWIFI_SUCCESS;
+		softap_flag = 0;
 	} else {
 		ndbg("[RTK] Failed to start STA mode\n");
 	}
@@ -632,6 +635,7 @@ trwifi_result_e wifi_netmgr_utils_stop_softap(struct netdev *dev)
 		if (ret == RTK_STATUS_SUCCESS) {
 			g_mode = RTK_WIFI_NONE;
 			wuret = TRWIFI_SUCCESS;
+			softap_flag = 0;
 			nvdbg("[RTK] Stop AP mode successfully\n");
 		} else {
 			ndbg("[RTK] Stop AP mode fail\n");

--- a/os/board/rtl8720e/src/component/wifi/inic/inic_ipc_host_trx.c
+++ b/os/board/rtl8720e/src/component/wifi/inic/inic_ipc_host_trx.c
@@ -149,13 +149,11 @@ static void inic_ipc_host_rx_tasklet(void)
 
 		while ((precvbuf = inic_dequeue_recvbuf(recv_queue))) {
 			p_buf = precvbuf->p_buf;
-			index = precvbuf->idx_wlan;
+			/* Currently TizenRT only uses idx 0 */
+			// index = precvbuf->idx_wlan;
 			g_inic_host_priv.rx_bytes += p_buf->len;
 			g_inic_host_priv.rx_pkts++;
 			
-			if (wifi_is_running(SOFTAP_WLAN_INDEX)) {
-				index = 0;
-			}
 			struct netdev *dev_tmp = NULL;
 			dev_tmp = (struct netdev *)rtk_get_netdev(index);
 			struct netif *netif = GET_NETIF_FROM_NETDEV(dev_tmp);
@@ -381,9 +379,6 @@ int inic_ipc_host_send(int idx, struct eth_drv_sg *sg_list, int sg_len,
 	DCache_CleanInvalidate(((u32)skb->head - sizeof(struct list_head)), sizeof(struct skb_data));
 	DCache_CleanInvalidate(((u32)skb - sizeof(struct list_head)), sizeof(struct skb_buf));
 #endif /* CONFIG_ENABLE_CACHE */
-	if (wifi_is_running(SOFTAP_WLAN_INDEX)) {
-		idx = 1;
-	}
 	WIFI_MONITOR_TIMER_START(wlan_send_time3);
 	inic_ipc_host_send_skb(idx, skb);
 	WIFI_MONITOR_TIMER_END(wlan_send_time3, total_len);


### PR DESCRIPTION
Fix check for wlan idx by using flag, previous implementation affected throughput

In 10.1a SDK update, STA is wlan idx 0 and SOFTAP is wlan idx 1 in Wi-Fi driver
Because application layer is using wlan idx 0 regardless of STA or SOFTAP, it needs to know whether to send to STA (idx 0) or SOFTAP (idx 1) when application is sending data to Wi-Fi driver. This is done by checking whether application layer is in SOFTAP mode
Previously, this was done using wifi_is_running(), but it affected the Wi-Fi throughput and caused a bottleneck
This PR will resolve the bottleneck by using a flag "softap_flag" to check whether application is in SOFTAP mode and send data to the Wi-Fi driver with the correct idx