### PR TITLE
external/libcxx/cmath: Fix incorrectly included and implemented math.h

### DIFF
--- a/external/include/libcxx/cmath
+++ b/external/include/libcxx/cmath
@@ -60,7 +60,7 @@
 #include <tinyara/config.h>
 #include <tinyara/compiler.h>
 
-#include <math.h>
+#include "math.h"
 
 //***************************************************************************
 // Namespace
@@ -94,6 +94,9 @@ namespace std
   using ::sqrtf;
   using ::tanf;
   using ::tanhf;
+  using ::isinf;
+  using ::isfinite;
+  using ::isnan;
 #endif
 
 #ifdef CONFIG_HAVE_DOUBLE
@@ -124,6 +127,9 @@ namespace std
   using ::tanh;
   using ::gamma;
   using ::lgamma;
+  using ::isinf;
+  using ::isfinite;
+  using ::isnan;
 #endif
 
 #ifdef CONFIG_HAVE_LONG_DOUBLE
@@ -152,6 +158,9 @@ namespace std
   using ::sqrtl;
   using ::tanl;
   using ::tanhl;
+  using ::isinf;
+  using ::isfinite;
+  using ::isnan;
 #endif
 
 }

--- a/external/include/libcxx/cmath
+++ b/external/include/libcxx/cmath
@@ -110,14 +110,14 @@ namespace std
     return (((__x) == INFINITY) || ((__x) == -INFINITY));
   }
 
+  inline bool isfinite(float __x)
+  { 
+    return (!(isinf(__x)) && (__x != NAN));
+  }
+
   inline bool isnan(float __x)
   { 
     return ((__x) != (__x));
-  }
-
-  inline bool isfinite(float __x)
-  { 
-    return (!(isinf(__x)) && !(isnan(__x)));
   }
 #endif
 
@@ -155,14 +155,14 @@ namespace std
     return (((__x) == INFINITY) || ((__x) == -INFINITY));
   }
 
+  inline bool isfinite(double __x)
+  { 
+    return (!(isinf(__x)) && (__x != NAN));
+  }
+
   inline bool isnan(double __x)
   { 
     return ((__x) != (__x));
-  }
-
-  inline bool isfinite(double __x)
-  { 
-    return (!(isinf(__x)) && !(isnan(__x)));
   }
 #endif
 
@@ -198,14 +198,14 @@ namespace std
     return (((__x) == INFINITY) || ((__x) == -INFINITY));
   }
 
+  inline bool isfinite(long double __x)
+  { 
+    return (!(isinf(__x)) && (__x != NAN));
+  }
+
   inline bool isnan(long double __x)
   { 
     return ((__x) != (__x));
-  }
-
-  inline bool isfinite(long double __x)
-  { 
-    return (!(isinf(__x)) && !(isnan(__x)));
   }
 #endif
 

--- a/external/include/libcxx/cmath
+++ b/external/include/libcxx/cmath
@@ -61,20 +61,10 @@
 #include <tinyara/compiler.h>
 
 #include <math.h>
-#include <type_traits>
 
 //***************************************************************************
 // Namespace
 //***************************************************************************
-
-//These functions should be defined in `std` namespace as functions, not a macros.
-//To prevent leaking C99 macros into the C++ codes, they should be undefined.
-#undef isfinite
-#undef isinf
-#undef isnan
-
-// C++ linkage is required here to support overloaded functions (e.g., isinf, isnan).
-extern "C++" {
 
 namespace std
 {
@@ -104,21 +94,6 @@ namespace std
   using ::sqrtf;
   using ::tanf;
   using ::tanhf;
-
-  bool isinf(float __x)
-  {
-    return (((__x) == INFINITY) || ((__x) == -INFINITY));
-  }
-
-  bool isfinite(float __x)
-  { 
-    return (!(isinf(__x)) && (__x != NAN));
-  }
-
-  bool isnan(float __x)
-  { 
-    return ((__x) != (__x));
-  }
 #endif
 
 #ifdef CONFIG_HAVE_DOUBLE
@@ -149,21 +124,6 @@ namespace std
   using ::tanh;
   using ::gamma;
   using ::lgamma;
-
-  bool isinf(double __x)
-  {
-    return (((__x) == INFINITY) || ((__x) == -INFINITY));
-  }
-
-  bool isfinite(double __x)
-  { 
-    return (!(isinf(__x)) && (__x != NAN));
-  }
-
-  bool isnan(double __x)
-  { 
-    return ((__x) != (__x));
-  }
 #endif
 
 #ifdef CONFIG_HAVE_LONG_DOUBLE
@@ -192,43 +152,7 @@ namespace std
   using ::sqrtl;
   using ::tanl;
   using ::tanhl;
-
-  bool isinf(long double __x)
-  {
-    return (((__x) == INFINITY) || ((__x) == -INFINITY));
-  }
-
-  bool isfinite(long double __x)
-  { 
-    return (!(isinf(__x)) && (__x != NAN));
-  }
-
-  bool isnan(long double __x)
-  { 
-    return ((__x) != (__x));
-  }
 #endif
-
-  // For integral types
-  template<typename T>  
-  typename std::enable_if<std::is_integral<T>::value, bool>::type  
-  isinf(T __x) { return false; }
-
-  template<typename T>  
-  typename std::enable_if<std::is_integral<T>::value, bool>::type  
-  isfinite(T __x) { return true; }
-
-  template<typename T>  
-  typename std::enable_if<std::is_integral<T>::value, bool>::type  
-  isnan(T __x) { return false; }
-
-}
-
-//There are some codes using these functions in global namespace.
-//This is non-standard.
-using std::isinf;
-using std::isfinite;
-using std::isnan;
 
 }
 

