### PR TITLE
kernel/wdog: Add to restore executing wdog and dump in assert

### DIFF
--- a/os/arch/arm/src/armv7-a/arm_assert.c
+++ b/os/arch/arm/src/armv7-a/arm_assert.c
@@ -116,6 +116,8 @@ extern sq_queue_t g_freemsg_list;
 extern uint32_t system_exception_location;
 extern uint32_t user_assert_location;
 extern int g_irq_num[CONFIG_SMP_NCPUS];
+
+extern struct wdog_s *g_wdog_debug;
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
@@ -264,6 +266,14 @@ static void check_assert_location(uint32_t *sp, bool *is_irq_assert)
 #ifdef CONFIG_DEBUG_IRQ_INFO
 		lldbg("IRQ name: %s\n", g_irqvector[g_irq_num[cpu]].irq_name);
 #endif
+		if (g_wdog_debug) {
+			/* Assert in wdog excuting*/
+			lldbg("Code asserted in wdog!\n");
+			lldbg_noarg("===========================================================\n");
+			lldbg_noarg("Asserted wdog details\n");
+			lldbg_noarg("===========================================================\n");
+			wd_corruption_dbg(g_wdog_debug);
+		}
 	} else {
 		/* Assert in user thread */
 		lldbg("Code asserted in normal thread!\n");

--- a/os/arch/arm/src/armv7-m/up_assert.c
+++ b/os/arch/arm/src/armv7-m/up_assert.c
@@ -121,6 +121,8 @@ bool abort_mode = false;
 extern uint32_t system_exception_location;
 extern uint32_t user_assert_location;
 extern int g_irq_nums[3];
+
+extern struct wdog_s *g_wdog_debug;
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
@@ -315,6 +317,14 @@ static void up_dumpstate(void)
 	/* Print IRQ handler details if required */
 
 	if (is_irq_assert) {
+		if (g_wdog_debug) {
+			/* Assert in wdog excuting*/
+			lldbg("Code asserted in wdog!\n");
+			lldbg_noarg("===========================================================\n");
+			lldbg_noarg("Asserted wdog details\n");
+			lldbg_noarg("===========================================================\n");
+			wd_corruption_dbg(g_wdog_debug);
+		}
 		lldbg("IRQ num: %d\n", g_irq_nums[irq_num]);
 		lldbg("IRQ handler: %08x\n", g_irqvector[g_irq_nums[irq_num]].handler);
 #ifdef CONFIG_DEBUG_IRQ_INFO

--- a/os/arch/arm/src/armv8-m/up_assert.c
+++ b/os/arch/arm/src/armv8-m/up_assert.c
@@ -131,6 +131,8 @@ extern sq_queue_t g_freemsg_list;
 extern uint32_t system_exception_location;
 extern uint32_t user_assert_location;
 extern int g_irq_nums[3];
+
+extern struct wdog_s *g_wdog_debug;
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
@@ -295,6 +297,15 @@ static void check_assert_location(uint32_t *sp, uint8_t *irq_num, bool *is_irq_a
 			 */
 			*sp = current_regs[REG_R13];
 		}
+	}
+
+	if (*is_irq_assert && g_wdog_debug) {
+		/* Assert in wdog excuting*/
+		lldbg("Code asserted in wdog!\n");
+		lldbg_noarg("===========================================================\n");
+		lldbg_noarg("Asserted wdog details\n");
+		lldbg_noarg("===========================================================\n");
+		wd_corruption_dbg(g_wdog_debug);
 	}
 }
 

--- a/os/kernel/wdog/wd_start.c
+++ b/os/kernel/wdog/wd_start.c
@@ -107,7 +107,9 @@ typedef void (*wdentry4_t)(int argc, uint32_t arg1, uint32_t arg2, uint32_t arg3
 /****************************************************************************
  * Private Variables
  ****************************************************************************/
-
+#ifdef CONFIG_DEBUG
+struct wdog_s *g_wdog_debug;
+#endif
 /****************************************************************************
  * Private Functions
  ****************************************************************************/
@@ -143,6 +145,13 @@ static inline void wd_expiration(void)
 			/* Remove the watchdog from the head of the list */
 
 			wdog = (FAR struct wdog_s *)sq_remfirst(&g_wdactivelist);
+
+#ifdef CONFIG_DEBUG
+			/* Save the executing wdog for debugging purposes if wdog is corrupted,
+			 * or if wdog->func excuting has abort.
+			 */
+			g_wdog_debug = wdog;
+#endif
 
 			/* If there is another watchdog behind this one, update its
 			 * its lag (this shouldn't be necessary).
@@ -190,6 +199,11 @@ static inline void wd_expiration(void)
 				break;
 #endif
 			}
+
+#ifdef CONFIG_DEBUG
+			g_wdog_debug = NULL;
+#endif
+
 		}
 	}
 }


### PR DESCRIPTION
If wdog is corrupted or if prefetch abort is occuring in wdog callback, current assertion log is not enough for debugging.

Therefore, during the executing wdog expireation, we save the executing wdog address, and printing wdog information during the assert log printing.