### PR TITLE
os/board/bk7239n: Report SoftAP station disconnection reason to adapter layer

### DIFF
--- a/os/board/bk7239n/src/bsp_adapter/src/net/bk_netmgr.c
+++ b/os/board/bk7239n/src/bsp_adapter/src/net/bk_netmgr.c
@@ -975,8 +975,14 @@ int beken_wifi_event_cb(void *arg, event_module_t event_module,
 
     case EVENT_WIFI_AP_DISCONNECTED:
         ap_disconnected = (wifi_event_ap_disconnected_t *)event_data;
-        ndbg(BK_MAC_FORMAT" disconnected from BK AP\n", BK_MAC_STR(ap_disconnected->mac));
-        trwifi_post_event(armino_dev_wlan1, LWNL_EVT_SOFTAP_STA_LEFT, NULL, 0);
+        {
+            trwifi_cbk_msg_s msg = {TRWIFI_REASON_UNKNOWN, {0,}, NULL};
+            os_memcpy(msg.bssid, ap_disconnected->mac, WIFI_BSSID_LEN);
+            msg.reason = ap_disconnected->disconnect_reason;
+            ndbg(BK_MAC_FORMAT" disconnected from BK AP, reason(%d)\n",
+                BK_MAC_STR(ap_disconnected->mac), ap_disconnected->disconnect_reason);
+            trwifi_post_event(armino_dev_wlan1, LWNL_EVT_SOFTAP_STA_LEFT, &msg, sizeof(trwifi_cbk_msg_s));
+        }
         break;
 
     case EVENT_WIFI_REGDOMAIN_CHANGED:

--- a/os/board/bk7239n/src/components/wpa_supplicant-2.10/src/ap/ap_mlme.c
+++ b/os/board/bk7239n/src/components/wpa_supplicant-2.10/src/ap/ap_mlme.c
@@ -17,6 +17,30 @@
 #include "sta_info.h"
 #include "ap_mlme.h"
 #include "hostapd.h"
+#ifdef BK_SUPPLICANT
+#include "../../wpa_supplicant/notify.h"
+#endif
+
+#ifdef BK_SUPPLICANT
+void mlme_report_sta_disconnect(struct hostapd_data *hapd,
+				struct sta_info *sta, u16 reason_code)
+{
+	if (sta == NULL || sta->disconnect_event_reported) {
+		return;
+	}
+
+	hapd_notify_sta_disconnected(hapd, sta->addr, reason_code);
+	sta->disconnect_event_reported = true;
+}
+#else
+void mlme_report_sta_disconnect(struct hostapd_data *hapd,
+				struct sta_info *sta, u16 reason_code)
+{
+	(void)hapd;
+	(void)sta;
+	(void)reason_code;
+}
+#endif
 
 
 #if !defined(CONFIG_NO_HOSTAPD_LOGGER) || (defined(BK_SUPPLICANT) && CONFIG_WPA_LOG)

--- a/os/board/bk7239n/src/components/wpa_supplicant-2.10/src/ap/ap_mlme.h
+++ b/os/board/bk7239n/src/components/wpa_supplicant-2.10/src/ap/ap_mlme.h
@@ -16,6 +16,8 @@ void mlme_authenticate_indication(struct hostapd_data *hapd,
 
 void mlme_deauthenticate_indication(struct hostapd_data *hapd,
 				    struct sta_info *sta, u16 reason_code);
+void mlme_report_sta_disconnect(struct hostapd_data *hapd,
+				struct sta_info *sta, u16 reason_code);
 
 void mlme_associate_indication(struct hostapd_data *hapd,
 			       struct sta_info *sta);

--- a/os/board/bk7239n/src/components/wpa_supplicant-2.10/src/ap/ieee802_11.c
+++ b/os/board/bk7239n/src/components/wpa_supplicant-2.10/src/ap/ieee802_11.c
@@ -5985,6 +5985,8 @@ static void handle_disassoc(struct hostapd_data *hapd,
 				       hapd, sta);
 	}
 
+	mlme_report_sta_disconnect(
+		hapd, sta, le_to_host16(mgmt->u.disassoc.reason_code));
 	mlme_disassociate_indication(
 		hapd, sta, le_to_host16(mgmt->u.disassoc.reason_code));
 
@@ -6037,6 +6039,8 @@ static void handle_deauth(struct hostapd_data *hapd,
 	wpa_auth_sm_event(sta->wpa_sm, WPA_DEAUTH);
 	hostapd_logger(hapd, sta->addr, HOSTAPD_MODULE_IEEE80211,
 		       HOSTAPD_LEVEL_DEBUG, "deauthenticated");
+	mlme_report_sta_disconnect(
+		hapd, sta, le_to_host16(mgmt->u.deauth.reason_code));
 	mlme_deauthenticate_indication(
 		hapd, sta, le_to_host16(mgmt->u.deauth.reason_code));
 #ifdef CONFIG_FULL_HOSTAPD

--- a/os/board/bk7239n/src/components/wpa_supplicant-2.10/src/ap/sta_info.c
+++ b/os/board/bk7239n/src/components/wpa_supplicant-2.10/src/ap/sta_info.c
@@ -642,6 +642,7 @@ skip_poll:
 			   __func__, MAC2STR(sta->addr), AP_DEAUTH_DELAY);
 		eloop_register_timeout(AP_DEAUTH_DELAY, 0, ap_handle_timer,
 				       hapd, sta);
+		mlme_report_sta_disconnect(hapd, sta, reason);
 		mlme_disassociate_indication(hapd, sta, reason);
 		break;
 	case STA_DEAUTH:
@@ -655,6 +656,8 @@ skip_poll:
 				RADIUS_ACCT_TERMINATE_CAUSE_IDLE_TIMEOUT;
 #endif
 		WPA_LOGD("ap_free_sta\r\n");
+		mlme_report_sta_disconnect(hapd, sta,
+				       WLAN_REASON_PREV_AUTH_NOT_VALID);
 		mlme_deauthenticate_indication(
 			hapd, sta,
 			WLAN_REASON_PREV_AUTH_NOT_VALID);
@@ -683,6 +686,8 @@ static void ap_handle_session_timer(void *eloop_ctx, void *timeout_ctx)
 
 	hostapd_drv_sta_deauth(hapd, sta->addr,
 			       WLAN_REASON_PREV_AUTH_NOT_VALID);
+	mlme_report_sta_disconnect(hapd, sta,
+				       WLAN_REASON_PREV_AUTH_NOT_VALID);
 	mlme_deauthenticate_indication(hapd, sta,
 				       WLAN_REASON_PREV_AUTH_NOT_VALID);
 	hostapd_logger(hapd, sta->addr, HOSTAPD_MODULE_IEEE80211,
@@ -887,6 +892,7 @@ static void ap_sta_disassoc_cb_timeout(void *eloop_ctx, void *timeout_ctx)
 	wpa_printf(MSG_DEBUG, "%s: Disassociation callback for STA " MACSTR,
 		   hapd->conf->iface, MAC2STR(sta->addr));
 	ap_sta_remove(hapd, sta);
+	mlme_report_sta_disconnect(hapd, sta, sta->disassoc_reason);
 	mlme_disassociate_indication(hapd, sta, sta->disassoc_reason);
 }
 
@@ -941,6 +947,7 @@ static void ap_sta_deauth_cb_timeout(void *eloop_ctx, void *timeout_ctx)
 	wpa_printf(MSG_DEBUG, "%s: Deauthentication callback for STA " MACSTR,
 		   hapd->conf->iface, MAC2STR(sta->addr));
 	ap_sta_remove(hapd, sta);
+	mlme_report_sta_disconnect(hapd, sta, sta->deauth_reason);
 	mlme_deauthenticate_indication(hapd, sta, sta->deauth_reason);
 }
 
