### PR TITLE
os/drivers/lcd: Update LCD_LOGO config

### DIFF
--- a/os/drivers/lcd/Kconfig
+++ b/os/drivers/lcd/Kconfig
@@ -167,7 +167,7 @@ config LCD_YRES
 
 config LCD_LOGO
 	bool "Lcd screen image shown at boot time"
-	default y
+	default n
 	---help---
 		This screen image is shown at boot time.
 		This image is shown till App makes first rendering call.


### PR DESCRIPTION
Update LCD_LOGO Kconfig to disable by default.
LCD logo is not essential.