### PR TITLE
drivers/input: Add suspending PM when a touch input.

### DIFF
--- a/os/drivers/input/ist415.h
+++ b/os/drivers/input/ist415.h
@@ -477,6 +477,8 @@ struct ist415_dev_s {
 
 	sem_t sem;
 
+	int pm_domain;
+
 	WDOG_ID wdog;
 	struct work_s work;
 };


### PR DESCRIPTION
Touch is a user interaction, so when a touch is detected, the power management is delayed
 for a certain period to prevent entering power sleep mode.

Furthermore, when I2C is used for checking the touch IC alive, the PM is also delayed
 to avoid entering power sleep mode and blocking the I2C.