### PR TITLE
pm_domain_register: fix heap corruption issue.

### DIFF
--- a/os/pm/pm_domain_register.c
+++ b/os/pm/pm_domain_register.c
@@ -98,7 +98,7 @@ int pm_domain_register(char *domain)
 		flags = enter_critical_section();
 		/* If we have unused domain ID then use it to register given domain */
 		if (pm_domain_map[index] == NULL) {
-			pm_domain_map[index] = (char *)kmm_malloc(length * sizeof(char));
+			pm_domain_map[index] = (char *)kmm_malloc((length + 1) * sizeof(char));
 			if (!pm_domain_map[index]) {
 				set_errno(ENOMEM);
 				pmdbg("Unable to allocate memory from heap\n");


### PR DESCRIPTION
When creating a new domain, it allocs as much memory as the length of the domain string. However, the domain is copied to the allocated memory as long as the domain length + 1 Because to store a space character.

It is breaking the next chunk header of the allocated memory, resuting in a corrupted heap.

Therefor, Fix to allocate length + 1.