### PR TITLE
os/kernel/binary_manager: Use highest version for BP recovery and print BP info

### DIFF
--- a/os/kernel/binary_manager/binary_manager.c
+++ b/os/kernel/binary_manager/binary_manager.c
@@ -130,6 +130,7 @@ int binary_manager(int argc, char *argv[])
 		is_found_bootparam = false;
 		goto errout_with_nobinary;
 	}
+	binary_manager_dump_bpdata();
 #endif
 
 	if (binary_manager_get_kcount() <= 0 || !binary_manager_scan_kbin()) {

--- a/os/kernel/binary_manager/binary_manager_bootparam.c
+++ b/os/kernel/binary_manager/binary_manager_bootparam.c
@@ -37,7 +37,7 @@ static binmgr_bpinfo_t g_bp_info;
 static binmgr_bp_recovery_info_t g_bp_recovery_info;
 
 #define BP_SEEK_OFFSET(index)   (index == 0 ? 0 : BOOTPARAM_PARTSIZE / 2)
-#define FACTORY_KBIN_VERSION    101
+#define FACTORY_BIN_VERSION     101
 
 /****************************************************************************
  * Public Functions
@@ -473,16 +473,18 @@ static int binary_manager_make_bootparam_from_partitions(binmgr_bpdata_t *bp_dat
 }
 
 /****************************************************************************
- * Name: binary_manager_validate_set
+ * Name: binary_manager_get_valid_set_highest_version
  *
  * Description:
- *	 This function validates all binaries in given set_idx and returns false on the
- *	 first invalid binary.
+ *	 This function validates all binaries in given set_idx and returns the highest
+ *	 binary version. It returns 0 if the set is invalid.
  *
  ****************************************************************************/
-static bool binary_manager_validate_set(uint8_t set_idx)
+static uint32_t binary_manager_get_valid_set_highest_version(uint8_t set_idx)
 {
 	int ret;
+	uint32_t version;
+	uint32_t highest_version = 0;
 #ifdef CONFIG_APP_BINARY_SEPARATION
 	int bin_idx;
 	uint32_t bin_count;
@@ -490,14 +492,23 @@ static bool binary_manager_validate_set(uint8_t set_idx)
 
 	if (set_idx >= PARTS_PER_BIN) {
 		bmdbg("Invalid set validation parameter, set idx %u\n", set_idx);
-		return false;
+		return 0;
 	}
 
 	ret = binary_manager_verify_kbin(set_idx);
 	if (ret != BINMGR_OK) {
 		bmdbg("Set %s kernel validation FAIL, ret %d\n", GET_PARTNAME(set_idx), ret);
-		return false;
+		return 0;
 	}
+
+	version = binary_manager_get_kbin_version(set_idx);
+	if (version == 0) {
+		return 0;
+	}
+	if (version > highest_version) {
+		highest_version = version;
+	}
+	bmvdbg("Set %s kernel validation PASS, version %u\n", GET_PARTNAME(set_idx), version);
 
 #ifdef CONFIG_APP_BINARY_SEPARATION
 	bin_count = binary_manager_get_ucount();
@@ -508,15 +519,23 @@ static bool binary_manager_validate_set(uint8_t set_idx)
 
 		if (set_idx >= BIN_COUNT(bin_idx)) {
 			bmdbg("Set %s app[%d:%s] has no partition, part count %u\n", GET_PARTNAME(set_idx), bin_idx, BIN_NAME(bin_idx), BIN_COUNT(bin_idx));
-			return false;
+			return 0;
 		}
 
 		ret = binary_manager_verify_ubin(bin_idx, set_idx);
 		if (ret != BINMGR_OK) {
 			bmdbg("Set %s app[%d:%s] validation FAIL, ret %d\n", GET_PARTNAME(set_idx), bin_idx, BIN_NAME(bin_idx), ret);
-			return false;
+			return 0;
 		}
-		bmvdbg("Set %s app[%d:%s] validation PASS\n", GET_PARTNAME(set_idx), bin_idx, BIN_NAME(bin_idx));
+
+		version = binary_manager_get_ubin_version(bin_idx, set_idx);
+		if (version == 0) {
+			return 0;
+		}
+		if (version > highest_version) {
+			highest_version = version;
+		}
+		bmvdbg("Set %s app[%d:%s] validation PASS, version %u\n", GET_PARTNAME(set_idx), bin_idx, BIN_NAME(bin_idx), version);
 	}
 #endif
 
@@ -524,45 +543,21 @@ static bool binary_manager_validate_set(uint8_t set_idx)
 	ret = binary_manager_verify_resource(set_idx);
 	if (ret != BINMGR_OK) {
 		bmdbg("Set %s resource validation FAIL, ret %d\n", GET_PARTNAME(set_idx), ret);
-		return false;
+		return 0;
 	}
-	bmvdbg("Set %s resource validation PASS\n", GET_PARTNAME(set_idx));
+	version = binary_manager_get_resource_version(set_idx);
+	if (version == 0) {
+		return 0;
+	}
+	if (version > highest_version) {
+		highest_version = version;
+	}
+	bmvdbg("Set %s resource validation PASS, version %u\n", GET_PARTNAME(set_idx), version);
 #endif
 
-	bmdbg("Set %s validation PASS\n", GET_PARTNAME(set_idx));
+	bmdbg("Set %s validation PASS, highest version %u\n", GET_PARTNAME(set_idx), highest_version);
 
-	return true;
-}
-
-/****************************************************************************
- * Name: binary_manager_get_kbin_version
- *
- * Description:
- *	 This function reads the kernel binary version from the given set.
- *	 It returns 0 if any step fails.
- *
- ****************************************************************************/
-static uint32_t binary_manager_get_kbin_version(uint8_t set_idx)
-{
-	int ret;
-	binmgr_kinfo_t *kdata;
-	kernel_binary_header_t header_data;
-	char filepath[BINARY_PATH_LEN];
-
-	kdata = binary_manager_get_kdata();
-	if (!kdata || set_idx >= kdata->part_count) {
-		bmdbg("Invalid kernel version request, set idx %u\n", set_idx);
-		return 0;
-	}
-
-	snprintf(filepath, BINARY_PATH_LEN, BINMGR_DEVNAME_FMT, kdata->part_info[set_idx].devnum);
-	ret = binary_manager_read_header(BINARY_KERNEL, filepath, &header_data, true);
-	if (ret != BINMGR_OK) {
-		bmdbg("Fail to read kernel header, set %s, devpath %s, ret %d\n", GET_PARTNAME(set_idx), filepath, ret);
-		return 0;
-	}
-
-	return header_data.version;
+	return highest_version;
 }
 
 /****************************************************************************
@@ -622,40 +617,31 @@ int binary_manager_recover_bootparam_set(void)
 	uint8_t target_set;
 	uint8_t write_bp_idx;
 	uint32_t new_version;
-	uint32_t set_a_version;
-	uint32_t set_b_version;
 	uint32_t target_version;
 	binmgr_bpdata_t update_bp_data;
-	bool set_a_valid;
-	bool set_b_valid;
 
 	bmdbg("BP set recovery required. valid BP %d, active idx %d, BP version %u\n", g_bp_recovery_info.has_valid_bp, g_bp_recovery_info.active_set, g_bp_recovery_info.bp_version);
 
-	set_a_valid = binary_manager_validate_set(0);
-	set_b_valid = binary_manager_validate_set(1);
-	set_a_version = set_a_valid ? binary_manager_get_kbin_version(0) : 0;
-	set_b_version = set_b_valid ? binary_manager_get_kbin_version(1) : 0;
+	g_bp_recovery_info.highest_version_a = binary_manager_get_valid_set_highest_version(0);
+	g_bp_recovery_info.highest_version_b = binary_manager_get_valid_set_highest_version(1);
 
-	bmdbg("Set A valid %d, version %u, Set B valid %d, version %u\n", set_a_valid, set_a_version, set_b_valid, set_b_version);
+	bmdbg("Set A highest version %u, Set B highest version %u\n", g_bp_recovery_info.highest_version_a, g_bp_recovery_info.highest_version_b);
 
-	if (set_a_valid && set_b_valid) {
-		if (g_bp_recovery_info.has_valid_bp) {
-			target_set = g_bp_recovery_info.active_set;
-		} else {
-			target_set = set_a_version > set_b_version ? 0 : 1;
-		}
+	if (g_bp_recovery_info.highest_version_a >= g_bp_recovery_info.highest_version_b) {
+		target_set = 0;
+		target_version = g_bp_recovery_info.highest_version_a;
 	} else {
-		target_set = set_a_valid ? 0 : 1;
+		target_set = 1;
+		target_version = g_bp_recovery_info.highest_version_b;
 	}
 
-	target_version = target_set == 0 ? set_a_version : set_b_version;
-	if (target_version == 0 || target_version == FACTORY_KBIN_VERSION) {
-		bmdbg("Invalid target kernel version, set %s, version %u. Reboot as recovery fail\n", GET_PARTNAME(target_set), target_version);
+	if (target_version == 0 || target_version == FACTORY_BIN_VERSION) {
+		bmdbg("Invalid target binary version, set %s, highest version %u. Reboot as recovery fail\n", GET_PARTNAME(target_set), target_version);
 		binary_manager_reset_board(REBOOT_SYSTEM_BINARY_RECOVERYFAIL);
 		return BINMGR_OPERATION_FAIL;
 	}
 
-	bmdbg("Select set %s for BP set alignment.\n", GET_PARTNAME(target_set));
+	bmdbg("Select set %s for BP set alignment by highest version %u\n", GET_PARTNAME(target_set), target_version);
 
 	new_version = g_bp_recovery_info.has_valid_bp ? g_bp_recovery_info.bp_version + 1 : 1;
 	ret = binary_manager_make_bootparam_from_partitions(&update_bp_data, target_set, new_version);

--- a/os/kernel/binary_manager/binary_manager_bootparam.c
+++ b/os/kernel/binary_manager/binary_manager_bootparam.c
@@ -112,6 +112,48 @@ static int binary_manager_open_bootparam(void)
 	return fd;
 }
 
+/****************************************************************************
+ * Name: binary_manager_dump_bpdata
+ *
+ * Description:
+ *	 This function prints bootparam data.
+ *
+ ****************************************************************************/
+void binary_manager_dump_bpdata(void)
+{
+	int bp_idx;
+	binmgr_bpdata_t *bp_data;
+	bool bp_valid;
+#ifdef CONFIG_APP_BINARY_SEPARATION
+	uint32_t bp_app_idx;
+	uint32_t bp_app_count;
+	int bp_app_log_len;
+	char bp_app_log[(CONFIG_NUM_APPS + 1) * 4 + 1];
+#endif
+
+	for (bp_idx = 0; bp_idx < BOOTPARAM_COUNT; bp_idx++) {
+		bp_data = binary_manager_get_slot_bpdata(bp_idx);
+		if (!bp_data) {
+			bmdbg("BP[%d] is NULL\n", bp_idx);
+			continue;
+		}
+		bp_valid = binary_manager_get_slot_bpvalid(bp_idx);
+		bmdbg("BP[%d] valid %d, ver %u, fmt %u, idx %u, addr %08x %08x, reason %u\n", bp_idx, bp_valid, bp_data->head.version, bp_data->head.format_ver, bp_data->head.active_idx, bp_data->head.address[0], bp_data->head.address[1], bp_data->tail.bp_update_reason);
+#ifdef CONFIG_APP_BINARY_SEPARATION
+		bp_app_count = sizeof(bp_data->head.app_data) / sizeof(bp_data->head.app_data[0]);
+		bp_app_log_len = 0;
+		for (bp_app_idx = 0; bp_app_idx < bp_app_count; bp_app_idx++) {
+			bp_app_log_len += snprintf(&bp_app_log[bp_app_log_len], sizeof(bp_app_log) - bp_app_log_len, "%u ", bp_data->head.app_data[bp_app_idx].useidx);
+		}
+		bp_app_log[bp_app_log_len] = '\0';
+		bmdbg("BP[%d] APP count %u, idx %s\n", bp_idx, bp_data->head.app_count, bp_app_log);
+#endif
+#ifdef CONFIG_RESOURCE_FS
+		bmdbg("BP[%d] RESOURCE idx %u\n", bp_idx, bp_data->head.resource_active_idx);
+#endif
+	}
+}
+
 /*****************************************************************************************************
  * Name: binary_manager_scan_bootparam
  *
@@ -126,7 +168,7 @@ int binary_manager_scan_bootparam(binmgr_bpinfo_t *bp_info)
 	int bp_idx;
 	uint32_t latest_ver = 0;
 	char *bootparam;
-	size_t update_reason_offset;
+	size_t tail_offset;
 	binmgr_bpdata_t scanned_bp_data;
 #ifdef CONFIG_APP_BINARY_SEPARATION
 	uint32_t bp_app_idx;
@@ -137,6 +179,7 @@ int binary_manager_scan_bootparam(binmgr_bpinfo_t *bp_info)
 		bmdbg("Invalid input bp_info\n");
 		return BINMGR_INVALID_PARAM;
 	}
+	memset(bp_info, 0, sizeof(*bp_info));
 
 	fd = binary_manager_open_bootparam();
 	if (fd < 0) {
@@ -165,33 +208,31 @@ int binary_manager_scan_bootparam(binmgr_bpinfo_t *bp_info)
 		if (ret != BOOTPARAM_SIZE) {
 			bmdbg("Fail to read BP, errno %d\n", errno);
 			continue;
-		} else if (!is_valid_bootparam(bootparam)) {
-			bmdbg("BP%d is invalid\n", bp_idx);
-			continue;
 		}
 
+		tail_offset = BOOTPARAM_SIZE - sizeof(scanned_bp_data.tail);
 		memcpy(&scanned_bp_data.head, bootparam, sizeof(scanned_bp_data.head));
+		memcpy(&scanned_bp_data.tail, &bootparam[tail_offset], sizeof(scanned_bp_data.tail));
+		memcpy(&bp_info->bp_data[bp_idx], &scanned_bp_data, sizeof(binmgr_bpdata_t));
 
-		/* Version 1 has no update reason and leaves the last byte as reserved. */
-		update_reason_offset = BOOTPARAM_SIZE - sizeof(scanned_bp_data.tail.bp_update_reason);
-		if (scanned_bp_data.head.format_ver < BOOTPARAM_FORMAT_VERSION_2 || ((uint8_t *)bootparam)[update_reason_offset] > BP_UPDATE_UNKNOWN) {
-			scanned_bp_data.tail.bp_update_reason = BP_UPDATE_UNKNOWN;
-		} else {
-			scanned_bp_data.tail.bp_update_reason = ((uint8_t *)bootparam)[update_reason_offset];
+		bp_info->bp_valid[bp_idx] = is_valid_bootparam(bootparam);
+		if (!bp_info->bp_valid[bp_idx]) {
+			bmdbg("BP%d is invalid\n", bp_idx);
+			continue;
 		}
 
 		bmdbg("BP%d is valid. crc %u, version %u, format %u, reason %u, active idx %u, address[0] 0x%x, address[1] 0x%x\n", bp_idx, scanned_bp_data.head.crc_hash, scanned_bp_data.head.version, scanned_bp_data.head.format_ver, scanned_bp_data.tail.bp_update_reason, scanned_bp_data.head.active_idx, scanned_bp_data.head.address[0], scanned_bp_data.head.address[1]);
 
 #ifdef CONFIG_APP_BINARY_SEPARATION
 		max_app_count = sizeof(scanned_bp_data.head.app_data) / sizeof(scanned_bp_data.head.app_data[0]);
-		bmdbg("BP%d: app count %u, max %u\n", bp_idx, scanned_bp_data.head.app_count, max_app_count);
+		bmvdbg("BP%d: app count %u, max %u\n", bp_idx, scanned_bp_data.head.app_count, max_app_count);
 		for (bp_app_idx = 0; bp_app_idx < scanned_bp_data.head.app_count && bp_app_idx < max_app_count; bp_app_idx++) {
-			bmdbg("BP%d: app[%u] name %.*s, useidx %u\n", bp_idx, bp_app_idx, BIN_NAME_MAX, scanned_bp_data.head.app_data[bp_app_idx].name, scanned_bp_data.head.app_data[bp_app_idx].useidx);
+			bmvdbg("BP%d: app[%u] name %.*s, useidx %u\n", bp_idx, bp_app_idx, BIN_NAME_MAX, scanned_bp_data.head.app_data[bp_app_idx].name, scanned_bp_data.head.app_data[bp_app_idx].useidx);
 		}
 #endif
 
 #ifdef CONFIG_RESOURCE_FS
-		bmdbg("BP%d: resource active idx %u\n", bp_idx, scanned_bp_data.head.resource_active_idx);
+		bmvdbg("BP%d: resource active idx %u\n", bp_idx, scanned_bp_data.head.resource_active_idx);
 #endif
 
 		/* Update the latest version and index */
@@ -199,7 +240,6 @@ int binary_manager_scan_bootparam(binmgr_bpinfo_t *bp_info)
 			latest_ver = scanned_bp_data.head.version;
 			/* Update bootparam data */
 			bp_info->inuse_idx = bp_idx;
-			memcpy(&bp_info->bp_data, &scanned_bp_data, sizeof(binmgr_bpdata_t));
 		}
 	}
 	close(fd);
