### PR TITLE
loadable_apps, binfmt: add config to use --whole-archieve option

### DIFF
--- a/loadable_apps/Makefile
+++ b/loadable_apps/Makefile
@@ -67,9 +67,13 @@ $(1)_$(2):
 endef
 $(foreach BDIR, $(CONFIGURED), $(eval $(call DIR_template,$(BDIR),context)))
 $(foreach BDIR, $(CONFIGURED), $(eval $(call DIR_template,$(BDIR),all)))
+ifeq ($(CONFIG_XIP_ELF),y)
+$(foreach BDIR, $(CONFIGURED), $(eval $(call DIR_template,$(BDIR),undefsym)))
+endif
 $(foreach BDIR, $(BUILDIRS), $(eval $(call DIR_template,$(BDIR),preconfig)))
 $(foreach CDIR, $(BUILDIRS), $(eval $(call DIR_template,$(CDIR),clean)))
 $(foreach CDIR, $(BUILDIRS), $(eval $(call DIR_template,$(CDIR),distclean)))
+
 
 ifeq ($(CONFIG_APP_BINARY_SEPARATION),y)
 $(foreach BDIR, $(CONFIGURED), $(eval $(call DIR_template,$(BDIR),install)))
@@ -86,6 +90,10 @@ all: build
 endif # CONFIG_APP_BINARY_SEPARATION
 
 build: $(foreach BDIR, $(CONFIGURED), $(BDIR)_all)
+
+ifeq ($(CONFIG_XIP_ELF),y)
+undefsym: $(foreach BDIR, $(CONFIGURED), $(BDIR)_undefsym)
+endif
 
 context: $(foreach BDIR, $(CONFIGURED), $(BDIR)_context)
 

--- a/loadable_apps/loadable.mk
+++ b/loadable_apps/loadable.mk
@@ -61,6 +61,10 @@ endif
 ifeq ($(CONFIG_XIP_ELF),y)
 $(BIN): $(OBJS)
 	$(Q) $(LD) -T $(USER_BIN_DIR)/$@_0.ld -T $(TOPDIR)/../build/configs/$(CONFIG_ARCH_BOARD)/scripts/xipelf/userspace_all.ld -e main -o $@ $(ARCHCRT0OBJ) $^ --start-group $(LIBGCC) $(LIBSUPXX) --end-group -R $(USER_BIN_DIR)/$(CONFIG_COMMON_BINARY_NAME)
+
+undefsym : $(OBJS)
+	$(Q) $(LD) $(LDELFFLAGS) -o $(USER_BIN_DIR)/$(BIN).relelf $(ARCHCRT0OBJ) $^ --start-group $(LIBGCC) --end-group
+	$(Q) $(NM) -u $(USER_BIN_DIR)/$(BIN).relelf | grep -v "w " | awk -F"U " '{print "--require-defined "$$2}' >> $(USER_BIN_DIR)/lib_symbols.txt
 endif
 
 clean:

--- a/os/Makefile.unix
+++ b/os/Makefile.unix
@@ -457,7 +457,12 @@ ifeq ($(CONFIG_ELF),y)
 else
 	$(Q) $(TOPDIR)/tools/mkldscript.py
 	$(Q) $(CC) -c $(CFLAGS) -D__COMMON_BINARY__ $(TOPDIR)/userspace/up_userspace.c -o  $(TOPDIR)/userspace/up_userspace_common.o
+ifneq ($(CONFIG_XIP_ELF_WARCHIVE), y)
+	$(Q) $(MAKE) -C $(LOADABLE_APPDIR) TOPDIR="$(TOPDIR)" LOADABLEDIR="${LOADABLE_APPDIR}" LIBRARIES_DIR="$(LIBRARIES_DIR)" USERLIBS="$(USERLIBS)" undefsym KERNEL=n
+	$(Q) $(LD) -o $(OUTBIN_DIR)/$(CONFIG_COMMON_BINARY_NAME) -T $(OUTBIN_DIR)/common_0.ld -T $(TOPDIR)/../build/configs/$(CONFIG_ARCH_BOARD)/scripts/xipelf/userspace_all.ld $(TOPDIR)/userspace/up_userspace_common.o -L $(LIBRARIES_DIR) --start-group $(USERLIBS) $(LIBGCC) $(LIBSUPXX) --end-group $$(cat $(OUTBIN_DIR)/lib_symbols.txt)
+else
 	$(Q) $(LD) -o $(OUTBIN_DIR)/$(CONFIG_COMMON_BINARY_NAME) -T $(OUTBIN_DIR)/common_0.ld -T $(TOPDIR)/../build/configs/$(CONFIG_ARCH_BOARD)/scripts/xipelf/userspace_all.ld $(TOPDIR)/userspace/up_userspace_common.o -L $(LIBRARIES_DIR) --whole-archive $(USERLIBS) --no-whole-archive --start-group $(LIBGCC) $(LIBSUPXX) --end-group
+endif
 	$(Q) $(MAKE) -C $(LOADABLE_APPDIR) TOPDIR="$(TOPDIR)" LOADABLEDIR="${LOADABLE_APPDIR}" LIBRARIES_DIR="$(LIBRARIES_DIR)" USERLIBS="$(USERLIBS)" all KERNEL=n
 endif
 endif

--- a/os/binfmt/Kconfig
+++ b/os/binfmt/Kconfig
@@ -48,6 +48,16 @@ config XIP_ELF
 endchoice
 
 
+if XIP_ELF
+
+config XIP_ELF_WARCHIVE
+	bool "Use Whole Archieve option to include full libraries"
+	default n
+	---help---
+		Use --whole-archieve flag for including full libraries
+
+endif
+
 if ELF
 source binfmt/libelf/Kconfig
 endif


### PR DESCRIPTION
If we use whole-archieve option, then full library gets included. Instead if not enabled, then only required symbols from the library will be picked

About ~350KB (7%) size reduction was observed on internal branch.