### PR TITLE
os/board/bk7239n, os/arch/arm/src: adjust adapter to support single wlan interface for non-concurrent mode

### DIFF
--- a/os/arch/arm/src/armino/armino_enet.c
+++ b/os/arch/arm/src/armino/armino_enet.c
@@ -122,7 +122,7 @@ void up_netinitialize(void)
 		bk_wifi_sta_get_mac(macptr);
 		netdev_set_hwaddr(armino_dev_wlan0, macptr, 6);
 	}
-
+#ifdef CONFIG_BK_CONCURRENT_MODE
 	armino_dev_wlan1 = armino_register_dev(alloc_size);
 	if (armino_dev_wlan1 == NULL) {
 		ndbg("Failed to register armino netdev wlan1\n");
@@ -131,7 +131,7 @@ void up_netinitialize(void)
 		bk_wifi_ap_get_mac(macptr);
 		netdev_set_hwaddr(armino_dev_wlan1, macptr, 6);
 	}
-
+#endif
 #ifdef CONFIG_VIRTUAL_BLE
 	vble_register();
 #else

--- a/os/board/bk7239n/src/bsp_adapter/src/net/bk_ethernetif.c
+++ b/os/board/bk7239n/src/bsp_adapter/src/net/bk_ethernetif.c
@@ -96,24 +96,38 @@ void ethernetif_input(int iface, struct pbuf *p);
 
 #ifdef CONFIG_NET_NETMGR
 extern struct netdev *armino_dev_wlan0;
+#ifdef CONFIG_BK_CONCURRENT_MODE
 extern struct netdev *armino_dev_wlan1;
+#else
+volatile int g_bk_wifi_current_vif = 0;
+#endif
 
 int get_idx_from_dev(struct netdev *dev)
 {
+#ifdef CONFIG_BK_CONCURRENT_MODE
 	if (!strcmp(WLAN0_NAME, dev->ifname))
 		return 0;
 	else if(!strcmp(WLAN1_NAME, dev->ifname))
 		return 1;
 	else
 		return -1;
+#else
+	(void)dev;
+	return g_bk_wifi_current_vif;
+#endif
 }
 
 static struct netdev *bk_get_netdev(int idx)
 {
+#ifdef CONFIG_BK_CONCURRENT_MODE
 	if (idx == 1)
 	    return armino_dev_wlan1;
 	else
 	    return armino_dev_wlan0;
+#else
+	(void)idx;
+	return armino_dev_wlan0;
+#endif
 }
 #endif
 
@@ -268,6 +282,10 @@ ethernetif_input(int iface, struct pbuf *p)
         return;
     }
     dev_tmp = (struct netdev *)bk_get_netdev(iface);
