### PR TITLE
tools/debug: Modify the trap tool to print exact line number

### DIFF
--- a/tools/trap/ramdumpParser.py
+++ b/tools/trap/ramdumpParser.py
@@ -884,7 +884,7 @@ def find_crash_point(log_file, elf):
 				os.system("python3 ../debug/debugsymbolviewer.py " + log_file + " " + str(g_app_idx) + " 3 " + BIN_PATH + " " + CONFIG_PATH)
 
 	# It displays the debug symbols corresponding to all the addresses in the kernel and application text address range
-	print('\nStack_address\t Symbol_address\t Symbol location  Symbol_name\t\tFile_name')
+	print('\nStack_address\t Symbol_address\t Symbol_location  Symbol_name\t\tFile_name')
 	os.system("python3 ../debug/debugsymbolviewer.py " + log_file + " " + str(g_app_idx) + " 0 " + BIN_PATH + " " + CONFIG_PATH)
 
 	print('\nh. Heap Region information:\n')


### PR DESCRIPTION
The trap tool makes use of nm tool to look up the symbols. However the nm tool does not give exact line number for the given address. So, we change the trap tool to use nm only for symbol name and then get the exact line number using the addr2line tool.

Trap output before change:
==================
```
Stack_address	 Symbol_address	 Symbol location  Symbol_name		File_name
 User stack
0x6068cbb4	 0xe01dc49	 kernel  	  sig_dispatch	/root/tizenrt/os/kernel/signal/sig_dispatch.c:435
0x6068cbc8	 0xe0293f9	 kernel  	  arm_sigdeliver	/root/tizenrt/os/arch/arm/src/armv7-a/arm_sigdeliver.c:71
0x6068cbd8	 0xe180521	 app1    	  libc_signal_main	/root/tizenrt/apps/examples/testcase/le_tc/kernel/tc_libc_signal.c:428
0x6068cc14	 0xe180521	 app1    	  libc_signal_main	/root/tizenrt/apps/examples/testcase/le_tc/kernel/tc_libc_signal.c:428
0x6068cc18	 0xe191f95	 app1    	  waitpid	/root/tizenrt/os/include/sys/wait.h:319
0x6068cd28	 0xe180521	 app1    	  libc_signal_main	/root/tizenrt/apps/examples/testcase/le_tc/kernel/tc_libc_signal.c:428
0x6068cd30	 0xe180209	 app1    	  libc_semaphore_main	/root/tizenrt/apps/examples/testcase/le_tc/kernel/tc_libc_semaphore.c:152
0x6068cd34	 0xe1a9ca4	 app1    	  utils_ttypenames	/root/tizenrt/apps/system/utils/utils_ps.c:94
0x6068cd38	 0xe1aa1a0	 app1    	  l_day
0x6068cd70	 0xe170425	 app1    	  tc_kernel_main	/root/tizenrt/apps/examples/testcase/le_tc/kernel/kernel_tc_main.c:43
0x6068cd74	 0xe170419	 app1    	  tc_get_drvfd	/root/tizenrt/apps/examples/testcase/le_tc/kernel/kernel_tc_main.c:35
0x6068cd78	 0xe16ba21	 app1    	  task_startup	/root/tizenrt/os/include/tinyara/userspace.h:145
0x6068cd80	 0xe01abb9	 kernel  	  task_start	/root/tizenrt/os/kernel/task/task_start.c:133
0x6068cd98	 0xe01a2b9	 kernel  	  group_zalloc	/root/tizenrt/os/include/tinyara/kmalloc.h:166

```

Trap output after change:
==================
```
Stack_address	 Symbol_address	 Symbol_location  Symbol_name		File_name
 User stack
0x6068cbb4	 0xe01dc63	 kernel binary    sig_dispatc           /root/tizenrt/os/kernel/signal/sig_deliver.c:104
0x6068cbc8	 0xe029429	 kernel binary    arm_sigdelive         /root/tizenrt/os/arch/arm/src/armv7-a/arm_sigdeliver.c:108 (discriminator 1)
0x6068cbd8	 0xe180c31	 common binary    libc_signal_mai       /root/tizenrt/apps/examples/testcase/le_tc/kernel/tc_libc_signal.c:414
0x6068cc14	 0xe180c31	 common binary    libc_signal_mai       /root/tizenrt/apps/examples/testcase/le_tc/kernel/tc_libc_signal.c:414
0x6068cc18	 0xe191fa2	 common binary    waitpi                /root/tizenrt/os/syscall/proxies/PROXY_waitpid.c:12
0x6068cd28	 0xe180c31	 common binary    libc_signal_mai       /root/tizenrt/apps/examples/testcase/le_tc/kernel/tc_libc_signal.c:414
0x6068cd30	 0xe18047b	 common binary    libc_semaphore_mai    /root/tizenrt/apps/examples/testcase/le_tc/kernel/tc_libc_semaphore.c:81
Symbol not found for address: 0xe1aa01c
Symbol not found for address: 0xe1ad39a
0x6068cd70	 0xe17047d	 common binary    tc_kernel_mai         /root/tizenrt/apps/examples/testcase/le_tc/kernel/kernel_tc_main.c:124
0x6068cd74	 0xe170425	 common binary    tc_get_drvf           /root/tizenrt/apps/examples/testcase/le_tc/kernel/kernel_tc_main.c:46
0x6068cd78	 0xe16ba39	 common binary    task_startu           /root/tizenrt/lib/libc/sched/task_startup.c:123 (discriminator 3)
0x6068cd80	 0xe01ac03	 kernel binary    task_star             /root/tizenrt/os/kernel/task/task_start.c:162
0x6068cd98	 0xe01a2c1	 kernel binary    group_zallo           /root/tizenrt/os/kernel/group/group_zalloc.c:104
```
