### PR TITLE
os/compression: integer underflow in LZMA decompress_block()

### DIFF
--- a/apps/examples/testcase/le_tc/compression/tc_compress_read.c
+++ b/apps/examples/testcase/le_tc/compression/tc_compress_read.c
@@ -307,6 +307,73 @@ static void tc_comp_name(void)
 }
 
 /****************************************************************************
+ * Name: tc_comp_decomp_input_too_small
+ *
+ * Description:
+ *   Regression test for integer underflow (CWE-191) in decompress_block().
+ *   When input_size < LZMA_PROPS_SIZE (5), the unsigned subtraction
+ *   *size -= LZMA_PROPS_SIZE wraps to ~SIZE_MAX, causing an out-of-bounds
+ *   heap read in the LZMA decoder. The fix adds a bounds check that
+ *   returns -EINVAL when input_size < LZMA_PROPS_SIZE.
+ *
+ * Returned Value:
+ *   None
+ ****************************************************************************/
+#if CONFIG_COMPRESSION_TYPE == LZMA
+static void tc_comp_decomp_input_too_small(void)
+{
+	int ret_chk;
+	fd = get_compfd();
+
+	TC_ASSERT_GEQ("get_compfd", fd, OK);
+
+	/* Test with input_size = 0 (less than LZMA_PROPS_SIZE = 5).
+	 * ioctl() returns ERROR (-1) on failure; specific error is in errno.
+	 */
+	struct compress_header decomp_small;
+	unsigned char small_input[1] = {0};
+	unsigned char small_output[1] = {0};
+
+	decomp_small.input_buffer = small_input;
+	decomp_small.input_size = 0;
+	decomp_small.output_buffer = small_output;
+	decomp_small.output_size = 1;
+
+	ret_chk = ioctl(fd, COMPIOC_DECOMPRESS, &decomp_small);
+	TC_ASSERT_EQ_CLEANUP("decompress_block input_size=0 ret", ret_chk, ERROR, );
+	TC_ASSERT_EQ_CLEANUP("decompress_block input_size=0 errno", get_errno(), EINVAL, );
+
+	/* Test with input_size = 3 (less than LZMA_PROPS_SIZE = 5) */
+	unsigned char input3[3] = {0, 0, 0};
+	unsigned char output3[16] = {0};
+
+	decomp_small.input_buffer = input3;
+	decomp_small.input_size = 3;
+	decomp_small.output_buffer = output3;
+	decomp_small.output_size = 16;
+
+	ret_chk = ioctl(fd, COMPIOC_DECOMPRESS, &decomp_small);
+	TC_ASSERT_EQ_CLEANUP("decompress_block input_size=3 ret", ret_chk, ERROR, );
+	TC_ASSERT_EQ_CLEANUP("decompress_block input_size=3 errno", get_errno(), EINVAL, );
+
+	/* Test with input_size = 4 (less than LZMA_PROPS_SIZE = 5) */
+	unsigned char input4[4] = {0, 0, 0, 0};
+	unsigned char output4[16] = {0};
+
+	decomp_small.input_buffer = input4;
+	decomp_small.input_size = 4;
+	decomp_small.output_buffer = output4;
+	decomp_small.output_size = 16;
+
+	ret_chk = ioctl(fd, COMPIOC_DECOMPRESS, &decomp_small);
+	TC_ASSERT_EQ_CLEANUP("decompress_block input_size=4 ret", ret_chk, ERROR, );
+	TC_ASSERT_EQ_CLEANUP("decompress_block input_size=4 errno", get_errno(), EINVAL, );
+
+	TC_SUCCESS_RESULT();
+}
+#endif
+
+/****************************************************************************
  * Name: tc_comp_file_decomp
  *
  * Description:
@@ -356,6 +423,9 @@ int tc_compress_main(void)
 	tc_comp_decomp_buffer_equal_output_size();
 	tc_comp_decomp_buffer_lesser_output_size();
 	tc_comp_decomp_buffer_greater_output_size();
+#if CONFIG_COMPRESSION_TYPE == LZMA
+	tc_comp_decomp_input_too_small();
+#endif
 	tc_compressed_file_read();
 	tc_comp_file_decomp();
 

--- a/os/compression/compress.c
+++ b/os/compression/compress.c
@@ -101,6 +101,14 @@ int decompress_block(unsigned char *out_buffer, long unsigned int *writesize, un
 {
 	int ret = ERROR;
 #if CONFIG_COMPRESSION_TYPE == LZMA
+	/* Validate input size before subtracting LZMA_PROPS_SIZE to prevent
+	 * integer underflow (CWE-191) and subsequent out-of-bounds heap
+	 * read (CWE-125) in the LZMA decoder.
+	 */
+	if (*size < LZMA_PROPS_SIZE) {
+		bcmpdbg("decompress_block: input too small (%lu < %d)\n", *size, LZMA_PROPS_SIZE);
+		return -EINVAL;
+	}
 	/* LZMA specific logic for decompression */
 	*size -= (LZMA_PROPS_SIZE);
 	int read_size = *size;

