### PR TITLE
os/board/rtl8730e/src/compoent: add critical section to GPIO write bit

### DIFF
--- a/os/board/rtl8730e/src/component/soc/amebad2/fwlib/rom_common/ameba_gpio_rom.c
+++ b/os/board/rtl8730e/src/component/soc/amebad2/fwlib/rom_common/ameba_gpio_rom.c
@@ -369,6 +369,9 @@ void GPIO_WriteBit(u32 GPIO_Pin, u32 Pin_State)
 	u8 pin_num;
 	u32 RegValue;
 
+#ifdef CONFIG_PLATFORM_TIZENRT_OS
+	irqstate_t flags = enter_critical_section();
+#endif
 	port_num = PORT_NUM(GPIO_Pin);
 	pin_num = PIN_NUM(GPIO_Pin);
 	GPIO = GPIO_PORTx[port_num];
@@ -380,6 +383,9 @@ void GPIO_WriteBit(u32 GPIO_Pin, u32 Pin_State)
 		RegValue |= BIT(pin_num);
 	}
 	GPIO->PORT[0].GPIO_DR = RegValue;
+#ifdef CONFIG_PLATFORM_TIZENRT_OS
+	leave_critical_section(flags);
+#endif
 }
 
 /**


### PR DESCRIPTION
1. With SMP/AMP, there might be race condition when both Core 0 and Core 1 attempt to modify the GPIO simultaneously, causing the the value pin to be abnormal
2. enter_critical_section is required to ensure that only one core can modify the GPIO register at any given time, we can prevent simultaneous access to the GPIO data register, thus eliminating the race condition.