### PR TITLE
framework/csimanager: feat/add interval-based CSI data collection and fix variable & typo

### DIFF
--- a/framework/src/csimanager/CSIManager.c
+++ b/framework/src/csimanager/CSIManager.c
@@ -39,12 +39,12 @@ static csifw_service_info_t *add_service(csifw_context_t *p_csifw_ctx, service_c
 
 static const char *csi_framework_state_strings[] = 
 {
-    "UNINITIALIZED",                    /* CSI_FRAMEWORK_STATE_UNINITIALIZED */
-    "STARTED",                          /* CSI_FRAMEWORK_STATE_STARTED */
-    "STARTED_WAITING_FOR_NW",           /* CSI_FRAMEWORK_STATE_STARTED_WAITING_FOR_NW */
-    "STOPPED",                          /* CSI_FRAMEWORK_STATE_STOPPED */
-    "INITIALIZED",                      /* CSI_FRAMEWORK_STATE_INITIALIZED */
-    "STARTED_WAITING_FOR_NW_RECONNECT"  /* CSI_FRAMEWORK_STATE_STARTED_WAITING_FOR_NW_RECONNECT */
+    "UNINITIALIZED",
+    "STARTED",
+    "STARTED_WAITING_FOR_NW",
+    "STOPPED",
+    "INITIALIZED",
+    "STARTED_WAITING_FOR_NW_RECONNECT"
 };
 
 static void csifw_update_state_and_log(CSI_FRAMEWORK_STATE new_state) 
@@ -129,23 +129,24 @@ static void CSIRawDataListener(CSIFW_RES res, int raw_csi_buff_len, unsigned cha
   // CSIRawDataListener callback can be invoked from a background thread when CSI data arrives. 
   // Simultaneously, application threads may call `csifw_start()/csifw_stop()` to modify service states. 
   // Without this mutex, race conditions will occur
-  CSIFW_MUTEX_LOCK(&g_pcsifw_context->data_reciever_mutex);
+  CSIFW_MUTEX_LOCK(&g_pcsifw_context->data_receiver_mutex);
   for (int i = 0; i < CSIFW_MAX_NUM_APPS; i++) {
-    // send raw
     if (g_pcsifw_context->csi_services[i].svc_id != 0 && g_pcsifw_context->csi_services[i].svc_state == CSI_SERVICE_START) {
       if (g_pcsifw_context->csi_services[i].raw_data_cb) {
-        g_pcsifw_context->csi_services[i].raw_data_cb(res,raw_csi_buff_len, raw_csi_buff, g_pcsifw_context->csi_services[i].service_data);
+        g_pcsifw_context->csi_services[i].raw_data_cb(res,
+                                                      raw_csi_buff_len,
+                                                      raw_csi_buff,
+                                                      g_pcsifw_context->csi_services[i].service_data);
       }
-      // send parsed
       if (g_pcsifw_context->csi_services[i].parsed_data_cb) {
         g_pcsifw_context->csi_services[i].parsed_data_cb(res,
-														g_pcsifw_context->ParsedDataBufferLen,
-														g_pcsifw_context->parsed_buffptr,
-														g_pcsifw_context->csi_services[i].service_data);
+                                                         g_pcsifw_context->ParsedDataBufferLen,
+                                                         g_pcsifw_context->parsed_buffptr,
+                                                         g_pcsifw_context->csi_services[i].service_data);
       }
     }
   }
-  CSIFW_MUTEX_UNLOCK(&g_pcsifw_context->data_reciever_mutex);
+  CSIFW_MUTEX_UNLOCK(&g_pcsifw_context->data_receiver_mutex);
 }
 
 CSIFW_RES csifw_registerService(csifw_service_handle *p_hnd, service_callbacks_t *p_svc_cb, csi_config_type_t config_type, unsigned int interval) 
@@ -169,8 +170,8 @@ CSIFW_RES csifw_registerService(csifw_service_handle *p_hnd, service_callbacks_t
       goto on_error;
     }
     CSIFW_LOGD("Context Created Successfully");
-    if (pthread_mutex_init(&g_pcsifw_context->data_reciever_mutex, NULL) != 0) {
-      CSIFW_LOGE("Mutex init failed of data_reciever_mutex");
+    if (pthread_mutex_init(&g_pcsifw_context->data_receiver_mutex, NULL) != 0) {
+      CSIFW_LOGE("Mutex init failed of data_receiver_mutex");
       destroy_csifw_context();
       res = CSIFW_ERROR;
       goto on_error;
@@ -280,12 +281,12 @@ CSIFW_RES csifw_start(csifw_service_handle hnd)
     }
   }
 
