### PR TITLE
Add performance test for internal & external flash for Read, write & Erase

### DIFF
--- a/apps/system/flash_test/flash_test.c
+++ b/apps/system/flash_test/flash_test.c
@@ -59,23 +59,41 @@
 #include <errno.h>
 #include <stdint.h>
 #include <sys/types.h>
-
+#include <arch/board/board.h>
+#include <tinyara/spi/spi.h>
 #include <tinyara/fs/mtd.h>
+#include <time.h>
+#include <tinyara/config.h>
+
+//#include <board/common/common.h>
 
 /****************************************************************************
  * Definitions
  ****************************************************************************/
-#define BUF_SIZE   1024
+#define BUF_SIZE   4096
 
 #define READ_CMD    "read"
+#define WRITE_CMD   "write"
+#define ERASE_CMD   "erase"
+
 /****************************************************************************
  * Private Data
  ****************************************************************************/
+struct timespec start_time;
+struct timespec end_time;
+
+enum flash_e {
+	FLASH_INTERNAL = 0,
+	FLASH_EXT = 1
+};
+typedef enum flash_e flash_t;
+
+FAR struct mtd_geometry_s geo;
 
 /****************************************************************************
  * Private Functions
  ****************************************************************************/
-static int flash_read(unsigned long addr, int size)
+static int flash_read(unsigned long addr, int size, flash_t flash)
 {
 	int ret;
 	int offset;
@@ -85,16 +103,54 @@ static int flash_read(unsigned long addr, int size)
 	FAR uint8_t *buffer;
 	FAR struct mtd_dev_s *dev_mtd = NULL;
 
+	long long total_duration_ms = 0;
+
+	int total_duration_s = 0;
 	if (addr == 0 || size <= 0) {
 		printf("Invalid arguments, offset 0x%x, read size %d\n", addr, size);
 		return ERROR;
 	}
+	if (flash == FLASH_INTERNAL) {
+		printf("Received Flash Read cmd for internal flash offset 0x%x, read size %d\n", addr, size);
+		dev_mtd = up_flashinitialize();
+		if (!dev_mtd) {
+			printf("up_flashinitialize Failed\n");
+			return ERROR;
+		}
 
-	dev_mtd = up_flashinitialize();
-	if (!dev_mtd) {
-		printf("up_flashinitialize Failed\n");
-		return ERROR;
 	}
+
+	else if (flash == FLASH_EXT) {
+		printf("Received Flash Read cmd for external flash offset 0x%x, read size %d\n", addr, size);
+#ifdef CONFIG_SECOND_FLASH_PARTITION
+		struct spi_dev_s *spi = up_spiinitialize(1);
+
+#ifdef CONFIG_MTD_JEDEC
+		dev_mtd = jedec_initialize(spi);
+		if (dev_mtd == NULL) {
+			lldbg("Jedec Init failed\n");
+			return ERROR;
+		}
+#elif defined(CONFIG_MTD_W25)
+		dev_mtd = w25_initialize(spi);
+		if (dev_mtd == NULL) {
+			lldbg("w25 Init failed\n");
+			return ERROR;
+		}
+		printf("w25_initialize: done for secondary flash \n");
+#endif
+#endif
+	}
+	/* Get the geometry of the FLASH device */
+	ret = dev_mtd->ioctl(dev_mtd, MTDIOC_GEOMETRY, (unsigned long)((uintptr_t) & geo));
+	if (ret < 0) {
+		fdbg("ERROR: mtd->ioctl failed: %d\n", ret);
+	}
+
+	printf("Flash Geometry:\n");
+	printf("  blocksize:      %lu\n", (unsigned long)geo.blocksize);
+	printf("  erasesize:      %lu\n", (unsigned long)geo.erasesize);
+	printf("  neraseblocks:   %lu\n", (unsigned long)geo.neraseblocks);
 
 	buffer = (uint8_t *)malloc(BUF_SIZE);
 	if (!buffer) {
@@ -108,6 +164,7 @@ static int flash_read(unsigned long addr, int size)
 	printf("Read 0x%x: ", addr);
 
 	while (remaining > 0) {
+		clock_gettime(CLOCK_REALTIME, &start_time);
 		read_size = BUF_SIZE < remaining ? BUF_SIZE : remaining;
 		ret = MTD_READ(dev_mtd, addr + offset, read_size, buffer);
 		if (ret <= 0) {
@@ -115,7 +172,9 @@ static int flash_read(unsigned long addr, int size)
 			free(buffer);
 			return ERROR;
 		}
+		clock_gettime(CLOCK_REALTIME, &end_time);
 
+		total_duration_ms += ((end_time.tv_sec - start_time.tv_sec) * 1000000000LL + (end_time.tv_nsec - start_time.tv_nsec)) / 1000000;
 		/* Print read buffer */
 		for (buf_idx = 0; buf_idx < ret; buf_idx++) {
 			if ((buf_idx % 16) == 0) {
@@ -126,10 +185,173 @@ static int flash_read(unsigned long addr, int size)
 		offset += ret;
 		remaining -= ret;
 	}
+	printf("\n time taken for Flash Read %lld(ms)\n", total_duration_ms);
+	printf("\n");
+	free(buffer);
+
+	return OK;
+}
+
+static fill_buffer(FAR uint8_t *buff)
+{
+	for (int i = 0; i < BUF_SIZE; i++) {
+		buff[i] = i;
+	}
+}
+
+static int flash_write(unsigned long addr, int size, flash_t flash)
+{
+	int ret;
+	int offset;
+	int buf_idx;
+	int write_size;
+	int remaining;
+	FAR uint8_t *buffer;
+	FAR struct mtd_dev_s *dev_mtd = NULL;
+
+	if (addr == 0 || size <= 0) {
+		printf("Invalid arguments, offset 0x%x, Write size %d\n", addr, size);
+		return ERROR;
+	}
+	if (flash == FLASH_INTERNAL) {
+		dev_mtd = up_flashinitialize();
+		if (!dev_mtd) {
+			printf("up_flashinitialize Failed\n");
+			return ERROR;
+		}
+	}
+
+	else if (flash == FLASH_EXT) {
+#ifdef CONFIG_SECOND_FLASH_PARTITION
+		struct spi_dev_s *spi = up_spiinitialize(1);
+
+#ifdef CONFIG_MTD_JEDEC
+		dev_mtd = jedec_initialize(spi);
+		if (dev_mtd == NULL) {
+			lldbg("Jedec Init failed\n");
+			return ERROR;
+		}
+#elif defined(CONFIG_MTD_W25)
+		dev_mtd = w25_initialize(spi);
+		if (dev_mtd == NULL) {
+			lldbg("w25 Init failed\n");
+			return ERROR;
+		}
+#endif
+#endif
+	}
+	buffer = (uint8_t *)malloc(BUF_SIZE);
+	if (!buffer) {
+		printf("Failed to allocate buffer %d\n", BUF_SIZE);
+		return ERROR;
+	}
+	fill_buffer(buffer);
+
+	offset = 0;
+	remaining = size;
+
+	printf("Write 0x%x: ", addr);
+	clock_gettime(CLOCK_REALTIME, &start_time);
+	while (remaining > 0) {
+		write_size = BUF_SIZE < remaining ? BUF_SIZE : remaining;
+		ret = MTD_WRITE(dev_mtd, addr + offset, write_size, buffer);
+		if (ret <= 0) {
+			printf("Write Failed : %d\n", ret);
+			free(buffer);
+			return ERROR;
+		}
+		offset += ret;
+		remaining -= ret;
+	}
+	clock_gettime(CLOCK_REALTIME, &end_time);
+	long duration = ((end_time.tv_sec - start_time.tv_sec) * 1000000000) + (end_time.tv_nsec - start_time.tv_nsec);
+	duration = duration / 1000000;
+
+	printf("\ntime taken for Flash Write %lld(ms)\n", ((end_time.tv_sec - start_time.tv_sec) * 1000000000LL + (end_time.tv_nsec - start_time.tv_nsec)) / 1000000);
 	printf("\n");
 
 	free(buffer);
 
+	return OK;
+}
+
+static int flash_erase(unsigned long addr, int size, flash_t flash)
+{
+	int ret;
+	int erase_sectors;
+	int erase_sector_st;
+
+	FAR struct mtd_dev_s *dev_mtd = NULL;
+
+	if (addr == 0 || size <= 0) {
+		printf("Invalid arguments, offset 0x%x, read size %d\n", addr, size);
+		return ERROR;
+	}
+
+	if (flash == FLASH_INTERNAL) {
+		dev_mtd = up_flashinitialize();
+		if (!dev_mtd) {
+			printf("up_flashinitialize Failed\n");
+			return ERROR;
+		}
+	}
+
+	else if (flash == FLASH_EXT) {
+#ifdef CONFIG_SECOND_FLASH_PARTITION
+		struct spi_dev_s *spi = up_spiinitialize(1);
+
+#ifdef CONFIG_MTD_JEDEC
+		dev_mtd = jedec_initialize(spi);
+		if (dev_mtd == NULL) {
+			lldbg("Jedec Init failed\n");
+			return ERROR;
+		}
+#elif defined(CONFIG_MTD_W25)
+		dev_mtd = w25_initialize(spi);
+		if (dev_mtd == NULL) {
+			lldbg("w25 Init failed\n");
+			return ERROR;
+		}
+#endif
+#endif
+	}
+
+	/* Get the geometry of the FLASH device */
+	ret = dev_mtd->ioctl(dev_mtd, MTDIOC_GEOMETRY, (unsigned long)((uintptr_t) & geo));
+	if (ret < 0) {
+		fdbg("ERROR: mtd->ioctl failed: %d\n", ret);
+	}
+
+	printf("Flash Geometry:\n");
+	printf("  blocksize:      %lu\n", (unsigned long)geo.blocksize);
+	printf("  erasesize:      %lu\n", (unsigned long)geo.erasesize);
+	printf("  neraseblocks:   %lu\n", (unsigned long)geo.neraseblocks);
+
+	if (addr % geo.erasesize != 0) {
+		printf("ERROR: Address not aligned with the Erase sector size\n");
+		return ERROR;
+	}
+	erase_sectors = size / geo.erasesize;
+	if (size % geo.erasesize != 0) {
+		erase_sectors++;
+	}
+	erase_sector_st = addr / geo.erasesize;
+
+	printf("Erase addr 0x%x & Secors 0x%x: ", addr, erase_sectors);
+	clock_gettime(CLOCK_REALTIME, &start_time);
+
+	ret = MTD_ERASE(dev_mtd, erase_sector_st, erase_sectors);
+	if (ret < 0) {
+		printf("Erase Failed: %d Erase sector is : %d\n", ret, erase_sector_st);
+		return ERROR;
+	}
+
+	clock_gettime(CLOCK_REALTIME, &end_time);
+	long duration = ((end_time.tv_sec - start_time.tv_sec) * 1000000000) + (end_time.tv_nsec - start_time.tv_nsec);
+	duration = duration / 1000000;
+
+	printf("\ntime taken for Flash Erase of %ld sectors of sector size %ld is  %lld(ms)\n", erase_sectors, geo.erasesize, ((end_time.tv_sec - start_time.tv_sec) * 1000000000LL + (end_time.tv_nsec - start_time.tv_nsec)) / 1000000);
+	printf("\n");
 	return OK;
 }
 
@@ -143,19 +365,37 @@ int flash_test_main(int argc, char *argv[])
 #endif
 {
 	off_t offset;
-	int read_size;
+	int size;
+	flash_t flash_type;
 
-	if (argc == 4 && !strncmp(argv[1], READ_CMD, sizeof(READ_CMD) + 1)) {
+	if (argc == 5 && !strncmp(argv[1], READ_CMD, sizeof(READ_CMD) + 1)) {
 		offset = strtoul(argv[2], NULL, 16);
-		read_size = (int)atoi(argv[3]);
+		size = (int)atoi(argv[3]);
+		flash_type = (flash_t) atoi(argv[4]);
 
 		/* Read an address in flash by size */
-		return flash_read(offset, read_size);
+		return flash_read(offset, size, flash_type);
+	} else if (argc == 5 && !strncmp(argv[1], WRITE_CMD, sizeof(WRITE_CMD) + 1)) {
+		offset = strtoul(argv[2], NULL, 16);
+		size = (int)atoi(argv[3]);
+		flash_type = (flash_t) atoi(argv[4]);
+		/* Write an address in flash by size */
+		return flash_write(offset, size, flash_type);
+	} else if (argc == 5 && !strncmp(argv[1], ERASE_CMD, sizeof(ERASE_CMD) + 1)) {
+		offset = strtoul(argv[2], NULL, 16);
+		size = (int)atoi(argv[3]);
+		flash_type = (flash_t) atoi(argv[4]);
+		/* Write an address in flash by size */
+		return flash_erase(offset, size, flash_type);
 	}
 
-	printf("Usage: flash_test read <offset> <size(bytes)>\n");
+	printf("Usage: flash_test read <offset> <size(bytes)> <Flash_type>(0: Internal, 1: External)\n");
+	printf("Usage: flash_test write <offset> <size(bytes)> <Flash_type>(0: Internal, 1: External)\n");
+	printf("Usage: flash_test erase <offset> <size(bytes)> <Flash_type>(0: Internal, 1: External)\n");
+
 	printf("Read flash by 'size' from 'flash base address + offset'\n");
 	printf(" * Flash base address is board-specific \n");
+	printf(" * Make sure to give the sector aligned address for the Flash erase \n");
 
 	return ERROR;
 }


### PR DESCRIPTION
Add performance test for internal & external flash for Read, write & Erase.

Measurement captured as below. 
**Note**: Flash sector Config for Internal & External Flash-> 4KB Sector.

<html xmlns:o="urn:schemas-microsoft-com:office:office"
xmlns:x="urn:schemas-microsoft-com:office:excel"
xmlns="http://www.w3.org/TR/REC-html40">

<head>

<meta name=ProgId content=Excel.Sheet>
<meta name=Generator content="Microsoft Excel 15">
<link id=Main-File rel=Main-File
href="file:///C:/Users/prabu.r/AppData/Local/Temp/msohtmlclip1/01/clip.htm">
<link rel=File-List
href="file:///C:/Users/prabu.r/AppData/Local/Temp/msohtmlclip1/01/clip_filelist.xml">
<style>
<!--table
	{mso-displayed-decimal-separator:"\.";
	mso-displayed-thousand-separator:"\,";}
@page
	{margin:.75in .7in .75in .7in;
	mso-header-margin:.3in;
	mso-footer-margin:.3in;}
tr
	{mso-height-source:auto;}
col
	{mso-width-source:auto;}
br
	{mso-data-placement:same-cell;}
td
	{padding-top:1px;
	padding-right:1px;
	padding-left:1px;
	mso-ignore:padding;
	color:black;
	font-size:11.0pt;
	font-weight:400;
	font-style:normal;
	text-decoration:none;
	font-family:Calibri, sans-serif;
	mso-font-charset:0;
	mso-number-format:General;
	text-align:general;
	vertical-align:bottom;
	border:none;
	mso-background-source:auto;
	mso-pattern:auto;
	mso-protection:locked visible;
	white-space:nowrap;
	mso-rotate:0;}
.xl63
	{border:.5pt solid windowtext;}
.xl64
	{font-weight:700;
	border:.5pt solid windowtext;
	background:#D9D9D9;
	mso-pattern:black none;}
-->
</style>
</head>

<body link="#0563C1" vlink="#954F72">


Flash_Type | Read_4K / 1 MB | Write_4K / 1MB | Erase_4K / 1MB
-- | -- | -- | --
Internal | 1 / 29msec | 7 msec / 1713 msec | 41 msec / 10567 msec
External | 6msec / 1496msec | 20 msec / 3008 msec | 6 msec / 8572 msec



</body>

</html>
