### PR TITLE
framework/preference: Fix build issues with perefernce framework

### DIFF
--- a/framework/src/preference/private_preference.c
+++ b/framework/src/preference/private_preference.c
@@ -26,6 +26,7 @@
 #include <sys/prctl.h>
 
 #include <tinyara/preference.h>
+#include <preference/preference.h>
 
 #include "preference_internal.h"
 
@@ -276,7 +277,7 @@ int preference_remove_all(void)
 /****************************************************************************
  * Callback Functions
  ****************************************************************************/
-int preference_set_changed_cb(char *key, preference_changed_cb callback, void *user_data)
+int preference_set_changed_cb(const char *key, preference_changed_cb callback, void *user_data)
 {
 	int ret;
 	struct sigaction act;
@@ -307,7 +308,7 @@ int preference_set_changed_cb(char *key, preference_changed_cb callback, void *u
 	return prctl(PR_SET_PREFERENCE_CB, &data);
 }
 
-int preference_unset_changed_cb(char *key)
+int preference_unset_changed_cb(const char *key)
 {
 	if (key == NULL) {
 		return PREFERENCE_INVALID_PARAMETER;

--- a/framework/src/preference/shared_preference.c
+++ b/framework/src/preference/shared_preference.c
@@ -26,6 +26,7 @@
 #include <sys/prctl.h>
 
 #include <tinyara/preference.h>
+#include <preference/preference.h>
 
 #include "preference_internal.h"
 


### PR DESCRIPTION
- Add missing header file for shared and private preference.
" CC:  src/preference/private_preference.c
src/preference/private_preference.c: In function 'preference_set_int':
src/preference/private_preference.c:45:19: error: 'PREFERENCE_TYPE_INT' undeclared (first use in this function)
  data.attr.type = PREFERENCE_TYPE_INT;
                   ^~~~~~~~~~~~~~~~~~~  "

- Correct input parameter type for private preference functions to match function declarations in header file
" CC:  src/preference/private_preference.c
src/preference/private_preference.c:281:5: error: conflicting types for 'preference_set_changed_cb'
 int preference_set_changed_cb(char *key, preference_changed_cb callback, void *user_data)
     ^~~~~~~~~~~~~~~~~~~~~~~~~
In file included from src/preference/private_preference.c:30:0:
/root/tizenrt/framework/include/preference/preference.h:195:5: note: previous declaration of 'preference_set_changed_cb' was here
 int preference_set_changed_cb(const char *key, preference_changed_cb callback, void *cb_data);
     ^~~~~~~~~~~~~~~~~~~~~~~~~
src/preference/private_preference.c:312:5: error: conflicting types for 'preference_unset_changed_cb'
 int preference_unset_changed_cb(char *key)
     ^~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from src/preference/private_preference.c:30:0:
/root/tizenrt/framework/include/preference/preference.h:204:5: note: previous declaration of 'preference_unset_changed_cb' was here
 int preference_unset_changed_cb(const char *key);
     ^~~~~~~~~~~~~~~~~~~~~~~~~~~
Makefile:57: recipe for target 'private_preference.o' failed "

Signed-off-by: Amogh Hassija <a.hassija@samsung.com>