### PR TITLE
os/board/rtl8730e: Modify wifi porting layer to prep for concurrent

### DIFF
--- a/os/arch/arm/src/amebasmart/amebasmart_enet.c
+++ b/os/arch/arm/src/amebasmart/amebasmart_enet.c
@@ -68,8 +68,6 @@
 #include "rtw_wifi_constants.h"
 #include "wifi_intf_drv_to_app_basic.h"
 
-//for concurrent mode, not supported now
-//#define RTK_CONCURRENT_MODE
 #ifdef CONFIG_AMEBASMART_WIFI
 
 struct netdev *ameba_nm_dev_wlan0 = NULL;
@@ -213,12 +211,12 @@ void arm_netinitialize(void)
 	if (ameba_nm_dev_wlan0 == NULL) {
 		rtw_printf("Failed to register amebasmart netdev\n");
 	}
-#ifdef RTK_CONCURRENT_MODE
+#ifdef CONFIG_ENABLE_HOMELYNK
 	ameba_nm_dev_wlan1 = amebasmart_register_dev(alloc_size);
 	if (ameba_nm_dev_wlan1 == NULL) {
 		rtw_printf("Failed to register amebasmart netdev\n");
 	}
-#endif
+#endif //#ifdef CONFIG_ENABLE_HOMELYNK
 #endif
 #if defined(CONFIG_AMEBASMART_BLE) && defined(CONFIG_DRIVERS_BLE)
 	ameba_bm_dev_ble0 = bledev_register(&g_trble_drv_ops);

--- a/os/board/rtl8730e/src/component/os/tizenrt/ethernetif_tizenrt.c
+++ b/os/board/rtl8730e/src/component/os/tizenrt/ethernetif_tizenrt.c
@@ -97,8 +97,10 @@
 #define IF2NAME1 '2'
 #endif
 
+#ifndef CONFIG_ENABLE_HOMELYNK
 /* Check if current mode is softap */
 extern int softap_flag;
+#endif //#ifndef CONFIG_ENABLE_HOMELYNK
 
 static void arp_timer(void *arg);
 
