### PR TITLE
Sync smartfs build failure fix commit

### DIFF
--- a/os/include/assert.h
+++ b/os/include/assert.h
@@ -63,6 +63,15 @@
 #ifndef __INCLUDE_ASSERT_H
 #define __INCLUDE_ASSERT_H
 
+#ifdef NXFUSE_HOST_BUILD
+#define FAR
+#define DEBUGASSERT(x)
+#define ASSERT(x) DEBUGASSERT(x)
+#define OK    0
+#define ERROR 1
+
+int get_errno(void);
+#else
 /****************************************************************************
  * Included Files
  ****************************************************************************/
@@ -265,6 +274,8 @@ void dump_all_stack(void);
 #ifdef __cplusplus
 }
 #endif
+
+#endif							/* NXFUSE_HOST_BUILD */
 
 #endif							/* __INCLUDE_ASSERT_H */
 

--- a/tools/nxfuse/mknxfuse.sh
+++ b/tools/nxfuse/mknxfuse.sh
@@ -46,6 +46,7 @@ ln -sf $SMARTFSDIR/../driver/mtd/smart.c $SMARTFS_TMPDIR/smart.c
 ln -svf $BASE_DIR/lib/libc/queue $SRCDIR/
 
 #Header Files
+ln -sf $BASE_INCLUDE_DIR/assert.h $DEST_INLCUDE_DIR/assert.h
 ln -sf $BASE_INCLUDE_DIR/crc16.h $DEST_INLCUDE_DIR/crc16.h
 ln -sf $BASE_INCLUDE_DIR/crc32.h $DEST_INLCUDE_DIR/crc32.h
 ln -sf $BASE_INCLUDE_DIR/crc8.h $DEST_INLCUDE_DIR/crc8.h
@@ -78,6 +79,7 @@ make -C $NXFUSE_TOOL_PATH || exit 1
 #Waiting for make to complete
 #After build done, remove the copied source & header files
 rm -rf $SRCDIR/lib_crc*
+rm -rf $DEST_INLCUDE_DIR/assert.h
 rm -rf $DEST_INLCUDE_DIR/crc16.h
 rm -rf $DEST_INLCUDE_DIR/crc32.h
 rm -rf $DEST_INLCUDE_DIR/crc8.h


### PR DESCRIPTION
tools/nxfuse, os/include: resolve smartfs build error

files modified: os/include/assert.h, tools/nxfuse/mknxfuse.sh

issue:
dq_cat.c and sq_cat.c needs DEBUGASSERT macro which is defined in .tizenrt/os/assert.h, but these files  are including assert.h from ubuntu. Below warning and linking error arises:

src/queue/sq_cat.c:42:3: warning: implicit declaration of function 'DEBUGASSERT' [-Wimplicit-function-declaration] DEBUGASSERT(queue1 != NULL && queue2 != NULL);

Linking nxfuse : error
obj/queue/dq_cat.o: In function dq_cat': /root/product/.tizenrt/tools/nxfuse/src/queue/dq_cat.c:42: undefined reference to DEBUGASSERT'

solution:
nxfuse is Linux application, it should not include TizenRT source code 1.set DEBUGASSERT() to empty when NXFUSE_HOST_BUILD is enabled 2.include os/include/assert.h as symbolic link