-  CSIFW_MUTEX_LOCK(&g_pcsifw_context->data_reciever_mutex);
+  CSIFW_MUTEX_LOCK(&g_pcsifw_context->data_receiver_mutex);
   p_svc_info->svc_state = CSI_SERVICE_START;
   if (p_svc_info->parsed_data_cb) {
     g_pcsifw_context->parsed_data_cb_started_count++;
   }
-  CSIFW_MUTEX_UNLOCK(&g_pcsifw_context->data_reciever_mutex);
+  CSIFW_MUTEX_UNLOCK(&g_pcsifw_context->data_receiver_mutex);
   CSIFW_LOGI("Service [%d] started successfully, services count is %d", p_svc_info->svc_id, g_pcsifw_context->service_count);
 
 on_error:
@@ -314,12 +315,12 @@ CSIFW_RES csifw_stop(csifw_service_handle hnd)
     goto on_error;
   }
 
-  CSIFW_MUTEX_LOCK(&g_pcsifw_context->data_reciever_mutex);
+  CSIFW_MUTEX_LOCK(&g_pcsifw_context->data_receiver_mutex);
   p_svc_info->svc_state = CSI_SERVICE_STOP;
   if (p_svc_info->parsed_data_cb) {
     g_pcsifw_context->parsed_data_cb_started_count--;
   }
-  CSIFW_MUTEX_UNLOCK(&g_pcsifw_context->data_reciever_mutex);
+  CSIFW_MUTEX_UNLOCK(&g_pcsifw_context->data_receiver_mutex);
 
   if (!all_services_stopped()) {
     goto on_error;
@@ -371,7 +372,7 @@ CSIFW_RES csifw_unregisterService(csifw_service_handle hnd)
       CSIFW_LOGE("Network monitor deinit failed");
       res = CSIFW_ERROR;
     }
-    pthread_mutex_destroy(&g_pcsifw_context->data_reciever_mutex);
+    pthread_mutex_destroy(&g_pcsifw_context->data_receiver_mutex);
     destroy_csifw_context();
   }
   CSIFW_LOGI("CSIFW Service Un-Registered Successfully.");
