### PR TITLE
os/arch/armv7-a: new line to distinguish between normal and crash logs

### DIFF
--- a/os/arch/arm/src/armv7-a/arm_dataabort.c
+++ b/os/arch/arm/src/armv7-a/arm_dataabort.c
@@ -78,6 +78,8 @@ uint32_t system_exception_location;
 
 static inline void print_dataabort_detail(uint32_t *regs, uint32_t dfar, uint32_t dfsr)
 {
+	/* Abort log must always start at a new line.*/
+	lldbg_noarg("\n");
 	_alert("#########################################################################\n");
 	_alert("PANIC!!! Data Abort at instruction : 0x%08x\n",  regs[REG_PC]);
 	_alert("PC: %08x DFAR: %08x DFSR: %08x\n", regs[REG_PC], dfar, dfsr);

--- a/os/arch/arm/src/armv7-a/arm_prefetchabort.c
+++ b/os/arch/arm/src/armv7-a/arm_prefetchabort.c
@@ -76,6 +76,8 @@ extern uint32_t system_exception_location;
 
 static inline void print_prefetchabort_detail(uint32_t *regs, uint32_t ifar, uint32_t ifsr)
 {
+	/* Abort log must always start at a new line.*/
+	lldbg_noarg("\n");
 	_alert("#########################################################################\n");
 	_alert("PANIC!!! Prefetch Abort at instruction : 0x%08x\n",  regs[REG_PC]);
 	_alert("PC: %08x IFAR: %08x IFSR: %08x\n", regs[REG_PC], ifar, ifsr);


### PR DESCRIPTION
This commit introduces a new line code in assert logs so that user can distinguish between normal logs and crash logs.