### PR TITLE
Update libc->math using nuttx's commit to fix libc

### DIFF
--- a/lib/libc/math/Make.defs
+++ b/lib/libc/math/Make.defs
@@ -81,6 +81,11 @@ CSRCS += lib_tanl.c lib_tanhl.c lib_asinhl.c lib_acoshl.c lib_atanhl.c lib_erfl.
 CSRCS += lib_copysignl.c lib_truncl.c lib_nextafterl.c lib_nexttowardl.c lib_remainderl.c
 CSRCS += lib_remquol.c
 
+CSRCS += lib_erfc.c lib_erfcf.c lib_erfcl.c
+CSRCS += lib_expm1.c lib_expm1f.c lib_expm1l.c
+CSRCS += lib_lround.c lib_lroundf.c lib_lroundl.c
+CSRCS += lib_llround.c lib_llroundf.c lib_llroundl.c
+CSRCS += lib_nan.c lib_nanf.c lib_nanl.c
 CSRCS += __cos.c __sin.c lib_gamma.c lib_lgamma.c
 
 CSRCS += lib_libexpi.c lib_libsqrtapprox.c

--- a/lib/libc/math/lib_erfc.c
+++ b/lib/libc/math/lib_erfc.c
@@ -1,4 +1,21 @@
 /****************************************************************************
+ *
+ * Copyright 2023 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+/****************************************************************************
  * lib/math/lib_erfc.c
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more

--- a/lib/libc/math/lib_erfc.c
+++ b/lib/libc/math/lib_erfc.c
@@ -50,6 +50,6 @@
 #ifdef CONFIG_HAVE_DOUBLE
 double erfc(double x)
 {
-  return 1 - erf(x);
+	return 1 - erf(x);
 }
 #endif

--- a/lib/libc/math/lib_erfc.c
+++ b/lib/libc/math/lib_erfc.c
@@ -1,0 +1,38 @@
+/****************************************************************************
+ * lib/math/lib_erfc.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <tinyara/compiler.h>
+
+#include <math.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+#ifdef CONFIG_HAVE_DOUBLE
+double erfc(double x)
+{
+  return 1 - erf(x);
+}
+#endif

--- a/lib/libc/math/lib_erfcf.c
+++ b/lib/libc/math/lib_erfcf.c
@@ -1,0 +1,34 @@
+/****************************************************************************
+ * lib/math/lib_erfcf.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <math.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+float erfcf(float x)
+{
+  return 1 - erff(x);
+}

--- a/lib/libc/math/lib_erfcf.c
+++ b/lib/libc/math/lib_erfcf.c
@@ -47,5 +47,5 @@
 
 float erfcf(float x)
 {
-  return 1 - erff(x);
+	return 1 - erff(x);
 }

--- a/lib/libc/math/lib_erfcf.c
+++ b/lib/libc/math/lib_erfcf.c
@@ -1,4 +1,21 @@
 /****************************************************************************
+ *
+ * Copyright 2023 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+/****************************************************************************
  * lib/math/lib_erfcf.c
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more

--- a/lib/libc/math/lib_erfcl.c
+++ b/lib/libc/math/lib_erfcl.c
@@ -50,6 +50,6 @@
 #ifdef CONFIG_HAVE_LONG_DOUBLE
 long double erfcl(long double x)
 {
-  return 1 - erfl(x);
+	return 1 - erfl(x);
 }
 #endif

--- a/lib/libc/math/lib_erfcl.c
+++ b/lib/libc/math/lib_erfcl.c
@@ -1,0 +1,38 @@
+/****************************************************************************
+ * lib/math/lib_erfcl.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <tinyara/compiler.h>
+
+#include <math.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+#ifdef CONFIG_HAVE_LONG_DOUBLE
+long double erfcl(long double x)
+{
+  return 1 - erfl(x);
+}
+#endif

--- a/lib/libc/math/lib_erfcl.c
+++ b/lib/libc/math/lib_erfcl.c
@@ -1,4 +1,21 @@
 /****************************************************************************
+ *
+ * Copyright 2023 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+/****************************************************************************
  * lib/math/lib_erfcl.c
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more

--- a/lib/libc/math/lib_expm1.c
+++ b/lib/libc/math/lib_expm1.c
@@ -1,0 +1,38 @@
+/****************************************************************************
+ * lib/math/lib_expm1.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <tinyara/compiler.h>
+
+#include <math.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+#ifdef CONFIG_HAVE_DOUBLE
+double expm1(double x)
+{
+  return exp(x) - 1.0;
+}
+#endif

--- a/lib/libc/math/lib_expm1.c
+++ b/lib/libc/math/lib_expm1.c
@@ -50,6 +50,6 @@
 #ifdef CONFIG_HAVE_DOUBLE
 double expm1(double x)
 {
-  return exp(x) - 1.0;
+	return exp(x) - 1.0;
 }
 #endif

--- a/lib/libc/math/lib_expm1.c
+++ b/lib/libc/math/lib_expm1.c
@@ -1,4 +1,21 @@
 /****************************************************************************
+ *
+ * Copyright 2023 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+/****************************************************************************
  * lib/math/lib_expm1.c
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more

--- a/lib/libc/math/lib_expm1f.c
+++ b/lib/libc/math/lib_expm1f.c
@@ -1,0 +1,34 @@
+/****************************************************************************
+ * lib/math/lib_expm1f.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <math.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+float expm1f(float x)
+{
+  return expf(x) - 1.0;
+}

--- a/lib/libc/math/lib_expm1f.c
+++ b/lib/libc/math/lib_expm1f.c
@@ -1,4 +1,21 @@
 /****************************************************************************
+ *
+ * Copyright 2023 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+/****************************************************************************
  * lib/math/lib_expm1f.c
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more

--- a/lib/libc/math/lib_expm1f.c
+++ b/lib/libc/math/lib_expm1f.c
@@ -47,5 +47,5 @@
 
 float expm1f(float x)
 {
-  return expf(x) - 1.0;
+	return expf(x) - 1.0;
 }

--- a/lib/libc/math/lib_expm1l.c
+++ b/lib/libc/math/lib_expm1l.c
@@ -1,4 +1,21 @@
 /****************************************************************************
+ *
+ * Copyright 2023 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+/****************************************************************************
  * lib/math/lib_expm1l.c
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more

--- a/lib/libc/math/lib_expm1l.c
+++ b/lib/libc/math/lib_expm1l.c
@@ -1,0 +1,38 @@
+/****************************************************************************
+ * lib/math/lib_expm1l.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <tinyara/compiler.h>
+
+#include <math.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+#ifdef CONFIG_HAVE_LONG_DOUBLE
+long double expm1l(long double x)
+{
+  return expl(x) - 1.0;
+}
+#endif

--- a/lib/libc/math/lib_expm1l.c
+++ b/lib/libc/math/lib_expm1l.c
@@ -50,6 +50,6 @@
 #ifdef CONFIG_HAVE_LONG_DOUBLE
 long double expm1l(long double x)
 {
-  return expl(x) - 1.0;
+	return expl(x) - 1.0;
 }
 #endif

--- a/lib/libc/math/lib_llround.c
+++ b/lib/libc/math/lib_llround.c
@@ -51,7 +51,7 @@
 #ifdef CONFIG_HAVE_DOUBLE
 long long llround(double x)
 {
-  return (long long)round(x);
+	return (long long)round(x);
 }
 #endif
 #endif

--- a/lib/libc/math/lib_llround.c
+++ b/lib/libc/math/lib_llround.c
@@ -1,4 +1,21 @@
 /****************************************************************************
+ *
+ * Copyright 2023 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+/****************************************************************************
  * lib/math/lib_llround.c
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more

--- a/lib/libc/math/lib_llround.c
+++ b/lib/libc/math/lib_llround.c
@@ -1,0 +1,40 @@
+/****************************************************************************
+ * lib/math/lib_llround.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <tinyara/compiler.h>
+
+#include <math.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+#ifdef CONFIG_HAVE_LONG_LONG
+#ifdef CONFIG_HAVE_DOUBLE
+long long llround(double x)
+{
+  return (long long)round(x);
+}
+#endif
+#endif

--- a/lib/libc/math/lib_llroundf.c
+++ b/lib/libc/math/lib_llroundf.c
@@ -1,4 +1,21 @@
 /****************************************************************************
+ *
+ * Copyright 2023 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+/****************************************************************************
  * lib/math/lib_llroundf.c
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more

--- a/lib/libc/math/lib_llroundf.c
+++ b/lib/libc/math/lib_llroundf.c
@@ -50,6 +50,6 @@
 #ifdef CONFIG_HAVE_LONG_LONG
 long long llroundf(float x)
 {
-  return (long long)roundf(x);
+	return (long long)roundf(x);
 }
 #endif

--- a/lib/libc/math/lib_llroundf.c
+++ b/lib/libc/math/lib_llroundf.c
@@ -1,0 +1,38 @@
+/****************************************************************************
+ * lib/math/lib_llroundf.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <tinyara/compiler.h>
+
+#include <math.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+#ifdef CONFIG_HAVE_LONG_LONG
+long long llroundf(float x)
+{
+  return (long long)roundf(x);
+}
+#endif

--- a/lib/libc/math/lib_llroundl.c
+++ b/lib/libc/math/lib_llroundl.c
@@ -1,0 +1,40 @@
+/****************************************************************************
+ * lib/math/lib_llroundl.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <tinyara/compiler.h>
+
+#include <math.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+#ifdef CONFIG_HAVE_LONG_LONG
+#ifdef CONFIG_HAVE_LONG_DOUBLE
+long long llroundl(long double x)
+{
+  return (long long)roundl(x);
+}
+#endif
+#endif

--- a/lib/libc/math/lib_llroundl.c
+++ b/lib/libc/math/lib_llroundl.c
@@ -51,7 +51,7 @@
 #ifdef CONFIG_HAVE_LONG_DOUBLE
 long long llroundl(long double x)
 {
-  return (long long)roundl(x);
+	return (long long)roundl(x);
 }
 #endif
 #endif

--- a/lib/libc/math/lib_llroundl.c
+++ b/lib/libc/math/lib_llroundl.c
@@ -1,4 +1,21 @@
 /****************************************************************************
+ *
+ * Copyright 2023 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+/****************************************************************************
  * lib/math/lib_llroundl.c
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more

--- a/lib/libc/math/lib_lround.c
+++ b/lib/libc/math/lib_lround.c
@@ -1,0 +1,38 @@
+/****************************************************************************
+ * lib/math/lib_lround.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <tinyara/compiler.h>
+
+#include <math.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+#ifdef CONFIG_HAVE_DOUBLE
+long int lround(double x)
+{
+  return (long int)round(x);
+}
+#endif

--- a/lib/libc/math/lib_lround.c
+++ b/lib/libc/math/lib_lround.c
@@ -50,6 +50,6 @@
 #ifdef CONFIG_HAVE_DOUBLE
 long int lround(double x)
 {
-  return (long int)round(x);
+	return (long int)round(x);
 }
 #endif

--- a/lib/libc/math/lib_lround.c
+++ b/lib/libc/math/lib_lround.c
@@ -1,4 +1,21 @@
 /****************************************************************************
+ *
+ * Copyright 2023 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+/****************************************************************************
  * lib/math/lib_lround.c
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more

--- a/lib/libc/math/lib_lroundf.c
+++ b/lib/libc/math/lib_lroundf.c
@@ -47,5 +47,5 @@
 
 long int lroundf(float x)
 {
-  return (long int)roundf(x);
+	return (long int)roundf(x);
 }

--- a/lib/libc/math/lib_lroundf.c
+++ b/lib/libc/math/lib_lroundf.c
@@ -1,0 +1,34 @@
+/****************************************************************************
+ * lib/math/lib_lroundf.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <math.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+long int lroundf(float x)
+{
+  return (long int)roundf(x);
+}

--- a/lib/libc/math/lib_lroundf.c
+++ b/lib/libc/math/lib_lroundf.c
@@ -1,4 +1,21 @@
 /****************************************************************************
+ *
+ * Copyright 2023 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+/****************************************************************************
  * lib/math/lib_lroundf.c
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more

--- a/lib/libc/math/lib_lroundl.c
+++ b/lib/libc/math/lib_lroundl.c
@@ -1,4 +1,21 @@
 /****************************************************************************
+ *
+ * Copyright 2023 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+/****************************************************************************
  * lib/math/lib_lroundl.c
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more

--- a/lib/libc/math/lib_lroundl.c
+++ b/lib/libc/math/lib_lroundl.c
@@ -50,6 +50,6 @@
 #ifdef CONFIG_HAVE_LONG_DOUBLE
 long int lroundl(long double x)
 {
-  return (long int)roundl(x);
+	return (long int)roundl(x);
 }
 #endif

--- a/lib/libc/math/lib_lroundl.c
+++ b/lib/libc/math/lib_lroundl.c
@@ -1,0 +1,38 @@
+/****************************************************************************
+ * lib/math/lib_lroundl.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <tinyara/compiler.h>
+
+#include <math.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+#ifdef CONFIG_HAVE_LONG_DOUBLE
+long int lroundl(long double x)
+{
+  return (long int)roundl(x);
+}
+#endif

--- a/lib/libc/math/lib_nan.c
+++ b/lib/libc/math/lib_nan.c
@@ -50,6 +50,6 @@
 #ifdef CONFIG_HAVE_DOUBLE
 double nan(const char *tagp)
 {
-  return (double)NAN;
+	return (double)NAN;
 }
 #endif

--- a/lib/libc/math/lib_nan.c
+++ b/lib/libc/math/lib_nan.c
@@ -1,4 +1,21 @@
 /****************************************************************************
+ *
+ * Copyright 2023 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+/****************************************************************************
  * lib/math/lib_nan.c
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more

--- a/lib/libc/math/lib_nan.c
+++ b/lib/libc/math/lib_nan.c
@@ -1,0 +1,38 @@
+/****************************************************************************
+ * lib/math/lib_nan.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <tinyara/compiler.h>
+
+#include <math.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+#ifdef CONFIG_HAVE_DOUBLE
+double nan(const char *tagp)
+{
+  return (double)NAN;
+}
+#endif

--- a/lib/libc/math/lib_nanf.c
+++ b/lib/libc/math/lib_nanf.c
@@ -1,4 +1,21 @@
 /****************************************************************************
+ *
+ * Copyright 2023 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+/****************************************************************************
  * lib/math/lib_nanf.c
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more

--- a/lib/libc/math/lib_nanf.c
+++ b/lib/libc/math/lib_nanf.c
@@ -47,5 +47,5 @@
 
 float nanf(const char *tagp)
 {
-  return (float)NAN;
+	return (float)NAN;
 }

--- a/lib/libc/math/lib_nanf.c
+++ b/lib/libc/math/lib_nanf.c
@@ -1,0 +1,34 @@
+/****************************************************************************
+ * lib/math/lib_nanf.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <math.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+float nanf(const char *tagp)
+{
+  return (float)NAN;
+}

--- a/lib/libc/math/lib_nanl.c
+++ b/lib/libc/math/lib_nanl.c
@@ -1,0 +1,38 @@
+/****************************************************************************
+ * lib/math/lib_nanl.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <tinyara/compiler.h>
+
+#include <math.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+#ifdef CONFIG_HAVE_LONG_DOUBLE
+long double nanl(const char *tagp)
+{
+  return (long double)NAN;
+}
+#endif

--- a/lib/libc/math/lib_nanl.c
+++ b/lib/libc/math/lib_nanl.c
@@ -50,6 +50,6 @@
 #ifdef CONFIG_HAVE_LONG_DOUBLE
 long double nanl(const char *tagp)
 {
-  return (long double)NAN;
+	return (long double)NAN;
 }
 #endif

--- a/lib/libc/math/lib_nanl.c
+++ b/lib/libc/math/lib_nanl.c
@@ -1,4 +1,21 @@
 /****************************************************************************
+ *
+ * Copyright 2023 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+/****************************************************************************
  * lib/math/lib_nanl.c
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more

--- a/os/include/tinyara/math.h
+++ b/os/include/tinyara/math.h
@@ -147,10 +147,10 @@ static __inline unsigned long long __DOUBLE_BITS(double __f)
 }
 #endif
 
-#define signbit(x) ( \
-		sizeof(x) == sizeof(float) ? (int)(__FLOAT_BITS(x) >> 31) : \
-		sizeof(x) == sizeof(double) ? (int)(__DOUBLE_BITS(x) >> 63) : \
-		(int)(__DOUBLE_BITS(x) >> 63))
+// #define signbit(x) ( \
+// 		sizeof(x) == sizeof(float) ? (int)(__FLOAT_BITS(x) >> 31) : \
+// 		sizeof(x) == sizeof(double) ? (int)(__DOUBLE_BITS(x) >> 63) : \
+// 		(int)(__DOUBLE_BITS(x) >> 63))
 
 /* Exponential and Logarithmic constants ************************************/
 
