### PR TITLE
framework/wifi_manager : remove ip reset in dhcpc close

### DIFF
--- a/framework/src/wifi_manager/wifi_manager_dhcpc.c
+++ b/framework/src/wifi_manager/wifi_manager_dhcpc.c
@@ -61,15 +61,11 @@ wifi_manager_result_e dhcpc_get_ipaddr(void)
 }
 #endif //CONFIG_WIFIMGR_DISABLE_DHCPC
 
-// Set IP to zero, regardless of DHCPC status
 void dhcpc_close_ipaddr(void)
 {
 #ifndef CONFIG_WIFIMGR_DISABLE_DHCPC
 	dhcp_client_stop(WIFIMGR_STA_IFNAME);
 #endif
-	/* To-Do is it right to clear IP address in here */
-	struct in_addr in = { .s_addr = INADDR_NONE };
-	WIFIMGR_SET_IP4ADDR(WIFIMGR_SOFTAP_IFNAME, in, in, in);
 	NET_LOGV(TAG, "release IP address\n");
 	return;
 }


### PR DESCRIPTION
Remove ip reset in dhcpc close
- Even dhcpc closed, softap ip needs to be maintained. Because even AP disconnected, STA can still be connected by bridge mode.
- Performing SOFTAP ip reset in dhcpc close is odd. 