### PR TITLE
os/pm: Adds PM functionalities for sending Wifi keep alive

### DIFF
--- a/os/arch/arm/src/amebasmart/amebasmart_pmhelpers.c
+++ b/os/arch/arm/src/amebasmart/amebasmart_pmhelpers.c
@@ -130,7 +130,7 @@ void pg_timer_int_handler(void *Data)
 			break;
 	}
 	// Reset the global struct
-	g_pm_timer.timer_type = 0;
+	g_pm_timer.timer_type = PM_NO_TIMER;
 	g_pm_timer.timer_interval = 0;
 }
 

--- a/os/include/tinyara/pm/pm.h
+++ b/os/include/tinyara/pm/pm.h
@@ -244,6 +244,9 @@
 /* Defines max length of device driver name for PM callback. */
 #define MAX_PM_CALLBACK_NAME    32
 
+/* Defines default sleep duration */
+#define DEFAULT_PM_SLEEP_DURATION    10000000 /* 10 sec in microsecond*/
+
 #define PM_LOCK_PATH					"/proc/power/domains/0/pm_lock"
 #define PM_UNLOCK_PATH					"/proc/power/domains/0/pm_unlock"
 #ifdef CONFIG_PM_DVFS
@@ -304,6 +307,7 @@ enum pm_state_e {
 };
 
 enum pm_timer_type_e {
+	PM_NO_TIMER = 0,
 	PM_WAKEUP_TIMER = 1,
 	PM_LOCK_TIMER = 2,
 	/* Scope for future expansion, up to 8 timer types can be supported */
@@ -312,6 +316,7 @@ enum pm_timer_type_e {
 struct pm_timer_s {
 	uint8_t timer_type;		/* Bits here are set according to the timer that is to be used */
 	uint32_t timer_interval;	/* The interval for whichever timer is to be used */
+	clock_t last_wifi_alive_send_time;       /* Time tick of the last wifi keep alive signal sent time */
 };
 
 /* This structure contain pointers callback functions in the driver.  These
@@ -547,6 +552,24 @@ void pm_relax(int domain, enum pm_state_e state);
  ****************************************************************************/
 
 void pm_set_timer(int timer_type, size_t timer_interval);
+
+/****************************************************************************
+ * Name: pm_adjust_sleep_duration
+ *
+ * Description:
+ *   This function is called just before sleep to calculate exact required
+ *   sleep duration "if needed". This function is used to timely wake up board
+ *   so that we can sent the next wifi keep alive signal.
+ *
+ * Input Parameters:
+ *   None
+ *
+ * Returned Value:
+ *   None.
+ *
+ ****************************************************************************/
+
+void pm_adjust_sleep_duration(void);
 
 /****************************************************************************
  * Name: pm_staycount

--- a/os/pm/Kconfig
+++ b/os/pm/Kconfig
@@ -164,7 +164,7 @@ config PM_IDLEEXIT_THRESH
 
 config PM_IDLEENTER_COUNT
 	int "PM IDLE enter count"
-	default 20
+	default 10
 	---help---
 		State changes occur when the weight activity account crosses
 		threshold values for certain periods of time (time slice count).
@@ -209,7 +209,7 @@ config PM_STANDBYEXIT_THRESH
 
 config PM_STANDBYENTER_COUNT
 	int "PM STANDBY enter count"
-	default 20
+	default 10
 	---help---
 		State changes occur when the weight activity account crosses
 		threshold values for certain periods of time (time slice count).
@@ -254,7 +254,7 @@ config PM_SLEEPEXIT_THRESH
 
 config PM_SLEEPENTER_COUNT
 	int "PM SLEEP enter count"
-	default 20
+	default 10
 	---help---
 		State changes occur when the weight activity account crosses
 		threshold values for certain periods of time (time slice count).

--- a/os/pm/pm_activity.c
+++ b/os/pm/pm_activity.c
@@ -239,6 +239,45 @@ void pm_set_timer(int pm_timer_type, size_t timer_interval)
 }
 
 /****************************************************************************
+ * Name: pm_adjust_sleep_duration
+ *
+ * Description:
+ *   This function is called just before sleep to calculate exact required
+ *   sleep duration "if needed". This function is used to timely wake up board
+ *   so that we can sent the next wifi keep alive signal.
+ *
+ * Input Parameters:
+ *   None
+ *
+ * Returned Value:
+ *   None.
+ *
+ ****************************************************************************/
+
+void pm_adjust_sleep_duration(void)
+{
+	/* This part calculates the new time interval of sleep just before sleep. This part is added
+	*  for correct functioning of sending of wifi keep alive signal. Basically, last_wifi_alive_send_time
+	*  variable stores the last time tick when wifi keep alive signal was sent. Now before sleep, 
+	*  it will calculate how much time has passed after that signal sent and accordingly it will 
+	*  set duration of sleep. So that board can wake up when it is requried to send signal again.
+	* 
+	*  Also, somehow we are unable to send wifi alive signal in this iteration ( because of other priority task
+	*  or very less time for wifi send action). Then also we need to wakeup the board , so that
+	*  system will send wifi alive signal in next iteration. 
+	*/
+	   
+	if (g_pm_timer.timer_type == PM_WAKEUP_TIMER && g_pm_timer.last_wifi_alive_send_time > 0) {
+		uint32_t elapsed_time_after_last_wakeup = (clock_systimer() - g_pm_timer.last_wifi_alive_send_time) * 1000;
+		if (elapsed_time_after_last_wakeup < g_pm_timer.timer_interval) {
+			g_pm_timer.timer_interval -= elapsed_time_after_last_wakeup;
+		}
+	} else if (g_pm_timer.timer_type == PM_NO_TIMER) {
+		pm_set_timer(PM_WAKEUP_TIMER, DEFAULT_PM_SLEEP_DURATION);
+	}
+}
+
+/****************************************************************************
  * Name: pm_relax
  *
  * Description:

--- a/os/pm/pm_changestate.c
+++ b/os/pm/pm_changestate.c
@@ -299,6 +299,13 @@ int pm_changestate(int domain_indx, enum pm_state_e newstate)
 		*/
 		pm_changeall(domain_indx, newstate);
 		pdom->state = newstate;
+		
+		/* Adjusting the sleep duration, so that system can revert to NORMAL
+		*  state when next Wifi keep alive signal is required to be sent. 
+		*/
+		if (newstate == PM_SLEEP) {
+			pm_adjust_sleep_duration();
+		}
 
 	}
 EXIT:


### PR DESCRIPTION
- This commits add methods to help board wake up for sending wifi keep alive signal. It stores time ticks of last time when wifi keep alive signal was sent and accordingly sets the sleep duration of board. So that board can wake up when next signal is supposed to be sent
- power_set_next_wakeup_interval() is added . This can be called from app side just after "wifi keep alive signal was sent" . This will set the WAKE_UP_TIMER again with the required time interval. This function will also store the time tick of the Wifi keep alive signal sent time. This can be used to calculate actual required sleep duration just before sleep.
- power_get_last_wifi_alive_send_time and power_get_current_time can be used to find difference between the time ticks of last wifi keep alive signal sent and now .
- I have also changed the threshold values of entering each state as (10 + 10 + 10)  , which is total of 3 sec from Normal to sleep. It is still a heuristic solution . This has been done to let board able to sleep some time before waking up after 10 sec.