### PR TITLE
tools/trap: Trap Tool support for armv8-m and armv7-a

### DIFF
--- a/os/arch/arm/src/armv7-a/arm_assert.c
+++ b/os/arch/arm/src/armv7-a/arm_assert.c
@@ -132,6 +132,11 @@ extern int g_irq_num;
 #define IS_FAULT_IN_USER_THREAD(fault_tcb)		((void *)fault_tcb->uheap != NULL)
 #define IS_FAULT_IN_USER_SPACE(asserted_location)	(is_kernel_space((void *)asserted_location) == false)
 
+#if CONFIG_TASK_NAME_SIZE > 0
+#define LOG_TASK_NAME  fault_tcb->name
+#else
+#define LOG_TASK_NAME   "N/A"
+#endif
 
 /****************************************************************************
  * Public Variables
@@ -157,8 +162,7 @@ static void up_stackdump(uint32_t sp, uint32_t stack_base)
 	uint32_t stack = sp & ~0x1f;
 	uint32_t *ptr = (uint32_t *)stack;
 	uint8_t i;
-
-	lldbg_noarg("%08x:", stack);
+	lldbg("%08x:", stack);
 	for (i = 0; i < 8; i++) {	// Print first 8 values for sp located
 		if (stack < sp) {
 			/* If stack pointer(sp) is aligned(sp & 0x1f) to an address outside allocated stack */
@@ -174,7 +178,7 @@ static void up_stackdump(uint32_t sp, uint32_t stack_base)
 	
 	for (; stack < stack_base; stack += 32) { // Print remaining stack values from 9th value to end
 		ptr = (uint32_t *)stack;
-		lldbg_noarg("%08x: %08x %08x %08x %08x %08x %08x %08x %08x\n",
+		lldbg("%08x: %08x %08x %08x %08x %08x %08x %08x %08x\n",
 			 stack, ptr[0], ptr[1], ptr[2], ptr[3], ptr[4], ptr[5], ptr[6], ptr[7]);
 	}
 }
