### PR TITLE
os/drivers: implement pause and resume for NDP120

### DIFF
--- a/os/drivers/ai-soc/ndp120/src/ndp120_api.c
+++ b/os/drivers/ai-soc/ndp120/src/ndp120_api.c
@@ -1237,13 +1237,19 @@ int ndp120_start_sample_ready(struct ndp120_dev_s *dev)
 
 	dev->recording = true;
 
+	/* reset the count of semaphore used to signal sample ready */	
+	sem_init(&dev->sample_ready_signal, 1, 0);
+
 	s =  ndp120_set_sample_ready_int(dev, 1);
 
 	uint32_t bytes_before_match = 0;
 
-	s = syntiant_ndp_extract_data(dev->ndp, SYNTIANT_NDP_EXTRACT_TYPE_INPUT,
+	if (!dev->running) {
+		/* we need not do this if this is resume case, we only need to do it if its recorder start case after keyword detection */
+		s = syntiant_ndp_extract_data(dev->ndp, SYNTIANT_NDP_EXTRACT_TYPE_INPUT,
                                                                 SYNTIANT_NDP_EXTRACT_FROM_MATCH, NULL,
                                                                 &bytes_before_match);
+	}
 
 	return s;
 }

--- a/os/drivers/audio/ndp120_voice.c
+++ b/os/drivers/audio/ndp120_voice.c
@@ -378,9 +378,8 @@ static int ndp120_start(FAR struct audio_lowerhalf_s *dev)
 	audvdbg(" ndp120_start Entry\n");
 	ndp120_takesem(&priv->devsem);
 
-	priv->running = true;
-
 	ndp120_start_sample_ready(priv);
+	priv->running = true;
 
 	/* Enqueue buffers (enqueueed before the start of alc) to lower layer */
 	sq_entry_t *tmp = NULL;
@@ -428,6 +427,10 @@ static int ndp120_pause(FAR struct audio_lowerhalf_s *dev, FAR void *session)
 static int ndp120_pause(FAR struct audio_lowerhalf_s *dev)
 #endif
 {
+	FAR struct ndp120_dev_s *priv = (FAR struct ndp120_dev_s *)dev;
+	ndp120_takesem(&priv->devsem);
+	ndp120_stop_sample_ready(priv);
+	ndp120_givesem(&priv->devsem);
 	return 0;
 }
 
@@ -437,6 +440,10 @@ static int ndp120_resume(FAR struct audio_lowerhalf_s *dev, FAR void *session)
 static int ndp120_resume(FAR struct audio_lowerhalf_s *dev)
 #endif
 {
+	FAR struct ndp120_dev_s *priv = (FAR struct ndp120_dev_s *)dev;
+	ndp120_takesem(&priv->devsem);
+	ndp120_start_sample_ready(priv);
+	ndp120_givesem(&priv->devsem);
 	return 0;
 }
 #endif


### PR DESCRIPTION
Implement pause and resume for NDP120. We turn off the sample ready interrupts for pause, and then turn them back on for resume