### PR TITLE
Revert "framework/ble_manager: Add prefix 'ble_manager' to the function name"

### DIFF
--- a/apps/examples/ble_perfs/ble_perfs_main.c
+++ b/apps/examples/ble_perfs/ble_perfs_main.c
@@ -70,24 +70,24 @@ static uint8_t g_adv_resp[] = {
 
 
 static char * attr_cb_type_str[] = {
-	"BLE_MANAGER_SERVER_ATTR_CB_WRITING",
-	"BLE_MANAGER_SERVER_ATTR_CB_READING",
-	"BLE_MANAGER_SERVER_ATTR_CB_WRITING_NO_RSP",
+	"BLE_SERVER_ATTR_CB_WRITING",
+	"BLE_SERVER_ATTR_CB_READING",
+	"BLE_SERVER_ATTR_CB_WRITING_NO_RSP",
 };
 
 static char * connection_type_str[] = {
-	"BLE_MANAGER_SERVER_LL_CONNECTED",  /* Link Layer connected */
-	"BLE_MANAGER_SERVER_SM_CONNECTED",  /* Security Manager connected */
-	"BLE_MANAGER_SERVER_DISCONNECTED",
+	"BLE_SERVER_LL_CONNECTED",  /* Link Layer connected */
+	"BLE_SERVER_SM_CONNECTED",  /* Security Manager connected */
+	"BLE_SERVER_DISCONNECTED",
 };
 
-static char * get_attr_cb_type_str(ble_manager_server_attr_cb_type_e cb_type)
+static char * get_attr_cb_type_str(ble_server_attr_cb_type_e cb_type)
 {
 	return  attr_cb_type_str[cb_type];
 };
 
 
-static char * get_conn_type_str(ble_manager_server_connection_type_e conn_type)
+static char * get_conn_type_str(ble_server_connection_type_e conn_type)
 {
 	return connection_type_str[conn_type];
 }
@@ -120,7 +120,7 @@ static void addr_type_to_string(char *address, const uint8_t *addr)
 }
 
 
