### PR TITLE
fs/driver: add support to register/unregister MTD driver

### DIFF
--- a/os/fs/driver/Make.defs
+++ b/os/fs/driver/Make.defs
@@ -81,6 +81,8 @@ endif
 
 ifeq ($(CONFIG_MTD),y)
 CSRCS_DRIVER += mtd/mtd_config.c
+CSRCS_DRIVER += mtd/fs_registermtddriver.c mtd/fs_unregistermtddriver.c
+
 
 ifeq ($(CONFIG_MTD_FTL),y)
 CSRCS_DRIVER += mtd/ftl.c

--- a/os/fs/driver/mtd/fs_registermtddriver.c
+++ b/os/fs/driver/mtd/fs_registermtddriver.c
@@ -1,0 +1,114 @@
+/****************************************************************************
+ *
+ * Copyright 2025 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+/****************************************************************************
+ * fs/driver/mtd/fs_registermtddriver.c
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+#include <tinyara/config.h>
+
+#include <sys/types.h>
+#include <errno.h>
+
+#include <tinyara/fs/fs.h>
+#include <tinyara/fs/mtd.h>
+
+#include "inode/inode.h"
+
+#if defined(CONFIG_MTD) && !defined(CONFIG_DISABLE_MOUNTPOINT)
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: register_mtddriver
+ *
+ * Description:
+ *   Register an MTD driver inode the pseudo file system.
+ *
+ * Input Parameters:
+ *   path - The path to the inode to create
+ *   mtd  - The MTD driver structure
+ *   mode - inode privileges (not used)
+ *   priv - Private, user data that will be associated with the inode.
+ *
+ * Returned Value:
+ *   Zero on success (with the inode point in 'inode'); A negated errno
+ *   value is returned on a failure (all error values returned by
+ *   inode_reserve):
+ *
+ *   EINVAL - 'path' is invalid for this operation
+ *   EEXIST - An inode already exists at 'path'
+ *   ENOMEM - Failed to allocate in-memory resources for the operation
+ *
+ ****************************************************************************/
+
+int register_mtddriver(FAR const char *path, FAR struct mtd_dev_s *mtd, mode_t mode, FAR void *priv)
+{
+	FAR struct inode *node;
+	int ret;
+
+	/* Insert an inode for the device driver -- we need to hold the inode
+	 * semaphore to prevent access to the tree while we this.  This is because
+	 * we will have a momentarily bad true until we populate the inode with
+	 * valid data.
+	 */
+
+	inode_semtake();
+	ret = inode_reserve(path, &node);
+	if (ret >= 0) {
+		/* We have it, now populate it with block driver specific information.
+		 * NOTE that the initial reference count on the new inode is zero.
+		 */
+
+		INODE_SET_MTD(node);
+
+		node->u.i_mtd = mtd;
+#ifdef CONFIG_FILE_MODE
+		node->i_mode = mode;
+#endif
+		node->i_private = priv;
+		ret = OK;
+	}
+
+	inode_semgive();
+	return ret;
+}
+
+#endif							/* CONFIG_MTD && !CONFIG_DISABLE_MOUNTPOINT */

--- a/os/fs/driver/mtd/fs_unregistermtddriver.c
+++ b/os/fs/driver/mtd/fs_unregistermtddriver.c
@@ -1,0 +1,70 @@
+/****************************************************************************
+ *
+ * Copyright 2025 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+/****************************************************************************
+ * fs/driver/mtd/fs_unregistermtddriver.c
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+#include <tinyara/config.h>
+
+#include <tinyara/fs/fs.h>
+#include <tinyara/fs/mtd.h>
+
+#include "inode/inode.h"
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: unregister_mtddriver
+ *
+ * Description:
+ *   Remove the named TMD driver inode at 'path' from the pseudo-file system
+ *
+ ****************************************************************************/
+
+int unregister_mtddriver(FAR const char *path)
+{
+	int ret;
+
+	inode_semtake();
+	ret = inode_remove(path);
+	inode_semgive();
+	return ret;
+}

--- a/os/fs/inode/inode.h
+++ b/os/fs/inode/inode.h
@@ -79,6 +79,7 @@
 #define   FSNODEFLAG_TYPE_NAMEDSEM 0x00000004	/*   Named semaphore          */
 #define   FSNODEFLAG_TYPE_MQUEUE   0x00000005	/*   Message Queue            */
 #define   FSNODEFLAG_TYPE_SHM      0x00000006	/*   Shared memory region     */
+#define   FSNODEFLAG_TYPE_MTD      0x00000007	/*   Named MTD driver         */
 #define FSNODEFLAG_DELETED         0x00000008	/* Unlinked                   */
 
 #define INODE_IS_TYPE(i, t) \
@@ -92,6 +93,7 @@
 #define INODE_IS_NAMEDSEM(i)  INODE_IS_TYPE(i, FSNODEFLAG_TYPE_NAMEDSEM)
 #define INODE_IS_MQUEUE(i)    INODE_IS_TYPE(i, FSNODEFLAG_TYPE_MQUEUE)
 #define INODE_IS_SHM(i)       INODE_IS_TYPE(i, FSNODEFLAG_TYPE_SHM)
+#define INODE_IS_MTD(i)       INODE_IS_TYPE(i, FSNODEFLAG_TYPE_MTD)
 
 #define INODE_GET_TYPE(i)     ((i)->i_flags & FSNODEFLAG_TYPE_MASK)
 #define INODE_SET_TYPE(i, t) \
@@ -105,6 +107,7 @@
 #define INODE_SET_NAMEDSEM(i) INODE_SET_TYPE(i, FSNODEFLAG_TYPE_NAMEDSEM)
 #define INODE_SET_MQUEUE(i)   INODE_SET_TYPE(i, FSNODEFLAG_TYPE_MQUEUE)
 #define INODE_SET_SHM(i)      INODE_SET_TYPE(i, FSNODEFLAG_TYPE_SHM)
+#define INODE_SET_MTD(i)      INODE_SET_TYPE(i, FSNODEFLAG_TYPE_MTD)
 
 /* Mountpoint fd_flags values */
 

--- a/os/include/tinyara/fs/fs.h
+++ b/os/include/tinyara/fs/fs.h
@@ -261,6 +261,7 @@ union inode_ops_u {
 		*i_ops;						/* Driver operations for inode */
 #ifndef CONFIG_DISABLE_MOUNTPOINT
 	FAR const struct block_operations *i_bops;	/* Block driver operations */
+	FAR struct mtd_dev_s *i_mtd;	/* MTD device driver */
 	FAR const struct mountpt_operations
 		*i_mops;					/* Operations on a mountpoint */
 #endif


### PR DESCRIPTION
fs/driver/mtd : add support to register and unregister the MTD driver.

littleFS can directly work with MTD driver.
Adding support for it.Build is working fine for configuration "rtl8730e/flat_dev_ddr_nand".

CC:  driver/mtd/mtd_config.c
CC:  driver/mtd/fs_registermtddriver.c
CC:  driver/mtd/fs_unregistermtddriver.c
CC:  driver/mtd/ftl.c
CC:  driver/mtd/ftl_nand.c
CC:  driver/mtd/little.c

