### PR TITLE
mm: replace watchdog stop to watchdog keepalive

### DIFF
--- a/os/mm/mm_heap/mm_manage_allocfail.c
+++ b/os/mm/mm_heap/mm_manage_allocfail.c
@@ -26,12 +26,6 @@
 #include <fcntl.h>
 #include <tinyara/fs/ioctl.h>
 #include <tinyara/mminfo.h>
-#endif
-#if defined(CONFIG_DEBUG_MM_HEAPINFO) && defined(CONFIG_WATCHDOG)
-#include <tinyara/watchdog.h>
-#include <fcntl.h>
-#endif
-#if defined(CONFIG_DEBUG_MM_HEAPINFO) && defined(CONFIG_WATCHDOG) || defined(CONFIG_APP_BINARY_SEPARATION) && !defined(__KERNEL__)
 #include <errno.h>
 #endif
 #include <debug.h>
@@ -47,62 +41,6 @@
 
 #define KERNEL_STR "kernel"
 #define USER_STR   "user"
-/****************************************************************************
- * Pre-processor Definitions
- ****************************************************************************/
-
-
-/************************************************************************
- * Name: mm_heapinfo_stop_watchdog
- *
- * Description:
- *   Stop the watchdog.
- *   Forced stop or pause of the watchdog breaks the time guaranteed by the watchdog.
- *   Therefore, if only watchdog is running and CONFIG_MM_ASSERT_ON_FAIL is enabled,
- *   try to stop the watchdog.
- *
- * Return Value:
- *   OK    - stopped watichdog or watchdog is not running.
- *   ERROR - fail to stop watchdog
- *
- ************************************************************************/
-#if defined(CONFIG_DEBUG_MM_HEAPINFO) && defined(CONFIG_WATCHDOG)
-static inline int mm_heapinfo_stop_watchdog(void)
-{
-	struct watchdog_status_s wd_status;
-	int fd = open(CONFIG_WATCHDOG_DEVPATH, O_RDWR);
-	if (fd < 0) {
-		mfdbg("Fail to open %s, errno %d\n", CONFIG_WATCHDOG_DEVPATH, get_errno());
-		return ERROR;
-	}
-
-	if (ioctl(fd, WDIOC_GETSTATUS, (unsigned long)&wd_status) != OK) {
-		mfdbg("Fail to get watchdog state, errno %d\n", get_errno());
-		close(fd);
-		return ERROR;
-	}
-
-	if (!(wd_status.flags & WDFLAGS_ACTIVE)) {
-		/* watchdog is not running */
-		close(fd);
-		return OK;
-	}
-
-#ifdef CONFIG_MM_ASSERT_ON_FAIL
-	/* watchdog can be stopped only when CONFIG_MM_ASSERT_ON_FAIL is enabled */
-	if (ioctl(fd, WDIOC_STOP, 0) == OK) {
-		close(fd);
-		return OK;
-	}
-	mfdbg("Fail to stop watchdog, errno %d\n", get_errno());
-#endif
-	close(fd);
-	return ERROR;
-}
-#else
-#define mm_heapinfo_stop_watchdog() OK
-#endif
-
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
@@ -179,23 +117,9 @@ void mm_manage_alloc_fail(struct mm_heap_s *heap, int startidx, int endidx, size
 #endif /* CONFIG_MM_ASSERT_ON_FAIL */
 
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
-	/* heapinfo_parse_heap() operations can print logs for more than 3 minutes,
-	 * which can be rebooted by watchdog. So try to stop the watchdog. */
-
-	int ret = mm_heapinfo_stop_watchdog();
-
-#ifndef CONFIG_MM_ASSERT_ON_FAIL
-	/* If CONFIG_MM_ASSERT_ON_FAIL is enabled, will be rebooted anyway, So even if
-	 * fail to stop watchdog, print heapinfo_parse_heap log. */
-
-	if (ret == OK)
-#endif
-	{
-		for (int idx = startidx; idx <= endidx; idx++) {
-			heapinfo_parse_heap(&heap[idx], HEAPINFO_DETAIL_ALL, HEAPINFO_PID_ALL);
-		}
+	for (int idx = startidx; idx <= endidx; idx++) {
+		heapinfo_parse_heap(&heap[idx], HEAPINFO_DETAIL_ALL, HEAPINFO_PID_ALL);
 	}
-
 #endif /* CONFIG_DEBUG_MM_HEAPINFO */
 
 #ifdef CONFIG_MM_ASSERT_ON_FAIL


### PR DESCRIPTION
If watchdog is active, the large amount of logging in heapinfo_parse_heap() can cause reboots by Watchdog To prevent this, we added code to stop Watchdog in mm_manage_allocfail, but some chipsets do not support stopping Watchdog.

Therefore, we modified it so that Watchdog keepalive is called along with log output inside heapinfo_parse_heap(),
 so that even if Watchdog stop is not supported, it will not be rebooted during log output.