### PR TITLE
framework/ble_manager: Deinitialize global scan context before call state change callback function

### DIFF
--- a/framework/src/ble_manager/ble_manager_state.c
+++ b/framework/src/ble_manager/ble_manager_state.c
@@ -151,11 +151,11 @@ static void _event_caller(int evt_pri, void *data) {
 		case BLE_EVT_SCAN_STATE: {
 			ble_scan_state_e state = *(ble_scan_state_e *)msg->param[2];
 			ble_client_scan_state_changed_cb callback = msg->param[0];
-			callback(state);
 			if (state == BLE_SCAN_STOPPED) {
 				memset(&(g_scan_ctx.filter), 0, sizeof(ble_scan_filter));
 				memset(&(g_scan_ctx.callback), 0, sizeof(ble_scan_callback_list));
 			}
+			callback(state);
 		} break;
 		default:
 			break;


### PR DESCRIPTION
After calling the callback function and setting the value of the global context to 0, a problem occurred when the ble scan started inside the callback function resulting in deinitialization. Therefore, I changed it so that the global context deinit is performed first and then the callback function is called.