### PR TITLE
framework/ble_manager : Fix the issue of callback function mismatch

### DIFF
--- a/framework/include/ble_manager/ble_server.h
+++ b/framework/include/ble_manager/ble_server.h
@@ -55,7 +55,7 @@ typedef enum {
 	BLE_SERVER_CCCD_NOTIFY_INDICATE	= 0x0003
 } ble_server_cccd_value_e;
 
-typedef void (*ble_server_cb_t)(ble_server_attr_cb_type_e type, ble_conn_handle con_handle, ble_attr_handle handle, void* arg);
+typedef void (*ble_server_cb_t)(ble_server_attr_cb_type_e type, ble_conn_handle con_handle, ble_attr_handle handle, void* arg, uint16_t result, uint16_t pending);
 
 typedef enum  {
 	BLE_ATTR_PROP_NONE          = 0x00,


### PR DESCRIPTION
- In PR #6094, the modification of adding the indication queue pending count and result as parameters to the attribute callback function was reflected. In the application layer, the callback has been modified to match this format and is currently being used properly. However, to avoid confusion during maintenance, the declaration has been modified to its original form.