### PR TITLE
os/include: resolve build warnings

### DIFF
--- a/os/include/signal.h
+++ b/os/include/signal.h
@@ -578,6 +578,18 @@ CODE void (*signal(int sig, CODE void (*func)(int sig)))(int sig);
 /**
  * @}
  */
+/*
+	Following changes are work around to resolve build warnings.
+
+	TODO : The build warnings are there because function `sigaction` shadows struct `sigaction`.
+
+	The proper fix for warning issue is below:
+
+		1. Either change struct or function name
+		2. Move functions declaration into separate header file
+*/
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wshadow"
 
 /**
  * @ingroup SIGNAL_KERNEL
@@ -588,6 +600,9 @@ CODE void (*signal(int sig, CODE void (*func)(int sig)))(int sig);
  * @since TizenRT v1.0
  */
 int sigaction(int sig, FAR const struct sigaction *act, FAR struct sigaction *oact);
+
+#pragma GCC diagnostic pop
+
 /**
  * @ingroup SIGNAL_KERNEL
  * @brief examine and change blocked signals

--- a/os/include/stdlib.h
+++ b/os/include/stdlib.h
@@ -592,6 +592,19 @@ void qsort(void *base, size_t nmemb, size_t size, int (*compar)(const void *, co
  */
 FAR void *bsearch(FAR const void *key, FAR const void *base, size_t nel, size_t width, CODE int (*compar)(FAR const void *, FAR const void *));
 
+/*
+	Following changes are work around to resolve build warnings.
+
+	TODO : The build warnings are there because function `mallinfo` shadows struct `mallinfo`.
+
+	The proper fix for warning issue is below:
+
+		1. Either change struct or function name
+		2. Move functions declaration into separate header file
+*/
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wshadow"
+
 #ifdef CONFIG_CAN_PASS_STRUCTS
 /**
  * @ingroup STDLIB_LIBC
@@ -612,6 +625,8 @@ struct mallinfo mallinfo(void);
  */
 int mallinfo(struct mallinfo *info);
 #endif
+
+#pragma GCC diagnostic pop
 
 #undef EXTERN
 #if defined(__cplusplus)


### PR DESCRIPTION
Issue: Getting below build warnings

```
include/signal.h:590:83: WARNING: 'int sigaction(int, const sigaction*, sigaction*)' hides constructor for 'struct sigaction' [-Wshadow]

  590 | int sigaction(int sig, FAR const struct sigaction *act, FAR struct sigaction *oact);

include/stdlib.h:603:30: WARNING: 'mallinfo mallinfo()' hides constructor for 'struct mallinfo' [-Wshadow]

  603 | struct mallinfo mallinfo(void);

```

Cause: the struct `sigaction` and function `sigaction` is declared with same
name. During compilation they were part of same  namespace that's
causing shadowing of struct with function declaration. Same is true for
`mallinfo`

Resolution: Disable shadow warning during function declaration and
enable it after declaration.

Note: GCC>=7 doesn't throw this error with -Wshadow flag. This
temporary changes is only needed to support build with old version of
GCC.