### PR TITLE
os/arch/armv7-a: Add condition to avoid recursive abort

### DIFF
--- a/os/arch/arm/src/armv7-a/arm_assert.c
+++ b/os/arch/arm/src/armv7-a/arm_assert.c
@@ -581,10 +581,16 @@ void up_assert(const uint8_t *filename, int lineno)
 	ARCH_GET_RET_ADDRESS(kernel_assert_location);
 
 	irqstate_t flags = enter_critical_section();
-	abort_mode = true;
 
 	uint32_t asserted_location = 0;
 
+	/* Check if we are in recursive abort */
+	if (abort_mode == true) {
+		/* treat kernel fault */
+		arm_assert();
+	} else {
+		abort_mode = true;
+	}
 	/* Extract the PC value of instruction which caused the abort/assert */
 
 	if (system_exception_location) {

--- a/os/arch/arm/src/armv7-m/up_assert.c
+++ b/os/arch/arm/src/armv7-m/up_assert.c
@@ -541,9 +541,15 @@ void up_assert(const uint8_t *filename, int lineno)
 
 	board_led_on(LED_ASSERTION);
 
-	abort_mode = true;
-
 	uint32_t asserted_location;
+
+	/* Check if we are in recursive abort */
+	if (abort_mode == true) {
+		/* treat kernel fault */
+		_up_assert(EXIT_FAILURE);
+	} else {
+		abort_mode = true;
+	}
 
 	/* Extract the PC value of instruction which caused the abort/assert */
 

--- a/os/arch/arm/src/armv7-r/arm_assert.c
+++ b/os/arch/arm/src/armv7-r/arm_assert.c
@@ -958,7 +958,16 @@ void up_assert(const uint8_t *filename, int lineno)
 		recursive_abort = true;
 	}
 #endif
-	abort_mode = true;
+
+	/* Check if we are in recursive abort */
+	if (abort_mode == true) {
+#if defined(CONFIG_BOARD_ASSERT_AUTORESET)
+		(void)boardctl(BOARDIOC_RESET, 0);
+#endif
+		_up_assert(EXIT_FAILURE);
+	} else {
+		abort_mode = true;
+	}
 
 	/* Add new line to distinguish between normal log and assert log.*/
 	lldbg_noarg("\n");

--- a/os/arch/arm/src/armv8-m/up_assert.c
+++ b/os/arch/arm/src/armv8-m/up_assert.c
@@ -602,9 +602,15 @@ void up_assert(const uint8_t *filename, int lineno)
 	reboot_reason_try_write_assert();
 #endif
 
-	abort_mode = true;
-
 	uint32_t asserted_location;
+
+	/* Check if we are in recursive abort */
+	if (abort_mode == true) {
+		/* treat kernel fault */
+		_up_assert(EXIT_FAILURE);
+	} else {
+		abort_mode = true;
+	}
 
 	/* Extract the PC value of instruction which caused the abort/assert */
 


### PR DESCRIPTION
This patch adds the condition check to avoid the series of aborts.

Test Results:
=========================================================== Checking kernel heap for corruption
=========================================================== mm_check_heap_corruption: Heap start = 0x6011c440 end = 0x6027fff0 mm_check_heap_corruption: No heap corruption detected

print_dataabort_detail: #########################################################################
print_dataabort_detail: PANIC!!! Data Abort at instruction : 0x0e0013b6
print_dataabort_detail: PC: 0e0013b6 DFAR: 00000000 DFSR: 0000080d
print_dataabort_detail: #########################################################################

boardctl: Board will Reboot now. pid: 20