### PR TITLE
os/arch/arm/src/armino: software-extended watchdog timeout period

### DIFF
--- a/os/arch/arm/src/armino/Kconfig
+++ b/os/arch/arm/src/armino/Kconfig
@@ -73,3 +73,21 @@ config ARMINO_I2S_ROLE_MASTER
 endif
 
 endmenu
+
+if WATCHDOG
+config ARMINO_WDG_SLICE_MAX_MS
+	int "Max WDT slice (ms) for software-extended timeout"
+	default 30000
+	range 1 32767
+	---help---
+		Hardware watchdog is reloaded in slices no longer than this value
+		(and never longer than the chip-specific hardware limit), so the
+		logical timeout can exceed one hardware period.
+
+config ARMINO_WDG_MAX_SOFT_TIMEOUT_MS
+	int "Max logical watchdog timeout (ms)"
+	default 300000
+	range 1 86400000
+	---help---
+		Upper bound for WDIOC_SETTIMEOUT / settimeout in milliseconds.
+endif

--- a/os/arch/arm/src/armino/armino_watchdog_lowerhalf.c
+++ b/os/arch/arm/src/armino/armino_watchdog_lowerhalf.c
@@ -66,6 +66,27 @@
 
 #ifdef CONFIG_WATCHDOG
 
+extern uint32_t sys_hal_nmi_wdt_get_clk_div(void);
+
+#if !defined(CONFIG_ARMINO_WDG_SLICE_MAX_MS) || (CONFIG_ARMINO_WDG_SLICE_MAX_MS < 1)
+#define ARMINO_WDG_SLICE_CAP_MS 30000u
+#else
+#define ARMINO_WDG_SLICE_CAP_MS ((uint32_t)CONFIG_ARMINO_WDG_SLICE_MAX_MS)
+#endif
+
+#if !defined(CONFIG_ARMINO_WDG_MAX_SOFT_TIMEOUT_MS) || (CONFIG_ARMINO_WDG_MAX_SOFT_TIMEOUT_MS < 1)
+#define ARMINO_WDG_MAX_SOFT_MS 300000u
+#else
+#define ARMINO_WDG_MAX_SOFT_MS ((uint32_t)CONFIG_ARMINO_WDG_MAX_SOFT_TIMEOUT_MS)
+#endif
+
+#define ARMINO_WDG_NMI_DEBOUNCE_MS 100u
+/* When last slice is <= debounce (incl. 100 ms logical timeout), re-arm HW WDT
+ * with this window before PANIC() so assert / stack dump can finish; capped by
+ * hw_max. Examples: 30001 ms -> 1 ms tail; 100 ms single-slice.
+ */
+#define ARMINO_WDG_PANIC_PREARM_MS 2000u
+
 #define WDT_STOP	0
 #define WDT_START	1
 #define WDT_PAUSE	2
@@ -86,6 +107,11 @@ struct armino_wdg_lowerhalf_s {
 	uint32_t start_tick;		/* Use to calculate timeleft before timeout */
 	uint32_t pause_start_tick;	/* Record the start tick of watchdog timer on pause */
 	uint32_t total_pause_duration;	/* Record the total duration of watchdog timer on pause */
+	uint32_t wdg_slice_ms;		/* Body slice (ms) for multi-NMI extension */
+	uint32_t wdg_last_slice_ms;	/* Final slice (ms) */
+	uint32_t wdg_nmi_total;		/* NMIs until logical expiry (>=1 when running) */
+	uint32_t wdg_nmi_seen;		/* NMIs handled in current epoch */
+	uint32_t wdg_hw_armed_ms;	/* Period passed to last bk_wdt_start(); debounce uses this */
 	bool int_mode;				/* True for timeout interrupt mode on */
 };
 
