### PR TITLE
os, apps: Add NULL parameter check in some functions

### DIFF
--- a/apps/shell/tash_command.c
+++ b/apps/shell/tash_command.c
@@ -690,6 +690,11 @@ int tash_cmd_install(const char *str, TASH_CMD_CALLBACK cb, int thread_exec)
 	int cmd_idx;
 	struct tash_cmd_s *new_cmd_buff;
 
+	if (!str || !cb) {
+		shdbg("ERROR: Invalid arguments, str: %p, cb: %p\n", str, cb);
+		return ERROR;
+	}
+
 	/* Lock mutex */
 	pthread_mutex_lock(&tash_cmds_info.tmutex);
 
@@ -748,6 +753,11 @@ int tash_cmd_install(const char *str, TASH_CMD_CALLBACK cb, int thread_exec)
 void tash_cmdlist_install(const tash_cmdlist_t list[])
 {
 	const tash_cmdlist_t *map;
+
+	if (!list) {
+		shdbg("ERROR: Invalid argument, list is NULL\n");
+		return;
+	}
 
 	for (map = list; map->entry; map++) {
 		tash_cmd_install(map->name, map->entry, map->exectype);

--- a/apps/system/i2c/i2c_common.c
+++ b/apps/system/i2c/i2c_common.c
@@ -98,6 +98,11 @@ int common_args(FAR struct i2ctool_s *i2ctool, FAR char **arg)
 	long value;
 	int ret;
 
+	if (!i2ctool || !ptr) {
+		printf("ERROR: Invalid arguments, i2ctool=%p, arg=%p\n", i2ctool, ptr);
+		return ERROR;
+	}
+
 	if (ptr[0] != '-') {
 		goto invalid_argument;
 	}

--- a/apps/system/inifile/inifile.c
+++ b/apps/system/inifile/inifile.c
@@ -550,6 +550,11 @@ FAR char *inifile_read_string(INIHANDLE handle, FAR const char *section, FAR con
 	FAR char *ret = NULL;
 	FAR const char *value;
 
+	if (!handle || !section || !variable) {
+		inivdbg("ERROR: Invalid arguments, handle: %p, section: %p, variable: %p\n", handle, section, variable);
+		return NULL;
+	}
+
 	/* Get a reference to the volatile version of the string */
 
 	value = inifile_find_variable(priv, section, variable);
@@ -590,6 +595,11 @@ long inifile_read_integer(INIHANDLE handle, FAR const char *section, FAR const c
 	FAR struct inifile_state_s *priv = (FAR struct inifile_state_s *)handle;
 	FAR char *value;
 	long ret = defvalue;
+
+	if (!handle || !section || !variable) {
+		inivdbg("Invalid arguments, handle: %p, section: %p, variable: %p\n", handle, section, variable);
+		return ret;
+	}
 
 	/* Assume failure to find the requested value */
 

--- a/apps/system/readline/readline_common.c
+++ b/apps/system/readline/readline_common.c
@@ -136,7 +136,7 @@ ssize_t readline_common(FAR struct rl_common_s *vtbl, FAR char *buf, int buflen)
 
 	/* Sanity checks */
 
-	DEBUGASSERT(buf && buflen > 0);
+	DEBUGASSERT(vtbl && buf && buflen > 0);
 
 	if (buflen < 2) {
 		*buf = '\0';

--- a/apps/system/utils/fscmd.c
+++ b/apps/system/utils/fscmd.c
@@ -425,7 +425,7 @@ static int tash_cd(int argc, char **args)
 {
 	const char *path = args[1];
 	char *temp = NULL;
-	int ret;
+	int ret = ERROR;
 
 	if (argc < 2 || strcmp(path, "~") == 0) {
 		path = CONFIG_LIB_HOMEDIR;
@@ -439,13 +439,15 @@ static int tash_cd(int argc, char **args)
 		temp = get_fullpath(path);
 		path = temp;
 	}
-	ret = chdir(path);
-	if (ret != 0) {
-		FSCMD_OUTPUT(CMD_FAILED, args[0], path);
-		ret = ERROR;
-	}
 
-	fscmd_free(temp);
+	if (path) {
+		ret = chdir(path);
+		if (ret != 0) {
+			FSCMD_OUTPUT(CMD_FAILED, args[0], path);
+			ret = ERROR;
+		}
+		fscmd_free(temp);
+	}
 
 	return ret;
 }
@@ -830,6 +832,11 @@ static int search_mountpoints(const char *dirpath, foreach_mountpoint_t handler)
 
 		/* Call statfs with the given file path */
 		fullpath = get_dirpath(dirpath, entryp->d_name);
+		if (!fullpath) {
+			FSCMD_OUTPUT(OUT_OF_MEMORY, dirpath);
+			closedir(dirp);
+			return ERROR;
+		}
 		ret = statfs(fullpath, &buf);
 		if (ret != OK) {
 			FSCMD_OUTPUT("statfs is failed at %s\n", fullpath);
@@ -1095,6 +1102,10 @@ static int tash_rm(int argc, char **args)
 	int ret = OK;
 	if (argc == 3) {
 		fullpath = get_fullpath(args[2]);
+		if (!fullpath) {
+			FSCMD_OUTPUT(OUT_OF_MEMORY, args[2]);
+			return ERROR;
+		}
 		if (strncmp(args[1], "-r", strlen(args[1])) == 0) {
 			ret = delete_entry(fullpath);
 		} else {
@@ -1102,6 +1113,10 @@ static int tash_rm(int argc, char **args)
 		}
 	} else if (argc == 2) {
 		fullpath = get_fullpath(args[1]);
+		if (!fullpath) {
+			FSCMD_OUTPUT(OUT_OF_MEMORY, args[1]);
+			return ERROR;
+		}
 		ret = unlink(fullpath);
 		if (ret != OK) {
 			FSCMD_OUTPUT(CMD_FAILED, args[0], "unlink");

--- a/os/arch/arm/src/common/up_createstack.c
+++ b/os/arch/arm/src/common/up_createstack.c
@@ -147,6 +147,8 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
 {
 	size_t stack_alloc_size = stack_size;
 
+	DEBUGASSERT(tcb);
+
 	/* new thread does not have the uheap value yet, It's added in the task_
 	 * schedsetup function.
 	 * Parent and child threads must have the same uheap value, so we are

--- a/os/arch/arm/src/common/up_releasestack.c
+++ b/os/arch/arm/src/common/up_releasestack.c
@@ -123,6 +123,8 @@ void up_release_stack(FAR struct tcb_s *dtcb, uint8_t ttype)
 {
 	/* Is there a stack allocated? */
 
+	DEBUGASSERT(dtcb);
+
 	if (dtcb->stack_alloc_ptr) {
 #ifdef CONFIG_MPU_STACK_OVERFLOW_PROTECTION
 		/* If this dtcb belongs to running thread, then it's stack

--- a/os/arch/arm/src/common/up_stackframe.c
+++ b/os/arch/arm/src/common/up_stackframe.c
@@ -118,6 +118,8 @@ FAR void *up_stack_frame(FAR struct tcb_s *tcb, size_t frame_size)
 {
 	uintptr_t topaddr;
 
+	DEBUGASSERT(tcb);
+
 	/* Align the frame_size */
 
 	frame_size = STACK_ALIGN_UP(frame_size);

--- a/os/arch/arm/src/common/up_usestack.c
+++ b/os/arch/arm/src/common/up_usestack.c
@@ -115,6 +115,8 @@ int up_use_stack(struct tcb_s *tcb, void *stack, size_t stack_size)
 	size_t top_of_stack;
 	size_t size_of_stack;
 
+	DEBUGASSERT(tcb);
+
 	/* Is there already a stack allocated? */
 
 	if (tcb->stack_alloc_ptr) {

--- a/os/binfmt/binfmt_exec.c
+++ b/os/binfmt/binfmt_exec.c
@@ -141,6 +141,12 @@ int exec(FAR const char *filename, FAR char *const *argv, FAR const struct symta
 	int errcode = OK;
 	int ret;
 
+	if (!filename) {
+		berr("ERROR: Invalid argument, filename is NULL");
+		errcode = EINVAL;
+		goto errout;
+	}
+
 #ifdef CONFIG_APP_BINARY_SEPARATION
 	/* Allocate the RAM partition to load the app into */
 	uint32_t *start_addr;
@@ -224,8 +230,8 @@ errout_with_bin:
 err_free_partition:
 #ifdef CONFIG_APP_BINARY_SEPARATION
 	kmm_free((void *)start_addr);
-errout:
 #endif
+	errout:
 	set_errno(errcode);
 	return ERROR;
 

--- a/os/binfmt/libbuiltin/libbuiltin_isavail.c
+++ b/os/binfmt/libbuiltin/libbuiltin_isavail.c
@@ -63,6 +63,7 @@
 
 #include <tinyara/config.h>
 
+#include <debug.h>
 #include <string.h>
 #include <limits.h>
 #include <errno.h>
@@ -86,6 +87,12 @@ int builtin_isavail(FAR const char *appname)
 {
 	FAR const char *name;
 	int i;
+
+	if (!appname) {
+		berr("ERROR: Invalid argument, appname is NULL\n");
+		set_errno(EINVAL);
+		return ERROR;
+	}
 
 	for (i = 0; (name = builtin_getname(i)); i++) {
 		if (!strncmp(name, appname, NAME_MAX)) {

--- a/os/board/common/partitions.c
+++ b/os/board/common/partitions.c
@@ -264,7 +264,18 @@ static void move_to_next_part(const char **par)
 int get_partition_num(char *part)
 {
 	int partno = 0;
-	int name_len = strlen(part);
+	int name_len;
+
+	if (!part) {
+		printf("ERROR: Invalid argument, part is NULL\n");
+		return ERROR;
+	}
+
+	name_len = strlen(part);
+	if (name_len == 0) {
+		printf("ERROR: name_len is 0\n");
+		return ERROR;
+	}
 
 	char *partname = CONFIG_FLASH_PART_NAME;
 	while (*partname) {

--- a/os/board/rtl8730e/src/rtl8730e_ist415.c
+++ b/os/board/rtl8730e/src/rtl8730e_ist415.c
@@ -92,12 +92,12 @@ static void rtl8730e_ist415_irq_handler(uint32_t id, gpio_irq_event event)
 	 * until we finish this particular interrupt related work
 	 * in the HPWORK thread
 	 */
-	struct ist415_config_s *dev;
+	struct ist415_config_s *dev = NULL;
 	if (id == 0) {
 		dev =  &g_rtl8730e_ist415_0;
 	}
 
-	if (dev->handler != NULL) {
+	if (dev && dev->handler != NULL) {
 		dev->handler(dev);
 	}
 }

--- a/os/board/rtl8730e/src/rtl8730e_st7789.c
+++ b/os/board/rtl8730e/src/rtl8730e_st7789.c
@@ -105,6 +105,10 @@ void rtl8730_st7789_initialize(void)
 	gpio_pins_init();
 
 	FAR struct spi_dev_s *spi = up_spiinitialize(CONFIG_LCD_ST7789_SPI_PORT);
+	if (!spi) {
+		lcddbg("ERROR: Failed to initialize SPI port %d\n", CONFIG_LCD_ST7789_SPI_PORT);
+		return;
+	}
 	struct lcd_dev_s *dev = st7789_lcdinitialize(spi, &g_rtl8730_config_dev_s.lcd_config);
 	if (lcddev_register(dev) < 0) {
 		lcddbg("ERROR: LCD driver register fail\n");

--- a/os/compression/compress.c
+++ b/os/compression/compress.c
@@ -69,17 +69,23 @@ unsigned char *allocate_compress_buffer(int offset, unsigned int size)
 int compress_block(unsigned char *out_buffer, long unsigned int *writesize, unsigned char *read_buffer, long unsigned int size)
 {
 	int ret;
+
+	if (!out_buffer || !writesize || !read_buffer) {
+		bcmpdbg("ERROR: Invalid Argument, out_buffer: %p, writesize: %p, read_buffer: %p, size: %lu\n", out_buffer, writesize, read_buffer, size);
+		return -EINVAL;
+	}
+
 #if CONFIG_COMPRESSION_TYPE == LZMA
 	unsigned int propsSize = LZMA_PROPS_SIZE;
 	ret = LzmaCompress(&out_buffer[LZMA_PROPS_SIZE], writesize, read_buffer, size, out_buffer, &propsSize, 0, 1 << 13, -1, -1, -1, -1, 1);
 	if (ret == SZ_ERROR_FAIL) {
-		dbg("Failure to compress with LZMACompress API\n");
+		bcmpdbg("ERROR: Failure to compress with LZMACompress API\n");
 		ret = -ret;
 	}
 #elif CONFIG_COMPRESSION_TYPE == MINIZ
 	ret = mz_compress(out_buffer, writesize, read_buffer, size);
 	if (ret != Z_OK) {
-		dbg("Failure to compress with Miniz's compress API; ret = %d\n", ret);
+		bcmpdbg("ERROR: Failure to compress with Miniz's compress API; ret = %d\n", ret);
 		if (ret > 0)
 			ret = -ret;
 	}
@@ -100,6 +106,12 @@ int compress_block(unsigned char *out_buffer, long unsigned int *writesize, unsi
 int decompress_block(unsigned char *out_buffer, long unsigned int *writesize, unsigned char *read_buffer, long unsigned int *size)
 {
 	int ret = ERROR;
+
+	if (!out_buffer || !writesize || !read_buffer || !size) {
+		bcmpdbg("ERROR: Invalid Argument, out_buffer: %p, writesize: %p, read_buffer: %p, size: %p\n", out_buffer, writesize, read_buffer, size);
+		return -EINVAL;
+	}
+
 #if CONFIG_COMPRESSION_TYPE == LZMA
 	/* LZMA specific logic for decompression */
 	*size -= (LZMA_PROPS_SIZE);
@@ -108,12 +120,12 @@ int decompress_block(unsigned char *out_buffer, long unsigned int *writesize, un
 	ret = LzmaUncompress(&out_buffer[0], (unsigned int *)writesize, &read_buffer[LZMA_PROPS_SIZE], (unsigned int *)size, &read_buffer[0], LZMA_PROPS_SIZE);
 	if (ret == SZ_OK) {
 		if (*size < read_size) {
-			bcmpdbg("Out buffer allocated is not sufficient, some inputs are still left to be uncompressed\n");
+			bcmpdbg("ERROR: Out buffer allocated is not sufficient, some inputs are still left to be uncompressed\n");
 			return -ENOMEM;
 		}
 		return OK;
 	} else {
-		bcmpdbg("Failure to decompress with LZMA's uncompress API; ret = %d\n", ret);
+		bcmpdbg("ERROR: Failure to decompress with LZMA's uncompress API; ret = %d\n", ret);
 		if (ret == SZ_ERROR_INPUT_EOF) {
 			return OK;
 		}
@@ -123,7 +135,7 @@ int decompress_block(unsigned char *out_buffer, long unsigned int *writesize, un
 	/* Miniz specific logic for decompression */
 	ret = mz_uncompress(out_buffer, writesize, read_buffer, *size);
 	if (ret != Z_OK) {
-		bcmpdbg("Failure to decompress with Miniz's uncompress API; ret = %d\n", ret);
+		bcmpdbg("ERROR: Failure to decompress with Miniz's uncompress API; ret = %d\n", ret);
 		if (ret == Z_BUF_ERROR) {
 			return -ENOMEM;
 		}

--- a/os/drivers/analog/dac.c
+++ b/os/drivers/analog/dac.c
@@ -446,6 +446,11 @@ int dac_txdone(FAR struct dac_dev_s *dev)
 {
 	int ret = -ENOENT;
 
+	if (!dev) {
+		lldbg("ERROR: Invalid argument, dev is NULL\n");
+		return -EINVAL;
+	}
+
 	/* Verify that the xmit FIFO is not empty */
 
 	if (dev->ad_xmit.af_head != dev->ad_xmit.af_tail) {
@@ -471,6 +476,11 @@ int dac_txdone(FAR struct dac_dev_s *dev)
 int dac_register(FAR const char *path, FAR struct dac_dev_s *dev)
 {
 	/* Initialize the DAC device structure */
+
+	if (!dev) {
+		lldbg("ERROR: Invalid argument, dev is NULL\n");
+		return -EINVAL;
+	}
 
 	dev->ad_ocount = 0;
 

--- a/os/drivers/serial/serial.c
+++ b/os/drivers/serial/serial.c
@@ -1358,6 +1358,11 @@ int uart_register(FAR const char *path, FAR uart_dev_t *dev)
 {
 	int ret;
 
+	if (!dev) {
+		lldbg("ERROR: Invalid argument, dev is NULL\n");
+		return -EINVAL;
+	}
+
 	/* Initialize semaphores */
 	sem_init(&dev->xmit.sem, 0, 1);
 	sem_init(&dev->recv.sem, 0, 1);

--- a/os/drivers/video/video_null_driver.c
+++ b/os/drivers/video/video_null_driver.c
@@ -1583,7 +1583,7 @@ int video_null_initialize(const char *devpath)
 	/* Allocate the null driver priv data */
 	priv = (FAR struct dummy_null_priv_s *)
 		   kmm_zalloc(sizeof(struct dummy_null_priv_s));
-	if (!lower) {
+	if (!priv) {
 		videovdbg("ERROR: Null driver private data allocation failed\n");
 		ret = -ENOMEM;
 		goto errout_with_priv_data;

--- a/os/kernel/clock/clock_abstime2ticks.c
+++ b/os/kernel/clock/clock_abstime2ticks.c
@@ -134,6 +134,11 @@ int clock_abstime2ticks(clockid_t clockid, FAR const struct timespec *abstime, F
 	struct timespec reltime;
 	int             ret;
 
+	if (!abstime || !ticks) {
+		sdbg("ERROR: Invalid arguments, abstime: %p, ticks: %p\n", abstime, ticks);
+		return EINVAL; 
+	}
+
 	/* Convert the timespec to clock ticks.  NOTE: Here we use internal knowledge
 	 * that CLOCK_REALTIME is defined to be zero!
 	 */

--- a/os/kernel/group/group_childstatus.c
+++ b/os/kernel/group/group_childstatus.c
@@ -262,6 +262,8 @@ void group_freechild(FAR struct child_status_s *child)
 
 void group_addchild(FAR struct task_group_s *group, FAR struct child_status_s *child)
 {
+	DEBUGASSERT(group && child);
+	
 	/* Add the entry into the TCB list of children */
 
 	child->flink = group->tg_children;

--- a/os/kernel/init/os_bringup.c
+++ b/os/kernel/init/os_bringup.c
@@ -270,7 +270,8 @@ static inline void os_workqueues(void)
 #if defined(CONFIG_INIT_ENTRYPOINT)
 static inline void os_do_appstart(void)
 {
-	int pid;
+	// Need to initialize pid to positive value to avoid assert when every CONFIG is disabled.
+	int pid = 1;
 
 #ifdef CONFIG_SILENT_REBOOT
 	silent_reboot_initialize();
@@ -384,6 +385,9 @@ static inline void os_do_appstart(void)
 
 #if defined(CONFIG_USER_ENTRYPOINT)
 	pid = task_create("appmain", PRI_USER_MAIN, CONFIG_USERMAIN_STACKSIZE, (main_t)CONFIG_USER_ENTRYPOINT, (FAR char *const *)NULL);
+	if (pid < 0) {
+		sdbg("ERROR: Failed to start appmain");
+	}
 #endif
 #endif // !CONFIG_APP_BINARY_SEPARATION
 

--- a/os/kernel/mqueue/mq_rcvinternal.c
+++ b/os/kernel/mqueue/mq_rcvinternal.c
@@ -125,7 +125,7 @@ int mq_verifyreceive(mqd_t mqdes, FAR char *msg, size_t msglen)
 {
 	/* Verify the input parameters */
 
-	if (!msg || !mqdes) {
+	if (!msg || !mqdes || !mqdes->msgq) {
 		set_errno(EINVAL);
 		return ERROR;
 	}

--- a/os/kernel/mqueue/mq_sndinternal.c
+++ b/os/kernel/mqueue/mq_sndinternal.c
@@ -130,7 +130,7 @@ int mq_verifysend(mqd_t mqdes, FAR const char *msg, size_t msglen, int prio)
 {
 	/* Verify the input parameters */
 
-	if (!msg || !mqdes || prio < 0 || prio > MQ_PRIO_MAX) {
+	if (!msg || !mqdes || !mqdes->msgq || prio < 0 || prio > MQ_PRIO_MAX) {
 		set_errno(EINVAL);
 		return ERROR;
 	}

--- a/os/kernel/pthread/pthread_create.c
+++ b/os/kernel/pthread/pthread_create.c
@@ -261,6 +261,10 @@ int pthread_create(FAR pthread_t *thread, FAR const pthread_attr_t *attr, pthrea
 	ASSERT((sched_self()->flags & TCB_FLAG_TTYPE_MASK) != TCB_FLAG_TTYPE_KERNEL);
 #endif
 
+	if (!start_routine) {
+		sdbg("ERROR: start_routine is NULL\n");
+		return EINVAL;
+	}
 
 	/* Check whether we are allowed to create new pthread ? */
 

--- a/os/kernel/sched/sched_addblocked.c
+++ b/os/kernel/sched/sched_addblocked.c
@@ -109,7 +109,7 @@ void sched_addblocked(FAR struct tcb_s *btcb, tstate_t task_state)
 {
 	/* Make sure that we received a valid blocked state */
 
-	ASSERT(task_state >= FIRST_BLOCKED_STATE && task_state <= LAST_BLOCKED_STATE);
+	ASSERT(btcb && task_state >= FIRST_BLOCKED_STATE && task_state <= LAST_BLOCKED_STATE);
 
 	/* Add the TCB to the blocked task list associated with this state.
 	 * First, determine if the task is to be added to a prioritized task

--- a/os/kernel/sched/sched_addprioritized.c
+++ b/os/kernel/sched/sched_addprioritized.c
@@ -116,11 +116,13 @@ bool sched_addprioritized(FAR struct tcb_s *tcb, DSEG dq_queue_t *list)
 {
 	FAR struct tcb_s *next;
 	FAR struct tcb_s *prev;
-	uint8_t sched_priority = tcb->sched_priority;
+	uint8_t sched_priority;
 	bool ret = false;
 
 	/* Lets do a sanity check before we get started. */
 
+	ASSERT(tcb && list);
+	sched_priority = tcb->sched_priority;
 	ASSERT(sched_priority >= SCHED_PRIORITY_MIN);
 
 	/* Search the list to find the location to insert the new Tcb.

--- a/os/kernel/sched/sched_migrate_tasks.c
+++ b/os/kernel/sched/sched_migrate_tasks.c
@@ -105,7 +105,8 @@ int sched_migrate_tasks(int offline_cpu)
 	 * Since there's no _foreach_safe macro, we must manually get the next
 	 * pointer before removing the current TCB.
 	 */
-
+	
+	DEBUGASSERT(task_list);
 	tcb = (FAR struct tcb_s *)task_list->tail;
 
 	DEBUGASSERT(tcb && tcb->flink == NULL);
@@ -131,7 +132,7 @@ int sched_migrate_tasks(int offline_cpu)
 	 * The idle task for that CPU would also have been processed.
 	 * We can now mark the CPU as offline in any global masks if not already done.
 	 */
-	DEBUGASSERT((task_list)->head->flink == NULL);	/* Assert if the head of assigned list is not idle */
+	DEBUGASSERT(task_list->head && (task_list)->head->flink == NULL);	/* Assert if the head of assigned list is not idle */
 
 	/* Release critical section and scheduler lock.
 	 * Releasing the scheduler lock (sched_unlock) will process any tasks

--- a/os/kernel/sched/sched_setscheduler.c
+++ b/os/kernel/sched/sched_setscheduler.c
@@ -130,6 +130,12 @@ int sched_setscheduler(pid_t pid, int policy, const struct sched_param *param)
 #endif
 	int ret;
 
+	if (!param) {
+		sdbg("ERROR: Invalid argument, param is NULL\n");
+		set_errno(EINVAL);
+		return ERROR;
+	}
+
 	/* Check for supported scheduling policy */
 
 #if CONFIG_RR_INTERVAL > 0

--- a/os/kernel/sched/sched_timerexpiration.c
+++ b/os/kernel/sched/sched_timerexpiration.c
@@ -255,6 +255,8 @@ static unsigned int sched_process_timeslice(int cpu, unsigned int ticks, bool no
 #endif
 	int decr;
 
+	DEBUGASSERT(rtcb);
+
 	/* Check if the currently executing task uses round robin
 	 * scheduling.
 	 */

--- a/os/kernel/semaphore/sem_holder.c
+++ b/os/kernel/semaphore/sem_holder.c
@@ -221,7 +221,7 @@ static int sem_foreachholder(FAR sem_t *sem, holderhandler_t handler, FAR void *
 
 		if (pholder->htcb) {
 			/* Call the handler */
-
+			DEBUGASSERT(handler);
 			ret = handler(pholder, sem, arg);
 		}
 	}

--- a/os/kernel/signal/sig_action.c
+++ b/os/kernel/signal/sig_action.c
@@ -198,7 +198,9 @@ int sigaction(int signo, FAR const struct sigaction *act, FAR struct sigaction *
 
 #ifdef CONFIG_SIGKILL_HANDLER
 	if (signo == SIGKILL) {
-		rtcb->sigkillusrhandler = act->sa_sigaction;
+		if (act) {
+			rtcb->sigkillusrhandler = act->sa_sigaction;
+		}
 		return OK;
 	}
 #endif

--- a/os/kernel/task/task_create.c
+++ b/os/kernel/task/task_create.c
@@ -136,6 +136,12 @@ static int thread_create(FAR const char *name, uint8_t ttype, int priority, int 
 	int errcode;
 	int ret;
 
+	if (stack_size < 0 || !entry) {
+		sdbg("ERROR: Invalid arguments, stack_size=%d, entry=%p\n", stack_size, entry);
+		errcode = EINVAL;
+		goto errout;
+	}
+
 	/* Check whether we are allowed to create new task ? */
 	if (g_alive_taskcount == CONFIG_MAX_TASKS) {
 		sdbg("ERROR: CONFIG_MAX_TASKS(%d) count reached\n", CONFIG_MAX_TASKS);

--- a/os/mm/mm_heap/mm_addfreechunk.c
+++ b/os/mm/mm_heap/mm_addfreechunk.c
@@ -84,6 +84,8 @@ void mm_addfreechunk(FAR struct mm_heap_s *heap, FAR struct mm_freenode_s *node)
 	FAR struct mm_freenode_s *next;
 	FAR struct mm_freenode_s *prev;
 
+	DEBUGASSERT(heap && node);
+
 	/* Convert the size to a nodelist index */
 
 	int ndx = mm_size2ndx(node->size);

--- a/os/mm/mm_heap/mm_calloc.c
+++ b/os/mm/mm_heap/mm_calloc.c
@@ -78,6 +78,11 @@ FAR void *mm_calloc(FAR struct mm_heap_s *heap, size_t n, size_t elem_size, mmad
 {
 	FAR void *ret = NULL;
 
+	if (elem_size == 0) {
+		mdbg("ERROR: Invalid argument, elem_size is 0\n");
+		return NULL;
+	}
+
 	if (n > (MMSIZE_MAX / elem_size)) {
 		mdbg("Parameter n(%u) should be smaller than (MMSIZE_MAX / elem_size)(%u), \
 			because multiplication of n and elem_size cannot overflow the size_t.\n", n, (MMSIZE_MAX / elem_size));

--- a/os/mm/mm_heap/mm_free.c
+++ b/os/mm/mm_heap/mm_free.c
@@ -141,6 +141,7 @@ static void mm_free_internal(FAR struct mm_heap_s *heap, FAR void *mem, mmaddres
 		return;
 	}
 
+	DEBUGASSERT(heap);
 	/* We need to hold the MM semaphore while we muck with the
 	 * nodelist.
 	 */

--- a/os/mm/mm_heap/mm_mallinfo.c
+++ b/os/mm/mm_heap/mm_mallinfo.c
@@ -100,7 +100,7 @@ int mm_mallinfo_aligned(FAR struct mm_heap_s *heap, FAR struct mallinfo *info, s
 #define region 0
 #endif
 
-	DEBUGASSERT(info);
+	DEBUGASSERT(info && heap);
 
 	/* Visit each region */
 

--- a/os/mm/mm_heap/mm_malloc.c
+++ b/os/mm/mm_heap/mm_malloc.c
@@ -153,6 +153,8 @@ FAR void *mm_malloc(FAR struct mm_heap_s *heap, size_t size, mmaddress_t caller_
 	size_t gc_before_size;
 #endif
 
+	DEBUGASSERT(heap);
+
 	/* Free the delay list first */
 	mm_free_delaylist(heap);
 

--- a/os/mm/mm_heap/mm_sbrk.c
+++ b/os/mm/mm_heap/mm_sbrk.c
@@ -116,6 +116,8 @@ FAR void *mm_sbrk(FAR struct mm_heap_s *heap, intptr_t incr, uintptr_t maxbreak)
 	size_t bytesize;
 	int err;
 
+	DEBUGASSERT(heap);
+
 	DEBUGASSERT(incr >= 0);
 	if (incr < 0) {
 		err = ENOSYS;

--- a/os/wqueue/work_cancel.c
+++ b/os/wqueue/work_cancel.c
@@ -58,6 +58,7 @@
 
 #include <queue.h>
 #include <assert.h>
+#include <debug.h>
 #include <errno.h>
 
 #include <tinyara/arch.h>
@@ -115,7 +116,11 @@ int work_qcancel(FAR struct wqueue_s *wqueue, FAR struct work_s *work)
 	struct work_s *cur_work;
 	int ret = -ENOENT;
 
-	DEBUGASSERT(work != NULL);
+	DEBUGASSERT(wqueue);
+	if (!work) {
+		sdbg("ERROR: Invalid argument, work is NULL\n");
+		return -ENOENT;
+	}
 
 	/* Cancelling the work is simply a matter of removing the work structure
 	 * from the work queue.  This must be done with interrupts disabled because

--- a/os/wqueue/work_process.c
+++ b/os/wqueue/work_process.c
@@ -130,6 +130,8 @@ void work_process(FAR struct wqueue_s *wqueue, int wndx)
 	clock_t ctick;
 	clock_t next;
 
+	DEBUGASSERT(wqueue);
+
 	/* Then process queued work.  We need to keep interrupts disabled while
 	 * we process items in the work list.
 	 */

--- a/os/wqueue/work_queue.c
+++ b/os/wqueue/work_queue.c
@@ -59,6 +59,7 @@
 #include <stdint.h>
 #include <queue.h>
 #include <assert.h>
+#include <debug.h>
 #include <errno.h>
 
 #include <tinyara/arch.h>
@@ -118,13 +119,17 @@
 
 int work_qqueue(FAR struct wqueue_s *wqueue, FAR struct work_s *work, worker_t worker, FAR void *arg, clock_t delay)
 {
-	DEBUGASSERT(work != NULL);
-
 	struct work_s *next_work = NULL;
 	struct work_s *cur_work;
 	clock_t elapsed;
 	clock_t ctick;
 	ctick = clock();
+
+	DEBUGASSERT(wqueue);
+	if (!work) {
+		sdbg("ERROR: Invalid argument, work is NULL\n");
+		return -ENOENT;
+	}
 
 #if defined(CONFIG_SCHED_USRWORK) && !defined(__KERNEL__)
 	while (work_lock() < 0);


### PR DESCRIPTION
### 1. os: Add NULL parameter check in some functions
Add DEBUGASSERT where parameter cannot be NULL in that function.
Add condition check where NULL parameter is not allowed.
There is no significant difference in performance between before and after adding NULL checks.

[After add NULL check]
```
########## Kernel TC End [PASS : 420, FAIL : 0] ##########
tc_kernel_main elapsed: 124.028000000 sec

########## Kernel TC End [PASS : 420, FAIL : 0] ##########
tc_kernel_main elapsed: 124.028000000 sec

########## Kernel TC End [PASS : 420, FAIL : 0] ##########
tc_kernel_main elapsed: 124.028000000 sec
```

[Before add NULL check]
```
########## Kernel TC End [PASS : 420, FAIL : 0] ##########
tc_kernel_main elapsed: 124.029000000 sec

########## Kernel TC End [PASS : 420, FAIL : 0] ##########
tc_kernel_main elapsed: 124.028000000 sec

########## Kernel TC End [PASS : 420, FAIL : 0] ##########
tc_kernel_main elapsed: 124.028000000 sec
```


### 2. apps: Add NULL parameter check in some functions
Add condition check where NULL parameter is not allowed.
