### PR TITLE
os/kernel/log_dump: Add crash log flash save

### DIFF
--- a/os/arch/arm/src/armv7-a/arm_assert.c
+++ b/os/arch/arm/src/armv7-a/arm_assert.c
@@ -611,6 +611,12 @@ void up_assert(const uint8_t *filename, int lineno)
 		asserted_location = kernel_assert_location;
 	}
 
+#ifdef CONFIG_BINMGR_RECOVERY
+	if (IS_FAULT_IN_USER_SPACE(asserted_location)) {
+		/* start assert log saving */
+		set_assert_situation();
+	}
+#endif
 #ifdef CONFIG_SMP
 	/* Pause all other CPUs to avoid mix up of logs while printing assert logs */
 	up_cpu_pause_all();
@@ -654,6 +660,7 @@ void up_assert(const uint8_t *filename, int lineno)
 	if (IS_FAULT_IN_USER_SPACE(asserted_location)) {
 		/* Recover user fault through binary manager */
 		binary_manager_recover_userfault();
+		state = NORMAL_STATE; 
 	} else
 #endif
 	{

--- a/os/include/syslog.h
+++ b/os/include/syslog.h
@@ -262,6 +262,8 @@ int lowsyslog(int priority, FAR const char *format, ...);
  */
 int lowvsyslog(int priority, FAR const char *format, va_list ap);
 
+
+
 #else
 
 #ifdef CONFIG_CPP_HAVE_VARARGS

--- a/os/include/tinyara/log_dump/log_dump_internal.h
+++ b/os/include/tinyara/log_dump/log_dump_internal.h
@@ -64,4 +64,59 @@ int log_dump_get_size(void);
  ****************************************************************************/
 int log_dump(int argc, char *argv[]);
 
+/****************************************************************************
+ * Description:
+ *   This is used to store logs that are output via lldbg() during a user crash situation into a buffer.
+ *
+ ****************************************************************************/
+void assert_log_to_buffer(FAR const char *fmt, va_list ap);
+
+
+/****************************************************************************
+ * Description:
+ *   This is used to enable assert handling.
+ *
+ ****************************************************************************/
+int set_assert_situation();
+
+/****************************************************************************
+ * Description:
+ *   This is used to unable assert handling.
+ *
+ ****************************************************************************/
+int set_notassert_situation();
+
+/****************************************************************************
+ * Description:
+ *   This is used to save not compressed assert log to file.
+    file name fixed: /mnt/assert_logsave.txt -> needs to be modified.
+ ****************************************************************************/
+int assert_log_to_file();
+
+/****************************************************************************
+ * Description:
+ *   This is used to compress assert log.
+    it's stored in the data section, but it needs to be changed to be stored in the heap section.
+ ****************************************************************************/
+void assert_log_compress();
+
+/****************************************************************************
+ * Description:
+ *   This is used to save compressed assert log to file.
+    file name fixed: /mnt/assert_logsave_zip -> needs to be modified.
+ ****************************************************************************/
+int compressed_assert_log_to_file();
+
+/****************************************************************************
+ * Description:
+ *   This is used to read compressed assert log from file to buf.
+ ****************************************************************************/
+int compressed_assert_log_read();
+
+/****************************************************************************
+ * Description:
+ *   This is used to decompress buf and print decompressed log.
+ ****************************************************************************/
+int decompress_and_print();
+
 #endif							/* __LOG_DUMP_INTERNAL_H */

--- a/os/kernel/binary_manager/binary_manager_recovery.c
+++ b/os/kernel/binary_manager/binary_manager_recovery.c
@@ -346,6 +346,13 @@ void binary_manager_recovery(int bin_idx)
 		goto reboot_board;
 	}
 #endif
