### PR TITLE
os/: Add IPv6 multicast support and fix BLE callback

### DIFF
--- a/os/board/rtl8730e/src/component/bluetooth/example/ble_peripheral/ble_tizenrt_service.c
+++ b/os/board/rtl8730e/src/component/bluetooth/example/ble_peripheral/ble_tizenrt_service.c
@@ -92,7 +92,7 @@ T_APP_RESULT ble_tizenrt_srv_callback(uint8_t event, void *p_data)
 
 			if (p_cha_info->cb) 
 			{
-				p_cha_info->cb(TRBLE_ATTR_CB_CCCD, p_cccd_ind->conn_handle, p_cha_info->abs_handle, p_cha_info->arg, p_cccd_ind->value, 0);
+				p_cha_info->cb(TRBLE_ATTR_CB_CCCD, p_cccd_ind->conn_handle, p_cha_info->abs_handle, p_cccd_ind->value, 0, 0);
 			} else { 
 				debug_print("NULL read callback abs_handle 0x%x \n", p_cha_info->abs_handle); 
 			} 

--- a/os/include/tinyara/preference.h
+++ b/os/include/tinyara/preference.h
@@ -41,6 +41,7 @@
 
 /* Error Type of Result Value returned from Preference */
 enum preference_result_error_e {
+	PREFERENCE_ERROR_NONE = 0,
 	PREFERENCE_IO_ERROR = -1,
 	PREFERENCE_INVALID_PARAMETER = -2,
 	PREFERENCE_PATH_NOT_FOUND = -3,

--- a/os/net/lwip/src/api/sockets.c
+++ b/os/net/lwip/src/api/sockets.c
@@ -2743,6 +2743,24 @@ static u8_t lwip_setsockopt_impl(int s, int level, int optname, const void *optv
 			}
 			LWIP_DEBUGF(SOCKETS_DEBUG, ("lwip_setsockopt(%d, IPPROTO_IPV6, IPV6_V6ONLY, ..) -> %d\n", s, (netconn_get_ipv6only(sock->conn) ? 1 : 0)));
 			break;
+		case IPV6_JOIN_GROUP:
+		case IPV6_LEAVE_GROUP: {
+			err_t err_ret;
+			const struct ipv6_mreq *imr = (const struct ipv6_mreq *)optval;
+
+			//LWIP_SOCKOPT_CHECK_OPTLEN_CONN_PCB_TYPE(sock, optlen, struct ipv6_mreq, NETCONN_UDP_IPV6);
+
+			if (optname == IPV6_JOIN_GROUP) {
+				err_ret = mld6_joingroup(IP6_ADDR_ANY6, &imr->ipv6mr_multiaddr);
+			} else {
+				err_ret = mld6_leavegroup(IP6_ADDR_ANY6, &imr->ipv6mr_multiaddr);
+			}
+
+			if (err_ret != ERR_OK) {
+				err = EADDRNOTAVAIL;
+			}
+		}
+			break;
 		default:
 			LWIP_DEBUGF(SOCKETS_DEBUG, ("lwip_setsockopt(%d, IPPROTO_IPV6, UNIMPL: optname=0x%x, ..)\n", s, optname));
 			err = ENOPROTOOPT;

--- a/os/net/lwip/src/include/lwip/sockets.h
+++ b/os/net/lwip/src/include/lwip/sockets.h
@@ -313,6 +313,8 @@ struct linger {
  */
 #define IPV6_CHECKSUM       7	/* RFC3542: calculate and insert the ICMPv6 checksum for raw sockets. */
 #define IPV6_V6ONLY         27	/* RFC3493: boolean control to restrict AF_INET6 sockets to IPv6 communications only. */
+#define IPV6_JOIN_GROUP     20
+#define IPV6_LEAVE_GROUP    21
 #endif							/* LWIP_IPV6 */
 
 #if LWIP_UDP && LWIP_UDPLITE
@@ -343,6 +345,14 @@ typedef struct ip_mreq {
 	struct in_addr imr_multiaddr;	/* IP multicast address of group */
 	struct in_addr imr_interface;	/* local IP address of interface */
 } ip_mreq;
+
+/* Used with certain IPv6 socket options */
+struct ipv6_mreq
+{
+	struct in6_addr ipv6mr_multiaddr; /* IPv6 multicast address of group */
+	unsigned int    ipv6mr_interface; /* Local interface index */
+};
+
 #endif							/* LWIP_IGMP */
 
 /*

--- a/os/net/netmgr/netmgr_ioctl_netdev.c
+++ b/os/net/netmgr/netmgr_ioctl_netdev.c
@@ -93,7 +93,7 @@ static int _netdev_getname(struct netdev *dev, void *arg)
 	uint8_t flag;
 	struct ifreq *req = (struct ifreq *)arg;
 	ND_NETOPS(dev, get_flag)(dev, &flag);
-	if ((flag & IFF_RUNNING) && req->ifr_name[0] == 0) {
+	if ((flag & IFF_RUNNING)) { //&& req->ifr_name[0] == 0) {/*This will provide latest running interface*/
 		strncpy(req->ifr_name, dev->ifname, IFNAMSIZ);
 	}
 	return 0;


### PR DESCRIPTION
- IPv6 multicast group join/leave socket options (IPV6_JOIN_GROUP, IPV6_LEAVE_GROUP)

- BLE callback parameter fix in ble_tizenrt_service.c

- PREFERENCE_ERROR_NONE enum addition

- Network interface name retrieval fix in netmgr_ioctl_netdev.c