### PR TITLE
os, build: Add support for loadable XIP_ELF offset calculation

### DIFF
--- a/build/configs/rtl8730e/loadable_apps_xip/defconfig
+++ b/build/configs/rtl8730e/loadable_apps_xip/defconfig
@@ -313,6 +313,8 @@ CONFIG_FLASH_MINOR=0
 CONFIG_FLASH_PART_SIZE="60,40,12,400,1844,2040,1000,1384,1844,2040,1000,1384,2048,1280,8,"
 CONFIG_FLASH_PART_TYPE="none,none,none,none,kernel,bin,bin,bin,kernel,bin,bin,bin,smartfs,ftl,bootparam,"
 CONFIG_FLASH_PART_NAME="bl1,reserved,ftl,ss,kernel,common,app1,app2,kernel,common,app1,app2,userfs,micom,bootparam,"
+CONFIG_TRPK_CONTAINS_MULTIPLE_BINARY=y
+CONFIG_FLASH_VSTART_LOADABLE=0xe000000
 # CONFIG_ARCH_BOARD_HAVE_SECOND_FLASH is not set
 CONFIG_AUTOMOUNT=y
 CONFIG_AUTOMOUNT_USERFS=y

--- a/build/tools/amebasmart/gnu_utility/loadable_xip_elf.py
+++ b/build/tools/amebasmart/gnu_utility/loadable_xip_elf.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python
+###########################################################################
+#
+# Copyright 2024 Samsung Electronics All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+#
+###########################################################################
+import os
+
+filepath = os.path.dirname(__file__) + "/km0_km4_app.bin"
+alignment = 4096
+
+def get_offset():
+    bin_size = os.path.getsize(filepath)
+    # Binary need to be aligned to 4K
+    bin_size = (bin_size + alignment - 1) // alignment * alignment
+    # 4K manifest before AP binary (ie. running on Tizen Lite) starts
+    bin_size = bin_size + alignment
+    return hex(bin_size)
+

--- a/build/tools/amebasmart/gnu_utility/rtk_data_binary.py
+++ b/build/tools/amebasmart/gnu_utility/rtk_data_binary.py
@@ -1,4 +1,21 @@
 #!/usr/bin/env python
+###########################################################################
+#
+# Copyright 2024 Samsung Electronics All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+#
+###########################################################################
 
 import os
 import sys

--- a/os/board/rtl8730e/Kconfig
+++ b/os/board/rtl8730e/Kconfig
@@ -20,6 +20,21 @@ config FLASH_START_ADDR
         A start address of flash (in hex).
         This is fixed value, so user doesn't need to change it.
 
+config TRPK_CONTAINS_MULTIPLE_BINARY
+    bool
+    default n
+    depends on XIP_ELF
+    help
+        This macro is to differentiate whether the kernel trpk contains
+        more than 1 binary. If yes, we have to recalculate the offset
+        according to the binary that is running on Tizen Lite, to make
+        sure the loadable_apps for XIP_ELF is placed to the correct
+        virtual flash address (ie. Only Loadable_apps with running on
+        XIP is needed, because the core has to know where to execute
+        from the correct remapped address)
+        This macro is not needed for flat configs, due to the kernel 
+        binaries remapping will be handled by the bootloader.
+
 config FLASH_VSTART_LOADABLE
     hex
     default 0xe000000


### PR DESCRIPTION
- mkldscript for loadable is generic tool, to break the dependency, chip specific should implement the logic independently
- If trpk file contains multiple binary, the logic should be applied
- Add flash virtual starting address and trpk multiple binary macros in defconfig