### PR TITLE
os/arch/arm/src/amebasmart: remove PB22 for I2S2 MCLK

### DIFF
--- a/os/arch/arm/src/amebasmart/amebasmart_i2s.c
+++ b/os/arch/arm/src/amebasmart/amebasmart_i2s.c
@@ -216,7 +216,7 @@ struct amebasmart_i2s_s {
 
 /* I2S device structures */
 static const struct amebasmart_i2s_config_s amebasmart_i2s2_config = {
-	.i2s_mclk_pin = PB_22,
+	.i2s_mclk_pin = NULL,
 	.i2s_sclk_pin = PB_21,
 	.i2s_ws_pin = PA_16,
 	.i2s_sd_tx_pin = PB_10,

--- a/os/board/rtl8730e/src/component/mbed/targets/hal/rtl8730e/i2s_api.c
+++ b/os/board/rtl8730e/src/component/mbed/targets/hal/rtl8730e/i2s_api.c
@@ -497,8 +497,9 @@ void i2s_init(i2s_t *obj, PinName sck, PinName ws, PinName sd_tx, PinName sd_rx,
 		/*Enable SPORT/AUDIO CODEC CLOCK and Function*/
 		RCC_PeriphClockCmd(APBPeriph_SPORT3, APBPeriph_SPORT3_CLOCK, ENABLE);
 	}
-
-	Pinmux_Config(mck, pin_func);
+	if (mck) {
+		Pinmux_Config(mck, pin_func);
+	}
 	Pinmux_Config(sck, pin_func);
 	Pinmux_Config(ws, pin_func);
 	Pinmux_Config(sd_tx, pin_func);


### PR DESCRIPTION
1. Only pinmux MCLK if required
2. remove I2S2 MCLK since it is not required in pinmux table