### PR TITLE
external/mbedtls/config.h: Enable MBEDTLS_AES_ROM_TABLES

### DIFF
--- a/external/include/mbedtls/config.h
+++ b/external/include/mbedtls/config.h
@@ -467,7 +467,7 @@
  *
  * Uncomment this macro to store the AES tables in ROM.
  */
-//#define MBEDTLS_AES_ROM_TABLES
+#define MBEDTLS_AES_ROM_TABLES
 
 /**
  * \def MBEDTLS_CAMELLIA_SMALL_MEMORY


### PR DESCRIPTION
If MBEDTLS_AES_ROM_TABLES is disabled, aes_gen_tabels() calculate S-Box table and save it in the static buffers. 
However, S-Box table is unchanged unless the seed is changed, and there was no operation to change the seed. 
Therefore, this commit enables MBEDTLS_AES_ROM_TABLES to save S-Box tables as const (to remove unnecessary static memory)