### PR TITLE
os/mm, os/arch: Update reboot reason before printing logs

### DIFF
--- a/os/arch/arm/src/armv7-a/arm_dataabort.c
+++ b/os/arch/arm/src/armv7-a/arm_dataabort.c
@@ -206,14 +206,14 @@ SRAMDRAM_ONLY_TEXT_SECTION uint32_t *arm_dataabort(uint32_t *regs, uint32_t dfar
 	uint32_t *saved_state = (uint32_t *)CURRENT_REGS;
 	CURRENT_REGS = regs;
 	system_exception_location = regs[REG_R15];
+#ifdef CONFIG_SYSTEM_REBOOT_REASON
+	up_reboot_reason_write(REBOOT_SYSTEM_DATAABORT);
+#endif
+
 	/* Crash -- possibly showing diagnostic debug information. */
 	if (!IS_SECURE_STATE()) {
 		print_dataabort_detail(regs, dfar, dfsr);
 	}
-
-#ifdef CONFIG_SYSTEM_REBOOT_REASON
-	up_reboot_reason_write(REBOOT_SYSTEM_DATAABORT);
-#endif
 
 	PANIC();
 	regs = (uint32_t *)CURRENT_REGS;

--- a/os/arch/arm/src/armv7-a/arm_prefetchabort.c
+++ b/os/arch/arm/src/armv7-a/arm_prefetchabort.c
@@ -153,13 +153,13 @@ uint32_t *arm_prefetchabort(uint32_t *regs, uint32_t ifar, uint32_t ifsr)
 
 		CURRENT_REGS = savestate;
 	} else {
-		if (!IS_SECURE_STATE()) {
-			print_prefetchabort_detail(regs, ifar, ifsr);
-		}
-
 #ifdef CONFIG_SYSTEM_REBOOT_REASON
 		up_reboot_reason_write(REBOOT_SYSTEM_PREFETCHABORT);
 #endif
+
+		if (!IS_SECURE_STATE()) {
+			print_prefetchabort_detail(regs, ifar, ifsr);
+		}
 
 		PANIC();
 	}
@@ -179,15 +179,15 @@ uint32_t *arm_prefetchabort(uint32_t *regs, uint32_t ifar, uint32_t ifsr)
 
 	system_exception_location = regs[REG_R15];
 
+#ifdef CONFIG_SYSTEM_REBOOT_REASON
+	up_reboot_reason_write(REBOOT_SYSTEM_PREFETCHABORT);
+#endif
+
 	/* Crash -- possibly showing diagnostic debug information. */
 
 	if (!IS_SECURE_STATE()) {
 		print_prefetchabort_detail(regs, ifar, ifsr);
 	}
-
-#ifdef CONFIG_SYSTEM_REBOOT_REASON
-	up_reboot_reason_write(REBOOT_SYSTEM_PREFETCHABORT);
-#endif
 
 	PANIC();
 	regs = (uint32_t *)CURRENT_REGS;

--- a/os/arch/arm/src/armv7-a/arm_undefinedinsn.c
+++ b/os/arch/arm/src/armv7-a/arm_undefinedinsn.c
@@ -69,13 +69,13 @@ extern uint32_t system_exception_location;
 
 uint32_t *arm_undefinedinsn(uint32_t *regs)
 {
+#ifdef CONFIG_SYSTEM_REBOOT_REASON
+	up_reboot_reason_write(REBOOT_SYSTEM_PREFETCHABORT);
+#endif
   _alert("Undefined instruction at 0x%x\n", regs[REG_PC]);
   uint32_t *saved_state = (uint32_t *)CURRENT_REGS;
   CURRENT_REGS = regs;
 
-#ifdef CONFIG_SYSTEM_REBOOT_REASON
-	up_reboot_reason_write(REBOOT_SYSTEM_PREFETCHABORT);
-#endif
   system_exception_location = regs[REG_R15];
   PANIC();
   regs = (uint32_t *)CURRENT_REGS;

--- a/os/mm/mm_heap/mm_manage_allocfail.c
+++ b/os/mm/mm_heap/mm_manage_allocfail.c
@@ -103,6 +103,12 @@ void mm_manage_alloc_fail(struct mm_heap_s *heap, int startidx, int endidx, size
 	abort_mode = true;
 #endif
 
+#ifdef CONFIG_MM_ASSERT_ON_FAIL
+#ifdef CONFIG_SYSTEM_REBOOT_REASON
+	WRITE_REBOOT_REASON(REBOOT_SYSTEM_MEMORYALLOCFAIL);
+#endif
+#endif /* CONFIG_MM_ASSERT_ON_FAIL */
+
 #ifdef CONFIG_MEM_LEAK_CHECKER
 	extern int mem_leak_checker_internal(int argc, char **argv);
 	/* run mem leak checker prior to calling PANIC */
@@ -142,13 +148,6 @@ void mm_manage_alloc_fail(struct mm_heap_s *heap, int startidx, int endidx, size
 		mfdbg(" - largest free size : %d\n", info.mxordblk);
 	}
 	mfdbg(" - total free size   : %d\n", info.fordblks);
-
-#ifdef CONFIG_MM_ASSERT_ON_FAIL
-#ifdef CONFIG_SYSTEM_REBOOT_REASON
-	WRITE_REBOOT_REASON(REBOOT_SYSTEM_MEMORYALLOCFAIL);
-#endif
-
-#endif /* CONFIG_MM_ASSERT_ON_FAIL */
 
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
 	for (int idx = startidx; idx <= endidx; idx++) {


### PR DESCRIPTION
When assert or fault happens due to abort or mem alloc failure, we need to update the reboot reason immediately and then start printing the detailed logs. When we update reboot reason, the KM4 core will avoid printing its own logs, which might otherwise result in log mixup while printing important information about assert situation.