### PR TITLE
arch/arm: Enhance assert handler with IRQ tracking and SP corruption diagnostics

### DIFF
--- a/os/arch/arm/src/amebasmart/amebasmart_irq.c
+++ b/os/arch/arm/src/amebasmart/amebasmart_irq.c
@@ -184,3 +184,35 @@ uintptr_t arm_intstack_alloc(void)
   return g_irqstack_top[up_cpu_index()] - INTSTACK_SIZE;
 }
 #endif
+
+/****************************************************************************
+ * Name: arm_intstack_top_for_cpu
+ *
+ * Description:
+ *   Return a pointer to the top the correct interrupt stack allocation
+ *   for the given CPU.
+ *
+ ****************************************************************************/
+
+#if defined(CONFIG_SMP) && CONFIG_ARCH_INTERRUPTSTACK > 7
+uintptr_t arm_intstack_top_for_cpu(int cpu)
+{
+  return g_irqstack_top[cpu];
+}
+#endif
+
+/****************************************************************************
+ * Name: arm_intstack_alloc_for_cpu
+ *
+ * Description:
+ *   Return a pointer to the "alloc" the correct interrupt stack allocation
+ *   for the given CPU.
+ *
+ ****************************************************************************/
+
+#if defined(CONFIG_SMP) && CONFIG_ARCH_INTERRUPTSTACK > 7
+uintptr_t arm_intstack_alloc_for_cpu(int cpu)
+{
+  return g_irqstack_top[cpu] - INTSTACK_SIZE;
+}
+#endif

--- a/os/arch/arm/src/armv7-a/arm_assert.c
+++ b/os/arch/arm/src/armv7-a/arm_assert.c
@@ -117,6 +117,8 @@ extern sq_queue_t g_freemsg_list;
 extern uint32_t system_exception_location;
 extern uint32_t user_assert_location;
 extern int g_irq_num[CONFIG_SMP_NCPUS];
+extern int g_last_irq_num[CONFIG_SMP_NCPUS];
+extern clock_t g_last_irq_time[CONFIG_SMP_NCPUS];
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
@@ -374,6 +376,8 @@ static void up_dumpstate(struct tcb_s *fault_tcb, uint32_t asserted_location)
 	uint32_t stacksize = 0;
 	uint32_t istackbase;
 	uint32_t istacksize;
+	int cpu = 0;
+	uint32_t *stack_bottom = 0;
 #if CONFIG_ARCH_INTERRUPTSTACK > 3
 	istackbase = 0;
 	istacksize = 0;
@@ -398,13 +402,38 @@ static void up_dumpstate(struct tcb_s *fault_tcb, uint32_t asserted_location)
 	stackbase = (uint32_t)fault_tcb->adj_stack_ptr;
 	stacksize = (uint32_t)fault_tcb->adj_stack_size;
 #if CONFIG_ARCH_INTERRUPTSTACK > 7
+	istacksize = (CONFIG_ARCH_INTERRUPTSTACK & ~7);
 #ifdef CONFIG_SMP
 	/* Initialize istackbase based on the interrupt stack size and proper alignment value (~7) */
+	for(cpu = 0; cpu <CONFIG_SMP_NCPUS; ++cpu) {
+		istackbase = ((uint32_t)arm_intstack_alloc_for_cpu(cpu) + (CONFIG_ARCH_INTERRUPTSTACK & ~7));
+		lldbg("CPU%d IRQ stack: base 0x%08x size 0x%08x (0x%08x - 0x%08x)\n",
+	      	cpu, istackbase, istacksize, istackbase - istacksize + 1, istackbase);
+#ifdef CONFIG_STACK_COLORATION
+		stack_bottom = (uint32_t *)(arm_intstack_alloc_for_cpu(cpu));
+		if (*stack_bottom != INTSTACK_COLOR) {
+			lldbg("CPU%d IRQ stack OVERFLOW detected! Bottom color overwritten: 0x%08x (expected 0x%08x)\n",
+				cpu, *stack_bottom, INTSTACK_COLOR);
+		}
+#endif
+		up_stackdump(istackbase - istacksize + 1, istackbase);
+		lldbg("CPU%d Last IRQ: %d at tick %llu\n",cpu, g_last_irq_num[cpu], g_last_irq_time[cpu]);
+	}
 	istackbase = ((uint32_t)arm_intstack_alloc() + (CONFIG_ARCH_INTERRUPTSTACK & ~7));
 #else
 	istackbase = (uint32_t)&g_intstackbase,
