### PR TITLE
os/board/rtl8730e/src: add timeout for i2c read

### DIFF
--- a/os/board/rtl8730e/src/component/soc/amebad2/fwlib/ram_common/ameba_i2c.c
+++ b/os/board/rtl8730e/src/component/soc/amebad2/fwlib/ram_common/ameba_i2c.c
@@ -50,11 +50,11 @@
   */
 
 #include "ameba_soc.h"
-
+#include <errno.h>
 static const char *TAG = "I2C";
 
 #define I2C_SPEED_FINE_TUNE 0
-
+#define I2C_TIMEOUT 2000
 const I2C_DevTable I2C_DEV_TABLE[3] = {
 #ifdef ARM_CORE_CM4
 	{I2C0_DEV, I2C0_IRQ},
@@ -617,9 +617,17 @@ u32 I2C_MasterWriteBrk(I2C_TypeDef *I2Cx, u8 *pBuf, u32 len)
 
 	/* Write in the DR register the data to be sent */
 	for (cnt = 0; cnt < len; cnt++) {
-		InTimeoutCount = 1000;
+		InTimeoutCount = I2C_TIMEOUT; /*2s*/
 
-		while ((I2C_CheckFlagState(I2Cx, I2C_BIT_TFNF)) == 0);
+		while ((I2C_CheckFlagState(I2Cx, I2C_BIT_TFNF)) == 0) {
+			DelayUs(1);
+			if (InTimeoutCount == 0) {
+				I2C_Cmd(I2Cx, DISABLE);
+				I2C_Cmd(I2Cx, ENABLE);
+				return -EAGAIN;
+			}
+			InTimeoutCount--;
+		}
 
 		if (cnt >= len - 1) {
 			/*generate stop signal*/
@@ -627,21 +635,20 @@ u32 I2C_MasterWriteBrk(I2C_TypeDef *I2Cx, u8 *pBuf, u32 len)
 		} else {
 			I2Cx->IC_DATA_CMD = (*pBuf++);
 		}
-
+		InTimeoutCount = I2C_TIMEOUT;
 		while ((I2C_CheckFlagState(I2Cx, I2C_BIT_TFE)) == 0) {
+			DelayUs(1);
 			/* reset I2C hardware if timeout occured */
 			if (InTimeoutCount == 0) {
-				RTK_LOGW(TAG, "MasterWriteBrk timeout - resetting I2C\n");
 				I2C_Cmd(I2Cx, DISABLE);
 				I2C_Cmd(I2Cx, ENABLE);
-				return cnt;
+				return -EAGAIN;
 			}
 
 			if (I2C_GetRawINT(I2Cx) & I2C_BIT_TX_ABRT) {
 				I2C_ClearAllINT(I2Cx);
-				return cnt;
+				return -EAGAIN;
 			}
-
 			InTimeoutCount--;
 		}
 	}
@@ -701,9 +708,10 @@ void I2C_MasterReadDW(I2C_TypeDef *I2Cx, u8 *pBuf, u32 len)
 u32 I2C_MasterRead(I2C_TypeDef *I2Cx, u8 *pBuf, u32 len)
 {
 	u32 cnt = 0;
-
+	u32 InTimeoutCount = 0;
 	/* read in the DR register the data to be received */
 	for (cnt = 0; cnt < len; cnt++) {
+		InTimeoutCount = I2C_TIMEOUT; /*timeout 2ms*/
 		if (cnt >= len - 1) {
 			/* generate stop singal */
 			I2Cx->IC_DATA_CMD = 0x0003 << 8;
@@ -715,8 +723,15 @@ u32 I2C_MasterRead(I2C_TypeDef *I2Cx, u8 *pBuf, u32 len)
 		while ((I2C_CheckFlagState(I2Cx, I2C_BIT_RFNE)) == 0) {
 			if (I2C_GetRawINT(I2Cx) & I2C_BIT_TX_ABRT) {
 				I2C_ClearAllINT(I2Cx);
-				return cnt;
+				return -EAGAIN;
 			}
+			DelayUs(1);
+			if (InTimeoutCount == 0) {
+				I2C_Cmd(I2Cx, DISABLE);
+				I2C_Cmd(I2Cx, ENABLE);
+				return -EAGAIN;
+			}
+			InTimeoutCount--;
 		}
 		*pBuf++ = (u8)I2Cx->IC_DATA_CMD;
 	}


### PR DESCRIPTION
1. add timeout to break from infinite loop when waiting for i2c rx flag in case error occur in middle of rx
2. in case where i2c stucked in trap state, we should only re-try limited times to prevent infinite loop.