### PR TITLE
os/board/rtl8730e: Update BSP driver irq priority running on cortex-A

### DIFF
--- a/os/arch/arm/src/amebasmart/amebasmart_serial.c
+++ b/os/arch/arm/src/amebasmart/amebasmart_serial.c
@@ -584,8 +584,8 @@ static int rtl8730e_log_uart_irq(void *Data)
 
 static int rtl8730e_log_up_attach(struct uart_dev_s *dev)
 {
-	InterruptRegister((IRQ_FUN)rtl8730e_log_uart_irq, RTL8730E_UART_LOG_IRQ-32, (int)NULL, 4);
-	InterruptEn(RTL8730E_UART_LOG_IRQ-32, 4);
+	InterruptRegister((IRQ_FUN)rtl8730e_log_uart_irq, RTL8730E_UART_LOG_IRQ-32, (int)NULL, INT_PRI_MIDDLE);
+	InterruptEn(RTL8730E_UART_LOG_IRQ-32, INT_PRI_MIDDLE);
 	return 0;
 }
 
@@ -837,8 +837,8 @@ static int rtl8730e_up_setup(struct uart_dev_s *dev)
 	if (uart_index_get(priv->tx) == 4)	{//Loguart cannot be stopped
 		irq_disable(RTL8730E_UART_LOG_IRQ-32);
 		irq_unregister(RTL8730E_UART_LOG_IRQ-32);
-		InterruptRegister((IRQ_FUN)rtl8730e_log_uart_irq, RTL8730E_UART_LOG_IRQ-32, (int)NULL, 4);
-		InterruptEn(RTL8730E_UART_LOG_IRQ-32, 4);
+		InterruptRegister((IRQ_FUN)rtl8730e_log_uart_irq, RTL8730E_UART_LOG_IRQ-32, (int)NULL, INT_PRI_MIDDLE);
+		InterruptEn(RTL8730E_UART_LOG_IRQ-32, INT_PRI_MIDDLE);
 	} else {
 		sdrv[uart_index_get(priv->tx)]->uart_idx = uart_index_get(priv->tx);
 		serial_init((serial_t *) sdrv[uart_index_get(priv->tx)], priv->tx, priv->rx);

--- a/os/board/rtl8730e/src/component/mbed/targets/hal/rtl8730e/gpio_irq_api.c
+++ b/os/board/rtl8730e/src/component/mbed/targets/hal/rtl8730e/gpio_irq_api.c
@@ -64,14 +64,14 @@ int gpio_irq_init(gpio_irq_t *obj, PinName pin, gpio_irq_handler handler, uint32
 	GPIO_Init(&GPIO_InitStruct);
 
 	if (port_num == GPIO_PORT_A) {
-		InterruptRegister(GPIO_INTHandler, GPIOA_IRQ, (u32)GPIOA_BASE, 5);
-		InterruptEn(GPIOA_IRQ, 5);
+		InterruptRegister(GPIO_INTHandler, GPIOA_IRQ, (u32)GPIOA_BASE, INT_PRI_MIDDLE);
+		InterruptEn(GPIOA_IRQ, INT_PRI_MIDDLE);
 	} else if (port_num == GPIO_PORT_B) {
-		InterruptRegister(GPIO_INTHandler, GPIOB_IRQ, (u32)GPIOB_BASE, 5);
-		InterruptEn(GPIOB_IRQ, 5);
+		InterruptRegister(GPIO_INTHandler, GPIOB_IRQ, (u32)GPIOB_BASE, INT_PRI_MIDDLE);
+		InterruptEn(GPIOB_IRQ, INT_PRI_MIDDLE);
 	} else if (port_num == GPIO_PORT_C) {
-		InterruptRegister(GPIO_INTHandler, GPIOC_IRQ, (u32)GPIOC_BASE, 5);
-		InterruptEn(GPIOC_IRQ, 5);
+		InterruptRegister(GPIO_INTHandler, GPIOC_IRQ, (u32)GPIOC_BASE, INT_PRI_MIDDLE);
+		InterruptEn(GPIOC_IRQ, INT_PRI_MIDDLE);
 	}
 
 	GPIO_UserRegIrq(GPIO_InitStruct.GPIO_Pin, (VOID *) handler, (VOID *) id);

--- a/os/board/rtl8730e/src/component/mbed/targets/hal/rtl8730e/rtc_api.c
+++ b/os/board/rtl8730e/src/component/mbed/targets/hal/rtl8730e/rtc_api.c
@@ -310,8 +310,8 @@ u32 rtc_set_alarm(alarm_t *alrm, alarm_irq_handler alarmHandler)
 	RTC_SetAlarm(RTC_Format_BIN, &RTC_AlarmStruct_temp);
 
 	RTC_AlarmCmd(ENABLE);
-	InterruptRegister((IRQ_FUN)rtc_alarm_intr_handler, RTC_IRQ, (u32)alrm, 5);
-	InterruptEn(RTC_IRQ, 5);
+	InterruptRegister((IRQ_FUN)rtc_alarm_intr_handler, RTC_IRQ, (u32)alrm, INT_PRI_MIDDLE);
+	InterruptEn(RTC_IRQ, INT_PRI_MIDDLE);
 
 	return _TRUE;
 }

--- a/os/board/rtl8730e/src/component/mbed/targets/hal/rtl8730e/serial_api.c
+++ b/os/board/rtl8730e/src/component/mbed/targets/hal/rtl8730e/serial_api.c
@@ -471,8 +471,8 @@ void serial_init(serial_t *obj, PinName tx, PinName rx)
 	UART_StructInit(&puart_adapter->UART_InitStruct);
 	UART_Init(puart_adapter->UARTx, &puart_adapter->UART_InitStruct);
 
-	InterruptRegister((IRQ_FUN)uart_irqhandler, puart_adapter->IrqNum, (u32)puart_adapter, 5);
-	InterruptEn(puart_adapter->IrqNum, 5);
+	InterruptRegister((IRQ_FUN)uart_irqhandler, puart_adapter->IrqNum, (u32)puart_adapter, INT_PRI_MIDDLE);
+	InterruptEn(puart_adapter->IrqNum, INT_PRI_MIDDLE);
 
 #ifdef CONFIG_MBED_ENABLED
 	// For stdio management

--- a/os/board/rtl8730e/src/component/mbed/targets/hal/rtl8730e/wdt_api.c
+++ b/os/board/rtl8730e/src/component/mbed/targets/hal/rtl8730e/wdt_api.c
@@ -144,8 +144,8 @@ void watchdog_refresh(void)
 void watchdog_irq_init(wdt_irq_handler handler, uint32_t id)
 {
 	WDG_ClearINT(WDGDev, WDG_BIT_EIC);
-	InterruptRegister((IRQ_FUN)handler, WdgIrqNum, (u32)id, 3);
-	InterruptEn(WdgIrqNum, 3);
+	InterruptRegister((IRQ_FUN)handler, WdgIrqNum, (u32)id, INT_PRI_HIGH);
+	InterruptEn(WdgIrqNum, INT_PRI_HIGH);
 	WDG_INTConfig(WDGDev, WDG_BIT_EIE, ENABLE);
 }
 /**

--- a/os/board/rtl8730e/src/component/soc/amebad2/fwlib/ram_hp/ameba_sport.c
+++ b/os/board/rtl8730e/src/component/soc/amebad2/fwlib/ram_hp/ameba_sport.c
@@ -1100,7 +1100,7 @@ BOOL AUDIO_SP_TXGDMA_Init(
 	assert_param(GDMA_InitStruct != NULL);
 	DCache_CleanInvalidate((u32)pTXData, Length);
 	/*obtain a DMA channel and register DMA interrupt handler*/
-	GdmaChnl = GDMA_ChnlAlloc(0, CallbackFunc, (u32)CallbackData, INT_PRI_MIDDLE);
+	GdmaChnl = GDMA_ChnlAlloc(0, CallbackFunc, (u32)CallbackData, INT_PRI_HIGH);
 	if (GdmaChnl == 0xFF) {
 		// No Available DMA channel
 		return _FALSE;
@@ -1312,7 +1312,7 @@ BOOL AUDIO_SP_LLPTXGDMA_Init(
 	u32 pTxData = Lli[0].LliEle.Sarx;
 
 	/*obtain a DMA channel and register DMA interrupt handler*/
-	GdmaChnl = GDMA_ChnlAlloc(0, CallbackFunc, (u32)CallbackData, INT_PRI_MIDDLE);
+	GdmaChnl = GDMA_ChnlAlloc(0, CallbackFunc, (u32)CallbackData, INT_PRI_HIGH);
 	if (GdmaChnl == 0xFF) {
 		// No Available DMA channel
 		return _FALSE;

--- a/os/board/rtl8730e/src/component/soc/amebad2/fwlib/rom_common/ameba_tim_rom.c
+++ b/os/board/rtl8730e/src/component/soc/amebad2/fwlib/rom_common/ameba_tim_rom.c
@@ -123,8 +123,8 @@ void RTIM_TimeBaseInit(RTIM_TypeDef *TIM, RTIM_TimeBaseInitTypeDef *TIM_InitStru
 
 	/* Initial TimerIRQHandle */
 	if (UserCB) {
-		InterruptRegister(UserCB, IrqNum, UserCBData, 3);
-		InterruptEn(IrqNum, 3);
+		InterruptRegister(UserCB, IrqNum, UserCBData, INT_PRI_HIGH);
+		InterruptEn(IrqNum, INT_PRI_HIGH);
 	}
 
 	/* Generate an update event */

--- a/os/board/rtl8730e/src/rtl8730e_mipi_lcdc.c
+++ b/os/board/rtl8730e/src/rtl8730e_mipi_lcdc.c
@@ -89,7 +89,7 @@ static u8 lcdc_nextframe = 0;
 struct irq lcdc_irq_info = {
 	.num = LCDC_IRQ,
 	.data = (u32) LCDC,
-	.priority = INT_PRI_MIDDLE,
+	.priority = INT_PRI_HIGH,
 };
 
 extern struct irq mipi_irq_info;


### PR DESCRIPTION
- Currently the driver priority setting is according to cortex-M value range (ie. NVIC), but rtl8730e is running on cortex-A, which has it's own value range for setting irq priority (ie. GIC).
- This PR revise the wrong usage on irq priority for peripheral drivers
- Due to performance issue, Increase irq priority level for LCDC