### PR TITLE
change way to update pid of stack

### DIFF
--- a/os/arch/arm/src/common/up_createstack.c
+++ b/os/arch/arm/src/common/up_createstack.c
@@ -62,9 +62,6 @@
 #include <debug.h>
 #include <errno.h>
 
-#ifdef CONFIG_DEBUG_MM_HEAPINFO
-#include <tinyara/mm/mm.h>
-#endif
 #include <tinyara/kmalloc.h>
 #include <tinyara/arch.h>
 #include <tinyara/sched.h>
@@ -294,9 +291,6 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
 		 */
 		up_stack_color(tcb->stack_alloc_ptr, tcb->adj_stack_size);
 #endif
-#endif
-#ifdef CONFIG_DEBUG_MM_HEAPINFO
-		heapinfo_exclude_stacksize(tcb->stack_alloc_ptr);
 #endif
 		board_led_on(LED_STACKCREATED);
 #ifdef CONFIG_MPU_STACK_OVERFLOW_PROTECTION

--- a/os/arch/arm/src/common/up_vfork.c
+++ b/os/arch/arm/src/common/up_vfork.c
@@ -187,7 +187,11 @@ pid_t up_vfork(const struct vfork_s *context)
 	}
 
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
-	/* Update the pid information in stack node */
+	/* Exclude a stack node from heap usages of current thread.
+	 * This will be shown separately as stack usages.
+	 */
+	heapinfo_exclude_stacksize(child->cmn.stack_alloc_ptr);
+	/* Update the pid information to set a stack node */
 	heapinfo_set_stack_node(child->cmn.stack_alloc_ptr, child->cmn.pid);
 #endif
 

--- a/os/arch/arm/src/common/up_vfork.c
+++ b/os/arch/arm/src/common/up_vfork.c
@@ -66,6 +66,10 @@
 #include <tinyara/arch.h>
 #include <arch/irq.h>
 
+#ifdef CONFIG_DEBUG_MM_HEAPINFO
+#include <tinyara/mm/mm.h>
+#endif
+
 #include "up_vfork.h"
 #include "sched/sched.h"
 
@@ -181,6 +185,11 @@ pid_t up_vfork(const struct vfork_s *context)
 		task_vforkabort(child, -ret);
 		return (pid_t)ERROR;
 	}
+
+#ifdef CONFIG_DEBUG_MM_HEAPINFO
+	/* Update the pid information in stack node */
+	heapinfo_set_stack_node(child->cmn.stack_alloc_ptr, child->cmn.pid);
+#endif
 
 	/* How much of the parent's stack was utilized?  The ARM uses
 	 * a push-down stack so that the current stack pointer should

--- a/os/binfmt/binfmt_execmodule.c
+++ b/os/binfmt/binfmt_execmodule.c
@@ -222,6 +222,11 @@ int exec_module(FAR struct binary_s *binp)
 	binp->uheap->alloc_list[hashpid].curr_alloc_size = 0;
 	binp->uheap->alloc_list[hashpid].num_alloc_free = 0;
 
+	/* Exclude a stack node from heap usages of current thread.
+	 * This will be shown separately as stack usages.
+	 */
+	heapinfo_exclude_stacksize(newtcb->cmn.stack_alloc_ptr);
+	/* Update the pid information to set a stack node */
 	heapinfo_set_stack_node(stack, newtcb->cmn.pid);
 #endif
 

--- a/os/binfmt/binfmt_execmodule.c
+++ b/os/binfmt/binfmt_execmodule.c
@@ -217,14 +217,12 @@ int exec_module(FAR struct binary_s *binp)
 	 * for calculating the heap usage per threads.
 	 */
 	int hashpid = PIDHASH(getpid());
-	struct mm_allocnode_s *node;
 
 	binp->uheap->alloc_list[hashpid].pid = HEAPINFO_INIT_INFO;
 	binp->uheap->alloc_list[hashpid].curr_alloc_size = 0;
 	binp->uheap->alloc_list[hashpid].num_alloc_free = 0;
 
