### PR TITLE
os/: Add PWM frequency set for ST7785 MIPI LCD

### DIFF
--- a/os/board/rtl8730e/src/rtl8730e_mipi_lcdc.c
+++ b/os/board/rtl8730e/src/rtl8730e_mipi_lcdc.c
@@ -234,6 +234,10 @@ static void rtl8730e_gpio_init(void)
 	pwmout_init(&g_rtl8730e_config_dev_s.pwm_led, GPIO_PIN_BACKLIGHT);
 	lcdvdbg("initial pwm read %f\n", pwmout_read(&g_rtl8730e_config_dev_s.pwm_led));
 #endif
+
+#if defined(LCD_BACKLIGHT_PWM_FREQ_KHZ)
+	pwmout_period_us(&g_rtl8730e_config_dev_s.pwm_led, 1000 / LCD_BACKLIGHT_PWM_FREQ_KHZ);
+#endif
 }
 
 static void rtl8730e_control_backlight(uint8_t level)

--- a/os/include/tinyara/lcd/st7785.h
+++ b/os/include/tinyara/lcd/st7785.h
@@ -202,4 +202,6 @@ static const lcd_vendor_map_t g_lcd_vendors[] = {
 
 #define NUM_LCD_VENDERS (AVD_NB01 + AVD_2701 + HLT_A196 + TEC_181A)
 
+#define LCD_BACKLIGHT_PWM_FREQ_KHZ 20
+
 #endif	/* __DRIVERS_LCD_ST7785_H */


### PR DESCRIPTION
Add PWM frequency set for MIPI based LCD ST7785, initial value is set to 100, can be changed from Kconfig