### PR TITLE
os/board/bk7239n：Resolve the issue of discontinuous CSI data reporting

### DIFF
--- a/os/board/bk7239n/src/bsp_adapter/src/net/bk_wifi_csi_adapter.c
+++ b/os/board/bk7239n/src/bsp_adapter/src/net/bk_wifi_csi_adapter.c
@@ -695,7 +695,11 @@ void bk_wifi_csi_disable_HE_and_VHT(void)
 	BK_LOG_ON_ERR(bk_wifi_capa_config(WIFI_CAPA_ID_VHT_EN, 0));
 	BK_LOG_ON_ERR(bk_wifi_capa_config(WIFI_CAPA_ID_HE_EN, 0));
 }
-
+void bk_wifi_csi_disable_AMPDU(void)
+{
+	BK_LOG_ON_ERR(bk_wifi_capa_config(WIFI_CAPA_ID_TX_AMPDU_EN, 0));
+	BK_LOG_ON_ERR(bk_wifi_capa_config(WIFI_CAPA_ID_RX_AMPDU_EN, 0));	
+}
 FAR struct wifi_csi_lowerhalf_s *bk_wifi_csi_initialize(void)
 {
 	int err = 0;
@@ -717,7 +721,9 @@ FAR struct wifi_csi_lowerhalf_s *bk_wifi_csi_initialize(void)
 	}
 	bk_wifi_csi_givesem();
 	bk_wifi_csi_disable_HE_and_VHT();
-
+	#if 0
+	bk_wifi_csi_disable_AMPDU();
+	#endif
 	return &g_bk_drv->dev;
 }
 

--- a/os/board/bk7239n/src/components/bk_wifi/include/generated/lmac_wifi_adapter.h
+++ b/os/board/bk7239n/src/components/bk_wifi/include/generated/lmac_wifi_adapter.h
@@ -39,6 +39,8 @@ typedef enum {
 	BK_PBUF_POOL
 } bk_pbuf_type;
 
