### PR TITLE
arch/amebasmart, board/rtl8730e: Fix i2c sem corruption issue

### DIFF
--- a/os/arch/arm/src/amebasmart/amebasmart_i2c.c
+++ b/os/arch/arm/src/amebasmart/amebasmart_i2c.c
@@ -238,8 +238,8 @@ static int amebasmart_i2c_isr_process(struct amebasmart_i2c_priv_s *priv);
 static int amebasmart_i2c_isr(int irq, void *context, FAR void *arg);
 #endif							/* !CONFIG_I2C_POLLED */
 
-static int amebasmart_i2c_init(FAR struct amebasmart_i2c_priv_s *priv);
-static int amebasmart_i2c_deinit(FAR struct amebasmart_i2c_priv_s *priv);
+int amebasmart_i2c_init(FAR struct amebasmart_i2c_priv_s *priv);
+int amebasmart_i2c_deinit(FAR struct amebasmart_i2c_priv_s *priv);
 #ifdef CONFIG_I2C_TRANSFER
 static int amebasmart_i2c_transfer(FAR struct i2c_dev_s *dev, FAR struct i2c_msg_s *msgs, int count);
 #endif
@@ -924,7 +924,7 @@ static int amebasmart_i2c_isr(int irq, void *context, FAR void *arg)
  *
  ************************************************************************************/
 
-static int amebasmart_i2c_init(FAR struct amebasmart_i2c_priv_s *priv)
+int amebasmart_i2c_init(FAR struct amebasmart_i2c_priv_s *priv)
 {
 	/* Power-up and configure GPIOs */
 	DEBUGASSERT(priv);
@@ -955,7 +955,7 @@ static int amebasmart_i2c_init(FAR struct amebasmart_i2c_priv_s *priv)
  *
  ************************************************************************************/
 
-static int amebasmart_i2c_deinit(FAR struct amebasmart_i2c_priv_s *priv)
+int amebasmart_i2c_deinit(FAR struct amebasmart_i2c_priv_s *priv)
 {
 
 	DEBUGASSERT(priv);

--- a/os/board/rtl8730e/src/rtl8730e_ist415.c
+++ b/os/board/rtl8730e/src/rtl8730e_ist415.c
@@ -124,16 +124,18 @@ static void rtl8730e_ist415_disable_irq(struct ist415_config_s *dev)
 static void rtl8730e_ist415_power_off(struct ist415_config_s *dev)
 {
 	struct rtl8730e_ist415_s *priv = (struct rtl8730e_ist415_s *)dev->priv;
-	up_i2cuninitialize(priv->i2c);	/* Workaround: IC20 write hang issue */
+	struct amebasmart_i2c_priv_s *priv_i2c = (struct amebasmart_i2c_priv_s *)priv->i2c;
+	amebasmart_i2c_deinit(priv_i2c);
 	GPIO_WriteBit(IST415_GPIO_RESET_PIN, PIN_LOW);
 }
 
 static void rtl8730e_ist415_power_on(struct ist415_config_s *dev)
 {
 	struct rtl8730e_ist415_s *priv = (struct rtl8730e_ist415_s *)dev->priv;
+	struct amebasmart_i2c_priv_s *priv_i2c = (struct amebasmart_i2c_priv_s *)priv->i2c;
 	GPIO_WriteBit(IST415_GPIO_RESET_PIN, PIN_HIGH);
 	DelayMs(1);  /* Wait for stable voltage before i2c commands issued */
-	priv->i2c = up_i2cinitialize(IST415_I2C_PORT);	/* Workaround: IC20 write hang issue */
+	amebasmart_i2c_init(priv_i2c);
 }
 
 static void rtl8730e_ist415_gpio_init(void)


### PR DESCRIPTION
since we are calling up_i2cuninitialize and up_i2cinitialize during ist415 TSC power on/off sequence for recovery I2C operation.

but the up_i2cuninitialize has sem_destroy
so the sem is destoryed, but a crash is occurring by accessing the sem from another thread.

we just need i2c operation recovery, therefore replace up_i2cuninitialze to amebasmart_i2c_deinit