### PR TITLE
apps/examples/rtc, os/arch/arm/src/armino, os/include/tinyara: Add RTC millisecond test functionality for BK7239N

### DIFF
--- a/os/arch/arm/src/armino/armino_rtc.c
+++ b/os/arch/arm/src/armino/armino_rtc.c
@@ -236,4 +236,24 @@ int up_rtc_initialize(void)
 	return OK;
 }
 
+/************************************************************************************
+ * Name: aon_rtc_get_ms
+ *
+ * Description:
+ *   Get the current RTC time in milliseconds (64-bit). This is an adapter
+ *   function that wraps the bk_aon_rtc_get_ms() function.
+ *
+ * Input Parameters:
+ *   None
+ *
+ * Returned Value:
+ *   The current time in milliseconds (64-bit)
+ *
+ ************************************************************************************/
+
+uint64_t aon_rtc_get_ms(void)
+{
+	return bk_aon_rtc_get_ms();
+}
+
 #endif							/* CONFIG_RTC */

--- a/os/arch/arm/src/armino/armino_rtc.h
+++ b/os/arch/arm/src/armino/armino_rtc.h
@@ -101,6 +101,22 @@ struct rtc_lowerhalf_s;
 FAR struct rtc_lowerhalf_s *armino_rtc_lowerhalf(void);
 #endif
 
+/****************************************************************************
+ * Name: aon_rtc_get_ms
+ *
+ * Description:
+ *   Get the current RTC time in milliseconds (64-bit).
+ *
+ * Input Parameters:
+ *   None
+ *
+ * Returned Value:
+ *   The current time in milliseconds (64-bit)
+ *
+ ****************************************************************************/
+
+uint64_t aon_rtc_get_ms(void);
+
 #undef EXTERN
 #if defined(__cplusplus)
 }

--- a/os/include/tinyara/rtc.h
+++ b/os/include/tinyara/rtc.h
@@ -195,6 +195,14 @@
 
 #define RTC_USER_IOCBASE   0x0006
 
+/* RTC_GET_MS returns the current RTC time in milliseconds (64-bit).
+ *
+ * Argument: A writeable reference to a uint64_t to receive the RTC's
+ *           time in milliseconds.
+ */
+
+#define RTC_GET_MS         _RTCIOC(RTC_USER_IOCBASE)
+
 /****************************************************************************
  * Public Types
  ****************************************************************************/


### PR DESCRIPTION
This commit adds a new "get_ms" command to the RTC example application for testing the aon_rtc_get_ms interface on BK7239N chips. It implements the RTC_GET_MS ioctl command in the RTC driver and provides a test function that can perform multiple readings with configurable delays.