### PR TITLE
os/kernel/silent_reboot: Add reference in silent reboot delay

### DIFF
--- a/os/kernel/silent_reboot/silent_reboot.c
+++ b/os/kernel/silent_reboot/silent_reboot.c
@@ -28,6 +28,7 @@
 #include <stdlib.h>
 #include <stdbool.h>
 #include <time.h>
+#include <errno.h>
 #include <tinyara/clock.h>
 #include <tinyara/wdog.h>
 

--- a/os/kernel/silent_reboot/silent_reboot.c
+++ b/os/kernel/silent_reboot/silent_reboot.c
@@ -326,7 +326,6 @@ int silent_reboot_force_perform_after_timeout(int timeout)
 {
 	int ret;
 	int tick_remain;
-	WDOG_ID wdog;
 
 	tick_remain = wd_gettime(g_silent_wdog);
 	if (SEC2TICK(timeout) > tick_remain) {


### PR DESCRIPTION
While building getting this error:
arm-none-eabi-ld: /root/tizenrt/os/../build/output/libraries/libkernel.a(silent_reboot.o): in function `silent_reboot_delay':
/root/tizenrt/os/kernel/silent_reboot/silent_reboot.c:309: undefined reference to `get_errno'
arm-none-eabi-ld: /root/tizenrt/os/../build/output/libraries/libkernel.a(silent_reboot.o): in function `silent_reboot_force_perform_after_timeout':
/root/tizenrt/os/kernel/silent_reboot/silent_reboot.c:340: undefined reference to `get_errno'

To solve this added reference of get errno.