### PR TITLE
os/pm: fix pm_timedsuspend cancel

### DIFF
--- a/os/pm/pm_timedsuspend.c
+++ b/os/pm/pm_timedsuspend.c
@@ -70,26 +70,23 @@
  * Private Variables
  ************************************************************************/
 
-/* This array maps the pid to their respective wdog timer. 
- * Assumption: when a thread does a timed lock , only the same thread 
- * can unlock the "timed lock" before it expire */
-static WDOG_ID pid_timer_map[CONFIG_MAX_TASKS];
+/* This array maps the domain to their respective wdog timer */
+static WDOG_ID domain_timer_map[CONFIG_PM_NDOMAINS];
 
 /************************************************************************
  * Private Functions
  ************************************************************************/
 
-static void timer_timeout(int argc, int domain_id, uint32_t hash_pid)
+static void timer_timeout(int argc, int domain_id)
 {
-	DEBUGASSERT(pid_timer_map[hash_pid] != NULL);
+	DEBUGASSERT(domain_timer_map[domain_id] != NULL);
 	/* PM transition will be resume here */
 	if (pm_resume(domain_id) != OK) {
 		pmlldbg("Unable to resume domain: %s\n", pm_domain_map[domain_id]);
 	}
-	(void)wd_delete(pid_timer_map[hash_pid]);
-	pid_timer_map[hash_pid] = NULL;
+	(void)wd_delete(domain_timer_map[domain_id]);
+	domain_timer_map[domain_id] = NULL;
 }
-
 /************************************************************************
  * Public Functions
  ************************************************************************/
@@ -106,51 +103,65 @@ static void timer_timeout(int argc, int domain_id, uint32_t hash_pid)
  *
  * Return Value:
  *   0 - success
- *   -1 - error
+ *  -1 - error
  *
  ************************************************************************/
 
 int pm_timedsuspend(int domain_id, unsigned int milliseconds)
 {
-	int hash_pid = PIDHASH(getpid());
-
-	if (domain_id >= CONFIG_PM_NDOMAINS || pm_domain_map[domain_id]==NULL) {
+	irqstate_t flags;
+	WDOG_ID wdog;
+	int tick_remain;
+	int ret = ERROR;
+	int delay = MSEC2TICK(milliseconds);
+	if ((domain_id < 0) || (domain_id >= CONFIG_PM_NDOMAINS) || (pm_domain_map[domain_id] == NULL)) {
 		set_errno(EINVAL);
-		return ERROR;
+		pmdbg("Invalid domain_id: %d\n", domain_id);
+		return ret;
 	}
-
-	/* Check if there is already a wdog lock timer running for 
-	 * the process */
-	if (pid_timer_map[hash_pid] != NULL) {
-		pmdbg("There is already a lock timer running for this process pid %d with domain %s\n", getpid(), pm_domain_map[domain_id]);
-		return ERROR;
-	}
-	/* Create WDog timer before suspending PM state transition */
-	WDOG_ID wdog = wd_create();
-	if (wdog == NULL) {
-		pmdbg("Unable to create WDog Timer, error = %d\n", get_errno());
-		set_errno(EAGAIN);
-		return ERROR;
-	}
-	pid_timer_map[hash_pid] = wdog;
-	/* Lock the pm transition and start the wdog timer */
-	if (pm_suspend(domain_id) != OK) {
-		pmdbg("Unable to suspend domain: %s\n", pm_domain_map[domain_id]);
-		goto errout;
-		
-	}
-	if (wd_start(wdog, MSEC2TICK(milliseconds), (wdentry_t)timer_timeout, 2, domain_id, (uint32_t)hash_pid) != OK) {
-		pmvdbg("Error starting Wdog timer\n");
-		if (pm_resume(domain_id) != OK) {
-			pmdbg("Unable to resume domain: %s\n", pm_domain_map[domain_id]);
+	flags = enter_critical_section();
+	wdog = domain_timer_map[domain_id];
+	/* If delay is zero then cancel the timer (PM Policy) */
+	if (delay == 0) {
+		if (wdog) {
+			timer_timeout(NULL, domain_id);
 		}
-		set_errno(EAGAIN);
-		goto errout;
+		ret = OK;
+		goto exit;
 	}
-	pmvdbg("PM is locked for pid %d and timer started for %d milliseconds\n", getpid(), milliseconds);
-	return OK;
-errout:
-	pid_timer_map[hash_pid] = NULL;
-	(void)wd_delete(pid_timer_map[hash_pid]);
-	return ERROR;
+	/* If timer is not there, then create a timer & suspend domain */
+	if (!wdog) {
+		wdog = wd_create();
+		if (wdog == NULL) {
+			pmdbg("Unable to create WDog Timer, error = %d\n", get_errno());
+			set_errno(EAGAIN);
+			goto exit;
+		}
+		/* Unable to suspend domain, so delete the timer */
+		if (pm_suspend(domain_id) != OK) {
+			pmdbg("Unable to suspend domain: %s\n", pm_domain_map[domain_id]);
+			(void)wd_delete(wdog);
+			goto exit;
+		}
+		domain_timer_map[domain_id] = wdog;
+	}
+	/* New delay is less than running timer ticks left, no need to do anyting */
+	tick_remain = wd_gettime(wdog);
+	if (delay <= tick_remain) {
+		pmvdbg("Domain: %s is already suspended for %d milliseconds\n", pm_domain_map[domain_id], TICK2MSEC(tick_remain));
+		ret = OK;
+		goto exit;
+	}
+	/* Start the timer */
+	if (wd_start(wdog, delay, (wdentry_t)timer_timeout, 1, domain_id) != OK) {
+		pmdbg("Error starting Wdog timer\n");
+		set_errno(EAGAIN);
+		timer_timeout(NULL, domain_id);
+		goto exit;
+	}
+	pmvdbg("Domain: %s is suspended for %d milliseconds\n", pm_domain_map[domain_id], milliseconds);
+	ret = OK;
+exit:
+	leave_critical_section(flags);
+	return ret;
 }


### PR DESCRIPTION
When a thread call pm_timedsuspend multiple times within timer expiration, then pm_timedsuspend doesn't stoping the timer, instead it was rasing error. Now when pm_timedsuspend call multiple times within timer expiration, then it changes timer duration to remain suspended for given time if it is greater than current expiration time. If application provide zero time interval, then it cancel the timer immediately and resume the suspended domain.