### PR TITLE
os/board/rtl8730e: Fix WiFi related Build Warning and SVACE

### DIFF
--- a/os/board/rtl8730e/src/component/wifi/inic/inic_ipc_host_api.c
+++ b/os/board/rtl8730e/src/component/wifi/inic/inic_ipc_host_api.c
@@ -275,7 +275,9 @@ void inic_ipc_api_host_task(void)
 		p_ipc_msg->EVENT_ID = 0;
 		DCache_Clean((u32)p_ipc_msg, sizeof(inic_ipc_dev_request_message));
 	} while (1);
-	vTaskDelete(NULL);
+#ifndef CONFIG_PLATFORM_TIZENRT_OS
+	rtw_delete_task(NULL);
+#endif
 }
 
 /**

--- a/os/board/rtl8730e/src/component/wifi/inic/inic_ipc_host_api_ext.c
+++ b/os/board/rtl8730e/src/component/wifi/inic/inic_ipc_host_api_ext.c
@@ -561,7 +561,7 @@ void rtw_autoreconnect_hdl(rtw_security_t security_type,
 	param.password_len = password_len;
 	param.key_id = key_id;
 
-	if (wifi_autoreconnect_task.task != NULL) {
+	if (wifi_autoreconnect_task.task != 0) {
 #if CONFIG_LWIP_LAYER
 		netifapi_dhcp_stop(&xnetif[0]);
 #endif
@@ -574,7 +574,7 @@ void rtw_autoreconnect_hdl(rtw_security_t security_type,
 				return;
 			}
 
-			if (wifi_autoreconnect_task.task == NULL) {
+			if (wifi_autoreconnect_task.task == 0) {
 				break;
 			}
 		}
@@ -935,7 +935,7 @@ int wifi_csi_report(u32 buf_len, u8 *csi_buf, u32 *len)
 	DCache_CleanInvalidate((u32)csi_buf_temp, buf_len);
 	DCache_CleanInvalidate((u32)len_temp, sizeof(u32));
 
-	ret = inic_ipc_api_host_message_send(IPC_API_WIFI_GET_CSI_REPORT, param_buf, 4);
+	ret = inic_ipc_api_host_message_send(IPC_API_WIFI_GET_CSI_REPORT, param_buf, 3);
 	DCache_Invalidate((u32)csi_buf_temp, buf_len);
 	rtw_memcpy(csi_buf, csi_buf_temp, buf_len);
 

--- a/os/board/rtl8730e/src/component/wifi/promisc/wifi_promisc_inic_ipc.c
+++ b/os/board/rtl8730e/src/component/wifi/promisc/wifi_promisc_inic_ipc.c
@@ -547,7 +547,7 @@ void cmd_promisc(int argc, char **argv)
 		//promisc_test(duration, 0);
 	{
 		promisc_test_all(duration, 0);
-	} else if ((argc == 3) && ((duration = atoi(argv[1])) > 0) && (strcmp(argv[2], "with_len") == 0)) {
+	} else if ((argc == 3) && ((duration = atoi(argv[1])) > 0) && (duration < 0x7FFFFFFF) && (strcmp(argv[2], "with_len") == 0)) {
 		promisc_test(duration, 1);
 	} else {
 		printf("\n\rUsage: %s DURATION_SECONDS [with_len]", argv[0]);

--- a/os/board/rtl8730e/src/component/wifi/wifi_interactive_mode.c
+++ b/os/board/rtl8730e/src/component/wifi/wifi_interactive_mode.c
@@ -594,10 +594,13 @@ int8_t cmd_wifi_disconnect(void)
 void cmd_wifi_info(int argc, char **argv)
 {
 	int i = 0;
-	u8 wlan_idx[2] = {0, 1};
+	u8 wlan_idx[NET_IF_NUM];// Declared the array size as follow the NET_IF_NUM
 	rtw_sw_statistics_t sw_stats;
-
 	rtw_wifi_setting_t setting;
+
+	memset(wlan_idx, 0, NET_IF_NUM);
+	wlan_idx[1] = 1; // Fixed , 1st element must be 0:STA and 2nd element must be 1:SoftAP
+
 	for (i = 0; i < NET_IF_NUM; i++) {
 		if (wifi_is_running(i)) {
 			nvdbg("\n\r\nWIFI %s Status: Running", ifname[i]);
@@ -952,7 +955,7 @@ static void cmd_debug(int argc, char **argv)
 		int i = 0;
 		int len = 0;
 		for (i = 1; i < argc; i++) {
-			strcpy(&buf[len], argv[i]);
+			strncpy(&buf[len], argv[i], strlen(argv[i]));
 			len = strlen(copy);
 			buf[len++] = ' ';
 			buf[len] = '\0';


### PR DESCRIPTION
Build Warning
- Added macro checking for declare the unused variable as it depends on the macro on/off
- Changed the NULL checking to 0 
SVACE
- DEREF_OF_NULL.RET.STAT: Added the NULL pointer checking
- BUFFER_OVERFLOW.LIB.EX: Modified the API with correct pass in parameter for the size
- UNREACHABLE_CODE: Added macro to wrap it for cover the switch case break
- OVERFLOW_UNDER_CHECK: Declared the wlan_idx[NET_IF_NUM] with follow thw NET_IF_NUM value
- PROC_USE.VULNERABLE: Replaced strcpy with strncpy with pass in length
- TAINTED_INT.LOOP: Added the condition checking for the unsigned value