### PR TITLE
os/drivers/pm: fix errno in pm_driver

### DIFF
--- a/os/drivers/pm/pm.c
+++ b/os/drivers/pm/pm.c
@@ -144,8 +144,11 @@ static int pm_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
 	default:
 		pmvdbg("Invalid command passed!\n");
 		break;
-        }
-        return ret;
+	}
+	if (ret == ERROR) {
+		ret = -get_errno();
+	}
+	return ret;
 }
 
 /****************************************************************************


### PR DESCRIPTION
This commit resolve ioctl overwrite issue of errno. Now pm_ioctl returning errno directly to fs_ioctl, which will set errno with given error.