### PR TITLE
os/kernel: Support silent reboot

### DIFF
--- a/os/drivers/Makefile
+++ b/os/drivers/Makefile
@@ -96,6 +96,7 @@ include power$(DELIM)Make.defs
 include seclink$(DELIM)Make.defs
 include sensors$(DELIM)Make.defs
 include serial$(DELIM)Make.defs
+include silent_reboot$(DELIM)Make.defs
 include spi$(DELIM)Make.defs
 include syslog$(DELIM)Make.defs
 include task_manager$(DELIM)Make.defs

--- a/os/drivers/silent_reboot/Make.defs
+++ b/os/drivers/silent_reboot/Make.defs
@@ -1,0 +1,25 @@
+##########################################################################
+#
+# Copyright 2024 Samsung Electronics All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+#
+##########################################################################
+# Include silent_reboot drivers
+
+CSRCS += silent_reboot_driver.c
+
+# Include silent_reboot driver support
+
+DEPPATH += --dep-path silent_reboot
+VPATH += :silent_reboot

--- a/os/drivers/silent_reboot/silent_reboot_driver.c
+++ b/os/drivers/silent_reboot/silent_reboot_driver.c
@@ -1,0 +1,124 @@
+/****************************************************************************
+ *
+ * Copyright 2024 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+#include <tinyara/config.h>
+
+#include <debug.h>
+#include <errno.h>
+#include <time.h>
+
+#include <sys/types.h>
+#include <tinyara/fs/fs.h>
+#include <tinyara/fs/ioctl.h>
+#include <tinyara/silent_reboot.h>
+
+/****************************************************************************
+ * Private Function Prototypes
+ ****************************************************************************/
+static int silent_reboot_ioctl(FAR struct file *filep, int cmd, unsigned long arg);
+static ssize_t silent_reboot_read(FAR struct file *filep, FAR char *buffer, size_t len);
+static ssize_t silent_reboot_write(FAR struct file *filep, FAR const char *buffer, size_t len);
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+static const struct file_operations silent_reboot_fops = {
+	0,                          /* open */
+	0,                          /* close */
+	silent_reboot_read,         /* read */
+	silent_reboot_write,        /* write */
+	0,                          /* seek */
+	silent_reboot_ioctl         /* ioctl */
+#ifndef CONFIG_DISABLE_POLL
+	, 0                         /* poll */
+#endif
+};
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+static ssize_t silent_reboot_read(FAR struct file *filep, FAR char *buffer, size_t len)
+{
+	return 0;
+}
+
+static ssize_t silent_reboot_write(FAR struct file *filep, FAR const char *buffer, size_t len)
+{
+	return 0;
+}
+
+/************************************************************************************
+ * Name: silent_reboot_ioctl
+ *
+ * Description: The ioctl method for silent reboot.
+ *
+ ************************************************************************************/
+static int silent_reboot_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
+{
+	int ret;
+	int ticks;
+	pid_t *result_addr;
+
+	ret = -EINVAL;
+
+	/* Handle built-in ioctl commands */
+
+	switch (cmd) {
+	case SILENTRBIOC_LOCK:
+		ret = silent_reboot_lock();
+		break;
+	case SILENTRBIOC_UNLOCK:
+		ret = silent_reboot_unlock();
+		break;
+	case SILENTRBIOC_DELAY:
+		ret = silent_reboot_delay((int)arg);
+		break;
+	case SILENTRBIOC_CHECKMODE:
+		ret = silent_reboot_is_silent_mode((bool *)arg);
+		break;
+	case SILENTRBIOC_GETSTATUS:
+		ret = silent_reboot_get_status((silent_reboot_status_t *)arg);
+		break;
+	case SILENTRBIOC_FORCE_REBOOT:
+		ret = silent_reboot_force_perform_after_timeout((int)arg);
+		break;
+	default:
+		dbg("Invalid cmd %d\n", cmd);
+		break;
+	}
+	return ret;
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+/****************************************************************************
+ * Name: silent_reboot_driver_register
+ *
+ * Description:
+ *   Register a driver path, SILENT_REBOOT_DRVPATH
+ *
+ ****************************************************************************/
+
+void silent_reboot_driver_register(void)
+{
+	/* Register silent_reboot driver path, SILENT_REBOOT_DRVPATH. */
+	(void)register_driver(SILENT_REBOOT_DRVPATH, &silent_reboot_fops, 0666, NULL);
+}

--- a/os/include/tinyara/fs/ioctl.h
+++ b/os/include/tinyara/fs/ioctl.h
@@ -106,7 +106,8 @@
 #define _PMBASE         (0x2b00)    	/* pm ioctl commands */
 #define _TESTIOCBASE    (0xfe00)	/* KERNEL TEST DRV module ioctl commands */
 #define _MIPIDSIBASE    (0x3900) 	/* Mipidsi device ioctl commands */
-
+#define _CSIIOCBASE     (0x3a00) 	/* Wifi CSI ioctl commands */
+#define _SILENTRBCBASE  (0x3b00) 	/* Silent reboot ioctl commands */
 
 
 /* boardctl() commands share the same number space */
@@ -333,6 +334,25 @@
 
 #define _QEIOCVALID(c)    (_IOC_TYPE(c) == _QEIOCBASE)
 #define _QEIOC(nr)        _IOC(_QEIOCBASE, nr)
+
+/* Wifi CSI driver ioctl definitions *************************************/
+/* (see tinyara/wifi_csi/wifi_csi.h) */
+
+#define _CSIIOCVALID(c) (_IOC_TYPE(c) == _CSIIOCBASE)
+#define _CSIIOC(nr)     _IOC(_CSIIOCBASE, nr)
+
+/* Silent reboot driver ioctl definitions *************************************/
+/* (see tinyara/silent_reboot.h) */
+
+#define _SILENTRBIOCVALID(c)       (_IOC_TYPE(c) == _SILENTRBCBASE)
+#define _SILENTRBIOC(nr)           _IOC(_SILENTRBCBASE, nr)
+
+#define SILENTRBIOC_LOCK           _SILENTRBIOC(0x0001)
+#define SILENTRBIOC_UNLOCK         _SILENTRBIOC(0x0002)
+#define SILENTRBIOC_DELAY          _SILENTRBIOC(0x0003)
+#define SILENTRBIOC_CHECKMODE      _SILENTRBIOC(0x0004)
+#define SILENTRBIOC_GETSTATUS      _SILENTRBIOC(0x0005)
+#define SILENTRBIOC_FORCE_REBOOT   _SILENTRBIOC(0x0006)
 
 /* Audio driver ioctl definitions *************************************/
 /* (see tinyara/audio/audio.h) */

--- a/os/include/tinyara/reboot_reason.h
+++ b/os/include/tinyara/reboot_reason.h
@@ -40,7 +40,8 @@ typedef enum {
 	REBOOT_SYSTEM_USER_INTENDED        = 56, /* Reboot from user intention */
 	REBOOT_SYSTEM_BINARY_UPDATE        = 57, /* Reboot for Binary Update */
 	REBOOT_SYSTEM_BINARY_RECOVERYFAIL  = 58, /* Binary Recovery Fail */
-	REBOOT_SYSTEM_ASSERT               = 59, /* Reboot from ASSERT or PANIC */
+	REBOOT_SYSTEM_PERIODIC_REBOOT      = 59, /* Periodic reboot */
+	REBOOT_SYSTEM_ASSERT               = 60, /* Reboot from ASSERT or PANIC */
 
 	REBOOT_NETWORK_WIFICORE_WATCHDOG   = 80, /* Wi-Fi Core Watchdog Reset */
 	REBOOT_NETWORK_WIFICORE_PANIC      = 81, /* Wi-Fi Core Panic */

--- a/os/include/tinyara/silent_reboot.h
+++ b/os/include/tinyara/silent_reboot.h
@@ -1,0 +1,70 @@
+/****************************************************************************
+ *
+ * Copyright 2024 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __INCLUDE_TINYARA_SILENT_REBOOT_H
+#define __INCLUDE_TINYARA_SILENT_REBOOT_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+#include <tinyara/config.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+#define SILENT_REBOOT_DRVPATH     "/dev/silent_reboot"
+
+typedef struct silent_reboot_status_s {
+    int lock_count;
+    int reboot_timezone_left;
+    int reboot_delay_left;
+} silent_reboot_status_t;
+
+void silent_reboot_driver_register(void);
+
+#ifdef CONFIG_SILENT_REBOOT
+int silent_reboot_lock(void);
+int silent_reboot_unlock(void);
+int silent_reboot_delay(int timeout);
+int silent_reboot_force_perform_after_timeout(int timeout);
+int silent_reboot_is_silent_mode(bool *is_silent_mode);
+int silent_reboot_get_status(silent_reboot_status_t *status);
+void silent_reboot_initialize(void);
+#else
+#define silent_reboot_lock()   (0)
+#define silent_reboot_unlock() (0)
+#define silent_reboot_delay(timeout) (0)
+#define silent_reboot_force_perform_after_timeout(timeout) (0)
+#define silent_reboot_is_silent_mode(is_silent_mode) (0)
+#define silent_reboot_get_status(status) (0)
+#define silent_reboot_initialize()
+#endif
+
+#ifdef __cplusplus
+#define EXTERN extern "C"
+extern "C" {
+#else
+#define EXTERN extern
+#endif
+
+#undef EXTERN
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __INCLUDE_TINYARA_SILENT_REBOOT_H */

--- a/os/kernel/Kconfig
+++ b/os/kernel/Kconfig
@@ -1137,3 +1137,11 @@ config LOG_DUMP_HANG_CHECK_SEC
 	an assert occurs due to a device hang.
 endif # LOG_DUMP_DEBUG_DETECT_HANG
 endif # LOG_DUMP
+
+config SILENT_REBOOT
+	bool "Enable Silent Reboot"
+	default y
+	depends on SYSTEM_REBOOT_REASON
+	depends on BOARDCTL_RESET
+	---help---
+		Enables Silent Reboot.

--- a/os/kernel/Makefile
+++ b/os/kernel/Makefile
@@ -79,6 +79,7 @@ include debug/Make.defs
 include preference/Make.defs
 include task_monitor/Make.defs
 include log_dump/Make.defs
+include silent_reboot/Make.defs
 
 AOBJS = $(ASRCS:.S=$(OBJEXT))
 COBJS = $(CSRCS:.c=$(OBJEXT))

--- a/os/kernel/init/os_bringup.c
+++ b/os/kernel/init/os_bringup.c
@@ -113,6 +113,9 @@
 #ifdef CONFIG_SECURITY_LEVEL
 #include <tinyara/security_level.h>
 #endif
+#ifdef CONFIG_SILENT_REBOOT
+#include <tinyara/silent_reboot.h>
+#endif
 
 /****************************************************************************
  * Pre-processor Definitions
@@ -263,6 +266,11 @@ static inline void os_workqueues(void)
 static inline void os_do_appstart(void)
 {
 	int pid;
+
+#ifdef CONFIG_SILENT_REBOOT
+	silent_reboot_initialize();
+#endif
+	silent_reboot_driver_register();
 
 #ifdef CONFIG_BOARD_INITIALIZE
 	/* Perform any last-minute, board-specific initialization, if so

--- a/os/kernel/silent_reboot/Make.defs
+++ b/os/kernel/silent_reboot/Make.defs
@@ -1,0 +1,27 @@
+###########################################################################
+#
+# Copyright 2024 Samsung Electronics All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+#
+###########################################################################
+
+ifeq ($(CONFIG_SILENT_REBOOT),y)
+
+CSRCS += silent_reboot.c
+
+# Include silent_reboot build support
+
+DEPPATH += --dep-path silent_reboot
+VPATH += :silent_reboot
+endif

--- a/os/kernel/silent_reboot/silent_reboot.c
+++ b/os/kernel/silent_reboot/silent_reboot.c
@@ -1,0 +1,416 @@
+/****************************************************************************
+ *
+ * Copyright 2024 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+/************************************************************************
+ * Included Files
+ ************************************************************************/
+
+#include <tinyara/config.h>
+#include <sys/boardctl.h>
+#include <tinyara/reboot_reason.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdbool.h>
+#include <time.h>
+#include <tinyara/clock.h>
+#include <tinyara/wdog.h>
+
+#include <tinyara/silent_reboot.h>
+
+/************************************************************************
+ * Definitions
+ ************************************************************************/
+#define REBOOT_TIME_START_SEC  0     // 0:00 AM
+#define REBOOT_TIME_END_SEC    300   // 5:00 AM
+#define DAYS_AFTER_BOOT        7     // days after reboot.
+#define A_DAY_TO_SEC           86400 // seconds for a day (24 hours * 60 * 60)
+#define SEVEN_DAYS_TO_SEC      604800 // seconds for 7 days (DAYS_AFTER_BOOT * A_DAY_TO_SEC)
+
+
+/************************************************************************
+ * Private Variables
+ ************************************************************************/
+static bool g_is_silent_mode;
+static bool g_is_silent_timezone;
+static int g_silent_lock_count;
+static WDOG_ID g_silent_wdog;
+static WDOG_ID g_silent_delaywdog;
+
+enum SILENT_TIMER_CMD {
+	SILENT_START = 0,
+	SILENT_RESTART = 1,
+	SILENT_END = 2,
+	SILENT_DELAY = 3,
+};
+
+/************************************************************************
+ * Private Function Prototypes
+ ************************************************************************/
+static int silent_reboot_set_timer(int timeout);
+
+/************************************************************************
+ * Private Functions
+ ************************************************************************/
+static void silent_reboot_perform(void)
+{
+	/* REBOOT with reboot reason, REBOOT_SYSTEM_PERIODIC_REBOOT.
+	 * Then board will silent reboot.
+	 */
+	lldbg("Perform SILENT REBOOT expired by periodic timer!!\n");
+	WRITE_REBOOT_REASON(REBOOT_SYSTEM_PERIODIC_REBOOT);
+	boardctl(BOARDIOC_RESET, EXIT_SUCCESS);
+}
+
+static void silent_reboot_set_mode(void)
+{
+	int reboot_reason = READ_REBOOT_REASON();
+
+	if (reboot_reason == REBOOT_SYSTEM_HW_RESET ||
+	reboot_reason == REBOOT_SYSTEM_USER_INTENDED ||
+	reboot_reason == REBOOT_CMNSERVICE_HASS ||
+	reboot_reason == REBOOT_CMNSERVICE_RM ||
+	reboot_reason == REBOOT_CMNSERVICE_FACTORYRESET) {
+		// Normal mode (non-silent mode)
+		g_is_silent_mode = false;
+		dbg("board boot with NORMAL MODE.\n");
+	} else {
+		// Silent mode
+		g_is_silent_mode = true;
+		dbg("board boot with SILENT MODE.\n");
+	}
+}
+
+static int get_random_number(int start, int end)
+{
+	srand(time(NULL));
+	return start + rand() % (end - start + 1);
+}
+
+static int silent_reboot_get_time(int cmd)
+{
+	int timeout_sec;
+	time_t curtime;
+	struct tm curtm;
+
+	timeout_sec = -1;
+
+	/* Get the current time */
+	curtime = time(&curtime);
+	if (curtime < 0) {
+		return ERROR;
+	}
+
+	(void)localtime_r(&curtime, &curtm);
+
+	if (cmd == SILENT_START) {
+		/* Intially 7 days */
+		timeout_sec = SEVEN_DAYS_TO_SEC;
+	} else if (cmd == SILENT_RESTART) {
+		/* Calculate the next 00:00 time */
+		timeout_sec = (A_DAY_TO_SEC - (curtm.tm_sec + curtm.tm_min * 60 + curtm.tm_hour * 3600));
+		/* Apply random time in (REBOOT_TIME_START_SEC, REBOOT_TIME_END_SEC)*/
+		timeout_sec += get_random_number(REBOOT_TIME_START_SEC, REBOOT_TIME_END_SEC);
+	} else if (cmd == SILENT_END) {
+		if (curtm.tm_hour < 5) {
+			/* Calculate the remaining time from now until 5:00 am */
+			timeout_sec = (5 * 60 * 60 - (curtm.tm_sec + curtm.tm_min * 60 + curtm.tm_hour * 3600));
+		}
+	}
+
+	if (timeout_sec < 0) {
+		dbg("Invalid timeout. cmd %d\n", cmd);
+		return ERROR;
+	}
+
+	return timeout_sec;
+}
+
+static void silent_reboot_enter_timezone(void)
+{
+	/* Set a flag allow reboot */
+	g_is_silent_timezone = true;
+
+	/* Time available for silent reboot started.
+	* If reboot is not performed in this function, it means the lock state (g_silent_lock_count > 0).
+	* Then, it will be checked again in unlock function.
+	*/
+	if (g_silent_lock_count <= 0) {
+		silent_reboot_perform();
+	}
+
+	/* Set timer for remaining time until the end time available for reboot */
+	silent_reboot_set_timer(SILENT_END);
+}
+
+static bool silent_reboot_is_timezone(void)
+{
+	time_t curtime;
+	struct tm curtm;
+
+	/* Get the current time */
+	curtime = time(&curtime);
+	if (curtime != ERROR) {
+		(void)localtime_r(&curtime, &curtm);
+		if (curtm.tm_hour < 5) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+static void silent_timer_callback(int argc, uint32_t cmd)
+{
+	switch (cmd) {
+		case SILENT_START:
+		case SILENT_RESTART:
+			/* Check whether current time is available for reboot because time can be changed after timer starts */
+			if (silent_reboot_is_timezone()) {
+				/* Do silent reboot if no lock. If not, set timer to end timezone */
+				silent_reboot_enter_timezone();
+			} else {
+				/* Set timer for remaining time until the next start time available for reboot */
+				silent_reboot_set_timer(SILENT_RESTART);
+			}
+			break;
+		case SILENT_END:
+			/* Set a flag prevent reboot */
+			g_is_silent_timezone = false;
+			/* Set timer for remaining time until the next start time available for reboot */
+			silent_reboot_set_timer(SILENT_RESTART);
+			break;
+		case SILENT_DELAY:
+			silent_reboot_unlock();
+			break;
+		default:
+			break;
+	}
+}
+
+static int silent_reboot_set_timer(int cmd)
+{
+	int ret;
+	int timeout;
+
+	/* Calculate time according to cmd */
+	timeout = silent_reboot_get_time(cmd);
+	if (timeout < 0) {
+		return ERROR;
+	}
+
+	ret = wd_start(g_silent_wdog, SEC2TICK(timeout), (wdentry_t)silent_timer_callback, 1, (uint32_t)cmd);
+	if (ret != OK) {
+		return ERROR;
+	}
+
+	return OK;
+}
+
+/************************************************************************
+ * Public Functions
+ ************************************************************************/
+/****************************************************************************
+ * Name: silent_reboot_lock
+ *
+ * Description:
+ *   Increase lock count.
+ *
+ ****************************************************************************/
+int silent_reboot_lock(void)
+{
+	g_silent_lock_count++;
+
+	dbg("silent reboot lock count = %d\n", g_silent_lock_count);
+
+	return OK;
+}
+
+/****************************************************************************
+ * Name: silent_reboot_unlock
+ *
+ * Description:
+ *   Decrease lock count and check whether it is possible to do silent reboot.
+ *
+ ****************************************************************************/
+int silent_reboot_unlock(void)
+{
+	g_silent_lock_count--;
+
+	/* Check timezone available for reboot */
+	if (g_is_silent_timezone) {
+		/* Check real time also because it can be changed after reboot timezone started */
+		if (silent_reboot_is_timezone()) {
+			if (g_silent_lock_count <= 0) {
+				silent_reboot_perform();
+			}	
+		} else {
+			/* Calibrate timer to set next silent reboot time */
+			g_is_silent_timezone = false;
+			silent_reboot_set_timer(SILENT_RESTART);
+		}
+	}
+
+	return OK;
+}
+
+/****************************************************************************
+ * Name: silent_reboot_delay
+ *
+ * Description:
+ *   Postpone silent reboot.
+ *   It gets lock and release lock after delay (seconds).
+ *
+ ****************************************************************************/
+int silent_reboot_delay(int delay)
+{
+	int ret;
+	int tick_remain;
+
+	if (delay <= 0) {
+		return ERROR;
+	}
+
+	if (g_silent_delaywdog == NULL) {
+		g_silent_delaywdog = wd_create();
+		if (!g_silent_delaywdog) {
+			dbg("Failed to set timer to unlock\n");
+			return ERROR;
+		}
+	}
+
+	tick_remain = wd_gettime(g_silent_delaywdog);
+	if (SEC2TICK(delay) <= tick_remain) {
+		dbg("Already reboot delayed for %d seconds\n", TICK2SEC(tick_remain));
+		return OK;
+	} 
+
+	if (tick_remain == 0) {
+		/* If delay watchdog is stopped, lock first*/
+		g_silent_lock_count++;
+	}
+
+	dbg("Watchdog Start for unlock: timeout %ds\n", delay);
+
+	/* Unlock by timer callback */
+	ret = wd_start(g_silent_delaywdog, SEC2TICK(delay), (wdentry_t)silent_timer_callback, 1, SILENT_DELAY);
+	if (ret != OK) {
+		dbg("Failed to start watchdog %d\n", get_errno());
+		return ERROR;
+	}
+
+	return OK;
+}
+
+/****************************************************************************
+ * Name: silent_reboot_force_perform_after_timeout
+ *
+ * Description:
+ *   Perform silent reboot after timeout(seconds).
+ *   It performs silent reboot forcedly if there is no lock in timezone available for reboot.
+ *
+ ****************************************************************************/
+int silent_reboot_force_perform_after_timeout(int timeout)
+{
+	int ret;
+	int tick_remain;
+	WDOG_ID wdog;
+
+	tick_remain = wd_gettime(g_silent_wdog);
+	if (SEC2TICK(timeout) > tick_remain) {
+		dbg("Timeout %d is smaller than remaining time of periodic reboot (%d s)\n", timeout, TICK2SEC(tick_remain));
+		return OK;
+	}
+
+	dbg("Reboot watchdog will be expired after %d seconds\n", timeout);
+
+	ret = wd_start(g_silent_wdog, SEC2TICK(timeout), (wdentry_t)silent_timer_callback, 1, SILENT_RESTART);
+	if (ret != OK) {
+		dbg("Failed to start watchdog %d\n", get_errno());
+		return ERROR;
+	}
+
+	return OK;
+}
+
+/****************************************************************************
+ * Name: silent_reboot_is_silent_mode
+ *
+ * Description:
+ *   Check whether silent mode or not.
+ *
+ ****************************************************************************/
+int silent_reboot_is_silent_mode(bool *is_silent_mode)
+{
+	*is_silent_mode = g_is_silent_mode;
+
+	return OK;
+}
+
+/****************************************************************************
+ * Name: silent_reboot_get_status
+ *
+ * Description:
+ *   Get status of silent reboot. It includes lock count, remaining time until next reboot and delay.
+ *
+ ****************************************************************************/
+int silent_reboot_get_status(silent_reboot_status_t *status)
+{
+	if (status == NULL) {
+		return ERROR;
+	}
+
+	status->lock_count = g_silent_lock_count;
+	if (g_is_silent_timezone) {
+		// Currently available for reboot
+		status->reboot_timezone_left = 0;
+	} else {
+		// Not available for reboot yet. Get remaining time until next available.
+		status->reboot_timezone_left = TICK2SEC(wd_gettime(g_silent_wdog));
+	}
+
+	status->reboot_delay_left = TICK2SEC(wd_gettime(g_silent_delaywdog));
+
+	return OK;
+}
+
+/****************************************************************************
+ * Name: silent_reboot_initialize
+ *
+ * Description:
+ *   Initialize silent reboot module. This function must be called once when system starts.
+ *
+ ****************************************************************************/
+void silent_reboot_initialize(void)
+{
+	g_silent_lock_count = 0;
+	g_is_silent_timezone = false;
+
+	/* Set silent mode by checking reboot reason. */
+	silent_reboot_set_mode();
+
+	/* Create timer to check the time zone available for silent reboot. */
+	g_silent_wdog = wd_create();
+	if (!g_silent_wdog) {
+		dbg("Failed to set timer periodic silent reboot\n");
+		return;
+	}
+
+	/* Create timer to check the time zone available for silent reboot. */
+	silent_reboot_set_timer(SILENT_START);
+}


### PR DESCRIPTION
- Support silent reboot driver for ioctl (lock, unlock, delay, checkmode)
- Set silent mode based on reboot reason
- Support periodic silent reboot when all the following conditions are satisfied.
  - Random time in (00:00 ~ 5:00 am) after 7 days from system boot.
  - No lock