### PR TITLE
external/libcxx: Fix linkage error and implementation error of math

### DIFF
--- a/external/include/libcxx/cmath
+++ b/external/include/libcxx/cmath
@@ -110,14 +110,14 @@ namespace std
     return (((__x) == INFINITY) || ((__x) == -INFINITY));
   }
 
-  inline bool isfinite(float __x)
-  { 
-    return (!(isinf(__x)) && (__x != NAN));
-  }
-
   inline bool isnan(float __x)
   { 
     return ((__x) != (__x));
+  }
+
+  inline bool isfinite(float __x)
+  { 
+    return (!(isinf(__x)) && !(isnan(__x)));
   }
 #endif
 
@@ -155,14 +155,14 @@ namespace std
     return (((__x) == INFINITY) || ((__x) == -INFINITY));
   }
 
-  inline bool isfinite(double __x)
-  { 
-    return (!(isinf(__x)) && (__x != NAN));
-  }
-
   inline bool isnan(double __x)
   { 
     return ((__x) != (__x));
+  }
+
+  inline bool isfinite(double __x)
+  { 
+    return (!(isinf(__x)) && !(isnan(__x)));
   }
 #endif
 
@@ -198,14 +198,14 @@ namespace std
     return (((__x) == INFINITY) || ((__x) == -INFINITY));
   }
 
-  inline bool isfinite(long double __x)
-  { 
-    return (!(isinf(__x)) && (__x != NAN));
-  }
-
   inline bool isnan(long double __x)
   { 
     return ((__x) != (__x));
+  }
+
+  inline bool isfinite(long double __x)
+  { 
+    return (!(isinf(__x)) && !(isnan(__x)));
   }
 #endif
 

--- a/external/include/libcxx/cmath
+++ b/external/include/libcxx/cmath
@@ -105,17 +105,17 @@ namespace std
   using ::tanf;
   using ::tanhf;
 
-  bool isinf(float __x)
+  inline bool isinf(float __x)
   {
     return (((__x) == INFINITY) || ((__x) == -INFINITY));
   }
 
-  bool isfinite(float __x)
+  inline bool isfinite(float __x)
   { 
     return (!(isinf(__x)) && (__x != NAN));
   }
 
-  bool isnan(float __x)
+  inline bool isnan(float __x)
   { 
     return ((__x) != (__x));
   }
@@ -150,17 +150,17 @@ namespace std
   using ::gamma;
   using ::lgamma;
 
-  bool isinf(double __x)
+  inline bool isinf(double __x)
   {
     return (((__x) == INFINITY) || ((__x) == -INFINITY));
   }
 
-  bool isfinite(double __x)
+  inline bool isfinite(double __x)
   { 
     return (!(isinf(__x)) && (__x != NAN));
   }
 
-  bool isnan(double __x)
+  inline bool isnan(double __x)
   { 
     return ((__x) != (__x));
   }
@@ -193,32 +193,32 @@ namespace std
   using ::tanl;
   using ::tanhl;
 
-  bool isinf(long double __x)
+  inline bool isinf(long double __x)
   {
     return (((__x) == INFINITY) || ((__x) == -INFINITY));
   }
 
-  bool isfinite(long double __x)
+  inline bool isfinite(long double __x)
   { 
     return (!(isinf(__x)) && (__x != NAN));
   }
 
-  bool isnan(long double __x)
+  inline bool isnan(long double __x)
   { 
     return ((__x) != (__x));
   }
 #endif
 
   // For integral types
-  template<typename T>  
+  template<typename T> inline
   typename std::enable_if<std::is_integral<T>::value, bool>::type  
   isinf(T __x) { return false; }
 
-  template<typename T>  
+  template<typename T> inline
   typename std::enable_if<std::is_integral<T>::value, bool>::type  
   isfinite(T __x) { return true; }
 
-  template<typename T>  
+  template<typename T> inline
   typename std::enable_if<std::is_integral<T>::value, bool>::type  
   isnan(T __x) { return false; }
 

--- a/os/include/tinyara/math.h
+++ b/os/include/tinyara/math.h
@@ -123,7 +123,7 @@
 
 #define isnan(x)    ((x) != (x))
 #define isinf(x)    (((x) == INFINITY) || ((x) == -INFINITY))
-#define isfinite(x) (!(isinf(x)) && (x != NAN))
+#define isfinite(x) (!(isinf(x)) && !(isnan(x)))
 
 static __inline unsigned __FLOAT_BITS(float __f)
 {


### PR DESCRIPTION
This resolves the linkage error(multiple definitions) when `cmath` header is included multiple times.

and
The original implementation returned true for NaN due to flawed comparison logic.  
This replaces `(x != NAN)` with `!isnan(x)` to correctly handle NaN values.  