--- a/external/include/libcxx/cmath
+++ b/external/include/libcxx/cmath
@@ -105,17 +105,17 @@ namespace std
   using ::tanf;
   using ::tanhf;
 
-  inline bool isinf(float __x)
+  bool isinf(float __x)
   {
     return (((__x) == INFINITY) || ((__x) == -INFINITY));
   }
 
-  inline bool isfinite(float __x)
+  bool isfinite(float __x)
   { 
     return (!(isinf(__x)) && (__x != NAN));
   }
 
-  inline bool isnan(float __x)
+  bool isnan(float __x)
   { 
     return ((__x) != (__x));
   }
@@ -150,17 +150,17 @@ namespace std
   using ::gamma;
   using ::lgamma;
 
-  inline bool isinf(double __x)
+  bool isinf(double __x)
   {
     return (((__x) == INFINITY) || ((__x) == -INFINITY));
   }
 
-  inline bool isfinite(double __x)
+  bool isfinite(double __x)
   { 
     return (!(isinf(__x)) && (__x != NAN));
   }
 
-  inline bool isnan(double __x)
+  bool isnan(double __x)
   { 
     return ((__x) != (__x));
   }
@@ -193,32 +193,32 @@ namespace std
   using ::tanl;
   using ::tanhl;
 
-  inline bool isinf(long double __x)
+  bool isinf(long double __x)
   {
     return (((__x) == INFINITY) || ((__x) == -INFINITY));
   }
 
-  inline bool isfinite(long double __x)
+  bool isfinite(long double __x)
   { 
     return (!(isinf(__x)) && (__x != NAN));
   }
 
-  inline bool isnan(long double __x)
+  bool isnan(long double __x)
   { 
     return ((__x) != (__x));
   }
 #endif
 
   // For integral types
-  template<typename T> inline
+  template<typename T>  
   typename std::enable_if<std::is_integral<T>::value, bool>::type  
   isinf(T __x) { return false; }
 
-  template<typename T> inline
+  template<typename T>  
   typename std::enable_if<std::is_integral<T>::value, bool>::type  
   isfinite(T __x) { return true; }
 
-  template<typename T> inline
+  template<typename T>  
   typename std::enable_if<std::is_integral<T>::value, bool>::type  
   isnan(T __x) { return false; }
 

--- a/os/include/tinyara/math.h
+++ b/os/include/tinyara/math.h
@@ -123,7 +123,7 @@
 
 #define isnan(x)    ((x) != (x))
 #define isinf(x)    (((x) == INFINITY) || ((x) == -INFINITY))
-#define isfinite(x) (!(isinf(x)) && (x != NAN))
+#define isfinite(x) (!(isinf(x)) && !(isnan(x)))
 
 static __inline unsigned __FLOAT_BITS(float __f)
 {

--- a/os/include/tinyara/math.h
+++ b/os/include/tinyara/math.h
@@ -123,7 +123,7 @@
 
 #define isnan(x)    ((x) != (x))
 #define isinf(x)    (((x) == INFINITY) || ((x) == -INFINITY))
-#define isfinite(x) (!(isinf(x)) && !(isnan(x)))
+#define isfinite(x) (!(isinf(x)) && (x != NAN))
 
 static __inline unsigned __FLOAT_BITS(float __f)
 {


### PR DESCRIPTION
`cmath` should include libcxx internal `math.h`
but it has included the wrong `math.h` from `os/include/math.h`

and the `isfinite()` macro was incorrectly implemented.
- isfinite(NAN) incorrectly returned true.
- Caused by (x != NAN) which always evaluates to true for NaN (since NaN != NaN).

This fixes the wrong inclusion by changing the angle bracket to quote mark
and replace the wrong implementation of `isfinite`.

This **REVERTS** the old wrong workaround to provide isinf, isfinite, isnan.