### PR TITLE
os/kernel/pthread: Pthread mutex wait must not reutrn EINTR

### DIFF
--- a/os/kernel/pthread/pthread.h
+++ b/os/kernel/pthread/pthread.h
@@ -122,19 +122,19 @@ void pthread_destroyjoin(FAR struct task_group_s *group, FAR struct join_s *pjoi
 FAR struct join_s *pthread_findjoininfo(FAR struct task_group_s *group, pid_t pid);
 int pthread_join_internal(pthread_t thread, FAR pthread_addr_t *pexit_value, bool blocking);
 void pthread_release(FAR struct task_group_s *group);
-int pthread_sem_take(sem_t *sem, bool intr);
+int pthread_sem_take(sem_t *sem);
 #ifdef CONFIG_PTHREAD_MUTEX_UNSAFE
 int pthread_sem_trytake(sem_t *sem);
 #endif
 int pthread_sem_give(sem_t *sem);
 
 #ifndef CONFIG_PTHREAD_MUTEX_UNSAFE
-int pthread_mutex_take(FAR struct pthread_mutex_s *mutex, bool intr);
+int pthread_mutex_take(FAR struct pthread_mutex_s *mutex);
 int pthread_mutex_trytake(FAR struct pthread_mutex_s *mutex);
 int pthread_mutex_give(FAR struct pthread_mutex_s *mutex);
 void pthread_mutex_inconsistent(FAR struct pthread_tcb_s *tcb);
 #else
-#define pthread_mutex_take(m, i) pthread_sem_take(&(m)->sem, (i))
+#define pthread_mutex_take(m) pthread_sem_take(&(m)->sem)
 #define pthread_mutex_trytake(m) pthread_sem_trytake(&(m)->sem)
 #define pthread_mutex_give(m)   pthread_sem_give(&(m)->sem)
 #endif

--- a/os/kernel/pthread/pthread_completejoin.c
+++ b/os/kernel/pthread/pthread_completejoin.c
@@ -128,7 +128,7 @@ static bool pthread_notifywaiters(FAR struct join_s *pjoin)
 		 * value.
 		 */
 
-		(void)pthread_sem_take(&pjoin->data_sem, false);
+		(void)pthread_sem_take(&pjoin->data_sem);
 		return true;
 	}
 
@@ -230,7 +230,7 @@ int pthread_completejoin(pid_t pid, FAR void *exit_value)
 
 	/* First, find thread's structure in the private data set. */
 
