### PR TITLE
os/arch: Add I2C timeout error log

### DIFF
--- a/os/arch/arm/src/amebad/amebad_i2c.c
+++ b/os/arch/arm/src/amebad/amebad_i2c.c
@@ -520,11 +520,14 @@ static inline int amebad_i2c_sem_waitdone(FAR struct amebad_i2c_priv_s *priv)
 
 	while (priv->intstate != INTSTATE_DONE && elapsed < timeout);
 
-	i2cinfo("intstate: %d elapsed: %d threshold: %d status: %08x\n", priv->intstate, elapsed, timeout, priv->status);
+	if (priv->intstate != INTSTATE_DONE) {
+		i2cerr("ERROR i2c timeout: intstate: %d elapsed: %d threshold: %d status: %08x\n", priv->intstate, elapsed, timeout, priv->status);
+		ret = -ETIMEDOUT;
+	} else {
+		i2cinfo("intstate: %d elapsed: %d threshold: %d status: %08x\n", priv->intstate, elapsed, timeout, priv->status);
+	}
 
 	/* Set the interrupt state back to IDLE */
-
-	ret = priv->intstate == INTSTATE_DONE ? ret : -ETIMEDOUT;
 	priv->intstate = INTSTATE_IDLE;
 	return ret;
 }

--- a/os/arch/arm/src/amebalite/amebalite_i2c.c
+++ b/os/arch/arm/src/amebalite/amebalite_i2c.c
@@ -552,11 +552,14 @@ static inline int amebalite_i2c_sem_waitdone(FAR struct amebalite_i2c_priv_s *pr
 
 	while (priv->intstate != INTSTATE_DONE && elapsed < timeout);
 
-	i2cinfo("intstate: %d elapsed: %d threshold: %d status: %08x\n", priv->intstate, elapsed, timeout, priv->status);
+	if (priv->intstate != INTSTATE_DONE) {
+		i2cerr("ERROR i2c timeout: intstate: %d elapsed: %d threshold: %d status: %08x\n", priv->intstate, elapsed, timeout, priv->status);
+		ret = -ETIMEDOUT;
+	} else {
+		i2cinfo("intstate: %d elapsed: %d threshold: %d status: %08x\n", priv->intstate, elapsed, timeout, priv->status);
+	}
 
 	/* Set the interrupt state back to IDLE */
-
-	ret = priv->intstate == INTSTATE_DONE ? ret : -ETIMEDOUT;
 	priv->intstate = INTSTATE_IDLE;
 	return ret;
 }

--- a/os/arch/arm/src/amebasmart/amebasmart_i2c.c
+++ b/os/arch/arm/src/amebasmart/amebasmart_i2c.c
@@ -586,11 +586,14 @@ static inline int amebasmart_i2c_sem_waitdone(FAR struct amebasmart_i2c_priv_s *
 
 	while (priv->intstate != INTSTATE_DONE && elapsed < timeout);
 
-	i2cinfo("intstate: %d elapsed: %d threshold: %d status: %08x\n", priv->intstate, elapsed, timeout, priv->status);
+	if (priv->intstate != INTSTATE_DONE) {
+		i2cerr("ERROR i2c timeout: intstate: %d elapsed: %d threshold: %d status: %08x\n", priv->intstate, elapsed, timeout, priv->status);
+		ret = -ETIMEDOUT;
+	} else {
+		i2cinfo("intstate: %d elapsed: %d threshold: %d status: %08x\n", priv->intstate, elapsed, timeout, priv->status);
+	}
 
 	/* Set the interrupt state back to IDLE */
-
-	ret = priv->intstate == INTSTATE_DONE ? ret : -ETIMEDOUT;
 	priv->intstate = INTSTATE_IDLE;
 	return ret;
 }


### PR DESCRIPTION
Add explicit error logging using `i2cerr` when an I2C timeout occurs.