### PR TITLE
version: Set Tizen Lite version to 5.0

### DIFF
--- a/os/Makefile.unix
+++ b/os/Makefile.unix
@@ -300,7 +300,7 @@ tools/mkversion$(HOSTEXEEXT):
 
 $(TOPDIR)/.version: force_build
 	echo "create .version file"; \
-	tools/version.sh -v 3.1 .version; \
+	tools/version.sh -v 5.0 .version; \
 	chmod 755 .version
 
 include/tinyara/version.h: $(TOPDIR)/.version tools/mkversion$(HOSTEXEEXT)

--- a/os/Makefile.win
+++ b/os/Makefile.win
@@ -263,14 +263,14 @@ tools\mkversion$(HOSTEXEEXT):
 	$(Q) $(MAKE) -C tools -f Makefile.host TOPDIR="$(TOPDIR)"  mkversion$(HOSTEXEEXT)
 
 $(TOPDIR)\.version:
-	$(Q) echo CONFIG_VERSION_STRING="3.1" > .version
-	$(Q) echo CONFIG_VERSION_MAJOR=3 >> .version
-	$(Q) echo CONFIG_VERSION_MINOR=1 >> .version
+	$(Q) echo CONFIG_VERSION_STRING="5.0" > .version
+	$(Q) echo CONFIG_VERSION_MAJOR=5 >> .version
+	$(Q) echo CONFIG_VERSION_MINOR=0 >> .version
 	$(Q) echo CONFIG_VERSION_BUILD="0" >> .version
 
 # $(Q) if [ ! -f .version ]; then \
 # 	echo "No .version file found, creating one"; \
-# 	tools\version.sh -v 3.1 -b 0 .version; \
+# 	tools\version.sh -v 5.0 -b 0 .version; \
 # 	chmod 755 .version; \
 # fi
 


### PR DESCRIPTION
Set Tizen Lite platform version to 5.0.
It is shown in "System Informatin" when booting.

System Information:
	Version:
		Platform: 5.0	Binary: 200204