### PR TITLE
apps/shell/tash_sleep.c: Add NULL check for args

### DIFF
--- a/apps/shell/tash_sleep.c
+++ b/apps/shell/tash_sleep.c
@@ -28,6 +28,11 @@ int tash_sleep(int argc, char **args)
 	char *endptr;
 	long secs;
 
+	if (argc != 2 || args[1] == NULL) {
+		shdbg("%s: argument invalid\n", args[0]);
+		return ERROR;
+	}
+
 	secs = strtol(args[1], &endptr, 0);
 	if (!secs || endptr == args[1] || *endptr != '\0') {
 		shdbg("%s: argument invalid\n", args[0]);

--- a/apps/shell/tash_usleep.c
+++ b/apps/shell/tash_usleep.c
@@ -32,6 +32,11 @@ int tash_usleep(int argc, char **args)
 	char *endptr;
 	long usecs;
 
+	if (argc != 2 || args[1] == NULL) {
+		shdbg("%s: argument invalid\n", args[0]);
+		return ERROR;
+	}
+
 	usecs = strtol(args[1], &endptr, 0);
 	if (!usecs || endptr == args[1] || *endptr != '\0') {
 		shdbg("%s: argument invalid\n", args[0]);


### PR DESCRIPTION
Issue: NULL Pointer dereference vulnerability can be occurred in tash_sleep / tash_usleep
Reference: https://github.com/Samsung/TizenRT/issues/6617
Solved: Add NULL pointer check for args[1]