### PR TITLE
MediaWorker: Changes for thread destory and creation

### DIFF
--- a/framework/src/media/MediaWorker.cpp
+++ b/framework/src/media/MediaWorker.cpp
@@ -19,9 +19,8 @@
 #include <debug.h>
 #include <sched.h>
 #include <pthread.h>
-
 #include "MediaWorker.h"
-
+#define START_WORKER_WAIT_TIME 500 * 1000
 namespace media {
 
 MediaWorker::MediaWorker() :
@@ -30,7 +29,9 @@ MediaWorker::MediaWorker() :
 	mThreadName("MediaWorker"),
 	mIsRunning(false),
 	mRefCnt(0),
-	mWorkerThread(0)
+	mWorkerThread(0),
+	mInsideThreadFunc(false),
+	mMAX_START_THREAD_WAIT_COUNT(10)
 {
 	medvdbg("MediaWorker::MediaWorker()\n");
 }
@@ -45,6 +46,17 @@ void MediaWorker::startWorker()
 	++mRefCnt;
 	medvdbg("%s::startWorker() - increase RefCnt : %d\n", mThreadName, mRefCnt);
 	if (mRefCnt == 1) {
+		unsigned short attemptCount = 0;
+		/* Thread is marked to exit but not exited yet, wait for thread to exit and then create again */
+		while (attemptCount < mMAX_START_THREAD_WAIT_COUNT && mIsRunning == false && mInsideThreadFunc == true) {
+			medwdbg("%s::startWorker() - wait for existing thread to finish\n", mThreadName);
+			usleep(START_WORKER_WAIT_TIME);
+			attemptCount++;
+		}
+		if (attemptCount >= mMAX_START_THREAD_WAIT_COUNT && mIsRunning == false && mInsideThreadFunc == true) {
+			meddbg("%s::startWorker() - existing thread is stuck. Abort creating new thread\n", mThreadName);
+			return;
+		}
 		int ret;
 		struct sched_param sparam;
 		pthread_attr_t attr;
@@ -55,7 +67,7 @@ void MediaWorker::startWorker()
 		mIsRunning = true;
 		ret = pthread_create(&mWorkerThread, &attr, static_cast<pthread_startroutine_t>(MediaWorker::mediaLooper), this);
 		if (ret != OK) {
-			medvdbg("Fail to create worker thread, return value : %d\n", ret);
+			meddbg("Fail to create worker thread, return value : %d\n", ret);
 			--mRefCnt;
 			mIsRunning = false;
 			return;
@@ -72,12 +84,20 @@ void MediaWorker::stopWorker()
 	}
 	medvdbg("%s::stopWorker() - decrease RefCnt : %d\n", mThreadName, mRefCnt);
 	if (mRefCnt <= 0) {
-		std::atomic<bool> &refBool = mIsRunning;
-		mWorkerQueue.enQueue([&refBool]() {
-			refBool = false;
-		});
-		pthread_join(mWorkerThread, NULL);
-		medvdbg("%s::stopWorker() - mWorkerthread exited\n", mThreadName);
+		pthread_t currentThreadId = pthread_self();
+		/* when current thread and join thread same, join API return immdiately */
+		/* directly mIsRunning = false; is done for immediate exit without dequeue operation and then exit */
+		if (mWorkerThread == currentThreadId) { 
+			mIsRunning = false;
+			meddbg("%s::stopWorker() - setting exit condition of mWorkerthread\n", mThreadName);
+		} else {
+			std::atomic<bool> &refBool = mIsRunning;
+			mWorkerQueue.enQueue([&refBool]() {
+				refBool = false;
+			});
+			pthread_join(mWorkerThread, NULL);
+			medvdbg("%s::stopWorker() - mWorkerthread exited\n", mThreadName);
+		}
 	}
 }
 
@@ -94,6 +114,7 @@ bool MediaWorker::processLoop()
 void *MediaWorker::mediaLooper(void *arg)
 {
 	auto worker = static_cast<MediaWorker *>(arg);
+	worker->mInsideThreadFunc = true;
 	medvdbg("MediaWorker : mediaLooper\n");
 
 	while (worker->mIsRunning) {
@@ -110,6 +131,7 @@ void *MediaWorker::mediaLooper(void *arg)
 			run();
 		}
 	}
+	worker->mInsideThreadFunc = false;
 	return NULL;
 }
 

--- a/framework/src/media/MediaWorker.h
+++ b/framework/src/media/MediaWorker.h
@@ -57,6 +57,8 @@ private:
 	int mRefCnt;
 	pthread_t mWorkerThread;
 	std::mutex mRefMtx;
+	std::atomic<bool> mInsideThreadFunc;
+	unsigned short mMAX_START_THREAD_WAIT_COUNT;
 };
 } // namespace media
 #endif


### PR DESCRIPTION
Issue: When destroy is called from PlayerObserverWorker thread, destroy function join operation fails. This leads to race condition for mIsRunning set to false in destroy and true in startWorker.

Solution: Wait for thread procedure function to complete and then create new thread