### PR TITLE
os/drivers/input/ist415.c: Fix watchdog setup order

### DIFF
--- a/os/drivers/input/ist415.c
+++ b/os/drivers/input/ist415.c
@@ -1124,7 +1124,9 @@ void ist415_start(struct ist415_dev_s *dev)
 	uint8_t mode;
 	int ret = 0;
 
-	(void)wd_start(dev->wdog, MSEC2TICK(IST415_LOOKUP_MS), (wdentry_t)ist415_timer_handler, 1, (uint32_t)dev);
+	if (wd_start(dev->wdog, MSEC2TICK(IST415_LOOKUP_MS), (wdentry_t)ist415_timer_handler, 1, (uint32_t)dev) != OK) {
+		ist415dbg("Fail to start ist415 wdog, errno : %d\n", get_errno());
+	}
 
 	if (dev->rec_mode) {
 		mode = REC_ENABLE;
@@ -1262,17 +1264,8 @@ int ist415_initialize(const char *path, struct i2c_dev_s *i2c, struct ist415_con
 		ist415vdbg("Get info success\n");
 	}
 
-	ist415_start(dev);
-	// ist415_enable(dev);
-
 	dev->wdog = wd_create();
-	if (dev->wdog) {
-		if (wd_start(dev->wdog, MSEC2TICK(IST415_LOOKUP_MS), (wdentry_t)ist415_timer_handler, 1, (uint32_t)dev) != OK) {
-			ist415dbg("Fail to start ist415 wdog\n");
-		}
-	} else {
-		ist415dbg("Fail to alloc ist415 wdog\n");
-	}
+	ist415_start(dev);
 
 	upper = (struct touchscreen_s *)kmm_zalloc(sizeof(struct touchscreen_s));
 	if (!upper) {


### PR DESCRIPTION
-Move wd_create() just above the ist415_start() call inside ist415_initialize() to ensure the watchdog is created before being started. -Remove wd_start() from ist415_initialize() since it is already called inside ist415_start() and was redundant.