### PR TITLE
[DO NOT MERGE] os/drivers/lcd: Refactor lcd driver architecture

### DIFF
--- a/os/arch/arm/src/amebasmart/amebasmart_mipi.c
+++ b/os/arch/arm/src/amebasmart/amebasmart_mipi.c
@@ -78,7 +78,7 @@ extern struct rtl8730e_lcdc_info_s g_rtl8730e_config_dev_s;
 extern volatile spinlock_t g_rtl8730e_config_dev_s_underflow;
 /* Helpers */
 static void amebasmart_set_clock(void);
-static void amebasmart_check_freq(struct lcd_data *data);
+static void amebasmart_check_freq(struct mipi_host_lcd_data *data);
 static void amebasmart_mipi_init_helper(FAR struct amebasmart_mipi_dsi_host_s *priv);
 static void amebasmart_register_interrupt(void);
 
@@ -383,7 +383,7 @@ static void amebasmart_mipidsi_isr(void)
 	}
 }
 
-static void amebasmart_check_freq(struct lcd_data *data)
+static void amebasmart_check_freq(struct mipi_host_lcd_data *data)
 {
 	u32 totaly = data->mipi_dsi_VSA + data->mipi_dsi_VBP + data->mipi_dsi_VFP + data->YPixels;
 	u32 totalx = data->mipi_dsi_HSA + data->mipi_dsi_HBP + data->mipi_dsi_HFP + data->XPixels;
@@ -562,7 +562,7 @@ void amebasmart_mipi_dsi_host_reinitialize(void)
 	amebasmart_mipi_init_helper(priv);
 }
 