@@ -275,6 +275,24 @@ double round(double x);
  */
 long double roundl(long double x);
 #endif
+
+long int lroundf(float x);
+#ifdef CONFIG_HAVE_DOUBLE
+long int lround(double x);
+#endif
+#ifdef CONFIG_HAVE_LONG_DOUBLE
+long int lroundl(long double x);
+#endif
+
+#ifdef CONFIG_HAVE_LONG_LONG
+long long int llroundf(float x);
+#ifdef CONFIG_HAVE_DOUBLE
+long long int llround (double x);
+#endif
+#ifdef CONFIG_HAVE_LONG_DOUBLE
+long long int llroundl(long double x);
+#endif
+#endif
 /**
  * @ingroup MATH_LIBC
  * @brief round-to-nearest integral value
@@ -302,6 +320,24 @@ double rint(double x);
  * @since TizenRT v1.1
  */
 long double rintl(long double x);	/* Not implemented */
+#endif
+
+long int    lrintf(float x);
+#ifdef CONFIG_HAVE_DOUBLE
+long int    lrint(double x);
+#endif
+#ifdef CONFIG_HAVE_LONG_DOUBLE
+long int    lrintl(long double x);
+#endif
+
+#ifdef CONFIG_HAVE_LONG_LONG
+long long int llrintf(float x);
+#ifdef CONFIG_HAVE_DOUBLE
+long long int llrint(double x);
+#endif
+#ifdef CONFIG_HAVE_LONG_DOUBLE
+long long int llrintl(long double x);
+#endif
 #endif
 /**
  * @ingroup MATH_LIBC
@@ -407,7 +443,8 @@ float expf(float x);
  * POSIX API (refer to : http://pubs.opengroup.org/onlinepubs/9699919799/)
  * @since TizenRT v1.1
  */
