### PR TITLE
os/arch/arm/src: Fix for checking app heap always during crash

### DIFF
--- a/os/arch/arm/src/armv7-a/arm_assert.c
+++ b/os/arch/arm/src/armv7-a/arm_assert.c
@@ -78,6 +78,7 @@
 #endif
 
 #ifdef CONFIG_APP_BINARY_SEPARATION
+#include "binary_manager/binary_manager_internal.h"
 #include <tinyara/binfmt/elf.h>
 #endif
 #include <tinyara/security_level.h>
@@ -496,12 +497,12 @@ void check_heap_corrupt(struct tcb_s *fault_tcb)
 {
 	if (!IS_SECURE_STATE()) {
 #ifdef CONFIG_APP_BINARY_SEPARATION
-		if (IS_FAULT_IN_USER_THREAD(fault_tcb)) {
+		for (int index = 1; index <= CONFIG_NUM_APPS; index++) {
 			lldbg_noarg("===========================================================\n");
-			lldbg_noarg("Checking app heap for corruption\n");
+			lldbg_noarg("Checking app %d heap for corruption \n",index);
 			lldbg_noarg("===========================================================\n");
-			mm_check_heap_corruption((struct mm_heap_s *)(fault_tcb->uheap));
-
+			struct mm_heap_s *app_heap = BIN_BINARY_HEAP_PTR(index);
+			mm_check_heap_corruption(app_heap);
 		}
 #endif
 


### PR DESCRIPTION
Initially app heap is only check when crash location is in app. So changes are added to check each app heap if crash is in kernel. So app heap is always check. For testing whether app heap is check or not, kernel side is made to crash and these are logs- =========================================================== Loading location information
=========================================================== elf_show_all_bin_section_addr: [common] Text Addr : 0xe161010, Text Size : 8679424 elf_show_all_bin_section_addr: [app1] Text Addr : 0xe9a8030, Text Size : 4894720 =========================================================== Checking each app heap for corruption
=========================================================== Checking app index 1
=========================================================== mm_check_heap_corruption: Heap start = 0x63a81230 end = 0x63f7fff0 mm_check_heap_corruption: No heap corruption detected check_heap_corrupt: No app heap corruption detected =========================================================== Checking kernel heap for corruption
=========================================================== mm_check_heap_corruption: Heap start = 0x60124500 end = 0x63a7fff0 mm_check_heap_corruption: No heap corruption detected