+    if(!dev_tmp) {
+        pbuf_free(p);
+        return;
+    }
     netif = GET_NETIF_FROM_NETDEV(dev_tmp);
     if(!netif) {
         //LWIP_LOGI("ethernetif_input no netif found %d\r\n", iface);

--- a/os/board/bk7239n/src/bsp_adapter/src/net/bk_netmgr.c
+++ b/os/board/bk7239n/src/bsp_adapter/src/net/bk_netmgr.c
@@ -142,6 +142,9 @@ struct trwifi_ops g_trwifi_bk_ops = {
 
 extern struct netdev *armino_dev_wlan0;
 extern struct netdev *armino_dev_wlan1;
+#ifndef CONFIG_BK_CONCURRENT_MODE
+extern volatile int g_bk_wifi_current_vif;
+#endif
 static int auth_fail_cnt = 0;
 static int valid_ch_list[] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 36, 40, 44, 48, 52, 56, 60, 64, 100, 104, 108, 112, 116, 120, 124, 128, 132, 136, 140, 144, 149, 153, 157, 161, 165};
 static int valid_ch_list_size = sizeof(valid_ch_list)/sizeof(valid_ch_list[0]);
@@ -972,7 +975,11 @@ int beken_wifi_event_cb(void *arg, event_module_t event_module,
 		if (bk_trwifi_new_sta_join_func) {
 			(*bk_trwifi_new_sta_join_func)();
 		}
+#ifdef CONFIG_BK_CONCURRENT_MODE
         trwifi_post_event(armino_dev_wlan1, LWNL_EVT_SOFTAP_STA_JOINED, NULL, 0);
+#else
+        trwifi_post_event(armino_dev_wlan0, LWNL_EVT_SOFTAP_STA_JOINED, NULL, 0);
+#endif
         break;
 
     case EVENT_WIFI_AP_DISCONNECTED:
@@ -983,7 +990,11 @@ int beken_wifi_event_cb(void *arg, event_module_t event_module,
             msg.reason = ap_disconnected->disconnect_reason;
             ndbg(BK_MAC_FORMAT" disconnected from BK AP, reason(%d)\n",
                 BK_MAC_STR(ap_disconnected->mac), ap_disconnected->disconnect_reason);
+#ifdef CONFIG_BK_CONCURRENT_MODE
             trwifi_post_event(armino_dev_wlan1, LWNL_EVT_SOFTAP_STA_LEFT, &msg, sizeof(trwifi_cbk_msg_s));
+#else
+            trwifi_post_event(armino_dev_wlan0, LWNL_EVT_SOFTAP_STA_LEFT, &msg, sizeof(trwifi_cbk_msg_s));
+#endif
         }
         break;
 
@@ -1456,6 +1467,9 @@ trwifi_result_e bk_wifi_netmgr_start_softap(struct netdev *dev, trwifi_softap_co
 		return ret;
 	}
 	g_softap_if = BK_WIFI_SOFTAP_IF;
+#ifndef CONFIG_BK_CONCURRENT_MODE
+	g_bk_wifi_current_vif = 1;
+#endif
 	nvdbg("[BK] SoftAP with SSID: %s has successfully started!\r\n", softap_config->ssid);
 
 	ret = TRWIFI_SUCCESS;
@@ -1468,6 +1482,9 @@ trwifi_result_e bk_wifi_netmgr_start_sta(struct netdev *dev)
 	trwifi_result_e ret = TRWIFI_FAIL;
 
 	g_station_if = BK_WIFI_STATION_IF;
+#ifndef CONFIG_BK_CONCURRENT_MODE
+	g_bk_wifi_current_vif = 0;
+#endif
 	ret = TRWIFI_SUCCESS;
 
 	return ret;
@@ -1480,6 +1497,9 @@ trwifi_result_e bk_wifi_netmgr_stop_softap(struct netdev *dev)
 	int res = bk_wifi_ap_stop();
 	if (res == BK_OK) {
 		g_softap_if = BK_WIFI_NONE;
+#ifndef CONFIG_BK_CONCURRENT_MODE
+		g_bk_wifi_current_vif = 0;
+#endif
 		ret = TRWIFI_SUCCESS;
 		nvdbg("[BK] Stop AP mode successfully\r\n");
 	} else {

--- a/os/board/bk7239n/src/components/bk_system/mac.c
+++ b/os/board/bk7239n/src/components/bk_system/mac.c
@@ -496,6 +496,7 @@ bk_err_t bk_get_mac(uint8_t *mac, mac_type_t type)
 		break;
 
 	case MAC_TYPE_AP:
+#if defined(CONFIG_BK_CONCURRENT_MODE)
 #if defined(CONFIG_CUS_MAC_MASK)
 		os_memcpy(mac, s_base_mac, BK_MAC_ADDR_LEN);
 		for (int i = 0; i < BK_MAC_ADDR_LEN; i++) {
@@ -514,6 +515,9 @@ bk_err_t bk_get_mac(uint8_t *mac, mac_type_t type)
 		mac[5] &= ~mac_mask;
 		mac_low = ((mac_low & mac_mask) ^ mac_mask);
 		mac[5] |= mac_low;
+#endif
+#else
+		os_memcpy(mac, s_base_mac, BK_MAC_ADDR_LEN);
 #endif
 		break;
 

--- a/os/board/bk7239n/src/components/bk_wifi/Kconfig
+++ b/os/board/bk7239n/src/components/bk_wifi/Kconfig
@@ -431,4 +431,10 @@ menu "Bk_Wifi"
 		default y
 		help
 			Enable update power with RSSI
+
+	config BK_CONCURRENT_MODE
+		bool "Enable bk concurrent mode (STA + SoftAP simultaneously)"
+		default n
+		help
+			Enable STA and SoftAP concurrent mode.
 endmenu


### PR DESCRIPTION

When BK_CONCURRENT_MODE is disabled, STA and SoftAP share different VIF index but both operate on a single wlan0 interface.

Key changes:
- Guard wlan1 device registration with BK_CONCURRENT_MODE macro, so only wlan0 is registered in non-concurrent mode.
- Switch VIF index and netdev routing to wlan0-only path.
- Route SoftAP events to wlan0 and update VIF index on STA/SoftAP transitions.