### PR TITLE
configs/rtl8721csm: fix exception handling on tp1x

### DIFF
--- a/build/configs/rtl8721csm/rtl8721csm_make_bin.sh
+++ b/build/configs/rtl8721csm/rtl8721csm_make_bin.sh
@@ -79,7 +79,7 @@ arm-none-eabi-objcopy -Obinary $BINDIR/target_pure_img2.axf $BINDIR/target_img2.
 arm-none-eabi-objcopy -j .ram_image2.entry -j .ram_image2.text -j .ram_image2.data \
 -Obinary $BINDIR/target_pure_img2.axf $BINDIR/ram_2.bin
 
-arm-none-eabi-objcopy -j .xip_image2.text \
+arm-none-eabi-objcopy -j .xip_image2.text -j .ARM.extab -j .ARM.exidx \
 -Obinary $BINDIR/target_pure_img2.axf $BINDIR/xip_image2.bin
 
 arm-none-eabi-objcopy -j .psram_image2.text -j .psram_image2.data \


### PR DESCRIPTION
ARM.exidx and ARM.extab sections are not being copied into the final binary, causing the exceptions to not work. Hence added them.

```

============ Test RTTI ==================================
extend

============ Test Exception =============================
Catch exception: runtime error

============ thread::operator= test =====================
Spawning 5 threads...
Done spawning threads. Now waiting for them to join:
pause of 1 seconds ended
pause of 2 seconds ended
pause of 3 seconds ended
```