### PR TITLE
kernel/debug/mem_leak_checker.c: modify print format of mem_leak

### DIFF
--- a/os/kernel/debug/mem_leak_checker.c
+++ b/os/kernel/debug/mem_leak_checker.c
@@ -315,7 +315,7 @@ static void print_info(char *bin_name, int leak_cnt, int broken_cnt, uint32_t bi
 #endif
 
 	if (leak_cnt > 0 || broken_cnt > 0) {
-		printf("Type   |    Addr   |   Size   |  Owner  | PID \n");
+		printf("Type   |    Addr    | Size(byte) |    Owner   | PID \n");
 		printf("---------------------------------------------------\n");
 
 		mm_takesemaphore((struct mm_heap_s *)leak_checker.heap);
@@ -347,7 +347,7 @@ static void print_info(char *bin_name, int leak_cnt, int broken_cnt, uint32_t bi
 					 */
 					pid = (-1) * pid;
 				}
-				printf("LEAK   |  %p  | %8d | %p | %d\n", (void *)((char *)node + SIZEOF_MM_ALLOCNODE), node->size - SIZEOF_MM_ALLOCNODE, owner_addr, pid);
+				printf("LEAK   | %10p |  %8d  | %10p | %d\n", (void *)((char *)node + SIZEOF_MM_ALLOCNODE), node->size - SIZEOF_MM_ALLOCNODE, owner_addr, pid);
 			} else if (node->reserved == MEM_BROKEN) {
 				printf("BROKEN | %p\n", node);
 			}


### PR DESCRIPTION
Modify print format to indicate byte which is unit of leak memory size.
 And modify the spaces so that the lines are aligned.

1)Before
```
Type   |    Addr   |   Size   |  Owner  | PID
---------------------------------------------------
LEAK   |  0x1006fef0  |       16 | 0xe007899 | 9
LEAK   |  0x100756c0  |     4000 | 0xe0078a1 | 9
LEAK   |  0x2001fc0  |    40000 | 0xe0078a9 | 9
*** 3 LEAKS, 0 BROKENS.
```

2)After
```
Type   |    Addr    | Size(byte) |    Owner   | PID
---------------------------------------------------
LEAK   | 0x1006fef0 |        16  |  0xe007899 | 9
LEAK   | 0x100756c0 |      4000  |  0xe0078a1 | 9
LEAK   |  0x2001fc0 |     40000  |  0xe0078a9 | 9
```
*** 3 LEAKS, 0 BROKENS.