### PR TITLE
os/board/rtl8730e: ensure cache coherency on csi config API

### DIFF
--- a/os/board/rtl8730e/src/component/wifi/inic/inic_ipc_host_api_ext.c
+++ b/os/board/rtl8730e/src/component/wifi/inic/inic_ipc_host_api_ext.c
@@ -897,10 +897,19 @@ int wifi_csi_config(rtw_csi_action_parm_t *act_param)
 	int ret = 0;
 	u32 param_buf[1];
 
-	param_buf[0] = (u32)act_param;
-	DCache_Clean((u32)act_param, sizeof(rtw_csi_action_parm_t));
+	rtw_csi_action_parm_t *act_param_temp = (rtw_csi_action_parm_t *)rtw_malloc(sizeof(rtw_csi_action_parm_t));
+	if (act_param_temp == NULL) {
+		return -1;
+	}
+
+	memcpy(act_param_temp, act_param, sizeof(rtw_csi_action_parm_t));
+	param_buf[0] = (u32)act_param_temp;
+	DCache_Clean((u32)act_param_temp, sizeof(rtw_csi_action_parm_t));
 	ret = inic_ipc_api_host_message_send(IPC_API_WIFI_CONFIG_CSI, param_buf, 1);
-	DCache_Invalidate((u32)act_param, sizeof(rtw_csi_action_parm_t));
+	DCache_Invalidate((u32)act_param_temp, sizeof(rtw_csi_action_parm_t));
+	memcpy(act_param, act_param_temp, sizeof(rtw_csi_action_parm_t));
+	rtw_mfree((u8 *)act_param_temp, 0);
+
 	return ret;
 }
 


### PR DESCRIPTION
- CSI config parameters will be passed from CA32 to KM4 for processing. Need to ensure config's buffer is aligned to prevent cache coherency issues
- Add an aligned temp buffer to store application's csi config to pass into KM4 to ensure the above point is met