### PR TITLE
apps/examples/lcd_test/:  Fix missing close fd in lcd example

### DIFF
--- a/apps/examples/lcd_test/example_lcd.c
+++ b/apps/examples/lcd_test/example_lcd.c
@@ -388,5 +388,6 @@ int lcd_test_main(int argc, char *argv[])
 		printf("count :%d\n", count);
 	}
 	test_fps();
+	close(fd);
 	return 0;
 }


### PR DESCRIPTION
close the missing lcd fd in int main of example_lcd.c