### PR TITLE
Svace fix

### DIFF
--- a/os/kernel/binary_manager/binary_manager_load.c
+++ b/os/kernel/binary_manager/binary_manager_load.c
@@ -506,7 +506,7 @@ static int loadingall_thread(int argc, char *argv[])
 	for (bin_idx = 1; bin_idx <= bin_count; bin_idx++) {
 		if (BIN_LOAD_PRIORITY(bin_idx, BIN_USEIDX(bin_idx)) == BINARY_LOADPRIO_HIGH) {
 			ret = binary_manager_load(bin_idx);
-			if (ret > 0) {
+			if (ret == BINMGR_OK) {
 				load_cnt++;
 			}
 		}

--- a/os/kernel/binary_manager/binary_manager_resource.c
+++ b/os/kernel/binary_manager/binary_manager_resource.c
@@ -99,7 +99,8 @@ int binary_manager_mount_resource(void)
 
 #ifdef CONFIG_USE_BP
 	binmgr_bpdata_t *bp_data;
-	if (binary_manager_update_bpinfo() != BINMGR_OK) {
+	ret = binary_manager_update_bpinfo();
+	if (ret != BINMGR_OK) {
 		bmdbg("Failed to update bpinfo %d\n", ret);
 		return ERROR;
 	}

--- a/os/kernel/debug/mem_leak_checker.c
+++ b/os/kernel/debug/mem_leak_checker.c
@@ -240,6 +240,7 @@ static void heap_check(struct mm_heap_s *heap, int checker_pid, int *leak_cnt)
 	void *exclude_bottom;
 
 	struct tcb_s *ctcb = sched_gettcb(checker_pid);
+	ASSERT(ctcb != NULL);
 	exclude_top = ctcb->adj_stack_ptr;
 	exclude_bottom = ctcb->adj_stack_ptr - ctcb->adj_stack_size;
 


### PR DESCRIPTION
Fixed issues reported by svace tool
1. kernel/binary_manager: 
-  make sure to increment the load_cnt on binary_manager_load success. 
-  proper error message on the debug print when binary_manager_update_bpinfo fails.

2. kernel/debug: 
- Added NULL pointer check in the heap_check to validate tcb.
