### PR TITLE
os/board/rtl8730e: fix idx_wlan used when enable bridge mode

### DIFF
--- a/os/board/rtl8730e/src/component/os/tizenrt/lwip_intf_tizenrt.c
+++ b/os/board/rtl8730e/src/component/os/tizenrt/lwip_intf_tizenrt.c
@@ -285,7 +285,9 @@ void rltk_wlan_indicate_lwip(int idx_wlan, void *p_buf)
 {
     /* TizenRT gets netif from netdev */
     /* Currently TizenRT only uses idx 0, remove below line if TizenRT supports concurrent */
+#ifndef CONFIG_ENABLE_HOMELYNK
     idx_wlan = 0;
+#endif //#ifndef CONFIG_ENABLE_HOMELYNK
     struct netdev *dev_tmp = NULL;
     dev_tmp = (struct netdev *)rtk_get_netdev(idx_wlan);
     struct netif *netif = GET_NETIF_FROM_NETDEV(dev_tmp);


### PR DESCRIPTION
- Fix SoftAP not working when bridge mode enabled