### PR TITLE
os/include/sys: Remove config use from syscalls

### DIFF
--- a/os/include/sys/syscall.h
+++ b/os/include/sys/syscall.h
@@ -112,119 +112,58 @@
 #define SYS_sem_timedwait              (__SYS_sem + 2)
 #define SYS_sem_trywait                (__SYS_sem + 3)
 #define SYS_sem_wait                   (__SYS_sem + 4)
-
-#ifdef CONFIG_PRIORITY_INHERITANCE
 #define SYS_sem_setprotocol            (__SYS_sem + 5)
 #define __SYS_named_sem                (__SYS_sem + 6)
-#else
-#define __SYS_named_sem                (__SYS_sem + 5)
-#endif
 
 /* Named semaphores */
 
-#ifdef CONFIG_FS_NAMED_SEMAPHORES
 #define SYS_sem_open                   __SYS_named_sem
 #define SYS_sem_close                  (__SYS_named_sem + 1)
 #define SYS_sem_unlink                 (__SYS_named_sem + 2)
 #define __SYS_task_create              (__SYS_named_sem + 3)
-#else
-#define __SYS_task_create              (__SYS_named_sem)
-#endif
 
 /* Task creation APIs based on global entry points cannot be use with
  * address environments.
  */
 
-#ifndef CONFIG_BUILD_KERNEL
 #define SYS_task_create                __SYS_task_create
-#define __SYS_task_delete              (__SYS_task_create + 1)
-
-/* pgalloc() is only available with address environments with the page
- * allocator selected.  MMU support from the CPU is also required.
- */
-
-#else
-#define SYS_pgalloc                    __SYS_task_create
-#define __SYS_task_delete              (__SYS_task_create + 1)
-#endif
+#define SYS_pgalloc                    __SYS_task_create + 1
+#define __SYS_task_delete              (__SYS_task_create + 2)
 
 #define SYS_task_delete                __SYS_task_delete
 #define SYS_task_restart               (__SYS_task_delete + 1)
-#ifdef CONFIG_CANCELLATION_POINTS
 #define SYS_task_testcancel            (__SYS_task_delete + 2)
 #define SYS_task_setcanceltype         (__SYS_task_delete + 3)
 #define SYS_task_setcancelstate        (__SYS_task_delete + 4)
 #define SYS_up_assert                  (__SYS_task_delete + 5)
 #define __SYS_vfork                    (__SYS_task_delete + 6)
-#else
-#define SYS_task_setcancelstate        (__SYS_task_delete + 2)
-#define SYS_up_assert                  (__SYS_task_delete + 3)
-#define __SYS_vfork                    (__SYS_task_delete + 4)
-#endif
-
 
 /* The following can be individually enabled */
 
-#if defined(CONFIG_ARCH_HAVE_VFORK) && defined(CONFIG_SCHED_WAITPID)
 #define SYS_vfork                      __SYS_vfork
 #define __SYS_atexit                   (__SYS_vfork + 1)
-#else
-#define __SYS_atexit                   __SYS_vfork
-#endif
-
-#ifdef CONFIG_SCHED_ATEXIT
 #define SYS_atexit                     __SYS_atexit
 #define __SYS_on_exit                  (__SYS_atexit + 1)
-#else
-#define __SYS_on_exit                  __SYS_atexit
-#endif
-
-#ifdef CONFIG_SCHED_ONEXIT
 #define SYS_on_exit                    __SYS_on_exit
 #define __SYS_waitpid                  (__SYS_on_exit + 1)
-#else
-#define __SYS_waitpid                  __SYS_on_exit
-#endif
-
-#ifdef CONFIG_SCHED_WAITPID
 #define SYS_waitpid                    __SYS_waitpid
-#ifdef CONFIG_SCHED_HAVE_PARENT
 #define SYS_wait                       (__SYS_waitpid + 1)
 #define SYS_waitid                     (__SYS_waitpid + 2)
 #define __SYS_exec                     (__SYS_waitpid + 3)
-#else
-#define __SYS_exec                     (__SYS_waitpid + 1)
-#endif
-#else
-#define __SYS_exec                     __SYS_waitpid
-#endif
 
 /* The following can only be defined if we are configured to execute
  * programs from a file system.
  */
 
-#ifdef CONFIG_BINFMT_ENABLE
-#ifndef CONFIG_BUILD_KERNEL
 #define SYS_exec                       __SYS_exec
 #define __SYS_execv                    (__SYS_exec + 1)
