### PR TITLE
os/drivers/input/ist415.c: Update ist415_disable_touch() and ist415_enable_touch() logic

### DIFF
--- a/os/drivers/input/ist415.c
+++ b/os/drivers/input/ist415.c
@@ -593,7 +593,10 @@ static void ist415_disable_touch(struct touchscreen_s *upper)
 {
 	struct ist415_dev_s *dev = upper->priv;
 	ist415vdbg("%s\n", __func__);
-	ist415_disable(upper->priv);
+	ist415_suspend_device(upper);
+	if (dev->knockknock) {
+		ist415_disable(upper->priv);
+	}
 }
 
 /****************************************************************************
@@ -604,7 +607,10 @@ static void ist415_enable_touch(struct touchscreen_s *upper)
 {
 	struct ist415_dev_s *dev = upper->priv;
 	ist415vdbg("%s\n", __func__);
-	ist415_enable(upper->priv);
+	ist415_resume_device(upper);
+	if (dev->knockknock) {
+		ist415_enable(upper->priv);
+	}
 }
 
 /****************************************************************************


### PR DESCRIPTION


- Modify `ist415_disable_touch()` to call `ist415_suspend_device()`, changing the power mode accordingly and disabled touch when knockknock is enabled to optimize power consumption.
- Modify `ist415_enable_touch()` to call `ist415_resume_device()`, restoring appropriate power mode and enable the touch when knockknock is enable.