### PR TITLE
os/board/rtl8730e: Change LCD update polling to semaphore

### DIFF
--- a/os/board/rtl8730e/src/rtl8730e_mipi_lcdc.c
+++ b/os/board/rtl8730e/src/rtl8730e_mipi_lcdc.c
@@ -87,6 +87,7 @@ LCDC_TypeDef *pLCDC = LCDC;
 LCDC_InitTypeDef lcdc_init_struct;
 static u32 UnderFlowCnt = 0;
 static u8 lcdc_nextframe = 0;
+static sem_t g_next_frame_block;
 
 struct irq lcdc_irq_info = {
 	.num = LCDC_IRQ,
@@ -122,6 +123,7 @@ static void rtl8730e_lcd_init(void)
 	rtl8730e_register_lcdc_isr();
 	LCDC_LineINTPosConfig(pLCDC, LCD_YRES * 4 / 5);
 	LCDC_INTConfig(pLCDC, LCDC_BIT_LCD_LIN_INTEN | LCDC_BIT_DMA_UN_INTEN | LCDC_BIT_LCD_FRD_INTEN, ENABLE);
+	sem_init(&g_next_frame_block, 0, 1);
 }
 
 static void rtl8730e_gpio_reset(void)
@@ -158,6 +160,7 @@ static void rtl8730e_lcd_layer_enable(int layer, bool enable)
 
 static void rtl8730e_lcd_put_area(u8 *lcd_img_buffer, u32 x_start, u32 y_start, u32 x_end, u32 y_end)
 {
+	irqstate_t flags;
 #ifdef CONFIG_PM
 	bsp_pm_domain_control(BSP_MIPI_DRV, 1);
 #endif
@@ -171,11 +174,11 @@ static void rtl8730e_lcd_put_area(u8 *lcd_img_buffer, u32 x_start, u32 y_start, 
 #endif
 	LCDC_LayerConfig(pLCDC, LCD_LAYER, &lcdc_init_struct.layerx[LCD_LAYER]);
 	DCache_CleanInvalidate((u32)lcd_img_buffer, LCDC_IMG_BUF_SIZE);
-	lcdc_nextframe = 0;
+	sem_wait(&g_next_frame_block);
+	flags = enter_critical_section();
+	lcdc_nextframe = 1;
 	LCDC_TrigerSHWReload(pLCDC);
-	while (!lcdc_nextframe) {
-		DelayMs(1);
-	}
+	leave_critical_section(flags);
 #ifdef CONFIG_PM
 	bsp_pm_domain_control(BSP_MIPI_DRV, 0);
 #endif
@@ -241,7 +244,10 @@ u32 rtl8730e_hv_isr(void *Data)
 
 	if (IntId & LCDC_BIT_LCD_FRD_INTS) {
 		LCDC_ClearINT(pLCDC, LCDC_BIT_LCD_FRD_INTS);
-		lcdc_nextframe = 1;
+		if (lcdc_nextframe == 1) {
+			lcdc_nextframe = 0;
+			sem_post(&g_next_frame_block);
+		}
 	}
 
 	if (IntId & LCDC_BIT_DMA_UN_INTS) {


### PR DESCRIPTION
- Remove while loop waiting for next frame display
- Introduce sem_wait to signal the next frame is ready to update
- Reduce CPU loading from continue checking, LCD threads will be block and be scheduled only when the resource becomes available.