### PR TITLE
os/drivers/mipidsi: Fix sem_wait to retry on EINTR

### DIFF
--- a/os/drivers/mipidsi/mipi_dsi_device_driver.c
+++ b/os/drivers/mipidsi/mipi_dsi_device_driver.c
@@ -127,10 +127,13 @@ static int dsi_dev_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
 	priv = inode->i_private;
 	DEBUGASSERT(priv);
 
-	ret = sem_wait(&priv->sem);
-	if (ret < 0) {
-		return ret;
-	}
+	/* This will be blocked until the semaphore is posted */
+	/* But this ioctl is only for getting the device params, so it's not a problem */
+	/* No possible to deadlock */
+	do {
+		ret = sem_wait(&priv->sem);
+		DEBUGASSERT(ret == 0 || errno == EINTR);
+	} while (ret < 0);
 
 	/* Process the IOCTL command */
 


### PR DESCRIPTION
Previously, `sem_wait` did not retry when interrupted by a signal (EINTR), which could cause issues. Fixed by adding a retry loop.