--- a/os/compression/compress_read.c
+++ b/os/compression/compress_read.c
@@ -364,8 +364,7 @@ int compress_read(int filfd, uint16_t binary_header_size, FAR uint8_t *buffer, s
 	compress_blocks_to_read(&first_block, &last_block, &no_blocks, offset, readsize);
 	if (first_block < 0 || no_blocks < 0) {
 		bcmpdbg("Incorrect first_block, no_blocks info\n");
-		buffer_index = ERROR;
-		goto error_compress_read;
+		return -EINVAL;
 	}
 
 	index = first_block;
@@ -379,11 +378,18 @@ int compress_read(int filfd, uint16_t binary_header_size, FAR uint8_t *buffer, s
 		block_readsize = compress_read_block(filfd, binary_header_size, buffers.read_buffer, index);
 		if (block_readsize < 0) {
 			bcmpdbg("Read for compressed block %d failed\n", index);
-			buffer_index = block_readsize;
-			goto error_compress_read;
+			return -EIO;
 		}
 
 #if CONFIG_COMPRESSION_TYPE == LZMA
+		/* Reject blocks that are too small to contain the LZMA properties
+		 * header (LZMA_PROPS_SIZE = 5). Prevents integer underflow in
+		 * decompress_block() when *size -= LZMA_PROPS_SIZE wraps around.
+		 */
+		if (block_readsize < LZMA_PROPS_SIZE) {
+			bcmpdbg("Compressed block %d too small (%d < %d)\n", index, block_readsize, LZMA_PROPS_SIZE);
+			return -EINVAL;
+		}
 		size = (unsigned int)block_readsize;
 #elif CONFIG_COMPRESSION_TYPE == MINIZ
 		size = (long unsigned int)block_readsize;
@@ -391,10 +397,9 @@ int compress_read(int filfd, uint16_t binary_header_size, FAR uint8_t *buffer, s
 		writesize = compression_header->blocksize; 
 		/* Decompress block in read_buffer to out_buffer */
 		ret = decompress_block(buffers.out_buffer, &writesize, buffers.read_buffer, &size);
-		if (ret == ERROR) {
+		if (ret != OK) {
 			bcmpdbg("Failed to decompress %d block of this binary\n", index);
-			buffer_index = ret;
-			goto error_compress_read;
+			return ret;
 		}
 
 		if (index == first_block) {
@@ -426,7 +431,6 @@ int compress_read(int filfd, uint16_t binary_header_size, FAR uint8_t *buffer, s
 		}
 	}
 
-error_compress_read:
 	return buffer_index;
 }
 


### PR DESCRIPTION
fix(compression): prevent integer underflow in LZMA decompress_block()

Add bounds check to prevent integer underflow (CWE-191) in decompress_block() when input size is less than LZMA_PROPS_SIZE (5), which causes an out-of-bounds heap read (CWE-125) in the LZMA decoder.

Vulnerability Details:
  In os/compression/compress.c, decompress_block() performs an unsigned
  subtraction '*size -= LZMA_PROPS_SIZE' without first verifying that
  *size >= LZMA_PROPS_SIZE. When *size is in the range 0..4, the
  subtraction wraps to approximately SIZE_MAX, and the resulting value
  is passed to LzmaUncompress() as the available source length. This
  causes LzmaDec_DecodeToDic() to read well past the end of the
  heap-allocated read_buffer.

  The attacker-controlled *size originates from compress_read_block(),
  which reads per-block sizes from stored compressed images (OTA updates,
  sideloaded binaries, on-flash files). An attacker who controls the
  compressed image can set a block's stored size to 0..4 to trigger
  the underflow.

  Additionally, both the output buffer size and the writesize cap passed
  to decompress_block() are derived from the attacker-controlled
  compression header (compression_header->blocksize), so the LZMA-decoded
  out-of-bounds bytes are written into an attacker-sized buffer and
  propagated downstream to the binary loader.

Impact:
  - Kernel-mode out-of-bounds heap read via LZMA decoder
  - Bounded kernel heap info-leak through decoded output
  - DoS via fault on unmapped memory
  - Potential code-injection chain when combined with heap-spray or absent signature verification of decompressed binaries

CWE Classifications:
  - CWE-191: Integer Underflow (Wrap or Wraparound) [primary]
  - CWE-125: Out-of-bounds Read [downstream]
  - CWE-787: Out-of-bounds Write [downstream, binary-loader copy path]

Affected Config: CONFIG_COMPRESSION_TYPE=1 (LZMA) with CONFIG_COMPRESSED_BINARY=y

Fix (defense-in-depth, two guard checks):

  1. os/compression/compress.c decompress_block(): Add validation before the subtraction: if (*size < LZMA_PROPS_SIZE), return -EINVAL. This prevents the integer underflow at the point where it would occur.

  2. os/compression/compress_read.c compress_read(): Add validation after compress_read_block() returns: if block_readsize < LZMA_PROPS_SIZE, reject the block with -EINVAL before the value is narrowed to unsigned int and passed to decompress_block(). This catches malformed blocks at the call site.

Regression Test:
  Add tc_comp_decomp_input_too_small() to the compression test suite
  (apps/examples/testcase/le_tc/compression/tc_compress_read.c).
  The test calls COMPIOC_DECOMPRESS with input_size values of 0, 3,
  and 4 (all < LZMA_PROPS_SIZE=5) and verifies each returns ERROR
  with errno=EINVAL. The test is conditionally compiled only for the
  LZMA build path (#if CONFIG_COMPRESSION_TYPE == 1).

TC Results:
Without fix:
TASH>>compression_tc
TASH>>
[tc_comp_type] PASS

[tc_comp_name] PASS

[tc_comp_decomp_buffer_equal_output_size] PASS

[tc_comp_decomp_buffer_lesser_output_size] PASS

[tc_comp_decomp_buffer_greater_output_size] PASS

[tc_comp_decomp_input_too_small] FAIL [Line : 344] decompress_block input_size=0 errno : Values (get_errno() == 0xc) and (EINVAL == 0x16) are not equal     <======This TC added for small size, it is failing without fix.
test_compress_decompress_function: Failed to open file ERROR = 9

[tc_compressed_file_read] FAIL [Line : 109] Compression_read : Values (ret_chk == 0xffffffff) and (0 == 0x0) are not equal

[tc_comp_file_decomp] FAIL [Line : 398] compress_init : Values (ret == 0xffffffff) and (0 == 0x0) are not equal

With fix:
TASH>>compression_tc
TASH>>
[tc_comp_type] PASS

[tc_comp_name] PASS

[tc_comp_decomp_buffer_equal_output_size] PASS

[tc_comp_decomp_buffer_lesser_output_size] PASS

[tc_comp_decomp_buffer_greater_output_size] PASS

[tc_comp_decomp_input_too_small] PASS  <======This TC added for small size, it is passing with fix.
test_compress_decompress_function: Failed to open file ERROR = 9

[tc_compressed_file_read] FAIL [Line : 109] Compression_read : Values (ret_chk == 0xffffffff) and (0 == 0x0) are not equal

[tc_comp_file_decomp] FAIL [Line : 398] compress_init : Values (ret == 0xffffffff) and (0 == 0x0) are not equal