### PR TITLE
os/arch/arm/include/armv7-m/: Move saved_exec_ret to build protected

### DIFF
--- a/os/arch/arm/include/armv7-m/irq_lazyfpu.h
+++ b/os/arch/arm/include/armv7-m/irq_lazyfpu.h
@@ -82,12 +82,8 @@
 #define REG_R10             (8)	/* R10 */
 #define REG_R11             (9)	/* R11 */
 
-#ifdef CONFIG_BUILD_PROTECTED
-#define REG_EXC_RETURN    (10)	/* EXC_RETURN */
-#define SW_INT_REGS       (11)
-#else
 #define SW_INT_REGS       (10)
-#endif
+#define REG_EXC_RETURN    (11)	/* EXC_RETURN */
 
 /* If the MCU supports a floating point unit, then it will be necessary
  * to save the state of the FPU status register and data registers on

--- a/os/arch/arm/src/armv7-m/up_schedulesigaction.c
+++ b/os/arch/arm/src/armv7-m/up_schedulesigaction.c
@@ -174,8 +174,9 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 				tcb->xcp.saved_xpsr = current_regs[REG_XPSR];
 #ifdef CONFIG_BUILD_PROTECTED
 				tcb->xcp.saved_lr = current_regs[REG_LR];
-				tcb->xcp.saved_exec_ret = current_regs[REG_EXC_RETURN];
 #endif
+
+				tcb->xcp.saved_exec_ret = current_regs[REG_EXC_RETURN];
 
 				/* Then set up to vector to the trampoline with interrupts
 				 * disabled.  The kernel-space trampoline must run in
@@ -190,10 +191,10 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 #endif
 #ifdef CONFIG_BUILD_PROTECTED
 				current_regs[REG_LR] = EXC_RETURN_PRIVTHR;
-				current_regs[REG_EXC_RETURN] = EXC_RETURN_PRIVTHR;
 #endif
-
+				current_regs[REG_EXC_RETURN] = EXC_RETURN_PRIVTHR;
 				current_regs[REG_XPSR] = ARMV7M_XPSR_T;
+
 				/* And make sure that the saved context in the TCB is the same
 				 * as the interrupt return context.
 				 */
@@ -223,8 +224,9 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 			tcb->xcp.saved_xpsr = tcb->xcp.regs[REG_XPSR];
 #ifdef CONFIG_BUILD_PROTECTED
 			tcb->xcp.saved_lr = tcb->xcp.regs[REG_LR];
-			tcb->xcp.saved_exec_ret = tcb->xcp.regs[REG_EXC_RETURN];
 #endif
+
+			tcb->xcp.saved_exec_ret = tcb->xcp.regs[REG_EXC_RETURN];
 
 			/* Then set up to vector to the trampoline with interrupts
 			 * disabled.  We must already be in privileged thread mode to be
@@ -239,11 +241,8 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 #endif
 #ifdef CONFIG_BUILD_PROTECTED
 			tcb->xcp.regs[REG_LR] = EXC_RETURN_PRIVTHR;
-			if (tcb->xcp.regs[REG_EXC_RETURN] == EXC_RETURN_HANDLER) {
-				tcb->xcp.regs[REG_EXC_RETURN] = EXC_RETURN_PRIVTHR;
-			}
 #endif
-
+			tcb->xcp.regs[REG_EXC_RETURN] = EXC_RETURN_PRIVTHR;
 			tcb->xcp.regs[REG_XPSR] = ARMV7M_XPSR_T;
 		}
 	}

--- a/os/arch/arm/src/armv7-m/up_sigdeliver.c
+++ b/os/arch/arm/src/armv7-m/up_sigdeliver.c
@@ -131,8 +131,9 @@ void up_sigdeliver(void)
 	regs[REG_XPSR] = rtcb->xcp.saved_xpsr;
 #ifdef CONFIG_BUILD_PROTECTED
 	regs[REG_LR] = rtcb->xcp.saved_lr;
-	regs[REG_EXC_RETURN] = rtcb->xcp.saved_exec_ret;
 #endif
+
+	regs[REG_EXC_RETURN] = rtcb->xcp.saved_exec_ret;
 
 	/* Get a local copy of the sigdeliver function pointer. We do this so that
 	 * we can nullify the sigdeliver function pointer in the TCB and accept


### PR DESCRIPTION
Remove extra build protected ifdef and move saved_exec_ret variable inside build protected