### PR TITLE
framework/ble_manager : Fix the issue of server config being passed as NULL value

### DIFF
--- a/framework/src/ble_manager/ble_manager_lwnl.c
+++ b/framework/src/ble_manager/ble_manager_lwnl.c
@@ -357,10 +357,10 @@ trble_result_e ble_drv_operation_write_no_response(trble_operation_handle *handl
 }
 
 /*** Peripheral(Server) ***/
-trble_result_e ble_drv_set_server_config(uint16_t *server_config)
+trble_result_e ble_drv_set_server_config(trble_server_init_config *server_config)
 {
 	trble_result_e res = TRBLE_SUCCESS;
-	lwnl_msg msg = {BLE_INTF_NAME, {LWNL_REQ_BLE_SET_SERVER_CONFIG}, sizeof(uint16_t *), (void *)server_config, (void *)&res};
+	lwnl_msg msg = {BLE_INTF_NAME, {LWNL_REQ_BLE_SET_SERVER_CONFIG}, sizeof(trble_server_init_config *), (void *)server_config, (void *)&res};
 	if (_send_msg(&msg) < 0) {
 		res = TRBLE_FILE_ERROR;
 	}

--- a/os/include/tinyara/ble/ble_manager.h
+++ b/os/include/tinyara/ble/ble_manager.h
@@ -67,6 +67,7 @@ trble_result_e ble_drv_operation_write(trble_operation_handle *handle, trble_dat
 trble_result_e ble_drv_operation_write_no_response(trble_operation_handle *handle, trble_data *in_data);
 
 /*** Peripheral(Server) ***/
+trble_result_e ble_drv_set_server_config(trble_server_init_config *server_config);
 trble_result_e ble_drv_get_profile_count(uint16_t *count);
 trble_result_e ble_drv_charact_notify(trble_attr_handle attr_handle, trble_conn_handle con_handle, trble_data *data);
 trble_result_e ble_drv_charact_indicate(trble_attr_handle attr_handle, trble_conn_handle con_handle, trble_data *data);

--- a/os/net/blemgr/bledev.c
+++ b/os/net/blemgr/bledev.c
@@ -436,15 +436,12 @@ int bledev_handle(struct bledev *dev, lwnl_req cmd, void *data, uint32_t data_le
 	//Server
 	case LWNL_REQ_BLE_SET_SERVER_CONFIG:
 	{
-		lwnl_msg_params param = { 0, };
+		trble_server_init_config *t_server = NULL;
 		if (data != NULL) {
-			memcpy(&param, data, data_len);
+			t_server = (trble_server_init_config *)data;
 		} else {
 			return TRBLE_INVALID_ARGS;
 		}
-
-		trble_server_init_config *t_server = (trble_server_init_config *)param.param[0];
-		
 		TRBLE_DRV_CALL(ret, dev, set_server_config, (dev, t_server));
 	}
 	case LWNL_REQ_BLE_GET_PROFILE_COUNT:

--- a/os/net/blemgr/bledev_mgr_server.c
+++ b/os/net/blemgr/bledev_mgr_server.c
@@ -81,7 +81,7 @@ static trble_server_init_config g_server_null_config = {
 	NULL,
 	true,
 	gatt_null_profile,
-	sizeof(gatt_null_profile) / sizeof(trble_gatt_t)
+	0,
 };
 
 trble_server_init_config *bledrv_server_get_null_config(void)


### PR DESCRIPTION
 - Resolved the issue where the config passed to the driver in the function that calls the newly added server config after ble_manager init is NULL.
 - Set the profile count value to 0 in g_server_null_config