### PR TITLE
os/board/rtl8721csm : reset scan with ssid setting to default

### DIFF
--- a/os/board/rtl8721csm/src/component/os/tizenrt/rtk_netmgr.c
+++ b/os/board/rtl8721csm/src/component/os/tizenrt/rtk_netmgr.c
@@ -356,35 +356,34 @@ rtw_result_t app_scan_result_handler(rtw_scan_handler_result_t *malloced_scan_re
 int parse_scan_with_ssid_res(char*buf, int buflen, char *target_ssid, void *user_data)
 {
 	if (rltk_wlan_scan_with_ssid_by_extended_security_is_enable()) {
-			int plen = 0, scan_cnt = 0;
-			rtw_scan_handler_result_t scan_result_report;
-			scan_result_report.scan_complete = RTW_FALSE;
-			scan_result_report.user_data = user_data;
-			while (plen < buflen) {
-				int len;
-				rtw_memset(&scan_result_report.ap_details, 0, sizeof(scan_result_report.ap_details));
-				len = (int)*(buf + plen);
-				if (len == 0) break;
-				scan_result_report.ap_details.SSID.len = len - 1 - 6 - 4 - 4 - 1 - 1;
-				rtw_memcpy(&scan_result_report.ap_details.SSID.val, (buf + plen + 1 + 6 + 4 + 4 + 1 + 1), scan_result_report.ap_details.SSID.len);
-				rtw_memcpy(&scan_result_report.ap_details.BSSID.octet, buf + plen + 1, 6);
-				rtw_memcpy(&scan_result_report.ap_details.signal_strength, buf + plen + 1 + 6, 4);
-				rtw_memcpy(&scan_result_report.ap_details.security, buf + plen + 1 + 6 + 4, 4);
-				scan_result_report.ap_details.wps_type = (int)*(buf + plen + 1 + 6 + 4 + 4);
-				scan_result_report.ap_details.channel = (int)*(buf + plen + 1 + 6 + 4 + 4 + 1);
-				app_scan_result_handler(&scan_result_report);
-				plen += len;
-				scan_cnt++;
-			}
-			//RTW_API_INFO("\n\rwifi_scan: scan count = %d, scan_cnt);
-			rltk_wlan_enable_scan_with_ssid_by_extended_security(0);
-			scan_result_report.scan_complete = RTW_TRUE;
+		int plen = 0, scan_cnt = 0;
+		rtw_scan_handler_result_t scan_result_report;
+		scan_result_report.scan_complete = RTW_FALSE;
+		scan_result_report.user_data = user_data;
+		while (plen < buflen) {
+			int len;
+			rtw_memset(&scan_result_report.ap_details, 0, sizeof(scan_result_report.ap_details));
+			len = (int)*(buf + plen);
+			if (len == 0) break;
+			scan_result_report.ap_details.SSID.len = len - 1 - 6 - 4 - 4 - 1 - 1;
+			rtw_memcpy(&scan_result_report.ap_details.SSID.val, (buf + plen + 1 + 6 + 4 + 4 + 1 + 1), scan_result_report.ap_details.SSID.len);
+			rtw_memcpy(&scan_result_report.ap_details.BSSID.octet, buf + plen + 1, 6);
+			rtw_memcpy(&scan_result_report.ap_details.signal_strength, buf + plen + 1 + 6, 4);
+			rtw_memcpy(&scan_result_report.ap_details.security, buf + plen + 1 + 6 + 4, 4);
+			scan_result_report.ap_details.wps_type = (int)*(buf + plen + 1 + 6 + 4 + 4);
+			scan_result_report.ap_details.channel = (int)*(buf + plen + 1 + 6 + 4 + 4 + 1);
 			app_scan_result_handler(&scan_result_report);
-			return RTW_SUCCESS;
-		} else {
-			RTW_API_INFO("scan_with_ssid_by_extended_security is not enabled\n");
-			return RTW_ERROR;
+			plen += len;
+			scan_cnt++;
 		}
+		//RTW_API_INFO("\n\rwifi_scan: scan count = %d, scan_cnt);
+		scan_result_report.scan_complete = RTW_TRUE;
+		app_scan_result_handler(&scan_result_report);
+		return RTW_SUCCESS;
+	} else {
+		RTW_API_INFO("scan_with_ssid_by_extended_security is not enabled\n");
+		return RTW_ERROR;
+	}
 }
 
 /*
@@ -534,8 +533,10 @@ trwifi_result_e wifi_netmgr_utils_scan_ap(struct netdev *dev, trwifi_scan_config
 			rltk_wlan_enable_scan_with_ssid_by_extended_security(1);
 			if (wifi_scan_networks_with_ssid(parse_scan_with_ssid_res, NULL,
 											scan_buf_len, config->ssid, config->ssid_length) != RTW_SUCCESS) {
+				rltk_wlan_enable_scan_with_ssid_by_extended_security(0);
 				return TRWIFI_FAIL;
 			}
+			rltk_wlan_enable_scan_with_ssid_by_extended_security(0);
 		} else {
 			RTW_API_INFO("Invalid channel range\n");
 			return TRWIFI_FAIL;


### PR DESCRIPTION
Reset the  "rltk_wlan_enable_scan_with_ssid_by_extended_security" setting back to default 0 
Modified for both success and fail case of scan with ssid