### PR TITLE
os/mm, os/drivers, os/include: Fix mem alloc fail due to dead task stack

### DIFF
--- a/os/drivers/memory/mminfo.c
+++ b/os/drivers/memory/mminfo.c
@@ -155,6 +155,10 @@ static int mminfo_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
 #endif
 				);
 		break;
+
+	case MMINFOIOC_GC:
+		sched_garbagecollection();
+		break;
 #endif
 	default:
 		mdbg("Not supported\n");

--- a/os/include/tinyara/fs/ioctl.h
+++ b/os/include/tinyara/fs/ioctl.h
@@ -465,6 +465,7 @@
 #define MMINFOIOC_HEAP              _MMINFOIOC(0x0001)
 #define MMINFOIOC_PARSE             _MMINFOIOC(0x0002)
 #define MMINFOIOC_MNG_ALLOCFAIL     _MMINFOIOC(0x0003)
+#define MMINFOIOC_GC                _MMINFOIOC(0x0004)
 
 /* Compress driver ioctl definitions ************************/
 #define _COMPIOCVALID(c)    (_IOC_TYPE(c) == _COMPBASE)

--- a/os/include/tinyara/kmalloc.h
+++ b/os/include/tinyara/kmalloc.h
@@ -196,15 +196,6 @@ void sched_kfree(FAR void *address);
 #define sched_kfree(a) sched_ufree(a)
 #endif
 
-/* Functions defined in sched/sched_garbage *********************************/
-
-/* Must be called periodically to clean up deallocations delayed by
- * sched_kmm_free().  This may be done from either the IDLE thread or from a
- * worker thread.  The IDLE thread has very low priority and could starve
- * the system for memory in some context.
- */
-
-void sched_garbagecollection(void);
 
 #undef KMALLOC_EXTERN
 #if defined(__cplusplus)

--- a/os/include/tinyara/mm/mm.h
+++ b/os/include/tinyara/mm/mm.h
@@ -806,12 +806,27 @@ void mm_ioctl_alloc_fail(size_t size, size_t align);
 							mm_ioctl_alloc_fail(s, a); \
 						} while (0)
 #endif
+
+void mm_ioctl_garbagecollection(void);
+#define sched_garbagecollection			mm_ioctl_garbagecollection
+
 #else
+
 void mm_manage_alloc_fail(struct mm_heap_s *heap, int startidx, int endidx, size_t size, size_t align, int heap_type
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
 		, mmaddress_t caller
 #endif
 		);
+
+/* Functions defined in sched/sched_garbage *********************************/
+
+/* Must be called periodically to clean up deallocations delayed by
+ * sched_kmm_free().  This may be done from either the IDLE thread or from a
+ * worker thread.  The IDLE thread has very low priority and could starve
+ * the system for memory in some context.
+ */
+
+void sched_garbagecollection(void);
 #endif
 
 #if CONFIG_KMM_NHEAPS > 1

--- a/os/mm/mm_heap/mm_manage_allocfail.c
+++ b/os/mm/mm_heap/mm_manage_allocfail.c
@@ -87,6 +87,20 @@ void mm_ioctl_alloc_fail(size_t size, size_t align)
 	}
 }
 
+void mm_ioctl_garbagecollection(void)
+{
+	int mmfd = open(MMINFO_DRVPATH, O_RDWR);
+	if (mmfd < 0) {
+		mdbg("Fail to open %s, errno %d\n", MMINFO_DRVPATH, get_errno());
+	} else {
+		int res = ioctl(mmfd, MMINFOIOC_GC, NULL);
+		if (res == ERROR) {
+			mdbg("Fail to call sched_garbagecollection, errno %d\n", get_errno());
+		}
+		close(mmfd);
+	}
+}
+
 #else
 
 #ifdef CONFIG_DEBUG_MM_HEAPINFO

--- a/os/mm/mm_heap/mm_memalign.c
+++ b/os/mm/mm_heap/mm_memalign.c
@@ -118,6 +118,7 @@ FAR void *mm_memalign(FAR struct mm_heap_s *heap, size_t alignment, size_t size)
 	FAR struct mm_allocnode_s *alignchunk = NULL;
 	bool found_align = false;
 	size_t mask = (size_t)(alignment - 1);
+	bool gc_done = false;
 
 	/* If this requested alinement's less than or equal to the natural alignment
 	 * of malloc, then just let malloc do the work.
@@ -144,6 +145,7 @@ FAR void *mm_memalign(FAR struct mm_heap_s *heap, size_t alignment, size_t size)
 
 	newsize = MM_ALIGN_UP(size + SIZEOF_MM_ALLOCNODE);
 
+retry_after_gc:
 	/* We need to hold the MM semaphore while we muck with the nodelist. */
 
 	DEBUGASSERT(mm_takesemaphore(heap));
