### PR TITLE
os/board/rtl8730e: Move Flash Related API to PSRAM

### DIFF
--- a/os/board/rtl8730e/src/component/mbed/targets/hal/rtl8730e/flash_api.c
+++ b/os/board/rtl8730e/src/component/mbed/targets/hal/rtl8730e/flash_api.c
@@ -64,6 +64,7 @@ void flash_write_protect(flash_t *obj, u32 protect)
   * @note  Please refer to the flash datasheet for more info about status register,
   *        as well as block protected area and related control bits.
   */
+SRAMDRAM_ONLY_TEXT_SECTION
 int flash_set_status(flash_t *obj, u32 data)
 {
 	/* To avoid gcc warnings */
@@ -98,6 +99,7 @@ int flash_set_status(flash_t *obj, u32 data)
   * @retval none
   * @note Make sure the operation is appropriate and remember to reset status register2 to 0 if flash chip has status register2.
   */
+SRAMDRAM_ONLY_TEXT_SECTION
 void flash_reset_status(flash_t *obj)
 {
 	flash_set_status(obj, 0);
@@ -109,6 +111,7 @@ void flash_reset_status(flash_t *obj)
   * @param  obj: Flash object defined in application software.
   * @return The value of status register1.
   */
+SRAMDRAM_ONLY_TEXT_SECTION
 int flash_get_status(flash_t *obj)
 {
 	/* To avoid gcc warnings */
@@ -130,6 +133,7 @@ int flash_get_status(flash_t *obj)
   * @retval none
   * @note LSB 12bits will be masked.
   */
+SRAMDRAM_ONLY_TEXT_SECTION
 void flash_erase_sector(flash_t *obj, u32 address)
 {
 	/* To avoid gcc warnings */
@@ -148,6 +152,7 @@ void flash_erase_sector(flash_t *obj, u32 address)
   * @retval none
   * @note LSB 16bits will be masked.
   */
+SRAMDRAM_ONLY_TEXT_SECTION
 void flash_erase_block(flash_t *obj, u32 address)
 {
 	/* To avoid gcc warnings */
@@ -164,6 +169,7 @@ void flash_erase_block(flash_t *obj, u32 address)
   * @param  obj: Flash object defined in application software.
   * @retval none
   */
+SRAMDRAM_ONLY_TEXT_SECTION
 void flash_erase_chip(flash_t *obj)
 {
 	/* To avoid gcc warnings */
@@ -185,11 +191,12 @@ void flash_erase_chip(flash_t *obj)
   * @retval Others: Error.
   * @note It is ok to read under auto mode due to flash cache.
   */
+SRAMDRAM_ONLY_TEXT_SECTION
 int  flash_read_word(flash_t *obj, u32 address, u32 *data)
 {
 	/* To avoid gcc warnings */
 	(void) obj;
-
+	FLASH_Write_Lock();
 	assert_param(data != NULL);
 
 	u32 offset_to_align = address & 0x03;
@@ -222,6 +229,7 @@ int  flash_read_word(flash_t *obj, u32 address, u32 *data)
 		arm_gic_freq_restore();
 	}
 #endif
+	FLASH_Write_Unlock();
 	return 1;
 }
 
@@ -235,6 +243,7 @@ int  flash_read_word(flash_t *obj, u32 address, u32 *data)
   * @retval Others: Error.
   * @note User mode write used.
   */
+SRAMDRAM_ONLY_TEXT_SECTION
 int  flash_write_word(flash_t *obj, u32 address, u32 data)
 {
 	/* To avoid gcc warnings */
@@ -274,11 +283,12 @@ int  flash_write_word(flash_t *obj, u32 address, u32 data)
   * @retval Others: Error.
   * @note It is ok to read under auto mode due to flash cache.
   */
+SRAMDRAM_ONLY_TEXT_SECTION
 int  flash_stream_read(flash_t *obj, u32 address, u32 len, u8 *data)
 {
 	/* To avoid gcc warnings */
 	(void) obj;
-
+	FLASH_Write_Lock();
 	assert_param(data != NULL);
 
 	u32 offset_to_align;
@@ -346,6 +356,7 @@ int  flash_stream_read(flash_t *obj, u32 address, u32 len, u8 *data)
 		arm_gic_freq_restore();
 	}
 #endif
+	FLASH_Write_Unlock();
 	return 1;
 }
 
@@ -359,6 +370,7 @@ int  flash_stream_read(flash_t *obj, u32 address, u32 len, u8 *data)
   * @retval 1: Success.
   * @retval Others: Error.
   */
+SRAMDRAM_ONLY_TEXT_SECTION
 int  flash_stream_write(flash_t *obj, u32 address, u32 len, u8 *data)
 {
 	/* To avoid gcc warnings */
@@ -404,6 +416,7 @@ int  flash_stream_write(flash_t *obj, u32 address, u32 len, u8 *data)
   * @retval Others: Error.
   * @note  It is the same with function flash_stream_write().
   */
+SRAMDRAM_ONLY_TEXT_SECTION
 int flash_burst_write(flash_t *obj, u32 address, u32 Length, u8 *data)
 {
 	flash_stream_write(obj, address, Length, data);
@@ -421,6 +434,7 @@ int flash_burst_write(flash_t *obj, u32 address, u32 Length, u8 *data)
   * @retval Others: Error.
   * @note It is the same with function flash_stream_read().
   */
+SRAMDRAM_ONLY_TEXT_SECTION
 int  flash_burst_read(flash_t *obj, u32 address, u32 Length, u8 *data)
 {
 	flash_stream_read(obj, address, Length, data);
@@ -438,6 +452,7 @@ int  flash_burst_read(flash_t *obj, u32 address, u32 Length, u8 *data)
   * @attention Only for Micron 128MB flash.
   * @note Please refer to the flash datasheet for more info about memory mapping.
   */
+SRAMDRAM_ONLY_TEXT_SECTION
 int flash_set_extend_addr(flash_t *obj, u32 data)
 {
 	/* To avoid gcc warnings */
@@ -459,6 +474,7 @@ int flash_set_extend_addr(flash_t *obj, u32 data)
   * @attention Only for Micron 128MB flash.
   * @note Please refer to the flash datasheet for more info about memory mapping.
   */
+SRAMDRAM_ONLY_TEXT_SECTION
 int flash_get_extend_addr(flash_t *obj)
 {
 	/* To avoid gcc warnings */
@@ -479,6 +495,7 @@ int flash_get_extend_addr(flash_t *obj)
   * @param  len: Length of the flash ID to read.
   * @return Length of the flash ID.
   */
+SRAMDRAM_ONLY_TEXT_SECTION
 int flash_read_id(flash_t *obj, uint8_t *buf, uint8_t len)
 {
 	/* To avoid gcc warnings */


### PR DESCRIPTION
Issue:
When perform smartfs "format" will causing hang.

Root Cause:
After implement the XIP changes, the flash api was default located to the XIP. 
For the flash related API must be locate to PSRAM.

Changes Note:
Add the SRAMDRAM_ONLY_TEXT_SECTION for the flash related API move to PSRAM. 
Add the FLASH_Write_Lock/Unlock to make sure before perform the flash operation, CA32 must be disable the IRQ.