-#else
-#define __SYS_execv                    __SYS_exec
-#endif
-#ifdef CONFIG_LIBC_EXECFUNCS
 #define SYS_execv                      __SYS_execv
 #define __SYS_signals                  (__SYS_execv + 1)
-#else
-#define __SYS_signals                  __SYS_execv
-#endif
-#else
-#define __SYS_signals                  __SYS_exec
-#endif
 
 /* The following are only defined is signals are supported in the TinyAra
  * configuration.
  */
 
-#ifndef CONFIG_DISABLE_SIGNALS
 #define SYS_kill                       (__SYS_signals + 0)
 #define SYS_sigaction                  (__SYS_signals + 1)
 #define SYS_sigpending                 (__SYS_signals + 2)
@@ -235,9 +174,6 @@
 #define SYS_sigwaitinfo                (__SYS_signals + 7)
 #define SYS_nanosleep                  (__SYS_signals + 8)
 #define __SYS_clock                    (__SYS_signals + 9)
-#else
-#define __SYS_clock                    __SYS_signals
-#endif
 
 /* The following are only defined if the system clock is enabled in the
  * TinyAra configuration.
@@ -252,16 +188,12 @@
 
 /* The following are defined only if POSIX timers are supported */
 
-#ifndef CONFIG_DISABLE_POSIX_TIMERS
 #define SYS_timer_create               (__SYS_timers + 0)
 #define SYS_timer_delete               (__SYS_timers + 1)
 #define SYS_timer_getoverrun           (__SYS_timers + 2)
 #define SYS_timer_gettime              (__SYS_timers + 3)
 #define SYS_timer_settime              (__SYS_timers + 4)
 #define __SYS_descriptors              (__SYS_timers + 5)
-#else
-#define __SYS_descriptors              __SYS_timers
-#endif
 
 /* The following are defined if either file or socket descriptor are
  * enabled.
@@ -272,48 +204,28 @@
 #define CONFIG_NSOCKET_DESCRIPTORS 0
 #endif
 
-#if CONFIG_NFILE_DESCRIPTORS > 0 || CONFIG_NSOCKET_DESCRIPTORS > 0
 #define SYS_close                      (__SYS_descriptors + 0)
-#ifdef CONFIG_LIBC_IOCTL_VARIADIC
 #define SYS_fs_ioctl                   (__SYS_descriptors + 1)
-#else
 #define SYS_ioctl                      (__SYS_descriptors + 1)
-#endif
 #define SYS_read                       (__SYS_descriptors + 2)
 #define SYS_write                      (__SYS_descriptors + 3)
 #define SYS_pread                      (__SYS_descriptors + 4)
 #define SYS_pwrite                     (__SYS_descriptors + 5)
-#ifdef CONFIG_FS_AIO
 #define SYS_aio_read                   (__SYS_descriptors + 6)
 #define SYS_aio_write                  (__SYS_descriptors + 7)
 #define SYS_aio_fsync                  (__SYS_descriptors + 8)
 #define SYS_aio_cancel                 (__SYS_descriptors + 9)
 #define __SYS_poll                     (__SYS_descriptors + 10)
-#else
-#define __SYS_poll                     (__SYS_descriptors + 6)
-#endif
-#ifndef CONFIG_DISABLE_POLL
 #define SYS_poll                       __SYS_poll
 #define SYS_select                     (__SYS_poll + 1)
 #define __SYS_boardctl                 (__SYS_poll + 2)
-#else
-#define __SYS_boardctl                 __SYS_poll
-#endif
-#else
-#define __SYS_boardctl                 __SYS_descriptors
-#endif
 
 /* Board support */
-#ifdef CONFIG_LIB_BOARDCTL
 #define SYS_boardctl                  __SYS_boardctl
 #define __SYS_filedesc                (__SYS_boardctl + 1)
-#else
-#define __SYS_filedesc                __SYS_boardctl
-#endif
 
 /* The following are defined if file descriptors are enabled */
 
-#if CONFIG_NFILE_DESCRIPTORS > 0
 #define SYS_closedir                   (__SYS_filedesc + 0)
 #define SYS_dup                        (__SYS_filedesc + 1)
 #define SYS_dup2                       (__SYS_filedesc + 2)
@@ -321,36 +233,21 @@
 #define SYS_fstat                      (__SYS_filedesc + 4)
 #define SYS_fstatfs                    (__SYS_filedesc + 5)
 #define SYS_lseek                      (__SYS_filedesc + 6)
