### PR TITLE
os/board/rtl8730e/src/component: change SPI dma channel allocation/free

### DIFF
--- a/os/board/rtl8730e/src/component/mbed/targets/hal/rtl8730e/spi_api.c
+++ b/os/board/rtl8730e/src/component/mbed/targets/hal/rtl8730e/spi_api.c
@@ -57,10 +57,10 @@ typedef struct {
 	/* mbed var */
 	u32 dma_en;
 
-	bool is_readwrite;
+	u32 is_readwrite;
 } HAL_SSI_ADAPTOR, *PHAL_SSI_ADAPTOR;
 
-HAL_SSI_ADAPTOR ssi_adapter_g[2];
+static HAL_SSI_ADAPTOR ssi_adapter_g[2];
 
 /**
   * @}
@@ -276,8 +276,8 @@ static u32 ssi_dma_tx_irq(void *Data)
 	}
 
 	SSI_SetDmaEnable(ssi_adapter->spi_dev, DISABLE, SPI_BIT_TDMAE);
-
-	GDMA_ChnlFree(GDMA_InitStruct->GDMA_Index, GDMA_InitStruct->GDMA_ChNum);
+	/* we should only free the channel during spi_free */
+	// GDMA_ChnlFree(GDMA_InitStruct->GDMA_Index, GDMA_InitStruct->GDMA_ChNum);
 
 	ssi_adapter->dma_en &= ~SPI_DMA_TX_EN;
 
@@ -306,8 +306,8 @@ static u32 ssi_dma_rx_irq(void *Data)
 	if (NULL != ssi_adapter->RxCompCallback) {
 		ssi_adapter->RxCompCallback(ssi_adapter->RxCompCbPara);
 	}
-
-	GDMA_ChnlFree(GDMA_InitStruct->GDMA_Index, GDMA_InitStruct->GDMA_ChNum);
+	/* we should only free the channel during spi_free */
+	// GDMA_ChnlFree(GDMA_InitStruct->GDMA_Index, GDMA_InitStruct->GDMA_ChNum);
 
 	ssi_adapter->dma_en &= ~SPI_DMA_RX_EN;
 

--- a/os/board/rtl8730e/src/component/soc/amebad2/fwlib/include/ameba_spi.h
+++ b/os/board/rtl8730e/src/component/soc/amebad2/fwlib/include/ameba_spi.h
@@ -508,6 +508,8 @@ typedef struct {
 	u32 Tx_HandshakeInterface;
 	u32 Rx_HandshakeInterface;
 	IRQn_Type IrqNum;
+	u8 tx_channel_allocated;
+	u8 rx_channel_allocated;
 } SPI_DevTable;
 
 /**
@@ -684,7 +686,7 @@ _LONG_CALL_ void SSI_SetDmaLevel(SPI_TypeDef *spi_dev, u32 TxLeve, u32 RxLevel);
 
 /* Other Definitions --------------------------------------------------------*/
 
-extern const SPI_DevTable SPI_DEV_TABLE[2];
+extern SPI_DevTable SPI_DEV_TABLE[2];
 
 /* MANUAL_GEN_END */
 


### PR DESCRIPTION
1. from our experiment, frequent allocating/free gdma channel is causing unexpected behavior (ie. system stability issue)
2. thus we only allocate it once during the first spi operation