### PR TITLE
framework/src/eventloop: Fix eventloop task creation in loadable builds

### DIFF
--- a/framework/src/eventloop/eventloop_task.c
+++ b/framework/src/eventloop/eventloop_task.c
@@ -29,7 +29,7 @@
 #include "eventloop_internal.h"
 
 #define EVENTLOOP_STACK_SIZE 4096
-#define EVENTLOOP_PRIORITY 201
+#define EVENTLOOP_PRIORITY 181
 
 static int el_task_pid = -1;
 


### PR DESCRIPTION
In loadable builds a task’s priority must be outside the exclusive range
(CONFIG_BM_PRIORITY_MIN < priority < CONFIG_BM_PRIORITY_MAX).

• CONFIG_BM_PRIORITY_MIN = 200
• CONFIG_BM_PRIORITY_MAX = 205

The eventloop task was assigned priority 201, which falls inside the forbidden interval.
Consequently the task failed to start and returned error ‑1.
`eventloop is failed to start, error code is -1`

This commit lowers the eventloop task priority to 181, placing it outside the prohibited range and allowing the task to start successfully.