### PR TITLE
os/kernel/binary_manager: Implement binary_manager recovery for partition set mismatch

### DIFF
--- a/os/board/rtl8730e/src/rtl8730e_boot.c
+++ b/os/board/rtl8730e/src/rtl8730e_boot.c
@@ -63,6 +63,9 @@
 
 #include <tinyara/fs/mksmartfs.h>
 #include <tinyara/board.h>
+#ifdef CONFIG_BINARY_MANAGER
+#include <tinyara/binary_manager.h>
+#endif
 #ifdef CONFIG_FLASH_PARTITION
 #include <tinyara/fs/mtd.h>
 #endif
@@ -331,6 +334,17 @@ void amebasmart_mount_partitions(void)
 	automount_fs_partition(&partinfo);
 #endif
 #endif /* end of CONFIG_SECOND_FLASH_PARTITION */
+
+#if defined(CONFIG_BINARY_MANAGER) && defined(CONFIG_USE_BP)
+	ret = binary_manager_check_bootparam_set();
+	if (ret != OK) {
+		ret = binary_manager_recover_bootparam_set();
+		if (ret != OK) {
+			lldbg("ERROR: Failed to recover bootparam set mismatch, ret %d\n", ret);
+			return;
+		}
+	}
+#endif
 
 #ifdef CONFIG_RESOURCE_FS
 	if (binary_manager_mount_resource() != OK) {

--- a/os/include/assert.h
+++ b/os/include/assert.h
@@ -236,6 +236,20 @@ extern char assert_info_str[CONFIG_STDIO_BUFFER_SIZE];
 #define assert ASSERT
 #endif
 
+/* Definition required for C11 compile-time assertion checking.  The
+ * static_assert macro simply expands to the _Static_assert keyword.
+ */
+
+#ifndef __cplusplus
+#if defined(__STDC_VERSION__) && __STDC_VERSION__  > 199901L
+#define static_assert _Static_assert
+#else
+#define static_assert(cond, msg) \
+	extern int (*__static_assert_function (void)) \
+	[!!sizeof (struct { int __error_if_negative: (cond) ? 2 : -1; })]
+#endif
+#endif
+
 /****************************************************************************
  * Included Files
  ****************************************************************************/

--- a/os/include/tinyara/binary_manager.h
+++ b/os/include/tinyara/binary_manager.h
@@ -300,6 +300,10 @@ void binary_manager_register_bppart(int part_num, int part_size);
 void binary_manager_register_upart(char *name, int part_num, int part_size, uint32_t part_addr);
 void binary_manager_register_respart(int part_num, int part_size, uint32_t part_addr);
 int binary_manager_mount_resource(void);
+#ifdef CONFIG_USE_BP
+int binary_manager_check_bootparam_set(void);
+int binary_manager_recover_bootparam_set(void);
+#endif
 void binary_manager_deinit_modules(void);
 
 #ifdef __cplusplus

--- a/os/kernel/binary_manager/binary_manager_bootparam.c
+++ b/os/kernel/binary_manager/binary_manager_bootparam.c
@@ -34,6 +34,7 @@
 
 /* Data for Boot parameters */
 static binmgr_bpinfo_t g_bp_info;
+static binmgr_bp_recovery_info_t g_bp_recovery_info;
 
 #define BP_SEEK_OFFSET(index)   (index == 0 ? 0 : BOOTPARAM_PARTSIZE / 2)
 #define FACTORY_KBIN_VERSION    101
@@ -226,7 +227,7 @@ int binary_manager_update_bpinfo(void)
 	binmgr_bpinfo_t bp_info;
 
 	ret = binary_manager_scan_bootparam(&bp_info);
-	if (ret == BINMGR_OK) {	
+	if (ret == BINMGR_OK) {
 		/* Set scanned bootparam data to g_bp_info */
 		g_bp_info.inuse_idx = bp_info.inuse_idx;
 		g_bp_info.bp_data = bp_info.bp_data;
@@ -237,17 +238,16 @@ int binary_manager_update_bpinfo(void)
 }
 
 /*********************************************************************************
-* Name: binary_manager_update_bootparam
-*
-* Description:
-*	 This function updates input bootparam data, bp_data to inactive bootparam partition.
-*
-********************************************************************************/
-int binary_manager_write_bootparam(binmgr_bpdata_t *bp_data)
+ * Name: binary_manager_write_bootparam_to_slot
+ *
+ * Description:
+ *	 This function writes input bootparam data, bp_data, to the requested BP slot.
+ *
+ ********************************************************************************/
+static int binary_manager_write_bootparam_to_slot(binmgr_bpdata_t *bp_data, uint8_t bp_idx)
 {
 	int fd;
-	int ret;	
-	uint8_t inuse_idx;
+	int ret;
 	char *bootparam;
 	size_t tail_offset;
 
@@ -256,8 +256,8 @@ int binary_manager_write_bootparam(binmgr_bpdata_t *bp_data)
 		return BINMGR_INVALID_PARAM;
 	}
 
-	if (g_bp_info.inuse_idx >= BOOTPARAM_COUNT) {
-		bmdbg("ERROR: Invalid g_bp_info, inuse idx %u\n", g_bp_info.inuse_idx);
+	if (bp_idx >= BOOTPARAM_COUNT) {
+		bmdbg("ERROR: Invalid BP index %u\n", bp_idx);
 		return BINMGR_INVALID_PARAM;
 	}
 
@@ -283,9 +283,8 @@ int binary_manager_write_bootparam(binmgr_bpdata_t *bp_data)
 	/* Update bootparam data : CRC */
 	bp_data->head.crc_hash = crc32((uint8_t *)bootparam + CHECKSUM_SIZE, BOOTPARAM_SIZE - CHECKSUM_SIZE);
 	((binmgr_bpdata_head_t *)bootparam)->crc_hash = bp_data->head.crc_hash;
-	inuse_idx = g_bp_info.inuse_idx ^ 1;
 
-	ret = lseek(fd, BP_SEEK_OFFSET(inuse_idx), SEEK_SET);
+	ret = lseek(fd, BP_SEEK_OFFSET(bp_idx), SEEK_SET);
 	if (ret < 0) {
 		bmdbg("ERROR: Seek Failed, errno %d\n", errno);
 		goto errout_with_fd;
@@ -307,6 +306,31 @@ errout_with_fd:
 	return BINMGR_OPERATION_FAIL;
 }
 
+/*********************************************************************************
+ * Name: binary_manager_write_bootparam
+ *
+ * Description:
+ *	 This function writes input bootparam data, bp_data, to the inactive BP slot.
+ *
+ ********************************************************************************/
+int binary_manager_write_bootparam(binmgr_bpdata_t *bp_data)
+{
+	if (g_bp_info.inuse_idx >= BOOTPARAM_COUNT) {
+		bmdbg("ERROR: Invalid g_bp_info, inuse idx %u\n", g_bp_info.inuse_idx);
+		return BINMGR_INVALID_PARAM;
+	}
+
+	return binary_manager_write_bootparam_to_slot(bp_data, g_bp_info.inuse_idx ^ 1);
+}
+
+/****************************************************************************
+ * Name: binary_manager_is_set_mismatch
+ *
+ * Description:
+ *	 This function checks whether all BP indices match the active kernel set.
+ *   Only AAAA or BBBB can be set as active set.
+ *
+ ****************************************************************************/
 static bool binary_manager_is_set_mismatch(binmgr_bpdata_t *bp_data)
 {
 	uint8_t active_idx;
@@ -353,232 +377,306 @@ static bool binary_manager_is_set_mismatch(binmgr_bpdata_t *bp_data)
 	return false;
 }
 
-static int binary_manager_get_kbin_version(uint8_t part_idx, uint32_t *version)
+/****************************************************************************
+ * Name: binary_manager_make_bootparam_from_partitions
+ *
+ * Description:
+ *	 This function rebuilds bootparam data for given set_idx as active_idx from registered partitions.
+ *   bp_data is updated with the new version and active set.
+ *
+ ****************************************************************************/
+static int binary_manager_make_bootparam_from_partitions(binmgr_bpdata_t *bp_data, uint8_t set_idx, uint32_t version)
 {
-	int ret;
-	char filepath[BINARY_PATH_LEN];
-	kernel_binary_header_t header_data;
+	uint32_t part_idx;
 	binmgr_kinfo_t *kdata;
+#ifdef CONFIG_APP_BINARY_SEPARATION
+	int ret;
+	int bin_idx;
+	uint32_t app_count;
+	uint32_t max_app_count;
+	uint32_t bin_count;
+	char devpath[BINARY_PATH_LEN];
+	user_binary_header_t user_header_data;
+#endif
 
-	if (!version) {
-		bmdbg("Kernel version output is NULL\n");
+	if (!bp_data || set_idx >= PARTS_PER_BIN) {
+		bmdbg("Invalid bootparam make parameter, set idx %u\n", set_idx);
 		return BINMGR_INVALID_PARAM;
 	}
+
+	memset(bp_data, 0, sizeof(binmgr_bpdata_t));
+	bp_data->head.version = version;
+	bp_data->head.format_ver = BOOTPARAM_FORMAT_VERSION_LATEST;
+	bp_data->head.active_idx = set_idx;
+	bp_data->tail.bp_update_reason = BP_UPDATE_BINARY_MANAGER_SET_ALIGNMENT;
 
 	kdata = binary_manager_get_kdata();
-	if (part_idx >= kdata->part_count) {
-		bmdbg("Invalid kernel part idx %u, part count %u\n", part_idx, kdata->part_count);
+	if (!kdata) {
+		bmdbg("kernel data is not found\n");
 		return BINMGR_INVALID_PARAM;
 	}
 
-	snprintf(filepath, BINARY_PATH_LEN, BINMGR_DEVNAME_FMT, kdata->part_info[part_idx].devnum);
-	ret = binary_manager_read_header(BINARY_KERNEL, filepath, &header_data, true);
-	if (ret != BINMGR_OK) {
-		bmdbg("Fail to read kernel version, part idx %u, devpath %s, ret %d\n", part_idx, filepath, ret);
-		return ret;
+	if (kdata->part_count > BOOTPARAM_COUNT) {
+		bmdbg("Invalid kernel part count %u\n", kdata->part_count);
+		return BINMGR_INVALID_PARAM;
 	}
 
-	*version = header_data.version;
+	for (part_idx = 0; part_idx < kdata->part_count; part_idx++) {
+		bp_data->head.address[part_idx] = kdata->part_info[part_idx].address;
+	}
+
+#ifdef CONFIG_APP_BINARY_SEPARATION
+	max_app_count = sizeof(bp_data->head.app_data) / sizeof(bp_data->head.app_data[0]);
+	bin_count = binary_manager_get_ucount();
+	app_count = 0;
+	for (bin_idx = 0; bin_idx <= bin_count; bin_idx++) {
+		if (BIN_COUNT(bin_idx) == 0) {
+			continue;
+		}
+
+		if (app_count >= max_app_count) {
+			bmdbg("App count exceeds BP max app count %u\n", max_app_count);
+			return BINMGR_INVALID_PARAM;
+		}
+
+		if (set_idx >= BIN_COUNT(bin_idx)) {
+			bmdbg("Invalid %s part idx %u, part count %u\n", BIN_NAME(bin_idx), set_idx, BIN_COUNT(bin_idx));
+			return BINMGR_INVALID_PARAM;
+		}
+
+#ifdef CONFIG_SUPPORT_COMMON_BINARY
+		if (bin_idx == BM_CMNLIB_IDX) {
+			strncpy(bp_data->head.app_data[app_count].name, BM_CMNLIB_NAME, BIN_NAME_MAX - 1);
+		} else
+#endif
+		{
+			snprintf(devpath, BINARY_PATH_LEN, BINMGR_DEVNAME_FMT, BIN_PARTNUM(bin_idx, set_idx));
+			ret = binary_manager_read_header(BINARY_USERAPP, devpath, &user_header_data, false);
+			if (ret != BINMGR_OK) {
+				bmdbg("Fail to read app header, name %s, set %s, ret %d\n", BIN_NAME(bin_idx), GET_PARTNAME(set_idx), ret);
+				return ret;
+			}
+			strncpy(bp_data->head.app_data[app_count].name, user_header_data.bin_name, BIN_NAME_MAX - 1);
+		}
+		bp_data->head.app_data[app_count].name[BIN_NAME_MAX - 1] = '\0';
+		bp_data->head.app_data[app_count].useidx = set_idx;
+		app_count++;
+	}
+	bp_data->head.app_count = app_count;
+#endif
+
+#ifdef CONFIG_RESOURCE_FS
+	bp_data->head.resource_active_idx = set_idx;
+#endif
+
 	return BINMGR_OK;
 }
 
-static int binary_manager_validate_set(binmgr_bpdata_t *bp_data, uint8_t set_idx, struct binmgr_set_validation_s *set_info)
+/****************************************************************************
+ * Name: binary_manager_validate_set
+ *
+ * Description:
+ *	 This function validates all binaries in given set_idx and returns false on the
+ *	 first invalid binary.
+ *
+ ****************************************************************************/
+static bool binary_manager_validate_set(uint8_t set_idx)
 {
 	int ret;
 #ifdef CONFIG_APP_BINARY_SEPARATION
 	int bin_idx;
-	uint32_t bp_app_idx;
-	uint32_t max_app_count;
+	uint32_t bin_count;
 #endif
 
-	if (!bp_data || !set_info || set_idx >= PARTS_PER_BIN) {
+	if (set_idx >= PARTS_PER_BIN) {
 		bmdbg("Invalid set validation parameter, set idx %u\n", set_idx);
-		return BINMGR_INVALID_PARAM;
+		return false;
 	}
 
 	ret = binary_manager_verify_kbin(set_idx);
-	set_info->kbin_valid = (ret == BINMGR_OK);
-	set_info->kbin_version = 0;
-	if (set_info->kbin_valid) {
-		ret = binary_manager_get_kbin_version(set_idx, &set_info->kbin_version);
-		if (ret != BINMGR_OK) {
-			set_info->kbin_valid = false;
-		}
+	if (ret != BINMGR_OK) {
+		bmdbg("Set %s kernel validation FAIL, ret %d\n", GET_PARTNAME(set_idx), ret);
+		return false;
 	}
 
-	set_info->ubin_valid = true;
 #ifdef CONFIG_APP_BINARY_SEPARATION
-	max_app_count = sizeof(bp_data->head.app_data) / sizeof(bp_data->head.app_data[0]);
-	if (bp_data->head.app_count > max_app_count) {
-		bmdbg("Invalid BP app count %u, max %u\n", bp_data->head.app_count, max_app_count);
-		set_info->ubin_valid = false;
-	} else {
-		for (bp_app_idx = 0; bp_app_idx < bp_data->head.app_count; bp_app_idx++) {
-			bin_idx = binary_manager_get_index_with_name(bp_data->head.app_data[bp_app_idx].name);
-			if (bin_idx < 0) {
-				bmdbg("Fail to find matched binary %s in binary table\n", bp_data->head.app_data[bp_app_idx].name);
-				set_info->ubin_valid = false;
-				continue;
-			}
-
-			ret = binary_manager_verify_ubin(bin_idx, set_idx);
-			if (ret != BINMGR_OK) {
-				bmdbg("Set %s app[%u:%s] validation FAIL, ret %d\n", GET_PARTNAME(set_idx), bp_app_idx, bp_data->head.app_data[bp_app_idx].name, ret);
-				set_info->ubin_valid = false;
-				continue;
-			}
-			bmvdbg("Set %s app[%u:%s] validation PASS\n", GET_PARTNAME(set_idx), bp_app_idx, bp_data->head.app_data[bp_app_idx].name);
+	bin_count = binary_manager_get_ucount();
+	for (bin_idx = 0; bin_idx <= bin_count; bin_idx++) {
+		if (BIN_COUNT(bin_idx) == 0) {
+			continue;
 		}
+
+		if (set_idx >= BIN_COUNT(bin_idx)) {
+			bmdbg("Set %s app[%d:%s] has no partition, part count %u\n", GET_PARTNAME(set_idx), bin_idx, BIN_NAME(bin_idx), BIN_COUNT(bin_idx));
+			return false;
+		}
+
+		ret = binary_manager_verify_ubin(bin_idx, set_idx);
+		if (ret != BINMGR_OK) {
+			bmdbg("Set %s app[%d:%s] validation FAIL, ret %d\n", GET_PARTNAME(set_idx), bin_idx, BIN_NAME(bin_idx), ret);
+			return false;
+		}
+		bmvdbg("Set %s app[%d:%s] validation PASS\n", GET_PARTNAME(set_idx), bin_idx, BIN_NAME(bin_idx));
 	}
 #endif
 
-	set_info->resource_valid = true;
 #ifdef CONFIG_RESOURCE_FS
 	ret = binary_manager_verify_resource(set_idx);
-	set_info->resource_valid = (ret == BINMGR_OK);
-	if (!set_info->resource_valid) {
+	if (ret != BINMGR_OK) {
 		bmdbg("Set %s resource validation FAIL, ret %d\n", GET_PARTNAME(set_idx), ret);
-	} else {
-		bmvdbg("Set %s resource validation PASS\n", GET_PARTNAME(set_idx));
+		return false;
 	}
+	bmvdbg("Set %s resource validation PASS\n", GET_PARTNAME(set_idx));
 #endif
 
-	bmdbg("Set %s validation: kbin %d version %u, apps %d, resource %d\n", GET_PARTNAME(set_idx), set_info->kbin_valid, set_info->kbin_version, set_info->ubin_valid, set_info->resource_valid);
+	bmdbg("Set %s validation PASS\n", GET_PARTNAME(set_idx));
 
-	return BINMGR_OK;
+	return true;
 }
 
-static int binary_manager_select_recovery_set(uint8_t active_set, struct binmgr_set_validation_s *set_a, struct binmgr_set_validation_s *set_b, uint8_t *target_set)
+/****************************************************************************
+ * Name: binary_manager_get_kbin_version
+ *
+ * Description:
+ *	 This function reads the kernel binary version from the given set.
+ *	 It returns 0 if any step fails.
+ *
+ ****************************************************************************/
+static uint32_t binary_manager_get_kbin_version(uint8_t set_idx)
 {
-	bool set_a_valid;
-	bool set_b_valid;
-	struct binmgr_set_validation_s *target_info;
+	int ret;
+	binmgr_kinfo_t *kdata;
+	kernel_binary_header_t header_data;
+	char filepath[BINARY_PATH_LEN];
 
-	if (!set_a || !set_b || !target_set || active_set >= PARTS_PER_BIN) {
-		bmdbg("Invalid recovery set select parameter\n");
-		return BINMGR_INVALID_PARAM;
+	kdata = binary_manager_get_kdata();
+	if (!kdata || set_idx >= kdata->part_count) {
+		bmdbg("Invalid kernel version request, set idx %u\n", set_idx);
+		return 0;
 	}
 
-	set_a_valid = set_a->kbin_valid && set_a->ubin_valid && set_a->resource_valid;
-	set_b_valid = set_b->kbin_valid && set_b->ubin_valid && set_b->resource_valid;
-
-	if (set_a_valid && set_b_valid) {
-		*target_set = active_set;
-	} else if (set_a_valid) {
-		*target_set = 0;
-	} else if (set_b_valid) {
-		*target_set = 1;
-	} else {
-		return BINMGR_NOT_FOUND;
+	snprintf(filepath, BINARY_PATH_LEN, BINMGR_DEVNAME_FMT, kdata->part_info[set_idx].devnum);
+	ret = binary_manager_read_header(BINARY_KERNEL, filepath, &header_data, true);
+	if (ret != BINMGR_OK) {
+		bmdbg("Fail to read kernel header, set %s, devpath %s, ret %d\n", GET_PARTNAME(set_idx), filepath, ret);
+		return 0;
 	}
 
-	if (*target_set != active_set) {
-		target_info = (*target_set == 0) ? set_a : set_b;
-		if (target_info->kbin_version == FACTORY_KBIN_VERSION) {
-			bmdbg("Do not switch to set %s because kernel version %u is factory binary\n", GET_PARTNAME(*target_set), target_info->kbin_version);
-			return BINMGR_NOT_FOUND;
-		}
-	}
-
-	return BINMGR_OK;
+	return header_data.version;
 }
 
+/****************************************************************************
+ * Name: binary_manager_check_bootparam_set
+ *
+ * Description:
+ *	 This function checks whether bootparam set recovery is required.
+ *	 It returns BINMGR_OPERATION_FAIL to enter the recovery path.
+ *
+ ****************************************************************************/
 int binary_manager_check_bootparam_set(void)
 {
 	int ret;
 	binmgr_bpdata_t *bp_data;
 
+	g_bp_recovery_info.has_valid_bp = false;
+	g_bp_recovery_info.inuse_idx = -1;
+	g_bp_recovery_info.active_set = -1;
+	g_bp_recovery_info.bp_version = -1;
+
 	ret = binary_manager_update_bpinfo();
 	if (ret != BINMGR_OK) {
-		bmdbg("Fail to update BP info before set-mismatch recovery, ret %d\n", ret);
-		return ret;
-	}
-
-	bp_data = binary_manager_get_bpdata();
-	if (!bp_data) {
-		bmdbg("BP data is NULL\n");
-		return BINMGR_INVALID_PARAM;
-	}
-
-	if (binary_manager_is_set_mismatch(bp_data)) {
+		bmdbg("No valid BP. Run BP recovery from partition information\n");
 		return BINMGR_OPERATION_FAIL;
 	}
 
-	bmdbg("BP set is already aligned, active idx %u\n", bp_data->head.active_idx);
+	bp_data = binary_manager_get_bpdata();
+	if (!bp_data) {
+		bmdbg("BP data is NULL. Run BP recovery from partition information\n");
+		return BINMGR_OPERATION_FAIL;
+	}
 
+	g_bp_recovery_info.has_valid_bp = true;
+	g_bp_recovery_info.inuse_idx = g_bp_info.inuse_idx;
+	g_bp_recovery_info.bp_version = bp_data->head.version;
+	g_bp_recovery_info.active_set = bp_data->head.active_idx;
+
+	if (binary_manager_is_set_mismatch(bp_data)) {
+		bmdbg("BP set mismatch detected. Run BP recovery from partition information\n");
+		return BINMGR_OPERATION_FAIL;
+	}
+
+	bmdbg("BP set is already aligned and active set %s is valid\n", GET_PARTNAME(bp_data->head.active_idx));
 	return BINMGR_OK;
 }
 
+/****************************************************************************
+ * Name: binary_manager_recover_bootparam_set
+ *
+ * Description:
+ *	 This function selects a valid binary set, writes an aligned BP, and reboots.
+ *
+ ****************************************************************************/
 int binary_manager_recover_bootparam_set(void)
 {
 	int ret;
-	uint8_t active_set;
 	uint8_t target_set;
+	uint8_t write_bp_idx;
+	uint32_t new_version;
+	uint32_t set_a_version;
+	uint32_t set_b_version;
+	uint32_t target_version;
 	binmgr_bpdata_t update_bp_data;
-	binmgr_bpdata_t *bp_data;
-	struct binmgr_set_validation_s set_a;
-	struct binmgr_set_validation_s set_b;
-#ifdef CONFIG_APP_BINARY_SEPARATION
-	uint32_t bp_app_idx;
-#endif
+	bool set_a_valid;
+	bool set_b_valid;
 
-	bp_data = binary_manager_get_bpdata();
-	if (!bp_data) {
-		bmdbg("BP data is NULL\n");
-		return BINMGR_INVALID_PARAM;
+	bmdbg("BP set recovery required. valid BP %d, active idx %d, BP version %u\n", g_bp_recovery_info.has_valid_bp, g_bp_recovery_info.active_set, g_bp_recovery_info.bp_version);
+
+	set_a_valid = binary_manager_validate_set(0);
+	set_b_valid = binary_manager_validate_set(1);
+	set_a_version = set_a_valid ? binary_manager_get_kbin_version(0) : 0;
+	set_b_version = set_b_valid ? binary_manager_get_kbin_version(1) : 0;
+
+	bmdbg("Set A valid %d, version %u, Set B valid %d, version %u\n", set_a_valid, set_a_version, set_b_valid, set_b_version);
+
+	if (set_a_valid && set_b_valid) {
+		if (g_bp_recovery_info.has_valid_bp) {
+			target_set = g_bp_recovery_info.active_set;
+		} else {
+			target_set = set_a_version > set_b_version ? 0 : 1;
+		}
+	} else {
+		target_set = set_a_valid ? 0 : 1;
 	}
 
-	active_set = bp_data->head.active_idx;
-	bmdbg("BP set mismatch detected. active idx %u, BP version %u\n", active_set, bp_data->head.version);
+	target_version = target_set == 0 ? set_a_version : set_b_version;
+	if (target_version == 0 || target_version == FACTORY_KBIN_VERSION) {
+		bmdbg("Invalid target kernel version, set %s, version %u. Reboot as recovery fail\n", GET_PARTNAME(target_set), target_version);
+		binary_manager_reset_board(REBOOT_SYSTEM_BINARY_RECOVERYFAIL);
+		return BINMGR_OPERATION_FAIL;
+	}
 
-	ret = binary_manager_validate_set(bp_data, 0, &set_a);
+	bmdbg("Select set %s for BP set alignment.\n", GET_PARTNAME(target_set));
+
+	new_version = g_bp_recovery_info.has_valid_bp ? g_bp_recovery_info.bp_version + 1 : 1;
+	ret = binary_manager_make_bootparam_from_partitions(&update_bp_data, target_set, new_version);
 	if (ret != BINMGR_OK) {
-		bmdbg("Fail to validate set A, ret %d\n", ret);
+		bmdbg("Fail to make recovery BP, ret %d. Reboot as recovery fail\n", ret);
 		binary_manager_reset_board(REBOOT_SYSTEM_BINARY_RECOVERYFAIL);
 		return ret;
 	}
 
-	ret = binary_manager_validate_set(bp_data, 1, &set_b);
-	if (ret != BINMGR_OK) {
-		bmdbg("Fail to validate set B, ret %d\n", ret);
-		binary_manager_reset_board(REBOOT_SYSTEM_BINARY_RECOVERYFAIL);
-		return ret;
-	}
-
-	ret = binary_manager_select_recovery_set(active_set, &set_a, &set_b, &target_set);
-	if (ret != BINMGR_OK) {
-		bmdbg("Fail to select recoverable set. Reboot as recovery fail\n");
-		binary_manager_reset_board(REBOOT_SYSTEM_BINARY_RECOVERYFAIL);
-		return ret;
-	}
-
-	bmdbg("Select set %s for BP set alignment. A valid kbin %d apps %d resource %d, B valid kbin %d apps %d resource %d\n", GET_PARTNAME(target_set), set_a.kbin_valid, set_a.ubin_valid, set_a.resource_valid, set_b.kbin_valid, set_b.ubin_valid, set_b.resource_valid);
-
-	memcpy(&update_bp_data, bp_data, sizeof(binmgr_bpdata_t));
-	update_bp_data.head.version++;
-	update_bp_data.head.active_idx = target_set;
-#ifdef CONFIG_APP_BINARY_SEPARATION
-	for (bp_app_idx = 0; bp_app_idx < update_bp_data.head.app_count; bp_app_idx++) {
-		update_bp_data.head.app_data[bp_app_idx].useidx = target_set;
-	}
-#endif
-#ifdef CONFIG_RESOURCE_FS
-	update_bp_data.head.resource_active_idx = target_set;
-#endif
-	update_bp_data.head.format_ver = BOOTPARAM_FORMAT_VERSION_LATEST;
-	update_bp_data.tail.bp_update_reason = BP_UPDATE_BINARY_MANAGER_SET_ALIGNMENT;
-
-	ret = binary_manager_write_bootparam(&update_bp_data);
+	write_bp_idx = g_bp_recovery_info.has_valid_bp ? (g_bp_recovery_info.inuse_idx ^ 1) : 0;
+	ret = binary_manager_write_bootparam_to_slot(&update_bp_data, write_bp_idx);
 	if (ret != BINMGR_OK) {
 		bmdbg("Fail to write aligned BP, ret %d. Reboot as recovery fail\n", ret);
 		binary_manager_reset_board(REBOOT_SYSTEM_BINARY_RECOVERYFAIL);
 		return ret;
 	}
 
-	bmdbg("Aligned BP to set %s, new version %u. Reboot for binary update\n", GET_PARTNAME(target_set), update_bp_data.head.version);
+	bmdbg("Aligned BP to set %s, BP slot %u, new version %u. Reboot for binary update\n", GET_PARTNAME(target_set), write_bp_idx, update_bp_data.head.version);
 	binary_manager_reset_board(REBOOT_SYSTEM_BINARY_UPDATE);
 
-	return BINMGR_OPERATION_FAIL;
+	return BINMGR_OK;
 }
 
 void binary_manager_update_bootparam(int requester_pid, uint8_t type)

--- a/os/kernel/binary_manager/binary_manager_bootparam.c
+++ b/os/kernel/binary_manager/binary_manager_bootparam.c
@@ -36,6 +36,7 @@
 static binmgr_bpinfo_t g_bp_info;
 
 #define BP_SEEK_OFFSET(index)   (index == 0 ? 0 : BOOTPARAM_PARTSIZE / 2)
+#define FACTORY_KBIN_VERSION    101
 
 /****************************************************************************
  * Public Functions
@@ -276,6 +277,280 @@ int binary_manager_write_bootparam(binmgr_bpdata_t *bp_data)
 errout_with_fd:
 	close(fd);
 	kmm_free(bootparam);
+	return BINMGR_OPERATION_FAIL;
+}
+
+static bool binary_manager_is_set_mismatch(binmgr_bpdata_t *bp_data)
+{
+	uint8_t active_idx;
+#ifdef CONFIG_APP_BINARY_SEPARATION
+	uint8_t app_idx;
+	uint32_t bp_app_idx;
+	uint32_t max_app_count;
+#endif
+
+	if (!bp_data) {
+		bmdbg("BP data is NULL\n");
+		return true;
+	}
+
+	active_idx = bp_data->head.active_idx;
+	if (active_idx >= PARTS_PER_BIN) {
+		bmdbg("Invalid BP kernel active idx %u\n", active_idx);
+		return true;
+	}
+
+#ifdef CONFIG_APP_BINARY_SEPARATION
+	max_app_count = sizeof(bp_data->head.app_data) / sizeof(bp_data->head.app_data[0]);
+	if (bp_data->head.app_count > max_app_count) {
+		bmdbg("Invalid BP app count %u, max %u\n", bp_data->head.app_count, max_app_count);
+		return true;
+	}
+
+	for (bp_app_idx = 0; bp_app_idx < bp_data->head.app_count; bp_app_idx++) {
+		app_idx = bp_data->head.app_data[bp_app_idx].useidx;
+		if (app_idx != active_idx) {
+			bmdbg("BP set mismatch: kernel %u, app[%u:%s] %u\n", active_idx, bp_app_idx, bp_data->head.app_data[bp_app_idx].name, app_idx);
+			return true;
+		}
+	}
+#endif
+
+#ifdef CONFIG_RESOURCE_FS
+	if (bp_data->head.resource_active_idx != active_idx) {
+		bmdbg("BP set mismatch: kernel %u, resource %u\n", active_idx, bp_data->head.resource_active_idx);
+		return true;
+	}
+#endif
+
+	return false;
+}
+
+static int binary_manager_get_kbin_version(uint8_t part_idx, uint32_t *version)
+{
+	int ret;
+	char filepath[BINARY_PATH_LEN];
+	kernel_binary_header_t header_data;
+	binmgr_kinfo_t *kdata;
+
+	if (!version) {
+		bmdbg("Kernel version output is NULL\n");
+		return BINMGR_INVALID_PARAM;
+	}
+
+	kdata = binary_manager_get_kdata();
+	if (part_idx >= kdata->part_count) {
+		bmdbg("Invalid kernel part idx %u, part count %u\n", part_idx, kdata->part_count);
+		return BINMGR_INVALID_PARAM;
+	}
+
+	snprintf(filepath, BINARY_PATH_LEN, BINMGR_DEVNAME_FMT, kdata->part_info[part_idx].devnum);
+	ret = binary_manager_read_header(BINARY_KERNEL, filepath, &header_data, true);
+	if (ret != BINMGR_OK) {
+		bmdbg("Fail to read kernel version, part idx %u, devpath %s, ret %d\n", part_idx, filepath, ret);
+		return ret;
+	}
+
+	*version = header_data.version;
+	return BINMGR_OK;
+}
+
+static int binary_manager_validate_set(binmgr_bpdata_t *bp_data, uint8_t set_idx, struct binmgr_set_validation_s *set_info)
+{
+	int ret;
+#ifdef CONFIG_APP_BINARY_SEPARATION
+	int bin_idx;
+	uint32_t bp_app_idx;
+	uint32_t max_app_count;
+#endif
+
+	if (!bp_data || !set_info || set_idx >= PARTS_PER_BIN) {
+		bmdbg("Invalid set validation parameter, set idx %u\n", set_idx);
+		return BINMGR_INVALID_PARAM;
+	}
+
+	ret = binary_manager_verify_kbin(set_idx);
+	set_info->kbin_valid = (ret == BINMGR_OK);
+	set_info->kbin_version = 0;
+	if (set_info->kbin_valid) {
+		ret = binary_manager_get_kbin_version(set_idx, &set_info->kbin_version);
+		if (ret != BINMGR_OK) {
+			set_info->kbin_valid = false;
+		}
+	}
+
+	set_info->ubin_valid = true;
+#ifdef CONFIG_APP_BINARY_SEPARATION
+	max_app_count = sizeof(bp_data->head.app_data) / sizeof(bp_data->head.app_data[0]);
+	if (bp_data->head.app_count > max_app_count) {
+		bmdbg("Invalid BP app count %u, max %u\n", bp_data->head.app_count, max_app_count);
+		set_info->ubin_valid = false;
+	} else {
+		for (bp_app_idx = 0; bp_app_idx < bp_data->head.app_count; bp_app_idx++) {
+			bin_idx = binary_manager_get_index_with_name(bp_data->head.app_data[bp_app_idx].name);
+			if (bin_idx < 0) {
+				bmdbg("Fail to find matched binary %s in binary table\n", bp_data->head.app_data[bp_app_idx].name);
+				set_info->ubin_valid = false;
+				continue;
+			}
+
+			ret = binary_manager_verify_ubin(bin_idx, set_idx);
+			if (ret != BINMGR_OK) {
+				bmdbg("Set %s app[%u:%s] validation FAIL, ret %d\n", GET_PARTNAME(set_idx), bp_app_idx, bp_data->head.app_data[bp_app_idx].name, ret);
+				set_info->ubin_valid = false;
+				continue;
+			}
+			bmvdbg("Set %s app[%u:%s] validation PASS\n", GET_PARTNAME(set_idx), bp_app_idx, bp_data->head.app_data[bp_app_idx].name);
+		}
+	}
+#endif
+
+	set_info->resource_valid = true;
+#ifdef CONFIG_RESOURCE_FS
+	ret = binary_manager_verify_resource(set_idx);
+	set_info->resource_valid = (ret == BINMGR_OK);
+	if (!set_info->resource_valid) {
+		bmdbg("Set %s resource validation FAIL, ret %d\n", GET_PARTNAME(set_idx), ret);
+	} else {
+		bmvdbg("Set %s resource validation PASS\n", GET_PARTNAME(set_idx));
+	}
+#endif
+
+	bmdbg("Set %s validation: kbin %d version %u, apps %d, resource %d\n", GET_PARTNAME(set_idx), set_info->kbin_valid, set_info->kbin_version, set_info->ubin_valid, set_info->resource_valid);
+
+	return BINMGR_OK;
+}
+
+static int binary_manager_select_recovery_set(uint8_t active_set, struct binmgr_set_validation_s *set_a, struct binmgr_set_validation_s *set_b, uint8_t *target_set)
+{
+	bool set_a_valid;
+	bool set_b_valid;
+	struct binmgr_set_validation_s *target_info;
+
+	if (!set_a || !set_b || !target_set || active_set >= PARTS_PER_BIN) {
+		bmdbg("Invalid recovery set select parameter\n");
+		return BINMGR_INVALID_PARAM;
+	}
+
+	set_a_valid = set_a->kbin_valid && set_a->ubin_valid && set_a->resource_valid;
+	set_b_valid = set_b->kbin_valid && set_b->ubin_valid && set_b->resource_valid;
+
+	if (set_a_valid && set_b_valid) {
+		*target_set = active_set;
+	} else if (set_a_valid) {
+		*target_set = 0;
+	} else if (set_b_valid) {
+		*target_set = 1;
+	} else {
+		return BINMGR_NOT_FOUND;
+	}
+
+	if (*target_set != active_set) {
+		target_info = (*target_set == 0) ? set_a : set_b;
+		if (target_info->kbin_version == FACTORY_KBIN_VERSION) {
+			bmdbg("Do not switch to set %s because kernel version %u is factory binary\n", GET_PARTNAME(*target_set), target_info->kbin_version);
+			return BINMGR_NOT_FOUND;
+		}
+	}
+
+	return BINMGR_OK;
+}
+
+int binary_manager_check_bootparam_set(void)
+{
+	int ret;
+	binmgr_bpdata_t *bp_data;
+
+	ret = binary_manager_update_bpinfo();
+	if (ret != BINMGR_OK) {
+		bmdbg("Fail to update BP info before set-mismatch recovery, ret %d\n", ret);
+		return ret;
+	}
+
+	bp_data = binary_manager_get_bpdata();
+	if (!bp_data) {
+		bmdbg("BP data is NULL\n");
+		return BINMGR_INVALID_PARAM;
+	}
+
+	if (binary_manager_is_set_mismatch(bp_data)) {
+		return BINMGR_OPERATION_FAIL;
+	}
+
+	bmdbg("BP set is already aligned, active idx %u\n", bp_data->head.active_idx);
+
+	return BINMGR_OK;
+}
+
+int binary_manager_recover_bootparam_set(void)
+{
+	int ret;
+	uint8_t active_set;
+	uint8_t target_set;
+	binmgr_bpdata_t update_bp_data;
+	binmgr_bpdata_t *bp_data;
+	struct binmgr_set_validation_s set_a;
+	struct binmgr_set_validation_s set_b;
+#ifdef CONFIG_APP_BINARY_SEPARATION
+	uint32_t bp_app_idx;
+#endif
+
+	bp_data = binary_manager_get_bpdata();
+	if (!bp_data) {
+		bmdbg("BP data is NULL\n");
+		return BINMGR_INVALID_PARAM;
+	}
+
+	active_set = bp_data->head.active_idx;
+	bmdbg("BP set mismatch detected. active idx %u, BP version %u\n", active_set, bp_data->head.version);
+
+	ret = binary_manager_validate_set(bp_data, 0, &set_a);
+	if (ret != BINMGR_OK) {
+		bmdbg("Fail to validate set A, ret %d\n", ret);
+		binary_manager_reset_board(REBOOT_SYSTEM_BINARY_RECOVERYFAIL);
+		return ret;
+	}
+
+	ret = binary_manager_validate_set(bp_data, 1, &set_b);
+	if (ret != BINMGR_OK) {
+		bmdbg("Fail to validate set B, ret %d\n", ret);
+		binary_manager_reset_board(REBOOT_SYSTEM_BINARY_RECOVERYFAIL);
+		return ret;
+	}
+
+	ret = binary_manager_select_recovery_set(active_set, &set_a, &set_b, &target_set);
+	if (ret != BINMGR_OK) {
+		bmdbg("Fail to select recoverable set. Reboot as recovery fail\n");
+		binary_manager_reset_board(REBOOT_SYSTEM_BINARY_RECOVERYFAIL);
+		return ret;
+	}
+
+	bmdbg("Select set %s for BP set alignment. A valid kbin %d apps %d resource %d, B valid kbin %d apps %d resource %d\n", GET_PARTNAME(target_set), set_a.kbin_valid, set_a.ubin_valid, set_a.resource_valid, set_b.kbin_valid, set_b.ubin_valid, set_b.resource_valid);
+
+	memcpy(&update_bp_data, bp_data, sizeof(binmgr_bpdata_t));
+	update_bp_data.head.version++;
+	update_bp_data.head.active_idx = target_set;
+#ifdef CONFIG_APP_BINARY_SEPARATION
+	for (bp_app_idx = 0; bp_app_idx < update_bp_data.head.app_count; bp_app_idx++) {
+		update_bp_data.head.app_data[bp_app_idx].useidx = target_set;
+	}
+#endif
+#ifdef CONFIG_RESOURCE_FS
+	update_bp_data.head.resource_active_idx = target_set;
+#endif
+	update_bp_data.head.format_ver = BOOTPARAM_FORMAT_VERSION_LATEST;
+	update_bp_data.tail.bp_update_reason = BP_UPDATE_BINARY_MANAGER_SET_ALIGNMENT;
+
+	ret = binary_manager_write_bootparam(&update_bp_data);
+	if (ret != BINMGR_OK) {
+		bmdbg("Fail to write aligned BP, ret %d. Reboot as recovery fail\n", ret);
+		binary_manager_reset_board(REBOOT_SYSTEM_BINARY_RECOVERYFAIL);
+		return ret;
+	}
+
+	bmdbg("Aligned BP to set %s, new version %u. Reboot for binary update\n", GET_PARTNAME(target_set), update_bp_data.head.version);
+	binary_manager_reset_board(REBOOT_SYSTEM_BINARY_UPDATE);
+
 	return BINMGR_OPERATION_FAIL;
 }
 

--- a/os/kernel/binary_manager/binary_manager_bootparam.c
+++ b/os/kernel/binary_manager/binary_manager_bootparam.c
@@ -63,6 +63,9 @@ void binary_manager_register_bppart(int part_num, int part_size)
 bool is_valid_bootparam(char *bootparam)
 {
 	binmgr_bpdata_head_t *bp_head = (binmgr_bpdata_head_t *)bootparam;
+#ifdef CONFIG_APP_BINARY_SEPARATION
+	uint32_t max_app_count;
+#endif
 
 	if (!bp_head) {
 		bmdbg("Boot param is NULL\n");
@@ -71,6 +74,14 @@ bool is_valid_bootparam(char *bootparam)
 		bmdbg("Invalid data. ver: %u, active index: %u, addresses: %x, %x\n", bp_head->version, bp_head->active_idx, bp_head->address[0], bp_head->address[1]);
 		return false;
 	}
+
+#ifdef CONFIG_APP_BINARY_SEPARATION
+	max_app_count = sizeof(bp_head->app_data) / sizeof(bp_head->app_data[0]);
+	if (bp_head->app_count > max_app_count) {
+		bmdbg("Invalid app count %u, max %u\n", bp_head->app_count, max_app_count);
+		return false;
+	}
+#endif
 
 	if (bp_head->crc_hash != crc32((uint8_t *)bootparam + CHECKSUM_SIZE, BOOTPARAM_SIZE - CHECKSUM_SIZE)) {
 		bmdbg("Invalid crc32 value, crc32 %u, ver: %u, active index: %u, addresses: %x, %x\n", bp_head->crc_hash, bp_head->version, bp_head->active_idx, bp_head->address[0], bp_head->address[1]);
@@ -116,6 +127,10 @@ int binary_manager_scan_bootparam(binmgr_bpinfo_t *bp_info)
 	char *bootparam;
 	size_t update_reason_offset;
 	binmgr_bpdata_t scanned_bp_data;
+#ifdef CONFIG_APP_BINARY_SEPARATION
+	uint32_t bp_app_idx;
+	uint32_t max_app_count;
+#endif
 
 	if (bp_info == NULL) {
 		bmdbg("Invalid input bp_info\n");
@@ -164,7 +179,19 @@ int binary_manager_scan_bootparam(binmgr_bpinfo_t *bp_info)
 			scanned_bp_data.tail.bp_update_reason = ((uint8_t *)bootparam)[update_reason_offset];
 		}
 
-		bmdbg("BP%d is valid. version: %u format: %u reason: %u\n", bp_idx, scanned_bp_data.head.version, scanned_bp_data.head.format_ver, scanned_bp_data.tail.bp_update_reason);
+		bmdbg("BP%d is valid. crc %u, version %u, format %u, reason %u, active idx %u, address[0] 0x%x, address[1] 0x%x\n", bp_idx, scanned_bp_data.head.crc_hash, scanned_bp_data.head.version, scanned_bp_data.head.format_ver, scanned_bp_data.tail.bp_update_reason, scanned_bp_data.head.active_idx, scanned_bp_data.head.address[0], scanned_bp_data.head.address[1]);
+
+#ifdef CONFIG_APP_BINARY_SEPARATION
+		max_app_count = sizeof(scanned_bp_data.head.app_data) / sizeof(scanned_bp_data.head.app_data[0]);
+		bmdbg("BP%d: app count %u, max %u\n", bp_idx, scanned_bp_data.head.app_count, max_app_count);
+		for (bp_app_idx = 0; bp_app_idx < scanned_bp_data.head.app_count && bp_app_idx < max_app_count; bp_app_idx++) {
+			bmdbg("BP%d: app[%u] name %.*s, useidx %u\n", bp_idx, bp_app_idx, BIN_NAME_MAX, scanned_bp_data.head.app_data[bp_app_idx].name, scanned_bp_data.head.app_data[bp_app_idx].useidx);
+		}
+#endif
+
+#ifdef CONFIG_RESOURCE_FS
+		bmdbg("BP%d: resource active idx %u\n", bp_idx, scanned_bp_data.head.resource_active_idx);
+#endif
 
 		/* Update the latest version and index */
 		if (latest_ver < scanned_bp_data.head.version) {

--- a/os/kernel/binary_manager/binary_manager_bootparam.c
+++ b/os/kernel/binary_manager/binary_manager_bootparam.c
@@ -18,6 +18,7 @@
 /****************************************************************************
  * Included Files
  ****************************************************************************/
+#include <stdint.h>
 #include <tinyara/config.h>
 #include <debug.h>
 #include <stdio.h>
@@ -60,18 +61,18 @@ void binary_manager_register_bppart(int part_num, int part_size)
 
 bool is_valid_bootparam(char *bootparam)
 {
-	binmgr_bpdata_t *bp_data = (binmgr_bpdata_t *)bootparam;
+	binmgr_bpdata_head_t *bp_head = (binmgr_bpdata_head_t *)bootparam;
 
-	if (!bp_data) {
+	if (!bp_head) {
 		bmdbg("Boot param is NULL\n");
 		return false;
-	} else if (bp_data->format_ver == 0 || bp_data->active_idx >= binary_manager_get_kdata()->part_count) {
-		bmdbg("Invalid data. ver: %u, active index: %u, addresses: %x, %x\n", bp_data->version, bp_data->active_idx, bp_data->address[0], bp_data->address[1]);
+	} else if ((bp_head->format_ver < BOOTPARAM_FORMAT_VERSION_1 || bp_head->format_ver > BOOTPARAM_FORMAT_VERSION_LATEST) || bp_head->active_idx >= binary_manager_get_kdata()->part_count) {
+		bmdbg("Invalid data. ver: %u, active index: %u, addresses: %x, %x\n", bp_head->version, bp_head->active_idx, bp_head->address[0], bp_head->address[1]);
 		return false;
 	}
 
-	if (bp_data->crc_hash != crc32((uint8_t *)bootparam + CHECKSUM_SIZE, BOOTPARAM_SIZE - CHECKSUM_SIZE)) {
-		bmdbg("Invalid crc32 value, crc32 %u, ver: %u, active index: %u, addresses: %x, %x\n", bp_data->crc_hash, bp_data->version, bp_data->active_idx, bp_data->address[0], bp_data->address[1]);
+	if (bp_head->crc_hash != crc32((uint8_t *)bootparam + CHECKSUM_SIZE, BOOTPARAM_SIZE - CHECKSUM_SIZE)) {
+		bmdbg("Invalid crc32 value, crc32 %u, ver: %u, active index: %u, addresses: %x, %x\n", bp_head->crc_hash, bp_head->version, bp_head->active_idx, bp_head->address[0], bp_head->address[1]);
 		return false;
 	}
 
@@ -112,6 +113,8 @@ int binary_manager_scan_bootparam(binmgr_bpinfo_t *bp_info)
 	int bp_idx;
 	uint32_t latest_ver = 0;
 	char *bootparam;
+	size_t update_reason_offset;
+	binmgr_bpdata_t scanned_bp_data;
 
 	if (bp_info == NULL) {
 		bmdbg("Invalid input bp_info\n");
@@ -150,14 +153,24 @@ int binary_manager_scan_bootparam(binmgr_bpinfo_t *bp_info)
 			continue;
 		}
 
-		bmdbg("BP%d is valid\n", bp_idx);
+		memcpy(&scanned_bp_data.head, bootparam, sizeof(scanned_bp_data.head));
+
+		/* Version 1 has no update reason and leaves the last byte as reserved. */
+		update_reason_offset = BOOTPARAM_SIZE - sizeof(scanned_bp_data.tail.bp_update_reason);
+		if (scanned_bp_data.head.format_ver < BOOTPARAM_FORMAT_VERSION_2 || ((uint8_t *)bootparam)[update_reason_offset] > BP_UPDATE_UNKNOWN) {
+			scanned_bp_data.tail.bp_update_reason = BP_UPDATE_UNKNOWN;
+		} else {
+			scanned_bp_data.tail.bp_update_reason = ((uint8_t *)bootparam)[update_reason_offset];
+		}
+
+		bmdbg("BP%d is valid. version: %u format: %u reason: %u\n", bp_idx, scanned_bp_data.head.version, scanned_bp_data.head.format_ver, scanned_bp_data.tail.bp_update_reason);
 
 		/* Update the latest version and index */
-		if (latest_ver < ((binmgr_bpdata_t *)bootparam)->version) {
-			latest_ver = ((binmgr_bpdata_t *)bootparam)->version;
+		if (latest_ver < scanned_bp_data.head.version) {
+			latest_ver = scanned_bp_data.head.version;
 			/* Update bootparam data */
 			bp_info->inuse_idx = bp_idx;
-			memcpy(&bp_info->bp_data, bootparam, sizeof(binmgr_bpdata_t));
+			memcpy(&bp_info->bp_data, &scanned_bp_data, sizeof(binmgr_bpdata_t));
 		}
 	}
 	close(fd);
@@ -189,7 +202,7 @@ int binary_manager_update_bpinfo(void)
 		/* Set scanned bootparam data to g_bp_info */
 		g_bp_info.inuse_idx = bp_info.inuse_idx;
 		g_bp_info.bp_data = bp_info.bp_data;
-		bmvdbg("BP[%d] ver: %u, active index: %u, addresses: %x, %x\n", g_bp_info.inuse_idx, g_bp_info.bp_data.version, g_bp_info.bp_data.active_idx, g_bp_info.bp_data.address[0], g_bp_info.bp_data.address[1]);
+		bmvdbg("BP[%d] ver: %u, format: %u, reason: %u, active index: %u, addresses: %x, %x\n", g_bp_info.inuse_idx, g_bp_info.bp_data.head.version, g_bp_info.bp_data.head.format_ver, g_bp_info.bp_data.tail.bp_update_reason, g_bp_info.bp_data.head.active_idx, g_bp_info.bp_data.head.address[0], g_bp_info.bp_data.head.address[1]);
 	}
 
 	return ret;
@@ -202,13 +215,15 @@ int binary_manager_update_bpinfo(void)
 *	 This function updates input bootparam data, bp_data to inactive bootparam partition.
 *
 ********************************************************************************/
-int binary_manager_write_bootparam(char *bootparam)
+int binary_manager_write_bootparam(binmgr_bpdata_t *bp_data)
 {
 	int fd;
 	int ret;	
 	uint8_t inuse_idx;
+	char *bootparam;
+	size_t tail_offset;
 
-	if (!bootparam) {
+	if (!bp_data) {
 		bmdbg("ERROR: Input bp data is NULL\n");
 		return BINMGR_INVALID_PARAM;
 	}
@@ -218,13 +233,28 @@ int binary_manager_write_bootparam(char *bootparam)
 		return BINMGR_INVALID_PARAM;
 	}
 
+	bootparam = (char *)kmm_malloc(BOOTPARAM_SIZE);
+	if (!bootparam) {
+		bmdbg("Fail to malloc to write BP\n");
+		return BINMGR_OUT_OF_MEMORY;
+	}
+	memset(bootparam, 0xff, BOOTPARAM_SIZE);
+
 	fd = binary_manager_open_bootparam();
 	if (fd < 0) {
+		kmm_free(bootparam);
 		return BINMGR_OPERATION_FAIL;
 	}
 
+	/* Update bootparam data : format version and bp tail */
+	bp_data->head.format_ver = BOOTPARAM_FORMAT_VERSION_LATEST;
+	tail_offset = BOOTPARAM_SIZE - sizeof(bp_data->tail);
+	memcpy(bootparam, &bp_data->head, sizeof(bp_data->head));
+	memcpy(&bootparam[tail_offset], &bp_data->tail, sizeof(bp_data->tail));
+
 	/* Update bootparam data : CRC */
-	((binmgr_bpdata_t *)bootparam)->crc_hash = crc32((uint8_t *)bootparam + CHECKSUM_SIZE, BOOTPARAM_SIZE - CHECKSUM_SIZE);
+	bp_data->head.crc_hash = crc32((uint8_t *)bootparam + CHECKSUM_SIZE, BOOTPARAM_SIZE - CHECKSUM_SIZE);
+	((binmgr_bpdata_head_t *)bootparam)->crc_hash = bp_data->head.crc_hash;
 	inuse_idx = g_bp_info.inuse_idx ^ 1;
 
 	ret = lseek(fd, BP_SEEK_OFFSET(inuse_idx), SEEK_SET);
@@ -240,17 +270,18 @@ int binary_manager_write_bootparam(char *bootparam)
 		goto errout_with_fd;
 	}
 	close(fd);
+	kmm_free(bootparam);
 
 	return BINMGR_OK;
 errout_with_fd:
 	close(fd);
+	kmm_free(bootparam);
 	return BINMGR_OPERATION_FAIL;
 }
 
 void binary_manager_update_bootparam(int requester_pid, uint8_t type)
 {
 	int ret;
-	char *bootparam;
 	bool is_all_updatable;
 	char q_name[BIN_PRIVMQ_LEN];
 	binmgr_bpdata_t update_bp_data;
@@ -268,27 +299,21 @@ void binary_manager_update_bootparam(int requester_pid, uint8_t type)
 		return;
 	}
 
-	bootparam = (char *)kmm_malloc(BOOTPARAM_SIZE);
-	if (!bootparam) {
-		bmdbg("Fail to malloc to read BP\n");
-		ret = BINMGR_OUT_OF_MEMORY;
-		goto send_response;
-	}
-	memset(bootparam, 0xff, BOOTPARAM_SIZE);
-
 	response_msg.result = BINMGR_OK;
 	is_all_updatable = true;
 
 	/* Get current bootparam data and update version */
 	memcpy(&update_bp_data, binary_manager_get_bpdata(), sizeof(binmgr_bpdata_t));
-	update_bp_data.version++;
+	update_bp_data.head.version++;
+	update_bp_data.head.format_ver = BOOTPARAM_FORMAT_VERSION_LATEST;
+	update_bp_data.tail.bp_update_reason = BP_UPDATE_BINARY_MANAGER_UPDATE;
 
 	if (BM_CHECK_GROUP(type, BINARY_KERNEL)) {
 		/* Update bootparam and Reboot if new kernel binary exists */
 		ret = binary_manager_check_kernel_update(true);
 		if (ret > 0) {
 			/* Update index for inactive partition */
-			update_bp_data.active_idx ^= 1;
+			update_bp_data.head.active_idx ^= 1;
 		} else if (ret == BINMGR_ALREADY_UPDATED || ret == BINMGR_NOT_FOUND) {
 			bmdbg("No kernel binary to update\n");
 			is_all_updatable = false;
@@ -305,7 +330,7 @@ void binary_manager_update_bootparam(int requester_pid, uint8_t type)
 		ret = binary_manager_check_resource_update(true);
 		if (ret > 0) {
 			/* Update index for inactive partition */
-			update_bp_data.resource_active_idx ^= 1;
+			update_bp_data.head.resource_active_idx ^= 1;
 		} else if (ret == BINMGR_ALREADY_UPDATED || ret == BINMGR_NOT_FOUND) {
 			bmdbg("No resource binary to update\n");
 			is_all_updatable = false;
@@ -328,7 +353,7 @@ void binary_manager_update_bootparam(int requester_pid, uint8_t type)
 			ret = binary_manager_check_user_update(bin_idx, true);
 			if (ret > 0) {
 				/* Update index for inactive partition */
-				update_bp_data.app_data[BIN_BPIDX(bin_idx)].useidx ^= 1;
+				update_bp_data.head.app_data[BIN_BPIDX(bin_idx)].useidx ^= 1;
 				need_update = true;
 			} else if (ret == BINMGR_ALREADY_UPDATED || ret == BINMGR_NOT_FOUND) {
 				bmdbg("No user binary to update: bin_idx %d, ret %d\n", bin_idx, ret);
@@ -349,7 +374,7 @@ void binary_manager_update_bootparam(int requester_pid, uint8_t type)
 		ret = binary_manager_check_user_update(BM_CMNLIB_IDX, true);
 		if (ret > 0) {
 			/* Update index for inactive partition */
-			update_bp_data.app_data[BIN_BPIDX(BM_CMNLIB_IDX)].useidx ^= 1;
+			update_bp_data.head.app_data[BIN_BPIDX(BM_CMNLIB_IDX)].useidx ^= 1;
 		} else if (ret == BINMGR_ALREADY_UPDATED || ret == BINMGR_NOT_FOUND) {
 			bmdbg("No common binary to update\n");
 			is_all_updatable = false;
@@ -364,8 +389,7 @@ void binary_manager_update_bootparam(int requester_pid, uint8_t type)
 
 	if (is_all_updatable) {
 		/* Then, Write bootparam with updated bootparam data */
-		memcpy(bootparam, &update_bp_data, sizeof(binmgr_bpdata_t));
-		ret = binary_manager_write_bootparam(bootparam);
+		ret = binary_manager_write_bootparam(&update_bp_data);
 		if (ret == BINMGR_OK) {
 			bmvdbg("Update BP SUCCESS\n");
 		} else {
@@ -377,9 +401,6 @@ void binary_manager_update_bootparam(int requester_pid, uint8_t type)
 	}
 
 send_response:
-	if (bootparam) {
-		kmm_free(bootparam);
-	}
 	response_msg.result = ret;
 	snprintf(q_name, BIN_PRIVMQ_LEN, "%s%d", BINMGR_RESPONSE_MQ_PREFIX, requester_pid);
 	binary_manager_send_response(q_name, &response_msg, sizeof(binmgr_setbp_response_t));
@@ -429,7 +450,6 @@ void binary_manager_set_bpidx(uint8_t index)
 void binary_manager_swap_bootparam(int requester_pid)
 {
 	int ret;
-	char *bootparam;
 	bool is_all_updatable;
 	char q_name[BIN_PRIVMQ_LEN];
 	binmgr_bpdata_t update_bp_data;
@@ -446,20 +466,14 @@ void binary_manager_swap_bootparam(int requester_pid)
 		return;
 	}
 
-	bootparam = (char *)kmm_malloc(BOOTPARAM_SIZE);
-	if (!bootparam) {
-		bmdbg("Fail to malloc to read BP\n");
-		ret = BINMGR_OUT_OF_MEMORY;
-		goto send_response;
-	}
-	memset(bootparam, 0xff, BOOTPARAM_SIZE);
-
 	response_msg.result = BINMGR_OK;
 	is_all_updatable = true;
 
 	/* Get current bootparam data */
 	memcpy(&update_bp_data, binary_manager_get_bpdata(), sizeof(binmgr_bpdata_t));
-	update_bp_data.version++;
+	update_bp_data.head.version++;
+	update_bp_data.head.format_ver = BOOTPARAM_FORMAT_VERSION_LATEST;
+	update_bp_data.tail.bp_update_reason = BP_UPDATE_BINARY_MANAGER_SWAP;
 
 	/* Update bootparam and Reboot if valid kernel binary exists */
 	ret = binary_manager_check_kernel_update(false);
@@ -467,7 +481,7 @@ void binary_manager_swap_bootparam(int requester_pid)
 		bmdbg("Fail to find valid kernel binary, %d\n", ret);
 		goto send_response;
 	}
-	update_bp_data.active_idx ^= 1;
+	update_bp_data.head.active_idx ^= 1;
 
 #ifdef CONFIG_RESOURCE_FS
 	/* Update bootparam if valid resource binary exists */
@@ -476,7 +490,7 @@ void binary_manager_swap_bootparam(int requester_pid)
 		bmdbg("Fail to find valid resource binary, %d\n", ret);
 		goto send_response;
 	}
-	update_bp_data.resource_active_idx ^= 1;
+	update_bp_data.head.resource_active_idx ^= 1;
 #endif
 
 #ifdef CONFIG_APP_BINARY_SEPARATION
@@ -488,7 +502,7 @@ void binary_manager_swap_bootparam(int requester_pid)
 			bmdbg("Fail to find valid user binary, %d\n", ret);
 			goto send_response;
 		}
-		update_bp_data.app_data[BIN_BPIDX(bin_idx)].useidx ^= 1;
+		update_bp_data.head.app_data[BIN_BPIDX(bin_idx)].useidx ^= 1;
 	}
 
 #ifdef CONFIG_SUPPORT_COMMON_BINARY
@@ -497,13 +511,12 @@ void binary_manager_swap_bootparam(int requester_pid)
 		bmdbg("Fail to find valid common binary, %d\n", ret);
 		goto send_response;
 	}
-	update_bp_data.app_data[BIN_BPIDX(BM_CMNLIB_IDX)].useidx ^= 1;
+	update_bp_data.head.app_data[BIN_BPIDX(BM_CMNLIB_IDX)].useidx ^= 1;
 #endif
 #endif
 
 	/* Then, Write bootparam with updated bootparam data */
-	memcpy(bootparam, &update_bp_data, sizeof(binmgr_bpdata_t));
-	ret = binary_manager_write_bootparam(bootparam);
+	ret = binary_manager_write_bootparam(&update_bp_data);
 	if (ret == BINMGR_OK) {
 		bmvdbg("Update BP SUCCESS\n");
 	} else {
@@ -511,9 +524,6 @@ void binary_manager_swap_bootparam(int requester_pid)
 	}
 
 send_response:
-	if (bootparam) {
-		kmm_free(bootparam);
-	}
 	response_msg.result = ret;
 	snprintf(q_name, BIN_PRIVMQ_LEN, "%s%d", BINMGR_RESPONSE_MQ_PREFIX, requester_pid);
 	binary_manager_send_response(q_name, &response_msg, sizeof(binmgr_response_t));

--- a/os/kernel/binary_manager/binary_manager_data.c
+++ b/os/kernel/binary_manager/binary_manager_data.c
@@ -114,6 +114,45 @@ void binary_manager_register_kpart(int part_num, int part_size, uint32_t part_ad
 }
 
 /****************************************************************************
+ * Name: binary_manager_verify_kbin
+ *
+ * Description:
+ *	 This function verifies the kernel binary in part_idx.
+ *
+ ****************************************************************************/
+int binary_manager_verify_kbin(uint8_t part_idx)
+{
+	int ret;
+	char filepath[BINARY_PATH_LEN];
+	kernel_binary_header_t header_data;
+
+	if (part_idx >= kernel_info.part_count) {
+		bmdbg("Invalid kernel part idx %u, part count %u\n", part_idx, kernel_info.part_count);
+		return BINMGR_INVALID_PARAM;
+	}
+
+#ifdef CONFIG_BINARY_SIGNING
+	ret = up_verify_kernelsignature(kernel_info.part_info[part_idx].address);
+	if (ret != SIGNATURE_VAILD) {
+		bmdbg("Invalid Kernel Signature, part idx %u, address : 0x%x\n", part_idx, kernel_info.part_info[part_idx].address);
+		return BINMGR_NOT_FOUND;
+	}
+	bmvdbg("Kernel Signature Checking Success, part idx %u\n", part_idx);
+#endif
+
+	snprintf(filepath, BINARY_PATH_LEN, BINMGR_DEVNAME_FMT, kernel_info.part_info[part_idx].devnum);
+	ret = binary_manager_read_header(BINARY_KERNEL, filepath, (void *)&header_data, true);
+	if (ret != BINMGR_OK) {
+		bmdbg("Invalid kernel candidate, part idx %u, devpath %s, ret %d\n", part_idx, filepath, ret);
+		return ret;
+	}
+
+	bmvdbg("Valid kernel candidate [%s], dev %d, version %u\n", GET_PARTNAME(part_idx), kernel_info.part_info[part_idx].devnum, header_data.version);
+
+	return BINMGR_OK;
+}
+
+/****************************************************************************
  * Name: binary_manager_scan_kbin
  *
  * Description:
@@ -386,6 +425,61 @@ void binary_manager_register_upart(char *name, int part_num, int part_size, uint
 	BIN_NAME(bin_idx)[BIN_NAME_MAX - 1] = '\0';
 	sq_init(&BIN_CBLIST(bin_idx));
 	bmdbg("[USER%d : 1] %s size %d num %d, address 0x%x\n", bin_idx, BIN_NAME(bin_idx), BIN_PARTSIZE(bin_idx, 0), BIN_PARTNUM(bin_idx, 0), BIN_PARTADDR(bin_idx, 0));
+}
+
+/****************************************************************************
+ * Name: binary_manager_verify_ubin
+ *
+ * Description:
+ *	 This function verifies the user/common binary candidate.
+ *
+ ****************************************************************************/
+int binary_manager_verify_ubin(int bin_idx, uint8_t part_idx)
+{
+	int ret;
+	char devpath[BINARY_PATH_LEN];
+#ifdef CONFIG_SUPPORT_COMMON_BINARY
+	common_binary_header_t common_header_data;
+#endif
+	user_binary_header_t user_header_data;
+
+	if (bin_idx < 0 || bin_idx > binary_manager_get_ucount()) {
+		bmdbg("Invalid bin idx %d\n", bin_idx);
+		return BINMGR_INVALID_PARAM;
+	}
+
+	if (part_idx >= BIN_COUNT(bin_idx)) {
+		bmdbg("Invalid %s part idx %u, part count %u\n", BIN_NAME(bin_idx), part_idx, BIN_COUNT(bin_idx));
+		return BINMGR_INVALID_PARAM;
+	}
+
+#ifdef CONFIG_BINARY_SIGNING
+	ret = up_verify_usersignature(BIN_PARTADDR(bin_idx, part_idx));
+	if (ret != SIGNATURE_VAILD) {
+		bmdbg("Invalid Signature, name : %s, part idx %u, address : 0x%x\n", BIN_NAME(bin_idx), part_idx, BIN_PARTADDR(bin_idx, part_idx));
+		return BINMGR_NOT_FOUND;
+	}
+	bmvdbg("%s Signature Checking Success, part idx %u\n", BIN_NAME(bin_idx), part_idx);
+#endif
+
+	snprintf(devpath, BINARY_PATH_LEN, BINMGR_DEVNAME_FMT, BIN_PARTNUM(bin_idx, part_idx));
+#ifdef CONFIG_SUPPORT_COMMON_BINARY
+	if (bin_idx == BM_CMNLIB_IDX) {
+		ret = binary_manager_read_header(BINARY_COMMON, devpath, (void *)&common_header_data, true);
+	} else
+#endif
+	{
+		ret = binary_manager_read_header(BINARY_USERAPP, devpath, (void *)&user_header_data, true);
+	}
+
+	if (ret != BINMGR_OK) {
+		bmdbg("Invalid binary candidate, name %s, part idx %u, devpath %s, ret %d\n", BIN_NAME(bin_idx), part_idx, devpath, ret);
+		return ret;
+	}
+
+	bmvdbg("Valid binary candidate %s [%s], dev %d\n", BIN_NAME(bin_idx), GET_PARTNAME(part_idx), BIN_PARTNUM(bin_idx, part_idx));
+
+	return BINMGR_OK;
 }
 
 /****************************************************************************

--- a/os/kernel/binary_manager/binary_manager_data.c
+++ b/os/kernel/binary_manager/binary_manager_data.c
@@ -130,11 +130,11 @@ bool binary_manager_scan_kbin(void)
 	binmgr_bpdata_t *bp_data;
 	bp_data = binary_manager_get_bpdata();
 	/* Verify running kernel binary based on bootparam */
-	snprintf(filepath, BINARY_PATH_LEN, BINMGR_DEVNAME_FMT, kernel_info.part_info[bp_data->active_idx].devnum);
+	snprintf(filepath, BINARY_PATH_LEN, BINMGR_DEVNAME_FMT, kernel_info.part_info[bp_data->head.active_idx].devnum);
 	ret = binary_manager_read_header(BINARY_KERNEL, filepath, &header_data, false);
 	if (ret == OK) {
 		/* Update inuse index and kernel version */
-		kernel_info.inuse_idx = bp_data->active_idx;
+		kernel_info.inuse_idx = bp_data->head.active_idx;
 		kernel_info.version = header_data.version;
 		bmdbg("Kernel version [%u] %u\n", kernel_info.inuse_idx, kernel_info.version);
 		return true;
@@ -244,17 +244,17 @@ int binary_manager_check_update(void)
 	}
 
 	/* Compare bootparam version with current running version */
-	if (binary_manager_get_bpdata()->version >= bp_info.bp_data.version) {
+	if (binary_manager_get_bpdata()->head.version >= bp_info.bp_data.head.version) {
 		/* No bootparam update */
 		bmdbg("All binaries are running based on BP\n");
 		return BINMGR_NOT_FOUND;
 	}
 
 	/* Do kernel need to update? */
-	if (binary_manager_get_kdata()->inuse_idx != bp_info.bp_data.active_idx) {
+	if (binary_manager_get_kdata()->inuse_idx != bp_info.bp_data.head.active_idx) {
 		/* Running partition and partition written in the latest BP are different.
 		 * Reboot to switch kernel binary in another partition. */
-		bmvdbg("Need to update to kernel binary in partition %d in the latest BP.\n", binary_manager_get_kdata()->part_info[bp_info.bp_data.active_idx].devnum);
+		bmvdbg("Need to update to kernel binary in partition %d in the latest BP.\n", binary_manager_get_kdata()->part_info[bp_info.bp_data.head.active_idx].devnum);
 		goto reboot;
 	}
 #else
@@ -417,14 +417,14 @@ bool binary_manager_scan_ubin_all(void)
 #ifdef CONFIG_USE_BP
 	bp_data = binary_manager_get_bpdata();
 	/* Update user binary data based on bootparam */
-	for (bp_app_idx = 0; bp_app_idx < bp_data->app_count; bp_app_idx++) {
-		bin_idx = binary_manager_get_index_with_name(bp_data->app_data[bp_app_idx].name);
+	for (bp_app_idx = 0; bp_app_idx < bp_data->head.app_count; bp_app_idx++) {
+		bin_idx = binary_manager_get_index_with_name(bp_data->head.app_data[bp_app_idx].name);
 		if (bin_idx < 0) {
-			bmdbg("Fail to find matched binary %s in binary table \n", bp_data->app_data[bp_app_idx].name);
+			bmdbg("Fail to find matched binary %s in binary table \n", bp_data->head.app_data[bp_app_idx].name);
 			continue;
 		}
 		BIN_BPIDX(bin_idx) = bp_app_idx;
-		part_idx = bp_data->app_data[bp_app_idx].useidx;
+		part_idx = bp_data->head.app_data[bp_app_idx].useidx;
 		snprintf(devpath, BINARY_PATH_LEN, BINMGR_DEVNAME_FMT, BIN_PARTNUM(bin_idx, part_idx));
 		bmdbg("Checking user in partition [%d], path %s\n", part_idx, devpath);
 #ifdef CONFIG_SUPPORT_COMMON_BINARY

--- a/os/kernel/binary_manager/binary_manager_internal.h
+++ b/os/kernel/binary_manager/binary_manager_internal.h
@@ -244,12 +244,13 @@ struct binmgr_bpinfo_s {
 };
 typedef struct binmgr_bpinfo_s binmgr_bpinfo_t;
 
-struct binmgr_set_validation_s {
-	bool kbin_valid;
-	uint32_t kbin_version;
-	bool ubin_valid;
-	bool resource_valid;
+struct binmgr_bp_recovery_info_s {
+	bool has_valid_bp;
+	int inuse_idx;
+	int active_set;
+	uint32_t bp_version;
 };
+typedef struct binmgr_bp_recovery_info_s binmgr_bp_recovery_info_t;
 
 struct statecb_node_s {
 	struct statecb_node_s *flink;

--- a/os/kernel/binary_manager/binary_manager_internal.h
+++ b/os/kernel/binary_manager/binary_manager_internal.h
@@ -196,10 +196,10 @@ enum bp_update_reason_e {
 	BP_UPDATE_BINARY_MANAGER_UPDATE = 9,
 	BP_UPDATE_BINARY_MANAGER_RECOVERY_USER = 10,
 	BP_UPDATE_BINARY_MANAGER_RECOVERY_RESOURCE = 11,
-	BP_UPDATE_BINARY_MANAGER_SPECIFIC_1 = 12,
-	BP_UPDATE_BINARY_MANAGER_SPECIFIC_2 = 13,
-	BP_UPDATE_BINARY_MANAGER_SPECIFIC_3 = 14,
-	BP_UPDATE_BINARY_MANAGER_SPECIFIC_4 = 15,
+	BP_UPDATE_BINARY_MANAGER_SET_ALIGNMENT = 12,
+	BP_UPDATE_BINARY_MANAGER_SPECIFIC_1 = 13,
+	BP_UPDATE_BINARY_MANAGER_SPECIFIC_2 = 14,
+	BP_UPDATE_BINARY_MANAGER_SPECIFIC_3 = 15,
 	BP_UPDATE_UNKNOWN = 16
 };
 
@@ -243,6 +243,13 @@ struct binmgr_bpinfo_s {
 	binmgr_bpdata_t bp_data;
 };
 typedef struct binmgr_bpinfo_s binmgr_bpinfo_t;
+
+struct binmgr_set_validation_s {
+	bool kbin_valid;
+	uint32_t kbin_version;
+	bool ubin_valid;
+	bool resource_valid;
+};
 
 struct statecb_node_s {
 	struct statecb_node_s *flink;
@@ -342,10 +349,15 @@ int binary_manager_update_kernel_binary(void);
 #ifdef CONFIG_RESOURCE_FS
 binmgr_resinfo_t *binary_manager_get_resdata(void);
 int binary_manager_unmount_resource(void);
+int binary_manager_verify_resource(uint8_t part_idx);
 int binary_manager_check_resource_update(bool check_updatable);
 #endif
+int binary_manager_verify_kbin(uint8_t part_idx);
 int binary_manager_check_kernel_update(bool check_updatable);
+#ifdef CONFIG_APP_BINARY_SEPARATION
+int binary_manager_verify_ubin(int bin_idx, uint8_t part_idx);
 int binary_manager_check_user_update(int bin_idx, bool check_updatable);
+#endif
 
 /****************************************************************************
  * Binary Manager Main Thread

--- a/os/kernel/binary_manager/binary_manager_internal.h
+++ b/os/kernel/binary_manager/binary_manager_internal.h
@@ -78,6 +78,9 @@
 #define BOOTPARAM_COUNT            2                          /* The number of boot parameters */
 #define BOOTPARAM_SIZE             4096                       /* The size of boot parameter : 4K */
 #define BOOTPARAM_PARTSIZE         (BOOTPARAM_SIZE * 2)       /* The size of partition for dual boot parameters : 8K */
+#define BOOTPARAM_FORMAT_VERSION_1       1
+#define BOOTPARAM_FORMAT_VERSION_2       2
+#define BOOTPARAM_FORMAT_VERSION_LATEST  BOOTPARAM_FORMAT_VERSION_2
 
 #define CHECKSUM_SIZE              4
 
@@ -180,8 +183,28 @@ struct binmgr_userbp_s {
 };
 typedef struct binmgr_userbp_s binmgr_userbp_t;
 
-/* Boot parameter data */
-struct binmgr_bpdata_s {
+enum bp_update_reason_e {
+	BP_UPDATE_INITIALIZED = 0,
+	BP_UPDATE_BOOTLOADER_BP_CRC_FAIL = 1,
+	BP_UPDATE_BOOTLOADER_KERNEL_CRC_FAIL = 2,
+	BP_UPDATE_BOOTLOADER_KERNEL_INVALID_SIZE = 3,
+	BP_UPDATE_BOOTLOADER_KERNEL_FAIL_TO_BOOT = 4,
+	BP_UPDATE_BOOTLOADER_SPECIFIC_1 = 5,
+	BP_UPDATE_BOOTLOADER_SPECIFIC_2 = 6,
+	BP_UPDATE_BOOTLOADER_SPECIFIC_3 = 7,
+	BP_UPDATE_BINARY_MANAGER_SWAP = 8,
+	BP_UPDATE_BINARY_MANAGER_UPDATE = 9,
+	BP_UPDATE_BINARY_MANAGER_RECOVERY_USER = 10,
+	BP_UPDATE_BINARY_MANAGER_RECOVERY_RESOURCE = 11,
+	BP_UPDATE_BINARY_MANAGER_SPECIFIC_1 = 12,
+	BP_UPDATE_BINARY_MANAGER_SPECIFIC_2 = 13,
+	BP_UPDATE_BINARY_MANAGER_SPECIFIC_3 = 14,
+	BP_UPDATE_BINARY_MANAGER_SPECIFIC_4 = 15,
+	BP_UPDATE_UNKNOWN = 16
+};
+
+/* Boot parameter head data, stored at the beginning of each BP. */
+struct binmgr_bpdata_head_s {
 	uint32_t crc_hash;
 	uint32_t version;
 	uint32_t format_ver;
@@ -195,7 +218,24 @@ struct binmgr_bpdata_s {
 	uint8_t resource_active_idx;
 #endif
 } __attribute__((__packed__));
+typedef struct binmgr_bpdata_head_s binmgr_bpdata_head_t;
+
+/* Boot parameter tail data, stored at the end of each BP. */
+struct binmgr_bpdata_tail_s {
+	/* future field should be added here */
+	uint8_t bp_update_reason;						/* Added on format version 2 */
+} __attribute__((__packed__));
+typedef struct binmgr_bpdata_tail_s binmgr_bpdata_tail_t;
+
+/* Logical boot parameter data */
+struct binmgr_bpdata_s {
+	binmgr_bpdata_head_t head;
+	binmgr_bpdata_tail_t tail;
+} __attribute__((__packed__));
 typedef struct binmgr_bpdata_s binmgr_bpdata_t;
+
+/* Compile-time assertion: serialized head and tail must fit in one BP. */
+static_assert(sizeof(binmgr_bpdata_t) <= BOOTPARAM_SIZE, "binmgr_bpdata_t size exceeds BOOTPARAM_SIZE");
 
 struct binmgr_bpinfo_s {
 	uint8_t inuse_idx;
@@ -293,6 +333,8 @@ void binary_manager_update_running_state(int bin_id);
 int binary_manager_get_index_with_name(char *bin_name);
 int binary_manager_scan_bootparam(binmgr_bpinfo_t *bp_info);
 binmgr_bpdata_t *binary_manager_get_bpdata(void);
+int binary_manager_set_bpdata(binmgr_bpdata_t *bp_data);
+int binary_manager_write_bootparam(binmgr_bpdata_t *bp_data);
 int binary_manager_get_inactive_path(int requester_pid, char *bin_name);
 void binary_manager_update_bootparam(int requester_pid, uint8_t type);
 void binary_manager_reset_board(int reboot_reason);

--- a/os/kernel/binary_manager/binary_manager_internal.h
+++ b/os/kernel/binary_manager/binary_manager_internal.h
@@ -191,7 +191,9 @@ struct binmgr_bpdata_s {
 	uint8_t app_count;
 	binmgr_userbp_t app_data[CONFIG_NUM_APPS + 1];
 #endif
+#ifdef CONFIG_RESOURCE_FS
 	uint8_t resource_active_idx;
+#endif
 } __attribute__((__packed__));
 typedef struct binmgr_bpdata_s binmgr_bpdata_t;
 

--- a/os/kernel/binary_manager/binary_manager_load.c
+++ b/os/kernel/binary_manager/binary_manager_load.c
@@ -287,8 +287,10 @@ static int binary_manager_load(int bin_idx)
 				/* Update boot param data because the binary not written to bootparam is loaded */
 				binmgr_bpdata_t update_bp_data;
 				memcpy(&update_bp_data, binary_manager_get_bpdata(), sizeof(binmgr_bpdata_t));
-				update_bp_data.version++;
-				update_bp_data.app_data[BIN_BPIDX(bin_idx)].useidx ^= 1;
+				update_bp_data.head.version++;
+				update_bp_data.head.format_ver = BOOTPARAM_FORMAT_VERSION_LATEST;
+				update_bp_data.head.app_data[BIN_BPIDX(bin_idx)].useidx ^= 1;
+				update_bp_data.tail.bp_update_reason = BP_UPDATE_BINARY_MANAGER_RECOVERY_USER;
 				ret = binary_manager_write_bootparam(&update_bp_data);
 				if (ret == BINMGR_OK) {
 					binary_manager_set_bpdata(&update_bp_data);

--- a/os/kernel/binary_manager/binary_manager_resource.c
+++ b/os/kernel/binary_manager/binary_manager_resource.c
@@ -111,7 +111,7 @@ int binary_manager_mount_resource(void)
 	}
 
 	bp_data = binary_manager_get_bpdata();
-	inuse_idx = bp_data->resource_active_idx;
+	inuse_idx = bp_data->head.resource_active_idx;
 #else
 	uint32_t latest_ver = 0;
 	int latest_partidx = -1;
@@ -214,8 +214,10 @@ int binary_manager_mount_resource(void)
 		/* Update boot param data because the binary not written to bootparam is loaded */
 		binmgr_bpdata_t update_bp_data;
 		memcpy(&update_bp_data, binary_manager_get_bpdata(), sizeof(binmgr_bpdata_t));
-		update_bp_data.version++;
-		update_bp_data.resource_active_idx = inuse_idx;
+		update_bp_data.head.version++;
+		update_bp_data.head.format_ver = BOOTPARAM_FORMAT_VERSION_LATEST;
+		update_bp_data.head.resource_active_idx = inuse_idx;
+		update_bp_data.tail.bp_update_reason = BP_UPDATE_BINARY_MANAGER_RECOVERY_RESOURCE;
 		ret = binary_manager_write_bootparam(&update_bp_data);
 		if (ret == BINMGR_OK) {
 			binary_manager_set_bpdata(&update_bp_data);

--- a/os/kernel/binary_manager/binary_manager_resource.c
+++ b/os/kernel/binary_manager/binary_manager_resource.c
@@ -80,6 +80,49 @@ void binary_manager_register_respart(int part_num, int part_size, uint32_t part_
 }
 
 /****************************************************************************
+ * Name: binary_manager_verify_resource
+ *
+ * Description:
+ *	 This function verifies the resource binary in part_idx.
+ *
+ ****************************************************************************/
+int binary_manager_verify_resource(uint8_t part_idx)
+{
+	int ret;
+	char filepath[BINARY_PATH_LEN];
+	resource_binary_header_t header_data;
+#ifdef CONFIG_RESOURCE_BINARY_SIGNING
+	uint32_t resource_start_address;
+#endif
+
+	if (part_idx >= resource_info.part_count) {
+		bmdbg("Invalid resource part idx %u, part count %u\n", part_idx, resource_info.part_count);
+		return BINMGR_INVALID_PARAM;
+	}
+
+#ifdef CONFIG_RESOURCE_BINARY_SIGNING
+	resource_start_address = resource_info.part_info[part_idx].address;
+	ret = up_verify_usersignature(resource_start_address);
+	if (ret != SIGNATURE_VAILD) {
+		bmdbg("Invalid Resource Signature, part idx %u, address : 0x%x\n", part_idx, resource_start_address);
+		return BINMGR_NOT_FOUND;
+	}
+	bmvdbg("Resource Signature Checking Success, part idx %u, address : 0x%x\n", part_idx, resource_start_address);
+#endif
+
+	snprintf(filepath, BINARY_PATH_LEN, BINMGR_DEVNAME_FMT, resource_info.part_info[part_idx].devnum);
+	ret = binary_manager_read_header(BINARY_RESOURCE, filepath, (void *)&header_data, true);
+	if (ret != BINMGR_OK) {
+		bmdbg("Invalid resource candidate, part idx %u, devpath %s, ret %d\n", part_idx, filepath, ret);
+		return ret;
+	}
+
+	bmvdbg("Valid resource candidate [%s], dev %d, version %u\n", GET_PARTNAME(part_idx), resource_info.part_info[part_idx].devnum, header_data.version);
+
+	return BINMGR_OK;
+}
+
+/****************************************************************************
  * Name: binary_manager_mount_resource
  *
  * Description:
@@ -95,7 +138,9 @@ int binary_manager_mount_resource(void)
 	char devpath[BINARY_PATH_LEN];
 	char fs_devpath[BINARY_PATH_LEN];
 	resource_binary_header_t header_data;
+#ifdef CONFIG_RESOURCE_BINARY_SIGNING
 	uint32_t resource_start_address = 0;
+#endif
 
 	if (resource_info.is_mounted) {
 		bmvdbg("RESOURCEFS is already mounted\n");
@@ -271,7 +316,9 @@ int binary_manager_check_resource_update(bool check_updatable)
 	int inactive_partidx;
 	char filepath[BINARY_PATH_LEN];
 	resource_binary_header_t header_data;
+#ifdef CONFIG_RESOURCE_BINARY_SIGNING
 	uint32_t resource_start_address;
+#endif
 
 	inactive_partidx = resource_info.inuse_idx ^ 1;
 

--- a/os/tools/mkbootparam.py
+++ b/os/tools/mkbootparam.py
@@ -40,7 +40,7 @@ SIZE_OF_BP_PARTITION = SIZE_OF_BPx * 2
 #  * An output, 'bootparam.bin' should be downloaded and be located at the end of a flash.
 #
 # Boot Parameter information (BPx) :
-#  - Boot Parameter Format Version 1 (bootparam_format_version = 1)
+#  - Boot Parameter Format Version 2 (bootparam_format_version = 2)
 #  - The data from 'App Count' depends on CONFIG_APP_SEPARATION.
 # +------------------------------------------------------------------------------------------
 # | Checksum | BP Version | BP Format Version | Active Idx | First Address | Second Address |
@@ -50,11 +50,11 @@ SIZE_OF_BP_PARTITION = SIZE_OF_BPx * 2
 # | App Count | App1 Name  | App1 Active Idx | App2 Name  | App2 Active Idx |     App# ...   |
 # |  (1byte)  | (16 bytes) |   (1 bytes)     | (16 bytes) |    (1 bytes)    |  (## bytes)    |
 # --------------------------------------------------------------------------------------------
-# ------------------------------------------------------------------+
-# | Resource Active Idx |                 Reserved                  |
-# |       (1 byte)      |        (4Kbytes - (23 + @)bytes)          |
-# ------------------------------------------------------------------+
-#  * The "Checksum" is crc32 value for data from "BP Version" to "Second Address".
+# -------------------------------------------------------------------------------+
+# | Resource Active Idx |              Reserved               | BP Update Reason |
+# |       (1 byte)      |       ... to fixed bp tail          |      (1 byte)    |
+# -------------------------------------------------------------------------------+
+#  * The "Checksum" is crc32 value for data from "BP Version" to the last byte of BP.
 #  * The "BP Version" is a version to check the latest of boot parameters.
 #  * The "BP Format Version" is a version to manage the format of boot parameters.
 #  * The "Active Idx" is a index indicating which address value to use.
@@ -70,6 +70,9 @@ SIZE_OF_BP_PARTITION = SIZE_OF_BPx * 2
 #    - All resource have 2 partitions.
 #    - If the value is 0, "First partition" will be mounted.
 #    - If the value is 1, "Second partition" will be mounted.
+#  * The "BP Update Reason" is the last successful reason for updating BP.
+#    It is located at the last byte of each 4KB BP so the bootloader can update
+#    it without knowing the variable app/resource data layout.
 #
 ###########################################################################################
 
@@ -81,8 +84,10 @@ def make_bootparam():
     SIZE_OF_KERNEL_INDEX = 1
     SIZE_OF_KERNEL_FIRST_ADDR = 4
     SIZE_OF_KERNEL_SECOND_ADDR = 4
+    SIZE_OF_RESOURCE_INDEX = 1
+    SIZE_OF_UPDATE_REASON = 1
 
-    kernel_data_size = SIZE_OF_CHECKSUM + SIZE_OF_BP_VERSION + SIZE_OF_BP_VERSION + SIZE_OF_KERNEL_INDEX + SIZE_OF_KERNEL_FIRST_ADDR + SIZE_OF_KERNEL_SECOND_ADDR
+    kernel_data_size = SIZE_OF_CHECKSUM + SIZE_OF_BP_VERSION + SIZE_OF_BP_FORMAT_VERSION + SIZE_OF_KERNEL_INDEX + SIZE_OF_KERNEL_FIRST_ADDR + SIZE_OF_KERNEL_SECOND_ADDR
 
     FLASH_START_ADDR = util.get_value_from_file(config_file_path, "CONFIG_FLASH_START_ADDR=")
     FLASH_SIZE = util.get_value_from_file(config_file_path, "CONFIG_FLASH_SIZE=")
@@ -92,6 +97,7 @@ def make_bootparam():
     sizes = filter(None, sizes)
 
     INITIAL_ACTIVE_IDX = 0
+    INITIAL_BP_REASON = 0
 
     # Check partitions of kernel and bootparam
     kernel_address = []
@@ -125,7 +131,7 @@ def make_bootparam():
     with open(bootparam_file_path, 'wb') as fp:
         # Write Data
         bootparam_version = 1
-        bootparam_format_version = 1
+        bootparam_format_version = 2
         fp.write(struct.pack('I', bootparam_version))
         fp.write(struct.pack('I', bootparam_format_version))
         # Kernel data
@@ -161,14 +167,16 @@ def make_bootparam():
     # Resource Data
     resource_data_size = 0
     if (util.check_config_existence(config_file_path, "CONFIG_RESOURCE_FS")) :
-        resource_data_size = 1
+        resource_data_size = SIZE_OF_RESOURCE_INDEX
         with open(bootparam_file_path, 'a') as fp:
                 fp.write(struct.pack('B', INITIAL_ACTIVE_IDX))
 
-    # Fill remaining space with '0xff'
+    # Fill remaining space with '0xff' up to the fixed BP tail and write bp_tail
+    bp_tail = struct.pack('B', INITIAL_BP_REASON)
     with open(bootparam_file_path, 'a') as fp:
         remain_size = SIZE_OF_BPx - (kernel_data_size + total_app_data_size + resource_data_size)
-        fp.write(b'\xff' * remain_size)
+        fp.write(b'\xff' * (remain_size - len(bp_tail)))
+        fp.write(bp_tail)
 
     # Add checksum for BP1
     mkchecksum_path = os.path.dirname(__file__) + '/mkchecksum.py'


### PR DESCRIPTION
Add functionality to recover binary manager when a mismatch is detected between the kernel active idx and other idx.
This includes validation of kernel, user binaries and resource binaries to ensure consistency.
The `binary_manager_recover_bootparam_set_mismatch` function checks the set mismatch before mounting resource in booting sequence.

[New recovery process description]
Validate all 8 binaries (Kernel, Common, App1, Resource A/B),
Update the Inactive BP with the latest valid version from Partitions A/B (upgrade to the active BP version + 1), and reboot.

This PR is based on #7302 