### PR TITLE
os/arch/arm/src/armv7-a: Fix build warning

### DIFF
--- a/os/arch/arm/src/armv7-a/arm_cpuhotplug.c
+++ b/os/arch/arm/src/armv7-a/arm_cpuhotplug.c
@@ -95,10 +95,10 @@ int arm_hotplug_handler(int irq, void *context, void *arg)
 	CURRENT_REGS = NULL;
 
 	/* MINOR: PSCI is a general interface for controlling power of cortex-A cores 
-	It is one of the feature in arm-trusted-firmware (ie. Trustzone-A)
-	Currently, the definitions are provided by chip specific arch layer
-	/* If the cpu off operation failed, we should face a problem during wakeup
-	booting the secondary core, thus we can ignore the return value here first
+	   It is one of the feature in arm-trusted-firmware (ie. Trustzone-A)
+	   Currently, the definitions are provided by chip specific arch layer
+	   If the cpu off operation failed, we should face a problem during wakeup
+	   booting the secondary core, thus we can ignore the return value here first
 	*/
 	/* Shut down the secondary core */
    	(void)psci_cpu_off(); 


### PR DESCRIPTION
armv7-a/arm_cpuhotplug.c:100:2: warning: "/*" within comment [-Wcomment]
  100 |  /* If the cpu off operation failed, we should face a problem during wakeup
      |