### PR TITLE
apps/examples/power: Fix argument parsing

### DIFF
--- a/apps/examples/power/power_main.c
+++ b/apps/examples/power/power_main.c
@@ -183,7 +183,7 @@ static int start_pm_test(int argc, char *argv[])
 
 		} else if (strncmp(argv[i], "--timed-wakeup", 15) == 0 || strncmp(argv[i], "-t", 3) == 0) {
 			timed_wakeup_test = true;
-			if (i + 1 < argc) {
+			if (i + 1 < argc && argv[i + 1][0] != '-') {
 				timed_wakeup_time = atoi(argv[++i]);
 			}
 		}


### PR DESCRIPTION
Fix an issue when `power start -t -l` is given, `-l` was expected to be a number and fail to start example.

[BEFROE]
```
TASH>>power start -t -l
TASH>>######################### PM LONG TERM TEST START #########################
pm sleep thread start (time: 0)
Fail to pm sleep(errno 38)
```

[AFTER]
```
TASH>>power start -t -l
TASH>>######################### PM LONG TERM TEST START #########################
pm supend resume repeat test start
call suspend(1)
pm sleep thread start (time: 100)
```