### PR TITLE
pm: Fix wrong pm metrics macros and remove checking CONFIG_PM_METRICS

### DIFF
--- a/os/drivers/pm/pm.c
+++ b/os/drivers/pm/pm.c
@@ -154,11 +154,9 @@ static int pm_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
 	case PMIOC_SUSPEND_COUNT:
 		ret = pm_suspendcount((struct pm_domain_s *)arg);
 		break;
-#ifdef CONFIG_PM_METRICS
 	case PMIOC_METRICS:
 		ret = pm_metrics((int)arg);
 		break;
-#endif
 #ifdef CONFIG_PM_DVFS
 	case PMIOC_TUNEFREQ:
 		pm_dvfs(arg);

--- a/os/include/tinyara/pm/pm.h
+++ b/os/include/tinyara/pm/pm.h
@@ -617,6 +617,8 @@ void pm_dvfs(int div_lvl);
  *
  ****************************************************************************/
 int pm_metrics(int milliseconds);
+#else
+#define pm_metrics(milliseconds) (ERROR)
 #endif
 
 /****************************************************************************
@@ -641,16 +643,7 @@ int pm_metrics(int milliseconds);
 #define pm_sleep(milliseconds)				usleep(milliseconds * USEC_PER_MSEC)
 #define pm_timedsuspend(domain, milliseconds)	(0)
 #define pm_suspendcount(domain)   (0)
-#ifdef CONFIG_PM_METRICS
 #define pm_metrics(milliseconds) (ERROR)
-#define pm_metrics_update_domain(domain)
-#define pm_metrics_update_suspend(domain)
-#define pm_metrics_update_resume(domain)
-#define pm_metrics_update_changestate()
-#define pm_metrics_update_idle()
-#define pm_metrics_update_wakehandler(missing_tick, wakeup_src)
-#endif
-
 #endif							/* CONFIG_PM */
 
 #undef EXTERN

--- a/os/pm/pm.h
+++ b/os/pm/pm.h
@@ -373,7 +373,14 @@ void pm_metrics_update_idle(void);
  *   None
  *
  ****************************************************************************/
-void pm_metrics_update_wakehandler(clock_t missing_tick, pm_wakeup_reason_code_t wakeup_src);
+void pm_metrics_update_wakehandler(clock_t missing_tick, pm_wakeup_reason_code_t wakeup_src)
+#else 
+#define pm_metrics_update_domain(domain)
+#define pm_metrics_update_suspend(domain)
+#define pm_metrics_update_resume(domain)
+#define pm_metrics_update_changestate()
+#define pm_metrics_update_idle()
+#define pm_metrics_update_wakehandler(missing_tick, wakeup_src)
 #endif
 
 #undef EXTERN

--- a/os/pm/pm_changestate.c
+++ b/os/pm/pm_changestate.c
@@ -234,9 +234,9 @@ int pm_changestate(enum pm_state_e newstate)
 		 * disagreed and the state has been reverted).  Set the new state.
 		 */
 		pm_changeall(newstate);
-#ifdef CONFIG_PM_METRICS
+
 		pm_metrics_update_changestate();
-#endif
+
 		g_pmglobals.state = newstate;
 	}
 EXIT:

--- a/os/pm/pm_domain_register.c
+++ b/os/pm/pm_domain_register.c
@@ -176,10 +176,8 @@ FAR struct pm_domain_s *pm_domain_register(FAR const char *domain)
 	dq_addlast(&new_domain->node, &g_pmglobals.domains);
 	g_pmglobals.ndomains++;
 
-#ifdef CONFIG_PM_METRICS
 	/* For newly registered domain initialize its pm metrics*/
 	pm_metrics_update_domain(new_domain);
-#endif
 
 	leave_critical_section(flags);
 	pmvdbg("Domain '%s' registered successfully\n", domain);

--- a/os/pm/pm_idle.c
+++ b/os/pm/pm_idle.c
@@ -96,9 +96,9 @@ void pm_idle(void)
 		stime = now;
 		/* Decide, which power saving level can be obtained */
 		newstate = pm_checkstate();
-#ifdef CONFIG_PM_METRICS
+
 		pm_metrics_update_idle();
-#endif
+
 #ifdef CONFIG_PM_TIMEDWAKEUP
 		/* get wakeup timer */
 		if (newstate == PM_SLEEP) {

--- a/os/pm/pm_resume.c
+++ b/os/pm/pm_resume.c
@@ -116,9 +116,7 @@ int pm_resume(FAR struct pm_domain_s *domain)
 		goto errout;
 	}
 
-#ifdef CONFIG_PM_METRICS
 	pm_metrics_update_resume(domain);
-#endif
 
 	domain->suspend_count--;
 

--- a/os/pm/pm_suspend.c
+++ b/os/pm/pm_suspend.c
@@ -119,9 +119,7 @@ int pm_suspend(FAR struct pm_domain_s *domain)
 		goto errout;
 	}
 
-#ifdef CONFIG_PM_METRICS
 	pm_metrics_update_suspend(domain);
-#endif
 
 	domain->suspend_count++;
 

--- a/os/pm/pm_wakehandler.c
+++ b/os/pm/pm_wakehandler.c
@@ -55,9 +55,9 @@
 void pm_wakehandler(clock_t missing_tick, pm_wakeup_reason_code_t wakeup_src)
 {
 	irqstate_t flags = enter_critical_section();
-#ifdef CONFIG_PM_METRICS
+
 	pm_metrics_update_wakehandler(missing_tick, wakeup_src);
-#endif
+
 	pmllvdbg("wakeup source code = %d\n", wakeup_src);
 	pmllvdbg("missing_tick: %llu\n", missing_tick);
 #ifdef CONFIG_PM_TICKSUPPRESS


### PR DESCRIPTION
This commit reorganizes the PM metrics related macros in the header files to improve code clarity and maintainability.
And, Remove #ifdef CONFIG_PM_METRICS in entire PM metrics api used location to consistency.

This change helps prevent potential compilation issues and makes the code more readable by centralizing the conditional macro definitions.