### PR TITLE
apps/shell/tash_command: fix tash_help character breakage issue.

### DIFF
--- a/apps/shell/tash_command.c
+++ b/apps/shell/tash_command.c
@@ -718,8 +718,9 @@ int tash_cmd_install(const char *str, TASH_CMD_CALLBACK cb, int thread_exec)
 		return -1; /* Memory Allocation Fail for new command */
 	}
 
-	/* store command string - no need of explicit NULL termination */
+	/* store command string */
 	strncpy(tash_cmds_info.cmd[tash_cmds_info.count].str, str, TASH_CMD_MAXSTRLENGTH - 1);
+	tash_cmds_info.cmd[tash_cmds_info.count].str[TASH_CMD_MAXSTRLENGTH - 1] = '\0';
 	/* store callback */
 	tash_cmds_info.cmd[tash_cmds_info.count].cb = cb;
 	/* store thread_exec flags */


### PR DESCRIPTION
If a string longer than 15 characters is registered as a tash command like 'testtest_testsetup', there is an issue where the end of the string gets corrupted when the 'help' command is executed, resulting in output like 'testtest_testse.Y9'.

Since tash only copies the first 15 characters when registering a command, the last character in the buffer is being printed out as garbage.

To fix this, Add a null character '\0' at the 16th position so that even if a command with more than 15 characters is registered, the output value won't get corrupted.