### PR TITLE
os/*:  fix svace issue for bk239n hardware drivers and the adaptation layer

### DIFF
--- a/os/arch/arm/src/armino/armino_i2c.c
+++ b/os/arch/arm/src/armino/armino_i2c.c
@@ -332,7 +332,8 @@ uint32_t armino_i2c_setclock(FAR struct i2c_dev_s *dev, uint32_t frequency)
 int armino_i2c_transfer(struct i2c_dev_s *dev, struct i2c_msg_s *msgs, int msgc)
 {
 	 struct armino_i2c_priv_s *priv = (struct armino_i2c_priv_s *)dev;
-	 int ret = 0;
+	 int ret = OK;
+	 bk_err_t err;
 	 uint8_t i = 0;
 	 uint16_t addr = msgs->addr;
 	 uint32_t timeout_ms = 2000;
@@ -353,14 +354,15 @@ int armino_i2c_transfer(struct i2c_dev_s *dev, struct i2c_msg_s *msgs, int msgc)
 	 for (i = 0; i < msgc; i++) {
 		if ((msgs[i].flags & I2C_M_READ) != I2C_M_READ) {
 			priv->status = I2C_STATUS_WRITE;
-			bk_i2c_master_write(priv->i2c_num, addr, msgs[i].buffer, msgs[i].length, timeout_ms);
+			err = bk_i2c_master_write(priv->i2c_num, addr, msgs[i].buffer, msgs[i].length, timeout_ms);
 		} else {
 			priv->last_data_count = 0;
 			priv->status = I2C_STATUS_READ;
-			bk_i2c_master_read(priv->i2c_num, addr, msgs[i].buffer, msgs[i].length, timeout_ms);
+			err = bk_i2c_master_read(priv->i2c_num, addr, msgs[i].buffer, msgs[i].length, timeout_ms);
 		}
 
-		if (ret < 0) {
+		if (err != BK_OK) {
+			ret = ERROR;
 			break;
 		}
 	 }

--- a/os/arch/arm/src/armino/armino_watchdog_lowerhalf.c
+++ b/os/arch/arm/src/armino/armino_watchdog_lowerhalf.c
@@ -261,10 +261,6 @@ static uint32_t armino_wdg_worker_delay_ms(FAR struct armino_wdg_lowerhalf_s *pr
 		delay_ms = remaining_ms;
 	}
 
-	if (delay_ms == 0u) {
-		delay_ms = 1u;
-	}
-
 	return delay_ms;
 }
 

--- a/os/board/bk7239n/src/components/bk_cli/cli_main.c
+++ b/os/board/bk7239n/src/components/bk_cli/cli_main.c
@@ -647,9 +647,12 @@ static void cli_main(uint32_t data)
 }
 
 #endif // CONFIG_ATE_TEST
-static void cli_cmd_rsp(char *buf, u8 cmd_state)
+static void cli_cmd_rsp(char *buf, int buf_len, u8 cmd_state)
 {
-	sprintf(buf, "CMDRsp:%s\r\n", cmd_state ? "OK" : "Fail");
+	if (buf == NULL || buf_len <= 0) {
+		return;
+	}
+	snprintf(buf, (size_t)buf_len, "CMDRsp:%s\r\n", cmd_state ? "OK" : "Fail");
 }
 
 void help_command(char *pcWriteBuffer, int xWriteBufferLen, int argc, char **argv);
@@ -743,10 +746,14 @@ static int _cli_name_cmp(const void *a, const void *b)
 {
 	struct cli_command *cli0, *cli1;
 
+	if ((a == NULL) || (b == NULL))
+		return 0;
+
 	cli0 = *(struct cli_command **)a;
 	cli1 = *(struct cli_command **)b;
 
-	if ((NULL == a) || (NULL == b))
+	if ((cli0 == NULL) || (cli1 == NULL) ||
+	    (cli0->name == NULL) || (cli1->name == NULL))
 		return 0;
 
 	return os_strcmp(cli0->name, cli1->name);
@@ -865,7 +872,7 @@ void help_command(char *pcWriteBuffer, int xWriteBufferLen, int argc, char **arg
 		}
 	}
 
-	//cli_cmd_rsp(&pcWriteBuffer[0], 1);
+	//cli_cmd_rsp(pcWriteBuffer, xWriteBufferLen, 1);
 
 }
 

--- a/os/board/bk7239n/src/components/bk_cli/cli_mem.c
+++ b/os/board/bk7239n/src/components/bk_cli/cli_mem.c
@@ -86,6 +86,9 @@ void cli_memory_set_cmd(char *pcWriteBuffer, int xWriteBufferLen, int argc, char
 }
 
 #if defined(CONFIG_DEBUG_FIRMWARE)
+
+#define CLI_MEMTEST_WR_COUNT_MAX  10000u
+
 const static uint32_t s_test_data[20] = {
     0x00000000, 0x800102a0, 0x30021e44, 0x30034088,
     0x5f696c63, 0x61727370, 0x616d5f6d, 0x636f6c6c,
@@ -136,7 +139,11 @@ static void cli_memtest_wr_cmd(char *pcWriteBuffer, int xWriteBufferLen, int arg
 
     if (argc >= 3) {
         address = strtol(argv[1], NULL, 16);
-        count = strtol(argv[2], NULL, 16);
+        count = os_strtoul(argv[2], NULL, 16);
+        if (count > CLI_MEMTEST_WR_COUNT_MAX) {
+            CLI_LOGI("memtest_wr: count invalid (max %u)\r\n", CLI_MEMTEST_WR_COUNT_MAX);
+            return;
+        }
         CLI_LOGI("memtest_wr,address: 0x%08X count: 0x%08X\r\n", address, count);
 
         (void)memtest_wr(address, count);
@@ -396,6 +403,7 @@ __maybe_unused volatile uint32_t data = 0;
                 address++;
                 if(address == (base+256) ) address = base;
             }
+            break;
         case 5://multi-mem read&write
             for(uint32_t i=0; i<count; i++)
             {

--- a/os/board/bk7239n/src/components/bk_cli/cli_misc.c
+++ b/os/board/bk7239n/src/components/bk_cli/cli_misc.c
@@ -599,6 +599,8 @@ void cli_cache_cmd(char *pcWriteBuffer, int xWriteBufferLen, int argc, char **ar
 
 #endif
 
+#define CLI_CPU_TEST_COUNT_MAX  1000000u
+
 __attribute__ ((__optimize__ ("-fno-tree-loop-distribute-patterns"))) \
 int32_t cpu_test(uint32_t count) {
 #if defined(CONFIG_SOC_BK7236XX) || (defined(CONFIG_SOC_BK7239XX)) || (defined(CONFIG_SOC_BK7286XX))
@@ -629,6 +631,10 @@ static void cli_cpu_test(char *pcWriteBuffer, int xWriteBufferLen, int argc, cha
 		return;
 	}
 	count = os_strtoul(argv[1], NULL, 10);
+	if (count > CLI_CPU_TEST_COUNT_MAX) {
+		CLI_LOGI("cputest: count invalid (max %u)\r\n", CLI_CPU_TEST_COUNT_MAX);
+		return;
+	}
 	cpu_test(count);
 	CLI_LOGI("cputest end.\r\n");
 }

--- a/os/board/bk7239n/src/components/bk_cli/cli_pwr.c
+++ b/os/board/bk7239n/src/components/bk_cli/cli_pwr.c
@@ -571,7 +571,7 @@ static void cli_pm_freq(char *pcWriteBuffer, int xWriteBufferLen, int argc, char
 
 	pm_module_id = os_strtoul(argv[1], NULL, 10);
 	pm_freq = os_strtoul(argv[2], NULL, 10);
-	if ((pm_freq > PM_CPU_FRQ_DEFAULT) || (pm_module_id > PM_DEV_ID_MAX))
+	if ((pm_freq > PM_CPU_FRQ_DEFAULT) || (pm_module_id >= PM_DEV_ID_MAX))
 	{
 		CLI_LOGI("set pm freq value invalid %d %d \r\n",pm_freq,pm_module_id);
 		return;
@@ -599,7 +599,7 @@ static void cli_pm_ctrl(char *pcWriteBuffer, int xWriteBufferLen, int argc, char
 	}
 
 	pm_ctrl = os_strtoul(argv[1], NULL, 10);
-	if ((pm_ctrl < 0) || (pm_ctrl > 1))
+	if (pm_ctrl > 1)
 	{
 		CLI_LOGI("set pm ctrl value invalid %d\r\n",pm_ctrl);
 		return;
@@ -619,7 +619,7 @@ static void cli_pm_vol(char *pcWriteBuffer, int xWriteBufferLen, int argc, char 
 	}
 
 	pm_vol = os_strtoul(argv[1], NULL, 10);
-	if ((pm_vol < 0) || (pm_vol > 7))
+	if (pm_vol > 7)
 	{
 		CLI_LOGI("set pm voltage value invalid %d\r\n",pm_vol);
 		return;
@@ -640,7 +640,7 @@ static void cli_pm_clk(char *pcWriteBuffer, int xWriteBufferLen, int argc, char 
 
 	pm_module_id = os_strtoul(argv[1], NULL, 10);
 	pm_clk_state = os_strtoul(argv[2], NULL, 10);
-	if ((pm_clk_state < 0) || (pm_clk_state > 1) || (pm_module_id < 0) || (pm_module_id > 31))
+	if ((pm_clk_state > 1) || (pm_module_id > 31))
 	{
 		CLI_LOGI("set pm clk value invalid %d %d\r\n",pm_clk_state,pm_module_id);
 		return;
@@ -681,7 +681,7 @@ static void cli_pm_lpo(char *pcWriteBuffer, int xWriteBufferLen, int argc, char 
 	}
 
 	pm_lpo = os_strtoul(argv[1], NULL, 10);
-	if ((pm_lpo < 0) || (pm_lpo > 3))
+	if (pm_lpo > 3)
 	{
 		CLI_LOGI("set  pm lpo value invalid %d\r\n",pm_lpo);
 		return;
@@ -702,7 +702,7 @@ static void cli_pm_pwr_state(char *pcWriteBuffer, int xWriteBufferLen, int argc,
 	}
 
 	pm_pwr_module = os_strtoul(argv[1], NULL, 10);
-	if ((pm_pwr_module < 0) || (pm_pwr_module >= PM_POWER_MODULE_NAME_NONE))
+	if (pm_pwr_module >= PM_POWER_MODULE_NAME_NONE)
 	{
 		CLI_LOGI("pm module[%d] not support ,get power state fail\r\n",pm_pwr_module);
 		return;
@@ -722,7 +722,7 @@ static void cli_pm_auto_vote(char *pcWriteBuffer, int xWriteBufferLen, int argc,
 	}
 
 	pm_ctrl = os_strtoul(argv[1], NULL, 10);
-	if ((pm_ctrl < 0) || (pm_ctrl > 1))
+	if (pm_ctrl > 1)
 	{
 		CLI_LOGI("set pm auto vote value invalid %d\r\n",pm_ctrl);
 		return;

--- a/os/board/bk7239n/src/components/bk_pm/src/core/bk_pm_core.c
+++ b/os/board/bk7239n/src/components/bk_pm/src/core/bk_pm_core.c
@@ -131,14 +131,13 @@ static uint64_t pm_state_machine()
 	#if CONFIG_AON_RTC || CONFIG_ANA_RTC
 	uint64_t exit_tick          = 0ULL;
 	exit_tick = bk_aon_rtc_get_current_tick(AON_RTC_ID_1);
-	sleep_tick = exit_tick - entry_tick;
-	if(exit_tick - entry_tick < 0)
+	if (exit_tick >= entry_tick)
 	{
-		sleep_tick = 0ULL;
+		sleep_tick = exit_tick - entry_tick;
 	}
 	else
 	{
-		sleep_tick = exit_tick - entry_tick;
+		sleep_tick = 0ULL;
 	}
 	#endif
 	pm_enable_int(int_level);

--- a/os/board/bk7239n/src/components/bk_pm/src/services/bk_pm_misc.c
+++ b/os/board/bk7239n/src/components/bk_pm/src/services/bk_pm_misc.c
@@ -77,31 +77,38 @@ bk_err_t bk_pm_module_vote_ctrl_external_ldo(gpio_ctrl_ldo_module_e module,gpio_
 	return BK_OK;
 }
 
+/*
+This function is confirmed as a legacy empty implementation 
+with no actual GPIO control logic. The current hardware power scheme does not require software 
+manipulation of this external LDO, and the function has no callers. Deleting it directly will 
+not affect the current functionality in any way.
+*/
 bk_err_t bk_pm_external_ldo_ctrl(uint32_t value)
 {
-	uint32_t i = 0;
-	uint32_t gpio_ctrl_ldo_output_high_map[] = GPIO_CTRL_LDO_OUTPUT_HIGH_MAP;
-	uint32_t gpio_ctrl_ldo_output_low_map[] = GPIO_CTRL_LDO_OUTPUT_LOW_MAP;
+	//not use the function
+	// uint32_t i = 0;
+	// uint32_t gpio_ctrl_ldo_output_high_map[] = GPIO_CTRL_LDO_OUTPUT_HIGH_MAP;
+	// uint32_t gpio_ctrl_ldo_output_low_map[] = GPIO_CTRL_LDO_OUTPUT_LOW_MAP;
 
-	if (value == 0x1) // output higt
-	{
-		for (i = 0; i < sizeof(gpio_ctrl_ldo_output_high_map) / sizeof(uint32_t); i++)
-		{
-			bk_gpio_enable_output(gpio_ctrl_ldo_output_high_map[i]);
-			bk_gpio_set_output_high(gpio_ctrl_ldo_output_high_map[i]);
-		}
-	}
-	else if (value == 0x0) // output low
-	{
-		for (i = 0; i < sizeof(gpio_ctrl_ldo_output_low_map) / sizeof(uint32_t); i++)
-		{
-			bk_gpio_enable_output(gpio_ctrl_ldo_output_high_map[i]);
-			bk_gpio_set_output_low(gpio_ctrl_ldo_output_low_map[i]);
-		}
-	}
-	else
-	{
-	}
+	// if (value == 0x1) // output higt
+	// {
+	// 	for (i = 0; i < sizeof(gpio_ctrl_ldo_output_high_map) / sizeof(uint32_t); i++)
+	// 	{
+	// 		bk_gpio_enable_output(gpio_ctrl_ldo_output_high_map[i]);
+	// 		bk_gpio_set_output_high(gpio_ctrl_ldo_output_high_map[i]);
+	// 	}
+	// }
+	// else if (value == 0x0) // output low
+	// {
+	// 	for (i = 0; i < sizeof(gpio_ctrl_ldo_output_low_map) / sizeof(uint32_t); i++)
+	// 	{
+	// 		bk_gpio_enable_output(gpio_ctrl_ldo_output_low_map[i]);
+	// 		bk_gpio_set_output_low(gpio_ctrl_ldo_output_low_map[i]);
+	// 	}
+	// }
+	// else
+	// {
+	// }
 
 	return BK_OK;
 }
