### PR TITLE
drivers/serial: Use lldbg in uart_register

### DIFF
--- a/os/drivers/serial/serial.c
+++ b/os/drivers/serial/serial.c
@@ -1357,6 +1357,8 @@ errout_with_sem:
 
 int uart_register(FAR const char *path, FAR uart_dev_t *dev)
 {
+	int ret;
+
 	/* Initialize semaphores */
 	sem_init(&dev->xmit.sem, 0, 1);
 	sem_init(&dev->recv.sem, 0, 1);
@@ -1377,8 +1379,13 @@ int uart_register(FAR const char *path, FAR uart_dev_t *dev)
 	dev->received = uart_datareceived;
 
 	/* Register the serial driver */
-	dbg("Registering %s\n", path);
-	return register_driver(path, &g_serialops, 0666, dev);
+	ret = register_driver(path, &g_serialops, 0666, dev);
+	if (ret < 0) {
+		lldbg("register_driver %s failed: %d\n", path, ret);
+	} else {
+		llvdbg("register_driver %s success\n", path);
+	}
+	return ret;
 }
 
 /************************************************************************************


### PR DESCRIPTION
To prevent idle task errno from being set to `EBADF` during boot, replace `dbg()` with `lldbg()` in `uart_register()`.
Because during `uart_register` stdout is not ready, so we have to use `lldbg`.

Registering log are printed like below.
```
up_initialize: [Reboot Reason] : 55
uart_register: Registering /dev/console
uart_register: Registering /dev/ttyS0
uart_register: Registering /dev/ttyS1
uart_register: Registering /dev/ttyS2
Logtask init ok!
```