### PR TITLE
os/arch/arm/src/armv7-a/arm_signal_handler.S: Fix SP 8-byte alignment…

### DIFF
--- a/os/arch/arm/src/armv7-a/arm_schedulesigaction.c
+++ b/os/arch/arm/src/armv7-a/arm_schedulesigaction.c
@@ -161,7 +161,14 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 										((uint32_t)CURRENT_REGS - (uint32_t)XCPTCONTEXT_SIZE);
 				memcpy((uint32_t *)CURRENT_REGS, tcb->xcp.saved_regs, XCPTCONTEXT_SIZE);
 
-				CURRENT_REGS[REG_SP] = (uint32_t)CURRENT_REGS + (uint32_t)XCPTCONTEXT_SIZE;
+				/* AAPCS: the stack pointer must be 8-byte aligned at every public
+				 * function-call boundary.  The duplicated register-save area top
+				 * used as the delivery SP is only word-aligned in the general
+				 * case, so force 8-byte alignment here.  Rounding down stays within
+				 * the already-duplicated context frame and is restored verbatim by
+				 * the signal trampoline, so no live state is disturbed.
+				 */
+				CURRENT_REGS[REG_SP] = (((uint32_t)CURRENT_REGS + (uint32_t)XCPTCONTEXT_SIZE) & ~7);
 
 				/* Then set up to vector to the trampoline with interrupts
 				 * disabled
@@ -201,7 +208,14 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 									((uint32_t)tcb->xcp.regs - (uint32_t)XCPTCONTEXT_SIZE);
 			memcpy(tcb->xcp.regs, tcb->xcp.saved_regs, XCPTCONTEXT_SIZE);
 
-			tcb->xcp.regs[REG_SP] = (uint32_t)tcb->xcp.regs + (uint32_t)XCPTCONTEXT_SIZE;
+			/* AAPCS: the stack pointer must be 8-byte aligned at every public
+			 * function-call boundary.  The duplicated register-save area top
+			 * used as the delivery SP is only word-aligned in the general
+			 * case, so force 8-byte alignment here.  Rounding down stays within
+			 * the already-duplicated context frame and is restored verbatim by
+			 * the signal trampoline, so no live state is disturbed.
+			 */
+			tcb->xcp.regs[REG_SP] = (((uint32_t)tcb->xcp.regs + (uint32_t)XCPTCONTEXT_SIZE) & ~7);
 
 			/* Then set up to vector to the trampoline with interrupts
 			 * disabled
@@ -296,7 +310,14 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 									((uint32_t)tcb->xcp.regs - (uint32_t)XCPTCONTEXT_SIZE);
 					memcpy(tcb->xcp.regs, tcb->xcp.saved_regs, XCPTCONTEXT_SIZE);
 
-					tcb->xcp.regs[REG_SP] = (uint32_t)tcb->xcp.regs + (uint32_t)XCPTCONTEXT_SIZE;
+					/* AAPCS: the stack pointer must be 8-byte aligned at every public
+					 * function-call boundary.  The duplicated register-save area top
+					 * used as the delivery SP is only word-aligned in the general
+					 * case, so force 8-byte alignment here.  Rounding down stays within
+					 * the already-duplicated context frame and is restored verbatim by
+					 * the signal trampoline, so no live state is disturbed.
+					 */
+					tcb->xcp.regs[REG_SP] = (((uint32_t)tcb->xcp.regs + (uint32_t)XCPTCONTEXT_SIZE) & ~7);
 
 					/* Then set up to vector to the trampoline with interrupts
 					 * disabled
@@ -333,7 +354,14 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 								   ((uint32_t)CURRENT_REGS - (uint32_t)XCPTCONTEXT_SIZE);
 					memcpy((uint32_t *) CURRENT_REGS, tcb->xcp.saved_regs, XCPTCONTEXT_SIZE);
 
-					CURRENT_REGS[REG_SP] = (uint32_t)CURRENT_REGS + (uint32_t)XCPTCONTEXT_SIZE;
+					/* AAPCS: the stack pointer must be 8-byte aligned at every public
+					 * function-call boundary.  The duplicated register-save area top
+					 * used as the delivery SP is only word-aligned in the general
+					 * case, so force 8-byte alignment here.  Rounding down stays within
+					 * the already-duplicated context frame and is restored verbatim by
+					 * the signal trampoline, so no live state is disturbed.
+					 */
+					CURRENT_REGS[REG_SP] = (((uint32_t)CURRENT_REGS + (uint32_t)XCPTCONTEXT_SIZE) & ~7);
 
 					/* Then set up vector to the trampoline with interrupts
 					 * disabled.  The kernel-space trampoline must run in
@@ -395,7 +423,14 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 							((uint32_t)tcb->xcp.regs - (uint32_t)XCPTCONTEXT_SIZE);
 			memcpy(tcb->xcp.regs, tcb->xcp.saved_regs, XCPTCONTEXT_SIZE);
 
-			tcb->xcp.regs[REG_SP] = (uint32_t)tcb->xcp.regs + (uint32_t)XCPTCONTEXT_SIZE;
+			/* AAPCS: the stack pointer must be 8-byte aligned at every public
+			 * function-call boundary.  The duplicated register-save area top
+			 * used as the delivery SP is only word-aligned in the general
+			 * case, so force 8-byte alignment here.  Rounding down stays within
+			 * the already-duplicated context frame and is restored verbatim by
+			 * the signal trampoline, so no live state is disturbed.
+			 */
+			tcb->xcp.regs[REG_SP] = (((uint32_t)tcb->xcp.regs + (uint32_t)XCPTCONTEXT_SIZE) & ~7);
 
 			/* Increment the IRQ lock count so that when the task is restarted,
 			 * it will hold the IRQ spinlock.

--- a/os/arch/arm/src/armv7-a/arm_signal_dispatch.c
+++ b/os/arch/arm/src/armv7-a/arm_signal_dispatch.c
@@ -84,9 +84,28 @@
 #ifndef CONFIG_DISABLE_SIGNALS
 void up_signal_dispatch(_sa_sigaction_t sighand, int signo, siginfo_t *info, void *ucontext)
 {
+	uint32_t saved_sp;
+
+	/* Save SP, force 8-byte alignment, call syscall4(), then restore SP */
+
+	__asm__ __volatile__ (
+        "mov %0, sp\n"
+        "bic sp, sp, #7\n"
+        : "=r"(saved_sp)
+        :
+        : "memory"
+    );
+
 	/* Let sys_call4() do all of the work */
 
 	sys_call4(SYS_signal_handler, (uintptr_t) sighand, (uintptr_t) signo, (uintptr_t) info, (uintptr_t) ucontext);
