### PR TITLE
os/board/bk7239n:Svace fix issue for bk239n related to Wi-Fi part

### DIFF
--- a/os/board/bk7239n/src/bsp_adapter/src/net/bk_netmgr.c
+++ b/os/board/bk7239n/src/bsp_adapter/src/net/bk_netmgr.c
@@ -910,19 +910,26 @@ int bk_wifi_softap_init(trwifi_softap_config_s *softap_config)
 			security_type = WIFI_SECURITY_NONE;
 			break;
 		case TRWIFI_AUTH_WPA2_PSK:
-			if(softap_config->ap_crypto_type == TRWIFI_CRYPTO_AES) {
+			if (softap_config->ap_crypto_type == TRWIFI_CRYPTO_AES) {
 				security_type = WIFI_SECURITY_WPA2_AES;
 				os_memcpy(ap_config.password, softap_config->passphrase, softap_config->passphrase_length);
 				break;
 			}
+			ndbg("[BK] AP AUTH type or CRYPTO type is not support (%d, %d)\r\n",
+			     softap_config->ap_auth_type, softap_config->ap_crypto_type);
+			return TRWIFI_INVALID_ARGS;
 		case TRWIFI_AUTH_WPA2_AND_WPA3_PSK:
-			if(softap_config->ap_crypto_type == TRWIFI_CRYPTO_AES) {
+			if (softap_config->ap_crypto_type == TRWIFI_CRYPTO_AES) {
 				security_type = WIFI_SECURITY_WPA3_WPA2_MIXED;
 				os_memcpy(ap_config.password, softap_config->passphrase, softap_config->passphrase_length);
 				break;
 			}
+			ndbg("[BK] AP AUTH type or CRYPTO type is not support (%d, %d)\r\n",
+			     softap_config->ap_auth_type, softap_config->ap_crypto_type);
+			return TRWIFI_INVALID_ARGS;
 		case TRWIFI_AUTH_UNKNOWN:
 			ndbg("[BK] AP AUTH type is unknown %d\r\n", softap_config->ap_auth_type);
+			/* fall through */
 		default:
 			ndbg("[BK] AP AUTH type or CRYPTO type is not support (%d, %d)\r\n", softap_config->ap_auth_type, softap_config->ap_crypto_type);
 			return TRWIFI_INVALID_ARGS;
@@ -1208,7 +1215,7 @@ trwifi_result_e bk_wifi_netmgr_scan_multi_ap(struct netdev *dev, trwifi_scan_mul
 
 		for (i = 0; i < config->scan_ap_config_count; i++) {
 			g_saved_multi_scan_list[i].is_valid = true;
-			if ((config->scan_ap_config[i].ssid_length == 0) || !config->scan_ap_config[i].ssid) {
+			if (config->scan_ap_config[i].ssid_length == 0) {
 				continue;
 			}
 

--- a/os/board/bk7239n/src/components/bk_event/event.c
+++ b/os/board/bk7239n/src/components/bk_event/event.c
@@ -439,8 +439,13 @@ static void event_task(beken_thread_arg_t arg)
 	while (1) {
 		rtos_pop_from_queue(&s_event_queue, &msg, BEKEN_WAIT_FOREVER);
 
-		if (msg && msg->msg_type == EVENT_MSG_DEINIT)
+		if (!msg) {
+			continue;
+		}
+
+		if (msg->msg_type == EVENT_MSG_DEINIT) {
 			break;
+		}
 
 		event_ret = event_task_handle_msg(msg);
 

--- a/os/board/bk7239n/src/components/bk_wifi/include/bk_private/bk_wifi_types.h
+++ b/os/board/bk7239n/src/components/bk_wifi/include/bk_private/bk_wifi_types.h
@@ -1225,7 +1225,7 @@ typedef struct
  */
 typedef  struct  _ScanResult
 {
-	char ApNum;       /**< The number of access points found in scanning. */
+	uint8_t ApNum;    /**< The number of access points found in scanning. */
 	struct _ApList
 	{
 		char ssid[33];  /**< The SSID of an access point. */
@@ -1238,7 +1238,7 @@ typedef  struct  _ScanResult
  */
 typedef  struct  _ScanResult_adv
 {
-	char ApNum;       /**< The number of access points found in scanning.*/
+	uint8_t ApNum;    /**< The number of access points found in scanning.*/
 	struct ApListStruct
 	{
 		char ssid[33];    /**< The SSID of an access point.*/
@@ -1275,7 +1275,7 @@ typedef struct sta_scan_res
  */
 typedef struct _network_InitTypeDef_st
 {
-	char wifi_mode;               /**< WiFi mode, BK_SOFT_AP or BK_STATION */
+	uint8_t wifi_mode;            /**< WiFi mode, BK_SOFT_AP or BK_STATION */
 	char wifi_ssid[33];           /**< For station, it's SSID of the AP to be connected, for AP, it's the SSID of our AP */
 	char wifi_key[65];            /**< Security key of the wlan needs to be connected, ignored in an open system.*/
 	char local_ip_addr[16];       /**< Static IP configuration, Local IP address. */

--- a/os/board/bk7239n/src/components/bk_wifi/src/bk_wifi_adapter.c
+++ b/os/board/bk7239n/src/components/bk_wifi/src/bk_wifi_adapter.c
@@ -203,15 +203,8 @@ int bk_net_wlan_remove_netif_wrapper(void *mac)
 //extern uint8_t* dhcp_lookup_mac(uint8_t *chaddr);
 uint32_t bk_lookup_ipaddr_wrapper(void *addr)
 {
-	char *ipstr;
-
-	ipstr = NULL; //(char *)dhcp_lookup_mac(addr);
-	if (ipstr) {
-		ip_addr_t ipaddr,*ptr;
-		ptr = &ipaddr;
-		ipaddr_aton(ipstr, ptr);
-		return ip_addr_get_ip4_u32(ptr);
-	}
+	(void)addr;
+	/* dhcp_lookup_mac() not enabled */
 	return 0;
 }
 
@@ -2176,8 +2169,8 @@ int bk_wifi_set_pwr_limit(wifi_tx_pwr_lmt_t *tx_pwr_lmt)
         if((reg == regulation)&&(rs == ratesection)&&(chnl ==channel))
         {
             array[i+6] = value;
+            flag = 1;
         }
-        flag = 1;
     }
     if(!flag)
     	return -1;

--- a/os/board/bk7239n/src/components/bk_wifi/src/hostapd_intf.c
+++ b/os/board/bk7239n/src/components/bk_wifi/src/hostapd_intf.c
@@ -116,9 +116,6 @@ struct mm_bcn_change_req *hadp_intf_get_bcn_change_req(uint8_t vif_id, struct be
 	return req;
 
 exit_get_failed:
-	if (req)
-		os_free(req);
-
 	if (beacon_ptr)
 		os_free(beacon_ptr);
 
@@ -424,7 +421,7 @@ int hapd_intf_del_key(struct prism2_hostapd_param *param, int len)
 {
 	u8 hw_key_idx = 0;
 
-	if ((param->sta_addr == NULL) || is_broadcast_ether_addr(param->sta_addr))
+	if (is_broadcast_ether_addr(param->sta_addr))
 		hw_key_idx = rwm_mgmt_get_hwkeyidx(param->vif_idx, 0xff);
 	else {
 		u8 staid = rwm_mgmt_sta_mac2idx(param->sta_addr);

--- a/os/board/bk7239n/src/components/bk_wifi/src/reg.c
+++ b/os/board/bk7239n/src/components/bk_wifi/src/reg.c
@@ -838,36 +838,45 @@ unsigned int reg_get_max_bandwidth(const struct ieee80211_regdomain *rd,
 	return bw;
 }
 
+static void regdom_append_flag(char *buf, size_t buf_len, const char *flag)
+{
+	size_t len = os_strlen(buf);
+
+	if (len >= buf_len)
+		return;
+	os_snprintf(buf + len, buf_len - len, "%s", flag);
+}
+
 const char *regdom_flag_str(uint32_t channel_flags)
 {
 	static char regd_flags_buf[128];
-	regd_flags_buf[0] = 0;
+	regd_flags_buf[0] = '\0';
 	if (channel_flags & IEEE80211_CHAN_DISABLED)
-		strcat(regd_flags_buf, "DISABLED,");
+		regdom_append_flag(regd_flags_buf, sizeof(regd_flags_buf), "DISABLED,");
 	if (channel_flags & IEEE80211_CHAN_NO_IR)
-		strcat(regd_flags_buf, "NO_IR,");
+		regdom_append_flag(regd_flags_buf, sizeof(regd_flags_buf), "NO_IR,");
 	if (channel_flags & IEEE80211_CHAN_RADAR)
-		strcat(regd_flags_buf, "RADAR,");
+		regdom_append_flag(regd_flags_buf, sizeof(regd_flags_buf), "RADAR,");
 	if (channel_flags & IEEE80211_CHAN_NO_HT40PLUS)
-		strcat(regd_flags_buf, "NO_HT40PLUS,");
+		regdom_append_flag(regd_flags_buf, sizeof(regd_flags_buf), "NO_HT40PLUS,");
 	if (channel_flags & IEEE80211_CHAN_NO_HT40MINUS)
-		strcat(regd_flags_buf, "NO_HT40MINUS,");
+		regdom_append_flag(regd_flags_buf, sizeof(regd_flags_buf), "NO_HT40MINUS,");
 	if (channel_flags & IEEE80211_CHAN_NO_OFDM)
-		strcat(regd_flags_buf, "NO_OFDM,");
+		regdom_append_flag(regd_flags_buf, sizeof(regd_flags_buf), "NO_OFDM,");
 	if (channel_flags & IEEE80211_CHAN_NO_80MHZ)
-		strcat(regd_flags_buf, "NO_80M,");
+		regdom_append_flag(regd_flags_buf, sizeof(regd_flags_buf), "NO_80M,");
 	if (channel_flags & IEEE80211_CHAN_NO_160MHZ)
-		strcat(regd_flags_buf, "NO_160M,");
+		regdom_append_flag(regd_flags_buf, sizeof(regd_flags_buf), "NO_160M,");
 	if (channel_flags & IEEE80211_CHAN_INDOOR_ONLY)
-		strcat(regd_flags_buf, "INDOOR,");
+		regdom_append_flag(regd_flags_buf, sizeof(regd_flags_buf), "INDOOR,");
 	if (channel_flags & IEEE80211_CHAN_IR_CONCURRENT)
-		strcat(regd_flags_buf, "IR_CON,");
+		regdom_append_flag(regd_flags_buf, sizeof(regd_flags_buf), "IR_CON,");
 	if (channel_flags & IEEE80211_CHAN_NO_20MHZ)
-		strcat(regd_flags_buf, "NO_20M,");
+		regdom_append_flag(regd_flags_buf, sizeof(regd_flags_buf), "NO_20M,");
 	if (channel_flags & IEEE80211_CHAN_NO_10MHZ)
-		strcat(regd_flags_buf, "NO_10M,");
+		regdom_append_flag(regd_flags_buf, sizeof(regd_flags_buf), "NO_10M,");
 	if (channel_flags & IEEE80211_CHAN_NO_HE)
-		strcat(regd_flags_buf, "NO_HE,");
+		regdom_append_flag(regd_flags_buf, sizeof(regd_flags_buf), "NO_HE,");
 
 	return regd_flags_buf;
 }

--- a/os/board/bk7239n/src/components/bk_wifi/src/rw_ieee80211.c
+++ b/os/board/bk7239n/src/components/bk_wifi/src/rw_ieee80211.c
@@ -611,17 +611,17 @@ void rwnx_hw_reinit(void)
 
 	memset(rwnx_hw, 0, sizeof(*rwnx_hw));
 
-	if(txq_temp == NULL){
-		rwnx_hw->txq = os_zalloc(NX_NB_TXQ*sizeof(struct rwnx_txq));
-		if(rwnx_hw->txq == NULL){
+	if (txq_temp == NULL) {
+		rwnx_hw->txq = os_zalloc(NX_NB_TXQ * sizeof(struct rwnx_txq));
+		if (rwnx_hw->txq == NULL) {
 			BK_ASSERT(0);
+			return;
 		}
-	}
-	else{
+	} else {
 		rwnx_hw->txq = txq_temp;
 	}
 
-	memset(rwnx_hw->txq, 0, (NX_NB_TXQ*sizeof(struct rwnx_txq)));
+	memset(rwnx_hw->txq, 0, (NX_NB_TXQ * sizeof(struct rwnx_txq)));
 
 }
 
@@ -860,15 +860,12 @@ int rw_ieee80211_set_country(const wifi_country_t *country)
 	}
 
 	// Validate country code format (should be 2-character string)
-	if (!country->cc) {
+	if (country->cc[0] == '\0') {
 		RWNX_LOGW("set_country: cc is null\r\n");
 		return BK_ERR_NULL_PARAM;
 	}
 #if CONFIG_WIFI_REGDOMAIN
 	char alpha2[4] = {0};
-
-	if (!country)
-		return BK_ERR_NULL_PARAM;
 
 	alpha2[0] = country->cc[0];
 	alpha2[1] = country->cc[1];

--- a/os/board/bk7239n/src/components/bk_wifi/src/rw_msg_rx.c
+++ b/os/board/bk7239n/src/components/bk_wifi/src/rw_msg_rx.c
@@ -1488,7 +1488,7 @@ void rwm_msdu_twt_ps_change_ind_handler(void *msg)
 	struct ke_msg *msg_ptr = (struct ke_msg *)msg;
 	struct mm_twt_ps_change_ind *ind;
 
-	if(!msg_ptr || !msg_ptr->param)
+	if (!msg_ptr || msg_ptr->param_len == 0)
 		return;
 
 	ind = (struct mm_twt_ps_change_ind *)msg_ptr->param;

--- a/os/board/bk7239n/src/components/bk_wifi/src/rw_msg_tx.c
+++ b/os/board/bk7239n/src/components/bk_wifi/src/rw_msg_tx.c
@@ -651,7 +651,9 @@ int rw_msg_send_twt_teardown(uint8_t vif_idx, uint8_t flow_id)
 	struct twt_teardown_cfm twt_teardown_cfm;
 
 	twt_teardown = ke_msg_alloc(TWT_TEARDOWN_REQ, TASK_TWT, TASK_API,
-								sizeof(struct twt_teardown_req));
+							sizeof(struct twt_teardown_req));
+	if (!twt_teardown)
+		return -1;
 
 	twt_teardown->id = flow_id;
 	twt_teardown->neg_type = 0; // XXX MAC_TWT_CTRL_NEGOT_INDIV;
@@ -1281,7 +1283,9 @@ int rw_msg_send_scanu_fast_req(FAST_SCAN_PARAM_T *fscan_param)
 
 	/* Build the SCANU_START_REQ message */
 	req = ke_msg_alloc(SCANU_FAST_REQ, TASK_SCANU, TASK_API,
-					   sizeof(struct scanu_fast_req));
+				   sizeof(struct scanu_fast_req));
+	if (!req)
+		return -1;
 
 	req->bssid = fscan_param->bssid;
 	req->ch_nbr = fscan_param->ch_num;
@@ -1297,6 +1301,9 @@ int rw_msg_send_connection_loss_ind(u8 vif_index)
 {
 	struct mm_connection_loss_ind *ind = ke_msg_alloc(MM_CONNECTION_LOSS_IND,
 										 TASK_SM, TASK_API, sizeof(struct mm_connection_loss_ind));
+
+	if (!ind)
+		return -1;
 
 	// Fill-in the indication message parameters
 	ind->inst_nbr = vif_index;

--- a/os/board/bk7239n/src/components/bk_wifi/src/rwnx_rx.c
+++ b/os/board/bk7239n/src/components/bk_wifi/src/rwnx_rx.c
@@ -181,6 +181,7 @@ __IRAM2 void rwm_check_rx_header_pattern(void *host_id)
 	{
 		RWNX_LOGE("host_id is NULL\n");
 		BK_ASSERT(0);
+		return;
 	}
 
 	p = (struct pbuf *)host_id;
@@ -194,6 +195,7 @@ __IRAM2 void rwm_check_rx_header_pattern(void *host_id)
 	{
 		RWNX_LOGE("rxhdr is NULL\n");
 		BK_ASSERT(0);
+		return;
 	}
 
 	if (rxhdr->pattern != DMA_HD_RXPATTERN)
@@ -552,9 +554,10 @@ void rwnx_upload_amsdu(struct fhost_rx_header *rxhdr)
 	iface = rxhdr->flags_vif_idx;
 
 	// upload the other sub-MSDUs of A-MSDU
-	q = (struct pbuf *)(amsdu_hostids[i]);
-
-	while (q && i < NX_MAX_MSDU_PER_RX_AMSDU) {
+	while (i < NX_MAX_MSDU_PER_RX_AMSDU) {
+		q = (struct pbuf *)(amsdu_hostids[i]);
+		if (!q)
+			break;
 #if BK_SS_WIFI_DP
 		uint32_t rxhdr_addr = (*((uint32_t*)q->payload));
 		pbuf_header(q, -(s16)macif_get_rxl_payload_offset());
@@ -568,8 +571,7 @@ void rwnx_upload_amsdu(struct fhost_rx_header *rxhdr)
 #if BK_SS_WIFI_DP
 		if(i != 0) os_free((void *)rxhdr_addr);
 #endif
-		/* get the next sub-MSDU */
-		q = (struct pbuf *)(amsdu_hostids[++i]);
+		i++;
 	}
 }
 

--- a/os/board/bk7239n/src/components/bk_wifi/src/rwnx_tx.c
+++ b/os/board/bk7239n/src/components/bk_wifi/src/rwnx_tx.c
@@ -109,11 +109,6 @@ __IRAM2 static bool rwnx_need_retry_tx_frame(struct sk_buff *skb)
 	struct txdesc *txdesc = &skb->ftxdesc->txdesc;
 
 	switch (PP_NTOHS(txdesc->host.ethertype)) {
-	//case ETH_P_ARP:
-		// Don't retry send special frame that doesn't open TD window
-		if (txdesc->host.flags & TXU_CNTRL_IS_SPECIAL_FRAME)
-			return false;
-		return true;
 	case ETH_P_EAPOL:
 	//case ETH_P_RARP:
 		return true;
@@ -137,13 +132,18 @@ __IRAM2 static inline struct pbuf *macif_get_txdesc_pbuf(struct txdesc *txdesc)
 __IRAM2 static void rwnx_tx_confirm(void *param)
 {
 	struct txdesc *txdesc = (struct txdesc *)param;
+	struct sk_buff *skb;
+
+	if (!txdesc)
+		return;
+
 #if NX_VERSION >= NX_VERSION_PACK(6, 22, 0, 0)
-	struct sk_buff *skb = txdesc->host.hostid;
+	skb = txdesc->host.hostid;
 #else
-	struct sk_buff *skb = txdesc->host.buf;
+	skb = txdesc->host.buf;
 #endif
 
-	if (txdesc && skb) {
+	if (skb) {
 		struct fhost_tx_desc_tag *fhost_txdesc =
 				container_of(txdesc, struct fhost_tx_desc_tag, txdesc);
 		//struct tx_cfm_tag *cfm = txl_cfm_tag_get(txdesc);
@@ -674,7 +674,7 @@ void rwnx_start_xmit_mgmt(struct sk_buff *skb)
 	//	sizeof(*fhost_txdesc), sizeof(*txdesc));
 
 	// sanity check
-	if (skb->vif_idx == INVALID_VIF_IDX)
+	if (!skb || skb->vif_idx == INVALID_VIF_IDX)
 		goto tx_exit;
 
 	if (more_pbuf)
@@ -774,7 +774,7 @@ void rwnx_start_xmit_raw_ex(struct sk_buff *skb, raw_tx_cntrl_t *raw_tx_cntrl)
 	bk_wifi_get_tx_raw_timeout(&raw_timeout);
 
 	// sanity check
-	if (skb->vif_idx == INVALID_VIF_IDX)
+	if (!skb || skb->vif_idx == INVALID_VIF_IDX)
 		goto tx_exit;
 
 	if (more_pbuf)

--- a/os/board/bk7239n/src/components/bk_wifi/src/sa_station.c
+++ b/os/board/bk7239n/src/components/bk_wifi/src/sa_station.c
@@ -162,8 +162,11 @@ void sa_reconnect_main(void *arg)
 
 void sa_reconnect_init(void)
 {
+	/* reconnect thread disabled */
+	return;
+#if 0
 	bk_err_t ret;
-	return; // try it;
+
 	if (NULL == reconnect_thread_handle) {
 		ret = rtos_create_thread(&reconnect_thread_handle,
 								 CONFIG_TASK_RECONNECT_PRIO,
@@ -172,8 +175,10 @@ void sa_reconnect_init(void)
 								 (unsigned short)reconnect_stack_size,
 								 (beken_thread_arg_t)0);
 		BK_ASSERT(kNoErr == ret); /* ASSERT VERIFIED */
-	} else
+	} else {
 		WIFI_LOGI("sa_reconnect_init_strange\r\n");
+	}
+#endif
 }
 #endif
 

--- a/os/board/bk7239n/src/components/bk_wifi/src/wifi_api.c
+++ b/os/board/bk7239n/src/components/bk_wifi/src/wifi_api.c
@@ -200,7 +200,7 @@ void demo_sta_bssid_app_init(uint8_t *oob_bssid, char *connect_key)
 
 	os_memset(sta_config.ssid, 0, sizeof(sta_config.ssid));
 	os_memcpy(sta_config.bssid, oob_bssid, 6);
-	os_strcpy(sta_config.password, connect_key);
+	os_strlcpy(sta_config.password, connect_key, sizeof(sta_config.password));
 
 	BK_WIFI_LOGI(TAG, "Scan specified BSSID %pm\r\n", sta_config.bssid);
 	BK_LOG_ON_ERR(bk_wifi_sta_set_config(&sta_config));
@@ -228,9 +228,9 @@ int demo_sta_app_init(char *oob_ssid, char *connect_key)
 		os_strlcpy((char *)sta_config.psk, (char *)psk, sizeof(sta_config.psk));
 	}
 #endif
-	os_strcpy(sta_config.ssid, oob_ssid);
+	os_strlcpy(sta_config.ssid, oob_ssid, sizeof(sta_config.ssid));
 	if (connect_key)
-		os_strcpy(sta_config.password, connect_key);
+		os_strlcpy(sta_config.password, connect_key, sizeof(sta_config.password));
 
 	BK_WIFI_LOGI(TAG, "ssid:%s key:%s\r\n", sta_config.ssid, sta_config.password);
 	BK_LOG_ON_ERR(bk_wifi_sta_set_config(&sta_config));
@@ -249,8 +249,8 @@ void demo_sta_adv_app_init(char *oob_ssid, char *connect_key)
 		return;
 	}
 
-	os_strcpy(sta_config.ssid, oob_ssid);
-	os_strcpy(sta_config.password, connect_key);
+	os_strlcpy(sta_config.ssid, oob_ssid, sizeof(sta_config.ssid));
+	os_strlcpy(sta_config.password, connect_key, sizeof(sta_config.password));
 
 	//TODO should NOT use hard-coded BSSID and channel
 	hwaddr_aton("48:ee:0c:48:93:12", (u8 *)sta_config.bssid);

--- a/os/board/bk7239n/src/components/bk_wifi/src/wifi_v2.c
+++ b/os/board/bk7239n/src/components/bk_wifi/src/wifi_v2.c
@@ -364,7 +364,8 @@ void bk_wlan_ap_init(network_InitTypeDef_st *inNetworkInitPara)
 	if (inNetworkInitPara) {
 		g_ap_param_ptr->ssid.length = MIN(SSID_MAX_LEN, os_strlen(inNetworkInitPara->wifi_ssid));
 		os_memcpy(g_ap_param_ptr->ssid.array, inNetworkInitPara->wifi_ssid, g_ap_param_ptr->ssid.length);
-		g_ap_param_ptr->key_len = os_strlen(inNetworkInitPara->wifi_key);
+		g_ap_param_ptr->key_len = MIN(sizeof(g_ap_param_ptr->key) - 1,
+					      os_strlen(inNetworkInitPara->wifi_key));
 		g_ap_param_ptr->hidden_ssid = inNetworkInitPara->hidden_ssid;
 		if (g_ap_param_ptr->key_len < 8)
 			g_ap_param_ptr->cipher_suite = BK_SECURITY_TYPE_NONE;
@@ -375,6 +376,7 @@ void bk_wlan_ap_init(network_InitTypeDef_st *inNetworkInitPara)
 			g_ap_param_ptr->cipher_suite = BK_SECURITY_TYPE_WPA2_AES;
 #endif
 			os_memcpy(g_ap_param_ptr->key, inNetworkInitPara->wifi_key, g_ap_param_ptr->key_len);
+			g_ap_param_ptr->key[g_ap_param_ptr->key_len] = '\0';
 		}
 
 #if 0//CONFIG_LWIP
@@ -821,10 +823,10 @@ bk_err_t bk_wlan_start(network_InitTypeDef_st *inNetworkInitPara)
 		bk_wlan_start_ap(inNetworkInitPara);
 #pragma GCC diagnostic pop
 	}
-	else if (inNetworkInitPara->wifi_mode == BK_STATION)
+	else if ((unsigned char)inNetworkInitPara->wifi_mode == BK_STATION)
 		bk_wlan_start_sta(inNetworkInitPara);
 #ifdef CONFIG_P2P
-	else if (inNetworkInitPara->wifi_mode == BK_P2P)
+	else if ((unsigned char)inNetworkInitPara->wifi_mode == BK_P2P)
 		bk_wlan_start_p2p(inNetworkInitPara);
 #endif
 	return 0;
@@ -1801,7 +1803,7 @@ void wlan_read_fast_connect_info(struct wlan_fast_connect_info *fci)
 	if(g_is_get_fci_from_flash && g_is_use_fci_from_flash)
 		get_net_info(FAST_CONNECT_ITEM, (UINT8 *)fci, NULL, NULL);
 	else
-		os_memcpy((UINT8 *)fci, &g_fci, sizeof(struct wlan_fast_connect_info));
+		os_memcpy(fci, &g_fci, sizeof(g_fci));
 
 
 #if defined(CONFIG_FAST_CONNECT_INFO_ENC_METHOD) && (CONFIG_FAST_CONNECT_INFO_ENC_METHOD != ENC_METHOD_NULL)
@@ -1832,7 +1834,7 @@ void wlan_write_fast_connect_info(struct wlan_fast_connect_info *fci)
 	if(g_is_get_fci_from_flash && g_is_use_fci_from_flash)
 		save_net_info(FAST_CONNECT_ITEM, (UINT8 *)fci, NULL, NULL);
 	else
-		os_memcpy(&g_fci, (UINT8 *)fci, sizeof(struct wlan_fast_connect_info));
+		os_memcpy(&g_fci, fci, sizeof(g_fci));
 
 	WIFI_LOGD("writed fci to flash\n");
 wr_exit:
@@ -1944,8 +1946,10 @@ void bk_wlan_ap_init_adv(network_InitTypeDef_ap_st *inNetworkInitParaAP)
 
 		g_ap_param_ptr->ssid.length = MIN(SSID_MAX_LEN, os_strlen(inNetworkInitParaAP->wifi_ssid));
 		os_memcpy(g_ap_param_ptr->ssid.array, inNetworkInitParaAP->wifi_ssid, g_ap_param_ptr->ssid.length);
-		g_ap_param_ptr->key_len = os_strlen(inNetworkInitParaAP->wifi_key);
+		g_ap_param_ptr->key_len = MIN(sizeof(g_ap_param_ptr->key) - 1,
+					      os_strlen(inNetworkInitParaAP->wifi_key));
 		os_memcpy(g_ap_param_ptr->key, inNetworkInitParaAP->wifi_key, g_ap_param_ptr->key_len);
+		g_ap_param_ptr->key[g_ap_param_ptr->key_len] = '\0';
 
 		g_ap_param_ptr->cipher_suite = inNetworkInitParaAP->security;
 	}
@@ -2231,7 +2235,7 @@ bk_err_t bk_wifi_scan_start(const wifi_scan_config_t *config)
 		scan_param.scan_cc = !!(config->flag & SCAN_TYPE_CC);
 	}
 
-	if (0 == config->ssid_cnt) {
+	if (!config || config->ssid_cnt == 0) {
 		WIFI_LOGI("scan all APs\n");
 		scan_param.num_ssids = 1;
 		scan_param.ssids[0].ssid_len = 0;
@@ -2413,7 +2417,7 @@ static int wifi_sta_get_global_config(wifi_sta_config_t *sta_config)
 	if (!sta_config)
 		return BK_ERR_NULL_PARAM;
 
-	os_memset(sta_config, 0, sizeof(sta_config));
+	os_memset(sta_config, 0, sizeof(*sta_config));
 	os_memcpy(sta_config->ssid, g_sta_param_ptr->ssid.array, g_sta_param_ptr->ssid.length);
 
 #ifdef CONFIG_CONNECT_THROUGH_PSK_OR_SAE_PASSWORD
@@ -2649,7 +2653,7 @@ bk_err_t bk_wifi_sta_get_config(wifi_sta_config_t *config)
 		return BK_ERR_NULL_PARAM;
 	}
 
-	os_memset(config, 0, sizeof(config));
+	os_memset(config, 0, sizeof(*config));
 
 	if (!wifi_sta_is_configured())
 		return BK_ERR_WIFI_STA_NOT_CONFIG;
@@ -2705,7 +2709,7 @@ bk_err_t bk_wifi_sta_get_link_status(wifi_link_status_t *link_status)
 	if (!link_status)
 		return BK_ERR_NULL_PARAM;
 
-	os_memset(link_status, 0, sizeof(link_status));
+	os_memset(link_status, 0, sizeof(*link_status));
 	link_status->aid = -1;
 	link_status->rssi = -128;
 	if (!wifi_sta_is_connected()) {
@@ -3156,7 +3160,8 @@ static bk_err_t wifi_ap_set_config(const wifi_ap_config_t *ap_config)
 
 	g_ap_param_ptr->ssid.length = MIN(SSID_MAX_LEN, os_strlen(ap_config->ssid));
 	os_memcpy(g_ap_param_ptr->ssid.array, ap_config->ssid, g_ap_param_ptr->ssid.length);
-	g_ap_param_ptr->key_len = os_strlen(ap_config->password);
+	g_ap_param_ptr->key_len = MIN(sizeof(g_ap_param_ptr->key) - 1,
+				      os_strlen(ap_config->password));
 	g_ap_param_ptr->hidden_ssid = ap_config->hidden;
 	if (g_ap_param_ptr->key_len < 8) {
 		g_ap_param_ptr->cipher_suite = BK_SECURITY_TYPE_NONE;
@@ -3195,6 +3200,7 @@ static bk_err_t wifi_ap_set_config(const wifi_ap_config_t *ap_config)
 		}
 		os_memset(g_ap_param_ptr->key, 0, sizeof(g_ap_param_ptr->key));
 		os_memcpy(g_ap_param_ptr->key, ap_config->password, g_ap_param_ptr->key_len);
+		g_ap_param_ptr->key[g_ap_param_ptr->key_len] = '\0';
 	}
 #if CONFIG_AP_VSIE
 	g_ap_param_ptr->vsie_len = ap_config->vsie_len;
@@ -3315,7 +3321,7 @@ bk_err_t bk_wifi_calculate_pmk(const char *ssid, const char *pwd, char *pmk)
 	}
 
 	ret = wpas_calculate_ap_pmk(pwd, (uint8_t *)ssid, tmp_pmk);
-	sprintf(pmk, "%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x"
+	os_snprintf(pmk, 65, "%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x"
 				 "%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x"
 				 "%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x",
 		tmp_pmk[0], tmp_pmk[1], tmp_pmk[2], tmp_pmk[3], tmp_pmk[4],

--- a/os/board/bk7239n/src/components/easy_flash/easy_flash_V4.X/src/ef_env.c
+++ b/os/board/bk7239n/src/components/easy_flash/easy_flash_V4.X/src/ef_env.c
@@ -1068,6 +1068,7 @@ static EfErrCode del_env(const char *key, env_node_obj_t old_env, bool complete_
     EfErrCode result = EF_NO_ERR;
     uint32_t dirty_status_addr;
     static bool last_is_complete_del = false;
+    struct env_node_obj local_env;
 
 #if (ENV_STATUS_TABLE_SIZE >= DIRTY_STATUS_TABLE_SIZE)
     uint8_t status_table[ENV_STATUS_TABLE_SIZE];
@@ -1077,10 +1078,9 @@ static EfErrCode del_env(const char *key, env_node_obj_t old_env, bool complete_
 
     /* need find ENV */
     if (!old_env) {
-        struct env_node_obj env;
         /* find ENV */
-        if (find_env(key, &env)) {
-            old_env = &env;
+        if (find_env(key, &local_env)) {
+            old_env = &local_env;
         } else {
             EF_DEBUG("Not found '%s' in ENV.\n", key);
             return EF_ENV_NAME_ERR;
@@ -1558,7 +1558,7 @@ EfErrCode ef_env_set_default(void)
             value_len = default_env_set[i].value_len;
         }
         sector.empty_env = FAILED_ADDR;
-        create_env_blob(&sector, default_env_set[i].key, default_env_set[i].value, value_len);
+        result = create_env_blob(&sector, default_env_set[i].key, default_env_set[i].value, value_len);
         if (result != EF_NO_ERR) {
             goto __exit;
         }

--- a/os/board/bk7239n/src/components/psa_mbedtls/mbedtls/library/ctr_drbg.c
+++ b/os/board/bk7239n/src/components/psa_mbedtls/mbedtls/library/ctr_drbg.c
@@ -87,13 +87,6 @@ int mbedtls_ctr_drbg_set_nonce_len(mbedtls_ctr_drbg_context *ctx,
         return MBEDTLS_ERR_CTR_DRBG_INPUT_TOO_BIG;
     }
 
-    /* This shouldn't be an issue because
-     * MBEDTLS_CTR_DRBG_MAX_SEED_INPUT < INT_MAX in any sensible
-     * configuration, but make sure anyway. */
-    if (len > INT_MAX) {
-        return MBEDTLS_ERR_CTR_DRBG_INPUT_TOO_BIG;
-    }
-
     /* For backward compatibility with Mbed TLS <= 2.19, store the
      * entropy nonce length in a field that already exists, but isn't
      * used until after the initial seeding. */

--- a/os/board/bk7239n/src/components/psa_mbedtls/mbedtls/library/hmac_drbg.c
+++ b/os/board/bk7239n/src/components/psa_mbedtls/mbedtls/library/hmac_drbg.c
@@ -346,6 +346,11 @@ int mbedtls_hmac_drbg_random_with_add(void *p_rng,
     while (left != 0) {
         size_t use_len = left > md_len ? md_len : left;
 
+        if (use_len > MBEDTLS_MD_MAX_SIZE) {
+            ret = MBEDTLS_ERR_HMAC_DRBG_REQUEST_TOO_BIG;
+            goto exit;
+        }
+
         if ((ret = mbedtls_md_hmac_reset(&ctx->md_ctx)) != 0) {
             goto exit;
         }

--- a/os/board/bk7239n/src/components/psa_mbedtls/mbedtls/library/ssl_client.c
+++ b/os/board/bk7239n/src/components/psa_mbedtls/mbedtls/library/ssl_client.c
@@ -352,6 +352,9 @@ static int ssl_write_client_hello_cipher_suites(
         const mbedtls_ssl_ciphersuite_t *ciphersuite_info;
 
         ciphersuite_info = mbedtls_ssl_ciphersuite_from_id(cipher_suite);
+        if (ciphersuite_info == NULL) {
+            continue;
+        }
 
         if (mbedtls_ssl_validate_ciphersuite(ssl, ciphersuite_info,
                                              ssl->handshake->min_tls_version,

--- a/os/board/bk7239n/src/components/psa_mbedtls/mbedtls/library/ssl_tls.c
+++ b/os/board/bk7239n/src/components/psa_mbedtls/mbedtls/library/ssl_tls.c
@@ -5287,27 +5287,27 @@ int mbedtls_ssl_config_defaults(mbedtls_ssl_config *conf,
     conf->tls13_kex_modes = MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_ALL;
 #endif /* MBEDTLS_SSL_PROTO_TLS1_3 */
 
-    if (transport == MBEDTLS_SSL_TRANSPORT_DATAGRAM) {
 #if defined(MBEDTLS_SSL_PROTO_TLS1_2)
-        conf->min_tls_version = MBEDTLS_SSL_VERSION_TLS1_2;
+    conf->min_tls_version = MBEDTLS_SSL_VERSION_TLS1_2;
+#if defined(MBEDTLS_SSL_PROTO_TLS1_3)
+    if (transport == MBEDTLS_SSL_TRANSPORT_DATAGRAM) {
         conf->max_tls_version = MBEDTLS_SSL_VERSION_TLS1_2;
-#else
-        return MBEDTLS_ERR_SSL_FEATURE_UNAVAILABLE;
-#endif
     } else {
-#if defined(MBEDTLS_SSL_PROTO_TLS1_2) && defined(MBEDTLS_SSL_PROTO_TLS1_3)
-        conf->min_tls_version = MBEDTLS_SSL_VERSION_TLS1_2;
         conf->max_tls_version = MBEDTLS_SSL_VERSION_TLS1_3;
-#elif defined(MBEDTLS_SSL_PROTO_TLS1_3)
-        conf->min_tls_version = MBEDTLS_SSL_VERSION_TLS1_3;
-        conf->max_tls_version = MBEDTLS_SSL_VERSION_TLS1_3;
-#elif defined(MBEDTLS_SSL_PROTO_TLS1_2)
-        conf->min_tls_version = MBEDTLS_SSL_VERSION_TLS1_2;
-        conf->max_tls_version = MBEDTLS_SSL_VERSION_TLS1_2;
-#else
-        return MBEDTLS_ERR_SSL_FEATURE_UNAVAILABLE;
-#endif
     }
+#else
+    conf->max_tls_version = MBEDTLS_SSL_VERSION_TLS1_2;
+    (void) transport;
+#endif /* MBEDTLS_SSL_PROTO_TLS1_3 */
+#elif defined(MBEDTLS_SSL_PROTO_TLS1_3)
+    if (transport == MBEDTLS_SSL_TRANSPORT_DATAGRAM) {
+        return MBEDTLS_ERR_SSL_FEATURE_UNAVAILABLE;
+    }
+    conf->min_tls_version = MBEDTLS_SSL_VERSION_TLS1_3;
+    conf->max_tls_version = MBEDTLS_SSL_VERSION_TLS1_3;
+#else
+    return MBEDTLS_ERR_SSL_FEATURE_UNAVAILABLE;
+#endif
 
     /*
      * Preset-specific defaults

--- a/os/board/bk7239n/src/components/psa_mbedtls/mbedtls/library/ssl_tls12_client.c
+++ b/os/board/bk7239n/src/components/psa_mbedtls/mbedtls/library/ssl_tls12_client.c
@@ -1431,15 +1431,6 @@ static int ssl_parse_server_hello(mbedtls_ssl_context *ssl)
     }
 #endif
 
-    if (comp != MBEDTLS_SSL_COMPRESS_NULL) {
-        MBEDTLS_SSL_DEBUG_MSG(1, ("bad server hello message"));
-        mbedtls_ssl_send_alert_message(
-            ssl,
-            MBEDTLS_SSL_ALERT_LEVEL_FATAL,
-            MBEDTLS_SSL_ALERT_MSG_ILLEGAL_PARAMETER);
-        return MBEDTLS_ERR_SSL_ILLEGAL_PARAMETER;
-    }
-
     ext = buf + 40 + n;
 
     MBEDTLS_SSL_DEBUG_MSG(2,

--- a/os/board/bk7239n/src/components/psa_mbedtls/mbedtls/library/ssl_tls12_server.c
+++ b/os/board/bk7239n/src/components/psa_mbedtls/mbedtls/library/ssl_tls12_server.c
@@ -3121,17 +3121,12 @@ curve_matching_done:
         /*
          * 2.2: Compute the hash to be signed
          */
-        if (md_alg != MBEDTLS_MD_NONE) {
-            ret = mbedtls_ssl_get_key_exchange_md_tls1_2(ssl, hash, &hashlen,
-                                                         dig_signed,
-                                                         dig_signed_len,
-                                                         md_alg);
-            if (ret != 0) {
-                return ret;
-            }
-        } else {
-            MBEDTLS_SSL_DEBUG_MSG(1, ("should never happen"));
-            return MBEDTLS_ERR_SSL_INTERNAL_ERROR;
+        ret = mbedtls_ssl_get_key_exchange_md_tls1_2(ssl, hash, &hashlen,
+                                                     dig_signed,
+                                                     dig_signed_len,
+                                                     md_alg);
+        if (ret != 0) {
+            return ret;
         }
 
         MBEDTLS_SSL_DEBUG_BUF(3, "parameters hash", hash, hashlen);

--- a/os/board/bk7239n/src/components/psa_mbedtls/mbedtls/library/x509_create.c
+++ b/os/board/bk7239n/src/components/psa_mbedtls/mbedtls/library/x509_create.c
@@ -304,6 +304,9 @@ int mbedtls_x509_string_to_names(mbedtls_asn1_named_data **head, const char *nam
             } else {
                 oid.len = strlen(attr_descr->oid);
                 oid.p = mbedtls_calloc(1, oid.len);
+                if (oid.p == NULL) {
+                    return MBEDTLS_ERR_X509_ALLOC_FAILED;
+                }
                 memcpy(oid.p, attr_descr->oid, oid.len);
                 numericoid = 0;
             }

--- a/os/board/bk7239n/src/components/wpa_supplicant-2.10/bk_patch/fake_socket.c
+++ b/os/board/bk7239n/src/components/wpa_supplicant-2.10/bk_patch/fake_socket.c
@@ -86,13 +86,12 @@ int ke_sk_recv(SOCKET sk, const unsigned char *buf, int len, int flag)
 	{
 		goto rx_exit;
 	}
-	dl_list_for_each_safe(sk_msg, tmp, &element->sk_tx_msg, SOCKET_MSG, data)
-	{
+	sk_msg = dl_list_first(&element->sk_tx_msg, SOCKET_MSG, data);
+	if (sk_msg) {
 		if (len != 0 && buf != NULL) {
 			count = MIN(sk_msg->len, len);
 
 			BK_ASSERT(count); /* BK_ASSERT VERIFIED */
-			BK_ASSERT(sk_msg); /* BK_ASSERT VERIFIED */
 			WPA_LOGD("r1:%d,buf:0x%x, len:%d\r\n", sk, buf, count);
 			os_memcpy((void *)buf, (void *)sk_msg->msg, count);
 
@@ -107,9 +106,6 @@ int ke_sk_recv(SOCKET sk, const unsigned char *buf, int len, int flag)
 
 		dl_list_del(&sk_msg->data);
 		os_free(sk_msg);
-		sk_msg = 0;
-
-		break;
 	}
 
 rx_exit:
@@ -131,11 +127,9 @@ int ke_sk_recv_peek_next_payload_size(SOCKET sk)
 		goto rx_exit;
 	}
 
-	dl_list_for_each_safe(sk_msg, tmp, &element->sk_tx_msg, SOCKET_MSG, data)
-	{
+	sk_msg = dl_list_first(&element->sk_tx_msg, SOCKET_MSG, data);
+	if (sk_msg)
 		ret = sk_msg->len;
-		break;
-	}
 
 rx_exit:
 	rtos_unlock_mutex(&socket_entity.fs_mutex);
@@ -156,11 +150,9 @@ int ke_sk_send_peek_next_payload_size(SOCKET sk)
 		goto rx_exit;
 	}
 
-	dl_list_for_each_safe(sk_msg, tmp, &element->sk_rx_msg, SOCKET_MSG, data)
-	{
+	sk_msg = dl_list_first(&element->sk_rx_msg, SOCKET_MSG, data);
+	if (sk_msg)
 		ret = sk_msg->len;
-		break;
-	}
 
 rx_exit:
 	rtos_unlock_mutex(&socket_entity.fs_mutex);
@@ -284,17 +276,15 @@ int fsocket_recv(SOCKET sk, const unsigned char *buf, int len, int flag)
 		goto rx_exit;
 	}
 
-	dl_list_for_each_safe(sk_msg, tmp, &element->sk_rx_msg, SOCKET_MSG, data)
-	{
-		if(sk_msg->len > len)
-		{
+	sk_msg = dl_list_first(&element->sk_rx_msg, SOCKET_MSG, data);
+	if (sk_msg) {
+		if (sk_msg->len > len) {
 			WPA_LOGW("recv_buf_small:%d:%d\r\n", sk_msg->len, len);
 		}
 
 		count = MIN(sk_msg->len, len);
 
 		BK_ASSERT(count); /* BK_ASSERT VERIFIED */
-		BK_ASSERT(sk_msg); /* BK_ASSERT VERIFIED */
 
 		os_memcpy((void *)buf, (void *)sk_msg->msg, count);
 		ret = count;
@@ -305,16 +295,12 @@ int fsocket_recv(SOCKET sk, const unsigned char *buf, int len, int flag)
 
 		dl_list_del(&sk_msg->data);
 		os_free(sk_msg);
-		sk_msg = 0;
-
-		break;
 	}
 
 rx_exit:
 	rtos_unlock_mutex(&socket_entity.fs_mutex);
 
 	return ret;
-;
 }
 
 void fsocket_close(SOCKET sk)
@@ -381,11 +367,9 @@ int fsocket_peek_recv_next_payload_size(SOCKET sk)
 		goto rx_exit;
 	}
 
-	dl_list_for_each_safe(sk_msg, tmp, &element->sk_rx_msg, SOCKET_MSG, data)
-	{
+	sk_msg = dl_list_first(&element->sk_rx_msg, SOCKET_MSG, data);
+	if (sk_msg)
 		ret = sk_msg->len;
-		break;
-	}
 
 rx_exit:
 	rtos_unlock_mutex(&socket_entity.fs_mutex);

--- a/os/board/bk7239n/src/components/wpa_supplicant-2.10/hostapd/main_none.c
+++ b/os/board/bk7239n/src/components/wpa_supplicant-2.10/hostapd/main_none.c
@@ -442,6 +442,8 @@ static int hostapd_config_fill(struct hostapd_config *conf,
 			return 1;
 		}
 		os_memcpy(bss->ssid.ssid, pos, bss->ssid.ssid_len);
+		if (bss->ssid.ssid_len < sizeof(bss->ssid.ssid))
+			bss->ssid.ssid[bss->ssid.ssid_len] = '\0';
 		bss->ssid.ssid_set = 1;
 	} else if (os_strcmp(buf, "utf8_ssid") == 0) {
 		bss->ssid.utf8_ssid = atoi(pos) > 0;

--- a/os/board/bk7239n/src/components/wpa_supplicant-2.10/src/ap/hostapd.c
+++ b/os/board/bk7239n/src/components/wpa_supplicant-2.10/src/ap/hostapd.c
@@ -2166,8 +2166,7 @@ static int hostapd_setup_interface_complete_sync(struct hostapd_iface *iface,
 	}
 
 	if (hapd->iconf->rts_threshold >= -1 &&
-	    hostapd_set_rts(hapd, hapd->iconf->rts_threshold) &&
-	    hapd->iconf->rts_threshold >= -1) {
+	    hostapd_set_rts(hapd, hapd->iconf->rts_threshold)) {
 		wpa_printf(MSG_ERROR, "Could not set RTS threshold for "
 			   "kernel driver");
 		goto fail;

--- a/os/board/bk7239n/src/components/wpa_supplicant-2.10/src/ap/ieee802_11.c
+++ b/os/board/bk7239n/src/components/wpa_supplicant-2.10/src/ap/ieee802_11.c
@@ -5676,6 +5676,9 @@ static void handle_assoc(struct hostapd_data *hapd,
 		}
 	}
 
+	if (!sta)
+		return;
+
 	if ((fc & WLAN_FC_RETRY) &&
 	    sta->last_seq_ctrl != WLAN_INVALID_MGMT_SEQ &&
 	    sta->last_seq_ctrl == seq_ctrl &&

--- a/os/board/bk7239n/src/components/wpa_supplicant-2.10/src/common/wpa_psk_cache.c
+++ b/os/board/bk7239n/src/components/wpa_supplicant-2.10/src/common/wpa_psk_cache.c
@@ -40,7 +40,7 @@ void send_psk_to_wpa_s(struct wpa_psk_cache_item *item)
 
 	os_memcpy(param.ssid, item->ssid, item->ssid_len);
 	param.ssid_len = item->ssid_len;
-	os_strcpy(param.passphrase, item->passphrase);  // XXX WARN
+	os_strlcpy(param.passphrase, item->passphrase, sizeof(param.passphrase));
 	os_memcpy(param.psk, item->psk, PMK_LEN);
 
 	wlan_sta_gen_psk(&param);
@@ -369,8 +369,14 @@ int wpa_psk_request(u8 *ssid, size_t ssid_len, char *passphrase, u8 *psk, size_t
 	cache->item.ssid = dup_binstr(ssid, ssid_len);
 	cache->item.ssid_len = ssid_len;
 	cache->item.passphrase = os_strdup(passphrase);
-
-	BK_ASSERT(cache->item.ssid && cache->item.passphrase);
+	if (!cache->item.ssid || !cache->item.passphrase) {
+		os_free(cache->item.ssid);
+		os_free(cache->item.passphrase);
+		cache->item.ssid = NULL;
+		cache->item.passphrase = NULL;
+		rtos_set_semaphore(&cache->sema);
+		return -1;
+	}
 
 	rtos_set_semaphore(&cache->sema);
 

--- a/os/board/bk7239n/src/components/wpa_supplicant-2.10/wpa_supplicant/ctrl_iface.c
+++ b/os/board/bk7239n/src/components/wpa_supplicant-2.10/wpa_supplicant/ctrl_iface.c
@@ -519,14 +519,16 @@ static int wpas_ctrl_scan(struct wpa_supplicant *wpa_s, wlan_sta_scan_param_t *p
 		wpa_s->known_wps_freq = 0;
 #endif
 #if CONFIG_WIFI_SCAN_COUNTRY_CODE
-		if (params->scan_cc)
-			site_survey_cc = true;
-		else
-			site_survey_cc = false;
+		if (params) {
+			if (params->scan_cc)
+				site_survey_cc = true;
+			else
+				site_survey_cc = false;
+		}
 #endif
 		ret = wpa_supplicant_req_scan(wpa_s, 0, 0);
 		if (wpa_s->manual_scan_use_id) {
-			if (params->id) {
+			if (params && params->id) {
 				wpa_s->manual_scan_id = params->id;
 			} else {
 				wpa_s->manual_scan_id++;
@@ -715,12 +717,12 @@ int wpa_supplicant_ctrl_iface_set_network(struct wpa_supplicant *wpa_s, wlan_sta
 			ssid->ssid = 0;
 			ssid->ssid_len = 0;
 		}
-		if (config->u.ssid.ssid && config->u.ssid.ssid_len) {
+		if (config->u.ssid.ssid_len) {
 			ssid->ssid = (u8 *)dup_binstr(config->u.ssid.ssid, config->u.ssid.ssid_len);
 			ssid->ssid_len = config->u.ssid.ssid_len;
 		}
 		if (bk_feature_bssid_connect_enable()) {
-			if (ssid->bssid) {
+			if (ssid->bssid_set) {
 				WPA_LOGD("clear bssid\r\n");
 				os_memset(ssid->bssid, 0, ETH_ALEN);
 				ssid->bssid_set = 0;

--- a/os/board/bk7239n/src/components/wpa_supplicant-2.10/wpa_supplicant/notify.c
+++ b/os/board/bk7239n/src/components/wpa_supplicant-2.10/wpa_supplicant/notify.c
@@ -136,7 +136,6 @@ uint8_t s_tk[16];
 void wlan_store_fci(struct wpa_supplicant *wpa_s)
 {
 	struct wlan_fast_connect_info fci;
-	char temp[4];
 	int i;
 	unsigned char *psk;
 	struct wpa_bss *bss;
@@ -174,13 +173,20 @@ void wlan_store_fci(struct wpa_supplicant *wpa_s)
 
 	if (wpa_s->pairwise_cipher > WPA_CIPHER_NONE) {
 		if (ssid->passphrase)
-			os_strcpy((char*)fci.pwd, ssid->passphrase);
+			os_strlcpy((char *) fci.pwd, ssid->passphrase, sizeof(fci.pwd));
 		fci.security = wpa_s->pairwise_cipher;
 		if (ssid->psk_set) {
+			char *psk_hex = (char *) fci.psk;
+			size_t psk_hex_left = sizeof(fci.psk);
+
 			psk = ssid->psk;
-			for (i = 0; i < PMK_LEN; i++) {
-				sprintf(temp, "%02x", psk[i]);
-				strcat((char*)fci.psk, temp);
+			for (i = 0; i < PMK_LEN && psk_hex_left > 2; i++) {
+				int n = os_snprintf(psk_hex, psk_hex_left, "%02x", psk[i]);
+
+				if (n <= 0 || (size_t) n >= psk_hex_left)
+					break;
+				psk_hex += n;
+				psk_hex_left -= n;
 			}
 		}
 	} else {

--- a/os/board/bk7239n/src/components/wpa_supplicant-2.10/wpa_supplicant/wpa_scan.c
+++ b/os/board/bk7239n/src/components/wpa_supplicant-2.10/wpa_supplicant/wpa_scan.c
@@ -2987,9 +2987,11 @@ wpa_supplicant_get_scan_results(struct wpa_supplicant *wpa_s,
 	}
 
 	wpa_bss_update_start(wpa_s);
-	for (i = 0; i < scan_res->num; i++)
-		wpa_bss_update_scan_res(wpa_s, scan_res->res[i],
-					&scan_res->fetch_time);
+	if (scan_res->res) {
+		for (i = 0; i < scan_res->num; i++)
+			wpa_bss_update_scan_res(wpa_s, scan_res->res[i],
+						&scan_res->fetch_time);
+	}
 	wpa_bss_update_end(wpa_s, info, new_scan);
 
 	return scan_res;


### PR DESCRIPTION
easyflash: use out-of-scope pointer;
bk_event: NULL pointer dereference
bk_netmgr:Unreachable code / control flow; redundant condition
bk_wifi:NULL; sizeof(pointer); buffer overflow; array OOB; unreachable; logic
wpa_supplicant:NULL pointer dereference; buffer overflow; redundant condition
psa_mbedtls:NULL pointer dereference; buffer overflow; unreachable code
