### PR TITLE
os/arch/arm/src/amebasmart: Revise BSP to follow PM new structure

### DIFF
--- a/os/arch/arm/src/amebasmart/amebasmart_flash.c
+++ b/os/arch/arm/src/amebasmart/amebasmart_flash.c
@@ -70,6 +70,9 @@
 #include "chip.h"
 #include "flash_api.h"
 #include "device_lock.h"
+#ifdef CONFIG_PM
+#include "tinyara/pm/pm.h"
+#endif
 /****************************************************************************
  * Pre-processor Definitions
  ************************************************************************************/
@@ -369,6 +372,9 @@ FAR struct mtd_dev_s *up_flashinitialize(void)
 		lldbg("Manufacturer : %u memory type : %u capacity : %u\n", chip_id[0], chip_id[1], chip_id[2]);
 		return (FAR struct mtd_dev_s *)priv;
 	}
+#ifdef CONFIG_PM
+	bsp_pm_domain_register("FLASH", BSP_FLASH_DRV);
+#endif
 	return NULL;
 }
 

--- a/os/arch/arm/src/amebasmart/amebasmart_i2c.c
+++ b/os/arch/arm/src/amebasmart/amebasmart_i2c.c
@@ -1024,10 +1024,16 @@ static int amebasmart_i2c_process(FAR struct i2c_dev_s *dev, FAR struct i2c_msg_
 	priv->msgv = msgs;
 	priv->msgc = count;
 
+#ifdef CONFIG_PM
+	bsp_pm_domain_control(BSP_I2C_DRV, 1);
+#endif
 	int ret = 0;
 	ret = amebasmart_i2c_sem_waitdone(priv);
 
 	amebasmart_i2c_sem_post(priv);
+#ifdef CONFIG_PM
+	bsp_pm_domain_control(BSP_I2C_DRV, 0);
+#endif
 	return ret;
 
 }
@@ -1284,6 +1290,7 @@ static uint32_t rtk_i2c_resume(uint32_t expected_idle_time, void *param)
 #ifdef CONFIG_PM
 void i2c_pminitialize(void)
 {
+	bsp_pm_domain_register("I2C", BSP_I2C_DRV);
 	pmu_register_sleep_callback(PMU_I2C_DEVICE, (PSM_HOOK_FUN)rtk_i2c_suspend, NULL, (PSM_HOOK_FUN)rtk_i2c_resume, NULL);
 }
 #endif

--- a/os/arch/arm/src/amebasmart/amebasmart_i2s.c
+++ b/os/arch/arm/src/amebasmart/amebasmart_i2s.c
@@ -387,6 +387,9 @@ static int amebasmart_i2s_tx(struct amebasmart_i2s_s *priv, struct amebasmart_bu
 	int *ptx_buf;
 	int tx_size;
 
+#ifdef CONFIG_PM
+	bsp_pm_domain_control(BSP_I2S_DRV, 1);
+#endif
 	tx_size = I2S_DMA_PAGE_SIZE; /* Track current byte size to increment by */
 	struct ap_buffer_s *apb;
 	if (NULL != bfcontainer && NULL != bfcontainer->apb) {
@@ -415,6 +418,9 @@ static int amebasmart_i2s_tx(struct amebasmart_i2s_s *priv, struct amebasmart_bu
 		ret = -1;
 		i2serr("ERROR: bfcontainer or bfcontainer->apb is NULL\n");
 	}
+#ifdef CONFIG_PM
+	bsp_pm_domain_control(BSP_I2S_DRV, 0);
+#endif
 	return ret;
 }
 
@@ -702,6 +708,9 @@ void i2s_transfer_tx_handleirq(void *data, char *pbuf)
 	struct amebasmart_i2s_s *priv = (struct amebasmart_i2s_s *)data;
 	int tx_size;
 
+#ifdef CONFIG_PM
+	bsp_pm_domain_control(BSP_I2S_DRV, 1);
+#endif
 	tx_size = I2S_DMA_PAGE_SIZE;							   /* Track current byte size to increment by */
 	if ((priv->apb_tx->nbytes - priv->apb_tx->curbyte) <= 0) { /* Condition to stop sending if all data in the buffer has been sent */
 		int result = OK;
@@ -720,6 +729,9 @@ void i2s_transfer_tx_handleirq(void *data, char *pbuf)
 		priv->apb_tx->curbyte += tx_size; /* No padding, ptx_buf is big enough to fill the whole tx_size */
 		i2s_send_page(priv->i2s_object, (uint32_t *)ptx_buf);
 	}
+#ifdef CONFIG_PM
+	bsp_pm_domain_control(BSP_I2S_DRV, 0);
+#endif
 }
 
 #if defined(I2S_HAVE_RX) && (0 < I2S_HAVE_RX)
