### PR TITLE
 arch/armv7-a: change format of abort logs to match with ARMv8-M's

### DIFF
--- a/os/arch/arm/src/armv7-a/arm_dataabort.c
+++ b/os/arch/arm/src/armv7-a/arm_dataabort.c
@@ -69,6 +69,22 @@
 uint32_t system_exception_location;
 
 /****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: print_dataabort_detail
+ ****************************************************************************/
+
+static inline void print_dataabort_detail(uint32_t *regs, uint32_t dfar, uint32_t dfsr)
+{
+	_alert("#########################################################################\n");
+	_alert("PANIC!!! Data Abort at instruction : 0x%08x\n",  regs[REG_PC]);
+	_alert("PC: %08x DFAR: %08x DFSR: %08x\n", regs[REG_PC], dfar, dfsr);
+	_alert("#########################################################################\n\n\n");
+}
+
+/****************************************************************************
  * Public Functions
  ****************************************************************************/
 
@@ -166,7 +182,9 @@ uint32_t *arm_dataabort(uint32_t *regs, uint32_t dfar, uint32_t dfsr)
 	return regs;
 
 segfault:
-	_alert("Data abort. PC: %08x DFAR: %08x DFSR: %08x\n", regs[REG_PC], dfar, dfsr);
+	if (!IS_SECURE_STATE()) {
+		print_dataabort_detail(regs, dfar, dfsr);
+	}
 
 #ifdef CONFIG_SYSTEM_REBOOT_REASON
 	up_reboot_reason_write(REBOOT_SYSTEM_DATAABORT);
