### PR TITLE
os/board/rtl8730e: BLE reserve MAC address before returning

### DIFF
--- a/os/board/rtl8730e/src/component/bluetooth/example/ble_scatternet/scatternet.c
+++ b/os/board/rtl8730e/src/component/bluetooth/example/ble_scatternet/scatternet.c
@@ -567,7 +567,9 @@ static rtk_bt_evt_cb_ret_t ble_tizenrt_scatternet_gap_app_callback(uint8_t evt_c
 				client_init_parm->trble_device_connected_cb(&connected_dev);
 			} else if (RTK_BT_LE_ROLE_SLAVE == ble_tizenrt_scatternet_conn_ind->role) {
 				if (server_init_parm.connected_cb) {
-					server_init_parm.connected_cb(auth_cplt_ind->conn_handle, TRBLE_SERVER_SM_CONNECTED, ble_tizenrt_scatternet_conn_ind->peer_addr.addr_val);
+					uint8_t addr[TRBLE_BD_ADDR_MAX_LEN];
+					_reverse_mac(ble_tizenrt_scatternet_conn_ind->peer_addr.addr_val, addr);
+					server_init_parm.connected_cb(auth_cplt_ind->conn_handle, TRBLE_SERVER_SM_CONNECTED, addr);
 				} else {
 					ble_tizenrt_dummy_callback();
 				}


### PR DESCRIPTION
-Reserve BLE MAC address before passing it to BLE manager