### PR TITLE
tools/uart_hw_test: update tool to include tx time gap stats

### DIFF
--- a/tools/uart_hw_test/uart_test.c
+++ b/tools/uart_hw_test/uart_test.c
@@ -137,6 +137,10 @@ static void test_uart_tx(int fd, int baud)
 {
 	volatile u_int8_t ch;
 	double tm_diff, max_diff = 0;
+	double tm_diff_usec;
+	double min_diff_usec = __DBL_MAX__;
+	double max_diff_usec = 0;
+	double total_diff_usec = 0;
 	struct timeval  tv1, tv2;
 	int cnt = 0;
 	int numfail = 0;
@@ -160,6 +164,17 @@ static void test_uart_tx(int fd, int baud)
 			cnt++;
 
 			tm_diff = ((tv2.tv_sec - tv1.tv_sec) * 1000) + ((tv2.tv_usec - tv1.tv_usec) / 1000);
+			tm_diff_usec = ((tv2.tv_sec - tv1.tv_sec) * 1000000) + (tv2.tv_usec - tv1.tv_usec);
+
+			total_diff_usec += tm_diff_usec;
+			if (tm_diff_usec > max_diff_usec) {
+				max_diff_usec = tm_diff_usec;
+			}
+
+			if (tm_diff_usec < min_diff_usec) {
+				min_diff_usec = tm_diff_usec;
+			}
+
 			if (tm_diff > UART_MAX_DELAY_MS) {
 				numfail++;
 				if (tm_diff > max_diff) {
@@ -173,9 +188,11 @@ result:
 	if (numfail) {
 		fail++;
 		printf("[BAUD %6d Tx] FAIL (Num out of spec = %d / %d Max delay = %fms)\n", baud, numfail, UART_TEST_COUNT, max_diff);
+		printf("[BAUD %6d Tx] tx packet gap stats(in usec):  Avg: %.2f  Min: %.2f  Max: %.2f\n", baud, total_diff_usec / cnt, min_diff_usec, max_diff_usec);
 	} else {
 		pass++;
 		printf("[BAUD %6d Tx] PASS\n", baud);
+		printf("[BAUD %6d Tx] tx packet gap stats(in usec):  Avg: %.2f  Min: %.2f  Max: %.2f\n", baud, total_diff_usec / cnt, min_diff_usec, max_diff_usec);
 	}
 
 	do {


### PR DESCRIPTION
Now the uart hardware test tool will include code to show tx time gap data (time gap between consecutive tx packet sent). It will show the minimum, maximum and average time gap in microsecond.

Following will be the output after new test result:

```
	Enter UART port number : 4
	Opened UART port : /dev/ttyUSB4
	######################## UART Test Start #############################
	######################################################################
	Test Scenario 0: UART test only
	######################################################################
	[BAUD 115200 Tx] PASS
	[BAUD 115200 Tx] tx packet gap stats(in usec):  Avg: 11.37  Min: 1.00  Max: 513.00
	[BAUD 115200 Rx] PASS
	[BAUD  38400 Tx] PASS
	[BAUD  38400 Tx] tx packet gap stats(in usec):  Avg: 1.22  Min: 1.00  Max: 2.00
	[BAUD  38400 Rx] PASS
	[BAUD  19200 Tx] PASS
	[BAUD  19200 Tx] tx packet gap stats(in usec):  Avg: 1.98  Min: 1.00  Max: 8.00
	[BAUD  19200 Rx] PASS
	[BAUD   9600 Tx] PASS
	[BAUD   9600 Tx] tx packet gap stats(in usec):  Avg: 1.84  Min: 1.00  Max: 21.00
	[BAUD   9600 Rx] PASS
	[BAUD   4800 Tx] PASS
	[BAUD   4800 Tx] tx packet gap stats(in usec):  Avg: 2.68  Min: 2.00  Max: 5.00
	[BAUD   4800 Rx] PASS

	######################################################################
	Test Scenario 1: UART test with background FS ops
	######################################################################
	[BAUD 115200 Tx] PASS
	[BAUD 115200 Tx] tx packet gap stats(in usec):  Avg: 6.07  Min: 2.00  Max: 384.00
	[BAUD 115200 Rx] PASS
	[BAUD  38400 Tx] PASS
	[BAUD  38400 Tx] tx packet gap stats(in usec):  Avg: 1.10  Min: 1.00  Max: 2.00
	[BAUD  38400 Rx] PASS
	[BAUD  19200 Tx] PASS
	[BAUD  19200 Tx] tx packet gap stats(in usec):  Avg: 2.04  Min: 1.00  Max: 42.00
	[BAUD  19200 Rx] PASS
	[BAUD   9600 Tx] PASS
	[BAUD   9600 Tx] tx packet gap stats(in usec):  Avg: 1.66  Min: 1.00  Max: 6.00
	[BAUD   9600 Rx] PASS
	[BAUD   4800 Tx] PASS
	[BAUD   4800 Tx] tx packet gap stats(in usec):  Avg: 5.01  Min: 1.00  Max: 294.00
	[BAUD   4800 Rx] PASS

	######################################################################
	Test Scenario 2: UART test with background console logs
	######################################################################
	[BAUD 115200 Tx] PASS
	[BAUD 115200 Tx] tx packet gap stats(in usec):  Avg: 3.17  Min: 2.00  Max: 6.00
	[BAUD 115200 Rx] PASS
	[BAUD  38400 Tx] PASS
	[BAUD  38400 Tx] tx packet gap stats(in usec):  Avg: 3.35  Min: 3.00  Max: 5.00
	[BAUD  38400 Rx] PASS
	[BAUD  19200 Tx] PASS
	[BAUD  19200 Tx] tx packet gap stats(in usec):  Avg: 1.21  Min: 1.00  Max: 2.00
	[BAUD  19200 Rx] PASS
	[BAUD   9600 Tx] PASS
	[BAUD   9600 Tx] tx packet gap stats(in usec):  Avg: 1.17  Min: 0.00  Max: 7.00
	[BAUD   9600 Rx] PASS
	[BAUD   4800 Tx] PASS
	[BAUD   4800 Tx] tx packet gap stats(in usec):  Avg: 1.51  Min: 1.00  Max: 3.00
	[BAUD   4800 Rx] PASS

	######################################################################
	Test Scenario 3: UART test with background iperf
	######################################################################
	[BAUD 115200 Tx] PASS
	[BAUD 115200 Tx] tx packet gap stats(in usec):  Avg: 0.84  Min: 0.00  Max: 1.00
	[BAUD 115200 Rx] PASS
	[BAUD  38400 Tx] PASS
	[BAUD  38400 Tx] tx packet gap stats(in usec):  Avg: 2.09  Min: 2.00  Max: 3.00
	[BAUD  38400 Rx] PASS
	[BAUD  19200 Tx] PASS
	[BAUD  19200 Tx] tx packet gap stats(in usec):  Avg: 2.89  Min: 2.00  Max: 3.00
	[BAUD  19200 Rx] PASS
	[BAUD   9600 Tx] PASS
	[BAUD   9600 Tx] tx packet gap stats(in usec):  Avg: 3.49  Min: 3.00  Max: 7.00
	[BAUD   9600 Rx] PASS
	[BAUD   4800 Tx] PASS
	[BAUD   4800 Tx] tx packet gap stats(in usec):  Avg: 2.64  Min: 1.00  Max: 78.00
	[BAUD   4800 Rx] PASS
	######################################################################
	################## UART Test End [PASS: 40, FAIL: 0] #################
```