### PR TITLE
kernel/sched: add missing condition for assigned list check in sched_…

### DIFF
--- a/os/kernel/sched/sched_removereadytorun.c
+++ b/os/kernel/sched/sched_removereadytorun.c
@@ -176,7 +176,7 @@ bool sched_removereadytorun(FAR struct tcb_s *rtcb)
 	 * occur.
 	 */
 
-	if (rtcb->blink == NULL) {
+	if (rtcb->blink == NULL && TLIST_ISRUNNABLE(rtcb->task_state)) {
 		FAR struct tcb_s *ntcb;
 		FAR struct tcb_s *rtrtcb = NULL;
 		int current_cpu;


### PR DESCRIPTION
…removereadytorun

add missing condition for assigned list check in sched_removereadytorun which was missed during porting.