### PR TITLE
os/arch/arm/src/amebasmart: remove unnecessary i2s_enable

### DIFF
--- a/os/board/rtl8730e/src/component/mbed/targets/hal/rtl8730e/i2s_api.c
+++ b/os/board/rtl8730e/src/component/mbed/targets/hal/rtl8730e/i2s_api.c
@@ -109,9 +109,9 @@ static void i2s_release_tx_page(uint8_t i2s_index)
 
 	if (sp_tx_info.tx_empty_flag) {
 	} else {
-		ptx_block->tx_gdma_own = 0;
 		memcpy((void *)ptx_block->tx_addr, sp_tx_info.tx_zero_block.tx_addr, sp_tx_info.tx_page_size);
 		DCache_CleanInvalidate((uint32_t)ptx_block->tx_addr, sp_tx_info.tx_page_size);
+		ptx_block->tx_gdma_own = 0;
 		sp_tx_info.tx_gdma_cnt++;
 		if (sp_tx_info.tx_gdma_cnt == sp_tx_info.tx_page_num) {
 			sp_tx_info.tx_gdma_cnt = 0;


### PR DESCRIPTION
1. i2s_enable should only be called if it was disabled previously
2. add flag i2s_enabled to keep track the status.
3. this reduce the chances of electronic noise significantly
4. test with product code, with this PR chances to reproduce the noise reduced significantly.