### PR TITLE
apps/examples/testcase/le_tc/kernel: Fix failing kernel testcases

### DIFF
--- a/apps/examples/testcase/le_tc/kernel/tc_pthread.c
+++ b/apps/examples/testcase/le_tc/kernel/tc_pthread.c
@@ -1627,25 +1627,21 @@ static void tc_pthread_set_get_affinity(void)
 	TC_ASSERT_EQ("pthread_attr_init", ret_chk, OK);
 	attr.affinity = affinity;
 
-#ifdef CONFIG_SMP
 	ret_chk = pthread_create(&pthread, &attr, self_pthread_join_n_exit, NULL);
 	TC_ASSERT_EQ("pthread create", ret_chk, OK);
+#ifdef CONFIG_SMP
 	TC_ASSERT_EQ("pthread_setaffinity_np", pthread_setaffinity_np(pthread, sizeof(attr.affinity), &affinity), OK);
 	affinity = 0;
 	TC_ASSERT_EQ("pthread_getaffinity_np", pthread_getaffinity_np(pthread, sizeof(attr.affinity), &affinity), OK);
 	TC_ASSERT_EQ("pthread_getaffinity_np", affinity, (1 << 0));
-	ret_chk = pthread_join(pthread, &p_value);
-	TC_ASSERT_EQ("pthread_join", ret_chk, OK);
 #else
-	ret_chk = pthread_create(&pthread, &attr, self_pthread_join_n_exit, NULL);
-	TC_ASSERT_EQ("pthread create", ret_chk, EINVAL);
 	ret_chk = pthread_create(&pthread, NULL, self_pthread_join_n_exit, NULL);
 	TC_ASSERT_EQ("pthread create", ret_chk, OK);
 	TC_ASSERT_EQ("pthread_setaffinity_np", pthread_setaffinity_np(pthread, sizeof(attr.affinity), &affinity), EINVAL);
 	TC_ASSERT_EQ("pthread_getaffinity_np", pthread_getaffinity_np(pthread, sizeof(attr.affinity), &affinity), 0);
+#endif
 	ret_chk = pthread_join(pthread, &p_value);
 	TC_ASSERT_EQ("pthread_join", ret_chk, OK);
-#endif
 
 	TC_SUCCESS_RESULT();
 }


### PR DESCRIPTION
On running kernel_tc following testcases are failing- [tc_pthread_set_get_affinity] FAIL [Line : 1641] pthread create : Values (ret_chk == 0x0) and (22 == 0x16) are not equal [tc_task_task_restart] FAIL [Line : 292] task_restart : Values (ret_chk == 0xffffffff) and (0 == 0x0) are not equal [tc_task_task_reparent] FAIL [Line : 531] task_reparent : Values (tc_reparent_chk == 0x2) and (0 == 0x0) are not equal [tc_libc_signal_sigwait] FAIL [Line : 425] waitpid : Values (recv_ret == 0xffffffff) and (ERROR == 0xffffffff) are equal