### PR TITLE
build/configs/rtl8730e: Fix incorrect NM override

### DIFF
--- a/build/configs/rtl8730e/Make.defs
+++ b/build/configs/rtl8730e/Make.defs
@@ -104,7 +104,6 @@ LD_ROM = $(CROSSDEV)ld
 CC_SIZE = $(CROSSDEV)size
 FROMELF = $(CROSSDEV)objcopy
 STRIP   = $(CROSSDEV)strip
-NM	= $(ARCROSSDEV)nm
 
 GDB = arm-none-eabi-gdb
 GDBR = arm-none-eabi-gdb


### PR DESCRIPTION
The `NM` variable was defined twice, with the second definition overriding the first one.
However, the first definition using `$(CROSSDEV)nm` is correct.

When `CONFIG_ARMV7A_TOOLCHAIN_GNU_EABI` is enabled, `NM` should resolve to `arm-none-eabi-nm`.
Since `ARCROSSDEV` is not defined for ARMv7-A, the second definition incorrectly sets `NM` to just `nm`.

This removes the redundant override to ensure the correct `NM` variable is set.