### PR TITLE
binfmt/libelf: export weak symbols from common to support cpp code

### DIFF
--- a/os/binfmt/libelf/libelf_bind.c
+++ b/os/binfmt/libelf/libelf_bind.c
@@ -310,7 +310,7 @@ static int export_library_symtab(FAR struct elf_loadinfo_s *loadinfo)
 			}
 		}
 
-		if (ELF32_ST_BIND(psym->st_info) == STB_GLOBAL) {
+		if (ELF32_ST_BIND(psym->st_info) == STB_GLOBAL || ELF32_ST_BIND(psym->st_info) == STB_WEAK) {
 			ret = elf_symname(loadinfo, psym);
 			if (ret < 0) {
 				berr("SHN_UNDEF: Failed to get symbol name: %d\n", ret);


### PR DESCRIPTION
currently we are only exporting global symbols which worked fine till now. But as we are expanding on cpp code, we also need to export weak symbols in common as they are required by app binary