### PR TITLE
os/board/rtl8730e: Workaround fix I2C hang issue during boot

### DIFF
--- a/os/board/rtl8730e/src/rtl8730e_ist415.c
+++ b/os/board/rtl8730e/src/rtl8730e_ist415.c
@@ -129,6 +129,7 @@ static void rtl8730e_ist415_gpio_reset(void)
 	GPIO_WriteBit(IST415_GPIO_RESET_PIN, PIN_LOW);
 	DelayMs(300);
 	GPIO_WriteBit(IST415_GPIO_RESET_PIN, PIN_HIGH);
+	DelayMs(1);  /* Workaround: IC20 write hang issue */
 }
 
 static void rtl8730e_ist415_gpio_init(void)


### PR DESCRIPTION
If you call GPIO_WriteBit right after calling I2c_write, there is an issue where the FIFO does not become empty after putting data in I2C FIFO. (I2C_BIT_TFE)

we have to check two point.
1. Why is there a problem with using I2C immediately after writing to GPIO?
2. When writing to I2C, do we have to put it in the FIFO and wait for the FIFO to be empty?

The changes is workarount adding delay