### PR TITLE
os/board/rtl8730e: update timedstay interval for ble trigger

### DIFF
--- a/os/board/rtl8730e/src/component/bluetooth/example/ble_scatternet/scatternet.c
+++ b/os/board/rtl8730e/src/component/bluetooth/example/ble_scatternet/scatternet.c
@@ -295,13 +295,12 @@ static rtk_bt_evt_cb_ret_t ble_tizenrt_scatternet_gap_app_callback(uint8_t evt_c
         rtk_bt_le_addr_to_str(&(conn_ind->peer_addr), le_addr, sizeof(le_addr));
         if (!conn_ind->err) {
 #ifdef CONFIG_PM
-            /* Register PM_BLE_DOMAIN */
+            /* Register PM_BLE_DOMAIN and Perform 10 minutes timedsuspend */
             domain = pm_domain_register("BLE");
             if (domain < 0) {
-                pmdbg("Unable to register PM_BLE_DOMAIN\n");
-            /* Set PM suspend timer for 10 minutes */
-            } else if (pm_timedsuspend(domain, 600000000) != 0) {
-                pmdbg("Unable to perform PM suspend for 10 minutes\n");
+                pmdbg("Unable to register BLE DOMAIN\n");
+            } else if (pm_timedsuspend(domain, 600000) != 0) {
+                pmdbg("Unable to perform PM suspend for 10 minutes for ble domain\n");
             }
 #endif
             role = conn_ind->role ? "slave" : "master";

--- a/os/include/tinyara/pm/pm.h
+++ b/os/include/tinyara/pm/pm.h
@@ -438,7 +438,7 @@ int pm_sleep(int milliseconds);
  * 
  * Parameters:
  *   domain_id - domain ID to be suspended
- *   timer_interval - expected lock duration in millisecond
+ *   milliseconds - expected lock duration in millisecond
  *
  * Return Value:
  *   0 - success
@@ -446,7 +446,7 @@ int pm_sleep(int milliseconds);
  *
  ************************************************************************/
 
-int pm_timedsuspend(int domain_id, unsigned int timer_interval);
+int pm_timedsuspend(int domain_id, unsigned int milliseconds);
 
 /****************************************************************************
  * Name: pm_suspendcount

--- a/os/pm/pm_timedsuspend.c
+++ b/os/pm/pm_timedsuspend.c
@@ -51,6 +51,7 @@
  * Included Files
  ************************************************************************/
 
+#include <tinyara/config.h>
 #include <tinyara/pm/pm.h>
 #include <tinyara/wdog.h>
 #include <tinyara/sched.h>
@@ -101,7 +102,7 @@ static void timer_timeout(int argc, int domain_id, uint32_t hash_pid)
  * 
  * Parameters:
  *   domain_id - ID of domain to be suspended
- *   timer_interval - expected lock duration in millisecond
+ *   milliseconds - expected lock duration in millisecond
  *
  * Return Value:
  *   0 - success
@@ -109,7 +110,7 @@ static void timer_timeout(int argc, int domain_id, uint32_t hash_pid)
  *
  ************************************************************************/
 
-int pm_timedsuspend(int domain_id, unsigned int timer_interval)
+int pm_timedsuspend(int domain_id, unsigned int milliseconds)
 {
 	int hash_pid = PIDHASH(getpid());
 
@@ -138,7 +139,7 @@ int pm_timedsuspend(int domain_id, unsigned int timer_interval)
 		goto errout;
 		
 	}
-	if (wd_start(wdog, timer_interval, (wdentry_t)timer_timeout, 2, domain_id, (uint32_t)hash_pid) != OK) {
+	if (wd_start(wdog, MSEC2TICK(milliseconds), (wdentry_t)timer_timeout, 2, domain_id, (uint32_t)hash_pid) != OK) {
 		pmvdbg("Error starting Wdog timer\n");
 		if (pm_resume(domain_id) != OK) {
 			pmdbg("Unable to resume domain: %s\n", pm_domain_map[domain_id]);
@@ -146,7 +147,7 @@ int pm_timedsuspend(int domain_id, unsigned int timer_interval)
 		set_errno(EAGAIN);
 		goto errout;
 	}
-	pmvdbg("PM is locked for pid %d and timer started for %d milliseconds\n", getpid(), timer_interval);
+	pmvdbg("PM is locked for pid %d and timer started for %d milliseconds\n", getpid(), milliseconds);
 	return OK;
 errout:
 	pid_timer_map[hash_pid] = NULL;


### PR DESCRIPTION
this commits updates the time unit value from nanoseconds to milliseconds in timedstay api of PM during ble onboarding trigger operation.