### PR TITLE
os/arch/arm/src/amebasmart, os/board/rtl8730e: Update critical zone API usage for SMP

### DIFF
--- a/os/arch/arm/src/amebasmart/Make.defs
+++ b/os/arch/arm/src/amebasmart/Make.defs
@@ -191,7 +191,7 @@ ifeq ($(CONFIG_ARCH_FPU),y)
 endif
 
 ifeq ($(CONFIG_SMP),y)
-  CMN_CSRCS += arm_cpuindex.c arm_cpustart.c arm_cpupause.c arm_cpuidlestack.c arm_cpuflash.c
+  CMN_CSRCS += arm_cpuindex.c arm_cpustart.c arm_cpupause.c arm_cpuidlestack.c arm_cpugating.c
   CMN_CSRCS += arm_scu.c
 endif
 

--- a/os/arch/arm/src/amebasmart/amebasmart_i2c.c
+++ b/os/arch/arm/src/amebasmart/amebasmart_i2c.c
@@ -470,7 +470,7 @@ static inline int amebasmart_i2c_sem_waitdone(FAR struct amebasmart_i2c_priv_s *
 	irqstate_t flags;
 	int ret;
 
-	flags = irqsave();
+	flags = enter_critical_section();
 
 	/* Enable I2C interrupts */
 	up_enable_irq(priv->config->irq);
@@ -533,7 +533,7 @@ static inline int amebasmart_i2c_sem_waitdone(FAR struct amebasmart_i2c_priv_s *
 
 	up_disable_irq(priv->config->irq);
 
-	irqrestore(flags);
+	leave_critical_section(flags);
 	return ret;
 }
 #else
@@ -1156,14 +1156,14 @@ FAR struct i2c_dev_s *up_i2cinitialize(int port)
 /* Initialize private data for the first time, increment reference count,
 	* power-up hardware and configure GPIOs.
 	*/
-	flags = irqsave();
+	flags = enter_critical_section();
 
 	if ((volatile int)priv->refs++ == 0) {
 		amebasmart_i2c_sem_init(priv);
 		amebasmart_i2c_init(priv);
 	}
 
-	irqrestore(flags);
+	leave_critical_section(flags);
 
 	return (struct i2c_dev_s *)priv;
 }
@@ -1189,14 +1189,14 @@ int up_i2cuninitialize(FAR struct i2c_dev_s *dev)
 		return ERROR;
 	}
 
-	flags = irqsave();
+	flags = enter_critical_section();
 
 	if (--priv->refs > 0) {
 		irqrestore(flags);
 		return OK;
 	}
 
-	irqrestore(flags);
+	leave_critical_section(flags);
 
 	/* Disable power and other HW resource (GPIO's) */
 

--- a/os/arch/arm/src/amebasmart/amebasmart_spi.c
+++ b/os/arch/arm/src/amebasmart/amebasmart_spi.c
@@ -1390,7 +1390,7 @@ FAR struct spi_dev_s *amebasmart_spibus_initialize(int bus)
 {
 	FAR struct amebasmart_spidev_s *priv = NULL;
 
-	irqstate_t flags = irqsave();
+	irqstate_t flags = enter_critical_section();
 	
 	if (bus == 0) {
 		/* Select SPI0 */
@@ -1424,7 +1424,7 @@ FAR struct spi_dev_s *amebasmart_spibus_initialize(int bus)
 		return NULL;
 	}
 
-	irqrestore(flags);
+	leave_critical_section(flags);
 
 	return (FAR struct spi_dev_s *)priv;
 }
@@ -1605,7 +1605,7 @@ FAR struct spi_dev_s *up_spiinitialize(int port)
 {
 	FAR struct amebasmart_spidev_s *priv = NULL;
 
-	irqstate_t flags = irqsave();
+	irqstate_t flags = enter_critical_section();
 
 	if (port == 0) {
 		/* Select SPI0 */
@@ -1638,7 +1638,7 @@ FAR struct spi_dev_s *up_spiinitialize(int port)
 		return NULL;
 	}
 
-	irqrestore(flags);
+	leave_critical_section(flags);
 
 	return (FAR struct spi_dev_s *)priv;
 }

