### PR TITLE
os: Change return value of up_read_decrypted_flash

### DIFF
--- a/os/arch/arm/src/armino/armino_flash.c
+++ b/os/arch/arm/src/armino/armino_flash.c
@@ -374,30 +374,32 @@ FAR struct mtd_dev_s *up_flashinitialize(void)
 * @param length size to read
 *
 * @return
-*    - BK_OK: succeed
+*    - length: succeed (returns the number of bytes read)
 *    - BK_ERR_FLASH_ADDR_OUT_OF_RANGE: flash address is out of range
 *    - others: other errors.
 */
 ssize_t up_read_decrypted_flash(size_t addr, void *buf, size_t length)
 {
+	ssize_t result;
+
 	// printf("func :%s, line :%d, addr :%x, length :%d\n", __func__, __LINE__, addr, length);
 #if (!CONFIG_SPE)
 	if (bk_addr_is_kernel(addr)) {
-		bk_security_flash_read_bytes(addr, (uint8_t *)buf, length);
+		result = bk_security_flash_read_bytes(addr, (uint8_t *)buf, length);
 		SCB_CleanInvalidateDCache();
 	}
 #ifdef CONFIG_BUILD_PROTECTED
 #ifdef CONFIG_FLASH_ENCRYPT_ENABLE
 	else if (bk_addr_is_app_or_common(addr)) {
-		bk_instruction_read_app_or_common(addr, (uint8_t *)buf, length);
+		result = bk_instruction_read_app_or_common(addr, (uint8_t *)buf, length);
 	}
 #endif
 #endif
 	else
 #endif
 	{
-		bk_flash_read_bytes(addr, (uint8_t *)buf, length);
+		result = bk_flash_read_bytes(addr, (uint8_t *)buf, length);
 	}
 
-	return BK_OK;
+	return result < 0 ? result : length;
 }

--- a/os/binfmt/libxipelf/xipelf.c
+++ b/os/binfmt/libxipelf/xipelf.c
@@ -70,19 +70,7 @@ static int xipelf_loadbinary(FAR struct binary_s *binp)
 
 	while (readsize > 0) {
 #ifdef CONFIG_BINMGR_READ_DECRYPTED_BINARY 
-		uint32_t part_addr;
-		uint32_t read_offset;
-		uint32_t read_addr;
-
-		part_addr = BIN_PARTADDR(binp->binary_idx, BIN_USEIDX(binp->binary_idx));
-		read_offset = (uint32_t)offset;
-		read_addr = part_addr + read_offset;
-		nbytes = up_read_decrypted_flash(read_addr, buffer, readsize);
-		if (nbytes != OK && nbytes != -EINTR) {
-			berr("Failed to read userspace header, addr 0x%x, size %u, ret %d\n", read_addr, (unsigned int)readsize, (int)nbytes);
-		} else if (nbytes == OK) {
-			nbytes = readsize;
-		}
+		nbytes = up_read_decrypted_flash(BIN_PARTADDR(binp->binary_idx, BIN_USEIDX(binp->binary_idx)) + offset, buffer, readsize);
 #else
 		rpos = lseek(filfd, offset, SEEK_SET);
 		if (rpos != offset) {

--- a/os/kernel/binary_manager/binary_manager_resource.c
+++ b/os/kernel/binary_manager/binary_manager_resource.c
@@ -82,8 +82,9 @@ static ssize_t resource_decblk_read(FAR struct inode *inode, FAR unsigned char *
 	}
 
 	ret = up_read_decrypted_flash(dev->part_addr + offset, (FAR void *)buffer, size);
-	if (ret != OK) {
-		return ret < 0 ? ret : -EIO;
+	if (ret != (ssize_t)size) {
+		bmdbg("Fail to read binary, part_addr 0x%x, offset %u, %size %u, ret %d\n", dev->part_addr, offset, size, (int)ret);
+		return ret;
 	}
 
 	return nsectors;

--- a/os/kernel/binary_manager/binary_manager_verify.c
+++ b/os/kernel/binary_manager/binary_manager_verify.c
@@ -107,7 +107,7 @@ static int binary_manager_read_flash(int type, bool is_header, char *devpath, ui
 		}
 
 		ret = up_read_decrypted_flash(read_addr, (FAR uint8_t *)buffer, size);
-		if (ret != OK) {
+		if (ret != (ssize_t)size) {
 			bmdbg("Fail to read binary, addr 0x%x, size %u, ret %d\n", read_addr, size, (int)ret);
 			return BINMGR_OPERATION_FAIL;
 		}


### PR DESCRIPTION
Previously, up_read_decrypted_flash returned OK on success.
It now returns the number of bytes read upon successful operation.
All callers have been updated to check the returned byte count instead of OK.