### PR TITLE
os/board/rtl8730e: Optimize wifi disconnect handler

### DIFF
--- a/os/board/rtl8730e/src/component/wifi/api/wifi_ind.c
+++ b/os/board/rtl8730e/src/component/wifi/api/wifi_ind.c
@@ -30,11 +30,6 @@ extern rtw_join_status_t rtw_join_status;
 extern rtw_join_status_t prev_join_status;
 extern internal_join_block_param_t *join_block_param;
 
-#ifdef CONFIG_PLATFORM_TIZENRT_OS
-extern rtk_network_link_callback_t g_link_up;
-extern rtk_network_link_callback_t g_link_down;
-#endif
-
 //----------------------------------------------------------------------------//
 rtw_result_t rtw_indicate_event_handle(int event_cmd, char *buf, int buf_len, int flags)
 {
@@ -161,15 +156,6 @@ void wifi_join_status_indicate(rtw_join_status_t join_status)
 #endif
 		LwIP_netif_set_link_down(0);
 #endif
-#endif
-#if defined(CONFIG_PLATFORM_TIZENRT_OS)
-		rtk_reason_t reason;
-		memset(&reason, 0, sizeof(rtk_reason_t));
-
-		if (g_link_down) {
-			nvdbg("RTK_API %s send link_down\n",__func__);
-			g_link_down(&reason);
-		}
 #endif
 #ifndef CONFIG_AS_INIC_NP
 		deauth_data_pre = (struct deauth_info *)rtw_zmalloc(sizeof(struct deauth_info));

--- a/os/board/rtl8730e/src/component/wifi/inic/inic_ipc_host_api_basic.c
+++ b/os/board/rtl8730e/src/component/wifi/inic/inic_ipc_host_api_basic.c
@@ -130,6 +130,15 @@ static void wifi_disconn_hdl(char *buf, int buf_len, int flags, void *userdata)
 		deauth_reason =*(u16*)(buf+6);
 		key_mgmt = *(u32*)(buf+8);
 	}
+#if defined(CONFIG_PLATFORM_TIZENRT_OS)
+	rtk_reason_t dummy_reason;
+	memset(&dummy_reason, 0, sizeof(rtk_reason_t));
+	if (g_link_down) {
+		nvdbg("RTK_API rtk_handle_disconnect send link_down\n");
+		g_link_down(&dummy_reason);
+	}
+	wifi_unreg_event_handler(WIFI_EVENT_DISCONNECT, wifi_disconn_hdl);
+#endif
 }
 
 //----------------------------------------------------------------------------//
@@ -191,6 +200,10 @@ int wifi_connect(rtw_network_info_t *connect_param, unsigned char block)
 	}
 	DCache_Clean((u32)connect_param, sizeof(rtw_network_info_t));
 	param_buf[0] = (u32)connect_param;
+#if defined(CONFIG_PLATFORM_TIZENRT_OS)
+	/* Register disconnect handler before starting join */
+	wifi_reg_event_handler(WIFI_EVENT_DISCONNECT, wifi_disconn_hdl, NULL);
+#endif
 	result = inic_ipc_api_host_message_send(IPC_API_WIFI_CONNECT, param_buf, 1);
 
 	if (result != RTW_SUCCESS) {
@@ -233,7 +246,6 @@ int wifi_connect(rtw_network_info_t *connect_param, unsigned char block)
 				printf("RTK_API %s() send link_up\n", __func__);
 				g_link_up(&reason);
 			}
-			wifi_reg_event_handler(WIFI_EVENT_DISCONNECT, wifi_disconn_hdl, NULL);
 #endif
 		}
 	}
@@ -259,14 +271,6 @@ int wifi_disconnect(void)
 	int ret = 0;
 
 	ret = inic_ipc_api_host_message_send(IPC_API_WIFI_DISCONNECT, NULL, 0);
-#if defined(CONFIG_PLATFORM_TIZENRT_OS)
-	rtk_reason_t dummy_reason;
-	memset(&dummy_reason, 0, sizeof(rtk_reason_t));
-	if (g_link_down) {
-		nvdbg("RTK_API rtk_handle_disconnect send link_down\n");
-		g_link_down(&dummy_reason); //dummy_reason was not processed in _wt_sta_disconnected callback in TizenRT
-	}
-#endif
 	return ret;
 }
 


### PR DESCRIPTION
- Previously, both wifi_disconnect and wifi_join_status_indicate could trigger TizenRT wifi linkdown callback
- Re-arrange flow such that TizenRT wifi linkdown callback is only called from RTK wifi disconnect handler for STA mode