### PR TITLE
os/board/rtl8730e/src/component: fix wifi connection failure with wpa…

### DIFF
--- a/os/board/rtl8730e/src/component/wifi/wifi_interactive_mode.c
+++ b/os/board/rtl8730e/src/component/wifi/wifi_interactive_mode.c
@@ -371,6 +371,7 @@ int8_t cmd_wifi_connect(trwifi_ap_config_s *ap_connect_config, void *arg, uint32
 		semaphore = NULL;
 		break;
 	case TRWIFI_AUTH_WPA3_PSK:
+	case TRWIFI_AUTH_WPA2_AND_WPA3_PSK:
 		security_type = RTW_SECURITY_WPA3_AES_PSK;
 		password = ap_connect_config->passphrase;
 		ssid_len = strlen((const char *)ssid);


### PR DESCRIPTION
- Changed file: os/board/rtl8730e/src/component/wifi/wifi_interactive_mode.c
- fix wifi connection failure when chose wpa23_aes, now driver will use wpa3 to connect under mix mode