### PR TITLE
apps/shell : Allow 'reboot' command before TASH authentication

### DIFF
--- a/apps/shell/tash_command.c
+++ b/apps/shell/tash_command.c
@@ -100,9 +100,6 @@ struct tash_cmd_info_s {
 static int tash_help(int argc, char **args);
 static int tash_clear(int argc, char **args);
 static int tash_exit(int argc, char **args);
-#ifdef CONFIG_TASH_REBOOT
-static int tash_reboot(int argc, char **argv);
-#endif
 #if TASH_MAX_STORE   > 0
 static int tash_history(int argc, char **argv);
 #endif
@@ -500,27 +497,6 @@ int check_exclam_cmd(char *buff)
 }
 #endif
 
-#ifdef CONFIG_TASH_REBOOT
-static int tash_reboot(int argc, char **argv)
-{
-	/*
-	 * Invoke the BOARDIOC_RESET board control to reset the board. If
-	 * the board_reset() function returns, then it was not possible to
-	 * reset the board due to some constraints.
-	 */
-#ifdef CONFIG_SYSTEM_REBOOT_REASON
-	WRITE_REBOOT_REASON(REBOOT_SYSTEM_USER_INTENDED);
-#endif
-	boardctl(BOARDIOC_RESET, EXIT_SUCCESS);
-
-	/*
-	 * boarctl() will not return in this case.  It if does, it means that
-	 * there was a problem with the reset operaion.
-	 */
-	return ERROR;
-}
-#endif /* CONFIG_TASH_REBOOT */
-
 /** @brief Launch a task to run tash cmd asynchronously
  *  @ingroup tash
  */
@@ -804,3 +780,24 @@ int tash_get_cmdpair(char *str, TASH_CMD_CALLBACK *cb, int index)
 	return ret;
 }
 #endif
+
+#ifdef CONFIG_TASH_REBOOT
+int tash_reboot(int argc, char **argv)
+{
+	/*
+	 * Invoke the BOARDIOC_RESET board control to reset the board. If
+	 * the board_reset() function returns, then it was not possible to
+	 * reset the board due to some constraints.
+	 */
+#ifdef CONFIG_SYSTEM_REBOOT_REASON
+	WRITE_REBOOT_REASON(REBOOT_SYSTEM_USER_INTENDED);
+#endif
+	boardctl(BOARDIOC_RESET, EXIT_SUCCESS);
+
+	/*
+	 * boarctl() will not return in this case.  It if does, it means that
+	 * there was a problem with the reset operaion.
+	 */
+	return ERROR;
+}
+#endif /* CONFIG_TASH_REBOOT */

--- a/apps/shell/tash_internal.h
+++ b/apps/shell/tash_internal.h
@@ -78,6 +78,9 @@ extern int tash_execute_cmdline(char *buff);
 extern int tash_execute_cmd(char **args, int argc);
 extern int tash_init(void);
 extern void tash_stop(void);
+#ifdef CONFIG_TASH_REBOOT
+extern int tash_reboot(int argc, char **argv);
+#endif
 char *tash_read_input_line(int fd);
 void tash_check_security(int fd);
 #ifdef CONFIG_TASH_SCRIPT

--- a/apps/shell/tash_security.c
+++ b/apps/shell/tash_security.c
@@ -24,6 +24,9 @@
 #include <string.h>
 #include <unistd.h>
 #include <mbedtls/sha256.h>
+#ifdef CONFIG_TASH_REBOOT
+#include <sys/boardctl.h>
+#endif
 #include "tash_internal.h"
 
 #define SHA256_HASH_nCHAR  (64) // 32 bytes
@@ -76,6 +79,14 @@ void tash_check_security(int fd)
 			tash_free(input);
 			continue;
 		}
+
+		/* Allow reboot command regardless of TASH authentication */
+		#ifdef CONFIG_TASH_REBOOT
+		if (!strncmp((unsigned char *)input, "reboot", 7)) {
+			(void)tash_reboot(0, NULL);
+			return;
+		}
+		#endif
 
 		/* Convert user input to SHA256 hash value */
 		mbedtls_sha256((unsigned char *)input, input_len, input_sha256_hex, 0);


### PR DESCRIPTION
Modify the reboot to operate regardless of TASH authentication. 
(To improve the accuracy of Hotfix download)