### PR TITLE
os/pm: Add sched_lock to avoid context switching during pm_idle

### DIFF
--- a/os/pm/pm_idle.c
+++ b/os/pm/pm_idle.c
@@ -87,6 +87,7 @@ void pm_idle(void)
 		return;
 	}
 	flags = enter_critical_section();
+	sched_lock();
 	now = clock_systimer();
 	/* We need to check and change PM state transition only if one tick time has been passed,
 	 * because state transition only happens when CPU receive TICK INTERRUPT. So checking pm state
@@ -190,6 +191,7 @@ EXIT:
 		gated_cpu_count--;
 	}
 #endif
+	sched_unlock();
 	leave_critical_section(flags);
 }
 


### PR DESCRIPTION
During the callback operation for suspending device, if another thread is awakened by sem_post, context switching may occur. This can cause the irq disable to be released, allowing the tick irq to occur, and cpu1 may already be in a hotplug situation, causing device hang due to cpu_pause being called for scheduling.

Therefore, Add sched_lock during board sleep.