@@ -1343,8 +1350,8 @@ void ap_sta_set_authorized(struct hostapd_data *hapd, struct sta_info *sta,
 #ifdef BK_SUPPLICANT
 	if (!!authorized)
 		hapd_notify_sta_connected(hapd, sta->addr);
-	else
-		hapd_notify_sta_disconnected(hapd, sta->addr);
+	if (!!authorized)
+		sta->disconnect_event_reported = false;
 #endif
 
 	if (authorized)

--- a/os/board/bk7239n/src/components/wpa_supplicant-2.10/src/ap/sta_info.h
+++ b/os/board/bk7239n/src/components/wpa_supplicant-2.10/src/ap/sta_info.h
@@ -111,6 +111,9 @@ struct sta_info {
 	struct dl_list ip6addr; /* list head for struct ip6addr */
 	u16 aid; /* STA's unique AID (1 .. 2007) or 0 if not yet assigned */
 	u16 disconnect_reason_code; /* RADIUS server override */
+#ifdef BK_SUPPLICANT
+	bool disconnect_event_reported;
+#endif
 	u32 flags; /* Bitfield of WLAN_STA_* */
 	u16 capability;
 	u16 listen_interval; /* or beacon_int for APs */

--- a/os/board/bk7239n/src/components/wpa_supplicant-2.10/src/ap/tkip_countermeasures.c
+++ b/os/board/bk7239n/src/components/wpa_supplicant-2.10/src/ap/tkip_countermeasures.c
@@ -51,6 +51,9 @@ static void ieee80211_tkip_countermeasures_start(struct hostapd_data *hapd)
 			RADIUS_ACCT_TERMINATE_CAUSE_ADMIN_RESET;
 #endif
 		if (sta->flags & WLAN_STA_AUTH) {
+			mlme_report_sta_disconnect(
+				hapd, sta,
+				WLAN_REASON_MICHAEL_MIC_FAILURE);
 			mlme_deauthenticate_indication(
 				hapd, sta,
 				WLAN_REASON_MICHAEL_MIC_FAILURE);

--- a/os/board/bk7239n/src/components/wpa_supplicant-2.10/wpa_supplicant/notify.c
+++ b/os/board/bk7239n/src/components/wpa_supplicant-2.10/wpa_supplicant/notify.c
@@ -547,7 +547,8 @@ void hapd_notify_sta_connected(struct hostapd_data *hapd, const u8 *mac)
 				&ap_connected, sizeof(ap_connected), BEKEN_NEVER_TIMEOUT));
 }
 
