### PR TITLE
os/board/rtl8730e: Restructure BLE PM APIs and Print BLE status before entering sleep

### DIFF
--- a/os/arch/arm/src/amebasmart/amebasmart_pmhelpers.c
+++ b/os/arch/arm/src/amebasmart/amebasmart_pmhelpers.c
@@ -150,6 +150,16 @@ void bsp_pm_domain_control(int bsp_drv_id, bool is_suspend)
 	}
 }
 
+void bsp_pm_domain_timesuspend(int bsp_drv_id, unsigned int milliseconds)
+{
+	/* Retrive the domain id from the bsp driver id */
+	int domain_id = g_bsp_domain_id[bsp_drv_id];
+
+	if (pm_timedsuspend(domain_id, milliseconds) != 0) {
+		pmdbg("Unable to suspend bsp_drv_id: %d for %d ms\n", bsp_drv_id, milliseconds);
+	}
+}
+
 /* Interrupt callback from wifi-keepalive, which LP received designated packet*/
 void SOCPS_LPWAP_ipc_int(VOID *Data, u32 IrqStatus, u32 ChanNum)
 {

--- a/os/board/rtl8730e/src/component/bluetooth/api/rtk_bt_power_control.c
+++ b/os/board/rtl8730e/src/component/bluetooth/api/rtk_bt_power_control.c
@@ -44,6 +44,7 @@ static uint32_t rtk_bt_suspend(uint32_t expected_idle_time, void *param)
 	(void)param;
 
 	pmvdbg("[BT_PS] Enter rtk_bt_suspend\r\n");
+	rtw_ble_combo_print_ble_status();	/* Print current BLE status */
 
 #ifndef CONFIG_PLATFORM_TIZENRT_OS
 #if defined(CONFIG_BT_SINGLE_CORE) && CONFIG_BT_SINGLE_CORE
@@ -83,6 +84,8 @@ static uint32_t rtk_bt_wake_host_irq_handler(void *data)
 void rtk_bt_power_save_init(void)
 {
 #ifdef CONFIG_PM	/* If PM is enable inti BT power save */
+	bsp_pm_domain_register("BLE", BSP_BLE_DRV);
+
 	/* register callback before entering ps mode and after exiting ps mode */
 	pmu_register_sleep_callback(PMU_BT_DEVICE, (PSM_HOOK_FUN)rtk_bt_suspend, NULL, (PSM_HOOK_FUN)rtk_bt_resume, NULL);
 	InterruptRegister((IRQ_FUN)rtk_bt_wake_host_irq_handler, BT_WAKE_HOST_IRQ, (int)NULL, INT_PRI_LOWEST);

--- a/os/board/rtl8730e/src/component/bluetooth/example/ble_peripheral/ble_tizenrt_server.c
+++ b/os/board/rtl8730e/src/component/bluetooth/example/ble_peripheral/ble_tizenrt_server.c
@@ -723,6 +723,10 @@ trble_result_e rtw_ble_server_start_adv(void)
         return TRBLE_FAIL;
     }
 
+#ifdef CONFIG_AMEBASMART_BLE_SCATTERNET
+    rtw_ble_combo_add_advstatus(0, rtw_ble_server_adv_interval);
+#endif
+
 #if !defined (RTK_BLE_5_0_AE_ADV_SUPPORT) && RTK_BLE_5_0_AE_ADV_SUPPORT
     do
     {   
@@ -786,6 +790,10 @@ trble_result_e rtw_ble_server_create_multi_adv(uint8_t adv_event_prop, uint32_t 
 	adv_param.secondary_adv_phy        = 1;
 	adv_param.adv_sid                  = 0;
 	uint16_t ret = rtk_bt_le_gap_create_ext_adv(&adv_param, adv_handle);
+
+#ifdef CONFIG_AMEBASMART_BLE_SCATTERNET
+	rtw_ble_combo_add_advstatus(*adv_handle, primary_adv_interval[0]);
+#endif
 
 	if (RTK_BT_OK != ret) {
 		return TRBLE_FAIL;

--- a/os/board/rtl8730e/src/component/bluetooth/example/ble_scatternet/scatternet.c
+++ b/os/board/rtl8730e/src/component/bluetooth/example/ble_scatternet/scatternet.c
@@ -181,18 +181,20 @@ static rtk_bt_evt_cb_ret_t ble_tizenrt_scatternet_gap_app_callback(uint8_t evt_c
     switch (evt_code) {
     case RTK_BT_LE_GAP_EVT_ADV_START_IND: {
         rtk_bt_le_adv_start_ind_t *adv_start_ind = (rtk_bt_le_adv_start_ind_t *)param;
-        if(!adv_start_ind->err)
+        if(!adv_start_ind->err) {
             dbg("[APP] ADV started: adv_type %d  \r\n", adv_start_ind->adv_type);
-        else
+            rtw_ble_combo_update_advstatus(0, 1);	/* Update Adv status */
+        } else
             dbg("[APP] ADV start failed, err 0x%x \r\n", adv_start_ind->err);
         break;
     }
 
     case RTK_BT_LE_GAP_EVT_ADV_STOP_IND: {
         rtk_bt_le_adv_stop_ind_t *adv_stop_ind = (rtk_bt_le_adv_stop_ind_t *)param;
-        if(!adv_stop_ind->err)
+        if(!adv_stop_ind->err) {
             dbg("[APP] ADV stopped: reason 0x%x \r\n",adv_stop_ind->stop_reason);
-        else
+            rtw_ble_combo_update_advstatus(0, 0);	/* Update Adv status */
+        } else
             dbg("[APP] ADV stop failed, err 0x%x \r\n", adv_stop_ind->err);
         break;
     }
@@ -205,6 +207,7 @@ static rtk_bt_evt_cb_ret_t ble_tizenrt_scatternet_gap_app_callback(uint8_t evt_c
 				dbg("[APP] Ext ADV(%d) started\r\n", ext_adv_ind->adv_handle);
 			else
 				dbg("[APP] Ext ADV(%d) stopped: reason 0x%x \r\n", ext_adv_ind->adv_handle, ext_adv_ind->stop_reason);
+			rtw_ble_combo_update_advstatus(ext_adv_ind->adv_handle, ext_adv_ind->is_start);	/* Update Adv status */
 		} else {
 			if(ext_adv_ind->is_start)
 				dbg("[APP] Ext ADV(%d) started failed, err 0x%x\r\n", ext_adv_ind->adv_handle, ext_adv_ind->err);
@@ -348,6 +351,7 @@ static rtk_bt_evt_cb_ret_t ble_tizenrt_scatternet_gap_app_callback(uint8_t evt_c
 					ble_client_connect_is_running = 0;
 			} else if (RTK_BT_LE_ROLE_SLAVE == conn_ind->role) {
 				uint8_t adv_handle = 0xff;
+				rtw_ble_combo_update_connnectstatus(conn_ind->conn_handle, 1, conn_ind->conn_interval); /* Update connection information */
 				if (server_init_parm.connected_cb) {
 					uint8_t addr[TRBLE_BD_ADDR_MAX_LEN];
 					_reverse_mac(conn_ind->peer_addr.addr_val, addr);
@@ -396,6 +400,7 @@ static rtk_bt_evt_cb_ret_t ble_tizenrt_scatternet_gap_app_callback(uint8_t evt_c
         if (RTK_BT_LE_ROLE_MASTER == disconn_ind->role) {
             client_init_parm->trble_device_disconnected_cb(disconn_ind->conn_handle);
         } else if (RTK_BT_LE_ROLE_SLAVE == disconn_ind->role) {
+            rtw_ble_combo_update_connnectstatus(disconn_ind->conn_handle, 0, 0); /* Update connection information */
             if (server_init_parm.disconnected_cb) {
                 server_init_parm.disconnected_cb(disconn_ind->conn_handle, disconn_ind->reason);
             } else {
@@ -419,6 +424,7 @@ static rtk_bt_evt_cb_ret_t ble_tizenrt_scatternet_gap_app_callback(uint8_t evt_c
                         conn_update_ind->conn_latency, 
                         conn_update_ind->supv_timeout);
         }
+        rtw_ble_combo_update_connnectstatus(conn_update_ind->conn_handle, 1, conn_update_ind->conn_interval); /* Update connection information */
         break;
     }
 

--- a/os/board/rtl8730e/src/component/bluetooth/example/ble_scatternet/scatternet.c
+++ b/os/board/rtl8730e/src/component/bluetooth/example/ble_scatternet/scatternet.c
@@ -30,6 +30,7 @@
 #include <debug.h>
 #include <tinyara/config.h>
 #ifdef CONFIG_PM
+#include "ameba_soc.h"
 #include <tinyara/pm/pm.h>
 #endif
 
@@ -176,9 +177,7 @@ static rtk_bt_evt_cb_ret_t ble_tizenrt_scatternet_gap_app_callback(uint8_t evt_c
 {
     char le_addr[30] = {0};
     char *role;
-#ifdef CONFIG_PM
-    int domain;
-#endif
+
     switch (evt_code) {
     case RTK_BT_LE_GAP_EVT_ADV_START_IND: {
         rtk_bt_le_adv_start_ind_t *adv_start_ind = (rtk_bt_le_adv_start_ind_t *)param;
@@ -315,13 +314,8 @@ static rtk_bt_evt_cb_ret_t ble_tizenrt_scatternet_gap_app_callback(uint8_t evt_c
         rtk_bt_le_addr_to_str(&(conn_ind->peer_addr), le_addr, sizeof(le_addr));
         if (!conn_ind->err) {
 #ifdef CONFIG_PM
-            /* Register PM_BLE_DOMAIN and Perform 10 minutes timedsuspend */
-            domain = pm_domain_register("BLE");
-            if (domain < 0) {
-                pmdbg("Unable to register BLE DOMAIN\n");
-            } else if (pm_timedsuspend(domain, 600000) != 0) {
-                pmdbg("Unable to perform PM suspend for 10 minutes for ble domain\n");
-            }
+            /* Perform 10 minutes timedsuspend */
+            bsp_pm_domain_timesuspend(BSP_BLE_DRV, 600000);
 #endif
             role = conn_ind->role ? "slave" : "master";
             dbg("[APP] Connected, handle: %d, role: %s, remote device: %s\r\n", 

--- a/os/board/rtl8730e/src/component/os/tizenrt/rtk_ble_utils.h
+++ b/os/board/rtl8730e/src/component/os/tizenrt/rtk_ble_utils.h
@@ -20,14 +20,19 @@
 #include <tinyara/config.h>
 #include <tinyara/net/if/ble.h>
 
-#ifdef CONFIG_AMEBALITE_BLE_SCATTERNET
+#ifdef CONFIG_AMEBASMART_BLE_SCATTERNET
 extern trble_result_e rtw_ble_combo_init(trble_client_init_config* init_client, trble_server_init_config* init_server);
 extern trble_result_e rtw_ble_combo_deinit(void);
 extern trble_result_e rtw_ble_combo_set_server_config(trble_server_init_config* init_server);
-#elif defined(CONFIG_AMEBALITE_BLE_CENTRAL)
+extern void rtw_ble_combo_add_advstatus(uint8_t adv_handle, uint16_t adv_interval);
+extern void rtw_ble_combo_update_advstatus(uint8_t adv_handle, uint8_t adv_start);
+extern void rtw_ble_combo_update_connnectstatus(uint8_t conn_handle, uint8_t connected, uint16_t conn_interval);
+extern void rtw_ble_combo_print_ble_status(void);
+extern void rtw_ble_combo_clear_status(void);
+#elif defined(CONFIG_AMEBASMART_BLE_CENTRAL)
 extern trble_result_e rtw_ble_client_init(trble_client_init_config* init_parm);
 extern trble_result_e rtw_ble_client_deinit(void);
-#elif defined(CONFIG_AMEBALITE_BLE_PERIPHERAL)
+#elif defined(CONFIG_AMEBASMART_BLE_PERIPHERAL)
 extern trble_result_e rtw_ble_server_init(trble_server_init_config* init_parm);
 extern trble_result_e rtw_ble_server_deinit(void);
 #endif

--- a/os/board/rtl8730e/src/component/soc/amebad2/misc/ameba_tizenrt_pmu.h
+++ b/os/board/rtl8730e/src/component/soc/amebad2/misc/ameba_tizenrt_pmu.h
@@ -26,6 +26,7 @@ typedef enum {
 	BSP_FLASH_DRV           = 3,
 	BSP_UART_DRV            = 4,
 	BSP_MIPI_DRV            = 5,
+	BSP_BLE_DRV             = 6,
 	BSP_DOMAIN_MAX,
 } BSP_DRV_DOMAIN;
 


### PR DESCRIPTION
-Register BLE PM domain during issue
-Add PM time suspend API
-Store BLE adv and connection status (for server only)
-Print BLE adv and connection status before entering sleep