-#if defined(CONFIG_PIPES)
 #define SYS_mkfifo                     (__SYS_filedesc + 7)
 #define __SYS_mmap                     (__SYS_filedesc + 8)
-#else
-#define __SYS_mmap                     (__SYS_filedesc + 7)
-#endif
 #define SYS_mmap                       (__SYS_mmap + 0)
 #define SYS_open                       (__SYS_mmap + 1)
 #define SYS_opendir                    (__SYS_mmap + 2)
-#if defined(CONFIG_PIPES)
 #define SYS_pipe                       (__SYS_mmap + 3)
 #define __SYS_readdir                  (__SYS_mmap + 4)
-#else
-#define __SYS_readdir                  (__SYS_mmap + 3)
-#endif
 #define SYS_readdir                    (__SYS_readdir + 0)
 #define SYS_rewinddir                  (__SYS_readdir + 1)
 #define SYS_seekdir                    (__SYS_readdir + 2)
 #define SYS_stat                       (__SYS_readdir + 3)
 #define SYS_statfs                     (__SYS_readdir + 4)
-
-#if CONFIG_NFILE_STREAMS > 0
 #define SYS_fs_fdopen                  (__SYS_readdir + 5)
 #define SYS_sched_getstreams           (__SYS_readdir + 6)
 #define __SYS_mountpoint               (__SYS_readdir + 7)
-#else
-#define __SYS_mountpoint               (__SYS_readdir + 5)
-#endif
-
-#if !defined(CONFIG_DISABLE_MOUNTPOINT)
 #define SYS_fsync                      (__SYS_mountpoint + 0)
 #define SYS_mkdir                      (__SYS_mountpoint + 1)
 #define SYS_mount                      (__SYS_mountpoint + 2)
@@ -360,29 +257,17 @@
 #define SYS_unlink                     (__SYS_mountpoint + 6)
 #define SYS_ftruncate                  (__SYS_mountpoint + 7)
 #define __SYS_shm                      (__SYS_mountpoint + 8)
-#else
-#define __SYS_shm                      __SYS_mountpoint
-#endif
-
-#else
-#define __SYS_shm                      __SYS_filedesc
-#endif
 
 /* Shared memory interfaces */
 
-#ifdef CONFIG_MM_SHM
 #define SYS_shmget                     (__SYS_shm + 0)
 #define SYS_shmat                      (__SYS_shm + 1)
 #define SYS_shmctl                     (__SYS_shm + 2)
 #define SYS_shmdt                      (__SYS_shm + 3)
 #define __SYS_pthread                  (__SYS_shm + 4)
-#else
-#define __SYS_pthread                  __SYS_shm
-#endif
 
 /* The following are defined if pthreads are enabled */
 
-#ifndef CONFIG_DISABLE_PTHREAD
 #define SYS_pthread_cancel             (__SYS_pthread + 0)
 #define SYS_pthread_cond_broadcast     (__SYS_pthread + 1)
 #define SYS_pthread_cond_signal        (__SYS_pthread + 2)
@@ -401,37 +286,20 @@
 #define SYS_pthread_mutex_lock         (__SYS_pthread + 15)
 #define SYS_pthread_mutex_trylock      (__SYS_pthread + 16)
 #define SYS_pthread_mutex_unlock       (__SYS_pthread + 17)
-
-#ifndef CONFIG_PTHREAD_MUTEX_UNSAFE
 #define SYS_pthread_mutex_consistent   (__SYS_pthread + 18)
 #define __SYS_pthread_setschedparam    (__SYS_pthread + 19)
-#else
-#define __SYS_pthread_setschedparam    (__SYS_pthread + 18)
-#endif
-
 #define SYS_pthread_setaffinity_np     (__SYS_pthread_setschedparam + 0)	
 #define SYS_pthread_getaffinity_np     (__SYS_pthread_setschedparam + 1)	
-
 #define SYS_pthread_setschedparam      (__SYS_pthread_setschedparam + 2)
 #define SYS_pthread_setschedprio       (__SYS_pthread_setschedparam + 3)
 #define SYS_pthread_setspecific        (__SYS_pthread_setschedparam + 4)
-
-#ifndef CONFIG_DISABLE_SIGNAL
 #define SYS_pthread_cond_timedwait     (__SYS_pthread_setschedparam + 5)
 #define SYS_pthread_kill               (__SYS_pthread_setschedparam + 6)
 #define SYS_pthread_sigmask            (__SYS_pthread_setschedparam + 7)
 #define __SYS_mqueue                   (__SYS_pthread_setschedparam + 8)
