### PR TITLE
os/kernel: Improve semaphore critical section protection and debug info

### DIFF
--- a/os/include/assert.h
+++ b/os/include/assert.h
@@ -122,7 +122,7 @@ extern char assert_info_str[CONFIG_STDIO_BUFFER_SIZE];
 #define DEBUGASSERT_INFO(f, fmt, ...) \
 	{ \
 		if (!(f)) { \
-			  DEBUGPANIC_INFO(fmt, ...); \
+			  DEBUGPANIC_INFO(fmt, ##__VA_ARGS__); \
 		} \
 	}
 

--- a/os/kernel/semaphore/sem_destroy.c
+++ b/os/kernel/semaphore/sem_destroy.c
@@ -119,6 +119,7 @@
 
 int sem_destroy(FAR sem_t *sem)
 {
+	irqstate_t saved_state;
 	/* Assure a valid semaphore is specified */
 
 	if (sem) {
@@ -138,6 +139,8 @@ int sem_destroy(FAR sem_t *sem)
 		 * leave the count unchanged but still return OK.
 		 */
 
+		saved_state = enter_critical_section();
+
 		if (sem->semcount >= 0) {
 			sem->semcount = 1;
 		}
@@ -153,7 +156,8 @@ int sem_destroy(FAR sem_t *sem)
 			sem_unregister(sem);
 		}
 #endif
-		sem->flags &= ~FLAGS_INITIALIZED;
+		sem->flags = 0;
+		leave_critical_section(saved_state);
 		return OK;
 	} else {
 		set_errno(EINVAL);

--- a/os/kernel/semaphore/sem_wait.c
+++ b/os/kernel/semaphore/sem_wait.c
@@ -124,6 +124,7 @@ int sem_wait(FAR sem_t *sem)
 	FAR struct tcb_s *rtcb = this_task();
 	irqstate_t saved_state;
 	int ret = ERROR;
+	size_t caller_retaddr = (size_t)GET_RETURN_ADDRESS();
 	/* This API should not be called from interrupt handlers */
 #if defined(CONFIG_DEBUG_DISPLAY_SYMBOL) || defined(CONFIG_BINMGR_RECOVERY)
 	DEBUGASSERT((sem != NULL && up_interrupt_context() == false) || abort_mode);
@@ -156,7 +157,7 @@ int sem_wait(FAR sem_t *sem)
 	if ((sem != NULL) && ((sem->flags & FLAGS_INITIALIZED) != 0)) {
 
 		if ((sem->flags & FLAGS_SEM_MUTEX) != 0) {
-			DEBUGASSERT(sem->semcount < 2);
+			ASSERT_INFO(sem->semcount < 2, "sem = 0x%x, semcount = %d, flags = 0x%x, caller address = 0x%x", sem, sem->semcount, sem->flags, caller_retaddr);
 		}
 
 		/* Check if the lock is available */


### PR DESCRIPTION
- Add critical section protection for semaphore flags in `sem_destroy`
- Move critical section entry to function start in `sem_post` to cover validation checks
- Replace `DEBUGASSERT` with `ASSERT_INFO` in `sem_post` and `sem_wait` for enhanced debugging
- Fix `DEBUGASSERT_INFO` to use `##__VA_ARGS__` instead of `...`