### PR TITLE
os/board/rtl8730e: fix task size before calling kernel_thread

### DIFF
--- a/os/board/rtl8730e/src/component/bluetooth/os/tizenrt/osif_tizenrt.c
+++ b/os/board/rtl8730e/src/component/bluetooth/os/tizenrt/osif_tizenrt.c
@@ -115,7 +115,6 @@ bool osif_task_create(void **pp_handle, const char *p_name, void (*p_routine)(vo
 	task_info[0] = itoa((int) p_routine, routine_addr, 16);
 	task_info[1] = itoa((int) p_param, param_addr, 16);
 	task_info[2] = NULL;
-	stack_size = stack_size * sizeof(uint32_t);
 	priority = priority + SCHED_PRIORITY_DEFAULT;
 	if (priority > SCHED_PRIORITY_MAX)
 		priority = SCHED_PRIORITY_DEFAULT;


### PR DESCRIPTION
- kernel_thread takes in task stack size in bytes, no need to multiply by word size