### PR TITLE
os/drivers/input/touchscreen.c: Add IOCTL for enabling and disabling touch

### DIFF
--- a/apps/examples/touchscreen/touchscreen_main.c
+++ b/apps/examples/touchscreen/touchscreen_main.c
@@ -202,6 +202,42 @@ static int touchsceen_resume(void)
 	return OK;
 }
 
+static int touchscreen_enable(void)
+{
+	int ret = OK;
+	int fd = open(TOUCH_DEV_PATH, O_RDWR);
+	if (fd < 0) {
+		printf("Fail to open %s, errno:%d\n", TOUCH_DEV_PATH, get_errno());
+		return ERROR;
+	}
+
+	ret = ioctl(fd, TSIOC_ENABLE, NULL);
+	if (ret != OK) {
+		printf("Fail to TSIOC_ENABLE %s, errno:%d\n", TOUCH_DEV_PATH, get_errno());
+	}
+
+	close(fd);
+	return ret;
+}
+
+static int touchscreen_disable(void)
+{
+	int ret = OK;
+	int fd = open(TOUCH_DEV_PATH, O_RDWR);
+	if (fd < 0) {
+		printf("Fail to open %s, errno:%d\n", TOUCH_DEV_PATH, get_errno());
+		return ERROR;
+	}
+
+	ret = ioctl(fd, TSIOC_DISABLE, NULL);
+	if (ret != OK) {
+		printf("Fail to TSIOC_DISABLE %s, errno:%d\n", TOUCH_DEV_PATH, get_errno());
+	}
+
+	close(fd);
+	return ret;
+}
+
 static void show_usage(void)
 {
 	printf("usage: touchscreen <command #>\n");
@@ -211,6 +247,8 @@ static void show_usage(void)
 	printf("    stop    : Stop  the touchscreen basic test\n");
 	printf("    suspend : Test suspend touchscreen ic operation\n");
 	printf("    resume  : Test reusme touchscreen ic operation\n");
+	printf("    enable  : Enable touch functionality\n");
+	printf("    disable : Disable touch functionality\n");
 }
 
 /****************************************************************************
@@ -239,6 +277,10 @@ int touchscreen_main(int argc, char *argv[])
 			return touchsceen_suspend();
 		} else if (!strncmp(argv[1], "resume", 7)) {
 			return touchsceen_resume();
+		} else if (!strncmp(argv[1], "enable", 7)) {
+			return touchscreen_enable();
+		} else if (!strncmp(argv[1], "disable", 8)) {
+			return touchscreen_disable();
 		}
 	}
 

--- a/os/drivers/input/touchscreen.c
+++ b/os/drivers/input/touchscreen.c
@@ -318,6 +318,20 @@ static int touch_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
 				ret = -EINVAL;
 			}
 		break;
+		case TSIOC_ENABLE:
+			if (priv->ops && priv->ops->touch_enable) {
+				priv->ops->touch_enable(priv);
+			} else {
+				ret = -EINVAL;
+			}
+		break;
+		case TSIOC_DISABLE:
+			if (priv->ops && priv->ops->touch_disable) {
+				priv->ops->touch_disable(priv);
+			} else {
+				ret = -EINVAL;
+			}
+		break;
 		default: {
 			touchdbg("ERROR: ioctl not found, cmd: %d\n", cmd);
 		}

--- a/os/include/tinyara/input/touchscreen.h
+++ b/os/include/tinyara/input/touchscreen.h
@@ -88,6 +88,8 @@
 #define TSIOC_RESUME         _TSIOC(0x0006)  /* Resume touch interrupt */
 #define TSIOC_SETAPPNOTIFY   _TSIOC(0x0007)  /* arg: Pointer to struct touch_set_callback_s. Support available only when CONFIG_TOUCH_CALLBACK is enabled */
 #define TSIOC_CMD            _TSIOC(0x0008)  /* arg: Pointer to struct touchscreen_cmd_s */
+#define TSIOC_ENABLE         _TSIOC(0x0009)  /* Enable touch interrupt */
+#define TSIOC_DISABLE        _TSIOC(0x000A)  /* Disable touch interrupt */
 #define TSC_FIRST            0x0001          /* First common command */
 #define TSC_NCMDS            4               /* Four common commands */
 


### PR DESCRIPTION


Added two new IOCTL commands TSIOC_ENABLE and TSIOC_DISABLE to enable and disable the touch functionality in the touch driver.