### PR TITLE
os: Fix XIP_ELF runtime loading crash issue

### DIFF
--- a/os/board/rtl8730e/Kconfig
+++ b/os/board/rtl8730e/Kconfig
@@ -20,6 +20,15 @@ config FLASH_START_ADDR
         A start address of flash (in hex).
         This is fixed value, so user doesn't need to change it.
 
+config FLASH_VSTART_LOADABLE
+    hex
+    default 0xe000000
+    depends on XIP_ELF
+    help
+        A start virtual address of flash (in hex). This macro
+        will be used to do address remapping for loadable running on XIP.
+        This is fixed value, so user doesn't need to change it.
+
 choice
     prompt "Board Flash Size"
     default BOARD_FLASH_16M


### PR DESCRIPTION
-  In TRPK file, it might include several binaries together, which means the binary running on TizenLite might not be the starting address of the TRPK file.
- In return, we will face crash issue, since there is a address mismatch between the correct address and the current address of the apps binary (ie. the address of the apps binary should be calculated from the binary which is running on TizenLite, not the trpk file itself)