### PR TITLE
os/pm: Extend pm driver for pm suspend count

### DIFF
--- a/os/drivers/pm/pm.c
+++ b/os/drivers/pm/pm.c
@@ -73,6 +73,7 @@ static ssize_t pm_write(FAR struct file *filep, FAR const char *buffer, size_t l
  *   PMIOC_SLEEP - to make board sleep for given time
  *   PMIOC_TIMEDSUSPEND - to suspend a pm state for given time duration
  *   PMIOC_TUNEFREQ - for changing the operating frequency of the core to save power
+ *   PMIOC_SUSPEND_COUNT - to get suspend count of pm domain
  * 
  * Arguments:
  *   filep is ioctl fd, cmd is required command, arg is required argument for
@@ -84,6 +85,7 @@ static ssize_t pm_write(FAR struct file *filep, FAR const char *buffer, size_t l
  *   for PMIOC_DOMAIN_REGISTER, arg should be a pointer to pm_domain_arg_t
  *   for PMIOC_METRICS, arg should be an int type.
  *   for PMIOC_TUNEFREQ, arg should be an int type.
+ *   for PMIOC_SUSPEND_COUNT, arg should be an int type.
  *
  * Description:
  *   This api can be used to perform PM operation.
@@ -127,6 +129,9 @@ static int pm_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
 				ret = OK;
 			}
 		}
+		break;
+	case PMIOC_SUSPEND_COUNT:
+		ret = pm_suspendcount((int)arg);
 		break;
 #ifdef CONFIG_PM_METRICS
 	case PMIOC_METRICS:

--- a/os/drivers/pm/pm.c
+++ b/os/drivers/pm/pm.c
@@ -72,6 +72,8 @@ static ssize_t pm_write(FAR struct file *filep, FAR const char *buffer, size_t l
  *   PMIOC_RESUME - for unlocking a specific PM state
  *   PMIOC_SLEEP - to make board sleep for given time
  *   PMIOC_TIMEDSUSPEND - to suspend a pm state for given time duration
+ *   PMIOC_DOMAIN_REGISTER - to register and get pm domain ID of given domain name
+ *   PMIOC_METRICS - to get pm metrics data for given time
  *   PMIOC_TUNEFREQ - for changing the operating frequency of the core to save power
  *   PMIOC_SUSPEND_COUNT - to get suspend count of pm domain
  * 
@@ -89,6 +91,18 @@ static ssize_t pm_write(FAR struct file *filep, FAR const char *buffer, size_t l
  *
  * Description:
  *   This api can be used to perform PM operation.
+ * 
+ * Returned Value:
+ *   Returns a non-negative number on success;  A negated errno value is
+ *   returned on any failure.
+ *   PMIOC_SUSPEND           -   return OK on success  
+ *   PMIOC_RESUME            -   return OK on success
+ *   PMIOC_SLEEP             -   return OK on success
+ *   PMIOC_TIMEDSUSPEND      -   return OK on success
+ *   PMIOC_DOMAIN_REGISTER   -   return OK on success
+ *   PMIOC_METRICS           -   return OK on success
+ *   PMIOC_TUNEFREQ          -   return OK on success
+ *   PMIOC_SUSPEND_COUNT     -   return non-negative suspend count of domain
  *
  ************************************************************************************/
 static int pm_ioctl(FAR struct file *filep, int cmd, unsigned long arg)

--- a/os/include/tinyara/fs/ioctl.h
+++ b/os/include/tinyara/fs/ioctl.h
@@ -466,6 +466,7 @@
 #define PMIOC_DOMAIN_REGISTER	 _PMIOC(0x0005)
 #define PMIOC_TUNEFREQ           _PMIOC(0x0006)
 #define PMIOC_METRICS            _PMIOC(0x0007)
+#define PMIOC_SUSPEND_COUNT      _PMIOC(0x0008)
 
 /* Cpuload driver ioctl definitions ************************/
 

--- a/os/include/tinyara/pm/pm.h
+++ b/os/include/tinyara/pm/pm.h
@@ -482,20 +482,18 @@ int pm_timedsuspend(int domain_id, unsigned int milliseconds);
  * Name: pm_suspendcount
  *
  * Description:
- *   This function is called to get current stay count.
+ *   This function is called to get current suspend count of domain.
  *
  * Input Parameters:
  *   domain_id - The domain ID of the PM activity
  *
  * Returned Value:
- *   Current pm stay count
- *
- * Assumptions:
- *   This function may be called from an interrupt handler.
+ *   Non-Negative Integer: the suspend count of domain
+ *   ERROR: for invalid domain_id
  *
  ****************************************************************************/
 
-uint16_t pm_suspendcount(int domain_id);
+int pm_suspendcount(int domain_id);
 
 #ifdef CONFIG_PM_DVFS
 /****************************************************************************
@@ -562,6 +560,7 @@ int pm_metrics(int milliseconds);
 #define pm_resume(domain_id)    (0)
 #define pm_sleep(milliseconds)				usleep(milliseconds * USEC_PER_MSEC)
 #define pm_timedsuspend(domain_id, milliseconds)	(0)
+#define pm_suspendcount(domain_id)   (0)
 
 #endif							/* CONFIG_PM */
 

--- a/os/pm/pm_suspendcount.c
+++ b/os/pm/pm_suspendcount.c
@@ -77,25 +77,23 @@
  * Name: pm_suspendcount
  *
  * Description:
- *   This function is called to get current stay count.
+ *   This function is called to get current suspend count of domain.
  *
  * Input Parameters:
  *   domain_id - The domain ID of the PM activity
  *
  * Returned Value:
- *   Current pm stay count
- *
- * Assumptions:
- *   This function may be called from an interrupt handler.
+ *   Non-Negative Integer: the suspend count of domain
+ *   ERROR: for invalid domain_id
  *
  ****************************************************************************/
 
-uint16_t pm_suspendcount(int domain_id)
+int pm_suspendcount(int domain_id)
 {
-	/* Get a convenience pointer to minimize all of the indexing */
-
-	DEBUGASSERT(domain_id >= 0 && domain_id < CONFIG_PM_NDOMAINS);
-
+	/* Check if domain_id is valid */
+	if (pm_check_domain(domain_id) != OK) {
+		return ERROR;
+	}
 	return g_pmglobals.suspend_count[domain_id];
 }
 


### PR DESCRIPTION
This commit extends pm driver for pm suspend count. It adds API to get suspend
count of given domain id inside pm driver.