### PR TITLE
kernel/sched: Fix sched_kfree Memory Leak in flat build

### DIFF
--- a/os/include/tinyara/kmalloc.h
+++ b/os/include/tinyara/kmalloc.h
@@ -190,7 +190,8 @@ void group_free(FAR struct task_group_s *group, FAR void *mem);
 
 void sched_ufree(FAR void *address);
 
-#if defined(CONFIG_MM_KERNEL_HEAP) && defined(__KERNEL__)
+#if (defined(CONFIG_BUILD_PROTECTED) || defined(CONFIG_BUILD_KERNEL)) && \
+	 defined(CONFIG_MM_KERNEL_HEAP) && defined(__KERNEL__)
 void sched_kfree(FAR void *address);
 #else
 #define sched_kfree(a) sched_ufree(a)

--- a/os/kernel/init/os_start.c
+++ b/os/kernel/init/os_start.c
@@ -240,7 +240,10 @@ volatile dq_queue_t g_inactivetasks;
 
 volatile sq_queue_t g_delayed_kufree;
 
+#if (defined(CONFIG_BUILD_PROTECTED) || defined(CONFIG_BUILD_KERNEL)) && \
+	 defined(CONFIG_MM_KERNEL_HEAP)
 volatile sq_queue_t g_delayed_kfree;
+#endif
 
 /* This gives number of alive tasks at any point of time in the system.
  * If the system is already running CONFIG_MAX_TASKS, Creating new

--- a/os/kernel/sched/sched.h
+++ b/os/kernel/sched/sched.h
@@ -267,7 +267,10 @@ extern volatile uint8_t g_alive_taskcount;
 
 extern volatile sq_queue_t g_delayed_kufree;
 
+#if (defined(CONFIG_BUILD_PROTECTED) || defined(CONFIG_BUILD_KERNEL)) && \
+	 defined(CONFIG_MM_KERNEL_HEAP)
 extern volatile sq_queue_t g_delayed_kfree;
+#endif
 
 /* This is the value of the last process ID assigned to a task */
 

--- a/os/kernel/sched/sched_free.c
+++ b/os/kernel/sched/sched_free.c
@@ -137,7 +137,8 @@ void sched_ufree(FAR void *address)
 	}
 }
 
-#ifdef CONFIG_MM_KERNEL_HEAP
+#if (defined(CONFIG_BUILD_PROTECTED) || defined(CONFIG_BUILD_KERNEL)) && \
+	 defined(CONFIG_MM_KERNEL_HEAP)
 void sched_kfree(FAR void *address)
 {
 	irqstate_t flags;


### PR DESCRIPTION
In a flat build, sched_kfree is used, which adds addresses to the queue but does not free memory because sched_kcleanup is excluded from the build.
This results in memory accumulation in the g_delayed_kfree queue, leading to allocation failures during prolonged operation.

The issue arises because sched_kfree is enabled under the condition #if defined(CONFIG_MM_KERNEL_HEAP),
while sched_kcleanup is enabled only under #if (defined(CONFIG_BUILD_PROTECTED) || defined(CONFIG_BUILD_KERNEL)) && defined(CONFIG_MM_KERNEL_HEAP).

In flat builds (where CONFIG_BUILD_PROTECTED and CONFIG_BUILD_KERNEL are disabled), sched_kfree is active, but sched_kcleanup is excluded,
causing memory to accumulate without being freed.

To resolve this, the activation condition for sched_kfree has been updated to include #if (defined(CONFIG_BUILD_PROTECTED) || defined(CONFIG_BUILD_KERNEL)).
This ensures that in flat builds, sched_kfree routes to sched_ufree, preventing memory leaks and allocation failures.