### PR TITLE
os/arch/arm/src/amebasmart: remove sleep callback for mipi

### DIFF
--- a/os/arch/arm/src/amebasmart/amebasmart_mipi.c
+++ b/os/arch/arm/src/amebasmart/amebasmart_mipi.c
@@ -379,7 +379,6 @@ struct mipi_dsi_host *amebasmart_mipi_dsi_host_initialize(struct lcd_data *confi
 	mipi_dsi_host_register(&priv->dsi_host);
 #ifdef CONFIG_PM
 	bsp_pm_domain_register("MIPI", BSP_MIPI_DRV);
-	pmu_register_sleep_callback(PMU_MIPI_DEVICE, (PSM_HOOK_FUN)rtk_mipi_suspend, NULL, (PSM_HOOK_FUN)rtk_mipi_resume, NULL);
 #endif
 
 	return (struct mipi_dsi_host *)priv;


### PR DESCRIPTION
1. MIPI and LCDC resume flow is now handled in lcd power on and backlight on, and this will be controlled by the application layer, so remove duplicate resume flow in amebasmart_mipi_dsi_host_initialize.