### PR TITLE
external/libcxx-test: Update Kconfig to make libcxx-test available in loadable builds.

### DIFF
--- a/external/libcxx-test/Kconfig
+++ b/external/libcxx-test/Kconfig
@@ -7,7 +7,7 @@ config LIBCXX_UTC
 	bool "Unit Test for LLVM Libc++"
 	default n
 	depends on LIBCXX
-	depends on HAVE_CXXINITIALIZE
+	depends on HAVE_CXXINITIALIZE || BINFMT_CONSTRUCTORS
 	---help---
 		Enables unit test for LLVM Libc++.
 


### PR DESCRIPTION
To enable libcxx-test(C++) in different build configurations:
- For flat builds: CONFIG_HAVE_CXXINITIALIZE must be enabled
- For loadable builds: CONFIG_BINFMT_CONSTRUCTORS must be enabled

This change modifies the Kconfig to make libcxx-test available when CONFIG_BINFMT_CONSTRUCTORS is enabled in loadable builds.