### PR TITLE
os/board/bk7239n: Adapt to the new flash id

### DIFF
--- a/os/board/bk7239n/src/middleware/driver/flash/flash_driver.c
+++ b/os/board/bk7239n/src/middleware/driver/flash/flash_driver.c
@@ -117,6 +117,11 @@ static const flash_config_t flash_config[] = {
 #endif
 	{0xEF4016,   2,               FLASH_SIZE_4M, FLASH_LINE_MODE_TWO, 14,       2,            0x1F,         0x1F,        0x00,         0x00,         0x101,                9,            1,           0xA0,                          0x01}, //w_25q32(bfj)
 #if defined(CONFIG_FLASH_QUAD_ENABLE)
+	{0xEF4018,   2,               FLASH_SIZE_16M, FLASH_LINE_MODE_FOUR, 14,     2,            0x1F,         0x1F,        0x00,         0x0E,         0x00E,                9,            1,           0xA0,                          0x02}, //w_25q128jv
+#else
+	{0xEF4018,   1,               FLASH_SIZE_16M, FLASH_LINE_MODE_TWO,   0,     2,            0x1F,         0x1F,        0x00,         0x0E,         0x00E,                0,            0,           0xA0,                          0x01}, //w_25q128jv
+#endif
+#if defined(CONFIG_FLASH_QUAD_ENABLE)
 	{0x204118,	 2, 			  FLASH_SIZE_16M,FLASH_LINE_MODE_FOUR, 0,		2,			  0x0F, 		0x0F,		 0x00,		   0x0A,		 0x00E, 			   9,			 1, 		  0xA0, 						 0x02}, //xm_25qu128c
 #else
 	{0x204118,	 1, 			  FLASH_SIZE_16M,FLASH_LINE_MODE_TWO,  0,		2,			  0x0F, 		0x0F,		 0x00,		   0x0A,		 0x00E, 			   0,			 0, 		  0xA0, 						 0x01}, //xm_25qu128c
@@ -130,10 +135,52 @@ static const flash_config_t flash_config[] = {
 #else
 	{0xC86517,	 1, 			  FLASH_SIZE_8M, FLASH_LINE_MODE_TWO, 0,		2,			  0x1F, 		0x1F,		 0x00,		   0x0E,		 0x00E, 			   0,			 0, 		  0xA0, 						 0x01}, //gd_25Q32E
 #endif
-    {0xCD6017,   3,               FLASH_SIZE_8M, FLASH_LINE_MODE_FOUR,   14,       2,            0x1F,         0x1F,        0x00,         0x0E,		  0x00E,                 9,            1,           0xA0,                         0x01}, //th_25q64ha
+#if defined(CONFIG_FLASH_QUAD_ENABLE)
+	{0x852017,	 2, 			  FLASH_SIZE_8M, FLASH_LINE_MODE_FOUR, 14,		2,			  0x1F, 		0x1F,		 0x00,		   0x0E,		 0x00E, 			   9,			 1, 		  0xA0, 						 0x02}, //PY25Q64HA
+#else
+	{0x852017,	 1, 			  FLASH_SIZE_8M, FLASH_LINE_MODE_TWO, 0,		2,			  0x1F, 		0x1F,		 0x00,		   0x0E,		 0x00E, 			   0,			 0, 		  0xA0, 						 0x01}, //PY25Q64HA
+#endif
+#if defined(CONFIG_FLASH_QUAD_ENABLE)
+    {0xCD6017,   2,               FLASH_SIZE_8M, FLASH_LINE_MODE_FOUR,   14,       2,            0x1F,         0x1F,        0x00,         0x0E,		  0x00E,                 9,            1,           0xA0,                         0x01}, //th_25q64ha
+#else
+    {0xCD6017,   1,               FLASH_SIZE_8M, FLASH_LINE_MODE_TWO,     0,       2,            0x1F,         0x1F,        0x00,         0x0E,		  0x00E,                 0,            0,           0xA0,                         0x01}, //th_25q64ha
+#endif
+#if defined(CONFIG_FLASH_QUAD_ENABLE)
+	{0xC86518,   2,               FLASH_SIZE_16M, FLASH_LINE_MODE_FOUR, 14,       2,            0x1F,         0x1F,        0x00,         0x0E,         0x00E,                9,            1,           0xA0,                          0x02}, //gd_25wq128e
+#else
+	{0xC86518,   1,               FLASH_SIZE_16M, FLASH_LINE_MODE_TWO,   0,       2,            0x1F,         0x1F,        0x00,         0x0E,         0x00E,                0,            0,           0xA0,                          0x01}, //gd_25wq128e
+#endif
+#if defined(CONFIG_FLASH_QUAD_ENABLE)
+	{0xC84018,   2,               FLASH_SIZE_16M, FLASH_LINE_MODE_FOUR, 14,       2,            0x1F,         0x1F,        0x00,         0x0E,         0x00E,                9,            1,           0xA0,                          0x02}, //gd_25q128e
+#else
+	{0xC84018,   1,               FLASH_SIZE_16M, FLASH_LINE_MODE_TWO,   0,       2,            0x1F,         0x1F,        0x00,         0x0E,         0x00E,                0,            0,           0xA0,                          0x01}, //gd_25q128e
+#endif
+#if defined(CONFIG_FLASH_QUAD_ENABLE)
 	{0xC86019,	 2, 			  FLASH_SIZE_16M, FLASH_LINE_MODE_FOUR, 14,		2,			  0x1F, 		0x1F,		 0x00,		   0x0E,		 0x00E, 			   9,			 1, 		  0xA0, 						 0x02}, //for FPGA simulation and debugging type size 16M
+#else
+	{0xC86019,	 1, 			  FLASH_SIZE_16M, FLASH_LINE_MODE_TWO,  0,		2,			  0x1F, 		0x1F,		 0x00,		   0x0E,		 0x00E, 			   0,			 0, 		  0xA0, 						 0x01}, //for FPGA simulation and debugging type size 16M
+#endif
+#if defined(CONFIG_FLASH_QUAD_ENABLE)
 	{0xC84016,	 2, 			  FLASH_SIZE_4M, FLASH_LINE_MODE_FOUR, 14,		2,			  0x1F, 		0x1F,		 0x00,		   0x0E,		 0x00E, 			   9,			 1, 		  0xA0, 						 0x02}, //for FPGA simulation and debugging type size 4M
-	{0x000000,   2,               FLASH_SIZE_4M, FLASH_LINE_MODE_TWO,    0,        2,            0x1F,         0x00,        0x00,         0x00,         0x000,                0,            0,           0x00,                          0x01}, //default
+#else
+	{0xC84016,	 1, 			  FLASH_SIZE_4M, FLASH_LINE_MODE_TWO,  0,		2,			  0x1F, 		0x1F,		 0x00,		   0x0E,		 0x00E, 			   0,			 0, 		  0xA0, 						 0x01}, //for FPGA simulation and debugging type size 4M
+#endif
+#if CONFIG_FLASH_QUAD_ENABLE
+	{0x684018,   2,               FLASH_SIZE_16M, FLASH_LINE_MODE_FOUR,   14,       2,            0x1F,         0x1F,        0x00,         0x0E,		  0x00E,                 9,            1,           0xA0,                     0x02}, //BY25Q128ES
+#else
+	{0x684018,   1,               FLASH_SIZE_16M, FLASH_LINE_MODE_TWO,    0,        2,            0x1F,         0x1F,        0x00,         0x0E,		  0x00E,                 0,            0,           0xA0,                         0x01}, //BY25Q128ES
+#endif
+#if defined(CONFIG_FLASH_QUAD_ENABLE)
+	{0x1C7118,   2,               FLASH_SIZE_16M, FLASH_LINE_MODE_FOUR, 14,       2,            0x1F,         0x1F,        0x00,         0x0E,         0x00E,                9,            1,           0xA5,                          0x02}, //GT25Q128EZ
+#else
+	{0x1C7118,   1,               FLASH_SIZE_16M, FLASH_LINE_MODE_TWO,   0,       2,            0x1F,         0x1F,        0x00,         0x0E,         0x00E,                0,            0,           0xA5,                          0x01}, //GT25Q128EZ
+#endif
+#if CONFIG_FLASH_QUAD_ENABLE
+	{0x204018,	 2, 			  FLASH_SIZE_16M,FLASH_LINE_MODE_FOUR,  14,		2,			  0x0F, 		0x0F,		 0x00,		   0x0A,		 0x00E, 			   9,			 1, 		  0x20, 						 0x02}, //xm_25QH128D
+#else
+	{0x204018,	 1, 			  FLASH_SIZE_16M,FLASH_LINE_MODE_TWO,  0,		2,			  0x0F, 		0x0F,		 0x00,		   0x0A,		 0x00E, 			   0,			 0, 		  0x20, 						 0x01}, //xm_25QH128D
+#endif
+	{0x000000,   2,               FLASH_SIZE_16M, FLASH_LINE_MODE_TWO,    0,        2,            0x1F,         0x00,        0x00,         0x00,         0x000,                0,            0,           0x00,                          0x01}, //default
 };
 
 static flash_driver_t s_flash = {0};

--- a/os/board/bk7239n/src/middleware/soc/bk7239n/hal/flash_ll.h
+++ b/os/board/bk7239n/src/middleware/soc/bk7239n/hal/flash_ll.h
@@ -128,32 +128,26 @@ static inline void flash_ll_write_status_reg(flash_hw_t *hw, uint8_t sr_width, u
 	hw->op_ctrl.wp_value = 1;
 	if (sr_width == 1) {
 		flash_ll_set_op_cmd(hw, FLASH_OP_CMD_WRSR);
-	} else if (sr_width == 2) {
-		flash_ll_set_op_cmd(hw, FLASH_OP_CMD_WRSR2);
 	} else {
-		if(FLASH_ID_GD25Q32C == flash_ll_get_id(hw) || FLASH_ID_TH25Q64 == flash_ll_get_id(hw)) {
-			flash_ll_set_op_cmd(hw, FLASH_OP_CMD_WRSR);
+		flash_ll_set_op_cmd(hw, FLASH_OP_CMD_WRSR);
 
-			while (flash_ll_is_busy(hw));
-			hw->config.wrsr_data = (sr_data >> LEN_WRSR_S0_S7);
-			flash_ll_init_wrsr_cmd(hw, CMD_WRSR_S8_S15);
-			// hw->op_ctrl.wp_value = 1;    //  ???
-			flash_ll_set_op_cmd(hw, FLASH_OP_CMD_WRSR);
+		while (flash_ll_is_busy(hw));
+		hw->config.wrsr_data = (sr_data >> LEN_WRSR_S0_S7);
+		flash_ll_init_wrsr_cmd(hw, CMD_WRSR_S8_S15);
+		// hw->op_ctrl.wp_value = 1;    //  ???
+		flash_ll_set_op_cmd(hw, FLASH_OP_CMD_WRSR);
 
-			#if 0
-			while (flash_ll_is_busy(hw));
-			hw->config.wrsr_data = (sr_data >> LEN_WRSR_S8_S15);
-			flash_ll_init_wrsr_cmd(hw, CMD_WRSR_S16_S24);
-			flash_ll_set_op_cmd(hw, FLASH_OP_CMD_WRSR);
-			#endif
+		#if 0
+		while (flash_ll_is_busy(hw));
+		hw->config.wrsr_data = (sr_data >> LEN_WRSR_S8_S15);
+		flash_ll_init_wrsr_cmd(hw, CMD_WRSR_S16_S24);
+		flash_ll_set_op_cmd(hw, FLASH_OP_CMD_WRSR);
+		#endif
 
-			while (flash_ll_is_busy(hw));
+		while (flash_ll_is_busy(hw));
 
-			// flash_ll_deinit_wrsr_cmd(hw);
-			hw->cmd_cfg.v = 0;
-		} else {
-			flash_ll_set_op_cmd(hw, FLASH_OP_CMD_WRSR2);
-		}
+		// flash_ll_deinit_wrsr_cmd(hw);
+		hw->cmd_cfg.v = 0;
 	}
 
 	while (flash_ll_is_busy(hw));


### PR DESCRIPTION
The bk7239n module needs to be compatible with multiple types of flash, and the software needs to adapt to the new flash ID.