-	node = (struct mm_allocnode_s *)((void *)stack - SIZEOF_MM_ALLOCNODE);
-	node->pid = (-1) * (newtcb->cmn.pid);
+	heapinfo_set_stack_node(stack, newtcb->cmn.pid);
 #endif
 
 	/* We can free the argument buffer now.

--- a/os/include/tinyara/mm/mm.h
+++ b/os/include/tinyara/mm/mm.h
@@ -703,6 +703,7 @@ void heapinfo_set_caller_addr(void *address, mmaddress_t caller_retaddr);
 void heapinfo_add_size(struct mm_heap_s *heap, pid_t pid, mmsize_t size);
 void heapinfo_subtract_size(struct mm_heap_s *heap, pid_t pid, mmsize_t size);
 void heapinfo_update_total_size(struct mm_heap_s *heap, mmsize_t size, pid_t pid);
+void heapinfo_set_stack_node(void *stack_ptr, pid_t pid);
 void heapinfo_exclude_stacksize(void *stack_ptr);
 void heapinfo_peak_init(struct mm_heap_s *heap);
 void heapinfo_dealloc_tcbinfo(void *address, pid_t pid);

--- a/os/kernel/pthread/pthread_create.c
+++ b/os/kernel/pthread/pthread_create.c
@@ -374,7 +374,11 @@ int pthread_create(FAR pthread_t *thread, FAR const pthread_attr_t *attr, pthrea
 	}
 
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
-	/* Update the pid information in stack node */
+	/* Exclude a stack node from heap usages of current thread.
+	 * This will be shown separately as stack usages.
+	 */
+	heapinfo_exclude_stacksize(ptcb->cmn.stack_alloc_ptr);
+	/* Update the pid information to set a stack node */
 	heapinfo_set_stack_node(ptcb->cmn.stack_alloc_ptr, ptcb->cmn.pid);
 #endif
 

--- a/os/kernel/pthread/pthread_create.c
+++ b/os/kernel/pthread/pthread_create.c
@@ -375,10 +375,7 @@ int pthread_create(FAR pthread_t *thread, FAR const pthread_attr_t *attr, pthrea
 
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
 	/* Update the pid information in stack node */
-	struct mm_allocnode_s *node;
-
-	node = (struct mm_allocnode_s *)(ptcb->cmn.stack_alloc_ptr - SIZEOF_MM_ALLOCNODE);
-	node->pid = (-1) * (ptcb->cmn.pid);
+	heapinfo_set_stack_node(ptcb->cmn.stack_alloc_ptr, ptcb->cmn.pid);
 #endif
 
 	/* Configure the TCB for a pthread receiving on parameter

--- a/os/kernel/task/task_create.c
+++ b/os/kernel/task/task_create.c
@@ -194,10 +194,7 @@ static int thread_create(FAR const char *name, uint8_t ttype, int priority, int 
 	}
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
 	/* Update the pid information in stack node */
-	struct mm_allocnode_s *node;
-
-	node = (struct mm_allocnode_s *)(tcb->cmn.stack_alloc_ptr - SIZEOF_MM_ALLOCNODE);
-	node->pid = (-1) * (tcb->cmn.pid);
+	heapinfo_set_stack_node(tcb->cmn.stack_alloc_ptr, tcb->cmn.pid);
 #endif
 
 	/* Setup to pass parameters to the new task */

--- a/os/kernel/task/task_create.c
+++ b/os/kernel/task/task_create.c
@@ -193,7 +193,11 @@ static int thread_create(FAR const char *name, uint8_t ttype, int priority, int 
 		goto errout_with_tcb;
 	}
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
-	/* Update the pid information in stack node */
+	/* Exclude a stack node from heap usages of current thread.
+	 * This will be shown separately as stack usages.
+	 */
+	heapinfo_exclude_stacksize(tcb->cmn.stack_alloc_ptr);
+	/* Update the pid information to set a stack node */
 	heapinfo_set_stack_node(tcb->cmn.stack_alloc_ptr, tcb->cmn.pid);
 #endif
 

--- a/os/mm/mm_heap/mm_heapinfo_utils.c
+++ b/os/mm/mm_heap/mm_heapinfo_utils.c
@@ -154,6 +154,23 @@ void heapinfo_set_caller_addr(void *address, mmaddress_t caller_retaddr)
 }
 
 /****************************************************************************
+ * Name: heapinfo_set_stack_node
+ *
+ * Description:
+ * This function sets a heap node as a stack node by setting negative value in the pid value.
+ * This function requires allocated stack pointer and assigned pid value.
+ ****************************************************************************/
+void heapinfo_set_stack_node(void *stack_ptr, pid_t pid)
+{
+	struct mm_allocnode_s *node;
+
+	node = (struct mm_allocnode_s *)(stack_ptr - SIZEOF_MM_ALLOCNODE);
+
+	DEBUGASSERT(node && pid > 0);
+	node->pid = (-1) * (pid);
+}
+
+/****************************************************************************
  * Name: heapinfo_exclude_stacksize
  *
  * Description:


### PR DESCRIPTION
If stack node, pid is negative number in heapinfo.
So, when create stack, updated pid in stack node chunk.

But at this time, it directly accesses the heap node.

Therefore, this PR adds `heapinfo_set_stack_node()` that updates pid in stack node chunk to negative.
and applied the function.