### PR TITLE
fs/driver/mtd/mtd_jedec: Add missing jedec_lock

### DIFF
--- a/os/fs/driver/mtd/mtd_jedec.c
+++ b/os/fs/driver/mtd/mtd_jedec.c
@@ -355,6 +355,8 @@ static void jedec_unprotect(FAR struct jedec_dev_s *priv)
 
 static void jedec_set_4byte_addr_mode(FAR struct jedec_dev_s *priv)
 {
+	jedec_lock(priv->dev);
+
 	/* Select this FLASH part */
 
 	SPI_SELECT(priv->dev, SPIDEV_FLASH, true);
@@ -366,6 +368,8 @@ static void jedec_set_4byte_addr_mode(FAR struct jedec_dev_s *priv)
 	/* Deselect the FLASH */
 
 	SPI_SELECT(priv->dev, SPIDEV_FLASH, false);
+
+	jedec_unlock(priv->dev);
 }
 
 
@@ -929,6 +933,8 @@ static ssize_t jedec_write(FAR struct mtd_dev_s *dev, off_t offset, size_t nbyte
 
 	fvdbg("offset: %08lx nbytes: %d\n", (long)offset, (int)nbytes);
 
+	jedec_lock(priv->dev);
+
 	/* We must test if the offset + count crosses one or more pages
 	 * and perform individual writes.  The devices can only write in
 	 * page increments.
@@ -973,6 +979,8 @@ static ssize_t jedec_write(FAR struct mtd_dev_s *dev, off_t offset, size_t nbyte
 			jedec_bytewrite(priv, &buffer[index], offset, count);
 		}
 	}
+
+	jedec_unlock(priv->dev);
 
 	return nbytes;
 }


### PR DESCRIPTION
In the function "jedec_waitwritecomplete", it is assumed that "jedec_lock" has already been called, and it unlocks and locks again. However, the function "jedec_bytewrite" (which is called by "jedec_write") does not call "jedec_lock" first.

The jedec_lock contains a spi_lock, which prevents simultaneous access to spi. So, when the jedec_lock is used out of pairs, it simultaneously accesses the spi and causes a spi malfunction resulting in a device hang.

Therefore, To ensure atomic operation of the spi, Add a missing jedec_lock.