### PR TITLE
os/board/rtl8730e/src: modify LCD power on/off flow

### DIFF
--- a/os/board/rtl8730e/src/rtl8730e_mipi_lcdc.c
+++ b/os/board/rtl8730e/src/rtl8730e_mipi_lcdc.c
@@ -140,7 +140,6 @@ static void rtl8730e_lcd_power_on(void)
 {
 	GPIO_WriteBit(MIPI_GPIO_RESET_PIN, PIN_HIGH);
 	DelayMs(120);
-	amebasmart_mipi_dsi_host_reinitialize();
 }
 static void rtl8730e_gpio_reset(void)
 {
@@ -225,8 +224,7 @@ static void rtl8730e_control_backlight(uint8_t level)
 	/* Re-initiate the LCD only when it is turned on from a powered-off state. */
 	if (g_rtl8730e_config_dev_s.pwm_level == 0 && level > 0) {
 		/* TO-DO: Move LCD IC Power ON flow */
-		rtl8730e_lcd_init();
-		rtl8730e_enable_lcdc();
+		InterruptEn(lcdc_irq_info.num, lcdc_irq_info.priority);
 	}
 #if defined(CONFIG_LCD_ST7785) || defined(CONFIG_LCD_ST7701SN)
 	pwmout_write(&g_rtl8730e_config_dev_s.pwm_led, 1.0-pwm_level);

--- a/os/drivers/lcd/mipi_lcd.c
+++ b/os/drivers/lcd/mipi_lcd.c
@@ -361,7 +361,9 @@ static int lcd_setpower(FAR struct lcd_dev_s *dev, int power)
 		if (priv->power == 0) {
 			priv->config->power_on();
 			/* We need to send init cmd after LCD IC power on */
+			priv->config->lcd_mode_switch(false);
 			send_init_cmd(priv, lcd_init_cmd_g);
+			priv->config->lcd_mode_switch(true);
 		}
 		priv->config->backlight(power);
 	}


### PR DESCRIPTION
1. There will be cases when LCD power off is called, but module do not enter PG. In this case, the lcdc and mipi drivers need not to re-initialize when LCD power on is called.
2. When LCD power on, we need to switch MIPI to cmd mode to send the lcd init cmd.
3. Fix UI coordinate offset shift gradually in lcd power on/off long run test