### PR TITLE
framework/csimanager: fix/improve error handling and resource management

### DIFF
--- a/framework/include/csimanager/csifw_api.h
+++ b/framework/include/csimanager/csifw_api.h
@@ -26,22 +26,23 @@ extern "C" {
 #include <tinyara/wifi_csi/wifi_csi_struct.h>
 
 typedef enum _CSIFW_RES {
-	CSIFW_ERROR_MAX_NUM_SERVICE_REGISTERED = -11,		/* ERROR: MAX number of Services is alreay Registered */
-	CSIFW_ERROR_NOT_INITIALIZED = -10,			/* ERROR: Not Initialized */
-	CSIFW_ERROR_INVALID_SERVICE_STATE = -9,			/* ERROR: Invalid Service State */
-	CSIFW_ERROR_ALREADY_INIT_WITH_DIFFERENT_CONFIG = -8,	/* ERROR: Service already initialized with different CSI_Configuration  */
-	CSIFW_ERROR_SERVICE_NOT_REGISTERED = -7,		/* ERROR: Service not registered. Cannot start/stop/deinit */
-	CSIFW_ERROR_WIFI_DIS_CONNECTED = -6,			/* ERROR: WIFI WIFI_DISCONNECTED */
-	CSIFW_INVALID_RAWDATA = -5,				/* Invalid Raw Data */
-	CSIFW_INVALID_ARG = -4,					/* Invalid argument */
-	CSIFW_NOT_ENOUGH_SPACE = -3,				/* read/write/other buffer has empty space less than required size */
-	CSIFW_NO_MEM = -2,					/* Memory allocation (malloc/calloc) failed */
-	CSIFW_ERROR = -1,					/* ERROR: All other types of error not specified by any following enum */
-	CSIFW_OK = 0,						/* OK: Without any error  */
-	CSIFW_OK_WIFI_CONNECTED = 1,				/* OK: Without any error  */
-	CSIFW_OK_ALREADY_STOPPED = 2,				/* CSIFW already stopped by running service, but no error */
-	CSIFW_OK_ALREADY_STARTED = 3,				/* CSIFW already started by running service, but no error */
-	CSIFW_OK_WIFI_NOT_CONNECTED = 4				/* CSIFW already started but WIFI not connected */
+    CSIFW_INTERNAL_ERROR = -12,                          /* ERROR: CSI Internal Error due to unforseen events */
+    CSIFW_ERROR_MAX_NUM_SERVICE_REGISTERED = -11,        /* ERROR: MAX number of Services is alreay Registered */
+    CSIFW_ERROR_NOT_INITIALIZED = -10,                   /* ERROR: Not Initialized */
+    CSIFW_ERROR_INVALID_SERVICE_STATE = -9,              /* ERROR: Invalid Service State */
+    CSIFW_ERROR_ALREADY_INIT_WITH_DIFFERENT_CONFIG = -8, /* ERROR: Service already initialized with different CSI_Configuration*/
+    CSIFW_ERROR_SERVICE_NOT_REGISTERED = -7,             /* ERROR: Service not registered. Cannot start/stop/deinit */
+    CSIFW_ERROR_WIFI_DIS_CONNECTED = -6,                 /* ERROR: WIFI WIFI_DISCONNECTED */
+    CSIFW_ERROR_DATA_NOT_AVAILABLE = -5,                 /* ERROR: CSI Data Not Available */
+    CSIFW_INVALID_ARG = -4,                              /* Invalid argument */
+    CSIFW_NOT_ENOUGH_SPACE = -3,                         /* read/write/other buffer has empty space less than required size */
+    CSIFW_NO_MEM = -2,                                   /* Memory allocation (malloc/calloc) failed */
+    CSIFW_ERROR = -1,                                    /* ERROR: All other types of error not specified by any following enum */
+    CSIFW_OK = 0,                                        /* OK: Without any error  */
+    CSIFW_OK_WIFI_CONNECTED = 1,                         /* OK: Without any error  */
+    CSIFW_OK_ALREADY_STOPPED = 2,                        /* CSIFW already stopped by running service, but no error */
+    CSIFW_OK_ALREADY_STARTED = 3,                        /* CSIFW already started by running service, but no error */
+    CSIFW_OK_WIFI_NOT_CONNECTED = 4                      /* CSIFW already started but WIFI not connected */
 } CSIFW_RES;
 
 typedef int csifw_service_handle;

--- a/framework/src/csimanager/CSIFrameworkMain.c
+++ b/framework/src/csimanager/CSIFrameworkMain.c
@@ -42,6 +42,7 @@ const static int CSIFW_TASK_PRIORITY = 100;
 const static int CSIFW_TASK_PERMISSION = TM_APP_PERMISSION_ALL;
 
 int csifw_task_Main(int argc, char *argv[]);
+static void task_manager_stop_and_unregister(int m_task_handle);
 
 int start_csi_framework(csifw_context_t *p_ctx)
 {
@@ -84,8 +85,14 @@ int start_csi_framework(csifw_context_t *p_ctx)
 	int result = task_manager_start(handle, TM_RESPONSE_WAIT_INF);
 	if (result < 0) {
 		CSIFW_LOGE("Failed to start %s (handle=%d). Return: %d. Cleaning up...", CSIFW_TASK_NAME, handle, result);
-		task_manager_unregister(handle, TM_RESPONSE_WAIT_INF);
-		CSIFW_LOGD("Unregistered task %s (handle=%d) after failed start", CSIFW_TASK_NAME, handle);
+		CSIFW_LOGD("Unregistering task %s (handle=%d)", CSIFW_TASK_NAME, handle);
+		int tm_unregister_return = task_manager_unregister(handle, TM_RESPONSE_WAIT_INF);
+		if (tm_unregister_return == OK) {
+			CSIFW_LOGD("Unregistered successfully csifw task to the task manager! Return: %d", tm_unregister_return);
+		} else {
+			CSIFW_LOGE("Failed to unregister csifw task to the task manager! Return: %d", tm_unregister_return);
+			//To-Do: Error handling logic to be addressed later.
+		}
 		sem_destroy(&p_ctx->csifw_task_sema);
 		CSIFW_LOGD("Destroyed semaphore for %s after failed start", CSIFW_TASK_NAME);
 	} else {
@@ -94,7 +101,7 @@ int start_csi_framework(csifw_context_t *p_ctx)
 
 		if (!p_ctx->task_run_success) {
 			CSIFW_LOGE("CSI framework task initialization failed");
-			task_manager_unregister(handle, TM_RESPONSE_WAIT_INF);
+			task_manager_stop_and_unregister(p_ctx->task_handle);
 			sem_destroy(&p_ctx->csifw_task_sema);
 			return -1;
 		}
@@ -113,8 +120,7 @@ int stop_csi_framework(csifw_context_t *p_ctx)
 	p_ctx->task_run_state = STOPPED;			//stop the main loop of the task
 	CSIFW_LOGD("Waiting for csifw_task to complete...");
 	sem_wait(&p_ctx->csifw_task_sema);
-	CSIFW_LOGD("Unregistering task %s (handle=%d)", CSIFW_TASK_NAME, p_ctx->task_handle);
-	task_manager_unregister(p_ctx->task_handle, TM_RESPONSE_WAIT_INF);
+	task_manager_stop_and_unregister(p_ctx->task_handle);
 	CSIFW_LOGD("Destroying semaphore for %s", CSIFW_TASK_NAME);
 	sem_destroy(&p_ctx->csifw_task_sema);
 	return 0;
@@ -136,7 +142,6 @@ int csifw_task_Main(int argc, char *argv[])
 		sem_post(&p_csifw_ctx->csifw_task_sema);
 		return -1;
 	}
-
 	if (csi_ping_generator_initialize() != CSIFW_OK) {
 		CSIFW_LOGE("CSI ping generator initialize failed");
 		csi_packet_receiver_stop_collect();
@@ -173,9 +178,32 @@ int csifw_task_Main(int argc, char *argv[])
 		CSIFW_LOGE("CSI packet receiver stop failed");
 	}
 	if (csi_packet_receiver_cleanup() == CSIFW_ERROR){
-		CSIFW_LOGD("CSI packet receiver cleanup failed");
+		CSIFW_LOGE("CSI packet receiver cleanup failed");
 	}
 	//to unlock stop_csi_framework()
 	sem_post(&p_csifw_ctx->csifw_task_sema);
 	return 0;
 }
+
+static void task_manager_stop_and_unregister(int m_task_handle)
+{
+	CSIFW_LOGD("Stopping task %s (Task_Handle=%d)", CSIFW_TASK_NAME, m_task_handle);
+	int tm_stop_return = task_manager_stop(m_task_handle, TM_RESPONSE_WAIT_INF);
+	if (tm_stop_return == OK) {
+		CSIFW_LOGD("Stopped successfully (Task_Handle=%d). Return: %d.", m_task_handle, tm_stop_return);
+	} else if (tm_stop_return == TM_ALREADY_STOPPED_APP) {
+		CSIFW_LOGD("Task already stopped (Task_Handle=%d)", m_task_handle);
+	} else {
+		CSIFW_LOGE("Failed to stop (Task_Handle=%d). Return: %d.", m_task_handle, tm_stop_return);
+	}
+
+	CSIFW_LOGD("Unregistering task %s (Task_Handle=%d)", CSIFW_TASK_NAME, m_task_handle);
+	int tm_unregister_return = task_manager_unregister(m_task_handle, TM_RESPONSE_WAIT_INF);
+	if (tm_unregister_return == OK) {
+		CSIFW_LOGD("Unregistered successfully csifw task to the task manager! Return: %d", tm_unregister_return);
+	} else {
+		CSIFW_LOGE("Failed to unregister csifw task to the task manager! Return: %d", tm_unregister_return);
+		//To-Do: Error handling logic to be addressed later.
+	}
+}
+

--- a/framework/src/csimanager/CSIManager.c
+++ b/framework/src/csimanager/CSIManager.c
@@ -53,7 +53,7 @@ static void csifw_update_state_and_log(CSI_FRAMEWORK_STATE new_state)
     return;
   }
   const int max_state = sizeof(csi_framework_state_strings) / sizeof(csi_framework_state_strings[0]);
