### PR TITLE
os/board/rtl8721csm: Remove GPIO PA12 initialisation

### DIFF
--- a/os/board/rtl8721csm/src/rtl8721csm_boot.c
+++ b/os/board/rtl8721csm/src/rtl8721csm_boot.c
@@ -180,8 +180,6 @@ void board_gpio_initialize(void)
 			PA_3, PIN_OUTPUT, PullNone
 		}, {
 			PB_5, PIN_OUTPUT, PullNone
-		}, {
-			PA_12, PIN_INPUT, PullDown
 		},
 		/*		{PA_6, PIN_OUTPUT, PullNone},
 				{PA_7, PIN_OUTPUT, PullNone},


### PR DESCRIPTION
Current GPIO PA12 is in conflict with UART1 init