### PR TITLE
build/configs/rtl8730e: Revise rtk data binary build flow

### DIFF
--- a/build/configs/rtl8730e/rtl8730e_make_bin.sh
+++ b/build/configs/rtl8730e/rtl8730e_make_bin.sh
@@ -63,7 +63,7 @@ cat $BINDIR/ram_2.bin > $BINDIR/ca32_image2_all.bin
 
 python $GNUUTL/code_analyze.py
 
-python $GNUUTL/rtk_data_binary.py
+ext_flash_support=$(python $GNUUTL/rtk_data_binary.py)
 
 echo "========== Image manipulating end =========="
 
@@ -83,10 +83,14 @@ $GNUUTL/prepend_header.sh $BINDIR/bl1_sram.bin  __ca32_bl1_sram_start__  $BINDIR
 $GNUUTL/prepend_header.sh $BINDIR/bl1.bin  __ca32_bl1_dram_start__  $BINDIR/target_img2.map
 $GNUUTL/prepend_header.sh $BINDIR/fip.bin  __ca32_fip_dram_start__  $BINDIR/target_img2.map
 
-$GNUUTL/prepend_header.sh $GNUUTL/rtk_ext_flash_data.bin  __flash_ext_data_start__  $BINDIR/target_img2.map
-cp $GNUUTL/rtk_ext_flash_data_prepend.bin $BINDIR/rtk_ext_flash_data.bin
-rm $GNUUTL/rtk_ext_flash_data.bin
-rm $GNUUTL/rtk_ext_flash_data_prepend.bin
+if [ "$ext_flash_support" = "1" ];then
+	$GNUUTL/prepend_header.sh $GNUUTL/rtk_ext_flash_data.bin  __flash_ext_data_start__  $BINDIR/target_img2.map
+	cp $GNUUTL/rtk_ext_flash_data_prepend.bin $BINDIR/rtk_ext_flash_data.bin
+	rm $GNUUTL/rtk_ext_flash_data.bin
+	rm $GNUUTL/rtk_ext_flash_data_prepend.bin
+else
+	echo "========== Current config does not support external flash!=========="
+fi
 
 cat $BINDIR/xip_image2_prepend.bin $BINDIR/bl1_sram_prepend.bin $BINDIR/bl1_prepend.bin $BINDIR/fip_prepend.bin > $BINDIR/ap_image_all.bin
 

--- a/build/tools/amebasmart/gnu_utility/rtk_data_binary.py
+++ b/build/tools/amebasmart/gnu_utility/rtk_data_binary.py
@@ -19,7 +19,10 @@
 
 import os
 import sys
+import string
 
+os_folder = os.path.dirname(__file__) + '/../../../../os'
+cfg_file = os_folder + '/.config'
 dirpath = os.path.dirname(__file__)
 
 def text_to_binary(input_file, output_file):
@@ -32,8 +35,18 @@ def text_to_binary(input_file, output_file):
             # Write binary data to the output file
             outfile.write(binary_data)
 
-if __name__ == "__main__":
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '../../../../os/tools')))
+import config_util as util
+CONFIG_SECOND_FLASH_PARTITION = util.get_value_from_file(cfg_file, "CONFIG_SECOND_FLASH_PARTITION=").rstrip('\n')
+if CONFIG_SECOND_FLASH_PARTITION == "y":
     input_file = dirpath + "/rtk_data_binary.txt"
     output_file = dirpath + "/rtk_ext_flash_data.bin"
 
     text_to_binary(input_file, output_file)
+    # Ext flash valid
+    print("1")
+else:
+    # Ext flash invalid
+    print("0")
+# Return value back to bash
+sys.exit(0)


### PR DESCRIPTION
- Get value from .config, to differentiate whether the data binary build is necessary
- Skip the operation if external flash is invalid