### PR TITLE
os/drivers, os/mm: Modify mm_manage_allocfail to print alignment

### DIFF
--- a/os/drivers/memory/mminfo.c
+++ b/os/drivers/memory/mminfo.c
@@ -149,7 +149,7 @@ static int mminfo_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
 #ifdef CONFIG_APP_BINARY_SEPARATION
 	case MMINFOIOC_MNG_ALLOCFAIL:
 		/* There is a single heap for user. So start and end indexes of heap are always 0. */
-		mm_manage_alloc_fail(BASE_HEAP, 0, 0, ((struct mm_alloc_fail_s *)arg)->size, USER_HEAP
+		mm_manage_alloc_fail(BASE_HEAP, 0, 0, ((struct mm_alloc_fail_s *)arg)->size, ((struct mm_alloc_fail_s *)arg)->align, USER_HEAP
 #if defined(CONFIG_DEBUG_MM_HEAPINFO)
 				, ((struct mm_alloc_fail_s *)arg)->caller
 #endif

--- a/os/include/tinyara/mm/mm.h
+++ b/os/include/tinyara/mm/mm.h
@@ -373,6 +373,7 @@ extern struct heapinfo_group_info_s group_info[HEAPINFO_THREAD_NUM];
 
 struct mm_alloc_fail_s {
 	uint32_t size;
+	uint32_t align;
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
 	mmaddress_t caller;
 #endif
@@ -690,6 +691,7 @@ void kmm_extend(FAR void *mem, size_t size, int region);
 
 struct mallinfo;				/* Forward reference */
 int mm_mallinfo(FAR struct mm_heap_s *heap, FAR struct mallinfo *info);
+int mm_mallinfo_aligned(FAR struct mm_heap_s *heap, FAR struct mallinfo *info, size_t align);
 
 /* Functions contained in kmm_mallinfo.c ************************************/
 
@@ -784,26 +786,26 @@ int mm_check_heap_corruption(struct mm_heap_s *heap);
 /* Function to manage the memory allocation failure case. */
 #if defined(CONFIG_APP_BINARY_SEPARATION) && !defined(__KERNEL__)
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
-void mm_ioctl_alloc_fail(size_t size, mmaddress_t caller);
-#define mm_manage_alloc_fail(h, b, e, s, t, c) 	do { \
-							(void)h; \
-							(void)b; \
-							(void)e; \
-							(void)t; \
-							mm_ioctl_alloc_fail(s, c); \
-						} while (0)
+void mm_ioctl_alloc_fail(size_t size, size_t align, mmaddress_t caller);
+#define mm_manage_alloc_fail(h, b, e, s, a, t, c) 	do { \
+								(void)h; \
+								(void)b; \
+								(void)e; \
+								(void)t; \
+								mm_ioctl_alloc_fail(s, a, c); \
+							} while (0)
 #else
-void mm_ioctl_alloc_fail(size_t size);
-#define mm_manage_alloc_fail(h, b, e, s, t) 	do { \
+void mm_ioctl_alloc_fail(size_t size, size_t align);
+#define mm_manage_alloc_fail(h, b, e, s, a, t) 	do { \
 							(void)h; \
 							(void)b; \
 							(void)e; \
 							(void)t; \
-							mm_ioctl_alloc_fail(s); \
+							mm_ioctl_alloc_fail(s, a); \
 						} while (0)
 #endif
 #else
-void mm_manage_alloc_fail(struct mm_heap_s *heap, int startidx, int endidx, size_t size, int heap_type
+void mm_manage_alloc_fail(struct mm_heap_s *heap, int startidx, int endidx, size_t size, size_t align, int heap_type
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
 		, mmaddress_t caller
 #endif

--- a/os/mm/kmm_heap/kmm_calloc.c
+++ b/os/mm/kmm_heap/kmm_calloc.c
@@ -88,7 +88,7 @@ static void *kheap_calloc(size_t n, size_t elem_size)
 		}
 	}
 
