### PR TITLE
amebad/Kconfig: fix syntax error

### DIFF
--- a/os/arch/arm/src/amebad/Kconfig
+++ b/os/arch/arm/src/amebad/Kconfig
@@ -101,7 +101,7 @@ config AMEBAD_I2CTIMEOTICKS
 	depends on !AMEBAD_I2C_DYNTIMEO
 
 config RTL8721D_SPI
-	bool "RTL8721D_SPI
+	bool "RTL8721D_SPI"
 	default n
 
 config SPI1_MASTER


### PR DESCRIPTION
Fix the occurrence of syntax errors because quotation marks are not closed