### PR TITLE
os/pm/Kconfig: Changes default values of state change threshold count

### DIFF
--- a/os/include/tinyara/pm/pm.h
+++ b/os/include/tinyara/pm/pm.h
@@ -200,7 +200,7 @@
 #endif
 
 #ifndef CONFIG_PM_IDLEENTER_COUNT
-#define CONFIG_PM_IDLEENTER_COUNT     30	/* Thirty IDLE slices to enter
+#define CONFIG_PM_IDLEENTER_COUNT     20	/* 20 IDLE slices to enter
 											 * IDLE mode from normal
 											 */
 #endif
@@ -218,7 +218,7 @@
 #endif
 
 #ifndef CONFIG_PM_STANDBYENTER_COUNT
-#define CONFIG_PM_STANDBYENTER_COUNT  50	/* Fifty IDLE slices to enter
+#define CONFIG_PM_STANDBYENTER_COUNT  20	/* 20 IDLE slices to enter
 											 * STANDBY mode from IDLE
 											 */
 #endif
@@ -236,7 +236,7 @@
 #endif
 
 #ifndef CONFIG_PM_SLEEPENTER_COUNT
-#define CONFIG_PM_SLEEPENTER_COUNT    70	/* 70 IDLE slices to enter SLEEP
+#define CONFIG_PM_SLEEPENTER_COUNT    20	/* 20 IDLE slices to enter SLEEP
 											 * mode from STANDBY
 											 */
 #endif

--- a/os/pm/Kconfig
+++ b/os/pm/Kconfig
@@ -136,7 +136,7 @@ config PM_IDLEENTER_THRESH
 	int "PM IDLE enter threshold"
 	default 1
 	---help---
-		State changes then occur when the weight activity account crosses
+		State changes occur when the weight activity account crosses
 		threshold values for certain periods of time (time slice count).
 
 			CONFIG_PM_xxxENTER_THRESH is the threshold value for entering state xxx.
@@ -151,7 +151,7 @@ config PM_IDLEEXIT_THRESH
 	int "PM IDLE exit threshold"
 	default 2
 	---help---
-		State changes then occur when the weight activity account crosses
+		State changes occur when the weight activity account crosses
 		threshold values for certain periods of time (time slice count).
 
 			CONFIG_PM_xxxENTER_THRESH is the threshold value for entering state xxx.
@@ -164,9 +164,9 @@ config PM_IDLEEXIT_THRESH
 
 config PM_IDLEENTER_COUNT
 	int "PM IDLE enter count"
-	default 30
+	default 20
 	---help---
-		State changes then occur when the weight activity account crosses
+		State changes occur when the weight activity account crosses
 		threshold values for certain periods of time (time slice count).
 
 			CONFIG_PM_xxxENTER_THRESH is the threshold value for entering state xxx.
@@ -181,7 +181,7 @@ config PM_STANDBYENTER_THRESH
 	int "PM STANDBY enter threshold"
 	default 1
 	---help---
-		State changes then occur when the weight activity account crosses
+		State changes occur when the weight activity account crosses
 		threshold values for certain periods of time (time slice count).
 
 			CONFIG_PM_xxxENTER_THRESH is the threshold value for entering state xxx.
@@ -196,7 +196,7 @@ config PM_STANDBYEXIT_THRESH
 	int "PM STANDBY exit threshold"
 	default 2
 	---help---
-		State changes then occur when the weight activity account crosses
+		State changes occur when the weight activity account crosses
 		threshold values for certain periods of time (time slice count).
 
 			CONFIG_PM_xxxENTER_THRESH is the threshold value for entering state xxx.
@@ -209,9 +209,9 @@ config PM_STANDBYEXIT_THRESH
 
 config PM_STANDBYENTER_COUNT
 	int "PM STANDBY enter count"
-	default 50
+	default 20
 	---help---
-		State changes then occur when the weight activity account crosses
+		State changes occur when the weight activity account crosses
 		threshold values for certain periods of time (time slice count).
 
 			CONFIG_PM_xxxENTER_THRESH is the threshold value for entering state xxx.
@@ -226,7 +226,7 @@ config PM_SLEEPENTER_THRESH
 	int "PM SLEEP enter threshold"
 	default 1
 	---help---
-		State changes then occur when the weight activity account crosses
+		State changes occur when the weight activity account crosses
 		threshold values for certain periods of time (time slice count).
 
 			CONFIG_PM_xxxENTER_THRESH is the threshold value for entering state xxx.
@@ -241,7 +241,7 @@ config PM_SLEEPEXIT_THRESH
 	int "PM SLEEP exit threshold"
 	default 2
 	---help---
-		State changes then occur when the weight activity account crosses
+		State changes occur when the weight activity account crosses
 		threshold values for certain periods of time (time slice count).
 
 			CONFIG_PM_xxxENTER_THRESH is the threshold value for entering state xxx.
@@ -254,9 +254,9 @@ config PM_SLEEPEXIT_THRESH
 
 config PM_SLEEPENTER_COUNT
 	int "PM SLEEP enter count"
-	default 70
+	default 20
 	---help---
-		State changes then occur when the weight activity account crosses
+		State changes occur when the weight activity account crosses
 		threshold values for certain periods of time (time slice count).
 
 			CONFIG_PM_xxxENTER_THRESH is the threshold value for entering state xxx.


### PR DESCRIPTION
- lower the threshold from the current total transition time of 15 seconds which is too much to wait for
- Also board does not go to sleep if the total threshold time is more than 10 seconds
- This is a heuristic solution
- The threshold count for different states have been changed from (3,5,7) to (2,2,2)