### PR TITLE
up_assert: fix used stack log of current task

### DIFF
--- a/os/arch/arm/src/armv7-m/up_assert.c
+++ b/os/arch/arm/src/armv7-m/up_assert.c
@@ -364,7 +364,7 @@ static void up_dumpstate(void)
 		lldbg("  base: %08x\n", stackbase);
 		lldbg("  size: %08x\n", stacksize);
 #ifdef CONFIG_STACK_COLORATION
-		lldbg("  used: %08x\n", up_check_assertstack((uintptr_t)(stackbase - stacksize), stacksize));
+		lldbg("  used: %08x\n", up_check_assertstack((uintptr_t)(stackbase - stacksize + 4), stacksize));
 #endif
 		up_stackdump(sp, stackbase);
 	}

--- a/os/arch/arm/src/armv8-m/up_assert.c
+++ b/os/arch/arm/src/armv8-m/up_assert.c
@@ -391,7 +391,7 @@ static void up_dumpstate(void)
 		lldbg("  base: %08x\n", stackbase);
 		lldbg("  size: %08x\n", stacksize);
 #ifdef CONFIG_STACK_COLORATION
-		lldbg("  used: %08x\n", up_check_assertstack((uintptr_t)(stackbase - stacksize), stacksize));
+		lldbg("  used: %08x\n", up_check_assertstack((uintptr_t)(stackbase - stacksize + 4), stacksize));
 #endif
 		up_stackdump(sp, stackbase);
 	}


### PR DESCRIPTION
When assert, There is problem that used stack and stack size of current task are same even through stack is not full.

The reason is below.
1. The stack size is (stack top address - stack allocated address + 4)
2. Check used stack of current task. start : (stack top address - stack size)
	end   : (start + stack size)
So, checking range : (stack allocated address - 4) ~ (stack top address)
This means is checking address not range of stack.

Also, stack_color is set to (stack allocate address) to (stack top address + 4) and This check uses stack color.

Therefore, This commit changes start address of check to (stack top addresss - stack size + 4)