+
+	__asm__ __volatile__ (
+        "mov sp, %0\n"
+        :
+        : "r"(saved_sp)
+        : "memory"
+    );
 }
 #endif
 #endif							/* !CONFIG_BUILD_FLAT && __KERNEL__ */

--- a/os/arch/arm/src/armv7-a/arm_signal_handler.S
+++ b/os/arch/arm/src/armv7-a/arm_signal_handler.S
@@ -91,7 +91,22 @@ up_signal_handler:
 
 	/* Save some register */
 
-	push		{lr}			/* Save LR on the stack */
+	push		{r12, lr}			/* Save R12 and LR on the stack = 8 byte alignment */
+
+#ifdef CONFIG_DEBUG
+	/* Verify the AAPCS 8-byte stack alignment before invoking the handler.
+	 * If the SP is only 4-byte aligned, the delivery-path contract has been
+	 * violated, so panic.  Present only when CONFIG_DEBUG is enabled, exactly
+	 * like DEBUGPANIC().
+	*/
+
+	tst		sp, #7			/* SP 8-byte aligned? (low 3 bits == 0) */
+	beq		1f			/* Yes: proceed to the handler */
+	ldr		r0, =.Lsigsp_file	/* up_assert() filename argument - loads address of string */
+	movw		r1, #103			/* up_assert() linenum argument - immediate value */
+	bl		up_assert		/* Panic on misalignment; does not return */
+1:
+#endif
 
 	/* Call the signal handler */
 
@@ -103,14 +118,19 @@ up_signal_handler:
 
 	/* Restore the registers */
 
-	pop		{r2}			/* Recover LR in R2 */
-	mov		lr, r2			/* Restore LR */
+	pop		{r12, lr}			/* Restore R12 and LR */
 
 	/* Execute the SYS_signal_handler_return SVCall (will not return) */
 
 	mov		r0, #SYS_signal_handler_return
 	svc		#SYS_syscall
 	nop
+
+#if defined(CONFIG_DEBUG)
+	.align		2
+.Lsigsp_file:
+	.asciz		"arm_signal_handler.S"
+#endif
 
 	.size	up_signal_handler, .-up_signal_handler
 	.end


### PR DESCRIPTION
… for signal handler call

up_signal_handler is called with either 4 byte or 8 byte alignment for SP. Before calling to signal handler, there is need to make SP aligned 8 byte as par ARM procedure call standard.

If an 8 byte alignment instruction is encountered for 4 byte aligned memory, then it will cause then it will create data abort with alignment fault.

to avoid such fault condition, the PR code changes will make sure signal handler is called with 8 byte alignment of SP in both cases.