### PR TITLE
os/arch/arm/src/amebasmart: fix SPI freq after wakeup from PG

### DIFF
--- a/os/arch/arm/src/amebasmart/amebasmart_spi.c
+++ b/os/arch/arm/src/amebasmart/amebasmart_spi.c
@@ -85,6 +85,7 @@
 #define AMEBASMART_SPI_MASTER	0
 #define AMEBASMART_SPI_SLAVE	1
 #define SPI_DMA_MAX_BUFFER_SIZE 65535
+#define SPI_DEFAULT_FREQUENCY 1000000
 /************************************************************************************
  * Private Types
  ************************************************************************************/
@@ -233,6 +234,7 @@ static struct amebasmart_spidev_s g_spi0dev = {
 */
 
 	.spi_object = {0},
+	.frequency = SPI_DEFAULT_FREQUENCY,
 	.refs = 0,
 	.spi_idx = MBED_SPI0,
 	.spi_mosi = SPI0_MOSI,
@@ -292,6 +294,7 @@ static struct amebasmart_spidev_s g_spi1dev = {
 */
 
 	.spi_object = {0},
+	.frequency = SPI_DEFAULT_FREQUENCY,
 	.refs = 0,
 	.spi_idx = MBED_SPI1,
 	.spi_mosi = SPI1_MOSI,
@@ -1399,6 +1402,10 @@ static void amebasmart_spi_bus_initialize(struct amebasmart_spidev_s *priv, uint
 
 	spi_init(&priv->spi_object, priv->spi_mosi, priv->spi_miso, priv->spi_sclk, priv->spi_cs0);
 	spi_format(&priv->spi_object, priv->nbits, priv->mode, priv->role);
+	/*should only set the frequency when its in master mode*/
+	if (priv->role == AMEBASMART_SPI_MASTER) {
+		spi_frequency(&priv->spi_object, priv->frequency);
+	}
 	sem_init(&priv->exclsem, 0, 1);
 #ifdef CONFIG_AMEBASMART_SPI_DMA
 	sem_init(&priv->rxsem, 0, 0);


### PR DESCRIPTION
- when wakeup from PG, rtk_spi_resume re-initialize SPI, bsp layer uses SSI_StructInit that has an initial SPI_ClockDivider = 6, which is 100MHZ/6 = 16.6MHz
- g_spi0dev.frequency and g_spi1dev.frequency remain the old value before suspend, thus when amebasmart_spi_setfrequency is called, it did not enter the if condition, hence freq will not be set and remained as 16.6MHz.
- fix by resetting g_spi0dev.frequency and g_spi1dev.frequency to 0 during suspend, so that after wakeup, when SPI_SETFREQUENCY is called, it can set to new frequency