@@ -230,8 +270,9 @@ int binary_manager_update_bpinfo(void)
 	if (ret == BINMGR_OK) {
 		/* Set scanned bootparam data to g_bp_info */
 		g_bp_info.inuse_idx = bp_info.inuse_idx;
-		g_bp_info.bp_data = bp_info.bp_data;
-		bmvdbg("BP[%d] ver: %u, format: %u, reason: %u, active index: %u, addresses: %x, %x\n", g_bp_info.inuse_idx, g_bp_info.bp_data.head.version, g_bp_info.bp_data.head.format_ver, g_bp_info.bp_data.tail.bp_update_reason, g_bp_info.bp_data.head.active_idx, g_bp_info.bp_data.head.address[0], g_bp_info.bp_data.head.address[1]);
+		memcpy(g_bp_info.bp_data, bp_info.bp_data, sizeof(g_bp_info.bp_data));
+		memcpy(g_bp_info.bp_valid, bp_info.bp_valid, sizeof(g_bp_info.bp_valid));
+		bmvdbg("BP[%d] ver: %u, format: %u, reason: %u, active index: %u, address: %x %x\n", g_bp_info.inuse_idx, g_bp_info.bp_data[g_bp_info.inuse_idx].head.version, g_bp_info.bp_data[g_bp_info.inuse_idx].head.format_ver, g_bp_info.bp_data[g_bp_info.inuse_idx].tail.bp_update_reason, g_bp_info.bp_data[g_bp_info.inuse_idx].head.active_idx, g_bp_info.bp_data[g_bp_info.inuse_idx].head.address[0], g_bp_info.bp_data[g_bp_info.inuse_idx].head.address[1]);
 	}
 
 	return ret;