@@ -185,41 +189,41 @@ static void up_stackdump(uint32_t sp, uint32_t stack_base)
 
 static void arm_registerdump(volatile uint32_t *regs)
 {
-	/* Dump the interrupt registers */
-	lldbg_noarg("=====================================================================\n");
-	lldbg_noarg("Register dump\n");
-	lldbg_noarg("=====================================================================\n");
-	lldbg_noarg("R0: %08x R1: %08x R2: %08x R3: %08x\n",
-	regs[REG_R0], regs[REG_R1], regs[REG_R2], regs[REG_R3]);
+	if (regs) {
+		/* Dump the interrupt registers */
+		lldbg_noarg("===========================================================\n");
+		lldbg_noarg("Asserted task's register dump\n");
+		lldbg_noarg("===========================================================\n");
+		lldbg("R0: %08x %08x %08x %08x",
+		regs[REG_R0], regs[REG_R1], regs[REG_R2], regs[REG_R3]);
 #ifdef CONFIG_ARM_THUMB
-	lldbg_noarg("R4: %08x R5: %08x R6: %08x FP: %08x\n",
-	regs[REG_R4], regs[REG_R5], regs[REG_R6], regs[REG_R7]);
-	lldbg_noarg("R8: %08x SB: %08x SL: %08x R11: %08x\n",
-	regs[REG_R8], regs[REG_R9], regs[REG_R10], regs[REG_R11]);
+		lldbg_noarg(" %08x %08x %08x %08x\n",
+		regs[REG_R4], regs[REG_R5], regs[REG_R6], regs[REG_R7]);
+		lldbg("R8: %08x %08x %08x %08x",
+		regs[REG_R8], regs[REG_R9], regs[REG_R10], regs[REG_R11]);
 #else
-	lldbg_noarg("R4: %08x R5: %08x R6: %08x R7: %08x\n",
-	regs[REG_R4], regs[REG_R5], regs[REG_R6], regs[REG_R7]);
-	lldbg_noarg("R8: %08x SB: %08x SL: %08x	FP: %08x\n",
-	regs[REG_R8], regs[REG_R9], regs[REG_R10], regs[REG_R11]);
+		lldbg_noarg(" %08x %08x %08x %08x\n",
+		regs[REG_R4], regs[REG_R5], regs[REG_R6], regs[REG_R7]);
+		lldbg("R8: %08x %08x %08x	%08x",
+		regs[REG_R8], regs[REG_R9], regs[REG_R10], regs[REG_R11]);
 #endif
-	lldbg_noarg("IP: %08x SP: %08x LR: %08x PC: %08x\n",
-	regs[REG_R12], regs[REG_R13], regs[REG_R14], regs[REG_R15]);
+		lldbg_noarg(" %08x %08x %08x %08x\n",
+		regs[REG_R12], regs[REG_R13], regs[REG_R14], regs[REG_R15]);
 
 #if defined(REG_BASEPRI)
-	lldbg_noarg("xPSR: %08x BASEPRI: %08x CONTROL: %08x\n",
-	regs[REG_XPSR], regs[REG_BASEPRI], getcontrol());
+		lldbg("xPSR: %08x BASEPRI: %08x CONTROL: %08x\n",
+		regs[REG_XPSR], regs[REG_BASEPRI], getcontrol());
 #elif defined(REG_PRIMASK)
-	lldbg_noarg("xPSR: %08x PRIMASK: %08x CONTROL: %08x\n",
-	regs[REG_XPSR], regs[REG_PRIMASK], getcontrol());
+		lldbg("xPSR: %08x PRIMASK: %08x CONTROL: %08x\n",
+		regs[REG_XPSR], regs[REG_PRIMASK], getcontrol());
 #elif defined(REG_CPSR)
-	lldbg_noarg("CPSR: %08x\n", regs[REG_CPSR]);
+		lldbg("CPSR: %08x\n", regs[REG_CPSR]);
 #endif
 
 #ifdef REG_EXC_RETURN
-	lldbg_noarg("EXC_RETURN: %08x\n", regs[REG_EXC_RETURN]);
+		lldbg("EXC_RETURN: %08x\n", regs[REG_EXC_RETURN]);
 #endif
-	lldbg_noarg("=====================================================================\n");
-	lldbg_noarg("\n");
+	}
 }
 
 /****************************************************************************
@@ -248,6 +252,115 @@ static int assert_tracecallback(FAR struct usbtrace_s *trace, FAR void *arg)
 #endif
 
 /****************************************************************************
+ * Name: check_assert_location
+ ****************************************************************************/
+
+static void check_assert_location(uint32_t *sp, bool *is_irq_assert)
+{
+	if (g_irq_num >= 0) {
+		/* Assert in irq */
+		*is_irq_assert = true;
+		lldbg("Code asserted in IRQ state!\n");
+		lldbg("IRQ num: %d\n", g_irq_num);
+		lldbg("IRQ handler: %08x \n", g_irqvector[g_irq_num].handler);
+#ifdef CONFIG_DEBUG_IRQ_INFO
+		lldbg("IRQ name: %s \n", g_irqvector[g_irq_num].irq_name);
+#endif
+	} else {
+		/* Assert in user thread */
+		lldbg("Code asserted in normal thread!\n");
+		if (CURRENT_REGS) {
+			/* If assert is in user thread, but current_regs is not NULL,
+			 * it means that assert happened due to a fault. So, we want to
+			 * reset the sp to the value just before the fault happened
+			 */
+			*sp = CURRENT_REGS[REG_R13];
+		}
+	}
+}
+
+/****************************************************************************
+ * Name: check_sp_corruption
+ ****************************************************************************/
+
+static void check_sp_corruption(uint32_t sp, uint32_t *stackbase, uint32_t *stacksize, uint32_t istackbase, uint32_t istacksize, bool is_irq_assert, bool *is_sp_corrupt)
+{
+	lldbg_noarg("===========================================================\n");
+	lldbg_noarg("Asserted task's stack details\n");
+	lldbg_noarg("===========================================================\n");	
+	if (is_irq_assert) {
+		/* Assert in irq */
+#if CONFIG_ARCH_INTERRUPTSTACK > 7
+		if ((sp <= istackbase) && (sp > (istackbase - istacksize))) {
+			*stackbase = istackbase;
+			*stacksize = istacksize;
+			lldbg("Current SP is IRQ SP: %08x\n", sp);
+			lldbg("IRQ stack:\n");
+		} else {
+			*is_sp_corrupt = true;
+		}
+#else
+		if ((sp <= *stackbase) && (sp > (*stackbase - *stacksize))) {
+			lldbg("Current SP is User Thread SP: %08x\n", sp);
+			lldbg("User stack:\n");
+		} else {
+			*is_sp_corrupt = true;
+		}
+#endif
+	} else if ((sp <= *stackbase) && (sp > (*stackbase - *stacksize))) {
+		lldbg("Current SP is User Thread SP: %08x\n", sp);
+		lldbg("User stack:\n");
+	} else {
+		*is_sp_corrupt = true;
+	}
+}
+
+/****************************************************************************
+ * Name: print_stack_dump
+ ****************************************************************************/
+
+static void print_stack_dump(uint32_t sp, uint32_t stackbase, uint32_t stacksize, uint32_t istackbase, uint32_t istacksize, bool is_irq_assert, bool is_sp_corrupt)
+{
+	if (is_sp_corrupt) {
+		lldbg("ERROR: Stack pointer is not within the allocated stack\n");
+		lldbg("ERROR: SP = 0x%08x\n", sp);
+		if (is_irq_assert) {
+#if CONFIG_ARCH_INTERRUPTSTACK > 7
+			lldbg("ERROR: IRQ stack = 0x%08x - 0x%08x\n", istackbase - istacksize + 1, istackbase);
+#else
+			lldbg("ERROR: USR stack = 0x%08x - 0x%08x\n", stackbase - stacksize + 1, stackbase);
+#endif
+		} else {
+			lldbg("ERROR: USR stack = 0x%08x - 0x%08x\n", stackbase - stacksize + 1, stackbase);
+		}
+		
+		lldbg("Wrong Stack pointer %08x: %08x %08x %08x %08x %08x %08x %08x %08x\n",
+		sp, *((uint32_t *)sp + 0), *((uint32_t *)sp + 1), *((uint32_t *)sp + 2), ((uint32_t *)sp + 3),
+		*((uint32_t *)sp + 4), ((uint32_t *)sp + 5), ((uint32_t *)sp + 6), ((uint32_t *)sp + 7));
+		if (is_irq_assert) {
+#if CONFIG_ARCH_INTERRUPTSTACK > 7
+			lldbg("IRQ stack dump:\n");
+			up_stackdump(istackbase - istacksize + 1, istackbase);
+#else
+			lldbg("User thread stack dump:\n");
+			up_stackdump(stackbase - stacksize + 1, stackbase);
+#endif
+		} else {
+			lldbg("User thread stack dump:\n");
+			up_stackdump(stackbase - stacksize + 1, stackbase);
+		}
+	} else {
+		/* Dump the stack region which contains the current stack pointer */
+		lldbg("  base: %08x\n", stackbase);
+		lldbg("  size: %08x\n", stacksize);
+#ifdef CONFIG_STACK_COLORATION
+		lldbg("  used: %08x\n", up_check_assertstack((uintptr_t)(stackbase - stacksize), stackbase));
+#endif
+		up_stackdump(sp, stackbase);
+	}
+}
+
+/****************************************************************************
  * Name: up_dumpstate
  ****************************************************************************/
 
