### PR TITLE
lib/libc/syslog: fix "printf" and "dbg" mix log issue

### DIFF
--- a/os/include/debug.h
+++ b/os/include/debug.h
@@ -93,12 +93,12 @@ int get_errno(void);
  * general, there are four forms of the debug macros:
  *
  * [a-z]dbg() -- Outputs messages to the console similar to printf() except
- *    that the output is not buffered.  The first character indicates the
- *    system system (e.g., n=network, f=filesystem, etc.).  If the first
- *    character is missing (i.e., dbg()), then it is common.  The common
- *    dbg() macro is enabled by CONFIG_DEBUG.  Subsystem debug requires an
- *    additional configuration setting to enable it (e.g., CONFIG_DEBUG_NET
- *    for the network, CONFIG_DEBUG_FS for the file system, etc).
+ *    that the output is not buffered for IDLE thread and thread running in ISR.
+ *    The first character indicates the system system (e.g., n=network,
+ *    f=filesystem, etc.). If the first character is missing (i.e., dbg()), then
+ *    it is common. The common dbg() macro is enabled by CONFIG_DEBUG. Subsystem
+ *    debug requires an additional configuration setting to enable it
+ *    (e.g., CONFIG_DEBUG_NET for the network, CONFIG_DEBUG_FS for the file system, etc).
  *
  *    In general, error messages and output of importance use [a-z]dbg().
  *    [a-z]dbg() is implementation dependent but usually uses file descriptors.
@@ -110,9 +110,9 @@ int get_errno(void);
  *    CONFIG_DEBUG_VERBOSE be defined.  This is intended for general debug
  *    output that you would normally want to suppress.
  *
- * [a-z]lldbg() -- Identical to [a-z]dbg() except this is uses special
- *    interfaces provided by architecture-specific logic to talk directly
- *    to the underlying console hardware.  If the architecture provides such
+ * [a-z]lldbg() -- Identical to [a-z]dbg() except that output is not buffered.
+ *    This uses special interfaces provided by architecture-specific logic to talk
+ *    directly to the underlying console hardware.  If the architecture provides such
  *    logic, it should define CONFIG_ARCH_LOWPUTC.
  *
  *    [a-z]lldbg() should not be used in normal code because the implementation


### PR DESCRIPTION
This commit resolve the log mix of 'printf' and 'dbg' API by directing log output to 'stdoutstream' instead of 'rawoutstream'

Logs Before:

```
ROM:[V1.1]
FLASHRATE:1
BOOT FROM NOR
IMG1(OTA1) VALID, ret: 0
IMG1 ENTRY[30005b81:0]
IMG1 SBOOT OFF
bootloader_version km4_bootloader_ver_a52222ac01_2024/08/08-10:37:20 [BOOT-I] NP Freq 333 MHz
[BOOT-I] AP Freq 1200 MHz
[FLASHCLK-I] Flash ID: ef-40-18
[FLASHCLK-I] Flash Read 4IO
[FLASHCLK-I] calibration_ok:[1:9:5]
[FLASHCLK-I] FLASH CALIB[0x4 OK]
[BOOT-I] Init PSRAM
[PSRAM-I] PSRAM Ctrl CLK: 500000000 Hz
[PSRAM-I] CalNmin = 0 CalNmax = 15 WindowSize = 16 phase: 2 LogUart Baudrate: 115200
Autoboot in 100 milliseconds
close yModem Transfer ...

Normal boot
flash_size: 16M
BP1 data valid, version:1
BP2 version invalid
BP1 CRC32 match, attached CRC: 0x4226e131, calculated CRC: 0x4226e131 BP1 selected
Active Index: 0
OTA1 CRC32 match, attached CRC: 0xf466329c, calculated CRC: 0xf466329c OTA1 USE, version: 200204
[BOOT-I] KM0 XIP IMG[0c000000:20]
[BOOT-I] KM0 SRAM[23002000:11680]
[BOOT-I] KM0 DRAM[6fffffdf:20]
                              [BOOT-I] KM4 XIP IMG[0d000000:551c0]
[BOOT-I] KM4 SRAM[20014000:40]
[BOOT-I] KM4 DRAM[60000000:800]
[MODULE_BOOT-LEVEL_INFO]:IMG2(OTA1) VALID, ret: 0
[BOOT-I] AP XIP IMG[0e000000:ab6e0]
[BOOT-I] AP BL1 SRAM[3001fde0:40]
[BOOT-I] AP BL1 DRAM[70017000:3709]
[BOOT-I] AP FIP[601fffe0:44f71]
[BOOT-I] RDP OFF
[BOOT-I] AP FIP[601fffe0:44f71]
[APP-I] KM0 APP_START
[APP-I] KM0 CPU CLK: 40000000 Hz
[APP-I] KM0 VTOR:0x23000000
[PMC-I] NP wake event: 2001000 0
[PMC-I] AP wake event 8404c080 40
[PMC-I] LP wake event 80001b 20
[MAIN-I] KM0 OS START
up_allocate_kheap: start = 0x60118f00 size = 1470720 up_initialize: [Reboot Reason] : 55
os_start: All SMP cores started!!
up_flashinitialize: Manufacturer : 239 memory type : 64 capacity : 24 smart_scan: Invalid logical sector 30540 at physical 520. smart_scan: Invalid logical sector 28751 at physical 521. smart_scan: Invalid logical sector 12885 at physical 526. smart_scan: Invalid logical sector 26436 at physical 528. smart_scan: Invalid logical sector 26986 at physical 534. smart_scan: Invalid logical sector 28498 at physical 541. smart_scan: Invalid logical sector 12611 at physical 542. smart_scan: Invalid logical sector 26439 at physical 544. smart_scan: Invalid logical sector 63494 at physical 592. smart_scan: Invalid logical sector 58378 at physical 600. smart_scan: Invalid logical sector 11509 at physical 621. smart_scan: Invalid logical sector 63749 at physical 641. smart_scan: Invalid logical sector 5884 at physical 654. smart_scan: Invalid logical sector 50147 at physical 657. smart_scan: Invalid logical sector 61183 at physical 661. smart_scan: Invalid logical sector 64514 at physical 663. smart_scan: Invalid logical sector 60159 at physical 671. smart_scan: Invalid logical sector 57084 at physical 683. smart_scan: Invalid logical sector 64487 at physical 694. smart_scan: Invalid logical sector 7713 at physical 703. smart_scan: Invalid logical sector 61165 at physical 704. smart_scan: Invalid logical sector 4887 at physical 713. smart_scan: Invalid logical sector 62973 at physical 736. smart_scan: Invalid logical sector 60935 at physical 742. smart_scan: Invalid logical sector 14075 at physical 761. smart_scan: Invalid logical sector 10500 at physical 773. smart_scan: Invalid logical sector 61975 at physical 784. smart_scan: Invalid logical sector 9228 at physical 786. smart_scan: Invalid logical sector 57086 at physical 788. smart_scan: Invalid logical sector 64507 at physical 794. smart_scan: Invalid logical sector 62970 at physical 795. smart_scan: Invalid logical sector 65185 at physical 802. smart_scan: Invalid logical sector 52203 at physical 808. smart_scan: Invalid logical sector 18445 at physical 813. smart_scan: Invalid logical sector 4421 at physical 819. smart_scan: Invalid logical sector 55383 at physical 822. smart_scan: Invalid logical sector 4369 at physical 827. smart_scan: Invalid logical sector 10769 at physical 833. smart_scan: Invalid logical sector 6426 at physical 861. smart_scan: Invalid logical sector 43673 at physical 862. smart_scan: Invalid logical sector 4556 at physical 885. smart_scan: Invalid logical sector 50123 at physical 913. smart_scan: Invalid logical sector 50379 at physical 914. smart_scan: Invalid logical sector 10628 at physical 942. smart_scan: Invalid logical sector 2011 at physical 952. smart_scan: Invalid logical sector 26667 at physical 960. smart_scan: Invalid logical sector 8311 at physical 1011. smart_scan: Invalid logical sector 14963 at physical 1020. smart_scan: SMART Scan
smart_scan:    Erase size:                 4096
smart_scan:    Erase block:                 512
smart_scan:    Sect/block:                    4
smart_scan:    MTD Blk/Sect:                  4
smart_scan:    avail sect/block:              4
smart_scan:    Data Erase block:            488
smart_scan:    Journal Erase block:          24
smart_scan:    Journal Data/Block:          315
smart_scan:    Journal total:              7560
smart_scan:    Journal usage:              5742
smartfs_mount:      SMARTFS:
smartfs_mount:      Sector size:     1024
smartfs_mount:      Bytes/sector     1018
smartfs_mount:      Num sectors:     1952
smartfs_mount:      Free sectors:    1909
smartfs_mount:      Max filename:    32
smartfs_mount:      RootDirSector:   3
smartfs_sector_recovery: ###############################
smartfs_sector_recovery: #      FS Recovery Report     #
smartfs_sector_recovery: ###############################
smartfs_sector_recovery: Total of active sectors : 46
smartfs_sector_recovery: Recovered Isolated Sectors : 0
smartfs_sector_recovery: Cleaned Entries : 0

/dev/smart0p10 is mounted successfully @ /mnt
[RTK] Link callback handles: registered
[rtl_readdecrypt_factorykey] Exit form here!set_security_level: LOW binary_manager_scan_bootpa
Initializing WIFI ...ram: Checking BP0 start
binary_manager_scan_bootparam: BP0 is valid
binary_manager_scan_bootparam: Checking BP1 start
is_valid_bootpa[OTP-I] ram: InvOTP_Logialid datcalMap_Ra. ver: ead: dat42949672a end at95, acti addressve index: 25 =88
5,[RTW]: ** Band = 2.4G and 5G **
 addresses: ffffffff, ffffffff
binary_manager_scan_bootparam: BP1 is invalid
binary_manager_scan_bootparam: BP USE index 0, version 1 binary_manager_scan_ubin_all: Found binary app1 in partition 6, version 190412 binary_manager_scan_ubin_all: Found binaryKM4 version:  km4_application_ver_c2b09705dc_2024/10/18-10:30:31
 common in partition 5, version 200204
binary_manager_load: common Header Checking Success dump_module: Module:
dump_module:   filename:  /dev/mtdblock5
dump_module:   argv:      0
dump_module:   entrypt:   0
dump_module:   start of alloc:     0xe162010
dump_module:   alloc:     0 0
dump_module:   ctors:     0xe181b98 nctors=2
dump_module:   dtors:     0 ndtors=0
dump_module:   stacksize: 0
dump_module:   unload:    0
binary_manager_load_binary: Load success! [Name: common] [Version: 200204] [Partition: A] [Text start : 0x0e162010] [Compressed Binary]
binary_manager_load: app1 Header Checking Success
dump_module: Module:
dump_module:   filename:  /dev/mtdblock6
dump_module:   argv:      0
dump_module:   entrypt:   0xe45a079
dump_module:   start of alloc:     0xe45a030
dump_module:   alloc:     0 0
dump_module:   ctors:     0xe45a1b1 nctors=0
dump_module:   dtors:     0 ndtors=0
dump_module:   stacksize: 8192
dump_module:   unload:    0
binary_manager_load_binary: Load success! [Name: apSystem Information:
p1] [Version: 19041     Version:
2] [Partition: A] [Text start : 0x0e45a030] [Comp               Platform: 5.0   Binary: 200204
ressed Binary]
        Commit Hash: cfbf844
        Build User: root@GauravSahitya
        Build Time: 2024-11-05 09:56:26 UTC
        System Time: 05 Nov 2024, 00:00:00 [s] UTC Hardware RTC Support
TASH>>This is WIFI App

Select Test Scenario.
        -Press X or x : Terminate Tests.
```