-#else
-#define __SYS_mqueue                   (__SYS_pthread_setschedparam + 5)
-#endif
-
-#else
-#define __SYS_mqueue                   __SYS_pthread
-#endif
 
 /* The following are defined only if message queues are enabled */
 
-#ifndef CONFIG_DISABLE_MQUEUE
 #define SYS_mq_close                   (__SYS_mqueue + 0)
 #define SYS_mq_getattr                 (__SYS_mqueue + 1)
 #define SYS_mq_notify                  (__SYS_mqueue + 2)
@@ -443,13 +311,9 @@
 #define SYS_mq_timedsend               (__SYS_mqueue + 8)
 #define SYS_mq_unlink                  (__SYS_mqueue + 9)
 #define __SYS_environ                  (__SYS_mqueue + 10)
-#else
-#define __SYS_environ                  __SYS_mqueue
-#endif
 
 /* The following are defined only if environment variables are supported */
 
-#ifndef CONFIG_DISABLE_ENVIRON
 #define SYS_clearenv                   (__SYS_environ + 0)
 #define SYS_getenv                     (__SYS_environ + 1)
 #define SYS_putenv                     (__SYS_environ + 2)
@@ -457,13 +321,9 @@
 #define SYS_unsetenv                   (__SYS_environ + 4)
 #define SYS_get_environ_ptr            (__SYS_environ + 5)
 #define __SYS_network                  (__SYS_environ + 6)
-#else
-#define __SYS_network                  __SYS_environ
-#endif
 
 /* The following are defined only if networking AND sockets are supported */
 
-#if CONFIG_NSOCKET_DESCRIPTORS > 0 && defined(CONFIG_NET)
 #define SYS_accept                     (__SYS_network + 0)
 #define SYS_bind                       (__SYS_network + 1)
 #define SYS_connect                    (__SYS_network + 2)
@@ -481,9 +341,6 @@
 #define SYS_shutdown                   (__SYS_network + 14)
 #define SYS_socket                     (__SYS_network + 15)
 #define __SYS_prctl                    (__SYS_network + 16)
-#else
-#define __SYS_prctl                    __SYS_network
-#endif
 
 #define SYS_prctl                      __SYS_prctl
 

--- a/os/tools/mksyscall.c
+++ b/os/tools/mksyscall.c
@@ -214,6 +214,22 @@ static FILE *open_proxy(void)
 	return stream;
 }
 
+static bool check_special_case(const char *name)
+{
+	static const char *special_syscalls[] = {
+		"ioctl",
+	};
+
+	int count = sizeof(special_syscalls) / sizeof(special_syscalls[0]);
+
+	for (int i = 0; i < count; i++) {
+		if (strncmp(name, special_syscalls[i], strlen(special_syscalls[i]) + 1) == 0) {
+			return true;
+		}
+	}
+	return false;
+}
+
 static void generate_proxy(int nparms)
 {
 	FILE *stream = open_proxy();
@@ -224,6 +240,7 @@ static void generate_proxy(int nparms)
 	int nactual;
 	char *cond_parm;
 	int i;
+	bool special_case = false;
 
 	/* Generate "up-front" information, include correct header files */
 
@@ -246,9 +263,12 @@ static void generate_proxy(int nparms)
 
 	fprintf(stream, "#include <syscall.h>\n\n");
 
+	special_case = check_special_case(get_parm(NAME_INDEX));
 	cond_parm = get_parm(COND_INDEX);
-	if (cond_parm[0] != '\0')
+
+	if (cond_parm[0] != '\0' && special_case == true) {
 		fprintf(stream, "#if %s\n\n", cond_parm);
+	}
 
 	/* Generate the function definition that matches standard function prototype */
 
@@ -337,11 +357,10 @@ static void generate_proxy(int nparms)
 	} else {
 		fprintf(stream, ");\n}\n\n");
 	}
-
-	cond_parm = get_parm(COND_INDEX);
-	if (cond_parm[0] != '\0')
+	if (cond_parm[0] != '\0' && special_case == true) {
 		fprintf(stream, "#endif /* %s */\n", cond_parm);
-
+		special_case = false;
+	}
 	fclose(stream);
 }
 
@@ -390,21 +409,23 @@ static void generate_stub(int nparms)
 	char *cond_parm;
 	int i;
 	int j;
