### PR TITLE
[DO NOT MERGE] os/kernel/pthread: Add global waiter list for condition variable tracking

### DIFF
--- a/lib/libc/pthread/pthread_conddestroy.c
+++ b/lib/libc/pthread/pthread_conddestroy.c
@@ -91,6 +91,12 @@ int pthread_cond_destroy(FAR pthread_cond_t *cond)
 		ret = EINVAL;
 	}
 
+	/* NOTE: Destroying a condition variable while threads are waiting
+	 * results in undefined behavior (POSIX). The internal waiter tracking
+	 * entry may not be cleaned up in this case, causing a memory leak.
+	 * Applications must ensure no threads are waiting before destroying.
+	 */
+
 	/* Destroy the semaphore contained in the structure */
 
 	else if (sem_destroy((sem_t *)&cond->sem) != OK) {

--- a/os/kernel/pthread/Make.defs
+++ b/os/kernel/pthread/Make.defs
@@ -58,6 +58,7 @@ CSRCS += pthread_getschedparam.c pthread_setschedparam.c
 CSRCS += pthread_mutexinit.c pthread_mutexdestroy.c
 CSRCS += pthread_mutexlock.c pthread_mutextrylock.c pthread_mutexunlock.c
 CSRCS += pthread_condwait.c pthread_condsignal.c pthread_condbroadcast.c
+CSRCS += pthread_cond_queue.c
 CSRCS += pthread_cancel.c
 ifneq ($(CONFIG_NPTHREAD_KEYS),0)
 CSRCS += pthread_keycreate.c pthread_setspecific.c pthread_getspecific.c

--- a/os/kernel/pthread/pthread.h
+++ b/os/kernel/pthread/pthread.h
@@ -94,6 +94,16 @@ struct join_s {
 	pthread_addr_t exit_value;	/* Returned data */
 };
 
+/* Condition variable waiter tracking - kernel internal
+ * This structure is used to track waiter counts per condition variable
+ * without modifying the public pthread_cond_s structure.
+ */
+struct cond_waiter_entry {
+	FAR struct cond_waiter_entry *next;	/* Next entry in list */
+	FAR pthread_cond_t *cond;			/* Key: condition variable pointer */
+	uint16_t waiters;					/* Value: count of waiting threads */
+};
+
 /****************************************************************************
  * Public Variables
  ****************************************************************************/
@@ -154,6 +164,11 @@ int pthread_mutexattr_verifytype(int type);
 #if defined(CONFIG_NPTHREAD_KEYS) && CONFIG_NPTHREAD_KEYS > 0
 void pthread_key_destroy(struct pthread_tcb_s *tcb);
 #endif
+
+/* Condition variable waiter tracking functions - kernel internal */
+int cond_waiter_increment(FAR pthread_cond_t *cond, FAR struct cond_waiter_entry *pre_alloc);
+FAR struct cond_waiter_entry *cond_waiter_decrement(FAR pthread_cond_t *cond);
+uint16_t cond_waiter_get_count(FAR pthread_cond_t *cond);
 
 #undef EXTERN
 #ifdef __cplusplus

--- a/os/kernel/pthread/pthread_cond_queue.c
+++ b/os/kernel/pthread/pthread_cond_queue.c
@@ -1,0 +1,236 @@
+/****************************************************************************
+ *
+ * Copyright 2016 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+/****************************************************************************
+ * kernel/pthread/pthread_cond_queue.c
+ *
+ *   Condition variable waiter tracking using linked list.
+ *   This is a kernel-internal implementation to track waiter counts
+ *   per condition variable without modifying public structures.
+ *
+ *   Memory allocation (kmm_malloc) and deallocation (kmm_free) are
+ *   the responsibility of the caller, and must NOT be performed while
+ *   a critical section is held. The caller pre-allocates entries before
+ *   entering a critical section and frees them after leaving it.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <tinyara/config.h>
+
+#include <pthread.h>
+#include <errno.h>
+
+#include <tinyara/irq.h>
+
+#include "pthread/pthread.h"
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+/* Global list head for condition variable waiter tracking
+ *
+ * NOTE: Entries are auto-removed when waiter count reaches 0.
+ * If pthread_cond_destroy() is called while threads are waiting,
+ * the entry remains in the list (memory leak). This is acceptable
+ * because POSIX defines this as undefined behavior.
+ */
+static struct cond_waiter_entry *g_cond_waiterlist_head = NULL;
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: cond_waiter_find
+ *
+ * Description:
+ *   Find an entry in the list by condition variable pointer.
+ *   Must be called within critical section.
+ *
+ * Parameters:
+ *   cond - Pointer to condition variable
+ *
+ * Return:
+ *   Pointer to entry if found, NULL otherwise
+ *
+ ****************************************************************************/
+
+static struct cond_waiter_entry *cond_waiter_find(FAR pthread_cond_t *cond)
+{
+	struct cond_waiter_entry *entry = g_cond_waiterlist_head;
+
+	while (entry != NULL) {
+		if (entry->cond == cond) {
+			return entry;
+		}
+		entry = entry->next;
+	}
+
+	return NULL;
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: cond_waiter_increment
+ *
+ * Description:
+ *   Increment the waiter count for a condition variable.
+ *   If an entry already exists, increments its count. If not, initializes
+ *   and links the caller-provided pre_alloc entry.
+ *
+ *   The caller must pre-allocate the entry BEFORE entering a critical
+ *   section, since kmm_malloc() must not be called with interrupts
+ *   disabled. This function only performs list operations (no allocation).
+ *
+ * Parameters:
+ *   cond      - Pointer to condition variable
+ *   pre_alloc - Pre-allocated entry (allocated outside critical section)
+ *
+ * Return:
+ *   0 if pre_alloc was consumed (linked into the list)
+ *   1 if pre_alloc was NOT consumed (existing entry found, caller must free)
+ *
+ ****************************************************************************/
+
+int cond_waiter_increment(FAR pthread_cond_t *cond, FAR struct cond_waiter_entry *pre_alloc)
+{
+	irqstate_t flags;
+	struct cond_waiter_entry *entry;
+
+	flags = enter_critical_section();
+
+	/* Find existing entry */
+	entry = cond_waiter_find(cond);
+
+	if (entry != NULL) {
+		/* Entry already exists — increment and discard pre_alloc */
+		entry->waiters++;
+		leave_critical_section(flags);
+		return 1;	/* pre_alloc NOT consumed */
+	}
+
+	/* No existing entry — initialize and link the pre-allocated node */
+	pre_alloc->cond = cond;
+	pre_alloc->waiters = 1;
+	pre_alloc->next = g_cond_waiterlist_head;
+	g_cond_waiterlist_head = pre_alloc;
+
+	leave_critical_section(flags);
+	return 0;	/* pre_alloc consumed */
+}
+
+/****************************************************************************
+ * Name: cond_waiter_decrement
+ *
+ * Description:
+ *   Decrement the waiter count for a condition variable.
+ *   Auto-unlinks entry when waiter count reaches 0 and returns it
+ *   to the caller for freeing outside the critical section.
+ *
+ *   The caller must free the returned entry AFTER leaving the critical
+ *   section, since kmm_free() must not be called with interrupts disabled.
+ *   This function only performs list operations (no deallocation).
+ *
+ * Parameters:
+ *   cond - Pointer to condition variable
+ *
+ * Return:
+ *   Pointer to unlinked entry if waiter count reached 0 (caller must free),
+ *   NULL otherwise
+ *
+ ****************************************************************************/
+
+FAR struct cond_waiter_entry *cond_waiter_decrement(FAR pthread_cond_t *cond)
+{
+	irqstate_t flags;
+	struct cond_waiter_entry *entry;
+	struct cond_waiter_entry *prev = NULL;
+	struct cond_waiter_entry *to_free = NULL;
+
+	flags = enter_critical_section();
+
+	/* Find entry AND track previous pointer for removal */
+	entry = g_cond_waiterlist_head;
+	while (entry != NULL) {
+		if (entry->cond == cond) {
+			break;
+		}
+		prev = entry;
+		entry = entry->next;
+	}
+
+	if (entry != NULL && entry->waiters > 0) {
+		entry->waiters--;
+
+		/* Auto-remove when no more waiters */
+		if (entry->waiters == 0) {
+			if (prev == NULL) {
+				/* Entry is at head */
+				g_cond_waiterlist_head = entry->next;
+			} else {
+				/* Entry is in middle or tail */
+				prev->next = entry->next;
+			}
+			to_free = entry;
+		}
+	}
+
+	leave_critical_section(flags);
+	return to_free;
+}
+
+/****************************************************************************
+ * Name: cond_waiter_get_count
+ *
+ * Description:
+ *   Get the current waiter count for a condition variable.
+ *
+ * Parameters:
+ *   cond - Pointer to condition variable
+ *
+ * Return:
+ *   Number of waiters (0 if entry doesn't exist)
+ *
+ ****************************************************************************/
+
+uint16_t cond_waiter_get_count(FAR pthread_cond_t *cond)
+{
+	irqstate_t flags;
+	struct cond_waiter_entry *entry;
+	uint16_t count = 0;
+
+	flags = enter_critical_section();
+
+	/* Find existing entry */
+	entry = cond_waiter_find(cond);
+
+	if (entry != NULL) {
+		count = entry->waiters;
+	}
+
+	leave_critical_section(flags);
+
+	return count;
+}

--- a/os/kernel/pthread/pthread_condbroadcast.c
+++ b/os/kernel/pthread/pthread_condbroadcast.c
@@ -107,7 +107,7 @@
 int pthread_cond_broadcast(FAR pthread_cond_t *cond)
 {
 	int ret = OK;
-	int sval;
+	uint16_t waiter_count;
 
 	svdbg("cond=0x%p\n", cond);
 
@@ -115,37 +115,25 @@ int pthread_cond_broadcast(FAR pthread_cond_t *cond)
 		ret = EINVAL;
 	} else {
 		/* Disable pre-emption until all of the waiting threads have been
-		 * restarted. This is necessary to assure that the sval behaves as
-		 * expected in the following while loop
+		 * restarted.
 		 */
 
 		sched_lock();
+		irqstate_t flags = enter_critical_section();
 
-		/* Get the current value of the semaphore */
+		/* Get waiter count once and store locally */
+		waiter_count = cond_waiter_get_count(cond);
 
-		if (sem_getvalue((sem_t *)&cond->sem, &sval) != OK) {
-			ret = EINVAL;
-		} else {
-			/* Loop until all of the waiting threads have been restarted. */
-
-			while (sval < 0) {
-				/* If the value is less than zero (meaning that one or more
-				 * thread is waiting), then post the condition semaphore.
-				 * Only the highest priority waiting thread will get to execute
-				 */
-
-				ret = pthread_sem_give((sem_t *)&cond->sem);
-
-				/* Increment the semaphore count (as was done by the
-				 * above post).
-				 */
-
-				sval++;
+		/* Loop to wake up all waiting threads */
+		while (waiter_count > 0) {
+			ret = pthread_sem_give((sem_t *)&cond->sem);
+			waiter_count--;
+			if (ret != OK) {
+				break;
 			}
 		}
 
-		/* Now we can let the restarted threads run */
-
+		leave_critical_section(flags);
 		sched_unlock();
 	}
 

--- a/os/kernel/pthread/pthread_condsignal.c
+++ b/os/kernel/pthread/pthread_condsignal.c
@@ -106,40 +106,21 @@
 int pthread_cond_signal(FAR pthread_cond_t *cond)
 {
 	int ret = OK;
-	int sval;
 
 	svdbg("cond=0x%p\n", cond);
 
 	if (!cond) {
 		ret = EINVAL;
 	} else {
-		/* Get the current value of the semaphore */
+		irqstate_t flags = enter_critical_section();
 
-		if (sem_getvalue((sem_t *)&cond->sem, &sval) != OK) {
-			ret = EINVAL;
+		/* Check if there are any waiters using our queue */
+		if (cond_waiter_get_count(cond) > 0) {
+			svdbg("Signalling...\n");
+			ret = pthread_sem_give((sem_t *)&cond->sem);
 		}
 
-		/* If the value is less than zero (meaning that one or more
-		 * thread is waiting), then post the condition semaphore.
-		 * Only the highest priority waiting thread will get to execute
-		 */
-
-		else {
-			/* One of my objectives in this design was to make pthread_cond_signal
-			 * usable from interrupt handlers.  However, from interrupt handlers,
-			 * you cannot take the associated mutex before signaling the condition.
-			 * As a result, I think that there could be a race condition with
-			 * the following logic which assumes that the if sval < 0 then the
-			 * thread is waiting.  Without the mutex, there is no atomic, protected
-			 * operation that will guarantee this to be so.
-			 */
-
-			svdbg("sval=%d\n", sval);
-			if (sval < 0) {
-				svdbg("Signalling...\n");
-				ret = pthread_sem_give((sem_t *)&cond->sem);
-			}
-		}
+		leave_critical_section(flags);
 	}
 
 	svdbg("Returning %d\n", ret);

--- a/os/kernel/pthread/pthread_condtimedwait.c
+++ b/os/kernel/pthread/pthread_condtimedwait.c
@@ -69,6 +69,7 @@
 
 #include <tinyara/cancelpt.h>
 #include <tinyara/wdog.h>
+#include <tinyara/mm/mm.h>
 
 #include "sched/sched.h"
 #include "pthread/pthread.h"
@@ -202,6 +203,9 @@ int pthread_cond_timedwait(FAR pthread_cond_t *cond, FAR pthread_mutex_t *mutex,
 	uint16_t oldstate;
 	int ret = OK;
 	int status;
+	int incr_result = 1;	/* 1 = pre_alloc NOT consumed (default for error paths) */
+	struct cond_waiter_entry *pre_alloc = NULL;
+	struct cond_waiter_entry *to_free = NULL;
 
 	svdbg("cond=0x%p mutex=0x%p abstime=0x%p\n", cond, mutex, abstime);
 
@@ -239,108 +243,146 @@ int pthread_cond_timedwait(FAR pthread_cond_t *cond, FAR pthread_mutex_t *mutex,
 		} else {
 			svdbg("Give up mutex...\n");
 
-			/* We must disable pre-emption and interrupts here so that
-			 * the time stays valid until the wait begins.   This adds
-			 * complexity because we assure that interrupts and
-			 * pre-emption are re-enabled correctly.
+			/* Pre-allocate waiter entry before entering critical section.
+			 * kmm_malloc() may take the heap semaphore, which must not
+			 * be called with interrupts disabled.
 			 */
 
-			sched_lock();
-			int_state = enter_critical_section();
-
-			/* Convert the timespec to clock ticks.  We must disable pre-emption
-			 * here so that this time stays valid until the wait begins.
-			 */
-
-			ret = clock_abstime2ticks(CLOCK_REALTIME, abstime, &ticks);
-			if (ret) {
-				/* Restore interrupts  (pre-emption will be enabled when
-				 * we fall through the if/then/else)
-				 */
-
-				leave_critical_section(int_state);
+			pre_alloc = (struct cond_waiter_entry *)kmm_malloc(sizeof(struct cond_waiter_entry));
+			if (pre_alloc == NULL) {
+				sdbg("Failed to allocate waiter entry for cond %p\n", cond);
+				DEBUGASSERT(0);
+				ret = ENOMEM;
 			} else {
-				/* Check the absolute time to wait.  If it is now or in the past, then
-				 * just return with the timedout condition.
+				/* We must disable pre-emption and interrupts here so that
+				 * the time stays valid until the wait begins.   This adds
+				 * complexity because we assure that interrupts and
+				 * pre-emption are re-enabled correctly.
 				 */
 
-				if (ticks <= 0) {
-					/* Restore interrupts and indicate that we have already timed out.
-					 * (pre-emption will be enabled when we fall through the
-					 * if/then/else
+				sched_lock();
+				int_state = enter_critical_section();
+
+				/* Convert the timespec to clock ticks.  We must disable pre-emption
+				 * here so that this time stays valid until the wait begins.
+				 */
+
+				ret = clock_abstime2ticks(CLOCK_REALTIME, abstime, &ticks);
+				if (ret) {
+					/* Restore interrupts and pre-emption, free pre_alloc.
+					 * kmm_free() must not be called with interrupts disabled.
 					 */
 
 					leave_critical_section(int_state);
-					ret = ETIMEDOUT;
+					sched_unlock();
+					kmm_free(pre_alloc);
+					pre_alloc = NULL;
 				} else {
-					/* Give up the mutex */
+					/* Check the absolute time to wait.  If it is now or in the past, then
+					 * just return with the timedout condition.
+					 */
 
-					mutex->pid = -1;
-					ret = pthread_mutex_give(mutex);
-					if (ret != 0) {
-						/* Restore interrupts  (pre-emption will be enabled when
-						 * we fall through the if/then/else)
+					if (ticks <= 0) {
+						/* Restore interrupts and indicate that we have already timed out.
+						 * (pre-emption will be enabled when we fall through the
+						 * if/then/else
 						 */
 
 						leave_critical_section(int_state);
+						ret = ETIMEDOUT;
 					} else {
-						/* Start the watchdog */
+						/* Give up the mutex */
 
-						wd_start(rtcb->waitdog, ticks, (wdentry_t)pthread_condtimedout, 2, (uint32_t)mypid, (uint32_t)SIGCONDTIMEDOUT);
-
-						/* Take the condition semaphore.  Do not restore interrupts
-						 * until we return from the wait.  This is necessary to
-						 * make sure that the watchdog timer and the condition wait
-						 * are started atomically.
-						 */
-
-						status = sem_wait((sem_t *)&cond->sem);
-
-						/* Did we get the condition semaphore. */
-
-						if (status != OK) {
-							/* NO.. Handle the special case where the semaphore wait was
-							 * awakened by the receipt of a signal -- presumably the
-							 * signal posted by pthread_condtimedout().
+						mutex->pid = -1;
+						ret = pthread_mutex_give(mutex);
+						if (ret != 0) {
+							/* Restore interrupts  (pre-emption will be enabled when
+							 * we fall through the if/then/else)
 							 */
 
-							if (get_errno() == EINTR) {
-								sdbg("Timedout!\n");
-								ret = ETIMEDOUT;
-							} else {
-								ret = EINVAL;
+							leave_critical_section(int_state);
+						} else {
+							/* Start the watchdog */
+
+							wd_start(rtcb->waitdog, ticks, (wdentry_t)pthread_condtimedout, 2, (uint32_t)mypid, (uint32_t)SIGCONDTIMEDOUT);
+
+							/* Increment waiter count using queue.
+							 * Returns 0 if pre_alloc was consumed, 1 if not.
+							 */
+							incr_result = cond_waiter_increment(cond, pre_alloc);
+
+							/* Take the condition semaphore.  Do not restore interrupts
+							 * until we return from the wait.  This is necessary to
+							 * make sure that the watchdog timer and the condition wait
+							 * are started atomically.
+							 */
+
+							status = sem_wait((sem_t *)&cond->sem);
+
+							/* Decrement waiter count using queue.
+							 * Returns unlinked entry if waiter count reached 0.
+							 */
+							to_free = cond_waiter_decrement(cond);
+
+							/* Did we get the condition semaphore. */
+
+							if (status != OK) {
+								/* NO.. Handle the special case where the semaphore wait was
+								 * awakened by the receipt of a signal -- presumably the
+								 * signal posted by pthread_condtimedout().
+								 */
+
+								if (get_errno() == EINTR) {
+									sdbg("Timedout!\n");
+									ret = ETIMEDOUT;
+								} else {
+									ret = EINVAL;
+								}
+							}
+
+							/* The interrupts stay disabled until after we sample the errno.
+							 * This is because when debug is enabled and the console is used
+							 * for debug output, then the errno can be altered by interrupt
+							 * handling! (bad)
+							 */
+
+							leave_critical_section(int_state);
+
+							/* Reacquire the mutex (retaining the ret). */
+
+							svdbg("Re-locking...\n");
+
+							oldstate = pthread_disable_cancel();
+							status = pthread_mutex_take(mutex);
+							pthread_enable_cancel(oldstate);
+
+							if (status == OK) {
+								mutex->pid = mypid;
+							} else if (ret == 0) {
+								ret = status;
 							}
 						}
-
-						/* The interrupts stay disabled until after we sample the errno.
-						 * This is because when debug is enabled and the console is used
-						 * for debug output, then the errno can be altered by interrupt
-						 * handling! (bad)
-						 */
-
-						leave_critical_section(int_state);
 					}
 
-					/* Reacquire the mutex (retaining the ret). */
+					/* Re-enable pre-emption (It is expected that interrupts
+					 * have already been re-enabled in the above logic)
+					 */
 
-					svdbg("Re-locking...\n");
+					sched_unlock();
 
-					oldstate = pthread_disable_cancel();
-					status = pthread_mutex_take(mutex);
-					pthread_enable_cancel(oldstate);
-
-					if (status == OK) {
-						mutex->pid = mypid;
-					} else if (ret == 0) {
-						ret = status;
+					/* Free memory outside critical section.
+					 * kmm_free() may take the heap semaphore, which must
+					 * not be called with interrupts disabled.
+					 */
+					if (incr_result == 1) {
+						/* pre_alloc was NOT consumed by increment - free it */
+						kmm_free(pre_alloc);
+					}
+					if (to_free != NULL) {
+						/* Entry was unlinked by decrement - free it */
+						kmm_free(to_free);
 					}
 				}
-
-				/* Re-enable pre-emption (It is expected that interrupts
-				 * have already been re-enabled in the above logic)
-				 */
-
-				sched_unlock();
 			}
 
 			/* We no longer need the watchdog */

--- a/os/kernel/pthread/pthread_condwait.c
+++ b/os/kernel/pthread/pthread_condwait.c
@@ -64,6 +64,7 @@
 #include <debug.h>
 
 #include <tinyara/cancelpt.h>
+#include <tinyara/mm/mm.h>
 #include "pthread/pthread.h"
 
 /****************************************************************************
@@ -90,6 +91,9 @@ int pthread_cond_wait(FAR pthread_cond_t *cond, FAR pthread_mutex_t *mutex)
 {
 	int status;
 	int ret;
+	int incr_result;
+	struct cond_waiter_entry *pre_alloc = NULL;
+	struct cond_waiter_entry *to_free = NULL;
 
 	svdbg("cond=0x%p mutex=0x%p\n", cond, mutex);
 
@@ -107,49 +111,84 @@ int pthread_cond_wait(FAR pthread_cond_t *cond, FAR pthread_mutex_t *mutex)
 	else if (mutex->pid != (int)getpid()) {
 		ret = EPERM;
 	} else {
+		irqstate_t int_state;
 		uint16_t oldstate;
 
-		/* Give up the mutex */
-
-		svdbg("Give up mutex / take cond\n");
-
-		sched_lock();
-		mutex->pid = -1;
-		ret = pthread_mutex_give(mutex);
-
-		/* Take the semaphore */
-
-		status = pthread_sem_take((FAR sem_t *)&cond->sem);
-		if (ret == OK) {
-			/* Report the first failure that occurs */
-
-			ret = status;
-		}
-
-		sched_unlock();
-
-		/* Reacquire the mutex
-		 * When cancellation points are enabled, we need to
-		 * hold the mutex when the pthread is canceled and
-		 * cleanup handlers, if any, are entered.
+		/* Pre-allocate waiter entry before entering critical section.
+		 * kmm_malloc() may take the heap semaphore, which must not
+		 * be called with interrupts disabled.
 		 */
 
-		svdbg("Reacquire mutex...\n");
+		pre_alloc = (struct cond_waiter_entry *)kmm_malloc(sizeof(struct cond_waiter_entry));
+		if (pre_alloc == NULL) {
+			sdbg("Failed to allocate waiter entry for cond %p\n", cond);
+			DEBUGASSERT(0);
+			ret = ENOMEM;
+		} else {
+			sched_lock();
+			int_state = enter_critical_section();
 
-		oldstate = pthread_disable_cancel();
-		status = pthread_mutex_take(mutex);
-		pthread_enable_cancel(oldstate);
+			/* Increment waiter count using queue.
+			 * Returns 0 if pre_alloc was consumed, 1 if not.
+			 */
+			incr_result = cond_waiter_increment(cond, pre_alloc);
 
-		if (ret == OK) {
-			/* Report the first failure that occurs */
+			/* Give up the mutex */
 
-			ret = status;
-		}
-		
-		/* Was all of the above successful? */
+			svdbg("Give up mutex / take cond\n");
 
-		if (ret == OK) {
-			mutex->pid = getpid();
+			mutex->pid = -1;
+			ret = pthread_mutex_give(mutex);
+
+			/* Take the semaphore */
+
+			status = pthread_sem_take((FAR sem_t *)&cond->sem);
+			if (ret == OK) {
+				/* Report the first failure that occurs */
+
+				ret = status;
+			}
+
+			/* Decrement waiter count using queue.
+			 * Returns unlinked entry if waiter count reached 0.
+			 */
+			to_free = cond_waiter_decrement(cond);
+
+			leave_critical_section(int_state);
+			sched_unlock();
+
+			/* Free memory outside critical section.
+			 * kmm_free() may take the heap semaphore, which must
+			 * not be called with interrupts disabled.
+			 */
+			if (incr_result == 1) {
+				/* pre_alloc was NOT consumed by increment - free it */
+				kmm_free(pre_alloc);
+			}
+			if (to_free != NULL) {
+				/* Entry was unlinked by decrement - free it */
+				kmm_free(to_free);
+			}
+
+			/* Reacquire the mutex
+			 * POSIX requires the mutex to be held on return from
+			 * pthread_cond_wait(), even if an error occurred.
+			 * When cancellation points are enabled, we need to
+			 * hold the mutex when the pthread is canceled and
+			 * cleanup handlers, if any, are entered.
+			 */
+
+			svdbg("Reacquire mutex...\n");
+
+			oldstate = pthread_disable_cancel();
+			status = pthread_mutex_take(mutex);
+			pthread_enable_cancel(oldstate);
+
+			if (status == OK) {
+				mutex->pid = getpid();
+			} else if (ret == OK) {
+				ret = status;
+			}
 		}
 	}
 


### PR DESCRIPTION
…n variable tracking

pthread_cond_signal() and pthread_cond_broadcast() previously used sem_getvalue() to determine if any threads are waiting on a condition variable. This approach has a race condition: between checking the semaphore value and posting, a waiting thread could time out or be canceled, causing a spurious semaphore post to a thread that is no longer waiting.

Fix by adding a kernel-internal global linked list that tracks waiter counts per condition variable:

- Add struct cond_waiter_entry with cond pointer (key) and waiters count (value), linked via a global singly-linked list
- Add pthread_cond_queue.c with three functions:
  - cond_waiter_increment(): increment count, create entry if needed
  - cond_waiter_decrement(): decrement count, auto-remove entry at 0
  - cond_waiter_get_count(): read current waiter count
- All operations protected by enter_critical_section/leave_critical_section
- Entries are auto-removed when waiter count reaches 0 to prevent memory leaks

Modify pthread_cond_signal() and pthread_cond_broadcast() to use cond_waiter_get_count() instead of sem_getvalue(), eliminating the race condition.

Modify pthread_cond_wait() and pthread_cond_timedwait() to call cond_waiter_increment() before waiting and cond_waiter_decrement() after waking up (both normal and timeout paths).