### PR TITLE
[DO NOT MERGE] os/kernel: Add new variable to pthread_cond_s

### DIFF
--- a/lib/libc/pthread/pthread_condinit.c
+++ b/lib/libc/pthread/pthread_condinit.c
@@ -104,6 +104,7 @@ int pthread_cond_init(FAR pthread_cond_t *cond, FAR const pthread_condattr_t *at
 		 * should not have priority inheritance enabled.
 		 */
 		sem_setprotocol(&cond->sem, SEM_PRIO_NONE);
+		cond->waiters = 0;
 	}
 
 	svdbg("Returning %d\n", ret);

--- a/os/include/pthread.h
+++ b/os/include/pthread.h
@@ -261,7 +261,7 @@ typedef FAR void *pthread_addr_t;
 typedef pthread_addr_t (*pthread_startroutine_t)(pthread_addr_t);
 typedef pthread_startroutine_t pthread_func_t;
 
-#define PTHREAD_COND_INITIALIZER { COND_SEM_INITIALIZER(0) }
+#define PTHREAD_COND_INITIALIZER { COND_SEM_INITIALIZER(0), 0}
 
 #define __PTHREAD_MUTEX_T_DEFINED 1
 

--- a/os/include/sys/types.h
+++ b/os/include/sys/types.h
@@ -379,6 +379,7 @@ typedef struct pthread_barrierattr_s pthread_barrierattr_t;
  */
 struct pthread_cond_s {
 	sem_t sem;
+	volatile uint16_t waiters;  /* Explicit counter for threads waiting or preparing to wait */
 };
 typedef struct pthread_cond_s pthread_cond_t;
 

