### PR TITLE
arch/arm: fix variable conflict by adding new one for recursive abort

### DIFF
--- a/os/arch/arm/src/armv7-a/arm_assert.c
+++ b/os/arch/arm/src/armv7-a/arm_assert.c
@@ -144,6 +144,9 @@ extern int g_irq_num[CONFIG_SMP_NCPUS];
 #define LOG_TASK_NAME   "N/A"
 #endif
 
+#define NORMAL_STATE 0
+#define ABORT_STATE 1
+
 /****************************************************************************
  * Public Variables
  ****************************************************************************/
@@ -152,6 +155,9 @@ char assert_info_str[CONFIG_STDIO_BUFFER_SIZE] = { '\0', };
 /****************************************************************************
  * Private Data
  ****************************************************************************/
+
+/* Variable to check the recursive abort */
+static int state = NORMAL_STATE;
 
 /****************************************************************************
  * Private Functions
@@ -584,12 +590,14 @@ void up_assert(const uint8_t *filename, int lineno)
 
 	uint32_t asserted_location = 0;
 
+	abort_mode = true;
+
 	/* Check if we are in recursive abort */
-	if (abort_mode == true) {
+	if (state == ABORT_STATE) {
 		/* treat kernel fault */
 		arm_assert();
 	} else {
-		abort_mode = true;
+		state = ABORT_STATE;
 	}
 	/* Extract the PC value of instruction which caused the abort/assert */
 

--- a/os/arch/arm/src/armv7-m/up_assert.c
+++ b/os/arch/arm/src/armv7-m/up_assert.c
@@ -137,6 +137,9 @@ extern int g_irq_nums[3];
 #define IS_FAULT_IN_USER_THREAD(fault_tcb)  ((void *)fault_tcb->uheap != NULL)
 #define IS_FAULT_IN_USER_SPACE(asserted_location)   (is_kernel_space((void *)asserted_location) == false)
 
+#define NORMAL_STATE 0
+#define ABORT_STATE 1
+
 /****************************************************************************
  * Public Variables
  ****************************************************************************/
@@ -145,6 +148,9 @@ char assert_info_str[CONFIG_STDIO_BUFFER_SIZE] = {'\0', };
 /****************************************************************************
  * Private Data
  ****************************************************************************/
+
+/* Variable to check the recursive abort */
+static int state = NORMAL_STATE;
 
 /****************************************************************************
  * Private Functions
@@ -543,12 +549,14 @@ void up_assert(const uint8_t *filename, int lineno)
 
 	uint32_t asserted_location;
 
+	abort_mode = true;
+
 	/* Check if we are in recursive abort */
-	if (abort_mode == true) {
+	if (state == ABORT_STATE) {
 		/* treat kernel fault */
 		_up_assert(EXIT_FAILURE);
 	} else {
-		abort_mode = true;
+		state = ABORT_STATE;
 	}
 
 	/* Extract the PC value of instruction which caused the abort/assert */

--- a/os/arch/arm/src/armv7-r/arm_assert.c
+++ b/os/arch/arm/src/armv7-r/arm_assert.c
@@ -120,6 +120,9 @@ static bool recursive_abort = false;
 
 #define FRAME_POINTER_ADDR __builtin_frame_address(0)
 
+#define NORMAL_STATE 0
+#define ABORT_STATE 1
+
 /* Flag used to detect the whether upassert called or not */
 bool g_upassert = false;
 
@@ -131,6 +134,9 @@ char assert_info_str[CONFIG_STDIO_BUFFER_SIZE] = {'\0', };
 /****************************************************************************
  * Private Data
  ****************************************************************************/
+
+/* Variable to check the recursive abort */
+static int state = NORMAL_STATE;
 
 /****************************************************************************
  * Private Functions
@@ -959,14 +965,16 @@ void up_assert(const uint8_t *filename, int lineno)
 	}
 #endif
 
+	abort_mode = true;
+
 	/* Check if we are in recursive abort */
-	if (abort_mode == true) {
+	if (state == ABORT_STATE) {
 #if defined(CONFIG_BOARD_ASSERT_AUTORESET)
 		(void)boardctl(BOARDIOC_RESET, 0);
 #endif
 		_up_assert(EXIT_FAILURE);
 	} else {
-		abort_mode = true;
+		state = ABORT_STATE;
 	}
 
 	/* Add new line to distinguish between normal log and assert log.*/

--- a/os/arch/arm/src/armv8-m/up_assert.c
+++ b/os/arch/arm/src/armv8-m/up_assert.c
@@ -147,6 +147,9 @@ extern int g_irq_nums[3];
 #define IS_FAULT_IN_USER_THREAD(fault_tcb)  ((void *)fault_tcb->uheap != NULL)
 #define IS_FAULT_IN_USER_SPACE(asserted_location)   (is_kernel_space((void *)asserted_location) == false)
 
+#define NORMAL_STATE 0
+#define ABORT_STATE 1
+
 /****************************************************************************
  * Public Variables
  ****************************************************************************/
@@ -155,6 +158,9 @@ char assert_info_str[CONFIG_STDIO_BUFFER_SIZE] = {'\0', };
 /****************************************************************************
  * Private Data
  ****************************************************************************/
+
+/* Variable to check the recursive abort */
+static int state = NORMAL_STATE;
 
 /****************************************************************************
  * Private Functions
@@ -604,12 +610,14 @@ void up_assert(const uint8_t *filename, int lineno)
 
 	uint32_t asserted_location;
 
+	abort_mode = true;
+
 	/* Check if we are in recursive abort */
-	if (abort_mode == true) {
+	if (state == ABORT_STATE) {
 		/* treat kernel fault */
 		_up_assert(EXIT_FAILURE);
 	} else {
-		abort_mode = true;
+		state = ABORT_STATE;
 	}
 
 	/* Extract the PC value of instruction which caused the abort/assert */


### PR DESCRIPTION
This patch adds new variable abort_state for recursive abort to avoid conflict with existing variable abort_mode.

Test results:
=========================================================== Loading location information
=========================================================== elf_show_all_bin_section_addr: [common] Text Addr : 0xe161010, Text Size : 3112960 elf_show_all_bin_section_addr: [app1] Text Addr : 0xe459030, Text Size : 1417216

print_dataabort_detail: #########################################################################
print_dataabort_detail: PANIC!!! Data Abort at instruction : 0x0e001340
print_dataabort_detail: PC: 0e001340 DFAR: 00000000 DFSR: 0000080d
print_dataabort_detail: #########################################################################

boardctl: Board will Reboot now. pid: 20
ROM:[V1.1]