### PR TITLE
os/board/rtl8721csm: Sync the BLE APIs table

### DIFF
--- a/os/board/rtl8721csm/src/component/os/tizenrt/rtk_blemgr.c
+++ b/os/board/rtl8721csm/src/component/os/tizenrt/rtk_blemgr.c
@@ -146,6 +146,7 @@ struct trble_ops g_trble_drv_ops = {
 	trble_netmgr_operation_write_no_response,
 
 	// Server
+	NULL,
 	trble_netmgr_get_profile_count,
 	trble_netmgr_charact_notify,
 	trble_netmgr_charact_indicate,


### PR DESCRIPTION
-Adding NULL to sync BLE APIs table
-To prevent APIs mismatch