### PR TITLE
os/drivers/lcd: Fix LCD mipi reinit flow

### DIFF
--- a/os/arch/arm/src/amebasmart/amebasmart_mipi.c
+++ b/os/arch/arm/src/amebasmart/amebasmart_mipi.c
@@ -256,6 +256,20 @@ static void amebasmart_mipidsi_rcmd_decode(MIPI_TypeDef *MIPIx, u8 rcmd_idx)
 
 	receive_cmd_done = 1;
 }
+
+static void amebasmart_mipi_reset_trx_helper(MIPI_TypeDef *MIPIx)
+{
+	MIPIx->MIPI_CKLANE_CTRL = (MIPIx->MIPI_CKLANE_CTRL & ~MIPI_MASK_FORCETXSTOPMODE) | MIPI_FORCETXSTOPMODE(1);
+	DelayUs(1);
+	MIPIx->MIPI_CKLANE_CTRL = (MIPIx->MIPI_CKLANE_CTRL & ~MIPI_MASK_FORCETXSTOPMODE) | MIPI_FORCETXSTOPMODE(0);
+
+	MIPIx->MIPI_MAIN_CTRL = (MIPIx->MIPI_MAIN_CTRL & ~MIPI_BIT_DSI_MODE) | MIPI_BIT_LPTX_RST | MIPI_BIT_LPRX_RST;
+	DelayUs(1);
+	MIPIx->MIPI_MAIN_CTRL = (MIPIx->MIPI_MAIN_CTRL & ~MIPI_BIT_DSI_MODE) & ~MIPI_BIT_LPTX_RST & ~MIPI_BIT_LPRX_RST;
+
+	memset(rx_data_buff, 0, 5);
+}
+
 static void amebasmart_mipidsi_isr(void)
 {
 	MIPI_TypeDef *MIPIx = g_dsi_host.MIPIx;
@@ -280,6 +294,11 @@ static void amebasmart_mipidsi_isr(void)
 		amebasmart_mipidsi_rcmd_decode(MIPIx, 2);
 	}
 
+	if (reg_val & (MIPI_BIT_RCMD1 | MIPI_BIT_RCMD2 | MIPI_BIT_RCMD3)){
+		mipillvdbg("RCMD: %x %x %x %x %x\n", rx_data_buff[0], rx_data_buff[1], rx_data_buff[2], rx_data_buff[3], rx_data_buff[4]);
+	}
+
+	/* A timeout was encountered on the DPHY */
 	if (reg_val & (MIPI_BIT_LPRX_TIMEOUT | MIPI_BIT_LPTX_TIMEOUT)) {
 		if (reg_val & MIPI_BIT_LPRX_TIMEOUT) {
 			mipidbg("LPRX TimeOut\n");
@@ -294,40 +313,49 @@ static void amebasmart_mipidsi_isr(void)
 		} else {
 			mipidbg("LPTX TimeOut\n");
 		}
-		MIPIx->MIPI_CKLANE_CTRL = (MIPIx->MIPI_CKLANE_CTRL & ~MIPI_MASK_FORCETXSTOPMODE) | MIPI_FORCETXSTOPMODE(1);
-		DelayUs(1);
-		MIPIx->MIPI_CKLANE_CTRL = (MIPIx->MIPI_CKLANE_CTRL & ~MIPI_MASK_FORCETXSTOPMODE) | MIPI_FORCETXSTOPMODE(0);
 
-		MIPIx->MIPI_MAIN_CTRL = (MIPIx->MIPI_MAIN_CTRL & ~MIPI_BIT_DSI_MODE) | MIPI_BIT_LPTX_RST | MIPI_BIT_LPRX_RST;
-		DelayUs(1);
-		MIPIx->MIPI_MAIN_CTRL = (MIPIx->MIPI_MAIN_CTRL & ~(MIPI_BIT_DSI_MODE | MIPI_BIT_LPTX_RST | MIPI_BIT_LPRX_RST));
+		/* Restart TRX after errors handled */
+		amebasmart_mipi_reset_trx_helper(MIPIx);
 	}
 
