### PR TITLE
external/libcxx-test: Fix build issue in C++14

### DIFF
--- a/external/libcxx-test/std/containers/associative/map/map.modifiers/erase_iter.pass.cpp
+++ b/external/libcxx-test/std/containers/associative/map/map.modifiers/erase_iter.pass.cpp
@@ -35,6 +35,14 @@
 #include "test_macros.h"
 #include "libcxx_tc_common.h"
 
+struct TemplateConstructor
+{
+    template <typename T>
+    TemplateConstructor (const T&) {}
+};
+
+static bool operator < (const TemplateConstructor&, const TemplateConstructor&) { return false; }
+
 int tc_libcxx_containers_map_modifiers_erase_iter(void)
 {
     {

--- a/external/libcxx-test/std/containers/associative/multimap/multimap.modifiers/erase_iter.pass.cpp
+++ b/external/libcxx-test/std/containers/associative/multimap/multimap.modifiers/erase_iter.pass.cpp
@@ -35,6 +35,14 @@
 #include "test_macros.h"
 #include "libcxx_tc_common.h"
 
+struct TemplateConstructor
+{
+    template <typename T>
+    TemplateConstructor (const T&) {}
+};
+
+static bool operator < (const TemplateConstructor&, const TemplateConstructor&) { return false; }
+
 int tc_libcxx_containers_multimap_modifiers_erase_iter(void)
 {
     {

--- a/external/libcxx-test/std/containers/unord/unord.map/unord.map.modifiers/erase_const_iter.pass.cpp
+++ b/external/libcxx-test/std/containers/unord/unord.map/unord.map.modifiers/erase_const_iter.pass.cpp
@@ -36,9 +36,18 @@
 #include <string>
 #include <cassert>
 #include "libcxx_tc_common.h"
-
 #include "test_macros.h"
 
+struct TemplateConstructor
+{
+    template <typename T>
+    TemplateConstructor (const T&) {}
+};
+
+static bool operator == (const TemplateConstructor&, const TemplateConstructor&) { return false; }
+struct Hash {
+  std::size_t operator () (const TemplateConstructor&) const { return 0; }
+};
 
 int tc_libcxx_containers_unord_map_modifiers_erase_const_iter(void)
 {

--- a/external/libcxx-test/std/containers/unord/unord.multimap/unord.multimap.modifiers/erase_const_iter.pass.cpp
+++ b/external/libcxx-test/std/containers/unord/unord.multimap/unord.multimap.modifiers/erase_const_iter.pass.cpp
@@ -39,6 +39,16 @@
 #include <cstddef>
 #include "test_macros.h"
 
+struct TemplateConstructor
+{
+    template <typename T>
+    TemplateConstructor (const T&) {}
+};
+
+static bool operator == (const TemplateConstructor&, const TemplateConstructor&) { return false; }
+struct Hash {
+  std::size_t operator () (const TemplateConstructor&) const { return 0; }
+};
 
 int tc_libcxx_containers_unord_multimap_modifiers_erase_const_iter(void)
 {

--- a/external/libcxx-test/support/is_transparent.h
+++ b/external/libcxx-test/support/is_transparent.h
@@ -32,6 +32,8 @@
 // testing transparent
 #if TEST_STD_VER > 11
 
+#include <utility>  //for std::forward
+
 struct transparent_less
 {
     template <class T, class U>
@@ -93,9 +95,10 @@ private:
     int i_;
     };
 
-bool operator <(int          rhs,   const C2Int& lhs) { return rhs       < lhs.get(); }
-bool operator <(const C2Int& rhs,   const C2Int& lhs) { return rhs.get() < lhs.get(); }
-bool operator <(const C2Int& rhs,            int lhs) { return rhs.get() < lhs; }
+//declare as inline function to prevent linking error (multiple definition error)
+inline bool operator <(int          rhs,   const C2Int& lhs) { return rhs       < lhs.get(); }
+inline bool operator <(const C2Int& rhs,   const C2Int& lhs) { return rhs.get() < lhs.get(); }
+inline bool operator <(const C2Int& rhs,            int lhs) { return rhs.get() < lhs; }
 
 #endif
 

--- a/external/libcxx-test/support/private_constructor.hpp
+++ b/external/libcxx-test/support/private_constructor.hpp
@@ -39,4 +39,12 @@ private:
     };
 
 
+//declare as inline function to prevent linking error (multiple definition error)
+inline bool operator < ( const PrivateConstructor &lhs, const PrivateConstructor &rhs ) { return lhs.get() < rhs.get(); }
+
+inline bool operator < ( const PrivateConstructor &lhs, int rhs ) { return lhs.get() < rhs; }
+inline bool operator < ( int lhs, const PrivateConstructor &rhs ) { return lhs < rhs.get(); }
+
+inline std::ostream & operator << ( std::ostream &os, const PrivateConstructor &foo ) { return os << foo.get (); }
+
 #endif

--- a/external/libcxx-test/support/test_allocator.cpp
+++ b/external/libcxx-test/support/test_allocator.cpp
@@ -17,7 +17,6 @@
  ****************************************************************************/
 
 #include "test_allocator.h"
-#include <private_constructor.hpp>
 #include "DefaultOnly.h"
 #include "Counter.h"
 
@@ -25,14 +24,6 @@ int test_alloc_base::count = 0;
 int test_alloc_base::time_to_throw = 0;
 int test_alloc_base::alloc_count = 0;
 int test_alloc_base::throw_after = INT_MAX;
-
-
-bool operator < ( const PrivateConstructor &lhs, const PrivateConstructor &rhs ) { return lhs.get() < rhs.get(); }
-
-bool operator < ( const PrivateConstructor &lhs, int rhs ) { return lhs.get() < rhs; }
-bool operator < ( int lhs, const PrivateConstructor &rhs ) { return lhs < rhs.get(); }
-
-std::ostream & operator << ( std::ostream &os, const PrivateConstructor &foo ) { return os << foo.get (); }
 
 int DefaultOnly::count = 0;
 int Counter_base::gConstructed = 0;


### PR DESCRIPTION
Issue:
When upgrading to C++14, the build of `Map` test failed due to missing `TemplateConstructor` and comparison operators for `PrivateConstructor`. These were likely excluded previously because TizenLite merges all tests into a single executable, causing linker errors ("multiple definitions").

Fix:
Resolve ODR violation by declaring missing operators as `inline` and `static` functions in the shared header.

Reference:
The approach is inspired by LLVM’s test structure (https://github.com/llvm/llvm-project/tree/main/libcxx/test).

This commit makes libcxx-test can be built in C++14.