@@ -99,10 +125,17 @@ static int armino_wdg_getstatus(FAR struct watchdog_lowerhalf_s *lower, FAR stru
 static int armino_wdg_settimeout(FAR struct watchdog_lowerhalf_s *lower, uint32_t timeout);
 static xcpt_t armino_wdg_capture(FAR struct watchdog_lowerhalf_s *lower, xcpt_t handler);
 static int armino_wdg_ioctl(FAR struct watchdog_lowerhalf_s *lower, int cmd, unsigned long arg);
+static uint32_t armino_wdt_hw_max_ms(void);
+static void armino_wdg_recalc_segments(FAR struct armino_wdg_lowerhalf_s *priv, uint32_t logical_ms);
+static void armino_wdg_program_first_slice(FAR struct armino_wdg_lowerhalf_s *priv, uint32_t logical_ms);
+static void armino_wdg_panic_arm_slack(FAR struct armino_wdg_lowerhalf_s *priv);
 
 /****************************************************************************
  * Private Data
  ****************************************************************************/
+
+static uint64_t g_wdg_nmi_last_ms;
+
 const struct watchdog_ops_s g_wdgops = {
 	.start = armino_wdg_start,
 	.stop = armino_wdg_stop,
@@ -116,6 +149,145 @@ const struct watchdog_ops_s g_wdgops = {
 /****************************************************************************
  * Private Functions
  ****************************************************************************/
+
+/****************************************************************************
+ * Name: armino_wdt_hw_max_ms
+ *
+ * Description:
+ *   Max milliseconds valid for bk_wdt_start such that wdt_ll_set_period's
+ *   internal multiply-by-multi does not exceed 16-bit period.
+ *
+ ****************************************************************************/
+
+static uint32_t armino_wdt_hw_max_ms(void)
+{
+	uint32_t nmi_wdt_clk_div = sys_hal_nmi_wdt_get_clk_div();
+	uint32_t multi = 1;
+
+	switch (nmi_wdt_clk_div) {
+	case 0:
+		multi = 16;
+		break;
+	case 1:
+		multi = 8;
+		break;
+	case 2:
+		multi = 4;
+		break;
+	case 3:
+		multi = 2;
+		break;
+	default:
+		multi = 1;
+		break;
+	}
+
+	return 0xFFFFu / multi;
+}
+
+/****************************************************************************
+ * Name: armino_wdg_recalc_segments
+ *
+ * Description:
+ *   Derive slice / last / nmi_total from logical timeout T (milliseconds).
+ *
+ ****************************************************************************/
+
+static void armino_wdg_recalc_segments(FAR struct armino_wdg_lowerhalf_s *priv, uint32_t logical_ms)
+{
+	uint32_t hw_max;
+	uint32_t slice_cap;
+	uint32_t n;
+
+	if (logical_ms == 0) {
+		priv->wdg_slice_ms = 0;
+		priv->wdg_last_slice_ms = 0;
+		priv->wdg_nmi_total = 1;
+		priv->wdg_nmi_seen = 0;
+		priv->wdg_hw_armed_ms = 0;
+		g_wdg_nmi_last_ms = 0;
+		return;
+	}
+
+	hw_max = armino_wdt_hw_max_ms();
+	slice_cap = ARMINO_WDG_SLICE_CAP_MS;
+	if (slice_cap > hw_max) {
+		slice_cap = hw_max;
+	}
+
+	if (slice_cap > logical_ms) {
+		slice_cap = logical_ms;
+	}
+
+	n = (logical_ms + slice_cap - 1u) / slice_cap;
+	if (n == 0) {
+		n = 1;
+	}
+
+	priv->wdg_slice_ms = slice_cap;
+	priv->wdg_nmi_total = n;
+	priv->wdg_last_slice_ms = logical_ms - (n - 1u) * slice_cap;
+	if (priv->wdg_last_slice_ms == 0) {
+		priv->wdg_last_slice_ms = slice_cap;
+	}
+
+	priv->wdg_nmi_seen = 0;
+	g_wdg_nmi_last_ms = 0;
+}
+
+/****************************************************************************
+ * Name: armino_wdg_program_first_slice
+ *
+ * Description:
+ *   Program hardware for first slice after recalc.
+ *
+ ****************************************************************************/
+
+static void armino_wdg_program_first_slice(FAR struct armino_wdg_lowerhalf_s *priv, uint32_t logical_ms)
+{
+	if (priv->wdg_nmi_total == 1u) {
+		(void)bk_wdt_start(logical_ms);
+		priv->wdg_hw_armed_ms = logical_ms;
+	} else {
+		(void)bk_wdt_start(priv->wdg_slice_ms);
+		priv->wdg_hw_armed_ms = priv->wdg_slice_ms;
+	}
+}
+
+/****************************************************************************
+ * Name: armino_wdg_panic_arm_slack
+ *
+ * Description:
+ *   When the last logical slice is very short, the HW period after the final
+ *   NMI is too small for PANIC/assert printing; re-arm with a longer window.
+ *
+ ****************************************************************************/
+
+static void armino_wdg_panic_arm_slack(FAR struct armino_wdg_lowerhalf_s *priv)
+{
+	uint32_t arm_ms;
+	uint32_t hw_max;
+
+	/* Use > debounce (not >=): logical 100 ms is last_slice_ms==100 and must
+	 * still get a longer HW window before PANIC(), otherwise dump is truncated.
+	 */
+	if (priv->wdg_last_slice_ms == 0u ||
+	    priv->wdg_last_slice_ms > ARMINO_WDG_NMI_DEBOUNCE_MS) {
+		return;
+	}
+
+	hw_max = armino_wdt_hw_max_ms();
+	arm_ms = ARMINO_WDG_PANIC_PREARM_MS;
+	if (arm_ms > hw_max) {
+		arm_ms = hw_max;
+	}
+	if (arm_ms < 1u) {
+		return;
+	}
+
+	(void)bk_wdt_start(arm_ms);
+	priv->wdg_hw_armed_ms = arm_ms;
+}
 
 /****************************************************************************
  * Name: armino_nmi_interrupt
@@ -141,15 +313,72 @@ static int armino_nmi_interrupt(int irq, void *context, FAR void *arg)
 		return -ENODEV;
 	}
 
-	if (s_nmi_occur)
-	{
+	if (s_nmi_occur) {
 		aon_pmu_drv_wdt_change_not_rosc_clk();
 		aon_pmu_drv_wdt_rst_dev_enable();
-		while(1);
+		while (1) {
+		}
 	}
 
-	if(REBOOT_TAG_REQ == sys_get_reboot_tag()) {
-		while(1);
+	if (REBOOT_TAG_REQ == sys_get_reboot_tag()) {
+		while (1) {
+		}
+	}
+
+	if (priv->wdt_status == WDT_START && priv->wdg_nmi_total > 0u) {
+		uint64_t now_ms;
+		uint64_t prev_ms;
+
+		now_ms = ((uint64_t)bk_aon_rtc_get_current_tick(AON_RTC_ID_1) * 1000ULL) /
+				 (uint64_t)bk_rtc_get_clock_freq();
+		prev_ms = g_wdg_nmi_last_ms;
+		/* Drop duplicate NMI edges shortly after arming a long slice. The legacy
+		 * debounce below disables itself while 0 < seen < total, so a spurious
+		 * second NMI right after bk_wdt_start(20000) could bump seen twice and
+		 * falsely expire the logical window. If armed slice > debounce window,
+		 * a real timeout cannot occur within debounce_ms; feed and ignore.
+		 * Final slices <= ARMINO_WDG_NMI_DEBOUNCE_MS still rely on the next
+		 * check so legitimate sub-debounce fires are not dropped.
+		 */
+		if (prev_ms != 0u && (now_ms - prev_ms) < ARMINO_WDG_NMI_DEBOUNCE_MS &&
+		    priv->wdg_hw_armed_ms > ARMINO_WDG_NMI_DEBOUNCE_MS) {
+			g_wdg_nmi_last_ms = now_ms;
+			(void)bk_wdt_feed();
+			s_nmi_occur = false;
+			return OK;
+		}
+		/* Do not debounce legitimate slice-chain NMIs: the next fire can be
+		 * much sooner than ARMINO_WDG_NMI_DEBOUNCE_MS (e.g. last slice 1 ms
+		 * when logical_ms == slice_cap + 1). Treating that as bounce only
+		 * feeds the WDT and breaks multi-slice expiry (possible hard fault).
+		 */
+		if (prev_ms != 0u && (now_ms - prev_ms) < ARMINO_WDG_NMI_DEBOUNCE_MS &&
+		    !(priv->wdg_nmi_seen > 0u && priv->wdg_nmi_seen < priv->wdg_nmi_total)) {
+			g_wdg_nmi_last_ms = now_ms;
+			(void)bk_wdt_feed();
+			s_nmi_occur = false;
+			return OK;
+		}
+
+		g_wdg_nmi_last_ms = now_ms;
+		priv->wdg_nmi_seen++;
+
+		if (priv->wdg_nmi_seen < priv->wdg_nmi_total) {
+			uint32_t next_ms;
+
+			if (priv->wdg_nmi_seen < priv->wdg_nmi_total - 1u) {
+				next_ms = priv->wdg_slice_ms;
+			} else {
+				next_ms = priv->wdg_last_slice_ms;
+			}
+
+			(void)bk_wdt_start(next_ms);
+			priv->wdg_hw_armed_ms = next_ms;
+			s_nmi_occur = false;
+			return OK;
+		}
+
+		priv->wdg_nmi_seen = 0;
 	}
 
 	s_nmi_occur = true;
@@ -160,28 +389,28 @@ static int armino_nmi_interrupt(int irq, void *context, FAR void *arg)
 		* about 8 ticks.
 		*/
 		bk_misc_set_reset_reason(RESET_SOURCE_WATCHDOG);
-		if (priv->handler) 
-		{
+		if (priv->handler) {
 			bk_wdt_feed();
 			priv->handler(irq, context, NULL);
 		}
 
 	} else {
 
-        (void)irqsave();
-        bk_wdt_feed();
-		if(REBOOT_TAG_REQ != sys_get_reboot_tag()) 
-		{
+		(void)irqsave();
+		bk_wdt_feed();
+		armino_wdg_panic_arm_slack(priv);
+		if (REBOOT_TAG_REQ != sys_get_reboot_tag()) {
 			bk_misc_set_reset_reason(RESET_SOURCE_WATCHDOG);
 		}
 		aon_pmu_drv_wdt_change_not_rosc_clk();
 		aon_pmu_drv_wdt_rst_dev_enable();
-        PANIC();
-		while(1);
+		PANIC();
+		while (1) {
+		}
 	}
 
 	return OK;
-	
+
 }
 /****************************************************************************
  * Name: armino_wdg_start
@@ -206,11 +435,13 @@ static int armino_wdg_start(FAR struct watchdog_lowerhalf_s *lower)
 	}
 	if (priv->wdt_status == WDT_STOP) {
 		/* Start watchdog timer */
-		bk_wdt_start(priv->timeout_ms);
+		armino_wdg_recalc_segments(priv, priv->timeout_ms);
+		armino_wdg_program_first_slice(priv, priv->timeout_ms);
 		priv->wdt_status = WDT_START;
 		priv->start_tick = bk_aon_rtc_get_current_tick(AON_RTC_ID_1);	// Record time right after wdt start
-		priv->pause_start_tick = 0; 
+		priv->pause_start_tick = 0;
 		priv->total_pause_duration = 0;
+		priv->timeout_left = priv->timeout_ms;	/* epoch for GETSTATUS timeleft */
 		return OK;
 	}
 
@@ -241,6 +472,10 @@ static int armino_wdg_stop(FAR struct watchdog_lowerhalf_s *lower)
 
 	/* Stop watchdog timer */
 	close_wdt();
+	priv->wdg_nmi_total = 0;
+	priv->wdg_nmi_seen = 0;
+	priv->wdg_hw_armed_ms = 0;
+	g_wdg_nmi_last_ms = 0;
 	priv->wdt_status = WDT_STOP;
 
 	return OK;
@@ -270,13 +505,13 @@ static int armino_wdg_keepalive(FAR struct watchdog_lowerhalf_s *lower)
 		return -ENODEV;
 	}
 	if (priv->wdt_status == WDT_START) {
-		/* Petting the dog */
-		bk_wdt_feed();
-
-		/* Update start time and reset on_pause_duration */
+		/* Petting the dog: restart logical window from full timeout */
 		priv->start_tick = bk_aon_rtc_get_current_tick(AON_RTC_ID_1);
-		priv->pause_start_tick = 0; 
+		priv->pause_start_tick = 0;
 		priv->total_pause_duration = 0;
+		priv->timeout_left = priv->timeout_ms;
+		armino_wdg_recalc_segments(priv, priv->timeout_ms);
+		armino_wdg_program_first_slice(priv, priv->timeout_ms);
 		return OK;
 	}
 