+	/* An error has occured on the DPHY */
 	if (reg_val & MIPI_BIT_ERROR) {
 		reg_dphy_err = MIPIx->MIPI_DPHY_ERR;
 		MIPIx->MIPI_DPHY_ERR = reg_dphy_err;
-		mipidbg("LPTX Error: 0x%x, DPHY Error: 0x%x\n", reg_val, reg_dphy_err);
+		mipilldbg("LPTX Error: 0x%x, DPHY Error: 0x%x\n", reg_val, reg_dphy_err);
 
+		/* If contention is detected during LP signalling on the data lines */
+		if (reg_dphy_err & (MIPI_BIT_ERRCONTECNTIAL_LP0_CH0 | MIPI_BIT_ERRCONTECNTIAL_LP0_CH1 | MIPI_BIT_ERRCONTECNTIAL_LP1_CH0 | MIPI_BIT_ERRCONTECNTIAL_LP1_CH1)) {
 		if (MIPIx->MIPI_CONTENTION_DETECTOR_AND_STOPSTATE_DT & MIPI_MASK_DETECT_ENABLE) {
 			MIPIx->MIPI_CONTENTION_DETECTOR_AND_STOPSTATE_DT &= ~MIPI_MASK_DETECT_ENABLE;
 
 			MIPIx->MIPI_DPHY_ERR = reg_dphy_err;
 			MIPI_DSI_INTS_Clr(MIPIx, MIPI_BIT_ERROR);
-			mipidbg("LPTX Error CLR: 0x%x, DPHY: 0x%x\n", MIPIx->MIPI_INTS, MIPIx->MIPI_DPHY_ERR);
+			mipilldbg("LPTX Error CLR: 0x%x, DPHY: 0x%x\n", MIPIx->MIPI_INTS, MIPIx->MIPI_DPHY_ERR);
 		}
+		}
+
+		/* Control error was detected */
+		if (reg_dphy_err & MIPI_BIT_ERRCONTROL) {
+			MIPI_DSI_INTS_Clr(MIPIx, MIPI_BIT_ERROR);
+			MIPIx->MIPI_DPHY_ERR = MIPIx->MIPI_DPHY_ERR & ~MIPI_BIT_ERRCONTROL;
+			mipilldbg("Handle ERRCONTROL: LPTX Error CLR: 0x%x, DPHY: 0x%x\n", MIPIx->MIPI_INTS, MIPIx->MIPI_DPHY_ERR);
+		}
+
+		/* A sync error has occured */
+		if (reg_dphy_err & MIPI_BIT_ERRSYNCESC) {
+			MIPI_DSI_INTS_Clr(MIPIx, MIPI_BIT_ERROR);
+			MIPIx->MIPI_DPHY_ERR = MIPIx->MIPI_DPHY_ERR & ~MIPI_BIT_ERRSYNCESC;
+			mipilldbg("Handle ERRSYNC: LPTX Error CLR: 0x%x, DPHY: 0x%x\n", MIPIx->MIPI_INTS, MIPIx->MIPI_DPHY_ERR);
+		}
+
+		/* Restart TRX after errors handled */
+		amebasmart_mipi_reset_trx_helper(MIPIx);
 
 		if (MIPIx->MIPI_DPHY_ERR == reg_dphy_err) {
 			mipidbg("LPTX Still Error\n");
 			MIPI_DSI_INT_Config(MIPIx, ENABLE, DISABLE, FALSE);
 		}
-	}
-
-	if (reg_val) {
-		mipidbg("LPTX Error Occur: 0x%x\n", reg_val);
-	}
-
-	if (reg_val2) {
-		mipidbg("error occured #\n");
 	}
 }
 

