### PR TITLE
apps/examples/testcase/le_tc/compression: Fix return check in compression test case

### DIFF
--- a/apps/examples/testcase/le_tc/compression/tc_compress_read.c
+++ b/apps/examples/testcase/le_tc/compression/tc_compress_read.c
@@ -193,7 +193,8 @@ static void tc_comp_decomp_buffer_lesser_output_size(void)
 	
 	// Test decompression method
 	ret_chk = ioctl(fd, COMPIOC_DECOMPRESS, decomp_tc_data);
-	TC_ASSERT_EQ_CLEANUP("decompress block", ret_chk, ENOMEM, uninitialize_tc_data());
+	TC_ASSERT_EQ_CLEANUP("decompress block ret", ret_chk, ERROR, uninitialize_tc_data());
+	TC_ASSERT_EQ_CLEANUP("decompress block errno", get_errno(), ENOMEM, uninitialize_tc_data());
 
 	uninitialize_tc_data();
 	TC_SUCCESS_RESULT();


### PR DESCRIPTION
`ioctl` function always returns `ERROR(-1)` with sets errno or `OK(0)`. 
So updated the decompression test to properly check both the return value and errno.