### PR TITLE
os/arch/arm/src, os/include/tinyara/reboot_reason.h: Add specific reboot reasons and improve error tracking

### DIFF
--- a/os/arch/arm/src/armino/armino_allocateheap.c
+++ b/os/arch/arm/src/armino/armino_allocateheap.c
@@ -70,6 +70,7 @@
 #include <tinyara/mm/mm.h>
 #include <tinyara/kmalloc.h>
 #include <tinyara/mm/heap_regioninfo.h>
+#include <tinyara/reboot_reason.h>
 
 #if defined(CONFIG_BUILD_PROTECTED) && defined(CONFIG_MM_KERNEL_HEAP)
 #include <string.h>
@@ -162,6 +163,9 @@ void up_add_kregion(void)
 			lldbg("ERROR: Failed to allocate kheap for ram region configuration\n");
 			lldbg("Region start = 0x%x region end = 0x%x\n_sdata = 0x%x end of stack = 0x%x\n",
 					kregionx_start[region_cnt], kregionx_end, &_sdata, stack_end);
+#ifdef CONFIG_SYSTEM_REBOOT_REASON
+			up_reboot_reason_write(REBOOT_SYSTEM_MEMORYALLOCFAIL);
+#endif
 			PANIC();
 		} else if (stack_end >= (void *)kregionx_start[region_cnt] && stack_end < (void *)kregionx_end) {
 			heap_start = stack_end;

--- a/os/arch/arm/src/armino/armino_watchdog_lowerhalf.c
+++ b/os/arch/arm/src/armino/armino_watchdog_lowerhalf.c
@@ -59,6 +59,7 @@
 #include <tinyara/watchdog.h>
 #include <tinyara/irq.h>
 #include <tinyara/arch.h>
+#include <tinyara/reboot_reason.h>
 #include "wdt.h"
 #include "hal_aon_rtc_types.h"
 #include "aon_rtc.h"
@@ -176,6 +177,9 @@ static int armino_nmi_interrupt(int irq, void *context, FAR void *arg)
 		}
 		aon_pmu_drv_wdt_change_not_rosc_clk();
 		aon_pmu_drv_wdt_rst_dev_enable();
+#ifdef CONFIG_SYSTEM_REBOOT_REASON
+		up_reboot_reason_write(REBOOT_SYSTEM_WATCHDOG);
+#endif
         PANIC();
 		while(1);
 	}

--- a/os/arch/arm/src/armv7-a/arm_doirq.c
+++ b/os/arch/arm/src/armv7-a/arm_doirq.c
@@ -75,6 +75,9 @@ uint32_t *arm_doirq(int irq, uint32_t *regs)
 
 	board_autoled_on(LED_INIRQ);
 #ifdef CONFIG_SUPPRESS_INTERRUPTS
+#ifdef CONFIG_SYSTEM_REBOOT_REASON
+	up_reboot_reason_write(REBOOT_SYSTEM_INTERRUPT_FAILURE);
+#endif
 	PANIC();
 #else
 	/* Nested interrupts are not supported */

--- a/os/arch/arm/src/armv7-a/arm_pthread_start.c
+++ b/os/arch/arm/src/armv7-a/arm_pthread_start.c
@@ -42,6 +42,7 @@
 #include <tinyara/config.h>
 #include <pthread.h>
 #include <tinyara/arch.h>
+#include <tinyara/reboot_reason.h>
 
 #include <assert.h>
 
@@ -86,6 +87,9 @@ void up_pthread_start(pthread_startroutine_t entrypt, pthread_addr_t arg)
 
 	sys_call2(SYS_pthread_start, (uintptr_t) entrypt, (uintptr_t) arg);
 
+#ifdef CONFIG_SYSTEM_REBOOT_REASON
+	up_reboot_reason_write(REBOOT_SYSTEM_PTHREAD_START_FAILURE);
+#endif
 	PANIC();
 }
 

