### PR TITLE
libc/machine/arm: move setjmp definition to libc for loadable

### DIFF
--- a/lib/libc/machine/arm/Make.defs
+++ b/lib/libc/machine/arm/Make.defs
@@ -65,3 +65,8 @@ include ${TOPDIR}/../lib/libc/machine/arm/armv7-m/Make.defs
 else ifeq ($(CONFIG_ARCH_ARMV7A_FAMILY),y)   # ARMV7A
 include ${TOPDIR}/../lib/libc/machine/arm/armv7-a/Make.defs
 endif
+
+ASRCS += setjmp.S
+
+DEPPATH += --dep-path machine/arm
+VPATH += :machine/arm

--- a/lib/libc/machine/arm/setjmp.S
+++ b/lib/libc/machine/arm/setjmp.S
@@ -60,11 +60,6 @@
 /****************************************************************************
  * Public Symbols
  ****************************************************************************/
-#ifdef CONFIG_ARCH_FPU
-	.cpu	cortex-r4
-#else
-	.cpu	cortex-r4f
-#endif
 
 	.syntax	unified
 	.file	"setjmp.S"

--- a/os/arch/arm/src/s5j/Make.defs
+++ b/os/arch/arm/src/s5j/Make.defs
@@ -74,7 +74,7 @@ CMN_ASRCS += arm_vectors.S arm_fullcontextrestore.S
 CMN_ASRCS += arm_saveusercontext.S arm_vectoraddrexcptn.S arm_vfork.S
 CMN_ASRCS += cp15_coherent_dcache.S cp15_invalidate_dcache.S
 CMN_ASRCS += cp15_clean_dcache.S cp15_flush_dcache.S cp15_invalidate_dcache_all.S
-CMN_ASRCS += arm_savefpu.S arm_restorefpu.S setjmp.S
+CMN_ASRCS += arm_savefpu.S arm_restorefpu.S
 
 # Configuration dependent assembly language files
 

--- a/os/arch/arm/src/tiva/Make.defs
+++ b/os/arch/arm/src/tiva/Make.defs
@@ -53,7 +53,7 @@
 HEAD_ASRC  = tiva_vectors.S
 
 CMN_ASRCS  = up_saveusercontext.S up_fullcontextrestore.S up_switchcontext.S
-CMN_ASRCS += vfork.S setjmp.S
+CMN_ASRCS += vfork.S
 
 CMN_CSRCS  = up_assert.c up_blocktask.c up_copyfullstate.c up_createstack.c
 CMN_CSRCS += up_mdelay.c up_udelay.c up_exit.c up_idle.c up_initialize.c


### PR DESCRIPTION
generally setjmp and longjump as provided as a part of libc. So, moved setjmp.S to libc. In this way, we also support setjmp in both flat and loadable.

Verification was done on artik flat, rtl8721csm flat, rtl8730e flat and loadable.

artik flat : 

```
TASH>>setjmp_test
diving(1, R, 0x2036584)
diving(2, R, 0x203646c)
diving(3, R, 0x2036344)
diving(4, R, 0x203621c)
diving(5, R, 0x20360f4)
diving(6, R, 0x2035fcc)
diving(7, R, 0x2035ea4)
diving(8, R, 0x2035d7c)
return(8, R, 0x2035d7c)
return(7, R, 0x2035ea4)
return(6, R, 0x2035fcc)
return(5, R, 0x20360f4)
return(4, R, 0x203621c)
return(3, R, 0x2036344)
return(2, R, 0x203646c)
return(1, R, 0x2036584)
setjmp does not break function return
diving(1, L, 0x2036584)
diving(2, L, 0x203646c)
diving(3, L, 0x2036344)
diving(4, L, 0x203621c)
diving(5, L, 0x20360f4)
diving(6, L, 0x2035fcc)
diving(7, L, 0x2035ea4)
diving(8, L, 0x2035d7c)
ascending(8, L, 0x2035d7c)
ascending(7, L, 0x2035ea4)
ascending(6, L, 0x2035fcc)
ascending(5, L, 0x20360f4)
ascending(4, L, 0x203621c)
ascending(3, L, 0x2036344)
ascending(2, L, 0x203646c)
ascending(1, L, 0x2036584)
setjmp skips a single stack frame
diving(1, E, 0x2036584)
diving(2, E, 0x2036584)
diving(3, E, 0x2036584)
diving(4, E, 0x2036584)
diving(5, E, 0x2036584)
diving(6, E, 0x2036584)
diving(7, E, 0x2036584)
diving(8, E, 0x2036584)
ascending(8, E, 0x2036584)
setjmp skips multiple frames
TASH>>
```

rtl8730e loadable :

```
[RTW]: ** Band = 2.4G and 5G **
binary_manager_load: app1 Header Checking Success
dump_module: Module:
dump_module:   filename:  /dev/mtdblock6
dump_module:   argv:      0
dump_module:   entrypt:   0xe45c079
dump_module:   start of alloc:     0xe45c030
dump_module:   alloc:     0 0
dump_module:   ctors:     0xe45c1b1 nctors=0
dump_module:   dtors:     0 ndtors=0
dump_module:   stacksize: 8192
dump_module:   unload:    0
System Information:
        Version:
                Platform: 3.1   Binary: 200204
        Commit Hash: 44e8583
        Build User: root@=
        Build Time: 2024-07-05 15:43:19 IST
        System Time: 05 Jul 2024, 00:00:00 [s] UTC Hardware RTC Support
TASH>>This is WIFI App

Select Test Scenario.
        -Press X or x : Terminate Tests.
binary_manager_load_binary: Load success! [Name: app1] [Version: 190412] [Partition: A] [Text start : 0x0e45c030] [Compressed Binary]
KM4 version:  km4_application_ver_68a34c3d71_2024/06/25-16:14:09
Test will be finished.

TASH>>setjmp_test
diving(1, R, 0x60605f34)
diving(2, R, 0x60605e1c)
diving(3, R, 0x60605cf4)
diving(4, R, 0x60605bcc)
diving(5, R, 0x60605aa4)
diving(6, R, 0x6060597c)
diving(7, R, 0x60605854)
diving(8, R, 0x6060572c)
return(8, R, 0x6060572c)
return(7, R, 0x60605854)
return(6, R, 0x6060597c)
return(5, R, 0x60605aa4)
return(4, R, 0x60605bcc)
return(3, R, 0x60605cf4)
return(2, R, 0x60605e1c)
return(1, R, 0x60605f34)
setjmp does not break function return
diving(1, L, 0x60605f34)
diving(2, L, 0x60605e1c)
diving(3, L, 0x60605cf4)
diving(4, L, 0x60605bcc)
diving(5, L, 0x60605aa4)
diving(6, L, 0x6060597c)
diving(7, L, 0x60605854)
diving(8, L, 0x6060572c)
ascending(8, L, 0x6060572c)
ascending(7, L, 0x60605854)
ascending(6, L, 0x6060597c)
ascending(5, L, 0x60605aa4)
ascending(4, L, 0x60605bcc)
ascending(3, L, 0x60605cf4)
ascending(2, L, 0x60605e1c)
ascending(1, L, 0x60605f34)
setjmp skips a single stack frame
diving(1, E, 0x60605f34)
diving(2, E, 0x60605f34)
diving(3, E, 0x60605f34)
diving(4, E, 0x60605f34)
diving(5, E, 0x60605f34)
diving(6, E, 0x60605f34)
diving(7, E, 0x60605f34)
diving(8, E, 0x60605f34)
ascending(8, E, 0x60605f34)
setjmp skips multiple frames
TASH>>
```