### PR TITLE
os/arch/arm/src: SMP/AMP migrate systick control to running core during pause

### DIFF
--- a/os/arch/arm/src/amebasmart/amebasmart_smp.c
+++ b/os/arch/arm/src/amebasmart/amebasmart_smp.c
@@ -168,6 +168,10 @@ void smp_init(void)
 			continue;
 		}
 		err = psci_cpu_on(xCoreID, (unsigned long)__cpu1_start);
+
+		/* Wait for CPU1 to boot from ATF to SGI1 WFI loop, before os_smp_start is called */
+		DelayUs(50);
+
 		/* If we failed to boot secondary core here, it will be very likely
 		issue is coming from ATF/kernel flow, and that operation is irreversible
 		(ie. There is no way we can restore the secondary core to come

--- a/os/arch/arm/src/armv7-a/arm_cpugating.c
+++ b/os/arch/arm/src/armv7-a/arm_cpugating.c
@@ -43,8 +43,6 @@
 #ifdef CONFIG_CPU_GATING
 static volatile uint32_t g_cpugating_flag[CONFIG_SMP_NCPUS];
 
-extern volatile uint32_t g_active_system_timer_cpu;
-
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
@@ -55,6 +53,9 @@ void up_set_gating_flag_status(uint32_t CoreID, uint32_t val)
 	ARM_DSB();
 	/* Flag already reach 0 */
 	if (!g_cpugating_flag[CoreID]) {
+		if (this_cpu() != 0) {
+			up_timer_disable();
+		}
 		SP_SEV();
 	}
 }
@@ -77,11 +78,6 @@ void up_do_gating(void)
 			SP_WFE();
 		}
 		irqrestore(PrevIrqStatus);
-
-		/* transfer systick control back to cpu0 if cpu0 exit gating. cpu1 do not need */
-		if (cpu == 0) {
-			g_active_system_timer_cpu = cpu;
-		}
 	}
 
 }
@@ -127,7 +123,9 @@ void up_cpu_gating(int cpu)
 	arm_cpu_sgi(GIC_IRQ_SGI3, (1 << cpu));
 
 	/* after gating other CPU, this cpu is the active timer, since the other one will be gated */
-	g_active_system_timer_cpu = this_cpu();
+	if (cpu == 0 && g_cpugating_flag[cpu] != 0) {
+		up_timer_enable();
+	}
 }
 
 #endif /* CONFIG_CPU_GATING */

--- a/os/arch/arm/src/armv7-a/arm_cpupause.c
+++ b/os/arch/arm/src/armv7-a/arm_cpupause.c
@@ -52,8 +52,11 @@
 #include "up_internal.h"
 #include "gic.h"
 #include "sched/sched.h"
+#include "arch_timer.h"
 
 #ifdef CONFIG_SMP
+
+extern volatile uint32_t g_active_system_timer_cpu;
 
 /****************************************************************************
  * Private Data
@@ -363,6 +366,9 @@ int up_cpu_pause(int cpu)
 	spin_lock(&g_cpu_paused[cpu]);
 	spin_unlock(&g_cpu_paused[cpu]);
 
+	/* after taking the spinlocks, this cpu is the active timer, since the other one will be paused */
+	g_active_system_timer_cpu = this_cpu();
+
 	/* On successful return g_cpu_wait will be locked, the other CPU will be
 	 * spinning on g_cpu_wait and will not continue until g_cpu_resume() is
 	 * called.  g_cpu_paused will be unlocked in any case.
@@ -418,6 +424,11 @@ int up_cpu_resume(int cpu)
 		spin_lock(&g_cpu_resumed[cpu]);
 
 		spin_unlock(&g_cpu_resumed[cpu]);
+
+		/* transfer systick control back to cpu0 if cpu0 is being resumed */
+		if (cpu == 0) {
+			g_active_system_timer_cpu = cpu;
+		}
 	}
 
 	return OK;

--- a/os/arch/arm/src/armv7-a/arm_cpustart.c
+++ b/os/arch/arm/src/armv7-a/arm_cpustart.c
@@ -54,6 +54,7 @@
 #include "gic.h"
 #include "sched/sched.h"
 #include "smp.h"
+#include "arch_timer.h"
 
 #ifdef CONFIG_SMP
 
@@ -110,6 +111,9 @@ int arm_start_handler(int irq, void *context, void *arg)
 	struct tcb_s *tcb = this_task();
 
 	svdbg("CPU%d Started\n", this_cpu());
+
+	/* start generic timer PPI for this core */
+	up_timer_initialize();
 
 #ifdef CONFIG_SCHED_INSTRUMENTATION
 	/* Notify that this CPU has started */


### PR DESCRIPTION
This PR demonstrates functional switching of systick count when pausing a core.

As systick is counted by each individual core's timer PPI, it will trigger independently of each other. Currently, this will cause the system tick to have multiple count and affect OS timing.

To avoid multiple counting, only one core will be allowed to increment the common OS tick counter

If Core0 happens to be paused, then the other core should take over, and then return control when Core0 resumes

Please check with flat_dev_ddr config