### PR TITLE
os/drivers/compression: Adds compression driver module

### DIFF
--- a/apps/examples/testcase/le_tc/compression/compression_tc_main.c
+++ b/apps/examples/testcase/le_tc/compression/compression_tc_main.c
@@ -25,6 +25,7 @@
 #include <fcntl.h>
 #include <errno.h>
 #include <tinyara/os_api_test_drv.h>
+#include <tinyara/compression.h>
 #include "tc_common.h"
 #include "tc_internal.h"
 
@@ -37,6 +38,13 @@ int tc2_get_drvfd(void)
 }
 #endif
 
+static int g_comp_tc_fd;
+
+int get_compfd(void)
+{
+	return g_comp_tc_fd;
+}
+
 #ifdef CONFIG_BUILD_KERNEL
 int main(int argc, FAR char *argv[])
 #else
@@ -45,14 +53,22 @@ int tc_compression_main(int argc, char *argv[])
 {
 #ifdef CONFIG_TC_COMPRESS_READ
 	g_tc_fd = open(OS_API_TEST_DRVPATH, O_WRONLY);
-
 	/*If FAIL : Failed to open testcase driver*/
 	if (g_tc_fd < 0) {
 		printf("Failed to open OS API test driver %d\n", errno);
 		return ERROR;
 	}
 
-	tc_compress_read_main();
+	g_comp_tc_fd = open(COMP_DRVPATH, O_WRONLY);
+	/*If FAIL : Failed to open compression driver*/
+	if (g_comp_tc_fd < 0) {
+		printf("Failed to open compression driver %d\n", errno);
+		close(g_tc_fd);
+		return ERROR;
+	}
+	
+	tc_compress_main();
+	close(g_comp_tc_fd);
 	close(g_tc_fd);
 #endif
 

--- a/apps/examples/testcase/le_tc/compression/tc_compress_read.c
+++ b/apps/examples/testcase/le_tc/compression/tc_compress_read.c
@@ -22,28 +22,83 @@
 #include <tinyara/config.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <errno.h>
 #include <fcntl.h>
 #include <sys/ioctl.h>
+#include <sys/types.h>
 #include <tc_common.h>
 #include <tinyara/os_api_test_drv.h>
+#include <tinyara/compression.h>
 #include "tc_internal.h"
+
+#define UNCOMPRESS_DATA_SIZE 20000
+
+static struct compress_header *comp_tc_data;
+static struct compress_header *decomp_tc_data;
+static int fd;
+
+static void uninitialize_tc_data(void)
+{
+	/* No need to free decomp_tc_data->input_buffer because 
+	 * it is same as comp_tc_data->output_buffer */
+	free(comp_tc_data->input_buffer);
+	free(comp_tc_data->output_buffer);
+	if (!decomp_tc_data) {
+		free(decomp_tc_data->output_buffer);
+	}
+	free(comp_tc_data);
+	free(decomp_tc_data);
+}
+
+static int initialize_tc_data(void)
+{
+	comp_tc_data = (struct compress_header *)malloc(sizeof(struct compress_header));
+	if (comp_tc_data == NULL) {
+		return ERROR;
+	}
+		
+	comp_tc_data->input_buffer = (unsigned char *)malloc(UNCOMPRESS_DATA_SIZE);
+	if (comp_tc_data->input_buffer == NULL) {
+		goto exit_with_comp_input;
+	}
+
+	comp_tc_data->input_size = UNCOMPRESS_DATA_SIZE;
+	
+	for(int i = 0; i < comp_tc_data->input_size; i++) {
+		comp_tc_data->input_buffer[i] = 'a' + (rand() % 26);
+	}
+	
+	comp_tc_data->output_size = UNCOMPRESS_DATA_SIZE;
+	comp_tc_data->output_buffer = (unsigned char *)malloc(UNCOMPRESS_DATA_SIZE);
+	if (comp_tc_data->output_buffer == NULL) {
+		goto exit_with_comp_output;
+	}
+	
+	decomp_tc_data = (struct compress_header *)malloc(sizeof(struct compress_header));
+	if (decomp_tc_data == NULL) {
+		goto exit_with_decomp;
+	}
+		
+	decomp_tc_data->input_buffer = comp_tc_data->output_buffer;
+	decomp_tc_data->input_size = comp_tc_data->output_size;
+	
+	return OK;
+	
+exit_with_decomp:
+	free(comp_tc_data->output_buffer);
+exit_with_comp_output:
+	free(comp_tc_data->input_buffer);
+exit_with_comp_input:
+	free(comp_tc_data);
+	
+	return ERROR;
+}
 
 /****************************************************************************
  * Private Functions
  ****************************************************************************/
-
-/****************************************************************************
- * Name: tc_compress_decompress
- *
- * Description:
- *   Block-wise compression and decompression of a file.
- *
- * Returned Value:
- *   None
- ****************************************************************************/
-static void tc_compress_decompress(void)
+static void tc_compressed_file_read(void)
 {
-	int fd;
 	int ret_chk;
 	fd = tc2_get_drvfd();
 
@@ -57,11 +112,210 @@ static void tc_compress_decompress(void)
 }
 
 /****************************************************************************
+ * Name: tc_comp_decom_buffer_known_output_size
+ *
+ * Description:
+ *   Testing compression and decompression of a file when the
+ *   output size after decompression is known .
+ *   This is the case where output size is kept equal to 
+ *   actual size of decompressed data.
+ *
+ * Returned Value:
+ *   None
+ ****************************************************************************/
+static void tc_comp_decomp_buffer_equal_output_size(void)
+{
+	int ret_chk;
+	fd = get_compfd();
+
+	/*If FAIL : Failed to open testcase driver*/
+	TC_ASSERT_GEQ("get_compfd", fd, OK);
+	
+	// initializing comp_tc_data
+	ret_chk = initialize_tc_data();
+	TC_ASSERT_EQ("compression data initialize", ret_chk, OK);
+	
+	// Test compression method 
+	ret_chk = ioctl(fd, COMPIOC_COMPRESS, comp_tc_data);
+	TC_ASSERT_EQ_CLEANUP("compress block", ret_chk, OK, uninitialize_tc_data());
+	
+	decomp_tc_data->input_size = comp_tc_data->output_size;
+	decomp_tc_data->output_size = UNCOMPRESS_DATA_SIZE;
+	decomp_tc_data->output_buffer = (unsigned char *)malloc(UNCOMPRESS_DATA_SIZE); 
+	
+	// Test decompression method
+	ret_chk = ioctl(fd, COMPIOC_DECOMPRESS, decomp_tc_data);
+	TC_ASSERT_EQ_CLEANUP("decompress block", ret_chk, OK, uninitialize_tc_data());
+	TC_ASSERT_EQ_CLEANUP("output size after decompress", decomp_tc_data->output_size, UNCOMPRESS_DATA_SIZE, uninitialize_tc_data());
+	
+	//check the data before compression and after decompression
+	for (int i = 0; i < comp_tc_data->input_size; i++){
+		TC_ASSERT_EQ_CLEANUP("output after decompress", comp_tc_data->input_buffer[i], decomp_tc_data->output_buffer[i], uninitialize_tc_data());
+	}
+
+	uninitialize_tc_data();
+	TC_SUCCESS_RESULT();
+
+}
+
+/****************************************************************************
+ * Name: tc_comp_decomp_buffer_lesser_output_size
+ *
+ * Description:
+ *   Testing compression and decompression of a file when the
+ *   output size after decompression is assigned same as input size
+ *   before decomrpession . 
+ *   This can be taken as the case where output size is kept less than
+ *   actual size of decompressed data.
+ *
+ * Returned Value:
+ *   None
+ ****************************************************************************/
+static void tc_comp_decomp_buffer_lesser_output_size(void)
+{
+	int ret_chk;
+	fd = get_compfd();
+
+	/*If FAIL : Failed to open testcase driver*/
+	TC_ASSERT_GEQ("get_compfd", fd, OK);
+	
+	// initializing comp_tc_data
+	ret_chk = initialize_tc_data();
+	TC_ASSERT_EQ("compression data initialize", ret_chk, OK);
+	
+	// Test compression method 
+	ret_chk = ioctl(fd, COMPIOC_COMPRESS, comp_tc_data);
+	TC_ASSERT_EQ_CLEANUP("compress block", ret_chk, OK, uninitialize_tc_data());
+	
+	decomp_tc_data->input_size = comp_tc_data->output_size;
+	decomp_tc_data->output_size = UNCOMPRESS_DATA_SIZE / 2;
+	decomp_tc_data->output_buffer = (unsigned char *)malloc(UNCOMPRESS_DATA_SIZE / 2);
+	
+	// Test decompression method
+	ret_chk = ioctl(fd, COMPIOC_DECOMPRESS, decomp_tc_data);
+	TC_ASSERT_EQ_CLEANUP("decompress block", ret_chk, ENOMEM, uninitialize_tc_data());
+
+	uninitialize_tc_data();
+	TC_SUCCESS_RESULT();
+}
+
+/****************************************************************************
+ * Name: tc_comp_decomp_buffer_greater_output_size
+ *
+ * Description:
+ *   Testing compression and decompression of a file when the
+ *   output size after decompression is very large than input size
+ *   before decomrpession . 
+ *   This can be taken as the case where output size is larger than
+ *   actual size of decompressed data.
+ *
+ * Returned Value:
+ *   None
+ ****************************************************************************/
+static void tc_comp_decomp_buffer_greater_output_size(void)
+{
+	int ret_chk;
+	fd = get_compfd();
+
+	/*If FAIL : Failed to open testcase driver*/
+	TC_ASSERT_GEQ("get_compfd", fd, OK);
+	
+	// initializing comp_tc_data
+	ret_chk = initialize_tc_data();
+	TC_ASSERT_EQ("compression data initialize", ret_chk, OK);
+	
+	// Test compression method 
+	ret_chk = ioctl(fd, COMPIOC_COMPRESS, comp_tc_data);
+	TC_ASSERT_EQ_CLEANUP("compress block", ret_chk, OK, uninitialize_tc_data());
+	
+	decomp_tc_data->input_size = comp_tc_data->output_size;
+	decomp_tc_data->output_size = 2 * UNCOMPRESS_DATA_SIZE;
+	decomp_tc_data->output_buffer = (unsigned char *)malloc(2 * UNCOMPRESS_DATA_SIZE);
+	
+	// Test decompression method
+	ret_chk = ioctl(fd, COMPIOC_DECOMPRESS, decomp_tc_data);
+	TC_ASSERT_EQ_CLEANUP("decompress block", ret_chk, OK, uninitialize_tc_data());
+	TC_ASSERT_EQ_CLEANUP("output size after decompress", decomp_tc_data->output_size, UNCOMPRESS_DATA_SIZE, uninitialize_tc_data());
+	
+	//check the data before compression and after decompression
+	for (int i = 0; i < comp_tc_data->input_size; i++){
+		TC_ASSERT_EQ_CLEANUP("output after decompress", comp_tc_data->input_buffer[i], decomp_tc_data->output_buffer[i], uninitialize_tc_data());
+	}
+	
+	uninitialize_tc_data();
+	TC_SUCCESS_RESULT();
+}
+
+/****************************************************************************
+ * Name: tc_comp_type
+ *
+ * Description:
+ *   Testing compression type command of compression ioctl
+ *
+ * Returned Value:
+ *   None
+ ****************************************************************************/
+static void tc_comp_type(void)
+{
+	int ret_chk;
+	fd = get_compfd();
+
+	/*If FAIL : Failed to open testcase driver*/
+	TC_ASSERT_GEQ("get_compfd", fd, OK);
+	
+	// Test to check compression type 
+	ret_chk = ioctl(fd, COMPIOC_GET_COMP_TYPE, NULL);
+	TC_ASSERT_EQ("compression_type_check", ret_chk, CONFIG_COMPRESSION_TYPE);
+	
+	TC_SUCCESS_RESULT();
+}
+
+/****************************************************************************
+ * Name: tc_comp_name
+ *
+ * Description:
+ *   Testing compression type name string command of compression ioctl
+ *
+ * Returned Value:
+ *   None
+ ****************************************************************************/
+static void tc_comp_name(void)
+{
+	int ret_chk;
+	char *tc_comp_type_name;
+	fd = get_compfd();
+
+	/*If FAIL : Failed to open testcase driver*/
+	TC_ASSERT_GEQ("get_compfd", fd, OK);
+	
+	// Test to check compression type string name
+	tc_comp_type_name = (char *)malloc(COMP_NAME_SIZE);
+	TC_ASSERT_NEQ("compression type string initialize", tc_comp_type_name, NULL);
+	
+	ret_chk = ioctl(fd, COMPIOC_GET_COMP_NAME, tc_comp_type_name);
+	TC_ASSERT_EQ_CLEANUP("compression type string check", ret_chk, OK, free(tc_comp_type_name));
+	
+	if ( CONFIG_COMPRESSION_TYPE == MINIZ_TYPE) {
+		TC_ASSERT_EQ_CLEANUP("compression type string check", strcmp(tc_comp_type_name, MINIZ_NAME), OK, free(tc_comp_type_name));
+	} else {
+		TC_ASSERT_EQ_CLEANUP("compression type string check", strcmp(tc_comp_type_name, LZMA_NAME), OK, free(tc_comp_type_name));
+	}
+	
+	free(tc_comp_type_name);
+	TC_SUCCESS_RESULT();
+}
+
+/****************************************************************************
  * Public Function
  ****************************************************************************/
-int tc_compress_read_main(void)
+int tc_compress_main(void)
 {
-	tc_compress_decompress();
+	tc_comp_type();
+	tc_comp_name();
+	tc_comp_decomp_buffer_equal_output_size();
+	tc_comp_decomp_buffer_lesser_output_size();
+	tc_comp_decomp_buffer_greater_output_size();
+	tc_compressed_file_read();
 
 	return 0;
 }

--- a/apps/examples/testcase/le_tc/compression/tc_internal.h
+++ b/apps/examples/testcase/le_tc/compression/tc_internal.h
@@ -25,7 +25,6 @@
 /**********************************************************
 * TC Function Declarations
 **********************************************************/
-
-int tc_compress_read_main(void);
+int tc_comrpess_main(void);
 
 #endif /* __EXAMPLES_TESTCASE_COMPRESSION_TC_INTERNAL_H */

--- a/os/drivers/Makefile
+++ b/os/drivers/Makefile
@@ -74,6 +74,7 @@ include analog$(DELIM)Make.defs
 include audio$(DELIM)Make.defs
 include bch$(DELIM)Make.defs
 include bluetooth$(DELIM)Make.defs
+include compression$(DELIM)Make.defs
 include cpuload$(DELIM)Make.defs
 include fota$(DELIM)Make.defs
 include gpio$(DELIM)Make.defs

--- a/os/drivers/compression/Make.defs
+++ b/os/drivers/compression/Make.defs
@@ -1,0 +1,63 @@
+############################################################################
+##
+## Copyright 2023 Samsung Electronics All Rights Reserved.
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+## http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing,
+## software distributed under the License is distributed on an
+## "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+## either express or implied. See the License for the specific
+## language governing permissions and limitations under the License.
+##
+############################################################################
+############################################################################
+# drivers/compression/Make.defs
+#
+#   Copyright (C) 2008, 2011-2012 Gregory Nutt. All rights reserved.
+#   Author: Gregory Nutt <gnutt@nuttx.org>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in
+#    the documentation and/or other materials provided with the
+#    distribution.
+# 3. Neither the name NuttX nor the names of its contributors may be
+#    used to endorse or promote products derived from this software
+#    without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+# OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+# AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+############################################################################
+
+ifeq ($(CONFIG_COMPRESSION),y)
+
+CSRCS += compress.c
+
+# Include Compression driver build support
+
+DEPPATH += --dep-path compression
+VPATH += :compression
+CFLAGS += ${shell $(INCDIR) $(INCDIROPT) "$(CC)" $(TOPDIR)$(DELIM)drivers$(DELIM)compression}
+
+endif

--- a/os/drivers/compression/README.md
+++ b/os/drivers/compression/README.md
@@ -1,0 +1,55 @@
+# Compression driver
+
+This driver APIs are used to access compression and decompression functions of compression module.
+The ioctl function of the compress driver supports following commands and accordingly perform 
+following tasks .
+
+## 1. COMPIOC_COMPRESS cmd :
+
+For this cmd, user needs to pass a struct compress_header pointer as arg to the ioctl and need to store
+the members of the struct as below : <br />
+input_size     ->  input size of the data <br />
+input_buffer   ->  input data <br />
+output_size    ->  should be same as input size because after compression, output size will be less than or equal to input size <br />
+output_buffer  ->  should be allocated before passing to ioctl function 
+
+The ioctl function will call the compression function and compressed data will be stored in 
+output_buffer and output_size will get updated to the length of compressed data. 
+
+## 2. COMPIOC_GET_COMP_TYPE cmd :
+
+For this cmd, user can pass arg as NULL because there is no need of an argument. The ioctl will return 
+the compression type.
+
+## 3. COMPIOC_GET_COMP_NAME cmd :
+
+For this cmd, user needs to pass a char pointer as arg that needs to be allocated memory with a size of
+COMP_NAME_SIZE (compression.h). This should be allocated memory before passing to the ioctl.
+The ioctl funtion will store the compression type name string in the char pointer.
+
+## 4. COMPIOC_DECOMPRESS cmd :
+
+For this cmd, user needs to pass a struct compress_header pointer as arg to the ioctl and need to store
+the members of the struct as below : <br />
+input_size      -> input size of compressed data <br />
+input_buffer    -> compressed data <br />
+output_buffer   -> should be allocated before passing to ioctl funtion <br />
+output_size     -> three cases are possible for output size which is discussed below 
+
+- ##### when output size passed is equal to actual decompressed data size : <br />
+        This is the case where user knows the size of decompressed data. The ioctl function will call the
+        decompress funtion and it will store the decompressed data in output_buffer and output_size will 
+        remain same.
+    
+- ##### when output size passed is more than actual decompressed data size : <br />
+        This is the case where user does not know the size of decompressed data and passes the output size 
+        larger than required for output buffer. The ioctl function will call the decompress funtion and it will
+        store the decompressed data in output buffer and update the output_size as the actual decompressed 
+        data size .Here, output_size after the ioctl call will be less than before.
+
+- ##### when output size passed is less than actual decompressed data size : <br />
+        This is the case where user does not know the size of decompressed data and passes the output size
+        smaller than required for output buffer. The ioctl call will return ENOMEM (out of memory) error 
+        and it will print that output buffer allocated is not sufficient. 
+        User need to update the output_size to a larger value and allocate memory to output_buffer 
+        and call ioctl function again to get full decompressed data.

--- a/os/drivers/compression/compress.c
+++ b/os/drivers/compression/compress.c
@@ -1,0 +1,137 @@
+/****************************************************************************
+ *
+ * Copyright 2023 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+#include <tinyara/config.h>
+
+#include <tinyara/fs/fs.h>
+#include <tinyara/fs/ioctl.h>
+#include <tinyara/compression.h>
+
+#include <errno.h>
+#include <debug.h>
+#include <assert.h>
+
+/****************************************************************************
+ * Function Prototypes
+ ****************************************************************************/
+
+static int comp_ioctl(FAR struct file *filep, int cmd, unsigned long arg);
+static ssize_t comp_read(FAR struct file *filep, FAR char *buffer, size_t len);
+static ssize_t comp_write(FAR struct file *filep, FAR const char *buffer, size_t len);
+
+/****************************************************************************
+ * Data
+ ****************************************************************************/
+static const struct file_operations compress_fops = {
+	0,                          /* open */
+	0,                          /* close */
+	comp_read,                  /* read */
+	comp_write,                 /* write */
+	0,                          /* seek */
+	comp_ioctl              /* ioctl */
+#ifndef CONFIG_DISABLE_POLL
+	, 0                         /* poll */
+#endif
+};
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+static ssize_t comp_read(FAR struct file *filep, FAR char *buffer, size_t len)
+{
+	return 0;
+}
+
+static ssize_t comp_write(FAR struct file *filep, FAR const char *buffer, size_t len)
+{
+	return 0;
+}
+
+
+/************************************************************************************
+ * Name: comp_ioctl
+ *
+ * Command description:
+ * 	 COMPIOC_COMPRESS - for compression of input data
+ * 	 COMPIOC_DECOMPRESS - for decompression of input data
+ * 	 COMPIOC_GET_COMP_TYPE - for getting compression type
+ * 	 COMPIOC_GET_COMP_NAME - for getting compression type in string
+ * 
+ * Arguments:
+ * 	 filep is ioctl fd, cmd is required command, arg is required argument for
+ * 	 the command. For compression and decompression, arg is a struct compress_header .
+ *	 For getting compression_type, arg is NULL.
+ *	 For getting compression_name, arg is a char pointer
+ *
+ * Description:
+ *   This api can be used to perform comrpession, decompression,
+ *   get compression type and name. Please go through README for more details.
+ *
+ ************************************************************************************/
+static int comp_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
+{
+	int ret = -ENOSYS;
+	struct compress_header *comp_info = (struct compress_header *)arg;
+
+	if (comp_info == NULL && cmd != COMPIOC_GET_COMP_TYPE) {
+		return -EINVAL;
+	}
+	/* Handle built-in ioctl commands */
+	switch (cmd) {
+	case COMPIOC_COMPRESS:
+		if (comp_info->output_size < comp_info->input_size) {
+			bcmpdbg("It is recommended to keep input size and output size equal during compression\n");
+		}
+		ret = compress_block(comp_info->output_buffer, &comp_info->output_size, comp_info->input_buffer, comp_info->input_size);
+		break;
+	case COMPIOC_GET_COMP_TYPE:
+		/* CONFIG_COMPRESSION_TYPE 1 for LZMA and 2 for MINIZ */
+		ret = CONFIG_COMPRESSION_TYPE;
+		break;
+	case COMPIOC_GET_COMP_NAME:
+		switch (CONFIG_COMPRESSION_TYPE) {
+			case LZMA_TYPE:
+				memcpy((char *)arg, LZMA_NAME, COMP_NAME_SIZE);
+				break;
+			case MINIZ_TYPE:
+				memcpy((char *)arg, MINIZ_NAME, COMP_NAME_SIZE);
+				break;
+		}
+		ret = OK;
+		break;
+ 	case COMPIOC_DECOMPRESS:
+		ret = decompress_block(comp_info->output_buffer, &comp_info->output_size, comp_info->input_buffer, &comp_info->input_size);
+		if (ret == ENOMEM) {
+			bcmpdbg("Output buffer allocated is not sufficient\n");
+		}
+	}
+	return ret;
+}
+
+/****************************************************************************
+ * Name: compress_register
+ *
+ * Description:
+ *   Register compress driver path, COMP_DRVPATH
+ *
+ ****************************************************************************/
+void compress_register(void)
+{
+	(void)register_driver(COMP_DRVPATH, &compress_fops, 0666, NULL);
+}

--- a/os/include/tinyara/compression.h
+++ b/os/include/tinyara/compression.h
@@ -32,6 +32,14 @@
 #define COMP_FAILURE            2
 #define COMP_INVALID_INPUT      3
 #define COMP_USAGE_ERROR        4
+#define COMP_DRVPATH		"/dev/compress"
+
+#define LZMA_TYPE	        1
+#define LZMA_NAME               "LZMA"
+
+#define MINIZ_TYPE		2
+#define MINIZ_NAME              "MINIZ"
+#define COMP_NAME_SIZE          6
 
 /****************************************************************************
  * Public Types
@@ -53,4 +61,46 @@ struct s_header {
 	int binary_size;			/* Uncompressed file size */
 	int secoff[];				/* Offsets to Compressed blocks */
 };
