### PR TITLE
os/mm: Add API to set custom PID for kernel module memory allocations

### DIFF
--- a/os/include/tinyara/mm/mm.h
+++ b/os/include/tinyara/mm/mm.h
@@ -218,8 +218,14 @@ typedef size_t mmsize_t;
  * This will show the real owner of the 'mem' even it's allocated through wrapping APIs of malloc.
  */
 #define DEBUG_SET_CALLER_ADDR(mem) heapinfo_set_caller_addr(mem, __builtin_return_address(0))
+/* This macro sets the PID of the memory node.
+ * This is useful when kernel modules allocate memory on behalf of other tasks
+ * and want to attribute the allocation to themselves.
+ */
+#define DEBUG_SET_PID(mem, pid) heapinfo_set_pid(mem, pid)
 #else
 #define DEBUG_SET_CALLER_ADDR(mem)
+#define DEBUG_SET_PID(mem, pid)
 #endif
 
 /* typedef is used for defining size of address space */
@@ -661,6 +667,7 @@ void heapinfo_parse_heap(FAR struct mm_heap_s *heap, int mode, pid_t pid);
 /* Funciton to add memory allocation info */
 void heapinfo_update_node(FAR struct mm_allocnode_s *node, mmaddress_t caller_retaddr);
 void heapinfo_set_caller_addr(void *address, mmaddress_t caller_retaddr);
+void heapinfo_set_pid(void *address, pid_t pid);
 
 void heapinfo_add_size(struct mm_heap_s *heap, pid_t pid, mmsize_t size);
 void heapinfo_subtract_size(struct mm_heap_s *heap, pid_t pid, mmsize_t size);

--- a/os/kernel/log_dump/log_dump.c
+++ b/os/kernel/log_dump/log_dump.c
@@ -112,6 +112,9 @@ static size_t writesize = CONFIG_LOG_DUMP_CHUNK_SIZE;
 static unsigned char *out_buf;
 static bool compress_full_block;	/* indicate completion of complete block compression */
 static int compress_ret;
+#ifdef CONFIG_DEBUG_MM_HEAPINFO
+static pid_t g_log_dump_pid;		/* PID of log_dump kernel thread */
+#endif
 
 /* Structures used to compress last partially filled block */
 static unsigned char *last_comp_block;
@@ -137,6 +140,7 @@ int log_dump_init(void)
 		ldpdbg("memory allocation failure\n");
 		return LOG_DUMP_MEM_FAIL;
 	}
+	DEBUG_SET_PID(node, g_log_dump_pid);
 
 	/* The buffers allocated below are required for log-dump till the 
 	 * device is shut down or restarted. So these buffers MUST NEVER
@@ -333,7 +337,7 @@ static int log_dump_tobuffer(char ch, size_t *free_size)
 			if (node == NULL) {
 				return LOG_DUMP_MEM_FAIL;
 			}
-
+			DEBUG_SET_PID(node, g_log_dump_pid);
 			compress_curbytes = 1;
 			node->arr[0] = ch;
 			sq_addlast((sq_entry_t *) node, &log_dump_chunks);
@@ -591,6 +595,11 @@ int log_dump(int argc, char *argv[])
 	attr.mq_maxmsg = 32;
 	attr.mq_msgsize = sizeof(int);
 	attr.mq_flags = 0;
+
+#ifdef CONFIG_DEBUG_MM_HEAPINFO
+	/* Store the PID of log_dump kernel thread for memory attribution */
+	g_log_dump_pid = getpid();
+#endif
 
 	/* Create log dump message queue */
 	mq_fd = mq_open(LOG_DUMP_MSGQ, O_RDWR | O_CREAT, 0666, &attr);

