### PR TITLE
os/net/blemgr : Free data allocated by `kmm_malloc` for client callback functions

### DIFF
--- a/os/net/blemgr/bledev_mgr_client.c
+++ b/os/net/blemgr/bledev_mgr_client.c
@@ -68,7 +68,7 @@ static void bledrv_device_disconnected_cb(trble_conn_handle conn_id, uint16_t ca
 	// Copy cause
 	memcpy(ptr, &cause, sizeof(uint16_t));
 
-	trble_post_event(LWNL_EVT_BLE_CLIENT_DISCONNECT, data, size);
+	trble_post_event(LWNL_EVT_BLE_CLIENT_DISCONNECT, data, -(size));
 
 	return;
 }
@@ -155,7 +155,7 @@ static void bledrv_operation_display_passkey_cb(uint32_t passkey, trble_conn_han
 	// Copy passkey
 	memcpy(ptr, &passkey, sizeof(uint32_t));
 	
-	trble_post_event(LWNL_EVT_BLE_CLIENT_DISPLAY_PASSKEY, data, size);
+	trble_post_event(LWNL_EVT_BLE_CLIENT_DISPLAY_PASSKEY, data, -(size));
 	return;
 }
 
@@ -174,7 +174,7 @@ static void bledrv_operation_pair_bond_cb(uint32_t pair_bond_result, trble_conn_
 	// Copy passkey
 	memcpy(ptr, &pair_bond_result, sizeof(uint32_t));
 
-	trble_post_event(LWNL_EVT_BLE_CLIENT_PAIR_BOND, data, size);
+	trble_post_event(LWNL_EVT_BLE_CLIENT_PAIR_BOND, data, -(size));
 	return;
 }
 


### PR DESCRIPTION
- In lwnl, if the buffer length is set to a negative value, existing data allocated with `kmm_malloc` is removed with `kmm_free`, and memory is allocated from the user area when copying to the buffer.
- I have modified the part where kernel memory was leaking because memory was being allocated using `kmm_malloc` in the client callback without changing the size to a negative value.