### PR TITLE
os/pm: resolve build warnings

### DIFF
--- a/os/include/tinyara/pm/pm.h
+++ b/os/include/tinyara/pm/pm.h
@@ -183,7 +183,6 @@ enum pm_state_e {
 								 */
 	PM_COUNT,
 };
-static const char *pm_state_name[PM_COUNT] = {"PM_NORMAL", "PM_IDLE", "PM_STANDBY", "PM_SLEEP"};
 
 /* This enumeration provides all power management related wakeup source code. */
 
@@ -198,9 +197,6 @@ typedef enum {
 	PM_WAKEUP_SRC_COUNT,
 } pm_wakeup_reason_code_t;
 
-#ifdef CONFIG_PM_METRICS
-static const char *wakeup_src_name[PM_WAKEUP_SRC_COUNT] = {"UNKNOWN", "BLE", "WIFI", "UART CONSOLE", "UART TTYS2", "GPIO", "HW TIMER"};
-#endif
 /* This structure contain pointers callback functions in the driver.  These
  * callback functions can be used to provide power management information
  * to the driver.
@@ -280,6 +276,9 @@ extern "C" {
 #else
 #define EXTERN extern
 #endif
+
+EXTERN const char *pm_state_name[PM_COUNT];
+EXTERN const char *wakeup_src_name[PM_WAKEUP_SRC_COUNT];
 
 /****************************************************************************
  * Public Function Prototypes

--- a/os/pm/pm_initialize.c
+++ b/os/pm/pm_initialize.c
@@ -76,6 +76,8 @@
  */
 
 struct pm_global_s g_pmglobals;
+const char *pm_state_name[PM_COUNT] = {"NORMAL", "IDLE", "STANDBY", "SLEEP"};
+const char *wakeup_src_name[PM_WAKEUP_SRC_COUNT] = {"UNKNOWN", "BLE", "WIFI", "UART CONSOLE", "UART TTYS2", "GPIO", "HW TIMER"};
 
 /****************************************************************************
  * Public Functions

--- a/os/pm/pm_metrics.c
+++ b/os/pm/pm_metrics.c
@@ -272,7 +272,7 @@ int pm_metrics(int milliseconds)
 	/* Avoid board sleep during PM Metrics initialization */
 	pm_suspended = pm_suspend(PM_IDLE_DOMAIN);
 	/* Allocate memory for initializing PM Metrics measurements */
-	g_pm_metrics = pm_alloc(1, sizeof(pm_metric_t));
+	g_pm_metrics = (pm_metric_t *)pm_alloc(1, sizeof(pm_metric_t));
 	if (g_pm_metrics == NULL) {
 		set_errno(ENOMEM);
 		pmdbg("Unable to initialize pm_metrics, error = %d\n", get_errno());

--- a/os/pm/pm_metrics.c
+++ b/os/pm/pm_metrics.c
@@ -55,6 +55,7 @@ static bool g_pm_metrics_running = false;
 static void pm_print_metrics(double total_time, int n_domains)
 {
 	int index;
+	enum pm_state_e pm_state;
 	pmdbg("\n");
 	pmdbg("TOTAL METRICS TIME [1] = %dms\n", TICK2MSEC((int)total_time));
 	pmdbg("TOTAL SLEEP TRY TIME [2] = %dms\n", TICK2MSEC(g_pm_metrics->total_try_ticks));
@@ -84,14 +85,12 @@ static void pm_print_metrics(double total_time, int n_domains)
 	pmdbg("\n");
 	pmdbg(" BOARD STATE | PM STATE |          TIME          \n");
 	pmdbg("-------------|----------|------------------------\n");
-	pmdbg(" %11s | %8s | %10dms (%6.2f%%) \n", "WAKEUP", "NORMAL", TICK2MSEC(g_pm_metrics->state_metrics.state_accum_ticks[0]),
-		  ((double)g_pm_metrics->state_metrics.state_accum_ticks[0]) * 100.0 / total_time);
-	pmdbg(" %11s | %8s | %10dms (%6.2f%%) \n", "", "IDLE", TICK2MSEC(g_pm_metrics->state_metrics.state_accum_ticks[1]),
-		  ((double)g_pm_metrics->state_metrics.state_accum_ticks[1]) * 100.0 / total_time);
-	pmdbg(" %11s | %8s | %10dms (%6.2f%%) \n", "", "STANDBY", TICK2MSEC(g_pm_metrics->state_metrics.state_accum_ticks[2]),
-		  ((double)g_pm_metrics->state_metrics.state_accum_ticks[2]) * 100.0 / total_time);
+	for (pm_state = PM_NORMAL; pm_state < PM_SLEEP; pm_state++) {
+		pmdbg(" %11s | %8s | %10dms (%6.2f%%) \n", ((pm_state == PM_NORMAL) ? "WAKEUP" : ""), pm_state_name[pm_state], TICK2MSEC(g_pm_metrics->state_metrics.state_accum_ticks[pm_state]),
+			((double)g_pm_metrics->state_metrics.state_accum_ticks[pm_state]) * 100.0 / total_time);
+	}
 	pmdbg("-------------|----------|------------------------\n");
-	pmdbg(" %11s | %8s | %10dms (%6.2f%%) \n", "SLEEP", "SLEEP", TICK2MSEC(g_pm_metrics->board_sleep_ticks),
+	pmdbg(" %11s | %8s | %10dms (%6.2f%%) \n", "SLEEP", pm_state_name[PM_SLEEP], TICK2MSEC(g_pm_metrics->board_sleep_ticks),
 		  ((double)g_pm_metrics->board_sleep_ticks) * 100.0 / total_time);
 }
 /************************************************************************************

--- a/os/pm/pm_procfs.c
+++ b/os/pm/pm_procfs.c
@@ -212,7 +212,7 @@ static void power_read_state(void (*readprint)(const char *, ...))
 
 static int power_find_dirref(FAR const char *relpath, FAR struct power_dir_s *dir)
 {
-	char *str;
+	const char *str;
 	int domain_id;
 	/* Function to check path is starting with given name */
 	int checkStart(char *name, bool isDirectory) {
@@ -350,7 +350,6 @@ static ssize_t power_read(FAR struct file *filep, FAR char *buffer, size_t bufle
 	size_t totalsize;
 	int domain_id;
 	int last_read;
-	int pm_state;
 	/* Function to copy domain information into buffer */
 	void readprint(const char *format, ...) {
 		size_t copysize;


### PR DESCRIPTION
This commit resolve the below build warnings:

```
warning: 'pm_state_name' defined but not used
warning: 'wakeup_src_name' defined but not used
warning: unused variable 'pm_state'
warning: assignment discards 'const' qualifier from pointer target type
warning: assignment to 'pm_metric_t *' {aka 'struct pm_metric_s *'} from 'int' makes pointer from integer without a cast
```