### PR TITLE
apps/system/init: Lower task manager priority

### DIFF
--- a/apps/system/init/init.c
+++ b/apps/system/init/init.c
@@ -170,7 +170,7 @@ int preapp_start(int argc, char *argv[])
 
 #ifdef CONFIG_TASK_MANAGER
 #define TASKMGR_STACK_SIZE 2048
-#define TASKMGR_PRIORITY 200
+#define TASKMGR_PRIORITY 180
 	ret = task_create("task_manager", TASKMGR_PRIORITY, TASKMGR_STACK_SIZE, task_manager, (FAR char *const *)NULL);
 	if (ret < 0) {
 		printf("Failed to create Task Manager\n");


### PR DESCRIPTION
Task Manager is started through task_create() during preapp startup. When CONFIG_BINARY_MANAGER and CONFIG_APP_BINARY_SEPARATION are enabled, task_create() rejects priorities in the Binary Manager reserved range and returns EPERM.

The reserved range is BM_PRIORITY_MIN through BM_PRIORITY_MAX, which defaults to 200 through 205 in binary_manager_internal.h. TASKMGR_PRIORITY was 200, so it overlapped that reserved Binary Manager range and could prevent task_manager from being created in app binary separation builds.

Move TASKMGR_PRIORITY to 180 so task_manager starts outside the Binary Manager priority range while keeping the existing stack size and task_create() flow unchanged.