### PR TITLE
tools/trap: Handle armv7a related aborts in trap tool

### DIFF
--- a/tools/trap/cli/logParser.py
+++ b/tools/trap/cli/logParser.py
@@ -99,6 +99,12 @@ class logParser:
 			print('\n2. Crash type               : usage fault')
 		elif 'up_hardfault' in string:
 			print('\n2. Crash type               : hard fault')
+		elif 'dataabort' in string:
+			print('\n2. Crash type               : data abort')
+		elif 'prefetchabort' in string:
+			print('\n2. Crash type               : prefetch abort')
+		elif 'undefinedinsn' in string:
+			print('\n2. Crash type               : undefined instruction abort')
 		elif 'Assertion failed' in string:
 			self.crash_type_assert = True
 			print('\n2. Crash type               : code assertion by code ASSERT or PANIC')


### PR DESCRIPTION
The crash point was not being printed properly for armv7a related aborts such as data abort, prefetch abort and undefinedins. This is because the trap tool was missing the logic to parse these abort types.
```
Data abort output before this commit
==================================================================
1. Crash Binary             : app1

2. Crash type               : code assertion by code ASSERT or PANIC

3. Crash point
	- armv7-a/arm_dataabort.c line 218 task: preLoader pid: 111

Data abort output with this commit
==================================================================
1. Crash Binary             : app1

2. Crash type               : data abort
   Crash log
	- Assertion failed CPU0 at file: armv7-a/arm_dataabort.c line 218 task: preLoader pid: 111

3. Crash point (PC or LR)

	[ Caller - return address (LR) - of the function which has caused the crash ]
	- symbol addr        : 0x0ea10013
	- function name      : _ZN12main_800x4803com3sec2da4home12HomeActivity7onPauseEv
	- file               : /conan/p/kerne3148bbed1319b/p/include/libcxx/memory:4811

	[ Current location (PC) of assert ]
	- symbol addr        : 0x0ea0f476
	- function name      : _ZNSt20__shared_ptr_emplaceIN12main_800x4803com3sec2da5bixby7service9indicator21UserspeakingIndicatorESaIS7_EED0Ev
	- file               : /conan/p/kerne3148bbed1319b/p/include/libcxx/memory:3998

	[ Exact crash point might be -4 or -8 bytes from the PC ]
	- symbol addr of (pc - 4)       : 0x0ea0f472
	- function name of (pc - 4)     : _ZNSt20__shared_ptr_emplaceIN12main_800x4803com3sec2da5bixby7service9indicator21UserspeakingIndicatorESaIS7_EED2Ev
	- file of (pc - 4)              : /conan/p/kerne3148bbed1319b/p/include/libcxx/memory:3998

	[ Exact crash point might be -4 or -8 bytes from the PC ]
	- symbol addr of (pc - 8)       : 0x0ea0f46e
	- function name of (pc - 8)     : _ZNSt20__shared_ptr_emplaceIN12main_800x4803com3sec2da5bixby7service9indicator21UserspeakingIndicatorESaIS7_EED2Ev
	- file of (pc - 8)              : /conan/p/kerne3148bbed1319b/p/include/libcxx/memory:3998
```