-	mm_manage_alloc_fail(kheap, HEAP_START_IDX, HEAP_END_IDX, n * elem_size, KERNEL_HEAP
+	mm_manage_alloc_fail(kheap, HEAP_START_IDX, HEAP_END_IDX, n * elem_size, 0, KERNEL_HEAP
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
 			, retaddr
 #endif
@@ -137,7 +137,7 @@ void *kmm_calloc_at(int heap_index, size_t n, size_t elem_size)
 #endif
 			);
 	if (ret == NULL) {
-		mm_manage_alloc_fail(&kheap[heap_index], heap_index, heap_index, n * elem_size, KERNEL_HEAP
+		mm_manage_alloc_fail(&kheap[heap_index], heap_index, heap_index, n * elem_size, 0, KERNEL_HEAP
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
 				, caller_retaddr
 #endif

--- a/os/mm/kmm_heap/kmm_malloc.c
+++ b/os/mm/kmm_heap/kmm_malloc.c
@@ -100,7 +100,7 @@ static void *kheap_malloc(size_t size)
 		}
 	}
 
-	mm_manage_alloc_fail(kheap, HEAP_START_IDX, HEAP_END_IDX, size, KERNEL_HEAP
+	mm_manage_alloc_fail(kheap, HEAP_START_IDX, HEAP_END_IDX, size, 0, KERNEL_HEAP
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
 			, caller_retaddr
 #endif
@@ -153,7 +153,7 @@ void *kmm_malloc_at(int heap_index, size_t size)
 #endif
 			);
 	if (ret == NULL) {
-		mm_manage_alloc_fail(&kheap[heap_index], heap_index, heap_index, size, KERNEL_HEAP
+		mm_manage_alloc_fail(&kheap[heap_index], heap_index, heap_index, size, 0, KERNEL_HEAP
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
 				, caller_retaddr
 #endif

--- a/os/mm/kmm_heap/kmm_memalign.c
+++ b/os/mm/kmm_heap/kmm_memalign.c
@@ -112,7 +112,7 @@ void *kmm_memalign_at(int heap_index, size_t alignment, size_t size)
 #endif
 			);
 	if (ret == NULL) {
-		mm_manage_alloc_fail(&kheap[heap_index], heap_index, heap_index, size, KERNEL_HEAP
+		mm_manage_alloc_fail(&kheap[heap_index], heap_index, heap_index, size, alignment, KERNEL_HEAP
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
 				, caller_retaddr
 #endif
@@ -161,7 +161,7 @@ FAR void *kmm_memalign(size_t alignment, size_t size)
 		}
 	}
 
-	mm_manage_alloc_fail(kheap, HEAP_START_IDX, HEAP_END_IDX, size, KERNEL_HEAP
+	mm_manage_alloc_fail(kheap, HEAP_START_IDX, HEAP_END_IDX, size, alignment, KERNEL_HEAP
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
 			, caller_retaddr
 #endif

--- a/os/mm/kmm_heap/kmm_realloc.c
+++ b/os/mm/kmm_heap/kmm_realloc.c
@@ -111,7 +111,7 @@ void *kmm_realloc_at(int heap_index, void *oldmem, size_t size)
 #endif
 			);
 	if (ret == NULL) {
-		mm_manage_alloc_fail(&kheap[heap_index], heap_index, heap_index, size, KERNEL_HEAP
+		mm_manage_alloc_fail(&kheap[heap_index], heap_index, heap_index, size, 0, KERNEL_HEAP
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
 				, caller_retaddr
 #endif
@@ -184,7 +184,7 @@ FAR void *kmm_realloc(FAR void *oldmem, size_t newsize)
 		}
 	}
 
-	mm_manage_alloc_fail(kheap_new, HEAP_START_IDX, HEAP_END_IDX, newsize, KERNEL_HEAP
+	mm_manage_alloc_fail(kheap_new, HEAP_START_IDX, HEAP_END_IDX, newsize, 0, KERNEL_HEAP
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
 			, caller_retaddr
 #endif

--- a/os/mm/kmm_heap/kmm_zalloc.c
+++ b/os/mm/kmm_heap/kmm_zalloc.c
@@ -105,7 +105,7 @@ void *kmm_zalloc_at(int heap_index, size_t size)
 #endif
 			);
 	if (ret == NULL) {
-		mm_manage_alloc_fail(&kheap[heap_index], heap_index, heap_index, size, KERNEL_HEAP
+		mm_manage_alloc_fail(&kheap[heap_index], heap_index, heap_index, size, 0, KERNEL_HEAP
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
 				, caller_retaddr
 #endif
@@ -153,7 +153,7 @@ FAR void *kmm_zalloc(size_t size)
 			return ret;
 		}
 	}
-	mm_manage_alloc_fail(kheap, HEAP_START_IDX, HEAP_END_IDX, size, KERNEL_HEAP
+	mm_manage_alloc_fail(kheap, HEAP_START_IDX, HEAP_END_IDX, size, 0, KERNEL_HEAP
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
 			, caller_retaddr
 #endif

--- a/os/mm/umm_heap/umm_calloc.c
+++ b/os/mm/umm_heap/umm_calloc.c
@@ -102,7 +102,7 @@ void *calloc_at(int heap_index, size_t n, size_t elem_size)
 #endif
 			);
 	if (ret == NULL) {
-		mm_manage_alloc_fail(&BASE_HEAP[heap_index], heap_index, heap_index, n * elem_size, USER_HEAP
+		mm_manage_alloc_fail(&BASE_HEAP[heap_index], heap_index, heap_index, n * elem_size, 0, USER_HEAP
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
 				, caller_retaddr
 #endif
@@ -148,7 +148,7 @@ static void *heap_calloc(size_t n, size_t elem_size, int s, int e)
 			return ret;
 		}
 	}
-	mm_manage_alloc_fail(BASE_HEAP, s, e, n * elem_size, USER_HEAP
+	mm_manage_alloc_fail(BASE_HEAP, s, e, n * elem_size, 0, USER_HEAP
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
 			, caller_retaddr
 #endif
@@ -186,7 +186,7 @@ FAR void *calloc(size_t n, size_t elem_size)
 #endif
 			);
 	if (ret == NULL) {
-		mm_manage_alloc_fail(BASE_HEAP, HEAP_START_IDX, HEAP_END_IDX, n * elem_size, USER_HEAP
+		mm_manage_alloc_fail(BASE_HEAP, HEAP_START_IDX, HEAP_END_IDX, n * elem_size, 0, USER_HEAP
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
 				, caller_retaddr
 #endif

--- a/os/mm/umm_heap/umm_malloc.c
+++ b/os/mm/umm_heap/umm_malloc.c
@@ -123,7 +123,7 @@ void *malloc_at(int heap_index, size_t size)
 #endif
 			);
 	if (ret == NULL) {
-		mm_manage_alloc_fail(&BASE_HEAP[heap_index], heap_index, heap_index, size, USER_HEAP
+		mm_manage_alloc_fail(&BASE_HEAP[heap_index], heap_index, heap_index, size, 0, USER_HEAP
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
 				, caller_retaddr
 #endif
@@ -169,7 +169,7 @@ static void *heap_malloc(size_t size, int s, int e)
 		}
 	}
 
-	mm_manage_alloc_fail(BASE_HEAP, s, e, size, USER_HEAP
+	mm_manage_alloc_fail(BASE_HEAP, s, e, size, 0, USER_HEAP
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
 			, caller_retaddr
 #endif
@@ -242,7 +242,7 @@ FAR void *malloc(size_t size)
 #endif
 			);
 	if (ret == NULL) {
-		mm_manage_alloc_fail(BASE_HEAP, HEAP_START_IDX, HEAP_END_IDX, size, USER_HEAP
+		mm_manage_alloc_fail(BASE_HEAP, HEAP_START_IDX, HEAP_END_IDX, size, 0, USER_HEAP
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
 				, caller_retaddr
 #endif

--- a/os/mm/umm_heap/umm_memalign.c
+++ b/os/mm/umm_heap/umm_memalign.c
@@ -107,7 +107,7 @@ void *memalign_at(int heap_index, size_t alignment, size_t size)
 #endif
 			);
 	if (ret == NULL) {
-		mm_manage_alloc_fail(&BASE_HEAP[heap_index], heap_index, heap_index, size, USER_HEAP
+		mm_manage_alloc_fail(&BASE_HEAP[heap_index], heap_index, heap_index, size, alignment, USER_HEAP
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
 				, caller_retaddr
 #endif
@@ -152,7 +152,7 @@ FAR void *memalign(size_t alignment, size_t size)
 #endif
 			);
 	if (ret == NULL) {
-		mm_manage_alloc_fail(BASE_HEAP, HEAP_START_IDX, HEAP_END_IDX, size, USER_HEAP
+		mm_manage_alloc_fail(BASE_HEAP, HEAP_START_IDX, HEAP_END_IDX, size, alignment, USER_HEAP
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
 				, caller_retaddr
 #endif
@@ -173,7 +173,7 @@ FAR void *memalign(size_t alignment, size_t size)
 		}
 	}
 
-	mm_manage_alloc_fail(BASE_HEAP, HEAP_START_IDX, HEAP_END_IDX, size, USER_HEAP
+	mm_manage_alloc_fail(BASE_HEAP, HEAP_START_IDX, HEAP_END_IDX, size, alignment, USER_HEAP
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
 			, caller_retaddr
 #endif

--- a/os/mm/umm_heap/umm_realloc.c
+++ b/os/mm/umm_heap/umm_realloc.c
@@ -110,7 +110,7 @@ void *realloc_at(int heap_index, void *oldmem, size_t size)
 #endif
 			);
 	if (ret == NULL) {
-		mm_manage_alloc_fail(&BASE_HEAP[heap_index], heap_index, heap_index, size, USER_HEAP
+		mm_manage_alloc_fail(&BASE_HEAP[heap_index], heap_index, heap_index, size, 0, USER_HEAP
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
 				, caller_retaddr
 #endif
@@ -159,7 +159,7 @@ FAR void *realloc(FAR void *oldmem, size_t size)
 #endif
 			);
 	if (ret == NULL) {
-		mm_manage_alloc_fail(BASE_HEAP, HEAP_START_IDX, HEAP_END_IDX, size, USER_HEAP
+		mm_manage_alloc_fail(BASE_HEAP, HEAP_START_IDX, HEAP_END_IDX, size, 0, USER_HEAP
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
 				, caller_retaddr
 #endif
@@ -204,7 +204,7 @@ FAR void *realloc(FAR void *oldmem, size_t size)
 		}
 	}
 
-	mm_manage_alloc_fail(BASE_HEAP, HEAP_START_IDX, HEAP_END_IDX, size, USER_HEAP
+	mm_manage_alloc_fail(BASE_HEAP, HEAP_START_IDX, HEAP_END_IDX, size, 0, USER_HEAP
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
 			, caller_retaddr
 #endif

--- a/os/mm/umm_heap/umm_zalloc.c
+++ b/os/mm/umm_heap/umm_zalloc.c
@@ -103,7 +103,7 @@ void *zalloc_at(int heap_index, size_t size)
 #endif
 			);
 	if (ret == NULL) {
-		mm_manage_alloc_fail(&BASE_HEAP[heap_index], heap_index, heap_index, size, USER_HEAP
+		mm_manage_alloc_fail(&BASE_HEAP[heap_index], heap_index, heap_index, size, 0, USER_HEAP
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
 				, caller_retaddr
 #endif
@@ -149,7 +149,7 @@ static void *heap_zalloc(size_t size, int s, int e)
 		}
 	}
 
-	mm_manage_alloc_fail(BASE_HEAP, s, e, size, USER_HEAP
+	mm_manage_alloc_fail(BASE_HEAP, s, e, size, 0, USER_HEAP
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
 			, caller_retaddr
 #endif
@@ -190,7 +190,7 @@ FAR void *zalloc(size_t size)
 	if (alloc) {
 		memset(alloc, 0, size);
 	} else {
-		mm_manage_alloc_fail(BASE_HEAP, HEAP_START_IDX, HEAP_END_IDX, size, USER_HEAP
+		mm_manage_alloc_fail(BASE_HEAP, HEAP_START_IDX, HEAP_END_IDX, size, 0, USER_HEAP
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
 				, caller_retaddr
 #endif
@@ -211,7 +211,7 @@ FAR void *zalloc(size_t size)
 #endif
 			);
 	if (ret == NULL) {
-		mm_manage_alloc_fail(BASE_HEAP, HEAP_START_IDX, HEAP_END_IDX, size, USER_HEAP
+		mm_manage_alloc_fail(BASE_HEAP, HEAP_START_IDX, HEAP_END_IDX, size, 0, USER_HEAP
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
 				, caller_retaddr
 #endif


### PR DESCRIPTION
Modify mm_manage_allocfail API to print alignment value for which the allocation has failed.