### PR TITLE
external/mbedtls/x509_create.c: Fix CVE-2024-23775

### DIFF
--- a/external/mbedtls/x509_create.c
+++ b/external/mbedtls/x509_create.c
@@ -221,12 +221,16 @@ int mbedtls_x509_set_extension(mbedtls_asn1_named_data **head, const char *oid, 
 {
     mbedtls_asn1_named_data *cur;
 
+    if (val_len > (SIZE_MAX  - 1)) {
+        return MBEDTLS_ERR_X509_BAD_INPUT_DATA;
+    }
+
     if ((cur = mbedtls_asn1_store_named_data(head, oid, oid_len,
                                              NULL, val_len + 1)) == NULL) {
         return MBEDTLS_ERR_X509_ALLOC_FAILED;
     }
 
-    cur->val.p[0] = critical == 0 ? 0 : 1;
+    cur->val.p[0] = critical;
     memcpy(cur->val.p + 1, val, val_len);
 
     return 0;


### PR DESCRIPTION
Issue: Integer Overflow vulnerability in Mbed TLS 2.x before 2.28.7 and 3.x before 3.5.2, allows attackers to cause a denial of service (DoS) via mbedtls_x509_set_extension(). (CVE-2024-23775)
Solve: Ensure that a length of SIZE_MAX cannot be passed into mbedtls_x509_set_extension()

https://mbed-tls.readthedocs.io/en/latest/security-advisories/mbedtls-security-advisory-2024-01-2/# 
https://github.com/Mbed-TLS/mbedtls/blob/v3.6.2/library/x509_create.c#L385