### PR TITLE
kernel/binary_manager: Add debugging logs about partitions

### DIFF
--- a/os/kernel/binary_manager/binary_manager.c
+++ b/os/kernel/binary_manager/binary_manager.c
@@ -252,6 +252,12 @@ int binary_manager(int argc, char *argv[])
 	return 0;
 errout_with_nobinary:
 	while (1) {
+		printf("Partition Info : \n");
+		printf("Partition types: %s\n", CONFIG_FLASH_PART_TYPE);
+		printf("Partition sizes: %s\n", CONFIG_FLASH_PART_SIZE);
+#ifdef CONFIG_MTD_PARTITION_NAMES
+		printf("Partition names: %s\n", CONFIG_FLASH_PART_NAME);
+#endif
 		printf("=============== !!ERROR!! ============== \n");
 #ifdef CONFIG_USE_BP
 		if (!is_found_bootparam) {

--- a/os/kernel/binary_manager/binary_manager_data.c
+++ b/os/kernel/binary_manager/binary_manager_data.c
@@ -108,7 +108,7 @@ void binary_manager_register_kpart(int part_num, int part_size, uint32_t part_ad
 	kernel_info.part_info[kernel_info.part_count].devnum = part_num;
 	kernel_info.part_info[kernel_info.part_count].address = part_addr;
 
-	bmvdbg("[KERNEL %d] part num %d size %d, address 0x%x\n", kernel_info.part_count, part_num, part_size, part_addr);
+	bmdbg("[KERNEL %d] part num %d size %d, address 0x%x\n", kernel_info.part_count, part_num, part_size, part_addr);
 
 	kernel_info.part_count++;
 }
@@ -136,7 +136,7 @@ bool binary_manager_scan_kbin(void)
 		/* Update inuse index and kernel version */
 		kernel_info.inuse_idx = bp_data->active_idx;
 		kernel_info.version = header_data.version;
-		bmvdbg("Kernel version [%u] %u\n", kernel_info.inuse_idx, kernel_info.version);
+		bmdbg("Kernel version [%u] %u\n", kernel_info.inuse_idx, kernel_info.version);
 		return true;
 	}
 #else
@@ -347,7 +347,7 @@ void binary_manager_register_upart(char *name, int part_num, int part_size, uint
 			BIN_PARTNUM(bin_idx, 1) = part_num;
 			BIN_PARTSIZE(bin_idx, 1) = part_size;
 			BIN_PARTADDR(bin_idx, 1) = part_addr;
-			bmvdbg("[USER%d : 2] %s size %d num %d, address 0x%x\n", bin_idx, BIN_NAME(bin_idx), BIN_PARTSIZE(bin_idx, 1), BIN_PARTNUM(bin_idx, 1), BIN_PARTADDR(bin_idx, 1));
+			bmdbg("[USER%d : 2] %s size %d num %d, address 0x%x\n", bin_idx, BIN_NAME(bin_idx), BIN_PARTSIZE(bin_idx, 1), BIN_PARTNUM(bin_idx, 1), BIN_PARTADDR(bin_idx, 1));
 			return;
 		}
 	}
@@ -377,7 +377,7 @@ void binary_manager_register_upart(char *name, int part_num, int part_size, uint
 	strncpy(BIN_NAME(bin_idx), name, BIN_NAME_MAX - 1);
 	BIN_NAME(bin_idx)[BIN_NAME_MAX - 1] = '\0';
 	sq_init(&BIN_CBLIST(bin_idx));
-	bmvdbg("[USER%d : 1] %s size %d num %d, address 0x%x\n", bin_idx, BIN_NAME(bin_idx), BIN_PARTSIZE(bin_idx, 0), BIN_PARTNUM(bin_idx, 0), BIN_PARTADDR(bin_idx, 0));
+	bmdbg("[USER%d : 1] %s size %d num %d, address 0x%x\n", bin_idx, BIN_NAME(bin_idx), BIN_PARTSIZE(bin_idx, 0), BIN_PARTNUM(bin_idx, 0), BIN_PARTADDR(bin_idx, 0));
 }
 
 /****************************************************************************
@@ -418,6 +418,7 @@ bool binary_manager_scan_ubin_all(void)
 		BIN_BPIDX(bin_idx) = bp_app_idx;
 		part_idx = bp_data->app_data[bp_app_idx].useidx;
 		snprintf(devpath, BINARY_PATH_LEN, BINMGR_DEVNAME_FMT, BIN_PARTNUM(bin_idx, part_idx));
+		bmdbg("Checking user in partition [%d], path %s\n", part_idx, devpath);
 #ifdef CONFIG_SUPPORT_COMMON_BINARY
 		if (bin_idx == BM_CMNLIB_IDX) {
 			ret = binary_manager_read_header(BINARY_COMMON, devpath, (void *)&common_header_data, false);			

--- a/os/kernel/binary_manager/binary_manager_resource.c
+++ b/os/kernel/binary_manager/binary_manager_resource.c
@@ -131,6 +131,7 @@ int binary_manager_mount_resource(void)
 	do {
 		/* Read and verify header data */
 		snprintf(devpath, BINARY_PATH_LEN, BINMGR_DEVNAME_FMT, resource_info.part_info[inuse_idx].devnum);
+		bmdbg("Checking resource in partition [%d], path %s\n", inuse_idx, devpath);
 		ret = binary_manager_read_header(BINARY_RESOURCE, devpath, &header_data, false);
 		if (ret == BINMGR_OK) {
 			bmvdbg("Resource [%d] Header Checking Success.\n", inuse_idx);


### PR DESCRIPTION
Add logs about partitions to debug issue easily.

For examples, if there is no valid user binary,
Partition Info :
Partition types: none,none,none,none,kernel,none,none,kernel,none,none,bootparam, Partition sizes: 60,40,12,400,1744,5604,584,1744,5604,584,8, Partition names: bl1,reserved,ftl,ss,kernel,common,app1,kernel,common,app1,bootparam, =============== !!ERROR!! ==============
ERROR!! Not found user partitions because parsing a partition list is failed. Please check logs from configure_mtd_partitions and whether the partition 'bin' exists in CONFIG_FLASH_PART_TYPE.