### PR TITLE
apps/system/utils/stackmonitor : Add config to toggle dead thread stack info

### DIFF
--- a/apps/system/utils/Kconfig
+++ b/apps/system/utils/Kconfig
@@ -232,6 +232,14 @@ config STACKMONITOR_INTERVAL
 		The rate in seconds that the stack monitor will wait before dumping
 		the next set stack usage information.  Default:  2 seconds.
 
+config STACKMONITOR_DISABLE_DEAD_THREAD  
+	bool "Disable dead threads stackinfo"  
+	default n
+	---help---
+		Enable this option if you want the stack monitor to **stop keeping**
+		stack information for threads that have already exited (dead threads).
+		This can reduce memory usage since dead thread stack infos are not stored.
+
 endif #ENABLE_STACKMONITOR
 
 config ENABLE_UPTIME

--- a/apps/system/utils/utils_stackmonitor.c
+++ b/apps/system/utils/utils_stackmonitor.c
@@ -259,6 +259,7 @@ static void *stackmonitor_daemon(void *arg)
 		printf("|------------");
 #endif
 		printf("\n");
+#if !defined(CONFIG_STACKMONITOR_DISABLE_DEAD_THREAD)
 		stkmon_print_inactive_list();
 		printf("------|----------|----------");
 #ifdef CONFIG_STACK_COLORATION
@@ -272,6 +273,7 @@ static void *stackmonitor_daemon(void *arg)
 		printf("|------------");
 #endif
 		printf("\n");
+#endif //!CONFIG_STACKMONITOR_DISABLE_DEAD_THREAD
 		utils_proc_pid_foreach(stkmon_read_proc, NULL);
 #ifndef CONFIG_DISABLE_SIGNALS
 		sleep(CONFIG_STACKMONITOR_INTERVAL);

--- a/os/kernel/debug/Make.defs
+++ b/os/kernel/debug/Make.defs
@@ -30,7 +30,9 @@ CSRCS += memdbg.c
 endif
 
 ifeq ($(CONFIG_ENABLE_STACKMONITOR)$(CONFIG_DEBUG),yy)
+ifneq ($(CONFIG_STACKMONITOR_DISABLE_DEAD_THREAD),y)
 CSRCS += stackinfo_save_terminated.c
+endif
 endif
 
 DEPPATH += --dep-path debug

--- a/os/kernel/debug/dbg_termination_info.c
+++ b/os/kernel/debug/dbg_termination_info.c
@@ -101,7 +101,7 @@
  ****************************************************************************/
 void dbg_save_termination_info(struct tcb_s *tcb)
 {
-#if defined(CONFIG_ENABLE_STACKMONITOR) && defined(CONFIG_DEBUG)
+#if defined(CONFIG_ENABLE_STACKMONITOR) && defined(CONFIG_DEBUG) && !defined(CONFIG_STACKMONITOR_DISABLE_DEAD_THREAD)
 	stackinfo_save_terminated(tcb);
 #endif
 

--- a/os/kernel/debug/debug.h
+++ b/os/kernel/debug/debug.h
@@ -30,7 +30,7 @@
 /********************************************************************************
  * Public Function Prototypes
  ********************************************************************************/
-#if defined(CONFIG_ENABLE_STACKMONITOR) && defined(CONFIG_DEBUG)
+#if defined(CONFIG_ENABLE_STACKMONITOR) && defined(CONFIG_DEBUG) && !defined(CONFIG_STACKMONITOR_DISABLE_DEAD_THREAD)
 void stackinfo_save_terminated(struct tcb_s *tcb);
 #endif
 

--- a/os/kernel/task/task_prctl.c
+++ b/os/kernel/task/task_prctl.c
@@ -247,7 +247,7 @@ int prctl(int option, ...)
 #endif /* CONFIG_MESSAGING_IPC */
 	case PR_GET_STKLOG:
 	{
-#if defined(CONFIG_ENABLE_STACKMONITOR) && defined(CONFIG_DEBUG)
+#if defined(CONFIG_ENABLE_STACKMONITOR) && defined(CONFIG_DEBUG) && !defined(CONFIG_STACKMONITOR_DISABLE_DEAD_THREAD)
 		struct stkmon_save_s *dest_buf = va_arg(ap, struct stkmon_save_s *);
 		stkmon_copy_log(dest_buf);
 #else


### PR DESCRIPTION
- Add CONFIG_STACKMONITOR_DISABLE_DEAD_THREAD (bool, default n).
- When enabled, dead thread stack infos are not stored, reducing RAM consumption.
- When disabled, the stack monitor retains stack info of threads that have exited.