### PR TITLE
os/.gitignore: Add gitignore ".download", "app_size_file" files

### DIFF
--- a/os/.gitignore
+++ b/os/.gitignore
@@ -19,3 +19,5 @@
 /.appSpec
 /.bininfo
 /dutils_output_*.txt
+/.download
+/app_size_file


### PR DESCRIPTION
the .download file is generated during bianry download script and app_size_file is generated in mkverifyappsize.py os.system('size ' + file_path + ' > ' + APP_SIZE_FILE)

So two files are generated by script.
Therefore, Add gitignore