### PR TITLE
os/arch/arm/src/ameba: GPIO pull up/down fix revert

### DIFF
--- a/os/arch/arm/src/amebad/amebad_lowerhalf.c
+++ b/os/arch/arm/src/amebad/amebad_lowerhalf.c
@@ -205,6 +205,7 @@ static int amebad_gpio_enable(FAR struct gpio_lowerhalf_s *lower, int falling,
 	} else {
 		gpio_irq_disable((gpio_irq_t *)&priv->obj);
 		gpio_irq_set((gpio_irq_t *)&priv->obj, event, 0);
+		gpio_irq_deinit((gpio_irq_t *)&priv->obj);
 	}
 
 	return OK;

--- a/os/arch/arm/src/amebalite/amebalite_lowerhalf.c
+++ b/os/arch/arm/src/amebalite/amebalite_lowerhalf.c
@@ -205,6 +205,7 @@ static int amebalite_gpio_enable(FAR struct gpio_lowerhalf_s *lower, int falling
 	} else {
 		gpio_irq_disable((gpio_irq_t *)&priv->obj);
 		gpio_irq_set((gpio_irq_t *)&priv->obj, event, 0);
+		gpio_irq_deinit((gpio_irq_t *)&priv->obj);
 	}
 
 	return OK;

--- a/os/arch/arm/src/amebasmart/amebasmart_gpio_lowerhalf.c
+++ b/os/arch/arm/src/amebasmart/amebasmart_gpio_lowerhalf.c
@@ -205,6 +205,7 @@ static int amebasmart_gpio_enable(FAR struct gpio_lowerhalf_s *lower, int fallin
 	} else {
 		gpio_irq_disable((gpio_irq_t *)&priv->obj);
 		gpio_irq_set((gpio_irq_t *)&priv->obj, event, 0);
+		gpio_irq_deinit((gpio_irq_t *)&priv->obj);
 	}
 
 	return OK;


### PR DESCRIPTION
GPIO pull direction works but induce UART initialisation delay
Revert and will seek alternative solution