### PR TITLE
os/board/rtl8730e: Add_BLE_indication_callback

### DIFF
--- a/framework/include/ble_manager/ble_server.h
+++ b/framework/include/ble_manager/ble_server.h
@@ -45,6 +45,7 @@ typedef enum {
 	BLE_SERVER_ATTR_CB_READING,
 	BLE_SERVER_ATTR_CB_WRITING_NO_RSP,
 	BLE_SERVER_ATTR_CB_CCCD,
+	BLE_SERVER_ATTR_CB_INDICATE,
 } ble_server_attr_cb_type_e;
 
 typedef enum {

--- a/os/board/rtl8720e/src/component/bluetooth/example/ble_peripheral/ble_tizenrt_service.c
+++ b/os/board/rtl8720e/src/component/bluetooth/example/ble_peripheral/ble_tizenrt_service.c
@@ -146,7 +146,7 @@ T_APP_RESULT ble_tizenrt_srv_callback(uint8_t event, void *p_data)
             {
             	trble_server_cb_t p_func = p_cha_info->cb;
                 p_func(TRBLE_ATTR_CB_READING, p_read_ind->conn_handle,
-                                                        p_cha_info->abs_handle, p_cha_info->arg);
+                                                        p_cha_info->abs_handle, p_cha_info->arg, 0, 0);
             } else {
                 debug_print("NULL read callback abs_handle 0x%x \n", p_cha_info->abs_handle);
             }
@@ -182,7 +182,7 @@ T_APP_RESULT ble_tizenrt_srv_callback(uint8_t event, void *p_data)
                     {
                         trble_server_cb_t p_func = p_cha_info->cb;
                         p_func(TRBLE_ATTR_CB_WRITING, p_write_ind->conn_handle,
-                                                                p_cha_info->abs_handle, p_cha_info->arg);
+                                                                p_cha_info->abs_handle, p_cha_info->arg, 0, 0);
                     } else {
                         debug_print("NULL write callback abs_handle 0x%x \n", p_cha_info->abs_handle);
                     }
@@ -195,7 +195,7 @@ T_APP_RESULT ble_tizenrt_srv_callback(uint8_t event, void *p_data)
                     {
                         trble_server_cb_t p_func = p_cha_info->cb;
                         p_func(TRBLE_ATTR_CB_WRITING_NO_RSP, p_write_ind->conn_handle,
-                                                                p_cha_info->abs_handle, p_cha_info->arg);
+                                                                p_cha_info->abs_handle, p_cha_info->arg, 0, 0);
                     } else {
                         debug_print("NULL write callback abs_handle 0x%x \n", p_cha_info->abs_handle);
                     }

--- a/os/board/rtl8721csm/src/component/common/bluetooth/realtek/sdk/example/ble_peripheral/ble_tizenrt_app.c
+++ b/os/board/rtl8721csm/src/component/common/bluetooth/realtek/sdk/example/ble_peripheral/ble_tizenrt_app.c
@@ -242,7 +242,7 @@ void  ble_tizenrt_handle_callback_msg(T_TIZENRT_APP_CALLBACK_MSG callback_msg)
             {
                 debug_print("Profile callback \n");
                 trble_server_cb_t pfunc = profile->cb;
-                pfunc(profile->type, profile->conn_id, profile->att_handle, profile->arg);
+                pfunc(profile->type, profile->conn_id, profile->att_handle, profile->arg, 0 , 0);
             } else {
                 debug_print("NULL profile callback \n");
             }
@@ -757,7 +757,7 @@ T_APP_RESULT ble_tizenrt_app_profile_callback(T_SERVER_ID service_id, void *p_da
                 {
                     trble_server_cb_t p_func = p_cha_info->cb;
                     p_func(TRBLE_ATTR_CB_READING, p_tizenrt_cb_data->conn_id,
-                                                            p_cha_info->abs_handle, p_cha_info->arg);
+                                                            p_cha_info->abs_handle, p_cha_info->arg, 0 , 0);
                 } else {
                     debug_print("NULL read callback abs_handle 0x%x \n", p_cha_info->abs_handle);
                 }
@@ -784,7 +784,7 @@ T_APP_RESULT ble_tizenrt_app_profile_callback(T_SERVER_ID service_id, void *p_da
                         {
                             trble_server_cb_t p_func = p_cha_info->cb;
                             p_func(TRBLE_ATTR_CB_WRITING, p_tizenrt_cb_data->conn_id,
-                                                                    p_cha_info->abs_handle, p_cha_info->arg);
+                                                                    p_cha_info->abs_handle, p_cha_info->arg, 0 , 0);
                         } else {
                             debug_print("NULL write callback abs_handle 0x%x \n", p_cha_info->abs_handle);
                         }
@@ -797,7 +797,7 @@ T_APP_RESULT ble_tizenrt_app_profile_callback(T_SERVER_ID service_id, void *p_da
                         {
                             trble_server_cb_t p_func = p_cha_info->cb;
                             p_func(TRBLE_ATTR_CB_WRITING_NO_RSP, p_tizenrt_cb_data->conn_id,
-                                                                    p_cha_info->abs_handle, p_cha_info->arg);
+                                                                    p_cha_info->abs_handle, p_cha_info->arg, 0 , 0);
                         } else {
                             debug_print("NULL write callback abs_handle 0x%x \n", p_cha_info->abs_handle);
                         }

