### PR TITLE
os/board/rtl8730e: print connection fail reason code for wifi sta mode

### DIFF
--- a/os/board/rtl8730e/src/component/wifi/api/wifi_ind.c
+++ b/os/board/rtl8730e/src/component/wifi/api/wifi_ind.c
@@ -28,6 +28,7 @@ extern write_fast_connect_info_ptr p_store_fast_connect_info;
 extern rtw_joinstatus_callback_t p_wifi_joinstatus_user_callback;
 extern rtw_join_status_t rtw_join_status;
 extern rtw_join_status_t prev_join_status;
+extern rtw_join_status_t last_join_status;
 extern internal_join_block_param_t *join_block_param;
 
 //----------------------------------------------------------------------------//
@@ -168,7 +169,12 @@ void wifi_join_status_indicate(rtw_join_status_t join_status)
 		rtw_mfree((u8 *)deauth_data_pre, 0);
 #endif
 	}
+#ifdef CONFIG_PLATFORM_TIZENRT_OS
+	if (join_status != RTW_JOINSTATUS_FAIL && join_status != RTW_JOINSTATUS_DISCONNECT) {
+		last_join_status = join_status;
+	}
 	prev_join_status = rtw_join_status;
+#endif //#ifdef CONFIG_PLATFORM_TIZENRT_OS
 	rtw_join_status = join_status;
 
 	/* step 2: execute user callback to process join_status*/

--- a/os/board/rtl8730e/src/component/wifi/driver/include/wifi_intf_drv_to_upper.h
+++ b/os/board/rtl8730e/src/component/wifi/driver/include/wifi_intf_drv_to_upper.h
@@ -48,6 +48,12 @@ typedef enum {
 	RTW_CONNECT_FAIL,  /**< connect fail*/
 	RTW_DHCP_FAIL,        /**< dhcp fail*/
 	RTW_UNKNOWN,         /**< unknown*/
+#ifdef CONFIG_PLATFORM_TIZENRT_OS
+	RTW_BCN_LOST,         /**< No beacon for a long time*/
+	RTW_DISCONNECT,         /**< Received deauth packet*/
+	RTW_MAX_STA,            /**< maximum number of station reached */
+	RTW_AP_BUSY,            /**< AP busy */
+#endif //#ifdef CONFIG_PLATFORM_TIZENRT_OS
 } rtw_connect_error_flag_t;
 
 enum WIFI_INDICATE_MODE {

--- a/os/board/rtl8730e/src/component/wifi/inic/inic_ipc_host_api_basic.c
+++ b/os/board/rtl8730e/src/component/wifi/inic/inic_ipc_host_api_basic.c
@@ -41,6 +41,7 @@ void (*promisc_user_callback_ptr)(void *) = NULL;
 extern void *param_indicator;
 rtw_join_status_t rtw_join_status;
 rtw_join_status_t prev_join_status;
+rtw_join_status_t last_join_status;
 rtw_joinstatus_callback_t p_wifi_joinstatus_user_callback = NULL;
 rtw_joinstatus_callback_t p_wifi_joinstatus_internal_callback = NULL;
 
@@ -56,6 +57,7 @@ extern void wifi_set_user_config(void);
 
 #if CONFIG_WLAN
 #if defined(CONFIG_PLATFORM_TIZENRT_OS)
+#include "wifi_intf_drv_to_upper.h"
 #include "rtk_wifi_utils.h"
 unsigned char ap_bssid[ETH_ALEN];
 rtk_network_link_callback_t g_link_up = NULL;
@@ -131,6 +133,37 @@ static void wifi_disconn_hdl(char *buf, int buf_len, int flags, void *userdata)
 		key_mgmt = *(u32*)(buf+8);
 	}
 #if defined(CONFIG_PLATFORM_TIZENRT_OS)
+	rtw_connect_error_flag_t error_flag = RTW_NO_ERROR;
+	rtw_join_status_t join_status = wifi_get_join_status();
+
+	if (join_status == RTW_JOINSTATUS_FAIL) {
+		if (last_join_status == RTW_JOINSTATUS_SCANNING) {
+			error_flag = RTW_NONE_NETWORK;
+		} else if (last_join_status == RTW_JOINSTATUS_AUTHENTICATING) {
+			if (deauth_reason == WLAN_STATUS_AP_UNABLE_TO_HANDLE_NEW_STA) {
+				error_flag = RTW_MAX_STA;
+			} else {
+				error_flag = RTW_AUTH_FAIL;
+			}
+		} else if (last_join_status == RTW_JOINSTATUS_AUTHENTICATED || last_join_status == RTW_JOINSTATUS_ASSOCIATING) {
+			error_flag = RTW_ASSOC_FAIL;
+		} else if (last_join_status == RTW_JOINSTATUS_ASSOCIATED || last_join_status == RTW_JOINSTATUS_4WAY_HANDSHAKING) {
+			if (deauth_reason == WLAN_REASON_DISASSOC_AP_BUSY) {
+				error_flag = RTW_AP_BUSY;
+			} else {
+				error_flag = RTW_4WAY_HANDSHAKE_TIMEOUT;
+			}
+		}
+		printf("Connection failed, deauth_reason=%d\n", deauth_reason);
+	} else if (join_status == RTW_JOINSTATUS_DISCONNECT) {
+		if (deauth_reason == WLAN_REASON_EXPIRATION_CHK) {
+			error_flag = RTW_BCN_LOST;
+		} else {
+			error_flag = RTW_DISCONNECT;
+		}
+		printf("Disconnected, deauth_reason=%d\n", deauth_reason);
+	}
+
 	rtk_reason_t reason;
 	memset(&reason, 0, sizeof(rtk_reason_t));
 	reason.if_id = RTK_WIFI_STATION_IF;


### PR DESCRIPTION
- wifi_disconn_hdl will set error_flag based on join status failure

Co-authored-by: jwei5 <48531347+jwei5@users.noreply.github.com>