### PR TITLE
os/arch/arm/src/amebasmart: fix module cannot enter PG when LCD and M…

### DIFF
--- a/os/arch/arm/src/amebasmart/amebasmart_mipi.c
+++ b/os/arch/arm/src/amebasmart/amebasmart_mipi.c
@@ -306,10 +306,16 @@ static int amebasmart_mipi_transfer(FAR struct mipi_dsi_host *dsi_host, FAR cons
 
 	if(msg->type == MIPI_DSI_END_OF_TRANSMISSION){
 		MIPI_DSI_INT_Config(g_dsi_host.MIPIx, DISABLE, DISABLE, FALSE);
+#ifdef CONFIG_PM
+		bsp_pm_domain_control(BSP_MIPI_DRV, 0);
+#endif
 		return OK;
 	}
 	int ret = mipi_dsi_create_packet(&packet, msg);
 	if (ret != OK) {
+#ifdef CONFIG_PM
+		bsp_pm_domain_control(BSP_MIPI_DRV, 0);
+#endif
 		return ret;
 	}
 	send_cmd_done = 0;


### PR DESCRIPTION
…IPI are enabled

1. domain control is not added at MIPI end of transmission/failure to create packet, result in counter not decrement to 0, causing board not go to PG even all data are tx
2. add bsp_pm_domain_control to ensure it is in pairs.