### PR TITLE
mm/mm_heap, mem_leak_checker: fix heap corruption hang

### DIFF
--- a/os/kernel/debug/mem_leak_checker.c
+++ b/os/kernel/debug/mem_leak_checker.c
@@ -22,6 +22,7 @@
 #include <tinyara/config.h>
 #include <stdlib.h>
 #include <debug.h>
+#include <assert.h>
 #include <stdio.h>
 #include <string.h>
 #include <queue.h>
@@ -127,6 +128,7 @@ static int get_node_cnt(void)
 	{
 		node_size = SIZEOF_MM_ALLOCNODE;
 		for (node = leak_checker.heap_start[region]; node < leak_checker.heap_end[region]; node = (struct mm_allocnode_s *)((char *)node + node->size)) {
+			ASSERT(node->size);
 			/* Ignore the heap start checking, because there is a guard node in heap start */
 			if (node == leak_checker.heap_start[region]) {
 				continue;
@@ -168,6 +170,7 @@ static void fill_hash_table(int *leak_cnt, int *broken_cnt)
 	{
 		node_size = SIZEOF_MM_ALLOCNODE;
 		for (node = leak_checker.heap_start[region]; node < leak_checker.heap_end[region]; node = (struct mm_allocnode_s *)((char *)node + node->size)) {
+			ASSERT(node->size);
 			/* Ignore the heap start checking, because there is a guard node in heap start */
 			if (node == leak_checker.heap_start[region]) {
 				continue;
@@ -323,6 +326,7 @@ static void print_info(char *bin_name, int leak_cnt, int broken_cnt, uint32_t bi
 #endif
 		{
 			for (node = leak_checker.heap_start[region]; node < leak_checker.heap_end[region]; node = (struct mm_allocnode_s *)((char *)node + node->size)) {
+				ASSERT(node->size);
 				if (node->reserved == MEM_LEAK) {
 					/* alloc_call_addr can be from kernel, app or common binary.
 					* based on the text addresses printed, user needs to check the

--- a/os/kernel/debug/mem_leak_checker.c
+++ b/os/kernel/debug/mem_leak_checker.c
@@ -278,7 +278,7 @@ static void ram_check(char *bin_name, int *leak_cnt, uint32_t *bin_text_addr)
 
 #ifdef CONFIG_APP_BINARY_SEPARATION
 	if (strncmp(bin_name, "kernel", strlen("kernel") + 1) == 0) {
-        	/* do nothing */
+		/* do nothing */
 	} else {
 #ifdef CONFIG_SUPPORT_COMMON_BINARY
 		search_addr((void *)info[CMN_BIN_IDX].data_addr, (void *)(info[CMN_BIN_IDX].data_addr + info[CMN_BIN_IDX].data_size), leak_cnt);
@@ -311,38 +311,37 @@ static void print_info(char *bin_name, int leak_cnt, int broken_cnt, uint32_t bi
 		mm_takesemaphore((struct mm_heap_s *)leak_checker.heap);
 
 #if CONFIG_KMM_REGIONS > 1
-        int region;
+		int region;
 #else
 #define region 0
 #endif
 
-        /* Visit each region */
+		/* Visit each region */
 
 #if CONFIG_KMM_REGIONS > 1
-        for (region = 0; region < leak_checker.regions; region++)
+		for (region = 0; region < leak_checker.regions; region++)
 #endif
-        {
-
-                for (node = leak_checker.heap_start[region]; node < leak_checker.heap_end[region]; node = (struct mm_allocnode_s *)((char *)node + node->size)) {
-			if (node->reserved == MEM_LEAK) {
-				/* alloc_call_addr can be from kernel, app or common binary.
-				 * based on the text addresses printed, user needs to check the
-				 * corresponding binaries accordingly 
-				 */
-				owner_addr = node->alloc_call_addr;
-				pid_t pid = node->pid;
-				if (pid < 0) {
-					/* For stack allocated node, pid is negative value.
-					 * To use the pid, change it to original positive value.
-					 */
-					pid = (-1) * pid;
+		{
+			for (node = leak_checker.heap_start[region]; node < leak_checker.heap_end[region]; node = (struct mm_allocnode_s *)((char *)node + node->size)) {
+				if (node->reserved == MEM_LEAK) {
+					/* alloc_call_addr can be from kernel, app or common binary.
+					* based on the text addresses printed, user needs to check the
+					* corresponding binaries accordingly
+					*/
+					owner_addr = node->alloc_call_addr;
+					pid_t pid = node->pid;
+					if (pid < 0) {
+						/* For stack allocated node, pid is negative value.
+						* To use the pid, change it to original positive value.
+						*/
+						pid = (-1) * pid;
+					}
+					printf("LEAK   | %10p |  %8d  | %10p | %d\n", (void *)((char *)node + SIZEOF_MM_ALLOCNODE), node->size - SIZEOF_MM_ALLOCNODE, owner_addr, pid);
+				} else if (node->reserved == MEM_BROKEN) {
+					printf("BROKEN | %p\n", node);
 				}
-				printf("LEAK   | %10p |  %8d  | %10p | %d\n", (void *)((char *)node + SIZEOF_MM_ALLOCNODE), node->size - SIZEOF_MM_ALLOCNODE, owner_addr, pid);
-			} else if (node->reserved == MEM_BROKEN) {
-				printf("BROKEN | %p\n", node);
 			}
 		}
-	}
 
 		mm_givesemaphore((struct mm_heap_s *)leak_checker.heap);
 
@@ -434,7 +433,7 @@ int run_all_mem_leak_checker(int checker_pid)
 			printf("%s :\n", BIN_NAME(bin_idx));
 			ret = run_mem_leak_checker(checker_pid, BIN_NAME(bin_idx));
 			if (ret != OK) {
-			       return ERROR;
+				return ERROR;
 			}
 		}
 	}

--- a/os/mm/mm_heap/mm_heapinfo_parse_heap.c
+++ b/os/mm/mm_heap/mm_heapinfo_parse_heap.c
@@ -55,6 +55,7 @@
 #include <tinyara/config.h>
 #include <tinyara/sched.h>
 #include <tinyara/mm/mm.h>
+#include <assert.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <syslog.h>
@@ -142,6 +143,7 @@ void heapinfo_parse_heap(FAR struct mm_heap_s *heap, int mode, pid_t pid)
 		}
 
 		for (node = heap->mm_heapstart[region]; node < heap->mm_heapend[region]; node = (struct mm_allocnode_s *)((char *)node + node->size)) {
+			ASSERT(node->size);
 
 			/* Check if the node corresponds to an allocated memory chunk */
 			if ((pid == HEAPINFO_PID_ALL || node->pid == pid) && (node->preceding & MM_ALLOC_BIT) != 0) {

--- a/os/mm/mm_heap/mm_mallinfo.c
+++ b/os/mm/mm_heap/mm_mallinfo.c
@@ -115,6 +115,7 @@ int mm_mallinfo(FAR struct mm_heap_s *heap, FAR struct mallinfo *info)
 		for (node = heap->mm_heapstart[region]; node < heap->mm_heapend[region]; node = (struct mm_allocnode_s *)((char *)node + node->size)) {
 			mvdbg("region=%d node=%p size=%u preceding=%u (%c)\n", region, node, node->size,
 				(node->preceding & ~MM_ALLOC_BIT), (node->preceding & MM_ALLOC_BIT) ? 'A' : 'F');
+			ASSERT(node->size);
 
 			/* Check if the node corresponds to an allocated memory chunk */
 			if ((node->preceding & MM_ALLOC_BIT) != 0) {


### PR DESCRIPTION
The chunk of heap can know the address of the next chunk through `node = node + node->size`.
Using this, all chunks of the heap can be traversed in the forward direction.

If the heap is corrupted and the node->size becomes 0, It can't move to the next chunk, and the iteration turns infinite.
Also, It is Locked the heap during the heap traversing. As a result, it becomes deadlock.

Therefore, Add to check the node size and it to cause ASSERT if it is zero during traversing forward direction.

hang reproduce code:
```
	int *val = (int*)malloc(sizeof(int) * 100);
	val = val - 1;
	*val = 0;

	mallinfo();
```