@@ -801,7 +842,41 @@ send_response:
  ****************************************************************************/
 binmgr_bpdata_t *binary_manager_get_bpdata(void)
 {
-	return &g_bp_info.bp_data;
+	return &g_bp_info.bp_data[g_bp_info.inuse_idx];
+}
+
+/****************************************************************************
+ * Name: binary_manager_get_slot_bpdata
+ *
+ * Description:
+ *	 This function gets boot parameter data by BP slot index.
+ *
+ ****************************************************************************/
+binmgr_bpdata_t *binary_manager_get_slot_bpdata(uint8_t bp_idx)
+{
+	if (bp_idx >= BOOTPARAM_COUNT) {
+		bmdbg("Invalid BP slot index %d\n", bp_idx);
+		return NULL;
+	}
+
+	return &g_bp_info.bp_data[bp_idx];
+}
+
+/****************************************************************************
+ * Name: binary_manager_get_slot_bpvalid
+ *
+ * Description:
+ *	 This function gets boot parameter valid state by BP slot index.
+ *
+ ****************************************************************************/
+bool binary_manager_get_slot_bpvalid(uint8_t bp_idx)
+{
+	if (bp_idx >= BOOTPARAM_COUNT) {
+		bmdbg("Invalid BP slot index %d\n", bp_idx);
+		return false;
+	}
+
+	return g_bp_info.bp_valid[bp_idx];
 }
 
 /****************************************************************************
@@ -816,7 +891,7 @@ int binary_manager_set_bpdata(binmgr_bpdata_t *bp_data)
 	if (bp_data == NULL) {
 		return ERROR;
 	}
-	memcpy(&g_bp_info.bp_data, bp_data, sizeof(binmgr_bpdata_t));
+	memcpy(&g_bp_info.bp_data[g_bp_info.inuse_idx], bp_data, sizeof(binmgr_bpdata_t));
 
 	return OK;
 }

--- a/os/kernel/binary_manager/binary_manager_bootparam.c
+++ b/os/kernel/binary_manager/binary_manager_bootparam.c
@@ -365,6 +365,41 @@ int binary_manager_write_bootparam(binmgr_bpdata_t *bp_data)
 }
 
 /****************************************************************************
+ * Name: binary_manager_is_bp_kernel_address_valid
+ *
+ * Description:
+ *	 This function checks whether in-use BP kernel addresses are valid
+ *   against registered partition addresses.
+ *
+ ****************************************************************************/
+static bool binary_manager_is_bp_kernel_address_valid(binmgr_bpdata_t *bp_data)
+{
+	uint32_t part_idx;
+	binmgr_kinfo_t *kdata;
+
+	if (!bp_data) {
+		bmdbg("BP data is NULL\n");
+		return false;
+	}
+
+	kdata = binary_manager_get_kdata();
+	if (!kdata || kdata->part_count == 0 || kdata->part_count > BOOTPARAM_COUNT || !kdata->part_info) {
+		bmdbg("Invalid kernel partition data\n");
+		return false;
+	}
+
+	for (part_idx = 0; part_idx < kdata->part_count; part_idx++) {
+		if (bp_data->head.address[part_idx] != kdata->part_info[part_idx].address) {
+			bmdbg("Invalid in-use BP kernel address: part[%u] BP 0x%x, partition 0x%x\n",
+					part_idx, bp_data->head.address[part_idx], kdata->part_info[part_idx].address);
+			return false;
+		}
+	}
+
+	return true;
+}
+
+/****************************************************************************
  * Name: binary_manager_is_set_mismatch
  *
  * Description:
@@ -638,6 +673,11 @@ int binary_manager_check_bootparam_set(void)
 
 	if (binary_manager_is_set_mismatch(bp_data)) {
 		bmdbg("BP set mismatch detected. Run BP recovery from partition information\n");
+		return BINMGR_OPERATION_FAIL;
+	}
+
+	if (!binary_manager_is_bp_kernel_address_valid(bp_data)) {
+		bmdbg("Invalid in-use BP kernel address detected. Run BP recovery from partition information\n");
 		return BINMGR_OPERATION_FAIL;
 	}
 

--- a/os/kernel/binary_manager/binary_manager_data.c
+++ b/os/kernel/binary_manager/binary_manager_data.c
@@ -302,6 +302,7 @@ int binary_manager_check_update(void)
 	int ret;
 #ifdef CONFIG_USE_BP
 	binmgr_bpinfo_t bp_info;
+	binmgr_bpdata_t *bp_data;
 
 	/* Get the latest bootparam */
 	ret = binary_manager_scan_bootparam(&bp_info);
