### PR TITLE
os/board: Correct partition mounting function names

### DIFF
--- a/os/board/esp32_devkit/src/esp32_boot.c
+++ b/os/board/esp32_devkit/src/esp32_boot.c
@@ -127,7 +127,7 @@ int up_check_proddownload(void)
  ************************************************************************************/
 extern int board_ledc_setup(void);
 
-void esp32_devKit_mount_partions(void)
+void esp32_devKit_mount_partitions(void)
 {
 #ifdef CONFIG_FLASH_PARTITION
 	int ret;
@@ -254,7 +254,7 @@ void board_initialize(void)
 #ifdef CONFIG_ESP32_SPIFLASH
 	esp_partition_initialize();
 #endif
-	esp32_devKit_mount_partions();
+	esp32_devKit_mount_partitions();
 	board_gpio_initialize();
 	board_i2c_initialize();
 	board_ledc_setup();

--- a/os/board/rtl8720e/src/rtl8720e_boot.c
+++ b/os/board/rtl8720e/src/rtl8720e_boot.c
@@ -207,7 +207,7 @@ void board_gpio_initialize(void)
 #endif
 }
 
-void amebalite_mount_partions(void)
+void amebalite_mount_partitions(void)
 {
 #ifdef CONFIG_FLASH_PARTITION
 	int ret;
@@ -301,7 +301,7 @@ void board_initialize(void)
 	/*switch shell control to KM0 */
 	//InterruptDis(UART_LOG_IRQ);
 
-	amebalite_mount_partions();
+	amebalite_mount_partitions();
 	board_gpio_initialize();
 	board_i2c_initialize();
 	board_spi_initialize();

--- a/os/board/rtl8721csm/src/rtl8721csm_boot.c
+++ b/os/board/rtl8721csm/src/rtl8721csm_boot.c
@@ -250,7 +250,7 @@ void board_gpio_initialize(void)
 #endif
 }
 
-void amebad_mount_partions(void)
+void amebad_mount_partitions(void)
 {
 #ifdef CONFIG_FLASH_PARTITION
 	int ret;
@@ -311,7 +311,7 @@ void board_initialize(void)
 	shell_init_rom(0, 0);
 	//shell_init_ram();
 	ipc_table_init();
-	amebad_mount_partions();
+	amebad_mount_partitions();
 	board_gpio_initialize();
 	board_i2c_initialize();
 	board_spi_initialize();

--- a/os/board/rtl8730e/src/rtl8730e_boot.c
+++ b/os/board/rtl8730e/src/rtl8730e_boot.c
@@ -250,7 +250,7 @@ void board_gpio_initialize(void)
 #endif
 }
 
-void amebasmart_mount_partions(void)
+void amebasmart_mount_partitions(void)
 {
 #ifdef CONFIG_FLASH_PARTITION
 	int ret;
@@ -324,7 +324,7 @@ void board_initialize(void)
 	}
 #endif
 
-	amebasmart_mount_partions();
+	amebasmart_mount_partitions();
 	board_gpio_initialize();
 	board_i2c_initialize();
 	board_spi_initialize();


### PR DESCRIPTION
- Correct the names of functions <esp32_devKit/amebad/amebalite/amebasmart>_mount_partions to <...>_mount_partitions