### PR TITLE
os/Makefile.unix: remove the CONFIG_RAW_BINARY dependency 

### DIFF
--- a/os/Kconfig
+++ b/os/Kconfig
@@ -315,12 +315,12 @@ config MOTOROLA_SREC
 		and should not be selected if you are not using the GNU toolchain.
 
 config RAW_BINARY
-	bool "Raw binary format"
-	default n
+	bool
+	default y
 	---help---
-		Create the tinyara.bin in the raw binary format that is used with many
-		different loaders using the GNU objcopy program.  This option
-		should not be selected if you are not using the GNU toolchain.
+		Create the tinyara.bin in the raw binary format that is used with many 
+		different loaders using the GNU objcopy program. 
+		This configuration should always be enabled mandatorily in TizenRT.	
 
 menuconfig UBOOT_UIMAGE
 	bool "U-Boot uImage"

--- a/os/Makefile.unix
+++ b/os/Makefile.unix
@@ -222,9 +222,9 @@ endif
 ifeq ($(CONFIG_RAW_BINARY),y)
 BIN_EXT = bin
 endif
+KERNEL_START=$(CONFIG_FLASH_START_ADDR)
 
 # This is the name of the final target (relative to the top level directorty)
-
 BIN_EXE = tinyara$(EXEEXT)
 BIN = $(OUTBIN_DIR)/$(BIN_EXE)
 
@@ -462,14 +462,6 @@ pass2: pass2deps
 		cp -f $(BIN) /tftpboot/$(BIN_EXE).${CONFIG_ARCH}; \
 	fi
 
-ifeq ($(CONFIG_INTELHEX_BINARY),y)
-	$(Q) echo "CP: $(BIN_EXE).hex"
-	$(Q) $(OBJCOPY) $(OBJCOPYARGS) -O ihex $(BIN) $(BIN).hex
-endif
-ifeq ($(CONFIG_MOTOROLA_SREC),y)
-	$(Q) echo "CP: $(BIN_EXE).srec"
-	$(Q) $(OBJCOPY) $(OBJCOPYARGS) -O srec $(BIN) $(BIN).srec
-endif
 ifeq ($(CONFIG_RAW_BINARY),y)
 	$(Q) echo "CP: $(BIN_EXE).bin"
 	$(Q) $(OBJCOPY) $(OBJCOPYARGS) -O binary $(BIN) $(BIN).bin
@@ -544,6 +536,17 @@ endif
 	$(Q) $(call MAKE_BOARD_SPECIFIC_BIN, $(BIN_EXE), $(BIN_EXT))
 	$(Q) python ./tools/set_bininfo.py $(BIN_EXT)
 	$(Q) $(call MAKE_SAMSUNG_HEADER, $(BIN_EXE), $(BIN_EXT))
+
+ifeq ($(CONFIG_INTELHEX_BINARY),y)
+	$(Q) echo "CP: $(BIN_EXE).hex"
+	$(Q) $(OBJCOPY) $(OBJCOPYARGS) --change-addresses $(KERNEL_START) -I binary -O ihex $(BIN).bin $(BIN).hex
+endif
+ifeq ($(CONFIG_MOTOROLA_SREC),y)
+	$(Q) echo "CP: $(BIN_EXE).srec"
+	$(Q) $(OBJCOPY) $(OBJCOPYARGS) --change-addresses $(KERNEL_START) -I binary -O srec $(BIN).bin $(BIN).srec
+endif
+
+
 ifeq ($(CONFIG_FLASH_PARTITION),y)
 	$(Q) python ./tools/validate_output.py
 endif


### PR DESCRIPTION
Remove dependency on CONFIG_RAW_BINARY from defconfig and always generate .bin format. Move the .hex creation logic after the addition of samsung headers.