### PR TITLE
arch/armv7-a: fix assert in up_cpu_resume() with common pause API

### DIFF
--- a/os/arch/arm/src/armv7-a/arm_schedulesigaction.c
+++ b/os/arch/arm/src/armv7-a/arm_schedulesigaction.c
@@ -363,7 +363,9 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 
 				/* RESUME the other CPUs if they were PAUSED */
 
-				up_cpu_resume_all();
+				if (cpu != me) {
+					up_cpu_resume_all();
+				}
 			}
 		}
 


### PR DESCRIPTION
This patch fix the assert issue happened on product with commit ("os/arch/armv7-a: add api to pause and resume all CPUs") If signaling task is scheduled on the current CPU, then we don't need to resume the other CPUS as we don't pause them before.

This patch is tested on both public and ecode. We are not able to reproduce the reported assert with the patch.