--- a/os/arch/arm/src/amebasmart/amebasmart_timer_lowerhalf.c
+++ b/os/arch/arm/src/amebasmart/amebasmart_timer_lowerhalf.c
@@ -348,7 +348,7 @@ static void amebasmart_gpt_setcallback(struct timer_lowerhalf_s *lower, tccb_t c
 	struct amebasmart_gpt_lowerhalf_s *priv = (struct amebasmart_gpt_lowerhalf_s *)lower;
 	DEBUGASSERT(priv);
 	if (priv) {
-		irqstate_t flags = irqsave();
+		irqstate_t flags = enter_critical_section();
 
 		/* Save the new callback */
 		priv->callback = callback;
@@ -363,7 +363,7 @@ static void amebasmart_gpt_setcallback(struct timer_lowerhalf_s *lower, tccb_t c
 			priv->obj.hid = 0;
 		}
 
-		irqrestore(flags);
+		leave_critical_section(flags);
 	}
 }
 

--- a/os/arch/arm/src/armv7-a/arm_gicv2.c
+++ b/os/arch/arm/src/armv7-a/arm_gicv2.c
@@ -127,7 +127,7 @@ void arm_gic0_initialize(void)
   DEBUGVERIFY(irq_attach(GIC_IRQ_SGI1, arm_start_handler, NULL));
   DEBUGVERIFY(irq_attach(GIC_IRQ_SGI2, arm_pause_handler, NULL));
 #ifdef CONFIG_CPU_GATING
-  DEBUGVERIFY(irq_attach(GIC_IRQ_SGI3, arm_flash_handler, NULL));
+  DEBUGVERIFY(irq_attach(GIC_IRQ_SGI3, arm_gating_handler, NULL));
 #endif
 #endif
 

--- a/os/arch/arm/src/armv7-a/gic.h
+++ b/os/arch/arm/src/armv7-a/gic.h
@@ -842,7 +842,7 @@ int arm_pause_handler(int irq, void *context, void *arg);
 #endif
 
 /****************************************************************************
- * Name: arm_pause_handler
+ * Name: arm_gating_handler
  *
  * Description:
  *   This is the handler for SGI3.  It performs the following operations:
@@ -862,7 +862,7 @@ int arm_pause_handler(int irq, void *context, void *arg);
  ****************************************************************************/
 
 #if (defined(CONFIG_SMP) && defined(CONFIG_CPU_GATING))
-int arm_flash_handler(int irq, void *context, void *arg);
+int arm_gating_handler(int irq, void *context, void *arg);
 #endif
 
 /****************************************************************************

--- a/os/board/rtl8730e/src/component/os_dep/device_lock.c
+++ b/os/board/rtl8730e/src/component/os_dep/device_lock.c
@@ -22,14 +22,22 @@ static _mutex device_mutex[RT_DEV_LOCK_MAX];
 static void device_mutex_init(RT_DEV_LOCK_E device)
 {
 	if (!DEVICE_MUTEX_IS_INIT(device)) {
+#ifdef CONFIG_PLATFORM_TIZENRT_OS
+		irqstate_t flags = enter_critical_section();
+#else
 		_lock lock;
 		_irqL irqL;
 		rtw_enter_critical(&lock, &irqL);
+#endif
 		if (!DEVICE_MUTEX_IS_INIT(device)) {
 			rtw_mutex_init(&device_mutex[device]);
 			DEVICE_MUTEX_SET_INIT(device);
 		}
+#ifdef CONFIG_PLATFORM_TIZENRT_OS
+		leave_critical_section(flags);
+#else
 		rtw_exit_critical(&lock, &irqL);
+#endif
 	}
 }
 
@@ -37,14 +45,22 @@ static void device_mutex_init(RT_DEV_LOCK_E device)
 void device_mutex_free(RT_DEV_LOCK_E device)
 {
 	if (DEVICE_MUTEX_IS_INIT(device)) {
+#ifdef CONFIG_PLATFORM_TIZENRT_OS
+		irqstate_t flags = enter_critical_section();
+#else
 		_lock lock;
 		_irqL irqL;
 		rtw_enter_critical(&lock, &irqL);
+#endif
 		if (DEVICE_MUTEX_IS_INIT(device)) {
 			rtw_mutex_free(&device_mutex[device]);
 			DEVICE_MUTEX_CLR_INIT(device);
 		}
+#ifdef CONFIG_PLATFORM_TIZENRT_OS
+		leave_critical_section(flags);
+#else
 		rtw_exit_critical(&lock, &irqL);
+#endif
 	}
 }
 

--- a/os/board/rtl8730e/src/component/os_dep/osdep_service_critical.h
+++ b/os/board/rtl8730e/src/component/os_dep/osdep_service_critical.h
@@ -26,6 +26,7 @@ typedef void	            *_lock;
 typedef unsigned long		_irqL;
 
 /*************************** SchedulerControl *******************************/
