### PR TITLE
os/board/rtl8730e/src: update ist415 gpio reset delay workaround message

### DIFF
--- a/os/board/rtl8730e/src/rtl8730e_ist415.c
+++ b/os/board/rtl8730e/src/rtl8730e_ist415.c
@@ -129,7 +129,7 @@ static void rtl8730e_ist415_gpio_reset(void)
 	GPIO_WriteBit(IST415_GPIO_RESET_PIN, PIN_LOW);
 	DelayMs(300);
 	GPIO_WriteBit(IST415_GPIO_RESET_PIN, PIN_HIGH);
-	DelayMs(1);  /* Workaround: IC20 write hang issue */
+	DelayMs(1);  /* Wait for stable voltage before i2c commands issued */
 }
 
 static void rtl8730e_ist415_gpio_init(void)


### PR DESCRIPTION
The workaround message for ist415 driver is replaced to indicate the root cause due to LDO voltage unstable before soft startup is complete (~500us)