### PR TITLE
[do not merge] Change CONFIG_RTL8730E_BOARD_REVISION to CONFIG_RTL8730E_BOARD_{type}

### DIFF
--- a/os/arch/arm/src/amebasmart/Kconfig
+++ b/os/arch/arm/src/amebasmart/Kconfig
@@ -17,11 +17,50 @@ config ARCH_CHIP_RTL8730E
 	select ARMV7A_HAVE_GICv2
 	select ARCH_HAVE_FPU
 	select AMEBASMART_WIFI
-	select ARCH_BOARD_HAVE_SECOND_FLASH if RTL8730E_BOARD_REVISION > 4
 
 endchoice
 
 menu "Realtek RTL8730E Peripheral Support"
+
+config BOARD_HAVE_MIPI
+	bool
+	default n
+
+config BOARD_HAVE_SPI0
+	bool
+	default n
+
+config BOARD_HAVE_SPI0_CS
+	bool
+	default n
+
+config BOARD_HAVE_SPI1
+	bool
+	default n
+
+config BOARD_HAVE_SPI1_CS
+	bool
+	default n
+
+config BOARD_HAVE_I2C0
+	bool
+	default n
+
+config BOARD_HAVE_I2C1
+	bool
+	default n
+
+config BOARD_HAVE_I2C2
+	bool
+	default n
+
+config BOARD_HAVE_I2S2
+	bool
+	default n
+
+config BOARD_HAVE_I2S3
+	bool
+	default n
 
 config RTL8730E_UART
 	bool "UART"
@@ -68,8 +107,9 @@ config RTL8730E_SERIAL_FIFO
 	default n
 
 config AMEBASMART_MIPI
-        bool "AMEBASMART_MIPI"
-        default n
+	bool "AMEBASMART_MIPI"
+	depends on BOARD_HAVE_MIPI
+	default n
 
 config AMEBASMART_USBDEVICE
 	bool "AMEBASMART_USBDEVICE"
@@ -97,13 +137,15 @@ endif
 config AMEBASMART_SPI
 	bool "AMEBASMART_SPI"
 	default n
-	
+
 if AMEBASMART_SPI
 config AMEBASMART_SPI0
 	bool "SPI0"
+	depends on BOARD_HAVE_SPI0
 	default n
 config AMEBASMART_SPI1
 	bool "SPI1"
+	depends on BOARD_HAVE_SPI1
 	default n
 config AMEBASMART_SPI_EXCHANGE
 	bool "Enable AMEBASMART SPI EXCHANGE"
@@ -120,13 +162,13 @@ if AMEBASMART_SPI0
 config AMEBASMART_SPI0_CS
 	bool "SPI0 Multi-slaves CS pins"
 	default n
-	depends on SPI_CS
+	depends on SPI_CS && BOARD_HAVE_SPI0_CS
 endif
 if AMEBASMART_SPI1
 config AMEBASMART_SPI1_CS
 	bool "SPI1 Multi-slaves CS pins"
 	default n
-	depends on SPI_CS
+	depends on SPI_CS && BOARD_HAVE_SPI1_CS
 endif
 endif
 
@@ -138,12 +180,15 @@ if AMEBASMART_I2C
 
 config AMEBASMART_I2C0
 	bool "I2C_0"
+	depends on BOARD_HAVE_I2C0
 	default n
 config AMEBASMART_I2C1
 	bool "I2C_1"
+	depends on BOARD_HAVE_I2C1
 	default n
 config AMEBASMART_I2C2
 	bool "I2C_2"
+	depends on BOARD_HAVE_I2C2
 	default n
 
 config AMEBASMART_I2C_DYNTIMEO
@@ -183,9 +228,11 @@ config AMEBASMART_I2S
 if AMEBASMART_I2S
 config AMEBASMART_I2S2
 	bool "I2S_2"
+	depends on BOARD_HAVE_I2S2
 	default n
 config AMEBASMART_I2S3
 	bool "I2S_3"
+	depends on BOARD_HAVE_I2S3
 	default n
 
 config AMEBASMART_I2S_RX

