### PR TITLE
tools/check_pacakage_size.py: Declare 'global' keyword once

### DIFF
--- a/os/tools/check_package_size.py
+++ b/os/tools/check_package_size.py
@@ -54,6 +54,9 @@ def check_binary_size(bin_type, part_size):
 
     # Compare the partition size and its binary size
     used_ratio = round(float(BINARY_SIZE) / float(PARTITION_SIZE) * 100, 2)
+
+    global FAIL_TO_BUILD
+
     if bin_type == "BOOTPARAM" :
         if PARTITION_SIZE == BINARY_SIZE :
             check_result = "PASS"
@@ -61,7 +64,6 @@ def check_binary_size(bin_type, part_size):
         else :
             fail_type_list.append(bin_type)
             os.remove(output_path)
-            global FAIL_TO_BUILD
             FAIL_TO_BUILD = True
             check_result = "FAIL"
             result_mark = ""
@@ -69,7 +71,6 @@ def check_binary_size(bin_type, part_size):
         if PARTITION_SIZE < int(BINARY_SIZE) :
             fail_type_list.append(bin_type)
             os.remove(output_path)
-            global FAIL_TO_BUILD
             FAIL_TO_BUILD = True
             check_result = "FAIL"
             result_mark = ""


### PR DESCRIPTION
In python, 'global' keyword is needed for usage of global variable. It is enough to declare 'global' keyword once in a function because 'if' context doesn't make new scope. With this change, the below build warning is fixed.

========== Verification of partition settings ========== => Partition verification SUCCESS!! The setting of all partitions is OK. ./tools/../tools/check_package_size.py:72: SyntaxWarning: name 'FAIL_TO_BUILD' is assigned to before global declaration
  global FAIL_TO_BUILD