### PR TITLE
framework/include/security : Increase secure storage data slot size

### DIFF
--- a/framework/include/security/security_common.h
+++ b/framework/include/security/security_common.h
@@ -25,8 +25,8 @@
 extern "C" {
 #endif
 
-#define SECURITY_MAX_KEY_BUF          256
-#define SECURITY_MAX_CERT_BUF         2048
+#define SECURITY_MAX_KEY_BUF          4096
+#define SECURITY_MAX_CERT_BUF         4096
 #define SECURITY_MAX_SS_BUF           4096
 #define SECURITY_MAX_BUF              SECURITY_MAX_SS_BUF
 


### PR DESCRIPTION
There is a slot that stores AP information, but the required size has increased while storing multi-AP information. 
Since the number of slots is limited, it is more efficient to store the data by increasing the size of existing slots instead of dividing it into several slots. 
Therefore, this commit increase data slot size from 256 to 4096. 
SECURITY_MAX_CERT_BUF is also changed to 4096 for the identity with trt_se.h (product code)