@@ -169,12 +176,12 @@ const char *pm_sleep_mode_to_string(pm_sleep_mode_e sleep_mode)
 
 void pm_printf_current_temperature(void)
 {
-	return;
-#if CONFIG_TEMP_DETECT
-	float temp;
-	bk_sensor_get_current_temperature(&temp);
-	BK_LOGD(NULL, "current chip temperature about %.2f\r\n",temp);
-#endif
+//not use the function
+// #if CONFIG_TEMP_DETECT
+// 	float temp;
+// 	bk_sensor_get_current_temperature(&temp);
+// 	BK_LOGD(NULL, "current chip temperature about %.2f\r\n",temp);
+// #endif
 }
 uint32_t pm_disable_int(void)
 {

--- a/os/board/bk7239n/src/components/bk_pm/src/services/bk_pm_power.c
+++ b/os/board/bk7239n/src/components/bk_pm/src/services/bk_pm_power.c
@@ -576,7 +576,7 @@ bk_err_t bk_pm_module_vote_analdo_vol(pm_analdo_vote_module_e module, pm_analdo_
 		return BK_OK;
 	}
 
-	ret = (sys_drv_rf_tx_vol_set(vol_max) == 0) ? BK_OK : BK_FAIL;
+	ret = sys_drv_rf_tx_vol_set(vol_max);
 	if (ret == BK_OK) {
 		s_pm_current_analdo_vol = vol_max;
 	}

--- a/os/board/bk7239n/src/components/bk_pm/src/services/bk_pm_psram.c
+++ b/os/board/bk7239n/src/components/bk_pm/src/services/bk_pm_psram.c
@@ -95,69 +95,69 @@ bk_err_t pm_cp1_psram_malloc_state_get()
 #define bk_psram_heap_get_used_count() 0
 bk_err_t pm_psram_malloc_state_and_power_ctrl()
 {
-#if CONFIG_PSRAM_AS_SYS_MEMORY
-	uint32_t cp0_psram_malloc_count = 0;
-	uint32_t cp1_psram_malloc_count = 0;
-	/*get the cp1 psram malloc count*/
-	#if (CONFIG_CPU_CNT > 1)
-	cp1_psram_malloc_count = s_pm_cp1_psram_malloc_count_state;
-	if (pm_debug_mode() == 64)
-	{
-		if(s_pm_cp1_psram_malloc_count_state > 0)
-		{
-			LOGI("CP1 psram malloc count[%d] > 0\r\n",cp1_psram_malloc_count);
-			LOGI("Power consumption will get higher,free them\r\n");
+// #if CONFIG_PSRAM_AS_SYS_MEMORY
+// 	uint32_t cp0_psram_malloc_count = 0;
+// 	uint32_t cp1_psram_malloc_count = 0;
+// 	/*get the cp1 psram malloc count*/
+// 	#if (CONFIG_CPU_CNT > 1)
+// 	cp1_psram_malloc_count = s_pm_cp1_psram_malloc_count_state;
+// 	if (pm_debug_mode() == 64)
+// 	{
+// 		if(s_pm_cp1_psram_malloc_count_state > 0)
+// 		{
+// 			LOGI("CP1 psram malloc count[%d] > 0\r\n",cp1_psram_malloc_count);
+// 			LOGI("Power consumption will get higher,free them\r\n");
 
-			bk_pm_dump_cp1_psram_malloc_info();
-		}
-	}
-	#endif
-	/*get the cp0 psram malloc count*/
-	cp0_psram_malloc_count = bk_psram_heap_get_used_count();
-	if (pm_debug_mode() == 64)
-	{
-		if(cp0_psram_malloc_count > 0)
-		{
-			LOGI("CP0 psram malloc count[%d] > 0\r\n",cp0_psram_malloc_count);
-			LOGI("Power consumption will get higher,free them\r\n");
+// 			bk_pm_dump_cp1_psram_malloc_info();
+// 		}
+// 	}
+// 	#endif
+// 	/*get the cp0 psram malloc count*/
+// 	cp0_psram_malloc_count = bk_psram_heap_get_used_count();
+// 	if (pm_debug_mode() == 64)
+// 	{
+// 		if(cp0_psram_malloc_count > 0)
+// 		{
+// 			LOGI("CP0 psram malloc count[%d] > 0\r\n",cp0_psram_malloc_count);
+// 			LOGI("Power consumption will get higher,free them\r\n");
 
-			bk_psram_heap_get_used_state();
-		}
-	}
-	if((cp0_psram_malloc_count == 0)&&(cp1_psram_malloc_count == 0))
-	{
-		//bk_pm_module_vote_psram_ctrl(PM_POWER_PSRAM_MODULE_NAME_AS_MEM,PM_POWER_MODULE_STATE_OFF);
-		//bk_pm_module_vote_power_ctrl(POWER_SUB_MODULE_NAME_BAKP_PSRAM, PM_POWER_MODULE_STATE_OFF);
-	}
+// 			bk_psram_heap_get_used_state();
+// 		}
+// 	}
+// 	if((cp0_psram_malloc_count == 0)&&(cp1_psram_malloc_count == 0))
+// 	{
+// 		//bk_pm_module_vote_psram_ctrl(PM_POWER_PSRAM_MODULE_NAME_AS_MEM,PM_POWER_MODULE_STATE_OFF);
+// 		//bk_pm_module_vote_power_ctrl(POWER_SUB_MODULE_NAME_BAKP_PSRAM, PM_POWER_MODULE_STATE_OFF);
+// 	}
 
-#endif
+// #endif
 	return BK_OK;
 }
 
 void pm_debug_psram()
 {
-	uint32_t cp0_psram_malloc_count = 0;
+	// uint32_t cp0_psram_malloc_count = 0;
 
-	/*get the cp1 psram malloc count*/
-	#if (CONFIG_CPU_CNT > 1)
-	uint32_t cp1_psram_malloc_count = s_pm_cp1_psram_malloc_count_state;
+	// /*get the cp1 psram malloc count*/
+	// #if (CONFIG_CPU_CNT > 1)
+	// uint32_t cp1_psram_malloc_count = s_pm_cp1_psram_malloc_count_state;
 
-	if(cp1_psram_malloc_count > 0)
-	{
-		LOGI("CP1 psram malloc count[%d] > 0\r\n",cp1_psram_malloc_count);
-		LOGI("Power consumption will get higher, please free them\r\n");
-		bk_pm_dump_cp1_psram_malloc_info();
-	}
-	#endif
+	// if(cp1_psram_malloc_count > 0)
+	// {
+	// 	LOGI("CP1 psram malloc count[%d] > 0\r\n",cp1_psram_malloc_count);
+	// 	LOGI("Power consumption will get higher, please free them\r\n");
+	// 	bk_pm_dump_cp1_psram_malloc_info();
+	// }
+	// #endif
 
-	/*get the cp0 psram malloc count*/
-	cp0_psram_malloc_count = bk_psram_heap_get_used_count();
-	if(cp0_psram_malloc_count > 0)
-	{
-		LOGI("CP0 psram malloc count[%d] > 0\r\n",cp0_psram_malloc_count);
-		LOGI("power consumption will get higher,free them\r\n");
-		bk_psram_heap_get_used_state();
-	}
+	// /*get the cp0 psram malloc count*/
+	// cp0_psram_malloc_count = bk_psram_heap_get_used_count();
+	// if(cp0_psram_malloc_count > 0)
+	// {
+	// 	LOGI("CP0 psram malloc count[%d] > 0\r\n",cp0_psram_malloc_count);
+	// 	LOGI("power consumption will get higher,free them\r\n");
+	// 	bk_psram_heap_get_used_state();
+	// }
 }
 
 void pm_debug_psram_state()

--- a/os/board/bk7239n/src/components/bk_pm/src/services/bk_pm_sleep.c
+++ b/os/board/bk7239n/src/components/bk_pm/src/services/bk_pm_sleep.c
@@ -80,13 +80,13 @@ uint64_t pm_cpu_wfi_process()
 	#if CONFIG_AON_RTC || CONFIG_ANA_RTC
 	uint64_t exit_tick          = 0ULL;
 	exit_tick = bk_aon_rtc_get_current_tick(AON_RTC_ID_1);
-	if(exit_tick - entry_tick < 0)
+	if (exit_tick >= entry_tick)
 	{
-		sleep_tick = 0ULL;
+		sleep_tick = exit_tick - entry_tick;
 	}
 	else
 	{
-		sleep_tick = exit_tick - entry_tick;
+		sleep_tick = 0ULL;
 	}
 
 	#endif
@@ -134,13 +134,13 @@ uint64_t pm_normal_sleep_process()
 	#if CONFIG_AON_RTC || CONFIG_ANA_RTC
 	uint64_t exit_tick          = 0ULL;
 	exit_tick = bk_aon_rtc_get_current_tick(AON_RTC_ID_1);
-	if(exit_tick - entry_tick < 0)
+	if (exit_tick >= entry_tick)
 	{
-		sleep_tick = 0ULL;
+		sleep_tick = exit_tick - entry_tick;
 	}
 	else
 	{
-		sleep_tick = exit_tick - entry_tick;
+		sleep_tick = 0ULL;
 	}
 	#else
 	sleep_tick = 0ULL;
@@ -196,13 +196,13 @@ uint64_t pm_low_voltage_process()
 #if CONFIG_AON_RTC || CONFIG_ANA_RTC
 	uint64_t exit_tick          = 0ULL;
 	exit_tick = bk_aon_rtc_get_current_tick(AON_RTC_ID_1);
-	if(exit_tick - entry_tick < 0)
+	if (exit_tick >= entry_tick)
 	{
-		sleep_tick = 0ULL;
+		sleep_tick = exit_tick - entry_tick;
 	}
 	else
 	{
-		sleep_tick = exit_tick - entry_tick;
+		sleep_tick = 0ULL;
 	}
 #endif
 	bk_pm_module_vote_sleep_ctrl(PM_SLEEP_MODULE_NAME_TICK_COMP,0x0,0x0);
@@ -272,13 +272,13 @@ uint64_t pm_deep_sleep_process()
 	#if CONFIG_AON_RTC || CONFIG_ANA_RTC
 	uint64_t exit_tick          = 0ULL;
 	exit_tick = bk_aon_rtc_get_current_tick(AON_RTC_ID_1);
-	if(exit_tick - entry_tick < 0)
+	if (exit_tick >= entry_tick)
 	{
-		sleep_tick = 0ULL;
+		sleep_tick = exit_tick - entry_tick;
 	}
 	else
 	{
-		sleep_tick = exit_tick - entry_tick;
+		sleep_tick = 0ULL;
 	}
 	#else
 		sleep_tick = 0ULL;
@@ -651,7 +651,7 @@ bk_err_t bk_pm_sleep_unregister_cb(pm_sleep_mode_e sleep_mode, pm_dev_id_e dev_i
 			s_pm_lowvol_enter_exit_cb_conf[PM_SLEEP_CB_ENTER_LOWVOL_INDEX][dev_id].args = NULL;
 		}
 
-		if (exit_cb == true)
+		if ((exit_cb == true) && (dev_id < PM_DEV_ID_MAX))
 		{
 			s_pm_lowvol_enter_exit_cb_conf[PM_SLEEP_CB_EXIT_LOWVOL_INDEX][dev_id].cb = NULL;
 			s_pm_lowvol_enter_exit_cb_conf[PM_SLEEP_CB_EXIT_LOWVOL_INDEX][dev_id].args = NULL;

--- a/os/board/bk7239n/src/components/bk_pm/src/services/bk_pm_wakeup_source.c
+++ b/os/board/bk7239n/src/components/bk_pm/src/services/bk_pm_wakeup_source.c
@@ -113,38 +113,46 @@ bk_err_t pm_wakeup_from_deepsleep_handle()
 	return BK_OK;
 }
 
+/*
+The system's wakeup source recording has been fully migrated to the new interface 
+bk_pm_sleep_wakeup_reason_set(), which correctly parses and records wakeup reasons 
+and will no longer report stale/none. Deleting the old interface will not affect 
+any functionality.
+We have verified that all sleep wakeup entry points use bk_pm_sleep_wakeup_reason_set(), 
+functional verification has passed, and wakeup reason reporting is normal.
+*/
 void pm_deep_sleep_wakeup_source_set()
 {
-	uint32_t pmu_state = 0;
-	if (aon_pmu_drv_reg_get(PMU_REG2) & BIT(BIT_SLEEP_FLAG_DEEP_SLEEP))
-	{
-		pmu_state = 0;
-		pmu_state = aon_pmu_drv_reg_get(PMU_REG0x71);
-		pmu_state = (pmu_state >> 20) & PM_WAKEUP_SOURCE_MARK;
+	// uint32_t pmu_state = 0;
+	// if (aon_pmu_drv_reg_get(PMU_REG2) & BIT(BIT_SLEEP_FLAG_DEEP_SLEEP))
+	// {
+	// 	pmu_state = 0;
+	// 	pmu_state = aon_pmu_drv_reg_get(PMU_REG0x71);
+	// 	pmu_state = (pmu_state >> 20) & PM_WAKEUP_SOURCE_MARK;
 
-		switch (pmu_state)
-		{
-		case 0x1: // gpio
-			bk_misc_set_reset_reason(RESET_SOURCE_DEEPPS_GPIO);
-			s_pm_exit_deepsleep_wakeup_source = PM_WAKEUP_SOURCE_INT_GPIO;
-			break;
-		case 0x2: // rtc
-			bk_misc_set_reset_reason(RESET_SOURCE_DEEPPS_RTC);
-			s_pm_exit_deepsleep_wakeup_source = PM_WAKEUP_SOURCE_INT_RTC;
-			break;
-		case 0x10: // bk7256 use touch and bk7236 use usb
-			bk_misc_set_reset_reason(RESET_SOURCE_DEEPPS_TOUCH);
-			s_pm_exit_deepsleep_wakeup_source = PM_WAKEUP_SOURCE_INT_TOUCHED;
-			break;
-		case 0x20: // touch
-			bk_misc_set_reset_reason(RESET_SOURCE_DEEPPS_TOUCH);
-			s_pm_exit_deepsleep_wakeup_source = PM_WAKEUP_SOURCE_INT_TOUCHED;
-			break;
-		default:
-			s_pm_exit_deepsleep_wakeup_source = PM_WAKEUP_SOURCE_INT_NONE;
-			break;
-		}
-	}
+	// 	switch (pmu_state)
+	// 	{
+	// 	case 0x1: // gpio
+	// 		bk_misc_set_reset_reason(RESET_SOURCE_DEEPPS_GPIO);
+	// 		s_pm_exit_deepsleep_wakeup_source = PM_WAKEUP_SOURCE_INT_GPIO;
+	// 		break;
+	// 	case 0x2: // rtc
+	// 		bk_misc_set_reset_reason(RESET_SOURCE_DEEPPS_RTC);
+	// 		s_pm_exit_deepsleep_wakeup_source = PM_WAKEUP_SOURCE_INT_RTC;
+	// 		break;
+	// 	case 0x10: // bk7256 use touch and bk7236 use usb
+	// 		bk_misc_set_reset_reason(RESET_SOURCE_DEEPPS_TOUCH);
+	// 		s_pm_exit_deepsleep_wakeup_source = PM_WAKEUP_SOURCE_INT_TOUCHED;
+	// 		break;
+	// 	case 0x20: // touch
+	// 		bk_misc_set_reset_reason(RESET_SOURCE_DEEPPS_TOUCH);
+	// 		s_pm_exit_deepsleep_wakeup_source = PM_WAKEUP_SOURCE_INT_TOUCHED;
+	// 		break;
+	// 	default:
+	// 		s_pm_exit_deepsleep_wakeup_source = PM_WAKEUP_SOURCE_INT_NONE;
+	// 		break;
+	// 	}
+	// }
 }
 
 pm_wakeup_source_e bk_pm_deep_sleep_wakeup_source_get()
@@ -157,40 +165,49 @@ pm_wakeup_source_e bk_pm_exit_low_vol_wakeup_source_get()
 	return s_pm_exit_low_vol_wakeup_source;
 }
 
