### PR TITLE
os/mm : Replace ARCH_GET_RET_ADDRESS api with __builtin_return_address api for debugging purpose

### DIFF
--- a/os/.download
+++ b/os/.download
@@ -1,0 +1,1 @@
+PREV_PORT=ttyUSB1

--- a/os/app_size_file
+++ b/os/app_size_file
@@ -1,0 +1,2 @@
+   text	   data	    bss	    dec	    hex	filename
+ 334631	    974	   7864	 343469	  53dad	../build/output/bin/common

--- a/os/kernel/semaphore/sem_post.c
+++ b/os/kernel/semaphore/sem_post.c
@@ -201,7 +201,7 @@ int sem_post(FAR sem_t *sem)
 	irqstate_t saved_state;
 	int ret = ERROR;
 	size_t caller_retaddr = 0;
-	ARCH_GET_RET_ADDRESS(caller_retaddr);
+	caller_retaddr = (mmaddress_t)__builtin_return_address(0);
 
 	/* Make sure we were supplied with a valid semaphore. */
 

--- a/os/mm/kmm_heap/kmm_calloc.c
+++ b/os/mm/kmm_heap/kmm_calloc.c
@@ -112,14 +112,15 @@ static void *kheap_calloc(size_t n, size_t elem_size)
  *   The address of the allocated memory (NULL on failure to allocate)
  *
  ************************************************************************/
