### PR TITLE
os/arch/arm: allocate fiq stack based on CONFIG_ARMV7A_DECODEFIQ

### DIFF
--- a/os/arch/arm/src/amebasmart/amebasmart_irq.c
+++ b/os/arch/arm/src/amebasmart/amebasmart_irq.c
@@ -54,7 +54,6 @@ volatile uint32_t *g_current_regs[CONFIG_SMP_NCPUS];
  */
 
 uint64_t g_irqstack_alloc[INTSTACK_ALLOC >> 3];
-uint64_t g_fiqstack_alloc[INTSTACK_ALLOC >> 3];
 
 /* These are arrays that point to the top of each interrupt stack */
 
@@ -72,6 +71,10 @@ uintptr_t g_irqstack_top[CONFIG_SMP_NCPUS] =
 #endif
 };
 
+#if defined(CONFIG_ARMV7A_DECODEFIQ)
+
+uint64_t g_fiqstack_alloc[INTSTACK_ALLOC >> 3];
+
 uintptr_t g_fiqstack_top[CONFIG_SMP_NCPUS] =
 {
   (uintptr_t)g_fiqstack_alloc + INTSTACK_SIZE,
@@ -85,6 +88,8 @@ uintptr_t g_fiqstack_top[CONFIG_SMP_NCPUS] =
   (uintptr_t)g_fiqstack_alloc + 4 * INTSTACK_SIZE
 #endif
 };
+
+#endif
 
 #endif
 

--- a/os/arch/arm/src/amebasmart/chip.h
+++ b/os/arch/arm/src/amebasmart/chip.h
@@ -101,7 +101,7 @@
  *
  ****************************************************************************/
 
-#if defined(CONFIG_SMP) && CONFIG_ARCH_INTERRUPTSTACK > 7
+#if defined(CONFIG_SMP) && defined(CONFIG_ARMV7A_DECODEFIQ) && CONFIG_ARCH_INTERRUPTSTACK > 7
   .macro  setfiqstack, tmp1, tmp2
   mrc  p15, 0, \tmp1, c0, c0, 5  /* tmp1=MPIDR */
   and  \tmp1, \tmp1, #3          /* Bits 0-1=CPU ID */

--- a/os/arch/arm/src/armv7-a/arm_vectors.S
+++ b/os/arch/arm/src/armv7-a/arm_vectors.S
@@ -99,7 +99,7 @@
  *
  ****************************************************************************/
 
-#if !defined(CONFIG_SMP) && CONFIG_ARCH_INTERRUPTSTACK > 7
+#if !defined(CONFIG_SMP) && CONFIG_ARCH_INTERRUPTSTACK > 7 && defined(CONFIG_ARMV7A_DECODEFIQ)
 	.macro	setfiqstack, tmp1, tmp2
 	ldr		sp, .Lfiqstacktop		/* SP = FIQ stack top */
 	.endm
@@ -832,7 +832,7 @@ arm_vectorfiq:
 	add		r14, r14, #(4*7)		/* (FIQ) r14=address of r15 storage */
 	ldmia		r14, {r15}^			/* Return */
 
-#if !defined(CONFIG_SMP) && CONFIG_ARCH_INTERRUPTSTACK > 7
+#if !defined(CONFIG_SMP) && CONFIG_ARCH_INTERRUPTSTACK > 7 && defined(CONFIG_ARMV7A_DECODEFIQ)
 .Lfiqstacktop:
 	.word	g_fiqstacktop
 #endif
@@ -865,6 +865,7 @@ g_intstackbase:
  *  Name: g_fiqstackalloc/g_fiqstacktop
  ****************************************************************************/
 
+#if defined(CONFIG_ARMV7A_DECODEFIQ)
 	.globl	g_fiqstackalloc
 	.type	g_fiqstackalloc, object
 	.globl	g_fiqstacktop
@@ -875,6 +876,7 @@ g_fiqstackalloc:
 g_fiqstacktop:
 	.size	g_fiqstacktop, 0
 	.size	g_fiqstackalloc, (CONFIG_ARCH_INTERRUPTSTACK & ~7)
+#endif
 
 #endif /* !CONFIG_SMP && CONFIG_ARCH_INTERRUPTSTACK > 7 */
 	.end

--- a/os/arch/arm/src/imx6/chip.h
+++ b/os/arch/arm/src/imx6/chip.h
@@ -118,7 +118,7 @@
  *
  ****************************************************************************/
 
-#if defined(CONFIG_SMP) && CONFIG_ARCH_INTERRUPTSTACK > 7
+#if defined(CONFIG_SMP) &&  defined(CONFIG_ARMV7A_DECODEFIQ) && CONFIG_ARCH_INTERRUPTSTACK > 7
   .macro  setfiqstack, tmp1, tmp2
   mrc  p15, 0, \tmp1, c0, c0, 5  /* tmp1=MPIDR */
   and  \tmp1, \tmp1, #3          /* Bits 0-1=CPU ID */

--- a/os/arch/arm/src/imx6/imx_irq.c
+++ b/os/arch/arm/src/imx6/imx_irq.c
@@ -68,7 +68,6 @@ volatile uint32_t *g_current_regs[CONFIG_SMP_NCPUS];
  */
 
 uint64_t g_irqstack_alloc[INTSTACK_ALLOC >> 3];
-uint64_t g_fiqstack_alloc[INTSTACK_ALLOC >> 3];
 
 /* These are arrays that point to the top of each interrupt stack */
 
@@ -86,6 +85,10 @@ uintptr_t g_irqstack_top[CONFIG_SMP_NCPUS] =
 #endif
 };
 
+#if defined(CONFIG_ARMV7A_DECODEFIQ)
+
+uint64_t g_fiqstack_alloc[INTSTACK_ALLOC >> 3];
+
 uintptr_t g_fiqstack_top[CONFIG_SMP_NCPUS] =
 {
   (uintptr_t)g_fiqstack_alloc + INTSTACK_SIZE,
@@ -99,6 +102,8 @@ uintptr_t g_fiqstack_top[CONFIG_SMP_NCPUS] =
   (uintptr_t)g_fiqstack_alloc + 4 * INTSTACK_SIZE
 #endif
 };
+
+#endif
 
 #endif
 


### PR DESCRIPTION
fiq stack is allocated in all cases as of now. Hence, allocate fiq stack only if CONFIG_ARMV7A_DECODEFIQ is enabled.