### PR TITLE
os/arch/arm/src/ameba: GPIO pull up/down fix

### DIFF
--- a/os/arch/arm/src/amebad/amebad_lowerhalf.c
+++ b/os/arch/arm/src/amebad/amebad_lowerhalf.c
@@ -205,7 +205,6 @@ static int amebad_gpio_enable(FAR struct gpio_lowerhalf_s *lower, int falling,
 	} else {
 		gpio_irq_disable((gpio_irq_t *)&priv->obj);
 		gpio_irq_set((gpio_irq_t *)&priv->obj, event, 0);
-		gpio_irq_deinit((gpio_irq_t *)&priv->obj);
 	}
 
 	return OK;
@@ -256,8 +255,9 @@ FAR struct gpio_lowerhalf_s *amebad_gpio_lowerhalf(u32 pinname, u32 pinmode, u32
 		return NULL;
 	}
 	gpio_init(&lower->obj, pinname);
-    	gpio_dir(&lower->obj, pinmode);
-    	gpio_mode(&lower->obj, pinpull);
+	gpio_dir(&lower->obj, pinmode);
+	gpio_mode(&lower->obj, pinpull);
+
 	lower->pinmode =pinmode;
 	lower->pinpull = pinpull;
 	lower->ops = &amebad_gpio_ops;

--- a/os/arch/arm/src/amebalite/amebalite_lowerhalf.c
+++ b/os/arch/arm/src/amebalite/amebalite_lowerhalf.c
@@ -205,7 +205,6 @@ static int amebalite_gpio_enable(FAR struct gpio_lowerhalf_s *lower, int falling
 	} else {
 		gpio_irq_disable((gpio_irq_t *)&priv->obj);
 		gpio_irq_set((gpio_irq_t *)&priv->obj, event, 0);
-		gpio_irq_deinit((gpio_irq_t *)&priv->obj);
 	}
 
 	return OK;
@@ -256,8 +255,8 @@ FAR struct gpio_lowerhalf_s *amebalite_gpio_lowerhalf(u32 pinname, u32 pinmode, 
 		return NULL;
 	}
 	gpio_init(&lower->obj, pinname);
-    	gpio_dir(&lower->obj, pinmode);
-    	gpio_mode(&lower->obj, pinpull);
+	gpio_dir(&lower->obj, pinmode);
+	gpio_mode(&lower->obj, pinpull);
 	lower->pinmode =pinmode;
 	lower->pinpull = pinpull;
 	lower->ops = &amebalite_gpio_ops;

--- a/os/arch/arm/src/amebasmart/amebasmart_gpio_lowerhalf.c
+++ b/os/arch/arm/src/amebasmart/amebasmart_gpio_lowerhalf.c
@@ -205,7 +205,6 @@ static int amebasmart_gpio_enable(FAR struct gpio_lowerhalf_s *lower, int fallin
 	} else {
 		gpio_irq_disable((gpio_irq_t *)&priv->obj);
 		gpio_irq_set((gpio_irq_t *)&priv->obj, event, 0);
-		gpio_irq_deinit((gpio_irq_t *)&priv->obj);
 	}
 
 	return OK;
@@ -256,8 +255,8 @@ FAR struct gpio_lowerhalf_s *amebasmart_gpio_lowerhalf(u32 pinname, u32 pinmode,
 		return NULL;
 	}
 	gpio_init(&lower->obj, pinname);
-    	gpio_dir(&lower->obj, pinmode);
-    	gpio_mode(&lower->obj, pinpull);
+	gpio_dir(&lower->obj, pinmode);
+	gpio_mode(&lower->obj, pinpull);
 	lower->pinmode =pinmode;
 	lower->pinpull = pinpull;
 	lower->ops = &amebasmart_gpio_ops;


### PR DESCRIPTION
Tested that by removing gpio int deinit** during gpio initialisation, pull up/ down is working.
The deinit interrupt function also clears out the previous parameters. To prevent doing so deinit, this line has been removed.
