### PR TITLE
Fix issue with audio tank init for NDP120, increase mic gain when using external clock

### DIFF
--- a/os/drivers/ai-soc/ndp120/src/ndp120_api.c
+++ b/os/drivers/ai-soc/ndp120/src/ndp120_api.c
@@ -956,7 +956,7 @@ int ndp120_init(struct ndp120_dev_s *dev)
 
 	/*const unsigned int DMIC_768KHZ_PDM_IN_SHIFT = 13;*/  /* currently unused */
 	const unsigned int DMIC_768KHZ_PDM_IN_SHIFT_FF = 8;
-	const unsigned int DMIC_1536KHZ_PDM_IN_SHIFT_FF = 3;
+	const unsigned int DMIC_1536KHZ_PDM_IN_SHIFT_FF = 6;
 
 	/* save handle so we can use it from debug routine later, e.g. from other util/shell */
 	_ndp_debug_handle = dev;


### PR DESCRIPTION
Tested by adding a delay of 300ms, keyword data is present in the recordings.

```
ndp120_irq_handler_work: #################### winner : 0 summary : 61504 network_id : 0
[2024-09-27 12:05:41.311] ndp120_irq_handler_work: [#1 Hi-Bixby] matched: NN0:hi-bixby
[2024-09-27 12:05:41.314] #### onSpeechDetectionListener
[2024-09-27 12:05:41.328] Event SPEECH_DETECT_KD
[2024-09-27 12:05:41.328] #### [SD] keyword detected.
[2024-09-27 12:05:41.328] #### [MR] create succeeded.
[2024-09-27 12:05:41.632] #### [MR] setDataSource succeeded.
[2024-09-27 12:05:41.632] #### [MR] setObserver succeeded.
[2024-09-27 12:05:41.632] #### [MR] prepare succeeded.
[2024-09-27 12:05:41.632] startRecorder: set Current Recorder!!
[2024-09-27 12:05:41.635] ndp120_start_sample_ready: entry
[2024-09-27 12:05:41.648] ##################################
[2024-09-27 12:05:41.648] ####     onRecordStarted      ####
[2024-09-27 12:05:41.648] ##################################

```