### PR TITLE
amebad/fwlib/ram_hp: set access level of PSRAM kernel heap as privileged only

### DIFF
--- a/os/board/rtl8721csm/src/component/soc/realtek/amebad/fwlib/ram_hp/rtl8721dhp_app_start.c
+++ b/os/board/rtl8721csm/src/component/soc/realtek/amebad/fwlib/ram_hp/rtl8721dhp_app_start.c
@@ -1037,7 +1037,7 @@ u32 app_mpu_nocache_init(void)
 	mpu_cfg.region_size = 0x400000;
 #endif
 	mpu_cfg.xn = MPU_EXEC_ALLOW;
-	mpu_cfg.ap = MPU_UN_PRIV_RW;
+	mpu_cfg.ap = MPU_PRIV_RW;
 	mpu_cfg.sh = MPU_NON_SHAREABLE;
 	mpu_cfg.attr_idx = MPU_MEM_ATTR_IDX_WB_T_RWA;
 	mpu_region_cfg(mpu_entry, &mpu_cfg);


### PR DESCRIPTION
Earlier, PSRAM kernel heap was set to be unprivileged accessible, which caused issue with memory protection. Hence, make it only privileged accessible.