### PR TITLE
framework/src/ble_manager : Using static variables to prevent memory violations

### DIFF
--- a/framework/src/ble_manager/ble_manager_api.c
+++ b/framework/src/ble_manager/ble_manager_api.c
@@ -79,7 +79,7 @@ ble_result_e ble_manager_start_bond(ble_conn_handle conn_handle)
 
 ble_result_e ble_manager_get_bonded_device(ble_bonded_device_list *device_list, uint16_t *device_count)
 {
-	blemgr_msg_params param = {2, {(void *)device_list, (void *)device_count}};
+	blemgr_msg_params param = { 2, {(void *)device_list, (void *)device_count} };
 	blemgr_msg_s msg = {BLE_CMD_GET_BONDED_DEV, BLE_MANAGER_FAIL, (void *)(&param), NULL};
 	int res = blemgr_post_message(&msg);
 
@@ -104,7 +104,7 @@ ble_result_e ble_manager_delete_bonded_all(void)
 
 ble_result_e ble_manager_conn_is_active(ble_conn_handle con_handle, bool *is_active)
 {
-	blemgr_msg_params param = {2, {(void *)&con_handle, (void *)is_active}};
+	blemgr_msg_params param = { 2, {(void *)&con_handle, (void *)is_active} };
 	blemgr_msg_s msg = {BLE_CMD_CONN_IS_ACTIVE, BLE_MANAGER_FAIL, (void *)(&param), NULL};
 	int res = blemgr_post_message(&msg);
 
@@ -129,7 +129,7 @@ ble_result_e ble_manager_get_version(uint8_t version[3])
 
 ble_result_e ble_manager_conn_param_update(ble_conn_handle *con_handle, ble_conn_param *conn_param)
 {
-	blemgr_msg_params param = {2, {(void *)con_handle, (void *)conn_param}};
+	blemgr_msg_params param = { 2, {(void *)con_handle, (void *) conn_param} };
 	blemgr_msg_s msg = {BLE_CMD_CONN_PARAM_UPDATE, BLE_MANAGER_FAIL, (void *)(&param), NULL};
 	int res = blemgr_post_message(&msg);
 
@@ -148,7 +148,7 @@ ble_result_e ble_client_set_scan(uint16_t scan_interval, uint16_t scan_window, u
 
 ble_result_e ble_client_start_scan(ble_scan_filter *filter, ble_scan_callback_list *callbacks)
 {
-	blemgr_msg_params param = {2, {(void *)filter, (void *)callbacks}};
+	blemgr_msg_params param = { 2, {(void *)filter, (void *)callbacks} };
 	blemgr_msg_s msg = {BLE_CMD_START_SCAN, BLE_MANAGER_FAIL, (void *)(&param), NULL};
 	int res = blemgr_post_message(&msg);
 
@@ -189,7 +189,7 @@ ble_result_e ble_scan_whitelist_clear_all(void)
 
 uint16_t ble_scan_whitelist_list(ble_addr addr[], uint16_t size)
 {
-	blemgr_msg_params param = {2, {(void *)addr, (void *)&size}};
+	blemgr_msg_params param = { 2, {(void *)addr, (void *)&size} };
 	blemgr_msg_s msg = {BLE_CMD_WHITELIST_LIST, BLE_MANAGER_FAIL, (void *)(&param), NULL};
 	int res = blemgr_post_message(&msg);
 
@@ -233,7 +233,7 @@ ble_client_state_e ble_client_get_state(ble_client_ctx *ctx)
 
 ble_result_e ble_client_connect(ble_client_ctx *ctx, ble_conn_info *conn_info)
 {
-	blemgr_msg_params param = {2, {(void *)ctx, (void *)conn_info}};
+	blemgr_msg_params param = { 2, {(void *)ctx, (void *)conn_info} };
 	blemgr_msg_s msg = {BLE_CMD_CLIENT_CONNECT, BLE_MANAGER_FAIL, (void *)(&param), NULL};
 	int res = blemgr_post_message(&msg);
 
@@ -285,7 +285,7 @@ ble_result_e ble_client_connected_device_list(ble_device_connected_list *out_con
 
 ble_result_e ble_client_connected_info(ble_client_ctx *ctx, ble_device_connected *out_connected_device)
 {
-	blemgr_msg_params param = {2, {(void *)ctx, (void *)out_connected_device}};
+	blemgr_msg_params param = { 2, {(void *)ctx, (void *)out_connected_device} };
 	blemgr_msg_s msg = {BLE_CMD_CONNECTED_INFO, BLE_MANAGER_FAIL, (void *)(&param), NULL};
 	int res = blemgr_post_message(&msg);
 
@@ -294,7 +294,7 @@ ble_result_e ble_client_connected_info(ble_client_ctx *ctx, ble_device_connected
 
 ble_result_e ble_client_operation_enable_notification(ble_client_ctx *ctx, ble_attr_handle attr_handle)
 {
-	blemgr_msg_params param = {2, {(void *)ctx, (void *)&attr_handle}};
+	blemgr_msg_params param = { 2, {(void *)ctx, (void *)&attr_handle} };
 	blemgr_msg_s msg = {BLE_CMD_OP_ENABLE_NOTI, BLE_MANAGER_FAIL, (void *)(&param), NULL};
 	int res = blemgr_post_message(&msg);
 
@@ -303,7 +303,7 @@ ble_result_e ble_client_operation_enable_notification(ble_client_ctx *ctx, ble_a
 
 ble_result_e ble_client_operation_enable_indication(ble_client_ctx *ctx, ble_attr_handle attr_handle)
 {
-	blemgr_msg_params param = {2, {(void *)ctx, (void *)&attr_handle}};
+	blemgr_msg_params param = { 2, {(void *)ctx, (void *)&attr_handle} };
 	blemgr_msg_s msg = {BLE_CMD_OP_ENABLE_INDICATE, BLE_MANAGER_FAIL, (void *)(&param), NULL};
 	int res = blemgr_post_message(&msg);
 
@@ -312,7 +312,7 @@ ble_result_e ble_client_operation_enable_indication(ble_client_ctx *ctx, ble_att
 
 ble_result_e ble_client_operation_enable_notification_and_indication(ble_client_ctx *ctx, ble_attr_handle attr_handle)
 {
-	blemgr_msg_params param = {2, {(void *)ctx, (void *)&attr_handle}};
+	blemgr_msg_params param = { 2, {(void *)ctx, (void *)&attr_handle} };
 	blemgr_msg_s msg = {BLE_CMD_OP_ENABLE_NOTI_AND_INDICATE, BLE_MANAGER_FAIL, (void *)(&param), NULL};
 	int res = blemgr_post_message(&msg);
 
@@ -321,7 +321,7 @@ ble_result_e ble_client_operation_enable_notification_and_indication(ble_client_
 
 ble_result_e ble_client_operation_read(ble_client_ctx *ctx, ble_attr_handle attr_handle, ble_data *data)
 {
-	blemgr_msg_params param = {3, {(void *)ctx, (void *)&attr_handle, (void *)data}};
+	blemgr_msg_params param = { 3, {(void *)ctx, (void *)&attr_handle, (void *)data} };
 	blemgr_msg_s msg = {BLE_CMD_OP_READ, BLE_MANAGER_FAIL, (void *)(&param), NULL};
 	int res = blemgr_post_message(&msg);
 
@@ -330,7 +330,7 @@ ble_result_e ble_client_operation_read(ble_client_ctx *ctx, ble_attr_handle attr
 
 ble_result_e ble_client_operation_write(ble_client_ctx *ctx, ble_attr_handle attr_handle, ble_data *data)
 {
-	blemgr_msg_params param = {3, {(void *)ctx, (void *)&attr_handle, (void *)data}};
+	blemgr_msg_params param = { 3, {(void *)ctx, (void *)&attr_handle, (void *)data} };
 	blemgr_msg_s msg = {BLE_CMD_OP_WRITE, BLE_MANAGER_FAIL, (void *)(&param), NULL};
 	int res = blemgr_post_message(&msg);
 
@@ -339,7 +339,7 @@ ble_result_e ble_client_operation_write(ble_client_ctx *ctx, ble_attr_handle att
 
 ble_result_e ble_client_operation_write_no_response(ble_client_ctx *ctx, ble_attr_handle attr_handle, ble_data *data)
 {
-	blemgr_msg_params param = {3, {(void *)ctx, (void *)&attr_handle, (void *)data}};
+	blemgr_msg_params param = { 3, {(void *)ctx, (void *)&attr_handle, (void *)data} };
 	blemgr_msg_s msg = {BLE_CMD_OP_WRITE_NO_RESP, BLE_MANAGER_FAIL, (void *)(&param), NULL};
 	int res = blemgr_post_message(&msg);
 
@@ -374,7 +374,7 @@ ble_result_e ble_server_get_profile_count(uint16_t *count)
 
 ble_result_e ble_server_charact_notify(ble_attr_handle attr_handle, ble_conn_handle con_handle, ble_data *data)
 {
-	blemgr_msg_params param = {3, {(void *)&attr_handle, (void *)&con_handle, (void *)data}};
+	blemgr_msg_params param = { 3, {(void *)&attr_handle, (void *)&con_handle, (void *)data} };
 	blemgr_msg_s msg = {BLE_CMD_CHARACT_NOTI, BLE_MANAGER_FAIL, (void *)(&param), NULL};
 	int res = blemgr_post_message(&msg);
 
@@ -383,7 +383,7 @@ ble_result_e ble_server_charact_notify(ble_attr_handle attr_handle, ble_conn_han
 
 ble_result_e ble_server_charact_indicate(ble_attr_handle attr_handle, ble_conn_handle con_handle, ble_data *data)
 {
-	blemgr_msg_params param = {3, {(void *)&attr_handle, (void *)&con_handle, (void *)data}};
+	blemgr_msg_params param = { 3, {(void *)&attr_handle, (void *)&con_handle, (void *)data} };
 	blemgr_msg_s msg = {BLE_CMD_CHARACT_INDI, BLE_MANAGER_FAIL, (void *)(&param), NULL};
 	int res = blemgr_post_message(&msg);
 
@@ -392,10 +392,11 @@ ble_result_e ble_server_charact_indicate(ble_attr_handle attr_handle, ble_conn_h
 
 ble_result_e ble_server_get_indicate_pending_count(ble_conn_handle con_handle, uint8_t *count)
 {
-	if (count == NULL) {
+	if (count == NULL)
+	{
 		return BLE_MANAGER_INVALID_ARGS;
 	}
-	blemgr_msg_params param = {2, {(void *)&con_handle, (void *)count}};
+	blemgr_msg_params param = { 2, {(void *)&con_handle, (void *)count} };
 	blemgr_msg_s msg = {BLE_CMD_GET_INDICATE_PENDING_CNT, BLE_MANAGER_FAIL, (void *)(&param), NULL};
 	int res = blemgr_post_message(&msg);
 
@@ -404,17 +405,22 @@ ble_result_e ble_server_get_indicate_pending_count(ble_conn_handle con_handle, u
 
 ble_result_e ble_server_attr_set_data(ble_attr_handle attr_handle, ble_data *data)
 {
-	blemgr_msg_params param = {2, {(void *)&attr_handle, (void *)data}};
+	blemgr_msg_params param = { 2, {(void *)&attr_handle, (void *)data} };
 	blemgr_msg_s msg = {BLE_CMD_ATTR_SET_DATA, BLE_MANAGER_FAIL, (void *)(&param), NULL};
 	int res = blemgr_post_message(&msg);
 
 	RETURN_RESULT(res, msg);
 }
 
+blemgr_msg_params param_attr_get_data;
+ble_attr_handle attr_handle_get_data;
 ble_result_e ble_server_attr_get_data(ble_attr_handle attr_handle, ble_data *data)
 {
-	blemgr_msg_params param = {2, {(void *)&attr_handle, (void *)data}};
-	blemgr_msg_s msg = {BLE_CMD_ATTR_GET_DATA, BLE_MANAGER_FAIL, (void *)(&param), NULL};
+	attr_handle_get_data = attr_handle;
+	param_attr_get_data.count = 2;
+	param_attr_get_data.param[0] = (void *)&attr_handle_get_data;
+	param_attr_get_data.param[1] = (void *)data;
+	static blemgr_msg_s msg = {BLE_CMD_ATTR_GET_DATA, BLE_MANAGER_FAIL, (void *)(&param_attr_get_data), NULL};
 	int res = blemgr_post_message(&msg);
 
 	RETURN_RESULT(res, msg);
@@ -422,7 +428,7 @@ ble_result_e ble_server_attr_get_data(ble_attr_handle attr_handle, ble_data *dat
 
 ble_result_e ble_server_reject(ble_attr_handle attr_handle, uint8_t app_errorcode)
 {
-	blemgr_msg_params param = {2, {(void *)&attr_handle, (void *)&app_errorcode}};
+	blemgr_msg_params param = { 2, {(void *)&attr_handle, (void *)&app_errorcode} };
 	blemgr_msg_s msg = {BLE_CMD_ATTR_REJECT, BLE_MANAGER_FAIL, (void *)(&param), NULL};
 	int res = blemgr_post_message(&msg);
 
@@ -437,18 +443,29 @@ ble_result_e ble_server_disconnect(ble_conn_handle con_handle)
 	RETURN_RESULT(res, msg);
 }
 
+blemgr_msg_s msg1;
+blemgr_msg_params param1;
+ble_conn_handle con_handle1;
 ble_result_e ble_server_get_mac_addr_by_conn_handle(ble_conn_handle con_handle, uint8_t bd_addr[BLE_BD_ADDR_MAX_LEN])
 {
-	blemgr_msg_params param = {2, {(void *)&con_handle, (void *)bd_addr}};
-	blemgr_msg_s msg = {BLE_CMD_GET_MAC_BY_CONN, BLE_MANAGER_FAIL, (void *)(&param), NULL};
-	int res = blemgr_post_message(&msg);
+	con_handle1 = con_handle;
 
-	RETURN_RESULT(res, msg);
+	param1.count = 2;
+	param1.param[0] = (void *)&con_handle1;
+	param1.param[1] = (void *)bd_addr;
+	
+	msg1.event = BLE_CMD_GET_MAC_BY_CONN;
+	msg1.result = BLE_MANAGER_FAIL;
+	msg1.param = (void *)(&param1);
+	msg1.signal = NULL;
+	int res = blemgr_post_message(&msg1);
+
+	RETURN_RESULT(res, msg1);
 }
 
 ble_result_e ble_server_get_conn_handle_by_addr(uint8_t bd_addr[BLE_BD_ADDR_MAX_LEN], ble_conn_handle *con_handle)
 {
-	blemgr_msg_params param = {2, {(void *)bd_addr, (void *)con_handle}};
+	blemgr_msg_params param = { 2, {(void *)bd_addr, (void *)con_handle} };
 	blemgr_msg_s msg = {BLE_CMD_GET_CONN_BY_MAC, BLE_MANAGER_FAIL, (void *)(&param), NULL};
 	int res = blemgr_post_message(&msg);
 
@@ -473,7 +490,7 @@ ble_result_e ble_server_set_adv_resp(ble_data *data)
 
 ble_result_e ble_server_set_adv_type(ble_adv_type_e adv_type, ble_addr *addr)
 {
-	blemgr_msg_params param = {2, {(void *)&adv_type, (void *)addr}};
+	blemgr_msg_params param = { 2, {(void *)&adv_type, (void *)addr} };
 	blemgr_msg_s msg = {BLE_CMD_SET_ADV_TYPE, BLE_MANAGER_FAIL, (void *)(&param), NULL};
 	int res = blemgr_post_message(&msg);
 
@@ -504,12 +521,16 @@ ble_result_e ble_server_start_adv(void)
 	RETURN_RESULT(res, msg);
 }
 
+blemgr_msg_s msg2;
 ble_result_e ble_server_stop_adv(void)
 {
-	blemgr_msg_s msg = {BLE_CMD_STOP_ADV, BLE_MANAGER_FAIL, NULL, NULL};
-	int res = blemgr_post_message(&msg);
+	msg2.event = BLE_CMD_STOP_ADV;
+	msg2.result = BLE_MANAGER_FAIL;
+	msg2.param = NULL;
+	msg2.signal = NULL;
+	int res = blemgr_post_message(&msg2);
 
-	RETURN_RESULT(res, msg);
+	RETURN_RESULT(res, msg2);
 }
 
 ble_result_e ble_server_one_shot_adv_init(void)
@@ -530,7 +551,7 @@ ble_result_e ble_server_one_shot_adv_deinit(void)
 
 ble_result_e ble_server_one_shot_adv_set(uint8_t adv_id, ble_data *data_adv, ble_data *data_scan_rsp, uint8_t type)
 {
-	blemgr_msg_params param = {4, {(void *)&adv_id, (void *)data_adv, (void *)data_scan_rsp, (void *)&type}};
+	blemgr_msg_params param = { 4, {(void *)&adv_id, (void *)data_adv, (void *)data_scan_rsp, (void *)&type}};
 	blemgr_msg_s msg = {BLE_CMD_ONE_SHOT_ADV_SET, BLE_MANAGER_FAIL, (void *)(&param), NULL};
 	int res = blemgr_post_message(&msg);
 


### PR DESCRIPTION
- The thread calling the attribute callback is a thread generated by the kernel, and when a user function is called to access the kernel's memory, a memory violation occurs.
- In the case of the BLE server, it is implemented to check the value written by the client through `ble_server_attr_get_data` inside the attribute callback.
- In the `ble_perfs_main.c` and `ble_tester_main.c` files, they are implemented to be used in such a structure inside the attribute callback, which caused a memory violation.
- Since such issues did not occur in ecode due to the use of static variables, it has been modified to use ecode's legacy code in the public as well until a clear solution is found.