### PR TITLE
os/board/rtl8730e: fix scan stop when extended adv and extended scan is enabled

### DIFF
--- a/os/board/rtl8730e/src/component/bluetooth/api/rtk_stack/rtk_stack_le_gap.c
+++ b/os/board/rtl8730e/src/component/bluetooth/api/rtk_stack/rtk_stack_le_gap.c
@@ -3054,6 +3054,35 @@ static uint16_t bt_stack_le_gap_set_scan_param(void *param)
 	rtk_bt_le_scan_param_t *p_gap_scan_param = (rtk_bt_le_scan_param_t *)param;
 	T_GAP_CAUSE cause;
 
+#if (defined(RTK_BLE_5_0_AE_SCAN_SUPPORT) && RTK_BLE_5_0_AE_SCAN_SUPPORT)
+	T_GAP_LE_EXT_SCAN_PARAM extended_scan_param = {0};
+	uint8_t scan_phys = GAP_EXT_SCAN_PHYS_1M_BIT;
+
+	cause = le_ext_scan_set_param(GAP_PARAM_EXT_SCAN_LOCAL_ADDR_TYPE, sizeof(p_gap_scan_param->own_addr_type), &p_gap_scan_param->own_addr_type);
+	if (cause) {
+		return RTK_BT_ERR_LOWER_STACK_API;
+	}
+
+	cause = le_ext_scan_set_param(GAP_PARAM_EXT_SCAN_FILTER_POLICY, sizeof(p_gap_scan_param->filter_policy), &p_gap_scan_param->filter_policy);
+	if (cause) {
+		return RTK_BT_ERR_LOWER_STACK_API;
+	}
+
+	cause = le_ext_scan_set_param(GAP_PARAM_EXT_SCAN_FILTER_DUPLICATES, sizeof(p_gap_scan_param->duplicate_opt), &p_gap_scan_param->duplicate_opt);
+	if (cause) {
+		return RTK_BT_ERR_LOWER_STACK_API;
+	}
+
+	cause = le_ext_scan_set_param(GAP_PARAM_EXT_SCAN_PHYS, sizeof(scan_phys), &scan_phys);
+	if (cause) {
+		return RTK_BT_ERR_LOWER_STACK_API;
+	}
+
+	extended_scan_param.scan_type = (T_GAP_SCAN_MODE)p_gap_scan_param->type;
+	extended_scan_param.scan_interval = p_gap_scan_param->interval;
+	extended_scan_param.scan_window = p_gap_scan_param->window;
+	le_ext_scan_set_phy_param(LE_SCAN_PHY_LE_1M, &extended_scan_param);
+#else
 	cause = le_scan_set_param(GAP_PARAM_SCAN_MODE, sizeof(p_gap_scan_param->type), &p_gap_scan_param->type);
 	if (cause) {
 		return RTK_BT_ERR_LOWER_STACK_API;
@@ -3083,7 +3112,7 @@ static uint16_t bt_stack_le_gap_set_scan_param(void *param)
 	if (cause) {
 		return RTK_BT_ERR_LOWER_STACK_API;
 	}
-
+#endif
 	return RTK_BT_OK;
 
 }
