### PR TITLE
apps/examples/rtc: initialize prev time to epoch for RTC to work

### DIFF
--- a/apps/examples/rtc/rtc_main.c
+++ b/apps/examples/rtc/rtc_main.c
@@ -86,7 +86,9 @@ static void *rtc_test(void *arg)
 {
 	int ret;
 	int fd;
-	struct rtc_time prev_time;
+
+	/* populate prev_time to epoch (01-01-1970) in order reset RTC as it provides number of seconds passed starting from epoch */
+	struct rtc_time prev_time = RTC_TIME_INITIALIZER(1970, 1, 1, 0, 0, 0);
 	struct rtc_time next_time;
 	struct tm prev_tm;
 	struct tm next_tm;
@@ -100,7 +102,6 @@ static void *rtc_test(void *arg)
 	 * You can check and compare the time which is from Serial Log Tool like Teraterm and the printed log from line 140.
 	 */
 
-	memset(&prev_time, 0, sizeof(struct rtc_time));
 	memset(&next_time, 0, sizeof(struct rtc_time));
 	memset(&prev_tm, 0, sizeof(struct tm));
 	memset(&next_tm, 0, sizeof(struct tm));

--- a/os/include/tinyara/rtc.h
+++ b/os/include/tinyara/rtc.h
@@ -219,6 +219,21 @@ struct rtc_time {
 	int tm_isdst; /* Non-0 if daylight savings time is in effect (unused) */
 };
 
+/*
+ * Below initializer can be used to convert regular date-time to rtc date-time. The input range is as follows,
+ *
+ * entry | range
+ * -------------- 
+ * year  | (>= 1900)
+ * month | (1-12)
+ * day   | (1-31)
+ * hour  | (0-23)
+ * min   | (0-59)
+ * sec   | (0-60)
+ *
+ */
+#define RTC_TIME_INITIALIZER(year, month, day, hour, min, sec) {sec, min, hour, day, month - 1, year - TM_YEAR_BASE, 0, 0, 0}
+
 #ifdef CONFIG_RTC_ALARM
 /* Structure used with the RTC_RD_ALARM IOCTL command and with
  * rdalarm() method.


### PR DESCRIPTION
RTC doesnt work because of wrong initialization. Hence, initialize RTC with epoch time

```
[RTW]: ** Band = 2.4G and 5G **
System Information:
        Version:
                Platform: 3.1   Binary: 200204
        Commit Hash: 85bd621
        Build User: root@=
        Build Time: 2024-06-19 10:57:01 IST
        System Time: 19 Jun 2024, 00:00:00 [s] UTC Hardware RTC Support
TASH>>Hello, World!!

TASH>>rtc
TASH>>=== RTC Accuracy Test ===
[Total 0m passed] Time Difference : 1s
[Total 0m passed] Time Difference : 1s
[Total 0m passed] Time Difference : 1s
[Total 0m passed] Time Difference : 1s
[Total 0m passed] Time Difference : 1s
[Total 0m passed] Time Difference : 1s
[Total 0m passed] Time Difference : 1s
[Total 0m passed] Time Difference : 1s

```