### PR TITLE
os/include : Fix compilation error after enabling all debug option.

### DIFF
--- a/os/arch/arm/src/armv7-a/arm_assert.c
+++ b/os/arch/arm/src/armv7-a/arm_assert.c
@@ -477,6 +477,22 @@ static void arm_assert(void)
 }
 
 /****************************************************************************
+ * Name: dump_stack : dumps the stack of current thread
+ ****************************************************************************/
+void dump_stack(void)
+{
+	/* ToDo: implement as per the armv7-a architecture */
+}
+
+/****************************************************************************
+ * Name: dump_all_stack : dumps the stack of current thread
+ ****************************************************************************/
+void dump_all_stack(void)
+{
+	/* ToDo: implement as per the armv7-a architecture */
+}
+
+/****************************************************************************
  * Name: check_heap_corrupt
  ****************************************************************************/
 

--- a/os/board/rtl8730e/src/component/wifi/wifi_interactive_mode.c
+++ b/os/board/rtl8730e/src/component/wifi/wifi_interactive_mode.c
@@ -604,7 +604,7 @@ void cmd_wifi_info(int argc, char **argv)
 
 	for (i = 0; i < NET_IF_NUM; i++) {
 		if (wifi_is_running(i)) {
-			nvdbg("\n\r\nWIFI %s Status: Running", ifname[i]);
+			nvdbg("\n\r\nWIFI idx %d Status: Running", i);
 			nvdbg("\n\r==============================");
 
 			rltk_wlan_statistic(i, &sw_stats);

--- a/os/include/debug.h
+++ b/os/include/debug.h
@@ -817,6 +817,12 @@ int get_errno(void);
 #define dmallvdbg(...)
 #endif
 
+#ifdef CONFIG_DEBUG_IRQ_INFO
+#define irqinfo(format, ...)   vdbg(format, ##__VA_ARGS__)
+#else
+#define irqinfo(...)
+#endif
+
 #ifdef CONFIG_DEBUG_PAGING_ERROR
 #define pgdbg(format, ...)    dbg(format, ##__VA_ARGS__)
 #define pglldbg(format, ...)  lldbg(format, ##__VA_ARGS__)
@@ -1633,6 +1639,12 @@ int get_errno(void);
 #else
 #define dmavdbg     (void)
 #define dmallvdbg   (void)
+#endif
+
+#ifdef CONFIG_DEBUG_IRQ_INFO
+#define irqinfo	 vdbg
+else
+#define irqinfo  (void)
 #endif
 
 #ifdef CONFIG_DEBUG_PAGING_ERROR

--- a/os/kernel/debug/memdbg.c
+++ b/os/kernel/debug/memdbg.c
@@ -99,9 +99,9 @@ void display_memory_information(void)
 	/* Print HEAP configuration */
 
 	for (heap_idx = 0; heap_idx < CONFIG_KMM_NHEAPS; heap_idx++) {
-		mllwdbg("Heap[%d] : size = %u, number of regions = %d\n", heap_idx, kheap[heap_idx].mm_heapsize, kheap[heap_idx].mm_nregions);
 		region_idx = 0;
 #if CONFIG_KMM_REGIONS > 1
+		mllwdbg("Heap[%d] : size = %u, number of regions = %d\n", heap_idx, kheap[heap_idx].mm_heapsize, kheap[heap_idx].mm_nregions);
 		for (; region_idx < kheap[heap_idx].mm_nregions; region_idx++)
 #endif
 		{


### PR DESCRIPTION
For the below error the changes are made to resolve :
error: 'struct mm_heap_s' has no member named 'mm_nregions'
	102 |   mllwdbg("Heap[%d] : size = %u, number of regions = %d\n", heap_idx, kheap[heap_idx].mm_heapsize, kheap[heap_idx].mm_nregions);

error: 'ifname' undeclared (first use in this function); did you mean 'rename'?
  607 |    nvdbg("\n\r\nWIFI %s Status: Running", ifname[i]);

error: too few arguments to function 'wifi_set_mac_address'
  886 |   nvdbg("\r\n%d", wifi_set_mac_address(argv[2]));

arm-none-eabi-ld: /root/tizenrt/os/../build/output/libraries/libarch.a(arm_gicv2_dump.o): in function `arm_gic_dumpregs':
/root/tizenrt/os/arch/arm/src/armv7-a/arm_gicv2_dump.c:115: undefined reference to `irqinfo'

arm-none-eabi-ld: /root/tizenrt/os/../build/output/libraries/libkernel.a(sysdbg.o): in function `sysdbg_write':
/root/tizenrt/os/kernel/debug/sysdbg.c:459: undefined reference to `dump_stack'

arm-none-eabi-ld: /root/tizenrt/os/kernel/debug/sysdbg.c:465: undefined reference to `dump_all_stack'.