### PR TITLE
apps/system/utils/README.md: fix minor typo

### DIFF
--- a/apps/system/utils/README.md
+++ b/apps/system/utils/README.md
@@ -17,7 +17,7 @@ Most of the commands support *--help* option to show how to use.
 |                    | [irqinfo](#irqinfo)                             | [mv](#mv)               |
 |                    | [kill/killall](#killkillall)                    | [mount](#mount)         |
 |                    | [prodconfig](#prodconfig)                       | [umount](#umount)       |
-|                    | [ps](#s)                                        | [pwd](#pwd)             |
+|                    | [ps](#ps)                                       | [pwd](#pwd)             |
 |                    | [reboot](#reboot)                               | [rm](#rm)               |
 |                    | [stkmon](#stkmon)                               | [rmdir](#rmdir)         |
 |                    | [uptime](#uptime)                               |                         |


### PR DESCRIPTION
This commit fixes minor typo from #s to #ps for correct link.