### PR TITLE
os/board/rtl8730e: get BLE MAC address before BLE init

### DIFF
--- a/framework/src/ble_manager/ble_manager_state.c
+++ b/framework/src/ble_manager/ble_manager_state.c
@@ -249,8 +249,6 @@ ble_result_e blemgr_handle_request(blemgr_msg_s *msg)
 	} break;
 
 	case BLE_CMD_GET_MAC: {
-		BLE_STATE_CHECK;
-
 		uint8_t *mac = (uint8_t *)msg->param;
 		if (mac == NULL) {
 			ret = TRBLE_INVALID_ARGS;

--- a/os/board/rtl8730e/src/component/bluetooth/driver/platform/amebad2/hci/hci_platform.c
+++ b/os/board/rtl8730e/src/component/bluetooth/driver/platform/amebad2/hci/hci_platform.c
@@ -1186,3 +1186,18 @@ uint8_t hci_platform_get_patch_cmd_buf(uint8_t *cmd_buf, uint8_t cmd_len)
 
 	return HCI_SUCCESS;
 }
+
+uint8_t hci_platform_get_ble_mac_address(uint8_t *ble_addr){
+	uint8_t *pbuf;
+
+	/* Read Logic Efuse */
+	pbuf = osif_mem_alloc(RAM_TYPE_DATA_ON, 6);
+	if (!pbuf || _FAIL == OTP_LogicalMap_Read(pbuf, 0x1B4, 6)) {
+		HCI_ERR("BT MAC address read failed");
+		return HCI_FAIL;
+	}
+
+	memcpy(ble_addr, pbuf, 6);
+	osif_mem_free(pbuf);
+	return HCI_SUCCESS;
+}

--- a/os/board/rtl8730e/src/component/os/tizenrt/rtk_blemgr.c
+++ b/os/board/rtl8730e/src/component/os/tizenrt/rtk_blemgr.c
@@ -52,6 +52,16 @@ static void _reverse_mac(uint8_t *mac, uint8_t *target)
 	}
 }
 
+static bool _check_mac_empty(uint8_t mac[TRBLE_BD_ADDR_MAX_LEN])
+{
+	for (int i = 0; i < TRBLE_BD_ADDR_MAX_LEN; i++) {
+		if (mac[i] != 0){
+			return false;
+		}
+	}
+	return true;
+}
+
 /*** Common ***/
 trble_result_e trble_netmgr_init(struct bledev *dev, trble_client_init_config *client, trble_server_init_config *server);
 trble_result_e trble_netmgr_deinit(struct bledev *dev);
@@ -234,7 +244,14 @@ trble_result_e trble_netmgr_deinit(struct bledev *dev)
 
 trble_result_e trble_netmgr_get_mac_addr(struct bledev *dev, uint8_t mac[TRBLE_BD_ADDR_MAX_LEN])
 {
-	memcpy(mac, dev->hwaddr, TRBLE_BD_ADDR_MAX_LEN);
+	if (_check_mac_empty(dev->hwaddr)){
+		if (!hci_platform_get_ble_mac_address(mac))
+		{
+			return TRBLE_FAIL;
+		}
+	} else {
+		memcpy(mac, dev->hwaddr, TRBLE_BD_ADDR_MAX_LEN);
+	}
 	return TRBLE_SUCCESS;
 }
 


### PR DESCRIPTION
- add hci_platform_get_ble_mac_address api to get address from efuse
- hci_platform_get_ble_mac_address can be used before BLE init