### PR TITLE
os/board/rtl8730e: add API to set BLE device name

### DIFF
--- a/os/board/rtl8730e/src/component/bluetooth/example/ble_peripheral/ble_tizenrt_server.c
+++ b/os/board/rtl8730e/src/component/bluetooth/example/ble_peripheral/ble_tizenrt_server.c
@@ -399,6 +399,18 @@ trble_conn_handle rtw_ble_server_get_conn_handle_by_address(uint8_t* mac)
     return conn_handle;
 }
 
+trble_result_e rtw_ble_server_set_device_name(uint8_t* name)
+{
+    if(RTK_BT_OK == rtk_bt_le_gap_set_device_name(name))
+    {
+        debug_print("Set device name success \n");
+    } else {
+        debug_print("Set device name fail \n");
+        return TRBLE_FAIL;
+    }
+    return TRBLE_SUCCESS;
+}
+
 trble_result_e rtw_ble_server_adv_into_idle(void)
 {
     rtk_bt_le_gap_dev_state_t new_state;

--- a/os/board/rtl8730e/src/component/os/tizenrt/rtk_blemgr.c
+++ b/os/board/rtl8730e/src/component/os/tizenrt/rtk_blemgr.c
@@ -95,6 +95,7 @@ trble_result_e trble_netmgr_attr_reject(struct bledev *dev, trble_attr_handle at
 trble_result_e trble_netmgr_server_disconnect(struct bledev *dev, trble_conn_handle con_handle);
 trble_result_e trble_netmgr_get_mac_addr_by_conn_handle(struct bledev *dev, trble_conn_handle con_handle, uint8_t bd_addr[TRBLE_BD_ADDR_MAX_LEN]);
 trble_result_e trble_netmgr_get_conn_handle_by_addr(struct bledev *dev, uint8_t bd_addr[TRBLE_BD_ADDR_MAX_LEN], trble_conn_handle *con_handle);
+trble_result_e trble_netmgr_set_gap_device_name(struct bledev *dev, uint8_t* device_name); 
 
 /*** Advertiser(Broadcaster) ***/
 trble_result_e trble_netmgr_set_adv_data(struct bledev *dev, trble_data *data);
@@ -148,7 +149,7 @@ struct trble_ops g_trble_drv_ops = {
 	trble_netmgr_server_disconnect,
 	trble_netmgr_get_mac_addr_by_conn_handle,
 	trble_netmgr_get_conn_handle_by_addr,
-	NULL,
+	trble_netmgr_set_gap_device_name, 
 
 	// Broadcaster
 	trble_netmgr_set_adv_data,
@@ -438,6 +439,11 @@ trble_result_e trble_netmgr_get_conn_handle_by_addr(struct bledev *dev, uint8_t 
 {
 	*con_handle = rtw_ble_server_get_conn_handle_by_address(bd_addr);
 	return TRBLE_SUCCESS;
+}
+
+trble_result_e trble_netmgr_set_gap_device_name(struct bledev *dev, uint8_t* device_name)
+{
+	return rtw_ble_server_set_device_name(device_name); 
 }
 
 


### PR DESCRIPTION
- add ble_server_set_device_name API to set BLE device name