### PR TITLE
arm/src/armv7-a: correct condition to allocate sections in mmu

### DIFF
--- a/os/arch/arm/src/armv7-a/arm_mmu.c
+++ b/os/arch/arm/src/armv7-a/arm_mmu.c
@@ -443,8 +443,10 @@ void mmu_map_app_region(int app_id, uint32_t *l1_pgtbl, uint32_t start, uint32_t
 
 	// Run a loop until the entire region is mapped.
 	while (start < end) {
-		// Check if this address can be mapped to a section.
-		if (!(start & SECTION_MASK) && !(size & SECTION_MASK)) {
+		// Check if this address can be mapped to a section. Below are the conditions,
+		// 1. start should be aligned to section size
+		// 2. remaining size should be greater than or equal to section size
+		if (!(start & SECTION_MASK) && size >= SECTION_SIZE) {
 			// Yes. Update the section entry in the the L1 page table.
 			idx = start >> 20;
 			val = start & PMD_PTE_PADDR_MASK;
@@ -453,6 +455,7 @@ void mmu_map_app_region(int app_id, uint32_t *l1_pgtbl, uint32_t start, uint32_t
 
 			// Advance the memory region address.
 			start += SECTION_SIZE;
+			size -= SECTION_SIZE;
 		} else {				// Check if this address can be mapped to a small page.
 
 			// Check if L2 page table is not created.
@@ -483,6 +486,7 @@ void mmu_map_app_region(int app_id, uint32_t *l1_pgtbl, uint32_t start, uint32_t
 
 			// Advance the memory region address.
 			start += SMALL_PAGE_SIZE;
+			size -= SMALL_PAGE_SIZE;
 		}
 	}
 	cp15_invalidate_tlbs();


### PR DESCRIPTION
Previous code was checking only if size is multiple of section size for allocating section. Modified the code to allocate section if size >= section size. This also makes sure that during binary loading, each binary atmost will need 4 l2 pages, 2 for rw data atmost and 2 for rox data atmost.

Before changes :
```
mmu_allocate_app_l2_pgtbl: app_id : 0, l2idx : 0
mmu_allocate_app_l2_pgtbl: app_id : 0, l2idx : 1
mmu_allocate_app_l2_pgtbl: app_id : 0, l2idx : 2
mmu_allocate_app_l2_pgtbl: app_id : 0, l2idx : 3
mmu_allocate_app_l2_pgtbl: app_id : 0, l2idx : 4
mmu_allocate_app_l2_pgtbl: app_id : 0, l2idx : 5
mmu_allocate_app_l2_pgtbl: app_id : 0, l2idx : 6

mmu_allocate_app_l2_pgtbl: app_id : 1, l2idx : 0
mmu_allocate_app_l2_pgtbl: app_id : 1, l2idx : 1
mmu_allocate_app_l2_pgtbl: app_id : 1, l2idx : 2
mmu_allocate_app_l2_pgtbl: app_id : 1, l2idx : 3
mmu_allocate_app_l2_pgtbl: app_id : 1, l2idx : 4
mmu_allocate_app_l2_pgtbl: app_id : 1, l2idx : 5
```
After changes :
```
mmu_allocate_app_l2_pgtbl: app_id : 0, l2idx : 0
mmu_allocate_app_l2_pgtbl: app_id : 0, l2idx : 1
mmu_allocate_app_l2_pgtbl: app_id : 0, l2idx : 2

mmu_allocate_app_l2_pgtbl: app_id : 1, l2idx : 0
mmu_allocate_app_l2_pgtbl: app_id : 1, l2idx : 1
```