### PR TITLE
apps/examples/testcase/le_tc/kernel: Fix oversized ret_val on stack in jn/jnf math tests

### DIFF
--- a/apps/examples/testcase/le_tc/kernel/tc_libc_math.c
+++ b/apps/examples/testcase/le_tc/kernel/tc_libc_math.c
@@ -2368,7 +2368,7 @@ static void tc_libc_math_jn(void)
 {
 	const double in_val[] = { ZERO, VAL1, -VAL1, VAL2, -VAL2, INFINITY, -INFINITY, NAN, 0x1p302, 0x1p-29, 0x1p-30, 0x1p-40 };
 	const double sol_val[][7] = { {ZERO, 1.0, ZERO, ZERO, ZERO, ZERO, ZERO}, { -ZERO, ZERO, ZERO, -ZERO, -ZERO, ZERO, ZERO}, {ZERO, ZERO, -ZERO, -ZERO, ZERO, ZERO, -ZERO}, { -ZERO, ZERO, ZERO, -ZERO, -ZERO, ZERO, ZERO}, {ZERO, ZERO, -ZERO, -ZERO, ZERO, ZERO, -ZERO}, {ZERO, ZERO, ZERO, ZERO, ZERO, ZERO, ZERO}, {ZERO, ZERO, -ZERO, ZERO, -ZERO, ZERO, -ZERO}, {NAN, NAN, NAN, NAN, NAN, NAN, NAN}, {ZERO, -ZERO, -ZERO, ZERO, ZERO, -ZERO, -ZERO}, { -ZERO, 1.0, ZERO, ZERO, ZERO, ZERO, ZERO}, { -ZERO, 1.0, ZERO, ZERO, ZERO, ZERO, ZERO}, { -ZERO, 1.0, ZERO, ZERO, ZERO, ZERO, ZERO} };
-	double ret_val[SIZE(sol_val, double)][7];
+	double ret_val[SIZE(in_val, double)][7];
 	int jn_idx;
 	int order_idx;
 
@@ -2398,7 +2398,7 @@ static void tc_libc_math_jnf(void)
 	const float in_val[] = { ZERO, VAL1, -VAL1, VAL2, -VAL2, INFINITY, -INFINITY, NAN, 0x1p-10, 0x1p-20, 0x2p-30 };
 	int order[] = { -1, 0, 1, 2, 9 };
 	const float sol_val[][SIZE(order, int)] = { { -ZERO, 1.0, ZERO, ZERO, ZERO}, { -ZERO, ZERO, ZERO, -ZERO, ZERO}, {ZERO, ZERO, -ZERO, -ZERO, -ZERO}, { -ZERO, ZERO, ZERO, -ZERO, ZERO}, {ZERO, ZERO, -ZERO, -ZERO, -ZERO}, { -ZERO, ZERO, ZERO, ZERO, ZERO}, {ZERO, ZERO, -ZERO, ZERO, -ZERO}, {NAN, NAN, NAN, NAN, NAN}, { -0.0004883, 0.9999998, 0.0004883, 0.0000001, ZERO}, { -0.0000005, 1.0, 0.0000005, ZERO, ZERO}, { -ZERO, 1.0, ZERO, ZERO, ZERO} };
-	float ret_val[SIZE(sol_val, float)][SIZE(order, int)];
+	float ret_val[SIZE(in_val, float)][SIZE(order, int)];
 	int jnf_idx;
 	int order_idx;
 


### PR DESCRIPTION
This commit fixes the issue kernel testcase crashes when the optimization is disabled (-O0)

In tc_libc_math_jn() and tc_libc_math_jnf(), the local ret_val array's first dimension was sized off sol_val (the expected-results matrix) instead of in_val (the inputs).
Since sol_val is a 2D const array of inputs * cols, SIZE(sol_val, T) returned (rows * cols) rather than just rows, blowing the array up by a factor of `cols`:

  jn:  double  ret_val[84][7] = 4704 B   (only [12][7] = 672 B is used)
  jnf: float   ret_val[55][5] = 1100 B   (only [11][5] = 220 B is used)

exceeds the kernel_tc task stack (4072 B). so heap is corrupted, and kernel crashed due to broken stack memory

This issue disappears at -Os/-O2 or higher opt: gcc proves the unused tail of ret_val is dead, drops it from the frame, and the overflow goes away.

Fix
---
Size ret_val by in_val, matching the loop bounds and the array's actual usage. ret_val now occupies 672 B (jn) / 220 B (jnf) and the frame fits comfortably in kernel_tc's stack at any optimization level.