### PR TITLE
os/pm: Enable pm locking after wakeup to send wifi signal

### DIFF
--- a/os/arch/arm/src/amebasmart/amebasmart_pmhelpers.c
+++ b/os/arch/arm/src/amebasmart/amebasmart_pmhelpers.c
@@ -124,6 +124,7 @@ void pg_timer_int_handler(void *Data)
 		case PM_WAKEUP_TIMER:
 			// Switch status back to normal mode after wake up from interrupt
 			pm_activity(PM_IDLE_DOMAIN, 9);
+			pm_stay(PM_IDLE_DOMAIN, PM_NORMAL);
 			break;
 		default:
 			pmdbg("Timer callback triggered without setting timer, Unexpected Error!!!\n");

--- a/os/pm/pm_activity.c
+++ b/os/pm/pm_activity.c
@@ -261,10 +261,6 @@ void pm_adjust_sleep_duration(void)
 	*  variable stores the last time tick when wifi keep alive signal was sent. Now before sleep, 
 	*  it will calculate how much time has passed after that signal sent and accordingly it will 
 	*  set duration of sleep. So that board can wake up when it is requried to send signal again.
-	* 
-	*  Also, somehow we are unable to send wifi alive signal in this iteration ( because of other priority task
-	*  or very less time for wifi send action). Then also we need to wakeup the board , so that
-	*  system will send wifi alive signal in next iteration. 
 	*/
 	   
 	if (g_pm_timer.timer_type == PM_WAKEUP_TIMER && g_pm_timer.last_wifi_alive_send_time > 0) {
@@ -272,9 +268,7 @@ void pm_adjust_sleep_duration(void)
 		if (elapsed_time_after_last_wakeup < g_pm_timer.timer_interval) {
 			g_pm_timer.timer_interval -= elapsed_time_after_last_wakeup;
 		}
-	} else if (g_pm_timer.timer_type == PM_NO_TIMER) {
-		pm_set_timer(PM_WAKEUP_TIMER, DEFAULT_PM_SLEEP_DURATION);
-	}
+	} 
 }
 
 /****************************************************************************
@@ -310,8 +304,9 @@ void pm_relax(int domain, enum pm_state_e state)
 
 	flags = enter_critical_section();
 	DEBUGASSERT(state < PM_COUNT);
-	DEBUGASSERT(pdom->stay[state] > 0);
-	pdom->stay[state]--;
+	if (pdom->stay[state] > 0) {
+		pdom->stay[state]--;
+	}
 	leave_critical_section(flags);
 }
 


### PR DESCRIPTION
- After PM_WAKEUP_TIMER expires , we apply pm_stay() in callback function. This is to ensure that board does not go to sleep before wifi keep alive has been sent. 
- After wifi keep alive has been sent, the funtion that sends it can call set_next_wakeup_interval from pm_procfs that will perform pm_relax() and also set the time for next wakeup , so that board can now go to sleep.
- If we dont lock pm transition after board wakes up , there is a chance that wifi keep alive signal might not be sent and board will go to sleep again. ( This can be due to other high priority task not letting that wifi keep alive send thread run or this can be also if normal to sleep time is very less, board can go to sleep directly without sending wifi signal)