### PR TITLE
os/arch/arm/src/amebasmart: refactor peripheral suspend flow memory management

### DIFF
--- a/os/arch/arm/src/amebasmart/amebasmart_i2c.c
+++ b/os/arch/arm/src/amebasmart/amebasmart_i2c.c
@@ -200,6 +200,8 @@ struct amebasmart_i2c_priv_s {
 	struct amebasmart_trace_s trace[CONFIG_I2C_NTRACE];
 #endif
 
+	uint8_t initialized;		/* Initialization status */
+
 	uint32_t status;			/* End of transfer SR2|SR1 status */
 };
 
@@ -923,7 +925,16 @@ static int amebasmart_i2c_init(FAR struct amebasmart_i2c_priv_s *priv)
 	/* Power-up and configure GPIOs */
 	DEBUGASSERT(priv);
 	DEBUGASSERT(!priv->i2c_object);
-	priv->i2c_object = (i2c_t *)kmm_malloc(sizeof(i2c_t));
+
+	if (!priv->initialized) {
+		priv->i2c_object = (i2c_t *)kmm_malloc(sizeof(i2c_t));
+		DEBUGASSERT(priv->i2c_object);
+		priv->initialized = true;
+	} else {
+		/* memset 0 if not required to allocate */
+		memset(priv->i2c_object, 0, sizeof(i2c_t));
+	}
+
 	DEBUGASSERT(priv->i2c_object);
 	i2c_init(priv->i2c_object, priv->config->sda_pin, priv->config->scl_pin);
 
@@ -960,8 +971,8 @@ static int amebasmart_i2c_deinit(FAR struct amebasmart_i2c_priv_s *priv)
 	irq_detach(priv->config->irq);
 #endif
 
-	kmm_free(priv->i2c_object);
-	priv->i2c_object = NULL;
+	/* must ensure that the priv->i2c_object do not get used, but do not set it to NULL */
+	memset(priv->i2c_object, 0, sizeof(i2c_t));
 
 	return OK;
 }

--- a/os/arch/arm/src/amebasmart/amebasmart_i2s.c
+++ b/os/arch/arm/src/amebasmart/amebasmart_i2s.c
@@ -242,6 +242,9 @@ static const struct amebasmart_i2s_config_s amebasmart_i2s3_config = {
 	.txenab = 0,
 };
 #endif
+
+static u8 g_i2s_inited[I2S_NUM_MAX];
+
 /****************************************************************************
  * Private Function Prototypes
  ****************************************************************************/
@@ -1842,7 +1845,14 @@ struct i2s_dev_s *amebasmart_i2s_initialize(uint16_t port, bool is_reinit)
 		DEBUGASSERT(priv);
 	}
 
-	priv->i2s_object = (i2s_t *)kmm_zalloc(sizeof(i2s_t));
+	if (!g_i2s_inited[port]) {
+		priv->i2s_object = (i2s_t *)kmm_zalloc(sizeof(i2s_t));
+		g_i2s_inited[port] = true;
+	} else {
+		/* memset 0 if not required to allocate */
+		memset(priv->i2s_object, 0, sizeof(i2s_t));
+	}
+
 	DEBUGASSERT(priv->i2s_object);
 	/* Config values initialization */
 	priv->config = hw_config_s;	/* Get HW configuation */
@@ -1914,8 +1924,10 @@ static void amebasmart_i2s_suspend(uint16_t port)
 
 	i2s_disable(priv->i2s_object, 1);
 	i2s_tx_enabled = 0;
-	kmm_free(priv->i2s_object);
-	priv->i2s_object = NULL;
+
+	/* must ensure that the priv->i2s_object do not get used, but do not set it to NULL */
+	memset(priv->i2s_object, 0, sizeof(i2s_t));
+	
 	sem_destroy(&priv->exclsem);
 	sem_destroy(&priv->bufsem_tx);
 #if defined(I2S_HAVE_RX) && (0 < I2S_HAVE_RX)

--- a/os/board/rtl8730e/src/component/mbed/hal/i2c_api.h
+++ b/os/board/rtl8730e/src/component/mbed/hal/i2c_api.h
@@ -74,6 +74,8 @@ void i2c_init(i2c_t *obj, uint32_t sda, uint32_t scl);
   * @retval none
   */
 void i2c_init(i2c_t *obj, PinName sda, PinName scl);
+
+uint32_t i2c_index_get(PinName sda);
 ///@}
 #endif //end of "#if defined(CONFIG_PLATFORM_8735B) && (CONFIG_PLATFORM_8735B == 1)"
 

--- a/os/board/rtl8730e/src/component/mbed/targets/hal/rtl8730e/i2c_api.c
+++ b/os/board/rtl8730e/src/component/mbed/targets/hal/rtl8730e/i2c_api.c
@@ -60,7 +60,7 @@ void i2c_send_restart(I2C_TypeDef *I2Cx, u8 *pBuf, u8 len, u8 restart);
   * @retval 1: I2C1 Device.
   * @retval 2: I2C2 Device.
   */
-static uint32_t i2c_index_get(PinName sda)
+uint32_t i2c_index_get(PinName sda)
 {
 	if ((sda == _PA_0) || (sda == _PA_5) || (sda == _PA_9) || (sda == _PA_30) || (sda == _PB_5) || (sda == _PB_29)) {
 		return 0;


### PR DESCRIPTION
This commit refactors peripheral object to remove kmm_free in suspend flow

The memory region is instead reused by memset to 0 and then reinitialized