### PR TITLE
os/arch/arm: separate the reboot reason for assert and boardctl reboot

### DIFF
--- a/os/arch/arm/include/reboot_reason.h
+++ b/os/arch/arm/include/reboot_reason.h
@@ -28,7 +28,7 @@
 void up_reboot_reason_init(void);
 reboot_reason_code_t up_reboot_reason_read(void);
 void up_reboot_reason_write(reboot_reason_code_t reason);
-void reboot_reason_write_user_intended(void);
+void reboot_reason_try_write_assert(void);
 void up_reboot_reason_clear(void);
 bool up_reboot_reason_is_written(void);
 

--- a/os/arch/arm/src/armv7-a/arm_assert.c
+++ b/os/arch/arm/src/armv7-a/arm_assert.c
@@ -610,7 +610,7 @@ void up_assert(const uint8_t *filename, int lineno)
 	board_autoled_on(LED_ASSERTION);
 
 #ifdef CONFIG_SYSTEM_REBOOT_REASON
-	reboot_reason_write_user_intended();
+	reboot_reason_try_write_assert();
 #endif
 
 

--- a/os/arch/arm/src/armv8-m/up_assert.c
+++ b/os/arch/arm/src/armv8-m/up_assert.c
@@ -599,7 +599,7 @@ void up_assert(const uint8_t *filename, int lineno)
 	board_led_on(LED_ASSERTION);
 
 #ifdef CONFIG_SYSTEM_REBOOT_REASON
-	reboot_reason_write_user_intended();
+	reboot_reason_try_write_assert();
 #endif
 
 	abort_mode = true;

--- a/os/arch/arm/src/common/up_reboot_reason.c
+++ b/os/arch/arm/src/common/up_reboot_reason.c
@@ -28,11 +28,11 @@
  * Name: reboot_reason_trywrite
  ****************************************************************************/
 #ifdef CONFIG_SYSTEM_REBOOT_REASON
-void reboot_reason_write_user_intended(void)
+void reboot_reason_try_write_assert(void)
 {
-	/* Write REBOOT_SYSTEM_USER_INTENDED only when there is no written reason before. */
+	/* Write REBOOT_SYSTEM_ASSERT only when there is no written reason before. */
 	if (!up_reboot_reason_is_written()) {
-		up_reboot_reason_write(REBOOT_SYSTEM_USER_INTENDED);
+		up_reboot_reason_write(REBOOT_SYSTEM_ASSERT);
 	}
 }
 #endif

--- a/os/arch/arm/src/stm32h745/stm32h745_systemreset.c
+++ b/os/arch/arm/src/stm32h745/stm32h745_systemreset.c
@@ -189,14 +189,6 @@ void up_reboot_reason_write(reboot_reason_code_t reason)
 }
 
 /****************************************************************************
- * Name: reboot_reason_write_user_intended
- ****************************************************************************/
-void reboot_reason_write_user_intended(void)
-{
-
-}
-
-/****************************************************************************
  * Name: up_reboot_reason_clear
  ****************************************************************************/
 void up_reboot_reason_clear(void)

--- a/os/include/tinyara/reboot_reason.h
+++ b/os/include/tinyara/reboot_reason.h
@@ -40,6 +40,7 @@ typedef enum {
 	REBOOT_SYSTEM_USER_INTENDED        = 56, /* Reboot from user intention */
 	REBOOT_SYSTEM_BINARY_UPDATE        = 57, /* Reboot for Binary Update */
 	REBOOT_SYSTEM_BINARY_RECOVERYFAIL  = 58, /* Binary Recovery Fail */
+	REBOOT_SYSTEM_ASSERT               = 59, /* Reboot from ASSERT or PANIC */
 
 	REBOOT_NETWORK_WIFICORE_WATCHDOG   = 80, /* Wi-Fi Core Watchdog Reset */
 	REBOOT_NETWORK_WIFICORE_PANIC      = 81, /* Wi-Fi Core Panic */


### PR DESCRIPTION
Earlier, ASSERT(PANIC) cases used to have same reboot reason as user intended reboot function (boardctl). So now, this patch adds new reboot reason for ASSERT cases to seperate out the reason.

Updated reboot reason:
REBOOT_SYSTEM_USER_INTENDED        = 56, /* Reboot from user intention */
REBOOT_SYSTEM_ASSERT               = 59, /* Reboot from ASSERT or PANIC */