### PR TITLE
tinyara/arch.h: Add dummy TZ APIs for ARMV7A

### DIFF
--- a/os/include/tinyara/arch.h
+++ b/os/include/tinyara/arch.h
@@ -445,6 +445,16 @@ void up_allocate_secure_context(TZ_ModuleId_t size);
  ****************************************************************************/
 
 void up_free_secure_context();
+
+#else		//CONFIG_ARMV8M_TRUSTZONE
+
+// Adding below defines to prevent errors when vendor code tries to call
+// security API's which are not implemented as they are not required by the 
+// architecture. For example ARMV7A does not use NSC based TZ calls.
+
+#define up_allocate_secure_context(size)
+#define up_free_secure_context()
+
 #endif
 
 /************************************************************************************

--- a/os/include/tinyara/arch.h
+++ b/os/include/tinyara/arch.h
@@ -444,7 +444,7 @@ void up_allocate_secure_context(TZ_ModuleId_t size);
  *
  ****************************************************************************/
 
-void up_free_secure_context();
+void up_free_secure_context(void);
 
 #else		//CONFIG_ARMV8M_TRUSTZONE
 


### PR DESCRIPTION
ARMV7A does not use NSC (Non Secure Callable) approach for calling secure APIs from non secure side. As a result APIs to allocate and free secure context are no longer required. However, RTK vendor code for SE tries to call these APIs, which is causing build error. This commit provides dummy defines for these APIs to prevent the errors.