### PR TITLE
driver/input: Add ist415 tmode command

### DIFF
--- a/os/drivers/input/ist415.c
+++ b/os/drivers/input/ist415.c
@@ -414,6 +414,7 @@ static void ist415_cmd_show_usage(void)
 	printf("	dbg     : Log level, 1:ERROR, 2:WARNING, 3:INFO\n");
 	printf("	selftest: Run selftest\n");
 	printf("	version : Display Version\n");
+	printf("	tmode   : test mode, 0:OFF, 1:ON\n");
 }
 
 /****************************************************************************
@@ -451,6 +452,8 @@ static int ist415_cmd(struct touchscreen_s *upper, int argc, char **argv)
 		ret = ist415_jittertest(dev);
 	} else if (strncmp(argv[1], "version", 8) == 0) {
 		ist415_display_version(dev);
+	} else if (strncmp(argv[1], "tmode", 6) == 0) {
+		ret = ist415_tmode(dev, argc, argv);
 	} else {
 		ret = -EINVAL;
 	}

--- a/os/drivers/input/ist415_misc.c
+++ b/os/drivers/input/ist415_misc.c
@@ -1018,3 +1018,30 @@ void ist415_display_version(struct ist415_dev_s *dev)
 	ist415vdbg("Main Ver: %X, Test Ver: %X\n", dev->fw.cur.main_ver, dev->fw.cur.test_ver);
 	ist415vdbg("Core Ver: %X, Config Ver: %X, Release Ver: %X\n", dev->fw.cur.core_ver, dev->fw.cur.config_ver, dev->fw.cur.release_ver);
 }
+
+/****************************************************************************
+ * Name: ist415_tmode
+ *
+ * Description
+ *   This function is called by Uart Command.
+ ****************************************************************************/
+
+int ist415_tmode(struct ist415_dev_s *dev, int argc, char **argv)
+{
+	int enable;
+
+	if (argc < 3) {
+		return -EINVAL;
+	}
+	
+	enable = atoi(argv[2]);
+	if (enable == 0) {
+		ist415_enable(dev);
+	} else if (enable == 1) {
+		ist415_disable(dev);
+	} else {
+		return -EINVAL;
+	}
+
+	return OK;	
+}

--- a/os/drivers/input/ist415_misc.h
+++ b/os/drivers/input/ist415_misc.h
@@ -97,5 +97,6 @@ int ist415_jittertest(struct ist415_dev_s *dev);
 int ist415_rec_mode(struct ist415_dev_s *dev, int argc, char **argv);
 void ist415_recording(struct ist415_dev_s *dev);
 void ist415_display_version(struct ist415_dev_s *dev);
+int ist415_tmode(struct ist415_dev_s *dev, int argc, char **argv);
 
 #endif				/* __DRIVERS_INPUT_IST415_MISC_H */


### PR DESCRIPTION
- Add tmode command.
- tmode is a command that disables Alive and Interrupt to connect the Tool for CS noise testing.