-#define expm1f(x) (expf(x) - 1.0)
+float exp2f (float x);
+float expm1f(float x);
 #ifdef CONFIG_HAVE_DOUBLE
 /**
  * @ingroup MATH_LIBC
@@ -417,7 +454,8 @@ float expf(float x);
  * @since TizenRT v1.1
  */
 double exp(double x);
-#define expm1(x) (exp(x) - 1.0)
+double exp2  (double x);
+double expm1 (double x);
 #endif
 #ifdef CONFIG_HAVE_LONG_DOUBLE
 /**
@@ -428,7 +466,8 @@ double exp(double x);
  * @since TizenRT v1.1
  */
 long double expl(long double x);
-#define expm1l(x) (expl(x) - 1.0)
+long double exp2l (long double x);
+long double expm1l(long double x);
 #endif
 /**
  * @ingroup MATH_LIBC
@@ -458,6 +497,49 @@ double exp2(double x);
  */
 long double exp2l(long double x);
 #endif
+
+float       fdimf(float x, float y);
+#ifdef CONFIG_HAVE_DOUBLE
+double      fdim(double x, double y);
+#endif
+#ifdef CONFIG_HAVE_LONG_DOUBLE
+long double fdiml(long double x, long double y);
+#endif
+
+float       fmaf(float x, float y, float z);
+#ifdef CONFIG_HAVE_DOUBLE
+double      fma(double x, double y, double z);
+#endif
+#ifdef CONFIG_HAVE_LONG_DOUBLE
+long double fmal(long double x, long double y, long double z);
+#endif
+
+float       fmaxf(float x, float y);
+#ifdef CONFIG_HAVE_DOUBLE
+double      fmax(double x, double y);
+#endif
+#ifdef CONFIG_HAVE_LONG_DOUBLE
+long double fmaxl(long double x, long double y);
+#endif
+
+float       fminf(float x, float y);
+#ifdef CONFIG_HAVE_DOUBLE
+double      fmin(double x, double y);
+#endif
+#ifdef CONFIG_HAVE_LONG_DOUBLE
+long double fminl(long double x, long double y);
+#endif
+
+float       hypotf(float x, float y);
+#ifdef CONFIG_HAVE_DOUBLE
+double      hypot(double x, double y);
+#endif
+#ifdef CONFIG_HAVE_LONG_DOUBLE
+long double hypotl(long double x, long double y);
+#endif
+
+float       lgammaf(float x);
+
 #ifdef CONFIG_HAVE_DOUBLE
 /**
 + * @cond
@@ -479,6 +561,18 @@ double lgamma(double x);
 /**
  * @endcond
  */
