### PR TITLE
os: Add userspace Makefile

### DIFF
--- a/loadable_apps/loadable.mk
+++ b/loadable_apps/loadable.mk
@@ -33,17 +33,20 @@ OBJCOPY = $(CROSSDEV)objcopy
 
 APPDEFINE = ${shell $(TOPDIR)/tools/define.sh "$(CC)" __APP_BUILD__}
 
-SRCS += $(USERSPACE).c
-
-OBJS = $(SRCS:.c=$(OBJEXT))
+APP_OBJS = $(SRCS:.c=$(OBJEXT))
+USERSPACE_OBJ = $(USERSPACE)$(OBJEXT)
+OBJS = $(APP_OBJS) $(USERSPACE_OBJ)
 
 prebuild:
-	$(call DELFILE, $(USERSPACE)$(OBJEXT))
+	$(call DELFILE, $(USERSPACE_OBJ))
 
 all: prebuild postbuild
 .PHONY: prebuild postbuild clean install distclean
 
-$(OBJS): %$(OBJEXT): %.c
+$(USERSPACE_OBJ):
+	$(Q) $(MAKE) -C $(TOPDIR)/userspace TOPDIR="$(TOPDIR)" APPDEFINE="$(APPDEFINE)" CELFFLAGS="$(CELFFLAGS)" app_obj
+
+$(APP_OBJS): %$(OBJEXT): %.c
 	@echo "CC: $<"
 	$(Q) $(CC) $(APPDEFINE) -c $(CELFFLAGS) $< -o $@
 

--- a/os/Directories.mk
+++ b/os/Directories.mk
@@ -277,3 +277,5 @@ CLEANDIRS += se
 ifeq ($(CONFIG_NDP120),y)
 CONTEXTDIRS += drivers
 endif
+
+CLEANDIRS += userspace

--- a/os/Makefile.unix
+++ b/os/Makefile.unix
@@ -456,7 +456,7 @@ ifeq ($(CONFIG_ELF),y)
 	$(Q) $(LD) -r -o $(OUTBIN_DIR)/$(CONFIG_COMMON_BINARY_NAME) -T $(TOPDIR)/userspace/userspace_apps.ld -L $(LIBRARIES_DIR) --start-group $(USERLIBS) $(LIBGCC) $(LIBSUPXX) --end-group $$(cat $(OUTBIN_DIR)/lib_symbols.txt)
 else
 	$(Q) $(TOPDIR)/tools/mkldscript.py
-	$(Q) $(CC) -c $(CFLAGS) -D__COMMON_BINARY__ $(TOPDIR)/userspace/up_userspace.c -o  $(TOPDIR)/userspace/up_userspace_common.o
+	$(Q) $(MAKE) -C userspace CFLAGS="$(CFLAGS)" TOPDIR="$(TOPDIR)" common_obj
 ifneq ($(CONFIG_XIP_ELF_WARCHIVE), y)
 	$(Q) $(MAKE) -C $(LOADABLE_APPDIR) TOPDIR="$(TOPDIR)" LOADABLEDIR="${LOADABLE_APPDIR}" LIBRARIES_DIR="$(LIBRARIES_DIR)" USERLIBS="$(USERLIBS)" undefsym KERNEL=n
 	$(Q) $(LD) -o $(OUTBIN_DIR)/$(CONFIG_COMMON_BINARY_NAME) -T $(OUTBIN_DIR)/common_0.ld -T $(TOPDIR)/../build/configs/$(CONFIG_ARCH_BOARD)/scripts/xipelf/userspace_all.ld $(TOPDIR)/userspace/up_userspace_common.o -L $(LIBRARIES_DIR) --start-group $(USERLIBS) $(LIBGCC) $(LIBSUPXX) --end-group $$(cat $(OUTBIN_DIR)/lib_symbols.txt) -Map $(OUTBIN_DIR)/$(CONFIG_COMMON_BINARY_NAME).map

--- a/os/userspace/Makefile
+++ b/os/userspace/Makefile
@@ -1,0 +1,41 @@
+###########################################################################
+#
+# Copyright 2026 Samsung Electronics All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+#
+###########################################################################
+
+-include $(TOPDIR)/Make.defs
+
+APP_OBJ = up_userspace$(OBJEXT)
+COMMON_OBJ = up_userspace_common$(OBJEXT)
+
+.PHONY: all app_obj common_obj clean distclean
+
+app_obj: $(APP_OBJ)
+
+common_obj: $(COMMON_OBJ)
+
+$(APP_OBJ): up_userspace.c
+	$(Q) $(CC) $(APPDEFINE) -c $(CELFFLAGS) $< -o $@
+
+$(COMMON_OBJ): up_userspace.c
+	$(Q) $(CC) -c $(CFLAGS) -D__COMMON_BINARY__ $< -o $@
+
+clean:
+	$(call DELFILE, $(APP_OBJ))
+	$(call DELFILE, $(COMMON_OBJ))
+	$(call CLEAN)
+
+distclean: clean


### PR DESCRIPTION
Add a new userspace Makefile to build userspace object file and clean it.
For app binary we need up_userspace.o, and for common binary we need up_userspace_common.o.
So split build targets into app_obj and common_obj to support each binary.

When we build loadable apps, userspace.o is built but not cleaned. This can make linking error between other boards.
This patch fix this issue by adding userspace Makefile.

[Linking Error]
```
make[1]: Leaving directory '/root/tizenrt/os/binfmt'
make[1]: Entering directory '/root/tizenrt/loadable_apps'
make[2]: Entering directory '/root/tizenrt/loadable_apps/loadable_sample/wifiapp'
CC: wifiapp.c
arm-none-eabi-ld: error: /root/tizenrt/os/../build/output/bin/app1.relelf uses VFP register arguments, /root/tizenrt/os/userspace/up_userspace.o does not
arm-none-eabi-ld: error: /root/tizenrt/os/userspace/up_userspace.o: conflicting CPU architectures 14/17
arm-none-eabi-ld: failed to merge target specific data of file /root/tizenrt/os/userspace/up_userspace.o
/root/tizenrt/os/../loadable_apps/loadable.mk:66: recipe for target 'undefsym' failed
make[2]: Leaving directory '/root/tizenrt/loadable_apps/loadable_sample/wifiapp'
make[2]: *** [undefsym] Error 1
Makefile:71: recipe for target 'loadable_sample/wifiapp_undefsym' failed
make[1]: Leaving directory '/root/tizenrt/loadable_apps'
make[1]: *** [loadable_sample/wifiapp_undefsym] Error 2
make: *** [pass1] Error 2
Makefile.unix:458: recipe for target 'pass1' failed
```