+	lldbg("IRQ stack: base 0x%08x size 0x%08x (0x%08x - 0x%08x)\n",
+	    istackbase, istacksize, istackbase - istacksize + 1, istackbase);
+#ifdef CONFIG_STACK_COLORATION
+	/* Check for interrupt stack overflow */
+	stack_bottom = (uint32_t *)&g_intstackalloc;
+	if (*stack_bottom != INTSTACK_COLOR) {
+		lldbg("IRQ stack OVERFLOW detected! Bottom color overwritten: 0x%08x (expected 0x%08x)\n",
+		    *stack_bottom, INTSTACK_COLOR);
+	}
+	up_stackdump(istackbase - istacksize + 1, istackbase);
 #endif
-	istacksize = (CONFIG_ARCH_INTERRUPTSTACK & ~7);
+#endif
 #endif
 	bool is_irq_assert = false;
 	bool is_sp_corrupt = false;
@@ -416,6 +445,11 @@ static void up_dumpstate(struct tcb_s *fault_tcb, uint32_t asserted_location)
 
 	/*Print IRQ handler details if required */
 	check_sp_corruption(sp, &stackbase, &stacksize, istackbase, istacksize, is_irq_assert, &is_sp_corrupt);
+
+	/* If SP is corrupt, find which heap node (if any) contains the address in SP */
+	if (is_sp_corrupt) {
+		mm_dump_node_containing((void *)sp);
+	}
 
 	/* Print stack dump */
 	print_stack_dump(sp, stackbase, stacksize, istackbase, istacksize, is_irq_assert, is_sp_corrupt);

--- a/os/arch/arm/src/armv7-a/arm_doirq.c
+++ b/os/arch/arm/src/armv7-a/arm_doirq.c
@@ -49,6 +49,7 @@
 #include <tinyara/arch.h>
 #include <tinyara/board.h>
 #include <arch/board/board.h>
+#include <tinyara/clock.h>
 
 #include "up_internal.h"
 #include "group/group.h"
@@ -59,6 +60,8 @@
  ****************************************************************************/
 
 int g_irq_num[CONFIG_SMP_NCPUS] = {-1, };				/* Array to store the last three interrupt numbers */
+int g_last_irq_num[CONFIG_SMP_NCPUS] = {-1, };			/* Array to store last serviced interrupt per cpu */
+clock_t g_last_irq_time[CONFIG_SMP_NCPUS] = {0, };		/* Arrray to store time of last serviced interrupt */
 /****************************************************************************
  * Name: arm_doirq
  *
@@ -120,6 +123,8 @@ uint32_t *arm_doirq(int irq, uint32_t *regs)
   CURRENT_REGS = NULL;
 #endif
 	/* Reset the interrupt number values */
+	g_last_irq_num[up_cpu_index()] = g_irq_num[up_cpu_index()];
+	g_last_irq_time[up_cpu_index()] = clock_systimer();
 	g_irq_num[up_cpu_index()] = -1;
 
 	board_autoled_off(LED_INIRQ);

--- a/os/arch/arm/src/common/up_internal.h
+++ b/os/arch/arm/src/common/up_internal.h
@@ -412,6 +412,8 @@ void arm_vectorfiq(void);
 #if defined(CONFIG_SMP) && CONFIG_ARCH_INTERRUPTSTACK > 7
 uintptr_t arm_intstack_alloc(void);
 uintptr_t arm_intstack_top(void);
+uintptr_t arm_intstack_alloc_for_cpu(int cpu);
+uintptr_t arm_intstack_top_for_cpu(int cpu);
 #endif
 
 #ifdef CONFIG_PAGING

