### PR TITLE
os: Add functionality for timed PM state locking

### DIFF
--- a/apps/examples/power/power_main.c
+++ b/apps/examples/power/power_main.c
@@ -35,7 +35,7 @@
  ****************************************************************************/
 #define POWER_THREAD_SIZE				2048
 #define POWER_THREAD_PRIORITY				255
-#define PM_DAEMON_SLEEP_INTERVAL			5000000	//Microseconds
+#define PM_DAEMON_SLEEP_INTERVAL			5	//Seconds
 #define PM_WAKEUP_TIMER_DURATION			5000000	//Microseconds
 
 /****************************************************************************

--- a/os/arch/arm/src/amebasmart/amebasmart_idle.c
+++ b/os/arch/arm/src/amebasmart/amebasmart_idle.c
@@ -92,7 +92,7 @@ static void up_idlepm(void)
 				   the secondary core state before going to sleep
 				*/
 #ifndef CONFIG_SMP
-				ap_timer_helper();
+				up_set_pm_timer();
 #endif
 				if (up_cpu_index() == 0) {
 					/* mask sys tick interrupt*/
@@ -124,7 +124,7 @@ static void up_idlepm(void)
 
 							/* For SMP case, timer should be set after confirming secondary core enter hotplug mode */
 							if (pmu_get_secondary_cpu_state(1) == CPU1_HOTPLUG) {
-								ap_timer_helper();
+								up_set_pm_timer();
 							}
 							/* CG flow */
 						} else {

--- a/os/arch/arm/src/amebasmart/amebasmart_pmhelpers.c
+++ b/os/arch/arm/src/amebasmart/amebasmart_pmhelpers.c
@@ -51,7 +51,7 @@
 #include "timer_api.h"
 
 gtimer_t g_timer1;
-extern struct pm_wakeup_timer_s g_timer_wakeup;
+extern struct pm_timer_s g_pm_timer;
 
 void SOCPS_SetAPWakeEvent_MSK0(u32 Option, u32 NewStatus)
 {
@@ -115,20 +115,32 @@ int SOCPS_AONWakeReason(void)
 
 void pg_timer_int_handler(void *Data)
 {
-	pmvdbg("Timer wakeup interrupt handler!!\n");
+	pmvdbg("PM Timer interrupt handler!!\n");
+	switch (g_pm_timer.timer_type) {
+		case PM_LOCK_TIMER:
+			// Relax the lock on the PM state transitions after the timer interrupt
+			pm_relax(PM_IDLE_DOMAIN, PM_NORMAL);
+			break;
+		case PM_WAKEUP_TIMER:
+			// Switch status back to normal mode after wake up from interrupt
+			pm_activity(PM_IDLE_DOMAIN, 9);
+			break;
+		default:
+			pmdbg("Timer callback triggered without setting timer, Unexpected Error!!!\n");
+			break;
+	}
 	// Reset the global struct
-    g_timer_wakeup.use_timer = 0;
-    g_timer_wakeup.timer_interval = 0;
-	// Switch status back to normal mode after wake up from interrupt
-	pm_activity(PM_IDLE_DOMAIN, 9);
+	g_pm_timer.timer_type = 0;
+	g_pm_timer.timer_interval = 0;
 }
 
-void ap_timer_helper(void) {
+void up_set_pm_timer(void) {
 	// Check whether timer interrupt need to be set
-	if (g_timer_wakeup.use_timer) {
+	if (g_pm_timer.timer_type) {
 		gtimer_init(&g_timer1, TIMER1);
-		gtimer_start_one_shout(&g_timer1, g_timer_wakeup.timer_interval, (void *)pg_timer_int_handler, NULL);
+		gtimer_start_one_shout(&g_timer1, g_pm_timer.timer_interval, (void *)pg_timer_int_handler, NULL);
 	}
+	return;
 }
 
 /* Interrupt callback from wifi-keepalive, which LP received designated packet*/

--- a/os/include/tinyara/pm/pm.h
+++ b/os/include/tinyara/pm/pm.h
@@ -303,9 +303,15 @@ enum pm_state_e {
 	PM_COUNT,
 };
 
-struct pm_wakeup_timer_s {
-	bool use_timer;
-	uint32_t timer_interval;
+enum pm_timer_type_e {
+	PM_WAKEUP_TIMER = 1,
+	PM_LOCK_TIMER = 2,
+	/* Scope for future expansion, up to 8 timer types can be supported */
+};
+
+struct pm_timer_s {
+	uint8_t timer_type;		/* Bits here are set according to the timer that is to be used */
+	uint32_t timer_interval;	/* The interval for whichever timer is to be used */
 };
 
 /* This structure contain pointers callback functions in the driver.  These
@@ -522,6 +528,25 @@ void pm_stay(int domain, enum pm_state_e state);
  ****************************************************************************/
 
 void pm_relax(int domain, enum pm_state_e state);
+
+/****************************************************************************
+ * Name: pm_set_timer
+ *
+ * Description:
+ *   This function is called to set a timed callback to an intended function.
+ *   It may be used to invoke pm_relax() after a fixed time duration of
+ *   locking using pm_stay().
+ *
+ * Input Parameters:
+ *   timer_type - the type of the timer which determines the callback
+ *   timer_interval - duration of the timer
+ *
+ * Returned Value:
+ *   None.
+ *
+ ****************************************************************************/
+
+void pm_set_timer(int timer_type, size_t timer_interval);
 
 /****************************************************************************
  * Name: pm_staycount

--- a/os/pm/pm_activity.c
+++ b/os/pm/pm_activity.c
@@ -68,6 +68,12 @@
 #ifdef CONFIG_PM
 
 /****************************************************************************
+ * External Definitons
+ ****************************************************************************/
+
+extern struct pm_timer_s g_pm_timer;
+
+/****************************************************************************
  * Public Functions
  ****************************************************************************/
 
@@ -200,6 +206,36 @@ void pm_stay(int domain, enum pm_state_e state)
 	DEBUGASSERT(pdom->stay[state] < UINT16_MAX);
 	pdom->stay[state]++;
 	leave_critical_section(flags);
+}
+
+/****************************************************************************
+ * Name: pm_set_timer
+ *
+ * Description:
+ *   This function is called to set a timed callback to an intended function.
+ *   It may be used to invoke pm_relax() after a fixed time duration of
+ *   locking using pm_stay().
+ *
+ * Input Parameters:
+ *   timer_type - the type of the timer which determines the callback
+ *   timer_interval - duration of the timer
+ *
+ * Returned Value:
+ *   None.
+ *
+ ****************************************************************************/
+
+void pm_set_timer(int pm_timer_type, size_t timer_interval)
+{
+	/* Set the global variables to trigger the appropriate timer */
+	g_pm_timer.timer_type = pm_timer_type;
+	g_pm_timer.timer_interval = timer_interval;
+
+	/* Wakeup timer will be triggered at the time of sleep, otherwise trigger now. */
+	if (pm_timer_type != PM_WAKEUP_TIMER) {
+		up_set_pm_timer();
+	}
+	return;
 }
 
 /****************************************************************************


### PR DESCRIPTION
os: Add functionality for timed PM state locking
-Add a timer API to pm layer that allows setting timed callbacks.
-This is currently used to relax PM state transition after a certain
time of locking.
-It may be expanded to other timed callbacks in the future

apps/examples/power: Fix bad sleep duration macro for power daemon
-Power daemon sleep duration value should be in seconds instead
of microseconds.

os/board/rtl8730e/src/component/bluetooth: Keep board in PM_NORMAL state when onboarding is triggered
-Once onboarding process is triggered by the user from the ST App, board
should stay in PM_NORMAL state for 10 minutes to allow successful completion

Signed-off-by: Amogh Hassija [a.hassija@samsung.com](mailto:a.hassija@samsung.com)