### PR TITLE
apps/shell : Apply PBKDF2 for TASH password

### DIFF
--- a/apps/shell/Kconfig
+++ b/apps/shell/Kconfig
@@ -59,18 +59,35 @@ config TASH_SCRIPT
 
 config SECURED_TASH
 	bool "Enable Secure shell"
-	depends on NET_SECURITY_TLS
+	select NET_SECURITY_TLS
+	select MBEDTLS_PKCS5_C
 	default n
 
 if SECURED_TASH
 
-config TASH_PASSWORD_SHA256
-	string "SHA256 encrypted password (32 Bytes)"
-	default "436890f31fcd6b154a0e49df9f190bd8b1dcd4b917a7a80b2d928452c22901f7"
+config TASH_PASSWORD_HASH
+	string "PBKDF2 encrypted password (32 Bytes)"
+	default "3D9740229177EBE6B11D0371342308881AE1463D1142E9FF932AB180AF4E8BD6"
 	---help---
-		Enable password to enter TASH. The password is hashed by SHA256 so that
+		Enable password to access TASH command line. The password is hashed by PBKDF2 so that
 		the length of this config should be 32 bytes (64 characters).
-		default : hash value of "TizenRT" (Password : TizenRT)
+		default : hash value of "tizenrt" (Password : tizenrt)
+
+config TASH_SALT_ENCRYPTED
+	string "AES encrypted salt (16 Bytes)"
+	default "00112233445566778899AABBCCDDEEFF"
+	---help---
+		Enable salt value for TASH password encryption. The salt is encrypted by AES128 so that
+		the length of this config should be 16 bytes (32 characters).
+		default : encrypted value of "00112233445566778899AABBCCDDEEFF"
+		Please encrypt this value with AES key and set this value.
+
+config TASH_HASH_ITERATION
+	int "Number of PBKDF2 iteration"
+	default 777
+	---help---
+		The number of hash iteration used in PBKDF2.
+
 endif
 
 endif

--- a/apps/shell/tash_security.c
+++ b/apps/shell/tash_security.c
@@ -23,15 +23,134 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
-#include <mbedtls/sha256.h>
 #ifdef CONFIG_TASH_REBOOT
 #include <sys/boardctl.h>
 #endif
+#include <security/security_crypto.h>
+#include <mbedtls/pkcs5.h>
 #include "tash_internal.h"
 
