### PR TITLE
os/board/rtl8730e: fix wifi SVACE warnings

### DIFF
--- a/os/board/rtl8730e/src/component/wifi/driver/include/rtw_autoconf.h
+++ b/os/board/rtl8730e/src/component/wifi/driver/include/rtw_autoconf.h
@@ -35,7 +35,7 @@
 
 /* no IOT chip supports 80M now, so close it in common */
 #define NOT_SUPPORT_80M
-#define CONFIG_AUTO_RECONNECT 1
+#define CONFIG_AUTO_RECONNECT 0
 
 /* For WPA3 */
 #define CONFIG_IEEE80211W


### PR DESCRIPTION
Change notes:
Also disabled CONFIG_AUTO_RECONNECT in rtw_autoconf.h