### PR TITLE
external/libcxx: Prevent C99 macro leakage in <cmath>

### DIFF
--- a/external/include/libcxx/cmath
+++ b/external/include/libcxx/cmath
@@ -61,10 +61,20 @@
 #include <tinyara/compiler.h>
 
 #include <math.h>
+#include <type_traits>
 
 //***************************************************************************
 // Namespace
 //***************************************************************************
+
+//These functions should be defined in `std` namespace as functions, not a macros.
+//To prevent leaking C99 macros into the C++ codes, they should be undefined.
+#undef isfinite
+#undef isinf
+#undef isnan
+
+// C++ linkage is required here to support overloaded functions (e.g., isinf, isnan).
+extern "C++" {
 
 namespace std
 {
@@ -94,6 +104,21 @@ namespace std
   using ::sqrtf;
   using ::tanf;
   using ::tanhf;
+
+  bool isinf(float __x)
+  {
+    return (((__x) == INFINITY) || ((__x) == -INFINITY));
+  }
+
+  bool isfinite(float __x)
+  { 
+    return (!(isinf(__x)) && (__x != NAN));
+  }
+
+  bool isnan(float __x)
+  { 
+    return ((__x) != (__x));
+  }
 #endif
 
 #ifdef CONFIG_HAVE_DOUBLE
@@ -124,6 +149,21 @@ namespace std
   using ::tanh;
   using ::gamma;
   using ::lgamma;
+
+  bool isinf(double __x)
+  {
+    return (((__x) == INFINITY) || ((__x) == -INFINITY));
+  }
+
+  bool isfinite(double __x)
+  { 
+    return (!(isinf(__x)) && (__x != NAN));
+  }
+
+  bool isnan(double __x)
+  { 
+    return ((__x) != (__x));
+  }
 #endif
 
 #ifdef CONFIG_HAVE_LONG_DOUBLE
@@ -152,7 +192,43 @@ namespace std
   using ::sqrtl;
   using ::tanl;
   using ::tanhl;
+
+  bool isinf(long double __x)
+  {
+    return (((__x) == INFINITY) || ((__x) == -INFINITY));
+  }
+
+  bool isfinite(long double __x)
+  { 
+    return (!(isinf(__x)) && (__x != NAN));
+  }
+
+  bool isnan(long double __x)
+  { 
+    return ((__x) != (__x));
+  }
 #endif
+
+  // For integral types
+  template<typename T>  
+  typename std::enable_if<std::is_integral<T>::value, bool>::type  
+  isinf(T __x) { return false; }
+
+  template<typename T>  
+  typename std::enable_if<std::is_integral<T>::value, bool>::type  
+  isfinite(T __x) { return true; }
+
+  template<typename T>  
+  typename std::enable_if<std::is_integral<T>::value, bool>::type  
+  isnan(T __x) { return false; }
+
+}
+
+//There are some codes using these functions in global namespace.
+//This is non-standard.
+using std::isinf;
+using std::isfinite;
+using std::isnan;
 
 }
 


### PR DESCRIPTION
Problem:
- Including `<cmath>` in C++ caused C99 macros (`isfinite`/`isinf`/`isnan`) from math.h to leak into global namespace.
- This led to compilation errors as macros overrode std functions: `std::isnan(NAN)` → `std::((NAN) != (NAN))` (invalid syntax).

Solution:
- Undefine C99 macros.
- Define `std::isfinite`, `std::isinf`, `std::isnan` as functions.

Result:
- Functions in std namespace work as defined by C++ standard.
- No macro interference in C++ compilation paths.