### PR TITLE
arch/armv7-a: Change cpu gating logic when cpu is already paused

### DIFF
--- a/os/arch/arm/src/amebasmart/amebasmart_smp.c
+++ b/os/arch/arm/src/amebasmart/amebasmart_smp.c
@@ -100,6 +100,8 @@ bool vPortGateOtherCore(void)
 		/* If there is a pause request, we should handle it first */
 		if (up_cpu_pausereq(up_cpu_index())) {
 			return false;
+		} else if (up_is_cpu_paused(ulCoreID)) {
+			break;
 		}
 	}
 	return true;


### PR DESCRIPTION
If this cpu has already been paused, then we
will not perform gating. However, we will set
the gating flag as if gating is performed. This
is because, the main intention of both gating and
pausing the cpu is to prevent the cpu from running. Since this is already handled and cpu is in pause state, we can perform critical opertion assuming gating is done. At a future point of time, the cpu will get resumed by the code which had initially paused it

NOTE: This only works for 2 cpu case, in case of more cpus, we need to redesign the pause and gating logic such that only the cpu or the task which called pause is allowed to call resume.