### PR TITLE
rtl8730/i2s : do not set watch dog as a null when i2s_suspend called

### DIFF
--- a/os/arch/arm/src/amebasmart/amebasmart_i2s.c
+++ b/os/arch/arm/src/amebasmart/amebasmart_i2s.c
@@ -1908,13 +1908,11 @@ static void amebasmart_i2s_suspend(uint16_t port)
 #if defined(I2S_HAVE_RX) && (0 < I2S_HAVE_RX)
 	if (priv->rx.dog) {
 		wd_cancel(priv->rx.dog);
-		priv->rx.dog = NULL;
 	}
 #endif
 #if defined(I2S_HAVE_TX) && (0 < I2S_HAVE_TX)
 	if (priv->tx.dog) {
 		wd_cancel(priv->tx.dog);
-		priv->tx.dog = NULL;
 	}
 #endif
 


### PR DESCRIPTION
i2s driver allocate wd when it initialized. Hence it should not set as null even if suspend called.