### PR TITLE
os/drivers/lcd: Use command mode to turn screen to black after power on

### DIFF
--- a/os/board/rtl8730e/src/rtl8730e_mipi_lcdc.c
+++ b/os/board/rtl8730e/src/rtl8730e_mipi_lcdc.c
@@ -56,7 +56,7 @@ static void rtl8730e_lcd_init(void);
 static void rtl8730e_gpio_reset(void);
 static void rtl8730e_lcd_power_off(void);
 static void rtl8730e_lcd_power_on(void);
-static void rtl8730e_lcd_mode_switch(bool flag);
+static void rtl8730e_mipi_mode_switch(mipi_mode_t mode);
 static void rtl8730e_lcd_layer_enable(int layer, bool enable);
 static void rtl8730e_lcd_put_area(u8 *lcd_img_buffer, u32 x_start, u32 y_start, u32 x_end, u32 y_end);
 static void rtl8730e_enable_lcdc(void);
@@ -72,7 +72,7 @@ struct rtl8730e_lcdc_info_s g_rtl8730e_config_dev_s = {
 	.lcd_config = {
 		.init = rtl8730e_lcd_init,
 		.reset = rtl8730e_gpio_reset,
-		.lcd_mode_switch = rtl8730e_lcd_mode_switch,
+		.mipi_mode_switch = rtl8730e_mipi_mode_switch,
 		.lcd_enable = rtl8730e_enable_lcdc,
 		.lcd_layer_enable = rtl8730e_lcd_layer_enable,
 		.lcd_put_area = rtl8730e_lcd_put_area,
@@ -152,9 +152,9 @@ static void rtl8730e_gpio_reset(void)
 	return;
 }
 
-static void rtl8730e_lcd_mode_switch(bool flag)
+static void rtl8730e_mipi_mode_switch(mipi_mode_t mode)
 {
-	if (flag == false) {
+	if (mode == CMD_MODE) {
 		mipidsi_mode_switch(false);
 		MIPI_DSI_INT_Config(MIPI, DISABLE, ENABLE, FALSE);
 		DelayMs(20);

--- a/os/include/tinyara/lcd/mipi_lcd.h
+++ b/os/include/tinyara/lcd/mipi_lcd.h
@@ -41,6 +41,13 @@
 #define INIT_CMD_SIZE 28
 #endif
 
+enum mipi_mode_e {
+        CMD_MODE = 0,
+        VIDEO_MODE = 1
+};
+
+typedef enum mipi_mode_e mipi_mode_t;
+
 typedef struct lcm_setting_table {
         u8 cmd;
         u16 count;
@@ -51,7 +58,7 @@ struct mipi_lcd_config_s {
 
 	void (*init)();
 	void (*reset)();
-	void (*lcd_mode_switch)(bool mode);			//false is command mode, true is video mode
+	void (*mipi_mode_switch)(mipi_mode_t mode);
 	void (*lcd_enable)();
 	void (*lcd_layer_enable)(int layer, bool enable);
 	void (*backlight)(u8 level);


### PR DESCRIPTION
Command mode keeps the LCD in black frame which is needed just after power on.
 APP will send its buffer after power on and then mipi mode will be changed to video