--- a/os/mm/mm_heap/mm_heapinfo_utils.c
+++ b/os/mm/mm_heap/mm_heapinfo_utils.c
@@ -130,6 +130,46 @@ void heapinfo_update_node(FAR struct mm_allocnode_s *node, mmaddress_t caller_re
 }
 
 /****************************************************************************
+ * Name: heapinfo_set_pid
+ *
+ * Description:
+ * Set PID of the task to mem chunk
+ * This is useful when kernel modules allocate memory on behalf of other tasks
+ * and want to attribute the allocation to themselves.
+ * This function also updates per-PID and group accounting to maintain consistency.
+ ****************************************************************************/
+void heapinfo_set_pid(void *address, pid_t pid)
+{
+	struct mm_allocnode_s *node;
+	struct mm_heap_s *heap;
+	pid_t old_pid;
+
+	heap = mm_get_heap(address);
+	if (heap) {
+		node = (struct mm_allocnode_s *)((char *)address - SIZEOF_MM_ALLOCNODE);
+		DEBUGASSERT(mm_takesemaphore(heap));
+		
+		old_pid = node->pid;
+		if (old_pid != pid) {
+			/* Subtract from old PID's accounting */
+			heapinfo_subtract_size(heap, old_pid, node->size);
+			heapinfo_update_total_size(heap, (-1) * node->size, old_pid);
+			
+			/* Update node PID */
+			node->pid = pid;
+			
+			/* Add to new PID's accounting */
+			heapinfo_add_size(heap, pid, node->size);
+			heapinfo_update_total_size(heap, node->size, pid);
+		}
+		
+		mm_givesemaphore(heap);
+	} else {
+		mdbg("Failed to set pid, heap not found. addr:%x\n", address);
+	}
+}
+
+/****************************************************************************
  * Name: heapinfo_set_caller_addr
  *
  * Description:


### PR DESCRIPTION
Problem:
When CONFIG_DEBUG_MM_HEAPINFO is enabled, the memory allocation node stores the PID of the currently running task to identify the memory owner. The log_dump module is a shared kernel infrastructure that maintains a ring buffer for system logs. Multiple applications can trigger log operations which internally cause memory allocations in the log_dump module. Since log_dump_save() executes in the calling application's context, kmm_malloc() correctly attributes the memory to that application. However, this memory logically belongs to the log_dump module, not the caller. When multiple applications trigger logging, the log_dump memory gets scattered across different applications' memory statistics, causing confusing reports and false leak alerts when those applications terminate.

Solution:
Add a new API heapinfo_set_pid() and corresponding DEBUG_SET_PID() macro that allows kernel modules to explicitly re-attribute allocated memory to their own identity after the initial allocation, with proper accounting updates.

Changes:
1. mm/mm_heap/mm_heapinfo_utils.c: Add heapinfo_set_pid() function
2. include/tinyara/mm/mm.h: Add DEBUG_SET_PID() macro and declaration
3. kernel/log_dump/log_dump.c: Use DEBUG_SET_PID() to set correct PID for all kmm_malloc() allocations

Design Decisions:
- Follow existing pattern of DEBUG_SET_CALLER_ADDR() for consistency
- Use a no-op macro when CONFIG_DEBUG_MM_HEAPINFO is disabled to avoid any overhead in release builds
- Store log_dump thread's PID at kernel thread initialization and reuse it for all subsequent allocations
- The API is generic and can be used by other kernel modules with similar requirements

Accounting Consistency: The heapinfo_set_pid() function maintains consistency between node metadata and per-PID/group accounting by:
- Subtracting allocation size from old PID's alloc_list and group stats
- Updating node->pid to the new PID
- Adding allocation size to new PID's alloc_list and group stats

This ensures that heapinfo_add_size() and heapinfo_subtract_size() operations during allocation and free remain balanced for both PIDs.

Impact:
- Memory allocated by log_dump module is now correctly attributed to the log_dump kernel thread
- No impact when CONFIG_DEBUG_MM_HEAPINFO is not enabled
- API is reusable by other kernel modules that need similar functionality
- Per-PID and group accounting remains consistent throughout allocation lifecycle

TC1: Flat build (rtl8730e)
log Dump pid = 13

13 |     4 | 10216 |     12496 |    331808 | log_dump()

0x601755f0 |     4128 |   A    | 0x e025bf3 |  13   |
0x60176610 |     4128 |   A    | 0x e025bf3 |  13   |

TC2: Loadable build (rtl8730e)
log dump pid: 15

15 |     4 | 10216 |     12496 |    331808 |   kernel | log_dump()

0x603a57e0 |     4128 |   A    | 0x e023003 |  15   |
0x603a6800 |     4128 |   A    | 0x e023003 |  15   |
0x603a7820 |     4128 |   A    | 0x e023003 |  15   |

Signed-Off By: Vivek Jain (vivek1.j@samsung.com)