### PR TITLE
rtl8730e/i2s : Rollback DMA size to 16K(temp code)

### DIFF
--- a/os/arch/arm/src/amebasmart/amebasmart_i2s.c
+++ b/os/arch/arm/src/amebasmart/amebasmart_i2s.c
@@ -119,8 +119,8 @@
 
 #define OVER_SAMPLE_RATE (384U)
 
-#define I2S_DMA_PAGE_SIZE 4096	/* 4 ~ 16384, set to a factor of APB size */
-#define I2S_DMA_PAGE_NUM 4	/* Vaild number is 2~4 */
+#define I2S_DMA_PAGE_SIZE 16384	/* 4 ~ 16384, set to a factor of APB size */
+#define I2S_DMA_PAGE_NUM 2	/* Vaild number is 2~4 */
 
 struct amebasmart_buffer_s {
 	struct amebasmart_buffer_s *flink; /* Supports a singly linked list */

--- a/os/drivers/audio/alc1019.c
+++ b/os/drivers/audio/alc1019.c
@@ -57,7 +57,7 @@
 #endif
 
 #ifndef CONFIG_ALC1019_NUM_BUFFERS
-#define CONFIG_ALC1019_NUM_BUFFERS       4
+#define CONFIG_ALC1019_NUM_BUFFERS       2
 #endif
 
 /****************************************************************************

--- a/os/drivers/audio/syu645b.c
+++ b/os/drivers/audio/syu645b.c
@@ -57,7 +57,7 @@
 #endif
 
 #ifndef CONFIG_SYU645B_NUM_BUFFERS
-#define CONFIG_SYU645B_NUM_BUFFERS       4
+#define CONFIG_SYU645B_NUM_BUFFERS       2
 #endif
 
 /****************************************************************************


### PR DESCRIPTION
If we use 4K of dma but 16k of audio buffer, then pause->start doesn't work properly Until Realtek fix this issue, keep 16k * 2 of buffer for both of dma & audio