### PR TITLE
kernel/binary_manager: Reduce stack size of binary manager to 3K

### DIFF
--- a/os/kernel/binary_manager/binary_manager_internal.h
+++ b/os/kernel/binary_manager/binary_manager_internal.h
@@ -57,7 +57,7 @@
 
 /* Binary Manager Core Thread information */
 #define BINARY_MANAGER_NAME        "binary_manager"           /* Binary manager thread name */
-#define BINARY_MANAGER_STACKSIZE   8192                       /* Binary manager thread stack size */
+#define BINARY_MANAGER_STACKSIZE   3072                       /* Binary manager thread stack size */
 #define BINARY_MANAGER_PRIORITY    203                        /* Binary manager thread priority */
 
 /* Loading Thread information */


### PR DESCRIPTION
Reduce stack size of binary manager to 3K.

We measured the peak stack usage of binary manager based on some tests and got the below result.
  PID |   STATUS |     SIZE | PEAK_STACK |  PEAK_HEAP |    TIME | THREAD NAME
------|----------|----------|------------|------------|---------|------------
   13 |   ACTIVE |     8168 |        928 |       8240 |  134687 | binary_manager