### PR TITLE
kernel/semaphore: Remove duplicate ASSERT() in sem_post.c

### DIFF
--- a/os/kernel/semaphore/sem_post.c
+++ b/os/kernel/semaphore/sem_post.c
@@ -215,7 +215,6 @@ int sem_post(FAR sem_t *sem)
 
 		/* Perform the semaphore unlock operation. */
 		ASSERT_INFO(sem->semcount < SEM_VALUE_MAX, "sem = 0x%x, caller address = 0x%x", sem, caller_retaddr);
-		ASSERT(sem->semcount < SEM_VALUE_MAX);
 		sem_releaseholder(sem, this_task());
 		sem->semcount++;
 


### PR DESCRIPTION
ASSERT_INFO() and ASSERT() are checking same condition. (sem->semcount < SEM_VALUE_MAX)
So, This commit removes ASSERT().

Signed-off-by: eunwoo.nam <eunwoo.nam@samsung.com>