### PR TITLE
os/arch/armv7-a: Add enter_critical_section in up_schedule_sigaction

### DIFF
--- a/os/arch/arm/src/armv7-a/arm_schedulesigaction.c
+++ b/os/arch/arm/src/armv7-a/arm_schedulesigaction.c
@@ -98,7 +98,11 @@
 #ifndef CONFIG_SMP
 void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 {
+	irqstate_t saved_state;
+
 	svdbg("tcb=%p sigdeliver=%p\n", tcb, sigdeliver);
+
+	saved_state = enter_critical_section();
 
 	/* Refuse to handle nested signal actions */
 
@@ -210,6 +214,9 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 #endif
 		}
 	}
+
+	leave_critical_section(saved_state);
+
 }
 #endif							/* !CONFIG_SMP */
 
@@ -218,8 +225,11 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 {
 	int cpu;
 	int me;
+	irqstate_t saved_state;
 
 	svdbg("tcb=%p sigdeliver=%p\n", tcb, sigdeliver);
+
+	saved_state = enter_critical_section();
 
 	/* Refuse to handle nested signal actions */
 
@@ -410,6 +420,9 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 #endif
 		}
 	}
+
+	leave_critical_section(saved_state);
+
 }
 #endif							/* CONFIG_SMP */
 


### PR DESCRIPTION
The up_schedule_sigaction increases the target task's stack frame to execute the sigaction operation,
 allowing the sigdeliver operation to be performed before the running operation.

Since it changes the stack, SP, and PC, it should be protected from IRQ operations including context switching.

If unprotected, a context switch may occur during the change of stack and PC, causing the target task to operate with incorrect stack SP and resulting in a crash.