### PR TITLE
os/pm: add pm_wakehandler to sleep ops

### DIFF
--- a/os/arch/arm/src/amebad/amebad_idle.c
+++ b/os/arch/arm/src/amebad/amebad_idle.c
@@ -106,7 +106,7 @@
  *
  ****************************************************************************/
 
-void up_pm_board_sleep(void (*wakeuphandler)(clock_t, pm_wakeup_reason_code_t))
+void up_pm_board_sleep()
 {
 	irqstate_t flags;
 	flags = irqsave();
@@ -114,7 +114,7 @@ void up_pm_board_sleep(void (*wakeuphandler)(clock_t, pm_wakeup_reason_code_t))
 	irqrestore(flags);
 }
 #else
-#define up_pm_board_sleep(wakeuphandler)
+#define up_pm_board_sleep()
 #endif
 /****************************************************************************
  * Name: up_idle

--- a/os/arch/arm/src/amebalite/amebalite_idle.c
+++ b/os/arch/arm/src/amebalite/amebalite_idle.c
@@ -106,7 +106,7 @@
  *
  ****************************************************************************/
 
-void up_pm_board_sleep(void (*wakeuphandler)(clock_t, pm_wakeup_reason_code_t))
+void up_pm_board_sleep()
 {
 	irqstate_t flags;
 	flags = irqsave();
@@ -114,7 +114,7 @@ void up_pm_board_sleep(void (*wakeuphandler)(clock_t, pm_wakeup_reason_code_t))
 	irqrestore(flags);
 }
 #else
-#define up_pm_board_sleep(wakeuphandler)
+#define up_pm_board_sleep()
 #endif
 /****************************************************************************
  * Name: up_idle

--- a/os/arch/arm/src/amebasmart/amebasmart_config.h
+++ b/os/arch/arm/src/amebasmart/amebasmart_config.h
@@ -51,8 +51,8 @@
 
 /* For power save */
 #ifdef CONFIG_PM
-extern void tizenrt_sleep_processing(void (*wakeuphandler)(clock_t, pm_wakeup_reason_code_t));
-#define config_SLEEP_PROCESSING( x )         		(tizenrt_sleep_processing( x ))
+extern void tizenrt_sleep_processing(clock_t *missing_tick, pm_wakeup_reason_code_t *wakeup_src);
+#define config_SLEEP_PROCESSING( x , y )         		(tizenrt_sleep_processing( x , y ))
 #endif
 
 /* Is there a serial console?  It could be on UART1-5 */

