### PR TITLE
os/drivers/input/ist415: Change to check the IC off state as "enable"

### DIFF
--- a/os/drivers/input/ist415.c
+++ b/os/drivers/input/ist415.c
@@ -777,7 +777,7 @@ static int ist415_event_thread(int argc, char **argv)
 		while (sem_wait(&dev->sem) != OK) {
 			ASSERT(get_errno() == EINTR);
 		}
-		if (dev->forcedoff) {
+		if (dev->enable == false) {
 			continue;
 		}
 		dev->lower->ops->irq_disable(dev->lower);


### PR DESCRIPTION
The method of checking whether the touch IC is turned off using the forcedoff variable is only possible when the app forcibly turns off the touch IC.

To prevent I2C reads when the IC is reset due to other logic such as lockup, Change it to check the "enable" variable, which is disabled during power off.