### PR TITLE
os: Add pm_start api

### DIFF
--- a/os/drivers/pm/pm.c
+++ b/os/drivers/pm/pm.c
@@ -76,6 +76,7 @@ static ssize_t pm_write(FAR struct file *filep, FAR const char *buffer, size_t l
  *   PMIOC_METRICS - to get pm metrics data for given time
  *   PMIOC_TUNEFREQ - for changing the operating frequency of the core to save power
  *   PMIOC_SUSPEND_COUNT - to get suspend count of pm domain
+ *   PMIOC_START - to start PM functionality to make board sleep
  * 
  * Arguments:
  *   filep is ioctl fd, cmd is required command, arg is required argument for
@@ -88,6 +89,7 @@ static ssize_t pm_write(FAR struct file *filep, FAR const char *buffer, size_t l
  *   for PMIOC_METRICS, arg should be an int type.
  *   for PMIOC_TUNEFREQ, arg should be an int type.
  *   for PMIOC_SUSPEND_COUNT, arg should be an int type.
+ *   for PMIOC_START, arg should be NULL
  *
  * Description:
  *   This api can be used to perform PM operation.
@@ -103,6 +105,7 @@ static ssize_t pm_write(FAR struct file *filep, FAR const char *buffer, size_t l
  *   PMIOC_METRICS           -   return OK on success
  *   PMIOC_TUNEFREQ          -   return OK on success
  *   PMIOC_SUSPEND_COUNT     -   return non-negative suspend count of domain
+ *   PMIOC_START             -   return OK
  *
  ************************************************************************************/
 static int pm_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
@@ -117,6 +120,12 @@ static int pm_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
         	break;
         case PMIOC_RESUME:
 		ret = pm_resume((int)arg);
+		/* Note: Below code is temporary fix to support old 'system_pm_start' API.
+		 * It needs to remove for later version.
+		 */
+		if (arg == PM_IDLE_DOMAIN) {
+			pm_start();
+		}
 		pmvdbg("State unlocked!\n");
 		break;
 	case PMIOC_SLEEP:
@@ -143,6 +152,10 @@ static int pm_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
 				ret = OK;
 			}
 		}
+		break;
+	case PMIOC_START:
+		pm_start();
+		ret = OK;
 		break;
 	case PMIOC_SUSPEND_COUNT:
 		ret = pm_suspendcount((int)arg);

--- a/os/include/tinyara/fs/ioctl.h
+++ b/os/include/tinyara/fs/ioctl.h
@@ -467,6 +467,7 @@
 #define PMIOC_TUNEFREQ           _PMIOC(0x0006)
 #define PMIOC_METRICS            _PMIOC(0x0007)
 #define PMIOC_SUSPEND_COUNT      _PMIOC(0x0008)
+#define PMIOC_START              _PMIOC(0x0009)
 
 /* Cpuload driver ioctl definitions ************************/
 

--- a/os/include/tinyara/pm/pm.h
+++ b/os/include/tinyara/pm/pm.h
@@ -294,6 +294,25 @@ EXTERN const char *wakeup_src_name[PM_WAKEUP_SRC_COUNT];
 void pm_driver_register(void);
 
 #ifdef CONFIG_PM
+
+/****************************************************************************
+ * Name: pm_start
+ *
+ * Description:
+ *   This function is called by the application thread to start the Power
+ *   Management system. This fucntion sets the is_running flag which
+ *   enables pm to transition between low and high power states.
+ *
+ * Input parameters:
+ *   None.
+ *
+ * Returned value:
+ *    None.
+ *
+ ****************************************************************************/
+
+void pm_start(void);
+
 /****************************************************************************
  * Name: pm_initialize
  *
@@ -550,6 +569,7 @@ int pm_metrics(int milliseconds);
  * avoid so much conditional compilation in driver code when PM is disabled:
  */
 
+#define pm_start()
 #define pm_initialize()
 #define pm_register(cb)         (0)
 #define pm_unregister(cb)       (0)

--- a/os/kernel/init/os_start.c
+++ b/os/kernel/init/os_start.c
@@ -838,12 +838,6 @@ void os_start(void)
 	/* Bring Up the System ****************************************************/
 	/* Create initial tasks and bring-up the system */
 
-#ifdef CONFIG_PM
-	/* We cannot enter low power state until boot complete */
-	pm_suspend(PM_IDLE_DOMAIN);
-	
-#endif
-
 #ifdef CONFIG_DEBUG_MM_WARN
 	display_memory_information();
 #endif

--- a/os/pm/pm.h
+++ b/os/pm/pm.h
@@ -135,6 +135,9 @@ struct pm_global_s {
 
 	/* No. of Registered Domains */
 	uint16_t ndomains;
+
+	/* Indicates Board is Ready to State Change */
+	bool is_running;
 };
 
 /****************************************************************************

--- a/os/pm/pm_idle.c
+++ b/os/pm/pm_idle.c
@@ -82,6 +82,10 @@ void pm_idle(void)
 	int gated_cpu_count = 0;
 	FAR struct tcb_s *tcb;
 #endif
+	/* State change only if PM is ready to state change */
+	if (!g_pmglobals.is_running) {
+		return;
+	}
 	flags = enter_critical_section();
 	now = clock_systimer();
 	/* We need to check and change PM state transition only if one tick time has been passed,

--- a/os/pm/pm_initialize.c
+++ b/os/pm/pm_initialize.c
@@ -84,6 +84,26 @@ const char *wakeup_src_name[PM_WAKEUP_SRC_COUNT] = {"UNKNOWN", "BLE", "WIFI", "U
  ****************************************************************************/
 
 /****************************************************************************
+ * Name: pm_start
+ *
+ * Description:
+ *   This function is called by the application thread to start the Power
+ *   Management system. This fucntion sets the is_running flag which
+ *   enables pm to transition between low and high power states.
+ *
+ * Input parameters:
+ *   None.
+ *
+ * Returned value:
+ *    None.
+ *
+ ****************************************************************************/
+
+void pm_start(void) {
+	g_pmglobals.is_running = true;
+}
+
+/****************************************************************************
  * Name: pm_initialize
  *
  * Description:

--- a/os/pm/pm_metrics.c
+++ b/os/pm/pm_metrics.c
@@ -266,6 +266,11 @@ int pm_metrics(int milliseconds)
 		pmdbg("PM Metrics already running\n");
 		return OK;
 	}
+	/* There is no need to do measurement if PM is not ready to state change */
+	if (!g_pmglobals.is_running) {
+		pmdbg("Please Start PM to enable PM Metrics\n");
+		return OK;
+	}
 	/* Lock PM so that no two thread can run PM Metrics simultaneously */
 	pm_lock();
 	/* Avoid board sleep during PM Metrics initialization */


### PR DESCRIPTION
This commit enable applications to start power
management system. This API should be called
when board is ready to transition into low
power state. This API helps PM to remove the
use of `PM_IDLE_DOMAIN` outside the scope of PM.

`pm_start` - This API meant to be called during app
initialization to enable low power state transition.
In PM side we can reduce some of the costlier operation
based on the `is_running` flag. In the event of crash
and app reloading, this API can be used for reinitialization.

`pm_resume` - This API removes pm state transition lock for
specific domain. It has domain information, which helps PM
to do domain specific operation, like "when LCD domain get
resume, do backlight dimming". This should be used in pair
with `pm_suspend` API.

`pm_suspend` and `pm_resume` are like locks, which should be used
in pairs to prevent board sleep in critical section. The current
usage `pm_suspend(0)` in OS and `pm_resume(0)` in application, to prevent
board sleep before app initialization is not good design. So, we kept
`PM (OFF)` by default and pm_start API will do `PM (ON)` when application
is ready to do power saving.