@@ -3092,6 +3121,12 @@ static uint16_t bt_stack_le_gap_start_scan(void)
 {
 	T_GAP_CAUSE cause;
 
+#if (defined(RTK_BLE_5_0_AE_SCAN_SUPPORT) && RTK_BLE_5_0_AE_SCAN_SUPPORT)
+	cause = le_ext_scan_start();
+	if (cause) {
+		return RTK_BT_ERR_LOWER_STACK_API;
+	}
+#else
 #if defined(RTK_BLE_MESH_SUPPORT) && RTK_BLE_MESH_SUPPORT
 extern uint8_t rtk_bt_mesh_stack_set_scan_switch(bool scan_switch);
 	if (rtk_bt_mesh_is_enable()) {
@@ -3105,14 +3140,20 @@ extern uint8_t rtk_bt_mesh_stack_set_scan_switch(bool scan_switch);
 	if (cause) {
 		return RTK_BT_ERR_LOWER_STACK_API;
 	}
-
+#endif
 	return 0;
 }
 
 static uint16_t bt_stack_le_gap_stop_scan(void)
 {
 	T_GAP_CAUSE cause;
+#if (defined(RTK_BLE_5_0_AE_SCAN_SUPPORT) && RTK_BLE_5_0_AE_SCAN_SUPPORT)
+	cause = le_ext_scan_stop();
+	if (cause) {
+		return RTK_BT_ERR_LOWER_STACK_API;
+	}
 
+#else
 #if defined(RTK_BLE_MESH_SUPPORT) && RTK_BLE_MESH_SUPPORT
 extern uint8_t rtk_bt_mesh_stack_set_scan_switch(bool scan_switch);
 	if (rtk_bt_mesh_is_enable()) {
@@ -3126,7 +3167,7 @@ extern uint8_t rtk_bt_mesh_stack_set_scan_switch(bool scan_switch);
 	if (cause) {
 		return RTK_BT_ERR_LOWER_STACK_API;
 	}
-
+#endif
 	return 0;
 }
 

--- a/os/board/rtl8730e/src/component/bluetooth/example/ble_scatternet/scatternet.c
+++ b/os/board/rtl8730e/src/component/bluetooth/example/ble_scatternet/scatternet.c
@@ -267,15 +267,28 @@ static rtk_bt_evt_cb_ret_t ble_tizenrt_scatternet_gap_app_callback(uint8_t evt_c
     }
 
 #if RTK_BLE_5_0_AE_SCAN_SUPPORT
-		case RTK_BT_LE_GAP_EVT_EXT_SCAN_RES_IND: {
-			rtk_bt_le_ext_scan_res_ind_t *scan_res_ind = (rtk_bt_le_ext_scan_res_ind_t *)param;
-			rtk_bt_le_addr_to_str(&(scan_res_ind->addr), le_addr, sizeof(le_addr));
-			printf("[APP] Ext Scan info, [Device]: %s, AD evt type: 0x%x, RSSI: %i, PHY: 0x%x, TxPower: %d, Len: %d\r\n", 
-					le_addr, scan_res_ind->evt_type, scan_res_ind->rssi,
-					(scan_res_ind->primary_phy << 4) | scan_res_ind->secondary_phy,
-					scan_res_ind->tx_power, scan_res_ind->len);
-			break;
-		}
+    case RTK_BT_LE_GAP_EVT_EXT_SCAN_RES_IND: {
+        rtk_bt_le_ext_scan_res_ind_t *scan_res_ind = (rtk_bt_le_ext_scan_res_ind_t *)param;
+        rtk_bt_le_addr_to_str(&(scan_res_ind->addr), le_addr, sizeof(le_addr));
+        // printf("[APP] Ext Scan info, [Device]: %s, AD evt type: 0x%x, RSSI: %i, PHY: 0x%x, TxPower: %d, Len: %d\r\n", 
+        // 		le_addr, scan_res_ind->evt_type, scan_res_ind->rssi,
+        // 		(scan_res_ind->primary_phy << 4) | scan_res_ind->secondary_phy,
+        // 		scan_res_ind->tx_power, scan_res_ind->len);
+        trble_scanned_device scanned_device;
+        scanned_device.adv_type = scan_res_ind->evt_type;
+        if(scanned_device.adv_type == 0x1b){
+            memcpy(scanned_device.resp_data, scan_res_ind->data, scan_res_ind->len);
+            scanned_device.resp_data_length = scan_res_ind->len;
+        } else {
+            memcpy(scanned_device.raw_data, scan_res_ind->data, scan_res_ind->len);
+            scanned_device.raw_data_length = scan_res_ind->len;
+        }
+        memcpy(scanned_device.addr.mac, scan_res_ind->addr.addr_val, RTK_BD_ADDR_LEN);
+        scanned_device.addr.type = scan_res_ind->addr.type;
+        scanned_device.rssi = scan_res_ind->rssi;
+        client_init_parm->trble_device_scanned_cb(&scanned_device);
+        break;
+    }
 #endif
 
     case RTK_BT_LE_GAP_EVT_SCAN_STOP_IND: {

--- a/os/board/rtl8730e/src/component/os/tizenrt/rtk_blemgr.c
+++ b/os/board/rtl8730e/src/component/os/tizenrt/rtk_blemgr.c
@@ -184,6 +184,7 @@ struct trble_ops g_trble_drv_ops = {
 	NULL,
 	NULL,
 	NULL,
+	NULL,
 #if defined (RTK_BLE_5_0_AE_ADV_SUPPORT) && RTK_BLE_5_0_AE_ADV_SUPPORT
 	trble_netmgr_create_multi_adv,
 	trble_netmgr_delete_multi_adv,


### PR DESCRIPTION
- when extended adv and scan is turned on, legacy scan may stop unexpectedly
- with this commit extended scan will always be used when extended adv and extended scan is turned on