### PR TITLE
os/arch/arm: Revise and CleanUp Config File

### DIFF
--- a/apps/examples/board_specific_demo/ameba_mipi_demo/Kconfig
+++ b/apps/examples/board_specific_demo/ameba_mipi_demo/Kconfig
@@ -6,7 +6,7 @@
 config EXAMPLES_AMEBA_MIPI
 	bool "AMEBA_MIPI example"
 	default n
-	select AMEBASMART_MIPI
+	depends on AMEBASMART_MIPI
 	---help---
 		Enable AMEBA_MIPI Example
 

--- a/os/arch/arm/src/amebasmart/Kconfig
+++ b/os/arch/arm/src/amebasmart/Kconfig
@@ -111,11 +111,6 @@ config AMEBASMART_SPI1_CS
 endif
 endif
 
-
-config AMEBASMART_MIPI
-	bool "AMEBASMART_MIPI"
-	default n
-	
 config AMEBASMART_I2C
 	bool "AMEBASMART_I2C"
 	default n

--- a/os/arch/arm/src/amebasmart/amebasmart_usb.c
+++ b/os/arch/arm/src/amebasmart/amebasmart_usb.c
@@ -88,7 +88,7 @@ static int received_flag = 0;
  ****************************************************************************/
 
 /* The various states of a control pipe */
-/* zhenbei: refer to the usbd_core.h */
+/* Refer to the usbd_core.h */
 /*  EP0 State */
 #define USBD_EP0_IDLE                                  0x00U    /* No request in progress */
 #define USBD_EP0_SETUP                                 0x01U    /* Setup packet received, preparing for OUT transfer */


### PR DESCRIPTION
Change Notes:
1. Change the select to depends on for the MIPI example. (ameba_mipi_demo/Kconfig)
- EXAMPLES_AMEBA_MIPI should be available only when AMEBASMART_MIPI is enabled, so using "depends on" is more suitable.
2. Remove the duplicate define AMEBASMART_MIPI. (amebasmart/Kconfig)
3. CleanUp the comment message. (amebasmart_usb.c)