### PR TITLE
os/arch/arm/src/armv7-a: Fix wrong assert logs

### DIFF
--- a/os/arch/arm/src/armv7-a/arm_assert.c
+++ b/os/arch/arm/src/armv7-a/arm_assert.c
@@ -115,7 +115,7 @@ extern sq_queue_t g_freemsg_list;
 
 extern uint32_t system_exception_location;
 extern uint32_t user_assert_location;
-extern int g_irq_num;
+extern int g_irq_num[CONFIG_SMP_NCPUS];
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
@@ -254,14 +254,15 @@ static int assert_tracecallback(FAR struct usbtrace_s *trace, FAR void *arg)
 
 static void check_assert_location(uint32_t *sp, bool *is_irq_assert)
 {
-	if (g_irq_num >= 0) {
+	int cpu = this_cpu();
+	if (g_irq_num[cpu] >= 0) {
 		/* Assert in irq */
 		*is_irq_assert = true;
 		lldbg("Code asserted in IRQ state!\n");
-		lldbg("IRQ num: %d\n", g_irq_num);
-		lldbg("IRQ handler: %08x\n", g_irqvector[g_irq_num].handler);
+		lldbg("IRQ num: %d\n", g_irq_num[cpu]);
+		lldbg("IRQ handler: %08x\n", g_irqvector[g_irq_num[cpu]].handler);
 #ifdef CONFIG_DEBUG_IRQ_INFO
-		lldbg("IRQ name: %s\n", g_irqvector[g_irq_num].irq_name);
+		lldbg("IRQ name: %s\n", g_irqvector[g_irq_num[cpu]].irq_name);
 #endif
 	} else {
 		/* Assert in user thread */

--- a/os/arch/arm/src/armv7-a/arm_doirq.c
+++ b/os/arch/arm/src/armv7-a/arm_doirq.c
@@ -58,7 +58,7 @@
  * Public Functions
  ****************************************************************************/
 
-int g_irq_num = -1;				/* Array to store the last three interrupt numbers */
+int g_irq_num[CONFIG_SMP_NCPUS] = {-1, };				/* Array to store the last three interrupt numbers */
 /****************************************************************************
  * Name: arm_doirq
  *
@@ -71,7 +71,7 @@ int g_irq_num = -1;				/* Array to store the last three interrupt numbers */
 uint32_t *arm_doirq(int irq, uint32_t *regs)
 {
 	/* Store the interrupt number for reference during assert */
-	g_irq_num = irq;
+	g_irq_num[up_cpu_index()] = irq;
 
 	board_autoled_on(LED_INIRQ);
 #ifdef CONFIG_SUPPRESS_INTERRUPTS
@@ -120,7 +120,7 @@ uint32_t *arm_doirq(int irq, uint32_t *regs)
   CURRENT_REGS = NULL;
 #endif
 	/* Reset the interrupt number values */
-	g_irq_num = -1;
+	g_irq_num[up_cpu_index()] = -1;
 
 	board_autoled_off(LED_INIRQ);
 	return regs;


### PR DESCRIPTION
Assert logs wrongly indicate the crash to be in irq context when the actual crash is in normal context, but on a different cpu. The issue is happening due to missing code to check the proper cpu when SMP is enabled.