### PR TITLE
os/kernel/binary_manager: Add recovery logic when active partition is broken for resource

### DIFF
--- a/os/kernel/binary_manager/binary_manager.h
+++ b/os/kernel/binary_manager/binary_manager.h
@@ -301,7 +301,6 @@ void binary_manager_reset_board(int reboot_reason);
 int binary_manager_update_kernel_binary(void);
 #ifdef CONFIG_RESOURCE_FS
 binmgr_resinfo_t *binary_manager_get_resdata(void);
-bool binary_manager_scan_resource(void);
 int binary_manager_unmount_resource(void);
 int binary_manager_check_resource_update(void);
 #endif


### PR DESCRIPTION
This is recovery steps when binary in active partition is broken.

1. CONFIG_USE_BP is enabled 1) Check bootparam. 2) Check resource binary with index based on bootparam. 3) If it is invalid, check another binary in opposite partition. 4) If opposite binary is valid, update bootparam with its index.

2. CONFIG_USE_BP is disabled 1) Check resource parititions 2) Check binary with the latest version 3) If it is invalid, check another binary in opposite partition. 4) If opposite binary is valid, update bootparam with its index.

But step 3 and 4 are missing in handling resource binary.