### PR TITLE
apps/examples: Fix kernel test case for sem_setprotocol

### DIFF
--- a/apps/examples/testcase/le_tc/kernel/tc_semaphore.c
+++ b/apps/examples/testcase/le_tc/kernel/tc_semaphore.c
@@ -380,7 +380,12 @@ static void tc_semaphore_sem_setprotocol(void)
 	TC_ASSERT_EQ("sem_init", ret_chk, OK);
 
 	ret_chk = sem_setprotocol(&sem, SEM_PRIO_NONE);
+#ifdef CONFIG_PRIORITY_INHERITANCE
 	TC_ASSERT_EQ("sem_setprotocol", ret_chk, OK);
+#else
+	TC_ASSERT_EQ("sem_setprotocol", ret_chk, ERROR);
+	TC_ASSERT_EQ("sem_setprotocol", errno, ENOSYS);
+#endif
 
 	ret_chk = sem_setprotocol(&sem, SEM_PRIO_INHERIT);
 #ifdef CONFIG_PRIORITY_INHERITANCE
@@ -396,7 +401,11 @@ static void tc_semaphore_sem_setprotocol(void)
 
 	ret_chk = sem_setprotocol(&sem, SEM_PRIO_DEFAULT);
 	TC_ASSERT_EQ("sem_setprotocol", ret_chk, ERROR);
+#ifdef CONFIG_PRIORITY_INHERITANCE
 	TC_ASSERT_EQ("sem_setprotocol", errno, EINVAL);
+#else
+	TC_ASSERT_EQ("sem_setprotocol", errno, ENOSYS);
+#endif
 
 	ret_chk = sem_destroy(&sem);
 	TC_ASSERT_EQ("sem_destroy", ret_chk, OK);


### PR DESCRIPTION
Fix `tc_semaphore_sem_setprotocol` to include checks for the `CONFIG_PRIORITY_INHERITANCE` configuration.
The testcase now checks the return value of `sem_setprotocol` and the errno value based on `CONFIG_PRIORITY_INHERITANCE`.

Tested with both `CONFIG_PRIORITY_INHERITANCE=y` and `# CONFIG_PRIORITY_INHERITANCE is not set`.
```
"########## Kernel TC End [PASS : 420, FAIL : 0] ##########"
```