+
+/* compress ioctl argument data struct */
+struct compress_header {
+	long unsigned int input_size;
+	unsigned char *input_buffer;
+	long unsigned int output_size;
+	unsigned char *output_buffer;
+};
+
+/****************************************************************************
+ * Name: compress_register
+ *
+ * Description:
+ *   Register compress driver path, MMINFO_DRVPATH
+ *
+ ****************************************************************************/
+void compress_register(void);
+
+/****************************************************************************
+ * Name: compress_block
+ *
+ * Description:
+ *   compresses block in 'read_buffer' of readsize into 'out_buffer' of writesize
+ *
+ * Returned Value:
+ *   Non-negative value on Success.
+ *   Negative value on Failure.
+ ****************************************************************************/
+int compress_block(unsigned char *out_buffer, long unsigned int *writesize, unsigned char *read_buffer, long unsigned int size);
+
+/****************************************************************************
+ * Name: decompress_block
+ *
+ * Description:
+ *   Decompress block in 'read_buffer' of readsize into 'out_buffer' of writesize
+ *
+ * Returned Value:
+ *   Non-negative value on Success.
+ *   Negative value on Failure.
+ ****************************************************************************/
+int decompress_block(unsigned char *out_buffer, long unsigned int *writesize, unsigned char *read_buffer, long unsigned int *size);
+
 #endif						/* __INCLUDE_COMPRESSION_H */

