### PR TITLE
os/arch/arm/src/amebasmart: allow booting normally when USB not attached

### DIFF
--- a/os/arch/arm/src/armv7-a/arm_initialize.c
+++ b/os/arch/arm/src/armv7-a/arm_initialize.c
@@ -188,7 +188,10 @@ void up_initialize(void)
 #ifdef USE_SERIALDRIVER
 	up_serialinit();
 #endif
-
+#ifdef CONFIG_AMEBASMART_USBDEVICE
+	/*if USB device enabled, we will unregister loguart and register /dev/console to usb*/
+	register_usb();
+#endif
 	/* Initialize the console device driver (if it is other than the standard
 	 * serial driver).
 	 */


### PR DESCRIPTION
1. allow it to boot normally even with no USB attached, use task instead of busy wait for usb init.
2. once USB attached, logs and tash can be input from usb port.