### PR TITLE
os/kernel: Reformat coding style in kernel/sched files

### DIFF
--- a/os/kernel/sched/sched_getaffinity.c
+++ b/os/kernel/sched/sched_getaffinity.c
@@ -65,39 +65,33 @@
 int sched_getaffinity(pid_t pid, size_t cpusetsize, FAR cpu_set_t *mask)
 {
 #ifdef CONFIG_SMP
-  FAR struct tcb_s *tcb;
-  int ret;
+	FAR struct tcb_s *tcb;
+	int ret;
 
-  DEBUGASSERT(cpusetsize == sizeof(cpu_set_t) && mask != NULL);
+	DEBUGASSERT(cpusetsize == sizeof(cpu_set_t) && mask != NULL);
 
-  /* Verify that the PID corresponds to a real task */
+	/* Verify that the PID corresponds to a real task */
 
-  sched_lock();
-  if (pid == 0)
-    {
-      tcb = this_task();
-    }
-  else
-    {
-      tcb = sched_gettcb(pid);
-    }
+	sched_lock();
+	if (pid == 0) {
+		tcb = this_task();
+	} else {
+		tcb = sched_gettcb(pid);
+	}
 
-  if (tcb == NULL)
-    {
-      ret = -ESRCH;
-    }
-  else
-    {
-      /* Return the affinity mask from the TCB. */
+	if (tcb == NULL) {
+		ret = -ESRCH;
+	} else {
+		/* Return the affinity mask from the TCB. */
 
-      *mask = tcb->affinity;
-      ret = OK;
-    }
+		*mask = tcb->affinity;
+		ret = OK;
+	}
 
-  sched_unlock();
-  return ret;
+	sched_unlock();
+	return ret;
 #else
-  /* In the absence of SMP, all tasks will always run on core 0 */
-  return 0;
+	/* In the absence of SMP, all tasks will always run on core 0 */
+	return 0;
 #endif
 }

--- a/os/kernel/sched/sched_processtimer.c
+++ b/os/kernel/sched/sched_processtimer.c
@@ -161,7 +161,6 @@ static inline void sched_process_timeslice(int cpu)
 #define sched_process_timeslice()
 #endif
 
-
 /****************************************************************************
  * Name:  sched_process_scheduler
  *
@@ -185,7 +184,7 @@ static inline void sched_process_scheduler(void)
 
 #ifdef CONFIG_SMP
 	int i;
-	
+
 	/* If we are running on a single CPU architecture, then we know interrupts
 	 * are disabled and there is no need to explicitly call
 	 * enter_critical_section().  However, in the SMP case,
@@ -194,14 +193,11 @@ static inline void sched_process_scheduler(void)
 	 * TCB that we are manipulating.
 	 */
 
-
 	/* Perform scheduler operations on all CPUs */
 
-	for (i = 0; i < CONFIG_SMP_NCPUS; i++)
-	  {
-	    sched_process_timeslice(i);
-	  }
-
+	for (i = 0; i < CONFIG_SMP_NCPUS; i++) {
+		sched_process_timeslice(i);
+	}
 
 #else
 	/* Perform scheduler operations on the single CPUs */
@@ -212,7 +208,7 @@ static inline void sched_process_scheduler(void)
 
 }
 #else
-#  define sched_process_scheduler()
+#define sched_process_scheduler()
 #endif
 
 /************************************************************************

--- a/os/kernel/sched/sched_resumescheduler.c
+++ b/os/kernel/sched/sched_resumescheduler.c
@@ -58,22 +58,21 @@
 void sched_resume_scheduler(FAR struct tcb_s *tcb)
 {
 #ifdef CONFIG_SCHED_SPORADIC
-  if ((tcb->flags & TCB_FLAG_POLICY_MASK) == TCB_FLAG_SCHED_SPORADIC)
-    {
-      /* Reset the replenishment cycle if it is appropriate to do so */
+	if ((tcb->flags & TCB_FLAG_POLICY_MASK) == TCB_FLAG_SCHED_SPORADIC) {
+		/* Reset the replenishment cycle if it is appropriate to do so */
 
-      DEBUGVERIFY(sched_resume_sporadic(tcb));
-    }
+		DEBUGVERIFY(sched_resume_sporadic(tcb));
+	}
 #endif
 
-  /* Indicate the task has been resumed */
+	/* Indicate the task has been resumed */
 
 #ifdef CONFIG_SCHED_CRITMONITOR
-  sched_resume_critmon(tcb);
+	sched_resume_critmon(tcb);
 #endif
 #ifdef CONFIG_SCHED_INSTRUMENTATION
-  sched_note_resume(tcb);
+	sched_note_resume(tcb);
 #endif
 }
 
-#endif /* CONFIG_RR_INTERVAL > 0 || CONFIG_SCHED_RESUMESCHEDULER */
+#endif							/* CONFIG_RR_INTERVAL > 0 || CONFIG_SCHED_RESUMESCHEDULER */

--- a/os/kernel/sched/sched_waitpid.c
+++ b/os/kernel/sched/sched_waitpid.c
@@ -267,9 +267,9 @@ pid_t waitpid(pid_t pid, int *stat_loc, int options)
 
 	leave_cancellation_point();
 #ifdef CONFIG_SMP
-        leave_critical_section(flags);
+	leave_critical_section(flags);
 #else
-        sched_unlock();
+	sched_unlock();
 #endif
 	return pid;
 
@@ -321,7 +321,7 @@ pid_t waitpid(pid_t pid, int *stat_loc, int options)
 
 	/* waitpid() is a cancellation point */
 	(void)enter_cancellation_point();
-	
+
 	/* Create a signal set that contains only SIGCHLD */
 
 	(void)sigemptyset(&sigset);
@@ -517,9 +517,9 @@ pid_t waitpid(pid_t pid, int *stat_loc, int options)
 
 	leave_cancellation_point();
 #ifdef CONFIG_SMP
-        leave_critical_section(flags);
+	leave_critical_section(flags);
 #else
-        sched_unlock();
+	sched_unlock();
 #endif
 	return (int)pid;
 


### PR DESCRIPTION
- Apply TizenRT C coding rules using `tools/cformatter.sh`.
- Standardize indentation to 4-space tabs and adjust bracket placements.
- Clean up whitespace and pointer alignment for better readability.