### PR TITLE
mm/mm_heap: fix crash when CONFIG_DEBUG_MM_INFO is eanbled

### DIFF
--- a/os/mm/mm_heap/mm_free.c
+++ b/os/mm/mm_heap/mm_free.c
@@ -92,7 +92,7 @@ void mm_free(FAR struct mm_heap_s *heap, FAR void *mem)
 	FAR struct mm_freenode_s *prev;
 	FAR struct mm_freenode_s *next;
 
-	mvdbg("Freeing %p\n", mem);
+	mllvdbg("Freeing %p\n", mem);
 
 	/* Protect against attempts to free a NULL reference */
 

--- a/os/mm/mm_heap/mm_mallinfo.c
+++ b/os/mm/mm_heap/mm_mallinfo.c
@@ -113,7 +113,7 @@ int mm_mallinfo(FAR struct mm_heap_s *heap, FAR struct mallinfo *info)
 		mm_takesemaphore(heap);
 
 		for (node = heap->mm_heapstart[region]; node < heap->mm_heapend[region]; node = (struct mm_allocnode_s *)((char *)node + node->size)) {
-			mvdbg("region=%d node=%p size=%u preceding=%u (%c)\n", region, node, node->size,
+			mllvdbg("region=%d node=%p size=%u preceding=%u (%c)\n", region, node, node->size,
 				(node->preceding & ~MM_ALLOC_BIT), (node->preceding & MM_ALLOC_BIT) ? 'A' : 'F');
 			ASSERT(node->size);
 
@@ -131,7 +131,7 @@ int mm_mallinfo(FAR struct mm_heap_s *heap, FAR struct mallinfo *info)
 
 		mm_givesemaphore(heap);
 
-		mvdbg("region=%d node=%p heapend=%p\n", region, node, heap->mm_heapend[region]);
+		mllvdbg("region=%d node=%p heapend=%p\n", region, node, heap->mm_heapend[region]);
 		ASSERT(node == heap->mm_heapend[region]);
 		uordblks += SIZEOF_MM_ALLOCNODE;	/* account for the tail node */
 	}

--- a/os/mm/mm_heap/mm_malloc.c
+++ b/os/mm/mm_heap/mm_malloc.c
@@ -226,7 +226,7 @@ FAR void *mm_malloc(FAR struct mm_heap_s *heap, size_t size)
 	 */
 
 	if (ret) {
-		mvdbg("Allocated %p, size %u\n", ret, size);
+		mllvdbg("Allocated %p, size %u\n", ret, size);
 	}
 
 	return ret;

--- a/os/mm/mm_heap/mm_memalign.c
+++ b/os/mm/mm_heap/mm_memalign.c
@@ -277,7 +277,7 @@ FAR void *mm_memalign(FAR struct mm_heap_s *heap, size_t alignment, size_t size)
 	 */
 
 	if (ret) {
-		mvdbg("Allocated %p, size %u\n", ret, size);
+		mllvdbg("Allocated %p, size %u\n", ret, size);
 	}
 
 	return ret;

--- a/os/mm/mm_heap/mm_sem.c
+++ b/os/mm/mm_heap/mm_sem.c
@@ -153,7 +153,7 @@ void mm_takesemaphore(FAR struct mm_heap_s *heap)
 	} else {
 		/* Take the semaphore (perhaps waiting) */
 
-		mvdbg("PID=%d taking\n", my_pid);
+		mllvdbg("PID=%d taking\n", my_pid);
 		while (sem_wait(&heap->mm_semaphore) != 0) {
 			/* The only case that an error should occur here is if
 			 * the wait was awakened by a signal.
@@ -168,7 +168,7 @@ void mm_takesemaphore(FAR struct mm_heap_s *heap)
 		heap->mm_counts_held = 1;
 	}
 
-	mvdbg("Holder=%d count=%d\n", heap->mm_holder, heap->mm_counts_held);
+	mllvdbg("Holder=%d count=%d\n", heap->mm_holder, heap->mm_counts_held);
 }
 
 /****************************************************************************
@@ -195,12 +195,12 @@ void mm_givesemaphore(FAR struct mm_heap_s *heap)
 		/* Yes, just release one count and return */
 
 		heap->mm_counts_held--;
-		mvdbg("Holder=%d count=%d\n", heap->mm_holder, heap->mm_counts_held);
+		mllvdbg("Holder=%d count=%d\n", heap->mm_holder, heap->mm_counts_held);
 	} else {
 		/* Nope, this is the last reference I have */
 
 #ifdef CONFIG_DEBUG
-		mvdbg("PID=%d giving\n", my_pid);
+		mllvdbg("PID=%d giving\n", my_pid);
 #endif
 
 		heap->mm_holder      = -1;


### PR DESCRIPTION
When CONFIG_DEBUG_MM_INFO, dbg is used to print few logs during task clean up stage. This causes issue as during task clean up the stdout stream related semaphore is uninitialized in the func lib_stream_release , but the same sem is used later for dbg logs. Thus, this results in assert failure in lib_filesem.c as the error number we get when taking sem on an invalid sem is EINVAL

So, use mllvdbg instead of mvdbg