### PR TITLE
lib: Apply DEBUG_SET_CALLER_ADDR macro

### DIFF
--- a/lib/libc/misc/lib_envpath.c
+++ b/lib/libc/misc/lib_envpath.c
@@ -65,6 +65,7 @@
 #include <assert.h>
 
 #include <tinyara/envpath.h>
+#include <tinyara/mm/mm.h>
 
 #include "libc.h"
 
@@ -138,7 +139,7 @@ ENVPATH_HANDLE envpath_init(FAR const char *name)
 		printf("Allocate a container failed\n");
 		return (ENVPATH_HANDLE) NULL;
 	}
-
+	DEBUG_SET_CALLER_ADDR(envpath);
 	/* Populate the container */
 
 	strcpy(envpath->path, path);

--- a/lib/libc/misc/lib_hashmap.c
+++ b/lib/libc/misc/lib_hashmap.c
@@ -97,6 +97,7 @@ struct hashmap_s *hashmap_create(int startsize)
 	if (hm == NULL) {
 		return NULL;
 	}
+	DEBUG_SET_CALLER_ADDR(hm);
 
 	if (!startsize) {
 		startsize = TABLE_STARTSIZE;
@@ -185,6 +186,7 @@ unsigned long* hashmap_get_keyset(struct hashmap_s *hash)
 
 		keyset = (unsigned long *)lib_malloc(sizeof(unsigned long) * hash->count);
 		if (keyset != NULL) {
+			DEBUG_SET_CALLER_ADDR(keyset);
 			for (i = 0; i < hash->size; i++) {
 				if (hash->table[i].flags & ACTIVE) {
 					keyset[idx++] = hash->table[i].key;

--- a/lib/libc/stdio/lib_asprintf.c
+++ b/lib/libc/stdio/lib_asprintf.c
@@ -56,6 +56,7 @@
 
 #include <stdio.h>
 #include <stdarg.h>
+#include <tinyara/mm/mm.h>
 
 #include "lib_internal.h"
 
@@ -118,6 +119,9 @@ int asprintf(FAR char **ptr, const char *fmt, ...)
 
 	va_start(ap, fmt);
 	ret = vasprintf(ptr, fmt, ap);
+	if (*ptr) {
+		DEBUG_SET_CALLER_ADDR(*ptr);
+	}
 	va_end(ap);
 
 	return ret;

--- a/lib/libc/stdio/lib_vasprintf.c
+++ b/lib/libc/stdio/lib_vasprintf.c
@@ -58,6 +58,7 @@
 #include <stdlib.h>
 #include <stdarg.h>
 #include <assert.h>
+#include <tinyara/mm/mm.h>
 
 #include "lib_internal.h"
 
@@ -162,6 +163,7 @@ int vasprintf(FAR char **ptr, const char *fmt, va_list ap)
 	if (!buf) {
 		return ERROR;
 	}
+	DEBUG_SET_CALLER_ADDR(buf);
 
 	/* Initialize a memory stream to write into the allocated buffer.  The
 	 * memory stream will reserve one byte at the end of the buffer for the

--- a/lib/libc/string/lib_strdup.c
+++ b/lib/libc/string/lib_strdup.c
@@ -55,6 +55,7 @@
  ************************************************************************/
 
 #include <tinyara/config.h>
+#include <tinyara/mm/mm.h>
 
 #include <string.h>
 
@@ -71,6 +72,7 @@ FAR char *strdup(const char *s)
 		size_t len = strlen(s) + 1;
 		news = (FAR char *)lib_malloc(len);
 		if (news) {
+			DEBUG_SET_CALLER_ADDR(news);
 			strncpy(news, s, len);
 		}
 	}

--- a/lib/libc/string/lib_strndup.c
+++ b/lib/libc/string/lib_strndup.c
@@ -55,6 +55,7 @@
  ************************************************************************/
 
 #include <tinyara/config.h>
+#include <tinyara/mm/mm.h>
 
 #include <string.h>
 
@@ -95,7 +96,7 @@ FAR char *strndup(FAR const char *s, size_t size)
 			/* Copy the string into the allocated memory and add a NUL
 			 * terminator in any case.
 			 */
-
+			DEBUG_SET_CALLER_ADDR(news);
 			memcpy(news, s, allocsize);
 			news[allocsize] = '\0';
 		}

--- a/lib/libxx/libxx_new.cxx
+++ b/lib/libxx/libxx_new.cxx
@@ -55,6 +55,7 @@
 //***************************************************************************
 
 #include <tinyara/config.h>
+#include <tinyara/mm/mm.h>
 #include <cstddef>
 #include <debug.h>
 
@@ -111,6 +112,8 @@ void *operator new(unsigned int nbytes)
     // we cannot throw an exception!  We are bad.
 
     dbg("Failed to allocate\n");
+  } else {
+    DEBUG_SET_CALLER_ADDR(alloc);
   }
 #endif
 

--- a/lib/libxx/libxx_newa.cxx
+++ b/lib/libxx/libxx_newa.cxx
@@ -55,6 +55,7 @@
 //***************************************************************************
 
 #include <tinyara/config.h>
+#include <tinyara/mm/mm.h>
 #include <cstddef>
 #include <debug.h>
 
@@ -111,6 +112,8 @@ void *operator new[](unsigned int nbytes)
     // we cannot throw an exception!  We are bad.
 
     dbg("Failed to allocate\n");
+  } else {
+    DEBUG_SET_CALLER_ADDR(alloc);
   }
 #endif
 

