### PR TITLE
os/tools/check_package_header.py: Fix non-signing build error

### DIFF
--- a/os/tools/check_package_header.py
+++ b/os/tools/check_package_header.py
@@ -42,7 +42,13 @@ else :
     COMMON_HEADER_SIZE = 12
     APP_HEADER_SIZE = 44
 
-SIGNING_SIZE = 32
+SIGNING_SIZE = util.get_value_from_file(cfg_path, "CONFIG_USER_SIGN_PREPEND_SIZE=").rstrip('\n')
+
+if SIGNING_SIZE == 'None' :
+    SIGNING_SIZE = 0
+else :
+    SIGNING_SIZE = int(SIGNING_SIZE)
+
 CHECKSUM_SIZE = 4
 
 LOADING_LOW = 1


### PR DESCRIPTION
SIGNING_SIZE is the header size of signing user binary.
But if CONFIG_USER_SIGN_PREPEND_SIZE is not set, SIGNING_SIZE value is 'None'. so it causes build error when directly convert SIGNING_SIZE type from string to int. 
This commit adds the process when the SIGNING_SIZE is none.