+	cond_parm = get_parm(COND_INDEX);
 
 	/* Generate "up-front" information, include correct header files */
 
 	fprintf(stream, "/* Auto-generated %s stub file -- do not edit */\n\n", get_parm(0));
 	fprintf(stream, "#include <tinyara/config.h>\n");
 	fprintf(stream, "#include <stdint.h>\n");
+	
+	if (cond_parm[0] != '\0') {
+		fprintf(stream, "#include <errno.h>\n");
+		fprintf(stream, "#include <sys/types.h>\n");
+	}
 
 	if (get_parm(HEADER_INDEX) && strlen(get_parm(HEADER_INDEX)) > 0)
 		fprintf(stream, "#include <%s>\n", get_parm(HEADER_INDEX));
 
 	putc('\n', stream);
-
-	cond_parm = get_parm(COND_INDEX);
-	if (cond_parm[0] != '\0')
-		fprintf(stream, "#if %s\n\n", cond_parm);
 
 	/* Generate the function definition that matches standard function prototype */
 
@@ -429,15 +450,19 @@ static void generate_stub(int nparms)
 
 	fprintf(stream, ")\n{\n");
 
+	if (cond_parm[0] != '\0') {
+		fprintf(stream, "#if %s\n", cond_parm);
+	}
+
 	/* Then call the proxied function.  Functions that have no return value are
 	 * a special case.
 	 */
 
-	if (strcmp(get_parm(RETTYPE_INDEX), "void") == 0)
+	if (strcmp(get_parm(RETTYPE_INDEX), "void") == 0) {
 		fprintf(stream, "  %s(", get_parm(NAME_INDEX));
-	else
+	} else {
 		fprintf(stream, "  return (uintptr_t)%s(", get_parm(NAME_INDEX));
-
+	}
 	/* The pass all of the system call parameters, casting to the correct type
 	 * as necessary.
 	 */
@@ -482,15 +507,26 @@ static void generate_stub(int nparms)
 	/* Tail end of the function.  If the proxied function has no return
 	 * value, just return zero (OK).
 	 */
-
-	if (strcmp(get_parm(RETTYPE_INDEX), "void") == 0)
-		fprintf(stream, ");\n  return 0;\n}\n\n");
-	else
-		fprintf(stream, ");\n}\n\n");
-
-	cond_parm = get_parm(COND_INDEX);
-	if (cond_parm[0] != '\0')
-		fprintf(stream, "#endif /* %s */\n", cond_parm);
+	if (cond_parm[0] == '\0') {
+		if (strcmp(get_parm(RETTYPE_INDEX), "void") == 0) {
+			fprintf(stream, ");\n  return 0;\n}\n\n");
+		} else {
+			fprintf(stream, ");\n}\n\n");
+		}
+	} else {
+		fprintf(stream, ");\n");
+		fprintf(stream, "#else\n");
+		fprintf(stream, "  set_errno(ENOSYS);\n");
+		if (strcmp(get_parm(RETTYPE_INDEX), "void") == 0) {
+			fprintf(stream, "  return 0;\n");
+		} else if (strcmp(get_parm(RETTYPE_INDEX), "int") == 0) {
+			fprintf(stream, "  return -1;\n");
+		} else {
+			fprintf(stream, "  return NULL;\n");
+		}
+		fprintf(stream, "#endif\n");
+		fprintf(stream, "}\n");
+	}
 	stub_close(stream);
 }
 


### PR DESCRIPTION
This commit remove config use from all syscalls to remove config dependency from syscalls.

- Output STUB files:

- STUB_accept.c (Has config dependency):

/* Auto-generated accept stub file -- do not edit */

#include <tinyara/config.h>
#include <stdint.h>
#include <errno.h>
#include <sys/socket.h>

uintptr_t STUB_accept(int nbr, uintptr_t parm1, uintptr_t parm2, uintptr_t parm3)
{
#if CONFIG_NSOCKET_DESCRIPTORS > 0 && defined(CONFIG_NET)
  return (uintptr_t)accept((int)parm1, (struct sockaddr*)parm2, (socklen_t*)parm3);
#else
  set_errno(ENOSYS);
  return -1;
#endif
}


- STUB_exit.c (Has no config dependency):

/* Auto-generated _exit stub file -- do not edit */

#include <tinyara/config.h>
#include <stdint.h>
#include <unistd.h>

uintptr_t STUB__exit(int nbr, uintptr_t parm1)
{
  _exit((int)parm1);
  return 0;
}

