### PR TITLE
[Do not merge] framework/src/media, os/audio : Add changeDSPFlow api for change dsp flow rule on real-time.

### DIFF
--- a/apps/examples/wakerec/wakerec.cxx
+++ b/apps/examples/wakerec/wakerec.cxx
@@ -40,6 +40,7 @@
 #include <media/voice/SpeechDetectorListenerInterface.h>
 #include <media/FocusManager.h>
 #include <media/stream_info.h>
+#include <audio/SoundManager.h>
 #include <iostream>
 #include <memory>
 #include <functional>
@@ -124,7 +125,7 @@ public:
 			return;
 		}
 
-		if (mr.setDuration(7) == RECORDER_ERROR_NONE && mr.prepare() == RECORDER_ERROR_NONE) {
+		if (mr.setDuration(15) == RECORDER_ERROR_NONE && mr.prepare() == RECORDER_ERROR_NONE) {
 			printf("#### [MR] prepare succeeded.\n");
 		} else {
 			printf("#### [MR] prepare failed.\n");
@@ -347,7 +348,12 @@ int wakerec_main(int argc, char *argv[])
 		return -1;
 	}
 	auto recorder = std::shared_ptr<WakeRec>(new WakeRec());
-	if (argc == 2 && atoi(argv[1]) == 0) {
+	if (atoi(argv[1]) == 0) {
+		uint8_t select_dsp_rules = atoi(argv[2]);
+		if (changeDSPFlow(select_dsp_rules)) {
+			printf("Success changeDSPFlow\n");
+		}
+		
 		printf("disable KD!!\n");
 		recorder->initWakeRec(false);
 		recorder->startRecord();

--- a/framework/include/audio/SoundManager.h
+++ b/framework/include/audio/SoundManager.h
@@ -82,6 +82,13 @@ bool setStreamMute(stream_policy_t stream_policy, bool mute);
  */
 bool getStreamMuteState(stream_policy_t stream_policy, bool *mute);
 
+/**
+ * @brief Change dsp flow rule.
+ * @param[in] dwp flow rule number to be changed.
+ * @return true if the operation was successful, false otherwise.
+ */
+bool changeDSPFlow(uint8_t dsp_flow_num);
+
 #if defined(__cplusplus)
 }
 #endif

--- a/framework/src/audio/SoundManager.c
+++ b/framework/src/audio/SoundManager.c
@@ -97,3 +97,20 @@ bool getStreamMuteState(stream_policy_t stream_policy, bool *mute)
 	return true;
 }
 
+bool changeDSPFlow(uint8_t dsp_flow_num)
+{
+	if (dsp_flow_num == 0) {
+		meddbg("dsp_flow_num can not be 0, it starts from 1\n");
+		return false;
+	}
+
+	meddbg("SoundManager : changeDSPFlow. dsp_flow_num: %d\n", dsp_flow_num);
+	audio_manager_result_t res = change_input_dsp_flow(dsp_flow_num);
+	if (res != AUDIO_MANAGER_SUCCESS) {
+		meddbg("change_output_dsp_flow failed dsp_flow_num : %d, ret : %d\n", dsp_flow_num, res);
+		return false;
+	}
+	return true;
+}
+
+

--- a/framework/src/media/audio/audio_manager.cpp
+++ b/framework/src/media/audio/audio_manager.cpp
@@ -2818,6 +2818,27 @@ audio_manager_result_t get_audio_stream_mute_state(stream_policy_t stream_policy
 	return AUDIO_MANAGER_SUCCESS;
 }
 
+audio_manager_result_t change_input_dsp_flow(uint8_t dsp_flow_num)
+{
+	audio_manager_result_t ret;
+	struct audio_caps_desc_s caps_desc;
+	audio_card_info_t *card;
+	char card_path[AUDIO_DEVICE_FULL_PATH_LENGTH];
+
+	card = &g_audio_in_cards[g_actual_audio_in_card_id];
+	get_card_path(card_path, card->card_id, card->device_id, INPUT);
+
+	pthread_mutex_lock(&(card->card_mutex));
+
+	ret = control_audio_stream_device(card_path, AUDIOIOC_CHANGEDSPFLOW, (unsigned long)dsp_flow_num);
+	if (ret != AUDIO_MANAGER_SUCCESS) {
+		meddbg("Fail to change dsp flow, ret = %d errno : %d\n", ret, get_errno());
+	}
+
+	pthread_mutex_unlock(&(card->card_mutex));
+	return ret;
+}
+
 #ifdef CONFIG_DEBUG_MEDIA_INFO
 void print_audio_card_info(audio_io_direction_t direct)
 {

--- a/framework/src/media/audio/audio_manager.h
+++ b/framework/src/media/audio/audio_manager.h
@@ -898,6 +898,21 @@ audio_manager_result_t set_audio_stream_mute_from_json(stream_policy_t stream_po
  ****************************************************************************/
 audio_manager_result_t get_audio_stream_mute_state(stream_policy_t stream_policy, bool *mute);
 
+/****************************************************************************
+ * Name: change_input_dsp_flow
+ *
+ * Description:
+ *   It changes the current dsp flow to dsp flow of given number.
+ *
+ * Input parameter:
+ * 	 stream_policy: dwp flow rule number to be changed.
+ *   mute: pointer to store the mute state of given stream policy.
+ *
+ * Return Value:
+ *   On success, AUDIO_MANAGER_SUCCESS. Otherwise, a negative value.
+ ****************************************************************************/
+audio_manager_result_t change_input_dsp_flow(uint8_t dsp_flow_num);
+
 #ifdef CONFIG_DEBUG_MEDIA_INFO
 /****************************************************************************
  * Name: dump_audio_card_info

--- a/os/drivers/audio/ndp120_voice.c
+++ b/os/drivers/audio/ndp120_voice.c
@@ -725,6 +725,11 @@ static int ndp120_ioctl(FAR struct audio_lowerhalf_s *dev, int cmd, unsigned lon
 		ndp120_change_kd(priv);
 		break;
 	}
+	case AUDIOIOC_CHANGEDSPFLOW: {
+		uint8_t dsp_flow_num = (uint8_t)arg;
+		ndp120_change_dsp_flow(priv, dsp_flow_num);
+		break;
+	}
 	default:
 		audvdbg("ndp120_ioctl received unkown cmd 0x%x\n", cmd);
 		ret = -EINVAL;
@@ -906,7 +911,7 @@ FAR struct audio_lowerhalf_s *ndp120_lowerhalf_initialize(FAR struct spi_dev_s *
 	int retry = NDP120_INIT_RETRY_COUNT;
 	while (retry--) {
 		lower->reset();
-		ret = ndp120_init(priv, false);
+		ret = ndp120_init(priv, 0);
 		if (ret != OK) {
 			auddbg("ndp120 init failed\n");
 		} else {

--- a/os/drivers/audio/ndp120_voice.h
+++ b/os/drivers/audio/ndp120_voice.h
@@ -84,6 +84,7 @@ struct ndp120_dev_s {
 	bool keyword_correction;
 	struct pm_domain_s *pm_domain;
 	uint32_t sample_ready_cnt;
+	uint8_t cur_dsp_flow_num;
 
 	/* moved to using pthread cond variable for parity with reference implementation in ilib examples */
 	pthread_mutex_t ndp_mutex_mbsync;

--- a/os/include/tinyara/audio/audio.h
+++ b/os/include/tinyara/audio/audio.h
@@ -154,6 +154,7 @@
 #define AUDIOIOC_GETKDDATA          _AUDIOIOC(26)
 #define AUDIOIOC_ENABLEDMIC         _AUDIOIOC(27)
 #define AUDIOIOC_CHANGEKD           _AUDIOIOC(28)
+#define AUDIOIOC_CHANGEDSPFLOW      _AUDIOIOC(29)
 
 /* Audio Device Types *******************************************************/
 /* The audio interface support different types of audio devices for


### PR DESCRIPTION
If we apply add_dsp_flow_rules_extract_raw_data using api added, We can extract recording data not preprocessing with AEC.