### PR TITLE
os/board/rtl8730e: fix clock instability of I2S when entering/exiting PG

### DIFF
--- a/os/board/rtl8730e/src/component/mbed/targets/hal/rtl8730e/i2s_api.c
+++ b/os/board/rtl8730e/src/component/mbed/targets/hal/rtl8730e/i2s_api.c
@@ -621,6 +621,13 @@ void i2s_disable(i2s_t *obj, bool is_suspend)
 		AUDIO_SP_TXStart(obj->i2s_idx, DISABLE);
 		if (is_suspend) {
 			AUDIO_SP_Deinit(obj->i2s_idx, obj->direction);
+
+			/* deinit the peripheral clock when suspending to avoid invalid state */
+			if (obj->i2s_idx == I2S2) {
+				RCC_PeriphClockCmd(APBPeriph_SPORT2, APBPeriph_SPORT2_CLOCK, DISABLE);
+			} else if (obj->i2s_idx == I2S3) {
+				RCC_PeriphClockCmd(APBPeriph_SPORT3, APBPeriph_SPORT3_CLOCK, DISABLE);
+			}
 		}
 	} else {
 


### PR DESCRIPTION
It was observed on some board that the BCLK signal of I2S is glitchy during rapid sleep/resume 

This lead to 2 issues:
- BCLK stuck high when wakeup causing audio unable to play as WCLK cannot be generated. Board unable to sleep as I2S TX is never completed
- BCLK generated but audio buffer is corrupted causing noise, since the bits are invalid when BCLK glitches

This fix completely turns off peripheral clock for I2S2/3 and ensure complete deinit during PG 

After power state change, this fix ensure that clock latches to correct frequency. There is no impact to wakeup time as the clock init delay is done in full resume

Verification: BCLK signal is cleanly generated, audio playback is clean without distortion after ~30 playback attempts