### PR TITLE
log_dump: fix log_dump hang issue

### DIFF
--- a/os/kernel/log_dump/log_dump.c
+++ b/os/kernel/log_dump/log_dump.c
@@ -373,7 +373,11 @@ static int compress_full_bufs(void)
 		mq_send(mq_fd, (const char *)&msg_compress, sizeof(int), 100);
 
 		/* wait for completion of the current full block compression */
-		while (compress_full_block) ;
+		while (compress_full_block) {
+			if (sched_lockcount()) {
+				usleep(10000);
+			}
+		}
 
 		if (compress_ret < 0) {
 			lldbg("Fail to compress ret = %d\n", compress_ret);


### PR DESCRIPTION
when the log is outputted while the scheduled lock is called, hang can be occur. 
because log_dump is waitting that compress is finish using only while()

So, even if log dump waits, context switching does not occur to log dump thread, so while() continues to circulate.