--- a/os/kernel/pthread/pthread_condbroadcast.c
+++ b/os/kernel/pthread/pthread_condbroadcast.c
@@ -107,44 +107,28 @@
 int pthread_cond_broadcast(FAR pthread_cond_t *cond)
 {
 	int ret = OK;
-	int sval;
 
 	svdbg("cond=0x%p\n", cond);
 
 	if (!cond) {
 		ret = EINVAL;
 	} else {
-		/* Disable pre-emption until all of the waiting threads have been
-		 * restarted. This is necessary to assure that the sval behaves as
-		 * expected in the following while loop
-		 */
-
 		sched_lock();
 
-		/* Get the current value of the semaphore */
+		irqstate_t flags = enter_critical_section();
 
-		if (sem_getvalue((sem_t *)&cond->sem, &sval) != OK) {
-			ret = EINVAL;
-		} else {
-			/* Loop until all of the waiting threads have been restarted. */
+		/* Loop to wake up all waiting threads */
+		while (cond->waiters > 0) {
 
-			while (sval < 0) {
-				/* If the value is less than zero (meaning that one or more
-				 * thread is waiting), then post the condition semaphore.
-				 * Only the highest priority waiting thread will get to execute
-				 */
-
-				ret = pthread_sem_give((sem_t *)&cond->sem);
-
-				/* Increment the semaphore count (as was done by the
-				 * above post).
-				 */
-
-				sval++;
+			/* Decrement waiters counter */
+			cond->waiters--;
+			ret = pthread_sem_give((sem_t *)&cond->sem);
+			if (ret != OK) {
+				break;
 			}
 		}
 
-		/* Now we can let the restarted threads run */
+		leave_critical_section(flags);
 
 		sched_unlock();
 	}

--- a/os/kernel/pthread/pthread_condsignal.c
+++ b/os/kernel/pthread/pthread_condsignal.c
@@ -106,40 +106,22 @@
 int pthread_cond_signal(FAR pthread_cond_t *cond)
 {
 	int ret = OK;
-	int sval;
 
 	svdbg("cond=0x%p\n", cond);
 
 	if (!cond) {
 		ret = EINVAL;
 	} else {
-		/* Get the current value of the semaphore */
+		irqstate_t flags = enter_critical_section();
 
-		if (sem_getvalue((sem_t *)&cond->sem, &sval) != OK) {
-			ret = EINVAL;
+		if (cond->waiters > 0) {
+
+			/* Decrement waiters counter */
+			cond->waiters--;
+			ret = pthread_sem_give((sem_t *)&cond->sem);
 		}
 
-		/* If the value is less than zero (meaning that one or more
-		 * thread is waiting), then post the condition semaphore.
-		 * Only the highest priority waiting thread will get to execute
-		 */
-
-		else {
-			/* One of my objectives in this design was to make pthread_cond_signal
-			 * usable from interrupt handlers.  However, from interrupt handlers,
-			 * you cannot take the associated mutex before signaling the condition.
-			 * As a result, I think that there could be a race condition with
-			 * the following logic which assumes that the if sval < 0 then the
-			 * thread is waiting.  Without the mutex, there is no atomic, protected
-			 * operation that will guarantee this to be so.
-			 */
-
-			svdbg("sval=%d\n", sval);
-			if (sval < 0) {
-				svdbg("Signalling...\n");
-				ret = pthread_sem_give((sem_t *)&cond->sem);
-			}
-		}
+		leave_critical_section(flags);
 	}
 
 	svdbg("Returning %d\n", ret);

--- a/os/kernel/pthread/pthread_condtimedwait.c
+++ b/os/kernel/pthread/pthread_condtimedwait.c
@@ -288,6 +288,9 @@ int pthread_cond_timedwait(FAR pthread_cond_t *cond, FAR pthread_mutex_t *mutex,
 
 						wd_start(rtcb->waitdog, ticks, (wdentry_t)pthread_condtimedout, 2, (uint32_t)mypid, (uint32_t)SIGCONDTIMEDOUT);
 
+						/* Increment the waiter count */
+						cond->waiters++;
+
 						/* Take the condition semaphore.  Do not restore interrupts
 						 * until we return from the wait.  This is necessary to
 						 * make sure that the watchdog timer and the condition wait
@@ -305,6 +308,12 @@ int pthread_cond_timedwait(FAR pthread_cond_t *cond, FAR pthread_mutex_t *mutex,
 							 */
 
 							if (get_errno() == EINTR) {
+
+								/* Decrement the waiter count for the timeout case
+								 * because it will not be handled by cond_signal()
+								 * or cond_broadcast()
+								 */
+								cond->waiters--;
 								sdbg("Timedout!\n");
 								ret = ETIMEDOUT;
 							} else {

--- a/os/kernel/pthread/pthread_condwait.c
+++ b/os/kernel/pthread/pthread_condwait.c
@@ -108,12 +108,19 @@ int pthread_cond_wait(FAR pthread_cond_t *cond, FAR pthread_mutex_t *mutex)
 		ret = EPERM;
 	} else {
 		uint16_t oldstate;
+		irqstate_t flags;
 
 		/* Give up the mutex */
 
 		svdbg("Give up mutex / take cond\n");
 
 		sched_lock();
+
+		/* Increment waiters counter */
+		flags = enter_critical_section();
+		cond->waiters++;
+		leave_critical_section(flags);
+
 		mutex->pid = -1;
 		ret = pthread_mutex_give(mutex);
 


### PR DESCRIPTION
Description:

This patch fixes a race condition which exists between pthread_cond_wait() and pthread_cond_signal().
When a timer/signal interrupt occurs during the wait inside pthread_cond_wait, the signal causes sem_waitirq() to modify the semaphore count, leading to a lost signal.

----------------------------------------------------------------------

Root Cause:

In pthread_cond_signal(), the signal is only sent if sval < 0:

"Kernel/os/kernel/pthread/pthread_condsignal.c"
if (sval < 0) {
    ret = pthread_sem_give(&cond->sem);  // Signal sent
}
// If sval >= 0, signal is LOST!

The root cause of the issue is that `pthread_cond_signal()` checks the semaphore count (`semcount`) to determine if any thread is waiting. However, when a timer or signal interrupt occurs during the wait, `sem_waitirq()` increments the semaphore count, causing `pthread_cond_signal()` to incorrectly conclude that no thread is waiting and discard the signal.

----------------------------------------------------------------------

Logs:

sem_wait: sval after semcount--: -1, pid: 24, sem=0x60324b50    ← Thread blocked
timer_sigqueue: calling signo: 0 for pid: 24                    ← Interrupt
sem_waitirq: sval incremented to: 0, pid: 39, sem=0x60324b50    ← semcount: -1 → 0
pthread_cond_signal: sval=0, sem=0x60324b50                     ← sval = 0, NOT < 0!
pthread_cond_signal: Now sval is 0                              ← SIGNAL LOST!

----------------------------------------------------------------------

Proposed Fix:
Add an explicit waiter counter directly to the `pthread_cond_s` structure. This counter would be incremented before a thread starts waiting and decremented after it wakes up.
Since this counter is separate from the semaphore, it would not be modified by signal interrupts.

----------------------------------------------------------------------