### PR TITLE
log_dump: change to not compress operation during sched_lock

### DIFF
--- a/os/kernel/log_dump/log_dump.c
+++ b/os/kernel/log_dump/log_dump.c
@@ -457,7 +457,7 @@ int log_dump_save(char ch)
 			 * priority, then there will be a lockup since both threads cannot proceed. 
 			 * So, in this case, we will return without performing the compression.
 			 */
-			if (sched_self()->sched_priority > CONFIG_LOG_DUMP_PRIO) {
+			if (sched_self()->sched_priority > CONFIG_LOG_DUMP_PRIO || sched_lockcount()) {
 				return LOG_DUMP_FAIL;
 			}
 


### PR DESCRIPTION
when the log is outputted while the scheduled lock is called, hang can be occur. 
For this, applied a8822cb commit. but This is breaking the intention of blocking context switching using sched_lock in the application, cpu is forcibly handed over to another thread.

So, This commit adds so that there is no compress operation when the sched_lock is stuck.