Logs After:

```
ROM:[V1.1]
FLASHRATE:1
BOOT FROM NOR
IMG1(OTA1) VALID, ret: 0
IMG1 ENTRY[30005b81:0]
IMG1 SBOOT OFF
bootloader_version km4_bootloader_ver_a52222ac01_2024/08/08-10:37:20 [BOOT-I] NP Freq 333 MHz
[BOOT-I] AP Freq 1200 MHz
[FLASHCLK-I] Flash ID: ef-40-18
[FLASHCLK-I] Flash Read 4IO
[FLASHCLK-I] calibration_ok:[1:9:5]
[FLASHCLK-I] FLASH CALIB[0x4 OK]
[BOOT-I] Init PSRAM
[PSRAM-I] PSRAM Ctrl CLK: 500000000 Hz
[PSRAM-I] CalNmin = 0 CalNmax = 15 WindowSize = 16 phase: 2 LogUart Baudrate: 115200
Autoboot in 100 milliseconds
close yModem Transfer ...

Normal boot
flash_size: 16M
BP1 data valid, version:1
BP2 version invalid
BP1 CRC32 match, attached CRC: 0x4226e131, calculated CRC: 0x4226e131 BP1 selected
Active Index: 0
OTA1 CRC32 match, attached CRC: 0xf2f3fbd7, calculated CRC: 0xf2f3fbd7 OTA1 USE, version: 200204
[BOOT-I] KM0 XIP IMG[0c000000:20]
[BOOT-I] KM0 SRAM[23002000:11680]
[BOOT-I] KM0 DRAM[6fffffdf:20]
[BOOT-I] KM4 XIP IMG[0d000000:551c0]
[BOOT-I] KM4 SRAM[20014000:40]
[BOOT-I] KM4 DRAM[60000000:800]
[MODULE_BOOT-LEVEL_INFO]:IMG2(OTA1) VALID, ret: 0
[BOOT-I] AP XIP IMG[0e000000:ab640]
[BOOT-I] AP BL1 SRAM[3001fde0:40]
[BOOT-I] AP BL1 DRAM[70017000:3709]
[BOOT-I] AP FIP[601fffe0:44f69]
[BOOT-I] RDP OFF
[BOOT-I] AP FIP[601fffe0:44f69]
[APP-I] KM0 APP_START
[APP-I] KM0 CPU CLK: 40000000 Hz
[APP-I] KM0 VTOR:0x23000000
[PMC-I] NP wake event: 2001000 0
[PMC-I] AP wake event 8404c080 40
[PMC-I] LP wake event 80001b 20
[MAIN-I] KM0 OS START
up_allocate_kheap: start = 0x60118f00 size = 1470720 up_initialize: [Reboot Reason] : 55
os_start: All SMP cores started!!
up_flashinitialize: Manufacturer : 239 memory type : 64 capacity : 24 smart_scan: Invalid logical sector 30540 at physical 520. smart_scan: Invalid logical sector 28751 at physical 521. smart_scan: Invalid logical sector 12885 at physical 526. smart_scan: Invalid logical sector 26436 at physical 528. smart_scan: Invalid logical sector 26986 at physical 534. smart_scan: Invalid logical sector 28498 at physical 541. smart_scan: Invalid logical sector 12611 at physical 542. smart_scan: Invalid logical sector 26439 at physical 544. smart_scan: Invalid logical sector 63494 at physical 592. smart_scan: Invalid logical sector 58378 at physical 600. smart_scan: Invalid logical sector 11509 at physical 621. smart_scan: Invalid logical sector 63749 at physical 641. smart_scan: Invalid logical sector 5884 at physical 654. smart_scan: Invalid logical sector 50147 at physical 657. smart_scan: Invalid logical sector 61183 at physical 661. smart_scan: Invalid logical sector 64514 at physical 663. smart_scan: Invalid logical sector 60159 at physical 671. smart_scan: Invalid logical sector 57084 at physical 683. smart_scan: Invalid logical sector 64487 at physical 694. smart_scan: Invalid logical sector 7713 at physical 703. smart_scan: Invalid logical sector 61165 at physical 704. smart_scan: Invalid logical sector 4887 at physical 713. smart_scan: Invalid logical sector 62973 at physical 736. smart_scan: Invalid logical sector 60935 at physical 742. smart_scan: Invalid logical sector 14075 at physical 761. smart_scan: Invalid logical sector 10500 at physical 773. smart_scan: Invalid logical sector 61975 at physical 784. smart_scan: Invalid logical sector 9228 at physical 786. smart_scan: Invalid logical sector 57086 at physical 788. smart_scan: Invalid logical sector 64507 at physical 794. smart_scan: Invalid logical sector 62970 at physical 795. smart_scan: Invalid logical sector 65185 at physical 802. smart_scan: Invalid logical sector 52203 at physical 808. smart_scan: Invalid logical sector 18445 at physical 813. smart_scan: Invalid logical sector 4421 at physical 819. smart_scan: Invalid logical sector 55383 at physical 822. smart_scan: Invalid logical sector 4369 at physical 827. smart_scan: Invalid logical sector 10769 at physical 833. smart_scan: Invalid logical sector 6426 at physical 861. smart_scan: Invalid logical sector 43673 at physical 862. smart_scan: Invalid logical sector 4556 at physical 885. smart_scan: Invalid logical sector 50123 at physical 913. smart_scan: Invalid logical sector 50379 at physical 914. smart_scan: Invalid logical sector 10628 at physical 942. smart_scan: Invalid logical sector 2011 at physical 952. smart_scan: Invalid logical sector 26667 at physical 960. smart_scan: Invalid logical sector 8311 at physical 1011. smart_scan: Invalid logical sector 14963 at physical 1020. smart_scan: SMART Scan
smart_scan:    Erase size:                 4096
smart_scan:    Erase block:                 512
smart_scan:    Sect/block:                    4
smart_scan:    MTD Blk/Sect:                  4
smart_scan:    avail sect/block:              4
smart_scan:    Data Erase block:            488
smart_scan:    Journal Erase block:          24
smart_scan:    Journal Data/Block:          315
smart_scan:    Journal total:              7560
smart_scan:    Journal usage:              5742
smartfs_mount:      SMARTFS:
smartfs_mount:      Sector size:     1024
smartfs_mount:      Bytes/sector     1018
smartfs_mount:      Num sectors:     1952
smartfs_mount:      Free sectors:    1909
smartfs_mount:      Max filename:    32
smartfs_mount:      RootDirSector:   3
smartfs_sector_recovery: ###############################
smartfs_sector_recovery: #      FS Recovery Report     #
smartfs_sector_recovery: ###############################
smartfs_sector_recovery: Total of active sectors : 46
smartfs_sector_recovery: Recovered Isolated Sectors : 0
smartfs_sector_recovery: Cleaned Entries : 0

/dev/smart0p10 is mounted successfully @ /mnt
[RTK] Link callback handles: registered
[rtl_readdecrypt_factorykey] Exit form here!set_security_level: LOW binary_manager_scan_bootparam: Checking BP0 start

Initializing WIFI ...binary_manager_scan_bootparam: BP0 is valid binary_manager_scan_bootparam: Checking BP1 start
is_valid_bootparam: Invalid data.[OTP-I]  ver: 42OTP_Logi94967295calMap_R, activeead: dat index: a end at255, add addressresses: ffffffff=88 , ffffffff

[RTW]: ** Band = 2.4G and 5G **
binary_manager_scan_bootparam: BP1 is invalid
binary_manager_scan_bootparam: BP USE index 0, version 1 binary_manager_scan_ubin_all: Found binary app1 in partition 6, version 190412 binary_manager_scan_ubin_all: Found binary common in partition 5, version 200204 KM4 version:  km4_application_ver_c2b09705dc_2024/10/18-10:30:31 binary_manager_load: common Header Checking Success dump_module: Module:
dump_module:   filename:  /dev/mtdblock5
dump_module:   argv:      0
dump_module:   entrypt:   0
dump_module:   start of alloc:     0xe162010
dump_module:   alloc:     0 0
dump_module:   ctors:     0xe181b14 nctors=2
dump_module:   dtors:     0 ndtors=0
dump_module:   stacksize: 0
dump_module:   unload:    0
binary_manager_load_binary: Load success! [Name: common] [Version: 200204] [Partition: A] [Text start : 0x0e162010] [Compressed Binary]
binary_manager_load: app1 Header Checking Success
dump_module: Module:
dump_module:   filename:  /dev/mtdblock6
dump_module:   argv:      0
dump_module:   entrypt:   0xe45a079
dump_module:   start of alloc:     0xe45a030
dump_module:   alloc:     0 0
dump_module:   ctors:     0xe45a1b1 nctors=0
dump_module:   dtors:     0 ndtors=0
dump_module:   stacksize: 8192
dump_module:   unload:    0
binary_manager_load_binary: Load success! [Name: app1] [Version: 190412] [Partition: A] [Text start : 0x0e45a030] [Compressed Binary]
System Information:
        Version:
                Platform: 5.0   Binary: 200204
        Commit Hash: cfbf844
        Build User: root@GauravSahitya
        Build Time: 2024-11-05 09:46:33 UTC
        System Time: 05 Nov 2024, 00:00:00 [s] UTC Hardware RTC Support
TASH>>This is WIFI App

Select Test Scenario.
        -Press X or x : Terminate Tests.
```