### PR TITLE
rtl8730e_boot.c: bringup gpio PB22 pin for lcd

### DIFF
--- a/os/board/rtl8730e/src/rtl8730e_boot.c
+++ b/os/board/rtl8730e/src/rtl8730e_boot.c
@@ -242,6 +242,7 @@ void board_gpio_initialize(void)
 				{PA_23, PIN_INPUT, PullNone},
 				/* PB_20 is gpio pin number for LED */
 				{PB_20, PIN_OUTPUT, PullDown},
+				{PB_22, PIN_INPUT, PullNone},
 		/* NOTE: Do not open pins not for GPIO usage. E.g uart,SPI pins
 		Loguart pins
 		*/


### PR DESCRIPTION
This commit brings up PB22 gpio pin. This pin will be used as wake up source for lcd.