### PR TITLE
log_dump: Add api to get size of the log dump

### DIFF
--- a/apps/examples/log_dump/log_dump_main.c
+++ b/apps/examples/log_dump/log_dump_main.c
@@ -43,6 +43,7 @@ int log_dump_main(int argc, char *argv[])
 #endif
 {
 	int ret = 1;
+	int total_read = 0;
 	char buf[READ_BUFFER_SIZE];
 	int fd = OPEN_LOGDUMP();
 
@@ -78,10 +79,12 @@ int log_dump_main(int argc, char *argv[])
 
 	while (ret > 0) {
 		ret = READ_LOGDUMP(fd, buf, sizeof(buf));
+		total_read += ret;
 		for (int i = 0; i < ret; i++) {
 			printf("%c", buf[i]);
 		}
 	}
+	printf("log_dump_size = %d, and total_read = %d, Both should be equal\n", GET_LOGDUMP_SIZE(fd), total_read);
 
         printf("\n*********************   LOG DUMP END  ***********************\n");
 

--- a/os/fs/procfs/fs_procfslogsave.c
+++ b/os/fs/procfs/fs_procfslogsave.c
@@ -120,10 +120,6 @@ static int logsave_open(FAR struct file *filep, FAR const char *relpath, int ofl
 {
 	FAR struct logsave_file_s *attr = (struct logsave_file_s *)kmm_zalloc(sizeof(struct logsave_file_s));
 	filep->f_priv = (FAR void *)attr;
-	if (log_dump_read_wake() != OK) {
-		fdbg("ERROR: log dump read wake fail\n");
-		return ERROR;
-	}
 	fvdbg("Open '%s'\n", relpath);
 	return OK;
 }

--- a/os/include/tinyara/log_dump/log_dump.h
+++ b/os/include/tinyara/log_dump/log_dump.h
@@ -33,6 +33,7 @@
 
 #define LOGDUMP_SAVE_START	"1"
 #define LOGDUMP_SAVE_STOP	"2"
+#define LOGDUMP_GET_SIZE    	"3"
 
 /********************************************************************************
  * Public Types
@@ -44,5 +45,6 @@
 #define OPEN_LOGDUMP()			open("/proc/logsave", O_RDWR)
 #define START_LOGDUMP_SAVE(fd)		write(fd, LOGDUMP_SAVE_START, strlen(LOGDUMP_SAVE_START) + 1)
 #define STOP_LOGDUMP_SAVE(fd)		write(fd, LOGDUMP_SAVE_STOP, strlen(LOGDUMP_SAVE_STOP) + 1)
+#define GET_LOGDUMP_SIZE(fd)        	write(fd, LOGDUMP_GET_SIZE, strlen(LOGDUMP_GET_SIZE) + 1)
 #define READ_LOGDUMP(fd, buf, bufsize)	read(fd, buf, bufsize)
 #define CLOSE_LOGDUMP(fd)		close(fd)

--- a/os/include/tinyara/log_dump/log_dump_internal.h
+++ b/os/include/tinyara/log_dump/log_dump_internal.h
@@ -52,6 +52,13 @@ int log_dump_set(FAR const char *buffer, size_t buflen);
 
 /****************************************************************************
  * Description:
+ *   This is used to get the size of the compressed log dump. 
+ *
+ ****************************************************************************/
+int log_dump_get_size(void);
+
+/****************************************************************************
+ * Description:
  *   Thread used to receive log data and compress the same
  *
  ****************************************************************************/


### PR DESCRIPTION
This commit adds an api to get the size of the compressed log dump.