### PR TITLE
binfmt: Fix build warnings.

### DIFF
--- a/os/binfmt/libelf/libelf_addrenv.c
+++ b/os/binfmt/libelf/libelf_addrenv.c
@@ -287,15 +287,15 @@ int elf_addrenv_alloc(FAR struct elf_loadinfo_s *loadinfo)
 void elf_addrenv_free(FAR struct elf_loadinfo_s *loadinfo)
 {
 	if (loadinfo->binp->sections[BIN_TEXT]) {
-		kmm_free(loadinfo->binp->sections[BIN_TEXT]);
-		loadinfo->binp->sections[BIN_TEXT] = NULL;
+		kmm_free((void *)(loadinfo->binp->sections[BIN_TEXT]));
+		loadinfo->binp->sections[BIN_TEXT] = (int)NULL;
 	}
 	if (loadinfo->binp->sections[BIN_DATA]) {
-		kmm_free(loadinfo->binp->sections[BIN_DATA]);
-		loadinfo->binp->sections[BIN_DATA] = NULL;
+		kmm_free((void *)(loadinfo->binp->sections[BIN_DATA]));
+		loadinfo->binp->sections[BIN_DATA] = (int)NULL;
 	}
 	if (loadinfo->binp->sections[BIN_RO]) {
-		kmm_free(loadinfo->binp->sections[BIN_RO]);
-		loadinfo->binp->sections[BIN_RO] = NULL;
+		kmm_free((void *)(loadinfo->binp->sections[BIN_RO]));
+		loadinfo->binp->sections[BIN_RO] = (int)NULL;
 	}
 }


### PR DESCRIPTION
CC:  libelf/libelf_addrenv.c
libelf/libelf_addrenv.c: In function 'elf_addrenv_free': libelf/libelf_addrenv.c:290:12: warning: passing argument 1 of 'kmm_free' makes pointer from integer without a cast [-Wint-conversion]
   kmm_free(loadinfo->binp->sections[BIN_TEXT]);
            ^~~~~~~~
In file included from /root/tizenrt/os/include/tinyara/kmalloc.h:65:0,
                 from libelf/libelf_addrenv.c:63:
/root/tizenrt/os/include/tinyara/mm/mm.h:538:6: note: expected 'void *' but argument is of type 'uint32_t {aka unsigned int}'
 void kmm_free(FAR void *mem);
      ^~~~~~~~
libelf/libelf_addrenv.c:291:38: warning: assignment makes integer from pointer without a cast [-Wint-conversion]
   loadinfo->binp->sections[BIN_TEXT] = NULL;
                                      ^
libelf/libelf_addrenv.c:294:12: warning: passing argument 1 of 'kmm_free' makes pointer from integer without a cast [-Wint-conversion]
   kmm_free(loadinfo->binp->sections[BIN_DATA]);
            ^~~~~~~~
In file included from /root/tizenrt/os/include/tinyara/kmalloc.h:65:0,
                 from libelf/libelf_addrenv.c:63:
/root/tizenrt/os/include/tinyara/mm/mm.h:538:6: note: expected 'void *' but argument is of type 'uint32_t {aka unsigned int}'
 void kmm_free(FAR void *mem);
      ^~~~~~~~
libelf/libelf_addrenv.c:295:38: warning: assignment makes integer from pointer without a cast [-Wint-conversion]
   loadinfo->binp->sections[BIN_DATA] = NULL;
                                      ^
libelf/libelf_addrenv.c:298:12: warning: passing argument 1 of 'kmm_free' makes pointer from integer without a cast [-Wint-conversion]
   kmm_free(loadinfo->binp->sections[BIN_RO]);
            ^~~~~~~~
In file included from /root/tizenrt/os/include/tinyara/kmalloc.h:65:0,
                 from libelf/libelf_addrenv.c:63:
/root/tizenrt/os/include/tinyara/mm/mm.h:538:6: note: expected 'void *' but argument is of type 'uint32_t {aka unsigned int}'
 void kmm_free(FAR void *mem);
      ^~~~~~~~
libelf/libelf_addrenv.c:299:36: warning: assignment makes integer from pointer without a cast [-Wint-conversion]
   loadinfo->binp->sections[BIN_RO] = NULL;
                                    ^