### PR TITLE
os/drivers/lcd: Add suspend pm operation during lcd init.

### DIFF
--- a/os/drivers/lcd/lcd_dev.c
+++ b/os/drivers/lcd/lcd_dev.c
@@ -463,6 +463,9 @@ int lcddev_register(struct lcd_dev_s *dev)
 		if (ret != OK) {
 			return ret;
 		}
+#ifdef CONFIG_PM
+		(void)pm_suspend(lcd_info->pm_domain);
+#endif
 	}
 	sem_init(&lcd_info->sem, 0, 1);
 	if (lcd_info->dev->getplaneinfo) {


### PR DESCRIPTION
When the LCD backlight is on, defer the PM operation. During LCD initialization, the LCD backlight is set to maximum power, but since we are not calling pm_suspend, the board enters sleep mode after LCD initialization.

Therefore, Add calling pm_suspend in lcd init.
Signed-off-by: eunwoo.nam <eunwoo.nam@samsung.com>