### PR TITLE
rtl8721csm_download, rtl8720e_download: fix to download fail

### DIFF
--- a/build/configs/rtl8720e/rtl8720e_download.sh
+++ b/build/configs/rtl8720e/rtl8720e_download.sh
@@ -52,7 +52,9 @@ function pre_download()
 	if test -f "${SMARTFS_BIN_PATH}"; then
 		cp -p ${SMARTFS_BIN_PATH} ${IMG_TOOL_PATH}/${CONFIG_ARCH_BOARD}_smartfs.bin
 	fi
-	cp -p ${BIN_PATH}/bootparam.bin ${IMG_TOOL_PATH}/bootparam.bin
+	if test -f "${BIN_PATH}/${BOOTPARAM}.bin"; then
+		cp -p ${BIN_PATH}/${BOOTPARAM}.bin ${IMG_TOOL_PATH}/${BOOTPARAM}.bin
+	fi
 }
 
 function board_download()
@@ -74,21 +76,13 @@ function board_erase()
 function post_download()
 {
 	cd ${IMG_TOOL_PATH}
-	[ -e ${BL1}.bin ] && rm ${BL1}.bin
-	[ -e ${KERNEL_BIN_NAME} ] && rm ${KERNEL_BIN_NAME}
-	if test -f "${APP1_BIN_NAME}"; then
-		[ -e ${APP1_BIN_NAME} ] && rm ${APP1_BIN_NAME}
-	fi
-	if test -f "${APP2_BIN_NAME}"; then
-		[ -e ${APP2_BIN_NAME} ] && rm ${APP2_BIN_NAME}
-	fi
-	if test -f "${COMMON_BIN_NAME}"; then
-		[ -e ${COMMON_BIN_NAME} ] && rm ${COMMON_BIN_NAME}
-	fi
-	if test -f "${SMARTFS_BIN_PATH}"; then
-		[ -e ${CONFIG_ARCH_BOARD}_smartfs.bin ] && rm ${CONFIG_ARCH_BOARD}_smartfs.bin
-	fi
-	[ -e ${BOOTPARAM}.bin ] && rm ${BOOTPARAM}.bin
+	[ -e "${BL1}.bin" ] && rm ${BL1}.bin
+	[ -e "${KERNEL_BIN_NAME}" ] && rm ${KERNEL_BIN_NAME}
+	[ -e "${APP1_BIN_NAME}" ] && rm ${APP1_BIN_NAME}
+	[ -e "${APP2_BIN_NAME}" ] && rm ${APP2_BIN_NAME}
+	[ -e "${COMMON_BIN_NAME}" ] && rm ${COMMON_BIN_NAME}
+	[ -e "${CONFIG_ARCH_BOARD}_smartfs.bin" ] && rm ${CONFIG_ARCH_BOARD}_smartfs.bin
+	[ -e "${BOOTPARAM}.bin" ] && rm ${BOOTPARAM}.bin
 }
 
 

--- a/build/configs/rtl8721csm/rtl8721csm_download.sh
+++ b/build/configs/rtl8721csm/rtl8721csm_download.sh
@@ -51,9 +51,11 @@ function pre_download()
 		cp -p ${BIN_PATH}/${COMMON_BIN_NAME} ${IMG_TOOL_PATH}/${COMMON_BIN_NAME}
 	fi
 	if test -f "${SMARTFS_BIN_PATH}"; then
-		cp -p ${BIN_PATH}/rtl8721csm_smartfs.bin ${IMG_TOOL_PATH}/rtl8721csm_smartfs.bin
+		cp -p ${SMARTFS_BIN_PATH} ${IMG_TOOL_PATH}/${CONFIG_ARCH_BOARD}_smartfs.bin
 	fi
-	cp -p ${BIN_PATH}/bootparam.bin ${IMG_TOOL_PATH}/bootparam.bin
+	if test -f "${BIN_PATH}/${BOOTPARAM}.bin"; then
+		cp -p ${BIN_PATH}/${BOOTPARAM}.bin ${IMG_TOOL_PATH}/${BOOTPARAM}.bin
+	fi
 }
 
 
@@ -76,20 +78,12 @@ function board_erase()
 function post_download()
 {
 	cd ${IMG_TOOL_PATH}
-	[ -e ${BL1}.bin ] && rm ${BL1}.bin
-	[ -e ${BL2}.bin ] && rm ${BL2}.bin
-	[ -e ${KERNEL_BIN_NAME} ] && rm ${KERNEL_BIN_NAME}
-	if test -f "${APP1_BIN_NAME}"; then
-		[ -e ${APP1_BIN_NAME} ] && rm ${APP1_BIN_NAME}
-	fi
-	if test -f "${APP2_BIN_NAME}"; then
-		[ -e ${APP2_BIN_NAME} ] && rm ${APP2_BIN_NAME}
-	fi
-	if test -f "${COMMON_BIN_NAME}"; then
-		[ -e ${COMMON_BIN_NAME} ] && rm ${COMMON_BIN_NAME}
-	fi
-	if test -f "${SMARTFS_BIN_PATH}"; then
-		[ -e ${CONFIG_ARCH_BOARD}_smartfs.bin ] && rm ${CONFIG_ARCH_BOARD}_smartfs.bin
-	fi
-	[ -e ${BOOTPARAM}.bin ] && rm ${BOOTPARAM}.bin
+	[ -e "${BL1}.bin" ] && rm ${BL1}.bin
+	[ -e "${BL2}.bin" ] && rm ${BL2}.bin
+	[ -e "${KERNEL_BIN_NAME}" ] && rm ${KERNEL_BIN_NAME}
+	[ -e "${APP1_BIN_NAME}" ] && rm ${APP1_BIN_NAME}
+	[ -e "${APP2_BIN_NAME}" ] && rm ${APP2_BIN_NAME}
+	[ -e "${COMMON_BIN_NAME}" ] && rm ${COMMON_BIN_NAME}
+	[ -e "${CONFIG_ARCH_BOARD}_smartfs.bin" ] && rm ${CONFIG_ARCH_BOARD}_smartfs.bin
+	[ -e "${BOOTPARAM}.bin" ] && rm ${BOOTPARAM}.bin
 }


### PR DESCRIPTION
when download without bootparam, we can have below error. because It is not check, during file copy and try download.

so, This commit adds to check for bootparam.bin file before try copy or download.

Error log:
	cp: cannot stat '/root/tizenrt/build/configs/../../build/output/bin/bootparam.bin': No such file or directory
	...
	Makefile.unix:630: recipe for target 'download' failed
	make: *** [download] Error 1

Also This commit removes unnecessary checking.