--- a/os/board/rtl8730e/src/rtl8730e_mipi_lcdc.c
+++ b/os/board/rtl8730e/src/rtl8730e_mipi_lcdc.c
@@ -67,11 +67,13 @@ static void rtl8730e_lcd_put_area(u8 *lcd_img_buffer, u32 x_start, u32 y_start, 
 static void rtl8730e_enable_lcdc(void);
 static void rtl8730e_register_lcdc_isr(void);
 static void rtl8730e_control_backlight(u8 level);
+static void rtl8730e_mipi_driver_reinitialize(void);
 FAR void mipi_mode_switch_to_video(bool do_enable);
 FAR void mipidsi_acpu_reg_clear(void);
 FAR struct mipi_dsi_host *amebasmart_mipi_dsi_host_initialize(struct lcd_data *config);
 FAR struct mipi_dsi_device *mipi_dsi_device_register(FAR struct mipi_dsi_host *host, FAR const char *name, int channel);
 FAR struct lcd_dev_s *mipi_lcdinitialize(FAR struct mipi_dsi_device *dsi, struct mipi_lcd_config_s *config);
+FAR void amebasmart_mipi_dsi_host_reinitialize(void);
 
 struct rtl8730e_lcdc_info_s g_rtl8730e_config_dev_s = {
 	.lcd_config = {
@@ -83,7 +85,10 @@ struct rtl8730e_lcdc_info_s g_rtl8730e_config_dev_s = {
 		.lcd_put_area = rtl8730e_lcd_put_area,
 		.backlight = rtl8730e_control_backlight,
 		.power_off = rtl8730e_lcd_power_off,
-		.power_on = rtl8730e_lcd_power_on
+		.power_on = rtl8730e_lcd_power_on,
+
+		/* for resetting host stack */
+		.mipi_drv_reset = rtl8730e_mipi_driver_reinitialize
 	},
 };
 
@@ -149,7 +154,7 @@ static void rtl8730e_lcd_power_off(void)
 static void rtl8730e_lcd_power_on(void)
 {
 	GPIO_WriteBit(MIPI_GPIO_RESET_PIN, PIN_HIGH);
-	DelayMs(120);
+	DelayMs(140);  // additional time needed for the panel to stabilize and accept commands 
 }
 static void rtl8730e_gpio_reset(void)
 {
@@ -306,6 +311,16 @@ u32 rtl8730e_hv_isr(void *Data)
 		}
 	}
 	return 0;
+}
+
+static void rtl8730e_mipi_driver_reinitialize(void)
+{
+	lcddbg("Reinit MIPI DSI Host Driver\n");
+	amebasmart_mipi_dsi_host_reinitialize();
+
+	lcddbg("Reinit LCDC Driver\n");
+	rtl8730e_lcd_init();
+	rtl8730e_enable_lcdc();
 }
 
 static void rtl8730e_register_lcdc_isr(void){

--- a/os/drivers/lcd/Kconfig
+++ b/os/drivers/lcd/Kconfig
@@ -208,6 +208,13 @@ config LCD_SEND_CMD_RETRY_COUNT
 		If send command gets fail in command mode, then this config will retry
 		send command to LCD.
 
+config LCD_SEND_VENDOR_ID_CMD_RETRY_COUNT
+	int "LCD send vendor id cmd retry count"
+	default 3
+	---help---
+		For certain LCD panels such as ST7785, vendor ID is used to determine the correct init sequence to send.
+		When these panels are hotplugged, the MIPI+LCD stack requires to be reinitialized while the panel is power cycled
+		After this is done, this config will allow driver to re-send the vendor ID command to check panel status.
 endif
 
 if LCD_ST7789

--- a/os/drivers/lcd/st7785.c
+++ b/os/drivers/lcd/st7785.c
@@ -30,10 +30,17 @@ int check_lcd_vendor_send_init_cmd(struct mipi_lcd_dev_s *priv)
 	int status;
 	status = set_return_packet_len(priv, length);
 	if (status != OK) {
-		return status;
+		lcddbg("Fail set return pkt len!\n");
+
+		/* 
+		allow this error case to drop down to next, allowing the MIPI DPHY to read ANY response length
+		because it is possible that some other response may be received outside of expected length 
+		as long as LCD responds with anything, we can properly reset it back to a working state
+		*/
 	}
 	status = read_response(priv, read_display_cmd, rxbuf, length);
 	if (status != OK) {
+		lcddbg("Fail read resp!\n");
 		return status;
 	}
 	combined_id = (rxbuf[0] << 16) | (rxbuf[1] << 8) | rxbuf[2];

--- a/os/include/tinyara/lcd/mipi_lcd.h
+++ b/os/include/tinyara/lcd/mipi_lcd.h
@@ -65,6 +65,9 @@ struct mipi_lcd_config_s {
 	void (*lcd_put_area)(u8 *lcd_img_buffer, u32 x1, u32 y1, u32 x2, u32 y2);
 	void (*power_off)();
 	void (*power_on)();
+
+	/* For resetting host stack */
+	void (*mipi_drv_reset)();
 };
 
 #endif	/* __DRIVERS_LCD_MIPI_H */


### PR DESCRIPTION
This commit fixes several issues in MIPI driver when certain LCDs are forcefully disconnected and reconnected, causing the driver stack to stop TX/RX. This issue was verified to happen on ST7785 panels, but not on ST7701 panels (using the respective configs)

The init sequence is retried multiple times (power cycle -> reset lcd -> reset driver stack)

Additional error handling is added for MIPI DPHY error cases such as ERRCONTROL and ERRSYNCESC, which happen when the LCD is out of sync with the MIPI host

```
TASH>>
TASH>>lcd_test
TASH>>=== LCD demo ===
xres : 320, yres:240

<--- LCD is detached during the test (display colors/patterns)

lcddev_ioctl: LCD Backlight 100 -> 0
lcd_setpower: Powering down the LCD
lcd_setpower: Switch to CMD mode
lcd_setpower: Changed lcd backlight to 0
lcddev_ioctl: Unlock pm & silent reboot
lcddev_ioctl: LCD Backlight 0 -> 100
lcddev_ioctl: Lock pm & silent reboot
lcd_setpower: Powering up the LCD
amebasmart_mipidsi_isr: LPTX Error: 0x40, DPHY Error: 0x8
amebasmart_mipidsi_isr: Handle ERRCONTROL: LPTX Error CLR: 0x40, DPHY: 0x8
amebasmart_mipidsi_isr: LPTX Still Error 

<--- LCD is plugged back when this message appears here

read_response: Command 4 not sent
rtl8730e_mipi_driver_reinitialize: Reinit MIPI DSI Host Driver
amebasmart_check_freq: vo_freq: 11
amebasmart_mipi_fill_buffer: DataLaneFreq: 141, LineTime: 874...bitsperpixel:16
amebasmart_mipidsi_isr: RCMD: 8a 0 0 0 0
amebasmart_mipidsi_isr: LPTX Error: 0x78, DPHY Error: 0x8
amebasmart_mipidsi_isr: Handle ERRCONTROL: LPTX Error CLR: 0x0, DPHY: 0x0

<--- As long as RCMD has some data, it means the LCD is partially reset and ready for re-init

rtl8730e_lcd_driver_reinitialize: Reinit LCDC Driver
amebasmart_mipidsi_isr: RCMD: 8a 8a 85 0 0
check_lcd_vendor_send_init_cmd: LCD ID: 8a8a85

<--- LCD ID has been received again, LCD is successfully init

lcd_setpower: Changed lcd backlight to 100
count :1
xres : 320, yres:240
lcd_putarea: Switch to VIDEO mode
lcddev_ioctl: LCD Backlight 100 -> 0
lcd_setpower: Powering down the LCD
lcd_setpower: Switch to CMD mode
lcd_setpower: Changed lcd backlight to 0
lcddev_ioctl: Unlock pm & silent reboot
lcddev_ioctl: LCD Backlight 0 -> 100
lcddev_ioctl: Lock pm & silent reboot
lcd_setpower: Powering up the LCD
amebasmart_mipidsi_isr: RCMD: 8a 8a 85 0 0
check_lcd_vendor_send_init_cmd: LCD ID: 8a8a85
lcd_setpower: Changed lcd backlight to 100
count :2
```