--- a/os/arch/arm/src/imx6/imx_irq.c
+++ b/os/arch/arm/src/imx6/imx_irq.c
@@ -205,3 +205,35 @@ uintptr_t arm_intstack_alloc(void)
   return g_irqstack_top[up_cpu_index()] - INTSTACK_SIZE;
 }
 #endif
+
+/****************************************************************************
+ * Name: arm_intstack_top_for_cpu
+ *
+ * Description:
+ *   Return a pointer to the top the correct interrupt stack allocation
+ *   for the given CPU.
+ *
+ ****************************************************************************/
+
+#if defined(CONFIG_SMP) && CONFIG_ARCH_INTERRUPTSTACK > 7
+uintptr_t arm_intstack_top_for_cpu(int cpu)
+{
+  return g_irqstack_top[cpu];
+}
+#endif
+
+/****************************************************************************
+ * Name: arm_intstack_alloc_for_cpu
+ *
+ * Description:
+ *   Return a pointer to the "alloc" the correct interrupt stack allocation
+ *   for the given CPU.
+ *
+ ****************************************************************************/
+
+#if defined(CONFIG_SMP) && CONFIG_ARCH_INTERRUPTSTACK > 7
+uintptr_t arm_intstack_alloc_for_cpu(int cpu)
+{
+  return g_irqstack_top[cpu] - INTSTACK_SIZE;
+}
+#endif

--- a/os/include/tinyara/mm/mm.h
+++ b/os/include/tinyara/mm/mm.h
@@ -660,6 +660,7 @@ int mm_size2ndx(size_t size);
 void mm_dump_node(struct mm_allocnode_s *node, char *node_type);
 void mm_dump_heap_region(uint32_t start, uint32_t end);
 void mm_dump_heap_free_node_list(struct mm_heap_s *heap);
+void mm_dump_node_containing(void *address);
 int heap_dbg(const char *fmt, ...);
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
 /* Functions contained in kmm_mallinfo.c . Used to display memory allocation details */

--- a/os/mm/mm_heap/mm_heap_dbg.c
+++ b/os/mm/mm_heap/mm_heap_dbg.c
@@ -142,3 +142,91 @@ void mm_dump_node(struct mm_allocnode_s *node, char *node_type)
 #endif
 #endif
 }
+
+/************************************************************************
+ * Name: mm_dump_node_containing
+ *
+ * Description: Given an arbitrary address, find and print the owner of
+ *              the heap node that contains this address. This is useful
+ *              when a corrupted SP points into the heap and you want to
+ *              know which allocation owns that memory.
+ ************************************************************************/
+void mm_dump_node_containing(void *address)
+{
+	struct mm_allocnode_s *node;
+	struct mm_heap_s *heap;
+	int region;
+	uint32_t target = (uint32_t)address;
+
+	if (!address) {
+		mfdbg("Cannot find node for NULL address\n");
+		return;
+	}
+
+	/* Find which heap this address belongs to */
+	heap = mm_get_heap(address);
+	if (!heap) {
+		mfdbg("Address 0x%08x is not in any heap\n", target);
+		return;
+	}
+
+	mfdbg("===========================================================\n");
+	mfdbg("Finding heap node containing address 0x%08x\n", target);
+	mfdbg("===========================================================\n");
+
+	/* Walk each region of the heap */
+#if CONFIG_KMM_REGIONS > 1
+	for (region = 0; region < heap->mm_nregions; region++)
+#else
+	region = 0;
+#endif
+	{
+		/* Walk nodes forward from heap start */
+		for (node = heap->mm_heapstart[region];
+		     node <= heap->mm_heapend[region];
+		     node = (struct mm_allocnode_s *)((char *)node + node->size)) {
+
+			/* Check if the target address falls within this node's data area.
+			 * The data area starts at (node + SIZEOF_MM_ALLOCNODE) and
+			 * extends to (node + node->size).
+			 */
+			if (target >= (uint32_t)node + SIZEOF_MM_ALLOCNODE &&
+			    target < (uint32_t)node + node->size) {
+
+				mfdbg("Address 0x%08x is inside heap node:\n", target);
+				mm_dump_node(node, "CONTAINING NODE");
+
+				/* Also dump adjacent nodes for context */
+				/*if (node->preceding & MM_ALLOC_BIT) {
+					mmsize_t prev_size = node->preceding & ~MM_ALLOC_BIT;
+					if (prev_size >= SIZEOF_MM_ALLOCNODE) {
+						struct mm_allocnode_s *prev_node =
+							(struct mm_allocnode_s *)((char *)node - prev_size);
+						if ((void *)prev_node >= (void *)heap->mm_heapstart[region] &&
+						    (void *)prev_node < (void *)heap->mm_heapend[region]) {
+							mm_dump_node(prev_node, "PREV ADJACENT NODE");
+						}
+					}
+				}
+
+				struct mm_allocnode_s *next_node =
+					(struct mm_allocnode_s *)((char *)node + node->size);
+				if ((void *)next_node >= (void *)heap->mm_heapstart[region] &&
+				    (void *)next_node <= (void *)heap->mm_heapend[region]) {
+					mm_dump_node(next_node, "NEXT ADJACENT NODE");
+				}*/
+
+				return;  /* Found it, done */
+			}
+
+			/* Safety: if node->size is 0 or corrupted, break to avoid infinite loop */
+			if (node->size < SIZEOF_MM_ALLOCNODE) {
+				mfdbg("Corrupted node at 0x%08x (size=%u), stopping search\n",
+				       node, node->size);
+				break;
+			}
+		}
+	}
+
+	mfdbg("Address 0x%08x not found in any heap node\n", target);
+}


