### PR TITLE
os/kernel/binary_manager: Expand bootparam format to add update reason

### DIFF
--- a/os/include/assert.h
+++ b/os/include/assert.h
@@ -236,6 +236,20 @@ extern char assert_info_str[CONFIG_STDIO_BUFFER_SIZE];
 #define assert ASSERT
 #endif
 
+/* Definition required for C11 compile-time assertion checking.  The
+ * static_assert macro simply expands to the _Static_assert keyword.
+ */
+
+#ifndef __cplusplus
+#if defined(__STDC_VERSION__) && __STDC_VERSION__  > 199901L
+#define static_assert _Static_assert
+#else
+#define static_assert(cond, msg) \
+	extern int (*__static_assert_function (void)) \
+	[!!sizeof (struct { int __error_if_negative: (cond) ? 2 : -1; })]
+#endif
+#endif
+
 /****************************************************************************
  * Included Files
  ****************************************************************************/

--- a/os/kernel/binary_manager/binary_manager_bootparam.c
+++ b/os/kernel/binary_manager/binary_manager_bootparam.c
@@ -18,6 +18,7 @@
 /****************************************************************************
  * Included Files
  ****************************************************************************/
+#include <stdint.h>
 #include <tinyara/config.h>
 #include <debug.h>
 #include <stdio.h>
