### PR TITLE
os/arch/arm/src/amebasmart: Remap timer index for app usage

### DIFF
--- a/os/arch/arm/src/amebasmart/amebasmart_timer_lowerhalf.c
+++ b/os/arch/arm/src/amebasmart/amebasmart_timer_lowerhalf.c
@@ -442,22 +442,22 @@ int amebasmart_timer_initialize(const char *devpath, int timer)
 	switch (timer) {
 	case TIMER0:
 		priv = &g_gpt0_lowerhalf;
-		priv->obj.timer_id = TIMER0;
+		priv->obj.timer_id = TIMER4;
 		break;
 
 	case TIMER1:
 		priv = &g_gpt1_lowerhalf;
-		priv->obj.timer_id = TIMER1;
+		priv->obj.timer_id = TIMER5;
 		break;
 
 	case TIMER2:
 		priv = &g_gpt2_lowerhalf;
-		priv->obj.timer_id = TIMER2;
+		priv->obj.timer_id = TIMER6;
 		break;
 
 	case TIMER3:
 		priv = &g_gpt3_lowerhalf;
-		priv->obj.timer_id = TIMER3;
+		priv->obj.timer_id = TIMER7;
 		break;
 
 	default:


### PR DESCRIPTION
- Normally, app uses lowest index for HW timer, such as /dev/timer0. But, currently the kernel and driver has allocated timer 0~2 for several usage:
- timer0: LP systimer
- timer1: PM one-shot wakeup timer
- timer2: Crash detector for KM4/KM0 cpu status
- Due to above reason, we have to remap the timer index, so that when app is using lower index timer, it will not cause conflict with the timer which already has designated usage.
- For example, if app use /dev/timer0, it actually uses HW timer 3, and the rules follow by incrementing the index