### PR TITLE
os/arch/arm/src/amebasmart: add related macro on peripherals priv struct

### DIFF
--- a/os/arch/arm/src/amebasmart/amebasmart_i2c.c
+++ b/os/arch/arm/src/amebasmart/amebasmart_i2c.c
@@ -295,7 +295,7 @@ static const struct i2c_ops_s amebasmart_i2c_ops = {
 };
 
 /* I2C device structures */
-
+#ifdef CONFIG_AMEBASMART_I2C0
 static const struct amebasmart_i2c_config_s amebasmart_i2c0_config = {
 	//.base = amebasmart_I2C0_BASE,
 	//.busy_idle = CONFIG_I2C0_BUSYIDLE,
@@ -330,7 +330,9 @@ static struct amebasmart_i2c_priv_s amebasmart_i2c0_priv = {
 	.flags = 0,
 	.status = 0
 };
+#endif
 
+#ifdef CONFIG_AMEBASMART_I2C1
 static const struct amebasmart_i2c_config_s amebasmart_i2c1_config = {
 	//.base = amebasmart_I2C1_BASE,
 	//.busy_idle = CONFIG_I2C1_BUSYIDLE,
@@ -365,7 +367,9 @@ static struct amebasmart_i2c_priv_s amebasmart_i2c1_priv = {
 	.flags = 0,
 	.status = 0
 };
+#endif
 
+#ifdef CONFIG_AMEBASMART_I2C2
 static const struct amebasmart_i2c_config_s amebasmart_i2c2_config = {
 	//.base = amebasmart_I2C2_BASE,
 	//.busy_idle = CONFIG_I2C2_BUSYIDLE,
@@ -395,6 +399,7 @@ static struct amebasmart_i2c_priv_s amebasmart_i2c2_priv = {
 	.flags = 0,
 	.status = 0
 };
+#endif
 /************************************************************************************
  * Private Functions
  ************************************************************************************/
@@ -1158,13 +1163,22 @@ FAR struct i2c_dev_s *up_i2cinitialize(int port)
 	irqstate_t flags;
 
 	/* Get I2C private structure */
+#ifdef CONFIG_AMEBASMART_I2C0
 	if (port == 0) {
 		priv = (struct amebasmart_i2c_priv_s *)&amebasmart_i2c0_priv;
-	} else if (port == 1) {
+	} else
+#endif
+#ifdef CONFIG_AMEBASMART_I2C1
+	if (port == 1) {
 		priv = (struct amebasmart_i2c_priv_s *)&amebasmart_i2c1_priv;
-	} else if (port == 2) {
+	} else 
+#endif
+#ifdef CONFIG_AMEBASMART_I2C2
+	if (port == 2) {
 		priv = (struct amebasmart_i2c_priv_s *)&amebasmart_i2c2_priv;
-	} else {
+	} else
+#endif
+	{
 		printf("Please select I2CO, I2C1 or I2C2 bus\n");
 		return NULL;
 	}

--- a/os/arch/arm/src/amebasmart/amebasmart_i2s.c
+++ b/os/arch/arm/src/amebasmart/amebasmart_i2s.c
@@ -213,7 +213,7 @@ struct amebasmart_i2s_s {
 	struct amebasmart_buffer_s containers_tx[I2S_DMA_PAGE_NUM];
 #endif
 };
-
+#ifdef CONFIG_AMEBASMART_I2S2
 /* I2S device structures */
 static const struct amebasmart_i2s_config_s amebasmart_i2s2_config = {
 	.i2s_mclk_pin = NULL,
@@ -226,7 +226,9 @@ static const struct amebasmart_i2s_config_s amebasmart_i2s2_config = {
 	.rxenab = 0,
 	.txenab = 1,
 };
+#endif
 
+#ifdef CONFIG_AMEBASMART_I2S3
 static const struct amebasmart_i2s_config_s amebasmart_i2s3_config = {
 	.i2s_mclk_pin = PA_15,
 	.i2s_sclk_pin = PA_14,
@@ -238,7 +240,7 @@ static const struct amebasmart_i2s_config_s amebasmart_i2s3_config = {
 	.rxenab = 1,
 	.txenab = 0,
 };
-
+#endif
 /****************************************************************************
  * Private Function Prototypes
  ****************************************************************************/
@@ -1785,11 +1787,17 @@ struct i2s_dev_s *amebasmart_i2s_initialize(uint16_t port, bool is_reinit)
 	int ret;
 
 	/* Assign HW configuration */
+#ifdef CONFIG_AMEBASMART_I2S2
 	if (port == I2S_NUM_2) {
 		hw_config_s = (struct amebasmart_i2s_config_s *)&amebasmart_i2s2_config;
-	} else if (port == I2S_NUM_3) {
+	} else
+#endif
+#ifdef CONFIG_AMEBASMART_I2S3
+	if (port == I2S_NUM_3) {
 		hw_config_s = (struct amebasmart_i2s_config_s *)&amebasmart_i2s3_config;
-	} else {
+	} else 
+#endif
+	{
 		i2serr("Please select I2S2 or I2S3 bus\n");
 		return NULL;
 	}

--- a/os/arch/arm/src/amebasmart/amebasmart_spi.c
+++ b/os/arch/arm/src/amebasmart/amebasmart_spi.c
@@ -188,7 +188,7 @@ static void amebasmart_spi_bus_initialize(FAR struct amebasmart_spidev_s *priv, 
 /************************************************************************************
  * Private Data
  ************************************************************************************/
-
+#ifdef CONFIG_AMEBASMART_SPI0
 static const struct spi_ops_s g_spi0ops = {
 	.lock         = amebasmart_spi_lock,
 	.select       = amebasmart_spi_select,
@@ -245,7 +245,9 @@ static struct amebasmart_spidev_s g_spi0dev = {
 	.mode = SPIDEV_MODE0,
 	.role = AMEBASMART_SPI_MASTER,
 };
+#endif
 
+#ifdef CONFIG_AMEBASMART_SPI1
 static const struct spi_ops_s g_spi1ops = {
 	.lock         = amebasmart_spi_lock,
 	.select       = amebasmart_spi_select,
@@ -302,6 +304,7 @@ static struct amebasmart_spidev_s g_spi1dev = {
 	.mode = SPIDEV_MODE0,
 	.role = AMEBASMART_SPI_MASTER
 };
+#endif
 
 /************************************************************************************
  * Private Functions
@@ -1380,7 +1383,7 @@ FAR struct spi_dev_s *amebasmart_spibus_initialize(int bus)
 	FAR struct amebasmart_spidev_s *priv = NULL;
 
 	irqstate_t flags = enter_critical_section();
-	
+#ifdef CONFIG_AMEBASMART_SPI0	
 	if (bus == 0) {
 		/* Select SPI0 */
 
@@ -1394,7 +1397,10 @@ FAR struct spi_dev_s *amebasmart_spibus_initialize(int bus)
 		amebasmart_spi_bus_initialize(priv, 0);
 #endif
 
-	} else if (bus == 1) {
+	} else
+#endif
+#ifdef CONFIG_AMEBASMART_SPI1
+	if (bus == 1) {
 		/* Select SPI1 */
 
 		priv = &g_spi1dev;
@@ -1407,7 +1413,9 @@ FAR struct spi_dev_s *amebasmart_spibus_initialize(int bus)
 		amebasmart_spi_bus_initialize(priv, 0);
 #endif
 
-	} else {
+	} else 
+#endif
+	{
 		spierr("ERROR: Unsupported SPI bus: %d\n", bus);
 		leave_critical_section(flags);
 		return NULL;
@@ -1485,7 +1493,7 @@ FAR struct spi_dev_s *up_spiinitialize(int port)
 	FAR struct amebasmart_spidev_s *priv = NULL;
 
 	irqstate_t flags = enter_critical_section();
-
+#ifdef CONFIG_AMEBASMART_SPI0
 	if (port == 0) {
 		/* Select SPI0 */
 
@@ -1504,7 +1512,10 @@ FAR struct spi_dev_s *up_spiinitialize(int port)
 		amebasmart_spi_bus_initialize(priv, 0);
 #endif
 	}
-	else if (port == 1) {
+	else 
+#endif
+#ifdef CONFIG_AMEBASMART_SPI1
+	if (port == 1) {
 		/* Select SPI1 */
 
 		priv = &g_spi1dev;
@@ -1521,6 +1532,7 @@ FAR struct spi_dev_s *up_spiinitialize(int port)
 		amebasmart_spi_bus_initialize(priv, 0);
 #endif
 	} else
+#endif
 	{
 		spierr("ERROR: Unsupported SPI bus: %d\n", port);
 		leave_critical_section(flags);


### PR DESCRIPTION
1. each priv struct should only be made available if it is enabled in menuconfig
2. it will return NULL when port is not enabled, error handling should be added in places calling intialization