### PR TITLE
os/board/rtl8730e: Fix module sleep while UART buffer Tx buffer not empty

### DIFF
--- a/os/board/rtl8730e/src/component/mbed/targets/hal/rtl8730e/serial_api.c
+++ b/os/board/rtl8730e/src/component/mbed/targets/hal/rtl8730e/serial_api.c
@@ -566,11 +566,10 @@ void serial_change_clcksrc(serial_t *obj, int baudrate, bool high_low)
 {
 	PMBED_UART_ADAPTER puart_adapter = &(uart_adapter[obj->uart_idx]);
 
-	if (high_low) {
-		RCC_PeriphClockSource_UART(puart_adapter->UARTx, UART_RX_CLK_XTAL_40M);
-		UART_SetBaud(puart_adapter->UARTx, baudrate);
-	}
-	else {
+	if ((high_low) && (baudrate > 115200)) {
+			RCC_PeriphClockSource_UART(puart_adapter->UARTx, UART_RX_CLK_XTAL_40M);
+			UART_SetBaud(puart_adapter->UARTx, baudrate);
+	} else {
 		RCC_PeriphClockSource_UART(puart_adapter->UARTx, UART_RX_CLK_OSC_LP);
 		UART_LPRxBaudSet(puart_adapter->UARTx, baudrate, 2000000);
 	}


### PR DESCRIPTION
- Do not suspend and resume UART domain in IRQ, it only check FIFO not Tx buffer
- Suspend UART domain PM sleep while Tx init is set
- Correct the clock set when wake up