### PR TITLE
os/board/bk7239n: Fix WiFi scan memory leak and error handling

### DIFF
--- a/os/board/bk7239n/src/bsp_adapter/src/net/bk_netmgr.c
+++ b/os/board/bk7239n/src/bsp_adapter/src/net/bk_netmgr.c
@@ -785,7 +785,7 @@ scan_res_finish:
 
 static int bk_trwlan_scan_start(wifi_scan_config_t *scan_config)
 {
-	int err;
+	int err = BK_OK;
 	wifi_scan_result_t scan_result = {0};
 
 	// Release previous cached scan result before starting new scan
@@ -855,8 +855,9 @@ static int bk_trwlan_scan_start(wifi_scan_config_t *scan_config)
 	bk_trwifi_wlan_scan_sema = NULL;
 	return 0;
 error:
-	if(bk_trwifi_wlan_scan_sema != NULL)
+	if (bk_trwifi_wlan_scan_sema != NULL) {
 		rtos_deinit_semaphore(&bk_trwifi_wlan_scan_sema);
+	}
 	bk_trwifi_wlan_scan_sema = NULL;
 	return -1;
 }

--- a/os/board/bk7239n/src/components/bk_wifi/src/wifi_v2.c
+++ b/os/board/bk7239n/src/components/bk_wifi/src/wifi_v2.c
@@ -2951,7 +2951,7 @@ bk_err_t bk_wifi_scan_get_result(wifi_scan_result_t *scan_result)
 
 _free_and_exit:
 	os_free(ap_list.ApList);
-	return BK_OK;
+	return ret;
 }
 
 static void wifi_scan_dump_ap(const wifi_scan_ap_info_t *ap)


### PR DESCRIPTION
Calling bk_wifi_scan_free_result after scan result to free memory. Fix return error case.