### PR TITLE
os/tinyara/security_hal.h : Remove ED25519

### DIFF
--- a/os/include/tinyara/security_hal.h
+++ b/os/include/tinyara/security_hal.h
@@ -133,7 +133,6 @@ typedef enum {
 	HAL_KEY_ECC_SEC_P384R1,		  // nist curve for p384r1
 	HAL_KEY_ECC_SEC_P512R1,		  // nist curve for p512r1
 	HAL_KEY_ECC_25519,			  // Montgomery curve for key exchange
-	HAL_KEY_ED_25519, // Twisted Edwards curve for signing and verification
 	/* HMAC */
 	HAL_KEY_HMAC_MD5,	 // hmac with md5
 	HAL_KEY_HMAC_SHA1,	 // hmac with sha1


### PR DESCRIPTION
Remove ED25519 because TP1x does not support it.