-#define SHA256_HASH_nCHAR  (64) // 32 bytes
-#define SHA256_HASH_nBYTE  (32) // 32 bytes
-#define CONVERT_nCHAR      (sizeof(unsigned long) * 2) // unsigned long for strtoul
+#define CONVERT_nCHAR           (sizeof(unsigned long) * 2) // unsigned long for strtoul
+
+#define PBKDF2_KEY_nCHAR        (64) // 32 bytes
+#define PBKDF2_KEY_LEN          (32) // 32 bytes
+#define PBKDF2_SALT_LEN         (16) // 16 bytes
+#define PBKDF2_SALT_nCHAR       (32) // 16 bytes
+#define AES_BLOCK_SIZE          (16)
+#define AES128_KEY_SLOT         "ss/38" // slot where AES key is stored
+
+
+static int salt_aes_decrypt(char *input, unsigned int input_size, char *output, unsigned int output_size) 
+{
+	if ((input_size <= 0) || (input_size % AES_BLOCK_SIZE)) {
+		printf("Invalid AES key input size\n");
+		printf("input size : %d\n", input_size);
+		return -1;
+	}
+
+	if (input == NULL) {
+		printf("AES input is null\n");
+		return -1;
+	} 
+
+	if (output_size < input_size) {
+		printf("Invalid AES key output size\n");
+		printf("output size : %d\n", output_size);
+		return -1;
+	}
+
+	if (output == NULL) {
+		printf("AES output is null\n");
+		return -1;
+	}
+
+	security_handle hnd;
+	security_data encrypt_data;
+	security_data decrypt_data;
+	security_aes_param aes_param;
+	security_error ret;
+	char *tmp = NULL;
+
+	ret = security_init(&hnd);
+	if (ret != SECURITY_OK) {
+		printf("security_crypto : security_init failed. ret : %d\n", ret);
+		return -1;
+	}
+
+	encrypt_data.data = input;
+	encrypt_data.length = input_size;
+
+	decrypt_data.length = output_size;
+
+	aes_param.mode = AES_CBC_NOPAD;
+	aes_param.iv = NULL;
+	aes_param.iv_len = 0;
+
+	ret = crypto_aes_decryption(hnd, &aes_param, AES128_KEY_SLOT, &encrypt_data, &decrypt_data);
+	if (ret != SECURITY_OK) {
+		printf("security_crypto : crypto_aes_decryption failed. ret : %d\n", ret);
+		return -1;
+	}
+
+	tmp = decrypt_data.data;
+	for (int i = 0; i < output_size; i++) {
+		output[i] = tmp[i];
+	}
+
+	return 1;
+}
+
+static int get_pbkdf2(char *input, int input_len, char *salt, int salt_len, int iteration, unsigned char *pbkdf2_output)
+{
+	mbedtls_md_context_t sha_ctx;
+	const mbedtls_md_info_t *info_sha;
+
+	/* Setup the hash/HMAC function, for the PBKDF2 function. */
+	mbedtls_md_init(&sha_ctx);
+
+	info_sha = mbedtls_md_info_from_type(MBEDTLS_MD_SHA256);
+	if (info_sha == NULL) {
+		printf("Failed to get hash information\n");
+		mbedtls_md_free(&sha_ctx);
+		return -1;
+	}
+
+	int ret = mbedtls_md_setup(&sha_ctx, info_sha, 1);
+	if (ret != 0) {
+		printf("Failed to setup hash function");
+		mbedtls_md_free(&sha_ctx);
+		return -1;
+	}
+
+	ret = mbedtls_pkcs5_pbkdf2_hmac(&sha_ctx, (const unsigned char *)input, input_len, (const unsigned char *)salt, salt_len, iteration, PBKDF2_KEY_LEN, pbkdf2_output);
+	if (ret != 0) {
+		printf("Call to mbedtls PBKDF2 function failed\n");
+		mbedtls_md_free(&sha_ctx);
+		return -1;
+	}
+
+	mbedtls_md_free(&sha_ctx);
+
+	return 1;
+}
+
+static void convert_str_to_hex(char *input, unsigned char *output, int char_len)
+{
+	char input_char[CONVERT_nCHAR + 1] = { 0, };
+	unsigned long converted_val;
+	int offset = 0;
+	int hex_idx = 0;
+
+	do {
+		strncpy(input_char, ((char *)input + offset), CONVERT_nCHAR);
+		converted_val = strtoul(input_char, NULL, 16);
+		output[hex_idx++] = (unsigned char)((converted_val >> 24) & 0xFF);
+		output[hex_idx++] = (unsigned char)((converted_val >> 16) & 0xFF);
+		output[hex_idx++] = (unsigned char)((converted_val >> 8) & 0xFF);
+		output[hex_idx++] = (unsigned char)(converted_val & 0xFF);
+		offset += CONVERT_nCHAR;
+	} while (offset < char_len);
+}
 
 void tash_check_security(int fd)
 {
@@ -39,30 +158,35 @@ void tash_check_security(int fd)
 	char *input;
 	int nbytes;
 	int input_len = 0;
-	char pw_sha256_char[CONVERT_nCHAR + 1] = { 0, };
-	unsigned char pw_sha256_hex[SHA256_HASH_nBYTE];
-	unsigned char input_sha256_hex[SHA256_HASH_nBYTE];
-	unsigned long converted_val;
-	int sha256_hex_idx = 0;
+	unsigned char pw_pbkdf2_hex[PBKDF2_KEY_LEN];
+	unsigned char input_pbkdf2_hex[PBKDF2_KEY_LEN];
+	unsigned char salt_encrypted_hex[PBKDF2_SALT_LEN];
+	unsigned char pbkdf2_salt[PBKDF2_SALT_LEN] = { 0, };
 	int retry_count = 0;
-	int offset = 0;
 
-	if (strlen(CONFIG_TASH_PASSWORD_SHA256) != SHA256_HASH_nCHAR) {
-		printf("TASH: CONFIG_TASH_PASSWORD_SHA256 has wrong length (%d).\n", strlen(CONFIG_TASH_PASSWORD_SHA256));
+	if (strlen(CONFIG_TASH_PASSWORD_HASH) != PBKDF2_KEY_nCHAR) {
+		printf("TASH: CONFIG_TASH_PASSWORD_HASH has wrong length (%d).\n", strlen(CONFIG_TASH_PASSWORD_HASH));
 		printf("      It should be 32 bytes, 64 characters.\n");
 		return;
 	}
 
 	/* Convert password character to hex */
-	do {
-		strncpy(pw_sha256_char, ((char *)CONFIG_TASH_PASSWORD_SHA256 + offset), CONVERT_nCHAR);
-		converted_val = strtoul(pw_sha256_char, NULL, 16);
-		pw_sha256_hex[sha256_hex_idx++] = (unsigned char)((converted_val >> 24) & 0xFF);
-		pw_sha256_hex[sha256_hex_idx++] = (unsigned char)((converted_val >> 16) & 0xFF);
-		pw_sha256_hex[sha256_hex_idx++] = (unsigned char)((converted_val >> 8) & 0xFF);
-		pw_sha256_hex[sha256_hex_idx++] = (unsigned char)(converted_val & 0xFF);
-		offset += CONVERT_nCHAR;
-	} while (offset < SHA256_HASH_nCHAR);
+	convert_str_to_hex(CONFIG_TASH_PASSWORD_HASH, pw_pbkdf2_hex, PBKDF2_KEY_nCHAR);
+
+	if (strlen(CONFIG_TASH_SALT_ENCRYPTED) != PBKDF2_SALT_nCHAR) {
+		printf("TASH: CONFIG_TASH_SALT_ENCRYPTED has wrong length (%d).\n", strlen(CONFIG_TASH_SALT_ENCRYPTED));
+		printf("      It should be 16 bytes, 32 characters.\n");
+		return;
+	}
+
+	/* Convert salt character to hex */
+	convert_str_to_hex(CONFIG_TASH_SALT_ENCRYPTED, salt_encrypted_hex, PBKDF2_SALT_nCHAR);
+	
+	/* Decrypt encrypted SALT by AES */
+	if (1 != salt_aes_decrypt(salt_encrypted_hex, PBKDF2_SALT_LEN, pbkdf2_salt, PBKDF2_SALT_LEN)) {
+		printf("TASH: salt_aes_decrypt() failed\n");
+		return;
+	}
 
 	do {
 		/* Print secure prompt */
@@ -88,13 +212,15 @@ void tash_check_security(int fd)
 		}
 		#endif
 
-		/* Convert user input to SHA256 hash value */
-		mbedtls_sha256((unsigned char *)input, input_len, input_sha256_hex, 0);
+		/* Convert user input to pbkdf2 value */
+		if (get_pbkdf2(input, input_len, pbkdf2_salt, PBKDF2_SALT_LEN, CONFIG_TASH_HASH_ITERATION, input_pbkdf2_hex) < 0) {
+			return;
+		}
 
 		tash_free(input);
 
 		/* Confirm the password */
-		if (!strncmp((char *)pw_sha256_hex, (char *)input_sha256_hex, SHA256_HASH_nBYTE)) {
+		if (!memcmp((char *)pw_pbkdf2_hex, (char *)input_pbkdf2_hex, PBKDF2_KEY_LEN)) {
 			break;
 		} else {
 			retry_count++;

--- a/external/include/mbedtls/mbedtls_tizenrt_config.h
+++ b/external/include/mbedtls/mbedtls_tizenrt_config.h
@@ -205,3 +205,8 @@
 #endif /* CONFIG_TLS_HW_AES_ENC */
 
 #endif /* CONFIG_SE */
+
+#if defined(CONFIG_MBEDTLS_PKCS5_C)
+/* MBEDTLS_PKCS5_C should be enabled to encrypt TASH password with PBKDF2 */
+#define MBEDTLS_PKCS5_C
+#endif /* CONFIG_MBEDTLS_PKCS5_C */

--- a/external/mbedtls/Kconfig.protocol
+++ b/external/mbedtls/Kconfig.protocol
@@ -22,7 +22,14 @@ config TLS_HAVE_NO_TIME_DATE
 		The time needs to be correct (not necesarily very accurate, but at least
 		* the date should be correct). This is used to verify the validity period of
 		* X.509 certificates.
-		
+
+config MBEDTLS_PKCS5_C
+	bool "PKCS#5 Support"
+	default n
+	---help---
+		Enable MBEDTLS_PKCS5_C.
+		If you need to use PKCS#5 functions(such as PBKDF2 function), please enable this config.
+
 if TLS_WITH_HW_ACCEL
 
 menu "HW Options"


### PR DESCRIPTION
Change TASH password encryption from SHA256 to PBKDF2 which already applied in previous version.
All of values used in this PR are sample.
- key length : 32 bytes (64 characters)
- salt : hard-coded with encrypted value (length = 16 bytes)
- iteration : 777
- default password : tizenrt