### PR TITLE
os/board/rtl8721csm: fix BLE get server connection status issue

### DIFF
--- a/os/board/rtl8721csm/src/component/common/bluetooth/realtek/sdk/example/ble_peripheral/ble_tizenrt_server.c
+++ b/os/board/rtl8721csm/src/component/common/bluetooth/realtek/sdk/example/ble_peripheral/ble_tizenrt_server.c
@@ -540,7 +540,10 @@ bool rtw_ble_server_conn_is_active(trble_conn_handle con_handle)
     T_GAP_CONN_INFO conn_info;
     if (le_get_conn_info(con_handle, &conn_info))
     {
-        return true;
+        if (conn_info.conn_state == GAP_CONN_STATE_CONNECTED && conn_info.role == GAP_LINK_ROLE_SLAVE)
+        {
+            return true;
+        }
     }
     return false;
 }


### PR DESCRIPTION
- added in check to make sure the input connection handle belongs to server before returning the connection status