### PR TITLE
resource: Disable resource by default

### DIFF
--- a/os/fs/Kconfig
+++ b/os/fs/Kconfig
@@ -29,7 +29,7 @@ config FS_WRITABLE
 config RESOURCE_FS
 	bool "Support Resource fs"
 	select FS_ROMFS
-	default y
+	default n
 
 if RESOURCE_FS
 config RESOURCE_BINARY_VERSION


### PR DESCRIPTION
Disable resource by default to avoid build failure of partition verification because of absence of 'resource' partition.