### PR TITLE
arch/arm/armv8-m/up_blocktask: Correct invaild tcb->tz_context check

### DIFF
--- a/os/arch/arm/src/armv8-m/up_blocktask.c
+++ b/os/arch/arm/src/armv8-m/up_blocktask.c
@@ -143,7 +143,7 @@ void up_block_task(struct tcb_s *tcb, tstate_t task_state)
 
 	if (switch_needed) {
 #ifdef CONFIG_ARMV8M_TRUSTZONE
-		if (tcb->tz_context) {
+		if (rtcb->tz_context) {
 			TZ_StoreContext_S(rtcb->tz_context);
 		}
 #endif


### PR DESCRIPTION
If thread is in the trustzone, (TCB)->tz_context is allocated. And when context switching while this thread is operating, saves the context related to the trustzone in (TCB)->tz_context.

Likewise in up_block_task, the tz_context of rtcb(running thread) must be checked and the context of the trustzone must be stored, but the tz_context of the wrong TCB is checked.

Therefore, Correct to check the tz_context of running tcb.