--- a/os/arch/arm/src/armv7-a/arm_reprioritizertr.c
+++ b/os/arch/arm/src/armv7-a/arm_reprioritizertr.c
@@ -48,6 +48,7 @@
 #include <debug.h>
 #include <tinyara/arch.h>
 #include <tinyara/sched.h>
+#include <tinyara/reboot_reason.h>
 
 #include "sched/sched.h"
 #include "group/group.h"
@@ -91,6 +92,9 @@ void up_reprioritize_rtr(struct tcb_s *tcb, uint8_t priority)
 		|| priority > SCHED_PRIORITY_MAX
 #endif
 	   ) {
+#ifdef CONFIG_SYSTEM_REBOOT_REASON
+		up_reboot_reason_write(REBOOT_SYSTEM_SCHEDULER_FAILURE);
+#endif
 		DEBUGPANIC();
 	} else {
 		struct tcb_s *rtcb = this_task();

--- a/os/arch/arm/src/armv7-a/arm_task_start.c
+++ b/os/arch/arm/src/armv7-a/arm_task_start.c
@@ -41,6 +41,7 @@
 
 #include <tinyara/config.h>
 #include <tinyara/arch.h>
+#include <tinyara/reboot_reason.h>
 
 #include <assert.h>
 
@@ -85,6 +86,9 @@ void up_task_start(main_t taskentry, int argc, char *argv[])
 
 	sys_call3(SYS_task_start, (uintptr_t)taskentry, (uintptr_t)argc, (uintptr_t)argv);
 
+#ifdef CONFIG_SYSTEM_REBOOT_REASON
+	up_reboot_reason_write(REBOOT_SYSTEM_TASK_START_FAILURE);
+#endif
 	PANIC();
 }
 

--- a/os/arch/arm/src/armv7-m/up_doirq.c
+++ b/os/arch/arm/src/armv7-m/up_doirq.c
@@ -63,6 +63,7 @@
 #include <tinyara/arch.h>
 #include <arch/board/board.h>
 #include <tinyara/security_level.h>
+#include <tinyara/reboot_reason.h>
 
 #include "up_arch.h"
 #include "up_internal.h"
@@ -102,6 +103,9 @@ uint32_t *up_doirq(int irq, uint32_t *regs)
 #endif
 	board_led_on(LED_INIRQ);
 #ifdef CONFIG_SUPPRESS_INTERRUPTS
+#ifdef CONFIG_SYSTEM_REBOOT_REASON
+	up_reboot_reason_write(REBOOT_SYSTEM_INTERRUPT_FAILURE);
+#endif
 	PANIC();
 #else
 

--- a/os/arch/arm/src/armv7-m/up_reprioritizertr.c
+++ b/os/arch/arm/src/armv7-m/up_reprioritizertr.c
@@ -61,6 +61,7 @@
 #include <sched.h>
 #include <debug.h>
 #include <tinyara/arch.h>
+#include <tinyara/reboot_reason.h>
 
 #include "sched/sched.h"
 #include "up_internal.h"
