### PR TITLE
os/board/rtl8721csm: fix BLE indicate semaphore release

### DIFF
--- a/os/board/rtl8721csm/src/component/common/bluetooth/realtek/sdk/example/ble_scatternet/ble_tizenrt_scatternet_app.c
+++ b/os/board/rtl8721csm/src/component/common/bluetooth/realtek/sdk/example/ble_scatternet/ble_tizenrt_scatternet_app.c
@@ -235,14 +235,6 @@ void ble_tizenrt_scatternet_handle_callback_msg(T_TIZENRT_APP_CALLBACK_MSG callb
             T_TIZENRT_CONNECTED_CALLBACK_DATA *connected = callback_msg.u.buf;
             if(connected != NULL && server_init_parm.connected_cb)
             {
-                debug_print("cb %p conn_id 0x%x conn_type 0x%x addr 0x%x0x%x0x%x0x%x0x%x0x%x \n",
-                                server_init_parm.connected_cb,
-                                connected->conn_id, connected->conn_type,
-                                connected->remote_bd[0], connected->remote_bd[1], connected->remote_bd[2],
-                                connected->remote_bd[3], connected->remote_bd[4], connected->remote_bd[5]);
-                trble_server_connected_t p_func = server_init_parm.connected_cb;
-                p_func(connected->conn_id, connected->conn_type, connected->remote_bd, 0xff);// the last field 0xff is a dummy value for adv handle which is for AI-Lite only
-
 #if defined(CONFIG_BLE_INDICATION)
                 if(connected->conn_type == TRBLE_SERVER_DISCONNECTED)
                 {
@@ -250,8 +242,15 @@ void ble_tizenrt_scatternet_handle_callback_msg(T_TIZENRT_APP_CALLBACK_MSG callb
                     {
                         os_mutex_give(ble_tizenrt_indicate_sem);
                     }
-                }	
+                }
 #endif
+                debug_print("cb %p conn_id 0x%x conn_type 0x%x addr 0x%x0x%x0x%x0x%x0x%x0x%x \n",
+                                server_init_parm.connected_cb,
+                                connected->conn_id, connected->conn_type,
+                                connected->remote_bd[0], connected->remote_bd[1], connected->remote_bd[2],
+                                connected->remote_bd[3], connected->remote_bd[4], connected->remote_bd[5]);
+                trble_server_connected_t p_func = server_init_parm.connected_cb;
+                p_func(connected->conn_id, connected->conn_type, connected->remote_bd, 0xff);// the last field 0xff is a dummy value for adv handle which is for AI-Lite only
             } else {
                 debug_print("NULL connected callback \n");
             }


### PR DESCRIPTION
- moved BLE indication semaphore release before calling app layer callback p_func
- to avoid semaphore not released due to action is done in app layer callback p_func