### PR TITLE
os/kernel/: Add null check to some kernel api

### DIFF
--- a/os/kernel/clock/clock_getres.c
+++ b/os/kernel/clock/clock_getres.c
@@ -107,6 +107,10 @@ int clock_getres(clockid_t clock_id, struct timespec *res)
 {
 	int ret = OK;
 
+	if (!res) {
+		return -EINVAL;
+	}
+
 	svdbg("clock_id=%d\n", clock_id);
 
 	/* Only CLOCK_REALTIME is supported */

--- a/os/kernel/clock/clock_gettime.c
+++ b/os/kernel/clock/clock_gettime.c
@@ -60,7 +60,6 @@
 
 #include <stdint.h>
 #include <time.h>
-#include <assert.h>
 #include <errno.h>
 #include <debug.h>
 
@@ -114,8 +113,11 @@ int clock_gettime(clockid_t clock_id, struct timespec *tp)
 	uint32_t carry;
 	int ret = OK;
 
+	if (!tp) {
+		return -EINVAL;
+	}
+
 	svdbg("clock_id=%d\n", clock_id);
-	DEBUGASSERT(tp != NULL);
 
 #ifdef CONFIG_CLOCK_MONOTONIC
 	/* CLOCK_MONOTONIC is an optional under POSIX: "If the Monotonic Clock

--- a/os/kernel/environ/env_getenvironptr.c
+++ b/os/kernel/environ/env_getenvironptr.c
@@ -92,6 +92,11 @@ FAR char *get_environ_ptr(size_t *envsize)
 	FAR struct task_group_s *group;
 	char *ret;
 
+	if (!envsize) {
+		set_errno(EINVAL);
+		return NULL;
+	}
+
 	group = ptcb->group;
 	if (group && group->tg_envp) {
 		*envsize = group->tg_envsize;

--- a/os/kernel/pthread/pthread_keycreate.c
+++ b/os/kernel/pthread/pthread_keycreate.c
@@ -98,7 +98,7 @@ int pthread_key_create(FAR pthread_key_t *key, pthread_destructor_t destructor)
 	DEBUGASSERT(group);
 
 	if (!key) {
-		return EINVAL;
+		return -EINVAL;
 	}
 
 	/* Find free key */

--- a/os/kernel/sched/sched_waitpid.c
+++ b/os/kernel/sched/sched_waitpid.c
@@ -208,7 +208,6 @@ pid_t waitpid(pid_t pid, int *stat_loc, int options)
 
 	DEBUGASSERT(stat_loc);
 
-
 	/* None of the options are supported */
 
 	if (options != 0) {
@@ -316,6 +315,10 @@ pid_t waitpid(pid_t pid, int *stat_loc, int options)
 	int ret;
 
 	DEBUGASSERT(stat_loc);
+	if (!stat_loc) {
+		set_errno(EINVAL);
+		return ERROR;
+	}
 
 	/* None of the options are supported */
 


### PR DESCRIPTION
For some syscalls, there are security issues because null check is not performed in corresponding kernel apis. This pr adds null check