### PR TITLE
os/se/security_level: Set security level high in default

### DIFF
--- a/os/include/tinyara/security_level.h
+++ b/os/include/tinyara/security_level.h
@@ -26,8 +26,8 @@
 /********************************************************************************
  * Pre-processor Definitions
  ********************************************************************************/
-#define HIGH_SECURITY_LEVEL     1
-#define LOW_SECURITY_LEVEL      0
+#define HIGH_SECURITY_LEVEL     1    /* Cannot see secure information logs */
+#define LOW_SECURITY_LEVEL      0    /* Can see all secure information logs */
 
 /********************************************************************************
  * Global Type Declarations

--- a/os/se/security_level/security_level.c
+++ b/os/se/security_level/security_level.c
@@ -106,10 +106,10 @@ int set_security_level(void)
 
 	int result = atoi(output.data);
 	if (result == HIGH_SECURITY_LEVEL) {
-		security_level = 1;
+		security_level = HIGH_SECURITY_LEVEL;
 		dbg("HIGH\n");
 	} else if (result == LOW_SECURITY_LEVEL) {
-		security_level = 0;
+		security_level = LOW_SECURITY_LEVEL;
 		dbg("LOW\n");
 	} else {
 		kmm_free(output.data);

--- a/os/se/security_level/security_level.c
+++ b/os/se/security_level/security_level.c
@@ -51,7 +51,8 @@
 /****************************************************************************
  * Private data
  ****************************************************************************/
-static int security_level = 0;
+/* Default security_level value: high */
+static int security_level = HIGH_SECURITY_LEVEL;
 
 /****************************************************************************
  * Private Functions


### PR DESCRIPTION
Set security level high in default (in case of failing to set security level or security level is not setting yet)