-struct mipi_dsi_host *amebasmart_mipi_dsi_host_initialize(struct lcd_data *config)
+struct mipi_dsi_host *amebasmart_mipi_dsi_host_initialize(struct mipi_host_lcd_data *config)
 {
 	FAR struct amebasmart_mipi_dsi_host_s *priv = NULL;
 	priv = &g_dsi_host;

--- a/os/board/rtl8730e/src/rtl8730e_boot.c
+++ b/os/board/rtl8730e/src/rtl8730e_boot.c
@@ -495,7 +495,16 @@ void board_initialize(void)
 	rtl8730_st7789_initialize();
 #endif
 
-#if defined(CONFIG_LCD_ST7785) || defined(CONFIG_LCD_ST7701) || defined(CONFIG_LCD_ST7701SN)
+#if defined(CONFIG_LCD_ST7785)
+	struct mipi_lcd_dev_s *dev = st7785_initialize();
+	rtl8730e_lcdc_initialize(dev);
+#endif
+
+#if defined(CONFIG_LCD_ST7701)
+	rtl8730e_lcdc_initialize();
+#endif
+
+#if defined(CONFIG_LCD_ST7701SN)
 	rtl8730e_lcdc_initialize();
 #endif
 

--- a/os/drivers/lcd/mipi_lcd.c
+++ b/os/drivers/lcd/mipi_lcd.c
@@ -117,7 +117,7 @@ struct mipi_lcd_dev_s {
 	/* Publicly visible device structure */
 
 	struct lcd_dev_s dev;
-
+	struct lcd_panel_s panel;
 	FAR struct mipi_dsi_device *dsi_dev;
 
 	u8 *lcd_img_buffer[MAX_NO_PLANES];
@@ -612,9 +612,8 @@ FAR void lcd_init_put_image(FAR struct lcd_dev_s *dev)
 
 }
 
-FAR struct lcd_dev_s *mipi_lcdinitialize(FAR struct mipi_dsi_device *dsi, struct mipi_lcd_config_s *config)
+FAR struct lcd_dev_s *mipi_lcd_initialize(struct mipi_lcd_dev_s *priv, FAR struct mipi_dsi_device *dsi, struct mipi_lcd_config_s *config)
 {
-	FAR struct mipi_lcd_dev_s *priv = &g_lcdcdev;
 	priv->dev.getplaneinfo = lcd_getplaneinfo;
 	priv->dev.getvideoinfo = lcd_getvideoinfo;
 	priv->dev.getlcdinfo = lcd_getlcdinfo;

--- a/os/drivers/lcd/st7785.c
+++ b/os/drivers/lcd/st7785.c
@@ -21,6 +21,9 @@
 #include <tinyara/lcd/lcd_dev.h>
 #include <debug.h>
 
+static struct mipi_lcd_dev_s g_lcdcdev;
+static struct mipi_lcd_config_s g_st7785_config;
+
 int check_lcd_vendor_send_init_cmd(struct mipi_lcd_dev_s *priv)
 {
 	/* Only one config is set in the build configuration. If it's true, use that init code. Otherwise, check vendor id. */
@@ -77,4 +80,37 @@ int get_lcdinfo(FAR struct lcd_info_s *lcdinfo)
 	lcdinfo->lcd_height_mm = (uint8_t)(LCD_HEIGHT_MM + 0.5f);
 	lcdinfo->lcd_width_mm = (uint8_t)(LCD_WIDTH_MM + 0.5f);
 	return OK;
+}
+
+static const struct lcd_panel_ops g_panel_ops = {
+	.send_init_cmd = check_lcd_vendor_send_init_cmd,
+	.get_lcdinfo = get_lcdinfo,
+};
+
+struct mipi_lcd_dev_s* st7785_initialize(void) {
+	FAR struct mipi_lcd_dev_s *priv = &g_lcdcdev;
+	priv->panel.mipi_host_config = &g_st7785_config;
+	
+	config.XPixels = CONFIG_LCD_XRES;
+	config.YPixels = CONFIG_LCD_YRES;
+	config.mipi_frame_rate = MIPI_FRAME_RATE;
+	config.mipi_dsi_HBP = MIPI_DSI_HBP;
+	config.mipi_dsi_HFP = MIPI_DSI_HFP;
+	config.mipi_dsi_HSA = MIPI_DSI_HSA;
+	config.mipi_dsi_RTNI = MIPI_DSI_RTNI;
+	config.mipi_dsi_VBP = MIPI_DSI_VBP;
+	config.mipi_dsi_VFP = MIPI_DSI_VFP;
+	config.mipi_dsi_VSA = MIPI_DSI_VSA;
+	config.mipi_lcd_limit = MIPI_LCD_LIMIT;
+	config.lcd_lane_num = MIPI_LANE_NUMBER;
+	priv->panel.mipi_host_config = &g_st7785_config;
+
+	priv->panel.width = LCD_HEIGHT_MM;
+	priv->panel.height = LCD_WIDTH_MM;
+	// priv->panel.lcd_size_inch = 
+	// priv->panel.lcd_dpi = 
+
+	priv->panel.ops =  g_panel_ops;
+
+	return &priv;
 }

--- a/os/include/tinyara/lcd/mipi_lcd.h
+++ b/os/include/tinyara/lcd/mipi_lcd.h
@@ -70,4 +70,18 @@ struct mipi_lcd_config_s {
 	void (*mipi_drv_reset)();
 };
 
+struct lcd_panel_ops {
+	CODE int (*send_init_cmd)(FAR struct mipi_dsi_device *device);
+	CODE int (*get_lcdinfo)(FAR struct lcd_info_s *lcdinfo);
+};
+
+struct lcd_panel_s {
+	uint8_t lcd_height_mm;
+	uint8_t lcd_width_mm;
+	float lcd_size_inch;
+	float lcd_dpi;
+	struct lcd_panel_ops *ops;
+	struct mipi_host_lcd_data mipi_host_config;
+};
+
 #endif	/* __DRIVERS_LCD_MIPI_H */

--- a/os/include/tinyara/mipidsi/mipi_dsi.h
+++ b/os/include/tinyara/mipidsi/mipi_dsi.h
@@ -189,7 +189,7 @@ struct mipi_dsi_host_ops {
 	CODE ssize_t(*transfer)(FAR struct mipi_dsi_host *host, FAR const struct mipi_dsi_msg *msg);
 };
 
-struct lcd_data {
+struct mipi_host_lcd_data {
 	int XPixels;
 	int YPixels;
 	int mipi_frame_rate;
@@ -206,7 +206,7 @@ struct lcd_data {
 /* Dsi host structure */
 struct mipi_dsi_host {
 	FAR const struct mipi_dsi_host_ops *ops;
-	struct lcd_data config;
+	struct mipi_host_lcd_data config;
 	int bus;
 };
 


### PR DESCRIPTION
[THIS IS ONGOING REFACTORING]

The ultimate goal of this change is to create a scalable architecture. To achieve this, separating the MIPI-DSI, LCD panel, and LCD driver modules. Implement initialization functions for each panel and register the necessary functions as ops.

The driver operates without knowing the panel and LCD protocol, mipi_lcd.c provides common functions (lcd_dev_s) for LCDs that use MIPI, st7785.c provides functions for the panel.

Feel free to give advise about this.