### PR TITLE
os/arch/arm/src/amebasmart: stop sending i2s data if there is no pend…

### DIFF
--- a/os/arch/arm/src/amebasmart/amebasmart_i2s.c
+++ b/os/arch/arm/src/amebasmart/amebasmart_i2s.c
@@ -402,6 +402,7 @@ static int amebasmart_i2s_tx(struct amebasmart_i2s_s *priv, struct amebasmart_bu
 							/* Start sending first page, after that the txdma callback will be called in the tx irq handler */
 		while ((priv->apb_tx->nbytes - priv->apb_tx->curbyte) > 0) {
 			ptx_buf = i2s_get_tx_page(priv->i2s_object);
+			i2s_enable(priv->i2s_object);
 			if (ptx_buf) {
 				if ((apb->nbytes - apb->curbyte) <= tx_size) {
 					tx_size = apb->nbytes - apb->curbyte;
@@ -412,7 +413,7 @@ static int amebasmart_i2s_tx(struct amebasmart_i2s_s *priv, struct amebasmart_bu
 				}
 				apb->curbyte += tx_size; /* No padding, ptx_buf is big enough to fill the whole tx_size */
 
-				i2s_enable(priv->i2s_object);
+				
 				i2s_send_page(priv->i2s_object, (uint32_t *)ptx_buf);
 			} else {
 				break;
@@ -557,6 +558,8 @@ static void i2s_tx_schedule(struct amebasmart_i2s_s *priv, int result)
 
 		/* Start next transfer */
 		amebasmart_i2s_tx(priv, bfcontainer);
+	} else if ((priv->apb_tx->nbytes - priv->apb_tx->curbyte) <= 0) {
+		ameba_i2s_pause(priv->i2s_object);
 	}
 
 	/* If the worker has completed running, then reschedule the working thread.


### PR DESCRIPTION
…ing buffer containing in tx.pend list

1. pause i2s send when there is no buffer in tx.pend list
2. it removes noise, (mute instead) if there is insufficient time to get the next buffer from application due to heavy loading