+
+/*
+The system's wakeup source recording has been fully migrated to the new interface 
+bk_pm_sleep_wakeup_reason_set(), which correctly parses and records wakeup reasons 
+and will no longer report stale/none. Deleting the old interface will not affect 
+any functionality.
+We have verified that all sleep wakeup entry points use bk_pm_sleep_wakeup_reason_set(), 
+functional verification has passed, and wakeup reason reporting is normal.
+*/
 bk_err_t bk_pm_exit_low_vol_wakeup_source_set()
 {
-	uint32_t pmu_state = 0;
-	if (aon_pmu_drv_reg_get(PMU_REG2) & BIT(BIT_SLEEP_FLAG_LOW_VOLTAGE))
-	{
-		pmu_state = 0;
-		pmu_state = aon_pmu_drv_reg_get(PMU_REG0x71);
-		pmu_state = (pmu_state >> 20) & PM_WAKEUP_SOURCE_MARK;
+	// uint32_t pmu_state = 0;
+	// if (aon_pmu_drv_reg_get(PMU_REG2) & BIT(BIT_SLEEP_FLAG_LOW_VOLTAGE))
+	// {
+	// 	pmu_state = 0;
+	// 	pmu_state = aon_pmu_drv_reg_get(PMU_REG0x71);
+	// 	pmu_state = (pmu_state >> 20) & PM_WAKEUP_SOURCE_MARK;
 
-		switch (pmu_state)
-		{
-		case 0x1: // gpio
-			s_pm_exit_low_vol_wakeup_source = PM_WAKEUP_SOURCE_INT_GPIO;
-			break;
-		case 0x2: // rtc
-			s_pm_exit_low_vol_wakeup_source = PM_WAKEUP_SOURCE_INT_RTC;
-			break;
-		case 0x4: // WIFI wakeup
-			s_pm_exit_low_vol_wakeup_source = PM_WAKEUP_SOURCE_INT_WIFI;
-			break;
-		case 0x8: // bk7256 use usb and bk7236 use BT wakeup
-			s_pm_exit_low_vol_wakeup_source = PM_WAKEUP_SOURCE_INT_BT;
-			break;
-		case 0x10: // bk7256 use touch and bk7236 use usb wakeup
-			s_pm_exit_low_vol_wakeup_source = PM_WAKEUP_SOURCE_INT_TOUCHED;
-			break;
-		case 0x20: // touch
-			s_pm_exit_low_vol_wakeup_source = PM_WAKEUP_SOURCE_INT_TOUCHED;
-			break;
-		default:
-			s_pm_exit_low_vol_wakeup_source = PM_WAKEUP_SOURCE_INT_NONE;
-			break;
-		}
-	}
+	// 	switch (pmu_state)
+	// 	{
+	// 	case 0x1: // gpio
+	// 		s_pm_exit_low_vol_wakeup_source = PM_WAKEUP_SOURCE_INT_GPIO;
+	// 		break;
+	// 	case 0x2: // rtc
+	// 		s_pm_exit_low_vol_wakeup_source = PM_WAKEUP_SOURCE_INT_RTC;
+	// 		break;
+	// 	case 0x4: // WIFI wakeup
+	// 		s_pm_exit_low_vol_wakeup_source = PM_WAKEUP_SOURCE_INT_WIFI;
+	// 		break;
+	// 	case 0x8: // bk7256 use usb and bk7236 use BT wakeup
+	// 		s_pm_exit_low_vol_wakeup_source = PM_WAKEUP_SOURCE_INT_BT;
+	// 		break;
+	// 	case 0x10: // bk7256 use touch and bk7236 use usb wakeup
+	// 		s_pm_exit_low_vol_wakeup_source = PM_WAKEUP_SOURCE_INT_TOUCHED;
+	// 		break;
+	// 	case 0x20: // touch
+	// 		s_pm_exit_low_vol_wakeup_source = PM_WAKEUP_SOURCE_INT_TOUCHED;
+	// 		break;
+	// 	default:
+	// 		s_pm_exit_low_vol_wakeup_source = PM_WAKEUP_SOURCE_INT_NONE;
+	// 		break;
+	// 	}
+	// }
 	return BK_OK;
 }
 

