### PR TITLE
[DO NOT MERGE] apps/system/i2c : i2c test tool return value fixed

### DIFF
--- a/apps/system/i2c/i2c_dev.c
+++ b/apps/system/i2c/i2c_dev.c
@@ -207,14 +207,14 @@ int i2ccmd_dev(FAR struct i2ctool_s *i2ctool, int argc, char **argv)
 
 			if (i2ctool->start) {
 				ret = I2C_TRANSFER(dev, &msg[0], 1);
-				if (ret == OK) {
+				if (ret > 0) {
 					ret = I2C_TRANSFER(dev, &msg[1], 1);
 				}
 			} else {
 				ret = I2C_TRANSFER(dev, msg, 2);
 			}
 
-			if (ret == OK) {
+			if (ret > 0) {
 				i2ctool_printf(i2ctool, "%02x ", addr);
 			} else {
 				i2ctool_printf(i2ctool, "-- ");

--- a/apps/system/i2c/i2c_get.c
+++ b/apps/system/i2c/i2c_get.c
@@ -171,7 +171,7 @@ int i2ccmd_get(FAR struct i2ctool_s *i2ctool, int argc, FAR char **argv)
 
 		/* Display the result */
 
-		if (ret == OK) {
+		if (ret > 0) {
 			i2ctool_printf(i2ctool, "READ Bus: %d Addr: %02x Subaddr: %02x Value: ", i2ctool->bus, i2ctool->addr, regaddr);
 
 			if (i2ctool->width == 8) {
@@ -228,7 +228,7 @@ int i2ctool_get(FAR struct i2ctool_s *i2ctool, FAR struct i2c_dev_s *dev, uint8_
 
 	if (i2ctool->start) {
 		ret = I2C_TRANSFER(dev, &msg[0], 1);
-		if (ret == OK) {
+		if (ret > 0) {
 			ret = I2C_TRANSFER(dev, &msg[1], 1);
 		}
 	} else {
@@ -237,7 +237,7 @@ int i2ctool_get(FAR struct i2ctool_s *i2ctool, FAR struct i2c_dev_s *dev, uint8_
 
 	/* Return the result of the read operation */
 
-	if (ret == OK) {
+	if (ret > 0) {
 		if (i2ctool->width == 8) {
 			*result = (uint16_t)u.data8;
 		} else {

--- a/apps/system/i2c/i2c_set.c
+++ b/apps/system/i2c/i2c_set.c
@@ -192,7 +192,7 @@ int i2ccmd_set(FAR struct i2ctool_s *i2ctool, int argc, FAR char **argv)
 
 		/* Display the result */
 
-		if (ret == OK) {
+		if (ret > 0) {
 			i2ctool_printf(i2ctool, "WROTE Bus: %d Addr: %02x Subaddr: %02x Value: ", i2ctool->bus, i2ctool->addr, i2ctool->regaddr);
 			if (i2ctool->width == 8) {
 				i2ctool_printf(i2ctool, "%02x\n", (int)value);
@@ -249,7 +249,7 @@ int i2ctool_set(FAR struct i2ctool_s *i2ctool, FAR struct i2c_dev_s *dev, uint8_
 
 	if (i2ctool->start) {
 		ret = I2C_TRANSFER(dev, &msg[0], 1);
-		if (ret == OK) {
+		if (ret > 0) {
 			ret = I2C_TRANSFER(dev, &msg[1], 1);
 		}
 	} else {

--- a/apps/system/i2c/i2c_verf.c
+++ b/apps/system/i2c/i2c_verf.c
@@ -201,7 +201,7 @@ int i2ccmd_verf(FAR struct i2ctool_s *i2ctool, int argc, FAR char **argv)
 		/* Write to the I2C bus */
 
 		ret = i2ctool_set(i2ctool, dev, regaddr, (uint16_t)wrvalue);
-		if (ret == OK) {
+		if (ret > 0) {
 			/* Read the value back from the I2C bus */
 
 			ret = i2ctool_get(i2ctool, dev, regaddr, &rdvalue);
@@ -209,7 +209,7 @@ int i2ccmd_verf(FAR struct i2ctool_s *i2ctool, int argc, FAR char **argv)
 
 		/* Display the result */
 
-		if (ret == OK) {
+		if (ret > 0) {
 			i2ctool_printf(i2ctool, "VERIFY Bus: %d Addr: %02x Subaddr: %02x Wrote: ", i2ctool->bus, i2ctool->addr, i2ctool->regaddr);
 
 			if (i2ctool->width == 8) {


### PR DESCRIPTION
[TEMP FIX]
To run i2c test tool, i2c transfer returns length of data, so modified check condition
Usage example - 
1. i2c help - to get supported list of commands

For i2c write and read . Device addr 0x50, bus 1, reg addr 0x23, data width 8 bit, frequency 100000 and value 0x00
TASH>>i2c set -a 0x50 -b 1 -r 0x23 -w 8 -f 100000 0x00
TASH>>WROTE Bus: 1 Addr: 50 Subaddr: 23 Value: 00
TASH>>i2c get
TASH>>READ Bus: 1 Addr: 50 Subaddr: 00 Value: 7d

