### PR TITLE
net/lwip: add null check

### DIFF
--- a/os/net/lwip/src/api/sockets.c
+++ b/os/net/lwip/src/api/sockets.c
@@ -451,7 +451,7 @@ struct lwip_sock *trycheck_selwait_socket(int s, pid_t pid)
 	struct lwip_sock *sock;
 	sock = tryget_socket_by_pid(s, pid);
 
-	if (!sock->conn) {
+	if (sock && !sock->conn) {
 		return sock;
 	}
 	return NULL;


### PR DESCRIPTION
there was no NULL check in trycheck_selwait_socket fucntion.
It can make an error, so I added NULL check logic.