--- a/os/board/rtl8721csm/src/component/common/bluetooth/realtek/sdk/example/ble_scatternet/ble_tizenrt_scatternet_app.c
+++ b/os/board/rtl8721csm/src/component/common/bluetooth/realtek/sdk/example/ble_scatternet/ble_tizenrt_scatternet_app.c
@@ -245,7 +245,7 @@ void ble_tizenrt_scatternet_handle_callback_msg(T_TIZENRT_APP_CALLBACK_MSG callb
             {
                 debug_print("Profile callback \n");
                 trble_server_cb_t pfunc = profile->cb;
-                pfunc(profile->type, profile->conn_id, profile->att_handle, profile->arg);
+                pfunc(profile->type, profile->conn_id, profile->att_handle, profile->arg, 0 , 0);
             } else {
                 debug_print("NULL profile callback \n");
             }
@@ -1910,7 +1910,7 @@ T_APP_RESULT ble_tizenrt_scatternet_app_profile_callback(T_SERVER_ID service_id,
                 if (p_cha_info->cb)
                 {
                     trble_server_cb_t p_func = p_cha_info->cb;
-                    p_func(TRBLE_ATTR_CB_CCCD, p_tizenrt_cb_data->conn_id, p_cha_info->abs_handle, p_tizenrt_cb_data->val);
+                    p_func(TRBLE_ATTR_CB_CCCD, p_tizenrt_cb_data->conn_id, p_cha_info->abs_handle, p_cha_info->arg, 0, 0);
                 }
                 break;
             }
@@ -1926,7 +1926,7 @@ T_APP_RESULT ble_tizenrt_scatternet_app_profile_callback(T_SERVER_ID service_id,
                 {
                     trble_server_cb_t p_func = p_cha_info->cb;
                     p_func(TRBLE_ATTR_CB_READING, p_tizenrt_cb_data->conn_id,
-                                                            p_cha_info->abs_handle, p_cha_info->arg);
+                                                            p_cha_info->abs_handle, p_cha_info->arg, 0, 0);
                 } else {
                     debug_print("NULL read callback abs_handle 0x%x \n", p_cha_info->abs_handle);
                 }
@@ -1953,7 +1953,7 @@ T_APP_RESULT ble_tizenrt_scatternet_app_profile_callback(T_SERVER_ID service_id,
                         {
                             trble_server_cb_t p_func = p_cha_info->cb;
                             p_func(TRBLE_ATTR_CB_WRITING, p_tizenrt_cb_data->conn_id,
-                                                                    p_cha_info->abs_handle, p_cha_info->arg);
+                                                                    p_cha_info->abs_handle, p_cha_info->arg, 0, 0);
                         } else {
                             debug_print("NULL write callback abs_handle 0x%x \n", p_cha_info->abs_handle);
                         }
@@ -1966,7 +1966,7 @@ T_APP_RESULT ble_tizenrt_scatternet_app_profile_callback(T_SERVER_ID service_id,
                         {
                             trble_server_cb_t p_func = p_cha_info->cb;
                             p_func(TRBLE_ATTR_CB_WRITING_NO_RSP, p_tizenrt_cb_data->conn_id,
-                                                                    p_cha_info->abs_handle, p_cha_info->arg);
+                                                                    p_cha_info->abs_handle, p_cha_info->arg, 0, 0);
                         } else {
                             debug_print("NULL write callback abs_handle 0x%x \n", p_cha_info->abs_handle);
                         }

--- a/os/board/rtl8730e/src/component/bluetooth/api/rtk_stack/rtk_stack_gatts.c
+++ b/os/board/rtl8730e/src/component/bluetooth/api/rtk_stack/rtk_stack_gatts.c
@@ -26,7 +26,7 @@
 #include <profile_server.h>
 #endif
 
-static rtk_bt_gatts_app_priv_t *g_rtk_bt_gatts_priv = NULL;
+rtk_bt_gatts_app_priv_t *g_rtk_bt_gatts_priv = NULL;
 
 static struct rtk_bt_gatt_service *bt_stack_gatts_find_service_node_by_server_id(T_SERVER_ID server_id);
 static T_APP_RESULT bt_stack_gatts_attr_read_cb(

--- a/os/board/rtl8730e/src/component/bluetooth/example/ble_peripheral/ble_tizenrt_server.c
+++ b/os/board/rtl8730e/src/component/bluetooth/example/ble_peripheral/ble_tizenrt_server.c
@@ -580,9 +580,6 @@ trble_result_e rtw_ble_server_start_adv(void)
 				debug_print("get conn info fail \n");
 				return TRBLE_FAIL;
 			}
-
-            if(conn_info.role == RTK_BT_LE_ROLE_SLAVE)
-                return TRBLE_FAIL;
         }
     }
 

--- a/os/include/tinyara/net/if/ble.h
+++ b/os/include/tinyara/net/if/ble.h
@@ -248,10 +248,11 @@ typedef enum {
 	TRBLE_ATTR_CB_WRITING,
 	TRBLE_ATTR_CB_READING,
 	TRBLE_ATTR_CB_WRITING_NO_RSP,
-	TRBLE_ATTR_CB_CCCD
+	TRBLE_ATTR_CB_CCCD,
+	TRBLE_ATTR_CB_INDICATE
 } trble_attr_cb_type_e;
 
-typedef void (*trble_server_cb_t)(trble_attr_cb_type_e type, trble_conn_handle con_handle, trble_attr_handle handle, void *arg);
+typedef void (*trble_server_cb_t)(trble_attr_cb_type_e type, trble_conn_handle con_handle, trble_attr_handle handle, void *arg, uint16_t result, uint16_t pending);
 
 typedef enum {
 	TRBLE_ATTR_PROP_NONE = 0x00,


### PR DESCRIPTION
- added indication callback to inform the application layer of the current indication's outcome and the number of pending indications.
- fixed wrongly used parameter in p_func in TP1x that causes fault when CCCD is updated