### PR TITLE
add DEBUGASSERT_MM_FREE_NODE macro 

### DIFF
--- a/os/mm/mm_heap/mm_free.c
+++ b/os/mm/mm_heap/mm_free.c
@@ -179,7 +179,7 @@ void mm_free(FAR struct mm_heap_s *heap, FAR void *mem)
 		/* Remove the next node.  There must be a predecessor,
 		 * but there may not be a successor node.
 		 */
-
+		DEBUGASSERT_MM_FREE_NODE(heap, next);
 		REMOVE_NODE_FROM_LIST(next);
 
 		/* Then merge the two chunks */
@@ -198,7 +198,7 @@ void mm_free(FAR struct mm_heap_s *heap, FAR void *mem)
 		/* Remove the node.  There must be a predecessor, but there may
 		 * not be a successor node.
 		 */
-
+		DEBUGASSERT_MM_FREE_NODE(heap, prev);
 		REMOVE_NODE_FROM_LIST(prev);
 
 		/* Then merge the two chunks */

--- a/os/mm/mm_heap/mm_heap_dbg.c
+++ b/os/mm/mm_heap/mm_heap_dbg.c
@@ -94,6 +94,7 @@ void mm_dump_heap_free_node_list(struct mm_heap_s *heap)
 			heap_dbg(" %08x(%d)", node, node->size);
 		}
 		heap_dbg("\n");
+
 		if (heap->mm_nodelist[ndx].size != 0) {
 			mfdbg("    Corrupted HEAD of free node link %08x\n", &heap->mm_nodelist[ndx]);
 		}

--- a/os/mm/mm_heap/mm_malloc.c
+++ b/os/mm/mm_heap/mm_malloc.c
@@ -209,7 +209,7 @@ FAR void *mm_malloc(FAR struct mm_heap_s *heap, size_t size)
 		/* Remove the node.  There must be a predecessor, but there may not be
 		 * a successor node.
 		 */
-
+		DEBUGASSERT_MM_FREE_NODE(heap, node);
 		REMOVE_NODE_FROM_LIST(node);
 
 		/* Check if we have to split the free node into one of the allocated

--- a/os/mm/mm_heap/mm_memalign.c
+++ b/os/mm/mm_heap/mm_memalign.c
@@ -216,7 +216,7 @@ FAR void *mm_memalign(FAR struct mm_heap_s *heap, size_t alignment, size_t size)
 		/* Remove the node.  There must be a predecessor, but there may not be
 		 * a successor node.
 		 */
-
+		DEBUGASSERT_MM_FREE_NODE(heap, node);
 		REMOVE_NODE_FROM_LIST(node);
 
 		/* Check if there is free space at the beginning of the aligned chunk */

--- a/os/mm/mm_heap/mm_node.h
+++ b/os/mm/mm_heap/mm_node.h
@@ -24,14 +24,29 @@
  ****************************************************************************/
 
 #include <assert.h>
+#include <debug.h>
+
+#include <tinyara/mm/mm.h>
 
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
 
+#define DEBUGASSERT_MM_FREE_NODE(heap, node)		\
+	do {		\
+		DEBUGASSERT(node);		\
+		if (!((node)->blink)) {		\
+			mfdbg("Corrupted free node %08x\n", node);		\
+			mm_dump_heap_free_node_list(heap);		\
+			mm_dump_node((struct mm_allocnode_s *)node, "CORRUPT NODE");		\
+			mm_dump_node((struct mm_allocnode_s *)((char *)node - (node->preceding & ~MM_ALLOC_BIT)), "PREV NODE");		\
+			mm_dump_node((struct mm_allocnode_s *)((char *)node + node->size), "NEXT NODE");		\
+			DEBUGPANIC();		\
+		}		\
+	} while (0)
+
 #define REMOVE_NODE_FROM_LIST(node)				\
 	do {							\
-		DEBUGASSERT((node)->blink);			\
 		(node)->blink->flink = (node)->flink;		\
 		if ((node)->flink) {				\
 			(node)->flink->blink = (node)->blink;	\

--- a/os/mm/mm_heap/mm_realloc.c
+++ b/os/mm/mm_heap/mm_realloc.c
@@ -266,7 +266,7 @@ FAR void *mm_realloc(FAR struct mm_heap_s *heap, FAR void *oldmem, size_t size)
 			/* Remove the previous node.  There must be a predecessor, but
 			 * there may not be a successor node.
 			 */
-
+			DEBUGASSERT_MM_FREE_NODE(heap, prev);
 			REMOVE_NODE_FROM_LIST(prev);
 
 			/* Extend the node into the previous free chunk */
@@ -320,7 +320,7 @@ FAR void *mm_realloc(FAR struct mm_heap_s *heap, FAR void *oldmem, size_t size)
 			/* Remove the next node.  There must be a predecessor, but there
 			 * may not be a successor node.
 			 */
-
+			DEBUGASSERT_MM_FREE_NODE(heap, next);
 			REMOVE_NODE_FROM_LIST(next);
 
 			/* Extend the node into the next chunk */

--- a/os/mm/mm_heap/mm_shrinkchunk.c
+++ b/os/mm/mm_heap/mm_shrinkchunk.c
@@ -104,7 +104,7 @@ void mm_shrinkchunk(FAR struct mm_heap_s *heap, FAR struct mm_allocnode_s *node,
 		/* Remove the next node.  There must be a predecessor, but there may
 		 * not be a successor node.
 		 */
-
+		DEBUGASSERT_MM_FREE_NODE(heap, next);
 		REMOVE_NODE_FROM_LIST(next);
 
 		/* Create a new chunk that will hold both the next chunk and the


### PR DESCRIPTION
### commit 1    
    mm/mm_heap: add mm_dump_heap_free_node_list function

    add mm_dump_heap_free_node_list function.
    This function prints the hex valuse contents of heap free nodes using heap free node list.
    
    example logs:
    
    ` #########################################################################################
      Dump heap free node list
      [ndx], [HEAD]: [FREE NODES(SIZE)]
    ` #########################################################################################
        0, 1003dc80:
        1, 1003dc98:
        2, 1003dcb0:
        3, 1003dcc8: 0200f220(240)
        4, 1003dce0:
        5, 1003dcf8: 02012dc0(592) 02016b70(576)
        6, 1003dd10: 0201eb70(1488)
        7, 1003dd28:
        8, 1003dd40:
        9, 1003dd58:
       10, 1003dd70:
       11, 1003dd88:
       12, 1003dda0:
       13, 1003ddb8:
       14, 1003ddd0:
       15, 1003dde8:
       16, 1003de00: 02201a10(1828320)
       17, 1003de18:
       18, 1003de30:
    `  #########################################################################################

### commit 2
    mm/mm_heap: move dump_node to mm_dump_node
    
    add the dump_node function, which was static, to the header for use in other codes and move it to mm_heap_dbg.c

### commit 3
    mm/mm_heap/mm_node.h: add DEBUGASSERT_MM_FREE_NODE macro
    
    The back link of heap free node cannot be null at any time, If null, it is an assert situation.
    Therefore, in the REMOVE_NODE_FROM_LIST macro, null is checked with DEBUGASSERT.
    But we can't known why the back link of the free node became null.
    
    Therefore, This commit adds DEBUGASSERT_MM_FREE_NODE macro, that print addresses of free nodes, head
    list of free node link and corrupted node nearby node for debugging.