### PR TITLE
os: fix amp hang issue

### DIFF
--- a/os/arch/arm/src/armv7-a/arm_cpupause.c
+++ b/os/arch/arm/src/armv7-a/arm_cpupause.c
@@ -187,15 +187,16 @@ int up_cpu_paused_save(void)
 
 int up_cpu_paused(int cpu)
 {
+	/* Ensure the CPU has been resumed to avoid causing a deadlock */
+
+	spin_lock(&g_cpu_resumed[cpu]);
+
 	/* Release the g_cpu_paused spinlock to synchronize with the
 	 * requesting CPU.
 	 */
 
 	spin_unlock(&g_cpu_paused[cpu]);
 
-	/* Ensure the CPU has been resumed to avoid causing a deadlock */
-
-	spin_lock(&g_cpu_resumed[cpu]);
 
 	/* Wait for the spinlock to be released.  The requesting CPU will release
 	 * the spinlock when the CPU is resumed.

--- a/os/kernel/irq/irq_csection.c
+++ b/os/kernel/irq/irq_csection.c
@@ -120,7 +120,7 @@ static bool irq_waitlock(int cpu)
 	 * for the deadlock condition.
 	 */
 
-	while (spin_trylock_wo_note(&g_cpu_irqlock) == SP_LOCKED) {
+	do {
 		/* Is a pause request pending? */
 
 		if (up_cpu_pausereq(cpu) || up_get_gating_flag_status(cpu) == 1) {
@@ -136,7 +136,7 @@ static bool irq_waitlock(int cpu)
 
 			return false;
 		}
-	}
+	} while(spin_trylock_wo_note(&g_cpu_irqlock) == SP_LOCKED);
 
 	/* We have g_cpu_irqlock! */
 


### PR DESCRIPTION
To pause the cpu, cpu should call `up_cpu_paused`. The call to `up_cpu_paused` will get missed when `g_cpu_irqlock` is unlocked (means none of the cpu having access to irqlock), `arm_pause_handler` rely on `enter_critical_section` to pause the cpu, it must handle `up_cpu_pausereq` without any fail, otherwise other cpu will wait forever in spinlock.

Change `while` loop to `do-while` loop in `irq_waitlock`, which will ensure there is no pending `up_cpu_pausereq` before getting lock on `g_cpu_irqlock` otherwise pause request will get missed.

The `SP_DMB` is needed to ensure both cpu read correct spinlock value.

The `spin_lock(&g_cpu_resumed[cpu])` is moved upward in code to avoid race condition between cpus.