### PR TITLE
drivers/audio: change DMA & audio buffer size

### DIFF
--- a/os/arch/arm/src/amebasmart/amebasmart_i2s.c
+++ b/os/arch/arm/src/amebasmart/amebasmart_i2s.c
@@ -119,7 +119,7 @@
 
 #define OVER_SAMPLE_RATE (384U)
 
-#define I2S_DMA_PAGE_SIZE 2048	/* 4 ~ 16384, set to a factor of APB size */
+#define I2S_DMA_PAGE_SIZE 16384	/* 4 ~ 16384, set to a factor of APB size */
 #define I2S_DMA_PAGE_NUM 4	/* Vaild number is 2~4 */
 
 struct amebasmart_buffer_s {

--- a/os/drivers/audio/syu645b.c
+++ b/os/drivers/audio/syu645b.c
@@ -52,7 +52,7 @@
  * It's good to match the buffer size with i2s DMA page size
  */
 #ifndef CONFIG_SYU645B_BUFFER_SIZE
-#define CONFIG_SYU645B_BUFFER_SIZE       2048
+#define CONFIG_SYU645B_BUFFER_SIZE       16384
 #endif
 
 #ifndef CONFIG_SYU645B_NUM_BUFFERS


### PR DESCRIPTION
1. change I2S_DMA_PAGE_SIZE 2048 -> 16384
2. change CONFIG_SYU645B_BUFFER_SIZE 2048 -> 16384

If the buffer size is too small, too many interrupts will be called, causing problems, so we allocate a larger size.
This is a temporary measure, and can be fixed later when the i2s problem is accurately analyzed.