### PR TITLE
os/board/bk7239n: Fix memory leak in BK7239N network manager

### DIFF
--- a/os/board/bk7239n/src/bsp_adapter/src/net/bk_netmgr.c
+++ b/os/board/bk7239n/src/bsp_adapter/src/net/bk_netmgr.c
@@ -1127,6 +1127,7 @@ trwifi_result_e bk_wifi_netmgr_deinit(struct netdev *dev)
     bk_trwifi_clear_scan_chain_list();
     bk_trwifi_clear_multi_scan_cache();
     rtos_unlock_mutex(&scanlistbusy);
+	rtos_deinit_mutex(&scanlistbusy);
 
     /* unregister beken event callback*/
     bk_event_unregister_cb(EVENT_MOD_WIFI, EVENT_ID_ALL, beken_wifi_event_cb);


### PR DESCRIPTION
**Problem**
When running `mem_leak` command, the following leak was detected:
- Owner: 0x18011c53 (rtos_pub.c:324 - rtos_init_mutex)
- Size: 32 bytes per leak
- PID: 17

The `scanlistbusy` mutex was initialized in `bk_wifi_netmgr_init()` but never 
deinitialized in `bk_wifi_netmgr_deinit()`, causing memory leak when the 
network interface is deinitialized.

**Solution**
Added `rtos_deinit_mutex(&scanlistbusy)` call at line 1130 in `bk_netmgr.c` 
to properly free the mutex resources during deinitialization.