### PR TITLE
os/kernel/sched: Fix assert fail in remove readytorun

### DIFF
--- a/os/kernel/sched/sched_removereadytorun.c
+++ b/os/kernel/sched/sched_removereadytorun.c
@@ -114,6 +114,9 @@ bool sched_removereadytorun(FAR struct tcb_s *rtcb)
 {
 	FAR struct tcb_s *ntcb = NULL;
 	bool ret = false;
+	FAR dq_queue_t *tasklist;
+
+	tasklist = TLIST_HEAD(rtcb->task_state);
 
 #ifdef CONFIG_SW_STACK_OVERFLOW_DETECTION
 	sched_checkstackoverflow(rtcb);
@@ -123,7 +126,7 @@ bool sched_removereadytorun(FAR struct tcb_s *rtcb)
 	 * In this case, we are removing the currently active task.
 	 */
 
-	if (!rtcb->blink) {
+	if (!rtcb->blink && TLIST_ISRUNNABLE(rtcb->task_state)) {
 		/* There must always be at least one task in the list (the idle task) */
 
 		ntcb = (FAR struct tcb_s *)rtcb->flink;
@@ -135,7 +138,7 @@ bool sched_removereadytorun(FAR struct tcb_s *rtcb)
 
 	/* Remove the TCB from the ready-to-run list */
 
-	dq_rem((FAR dq_entry_t *)rtcb, (FAR dq_queue_t *)&g_readytorun);
+	dq_rem((FAR dq_entry_t *)rtcb, tasklist);
 
 	/* Since the TCB is not in any list, it is now invalid */
 


### PR DESCRIPTION
Assert fail is observed at below lines of code.

	ntcb = (FAR struct tcb_s *)rtcb->flink;
	DEBUGASSERT(ntcb != NULL);

However, we need to check the flink only if the list is runnable. Otherwise the list can be empty and we dont need to check flink.