### PR TITLE
os/arch/arm/amebasmart: Change peripheral config to board level config.

### DIFF
--- a/os/arch/arm/src/amebasmart/Make.defs
+++ b/os/arch/arm/src/amebasmart/Make.defs
@@ -236,10 +236,10 @@ CHIP_CSRCS += amebasmart_timer_lowerhalf.c
 CHIP_CSRCS += amebasmart_rtc_lowerhalf.c
 CHIP_CSRCS += amebasmart_rtc.c
 CHIP_CSRCS += amebasmart_watchdog_lowerhalf.c
-ifeq ($(CONFIG_I2C),y)
+ifeq ($(CONFIG_AMEBASMART_I2C),y)
 CHIP_CSRCS += amebasmart_i2c.c
 endif
-ifeq ($(CONFIG_SPI),y)
+ifeq ($(CONFIG_AMEBASMART_SPI),y)
 CHIP_CSRCS += amebasmart_spi.c
 endif
 ifeq ($(CONFIG_AMEBASMART_I2S),y)


### PR DESCRIPTION
amebasmart_i2c.c have dependency CONFIG_AMEBASMART_I2C_XXXX configuration
So, when deciding whether to include this file in build, we should check CONFIG_AMEBASMART_I2C, not CONFIG_I2C. 
The same goes for amebasmart_spi.c.

Therefore, Change CONFIG_I2C and CONFIG_SPI to each CONFIG_AMEBASMART_I2C and CONFIG_AMEBASMART_SPI.