### PR TITLE
os/arc/arm/src/amebasmart: set loguart isr priority as lowest

### DIFF
--- a/os/arch/arm/src/amebasmart/amebasmart_serial.c
+++ b/os/arch/arm/src/amebasmart/amebasmart_serial.c
@@ -580,8 +580,8 @@ static int rtl8730e_log_uart_irq(void *Data)
 
 static int rtl8730e_log_up_attach(struct uart_dev_s *dev)
 {
-	InterruptRegister((IRQ_FUN)rtl8730e_log_uart_irq, RTL8730E_UART_LOG_IRQ-32, (int)NULL, INT_PRI_MIDDLE);
-	InterruptEn(RTL8730E_UART_LOG_IRQ-32, INT_PRI_MIDDLE);
+	InterruptRegister((IRQ_FUN)rtl8730e_log_uart_irq, RTL8730E_UART_LOG_IRQ-32, (int)NULL, INT_PRI_LOWEST);
+	InterruptEn(RTL8730E_UART_LOG_IRQ-32, INT_PRI_LOWEST);
 	return 0;
 }
 
@@ -841,8 +841,8 @@ static int rtl8730e_up_setup(struct uart_dev_s *dev)
 	if (uart_index_get(priv->tx) == 4)	{//Loguart cannot be stopped
 		irq_disable(RTL8730E_UART_LOG_IRQ-32);
 		irq_unregister(RTL8730E_UART_LOG_IRQ-32);
-		InterruptRegister((IRQ_FUN)rtl8730e_log_uart_irq, RTL8730E_UART_LOG_IRQ-32, (int)NULL, INT_PRI_MIDDLE);
-		InterruptEn(RTL8730E_UART_LOG_IRQ-32, INT_PRI_MIDDLE);
+		InterruptRegister((IRQ_FUN)rtl8730e_log_uart_irq, RTL8730E_UART_LOG_IRQ-32, (int)NULL, INT_PRI_LOWEST);
+		InterruptEn(RTL8730E_UART_LOG_IRQ-32, INT_PRI_LOWEST);
 	} else {
 		sdrv[uart_index_get(priv->tx)]->uart_idx = uart_index_get(priv->tx);
 		serial_init((serial_t *) sdrv[uart_index_get(priv->tx)], priv->tx, priv->rx);


### PR DESCRIPTION
1. loguart isr should set lower than other peripheral priority