### PR TITLE
kernel/preference: Return if registered callbacks are not exisiting or sending callback messages are done

### DIFF
--- a/framework/src/preference/preference_callback.c
+++ b/framework/src/preference/preference_callback.c
@@ -46,7 +46,7 @@ void preference_signal_cb(int signo)
 	snprintf(q_name, PREFERENCE_CBMQ_LEN, "%s%d", PREFERENCE_CBMSG_MQ, getpid());
 	mqfd = mq_open(q_name, O_RDONLY, 0666);
 	if (mqfd == (mqd_t)ERROR) {
-		prefdbg("Failed to open mq, errno %d\n", errno);
+		prefdbg("Failed to open mq, errno %d\n", get_errno());
 		return;
 	}
 
@@ -60,7 +60,7 @@ void preference_signal_cb(int signo)
 			/* Execute callback function */
 			data.cb_func(data.key, data.cb_data);
 		} else {
-			prefdbg("receive ERROR, ret %d errno %d\n", nbytes, errno);
+			prefdbg("receive ERROR, ret %d errno %d\n", nbytes, get_errno());
 		}
 	}
 	mq_close(mqfd);

--- a/framework/src/preference/preference_init.c
+++ b/framework/src/preference/preference_init.c
@@ -29,28 +29,38 @@
 int preference_init(void)
 {
 	int ret;
+	int errval;
 
 	/* Make preference directory */
 	ret = mkdir(PREF_PATH, 0777);
-	if (ret < 0 && errno != EEXIST) {
-		prefdbg("mkdir fail, %d\n", errno);
-		return PREFERENCE_IO_ERROR;
+	if (ret < 0) {
+		errval = get_errno();
+		if (errval != EEXIST) {
+			prefdbg("mkdir fail, %d\n", errval);
+			return PREFERENCE_IO_ERROR;
+		}
 	}
 #if CONFIG_TASK_NAME_SIZE > 0
 
 	/* Make private preference directory */
 	ret = mkdir(PREF_PRIVATE_PATH, 0777);
-	if (ret < 0 && errno != EEXIST) {
-		prefdbg("mkdir fail, %d\n", errno);
-		return PREFERENCE_IO_ERROR;
+	if (ret < 0) {
+		errval = get_errno();
+		if (errval != EEXIST) {
+			prefdbg("mkdir fail, %d\n", errval);
+			return PREFERENCE_IO_ERROR;
+		}
 	}
 #endif
 
 	/* Make shared preference directory */
 	ret = mkdir(PREF_SHARED_PATH, 0777);
-	if (ret < 0 && errno != EEXIST) {
-		prefdbg("mkdir fail, %d\n", errno);
-		return PREFERENCE_IO_ERROR;
+	if (ret < 0) {
+		errval = get_errno();
+		if (errval != EEXIST) {
+			prefdbg("mkdir fail, %d\n", errval);
+			return PREFERENCE_IO_ERROR;
+		}
 	}
 
 	return OK;

--- a/framework/src/preference/private_preference.c
+++ b/framework/src/preference/private_preference.c
@@ -295,7 +295,7 @@ int preference_set_changed_cb(const char *key, preference_changed_cb callback, v
 	
 	ret = sigaction(SIG_PREFERENCE, &act, NULL);
 	if (ret != OK) {
-		prefdbg("sigaction fail, errno %d", errno);
+		prefdbg("sigaction fail, errno %d", get_errno());
 		return PREFERENCE_OPERATION_FAIL;
 	}
 

--- a/framework/src/preference/shared_preference.c
+++ b/framework/src/preference/shared_preference.c
@@ -300,7 +300,7 @@ int preference_shared_set_changed_cb(const char *key, preference_changed_cb call
 	
 	ret = sigaction(SIG_PREFERENCE, &act, NULL);
 	if (ret == (int)SIG_ERR) {
-		prefdbg("sigaction fail, errno %d", errno);
+		prefdbg("sigaction fail, errno %d", get_errno());
 		return PREFERENCE_OPERATION_FAIL;
 	}
 


### PR DESCRIPTION
If a thread registers callback, it is invoked when value of the given key in the preference changes. This callbacks operate based on signals and message queues. If there is a registered callback, it sends data to the created message queue and sends a signal then a handler that receives the callback deletes this created mq. So just return if registered callbacks are not  or sending callback messages are done.