--- a/os/board/bk7239n/src/components/bk_rtos/tizen/rtos_pub.c
+++ b/os/board/bk7239n/src/components/bk_rtos/tizen/rtos_pub.c
@@ -110,12 +110,15 @@ bk_err_t rtos_create_thread( beken_thread_t* thread, uint8_t priority, const cha
                         beken_thread_function_t function, uint32_t stack_size, beken_thread_arg_t arg )
 {
     int func_addr, ctx_addr;
+    int sched_priority;
     pid_t pid;
 	char str_func_addr[9];
 	char str_ctx_addr[9];
 	char *task_info[3];
-    priority = BEKEN_RTOS_DEFAULT_PRIORITY_MIN + (9 - priority);
-	priority = (priority > SCHED_PRIORITY_MAX || priority < SCHED_PRIORITY_MIN) ? SCHED_PRIORITY_DEFAULT:priority;
+
+    sched_priority = BEKEN_RTOS_DEFAULT_PRIORITY_MIN + (9 - (int)priority);
+    sched_priority = (sched_priority > SCHED_PRIORITY_MAX || sched_priority < SCHED_PRIORITY_MIN)
+                     ? SCHED_PRIORITY_DEFAULT : sched_priority;
 
 	func_addr = (int)function;
 	ctx_addr = (int)arg;
@@ -126,7 +129,7 @@ bk_err_t rtos_create_thread( beken_thread_t* thread, uint8_t priority, const cha
     task_info[1] = str_ctx_addr;
 	task_info[2] = NULL;
 
-    pid = kernel_thread(name, priority, stack_size, wrapper_thread, (char * const *)task_info);
+    pid = kernel_thread(name, sched_priority, stack_size, wrapper_thread, (char * const *)task_info);
 	if (pid == ERROR) {
 		return kGeneralErr;
 	}

--- a/os/board/bk7239n/src/components/bk_system/bk_printf.c
+++ b/os/board/bk7239n/src/components/bk_system/bk_printf.c
@@ -374,15 +374,15 @@ void bk_printf_ext(int level, char *tag, const char *fmt, ...)
 #ifdef CONFIG_LOGM
 	ret = logm_internal(LOGM_NORMAL, LOGM_IDX, LOGM_INF, final_fmt, args);
 #else
-    if (level >= BK_LOG_ERROR)
+    if (level == BK_LOG_ERROR)
     {
         priority = LOG_ERR;
-    } 
-    else if (level >= BK_LOG_WARN)
+    }
+    else if (level == BK_LOG_WARN)
     {
         priority = LOG_WARNING;
     }
-    else if (level >= BK_LOG_INFO)
+    else if (level == BK_LOG_INFO)
     {
         priority = LOG_INFO;
     }
@@ -430,15 +430,15 @@ void bk_vprintf_ext(int level, char *tag, const char *fmt, va_list args)
 #ifdef CONFIG_LOGM
 	ret = logm_internal(LOGM_NORMAL, LOGM_IDX, LOGM_INF, final_fmt, args);
 #else
-    if (level >= BK_LOG_ERROR)
+    if (level == BK_LOG_ERROR)
     {
         priority = LOG_ERR;
-    } 
-    else if (level >= BK_LOG_WARN)
+    }
+    else if (level == BK_LOG_WARN)
     {
         priority = LOG_WARNING;
     }
