### PR TITLE
os/kernel/binary_manager.c: Add binary_manager_sync_bootparam

### DIFF
--- a/apps/examples/kernel_update_test/kernel_update_test_main.c
+++ b/apps/examples/kernel_update_test/kernel_update_test_main.c
@@ -619,6 +619,16 @@ static int binary_update_run_tests(void)
 	return OK;
 }
 
+static void show_usage(void)
+{
+	printf("Usage: kernel_update <test_type>\n");
+	printf("Available test types:\n");
+	printf("  all          - Run all tests\n");
+	printf("  same_version - Run same version test\n");
+	printf("  new_version  - Run new version test\n");
+	printf("  invalid      - Run invalid binary test\n");
+}
+
 /****************************************************************************
  * binary_update_aging_test
  ****************************************************************************/
@@ -628,5 +638,39 @@ int main(int argc, FAR char *argv[])
 int kernel_update_main(int argc, char *argv[])
 #endif
 {
-	binary_update_run_tests();	
+	if (argc == 2 && !strncmp(argv[1], "all", 4)) {
+		/* Run all tests */
+		return binary_update_run_tests();
+
+	} else if (argc == 2 && !strncmp(argv[1], "same_version", 13)) {
+		/* Get info all test. */
+		binary_update_getinfo_all();
+		
+		int ret = binary_update_same_version_test();
+		if (ret != OK) {
+			printf("Same version test failed\n");
+		}
+		return ret;
+	} else if (argc == 2 && !strncmp(argv[1], "new_version", 12)) {
+		/* Get info all test. */
+		binary_update_getinfo_all();
+		
+		int ret = binary_update_new_version_test();
+		if (ret != OK) {
+			printf("New version test failed\n");
+		}
+		return ret;
+	} else if (argc == 2 && !strncmp(argv[1], "invalid", 8)) {
+		/* Get info all test. */
+		binary_update_getinfo_all();
+		
+		int ret = binary_update_invalid_binary_test();
+		if (ret != OK) {
+			printf("Invalid binary test failed\n");
+		}
+		return ret;
+	}
+	printf("Invalid test type: %s\n", argv[1]);
+	show_usage();
+	return ERROR;
 }

--- a/apps/examples/kernel_update_test/kernel_update_test_main.c
+++ b/apps/examples/kernel_update_test/kernel_update_test_main.c
@@ -45,10 +45,22 @@
 /* Kernel binary information for update test */
 #define KERNEL                  "kernel"
 
-/* Common/app1 binary names for testing */
-/* Kernel / Common / App1 binary must be set at once */
+/* Common/app1/app2 binary names for testing */
+/* Kernel / Common / App1 / App2 binary must be set at once */
 #define COMMON                   "common"
 #define APP1                     "app1"
+#define APP2                     "app2"
+
+#ifdef CONFIG_SUPPORT_COMMON_BINARY
+char *bin_names[] = {KERNEL, COMMON, APP1};
+uint8_t bin_types[] = {BINARY_KERNEL, BINARY_COMMON, BINARY_USERAPP};
+#else
+char *bin_names[] = {KERNEL, APP1, APP2};
+uint8_t bin_types[] = {BINARY_KERNEL, BINARY_USERAPP, BINARY_USERAPP};
+#endif
+
+int bin_count = sizeof(bin_names) / sizeof(bin_names[0]);
+
 
 #define DOWNLOAD_VALID_BIN          0
 #define DOWNLOAD_INVALID_BIN        1
@@ -410,9 +422,6 @@ static int binary_update_same_version_test(void)
 	int ret;
 	binary_update_info_t pre_bin_info[3];
 	binary_update_info_t cur_bin_info[3];
-	char *bin_names[] = {KERNEL, COMMON, APP1};
-	uint8_t bin_types[] = {BINARY_KERNEL, BINARY_COMMON, BINARY_USERAPP};
-	int bin_count = sizeof(bin_names) / sizeof(bin_names[0]);
 	int i;
 	update_type_flag = 0;
 
@@ -468,9 +477,6 @@ static int binary_update_new_version_test(void)
 	int ret;
 	binary_update_info_t pre_bin_info[3];
 	binary_update_info_t cur_bin_info[3];
-	char *bin_names[] = {KERNEL, COMMON, APP1};
-	uint8_t bin_types[] = {BINARY_KERNEL, BINARY_COMMON, BINARY_USERAPP};
-	int bin_count = sizeof(bin_names) / sizeof(bin_names[0]);
 	int i;
 	update_type_flag = 0;
 
