### PR TITLE
silent_reboot: Build and Register silent_reboot driver when CONFIG_SILENT_REBOOT is enabled only

### DIFF
--- a/os/drivers/silent_reboot/Make.defs
+++ b/os/drivers/silent_reboot/Make.defs
@@ -17,9 +17,12 @@
 ##########################################################################
 # Include silent_reboot drivers
 
+ifeq ($(CONFIG_SILENT_REBOOT),y)
+
 CSRCS += silent_reboot_driver.c
 
 # Include silent_reboot driver support
 
 DEPPATH += --dep-path silent_reboot
 VPATH += :silent_reboot
+endif

--- a/os/drivers/silent_reboot/silent_reboot_driver.c
+++ b/os/drivers/silent_reboot/silent_reboot_driver.c
@@ -73,8 +73,6 @@ static ssize_t silent_reboot_write(FAR struct file *filep, FAR const char *buffe
 static int silent_reboot_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
 {
 	int ret;
-	int ticks;
-	pid_t *result_addr;
 
 	ret = -EINVAL;
 

--- a/os/kernel/init/os_bringup.c
+++ b/os/kernel/init/os_bringup.c
@@ -269,8 +269,8 @@ static inline void os_do_appstart(void)
 
 #ifdef CONFIG_SILENT_REBOOT
 	silent_reboot_initialize();
-#endif
 	silent_reboot_driver_register();
+#endif
 
 #ifdef CONFIG_BOARD_INITIALIZE
 	/* Perform any last-minute, board-specific initialization, if so

--- a/os/kernel/silent_reboot/silent_reboot.c
+++ b/os/kernel/silent_reboot/silent_reboot.c
@@ -36,12 +36,11 @@
 /************************************************************************
  * Definitions
  ************************************************************************/
-#define REBOOT_TIME_START_SEC  0     // 0:00 AM
-#define REBOOT_TIME_END_SEC    300   // 5:00 AM
-#define DAYS_AFTER_BOOT        7     // days after reboot.
-#define A_DAY_TO_SEC           86400 // seconds for a day (24 hours * 60 * 60)
-#define SEVEN_DAYS_TO_SEC      604800 // seconds for 7 days (DAYS_AFTER_BOOT * A_DAY_TO_SEC)
-
+#define REBOOT_TIME_START_SEC  0	// 0:00 AM
+#define REBOOT_TIME_END_SEC    300	// 5:00 AM
+#define DAYS_AFTER_BOOT        7	// days after reboot.
+#define A_DAY_TO_SEC           86400	// seconds for a day (24 hours * 60 * 60)
+#define SEVEN_DAYS_TO_SEC      604800	// seconds for 7 days (DAYS_AFTER_BOOT * A_DAY_TO_SEC)
 
 /************************************************************************
  * Private Variables
@@ -121,7 +120,7 @@ static int silent_reboot_get_time(int cmd)
 	} else if (cmd == SILENT_RESTART) {
 		/* Calculate the next 00:00 time */
 		timeout_sec = (A_DAY_TO_SEC - (curtm.tm_sec + curtm.tm_min * 60 + curtm.tm_hour * 3600));
-		/* Apply random time in (REBOOT_TIME_START_SEC, REBOOT_TIME_END_SEC)*/
+		/* Apply random time in (REBOOT_TIME_START_SEC, REBOOT_TIME_END_SEC) */
 		timeout_sec += get_random_number(REBOOT_TIME_START_SEC, REBOOT_TIME_END_SEC);
 	} else if (cmd == SILENT_END) {
 		if (curtm.tm_hour < 5) {
@@ -144,9 +143,9 @@ static void silent_reboot_enter_timezone(void)
 	g_is_silent_timezone = true;
 
 	/* Time available for silent reboot started.
-	* If reboot is not performed in this function, it means the lock state (g_silent_lock_count > 0).
-	* Then, it will be checked again in unlock function.
-	*/
+	 * If reboot is not performed in this function, it means the lock state (g_silent_lock_count > 0).
+	 * Then, it will be checked again in unlock function.
+	 */
 	if (g_silent_lock_count <= 0) {
 		silent_reboot_perform();
 	}
@@ -175,28 +174,28 @@ static bool silent_reboot_is_timezone(void)
 static void silent_timer_callback(int argc, uint32_t cmd)
 {
 	switch (cmd) {
-		case SILENT_START:
-		case SILENT_RESTART:
-			/* Check whether current time is available for reboot because time can be changed after timer starts */
-			if (silent_reboot_is_timezone()) {
-				/* Do silent reboot if no lock. If not, set timer to end timezone */
-				silent_reboot_enter_timezone();
-			} else {
-				/* Set timer for remaining time until the next start time available for reboot */
-				silent_reboot_set_timer(SILENT_RESTART);
-			}
-			break;
-		case SILENT_END:
-			/* Set a flag prevent reboot */
-			g_is_silent_timezone = false;
+	case SILENT_START:
+	case SILENT_RESTART:
+		/* Check whether current time is available for reboot because time can be changed after timer starts */
+		if (silent_reboot_is_timezone()) {
+			/* Do silent reboot if no lock. If not, set timer to end timezone */
+			silent_reboot_enter_timezone();
+		} else {
 			/* Set timer for remaining time until the next start time available for reboot */
 			silent_reboot_set_timer(SILENT_RESTART);
-			break;
-		case SILENT_DELAY:
-			silent_reboot_unlock();
-			break;
-		default:
-			break;
+		}
+		break;
+	case SILENT_END:
+		/* Set a flag prevent reboot */
+		g_is_silent_timezone = false;
+		/* Set timer for remaining time until the next start time available for reboot */
+		silent_reboot_set_timer(SILENT_RESTART);
+		break;
+	case SILENT_DELAY:
+		silent_reboot_unlock();
+		break;
+	default:
+		break;
 	}
 }
 
@@ -255,7 +254,7 @@ int silent_reboot_unlock(void)
 		if (silent_reboot_is_timezone()) {
 			if (g_silent_lock_count <= 0) {
 				silent_reboot_perform();
-			}	
+			}
 		} else {
 			/* Calibrate timer to set next silent reboot time */
 			g_is_silent_timezone = false;
@@ -295,10 +294,10 @@ int silent_reboot_delay(int delay)
 	if (SEC2TICK(delay) <= tick_remain) {
 		dbg("Already reboot delayed for %d seconds\n", TICK2SEC(tick_remain));
 		return OK;
-	} 
+	}
 
 	if (tick_remain == 0) {
-		/* If delay watchdog is stopped, lock first*/
+		/* If delay watchdog is stopped, lock first */
 		g_silent_lock_count++;
 	}
 

--- a/os/kernel/silent_reboot/silent_reboot.c
+++ b/os/kernel/silent_reboot/silent_reboot.c
@@ -82,10 +82,7 @@ static void silent_reboot_set_mode(void)
 	int reboot_reason = READ_REBOOT_REASON();
 
 	if (reboot_reason == REBOOT_SYSTEM_HW_RESET ||
-	reboot_reason == REBOOT_SYSTEM_USER_INTENDED ||
-	reboot_reason == REBOOT_CMNSERVICE_HASS ||
-	reboot_reason == REBOOT_CMNSERVICE_RM ||
-	reboot_reason == REBOOT_CMNSERVICE_FACTORYRESET) {
+	reboot_reason == REBOOT_SYSTEM_USER_INTENDED) {
 		// Normal mode (non-silent mode)
 		g_is_silent_mode = false;
 		dbg("board boot with NORMAL MODE.\n");


### PR DESCRIPTION
Build and Register silent_reboot driver when CONFIG_SILENT_REBOOT is enabled only to reduce unnecessary memory usages.