### PR TITLE
os/arch/arm/amebasmart: Remove CONFIG_PM from up_timerisr

### DIFF
--- a/os/arch/arm/src/amebasmart/amebasmart_timerisr.c
+++ b/os/arch/arm/src/amebasmart/amebasmart_timerisr.c
@@ -56,15 +56,11 @@ int up_timerisr(int irq, uint32_t *regs)
 
     last_cycle = arm_arch_timer_compare();
 
-#ifdef CONFIG_PM
-	  if (arm_arch_timer_count() < last_cycle) {
-		  return -1;
-	  } else {
-		  delta_ticks = (uint32_t)((arm_arch_timer_count() - last_cycle) / pdTICKS_TO_CNT) + 1;
-	  }
-#else
-	  delta_ticks = 1;
-#endif
+    if (arm_arch_timer_count() < last_cycle) {
+      return -1;
+    } else {
+      delta_ticks = (uint32_t)((arm_arch_timer_count() - last_cycle) / pdTICKS_TO_CNT) + 1;
+    }
 
     u32 ticks_to_process = delta_ticks;
     while (ticks_to_process > 0) {


### PR DESCRIPTION
PM is not related with `up_timerisr`, so remove `#ifdef CONFIG_PM` from up_timerisr.
If there's missing tick whether `CONFIG_PM` is enabled or not, we should compensate it.