### PR TITLE
os/binfmt: Fix code to remove warning message during build

### DIFF
--- a/os/binfmt/binfmt_unloadmodule.c
+++ b/os/binfmt/binfmt_unloadmodule.c
@@ -135,7 +135,9 @@ static inline int exec_dtors(FAR struct binary_s *binp)
 int unload_module(FAR struct binary_s *binp)
 {
 	int ret;
+#ifdef CONFIG_OPTIMIZE_APP_RELOAD_TIME
 	int section_idx;
+#endif
 
 	if (binp) {
 		/* Perform any format-specific unload operations */


### PR DESCRIPTION
This commit updates binfmt/binfmt_unloadmodule.c file to remove warning message during build. Follwing is the logs during build before this changes:

binfmt_unloadmodule.c: In function 'unload_module': binfmt_unloadmodule.c:138:6: warning: unused variable 'section_idx' [-Wunused-variable]
  138 |  int section_idx;
      |      ^~~~~~~~~~~