+#endif
+
+#ifdef CONFIG_HAVE_LONG_DOUBLE
+long double lgammal(long double x);
+#endif
+
+float       tgammaf(float x);
+#ifdef CONFIG_HAVE_DOUBLE
+double      tgamma(double x);
+#endif
+#ifdef CONFIG_HAVE_LONG_DOUBLE
+long double tgammal(long double x);
 #endif
 /**
  * @cond
@@ -513,6 +607,15 @@ double log10(double x);
  */
 long double log10l(long double x);
 #endif
+
+float       log1pf(float x);
+#ifdef CONFIG_HAVE_DOUBLE
+double      log1p (double x);
+#endif
+#ifdef CONFIG_HAVE_LONG_DOUBLE
+long double log1pl(long double x);
+#endif
+
 /**
  * @endcond
  */
@@ -543,6 +646,22 @@ double log2(double x);
  * @since TizenRT v1.1
  */
 long double log2l(long double x);
+#endif
+
+float       logbf (float x);
+#ifdef CONFIG_HAVE_DOUBLE
+double      logb  (double x);
+#endif
+#ifdef CONFIG_HAVE_LONG_DOUBLE
+long double logbl (long double x);
+#endif
+
+int         ilogbf (float x);
+#ifdef CONFIG_HAVE_DOUBLE
+int         ilogb  (double x);
+#endif
+#ifdef CONFIG_HAVE_LONG_DOUBLE
+int         ilogbl (long double x);
 #endif
 /**
  * @ingroup MATH_LIBC
@@ -1034,7 +1153,7 @@ float erff(float x);
  * @cond
  * @internal
  */
