### PR TITLE
configs/rtl8730e: Relocate cpu_pause execution from flash to RAM

### DIFF
--- a/build/configs/rtl8730e/scripts/rlx8730e_img2.ld
+++ b/build/configs/rtl8730e/scripts/rlx8730e_img2.ld
@@ -136,7 +136,7 @@ SECTIONS
 		_stext_flash = ABSOLUTE(.);
 
 		*(.text)		/* .text sections (code) */
-		EXCLUDE_FILE (*arm_mmu.o arm_cpugating.o)*(.text*)      /* .text* sections (code) */
+		EXCLUDE_FILE (*arm_mmu.o *arm_cpupause.o *arm_testset.o *spinlock.o)*(.text*)      /* .text* sections (code) */
 		*(.rodata)      /* .rodata sections (constants, strings, etc.) */
 		*(.rodata*)     /* .rodata* sections (constants, strings, etc.) */
 		*(.glue_7)      /* glue arm to thumb code */
@@ -178,7 +178,9 @@ SECTIONS
 		*(.sramdram.only.text*)     
 		/* Place arm_mmu.c in PSRAM to reduce delay in boot sequence */
 		*arm_mmu.o (.text*)
-		*arm_cpugating.o (.text*)
+		*arm_cpupause.o (.text*)
+		*arm_testset.o (.text*)
+		*spinlock.o (.text*)
 
 		. = ALIGN(4096);
 		__dram_text_end__ = .;

--- a/build/configs/rtl8730e/scripts/rlx8730e_img2_ddr.ld
+++ b/build/configs/rtl8730e/scripts/rlx8730e_img2_ddr.ld
@@ -136,7 +136,7 @@ SECTIONS
 		_stext_flash = ABSOLUTE(.);
 
 		*(.text)		/* .text sections (code) */
-		EXCLUDE_FILE (*arm_mmu.o arm_cpugating.o)*(.text*)      /* .text* sections (code) */
+		EXCLUDE_FILE (*arm_mmu.o *arm_cpupause.o *arm_testset.o *spinlock.o)*(.text*)      /* .text* sections (code) */
 		*(.rodata)      /* .rodata sections (constants, strings, etc.) */
 		*(.rodata*)     /* .rodata* sections (constants, strings, etc.) */
 		*(.glue_7)      /* glue arm to thumb code */
@@ -178,7 +178,9 @@ SECTIONS
 		*(.sramdram.only.text*)     
 		/* Place arm_mmu.c in PSRAM to reduce delay in boot sequence */
 		*arm_mmu.o (.text*)
-		*arm_cpugating.o (.text*)
+		*arm_cpupause.o (.text*)
+		*arm_testset.o (.text*)
+		*spinlock.o (.text*)
 
 		. = ALIGN(4096);
 		__dram_text_end__ = .;


### PR DESCRIPTION
When CPU locks the flash, it can't fetch code from Flash.
We need to execute functions that can be called when other CPU locks the flash in RAM.
So relocate arm_cpupause.o, arm_testset.o, and spinlock.o from Flash execution(XIP) to RAM execution.