### PR TITLE
os/arch/arm/src/amebad: Fix I2S for RTL8721CSM

### DIFF
--- a/os/arch/arm/src/amebad/Kconfig
+++ b/os/arch/arm/src/amebad/Kconfig
@@ -51,6 +51,55 @@ config RTL8721D_SERIAL_FIFO
 	bool "UART SERIAL FIFO"
 	default n
 
+config AMEBAD_I2S
+	bool "Enable Amebad I2S"
+	default n
+
+if AMEBAD_I2S
+config AMEBAD_I2S_RX
+	bool "Enable I2S RX"
+	default n
+
+config AMEBAD_I2S_TX
+	bool "Enable I2S TX"
+	default n
+
+config AMEBAD_I2S_16BIT_PADDING
+	bool "Enable I2S 16-bit padding"
+	default n
+	---help---
+		Enable 16-bit padding to send 16bit I2S data in 32bit word length
+endif
+
+config AMEBAD_I2C_DYNTIMEO
+	bool "[Amebad I2C]Use dynamic timeouts"
+	default n
+
+config AMEBAD_I2C_DYNTIMEO_USECPERBYTE
+	int "[Amebad I2C]Timeout Microseconds per Byte"
+	default 500
+	depends on AMEBAD_I2C_DYNTIMEO
+
+config AMEBAD_I2C_DYNTIMEO_STARTSTOP
+	int "[Amebad I2C]Timeout for Start/Stop (Milliseconds)"
+	default 1000
+	depends on AMEBAD_I2C_DYNTIMEO
+
+config AMEBAD_I2CTIMEOSEC
+	int "[Amebad I2C]Timeout seconds"
+	default 0
+	depends on !AMEBAD_I2C_DYNTIMEO
+
+config AMEBAD_I2CTIMEOMS
+	int "[Amebad I2C]Timeout Milliseconds"
+	default 500
+	depends on !AMEBAD_I2C_DYNTIMEO
+
+config AMEBAD_I2CTIMEOTICKS
+	int "[Amebad I2C]Timeout for Done and Stop (ticks)"
+	default 500
+	depends on !AMEBAD_I2C_DYNTIMEO
+
 endmenu
 
 menu "Realtek RTL8721D WIFI Support"

--- a/os/arch/arm/src/amebad/Make.defs
+++ b/os/arch/arm/src/amebad/Make.defs
@@ -169,9 +169,11 @@ CHIP_CSRCS += amebad_rtc_lowerhalf.c
 CHIP_CSRCS += amebad_rtc.c
 CHIP_CSRCS += amebad_watchdog_lowerhalf.c
 CHIP_CSRCS += amebad_i2c.c
-CHIP_CSRCS += amebad_i2s.c
 CHIP_CSRCS += amebad_spi.c
 
+ifeq ($(CONFIG_AMEBAD_I2S),y)
+CHIP_CSRCS += amebad_i2s.c
+endif
 ifeq ($(CONFIG_BOARDCTL_RESET),y)
 CHIP_CSRCS += amebad_systemreset.c
 endif

--- a/os/arch/arm/src/amebad/amebad_i2s.c
+++ b/os/arch/arm/src/amebad/amebad_i2s.c
@@ -116,10 +116,13 @@
 
 #define OVER_SAMPLE_RATE (384U)
 
-#define I2S_DMA_PAGE_SIZE	768   // 2 ~ 4096
-#define I2S_DMA_PAGE_NUM    4   // Vaild number is 2~4
+#define I2S_DMA_PAGE_SIZE	1024   /* 4 ~ 16384, set to a factor of APB size */
+#define I2S_DMA_PAGE_NUM    4   /* Vaild number is 2~4 */
 
 /* I2S buffer container */