@@ -117,6 +118,9 @@ void up_reprioritize_rtr(struct tcb_s *tcb, uint8_t priority)
 		|| priority > SCHED_PRIORITY_MAX
 #endif
 	   ) {
+#ifdef CONFIG_SYSTEM_REBOOT_REASON
+		up_reboot_reason_write(REBOOT_SYSTEM_SCHEDULER_FAILURE);
+#endif
 		PANIC();
 	} else {
 		struct tcb_s *rtcb = this_task();

--- a/os/arch/arm/src/armv7-r/arm_doirq.c
+++ b/os/arch/arm/src/armv7-r/arm_doirq.c
@@ -63,6 +63,7 @@
 
 #include <tinyara/board.h>
 #include <arch/board/board.h>
+#include <tinyara/reboot_reason.h>
 
 #include "up_arch.h"
 #include "up_internal.h"
@@ -94,6 +95,9 @@ uint32_t *arm_doirq(int irq, uint32_t *regs)
 	board_autoled_on(LED_INIRQ);
 
 #ifdef CONFIG_SUPPRESS_INTERRUPTS
+#ifdef CONFIG_SYSTEM_REBOOT_REASON
+	up_reboot_reason_write(REBOOT_SYSTEM_INTERRUPT_FAILURE);
+#endif
 	PANIC();
 #else
 	/* Nested interrupts are not supported */

--- a/os/arch/arm/src/armv7-r/arm_reprioritizertr.c
+++ b/os/arch/arm/src/armv7-r/arm_reprioritizertr.c
@@ -62,6 +62,7 @@
 #include <debug.h>
 #include <tinyara/arch.h>
 #include <tinyara/sched.h>
+#include <tinyara/reboot_reason.h>
 
 #include "sched/sched.h"
 #include "group/group.h"
@@ -106,6 +107,9 @@ void up_reprioritize_rtr(struct tcb_s *tcb, uint8_t priority)
 		|| priority > SCHED_PRIORITY_MAX
 #endif
 	   ) {
+#ifdef CONFIG_SYSTEM_REBOOT_REASON
+		up_reboot_reason_write(REBOOT_SYSTEM_SCHEDULER_FAILURE);
+#endif
 		PANIC();
 	} else {
 		struct tcb_s *rtcb = this_task();

--- a/os/arch/arm/src/armv8-m/up_doirq.c
+++ b/os/arch/arm/src/armv8-m/up_doirq.c
@@ -63,6 +63,7 @@
 #include <tinyara/arch.h>
 #include <arch/board/board.h>
 #include <tinyara/security_level.h>
+#include <tinyara/reboot_reason.h>
 
 #include "up_arch.h"
 #include "up_internal.h"
@@ -102,6 +103,9 @@ uint32_t *up_doirq(int irq, uint32_t *regs)
 #endif
 	board_led_on(LED_INIRQ);
 #ifdef CONFIG_SUPPRESS_INTERRUPTS
+#ifdef CONFIG_SYSTEM_REBOOT_REASON
+	up_reboot_reason_write(REBOOT_SYSTEM_INTERRUPT_FAILURE);
+#endif
 	PANIC();
 #else
 

--- a/os/arch/arm/src/armv8-m/up_reprioritizertr.c
+++ b/os/arch/arm/src/armv8-m/up_reprioritizertr.c
@@ -61,6 +61,7 @@
 #include <sched.h>
 #include <debug.h>
 #include <tinyara/arch.h>
+#include <tinyara/reboot_reason.h>
 
 #include "sched/sched.h"
 #include "up_internal.h"
@@ -121,6 +122,9 @@ void up_reprioritize_rtr(struct tcb_s *tcb, uint8_t priority)
 		|| priority > SCHED_PRIORITY_MAX
 #endif
 	   ) {
+#ifdef CONFIG_SYSTEM_REBOOT_REASON
+		up_reboot_reason_write(REBOOT_SYSTEM_SCHEDULER_FAILURE);
+#endif
 		PANIC();
 	} else {
 		struct tcb_s *rtcb = this_task();

--- a/os/arch/arm/src/common/up_allocateheap.c
+++ b/os/arch/arm/src/common/up_allocateheap.c
@@ -70,6 +70,7 @@
 #include <tinyara/mm/mm.h>
 #include <tinyara/kmalloc.h>
 #include <tinyara/mm/heap_regioninfo.h>
+#include <tinyara/reboot_reason.h>
 
 #if defined(CONFIG_BUILD_PROTECTED) && defined(CONFIG_MM_KERNEL_HEAP)
 #include <string.h>
@@ -134,6 +135,9 @@ void up_allocate_kheap(FAR void **heap_start, size_t *heap_size)
 	if ((void *)&_sdata <= (void *)KREGION_END && stack_end >= (void *)KREGION_END) {
 		lldbg("ERROR: Failed to allocate kheap for ram region configuration\n");
 		lldbg("Region start = 0x%x region end = 0x%x\n_sdata = 0x%x end of stack = 0x%x\n", KREGION_START, KREGION_END, &_sdata, stack_end);
+#ifdef CONFIG_SYSTEM_REBOOT_REASON
+		up_reboot_reason_write(REBOOT_SYSTEM_MEMORYALLOCFAIL);
+#endif
 		PANIC();
 	} else if (stack_end >= (void *)KREGION_START && stack_end < (void *)KREGION_END) {
 		*heap_start = stack_end;
@@ -171,6 +175,9 @@ void up_add_kregion(void)
 		if ((void *)&_sdata <= (void *)kregionx_end && stack_end >= (void *)kregionx_end) {
 			lldbg("ERROR: Failed to allocate kheap for ram region configuration\n");
 			lldbg("Region start = 0x%x region end = 0x%x\n_sdata = 0x%x end of stack = 0x%x\n", kregionx_start[region_cnt], kregionx_end, &_sdata, stack_end);
+#ifdef CONFIG_SYSTEM_REBOOT_REASON
+			up_reboot_reason_write(REBOOT_SYSTEM_MEMORYALLOCFAIL);
+#endif
 			PANIC();
 		} else if (stack_end >= (void *)kregionx_start[region_cnt] && stack_end < (void *)kregionx_end) {
 			heap_start = stack_end;

--- a/os/arch/arm/src/common/up_checkstackoverflow.c
+++ b/os/arch/arm/src/common/up_checkstackoverflow.c
@@ -24,6 +24,7 @@
 #include <tinyara/arch.h>
 #include <tinyara/sched.h>
 #include <tinyara/irq.h>
+#include <tinyara/reboot_reason.h>
 
 #include <assert.h>
 #include <debug.h>
@@ -93,6 +94,9 @@ void up_checkstackoverflow(FAR struct tcb_s *rtcb)
             lldbg_noarg("###################\n");
 			lldbg_noarg("Stack base pointer (corrupted value) : %p", (void *)(rtcb->stack_base_ptr));
 		}
+#ifdef CONFIG_SYSTEM_REBOOT_REASON
+		up_reboot_reason_write(REBOOT_SYSTEM_STACK_OVERFLOW);
+#endif
 		PANIC();
 		leave_critical_section(flags);
 	}

--- a/os/include/tinyara/reboot_reason.h
+++ b/os/include/tinyara/reboot_reason.h
@@ -42,6 +42,11 @@ typedef enum {
 	REBOOT_SYSTEM_BINARY_RECOVERYFAIL  = 58, /* Binary Recovery Fail */
 	REBOOT_SYSTEM_PERIODIC_REBOOT      = 59, /* Periodic reboot */
 	REBOOT_SYSTEM_ASSERT               = 60, /* Reboot from ASSERT or PANIC */
+	REBOOT_SYSTEM_INTERRUPT_FAILURE    = 61, /* Interrupt handling failure */
+	REBOOT_SYSTEM_SCHEDULER_FAILURE    = 62, /* Scheduler/reprioritization failure */
+	REBOOT_SYSTEM_TASK_START_FAILURE   = 63, /* Task start failure */
+	REBOOT_SYSTEM_PTHREAD_START_FAILURE = 64, /* Pthread start failure */
+	REBOOT_SYSTEM_STACK_OVERFLOW       = 65, /* Stack overflow detected */
 
 	REBOOT_NETWORK_WIFICORE_WATCHDOG   = 80, /* Wi-Fi Core Watchdog Reset */
 	REBOOT_NETWORK_WIFICORE_PANIC      = 81, /* Wi-Fi Core Panic */


### PR DESCRIPTION
This commit improves the reboot reason system in TizenRT by adding specific reboot reasons at system failure points where they were previously missing. This enhancement provides better error tracking and debugging capabilities. 
New reboot reasons added (61-65):
- REBOOT_SYSTEM_INTERRUPT_FAILURE (61) - Interrupt handling failures
- REBOOT_SYSTEM_SCHEDULER_FAILURE (62) - Scheduler/reprioritization failures
- REBOOT_SYSTEM_TASK_START_FAILURE (63) - Task start failures
- REBOOT_SYSTEM_PTHREAD_START_FAILURE (64) - Pthread start failures
- REBOOT_SYSTEM_STACK_OVERFLOW (65) - Stack overflow detected