### PR TITLE
os/include/tinyara/security_hal.h: Change the order of internal API of sec_ops_s

### DIFF
--- a/os/include/tinyara/security_hal.h
+++ b/os/include/tinyara/security_hal.h
@@ -663,11 +663,11 @@ struct sec_ops_s {
 	hal_aes_decrypt aes_decrypt;
 	hal_rsa_encrypt rsa_encrypt;
 	hal_rsa_decrypt rsa_decrypt;
-	hal_gcm_encrypt gcm_encrypt;
-	hal_gcm_decrypt gcm_decrypt;
 	hal_write_storage write_storage;
 	hal_read_storage read_storage;
 	hal_delete_storage delete_storage;
+	hal_gcm_encrypt gcm_encrypt;
+	hal_gcm_decrypt gcm_decrypt;
 };
 
 int se_initialize(void);


### PR DESCRIPTION
Issue: Secure hardfault while booting
```
[rtl_readdecrypt_factorykey] Exit form here!arm_prefetchabort: Prefetch abort. PC: 00000000 IFAR: 00000000 IFSR: 00000008
security level: 1
```

Cause: sec_ops_s of security_ameba_wrapper_tz.c and security_hal.h are not matched.
Solve: Move GCM APIs to the end of sec_ops_s