### PR TITLE
os/arch/arm/src/amebasmart: fix race condition in systick ISR when PM

### DIFF
--- a/os/arch/arm/src/amebasmart/amebasmart_timerisr.c
+++ b/os/arch/arm/src/amebasmart/amebasmart_timerisr.c
@@ -34,6 +34,7 @@
 #include "up_internal.h"
 #include "gic.h"
 #include "arch_timer.h"
+#include "barriers.h"
 
 /*----------------------------------------------------------------------------
   Clock Variable definitions
@@ -59,6 +60,29 @@
 #if SYSTICK_RELOAD > 0x00ffffff
 #  error SYSTICK_RELOAD exceeds the range of the RELOAD register
 #endif
+
+#ifdef CONFIG_SMP
+static volatile u8 systimer_status[CONFIG_SMP_NCPUS];
+
+void up_systimer_pause(u8 cpu)
+{
+  systimer_status[cpu] = 1;
+  ARM_DSB();
+}
+
+void up_systimer_resume(u8 cpu)
+{
+  systimer_status[cpu] = 0;
+  ARM_DSB();
+}
+
+u8 up_systimer_is_paused(u8 cpu)
+{
+  return systimer_status[cpu];
+}
+#endif
+
+void up_timer_disable(void);
 
 /****************************************************************************
  * Private Functions
@@ -91,6 +115,24 @@ int up_timerisr(int irq, uint32_t *regs)
 	  delta_ticks = 1;
 #endif
 
+
+#ifdef CONFIG_SMP
+    /* 
+       If this CPU is about to be hotplugged and a tick ISR is still triggering, prevent it from entering any critical sections.
+       
+       A deadlock condition may otherwise occur when pm_idle is processing and has entered critical section on CPU0
+       but when CPU1 tick ISR fires during this time, the scheduler processing loop (sched_process_timer())
+       tries to acquire a spinlock and fails
+
+       This behavior is easily reproducible when performing many HW TIMER sleeps in sequence (e.g LCD) and may be
+       classified as a race condition, since there are often several sleep-wakeup successful iterations before deadlock happens
+    */
+    if (up_systimer_is_paused(up_cpu_index())) {
+      up_timer_disable();
+      goto skip_sched;
+    }
+#endif
+
     u32 ticks_to_process = delta_ticks;
     while (ticks_to_process > 0) {
       /* process missing ticks */
@@ -98,6 +140,7 @@ int up_timerisr(int irq, uint32_t *regs)
       ticks_to_process--;
     }
 
+skip_sched:
     arm_arch_timer_set_compare(last_cycle + delta_ticks * SYSTICK_RELOAD);
     return 0;
 }
@@ -123,9 +166,16 @@ void up_timer_initialize(void)
   /* Attach the timer interrupt vector */
   irq_attach(ARM_ARCH_TIMER_IRQ, (xcpt_t)up_timerisr, NULL);
 
-  //arm_arch_timer_count
-	arm_arch_timer_set_compare(arm_arch_timer_count() + SYSTICK_RELOAD);
-	arm_arch_timer_enable(1);
+#ifdef CONFIG_SMP
+  /* reset the hotplug status bit on startup */
+  up_systimer_resume(up_cpu_index());
+#endif
+
+  /* Only enable the timer for CPU0 on startup, CPU1's will be enabled when pause/gating takes place  */
+  if (up_cpu_index() == 0) {
+    arm_arch_timer_set_compare(arm_arch_timer_count() + SYSTICK_RELOAD);
+    arm_arch_timer_enable(1);
+  }
 
   /* And enable the timer interrupt at the GIC */
   up_prioritize_irq(ARM_ARCH_TIMER_IRQ, 224);

--- a/os/arch/arm/src/armv7-a/arm_cpuhotplug.c
+++ b/os/arch/arm/src/armv7-a/arm_cpuhotplug.c
@@ -130,6 +130,9 @@ void up_cpu_hotplug(int cpu)
 {
 	DEBUGASSERT(cpu >= 0 && cpu < CONFIG_SMP_NCPUS && cpu != this_cpu());
 
+	/* Ensure that hotplug target CPU's systick PPI stops firing to prevent deadlock condition */
+	up_systimer_pause(cpu);
+
 	/* Fire SGI for cpu to enter hotplug */
 	arm_cpu_sgi(GIC_IRQ_SGI4, (1 << cpu));
 }


### PR DESCRIPTION
During PM, there is a race condition where pm is about to hotplug other CPU in critical section and then other CPU tick ISR triggers. Due to sched_process_loop in the tick ISR, it may re-enter critical section and acquire a spinlock that will never be released in this state

This commit adds a flag to let the target CPU disable its own timer and prevent further tick ISRs from entering scheduler loop when hotplug is about to fire. Because hotplug is effectively turning CPU offline, the PM resume boot flow will re-enable the timer and then lost ticks will be compensated.

This commit addresses the hang issue for #6826 for gating removal in pm_idle