-#define     erfcf(x) (1 - erff(x))
+float erfcf(float x);
 #ifdef CONFIG_HAVE_DOUBLE
 /**
  * @endcond
@@ -1047,7 +1166,7 @@ float erff(float x);
  * @since TizenRT v1.1
  */
 double erf(double x);
-#define     erfc(x) (1 - erf(x))
+double erfc(double x);
 #endif
 #ifdef CONFIG_HAVE_LONG_DOUBLE
 /**
@@ -1058,7 +1177,7 @@ double erf(double x);
  * @since TizenRT v1.1
  */
 long double erfl(long double x);
-#define     erfcl(x) (1 - erfl(x))
+long double erfcl(long double x);
 #endif
 /**
  * @ingroup MATH_LIBC
@@ -1489,17 +1608,90 @@ long double remquol(long double x, long double y, int *quo);
  * @cond
  * @internal
  */
-#define nanf(x) ((float)(NAN))
+float       nanf(const char *tagp);
+#ifdef CONFIG_HAVE_DOUBLE
+double      nan(const char *tagp);
+#endif
+#ifdef CONFIG_HAVE_LONG_DOUBLE
+long double nanl(const char *tagp);
+#endif
+
+float       nearbyintf(float x);
+#ifdef CONFIG_HAVE_DOUBLE
+double      nearbyint(double x);
+#endif
+#ifdef CONFIG_HAVE_LONG_DOUBLE
+long double nearbyintl(long double x);
+#endif
+
+float       nextafterf(float x, float y);
+#ifdef CONFIG_HAVE_DOUBLE
+double      nextafter(double x, double y);
+#endif
+#ifdef CONFIG_HAVE_LONG_DOUBLE
+long double nextafterl(long double x, long double y);
+#endif
+
+float       nexttowardf(float x, long double y);
+#ifdef CONFIG_HAVE_DOUBLE
+double      nexttoward(double x, long double y);
+#endif
+#ifdef CONFIG_HAVE_LONG_DOUBLE
+long double nexttowardl(long double x, long double y);
+#endif
+
+float       remainderf(float x, float y);
+#ifdef CONFIG_HAVE_DOUBLE
+double      remainder(double x, double y);
+#endif
+#ifdef CONFIG_HAVE_LONG_DOUBLE
+long double remainderl(long double x, long double y);
+#endif
+
+float       remquof(float x, float y, int *quo);
+#ifdef CONFIG_HAVE_DOUBLE
+double      remquo(double x, double y, int *quo);
+#endif
+#ifdef CONFIG_HAVE_LONG_DOUBLE
+long double remquol(long double x, long double y, int *quo);
+#endif
+
+float       scalblnf(float x, long int n);
 /**
  * @internal
  */
 #ifdef CONFIG_HAVE_DOUBLE
