### PR TITLE
os/arch/arm: Remove Unused API

### DIFF
--- a/os/arch/arm/src/armv7-a/arm_cpugating.c
+++ b/os/arch/arm/src/armv7-a/arm_cpugating.c
@@ -42,6 +42,10 @@
 #ifdef CONFIG_CPU_GATING
 static volatile uint32_t g_cpugating_flag[CONFIG_SMP_NCPUS];
 
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
 void up_set_gating_flag_status(uint32_t CoreID, uint32_t val)
 {
 	g_cpugating_flag[CoreID] = val;
@@ -56,37 +60,9 @@ uint32_t up_get_gating_flag_status(uint32_t CoreID)
 {
 	return g_cpugating_flag[CoreID];
 }
+
 /****************************************************************************
  * Name: arm_gating_handler
-=======
- * Private Functions
- ****************************************************************************/
-#define portCPU_IRQ_DISABLE()										\
-	__asm volatile ( "CPSID i" ::: "memory" );						\
-	__asm volatile ( "DSB" );										\
-	__asm volatile ( "ISB" );
-/****************************************************************************
- * Public Functions
- ****************************************************************************/
-uint32_t ulPortInterruptLock(void)
-{
-	uint32_t key;
-
-	__asm volatile("mrs	%0, cpsr	\n":"=r"(key)::"memory");
-	portCPU_IRQ_DISABLE();
-
-	return key;
-}
-
-/*-----------------------------------------------------------*/
-
-void ulPortInterruptUnLock(uint32_t key)
-{
-	__asm volatile("msr	cpsr_c, %0	\n"::"r"(key):"memory");
-}
-
-/****************************************************************************
- * Name: arm_flash_handler
  *
  * Description:
  *   This is the handler for SGI3.  This handler simply send the another core


### PR DESCRIPTION
Change Notes:
- Removed the API that was used for FreeRTOS.
- This mistake originated from the previous PR#6224, which unintentionally resulted API being added back.