### PR TITLE
os/drivers/input/ist415.c: Fix memory leaks in ist415_initialize() on error paths

### DIFF
--- a/os/board/rtl8730e/src/rtl8730e_ist415.c
+++ b/os/board/rtl8730e/src/rtl8730e_ist415.c
@@ -186,6 +186,7 @@ void rtl8730e_ist415_initialize(void)
 	if (ist415_initialize(TOUCH_DEV_PATH, i2c, dev) < 0) {
 		touchdbg("ERROR: Touch driver register fail\n");
 		up_i2cuninitialize(i2c);
+	} else {
+		touchdbg("Touch driver register success\n");
 	}
-	touchdbg("Touch driver register success\n");
 }


### PR DESCRIPTION
The ist415_initialize () function had several error return paths where allocated resources such as semaphores, watchdog timers, and kernel threads were not properly released. This could lead to memory leaks on initialization failure. This commit ensures that all allocated resources are correctly cleaned up in all failure scenarios.