### PR TITLE
Sync NDP drivers code

### DIFF
--- a/apps/examples/wakerec/wakerec.cxx
+++ b/apps/examples/wakerec/wakerec.cxx
@@ -49,7 +49,7 @@ using namespace media::voice;
 
 media::voice::SpeechDetector *sd;
 
-static const char *filePath = "/mnt/record.pcm";
+static const char *filePath = "/tmp/record.pcm";
 uint8_t *gBuffer = NULL;
 uint32_t bufferSize = 0;
 

--- a/os/board/rtl8730e/src/rtl8730e_ndp120.c
+++ b/os/board/rtl8730e/src/rtl8730e_ndp120.c
@@ -62,6 +62,7 @@ struct rtl8730e_ndp120_audioinfo_s {
 	struct ndp120_lower_s lower;
 	ndp120_handler_t handler;
 	gpio_t dmic;
+	gpio_t reset;
 	gpio_irq_t data_ready;
 };
 
@@ -131,6 +132,18 @@ static void rtl8730e_ndp120_set_dmic(bool enable)
 	}
 }
 
+static void rtl8730e_ndp120_reset()
+{
+	gpio_dir(&g_ndp120info.reset, PIN_OUTPUT);
+	gpio_mode(&g_ndp120info.reset, PullDown);
+	gpio_write(&g_ndp120info.reset, 0);
+	up_mdelay(20);
+
+	gpio_mode(&g_ndp120info.reset, PullUp);
+	gpio_write(&g_ndp120info.reset, 1);
+	up_mdelay(20);
+}
+
 #ifdef CONFIG_PM
 static void rtl8730e_ndp120_pm(bool sleep)
 {	
@@ -185,7 +198,8 @@ int rtl8730e_ndp120_initialize(int minor)
 		g_ndp120info.lower.irq_enable = rtl8730e_ndp120_enable_irq;
 		g_ndp120info.lower.set_dmic = rtl8730e_ndp120_set_dmic;
 		gpio_init(&g_ndp120info.dmic, GPIO_DMIC_EN);
-		
+		gpio_init(&g_ndp120info.reset, PA_24);
+		rtl8730e_ndp120_reset();
 		rtl8730e_ndp120_set_dmic(false);
 #ifdef CONFIG_PM
 		g_ndp120info.lower.set_pm_state = rtl8730e_ndp120_pm;

--- a/os/board/rtl8730e/src/rtl8730e_ndp120.c
+++ b/os/board/rtl8730e/src/rtl8730e_ndp120.c
@@ -114,7 +114,7 @@ static void rtl8730e_ndp120_irq_attach(ndp120_handler_t handler, FAR char *arg)
 {
 	g_ndp120info.handler = handler;
 	gpio_irq_init(&g_ndp120info.data_ready, PA_23, rtl8730e_ndp120_irq_handler, arg);
-	gpio_irq_set(&g_ndp120info.data_ready, IRQ_FALL_RISE, 1);
+	gpio_irq_set(&g_ndp120info.data_ready, IRQ_HIGH, 1);
 	gpio_irq_enable(&g_ndp120info.data_ready);
 }
 

--- a/os/drivers/ai-soc/ndp120/src/ndp120_api.c
+++ b/os/drivers/ai-soc/ndp120/src/ndp120_api.c
@@ -380,6 +380,9 @@ static int initialize_ndp(struct ndp120_dev_s *dev)
 
 	dev->ndp_interrupts_enabled = false;
 
+	int full_speed_freq = dev->lower->spi_config.freq;
+	dev->lower->spi_config.freq = NDP120_SPI_FREQ_INIT;
+
 	/*
 	 * initialize the ILib with the integration interface functions and
 	 * reset the NDP device

--- a/os/drivers/ai-soc/ndp120/src/ndp120_api.c
+++ b/os/drivers/ai-soc/ndp120/src/ndp120_api.c
@@ -1365,9 +1365,16 @@ int ndp120_extract_audio(struct ndp120_dev_s *dev, struct ap_buffer_s *apb)
 	}
 
 	do {
+		/* Incase we receive data reread error, then sample_size would be 
+		 * zero in 2nd iter. So, reinitialize sample_size to dev->sample_size
+		 * to prevent reading the entrie audio tank into the apb */
+		sample_size = dev->sample_size;
 		s = syntiant_ndp_extract_data(dev->ndp,
 			SYNTIANT_NDP_EXTRACT_TYPE_INPUT,
 			SYNTIANT_NDP_EXTRACT_FROM_UNREAD, apb->samp, &sample_size);
+		if (s == SYNTIANT_NDP_ERROR_DATA_REREAD) {
+			auddbg("DATA_REREAD error occured\n");
+		}
 	} while (s == SYNTIANT_NDP_ERROR_DATA_REREAD);
 
 	apb->nbytes = dev->sample_size;