+#ifndef CONFIG_PLATFORM_TIZENRT_OS
 /**
  * @brief  This function marks the start of a critical code region.
  * 		   Preemptive context switches cannot occur when in a critical region.
@@ -36,7 +37,8 @@ typedef unsigned long		_irqL;
  * so must be used with care!
  */
 void	rtw_enter_critical(_lock *plock, _irqL *pirqL);
-
+#endif
+#ifndef CONFIG_PLATFORM_TIZENRT_OS
 /**
  * @brief  This function marks end of a critical code region. Preemptive context
  * switches cannot occur when in a critical region.
@@ -47,6 +49,7 @@ void	rtw_enter_critical(_lock *plock, _irqL *pirqL);
  * so must be used with care!
  */
 void	rtw_exit_critical(_lock *plock, _irqL *pirqL);
+#endif
 
 /**
  * @brief  This function obtains a spin lock semaphore.
@@ -130,7 +133,4 @@ void	rtw_spin_unlock(_lock *plock);
 #ifdef __cplusplus
 }
 #endif
-// void save_and_cli(void);
-// void restore_flags(void);
-// void cli(void);
 #endif

--- a/os/board/rtl8730e/src/component/wifi/inic/inic_ipc_host_trx.c
+++ b/os/board/rtl8730e/src/component/wifi/inic/inic_ipc_host_trx.c
@@ -78,11 +78,19 @@ struct skb_info *host_skb_info;
  */
 static sint inic_enqueue_recvbuf(struct host_recv_buf *precvbuf, _queue *queue)
 {
+#ifdef CONFIG_PLATFORM_TIZENRT_OS
+	irqstate_t flags = enter_critical_section();
+#else
 	_irqL irqL;
 
 	rtw_enter_critical(&queue->lock, &irqL);
+#endif
 	rtw_list_insert_tail(&precvbuf->list, get_list_head(queue));
+#ifdef CONFIG_PLATFORM_TIZENRT_OS
+	leave_critical_section(flags);
+#else
 	rtw_exit_critical(&queue->lock, &irqL);
+#endif
 
 	return _SUCCESS;
 }
@@ -94,11 +102,16 @@ static sint inic_enqueue_recvbuf(struct host_recv_buf *precvbuf, _queue *queue)
  */
 static struct host_recv_buf *inic_dequeue_recvbuf(_queue *queue)
 {
-	_irqL irqL;
 	struct host_recv_buf *precvbuf;
 	_list *plist, *phead;
 
+#ifdef CONFIG_PLATFORM_TIZENRT_OS
+	irqstate_t flags = enter_critical_section();
+#else
+	_irqL irqL;
+
 	rtw_enter_critical(&queue->lock, &irqL);
+#endif
 
 	if (rtw_queue_empty(queue) == _TRUE) {
 		precvbuf = NULL;
@@ -109,7 +122,11 @@ static struct host_recv_buf *inic_dequeue_recvbuf(_queue *queue)
 		rtw_list_delete(&precvbuf->list);
 	}
 
+#ifdef CONFIG_PLATFORM_TIZENRT_OS
+	leave_critical_section(flags);
+#else
 	rtw_exit_critical(&queue->lock, &irqL);
+#endif
 
 	return precvbuf;
 }


### PR DESCRIPTION
- Change to use enter/leave_critical_section instead of irqsave/irqrestore, for both arch and driver layer
- Reduce overhead for critical zone implementation in porting layer
- Driver Features verification pending due to several logic crashes
- Related PR: https://github.com/Samsung/TizenRT/pull/6049