### PR TITLE
os/net/lwip: fix svace issues network

### DIFF
--- a/os/net/lwip/src/api/sockets.c
+++ b/os/net/lwip/src/api/sockets.c
@@ -499,8 +499,8 @@ static int alloc_socket(struct netconn *newconn, int accepted)
 			newconn->group = (void *)tcb->group;
 			sock->conn = newconn;
 			sock->sendevent = (NETCONNTYPE_GROUP(newconn->type) == NETCONN_TCP ? (accepted != 0) : 1);
-			sock->pid = getpid();
-			_get_pid_name(sock->pid, sock->pname);
+			sock->pid = (u32_t)getpid();
+			_get_pid_name(getpid(), sock->pname);
 			list->sl_sockets[idx].sock = sock;
 			list->sl_sockets[idx].s_crefs = 1;
 			SYS_ARCH_UNPROTECT(lev);
@@ -937,7 +937,7 @@ int lwip_recvfrom(int s, void *mem, size_t len, int flags, struct sockaddr *from
 		/* Check to see from where the data was. */
 		if (done) {
 			if (from && fromlen) {
-				u16_t port;
+				u16_t port = 0;
 				ip_addr_t tmpaddr;
 				ip_addr_t *fromaddr;
 				union sockaddr_aligned saddr;

--- a/os/net/lwip/src/core/ipv4/dhcp.c
+++ b/os/net/lwip/src/core/ipv4/dhcp.c
@@ -723,6 +723,10 @@ void dhcp_hostname(struct netif *netif, char *name)
 	}
 
 	name_heap = (char *)kmm_malloc(strlen(name) + 1);
+	if (name_heap == NULL) {
+		LWIP_DEBUGF(DHCP_DEBUG | LWIP_DBG_TRACE | LWIP_DBG_LEVEL_WARNING, ("%s(): could not allocate hostname\n", __func__));
+		return;
+	}
 	strncpy(name_heap, name, strlen(name) + 1);
 	name_heap[strlen(name)] = '\0'; //for safety
 

--- a/os/net/lwip/src/core/ipv6/ip6.c
+++ b/os/net/lwip/src/core/ipv6/ip6.c
@@ -1027,7 +1027,14 @@ err_t ip6_output_if(struct pbuf *p, const ip6_addr_t *src, const ip6_addr_t *des
 	const ip6_addr_t *src_used = src;
 	if (dest != LWIP_IP_HDRINCL) {
 		if (src != NULL && ip6_addr_isany(src)) {
-			src_used = ip_2_ip6(ip6_select_source_address(netif, dest));
+			const ip_addr_t *selected_src = ip6_select_source_address(netif, dest);
+			if (selected_src == NULL) {
+				/* No appropriate source address was found for this packet. */
+				LWIP_DEBUGF(IP6_DEBUG | LWIP_DBG_LEVEL_SERIOUS, ("%s: No suitable source address for packet.\n", __func__));
+				IP6_STATS_INC(ip6.rterr);
+				return ERR_RTE;
+			}
+			src_used = ip_2_ip6(selected_src);
 			if ((src_used == NULL) || ip6_addr_isany(src_used)) {
 				/* No appropriate source address was found for this packet. */
 				LWIP_DEBUGF(IP6_DEBUG | LWIP_DBG_LEVEL_SERIOUS, ("ip6_output: No suitable source address for packet.\n"));


### PR DESCRIPTION
Fix svace issues in network.

os/net/lwip/src/api/sockets.c
WID:50385093 Uninitialized data is read from local variable 'port' at sockets.c:969.

os/net/lwip/src/core/ipv4/dhcp.c
WID:50385151 Return value of a function 'kmm_malloc' is dereferenced at dhcp.c:746 without checking for null, but it is usually checked for this function (95/96).

os/net/lwip/src/core/ipv6/ip6.c
WID:50385153 Return value of a function 'ip6_select_source_address' is dereferenced at ip6.c:1031 without checking for null, but it is usually checked for this function (4/5).

os/net/lwip/src/api/sockets.c
WID:50385140 Assignment of a signed value which has type 'pid_t' to a variable of a bigger integer type 'u32_t'