### PR TITLE
apps/system/utils/security_level_cmd.c: Add security_deinit in edge case

### DIFF
--- a/apps/system/utils/security_level_cmd.c
+++ b/apps/system/utils/security_level_cmd.c
@@ -102,6 +102,7 @@ static void tash_security_level(int argc, char **args)
 	} else {
 		printf("Invalid argument (%s).\n", args[1]);
 		show_usage();
+		(void)security_deinit(hnd);
 		return;
 	}
 	


### PR DESCRIPTION
Add `security_deinit` in invalid argument case.
It prevents memory leak.