### PR TITLE
framework/ble_manager: Rename api for setting gap_device_name

### DIFF
--- a/framework/include/ble_manager/ble_common.h
+++ b/framework/include/ble_manager/ble_common.h
@@ -34,6 +34,7 @@
 /* Length defines */
 #define BLE_BD_ADDR_MAX_LEN 6
 #define BLE_BD_ADDR_STR_LEN 17
+#define BLE_GAP_DEVICE_NAME_LEN (39+1)/*!< Max length of device name, if device name length exceeds it, it will be truncated. */
 #define BLE_ADV_RAW_DATA_MAX_LEN 31
 #define BLE_ADV_RESP_DATA_MAX_LEN 31
 

--- a/framework/include/ble_manager/ble_manager.h
+++ b/framework/include/ble_manager/ble_manager.h
@@ -176,3 +176,4 @@ ble_result_e ble_manager_get_version(uint8_t version[3]);
  ****************************************************************************/
 ble_result_e ble_manager_conn_param_update(ble_conn_handle *con_handle, ble_conn_param *conn_param);
 
+ble_result_e ble_manager_set_gap_device_name(char name[BLE_GAP_DEVICE_NAME_LEN]);

--- a/framework/src/ble_manager/ble_manager_api.c
+++ b/framework/src/ble_manager/ble_manager_api.c
@@ -490,7 +490,7 @@ ble_result_e ble_manager_server_stop_adv(void)
 	RETURN_RESULT(res, msg);
 }
 
-ble_result_e ble_manager_server_set_device_name(char* name)
+ble_result_e ble_manager_set_gap_device_name(char name[BLE_GAP_DEVICE_NAME_LEN])
 {
 	blemgr_msg_s msg = {BLE_CMD_SET_DEVICE_NAME, BLE_MANAGER_FAIL, (void *)name, NULL};
 	int res = blemgr_post_message(&msg);


### PR DESCRIPTION
- Since the `gap device name` is not used only in ble server, I modified it to define an API in ble_manager.h.
- Additionally, I defined the length of the `gap device name`, which is being used identically on each board, so that a string with corresponding length can be inputted.