### PR TITLE
[DO NOT MERGE][TESTING REQUIRED]arm/armv8-m: fix issues in signal handling

### DIFF
--- a/os/arch/arm/include/armv8-m/irq.h
+++ b/os/arch/arm/include/armv8-m/irq.h
@@ -157,6 +157,7 @@ struct xcptcontext {
 #ifdef CONFIG_BUILD_PROTECTED
 	uint32_t saved_lr;
 #endif
+	uint32_t saved_exec_ret;
 
 #ifdef CONFIG_BUILD_PROTECTED
 	/* This is the saved address to use when returning from a user-space

--- a/os/arch/arm/src/armv8-m/up_schedulesigaction.c
+++ b/os/arch/arm/src/armv8-m/up_schedulesigaction.c
@@ -175,6 +175,8 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 #ifdef CONFIG_BUILD_PROTECTED
 				tcb->xcp.saved_lr = current_regs[REG_LR];
 #endif
+				tcb->xcp.saved_exec_ret = current_regs[REG_EXC_RETURN];
+
 				/* Then set up to vector to the trampoline with interrupts
 				 * disabled.  The kernel-space trampoline must run in
 				 * privileged thread mode.
@@ -189,6 +191,11 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 #ifdef CONFIG_BUILD_PROTECTED
 				current_regs[REG_LR] = EXC_RETURN_PRIVTHR;
 #endif
+				if (current_regs[REG_EXC_RETURN] == EXC_RETURN_HANDLER) {
+					current_regs[REG_EXC_RETURN] = EXC_RETURN_PRIVTHR;
+				}
+
+				current_regs[REG_XPSR] = ARMV8M_XPSR_T;
 				/* And make sure that the saved context in the TCB is the same
 				 * as the interrupt return context.
 				 */
@@ -220,6 +227,8 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 #ifdef CONFIG_BUILD_PROTECTED
 			tcb->xcp.saved_lr = tcb->xcp.regs[REG_LR];
 #endif
+			tcb->xcp.saved_exec_ret = tcb->xcp.regs[REG_EXC_RETURN];
+
 			/* Then set up to vector to the trampoline with interrupts
 			 * disabled.  We must already be in privileged thread mode to be
 			 * here.
@@ -234,6 +243,11 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 #ifdef CONFIG_BUILD_PROTECTED
 			tcb->xcp.regs[REG_LR] = EXC_RETURN_PRIVTHR;
 #endif
+			if (tcb->xcp.regs[REG_EXC_RETURN] == EXC_RETURN_HANDLER) {
+				tcb->xcp.regs[REG_EXC_RETURN] = EXC_RETURN_PRIVTHR;
+			}
+
+			tcb->xcp.regs[REG_XPSR] = ARMV8M_XPSR_T;
 		}
 	}
 

--- a/os/arch/arm/src/armv8-m/up_sigdeliver.c
+++ b/os/arch/arm/src/armv8-m/up_sigdeliver.c
@@ -132,6 +132,7 @@ void up_sigdeliver(void)
 #ifdef CONFIG_BUILD_PROTECTED
 	regs[REG_LR] = rtcb->xcp.saved_lr;
 #endif
+	regs[REG_EXC_RETURN] = rtcb->xcp.saved_exec_ret;
 
 	/* Get a local copy of the sigdeliver function pointer. We do this so that
 	 * we can nullify the sigdeliver function pointer in the TCB and accept
@@ -139,7 +140,6 @@ void up_sigdeliver(void)
 	 */
 
 	sigdeliver = (sig_deliver_t)rtcb->xcp.sigdeliver;
-	rtcb->xcp.sigdeliver = NULL;
 
 	/* Then restore the task interrupt state */
 
@@ -165,6 +165,9 @@ void up_sigdeliver(void)
 	/* Then restore the correct state for this thread of
 	 * execution.
 	 */
+
+	/* handle new signal only after finishing current signal processing */
+	rtcb->xcp.sigdeliver = NULL;
 
 	board_led_off(LED_SIGNAL);
 


### PR DESCRIPTION
set the XPSR value to ARMV8M_XPSR_T to enusure that the T bit is 1 during signal handling. Set EXC_RETURN to thread mode when handling signal if in handler mode, to avoid the integrity check while restoring context in HANDLER mode.