### PR TITLE
os/board/bk7239n, wpa_supplicant: report fine-grained WPA state during WiFi join process

### DIFF
--- a/os/board/bk7239n/src/bsp_adapter/src/net/bk_netmgr.c
+++ b/os/board/bk7239n/src/bsp_adapter/src/net/bk_netmgr.c
@@ -150,6 +150,41 @@ static int valid_ch_list[] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 36,
 static int valid_ch_list_size = sizeof(valid_ch_list)/sizeof(valid_ch_list[0]);
 
 bool g_sta_is_start = 0;
+
+static void bk_netmgr_log_sta_connect_failure(uint32_t reason_code, uint8_t last_join_wpa_state)
+{
+        if (reason_code == WIFI_REASON_NO_AP_FOUND || last_join_wpa_state == WPA_SCANNING) {
+                return;
+        }
+
+        if (reason_code == WIFI_REASON_WRONG_PASSWORD ||
+                reason_code == WIFI_REASON_4WAY_HANDSHAKE_TIMEOUT ||
+                last_join_wpa_state == WPA_ASSOCIATED ||
+                last_join_wpa_state == WPA_4WAY_HANDSHAKE) {
+                return;
+        }
+
+        if (last_join_wpa_state == WPA_AUTHENTICATING ||
+                reason_code == WIFI_REASON_IEEE_802_1X_AUTH_FAILED ||
+                reason_code == WIFI_REASON_PREV_AUTH_NOT_VALID) {
+                return;
+        }
+
+        if (last_join_wpa_state == WPA_ASSOCIATING ||
+                reason_code == WIFI_REASON_STA_REQ_ASSOC_WITHOUT_AUTH ||
+                reason_code == WIFI_REASON_CLASS3_FRAME_FROM_NONASSOC_STA) {
+        }
+}
+
+static void bk_netmgr_log_sta_disconnection(uint32_t reason_code, bool local_generated)
+{
+        if (reason_code == WIFI_REASON_BEACON_LOST) {
+                return;
+        }
+
+        if (!local_generated && reason_code != WIFI_REASON_DISCONNECT_BY_APP) {
+        }
+}
 /*
  * Callback
 */
