### PR TITLE
os: Resolve warning

### DIFF
--- a/os/binfmt/libxipelf/xipelf.c
+++ b/os/binfmt/libxipelf/xipelf.c
@@ -100,11 +100,11 @@ static int xipelf_loadbinary(FAR struct binary_s *binp)
 
 	close(filfd);
 
-	binp->sections[BIN_TEXT] = uspace.text_start;
-	binp->flash_region_start = uspace.text_start - uspace_offset + 4;
-	binp->flash_region_end = uspace.flash_end;
-	binp->ram_region_start = uspace.ram_start;
-	binp->ram_region_end = uspace.ram_end;
+	binp->sections[BIN_TEXT] = (uint32_t)uspace.text_start;
+	binp->flash_region_start = (uint32_t)uspace.text_start - uspace_offset + 4;
+	binp->flash_region_end = (uint32_t)uspace.flash_end;
+	binp->ram_region_start = (uint32_t)uspace.ram_start;
+	binp->ram_region_end = (uint32_t)uspace.ram_end;
 	binp->sizes[BIN_TEXT] = binp->flash_region_end - binp->flash_region_start;
 
 	/* zero out the bss... */

--- a/os/board/common/partitions.c
+++ b/os/board/common/partitions.c
@@ -281,8 +281,6 @@ static void configure_partition_name(FAR struct mtd_dev_s *mtd_part, const char 
 #ifdef CONFIG_RESOURCE_FS
 static int make_resource_mtd_partition(struct mtd_dev_s *mtd, off_t partoffset, off_t nblocks, uint16_t partno)
 {
-	int ret;
-	char fs_devname[FS_PATH_MAX];
 	FAR struct mtd_dev_s *mtd_part;
 	uint16_t resource_partno;
 

--- a/os/board/rtl8730e/src/rtl8730e_boot.c
+++ b/os/board/rtl8730e/src/rtl8730e_boot.c
@@ -178,7 +178,7 @@ void board_i2c_initialize(void)
 #ifdef CONFIG_AMEBASMART_I2C0
 	bus = 0;
 	snprintf(path, sizeof(path), "/dev/i2c-%d", bus);
-	i2c = up_i2cinitialize(bus);
+	i2c = (struct i2c_dev_s *)up_i2cinitialize(bus);
 #ifdef CONFIG_I2C_USERIO
 	if (i2c != NULL) {
 		ret = i2c_uioregister(path, i2c);

--- a/os/board/rtl8730e/src/rtl8730e_ndp120.c
+++ b/os/board/rtl8730e/src/rtl8730e_ndp120.c
@@ -142,7 +142,7 @@ int rtl8730e_ndp120_initialize(int minor)
 	FAR struct audio_lowerhalf_s *ndp120;
 	static bool initialized = false;
 	char devname[12];
-	int ret;
+	int ret = OK;
 	gpio_t gpio_dmic_en;
 
 	audvdbg("minor %d\n", minor);
@@ -176,7 +176,7 @@ int rtl8730e_ndp120_initialize(int minor)
 		SPI_SETFREQUENCY(spi, NDP120_SPI_FREQ);
 		SPI_SETBITS(spi, NDP120_SPI_BPW);
 		
-		ndp120 = ndp120_lowerhalf_initialize(spi, &g_ndp120info.lower);
+		ndp120 = (struct audio_lowerhalf_s *)ndp120_lowerhalf_initialize(spi, &g_ndp120info.lower);
 		if (ndp120 == NULL) {
 			return ERROR;
 		}

--- a/os/drivers/audio/syu645bscripts.h
+++ b/os/drivers/audio/syu645bscripts.h
@@ -33,7 +33,7 @@ typedef enum reg_data_type{
 	SYU645B_REG_D_3BYTE = 3,
 	SYU645B_REG_D_5BYTE = 5,
 	SYU645B_REG_DATA_TYPE_MAX
-};
+} reg_data_type;
 
 /* TYPEDEFS */
 typedef struct {

--- a/os/kernel/binary_manager/binary_manager_verify.c
+++ b/os/kernel/binary_manager/binary_manager_verify.c
@@ -105,11 +105,11 @@ int binary_manager_read_header(int type, char *devpath, void *header_data, bool 
 	int fd;
 	int ret;
 	uint32_t read_size;
-	uint32_t bin_size;
+	uint32_t bin_size = 0;
 	uint32_t calculate_crc = 0;
 	uint8_t *crc_buffer;
 	uint32_t crc_hash;
-	uint32_t crc_bufsize;
+	uint32_t crc_bufsize = 0;
 	int header_size = 0;
 
 	if (type < BINARY_KERNEL || type >= BINARY_TYPE_MAX || !header_data) {

--- a/os/pm/pm_timedsuspend.c
+++ b/os/pm/pm_timedsuspend.c
@@ -124,7 +124,7 @@ int pm_timedsuspend(int domain_id, unsigned int milliseconds)
 	/* If delay is zero then cancel the timer (PM Policy) */
 	if (delay == 0) {
 		if (wdog) {
-			timer_timeout(NULL, domain_id);
+			timer_timeout(0, domain_id);
 		}
 		ret = OK;
 		goto exit;
@@ -156,7 +156,7 @@ int pm_timedsuspend(int domain_id, unsigned int milliseconds)
 	if (wd_start(wdog, delay, (wdentry_t)timer_timeout, 1, domain_id) != OK) {
 		pmdbg("Error starting Wdog timer\n");
 		set_errno(EAGAIN);
-		timer_timeout(NULL, domain_id);
+		timer_timeout(0, domain_id);
 		goto exit;
 	}
 	pmvdbg("Domain: %s is suspended for %d milliseconds\n", pm_domain_map[domain_id], milliseconds);


### PR DESCRIPTION
		libxipelf/xipelf.c:103:27: warning: assignment to 'uint32_t' {aka 'unsigned int'} from 'void *' makes integer from pointer without a cast [-Wint-conversion]
 		libxipelf/xipelf.c:104:27: warning: assignment to 'uint32_t' {aka 'unsigned int'} from 'void *' makes integer from pointer without a cast [-Wint-conversion]
 		libxipelf/xipelf.c:105:25: warning: assignment to 'uint32_t' {aka 'unsigned int'} from 'void *' makes integer from pointer without a cast [-Wint-conversion]
 		libxipelf/xipelf.c:106:25: warning: assignment to 'uint32_t' {aka 'unsigned int'} from 'void *' makes integer from pointer without a cast [-Wint-conversion]
		libxipelf/xipelf.c:107:23: warning: assignment to 'uint32_t' {aka 'unsigned int'} from 'void *' makes integer from pointer without a cast [-Wint-conversion]
		/root/tizenrt/os/board/common/partitions.c:285:7: warning: unused variable 'fs_devname' [-Wunused-variable]
		/root/tizenrt/os/board/common/partitions.c:284:6: warning: unused variable 'ret' [-Wunused-variable]
		rtl8730e_boot.c:181:6: warning: assignment to 'struct i2c_dev_s *' from 'int' makes pointer from integer without a cast [-Wint-conversion]
		rtl8730e_ndp120.c:179:10: warning: assignment to 'struct audio_lowerhalf_s *' from 'int' makes pointer from integer without a cast [-Wint-conversion]
		rtl8730e_ndp120.c:145:6: warning: 'ret' may be used uninitialized in this function [-Wmaybe-uninitialized]
		audio/syu645bscripts.h:36:1: warning: useless storage class specifier in empty declaration
		binary_manager/binary_manager_verify.c:184:15: warning: 'crc_bufsize' may be used uninitialized in this function [-Wmaybe-uninitialized]
		log_dump/log_dump.c:231:52: warning: passing argument 2 of 'compress_block' from incompatible pointer type [-Wincompatible-pointer-types]
		pm_timedsuspend.c:127:18: warning: passing argument 1 of 'timer_timeout' makes integer from pointer without a cast [-Wint-conversion]
		pm_timedsuspend.c:159:17: warning: passing argument 1 of 'timer_timeout' makes integer from pointer without a cast [-Wint-conversion]