### PR TITLE
os/dutils.sh: fix path to crash logs when calling trap tool

### DIFF
--- a/os/dutils.sh
+++ b/os/dutils.sh
@@ -118,7 +118,7 @@ function TRAP_MENU()
 				echo "No output file in $BINDIR, Build the code and run TRAP again."
 				return
 			fi
-			echo "Enter the crash log file name: (ex: ../tools/trap/testlogs)"
+			echo "Enter the crash log file name relative to os folder: (ex: ../tools/trap/testlogs)"
 			read LOG_FILE
 			if [ ! -f ${LOG_FILE} ]; then
 				echo "$LOG_FILE: No such file, try again"
@@ -304,7 +304,7 @@ function TOOLCHAIN()
 
 function TRAP_RUN()
 {
-	TRAPCMD="ramdumpParser.py -t $2"
+	TRAPCMD="ramdumpParser.py -t /root/tizenrt/os/$2"
 
 	if [ ! -z "$3" ]; then
 		# Append the binary path


### PR DESCRIPTION
The path to the crash logs when using trap with dutils is taken relative to the os folder (ex : ../tools/trap/testlogs) but the same path is also used when calling trap command from ```os/tools/trap```,
```
dutils.sh log : Executing: ramdumpParser.py -t ../tools/trap/testlogs -e tinyara.axf
```
which results in the following error,
```
../tools/trap/testlogs does not exist. Please provide the proper path for log_file...
```
So, added comment to provide the path relative to os folder and also have corrected the crash logs path by adding /root/tizenrt/os prefix