--- a/os/include/tinyara/mm/mm.h
+++ b/os/include/tinyara/mm/mm.h
@@ -266,7 +266,7 @@ typedef size_t mmsize_t;
 /* typedef is used for defining size of address space */
 
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
-typedef size_t mmaddress_t;             /* 32 bit address space */
+typedef void *mmaddress_t;             /* 32 bit address space */
 
 #define SIZEOF_MM_MALLOC_DEBUG_INFO \
 	(sizeof(mmaddress_t) + sizeof(pid_t) + sizeof(uint16_t))
@@ -373,7 +373,9 @@ extern struct heapinfo_group_info_s group_info[HEAPINFO_THREAD_NUM];
 
 struct mm_alloc_fail_s {
 	uint32_t size;
-	uint32_t caller;
+#ifdef CONFIG_DEBUG_MM_HEAPINFO
+	mmaddress_t caller;
+#endif
 };
 
 /* This describes one heap (possibly with multiple regions) */
@@ -770,7 +772,7 @@ int mm_check_heap_corruption(struct mm_heap_s *heap);
 /* Function to manage the memory allocation failure case. */
 #if defined(CONFIG_APP_BINARY_SEPARATION) && !defined(__KERNEL__)
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
-void mm_ioctl_alloc_fail(size_t size, uint32_t caller);
+void mm_ioctl_alloc_fail(size_t size, mmaddress_t caller);
 #define mm_manage_alloc_fail(h, b, e, s, t, c) 	do { \
 							(void)h; \
 							(void)b; \
@@ -791,7 +793,7 @@ void mm_ioctl_alloc_fail(size_t size);
 #else
 void mm_manage_alloc_fail(struct mm_heap_s *heap, int startidx, int endidx, size_t size, int heap_type
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
-		, uint32_t caller
+		, mmaddress_t caller
 #endif
 		);
 #endif

--- a/os/mm/kmm_heap/kmm_calloc.c
+++ b/os/mm/kmm_heap/kmm_calloc.c
@@ -67,7 +67,11 @@
 /****************************************************************************
  * Private Functions
  ****************************************************************************/
