### PR TITLE
/os/mm: Unify mm apis like mm_alloc, mm_realloc, mm_memalign, mm_zalloc, mm_calloc

### DIFF
--- a/os/include/tinyara/mm/mm.h
+++ b/os/include/tinyara/mm/mm.h
@@ -242,9 +242,9 @@ typedef size_t mmsize_t;
 #endif
 
 /* typedef is used for defining size of address space */
+typedef void *mmaddress_t;             /* 32 bit address space */
 
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
-typedef void *mmaddress_t;             /* 32 bit address space */
 
 #define SIZEOF_MM_MALLOC_DEBUG_INFO \
 	(sizeof(mmaddress_t) + sizeof(pid_t) + sizeof(uint16_t))
@@ -514,18 +514,11 @@ void umm_givesemaphore(void *address);
 int kmm_trysemaphore(void *address);
 void kmm_givesemaphore(void *address);
 #endif
-#ifdef CONFIG_DEBUG_MM_HEAPINFO
 
 /* Functions contained in mm_malloc.c ***************************************/
+/* unified mm_malloc api */
 
 FAR void *mm_malloc(FAR struct mm_heap_s *heap, size_t size, mmaddress_t caller_retaddr);
-
-#else
-
-/* Functions contained in mm_malloc.c ***************************************/
-
-FAR void *mm_malloc(FAR struct mm_heap_s *heap, size_t size);
-#endif
 
 /* Functions contained in kmm_malloc.c **************************************/
 
@@ -543,36 +536,21 @@ void mm_free(FAR struct mm_heap_s *heap, FAR void *mem);
 void kmm_free(FAR void *mem);
 #endif
 
-#ifdef CONFIG_DEBUG_MM_HEAPINFO
-
 /* Functions contained in mm_realloc.c **************************************/
+/* unified mm_realloc api */
 
 FAR void *mm_realloc(FAR struct mm_heap_s *heap, FAR void *oldmem, size_t size, mmaddress_t caller_retaddr);
-
-#else
-
-/* Functions contained in mm_realloc.c **************************************/
-
-FAR void *mm_realloc(FAR struct mm_heap_s *heap, FAR void *oldmem, size_t size);
-#endif
 
 /* Functions contained in kmm_realloc.c *************************************/
 
 #ifdef CONFIG_MM_KERNEL_HEAP
 FAR void *kmm_realloc(FAR void *oldmem, size_t newsize);
 #endif
-#ifdef CONFIG_DEBUG_MM_HEAPINFO
 
 /* Functions contained in mm_calloc.c ***************************************/
+/* unified mm_calloc api */
 
 FAR void *mm_calloc(FAR struct mm_heap_s *heap, size_t n, size_t elem_size, mmaddress_t caller_retaddr);
-
-#else
-
-/* Functions contained in mm_calloc.c ***************************************/
-
-FAR void *mm_calloc(FAR struct mm_heap_s *heap, size_t n, size_t elem_size);
-#endif
 
 /* Functions contained in kmm_calloc.c **************************************/
 
@@ -580,32 +558,21 @@ FAR void *mm_calloc(FAR struct mm_heap_s *heap, size_t n, size_t elem_size);
 FAR void *kmm_calloc(size_t n, size_t elem_size);
 #endif
 
-#ifdef CONFIG_DEBUG_MM_HEAPINFO
 /* Functions contained in mm_zalloc.c ***************************************/
+/* unified mm_zalloc api */
 
 FAR void *mm_zalloc(FAR struct mm_heap_s *heap, size_t size, mmaddress_t caller_retaddr);
-#else
-/* Functions contained in mm_zalloc.c ***************************************/
-
-FAR void *mm_zalloc(FAR struct mm_heap_s *heap, size_t size);
-#endif
 
 /* Functions contained in kmm_zalloc.c **************************************/
 
 #ifdef CONFIG_MM_KERNEL_HEAP
 FAR void *kmm_zalloc(size_t size);
 #endif
-#ifdef CONFIG_DEBUG_MM_HEAPINFO
+
 /* Functions contained in mm_memalign.c *************************************/
+/* unified mm_memalign */
 
 FAR void *mm_memalign(FAR struct mm_heap_s *heap, size_t alignment, size_t size, mmaddress_t caller_retaddr);
-
-#else
-
-/* Functions contained in mm_memalign.c *************************************/
-
-FAR void *mm_memalign(FAR struct mm_heap_s *heap, size_t alignment, size_t size);
-#endif
 
 /* Functions contained in kmm_memalign.c ************************************/
 

--- a/os/mm/kmm_heap/kmm_calloc.c
+++ b/os/mm/kmm_heap/kmm_calloc.c
@@ -67,22 +67,16 @@
 /****************************************************************************
  * Private Functions
  ****************************************************************************/
-#ifdef CONFIG_DEBUG_MM_HEAPINFO
+
+/* unified kheap_calloc api */
 static void *kheap_calloc(size_t n, size_t elem_size, mmaddress_t retaddr)
