### PR TITLE
os/include/tinyara/log_dump: Reduce stack size of log_dump

### DIFF
--- a/os/include/tinyara/log_dump/log_dump.h
+++ b/os/include/tinyara/log_dump/log_dump.h
@@ -28,7 +28,7 @@
 
 /* Log Dump Thread information */
 #define LOG_DUMP_NAME        "log_dump"		/* Log dump thread name */
-#define LOG_DUMP_STACKSIZE   16384		/* Log dump thread stack size */
+#define LOG_DUMP_STACKSIZE   10240		/* Log dump thread stack size */
 #define LOG_DUMP_PRIORITY    100		/* Log dump thread priority */
 
 #define LOGDUMP_SAVE_START	"1"


### PR DESCRIPTION
log_dump uses global variables or static allocations, so it does not appear to consume additional stack space. 
Its current peak stack usage is approximately 7K against a 16K allocation. 
Reducing this allocation to 10K would free roughly 6K of stack memory while retaining a 3K buffer.