### PR TITLE
os/include/tinyara/security_hal.h: Add AES-GCM mode

### DIFF
--- a/os/se/ameba/Kconfig
+++ b/os/se/ameba/Kconfig
@@ -44,6 +44,13 @@ config HW_AES_ENC
 	---help---
 		Encrypts a data based on hardware.
 
+config HW_GCM_ENC
+	bool "HW GCM encryption decryption"
+	default n
+	---help---
+		Encrypts a data with GCM based on hardware.
+		Support crypto algorithm: AES
+
 config HW_SE_STORAGE
 	bool "Secure Storage Support"
 	default n


### PR DESCRIPTION
Add AES-GCM mode and parameter to support AES-GCM encryption/decryption. AES-GCM mode needs 4 additional parameter.
- AAD (Additional Authentication Data)
- AAD length
- TAG (Authentication Tag)
- TAG length