### PR TITLE
os/kernel/log_dump: Fix wrong free log dump chunk.

### DIFF
--- a/os/kernel/log_dump/log_dump.c
+++ b/os/kernel/log_dump/log_dump.c
@@ -336,14 +336,7 @@ static int log_dump_tobuffer(char ch, size_t *free_size)
 		} else {
 			/* logs reached memory limit, reuse the head and free extra logs */
 			struct log_dump_chunk_s *node = (struct log_dump_chunk_s *)sq_remfirst(&log_dump_chunks);
-
-			if (node == NULL) {
-				/* this will not be reached as we set the minimum number nodes in
-				 * the worst case to be atleast one, added this to fix svace issue
-				 */
-				ldpdbg("no log dump nodes in the list\n");
-				return LOG_DUMP_MEM_FAIL;
-			}
+			ASSERT(node);
 
 			compress_curbytes = 1;
 			compress_rdptr = 0;	/* reset the read pointer as head is modified */
@@ -361,6 +354,7 @@ static int log_dump_tobuffer(char ch, size_t *free_size)
 
 	} else {					/* there is place in tail */
 		struct log_dump_chunk_s *log_dump_tail = (struct log_dump_chunk_s *)sq_tail(&log_dump_chunks);
+		ASSERT(log_dump_tail);
 		log_dump_tail->arr[compress_curbytes] = ch;
 		compress_curbytes += 1;
 		if (set_comp_head) {	/* new node, so compressed block starts at 0 */

--- a/os/kernel/log_dump/log_dump.c
+++ b/os/kernel/log_dump/log_dump.c
@@ -264,6 +264,7 @@ static void log_dump_mem_check(size_t max_size)
 		for (int i = 0; i < extra_chunks_count; i++) {
 			next_chunk = (struct log_dump_chunk_s *)sq_remfirst(&log_dump_chunks);
 			compress_rdptr = 0;	/* reset the read pointer as the head is removed */
+			log_dump_size -= LOG_CHUNK_SIZE;
 			kmm_free(next_chunk);
 		}
 	}


### PR DESCRIPTION
Fix the following problems.
1. When a part of the chunks of the log dump needs to be discarded due to insufficient kernel memory, the chunks are being freed but not subtracted from the total chunk size held by the log dump.
2. The current log dump structure must always have more than one log dump chunk. However, as above issue, all chunks can be freed, resulting in an abort.