### PR TITLE
os/board/bk7239n/src: modify VIO configuration to improve flash power supply capability

### DIFF
--- a/os/board/bk7239n/src/components/bk_init/components_init.c
+++ b/os/board/bk7239n/src/components/bk_init/components_init.c
@@ -328,7 +328,8 @@ int components_init(void)
 		return BK_FAIL;
 
 #if (defined(CONFIG_TEMP_DETECT) || defined(CONFIG_VOLT_DETECT))
-	bk_sensor_init();
+    bk_sensor_init();
+    volt_single_get_vbat_voltage();
 #endif
 
 	pm_init();

--- a/os/board/bk7239n/src/components/temp_detect/volt_detect.c
+++ b/os/board/bk7239n/src/components/temp_detect/volt_detect.c
@@ -435,4 +435,41 @@ int volt_single_get_current_voltage(UINT32 *volt_value)
 
     return result;
 }
+
+void volt_single_get_vbat_voltage(void)
+{
+    int result;
+    int retry_count = 3;
+    UINT32 volt_adc = 0;
+    float volt = 0.0;
+
+    BK_RETURN_ON_ERR(_volt_detect_init_adc_buffer());
+
+    for (; retry_count > 0; retry_count--)
+    {
+        result = _volt_detect_get_adc_data(ADC_VOLT_SENSER_CHANNEL, s_raw_voltage_data);
+        if (BK_OK != result)
+        {
+            TEMPD_LOGW("get volt_single failed(%d), retry\n", result);
+            continue;
+        }
+
+        volt_adc = _volt_detect_calculate_voltage(s_raw_voltage_data);
+        if ((ADC_TEMP_VAL_MIN < volt_adc)/* && (*volt_value < ADC_TEMP_VAL_MAX)*/)
+        {
+            break;
+        }
+    }
+    volt = volt_detect_calc_voltage(volt_adc);
+
+    if(volt < 3.5)
+    {
+        sys_drv_set_iobypassen_by_volt_detect(1);
+    }
+    else if(volt >= 3.6)
+    {
+        sys_drv_set_iobypassen_by_volt_detect(0);
+    }
+
+}
 #endif

--- a/os/board/bk7239n/src/components/temp_detect/volt_detect.h
+++ b/os/board/bk7239n/src/components/temp_detect/volt_detect.h
@@ -24,4 +24,5 @@ void volt_daemon_deinit(void);
 void volt_daemon_polling_handler(void);
 int volt_daemon_restart(void);
 int volt_daemon_stop(void);
+void volt_single_get_vbat_voltage(void);
 

--- a/os/board/bk7239n/src/middleware/driver/sys_ctrl/sys_driver.h
+++ b/os/board/bk7239n/src/middleware/driver/sys_ctrl/sys_driver.h
@@ -363,7 +363,7 @@ uint32_t sys_drv_enable_mac_txrx_timer_int(void);
 uint32_t sys_drv_enable_modem_int(void);
 uint32_t sys_drv_enable_modem_rc_int(void);
 uint32_t sys_drv_enable_hsu_int(void);
-
+void sys_drv_set_iobypassen_by_volt_detect(uint32_t v);
 
 //Yantao Add End
 

--- a/os/board/bk7239n/src/middleware/driver/sys_ctrl/sys_wifi_driver.c
+++ b/os/board/bk7239n/src/middleware/driver/sys_ctrl/sys_wifi_driver.c
@@ -674,6 +674,22 @@ uint32_t  sys_drv_enable_hsu_int(void)
 	return SYS_DRV_SUCCESS;
 }
 
+void sys_drv_set_iobypassen_by_volt_detect(uint32_t v)
+{
+    sys_hal_set_ana_reg_spi_latch1v(1);
+    if (v)
+    {
+        //tenglong20250508: ioldo >= vbat(3.5V) before iobypass change
+        sys_hal_set_ioldo_volt(6);
+        sys_hal_set_ioldo_bypass(1);
+    }
+    else
+    {
+        sys_hal_set_ioldo_bypass(0);
+        sys_hal_set_ioldo_volt(4); //shuguang20250512:vio=3.3V
+    }
+    sys_hal_set_ana_reg_spi_latch1v(0);
+}
 //Yantao Add End
 /**  WIFI End **/
 


### PR DESCRIPTION
- Modify VIO configuration to improve flash power supply capability
- This improvment can resolve the winbon flash write issue
- We have reproduced the winbon flash write issue with hello project, all 8 winbon boards can have this issue, and 12 other boards with different flash type does not have the issue. After modify VIO configuration, all the 8 winbon board is normal after 10 hours' test.