### PR TITLE
build/configs/rtl87XX: Set -fno-common flag always

### DIFF
--- a/build/configs/rtl8720e/Make.defs
+++ b/build/configs/rtl8720e/Make.defs
@@ -120,11 +120,7 @@ ifeq ($(CONFIG_FRAME_POINTER),y)
   ARCHOPTIMIZATION += -fomit-frame-pointer -mapcs -mno-sched-prolog
 endif
 
-ARCHCFLAGS = -fno-builtin -mcpu=cortex-m33 -mfpu=fpv5-sp-d16
-
-ifeq ($(CONFIG_APP_BINARY_SEPARATION),y)
-  ARCHCFLAGS += -fno-common
-endif
+ARCHCFLAGS = -fno-builtin -fno-common -mcpu=cortex-m33 -mfpu=fpv5-sp-d16
 ARCHCXXFLAGS = -fno-builtin -mcpu=cortex-m33 -mfpu=fpv5-sp-d16
 ARCHWARNINGS = -Wall -Wstrict-prototypes -Wshadow -Wundef -Wno-implicit-function-declaration -Wno-unused-function -Wno-unused-but-set-variable
 ARCHWARNINGSXX = -Wall -Wshadow -Wundef

--- a/build/configs/rtl8721csm/Make.defs
+++ b/build/configs/rtl8721csm/Make.defs
@@ -136,12 +136,7 @@ ifeq ($(CONFIG_FRAME_POINTER),y)
   ARCHOPTIMIZATION += -fomit-frame-pointer -mapcs -mno-sched-prolog
 endif
 
-ARCHCFLAGS = -fno-builtin -mcpu=cortex-m33 -mfpu=fpv5-sp-d16
-
-ifeq ($(CONFIG_APP_BINARY_SEPARATION),y)
-  ARCHCFLAGS += -fno-common
-endif
-
+ARCHCFLAGS = -fno-builtin -fno-common -mcpu=cortex-m33 -mfpu=fpv5-sp-d16
 ARCHCXXFLAGS = -fno-builtin -mcpu=cortex-m33 -mfpu=fpv5-sp-d16
 
 ifeq ($(CONFIG_HAVE_CXX),y)

--- a/build/configs/rtl8730e/Make.defs
+++ b/build/configs/rtl8730e/Make.defs
@@ -120,10 +120,7 @@ ifeq ($(CONFIG_FRAME_POINTER),y)
   ARCHOPTIMIZATION += -fomit-frame-pointer -mapcs -mno-sched-prolog
 endif
 
-ARCHCFLAGS += -fno-builtin 
-ifeq ($(CONFIG_APP_BINARY_SEPARATION),y)
-  ARCHCFLAGS += -fno-common
-endif
+ARCHCFLAGS += -fno-builtin -fno-common
 ARCHCXXFLAGS = -fno-builtin -fexceptions 
 ifeq ($(QUICKBUILD),y)
 ARCHWARNINGS = -Wall -Werror -Wstrict-prototypes -Wshadow -Wundef -Wno-implicit-function-declaration -Wno-unused-function -Wno-unused-but-set-variable


### PR DESCRIPTION
This flag specifies that the compiler places uninitialized global variables in the BSS section of the object file. It is ok to always have the fno-common flag, so I set the flag to avoid confusion.