### PR TITLE
os/syscall, os/include, os/kernel: Remove SMP check for getcpu syscall

### DIFF
--- a/os/include/sys/syscall.h
+++ b/os/include/sys/syscall.h
@@ -101,12 +101,8 @@
 
 #define SYS_sched_getaffinity          (CONFIG_SYS_RESERVED + 14)
 #define SYS_sched_setaffinity          (CONFIG_SYS_RESERVED + 15)
-#ifdef CONFIG_SMP
 #define SYS_sched_getcpu               (CONFIG_SYS_RESERVED + 16)
 #define __SYS_sem                      (CONFIG_SYS_RESERVED + 17)
-#else
-#define __SYS_sem                      (CONFIG_SYS_RESERVED + 16)
-#endif
 
 /* Semaphores */
 

--- a/os/kernel/sched/Make.defs
+++ b/os/kernel/sched/Make.defs
@@ -60,6 +60,7 @@ CSRCS += sched_setscheduler.c sched_getscheduler.c
 CSRCS += sched_yield.c sched_rrgetinterval.c sched_foreach.c
 CSRCS += sched_lock.c sched_unlock.c sched_lockcount.c sched_self.c
 CSRCS += sched_getaffinity.c sched_setaffinity.c
+CSRCS += sched_getcpu.c
 
 ifeq ($(CONFIG_PRIORITY_INHERITANCE),y)
 CSRCS += sched_reprioritize.c
@@ -67,7 +68,6 @@ endif
 
 ifeq ($(CONFIG_SMP),y)
 CSRCS += sched_cpuselect.c sched_cpupause.c
-CSRCS += sched_getcpu.c
 
 CSRCS += sched_thistask.c
 endif

--- a/os/syscall/syscall.csv
+++ b/os/syscall/syscall.csv
@@ -102,7 +102,7 @@
 "rmdir", "unistd.h", "CONFIG_NFILE_DESCRIPTORS > 0 && !defined(CONFIG_DISABLE_MOUNTPOINT)", "int", "FAR const char*"
 "sched_getaffinity","sched.h","","int","pid_t","size_t","FAR cpu_set_t *"
 "sched_setaffinity","sched.h","","int","pid_t","size_t","FAR const cpu_set_t*"
-"sched_getcpu", "sched.h", "defined(CONFIG_SMP)", "int"
+"sched_getcpu", "sched.h", "", "int"
 "sched_getparam", "sched.h", "", "int", "pid_t", "struct sched_param*"
 "sched_getscheduler", "sched.h", "", "int", "pid_t"
 "sched_getstreams", "tinyara/sched.h", "CONFIG_NFILE_DESCRIPTORS > 0 && CONFIG_NFILE_STREAMS > 0", "FAR struct streamlist*"

--- a/os/syscall/syscall_lookup.h
+++ b/os/syscall/syscall_lookup.h
@@ -77,9 +77,7 @@ SYSCALL_LOOKUP(set_errno,                 1, STUB_set_errno)
 
 SYSCALL_LOOKUP(sched_getaffinity,         3, STUB_sched_getaffinity)
 SYSCALL_LOOKUP(sched_setaffinity,         3, STUB_sched_setaffinity)
-#ifdef CONFIG_SMP
 SYSCALL_LOOKUP(sched_getcpu,              0, STUB_sched_getcpu)
-#endif
 
 /* Semaphores */
 

--- a/os/syscall/syscall_stublookup.c
+++ b/os/syscall/syscall_stublookup.c
@@ -93,9 +93,7 @@ uintptr_t STUB_sched_setscheduler(int nbr, uintptr_t parm1, uintptr_t parm2,
 
 int STUB_sched_getaffinity(pid_t pid, size_t cpusetsize, FAR cpu_set_t *mask);
 int STUB_sched_setaffinity(pid_t pid, size_t cpusetsize, FAR const cpu_set_t *mask);
-#ifdef CONFIG_SMP
 int STUB_sched_getcpu(void);
-#endif
 
 uintptr_t STUB_sched_unlock(int nbr);
 uintptr_t STUB_sched_yield(int nbr);


### PR DESCRIPTION
Remove check on CONFIG_SMP for getcpu syscall. If smp is not enabled then this syscall will return zero value.