### PR TITLE
os/arch/arm/src/armv7-a/arm_assert.c: Add \n in security_level lldbg

### DIFF
--- a/os/arch/arm/src/armv7-a/arm_assert.c
+++ b/os/arch/arm/src/armv7-a/arm_assert.c
@@ -555,6 +555,8 @@ void up_assert(const uint8_t *filename, int lineno)
 	ARCH_GET_RET_ADDRESS(kernel_assert_location)
 	struct tcb_s *fault_tcb = this_task();
 
+	/* Add new line to distinguish between normal log and assert log.*/
+	lldbg_noarg("\n");
 
 	board_autoled_on(LED_ASSERTION);
 

--- a/os/arch/arm/src/armv7-m/up_assert.c
+++ b/os/arch/arm/src/armv7-m/up_assert.c
@@ -533,6 +533,9 @@ void up_assert(const uint8_t *filename, int lineno)
 
 	irqstate_t flags = irqsave();
 
+	/* Add new line to distinguish between normal log and assert log.*/
+	lldbg_noarg("\n");
+
 	struct tcb_s *fault_tcb = this_task();
 	bool is_kmm_corruption = false;
 

--- a/os/arch/arm/src/armv7-m/up_busfault.c
+++ b/os/arch/arm/src/armv7-m/up_busfault.c
@@ -125,6 +125,9 @@ int up_busfault(int irq, FAR void *context, FAR void *arg)
 	uint32_t bfar = getreg32(NVIC_BFAULT_ADDR);
 	system_exception_location = regs[REG_R15];
 
+	/* Add new line to distinguish between normal log and assert log.*/
+	lldbg_noarg("\n");
+
 	if (!IS_SECURE_STATE()) {
 		print_busfault_detail(regs, cfsr, bfar);
 	}

--- a/os/arch/arm/src/armv7-m/up_hardfault.c
+++ b/os/arch/arm/src/armv7-m/up_hardfault.c
@@ -201,6 +201,9 @@ int up_hardfault(int irq, FAR void *context, FAR void *arg)
 	}
 #endif
 
+	/* Add new line to distinguish between normal log and assert log.*/
+	lldbg_noarg("\n");
+
 	if (!IS_SECURE_STATE()) {
 		print_hardfault_detail(irq, regs);
 	}

--- a/os/arch/arm/src/armv7-m/up_usagefault.c
+++ b/os/arch/arm/src/armv7-m/up_usagefault.c
@@ -120,6 +120,9 @@ int up_usagefault(int irq, FAR void *context, FAR void *arg)
 		system_exception_location = regs[REG_R14];
 	}
 
+	/* Add new line to distinguish between normal log and assert log.*/
+	lldbg_noarg("\n");
+
 	if (!IS_SECURE_STATE()) {
 		print_usagefault_detail(regs, cfsr);
 	}

--- a/os/arch/arm/src/armv7-r/arm_assert.c
+++ b/os/arch/arm/src/armv7-r/arm_assert.c
@@ -960,6 +960,9 @@ void up_assert(const uint8_t *filename, int lineno)
 #endif
 	abort_mode = true;
 
+	/* Add new line to distinguish between normal log and assert log.*/
+	lldbg_noarg("\n");
+
 	lldbg("==============================================\n");
 	lldbg("Assertion failed\n");
 	lldbg("==============================================\n");

--- a/os/arch/arm/src/armv8-m/up_assert.c
+++ b/os/arch/arm/src/armv8-m/up_assert.c
@@ -591,6 +591,9 @@ void up_assert(const uint8_t *filename, int lineno)
 
 	irqstate_t flags = irqsave();
 
+	/* Add new line to distinguish between normal log and assert log.*/
+	lldbg_noarg("\n");
+
 	struct tcb_s *fault_tcb = this_task();
 
 	board_led_on(LED_ASSERTION);

--- a/os/arch/arm/src/armv8-m/up_busfault.c
+++ b/os/arch/arm/src/armv8-m/up_busfault.c
@@ -124,6 +124,9 @@ int up_busfault(int irq, FAR void *context, FAR void *arg)
 	uint32_t bfar = getreg32(NVIC_BFAULT_ADDR);
 	system_exception_location = regs[REG_R15];
 
+	/* Add new line to distinguish between normal log and assert log.*/
+	lldbg_noarg("\n");
+
 	if (!IS_SECURE_STATE()) {
 		print_busfault_detail(regs, cfsr, bfar);
 	}

--- a/os/arch/arm/src/armv8-m/up_hardfault.c
+++ b/os/arch/arm/src/armv8-m/up_hardfault.c
@@ -200,6 +200,9 @@ int up_hardfault(int irq, FAR void *context, FAR void *arg)
 	}
 #endif
 
+	/* Add new line to distinguish between normal log and assert log.*/
+	lldbg_noarg("\n");
+
 	if (!IS_SECURE_STATE()) {
 		print_hardfault_detail(irq, regs);
 	}

--- a/os/arch/arm/src/armv8-m/up_memfault.c
+++ b/os/arch/arm/src/armv8-m/up_memfault.c
@@ -159,6 +159,9 @@ int up_memfault(int irq, FAR void *context, FAR void *arg)
 		system_exception_location = regs[REG_R14];	/* The PC value might be invalid, so use LR */
 	}
 
+	/* Add new line to distinguish between normal log and assert log.*/
+	lldbg_noarg("\n");
+
 	if (!IS_SECURE_STATE()) {
 		print_memfault_detail(regs, cfsr, mmfar);
 	}

--- a/os/arch/arm/src/armv8-m/up_usagefault.c
+++ b/os/arch/arm/src/armv8-m/up_usagefault.c
@@ -123,6 +123,9 @@ int up_usagefault(int irq, FAR void *context, FAR void *arg)
 		system_exception_location = regs[REG_R14];
 	}
 
+	/* Add new line to distinguish between normal log and assert log.*/
+	lldbg_noarg("\n");
+
 	if (!IS_SECURE_STATE()) {
 		print_usagefault_detail(regs, cfsr);
 	}


### PR DESCRIPTION
When assert occurs, the assert log is printed continuously with the previous log. (It occurs only in AIDual)

```
E[MEDIA][audio_manager.c]::get_device_process_handler_mesecurity level: 0
===========================================================
Assertion details
===========================================================
```

This commit adds \n in front of security_level log to distinguish between normal log and assert log.