### PR TITLE
kernel/binary_manager: Skip crc checking of resource binary when booting

### DIFF
--- a/os/kernel/binary_manager/binary_manager_resource.c
+++ b/os/kernel/binary_manager/binary_manager_resource.c
@@ -155,7 +155,7 @@ int binary_manager_mount_resource(void)
 	do {
 		/* Read header data and Check crc */
 		snprintf(devpath, BINARY_PATH_LEN, BINMGR_DEVNAME_FMT, resource_info.part_info[inuse_idx].devnum);
-		ret = binary_manager_read_header(BINARY_RESOURCE, devpath, &resource_header_data, true);
+		ret = binary_manager_read_header(BINARY_RESOURCE, devpath, &resource_header_data, false);
 		if (ret == BINMGR_OK) {
 			bmvdbg("Resource Header Checking Success\n");
 			snprintf(fs_devpath, BINARY_PATH_LEN, BINMGR_DEVNAME_FMT, resource_info.part_info[inuse_idx].devnum + RESOURCE_DEVNUM_OFFSET);


### PR DESCRIPTION
It takes too long to check CRC of large resource binary file. So binary manager skips crc checking resource binary when booting because it affects booting time.