### PR TITLE
pm/pm.h: Add missing semicolon

### DIFF
--- a/os/pm/pm.h
+++ b/os/pm/pm.h
@@ -373,7 +373,7 @@ void pm_metrics_update_idle(void);
  *   None
  *
  ****************************************************************************/
-void pm_metrics_update_wakehandler(clock_t missing_tick, pm_wakeup_reason_code_t wakeup_src)
+void pm_metrics_update_wakehandler(clock_t missing_tick, pm_wakeup_reason_code_t wakeup_src);
 #else 
 #define pm_metrics_update_domain(domain)
 #define pm_metrics_update_suspend(domain)


### PR DESCRIPTION
The semicolon was missed at void pm_metrics_update_wakehandler(clock_t missing_tick, pm_wakeup_reason_code_t wakeup_src)

Add semicolon