@@ -641,11 +642,9 @@ static void nw_state_notify_service(CONNECTION_STATE state)
     res = CSIFW_ERROR_WIFI_DIS_CONNECTED;
   }
   for (int i = 0; i < CSIFW_MAX_NUM_APPS; i++) {
-    // send raw data
     if (g_pcsifw_context->csi_services[i].svc_id) {
       if (g_pcsifw_context->csi_services[i].raw_data_cb) {
         g_pcsifw_context->csi_services[i].raw_data_cb(res, 0, NULL, g_pcsifw_context->csi_services[i].service_data);
-		// send parsed data
       } else if (g_pcsifw_context->csi_services[i].parsed_data_cb) {
         g_pcsifw_context->csi_services[i].parsed_data_cb(res, 0, NULL, g_pcsifw_context->csi_services[i].service_data);
       }
@@ -658,9 +657,7 @@ csifw_context_t *get_csifw_context() { return g_pcsifw_context; }
 static CSIFW_RES check_hnd_validity(csifw_service_handle hnd) 
 {
   if (!hnd) {
-    CSIFW_LOGE(
-        "Invalid/NULL handle argument, should be same as csifw_service_handle "
-        "returned from csifw_registerService()");
+    CSIFW_LOGE("Invalid/NULL handle argument, should be same as csifw_service_handle returned from csifw_registerService()");
     return CSIFW_INVALID_ARG;
   }
 

--- a/framework/src/csimanager/CSIPacketReceiver.c
+++ b/framework/src/csimanager/CSIPacketReceiver.c
@@ -27,7 +27,8 @@
 #define MAX_CONSECUTIVE_FAILURES 50
 #define RCVR_TH_NAME "csifw_data_receiver_th"
 
-static inline CSIFW_RES open_driver(int *fd) {
+static inline CSIFW_RES open_driver(int *fd) 
+{
   *fd = open(CONFIG_WIFICSI_CUSTOM_DEV_PATH, O_RDONLY);
   if (*fd < 0) {
     CSIFW_LOGE("Failed to open device path : %s errno : %d",
@@ -37,15 +38,20 @@ static inline CSIFW_RES open_driver(int *fd) {
   return CSIFW_OK;
 }
 
-static inline void close_driver(int fd) {
+static inline void close_driver(int fd) 
+{
   close(fd);
 }
 
-static inline unsigned long long get_monotonic_time_us(void)
+static inline u64 get_monotonic_time_ms(void)
 {
-	struct timespec ts;
-	clock_gettime(CLOCK_MONOTONIC, &ts);
-	return (unsigned long long)ts.tv_sec * 1000000ULL + ts.tv_nsec / 1000ULL;
+  struct timespec ts;
+  if (clock_gettime(CLOCK_MONOTONIC, &ts) != 0) {
+  	CSIFW_LOGE("Failed to get monotonic time - errno: %d (%s)", 
+  	           get_errno(), strerror(get_errno()));
+  	return 0;
+  }
+  return (u64)ts.tv_sec * 1000ULL + ts.tv_nsec / 1000000ULL;
 }
 
 CSIFW_RES csi_packet_receiver_set_csi_config(csi_config_action_t config_action);
@@ -59,7 +65,7 @@ static int readCSIData(int fd, unsigned char *buf, int size)
 	err = ioctl(fd, CSIIOC_GET_DATA, (unsigned long)&buf_args);
 	if (err <= OK) {
 		CSIFW_LOGE("IOCTL CSIIOC_GET_DATA failed - fd: %d, errno: %d (%s)", 
-			fd, get_errno(), strerror(get_errno()));
+					fd, get_errno(), strerror(get_errno()));
 	}
 	return err;
 }
@@ -74,75 +80,91 @@ static void *dataReceiverThread(void *vargp)
 
 	int len;
 	int prio;
-	size_t size;
+	ssize_t size;
+	u64 current_time;
 	int timeout_count = 0;
 	struct wifi_csi_msg_s msg;
 	int consecutive_failures = 0;
 	struct timespec st_time = {0,};
+	bool last_data_read_status = false;
+	u64 last_data_read_timestamp_ms = 0;
 	int fd = p_csifw_ctx->data_receiver_fd;
 	mqd_t mq_handle = p_csifw_ctx->mq_handle;
 	unsigned char *get_data_buffptr = p_csifw_ctx->get_data_buffptr;
 
 	while (!p_csifw_ctx->data_receiver_thread_stop) {
-		CSIFW_LOGI("Reading from MQ %llu", get_monotonic_time_us());
-		clock_gettime(CLOCK_REALTIME, &st_time);
-		st_time.tv_sec += 1;
-		size = mq_timedreceive(mq_handle, (char *)&msg, sizeof(msg), &prio, &st_time);
-		if (size >= 0) {
-			CSIFW_LOGD("Message received - msgId: %d, data_len: %d, size: %zu: %d", msg.msgId, msg.data_len, size);
-			switch (msg.msgId) {
-			case CSI_MSG_DATA_READY_CB:
-				len = readCSIData(fd, get_data_buffptr, CSIFW_MAX_RAW_BUFF_LEN);
-				CSIFW_LOGI("CSI Data read complete %llu", get_monotonic_time_us());
-				if (len < 0) {
-					consecutive_failures++;
-					CSIFW_LOGE("Skipping packet: error: %d", len);
-					if (consecutive_failures >= MAX_CONSECUTIVE_FAILURES) {
-						CSIFW_LOGE("CRITICAL: %d consecutive readCSIData failures detected!", consecutive_failures);
-						p_csifw_ctx->CSI_DataCallback(CSIFW_ERROR_DATA_NOT_AVAILABLE, 0, NULL, 0);
-						break;
+		current_time = get_monotonic_time_ms();
+		if ((last_data_read_status == false) ||
+			(last_data_read_timestamp_ms == 0) ||
+			(current_time - last_data_read_timestamp_ms >= p_csifw_ctx->csi_interval)) {
+			last_data_read_status = false;
+			last_data_read_timestamp_ms = current_time;
+			CSIFW_LOGI("Reading event from MQ %llu", current_time);
+			clock_gettime(CLOCK_REALTIME, &st_time);
+			st_time.tv_sec += 1;
+			size = mq_timedreceive(mq_handle, (char *)&msg, sizeof(msg), &prio, &st_time);
+			if (size >= 0) {
+				CSIFW_LOGD("Message received - msgId: %d, data_len: %d, size: %zu: %d", msg.msgId, msg.data_len, size);
+				switch (msg.msgId) {
+				case CSI_MSG_DATA_READY_CB:
+					len = readCSIData(fd, get_data_buffptr, CSIFW_MAX_RAW_BUFF_LEN);
+					CSIFW_LOGI("CSI Data read complete %llu", get_monotonic_time_ms());
+					if (len < 0) {
+						consecutive_failures++;
+						CSIFW_LOGE("Skipping packet: error: %d", len);
+						if (consecutive_failures >= MAX_CONSECUTIVE_FAILURES) {
+							CSIFW_LOGE("CRITICAL: %d consecutive readCSIData failures detected!", consecutive_failures);
+							p_csifw_ctx->CSI_DataCallback(CSIFW_ERROR_DATA_NOT_AVAILABLE, 0, NULL, 0);
+							break;
+						}
+						continue;
 					}
-					continue;
-				}
-				if ((consecutive_failures > 0) || (timeout_count > 0)) {
-					consecutive_failures = 0;
-					timeout_count = 0;
-				}
-				#if defined(CONFIG_WIFI_CSI_RTL8730E)
-					/* RTL8730E driver returns length without the CSI header*/
-					p_csifw_ctx->CSI_DataCallback(CSIFW_OK, len + CSIFW_RTK_CSI_HEADER_LEN, get_data_buffptr, len);
-				#elif defined(CONFIG_BK_WIFI_CSI_ADAPTER)
-					/* Beken driver already includes the CSI header in the length*/
-					p_csifw_ctx->CSI_DataCallback(CSIFW_OK, len, get_data_buffptr, len);
-				#else
-					CSIFW_LOGE("Unknown CSI board configuration");
-				#endif
-				break;
+					if ((consecutive_failures > 0) || (timeout_count > 0)) {
+						consecutive_failures = 0;
+						timeout_count = 0;
+					}
+					last_data_read_status = true;
+					#if defined(CONFIG_WIFI_CSI_RTL8730E)
+					  /* RTL8730E driver returns length without the CSI header*/
+					  p_csifw_ctx->CSI_DataCallback(CSIFW_OK, len + CSIFW_RTK_CSI_HEADER_LEN, get_data_buffptr, len);
+					#elif defined(CONFIG_BK_WIFI_CSI_ADAPTER)
+					  /* Beken driver already includes the CSI header in the length*/
+					  p_csifw_ctx->CSI_DataCallback(CSIFW_OK, len, get_data_buffptr, len);
+					#else
+					  CSIFW_LOGE("Unknown CSI board configuration");
+					#endif
+					break;
 
-			case CSI_MSG_ERROR:
-				CSIFW_LOGE("CSI_MSG_ERROR received");
-				break;
+				case CSI_MSG_ERROR:
+					CSIFW_LOGE("CSI_MSG_ERROR received");
+					break;
 
-			default:
-				CSIFW_LOGE("Received unknown message ID: %d", msg.msgId);
-				break;
+				default:
+					CSIFW_LOGE("Received unknown message ID: %d", msg.msgId);
+					break;
+				}
+			} else if (size == -1) {
+				CSIFW_LOGE("MQ returned %zd || errno: %d (%s)", size, errno, strerror(errno));
+				if (errno == ETIMEDOUT) {
+					timeout_count++;
+					if (timeout_count >= CONFIG_CSI_DATA_TIMEOUT_SEC) {
+						CSIFW_LOGE("CRITICAL: No CSI data for %d seconds", timeout_count);
+						timeout_count = 0;
+						p_csifw_ctx->CSI_DataCallback(CSIFW_ERROR_DATA_NOT_AVAILABLE, 0, NULL, 0);
+					}
+				} else {
+					consecutive_failures++;
+					if (consecutive_failures >= MAX_CONSECUTIVE_FAILURES) {
+						CSIFW_LOGE("CRITICAL: %d consecutive failures detected", consecutive_failures);
+						consecutive_failures = 0;
+						p_csifw_ctx->CSI_DataCallback(CSIFW_INTERNAL_ERROR, 0, NULL, 0);
+					}
+				}
 			}
-		} else if (size == -1) {
-			if (errno == ETIMEDOUT) {
-				timeout_count++;
-				if (timeout_count >= CONFIG_CSI_DATA_TIMEOUT_SEC) {
-					 CSIFW_LOGE("CRITICAL: No CSI data for %d seconds", timeout_count);
-					timeout_count = 0;
-					p_csifw_ctx->CSI_DataCallback(CSIFW_ERROR_DATA_NOT_AVAILABLE, 0, NULL, 0);
-				}
-			} else {
-				CSIFW_LOGE("Message received size error - msgId: %d, data_len: %d, size: %zu, errno: %d (%s)", msg.msgId, msg.data_len, size, errno, strerror(errno));
-				consecutive_failures++;
-				if (consecutive_failures >= MAX_CONSECUTIVE_FAILURES) {
-					CSIFW_LOGE("CRITICAL: %d consecutive failures detected", consecutive_failures);
-					consecutive_failures = 0;
-					p_csifw_ctx->CSI_DataCallback(CSIFW_INTERNAL_ERROR, 0, NULL, 0);
-				}
+		} else {
+			u64 sleep_time = p_csifw_ctx->csi_interval - (current_time - last_data_read_timestamp_ms);
+			if (sleep_time > 0) {
+				usleep(sleep_time * 1000); // Convert ms to microseconds
 			}
 		}
 	}
@@ -210,7 +232,7 @@ CSIFW_RES csi_packet_receiver_change_interval(void)
 		CSIFW_LOGE("Failed to disable CSI configuration - error: %d", res);
 		return res;
 	}
-	usleep(10000);				//10ms sleep
+	usleep(10000);
 	res = csi_packet_receiver_set_csi_config(CSI_CONFIG_ENABLE);
 	if (res != CSIFW_OK) {
 		CSIFW_LOGE("Failed to enable CSI configuration - error: %d", res);
@@ -232,10 +254,10 @@ CSIFW_RES csi_packet_receiver_get_mac_addr(csifw_mac_info *mac_info)
 		return CSIFW_ERROR;
 	}
 	close_driver(fd);
-	CSIFW_LOGD("MAC address from driver: [%02x:%02x:%02x:%02x:%02x:%02x]", 
-		mac_info->mac_addr[0], mac_info->mac_addr[1], 
-		mac_info->mac_addr[2], mac_info->mac_addr[3], 
-		mac_info->mac_addr[4], mac_info->mac_addr[5]);
+	CSIFW_LOGD("MAC address from driver: [%02x:%02x:%02x:%02x:%02x:%02x]",
+				mac_info->mac_addr[0], mac_info->mac_addr[1],
+				mac_info->mac_addr[2], mac_info->mac_addr[3],
+				mac_info->mac_addr[4], mac_info->mac_addr[5]);
 	return CSIFW_OK;
 }
 
@@ -280,7 +302,8 @@ CSIFW_RES csi_packet_receiver_start_collect(void)
 		return CSIFW_ERROR;
 	}
 	if (pthread_attr_setstacksize(&recv_th_attr, (3*1024)) != 0) {
-		CSIFW_LOGE("Failed to set receiver thread stack size to 5KB - errno: %d (%s). Proceeding with default stack size.", get_errno(), strerror(get_errno()));
+		CSIFW_LOGE("Failed to set receiver thread stack size to 3KB - errno: %d (%s). Proceeding with default stack size.", 
+					get_errno(), strerror(get_errno()));
 	}
 	if (pthread_create(&p_csifw_ctx->csi_data_receiver_th, &recv_th_attr, dataReceiverThread, NULL) != 0) {
 		CSIFW_LOGE("Failed to create CSI data receiver thread - errno: %d (%s)", get_errno(), strerror(get_errno()));

--- a/framework/src/csimanager/inc/CSIManager.h
+++ b/framework/src/csimanager/inc/CSIManager.h
@@ -91,7 +91,7 @@ typedef struct {
   int task_handle;                      /* Task Manager handle */
   int ping_socket;                      /* Ping Socket */
 
-  pthread_mutex_t data_reciever_mutex; /* CSI Data Reciever Mutex */
+  pthread_mutex_t data_receiver_mutex; /* CSI Data Receiver Mutex */
   pthread_t csi_data_receiver_th;      /* CSI Data Receiver Thread Status */
   struct icmp_echo_hdr *p_iecho;       /* Echo Header */
   struct sockaddr *socketAddr;         /* Sokcet Address */


### PR DESCRIPTION
- Add interval-based reading logic using csi_interval configuration
- Fixed typo data_reciever_mutex to data_receiver_mutex
- Fix 'size' variable type to 'sszie_t' to handle negative return values from mq_timedreceive()
- Correct stack size comment from 5KB to 3KB
- Improve code formatting and indentation
- Remove redundant comments

Modified files:
- framework/src/csimanager/CSIManager.c
- framework/src/csimanager/CSIPacketReceiver.c
- framework/src/csimanager/inc/CSIManager.h