### PR TITLE
tools/nxfuse: Remove inclusion of security_level.h in case of NXFUSE build

### DIFF
--- a/os/include/debug.h
+++ b/os/include/debug.h
@@ -71,9 +71,8 @@
 #ifndef NXFUSE_HOST_BUILD
 #include <tinyara/compiler.h>
 #include <tinyara/logm.h>
-#endif
-
 #include <tinyara/security_level.h>
+#endif
 
 #include <syslog.h>
 


### PR DESCRIPTION

- Fix missing header file security_level.h error during smartfs pre-image build
- security_level.h file need not be copied to Nxfuse sources along with other dependant files during NXFUSE_HOST_BUILD as the functionality is not needed during Nxfuse pre-image build.