### PR TITLE
os/kernel/task: Kernel thread must not inherit app's heap, etc..

### DIFF
--- a/os/arch/arm/src/common/up_restoretask.c
+++ b/os/arch/arm/src/common/up_restoretask.c
@@ -83,7 +83,7 @@ void up_restoretask(struct tcb_s *tcb)
 #endif
 
 #ifdef CONFIG_ARCH_USE_MMU
-		if (tcb->app_id && tcb->pgtbl != mmu_l1_pgtable()) {
+		if (tcb->app_id && tcb->pgtbl && tcb->pgtbl != mmu_l1_pgtable()) {
 			cp15_wrttb((uint32_t) tcb->pgtbl | TTBR0_RGN_WBWA | TTBR0_IRGN0);
 			cp15_invalidate_tlbs();
 		}

--- a/os/binfmt/binfmt_arch_apis.c
+++ b/os/binfmt/binfmt_arch_apis.c
@@ -46,6 +46,8 @@ static inline void binfmt_set_mpu(struct binary_s *binp)
 		nregion = mpu_get_nregion_info(MPU_REGION_APP_BIN);
 	}
 
+	DEBUGASSERT(regs);
+
 #ifdef CONFIG_OPTIMIZE_APP_RELOAD_TIME
 	/* Configure text section as RO and executable region */
 	mpu_get_register_config_value(&regs[0], nregion - 3, (uintptr_t)binp->sections[BIN_TEXT], binp->sizes[BIN_TEXT], true, true);

--- a/os/kernel/task/task_setup.c
+++ b/os/kernel/task/task_setup.c
@@ -497,28 +497,36 @@ static int thread_schedsetup(FAR struct tcb_s *tcb, int priority, start_t start,
 		up_initial_state(tcb);
 
 #ifdef CONFIG_APP_BINARY_SEPARATION
-		/* Copy the parent task ram details to this task */
+		/* Copy some attributes from parent task to this task */
 		rtcb = this_task();
-		tcb->uspace = rtcb->uspace;
-		tcb->uheap = rtcb->uheap;
 		tcb->app_id = rtcb->app_id;
+
+		/* If a kernel thread is getting created due to some
+		 * call from a user task or pthread, then the kernel thread
+		 * will not inherit the some attributes related to heap, uspace,
+		 * memory protection, etc..
+		 */
+		if ((tcb->flags & TCB_FLAG_TTYPE_MASK) != TCB_FLAG_TTYPE_KERNEL) {
+			tcb->uspace = rtcb->uspace;
+			tcb->uheap = rtcb->uheap;
 #ifdef CONFIG_ARCH_USE_MMU
-		tcb->pgtbl = rtcb->pgtbl;
+			tcb->pgtbl = rtcb->pgtbl;
 #endif
-		/* Copy the MPU register values from parent to child task */
+			/* Copy the MPU register values from parent to child task */
 #ifdef CONFIG_ARM_MPU
-		int i = 0;
+			int i = 0;
 #ifdef CONFIG_OPTIMIZE_APP_RELOAD_TIME
-		for (; i < MPU_REG_NUMBER * NUM_APP_REGIONS; i += MPU_REG_NUMBER)
+			for (; i < MPU_REG_NUMBER * NUM_APP_REGIONS; i += MPU_REG_NUMBER)
 #endif
-		{
-			tcb->mpu_regs[i + MPU_REG_RNR] = rtcb->mpu_regs[i + MPU_REG_RNR];
-			tcb->mpu_regs[i + MPU_REG_RBAR] = rtcb->mpu_regs[i + MPU_REG_RBAR];
-			tcb->mpu_regs[i + MPU_REG_RASR] = rtcb->mpu_regs[i + MPU_REG_RASR];
+			{
+				tcb->mpu_regs[i + MPU_REG_RNR] = rtcb->mpu_regs[i + MPU_REG_RNR];
+				tcb->mpu_regs[i + MPU_REG_RBAR] = rtcb->mpu_regs[i + MPU_REG_RBAR];
+				tcb->mpu_regs[i + MPU_REG_RASR] = rtcb->mpu_regs[i + MPU_REG_RASR];
+			}
+#endif
 		}
 #endif
 
-#endif
 		tcb->fin_data = NO_FIN_DATA;
 
 		/* Add the task to the inactive task list */


### PR DESCRIPTION
If a kernel thread gets created from an app thread, then it must not inherit the app uheap, uspace and memory protection data.