### PR TITLE
os/board/rtl8730e : Fix svace issues in Bluetooth service code

### DIFF
--- a/os/board/rtl8730e/src/component/bluetooth/example/ble_central/ble_tizenrt_client.c
+++ b/os/board/rtl8730e/src/component/bluetooth/example/ble_central/ble_tizenrt_client.c
@@ -425,7 +425,7 @@ trble_result_e rtw_ble_client_read_connected_info(trble_conn_handle conn_handle,
     }
 
 	rtk_bt_le_conn_info_t conn_info;
-	uint8_t bond_size;
+	uint8_t bond_size = 0;
 	bool is_bonded = false;
 	uint16_t mtu_size = 0;
 	
@@ -490,7 +490,7 @@ trble_result_e rtw_ble_client_delete_bond(trble_addr* addr)
         return TRBLE_INVALID_ARGS;
     }
 	
-	uint16_t device_count;
+	uint16_t device_count = 0;
     trble_result_e ret = TRBLE_FAIL;
     rtk_bt_le_addr_t del_addr;
 	bool bond_addr_found = false;

--- a/os/board/rtl8730e/src/component/bluetooth/example/ble_peripheral/ble_tizenrt_service.c
+++ b/os/board/rtl8730e/src/component/bluetooth/example/ble_peripheral/ble_tizenrt_service.c
@@ -90,6 +90,11 @@ T_APP_RESULT ble_tizenrt_srv_callback(uint8_t event, void *p_data)
                 dbg("[APP] BLE tizenrt indicate cccd, indicate bit disable\r\n");
             }
 
+			if (p_cha_info == NULL) {
+				dbg("[APP] p_cha_info is null\r\n");
+				break;
+			}
+
 			if (p_cha_info->cb) 
 			{
 				p_cha_info->cb(TRBLE_ATTR_CB_CCCD, p_cccd_ind->conn_handle, p_cha_info->abs_handle, p_cha_info->arg, p_cccd_ind->value, 0);

--- a/os/board/rtl8730e/src/component/bluetooth/example/ble_scatternet/ble_tizenrt_combo.c
+++ b/os/board/rtl8730e/src/component/bluetooth/example/ble_scatternet/ble_tizenrt_combo.c
@@ -132,7 +132,7 @@ trble_result_e rtw_ble_combo_set_server_config(trble_server_init_config* init_se
 		return TRBLE_FAIL;
 	}
 
-	if (init_server != NULL || init_server->profile != NULL || init_server->profile_count != 0) {	/* There is valid profile*/
+	if (init_server != NULL && init_server->profile != NULL && init_server->profile_count != 0) {	/* There is valid profile*/
 		server_profile_count = init_server->profile_count;
 		for (int i = 0; i < init_server->profile_count; i++) {
 			if (init_server->profile[i].type == TRBLE_GATT_CHARACT) {
@@ -150,6 +150,7 @@ trble_result_e rtw_ble_combo_set_server_config(trble_server_init_config* init_se
 
 		ble_tizenrt_srv_add();	/* Add service */
 	}
+    return TRBLE_SUCCESS;
 }
 
 #endif /* TRBLE_COMBO_C_ */

--- a/os/board/rtl8730e/src/component/bluetooth/example/ble_scatternet/scatternet.c
+++ b/os/board/rtl8730e/src/component/bluetooth/example/ble_scatternet/scatternet.c
@@ -317,7 +317,7 @@ static rtk_bt_evt_cb_ret_t ble_tizenrt_scatternet_gap_app_callback(uint8_t evt_c
 #ifdef CONFIG_PM
             /* Register PM_BLE_DOMAIN and Perform 10 minutes timedsuspend */
             domain = pm_domain_register("BLE");
-            if (domain < 0) {
+            if (domain == NULL) {
                 pmdbg("Unable to register BLE DOMAIN\n");
             } else if (pm_timedsuspend(domain, 600000) != 0) {
                 pmdbg("Unable to perform PM suspend for 10 minutes for ble domain\n");


### PR DESCRIPTION
- Added a null check for p_cha_info in ble_tizenrt_srv_callback to prevent potential dereferencing of a null pointer.
- Updated the condition in rtw_ble_combo_set_server_config to use logical AND instead of OR for validating the server profile.
- Corrected the domain check in ble_tizenrt_scatternet_gap_app_callback to compare against NULL instead of a negative value.
- The above modifications resolve the following 8 defects.
```
1. WID:50385187 After having been assigned to NULL value at ble_tizenrt_service.c:66, pointer 'p_cha_info' is dereferenced at ble_tizenrt_service.c:93.
/root/dev/os/board/rtl8730e/src/component/bluetooth/example/ble_peripheral/ble_tizenrt_service.c line 93
2. WID:50385089 Missed return statement.
/root/dev/os/board/rtl8730e/src/component/bluetooth/example/ble_scatternet/ble_tizenrt_combo.c line 153
3. WID:50385108 After having been compared to NULL value at ble_tizenrt_combo.c:135, pointer 'init_server' is dereferenced at ble_tizenrt_combo.c:136.
/root/dev/os/board/rtl8730e/src/component/bluetooth/example/ble_scatternet/ble_tizenrt_combo.c line 136
4. WID:50385110 After having been compared to NULL value at ble_tizenrt_combo.c:135, pointer 'init_server->profile' is dereferenced at ble_tizenrt_combo.c:138.
/root/dev/os/board/rtl8730e/src/component/bluetooth/example/ble_scatternet/ble_tizenrt_combo.c line 138
5. WID:50385121 Pointer 'init_server' that can have only NULL value (checked at ble_tizenrt_combo.c:135), is dereferenced at ble_tizenrt_combo.c:135.
/root/dev/os/board/rtl8730e/src/component/bluetooth/example/ble_scatternet/ble_tizenrt_combo.c line 135
6. WID:50385175 This statement in the source code might be unreachable during program execution.
/root/dev/os/board/rtl8730e/src/component/bluetooth/example/ble_scatternet/scatternet.c line 321
7. UNINIT.LOCAL_VAR.EX: Uninitialized data is read from local variable 'bond_size' at ble_tizenrt_client.c:450.
    [access] access at /root/dev/os/board/rtl8730e/src/component/bluetooth/example/ble_central/ble_tizenrt_client.c:450
    [info] Variable 'bond_size' is allocated at /root/dev/os/board/rtl8730e/src/component/bluetooth/example/ble_central/ble_tizenrt_client.c:428
8. UNINIT.LOCAL_VAR.EX: Uninitialized data is read from local variable 'device_count' at ble_tizenrt_client.c:502.
    [access] access at /root/dev/os/board/rtl8730e/src/component/bluetooth/example/ble_central/ble_tizenrt_client.c:502
    [info] Variable 'device_count' is allocated at /root/dev/os/board/rtl8730e/src/component/bluetooth/example/ble_central/ble_tizenrt_client.c:493
```