--- a/os/arch/arm/src/amebasmart/amebasmart_i2c.c
+++ b/os/arch/arm/src/amebasmart/amebasmart_i2c.c
@@ -301,12 +301,11 @@ static const struct amebasmart_i2c_config_s amebasmart_i2c0_config = {
 	//.busy_idle = CONFIG_I2C0_BUSYIDLE,
 	//.filtscl = CONFIG_I2C0_FILTSCL,
 	//.filtsda = CONFIG_I2C0_FILTSDA,
-#if CONFIG_RTL8730E_BOARD_REVISION >= 5
+#if defined(CONFIG_RTL8730E_BOARD_AIL) || defined(CONFIG_RTL8730E_BOARD_AILP) || defined(CONFIG_RTL8730E_BOARD_AILPW)
 	.scl_pin = PB_30,
 	.sda_pin = PB_29,
 #else
-	.scl_pin = PA_10,
-	.sda_pin = PA_9,
+#error Not Supported, Please check the board type configure
 #endif
 #ifndef CONFIG_I2C_SLAVE
 	.mode = AMEBASMART_I2C_MASTER,
@@ -338,12 +337,11 @@ static const struct amebasmart_i2c_config_s amebasmart_i2c1_config = {
 	//.busy_idle = CONFIG_I2C1_BUSYIDLE,
 	//.filtscl = CONFIG_I2C1_FILTSCL,
 	//.filtsda = CONFIG_I2C1_FILTSDA,
-#if CONFIG_RTL8730E_BOARD_REVISION >= 5
+#if defined(CONFIG_RTL8730E_BOARD_AIL) || defined(CONFIG_RTL8730E_BOARD_AILP) || defined(CONFIG_RTL8730E_BOARD_AILPW)
 	.scl_pin = PA_4,
 	.sda_pin = PA_3,
 #else
-	.scl_pin = PA_21,
-	.sda_pin = PA_20,
+#error Not Supported, Please check the board type configure
 #endif
 #ifndef CONFIG_I2C_SLAVE
 	.mode = AMEBASMART_I2C_MASTER,

--- a/os/arch/arm/src/amebasmart/amebasmart_serial.c
+++ b/os/arch/arm/src/amebasmart/amebasmart_serial.c
@@ -383,12 +383,14 @@ static struct rtl8730e_up_dev_s g_uart1priv = {
 	.baud = CONFIG_UART1_BAUD,
 	.irq = RTL8730E_UART1_IRQ,
 
-#if CONFIG_RTL8730E_BOARD_REVISION >= 5
+#if defined(CONFIG_RTL8730E_BOARD_AID)
 	.tx = PA_10,
 	.rx = PA_9,
-#else
+#elif defined(CONFIG_RTL8730E_BOARD_AIL) || defined(CONFIG_RTL8730E_BOARD_AILP) || defined(CONFIG_RTL8730E_BOARD_AILPW)
 	.tx = PA_5,
 	.rx = PA_4,
+#else
+#error Not Supported, Please check the board type configure
 #endif
 	.FlowControl = FlowControlNone,
 	.txint_enable = false,

--- a/os/board/rtl8730e/Kconfig
+++ b/os/board/rtl8730e/Kconfig
@@ -79,12 +79,61 @@ config SECOND_FLASH_START_ADDR
         This is fixed value, so user doesn't need to change it.
 endif
 
-config RTL8730E_BOARD_REVISION
-	int "Select target board revision"
-	default 0
-	---help---
-		Select the board revision.
-		The pins of the peripherals may differ depending on this
+choice
+    prompt "Select target board type"
+    default RTL8730E_BOARD_AID
+    help
+        Select the board type.
+        The pins of the peripherals and supported features differ depending on this
+
+config RTL8730E_BOARD_AID
+    bool "AID Board"
+    select RAM_PSRAM
+    select BOARD_FLASH_16M
+    help
+        AID board supports basic loadable applications
+
+config RTL8730E_BOARD_AIL
+    bool "AIL Board"
+    select RAM_PSRAM
+    select BOARD_FLASH_16M
+    select BOARD_HAVE_SPI0
+    select BOARD_HAVE_SPI1
+    select BOARD_HAVE_I2C2
+    select BOARD_HAVE_I2S2
+    select ARCH_BOARD_HAVE_SECOND_FLASH
+    help
+        AIL board supports audio features
+
+config RTL8730E_BOARD_AILP
+    bool "AILP Board"
+    select RAM_DDR
+    select BOARD_FLASH_32M
+    select BOARD_HAVE_SPI0
+    select BOARD_HAVE_SPI1
+    select BOARD_HAVE_I2C2
+    select BOARD_HAVE_I2S2
+    select BOARD_HAVE_MIPI
+    select ARCH_BOARD_HAVE_SECOND_FLASH
+    help
+        AILP board supports audio and lcd features
+
+config RTL8730E_BOARD_AILPW
+    bool "AILPW Board"
+    select RAM_DDR
+    select BOARD_FLASH_32M
+    select BOARD_HAVE_SPI0
+    select BOARD_HAVE_SPI1
+    select AMEBASMART_I2C
+    select BOARD_HAVE_I2C0
+    select BOARD_HAVE_I2C2
+    select BOARD_HAVE_I2S2
+    select BOARD_HAVE_MIPI
+    select ARCH_BOARD_HAVE_SECOND_FLASH
+    help
+        AILPW board supports extended peripherals
+
+endchoice
 
 choice
     prompt "Board Memory Type"

--- a/os/board/rtl8730e/src/rtl8730e_alc1019.c
+++ b/os/board/rtl8730e/src/rtl8730e_alc1019.c
@@ -43,10 +43,10 @@ extern FAR struct i2s_dev_s *amebasmart_i2s_initialize(uint16_t port);
  * Pre-processor Definitions
  ****************************************************************************/
 /* i2c config */
-#if CONFIG_RTL8730E_BOARD_REVISION >= 5
+#if defined(CONFIG_RTL8730E_BOARD_AIL) || defined(CONFIG_RTL8730E_BOARD_AILP) || defined(CONFIG_RTL8730E_BOARD_AILPW)
 #define ALC1019_I2C_PORT		2
 #else
-#define ALC1019_I2C_PORT		1
+#error Not Supported, Please check the board type configure
 #endif
 
 #define ALC1019_I2C_FREQ		100000

--- a/os/board/rtl8730e/src/rtl8730e_ist415.c
+++ b/os/board/rtl8730e/src/rtl8730e_ist415.c
@@ -39,20 +39,17 @@
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
-/* i2c config */
-#if CONFIG_RTL8730E_BOARD_REVISION >= 6
+#if defined(CONFIG_RTL8730E_BOARD_AIL) || defined(CONFIG_RTL8730E_BOARD_AILP) || defined(CONFIG_RTL8730E_BOARD_AILPW)
+ /* i2c config */
 #define IST415_I2C_PORT		0
-#else
-#define IST415_I2C_PORT		1
-#endif
 
 /* pin config */
 #define IST415_GPIO_RESET_PIN	PA_5
-#if CONFIG_RTL8730E_BOARD_REVISION >= 6
 #define IST415_GPIO_I2C_PIN		PA_4
 #else
-#define IST415_GPIO_I2C_PIN		PA_2
+#error Not Supported, Please check the board type configure
 #endif
+
 
 /****************************************************************************
  * Private Types

--- a/os/board/rtl8730e/src/rtl8730e_st7789.c
+++ b/os/board/rtl8730e/src/rtl8730e_st7789.c
@@ -31,7 +31,7 @@
 #define CONFIG_LCD_ST7789_SPI_PORT 1
 #endif
 
-#if CONFIG_RTL8730E_BOARD_REVISION >= 5
+#if defined(CONFIG_RTL8730E_BOARD_AIL) || defined(CONFIG_RTL8730E_BOARD_AILP) || defined(CONFIG_RTL8730E_BOARD_AILPW)
 #error "ERROR, Not supported this revision"
 #else
 #define GPIO_PIN_RESET 		PB_11


### PR DESCRIPTION
Previously, CONFIG_RTL8730E_BOARD_REVISION was used to manage configurations related to external flash presence and peripheral pin mapping setup.

the config name has been changed to CONFIG_RTL8730E_BOARD_{TYPE NAME} to align with the board type-based configuration approach.

Additionally, new config dependencies have been introduced to ensure that if a specific peripheral is not supported on a given board type (e.g., A type), the corresponding BSP configuration for that peripheral is disabled. This change enhances clarity and ensures proper configuration management based on board types
 rather than revisions.