### PR TITLE
os/drivers/input/ist415.c: Add missing sem_post() in function ist415_event_thread()

### DIFF
--- a/os/drivers/input/ist415.c
+++ b/os/drivers/input/ist415.c
@@ -778,6 +778,7 @@ static int ist415_event_thread(int argc, char **argv)
 			ASSERT(get_errno() == EINTR);
 		}
 		if (dev->enable == false) {
+			sem_post(&dev->sem);
 			continue;
 		}
 		dev->lower->ops->irq_disable(dev->lower);


### PR DESCRIPTION
Add missing sem_post() in function ist415_event_thread()