@@ -1882,6 +1894,7 @@ static uint32_t rtk_i2s_resume(uint32_t expected_idle_time, void *param)
 #ifdef CONFIG_PM
 void i2s_pminitialize(void)
 {
+	bsp_pm_domain_register("I2S", BSP_I2S_DRV);
 	pmu_register_sleep_callback(PMU_I2S_DEVICE, (PSM_HOOK_FUN)rtk_i2s_suspend, NULL, (PSM_HOOK_FUN)rtk_i2s_resume, NULL);
 }
 #endif

--- a/os/arch/arm/src/amebasmart/amebasmart_mipi.c
+++ b/os/arch/arm/src/amebasmart/amebasmart_mipi.c
@@ -298,6 +298,9 @@ static int amebasmart_mipi_detach(FAR struct mipi_dsi_host *dsi_host, FAR struct
 
 static int amebasmart_mipi_transfer(FAR struct mipi_dsi_host *dsi_host, FAR const struct mipi_dsi_msg *msg)
 {
+#ifdef CONFIG_PM
+	bsp_pm_domain_control(BSP_MIPI_DRV, 1);
+#endif
 	FAR struct amebasmart_mipi_dsi_host_s *priv = (FAR struct amebasmart_mipi_dsi_host_s *)dsi_host;
 	struct mipi_dsi_packet packet;
 
@@ -322,6 +325,9 @@ static int amebasmart_mipi_transfer(FAR struct mipi_dsi_host *dsi_host, FAR cons
 	while(send_cmd_done != 1) {
 		DelayMs(1);
 	}
+#ifdef CONFIG_PM
+	bsp_pm_domain_control(BSP_MIPI_DRV, 0);
+#endif
 	return OK;
 }
 
@@ -358,7 +364,7 @@ struct mipi_dsi_host *amebasmart_mipi_dsi_host_initialize(struct lcd_data *confi
 	amebasmart_mipi_init_helper(priv);
 	mipi_dsi_host_register(&priv->dsi_host);
 #ifdef CONFIG_PM
-	(void)pm_domain_register("MIPI");
+	bsp_pm_domain_register("MIPI", BSP_MIPI_DRV);
 	pmu_register_sleep_callback(PMU_MIPI_DEVICE, (PSM_HOOK_FUN)rtk_mipi_suspend, NULL, (PSM_HOOK_FUN)rtk_mipi_resume, NULL);
 #endif
 

--- a/os/arch/arm/src/amebasmart/amebasmart_pmhelpers.c
+++ b/os/arch/arm/src/amebasmart/amebasmart_pmhelpers.c
@@ -50,7 +50,8 @@
 #include "osdep_service.h"
 #include "timer_api.h"
 
-gtimer_t g_timer1;
+static gtimer_t g_timer1;
+static int g_bsp_domain_id[BSP_DOMAIN_MAX];
 
 void SOCPS_SetAPWakeEvent_MSK0(u32 Option, u32 NewStatus)
 {
@@ -112,19 +113,41 @@ int SOCPS_AONWakeReason(void)
 	return reason;
 }
 
-void pg_timer_int_handler(void *Data)
+void up_set_pm_timer(unsigned int interval_us) 
 {
-	pmvdbg("PM Timer interrupt handler!!\n");
-}
-
-void up_set_pm_timer(unsigned int interval_us) {
 	// Check whether timer interrupt need to be set
 	if (interval_us > 0) {
 		gtimer_init(&g_timer1, TIMER1);
 		/* Pass in timer obj to avoid compile warning, the last argument will not be used in the callback handler */
-		gtimer_start_one_shout(&g_timer1, interval_us, (void *)pg_timer_int_handler, (uint32_t)&g_timer1);
+		gtimer_start_one_shout(&g_timer1, interval_us, NULL, (uint32_t)&g_timer1);
 	}
 	return;
+}
+
+void bsp_pm_domain_register(char *domain_name, int bsp_drv_id)
+{
+	int domain_id = pm_domain_register(domain_name);
+	if (domain_id < 0) {
+		pmdbg("Unable to register %s DOMAIN\n", domain_name);
+	} else {
+		g_bsp_domain_id[bsp_drv_id] = domain_id;
+	}
+}
+
+void bsp_pm_domain_control(int bsp_drv_id, bool is_suspend)
+{
+	/* Retrive the domain id from the bsp driver id */
+	int domain_id = g_bsp_domain_id[bsp_drv_id];
+	if (is_suspend) {
+		/* Check BSP_DRV_DOMAIN enum for more info */
+		if (pm_suspend(domain_id) != OK) {
+			pmdbg("Unable to suspend bsp_drv_id: %d!\n", bsp_drv_id);
+		}
+	} else {
+		if (pm_resume(domain_id) != OK) {
+			pmdbg("Unable to resume bsp_drv_id: %d!\n", bsp_drv_id);
+		}
+	}
 }
 
 /* Interrupt callback from wifi-keepalive, which LP received designated packet*/

--- a/os/board/rtl8730e/src/component/bluetooth/api/rtk_bt_power_control.c
+++ b/os/board/rtl8730e/src/component/bluetooth/api/rtk_bt_power_control.c
@@ -18,36 +18,6 @@
 #include "ameba_soc.h"
 #include "wifi_conf.h"
 
-/* Power management definitions */
-#ifdef CONFIG_PM
-#include <tinyara/pm/pm.h>
-static void amebasmart_ble_pmnotify(FAR struct pm_callback_s *cb,
-										enum pm_state_e pmstate);
-static int  amebasmart_ble_pmprepare(FAR struct pm_callback_s *cb,
-										enum pm_state_e pmstate);
-#endif
-
-rtk_bt_ps_callback rtk_bt_suspend_callback = NULL;
-rtk_bt_ps_callback rtk_bt_resume_callback = NULL;
-
-static void bt_power_suspend_callback(void)
-{
-	pmvdbg("[BT_PS] BT is entering sleep wake now\r\n");
-}
-
-static void bt_power_resume_callback(void)
-{
-	pmvdbg("[BT_PS] BT is wake now\r\n");
-}
-
-extern int wifi_set_ips_internal(u8 enable);
-static void system_enable_power_save(void)
-{
-	/* Release other wake lock if needed */
-	wifi_set_lps_enable(TRUE);
-	wifi_set_ips_internal(TRUE);
-}
-
 static void rtk_bt_enable_bt_wake_host(void)
 {
 	if (irq_get_pending(BT_WAKE_HOST_IRQ)) {
@@ -80,12 +50,7 @@ static uint32_t rtk_bt_suspend(uint32_t expected_idle_time, void *param)
 	hci_platform_force_uart_rts(true);
 #endif
 #endif
-
 	rtk_bt_enable_bt_wake_host();
-
-	if (rtk_bt_suspend_callback) {
-		rtk_bt_suspend_callback();
-	}
 
 	return 1;
 }
@@ -98,10 +63,6 @@ static uint32_t rtk_bt_resume(uint32_t expected_idle_time, void *param)
 	pmvdbg("[BT_PS] Enter rtk_bt_resume\r\n");
 
 	rtk_bt_disable_bt_wake_host();
-
-	if (rtk_bt_resume_callback) {
-		rtk_bt_resume_callback();
-	}
 
 #ifndef CONFIG_PLATFORM_TIZENRT_OS
 #if defined(CONFIG_BT_SINGLE_CORE) && CONFIG_BT_SINGLE_CORE
@@ -119,131 +80,12 @@ static uint32_t rtk_bt_wake_host_irq_handler(void *data)
 	return 1;
 }
 
-#ifdef CONFIG_PM
-static struct
-{
-	struct pm_callback_s pm_cb;
-} g_blepm =
-	{
-		.pm_cb.name = "rtl8730e_ble",
-		.pm_cb.notify  = amebasmart_ble_pmnotify,
-		.pm_cb.prepare = amebasmart_ble_pmprepare,
-	};
-#endif
-
-/****************************************************************************
- * Name: up_pm_notify
- *
- * Description:
- *   Notify the driver of new power state. This callback is called after
- *   all drivers have had the opportunity to prepare for the new power state.
- *
- * Input Parameters:
- *
- *    cb - Returned to the driver. The driver version of the callback
- *         structure may include additional, driver-specific state data at
- *         the end of the structure.
- *
- *    pmstate - Identifies the new PM state
- *
- * Returned Value:
- *   None - The driver already agreed to transition to the low power
- *   consumption state when it returned OK to the prepare() call.
- *
- ****************************************************************************/
-#ifdef CONFIG_PM
-static void amebasmart_ble_pmnotify(struct pm_callback_s *cb,
-				enum pm_state_e pmstate)
-{
-	switch (pmstate) {
-	case PM_NORMAL:		/* Logic for PM_NORMAL goes here */
-	case PM_IDLE:		/* Logic for PM_IDLE goes here */
-	case PM_STANDBY:	/* Logic for PM_STANDBY goes here */
-		break;
-
-	case PM_SLEEP:		/* Logic for PM_SLEEP goes here */
-        system_enable_power_save();
-		break;
-
-	default:
-		/* Should not get here */
-		break;
-	}
-}
-#endif
-
-/****************************************************************************
- * Name: up_pm_prepare
- *
- * Description:
- *   Request the driver to prepare for a new power state. This is a warning
- *   that the system is about to enter into a new power state. The driver
- *   should begin whatever operations that may be required to enter power
- *   state. The driver may abort the state change mode by returning a
- *   non-zero value from the callback function.
- *
- * Input Parameters:
- *
- *    cb - Returned to the driver. The driver version of the callback
- *         structure may include additional, driver-specific state data at
- *         the end of the structure.
- *
- *    pmstate - Identifies the new PM state
- *
- * Returned Value:
- *   Zero - (OK) means the event was successfully processed and that the
- *          driver is prepared for the PM state change.
- *
- *   Non-zero - means that the driver is not prepared to perform the tasks
- *              needed achieve this power setting and will cause the state
- *              change to be aborted. NOTE: The prepare() method will also
- *              be called when reverting from lower back to higher power
- *              consumption modes (say because another driver refused a
- *              lower power state change). Drivers are not permitted to
- *              return non-zero values when reverting back to higher power
- *              consumption modes!
- *
- ****************************************************************************/
-#ifdef CONFIG_PM
-extern uint8_t ble_client_connect_is_running;
-static int amebasmart_ble_pmprepare(struct pm_callback_s *cb,
-		enum pm_state_e pmstate)
-{
-	switch (pmstate) {
-	case PM_NORMAL:		/* Logic for PM_NORMAL goes here */
-	case PM_IDLE:		/* Logic for PM_IDLE goes here */
-	case PM_STANDBY:	/* Logic for PM_STANDBY goes here */
-		break;
-
-	case PM_SLEEP:		/* Logic for PM_SLEEP goes here */
-		if(ble_client_connect_is_running)
-			return ERROR;
-		break;
-
-	default:
-		/* Should not get here */
-		break;
-	}
-	return OK;
-}
-#endif /* CONFIG_PM */
-
 void rtk_bt_power_save_init(void)
 {
 #ifdef CONFIG_PM	/* If PM is enable inti BT power save */
-	int result;
-	rtk_bt_suspend_callback = bt_power_suspend_callback;
-	rtk_bt_resume_callback = bt_power_resume_callback;
-
 	/* register callback before entering ps mode and after exiting ps mode */
 	pmu_register_sleep_callback(PMU_BT_DEVICE, (PSM_HOOK_FUN)rtk_bt_suspend, NULL, (PSM_HOOK_FUN)rtk_bt_resume, NULL);
-
 	InterruptRegister((IRQ_FUN)rtk_bt_wake_host_irq_handler, BT_WAKE_HOST_IRQ, (int)NULL, INT_PRI_LOWEST);
-
-	/* Register to receive power management callbacks */
-	result = pm_register(&g_blepm.pm_cb);
-	DEBUGASSERT(result == OK);
-	UNUSED(result);
 #endif
 }
 
@@ -252,14 +94,7 @@ void rtk_bt_power_save_deinit(void)
 #ifdef CONFIG_PM
 	InterruptDis(BT_WAKE_HOST_IRQ);
 	InterruptUnRegister(BT_WAKE_HOST_IRQ);
-
 	pmu_unregister_sleep_callback(PMU_BT_DEVICE);
-
-	rtk_bt_suspend_callback = NULL;
-	rtk_bt_resume_callback = NULL;
-
-	/* Unregister power management callbacks */
-	pm_unregister(&g_blepm.pm_cb);
 #endif
 }
 #endif

--- a/os/board/rtl8730e/src/component/mbed/targets/hal/rtl8730e/i2s_api.c
+++ b/os/board/rtl8730e/src/component/mbed/targets/hal/rtl8730e/i2s_api.c
@@ -216,7 +216,9 @@ void i2s_set_dma_buffer(i2s_t *obj, char *tx_buf, char *rx_buf,
 {
 	assert_param(IS_SP_SEL_I2S(obj->i2s_idx));
 
+#if defined(CONFIG_AMEBASMART_I2S_TX) || defined(CONFIG_AMEBASMART_I2S_RX)
 	uint32_t i, j;
+#endif
 
 	if ((page_num < 2) || (page_num > 8) || (page_size < 8)) {
 		DBG_PRINTF(MODULE_I2S, LEVEL_INFO, "%s: PageNum(%d) valid value is 2~8; PageSize(%d must > 8)\r\n", \

--- a/os/board/rtl8730e/src/component/soc/amebad2/misc/ameba_tizenrt_pmu.c
+++ b/os/board/rtl8730e/src/component/soc/amebad2/misc/ameba_tizenrt_pmu.c
@@ -2,7 +2,6 @@
 #include "ameba_soc.h"
 #ifdef CONFIG_PM
 #include <tinyara/pm/pm.h>
-#endif
 
 uint32_t missing_tick = 0;
 
@@ -197,7 +196,6 @@ int tizenrt_ready_to_sleep(void)
 	return TRUE;
 }
 
-#ifdef CONFIG_PM
 void tizenrt_pre_sleep_processing(uint32_t *expected_idle_time, void (*handler)(clock_t, pm_wakeup_reason_code_t))
 {
 	uint32_t tick_before_sleep;
@@ -271,7 +269,6 @@ void tizenrt_post_sleep_processing(uint32_t *expected_idle_time)
 #endif
 
 }
-#endif
 
 u32 check_wfi_state(u8 core_id)
 {
@@ -348,3 +345,4 @@ uint32_t pmu_get_sleep_type(void)
 {
 	return sleep_type;
 }
+#endif	/* CONFIG_PM */

--- a/os/board/rtl8730e/src/component/soc/amebad2/misc/ameba_tizenrt_pmu.h
+++ b/os/board/rtl8730e/src/component/soc/amebad2/misc/ameba_tizenrt_pmu.h
@@ -3,7 +3,7 @@
 
 #ifdef CONFIG_PM
 #include <tinyara/pm/pm.h>
-#endif
+/* This enum is for pre/post sleep processing */
 typedef enum {
 	PMU_OS                  = 0,
 	PMU_WLAN_DEVICE         = 1,
@@ -17,6 +17,17 @@ typedef enum {
 	PMU_MIPI_DEVICE         = 9,
 	PMU_MAX,
 } PMU_DEVICE;
+
+/* This enum is for domain register to halt the PM state if driver operation is running */
+typedef enum {
+	BSP_SPI_DRV             = 0,
+	BSP_I2C_DRV             = 1,
+	BSP_I2S_DRV             = 2,
+	BSP_FLASH_DRV           = 3,
+	BSP_UART_DRV            = 4,
+	BSP_MIPI_DRV            = 5,
+	BSP_DOMAIN_MAX,
+} BSP_DRV_DOMAIN;
 
 // default locked by OS and not to sleep until OS release wakelock in somewhere
 #ifndef CONFIG_PLATFORM_TIZENRT_OS
@@ -60,10 +71,8 @@ void pmu_unregister_sleep_callback(u32 nDeviceId);
 
 int tizenrt_ready_to_sleep(void);
 int tizenrt_ready_to_dsleep(void);
-#ifdef CONFIG_PM
 void tizenrt_pre_sleep_processing(uint32_t *expected_idle_time, void (*handler)(clock_t, pm_wakeup_reason_code_t));
 void tizenrt_post_sleep_processing(uint32_t *expected_idle_time);
-#endif
 
 #ifndef CONFIG_PLATFORM_TIZENRT_OS
 void pmu_acquire_wakelock(uint32_t nDeviceId);
@@ -71,4 +80,5 @@ void pmu_release_wakelock(uint32_t nDeviceId);
 uint32_t pmu_get_wakelock_status(void);
 #endif
 
+#endif
 #endif

--- a/os/board/rtl8730e/src/component/wifi/inic/inic_ipc_host_api.c
+++ b/os/board/rtl8730e/src/component/wifi/inic/inic_ipc_host_api.c
@@ -393,7 +393,9 @@ void inic_ipc_api_init_host(VOID)
 	rtw_up_sema(&g_host_inic_api_message_send_sema);
 
 	/*for updating ip address before sleep*/
+#ifdef CONFIG_PM
 	pmu_register_sleep_callback(PMU_WLAN_DEVICE, (PSM_HOOK_FUN)_inic_ipc_ip_addr_update_in_wowlan, NULL, NULL, NULL);
+#endif
 
 	/* Initialize the event task */
 	if (rtw_create_task(&inic_ipc_api_host_handler, (const char *const)"inic_ipc_api_host_task", HOST_STACK_SIZE, (0 + CONFIG_INIC_IPC_HOST_API_PRIO), (void*)inic_ipc_api_host_task, NULL) != 1) {

--- a/os/board/rtl8730e/src/rtl8730e_mipi_lcdc.c
+++ b/os/board/rtl8730e/src/rtl8730e_mipi_lcdc.c
@@ -156,6 +156,9 @@ static void rtl8730e_lcd_layer_enable(int layer, bool enable)
 
 static void rtl8730e_lcd_put_area(u8 *lcd_img_buffer, u32 x_start, u32 y_start, u32 x_end, u32 y_end)
 {
+#ifdef CONFIG_PM
+	bsp_pm_domain_control(BSP_MIPI_DRV, 1);
+#endif
 	lcdc_init_struct.layerx[LCD_LAYER].LCDC_LayerImgBaseAddr = (u32) lcd_img_buffer;
 #if defined(CONFIG_ENABLE_LCD_CHANGE_WINDOW_SIZE)
 	lcdc_init_struct.layerx[LCD_LAYER].LCDC_LayerHorizontalStart = y_start;
@@ -171,6 +174,9 @@ static void rtl8730e_lcd_put_area(u8 *lcd_img_buffer, u32 x_start, u32 y_start, 
 	while (!lcdc_nextframe) {
 		DelayMs(1);
 	}
+#ifdef CONFIG_PM
+	bsp_pm_domain_control(BSP_MIPI_DRV, 0);
+#endif
 }
 
 static void rtl8730e_gpio_init(void)


### PR DESCRIPTION
- pm_register is removed from pm driver, changed to domain registration according to different driver module
- Old way: Register callback to PM driver, every PM state change will inform driver, some driver status will be checked to determine whether a PM state change is given approval
- Revised way: Register domain to PM driver, suspend/resume domain according to operation in different driver module