-	(void)pthread_sem_take(&group->tg_joinsem, false);
+	(void)pthread_sem_take(&group->tg_joinsem);
 	pjoin = pthread_findjoininfo(group, pid);
 	if (!pjoin) {
 		sdbg("Could not find join info, pid=%d\n", pid);

--- a/os/kernel/pthread/pthread_condtimedwait.c
+++ b/os/kernel/pthread/pthread_condtimedwait.c
@@ -326,7 +326,7 @@ int pthread_cond_timedwait(FAR pthread_cond_t *cond, FAR pthread_mutex_t *mutex,
 					svdbg("Re-locking...\n");
 
 					oldstate = pthread_disable_cancel();
-					status = pthread_mutex_take(mutex, false);
+					status = pthread_mutex_take(mutex);
 					pthread_enable_cancel(oldstate);
 
 					if (status == OK) {

--- a/os/kernel/pthread/pthread_condwait.c
+++ b/os/kernel/pthread/pthread_condwait.c
@@ -119,7 +119,7 @@ int pthread_cond_wait(FAR pthread_cond_t *cond, FAR pthread_mutex_t *mutex)
 
 		/* Take the semaphore */
 
-		status = pthread_sem_take((FAR sem_t *)&cond->sem, false);
+		status = pthread_sem_take((FAR sem_t *)&cond->sem);
 		if (ret == OK) {
 			/* Report the first failure that occurs */
 
@@ -137,7 +137,7 @@ int pthread_cond_wait(FAR pthread_cond_t *cond, FAR pthread_mutex_t *mutex)
 		svdbg("Reacquire mutex...\n");
 
 		oldstate = pthread_disable_cancel();
-		status = pthread_mutex_take(mutex, false);
+		status = pthread_mutex_take(mutex);
 		pthread_enable_cancel(oldstate);
 
 		if (ret == OK) {

--- a/os/kernel/pthread/pthread_create.c
+++ b/os/kernel/pthread/pthread_create.c
@@ -195,7 +195,7 @@ static void pthread_start(void)
 
 	/* Sucessfully spawned, add the pjoin to our data set. */
 
-	(void)pthread_sem_take(&group->tg_joinsem, false);
+	(void)pthread_sem_take(&group->tg_joinsem);
 	pthread_addjoininfo(group, pjoin);
 	(void)pthread_sem_give(&group->tg_joinsem);
 
@@ -485,7 +485,7 @@ int pthread_create(FAR pthread_t *thread, FAR const pthread_attr_t *attr, pthrea
 		 * its join structure.
 		 */
 
-		(void)pthread_sem_take(&pjoin->data_sem, false);
+		(void)pthread_sem_take(&pjoin->data_sem);
 
 		/* Return the thread information to the caller */
 

--- a/os/kernel/pthread/pthread_detach.c
+++ b/os/kernel/pthread/pthread_detach.c
@@ -124,7 +124,7 @@ int pthread_detach(pthread_t thread)
 
 	/* Find the entry associated with this pthread. */
 
-	(void)pthread_sem_take(&group->tg_joinsem, false);
+	(void)pthread_sem_take(&group->tg_joinsem);
 	pjoin = pthread_findjoininfo(group, (pid_t)thread);
 	if (!pjoin) {
 		sdbg("Could not find thread entry\n");

--- a/os/kernel/pthread/pthread_initialize.c
+++ b/os/kernel/pthread/pthread_initialize.c
@@ -123,15 +123,13 @@ void pthread_initialize(void)
  *
  * Parameters:
  *  sem  - The semaphore to lock or unlock
- *  intr - false: ignore EINTR errors when locking; true tread EINTR as
- *         other errors by returning the errno value
  *
  * Return Value:
  *   0 on success or an errno value on failure.
  *
  ****************************************************************************/
 
-int pthread_sem_take(sem_t *sem, bool intr)
+int pthread_sem_take(sem_t *sem)
 {
 	/* Verify input parameters */
 
@@ -146,7 +144,7 @@ int pthread_sem_take(sem_t *sem, bool intr)
 			 * awakened by the receipt of a signal.
 			 */
 
-			if (intr || errcode != EINTR) {
+			if (errcode != EINTR) {
 				return errcode;
 			}
 		}

--- a/os/kernel/pthread/pthread_join_internal.c
+++ b/os/kernel/pthread/pthread_join_internal.c
@@ -147,7 +147,7 @@ int pthread_join_internal(pthread_t thread, FAR pthread_addr_t *pexit_value, boo
 	 * because it will also attempt to get this semaphore.
 	 */
 
-	(void)pthread_sem_take(&group->tg_joinsem, false);
+	(void)pthread_sem_take(&group->tg_joinsem);
 
 	/* Find the join information associated with this thread.
 	 * This can fail for one of three reasons:  (1) There is no
@@ -230,7 +230,7 @@ int pthread_join_internal(pthread_t thread, FAR pthread_addr_t *pexit_value, boo
 				 * pthread to exit.
 				 */
 
-				(void)pthread_sem_take(&pjoin->exit_sem, false);
+				(void)pthread_sem_take(&pjoin->exit_sem);
 
 				/* The thread has exited! Get the thread exit value */
 
@@ -249,7 +249,7 @@ int pthread_join_internal(pthread_t thread, FAR pthread_addr_t *pexit_value, boo
 				 * pthread_destroyjoin is called.
 				 */
 
-				(void)pthread_sem_take(&group->tg_joinsem, false);
+				(void)pthread_sem_take(&group->tg_joinsem);
 			} else {
 				sdbg("fail to get exit value\n");
 

--- a/os/kernel/pthread/pthread_mutex.c
+++ b/os/kernel/pthread/pthread_mutex.c
@@ -113,15 +113,13 @@ static void pthread_mutex_add(FAR struct pthread_mutex_s *mutex)
  *
  * Parameters:
  *  mutex - The mutex to be locked
- *  intr  - false: ignore EINTR errors when locking; true treat EINTR as
- *          other errors by returning the errno value
  *
  * Return Value:
  *   0 on success or an errno value on failure.
  *
  ****************************************************************************/
 
-int pthread_mutex_take(FAR struct pthread_mutex_s *mutex, bool intr)
+int pthread_mutex_take(FAR struct pthread_mutex_s *mutex)
 {
 	int ret = EINVAL;
 
@@ -142,7 +140,7 @@ int pthread_mutex_take(FAR struct pthread_mutex_s *mutex, bool intr)
 			 * returns zero on success and a positive errno value on failure.
 			 */
 
-			ret = pthread_sem_take(&mutex->sem, intr);
+			ret = pthread_sem_take(&mutex->sem);
 			if (ret == OK) {
 				/* Check if the holder of the mutex has terminated without
 				 * releasing.  In that case, the state of the mutex is
@@ -176,8 +174,6 @@ int pthread_mutex_take(FAR struct pthread_mutex_s *mutex, bool intr)
  *
  * Parameters:
  *  mutex - The mutex to be locked
- *  intr  - false: ignore EINTR errors when locking; true treat EINTR as
- *          other errors by returning the errno value
  *
  * Return Value:
  *   0 on success or an errno value on failure.

--- a/os/kernel/pthread/pthread_mutexlock.c
+++ b/os/kernel/pthread/pthread_mutexlock.c
@@ -233,7 +233,7 @@ int pthread_mutex_lock(FAR pthread_mutex_t *mutex)
 			 * default mutex.
 			 */
 
-			ret = pthread_mutex_take(mutex, true);
+			ret = pthread_mutex_take(mutex);
 
 			/* If we succussfully obtained the semaphore, then indicate
 			 * that we own it.


### PR DESCRIPTION
According to posix standard, if a pthread is waiting to aquire mutex and gets interrupted by a signal, then it is supposed to execute the signal and then continue to wait for the mutex.

Previously, our code allowed to pass an argument which decided whether an EINTR error is retured or not. Since this is not posix compliant behavior, this commit removes this argument.


Kernel tc has be verified with this commit.