### PR TITLE
os/arch/arm: Improve CPU off/on functions with validation checks

### DIFF
--- a/os/arch/arm/src/armv7-a/arm_cpuoff.c
+++ b/os/arch/arm/src/armv7-a/arm_cpuoff.c
@@ -245,12 +245,20 @@ int arm_hotplug_handler(int irq, void *context, void *arg)
 
 int up_cpu_off(int cpu)
 {
-	struct tcb_s * tcb;
+	struct tcb_s *tcb;
 	int ret = OK;
 
 	smpllvdbg("Disabling CPU%d\n", cpu);
 
-	DEBUGASSERT(cpu > 0 && cpu < CONFIG_SMP_NCPUS && cpu != this_cpu());
+	if (cpu <= 0 || cpu >= CONFIG_SMP_NCPUS) {
+		smplldbg("Invalid CPU index: %d (valid: 1 ~ %d)\n", cpu, CONFIG_SMP_NCPUS - 1);
+		return -EINVAL;
+	}
+
+	if (cpu == this_cpu()) {
+		smplldbg("Cannot stop current CPU%d from itself\n", cpu);
+		return -EINVAL;
+	}
 
 	/* Check the target cpu idle */
 	tcb = current_task(cpu);

--- a/os/arch/arm/src/armv7-a/arm_cpuon.c
+++ b/os/arch/arm/src/armv7-a/arm_cpuon.c
@@ -44,6 +44,7 @@
 #include <stdint.h>
 #include <assert.h>
 #include <debug.h>
+#include <errno.h>
 
 #include <tinyara/arch.h>
 #include <tinyara/sched.h>
@@ -177,11 +178,19 @@ int arm_start_handler(int irq, void *context, void *arg)
 
 int up_cpu_on(int cpu)
 {
-	int ret ;
+	int ret;
 
 	smpllvdbg("Starting CPU%d\n", cpu);
 
-	DEBUGASSERT(cpu >= 0 && cpu < CONFIG_SMP_NCPUS && cpu != this_cpu());
+	if (cpu <= 0 || cpu >= CONFIG_SMP_NCPUS) {
+		smplldbg("Invalid CPU index: %d (valid: 1 ~ %d)\n", cpu, CONFIG_SMP_NCPUS - 1);
+		return -EINVAL;
+	}
+
+	if (cpu == this_cpu()) {
+		smplldbg("Cannot start current CPU%d from itself\n", cpu);
+		return -EINVAL;
+	}
 
 	ret = up_cpu_up(cpu);
 	if (ret < 0) {


### PR DESCRIPTION
Updated `up_cpu_off` and `up_cpu_on` functions to include checks for valid CPU indices and prevent operations on the current CPU. 
Added error logging for invalid CPU index and self-referential operations to improve debugging and stability. 
This changes is to prevent assertion when passing invalid parameters to `up_cpu_off` and `up_cpu_on` functions.