### PR TITLE
os: remove CONFIG_ENABLE_STACKMONITOR dependency from kernel

### DIFF
--- a/os/include/tinyara/sched.h
+++ b/os/include/tinyara/sched.h
@@ -69,7 +69,7 @@
 #include <mqueue.h>
 #include <time.h>
 
-#if defined(CONFIG_ENABLE_STACKMONITOR) && defined(CONFIG_DEBUG)
+#ifdef CONFIG_DEBUG
 #include <tinyara/clock.h>
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
 #include <tinyara/mm/mm.h>

--- a/os/kernel/debug/Make.defs
+++ b/os/kernel/debug/Make.defs
@@ -29,7 +29,7 @@ ifeq ($(CONFIG_DEBUG_MM_WARN),y)
 CSRCS += memdbg.c
 endif
 
-ifeq ($(CONFIG_ENABLE_STACKMONITOR)$(CONFIG_DEBUG),yy)
+ifeq ($(CONFIG_DEBUG),y)
 CSRCS += stackinfo_save_terminated.c
 endif
 

--- a/os/kernel/debug/dbg_termination_info.c
+++ b/os/kernel/debug/dbg_termination_info.c
@@ -101,7 +101,7 @@
  ****************************************************************************/
 void dbg_save_termination_info(struct tcb_s *tcb)
 {
-#if defined(CONFIG_ENABLE_STACKMONITOR) && defined(CONFIG_DEBUG)
+#ifdef CONFIG_DEBUG
 	stackinfo_save_terminated(tcb);
 #endif
 

--- a/os/kernel/task/task_prctl.c
+++ b/os/kernel/task/task_prctl.c
@@ -249,7 +249,7 @@ int prctl(int option, ...)
 #endif /* CONFIG_MESSAGING_IPC */
 	case PR_GET_STKLOG:
 	{
-#if defined(CONFIG_ENABLE_STACKMONITOR) && defined(CONFIG_DEBUG)
+#ifdef CONFIG_DEBUG
 		struct stkmon_save_s *dest_buf = va_arg(ap, struct stkmon_save_s *);
 		stkmon_copy_log(dest_buf);
 #else


### PR DESCRIPTION
This patch removes CONFIG_ENABLE_STACKMONITOR dependency from kernel side. As the config is only present in application side. We shouldn't use it from Kernel.

Output:
 PID |   STATUS |     SIZE | PEAK_STACK |  PEAK_HEAP |    TIME | THREAD NAME
------|----------|----------|------------|------------|---------|------------
    4 | INACTIVE |     2024 |       1020 |      97392 |     251 | AppBringUp
    9 | INACTIVE |     5088 |        748 |      18032 |     303 | init
   14 | INACTIVE |     4072 |       1076 |     512416 |     361 | bm_loader
   15 | INACTIVE |     4072 |       1052 |     616064 |     418 | bm_loader
------|----------|----------|------------|------------|---------|------------
    0 |   ACTIVE |     1024 |        696 |         -1 |   25035 | CPU0 IDLE
    1 |   ACTIVE |     1024 |        656 |         -1 |   25035 | CPU1 IDLE
    2 |   ACTIVE |     2032 |        452 |          0 |   25036 | hpwork
    3 |   ACTIVE |     4080 |        452 |          0 |   25036 | lpwork
    5 |   ACTIVE |     2008 |        732 |        208 |   25037 | km4_log_task
    6 |   ACTIVE |     4048 |        444 |          0 |   25037 | inic_msg_q_task
    7 |   ACTIVE |     4048 |        500 |          0 |   25038 | inic_host_rx_tasklet
    8 |   ACTIVE |     8136 |        460 |          0 |   25039 | inic_ipc_api_host_task
   10 |   ACTIVE |     4072 |        508 |          0 |   25042 | LWIP_TCP/IP
   11 |   ACTIVE |     2016 |        388 |          0 |   25048 | netmgr_event_handler
   12 |   ACTIVE |    16360 |       6636 |     331808 |   25056 | log_dump
   13 |   ACTIVE |     8168 |        956 |       7488 |   25062 | binary_manager
   16 |   ACTIVE |     8168 |        844 |      17360 |   25069 | app1
   17 |   ACTIVE |     2032 |        472 |          0 |   25075 | uwork
   18 |   ACTIVE |     4080 |       1396 |       5232 |   25082 | tash
   19 |   ACTIVE |     4064 |        572 |          0 |   25088 | wifi msg handler
   20 |   ACTIVE |     4072 |        572 |          0 |   25095 | ble msg handler
   21 |   ACTIVE |     4096 |       1060 |      14352 |   25102 | StackMonitor