### PR TITLE
os/arch/arm/src/amebasmart, os/pm: Refine PM DVFS and fix struct naming mismatch for RTL8730E

### DIFF
--- a/os/arch/arm/src/amebasmart/amebasmart_pmc.c
+++ b/os/arch/arm/src/amebasmart/amebasmart_pmc.c
@@ -58,6 +58,8 @@
 #include <task.h>
 #include "freertos_pmu.h"
 #endif
+/* Include header for DVFS implementation */
+#include <tinyara/pm/pm.h>
 #include "ameba_soc.h"
 #include "sys_io.h"
 #include "gic.h"
@@ -281,7 +283,8 @@ void SOCPS_SleepCG(void)
 	//pmu_acquire_wakelock(PMU_OS);
 }
 
-void up_set_dvfs(u32 val)
+#ifdef CONFIG_PM_DVFS
+void up_set_dvfs(int div_lvl)
 {
 	/* Please refer to sysreg_hsys.h */
 	// AP_CLK_DIV1		0
@@ -292,6 +295,7 @@ void up_set_dvfs(u32 val)
 	/* Div clock speed by input val */
 	reg_div = HAL_READ32(SYSTEM_CTRL_BASE_HP, REG_HSYS_HP_CKSL);
 	reg_div &= ~HSYS_MASK_CKD_AP;
-	reg_div |= HSYS_CKD_AP(val);
+	reg_div |= HSYS_CKD_AP(div_lvl);
 	HAL_WRITE32(SYSTEM_CTRL_BASE_HP, REG_HSYS_HP_CKSL, reg_div);
 }
+#endif

--- a/os/arch/arm/src/amebasmart/amebasmart_pmhelpers.c
+++ b/os/arch/arm/src/amebasmart/amebasmart_pmhelpers.c
@@ -51,7 +51,7 @@
 #include "timer_api.h"
 
 gtimer_t g_timer1;
-extern struct timer_s g_timer_wakeup;
+extern struct pm_wakeup_timer_s g_timer_wakeup;
 
 void SOCPS_SetAPWakeEvent_MSK0(u32 Option, u32 NewStatus)
 {

--- a/os/include/tinyara/pm/pm.h
+++ b/os/include/tinyara/pm/pm.h
@@ -616,12 +616,16 @@ int pm_changestate(int domain, enum pm_state_e newstate);
 
 enum pm_state_e pm_querystate(int domain);
 
+#ifdef CONFIG_PM_DVFS
 /****************************************************************************
  * Name: pm_dvfs
  *
  * Description:
- *   This internal function is called to reduce the frequency of operation
- *   of the secondary AP core of AI_Dual chipset.
+ *   This internal function is called to reduce the clock frequency
+ *   of CPU core. It can be applied on some scenario which when low
+ *	 loading activity is expected, we can invoke this API to wind down
+ *   CPU cores with high operating frequency, to enhance the effectiveness
+ *	 for power saving.
  *
  * Input Parameters:
  *   div_lvl - voltage frequency scaling level
@@ -634,6 +638,29 @@ enum pm_state_e pm_querystate(int domain);
  *
  ****************************************************************************/
 void pm_dvfs(int div_lvl);
+#endif
+
+#ifdef CONFIG_PM_DVFS
+/****************************************************************************
+ * Name: up_set_dvfs
+ *
+ * Description:
+ *   BSP operation called from wrapper API pm_dvfs() to reduce the clock 
+ *   frequency of CPU core. It can be applied on some scenario which when low
+ *	 loading activity is expected, we can invoke this API to wind down
+ *   CPU cores with high operating frequency, to enhance the effectiveness
+ *	 for power saving.
+ *
+ * Input Parameters:
+ *   div_lvl - voltage frequency scaling level
+ *
+ * Returned Value:
+ *   None.
+ *
+ *
+ ****************************************************************************/
+void up_set_dvfs(int div_lvl);
+#endif
 
 #undef EXTERN
 #ifdef __cplusplus

--- a/os/pm/pm_procfs.c
+++ b/os/pm/pm_procfs.c
@@ -117,7 +117,7 @@ struct power_procfs_entry_s {
 };
 
 /* Added to record timer countdown interrupt */
-struct timer_s g_timer_wakeup = { 0, 0 };
+struct pm_wakeup_timer_s g_timer_wakeup = { 0, 0 };
 
 /****************************************************************************
  * Private Function Prototypes


### PR DESCRIPTION
- Update DVFS wrapper layer
- Fixed PM timer struct naming mismatch (For PR#6015)