### PR TITLE
lib_buffer: add DEBUG_SET_CALLER_ADDR macro

### DIFF
--- a/lib/libc/audio/lib_buffer.c
+++ b/lib/libc/audio/lib_buffer.c
@@ -149,6 +149,7 @@ int apb_alloc(FAR struct audio_buf_desc_s *bufdesc)
 		ret = -ENOMEM;
 	} else {
 		/* Populate the buffer contents */
+		DEBUG_SET_CALLER_ADDR(*bufdesc->u.ppBuffer);
 
 		memset(apb, 0, bufsize);
 		apb->i.channels = 1;

--- a/lib/libc/misc/lib_hashmap.c
+++ b/lib/libc/misc/lib_hashmap.c
@@ -106,6 +106,9 @@ struct hashmap_s *hashmap_create(int startsize)
 	}
 
 	hm->table = (h_entry_t *)lib_calloc(sizeof(h_entry_t), startsize);
+	if (!hm->table) {
+		DEBUG_SET_CALLER_ADDR(hm->table);
+	}
 	hm->size = startsize;
 	hm->count = 0;
 


### PR DESCRIPTION
The apb_alloc api is wrapping malloc apis.
So we don't know who was the requesting alloc memory using heapinfo.

Therefore, Add DEBUG_SET_CALLER_ADDR to update the caller address that requested the actual memory.