-static void *kheap_calloc(size_t n, size_t elem_size, size_t retaddr)
+#ifdef CONFIG_DEBUG_MM_HEAPINFO
+static void *kheap_calloc(size_t n, size_t elem_size, mmaddress_t retaddr)
+#else
+static void *kheap_calloc(size_t n, size_t elem_size)
+#endif
 {
 	int heap_idx;
 	void *ret;
@@ -114,7 +118,7 @@ void *kmm_calloc_at(int heap_index, size_t n, size_t elem_size)
 	void *ret;
 	struct mm_heap_s *kheap;
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
-	size_t caller_retaddr = 0;
+	mmaddress_t caller_retaddr = 0;
 	ARCH_GET_RET_ADDRESS(caller_retaddr)
 #endif
 	if (heap_index > HEAP_END_IDX || heap_index < HEAP_START_IDX) {
@@ -153,14 +157,18 @@ void *kmm_calloc_at(int heap_index, size_t n, size_t elem_size)
 
 FAR void *kmm_calloc(size_t n, size_t elem_size)
 {
-	size_t caller_retaddr = 0;
 	if (n == 0 || elem_size == 0) {
 		return NULL;
 	}
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
+	mmaddress_t caller_retaddr = 0;
 	ARCH_GET_RET_ADDRESS(caller_retaddr)
 #endif
-	return kheap_calloc(n, elem_size, caller_retaddr);
+	return kheap_calloc(n, elem_size
+#ifdef CONFIG_DEBUG_MM_HEAPINFO
+				, caller_retaddr
+#endif
+				);
 }
 
 #endif							/* CONFIG_MM_KERNEL_HEAP */

--- a/os/mm/kmm_heap/kmm_malloc.c
+++ b/os/mm/kmm_heap/kmm_malloc.c
@@ -79,8 +79,11 @@
 /****************************************************************************
  * Private Functions
  ****************************************************************************/
-
-static void *kheap_malloc(size_t size, size_t caller_retaddr)
+#ifdef CONFIG_DEBUG_MM_HEAPINFO
+static void *kheap_malloc(size_t size, mmaddress_t caller_retaddr)
+#else
+static void *kheap_malloc(size_t size)
+#endif
 {
 	int heap_idx;
 	void *ret;
@@ -131,7 +134,7 @@ void *kmm_malloc_at(int heap_index, size_t size)
 	void *ret;
 	struct mm_heap_s *kheap;
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
-	size_t caller_retaddr = 0;
+	mmaddress_t caller_retaddr = 0;
 	ARCH_GET_RET_ADDRESS(caller_retaddr)
 #endif
 	if (heap_index > HEAP_END_IDX || heap_index < HEAP_START_IDX) {
@@ -176,13 +179,18 @@ void *kmm_malloc_at(int heap_index, size_t size)
 
 FAR void *kmm_malloc(size_t size)
 {
-	size_t caller_retaddr = 0;
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
+	mmaddress_t caller_retaddr = 0;
 	ARCH_GET_RET_ADDRESS(caller_retaddr)
 #endif
 	if (size == 0) {
 		return NULL;
 	}
-	return kheap_malloc(size, caller_retaddr);
+
+	return kheap_malloc(size
+#ifdef CONFIG_DEBUG_MM_HEAPINFO
+				, caller_retaddr
+#endif
+				);
 }
 #endif							/* CONFIG_MM_KERNEL_HEAP */

--- a/os/mm/kmm_heap/kmm_memalign.c
+++ b/os/mm/kmm_heap/kmm_memalign.c
@@ -93,7 +93,7 @@ void *kmm_memalign_at(int heap_index, size_t alignment, size_t size)
 	void *ret;
 	struct mm_heap_s *kheap;
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
-	size_t caller_retaddr = 0;
+	mmaddress_t caller_retaddr = 0;
 	ARCH_GET_RET_ADDRESS(caller_retaddr)
 #endif
 	if (heap_index > HEAP_END_IDX || heap_index < HEAP_START_IDX) {
@@ -146,7 +146,7 @@ FAR void *kmm_memalign(size_t alignment, size_t size)
 		return NULL;
 	}
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
-	size_t caller_retaddr = 0;
+	mmaddress_t caller_retaddr = 0;
 	ARCH_GET_RET_ADDRESS(caller_retaddr)
 #endif
 	struct mm_heap_s *kheap = kmm_get_baseheap();

--- a/os/mm/kmm_heap/kmm_realloc.c
+++ b/os/mm/kmm_heap/kmm_realloc.c
@@ -90,7 +90,7 @@ void *kmm_realloc_at(int heap_index, void *oldmem, size_t size)
 	void *ret;
 	struct mm_heap_s *kheap;
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
-	size_t caller_retaddr = 0;
+	mmaddress_t caller_retaddr = 0;
 	ARCH_GET_RET_ADDRESS(caller_retaddr)
 #endif
 	if (heap_index > HEAP_END_IDX || heap_index < HEAP_START_IDX) {
@@ -141,7 +141,7 @@ FAR void *kmm_realloc(FAR void *oldmem, size_t newsize)
 	void *ret;
 	int kheap_idx;
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
-	size_t caller_retaddr = 0;
+	mmaddress_t caller_retaddr = 0;
 	ARCH_GET_RET_ADDRESS(caller_retaddr)
 #endif
 	struct mm_heap_s *kheap_origin = mm_get_heap(oldmem);

--- a/os/mm/kmm_heap/kmm_zalloc.c
+++ b/os/mm/kmm_heap/kmm_zalloc.c
@@ -86,7 +86,7 @@ void *kmm_zalloc_at(int heap_index, size_t size)
 	void *ret;
 	struct mm_heap_s *kheap;
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
-	size_t caller_retaddr = 0;
+	mmaddress_t caller_retaddr = 0;
 	ARCH_GET_RET_ADDRESS(caller_retaddr)
 #endif
 	if (heap_index > HEAP_END_IDX || heap_index < HEAP_START_IDX) {
@@ -134,7 +134,7 @@ FAR void *kmm_zalloc(size_t size)
 	void *ret;
 	int kheap_idx;
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
-	size_t caller_retaddr = 0;
+	mmaddress_t caller_retaddr = 0;
 	ARCH_GET_RET_ADDRESS(caller_retaddr)
 #endif
 	if (size == 0) {

--- a/os/mm/mm_heap/mm_initialize.c
+++ b/os/mm/mm_heap/mm_initialize.c
@@ -167,14 +167,14 @@ int mm_addregion(FAR struct mm_heap_s *heap, FAR void *heapstart, size_t heapsiz
 	heap->mm_heapstart[IDX]->preceding = MM_ALLOC_BIT;
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
 	/* fill magic number 0xDEAD as malloc info for head node */
-	heapinfo_update_node((FAR struct mm_allocnode_s *)heap->mm_heapstart[IDX], 0xDEAD);
+	heapinfo_update_node((FAR struct mm_allocnode_s *)heap->mm_heapstart[IDX], (mmaddress_t)0xDEAD);
 #endif
 
 	node            = (FAR struct mm_freenode_s *)(heapbase + SIZEOF_MM_ALLOCNODE);
 	node->size      = heapsize - 2 * SIZEOF_MM_ALLOCNODE;
 	node->preceding = SIZEOF_MM_ALLOCNODE;
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
-	heapinfo_update_node((FAR struct mm_allocnode_s *)node, 0xDEADDEAD);
+	heapinfo_update_node((FAR struct mm_allocnode_s *)node, (mmaddress_t)0xDEADDEAD);
 #endif
 
 	heap->mm_heapend[IDX]            = (FAR struct mm_allocnode_s *)(heapend - SIZEOF_MM_ALLOCNODE);
@@ -182,7 +182,7 @@ int mm_addregion(FAR struct mm_heap_s *heap, FAR void *heapstart, size_t heapsiz
 	heap->mm_heapend[IDX]->preceding = node->size | MM_ALLOC_BIT;
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
 	/* Fill magic number 0xDEADDEAD as malloc info for tail node */
-	heapinfo_update_node((FAR struct mm_allocnode_s *)heap->mm_heapend[IDX], 0xDEADDEAD);
+	heapinfo_update_node((FAR struct mm_allocnode_s *)heap->mm_heapend[IDX], (mmaddress_t)0xDEADDEAD);
 #endif
 
 #undef IDX

--- a/os/mm/mm_heap/mm_manage_allocfail.c
+++ b/os/mm/mm_heap/mm_manage_allocfail.c
@@ -120,7 +120,7 @@ static inline int mm_heapinfo_stop_watchdog(void)
 
 #if defined(CONFIG_APP_BINARY_SEPARATION) && !defined(__KERNEL__)
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
-void mm_ioctl_alloc_fail(size_t size, uint32_t caller)
+void mm_ioctl_alloc_fail(size_t size, mmaddress_t caller)
 #else
 void mm_ioctl_alloc_fail(size_t size)
 #endif
@@ -128,7 +128,7 @@ void mm_ioctl_alloc_fail(size_t size)
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
 	struct mm_alloc_fail_s arg = {size, caller};
 #else
-	struct mm_alloc_fail_s arg = {size, 0};
+	struct mm_alloc_fail_s arg = {size};
 #endif
 	int mmfd = open(MMINFO_DRVPATH, O_RDWR);
 	if (mmfd < 0) {
@@ -145,7 +145,7 @@ void mm_ioctl_alloc_fail(size_t size)
 #else
 
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
-void mm_manage_alloc_fail(struct mm_heap_s *heap, int startidx, int endidx, size_t size, int heap_type, uint32_t caller)
+void mm_manage_alloc_fail(struct mm_heap_s *heap, int startidx, int endidx, size_t size, int heap_type, mmaddress_t caller)
 #else
 void mm_manage_alloc_fail(struct mm_heap_s *heap, int startidx, int endidx, size_t size, int heap_type)
 #endif

--- a/os/mm/umm_heap/umm_memalign.c
+++ b/os/mm/umm_heap/umm_memalign.c
@@ -89,7 +89,7 @@ void *memalign_at(int heap_index, size_t alignment, size_t size)
 {
 	void *ret;
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
-	size_t caller_retaddr = 0;
+	mmaddress_t caller_retaddr = 0;
 	ARCH_GET_RET_ADDRESS(caller_retaddr)
 #endif
 	if (heap_index > HEAP_END_IDX || heap_index < HEAP_START_IDX) {
@@ -134,7 +134,7 @@ FAR void *memalign(size_t alignment, size_t size)
 {
 	void *ret;
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
-	size_t caller_retaddr = 0;
+	mmaddress_t caller_retaddr = 0;
 #endif
 
 	if (size == 0) {

--- a/os/mm/umm_heap/umm_realloc.c
+++ b/os/mm/umm_heap/umm_realloc.c
@@ -89,7 +89,7 @@ void *realloc_at(int heap_index, void *oldmem, size_t size)
 {
 	void *ret;
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
-	size_t caller_retaddr = 0;
+	mmaddress_t caller_retaddr = 0;
 
 	ARCH_GET_RET_ADDRESS(caller_retaddr)
 #endif
@@ -140,7 +140,7 @@ FAR void *realloc(FAR void *oldmem, size_t size)
 	int prev_heap_idx;
 	void *ret;
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
-	size_t caller_retaddr = 0;
+	mmaddress_t caller_retaddr = 0;
 
 	ARCH_GET_RET_ADDRESS(caller_retaddr)
 #endif

--- a/os/mm/umm_heap/umm_xalloc_user_at.c
+++ b/os/mm/umm_heap/umm_xalloc_user_at.c
@@ -43,7 +43,7 @@ void *calloc_user_at(struct mm_heap_s *heap, size_t n, size_t elem_size)
 		return NULL;
 	}
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
-	size_t caller_retaddr;
+	mmaddress_t caller_retaddr;
 	ARCH_GET_RET_ADDRESS(caller_retaddr)	
 	return mm_calloc(heap, n, elem_size, caller_retaddr);
 #else
@@ -66,7 +66,7 @@ void *memalign_user_at(struct mm_heap_s *heap, size_t alignment, size_t size)
 		return NULL;
 	}
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
-	size_t caller_retaddr;
+	mmaddress_t caller_retaddr;
 	ARCH_GET_RET_ADDRESS(caller_retaddr)	
 	return mm_memalign(heap, alignment, size, caller_retaddr);
 #else
@@ -96,7 +96,7 @@ void *malloc_user_at(struct mm_heap_s *heap, size_t size)
 		return NULL;
 	}
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
-	size_t caller_retaddr = 0;
+	mmaddress_t caller_retaddr = 0;
 	ARCH_GET_RET_ADDRESS(caller_retaddr)	
 	return mm_malloc(heap, size, caller_retaddr);
 #else
@@ -116,7 +116,7 @@ void *malloc_user_at(struct mm_heap_s *heap, size_t size)
 void *realloc_user_at(struct mm_heap_s *heap, void *oldmem, size_t newsize)
 {
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
-	size_t caller_retaddr = 0;
+	mmaddress_t caller_retaddr = 0;
 	ARCH_GET_RET_ADDRESS(caller_retaddr)
 #endif
 	if (newsize == 0) {
@@ -145,7 +145,7 @@ void *zalloc_user_at(struct mm_heap_s *heap, size_t size)
 		return NULL;
 	}
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
-	size_t caller_retaddr = 0;
+	mmaddress_t caller_retaddr = 0;
 	ARCH_GET_RET_ADDRESS(caller_retaddr)	
 	return mm_zalloc(heap, size, caller_retaddr);
 #else


### PR DESCRIPTION
When a memory is alloc, we store the caller address requested by which code. However, if we wrap the alloc api and use it, the caller only looks at the wrapped api.

Therefore, we apply the DEBUG_SET_CALLER_ADDR macro to actually store the caller's address in alloc.