@@ -209,6 +211,8 @@ FAR void *mm_memalign(FAR struct mm_heap_s *heap, size_t alignment, size_t size)
 	}
 
 	if (found_align) {
+		DEBUGASSERT(node);
+
 		FAR struct mm_allocnode_s *newnode = (FAR struct mm_allocnode_s *)((size_t)alignchunk - SIZEOF_MM_ALLOCNODE);
 		/* Get the next node after the allocation. */
 		FAR struct mm_allocnode_s *next = (FAR struct mm_allocnode_s *)((char *)node + node->size);
@@ -271,6 +275,13 @@ FAR void *mm_memalign(FAR struct mm_heap_s *heap, size_t alignment, size_t size)
 	}
 
 	mm_givesemaphore(heap);
+
+	if (!ret && gc_done == false) {
+		mdbg("Allocation failed!!! We dont have enough memory. Try to free dead task stack areas\n");
+		sched_garbagecollection();
+		gc_done = true;
+		goto retry_after_gc;
+	}
 
 	/* If CONFIG_DEBUG_MM is defined, then output the result of the allocation
 	 * to the SYSLOG.


### PR DESCRIPTION
When a task or thread is terminated, we place the stack details in a queue and it will be freed at a later point using the LPWORK thread. However, if LPWORK is not able to run due to some reason, then we run into "out of mem" error.

This commit adds code to check and release all the dead task stack space when we run into "out of mem" scenario.

Test results
===============
```
Test stack free for dead tasks
Create 5 tasks with 100KB stack
up_create_stack: Stack = 0x6028bff0
up_create_stack: Stack = 0x602a54d0
up_create_stack: Stack = 0x602be9b0
up_create_stack: Stack = 0x602d7e90
up_create_stack: Stack = 0x602f1370
Sleep for 10 secs
task_0 start
task_1 start
task_2 start
task_3 start
task_4 start
task_0 exit
task_1 exit
task_2 exit
task_3 exit
task_4 exit
All 5 tasks must be dead by now. Try to allocate memory repeatedly.
1. Allocated 100KB at 0x6030a380
2. Allocated 100KB at 0x60323390
3. Allocated 100KB at 0x6033c3a0
4. Allocated 100KB at 0x603553b0
5. Allocated 100KB at 0x6036e3c0
...
...
28. Allocated 100KB at 0x605ad530
29sched_kcleanup: Free stack at 0x60127a60
sched_kcleanup: Free stack at 0x601285f0
sched_kcleanup: Free stack at 0x60127950
sched_kcleanup: Free stack at 0x6014aa70
sched_kcleanup: Free stack at 0x6014b350
sched_kcleanup: Free stack at 0x60128200
sched_kcleanup: Free stack at 0x6013be90
sched_kcleanup: Free stack at 0x6013ca20
sched_kcleanup: Free stack at 0x6013bd80
sched_kcleanup: Free stack at 0x6014f630
sched_kcleanup: Free stack at 0x601501c0
sched_kcleanup: Free stack at 0x6014f520
sched_kcleanup: Free stack at 0x601587c0
sched_kcleanup: Free stack at 0x6014fe00
sched_kcleanup: Free stack at 0x60158e80
sched_kcleanup: Free stack at 0x60150060
sched_kcleanup: Free stack at 0x60159650
sched_kcleanup: Free stack at 0x60159540
sched_kcleanup: Free stack at 0x60159e20
sched_kcleanup: Free stack at 0x60159d10
sched_kcleanup: Free stack at 0x6015a5f0
sched_kcleanup: Free stack at 0x6015a4e0
sched_kucleanup: Free stack at 0x6028bff0
sched_kucleanup: Free stack at 0x602a54d0
sched_kucleanup: Free stack at 0x602be9b0
sched_kucleanup: Free stack at 0x602d7e90
sched_kucleanup: Free stack at 0x602f1370
. Allocated 100KB at 0x605c6540
30. Allocated 100KB at 0x605df550
31. Allocated 100KB at 0x605f85mm_manage_alloc_fail: Allocation failed from user heap.
mm_manage_alloc_fail:  - requested size 102400
mm_manage_alloc_fail:  - caller address = 0x0e16d5f9
mm_manage_alloc_fail:  - largest free size : 68016
mm_manage_alloc_fail:  - total free size   : 74176
```