### PR TITLE
os/tools/check_package_header.py: Change SIGNING_SIZE

### DIFF
--- a/os/tools/check_package_header.py
+++ b/os/tools/check_package_header.py
@@ -42,7 +42,7 @@ else :
     COMMON_HEADER_SIZE = 12
     APP_HEADER_SIZE = 44
 
-SIGNING_SIZE = 32
+SIGNING_SIZE = int(util.get_value_from_file(cfg_path, "CONFIG_USER_SIGN_PREPEND_SIZE=").rstrip('\n'))
 CHECKSUM_SIZE = 4
 
 LOADING_LOW = 1


### PR DESCRIPTION
SIGNING_SIZE is a header size of signing binary.
Since it depends on the type of board, this commit changes SINGING_SIZE to read from config file.