### PR TITLE
os/kernel/irq: Correct the input parameter comment in irq_cpu_locked.

### DIFF
--- a/os/kernel/irq/irq_csection.c
+++ b/os/kernel/irq/irq_csection.c
@@ -601,7 +601,7 @@ void leave_critical_section(irqstate_t flags)
  *   holder of the IRQ lock.
  *
  * Input Parameters:
- *   rtcb - Points to the blocked TCB that is ready-to-run
+ *   cpu - The index of the CPU for check whether it holds the IRQ lock.
  *
  * Returned Value:
  *   true  - IRQs are locked by a different CPU.


### PR DESCRIPTION
- Correct the input parameter comment from rtcb to cpu in irq_cpu_locked.
- Write a description of input parameter `cpu`.