### PR TITLE
os: fix pm wakeup hang issue

### DIFF
--- a/os/kernel/wdog/wdog.h
+++ b/os/kernel/wdog/wdog.h
@@ -160,7 +160,7 @@ unsigned int wd_timer(int ticks);
 void wd_timer(void);
 #endif
 #ifdef CONFIG_SCHED_TICKSUPPRESS
-void wd_timer_nohz(int ticks);
+void wd_timer_nohz(clock_t ticks);
 #endif
 /****************************************************************************
  * Name: wd_recover

--- a/os/pm/pm_wakehandler.c
+++ b/os/pm/pm_wakehandler.c
@@ -60,8 +60,8 @@ void pm_wakehandler(clock_t missing_tick, pm_wakeup_reason_code_t wakeup_src)
 	pmllvdbg("missing_tick: %llu\n", missing_tick);
 
 	if (missing_tick > 0) {
-		clock_timer_nohz((clock_t)missing_tick);
-		wd_timer_nohz(missing_tick > INT_MAX ? INT_MAX : (int)missing_tick);
+		clock_timer_nohz(missing_tick);
+		wd_timer_nohz(missing_tick);
 	}
 
 	/* After wakeup change PM State to STANDBY and reset the time slice */


### PR DESCRIPTION
The pm_wakehandler is currently experiencing a hang. This is caused by the IDLE thread giving up the CPU while executing the pm_wakehandler. The pm_wakehandler is executed by the IDLE thread after the main core has awakened and the tick timer is still stopped. Therefore, if the IDLE thread gives up the CPU while executing the pm_wakehandler, it cannot regain the CPU without another thread voluntarily relinquishing it, which prevents the tick timer from restarting. This is because the tick timer is stopped and the RR scheduling does not work.

The pm_wakehandler includes the wd_expire operation. However, since the wd expire handler can include context switching operations such as sem_post or signals, the IDLE thread may give up the CPU.

Therefore, Change to so that, the suppressed tick is corrected in the pm_wakehandler and the wd_exipre is modified to be executed in the next tick ISR.