### PR TITLE
os/arch/arm/src/armv7-a: Place MMU mapping related APIs to PSRAM

### DIFF
--- a/build/configs/rtl8730e/scripts/rlx8730e_img2.ld
+++ b/build/configs/rtl8730e/scripts/rlx8730e_img2.ld
@@ -128,6 +128,24 @@ __ca32_fip_dram_start__ = ORIGIN(CA32_FIP_DRAM_NS);
 
 SECTIONS
 {
+	.code :
+	{
+		. = ALIGN(4096);
+		__dram_text_start__ = .;
+		. = ALIGN(0x4);
+
+		*(.vectors)
+		*(.start)
+		*(.timesensitive.text*)
+		*(.sramdram.only.text*)		
+		/* Place arm_mmu.c in PSRAM to reduce delay in boot sequence */
+		*arm_mmu.o (.text*)
+
+		. = ALIGN(4096);
+		__dram_text_end__ = .;
+		_etext_ram = ABSOLUTE(.);
+	} > CA32_BL3_DRAM_NS
+
 	/* xip part */
 	.xip_image2.text ORIGIN(CA32_IMG2_XIP):
 	{
@@ -162,22 +180,6 @@ SECTIONS
 		_etext_flash = ABSOLUTE(.);
 		__flash_text_end__ = .;
 	} > CA32_IMG2_XIP
-
-	.code :
-	{
-		. = ALIGN(4096);
-		__dram_text_start__ = .;
-		. = ALIGN(0x4);
-
-		*(.vectors)
-		*(.start)
-		*(.timesensitive.text*)
-		*(.sramdram.only.text*)
-
-		. = ALIGN(4096);
-		__dram_text_end__ = .;
-		_etext_ram = ABSOLUTE(.);
-	} > CA32_BL3_DRAM_NS
 
 	/* C++ .ARM.extab/.ARM.exidx address shall same as *(.text*) */
 	.ARM.extab  : 


### PR DESCRIPTION
- Changed file: os/arch/arm/src/armv7-a/arm_mmu.c
- After moving out all files to XIP, there is an unexpected delay in boot sequence (around 5 secs)
- Discovered that TLB invalidation operation is causing the delay
- Move several MMU related APIs to PSRAM, delay in boot sequence can be shorten (around 1 sec)
- Note: Commenting out mmu_invalidate_region() in mmu_l1_setentry() will not incur any delay in boot sequence, and able to boot up successfully. The operation flow should be checked in depth.