### PR TITLE
os/arch/arm/src/amebasmart: Fix SPI clock divider to be even number

### DIFF
--- a/os/board/rtl8730e/src/component/mbed/targets/hal/rtl8730e/spi_api.c
+++ b/os/board/rtl8730e/src/component/mbed/targets/hal/rtl8730e/spi_api.c
@@ -622,16 +622,17 @@ void spi_frequency(spi_t *obj, int hz)
 
 	IpClk = 100000000;
 
-	/*Adjust SCKDV-Parameter to an even number */
-	ClockDivider = IpClk / hz + 1;
-	if ((IpClk % hz) > (u32)(hz / 2)) {
-		ClockDivider++;
+	/* Adjust SCK Divider to an even number */
+	ClockDivider = (u32)(IpClk / hz / 2) * 2;
+
+	if ((IpClk / ClockDivider) > (u32)hz) {
+		ClockDivider += 2;
 	}
+
 	if (ClockDivider >= 0xFFFF) {
-		/*  devider is 16 bits */
+		/* devider is 16 bits */
 		ClockDivider = 0xFFFE;
 	}
-	ClockDivider &= 0xFFFE;     // bit 0 always is 0
 
 	SSI_SetBaudDiv(ssi_adapter->spi_dev, ClockDivider);
 }


### PR DESCRIPTION
Fix the divider to be even, as a requirement of the specs sheet