@@ -60,18 +61,18 @@ void binary_manager_register_bppart(int part_num, int part_size)
 
 bool is_valid_bootparam(char *bootparam)
 {
-	binmgr_bpdata_t *bp_data = (binmgr_bpdata_t *)bootparam;
+	binmgr_bpdata_head_t *bp_head = (binmgr_bpdata_head_t *)bootparam;
 
-	if (!bp_data) {
+	if (!bp_head) {
 		bmdbg("Boot param is NULL\n");
 		return false;
-	} else if (bp_data->format_ver == 0 || bp_data->active_idx >= binary_manager_get_kdata()->part_count) {
-		bmdbg("Invalid data. ver: %u, active index: %u, addresses: %x, %x\n", bp_data->version, bp_data->active_idx, bp_data->address[0], bp_data->address[1]);
+	} else if ((bp_head->format_ver < BOOTPARAM_FORMAT_VERSION_1 || bp_head->format_ver > BOOTPARAM_FORMAT_VERSION_LATEST) || bp_head->active_idx >= binary_manager_get_kdata()->part_count) {
+		bmdbg("Invalid data. ver: %u, active index: %u, addresses: %x, %x\n", bp_head->version, bp_head->active_idx, bp_head->address[0], bp_head->address[1]);
 		return false;
 	}
 
-	if (bp_data->crc_hash != crc32((uint8_t *)bootparam + CHECKSUM_SIZE, BOOTPARAM_SIZE - CHECKSUM_SIZE)) {
-		bmdbg("Invalid crc32 value, crc32 %u, ver: %u, active index: %u, addresses: %x, %x\n", bp_data->crc_hash, bp_data->version, bp_data->active_idx, bp_data->address[0], bp_data->address[1]);
+	if (bp_head->crc_hash != crc32((uint8_t *)bootparam + CHECKSUM_SIZE, BOOTPARAM_SIZE - CHECKSUM_SIZE)) {
+		bmdbg("Invalid crc32 value, crc32 %u, ver: %u, active index: %u, addresses: %x, %x\n", bp_head->crc_hash, bp_head->version, bp_head->active_idx, bp_head->address[0], bp_head->address[1]);
 		return false;
 	}
 
@@ -112,6 +113,8 @@ int binary_manager_scan_bootparam(binmgr_bpinfo_t *bp_info)
 	int bp_idx;
 	uint32_t latest_ver = 0;
 	char *bootparam;
+	size_t update_reason_offset;
+	binmgr_bpdata_t scanned_bp_data;
 
 	if (bp_info == NULL) {
 		bmdbg("Invalid input bp_info\n");
@@ -150,14 +153,24 @@ int binary_manager_scan_bootparam(binmgr_bpinfo_t *bp_info)
 			continue;
 		}
 
-		bmdbg("BP%d is valid\n", bp_idx);
+		memcpy(&scanned_bp_data.head, bootparam, sizeof(scanned_bp_data.head));
+
+		/* Version 1 has no update reason and leaves the last byte as reserved. */
+		update_reason_offset = BOOTPARAM_SIZE - sizeof(scanned_bp_data.tail.bp_update_reason);
+		if (scanned_bp_data.head.format_ver < BOOTPARAM_FORMAT_VERSION_2 || ((uint8_t *)bootparam)[update_reason_offset] > BP_UPDATE_UNKNOWN) {
+			scanned_bp_data.tail.bp_update_reason = BP_UPDATE_UNKNOWN;
+		} else {
+			scanned_bp_data.tail.bp_update_reason = ((uint8_t *)bootparam)[update_reason_offset];
+		}
+
+		bmdbg("BP%d is valid. version: %u format: %u reason: %u\n", bp_idx, scanned_bp_data.head.version, scanned_bp_data.head.format_ver, scanned_bp_data.tail.bp_update_reason);
 
 		/* Update the latest version and index */
-		if (latest_ver < ((binmgr_bpdata_t *)bootparam)->version) {
-			latest_ver = ((binmgr_bpdata_t *)bootparam)->version;
+		if (latest_ver < scanned_bp_data.head.version) {
+			latest_ver = scanned_bp_data.head.version;
 			/* Update bootparam data */
 			bp_info->inuse_idx = bp_idx;
-			memcpy(&bp_info->bp_data, bootparam, sizeof(binmgr_bpdata_t));
+			memcpy(&bp_info->bp_data, &scanned_bp_data, sizeof(binmgr_bpdata_t));
 		}
 	}
 	close(fd);
@@ -189,7 +202,7 @@ int binary_manager_update_bpinfo(void)
 		/* Set scanned bootparam data to g_bp_info */
 		g_bp_info.inuse_idx = bp_info.inuse_idx;
 		g_bp_info.bp_data = bp_info.bp_data;
-		bmvdbg("BP[%d] ver: %u, active index: %u, addresses: %x, %x\n", g_bp_info.inuse_idx, g_bp_info.bp_data.version, g_bp_info.bp_data.active_idx, g_bp_info.bp_data.address[0], g_bp_info.bp_data.address[1]);
+		bmvdbg("BP[%d] ver: %u, format: %u, reason: %u, active index: %u, addresses: %x, %x\n", g_bp_info.inuse_idx, g_bp_info.bp_data.head.version, g_bp_info.bp_data.head.format_ver, g_bp_info.bp_data.tail.bp_update_reason, g_bp_info.bp_data.head.active_idx, g_bp_info.bp_data.head.address[0], g_bp_info.bp_data.head.address[1]);
 	}
 
 	return ret;
@@ -202,13 +215,15 @@ int binary_manager_update_bpinfo(void)
 *	 This function updates input bootparam data, bp_data to inactive bootparam partition.
 *
 ********************************************************************************/
-int binary_manager_write_bootparam(char *bootparam)
+int binary_manager_write_bootparam(binmgr_bpdata_t *bp_data)
 {
 	int fd;
 	int ret;	
 	uint8_t inuse_idx;
+	char *bootparam;
+	size_t tail_offset;
 
-	if (!bootparam) {
+	if (!bp_data) {
 		bmdbg("ERROR: Input bp data is NULL\n");
 		return BINMGR_INVALID_PARAM;
 	}
@@ -218,13 +233,28 @@ int binary_manager_write_bootparam(char *bootparam)
 		return BINMGR_INVALID_PARAM;
 	}
 
+	bootparam = (char *)kmm_malloc(BOOTPARAM_SIZE);
+	if (!bootparam) {
+		bmdbg("Fail to malloc to write BP\n");
+		return BINMGR_OUT_OF_MEMORY;
+	}
+	memset(bootparam, 0xff, BOOTPARAM_SIZE);
+
 	fd = binary_manager_open_bootparam();
 	if (fd < 0) {
+		kmm_free(bootparam);
 		return BINMGR_OPERATION_FAIL;
 	}
 
+	/* Update bootparam data : format version and bp tail */
+	bp_data->head.format_ver = BOOTPARAM_FORMAT_VERSION_LATEST;
+	tail_offset = BOOTPARAM_SIZE - sizeof(bp_data->tail);
+	memcpy(bootparam, &bp_data->head, sizeof(bp_data->head));
+	memcpy(&bootparam[tail_offset], &bp_data->tail, sizeof(bp_data->tail));
+
 	/* Update bootparam data : CRC */
-	((binmgr_bpdata_t *)bootparam)->crc_hash = crc32((uint8_t *)bootparam + CHECKSUM_SIZE, BOOTPARAM_SIZE - CHECKSUM_SIZE);
+	bp_data->head.crc_hash = crc32((uint8_t *)bootparam + CHECKSUM_SIZE, BOOTPARAM_SIZE - CHECKSUM_SIZE);
+	((binmgr_bpdata_head_t *)bootparam)->crc_hash = bp_data->head.crc_hash;
 	inuse_idx = g_bp_info.inuse_idx ^ 1;
 
 	ret = lseek(fd, BP_SEEK_OFFSET(inuse_idx), SEEK_SET);
@@ -240,17 +270,18 @@ int binary_manager_write_bootparam(char *bootparam)
 		goto errout_with_fd;
 	}
 	close(fd);
+	kmm_free(bootparam);
 
 	return BINMGR_OK;
 errout_with_fd:
 	close(fd);
+	kmm_free(bootparam);
 	return BINMGR_OPERATION_FAIL;
 }
 
 void binary_manager_update_bootparam(int requester_pid, uint8_t type)
 {
 	int ret;
-	char *bootparam;
 	bool is_all_updatable;
 	char q_name[BIN_PRIVMQ_LEN];
 	binmgr_bpdata_t update_bp_data;
@@ -268,27 +299,21 @@ void binary_manager_update_bootparam(int requester_pid, uint8_t type)
 		return;
 	}
 
-	bootparam = (char *)kmm_malloc(BOOTPARAM_SIZE);
-	if (!bootparam) {
-		bmdbg("Fail to malloc to read BP\n");
-		ret = BINMGR_OUT_OF_MEMORY;
-		goto send_response;
-	}
-	memset(bootparam, 0xff, BOOTPARAM_SIZE);
-
 	response_msg.result = BINMGR_OK;
 	is_all_updatable = true;
 
 	/* Get current bootparam data and update version */
 	memcpy(&update_bp_data, binary_manager_get_bpdata(), sizeof(binmgr_bpdata_t));
-	update_bp_data.version++;
+	update_bp_data.head.version++;
+	update_bp_data.head.format_ver = BOOTPARAM_FORMAT_VERSION_LATEST;
+	update_bp_data.tail.bp_update_reason = BP_UPDATE_BINARY_MANAGER_UPDATE;
 
 	if (BM_CHECK_GROUP(type, BINARY_KERNEL)) {
 		/* Update bootparam and Reboot if new kernel binary exists */
 		ret = binary_manager_check_kernel_update(true);
 		if (ret > 0) {
 			/* Update index for inactive partition */
-			update_bp_data.active_idx ^= 1;
+			update_bp_data.head.active_idx ^= 1;
 		} else if (ret == BINMGR_ALREADY_UPDATED || ret == BINMGR_NOT_FOUND) {
 			bmdbg("No kernel binary to update\n");
 			is_all_updatable = false;
@@ -305,7 +330,7 @@ void binary_manager_update_bootparam(int requester_pid, uint8_t type)
 		ret = binary_manager_check_resource_update(true);
 		if (ret > 0) {
 			/* Update index for inactive partition */
-			update_bp_data.resource_active_idx ^= 1;
+			update_bp_data.head.resource_active_idx ^= 1;
 		} else if (ret == BINMGR_ALREADY_UPDATED || ret == BINMGR_NOT_FOUND) {
 			bmdbg("No resource binary to update\n");
 			is_all_updatable = false;
@@ -328,7 +353,7 @@ void binary_manager_update_bootparam(int requester_pid, uint8_t type)
 			ret = binary_manager_check_user_update(bin_idx, true);
 			if (ret > 0) {
 				/* Update index for inactive partition */
-				update_bp_data.app_data[BIN_BPIDX(bin_idx)].useidx ^= 1;
+				update_bp_data.head.app_data[BIN_BPIDX(bin_idx)].useidx ^= 1;
 				need_update = true;
 			} else if (ret == BINMGR_ALREADY_UPDATED || ret == BINMGR_NOT_FOUND) {
 				bmdbg("No user binary to update: bin_idx %d, ret %d\n", bin_idx, ret);
@@ -349,7 +374,7 @@ void binary_manager_update_bootparam(int requester_pid, uint8_t type)
 		ret = binary_manager_check_user_update(BM_CMNLIB_IDX, true);
 		if (ret > 0) {
 			/* Update index for inactive partition */
-			update_bp_data.app_data[BIN_BPIDX(BM_CMNLIB_IDX)].useidx ^= 1;
+			update_bp_data.head.app_data[BIN_BPIDX(BM_CMNLIB_IDX)].useidx ^= 1;
 		} else if (ret == BINMGR_ALREADY_UPDATED || ret == BINMGR_NOT_FOUND) {
 			bmdbg("No common binary to update\n");
 			is_all_updatable = false;
@@ -364,8 +389,7 @@ void binary_manager_update_bootparam(int requester_pid, uint8_t type)
 
 	if (is_all_updatable) {
 		/* Then, Write bootparam with updated bootparam data */
-		memcpy(bootparam, &update_bp_data, sizeof(binmgr_bpdata_t));
-		ret = binary_manager_write_bootparam(bootparam);
+		ret = binary_manager_write_bootparam(&update_bp_data);
 		if (ret == BINMGR_OK) {
 			bmvdbg("Update BP SUCCESS\n");
 		} else {
@@ -377,9 +401,6 @@ void binary_manager_update_bootparam(int requester_pid, uint8_t type)
 	}
 
 send_response:
-	if (bootparam) {
-		kmm_free(bootparam);
-	}
 	response_msg.result = ret;
 	snprintf(q_name, BIN_PRIVMQ_LEN, "%s%d", BINMGR_RESPONSE_MQ_PREFIX, requester_pid);
 	binary_manager_send_response(q_name, &response_msg, sizeof(binmgr_setbp_response_t));
@@ -429,7 +450,6 @@ void binary_manager_set_bpidx(uint8_t index)
 void binary_manager_swap_bootparam(int requester_pid)
 {
 	int ret;
-	char *bootparam;
 	bool is_all_updatable;
 	char q_name[BIN_PRIVMQ_LEN];
 	binmgr_bpdata_t update_bp_data;
@@ -446,20 +466,14 @@ void binary_manager_swap_bootparam(int requester_pid)
 		return;
 	}
 
-	bootparam = (char *)kmm_malloc(BOOTPARAM_SIZE);
-	if (!bootparam) {
-		bmdbg("Fail to malloc to read BP\n");
-		ret = BINMGR_OUT_OF_MEMORY;
-		goto send_response;
-	}
-	memset(bootparam, 0xff, BOOTPARAM_SIZE);
-
 	response_msg.result = BINMGR_OK;
 	is_all_updatable = true;
 
 	/* Get current bootparam data */
 	memcpy(&update_bp_data, binary_manager_get_bpdata(), sizeof(binmgr_bpdata_t));
-	update_bp_data.version++;
+	update_bp_data.head.version++;
+	update_bp_data.head.format_ver = BOOTPARAM_FORMAT_VERSION_LATEST;
+	update_bp_data.tail.bp_update_reason = BP_UPDATE_BINARY_MANAGER_SWAP;
 
 	/* Update bootparam and Reboot if valid kernel binary exists */
 	ret = binary_manager_check_kernel_update(false);
@@ -467,7 +481,7 @@ void binary_manager_swap_bootparam(int requester_pid)
 		bmdbg("Fail to find valid kernel binary, %d\n", ret);
 		goto send_response;
 	}
-	update_bp_data.active_idx ^= 1;
+	update_bp_data.head.active_idx ^= 1;
 
 #ifdef CONFIG_RESOURCE_FS
 	/* Update bootparam if valid resource binary exists */
@@ -476,7 +490,7 @@ void binary_manager_swap_bootparam(int requester_pid)
 		bmdbg("Fail to find valid resource binary, %d\n", ret);
 		goto send_response;
 	}
-	update_bp_data.resource_active_idx ^= 1;
+	update_bp_data.head.resource_active_idx ^= 1;
 #endif
 
 #ifdef CONFIG_APP_BINARY_SEPARATION
@@ -488,7 +502,7 @@ void binary_manager_swap_bootparam(int requester_pid)
 			bmdbg("Fail to find valid user binary, %d\n", ret);
 			goto send_response;
 		}
-		update_bp_data.app_data[BIN_BPIDX(bin_idx)].useidx ^= 1;
+		update_bp_data.head.app_data[BIN_BPIDX(bin_idx)].useidx ^= 1;
 	}
 
 #ifdef CONFIG_SUPPORT_COMMON_BINARY
@@ -497,13 +511,12 @@ void binary_manager_swap_bootparam(int requester_pid)
 		bmdbg("Fail to find valid common binary, %d\n", ret);
 		goto send_response;
 	}
-	update_bp_data.app_data[BIN_BPIDX(BM_CMNLIB_IDX)].useidx ^= 1;
+	update_bp_data.head.app_data[BIN_BPIDX(BM_CMNLIB_IDX)].useidx ^= 1;
 #endif
 #endif
 
 	/* Then, Write bootparam with updated bootparam data */
-	memcpy(bootparam, &update_bp_data, sizeof(binmgr_bpdata_t));
-	ret = binary_manager_write_bootparam(bootparam);
+	ret = binary_manager_write_bootparam(&update_bp_data);
 	if (ret == BINMGR_OK) {
 		bmvdbg("Update BP SUCCESS\n");
 	} else {
@@ -511,9 +524,6 @@ void binary_manager_swap_bootparam(int requester_pid)
 	}
 
 send_response:
-	if (bootparam) {
-		kmm_free(bootparam);
-	}
 	response_msg.result = ret;
 	snprintf(q_name, BIN_PRIVMQ_LEN, "%s%d", BINMGR_RESPONSE_MQ_PREFIX, requester_pid);
 	binary_manager_send_response(q_name, &response_msg, sizeof(binmgr_response_t));

--- a/os/kernel/binary_manager/binary_manager_data.c
+++ b/os/kernel/binary_manager/binary_manager_data.c
@@ -130,11 +130,11 @@ bool binary_manager_scan_kbin(void)
 	binmgr_bpdata_t *bp_data;
 	bp_data = binary_manager_get_bpdata();
 	/* Verify running kernel binary based on bootparam */
-	snprintf(filepath, BINARY_PATH_LEN, BINMGR_DEVNAME_FMT, kernel_info.part_info[bp_data->active_idx].devnum);
+	snprintf(filepath, BINARY_PATH_LEN, BINMGR_DEVNAME_FMT, kernel_info.part_info[bp_data->head.active_idx].devnum);
 	ret = binary_manager_read_header(BINARY_KERNEL, filepath, &header_data, false);
 	if (ret == OK) {
 		/* Update inuse index and kernel version */
-		kernel_info.inuse_idx = bp_data->active_idx;
+		kernel_info.inuse_idx = bp_data->head.active_idx;
 		kernel_info.version = header_data.version;
 		bmdbg("Kernel version [%u] %u\n", kernel_info.inuse_idx, kernel_info.version);
 		return true;
@@ -244,17 +244,17 @@ int binary_manager_check_update(void)
 	}
 
 	/* Compare bootparam version with current running version */
-	if (binary_manager_get_bpdata()->version >= bp_info.bp_data.version) {
+	if (binary_manager_get_bpdata()->head.version >= bp_info.bp_data.head.version) {
 		/* No bootparam update */
 		bmdbg("All binaries are running based on BP\n");
 		return BINMGR_NOT_FOUND;
 	}
 
 	/* Do kernel need to update? */
-	if (binary_manager_get_kdata()->inuse_idx != bp_info.bp_data.active_idx) {
+	if (binary_manager_get_kdata()->inuse_idx != bp_info.bp_data.head.active_idx) {
 		/* Running partition and partition written in the latest BP are different.
 		 * Reboot to switch kernel binary in another partition. */
-		bmvdbg("Need to update to kernel binary in partition %d in the latest BP.\n", binary_manager_get_kdata()->part_info[bp_info.bp_data.active_idx].devnum);
+		bmvdbg("Need to update to kernel binary in partition %d in the latest BP.\n", binary_manager_get_kdata()->part_info[bp_info.bp_data.head.active_idx].devnum);
 		goto reboot;
 	}
 #else
@@ -417,14 +417,14 @@ bool binary_manager_scan_ubin_all(void)
 #ifdef CONFIG_USE_BP
 	bp_data = binary_manager_get_bpdata();
 	/* Update user binary data based on bootparam */
-	for (bp_app_idx = 0; bp_app_idx < bp_data->app_count; bp_app_idx++) {
-		bin_idx = binary_manager_get_index_with_name(bp_data->app_data[bp_app_idx].name);
+	for (bp_app_idx = 0; bp_app_idx < bp_data->head.app_count; bp_app_idx++) {
+		bin_idx = binary_manager_get_index_with_name(bp_data->head.app_data[bp_app_idx].name);
 		if (bin_idx < 0) {
-			bmdbg("Fail to find matched binary %s in binary table \n", bp_data->app_data[bp_app_idx].name);
+			bmdbg("Fail to find matched binary %s in binary table \n", bp_data->head.app_data[bp_app_idx].name);
 			continue;
 		}
 		BIN_BPIDX(bin_idx) = bp_app_idx;
-		part_idx = bp_data->app_data[bp_app_idx].useidx;
+		part_idx = bp_data->head.app_data[bp_app_idx].useidx;
 		snprintf(devpath, BINARY_PATH_LEN, BINMGR_DEVNAME_FMT, BIN_PARTNUM(bin_idx, part_idx));
 		bmdbg("Checking user in partition [%d], path %s\n", part_idx, devpath);
 #ifdef CONFIG_SUPPORT_COMMON_BINARY

--- a/os/kernel/binary_manager/binary_manager_internal.h
+++ b/os/kernel/binary_manager/binary_manager_internal.h
@@ -78,6 +78,9 @@
 #define BOOTPARAM_COUNT            2                          /* The number of boot parameters */
 #define BOOTPARAM_SIZE             4096                       /* The size of boot parameter : 4K */
 #define BOOTPARAM_PARTSIZE         (BOOTPARAM_SIZE * 2)       /* The size of partition for dual boot parameters : 8K */
+#define BOOTPARAM_FORMAT_VERSION_1       1
+#define BOOTPARAM_FORMAT_VERSION_2       2
+#define BOOTPARAM_FORMAT_VERSION_LATEST  BOOTPARAM_FORMAT_VERSION_2
 
 #define CHECKSUM_SIZE              4
 
@@ -180,8 +183,28 @@ struct binmgr_userbp_s {
 };
 typedef struct binmgr_userbp_s binmgr_userbp_t;
 
-/* Boot parameter data */
-struct binmgr_bpdata_s {
+enum bp_update_reason_e {
+	BP_UPDATE_INITIALIZED = 0,
+	BP_UPDATE_BOOTLOADER_BP_CRC_FAIL = 1,
+	BP_UPDATE_BOOTLOADER_KERNEL_CRC_FAIL = 2,
+	BP_UPDATE_BOOTLOADER_KERNEL_INVALID_SIZE = 3,
+	BP_UPDATE_BOOTLOADER_KERNEL_FAIL_TO_BOOT = 4,
+	BP_UPDATE_BOOTLOADER_SPECIFIC_1 = 5,
+	BP_UPDATE_BOOTLOADER_SPECIFIC_2 = 6,
+	BP_UPDATE_BOOTLOADER_SPECIFIC_3 = 7,
+	BP_UPDATE_BINARY_MANAGER_SWAP = 8,
+	BP_UPDATE_BINARY_MANAGER_UPDATE = 9,
+	BP_UPDATE_BINARY_MANAGER_RECOVERY_USER = 10,
+	BP_UPDATE_BINARY_MANAGER_RECOVERY_RESOURCE = 11,
+	BP_UPDATE_BINARY_MANAGER_SPECIFIC_1 = 12,
+	BP_UPDATE_BINARY_MANAGER_SPECIFIC_2 = 13,
+	BP_UPDATE_BINARY_MANAGER_SPECIFIC_3 = 14,
+	BP_UPDATE_BINARY_MANAGER_SPECIFIC_4 = 15,
+	BP_UPDATE_UNKNOWN = 16
+};
+
+/* Boot parameter head data, stored at the beginning of each BP. */
+struct binmgr_bpdata_head_s {
 	uint32_t crc_hash;
 	uint32_t version;
 	uint32_t format_ver;
@@ -195,7 +218,24 @@ struct binmgr_bpdata_s {
 	uint8_t resource_active_idx;
 #endif
 } __attribute__((__packed__));
+typedef struct binmgr_bpdata_head_s binmgr_bpdata_head_t;
+
+/* Boot parameter tail data, stored at the end of each BP. */
+struct binmgr_bpdata_tail_s {
+	/* future field should be added here */
+	uint8_t bp_update_reason;						/* Added on format version 2 */
+} __attribute__((__packed__));
+typedef struct binmgr_bpdata_tail_s binmgr_bpdata_tail_t;
+
+/* Logical boot parameter data */
+struct binmgr_bpdata_s {
+	binmgr_bpdata_head_t head;
+	binmgr_bpdata_tail_t tail;
+} __attribute__((__packed__));
 typedef struct binmgr_bpdata_s binmgr_bpdata_t;
+
+/* Compile-time assertion: serialized head and tail must fit in one BP. */
+static_assert(sizeof(binmgr_bpdata_t) <= BOOTPARAM_SIZE, "binmgr_bpdata_t size exceeds BOOTPARAM_SIZE");
 
 struct binmgr_bpinfo_s {
 	uint8_t inuse_idx;
@@ -293,6 +333,8 @@ void binary_manager_update_running_state(int bin_id);
 int binary_manager_get_index_with_name(char *bin_name);
 int binary_manager_scan_bootparam(binmgr_bpinfo_t *bp_info);
 binmgr_bpdata_t *binary_manager_get_bpdata(void);
+int binary_manager_set_bpdata(binmgr_bpdata_t *bp_data);
+int binary_manager_write_bootparam(binmgr_bpdata_t *bp_data);
 int binary_manager_get_inactive_path(int requester_pid, char *bin_name);
 void binary_manager_update_bootparam(int requester_pid, uint8_t type);
 void binary_manager_reset_board(int reboot_reason);

--- a/os/kernel/binary_manager/binary_manager_internal.h
+++ b/os/kernel/binary_manager/binary_manager_internal.h
@@ -191,7 +191,9 @@ struct binmgr_bpdata_s {
 	uint8_t app_count;
 	binmgr_userbp_t app_data[CONFIG_NUM_APPS + 1];
 #endif
+#ifdef CONFIG_RESOURCE_FS
 	uint8_t resource_active_idx;
+#endif
 } __attribute__((__packed__));
 typedef struct binmgr_bpdata_s binmgr_bpdata_t;
 

--- a/os/kernel/binary_manager/binary_manager_load.c
+++ b/os/kernel/binary_manager/binary_manager_load.c
@@ -287,8 +287,10 @@ static int binary_manager_load(int bin_idx)
 				/* Update boot param data because the binary not written to bootparam is loaded */
 				binmgr_bpdata_t update_bp_data;
 				memcpy(&update_bp_data, binary_manager_get_bpdata(), sizeof(binmgr_bpdata_t));
-				update_bp_data.version++;
-				update_bp_data.app_data[BIN_BPIDX(bin_idx)].useidx ^= 1;
+				update_bp_data.head.version++;
+				update_bp_data.head.format_ver = BOOTPARAM_FORMAT_VERSION_LATEST;
+				update_bp_data.head.app_data[BIN_BPIDX(bin_idx)].useidx ^= 1;
+				update_bp_data.tail.bp_update_reason = BP_UPDATE_BINARY_MANAGER_RECOVERY_USER;
 				ret = binary_manager_write_bootparam(&update_bp_data);
 				if (ret == BINMGR_OK) {
 					binary_manager_set_bpdata(&update_bp_data);

--- a/os/kernel/binary_manager/binary_manager_resource.c
+++ b/os/kernel/binary_manager/binary_manager_resource.c
@@ -111,7 +111,7 @@ int binary_manager_mount_resource(void)
 	}
 
 	bp_data = binary_manager_get_bpdata();
-	inuse_idx = bp_data->resource_active_idx;
+	inuse_idx = bp_data->head.resource_active_idx;
 #else
 	uint32_t latest_ver = 0;
 	int latest_partidx = -1;
@@ -214,8 +214,10 @@ int binary_manager_mount_resource(void)
 		/* Update boot param data because the binary not written to bootparam is loaded */
 		binmgr_bpdata_t update_bp_data;
 		memcpy(&update_bp_data, binary_manager_get_bpdata(), sizeof(binmgr_bpdata_t));
-		update_bp_data.version++;
-		update_bp_data.resource_active_idx = inuse_idx;
+		update_bp_data.head.version++;
+		update_bp_data.head.format_ver = BOOTPARAM_FORMAT_VERSION_LATEST;
+		update_bp_data.head.resource_active_idx = inuse_idx;
+		update_bp_data.tail.bp_update_reason = BP_UPDATE_BINARY_MANAGER_RECOVERY_RESOURCE;
 		ret = binary_manager_write_bootparam(&update_bp_data);
 		if (ret == BINMGR_OK) {
 			binary_manager_set_bpdata(&update_bp_data);

--- a/os/tools/mkbootparam.py
+++ b/os/tools/mkbootparam.py
@@ -40,7 +40,7 @@ SIZE_OF_BP_PARTITION = SIZE_OF_BPx * 2
 #  * An output, 'bootparam.bin' should be downloaded and be located at the end of a flash.
 #
 # Boot Parameter information (BPx) :
-#  - Boot Parameter Format Version 1 (bootparam_format_version = 1)
+#  - Boot Parameter Format Version 2 (bootparam_format_version = 2)
 #  - The data from 'App Count' depends on CONFIG_APP_SEPARATION.
 # +------------------------------------------------------------------------------------------
 # | Checksum | BP Version | BP Format Version | Active Idx | First Address | Second Address |
@@ -50,11 +50,11 @@ SIZE_OF_BP_PARTITION = SIZE_OF_BPx * 2
 # | App Count | App1 Name  | App1 Active Idx | App2 Name  | App2 Active Idx |     App# ...   |
 # |  (1byte)  | (16 bytes) |   (1 bytes)     | (16 bytes) |    (1 bytes)    |  (## bytes)    |
 # --------------------------------------------------------------------------------------------
-# ------------------------------------------------------------------+
-# | Resource Active Idx |                 Reserved                  |
-# |       (1 byte)      |        (4Kbytes - (23 + @)bytes)          |
-# ------------------------------------------------------------------+
-#  * The "Checksum" is crc32 value for data from "BP Version" to "Second Address".
+# -------------------------------------------------------------------------------+
+# | Resource Active Idx |              Reserved               | BP Update Reason |
+# |       (1 byte)      |       ... to fixed bp tail          |      (1 byte)    |
+# -------------------------------------------------------------------------------+
+#  * The "Checksum" is crc32 value for data from "BP Version" to the last byte of BP.
 #  * The "BP Version" is a version to check the latest of boot parameters.
 #  * The "BP Format Version" is a version to manage the format of boot parameters.
 #  * The "Active Idx" is a index indicating which address value to use.
@@ -70,6 +70,9 @@ SIZE_OF_BP_PARTITION = SIZE_OF_BPx * 2
 #    - All resource have 2 partitions.
 #    - If the value is 0, "First partition" will be mounted.
 #    - If the value is 1, "Second partition" will be mounted.
+#  * The "BP Update Reason" is the last successful reason for updating BP.
+#    It is located at the last byte of each 4KB BP so the bootloader can update
+#    it without knowing the variable app/resource data layout.
 #
 ###########################################################################################
 
@@ -81,8 +84,10 @@ def make_bootparam():
     SIZE_OF_KERNEL_INDEX = 1
     SIZE_OF_KERNEL_FIRST_ADDR = 4
     SIZE_OF_KERNEL_SECOND_ADDR = 4
+    SIZE_OF_RESOURCE_INDEX = 1
+    SIZE_OF_UPDATE_REASON = 1
 
-    kernel_data_size = SIZE_OF_CHECKSUM + SIZE_OF_BP_VERSION + SIZE_OF_BP_VERSION + SIZE_OF_KERNEL_INDEX + SIZE_OF_KERNEL_FIRST_ADDR + SIZE_OF_KERNEL_SECOND_ADDR
+    kernel_data_size = SIZE_OF_CHECKSUM + SIZE_OF_BP_VERSION + SIZE_OF_BP_FORMAT_VERSION + SIZE_OF_KERNEL_INDEX + SIZE_OF_KERNEL_FIRST_ADDR + SIZE_OF_KERNEL_SECOND_ADDR
 
     FLASH_START_ADDR = util.get_value_from_file(config_file_path, "CONFIG_FLASH_START_ADDR=")
     FLASH_SIZE = util.get_value_from_file(config_file_path, "CONFIG_FLASH_SIZE=")
@@ -92,6 +97,7 @@ def make_bootparam():
     sizes = filter(None, sizes)
 
     INITIAL_ACTIVE_IDX = 0
+    INITIAL_BP_REASON = 0
 
     # Check partitions of kernel and bootparam
     kernel_address = []
@@ -125,7 +131,7 @@ def make_bootparam():
     with open(bootparam_file_path, 'wb') as fp:
         # Write Data
         bootparam_version = 1
-        bootparam_format_version = 1
+        bootparam_format_version = 2
         fp.write(struct.pack('I', bootparam_version))
         fp.write(struct.pack('I', bootparam_format_version))
         # Kernel data
@@ -161,14 +167,16 @@ def make_bootparam():
     # Resource Data
     resource_data_size = 0
     if (util.check_config_existence(config_file_path, "CONFIG_RESOURCE_FS")) :
-        resource_data_size = 1
+        resource_data_size = SIZE_OF_RESOURCE_INDEX
         with open(bootparam_file_path, 'a') as fp:
                 fp.write(struct.pack('B', INITIAL_ACTIVE_IDX))
 
-    # Fill remaining space with '0xff'
+    # Fill remaining space with '0xff' up to the fixed BP tail and write bp_tail
+    bp_tail = struct.pack('B', INITIAL_BP_REASON)
     with open(bootparam_file_path, 'a') as fp:
         remain_size = SIZE_OF_BPx - (kernel_data_size + total_app_data_size + resource_data_size)
-        fp.write(b'\xff' * remain_size)
+        fp.write(b'\xff' * (remain_size - len(bp_tail)))
+        fp.write(bp_tail)
 
     # Add checksum for BP1
     mkchecksum_path = os.path.dirname(__file__) + '/mkchecksum.py'


### PR DESCRIPTION
### 1. os/include/assert.h: Add static_assert for compile time assertion checking
Add new macro static_assert for compile time assertion checking.
This macro is used to check if the condition is true at compile time.
Make this macro in C89, C99 with C11 style.


### 2. os/kernel/binary_manager: Add condition in binmgr_bpdata_s for resource_active_idx
Add condition in binmgr_bpdata_s for resource_active_idx to fix wrong format.
In mkbootparam script, the resource_active_idx was also wrapped with CONFIG_RESOURCE_FS condition.
And in binary_manager the resource_active_idx was only used in CONFIG_RESOURCE_FS condition.

So this code wasn't effect to other code and this change also doesn't effect to other code.
But need to fix for future format version.


### 3. os/kernel/binary_manager: Expand bootparam format to add update reason
Expand bootparam format version 2 and add update reason to make compatible with old format version.
New update reason is located at the last byte of each bootparam.
The `binary_manager_write_bootparam` function takes `bp_data` as an argument, rearranges the bootparam based on it to the appropriate locations, and then performs the actual write operation.
Through this, the user does not need to know where the update reason will be written.
With old format version, the bootparam format version is 1 and the update reason is unknown.
When the binary manager updates bootparam, added to set the format version to 2 and set the update reason.

<details>
  <summary>[Kernel update test result]</summary>

Scenario:
1. Version 1 bootparam -> Version 2 bootparam New Version Test
1. Version 2 bootparam -> Version 2 bootparam New Version Test
1. Version 2 bootparam -> Version 2 bootparam Same Version Test
```
ROM:[V1.1]
FLASHRATE:1
BOOT FROM NOR
FLASH ADDR 4B EN
Flash Download Start 
ROM:[V1.1]
FLASHRATE:1
BOOT FROM NOR
FLASH ADDR 4B EN
IMG1(OTA1) VALID, ret: 0
IMG1 ENTRY[30005929:0]
IMG1 SBOOT OFF
bootloader_version km4_bootloader_ver_e520f50b6e_2025/10/14-16:23:45
[BOOT-I] NP Freq 333 MHz
[BOOT-I] AP Freq 1200 MHz
[FLASHCLK-I] Flash ID: ef-40-19
[FLASHCLK-I] Flash Read 4IO
[FLASHCLK-I] calibration_ok:[1:9:5] 
[FLASHCLK-I] FLASH CALIB[0x4 OK]
[BOOT-I] Init DDR
[BOOT-I] BKUP_REG2 0x0 
LogUart Baudrate: 1500000

Normal boot
flash_size: 32M
BP1 data valid, version:1
BP2 version invalid
BP1 CRC32 match, attached CRC: 0x3ec5eebe, calculated CRC: 0x3ec5eebe
BP1 selected
Active Index: 0
OTA1 CRC32 match, attached CRC: 0xbc42c1be, calculated CRC: 0xbc42c1be
OTA1 USE, version: 200204
[BOOT-I] KM0 XIP IMG[0c000000:20]
[BOOT-I] KM0 SRAM[23002000:12300]
[BOOT-I] KM0 DRAM[6fffffdf:20]
[BOOT-I] KM4 XIP IMG[0d000000:558e0]
[BOOT-I] KM4 SRAM[20014000:40]
[BOOT-I] KM4 DRAM[60000000:800]
[MODULE_BOOT-LEVEL_INFO]:IMG2(OTA1) VALID, ret: 0
[BOOT-I] AP XIP IMG[0e000000:dec20]
[BOOT-I] AP BL1 SRAM[3001fde0:40]
[BOOT-I] AP BL1 DRAM[70017000:3709]
[BOOT-I] AP FIP[601fffe0:47001]
[BOOT-I] RDP OFF
[BOOT-I] AP FIP[601fffe0:47001]
[APP_LP-I] KM0 APP_START 
[APP_LP-I] KM0 CPU CLK: 40000000 Hz 
[APP_LP-I] KM0 VTOR:0x23000000 
[PMC-I] NP wake event: 2001000 0
[PMC-I] AP wake event 8405c080 40
[PMC-I] LP wake event 80001b 20
[MAIN-I] KM0 OS START 
up_allocate_kheap: start = 0x60126800 size = 60135424
up_initialize: [Reboot Reason] : 55
os_start: All SMP cores started!!
silent_reboot_set_mode: board boot with NORMAL MODE.
Logtask init ok!
up_flashinitialize: Manufacturer : 239 memory type : 64 capacity : 25
binary_manager_register_kpart: [KERNEL 0] part num 4 size 2936832, address 0x8080000
binary_manager_register_upart: [USER0 : 1] common size 8679424 num 5, address 0x834d000
binary_manager_register_upart: [USER1 : 1] app1 size 4894720 num 6, address 0x8b94000
binary_manager_register_kpart: [KERNEL 1] part num 7 size 2936832, address 0x903f000
binary_manager_register_upart: [USER0 : 2] common size 8679424 num 8, address 0x930c000
binary_manager_register_upart: [USER1 : 2] app1 size 4894720 num 9, address 0x9b53000
jedec_readid: manufacturer: ef memory: 40 capacity: 20
jedec_set_geometry: Vendor : Winbond, Size = 64MB
binary_manager_register_respart: [RESOURCE 0] part num 11 size 31850496, address 0xa000000
binary_manager_register_respart: [RESOURCE 1] part num 12 size 31850496, address 0xbe60000
smart_scan: Formatted, continue scanning!!
smart_scan: SMART Scan
smart_scan:    Erase size:                 4096
smart_scan:    Erase block:                 512
smart_scan:    Sect/block:                    4
smart_scan:    MTD Blk/Sect:                  4
smart_scan:    avail sect/block:              4
smart_scan:    Data Erase block:            488
smart_scan:    Journal Erase block:          24
smart_scan:    Journal Data/Block:          315
smart_scan:    Journal total:              7560
smart_scan:    Journal usage:              2704
smartfs_mount: 	    SMARTFS:
smartfs_mount: 	    Sector size:     1024
smartfs_mount: 	    Bytes/sector     1018
smartfs_mount: 	    Num sectors:     1952
smartfs_mount: 	    Free sectors:    1797
smartfs_mount: 	    Max filename:    32
smartfs_mount: 	    RootDirSector:   3
smartfs_sector_recovery: ###############################
smartfs_sector_recovery: #      FS Recovery Report     #
smartfs_sector_recovery: ###############################
smartfs_sector_recovery: Total of active sectors : 146
smartfs_sector_recovery: Recovered Isolated Sectors : 0
smartfs_sector_recovery: Cleaned Entries : 0

/dev/smart1p13 is mounted successfully @ /mnt 
binary_manager_scan_bootparam: Checking BP0 start
binary_manager_scan_bootparam: BP0 is valid. version: 1 format: 1 reason: 16
binary_manager_scan_bootparam: Checking BP1 start
is_valid_bootparam: Invalid data. ver: 4294967295, active index: 255, addresses: ffffffff, ffffffff
binary_manager_scan_bootparam: BP1 is invalid
binary_manager_scan_bootparam: BP USE index 0, version 1
binary_manager_mount_resource: Checking resource in partition [0], path /dev/mtdblock11
ftl_ioctl: XIP is not supported path : /dev/mtdblock11
/dev/mtdblock11 is mounted successfully @ /res 
binary_manager_mount_resource: Mount resource success! [Version: 240421] [Partition: A] 
i2c_uioregister: Registering /dev/i2c-0
i2c_uioregister: Registering /dev/i2c-2
romfs_open: Failed to find directory directory entry for 'kernel/graphics/320x240/splash_normal.bmp': -2
lcd_init_put_image: BMP file not found at /res/kernel/graphics/320x240/splash_normal.bmp. LCD OFF
[RTK] Link callback handles: registered
rtl8730e_syu645b_initialize: i2c init done
rtl8730e_syu645b_initialize: calling init i2s
rtl8730e_syu645b_initialize: i2s init done

Initializing WIFI ...
[RTW]: ** Band = 2.4G and 5G **
rtl8730e_syu645b_initialize: calling init lower
KM4 version: km4_application_ver_1e2f487864_2026/03/13-19:28:22
rtl8730e_syu645b_initialize: calling init lower done
rtl8730e_syu645b_initialize: registering audio device here
rtl8730e_syu645b_initialize: registered the device
rtl8730e_ndp120_set_dmic: Enable DMIC enable : 0
up_spiinitialize: SPI port0 has been initialized before!
board_initialize_bor: Brownout reset enabled
up_print_iwdg_status: IWDG is disabled
se_register: Registering /dev/seclink
[rtl_readdecrypt_factorykey] Exit form here!set_security_level: LOW
binary_manager_scan_bootparam: Checking BP0 start
binary_manager_scan_bootparam: BP0 is valid. version: 1 format: 1 reason: 16
binary_manager_scan_bootparam: Checking BP1 start
is_valid_bootparam: Invalid data. ver: 4294967295, active index: 255, addresses: ffffffff, ffffffff
binary_manager_scan_bootparam: BP1 is invalid
binary_manager_scan_bootparam: BP USE index 0, version 1
binary_manager_scan_kbin: Kernel version [0] 200204
binary_manager_scan_ubin_all: Checking user in partition [0], path /dev/mtdblock5
binary_manager_scan_ubin_all: Found binary common in partition 5, version 200204
binary_manager_scan_ubin_all: Checking user in partition [0], path /dev/mtdblock6
binary_manager_scan_ubin_all: Found binary app1 in partition 6, version 190412
binary_manager_load: common Header Checking Success
dump_module: Module:
dump_module:   filename:  /dev/mtdblock5
dump_module:   argv:      0
dump_module:   entrypt:   0
dump_module:   start of alloc:     0xe260010
dump_module:   alloc:     0 0
dump_module:   ctors:     0xe34bb00 nctors=8
dump_module:   dtors:     0 ndtors=0
dump_module:   stacksize: 0
dump_module:   unload:    0
mmu_allocate_app_l2_pgtbl: app_id : 0, l2idx : 0
mmu_allocate_app_l2_pgtbl: app_id : 0, l2idx : 1
mmu_allocate_app_l2_pgtbl: app_id : 0, l2idx : 2
binary_manager_load_binary: Load success! [Name: common] [Version: 200204] [Partition: A] [Text start : 0x0e260010] [Compressed Binary]
binary_manager_load: app1 Header Checking Success
dump_module: Module:
dump_module:   filename:  /dev/mtdblock6
dump_module:   argv:      0
dump_module:   entrypt:   0xeaa7085
dump_module:   start of alloc:     0xeaa7030
dump_module:   alloc:     0 0
dump_module:   ctors:     0xeaa898e nctors=0
dump_module:   dtors:     0 ndtors=0
dump_module:   stacksize: 8192
dump_module:   unload:    0
mmu_allocate_app_l2_pgtbl: app_id : 1, l2idx : 0
mmu_allocate_app_l2_pgtbl: app_id : 1, l2idx : 1
System Information:
	Version:
		Platform: 5.0	Binary: 200204
	Commit Hash: NA
	Build User: root@seokhun-eom
	Build Time: 2026-04-27 17:07:25 KST
	System Time: 27 Apr 2026, 00:00:01 [s] UTC Hardware RTC Support
TASH>>audio_manager_init: retVal : 0
binary_manager_load_binary: Load success! [Name: app1] [Version: 190412] [Partition: A] [Text start : 0x0eaa7030] [Compressed Binary]
PlayerWorker: Output audio read timeout: 170
startWorker: PlayerWorker::startWorker() - increase RefCnt : 1
startWorker: RecorderWorker::startWorker() - increase RefCnt : 1
startWorker: PlayerObserverWorker::startWorker() - increase RefCnt : 1
startWorker: RecorderObserverWorker::startWorker() - increase RefCnt : 1
startWorker: FocusManagerWorker::startWorker() - increase RefCnt : 1
This is WIFI App

Select Test Scenario.
	-Press U or u : Binary Update Test (All Tests)
	-Press S or s : Same Version Test
	-Press N or n : New Version Test
	-Press I or i : Invalid Binary Test
	-Press X or x : Terminate Tests.

** Binary Update New Version Test. **

** Binary Update GETINFO [app1] test.
 =========== binary [app1] info ============ 
    Version | Available size
 -------------------------------------------- 
   190412 |  4894720
 ============================================ 

** Download and set bootparam for app binary. (new version) **

** Binary Update GETINFO [app1] test.
 =========== binary [app1] info ============ 
    Version | Available size
 -------------------------------------------- 
   190412 |  4894720
 ============================================ 
path to app1's currently used partition /dev/mtdblock6
current version: 190412
new version: 190413
path to app1's inactive partition /dev/mtdblock9
Copy app1 binary to /dev/mtdblock9 [7%]Copy app1 binary to /dev/mtdblock9 [15%]Copy app1 binary to /dev/mtdblock9 [23%]Copy app1 binary to /dev/mtdblock9 [31%]Copy app1 binary to /dev/mtdblock9 [39%]Copy app1 binary to /dev/mtdblock9 [47%]Copy app1 binary to /dev/mtdblock9 [55%]Copy app1 binary to /dev/mtdblock9 [63%]Copy app1 binary to /dev/mtdblock9 [70%]Copy app1 binary to /dev/mtdblock9 [78%]Copy app1 binary to /dev/mtdblock9 [86%]Copy app1 binary to /dev/mtdblock9 [94%]Copy app1 binary to /dev/mtdblock9 [100%]
Copy SUCCESS
Download binary app1 version 190413 Done!
Successfully downloaded and set bootparam for app1

** Binary Update RELOAD test.
binary_manager_scan_bootparam: Checking BP0 start
binary_manager_scan_bootparam: BP0 is valid. version: 1 format: 1 reason: 16
binary_manager_scan_bootparam: Checking BP1 start
binary_manager_scan_bootparam: BP1 is valid. version: 2 format: 2 reason: 9
binary_manager_scan_bootparam: BP USE index 1, version 2
boardctl: Board will Reboot now. pid: 28
ROM:[V1.1]
FLASHRATE:1
BOOT FROM NOR
FLASH ADDR 4B EN
IMG1(OTA1) VALID, ret: 0
IMG1 ENTRY[30005929:0]
IMG1 SBOOT OFF
bootloader_version km4_bootloader_ver_e520f50b6e_2025/10/14-16:23:45
[BOOT-I] NP Freq 333 MHz
[BOOT-I] AP Freq 1200 MHz
[FLASHCLK-I] Flash ID: ef-40-19
[FLASHCLK-I] Flash Read 4IO
[FLASHCLK-I] calibration_ok:[1:9:5] 
[FLASHCLK-I] FLASH CALIB[0x4 OK]
[BOOT-I] Init DDR
[BOOT-I] BKUP_REG2 0x0 
LogUart Baudrate: 1500000

Normal boot
flash_size: 32M
BP1 data valid, version:1
BP2 data valid, version:2
BP1 CRC32 match, attached CRC: 0x3ec5eebe, calculated CRC: 0x3ec5eebe
BP2 CRC32 match, attached CRC: 0xdd4d9409, calculated CRC: 0xdd4d9409
Both BP CRC valid
BP2 selected
Active Index: 0
OTA1 CRC32 match, attached CRC: 0xbc42c1be, calculated CRC: 0xbc42c1be
OTA1 USE, version: 200204
[BOOT-I] KM0 XIP IMG[0c000000:20]
[BOOT-I] KM0 SRAM[23002000:12300]
[BOOT-I] KM0 DRAM[6fffffdf:20]
[BOOT-I] KM4 XIP IMG[0d000000:558e0]
[BOOT-I] KM4 SRAM[20014000:40]
[BOOT-I] KM4 DRAM[60000000:800]
[MODULE_BOOT-LEVEL_INFO]:IMG2(OTA1) VALID, ret: 0
[BOOT-I] AP XIP IMG[0e000000:dec20]
[BOOT-I] AP BL1 SRAM[3001fde0:40]
[BOOT-I] AP BL1 DRAM[70017000:3709]
[BOOT-I] AP FIP[601fffe0:47001]
[BOOT-I] RDP OFF
[BOOT-I] AP FIP[601fffe0:47001]
[APP_LP-I] KM0 APP_START 
[APP_LP-I] KM0 CPU CLK: 40000000 Hz 
[APP_LP-I] KM0 VTOR:0x23000000 
[PMC-I] NP wake event: 2001000 0
[PMC-I] AP wake event 8405c080 40
[PMC-I] LP wake event 80001b 20
[MAIN-I] KM0 OS START 
up_allocate_kheap: start = 0x60126800 size = 60135424
up_initialize: [Reboot Reason] : 57
os_start: All SMP cores started!!
silent_reboot_set_mode: board boot with SILENT MODE.
Logtask init ok!
up_flashinitialize: Manufacturer : 239 memory type : 64 capacity : 25
binary_manager_register_kpart: [KERNEL 0] part num 4 size 2936832, address 0x8080000
binary_manager_register_upart: [USER0 : 1] common size 8679424 num 5, address 0x834d000
binary_manager_register_upart: [USER1 : 1] app1 size 4894720 num 6, address 0x8b94000
binary_manager_register_kpart: [KERNEL 1] part num 7 size 2936832, address 0x903f000
binary_manager_register_upart: [USER0 : 2] common size 8679424 num 8, address 0x930c000
binary_manager_register_upart: [USER1 : 2] app1 size 4894720 num 9, address 0x9b53000
jedec_readid: manufacturer: ef memory: 40 capacity: 20
jedec_set_geometry: Vendor : Winbond, Size = 64MB
binary_manager_register_respart: [RESOURCE 0] part num 11 size 31850496, address 0xa000000
binary_manager_register_respart: [RESOURCE 1] part num 12 size 31850496, address 0xbe60000
smart_scan: Formatted, continue scanning!!
smart_scan: SMART Scan
smart_scan:    Erase size:                 4096
smart_scan:    Erase block:                 512
smart_scan:    Sect/block:                    4
smart_scan:    MTD Blk/Sect:                  4
smart_scan:    avail sect/block:              4
smart_scan:    Data Erase block:            488
smart_scan:    Journal Erase block:          24
smart_scan:    Journal Data/Block:          315
smart_scan:    Journal total:              7560
smart_scan:    Journal usage:              2706
smartfs_mount: 	    SMARTFS:
smartfs_mount: 	    Sector size:     1024
smartfs_mount: 	    Bytes/sector     1018
smartfs_mount: 	    Num sectors:     1952
smartfs_mount: 	    Free sectors:    1797
smartfs_mount: 	    Max filename:    32
smartfs_mount: 	    RootDirSector:   3
smartfs_sector_recovery: ###############################
smartfs_sector_recovery: #      FS Recovery Report     #
smartfs_sector_recovery: ###############################
smartfs_sector_recovery: Total of active sectors : 146
smartfs_sector_recovery: Recovered Isolated Sectors : 0
smartfs_sector_recovery: Cleaned Entries : 0

/dev/smart1p13 is mounted successfully @ /mnt 
binary_manager_scan_bootparam: Checking BP0 start
binary_manager_scan_bootparam: BP0 is valid. version: 1 format: 1 reason: 16
binary_manager_scan_bootparam: Checking BP1 start
binary_manager_scan_bootparam: BP1 is valid. version: 2 format: 2 reason: 9
binary_manager_scan_bootparam: BP USE index 1, version 2
binary_manager_mount_resource: Checking resource in partition [0], path /dev/mtdblock11
ftl_ioctl: XIP is not supported path : /dev/mtdblock11
/dev/mtdblock11 is mounted successfully @ /res 
binary_manager_mount_resource: Mount resource success! [Version: 240421] [Partition: A] 
i2c_uioregister: Registering /dev/i2c-0
i2c_uioregister: Registering /dev/i2c-2
romfs_open: Failed to find directory directory entry for 'kernel/graphics/320x240/splash_silent.bmp': -2
lcd_init_put_image: BMP file not found at /res/kernel/graphics/320x240/splash_silent.bmp. LCD OFF
[RTK] Link callback handles: registered
rtl8730e_syu645b_initialize: i2c init done
rtl8730e_syu645b_initialize: calling init i2s
rtl8730e_syu645b_initialize: i2s init done

Initializing WIFI ...
[RTW]: ** Band = 2.4G and 5G **
rtl8730e_syu645b_initialize: calling init lower
KM4 version: km4_application_ver_1e2f487864_2026/03/13-19:28:22
rtl8730e_syu645b_initialize: calling init lower done
rtl8730e_syu645b_initialize: registering audio device here
rtl8730e_syu645b_initialize: registered the device
rtl8730e_ndp120_set_dmic: Enable DMIC enable : 0
up_spiinitialize: SPI port0 has been initialized before!
board_initialize_bor: Brownout reset enabled
up_print_iwdg_status: IWDG is disabled
se_register: Registering /dev/seclink
[rtl_readdecrypt_factorykey] Exit form here!set_security_level: LOW
binary_manager_scan_bootparam: Checking BP0 start
binary_manager_scan_bootparam: BP0 is valid. version: 1 format: 1 reason: 16
binary_manager_scan_bootparam: Checking BP1 start
binary_manager_scan_bootparam: BP1 is valid. version: 2 format: 2 reason: 9
binary_manager_scan_bootparam: BP USE index 1, version 2
binary_manager_scan_kbin: Kernel version [0] 200204
binary_manager_scan_ubin_all: Checking user in partition [0], path /dev/mtdblock5
binary_manager_scan_ubin_all: Found binary common in partition 5, version 200204
binary_manager_scan_ubin_all: Checking user in partition [1], path /dev/mtdblock9
binary_manager_scan_ubin_all: Found binary app1 in partition 9, version 190413
binary_manager_load: common Header Checking Success
dump_module: Module:
dump_module:   filename:  /dev/mtdblock5
dump_module:   argv:      0
dump_module:   entrypt:   0
dump_module:   start of alloc:     0xe260010
dump_module:   alloc:     0 0
dump_module:   ctors:     0xe34bb00 nctors=8
dump_module:   dtors:     0 ndtors=0
dump_module:   stacksize: 0
dump_module:   unload:    0
mmu_allocate_app_l2_pgtbl: app_id : 0, l2idx : 0
mmu_allocate_app_l2_pgtbl: app_id : 0, l2idx : 1
mmu_allocate_app_l2_pgtbl: app_id : 0, l2idx : 2
binary_manager_load_binary: Load success! [Name: common] [Version: 200204] [Partition: A] [Text start : 0x0e260010] [Compressed Binary]
binary_manager_load: app1 Header Checking Success
dump_module: Module:
dump_module:   filename:  /dev/mtdblock9
dump_module:   argv:      0
dump_module:   entrypt:   0xeaa7085
dump_module:   start of alloc:     0xeaa7030
dump_module:   alloc:     0 0
dump_module:   ctors:     0xeaa898e nctors=0
dump_module:   dtors:     0 ndtors=0
dump_module:   stacksize: 8192
dump_module:   unload:    0
mmu_allocate_app_l2_pgtbl: app_id : 1, l2idx : 0
mmu_allocate_app_l2_pgtbl: app_id : 1, l2idx : 1
System Information:
	Version:
		Platform: 5.0	Binary: 200204
	Commit Hash: NA
	Build User: root@seokhun-eom
	Build Time: 2026-04-27 17:07:25 KST
	System Time: 27 Apr 2026, 00:00:01 [s] UTC Hardware RTC Support
TASH>>audio_manager_init: retVal : 0
binary_manager_load_binary: Load success! [Name: app1] [Version: 190413] [Partition: B] [Text start : 0x0eaa7030] [Compressed Binary]
PlayerWorker: Output audio read timeout: 170
startWorker: PlayerWorker::startWorker() - increase RefCnt : 1
startWorker: RecorderWorker::startWorker() - increase RefCnt : 1
startWorker: PlayerObserverWorker::startWorker() - increase RefCnt : 1
startWorker: RecorderObserverWorker::startWorker() - increase RefCnt : 1
startWorker: FocusManagerWorker::startWorker() - increase RefCnt : 1
This is WIFI App

Select Test Scenario.
	-Press U or u : Binary Update Test (All Tests)
	-Press S or s : Same Version Test
	-Press N or n : New Version Test
	-Press I or i : Invalid Binary Test
	-Press X or x : Terminate Tests.

** Binary Update New Version Test. **

** Binary Update GETINFO [app1] test.
 =========== binary [app1] info ============ 
    Version | Available size
 -------------------------------------------- 
   190413 |  4894720
 ============================================ 

** Download and set bootparam for app binary. (new version) **

** Binary Update GETINFO [app1] test.
 =========== binary [app1] info ============ 
    Version | Available size
 -------------------------------------------- 
   190413 |  4894720
 ============================================ 
path to app1's currently used partition /dev/mtdblock9
current version: 190413
new version: 190414
path to app1's inactive partition /dev/mtdblock6
Copy app1 binary to /dev/mtdblock6 [7%]Copy app1 binary to /dev/mtdblock6 [15%]Copy app1 binary to /dev/mtdblock6 [23%]Copy app1 binary to /dev/mtdblock6 [31%]Copy app1 binary to /dev/mtdblock6 [39%]Copy app1 binary to /dev/mtdblock6 [47%]Copy app1 binary to /dev/mtdblock6 [55%]Copy app1 binary to /dev/mtdblock6 [63%]Copy app1 binary to /dev/mtdblock6 [70%]Copy app1 binary to /dev/mtdblock6 [78%]Copy app1 binary to /dev/mtdblock6 [86%]Copy app1 binary to /dev/mtdblock6 [94%]Copy app1 binary to /dev/mtdblock6 [100%]
Copy SUCCESS
Download binary app1 version 190414 Done!
Successfully downloaded and set bootparam for app1

** Binary Update RELOAD test.
binary_manager_scan_bootparam: Checking BP0 start
binary_manager_scan_bootparam: BP0 is valid. version: 3 format: 2 reason: 9
binary_manager_scan_bootparam: Checking BP1 start
binary_manager_scan_bootparam: BP1 is valid. version: 2 format: 2 reason: 9
binary_manager_scan_bootparam: BP USE index 0, version 3
boardctl: Board will Reboot now. pid: 28
ROM:[V1.1]
FLASHRATE:1
BOOT FROM NOR
FLASH ADDR 4B EN
IMG1(OTA1) VALID, ret: 0
IMG1 ENTRY[30005929:0]
IMG1 SBOOT OFF
bootloader_version km4_bootloader_ver_e520f50b6e_2025/10/14-16:23:45
[BOOT-I] NP Freq 333 MHz
[BOOT-I] AP Freq 1200 MHz
[FLASHCLK-I] Flash ID: ef-40-19
[FLASHCLK-I] Flash Read 4IO
[FLASHCLK-I] calibration_ok:[1:9:5] 
[FLASHCLK-I] FLASH CALIB[0x4 OK]
[BOOT-I] Init DDR
[BOOT-I] BKUP_REG2 0x0 
LogUart Baudrate: 1500000

Normal boot
flash_size: 32M
BP1 data valid, version:3
BP2 data valid, version:2
BP1 CRC32 match, attached CRC: 0xf4a30ce4, calculated CRC: 0xf4a30ce4
BP2 CRC32 match, attached CRC: 0xdd4d9409, calculated CRC: 0xdd4d9409
Both BP CRC valid
BP1 selected
Active Index: 0
OTA1 CRC32 match, attached CRC: 0xbc42c1be, calculated CRC: 0xbc42c1be
OTA1 USE, version: 200204
[BOOT-I] KM0 XIP IMG[0c000000:20]
[BOOT-I] KM0 SRAM[23002000:12300]
[BOOT-I] KM0 DRAM[6fffffdf:20]
[BOOT-I] KM4 XIP IMG[0d000000:558e0]
[BOOT-I] KM4 SRAM[20014000:40]
[BOOT-I] KM4 DRAM[60000000:800]
[MODULE_BOOT-LEVEL_INFO]:IMG2(OTA1) VALID, ret: 0
[BOOT-I] AP XIP IMG[0e000000:dec20]
[BOOT-I] AP BL1 SRAM[3001fde0:40]
[BOOT-I] AP BL1 DRAM[70017000:3709]
[BOOT-I] AP FIP[601fffe0:47001]
[BOOT-I] RDP OFF
[BOOT-I] AP FIP[601fffe0:47001]
[APP_LP-I] KM0 APP_START 
[APP_LP-I] KM0 CPU CLK: 40000000 Hz 
[APP_LP-I] KM0 VTOR:0x23000000 
[PMC-I] NP wake event: 2001000 0
[PMC-I] AP wake event 8405c080 40
[PMC-I] LP wake event 80001b 20
[MAIN-I] KM0 OS START 
up_allocate_kheap: start = 0x60126800 size = 60135424
up_initialize: [Reboot Reason] : 57
os_start: All SMP cores started!!
silent_reboot_set_mode: board boot with SILENT MODE.
Logtask init ok!
up_flashinitialize: Manufacturer : 239 memory type : 64 capacity : 25
binary_manager_register_kpart: [KERNEL 0] part num 4 size 2936832, address 0x8080000
binary_manager_register_upart: [USER0 : 1] common size 8679424 num 5, address 0x834d000
binary_manager_register_upart: [USER1 : 1] app1 size 4894720 num 6, address 0x8b94000
binary_manager_register_kpart: [KERNEL 1] part num 7 size 2936832, address 0x903f000
binary_manager_register_upart: [USER0 : 2] common size 8679424 num 8, address 0x930c000
binary_manager_register_upart: [USER1 : 2] app1 size 4894720 num 9, address 0x9b53000
jedec_readid: manufacturer: ef memory: 40 capacity: 20
jedec_set_geometry: Vendor : Winbond, Size = 64MB
binary_manager_register_respart: [RESOURCE 0] part num 11 size 31850496, address 0xa000000
binary_manager_register_respart: [RESOURCE 1] part num 12 size 31850496, address 0xbe60000
smart_scan: Formatted, continue scanning!!
smart_scan: SMART Scan
smart_scan:    Erase size:                 4096
smart_scan:    Erase block:                 512
smart_scan:    Sect/block:                    4
smart_scan:    MTD Blk/Sect:                  4
smart_scan:    avail sect/block:              4
smart_scan:    Data Erase block:            488
smart_scan:    Journal Erase block:          24
smart_scan:    Journal Data/Block:          315
smart_scan:    Journal total:              7560
smart_scan:    Journal usage:              2708
smartfs_mount: 	    SMARTFS:
smartfs_mount: 	    Sector size:     1024
smartfs_mount: 	    Bytes/sector     1018
smartfs_mount: 	    Num sectors:     1952
smartfs_mount: 	    Free sectors:    1797
smartfs_mount: 	    Max filename:    32
smartfs_mount: 	    RootDirSector:   3
smartfs_sector_recovery: ###############################
smartfs_sector_recovery: #      FS Recovery Report     #
smartfs_sector_recovery: ###############################
smartfs_sector_recovery: Total of active sectors : 146
smartfs_sector_recovery: Recovered Isolated Sectors : 0
smartfs_sector_recovery: Cleaned Entries : 0

/dev/smart1p13 is mounted successfully @ /mnt 
binary_manager_scan_bootparam: Checking BP0 start
binary_manager_scan_bootparam: BP0 is valid. version: 3 format: 2 reason: 9
binary_manager_scan_bootparam: Checking BP1 start
binary_manager_scan_bootparam: BP1 is valid. version: 2 format: 2 reason: 9
binary_manager_scan_bootparam: BP USE index 0, version 3
binary_manager_mount_resource: Checking resource in partition [0], path /dev/mtdblock11
ftl_ioctl: XIP is not supported path : /dev/mtdblock11
/dev/mtdblock11 is mounted successfully @ /res 
binary_manager_mount_resource: Mount resource success! [Version: 240421] [Partition: A] 
i2c_uioregister: Registering /dev/i2c-0
i2c_uioregister: Registering /dev/i2c-2
romfs_open: Failed to find directory directory entry for 'kernel/graphics/320x240/splash_silent.bmp': -2
lcd_init_put_image: BMP file not found at /res/kernel/graphics/320x240/splash_silent.bmp. LCD OFF
[RTK] Link callback handles: registered
rtl8730e_syu645b_initialize: i2c init done
rtl8730e_syu645b_initialize: calling init i2s
rtl8730e_syu645b_initialize: i2s init done

Initializing WIFI ...
[RTW]: ** Band = 2.4G and 5G **
rtl8730e_syu645b_initialize: calling init lower
KM4 version: km4_application_ver_1e2f487864_2026/03/13-19:28:22
rtl8730e_syu645b_initialize: calling init lower done
rtl8730e_syu645b_initialize: registering audio device here
rtl8730e_syu645b_initialize: registered the device
rtl8730e_ndp120_set_dmic: Enable DMIC enable : 0
up_spiinitialize: SPI port0 has been initialized before!
board_initialize_bor: Brownout reset enabled
up_print_iwdg_status: IWDG is disabled
se_register: Registering /dev/seclink
[rtl_readdecrypt_factorykey] Exit form here!set_security_level: LOW
binary_manager_scan_bootparam: Checking BP0 start
binary_manager_scan_bootparam: BP0 is valid. version: 3 format: 2 reason: 9
binary_manager_scan_bootparam: Checking BP1 start
binary_manager_scan_bootparam: BP1 is valid. version: 2 format: 2 reason: 9
binary_manager_scan_bootparam: BP USE index 0, version 3
binary_manager_scan_kbin: Kernel version [0] 200204
binary_manager_scan_ubin_all: Checking user in partition [0], path /dev/mtdblock5
binary_manager_scan_ubin_all: Found binary common in partition 5, version 200204
binary_manager_scan_ubin_all: Checking user in partition [0], path /dev/mtdblock6
binary_manager_scan_ubin_all: Found binary app1 in partition 6, version 190414
binary_manager_load: common Header Checking Success
dump_module: Module:
dump_module:   filename:  /dev/mtdblock5
dump_module:   argv:      0
dump_module:   entrypt:   0
dump_module:   start of alloc:     0xe260010
dump_module:   alloc:     0 0
dump_module:   ctors:     0xe34bb00 nctors=8
dump_module:   dtors:     0 ndtors=0
dump_module:   stacksize: 0
dump_module:   unload:    0
mmu_allocate_app_l2_pgtbl: app_id : 0, l2idx : 0
mmu_allocate_app_l2_pgtbl: app_id : 0, l2idx : 1
mmu_allocate_app_l2_pgtbl: app_id : 0, l2idx : 2
binary_manager_load_binary: Load success! [Name: common] [Version: 200204] [Partition: A] [Text start : 0x0e260010] [Compressed Binary]
binary_manager_load: app1 Header Checking Success
dump_module: Module:
dump_module:   filename:  /dev/mtdblock6
dump_module:   argv:      0
dump_module:   entrypt:   0xeaa7085
dump_module:   start of alloc:     0xeaa7030
dump_module:   alloc:     0 0
dump_module:   ctors:     0xeaa898e nctors=0
dump_module:   dtors:     0 ndtors=0
dump_module:   stacksize: 8192
dump_module:   unload:    0
mmu_allocate_app_l2_pgtbl: app_id : 1, l2idx : 0
mmu_allocate_app_l2_pgtbl: app_id : 1, l2idx : 1
System Information:
	Version:
		Platform: 5.0	Binary: 200204
	Commit Hash: NA
	Build User: root@seokhun-eom
	Build Time: 2026-04-27 17:07:25 KST
	System Time: 27 Apr 2026, 00:00:01 [s] UTC Hardware RTC Support
TASH>>audio_manager_init: retVal : 0
binary_manager_load_binary: Load success! [Name: app1] [Version: 190414] [Partition: A] [Text start : 0x0eaa7030] [Compressed Binary]
PlayerWorker: Output audio read timeout: 170
startWorker: PlayerWorker::startWorker() - increase RefCnt : 1
startWorker: RecorderWorker::startWorker() - increase RefCnt : 1
startWorker: PlayerObserverWorker::startWorker() - increase RefCnt : 1
startWorker: RecorderObserverWorker::startWorker() - increase RefCnt : 1
startWorker: FocusManagerWorker::startWorker() - increase RefCnt : 1
This is WIFI App

Select Test Scenario.
	-Press U or u : Binary Update Test (All Tests)
	-Press S or s : Same Version Test
	-Press N or n : New Version Test
	-Press I or i : Invalid Binary Test
	-Press X or x : Terminate Tests.

** Binary Update Same Version Test. **

** Binary Update GETINFO [app1] test.
 =========== binary [app1] info ============ 
    Version | Available size
 -------------------------------------------- 
   190414 |  4894720
 ============================================ 

** Download and set bootparam for APP1 binary. (same version) **

** Binary Update GETINFO [app1] test.
 =========== binary [app1] info ============ 
    Version | Available size
 -------------------------------------------- 
   190414 |  4894720
 ============================================ 
path to app1's currently used partition /dev/mtdblock6
path to app1's inactive partition /dev/mtdblock9
Copy app1 binary to /dev/mtdblock9 [7%]Copy app1 binary to /dev/mtdblock9 [15%]Copy app1 binary to /dev/mtdblock9 [23%]Copy app1 binary to /dev/mtdblock9 [31%]Copy app1 binary to /dev/mtdblock9 [39%]Copy app1 binary to /dev/mtdblock9 [47%]Copy app1 binary to /dev/mtdblock9 [55%]Copy app1 binary to /dev/mtdblock9 [63%]Copy app1 binary to /dev/mtdblock9 [70%]Copy app1 binary to /dev/mtdblock9 [78%]Copy app1 binary to /dev/mtdblock9 [86%]Copy app1 binary to /dev/mtdblock9 [94%]Copy app1 binary to /dev/mtdblock9 [100%]
Copy SUCCESS
Download binary app1 version 190414 Done!
Successfully downloaded and set bootparam for app1

** Binary Update RELOAD test.
binary_manager_scan_bootparam: Checking BP0 start
binary_manager_scan_bootparam: BP0 is valid. version: 3 format: 2 reason: 9
binary_manager_scan_bootparam: Checking BP1 start
binary_manager_scan_bootparam: BP1 is valid. version: 4 format: 2 reason: 9
binary_manager_scan_bootparam: BP USE index 1, version 4
boardctl: Board will Reboot now. pid: 28
ROM:[V1.1]
FLASHRATE:1
BOOT FROM NOR
FLASH ADDR 4B EN
IMG1(OTA1) VALID, ret: 0
IMG1 ENTRY[30005929:0]
IMG1 SBOOT OFF
bootloader_version km4_bootloader_ver_e520f50b6e_2025/10/14-16:23:45
[BOOT-I] NP Freq 333 MHz
[BOOT-I] AP Freq 1200 MHz
[FLASHCLK-I] Flash ID: ef-40-19
[FLASHCLK-I] Flash Read 4IO
[FLASHCLK-I] calibration_ok:[1:9:5] 
[FLASHCLK-I] FLASH CALIB[0x4 OK]
[BOOT-I] Init DDR
[BOOT-I] BKUP_REG2 0x0 
LogUart Baudrate: 1500000

Normal boot
flash_size: 32M
BP1 data valid, version:3
BP2 data valid, version:4
BP1 CRC32 match, attached CRC: 0xf4a30ce4, calculated CRC: 0xf4a30ce4
BP2 CRC32 match, attached CRC: 0xb546624d, calculated CRC: 0xb546624d
Both BP CRC valid
BP2 selected
Active Index: 0
OTA1 CRC32 match, attached CRC: 0xbc42c1be, calculated CRC: 0xbc42c1be
OTA1 USE, version: 200204
[BOOT-I] KM0 XIP IMG[0c000000:20]
[BOOT-I] KM0 SRAM[23002000:12300]
[BOOT-I] KM0 DRAM[6fffffdf:20]
[BOOT-I] KM4 XIP IMG[0d000000:558e0]
[BOOT-I] KM4 SRAM[20014000:40]
[BOOT-I] KM4 DRAM[60000000:800]
[MODULE_BOOT-LEVEL_INFO]:IMG2(OTA1) VALID, ret: 0
[BOOT-I] AP XIP IMG[0e000000:dec20]
[BOOT-I] AP BL1 SRAM[3001fde0:40]
[BOOT-I] AP BL1 DRAM[70017000:3709]
[BOOT-I] AP FIP[601fffe0:47001]
[BOOT-I] RDP OFF
[BOOT-I] AP FIP[601fffe0:47001]
[APP_LP-I] KM0 APP_START 
[APP_LP-I] KM0 CPU CLK: 40000000 Hz 
[APP_LP-I] KM0 VTOR:0x23000000 
[PMC-I] NP wake event: 2001000 0
[PMC-I] AP wake event 8405c080 40
[PMC-I] LP wake event 80001b 20
[MAIN-I] KM0 OS START 
up_allocate_kheap: start = 0x60126800 size = 60135424
up_initialize: [Reboot Reason] : 57
os_start: All SMP cores started!!
silent_reboot_set_mode: board boot with SILENT MODE.
Logtask init ok!
up_flashinitialize: Manufacturer : 239 memory type : 64 capacity : 25
binary_manager_register_kpart: [KERNEL 0] part num 4 size 2936832, address 0x8080000
binary_manager_register_upart: [USER0 : 1] common size 8679424 num 5, address 0x834d000
binary_manager_register_upart: [USER1 : 1] app1 size 4894720 num 6, address 0x8b94000
binary_manager_register_kpart: [KERNEL 1] part num 7 size 2936832, address 0x903f000
binary_manager_register_upart: [USER0 : 2] common size 8679424 num 8, address 0x930c000
binary_manager_register_upart: [USER1 : 2] app1 size 4894720 num 9, address 0x9b53000
jedec_readid: manufacturer: ef memory: 40 capacity: 20
jedec_set_geometry: Vendor : Winbond, Size = 64MB
binary_manager_register_respart: [RESOURCE 0] part num 11 size 31850496, address 0xa000000
binary_manager_register_respart: [RESOURCE 1] part num 12 size 31850496, address 0xbe60000
smart_scan: Formatted, continue scanning!!
smart_scan: SMART Scan
smart_scan:    Erase size:                 4096
smart_scan:    Erase block:                 512
smart_scan:    Sect/block:                    4
smart_scan:    MTD Blk/Sect:                  4
smart_scan:    avail sect/block:              4
smart_scan:    Data Erase block:            488
smart_scan:    Journal Erase block:          24
smart_scan:    Journal Data/Block:          315
smart_scan:    Journal total:              7560
smart_scan:    Journal usage:              2710
smartfs_mount: 	    SMARTFS:
smartfs_mount: 	    Sector size:     1024
smartfs_mount: 	    Bytes/sector     1018
smartfs_mount: 	    Num sectors:     1952
smartfs_mount: 	    Free sectors:    1797
smartfs_mount: 	    Max filename:    32
smartfs_mount: 	    RootDirSector:   3
smartfs_sector_recovery: ###############################
smartfs_sector_recovery: #      FS Recovery Report     #
smartfs_sector_recovery: ###############################
smartfs_sector_recovery: Total of active sectors : 146
smartfs_sector_recovery: Recovered Isolated Sectors : 0
smartfs_sector_recovery: Cleaned Entries : 0

/dev/smart1p13 is mounted successfully @ /mnt 
binary_manager_scan_bootparam: Checking BP0 start
binary_manager_scan_bootparam: BP0 is valid. version: 3 format: 2 reason: 9
binary_manager_scan_bootparam: Checking BP1 start
binary_manager_scan_bootparam: BP1 is valid. version: 4 format: 2 reason: 9
binary_manager_scan_bootparam: BP USE index 1, version 4
binary_manager_mount_resource: Checking resource in partition [0], path /dev/mtdblock11
ftl_ioctl: XIP is not supported path : /dev/mtdblock11
/dev/mtdblock11 is mounted successfully @ /res 
binary_manager_mount_resource: Mount resource success! [Version: 240421] [Partition: A] 
i2c_uioregister: Registering /dev/i2c-0
i2c_uioregister: Registering /dev/i2c-2
romfs_open: Failed to find directory directory entry for 'kernel/graphics/320x240/splash_silent.bmp': -2
lcd_init_put_image: BMP file not found at /res/kernel/graphics/320x240/splash_silent.bmp. LCD OFF
[RTK] Link callback handles: registered
rtl8730e_syu645b_initialize: i2c init done
rtl8730e_syu645b_initialize: calling init i2s
rtl8730e_syu645b_initialize: i2s init done

Initializing WIFI ...
[RTW]: ** Band = 2.4G and 5G **
rtl8730e_syu645b_initialize: calling init lower
KM4 version: km4_application_ver_1e2f487864_2026/03/13-19:28:22
rtl8730e_syu645b_initialize: calling init lower done
rtl8730e_syu645b_initialize: registering audio device here
rtl8730e_syu645b_initialize: registered the device
rtl8730e_ndp120_set_dmic: Enable DMIC enable : 0
up_spiinitialize: SPI port0 has been initialized before!
board_initialize_bor: Brownout reset enabled
up_print_iwdg_status: IWDG is disabled
se_register: Registering /dev/seclink
[rtl_readdecrypt_factorykey] Exit form here!set_security_level: LOW
binary_manager_scan_bootparam: Checking BP0 start
binary_manager_scan_bootparam: BP0 is valid. version: 3 format: 2 reason: 9
binary_manager_scan_bootparam: Checking BP1 start
binary_manager_scan_bootparam: BP1 is valid. version: 4 format: 2 reason: 9
binary_manager_scan_bootparam: BP USE index 1, version 4
binary_manager_scan_kbin: Kernel version [0] 200204
binary_manager_scan_ubin_all: Checking user in partition [0], path /dev/mtdblock5
binary_manager_scan_ubin_all: Found binary common in partition 5, version 200204
binary_manager_scan_ubin_all: Checking user in partition [1], path /dev/mtdblock9
binary_manager_scan_ubin_all: Found binary app1 in partition 9, version 190414
binary_manager_load: common Header Checking Success
dump_module: Module:
dump_module:   filename:  /dev/mtdblock5
dump_module:   argv:      0
dump_module:   entrypt:   0
dump_module:   start of alloc:     0xe260010
dump_module:   alloc:     0 0
dump_module:   ctors:     0xe34bb00 nctors=8
dump_module:   dtors:     0 ndtors=0
dump_module:   stacksize: 0
dump_module:   unload:    0
mmu_allocate_app_l2_pgtbl: app_id : 0, l2idx : 0
mmu_allocate_app_l2_pgtbl: app_id : 0, l2idx : 1
mmu_allocate_app_l2_pgtbl: app_id : 0, l2idx : 2
binary_manager_load_binary: Load success! [Name: common] [Version: 200204] [Partition: A] [Text start : 0x0e260010] [Compressed Binary]
binary_manager_load: app1 Header Checking Success
dump_module: Module:
dump_module:   filename:  /dev/mtdblock9
dump_module:   argv:      0
dump_module:   entrypt:   0xeaa7085
dump_module:   start of alloc:     0xeaa7030
dump_module:   alloc:     0 0
dump_module:   ctors:     0xeaa898e nctors=0
dump_module:   dtors:     0 ndtors=0
dump_module:   stacksize: 8192
dump_module:   unload:    0
mmu_allocate_app_l2_pgtbl: app_id : 1, l2idx : 0
mmu_allocate_app_l2_pgtbl: app_id : 1, l2idx : 1
System Information:
	Version:
		Platform: 5.0	Binary: 200204
	Commit Hash: NA
	Build User: root@seokhun-eom
	Build Time: 2026-04-27 17:07:25 KST
	System Time: 27 Apr 2026, 00:00:01 [s] UTC Hardware RTC Support
TASH>>audio_manager_init: retVal : 0
binary_manager_load_binary: Load success! [Name: app1] [Version: 190414] [Partition: B] [Text start : 0x0eaa7030] [Compressed Binary]
PlayerWorker: Output audio read timeout: 170
startWorker: PlayerWorker::startWorker() - increase RefCnt : 1
startWorker: RecorderWorker::startWorker() - increase RefCnt : 1
startWorker: PlayerObserverWorker::startWorker() - increase RefCnt : 1
startWorker: RecorderObserverWorker::startWorker() - increase RefCnt : 1
startWorker: FocusManagerWorker::startWorker() - increase RefCnt : 1
This is WIFI App

Select Test Scenario.
	-Press U or u : Binary Update Test (All Tests)
	-Press S or s : Same Version Test
	-Press N or n : New Version Test
	-Press I or i : Invalid Binary Test
	-Press X or x : Terminate Tests.

```

</details>


### 4. os/tools/mkbootparam: Add bootparam update reason in mkbootparam script
Add bootparam update reason to the mkbootparam script.
This script is generate bootparam format version 2 with newly added update reason.