-static void utc_cb_charact_a_1(ble_manager_server_attr_cb_type_e type, ble_conn_handle conn_handle, ble_attr_handle attr_handle, void *arg)
+static void utc_cb_charact_a_1(ble_server_attr_cb_type_e type, ble_conn_handle conn_handle, ble_attr_handle attr_handle, void *arg)
 {
 	char *arg_str = "None";
 
@@ -131,7 +131,7 @@ static void utc_cb_charact_a_1(ble_manager_server_attr_cb_type_e type, ble_conn_
 	BLE_LOGD("[CHAR_A_1][%s] type : %d / handle : %d / attr : %02x \n", arg_str, type, conn_handle, attr_handle);
 }
 
-static void utc_cb_desc_b_1(ble_manager_server_attr_cb_type_e type, ble_conn_handle conn_handle, ble_attr_handle attr_handle, void *arg)
+static void utc_cb_desc_b_1(ble_server_attr_cb_type_e type, ble_conn_handle conn_handle, ble_attr_handle attr_handle, void *arg)
 {
 	char *arg_str = "None";
 	if (arg != NULL) {
@@ -185,13 +185,13 @@ static int perfs_ble_get_result(void)
 	return 0;
 }
 
-static void ble_peri_cb_charact_rmc_sync(ble_manager_server_attr_cb_type_e type, ble_conn_handle conn_handle, ble_attr_handle attr_handle, void* arg) 
+static void ble_peri_cb_charact_rmc_sync(ble_server_attr_cb_type_e type, ble_conn_handle conn_handle, ble_attr_handle attr_handle, void* arg) 
 {
 	uint8_t buf[256] = { 0, };
 	ble_data blue_data = { buf, sizeof(buf) };
 	struct perfs_data_t *p_data = (struct perfs_data_t *)arg;
 
-	ble_result_e ret = ble_manager_server_attr_get_data(attr_handle, &blue_data);
+	ble_result_e ret = ble_server_attr_get_data(attr_handle, &blue_data);
 	if (ret != BLE_MANAGER_SUCCESS) {
 		BLE_LOGD( "[RMC_SYNC] Fail to get attr data\n");
 		return;
@@ -206,7 +206,7 @@ static void ble_peri_cb_charact_rmc_sync(ble_manager_server_attr_cb_type_e type,
 
 	p_data->packet_count ++;
 
-	if (type == BLE_MANAGER_SERVER_ATTR_CB_WRITING_NO_RSP || type == BLE_MANAGER_SERVER_ATTR_CB_WRITING) {
+	if (type == BLE_SERVER_ATTR_CB_WRITING_NO_RSP || type == BLE_SERVER_ATTR_CB_WRITING) {
 		if (blue_data.data[0] == blue_data.data[p_data->packet_size - 1]) {
 			BLE_LOGD( "[WRITE] Success [%d] : %d \n" , blue_data.length, p_data->packet_count);
 		} else {
@@ -228,39 +228,39 @@ static void ble_peri_cb_charact_rmc_sync(ble_manager_server_attr_cb_type_e type,
 	}
 }
 
-static ble_manager_server_gatt_t gatt_profile[] = {
-	{.type = BLE_MANAGER_SERVER_GATT_SERVICE, .uuid = {0x12, 0xB6, 0x6E, 0x45, 0xA7, 0x68, 0x9D, 0x8D, 0x9A, 0x40, 0x17, 0x2B, 0xE9, 0xCB, 0xF2, 0x13}, .uuid_length = 16,
+static ble_server_gatt_t gatt_profile[] = {
+	{.type = BLE_SERVER_GATT_SERVICE, .uuid = {0x12, 0xB6, 0x6E, 0x45, 0xA7, 0x68, 0x9D, 0x8D, 0x9A, 0x40, 0x17, 0x2B, 0xE9, 0xCB, 0xF2, 0x13}, .uuid_length = 16,
 		.attr_handle = BLE_APP_HANDLE_SERVICE_0,},
 
-	{.type = BLE_MANAGER_SERVER_GATT_CHARACT, .uuid = {0x99, 0xC7, 0xAA, 0xE7, 0xF8, 0x9A, 0xCB, 0x88, 0x43, 0x4C, 0x44, 0xCF, 0x0D, 0x5B, 0xDA, 0xF2}, .uuid_length = 16,
-		.property =  BLE_MANAGER_ATTR_PROP_RWN|BLE_MANAGER_ATTR_PROP_WRITE_NO_RSP, .permission = BLE_MANAGER_ATTR_PERM_R_PERMIT|BLE_MANAGER_ATTR_PERM_W_PERMIT,
+	{.type = BLE_SERVER_GATT_CHARACT, .uuid = {0x99, 0xC7, 0xAA, 0xE7, 0xF8, 0x9A, 0xCB, 0x88, 0x43, 0x4C, 0x44, 0xCF, 0x0D, 0x5B, 0xDA, 0xF2}, .uuid_length = 16,
+		.property =  BLE_ATTR_PROP_RWN|BLE_ATTR_PROP_WRITE_NO_RSP, .permission = BLE_ATTR_PERM_R_PERMIT|BLE_ATTR_PERM_W_PERMIT,
 		.attr_handle = BLE_STATE_MANAGER_RMC_HANDLE_KEY_COMMAND, .cb = utc_cb_charact_a_1, .arg = "char_1"},
 
-	{.type = BLE_MANAGER_SERVER_GATT_DESC, .uuid = {0x02, 0x29}, .uuid_length = 2,
-		.permission = BLE_MANAGER_ATTR_PERM_R_PERMIT|BLE_MANAGER_ATTR_PERM_W_PERMIT,
+	{.type = BLE_SERVER_GATT_DESC, .uuid = {0x02, 0x29}, .uuid_length = 2,
+		.permission = BLE_ATTR_PERM_R_PERMIT|BLE_ATTR_PERM_W_PERMIT,
 		.attr_handle = BLE_STATE_MANAGER_RMC_HANDLE_KEY_CCCD, .cb = utc_cb_desc_b_1, .arg = "desc_1"},
 
-	{.type = BLE_MANAGER_SERVER_GATT_SERVICE, .uuid = {0xAD, 0xB6, 0x6E, 0x45, 0xA7, 0x68, 0x9D, 0x8D, 0x9A, 0x40, 0x17, 0x2B, 0xE9, 0xCB, 0xF2, 0x13}, .uuid_length = 16,
+	{.type = BLE_SERVER_GATT_SERVICE, .uuid = {0xAD, 0xB6, 0x6E, 0x45, 0xA7, 0x68, 0x9D, 0x8D, 0x9A, 0x40, 0x17, 0x2B, 0xE9, 0xCB, 0xF2, 0x13}, .uuid_length = 16,
 		.attr_handle = BLE_APP_HANDLE_SERVICE_1,},
 
-	{.type = BLE_MANAGER_SERVER_GATT_CHARACT, .uuid = {0x04, 0xC7, 0xAA, 0xE7, 0xF8, 0x9A, 0xCB, 0x88, 0x43, 0x4C, 0x44, 0xCF, 0x0D, 0x5B, 0xDA, 0xF2}, .uuid_length = 16,
-		.property =  BLE_MANAGER_ATTR_PROP_RWN|BLE_MANAGER_ATTR_PROP_WRITE_NO_RSP, .permission = BLE_MANAGER_ATTR_PERM_R_PERMIT|BLE_MANAGER_ATTR_PERM_W_PERMIT,
+	{.type = BLE_SERVER_GATT_CHARACT, .uuid = {0x04, 0xC7, 0xAA, 0xE7, 0xF8, 0x9A, 0xCB, 0x88, 0x43, 0x4C, 0x44, 0xCF, 0x0D, 0x5B, 0xDA, 0xF2}, .uuid_length = 16,
+		.property =  BLE_ATTR_PROP_RWN|BLE_ATTR_PROP_WRITE_NO_RSP, .permission = BLE_ATTR_PERM_R_PERMIT|BLE_ATTR_PERM_W_PERMIT,
 		.attr_handle = BLE_APP_HANDLE_CHAR_RMC_KEY, .cb = utc_cb_charact_a_1, .arg = "char_2"},
 
-	{.type = BLE_MANAGER_SERVER_GATT_DESC, .uuid = {0x02, 0x29}, .uuid_length = 2,
-		.permission = BLE_MANAGER_ATTR_PERM_R_PERMIT|BLE_MANAGER_ATTR_PERM_W_PERMIT,
+	{.type = BLE_SERVER_GATT_DESC, .uuid = {0x02, 0x29}, .uuid_length = 2,
+		.permission = BLE_ATTR_PERM_R_PERMIT|BLE_ATTR_PERM_W_PERMIT,
 		.attr_handle = BLE_APP_HANDLE_DESC_RMC_KEY, .cb = utc_cb_desc_b_1, .arg = "desc_2"},
 
 
-	{.type = BLE_MANAGER_SERVER_GATT_SERVICE, .uuid = {0xF4, 0x7A, 0x07, 0x08, 0xFD, 0xC7, 0x9D, 0xB5, 0xFF, 0x4E, 0x85, 0xDE, 0x48, 0x80, 0xFE, 0xA2}, .uuid_length = 16,
+	{.type = BLE_SERVER_GATT_SERVICE, .uuid = {0xF4, 0x7A, 0x07, 0x08, 0xFD, 0xC7, 0x9D, 0xB5, 0xFF, 0x4E, 0x85, 0xDE, 0x48, 0x80, 0xFE, 0xA2}, .uuid_length = 16,
 		.attr_handle = BLE_APP_HANDLE_SERVICE_2,},
 
-	{.type = BLE_MANAGER_SERVER_GATT_CHARACT, .uuid = {0x06, 0xC7, 0xAA, 0xE7, 0xF8, 0x9A, 0xCB, 0x88, 0x43, 0x4C, 0x44, 0xCF, 0x0D, 0x5B, 0xDA, 0xBB}, .uuid_length = 16,
-		.property =  BLE_MANAGER_ATTR_PROP_RWN|BLE_MANAGER_ATTR_PROP_WRITE_NO_RSP, .permission = BLE_MANAGER_ATTR_PERM_R_PERMIT|BLE_MANAGER_ATTR_PERM_W_PERMIT,
+	{.type = BLE_SERVER_GATT_CHARACT, .uuid = {0x06, 0xC7, 0xAA, 0xE7, 0xF8, 0x9A, 0xCB, 0x88, 0x43, 0x4C, 0x44, 0xCF, 0x0D, 0x5B, 0xDA, 0xBB}, .uuid_length = 16,
+		.property =  BLE_ATTR_PROP_RWN|BLE_ATTR_PROP_WRITE_NO_RSP, .permission = BLE_ATTR_PERM_R_PERMIT|BLE_ATTR_PERM_W_PERMIT,
 		.attr_handle = BLE_APP_HANDLE_CHAR_RMC_SYNC, .cb = ble_peri_cb_charact_rmc_sync, .arg = &g_perf_data},
 };
 
-static void ble_server_connected_cb(ble_conn_handle con_handle, ble_manager_server_connection_type_e conn_type, uint8_t mac[BLE_BD_ADDR_MAX_LEN])
+static void ble_server_connected_cb(ble_conn_handle con_handle, ble_server_connection_type_e conn_type, uint8_t mac[BLE_BD_ADDR_MAX_LEN])
 {
 	char address_str[BLE_BD_ADDR_STR_LEN + 1] = {0,};
 
@@ -269,17 +269,17 @@ static void ble_server_connected_cb(ble_conn_handle con_handle, ble_manager_serv
 	addr_type_to_string(address_str, mac);
 	BLE_LOGD( "device address [%s] \n", address_str);
 
-	if (conn_type == BLE_MANAGER_SERVER_DISCONNECTED) {
+	if (conn_type == BLE_SERVER_DISCONNECTED) {
 		perfs_ble_reset_data();
 	}
 
 	return;
 }
 
-static ble_manager_server_init_config server_config = {
+static ble_server_init_config server_config = {
 	ble_server_connected_cb,
 	true,
-	gatt_profile, sizeof(gatt_profile) / sizeof(ble_manager_server_gatt_t)};
+	gatt_profile, sizeof(gatt_profile) / sizeof(ble_server_gatt_t)};
 
 
 static void perfs_ble_usage(void)
@@ -337,7 +337,7 @@ static int perfs_ble_server_start(void)
 	blue_data->data = g_adv_raw;
 	blue_data->length = sizeof(g_adv_raw);
 
-	ret = ble_manager_server_set_adv_data(blue_data);
+	ret = ble_server_set_adv_data(blue_data);
 	if (ret != BLE_MANAGER_SUCCESS) {
 		BLE_LOGD( "Fail to set adv raw data ret:[%d]\n", ret);
 		return -1;
@@ -347,14 +347,14 @@ static int perfs_ble_server_start(void)
 	blue_data->data = g_adv_resp;
 	blue_data->length = sizeof(g_adv_resp);
 
-	ret = ble_manager_server_set_adv_resp(blue_data);
+	ret = ble_server_set_adv_resp(blue_data);
 	if (ret != BLE_MANAGER_SUCCESS) {
 		BLE_LOGD( "Fail to set adv resp data ret:[%d]\n", ret);
 		return -1;
 	}
 	BLE_LOGD( "Set adv resp data ... ok\n");
 
-	ret = ble_manager_server_start_adv();
+	ret = ble_server_start_adv();
 	if (ret != BLE_MANAGER_SUCCESS) {
 		BLE_LOGD( "Fail to start adv ret:[%d]\n", ret);
 		return -1;

--- a/apps/examples/ble_tester/ble_tester_main.c
+++ b/apps/examples/ble_tester/ble_tester_main.c
@@ -83,7 +83,7 @@ static int g_scan_done = -1;
 static int g_is_scan = 0;
 static int g_server_process_run = 0;
 static ble_addr g_target = { 0, };
-static ble_manager_client_ctx *g_ctx = NULL;
+static ble_client_ctx *g_ctx = NULL;
 
 static int g_scan_time = 20; // 20 seconds
 static int g_packet_size = BLE_MAX_MTU - 3; // 244 bytes
@@ -123,13 +123,13 @@ static char *client_state_str[] = {
 	"\x1b[35mAUTO-CONNECTING\x1b[0m",
 };
 
-static char *__client_state_str(ble_manager_client_state_e state)
+static char *__client_state_str(ble_client_state_e state)
 {
 	return client_state_str[state];
 }
 
-static void ble_get_state(ble_manager_client_ctx *ctx) {
-	RMC_LOG(RMC_CLIENT_TAG, "Client State [ %s ]\n", __client_state_str(ble_manager_client_get_state(ctx)));
+static void ble_get_state(ble_client_ctx *ctx) {
+	RMC_LOG(RMC_CLIENT_TAG, "Client State [ %s ]\n", __client_state_str(ble_client_get_state(ctx)));
 }
 
 static void ble_scan_state_changed_cb(ble_scan_state_e scan_state)
@@ -186,7 +186,7 @@ static void ble_device_scanned_cb_without_filter(ble_scanned_device *scanned_dev
 	return;
 }
 
-static void ble_device_disconnected_cb(ble_manager_client_ctx *ctx)
+static void ble_device_disconnected_cb(ble_client_ctx *ctx)
 {
 	RMC_LOG(RMC_CLIENT_TAG, "'%s' is called[%p]\n", __FUNCTION__, ctx);
 	g_is_conn = 0;
@@ -194,7 +194,7 @@ static void ble_device_disconnected_cb(ble_manager_client_ctx *ctx)
 	return;
 }
 
-static void ble_manager_device_connected_cb(ble_manager_client_ctx *ctx, ble_manager_device_connected *dev)
+static void ble_device_connected_cb(ble_client_ctx *ctx, ble_device_connected *dev)
 {
 	RMC_LOG(RMC_CLIENT_TAG, "'%s' is called[%p]\n", __FUNCTION__, ctx);
 
@@ -219,7 +219,7 @@ static void ble_manager_device_connected_cb(ble_manager_client_ctx *ctx, ble_man
 	return;
 }
 
-static void ble_operation_notification_cb(ble_manager_client_ctx *ctx, ble_attr_handle attr_handle, ble_data *read_result)
+static void ble_operation_notification_cb(ble_client_ctx *ctx, ble_attr_handle attr_handle, ble_data *read_result)
 {
 	RMC_LOG(RMC_CLIENT_TAG, "'%s' is called[%p]\n", __FUNCTION__, ctx);
 	printf("attr : %x // len : %d\n", attr_handle, read_result->length);
@@ -240,7 +240,7 @@ static void ble_operation_notification_cb(ble_manager_client_ctx *ctx, ble_attr_
 	return;
 }
 
-static void ble_server_connected_cb(ble_conn_handle con_handle, ble_manager_server_connection_type_e conn_type, uint8_t mac[BLE_BD_ADDR_MAX_LEN])
+static void ble_server_connected_cb(ble_conn_handle con_handle, ble_server_connection_type_e conn_type, uint8_t mac[BLE_BD_ADDR_MAX_LEN])
 {
 	RMC_LOG(RMC_SERVER_TAG, "'%s' is called\n", __FUNCTION__);
 	RMC_LOG(RMC_SERVER_TAG, "conn : %d / conn_type : %d\n", con_handle, conn_type);
@@ -271,7 +271,7 @@ static void ble_server_oneshot_adv_cb(uint16_t adv_result)
 	return;
 }
 
-static void utc_cb_charact_a_1(ble_manager_server_attr_cb_type_e type, ble_conn_handle conn_handle, ble_attr_handle attr_handle, void *arg)
+static void utc_cb_charact_a_1(ble_server_attr_cb_type_e type, ble_conn_handle conn_handle, ble_attr_handle attr_handle, void *arg)
 {
 	char *arg_str = "None";
 	if (arg != NULL) {
@@ -280,7 +280,7 @@ static void utc_cb_charact_a_1(ble_manager_server_attr_cb_type_e type, ble_conn_
 	RMC_LOG(RMC_SERVER_TAG, "[CHAR_A_1][%s] type : %d / handle : %d / attr : %02x \n", arg_str, type, conn_handle, attr_handle);
 }
 
-static void utc_cb_desc_b_1(ble_manager_server_attr_cb_type_e type, ble_conn_handle conn_handle, ble_attr_handle attr_handle, void *arg)
+static void utc_cb_desc_b_1(ble_server_attr_cb_type_e type, ble_conn_handle conn_handle, ble_attr_handle attr_handle, void *arg)
 {
 	char *arg_str = "None";
 	if (arg != NULL) {
@@ -289,15 +289,15 @@ static void utc_cb_desc_b_1(ble_manager_server_attr_cb_type_e type, ble_conn_han
 	RMC_LOG(RMC_SERVER_TAG, "[DESC_A_1][%s] type : %d / handle : %d / attr : %02x \n", arg_str, type, conn_handle, attr_handle);
 }
 
-static void ble_peri_cb_charact_rmc_sync(ble_manager_server_attr_cb_type_e type, ble_conn_handle conn_handle, ble_attr_handle attr_handle, void* arg) {
+static void ble_peri_cb_charact_rmc_sync(ble_server_attr_cb_type_e type, ble_conn_handle conn_handle, ble_attr_handle attr_handle, void* arg) {
 	uint8_t buf[256] = { 0, };
 	ble_data data = { buf, sizeof(buf) };
-	ble_result_e ret = ble_manager_server_attr_get_data(attr_handle, &data);
+	ble_result_e ret = ble_server_attr_get_data(attr_handle, &data);
 	if (ret != BLE_MANAGER_SUCCESS) {
 		RMC_LOG(RMC_SERVER_TAG, "[RMC_SYNC] Fail to get attr data\n");
 		return;
 	}
-	if (type == BLE_MANAGER_SERVER_ATTR_CB_WRITING_NO_RSP || type == BLE_MANAGER_SERVER_ATTR_CB_WRITING) {
+	if (type == BLE_SERVER_ATTR_CB_WRITING_NO_RSP || type == BLE_SERVER_ATTR_CB_WRITING) {
 		if (data.data[0] != data.data[data.length - 1]) {
 			RMC_LOG(RMC_SERVER_TAG, "[WRITE] Fail[%d] : %d / %d\n" , data.length, data.data[0], data.data[1]);
 		} else {
@@ -323,7 +323,7 @@ static void ble_peri_cb_charact_rmc_sync(ble_manager_server_attr_cb_type_e type,
 	}
 }
 
-static void ble_peri_cb_charact_ota(ble_manager_server_attr_cb_type_e type, ble_conn_handle conn_handle, ble_attr_handle attr_handle, void* arg) {
+static void ble_peri_cb_charact_ota(ble_server_attr_cb_type_e type, ble_conn_handle conn_handle, ble_attr_handle attr_handle, void* arg) {
 	char *arg_str = "None";
 	if (arg != NULL) {
 		arg_str = (char *)arg;
@@ -331,45 +331,45 @@ static void ble_peri_cb_charact_ota(ble_manager_server_attr_cb_type_e type, ble_
 	RMC_LOG(RMC_SERVER_TAG, "[CHAR_OTA][%s] type : %d / handle : %d / attr : %02x \n", arg_str, type, conn_handle, attr_handle);
 }
 
-static ble_manager_server_gatt_t gatt_profile[] = {
-	{.type = BLE_MANAGER_SERVER_GATT_SERVICE, .uuid = {0x12,0xB6,0x6E,0x45,0xA7,0x68,0x9D,0x8D,0x9A,0x40,0x17,0x2B,0xE9,0xCB,0xF2,0x13}, .uuid_length = 16,
+static ble_server_gatt_t gatt_profile[] = {
+	{.type = BLE_SERVER_GATT_SERVICE, .uuid = {0x12,0xB6,0x6E,0x45,0xA7,0x68,0x9D,0x8D,0x9A,0x40,0x17,0x2B,0xE9,0xCB,0xF2,0x13}, .uuid_length = 16,
 	.attr_handle = BLE_APP_HANDLE_SERVICE_0,},
 
-	{.type = BLE_MANAGER_SERVER_GATT_CHARACT, .uuid = {0x99,0xC7,0xAA,0xE7,0xF8,0x9A,0xCB,0x88,0x43,0x4C,0x44,0xCF,0x0D,0x5B,0xDA,0xF2}, .uuid_length = 16,
-	.property =  BLE_MANAGER_ATTR_PROP_RWN|BLE_MANAGER_ATTR_PROP_WRITE_NO_RSP, .permission = BLE_MANAGER_ATTR_PERM_R_PERMIT|BLE_MANAGER_ATTR_PERM_W_PERMIT,
+	{.type = BLE_SERVER_GATT_CHARACT, .uuid = {0x99,0xC7,0xAA,0xE7,0xF8,0x9A,0xCB,0x88,0x43,0x4C,0x44,0xCF,0x0D,0x5B,0xDA,0xF2}, .uuid_length = 16,
+	.property =  BLE_ATTR_PROP_RWN|BLE_ATTR_PROP_WRITE_NO_RSP, .permission = BLE_ATTR_PERM_R_PERMIT|BLE_ATTR_PERM_W_PERMIT,
 	.attr_handle = BLE_STATE_MANAGER_RMC_HANDLE_KEY_COMMAND, .cb = utc_cb_charact_a_1, .arg = "char_1"},
 
-	{.type = BLE_MANAGER_SERVER_GATT_DESC, .uuid = {0x02,0x29}, .uuid_length = 2,
-	.permission = BLE_MANAGER_ATTR_PERM_R_PERMIT|BLE_MANAGER_ATTR_PERM_W_PERMIT,
+	{.type = BLE_SERVER_GATT_DESC, .uuid = {0x02,0x29}, .uuid_length = 2,
+	.permission = BLE_ATTR_PERM_R_PERMIT|BLE_ATTR_PERM_W_PERMIT,
 	.attr_handle = BLE_STATE_MANAGER_RMC_HANDLE_KEY_CCCD, .cb = utc_cb_desc_b_1, .arg = "desc_1"},
 
-	{.type = BLE_MANAGER_SERVER_GATT_SERVICE, .uuid = {0xAD,0xB6,0x6E,0x45,0xA7,0x68,0x9D,0x8D,0x9A,0x40,0x17,0x2B,0xE9,0xCB,0xF2,0x13}, .uuid_length = 16,
+	{.type = BLE_SERVER_GATT_SERVICE, .uuid = {0xAD,0xB6,0x6E,0x45,0xA7,0x68,0x9D,0x8D,0x9A,0x40,0x17,0x2B,0xE9,0xCB,0xF2,0x13}, .uuid_length = 16,
 	.attr_handle = BLE_APP_HANDLE_SERVICE_1,},
 
-	{.type = BLE_MANAGER_SERVER_GATT_CHARACT, .uuid = {0x04,0xC7,0xAA,0xE7,0xF8,0x9A,0xCB,0x88,0x43,0x4C,0x44,0xCF,0x0D,0x5B,0xDA,0xF2}, .uuid_length = 16,
-	.property =  BLE_MANAGER_ATTR_PROP_RWN|BLE_MANAGER_ATTR_PROP_WRITE_NO_RSP, .permission = BLE_MANAGER_ATTR_PERM_R_PERMIT|BLE_MANAGER_ATTR_PERM_W_PERMIT,
+	{.type = BLE_SERVER_GATT_CHARACT, .uuid = {0x04,0xC7,0xAA,0xE7,0xF8,0x9A,0xCB,0x88,0x43,0x4C,0x44,0xCF,0x0D,0x5B,0xDA,0xF2}, .uuid_length = 16,
+	.property =  BLE_ATTR_PROP_RWN|BLE_ATTR_PROP_WRITE_NO_RSP, .permission = BLE_ATTR_PERM_R_PERMIT|BLE_ATTR_PERM_W_PERMIT,
 	.attr_handle = BLE_APP_HANDLE_CHAR_RMC_KEY, .cb = utc_cb_charact_a_1, .arg = "char_2"},
 
-	{.type = BLE_MANAGER_SERVER_GATT_DESC, .uuid = {0x02,0x29}, .uuid_length = 2,
-	.permission = BLE_MANAGER_ATTR_PERM_R_PERMIT|BLE_MANAGER_ATTR_PERM_W_PERMIT,
+	{.type = BLE_SERVER_GATT_DESC, .uuid = {0x02,0x29}, .uuid_length = 2,
+	.permission = BLE_ATTR_PERM_R_PERMIT|BLE_ATTR_PERM_W_PERMIT,
 	.attr_handle = BLE_APP_HANDLE_DESC_RMC_KEY, .cb = utc_cb_desc_b_1, .arg = "desc_2"},
 
-	{.type = BLE_MANAGER_SERVER_GATT_SERVICE, .uuid = {0xF4,0x7A,0x07,0x08,0xFD,0xC7,0x9D,0xB5,0xFF,0x4E,0x85,0xDE,0x48,0x80,0xFE,0xA2}, .uuid_length = 16,
+	{.type = BLE_SERVER_GATT_SERVICE, .uuid = {0xF4,0x7A,0x07,0x08,0xFD,0xC7,0x9D,0xB5,0xFF,0x4E,0x85,0xDE,0x48,0x80,0xFE,0xA2}, .uuid_length = 16,
 	.attr_handle = BLE_APP_HANDLE_SERVICE_2,},
 
-	{.type = BLE_MANAGER_SERVER_GATT_CHARACT, .uuid = {0x06,0xC7,0xAA,0xE7,0xF8,0x9A,0xCB,0x88,0x43,0x4C,0x44,0xCF,0x0D,0x5B,0xDA,0xBB}, .uuid_length = 16,
-	.property =  BLE_MANAGER_ATTR_PROP_RWN|BLE_MANAGER_ATTR_PROP_WRITE_NO_RSP, .permission = BLE_MANAGER_ATTR_PERM_R_PERMIT|BLE_MANAGER_ATTR_PERM_W_PERMIT,
+	{.type = BLE_SERVER_GATT_CHARACT, .uuid = {0x06,0xC7,0xAA,0xE7,0xF8,0x9A,0xCB,0x88,0x43,0x4C,0x44,0xCF,0x0D,0x5B,0xDA,0xBB}, .uuid_length = 16,
+	.property =  BLE_ATTR_PROP_RWN|BLE_ATTR_PROP_WRITE_NO_RSP, .permission = BLE_ATTR_PERM_R_PERMIT|BLE_ATTR_PERM_W_PERMIT,
 	.attr_handle = BLE_APP_HANDLE_CHAR_RMC_SYNC, .cb = ble_peri_cb_charact_rmc_sync, .arg = "char_3"},
 
-	{.type = BLE_MANAGER_SERVER_GATT_SERVICE, .uuid = {0x11,0xB6,0x6E,0x45,0xA7,0x68,0x9D,0x8D,0x9A,0x40,0x17,0x2B,0xE9,0xCB,0xF2,0x13}, .uuid_length = 16,
+	{.type = BLE_SERVER_GATT_SERVICE, .uuid = {0x11,0xB6,0x6E,0x45,0xA7,0x68,0x9D,0x8D,0x9A,0x40,0x17,0x2B,0xE9,0xCB,0xF2,0x13}, .uuid_length = 16,
 	.attr_handle = BLE_STATE_MANAGER_RMC_HANDLE_OTA_SERVICE,},
 
-	{.type = BLE_MANAGER_SERVER_GATT_CHARACT, .uuid = {0x22,0xC7,0xAA,0xE7,0xF8,0x9A,0xCB,0x88,0x43,0x4C,0x44,0xCF,0x0D,0x5B,0xDA,0xF2}, .uuid_length = 16,
-	.property =  BLE_MANAGER_ATTR_PROP_READ|BLE_MANAGER_ATTR_PROP_WRITE|BLE_MANAGER_ATTR_PROP_INDICATE, .permission = BLE_MANAGER_ATTR_PERM_R_PERMIT|BLE_MANAGER_ATTR_PERM_W_PERMIT,
+	{.type = BLE_SERVER_GATT_CHARACT, .uuid = {0x22,0xC7,0xAA,0xE7,0xF8,0x9A,0xCB,0x88,0x43,0x4C,0x44,0xCF,0x0D,0x5B,0xDA,0xF2}, .uuid_length = 16,
+	.property =  BLE_ATTR_PROP_READ|BLE_ATTR_PROP_WRITE|BLE_ATTR_PROP_INDICATE, .permission = BLE_ATTR_PERM_R_PERMIT|BLE_ATTR_PERM_W_PERMIT,
 	.attr_handle = BLE_STATE_MANAGER_RMC_HANDLE_OTA_COMMAND, .cb = ble_peri_cb_charact_ota, .arg = "char_4"},
 
-	{.type = BLE_MANAGER_SERVER_GATT_DESC, .uuid = {0x02,0x29}, .uuid_length = 2,
-	.permission = BLE_MANAGER_ATTR_PERM_R_PERMIT|BLE_MANAGER_ATTR_PERM_W_PERMIT,
+	{.type = BLE_SERVER_GATT_DESC, .uuid = {0x02,0x29}, .uuid_length = 2,
+	.permission = BLE_ATTR_PERM_R_PERMIT|BLE_ATTR_PERM_W_PERMIT,
 	.attr_handle = BLE_STATE_MANAGER_RMC_HANDLE_OTA_INDI_CCCD, .cb = utc_cb_desc_b_1, .arg = "desc_4"},
 };
 
@@ -385,28 +385,28 @@ static ble_scan_callback_list scan_config = {
 	NULL,
 };
 
-static ble_manager_client_callback_list client_config = {
+static ble_client_callback_list client_config = {
 	ble_device_disconnected_cb,
-	ble_manager_device_connected_cb,
+	ble_device_connected_cb,
 	ble_operation_notification_cb,
 };
 
-static ble_manager_server_init_config server_config = {
+static ble_server_init_config server_config = {
 	ble_server_connected_cb,
 	ble_server_disconnected_cb,
 	ble_server_mtu_update_cb,
 	ble_server_oneshot_adv_cb,
 	true,
 	gatt_profile, 
-	sizeof(gatt_profile) / sizeof(ble_manager_server_gatt_t)
+	sizeof(gatt_profile) / sizeof(ble_server_gatt_t)
 };
 
 static int ble_connect_common(bool is_auto)
 {
 	ble_result_e ret = BLE_MANAGER_FAIL;
 	struct timespec abstime;
-	ble_manager_client_state_e cli_state = BLE_MANAGER_CLIENT_NONE;
-	ble_manager_conn_info conn_info = { 0, };
+	ble_client_state_e cli_state = BLE_CLIENT_NONE;
+	ble_conn_info conn_info = { 0, };
 	int conn_timeout = 5; /* conn timeout : 5 seconds */
 
 	memcpy(conn_info.addr.mac, g_target.mac, BLE_BD_ADDR_MAX_LEN);
@@ -421,7 +421,7 @@ static int ble_connect_common(bool is_auto)
 	sem_init(&g_conn_sem, 0, 0);
 
 	if (g_ctx == NULL) {
-		g_ctx = ble_manager_client_create_ctx(&client_config);
+		g_ctx = ble_client_create_ctx(&client_config);
 		if (g_ctx == NULL) {
 			RMC_LOG(RMC_CLIENT_TAG, "create ctx fail\n");
 			return 0;
@@ -429,22 +429,22 @@ static int ble_connect_common(bool is_auto)
 	}
 	RMC_LOG(RMC_CLIENT_TAG, "create ctx ok[%p]\n", g_ctx);
 
-	ret = ble_manager_client_autoconnect(g_ctx, is_auto);
+	ret = ble_client_autoconnect(g_ctx, is_auto);
 	if (ret != BLE_MANAGER_SUCCESS) {
 		RMC_LOG(RMC_CLIENT_TAG, "fail to set autoconnect=%d [%d]\n", is_auto, ret);
 	}
 
-	cli_state = ble_manager_client_get_state(g_ctx);
+	cli_state = ble_client_get_state(g_ctx);
 	RMC_LOG(RMC_CLIENT_TAG, "Client State [ %s ]\n", __client_state_str(cli_state));
 
-	ret = ble_manager_client_connect(g_ctx, &conn_info);
+	ret = ble_client_connect(g_ctx, &conn_info);
 	if (ret != BLE_MANAGER_SUCCESS) {
 		RMC_LOG(RMC_CLIENT_TAG, "connect fail[%d]\n", ret);
 		sem_destroy(&g_conn_sem);
 		return 0;
 	}
 
-	cli_state = ble_manager_client_get_state(g_ctx);
+	cli_state = ble_client_get_state(g_ctx);
 	RMC_LOG(RMC_CLIENT_TAG, "Client State [ %s ]\n", __client_state_str(cli_state));
 
 	ret = clock_gettime(CLOCK_REALTIME, &abstime);
@@ -461,10 +461,10 @@ static int ble_connect_common(bool is_auto)
 		RMC_LOG(RMC_CLIENT_TAG, "PASS: sem_timedwait succeeded\n");
 	}
 
-	cli_state = ble_manager_client_get_state(g_ctx);
+	cli_state = ble_client_get_state(g_ctx);
 	RMC_LOG(RMC_CLIENT_TAG, "Client State [ %s ]\n", __client_state_str(cli_state));
 
-	if (cli_state != BLE_MANAGER_CLIENT_CONNECTED) {
+	if (cli_state != BLE_CLIENT_CONNECTED) {
 		RMC_LOG(RMC_CLIENT_TAG, "BLE is not connected");
 		return 0;
 	} else {
@@ -473,7 +473,7 @@ static int ble_connect_common(bool is_auto)
 	
 	ble_attr_handle attr_handle;
 	attr_handle = BLE_STATE_MANAGER_RMC_HANDLE_KEY_CCCD;
-	ret = ble_manager_client_operation_enable_notification(g_ctx, attr_handle);
+	ret = ble_client_operation_enable_notification(g_ctx, attr_handle);
 	if (ret != BLE_MANAGER_SUCCESS) {
 		RMC_LOG(RMC_CLIENT_TAG, "Fail to enable noti handle[%02x][%d]\n", attr_handle, ret);
 	} else {
@@ -481,7 +481,7 @@ static int ble_connect_common(bool is_auto)
 	}
 
 	attr_handle = BLE_STATE_MANAGER_RMC_HANDLE_OTA_INDI_CCCD;
-	ret = ble_manager_client_operation_enable_indication(g_ctx, attr_handle);
+	ret = ble_client_operation_enable_indication(g_ctx, attr_handle);
 	if (ret != BLE_MANAGER_SUCCESS) {
 		RMC_LOG(RMC_CLIENT_TAG, "Fail to enable indi handle[%02x][%d]\n", attr_handle, ret);
 	} else {
@@ -508,14 +508,14 @@ static int ble_change_adv_interval(int type) {
 		interval = COMBO_TEST_ADV_INTERVAL_POWERSAVE;
 		break;
 	}
-	ret = ble_manager_server_set_adv_interval(interval);
+	ret = ble_server_set_adv_interval(interval);
 	if (ret != BLE_MANAGER_SUCCESS) {
 		RMC_LOG(RMC_SERVER_TAG, "Fail to set adv interval[%d]\n", ret);
 	} else {
 		RMC_LOG(RMC_SERVER_TAG, "Success to set adv interval\n");
 	}
 
-	ret = ble_manager_server_set_adv_type(BLE_ADV_TYPE_IND, NULL);
+	ret = ble_server_set_adv_type(BLE_ADV_TYPE_IND, NULL);
 	if (ret != BLE_MANAGER_SUCCESS) {
 		RMC_LOG(RMC_SERVER_TAG, "Fail to set adv type[%d]\n", ret);
 	} else {
@@ -532,7 +532,7 @@ static void *_ble_scan_process(void *data)
 	ble_result_e ret = BLE_MANAGER_FAIL;
 	scan_config.device_scanned_cb = ble_device_scanned_cb_without_filter;
 	RMC_LOG(RMC_CLIENT_TAG, "Start Scan for [ %d ] seconds \n", scan_time);
-	ret = ble_manager_client_start_scan(NULL, &scan_config);
+	ret = ble_client_start_scan(NULL, &scan_config);
 	if (ret != BLE_MANAGER_SUCCESS) {
 		RMC_LOG(RMC_CLIENT_TAG, "scan start fail[%d]\n", ret);
 		return NULL;
@@ -540,7 +540,7 @@ static void *_ble_scan_process(void *data)
 
 	sleep(scan_time);
 
-	ret = ble_manager_client_stop_scan();
+	ret = ble_client_stop_scan();
 	if (ret != BLE_MANAGER_SUCCESS) {
 		RMC_LOG(RMC_CLIENT_TAG, "scan stop fail[%d]\n", ret);
 		return NULL;
@@ -563,12 +563,12 @@ static int ble_prepare_test(void)
 {
 	ble_result_e ret;
 	
-	ret = ble_manager_server_stop_adv();
+	ret = ble_server_stop_adv();
 	if (ret != BLE_MANAGER_SUCCESS) {
 		RMC_LOG(RMC_TAG, "Fail to start adv [%d]\n", ret);
 	}
 
-	ret = ble_manager_client_stop_scan();
+	ret = ble_client_stop_scan();
 	if (ret != BLE_MANAGER_SUCCESS) {
 		RMC_LOG(RMC_TAG, "scan stop fail[%d]\n", ret);
 	}
@@ -582,9 +582,9 @@ static int ble_prepare_test(void)
 static int ble_write_test(int mode) 
 {
 	ble_result_e ret;
-	ble_manager_client_state_e cli_state;
+	ble_client_state_e cli_state;
 	
-	if ((cli_state = ble_manager_client_get_state(g_ctx)) != BLE_MANAGER_CLIENT_CONNECTED) {
+	if ((cli_state = ble_client_get_state(g_ctx)) != BLE_CLIENT_CONNECTED) {
 		RMC_LOG(RMC_CLIENT_TAG, "BLE is not connected [ %s ]\n", __client_state_str(cli_state));
 		return 0;
 	}
@@ -607,9 +607,9 @@ static int ble_write_test(int mode)
 		packet_data[1] = g_packet_count;
 		packet_data[g_packet_size - 1] = i + 1;
 		if (mode == BLE_WRITE_NORESP) {
-			ret = ble_manager_client_operation_write_no_response(g_ctx, attr_handle, packet);
+			ret = ble_client_operation_write_no_response(g_ctx, attr_handle, packet);
 		} else {
-			ret = ble_manager_client_operation_write(g_ctx, attr_handle, packet);
+			ret = ble_client_operation_write(g_ctx, attr_handle, packet);
 		}
 		if (ret != BLE_MANAGER_SUCCESS) {
 			send_fail++;
@@ -669,7 +669,7 @@ static void *_ble_server_process(void *val)
 			
 			data.data = (uint8_t *)send_str;
 			data.length = strlen(send_str) + 1;
-			ret = ble_manager_server_charact_notify(BLE_STATE_MANAGER_RMC_HANDLE_KEY_COMMAND + 1, conn_handle, &data);
+			ret = ble_server_charact_notify(BLE_STATE_MANAGER_RMC_HANDLE_KEY_COMMAND + 1, conn_handle, &data);
 			if (ret != BLE_MANAGER_SUCCESS) {
 				RMC_LOG(RMC_SERVER_TAG, "Notify Value fail[%d]\n", ret);
 			}
@@ -742,7 +742,7 @@ int ble_tester_main(int argc, char *argv[])
 			data->data = g_adv_raw;
 			data->length = sizeof(g_adv_raw);
 
-			ret = ble_manager_server_set_adv_data(data);
+			ret = ble_server_set_adv_data(data);
 			if (ret != BLE_MANAGER_SUCCESS) {
 				RMC_LOG(RMC_SERVER_TAG, "Fail to set adv raw data[%d]\n", ret);
 				goto tester_done;
@@ -752,21 +752,21 @@ int ble_tester_main(int argc, char *argv[])
 			data->data = g_adv_resp;
 			data->length = sizeof(g_adv_resp);
 
-			ret = ble_manager_server_set_adv_resp(data);
+			ret = ble_server_set_adv_resp(data);
 			if (ret != BLE_MANAGER_SUCCESS) {
 				RMC_LOG(RMC_SERVER_TAG, "Fail to set adv resp data[%d]\n", ret);
 				goto tester_done;
 			}
 			RMC_LOG(RMC_SERVER_TAG, "Set adv resp data ... ok\n");
 
-			ret = ble_manager_server_set_adv_type(BLE_ADV_TYPE_IND, NULL);
+			ret = ble_server_set_adv_type(BLE_ADV_TYPE_IND, NULL);
 			if (ret != BLE_MANAGER_SUCCESS) {
 				RMC_LOG(RMC_SERVER_TAG, "Fail to set adv type[%d]\n", ret);
 				goto tester_done;
 			}
 			RMC_LOG(RMC_SERVER_TAG, "Set adv type ... ok\n");
 
-			ret = ble_manager_server_start_adv();
+			ret = ble_server_start_adv();
 			if (ret != BLE_MANAGER_SUCCESS) {
 				RMC_LOG(RMC_SERVER_TAG, "Fail to start adv [%d]\n", ret);
 				goto tester_done;
@@ -808,14 +808,14 @@ int ble_tester_main(int argc, char *argv[])
 
 		} else if (strncmp(argv[1], "disconn", 8) == 0) {
 			if (g_ctx != NULL) {
-				ret = ble_manager_client_disconnect(g_ctx);
+				ret = ble_client_disconnect(g_ctx);
 				if (ret != BLE_MANAGER_SUCCESS) {
 					RMC_LOG(RMC_CLIENT_TAG, "Fail to disconnect[%d]\n", ret);
 				}
 
 				int i;				
 				for (i = 0; i < 10; i++) {
-					if (ble_manager_client_get_state(g_ctx) == BLE_MANAGER_CLIENT_IDLE) {
+					if (ble_client_get_state(g_ctx) == BLE_CLIENT_IDLE) {
 						RMC_LOG(RMC_CLIENT_TAG, "Success to disconnect\n");
 						is_ble_ready = 0;
 						break;
@@ -853,7 +853,7 @@ int ble_tester_main(int argc, char *argv[])
 			filter.scan_duration = 1000 * scan_time;
 			scan_config.device_scanned_cb = ble_device_scanned_cb_with_filter;
 			g_scan_done = 0;
-			ret = ble_manager_client_start_scan(&filter, &scan_config);
+			ret = ble_client_start_scan(&filter, &scan_config);
 			if (ret != BLE_MANAGER_SUCCESS) {
 				RMC_LOG(RMC_CLIENT_TAG, "scan start fail[%d]\n", ret);
 				goto tester_done;
@@ -868,7 +868,7 @@ int ble_tester_main(int argc, char *argv[])
 				RMC_LOG(RMC_CLIENT_TAG, "Device is not found\n", ret);
 				goto tester_done;
 			} else {
-				ret = ble_manager_client_stop_scan();
+				ret = ble_client_stop_scan();
 				if (ret != BLE_MANAGER_SUCCESS) {
 					RMC_LOG(RMC_CLIENT_TAG, "scan stop fail[%d]\n", ret);
 				}
@@ -884,7 +884,7 @@ int ble_tester_main(int argc, char *argv[])
 
 				sleep(1);
 
-				if (ble_manager_client_get_state(g_ctx) == BLE_MANAGER_CLIENT_CONNECTED) {
+				if (ble_client_get_state(g_ctx) == BLE_CLIENT_CONNECTED) {
 					is_ble_ready = 1;
 					break;
 				}
@@ -899,7 +899,7 @@ int ble_tester_main(int argc, char *argv[])
 			
 			ble_change_adv_interval(SET_ADV_INTERVAL_PERFORMANCE);
 
-			ret = ble_manager_server_start_adv();
+			ret = ble_server_start_adv();
 			if (ret != BLE_MANAGER_SUCCESS) {
 				RMC_LOG(RMC_SERVER_TAG, "Fail to start adv [%d]\n", ret);
 			}
@@ -911,7 +911,7 @@ int ble_tester_main(int argc, char *argv[])
 
 			ble_change_adv_interval(SET_ADV_INTERVAL_BALANCED);
 
-			ret = ble_manager_server_start_adv();
+			ret = ble_server_start_adv();
 			if (ret != BLE_MANAGER_SUCCESS) {
 				RMC_LOG(RMC_SERVER_TAG, "Fail to start adv [%d]\n", ret);
 			}
@@ -923,7 +923,7 @@ int ble_tester_main(int argc, char *argv[])
 
 			ble_change_adv_interval(SET_ADV_INTERVAL_POWERSAVE);
 
-			ret = ble_manager_server_start_adv();
+			ret = ble_server_start_adv();
 			if (ret != BLE_MANAGER_SUCCESS) {
 				RMC_LOG(RMC_SERVER_TAG, "Fail to start adv [%d]\n", ret);
 			}
@@ -973,7 +973,7 @@ int ble_tester_main(int argc, char *argv[])
 			
 			packet.data = (uint8_t *)data;
 			packet.length = sizeof(data);
-			ret = ble_manager_server_charact_notify(BLE_STATE_MANAGER_RMC_HANDLE_KEY_COMMAND + 1, conn_handle, &packet);
+			ret = ble_server_charact_notify(BLE_STATE_MANAGER_RMC_HANDLE_KEY_COMMAND + 1, conn_handle, &packet);
 			if (ret != BLE_MANAGER_SUCCESS) {
 				RMC_LOG(RMC_SERVER_TAG, "Notify Value fail[%d]\n", ret);
 			} else {
@@ -998,7 +998,7 @@ int ble_tester_main(int argc, char *argv[])
 			
 			packet.data = (uint8_t *)data;
 			packet.length = sizeof(data);
-			ret = ble_manager_server_charact_notify(BLE_STATE_MANAGER_RMC_HANDLE_KEY_COMMAND, conn_handle, &packet);
+			ret = ble_server_charact_notify(BLE_STATE_MANAGER_RMC_HANDLE_KEY_COMMAND, conn_handle, &packet);
 			if (ret != BLE_MANAGER_SUCCESS) {
 				RMC_LOG(RMC_SERVER_TAG, "Notify Value fail[%d]\n", ret);
 			} else {
@@ -1023,7 +1023,7 @@ int ble_tester_main(int argc, char *argv[])
 			
 			packet.data = (uint8_t *)data;
 			packet.length = sizeof(data);
-			ret = ble_manager_server_charact_indicate(BLE_STATE_MANAGER_RMC_HANDLE_OTA_COMMAND + 1, conn_handle, &packet);
+			ret = ble_server_charact_indicate(BLE_STATE_MANAGER_RMC_HANDLE_OTA_COMMAND + 1, conn_handle, &packet);
 			if (ret != BLE_MANAGER_SUCCESS) {
 				RMC_LOG(RMC_SERVER_TAG, "Indicate Value fail[%d]\n", ret);
 			} else {

--- a/apps/examples/testcase/ta_tc/ble_manager/itc/itc_blemanager_main.c
+++ b/apps/examples/testcase/ta_tc/ble_manager/itc/itc_blemanager_main.c
@@ -79,52 +79,52 @@ static void ble_device_scanned_cb(ble_scanned_device *scanned_device)
 	);
 }
 
-static void ble_device_disconnected_cb(ble_manager_client_ctx *ctx)
+static void ble_device_disconnected_cb(ble_client_ctx *ctx)
 {
 	printf("client disconnected callback received\n");
 	ITC_FUNC_SIGNAL;
 }
 
-static void ble_manager_device_connected_cb(ble_manager_client_ctx *ctx, ble_manager_device_connected *dev)
+static void ble_device_connected_cb(ble_client_ctx *ctx, ble_device_connected *dev)
 {
 	printf("client connected callback received\n");
 	ITC_FUNC_SIGNAL;
 }
 
-static void ble_operation_notification_cb(ble_manager_client_ctx *ctx, ble_attr_handle attr_handle, ble_data *read_result)
+static void ble_operation_notification_cb(ble_client_ctx *ctx, ble_attr_handle attr_handle, ble_data *read_result)
 {
 	printf("notification callback received\n");
 	ITC_FUNC_SIGNAL;
 }
 
-static void ble_server_connected_cb(ble_conn_handle con_handle, ble_manager_server_connection_type_e conn_type, uint8_t mac[BLE_BD_ADDR_MAX_LEN])
+static void ble_server_connected_cb(ble_conn_handle con_handle, ble_server_connection_type_e conn_type, uint8_t mac[BLE_BD_ADDR_MAX_LEN])
 {
 	printf("server connect callback received");
 }
 
-static ble_manager_server_gatt_t gatt_profile[] = {
+static ble_server_gatt_t gatt_profile[] = {
 	{
-		.type = BLE_MANAGER_SERVER_GATT_SERVICE,
+		.type = BLE_SERVER_GATT_SERVICE,
 		.uuid = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x01, 0x01, 0x01, 0x01},
 		.uuid_length = 16,
 		.attr_handle = 0x006a,
 	},
 
 	{
-		.type = BLE_MANAGER_SERVER_GATT_CHARACT,
+		.type = BLE_SERVER_GATT_CHARACT,
 		.uuid = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x01, 0x01, 0x01, 0x02},
 		.uuid_length = 16,
-		.property = BLE_MANAGER_ATTR_PROP_RWN | BLE_MANAGER_ATTR_PROP_WRITE_NO_RSP,
-		.permission = BLE_MANAGER_ATTR_PERM_R_PERMIT | BLE_MANAGER_ATTR_PERM_W_PERMIT,
+		.property = BLE_ATTR_PROP_RWN | BLE_ATTR_PROP_WRITE_NO_RSP,
+		.permission = BLE_ATTR_PERM_R_PERMIT | BLE_ATTR_PERM_W_PERMIT,
 		.attr_handle = 0x006b,
 		.arg = "char_a_1"
 	},
 
 	{
-		.type = BLE_MANAGER_SERVER_GATT_DESC,
+		.type = BLE_SERVER_GATT_DESC,
 		.uuid = {0x02, 0x29},
 		.uuid_length = 2,
-		.permission = BLE_MANAGER_ATTR_PERM_R_PERMIT | BLE_MANAGER_ATTR_PERM_W_PERMIT,
+		.permission = BLE_ATTR_PERM_R_PERMIT | BLE_ATTR_PERM_W_PERMIT,
 		.attr_handle = 0x006c,
 		.arg = "desc_b_1",
 	},
@@ -142,17 +142,17 @@ static ble_scan_callback_list scan_config = {
 	ble_device_scanned_cb,
 };
 
-static ble_manager_client_callback_list client_config = {
+static ble_client_callback_list client_config = {
 	ble_device_disconnected_cb,
-	ble_manager_device_connected_cb,
+	ble_device_connected_cb,
 	ble_operation_notification_cb,
 };
 
-static ble_manager_server_init_config server_config = {
+static ble_server_init_config server_config = {
 	ble_server_connected_cb,
 	true,
 	gatt_profile,
-	sizeof(gatt_profile) / sizeof(ble_manager_server_gatt_t)
+	sizeof(gatt_profile) / sizeof(ble_server_gatt_t)
 };
 
 static void set_scan_filter(ble_scan_filter *filter, uint8_t *raw_data, uint8_t len, bool whitelist_enable, uint32_t scan_duration)
@@ -230,7 +230,7 @@ static void itc_blemanager_init_deinit_n(void)
  * @testcase         itc_blemanager_scan_p
  * @brief            check initalization, scan,and de-initalization of ble manager
  * @scenario         check initalization, scan,and de-initalization of ble manager
- * @apicovered       ble_manager_init, ble_manager_client_start_scan, ble_manager_client_stop_scan, ble_manager_deinit
+ * @apicovered       ble_manager_init, ble_client_start_scan, ble_client_stop_scan, ble_manager_deinit
  * @precondition     none
  * @postcondition    none
  */
@@ -241,20 +241,20 @@ static void itc_blemanager_scan_p(void)
 	TC_ASSERT_EQ("ble_manager_init", ret, BLE_MANAGER_SUCCESS);
 
 	//no filter scan
-	ret = ble_manager_client_start_scan(NULL, &scan_config);
+	ret = ble_client_start_scan(NULL, &scan_config);
 	TC_ASSERT_EQ_CLEANUP("ble_client_start_scan", ret, BLE_MANAGER_SUCCESS, ble_manager_deinit());
 	ITC_FUNC_WAIT;
-	ret = ble_manager_client_stop_scan();
+	ret = ble_client_stop_scan();
 	TC_ASSERT_EQ_CLEANUP("ble_client_stop_scan", ret, BLE_MANAGER_SUCCESS, ble_manager_deinit());
 	ITC_FUNC_WAIT;
 
 	//filter scan
 	ble_scan_filter filter = { 0, };
 	set_scan_filter(&filter, ble_filter, sizeof(ble_filter), false, 1000);
-	ret = ble_manager_client_start_scan(&filter, &scan_config);
+	ret = ble_client_start_scan(&filter, &scan_config);
 	TC_ASSERT_EQ_CLEANUP("ble_client_start_scan", ret, BLE_MANAGER_SUCCESS, ble_manager_deinit());
 	ITC_FUNC_WAIT;
-	ret = ble_manager_client_stop_scan();
+	ret = ble_client_stop_scan();
 	TC_ASSERT_EQ_CLEANUP("ble_client_stop_scan", ret, BLE_MANAGER_SUCCESS, ble_manager_deinit());
 	ITC_FUNC_WAIT;
 
@@ -278,9 +278,9 @@ static void itc_blemanager_connect_disconnect_p(void)
 	TC_ASSERT_EQ("ble_manager_init", ret, BLE_MANAGER_SUCCESS);
 
 	//connect
-	ble_manager_client_ctx *ctx;
-	ctx = ble_manager_client_create_ctx(&client_config);
-	ble_manager_conn_info conn_info = { 0, };
+	ble_client_ctx *ctx;
+	ctx = ble_client_create_ctx(&client_config);
+	ble_conn_info conn_info = { 0, };
 	memcpy(conn_info.addr.mac, g_target.mac, BLE_BD_ADDR_MAX_LEN);
 	conn_info.addr.type = BLE_ADV_TYPE_IND;
 	conn_info.conn_interval = 8;
@@ -296,12 +296,12 @@ static void itc_blemanager_connect_disconnect_p(void)
 		conn_info.addr.mac[4],
 		conn_info.addr.mac[5]
 	);
-	ret = ble_manager_client_connect(ctx, &conn_info);
+	ret = ble_client_connect(ctx, &conn_info);
 	TC_ASSERT_EQ_CLEANUP("ble_client_connect", ret, BLE_MANAGER_SUCCESS, ble_manager_deinit());
 	ITC_FUNC_WAIT;
 
 	//disconnect
-	ret = ble_manager_client_disconnect(ctx);
+	ret = ble_client_disconnect(ctx);
 	TC_ASSERT_EQ_CLEANUP("ble_client_disconnect", ret, BLE_MANAGER_SUCCESS, ble_manager_deinit());
 	ITC_FUNC_WAIT;
 
@@ -325,9 +325,9 @@ static void itc_blemanager_connect_disconnect_n(void)
 	TC_ASSERT_EQ("ble_manager_init", ret, BLE_MANAGER_SUCCESS);
 
 	//connect
-	ble_manager_client_ctx *ctx;
-	ctx = ble_manager_client_create_ctx(&client_config);
-	ble_manager_conn_info conn_info = { 0, };
+	ble_client_ctx *ctx;
+	ctx = ble_client_create_ctx(&client_config);
+	ble_conn_info conn_info = { 0, };
 	memcpy(conn_info.addr.mac, g_target.mac, BLE_BD_ADDR_MAX_LEN);
 	conn_info.addr.type = BLE_ADV_TYPE_IND;
 	conn_info.conn_interval = 8;
@@ -335,16 +335,16 @@ static void itc_blemanager_connect_disconnect_n(void)
 	conn_info.mtu = 240;
 	conn_info.scan_timeout = 1000;
 	conn_info.is_secured_connect = true;
-	ret = ble_manager_client_connect(ctx, &conn_info);
+	ret = ble_client_connect(ctx, &conn_info);
 	TC_ASSERT_EQ_CLEANUP("ble_client_connect", ret, BLE_MANAGER_SUCCESS, ble_manager_deinit());
 
 	//disconnect
-	ret = ble_manager_client_disconnect(ctx);
+	ret = ble_client_disconnect(ctx);
 	TC_ASSERT_EQ_CLEANUP("ble_client_disconnect", ret, BLE_MANAGER_INVALID_STATE, ble_manager_deinit());
 	ITC_FUNC_WAIT;
 
 	//disconnect
-	ret = ble_manager_client_disconnect(ctx);
+	ret = ble_client_disconnect(ctx);
 	TC_ASSERT_EQ_CLEANUP("ble_client_disconnect", ret, BLE_MANAGER_SUCCESS, ble_manager_deinit());
 	ITC_FUNC_WAIT;
 
@@ -368,9 +368,9 @@ static void itc_blemanager_bonded_device_p(void)
 	TC_ASSERT_EQ("ble_manager_init", ret, BLE_MANAGER_SUCCESS);
 
 	//connect
-	ble_manager_client_ctx *ctx;
-	ctx = ble_manager_client_create_ctx(&client_config);
-	ble_manager_conn_info conn_info = { 0, };
+	ble_client_ctx *ctx;
+	ctx = ble_client_create_ctx(&client_config);
+	ble_conn_info conn_info = { 0, };
 	memcpy(conn_info.addr.mac, g_target.mac, BLE_BD_ADDR_MAX_LEN);
 	conn_info.addr.type = BLE_ADV_TYPE_IND;
 	conn_info.conn_interval = 8;
@@ -386,7 +386,7 @@ static void itc_blemanager_bonded_device_p(void)
 		conn_info.addr.mac[4],
 		conn_info.addr.mac[5]
 	);
-	ret = ble_manager_client_connect(ctx, &conn_info);
+	ret = ble_client_connect(ctx, &conn_info);
 	TC_ASSERT_EQ_CLEANUP("ble_client_connect", ret, BLE_MANAGER_SUCCESS, ble_manager_deinit());
 	ITC_FUNC_WAIT;
 
@@ -398,7 +398,7 @@ static void itc_blemanager_bonded_device_p(void)
 	TC_ASSERT_EQ_CLEANUP("ble_manager_delete_bonded", ret, BLE_MANAGER_SUCCESS, ble_manager_deinit());
 
 	//disconnect
-	ret = ble_manager_client_disconnect(ctx);
+	ret = ble_client_disconnect(ctx);
 	TC_ASSERT_EQ_CLEANUP("ble_client_disconnect", ret, BLE_MANAGER_SUCCESS, ble_manager_deinit());
 	ITC_FUNC_WAIT;
 
@@ -422,9 +422,9 @@ static void itc_blemanager_client_con_list_p(void)
 	TC_ASSERT_EQ("ble_manager_init", ret, BLE_MANAGER_SUCCESS);
 
 	//connect
-	ble_manager_client_ctx *ctx;
-	ctx = ble_manager_client_create_ctx(&client_config);
-	ble_manager_conn_info conn_info = { 0, };
+	ble_client_ctx *ctx;
+	ctx = ble_client_create_ctx(&client_config);
+	ble_conn_info conn_info = { 0, };
 	memcpy(conn_info.addr.mac, g_target.mac, BLE_BD_ADDR_MAX_LEN);
 	conn_info.addr.type = BLE_ADV_TYPE_IND;
 	conn_info.conn_interval = 8;
@@ -440,16 +440,16 @@ static void itc_blemanager_client_con_list_p(void)
 		conn_info.addr.mac[4],
 		conn_info.addr.mac[5]
 	);
-	ret = ble_manager_client_connect(ctx, &conn_info);
+	ret = ble_client_connect(ctx, &conn_info);
 	TC_ASSERT_EQ_CLEANUP("ble_client_connect", ret, BLE_MANAGER_SUCCESS, ble_manager_deinit());
 	ITC_FUNC_WAIT;
 
-	ble_manager_device_connected_list connected_list;
-	ret = ble_manager_client_connected_device_list(&connected_list);
+	ble_device_connected_list connected_list;
+	ret = ble_client_connected_device_list(&connected_list);
 	TC_ASSERT_EQ_CLEANUP("ble_client_connected_device_list", ret, BLE_MANAGER_SUCCESS, ble_manager_deinit());
 
 	//disconnect
-	ret = ble_manager_client_disconnect(ctx);
+	ret = ble_client_disconnect(ctx);
 	TC_ASSERT_EQ_CLEANUP("ble_client_disconnect", ret, BLE_MANAGER_SUCCESS, ble_manager_deinit());
 	ITC_FUNC_WAIT;
 
@@ -473,9 +473,9 @@ static void itc_blemanager_connected_dev_info_p(void)
 	TC_ASSERT_EQ("ble_manager_init", ret, BLE_MANAGER_SUCCESS);
 
 	//connect
-	ble_manager_client_ctx *ctx;
-	ctx = ble_manager_client_create_ctx(&client_config);
-	ble_manager_conn_info conn_info = { 0, };
+	ble_client_ctx *ctx;
+	ctx = ble_client_create_ctx(&client_config);
+	ble_conn_info conn_info = { 0, };
 	memcpy(conn_info.addr.mac, g_target.mac, BLE_BD_ADDR_MAX_LEN);
 	conn_info.addr.type = BLE_ADV_TYPE_IND;
 	conn_info.conn_interval = 8;
@@ -491,16 +491,16 @@ static void itc_blemanager_connected_dev_info_p(void)
 		conn_info.addr.mac[4],
 		conn_info.addr.mac[5]
 	);
-	ret = ble_manager_client_connect(ctx, &conn_info);
+	ret = ble_client_connect(ctx, &conn_info);
 	TC_ASSERT_EQ_CLEANUP("ble_client_connect", ret, BLE_MANAGER_SUCCESS, ble_manager_deinit());
 	ITC_FUNC_WAIT;
 
-	ble_manager_device_connected connected_dev;
-	ret = ble_manager_client_connected_info(ctx, &connected_dev);
+	ble_device_connected connected_dev;
+	ret = ble_client_connected_info(ctx, &connected_dev);
 	TC_ASSERT_EQ_CLEANUP("ble_client_connected_info", ret, BLE_MANAGER_SUCCESS, ble_manager_deinit());
 
 	//disconnect
-	ret = ble_manager_client_disconnect(ctx);
+	ret = ble_client_disconnect(ctx);
 	TC_ASSERT_EQ_CLEANUP("ble_client_disconnect", ret, BLE_MANAGER_SUCCESS, ble_manager_deinit());
 	ITC_FUNC_WAIT;
 
@@ -527,12 +527,12 @@ static void itc_blemanager_advertisement_p(void)
 	ble_data data[1] = { 0, };
 	data->data = g_adv_raw;
 	data->length = sizeof(g_adv_raw);
-	ret = ble_manager_server_set_adv_data(data);
+	ret = ble_server_set_adv_data(data);
 	TC_ASSERT_EQ_CLEANUP("ble_server_set_adv_data", ret, BLE_MANAGER_SUCCESS, ble_manager_deinit());
 	//set adv resp
 	data->data = g_adv_resp;
 	data->length = sizeof(g_adv_resp);
-	ret = ble_manager_server_set_adv_data(data);
+	ret = ble_server_set_adv_data(data);
 	TC_ASSERT_EQ_CLEANUP("ble_server_set_adv_data", ret, BLE_MANAGER_SUCCESS, ble_manager_deinit());
 	//set adv type
 	ble_adv_type_e type = BLE_ADV_TYPE_IND;
@@ -543,17 +543,17 @@ static void itc_blemanager_advertisement_p(void)
 			type,
 		}
 	};
-	ret = ble_manager_server_set_adv_type(type, &addr);
+	ret = ble_server_set_adv_type(type, &addr);
 	TC_ASSERT_EQ_CLEANUP("ble_server_set_adv_type", ret, BLE_MANAGER_SUCCESS, ble_manager_deinit());
 	//set adv interval
 	unsigned int interval = 10;
-	ret = ble_manager_server_set_adv_interval(interval);
+	ret = ble_server_set_adv_interval(interval);
 	TC_ASSERT_EQ_CLEANUP("ble_server_set_adv_interval", ret, BLE_MANAGER_SUCCESS, ble_manager_deinit());
 	//start adv
-	ret = ble_manager_server_start_adv();
+	ret = ble_server_start_adv();
 	TC_ASSERT_EQ_CLEANUP("ble_server_start_adv", ret, BLE_MANAGER_SUCCESS, ble_manager_deinit());
 	//stop adv
-	ret = ble_manager_server_stop_adv();
+	ret = ble_server_stop_adv();
 	TC_ASSERT_EQ_CLEANUP("ble_server_stop_adv", ret, BLE_MANAGER_SUCCESS, ble_manager_deinit());
 
 	ret = ble_manager_deinit();
@@ -579,12 +579,12 @@ static void itc_blemanager_readvertisement_p(void)
 	ble_data data[1] = { 0, };
 	data->data = g_adv_raw;
 	data->length = sizeof(g_adv_raw);
-	ret = ble_manager_server_set_adv_data(data);
+	ret = ble_server_set_adv_data(data);
 	TC_ASSERT_EQ_CLEANUP("ble_server_set_adv_data", ret, BLE_MANAGER_SUCCESS, ble_manager_deinit());
 	//set adv resp
 	data->data = g_adv_resp;
 	data->length = sizeof(g_adv_resp);
-	ret = ble_manager_server_set_adv_data(data);
+	ret = ble_server_set_adv_data(data);
 	TC_ASSERT_EQ_CLEANUP("ble_server_set_adv_data", ret, BLE_MANAGER_SUCCESS, ble_manager_deinit());
 	//set adv type
 	ble_adv_type_e type = BLE_ADV_TYPE_IND;
@@ -595,20 +595,20 @@ static void itc_blemanager_readvertisement_p(void)
 			type,
 		}
 	};
-	ret = ble_manager_server_set_adv_type(type, &addr);
+	ret = ble_server_set_adv_type(type, &addr);
 	TC_ASSERT_EQ_CLEANUP("ble_server_set_adv_type", ret, BLE_MANAGER_SUCCESS, ble_manager_deinit());
 	//set adv interval
 	unsigned int interval = 10;
-	ret = ble_manager_server_set_adv_interval(interval);
+	ret = ble_server_set_adv_interval(interval);
 	TC_ASSERT_EQ_CLEANUP("ble_server_set_adv_interval", ret, BLE_MANAGER_SUCCESS, ble_manager_deinit());
 	//start adv
-	ret = ble_manager_server_start_adv();
+	ret = ble_server_start_adv();
 	TC_ASSERT_EQ_CLEANUP("ble_server_start_adv", ret, BLE_MANAGER_SUCCESS, ble_manager_deinit());
 	//start adv
-	ret = ble_manager_server_start_adv();
+	ret = ble_server_start_adv();
 	TC_ASSERT_EQ_CLEANUP("ble_server_start_adv", ret, BLE_MANAGER_SUCCESS, ble_manager_deinit());
 	//stop adv
-	ret = ble_manager_server_stop_adv();
+	ret = ble_server_stop_adv();
 	TC_ASSERT_EQ_CLEANUP("ble_server_stop_adv", ret, BLE_MANAGER_SUCCESS, ble_manager_deinit());
 
 	ret = ble_manager_deinit();
@@ -620,7 +620,7 @@ static void itc_blemanager_readvertisement_p(void)
  * @testcase         itc_blemanager_whitelist_add_del_p
  * @brief            check initalization, whitelist add, whitelist delete,and de-initalization of ble manager
  * @scenario         check initalization, whitelist add, whitelist delete,and de-initalization of ble manager
- * @apicovered       ble_manager_init, ble_manager_scan_whitelist_add, ble_manager_scan_whitelist_delete, ble_manager_deinit
+ * @apicovered       ble_manager_init, ble_scan_whitelist_add, ble_scan_whitelist_delete, ble_manager_deinit
  * @precondition     none
  * @postcondition    none
  */
@@ -632,9 +632,9 @@ static void itc_blemanager_whitelist_add_del_p(void)
 
 	ble_addr addr;
 	memcpy(addr.mac, g_target.mac, BLE_BD_ADDR_MAX_LEN);
-	ret = ble_manager_scan_whitelist_add(&addr);
+	ret = ble_scan_whitelist_add(&addr);
 	TC_ASSERT_EQ_CLEANUP("ble_scan_whitelist_add", ret, BLE_MANAGER_SUCCESS, ble_manager_deinit());
-	ret = ble_manager_scan_whitelist_delete(&addr);
+	ret = ble_scan_whitelist_delete(&addr);
 	TC_ASSERT_EQ_CLEANUP("ble_scan_whitelist_delete", ret, BLE_MANAGER_SUCCESS, ble_manager_deinit());
 
 	ret = ble_manager_deinit();
@@ -656,7 +656,7 @@ static void itc_blemanager_get_profile_count_p(void) {
 	TC_ASSERT_EQ("ble_manager_init", ret, BLE_MANAGER_SUCCESS);
 
 	uint16_t count;
-	ret = ble_manager_server_get_profile_count(&count);
+	ret = ble_server_get_profile_count(&count);
 	TC_ASSERT_EQ_CLEANUP("ble_server_get_profile_count", ret, BLE_MANAGER_SUCCESS, ble_manager_deinit());
 
 	ret = ble_manager_deinit();
@@ -683,9 +683,9 @@ static void itc_blemanager_average_connect_time(void)
 	ret = ble_manager_init(NULL);
 	TC_ASSERT_EQ("ble_manager_init", ret, BLE_MANAGER_SUCCESS);
 
-	ble_manager_client_ctx *ctx;
-	ctx = ble_manager_client_create_ctx(&client_config);
-	ble_manager_conn_info conn_info = { 0, };
+	ble_client_ctx *ctx;
+	ctx = ble_client_create_ctx(&client_config);
+	ble_conn_info conn_info = { 0, };
 	memcpy(conn_info.addr.mac, g_target.mac, BLE_BD_ADDR_MAX_LEN);
 	conn_info.addr.type = BLE_ADV_TYPE_IND;
 	conn_info.conn_interval = 8;
@@ -696,13 +696,13 @@ static void itc_blemanager_average_connect_time(void)
 
 	for (i = 1; i <= LOOP_SIZE; i++) {
 		gettimeofday(&start_t, NULL);
-		ret = ble_manager_client_connect(ctx, &conn_info);
+		ret = ble_client_connect(ctx, &conn_info);
 		TC_ASSERT_EQ_CLEANUP("ble_client_connect", ret, BLE_MANAGER_SUCCESS, ble_manager_deinit());
 		ITC_FUNC_WAIT;
 		gettimeofday(&end_t, NULL);
 		average += diff_time(&start_t, &end_t);
 
-		ret = ble_manager_client_disconnect(ctx);
+		ret = ble_client_disconnect(ctx);
 		TC_ASSERT_EQ_CLEANUP("ble_client_disconnect", ret, BLE_MANAGER_SUCCESS, ble_manager_deinit());
 		ITC_FUNC_WAIT;
 		sleep(1);
@@ -733,9 +733,9 @@ static void itc_blemanager_average_disconnect_time(void)
 	ret = ble_manager_init(NULL);
 	TC_ASSERT_EQ("ble_manager_init", ret, BLE_MANAGER_SUCCESS);
 
-	ble_manager_client_ctx *ctx;
-	ctx = ble_manager_client_create_ctx(&client_config);
-	ble_manager_conn_info conn_info = { 0, };
+	ble_client_ctx *ctx;
+	ctx = ble_client_create_ctx(&client_config);
+	ble_conn_info conn_info = { 0, };
 	memcpy(conn_info.addr.mac, g_target.mac, BLE_BD_ADDR_MAX_LEN);
 	conn_info.addr.type = BLE_ADV_TYPE_IND;
 	conn_info.conn_interval = 8;
@@ -745,12 +745,12 @@ static void itc_blemanager_average_disconnect_time(void)
 	conn_info.is_secured_connect = true;
 
 	for (i = 1; i <= LOOP_SIZE; i++) {
-		ret = ble_manager_client_connect(ctx, &conn_info);
+		ret = ble_client_connect(ctx, &conn_info);
 		TC_ASSERT_EQ_CLEANUP("ble_client_connect", ret, BLE_MANAGER_SUCCESS, ble_manager_deinit());
 		ITC_FUNC_WAIT;
 
 		gettimeofday(&start_t, NULL);
-		ret = ble_manager_client_disconnect(ctx);
+		ret = ble_client_disconnect(ctx);
 		TC_ASSERT_EQ_CLEANUP("ble_client_disconnect", ret, BLE_MANAGER_SUCCESS, ble_manager_deinit());
 		ITC_FUNC_WAIT;
 		gettimeofday(&end_t, NULL);

--- a/apps/examples/testcase/ta_tc/ble_manager/utc/utc_blemanager_main.c
+++ b/apps/examples/testcase/ta_tc/ble_manager/utc/utc_blemanager_main.c
@@ -70,7 +70,7 @@ static void ble_device_scanned_cb(ble_scanned_device *scanned_device)
 	return;
 }
 
-static void ble_device_disconnected_cb(ble_manager_client_ctx *ctx)
+static void ble_device_disconnected_cb(ble_client_ctx *ctx)
 {
 	printf("client disconnected callback received\n");
 	g_client_connected = BEVT_DISCONNECTED;
@@ -78,7 +78,7 @@ static void ble_device_disconnected_cb(ble_manager_client_ctx *ctx)
 	return;
 }
 
-static void ble_manager_device_connected_cb(ble_manager_client_ctx *ctx, ble_manager_device_connected *dev)
+static void ble_device_connected_cb(ble_client_ctx *ctx, ble_device_connected *dev)
 {
 	printf("client connected callback received\n");
 	g_client_connected = BEVT_CONNECTED;
@@ -86,7 +86,7 @@ static void ble_manager_device_connected_cb(ble_manager_client_ctx *ctx, ble_man
 	return;
 }
 
-static void ble_operation_notification_cb(ble_manager_client_ctx *ctx, ble_attr_handle attr_handle, ble_data *read_result)
+static void ble_operation_notification_cb(ble_client_ctx *ctx, ble_attr_handle attr_handle, ble_data *read_result)
 {
 	printf("notification callback received\n");
 	g_client_noti = BEVT_NOTI;
@@ -94,35 +94,35 @@ static void ble_operation_notification_cb(ble_manager_client_ctx *ctx, ble_attr_
 	return;
 }
 
-static void ble_manager_server_connected_cb(ble_conn_handle con_handle, ble_manager_server_connection_type_e conn_type, uint8_t mac[BLE_BD_ADDR_MAX_LEN])
+static void ble_server_connected_cb(ble_conn_handle con_handle, ble_server_connection_type_e conn_type, uint8_t mac[BLE_BD_ADDR_MAX_LEN])
 {
 	printf("server connect callback received");
 	return;
 }
 
-static ble_manager_server_gatt_t gatt_profile[] = {
+static ble_server_gatt_t gatt_profile[] = {
 	{
-		.type = BLE_MANAGER_SERVER_GATT_SERVICE,
+		.type = BLE_SERVER_GATT_SERVICE,
 		.uuid = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x01, 0x01, 0x01, 0x01},
 		.uuid_length = 16,
 		.attr_handle = 0x006a,
 	},
 
 	{
-		.type = BLE_MANAGER_SERVER_GATT_CHARACT,
+		.type = BLE_SERVER_GATT_CHARACT,
 		.uuid = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x01, 0x01, 0x01, 0x02},
 		.uuid_length = 16,
-		.property = BLE_MANAGER_ATTR_PROP_RWN | BLE_MANAGER_ATTR_PROP_WRITE_NO_RSP,
-		.permission = BLE_MANAGER_ATTR_PERM_R_PERMIT | BLE_MANAGER_ATTR_PERM_W_PERMIT,
+		.property = BLE_ATTR_PROP_RWN | BLE_ATTR_PROP_WRITE_NO_RSP,
+		.permission = BLE_ATTR_PERM_R_PERMIT | BLE_ATTR_PERM_W_PERMIT,
 		.attr_handle = 0x006b,
 		.arg = "char_a_1"
 	},
 
 	{
-		.type = BLE_MANAGER_SERVER_GATT_DESC,
+		.type = BLE_SERVER_GATT_DESC,
 		.uuid = {0x02, 0x29},
 		.uuid_length = 2,
-		.permission = BLE_MANAGER_ATTR_PERM_R_PERMIT | BLE_MANAGER_ATTR_PERM_W_PERMIT,
+		.permission = BLE_ATTR_PERM_R_PERMIT | BLE_ATTR_PERM_W_PERMIT,
 		.attr_handle = 0x006c,
 		.arg = "desc_b_1",
 	},
@@ -140,17 +140,17 @@ static ble_scan_callback_list scan_config = {
 	ble_device_scanned_cb,
 };
 
-static ble_manager_client_callback_list client_config = {
+static ble_client_callback_list client_config = {
 	ble_device_disconnected_cb,
-	ble_manager_device_connected_cb,
+	ble_device_connected_cb,
 	ble_operation_notification_cb,
 };
 
-static ble_manager_server_init_config server_config = {
-	ble_manager_server_connected_cb,
+static ble_server_init_config server_config = {
+	ble_server_connected_cb,
 	true,
 	gatt_profile,
-	sizeof(gatt_profile) / sizeof(ble_manager_server_gatt_t)
+	sizeof(gatt_profile) / sizeof(ble_server_gatt_t)
 };
 
 static void set_scan_filter(ble_scan_filter *filter, uint8_t *raw_data, uint8_t len, bool whitelist_enable, uint32_t scan_duration)
@@ -219,10 +219,10 @@ static void utc_blemanager_get_bonded_device_p(void)
 	TC_ASSERT_EQ("ble_manager_init", ble_manager_init(NULL), BLE_MANAGER_SUCCESS);
 	ble_bonded_device_list dev_list[BLE_MAX_BONDED_DEVICE] = { 0, };
 	uint16_t dev_count = 0;
-	ble_manager_client_ctx *ctx;
-	ctx = ble_manager_client_create_ctx(&client_config);
+	ble_client_ctx *ctx;
+	ctx = ble_client_create_ctx(&client_config);
 	uint8_t dummy[] = {0x00, 0x1E, 0xC0, 0x04, 0x9F, 0xF3};
-	ble_manager_conn_info conn_info = { 0, };
+	ble_conn_info conn_info = { 0, };
 	memcpy(conn_info.addr.mac, dummy, BLE_BD_ADDR_MAX_LEN);
 	conn_info.addr.type = BLE_ADV_TYPE_IND;
 	conn_info.conn_interval = 8;
@@ -230,15 +230,15 @@ static void utc_blemanager_get_bonded_device_p(void)
 	conn_info.mtu = 240;
 	conn_info.scan_timeout = 1000;
 	conn_info.is_secured_connect = true;
-	TC_ASSERT_EQ_CLEANUP("ble_manager_client_connect", ble_manager_client_connect(ctx, &conn_info), BLE_MANAGER_SUCCESS, ble_manager_deinit());
+	TC_ASSERT_EQ_CLEANUP("ble_client_connect", ble_client_connect(ctx, &conn_info), BLE_MANAGER_SUCCESS, ble_manager_deinit());
 	CONTROL_VVDRIVER(VBLE_CMD_GEN_EVT, LWNL_EVT_BLE_CLIENT_CONNECT, 0, 3);
 	UTC_FUNC_WAIT;
-	TC_ASSERT_EQ_CLEANUP("ble_manager_client_connected cb", g_client_connected, BEVT_CONNECTED, ble_manager_deinit());
+	TC_ASSERT_EQ_CLEANUP("ble_client_connected cb", g_client_connected, BEVT_CONNECTED, ble_manager_deinit());
 	TC_ASSERT_EQ_CLEANUP("ble_manager_get_bonded_device", ble_manager_get_bonded_device(dev_list, &dev_count), BLE_MANAGER_SUCCESS, ble_manager_deinit());
-	TC_ASSERT_EQ_CLEANUP("ble_manager_client_disconnect", ble_manager_client_disconnect(ctx), BLE_MANAGER_SUCCESS, ble_manager_deinit());
+	TC_ASSERT_EQ_CLEANUP("ble_client_disconnect", ble_client_disconnect(ctx), BLE_MANAGER_SUCCESS, ble_manager_deinit());
 	CONTROL_VVDRIVER(VBLE_CMD_GEN_EVT, LWNL_EVT_BLE_CLIENT_DISCONNECT, 0, 3);
 	UTC_FUNC_WAIT;
-	TC_ASSERT_EQ_CLEANUP("ble_manager_client_disconnected cb", g_client_connected, BEVT_DISCONNECTED, ble_manager_deinit());
+	TC_ASSERT_EQ_CLEANUP("ble_client_disconnected cb", g_client_connected, BEVT_DISCONNECTED, ble_manager_deinit());
 	TC_ASSERT_EQ("ble_manager deinit", ble_manager_deinit(), BLE_MANAGER_SUCCESS);
 	TC_SUCCESS_RESULT();
 }
@@ -259,10 +259,10 @@ static void utc_blemanager_delete_bonded_device_p(void)
 	TC_ASSERT_EQ("ble_manager_init", ble_manager_init(NULL), BLE_MANAGER_SUCCESS);
 	ble_bonded_device_list dev_list[BLE_MAX_BONDED_DEVICE] = { 0, };
 	uint16_t dev_count = 0;
-	ble_manager_client_ctx *ctx;
-	ctx = ble_manager_client_create_ctx(&client_config);
+	ble_client_ctx *ctx;
+	ctx = ble_client_create_ctx(&client_config);
 	uint8_t dummy[] = {0x00, 0x1E, 0xC0, 0x04, 0x9F, 0xF3};
-	ble_manager_conn_info conn_info = { 0, };
+	ble_conn_info conn_info = { 0, };
 	memcpy(conn_info.addr.mac, dummy, BLE_BD_ADDR_MAX_LEN);
 	conn_info.addr.type = BLE_ADV_TYPE_IND;
 	conn_info.conn_interval = 8;
@@ -270,17 +270,17 @@ static void utc_blemanager_delete_bonded_device_p(void)
 	conn_info.mtu = 240;
 	conn_info.scan_timeout = 1000;
 	conn_info.is_secured_connect = true;
-	TC_ASSERT_EQ_CLEANUP("ble_manager_client_connect", ble_manager_client_connect(ctx, &conn_info), BLE_MANAGER_SUCCESS, ble_manager_deinit());
+	TC_ASSERT_EQ_CLEANUP("ble_client_connect", ble_client_connect(ctx, &conn_info), BLE_MANAGER_SUCCESS, ble_manager_deinit());
 	CONTROL_VVDRIVER(VBLE_CMD_GEN_EVT, LWNL_EVT_BLE_CLIENT_CONNECT, 0, 3);
 	UTC_FUNC_WAIT;
-	TC_ASSERT_EQ_CLEANUP("ble_manager_client_connected cb", g_client_connected, BEVT_CONNECTED, ble_manager_deinit());
+	TC_ASSERT_EQ_CLEANUP("ble_client_connected cb", g_client_connected, BEVT_CONNECTED, ble_manager_deinit());
 	TC_ASSERT_EQ_CLEANUP("ble_manager_get_bonded_device", ble_manager_get_bonded_device(dev_list, &dev_count), BLE_MANAGER_SUCCESS, ble_manager_deinit());
 	TC_ASSERT_EQ_CLEANUP("ble_manager_delete_bonded", ble_manager_delete_bonded(&conn_info.addr), BLE_MANAGER_SUCCESS, ble_manager_deinit());
 	TC_ASSERT_EQ_CLEANUP("ble_manager_get_bonded_device", ble_manager_get_bonded_device(dev_list, &dev_count), BLE_MANAGER_SUCCESS, ble_manager_deinit());
-	TC_ASSERT_EQ_CLEANUP("ble_manager_client_disconnect", ble_manager_client_disconnect(ctx), BLE_MANAGER_SUCCESS, ble_manager_deinit());
+	TC_ASSERT_EQ_CLEANUP("ble_client_disconnect", ble_client_disconnect(ctx), BLE_MANAGER_SUCCESS, ble_manager_deinit());
 	CONTROL_VVDRIVER(VBLE_CMD_GEN_EVT, LWNL_EVT_BLE_CLIENT_DISCONNECT, 0, 3);
 	UTC_FUNC_WAIT;
-	TC_ASSERT_EQ_CLEANUP("ble_manager_client_disconnected cb", g_client_connected, BEVT_DISCONNECTED, ble_manager_deinit());
+	TC_ASSERT_EQ_CLEANUP("ble_client_disconnected cb", g_client_connected, BEVT_DISCONNECTED, ble_manager_deinit());
 	TC_ASSERT_EQ("ble_manager deinit", ble_manager_deinit(), BLE_MANAGER_SUCCESS);
 	TC_SUCCESS_RESULT();
 }
@@ -301,10 +301,10 @@ static void utc_blemanager_delete_bonded_all_p(void)
 	TC_ASSERT_EQ("ble_manager_init", ble_manager_init(NULL), BLE_MANAGER_SUCCESS);
 	ble_bonded_device_list dev_list[BLE_MAX_BONDED_DEVICE] = { 0, };
 	uint16_t dev_count = 0;
-	ble_manager_client_ctx *ctx;
-	ctx = ble_manager_client_create_ctx(&client_config);
+	ble_client_ctx *ctx;
+	ctx = ble_client_create_ctx(&client_config);
 	uint8_t dummy[] = {0x00, 0x1E, 0xC0, 0x04, 0x9F, 0xF3};
-	ble_manager_conn_info conn_info = { 0, };
+	ble_conn_info conn_info = { 0, };
 	memcpy(conn_info.addr.mac, dummy, BLE_BD_ADDR_MAX_LEN);
 	conn_info.addr.type = BLE_ADV_TYPE_IND;
 	conn_info.conn_interval = 8;
@@ -312,17 +312,17 @@ static void utc_blemanager_delete_bonded_all_p(void)
 	conn_info.mtu = 240;
 	conn_info.scan_timeout = 1000;
 	conn_info.is_secured_connect = true;
-	TC_ASSERT_EQ_CLEANUP("ble_manager_client_connect", ble_manager_client_connect(ctx, &conn_info), BLE_MANAGER_SUCCESS, ble_manager_deinit());
+	TC_ASSERT_EQ_CLEANUP("ble_client_connect", ble_client_connect(ctx, &conn_info), BLE_MANAGER_SUCCESS, ble_manager_deinit());
 	CONTROL_VVDRIVER(VBLE_CMD_GEN_EVT, LWNL_EVT_BLE_CLIENT_CONNECT, 0, 3);
 	UTC_FUNC_WAIT;
-	TC_ASSERT_EQ_CLEANUP("ble_manager_client_connected cb", g_client_connected, BEVT_CONNECTED, ble_manager_deinit());
+	TC_ASSERT_EQ_CLEANUP("ble_client_connected cb", g_client_connected, BEVT_CONNECTED, ble_manager_deinit());
 	TC_ASSERT_EQ_CLEANUP("ble_manager_get_bonded_device", ble_manager_get_bonded_device(dev_list, &dev_count), BLE_MANAGER_SUCCESS, ble_manager_deinit());
 	TC_ASSERT_EQ_CLEANUP("ble_manager_delete_bonded_all", ble_manager_delete_bonded_all(), BLE_MANAGER_SUCCESS, ble_manager_deinit());
 	TC_ASSERT_EQ_CLEANUP("ble_manager_get_bonded_device", ble_manager_get_bonded_device(dev_list, &dev_count), BLE_MANAGER_SUCCESS, ble_manager_deinit());
-	TC_ASSERT_EQ_CLEANUP("ble_manager_client_disconnect", ble_manager_client_disconnect(ctx), BLE_MANAGER_SUCCESS, ble_manager_deinit());
+	TC_ASSERT_EQ_CLEANUP("ble_client_disconnect", ble_client_disconnect(ctx), BLE_MANAGER_SUCCESS, ble_manager_deinit());
 	CONTROL_VVDRIVER(VBLE_CMD_GEN_EVT, LWNL_EVT_BLE_CLIENT_DISCONNECT, 0, 3);
 	UTC_FUNC_WAIT;
-	TC_ASSERT_EQ_CLEANUP("ble_manager_client_disconnected cb", g_client_connected, BEVT_DISCONNECTED, ble_manager_deinit());
+	TC_ASSERT_EQ_CLEANUP("ble_client_disconnected cb", g_client_connected, BEVT_DISCONNECTED, ble_manager_deinit());
 	TC_ASSERT_EQ("ble_manager deinit", ble_manager_deinit(), BLE_MANAGER_SUCCESS);
 	TC_SUCCESS_RESULT();
 }
@@ -332,10 +332,10 @@ static void utc_blemanager_conn_active_p(void)
 	TC_ASSERT_EQ("ble_manager_init", ble_manager_init(NULL), BLE_MANAGER_SUCCESS);
 	ble_conn_handle conn_handle = 0;
 	bool is_active;
-	ble_manager_client_ctx *ctx;
-	ctx = ble_manager_client_create_ctx(&client_config);
+	ble_client_ctx *ctx;
+	ctx = ble_client_create_ctx(&client_config);
 	uint8_t dummy[] = {0x00, 0x1E, 0xC0, 0x04, 0x9F, 0xF3};
-	ble_manager_conn_info conn_info = { 0, };
+	ble_conn_info conn_info = { 0, };
 	memcpy(conn_info.addr.mac, dummy, BLE_BD_ADDR_MAX_LEN);
 	conn_info.addr.type = BLE_ADV_TYPE_IND;
 	conn_info.conn_interval = 8;
@@ -343,16 +343,16 @@ static void utc_blemanager_conn_active_p(void)
 	conn_info.mtu = 240;
 	conn_info.scan_timeout = 1000;
 	conn_info.is_secured_connect = true;
-	TC_ASSERT_EQ_CLEANUP("ble_manager_client_connect", ble_manager_client_connect(ctx, &conn_info), BLE_MANAGER_SUCCESS, ble_manager_deinit());
+	TC_ASSERT_EQ_CLEANUP("ble_client_connect", ble_client_connect(ctx, &conn_info), BLE_MANAGER_SUCCESS, ble_manager_deinit());
 	CONTROL_VVDRIVER(VBLE_CMD_GEN_EVT, LWNL_EVT_BLE_CLIENT_CONNECT, 0, 3);
 	UTC_FUNC_WAIT;
-	TC_ASSERT_EQ_CLEANUP("ble_manager_client_connected cb", g_client_connected, BEVT_CONNECTED, ble_manager_deinit());
+	TC_ASSERT_EQ_CLEANUP("ble_client_connected cb", g_client_connected, BEVT_CONNECTED, ble_manager_deinit());
 	TC_ASSERT_EQ_CLEANUP("ble_manager_conn_is_active", ble_manager_conn_is_active(conn_handle, &is_active), BLE_MANAGER_SUCCESS, ble_manager_deinit());
-	TC_ASSERT_EQ_CLEANUP("ble_manager_client_disconnect", ble_manager_client_disconnect(ctx), BLE_MANAGER_SUCCESS, ble_manager_deinit());
+	TC_ASSERT_EQ_CLEANUP("ble_client_disconnect", ble_client_disconnect(ctx), BLE_MANAGER_SUCCESS, ble_manager_deinit());
 	TC_ASSERT_EQ_CLEANUP("ble_manager_conn_is_active", ble_manager_conn_is_active(conn_handle, &is_active), BLE_MANAGER_SUCCESS, ble_manager_deinit());
 	CONTROL_VVDRIVER(VBLE_CMD_GEN_EVT, LWNL_EVT_BLE_CLIENT_DISCONNECT, 0, 3);
 	UTC_FUNC_WAIT;
-	TC_ASSERT_EQ_CLEANUP("ble_manager_client_disconnected cb", g_client_connected, BEVT_DISCONNECTED, ble_manager_deinit());
+	TC_ASSERT_EQ_CLEANUP("ble_client_disconnected cb", g_client_connected, BEVT_DISCONNECTED, ble_manager_deinit());
 	TC_ASSERT_EQ_CLEANUP("ble_manager_conn_is_active", ble_manager_conn_is_active(conn_handle, &is_active), BLE_MANAGER_SUCCESS, ble_manager_deinit());
 	TC_ASSERT_EQ("ble_manager deinit", ble_manager_deinit(), BLE_MANAGER_SUCCESS);
 	TC_SUCCESS_RESULT();
@@ -371,10 +371,10 @@ static void utc_blemanager_conn_any_active_p(void)
 {
 	TC_ASSERT_EQ("ble_manager_init", ble_manager_init(NULL), BLE_MANAGER_SUCCESS);
 	bool is_active;
-	ble_manager_client_ctx *ctx;
-	ctx = ble_manager_client_create_ctx(&client_config);
+	ble_client_ctx *ctx;
+	ctx = ble_client_create_ctx(&client_config);
 	uint8_t dummy[] = {0x00, 0x1E, 0xC0, 0x04, 0x9F, 0xF3};
-	ble_manager_conn_info conn_info = { 0, };
+	ble_conn_info conn_info = { 0, };
 	memcpy(conn_info.addr.mac, dummy, BLE_BD_ADDR_MAX_LEN);
 	conn_info.addr.type = BLE_ADV_TYPE_IND;
 	conn_info.conn_interval = 8;
@@ -382,16 +382,16 @@ static void utc_blemanager_conn_any_active_p(void)
 	conn_info.mtu = 240;
 	conn_info.scan_timeout = 1000;
 	conn_info.is_secured_connect = true;
-	TC_ASSERT_EQ_CLEANUP("ble_manager_client_connect", ble_manager_client_connect(ctx, &conn_info), BLE_MANAGER_SUCCESS, ble_manager_deinit());
+	TC_ASSERT_EQ_CLEANUP("ble_client_connect", ble_client_connect(ctx, &conn_info), BLE_MANAGER_SUCCESS, ble_manager_deinit());
 	CONTROL_VVDRIVER(VBLE_CMD_GEN_EVT, LWNL_EVT_BLE_CLIENT_CONNECT, 0, 3);
 	UTC_FUNC_WAIT;
-	TC_ASSERT_EQ_CLEANUP("ble_manager_client_connected cb", g_client_connected, BEVT_CONNECTED, ble_manager_deinit());
+	TC_ASSERT_EQ_CLEANUP("ble_client_connected cb", g_client_connected, BEVT_CONNECTED, ble_manager_deinit());
 	TC_ASSERT_EQ_CLEANUP("ble_manager_conn_is_active", ble_manager_conn_is_any_active(&is_active), BLE_MANAGER_SUCCESS, ble_manager_deinit());
-	TC_ASSERT_EQ_CLEANUP("ble_manager_client_disconnect", ble_manager_client_disconnect(ctx), BLE_MANAGER_SUCCESS, ble_manager_deinit());
+	TC_ASSERT_EQ_CLEANUP("ble_client_disconnect", ble_client_disconnect(ctx), BLE_MANAGER_SUCCESS, ble_manager_deinit());
 	TC_ASSERT_EQ_CLEANUP("ble_manager_conn_is_active", ble_manager_conn_is_any_active(&is_active), BLE_MANAGER_SUCCESS, ble_manager_deinit());
 	CONTROL_VVDRIVER(VBLE_CMD_GEN_EVT, LWNL_EVT_BLE_CLIENT_DISCONNECT, 0, 3);
 	UTC_FUNC_WAIT;
-	TC_ASSERT_EQ_CLEANUP("ble_manager_client_disconnected cb", g_client_connected, BEVT_DISCONNECTED, ble_manager_deinit());
+	TC_ASSERT_EQ_CLEANUP("ble_client_disconnected cb", g_client_connected, BEVT_DISCONNECTED, ble_manager_deinit());
 	TC_ASSERT_EQ_CLEANUP("ble_manager_conn_is_active", ble_manager_conn_is_any_active(&is_active), BLE_MANAGER_SUCCESS, ble_manager_deinit());
 	TC_ASSERT_EQ("ble_manager deinit", ble_manager_deinit(), BLE_MANAGER_SUCCESS);
 	TC_SUCCESS_RESULT();
@@ -403,7 +403,7 @@ static void utc_blemanager_set_adv_data_p(void)
 	ble_data data[1] = { 0, };
 	data->data = g_adv_raw;
 	data->length = sizeof(g_adv_raw);
-	TC_ASSERT_EQ_CLEANUP("ble_manager_server_set_adv_data", ble_manager_server_set_adv_data(data), BLE_MANAGER_SUCCESS, ble_manager_deinit());
+	TC_ASSERT_EQ_CLEANUP("ble_server_set_adv_data", ble_server_set_adv_data(data), BLE_MANAGER_SUCCESS, ble_manager_deinit());
 	TC_ASSERT_EQ("ble_manager deinit", ble_manager_deinit(), BLE_MANAGER_SUCCESS);
 	TC_SUCCESS_RESULT();
 }
@@ -411,7 +411,7 @@ static void utc_blemanager_set_adv_data_p(void)
 static void utc_blemanager_set_adv_data_n(void)
 {
 	TC_ASSERT_EQ("ble_manager_init", ble_manager_init(&server_config), BLE_MANAGER_SUCCESS);
-	TC_ASSERT_EQ("ble_manager_server_set_adv_data", ble_manager_server_set_adv_data(NULL), BLE_MANAGER_INVALID_ARGS);
+	TC_ASSERT_EQ("ble_server_set_adv_data", ble_server_set_adv_data(NULL), BLE_MANAGER_INVALID_ARGS);
 	TC_ASSERT_EQ("ble_manager deinit", ble_manager_deinit(), BLE_MANAGER_SUCCESS);
 	TC_SUCCESS_RESULT();
 }
@@ -422,7 +422,7 @@ static void utc_blemanager_set_adv_resp_p(void)
 	ble_data data[1] = { 0, };
 	data->data = g_adv_resp;
 	data->length = sizeof(g_adv_resp);
-	TC_ASSERT_EQ_CLEANUP("ble_manager_server_set_adv_resp", ble_manager_server_set_adv_resp(data), BLE_MANAGER_SUCCESS, ble_manager_deinit());
+	TC_ASSERT_EQ_CLEANUP("ble_server_set_adv_resp", ble_server_set_adv_resp(data), BLE_MANAGER_SUCCESS, ble_manager_deinit());
 	TC_ASSERT_EQ("ble_manager deinit", ble_manager_deinit(), BLE_MANAGER_SUCCESS);
 	TC_SUCCESS_RESULT();
 }
@@ -430,7 +430,7 @@ static void utc_blemanager_set_adv_resp_p(void)
 static void utc_blemanager_set_adv_resp_n(void)
 {
 	TC_ASSERT_EQ("ble_manager_init", ble_manager_init(&server_config), BLE_MANAGER_SUCCESS);
-	TC_ASSERT_EQ("ble_manager_server_set_adv_resp", ble_manager_server_set_adv_resp(NULL), BLE_MANAGER_INVALID_ARGS);
+	TC_ASSERT_EQ("ble_server_set_adv_resp", ble_server_set_adv_resp(NULL), BLE_MANAGER_INVALID_ARGS);
 	TC_ASSERT_EQ("ble_manager deinit", ble_manager_deinit(), BLE_MANAGER_SUCCESS);
 	TC_SUCCESS_RESULT();
 }
@@ -446,7 +446,7 @@ static void utc_blemanager_set_adv_type_p(void)
 			type,
 		}
 	};
-	TC_ASSERT_EQ_CLEANUP("ble_manager_server_set_adv_type", ble_manager_server_set_adv_type(type, &addr), BLE_MANAGER_SUCCESS, ble_manager_deinit());
+	TC_ASSERT_EQ_CLEANUP("ble_server_set_adv_type", ble_server_set_adv_type(type, &addr), BLE_MANAGER_SUCCESS, ble_manager_deinit());
 	TC_ASSERT_EQ("ble_manager deinit", ble_manager_deinit(), BLE_MANAGER_SUCCESS);
 	TC_SUCCESS_RESULT();
 }
@@ -455,7 +455,7 @@ static void utc_blemanager_set_adv_type_n(void)
 {
 	TC_ASSERT_EQ("ble_manager_init", ble_manager_init(&server_config), BLE_MANAGER_SUCCESS);
 	ble_adv_type_e type = BLE_ADV_TYPE_IND;
-	TC_ASSERT_EQ("ble_manager_server_set_adv_type", ble_manager_server_set_adv_type(type, NULL), BLE_MANAGER_INVALID_ARGS);
+	TC_ASSERT_EQ("ble_server_set_adv_type", ble_server_set_adv_type(type, NULL), BLE_MANAGER_INVALID_ARGS);
 	TC_ASSERT_EQ("ble_manager deinit", ble_manager_deinit(), BLE_MANAGER_SUCCESS);
 	TC_SUCCESS_RESULT();
 }
@@ -464,7 +464,7 @@ static void utc_blemanager_set_adv_interval_p(void)
 {
 	TC_ASSERT_EQ("ble_manager_init", ble_manager_init(&server_config), BLE_MANAGER_SUCCESS);
 	unsigned int interval = 10;
-	TC_ASSERT_EQ_CLEANUP("ble_manager_server_set_adv_interval", ble_manager_server_set_adv_interval(interval), BLE_MANAGER_SUCCESS, ble_manager_deinit());
+	TC_ASSERT_EQ_CLEANUP("ble_server_set_adv_interval", ble_server_set_adv_interval(interval), BLE_MANAGER_SUCCESS, ble_manager_deinit());
 	TC_ASSERT_EQ("ble_manager deinit", ble_manager_deinit(), BLE_MANAGER_SUCCESS);
 	TC_SUCCESS_RESULT();
 }
@@ -472,8 +472,8 @@ static void utc_blemanager_set_adv_interval_p(void)
 static void utc_blemanager_start_adv_p(void)
 {
 	TC_ASSERT_EQ("ble_manager_init", ble_manager_init(&server_config), BLE_MANAGER_SUCCESS);
-	TC_ASSERT_EQ_CLEANUP("ble_manager_server_start_adv", ble_manager_server_start_adv(), BLE_MANAGER_SUCCESS, ble_manager_deinit());
-	TC_ASSERT_EQ_CLEANUP("ble_manager_server_stop_adv", ble_manager_server_stop_adv(), BLE_MANAGER_SUCCESS, ble_manager_deinit());
+	TC_ASSERT_EQ_CLEANUP("ble_server_start_adv", ble_server_start_adv(), BLE_MANAGER_SUCCESS, ble_manager_deinit());
+	TC_ASSERT_EQ_CLEANUP("ble_server_stop_adv", ble_server_stop_adv(), BLE_MANAGER_SUCCESS, ble_manager_deinit());
 	TC_ASSERT_EQ("ble_manager deinit", ble_manager_deinit(), BLE_MANAGER_SUCCESS);
 	TC_SUCCESS_RESULT();
 }
@@ -481,8 +481,8 @@ static void utc_blemanager_start_adv_p(void)
 static void utc_blemanager_stop_adv_p(void)
 {
 	TC_ASSERT_EQ("ble_manager_init", ble_manager_init(&server_config), BLE_MANAGER_SUCCESS);
-	TC_ASSERT_EQ_CLEANUP("ble_manager_server_start_adv", ble_manager_server_start_adv(), BLE_MANAGER_SUCCESS, ble_manager_deinit());
-	TC_ASSERT_EQ_CLEANUP("ble_manager_server_stop_adv", ble_manager_server_stop_adv(), BLE_MANAGER_SUCCESS, ble_manager_deinit());
+	TC_ASSERT_EQ_CLEANUP("ble_server_start_adv", ble_server_start_adv(), BLE_MANAGER_SUCCESS, ble_manager_deinit());
+	TC_ASSERT_EQ_CLEANUP("ble_server_stop_adv", ble_server_stop_adv(), BLE_MANAGER_SUCCESS, ble_manager_deinit());
 	TC_ASSERT_EQ("ble_manager deinit", ble_manager_deinit(), BLE_MANAGER_SUCCESS);
 	TC_SUCCESS_RESULT();
 }
@@ -490,14 +490,14 @@ static void utc_blemanager_stop_adv_p(void)
 static void utc_blemanager_get_profile_count_p(void) {
 	TC_ASSERT_EQ("ble_manager_init", ble_manager_init(&server_config), BLE_MANAGER_SUCCESS);
 	uint16_t count;
-	TC_ASSERT_EQ_CLEANUP("ble_manager_server_get_profile_count", ble_manager_server_get_profile_count(&count), BLE_MANAGER_SUCCESS, ble_manager_deinit());
+	TC_ASSERT_EQ_CLEANUP("ble_server_get_profile_count", ble_server_get_profile_count(&count), BLE_MANAGER_SUCCESS, ble_manager_deinit());
 	TC_ASSERT_EQ("ble_manager deinit", ble_manager_deinit(), BLE_MANAGER_SUCCESS);
 	TC_SUCCESS_RESULT();
 }
 
 static void utc_blemanager_get_profile_count_n(void) {
 	TC_ASSERT_EQ("ble_manager_init", ble_manager_init(&server_config), BLE_MANAGER_SUCCESS);
-	TC_ASSERT_EQ("ble_manager_server_get_profile_count", ble_manager_server_get_profile_count(NULL), BLE_MANAGER_INVALID_ARGS);
+	TC_ASSERT_EQ("ble_server_get_profile_count", ble_server_get_profile_count(NULL), BLE_MANAGER_INVALID_ARGS);
 	TC_ASSERT_EQ("ble_manager deinit", ble_manager_deinit(), BLE_MANAGER_SUCCESS);
 	TC_SUCCESS_RESULT();
 }
@@ -508,7 +508,7 @@ static void utc_blemanager_attr_set_data_p(void)
 	ble_attr_handle attr_handle = 0x006b + 1;
 	uint8_t buf[256] = { 0, };
 	ble_data in_data = { buf, sizeof(buf) };
-	TC_ASSERT_EQ_CLEANUP("ble_manager_server_attr_set_data", ble_manager_server_attr_set_data(attr_handle, &in_data), BLE_MANAGER_SUCCESS, ble_manager_deinit());
+	TC_ASSERT_EQ_CLEANUP("ble_server_attr_set_data", ble_server_attr_set_data(attr_handle, &in_data), BLE_MANAGER_SUCCESS, ble_manager_deinit());
 	TC_ASSERT_EQ("ble_manager deinit", ble_manager_deinit(), BLE_MANAGER_SUCCESS);
 	TC_SUCCESS_RESULT();
 }
@@ -517,7 +517,7 @@ static void utc_blemanager_attr_set_data_n(void)
 {
 	TC_ASSERT_EQ("ble_manager_init", ble_manager_init(&server_config), BLE_MANAGER_SUCCESS);
 	ble_attr_handle attr_handle = 0x006b + 1;
-	TC_ASSERT_EQ("ble_manager_server_attr_set_data", ble_manager_server_attr_set_data(attr_handle, NULL), BLE_MANAGER_INVALID_ARGS);
+	TC_ASSERT_EQ("ble_server_attr_set_data", ble_server_attr_set_data(attr_handle, NULL), BLE_MANAGER_INVALID_ARGS);
 	TC_ASSERT_EQ("ble_manager deinit", ble_manager_deinit(), BLE_MANAGER_SUCCESS);
 	TC_SUCCESS_RESULT();
 }
@@ -528,9 +528,9 @@ static void utc_blemanager_attr_get_data_p(void)
 	ble_attr_handle attr_handle = 0x006b + 1;
 	uint8_t buf[256] = { 0, };
 	ble_data in_data = { buf, sizeof(buf) };
-	TC_ASSERT_EQ_CLEANUP("ble_manager_server_attr_set_data", ble_manager_server_attr_set_data(attr_handle, &in_data), BLE_MANAGER_SUCCESS, ble_manager_deinit());
+	TC_ASSERT_EQ_CLEANUP("ble_server_attr_set_data", ble_server_attr_set_data(attr_handle, &in_data), BLE_MANAGER_SUCCESS, ble_manager_deinit());
 	ble_data out_data;
-	TC_ASSERT_EQ_CLEANUP("ble_manager_server_attr_get_data", ble_manager_server_attr_get_data(attr_handle, &out_data), BLE_MANAGER_SUCCESS, ble_manager_deinit());
+	TC_ASSERT_EQ_CLEANUP("ble_server_attr_get_data", ble_server_attr_get_data(attr_handle, &out_data), BLE_MANAGER_SUCCESS, ble_manager_deinit());
 	TC_ASSERT_EQ("ble_manager deinit", ble_manager_deinit(), BLE_MANAGER_SUCCESS);
 	TC_SUCCESS_RESULT();
 }
@@ -539,7 +539,7 @@ static void utc_blemanager_attr_get_data_n(void)
 {
 	TC_ASSERT_EQ("ble_manager_init", ble_manager_init(&server_config), BLE_MANAGER_SUCCESS);
 	ble_attr_handle attr_handle = 0x006b + 1;
-	TC_ASSERT_EQ("ble_manager_server_attr_get_data", ble_manager_server_attr_get_data(attr_handle, NULL), BLE_MANAGER_INVALID_ARGS);
+	TC_ASSERT_EQ("ble_server_attr_get_data", ble_server_attr_get_data(attr_handle, NULL), BLE_MANAGER_INVALID_ARGS);
 	TC_ASSERT_EQ("ble_manager deinit", ble_manager_deinit(), BLE_MANAGER_SUCCESS);
 	TC_SUCCESS_RESULT();
 }
@@ -549,7 +549,7 @@ static void utc_blemanager_reject_p(void)
 	TC_ASSERT_EQ("ble_manager_init", ble_manager_init(&server_config), BLE_MANAGER_SUCCESS);
 	ble_attr_handle attr_handle = 0x006b + 1;
 	uint8_t err_code = 0x02;
-	TC_ASSERT_EQ_CLEANUP("ble_manager_server_reject", ble_manager_server_reject(attr_handle, err_code), BLE_MANAGER_SUCCESS, ble_manager_deinit());
+	TC_ASSERT_EQ_CLEANUP("ble_server_reject", ble_server_reject(attr_handle, err_code), BLE_MANAGER_SUCCESS, ble_manager_deinit());
 	TC_ASSERT_EQ("ble_manager deinit", ble_manager_deinit(), BLE_MANAGER_SUCCESS);
 	TC_SUCCESS_RESULT();
 }
@@ -558,40 +558,40 @@ static void utc_blemanager_client_start_scan_p(void)
 {
 	TC_ASSERT_EQ("ble_manager_init", ble_manager_init(NULL), BLE_MANAGER_SUCCESS);
 	//no filter scan
-	TC_ASSERT_EQ_CLEANUP("ble_manager_client_start_scan", ble_manager_client_start_scan(NULL, &scan_config), BLE_MANAGER_SUCCESS, ble_manager_deinit());
+	TC_ASSERT_EQ_CLEANUP("ble_client_start_scan", ble_client_start_scan(NULL, &scan_config), BLE_MANAGER_SUCCESS, ble_manager_deinit());
 	CONTROL_VVDRIVER(VBLE_CMD_GEN_EVT, LWNL_EVT_BLE_SCAN_STATE, BLE_SCAN_STARTED, 3);
 	UTC_FUNC_WAIT;
-	TC_ASSERT_EQ_CLEANUP("ble_manager_client_stop_scan cb", g_scan_state, BLE_SCAN_STARTED, ble_manager_deinit());
-	TC_ASSERT_EQ_CLEANUP("ble_manager_client_stop_scan", ble_manager_client_stop_scan(), BLE_MANAGER_SUCCESS, ble_manager_deinit());
+	TC_ASSERT_EQ_CLEANUP("ble_client_stop_scan cb", g_scan_state, BLE_SCAN_STARTED, ble_manager_deinit());
+	TC_ASSERT_EQ_CLEANUP("ble_client_stop_scan", ble_client_stop_scan(), BLE_MANAGER_SUCCESS, ble_manager_deinit());
 	CONTROL_VVDRIVER(VBLE_CMD_GEN_EVT, LWNL_EVT_BLE_SCAN_STATE, BLE_SCAN_STOPPED, 3);
 	UTC_FUNC_WAIT;
-	TC_ASSERT_EQ_CLEANUP("ble_manager_client_stop_scan cb", g_scan_state, BLE_SCAN_STOPPED, ble_manager_deinit());
+	TC_ASSERT_EQ_CLEANUP("ble_client_stop_scan cb", g_scan_state, BLE_SCAN_STOPPED, ble_manager_deinit());
 	//filter scan without whitelist
 	ble_scan_filter filter = { 0, };
 	set_scan_filter(&filter, ble_filter, sizeof(ble_filter), false, 1000);
-	TC_ASSERT_EQ_CLEANUP("ble_manager_client_start_scan", ble_manager_client_start_scan(&filter, &scan_config), BLE_MANAGER_SUCCESS, ble_manager_deinit());
+	TC_ASSERT_EQ_CLEANUP("ble_client_start_scan", ble_client_start_scan(&filter, &scan_config), BLE_MANAGER_SUCCESS, ble_manager_deinit());
 	CONTROL_VVDRIVER(VBLE_CMD_GEN_EVT, LWNL_EVT_BLE_SCAN_STATE, BLE_SCAN_STARTED, 3);
 	UTC_FUNC_WAIT;
-	TC_ASSERT_EQ_CLEANUP("ble_manager_client_stop_scan cb", g_scan_state, BLE_SCAN_STARTED, ble_manager_deinit());
-	TC_ASSERT_EQ_CLEANUP("ble_manager_client_stop_scan", ble_manager_client_stop_scan(), BLE_MANAGER_SUCCESS, ble_manager_deinit());
+	TC_ASSERT_EQ_CLEANUP("ble_client_stop_scan cb", g_scan_state, BLE_SCAN_STARTED, ble_manager_deinit());
+	TC_ASSERT_EQ_CLEANUP("ble_client_stop_scan", ble_client_stop_scan(), BLE_MANAGER_SUCCESS, ble_manager_deinit());
 	CONTROL_VVDRIVER(VBLE_CMD_GEN_EVT, LWNL_EVT_BLE_SCAN_STATE, BLE_SCAN_STOPPED, 3);
 	UTC_FUNC_WAIT;
-	TC_ASSERT_EQ_CLEANUP("ble_manager_client_stop_scan cb", g_scan_state, BLE_SCAN_STOPPED, ble_manager_deinit());
+	TC_ASSERT_EQ_CLEANUP("ble_client_stop_scan cb", g_scan_state, BLE_SCAN_STOPPED, ble_manager_deinit());
 	//scan with whitelist
 	set_scan_filter(&filter, NULL, 0, true, 1000);
 	ble_addr addr;
 	addr.type = BLE_ADV_TYPE_IND;
 	uint8_t dummy[] = {0x01, 0x1E, 0xC0, 0x04, 0x9F, 0xF6};
 	memcpy(addr.mac, dummy, BLE_BD_ADDR_MAX_LEN);
-	TC_ASSERT_EQ_CLEANUP("ble_scan_whitelist_add", ble_manager_scan_whitelist_add(&addr), BLE_MANAGER_SUCCESS, ble_manager_deinit());
-	TC_ASSERT_EQ_CLEANUP("ble_manager_client_start_scan", ble_manager_client_start_scan(&filter, &scan_config), BLE_MANAGER_SUCCESS, ble_manager_deinit());
+	TC_ASSERT_EQ_CLEANUP("ble_scan_whitelist_add", ble_scan_whitelist_add(&addr), BLE_MANAGER_SUCCESS, ble_manager_deinit());
+	TC_ASSERT_EQ_CLEANUP("ble_client_start_scan", ble_client_start_scan(&filter, &scan_config), BLE_MANAGER_SUCCESS, ble_manager_deinit());
 	CONTROL_VVDRIVER(VBLE_CMD_GEN_EVT, LWNL_EVT_BLE_SCAN_STATE, BLE_SCAN_STARTED, 3);
 	UTC_FUNC_WAIT;
-	TC_ASSERT_EQ_CLEANUP("ble_manager_client_stop_scan cb", g_scan_state, BLE_SCAN_STARTED, ble_manager_deinit());
-	TC_ASSERT_EQ_CLEANUP("ble_manager_client_stop_scan", ble_manager_client_stop_scan(), BLE_MANAGER_SUCCESS, ble_manager_deinit());
+	TC_ASSERT_EQ_CLEANUP("ble_client_stop_scan cb", g_scan_state, BLE_SCAN_STARTED, ble_manager_deinit());
+	TC_ASSERT_EQ_CLEANUP("ble_client_stop_scan", ble_client_stop_scan(), BLE_MANAGER_SUCCESS, ble_manager_deinit());
 	CONTROL_VVDRIVER(VBLE_CMD_GEN_EVT, LWNL_EVT_BLE_SCAN_STATE, BLE_SCAN_STOPPED, 3);
 	UTC_FUNC_WAIT;
-	TC_ASSERT_EQ_CLEANUP("ble_manager_client_stop_scan cb", g_scan_state, BLE_SCAN_STOPPED, ble_manager_deinit());
+	TC_ASSERT_EQ_CLEANUP("ble_client_stop_scan cb", g_scan_state, BLE_SCAN_STOPPED, ble_manager_deinit());
 	TC_ASSERT_EQ("ble_manager deinit", ble_manager_deinit(), BLE_MANAGER_SUCCESS);
 	TC_SUCCESS_RESULT();
 }
@@ -599,13 +599,13 @@ static void utc_blemanager_client_start_scan_p(void)
 static void utc_blemanager_client_stop_scan_p(void)
 {
 	TC_ASSERT_EQ("ble_manager_init", ble_manager_init(NULL), BLE_MANAGER_SUCCESS);
-	TC_ASSERT_EQ_CLEANUP("ble_manager_client_start_scan", ble_manager_client_start_scan(NULL, &scan_config), BLE_MANAGER_SUCCESS, ble_manager_deinit());
+	TC_ASSERT_EQ_CLEANUP("ble_client_start_scan", ble_client_start_scan(NULL, &scan_config), BLE_MANAGER_SUCCESS, ble_manager_deinit());
 	CONTROL_VVDRIVER(VBLE_CMD_GEN_EVT, LWNL_EVT_BLE_SCAN_STATE, BLE_SCAN_STARTED, 3);
 	UTC_FUNC_WAIT;
-	TC_ASSERT_EQ_CLEANUP("ble_manager_client_stop_scan", ble_manager_client_stop_scan(), BLE_MANAGER_SUCCESS, ble_manager_deinit());
+	TC_ASSERT_EQ_CLEANUP("ble_client_stop_scan", ble_client_stop_scan(), BLE_MANAGER_SUCCESS, ble_manager_deinit());
 	CONTROL_VVDRIVER(VBLE_CMD_GEN_EVT, LWNL_EVT_BLE_SCAN_STATE, BLE_SCAN_STOPPED, 3);
 	UTC_FUNC_WAIT;
-	TC_ASSERT_EQ_CLEANUP("ble_manager_client_start_scan cb", g_scan_state, BLE_SCAN_STOPPED, ble_manager_deinit());
+	TC_ASSERT_EQ_CLEANUP("ble_client_start_scan cb", g_scan_state, BLE_SCAN_STOPPED, ble_manager_deinit());
 	TC_ASSERT_EQ("ble_manager deinit", ble_manager_deinit(), BLE_MANAGER_SUCCESS);
 	TC_SUCCESS_RESULT();
 }
@@ -619,8 +619,8 @@ static void utc_blemanager_whitelist_add_p(void)
 	addr.type = BLE_ADV_TYPE_IND;
 	uint8_t dummy[] = {0x01, 0x1E, 0xC0, 0x04, 0x9F, 0xF6};
 	memcpy(addr.mac, dummy, BLE_BD_ADDR_MAX_LEN);
-	TC_ASSERT_EQ_CLEANUP("ble_scan_whitelist_add", ble_manager_scan_whitelist_add(&addr), BLE_MANAGER_SUCCESS, ble_manager_deinit());
-	TC_ASSERT_EQ_CLEANUP("ble_scan_whitelist_delete", ble_manager_scan_whitelist_delete(&addr), BLE_MANAGER_SUCCESS, ble_manager_deinit());
+	TC_ASSERT_EQ_CLEANUP("ble_scan_whitelist_add", ble_scan_whitelist_add(&addr), BLE_MANAGER_SUCCESS, ble_manager_deinit());
+	TC_ASSERT_EQ_CLEANUP("ble_scan_whitelist_delete", ble_scan_whitelist_delete(&addr), BLE_MANAGER_SUCCESS, ble_manager_deinit());
 	TC_ASSERT_EQ("ble_manager deinit", ble_manager_deinit(), BLE_MANAGER_SUCCESS);
 	TC_SUCCESS_RESULT();
 }
@@ -628,7 +628,7 @@ static void utc_blemanager_whitelist_add_p(void)
 static void utc_blemanager_whitelist_add_n(void)
 {
 	TC_ASSERT_EQ("ble_manager_init", ble_manager_init(NULL), BLE_MANAGER_SUCCESS);
-	TC_ASSERT_EQ("ble_scan_whitelist_add", ble_manager_scan_whitelist_add(NULL), BLE_MANAGER_INVALID_ARGS);
+	TC_ASSERT_EQ("ble_scan_whitelist_add", ble_scan_whitelist_add(NULL), BLE_MANAGER_INVALID_ARGS);
 	TC_ASSERT_EQ("ble_manager deinit", ble_manager_deinit(), BLE_MANAGER_SUCCESS);
 	TC_SUCCESS_RESULT();
 }
@@ -642,8 +642,8 @@ static void utc_blemanager_whitelist_del_p(void)
 	addr.type = BLE_ADV_TYPE_IND;
 	uint8_t dummy[] = {0x01, 0x1E, 0xC0, 0x04, 0x9F, 0xF6};
 	memcpy(addr.mac, dummy, BLE_BD_ADDR_MAX_LEN);
-	TC_ASSERT_EQ_CLEANUP("ble_scan_whitelist_add", ble_manager_scan_whitelist_add(&addr), BLE_MANAGER_SUCCESS, ble_manager_deinit());
-	TC_ASSERT_EQ_CLEANUP("ble_scan_whitelist_delete", ble_manager_scan_whitelist_delete(&addr), BLE_MANAGER_SUCCESS, ble_manager_deinit());
+	TC_ASSERT_EQ_CLEANUP("ble_scan_whitelist_add", ble_scan_whitelist_add(&addr), BLE_MANAGER_SUCCESS, ble_manager_deinit());
+	TC_ASSERT_EQ_CLEANUP("ble_scan_whitelist_delete", ble_scan_whitelist_delete(&addr), BLE_MANAGER_SUCCESS, ble_manager_deinit());
 	TC_ASSERT_EQ("ble_manager deinit", ble_manager_deinit(), BLE_MANAGER_SUCCESS);
 	TC_SUCCESS_RESULT();
 }
@@ -651,7 +651,7 @@ static void utc_blemanager_whitelist_del_p(void)
 static void utc_blemanager_whitelist_del_n(void)
 {
 	TC_ASSERT_EQ("ble_manager_init", ble_manager_init(NULL), BLE_MANAGER_SUCCESS);
-	TC_ASSERT_EQ("ble_scan_whitelist_add", ble_manager_scan_whitelist_delete(NULL), BLE_MANAGER_INVALID_ARGS);
+	TC_ASSERT_EQ("ble_scan_whitelist_add", ble_scan_whitelist_delete(NULL), BLE_MANAGER_INVALID_ARGS);
 	TC_ASSERT_EQ("ble_manager deinit", ble_manager_deinit(), BLE_MANAGER_SUCCESS);
 	TC_SUCCESS_RESULT();
 }
@@ -665,8 +665,8 @@ static void utc_blemanager_whitelist_clear_all_p(void)
 	addr.type = BLE_ADV_TYPE_IND;
 	uint8_t dummy[] = {0x01, 0x1E, 0xC0, 0x04, 0x9F, 0xF6};
 	memcpy(addr.mac, dummy, BLE_BD_ADDR_MAX_LEN);
-	TC_ASSERT_EQ_CLEANUP("ble_scan_whitelist_add", ble_manager_scan_whitelist_add(&addr), BLE_MANAGER_SUCCESS, ble_manager_deinit());
-	TC_ASSERT_EQ_CLEANUP("ble_scan_whitelist_clear_all", ble_manager_scan_whitelist_clear_all(), BLE_MANAGER_SUCCESS, ble_manager_deinit());
+	TC_ASSERT_EQ_CLEANUP("ble_scan_whitelist_add", ble_scan_whitelist_add(&addr), BLE_MANAGER_SUCCESS, ble_manager_deinit());
+	TC_ASSERT_EQ_CLEANUP("ble_scan_whitelist_clear_all", ble_scan_whitelist_clear_all(), BLE_MANAGER_SUCCESS, ble_manager_deinit());
 	TC_ASSERT_EQ("ble_manager deinit", ble_manager_deinit(), BLE_MANAGER_SUCCESS);
 	TC_SUCCESS_RESULT();
 }
@@ -674,10 +674,10 @@ static void utc_blemanager_whitelist_clear_all_p(void)
 static void utc_blemanager_client_connect_p(void)
 {
 	TC_ASSERT_EQ("ble_manager_init", ble_manager_init(NULL), BLE_MANAGER_SUCCESS);//not server role
-	ble_manager_client_ctx *ctx;
-	ctx = ble_manager_client_create_ctx(&client_config);
+	ble_client_ctx *ctx;
+	ctx = ble_client_create_ctx(&client_config);
 	uint8_t dummy[] = {0x00, 0x1E, 0xC0, 0x04, 0x9F, 0xF3};
-	ble_manager_conn_info conn_info = { 0, };
+	ble_conn_info conn_info = { 0, };
 	memcpy(conn_info.addr.mac, dummy, BLE_BD_ADDR_MAX_LEN);
 	conn_info.addr.type = BLE_ADV_TYPE_IND;
 	conn_info.conn_interval = 8;
@@ -685,14 +685,14 @@ static void utc_blemanager_client_connect_p(void)
 	conn_info.mtu = 240;
 	conn_info.scan_timeout = 1000;
 	conn_info.is_secured_connect = true;
-	TC_ASSERT_EQ_CLEANUP("ble_manager_client_connect", ble_manager_client_connect(ctx, &conn_info), BLE_MANAGER_SUCCESS, ble_manager_deinit());
+	TC_ASSERT_EQ_CLEANUP("ble_client_connect", ble_client_connect(ctx, &conn_info), BLE_MANAGER_SUCCESS, ble_manager_deinit());
 	CONTROL_VVDRIVER(VBLE_CMD_GEN_EVT, LWNL_EVT_BLE_CLIENT_CONNECT, 0, 3);
 	UTC_FUNC_WAIT;
-	TC_ASSERT_EQ_CLEANUP("ble_manager_client_connected cb", g_client_connected, BEVT_CONNECTED, ble_manager_deinit());
-	TC_ASSERT_EQ_CLEANUP("ble_manager_client_disconnect", ble_manager_client_disconnect(ctx), BLE_MANAGER_SUCCESS, ble_manager_deinit());
+	TC_ASSERT_EQ_CLEANUP("ble_client_connected cb", g_client_connected, BEVT_CONNECTED, ble_manager_deinit());
+	TC_ASSERT_EQ_CLEANUP("ble_client_disconnect", ble_client_disconnect(ctx), BLE_MANAGER_SUCCESS, ble_manager_deinit());
 	CONTROL_VVDRIVER(VBLE_CMD_GEN_EVT, LWNL_EVT_BLE_CLIENT_DISCONNECT, 0, 3);
 	UTC_FUNC_WAIT;
-	TC_ASSERT_EQ_CLEANUP("ble_manager_client_disconnected cb", g_client_connected, BEVT_DISCONNECTED, ble_manager_deinit());
+	TC_ASSERT_EQ_CLEANUP("ble_client_disconnected cb", g_client_connected, BEVT_DISCONNECTED, ble_manager_deinit());
 	TC_ASSERT_EQ("ble_manager deinit", ble_manager_deinit(), BLE_MANAGER_SUCCESS);
 	TC_SUCCESS_RESULT();
 }
@@ -700,10 +700,10 @@ static void utc_blemanager_client_connect_p(void)
 static void utc_blemanager_client_disconnect_p(void)
 {
 	TC_ASSERT_EQ("ble_manager_init", ble_manager_init(NULL), BLE_MANAGER_SUCCESS);//not server role
-	ble_manager_client_ctx *ctx;
-	ctx = ble_manager_client_create_ctx(&client_config);
+	ble_client_ctx *ctx;
+	ctx = ble_client_create_ctx(&client_config);
 	uint8_t dummy[] = {0x00, 0x1E, 0xC0, 0x04, 0x9F, 0xF3};
-	ble_manager_conn_info conn_info = { 0, };
+	ble_conn_info conn_info = { 0, };
 	memcpy(conn_info.addr.mac, dummy, BLE_BD_ADDR_MAX_LEN);
 	conn_info.addr.type = BLE_ADV_TYPE_IND;
 	conn_info.conn_interval = 8;
@@ -711,14 +711,14 @@ static void utc_blemanager_client_disconnect_p(void)
 	conn_info.mtu = 240;
 	conn_info.scan_timeout = 1000;
 	conn_info.is_secured_connect = true;
-	TC_ASSERT_EQ_CLEANUP("ble_manager_client_connect", ble_manager_client_connect(ctx, &conn_info), BLE_MANAGER_SUCCESS, ble_manager_deinit());
+	TC_ASSERT_EQ_CLEANUP("ble_client_connect", ble_client_connect(ctx, &conn_info), BLE_MANAGER_SUCCESS, ble_manager_deinit());
 	CONTROL_VVDRIVER(VBLE_CMD_GEN_EVT, LWNL_EVT_BLE_CLIENT_CONNECT, 0, 3);
 	UTC_FUNC_WAIT;
-	TC_ASSERT_EQ_CLEANUP("ble_manager_client_connected cb", g_client_connected, BEVT_CONNECTED, ble_manager_deinit());
-	TC_ASSERT_EQ_CLEANUP("ble_manager_client_disconnect", ble_manager_client_disconnect(ctx), BLE_MANAGER_SUCCESS, ble_manager_deinit());
+	TC_ASSERT_EQ_CLEANUP("ble_client_connected cb", g_client_connected, BEVT_CONNECTED, ble_manager_deinit());
+	TC_ASSERT_EQ_CLEANUP("ble_client_disconnect", ble_client_disconnect(ctx), BLE_MANAGER_SUCCESS, ble_manager_deinit());
 	CONTROL_VVDRIVER(VBLE_CMD_GEN_EVT, LWNL_EVT_BLE_CLIENT_DISCONNECT, 0, 3);
 	UTC_FUNC_WAIT;
-	TC_ASSERT_EQ_CLEANUP("ble_manager_client_disconnected cb", g_client_connected, BEVT_DISCONNECTED, ble_manager_deinit());
+	TC_ASSERT_EQ_CLEANUP("ble_client_disconnected cb", g_client_connected, BEVT_DISCONNECTED, ble_manager_deinit());
 	TC_ASSERT_EQ("ble_manager deinit", ble_manager_deinit(), BLE_MANAGER_SUCCESS);
 	TC_SUCCESS_RESULT();
 }
@@ -726,10 +726,10 @@ static void utc_blemanager_client_disconnect_p(void)
 static void utc_blemanager_client_disconnect_all_p(void)
 {
 	TC_ASSERT_EQ("ble_manager_init", ble_manager_init(NULL), BLE_MANAGER_SUCCESS);
-	ble_manager_client_ctx *ctx;
-	ctx = ble_manager_client_create_ctx(&client_config);
+	ble_client_ctx *ctx;
+	ctx = ble_client_create_ctx(&client_config);
 	uint8_t dummy[] = {0x00, 0x1E, 0xC0, 0x04, 0x9F, 0xF3};
-	ble_manager_conn_info conn_info = { 0, };
+	ble_conn_info conn_info = { 0, };
 	memcpy(conn_info.addr.mac, dummy, BLE_BD_ADDR_MAX_LEN);
 	conn_info.addr.type = BLE_ADV_TYPE_IND;
 	conn_info.conn_interval = 8;
@@ -737,27 +737,27 @@ static void utc_blemanager_client_disconnect_all_p(void)
 	conn_info.mtu = 240;
 	conn_info.scan_timeout = 1000;
 	conn_info.is_secured_connect = true;
-	TC_ASSERT_EQ_CLEANUP("ble_manager_client_connect", ble_manager_client_connect(ctx, &conn_info), BLE_MANAGER_SUCCESS, ble_manager_deinit());
+	TC_ASSERT_EQ_CLEANUP("ble_client_connect", ble_client_connect(ctx, &conn_info), BLE_MANAGER_SUCCESS, ble_manager_deinit());
 	CONTROL_VVDRIVER(VBLE_CMD_GEN_EVT, LWNL_EVT_BLE_CLIENT_CONNECT, 0, 3);
 	UTC_FUNC_WAIT;
-	TC_ASSERT_EQ_CLEANUP("ble_manager_client_connected cb", g_client_connected, BEVT_CONNECTED, ble_manager_deinit());
-	TC_ASSERT_EQ_CLEANUP("ble_manager_client_disconnect_all", ble_manager_client_disconnect_all(), BLE_MANAGER_SUCCESS, ble_manager_deinit());
+	TC_ASSERT_EQ_CLEANUP("ble_client_connected cb", g_client_connected, BEVT_CONNECTED, ble_manager_deinit());
+	TC_ASSERT_EQ_CLEANUP("ble_client_disconnect_all", ble_client_disconnect_all(), BLE_MANAGER_SUCCESS, ble_manager_deinit());
 	UTC_FUNC_WAIT;
-	TC_ASSERT_EQ_CLEANUP("ble_manager_client_disconnected cb", g_client_connected, BEVT_DISCONNECTED, ble_manager_deinit());
+	TC_ASSERT_EQ_CLEANUP("ble_client_disconnected cb", g_client_connected, BEVT_DISCONNECTED, ble_manager_deinit());
 	TC_ASSERT_EQ_CLEANUP("ble_manager deinit", ble_manager_deinit(), BLE_MANAGER_SUCCESS, ble_manager_deinit());
 	TC_SUCCESS_RESULT();
 }
 
 static void utc_blemanager_client_con_list_p(void)
 {
-	ble_manager_device_connected_list connected_list;
+	ble_device_connected_list connected_list;
 	TC_ASSERT_EQ("ble_manager_init", ble_manager_init(NULL), BLE_MANAGER_SUCCESS);
-	ble_manager_client_ctx *ctx1, *ctx2;
-	ctx1 = ble_manager_client_create_ctx(&client_config);
-	ctx2 = ble_manager_client_create_ctx(&client_config);
+	ble_client_ctx *ctx1, *ctx2;
+	ctx1 = ble_client_create_ctx(&client_config);
+	ctx2 = ble_client_create_ctx(&client_config);
 	uint8_t dummy1[] = {0x00, 0x1E, 0xC0, 0x04, 0x9F, 0xF3};
 	uint8_t dummy2[] = {0x00, 0x1E, 0xC0, 0x04, 0x9F, 0xF2};
-	ble_manager_conn_info conn_info = { 0, };
+	ble_conn_info conn_info = { 0, };
 	memcpy(conn_info.addr.mac, dummy1, BLE_BD_ADDR_MAX_LEN);
 	conn_info.addr.type = BLE_ADV_TYPE_IND;
 	conn_info.conn_interval = 8;
@@ -765,19 +765,19 @@ static void utc_blemanager_client_con_list_p(void)
 	conn_info.mtu = 240;
 	conn_info.scan_timeout = 1000;
 	conn_info.is_secured_connect = true;
-	TC_ASSERT_EQ_CLEANUP("ble_manager_client_connect", ble_manager_client_connect(ctx1, &conn_info), BLE_MANAGER_SUCCESS, ble_manager_deinit());
+	TC_ASSERT_EQ_CLEANUP("ble_client_connect", ble_client_connect(ctx1, &conn_info), BLE_MANAGER_SUCCESS, ble_manager_deinit());
 	CONTROL_VVDRIVER(VBLE_CMD_GEN_EVT, LWNL_EVT_BLE_CLIENT_CONNECT, 0, 3);
 	UTC_FUNC_WAIT;
-	TC_ASSERT_EQ_CLEANUP("ble_manager_client_connected cb", g_client_connected, BEVT_CONNECTED, ble_manager_deinit());
+	TC_ASSERT_EQ_CLEANUP("ble_client_connected cb", g_client_connected, BEVT_CONNECTED, ble_manager_deinit());
 	memcpy(conn_info.addr.mac, dummy2, BLE_BD_ADDR_MAX_LEN);
-	TC_ASSERT_EQ_CLEANUP("ble_manager_client_connect", ble_manager_client_connect(ctx2, &conn_info), BLE_MANAGER_SUCCESS, ble_manager_deinit());
+	TC_ASSERT_EQ_CLEANUP("ble_client_connect", ble_client_connect(ctx2, &conn_info), BLE_MANAGER_SUCCESS, ble_manager_deinit());
 	CONTROL_VVDRIVER(VBLE_CMD_GEN_EVT, LWNL_EVT_BLE_CLIENT_CONNECT, 0, 3);
 	UTC_FUNC_WAIT;
-	TC_ASSERT_EQ_CLEANUP("ble_manager_client_connected cb", g_client_connected, BEVT_CONNECTED, ble_manager_deinit());
-	TC_ASSERT_EQ_CLEANUP("ble_manager_client_connected_device_list", ble_manager_client_connected_device_list(&connected_list), BLE_MANAGER_SUCCESS, ble_manager_deinit());
-	TC_ASSERT_EQ_CLEANUP("ble_manager_client_disconnect_all", ble_manager_client_disconnect_all(), BLE_MANAGER_SUCCESS, ble_manager_deinit());
+	TC_ASSERT_EQ_CLEANUP("ble_client_connected cb", g_client_connected, BEVT_CONNECTED, ble_manager_deinit());
+	TC_ASSERT_EQ_CLEANUP("ble_client_connected_device_list", ble_client_connected_device_list(&connected_list), BLE_MANAGER_SUCCESS, ble_manager_deinit());
+	TC_ASSERT_EQ_CLEANUP("ble_client_disconnect_all", ble_client_disconnect_all(), BLE_MANAGER_SUCCESS, ble_manager_deinit());
 	UTC_FUNC_WAIT;
-	TC_ASSERT_EQ_CLEANUP("ble_manager_client_disconnected cb", g_client_connected, BEVT_DISCONNECTED, ble_manager_deinit());
+	TC_ASSERT_EQ_CLEANUP("ble_client_disconnected cb", g_client_connected, BEVT_DISCONNECTED, ble_manager_deinit());
 	TC_ASSERT_EQ("ble_manager deinit", ble_manager_deinit(), BLE_MANAGER_SUCCESS);
 	TC_SUCCESS_RESULT();
 }
@@ -785,10 +785,10 @@ static void utc_blemanager_client_con_list_p(void)
 static void utc_blemanager_connected_dev_info_p(void)
 {
 	TC_ASSERT_EQ("ble_manager_init", ble_manager_init(NULL), BLE_MANAGER_SUCCESS);
-	ble_manager_client_ctx *ctx;
-	ctx = ble_manager_client_create_ctx(&client_config);
+	ble_client_ctx *ctx;
+	ctx = ble_client_create_ctx(&client_config);
 	uint8_t dummy1[] = {0x00, 0x1E, 0xC0, 0x04, 0x9F, 0xF3};
-	ble_manager_conn_info conn_info = { 0, };
+	ble_conn_info conn_info = { 0, };
 	memcpy(conn_info.addr.mac, dummy1, BLE_BD_ADDR_MAX_LEN);
 	conn_info.addr.type = BLE_ADV_TYPE_IND;
 	conn_info.conn_interval = 8;
@@ -796,16 +796,16 @@ static void utc_blemanager_connected_dev_info_p(void)
 	conn_info.mtu = 240;
 	conn_info.scan_timeout = 1000;
 	conn_info.is_secured_connect = true;
-	TC_ASSERT_EQ_CLEANUP("ble_manager_client_connect", ble_manager_client_connect(ctx, &conn_info), BLE_MANAGER_SUCCESS, ble_manager_deinit());
+	TC_ASSERT_EQ_CLEANUP("ble_client_connect", ble_client_connect(ctx, &conn_info), BLE_MANAGER_SUCCESS, ble_manager_deinit());
 	CONTROL_VVDRIVER(VBLE_CMD_GEN_EVT, LWNL_EVT_BLE_CLIENT_CONNECT, 0, 3);
 	UTC_FUNC_WAIT;
-	TC_ASSERT_EQ_CLEANUP("ble_manager_client_connected cb", g_client_connected, BEVT_CONNECTED, ble_manager_deinit());
-	ble_manager_device_connected connected_dev;
-	TC_ASSERT_EQ_CLEANUP("ble_manager_client_connected_info", ble_manager_client_connected_info(ctx, &connected_dev), BLE_MANAGER_SUCCESS, ble_manager_deinit());
-	TC_ASSERT_EQ_CLEANUP("ble_manager_client_disconnect", ble_manager_client_disconnect(ctx), BLE_MANAGER_SUCCESS, ble_manager_deinit());
+	TC_ASSERT_EQ_CLEANUP("ble_client_connected cb", g_client_connected, BEVT_CONNECTED, ble_manager_deinit());
+	ble_device_connected connected_dev;
+	TC_ASSERT_EQ_CLEANUP("ble_client_connected_info", ble_client_connected_info(ctx, &connected_dev), BLE_MANAGER_SUCCESS, ble_manager_deinit());
+	TC_ASSERT_EQ_CLEANUP("ble_client_disconnect", ble_client_disconnect(ctx), BLE_MANAGER_SUCCESS, ble_manager_deinit());
 	CONTROL_VVDRIVER(VBLE_CMD_GEN_EVT, LWNL_EVT_BLE_CLIENT_DISCONNECT, 0, 3);
 	UTC_FUNC_WAIT;
-	TC_ASSERT_EQ_CLEANUP("ble_manager_client_disconnected cb", g_client_connected, BEVT_DISCONNECTED, ble_manager_deinit());
+	TC_ASSERT_EQ_CLEANUP("ble_client_disconnected cb", g_client_connected, BEVT_DISCONNECTED, ble_manager_deinit());
 	TC_ASSERT_EQ("ble_manager deinit", ble_manager_deinit(), BLE_MANAGER_SUCCESS);
 	TC_SUCCESS_RESULT();
 }
@@ -813,10 +813,10 @@ static void utc_blemanager_connected_dev_info_p(void)
 static void utc_blemanager_operation_enable_notification_p(void)
 {
 	TC_ASSERT_EQ("ble_manager_init", ble_manager_init(NULL), BLE_MANAGER_SUCCESS);
-	ble_manager_client_ctx *ctx;
-	ctx = ble_manager_client_create_ctx(&client_config);
+	ble_client_ctx *ctx;
+	ctx = ble_client_create_ctx(&client_config);
 	uint8_t dummy1[] = {0x00, 0x1E, 0xC0, 0x04, 0x9F, 0xF3};
-	ble_manager_conn_info conn_info = { 0, };
+	ble_conn_info conn_info = { 0, };
 	memcpy(conn_info.addr.mac, dummy1, BLE_BD_ADDR_MAX_LEN);
 	conn_info.addr.type = BLE_ADV_TYPE_IND;
 	conn_info.conn_interval = 8;
@@ -825,18 +825,18 @@ static void utc_blemanager_operation_enable_notification_p(void)
 	conn_info.scan_timeout = 1000;
 	conn_info.is_secured_connect = true;
 	ble_attr_handle attr_handle = 0x006e + 1;
-	TC_ASSERT_EQ_CLEANUP("ble_manager_client_connect", ble_manager_client_connect(ctx, &conn_info), BLE_MANAGER_SUCCESS, ble_manager_deinit());
+	TC_ASSERT_EQ_CLEANUP("ble_client_connect", ble_client_connect(ctx, &conn_info), BLE_MANAGER_SUCCESS, ble_manager_deinit());
 	CONTROL_VVDRIVER(VBLE_CMD_GEN_EVT, LWNL_EVT_BLE_CLIENT_CONNECT, 0, 3);
 	UTC_FUNC_WAIT;
-	TC_ASSERT_EQ_CLEANUP("ble_manager_client_connected cb", g_client_connected, BEVT_CONNECTED, ble_manager_deinit());
-	TC_ASSERT_EQ_CLEANUP("ble_manager_client_operation_enable_notification", ble_manager_client_operation_enable_notification(ctx, attr_handle), BLE_MANAGER_SUCCESS, ble_manager_deinit());
+	TC_ASSERT_EQ_CLEANUP("ble_client_connected cb", g_client_connected, BEVT_CONNECTED, ble_manager_deinit());
+	TC_ASSERT_EQ_CLEANUP("ble_client_operation_enable_notification", ble_client_operation_enable_notification(ctx, attr_handle), BLE_MANAGER_SUCCESS, ble_manager_deinit());
 	CONTROL_VVDRIVER(VBLE_CMD_GEN_EVT, LWNL_EVT_BLE_CLIENT_NOTI, 0, 3);
 	UTC_FUNC_WAIT;
-	TC_ASSERT_EQ_CLEANUP("ble_manager_client_notification cb", g_client_noti, BEVT_NOTI, ble_manager_deinit());
-	TC_ASSERT_EQ_CLEANUP("ble_manager_client_disconnect", ble_manager_client_disconnect(ctx), BLE_MANAGER_SUCCESS, ble_manager_deinit());
+	TC_ASSERT_EQ_CLEANUP("ble_client_notification cb", g_client_noti, BEVT_NOTI, ble_manager_deinit());
+	TC_ASSERT_EQ_CLEANUP("ble_client_disconnect", ble_client_disconnect(ctx), BLE_MANAGER_SUCCESS, ble_manager_deinit());
 	CONTROL_VVDRIVER(VBLE_CMD_GEN_EVT, LWNL_EVT_BLE_CLIENT_DISCONNECT, 0, 3);
 	UTC_FUNC_WAIT;
-	TC_ASSERT_EQ_CLEANUP("ble_manager_client_disconnected cb", g_client_connected, BEVT_DISCONNECTED, ble_manager_deinit());
+	TC_ASSERT_EQ_CLEANUP("ble_client_disconnected cb", g_client_connected, BEVT_DISCONNECTED, ble_manager_deinit());
 	TC_ASSERT_EQ("ble_manager deinit", ble_manager_deinit(), BLE_MANAGER_SUCCESS);
 	TC_SUCCESS_RESULT();
 }
@@ -844,10 +844,10 @@ static void utc_blemanager_operation_enable_notification_p(void)
 static void utc_blemanager_read_p(void)
 {
 	TC_ASSERT_EQ("ble_manager_init", ble_manager_init(NULL), BLE_MANAGER_SUCCESS);
-	ble_manager_client_ctx *ctx;
-	ctx = ble_manager_client_create_ctx(&client_config);
+	ble_client_ctx *ctx;
+	ctx = ble_client_create_ctx(&client_config);
 	uint8_t dummy1[] = {0x00, 0x1E, 0xC0, 0x04, 0x9F, 0xF3};
-	ble_manager_conn_info conn_info = { 0, };
+	ble_conn_info conn_info = { 0, };
 	memcpy(conn_info.addr.mac, dummy1, BLE_BD_ADDR_MAX_LEN);
 	conn_info.addr.type = BLE_ADV_TYPE_IND;
 	conn_info.conn_interval = 8;
@@ -858,15 +858,15 @@ static void utc_blemanager_read_p(void)
 	ble_attr_handle attr_handle = 0x006e + 1;
 	uint8_t buf[256] = { 0, };
 	ble_data data = { buf, sizeof(buf) };
-	TC_ASSERT_EQ_CLEANUP("ble_manager_client_connect", ble_manager_client_connect(ctx, &conn_info), BLE_MANAGER_SUCCESS, ble_manager_deinit());
+	TC_ASSERT_EQ_CLEANUP("ble_client_connect", ble_client_connect(ctx, &conn_info), BLE_MANAGER_SUCCESS, ble_manager_deinit());
 	CONTROL_VVDRIVER(VBLE_CMD_GEN_EVT, LWNL_EVT_BLE_CLIENT_CONNECT, 0, 3);
 	UTC_FUNC_WAIT;
-	TC_ASSERT_EQ_CLEANUP("ble_manager_client_connected cb", g_client_connected, BEVT_CONNECTED, ble_manager_deinit());
-	TC_ASSERT_EQ_CLEANUP("ble_manager_client_operation_read", ble_manager_client_operation_read(ctx, attr_handle, &data), BLE_MANAGER_SUCCESS, ble_manager_deinit());
-	TC_ASSERT_EQ_CLEANUP("ble_manager_client_disconnect", ble_manager_client_disconnect(ctx), BLE_MANAGER_SUCCESS, ble_manager_deinit());
+	TC_ASSERT_EQ_CLEANUP("ble_client_connected cb", g_client_connected, BEVT_CONNECTED, ble_manager_deinit());
+	TC_ASSERT_EQ_CLEANUP("ble_client_operation_read", ble_client_operation_read(ctx, attr_handle, &data), BLE_MANAGER_SUCCESS, ble_manager_deinit());
+	TC_ASSERT_EQ_CLEANUP("ble_client_disconnect", ble_client_disconnect(ctx), BLE_MANAGER_SUCCESS, ble_manager_deinit());
 	CONTROL_VVDRIVER(VBLE_CMD_GEN_EVT, LWNL_EVT_BLE_CLIENT_DISCONNECT, 0, 3);
 	UTC_FUNC_WAIT;
-	TC_ASSERT_EQ_CLEANUP("ble_manager_client_disconnected cb", g_client_connected, BEVT_DISCONNECTED, ble_manager_deinit());
+	TC_ASSERT_EQ_CLEANUP("ble_client_disconnected cb", g_client_connected, BEVT_DISCONNECTED, ble_manager_deinit());
 	TC_ASSERT_EQ("ble_manager deinit", ble_manager_deinit(), BLE_MANAGER_SUCCESS);
 	TC_SUCCESS_RESULT();
 }
@@ -874,10 +874,10 @@ static void utc_blemanager_read_p(void)
 static void utc_blemanager_read_n(void)
 {
 	TC_ASSERT_EQ("ble_manager_init", ble_manager_init(NULL), BLE_MANAGER_SUCCESS);
-	ble_manager_client_ctx *ctx;
-	ctx = ble_manager_client_create_ctx(&client_config);
+	ble_client_ctx *ctx;
+	ctx = ble_client_create_ctx(&client_config);
 	uint8_t dummy1[] = {0x00, 0x1E, 0xC0, 0x04, 0x9F, 0xF3};
-	ble_manager_conn_info conn_info = { 0, };
+	ble_conn_info conn_info = { 0, };
 	memcpy(conn_info.addr.mac, dummy1, BLE_BD_ADDR_MAX_LEN);
 	conn_info.addr.type = BLE_ADV_TYPE_IND;
 	conn_info.conn_interval = 8;
@@ -886,15 +886,15 @@ static void utc_blemanager_read_n(void)
 	conn_info.scan_timeout = 1000;
 	conn_info.is_secured_connect = true;
 	ble_attr_handle attr_handle = 0x006e + 1;
-	TC_ASSERT_EQ("ble_manager_client_connect", ble_manager_client_connect(ctx, &conn_info), BLE_MANAGER_SUCCESS);
+	TC_ASSERT_EQ("ble_client_connect", ble_client_connect(ctx, &conn_info), BLE_MANAGER_SUCCESS);
 	CONTROL_VVDRIVER(VBLE_CMD_GEN_EVT, LWNL_EVT_BLE_CLIENT_CONNECT, 0, 3);
 	UTC_FUNC_WAIT;
-	TC_ASSERT_EQ("ble_manager_client_connected cb", g_client_connected, BEVT_CONNECTED);
-	TC_ASSERT_EQ("ble_manager_client_operation_read", ble_manager_client_operation_read(ctx, attr_handle, NULL), BLE_MANAGER_INVALID_ARGS);
-	TC_ASSERT_EQ("ble_manager_client_disconnect", ble_manager_client_disconnect(ctx), BLE_MANAGER_SUCCESS);
+	TC_ASSERT_EQ("ble_client_connected cb", g_client_connected, BEVT_CONNECTED);
+	TC_ASSERT_EQ("ble_client_operation_read", ble_client_operation_read(ctx, attr_handle, NULL), BLE_MANAGER_INVALID_ARGS);
+	TC_ASSERT_EQ("ble_client_disconnect", ble_client_disconnect(ctx), BLE_MANAGER_SUCCESS);
 	CONTROL_VVDRIVER(VBLE_CMD_GEN_EVT, LWNL_EVT_BLE_CLIENT_DISCONNECT, 0, 3);
 	UTC_FUNC_WAIT;
-	TC_ASSERT_EQ("ble_manager_client_disconnected cb", g_client_connected, BEVT_DISCONNECTED);
+	TC_ASSERT_EQ("ble_client_disconnected cb", g_client_connected, BEVT_DISCONNECTED);
 	TC_ASSERT_EQ("ble_manager deinit", ble_manager_deinit(), BLE_MANAGER_SUCCESS);
 	TC_SUCCESS_RESULT();
 }
@@ -902,10 +902,10 @@ static void utc_blemanager_read_n(void)
 static void utc_blemanager_write_p(void)
 {
 	TC_ASSERT_EQ("ble_manager_init", ble_manager_init(NULL), BLE_MANAGER_SUCCESS);
-	ble_manager_client_ctx *ctx;
-	ctx = ble_manager_client_create_ctx(&client_config);
+	ble_client_ctx *ctx;
+	ctx = ble_client_create_ctx(&client_config);
 	uint8_t dummy1[] = {0x00, 0x1E, 0xC0, 0x04, 0x9F, 0xF3};
-	ble_manager_conn_info conn_info = { 0, };
+	ble_conn_info conn_info = { 0, };
 	memcpy(conn_info.addr.mac, dummy1, BLE_BD_ADDR_MAX_LEN);
 	conn_info.addr.type = BLE_ADV_TYPE_IND;
 	conn_info.conn_interval = 8;
@@ -916,15 +916,15 @@ static void utc_blemanager_write_p(void)
 	ble_attr_handle attr_handle = 0x006e + 1;
 	uint8_t buf[256] = { 0, };
 	ble_data data = { buf, sizeof(buf) };
-	TC_ASSERT_EQ_CLEANUP("ble_manager_client_connect", ble_manager_client_connect(ctx, &conn_info), BLE_MANAGER_SUCCESS, ble_manager_deinit());
+	TC_ASSERT_EQ_CLEANUP("ble_client_connect", ble_client_connect(ctx, &conn_info), BLE_MANAGER_SUCCESS, ble_manager_deinit());
 	CONTROL_VVDRIVER(VBLE_CMD_GEN_EVT, LWNL_EVT_BLE_CLIENT_CONNECT, 0, 3);
 	UTC_FUNC_WAIT;
-	TC_ASSERT_EQ_CLEANUP("ble_manager_client_connected cb", g_client_connected, BEVT_CONNECTED, ble_manager_deinit());
-	TC_ASSERT_EQ_CLEANUP("ble_manager_client_operation_write", ble_manager_client_operation_write(ctx, attr_handle, &data), BLE_MANAGER_SUCCESS, ble_manager_deinit());
-	TC_ASSERT_EQ_CLEANUP("ble_manager_client_disconnect", ble_manager_client_disconnect(ctx), BLE_MANAGER_SUCCESS, ble_manager_deinit());
+	TC_ASSERT_EQ_CLEANUP("ble_client_connected cb", g_client_connected, BEVT_CONNECTED, ble_manager_deinit());
+	TC_ASSERT_EQ_CLEANUP("ble_client_operation_write", ble_client_operation_write(ctx, attr_handle, &data), BLE_MANAGER_SUCCESS, ble_manager_deinit());
+	TC_ASSERT_EQ_CLEANUP("ble_client_disconnect", ble_client_disconnect(ctx), BLE_MANAGER_SUCCESS, ble_manager_deinit());
 	CONTROL_VVDRIVER(VBLE_CMD_GEN_EVT, LWNL_EVT_BLE_CLIENT_DISCONNECT, 0, 3);
 	UTC_FUNC_WAIT;
-	TC_ASSERT_EQ_CLEANUP("ble_manager_client_disconnected cb", g_client_connected, BEVT_DISCONNECTED, ble_manager_deinit());
+	TC_ASSERT_EQ_CLEANUP("ble_client_disconnected cb", g_client_connected, BEVT_DISCONNECTED, ble_manager_deinit());
 	TC_ASSERT_EQ("ble_manager deinit", ble_manager_deinit(), BLE_MANAGER_SUCCESS);
 	TC_SUCCESS_RESULT();
 }
@@ -932,10 +932,10 @@ static void utc_blemanager_write_p(void)
 static void utc_blemanager_write_n(void)
 {
 	TC_ASSERT_EQ("ble_manager_init", ble_manager_init(NULL), BLE_MANAGER_SUCCESS);
-	ble_manager_client_ctx *ctx;
-	ctx = ble_manager_client_create_ctx(&client_config);
+	ble_client_ctx *ctx;
+	ctx = ble_client_create_ctx(&client_config);
 	uint8_t dummy1[] = {0x00, 0x1E, 0xC0, 0x04, 0x9F, 0xF3};
-	ble_manager_conn_info conn_info = { 0, };
+	ble_conn_info conn_info = { 0, };
 	memcpy(conn_info.addr.mac, dummy1, BLE_BD_ADDR_MAX_LEN);
 	conn_info.addr.type = BLE_ADV_TYPE_IND;
 	conn_info.conn_interval = 8;
@@ -944,15 +944,15 @@ static void utc_blemanager_write_n(void)
 	conn_info.scan_timeout = 1000;
 	conn_info.is_secured_connect = true;
 	ble_attr_handle attr_handle = 0x006e + 1;
-	TC_ASSERT_EQ("ble_manager_client_connect", ble_manager_client_connect(ctx, &conn_info), BLE_MANAGER_SUCCESS);
+	TC_ASSERT_EQ("ble_client_connect", ble_client_connect(ctx, &conn_info), BLE_MANAGER_SUCCESS);
 	CONTROL_VVDRIVER(VBLE_CMD_GEN_EVT, LWNL_EVT_BLE_CLIENT_CONNECT, 0, 3);
 	UTC_FUNC_WAIT;
-	TC_ASSERT_EQ("ble_manager_client_connected cb", g_client_connected, BEVT_CONNECTED);
-	TC_ASSERT_EQ("ble_manager_client_operation_write", ble_manager_client_operation_write(ctx, attr_handle, NULL), BLE_MANAGER_INVALID_ARGS);
-	TC_ASSERT_EQ("ble_manager_client_disconnect", ble_manager_client_disconnect(ctx), BLE_MANAGER_SUCCESS);
+	TC_ASSERT_EQ("ble_client_connected cb", g_client_connected, BEVT_CONNECTED);
+	TC_ASSERT_EQ("ble_client_operation_write", ble_client_operation_write(ctx, attr_handle, NULL), BLE_MANAGER_INVALID_ARGS);
+	TC_ASSERT_EQ("ble_client_disconnect", ble_client_disconnect(ctx), BLE_MANAGER_SUCCESS);
 	CONTROL_VVDRIVER(VBLE_CMD_GEN_EVT, LWNL_EVT_BLE_CLIENT_DISCONNECT, 0, 3);
 	UTC_FUNC_WAIT;
-	TC_ASSERT_EQ("ble_manager_client_disconnected cb", g_client_connected, BEVT_DISCONNECTED);
+	TC_ASSERT_EQ("ble_client_disconnected cb", g_client_connected, BEVT_DISCONNECTED);
 	TC_ASSERT_EQ("ble_manager deinit", ble_manager_deinit(), BLE_MANAGER_SUCCESS);
 	TC_SUCCESS_RESULT();
 }
@@ -960,10 +960,10 @@ static void utc_blemanager_write_n(void)
 static void utc_blemanager_write_no_resp_p(void)
 {
 	TC_ASSERT_EQ("ble_manager_init", ble_manager_init(NULL), BLE_MANAGER_SUCCESS);
-	ble_manager_client_ctx *ctx;
-	ctx = ble_manager_client_create_ctx(&client_config);
+	ble_client_ctx *ctx;
+	ctx = ble_client_create_ctx(&client_config);
 	uint8_t dummy1[] = {0x00, 0x1E, 0xC0, 0x04, 0x9F, 0xF3};
-	ble_manager_conn_info conn_info = { 0, };
+	ble_conn_info conn_info = { 0, };
 	memcpy(conn_info.addr.mac, dummy1, BLE_BD_ADDR_MAX_LEN);
 	conn_info.addr.type = BLE_ADV_TYPE_IND;
 	conn_info.conn_interval = 8;
@@ -974,15 +974,15 @@ static void utc_blemanager_write_no_resp_p(void)
 	ble_attr_handle attr_handle = 0x006e + 1;
 	uint8_t buf[256] = { 0, };
 	ble_data data = { buf, sizeof(buf) };
-	TC_ASSERT_EQ_CLEANUP("ble_manager_client_connect", ble_manager_client_connect(ctx, &conn_info), BLE_MANAGER_SUCCESS, ble_manager_deinit());
+	TC_ASSERT_EQ_CLEANUP("ble_client_connect", ble_client_connect(ctx, &conn_info), BLE_MANAGER_SUCCESS, ble_manager_deinit());
 	CONTROL_VVDRIVER(VBLE_CMD_GEN_EVT, LWNL_EVT_BLE_CLIENT_CONNECT, 0, 3);
 	UTC_FUNC_WAIT;
-	TC_ASSERT_EQ_CLEANUP("ble_manager_client_connected cb", g_client_connected, BEVT_CONNECTED, ble_manager_deinit());
-	TC_ASSERT_EQ_CLEANUP("ble_manager_client_operation_write_no_response", ble_manager_client_operation_write_no_response(ctx, attr_handle, &data), BLE_MANAGER_SUCCESS, ble_manager_deinit());
-	TC_ASSERT_EQ_CLEANUP("ble_manager_client_disconnect", ble_manager_client_disconnect(ctx), BLE_MANAGER_SUCCESS, ble_manager_deinit());
+	TC_ASSERT_EQ_CLEANUP("ble_client_connected cb", g_client_connected, BEVT_CONNECTED, ble_manager_deinit());
+	TC_ASSERT_EQ_CLEANUP("ble_client_operation_write_no_response", ble_client_operation_write_no_response(ctx, attr_handle, &data), BLE_MANAGER_SUCCESS, ble_manager_deinit());
+	TC_ASSERT_EQ_CLEANUP("ble_client_disconnect", ble_client_disconnect(ctx), BLE_MANAGER_SUCCESS, ble_manager_deinit());
 	CONTROL_VVDRIVER(VBLE_CMD_GEN_EVT, LWNL_EVT_BLE_CLIENT_DISCONNECT, 0, 3);
 	UTC_FUNC_WAIT;
-	TC_ASSERT_EQ_CLEANUP("ble_manager_client_disconnected cb", g_client_connected, BEVT_DISCONNECTED, ble_manager_deinit());
+	TC_ASSERT_EQ_CLEANUP("ble_client_disconnected cb", g_client_connected, BEVT_DISCONNECTED, ble_manager_deinit());
 	TC_ASSERT_EQ("ble_manager deinit", ble_manager_deinit(), BLE_MANAGER_SUCCESS);
 	TC_SUCCESS_RESULT();
 }
@@ -990,10 +990,10 @@ static void utc_blemanager_write_no_resp_p(void)
 static void utc_blemanager_write_no_resp_n(void)
 {
 	TC_ASSERT_EQ("ble_manager_init", ble_manager_init(NULL), BLE_MANAGER_SUCCESS);
-	ble_manager_client_ctx *ctx;
-	ctx = ble_manager_client_create_ctx(&client_config);
+	ble_client_ctx *ctx;
+	ctx = ble_client_create_ctx(&client_config);
 	uint8_t dummy1[] = {0x00, 0x1E, 0xC0, 0x04, 0x9F, 0xF3};
-	ble_manager_conn_info conn_info = { 0, };
+	ble_conn_info conn_info = { 0, };
 	memcpy(conn_info.addr.mac, dummy1, BLE_BD_ADDR_MAX_LEN);
 	conn_info.addr.type = BLE_ADV_TYPE_IND;
 	conn_info.conn_interval = 8;
@@ -1002,15 +1002,15 @@ static void utc_blemanager_write_no_resp_n(void)
 	conn_info.scan_timeout = 1000;
 	conn_info.is_secured_connect = true;
 	ble_attr_handle attr_handle = 0x006e + 1;
-	TC_ASSERT_EQ("ble_manager_client_connect", ble_manager_client_connect(ctx, &conn_info), BLE_MANAGER_SUCCESS);
+	TC_ASSERT_EQ("ble_client_connect", ble_client_connect(ctx, &conn_info), BLE_MANAGER_SUCCESS);
 	CONTROL_VVDRIVER(VBLE_CMD_GEN_EVT, LWNL_EVT_BLE_CLIENT_CONNECT, 0, 3);
 	UTC_FUNC_WAIT;
-	TC_ASSERT_EQ("ble_manager_client_connected cb", g_client_connected, BEVT_CONNECTED);
-	TC_ASSERT_EQ("ble_manager_client_operation_write_no_response", ble_manager_client_operation_write_no_response(ctx, attr_handle, NULL), BLE_MANAGER_INVALID_ARGS);
-	TC_ASSERT_EQ("ble_manager_client_disconnect", ble_manager_client_disconnect(ctx), BLE_MANAGER_SUCCESS);
+	TC_ASSERT_EQ("ble_client_connected cb", g_client_connected, BEVT_CONNECTED);
+	TC_ASSERT_EQ("ble_client_operation_write_no_response", ble_client_operation_write_no_response(ctx, attr_handle, NULL), BLE_MANAGER_INVALID_ARGS);
+	TC_ASSERT_EQ("ble_client_disconnect", ble_client_disconnect(ctx), BLE_MANAGER_SUCCESS);
 	CONTROL_VVDRIVER(VBLE_CMD_GEN_EVT, LWNL_EVT_BLE_CLIENT_DISCONNECT, 0, 3);
 	UTC_FUNC_WAIT;
-	TC_ASSERT_EQ("ble_manager_client_disconnected cb", g_client_connected, BEVT_DISCONNECTED);
+	TC_ASSERT_EQ("ble_client_disconnected cb", g_client_connected, BEVT_DISCONNECTED);
 	TC_ASSERT_EQ("ble_manager deinit", ble_manager_deinit(), BLE_MANAGER_SUCCESS);
 	TC_SUCCESS_RESULT();
 }

--- a/framework/include/ble_manager/ble_client.h
+++ b/framework/include/ble_manager/ble_client.h
@@ -34,13 +34,13 @@
 #include "ble_common.h"
 
 typedef enum {
-	BLE_MANAGER_CLIENT_NONE = 0,
-	BLE_MANAGER_CLIENT_IDLE,
-	BLE_MANAGER_CLIENT_CONNECTED,
-	BLE_MANAGER_CLIENT_CONNECTING,
-	BLE_MANAGER_CLIENT_DISCONNECTING,
-	BLE_MANAGER_CLIENT_AUTOCONNECTING,
-} ble_manager_client_state_e;
+	BLE_CLIENT_NONE = 0,
+	BLE_CLIENT_IDLE,
+	BLE_CLIENT_CONNECTED,
+	BLE_CLIENT_CONNECTING,
+	BLE_CLIENT_DISCONNECTING,
+	BLE_CLIENT_AUTOCONNECTING,
+} ble_client_state_e;
 
 typedef struct {
 	ble_addr addr;
@@ -49,43 +49,43 @@ typedef struct {
 	uint16_t mtu;
 	uint16_t scan_timeout; /* ms */
 	bool is_secured_connect;
-} ble_manager_conn_info;
+} ble_conn_info;
 
 typedef struct {
-	ble_manager_conn_info conn_info;
+	ble_conn_info conn_info;
 	bool is_bonded;
 	ble_conn_handle conn_handle;
-} ble_manager_device_connected;
+} ble_device_connected;
 
 typedef struct {
 	ble_conn_handle conn_handle[BLE_MAX_CONNECTION_COUNT];
 	uint8_t connected_count;
-} ble_manager_device_connected_list;
+} ble_device_connected_list;
 
 typedef struct {
 	ble_conn_handle conn_handle;
-	volatile ble_manager_client_state_e state;
-	ble_manager_conn_info info;
+	volatile ble_client_state_e state;
+	ble_conn_info info;
 	bool is_bonded;
 	bool auto_connect;
-} ble_manager_client_ctx;
+} ble_client_ctx;
 
-typedef void(*ble_manager_client_device_disconnected_cb)(ble_manager_client_ctx *ctx);
-typedef void(*ble_manager_client_device_connected_cb)(ble_manager_client_ctx *ctx, ble_manager_device_connected* connected_device);
-typedef void(*ble_manager_client_operation_notification_cb)(ble_manager_client_ctx *ctx, ble_attr_handle attr_handle, ble_data* read_result);
-typedef void (*ble_manager_client_operation_indication_cb)(ble_manager_client_ctx *ctx, ble_attr_handle attr_handle, ble_data* read_result);
+typedef void(*ble_client_device_disconnected_cb)(ble_client_ctx *ctx);
+typedef void(*ble_client_device_connected_cb)(ble_client_ctx *ctx, ble_device_connected* connected_device);
+typedef void(*ble_client_operation_notification_cb)(ble_client_ctx *ctx, ble_attr_handle attr_handle, ble_data* read_result);
+typedef void (*ble_client_operation_indication_cb)(ble_client_ctx *ctx, ble_attr_handle attr_handle, ble_data* read_result);
 
 typedef struct {
 	/* This is a set of callback function for BLE client */
-	ble_manager_client_device_disconnected_cb disconnected_cb;
-	ble_manager_client_device_connected_cb connected_cb;
-	ble_manager_client_operation_notification_cb notification_cb;
-	ble_manager_client_operation_indication_cb indication_cb;
-} ble_manager_client_callback_list;
+	ble_client_device_disconnected_cb disconnected_cb;
+	ble_client_device_connected_cb connected_cb;
+	ble_client_operation_notification_cb notification_cb;
+	ble_client_operation_indication_cb indication_cb;
+} ble_client_callback_list;
 
-ble_manager_client_ctx *ble_manager_client_create_ctx(ble_manager_client_callback_list *callbacks);
-ble_result_e ble_manager_client_destroy_ctx(ble_manager_client_ctx *ctx);
-ble_manager_client_state_e ble_manager_client_get_state(ble_manager_client_ctx *ctx);
+ble_client_ctx *ble_client_create_ctx(ble_client_callback_list *callbacks);
+ble_result_e ble_client_destroy_ctx(ble_client_ctx *ctx);
+ble_client_state_e ble_client_get_state(ble_client_ctx *ctx);
 
 /****************************************************************************
  * Name: ble_client_connect
@@ -102,9 +102,9 @@ ble_manager_client_state_e ble_manager_client_get_state(ble_manager_client_ctx *
  *   failure.
  *
  ****************************************************************************/
-ble_result_e ble_manager_client_connect(ble_manager_client_ctx *ctx, ble_manager_conn_info* conn_info);
-ble_result_e ble_manager_client_reconnect(ble_manager_client_ctx *ctx);
-ble_result_e ble_manager_client_autoconnect(ble_manager_client_ctx *ctx, bool is_auto);
+ble_result_e ble_client_connect(ble_client_ctx *ctx, ble_conn_info* conn_info);
+ble_result_e ble_client_reconnect(ble_client_ctx *ctx);
+ble_result_e ble_client_autoconnect(ble_client_ctx *ctx, bool is_auto);
 
 /****************************************************************************
  * Name: ble_client_disconnect
@@ -120,7 +120,7 @@ ble_result_e ble_manager_client_autoconnect(ble_manager_client_ctx *ctx, bool is
  *   failure.
  *
  ****************************************************************************/
-ble_result_e ble_manager_client_disconnect(ble_manager_client_ctx *ctx);
+ble_result_e ble_client_disconnect(ble_client_ctx *ctx);
 
 /****************************************************************************
  * Name: ble_client_disconnect_all
@@ -133,7 +133,7 @@ ble_result_e ble_manager_client_disconnect(ble_manager_client_ctx *ctx);
  *   failure.
  *
  ****************************************************************************/
-ble_result_e ble_manager_client_disconnect_all(void);
+ble_result_e ble_client_disconnect_all(void);
 
 /****************************************************************************
  * Name: ble_client_connected_device_list
@@ -150,7 +150,7 @@ ble_result_e ble_manager_client_disconnect_all(void);
  *   failure.
  *
  ****************************************************************************/
-ble_result_e ble_manager_client_connected_device_list(ble_manager_device_connected_list* out_connected_list);
+ble_result_e ble_client_connected_device_list(ble_device_connected_list* out_connected_list);
 
 /****************************************************************************
  * Name: ble_client_connected_info
@@ -168,7 +168,7 @@ ble_result_e ble_manager_client_connected_device_list(ble_manager_device_connect
  *   failure.
  *
  ****************************************************************************/
-ble_result_e ble_manager_client_connected_info(ble_manager_client_ctx *ctx, ble_manager_device_connected* out_connected_device);
+ble_result_e ble_client_connected_info(ble_client_ctx *ctx, ble_device_connected* out_connected_device);
 
 /****************************************************************************
  * Name: ble_client_operation_enable_notification
@@ -187,9 +187,9 @@ ble_result_e ble_manager_client_connected_info(ble_manager_client_ctx *ctx, ble_
  *   failure.
  *
  ****************************************************************************/
-ble_result_e ble_manager_client_operation_enable_notification(ble_manager_client_ctx *ctx, ble_attr_handle attr_handle);
-ble_result_e ble_manager_client_operation_enable_indication(ble_manager_client_ctx *ctx, ble_attr_handle attr_handle);
-ble_result_e ble_manager_client_operation_enable_notification_and_indication(ble_manager_client_ctx *ctx, ble_attr_handle attr_handle);
+ble_result_e ble_client_operation_enable_notification(ble_client_ctx *ctx, ble_attr_handle attr_handle);
+ble_result_e ble_client_operation_enable_indication(ble_client_ctx *ctx, ble_attr_handle attr_handle);
+ble_result_e ble_client_operation_enable_notification_and_indication(ble_client_ctx *ctx, ble_attr_handle attr_handle);
 
 /****************************************************************************
  * Name: ble_client_operation_read
@@ -211,6 +211,6 @@ ble_result_e ble_manager_client_operation_enable_notification_and_indication(ble
  *   failure.
  *
  ****************************************************************************/
-ble_result_e ble_manager_client_operation_read(ble_manager_client_ctx *ctx, ble_attr_handle attr_handle, ble_data* data);
-ble_result_e ble_manager_client_operation_write(ble_manager_client_ctx *ctx, ble_attr_handle attr_handle, ble_data* data);
-ble_result_e ble_manager_client_operation_write_no_response(ble_manager_client_ctx *ctx, ble_attr_handle attr_handle, ble_data* data);
+ble_result_e ble_client_operation_read(ble_client_ctx *ctx, ble_attr_handle attr_handle, ble_data* data);
+ble_result_e ble_client_operation_write(ble_client_ctx *ctx, ble_attr_handle attr_handle, ble_data* data);
+ble_result_e ble_client_operation_write_no_response(ble_client_ctx *ctx, ble_attr_handle attr_handle, ble_data* data);

--- a/framework/include/ble_manager/ble_manager.h
+++ b/framework/include/ble_manager/ble_manager.h
@@ -61,7 +61,7 @@ typedef struct _ble_bonded_device_list {
  *   failure.
  *
  ****************************************************************************/
-ble_result_e ble_manager_init(ble_manager_server_init_config *server_config);
+ble_result_e ble_manager_init(ble_server_init_config *server_config);
 
 /****************************************************************************
  * Name: ble_manager_deinit

--- a/framework/include/ble_manager/ble_scan.h
+++ b/framework/include/ble_manager/ble_scan.h
@@ -78,7 +78,7 @@ typedef struct {
 } ble_scan_whitelist;
 
 /****************************************************************************
- * Name: ble_manager_client_start_scan
+ * Name: ble_client_start_scan
  *
  * Description:
  *   Start BLE adv scanning
@@ -95,25 +95,25 @@ typedef struct {
  *   failure.
  *
  ****************************************************************************/
-ble_result_e ble_manager_client_start_scan(ble_scan_filter* filter, ble_scan_callback_list *callbacks);
+ble_result_e ble_client_start_scan(ble_scan_filter* filter, ble_scan_callback_list *callbacks);
 
 /****************************************************************************
- * Name: ble_manager_client_stop_scan
+ * Name: ble_client_stop_scan
  *
  * Description:
  *   Stop BLE adv scanning. This should be called to stop BLE scanning after 
- *   ble_manager_client_start_scan is called without filter.
+ *   ble_client_start_scan is called without filter.
  *
  * Returned Value
  *   Zero (BLE_RESULT_SUCCESS) is returned on success; a positive value is returned on
  *   failure.
  *
  ****************************************************************************/
-ble_result_e ble_manager_client_stop_scan(void);
+ble_result_e ble_client_stop_scan(void);
 
 /****************************************************************************
- * Name: ble_manager_scan_whitelist_add
- *       ble_manager_scan_whitelist_delete
+ * Name: ble_scan_whitelist_add
+ *       ble_scan_whitelist_delete
  *
  * Input Parameters:
  *   addr  - BLE Address value including type.
@@ -127,11 +127,11 @@ ble_result_e ble_manager_client_stop_scan(void);
  *   failure.
  *
  ****************************************************************************/
-ble_result_e ble_manager_scan_whitelist_add(ble_addr *addr);
-ble_result_e ble_manager_scan_whitelist_delete(ble_addr *addr);
+ble_result_e ble_scan_whitelist_add(ble_addr *addr);
+ble_result_e ble_scan_whitelist_delete(ble_addr *addr);
 
 /****************************************************************************
- * Name: ble_manager_scan_whitelist_clear_all
+ * Name: ble_scan_whitelist_clear_all
  *
  * Description:
  *   Clear data of the scan whitelist.
@@ -141,10 +141,10 @@ ble_result_e ble_manager_scan_whitelist_delete(ble_addr *addr);
  *   failure.
  *
  ****************************************************************************/
-ble_result_e ble_manager_scan_whitelist_clear_all(void);
+ble_result_e ble_scan_whitelist_clear_all(void);
 
 /****************************************************************************
- * Name: ble_manager_scan_whitelist_list
+ * Name: ble_scan_whitelist_list
  *
  * Input Parameters:
  *   addr  - BLE Address Array. This must be pre-allocated.
@@ -157,4 +157,4 @@ ble_result_e ble_manager_scan_whitelist_clear_all(void);
  *   The number of whitelist.
  *
  ****************************************************************************/
-uint16_t ble_manager_scan_whitelist_list(ble_addr addr[], uint16_t size);
+uint16_t ble_scan_whitelist_list(ble_addr addr[], uint16_t size);

--- a/framework/include/ble_manager/ble_server.h
+++ b/framework/include/ble_manager/ble_server.h
@@ -34,73 +34,73 @@
 #include "ble_common.h"
 
 typedef enum  {
-	BLE_MANAGER_SERVER_GATT_SERVICE,
-	BLE_MANAGER_SERVER_GATT_CHARACT,
-	BLE_MANAGER_SERVER_GATT_DESC,
-	BLE_MANAGER_SERVER_GATT_MAX
-} ble_manager_server_gatt_profile_type_e;
+	BLE_SERVER_GATT_SERVICE,
+	BLE_SERVER_GATT_CHARACT,
+	BLE_SERVER_GATT_DESC,
+	BLE_SERVER_GATT_MAX
+} ble_server_gatt_profile_type_e;
 
 typedef enum {
-	BLE_MANAGER_SERVER_ATTR_CB_WRITING,
-	BLE_MANAGER_SERVER_ATTR_CB_READING,
-	BLE_MANAGER_SERVER_ATTR_CB_WRITING_NO_RSP,
-	BLE_MANAGER_SERVER_ATTR_CB_CCCD,
-	BLE_MANAGER_SERVER_ATTR_CB_INDICATE,
-} ble_manager_server_attr_cb_type_e;
+	BLE_SERVER_ATTR_CB_WRITING,
+	BLE_SERVER_ATTR_CB_READING,
+	BLE_SERVER_ATTR_CB_WRITING_NO_RSP,
+	BLE_SERVER_ATTR_CB_CCCD,
+	BLE_SERVER_ATTR_CB_INDICATE,
+} ble_server_attr_cb_type_e;
 
 typedef enum {
-	BLE_MANAGER_SERVER_CCCD_DEFAULT 		= 0x0000,
-	BLE_MANAGER_SERVER_CCCD_NOTIFY  		= 0x0001,
-	BLE_MANAGER_SERVER_CCCD_INDICATE		= 0x0002,
-	BLE_MANAGER_SERVER_CCCD_NOTIFY_INDICATE	= 0x0003
-} ble_manager_server_cccd_value_e;
+	BLE_SERVER_CCCD_DEFAULT 		= 0x0000,
+	BLE_SERVER_CCCD_NOTIFY  		= 0x0001,
+	BLE_SERVER_CCCD_INDICATE		= 0x0002,
+	BLE_SERVER_CCCD_NOTIFY_INDICATE	= 0x0003
+} ble_server_cccd_value_e;
 
-typedef void (*ble_server_cb_t)(ble_manager_server_attr_cb_type_e type, ble_conn_handle con_handle, ble_attr_handle handle, void* arg);
+typedef void (*ble_server_cb_t)(ble_server_attr_cb_type_e type, ble_conn_handle con_handle, ble_attr_handle handle, void* arg);
 
 typedef enum  {
-	BLE_MANAGER_ATTR_PROP_NONE          = 0x00,
-	BLE_MANAGER_ATTR_PROP_BCAST         = 0x01,
-	BLE_MANAGER_ATTR_PROP_READ          = 0x02,
-	BLE_MANAGER_ATTR_PROP_WRITE_NO_RSP  = 0x04,
-	BLE_MANAGER_ATTR_PROP_WRITE         = 0x08,
-	BLE_MANAGER_ATTR_PROP_NOTIFY        = 0x10,
-	BLE_MANAGER_ATTR_PROP_INDICATE      = 0x20,
-	BLE_MANAGER_ATTR_PROP_AUTHEN        = 0x40,
-	BLE_MANAGER_ATTR_PROP_EXTENDED      = 0x80,
-	BLE_MANAGER_ATTR_PROP_RWN           = 0x1a,
-} ble_manager_attr_property_e;
+	BLE_ATTR_PROP_NONE          = 0x00,
+	BLE_ATTR_PROP_BCAST         = 0x01,
+	BLE_ATTR_PROP_READ          = 0x02,
+	BLE_ATTR_PROP_WRITE_NO_RSP  = 0x04,
+	BLE_ATTR_PROP_WRITE         = 0x08,
+	BLE_ATTR_PROP_NOTIFY        = 0x10,
+	BLE_ATTR_PROP_INDICATE      = 0x20,
+	BLE_ATTR_PROP_AUTHEN        = 0x40,
+	BLE_ATTR_PROP_EXTENDED      = 0x80,
+	BLE_ATTR_PROP_RWN           = 0x1a,
+} ble_attr_property_e;
 
 typedef enum {
-	BLE_MANAGER_ATTR_PERM_R_PERMIT    = 0x00,         /* Always permitted, no restrictions*/
-	BLE_MANAGER_ATTR_PERM_R_AUTHEN    = 0x01,         /* Authentication required */
-	BLE_MANAGER_ATTR_PERM_R_AUTHOR    = 0x02,         /* Authorization required */
-	BLE_MANAGER_ATTR_PERM_R_ENCRYPT   = 0x04,         /* Can only be accessed in encrypted link*/
-	BLE_MANAGER_ATTR_PERM_R_BANNED    = 0x08,         /* Operation not permitted */
+	BLE_ATTR_PERM_R_PERMIT    = 0x00,         /* Always permitted, no restrictions*/
+	BLE_ATTR_PERM_R_AUTHEN    = 0x01,         /* Authentication required */
+	BLE_ATTR_PERM_R_AUTHOR    = 0x02,         /* Authorization required */
+	BLE_ATTR_PERM_R_ENCRYPT   = 0x04,         /* Can only be accessed in encrypted link*/
+	BLE_ATTR_PERM_R_BANNED    = 0x08,         /* Operation not permitted */
 
-	BLE_MANAGER_ATTR_PERM_W_PERMIT    = 0x00,         /* Always permitted, no restrictions*/
-	BLE_MANAGER_ATTR_PERM_W_AUTHEN    = 0x10,         /* Authentication required */
-	BLE_MANAGER_ATTR_PERM_W_AUTHOR    = 0x20,         /* Authorization required */
-	BLE_MANAGER_ATTR_PERM_W_ENCRYPT   = 0x40,         /* Can only be accessed in encrypted link*/
-	BLE_MANAGER_ATTR_PERM_W_BANNED    = 0x80,         /* Operation not permitted */
-} ble_manager_attr_permission_e;
-
-typedef enum {
-	BLE_MANAGER_SERVER_LL_CONNECTED,
-	BLE_MANAGER_SERVER_SM_CONNECTED,
-	BLE_MANAGER_SERVER_DISCONNECTED,
-} ble_manager_server_connection_type_e;
+	BLE_ATTR_PERM_W_PERMIT    = 0x00,         /* Always permitted, no restrictions*/
+	BLE_ATTR_PERM_W_AUTHEN    = 0x10,         /* Authentication required */
+	BLE_ATTR_PERM_W_AUTHOR    = 0x20,         /* Authorization required */
+	BLE_ATTR_PERM_W_ENCRYPT   = 0x40,         /* Can only be accessed in encrypted link*/
+	BLE_ATTR_PERM_W_BANNED    = 0x80,         /* Operation not permitted */
+} ble_attr_permission_e;
 
 typedef enum {
-	BLE_MANAGER_SERVER_NONE = 0,
-	BLE_MANAGER_SERVER_IDLE,
-	BLE_MANAGER_SERVER_LL_CONNECT,
-	BLE_MANAGER_SERVER_SM_CONNECT,
-	BLE_MANAGER_SERVER_CONNECTING,
-	BLE_MANAGER_SERVERDISCONNECTING,
-} ble_manager_server_state_e;
+	BLE_SERVER_LL_CONNECTED,
+	BLE_SERVER_SM_CONNECTED,
+	BLE_SERVER_DISCONNECTED,
+} ble_server_connection_type_e;
+
+typedef enum {
+	BLE_SERVER_NONE = 0,
+	BLE_SERVER_IDLE,
+	BLE_SERVER_LL_CONNECT,
+	BLE_SERVER_SM_CONNECT,
+	BLE_SERVER_CONNECTING,
+	BLE_SERVER_DISCONNECTING,
+} ble_server_state_e;
 
 typedef struct {
-	ble_manager_server_gatt_profile_type_e type;
+	ble_server_gatt_profile_type_e type;
 	uint8_t uuid[16];
 	uint16_t uuid_length;
 	uint8_t property;
@@ -108,60 +108,60 @@ typedef struct {
 	ble_attr_handle attr_handle;
 	ble_server_cb_t cb;
 	void* arg;
-} ble_manager_server_gatt_t;
+} ble_server_gatt_t;
 
-typedef void (*ble_manager_server_connected_t)(ble_conn_handle con_handle, ble_manager_server_connection_type_e conn_type, uint8_t mac[BLE_BD_ADDR_MAX_LEN]);
-typedef void (*ble_manager_server_disconnected_t)(ble_conn_handle con_handle, uint16_t cause);
-typedef void (*ble_manager_server_mtu_update_t)(ble_conn_handle con_handle, uint16_t mtu_size);
-typedef void (*ble_manager_server_oneshot_adv_t)(uint16_t adv_result);
+typedef void (*ble_server_connected_t)(ble_conn_handle con_handle, ble_server_connection_type_e conn_type, uint8_t mac[BLE_BD_ADDR_MAX_LEN]);
+typedef void (*ble_server_disconnected_t)(ble_conn_handle con_handle, uint16_t cause);
+typedef void (*ble_server_mtu_update_t)(ble_conn_handle con_handle, uint16_t mtu_size);
+typedef void (*ble_server_oneshot_adv_t)(uint16_t adv_result);
 
 typedef struct {
-	ble_manager_server_connected_t connected_cb;
-	ble_manager_server_disconnected_t disconnected_cb;
-	ble_manager_server_mtu_update_t mtu_update_cb;
-	ble_manager_server_oneshot_adv_t oneshot_adv_cb;
+	ble_server_connected_t connected_cb;
+	ble_server_disconnected_t disconnected_cb;
+	ble_server_mtu_update_t mtu_update_cb;
+	ble_server_oneshot_adv_t oneshot_adv_cb;
 	// true : Secure Manager is enabled. Bondable.
 	// false : Secure Manager is disabled. Requesting Pairing will be rejected. Non-Bondable.
 	bool is_secured_connect_allowed; 
-	ble_manager_server_gatt_t *profile;
+	ble_server_gatt_t *profile;
 	uint16_t profile_count;
-} ble_manager_server_init_config;
+} ble_server_init_config;
 
-ble_result_e ble_manager_server_get_profile_count(uint16_t *count);
+ble_result_e ble_server_get_profile_count(uint16_t *count);
 
 // API for sending a characteristic value notification to the selected target(s). (notify to all clients conn_handle (notify all = 0x99))
-ble_result_e ble_manager_server_charact_notify(ble_attr_handle attr_handle, ble_conn_handle con_handle, ble_data *data);
+ble_result_e ble_server_charact_notify(ble_attr_handle attr_handle, ble_conn_handle con_handle, ble_data *data);
 
 // API for sending a characteristic value indication to the selected target(s). (notify to all clients conn_handle (notify all = 0x99))
-ble_result_e ble_manager_server_charact_indicate(ble_attr_handle attr_handle, ble_conn_handle con_handle, ble_data *data);
+ble_result_e ble_server_charact_indicate(ble_attr_handle attr_handle, ble_conn_handle con_handle, ble_data *data);
 
 // set data of attribute value
-ble_result_e ble_manager_server_attr_set_data(ble_attr_handle attr_handle, ble_data *data);
+ble_result_e ble_server_attr_set_data(ble_attr_handle attr_handle, ble_data *data);
 
 // get data of attribute value
-ble_result_e ble_manager_server_attr_get_data(ble_attr_handle attr_handle, ble_data *data);
+ble_result_e ble_server_attr_get_data(ble_attr_handle attr_handle, ble_data *data);
 
 // reject attribute request in callback function and return error code
-ble_result_e ble_manager_server_reject(ble_attr_handle attr_handle, uint8_t app_errorcode);
+ble_result_e ble_server_reject(ble_attr_handle attr_handle, uint8_t app_errorcode);
 
-ble_result_e ble_manager_server_get_mac_addr_by_conn_handle(ble_conn_handle con_handle, uint8_t bd_addr[BLE_BD_ADDR_MAX_LEN]);
-ble_result_e ble_manager_server_get_conn_handle_by_addr(uint8_t bd_addr[BLE_BD_ADDR_MAX_LEN], ble_conn_handle *con_handle);
+ble_result_e ble_server_get_mac_addr_by_conn_handle(ble_conn_handle con_handle, uint8_t bd_addr[BLE_BD_ADDR_MAX_LEN]);
+ble_result_e ble_server_get_conn_handle_by_addr(uint8_t bd_addr[BLE_BD_ADDR_MAX_LEN], ble_conn_handle *con_handle);
 
 // Set Advertisement Data 
-ble_result_e ble_manager_server_set_adv_data(ble_data *data);
+ble_result_e ble_server_set_adv_data(ble_data *data);
 
 // Set Scan Response Data 
-ble_result_e ble_manager_server_set_adv_resp(ble_data *data);
+ble_result_e ble_server_set_adv_resp(ble_data *data);
 
 // Set Adv type
-ble_result_e ble_manager_server_set_adv_type(ble_adv_type_e adv_type, ble_addr *addr);
+ble_result_e ble_server_set_adv_type(ble_adv_type_e adv_type, ble_addr *addr);
 
 /*
 You can set the fixed interval from 20ms to 10.24 seconds, in steps of 0.625ms. 
 The random delay is a pseudo-random value from 0ms to 10ms that is automatically added. 
 This randomness helps reduce the possibility of collisions between advertisements of different devices
 */
-ble_result_e ble_manager_server_set_adv_interval(unsigned int interval);
+ble_result_e ble_server_set_adv_interval(unsigned int interval);
 
 /* Set tx power for advertising
    Arguement txpower: 
@@ -169,10 +169,10 @@ ble_result_e ble_manager_server_set_adv_interval(unsigned int interval);
 			step : 0.5dBm
 			tested value: 0x06, 0x1A, 0x26
 */
-ble_result_e ble_manager_server_set_adv_tx_power(uint8_t txpower);
+ble_result_e ble_server_set_adv_tx_power(uint8_t txpower);
 
-ble_result_e ble_manager_server_start_adv(void);
-ble_result_e ble_manager_server_stop_adv(void);
+ble_result_e ble_server_start_adv(void);
+ble_result_e ble_server_stop_adv(void);
 
 // Disconnect client. The client with secured connection would be required pairing again. 
-ble_result_e ble_manager_server_disconnect(ble_conn_handle con_handle);
+ble_result_e ble_server_disconnect(ble_conn_handle con_handle);

--- a/framework/src/ble_manager/ble_manager_api.c
+++ b/framework/src/ble_manager/ble_manager_api.c
@@ -32,7 +32,7 @@
 		}                            \
 	} while (0)
 
-ble_result_e ble_manager_init(ble_manager_server_init_config *server_config)
+ble_result_e ble_manager_init(ble_server_init_config *server_config)
 {
 	blemgr_msg_s msg = {BLE_CMD_INIT, BLE_MANAGER_FAIL, (void *)(server_config), NULL};
 	int res = blemgr_post_message(&msg);
@@ -56,9 +56,9 @@ ble_result_e ble_manager_get_mac_addr(uint8_t mac[BLE_BD_ADDR_MAX_LEN])
 	RETURN_RESULT(res, msg);
 }
 
-ble_result_e ble_manager_get_bonded_device(ble_bonded_device_list* device_list, uint16_t* device_count)
+ble_result_e ble_manager_get_bonded_device(ble_bonded_device_list *device_list, uint16_t *device_count)
 {
-	blemgr_msg_params param = { 2, {(void *)device_list, (void *)device_count} };
+	blemgr_msg_params param = {2, {(void *)device_list, (void *)device_count}};
 	blemgr_msg_s msg = {BLE_CMD_GET_BONDED_DEV, BLE_MANAGER_FAIL, (void *)(&param), NULL};
 	int res = blemgr_post_message(&msg);
 
@@ -83,7 +83,7 @@ ble_result_e ble_manager_delete_bonded_all(void)
 
 ble_result_e ble_manager_conn_is_active(ble_conn_handle con_handle, bool *is_active)
 {
-	blemgr_msg_params param = { 2, {(void *)&con_handle, (void *)is_active} };
+	blemgr_msg_params param = {2, {(void *)&con_handle, (void *)is_active}};
 	blemgr_msg_s msg = {BLE_CMD_CONN_IS_ACTIVE, BLE_MANAGER_FAIL, (void *)(&param), NULL};
 	int res = blemgr_post_message(&msg);
 
@@ -108,7 +108,7 @@ ble_result_e ble_manager_get_version(uint8_t version[3])
 
 ble_result_e ble_manager_conn_param_update(ble_conn_handle *con_handle, ble_conn_param *conn_param)
 {
-	blemgr_msg_params param = { 2, {(void *)con_handle, (void *) conn_param} };
+	blemgr_msg_params param = {2, {(void *)con_handle, (void *)conn_param}};
 	blemgr_msg_s msg = {BLE_CMD_CONN_PARAM_UPDATE, BLE_MANAGER_FAIL, (void *)(&param), NULL};
 	int res = blemgr_post_message(&msg);
 
@@ -116,16 +116,16 @@ ble_result_e ble_manager_conn_param_update(ble_conn_handle *con_handle, ble_conn
 }
 
 /* Scanner */
-ble_result_e ble_manager_client_start_scan(ble_scan_filter *filter, ble_scan_callback_list *callbacks)
+ble_result_e ble_client_start_scan(ble_scan_filter *filter, ble_scan_callback_list *callbacks)
 {
-	blemgr_msg_params param = { 2, {(void *)filter, (void *)callbacks} };
+	blemgr_msg_params param = {2, {(void *)filter, (void *)callbacks}};
 	blemgr_msg_s msg = {BLE_CMD_START_SCAN, BLE_MANAGER_FAIL, (void *)(&param), NULL};
 	int res = blemgr_post_message(&msg);
 
 	RETURN_RESULT(res, msg);
 }
 
-ble_result_e ble_manager_client_stop_scan(void)
+ble_result_e ble_client_stop_scan(void)
 {
 	blemgr_msg_s msg = {BLE_CMD_STOP_SCAN, BLE_MANAGER_FAIL, NULL, NULL};
 	int res = blemgr_post_message(&msg);
@@ -133,7 +133,7 @@ ble_result_e ble_manager_client_stop_scan(void)
 	RETURN_RESULT(res, msg);
 }
 
-ble_result_e ble_manager_scan_whitelist_add(ble_addr *addr)
+ble_result_e ble_scan_whitelist_add(ble_addr *addr)
 {
 	blemgr_msg_s msg = {BLE_CMD_WHITELIST_ADD, BLE_MANAGER_FAIL, (void *)(addr), NULL};
 	int res = blemgr_post_message(&msg);
@@ -141,7 +141,7 @@ ble_result_e ble_manager_scan_whitelist_add(ble_addr *addr)
 	RETURN_RESULT(res, msg);
 }
 
-ble_result_e ble_manager_scan_whitelist_delete(ble_addr *addr)
+ble_result_e ble_scan_whitelist_delete(ble_addr *addr)
 {
 	blemgr_msg_s msg = {BLE_CMD_WHITELIST_DELETE, BLE_MANAGER_FAIL, (void *)(addr), NULL};
 	int res = blemgr_post_message(&msg);
@@ -149,7 +149,7 @@ ble_result_e ble_manager_scan_whitelist_delete(ble_addr *addr)
 	RETURN_RESULT(res, msg);
 }
 
-ble_result_e ble_manager_scan_whitelist_clear_all(void)
+ble_result_e ble_scan_whitelist_clear_all(void)
 {
 	blemgr_msg_s msg = {BLE_CMD_WHITELIST_CLEAR_ALL, BLE_MANAGER_FAIL, NULL, NULL};
 	int res = blemgr_post_message(&msg);
@@ -157,9 +157,9 @@ ble_result_e ble_manager_scan_whitelist_clear_all(void)
 	RETURN_RESULT(res, msg);
 }
 
-uint16_t ble_manager_scan_whitelist_list(ble_addr addr[], uint16_t size)
+uint16_t ble_scan_whitelist_list(ble_addr addr[], uint16_t size)
 {
-	blemgr_msg_params param = { 2, {(void *)addr, (void *)&size} };
+	blemgr_msg_params param = {2, {(void *)addr, (void *)&size}};
 	blemgr_msg_s msg = {BLE_CMD_WHITELIST_LIST, BLE_MANAGER_FAIL, (void *)(&param), NULL};
 	int res = blemgr_post_message(&msg);
 
@@ -171,7 +171,7 @@ uint16_t ble_manager_scan_whitelist_list(ble_addr addr[], uint16_t size)
 }
 
 /* Client */
-ble_manager_client_ctx *ble_manager_client_create_ctx(ble_manager_client_callback_list *callbacks)
+ble_client_ctx *ble_client_create_ctx(ble_client_callback_list *callbacks)
 {
 	blemgr_msg_s msg = {BLE_CMD_CREATE_CTX, BLE_MANAGER_FAIL, (void *)callbacks, NULL};
 	int res = blemgr_post_message(&msg);
@@ -179,10 +179,10 @@ ble_manager_client_ctx *ble_manager_client_create_ctx(ble_manager_client_callbac
 	if (res < 0 || msg.result != BLE_MANAGER_SUCCESS) {
 		return NULL;
 	}
-	return (ble_manager_client_ctx *)msg.ret.ptr;
+	return (ble_client_ctx *)msg.ret.ptr;
 }
 
-ble_result_e ble_manager_client_destroy_ctx(ble_manager_client_ctx *ctx)
+ble_result_e ble_client_destroy_ctx(ble_client_ctx *ctx)
 {
 	blemgr_msg_s msg = {BLE_CMD_DESTROY_CTX, BLE_MANAGER_FAIL, (void *)ctx, NULL};
 	int res = blemgr_post_message(&msg);
@@ -190,27 +190,27 @@ ble_result_e ble_manager_client_destroy_ctx(ble_manager_client_ctx *ctx)
 	RETURN_RESULT(res, msg);
 }
 
-ble_manager_client_state_e ble_manager_client_get_state(ble_manager_client_ctx *ctx)
+ble_client_state_e ble_client_get_state(ble_client_ctx *ctx)
 {
 	blemgr_msg_s msg = {BLE_CMD_GET_CLIENT_STATE, BLE_MANAGER_FAIL, (void *)ctx, NULL};
 	int res = blemgr_post_message(&msg);
 
 	if (res < 0 || msg.result != BLE_MANAGER_SUCCESS) {
-		return BLE_MANAGER_CLIENT_NONE;
+		return BLE_CLIENT_NONE;
 	}
-	return (ble_manager_client_state_e)msg.ret.val;
+	return (ble_client_state_e)msg.ret.val;
 }
 
-ble_result_e ble_manager_client_connect(ble_manager_client_ctx *ctx, ble_manager_conn_info *conn_info)
+ble_result_e ble_client_connect(ble_client_ctx *ctx, ble_conn_info *conn_info)
 {
-	blemgr_msg_params param = { 2, {(void *)ctx, (void *)conn_info} };
+	blemgr_msg_params param = {2, {(void *)ctx, (void *)conn_info}};
 	blemgr_msg_s msg = {BLE_CMD_CLIENT_CONNECT, BLE_MANAGER_FAIL, (void *)(&param), NULL};
 	int res = blemgr_post_message(&msg);
 
 	RETURN_RESULT(res, msg);
 }
 
-ble_result_e ble_manager_client_autoconnect(ble_manager_client_ctx *ctx, bool is_auto)
+ble_result_e ble_client_autoconnect(ble_client_ctx *ctx, bool is_auto)
 {
 	blemgr_msg_s msg = {BLE_CMD_CLIENT_DISABLE_AUTOCONNECT, BLE_MANAGER_FAIL, (void *)(ctx), NULL};
 	if (is_auto == true) {
@@ -221,7 +221,7 @@ ble_result_e ble_manager_client_autoconnect(ble_manager_client_ctx *ctx, bool is
 	RETURN_RESULT(res, msg);
 }
 
-ble_result_e ble_manager_client_reconnect(ble_manager_client_ctx *ctx)
+ble_result_e ble_client_reconnect(ble_client_ctx *ctx)
 {
 	blemgr_msg_s msg = {BLE_CMD_CLIENT_RECONNECT, BLE_MANAGER_FAIL, (void *)(ctx), NULL};
 	int res = blemgr_post_message(&msg);
@@ -229,7 +229,7 @@ ble_result_e ble_manager_client_reconnect(ble_manager_client_ctx *ctx)
 	RETURN_RESULT(res, msg);
 }
 
-ble_result_e ble_manager_client_disconnect(ble_manager_client_ctx *ctx)
+ble_result_e ble_client_disconnect(ble_client_ctx *ctx)
 {
 	blemgr_msg_s msg = {BLE_CMD_CLIENT_DISCONNECT, BLE_MANAGER_FAIL, (void *)(ctx), NULL};
 	int res = blemgr_post_message(&msg);
@@ -237,7 +237,7 @@ ble_result_e ble_manager_client_disconnect(ble_manager_client_ctx *ctx)
 	RETURN_RESULT(res, msg);
 }
 
-ble_result_e ble_manager_client_disconnect_all(void)
+ble_result_e ble_client_disconnect_all(void)
 {
 	blemgr_msg_s msg = {BLE_CMD_CLIENT_DISCONNECT_ALL, BLE_MANAGER_FAIL, NULL, NULL};
 	int res = blemgr_post_message(&msg);
@@ -245,7 +245,7 @@ ble_result_e ble_manager_client_disconnect_all(void)
 	RETURN_RESULT(res, msg);
 }
 
-ble_result_e ble_manager_client_connected_device_list(ble_manager_device_connected_list *out_connected_list)
+ble_result_e ble_client_connected_device_list(ble_device_connected_list *out_connected_list)
 {
 	blemgr_msg_s msg = {BLE_CMD_CONNECTED_DEV_LIST, BLE_MANAGER_FAIL, (void *)(out_connected_list), NULL};
 	int res = blemgr_post_message(&msg);
@@ -253,63 +253,63 @@ ble_result_e ble_manager_client_connected_device_list(ble_manager_device_connect
 	RETURN_RESULT(res, msg);
 }
 
-ble_result_e ble_manager_client_connected_info(ble_manager_client_ctx *ctx, ble_manager_device_connected *out_connected_device)
+ble_result_e ble_client_connected_info(ble_client_ctx *ctx, ble_device_connected *out_connected_device)
 {
-	blemgr_msg_params param = { 2, {(void *)ctx, (void *)out_connected_device} };
+	blemgr_msg_params param = {2, {(void *)ctx, (void *)out_connected_device}};
 	blemgr_msg_s msg = {BLE_CMD_CONNECTED_INFO, BLE_MANAGER_FAIL, (void *)(&param), NULL};
 	int res = blemgr_post_message(&msg);
 
 	RETURN_RESULT(res, msg);
 }
 
-ble_result_e ble_manager_client_operation_enable_notification(ble_manager_client_ctx *ctx, ble_attr_handle attr_handle)
+ble_result_e ble_client_operation_enable_notification(ble_client_ctx *ctx, ble_attr_handle attr_handle)
 {
-	blemgr_msg_params param = { 2, {(void *)ctx, (void *)&attr_handle} };
+	blemgr_msg_params param = {2, {(void *)ctx, (void *)&attr_handle}};
 	blemgr_msg_s msg = {BLE_CMD_OP_ENABLE_NOTI, BLE_MANAGER_FAIL, (void *)(&param), NULL};
 	int res = blemgr_post_message(&msg);
 
 	RETURN_RESULT(res, msg);
 }
 
-ble_result_e ble_manager_client_operation_enable_indication(ble_manager_client_ctx *ctx, ble_attr_handle attr_handle)
+ble_result_e ble_client_operation_enable_indication(ble_client_ctx *ctx, ble_attr_handle attr_handle)
 {
-	blemgr_msg_params param = { 2, {(void *)ctx, (void *)&attr_handle} };
+	blemgr_msg_params param = {2, {(void *)ctx, (void *)&attr_handle}};
 	blemgr_msg_s msg = {BLE_CMD_OP_ENABLE_INDICATE, BLE_MANAGER_FAIL, (void *)(&param), NULL};
 	int res = blemgr_post_message(&msg);
 
 	RETURN_RESULT(res, msg);
 }
 
-ble_result_e ble_manager_client_operation_enable_notification_and_indication(ble_manager_client_ctx *ctx, ble_attr_handle attr_handle)
+ble_result_e ble_client_operation_enable_notification_and_indication(ble_client_ctx *ctx, ble_attr_handle attr_handle)
 {
-	blemgr_msg_params param = { 2, {(void *)ctx, (void *)&attr_handle} };
+	blemgr_msg_params param = {2, {(void *)ctx, (void *)&attr_handle}};
 	blemgr_msg_s msg = {BLE_CMD_OP_ENABLE_NOTI_AND_INDICATE, BLE_MANAGER_FAIL, (void *)(&param), NULL};
 	int res = blemgr_post_message(&msg);
 
 	RETURN_RESULT(res, msg);
 }
 
-ble_result_e ble_manager_client_operation_read(ble_manager_client_ctx *ctx, ble_attr_handle attr_handle, ble_data *data)
+ble_result_e ble_client_operation_read(ble_client_ctx *ctx, ble_attr_handle attr_handle, ble_data *data)
 {
-	blemgr_msg_params param = { 3, {(void *)ctx, (void *)&attr_handle, (void *)data} };
+	blemgr_msg_params param = {3, {(void *)ctx, (void *)&attr_handle, (void *)data}};
 	blemgr_msg_s msg = {BLE_CMD_OP_READ, BLE_MANAGER_FAIL, (void *)(&param), NULL};
 	int res = blemgr_post_message(&msg);
 
 	RETURN_RESULT(res, msg);
 }
 
-ble_result_e ble_manager_client_operation_write(ble_manager_client_ctx *ctx, ble_attr_handle attr_handle, ble_data *data)
+ble_result_e ble_client_operation_write(ble_client_ctx *ctx, ble_attr_handle attr_handle, ble_data *data)
 {
-	blemgr_msg_params param = { 3, {(void *)ctx, (void *)&attr_handle, (void *)data} };
+	blemgr_msg_params param = {3, {(void *)ctx, (void *)&attr_handle, (void *)data}};
 	blemgr_msg_s msg = {BLE_CMD_OP_WRITE, BLE_MANAGER_FAIL, (void *)(&param), NULL};
 	int res = blemgr_post_message(&msg);
 
 	RETURN_RESULT(res, msg);
 }
 
-ble_result_e ble_manager_client_operation_write_no_response(ble_manager_client_ctx *ctx, ble_attr_handle attr_handle, ble_data *data)
+ble_result_e ble_client_operation_write_no_response(ble_client_ctx *ctx, ble_attr_handle attr_handle, ble_data *data)
 {
-	blemgr_msg_params param = { 3, {(void *)ctx, (void *)&attr_handle, (void *)data} };
+	blemgr_msg_params param = {3, {(void *)ctx, (void *)&attr_handle, (void *)data}};
 	blemgr_msg_s msg = {BLE_CMD_OP_WRITE_NO_RESP, BLE_MANAGER_FAIL, (void *)(&param), NULL};
 	int res = blemgr_post_message(&msg);
 
@@ -317,7 +317,7 @@ ble_result_e ble_manager_client_operation_write_no_response(ble_manager_client_c
 }
 
 /* Server */
-ble_result_e ble_manager_server_get_profile_count(uint16_t *count)
+ble_result_e ble_server_get_profile_count(uint16_t *count)
 {
 	blemgr_msg_s msg = {BLE_CMD_GET_PROFILE_COUNT, BLE_MANAGER_FAIL, (void *)(count), NULL};
 	int res = blemgr_post_message(&msg);
@@ -325,65 +325,64 @@ ble_result_e ble_manager_server_get_profile_count(uint16_t *count)
 	RETURN_RESULT(res, msg);
 }
 
-ble_result_e ble_manager_server_charact_notify(ble_attr_handle attr_handle, ble_conn_handle con_handle, ble_data *data)
+ble_result_e ble_server_charact_notify(ble_attr_handle attr_handle, ble_conn_handle con_handle, ble_data *data)
 {
-	blemgr_msg_params param = { 3, {(void *)&attr_handle, (void *)&con_handle, (void *)data} };
+	blemgr_msg_params param = {3, {(void *)&attr_handle, (void *)&con_handle, (void *)data}};
 	blemgr_msg_s msg = {BLE_CMD_CHARACT_NOTI, BLE_MANAGER_FAIL, (void *)(&param), NULL};
 	int res = blemgr_post_message(&msg);
 
 	RETURN_RESULT(res, msg);
 }
 
-ble_result_e ble_manager_server_charact_indicate(ble_attr_handle attr_handle, ble_conn_handle con_handle, ble_data *data)
+ble_result_e ble_server_charact_indicate(ble_attr_handle attr_handle, ble_conn_handle con_handle, ble_data *data)
 {
-	blemgr_msg_params param = { 3, {(void *)&attr_handle, (void *)&con_handle, (void *)data} };
+	blemgr_msg_params param = {3, {(void *)&attr_handle, (void *)&con_handle, (void *)data}};
 	blemgr_msg_s msg = {BLE_CMD_CHARACT_INDI, BLE_MANAGER_FAIL, (void *)(&param), NULL};
 	int res = blemgr_post_message(&msg);
 
 	RETURN_RESULT(res, msg);
 }
 
-ble_result_e ble_manager_server_get_indicate_pending_count(ble_conn_handle con_handle, uint8_t *count)
+ble_result_e ble_server_get_indicate_pending_count(ble_conn_handle con_handle, uint8_t *count)
 {
-	if (count == NULL)
-	{
+	if (count == NULL) {
 		return BLE_MANAGER_INVALID_ARGS;
 	}
-	blemgr_msg_params param = { 2, {(void *)&con_handle, (void *)count} };
+	blemgr_msg_params param = {2, {(void *)&con_handle, (void *)count}};
 	blemgr_msg_s msg = {BLE_CMD_GET_INDICATE_PENDING_CNT, BLE_MANAGER_FAIL, (void *)(&param), NULL};
 	int res = blemgr_post_message(&msg);
 
 	RETURN_RESULT(res, msg);
 }
 
-ble_result_e ble_manager_server_attr_set_data(ble_attr_handle attr_handle, ble_data *data)
+ble_result_e ble_server_attr_set_data(ble_attr_handle attr_handle, ble_data *data)
 {
-	blemgr_msg_params param = { 2, {(void *)&attr_handle, (void *)data} };
+	blemgr_msg_params param = {2, {(void *)&attr_handle, (void *)data}};
 	blemgr_msg_s msg = {BLE_CMD_ATTR_SET_DATA, BLE_MANAGER_FAIL, (void *)(&param), NULL};
 	int res = blemgr_post_message(&msg);
 
 	RETURN_RESULT(res, msg);
 }
 
-ble_result_e ble_manager_server_attr_get_data(ble_attr_handle attr_handle, ble_data *data)
+ble_result_e ble_server_attr_get_data(ble_attr_handle attr_handle, ble_data *data)
 {
-	blemgr_msg_params param = { 2, {(void *)&attr_handle, (void *)data} };
+	blemgr_msg_params param = {2, {(void *)&attr_handle, (void *)data}};
 	blemgr_msg_s msg = {BLE_CMD_ATTR_GET_DATA, BLE_MANAGER_FAIL, (void *)(&param), NULL};
 	int res = blemgr_post_message(&msg);
 
 	RETURN_RESULT(res, msg);
 }
 
-ble_result_e ble_manager_server_reject(ble_attr_handle attr_handle, uint8_t app_errorcode)
+ble_result_e ble_server_reject(ble_attr_handle attr_handle, uint8_t app_errorcode)
 {
-	blemgr_msg_params param = { 2, {(void *)&attr_handle, (void *)&app_errorcode} };
+	blemgr_msg_params param = {2, {(void *)&attr_handle, (void *)&app_errorcode}};
 	blemgr_msg_s msg = {BLE_CMD_ATTR_REJECT, BLE_MANAGER_FAIL, (void *)(&param), NULL};
 	int res = blemgr_post_message(&msg);
 
 	RETURN_RESULT(res, msg);
 }
 
-ble_result_e ble_manager_server_disconnect(ble_conn_handle con_handle)
+ble_result_e ble_server_disconnect(ble_conn_handle con_handle)
 {
 	blemgr_msg_s msg = {BLE_CMD_SERVER_DISCONNECT, BLE_MANAGER_FAIL, (void *)(&con_handle), NULL};
 	int res = blemgr_post_message(&msg);
@@ -391,25 +390,25 @@ ble_result_e ble_manager_server_disconnect(ble_conn_handle con_handle)
 	RETURN_RESULT(res, msg);
 }
 
-ble_result_e ble_manager_server_get_mac_addr_by_conn_handle(ble_conn_handle con_handle, uint8_t bd_addr[BLE_BD_ADDR_MAX_LEN])
+ble_result_e ble_server_get_mac_addr_by_conn_handle(ble_conn_handle con_handle, uint8_t bd_addr[BLE_BD_ADDR_MAX_LEN])
 {
-	blemgr_msg_params param = { 2, {(void *)&con_handle, (void *)bd_addr} };
+	blemgr_msg_params param = {2, {(void *)&con_handle, (void *)bd_addr}};
 	blemgr_msg_s msg = {BLE_CMD_GET_MAC_BY_CONN, BLE_MANAGER_FAIL, (void *)(&param), NULL};
 	int res = blemgr_post_message(&msg);
 
 	RETURN_RESULT(res, msg);
 }
 
-ble_result_e ble_manager_server_get_conn_handle_by_addr(uint8_t bd_addr[BLE_BD_ADDR_MAX_LEN], ble_conn_handle *con_handle)
+ble_result_e ble_server_get_conn_handle_by_addr(uint8_t bd_addr[BLE_BD_ADDR_MAX_LEN], ble_conn_handle *con_handle)
 {
-	blemgr_msg_params param = { 2, {(void *)bd_addr, (void *)con_handle} };
+	blemgr_msg_params param = {2, {(void *)bd_addr, (void *)con_handle}};
 	blemgr_msg_s msg = {BLE_CMD_GET_CONN_BY_MAC, BLE_MANAGER_FAIL, (void *)(&param), NULL};
 	int res = blemgr_post_message(&msg);
 
 	RETURN_RESULT(res, msg);
 }
 
-ble_result_e ble_manager_server_set_adv_data(ble_data *data)
+ble_result_e ble_server_set_adv_data(ble_data *data)
 {
 	blemgr_msg_s msg = {BLE_CMD_SET_ADV_DATA, BLE_MANAGER_FAIL, (void *)(data), NULL};
 	int res = blemgr_post_message(&msg);
@@ -417,7 +416,7 @@ ble_result_e ble_manager_server_set_adv_data(ble_data *data)
 	RETURN_RESULT(res, msg);
 }
 
-ble_result_e ble_manager_server_set_adv_resp(ble_data *data)
+ble_result_e ble_server_set_adv_resp(ble_data *data)
 {
 	blemgr_msg_s msg = {BLE_CMD_SET_ADV_RESP, BLE_MANAGER_FAIL, (void *)(data), NULL};
 	int res = blemgr_post_message(&msg);
@@ -425,16 +424,16 @@ ble_result_e ble_manager_server_set_adv_resp(ble_data *data)
 	RETURN_RESULT(res, msg);
 }
 
-ble_result_e ble_manager_server_set_adv_type(ble_adv_type_e adv_type, ble_addr *addr)
+ble_result_e ble_server_set_adv_type(ble_adv_type_e adv_type, ble_addr *addr)
 {
-	blemgr_msg_params param = { 2, {(void *)&adv_type, (void *)addr} };
+	blemgr_msg_params param = {2, {(void *)&adv_type, (void *)addr}};
 	blemgr_msg_s msg = {BLE_CMD_SET_ADV_TYPE, BLE_MANAGER_FAIL, (void *)(&param), NULL};
 	int res = blemgr_post_message(&msg);
 
 	RETURN_RESULT(res, msg);
 }
 
-ble_result_e ble_manager_server_set_adv_interval(unsigned int interval)
+ble_result_e ble_server_set_adv_interval(unsigned int interval)
 {
 	blemgr_msg_s msg = {BLE_CMD_SET_ADV_INTERVAL, BLE_MANAGER_FAIL, (void *)(&interval), NULL};
 	int res = blemgr_post_message(&msg);
@@ -442,7 +441,7 @@ ble_result_e ble_manager_server_set_adv_interval(unsigned int interval)
 	RETURN_RESULT(res, msg);
 }
 
-ble_result_e ble_manager_server_set_adv_tx_power(uint8_t txpower)
+ble_result_e ble_server_set_adv_tx_power(uint8_t txpower)
 {
 	blemgr_msg_s msg = {BLE_CMD_SET_ADV_TXPOWER, BLE_MANAGER_FAIL, (void *)(&txpower), NULL};
 	int res = blemgr_post_message(&msg);
@@ -450,14 +449,14 @@ ble_result_e ble_manager_server_set_adv_tx_power(uint8_t txpower)
 	RETURN_RESULT(res, msg);
 }
 
-ble_result_e ble_manager_server_start_adv(void)
+ble_result_e ble_server_start_adv(void)
 {
 	blemgr_msg_s msg = {BLE_CMD_START_ADV, BLE_MANAGER_FAIL, NULL, NULL};
 	int res = blemgr_post_message(&msg);
 
 	RETURN_RESULT(res, msg);
 }
-ble_result_e ble_manager_server_one_shot_adv_init(void)
+ble_result_e ble_server_one_shot_adv_init(void)
 {
 	blemgr_msg_s msg = {BLE_CMD_ONE_SHOT_ADV_INIT, BLE_MANAGER_FAIL, NULL, NULL};
 	int res = blemgr_post_message(&msg);
@@ -465,7 +464,7 @@ ble_result_e ble_manager_server_one_shot_adv_init(void)
 	RETURN_RESULT(res, msg);
 }
 
-ble_result_e ble_manager_server_one_shot_adv_deinit(void)
+ble_result_e ble_server_one_shot_adv_deinit(void)
 {
 	blemgr_msg_s msg = {BLE_CMD_ONE_SHOT_ADV_DEINIT, BLE_MANAGER_FAIL, NULL, NULL};
 	int res = blemgr_post_message(&msg);
@@ -473,16 +472,16 @@ ble_result_e ble_manager_server_one_shot_adv_deinit(void)
 	RETURN_RESULT(res, msg);
 }
 
-ble_result_e ble_manager_server_one_shot_adv(ble_data *data_adv, ble_data *data_scan_rsp, uint8_t type)
+ble_result_e ble_server_one_shot_adv(ble_data *data_adv, ble_data *data_scan_rsp, uint8_t type)
 {
-	blemgr_msg_params param = { 3, {(void *)data_adv, (void *)data_scan_rsp, (void *)&type}};
+	blemgr_msg_params param = {3, {(void *)data_adv, (void *)data_scan_rsp, (void *)&type}};
 	blemgr_msg_s msg = {BLE_CMD_ONE_SHOT_ADV, BLE_MANAGER_FAIL, (void *)(&param), NULL};
 	int res = blemgr_post_message(&msg);
 
 	RETURN_RESULT(res, msg);
 }
 
-ble_result_e ble_manager_server_stop_adv(void)
+ble_result_e ble_server_stop_adv(void)
 {
 	blemgr_msg_s msg = {BLE_CMD_STOP_ADV, BLE_MANAGER_FAIL, NULL, NULL};
 	int res = blemgr_post_message(&msg);

--- a/framework/src/ble_manager/ble_manager_autoconnect.c
+++ b/framework/src/ble_manager/ble_manager_autoconnect.c
@@ -27,7 +27,7 @@
 #include "ble_manager_autoconnect.h"
 #include "ble_manager_log.h"
 
-static ble_manager_client_ctx_internal *g_ctx = NULL;
+static ble_client_ctx_internal *g_ctx = NULL;
 
 static void ble_auto_scan_state_changed_cb(ble_scan_state_e scan_state)
 {
@@ -82,7 +82,7 @@ static void *_autocon_process(void *param)
 
 	ble_autocon_state state = BLE_AUTOCON_STATE_DISCONNECT;
 	ble_autocon_event evt;
-	ble_manager_client_ctx_internal *ctx = (ble_manager_client_ctx_internal *)param;
+	ble_client_ctx_internal *ctx = (ble_client_ctx_internal *)param;
 
 	struct mq_attr attr;
 	char mq_name[10] = { 0, };
@@ -99,14 +99,14 @@ static void *_autocon_process(void *param)
 	ctx->mqfd = mq_open(mq_name, O_RDWR | O_CREAT, 0666, &attr);
 	if (ctx->mqfd == (mqd_t)ERROR) {
 		BLE_LOG_ERROR("[BLEMGR] fail to open mqueue(fd : %d , err : %d)", ctx->mqfd, errno);
-		ctx->state = BLE_MANAGER_CLIENT_IDLE;
+		ctx->state = BLE_CLIENT_IDLE;
 		return NULL;
 	}
 	g_ctx = ctx;
 
-	while (ctx->state == BLE_MANAGER_CLIENT_AUTOCONNECTING) {
+	while (ctx->state == BLE_CLIENT_AUTOCONNECTING) {
 		if (state == BLE_AUTOCON_STATE_DISCONNECT) {
-			ret = ble_manager_client_start_scan(NULL, &scan_config);
+			ret = ble_client_start_scan(NULL, &scan_config);
 			if (ret != BLE_MANAGER_SUCCESS) {
 				BLE_LOG_ERROR("[BLEMGR] auto conn scan fail[%d]\n", ret);
 				goto finish_auto;
@@ -133,7 +133,7 @@ static void *_autocon_process(void *param)
 			conn_stop = 1;
 			if (state == BLE_AUTOCON_STATE_SCAN_STARTING) {
 				state = BLE_AUTOCON_STATE_SCAN_STOPPING;
-				ret = ble_manager_client_stop_scan();
+				ret = ble_client_stop_scan();
 				if (ret != BLE_MANAGER_SUCCESS) {
 					BLE_LOG_ERROR("[BLEMGR] auto conn scan stop fail[%d]\n", ret);
 					goto finish_auto;
@@ -155,7 +155,7 @@ static void *_autocon_process(void *param)
 			}
 
 			if (state == BLE_AUTOCON_STATE_DONE) {
-				ctx->state = BLE_MANAGER_CLIENT_IDLE;
+				ctx->state = BLE_CLIENT_IDLE;
 				ctx->auto_connect = false;
 				break;
 			}
@@ -168,7 +168,7 @@ static void *_autocon_process(void *param)
 		} else if (state == BLE_AUTOCON_STATE_SCAN_STARTING) {
 			if (evt == BLE_AUTOCON_EVT_MAC_SCANNED) {
 				state = BLE_AUTOCON_STATE_SCAN_STOPPING;
-				ret = ble_manager_client_stop_scan();
+				ret = ble_client_stop_scan();
 				if (ret != BLE_MANAGER_SUCCESS) {
 					BLE_LOG_ERROR("[BLEMGR] auto conn scan stop fail[%d]\n", ret);
 					goto finish_auto;
@@ -177,7 +177,7 @@ static void *_autocon_process(void *param)
 		} else if (state == BLE_AUTOCON_STATE_SCAN_STOPPING) {
 			if (evt == BLE_AUTOCON_EVT_SCAN_STOP) {
 				state = BLE_AUTOCON_STATE_CONNECTING;
-				ret = ble_manager_client_reconnect((ble_manager_client_ctx *)ctx);
+				ret = ble_client_reconnect((ble_client_ctx *)ctx);
 				if (ret != BLE_MANAGER_SUCCESS) {
 					BLE_LOG_ERROR("[BLEMGR] auto conn reconnect fail[%d]\n", ret);
 					goto finish_auto;
@@ -204,9 +204,9 @@ finish_auto:
 	return NULL;
 }
 
-ble_autocon_result_e ble_manager_autoconnect(ble_manager_client_ctx_internal *ctx)
+ble_autocon_result_e ble_manager_autoconnect(ble_client_ctx_internal *ctx)
 {
-	if (ctx->state != BLE_MANAGER_CLIENT_AUTOCONNECTING) {
+	if (ctx->state != BLE_CLIENT_AUTOCONNECTING) {
 		return BLE_AUTOCON_INVALID_STATE;
 	}
 

--- a/framework/src/ble_manager/ble_manager_autoconnect.h
+++ b/framework/src/ble_manager/ble_manager_autoconnect.h
@@ -44,4 +44,4 @@ typedef enum {
 	BLE_AUTOCON_EVT_CANCEL,
 } ble_autocon_event;
 
-ble_autocon_result_e ble_manager_autoconnect(ble_manager_client_ctx_internal *ctx);
+ble_autocon_result_e ble_manager_autoconnect(ble_client_ctx_internal *ctx);

--- a/framework/src/ble_manager/ble_manager_common.h
+++ b/framework/src/ble_manager/ble_manager_common.h
@@ -22,13 +22,13 @@
 
 typedef struct {
 	ble_conn_handle conn_handle;
-	volatile ble_manager_client_state_e state;
-	ble_manager_conn_info info;
+	volatile ble_client_state_e state;
+	ble_conn_info info;
 	bool is_bonded;
 	bool auto_connect;
 	mqd_t mqfd;
-	ble_manager_client_callback_list callbacks;
-} ble_manager_client_ctx_internal;
+	ble_client_callback_list callbacks;
+} ble_client_ctx_internal;
 
 typedef struct {
 	volatile ble_scan_state_e state;
@@ -38,9 +38,9 @@ typedef struct {
 
 typedef struct {
 	ble_conn_handle conn_handle;
-	volatile ble_manager_server_state_e state;
+	volatile ble_server_state_e state;
 	bool is_secured_connect_allowed;
-	ble_manager_server_gatt_t *profile;
+	ble_server_gatt_t *profile;
 	uint16_t profile_count;
-	ble_manager_server_connected_t callback;
+	ble_server_connected_t callback;
 } ble_server_ctx;


### PR DESCRIPTION
This reverts commit cb52843133e846c26cb141955b6f0fd44268ca40.
- To maintain compatibility with existing product codes, we postpone the renaming of functions.