### PR TITLE
os/driver/input/ist415: Fix i2c read stuck issue during IC power off.

### DIFF
--- a/os/drivers/input/ist415.c
+++ b/os/drivers/input/ist415.c
@@ -774,6 +774,12 @@ static int ist415_event_thread(int argc, char **argv)
 			ASSERT(get_errno() == EINTR);
 		}
 
+		while (sem_wait(&dev->sem) != OK) {
+			ASSERT(get_errno() == EINTR);
+		}
+		if (dev->forcedoff) {
+			continue;
+		}
 		dev->lower->ops->irq_disable(dev->lower);
 		dev->irq_working = true;
 
@@ -784,6 +790,7 @@ static int ist415_event_thread(int argc, char **argv)
 
 		dev->irq_working = false;
 		dev->lower->ops->irq_enable(dev->lower);
+		sem_post(&dev->sem);
 	}
 
 	return OK;


### PR DESCRIPTION
During the execution of the operation to turn off the TOUCH IC power, if a touch IRQ occurs before the IRQ disable, the TOUCH IC power may be cut off before the I2C read operation is completed, resulting in I2C communication failure.

To resolve this, Add mutex to prevent the TOUCH IC read operation and the power OFF operation from operating simultaneously, and if the power is already turned off before reading the touch data, the read operation is not performed.