### PR TITLE
kmm_realloc: fix crash issue case of oldmem is NULL

### DIFF
--- a/os/mm/kmm_heap/kmm_realloc.c
+++ b/os/mm/kmm_heap/kmm_realloc.c
@@ -144,21 +144,30 @@ FAR void *kmm_realloc(FAR void *oldmem, size_t newsize)
 	mmaddress_t caller_retaddr = 0;
 	ARCH_GET_RET_ADDRESS(caller_retaddr)
 #endif
-	struct mm_heap_s *kheap_origin = mm_get_heap(oldmem);
+	struct mm_heap_s *kheap_origin;
 	struct mm_heap_s *kheap_new;
 
-	if (newsize == 0) {
-		mm_free(kheap_origin, oldmem);
-		return NULL;
-	}
+	if (oldmem) {
+		kheap_origin = mm_get_heap(oldmem);
+
+		/* The oldmem given by first argument is not a dynamically
+		 * allocated address. This will cause ASSERT like Linux.
+		 */
+		ASSERT(kheap_origin);
+
+		if (newsize == 0) {
+			mm_free(kheap_origin, oldmem);
+			return NULL;
+		}
 
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
-	ret = mm_realloc(kheap_origin, oldmem, newsize, caller_retaddr);
+		ret = mm_realloc(kheap_origin, oldmem, newsize, caller_retaddr);
 #else
-	ret = mm_realloc(kheap_origin, oldmem, newsize);
+		ret = mm_realloc(kheap_origin, oldmem, newsize);
 #endif
-	if (ret != NULL) {
-		return ret;
+		if (ret != NULL) {
+			return ret;
+		}
 	}
 
 	/* Try to mm_malloc to another heap. */


### PR DESCRIPTION
if oldmem argument is NULL or not in heap address, we get a crash in mm_free_delaylist:103

When we call the mm_malloc API, we guarantee that the argument's heap is valid before calling it. Therefore, there is no NULL check for the heap argument in mm_malloc. So, when calling mm from kmm or umm, we need to pass the correct heap variable as an argument.

In this issue, when oldmem was passed as NULL in kmm_realloc, mm_get_heap returned NULL and caused a crash because mm_realloc was called with a NULL argument. To fix this,

Change to so that, if we cannot find the heap using oldmem, mm_realloc is not called with NULL.