### PR TITLE
os/include/tinyara : Add definition to ss_slot_index header file

### DIFF
--- a/framework/src/wifi_manager/wifi_manager_profile.c
+++ b/framework/src/wifi_manager/wifi_manager_profile.c
@@ -31,6 +31,9 @@
 #include <security/security_api.h>
 #include <tinyara/net/if/wifi.h>
 #include <tinyara/net/netlog.h>
+#ifdef CONFIG_WIFI_PROFILE_SECURESTORAGE
+#include <tinyara/ss_slot_index.h>
+#endif
 #include "wifi_manager_profile.h"
 
 //#define WIFI_PROFILE_USE_ETC
@@ -44,11 +47,6 @@
 #define DELI_LEN 1
 
 #define WIFI_PROFILE_BUFSIZE 128
-
-#ifdef CONFIG_WIFI_PROFILE_SECURESTORAGE
-#define WIFI_PROFILE_SS_INDEX 1
-#define WIFI_PROFILE_SS_INDEX_INTERNAL 2
-#endif
 
 #define ENCODE_STRING(buf, size, data, pos)					\
 	do {													\

--- a/os/include/tinyara/ss_slot_index.h
+++ b/os/include/tinyara/ss_slot_index.h
@@ -18,4 +18,11 @@
 
 /// @brief ss_info contains the slot information used in secure storage.
 
-#define SS_SLOT_INDEX_SECURITY_LEVEL    (32)
+/* wifi_manager */
+// wifi_manager_profile.c
+#define WIFI_PROFILE_SS_INDEX                   (1)
+#define WIFI_PROFILE_SS_INDEX_INTERNAL          (2)
+
+/* security_level */
+// security_level.c
+#define SS_SLOT_INDEX_SECURITY_LEVEL            (32)


### PR DESCRIPTION
It is difficult to find the secure storage slots currently in use, and there is a possibility of duplicate use. So I collected  the secure storage slots currently in use in one header. (exclude example codes & not currently used code)