### PR TITLE
os/arch/arm/src/amebasmart: Update missing leave_critical_section

### DIFF
--- a/os/arch/arm/src/amebasmart/amebasmart_spi.c
+++ b/os/arch/arm/src/amebasmart/amebasmart_spi.c
@@ -1409,7 +1409,7 @@ FAR struct spi_dev_s *amebasmart_spibus_initialize(int bus)
 
 	} else {
 		spierr("ERROR: Unsupported SPI bus: %d\n", bus);
-		irqrestore(flags);
+		leave_critical_section(flags);
 		return NULL;
 	}
 
@@ -1493,6 +1493,7 @@ FAR struct spi_dev_s *up_spiinitialize(int port)
 
 		if (priv->refs > 0) {
 			dbg("SPI port%d has been initialized before!\n", port);
+			leave_critical_section(flags);
 			return (FAR struct spi_dev_s *)priv;
 		}
 		/* Only configure if the bus is not already configured */
@@ -1510,6 +1511,7 @@ FAR struct spi_dev_s *up_spiinitialize(int port)
 
 		if (priv->refs > 0) {
 			dbg("SPI port%d has been initialized before!\n", port);
+			leave_critical_section(flags);
 			return (FAR struct spi_dev_s *)priv;
 		}
 		/* Only configure if the bus is not already configured */
@@ -1521,7 +1523,7 @@ FAR struct spi_dev_s *up_spiinitialize(int port)
 	} else
 	{
 		spierr("ERROR: Unsupported SPI bus: %d\n", port);
-		irqrestore(flags);
+		leave_critical_section(flags);
 		return NULL;
 	}
 


### PR DESCRIPTION
- Missing leave_critical_section for SPI initialization lead to several unexpected behaviour, thus add leave_critical_section to necessary places (ie. early return condition)