### PR TITLE
apps/system/utils: fix cat to display contents properly

### DIFF
--- a/apps/system/utils/fscmd.c
+++ b/apps/system/utils/fscmd.c
@@ -325,12 +325,8 @@ static int tash_cat(int argc, char **args)
 			read_size = read(fd, fscmd_buffer, FSCMD_BUFFER_LEN - 1);
 			if (read_size > 0) {
 				int output_size = 0;
-				fscmd_buffer[read_size] = '\0';
 				while (output_size < read_size) {
 					FSCMD_OUTPUT("%c", fscmd_buffer[output_size++]);
-					if (output_size % 100 == 0) {
-						FSCMD_OUTPUT("\n");
-					}
 				}
 			}
 		} while (read_size > 0);


### PR DESCRIPTION
Previously the cat is printing newline after every 100th character which
leads to line break for read data from file. This commit resolve this
issue by reverting the code changes.

Before:

```
TASH>>cat /proc/power/domains/info
 DOMAIN ID |            DOMAIN NAME            | SUSPEND COUNTS
-----------|-----------------------
------------|----------------
         0 |                              IDLE |              0

    1 |                            SCREEN |              0
         2 |                              UART |              1
         3 |
              SPI |              0
         4 |                              TASH |              2
```

After:

```
TASH>>cat /proc/power/domains/info
 DOMAIN ID |            DOMAIN NAME            | SUSPEND COUNTS
-----------|-----------------------------------|----------------
         0 |                              IDLE |              0
         1 |                            SCREEN |              0
         2 |                              UART |              1
         3 |                               SPI |              0
         4 |                              TASH |              2
```