### PR TITLE
arm/src/amebasmart,drivers/audio: align alc1019 buffer size with DMA page size

### DIFF
--- a/os/arch/arm/src/amebasmart/amebasmart_i2s.c
+++ b/os/arch/arm/src/amebasmart/amebasmart_i2s.c
@@ -116,8 +116,8 @@
 
 #define OVER_SAMPLE_RATE (384U)
 
-#define I2S_DMA_PAGE_SIZE 1024 /* 4 ~ 16384, set to a factor of APB size */
-#define I2S_DMA_PAGE_NUM 4	   /* Vaild number is 2~4 */
+#define I2S_DMA_PAGE_SIZE 2048	/* 4 ~ 16384, set to a factor of APB size */
+#define I2S_DMA_PAGE_NUM 4	/* Vaild number is 2~4 */
 
 struct amebasmart_buffer_s {
 	struct amebasmart_buffer_s *flink; /* Supports a singly linked list */

--- a/os/drivers/audio/alc1019.c
+++ b/os/drivers/audio/alc1019.c
@@ -47,8 +47,12 @@
 #define ALC1019_I2S_TIMEOUT_MS 200
 
 /* Default configuration values */
+
+/*
+ * It's good to match the buffer size with i2s DMA page size
+ */
 #ifndef CONFIG_ALC1019_BUFFER_SIZE
-#define CONFIG_ALC1019_BUFFER_SIZE       4096
+#define CONFIG_ALC1019_BUFFER_SIZE       2048
 #endif
 
 #ifndef CONFIG_ALC1019_NUM_BUFFERS

--- a/os/include/tinyara/audio/alc1019.h
+++ b/os/include/tinyara/audio/alc1019.h
@@ -43,8 +43,6 @@
  *   will send to the I2S driver before any have completed.
  * CONFIG_ALC1019_MSG_PRIO - Priority of messages sent to the ALC1019 worker
  *   thread.
- * CONFIG_ALC1019_BUFFER_SIZE - Preferred buffer size
- * CONFIG_ALC1019_NUM_BUFFERS - Preferred number of buffers
  * CONFIG_ALC1019_WORKER_STACKSIZE - Stack size to use when creating the
  *   ALC1019 worker thread.
  */
@@ -83,14 +81,6 @@
 
 #ifndef CONFIG_ALC1019_MSG_PRIO
 #define CONFIG_ALC1019_MSG_PRIO          1
-#endif
-
-#ifndef CONFIG_ALC1019_BUFFER_SIZE
-#define CONFIG_ALC1019_BUFFER_SIZE       8192
-#endif
-
-#ifndef CONFIG_ALC1019_NUM_BUFFERS
-#define CONFIG_ALC1019_NUM_BUFFERS       4
 #endif
 
 #ifndef CONFIG_ALC1019_WORKER_STACKSIZE


### PR DESCRIPTION


Set alc1019 apb buffer size to be equal to i2s DMA page size. Also increase i2s DMA page size to 2048