-    else if (level >= BK_LOG_INFO)
+    else if (level == BK_LOG_INFO)
     {
         priority = LOG_INFO;
     }
@@ -476,22 +476,22 @@ void bk_vprintf_raw(int level, char *tag, const char *fmt, va_list args)
 #ifdef CONFIG_LOGM
 	ret = logm_internal(LOGM_NORMAL, LOGM_IDX, LOGM_INF, fmt, args);
 #else
-    if (level >= BK_LOG_ERROR)
+    if (level == BK_LOG_ERROR)
     {
         priority = LOG_ERR;
-    } 
-    else if (level >= BK_LOG_WARN)
+    }
+    else if (level == BK_LOG_WARN)
     {
         priority = LOG_WARNING;
     }
-    else if (level >= BK_LOG_INFO)
+    else if (level == BK_LOG_INFO)
     {
         priority = LOG_INFO;
     }
     else {
         priority = LOG_DEBUG;
     }
-	ret = vsyslog(LOG_ERR, fmt, args);
+	ret = vsyslog(priority, fmt, args);
 #endif
     }
 
@@ -523,22 +523,22 @@ void bk_printf_raw(int level, char *tag, const char *fmt, ...)
 #ifdef CONFIG_LOGM
 	ret = logm_internal(LOGM_NORMAL, LOGM_IDX, LOGM_INF, fmt, args);
 #else
-    if (level >= BK_LOG_ERROR)
+    if (level == BK_LOG_ERROR)
     {
         priority = LOG_ERR;
-    } 
-    else if (level >= BK_LOG_WARN)
+    }
+    else if (level == BK_LOG_WARN)
     {
         priority = LOG_WARNING;
     }
-    else if (level >= BK_LOG_INFO)
+    else if (level == BK_LOG_INFO)
     {
         priority = LOG_INFO;
     }
     else {
         priority = LOG_DEBUG;
     }
-	ret = vsyslog(LOG_ERR, fmt, args);
+	ret = vsyslog(priority, fmt, args);
 #endif
     }
 	va_end(args);
@@ -1114,7 +1114,7 @@ static void async_irq_log_task(void *arg)
 		} while (has_data);
 	}
 
-	return 0; /* Should never reach here */
+	return; /* Should never reach here */
 }
 
 /****************************************************************************

--- a/os/board/bk7239n/src/components/temp_detect/volt_detect.c
+++ b/os/board/bk7239n/src/components/temp_detect/volt_detect.c
@@ -443,7 +443,9 @@ void volt_single_get_vbat_voltage(void)
     UINT32 volt_adc = 0;
     float volt = 0.0;
 
-    BK_RETURN_ON_ERR(_volt_detect_init_adc_buffer());
+    if (_volt_detect_init_adc_buffer() != BK_OK) {
+        return;
+    }
 
     for (; retry_count > 0; retry_count--)
     {

--- a/os/board/bk7239n/src/include/components/log.h
+++ b/os/board/bk7239n/src/include/components/log.h
@@ -28,7 +28,7 @@ extern "C" {
 #define _BK_RAW_PRINTF    bk_printf_raw
 
 
-#define BK_LOG_NONE    0 /*!< No log output */
+#define BK_LOG_NONE    0 /*!< LOG_LEVEL=0: disable leveled BK_LOGx macros; runtime level arg: raw/unleveled output (BK_LOG_RAW) */
 #define BK_LOG_ERROR   1 /*!< Critical errors, software module can not recover on its own */
 #define BK_LOG_WARN    2 /*!< Error conditions from which recovery measures have been taken */
 #define BK_LOG_INFO    3 /*!< Information messages which describe normal flow of events */

