### PR TITLE
os/board/rtl8730e: Change alignment of malloc

### DIFF
--- a/os/board/rtl8730e/src/component/os_dep/osdep_service_memory.c
+++ b/os/board/rtl8730e/src/component/os_dep/osdep_service_memory.c
@@ -6,15 +6,17 @@
 #include <osdep_service.h>
 #include <stdio.h>
 
+/* For Smart, need to align malloc to 64bytes (cache line size of AP) for cache operations */
+int align = 64;
+
 void *rtw_vmalloc(u32 sz)
 {
 	void *pbuf = NULL;
-	pbuf = kmm_malloc(sz);
+	pbuf = kmm_memalign(align, sz);
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
-        if (pbuf)
-        {
-            DEBUG_SET_CALLER_ADDR(pbuf);
-        }
+	if (pbuf){
+		DEBUG_SET_CALLER_ADDR(pbuf);
+	}
 #endif
 	return pbuf;
 }
@@ -23,13 +25,13 @@ void *rtw_zvmalloc(u32 sz)
 {
 	void *pbuf = NULL;
 
-	pbuf = kmm_zalloc(sz);
+	pbuf = kmm_memalign(align, sz);
+	if (pbuf){
+		memset(pbuf, 0 ,sz);
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
-        if (pbuf)
-        {
-            DEBUG_SET_CALLER_ADDR(pbuf);
-        }
+		DEBUG_SET_CALLER_ADDR(pbuf);
 #endif
+	}
 	return pbuf;
 }
 
@@ -43,12 +45,11 @@ void rtw_vmfree(u8 *pbuf, u32 sz)
 void *rtw_malloc(u32 sz)
 {
 	void *pbuf = NULL;
-	pbuf = kmm_malloc(sz);
+	pbuf = kmm_memalign(align, sz);
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
-        if (pbuf)
-        {
-            DEBUG_SET_CALLER_ADDR(pbuf);
-        }
+	if (pbuf){
+		DEBUG_SET_CALLER_ADDR(pbuf);
+	}
 #endif
 	return pbuf;
 }
@@ -57,26 +58,26 @@ void *rtw_zmalloc(u32 sz)
 {
 	void *pbuf = NULL;
 
-	pbuf = kmm_zalloc(sz);
+	pbuf = kmm_memalign(align, sz);
+	if (pbuf){
+		memset(pbuf, 0, sz);
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
-        if (pbuf)
-        {
-            DEBUG_SET_CALLER_ADDR(pbuf);
-        }
+		DEBUG_SET_CALLER_ADDR(pbuf);
 #endif
+	}
 	return pbuf;
 }
 
 void *rtw_calloc(u32 nelements, u32 elementSize)
 {
 	u32 sz = nelements * elementSize;
-	void *pbuf = kmm_zalloc(sz);
+	void *pbuf = kmm_memalign(align, sz);
+	if (pbuf){
+		memset(pbuf, 0, sz);
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
-        if (pbuf)
-        {
-            DEBUG_SET_CALLER_ADDR(pbuf);
-        }
+		DEBUG_SET_CALLER_ADDR(pbuf);
 #endif
+	}
 	return pbuf;
 }
 

--- a/os/board/rtl8730e/src/component/wifi/inic/inic_ipc_host_api_basic.c
+++ b/os/board/rtl8730e/src/component/wifi/inic/inic_ipc_host_api_basic.c
@@ -398,7 +398,17 @@ int wifi_scan_networks(rtw_scan_param_t *scan_param, unsigned char block)
 	scan_each_report_user_callback_ptr = scan_param->scan_report_each_mode_user_callback;
 
 	if (scan_param->ssid) {
+#if defined(CONFIG_PLATFORM_TIZENRT_OS)
+		/* for TizenRT, ensure the entire ssid array is cleaned when ssid is empty */
+		if (strlen(scan_param->ssid) == 0) {
+			DCache_Clean((u32)scan_param->ssid, (TRWIFI_PASSPHRASE_LEN + 1));
+		}
+		else {
+			DCache_Clean((u32)scan_param->ssid, strlen(scan_param->ssid));
+		}
+#else
 		DCache_Clean((u32)scan_param->ssid, strlen(scan_param->ssid));
+#endif
 	}
 	if (scan_param->channel_list) {
 		DCache_Clean((u32)scan_param->channel_list, scan_param->channel_list_num);


### PR DESCRIPTION
- Use kmm_memalign instead of kmm_malloc in RTK malloc operations to align malloc to 64b to resolve cache operation issues on CA32
- Fix DCache_Clean for ssid array during wifi scan to ensure cache is cleaned properly for cache coherency