### PR TITLE
os/include/tinyara : Add BLE fw reset reboot reason

### DIFF
--- a/os/include/tinyara/reboot_reason.h
+++ b/os/include/tinyara/reboot_reason.h
@@ -46,6 +46,7 @@ typedef enum {
 
 	REBOOT_NETWORK_WIFICORE_WATCHDOG   = 80, /* Wi-Fi Core Watchdog Reset */
 	REBOOT_NETWORK_WIFICORE_PANIC      = 81, /* Wi-Fi Core Panic */
+	REBOOT_NETWORK_BTCORE_WATCHDOG     = 90, /* BT Core Watchdog Reset */
 
 	REBOOT_BOARD_SPECIFIC6             = 246, /* Board Specific Reboot Reason */
 	REBOOT_BOARD_SPECIFIC7             = 247,


### PR DESCRIPTION
- Add a reboot reason for rebooting during BLE firmware reset when an event is delivered and recovery is not possible.