@@ -309,19 +310,20 @@ int binary_manager_check_update(void)
 		bmdbg("Fail to scan BP %d\n", ret);
 		return ret;
 	}
+	bp_data = &bp_info.bp_data[bp_info.inuse_idx];
 
 	/* Compare bootparam version with current running version */
-	if (binary_manager_get_bpdata()->head.version >= bp_info.bp_data.head.version) {
+	if (binary_manager_get_bpdata()->head.version >= bp_data->head.version) {
 		/* No bootparam update */
 		bmdbg("All binaries are running based on BP\n");
 		return BINMGR_NOT_FOUND;
 	}
 
 	/* Do kernel need to update? */
-	if (binary_manager_get_kdata()->inuse_idx != bp_info.bp_data.head.active_idx) {
+	if (binary_manager_get_kdata()->inuse_idx != bp_data->head.active_idx) {
 		/* Running partition and partition written in the latest BP are different.
 		 * Reboot to switch kernel binary in another partition. */
-		bmvdbg("Need to update to kernel binary in partition %d in the latest BP.\n", binary_manager_get_kdata()->part_info[bp_info.bp_data.head.active_idx].devnum);
+		bmvdbg("Need to update to kernel binary in partition %d in the latest BP.\n", binary_manager_get_kdata()->part_info[bp_data->head.active_idx].devnum);
 		goto reboot;
 	}
 #else

--- a/os/kernel/binary_manager/binary_manager_data.c
+++ b/os/kernel/binary_manager/binary_manager_data.c
@@ -153,6 +153,34 @@ int binary_manager_verify_kbin(uint8_t part_idx)
 }
 
 /****************************************************************************
+ * Name: binary_manager_get_kbin_version
+ *
+ * Description:
+ *	 This function reads the kernel binary version from part_idx.
+ *
+ ****************************************************************************/
+uint32_t binary_manager_get_kbin_version(uint8_t part_idx)
+{
+	int ret;
+	char filepath[BINARY_PATH_LEN];
+	kernel_binary_header_t header_data;
+
+	if (part_idx >= kernel_info.part_count) {
+		bmdbg("Invalid kernel part idx %u, part count %u\n", part_idx, kernel_info.part_count);
+		return 0;
+	}
+
+	snprintf(filepath, BINARY_PATH_LEN, BINMGR_DEVNAME_FMT, kernel_info.part_info[part_idx].devnum);
+	ret = binary_manager_read_header(BINARY_KERNEL, filepath, &header_data, false);
+	if (ret != BINMGR_OK) {
+		bmdbg("Fail to read kernel header, set %s, devpath %s, ret %d\n", GET_PARTNAME(part_idx), filepath, ret);
+		return 0;
+	}
+
+	return header_data.version;
+}
+
+/****************************************************************************
  * Name: binary_manager_scan_kbin
  *
  * Description:
@@ -480,6 +508,53 @@ int binary_manager_verify_ubin(int bin_idx, uint8_t part_idx)
 	bmvdbg("Valid binary candidate %s [%s], dev %d\n", BIN_NAME(bin_idx), GET_PARTNAME(part_idx), BIN_PARTNUM(bin_idx, part_idx));
 
 	return BINMGR_OK;
+}
+
+/****************************************************************************
+ * Name: binary_manager_get_ubin_version
+ *
+ * Description:
+ *	 This function reads the user/common binary version from part_idx.
+ *
+ ****************************************************************************/
+uint32_t binary_manager_get_ubin_version(int bin_idx, uint8_t part_idx)
+{
+	int ret;
+	char devpath[BINARY_PATH_LEN];
+#ifdef CONFIG_SUPPORT_COMMON_BINARY
+	common_binary_header_t common_header_data;
+#endif
+	user_binary_header_t user_header_data;
+
+	if (bin_idx < 0 || bin_idx > binary_manager_get_ucount()) {
+		bmdbg("Invalid bin idx %d\n", bin_idx);
+		return 0;
+	}
+
+	if (part_idx >= BIN_COUNT(bin_idx)) {
+		bmdbg("Invalid %s part idx %u, part count %u\n", BIN_NAME(bin_idx), part_idx, BIN_COUNT(bin_idx));
+		return 0;
+	}
+
+	snprintf(devpath, BINARY_PATH_LEN, BINMGR_DEVNAME_FMT, BIN_PARTNUM(bin_idx, part_idx));
+#ifdef CONFIG_SUPPORT_COMMON_BINARY
+	if (bin_idx == BM_CMNLIB_IDX) {
+		ret = binary_manager_read_header(BINARY_COMMON, devpath, &common_header_data, false);
+		if (ret != BINMGR_OK) {
+			bmdbg("Fail to read common header, set %s, devpath %s, ret %d\n", GET_PARTNAME(part_idx), devpath, ret);
+			return 0;
+		}
+		return common_header_data.version;
+	}
+#endif
+
+	ret = binary_manager_read_header(BINARY_USERAPP, devpath, &user_header_data, false);
+	if (ret != BINMGR_OK) {
+		bmdbg("Fail to read app header, name %s, set %s, devpath %s, ret %d\n", BIN_NAME(bin_idx), GET_PARTNAME(part_idx), devpath, ret);
+		return 0;
+	}
+
+	return user_header_data.bin_ver;
 }
 
 /****************************************************************************

--- a/os/kernel/binary_manager/binary_manager_internal.h
+++ b/os/kernel/binary_manager/binary_manager_internal.h
@@ -249,6 +249,8 @@ struct binmgr_bp_recovery_info_s {
 	int inuse_idx;
 	int active_set;
 	uint32_t bp_version;
+	uint32_t highest_version_a;
+	uint32_t highest_version_b;
 };
 typedef struct binmgr_bp_recovery_info_s binmgr_bp_recovery_info_t;
 
@@ -351,12 +353,15 @@ int binary_manager_update_kernel_binary(void);
 binmgr_resinfo_t *binary_manager_get_resdata(void);
 int binary_manager_unmount_resource(void);
 int binary_manager_verify_resource(uint8_t part_idx);
+uint32_t binary_manager_get_resource_version(uint8_t part_idx);
 int binary_manager_check_resource_update(bool check_updatable);
 #endif
 int binary_manager_verify_kbin(uint8_t part_idx);
+uint32_t binary_manager_get_kbin_version(uint8_t part_idx);
 int binary_manager_check_kernel_update(bool check_updatable);
 #ifdef CONFIG_APP_BINARY_SEPARATION
 int binary_manager_verify_ubin(int bin_idx, uint8_t part_idx);
+uint32_t binary_manager_get_ubin_version(int bin_idx, uint8_t part_idx);
 int binary_manager_check_user_update(int bin_idx, bool check_updatable);
 #endif
 

--- a/os/kernel/binary_manager/binary_manager_internal.h
+++ b/os/kernel/binary_manager/binary_manager_internal.h
@@ -240,7 +240,8 @@ static_assert(sizeof(binmgr_bpdata_t) <= BOOTPARAM_SIZE, "binmgr_bpdata_t size e
 struct binmgr_bpinfo_s {
 	uint8_t inuse_idx;
 	int part_num;
-	binmgr_bpdata_t bp_data;
+	binmgr_bpdata_t bp_data[BOOTPARAM_COUNT];
+	bool bp_valid[BOOTPARAM_COUNT];
 };
 typedef struct binmgr_bpinfo_s binmgr_bpinfo_t;
 
@@ -341,8 +342,11 @@ int binary_manager_create_entry(int requester_pid, char *bin_name, int version);
 void binary_manager_release_binary_sem(int bin_idx);
 void binary_manager_update_running_state(int bin_id);
 int binary_manager_get_index_with_name(char *bin_name);
+void binary_manager_dump_bpdata(void);
 int binary_manager_scan_bootparam(binmgr_bpinfo_t *bp_info);
 binmgr_bpdata_t *binary_manager_get_bpdata(void);
+binmgr_bpdata_t *binary_manager_get_slot_bpdata(uint8_t bp_idx);
+bool binary_manager_get_slot_bpvalid(uint8_t bp_idx);
 int binary_manager_set_bpdata(binmgr_bpdata_t *bp_data);
 int binary_manager_write_bootparam(binmgr_bpdata_t *bp_data);
 int binary_manager_get_inactive_path(int requester_pid, char *bin_name);

--- a/os/kernel/binary_manager/binary_manager_resource.c
+++ b/os/kernel/binary_manager/binary_manager_resource.c
@@ -123,6 +123,34 @@ int binary_manager_verify_resource(uint8_t part_idx)
 }
 
 /****************************************************************************
+ * Name: binary_manager_get_resource_version
+ *
+ * Description:
+ *	 This function reads the resource binary version from part_idx.
+ *
+ ****************************************************************************/
+uint32_t binary_manager_get_resource_version(uint8_t part_idx)
+{
+	int ret;
+	char filepath[BINARY_PATH_LEN];
+	resource_binary_header_t header_data;
+
+	if (part_idx >= resource_info.part_count) {
+		bmdbg("Invalid resource part idx %u, part count %u\n", part_idx, resource_info.part_count);
+		return 0;
+	}
+
+	snprintf(filepath, BINARY_PATH_LEN, BINMGR_DEVNAME_FMT, resource_info.part_info[part_idx].devnum);
+	ret = binary_manager_read_header(BINARY_RESOURCE, filepath, &header_data, false);
+	if (ret != BINMGR_OK) {
+		bmdbg("Fail to read resource header, set %s, devpath %s, ret %d\n", GET_PARTNAME(part_idx), filepath, ret);
+		return 0;
+	}
+
+	return header_data.version;
+}
+
+/****************************************************************************
  * Name: binary_manager_mount_resource
  *
  * Description:


### PR DESCRIPTION
### 1. os/kernel/binary_manager: Use highest version as target binary for BP recovery

Add new functions `binary_manager_get_resource_version` and `binary_manager_get_ubin_version` to get binary version from partition.
Expand binmgr_bp_recovery_info_s to store highest version for each binary set.
Change binary_manager_validate_set function to binary_manager_get_valid_set_highest_version that returns highest version for valid binary set.
Highest version is used to choice target binary for BP recovery.


### 2. os/kernel/binary_manager: Print log both BP slots in binary_manager
Save both BP data and validity in binmgr_bpinfo_s.
`binary_manager_update_bpinfo` function memcpy both BP data and validity from scanned BP data.
Add new helper function `binary_manager_get_slot_bpdata` and `binary_manager_get_slot_bpvalid` to get BP data and validity by slot index.
Print both BP data log in binary_manager thread start.

[Log Example]
```
binary_manager: BP[0] valid 1, ver 1, fmt 2, idx 0, addr 08080000 0903f000, reason 0
binary_manager: BP[0] APP count 2, idx 0 0
binary_manager: BP[0] RESOURCE idx 0
binary_manager: BP[1] valid 0, ver 4294967295, fmt 4294967295, idx 255, addr ffffffff ffffffff, reason 255
binary_manager: BP[1] APP count 255, idx 255 255
binary_manager: BP[1] RESOURCE idx 255
```

### 3. os/kernel/binary_manager: Add validation for in-use BP kernel addresses
Add new function `binary_manager_is_bp_kernel_address_valid` to validate in-use BP's kernel addresses against registered partition addresses.
If in-use BP's kernel address is wrong, binary_manager should recover BP from partition information.