### PR TITLE
os/pm: prevent PM if cpu is already paused

### DIFF
--- a/os/pm/pm_idle.c
+++ b/os/pm/pm_idle.c
@@ -137,6 +137,9 @@ void pm_idle(void)
 						pmdbg("Sleep abort! CPU%d\n", cpu);
 						goto EXIT;
 					}
+
+					/* If the target cpu is already paused it will not be in idle thread, so PM should abort */
+					ASSERT(!up_is_cpu_paused(cpu));
 				}
 
 				tcb = current_task(cpu);


### PR DESCRIPTION
In an unlikely case where secondary CPU was already paused by another operation, PM will hang as the pause request was already handled, so up_cpu_pausereq is 0

An additional preventive check is added to ensure the secondary cpu is actually paused, so that PM should be aborted until the secondary cpu is resumed to re-enter idle task

While checking #6815 case of Pause CPU1 then Abort on CPU0 in PM, this case was caught where the board hang due to infinite loop. Normally this case should not happen, but in the event that it does due to improper API use, this fix should help abort PM and fix the hang @kishore-sn @sunghan-chang 