### PR TITLE
os/board/rtl8730e: Fix serial data corruption during wakeup

### DIFF
--- a/os/arch/arm/src/amebasmart/amebasmart_serial.c
+++ b/os/arch/arm/src/amebasmart/amebasmart_serial.c
@@ -1136,7 +1136,8 @@ static bool rtl8730e_up_txempty(struct uart_dev_s *dev)
 {
 	struct rtl8730e_up_dev_s *priv = (struct rtl8730e_up_dev_s *)dev->priv;
 	DEBUGASSERT(priv);
-	return (serial_writable(sdrv[uart_index_get(priv->tx)]));
+
+	return (serial_tx_empty(sdrv[uart_index_get(priv->tx)]));
 }
 
 /****************************************************************************
@@ -1180,7 +1181,8 @@ static uint32_t rtk_uart_suspend(uint32_t expected_idle_time, void *param)
 	(void)expected_idle_time;
 	(void)param;
 #ifdef CONFIG_RTL8730E_UART1
-	if (sdrv[uart_index_get(g_uart1priv.tx)] != NULL) {
+	if ((sdrv[uart_index_get(g_uart1priv.tx)] != NULL) && (g_uart1priv.baud > 115200)) {
+		/* Change to low clock speed when baudrate is higher than 115200, because clock will be power off */
 		serial_change_clcksrc(sdrv[uart_index_get(g_uart1priv.tx)], g_uart1priv.baud, 0);
 	}
 #endif
@@ -1192,7 +1194,8 @@ static uint32_t rtk_uart_resume(uint32_t expected_idle_time, void *param)
 	(void)expected_idle_time;
 	(void)param;
 #ifdef CONFIG_RTL8730E_UART1
-	if (sdrv[uart_index_get(g_uart1priv.tx)] != NULL) {
+	if ((sdrv[uart_index_get(g_uart1priv.tx)] != NULL) && (g_uart1priv.baud > 115200)) {
+		/* Change to high clock speed when baudrate is higher than 115200 */
 		serial_change_clcksrc(sdrv[uart_index_get(g_uart1priv.tx)], g_uart1priv.baud, 1);
 	}
 #endif

--- a/os/board/rtl8730e/src/component/mbed/hal/serial_api.h
+++ b/os/board/rtl8730e/src/component/mbed/hal/serial_api.h
@@ -197,6 +197,15 @@ int  serial_readable(serial_t *obj);
 int  serial_writable(serial_t *obj);
 
 /**
+  * @brief  check if transmit fifo is empty
+  * @param  obj: uart object define in application software.
+  * @retval status value:
+  *          - 1: TRUE
+  *          - 0: FALSE
+  */
+int serial_tx_empty(serial_t *obj);
+
+/**
   * @brief  Clear Rx fifo.
   * @param  obj: uart object define in application software.
   * @retval none

--- a/os/board/rtl8730e/src/component/mbed/targets/hal/rtl8730e/serial_api.c
+++ b/os/board/rtl8730e/src/component/mbed/targets/hal/rtl8730e/serial_api.c
@@ -788,6 +788,25 @@ int serial_writable(serial_t *obj)
 }
 
 /**
+  * @brief  Check if transmit fifo is empty
+  * @param  obj: uart object define in application software.
+  * @retval status value:
+  *          - 1: TRUE
+  *          - 0: FALSE
+  */
+int serial_tx_empty(serial_t *obj)
+{
+	PMBED_UART_ADAPTER puart_adapter = &(uart_adapter[obj->uart_idx]);
+	u32 reg_lsr = UART_LineStatusGet(puart_adapter->UARTx);
+
+	if (reg_lsr & RUART_BIT_TX_EMPTY) {
+		return 1;
+	} else {
+		return 0;
+	}
+}
+
+/**
   * @brief  Clear Rx FIFO.
   * @param  obj: UART object defined in application software.
   * @retval none


### PR DESCRIPTION
- Do not change clock speed when baudrate is lower than 115200 during resume and suspend
- Corect serial tx empty check API