### PR TITLE
os/arch/arm/amebasmart: Remove sem calling during enter PG.

### DIFF
--- a/os/arch/arm/src/amebasmart/amebasmart_i2s.h
+++ b/os/arch/arm/src/amebasmart/amebasmart_i2s.h
@@ -50,12 +50,6 @@ extern "C" {
 * @brief I2S Peripheral, 0 & 1.
 *
 */
-
-#undef I2S_INIT
-#undef I2S_REINIT
-#define I2S_INIT   0
-#define I2S_REINIT 1
-
 typedef enum {
 	I2S_NUM_2 = 0x2,			/*!< I2S 2 */
 	I2S_NUM_3 = 0x3,			/*!< I2S 3 */
@@ -85,7 +79,7 @@ typedef enum {
  *
  ****************************************************************************/
 
-FAR struct i2s_dev_s *amebasmart_i2s_initialize(uint16_t port, bool is_reinit);
+FAR struct i2s_dev_s *amebasmart_i2s_initialize(uint16_t port);
 
 #undef EXTERN
 #if defined(__cplusplus)

--- a/os/board/rtl8730e/src/rtl8730e_alc1019.c
+++ b/os/board/rtl8730e/src/rtl8730e_alc1019.c
@@ -37,7 +37,7 @@
 #include "PinNames.h"
 #include "gpio_api.h"
 
-extern FAR struct i2s_dev_s *amebasmart_i2s_initialize(uint16_t port, bool is_reinit);
+extern FAR struct i2s_dev_s *amebasmart_i2s_initialize(uint16_t port);
 
 /****************************************************************************
  * Pre-processor Definitions
@@ -166,7 +166,7 @@ int rtl8730e_alc1019_initialize(int minor)
 		auddbg("i2c init done\n");
 		auddbg("calling init i2s\n");
 		/* Get an instance of the I2S interface for the ALC1019 data channel */
-		i2s = amebasmart_i2s_initialize(ALC1019_I2S_PORT, I2S_INIT);
+		i2s = amebasmart_i2s_initialize(ALC1019_I2S_PORT);
 		if (!i2s) {
 			auddbg("ERROR: Failed to initialize I2S\n");
 			ret = -ENODEV;

--- a/os/board/rtl8730e/src/rtl8730e_i2schar.c
+++ b/os/board/rtl8730e/src/rtl8730e_i2schar.c
@@ -74,7 +74,7 @@ int i2schar_devinit(void)
 #if defined(CONFIG_AMEBASMART_I2S2) && !defined(CONFIG_AUDIO_ALC1019)
 		/* Call amebasmart_i2s_initialize() to get an instance of the I2S interface */
 		/* Initialise I2S2 */
-		i2s = amebasmart_i2s_initialize(I2S_NUM_2, I2S_INIT);
+		i2s = amebasmart_i2s_initialize(I2S_NUM_2);
 
 		if (!i2s) {
 			lldbg("ERROR: Failed to get the amebasmart I2S driver\n");
@@ -91,7 +91,7 @@ int i2schar_devinit(void)
 		I2S_ERR_CB_REG(i2s, err_cb, "Error_Test_String");
 #endif
 #ifdef CONFIG_AMEBASMART_I2S3
-		i2s = amebasmart_i2s_initialize(I2S_NUM_3, I2S_INIT);
+		i2s = amebasmart_i2s_initialize(I2S_NUM_3);
 
 		if (!i2s) {
 			lldbg("ERROR: Failed to get the amebasmart I2S driver\n");

--- a/os/board/rtl8730e/src/rtl8730e_syu645b.c
+++ b/os/board/rtl8730e/src/rtl8730e_syu645b.c
@@ -121,7 +121,7 @@ static void rtl8730e_syu645b_pm(bool sleep)
  * Public Functions
  ****************************************************************************/
 
-extern FAR struct i2s_dev_s *amebasmart_i2s_initialize(uint16_t port, bool is_reinit);
+extern FAR struct i2s_dev_s *amebasmart_i2s_initialize(uint16_t port);
 
 /****************************************************************************
  * Name: rtl8730e_syu645b_initialize
@@ -171,7 +171,7 @@ int rtl8730e_syu645b_initialize(int minor)
 		auddbg("i2c init done\n");
 		auddbg("calling init i2s\n");
 		/* Get an instance of the I2S interface for the SYU645B data channel */
-		i2s = amebasmart_i2s_initialize(SYU645B_I2S_PORT, I2S_INIT);
+		i2s = amebasmart_i2s_initialize(SYU645B_I2S_PORT);
 		if (!i2s) {
 			auddbg("ERROR: Failed to initialize I2S\n");
 			ret = -ENODEV;


### PR DESCRIPTION
the board sleep seqeunce is in idle.
So, we can't call sem_wait in this time because we can't give up the cpu in idle.

Therefore, Remove sem calling situation during enter PG