### PR TITLE
os/* : Support new reboot reason for bk7239n

### DIFF
--- a/os/arch/arm/src/armino/armino_reboot_reason.c
+++ b/os/arch/arm/src/armino/armino_reboot_reason.c
@@ -59,6 +59,7 @@
 #include <debug.h>
 #include <tinyara/reboot_reason.h>
 #include "armino_reboot_reason.h"
+#include "system.h"
 /****************************************************************************
  * Public functions
  ****************************************************************************/
@@ -75,7 +76,7 @@ static reboot_reason_code_t up_reboot_reason_get_hw_value(void)
     rrvdbg("boot_reason = %d\n", boot_reason);
 
 	/* Check if this is a software-written reboot reason (value >= 50) */
-	if (boot_reason >= REBOOT_REASON_INITIALIZED) {
+	if (boot_reason > REBOOT_REASON_INITIALIZED) {
 		return boot_reason;
 	}
 
@@ -96,6 +97,14 @@ static reboot_reason_code_t up_reboot_reason_get_hw_value(void)
 		/* WDT reset - NMI interrupt */
 		case RESET_SOURCE_NMI_WDT:
 			return REBOOT_SYSTEM_WATCHDOG;
+
+        /* Brown out -
+		   Since 50 is the initial value, it is written to the 
+		   internal PMU register.When a brownout occurs, the core 
+		   resets, but the value of the PMU register is retained 
+		*/
+        case REBOOT_REASON_INITIALIZED:
+            return REBOOT_SYSTEM_BOR_RESET;
 
 		default:
 			return REBOOT_UNKNOWN;

--- a/os/arch/arm/src/armino/armino_reboot_reason.h
+++ b/os/arch/arm/src/armino/armino_reboot_reason.h
@@ -20,8 +20,11 @@
 #define __ARMINO_REBOOT_REASON_H__
 
 #include <tinyara/reboot_reason.h>
-#include "system.h"
 
-
+enum {
+    REBOOT_SYSTEM_BT_RESET     = REBOOT_BOARD_SPECIFIC2,   /* bluetooth memeory exhausted*/
+	REBOOT_SYSTEM_BOR_RESET    = REBOOT_BOARD_SPECIFIC3,   /* Brownout reset */
+    REBOOT_SYSTEM_TFM_RESET    = REBOOT_BOARD_SPECIFIC4,   /* secure fault  */
+};
 
 #endif /* __ARMINO_REBOOT_REASON_H__ */

--- a/os/board/bk7239n/src/components/bk_bluetooth/soc/bk7239n/bluetooth.c
+++ b/os/board/bk7239n/src/components/bk_bluetooth/soc/bk7239n/bluetooth.c
@@ -40,6 +40,12 @@
 #include "cache.h"
 #endif
 
+#ifdef CONFIG_SYSTEM_REBOOT_REASON
+#include <arch/reboot_reason.h>
+#include "armino_reboot_reason.h"
+#endif
+
+
 #include <driver/aon_rtc.h>
 #define PM_BT_LP_RTC_ALARM_NAME PM_BT_RTC_ALARM_NAME
 
@@ -859,7 +865,10 @@ static uint32_t bt_rf_pll_ctrl_wrapper(uint32_t set)
 
 static void reboot_wrapper(void)
 {
-    bk_reboot();
+#ifdef CONFIG_SYSTEM_REBOOT_REASON
+    up_reboot_reason_write(REBOOT_SYSTEM_BT_RESET);
+#endif
+    bk_reboot_reset_reason();
 }
 
 static int uart_read_byte_ex_wrapper(uint8_t id, uint8_t *ch)

--- a/os/board/bk7239n/src/include/components/system.h
+++ b/os/board/bk7239n/src/include/components/system.h
@@ -128,6 +128,7 @@ bk_err_t bk_get_mac(uint8_t *mac, mac_type_t type);
  */
 void bk_reboot(void);
 void bk_reboot_ex(uint32_t reset_reason);
+void bk_reboot_reset_reason(void);
 
 int bk_tick_init(void);
 int bk_tick_reload(uint32_t time_ms);

--- a/os/board/bk7239n/src/middleware/arch/cm33/trap_base.c
+++ b/os/board/bk7239n/src/middleware/arch/cm33/trap_base.c
@@ -35,8 +35,7 @@
 
 #include <driver/flash_types.h>
 #include <driver/flash.h>
-
-#define BK_SECURE_FAULT_REBOOT_REASON   (REBOOT_BOARD_SPECIFIC4) /* TFM watch dog */
+#include "armino_reboot_reason.h"
 
 #define MAX_DUMP_SYS_MEM_COUNT       (8)
 #define SOC_DTCM_DATA_SIZE           (0x4000)
@@ -750,7 +749,7 @@ static void exception_frame_printf (uint32_t *ptr_buff , uint32_t buflen)
 static void panic_secure_fault(void)
 {
 #ifdef CONFIG_SYSTEM_REBOOT_REASON
-    up_reboot_reason_write(BK_SECURE_FAULT_REBOOT_REASON);
+    up_reboot_reason_write(REBOOT_SYSTEM_TFM_RESET);
 #endif
     PANIC();
 }


### PR DESCRIPTION
Three board-specific reboot reasons have been added
1.When the reboot reason is 50, it indicates a brownout has occurred.
Since 50 is the initial value, it is written to the internal PMU register.
When a brownout occurs, the core resets, but the value of the PMU register is retained.

This reboot reason was ultimately translated into REBOOT_BOARD_SPECIFIC3

2.When a reboot occurs due to Bluetooth fixed memory pool exhaustion, the reboot
 reason is REBOOT_BOARD_SPECIFIC2.

3.When a security exception causes a reboot, the reboot_reason is
REBOOT_BOARD_SPECIFIC4.