### PR TITLE
os/drivers: Fix to initialize all members of mipi_dsi_msg

### DIFF
--- a/os/drivers/lcd/mipi_lcd.c
+++ b/os/drivers/lcd/mipi_lcd.c
@@ -223,6 +223,8 @@ static int send_cmd(struct mipi_lcd_dev_s *priv, lcm_setting_table_t command)
 	}
 	msg.tx_buf = cmd_addr;
 	msg.tx_len = payload_len;
+	msg.rx_buf = NULL;
+	msg.rx_len = 0;
 	msg.flags = 0;
 	transfer_status = send_to_mipi_dsi(priv, &msg);
 
@@ -239,7 +241,10 @@ int set_return_packet_len(struct mipi_lcd_dev_s *priv, u8 rx_len)
 	struct mipi_dsi_msg msg;
 	msg.channel = rx_len;
 	msg.type = MIPI_DSI_SET_MAXIMUM_RETURN_PACKET_SIZE;
+	msg.tx_buf = NULL;
 	msg.tx_len = 0;
+	msg.rx_buf = NULL;
+	msg.rx_len = 0;
 	msg.flags = 0;
 	transfer_status = send_to_mipi_dsi(priv, &msg);
 
@@ -306,6 +311,8 @@ int send_init_cmd(struct mipi_lcd_dev_s *priv, lcm_setting_table_t *table)
 			}
 			msg.tx_buf = cmd_addr;
 			msg.tx_len = payload_len;
+			msg.rx_buf = NULL;
+			msg.rx_len = 0;
 			msg.flags = 0;
 			transfer_status = send_to_mipi_dsi(priv, &msg);
 			if (transfer_status != OK) {

--- a/os/drivers/mipidsi/mipi_dsi_device.c
+++ b/os/drivers/mipidsi/mipi_dsi_device.c
@@ -74,6 +74,8 @@ static int mipi_dsi_fill_tx_buff(FAR struct mipi_dsi_device *device, uint8_t *tx
 	msg.channel = device->channel;
 	msg.tx_buf = tx;
 	msg.tx_len = sizeof(tx);
+	msg.rx_buf = NULL;
+	msg.rx_len = 0;
 	msg.flags = 0;
 	msg.type = type;
 	
@@ -282,6 +284,8 @@ int mipi_dsi_generic_write(FAR struct mipi_dsi_device *device, FAR const void *p
 	msg.channel = device->channel;
 	msg.tx_buf = payload;
 	msg.tx_len = size;
+	msg.rx_buf = NULL;
+	msg.rx_len = 0;
 	msg.flags = 0;
 
 	switch (size) {
@@ -381,6 +385,8 @@ ssize_t mipi_dsi_dcs_write_buffer(FAR struct mipi_dsi_device *device, FAR const 
 	msg.channel = device->channel;
 	msg.tx_buf = data;
 	msg.tx_len = len;
+	msg.rx_buf = NULL;
+	msg.rx_len = 0;
 	msg.flags = 0;
 
 	switch (len) {


### PR DESCRIPTION
Explicitly initialize all members of `mipi_dsi_msg` to avoid garbage values.