--- a/os/include/tinyara/fs/ioctl.h
+++ b/os/include/tinyara/fs/ioctl.h
@@ -101,6 +101,7 @@
 #define _IOTBUSBASE     (0x2600)	/* iotbus ioctl commands */
 #define _FBIOCBASE      (0x2700)	/* Frame buffer character driver ioctl commands */
 #define _CPULOADBASE    (0x2800)	/* cpuload ioctl commands */
+#define _COMPBASE       (0x2900)	/* compress ioctl commands */
 #define _TESTIOCBASE    (0xfe00)	/* KERNEL TEST DRV module ioctl commands */
 
 
@@ -432,6 +433,15 @@
 #define MMINFOIOC_HEAP              _MMINFOIOC(0x0001)
 #define MMINFOIOC_PARSE             _MMINFOIOC(0x0002)
 #define MMINFOIOC_MNG_ALLOCFAIL     _MMINFOIOC(0x0003)
+
+/* Compress driver ioctl definitions ************************/
+#define _COMPIOCVALID(c)    (_IOC_TYPE(c) == _COMPBASE)
+#define _COMPIOC(nr)        _IOC(_COMPBASE, nr)
+
+#define COMPIOC_COMPRESS           _COMPIOC(0x0001)
+#define COMPIOC_GET_COMP_TYPE      _COMPIOC(0x0002)
+#define COMPIOC_GET_COMP_NAME      _COMPIOC(0x0003)
+#define COMPIOC_DECOMPRESS	   _COMPIOC(0x0004)
 
 /* Cpuload driver ioctl definitions ************************/
 

--- a/os/kernel/init/os_bringup.c
+++ b/os/kernel/init/os_bringup.c
@@ -84,6 +84,9 @@
 #ifdef CONFIG_MMINFO
 #include <tinyara/mminfo.h>
 #endif
+#ifdef CONFIG_COMPRESSION
+#include <tinyara/compression.h>
+#endif
 #ifdef CONFIG_TASK_MANAGER
 #include <tinyara/task_manager_drv.h>
 #endif
@@ -298,6 +301,10 @@ static inline void os_do_appstart(void)
 
 #ifdef CONFIG_MMINFO
 	mminfo_register();
+#endif
+
+#ifdef CONFIG_COMPRESSION
+	compress_register();
 #endif
 
 #ifdef CONFIG_PRODCONFIG


### PR DESCRIPTION
- adds compression api at public header(compression.h)
- adds compression module in driver , so that it can be used by application
- driver is able to return the compressor compression type
- adds README file in drivers/compression module for more details
- creates testcases to test compression and decompression