### PR TITLE
os/board/rtl8730e: Revise BSP assert code

### DIFF
--- a/os/board/rtl8730e/src/component/mbed/targets/hal/rtl8730e/wdt_api.c
+++ b/os/board/rtl8730e/src/component/mbed/targets/hal/rtl8730e/wdt_api.c
@@ -121,8 +121,7 @@ void watchdog_start(void)
  */
 void watchdog_stop(void)
 {
-	DBG_8195A("Ameba-D2 not support watchdog_stop function!\n");
-	assert_param(0);
+	dbg("Ameba-D2 not support watchdog_stop function!\n");
 }
 
 /**

--- a/os/board/rtl8730e/src/component/os_dep/osdep_service.h
+++ b/os/board/rtl8730e/src/component/os_dep/osdep_service.h
@@ -259,29 +259,6 @@ void cli(void);
 #define DBG_TRACE(fmt, args...)
 #define DBG_INFO(fmt, args...)
 #endif
-#define HALT()   \
-	do {         \
-		cli();   \
-		for (;;) \
-			;    \
-	} while (0)
-#undef ASSERT
-#define ASSERT(x)                                                              \
-	do {                                                                       \
-		if ((x) == 0) {                                                        \
-			nvdbg("\n\rAssert(" #x ") failed on line %d in file %s", __LINE__, \
-				  __FILE__);                                                   \
-			HALT();                                                            \
-		}                                                                      \
-	} while (0)
-
-#undef DBG_ASSERT
-#define DBG_ASSERT(x, msg)                                                    \
-	do {                                                                      \
-		if ((x) == 0)                                                         \
-			nvdbg("\n\r%s, Assert(" #x ") failed on line %d in file %s", msg, \
-				  __LINE__, __FILE__);                                        \
-	} while (0)
 
 //----- ------------------------------------------------------------------
 // Atomic Operation

--- a/os/board/rtl8730e/src/component/os_dep/osdep_service_misc.h
+++ b/os/board/rtl8730e/src/component/os_dep/osdep_service_misc.h
@@ -17,19 +17,21 @@
 #ifndef __OSDEP_SERVICE_MISC_H_
 #define __OSDEP_SERVICE_MISC_H_
 
-// #define printk				printf
-// #define DBG_ERR(fmt, args...)		printf("\n\r[%s] " fmt, __FUNCTION__, ## args)
-
-// #define HALT()				do { cli(); for(;;);} while(0)
-#undef ASSERT
-#define ASSERT(x)			do { \
+#define RTK_HALT()   \
+	do {         \
+		cli();   \
+		for (;;) \
+			;    \
+	} while (0)
+#undef RTK_ASSERT
+#define RTK_ASSERT(x)			do { \
 						if((x) == 0){\
 							printf("\n\rAssert(" #x ") failed on line %d in file %s\n", __LINE__, __FILE__); \
-						HALT();}\
+						RTK_HALT();}\
 					} while(0)
 
-#undef DBG_ASSERT
-#define DBG_ASSERT(x, msg)		do { \
+#undef RTK_DBG_ASSERT
+#define RTK_DBG_ASSERT(x, msg)		do { \
 						if((x) == 0) \
 							printf("\n\r%s, Assert(" #x ") failed on line %d in file %s", msg, __LINE__, __FILE__); \
 					} while(0)

--- a/os/board/rtl8730e/src/component/soc/amebad2/fwlib/include/ameba.h
+++ b/os/board/rtl8730e/src/component/soc/amebad2/fwlib/include/ameba.h
@@ -207,9 +207,12 @@ typedef enum  _HAL_Status {
   *         that failed. If expr is true, it returns no value.
   * @retval None
   */
-#define assert_param(expr) ((expr) ? (void)0 : io_assert_failed((uint8_t *)__FUNCTION__, __LINE__))
+/* Remap assert to call Tizen Lite assert for additional crash information */
+#define assert_param(expr) { if (!(expr)) up_assert((const uint8_t *)__FILE__, (int)__LINE__); }
 /* Exported functions ------------------------------------------------------- */
+#ifndef CONFIG_PLATFORM_TIZENRT_OS
 void io_assert_failed(uint8_t *file, uint32_t line);
+#endif
 #else
 #define assert_param(expr) ((void)0)
 #endif /* USE_FULL_ASSERT */

--- a/os/board/rtl8730e/src/component/soc/amebad2/fwlib/rom_common/Make.defs
+++ b/os/board/rtl8730e/src/component/soc/amebad2/fwlib/rom_common/Make.defs
@@ -50,7 +50,6 @@
 ############################################################################
 
 CSRCS += ameba_systimer_rom.c \
-	ameba_assert_rom.c \
 	ameba_syscfg_rom.c \
 	ameba_backup_reg.c \
 	ameba_tim_rom.c \

--- a/os/board/rtl8730e/src/component/soc/amebad2/fwlib/rom_common/ameba_assert_rom.c
+++ b/os/board/rtl8730e/src/component/soc/amebad2/fwlib/rom_common/ameba_assert_rom.c
@@ -11,7 +11,7 @@
 __weak HAL_ROM_TEXT_SECTION
 void io_assert_failed(uint8_t *file, uint32_t line)
 {
-	DBG_8195A("io driver parameters error! file_name: %s, line: %d", file, line);
+	dbg("io driver parameters error! file_name: %s, line: %d", file, line);
 
-	for (;;);
+	ASSERT(0);
 }


### PR DESCRIPTION
- Link BSP assert to Tizen Lite kernel assert
- Remove the assert in watchdog_stop, so that it would not affect the normal workflow of kernel failure crashes