### PR TITLE
os/kernel: Rename function name in sched_unlock

### DIFF
--- a/os/kernel/sched/sched_unlock.c
+++ b/os/kernel/sched/sched_unlock.c
@@ -203,7 +203,7 @@ int sched_unlock(void)
 				}
 #ifdef CONFIG_SCHED_TICKLESS
 				else {
-					sched_reassess_timer();
+					sched_timer_reassess();
 				}
 #endif
 			}


### PR DESCRIPTION
- Fix the function name from undefined function `sched_reassess_timer` to correct function `sched_timer_reassess` in `sched_unlock.c`.
- `CONFIG_SMP` not defined case has right function name. (line 275)