### PR TITLE
drivers/audio: change audio buffer size

### DIFF
--- a/os/drivers/audio/alc1019.c
+++ b/os/drivers/audio/alc1019.c
@@ -52,7 +52,7 @@
  * It's good to match the buffer size with i2s DMA page size
  */
 #ifndef CONFIG_ALC1019_BUFFER_SIZE
-#define CONFIG_ALC1019_BUFFER_SIZE       2048
+#define CONFIG_ALC1019_BUFFER_SIZE       16384
 #endif
 
 #ifndef CONFIG_ALC1019_NUM_BUFFERS


### PR DESCRIPTION
change CONFIG_ALC1019_BUFFER_SIZE 2048 -> 16384

Commit is raised for RTL8730E rev 5 boards using ALC1019. 
Commit is based on following previous commit raised for rev 6 and above versions using SYU645B. https://github.com/Samsung/TizenRT/commit/e26b55ef1ca30c5f52c33a87d090232d4c51dbd1

For more details, please refer to above commit.