### PR TITLE
preference: Move PREFERENCE_TYPE macros to framewrk/../preference.h

### DIFF
--- a/framework/include/preference/preference.h
+++ b/framework/include/preference/preference.h
@@ -27,12 +27,29 @@
 #ifndef __FRAMEWORK_INCLUDE_PREFERENCE_PREFERENCE_H__
 #define __FRAMEWORK_INCLUDE_PREFERENCE_PREFERENCE_H__
 
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
 #include <stdbool.h>
 #include <tinyara/preference.h>
 
-#ifdef __cplusplus
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+#ifdef __cpluplus
 extern "C" {
 #endif
+
+/****************************************************************************
+ * Public Type Definitions
+ ****************************************************************************/
+enum preference_type_e {
+        PREFERENCE_TYPE_INT = 0,
+        PREFERENCE_TYPE_DOUBLE,
+        PREFERENCE_TYPE_BOOL,
+        PREFERENCE_TYPE_STRING,
+        PREFERENCE_TYPE_BINARY,
+};
 
 /****************************************************************************
  * Public Function Prototypes

--- a/os/include/tinyara/preference.h
+++ b/os/include/tinyara/preference.h
@@ -39,14 +39,6 @@
 #define PREF_PRIVATE_PATH PREF_PATH"/private"
 #define PREF_SHARED_PATH PREF_PATH"/shared"
 
-enum preference_type_e {
-	PREFERENCE_TYPE_INT = 0,
-	PREFERENCE_TYPE_DOUBLE,
-	PREFERENCE_TYPE_BOOL,
-	PREFERENCE_TYPE_STRING,
-	PREFERENCE_TYPE_BINARY,
-};
-
 /* Error Type of Result Value returned from Preference */
 enum preference_result_error_e {
 	PREFERENCE_IO_ERROR = -1,


### PR DESCRIPTION
- PREFERENCE_TYPE macros are only used by the preference framework code so they need not be defined in kernel/../preference.h header file