### PR TITLE
os/board/rtl8730e/rtl8730e_mipi_lcdc: Change to booting backlight 0

### DIFF
--- a/os/board/rtl8730e/src/rtl8730e_mipi_lcdc.c
+++ b/os/board/rtl8730e/src/rtl8730e_mipi_lcdc.c
@@ -324,6 +324,7 @@ void rtl8730e_lcdc_initialize(void)
 	config.mipi_lcd_limit = MIPI_LCD_LIMIT;
 	config.lcd_lane_num = MIPI_LANE_NUMBER;
 	rtl8730e_gpio_reset();
+	rtl8730e_control_backlight(0);
 	struct mipi_dsi_host *dsi_host = (struct mipi_dsi_host *)amebasmart_mipi_dsi_host_initialize(&config);
 	struct mipi_dsi_device *dsi_device = (struct mipi_dsi_device *)mipi_dsi_device_register(dsi_host, "dsi", 0);
 	struct lcd_dev_s *dev = (struct lcd_dev_s *)mipi_lcdinitialize(dsi_device, &g_rtl8730e_config_dev_s.lcd_config);


### PR DESCRIPTION
For PWM control of the backlight of the ST7785 and ST7701SN LCDs, the maximum brightness is achieved when the PWM output is 0. Therefore, after booting and initializing the PWM, since the output power is 0, the LCD backlight is set to maximum brightness.

Since we only set the LCD backlight to maximum brightness in cases other than silent reboots, to set the default backlight brightness to 0 after booting, we need to set the PWM output power to 100 (MAX) after booting.

Therefore, Add to set lcd backlight 0 during lcd init.