### PR TITLE
os/arch/armino: Make the NMI interrupt context run in RAM

### DIFF
--- a/os/arch/arm/src/armino/armino_watchdog_lowerhalf.c
+++ b/os/arch/arm/src/armino/armino_watchdog_lowerhalf.c
@@ -428,8 +428,8 @@ static void armino_wdg_arm_hw_feed_window(FAR struct armino_wdg_lowerhalf_s *pri
  *   Always returns OK.
  *
  ****************************************************************************/
-
-static int armino_nmi_interrupt(int irq, void *context, FAR void *arg)
+static int __attribute__((section(".iram"), noinline))
+armino_nmi_interrupt(int irq, void *context, FAR void *arg)
 {
 	struct armino_wdg_lowerhalf_s *priv = (struct armino_wdg_lowerhalf_s *)arg;
 


### PR DESCRIPTION
Considering a scenario where  requires a long write to flash, the NMI interrupt callback might not be invoked if it's also in flash. Therefore, it's moved to RAM, allowing both to run in parallel.