### PR TITLE
[DO NOT MERGE] os/arch/arm/src/amebasmart: TDM implementation for single dma buff

### DIFF
--- a/apps/examples/sensor_test/sensor_main.c
+++ b/apps/examples/sensor_test/sensor_main.c
@@ -81,9 +81,14 @@ static void mems_teardown();
 
 static void print_sensor_data(sensor_data_s *data)
 {
+	// for (int i = 0; i < AIS25BA_BUFLENGTH; i++) {
+	// 	printf("x: %f, y: %f, z: %f\n", data[i].x, data[i].y, data[i].z);
+	// }
 	for (int i = 0; i < AIS25BA_BUFLENGTH; i++) {
-		printf("x: %f, y: %f, z: %f\n", data[i].x, data[i].y, data[i].z);
+		printf("%04x %04x %04x\n", data[i].samples[0], data[i].samples[1], data[i].samples[2]);
+		// printf("%04x %04x %04x %04x\n", data[i].samples[4], data[i].samples[5], data[i].samples[6], data[i].samples[7]);
 	}
+	printf("=======================================================================================\n");
 }
 
 static int mems_sensor_init()

--- a/os/board/rtl8730e/src/component/soc/amebad2/fwlib/include/ameba_sport.h
+++ b/os/board/rtl8730e/src/component/soc/amebad2/fwlib/include/ameba_sport.h
@@ -1100,6 +1100,7 @@ _LONG_CALL_ void AUDIO_SP_SetTXCounter(u32 index, u32 state);
 _LONG_CALL_ void AUDIO_SP_SetTXCounterCompVal(u32 index, u32 comp_val);
 _LONG_CALL_ void AUDIO_SP_ClearTXCounterIrq(u32 index);
 _LONG_CALL_ void AUDIO_SP_SetPhaseLatch(u32 index);
+_LONG_CALL_ void AUDIO_SP_SetBCLK_Inverse(u32 index, u8 enable);
 _LONG_CALL_ u32 AUDIO_SP_GetTXCounterVal(u32 index);
 _LONG_CALL_ u32 AUDIO_SP_GetTXPhaseVal(u32 index);
 _LONG_CALL_ void AUDIO_SP_SetRXCounter(u32 index, u32 state);

--- a/os/board/rtl8730e/src/component/soc/amebad2/fwlib/ram_hp/ameba_sport.c
+++ b/os/board/rtl8730e/src/component/soc/amebad2/fwlib/ram_hp/ameba_sport.c
@@ -1590,6 +1590,16 @@ void AUDIO_SP_SetPhaseLatch(u32 index)
 	SPORTx->SP_RX_LRCLK |= SP_BIT_EN_FS_PHASE_LATCH;
 }
 
+void AUDIO_SP_SetBCLK_Inverse(u32 index, u8 enable)
+{
+	AUDIO_SPORT_TypeDef *SPORTx = AUDIO_DEV_TABLE[index].SPORTx;
+	if (enable) {
+		SPORTx->SP_CTRL0 |= SP_BIT_INV_I2S_SCLK;
+	} else {
+		SPORTx->SP_CTRL0 &= ~SP_BIT_INV_I2S_SCLK;
+	}
+}
+
 /**
   * @brief  Set SPORT tx counter value.
   * @param  index: select SPORT.

--- a/os/include/tinyara/sensors/ais25ba.h
+++ b/os/include/tinyara/sensors/ais25ba.h
@@ -88,9 +88,10 @@ typedef struct ais25ba_dev_s {
 } ais25ba_dev_s;
 
 typedef struct sensor_data_s {
-	float x;
-	float y;
-	float z;
+	//float x;
+	//float y;
+	//float z;
+	uint16_t samples[8];
 } sensor_data_s;
 
 typedef struct ais25ba_buf_s {


### PR DESCRIPTION
1. includes changes in PR6969
2. includes changes in PR6968
3. fixed issue where data in app cannot be found in LA.
4. All data printed in application can be found in LA, some data between two i2s receive are discarded because i2s clk is always on, it continue sampling but not callback to application layer.