### PR TITLE
Spi lcd config orientation set

### DIFF
--- a/apps/examples/lcd_test/example_lcd.c
+++ b/apps/examples/lcd_test/example_lcd.c
@@ -124,12 +124,7 @@ static void test_put_area(void)
 	yres = vinfo.yres;
 	printf("xres : %d, yres:%d\n", xres, yres);
 	close(fd);
-
-	#if defined(CONFIG_LCD_PORTRAIT) || defined(CONFIG_LCD_RPORTRAIT)
-		putarea(0, yres - 1, 0, xres - 1, RED);
-	#else
-		putarea(0, xres - 1, 0, yres - 1, RED);
-	#endif
+	putarea(0, yres - 1, 0, xres - 1, RED);
 	/* fill square with side  = OFFSET */
 	putarea(0, OFFSET, 0, OFFSET, WHITE);
 }
@@ -179,11 +174,7 @@ static void test_clear(void)
 	xres = vinfo.xres;
 	yres = vinfo.yres;
 	close(fd);
-	#if defined(CONFIG_LCD_PORTRAIT) || defined(CONFIG_LCD_RPORTRAIT)
-		putarea(0, yres - 1, 0, xres - 1, BLACK);
-	#else
-		putarea(0, xres - 1, 0, yres - 1, BLACK);
-	#endif
+	putarea(0, yres - 1, 0, xres - 1, BLACK);
 }
 
 static void test_init(void)
@@ -218,8 +209,12 @@ static void test_orientation(void)
 	test_put_run();
 
 	sleep(1);
-	/* resolution should be swapped now as orientation is changed*/
-	putarea(0, xres - 1, 0, yres - 1, RED);
+	/* resolution should be swapped now as orientation is changed */
+	#if defined(CONFIG_LCD_PORTRAIT) || defined(CONFIG_LCD_RPORTRAIT)
+		putarea(0, xres - 1, 0, yres - 1, RED);
+	#else
+		putarea(0, yres - 1, 0, xres - 1, RED);
+	#endif
 	/* fill square with side  = OFFSET */
 	putarea(0, OFFSET, 0, OFFSET, WHITE);
 

--- a/os/drivers/lcd/st7789.c
+++ b/os/drivers/lcd/st7789.c
@@ -910,6 +910,17 @@ FAR struct lcd_dev_s *st7789_lcdinitialize(FAR struct spi_dev_s *spi, struct st7
 	st7789_init_cmd(priv);
 	lcd_unlock(priv->spi);
 
+	#if defined(CONFIG_LCD_PORTRAIT)
+		st7789_setorientation(priv, LCD_PORTRAIT);
+	#elif defined(CONFIG_LCD_LANDSCAPE)
+		st7789_setorientation(priv, LCD_LANDSCAPE);
+	#elif defined(CONFIG_LCD_RLANDSCAPE)
+		st7789_setorientation(priv, LCD_RLANDSCAPE);
+	#elif defined(CONFIG_LCD_RPORTRAIT)
+		st7789_setorientation(priv, LCD_RPORTRAIT);
+	#else
+		st7789_setorientation(priv, LCD_LANDSCAPE);
+	#endif
 	return &priv->dev;
 }
 

--- a/os/drivers/lcd/st7789.c
+++ b/os/drivers/lcd/st7789.c
@@ -121,6 +121,14 @@
 #define CONFIG_LCD_ST7789_YRES 320
 #endif
 
+#if !defined(CONFIG_LCD_ST7789_YOFFSET)
+#define CONFIG_LCD_ST7789_YOFFSET 0
+#endif
+
+#if !defined(CONFIG_LCD_ST7789_XOFFSET)
+#define CONFIG_LCD_ST7789_XOFFSET 0
+#endif
+
 #define ST7789_LUT_SIZE    CONFIG_LCD_ST7789_YRES
 
 #if defined(CONFIG_LCD_LANDSCAPE) || defined(CONFIG_LCD_RLANDSCAPE)
@@ -128,11 +136,16 @@
 #define ST7789_YRES       CONFIG_LCD_ST7789_XRES
 #define ST7789_XOFFSET    CONFIG_LCD_ST7789_YOFFSET
 #define ST7789_YOFFSET    CONFIG_LCD_ST7789_XOFFSET
-#else
+#elif defined(CONFIG_LCD_PORTRAIT) || defined(CONFIG_LCD_RPORTRAIT)
 #define ST7789_XRES       CONFIG_LCD_ST7789_XRES
 #define ST7789_YRES       CONFIG_LCD_ST7789_YRES
 #define ST7789_XOFFSET    0
 #define ST7789_YOFFSET    0
+#else
+#define ST7789_XRES       CONFIG_LCD_ST7789_YRES
+#define ST7789_YRES       CONFIG_LCD_ST7789_XRES
+#define ST7789_XOFFSET    CONFIG_LCD_ST7789_YOFFSET
+#define ST7789_YOFFSET    CONFIG_LCD_ST7789_XOFFSET
 #endif
 
 /* Color depth and format */
@@ -782,11 +795,7 @@ static int st7789_init(FAR struct lcd_dev_s *dev)
 		st7789_setorientation(priv, LCD_LANDSCAPE);
 	#endif
 	lcd_lock(priv->spi);
-	#if defined(CONFIG_LCD_PORTRAIT) || defined(CONFIG_LCD_RPORTRAIT)
-		st7789_fill_frame(priv, 0xFFFF, 0, 0, ST7789_XRES, ST7789_YRES);
-	#else
-		st7789_fill_frame(priv, 0xFFFF, 0, 0, ST7789_YRES, ST7789_XRES);
-	#endif
+	st7789_fill_frame(priv, 0xFFFF, 0, 0, ST7789_XRES, ST7789_YRES);
 	lcd_unlock(priv->spi);
 	return OK;
 }


### PR DESCRIPTION
config orientation is being set in st7789_lcdintialize as calling init is not mandatory.