### PR TITLE
os/driver/lcd: modify lcd power on off flow

### DIFF
--- a/os/arch/arm/src/amebasmart/amebasmart_mipi.c
+++ b/os/arch/arm/src/amebasmart/amebasmart_mipi.c
@@ -270,7 +270,7 @@ static void amebasmart_register_interrupt(void)
 	InterruptEn(mipi_irq_info.num, mipi_irq_info.priority);
 }
 
-void mipidsi_mode_switch(bool do_enable){
+void mipi_mode_switch_to_video(bool do_enable){
 	if(do_enable){
 		MIPI_DSI_Mode_Switch(g_dsi_host.MIPIx, ENABLE);
 	}

--- a/os/board/rtl8730e/src/rtl8730e_mipi_lcdc.c
+++ b/os/board/rtl8730e/src/rtl8730e_mipi_lcdc.c
@@ -134,6 +134,10 @@ static void rtl8730e_lcd_init(void)
 static void rtl8730e_lcd_power_off(void)
 {
 	InterruptDis(lcdc_irq_info.num);
+	if (lcdc_nextframe == 1) {
+		lcdc_nextframe = 0;
+		sem_post(&g_next_frame_block);
+	}
 	GPIO_WriteBit(MIPI_GPIO_RESET_PIN, PIN_LOW);
 }
 static void rtl8730e_lcd_power_on(void)
@@ -236,7 +240,6 @@ static void rtl8730e_enable_lcdc(void)
 {
 	LCDC_Cmd(pLCDC, ENABLE);
 	while (!LCDC_CheckLCDCReady(pLCDC)) ;
-	mipidsi_mode_switch(true);
 }
 
 void rtl8730e_mipidsi_underflowreset(void)
@@ -318,6 +321,7 @@ void rtl8730e_lcdc_initialize(void)
 	LcdcInitValues(config);
 	rtl8730e_lcd_init();
 	rtl8730e_enable_lcdc();
+	mipidsi_mode_switch(true);
 
 	if (lcddev_register(dev) < 0) {
 		lcddbg("ERROR: LCD driver register fail\n");

--- a/os/board/rtl8730e/src/rtl8730e_mipi_lcdc.c
+++ b/os/board/rtl8730e/src/rtl8730e_mipi_lcdc.c
@@ -62,7 +62,7 @@ static void rtl8730e_lcd_put_area(u8 *lcd_img_buffer, u32 x_start, u32 y_start, 
 static void rtl8730e_enable_lcdc(void);
 static void rtl8730e_register_lcdc_isr(void);
 static void rtl8730e_control_backlight(u8 level);
-FAR void mipidsi_mode_switch(bool do_enable);
+FAR void mipi_mode_switch_to_video(bool do_enable);
 FAR void mipidsi_acpu_reg_clear(void);
 FAR struct mipi_dsi_host *amebasmart_mipi_dsi_host_initialize(struct lcd_data *config);
 FAR struct mipi_dsi_device *mipi_dsi_device_register(FAR struct mipi_dsi_host *host, FAR const char *name, int channel);
@@ -159,12 +159,12 @@ static void rtl8730e_gpio_reset(void)
 static void rtl8730e_mipi_mode_switch(mipi_mode_t mode)
 {
 	if (mode == CMD_MODE) {
-		mipidsi_mode_switch(false);
+		mipi_mode_switch_to_video(false);
 		MIPI_DSI_INT_Config(MIPI, DISABLE, ENABLE, FALSE);
 		DelayMs(140);
 	} else {
 		MIPI_DSI_INT_Config(MIPI, DISABLE, DISABLE, FALSE);
-		mipidsi_mode_switch(true);
+		mipi_mode_switch_to_video(true);
 	}
 }
 
@@ -284,7 +284,7 @@ u32 rtl8730e_hv_isr(void *Data)
 			InterruptRegister((IRQ_FUN)rtl8730e_mipidsi_underflowreset, mipi_irq_info.num, (u32)mipi_irq_info.data, mipi_irq_info.priority);
 			InterruptEn(mipi_irq_info.num, mipi_irq_info.priority);
 			mipidsi_acpu_reg_clear();
-			mipidsi_mode_switch(false);
+			mipi_mode_switch_to_video(false);
 			MIPI_DSI_INT_Config(MIPI, ENABLE, ENABLE, ENABLE);
 		}
 	}
@@ -321,7 +321,7 @@ void rtl8730e_lcdc_initialize(void)
 	LcdcInitValues(config);
 	rtl8730e_lcd_init();
 	rtl8730e_enable_lcdc();
-	mipidsi_mode_switch(true);
+	mipi_mode_switch_to_video(true);
 
 	if (lcddev_register(dev) < 0) {
 		lcddbg("ERROR: LCD driver register fail\n");

--- a/os/drivers/lcd/mipi_lcd.c
+++ b/os/drivers/lcd/mipi_lcd.c
@@ -165,9 +165,7 @@ static int send_cmd(struct mipi_lcd_dev_s *priv, lcm_setting_table_t command)
 	msg.tx_buf = cmd_addr;
 	msg.tx_len = payload_len;
 	msg.flags = 0;
-	priv->config->mipi_mode_switch(CMD_MODE);
 	transfer_status = send_to_mipi_dsi(priv, &msg);
-	priv->config->mipi_mode_switch(VIDEO_MODE);
 	return transfer_status;
 }
 
@@ -382,6 +380,8 @@ static int lcd_setpower(FAR struct lcd_dev_s *dev, int power)
 	}
 	if (power == 0) {
 		priv->config->backlight(power);
+		priv->config->mipi_mode_switch(CMD_MODE);
+		priv->lcdonoff = LCD_OFF;
 		lcm_setting_table_t display_off_cmd = {0x28, 0, {0x00}};
 		send_cmd(priv, display_off_cmd);
 		/* The power off must operate only when LCD is ON */
@@ -390,8 +390,6 @@ static int lcd_setpower(FAR struct lcd_dev_s *dev, int power)
 		/* The power on must operate only when LCD is OFF */
 		if (priv->power == 0) {
 			priv->config->power_on();
-			priv->config->mipi_mode_switch(CMD_MODE);
-			priv->lcdonoff = LCD_OFF;
 			/* We need to send init cmd after LCD IC power on */
 			send_init_cmd(priv, lcd_init_cmd_g);
 		}


### PR DESCRIPTION
1. when lcd power off, it switches to cmd mode, we should keep it in cmd mode, and set lcdonoff as LCD_OFF
2. So that when lcd power on, we do not need to switch to cmd again to send init cmd table
3. move video mode switch out from rtl8730e_enable_lcdc so that when wake up from PG, it stays in cmd mode
4. when lcd power off, we need to check if there is pending framedone interrupt in LCDC before disable irq, and if there is, sem_post, to prevent g_next_frame_block being hold during lcd power off, and when power on again, it could not send next frame. Eg: fps_test() is sending frames very fast, so it will hit the case where it sem_wait at rtl8730e_lcd_put_area and at the same time lcd power off.