### PR TITLE
os/arch/arm/src/armino: Fix wrong macro condition check

### DIFF
--- a/os/arch/arm/src/armino/armino_flash.c
+++ b/os/arch/arm/src/armino/armino_flash.c
@@ -376,7 +376,7 @@ FAR struct mtd_dev_s *up_flashinitialize(void)
 ssize_t up_read_decrypted_flash(size_t addr, void *buf, size_t length)
 {
 	// printf("func :%s, line :%d, addr :%x, length :%d\n", __func__, __LINE__, addr, length);
-#ifndef CONFIG_SPE
+#if (!CONFIG_SPE)
 	if (bk_addr_is_kernel(addr)) {
 		bk_security_flash_read_bytes(addr, (uint8_t *)buf, length);
 		SCB_CleanInvalidateDCache();


### PR DESCRIPTION
Fix wrong macro condition check in up_read_decrypted_flash. `CONFIG_SPE` value can be 0, 1, and undefined.
`#if (!CONFIG_SPE)` is correct.
`#ifndef CONFIG_SPE` is works differently when `#define CONFIG_SPE 0`.

| CONFIG_SPE | `#if (!CONFIG_SPE)` | `#ifndef CONFIG_SPE` |
|---|---|---|
| `#define CONFIG_SPE 0` | true | false |
| `#define CONFIG_SPE 1` | false | false |
| Not defined | true (undefined → 0 treated) | true |