@@ -256,21 +369,24 @@ static void up_dumpstate(struct tcb_s *fault_tcb, uint32_t asserted_location)
 	uint32_t sp = up_getsp();
 	uint32_t stackbase = 0;
 	uint32_t stacksize = 0;
+	uint32_t istackbase;
+	uint32_t istacksize;
 #if CONFIG_ARCH_INTERRUPTSTACK > 3
-	uint32_t istackbase = 0;
-	uint32_t istacksize = 0;
+	istackbase = 0;
+	istacksize = 0;
+#else
+	istackbase = 0xFFFFFFFF;
+	istacksize = 0xFFFFFFFF;
 #endif
 
 	/* Update the xcp context */
 #ifdef CONFIG_APP_BINARY_SEPARATION
 	if (!IS_FAULT_IN_USER_THREAD(fault_tcb)) {
 #endif
-		if (CURRENT_REGS)
-		{
+		if (CURRENT_REGS) {
 			fault_tcb->xcp.regs = (uint32_t *)CURRENT_REGS;
 		}
-		else
-		{
+		else {
 			up_saveusercontext(fault_tcb->xcp.regs);
 		}
 #ifdef CONFIG_APP_BINARY_SEPARATION
@@ -289,114 +405,27 @@ static void up_dumpstate(struct tcb_s *fault_tcb, uint32_t asserted_location)
 #endif
 	bool is_irq_assert = false;
 	bool is_sp_corrupt = false;
-
 	/* Check if the assert location is in user thread or IRQ handler.
 	 * If the irq_num is lesser than NVIC_IRQ_USAGEFAULT, then it is
 	 * a fault and not an irq.
 	 */
-	if (g_irq_num >= 0) {
-		/* Assert in irq */
-		is_irq_assert = true;
-		lldbg_noarg("Code asserted in IRQ state!\n");
-		lldbg_noarg("IRQ num: %d\n", g_irq_num);
-		lldbg_noarg("IRQ handler: %08x \n", g_irqvector[g_irq_num].handler);
-#ifdef CONFIG_DEBUG_IRQ_INFO
-		lldbg_noarg("IRQ name: %s \n", g_irqvector[g_irq_num].irq_name);
-#endif
-	} else {
-		/* Assert in user thread */
-		lldbg_noarg("Code asserted in normal thread!\n");
-		if (CURRENT_REGS) {
-			/* If assert is in user thread, but current_regs is not NULL,
-			 * it means that assert happened due to a fault. So, we want to
-			 * reset the sp to the value just before the fault happened
-			 */
-			sp = CURRENT_REGS[REG_R13];
-		}
-	}
-	lldbg_noarg("Assert location (PC) : 0x%08x\n", asserted_location);
-	lldbg_noarg("\n");
+	check_assert_location(&sp, &is_irq_assert);
+	
+	/*Print IRQ handler details if required */
+	check_sp_corruption(sp, &stackbase, &stacksize, istackbase, istacksize, is_irq_assert, &is_sp_corrupt);
+
+	/* Print stack dump */
+	print_stack_dump(sp, stackbase, stacksize, istackbase, istacksize, is_irq_assert, is_sp_corrupt);
+
+	/* Dump the asserted TCB */
+	task_show_tcbinfo(fault_tcb);
 
 	/* Dump the registers */
-	if (CURRENT_REGS) {
-		arm_registerdump(CURRENT_REGS);
-	}
-
-	lldbg_noarg("=====================================================================\n");
-	lldbg_noarg("Stack Dump\n");
-	lldbg_noarg("=====================================================================\n");
-	/* Print stack dump */
-	if (is_irq_assert) {
-		/* Assert in irq */
-#if CONFIG_ARCH_INTERRUPTSTACK > 7
-		if ((sp <= istackbase) && (sp > (istackbase - istacksize))) {
-			stackbase = istackbase;
-			stacksize = istacksize;
-			lldbg_noarg("Current SP is IRQ SP: %08x\n", sp);
-			lldbg_noarg("IRQ stack:\n");
-		} else {
-			is_sp_corrupt = true;
-		}
-#else
-		if ((sp <= stackbase) && (sp > (stackbase - stacksize))) {
-			lldbg_noarg("Current SP is User Thread SP: %08x\n", sp);
-			lldbg_noarg("User stack:\n");
-		} else {
-			is_sp_corrupt = true;
-		}
-#endif
-	} else if ((sp <= stackbase) && (sp > (stackbase - stacksize))) {
-		lldbg_noarg("Current SP is User Thread SP: %08x\n", sp);
-		lldbg_noarg("User stack:\n");
-	} else {
-		is_sp_corrupt = true;
-	}
-
-	if (is_sp_corrupt) {
-		lldbg_noarg("ERROR: Stack pointer is not within the allocated stack\n");
-		lldbg_noarg("ERROR: SP = 0x%08x\n", sp);
-		if (is_irq_assert) {
-#if CONFIG_ARCH_INTERRUPTSTACK > 7
-			lldbg_noarg("ERROR: IRQ stack = 0x%08x - 0x%08x\n", istackbase - istacksize + 1, istackbase);
-#else
-			lldbg_noarg("ERROR: USR stack = 0x%08x - 0x%08x\n", stackbase - stacksize + 1, stackbase);
-#endif
-		} else {
-			lldbg_noarg("ERROR: USR stack = 0x%08x - 0x%08x\n", stackbase - stacksize + 1, stackbase);
-		}
-		
-		lldbg_noarg("Wrong Stack pointer %08x: %08x %08x %08x %08x %08x %08x %08x %08x\n",
-		sp, *((uint32_t *)sp + 0), *((uint32_t *)sp + 1), *((uint32_t *)sp + 2), ((uint32_t *)sp + 3),
-		*((uint32_t *)sp + 4), ((uint32_t *)sp + 5), ((uint32_t *)sp + 6), ((uint32_t *)sp + 7));
-
-		if (is_irq_assert) {
-#if CONFIG_ARCH_INTERRUPTSTACK > 7
-			lldbg_noarg("IRQ stack dump:\n");
-			up_stackdump(istackbase - istacksize + 1, istackbase);
-#else
-			lldbg_noarg("User thread stack dump:\n");
-			up_stackdump(stackbase - stacksize + 1, stackbase);
-#endif
-		} else {
-			lldbg_noarg("User thread stack dump:\n");
-			up_stackdump(stackbase - stacksize + 1, stackbase);
-		}
-	} else {
-		/* Dump the stack region which contains the current stack pointer */
-		lldbg_noarg("  base: %08x\n", stackbase);
-		lldbg_noarg("  size: %08x\n", stacksize);
-#ifdef CONFIG_STACK_COLORATION
-		lldbg_noarg("  used: %08x\n", up_check_assertstack((uintptr_t)(stackbase - stacksize), stackbase));
-#endif
-		up_stackdump(sp, stackbase);
-	}
-	lldbg_noarg("=====================================================================\n");
-	lldbg_noarg("\n");
+	arm_registerdump(CURRENT_REGS);
 
 #if defined(CONFIG_APP_BINARY_SEPARATION) && defined(CONFIG_ARCH_MMUDUMP)
 	if (IS_FAULT_IN_USER_THREAD(fault_tcb)) {
 		mmu_dump_app_pgtbl();
-		lldbg_noarg("\n");
 	}
 #endif
 
@@ -405,7 +434,6 @@ static void up_dumpstate(struct tcb_s *fault_tcb, uint32_t asserted_location)
 	(void)usbtrace_enumerate(assert_tracecallback, NULL);
 #endif
 
-	lldbg_noarg("\n");
 }
 #endif /* CONFIG_ARCH_STACKDUMP */
 
@@ -431,8 +459,7 @@ static void arm_assert(void)
 		spin_trylock(&g_cpu_irqlock);
 #endif
 
-		for (; ; )
-		{
+		for (; ; ) {
 #ifdef CONFIG_ARCH_LEDS
 		/* FLASH LEDs a 2Hz */
 		board_autoled_on(LED_PANIC);
@@ -450,43 +477,47 @@ static void arm_assert(void)
 }
 
 /****************************************************************************
+ * Name: check_heap_corrupt
+ ****************************************************************************/
+
+void check_heap_corrupt(struct tcb_s *fault_tcb) 
+{
+	if (!IS_SECURE_STATE()) {
+#ifdef CONFIG_APP_BINARY_SEPARATION
+		if (IS_FAULT_IN_USER_THREAD(fault_tcb)) {
+			lldbg_noarg("===========================================================\n");
+			lldbg_noarg("Checking app heap for corruption\n");
+			lldbg_noarg("===========================================================\n");
+			mm_check_heap_corruption((struct mm_heap_s *)(fault_tcb->uheap));
+
+		}
+#endif
+
+		lldbg_noarg("===========================================================\n");
+		lldbg_noarg("Checking kernel heap for corruption\n");
+		lldbg_noarg("===========================================================\n");
+	}
+	if (mm_check_heap_corruption(g_kmmheap) != OK) {
+			/* treat kernel fault */
+			arm_assert();
+	} 
+}
+
+/****************************************************************************
  * Name: print_assert_detail
  ****************************************************************************/
 
 static inline void print_assert_detail(const uint8_t *filename, int lineno, struct tcb_s *fault_tcb, uint32_t asserted_location)
 {
-  board_autoled_on(LED_ASSERTION);
-
-#ifdef CONFIG_SYSTEM_REBOOT_REASON
-	reboot_reason_write_user_intended();
-#endif
-
-#if CONFIG_TASK_NAME_SIZE > 0
-	lldbg_noarg("Assertion failed "
-#ifdef CONFIG_SMP
-	"CPU%d "
-#endif
-	"at file:%s line: %d task: %s pid: %d\n",
-#ifdef CONFIG_SMP
-	up_cpu_index(),
-#endif
-	filename, lineno, fault_tcb->name, fault_tcb->pid);
-#else
-	lldbg_noarg("Assertion failed "
-#ifdef CONFIG_SMP
-	"CPU%d "
-#endif
-	"at file:%s line: %d pid: %d\n", 
-#ifdef CONFIG_SMP
-	up_cpu_index(),
-#endif
-	filename, lineno, fault_tcb->pid);
-#endif
-
+	lldbg_noarg("===========================================================\n");
+	lldbg_noarg("Assertion details\n");
+	lldbg_noarg("===========================================================\n");
+	lldbg("Assertion Failed CPU%d at file: %s line %d task: %s pid: %d\n", up_cpu_index(), filename, lineno, LOG_TASK_NAME, fault_tcb->pid);
 	/* Print the extra arguments (if any) from ASSERT_INFO macro */
 	if (assert_info_str[0]) {
-		lldbg_noarg("%s\n", assert_info_str);
+		lldbg("%s\n", assert_info_str);
 	}
+	lldbg("Assert location (PC) : 0x%08x\n", asserted_location);
 
 #if defined(CONFIG_DEBUG_WORKQUEUE)
 #if defined(CONFIG_BUILD_FLAT) || (defined(CONFIG_BUILD_PROTECTED) && defined(__KERNEL__))
@@ -496,60 +527,13 @@ static inline void print_assert_detail(const uint8_t *filename, int lineno, stru
 	}
 #endif
 #endif /* defined(CONFIG_DEBUG_WORKQUEUE) */
-
-	lldbg_noarg("=====================================================================\n");
-	lldbg_noarg("Checking kernel heap for corruption...\n");
-	lldbg_noarg("=====================================================================\n");
-	if (mm_check_heap_corruption(g_kmmheap) == OK) {
-		lldbg_noarg("No kernel heap corruption detected\n");
-	} else {
-		lldbg_noarg("##########################################################################################################################################\n");
-		lldbg_noarg("\n\n");
-		/* treat kernel fault */
-		arm_assert();
-	}
-	lldbg_noarg("=====================================================================\n");
-	lldbg_noarg("\n");
+	up_dumpstate(fault_tcb, asserted_location);
 	
 	/* Dump the state of all tasks (if available) */
 	task_show_alivetask_list();
-	lldbg_noarg("\n");
-
-	/* Dump the asserted TCB */
-	lldbg_noarg("=====================================================================\n");
-	lldbg_noarg("Asserted TCB Info\n");
-	lldbg_noarg("=====================================================================\n");
-	task_show_tcbinfo(fault_tcb);
-	lldbg_noarg("=====================================================================\n");
-	lldbg_noarg("\n");
 
 #ifdef CONFIG_APP_BINARY_SEPARATION
-	lldbg_noarg("=====================================================================\n");
-	lldbg_noarg("Application Info\n");
-	lldbg_noarg("=====================================================================\n");
 	elf_show_all_bin_section_addr();
-	lldbg_noarg("=====================================================================\n");
-	lldbg_noarg("\n");
-#endif
-
-	up_dumpstate(fault_tcb, asserted_location);
-
-#ifdef CONFIG_APP_BINARY_SEPARATION
-	if (IS_FAULT_IN_USER_THREAD(fault_tcb)) {
-		lldbg_noarg("=====================================================================\n");
-		lldbg_noarg("Checking current app heap for corruption...\n");
-		lldbg_noarg("=====================================================================\n");
-		if (mm_check_heap_corruption((struct mm_heap_s *)(fault_tcb->uheap)) == OK) {
-			lldbg_noarg("No app heap corruption detected\n");
-		}
-		lldbg_noarg("=====================================================================\n");
-	}
-#endif
-
-#if defined(CONFIG_BOARD_CRASHDUMP)
-	lldbg_noarg("Perform Crashdump\n");
-	board_crashdump(up_getsp(), fault_tcb, (uint8_t *)filename, lineno);
-	lldbg_noarg("\n");
 #endif
 
 }
@@ -573,6 +557,7 @@ void up_assert(const uint8_t *filename, int lineno)
 
 
 	board_autoled_on(LED_ASSERTION);
+
 #ifdef CONFIG_SYSTEM_REBOOT_REASON
 	reboot_reason_write_user_intended();
 #endif
@@ -594,10 +579,6 @@ void up_assert(const uint8_t *filename, int lineno)
 	}
 
 	irqstate_t flags = irqsave();
-	lldbg_noarg("\n\n");
-	lldbg_noarg("##########################################################################################################################################\n");
-	lldbg_noarg("Assertion failed\n");
-	lldbg_noarg("##########################################################################################################################################\n");
 #ifdef CONFIG_SECURITY_LEVEL
 	lldbg_noarg("security level: %d\n", get_security_level());
 #endif
@@ -608,8 +589,18 @@ void up_assert(const uint8_t *filename, int lineno)
 		print_assert_detail(filename, lineno, fault_tcb, asserted_location);
 	}
 
+	/* Heap corruption check */
+	check_heap_corrupt(fault_tcb);
+
+	/* Closing log line */
 	lldbg_noarg("##########################################################################################################################################\n");
-	lldbg_noarg("\n\n");
+
+#if defined(CONFIG_BOARD_CRASHDUMP)
+	lldbg_noarg("Perform Crashdump\n");
+	board_crashdump(up_getsp(), fault_tcb, (uint8_t *)filename, lineno);
+	lldbg_noarg("\n");
+#endif
+
 	irqrestore(flags);
 
 #ifdef CONFIG_BINMGR_RECOVERY

--- a/os/arch/arm/src/armv8-m/mpu.h
+++ b/os/arch/arm/src/armv8-m/mpu.h
@@ -326,7 +326,9 @@ static inline void mpu_show_regioninfo(void)
 
 	/* save the current region before printing the information */
 	temp = getreg32(MPU_RNR);
-
+	lldbg_noarg("===========================================================\n");
+	lldbg_noarg("List of MPU regions and permissions\n");
+	lldbg_noarg("===========================================================\n");
 	lldbg("********************************************************************************************\n");
 	lldbg("%-12s\t%-12s\t%-12s\t%-12s\t%-12s\t%-12s\n", "REGION_NO.", "BASE_ADDRESS", "SIZE", "STATUS", "ACCESS (P/U)", "EXECUTE");
 	lldbg("********************************************************************************************\n");

--- a/os/binfmt/libelf/libelf_sections.c
+++ b/os/binfmt/libelf/libelf_sections.c
@@ -258,7 +258,9 @@ void elf_delete_bin_section_addr(uint8_t bin_idx)
 void elf_show_all_bin_section_addr(void)
 {
 	int bin_idx;
-
+	lldbg_noarg("===========================================================\n");
+	lldbg_noarg("Loading location information\n");
+	lldbg_noarg("===========================================================\n");	
 	for (bin_idx = 0; bin_idx <= CONFIG_NUM_APPS; bin_idx++) {
 		if (g_bin_addr_list[bin_idx].text_addr != 0) {
 			lldbg("[%s] Text Addr : %p, Text Size : %u\n", BIN_NAME(bin_idx), g_bin_addr_list[bin_idx].text_addr, g_bin_addr_list[bin_idx].text_size);

--- a/os/kernel/task/task_dumptasks.c
+++ b/os/kernel/task/task_dumptasks.c
@@ -88,23 +88,26 @@
 
 void task_show_tcbinfo(struct tcb_s *tcb)
 {
-	lldbg_noarg("State       : %u\n", tcb->task_state);
-	lldbg_noarg("Flags       : %u\n", tcb->flags);
-	lldbg_noarg("Lock count  : %u\n", tcb->lockcount);
+	lldbg_noarg("===========================================================\n");
+	lldbg_noarg("Asserted task's TCB info \n");
+	lldbg_noarg("===========================================================\n");
+	lldbg("State       : %u\n", tcb->task_state);
+	lldbg("Flags       : %u\n", tcb->flags);
+	lldbg("Lock count  : %u\n", tcb->lockcount);
 #if CONFIG_RR_INTERVAL > 0
-	lldbg_noarg("Timeslice   : %d\n", tcb->timeslice);
+	lldbg("Timeslice   : %d\n", tcb->timeslice);
 #endif
-	lldbg_noarg("Waitdog     : %p\n", tcb->waitdog);
-	lldbg_noarg("WaitSem     : %p\n", tcb->waitsem);
+	lldbg("Waitdog     : %p\n", tcb->waitdog);
+	lldbg("WaitSem     : %p\n", tcb->waitsem);
 #ifndef CONFIG_DISABLE_MQUEUE
-	lldbg_noarg("MsgwaitQ    : %p\n", tcb->msgwaitq);
+	lldbg("MsgwaitQ    : %p\n", tcb->msgwaitq);
 #endif
 #ifndef CONFIG_DISABLE_SIGNALS
-	lldbg_noarg("Sigdeliver  : %p\n", tcb->xcp.sigdeliver);
+	lldbg("Sigdeliver  : %p\n", tcb->xcp.sigdeliver);
 #endif
 #ifdef CONFIG_LIB_SYSCALL
-	lldbg_noarg("Nsyscalls   : %u\n", tcb->xcp.nsyscalls);
-	lldbg_noarg("Syscall     : %p\n", tcb->xcp.syscall);
+	lldbg("Nsyscalls   : %u\n", tcb->xcp.nsyscalls);
+	lldbg("Syscall     : %p\n", tcb->xcp.syscall);
 #endif
 }
 
@@ -139,9 +142,9 @@ static void task_taskdump(FAR struct tcb_s *tcb, FAR void *arg)
 
 void task_show_alivetask_list(void)
 {
-	lldbg_noarg("---------------------------------------------------------------------------------------------------\n");
-	lldbg_noarg("List of all tasks in the system:\n");
-	lldbg_noarg("---------------------------------------------------------------------------------------------------\n");
+	lldbg_noarg("===========================================================\n");
+	lldbg_noarg("List of all tasks in the system\n");
+	lldbg_noarg("===========================================================\n");
 
 	lldbg_noarg(TASKDUMP_ARGS_FORMAT, TASKDUMP_ARGS);
 	lldbg_noarg("---------------------------------------------------------------------------------------------------\n");

--- a/os/mm/mm_heap/mm_check_heap_corruption.c
+++ b/os/mm/mm_heap/mm_check_heap_corruption.c
@@ -262,6 +262,6 @@ int mm_check_heap_corruption(struct mm_heap_s *heap)
 			return -1;
 		}
 	}
-
+	mfdbg("No heap corruption detected\n");
 	return 0;
 }


### PR DESCRIPTION
1. We have added API tags to assert logs and these tags are further used by trap for parsing.
2. We have added closing log line to assert log.
3. We do changes in trap tools to support the new log format of tp1x and AI Dual. 
4. Order sequence for Assert Log: 

- Assertion details
- Asserted task's stack details
- Asserted task's TCB info 
- Asserted task's register dump
- List of all tasks in the system
- List of MPU regions and permissions
- Loading location information
- Checking app heap for corruption
- Checking kernel heap for corruption

5. Attached the document containing Assert log and Trap run log.

[Sample Assert Log.txt](https://github.com/Samsung/TizenRT/files/14276064/Assert.Log.After.txt)
[Trap Run Log.txt](https://github.com/Samsung/TizenRT/files/13917645/Trap.Run.Log.txt)
