### PR TITLE
os/kernel/binary_manager: Recover BP again when bootloader recovered BP

### DIFF
--- a/os/kernel/binary_manager/binary_manager_bootparam.c
+++ b/os/kernel/binary_manager/binary_manager_bootparam.c
@@ -681,6 +681,11 @@ int binary_manager_check_bootparam_set(void)
 		return BINMGR_OPERATION_FAIL;
 	}
 
+	if (bp_data->tail.bp_update_reason >= BP_UPDATE_BOOTLOADER_BP_CRC_FAIL && bp_data->tail.bp_update_reason <= BP_UPDATE_BOOTLOADER_SPECIFIC_3) {
+		bmdbg("Don't trust the recovery by bootloader, try to recover again.\n");
+		return BINMGR_OPERATION_FAIL;
+	}
+
 	bmdbg("BP set is already aligned and active set %s is valid\n", GET_PARTNAME(bp_data->head.active_idx));
 	return BINMGR_OK;
 }


### PR DESCRIPTION
When the bootloader recovers the BP, we cannot fully trust the result. 
The bootloader's recovery is minimal; it only recovers the CRC and the active index, without validating other data. 
There can be cases where the bootloader recovers to a certain partition, but another partition actually contains a more recent binary. 
Even if the bootloader's recovery seems valid, the binary manager must perform another recovery check to handle such scenarios. 
To ensure the system boots with the correct binary, the binary manager, which has all the necessary information, will now always perform its own recovery process for safety, even if the bootloader has already performed one.