### PR TITLE
libc/time, arm/stm* : fix range of tm_yday in gmtime_r

### DIFF
--- a/lib/libc/time/lib_gmtimer.c
+++ b/lib/libc/time/lib_gmtimer.c
@@ -358,7 +358,7 @@ FAR struct tm *gmtime_r(FAR const time_t *timer, FAR struct tm *result)
 	result->tm_min = (int)min;
 	result->tm_sec = (int)sec;
 	result->tm_wday = clock_dayoftheweek(day, month, year);
-	result->tm_yday = day + clock_daysbeforemonth(result->tm_mon, clock_isleapyear(year));
+	result->tm_yday = day - 1 + clock_daysbeforemonth(result->tm_mon, clock_isleapyear(year));
 	result->tm_isdst = 0;
 
 	return result;

--- a/os/arch/arm/src/stm32/stm32_rtcc.c
+++ b/os/arch/arm/src/stm32/stm32_rtcc.c
@@ -813,7 +813,7 @@ int up_rtc_getdatetime(FAR struct tm *tp)
 
 	tmp = (dr & RTC_DR_WDU_MASK) >> RTC_DR_WDU_SHIFT;
 	tp->tm_wday = tmp % 7;
-	tp->tm_yday = tp->tm_mday + clock_daysbeforemonth(tp->tm_mon, clock_isleapyear(tp->tm_year + 1900));
+	tp->tm_yday = tp->tm_mday - 1 + clock_daysbeforemonth(tp->tm_mon, clock_isleapyear(tp->tm_year + 1900));
 	tp->tm_isdst = 0
 
 	rtc_dumptime(tp, "Returning");

--- a/os/arch/arm/src/stm32l4/stm32l4_rtc.c
+++ b/os/arch/arm/src/stm32l4/stm32l4_rtc.c
@@ -1093,7 +1093,7 @@ int stm32l4_rtc_getdatetime_with_subseconds(FAR struct tm *tp, FAR long *nsec)
 
   tmp = (dr & RTC_DR_WDU_MASK) >> RTC_DR_WDU_SHIFT;
   tp->tm_wday = tmp % 7;
-  tp->tm_yday = tp->tm_mday + clock_daysbeforemonth(tp->tm_mon, clock_isleapyear(tp->tm_year + 1900));
+  tp->tm_yday = tp->tm_mday -1 + clock_daysbeforemonth(tp->tm_mon, clock_isleapyear(tp->tm_year + 1900));
   tp->tm_isdst = 0;
 
   /* Return RTC sub-seconds if a non-NULL value


### PR DESCRIPTION
sync changes to gmtime_r, stm rtc drivers from nuttx

before :
TASH>>=== RTC Accuracy Test ===
[Total 0m passed] Time Difference : 86401s
[Total 0m passed] Time Difference : 1s
[Total 0m passed] Time Difference : 1s

after :
TASH>>rtc
TASH>>=== RTC Accuracy Test ===
[Total 0m passed] Time Difference : 1s
[Total 0m passed] Time Difference : 1s
[Total 0m passed] Time Difference : 1s