-#define nan(x) ((double)(NAN))
+double      scalbln(double x, long int n);
 #endif
 #ifdef CONFIG_HAVE_LONG_DOUBLE
-#define nanl(x) ((long double)(NAN))
+long double scalblnl(long double x, long int n);
 #endif
 
+float       scalbnf(float x, int n);
+#ifdef CONFIG_HAVE_DOUBLE
+double      scalbn(double x, int n);
+#endif
+#ifdef CONFIG_HAVE_LONG_DOUBLE
+long double scalbnl(long double x, int n);
+#endif
+
+#define FP_INFINITE     0
+#define FP_NAN          1
+#define FP_NORMAL       2
+#define FP_SUBNORMAL    3
+#define FP_ZERO         4
+#define fpclassify(x) \
+    __builtin_fpclassify(FP_NAN, FP_INFINITE, FP_NORMAL, FP_SUBNORMAL, \
+                         FP_ZERO, x)
+
+#define isunordered(x, y)    __builtin_isunordered(x, y)
+#define isgreater(x, y)      __builtin_isgreater(x, y)
+#define isgreaterequal(x, y) __builtin_isgreaterequal(x, y)
+#define isless(x, y)         __builtin_isless(x, y)
+#define islessequal(x, y)    __builtin_islessequal(x, y)
+#define islessgreater(x, y)  __builtin_islessgreater(x, y)
+#define isnormal(x)          __builtin_isnormal(x)
+#define signbit(x)           __builtin_signbit(x)
 /**
  * @endcond
  */


### PR DESCRIPTION
Issue fixed: Libc caused build issues in libcxx.
libcxx/math.h functions' definitions are not found due to issue in old libc/math.h, which has definitions of same functions in form of macros.

This commit by Nuttx changes the macros to function declarations and defines them in separate files. Nuttx commit id: https://github.com/apache/nuttx/commit/df812d09a219495a8ba1d0c30a2e9ebc05c37f3b Commit message by nuttx:

math: Make this friendly with libcxx
- Turn some macros into functions

- Implement some type-agnostic functions. (Just use __builtin_xxx)

- Add some missing function prototypes (Just prototypes, not actually implemented in this commit)