### PR TITLE
os/board/rtl8730e: Only disable SWD when PA_14 is in use

### DIFF
--- a/os/board/rtl8730e/src/rtl8730e_mipi_lcdc.c
+++ b/os/board/rtl8730e/src/rtl8730e_mipi_lcdc.c
@@ -202,7 +202,9 @@ static void rtl8730e_lcd_put_area(u8 *lcd_img_buffer, u32 x_start, u32 y_start, 
 
 static void rtl8730e_gpio_init(void)
 {
+#if defined(CONFIG_LCD_ST7701)	/* It used PA_14 SWD_CLK as reset, SWD disable is needed */
 	Pinmux_Swdoff();
+#endif
 	Pinmux_Config(MIPI_GPIO_RESET_PIN, PINMUX_FUNCTION_GPIO);
 
 	GPIO_InitTypeDef ResetPin;

--- a/os/board/rtl8730e/src/rtl8730e_st7789.c
+++ b/os/board/rtl8730e/src/rtl8730e_st7789.c
@@ -90,7 +90,6 @@ static void gpio_pins_init(void)
 	GPIO_InitTypeDef ResetPin;
 	GPIO_InitTypeDef CmdPin;
 
-	Pinmux_Swdoff();
 	Pinmux_Config(GPIO_PIN_RESET, PINMUX_FUNCTION_GPIO);
 
 	ResetPin.GPIO_Pin = GPIO_PIN_RESET;


### PR DESCRIPTION
-Only disable SWD when PA_14 is in use
-Prevent all LCD model to disable SWD