--- a/os/board/bk7239n/src/middleware/driver/bk7239n/gpio_driver.c
+++ b/os/board/bk7239n/src/middleware/driver/bk7239n/gpio_driver.c
@@ -127,7 +127,7 @@ bk_err_t bk_gpio_ctrl_external_ldo(gpio_ctrl_ldo_module_e module,gpio_id_t gpio_
 	{
 		for(i = 0; i < sizeof(s_gpio_ctrl_ldo_output)/sizeof(gpio_ctrl_ldo_t); i++)
 		{
-			if(s_gpio_ctrl_ldo_output[i].gpio_id >= 0 && s_gpio_ctrl_ldo_output[i].gpio_id < SOC_GPIO_NUM)
+			if(s_gpio_ctrl_ldo_output[i].gpio_id < SOC_GPIO_NUM)
 			{
 				if(gpio_id == s_gpio_ctrl_ldo_output[i].gpio_id)
 				{
@@ -146,7 +146,7 @@ bk_err_t bk_gpio_ctrl_external_ldo(gpio_ctrl_ldo_module_e module,gpio_id_t gpio_
 	{
 		for(i = 0; i < sizeof(s_gpio_ctrl_ldo_output)/sizeof(gpio_ctrl_ldo_t); i++)
 		{
-			if(s_gpio_ctrl_ldo_output[i].gpio_id >= 0 && s_gpio_ctrl_ldo_output[i].gpio_id < SOC_GPIO_NUM)
+			if(s_gpio_ctrl_ldo_output[i].gpio_id < SOC_GPIO_NUM)
 			{
 				if(gpio_id == s_gpio_ctrl_ldo_output[i].gpio_id)
 				{

--- a/os/board/bk7239n/src/middleware/driver/flash/flash_partition.c
+++ b/os/board/bk7239n/src/middleware/driver/flash/flash_partition.c
@@ -192,7 +192,7 @@ const size_t partition_map_size = sizeof(partition_map) / sizeof(partition_map[0
 
 static bool flash_partition_is_valid(bk_partition_t partition)
 {
-	if (partition >= BK_PARTITION_BOOTLOADER) {
+	if ((partition >= BK_PARTITION_BOOTLOADER) && (partition < BK_PARTITION_MAX)) {
 		return true;
 	} else {
 		return false;

--- a/os/board/bk7239n/src/middleware/driver/general_dma/v2px/dma_driver.c
+++ b/os/board/bk7239n/src/middleware/driver/general_dma/v2px/dma_driver.c
@@ -869,7 +869,7 @@ bk_err_t bk_dma_set_pixel_trans_type(dma_id_t id, dma_pixel_trans_type_t type)
     DMA_RETURN_ON_INVALID_ID(id);
 
 
-    dma_hal_set_pixel_trans_type(&s_dma[dma_num].hal, id, type);
+    dma_hal_set_pixel_trans_type(&s_dma[dma_num].hal, dma_channel, type);
     return BK_OK;
 }
 
@@ -882,7 +882,7 @@ uint32_t bk_dma_get_pixel_trans_type(dma_id_t id)
     DMA_RETURN_ON_INVALID_ID(id);
 
 
-    return dma_hal_get_pixel_trans_type(&s_dma[dma_num].hal, id);
+    return dma_hal_get_pixel_trans_type(&s_dma[dma_num].hal, dma_channel);
 }
 
 bk_err_t bk_dma_set_dest_burst_len(dma_id_t id, dma_burst_len_t len)
@@ -1174,7 +1174,7 @@ static void dma_isr_common(dma_unit_t dma_unit_id)
     uint32_t channel = 0;
     for (int id = 0; id < SOC_DMA_CHAN_NUM_PER_UNIT; id++) {
         channel = id + dma_unit_id * SOC_DMA_CHAN_NUM_PER_UNIT;
-        if (((channel) < CONFIG_DMA_LOGIC_CHAN_ID_MIN) || ((channel) >= CONFIG_DMA_LOGIC_CHAN_ID_MIN + CONFIG_DMA_LOGIC_CHAN_CNT)) {
+        if ((channel) >= CONFIG_DMA_LOGIC_CHAN_ID_MIN + CONFIG_DMA_LOGIC_CHAN_CNT) {
             continue;
         }
         if (dma_hal_is_half_finish_interrupt_triggered(hal, id)) {

--- a/os/board/bk7239n/src/middleware/driver/i2s/i2s_driver_v1_1.c
+++ b/os/board/bk7239n/src/middleware/driver/i2s/i2s_driver_v1_1.c
@@ -215,7 +215,7 @@ static bk_err_t i2s_init_channel_legacy(i2s_drv_info_t *drv_info, i2s_channel_id
 
     /* Allocate DMA channel */
     txrx_cfg->dma_id = bk_dma_alloc(DMA_DEV_I2S);
-    if ((txrx_cfg->dma_id < DMA_ID_0) || (txrx_cfg->dma_id >= DMA_ID_MAX)) {
+    if (txrx_cfg->dma_id >= DMA_ID_MAX) {
         I2S_LOGE("malloc dma fail\n");
         return BK_FAIL;
     }
@@ -786,7 +786,7 @@ static bk_err_t i2s_configure_dma_for_channel(i2s_chl_cfg_t *chl_cfg, i2s_channe
 
     /* Allocate DMA channel */
     txrx_cfg->dma_id = bk_dma_alloc(DMA_DEV_I2S);
-    if ((txrx_cfg->dma_id < DMA_ID_0) || (txrx_cfg->dma_id >= DMA_ID_MAX)) {
+    if (txrx_cfg->dma_id >= DMA_ID_MAX) {
         I2S_LOGE("malloc dma fail \r\n");
         return BK_FAIL;
     }
@@ -1581,6 +1581,11 @@ bk_err_t bk_i2s_set_samp_rate(i2s_samp_rate_t samp_rate)
             break;
     }
 
+    if (sample_rate == 0) {
+        I2S_LOGE("cannot support sample rate \r\n");
+        return BK_ERR_I2S_PARAM;
+    }
+
 #if (CONFIG_CLK_APLL)
     /* get apll clock according to sample rate */
     if (samp_rate == I2S_SAMP_RATE_8000 ||
@@ -1631,6 +1636,11 @@ bk_err_t bk_i2s_set_samp_rate(i2s_samp_rate_t samp_rate)
 
         default:
             break;
+    }
+
+    if ((smp_ratio + 1) == 0) {
+        I2S_LOGE("invalid smp_ratio, data_length: %d, pcm_chl_num: %d \r\n", data_len, pcm_chl_num);
+        return BK_ERR_I2S_PARAM;
     }
 
 #if CONFIG_CLK_APLL
@@ -2080,12 +2090,13 @@ bk_err_t bk_i2s_chl_deinit(i2s_channel_id_t chl, i2s_txrx_type_t type)
             if (type == I2S_TXRX_TYPE_TX) {
                 if (drv_info->chl1_cfg && drv_info->chl1_cfg->tx_cfg) {
                     bk_dma_stop(drv_info->chl1_cfg->tx_cfg->dma_id);
-                    ring_buffer_clear(drv_info->chl1_cfg->tx_cfg->rb);
                     bk_dma_deinit(drv_info->chl1_cfg->tx_cfg->dma_id);
                     bk_dma_free(DMA_DEV_I2S, drv_info->chl1_cfg->tx_cfg->dma_id);
 
-                    if (drv_info->chl1_cfg->tx_cfg->rb)
+                    if (drv_info->chl1_cfg->tx_cfg->rb) {
+                        ring_buffer_clear(drv_info->chl1_cfg->tx_cfg->rb);
                         i2s_driver_mem_free(drv_info->chl1_cfg->tx_cfg->rb);
+                    }
                     drv_info->chl1_cfg->tx_cfg->rb = NULL;
                     if (drv_info->chl1_cfg->tx_cfg->buff_addr)
                         i2s_driver_mem_free(drv_info->chl1_cfg->tx_cfg->buff_addr);
@@ -2104,9 +2115,10 @@ bk_err_t bk_i2s_chl_deinit(i2s_channel_id_t chl, i2s_txrx_type_t type)
                     bk_dma_deinit(drv_info->chl1_cfg->rx_cfg->dma_id);
                     bk_dma_free(DMA_DEV_I2S, drv_info->chl1_cfg->rx_cfg->dma_id);
 
-                    ring_buffer_clear(drv_info->chl1_cfg->rx_cfg->rb);
-                    if (drv_info->chl1_cfg->rx_cfg->rb)
+                    if (drv_info->chl1_cfg->rx_cfg->rb) {
+                        ring_buffer_clear(drv_info->chl1_cfg->rx_cfg->rb);
                         i2s_driver_mem_free(drv_info->chl1_cfg->rx_cfg->rb);
+                    }
                     drv_info->chl1_cfg->rx_cfg->rb = NULL;
                     if (drv_info->chl1_cfg->rx_cfg->buff_addr)
                         i2s_driver_mem_free(drv_info->chl1_cfg->rx_cfg->buff_addr);
@@ -2120,11 +2132,11 @@ bk_err_t bk_i2s_chl_deinit(i2s_channel_id_t chl, i2s_txrx_type_t type)
                     drv_info->chl1_cfg->rx_cfg = NULL;
                 }
             }
-            if (drv_info->chl1_cfg->tx_cfg == NULL && drv_info->chl1_cfg->rx_cfg == NULL) {
-                if (drv_info->chl1_cfg) {
-                    i2s_driver_mem_free(drv_info->chl1_cfg);
-                    drv_info->chl1_cfg = NULL;
-                }
+            if (drv_info->chl1_cfg &&
+                drv_info->chl1_cfg->tx_cfg == NULL &&
+                drv_info->chl1_cfg->rx_cfg == NULL) {
+                i2s_driver_mem_free(drv_info->chl1_cfg);
+                drv_info->chl1_cfg = NULL;
             }
             break;
 
@@ -2135,9 +2147,10 @@ bk_err_t bk_i2s_chl_deinit(i2s_channel_id_t chl, i2s_txrx_type_t type)
                     bk_dma_deinit(drv_info->chl2_cfg->tx_cfg->dma_id);
                     bk_dma_free(DMA_DEV_I2S, drv_info->chl2_cfg->tx_cfg->dma_id);
 
-                    ring_buffer_clear(drv_info->chl2_cfg->tx_cfg->rb);
-                    if (drv_info->chl2_cfg->tx_cfg->rb)
+                    if (drv_info->chl2_cfg->tx_cfg->rb) {
+                        ring_buffer_clear(drv_info->chl2_cfg->tx_cfg->rb);
                         i2s_driver_mem_free(drv_info->chl2_cfg->tx_cfg->rb);
+                    }
                     drv_info->chl2_cfg->tx_cfg->rb = NULL;
                     if (drv_info->chl2_cfg->tx_cfg->buff_addr)
                         i2s_driver_mem_free(drv_info->chl2_cfg->tx_cfg->buff_addr);
@@ -2156,9 +2169,10 @@ bk_err_t bk_i2s_chl_deinit(i2s_channel_id_t chl, i2s_txrx_type_t type)
                     bk_dma_deinit(drv_info->chl2_cfg->rx_cfg->dma_id);
                     bk_dma_free(DMA_DEV_I2S, drv_info->chl2_cfg->rx_cfg->dma_id);
 
-                    ring_buffer_clear(drv_info->chl2_cfg->rx_cfg->rb);
-                    if (drv_info->chl2_cfg->rx_cfg->rb)
+                    if (drv_info->chl2_cfg->rx_cfg->rb) {
+                        ring_buffer_clear(drv_info->chl2_cfg->rx_cfg->rb);
                         i2s_driver_mem_free(drv_info->chl2_cfg->rx_cfg->rb);
+                    }
                     drv_info->chl2_cfg->rx_cfg->rb = NULL;
                     if (drv_info->chl2_cfg->rx_cfg->buff_addr)
                         i2s_driver_mem_free(drv_info->chl2_cfg->rx_cfg->buff_addr);
@@ -2172,11 +2186,11 @@ bk_err_t bk_i2s_chl_deinit(i2s_channel_id_t chl, i2s_txrx_type_t type)
                     drv_info->chl2_cfg->rx_cfg = NULL;
                 }
             }
-            if (drv_info->chl2_cfg->tx_cfg == NULL && drv_info->chl2_cfg->rx_cfg == NULL) {
-                if (drv_info->chl2_cfg) {
-                    i2s_driver_mem_free(drv_info->chl2_cfg);
-                    drv_info->chl2_cfg = NULL;
-                }
+            if (drv_info->chl2_cfg &&
+                drv_info->chl2_cfg->tx_cfg == NULL &&
+                drv_info->chl2_cfg->rx_cfg == NULL) {
+                i2s_driver_mem_free(drv_info->chl2_cfg);
+                drv_info->chl2_cfg = NULL;
             }
             break;
 
@@ -2187,9 +2201,10 @@ bk_err_t bk_i2s_chl_deinit(i2s_channel_id_t chl, i2s_txrx_type_t type)
                     bk_dma_deinit(drv_info->chl3_cfg->tx_cfg->dma_id);
                     bk_dma_free(DMA_DEV_I2S, drv_info->chl3_cfg->tx_cfg->dma_id);
 
-                    ring_buffer_clear(drv_info->chl3_cfg->tx_cfg->rb);
-                    if (drv_info->chl3_cfg->tx_cfg->rb)
+                    if (drv_info->chl3_cfg->tx_cfg->rb) {
+                        ring_buffer_clear(drv_info->chl3_cfg->tx_cfg->rb);
                         i2s_driver_mem_free(drv_info->chl3_cfg->tx_cfg->rb);
+                    }
                     drv_info->chl3_cfg->tx_cfg->rb = NULL;
                     if (drv_info->chl3_cfg->tx_cfg->buff_addr)
                         i2s_driver_mem_free(drv_info->chl3_cfg->tx_cfg->buff_addr);
@@ -2208,9 +2223,10 @@ bk_err_t bk_i2s_chl_deinit(i2s_channel_id_t chl, i2s_txrx_type_t type)
                     bk_dma_deinit(drv_info->chl3_cfg->rx_cfg->dma_id);
                     bk_dma_free(DMA_DEV_I2S, drv_info->chl3_cfg->rx_cfg->dma_id);
 
-                    ring_buffer_clear(drv_info->chl3_cfg->rx_cfg->rb);
-                    if (drv_info->chl3_cfg->rx_cfg->rb)
+                    if (drv_info->chl3_cfg->rx_cfg->rb) {
+                        ring_buffer_clear(drv_info->chl3_cfg->rx_cfg->rb);
                         i2s_driver_mem_free(drv_info->chl3_cfg->rx_cfg->rb);
+                    }
                     drv_info->chl3_cfg->rx_cfg->rb = NULL;
                     if (drv_info->chl3_cfg->rx_cfg->buff_addr)
                         i2s_driver_mem_free(drv_info->chl3_cfg->rx_cfg->buff_addr);
@@ -2224,11 +2240,11 @@ bk_err_t bk_i2s_chl_deinit(i2s_channel_id_t chl, i2s_txrx_type_t type)
                     drv_info->chl3_cfg->rx_cfg = NULL;
                 }
             }
-            if (drv_info->chl3_cfg->tx_cfg == NULL && drv_info->chl3_cfg->rx_cfg == NULL) {
-                if (drv_info->chl3_cfg) {
-                    i2s_driver_mem_free(drv_info->chl3_cfg);
-                    drv_info->chl3_cfg = NULL;
-                }
+            if (drv_info->chl3_cfg &&
+                drv_info->chl3_cfg->tx_cfg == NULL &&
+                drv_info->chl3_cfg->rx_cfg == NULL) {
+                i2s_driver_mem_free(drv_info->chl3_cfg);
+                drv_info->chl3_cfg = NULL;
             }
             break;
 

--- a/os/board/bk7239n/src/middleware/driver/io_matrix/v2.0/io_matrix_driver.c
+++ b/os/board/bk7239n/src/middleware/driver/io_matrix/v2.0/io_matrix_driver.c
@@ -151,7 +151,9 @@ bk_err_t bk_iomx_set_gpio_func(uint32_t gpio_id, IOMX_CODE_T func_code)
 
 void bk_iomx_set_value(gpio_id_t id, uint32_t v)
 {
-	IOMX_RETURN_ON_INVALID_ID(id);
+	if (id >= SOC_GPIO_NUM) {
+		return;
+	}
 	iomx_hal_set_value(id, v);
 }
 

--- a/os/board/bk7239n/src/middleware/driver/psram/psram_driver.c
+++ b/os/board/bk7239n/src/middleware/driver/psram/psram_driver.c
@@ -246,14 +246,7 @@ __FLASH_BOOT_CODE bk_err_t bk_psram_init(void)
 	//PSRAM_LOGI("chip_version:%d\r\n", chip_version);
 
 	// psram voltage sel
-	if (chip_version == CHIP_VERSION_D)
-	{
-		bk_psram_set_voltage(PSRAM_OUT_1_90V);
-	}
-	else
-	{
-		bk_psram_set_voltage(PSRAM_OUT_1_90V);
-	}
+	bk_psram_set_voltage(PSRAM_OUT_1_90V);
 
 	// power up and clk config
 	psram_hal_power_clk_enable(1);
@@ -472,8 +465,9 @@ bk_err_t bk_psram_memread(uint8_t *start_addr, uint8_t *data_buf, uint32_t len)
 			}
 			len = 0;
 		} else {
-			*(uint32_t *)(start_addr) = val;
-			*data_buf++ = val;
+			val = *((uint32_t *)(start_addr));
+			*(uint32_t *)data_buf = val;
+			data_buf += 4;
 			start_addr += 4;
 			len -= 4;
 		}

--- a/os/board/bk7239n/src/middleware/driver/saradc/adc_driver.c
+++ b/os/board/bk7239n/src/middleware/driver/saradc/adc_driver.c
@@ -756,11 +756,7 @@ bk_err_t bk_adc_channel_read(adc_chan_t chan_id, uint16_t *data, uint32_t timeou
         sum += samples[i];
     }
 
-    if ((average_sample_count - num) > 0) {
-        sum = sum / (average_sample_count - num);
-    } else {
-        sum = 0;
-    }
+    sum = sum / (average_sample_count - num);
 
     #if defined(CONFIG_SARADC_RANGE_DIVIDE)
     sum = sum >> 1;

--- a/os/board/bk7239n/src/middleware/driver/timer/timer_driver.c
+++ b/os/board/bk7239n/src/middleware/driver/timer/timer_driver.c
@@ -615,8 +615,8 @@ bk_err_t bk_timer_delay_with_callback(timer_id_t timer_id, uint64_t time_us, tim
     delta_count = timer_hal_cal_end_count(timer_id, time_us, 1, TIMER_UNIT_US);
     end_count = current_count + delta_count;
 
-    if(end_count > 0xFFFFFFFFFFFFFFFF){
-        end_count = 0xFFFFFFFFFFFFFFFF;
+    if (end_count > UINT32_MAX) {
+        end_count = UINT32_MAX;
     }
 
     timer_ll_set_end_count(s_timer.hal.hw, timer_id, (uint32_t)end_count);

--- a/os/board/bk7239n/src/middleware/soc/bk7239n/hal/adc_hal.c
+++ b/os/board/bk7239n/src/middleware/soc/bk7239n/hal/adc_hal.c
@@ -432,9 +432,6 @@ uint32_t adc_hal_get_mode(adc_hal_t *hal)
 
 	if (adc_mode == 1) {
 		return ADC_CONTINUOUS_MODE;
-	} else if (adc_mode == 0) {
-		return ADC_SINGLE_STEP_MODE;
-	} else {
-		return ADC_CONTINUOUS_MODE;
 	}
+	return ADC_SINGLE_STEP_MODE;
 }

--- a/os/se/armino/security_armino_wrapper_tz.c
+++ b/os/se/armino/security_armino_wrapper_tz.c
@@ -72,7 +72,7 @@ static void print_hex(char *name, uint8_t *data, uint32_t len) {
     }
     sevdbg("%s len %d\r\n", name, len);
     for (size_t i = 0; i < len; i++) {
-        sprintf(s_hex_buff + (2 * i), "%02x", data[i]);
+        snprintf(s_hex_buff + (2 * i), sizeof(s_hex_buff) - (2 * i), "%02x", data[i]);
     }
     s_hex_buff[len * 2] = 0;
     sevdbg("%s\n", s_hex_buff);
@@ -858,8 +858,8 @@ int armino_hal_set_key(hal_key_type mode, uint32_t key_idx, hal_data *key, hal_d
 
     // Create and initialize key attributes
     psa_key_attributes_t attributes = psa_key_attributes_init();
-    psa_status_t status;
-    psa_key_id_t imported_key_id;
+    psa_status_t status = PSA_ERROR_GENERIC_ERROR;
+    psa_key_id_t imported_key_id = 0;
     hal_data pubkey, prikey_der;
     int ret;
 
@@ -1044,20 +1044,6 @@ int armino_hal_set_key(hal_key_type mode, uint32_t key_idx, hal_data *key, hal_d
                 psa_reset_key_attributes(&attributes);
                 return HAL_INVALID_ARGS;
             }
-            break;
-        case HAL_KEY_ECC_25519:
-            psa_set_key_type(&attributes, PSA_KEY_TYPE_ECC_PUBLIC_KEY(PSA_ECC_FAMILY_MONTGOMERY));
-            psa_set_key_bits(&attributes, 255);
-            psa_set_key_usage_flags(&attributes, PSA_KEY_USAGE_DERIVE);
-            psa_set_key_algorithm(&attributes, PSA_ALG_ECDH);
-            // Import the key
-            status = psa_import_key(&attributes, key->data, key->data_len, &imported_key_id);
-            break;
-        case HAL_KEY_ED_25519:
-            // psa_set_key_type(&attributes, PSA_KEY_TYPE_ECC_PUBLIC_KEY(PSA_ECC_FAMILY_EDWARDS));
-            // psa_set_key_bits(&attributes, 255);
-            // psa_set_key_usage_flags(&attributes, PSA_KEY_USAGE_VERIFY_MESSAGE);
-            // psa_set_key_algorithm(&attributes, PSA_ALG_ED25519);
             break;
         case HAL_KEY_HMAC_MD5:
         case HAL_KEY_HMAC_SHA1:
@@ -1269,7 +1255,7 @@ int armino_hal_remove_key(hal_key_type mode, uint32_t key_idx)
 int armino_hal_generate_key(hal_key_type mode, uint32_t key_idx)
 {
     HWRAP_ENTER;
-    psa_status_t status;
+    psa_status_t status = PSA_ERROR_GENERIC_ERROR;
 
     if((armino_index_chk(key_idx)) != HAL_SUCCESS){
         return HAL_INVALID_SLOT_RANGE;
@@ -1376,12 +1362,6 @@ int armino_hal_generate_key(hal_key_type mode, uint32_t key_idx)
             psa_set_key_usage_flags(&attributes, PSA_KEY_USAGE_SIGN_HASH | PSA_KEY_USAGE_VERIFY_HASH | PSA_KEY_USAGE_DERIVE | PSA_KEY_USAGE_EXPORT);
             psa_set_key_algorithm(&attributes, PSA_ALG_ECDSA(PSA_ALG_SHA_512));
             break;
-        case HAL_KEY_ECC_25519:
-            psa_set_key_type(&attributes, PSA_KEY_TYPE_ECC_KEY_PAIR(PSA_ECC_FAMILY_MONTGOMERY));
-            psa_set_key_bits(&attributes, 255);
-            psa_set_key_usage_flags(&attributes, PSA_KEY_USAGE_DERIVE);
-            psa_set_key_algorithm(&attributes, PSA_ALG_ECDH);
-            break;
         case HAL_KEY_HMAC_MD5:
             psa_set_key_type(&attributes, PSA_KEY_TYPE_HMAC);
             psa_set_key_bits(&attributes, 128);
@@ -1443,7 +1423,7 @@ int armino_hal_generate_key(hal_key_type mode, uint32_t key_idx)
     }
 
     // Generate the key
-    psa_key_id_t generated_key_id;
+    psa_key_id_t generated_key_id = 0;
     status = psa_generate_key(&attributes, &generated_key_id);
     psa_reset_key_attributes(&attributes);
     if (status != PSA_SUCCESS) {
@@ -2085,7 +2065,7 @@ int armino_hal_dh_generate_param(uint32_t dh_idx, hal_dh_data *dh_param)
     }
 
     size_t key_bytes = 0;
-    psa_key_id_t key_id;
+    psa_key_id_t key_id = 0;
 
     switch(dh_param->mode) {
         case HAL_DH_1024:


### PR DESCRIPTION
Fix categories:

1. Unreachable code / invariant results (UNREACHABLE_CODE, INVARIANT_RESULT)
Remove or rewrite branches and comparisons that are always true/false under static analysis.
Examples: `bk_printf` log level vs `BK_LOG_*`; `adc_driver` / `adc_hal` averaging and 1-bit mode register; `timer_driver` `end_count` vs `UINT32_MAX`; `armino_watchdog` dead `delay_ms == 0` guard; `ef_env` missing `create_env_blob` assignment; dead paths in `bk_pm` / `bk_pm_power`.

2. Out-of-bounds access / bad indices (BUFFER_OVERFLOW, array index)
Correct range checks before table/array access (e.g. drop `>= 0` on unsigned IDs, use `< MAX`, fix off-by-one).
Examples: `gpio_driver`, `flash_partition`, `dma_driver` (logical channel vs HAL `dma_channel`), `bk_pm_sleep` low-voltage callback `dev_id` bounds.

3. Uninitialized data / logic errors (UNINIT.LOCAL_VAR, real bugs)
Fix use of uninitialized locals and copy-paste logic errors.
Example: `bk_psram_memread()` word path (was using uninitialized `val` and wrong read/write direction).

4. Null pointer risks (DEREF_AFTER_NULL)
Add NULL checks before dereference on reported paths.
Example: `i2s_driver` channel deinit, `ring_buffer_clear` only when buffer is non-NULL.

5. Invalid arithmetic (DIVISION_BY_ZERO, meaningless unsigned compares)
Guard divisors (`sample_rate`, `smp_ratio`, etc.); remove invalid checks such as `exit_tick - entry_tick < 0` on `uint64_t` where applicable in PM/sleep code.

6. Lifetime and return misuse (RETURN_LOCAL_ADDR, UNUSED_RETURN_VALUE)
`ef_env`: `env` at function scope in `del_env()` to avoid returning stack address.
`io_matrix`: early `return` in `void` `bk_iomx_set_value()` instead of returning an error code.
`volt_detect`: explicit `return` on failure in `void` API (no `BK_RETURN_ON_ERR`).
`armino_i2c`: check `bk_err_t` from `bk_i2c_master_*` instead of an unused `ret`.

7. Redundant branches (SIMILAR_BRANCHES)
Collapse identical branches with no behavior change.
Example: `psram_driver` voltage selection (same voltage for all chip revisions).