### PR TITLE
os/kernel/clock: Correct a typo in description

### DIFF
--- a/os/include/tinyara/clock.h
+++ b/os/include/tinyara/clock.h
@@ -344,7 +344,7 @@ int clock_systimespec(FAR struct timespec *ts);
  * Name: clock_getinittime
  *
  * Description:
- *   This function returns initalized system time.
+ *   This function returns initialized system time.
  *
  * Parameters:
  *   tp - Location to return the time

--- a/os/kernel/clock/clock_initialize.c
+++ b/os/kernel/clock/clock_initialize.c
@@ -232,7 +232,7 @@ static void initialize_system_time(void)
  * Name: clock_getinittime
  *
  * Description:
- *   This function returns initalized system time.
+ *   This function returns initialized system time.
  *
  * Parameters:
  *   tp - Location to return the time


### PR DESCRIPTION
Correct a tpyo in description
initalized -> initialized