### PR DESCRIPTION
Add last serviced IRQ tracking with timestamp in arm_doirq, storing the IRQ number and system tick time per CPU after each interrupt handler completes. This information is printed in the assert handler to show the last IRQ serviced on each CPU along with its timestamp.

Extend interrupt stack information dump to print IRQ stack base, size, and last IRQ details for ALL CPUs in SMP configurations (previously only the current CPU was displayed). Add per-CPU accessor functions arm_intstack_alloc_for_cpu() and arm_intstack_top_for_cpu() to enable querying any CPU's interrupt stack bounds.

Add interrupt stack overflow detection by checking the INTSTACK_COLOR (0xdeadbeef) marker at the bottom of each CPU's interrupt stack. If the color value has been overwritten, the stack has overflowed and a warning is printed. This check is enabled when CONFIG_STACK_COLORATION is enabled.

Add mm_dump_node_containing() helper in the heap debug module that, given an arbitrary address, walks the heap to find and print the owner of the heap node containing that address. This is called from the assert handler when SP corruption is detected, allowing identification of which heap allocation the corrupted stack pointer points into.

Modified files:
- arch/arm/src/armv7-a/arm_doirq.c: Add g_last_irq_num, g_last_irq_time arrays and capture them after IRQ dispatch
- arch/arm/src/armv7-a/arm_assert.c: Print IRQ stack info for all CPUs, detect interrupt stack overflow via INTSTACK_COLOR check, and look up heap node owner when SP is corrupt
- arch/arm/src/amebasmart/amebasmart_irq.c: Add arm_intstack_alloc_for_cpu() and arm_intstack_top_for_cpu() per-CPU accessor functions
- arch/arm/src/imx6/imx_irq.c: Add arm_intstack_alloc_for_cpu() and arm_intstack_top_for_cpu() per-CPU accessor functions
- arch/arm/src/common/up_internal.h: Declare new per-CPU intstack accessor functions
- mm/mm_heap/mm_heap_dbg.c: Add mm_dump_node_containing() function
- include/tinyara/mm/mm.h: Declare mm_dump_node_containing()

Additional information added for assertion failure debugging.

| Log File | TRAP Tool Output | Test Description |
|-------|----------------------|---------------|
| buffer_overflow.log | trap_buffer_oveflow.txt | Buffer overflow to corrupt next node header |
| direct_node_header.log | trap_direct_node_out | Directly corrupt node size field (0x0E037513) |

Signed-Off By: Vivek Jain (vivek1.j@samsung.com)