### PR TITLE
external/libcxx: Fix iostream in loadable build

### DIFF
--- a/external/libcxx/iostream.cxx
+++ b/external/libcxx/iostream.cxx
@@ -58,7 +58,11 @@ static mbstate_t mb_wcerr;
 _ALIGNAS_TYPE (ostream)  _LIBCPP_FUNC_VIS char clog[sizeof(ostream)];
 _ALIGNAS_TYPE (wostream) _LIBCPP_FUNC_VIS char wclog[sizeof(wostream)];
 
+#ifdef CONFIG_BINFMT_CONSTRUCTORS
+ios_base::Init __start_std_streams;
+#else
 ios_base::Init __start_std_streams __attribute__ ((init_priority (500)));
+#endif
 
 ios_base::Init::Init()
 {


### PR DESCRIPTION
Problem:
- The `iostream` static objects did not initialized in loadable build.
- So, `std::cout` did not work in loadable build (works only in flat build).

Why:
- If `__start_std_streams` have `init_priority`, its constructor did not be included to `ctors`.
- As the `__start_std_streams` declared as static variable, its constructor has to be called before C++ app starts.
- But since its constructor did not be included to `ctors`, it was not called.

Solution:
- I assume there is some reason why `__start_std_streams` has `init_priority`.
- So remove the `__attribute__((init_priority))` from `__start_std_streams` in loadable build only.

Result:
- The `iostream` objects initialize correctly in loadable build.
- `std::cout` works normally in loadable build.