### PR TITLE
[Do Not Merge] os/pm: Change pm_suspend and pm_resume API logic

### DIFF
--- a/os/pm/pm_resume.c
+++ b/os/pm/pm_resume.c
@@ -102,15 +102,14 @@ int pm_resume(int domain_id)
 	if (ret != OK) {
 		goto errout;
 	}
-	if (g_pmglobals.suspend_count[domain_id] <= 0) {
-		ret = ERROR;
-		set_errno(ERANGE);
-		goto errout;
+	if (g_pmglobals.suspend_count[domain_id]) {
+		g_pmglobals.suspend_count[domain_id] = false;
+	} else {
+		pmdbg("Thread with pid (%d) tried to resume domain (%s) again\n", getpid(), pm_domain_map[domain_id]);
 	}
 #ifdef CONFIG_PM_METRICS
 	pm_metrics_update_resume(domain_id);
 #endif
-	g_pmglobals.suspend_count[domain_id]--;
 errout:
 	leave_critical_section(flags);
 	return ret;

--- a/os/pm/pm_suspend.c
+++ b/os/pm/pm_suspend.c
@@ -105,15 +105,14 @@ int pm_suspend(int domain_id)
 	if (ret != OK) {
 		goto errout;
 	}
-	if (g_pmglobals.suspend_count[domain_id] >= UINT16_MAX) {
-		ret = ERROR;
-		set_errno(ERANGE);
-		goto errout;
+	if (g_pmglobals.suspend_count[domain_id]) {
+		pmdbg("Thread with pid (%d) tried to suspend domain (%s) again\n", getpid(), pm_domain_map[domain_id]);
+	} else {
+		g_pmglobals.suspend_count[domain_id] = true;
 	}
 #ifdef CONFIG_PM_METRICS
 	pm_metrics_update_suspend(domain_id);
 #endif
-	g_pmglobals.suspend_count[domain_id]++;
 errout:
 	leave_critical_section(flags);
 	return ret;


### PR DESCRIPTION
This commit change the logic of pm_suspend and pm_resume API. Now, instead of incrementing or decrementing suspend counts, we maintain only suspended domain flag to prevent board sleep.