-#else
-static void *kheap_calloc(size_t n, size_t elem_size)
-#endif
 {
 	int heap_idx;
 	void *ret;
 	struct mm_heap_s *kheap = kmm_get_baseheap();
 
 	for (heap_idx = HEAP_START_IDX; heap_idx <= HEAP_END_IDX; heap_idx++) {
-		ret = mm_calloc(&kheap[heap_idx], n, elem_size
-#ifdef CONFIG_DEBUG_MM_HEAPINFO
-				, retaddr
-#endif
-				);
+		ret = mm_calloc(&kheap[heap_idx], n, elem_size, retaddr);
 		if (ret != NULL) {
 			return ret;
 		}
@@ -117,8 +111,10 @@ void *kmm_calloc_at(int heap_index, size_t n, size_t elem_size)
 {
 	void *ret;
 	struct mm_heap_s *kheap;
+
+	mmaddress_t caller_retaddr = NULL;	/* for generalising the call to mm_calloc api */
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
-	mmaddress_t caller_retaddr = GET_RETURN_ADDRESS();
+	caller_retaddr = GET_RETURN_ADDRESS();
 #endif
 	if (heap_index > HEAP_END_IDX || heap_index < HEAP_START_IDX) {
 		mdbg("kmm_calloc_at failed. Wrong heap index (%d) of (%d)\n", heap_index, HEAP_END_IDX);
@@ -130,11 +126,7 @@ void *kmm_calloc_at(int heap_index, size_t n, size_t elem_size)
 	}
 
 	kheap = kmm_get_baseheap();
-	ret = mm_calloc(&kheap[heap_index], n, elem_size
-#ifdef CONFIG_DEBUG_MM_HEAPINFO
-			, caller_retaddr
-#endif
-			);
+	ret = mm_calloc(&kheap[heap_index], n, elem_size, caller_retaddr);
 	if (ret == NULL) {
 		mm_manage_alloc_fail(&kheap[heap_index], heap_index, heap_index, n * elem_size, 0, KERNEL_HEAP
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
@@ -159,14 +151,13 @@ FAR void *kmm_calloc(size_t n, size_t elem_size)
 	if (n == 0 || elem_size == 0) {
 		return NULL;
 	}
+
+	mmaddress_t caller_retaddr = NULL;	/* for generalising the call to kheap_calloc api */
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
-	mmaddress_t caller_retaddr = GET_RETURN_ADDRESS();
+	caller_retaddr = GET_RETURN_ADDRESS();
 #endif
-	return kheap_calloc(n, elem_size
-#ifdef CONFIG_DEBUG_MM_HEAPINFO
-				, caller_retaddr
-#endif
-				);
+
+	return kheap_calloc(n, elem_size, caller_retaddr);
 }
 
 #endif							/* CONFIG_MM_KERNEL_HEAP */

--- a/os/mm/kmm_heap/kmm_malloc.c
+++ b/os/mm/kmm_heap/kmm_malloc.c
@@ -79,22 +79,16 @@
 /****************************************************************************
  * Private Functions
  ****************************************************************************/
-#ifdef CONFIG_DEBUG_MM_HEAPINFO
+
+/* unified kheap_malloc api */
 static void *kheap_malloc(size_t size, mmaddress_t caller_retaddr)
-#else
-static void *kheap_malloc(size_t size)
-#endif
 {
 	int heap_idx;
 	void *ret;
 	struct mm_heap_s *kheap = kmm_get_baseheap();
 
 	for (heap_idx = HEAP_START_IDX; heap_idx <= HEAP_END_IDX; heap_idx++) {
-		ret = mm_malloc(&kheap[heap_idx], size
-#ifdef CONFIG_DEBUG_MM_HEAPINFO
-				, caller_retaddr
-#endif
-				);
+		ret = mm_malloc(&kheap[heap_idx], size, caller_retaddr);
 		if (ret != NULL) {
 			return ret;
 		}
@@ -133,8 +127,10 @@ void *kmm_malloc_at(int heap_index, size_t size)
 {
 	void *ret;
 	struct mm_heap_s *kheap;
+
+	mmaddress_t caller_retaddr = NULL;	/* for generalising the call to mm_malloc api */
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
-	mmaddress_t caller_retaddr = GET_RETURN_ADDRESS();
+	caller_retaddr = GET_RETURN_ADDRESS();
 #endif
 	if (heap_index > HEAP_END_IDX || heap_index < HEAP_START_IDX) {
 		mdbg("kmm_malloc_at failed. Wrong heap index (%d) of (%d)\n", heap_index, HEAP_END_IDX);
@@ -146,11 +142,7 @@ void *kmm_malloc_at(int heap_index, size_t size)
 	}
 
 	kheap = kmm_get_baseheap();
-	ret = mm_malloc(&kheap[heap_index], size
-#ifdef CONFIG_DEBUG_MM_HEAPINFO
-			, caller_retaddr
-#endif
-			);
+	ret = mm_malloc(&kheap[heap_index], size, caller_retaddr);
 	if (ret == NULL) {
 		mm_manage_alloc_fail(&kheap[heap_index], heap_index, heap_index, size, 0, KERNEL_HEAP
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
@@ -178,17 +170,14 @@ void *kmm_malloc_at(int heap_index, size_t size)
 
 FAR void *kmm_malloc(size_t size)
 {
+	mmaddress_t caller_retaddr = NULL;	/* for generalising the call to kheap_malloc api */
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
-	mmaddress_t caller_retaddr = GET_RETURN_ADDRESS();
+	caller_retaddr = GET_RETURN_ADDRESS();
 #endif
 	if (size == 0) {
 		return NULL;
 	}
 
-	return kheap_malloc(size
-#ifdef CONFIG_DEBUG_MM_HEAPINFO
-				, caller_retaddr
-#endif
-				);
+	return kheap_malloc(size, caller_retaddr);
 }
 #endif							/* CONFIG_MM_KERNEL_HEAP */

--- a/os/mm/kmm_heap/kmm_memalign.c
+++ b/os/mm/kmm_heap/kmm_memalign.c
@@ -92,8 +92,10 @@ void *kmm_memalign_at(int heap_index, size_t alignment, size_t size)
 {
 	void *ret;
 	struct mm_heap_s *kheap;
+
+	mmaddress_t caller_retaddr = NULL;	/* for generalising the call to mm_memalign api */
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
-	mmaddress_t caller_retaddr = GET_RETURN_ADDRESS();
+	caller_retaddr = GET_RETURN_ADDRESS();
 #endif
 	if (heap_index > HEAP_END_IDX || heap_index < HEAP_START_IDX) {
 		mdbg("kmm_memalign_at failed. Wrong heap index (%d) of (%d)\n", heap_index, HEAP_END_IDX);
@@ -105,11 +107,7 @@ void *kmm_memalign_at(int heap_index, size_t alignment, size_t size)
 	}
 
 	kheap = kmm_get_baseheap();
-	ret = mm_memalign(&kheap[heap_index], alignment, size
-#ifdef CONFIG_DEBUG_MM_HEAPINFO
-			, caller_retaddr
-#endif
-			);
+	ret = mm_memalign(&kheap[heap_index], alignment, size, caller_retaddr);
 	if (ret == NULL) {
 		mm_manage_alloc_fail(&kheap[heap_index], heap_index, heap_index, size, alignment, KERNEL_HEAP
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
@@ -144,16 +142,14 @@ FAR void *kmm_memalign(size_t alignment, size_t size)
 	if (size == 0) {
 		return NULL;
 	}
+
+	mmaddress_t caller_retaddr = NULL;	/* for generalising the call to mm_memalign api */
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
-	mmaddress_t caller_retaddr = GET_RETURN_ADDRESS();
+	caller_retaddr = GET_RETURN_ADDRESS();
 #endif
 	struct mm_heap_s *kheap = kmm_get_baseheap();
 	for (kheap_idx = HEAP_START_IDX; kheap_idx <= HEAP_END_IDX; kheap_idx++) {
-		ret = mm_memalign(&kheap[kheap_idx], alignment, size
-#ifdef CONFIG_DEBUG_MM_HEAPINFO
-				, caller_retaddr
-#endif
-				);
+		ret = mm_memalign(&kheap[kheap_idx], alignment, size, caller_retaddr);
 		if (ret != NULL) {
 			return ret;
 		}

--- a/os/mm/kmm_heap/kmm_realloc.c
+++ b/os/mm/kmm_heap/kmm_realloc.c
@@ -89,8 +89,10 @@ void *kmm_realloc_at(int heap_index, void *oldmem, size_t size)
 {
 	void *ret;
 	struct mm_heap_s *kheap;
+
+	mmaddress_t caller_retaddr = NULL;	/* for generalising the call to mm_realloc api */
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
-	mmaddress_t caller_retaddr = GET_RETURN_ADDRESS();
+	caller_retaddr = GET_RETURN_ADDRESS();
 #endif
 	if (heap_index > HEAP_END_IDX || heap_index < HEAP_START_IDX) {
 		mdbg("kmm_realloc_at failed. Wrong heap index (%d) of (%d)\n", heap_index, HEAP_END_IDX);
@@ -104,11 +106,7 @@ void *kmm_realloc_at(int heap_index, void *oldmem, size_t size)
 		return NULL;
 	}
 
-	ret = mm_realloc(&kheap[heap_index], oldmem, size
-#ifdef CONFIG_DEBUG_MM_HEAPINFO
-			, caller_retaddr
-#endif
-			);
+	ret = mm_realloc(&kheap[heap_index], oldmem, size, caller_retaddr);
 	if (ret == NULL) {
 		mm_manage_alloc_fail(&kheap[heap_index], heap_index, heap_index, size, 0, KERNEL_HEAP
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
@@ -139,8 +137,10 @@ FAR void *kmm_realloc(FAR void *oldmem, size_t newsize)
 {
 	void *ret;
 	int kheap_idx;
+
+	mmaddress_t caller_retaddr = NULL;	/* for generalising the call to mm_malloc api */
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
-	mmaddress_t caller_retaddr = GET_RETURN_ADDRESS();
+	caller_retaddr = GET_RETURN_ADDRESS();
 #endif
 	struct mm_heap_s *kheap_origin;
 	struct mm_heap_s *kheap_new;
@@ -158,11 +158,7 @@ FAR void *kmm_realloc(FAR void *oldmem, size_t newsize)
 			return NULL;
 		}
 
-#ifdef CONFIG_DEBUG_MM_HEAPINFO
 		ret = mm_realloc(kheap_origin, oldmem, newsize, caller_retaddr);
-#else
-		ret = mm_realloc(kheap_origin, oldmem, newsize);
-#endif
 		if (ret != NULL) {
 			return ret;
 		}
@@ -171,11 +167,7 @@ FAR void *kmm_realloc(FAR void *oldmem, size_t newsize)
 	/* Try to mm_malloc to another heap. */
 	kheap_new = kmm_get_baseheap();
 	for (kheap_idx = HEAP_START_IDX; kheap_idx <= HEAP_END_IDX; kheap_idx++) {
-		ret = mm_malloc(&kheap_new[kheap_idx], newsize
-#ifdef CONFIG_DEBUG_MM_HEAPINFO
-				, caller_retaddr
-#endif
-				);
+		ret = mm_malloc(&kheap_new[kheap_idx], newsize, caller_retaddr);
 		if (ret != NULL) {
 			kmm_free(oldmem);
 			return ret;

--- a/os/mm/kmm_heap/kmm_zalloc.c
+++ b/os/mm/kmm_heap/kmm_zalloc.c
@@ -85,8 +85,10 @@ void *kmm_zalloc_at(int heap_index, size_t size)
 {
 	void *ret;
 	struct mm_heap_s *kheap;
+
+	mmaddress_t caller_retaddr = NULL;	/* for generalising the call to mm_zalloc api */
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
-	mmaddress_t caller_retaddr = GET_RETURN_ADDRESS();
+	caller_retaddr = GET_RETURN_ADDRESS();
 #endif
 	if (heap_index > HEAP_END_IDX || heap_index < HEAP_START_IDX) {
 		mdbg("kmm_zalloc_at failed. Wrong heap index (%d) of (%d)\n", heap_index, HEAP_END_IDX);
@@ -98,11 +100,7 @@ void *kmm_zalloc_at(int heap_index, size_t size)
 	}
 
 	kheap = kmm_get_baseheap();
-	ret = mm_zalloc(&kheap[heap_index], size
-#ifdef CONFIG_DEBUG_MM_HEAPINFO
-			, caller_retaddr
-#endif
-			);
+	ret = mm_zalloc(&kheap[heap_index], size, caller_retaddr);
 	if (ret == NULL) {
 		mm_manage_alloc_fail(&kheap[heap_index], heap_index, heap_index, size, 0, KERNEL_HEAP
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
@@ -132,8 +130,10 @@ FAR void *kmm_zalloc(size_t size)
 {
 	void *ret;
 	int kheap_idx;
+
+	mmaddress_t caller_retaddr = NULL;	/* for generalising the call to mm_zalloc api */
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
-	mmaddress_t caller_retaddr = GET_RETURN_ADDRESS();
+	caller_retaddr = GET_RETURN_ADDRESS();
 #endif
 	if (size == 0) {
 		return NULL;
@@ -142,11 +142,7 @@ FAR void *kmm_zalloc(size_t size)
 	struct mm_heap_s *kheap = kmm_get_baseheap();
 
 	for (kheap_idx = HEAP_START_IDX; kheap_idx <= HEAP_END_IDX; kheap_idx++) {
-		ret = mm_zalloc(&kheap[kheap_idx], size
-#ifdef CONFIG_DEBUG_MM_HEAPINFO
-				, caller_retaddr
-#endif
-				);
+		ret = mm_zalloc(&kheap[kheap_idx], size, caller_retaddr);
 		if (ret != NULL) {
 			return ret;
 		}

--- a/os/mm/mm_heap/mm_calloc.c
+++ b/os/mm/mm_heap/mm_calloc.c
@@ -74,11 +74,8 @@
  *
  ****************************************************************************/
 
-#ifdef CONFIG_DEBUG_MM_HEAPINFO
+/* unified mm_calloc api */
 FAR void *mm_calloc(FAR struct mm_heap_s *heap, size_t n, size_t elem_size, mmaddress_t caller_retaddr)
-#else
-FAR void *mm_calloc(FAR struct mm_heap_s *heap, size_t n, size_t elem_size)
-#endif
 {
 	FAR void *ret = NULL;
 
@@ -87,11 +84,8 @@ FAR void *mm_calloc(FAR struct mm_heap_s *heap, size_t n, size_t elem_size)
 			because multiplication of n and elem_size cannot overflow the size_t.\n", n, (MMSIZE_MAX / elem_size));
 		return NULL;
 	}
-#ifdef CONFIG_DEBUG_MM_HEAPINFO
+
 	ret = mm_zalloc(heap, n * elem_size, caller_retaddr);
-#else
-	ret = mm_zalloc(heap, n * elem_size);
-#endif
 
 	return ret;
 }

--- a/os/mm/mm_heap/mm_malloc.c
+++ b/os/mm/mm_heap/mm_malloc.c
@@ -139,11 +139,8 @@ static void mm_free_delaylist(FAR struct mm_heap_s *heap)
  *  8-byte alignment of the allocated data is assured.
  *
  ****************************************************************************/
-#ifdef CONFIG_DEBUG_MM_HEAPINFO
+/* the unified mm_malloc api */
 FAR void *mm_malloc(FAR struct mm_heap_s *heap, size_t size, mmaddress_t caller_retaddr)
-#else
-FAR void *mm_malloc(FAR struct mm_heap_s *heap, size_t size)
-#endif
 {
 	FAR struct mm_freenode_s *node;
 	void *ret = NULL;

--- a/os/mm/mm_heap/mm_memalign.c
+++ b/os/mm/mm_heap/mm_memalign.c
@@ -105,11 +105,9 @@
  *   alignment is guaranteed by normal malloc calls.
  *
  ****************************************************************************/
-#ifdef CONFIG_DEBUG_MM_HEAPINFO
+
+/* unification of mm_memalign api*/
 FAR void *mm_memalign(FAR struct mm_heap_s *heap, size_t alignment, size_t size, mmaddress_t caller_retaddr)
-#else
-FAR void *mm_memalign(FAR struct mm_heap_s *heap, size_t alignment, size_t size)
-#endif
 {
 	FAR struct mm_freenode_s *node = NULL;
 	void *ret = NULL;
@@ -125,11 +123,7 @@ FAR void *mm_memalign(FAR struct mm_heap_s *heap, size_t alignment, size_t size)
 	 */
 
 	if (alignment <= MM_MIN_CHUNK) {
-#ifdef CONFIG_DEBUG_MM_HEAPINFO
 		return mm_malloc(heap, size, caller_retaddr);
-#else
-		return mm_malloc(heap, size);
-#endif
 	}
 
 	if (size > MM_ALIGN_DOWN(MMSIZE_MAX) - SIZEOF_MM_ALLOCNODE) {

--- a/os/mm/mm_heap/mm_realloc.c
+++ b/os/mm/mm_heap/mm_realloc.c
@@ -100,11 +100,9 @@
  *  and free the old buffer.
  *
  ****************************************************************************/
-#ifdef CONFIG_DEBUG_MM_HEAPINFO
+
+/* unified mm_realloc api */
 FAR void *mm_realloc(FAR struct mm_heap_s *heap, FAR void *oldmem, size_t size, mmaddress_t caller_retaddr)
-#else
-FAR void *mm_realloc(FAR struct mm_heap_s *heap, FAR void *oldmem, size_t size)
-#endif
 {
 	FAR struct mm_allocnode_s *oldnode;
 #ifndef CONFIG_REALLOC_DISABLE_NEIGHBOR_EXTENSION
@@ -118,15 +116,10 @@ FAR void *mm_realloc(FAR struct mm_heap_s *heap, FAR void *oldmem, size_t size)
 	size_t nextsize = 0;
 #endif
 	FAR void *newmem;
-
 	/* If oldmem is NULL, then realloc is equivalent to malloc */
 
 	if (!oldmem) {
-#ifdef CONFIG_DEBUG_MM_HEAPINFO
 		return mm_malloc(heap, size, caller_retaddr);
-#else
-		return mm_malloc(heap, size);
-#endif
 	}
 
 	if (size > MM_ALIGN_DOWN(MMSIZE_MAX) - SIZEOF_MM_ALLOCNODE) {
@@ -367,11 +360,7 @@ FAR void *mm_realloc(FAR struct mm_heap_s *heap, FAR void *oldmem, size_t size)
 		 * leave the original memory in place.
 		 */
 		mm_givesemaphore(heap);
-#ifdef CONFIG_DEBUG_MM_HEAPINFO
 		newmem = (FAR void *)mm_malloc(heap, size, caller_retaddr);
-#else
-		newmem = (FAR void *)mm_malloc(heap, size);
-#endif
 		if (newmem) {
 			memcpy(newmem, oldmem, oldsize - SIZEOF_MM_ALLOCNODE);
 			mm_free(heap, oldmem);

--- a/os/mm/mm_heap/mm_zalloc.c
+++ b/os/mm/mm_heap/mm_zalloc.c
@@ -76,17 +76,10 @@
  *
  ****************************************************************************/
 
-#ifdef CONFIG_DEBUG_MM_HEAPINFO
+/* unified mm_zalloc api */
 FAR void *mm_zalloc(FAR struct mm_heap_s *heap, size_t size, mmaddress_t caller_retaddr)
-#else
-FAR void *mm_zalloc(FAR struct mm_heap_s *heap, size_t size)
-#endif
 {
-#ifdef CONFIG_DEBUG_MM_HEAPINFO
 	FAR void *alloc = mm_malloc(heap, size, caller_retaddr);
-#else
-	FAR void *alloc = mm_malloc(heap, size);
-#endif
 	if (alloc) {
 		memset(alloc, 0, size);
 	}

--- a/os/mm/umm_heap/umm_calloc.c
+++ b/os/mm/umm_heap/umm_calloc.c
@@ -84,8 +84,10 @@
 void *calloc_at(int heap_index, size_t n, size_t elem_size)
 {
 	void *ret;
+
+	mmaddress_t caller_retaddr = NULL;	/* for generalising the call to mm_calloc api */
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
-	mmaddress_t caller_retaddr = GET_RETURN_ADDRESS();
+	caller_retaddr = GET_RETURN_ADDRESS();
 #endif
 	if (heap_index > HEAP_END_IDX || heap_index < 0) {
 		mdbg("calloc_at failed. Wrong heap index (%d) of (%d)\n", heap_index, HEAP_END_IDX);
@@ -95,11 +97,7 @@ void *calloc_at(int heap_index, size_t n, size_t elem_size)
 	if (n == 0 || elem_size == 0) {
 		return NULL;
 	}
-	ret = mm_calloc(&BASE_HEAP[heap_index], n, elem_size
-#ifdef CONFIG_DEBUG_MM_HEAPINFO
-			, caller_retaddr
-#endif
-			);
+	ret = mm_calloc(&BASE_HEAP[heap_index], n, elem_size, caller_retaddr);
 	if (ret == NULL) {
 		mm_manage_alloc_fail(&BASE_HEAP[heap_index], heap_index, heap_index, n * elem_size, 0, USER_HEAP
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
@@ -128,21 +126,14 @@ void *calloc_at(int heap_index, size_t n, size_t elem_size)
  *
  ************************************************************************/
 
-#ifdef CONFIG_DEBUG_MM_HEAPINFO
+/* unified heap_calloc api */
 static void *heap_calloc(size_t n, size_t elem_size, int s, int e, mmaddress_t caller_retaddr)
-#else
-static void *heap_calloc(size_t n, size_t elem_size, int s, int e)
-#endif
 {
 	int heap_idx;
 	void *ret;
 
 	for (heap_idx = s; heap_idx <= e; heap_idx++) {
-		ret = mm_calloc(&BASE_HEAP[heap_idx], n, elem_size
-#ifdef CONFIG_DEBUG_MM_HEAPINFO
-				, caller_retaddr
-#endif
-				);
+		ret = mm_calloc(&BASE_HEAP[heap_idx], n, elem_size, caller_retaddr);
 		if (ret != NULL) {
 			return ret;
 		}
@@ -168,8 +159,9 @@ FAR void *calloc(size_t n, size_t elem_size)
 {
 	void *ret = NULL;
 
+	mmaddress_t caller_retaddr = NULL;	/* for generalising the call to mm_calloc api */
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
-	mmaddress_t caller_retaddr = GET_RETURN_ADDRESS();
+	caller_retaddr = GET_RETURN_ADDRESS();
 #endif
 
 	if (n == 0 || elem_size == 0) {
@@ -178,11 +170,7 @@ FAR void *calloc(size_t n, size_t elem_size)
 
 #ifdef CONFIG_APP_BINARY_SEPARATION
 	/* User supports a single heap on app separation */
-	ret = mm_calloc(BASE_HEAP, n, elem_size
-#ifdef CONFIG_DEBUG_MM_HEAPINFO
-			, caller_retaddr
-#endif
-			);
+	ret = mm_calloc(BASE_HEAP, n, elem_size, caller_retaddr);
 	if (ret == NULL) {
 		mm_manage_alloc_fail(BASE_HEAP, HEAP_START_IDX, HEAP_END_IDX, n * elem_size, 0, USER_HEAP
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
@@ -197,22 +185,14 @@ FAR void *calloc(size_t n, size_t elem_size)
 #ifdef CONFIG_RAM_MALLOC_PRIOR_INDEX
 	heap_idx = CONFIG_RAM_MALLOC_PRIOR_INDEX;
 #endif
-	ret = heap_calloc(n, elem_size, heap_idx, HEAP_END_IDX
-#ifdef CONFIG_DEBUG_MM_HEAPINFO
-				, caller_retaddr
-#endif
-				);
+	ret = heap_calloc(n, elem_size, heap_idx, HEAP_END_IDX, caller_retaddr);
 	if (ret != NULL) {
 		return ret;
 	}
 
 #if (defined(CONFIG_RAM_MALLOC_PRIOR_INDEX) && CONFIG_RAM_MALLOC_PRIOR_INDEX > 0)
 	/* Try to mm_calloc to other heaps */
-	ret = heap_calloc(n, elem_size, HEAP_START_IDX, CONFIG_RAM_MALLOC_PRIOR_INDEX - 1
-#ifdef CONFIG_DEBUG_MM_HEAPINFO
-				, caller_retaddr
-#endif
-				);
+	ret = heap_calloc(n, elem_size, HEAP_START_IDX, CONFIG_RAM_MALLOC_PRIOR_INDEX - 1, caller_retaddr);
 #endif
 
 #endif  /* CONFIG_APP_BINARY_SEPARATION */

--- a/os/mm/umm_heap/umm_malloc.c
+++ b/os/mm/umm_heap/umm_malloc.c
@@ -105,8 +105,10 @@
 void *malloc_at(int heap_index, size_t size)
 {
 	void *ret;
+
+	mmaddress_t caller_retaddr = NULL;	/* for generalising the call to mm_malloc api */
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
-	mmaddress_t caller_retaddr = GET_RETURN_ADDRESS();
+	caller_retaddr = GET_RETURN_ADDRESS();
 #endif
 	if (heap_index > HEAP_END_IDX || heap_index < HEAP_START_IDX) {
 		mdbg("malloc_at failed. Wrong heap index (%d) of (%d)\n", heap_index, HEAP_END_IDX);
@@ -116,11 +118,7 @@ void *malloc_at(int heap_index, size_t size)
 	if (size == 0) {
 		return NULL;
 	}
-	ret = mm_malloc(&BASE_HEAP[heap_index], size
-#ifdef CONFIG_DEBUG_MM_HEAPINFO
-			, caller_retaddr
-#endif
-			);
+	ret = mm_malloc(&BASE_HEAP[heap_index], size, caller_retaddr);
 	if (ret == NULL) {
 		mm_manage_alloc_fail(&BASE_HEAP[heap_index], heap_index, heap_index, size, 0, USER_HEAP
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
@@ -148,21 +146,15 @@ void *malloc_at(int heap_index, size_t size)
  *   The address of the allocated memory (NULL on failure to allocate)
  *
  ************************************************************************/
-#ifdef CONFIG_DEBUG_MM_HEAPINFO
+
+/* unified heap_malloc api */
 static void *heap_malloc(size_t size, int s, int e, mmaddress_t caller_retaddr)
-#else
-static void *heap_malloc(size_t size, int s, int e)
-#endif
 {
 	int heap_idx;
 	void *ret;
 
 	for (heap_idx = s; heap_idx <= e; heap_idx++) {
-		ret = mm_malloc(&BASE_HEAP[heap_idx], size
-#ifdef CONFIG_DEBUG_MM_HEAPINFO
-				, caller_retaddr
-#endif
-				);
+		ret = mm_malloc(&BASE_HEAP[heap_idx], size, caller_retaddr);
 		if (ret != NULL) {
 			return ret;
 		}
@@ -194,6 +186,8 @@ static void *heap_malloc(size_t size, int s, int e)
 
 FAR void *malloc(size_t size)
 {
+	mmaddress_t caller_retaddr = NULL;	/* for generalising the call to mm_malloc api */
+
 #ifdef CONFIG_BUILD_KERNEL
 	FAR void *brkaddr;
 	FAR void *mem;
@@ -208,9 +202,8 @@ FAR void *malloc(size_t size)
 	 * execute more than twice (but more memory than we need may be
 	 * allocated).
 	 */
-
 	do {
-		mem = mm_malloc(BASE_HEAP, size);
+		mem = mm_malloc(BASE_HEAP, size, caller_retaddr);
 		if (!mem) {
 			brkaddr = sbrk(size);
 			if (brkaddr == (FAR void *)-1) {
@@ -229,16 +222,12 @@ FAR void *malloc(size_t size)
 	}
 
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
-	mmaddress_t caller_retaddr = GET_RETURN_ADDRESS();
+	caller_retaddr = GET_RETURN_ADDRESS();
 #endif
 
 #ifdef CONFIG_APP_BINARY_SEPARATION
 	/* User supports a single heap on app separation */
-	ret = mm_malloc(BASE_HEAP, size
-#ifdef CONFIG_DEBUG_MM_HEAPINFO
-			, caller_retaddr
-#endif
-			);
+	ret = mm_malloc(BASE_HEAP, size, caller_retaddr);
 	if (ret == NULL) {
 		mm_manage_alloc_fail(BASE_HEAP, HEAP_START_IDX, HEAP_END_IDX, size, 0, USER_HEAP
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
@@ -254,22 +243,14 @@ FAR void *malloc(size_t size)
 	heap_idx = CONFIG_RAM_MALLOC_PRIOR_INDEX;
 #endif
 
-	ret = heap_malloc(size, heap_idx, HEAP_END_IDX
-#ifdef CONFIG_DEBUG_MM_HEAPINFO
-				, caller_retaddr
-#endif
-				);
+	ret = heap_malloc(size, heap_idx, HEAP_END_IDX, caller_retaddr);
 	if (ret != NULL) {
 		return ret;
 	}
 
 #if (defined(CONFIG_RAM_MALLOC_PRIOR_INDEX) && CONFIG_RAM_MALLOC_PRIOR_INDEX > 0)
 	/* Try to mm_calloc to other heaps */
-	ret = heap_malloc(size, HEAP_START_IDX, CONFIG_RAM_MALLOC_PRIOR_INDEX - 1
-#ifdef CONFIG_DEBUG_MM_HEAPINFO
-				, caller_retaddr
-#endif
-				);
+	ret = heap_malloc(size, HEAP_START_IDX, CONFIG_RAM_MALLOC_PRIOR_INDEX - 1, caller_retaddr);
 #endif
 #endif /* CONFIG_APP_BINARY_SEPARATION */
 

--- a/os/mm/umm_heap/umm_memalign.c
+++ b/os/mm/umm_heap/umm_memalign.c
@@ -88,8 +88,10 @@
 void *memalign_at(int heap_index, size_t alignment, size_t size)
 {
 	void *ret;
+
+	mmaddress_t caller_retaddr = NULL;	/* for generalising the call to mm_memalign api */
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
-	mmaddress_t caller_retaddr = GET_RETURN_ADDRESS();
+	caller_retaddr = GET_RETURN_ADDRESS();
 #endif
 	if (heap_index > HEAP_END_IDX || heap_index < HEAP_START_IDX) {
 		mdbg("memalign_at failed. Wrong heap index (%d) of (%d)\n", heap_index, HEAP_END_IDX);
@@ -100,11 +102,7 @@ void *memalign_at(int heap_index, size_t alignment, size_t size)
 		return NULL;
 	}
 
-	ret = mm_memalign(&BASE_HEAP[heap_index], alignment, size
-#ifdef CONFIG_DEBUG_MM_HEAPINFO
-			, caller_retaddr
-#endif
-			);
+	ret = mm_memalign(&BASE_HEAP[heap_index], alignment, size, caller_retaddr);
 	if (ret == NULL) {
 		mm_manage_alloc_fail(&BASE_HEAP[heap_index], heap_index, heap_index, size, alignment, USER_HEAP
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
@@ -137,16 +135,13 @@ FAR void *memalign(size_t alignment, size_t size)
 		return NULL;
 	}
 
+	mmaddress_t caller_retaddr = NULL;	/* for generalising the call to mm_memalign api */
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
-	mmaddress_t caller_retaddr = GET_RETURN_ADDRESS();
+	caller_retaddr = GET_RETURN_ADDRESS();
 #endif
 #ifdef CONFIG_APP_BINARY_SEPARATION
 	/* User supports a single heap on app separation */
-	ret = mm_memalign(BASE_HEAP, alignment, size
-#ifdef CONFIG_DEBUG_MM_HEAPINFO
-			, caller_retaddr
-#endif
-			);
+	ret = mm_memalign(BASE_HEAP, alignment, size, caller_retaddr);
 	if (ret == NULL) {
 		mm_manage_alloc_fail(BASE_HEAP, HEAP_START_IDX, HEAP_END_IDX, size, alignment, USER_HEAP
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
@@ -159,11 +154,7 @@ FAR void *memalign(size_t alignment, size_t size)
 
 	int heap_idx;
 	for (heap_idx = HEAP_START_IDX; heap_idx <= HEAP_END_IDX; heap_idx++) {
-		ret = mm_memalign(&BASE_HEAP[heap_idx], alignment, size
-#ifdef CONFIG_DEBUG_MM_HEAPINFO
-				, caller_retaddr
-#endif
-				);
+		ret = mm_memalign(&BASE_HEAP[heap_idx], alignment, size, caller_retaddr);
 		if (ret != NULL) {
 			return ret;
 		}

--- a/os/mm/umm_heap/umm_realloc.c
+++ b/os/mm/umm_heap/umm_realloc.c
@@ -88,8 +88,10 @@
 void *realloc_at(int heap_index, void *oldmem, size_t size)
 {
 	void *ret;
+
+	mmaddress_t caller_retaddr = NULL;	/* for generalising the call to mm_realloc api */
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
-	mmaddress_t caller_retaddr = GET_RETURN_ADDRESS();
+	caller_retaddr = GET_RETURN_ADDRESS();
 #endif
 
 	if (heap_index > HEAP_END_IDX || heap_index < HEAP_START_IDX) {
@@ -102,11 +104,7 @@ void *realloc_at(int heap_index, void *oldmem, size_t size)
 		return NULL;
 	}
 
-	ret = mm_realloc(&BASE_HEAP[heap_index], oldmem, size
-#ifdef CONFIG_DEBUG_MM_HEAPINFO
-			, caller_retaddr
-#endif
-			);
+	ret = mm_realloc(&BASE_HEAP[heap_index], oldmem, size, caller_retaddr);
 	if (ret == NULL) {
 		mm_manage_alloc_fail(&BASE_HEAP[heap_index], heap_index, heap_index, size, 0, USER_HEAP
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
@@ -139,8 +137,10 @@ FAR void *realloc(FAR void *oldmem, size_t size)
 	int prev_heap_idx ;
 #endif
 	void *ret;
+
+	mmaddress_t caller_retaddr = NULL;	/* for generalising the call to mm_realloc api */
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
-	mmaddress_t caller_retaddr = GET_RETURN_ADDRESS();
+	caller_retaddr = GET_RETURN_ADDRESS();
 #endif
 
 #ifdef CONFIG_APP_BINARY_SEPARATION
@@ -149,11 +149,7 @@ FAR void *realloc(FAR void *oldmem, size_t size)
 		return NULL;
 	}	
 	/* User supports a single heap on app separation */
-	ret = mm_realloc(BASE_HEAP, oldmem, size
-#ifdef CONFIG_DEBUG_MM_HEAPINFO
-			, caller_retaddr
-#endif
-			);
+	ret = mm_realloc(BASE_HEAP, oldmem, size, caller_retaddr);
 	if (ret == NULL) {
 		mm_manage_alloc_fail(BASE_HEAP, HEAP_START_IDX, HEAP_END_IDX, size, 0, USER_HEAP
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
@@ -176,11 +172,7 @@ FAR void *realloc(FAR void *oldmem, size_t size)
 
 	/* Try to realloc in previous allocated heap */
 
-#ifdef CONFIG_DEBUG_MM_HEAPINFO
 	ret = mm_realloc(&BASE_HEAP[heap_idx], oldmem, size, caller_retaddr);
-#else
-	ret = mm_realloc(&BASE_HEAP[heap_idx], oldmem, size);
-#endif
 	if (ret != NULL) {
 		return ret;
 	}
@@ -189,11 +181,7 @@ FAR void *realloc(FAR void *oldmem, size_t size)
 
 	prev_heap_idx = heap_idx;
 	for (heap_idx = HEAP_START_IDX; heap_idx <= HEAP_END_IDX; heap_idx++) {
-		ret = mm_malloc(&BASE_HEAP[heap_idx], size
-#ifdef CONFIG_DEBUG_MM_HEAPINFO
-				, caller_retaddr
-#endif
-				);
+		ret = mm_malloc(&BASE_HEAP[heap_idx], size, caller_retaddr);
 		if (ret != NULL) {
 			mm_free(&BASE_HEAP[prev_heap_idx], oldmem);
 			return ret;

--- a/os/mm/umm_heap/umm_xalloc_user_at.c
+++ b/os/mm/umm_heap/umm_xalloc_user_at.c
@@ -42,12 +42,13 @@ void *calloc_user_at(struct mm_heap_s *heap, size_t n, size_t elem_size)
 	if (n == 0 || elem_size == 0) {
 		return NULL;
 	}
+
+	mmaddress_t caller_retaddr = NULL;	/* for generalisng the call to mm_calloc api */
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
-	mmaddress_t caller_retaddr = GET_RETURN_ADDRESS();
-	return mm_calloc(heap, n, elem_size, caller_retaddr);
-#else
-	return mm_calloc(heap, n, elem_size);
+	caller_retaddr = GET_RETURN_ADDRESS();
 #endif
+
+	return mm_calloc(heap, n, elem_size, caller_retaddr);
 }
 
 /************************************************************************
@@ -64,12 +65,13 @@ void *memalign_user_at(struct mm_heap_s *heap, size_t alignment, size_t size)
 	if (size == 0) {
 		return NULL;
 	}
+
+	mmaddress_t caller_retaddr = NULL;	/* for generalising the call to mm_memalign api */
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
-	mmaddress_t caller_retaddr = GET_RETURN_ADDRESS();
-	return mm_memalign(heap, alignment, size, caller_retaddr);
-#else
-	return mm_memalign(heap, alignment, size);
+	caller_retaddr = GET_RETURN_ADDRESS();
 #endif
+
+	return mm_memalign(heap, alignment, size, caller_retaddr);
 }
 
 /************************************************************************
@@ -93,12 +95,13 @@ void *malloc_user_at(struct mm_heap_s *heap, size_t size)
 	if (size == 0) {
 		return NULL;
 	}
+
+	mmaddress_t caller_retaddr = NULL;	/* for generalising the call to mm_malloc api */
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
-	mmaddress_t caller_retaddr = GET_RETURN_ADDRESS();
-	return mm_malloc(heap, size, caller_retaddr);
-#else
-	return mm_malloc(heap, size);
+	caller_retaddr = GET_RETURN_ADDRESS();
 #endif
+
+	return mm_malloc(heap, size, caller_retaddr);
 }
 
 /************************************************************************
@@ -112,18 +115,17 @@ void *malloc_user_at(struct mm_heap_s *heap, size_t size)
  ************************************************************************/
 void *realloc_user_at(struct mm_heap_s *heap, void *oldmem, size_t newsize)
 {
-#ifdef CONFIG_DEBUG_MM_HEAPINFO
-	mmaddress_t caller_retaddr = GET_RETURN_ADDRESS();
-#endif
 	if (newsize == 0) {
 		free_user_at(heap, oldmem);
 		return NULL;
 	}
+	
+	mmaddress_t caller_retaddr = NULL;	/* for generalising the call to mm_realloc api */
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
-	return mm_realloc(heap, oldmem, newsize, caller_retaddr);
-#else
-	return mm_realloc(heap, oldmem, newsize);
+	caller_retaddr = GET_RETURN_ADDRESS();
 #endif
+
+	return mm_realloc(heap, oldmem, newsize, caller_retaddr);
 }
 
 /************************************************************************
@@ -140,10 +142,11 @@ void *zalloc_user_at(struct mm_heap_s *heap, size_t size)
 	if (size == 0) {
 		return NULL;
 	}
+
+	mmaddress_t caller_retaddr = NULL;	/* for generalising the call to mm_zalloc api */
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
-	mmaddress_t caller_retaddr = GET_RETURN_ADDRESS();
-	return mm_zalloc(heap, size, caller_retaddr);
-#else
-	return mm_zalloc(heap, size);
+	caller_retaddr = GET_RETURN_ADDRESS();
 #endif
+
+	return mm_zalloc(heap, size, caller_retaddr);
 }


### PR DESCRIPTION
Here unifying means merging the two conditional definitions of apis into one as per the requirement to remove #ifdef CONFIG_DEBUG_MM_HEAPINFO in mm apis.
For ex :
As-is:
#ifdef CONFIG_DEBUG_MM_HEAPINFO
FAR void *mm_malloc(FAR struct mm_heap_s *heap, size_t size, mmaddress_t caller_retaddr)
#else
FAR void *mm_malloc(FAR struct mm_heap_s *heap, size_t size)
#endif
{
...
}

To-Be: 

FAR void *mm_malloc(FAR struct mm_heap_s *heap, size_t size, mmaddress_t caller_retaddr)
{
...
}