### PR TITLE
os/mm: Rename reserved field to memory_state in mm_allocnode_s and mm_freenode_s

### DIFF
--- a/os/include/tinyara/mm/mm.h
+++ b/os/include/tinyara/mm/mm.h
@@ -227,6 +227,12 @@ typedef void *mmaddress_t;             /* 32 bit address space */
 
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
 #define SIZEOF_MM_MALLOC_DEBUG_INFO (sizeof(mmaddress_t) + sizeof(pid_t) + sizeof(uint16_t))
+
+/* Memory state values */
+#define MM_MEMORY_STATE_UNUSED   0  /* Initial state */
+#define MM_MEMORY_STATE_USED     1  /* Memory is referenced */
+#define MM_MEMORY_STATE_LEAK     2  /* Potential memory leak */
+#define MM_MEMORY_STATE_BROKEN   3  /* Heap corruption detected */
 #else
 #define SIZEOF_MM_MALLOC_DEBUG_INFO 0
 #endif
@@ -247,7 +253,7 @@ struct mm_allocnode_s {
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
 	mmaddress_t alloc_call_addr;			/* malloc call address */
 	pid_t pid;					/* PID info */
-	uint16_t reserved;				/* Reserved for future use. */
+	uint16_t memory_state;				/* Memory state for leak detection. */
 #endif
 	mmsize_t size;					/* Size of this chunk */
 
@@ -268,7 +274,7 @@ struct mm_freenode_s {
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
 	mmaddress_t alloc_call_addr;			/* malloc call address */
 	pid_t pid;					/* PID info */
-	uint16_t reserved;				/* Reserved for future use. */
+	uint16_t memory_state;				/* Memory state for leak detection. */
 #endif
 	mmsize_t size;				/* Size of this chunk */
 	FAR struct mm_freenode_s *flink;	/* Supports a doubly linked list */
@@ -276,7 +282,7 @@ struct mm_freenode_s {
 #ifdef CONFIG_DEBUG_MM_FREEINFO
 	mmaddress_t free_call_addr;		/* free call address */
 	pid_t free_call_pid;			/* free call PID */
-	uint16_t reserved2;				/* Reserved for future use and padding for 4-byte alignment */
+	uint16_t reserved;				/* Reserved for future use and padding for 4-byte alignment */
 #endif
 };
 
@@ -301,7 +307,7 @@ struct mm_delaynode_s {
 #ifdef CONFIG_DEBUG_MM_FREEINFO
 	mmaddress_t free_call_addr;
 	pid_t free_call_pid;
-	uint16_t reserved2;
+	uint16_t reserved;
 #endif
 };
 

--- a/os/kernel/debug/mem_leak_checker.c
+++ b/os/kernel/debug/mem_leak_checker.c
@@ -37,9 +37,6 @@
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
-#define MEM_USED   0
-#define MEM_LEAK   1
-#define MEM_BROKEN 2
 #define CMN_BIN_IDX 0
 
 #define MEM_ACCESS_UNIT    0x04
@@ -112,10 +109,10 @@ static bool search_hash(unsigned long value)
 
 	while (cur != NULL) {
 		if ((unsigned long)cur->node == value) {
-			if (cur->node->reserved == MEM_USED) {
+			if (cur->node->memory_state == MM_MEMORY_STATE_USED) {
 				return false;
 			}
-			cur->node->reserved = MEM_USED;
+			cur->node->memory_state = MM_MEMORY_STATE_USED;
 			return true;
 		}
 		if (cur->next == NULL) {
@@ -198,7 +195,7 @@ static void fill_hash_table(struct mm_heap_s *heap, int *leak_cnt, int *broken_c
 
 			/* Check broken link */
 			if (node_size != MM_PREV_NODE_SIZE(node)) {
-				node->reserved = MEM_BROKEN;
+				node->memory_state = MM_MEMORY_STATE_BROKEN;
 				(*broken_cnt)++;
 				continue;
 			}
@@ -211,7 +208,7 @@ static void fill_hash_table(struct mm_heap_s *heap, int *leak_cnt, int *broken_c
 			if ((node->preceding & MM_ALLOC_BIT) != 0) {
 				g_node_info[*leak_cnt].node = node;
 				g_node_info[*leak_cnt].next = NULL;
-				node->reserved = MEM_LEAK;
+				node->memory_state = MM_MEMORY_STATE_LEAK;
 				add_hash(*leak_cnt);
 				(*leak_cnt)++;
 			}
@@ -361,7 +358,7 @@ static void print_info(struct mm_heap_s *heap, int leak_cnt, int broken_cnt)
 		{
 			for (node = heap->mm_heapstart[region]; node <  heap->mm_heapend[region]; node = (struct mm_allocnode_s *)((char *)node + node->size)) {
 				ASSERT(node->size);
-				if (node->reserved == MEM_LEAK) {
+				if (node->memory_state == MM_MEMORY_STATE_LEAK) {
 					/* alloc_call_addr can be from kernel, app or common binary.
 					* based on the text addresses printed, user needs to check the
 					* corresponding binaries accordingly
@@ -376,7 +373,7 @@ static void print_info(struct mm_heap_s *heap, int leak_cnt, int broken_cnt)
 					}
 					printf("LEAK   | %10p |  %8d  | %10p | %d\n", (void *)((char *)node + SIZEOF_MM_ALLOCNODE), node->size - SIZEOF_MM_ALLOCNODE, owner_addr, pid);
 					print_mem_hex_dump((void *)((char *)node + SIZEOF_MM_ALLOCNODE), node->size - SIZEOF_MM_ALLOCNODE);
-				} else if (node->reserved == MEM_BROKEN) {
+				} else if (node->memory_state == MM_MEMORY_STATE_BROKEN) {
 					printf("BROKEN | %p\n", node);
 				}
 			}

--- a/os/mm/mm_heap/mm_heapinfo_utils.c
+++ b/os/mm/mm_heap/mm_heapinfo_utils.c
@@ -125,7 +125,7 @@ void heapinfo_update_node(FAR struct mm_allocnode_s *node, mmaddress_t caller_re
 {
 	DEBUGASSERT(node);
 	node->alloc_call_addr = caller_retaddr;
-	node->reserved = 0;
+	node->memory_state = MM_MEMORY_STATE_UNUSED;
 	node->pid = getpid();
 }
 


### PR DESCRIPTION
Rename reserved field to memory_state in `mm_allocnode_s` and `mm_freenode_s` structures to track memory usage state.
Add definitions for memory state values to enhance memory management debugging.