### PR TITLE
drivers/compression: fix decompress ioctl

### DIFF
--- a/os/drivers/compression/compress.c
+++ b/os/drivers/compression/compress.c
@@ -158,6 +158,7 @@ static int comp_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
 		if (ret == ENOMEM) {
 			bcmpdbg("Output buffer allocated is not sufficient\n");
 		}
+		break;
 	case COMPIOC_FCOMP_INIT:
 		if ((char *)arg == NULL) {
 			return -EINVAL;


### PR DESCRIPTION
Add a break statement to the COMPIOC_DECOMPRESS case in comp_ioctl.
This fix ensures proper handling of decompression requests.