### PR TITLE
mm_heap/mm_initialize.c: set total_alloc_size to include first and last node

### DIFF
--- a/os/mm/mm_heap/mm_initialize.c
+++ b/os/mm/mm_heap/mm_initialize.c
@@ -191,6 +191,14 @@ int mm_addregion(FAR struct mm_heap_s *heap, FAR void *heapstart, size_t heapsiz
 	heap->mm_nregions++;
 #endif
 
+#ifdef CONFIG_DEBUG_MM_HEAPINFO
+	/* add guard nodes size to the newly added region as they are considered as allocated*/
+	heap->total_alloc_size += 2 * SIZEOF_MM_ALLOCNODE;
+	if (heap->peak_alloc_size < heap->total_alloc_size) {
+		heap->peak_alloc_size = heap->total_alloc_size;
+	}
+#endif
+
 	/* Add the single, large free node to the nodelist */
 
 	mm_addfreechunk(heap, node);
@@ -253,6 +261,10 @@ int mm_initialize(FAR struct mm_heap_s *heap, FAR void *heapstart, size_t heapsi
 
 	mm_seminitialize(heap);
 
+#ifdef CONFIG_DEBUG_MM_HEAPINFO
+	heap->total_alloc_size = heap->peak_alloc_size = 0;
+#endif
+
 	/* Add the initial region of memory to the heap */
 
 	ret = mm_addregion(heap, heapstart, heapsize);
@@ -263,7 +275,6 @@ int mm_initialize(FAR struct mm_heap_s *heap, FAR void *heapstart, size_t heapsi
 	for (i = 0; i < CONFIG_MAX_TASKS; i++) {
 		heap->alloc_list[i].pid = HEAPINFO_INIT_INFO;
 	}
-	heap->total_alloc_size = heap->peak_alloc_size = 0;
 #ifdef CONFIG_HEAPINFO_USER_GROUP
 	heapinfo_update_group_info(INVALID_PROCESS_ID, HEAPINFO_INVALID_GROUPID, HEAPINFO_INIT_INFO);
 #endif


### PR DESCRIPTION
total_alloc_size is being initialized to zero and is being updated only during mm related calls (malloc, free etc). So, it will not include the size of the gaurd nodes. If we check mallinfo implementation, the allocated size includes the size of guard nodes. So, initialize it to proper value.

before fix :
[tc_umm_heap_get_heap_free_size] FAIL [Line : 485] umm_get_heap_free_size : Values (free_size == 0x736c0) and (info.fordblks == 0x736a0) are not equal

after fix :
[tc_umm_heap_get_heap_free_size] PASS
.
.
.########## Kernel TC End [PASS : 415, FAIL : 0] ##########