### PR TITLE
os/board/bk7239n: Fix reboot issue

### DIFF
--- a/os/board/bk7239n/src/components/bk_system/reboot.c
+++ b/os/board/bk7239n/src/components/bk_system/reboot.c
@@ -79,7 +79,6 @@ void bk_reboot(void)
 void bk_reboot_reset_reason(void)
 {
 #if defined(CONFIG_SYS_CPU0)
-	bk_pm_module_vote_cpu_freq(PM_DEV_ID_DEFAULT,PM_CPU_FRQ_60M);
 	rtos_disable_int();
 
 	bk_flash_set_line_mode(FLASH_LINE_MODE_TWO);


### PR DESCRIPTION
Remove the CPU frequency vote from the board reset path because it is redundant before triggering WDT reboot. The PM vote flow may call system APIs internally, which is unsafe when the system is already in an abnormal state during panic recovery, and can prevent the reset from being triggered.

Based on this change, I repeatedly tested the code in the internal repository and no longer encountered the hanging problem.