@@ -530,9 +536,6 @@ static int binary_update_invalid_binary_test(void)
 	int ret;
 	binary_update_info_t pre_bin_info[3];
 	binary_update_info_t cur_bin_info[3];
-	char *bin_names[] = {KERNEL, COMMON, APP1};
-	uint8_t bin_types[] = {BINARY_KERNEL, BINARY_COMMON, BINARY_USERAPP};
-	int bin_count = sizeof(bin_names) / sizeof(bin_names[0]);
 	int i;
 	update_type_flag = 0;
 

--- a/apps/examples/kernel_update_test/kernel_update_test_main.c
+++ b/apps/examples/kernel_update_test/kernel_update_test_main.c
@@ -30,6 +30,11 @@
 #include <crc32.h>
 
 #include <sys/types.h>
+
+#ifdef CONFIG_BOARDCTL_RESET
+#include <sys/boardctl.h>
+#endif
+
 #ifdef CONFIG_MMINFO
 #include <tinyara/fs/ioctl.h>
 #include <tinyara/mminfo.h>
@@ -50,17 +55,46 @@
 #define COMMON                   "common"
 #define APP1                     "app1"
 #define APP2                     "app2"
+#define RESOURCE                 "resource"
 
+/* Dynamic binary configuration based on CONFIG settings */
+static char *bin_names[BINARY_COUNT];  /* Maximum possible binaries */
+static uint8_t bin_types[BINARY_COUNT]; /* Corresponding binary types */
+static int bin_count = 0;
+
+static void configure_binary_arrays(void)
+{
+	bin_count = 0;
+	
+	/* Always include kernel */
+	bin_names[bin_count] = KERNEL;
+	bin_types[bin_count] = BINARY_KERNEL;
+	bin_count++;
+	
+#ifdef CONFIG_APP_BINARY_SEPARATION
+	/* Include app1 */
+	bin_names[bin_count] = APP1;
+	bin_types[bin_count] = BINARY_USERAPP;
+	bin_count++;
 #ifdef CONFIG_SUPPORT_COMMON_BINARY
-char *bin_names[] = {KERNEL, COMMON, APP1};
-uint8_t bin_types[] = {BINARY_KERNEL, BINARY_COMMON, BINARY_USERAPP};
+	/* Include common binary when app separation and common binary are supported */
+	bin_names[bin_count] = COMMON;
+	bin_types[bin_count] = BINARY_COMMON;
+	bin_count++;
 #else
-char *bin_names[] = {KERNEL, APP1, APP2};
-uint8_t bin_types[] = {BINARY_KERNEL, BINARY_USERAPP, BINARY_USERAPP};
+	bin_names[bin_count] = APP2;
+	bin_types[bin_count] = BINARY_USERAPP;
+	bin_count++;
+#endif
 #endif
 
-int bin_count = sizeof(bin_names) / sizeof(bin_names[0]);
-
+#ifdef CONFIG_RESOURCE_FS
+	/* Include resource binary when resource filesystem is supported */
+	bin_names[bin_count] = RESOURCE;
+	bin_types[bin_count] = BINARY_RESOURCE;
+	bin_count++;
+#endif
+}
 
 #define DOWNLOAD_VALID_BIN          0
 #define DOWNLOAD_INVALID_BIN        1
@@ -114,6 +148,7 @@ static int binary_update_download_binary(binary_update_info_t *binary_info, bool
 		user_binary_header_t user_header;
 		kernel_binary_header_t kernel_header;
 		common_binary_header_t common_header;
+		resource_binary_header_t resource_header;
 	} header_data;
 	
 	int header_size;
@@ -171,6 +206,23 @@ static int binary_update_download_binary(binary_update_info_t *binary_info, bool
 			header_data.common_header.version = binary_info->version + 1;
 			printf("new version: %d\n", header_data.common_header.version);
 		}
