### PR TITLE
os: Fix nxsched_* functions to sched_*

### DIFF
--- a/os/arch/arm/src/amebasmart/amebasmart_idle.c
+++ b/os/arch/arm/src/amebasmart/amebasmart_idle.c
@@ -124,7 +124,7 @@ void up_idle(void)
 	 * "fake" timer interrupts. Hopefully, something will wake up.
 	 */
 
-	nxsched_process_timer();
+	sched_process_timer();
 #else
 
 #ifdef CONFIG_PM

--- a/os/arch/arm/src/imx6/imx_idle.c
+++ b/os/arch/arm/src/imx6/imx_idle.c
@@ -68,7 +68,7 @@ void up_idle(void)
    * "fake" timer interrupts. Hopefully, something will wake up.
    */
 
-  nxsched_process_timer();
+  sched_process_timer();
 #else
 
   /* Sleep until an interrupt occurs to save power */

--- a/os/arch/arm/src/stm32l4/stm32l4_idle.c
+++ b/os/arch/arm/src/stm32l4/stm32l4_idle.c
@@ -134,7 +134,7 @@ void up_idle(void)
    * "fake" timer interrupts. Hopefully, something will wake up.
    */
 
-  nxsched_process_timer();
+  sched_process_timer();
 #else
 	/* set core to WFI */
 #if !(defined(CONFIG_DEBUG_SYMBOLS) && defined(CONFIG_STM32L4_DISABLE_IDLE_SLEEP_DURING_DEBUG))

--- a/os/arch/arm/src/stm32l4/stm32l4_tickless.c
+++ b/os/arch/arm/src/stm32l4/stm32l4_tickless.c
@@ -41,7 +41,7 @@
  * following custom functions.
  *
  *   void arm_timer_initialize(void): Initializes the timer facilities.
- *     Called early in the initialization sequence (by up_intialize()).
+ *     Called early in the initialization sequence (by up_initialize()).
  *   int up_timer_gettime(FAR struct timespec *ts):  Returns the current
  *     time from the platform specific time source.
  *   int up_timer_cancel(void):  Cancels the interval timer.
@@ -51,7 +51,7 @@
  * The RTOS will provide the following interfaces for use by the platform-
  * specific interval timer implementation:
  *
- *   void nxsched_timer_expiration(void):  Called by the platform-specific
+ *   void sched_timer_expiration(void):  Called by the platform-specific
  *     logic when the interval timer expires.
  *
  ****************************************************************************/
@@ -155,7 +155,7 @@ static struct stm32l4_tickless_s g_tickless;
 static void stm32l4_oneshot_handler(FAR void *arg)
 {
   tmrinfo("Expired...\n");
-  nxsched_timer_expiration();
+  sched_timer_expiration();
 }
 
 /****************************************************************************
@@ -284,7 +284,7 @@ int up_timer_gettime(FAR struct timespec *ts)
  * Description:
  *   Cancel the interval timer and return the time remaining on the timer.
  *   These two steps need to be as nearly atomic as possible.
- *   nxsched_timer_expiration() will not be called unless the timer is
+ *   sched_timer_expiration() will not be called unless the timer is
  *   restarted with up_timer_start().
  *
  *   If, as a race condition, the timer has already expired when this
@@ -323,14 +323,14 @@ int up_timer_cancel(FAR struct timespec *ts)
  * Name: up_timer_start
  *
  * Description:
- *   Start the interval timer.  nxsched_timer_expiration() will be
+ *   Start the interval timer.  sched_timer_expiration() will be
  *   called at the completion of the timeout (unless up_timer_cancel
  *   is called to stop the timing.
  *
  *   Provided by platform-specific code and called from the RTOS base code.
  *
  * Input Parameters:
- *   ts - Provides the time interval until nxsched_timer_expiration() is
+ *   ts - Provides the time interval until sched_timer_expiration() is
  *        called.
  *
  * Returned Value:

--- a/os/kernel/sched/sched_getaffinity.c
+++ b/os/kernel/sched/sched_getaffinity.c
@@ -46,12 +46,12 @@
  *   argument specifies the size (in bytes) of mask.  If pid is zero, then
  *   the mask of the calling thread is returned.
  *
- *   This function is a simply wrapper around nxsched_get_affinity() that
+ *   This function is a simply wrapper around sched_gettcb() that
  *   sets the errno value in the event of an error.
  *
  * Input Parameters:
  *   pid        - The ID of thread whose affinity set will be retrieved.
- *   cpusetsize - Size of mask.  MUST be sizeofcpu_set_t().
+ *   cpusetsize - Size of mask.  MUST be sizeof cpu_set_t().
  *   mask       - The location to return the thread's new affinity set.
  *
  * Returned Value:

--- a/os/kernel/sched/sched_lock.c
+++ b/os/kernel/sched/sched_lock.c
@@ -238,7 +238,7 @@ int sched_lock(void)
 
 		/* Move any tasks in the ready-to-run list to the pending task list
 		 * where they will not be available to run until the scheduler is
-		 * unlocked and nxsched_merge_pending() is called.
+		 * unlocked and sched_mergepending() is called.
 		 */
 
 		sched_merge_prioritized((FAR dq_queue_t *)&g_readytorun, \

--- a/os/kernel/sched/sched_setaffinity.c
+++ b/os/kernel/sched/sched_setaffinity.c
@@ -51,12 +51,12 @@
  *   CPUs specified in mask, then that thread is migrated to one of the
  *   CPUs specified in mask.
  *
- *   This function is a simply wrapper around nxsched_set_affinity() that
+ *   This function is a simply wrapper around sched_setpriority() that
  *   sets the errno value in the event of an error.
  *
  * Input Parameters:
  *   pid        - The ID of thread whose affinity set will be modified.
- *   cpusetsize - Size of mask.  MUST be sizeofcpu_set_t().
+ *   cpusetsize - Size of mask.  MUST be sizeof cpu_set_t().
  *   mask       - The location to return the thread's new affinity set.
  *
  * Returned Value:
@@ -128,7 +128,7 @@ int sched_setaffinity(pid_t pid, size_t cpusetsize, FAR const cpu_set_t *mask)
           /* No.. then we will need to move the task from the assigned
            * task list to some other ready to run list.
            *
-           * nxsched_set_priority() will do just what we want... it will
+           * sched_set_priority() will do just what we want... it will
            * remove the task from its current position in the some assigned
            * task list and then simply put it back in the right place.  This
            * works even if the task is this task.


### PR DESCRIPTION
This commit fixes function names from the 'nxsched_*' prefix to 'sched_*'. And fix some typo errors and wrong wrapper function description.

- nxsched_process_timer -> sched_process_timer
- nxsched_timer_expiration -> sched_timer_expiration
- nxsched_merge_pending -> sched_mergepending
- sched_getaffinity is wrapper of sched_gettcb
- sched_setaffinity is wrapper of sched_setpriority

This changes are inspired by https://github.com/Samsung/TizenRT/pull/6896