### PR TITLE
os/arch/arm/amebasmart: Fix I2C hang issue.

### DIFF
--- a/os/arch/arm/src/amebasmart/amebasmart_i2c.c
+++ b/os/arch/arm/src/amebasmart/amebasmart_i2c.c
@@ -439,7 +439,7 @@ static inline void amebasmart_i2c_sem_wait(FAR struct amebasmart_i2c_priv_s *pri
 		 */
 
 		DEBUGASSERT(ret == OK || errno == EINTR);
-	} while (errno == EINTR);
+	} while (ret != OK);
 }
 
 /************************************************************************************


### PR DESCRIPTION
it's calling sem_wait for i2c usage.
The i2c hang issue is occuring if it is using i2c in work queue.

The work queue operation is using signal a lot, and The signal can wakeup a sem blocking with return EINTR errno. So, we should check if errno is EINTR, then we call sem_wait again.

The i2c hang issue is wrong check condition for calling sem_wait again above case . The while condition should be ret != OK.