### PR TITLE
os/fs/procfs, os/kernel/init: Fix issue in running the ps command with smp configs enabled

### DIFF
--- a/apps/system/utils/utils_ps.c
+++ b/apps/system/utils/utils_ps.c
@@ -72,6 +72,9 @@ static const char *utils_statenames[] = {
 	"INVALID ",
 	"PENDING ",
 	"READY   ",
+#ifdef CONFIG_SMP
+	"ASSIGNED",		
+#endif
 	"RUNNING ",
 	"INACTIVE",
 	"WAITSEM ",
@@ -81,7 +84,10 @@ static const char *utils_statenames[] = {
 #endif
 #ifndef CONFIG_DISABLE_MQUEUE
 	"MQNEMPTY",
-	"MQNFULL "
+	"MQNFULL ",
+#endif
+#ifdef CONFIG_PAGING
+	"WAITPAGEFILL "
 #endif
 };
 

--- a/os/fs/procfs/fs_procfsproc.c
+++ b/os/fs/procfs/fs_procfsproc.c
@@ -385,7 +385,7 @@ static ssize_t proc_entry_stat(FAR struct proc_file_s *procfile, FAR struct tcb_
 	curr_heap = -1;
 	peak_heap = -1;
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
-	if (tcb->pid == 0) {
+	if (tcb->pid < CONFIG_SMP_NCPUS) {
 		/* Idle task normally uses heap with index 0. */
 		heap = kmm_get_heap_with_index(0);
 	} else {

--- a/os/kernel/init/os_start.c
+++ b/os/kernel/init/os_start.c
@@ -590,6 +590,7 @@ void os_start(void)
 
 		hashndx  = PIDHASH(i);
 		g_pidhash[hashndx].tcb = &g_idletcb[i].cmn;
+		g_pidhash[hashndx].pid = g_idletcb[i].cmn.pid;
 		/* Allocate the IDLE group */
 #ifdef HAVE_TASK_GROUP
 


### PR DESCRIPTION
```ps``` command was not working properly with smp configs enabled. Idle task stack are not stored in heap region, instead they are stored in .bss region. For retrieving idle task stack, we should not search in heap region And this case was not handled properly for all cpu's idle task. So, we handle the case for every cpu's idle task.