### PR TITLE
os/kernel/task: Fix for multiple exit scenario via task_exithook()

### DIFF
--- a/os/kernel/task/task_exithook.c
+++ b/os/kernel/task/task_exithook.c
@@ -553,9 +553,17 @@ void task_exithook(FAR struct tcb_s *tcb, int status, bool nonblocking)
 	 * that bit is set, then just exit doing nothing more..
 	 */
 
+	irqstate_t flags;
+
+	flags = enter_critical_section();
+
 	if ((tcb->flags & TCB_FLAG_EXIT_PROCESSING) != 0) {
+
+		leave_critical_section(flags);
 		return;
 	}
+
+	leave_critical_section(flags);
 
 #ifdef CONFIG_DEBUG
 	/* Save the terminated task/pthread's information for stack monitor and heapinfo. */
@@ -604,17 +612,8 @@ void task_exithook(FAR struct tcb_s *tcb, int status, bool nonblocking)
 	task_recover(tcb);
 
 	/* NOTE: signal handling needs to be done in a critical section. */
-#ifdef CONFIG_SMP
-	irqstate_t flags = enter_critical_section();
-#endif
 
-	/* Send the SIGCHILD signal to the parent task group */
-
-	task_signalparent(tcb, status);
-
-	/* Wakeup any tasks waiting for this task to exit */
-
-	task_exitwakeup(tcb, status);
+	flags = enter_critical_section();
 
 	/* If this is the last thread in the group, then flush all streams (File
 	 * descriptors will be closed when the TCB is deallocated).
@@ -630,6 +629,22 @@ void task_exithook(FAR struct tcb_s *tcb, int status, bool nonblocking)
 	if (!nonblocking) {
 		task_flushstreams(tcb);
 	}
+
+	/* This function can be re-entered in certain cases.  Set a flag
+	 * bit in the TCB to note that we have already completed this exit
+	 * processing.
+	 */
+
+	tcb->flags |= TCB_FLAG_EXIT_PROCESSING;
+
+	/* Send the SIGCHILD signal to the parent task group */
+
+	task_signalparent(tcb, status);
+
+	/* Wakeup any tasks waiting for this task to exit */
+
+	task_exitwakeup(tcb, status);
+
 
 #if defined(CONFIG_BINARY_MANAGER) && defined(CONFIG_APP_BINARY_SEPARATION)
 	/* Remove a tcb from binary list */
@@ -650,14 +665,5 @@ void task_exithook(FAR struct tcb_s *tcb, int status, bool nonblocking)
 	sig_cleanup(tcb);			/* Deallocate Signal lists */
 #endif
 
-#ifdef CONFIG_SMP
 	leave_critical_section(flags);
-#endif
-
-	/* This function can be re-entered in certain cases.  Set a flag
-	 * bit in the TCB to not that we have already completed this exit
-	 * processing.
-	 */
-
-	tcb->flags |= TCB_FLAG_EXIT_PROCESSING;
 }

--- a/os/kernel/task/task_terminate_unloaded.c
+++ b/os/kernel/task/task_terminate_unloaded.c
@@ -144,7 +144,12 @@ int task_terminate_unloaded(FAR struct tcb_s *tcb)
 #ifdef CONFIG_PREFERENCE
 	preference_clear_callbacks(tcb->pid);
 #endif
+
+	saved_state = enter_critical_section();
+
 	tcb->flags |= TCB_FLAG_EXIT_PROCESSING;
+
+	leave_critical_section(saved_state);
 
 	/* No need to release the unloading thread's stack,
 	 * because whole heap memory will be released at one go.


### PR DESCRIPTION
Description:
This patch prevents multiple exit of task via task_exithook(), in SMP case.

----------------------------------------------------------------------

AS-IS:
TCB_FLAG_EXIT_PROCESSING is bit set in tcb->flag to prevent multiple exit. But the checker and setter code are not protected and are being called at different places.
Checker: at the start of the function to return early if the flag is set. Setter: flag is set at the end of task_exithook(). This difference in exection of checker and setter opens a window of race where one process sets it, but another process has already passed the checker point.
In this race, both the processes may attempt to kill the same task, which leads to a multiple-exit scenario.

----------------------------------------------------------------------

LOGS:
log_csi_config: enable: 0
wifi_csi_mq_close: MQ cltask_sigchild: task: csifw_task_Main, tg_nchildren = 1 task_sigchild: task: task_manager, tg_nchildren = 0

security level: 0
=========================================================== Assertion details
=========================================================== Assertion failed CPU0 at file: task/task_exithook.c line 339 task: task_manager pid: 17 print_assert_detail: Assert location (PC) : 0x0e024eff check_assert_location: Code asserted in normal thread! =========================================================== Asserted task's stack details
=========================================================== check_sp_corruption: Current SP is User Thread SP: 60154490

----------------------------------------------------------------------

Fix: We move the setter code to the beginning of task_exithook() (just after the checker) and protect them within critical section to ensure atomicity.

----------------------------------------------------------------------