### PR TITLE
os/pm: fix pm_sleep build error

### DIFF
--- a/os/pm/pm_sleep.c
+++ b/os/pm/pm_sleep.c
@@ -55,8 +55,8 @@
 #include <tinyara/irq.h>
 #include <tinyara/wdog.h>
 #include <tinyara/clock.h>
+#include <tinyara/sched.h>
 #include <errno.h>
-
 /************************************************************************
  * Pre-processor Definitions
  ************************************************************************/
@@ -108,7 +108,7 @@ int pm_sleep(int milliseconds)
 	/* TODO - Since PM & Kernel are separate, we should not use tcb inside pm.
 	 * We need to remove tcb in future.
 	 */
-	FAR struct tcb_s *rtcb = this_task();
+	FAR struct tcb_s *rtcb = sched_self();
 	/* initialize the timer's semaphore. It will be used to lock the
 	 * thread before sleep and unlock after expire */
 	sem_init(&pm_sem, 0, 0);


### PR DESCRIPTION
This commit resolve undefined reference to 'this_task' build error on pm_sleep.c with loadable_apps configuration without SMP.