### PR TITLE
os/arch/arm/src/amebasmart: declare send_cmd_done flag as volatile

### DIFF
--- a/os/arch/arm/src/amebasmart/amebasmart_mipi.c
+++ b/os/arch/arm/src/amebasmart/amebasmart_mipi.c
@@ -46,7 +46,7 @@
 #endif
 
 static u32 vo_freq;
-static u32 send_cmd_done = 0;
+static volatile u8 send_cmd_done = 0;
 
 struct amebasmart_mipi_dsi_host_s {
 	struct mipi_dsi_host dsi_host;


### PR DESCRIPTION
1. send_cmd_done flag is updated in ISR, add volatile to prevent compiler from optimizing out memory reads, ensures the latest value is always read from memory.
2. since it is just a flag, use u8 instead of u32.