### PR TITLE
os/kernel/sched: update cpuload measurement for smp

### DIFF
--- a/os/crypto/random_pool.c
+++ b/os/crypto/random_pool.c
@@ -245,7 +245,12 @@ static void getentropy(FAR blake2s_state *S)
 	tmp <<= 27;
 #ifdef CONFIG_SCHED_CPULOAD
 	clock_cpuload(getpid(), 0, &load);
-	tmp += load.total ^ ROTL_32(load.active, 23);
+	uint32 total = 0, active = 0;
+	for (int cpu = 0; cpu < CONFIG_SMP_NCPUS; cpu++) {
+		total += load.total[cpu];
+		active += load.active[cpu];
+	}
+	tmp += total ^ ROTL_32(active, 23);
 #endif
 	add_sw_randomness(tmp);
 

--- a/os/include/tinyara/clock.h
+++ b/os/include/tinyara/clock.h
@@ -200,8 +200,8 @@
 
 #ifdef CONFIG_SCHED_CPULOAD
 struct cpuload_s {
-	volatile uint32_t total;	/* Total number of clock ticks */
-	volatile uint32_t active;	/* Number of ticks while this thread was active */
+	volatile uint32_t total[CONFIG_SMP_NCPUS];   /* Total number of clock ticks per cpu */
+	volatile uint32_t active[CONFIG_SMP_NCPUS];  /* Number of ticks while this thread was active on the specific cpu */
 };
 
 #ifdef CONFIG_SCHED_MULTI_CPULOAD

--- a/os/kernel/sched/sched.h
+++ b/os/kernel/sched/sched.h
@@ -137,7 +137,8 @@ struct pidhash_s {
 	FAR struct tcb_s *tcb;		/* TCB assigned to this PID */
 	pid_t pid;					/* The full PID value */
 #ifdef CONFIG_SCHED_CPULOAD
-	uint32_t ticks[SCHED_NCPULOAD];				/* Number of ticks on this thread */
+	uint32_t ticks[CONFIG_SMP_NCPUS][SCHED_NCPULOAD];     /* Number of ticks of thread in specific cpu */
+
 #endif
 };
 

--- a/os/kernel/task/task_setup.c
+++ b/os/kernel/task/task_setup.c
@@ -173,7 +173,9 @@ static int task_assignpid(FAR struct tcb_s *tcb)
 #ifdef CONFIG_SCHED_CPULOAD
 			int cpuload_idx;
 			for (cpuload_idx = 0; cpuload_idx < SCHED_NCPULOAD; cpuload_idx++) {
-				g_pidhash[hash_ndx].ticks[cpuload_idx] = 0;
+				for (int cpu = 0; cpu < CONFIG_SMP_NCPUS; cpu++) {
+					g_pidhash[hash_ndx].ticks[cpu][cpuload_idx] = 0;
+				}
 			}
 #endif
 			tcb->pid = next_pid;


### PR DESCRIPTION
 This commit calculates cpu load for each core separately whereas previously it was only calculating for one core. This gives the cpu load percentage of each thread for their respective cores.

It also outputs only threads with more than 0 cpu loads

```
	  The previous output when when we tash command as "cpuload" was : 
          TASH>> cpuload Started CPU monitor with interval 5.
	  PID | Pri |    2s |
	  --------------------------------------------------
	    0 |   0 |  99.1 | Idle Task
  	    1 | 224 |   0.0 | hpwork
 	    2 | 113 |   0.0 | lpwork
	    3 | 120 |   0.0 | EHCI Monitor
	    4 | 110 |   0.0 | LWIP_TCP/IP
  	    5 | 250 |   0.0 | binary_manager
   	    7 | 220 |   0.0 | /dev/mtdblock2
  	    8 | 221 |   0.0 | msg_receiver
	    9 | 221 |   0.0 | multi_recv_nonblock
	   10 | 221 |   0.0 | multi_recv_block1
	   11 | 221 |   0.0 | multi_recv_block2
	   12 | 180 |   0.0 | /dev/mtdblock4
	   13 | 100 |   0.0 | uwork
	   14 | 125 |   0.9 | tash
	   15 | 100 |   0.0 | CPULoadMonitor
	  --------------------------------------------------

	  After this commit , output is : 
          Started CPU monitor with interval 5 sec.
	  Non-Zero CPU utilization trend (updated every 2s)
          --------------------------------------------------
	  PID | Pri |  CPU0 |  CPU1 |  2s  Avg|
	  --------------------------------------------------
 	    0 |   0 |  99.9 |   0.0 |  42.8 | CPU0 IDLE
 	    1 |   0 |   0.0 | 100.0 |  57.2 | CPU1 IDLE
 	   20 | 100 |   1.4 |   0.0 |   0.6 | CPULoadMonitor
	  --------------------------------------------------
```