### PR TITLE
os/mm: update crash logs of memory alloc failure

### DIFF
--- a/os/binfmt/binfmt_execmodule.c
+++ b/os/binfmt/binfmt_execmodule.c
@@ -330,9 +330,7 @@ int exec_module(FAR struct binary_s *binp)
 	BIN_ID(binary_idx) = pid;
 	BIN_STATE(binary_idx) = BINARY_LOADED;
 	BIN_LOADVER(binary_idx) = binp->bin_ver;
-#ifdef CONFIG_OPTIMIZE_APP_RELOAD_TIME
 	BIN_LOADINFO(binary_idx) = binp;
-#endif
 #endif
 
 #ifndef CONFIG_DISABLE_SIGNALS
@@ -365,9 +363,7 @@ errout_with_tcbinit:
 		BIN_ID(binary_idx) = -1;
 		BIN_STATE(binary_idx) = BINARY_INACTIVE;
 		BIN_LOADVER(binary_idx) = 0;
-#ifdef CONFIG_OPTIMIZE_APP_RELOAD_TIME
 		BIN_LOADINFO(binary_idx) = NULL;
-#endif
 		binary_manager_remove_binlist(&newtcb->cmn);
 #endif
 		sched_releasetcb(&newtcb->cmn, TCB_FLAG_TTYPE_TASK);