@@ -187,7 +205,9 @@ SRAMDRAM_ONLY_TEXT_SECTION uint32_t *arm_dataabort(uint32_t *regs, uint32_t dfar
   CURRENT_REGS = regs;
   system_exception_location = regs[REG_R15];
   /* Crash -- possibly showing diagnostic debug information. */
-	_alert("Data abort. PC: %08x DFAR: %08x DFSR: %08x\n", regs[REG_PC], dfar, dfsr);
+	if (!IS_SECURE_STATE()) {
+		print_dataabort_detail(regs, dfar, dfsr);
+	}
 
 #ifdef CONFIG_SYSTEM_REBOOT_REASON
 	up_reboot_reason_write(REBOOT_SYSTEM_DATAABORT);

--- a/os/arch/arm/src/armv7-a/arm_dataabort.c
+++ b/os/arch/arm/src/armv7-a/arm_dataabort.c
@@ -198,13 +198,13 @@ segfault:
 #include "section_config.h"
 SRAMDRAM_ONLY_TEXT_SECTION uint32_t *arm_dataabort(uint32_t *regs, uint32_t dfar, uint32_t dfsr)
 {
-  /* Save the saved processor context in CURRENT_REGS where it can be
-   * accessed for register dumps and possibly context switching.
-   */
-  uint32_t *saved_state = (uint32_t *)CURRENT_REGS;
-  CURRENT_REGS = regs;
-  system_exception_location = regs[REG_R15];
-  /* Crash -- possibly showing diagnostic debug information. */
+	/* Save the saved processor context in CURRENT_REGS where it can be
+	 * accessed for register dumps and possibly context switching.
+	 */
+	uint32_t *saved_state = (uint32_t *)CURRENT_REGS;
+	CURRENT_REGS = regs;
+	system_exception_location = regs[REG_R15];
+	/* Crash -- possibly showing diagnostic debug information. */
 	if (!IS_SECURE_STATE()) {
 		print_dataabort_detail(regs, dfar, dfsr);
 	}
@@ -212,11 +212,11 @@ SRAMDRAM_ONLY_TEXT_SECTION uint32_t *arm_dataabort(uint32_t *regs, uint32_t dfar
 #ifdef CONFIG_SYSTEM_REBOOT_REASON
 	up_reboot_reason_write(REBOOT_SYSTEM_DATAABORT);
 #endif
-  
-  PANIC();
-  regs = (uint32_t *)CURRENT_REGS;
-  CURRENT_REGS = saved_state;
-  return regs; /* To keep the compiler happy */
+
+	PANIC();
+	regs = (uint32_t *)CURRENT_REGS;
+	CURRENT_REGS = saved_state;
+	return regs; /* To keep the compiler happy */
 }
 
 #endif							/* CONFIG_PAGING */

--- a/os/arch/arm/src/armv7-a/arm_prefetchabort.c
+++ b/os/arch/arm/src/armv7-a/arm_prefetchabort.c
@@ -169,11 +169,11 @@ uint32_t *arm_prefetchabort(uint32_t *regs, uint32_t ifar, uint32_t ifsr)
 
 uint32_t *arm_prefetchabort(uint32_t *regs, uint32_t ifar, uint32_t ifsr)
 {
-  /* Save the saved processor context in CURRENT_REGS where it can be
-   * accessed for register dumps and possibly context switching.
-   */
-  uint32_t *saved_state = (uint32_t *)CURRENT_REGS;
-  CURRENT_REGS = regs;
+	/* Save the saved processor context in CURRENT_REGS where it can be
+	 * accessed for register dumps and possibly context switching.
+	 */
+	uint32_t *saved_state = (uint32_t *)CURRENT_REGS;
+	CURRENT_REGS = regs;
 
 	system_exception_location = regs[REG_R15];
 
@@ -187,10 +187,10 @@ uint32_t *arm_prefetchabort(uint32_t *regs, uint32_t ifar, uint32_t ifsr)
 	up_reboot_reason_write(REBOOT_SYSTEM_PREFETCHABORT);
 #endif
 
-  PANIC();
-  regs = (uint32_t *)CURRENT_REGS;
-  CURRENT_REGS = saved_state;
-  return regs; /* To keep the compiler happy */
+	PANIC();
+	regs = (uint32_t *)CURRENT_REGS;
+	CURRENT_REGS = saved_state;
+	return regs; /* To keep the compiler happy */
 }
 
 #endif							/* CONFIG_PAGING */

--- a/os/arch/arm/src/armv7-a/arm_prefetchabort.c
+++ b/os/arch/arm/src/armv7-a/arm_prefetchabort.c
@@ -65,6 +65,23 @@
  ****************************************************************************/
 
 extern uint32_t system_exception_location;
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: print_prefetchabort_detail
+ ****************************************************************************/
+
+static inline void print_prefetchabort_detail(uint32_t *regs, uint32_t ifar, uint32_t ifsr)
+{
+	_alert("#########################################################################\n");
+	_alert("PANIC!!! Prefetch Abort at instruction : 0x%08x\n",  regs[REG_PC]);
+	_alert("PC: %08x IFAR: %08x IFSR: %08x\n", regs[REG_PC], ifar, ifsr);
+	_alert("#########################################################################\n\n\n");
+}
+
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
@@ -134,7 +151,9 @@ uint32_t *arm_prefetchabort(uint32_t *regs, uint32_t ifar, uint32_t ifsr)
 
 		CURRENT_REGS = savestate;
 	} else {
-		_alert("Prefetch abort. PC: %08x IFAR: %08x IFSR: %08x\n", regs[REG_PC], ifar, ifsr);
+		if (!IS_SECURE_STATE()) {
+			print_prefetchabort_detail(regs, ifar, ifsr);
+		}
 
 #ifdef CONFIG_SYSTEM_REBOOT_REASON
 		up_reboot_reason_write(REBOOT_SYSTEM_PREFETCHABORT);
@@ -160,7 +179,9 @@ uint32_t *arm_prefetchabort(uint32_t *regs, uint32_t ifar, uint32_t ifsr)
 
 	/* Crash -- possibly showing diagnostic debug information. */
 
-	_alert("Prefetch abort. PC: %08x IFAR: %08x IFSR: %08x\n", regs[REG_PC], ifar, ifsr);
+	if (!IS_SECURE_STATE()) {
+		print_prefetchabort_detail(regs, ifar, ifsr);
+	}
 
 #ifdef CONFIG_SYSTEM_REBOOT_REASON
 	up_reboot_reason_write(REBOOT_SYSTEM_PREFETCHABORT);


### PR DESCRIPTION
This patch changes the log format for data abort and prefetch abort logs to make it as same as fault handler's logs in armv8-m. It also corrects the indentation issues in the change intended files.

armv7-a old abort logs:
arm_dataabort: Data abort. PC: 0e16f0ba DFAR: 00000000 DFSR: 0000000d

armv7-a new abort logs after this commit:
print_dataabort_detail: ######################################################################### print_dataabort_detail: PANIC!!! Data Abort at instruction : 0x0e16f0ba
print_dataabort_detail: PC: 0e16f0ba DFAR: 00000000 DFSR: 0000000d
print_dataabort_detail: #########################################################################