### PR TITLE
os/fs/smartfs: Skip smartfs_sector_recovery in Nxfuse image build

### DIFF
--- a/os/fs/smartfs/smartfs_smart.c
+++ b/os/fs/smartfs/smartfs_smart.c
@@ -1274,11 +1274,13 @@ static int smartfs_bind(FAR struct inode *blkdriver, const void *data, void **ha
 	}
 
 	*handle = (void *)fs;
-	
+
+#ifndef NXFUSE_HOST_BUILD
 	ret = smartfs_sector_recovery(fs);
 	if (ret != 0) {
 		goto error_with_semaphore;
 	}
+#endif
 
 	smartfs_semgive(fs);
 	return ret;


### PR DESCRIPTION
- smartfs_sector_recovery() need not be invoked during Nxfuse image build because we are building a fresh image to flash to the partition and hence recovery is not required.
- Additionally, in the case of Nxfuse host build, we will always get the error message "CRITICAL BUG!! Root sector is gone!!" from smartfs_sector_recovery despite successful completion.