### PR TITLE
os/board/rtl8730e/src/ fix audio not played when last audio buffer is…

### DIFF
--- a/os/arch/arm/src/amebasmart/amebasmart_i2s.c
+++ b/os/arch/arm/src/amebasmart/amebasmart_i2s.c
@@ -407,7 +407,7 @@ static int amebasmart_i2s_tx(struct amebasmart_i2s_s *priv, struct amebasmart_bu
 			ptx_buf = i2s_get_tx_page(priv->i2s_object);
 			i2s_enable(priv->i2s_object);
 			if (ptx_buf) {
-				if ((apb->nbytes - apb->curbyte) <= tx_size) {
+				if ((apb->nbytes - apb->curbyte) < tx_size) {
 					tx_size = apb->nbytes - apb->curbyte;
 					memset(ptx_buf, 0, I2S_DMA_PAGE_SIZE); /* Clear ptx_buf to prevent sending old data since we are sending less than I2S_DMA_PAGE_SIZE */
 					memcpy((void *)ptx_buf, (void *)&apb->samp[apb->curbyte], tx_size);
@@ -417,7 +417,7 @@ static int amebasmart_i2s_tx(struct amebasmart_i2s_s *priv, struct amebasmart_bu
 				apb->curbyte += tx_size; /* No padding, ptx_buf is big enough to fill the whole tx_size */
 
 				
-				i2s_send_page(priv->i2s_object, (uint32_t *)ptx_buf);
+				i2s_send_page();
 			} else {
 				break;
 			}
@@ -559,7 +559,16 @@ static void i2s_tx_schedule(struct amebasmart_i2s_s *priv, int result)
 		/* Start next transfer */
 		amebasmart_i2s_tx(priv, bfcontainer);
 	} else if ((priv->apb_tx->nbytes - priv->apb_tx->curbyte) <= 0) {
-		ameba_i2s_pause(priv->i2s_object);
+		if (i2s_dma_tx_done(I2S_DMA_PAGE_NUM) == OK ){
+			/*if all dma tx done, we should pause i2s dma to mute it*/
+			ameba_i2s_pause(priv->i2s_object);
+		} else if (priv->apb_tx->nbytes < I2S_DMA_PAGE_SIZE * I2S_DMA_PAGE_NUM) {
+			/*we should wait for all dma page tx complete before call back to application 
+			to terminate i2s tx during the last container, here we assume last container data is smaller than total size
+			if it is not the last container, we can callback to application to send the next container while dma page not fully
+			tx complete to prevent delay in updating data in application that might lead to noise.*/
+			return;
+		}
 	}
 
 	/* If the worker has completed running, then reschedule the working thread.
@@ -732,7 +741,7 @@ void i2s_transfer_tx_handleirq(void *data, char *pbuf)
 			int *ptx_buf;
 			ptx_buf = i2s_get_tx_page(priv->i2s_object);
 			if (ptx_buf) {
-				if ((priv->apb_tx->nbytes - priv->apb_tx->curbyte) <= tx_size) {
+				if ((priv->apb_tx->nbytes - priv->apb_tx->curbyte) < tx_size) {
 					tx_size = priv->apb_tx->nbytes - priv->apb_tx->curbyte;
 					memset(ptx_buf, 0, I2S_DMA_PAGE_SIZE); /* Clear ptx_buf to prevent sending old data since we are sending less than I2S_DMA_PAGE_SIZE */
 					memcpy((void *)ptx_buf, (void *)&priv->apb_tx->samp[priv->apb_tx->curbyte], tx_size);
@@ -740,7 +749,7 @@ void i2s_transfer_tx_handleirq(void *data, char *pbuf)
 					memcpy((void *)ptx_buf, (void *)&priv->apb_tx->samp[priv->apb_tx->curbyte], I2S_DMA_PAGE_SIZE);
 				}
 				priv->apb_tx->curbyte += tx_size; /* No padding, ptx_buf is big enough to fill the whole tx_size */
-				i2s_send_page(priv->i2s_object, (uint32_t *)ptx_buf);
+				i2s_send_page();
 			} else {
 				break;
 			}

--- a/os/board/rtl8730e/src/component/mbed/hal_ext/i2s_api.h
+++ b/os/board/rtl8730e/src/component/mbed/hal_ext/i2s_api.h
@@ -334,7 +334,7 @@ int *i2s_get_tx_page(i2s_t *obj);
   * @param  pbuf: tx buffer adderss.
   * @retval none
   */
-void i2s_send_page(i2s_t *obj, uint32_t *pbuf);
+void i2s_send_page(void);
 
 /**
   * @brief  Sets current rx page own by i2s.


### PR DESCRIPTION
… small

1. during the last buffer, we should ensure all dma pages have been tx complete before callback to application to terminate it. if it is not the last buffer, we need not to wait for all dma pages to be tx to prevent latency of updating the data from application that might lead to noise. Here we assume the last buffer is not aligned with page*size.
2. remove duplicate memcpy of data to dma link list in i2s_send_page
3. remove unnecessary memset of ptx_buf to 0 when remaining bytes equals to tx_size, change condition from less than equals to less than.

Verified with test audio:
soundplayer /mnt/audio_cut_10ms_raw.raw 1 48000 1
soundplayer /mnt/audio_cut_2ms_raw.raw 1 48000 1
soundplayer /mnt/audio_cut_5ms_raw.raw 1 48000 1
soundplayer /mnt/audio_cut_raw.raw 1 48000 1