### PR TITLE
os/drivers: update Kconfig for VIRTKEY_QUEUE_LEN

### DIFF
--- a/os/drivers/Kconfig
+++ b/os/drivers/Kconfig
@@ -59,6 +59,15 @@ config VIRTKEY
 	default n
 	depends on NFILE_DESCRIPTORS != 0
 
+if VIRTKEY
+config VIRTKEY_QUEUE_LEN
+	int "Virtual key event queue length"
+	default 1024
+	---help---
+		Use this to specify length of event queue for virtual keyboard driver,
+		Event generator will write to the queue and receiver will read from it.
+endif
+
 menuconfig DRVR_WRITEBUFFER
 	bool "Enable write buffer support"
 	depends on SCHED_WORKQUEUE


### PR DESCRIPTION
New config was added for Virtual key driver event queue length. It was not added in Kconfig, adding it after review.