### PR TITLE
os/board/rtl8721csm: fix BLE function array mismatch due to PR6193

### DIFF
--- a/os/board/rtl8721csm/src/component/os/tizenrt/rtk_blemgr.c
+++ b/os/board/rtl8721csm/src/component/os/tizenrt/rtk_blemgr.c
@@ -144,6 +144,7 @@ struct trble_ops g_trble_drv_ops = {
 	trble_netmgr_get_profile_count,
 	trble_netmgr_charact_notify,
 	trble_netmgr_charact_indicate,
+	NULL,
 	trble_netmgr_attr_set_data,
 	trble_netmgr_attr_get_data,
 	trble_netmgr_attr_reject,


### PR DESCRIPTION
- NULL added to g_trble_drv_ops to match function in trble_ops struct