### PR TITLE
apps/examples: Fix error during distclean

### DIFF
--- a/apps/examples/board_specific_demo/ameba_cmsis_nn_demo/Makefile
+++ b/apps/examples/board_specific_demo/ameba_cmsis_nn_demo/Makefile
@@ -148,12 +148,10 @@ depend: .depend
 clean:
 	$(call DELFILE, .built)
 	$(call CLEAN)
-	rm $(wildcard ./*/*.o)
 
 distclean: clean
 	$(call DELFILE, Make.dep)
 	$(call DELFILE, .depend)
-	rm $(wildcard ./*/*.o)
 
 -include Make.dep
 .PHONY: preconfig


### PR DESCRIPTION
Remove unnecessary statements in Makefile to fix error during clean and distclean.

```
====================================================================
make[4]: Entering directory '/root/tizenrt/apps/examples/board_specific_demo/ameba_cmsis_nn_demo' rm
rm: missing operand
Try 'rm --help' for more information.
Makefile:149: recipe for target 'clean' failed
make[4]:  [clean] Error 1
make[4]: Leaving directory '/root/tizenrt/apps/examples/board_specific_demo/ameba_cmsis_nn_demo' Makefile:38: recipe for target 'ameba_cmsis_nn_demo/_distclean' failed make[3]:  [ameba_cmsis_nn_demo/_distclean] Error 2 make[3]: Leaving directory '/root/tizenrt/apps/examples/board_specific_demo' /root/tizenrt/apps/Directory.mk:74: recipe for target 'board_specific_demo/_distclean' failed make[2]:  [board_specific_demo/_distclean] Error 2 make[2]: Leaving directory '/root/tizenrt/apps/examples' Makefile:114: recipe for target 'examples/_distclean' failed make[1]: [examples/_distclean] Error 2
make[1]: Leaving directory '/root/tizenrt/apps'
====================================================================
```