### PR TITLE
os/se: RTL8730E Remove the SE dummy API

### DIFF
--- a/apps/examples/board_specific_demo/ameba_secure_storage_demo/Kconfig
+++ b/apps/examples/board_specific_demo/ameba_secure_storage_demo/Kconfig
@@ -6,7 +6,7 @@
 config EXAMPLES_SSTORAGE
 	bool "Secure Storage example"
 	default n
-	depends on ARMV8M_TRUSTZONE && SE_AMEBA
+	depends on SE_AMEBA
 	---help---
 		Enable the Secure Storage example
 

--- a/os/se/ameba/rtl_security_api_wrapper_tz.c
+++ b/os/se/ameba/rtl_security_api_wrapper_tz.c
@@ -109,16 +109,6 @@ void *rtl_set_ns_func(void)
 	/* No need for RTL8730E */
 	return NULL;
 }
-
-void up_allocate_secure_context(size_t size)
-{
-	/* No need for RTL8730E */
-}
-
-void up_free_secure_context(void)
-{
-	/* No need for RTL8730E */
-}
 #else
 extern int rtw_get_random_bytes(void *dst, u32 size);
 void *rtl_set_ns_func(void)

--- a/os/se/ameba/security_ameba_wrapper_tz.c
+++ b/os/se/ameba/security_ameba_wrapper_tz.c
@@ -21,6 +21,7 @@
 #include <stdint.h>
 
 #include <tinyara/config.h>
+#include <tinyara/arch.h>
 #include <semaphore.h>
 #include <tinyara/seclink_drv.h>
 #include <tinyara/kmalloc.h>


### PR DESCRIPTION
Removed the depends on ARMV8M_TRUSTZONE for secure storage example apps/examples/board_specific_demo/ameba_secure_storage_demo/Kconfig

Removed the SE dummy API and handle in arch.h by Samsung os/se/ameba/rtl_security_api_wrapper_tz.c

Added the arch.h header file for SE code
os/se/ameba/security_ameba_wrapper_tz.c