### PR TITLE
os/board/bk7239n: Fix the issue of not reboot after a security fault occur

### DIFF
--- a/os/board/bk7239n/src/middleware/arch/cm33/trap_base.c
+++ b/os/board/bk7239n/src/middleware/arch/cm33/trap_base.c
@@ -14,6 +14,7 @@
 
 #include <stdio.h>
 #include <stdint.h>
+#include <arch/reboot_reason.h>
 #include "boot.h"
 #include "sdkconfig.h"
 #include "reset_reason.h"
@@ -35,6 +36,7 @@
 #include <driver/flash_types.h>
 #include <driver/flash.h>
 
+#define BK_SECURE_FAULT_REBOOT_REASON   (REBOOT_BOARD_SPECIFIC4) /* TFM watch dog */
 
 #define MAX_DUMP_SYS_MEM_COUNT       (8)
 #define SOC_DTCM_DATA_SIZE           (0x4000)
@@ -815,15 +817,16 @@ static void NS_handle_securt_fault(uint32_t reset_reason, struct tfm_exception_i
         rtos_dump_system(msp, psp);
 
 
-        bk_reboot_ex(reset_reason);
+        up_reboot_reason_write(BK_SECURE_FAULT_REBOOT_REASON);
+        bk_reboot_reset_reason();
 
         while(g_enter_exception);
 
         // rtos_enable_int(int_level);
     } else {
 
-        bk_misc_set_reset_reason(reset_reason);
-        bk_wdt_force_reboot();
+        up_reboot_reason_write(BK_SECURE_FAULT_REBOOT_REASON);
+        bk_reboot_reset_reason();
     }
 }
 
@@ -831,6 +834,8 @@ void bk_security_donmain_notifies_non_security_domain_to_dump(uint32_t *reg)
 {
     // High security level will not dump the exception information.
     if (get_security_level() > LOW_SECURITY_LEVEL) { 
+        up_reboot_reason_write(BK_SECURE_FAULT_REBOOT_REASON);
+        bk_reboot_reset_reason();
         return;
     }
 
@@ -888,10 +893,6 @@ void bk_security_donmain_notifies_non_security_domain_to_dump(uint32_t *reg)
 
 void bk_security_to_nosecurity_dump_register_callback(void)
 {
-    if (get_security_level() >  LOW_SECURITY_LEVEL) {
-        return;
-    }
-    
     uint32_t callback_address = (uint32_t)(&bk_security_donmain_notifies_non_security_domain_to_dump);
     psa_register_dump_callback(callback_address, (uint32_t)&tfm_exception_info);
 }

--- a/os/board/bk7239n/src/middleware/driver/reset_reason/reset_reason.c
+++ b/os/board/bk7239n/src/middleware/driver/reset_reason/reset_reason.c
@@ -222,7 +222,7 @@ uint32_t bk_misc_get_reset_reason(void)
 	uint32_t misc_value;
 
 	if (s_start_type) {
-		if (s_start_type == 0x7f)
+		if ((s_start_type == 0x7f) || (s_start_type == 0x7d))
 		{
 			s_start_type += 0x80;
 		}
@@ -231,7 +231,7 @@ uint32_t bk_misc_get_reset_reason(void)
 	}
 
 	misc_value = aon_pmu_hal_get_reset_reason();
-	if (misc_value == 0x7f)
+	if ((misc_value == 0x7f) || (misc_value == 0x7d))
 	{
 		misc_value += 0x80;
 	}


### PR DESCRIPTION
Support rebooting when a security exception occurs, and configure the reset reason as REBOOT_BOARD_SPECIFIC4

I locally triggered a security exception, and after testing, it can restart normally, with the reboot reason being **REBOOT_BOARD_SPECIFIC4 （253）**

`System Information:
Version:
Platform: 5.0 Binary: 200204
Commit Hash: NA
Build User: [root@jun.pan](mailto:root@jun.pan)
Build Time: 2026-04-17 16:10:29 CST
System Time: 17 Apr 2026, 00:00:00 [s] UTC Hardware RTC Support
Failed to create Task Manager
This is WIFI App
TASH>>binary_manager_load_binary: Load success! [Name: app1] [Version: 190412] [Partition: A] [Text start : 0x1259f030] [Compressed Binary]
**[TFM] E (0) I: SF
[TFM] E (0) I:
psp_ns_p:0x0x702832a0
[TFM] 00000000: 00000000 700159F0 00000000 00000000 00000000 1225580B 1259F0A4 61000000
[TFM] 00000008: 1259F085 1225583D 702832E4 1217F3C1 00000000 00000000 00000000 00000000
[TFM] 00000010: DEADBEEF 702832EC 00000000 7665642F 64746D2F 636F6C62 5500366B 554454A6
[TFM] 00000018: 80002010 1217EC91 0000000E 000003E0 00000000 00020001 0000000**

[FORCE] main 0x200428d
[FORCE] Starting bootloader

efuse=8000000
[FORCE] verify start

[FORCE] do_boot_without_signing start

boot_param: line[359](https://support.bekencorp.com/issues/7180#fn359), CONFIG_NUM_APPS : 1
boot_param: line[424](https://support.bekencorp.com/issues/7180#fn424),BP0 crc verify ok
[FORCE] active_slot :0x0

[FORCE] normal slot :0x0

boot_param: slot=0 stored_crc=0xf4c94f3a computed_crc=0xf4c94f3a (full partition, size=0x0016c28c) attempt 1
[FORCE]
Jumping to the first slot
[FORCE] primary_off: 0x80000

[FORCE] do_boot_without_signing end vt: 0x2081000

M] config ppc and NSPE is coming
[flash]id=0xb4018
mpu_showtype: Unified MPU Regions: data=16 instr=0
[arch]Intialize random stack guard.
up_allocate_kheap: start = 0x70009480 size = 2583424
mm_initialize: Heap: start=0x70009480 size=2583424
mm_addregion: Region 1: base=0x70009480 size=2583424
up_add_kregion: Heap idx = 1 start = 0x380581e0 size = 40472
mm_initialize: Heap: start=0x380581e0 size=40472
mm_addregion: Region 1: base=0x380581e0 size=40464
[rosc]rosc rtc tick compensation start
**up_initialize: [Reboot Reason] : 253**
up_irqinitialize: irqenable
silent_reboot_set_mode: board boot with SILENT MODE.
[adc]invalid otp cwt value:[0]`