### PR TITLE
os/board/rtl8730e: Fix SOC SVACE warning

### DIFF
--- a/os/board/rtl8730e/src/component/bluetooth/api/rtk_stack/rtk_stack_gattc.c
+++ b/os/board/rtl8730e/src/component/bluetooth/api/rtk_stack/rtk_stack_gattc.c
@@ -1599,11 +1599,14 @@ static void bt_stack_gattc_write_result_cb(uint8_t conn_id, T_GATT_WRITE_TYPE ty
 	rtk_bt_evt_indicate(p_evt, NULL);
 
 end:
-	req_type = p_req->req_type;
-	bt_stack_gattc_free_req(p_req);
-	if (req_type != BT_STACK_GATTC_WRITE_CMD) {
-		bt_stack_gattc_handle_pending_req(conn_id);
+	if (p_req != NULL) {
+		req_type = p_req->req_type;
+		bt_stack_gattc_free_req(p_req);
+		if (req_type != BT_STACK_GATTC_WRITE_CMD) {
+			bt_stack_gattc_handle_pending_req(conn_id);
+		}
 	}
+
 }
 
 static void bt_stack_gattc_disconnect_cb(uint8_t conn_id)

--- a/os/board/rtl8730e/src/component/soc/amebad2/fwlib/ram_common/ameba_ota.c
+++ b/os/board/rtl8730e/src/component/soc/amebad2/fwlib/ram_common/ameba_ota.c
@@ -312,7 +312,7 @@ int OTA_UserImageSignatureCheck(uint32_t input_addr)
 
 }
 
-static int BOOT_OTA_AP (u32 addr, Certificate_TypeDef Cert)
+static int BOOT_OTA_AP (u32 addr, Certificate_TypeDef *Cert)
 {
 	u8 Cnt;
 	SubImgInfo_TypeDef SubImgInfo;
@@ -326,7 +326,7 @@ static int BOOT_OTA_AP (u32 addr, Certificate_TypeDef Cert)
 	
 	if (BOOT_LoadSubImage_OTA(&SubImgInfo, PhyAddr, Cnt, APLabel, TRUE) == TRUE) {
 				/* AP ECC verify if need */
-		if (Kernel_SignatureCheck_OTA(&Manifest, &SubImgInfo, Cnt, &Cert, KEYID_AP) == FALSE){
+		if (Kernel_SignatureCheck_OTA(&Manifest, &SubImgInfo, Cnt, Cert, KEYID_AP) == FALSE){
 			return FALSE;
 		}
 	} else {
@@ -424,7 +424,7 @@ int OTA_KernelImageSignatureCheck(uint32_t input_addr)
 	
 		return FALSE;
 	}
-	BOOT_OTA_AP(PhyAddr, Cert);
+	BOOT_OTA_AP(PhyAddr, &Cert);
 
 	return TRUE;
 }


### PR DESCRIPTION
Changes Note:
rtk_stack_gattc.c
SVACE: 287217
Added NULL pointer checking p_req before performance free.

ameba_ota.c
SVACE: 287218
Fix by pass the parameter "Cert" by reference, to avoid huge data pass in may lead the unnecessary performance loss.