### PR TITLE
os/pm: checks for wifi keep alive send

### DIFF
--- a/os/include/tinyara/pm/pm.h
+++ b/os/include/tinyara/pm/pm.h
@@ -316,6 +316,7 @@ enum pm_timer_type_e {
 struct pm_timer_s {
 	uint8_t timer_type;		/* Bits here are set according to the timer that is to be used */
 	uint32_t timer_interval;	/* The interval for whichever timer is to be used */
+	bool is_wifi_send_required;              /* boolean to check if wifi keep alive send is required */
 	clock_t last_wifi_alive_send_time;       /* Time tick of the last wifi keep alive signal sent time */
 };
 

--- a/os/pm/pm_activity.c
+++ b/os/pm/pm_activity.c
@@ -275,6 +275,7 @@ void pm_adjust_sleep_duration(void)
 	} else if (g_pm_timer.timer_type == PM_NO_TIMER) {
 		pm_set_timer(PM_WAKEUP_TIMER, DEFAULT_PM_SLEEP_DURATION);
 	}
+	g_pm_timer.is_wifi_send_required = true;
 }
 
 /****************************************************************************

--- a/os/pm/pm_checkstate.c
+++ b/os/pm/pm_checkstate.c
@@ -65,6 +65,12 @@
 #ifdef CONFIG_PM
 
 /****************************************************************************
+ * External Definitons
+ ****************************************************************************/
+
+extern struct pm_timer_s g_pm_timer;
+
+/****************************************************************************
  * Public Functions
  ****************************************************************************/
 
@@ -154,6 +160,13 @@ enum pm_state_e pm_checkstate(int domain)
 			pdom->recommended = index;
 			break;
 		}
+	}
+
+	/* Consider if Wifi keep alive sending is required or not */
+
+	if (g_pm_timer.is_wifi_send_required) {
+		pdom->recommended = PM_NORMAL;
+		pmdbg("Board will stay at NORMAL until WIFI keep alive signal is sent\n");
 	}
 
 	leave_critical_section(flags);

--- a/os/pm/pm_procfs.c
+++ b/os/pm/pm_procfs.c
@@ -118,7 +118,7 @@ struct power_procfs_entry_s {
 };
 
 /* Added to record timer countdown interrupt */
-struct pm_timer_s g_pm_timer = { 0, 0, 0};
+struct pm_timer_s g_pm_timer = { 0, 0, false, 0};
 
 /****************************************************************************
  * Private Function Prototypes
@@ -540,6 +540,8 @@ static size_t power_unlock_write(FAR struct file *filep, FAR const char *buffer,
  *  Also we dont want to do pm_set_timer to PM_WAKEUP_TIMER if the
  *  system is already in PM_LOCK_TIMER state. If system is in 
  *  PM_LOCK_TIMER state, then power_unlock_write can only change that state.
+ * 
+ *  It sets is_wifi_send_required to false, so that board can now go to sleep.
  *
  * Input Parameters:
  *   filep          - File path of the power domain
@@ -555,6 +557,7 @@ static size_t power_set_next_wakeup_interval(FAR struct file *filep, FAR const c
 	(void)buffer;
 
 	g_pm_timer.last_wifi_alive_send_time = clock_systimer();
+	g_pm_timer.is_wifi_send_required = false;
 	if (g_pm_timer.timer_type == PM_NO_TIMER && buflen > 0) {
 		pm_set_timer(PM_WAKEUP_TIMER, buflen);
 	}	


### PR DESCRIPTION
it adds a new member to global pm timer that is is_wifi_send_required. It checks if the wifi keep alive signal has been send and accordingly set PM transition.