### PR TITLE
os/include/tinyara/input/touchscreen.h: Add missing header

### DIFF
--- a/os/include/tinyara/input/touchscreen.h
+++ b/os/include/tinyara/input/touchscreen.h
@@ -71,6 +71,7 @@
 #if defined(CONFIG_TOUCH)
 #include <tinyara/fs/ioctl.h>
 #include <tinyara/i2c.h>
+#include <semaphore.h>
 
 /************************************************************************************
  * Pre-processor Definitions


### PR DESCRIPTION
There was a build error in UI like below.
```
include/tinyara/input/touchscreen.h:191:2: error: 'sem_t' does not name a type
  191 |  sem_t sem;
      |  ^~~~~
include/tinyara/input/touchscreen.h:194:2: error: 'sem_t' does not name a type
  194 |  sem_t pollsem;
```

Add missing header(semaphore.h) to fix build error.