### PR TITLE
os/include/tinyara/lcd/st7785.h: Fix init code for display sync

### DIFF
--- a/os/include/tinyara/lcd/st7785.h
+++ b/os/include/tinyara/lcd/st7785.h
@@ -61,7 +61,7 @@
 #define LCDC_IMG_BUF_SIZE               LCDC_IMG_BUF_ALIGNED64B(LCD_XRES * LCD_YRES * 2)
 
 #define ST7785_COMMON_INIT {0x3A, 2, {0x00, 0x55}},														/* Interface Pixel format 0x55 for RGB565 */ \
-						   {0xB0, 2, {0x00, 0x10}},														/* RAM control */                            \
+						   {0xB0, 2, {0x00, 0x11}},														/* RAM control */                            \
 						   {0xB2, 10, {0x00, 0x0C, 0x00, 0x0C, 0x00, 0x00, 0x00, 0x33, 0x00, 0x33}},	/* Porch Setting */                          \
 						   {0xB7, 2, {0x00, 0x51}},														/* Gate Control */                           \
 						   {0xBB, 2, {0x00, 0x22}},														/* VCOMS Setting */                          \
@@ -104,7 +104,7 @@ static const lcm_setting_table_t lcd_init_cmd_g_avd_nb01[] = {
 	{REGFLAG_DELAY, 120, {}},													/* Delayms (120) */
 	{0x36, 2, {0x00, LCD_ORIENTATION}},											/* Memory Data Access Control */
 	{0x3A, 2, {0x00, 0x55}},													/* Interface Pixel format 0x55 for RGB565 */
-	{0xB0, 2, {0x00, 0x10}},													/* RAM control */
+	{0xB0, 2, {0x00, 0x11}},													/* RAM control */
 	{0xB2, 10, {0x00, 0x0C, 0x00, 0x0C, 0x00, 0x00, 0x00, 0x33, 0x00, 0x33}},	/* Porch Setting */
 	{0xB7, 2, {0x00, 0x57}},													/* Gate Control */
 	{0xBB, 2, {0x00, 0x1A}},													/* VCOMS Setting */
@@ -130,7 +130,7 @@ static const lcm_setting_table_t lcd_init_cmd_g_hlt_a196[] = {
 	{0x35, 2, {0x00, 0x00}},													/* Tearing Effect Line On 0x00 for The Tearing Effect output line consists of V-Blanking information only */
 	{0x36, 2, {0x00, LCD_ORIENTATION}},											/* Memory Data Access Control */
 	{0x3A, 2, {0x00, 0x55}},													/* Interface Pixel format 0x55 for RGB565 */
-	{0xB0, 2, {0x00, 0x10}},													/* RAM control 0x10 for Ram access from RGB and MIPI interface, Internal clock SYNC mode */
+	{0xB0, 2, {0x00, 0x11}},													/* RAM control 0x11 for Ram access from RGB and MIPI interface, Display SYNC: RGB Interface DOTCLK SYNC mode */
 	{0xB7, 2, {0x00, 0x52}},													/* Gate Control 0x52 for VGH 14.06V, VGL -8.23V */
 	{0xBB, 2, {0x00, 0x17}},													/* VCOMS Setting 0x17 for VCOMS 0.675V */
 	{0xC0, 2, {0x00, 0x2C}},													/* LCM Control 0x2C for XOR RGB setting in command 36h, XOR MX setting in command 36h, can reverse source output order and only support for RGB interface without RAM mode */


### PR DESCRIPTION
We currently have an issue where a green light flash appears upon initial LCD render. 
To address this problem, the display sync mode was modified in the initialization code. 
The change from the previous Internal clock SYNC mode to RGB Interface DOTCLK SYNC mode.