--- a/os/arch/arm/src/amebasmart/amebasmart_idle.c
+++ b/os/arch/arm/src/amebasmart/amebasmart_idle.c
@@ -66,14 +66,20 @@ struct pm_clock_ops rtl8730e_clock_ops = {
  *
  ****************************************************************************/
 
-void up_pm_board_sleep(void (*wakeuphandler)(clock_t, pm_wakeup_reason_code_t))
+void up_pm_board_sleep()
 {
 	/* mask sys tick interrupt*/
 	arm_arch_timer_int_mask(1);
 	up_timer_disable();
+
+	clock_t missing_tick;
+	pm_wakeup_reason_code_t wakeup_src;
 	/* Interrupt source will wake cpu up, just leave expected idle time as 0
 	Enter sleep mode for AP */
-	config_SLEEP_PROCESSING(wakeuphandler);
+	config_SLEEP_PROCESSING(&missing_tick, &wakeup_src);
+
+	rtl8730e_sleep_ops.wakehandler(missing_tick, wakeup_src);
+	
 	/* When wake from pg, arm timer has been reset, so a new compare value is necessary to
 	trigger an timer interrupt */
 	up_timer_enable();
@@ -82,7 +88,7 @@ void up_pm_board_sleep(void (*wakeuphandler)(clock_t, pm_wakeup_reason_code_t))
 	arm_arch_timer_int_mask(0);
 }
 #else
-#define up_pm_board_sleep(wakeuphandler)
+#define up_pm_board_sleep()
 #endif
 
 /****************************************************************************

--- a/os/arch/arm/src/imxrt/imxrt_idle.c
+++ b/os/arch/arm/src/imxrt/imxrt_idle.c
@@ -107,7 +107,7 @@
  *
  ****************************************************************************/
 
-void up_pm_board_sleep(void (*wakeuphandler)(clock_t, pm_wakeup_reason_code_t))
+void up_pm_board_sleep()
 {
 	irqstate_t flags;
 	flags = enter_critical_section();
@@ -116,7 +116,7 @@ void up_pm_board_sleep(void (*wakeuphandler)(clock_t, pm_wakeup_reason_code_t))
 	leave_critical_section(flags);
 }
 #else
-#define up_pm_board_sleep(wakeuphandler)
+#define up_pm_board_sleep()
 #endif
 
 /****************************************************************************

--- a/os/arch/arm/src/s5j/s5j_idle.c
+++ b/os/arch/arm/src/s5j/s5j_idle.c
@@ -93,7 +93,7 @@
  *
  ****************************************************************************/
 
-void up_pm_board_sleep(void (*wakeuphandler)(clock_t, pm_wakeup_reason_code_t))
+void up_pm_board_sleep()
 {
 	irqstate_t flags;
 	flags = irqsave();
@@ -102,7 +102,7 @@ void up_pm_board_sleep(void (*wakeuphandler)(clock_t, pm_wakeup_reason_code_t))
 	irqrestore(flags);
 }
 #else
-#define up_pm_board_sleep(wakeuphandler)
+#define up_pm_board_sleep()
 #endif
 
 /****************************************************************************

--- a/os/arch/arm/src/stm32/stm32_idle.c
+++ b/os/arch/arm/src/stm32/stm32_idle.c
@@ -110,7 +110,7 @@
  *
  ****************************************************************************/
 
-void up_pm_board_sleep(void (*wakeuphandler)(clock_t, pm_wakeup_reason_code_t))
+void up_pm_board_sleep()
 {
 	irqstate_t flags;
 	flags = irqsave();
@@ -119,7 +119,7 @@ void up_pm_board_sleep(void (*wakeuphandler)(clock_t, pm_wakeup_reason_code_t))
 	irqrestore(flags);
 }
 #else
-#define up_pm_board_sleep(wakeuphandler)
+#define up_pm_board_sleep()
 #endif
 
 /****************************************************************************

--- a/os/arch/arm/src/stm32h745/stm32h745_idle.c
+++ b/os/arch/arm/src/stm32h745/stm32h745_idle.c
@@ -91,12 +91,12 @@
  *
  ****************************************************************************/
 
-void up_pm_board_sleep(void (*wakeuphandler)(clock_t, pm_wakeup_reason_code_t))
+void up_pm_board_sleep()
 {
 
 }
 #else
-#define up_pm_board_sleep(wakeuphandler)
+#define up_pm_board_sleep()
 #endif
 
 /****************************************************************************

--- a/os/arch/arm/src/stm32l4/stm32l4_idle.c
+++ b/os/arch/arm/src/stm32l4/stm32l4_idle.c
@@ -147,7 +147,7 @@ void set_exti_button(void)
  *
  ****************************************************************************/
 
-void up_pm_board_sleep(void (*wakeuphandler)(clock_t, pm_wakeup_reason_code_t))
+void up_pm_board_sleep()
 {
 	irqstate_t flags;
 	flags = irqsave();
@@ -163,7 +163,7 @@ void up_pm_board_sleep(void (*wakeuphandler)(clock_t, pm_wakeup_reason_code_t))
 	irqrestore(flags);
 }
 #else
-#define up_pm_board_sleep(wakeuphandler)
+#define up_pm_board_sleep()
 #endif
 
 /****************************************************************************

--- a/os/board/rtl8730e/src/component/soc/amebad2/misc/ameba_tizenrt_pmu.h
+++ b/os/board/rtl8730e/src/component/soc/amebad2/misc/ameba_tizenrt_pmu.h
@@ -71,7 +71,7 @@ void pmu_unregister_sleep_callback(u32 nDeviceId);
 
 int tizenrt_ready_to_sleep(void);
 int tizenrt_ready_to_dsleep(void);
-void tizenrt_sleep_processing(void (*wakeuphandler)(clock_t, pm_wakeup_reason_code_t));
+void tizenrt_sleep_processing(clock_t *missing_tick, pm_wakeup_reason_code_t *wakeup_src);
 
 #ifndef CONFIG_PLATFORM_TIZENRT_OS
 void pmu_acquire_wakelock(uint32_t nDeviceId);

--- a/os/board/stm32f429i-disco/src/stm32_idle.c
+++ b/os/board/stm32f429i-disco/src/stm32_idle.c
@@ -127,7 +127,7 @@
  *
  ****************************************************************************/
 
-void up_pm_board_sleep(void (*wakeuphandler)(clock_t, pm_wakeup_reason_code_t))
+void up_pm_board_sleep()
 {
 	irqstate_t flags;
 	flags = irqsave();

--- a/os/include/tinyara/arch.h
+++ b/os/include/tinyara/arch.h
@@ -2295,7 +2295,7 @@ int up_rtc_settime(FAR const struct timespec *tp);
  *
  ****************************************************************************/
 
-void up_pm_board_sleep(void (*wakeuphandler)(clock_t, pm_wakeup_reason_code_t));
+void up_pm_board_sleep();
 
 /****************************************************************************
  * Name: up_set_dvfs

--- a/os/include/tinyara/pm/pm.h
+++ b/os/include/tinyara/pm/pm.h
@@ -277,8 +277,9 @@ struct pm_callback_s {
  */
 
 struct pm_sleep_ops {
-	void (*sleep)(pm_wakehandler_t handler);
+	void (*sleep)(void);
 	void (*set_timer)(unsigned int delay_us);
+	void (*wakehandler)(clock_t missing_tick, pm_wakeup_reason_code_t wakeup_src);
 };
 
 /*

--- a/os/pm/pm_idle.c
+++ b/os/pm/pm_idle.c
@@ -180,7 +180,7 @@ void pm_idle(void)
 			g_pmglobals.sleep_ops->set_timer(TICK2USEC(delay));
 		}
 #endif
-		g_pmglobals.sleep_ops->sleep(pm_wakehandler);
+		g_pmglobals.sleep_ops->sleep();
 		stime = clock_systimer();
 	}
 EXIT:

--- a/os/pm/pm_initialize.c
+++ b/os/pm/pm_initialize.c
@@ -127,6 +127,7 @@ void pm_initialize(struct pm_sleep_ops *sleep_ops)
 
 	/* Register the PM ops structures */
 	g_pmglobals.sleep_ops = sleep_ops;
+	g_pmglobals.sleep_ops->wakehandler = pm_wakehandler;
 
 	/* Register Special Domains, which are specific to Kernel*/
 	DEBUGASSERT(pm_domain_register("IDLE") == PM_IDLE_DOMAIN);


### PR DESCRIPTION
This commit adds pm_wakehandler api to sleep ops structure of PM. Previously pm_wakehandler was passed as a functional pointer to bsp sleep api. But now it is added as a parameter for sleep ops structure.