+#if defined(CONFIG_AMEBAD_I2S_16BIT_PADDING)
+static uint8_t audio_buf[I2S_DMA_PAGE_SIZE];
+#endif
 
 struct amebad_buffer_s {
 	struct amebad_buffer_s *flink;	/* Supports a singly linked list */
@@ -164,7 +167,7 @@ struct amebad_i2s_s {
 	uint32_t i2s_sd_rx_pin;
 	uint32_t i2s_mck_pin;
 
-	uint8_t* i2s_tx_buf;
+	uint8_t i2s_tx_buf[I2S_DMA_PAGE_NUM * I2S_DMA_PAGE_SIZE]; /* Allocate buffer for use in TX */
 	uint8_t* i2s_rx_buf;
 
 	i2s_irq_handler rx_isr_handler;
@@ -183,6 +186,7 @@ struct amebad_i2s_s {
 	int sample_rate;                /*!< I2S sample rate */
 	int channel_num;                /*!< Number of channels */
 	int bits_per_sample;            /*!< Bits per sample */
+	struct ap_buffer_s *apb_tx;		/* Pointer to application TX audio buffer to track current TX byte count */
 
 #if defined(I2S_HAVE_RX) && (0 < I2S_HAVE_RX)
 	struct amebad_transport_s rx;		/* RX transport state */
@@ -242,7 +246,6 @@ static void i2s_buf_rx_initialize(struct amebad_i2s_s *priv);
 #if defined(I2S_HAVE_TX) && (0 < I2S_HAVE_TX)
 static void i2s_txdma_callback(struct amebad_i2s_s* priv, int result);
 static void i2s_txdma_timeout(int argc, uint32_t arg);
-static int i2s_txdma_prep(struct amebad_i2s_s *priv, struct amebad_buffer_s *bfcontainer);
 static int i2s_tx_start(struct amebad_i2s_s *priv);
 static void i2s_tx_worker(void *arg);
 static void i2s_tx_schedule(struct amebad_i2s_s *priv, int result);
@@ -281,10 +284,10 @@ static int i2s_err_cb_register(struct i2s_dev_s *dev, i2s_err_cb_t cb, void *arg
 
 static const i2s_config_t i2s_default_config = {
 
-	.sample_rate = CONFIG_AMEBAD_I2S_SAMPLERATE,
-	.bits_per_sample = CONFIG_AMEBAD_I2S_DATALEN,
+	.sample_rate =  I2S_SR_48KHZ,
+	.bits_per_sample = I2S_BITS_PER_SAMPLE_32BIT,
 
-	.channel_num = CH_MONO,
+	.channel_num = CH_STEREO,
 #if defined(I2S_HAVE_TX) && (0 < I2S_HAVE_TX)
 	.direction = I2S_DIR_TX,
 #endif
@@ -361,16 +364,56 @@ static void i2s_txdma_timeout(int argc, uint32_t arg)
 	i2s_tx_schedule(priv, -ETIMEDOUT);
 }
 
-static int i2s_txdma_prep(struct amebad_i2s_s *priv, struct amebad_buffer_s *bfcontainer)
+static int amebad_i2s_tx(struct amebad_i2s_s *priv, struct amebad_buffer_s *bfcontainer)
 {
+	int ret;
+	int* ptx_buf;
+	int tx_size;
+
+	tx_size = I2S_DMA_PAGE_SIZE; /* Track current byte size to increment by */
 	struct ap_buffer_s *apb;
+	if (NULL != bfcontainer && NULL != bfcontainer->apb) {
 
-	apb = bfcontainer->apb;
+		apb = bfcontainer->apb;
+		/* Add the container to the list of active DMAs */
+		sq_addlast((sq_entry_t *)bfcontainer, &priv->tx.act);
 
-	priv->i2s_tx_buf = (void *)&(apb->samp[apb->curbyte]);
-	i2s_set_dma_buffer(&priv->i2s_object, (char*)priv->i2s_tx_buf, NULL, I2S_DMA_PAGE_NUM, I2S_DMA_PAGE_SIZE);
-
-	return 0;
+		i2s_set_direction(&priv->i2s_object, I2S_DIR_TX);
+		priv->apb_tx = apb; /* Reference current TX apb in our I2S struct */ 
+		/* Start sending first page, after that the txdma callback will be called in the tx irq handler */
+			ptx_buf = i2s_get_tx_page(&priv->i2s_object);
+#if defined(CONFIG_AMEBAD_I2S_16BIT_PADDING)
+			memset(audio_buf, 0, sizeof(audio_buf));
+			if ((apb->nbytes - apb->curbyte) <= (tx_size/2)) { /* Check if remaining bytes to TX is less than the maximum length we can pad */
+				tx_size = apb->nbytes - apb->curbyte; /* Update tx_size to the remaining bytes left to TX */
+				for (int j=0; j<tx_size/2; j++) {
+					memcpy(audio_buf+(2+(j*4)), &apb->samp[apb->curbyte+(j*2)], 2);
+				}
+				memset(ptx_buf, 0, I2S_DMA_PAGE_SIZE); /* Clear ptx_buf to prevent sending old data since we are sending less than I2S_DMA_PAGE_SIZE */
+				memcpy((void*)ptx_buf, (void*)audio_buf, tx_size*2);
+				apb->curbyte += tx_size; /* Remaining bytes to TX can fit into buffer, increment current byte by the remaining tx_size  */
+			}
+			else {
+				for (int j=0; j<(I2S_DMA_PAGE_SIZE/4); j++) {
+					memcpy(audio_buf+(2+(j*4)), &apb->samp[apb->curbyte+(j*2)], 2);
+				}
+				memcpy((void*)ptx_buf, (void*)audio_buf, I2S_DMA_PAGE_SIZE);
+				apb->curbyte += tx_size/2; /* We padded half of I2S_DMA_PAGE_SIZE worth of data */
+			}
+#else
+			if ((apb->nbytes - apb->curbyte) <= tx_size) {
+				tx_size = apb->nbytes - apb->curbyte;
+				memset(ptx_buf, 0, I2S_DMA_PAGE_SIZE); /* Clear ptx_buf to prevent sending old data since we are sending less than I2S_DMA_PAGE_SIZE */
+				memcpy((void*)ptx_buf, (void*)&apb->samp[apb->curbyte], tx_size);
+			}
+			else {
+				memcpy((void*)ptx_buf, (void*)&apb->samp[apb->curbyte], I2S_DMA_PAGE_SIZE);
+			}
+			apb->curbyte += tx_size; /* No padding, ptx_buf is big enough to fill the whole tx_size */
+#endif
+			i2s_send_page(&priv->i2s_object, (uint32_t*)ptx_buf);
+	}
+	return;
 }
 
 static int i2s_tx_start(struct amebad_i2s_s *priv)
@@ -378,11 +421,8 @@ static int i2s_tx_start(struct amebad_i2s_s *priv)
 	struct amebad_buffer_s *bfcontainer = NULL;
 	int ret;
 	irqstate_t flags;
-	int* ptx_buf;
-	int pg_idx;
 
 	struct ap_buffer_s *apb;
-	apb = bfcontainer->apb;
 
 	/* Check if the DMA is IDLE */
 	if (!sq_empty(&priv->tx.act)) {
@@ -400,24 +440,9 @@ static int i2s_tx_start(struct amebad_i2s_s *priv)
 
 	/* Remove the pending TX transfer at the head of the TX pending queue. */
 	bfcontainer = (struct amebad_buffer_s *)sq_remfirst(&priv->tx.pend);
-	if (NULL != bfcontainer && NULL != bfcontainer->apb) {
 
-		/* Add the container to the list of active DMAs */
-		sq_addlast((sq_entry_t *)bfcontainer, &priv->tx.act);
-
-		i2s_set_direction(&priv->i2s_object, I2S_DIR_TX);
-
-		/* send I2S_DMA_PAGE_NUM page, after that the txdma callback will be called in the tx irq handler */
-		for (pg_idx = 0; pg_idx < I2S_DMA_PAGE_NUM; ++pg_idx) {
-
-			ptx_buf = i2s_get_tx_page(&priv->i2s_object);
-			i2s_send_page(&priv->i2s_object, (uint32_t*)ptx_buf);
-			apb->curbyte += (I2S_DMA_PAGE_SIZE/sizeof(short));
-			if(apb->curbyte >= apb->nmaxbytes*(priv->i2s_object.channel_num == CH_MONO?1:2))
-				apb->curbyte = 0;
-		}
-	}
-
+	/* Start first transfer */
+	amebad_i2s_tx(priv, bfcontainer);
 	irqrestore(flags);
 
 	/* Start a watchdog to catch DMA timeouts */
@@ -468,7 +493,6 @@ static void i2s_tx_worker(void *arg)
 		flags = irqsave();
 		bfcontainer = (struct amebad_buffer_s *)sq_remfirst(&priv->tx.done);
 		irqrestore(flags);
-
 		/* Perform the TX transfer done callback */
 
 		DEBUGASSERT(bfcontainer && bfcontainer->callback);
@@ -521,9 +545,8 @@ static void i2s_tx_schedule(struct amebad_i2s_s *priv, int result)
 		/* Remove the next buffer container from the tx.pend list */
 		bfcontainer = (struct amebad_buffer_s *)sq_remfirst(&priv->tx.pend);
 
-		/* Add the completed buffer container to the tail of the tx.act queue */
-		sq_addlast((sq_entry_t *) bfcontainer, &priv->tx.act);
-
+		/* Start next transfer */
+		amebad_i2s_tx(priv, bfcontainer);
 	}
 
 	/* If the worker has completed running, then reschedule the working thread.
@@ -564,8 +587,8 @@ static uint32_t i2s_txdatawidth(struct i2s_dev_s *dev, int bits)
 	struct amebad_i2s_s *priv = (struct amebad_i2s_s *)dev;
 
 	/* Support 16, 24, 32 bits */
-	DEBUGASSERT(priv && (bits == I2S_BITS_PER_SAMPLE_16BIT /
-				|| bits == I2S_BITS_PER_SAMPLE_32BIT /
+	DEBUGASSERT(priv && (bits == I2S_BITS_PER_SAMPLE_16BIT \
+				|| bits == I2S_BITS_PER_SAMPLE_32BIT \
 				|| bits == I2S_BITS_PER_SAMPLE_24BIT));
 
 	priv->bits_per_sample = bits;
@@ -617,10 +640,8 @@ static int i2s_send(struct i2s_dev_s *dev, struct ap_buffer_s *apb, i2s_callback
 
 	DEBUGASSERT(priv && apb);
 
-	i2sinfo("[I2S TX] apb=%p nbytes=%d arg=%p samp=%p timeout=%d\n", apb, apb->nbytes - apb->curbyte, apb->samp, arg, timeout);
-
+	// i2sinfo("[I2S TX] apb=%p nbytes=%d samp=%p arg=%p timeout=%d\n", apb, apb->nbytes - apb->curbyte, apb->samp, arg, timeout);
 	i2s_dump_buffer("Sending", &apb->samp[apb->curbyte], apb->nbytes - apb->curbyte);
-
 #if defined(I2S_HAVE_TX) && (0 < I2S_HAVE_TX)
 	struct amebad_buffer_s *bfcontainer;
 	irqstate_t flags;
@@ -649,9 +670,6 @@ static int i2s_send(struct i2s_dev_s *dev, struct ap_buffer_s *apb, i2s_callback
 	bfcontainer->apb = apb;
 	bfcontainer->result = -EBUSY;
 
-	/* Prepare DMA microcode */
-	i2s_txdma_prep(priv, bfcontainer);
-
 	flags = irqsave();
 	sq_addlast((sq_entry_t *) bfcontainer, &priv->tx.pend);
 	irqrestore(flags);
@@ -679,10 +697,49 @@ static int i2s_send(struct i2s_dev_s *dev, struct ap_buffer_s *apb, i2s_callback
 
 void i2s_transfer_tx_handleirq(void *data, char *pbuf)
 {
+	/* This handler is called after every completion of i2s_send_page() */
 	struct amebad_i2s_s *priv = (struct amebad_i2s_s *)data;
+	int tx_size;
 
-	int result = OK;
-	i2s_txdma_callback(priv, result);
+	tx_size = I2S_DMA_PAGE_SIZE; /* Track current byte size to increment by */
+	if ((priv->apb_tx->nbytes - priv->apb_tx->curbyte) <= 0) { /* Condition to stop sending if all data in the buffer has been sent */
+		int result = OK;
+		i2s_txdma_callback(priv, result);
+	}
+	else {
+		int *ptx_buf;
+		ptx_buf = i2s_get_tx_page(&priv->i2s_object);
+#if defined(CONFIG_AMEBAD_I2S_16BIT_PADDING)
+		memset(audio_buf, 0, sizeof(audio_buf));
+		if ((priv->apb_tx->nbytes - priv->apb_tx->curbyte) <= (tx_size/2)) { /* Check if remaining bytes to TX is less than the maximum length we can pad */
+			tx_size = priv->apb_tx->nbytes - priv->apb_tx->curbyte; /* Update tx_size to the remaining bytes left to TX */
+			for (int j=0; j<tx_size/2; j++) {
+				memcpy(audio_buf+(2+(j*4)), &priv->apb_tx->samp[priv->apb_tx->curbyte+(j*2)], 2);
+			}
+			memset(ptx_buf, 0, I2S_DMA_PAGE_SIZE); /* Clear ptx_buf to prevent sending old data since we are sending less than I2S_DMA_PAGE_SIZE */
+			memcpy((void*)ptx_buf, (void*)audio_buf, tx_size*2);
+			priv->apb_tx->curbyte += tx_size; /* Remaining bytes to TX can fit into buffer, increment current byte by the remaining tx_size  */
+		}
+		else {
+			for (int j=0; j<(I2S_DMA_PAGE_SIZE/4); j++) {
+				memcpy(audio_buf+(2+(j*4)), &priv->apb_tx->samp[priv->apb_tx->curbyte+(j*2)], 2);
+			}
+			memcpy((void*)ptx_buf, (void*)audio_buf, I2S_DMA_PAGE_SIZE);
+			priv->apb_tx->curbyte += tx_size/2; /* We padded half of I2S_DMA_PAGE_SIZE worth of data */
+		}
+#else
+		if ((priv->apb_tx->nbytes - priv->apb_tx->curbyte) <= tx_size) {
+			tx_size = priv->apb_tx->nbytes - priv->apb_tx->curbyte;
+			memset(ptx_buf, 0, I2S_DMA_PAGE_SIZE); /* Clear ptx_buf to prevent sending old data since we are sending less than I2S_DMA_PAGE_SIZE */
+			memcpy((void*)ptx_buf, (void*)&priv->apb_tx->samp[priv->apb_tx->curbyte], tx_size);
+		}
+		else {
+			memcpy((void*)ptx_buf, (void*)&priv->apb_tx->samp[priv->apb_tx->curbyte], I2S_DMA_PAGE_SIZE);
+		}
+		priv->apb_tx->curbyte += tx_size; /* No padding, ptx_buf is big enough to fill the whole tx_size */
+#endif
+		i2s_send_page(&priv->i2s_object, (uint32_t*)ptx_buf);
+	}
 
 }
 
@@ -744,7 +801,7 @@ static int i2s_rxdma_prep(struct amebad_i2s_s *priv, struct amebad_buffer_s *bfc
 
 static int i2s_rx_start(struct amebad_i2s_s *priv)
 {
-	struct amebad_buffer_s *bfcontainer;
+	struct amebad_buffer_s *bfcontainer = NULL;
 	int ret;
 	irqstate_t flags;
 
@@ -931,8 +988,8 @@ static uint32_t i2s_rxdatawidth(struct i2s_dev_s *dev, int bits)
 	struct amebad_i2s_s *priv = (struct amebad_i2s_s *)dev;
 
 	/* Support 16, 24, 32 bits */
-	DEBUGASSERT(priv && (bits == I2S_BITS_PER_SAMPLE_16BIT /
-				|| bits == I2S_BITS_PER_SAMPLE_32BIT /
+	DEBUGASSERT(priv && (bits == I2S_BITS_PER_SAMPLE_16BIT \
+				|| bits == I2S_BITS_PER_SAMPLE_32BIT \
 				|| bits == I2S_BITS_PER_SAMPLE_24BIT));
 
 	priv->bits_per_sample = bits;
@@ -1775,7 +1832,7 @@ struct i2s_dev_s *amebad_i2s_initialize(uint16_t port)
 	i2s_init(&priv->i2s_object, priv->i2s_sclk_pin, priv->i2s_ws_pin, priv->i2s_sd_tx_pin, priv->i2s_sd_rx_pin, priv->i2s_mck_pin);
 
 	/* Initialize buffering */
-	//i2s_set_dma_buffer(&priv->i2s_object, priv->i2s_tx_buf, priv->i2s_rx_buf, I2S_DMA_PAGE_NUM, I2S_DMA_PAGE_SIZE);
+	i2s_set_dma_buffer(&priv->i2s_object, (char*)priv->i2s_tx_buf, NULL, I2S_DMA_PAGE_NUM, I2S_DMA_PAGE_SIZE); /* Allocate DMA Buffer for TX */
 
 	/* configures IRQ */
 	priv->rx_isr_handler = (i2s_irq_handler)&i2s_transfer_rx_handleirq;


### PR DESCRIPTION
os/arch/arm/src/amebad: Fix I2S for RTL8721CSM
- Add I2S and I2C options into Kconfig
- Fix I2S Tx and add 16bit padding feature for I2S (Comment #define __16_BIT_PADDING__ to disable feature)
- Note: Pin configs are unchanged