--- a/os/drivers/ai-soc/ndp120/src/ndp120_api.c
+++ b/os/drivers/ai-soc/ndp120/src/ndp120_api.c
@@ -1260,11 +1260,6 @@ int ndp120_irq_handler_work(struct ndp120_dev_s *dev)
 				case 0:
 					serialno++;
 					auddbg("[#%d Hi-Bixby] matched: %s\n", serialno, dev->labels_per_network[network_id][winner]);
-					/* extract keyword immediately */
-					extract_keyword(dev);
-#ifdef CONFIG_NDP120_AEC_SUPPORT
-					g_ndp120_state = IS_RECORDING;
-#endif
 					break;
 				case 1:
 					auddbg("[#%d Voice Commands] matched: %s\n", serialno, dev->labels_per_network[network_id][winner]);
@@ -1277,6 +1272,11 @@ int ndp120_irq_handler_work(struct ndp120_dev_s *dev)
 			msg.u.pPtr = NULL;
 			msg.msgId = AUDIO_MSG_NONE;
 			if (network_id == 0 && !dev->recording) {
+				/* extract keyword immediately */
+				extract_keyword(dev);
+#ifdef CONFIG_NDP120_AEC_SUPPORT
+				g_ndp120_state = IS_RECORDING;
+#endif
 				msg.msgId = AUDIO_MSG_KD;
 			} else if (network_id == 1) {
 				switch (winner) {
@@ -1320,6 +1320,7 @@ int ndp120_set_sample_ready_int(struct ndp120_dev_s *dev, int on)
 {
 	int s;
 	s = syntiant_ndp120_config_notify_on_sample_ready(dev->ndp, on);
+	auddbg("sample ready state (%d), ret (%d)\n", on, s);
 	return s;
 }
 

--- a/os/drivers/ai-soc/ndp120/src/syntiant_portability.c
+++ b/os/drivers/ai-soc/ndp120/src/syntiant_portability.c
@@ -100,5 +100,3 @@ unsigned long syntiant_get_ms_elapsed(syntiant_ms_time *ms_time)
 
 #endif
 
-
-

--- a/os/drivers/audio/ndp120_voice.c
+++ b/os/drivers/audio/ndp120_voice.c
@@ -567,7 +567,7 @@ static int ndp120_ioctl(FAR struct audio_lowerhalf_s *dev, int cmd, unsigned lon
 
 		bufinfo = (FAR struct ap_buffer_info_s *)arg;
 
-		bufinfo->buffer_size = priv->sample_size;
+		bufinfo->buffer_size = 4 * priv->sample_size;
 		bufinfo->nbuffers = CONFIG_NDP120_NUM_BUFFERS;
 		
 		audvdbg("buffer_size : %d nbuffers : %d\n",


### PR DESCRIPTION
when "SYNTIANT_NDP_ERROR_DATA_REREAD" error occurs, zero is returned in the argument extract size as no bytes are extracted. However, in the next iteration, zero is passed as extract size, causing to extract the entire audio tank, hence corrupting the heap. This exactly matches the crash we observed as the heap corrupted (around 60KB) matches the size of the audio tank (60KB)