### PR TITLE
os/arch/arm/src/amebasmart: Improve power efficiency for RTL8730E

### DIFF
--- a/os/arch/arm/src/amebasmart/amebasmart_idle.c
+++ b/os/arch/arm/src/amebasmart/amebasmart_idle.c
@@ -77,12 +77,23 @@ static void up_idlepm(void)
 			oldstate = newstate;
 		}
 		/* MCU-specific power management logic */
+		/* TODO: When LCD is integrated, some of the state operation might require revision
+		   PM_IDLE: We will expect LCD to go through background light dimming
+		   PM_STANDBY: LCD shut down, single core might be able to handle remaining tasks
+		   			   Then, we can do vPortSecondaryOff() for SMP case (ie. shutdown secondary core)
+		*/
 		switch (newstate) {
 			case PM_NORMAL:
+				/* In PM_NORMAL, we have nothing to do, set core to WFE */
+				__asm(" WFE");
 				break;
 			case PM_IDLE:
+				/* In PM_IDLE, we have nothing to do, set core to WFE */
+				__asm(" WFE");
 				break;
 			case PM_STANDBY:
+				/* In PM_STANDBY, we have nothing to do, set core to WFE */
+				__asm(" WFE");
 				break;
 			case PM_SLEEP:
 				/* TODO: When enabling SMP, PM state coherency should be verified for 
@@ -193,6 +204,14 @@ REJECTED:
 			default:
 				break;
 		}
+	} else {
+		/* If a state is locked, we will not be able to do state transition
+		But idle thread might still have chance to be doing judgement under some
+		conditions (ie. context switched to idle loop), thus if there is no
+		state transition happening, we invoke WFE for the core to rest (ie. a kind of HW sleep),
+		to prevent from unecessary power consumption
+		*/
+		__asm(" WFE");
 	}
 }
 #else


### PR DESCRIPTION
- In idle thread, apply "WFE" for cpu to enter low power state, under all PM states other than PM_SLEEP, as there is nothing to be done for idle thread under those PM states.
- If a state is locked (ie. state transition will not be happening), but we might still enter idle loop under some circumstances, in this case, WFE should also be applied as well, because there will be no system variable changes happening from idle thread