--- a/os/binfmt/binfmt_loadbinary.c
+++ b/os/binfmt/binfmt_loadbinary.c
@@ -199,9 +199,7 @@ int load_binary(int binary_idx, FAR const char *filename, load_attr_t *load_attr
 		/* Update binary table */
 		BIN_STATE(binary_idx) = BINARY_RUNNING;
 		BIN_LOADVER(binary_idx) = bin->bin_ver;
-#ifdef CONFIG_OPTIMIZE_APP_RELOAD_TIME
 		BIN_LOADINFO(binary_idx) = bin;
-#endif
 		return OK;
 	}
 	/* If we support common binary, then we need to place a pointer to the app's heap object

--- a/os/kernel/binary_manager/binary_manager.h
+++ b/os/kernel/binary_manager/binary_manager.h
@@ -152,9 +152,7 @@ struct binmgr_uinfo_s {
 	struct tcb_s *rt_list;
 	struct tcb_s *nrt_list;
 	sq_queue_t cb_list; // list node type : statecb_node_t
-#ifdef CONFIG_OPTIMIZE_APP_RELOAD_TIME
 	struct binary_s *binp;
-#endif
 };
 typedef struct binmgr_uinfo_s binmgr_uinfo_t;
 
@@ -239,9 +237,9 @@ binmgr_uinfo_t *binary_manager_get_udata(uint32_t bin_idx);
 #define BIN_OFFSET(bin_idx)                             binary_manager_get_udata(bin_idx)->load_attr.offset
 #define BIN_STACKSIZE(bin_idx)                          binary_manager_get_udata(bin_idx)->load_attr.stack_size
 #define BIN_PRIORITY(bin_idx)                           binary_manager_get_udata(bin_idx)->load_attr.priority
-#ifdef CONFIG_OPTIMIZE_APP_RELOAD_TIME
 #define BIN_LOADINFO(bin_idx)                           binary_manager_get_udata(bin_idx)->binp
-#endif
+#define BIN_BINARY_HEAP_PTR(bin_idx)                    binary_manager_get_udata(bin_idx)->binp->uheap
+
 
 /****************************************************************************
  * Function Prototypes

--- a/os/mm/Makefile
+++ b/os/mm/Makefile
@@ -65,6 +65,11 @@ else
 endif
 endif
 
+# include kernel header files to use kernel api during memory allocation failure
+ifeq ($(CONFIG_APP_BINARY_SEPARATION),y)
+CFLAGS += ${shell $(INCDIR) $(INCDIROPT) "$(CC)" "$(TOPDIR)$(DELIM)kernel"}
+endif
+
 # Sources and paths
 
 ASRCS  =


### PR DESCRIPTION
This commit adds code to update printing logs after memory allocation failure in user heap. Previously, It was only printing user heap summary and node info. But now it will also print logs for the summary of kernel heap information.

Below is the updated logs after user heap memory alloc error (memory overflow) :

```
TASH>>Hello, World!!
Inside thread2_task
Assigned 10Kb mm_manage_alloc_fail: Allocation failed from user heap.
mm_manage_alloc_fail:  - requested size 1024000
mm_manage_alloc_fail:  - caller address = 0x0e16ed59
mm_manage_alloc_fail:  - largest free size : 60960
mm_manage_alloc_fail:  - total free size   : 69248
mm_check_heap_corruption: Heap start = 0x63a81230 end = 0x63f7fff0
mm_check_heap_corruption: No heap corruption detected
****************************************************************
REGION #0 Start=0x0x63a81230, End=0x0x63f7fff0, Size=5238224
****************************************************************
  MemAddr |   Size   | Status |    Owner   |  Pid  |
----------|----------|--------|------------|-------|
0x63a81230 |       16 |   A    | 0x    dead |  17   |
0x63a81240 |     8208 |   A    | 0x e02af75 |  18(S)|
0x63a83250 |      992 |   A    | 0x e01b899 |  17   |
0x63a83630 |      272 |   A    | 0x e043051 |  17   |
0x63a83740 |      272 |   A    | 0x e043051 |  17   |
0x63a83850 |      272 |   A    | 0x e043051 |  17   |
0x63a83960 |       32 |   A    | 0x e187ae9 |  18   |
0x63a83980 |     2544 |   A    | 0x e17821f |  18   |
0x63a84370 |     3360 |   A    | 0x e17c491 |  18   |
0x63a85090 |      992 |   A    | 0x e01b899 |  18   |
0x63a85470 |      272 |   A    | 0x e043051 |  18   |
0x63a85580 |      272 |   A    | 0x e043051 |  18   |
0x63a85690 |      272 |   A    | 0x e043051 |  18   |
0x63a857a0 |     2064 |   A    | 0x e02af75 |  19(S)|
0x63a85fb0 |      992 |   A    | 0x e01b899 |  18   |
0x63a86390 |      272 |   A    | 0x e043051 |  18   |
0x63a864a0 |      272 |   A    | 0x e043051 |  18   |
0x63a865b0 |      272 |   A    | 0x e043051 |  18   |
0x63a866c0 |     4112 |   A    | 0x e02af75 |  20(S)|
0x63a876d0 |      272 |   A    | 0x e043051 |  18   |
0x63a877e0 |      144 |   A    | 0x e16a269 |  20   |
0x63a87870 |       80 |   F    |            |       |
0x63a878c0 |     1120 |   A    | 0x e16a17f |  18   |
0x63a87d20 |      992 |   A    | 0x e01b899 |  18   |
0x63a88100 |      272 |   A    | 0x e043051 |  18   |
0x63a88210 |      272 |   A    | 0x e043051 |  18   |
0x63a88320 |     4112 |   A    | 0x e02af75 |  21(S)|
0x63a89330 |      992 |   A    | 0x e01b899 |  18   |
0x63a89710 |      272 |   A    | 0x e043051 |  18   |
0x63a89820 |      272 |   A    | 0x e043051 |  18   |
0x63a89930 |      272 |   A    | 0x e043051 |  18   |
0x63a89a40 |     4112 |   A    | 0x e02af75 |  22(S)|
0x63a8aa50 |      992 |   A    | 0x e01b899 |  20   |
0x63a8ae30 |      272 |   A    | 0x e043051 |  20   |
0x63a8af40 |      272 |   A    | 0x e043051 |  20   |
0x63a8b050 |      272 |   A    | 0x e043051 |  20   |
0x63a8b160 |     8208 |   F    |            |       |
0x63a8d170 |     8208 |   A    | 0x e02af75 |  24(S)|
0x63a8f180 |  1024016 |   A    | 0x e16ed59 |  24   |
0x63b89190 |  1024016 |   A    | 0x e16ed59 |  24   |
0x63c831a0 |  1024016 |   A    | 0x e16ed59 |  24   |
0x63d7d1b0 |  1024016 |   A    | 0x e16ed59 |  24   |
0x63e771c0 |  1024016 |   A    | 0x e16ed59 |  24   |
0x63f711d0 |    60960 |   F    |            |       |
** PID(S) in Pid column means that mem is used for stack of PID


****************************************************************
     Summary of Heap Usages (Size in Bytes)
****************************************************************
Total                           : 5238224 (100%)
  - Allocated (Current / Peak)  : 5168976 (98%) / 5168976 (98%)
  - Free (Current)              : 69248 (1%)
  - Reserved                    : 32

****************************************************************
     Details of Heap Usages (Size in Bytes)
****************************************************************
< Free >
  - Number of Free Node               : 3
  - Largest Free Node Size            : 60960

< Allocation >
  - Current Size (Alive Allocation) = (1) + (2) + (3)
     . by Dead Threads (*) (1)        : 1824
     . by Alive Threads
        - Sum of "STACK"(**) (2)      : 30816
        - Sum of "CURR_HEAP" (3)      : 5136304
** NOTE **
(*)  Alive allocation by dead threads might be used by others or might be a leakage.
(**) Only Idle task has a separate stack region,
  rest are all allocated on the heap region.

< by Dead Threads >
 Pid | Size  | Name 
-----|-------|------
  17 |  1824 | bm_loader
mm_manage_alloc_fail:#####################################################################################

mm_manage_alloc_fail: *************************************************************************************
mm_manage_alloc_fail:                           Summary of Kernel heap memory usage                        
mm_manage_alloc_fail: *************************************************************************************

mm_check_heap_corruption: Heap start = 0x6011d500 end = 0x63a7fff0
mm_check_heap_corruption: No heap corruption detected

****************************************************************
     Summary of Heap Usages (Size in Bytes)
****************************************************************
Total                           : 60173056 (100%)
  - Allocated (Current / Peak)  : 2597072 (4%) / 10978208 (18%)
  - Free (Current)              : 57575984 (95%)
  - Reserved                    : 32

****************************************************************
     Details of Heap Usages (Size in Bytes)
****************************************************************
< Free >
  - Number of Free Node               : 4
  - Largest Free Node Size            : 57575504

< Allocation >
  - Current Size (Alive Allocation) = (1) + (2) + (3)
     . by Dead Threads (*) (1)        : 2459200
     . by Alive Threads
        - Sum of "STACK"(**) (2)      : 65728
        - Sum of "CURR_HEAP" (3)      : 72112
** NOTE **
(*)  Alive allocation by dead threads might be used by others or might be a leakage.
(**) Only Idle task has a separate stack region,
  rest are all allocated on the heap region.
mm_manage_alloc_fail:#####################################################################################


security level: 0
===========================================================
Assertion details
===========================================================
print_assert_detail: Assertion failed CPU1 at file: mm_heap/mm_manage_allocfail.c line 160 task: <pthread> pid: 24
print_assert_detail: Assert location (PC) : 0x0e027fe5
check_assert_location: Code asserted in normal thread!
===========================================================
Asserted task's stack details
===========================================================
check_sp_corruption: Current SP is User Thread SP: 63a8f018
check_sp_corruption: User stack:
print_stack_dump:   base: 63a8f180
print_stack_dump:   size: 00002000
print_stack_dump:   used: 0000088c
up_stackdump: 63a8f000: xxxxxxxx xxxxxxxx xxxxxxxx xxxxxxxx xxxxxxxx xxxxxxxx 0e09e080 000000a0
up_stackdump: 63a8f020: 6037d688 00000018 0e023979 0000006d 00000000 60103c48 60109bf0 60103c48
up_stackdump: 63a8f040: 60109bf0 63a80020 00000000 00001210 00000001 0000005f 00001210 0e027fe5
up_stackdump: 63a8f060: 00000000 004fedd0 00000003 0000ee20 004edf50 00010e80 00000000 63a8f124
up_stackdump: 63a8f080:

```