+struct mac_chan_op;
+
 typedef struct {
 	int _version;
 	int (*_manual_cal_rfcali)(void);
@@ -82,6 +84,7 @@ typedef struct {
 	void (*_bk7011_cal_dpd)(uint32_t freq, uint32_t connect_mode);
 	void (*_bk7011_cal_pll)(void);
 	void (*_bk7011_update_by_rx)(int8_t rssi, int8_t freq_offset);
+	void (*_bk7011_update_max_tx_power)(struct mac_chan_op *chan);
 	INT32 (*_rwnx_cal_load_trx_rcbekn_reg_val)(void);
 	UINT8 (*_manual_get_epa_flag)(void);
 	UINT32(*_rxsens_start_flag_get)(void);

--- a/os/board/bk7239n/src/components/bk_wifi/include/rw_ieee80211.h
+++ b/os/board/bk7239n/src/components/bk_wifi/include/rw_ieee80211.h
@@ -1458,6 +1458,7 @@ int ieee80211_freq_khz_to_channel(u32 freq);
 const char *regdom_flag_str(uint32_t channel_flags);
 enum nl80211_dfs_regions reg_get_dfs_region(struct wiphy *wiphy);
 bool rwnx_ieee80211_check_conn_instrument(const struct mac_ssid *ssid, const struct mac_addr *bssid);
+void rwnx_reg_update_max_txpower(struct mac_chan_op *chan);
 #endif // _RW_IEEE80211_H_
 // eof
 

--- a/os/board/bk7239n/src/components/bk_wifi/include/rwnx_defs.h
+++ b/os/board/bk7239n/src/components/bk_wifi/include/rwnx_defs.h
@@ -133,6 +133,7 @@ struct rwnx_hw {
 	u8 avail_idx_map;
 	u8 vif_started;
 	bool adding_sta;
+	bool connected;
 
     /* RoC Management */
     struct rwnx_roc_elem *roc_elem;             /* Information provided by cfg80211 in its remain on channel request */
@@ -162,6 +163,10 @@ struct rwnx_hw {
 	struct hostapd_freq_params freq_params;
 
 	struct bk_work csa_work;
+
+#ifdef CONFIG_WIFI_REGDOMAIN
+	struct mac_chan_op chan;
+#endif
 };
 
 #if CONFIG_RWNX_SW_TXQ

--- a/os/board/bk7239n/src/components/bk_wifi/src/bk_wifi_adapter.c
+++ b/os/board/bk7239n/src/components/bk_wifi/src/bk_wifi_adapter.c
@@ -285,6 +285,14 @@ static void bk7011_update_by_rx_wrapper(int8_t rssi, int8_t freq_offset)
 	#endif
 }
 
+static void bk7011_update_max_tx_power_wrapper(struct mac_chan_op *chan)
+{
+#if CONFIG_WIFI_REGDOMAIN
+	extern void rwnx_reg_update_max_txpower(struct mac_chan_op *chan);
+	rwnx_reg_update_max_txpower(chan);
+#endif
+}
+
 static void sys_ll_set_cpu_power_sleep_wakeup_pwd_ofdm_wrapper(uint32_t v)
 {
     #if (CONFIG_SOC_BK7236XX || CONFIG_SOC_BK7239XX)
@@ -1493,6 +1501,7 @@ __attribute__((section(".dtcm_sec_data "))) wifi_os_funcs_t g_wifi_os_funcs = {
 	._bk7011_cal_dpd = bk7011_cal_dpd_wrapper,
 	._bk7011_cal_pll = bk7011_cal_pll,
 	._bk7011_update_by_rx = bk7011_update_by_rx_wrapper,
+	._bk7011_update_max_tx_power = bk7011_update_max_tx_power_wrapper,
 	._rwnx_cal_load_trx_rcbekn_reg_val = rwnx_cal_load_trx_rcbekn_reg_val,
 	._manual_get_epa_flag = manual_get_epa_flag,
 #if CONFIG_NON_SIGANL_PHY_ENABLE

--- a/os/board/bk7239n/src/components/bk_wifi/src/rw_ieee80211.c
+++ b/os/board/bk7239n/src/components/bk_wifi/src/rw_ieee80211.c
@@ -1641,50 +1641,69 @@ int get_wiphy_idx(struct wiphy *wiphy)
 	return 1;
 }
 
-int rwnx_reg_notifier(struct wiphy *wiphy,
-			    struct regulatory_request *request)
+#if CONFIG_WIFI_REGDOMAIN
+void rwnx_reg_update_max_txpower(struct mac_chan_op *chan)
 {
+	struct wiphy *wiphy = &g_wiphy;
+	struct ieee80211_supported_band *sband;
+	struct ieee80211_channel *channel;
+	struct ieee80211_channel *channel_sec = NULL;
 	float pwr;
 	int regd_max_pwr = 0;
 
-	// Iterates all bands
-	for (wifi_band_t band = 0; band < IEEE80211_NUM_BANDS; band++) {
-		struct ieee80211_supported_band *sband = wiphy->bands[band];
-		if (!sband)
-			continue;
+	// Invalid band
+	if (chan->band >= IEEE80211_NUM_BANDS)
+		return;
 
-		// Iterates all channels
-		for (int i = 0; i < sband->n_channels; i++) {
-			struct ieee80211_channel *channel = &sband->channels[i];
+	// Support bands
+	sband = wiphy->bands[chan->band];
+	if (!sband)
+		return;
 
-			// Skip disabled channel
-			if (channel->flags & IEEE80211_CHAN_DISABLED)
-				continue;
+	// Get current channel of supported band
+	channel = ieee80211_get_channel(wiphy, chan->prim20_freq);
+	// Skip disabled channel
+	if (channel->flags & IEEE80211_CHAN_DISABLED) {
+		WIFI_LOGE("chan is disabled while set max tx power\n");
+		return;
+	}
 
-			// Since we doesn't support different channel use different tx pwr,
-			// save max tx pwr here
-			if (regd_max_pwr == 0)
-				regd_max_pwr = channel->max_power;
-			if (regd_max_pwr > channel->max_power)
-				regd_max_pwr = channel->max_power;
+	// TODO: BW80, 160, 80+80
+	if (chan->type == PHY_CHNL_BW_40) {
+		if (chan->center1_freq < chan->prim20_freq)
+			channel_sec = ieee80211_get_channel(wiphy, chan->center1_freq - 10);  // HT40-
+		else
+			channel_sec = ieee80211_get_channel(wiphy, chan->center1_freq + 10);  // HT40+
+		WIFI_LOGD("secondary chan power %d\n", channel_sec->max_power);
+	}
 
-			WIFI_LOGD("band %d, center %d, flags %s, max_power %d/%d, dfs region %d\n",
-					  channel->band, channel->center_freq, regdom_flag_str(channel->flags),
-					  channel->max_power, regd_max_pwr,
-					  reg_get_dfs_region(&g_wiphy));
+	// regulatory domain's max tx power
+	regd_max_pwr = channel->max_power;
 
-			for (wifi_standard std = WIFI_STANDARD_11A; std <= WIFI_STANDARD_11AX; std++) {
-				if (manual_cal_get_tx_power(std, &pwr) == BK_OK) {
-					WIFI_LOGD("current txpwr %f\n", pwr);
-					if (pwr > regd_max_pwr) {
-						if (manual_cal_set_tx_power(std, regd_max_pwr) != BK_OK)
-							WIFI_LOGE("set regd txpwr fail, band %d, freq %d\n",
-									  channel->band, channel->freq_offset);
-					}
-				}
+	// If secondary channel's max power less than primary
+	if (channel_sec && (channel_sec->max_power < regd_max_pwr))
+		regd_max_pwr = channel_sec->max_power;
+
+	// Update current tx power of this channel
+	for (wifi_standard std = WIFI_STANDARD_11A; std <= WIFI_STANDARD_11AX; std++) {
+		if (manual_cal_get_tx_power(std, &pwr) == BK_OK) {
+			WIFI_LOGD("current txpwr %f, reg %d\n", pwr, regd_max_pwr);
+			if (pwr > regd_max_pwr) {
+				if (manual_cal_set_tx_power(std, regd_max_pwr) != BK_OK)
+					WIFI_LOGE("set regd txpwr fail, band %d, freq %d\n",
+							  channel->band, channel->freq_offset);
 			}
 		}
 	}
+}
+
+
+int rwnx_reg_notifier(struct wiphy *wiphy,
+			    struct regulatory_request *request)
+{
+	// After sta connected to AP, set max tx power
+	if (g_rwnx_hw.connected)
+		rwnx_reg_update_max_txpower(&g_rwnx_hw.chan);
 
 	// Reconfig mac channel
 	if (rwm_mgmt_is_vif_first_used()) {
@@ -1706,6 +1725,7 @@ void rwnx_regulatory_hint_11d(int freq, const u8 *country_ie, u8 country_ie_len)
     }
 	regulatory_hint_11d(&g_wiphy, band, country_ie, country_ie_len);
 }
+#endif
 
 /// Instrument discernible ssid & bssid
 bool rwnx_ieee80211_check_conn_instrument(const struct mac_ssid *ssid, const struct mac_addr *bssid)

--- a/os/board/bk7239n/src/components/bk_wifi/src/rw_msg_rx.c
+++ b/os/board/bk7239n/src/components/bk_wifi/src/rw_msg_rx.c
@@ -506,7 +506,10 @@ void mhdr_connect_ind(void *msg, UINT32 len)
 
 	if (!ind->status_code) {
 		RWNX_LOGD("connect ok\n");
-
+		g_rwnx_hw.connected = true;
+#ifdef CONFIG_WIFI_REGDOMAIN
+		g_rwnx_hw.chan = ind->chan;
+#endif
 		bk7011_default_rxsens_setting();
 
 #if NX_VERSION > NX_VERSION_PACK(6, 22, 0, 0)
@@ -1591,7 +1594,7 @@ void rwnx_handle_recv_msg(struct ke_msg *rx_msg)
 
 		msg_ptr = (struct ke_msg *)rx_msg;
 		ind = (struct sm_disconnect_ind *)msg_ptr->param;
-
+		g_rwnx_hw.connected = false;
 		RWNX_LOGD("disconnect\r\n");
 
 #if defined(CONFIG_IEEE80211R) || defined(CONFIG_WNM)

--- a/os/board/bk7239n/src/libs/RELEASE_NOTE.txt
+++ b/os/board/bk7239n/src/libs/RELEASE_NOTE.txt
@@ -1,0 +1,5 @@
+/* == "version" + "BK git version" + "compile date" + "compile time" == */
+
+== version libwifi_ver_e9097bd09e04e9d7ced6ae6879c05fbefffcd317_2026/06/18-15:15:00 ==
+1.	Resolve the issue of discontinuous CSI data reporting 
+2.             Limit tx power for current working channel


### PR DESCRIPTION
Resolve the issue of discontinuous CSI data reporting

keys：
Relax the filtering conditions and reduce erroneous removal of CSI information