### PR TITLE
os/kernel/debug/mem_leak_checker: Add memory dump feature

### DIFF
--- a/os/kernel/debug/mem_leak_checker.c
+++ b/os/kernel/debug/mem_leak_checker.c
@@ -45,6 +45,7 @@
 #define MEM_ACCESS_UNIT    0x04
 #define MAX_ALLOC_COUNT    CONFIG_MEM_LEAK_CHECKER_MAX_ALLOC_COUNT
 #define HASH_SIZE          CONFIG_MEM_LEAK_CHECKER_HASH_TABLE_SIZE
+#define MEM_DUMP_MAX_BYTES 32
 
 #define MM_PREV_NODE_SIZE(x)            ((x)->preceding & ~MM_ALLOC_BIT)
 
@@ -319,6 +320,22 @@ static void ram_check(struct mm_heap_s *heap, int checker_pid, char *bin_name, i
 	heap_check(heap, checker_pid, leak_cnt);
 }
 
+static void print_mem_hex_dump(void *addr, size_t alloc_size)
+{
+	unsigned char *ptr = (unsigned char *)addr;
+	size_t dump_size = (alloc_size < MEM_DUMP_MAX_BYTES) ? alloc_size : MEM_DUMP_MAX_BYTES;
+	size_t i;
+
+	printf("[DATA] ");
+	for (i = 0; i < dump_size; i++) {
+		printf("%02x ", ptr[i]);
+		if ((i + 1) % 16 == 0 && (i + 1) < dump_size) {
+			printf("\n       ");
+		}
+	}
+	printf("\n");
+}
+
 static void print_info(struct mm_heap_s *heap, int leak_cnt, int broken_cnt)
 {
 	volatile struct mm_allocnode_s *node;
@@ -358,6 +375,7 @@ static void print_info(struct mm_heap_s *heap, int leak_cnt, int broken_cnt)
 						pid = (-1) * pid;
 					}
 					printf("LEAK   | %10p |  %8d  | %10p | %d\n", (void *)((char *)node + SIZEOF_MM_ALLOCNODE), node->size - SIZEOF_MM_ALLOCNODE, owner_addr, pid);
+					print_mem_hex_dump((void *)((char *)node + SIZEOF_MM_ALLOCNODE), node->size - SIZEOF_MM_ALLOCNODE);
 				} else if (node->reserved == MEM_BROKEN) {
 					printf("BROKEN | %p\n", node);
 				}


### PR DESCRIPTION
Add new feature to dump memory contents when memory leak is detected. 
Limited to max 32 bytes for dump memory contents.

[EXAMPLE]
```
TASH>>mem_leak

Kernel :
*** NO MEMORY LEAK.

Below are text addresses of loadable apps (and common binary if enabled) :
The pc value of the allocation can be obtained by subtracting the text start address of the appropriate binary

[common] Text Addr : 0xe261010, Text Size : 8679424
[app1] Text Addr : 0xeaa8030, Text Size : 4894720

app1 :
Type   |    Addr    | Size(byte) |    Owner   | PID
---------------------------------------------------
LEAK   | 0x63a947c0 |        64  |  0xe27085d | 30
       [DATA] 4c 45 41 4b 5f 54 45 53 54 5f 53 54 52 49 4e 47
              5f 31 32 33 34 35 36 37 38 39 30 00 aa 96 aa 96 ...
LEAK   | 0x63a94810 |        16  |  0xe270877 | 30
       [DATA] 53 4d 41 4c 4c 5f 4c 45 41 4b 00 fe ff ff aa 96
LEAK   | 0x63a94830 |       128  |  0xe270891 | 30
       [DATA] ef be ad de be ba fe ca 78 56 34 12 ff ff aa 96
              aa 96 aa 96 aa 96 aa 96 aa 96 aa 96 aa 96 aa 96 ...
*** 3 LEAKS, 0 BROKENS.
```