### PR TITLE
os/arch/arm/src/amebasmart/Kconfig: Turn on SPI1 smart by default

### DIFF
--- a/os/arch/arm/src/amebasmart/Kconfig
+++ b/os/arch/arm/src/amebasmart/Kconfig
@@ -76,7 +76,7 @@ config AMEBASMART_SPI0
 	default n
 config AMEBASMART_SPI1
 	bool "SPI1"
-	default n
+	default y
 
 config AMEBASMART_SPI_EXCHANGE
 	bool "Enable AMEBASMART SPI EXCHANGE"


### PR DESCRIPTION
Set SPI1 Smart Kconfig to default yes