### PR TITLE
os/arch/arm/src/amebasmart: reset timer to avoid stale ticks

### DIFF
--- a/os/arch/arm/src/amebasmart/amebasmart_timerisr.c
+++ b/os/arch/arm/src/amebasmart/amebasmart_timerisr.c
@@ -139,5 +139,6 @@ void up_timer_disable(void)
 
 void up_timer_enable(void)
 {
+  arm_arch_timer_set_compare(arm_arch_timer_count() + SYSTICK_RELOAD);
   arm_arch_timer_enable(1);
 }


### PR DESCRIPTION
When the timer is paused and started on other core due to a cpu pause/gate operation, the timer comparator needs to be re-initialized or additional ticks may be counted, causing observed time to be longer than expected

Before the fix is applied:
```
(10:12:23.294) TASH>><NUL>Hello, World!!
(10:12:29.211) smpgate 0 sleep
(10:12:29.277) smpgate 0 sleep
(10:12:29.277) 
(10:12:29.277) TASH>><NUL>argc: 3
(10:12:29.277) target cpu: 0
(10:12:29.277) sleep example on cpu0
(10:12:29.277) 
(10:12:29.277) START/BEFORE
(10:12:29.277) I am CPU0 --> Pausing CPU1
(10:12:29.277) I am CPU0 sleeping for 10s [t2]
(10:12:39.213) I am CPU0 finished sleep [t3]
(10:12:39.213) I am CPU0 --> Release CPU1 from pause
(10:12:39.236) 
(10:12:39.236) END/AFTER
(10:12:39.236) clock_gettime BEFORE: (1747872009 sec, 180000000 nsec)
(10:12:39.236) clock_gettime t2: (1747872009 sec, 180000000 nsec)
(10:12:39.236) clock_gettime t3: (1747872019 sec, 181000000 nsec)
(10:12:39.236) clock_gettime AFTER:  (1747872019 sec, 181000000 nsec)  // this set of reading is normal
(10:12:45.969) smpgate 1 sleep
(10:12:46.062) smpgate 1 sleep
(10:12:46.062) 
(10:12:46.062) TASH>><NUL>argc: 3
(10:12:46.062) target cpu: 1
(10:12:46.062) sleep example on cpu1
(10:12:46.062) 
(10:12:46.062) START/BEFORE
(10:12:46.062) I am CPU1 --> Pausing CPU0
(10:12:55.996) I am CPU1 sleeping for 10s [t2]
(10:12:55.996) I am CPU1 finished sleep [t3]
(10:12:56.006) I am CPU1 --> Release CPU0 from pause
(10:12:56.006) 
(10:12:56.006) END/AFTER
(10:12:56.006) clock_gettime BEFORE: (1747872025 sec, 939000000 nsec)
(10:12:56.006) clock_gettime t2: (1747872045 sec, 676000000 nsec)
(10:12:56.006) clock_gettime t3: (1747872055 sec, 677000000 nsec)
(10:12:56.006) clock_gettime AFTER:  (1747872055 sec, 677000000 nsec)  // this set of reading is faulty, BEFORE and AFTER shows 30s but only 10s should have passed
```

After the fix is applied:
```
(10:14:45.993) TASH>><NUL>Hello, World!!
(10:14:49.929) smpgate 0 sleep
(10:14:50.003) smpgate 0 sleep
(10:14:50.003) 
(10:14:50.003) TASH>><NUL>argc: 3
(10:14:50.003) target cpu: 0
(10:14:50.003) sleep example on cpu0
(10:14:50.003) 
(10:14:50.003) START/BEFORE
(10:14:50.003) I am CPU0 --> Pausing CPU1
(10:14:50.003) I am CPU0 sleeping for 10s [t2]
(10:14:59.931) I am CPU0 finished sleep [t3]
(10:14:59.931) I am CPU0 --> Release CPU1 from pause
(10:14:59.931) 
(10:14:59.931) END/AFTER
(10:14:59.931) clock_gettime BEFORE: (1747872004 sec, 159000000 nsec)
(10:14:59.944) clock_gettime t2: (1747872004 sec, 159000000 nsec)
(10:14:59.944) clock_gettime t3: (1747872014 sec, 160000000 nsec)
(10:14:59.944) clock_gettime AFTER:  (1747872014 sec, 160000000 nsec)
(10:15:02.475) smpgate 1 sleep
(10:15:02.566) smpgate 1 sleep
(10:15:02.566) 
(10:15:02.566) TASH>><NUL>argc: 3
(10:15:02.566) target cpu: 1
(10:15:02.566) sleep example on cpu1
(10:15:02.566) 
(10:15:02.566) START/BEFORE
(10:15:02.566) I am CPU1 --> Pausing CPU0
(10:15:12.491) I am CPU1 sleeping for 10s [t2]
(10:15:12.491) I am CPU1 finished sleep [t3]
(10:15:12.491) I am CPU1 --> Release CPU0 from pause
(10:15:12.491) 
(10:15:12.491) END/AFTER
(10:15:12.491) clock_gettime BEFORE: (1747872016 sec, 705000000 nsec)
(10:15:12.491) clock_gettime t2: (1747872016 sec, 705000000 nsec)
(10:15:12.491) clock_gettime t3: (1747872026 sec, 706000000 nsec)
(10:15:12.491) clock_gettime AFTER:  (1747872026 sec, 706000000 nsec)
```