+	//for now, these must be executed in this exact order
+	set_notassert_situation();
+	assert_log_to_file();
+	assert_log_compress();
+	compressed_assert_log_to_file();
+	compressed_assert_log_read();
+	decompress_and_print();
 	/* Create loader to reload binary */
 	ret = binary_manager_execute_loader(LOADCMD_RELOAD, bin_idx);
 	if (ret == OK) {

--- a/os/kernel/log_dump/log_dump.c
+++ b/os/kernel/log_dump/log_dump.c
@@ -70,6 +70,9 @@
 #define LOG_DUMP_COMP_CHECK_RETRY_CNT 		(CONFIG_LOG_DUMP_HANG_CHECK_SEC * USEC_PER_SEC / LOG_DUMP_COMP_CHECK_RETRY_USEC)
 #endif
 
+ #define ASSERT_LOG_BUF_SIZE 8192 /* Buffer size for logs printed during an assert */
+
+
 static bool is_started_to_save;
 
 /****************************************************************************
@@ -118,6 +121,17 @@ static unsigned char *last_comp_block;
 static size_t last_comp_block_size;
 static int last_comp_block_ptr;
 static bool compress_last_block;
+
+/* Structures used to save compressed log data*/
+static unsigned char compressed_buf[ASSERT_LOG_BUF_SIZE]; 
+static unsigned int compressed_buf_size;
+static char assert_log[ASSERT_LOG_BUF_SIZE];
+static int assert_situation=0;
+static int assert_log_index=0;
+static int log_len=0;
+
+/* Structures used to decompress and print compressed log data*/
+static char tm[ASSERT_LOG_BUF_SIZE];
 
 /****************************************************************************
  * Private Functions
@@ -569,6 +583,14 @@ size_t log_dump_read(FAR char *buffer, size_t buflen)
 	return ret;
 }
 
+
+
+
+
+
+
+
+
 int log_dump(int argc, char *argv[])
 {
 	struct mq_attr attr;
@@ -612,4 +634,135 @@ int log_dump(int argc, char *argv[])
 			compress_full_block = false;
 		}
 	}
+}
+
+
+void assert_log_init(){
+	assert_situation=0;
+	assert_log_index=0;
+}
+int assert_log_save(char ch){
+	if(assert_log_index<ASSERT_LOG_BUF_SIZE) assert_log[assert_log_index++]=ch;
+}
+int get_assert_log_save_size(){
+	return log_len;
+}
+int set_assert_situation(){
+	lldbg("\n\n\n===============================FROM THIS, lldbg LOG WILL BE SAVED!!================================\n\n\n\n");
+	assert_situation=1;
+}
+int set_notassert_situation(){
+	lldbg("\n\n\n=============================================TO THIS===============================================\n\n\n");
+	
+	assert_situation=0;
+}
+int get_assert_log(char *buf,int size){
+	int i;
+	for(i=0;i<get_assert_log_save_size;i++){
+		if(i>=size) break;
+		buf[i]=assert_log[i];
+	}
+	return i;
+}
+void append_assert_log(const char *fmt, va_list ap){
+	if (log_len>=ASSERT_LOG_BUF_SIZE - 1){
+		return ;
+	}
+	size_t remain=ASSERT_LOG_BUF_SIZE - log_len-1;
+	int written = vsnprintf(assert_log + log_len, remain+1,fmt,ap);
+	if(written<0) return;
+	if((size_t)written > remain){
+		log_len = ASSERT_LOG_BUF_SIZE -1 ;
+	}
+	else{
+		log_len +=(size_t)written;
+	}
+	assert_log[log_len]='\0';
+}
+void assert_log_to_buffer(FAR const char *fmt, va_list ap){
+	if(assert_situation){
+		va_list ap2;
+		va_copy(ap2,ap);
+		append_assert_log(fmt,ap2);
+		va_end(ap2);
+	}
+}
+
+
+
+int assert_log_to_file(){
+	lldbg("\n\n\n===============assert log file saving start==================\n\n\n");
+	lldbg("\nlog_save_size is %d\n",get_assert_log_save_size());
+	int fd=open("/mnt/assert_logsave.txt",O_WRONLY|O_CREAT|O_TRUNC);
+	if(fd<0){
+		lldbg("file open failed\n");
+		return -1;
+	}
+	lldbg("file open success\n");
+	int log_size=write(fd,assert_log,strlen(assert_log));
+	close(fd);
+	if(log_size<0){
+		lldbg("file write failed\n");
+		return -1;
+	}
+	lldbg("file write success, count:%d\n",log_size);
+	lldbg("\n\n\n===============assert log file saving end=====================\n\n\n");
+	return log_size;
+}
+void assert_log_compress(){
+
+	lldbg("\n\n================compress start==============\n\n");
+	compressed_buf_size=ASSERT_LOG_BUF_SIZE;
+	compress_block(compressed_buf,&compressed_buf_size,assert_log,ASSERT_LOG_BUF_SIZE);
+	lldbg("compressed buf size: %d\n",compressed_buf_size);
+	lldbg("\n====================compress end =====================\n");
+		
+}
+int compressed_assert_log_to_file(){
+	lldbg("\n\n================compress file write start==============\n\n");
+	int fd=open("/mnt/ssert_logsave_zip",O_WRONLY|O_CREAT|O_TRUNC);
+	if(fd<0){
+		lldbg("file open failed\n");
+		return -1;
+	}
+	lldbg("file open success\n");
+	int ret=write(fd,compressed_buf,compressed_buf_size);
+	if(ret<0){
+		lldbg("file write failed\n");
+		return -1;
+	}
+	close(fd);
+	lldbg("write count: %d\n",ret);
+	lldbg("\n\n=====================compress file write end ===================\n\n");
+	return ret;
+}
+int compressed_assert_log_read(){
+	lldbg("\n========================== compressed_assert_log_read start======================\n");
+	for(int i=0;i<ASSERT_LOG_BUF_SIZE;i++)compressed_buf[i]=0;
+	int fd=open("/mnt/assert_logsave_zip",O_RDONLY);
+		if(fd<0){
+			lldbg("file open failed\n");
+			return -1;
+		}
+		lldbg("file open success\n");
+	int ret=read(fd,compressed_buf,sizeof(compressed_buf));
+	if(ret<0){
+		lldbg("file read failed\n");
+		return -1;
+	}
+	lldbg("file read successed, count:%d\n",ret);
+	close(fd);
+	lldbg("\n========================== compressed_assert_log_read end========================\n");
+	compressed_buf_size=ret;
+	return ret;
+
+}
+int decompress_and_print(){
+		lldbg("\n========================== compressed data decompress and print start======================\n");
+		int tm_size=ASSERT_LOG_BUF_SIZE;
+		decompress_block(tm,&tm_size,compressed_buf,&compressed_buf_size);
+		lldbg("decompressed size: %d\n",tm_size);
+		tm[ASSERT_LOG_BUF_SIZE-1]='\0';
+		lldbg("\n%s\n",tm);
+		lldbg("\n========================== compressed data decompress and print end======================\n");
 }


### PR DESCRIPTION
Developed a new feature to store logs during assert situations. It only operates when a crash occurs in the user space.

The following modifications are required:
1. Avoid using double vsnprintf.
2. Check available space in the file system before wrting.
3. Check available heap memory before compression.
4. Store compressed data in the heap instead of the data section.
5. Add a unique identifier or delimiter to the file name.
6. Implement a retry count mechanism.
7. Ensure logs from functions like __alert() are also captured.