@@ -174,10 +176,15 @@ err_t low_level_output(struct netdev *dev, uint8_t *data, uint16_t dlen)
 	if (sg_len) {
 #if CONFIG_WLAN
 #if defined(CONFIG_AS_INIC_AP)
-		/* Currently TizenRT only uses idx 0 on application layer, but KR4 splits STA and SOFTAP into idx 0 and idx 1, need to check which idx to send to */
+#ifdef CONFIG_ENABLE_HOMELYNK
+		/* If concurrent is enabled, get idx based on the two netif */
+		idx = get_idx_from_dev(dev);
+#else
+		/* If concurrent is disabled, TizenRT only uses idx 0 on application layer, but driver splits STA and SOFTAP into idx 0 and idx 1, need to check which idx to send to */
 		if (softap_flag == 1) {
 			idx = 1;
 		}
+#endif //#ifdef CONFIG_ENABLE_HOMELYNK
 		ret = inic_ipc_host_send(idx, sg_list, sg_len, dlen, NULL);
 		if (ret == ERR_IF) {
 			return ret;

--- a/os/board/rtl8730e/src/component/os/tizenrt/rtk_netmgr.c
+++ b/os/board/rtl8730e/src/component/os/tizenrt/rtk_netmgr.c
@@ -96,7 +96,9 @@ static trwifi_scan_list_s *g_scan_list;
 static int g_scan_num;
 extern struct netdev *ameba_nm_dev_wlan0;
 rtw_result_t app_scan_result_handler_legacy(rtw_scan_handler_result_t *malloced_scan_result);
+#ifndef CONFIG_ENABLE_HOMELYNK
 int softap_flag = 0;
+#endif //#ifndef CONFIG_ENABLE_HOMELYNK
 
 
 #define SCAN_TIMER_DURATION 180000
@@ -380,7 +382,9 @@ trwifi_result_e wifi_netmgr_utils_init(struct netdev *dev)
 		/*extern const char lib_wlan_rev[];
 		RTW_API_INFO("\n\rwlan_version %s\n", lib_wlan_rev);*/
 		wuret = TRWIFI_SUCCESS;
+#ifndef CONFIG_ENABLE_HOMELYNK
 		softap_flag = 0;
+#endif //#ifndef CONFIG_ENABLE_HOMELYNK
 		rtw_mutex_init(&scanlistbusy);
 	} else {
 		ndbg("Already %d\n", g_mode);
@@ -838,7 +842,9 @@ trwifi_result_e wifi_netmgr_utils_start_softap(struct netdev *dev, trwifi_softap
 	}
 	g_mode = RTK_WIFI_SOFT_AP_IF;
 	nvdbg("[RTK] SoftAP with SSID: %s has successfully started!\n", softap_config->ssid);
+#ifndef CONFIG_ENABLE_HOMELYNK
 	softap_flag = 1;
+#endif //#ifndef CONFIG_ENABLE_HOMELYNK
 	ret = TRWIFI_SUCCESS;
 
 	return ret;
@@ -866,7 +872,9 @@ trwifi_result_e wifi_netmgr_utils_start_sta(struct netdev *dev)
 	if (ret == RTK_STATUS_SUCCESS) {
 		g_mode = RTK_WIFI_STATION_IF;
 		wuret = TRWIFI_SUCCESS;
+#ifndef CONFIG_ENABLE_HOMELYNK
 		softap_flag = 0;
+#endif //#ifndef CONFIG_ENABLE_HOMELYNK
 	} else {
 		ndbg("[RTK] Failed to start STA mode\n");
 	}
@@ -882,7 +890,9 @@ trwifi_result_e wifi_netmgr_utils_stop_softap(struct netdev *dev)
 		if (ret == RTK_STATUS_SUCCESS) {
 			g_mode = RTK_WIFI_NONE;
 			wuret = TRWIFI_SUCCESS;
+#ifndef CONFIG_ENABLE_HOMELYNK
 			softap_flag = 0;
+#endif //#ifndef CONFIG_ENABLE_HOMELYNK
 			nvdbg("[RTK] Stop AP mode successfully\n");
 		} else {
 			ndbg("[RTK] Stop AP mode fail\n");

--- a/os/board/rtl8730e/src/component/usrcfg/rtl8730e/ameba_wificfg.c
+++ b/os/board/rtl8730e/src/component/usrcfg/rtl8730e/ameba_wificfg.c
@@ -18,7 +18,11 @@ _WEAK void wifi_set_user_config(void)
 	rtw_memset(&wifi_user_config, 0, sizeof(struct wifi_user_conf));
 
 	/* below items for user config */
-	wifi_user_config.concurrent_enabled = (u8)_FALSE; /*Softap's mac address will equal chip's mac address + 1 if this value set as _TRUE*/
+#ifdef CONFIG_ENABLE_HOMELYNK
+	wifi_user_config.concurrent_enabled = (u8)_TRUE; /*Softap's mac address will equal chip's mac address + 1 if this value set as _TRUE*/
+#else
+	wifi_user_config.concurrent_enabled = (u8)_FALSE;
+#endif //#ifdef CONFIG_ENABLE_HOMELYNK
 	wifi_user_config.auto_reconnect_count = 8;
 	wifi_user_config.auto_reconnect_interval = 5; /* in sec*/
 #ifdef CONFIG_HIGH_TP_TEST /*enable high tp in make menuconfig*/

--- a/os/board/rtl8730e/src/component/wifi/inic/inic_ipc_host_trx.c
+++ b/os/board/rtl8730e/src/component/wifi/inic/inic_ipc_host_trx.c
@@ -158,9 +158,10 @@ static void inic_ipc_host_rx_tasklet(void)
 			g_inic_host_priv.rx_pkts++;
 #if defined(CONFIG_PLATFORM_TIZENRT_OS)
 			/* TizenRT gets netif from netdev */
-			/* Currently TizenRT only uses idx 0 */
-			// index = precvbuf->idx_wlan;
-
+			/* If concurrent is not enabled, TizenRT only uses idx 0 */
+#ifdef CONFIG_ENABLE_HOMELYNK
+			index = precvbuf->idx_wlan;
+#endif //#ifdef CONFIG_ENABLE_HOMELYNK
 			struct netdev *dev_tmp = NULL;
 			dev_tmp = (struct netdev *)rtk_get_netdev(index);
 			struct netif *netif = GET_NETIF_FROM_NETDEV(dev_tmp);


### PR DESCRIPTION
- Certain parts of wifi porting code requires to be changed if concurrent mode is supported in the future
- Main point is to ensure wlan index on the application side is matched to the correct interface in wifi driver
- Use preprocessor CONFIG_RTK_CONCURRENT_MODE to set the right code flow based on whether concurrent mode is supported