### PR TITLE
apps/mem_leak_checker, kernel/debug: change usage for mem leak checker

### DIFF
--- a/apps/system/mem_leak_checker/mem_leak_checker_main.c
+++ b/apps/system/mem_leak_checker/mem_leak_checker_main.c
@@ -24,37 +24,11 @@
 int mem_leak_checker_main(int argc, char **argv)
 {
 	int ret;
-
-#ifdef CONFIG_APP_BINARY_SEPARATION
-	if (argc != 2) {
-#else 
-	if (argc != 1) {
-#endif
-		printf("Fail to launch MEMORY LEAK CHECKER : Invalid arguments.\n");
-		goto usage;
-	}
-
-#ifdef CONFIG_APP_BINARY_SEPARATION
-	ret = prctl(PR_MEM_LEAK_CHECKER, getpid(), argv[1]);
-#else
-	ret = prctl(PR_MEM_LEAK_CHECKER, getpid(), NULL);
-#endif
+	ret = prctl(PR_MEM_LEAK_CHECKER, getpid());
 	if (ret < 0) {
 		printf("Fail to launch MEMORY LEAK CHECKER.\n");
 		return ERROR;
 	}
 
 	return OK;
-
-usage:
-#ifdef CONFIG_APP_BINARY_SEPARATION
-	printf("\nUsage: mem_leak [TARGET]\n");
-	printf("\nTargets:\n");
-	printf(" kernel         Check memory leak from kernel threads.\n");
-	printf(" app1            Check memory leak from app1 Binary.\n");
-	printf(" app2            Check memory leak from app2 Binary.\n");
-#else
-	printf("\nUsage: mem_leak\n");
-#endif
-	return ERROR;
 }

--- a/os/include/tinyara/mm/mm.h
+++ b/os/include/tinyara/mm/mm.h
@@ -869,7 +869,7 @@ struct mem_leak_checker_info_s {
 	void *heap;
 	int regions;
 };
-int run_mem_leak_checker(int checker_pid, char *bin_name);
+int run_all_mem_leak_checker(int checker_pid);
 #endif
 /**
  * @brief Free the memory from specified user heap.

--- a/os/kernel/task/task_prctl.c
+++ b/os/kernel/task/task_prctl.c
@@ -359,11 +359,9 @@ int prctl(int option, ...)
 	{
 		int ret;
 		int checker_pid;
-		char *bin_name;
 		checker_pid = va_arg(ap, int);
-		bin_name = va_arg(ap, char *);
 
-		ret = run_mem_leak_checker(checker_pid, bin_name);
+		ret = run_all_mem_leak_checker(checker_pid);
 		va_end(ap);
 
 		return ret;


### PR DESCRIPTION
Consolidate app and kernel leak check under mem_leak

```
TASH>>mem_leak

Kernel :
*** NO MEMORY LEAK.

Below are text addresses of loadable apps (and common binary if enabled) :
The pc value of the allocation can be obtained by subtracting the text start address of the appropriate binary

[app1] Text Addr : 0x217d040, Text Size : 8064
[app2] Text Addr : 0x21fe700, Text Size : 366624

app1 :
*** NO MEMORY LEAK.
app2 :
*** NO MEMORY LEAK.
TASH>>
```

Signed-off-by: Abhishek Akkabathula <a.akkabathul@samsung.com>