-void hapd_notify_sta_disconnected(struct hostapd_data *hapd, const u8 *mac)
+void hapd_notify_sta_disconnected(struct hostapd_data *hapd, const u8 *mac,
+					 u16 reason_code)
 {
 	wifi_event_ap_disconnected_t ap_disconnected = {0};
 #if !CONFIG_DISABLE_DEPRECIATED_WIFI_API
@@ -563,6 +564,7 @@ void hapd_notify_sta_disconnected(struct hostapd_data *hapd, const u8 *mac)
 	}
 #endif
 	os_memcpy(ap_disconnected.mac, mac, ETH_ALEN);
+	ap_disconnected.disconnect_reason = reason_code;
 #if CONFIG_AP_STATYPE_LIMIT
 	if (bk_feature_ap_statype_limit_enable())
 		bk_vsie_cus_del_sta(ap_disconnected.mac, true);

--- a/os/board/bk7239n/src/components/wpa_supplicant-2.10/wpa_supplicant/notify.h
+++ b/os/board/bk7239n/src/components/wpa_supplicant-2.10/wpa_supplicant/notify.h
@@ -181,7 +181,8 @@ void wpas_notify_interworking_select_done(struct wpa_supplicant *wpa_s);
 void wpas_notify_psk_mismatch(struct wpa_supplicant *wpa_s, u16 reason_code,
 						 int locally_generated);
 void hapd_notify_sta_connected(struct hostapd_data *hapd, const u8 *mac);
-void hapd_notify_sta_disconnected(struct hostapd_data *hapd, const u8 *mac);
+void hapd_notify_sta_disconnected(struct hostapd_data *hapd, const u8 *mac,
+					 u16 reason_code);
 void hapd_notify_sta_psk_failure(struct hostapd_data *hapd, const u8 *mac);
 void wpas_notify_disconnected(struct wpa_supplicant *wpa_s);
 void wpas_notify_connected(struct wpa_supplicant *wpa_s);

--- a/os/board/bk7239n/src/include/modules/wifi_types.h
+++ b/os/board/bk7239n/src/include/modules/wifi_types.h
@@ -649,6 +649,7 @@ typedef struct {
 
 typedef struct {
 	uint8_t mac[WIFI_MAC_LEN];            /**< MAC of the STA disconnected from the BK AP */
+	int disconnect_reason;                /**< Disconnect reason of the STA from BK AP */
 } wifi_event_ap_disconnected_t;
 
 typedef struct {


### PR DESCRIPTION
This commit implements the reporting of disconnection reasons when a station is disconnected in SoftAP mode.

Key changes:
Enhanced the event mechanism to trigger a notification when a station is deauthenticated or dissociated from the SoftAP. 
Passes the extracted MAC and Reason Code directly to the adapter layer.