@@ -201,6 +236,8 @@ void rtw_mutex_put(_mutex *pmutex)
 void beken_report_wrong_password( void )
 {
     auth_fail_cnt++;
+    bk_netmgr_log_sta_connect_failure(WIFI_REASON_WRONG_PASSWORD,
+                                      bk_get_last_join_wpa_state());
     //set80211_sta_error_flag(CLP_STA_WRONG_PASSWORD);
     if (auth_fail_cnt%2 == 1) {
         trwifi_post_event(armino_dev_wlan0, LWNL_EVT_STA_DISCONNECTED, NULL, 0);
@@ -925,6 +962,7 @@ int beken_wifi_event_cb(void *arg, event_module_t event_module,
     case EVENT_WIFI_STA_CONNECTED:
         sta_connected = (wifi_event_sta_connected_t *)event_data;
         BK_WIFI_LOGI("BEKEN_WIFI_EVENT", "BK STA connected %s\n", sta_connected->ssid);
+        auth_fail_cnt = 0;
         // set ap info start
 		g_sta_is_start = 1;
 #if 0
@@ -952,8 +990,12 @@ int beken_wifi_event_cb(void *arg, event_module_t event_module,
         ndbg("BK STA disconnected, reason(%d)%s\n", sta_disconnected->disconnect_reason,
             sta_disconnected->local_generated ? ", local_generated" : "");
         if (g_sta_connecting) {
+            bk_netmgr_log_sta_connect_failure(sta_disconnected->disconnect_reason,
+                                              bk_get_last_join_wpa_state());
             trwifi_post_event(armino_dev_wlan0, LWNL_EVT_STA_CONNECT_FAILED, NULL, 0);
         } else {
+            bk_netmgr_log_sta_disconnection(sta_disconnected->disconnect_reason,
+                                            sta_disconnected->local_generated);
             trwifi_post_event(armino_dev_wlan0, LWNL_EVT_STA_DISCONNECTED, NULL, 0);
         }
         g_sta_connecting = false;
@@ -1420,13 +1462,19 @@ trwifi_result_e bk_wifi_netmgr_get_info(struct netdev *dev, trwifi_info *wifi_in
 trwifi_result_e bk_wifi_netmgr_get_wpa_supplicant_state(struct netdev *dev, trwifi_wpa_states *wpa_supplicant_state)
 {
     wifi_linkstate_reason_t wpas_state = mhdr_get_station_status();
+    uint8_t last_join_wpa_state = bk_get_last_join_wpa_state();
     
     switch (wpas_state.state) {
         case WIFI_LINKSTATE_STA_IDLE:
         wpa_supplicant_state->wpa_supplicant_state = WPA_INACTIVE;
         break;
         case WIFI_LINKSTATE_STA_CONNECTING:
-        wpa_supplicant_state->wpa_supplicant_state = WPA_ASSOCIATING;
+        if (last_join_wpa_state >= WPA_AUTHENTICATING &&
+            last_join_wpa_state < WPA_COMPLETED) {
+            wpa_supplicant_state->wpa_supplicant_state = last_join_wpa_state;
+        } else {
+            wpa_supplicant_state->wpa_supplicant_state = WPA_ASSOCIATING;
+        }
         break;
         case WIFI_LINKSTATE_STA_CONNECTED:
         wpa_supplicant_state->wpa_supplicant_state = WPA_COMPLETED;

--- a/os/board/bk7239n/src/components/bk_wifi/include/bk_private/bk_wifi.h
+++ b/os/board/bk7239n/src/components/bk_wifi/include/bk_private/bk_wifi.h
@@ -504,6 +504,8 @@ void demo_wifi_mem_apply_init(uint8_t module, uint8_t value);
 /* bk_wifi_rw  */
 void mhdr_set_station_status(wifi_linkstate_reason_t info);
 wifi_linkstate_reason_t mhdr_get_station_status(void);
+void bk_set_last_join_wpa_state(uint8_t state);
+uint8_t bk_get_last_join_wpa_state(void);
 void rwm_mgmt_set_vif_netif(uint8_t *mac, void *netif);
 int rw_msg_send_arp_msg(u8 vif_idx);
 

--- a/os/board/bk7239n/src/components/wpa_supplicant-2.10/wpa_supplicant/notify.c
+++ b/os/board/bk7239n/src/components/wpa_supplicant-2.10/wpa_supplicant/notify.c
@@ -51,9 +51,23 @@
 #include "bk_ef.h"
 #endif
 
-#if BK_SUPPLICANT
 extern uint32_t wpa_hostapd_no_password_connected(const uint8_t *addr);
-#endif
+static uint8_t g_last_join_wpa_state = WPA_DISCONNECTED;
+
+void bk_set_last_join_wpa_state(uint8_t state)
+{
+        g_last_join_wpa_state = state;
+}
+
+uint8_t bk_get_last_join_wpa_state(void)
+{
+        return g_last_join_wpa_state;
+}
+
+static int bk_is_join_progress_state(enum wpa_states state)
+{
+        return state >= WPA_AUTHENTICATING && state < WPA_COMPLETED;
+}
 
 int wpas_notify_supplicant_initialized(struct wpa_global *global)
 {
@@ -399,6 +413,16 @@ void wpas_notify_state_changed(struct wpa_supplicant *wpa_s,
 {
 	if (wpa_s->p2p_mgmt)
 		return;
+
+#if BK_SUPPLICANT
+        if (bk_is_join_progress_state(new_state)) {
+                bk_set_last_join_wpa_state((uint8_t)new_state);
+        } else if (new_state == WPA_DISCONNECTED && bk_is_join_progress_state(old_state)) {
+                bk_set_last_join_wpa_state((uint8_t)old_state);
+        } else if (new_state <= WPA_SCANNING) {
+                bk_set_last_join_wpa_state((uint8_t)new_state);
+        }
+#endif
 
 #ifdef CONFIG_DBUS
 	/* notify the new DBus API */

--- a/os/board/bk7239n/src/components/wpa_supplicant-2.10/wpa_supplicant/wpa_scan.c
+++ b/os/board/bk7239n/src/components/wpa_supplicant-2.10/wpa_supplicant/wpa_scan.c
@@ -1584,6 +1584,7 @@ int wpa_supplicant_req_scan(struct wpa_supplicant *wpa_s, int sec, int usec)
 				info.state = WIFI_LINKSTATE_STA_CONNECTING;
 				info.reason_code = WIFI_REASON_MAX;
 				mhdr_set_station_status(info);
+				bk_set_last_join_wpa_state((uint8_t)WPA_SCANNING);
 				wpa_s->auto_reconnect_count--;
 				eloop_register_timeout(sec, usec, wpa_supplicant_scan, wpa_s, NULL);
 			} else if (wpa_s->auto_reconnect_count == 0) {
@@ -2930,6 +2931,7 @@ wpa_supplicant_get_scan_results(struct wpa_supplicant *wpa_s,
 		linkinfo.state = WIFI_LINKSTATE_STA_DISCONNECTED;
 		linkinfo.reason_code= WIFI_REASON_NO_AP_FOUND;
 		mhdr_set_station_status(linkinfo);
+		bk_set_last_join_wpa_state((uint8_t)WPA_SCANNING);
 
 #ifdef CONFIG_AUTO_RECONNECT
 		if (!wpas_auto_reconnect_limited(wpa_s)) {


### PR DESCRIPTION

adapter requires more detailed WPA supplicant state reporting during the STA connection process.

Key changes:
- Track the actual WPA state in wpa_supplicant and expose it to the adapter layer.
- Return the real WPA sub-state when upper layer queries connection progress.
- Classify STA connect failure and disconnection by reason code and WPA state.
- Reset auth_fail_cnt on successful STA connection.