-  if (new_state < CSI_FRAMEWORK_STATE_UNINITIALIZED || new_state >= max_state) {
+  if (new_state < CSI_FRAMEWORK_STATE_UNINITIALIZED || new_state >= max_state - 1) {
     CSIFW_LOGE("Invalid state value: %d", new_state);
     return;
   }
@@ -111,13 +111,24 @@ static void CSIRawDataListener(CSIFW_RES res, int raw_csi_buff_len, unsigned cha
   }
 
   if (g_pcsifw_context->parsed_data_cb_count > 0 && g_pcsifw_context->parsed_data_cb_started_count > 0) {
-    getParsedData(raw_csi_buff, raw_csi_buff_len, 
-					g_pcsifw_context->csi_config,
-					g_pcsifw_context->parsed_buffptr,
-					&g_pcsifw_context->ParsedDataBufferLen);
+        #if defined(CONFIG_WIFI_CSI_RTL8730E)
+          getParsedData(raw_csi_buff,
+                        raw_csi_buff_len,
+                        g_pcsifw_context->csi_config,
+                        g_pcsifw_context->parsed_buffptr,
+                        &g_pcsifw_context->ParsedDataBufferLen);
+        #elif defined(CONFIG_BK_WIFI_CSI_ADAPTER)
+          CSIFW_LOGE("Parsing is not enabled for BEKEN");
+          return;
+        #else
+          CSIFW_LOGE("Unknown CSI board configuration");
+          return;
+        #endif
   }
 
-  // we use this service state but if its called parelly this is will stuck
+  // CSIRawDataListener callback can be invoked from a background thread when CSI data arrives. 
+  // Simultaneously, application threads may call `csifw_start()/csifw_stop()` to modify service states. 
+  // Without this mutex, race conditions will occur
   CSIFW_MUTEX_LOCK(&g_pcsifw_context->data_reciever_mutex);
   for (int i = 0; i < CSIFW_MAX_NUM_APPS; i++) {
     // send raw
@@ -401,6 +412,10 @@ CSIFW_RES csifw_set_interval(csifw_service_handle hnd, unsigned int interval)
     ping_generator_change_interval(g_pcsifw_context->csi_interval);
   } else {
     res = csi_packet_receiver_change_interval();
+    if (res != CSIFW_OK) {
+      CSIFW_LOGE("Interval update Failed %d", res);
+      goto on_error;
+    }
   }
   CSIFW_LOGD("Interval updated : %u", g_pcsifw_context->csi_interval);
 
@@ -482,6 +497,10 @@ CSIFW_RES csifw_get_ap_mac_addr(csifw_service_handle hnd, csifw_mac_info *p_mac_
   }
 
   res = csi_packet_receiver_get_mac_addr(p_mac_info);
+  if (res != CSIFW_OK) {
+    CSIFW_LOGE("Failed to get AP MAC %d", res);
+    goto on_error;
+  }
 
 on_error:
   CSIFW_MUTEX_UNLOCK(&g_api_mutex);
@@ -563,7 +582,7 @@ csifw_service_info_t *add_service(csifw_context_t *p_csifw_ctx, service_callback
   }
 
   if (get_service_idx(cid) != -1) {
-    if (!p_csifw_ctx->parsed_buffptr) {
+    if (p_csifw_ctx->parsed_buffptr) {
       free(p_csifw_ctx->parsed_buffptr);
       p_csifw_ctx->parsed_buffptr = NULL;
     }
@@ -702,3 +721,4 @@ static int all_services_stopped(void)
   CSIFW_LOGI("All services are stopped\n");
   return 1;
 }
+

--- a/framework/src/csimanager/CSIPacketReceiver.c
+++ b/framework/src/csimanager/CSIPacketReceiver.c
@@ -24,6 +24,7 @@
 #include "CSIPacketReceiver.h"
 #include <tinyara/wifi_csi/wifi_csi.h>
 
+#define MAX_CONSECUTIVE_FAILURES 50
 #define RCVR_TH_NAME "csifw_data_receiver_th"
 
 static inline CSIFW_RES open_driver(int *fd) {
@@ -38,6 +39,13 @@ static inline CSIFW_RES open_driver(int *fd) {
 
 static inline void close_driver(int fd) {
   close(fd);
+}
+
+static inline unsigned long long get_monotonic_time_us(void)
+{
+	struct timespec ts;
+	clock_gettime(CLOCK_MONOTONIC, &ts);
+	return (unsigned long long)ts.tv_sec * 1000000ULL + ts.tv_nsec / 1000ULL;
 }
 
 CSIFW_RES csi_packet_receiver_set_csi_config(csi_config_action_t config_action);
@@ -67,33 +75,48 @@ static void *dataReceiverThread(void *vargp)
 	int len;
 	int prio;
 	size_t size;
-	int csi_data_len = 0;
+	int timeout_count = 0;
 	struct wifi_csi_msg_s msg;
+	int consecutive_failures = 0;
+	struct timespec st_time = {0,};
 	int fd = p_csifw_ctx->data_receiver_fd;
 	mqd_t mq_handle = p_csifw_ctx->mq_handle;
 	unsigned char *get_data_buffptr = p_csifw_ctx->get_data_buffptr;
 
 	while (!p_csifw_ctx->data_receiver_thread_stop) {
-		size = mq_receive(mq_handle, (char *)&msg, sizeof(msg), &prio);
-		if (size != sizeof(msg)) {
-			CSIFW_LOGE("Interrupted while waiting for deque message from kernel %zu, errno: %d (%s)", size, get_errno(), strerror(get_errno()));
-		} else {
+		CSIFW_LOGI("Reading from MQ %llu", get_monotonic_time_us());
+		clock_gettime(CLOCK_REALTIME, &st_time);
+		st_time.tv_sec += 1;
+		size = mq_timedreceive(mq_handle, (char *)&msg, sizeof(msg), &prio, &st_time);
+		if (size >= 0) {
+			CSIFW_LOGD("Message received - msgId: %d, data_len: %d, size: %zu: %d", msg.msgId, msg.data_len, size);
 			switch (msg.msgId) {
 			case CSI_MSG_DATA_READY_CB:
-				if (msg.data_len == 0 || msg.data_len > CSIFW_MAX_RAW_BUFF_LEN) {
-					CSIFW_LOGE("Skipping packet: invalid data length: %d", msg.data_len);
-					continue;
-				}
-				csi_data_len = msg.data_len;
-				len = readCSIData(fd, get_data_buffptr, csi_data_len);
+				len = readCSIData(fd, get_data_buffptr, CSIFW_MAX_RAW_BUFF_LEN);
+				CSIFW_LOGI("CSI Data read complete %llu", get_monotonic_time_us());
 				if (len < 0) {
+					consecutive_failures++;
 					CSIFW_LOGE("Skipping packet: error: %d", len);
+					if (consecutive_failures >= MAX_CONSECUTIVE_FAILURES) {
+						CSIFW_LOGE("CRITICAL: %d consecutive readCSIData failures detected!", consecutive_failures);
+						p_csifw_ctx->CSI_DataCallback(CSIFW_ERROR_DATA_NOT_AVAILABLE, 0, NULL, 0);
+						break;
+					}
 					continue;
 				}
-				if (len != csi_data_len - CSIFW_CSI_HEADER_LEN) {
-					csi_data_len = len + CSIFW_CSI_HEADER_LEN;
+				if ((consecutive_failures > 0) || (timeout_count > 0)) {
+					consecutive_failures = 0;
+					timeout_count = 0;
 				}
-				p_csifw_ctx->CSI_DataCallback(CSIFW_OK, csi_data_len, get_data_buffptr, len);
+				#if defined(CONFIG_WIFI_CSI_RTL8730E)
+					/* RTL8730E driver returns length without the CSI header*/
+					p_csifw_ctx->CSI_DataCallback(CSIFW_OK, len + CSIFW_RTK_CSI_HEADER_LEN, get_data_buffptr, len);
+				#elif defined(CONFIG_BK_WIFI_CSI_ADAPTER)
+					/* Beken driver already includes the CSI header in the length*/
+					p_csifw_ctx->CSI_DataCallback(CSIFW_OK, len, get_data_buffptr, len);
+				#else
+					CSIFW_LOGE("Unknown CSI board configuration");
+				#endif
 				break;
 
 			case CSI_MSG_ERROR:
@@ -103,6 +126,23 @@ static void *dataReceiverThread(void *vargp)
 			default:
 				CSIFW_LOGE("Received unknown message ID: %d", msg.msgId);
 				break;
+			}
+		} else if (size == -1) {
+			if (errno == ETIMEDOUT) {
+				timeout_count++;
+				if (timeout_count >= CONFIG_CSI_DATA_TIMEOUT_SEC) {
+					 CSIFW_LOGE("CRITICAL: No CSI data for %d seconds", timeout_count);
+					timeout_count = 0;
+					p_csifw_ctx->CSI_DataCallback(CSIFW_ERROR_DATA_NOT_AVAILABLE, 0, NULL, 0);
+				}
+			} else {
+				CSIFW_LOGE("Message received size error - msgId: %d, data_len: %d, size: %zu, errno: %d (%s)", msg.msgId, msg.data_len, size, errno, strerror(errno));
+				consecutive_failures++;
+				if (consecutive_failures >= MAX_CONSECUTIVE_FAILURES) {
+					CSIFW_LOGE("CRITICAL: %d consecutive failures detected", consecutive_failures);
+					consecutive_failures = 0;
+					p_csifw_ctx->CSI_DataCallback(CSIFW_INTERNAL_ERROR, 0, NULL, 0);
+				}
 			}
 		}
 	}
@@ -207,18 +247,9 @@ CSIFW_RES csi_packet_receiver_start_collect(void)
 		CSIFW_LOGE("Invalid context pointer (NULL)");
 		return CSIFW_ERROR_NOT_INITIALIZED;
 	}
-	// allocate buffer for receiveing data from driver
-	if (!p_csifw_ctx->get_data_buffptr) {
-		p_csifw_ctx->get_data_buffptr = (unsigned char *)malloc(CSIFW_MAX_RAW_BUFF_LEN);
-		if (!p_csifw_ctx->get_data_buffptr) {
-			CSIFW_LOGE("Buffer allocation Fail.");
-			return CSIFW_ERROR;
-		}
-		CSIFW_LOGD("Get data buffer allocation done, size: %d", CSIFW_MAX_RAW_BUFF_LEN);
-	}
+
 	if (p_csifw_ctx->disable_required) {
 		CSIFW_LOGD("WiFi reconnected: Disabling CSI config");
-		csi_packet_receiver_set_csi_config(CSI_CONFIG_ENABLE);
 		csi_packet_receiver_set_csi_config(CSI_CONFIG_DISABLE);
 		p_csifw_ctx->disable_required = false;
 	}
@@ -228,6 +259,17 @@ CSIFW_RES csi_packet_receiver_start_collect(void)
 		return res;
 	}
 	p_csifw_ctx->data_receiver_thread_stop = false;
+
+	// allocate buffer for receiveing data from driver
+	if (!p_csifw_ctx->get_data_buffptr) {
+		p_csifw_ctx->get_data_buffptr = (unsigned char *)malloc(CSIFW_MAX_RAW_BUFF_LEN);
+		if (!p_csifw_ctx->get_data_buffptr) {
+			csi_packet_receiver_set_csi_config(CSI_CONFIG_DISABLE);
+			CSIFW_LOGE("Buffer allocation Fail.");
+			return CSIFW_ERROR;
+		}
+		CSIFW_LOGD("CSI data buffer allocated successfully, size: %d bytes", CSIFW_MAX_RAW_BUFF_LEN);
+	}
 
 	pthread_attr_t recv_th_attr;
 	if (pthread_attr_init(&recv_th_attr) != 0) {
@@ -245,11 +287,16 @@ CSIFW_RES csi_packet_receiver_start_collect(void)
 		csi_packet_receiver_set_csi_config(CSI_CONFIG_DISABLE);
 		free(p_csifw_ctx->get_data_buffptr);
 		p_csifw_ctx->get_data_buffptr = NULL;
+		pthread_attr_destroy(&recv_th_attr);
 		return CSIFW_ERROR;
 	}
 	if (pthread_setname_np(p_csifw_ctx->csi_data_receiver_th, RCVR_TH_NAME) != 0) {
 		CSIFW_LOGE("Failed to set receiver thread name - errno: %d (%s)", get_errno(), strerror(get_errno()));
 	}
+	if (pthread_attr_destroy(&recv_th_attr) != 0) {
+		CSIFW_LOGE("Failed to destroy thread attr - errno: %d (%s)", get_errno(), strerror(get_errno()));
+	}
+
 	CSIFW_LOGD("CSI Data_Receive_Thread created (thread ID: %lu)", (unsigned long)p_csifw_ctx->csi_data_receiver_th);
 	return res;
 }
@@ -334,7 +381,17 @@ CSIFW_RES csi_packet_receiver_stop_collect(void)
 		CSIFW_LOGD("Sending dummy message to close blocking mq");
 		struct wifi_csi_msg_s msg;
 		msg.msgId = CSI_MSG_ERROR;
-		mq_send(p_csifw_ctx->mq_handle, (FAR const char *)&msg, sizeof(msg), MQ_PRIO_MAX);
+		struct timespec timeout;
+		clock_gettime(CLOCK_REALTIME, &timeout);
+		timeout.tv_sec += 1;
+		int mq_send_ret = mq_timedsend(p_csifw_ctx->mq_handle, (FAR const char *)&msg, sizeof(msg), MQ_PRIO_MAX, &timeout);
+		if (mq_send_ret != 0) {
+			if (errno == ETIMEDOUT) {
+				CSIFW_LOGE("Timeout sending dummy message - message queue may be full");
+			} else {
+        		CSIFW_LOGE("Failed to send dummy message - errno: %d (%s)", errno, strerror(errno));
+			}
+		} 
 	} else {
 		CSIFW_LOGE("Failed to close blocking mq as MQ_Discriptor is Invalid");
 	}
@@ -369,3 +426,4 @@ CSIFW_RES csi_packet_receiver_deinit(void)
 	CSIFW_LOGD("CSI packet receiver successfully deinitialized (callback: %p)", p_csifw_ctx->CSI_DataCallback);
 	return CSIFW_OK;
 }
+

--- a/framework/src/csimanager/Kconfig
+++ b/framework/src/csimanager/Kconfig
@@ -13,6 +13,12 @@ config CSIFW
 
 if CSIFW
 
+config CSI_DATA_TIMEOUT_SEC
+	int "CSI DATA TIMEOUT"
+	default 15
+	---help---
+		CSI DATA TIMEOUT
+
 menu "CSIFW Debug Logs"
 
 config CSIFW_LOGS

--- a/framework/src/csimanager/inc/CSIManager.h
+++ b/framework/src/csimanager/inc/CSIManager.h
@@ -30,9 +30,14 @@
 
 #define ERROR -1  // for ERROR
 #define CSIFW_MAX_NUM_APPS 3 // Max number of Services
-#define CSIFW_CSI_HEADER_LEN 43 // CSI packet header size
 #define CSIFW_MIN_INTERVAL_MS 30  // Minimum supported CSI interval in milliseconds
 #define CSIFW_MAX_RAW_BUFF_LEN 1024 // CSI data buffer xax size
+#define CSIFW_RTK_CSI_HEADER_LEN 43 // CSI packet header size
+#define CSIFW_BEKEN_CSI_HEADER_LEN 28 // CSI packet header size
+
+#ifndef CONFIG_CSI_DATA_TIMEOUT_SEC /* In case not defined in defconfig, force it to default value*/ 
+#define CONFIG_CSI_DATA_TIMEOUT_SEC 15 
+#endif
 
 typedef unsigned long long u64;  // for u64
 typedef void (*CSIDataListener)(CSIFW_RES res, int csi_buff_len, unsigned char *csi_buff, int csi_data_len);

--- a/os/drivers/wifi_csi/wifi_csi.c
+++ b/os/drivers/wifi_csi/wifi_csi.c
@@ -535,8 +535,9 @@ int wifi_csi_register(FAR const char *name, FAR struct wifi_csi_lowerhalf_s *dev
 	char* path;
 #ifndef CONFIG_WIFICSI_CUSTOM_DEV_PATH
 	path = "/dev/wificsi";
-#endif
+#else
 	path = CONFIG_WIFICSI_CUSTOM_DEV_PATH;
+#endif
 
 	/* Allocate the upper-half data structure */
 	upper = (FAR struct wifi_csi_upperhalf_s *)kmm_zalloc(sizeof(struct wifi_csi_upperhalf_s));


### PR DESCRIPTION
This commit enhances the Channel State Information (CSI) framework with improved error handling, resource management, and robustness:

- Renamed CSIFW_INVALID_RAWDATA to CSIFW_ERROR_DATA_NOT_AVAILABLE for clearer error reporting
- Implemented timeout handling in message queue operations to prevent indefinite blocking
- Enhanced error reporting with more descriptive messages and callback notifications
- Added consecutive failure detection mechanism to prevent system lockups
- Fixed preprocessor directive logic for custom device path configuration
- Fixed logic error in add_service function for proper buffer management
- Improved resource management with proper pthread attribute cleanup
- Added configurable timeout option for CSI data collection
- Removed invalid csi config enable after wifi reconnect
- Added task_manager stop and unregister