### PR TITLE
platform/gnu, libxx: select config appropriately for static constructors init

### DIFF
--- a/apps/platform/gnu/Kconfig
+++ b/apps/platform/gnu/Kconfig
@@ -6,7 +6,7 @@
 config HAVE_CXXINITIALIZE
 	bool "Have C++ initialization"
 	default n
-	depends on HAVE_CXX
+	depends on HAVE_CXX && BUILD_FLAT
 	select SYSTEM_PREAPP_INIT
 	---help---
 		The platform-specific logic includes support for initialization

--- a/lib/libxx/Kconfig
+++ b/lib/libxx/Kconfig
@@ -51,6 +51,8 @@ comment "LLVM C++ Library (libcxx)"
 config LIBCXX
 	bool "Build LLVM libcxx"
 	default n
+	select HAVE_CXXINITIALIZE if BUILD_FLAT
+	select BINFMT_CONSTRUCTORS if APP_BINARY_SEPARATION
 	---help---
 		LLVM libc++ can be built by selecting this option.
 


### PR DESCRIPTION
In the case of flat, CONFIG_HAVE_CXXINITIALIZE is required and in the
case of loadable, CONFIG_BINFMT_CONSTRUCTORS is required for cpp static
constructors initialization. Hence, select them appropriately when cpp is
enabled. Users need not select them specially as from now on they are enabled
by default.

Make CONFIG_HAVE_CXXINITIALIZE dependent on BUILD_FLAT so users will not
enable it in loadable configs by mistake

Signed-off-by: Abhishek Akkabathula <a.akkabathul@samsung.com>