### PR TITLE
os/arch/arm/src/armv7-a: Fix prefetch abort issue during AMP boot up

### DIFF
--- a/os/arch/arm/src/armv7-a/arm_sigdeliver.c
+++ b/os/arch/arm/src/armv7-a/arm_sigdeliver.c
@@ -53,6 +53,7 @@
 
 #include "sched/sched.h"
 #include "up_internal.h"
+#include "arm.h"
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
@@ -101,6 +102,7 @@ void arm_sigdeliver(void)
 	 */
 
 	do {
+		regs[REG_CPSR] |= PSR_MODE_SYS;
 		leave_critical_section(regs[REG_CPSR]);
 	} while (rtcb->irqcount > 0);
 #endif							/* CONFIG_SMP */


### PR DESCRIPTION
When AMP is enabled, there is a prefetch abort during device boot up. During signal handling with SMP / AMP, the up_sigdeliver API calls leave_critical_section with the saved CPSR as an argument. At the end of leave_critical_section, this value is restored to the HW using irqrestore.

In the abort scenario, it is seen that the saved CPSR contains the user mode setting, where as we are still executing kernel code. As a result, when this CPSR value is updated, there is a prefetch abort upon executing the next instruction. To avoid this situation, we reset the mode setting value in the saved CPSR register to SYSTEM mode just before calling the leave_critical_section API.