-#if CONFIG_KMM_NHEAPS > 1
+
+ #if CONFIG_KMM_NHEAPS > 1
 void *kmm_calloc_at(int heap_index, size_t n, size_t elem_size)
 {
 	void *ret;
 	struct mm_heap_s *kheap;
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
 	mmaddress_t caller_retaddr = 0;
-	ARCH_GET_RET_ADDRESS(caller_retaddr)
+	caller_retaddr = (mmaddress_t)__builtin_return_address(0);
 #endif
 	if (heap_index > HEAP_END_IDX || heap_index < HEAP_START_IDX) {
 		mdbg("kmm_calloc_at failed. Wrong heap index (%d) of (%d)\n", heap_index, HEAP_END_IDX);
@@ -162,7 +163,7 @@ FAR void *kmm_calloc(size_t n, size_t elem_size)
 	}
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
 	mmaddress_t caller_retaddr = 0;
-	ARCH_GET_RET_ADDRESS(caller_retaddr)
+	caller_retaddr = (mmaddress_t)__builtin_return_address(0);
 #endif
 	return kheap_calloc(n, elem_size
 #ifdef CONFIG_DEBUG_MM_HEAPINFO

--- a/os/mm/kmm_heap/kmm_malloc.c
+++ b/os/mm/kmm_heap/kmm_malloc.c
@@ -128,14 +128,15 @@ static void *kheap_malloc(size_t size)
  *   The address of the allocated memory (NULL on failure to allocate)
  *
  ************************************************************************/
-#if CONFIG_KMM_NHEAPS > 1
+
+ #if CONFIG_KMM_NHEAPS > 1
 void *kmm_malloc_at(int heap_index, size_t size)
 {
 	void *ret;
 	struct mm_heap_s *kheap;
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
 	mmaddress_t caller_retaddr = 0;
-	ARCH_GET_RET_ADDRESS(caller_retaddr)
+	caller_retaddr = (mmaddress_t)__builtin_return_address(0);
 #endif
 	if (heap_index > HEAP_END_IDX || heap_index < HEAP_START_IDX) {
 		mdbg("kmm_malloc_at failed. Wrong heap index (%d) of (%d)\n", heap_index, HEAP_END_IDX);
@@ -181,11 +182,13 @@ FAR void *kmm_malloc(size_t size)
 {
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
 	mmaddress_t caller_retaddr = 0;
-	ARCH_GET_RET_ADDRESS(caller_retaddr)
-#endif
+	caller_retaddr = (mmaddress_t)__builtin_return_address(0);	
+ #endif
 	if (size == 0) {
 		return NULL;
 	}
+
+
 
 	return kheap_malloc(size
 #ifdef CONFIG_DEBUG_MM_HEAPINFO

--- a/os/mm/kmm_heap/kmm_memalign.c
+++ b/os/mm/kmm_heap/kmm_memalign.c
@@ -87,14 +87,14 @@
  *   The address of the allocated memory (NULL on failure to allocate)
  *
  ************************************************************************/
-#if CONFIG_KMM_NHEAPS > 1
+ #if CONFIG_KMM_NHEAPS > 1
 void *kmm_memalign_at(int heap_index, size_t alignment, size_t size)
 {
 	void *ret;
 	struct mm_heap_s *kheap;
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
 	mmaddress_t caller_retaddr = 0;
-	ARCH_GET_RET_ADDRESS(caller_retaddr)
+	caller_retaddr = (mmaddress_t)__builtin_return_address(0);
 #endif
 	if (heap_index > HEAP_END_IDX || heap_index < HEAP_START_IDX) {
 		mdbg("kmm_memalign_at failed. Wrong heap index (%d) of (%d)\n", heap_index, HEAP_END_IDX);
@@ -147,7 +147,7 @@ FAR void *kmm_memalign(size_t alignment, size_t size)
 	}
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
 	mmaddress_t caller_retaddr = 0;
-	ARCH_GET_RET_ADDRESS(caller_retaddr)
+	caller_retaddr = (mmaddress_t)__builtin_return_address(0);
 #endif
 	struct mm_heap_s *kheap = kmm_get_baseheap();
 	for (kheap_idx = HEAP_START_IDX; kheap_idx <= HEAP_END_IDX; kheap_idx++) {

--- a/os/mm/kmm_heap/kmm_realloc.c
+++ b/os/mm/kmm_heap/kmm_realloc.c
@@ -84,14 +84,15 @@
  *   The address of the allocated memory (NULL on failure to allocate)
  *
  ************************************************************************/
-#if CONFIG_KMM_NHEAPS > 1
+
+ #if CONFIG_KMM_NHEAPS > 1
 void *kmm_realloc_at(int heap_index, void *oldmem, size_t size)
 {
 	void *ret;
 	struct mm_heap_s *kheap;
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
 	mmaddress_t caller_retaddr = 0;
-	ARCH_GET_RET_ADDRESS(caller_retaddr)
+	caller_retaddr = (mmaddress_t)__builtin_return_address(0);
 #endif
 	if (heap_index > HEAP_END_IDX || heap_index < HEAP_START_IDX) {
 		mdbg("kmm_realloc_at failed. Wrong heap index (%d) of (%d)\n", heap_index, HEAP_END_IDX);
@@ -142,7 +143,7 @@ FAR void *kmm_realloc(FAR void *oldmem, size_t newsize)
 	int kheap_idx;
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
 	mmaddress_t caller_retaddr = 0;
-	ARCH_GET_RET_ADDRESS(caller_retaddr)
+	caller_retaddr = (mmaddress_t)__builtin_return_address(0);
 #endif
 	struct mm_heap_s *kheap_origin;
 	struct mm_heap_s *kheap_new;

--- a/os/mm/kmm_heap/kmm_zalloc.c
+++ b/os/mm/kmm_heap/kmm_zalloc.c
@@ -80,14 +80,15 @@
  *   The address of the allocated memory (NULL on failure to allocate)
  *
  ************************************************************************/
-#if CONFIG_KMM_NHEAPS > 1
+
+ #if CONFIG_KMM_NHEAPS > 1
 void *kmm_zalloc_at(int heap_index, size_t size)
 {
 	void *ret;
 	struct mm_heap_s *kheap;
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
 	mmaddress_t caller_retaddr = 0;
-	ARCH_GET_RET_ADDRESS(caller_retaddr)
+	caller_retaddr = (mmaddress_t)__builtin_return_address(0);
 #endif
 	if (heap_index > HEAP_END_IDX || heap_index < HEAP_START_IDX) {
 		mdbg("kmm_zalloc_at failed. Wrong heap index (%d) of (%d)\n", heap_index, HEAP_END_IDX);
@@ -135,7 +136,7 @@ FAR void *kmm_zalloc(size_t size)
 	int kheap_idx;
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
 	mmaddress_t caller_retaddr = 0;
-	ARCH_GET_RET_ADDRESS(caller_retaddr)
+	caller_retaddr = (mmaddress_t)__builtin_return_address(0);
 #endif
 	if (size == 0) {
 		return NULL;

--- a/os/mm/umm_heap/umm_calloc.c
+++ b/os/mm/umm_heap/umm_calloc.c
@@ -79,14 +79,13 @@
  *   The address of the allocated memory (NULL on failure to allocate)
  *
  ************************************************************************/
-
 #if CONFIG_KMM_NHEAPS > 1
 void *calloc_at(int heap_index, size_t n, size_t elem_size)
-{
+{ 	
 	void *ret;
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
 	mmaddress_t caller_retaddr = 0;
-	ARCH_GET_RET_ADDRESS(caller_retaddr)
+	caller_retaddr = (mmaddress_t)__builtin_return_address(0);
 #endif
 	if (heap_index > HEAP_END_IDX || heap_index < 0) {
 		mdbg("calloc_at failed. Wrong heap index (%d) of (%d)\n", heap_index, HEAP_END_IDX);
@@ -171,7 +170,7 @@ FAR void *calloc(size_t n, size_t elem_size)
 
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
 	mmaddress_t caller_retaddr = 0;
-	ARCH_GET_RET_ADDRESS(caller_retaddr)
+	caller_retaddr = (mmaddress_t)__builtin_return_address(0);
 #endif
 
 	if (n == 0 || elem_size == 0) {

--- a/os/mm/umm_heap/umm_malloc.c
+++ b/os/mm/umm_heap/umm_malloc.c
@@ -101,13 +101,13 @@
  *
  ************************************************************************/
 
-#if CONFIG_KMM_NHEAPS > 1
+ #if CONFIG_KMM_NHEAPS > 1
 void *malloc_at(int heap_index, size_t size)
 {
 	void *ret;
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
 	mmaddress_t caller_retaddr = 0;
-	ARCH_GET_RET_ADDRESS(caller_retaddr)
+	caller_retaddr = (mmaddress_t)__builtin_return_address(0);	
 #endif
 	if (heap_index > HEAP_END_IDX || heap_index < HEAP_START_IDX) {
 		mdbg("malloc_at failed. Wrong heap index (%d) of (%d)\n", heap_index, HEAP_END_IDX);
@@ -231,7 +231,7 @@ FAR void *malloc(size_t size)
 
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
 	mmaddress_t caller_retaddr = 0;
-	ARCH_GET_RET_ADDRESS(caller_retaddr)
+	caller_retaddr = (mmaddress_t)__builtin_return_address(0);
 #endif
 
 #ifdef CONFIG_APP_BINARY_SEPARATION

--- a/os/mm/umm_heap/umm_memalign.c
+++ b/os/mm/umm_heap/umm_memalign.c
@@ -83,14 +83,13 @@
  *   The address of the allocated memory (NULL on failure to allocate)
  *
  ************************************************************************/
-
-#if CONFIG_KMM_NHEAPS > 1
+ #if CONFIG_KMM_NHEAPS > 1
 void *memalign_at(int heap_index, size_t alignment, size_t size)
 {
 	void *ret;
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
 	mmaddress_t caller_retaddr = 0;
-	ARCH_GET_RET_ADDRESS(caller_retaddr)
+	caller_retaddr = (mmaddress_t)__builtin_return_address(0);
 #endif
 	if (heap_index > HEAP_END_IDX || heap_index < HEAP_START_IDX) {
 		mdbg("memalign_at failed. Wrong heap index (%d) of (%d)\n", heap_index, HEAP_END_IDX);
@@ -142,7 +141,7 @@ FAR void *memalign(size_t alignment, size_t size)
 	}
 
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
-	ARCH_GET_RET_ADDRESS(caller_retaddr)
+	caller_retaddr = (mmaddress_t)__builtin_return_address(0);
 #endif
 #ifdef CONFIG_APP_BINARY_SEPARATION
 	/* User supports a single heap on app separation */

--- a/os/mm/umm_heap/umm_realloc.c
+++ b/os/mm/umm_heap/umm_realloc.c
@@ -83,15 +83,13 @@
  *   The address of the allocated memory (NULL on failure to allocate)
  *
  ************************************************************************/
-
 #if CONFIG_KMM_NHEAPS > 1
 void *realloc_at(int heap_index, void *oldmem, size_t size)
 {
 	void *ret;
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
 	mmaddress_t caller_retaddr = 0;
-
-	ARCH_GET_RET_ADDRESS(caller_retaddr)
+	caller_retaddr = (mmaddress_t)__builtin_return_address(0);
 #endif
 
 	if (heap_index > HEAP_END_IDX || heap_index < HEAP_START_IDX) {
@@ -143,8 +141,7 @@ FAR void *realloc(FAR void *oldmem, size_t size)
 	void *ret;
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
 	mmaddress_t caller_retaddr = 0;
-
-	ARCH_GET_RET_ADDRESS(caller_retaddr)
+	caller_retaddr = (mmaddress_t)__builtin_return_address(0);
 #endif
 
 #ifdef CONFIG_APP_BINARY_SEPARATION

--- a/os/mm/umm_heap/umm_xalloc_user_at.c
+++ b/os/mm/umm_heap/umm_xalloc_user_at.c
@@ -44,7 +44,7 @@ void *calloc_user_at(struct mm_heap_s *heap, size_t n, size_t elem_size)
 	}
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
 	mmaddress_t caller_retaddr;
-	ARCH_GET_RET_ADDRESS(caller_retaddr)	
+	builtin_retaddr = (mmaddress_t)__builtin_return_address(0);
 	return mm_calloc(heap, n, elem_size, caller_retaddr);
 #else
 	return mm_calloc(heap, n, elem_size);
@@ -66,8 +66,8 @@ void *memalign_user_at(struct mm_heap_s *heap, size_t alignment, size_t size)
 		return NULL;
 	}
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
-	mmaddress_t caller_retaddr;
-	ARCH_GET_RET_ADDRESS(caller_retaddr)	
+	mmaddress_t caller_retaddr=0;
+	caller_retaddr = (mmaddress_t)__builtin_return_address(0);
 	return mm_memalign(heap, alignment, size, caller_retaddr);
 #else
 	return mm_memalign(heap, alignment, size);
@@ -97,7 +97,7 @@ void *malloc_user_at(struct mm_heap_s *heap, size_t size)
 	}
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
 	mmaddress_t caller_retaddr = 0;
-	ARCH_GET_RET_ADDRESS(caller_retaddr)	
+	caller_retaddr = (mmaddress_t)__builtin_return_address(0);
 	return mm_malloc(heap, size, caller_retaddr);
 #else
 	return mm_malloc(heap, size);
@@ -117,12 +117,13 @@ void *realloc_user_at(struct mm_heap_s *heap, void *oldmem, size_t newsize)
 {
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
 	mmaddress_t caller_retaddr = 0;
-	ARCH_GET_RET_ADDRESS(caller_retaddr)
+	caller_retaddr = (mmaddress_t)__builtin_return_address(0);
 #endif
 	if (newsize == 0) {
 		free_user_at(heap, oldmem);
 		return NULL;
 	}
+
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
 	return mm_realloc(heap, oldmem, newsize, caller_retaddr);
 #else
@@ -146,9 +147,10 @@ void *zalloc_user_at(struct mm_heap_s *heap, size_t size)
 	}
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
 	mmaddress_t caller_retaddr = 0;
-	ARCH_GET_RET_ADDRESS(caller_retaddr)	
+	caller_retaddr = (mmaddress_t)__builtin_return_address(0);
 	return mm_zalloc(heap, size, caller_retaddr);
 #else
 	return mm_zalloc(heap, size);
 #endif
+
 }

--- a/os/mm/umm_heap/umm_zalloc.c
+++ b/os/mm/umm_heap/umm_zalloc.c
@@ -80,14 +80,13 @@
  *   The address of the allocated memory (NULL on failure to allocate)
  *
  ************************************************************************/
-
 #if CONFIG_KMM_NHEAPS > 1
 void *zalloc_at(int heap_index, size_t size)
 {
 	void *ret;
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
 	mmaddress_t caller_retaddr = 0;
-	ARCH_GET_RET_ADDRESS(caller_retaddr)
+	caller_retaddr = (mmaddress_t)__builtin_return_address(0);
 #endif
 	if (heap_index > HEAP_END_IDX || heap_index < HEAP_START_IDX) {
 		mdbg("zalloc_at failed. Wrong heap index (%d) of (%d)\n", heap_index, HEAP_END_IDX);
@@ -177,12 +176,14 @@ FAR void *zalloc(size_t size)
 {
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
 	mmaddress_t caller_retaddr = 0;
-	ARCH_GET_RET_ADDRESS(caller_retaddr)
+	caller_retaddr = (mmaddress_t)__builtin_return_address(0);
 #endif
 
 	if (size == 0) {
 		return NULL;
 	}
+
+
 #ifdef CONFIG_ARCH_ADDRENV
 	/* Use malloc() because it implements the sbrk() logic */
 


### PR DESCRIPTION
Replaces ARCH_GET_RET_ADDRESS api with __builtin_return_address api with level zero returning the address for current function.