### PR TITLE
silent_reboot: Change return type of silent_reboot_is_silent_mode to bool

### DIFF
--- a/os/drivers/silent_reboot/silent_reboot_driver.c
+++ b/os/drivers/silent_reboot/silent_reboot_driver.c
@@ -89,7 +89,8 @@ static int silent_reboot_ioctl(FAR struct file *filep, int cmd, unsigned long ar
 		ret = silent_reboot_delay((int)arg);
 		break;
 	case SILENTRBIOC_CHECKMODE:
-		ret = silent_reboot_is_silent_mode((bool *)arg);
+		*(bool *)arg = silent_reboot_is_silent_mode();
+		ret = OK;
 		break;
 	case SILENTRBIOC_GETSTATUS:
 		ret = silent_reboot_get_status((silent_reboot_status_t *)arg);

--- a/os/include/tinyara/silent_reboot.h
+++ b/os/include/tinyara/silent_reboot.h
@@ -42,7 +42,7 @@ int silent_reboot_lock(void);
 int silent_reboot_unlock(void);
 int silent_reboot_delay(int timeout);
 int silent_reboot_force_perform_after_timeout(int timeout);
-int silent_reboot_is_silent_mode(bool *is_silent_mode);
+bool silent_reboot_is_silent_mode(void);
 int silent_reboot_get_status(silent_reboot_status_t *status);
 void silent_reboot_initialize(void);
 #else
@@ -50,7 +50,7 @@ void silent_reboot_initialize(void);
 #define silent_reboot_unlock() (0)
 #define silent_reboot_delay(timeout) (0)
 #define silent_reboot_force_perform_after_timeout(timeout) (0)
-#define silent_reboot_is_silent_mode(is_silent_mode) (0)
+#define silent_reboot_is_silent_mode() (false)
 #define silent_reboot_get_status(status) (0)
 #define silent_reboot_initialize()
 #endif

--- a/os/kernel/silent_reboot/silent_reboot.c
+++ b/os/kernel/silent_reboot/silent_reboot.c
@@ -351,11 +351,9 @@ int silent_reboot_force_perform_after_timeout(int timeout)
  *   Check whether silent mode or not.
  *
  ****************************************************************************/
-int silent_reboot_is_silent_mode(bool *is_silent_mode)
+bool silent_reboot_is_silent_mode(void)
 {
-	*is_silent_mode = g_is_silent_mode;
-
-	return OK;
+	return g_is_silent_mode;
 }
 
 /****************************************************************************


### PR DESCRIPTION
Change return type from int to bool because it just get gloval variable value and always return OK.