### PR TITLE
Handle LCD_ST7785_TYPEA(inverted) and LCD_ST7785_TYPEB(non_inverted) in power logic

### DIFF
--- a/os/board/rtl8730e/src/rtl8730e_mipi_lcdc.c
+++ b/os/board/rtl8730e/src/rtl8730e_mipi_lcdc.c
@@ -235,9 +235,9 @@ static void rtl8730e_control_backlight(uint8_t level)
 		/* TO-DO: Move LCD IC Power ON flow */
 		InterruptEn(lcdc_irq_info.num, lcdc_irq_info.priority);
 	}
-#if defined(CONFIG_LCD_ST7701SN)
+#if defined(CONFIG_LCD_ST7701SN) || defined(CONFIG_LCD_ST7785_TYPEA)
 	pwmout_write(&g_rtl8730e_config_dev_s.pwm_led, 1.0-pwm_level);
-#elif defined(CONFIG_LCD_ST7785)
+#elif defined(CONFIG_LCD_ST7785_TYPEB)
 	pwmout_write(&g_rtl8730e_config_dev_s.pwm_led, pwm_level);
 #endif
 	g_rtl8730e_config_dev_s.pwm_level = level;


### PR DESCRIPTION
We are using config macros to perform backlight inversion because we are setting backlight to 0 before initialization. At this point we can not read the value of power_inversion, so the inversion logic must be decided statically using config macros.