+	} else if (strcmp(binary_info->name, "resource") == 0) {
+		/* Resource binary */
+		ret = read(read_fd, (FAR uint8_t *)&header_data.resource_header, sizeof(resource_binary_header_t));
+		if (ret != sizeof(resource_binary_header_t)) {
+			printf("Failed to read resource header %s: %d\n", origin_path, ret);
+			ret = ERROR;
+			goto errout_with_close_fd1;
+		}
+		header_size = sizeof(resource_binary_header_t);
+		binary_size = header_data.resource_header.bin_size;
+		version = header_data.resource_header.version;
+		
+		if (version_up) {
+			printf("current version: %d\n", header_data.resource_header.version);
+			header_data.resource_header.version = binary_info->version + 1;
+			printf("new version: %d\n", header_data.resource_header.version);
+		}
 	} else {
 		/* User application binary (app1, app2, etc.) */
 		ret = read(read_fd, (FAR uint8_t *)&header_data.user_header, sizeof(user_binary_header_t));
@@ -223,6 +275,14 @@ static int binary_update_download_binary(binary_update_info_t *binary_info, bool
 			goto errout_with_close_fd2;
 		}
 		crc_hash = crc32part((uint8_t *)&header_data.common_header + CHECKSUM_SIZE, header_data.common_header.header_size, crc_hash);
+	} else if (strcmp(binary_info->name, "resource") == 0) {
+		ret = write(write_fd, (FAR uint8_t *)&header_data.resource_header, sizeof(resource_binary_header_t));
+		if (ret != sizeof(resource_binary_header_t)) {
+			printf("Failed to write resource header: %d\n", ret);
+			ret = ERROR;
+			goto errout_with_close_fd2;
+		}
+		crc_hash = crc32part((uint8_t *)&header_data.resource_header + CHECKSUM_SIZE, header_data.resource_header.header_size, crc_hash);
 	} else {
 		ret = write(write_fd, (FAR uint8_t *)&header_data.user_header, sizeof(user_binary_header_t));
 		if (ret != sizeof(user_binary_header_t)) {
@@ -420,8 +480,8 @@ static int binary_update_reload(void)
 static int binary_update_same_version_test(void)
 {
 	int ret;
-	binary_update_info_t pre_bin_info[3];
-	binary_update_info_t cur_bin_info[3];
+	binary_update_info_t pre_bin_info[BINARY_COUNT];
+	binary_update_info_t cur_bin_info[BINARY_COUNT];
 	int i;
 	update_type_flag = 0;
 
@@ -475,8 +535,8 @@ static int binary_update_same_version_test(void)
 static int binary_update_new_version_test(void)
 {
 	int ret;
-	binary_update_info_t pre_bin_info[3];
-	binary_update_info_t cur_bin_info[3];
+	binary_update_info_t pre_bin_info[BINARY_COUNT];
+	binary_update_info_t cur_bin_info[BINARY_COUNT];
 	int i;
 	update_type_flag = 0;
 
@@ -534,8 +594,8 @@ static int binary_update_new_version_test(void)
 static int binary_update_invalid_binary_test(void)
 {
 	int ret;
-	binary_update_info_t pre_bin_info[3];
-	binary_update_info_t cur_bin_info[3];
+	binary_update_info_t pre_bin_info[BINARY_COUNT];
+	binary_update_info_t cur_bin_info[BINARY_COUNT];
 	int i;
 	update_type_flag = 0;
 
@@ -590,6 +650,80 @@ static int binary_update_invalid_binary_test(void)
 	return OK;
 }
 
+/****************************************************************************
+ * sync_bootparam_partitions_test Functions
+ ****************************************************************************/
+
+static int create_mismatched_bootparam_scenario(void)
+{
+	int ret;
+	binary_update_info_t bin_info;
+	binary_setbp_result_t result;
+	update_type_flag = 0;
+
+	printf("\n** Creating Mismatched Bootparam Scenario **\n");
+	printf("This test creates a scenario where A and B partitions have binaries,\n");
+	printf("but bootparam indices are mismatched with kernel partition.\n");
+
+	/* Step 1: Download binaries to both partitions to ensure they exist */
+	for (int i = 0; i < bin_count; i++) {
+		ret = binary_update_getinfo(bin_names[i], &bin_info);
+		if (ret != OK) {
+			printf("Failed to get info for %s\n", bin_names[i]);
+			return ret;
+		}
+
+		/* Download binary to inactive partition */
+		ret = binary_update_download_binary(&bin_info, false, DOWNLOAD_VALID_BIN);
+		if (ret != OK) {
+			printf("Failed to download %s binary to inactive partition\n", bin_names[i]);
+			return ret;
+		}
+		printf("Downloaded %s to inactive partition\n", bin_names[i]);
+	}
+
+	/* Wait a bit more to ensure the binary is properly written */
+	sleep(2);
+
+	/* Step 2: Set bootparam only for kernel to create mismatch */
+	BM_SET_GROUP(update_type_flag, BINARY_KERNEL);
+	ret = binary_manager_set_bootparam(update_type_flag, &result);
+	if (ret != OK) {
+		printf("Failed to set bootparam for kernel only, ret %d\n", ret);
+		return ret;
+	}
+
+	printf("Created mismatched scenario: kernel bootparam updated, but common/app1 still point to old partitions\n");
+	return OK;
+}
+
+static int test_sync_bootparam_partitions(void)
+{
+	int ret;
+	binary_update_info_t pre_bin_info[BINARY_COUNT];
+	binary_update_info_t cur_bin_info[BINARY_COUNT];
+
+	printf("\n** Test binary_manager_sync_bootparam_partitions **\n");
+
+	/* Get pre-sync info for all binaries */
+	for (int i = 0; i < bin_count; i++) {
+		ret = binary_update_getinfo(bin_names[i], &pre_bin_info[i]);
+		if (ret != OK) {
+			printf("Failed to get pre-sync info for %s\n", bin_names[i]);
+			return ret;
+		}
+	}
+
+	/* Create mismatched bootparam scenario */
+	ret = create_mismatched_bootparam_scenario();
+	if (ret != OK) {
+		printf("Failed to create mismatched bootparam scenario\n");
+		return ret;
+	}
+
+	return OK;
+}
+
 static int binary_update_run_tests(void)
 {
 	int ret;
@@ -618,6 +752,16 @@ static int binary_update_run_tests(void)
 		return ret;
 	}
 
+	/* 5. Test sync bootparam partitions. */
+	ret = test_sync_bootparam_partitions();
+	if (ret != OK) {
+		printf("Sync bootparam partitions test failed\n");
+		return ret;
+	} else {
+		printf("[REBOOT] Success test_sync_bootparam_partitions. Board will be reboot...\n");
+		boardctl(BOARDIOC_RESET, EXIT_SUCCESS);
+	}
+
 	printf("All tests completed successfully\n");
 	return OK;
 }
@@ -630,6 +774,7 @@ static void show_usage(void)
 	printf("  same_version - Run same version test\n");
 	printf("  new_version  - Run new version test\n");
 	printf("  invalid      - Run invalid binary test\n");
+	printf("  sync_bp      - Run sync bootparam test\n");
 }
 
 /****************************************************************************
@@ -641,6 +786,9 @@ int main(int argc, FAR char *argv[])
 int kernel_update_main(int argc, char *argv[])
 #endif
 {
+	/* Configure binary arrays based on CONFIG settings */
+	configure_binary_arrays();
+	
 	if (argc == 2 && !strncmp(argv[1], "all", 4)) {
 		/* Run all tests */
 		return binary_update_run_tests();
@@ -670,6 +818,18 @@ int kernel_update_main(int argc, char *argv[])
 		int ret = binary_update_invalid_binary_test();
 		if (ret != OK) {
 			printf("Invalid binary test failed\n");
+		}
+		return ret;
+	} else if (argc == 2 && !strncmp(argv[1], "sync_bp", 8)) {
+		/* Get info all test. */
+		binary_update_getinfo_all();
+		
+		int ret = test_sync_bootparam_partitions();
+		if (ret != OK) {
+			printf("Sync bootparam partitions test failed\n");
+		} else {
+			printf("[REBOOT] Success test_sync_bootparam_partitions. Board will be reboot...\n");
+			boardctl(BOARDIOC_RESET, EXIT_SUCCESS);
 		}
 		return ret;
 	}

--- a/loadable_apps/loadable_sample/wifiapp/binary_update.c
+++ b/loadable_apps/loadable_sample/wifiapp/binary_update.c
@@ -677,6 +677,31 @@ void binary_update_test(void)
 {
 	binary_update_execute_ntimes(1);
 }
+
+/****************************************************************************
+ * binary_update_test_with_type
+ ****************************************************************************/
+void binary_update_test_with_type(const char *test_type)
+{
+	if (test_type == NULL) {
+		/* Default: run all tests */
+		binary_update_run_tests();
+		return;
+	}
+
+	if (strcmp(test_type, "same_version") == 0) {
+		binary_update_same_version_test(APP1_NAME);
+	} else if (strcmp(test_type, "new_version") == 0) {
+		binary_update_new_version_test(APP1_NAME);
+	} else if (strcmp(test_type, "invalid_binary") == 0) {
+		binary_update_invalid_binary_test(APP1_NAME);
+	} else if (strcmp(test_type, "all_tests") == 0) {
+		binary_update_run_tests();
+	} else {
+		printf("Unknown test type: %s\n", test_type);
+		printf("Available test types: same_version, new_version, invalid_binary, all_tests\n");
+	}
+}
 #endif
 
 #ifdef CONFIG_EXAMPLES_UPDATE_AGING_TEST

--- a/loadable_apps/loadable_sample/wifiapp/wifiapp.c
+++ b/loadable_apps/loadable_sample/wifiapp/wifiapp.c
@@ -42,7 +42,10 @@ static void display_test_scenario(void)
 	printf("\t-Press R or r : Recovery Test\n");
 #endif
 #ifdef CONFIG_EXAMPLES_BINARY_UPDATE_TEST
-	printf("\t-Press U or u : Binary Update Test\n");
+	printf("\t-Press U or u : Binary Update Test (All Tests)\n");
+	printf("\t-Press S or s : Same Version Test\n");
+	printf("\t-Press N or n : New Version Test\n");
+	printf("\t-Press I or i : Invalid Binary Test\n");
 #endif
 	printf("\t-Press X or x : Terminate Tests.\n");
 }
@@ -103,7 +106,19 @@ int wifiapp_main(int argc, char **argv)
 #ifdef CONFIG_EXAMPLES_BINARY_UPDATE_TEST
 		case 'U':
 		case 'u':
-			binary_update_test();
+			binary_update_test_with_type("all_tests");
+			break;
+		case 'S':
+		case 's':
+			binary_update_test_with_type("same_version");
+			break;
+		case 'N':
+		case 'n':
+			binary_update_test_with_type("new_version");
+			break;
+		case 'I':
+		case 'i':
+			binary_update_test_with_type("invalid_binary");
 			break;
 #endif
 		case 'X':

--- a/os/kernel/binary_manager/binary_manager.c
+++ b/os/kernel/binary_manager/binary_manager.c
@@ -111,6 +111,7 @@ void binary_manager_reset_board(int reboot_reason)
 int binary_manager(int argc, char *argv[])
 {
 	int nbytes;
+	int ret;
 #if !defined(CONFIG_DISABLE_SIGNALS)
 	sigset_t sigset;
 #endif
@@ -121,7 +122,6 @@ int binary_manager(int argc, char *argv[])
 	bool is_found_bootparam = true;
 #endif
 #ifdef CONFIG_APP_BINARY_SEPARATION
-	int ret;
 	bool is_found_ubin = true;
 #endif
 
@@ -148,6 +148,15 @@ int binary_manager(int argc, char *argv[])
 	if (binary_manager_get_ucount() <= 0) {
 		is_found_ubin = false;
 		goto errout_with_nobinary;
+	}
+#endif
+
+#ifdef CONFIG_USE_BP
+	/* Check and synchronize bootparam indices at boot time */
+	ret = binary_manager_sync_bootparam_partitions();
+	if (binary_manager_sync_bootparam_partitions() != BINMGR_OK) {
+		bmdbg("Failed to synchronize bootparam partitions, ret %d\n", ret);
+		return 0;
 	}
 #endif
 

--- a/os/kernel/binary_manager/binary_manager_internal.h
+++ b/os/kernel/binary_manager/binary_manager_internal.h
@@ -293,6 +293,7 @@ int binary_manager_scan_bootparam(binmgr_bpinfo_t *bp_info);
 binmgr_bpdata_t *binary_manager_get_bpdata(void);
 int binary_manager_get_inactive_path(int requester_pid, char *bin_name);
 void binary_manager_update_bootparam(int requester_pid, uint8_t type);
+int binary_manager_sync_bootparam_partitions(void);
 void binary_manager_reset_board(int reboot_reason);
 int binary_manager_update_kernel_binary(void);
 #ifdef CONFIG_RESOURCE_FS


### PR DESCRIPTION
All useidx and active_idx should be same in bootparam.
But sometimes partition indices of each binary are being set differently during factory process, and it causes booting failure.

This commit adds `binary_manager_sync_bootparam` to sync all binaries' partition to kernel's active partition.
(Because both BPs are corrupted, bootloader restores kernel address.)
However, in order to prevent kernel from rollback due to bootloader's restoration, `binary_manager_sync_bootparam` checks the partition which contains the latest version of kernel.

[Prerequisite]
Partition mixing in bootparam can occur only if binaries exist in both A and B partitions.

[example]
```
- Current bootparam
---------------------------------
kernel | common | app1 | resource
A      | B      | A    | B
---------------------------------

- Updated bootparam (updated by `binary_manager_sync_bootparam`)
---------------------------------
kernel | common | app1 | resource
A      | A      | A    | A
---------------------------------
```