### PR TITLE
board/rtl8730e: Rename and fix return type of the IWDG status function

### DIFF
--- a/os/board/rtl8730e/src/rtl8730e_boot.c
+++ b/os/board/rtl8730e/src/rtl8730e_boot.c
@@ -145,7 +145,7 @@ static void board_initialize_bor(void)
 }
 #endif
 
-int up_check_iwdg(void)
+void up_print_iwdg_status(void)
 {
 	u32 Temp = HAL_READ32(SYSTEM_CTRL_BASE, REG_AON_FEN);
 
@@ -507,7 +507,7 @@ void board_initialize(void)
 	ipc_msg_loguart.rsvd = 0; /* for coverity init issue */
 	ipc_send_message(IPC_AP_TO_LP, IPC_A2L_DISLOGUART, &ipc_msg_loguart);
 	
-	up_check_iwdg();
+	up_print_iwdg_status();
 }
 #else
 #error "CONFIG_BOARD_INITIALIZE MUST ENABLE"


### PR DESCRIPTION
The `up_check_iwdg` function was called during board initialization only prints whether the IWDG is enabled,
Ant function return type was int but it doesn't return any value.
So rename this function to `up_print_iwdg_status` and fix the return type to void.