@@ -322,10 +557,23 @@ static int armino_wdg_getstatus(FAR struct watchdog_lowerhalf_s *lower, FAR stru
 		status->flags |= WDFLAGS_WAIT;
 		status->timeleft = priv->timeout_left;
 	} else {
-		uint32_t time_elapse;
+		uint32_t time_elapse_ms;
+		uint64_t now_tick;
+		uint64_t elapsed_ticks;
 
-		time_elapse = ((bk_aon_rtc_get_current_tick(AON_RTC_ID_1) - priv->start_tick - priv->total_pause_duration) * 1000) / bk_rtc_get_clock_freq();
-		status->timeleft = status->timeout - time_elapse;
+		/* Remaining in the current arm: timeout_left at last start/resume/keepalive
+		 * minus wall time since start_tick. Do not subtract total_pause_duration here:
+		 * RESUME resets start_tick but used to leave total_pause_duration set, which
+		 * caused unsigned underflow and bogus timeleft.
+		 */
+		now_tick = (uint64_t)bk_aon_rtc_get_current_tick(AON_RTC_ID_1);
+		elapsed_ticks = now_tick - (uint64_t)priv->start_tick;
+		time_elapse_ms = (uint32_t)((elapsed_ticks * 1000ULL) / (uint64_t)bk_rtc_get_clock_freq());
+		if (time_elapse_ms > priv->timeout_left) {
+			time_elapse_ms = priv->timeout_left;
+		}
+
+		status->timeleft = priv->timeout_left - time_elapse_ms;
 
 		/* Return ACTIVE if watchdog timer is started */
 		if (priv->wdt_status == WDT_START) {
@@ -359,13 +607,19 @@ static int armino_wdg_settimeout(FAR struct watchdog_lowerhalf_s *lower, uint32_
 		return -ENODEV;
 	}
 
+	if (timeout > ARMINO_WDG_MAX_SOFT_MS) {
+		return -EINVAL;
+	}
+
 	/*  Reset the watchdog timer with new timeout value */
 	priv->timeout_ms = timeout;
 
 	/* Re-start watchdog only if the status is WDT_START */
 	if (priv->wdt_status == WDT_START) {
-		bk_wdt_start(priv->timeout_ms);
+		armino_wdg_recalc_segments(priv, priv->timeout_ms);
+		armino_wdg_program_first_slice(priv, priv->timeout_ms);
 		priv->start_tick = bk_aon_rtc_get_current_tick(AON_RTC_ID_1);	// Record time right after wdt start
+		priv->timeout_left = priv->timeout_ms;
 	}
 
 	return OK;
@@ -408,11 +662,23 @@ static xcpt_t armino_wdg_capture(FAR struct watchdog_lowerhalf_s *lower, xcpt_t 
 	priv->handler = handler;
 
 	/* Set to default RESET_MODE first */
-	if (priv->wdt_status == WDT_START) {	// Skip the timeout_left calculation if the status is WDT_PAUSE
-		priv->timeout_left = priv->timeout_ms - ((bk_aon_rtc_get_current_tick(AON_RTC_ID_1) - priv->start_tick - priv->total_pause_duration) * 1000 / bk_rtc_get_clock_freq());
+	if (priv->wdt_status == WDT_START) {
+		uint64_t now_tick = (uint64_t)bk_aon_rtc_get_current_tick(AON_RTC_ID_1);
+		uint64_t elapsed_ticks = now_tick - (uint64_t)priv->start_tick;
+		uint32_t time_elapse_ms = (uint32_t)((elapsed_ticks * 1000ULL) / (uint64_t)bk_rtc_get_clock_freq());
+
+		if (time_elapse_ms > priv->timeout_left) {
+			time_elapse_ms = priv->timeout_left;
+		}
+
+		priv->timeout_left -= time_elapse_ms;
 	}
 	// watchdog_init(priv->timeout_left);	// Re-init watchdog with remaining timeout
 	priv->timeout_ms = priv->timeout_left;
+	if (priv->timeout_ms > ARMINO_WDG_MAX_SOFT_MS) {
+		priv->timeout_ms = ARMINO_WDG_MAX_SOFT_MS;
+	}
+
 	priv->int_mode = false;
 
 	/* Change to INT_MODE if handler exists */
@@ -423,10 +689,12 @@ static xcpt_t armino_wdg_capture(FAR struct watchdog_lowerhalf_s *lower, xcpt_t 
 
 	/* Re-start watchdog only if the status is WDT_START */
 	if (priv->wdt_status == WDT_START) {
-		bk_wdt_start(priv->timeout_ms);
+		armino_wdg_recalc_segments(priv, priv->timeout_ms);
+		armino_wdg_program_first_slice(priv, priv->timeout_ms);
 		priv->start_tick = bk_aon_rtc_get_current_tick(AON_RTC_ID_1);	// Record time right after wdt start
-		priv->pause_start_tick = 0; 
+		priv->pause_start_tick = 0;
 		priv->total_pause_duration = 0;
+		priv->timeout_left = priv->timeout_ms;
 	}
 
 	return oldhandler;
@@ -454,7 +722,6 @@ static xcpt_t armino_wdg_capture(FAR struct watchdog_lowerhalf_s *lower, xcpt_t 
 static int armino_wdg_ioctl(FAR struct watchdog_lowerhalf_s *lower, int cmd, unsigned long arg)
 {
 	struct armino_wdg_lowerhalf_s *priv = (struct armino_wdg_lowerhalf_s *)lower;
-	uint32_t time_elapse;
 	DEBUGASSERT(priv);
 	if (!priv) {
 		return -ENODEV;
@@ -462,11 +729,22 @@ static int armino_wdg_ioctl(FAR struct watchdog_lowerhalf_s *lower, int cmd, uns
 
 	switch (cmd) {
 	case WDIOC_PAUSE: {
-		/* Pause watchdog and get remaining timeout */
-		time_elapse = ((bk_aon_rtc_get_current_tick(AON_RTC_ID_1) - priv->start_tick - priv->total_pause_duration) * 1000) / bk_rtc_get_clock_freq();	// Get time elapse in ms
+		uint64_t now_tick;
+		uint64_t elapsed_ticks;
+		uint32_t time_elapse_ms;
+
+		/* Freeze remaining = epoch timeout_left minus time since start_tick */
+		now_tick = (uint64_t)bk_aon_rtc_get_current_tick(AON_RTC_ID_1);
+		elapsed_ticks = now_tick - (uint64_t)priv->start_tick;
+		time_elapse_ms = (uint32_t)((elapsed_ticks * 1000ULL) / (uint64_t)bk_rtc_get_clock_freq());
+		if (time_elapse_ms > priv->timeout_left) {
+			time_elapse_ms = priv->timeout_left;
+		}
+
+		priv->timeout_left -= time_elapse_ms;
+
 		armino_wdg_stop((struct watchdog_lowerhalf_s *)priv);
-		priv->pause_start_tick = bk_aon_rtc_get_current_tick(AON_RTC_ID_1);	// Record PAUSE start time
-		priv->timeout_left = priv->timeout_ms - time_elapse;	// Record remaining timeout
+		priv->pause_start_tick = bk_aon_rtc_get_current_tick(AON_RTC_ID_1);
 		priv->wdt_status = WDT_PAUSE;
 	}
 	break;
@@ -474,12 +752,13 @@ static int armino_wdg_ioctl(FAR struct watchdog_lowerhalf_s *lower, int cmd, uns
 	case WDIOC_RESUME: {
 		/* Pre-assumption: the WDIOC_PAUSE can only be resumed by WDIOC_RESUME */
 		if (priv->wdt_status == WDT_PAUSE) {
-			uint32_t pause_duration = bk_aon_rtc_get_current_tick(AON_RTC_ID_1) - priv->pause_start_tick;
-			priv->total_pause_duration += pause_duration;
+			priv->total_pause_duration = 0;
 			priv->pause_start_tick = 0;
 			priv->wdt_status = WDT_START;
-			bk_wdt_start(priv->timeout_left);
-			
+			armino_wdg_recalc_segments(priv, priv->timeout_left);
+			armino_wdg_program_first_slice(priv, priv->timeout_left);
+			priv->start_tick = bk_aon_rtc_get_current_tick(AON_RTC_ID_1);
+			/* timeout_left unchanged: remaining ms for this arm (GETSTATUS epoch) */
 		}
 	}
 	break;
@@ -503,7 +782,7 @@ static int armino_wdg_ioctl(FAR struct watchdog_lowerhalf_s *lower, int cmd, uns
 int armino_wdg_initialize(const char *devpath)
 {
 	struct armino_wdg_lowerhalf_s *priv = NULL;
-	priv = (struct armino_wdg_lowerhalf_s *)kmm_malloc(sizeof(struct armino_wdg_lowerhalf_s));
+	priv = (struct armino_wdg_lowerhalf_s *)kmm_zalloc(sizeof(struct armino_wdg_lowerhalf_s));
 
 	if (!priv) {
 		llvdbg("wdg_lowerhalf_s allocation error.\n");


### PR DESCRIPTION
- Increment nmi_seen on each WDT expiry NMI (only when watchdog is logically STARTed and extension state is valid).
- If nmi_seen < n: intermediate — bk_wdt_start(next_slice_ms), clear s_nmi_occur (or equivalent) so the “second NMI hard hang” does not trigger on legitimate chained expiries; if int_mode with a user handler, do not call the handler on intermediates; return.
- If nmi_seen == n``: **final** — **reset nmi_seen`, then existing reset / PANIC / int_mode handler path.