### PR TITLE
os: Distinguish reboot reasons by kernel and user

### DIFF
--- a/apps/examples/reboot_reason_test/reboot_reason_main.c
+++ b/apps/examples/reboot_reason_test/reboot_reason_main.c
@@ -196,14 +196,22 @@ int reboot_reason_main(int argc, char *argv[])
 		case 'M':
 		case 'm':
 			/* Test for Memory Allocation Fail */
+#ifdef CONFIG_APP_BINARY_SEPARATION
+			printf("After Memory Allocation Fail, Expected Reboot reason is %d\n", REBOOT_USER_MEMORYALLOCFAIL);
+#else
 			printf("After Memory Allocation Fail, Expected Reboot reason is %d\n", REBOOT_SYSTEM_MEMORYALLOCFAIL);
+#endif
 			memory_alloc_fail_test();
 			break;
 #endif
 		case 'P':
 		case 'p':
 			/* Test for Prefetch Abort */
+#ifdef CONFIG_APP_BINARY_SEPARATION
+			printf("After Prefetch Abort, Expected Reboot reason is %d\n", REBOOT_USER_PREFETCHABORT);
+#else
 			printf("After Prefetch Abort, Expected Reboot reason is %d\n", REBOOT_SYSTEM_PREFETCHABORT);
+#endif
 			prefetch_abort_test();
 			break;
 		case 'V':
@@ -217,7 +225,11 @@ int reboot_reason_main(int argc, char *argv[])
 		case 'c':
 			/* Clear the previous reboot reason with REBOOT_REASON_INITIALIZED(0) */
 			printf("Will write %d and then will clear.\n", REBOOT_REASON_TEST_VAL);
-			printf("Expected reboot reason after reset is %d, otherwise wrong operation.\n", REBOOT_UNKNOWN);
+#ifdef CONFIG_APP_BINARY_SEPARATION
+			printf("Expected reboot reason after reset is %d, otherwise wrong operation.\n", REBOOT_USER_WITHOUT_SET_REASON);
+#else
+			printf("Expected reboot reason after reset is %d, otherwise wrong operation.\n", REBOOT_SYSTEM_WITHOUT_SET_REASON);
+#endif
 			WRITE_REBOOT_REASON(REBOOT_REASON_TEST_VAL);
 			CLEAR_REBOOT_REASON();
 			reboot_board();

--- a/apps/examples/reboot_reason_test/reboot_reason_main.c
+++ b/apps/examples/reboot_reason_test/reboot_reason_main.c
@@ -205,26 +205,42 @@ int reboot_reason_main(int argc, char *argv[])
 		case 'M':
 		case 'm':
 			/* Test for Memory Allocation Fail */
+#ifdef CONFIG_APP_BINARY_SEPARATION
+			printf("After Memory Allocation Fail, Expected Reboot reason is %d\n", REBOOT_USER_MEMORYALLOCFAIL);
+#else
 			printf("After Memory Allocation Fail, Expected Reboot reason is %d\n", REBOOT_SYSTEM_MEMORYALLOCFAIL);
+#endif
 			memory_alloc_fail_test();
 			break;
 #endif
 		case 'D':
 		case 'd':
 			/* Test for Data Abort */
+#ifdef CONFIG_APP_BINARY_SEPARATION
+			printf("After Data Abort, Expected Reboot reason is %d\n", REBOOT_USER_DATAABORT);
+#else
 			printf("After Data Abort, Expected Reboot reason is %d\n", REBOOT_SYSTEM_DATAABORT);
+#endif
 			data_abort_test();
 			break;
 		case 'P':
 		case 'p':
 			/* Test for Prefetch Abort */
+#ifdef CONFIG_APP_BINARY_SEPARATION
+			printf("After Prefetch Abort, Expected Reboot reason is %d\n", REBOOT_USER_PREFETCHABORT);
+#else
 			printf("After Prefetch Abort, Expected Reboot reason is %d\n", REBOOT_SYSTEM_PREFETCHABORT);
+#endif
 			prefetch_abort_test();
 			break;
 		case 'A':
 		case 'a':
 			/* Test for Assert */
+#ifdef CONFIG_APP_BINARY_SEPARATION
+			printf("After Assert, Expected Reboot reason is %d\n", REBOOT_USER_ASSERT);
+#else
 			printf("After Assert, Expected Reboot reason is %d\n", REBOOT_SYSTEM_ASSERT);
+#endif
 			assert(0);
 			break;
 		case 'V':
@@ -238,7 +254,11 @@ int reboot_reason_main(int argc, char *argv[])
 		case 'c':
 			/* Clear the previous reboot reason with REBOOT_REASON_INITIALIZED(0) */
 			printf("Will write %d and then will clear.\n", REBOOT_REASON_TEST_VAL);
+#ifdef CONFIG_APP_BINARY_SEPARATION
+			printf("Expected reboot reason after reset is %d, otherwise wrong operation.\n", REBOOT_USER_WITHOUT_SET_REASON);
+#else
 			printf("Expected reboot reason after reset is %d, otherwise wrong operation.\n", REBOOT_SYSTEM_WITHOUT_SET_REASON);
+#endif
 			WRITE_REBOOT_REASON(REBOOT_REASON_TEST_VAL);
 			CLEAR_REBOOT_REASON();
 			reboot_board();

--- a/os/arch/arm/include/reboot_reason.h
+++ b/os/arch/arm/include/reboot_reason.h
@@ -19,6 +19,7 @@
 #define __ARCH_ARM_INCLUDE_REBOOT_REASON_H
 
 #include <stdbool.h>
+#include <stdint.h>
 #include <tinyara/reboot_reason.h>
 
 /****************************************************************************
@@ -28,7 +29,8 @@
 void up_reboot_reason_init(void);
 reboot_reason_code_t up_reboot_reason_read(void);
 void up_reboot_reason_write(reboot_reason_code_t reason);
-void reboot_reason_try_write_assert(void);
+void reboot_reason_try_write_assert(bool is_user_assert);
+void reboot_reason_write_by_addr(uintptr_t addr, reboot_reason_code_t system_reason, reboot_reason_code_t user_reason);
 void up_reboot_reason_clear(void);
 bool up_reboot_reason_is_written(void);
 

--- a/os/arch/arm/include/reboot_reason.h
+++ b/os/arch/arm/include/reboot_reason.h
@@ -19,6 +19,7 @@
 #define __ARCH_ARM_INCLUDE_REBOOT_REASON_H
 
 #include <stdbool.h>
+#include <stdint.h>
 #include <tinyara/reboot_reason.h>
 
 /****************************************************************************
@@ -28,7 +29,8 @@
 void up_reboot_reason_init(void);
 reboot_reason_code_t up_reboot_reason_read(void);
 void up_reboot_reason_write(reboot_reason_code_t reason);
-void reboot_reason_try_write_assert(void);
+void reboot_reason_try_write_assert(uintptr_t addr);
+void up_reboot_reason_write_by_addr(uintptr_t addr, reboot_reason_code_t reason);
 void up_reboot_reason_clear(void);
 bool up_reboot_reason_is_written(void);
 

--- a/os/arch/arm/src/amebad/amebad_irq.c
+++ b/os/arch/arm/src/amebad/amebad_irq.c
@@ -112,6 +112,18 @@ volatile uint32_t *current_regs;
  * Private Functions
  ****************************************************************************/
 
+#ifdef CONFIG_SYSTEM_REBOOT_REASON
+static void amebad_write_prefetchabort_reason(FAR void *context)
+{
+  if (context) {
+    uint32_t *regs = (uint32_t *)context;
+    reboot_reason_write_by_addr(regs[REG_R15], REBOOT_SYSTEM_PREFETCHABORT, REBOOT_USER_PREFETCHABORT);
+  } else {
+    up_reboot_reason_write(REBOOT_SYSTEM_PREFETCHABORT);
+  }
+}
+#endif
+
 /****************************************************************************
  * Name: amebad_dumpnvic
  *
@@ -161,7 +173,7 @@ static int amebad_nmi(int irq, FAR void *context, FAR void *arg)
   (void)irqsave();
   dbg("PANIC!!! NMI received\n");
 #ifdef CONFIG_SYSTEM_REBOOT_REASON
-  up_reboot_reason_write(REBOOT_SYSTEM_PREFETCHABORT);
+  amebad_write_prefetchabort_reason(context);
 #endif
   PANIC();
   return 0;
@@ -172,7 +184,7 @@ static int amebad_pendsv(int irq, FAR void *context, FAR void *arg)
   (void)irqsave();
   dbg("PANIC!!! PendSV received\n");
 #ifdef CONFIG_SYSTEM_REBOOT_REASON
-  up_reboot_reason_write(REBOOT_SYSTEM_PREFETCHABORT);
+  amebad_write_prefetchabort_reason(context);
 #endif
   PANIC();
   return 0;
@@ -183,7 +195,7 @@ static int amebad_dbgmonitor(int irq, FAR void *context, FAR void *arg)
   (void)irqsave();
   dbg("PANIC!!! Debug Monitor received\n");
 #ifdef CONFIG_SYSTEM_REBOOT_REASON
-  up_reboot_reason_write(REBOOT_SYSTEM_PREFETCHABORT);
+  amebad_write_prefetchabort_reason(context);
 #endif
   PANIC();
   return 0;
@@ -194,7 +206,7 @@ static int amebad_reserved(int irq, FAR void *context, FAR void *arg)
   (void)irqsave();
   dbg("PANIC!!! Reserved interrupt\n");
 #ifdef CONFIG_SYSTEM_REBOOT_REASON
-  up_reboot_reason_write(REBOOT_SYSTEM_PREFETCHABORT);
+  amebad_write_prefetchabort_reason(context);
 #endif
   PANIC();
   return 0;

--- a/os/arch/arm/src/amebad/amebad_irq.c
+++ b/os/arch/arm/src/amebad/amebad_irq.c
@@ -161,7 +161,7 @@ static int amebad_nmi(int irq, FAR void *context, FAR void *arg)
   (void)irqsave();
   dbg("PANIC!!! NMI received\n");
 #ifdef CONFIG_SYSTEM_REBOOT_REASON
-  up_reboot_reason_write(REBOOT_SYSTEM_PREFETCHABORT);
+  up_reboot_reason_write_by_addr(((uint32_t *)context)[REG_R15], REBOOT_SYSTEM_PREFETCHABORT);
 #endif
   PANIC();
   return 0;
@@ -172,7 +172,7 @@ static int amebad_pendsv(int irq, FAR void *context, FAR void *arg)
   (void)irqsave();
   dbg("PANIC!!! PendSV received\n");
 #ifdef CONFIG_SYSTEM_REBOOT_REASON
-  up_reboot_reason_write(REBOOT_SYSTEM_PREFETCHABORT);
+  up_reboot_reason_write_by_addr(((uint32_t *)context)[REG_R15], REBOOT_SYSTEM_PREFETCHABORT);
 #endif
   PANIC();
   return 0;
@@ -183,7 +183,7 @@ static int amebad_dbgmonitor(int irq, FAR void *context, FAR void *arg)
   (void)irqsave();
   dbg("PANIC!!! Debug Monitor received\n");
 #ifdef CONFIG_SYSTEM_REBOOT_REASON
-  up_reboot_reason_write(REBOOT_SYSTEM_PREFETCHABORT);
+  up_reboot_reason_write_by_addr(((uint32_t *)context)[REG_R15], REBOOT_SYSTEM_PREFETCHABORT);
 #endif
   PANIC();
   return 0;
@@ -194,7 +194,7 @@ static int amebad_reserved(int irq, FAR void *context, FAR void *arg)
   (void)irqsave();
   dbg("PANIC!!! Reserved interrupt\n");
 #ifdef CONFIG_SYSTEM_REBOOT_REASON
-  up_reboot_reason_write(REBOOT_SYSTEM_PREFETCHABORT);
+  up_reboot_reason_write_by_addr(((uint32_t *)context)[REG_R15], REBOOT_SYSTEM_PREFETCHABORT);
 #endif
   PANIC();
   return 0;

--- a/os/arch/arm/src/amebalite/amebalite_irq.c
+++ b/os/arch/arm/src/amebalite/amebalite_irq.c
@@ -112,6 +112,18 @@ volatile uint32_t *current_regs;
  * Private Functions
  ****************************************************************************/
 
+#ifdef CONFIG_SYSTEM_REBOOT_REASON
+static void amebalite_write_prefetchabort_reason(FAR void *context)
+{
+  if (context) {
+    uint32_t *regs = (uint32_t *)context;
+    reboot_reason_write_by_addr(regs[REG_R15], REBOOT_SYSTEM_PREFETCHABORT, REBOOT_USER_PREFETCHABORT);
+  } else {
+    up_reboot_reason_write(REBOOT_SYSTEM_PREFETCHABORT);
+  }
+}
+#endif
+
 /****************************************************************************
  * Name: amebalite_dumpnvic
  *
@@ -161,7 +173,7 @@ static int amebalite_nmi(int irq, FAR void *context, FAR void *arg)
   (void)irqsave();
   dbg("PANIC!!! NMI received\n");
 #ifdef CONFIG_SYSTEM_REBOOT_REASON
-  up_reboot_reason_write(REBOOT_SYSTEM_PREFETCHABORT);
+  amebalite_write_prefetchabort_reason(context);
 #endif
   PANIC();
   return 0;
@@ -172,7 +184,7 @@ static int amebalite_pendsv(int irq, FAR void *context, FAR void *arg)
   (void)irqsave();
   dbg("PANIC!!! PendSV received\n");
 #ifdef CONFIG_SYSTEM_REBOOT_REASON
-  up_reboot_reason_write(REBOOT_SYSTEM_PREFETCHABORT);
+  amebalite_write_prefetchabort_reason(context);
 #endif
   PANIC();
   return 0;
@@ -183,7 +195,7 @@ static int amebalite_dbgmonitor(int irq, FAR void *context, FAR void *arg)
   (void)irqsave();
   dbg("PANIC!!! Debug Monitor received\n");
 #ifdef CONFIG_SYSTEM_REBOOT_REASON
-  up_reboot_reason_write(REBOOT_SYSTEM_PREFETCHABORT);
+  amebalite_write_prefetchabort_reason(context);
 #endif
   PANIC();
   return 0;
@@ -194,7 +206,7 @@ static int amebalite_reserved(int irq, FAR void *context, FAR void *arg)
   (void)irqsave();
   dbg("PANIC!!! Reserved interrupt\n");
 #ifdef CONFIG_SYSTEM_REBOOT_REASON
-  up_reboot_reason_write(REBOOT_SYSTEM_PREFETCHABORT);
+  amebalite_write_prefetchabort_reason(context);
 #endif
   PANIC();
   return 0;

--- a/os/arch/arm/src/amebalite/amebalite_irq.c
+++ b/os/arch/arm/src/amebalite/amebalite_irq.c
@@ -161,7 +161,7 @@ static int amebalite_nmi(int irq, FAR void *context, FAR void *arg)
   (void)irqsave();
   dbg("PANIC!!! NMI received\n");
 #ifdef CONFIG_SYSTEM_REBOOT_REASON
-  up_reboot_reason_write(REBOOT_SYSTEM_PREFETCHABORT);
+  up_reboot_reason_write_by_addr(((uint32_t *)context)[REG_R15], REBOOT_SYSTEM_PREFETCHABORT);
 #endif
   PANIC();
   return 0;
@@ -172,7 +172,7 @@ static int amebalite_pendsv(int irq, FAR void *context, FAR void *arg)
   (void)irqsave();
   dbg("PANIC!!! PendSV received\n");
 #ifdef CONFIG_SYSTEM_REBOOT_REASON
-  up_reboot_reason_write(REBOOT_SYSTEM_PREFETCHABORT);
+  up_reboot_reason_write_by_addr(((uint32_t *)context)[REG_R15], REBOOT_SYSTEM_PREFETCHABORT);
 #endif
   PANIC();
   return 0;
@@ -183,7 +183,7 @@ static int amebalite_dbgmonitor(int irq, FAR void *context, FAR void *arg)
   (void)irqsave();
   dbg("PANIC!!! Debug Monitor received\n");
 #ifdef CONFIG_SYSTEM_REBOOT_REASON
-  up_reboot_reason_write(REBOOT_SYSTEM_PREFETCHABORT);
+  up_reboot_reason_write_by_addr(((uint32_t *)context)[REG_R15], REBOOT_SYSTEM_PREFETCHABORT);
 #endif
   PANIC();
   return 0;
@@ -194,7 +194,7 @@ static int amebalite_reserved(int irq, FAR void *context, FAR void *arg)
   (void)irqsave();
   dbg("PANIC!!! Reserved interrupt\n");
 #ifdef CONFIG_SYSTEM_REBOOT_REASON
-  up_reboot_reason_write(REBOOT_SYSTEM_PREFETCHABORT);
+  up_reboot_reason_write_by_addr(((uint32_t *)context)[REG_R15], REBOOT_SYSTEM_PREFETCHABORT);
 #endif
   PANIC();
   return 0;

--- a/os/arch/arm/src/armino/armino_irq.c
+++ b/os/arch/arm/src/armino/armino_irq.c
@@ -120,6 +120,18 @@ volatile uint32_t *current_regs;
  * Private Functions
  ****************************************************************************/
 
+#ifdef CONFIG_SYSTEM_REBOOT_REASON
+static void armino_write_prefetchabort_reason(FAR void *context)
+{
+  if (context) {
+    uint32_t *regs = (uint32_t *)context;
+    reboot_reason_write_by_addr(regs[REG_R15], REBOOT_SYSTEM_PREFETCHABORT, REBOOT_USER_PREFETCHABORT);
+  } else {
+    up_reboot_reason_write(REBOOT_SYSTEM_PREFETCHABORT);
+  }
+}
+#endif
+
 /****************************************************************************
  * Name: armino_dumpnvic
  *
@@ -169,7 +181,7 @@ static int armino_securefault(int irq, FAR void *context, FAR void *arg)
   (void)irqsave();
   dbg("PANIC!!! secure received\n");
 #ifdef CONFIG_SYSTEM_REBOOT_REASON
-  up_reboot_reason_write(REBOOT_SYSTEM_PREFETCHABORT);
+  armino_write_prefetchabort_reason(context);
 #endif
   PANIC();
   return 0;
@@ -180,7 +192,7 @@ static int armino_pendsv(int irq, FAR void *context, FAR void *arg)
   (void)irqsave();
   dbg("PANIC!!! PendSV received\n");
 #ifdef CONFIG_SYSTEM_REBOOT_REASON
-  up_reboot_reason_write(REBOOT_SYSTEM_PREFETCHABORT);
+  armino_write_prefetchabort_reason(context);
 #endif
   PANIC();
   return 0;
@@ -191,7 +203,7 @@ static int armino_dbgmonitor(int irq, FAR void *context, FAR void *arg)
   (void)irqsave();
   dbg("PANIC!!! Debug Monitor received\n");
 #ifdef CONFIG_SYSTEM_REBOOT_REASON
-  up_reboot_reason_write(REBOOT_SYSTEM_PREFETCHABORT);
+  armino_write_prefetchabort_reason(context);
 #endif
   PANIC();
   return 0;
@@ -202,7 +214,7 @@ static int armino_reserved(int irq, FAR void *context, FAR void *arg)
   (void)irqsave();
   dbg("PANIC!!! Reserved interrupt\n");
 #ifdef CONFIG_SYSTEM_REBOOT_REASON
-  up_reboot_reason_write(REBOOT_SYSTEM_PREFETCHABORT);
+  armino_write_prefetchabort_reason(context);
 #endif
   PANIC();
   return 0;

--- a/os/arch/arm/src/armino/armino_irq.c
+++ b/os/arch/arm/src/armino/armino_irq.c
@@ -169,7 +169,7 @@ static int armino_securefault(int irq, FAR void *context, FAR void *arg)
   (void)irqsave();
   dbg("PANIC!!! secure received\n");
 #ifdef CONFIG_SYSTEM_REBOOT_REASON
-  up_reboot_reason_write(REBOOT_SYSTEM_PREFETCHABORT);
+  up_reboot_reason_write_by_addr(((uint32_t *)context)[REG_R15], REBOOT_SYSTEM_PREFETCHABORT);
 #endif
   PANIC();
   return 0;
@@ -180,7 +180,7 @@ static int armino_pendsv(int irq, FAR void *context, FAR void *arg)
   (void)irqsave();
   dbg("PANIC!!! PendSV received\n");
 #ifdef CONFIG_SYSTEM_REBOOT_REASON
-  up_reboot_reason_write(REBOOT_SYSTEM_PREFETCHABORT);
+  up_reboot_reason_write_by_addr(((uint32_t *)context)[REG_R15], REBOOT_SYSTEM_PREFETCHABORT);
 #endif
   PANIC();
   return 0;
@@ -191,7 +191,7 @@ static int armino_dbgmonitor(int irq, FAR void *context, FAR void *arg)
   (void)irqsave();
   dbg("PANIC!!! Debug Monitor received\n");
 #ifdef CONFIG_SYSTEM_REBOOT_REASON
-  up_reboot_reason_write(REBOOT_SYSTEM_PREFETCHABORT);
+  up_reboot_reason_write_by_addr(((uint32_t *)context)[REG_R15], REBOOT_SYSTEM_PREFETCHABORT);
 #endif
   PANIC();
   return 0;
@@ -202,7 +202,7 @@ static int armino_reserved(int irq, FAR void *context, FAR void *arg)
   (void)irqsave();
   dbg("PANIC!!! Reserved interrupt\n");
 #ifdef CONFIG_SYSTEM_REBOOT_REASON
-  up_reboot_reason_write(REBOOT_SYSTEM_PREFETCHABORT);
+  up_reboot_reason_write_by_addr(((uint32_t *)context)[REG_R15], REBOOT_SYSTEM_PREFETCHABORT);
 #endif
   PANIC();
   return 0;

--- a/os/arch/arm/src/armv7-a/arm_assert.c
+++ b/os/arch/arm/src/armv7-a/arm_assert.c
@@ -621,9 +621,8 @@ void up_assert(const uint8_t *filename, int lineno)
 	board_autoled_on(LED_ASSERTION);
 
 #ifdef CONFIG_SYSTEM_REBOOT_REASON
-	reboot_reason_try_write_assert();
+	reboot_reason_try_write_assert(IS_FAULT_IN_USER_SPACE(asserted_location));
 #endif
-
 
 #ifdef CONFIG_SECURITY_LEVEL
 	lldbg_noarg("security level: %d\n", get_security_level());

--- a/os/arch/arm/src/armv7-a/arm_assert.c
+++ b/os/arch/arm/src/armv7-a/arm_assert.c
@@ -621,9 +621,8 @@ void up_assert(const uint8_t *filename, int lineno)
 	board_autoled_on(LED_ASSERTION);
 
 #ifdef CONFIG_SYSTEM_REBOOT_REASON
-	reboot_reason_try_write_assert();
+	reboot_reason_try_write_assert(asserted_location);
 #endif
-
 
 #ifdef CONFIG_SECURITY_LEVEL
 	lldbg_noarg("security level: %d\n", get_security_level());

--- a/os/arch/arm/src/armv7-a/arm_dataabort.c
+++ b/os/arch/arm/src/armv7-a/arm_dataabort.c
@@ -189,7 +189,7 @@ segfault:
 	}
 
 #ifdef CONFIG_SYSTEM_REBOOT_REASON
-	up_reboot_reason_write(REBOOT_SYSTEM_DATAABORT);
+	reboot_reason_write_by_addr(regs[REG_R15], REBOOT_SYSTEM_DATAABORT, REBOOT_USER_DATAABORT);
 #endif
 	PANIC();
 	return regs;				/* To keep the compiler happy */
@@ -207,7 +207,7 @@ SRAMDRAM_ONLY_TEXT_SECTION uint32_t *arm_dataabort(uint32_t *regs, uint32_t dfar
 	CURRENT_REGS = regs;
 	system_exception_location = regs[REG_R15];
 #ifdef CONFIG_SYSTEM_REBOOT_REASON
-	up_reboot_reason_write(REBOOT_SYSTEM_DATAABORT);
+	reboot_reason_write_by_addr(regs[REG_R15], REBOOT_SYSTEM_DATAABORT, REBOOT_USER_DATAABORT);
 #endif
 
 	/* Crash -- possibly showing diagnostic debug information. */

--- a/os/arch/arm/src/armv7-a/arm_dataabort.c
+++ b/os/arch/arm/src/armv7-a/arm_dataabort.c
@@ -189,7 +189,7 @@ segfault:
 	}
 
 #ifdef CONFIG_SYSTEM_REBOOT_REASON
-	up_reboot_reason_write(REBOOT_SYSTEM_DATAABORT);
+	up_reboot_reason_write_by_addr(regs[REG_R15], REBOOT_SYSTEM_DATAABORT);
 #endif
 	PANIC();
 	return regs;				/* To keep the compiler happy */
@@ -207,7 +207,7 @@ SRAMDRAM_ONLY_TEXT_SECTION uint32_t *arm_dataabort(uint32_t *regs, uint32_t dfar
 	CURRENT_REGS = regs;
 	system_exception_location = regs[REG_R15];
 #ifdef CONFIG_SYSTEM_REBOOT_REASON
-	up_reboot_reason_write(REBOOT_SYSTEM_DATAABORT);
+	up_reboot_reason_write_by_addr(regs[REG_R15], REBOOT_SYSTEM_DATAABORT);
 #endif
 
 	/* Crash -- possibly showing diagnostic debug information. */

--- a/os/arch/arm/src/armv7-a/arm_prefetchabort.c
+++ b/os/arch/arm/src/armv7-a/arm_prefetchabort.c
@@ -154,7 +154,7 @@ uint32_t *arm_prefetchabort(uint32_t *regs, uint32_t ifar, uint32_t ifsr)
 		CURRENT_REGS = savestate;
 	} else {
 #ifdef CONFIG_SYSTEM_REBOOT_REASON
-		up_reboot_reason_write(REBOOT_SYSTEM_PREFETCHABORT);
+		reboot_reason_write_by_addr(regs[REG_R15], REBOOT_SYSTEM_PREFETCHABORT, REBOOT_USER_PREFETCHABORT);
 #endif
 
 		if (!IS_SECURE_STATE()) {
@@ -180,7 +180,7 @@ uint32_t *arm_prefetchabort(uint32_t *regs, uint32_t ifar, uint32_t ifsr)
 	system_exception_location = regs[REG_R15];
 
 #ifdef CONFIG_SYSTEM_REBOOT_REASON
-	up_reboot_reason_write(REBOOT_SYSTEM_PREFETCHABORT);
+	reboot_reason_write_by_addr(regs[REG_R15], REBOOT_SYSTEM_PREFETCHABORT, REBOOT_USER_PREFETCHABORT);
 #endif
 
 	/* Crash -- possibly showing diagnostic debug information. */

--- a/os/arch/arm/src/armv7-a/arm_prefetchabort.c
+++ b/os/arch/arm/src/armv7-a/arm_prefetchabort.c
@@ -154,7 +154,7 @@ uint32_t *arm_prefetchabort(uint32_t *regs, uint32_t ifar, uint32_t ifsr)
 		CURRENT_REGS = savestate;
 	} else {
 #ifdef CONFIG_SYSTEM_REBOOT_REASON
-		up_reboot_reason_write(REBOOT_SYSTEM_PREFETCHABORT);
+		up_reboot_reason_write_by_addr(regs[REG_R15], REBOOT_SYSTEM_PREFETCHABORT);
 #endif
 
 		if (!IS_SECURE_STATE()) {
@@ -180,7 +180,7 @@ uint32_t *arm_prefetchabort(uint32_t *regs, uint32_t ifar, uint32_t ifsr)
 	system_exception_location = regs[REG_R15];
 
 #ifdef CONFIG_SYSTEM_REBOOT_REASON
-	up_reboot_reason_write(REBOOT_SYSTEM_PREFETCHABORT);
+	up_reboot_reason_write_by_addr(regs[REG_R15], REBOOT_SYSTEM_PREFETCHABORT);
 #endif
 
 	/* Crash -- possibly showing diagnostic debug information. */

--- a/os/arch/arm/src/armv7-a/arm_undefinedinsn.c
+++ b/os/arch/arm/src/armv7-a/arm_undefinedinsn.c
@@ -89,7 +89,7 @@ uint32_t *arm_undefinedinsn(uint32_t *regs)
 	CURRENT_REGS = regs;
 	system_exception_location = regs[REG_R15];
 #ifdef CONFIG_SYSTEM_REBOOT_REASON
-	up_reboot_reason_write(REBOOT_SYSTEM_PREFETCHABORT);
+	reboot_reason_write_by_addr(regs[REG_R15], REBOOT_SYSTEM_PREFETCHABORT, REBOOT_USER_PREFETCHABORT);
 #endif
 
 	/* Crash -- possibly showing diagnostic debug information. */

--- a/os/arch/arm/src/armv7-a/arm_undefinedinsn.c
+++ b/os/arch/arm/src/armv7-a/arm_undefinedinsn.c
@@ -89,7 +89,7 @@ uint32_t *arm_undefinedinsn(uint32_t *regs)
 	CURRENT_REGS = regs;
 	system_exception_location = regs[REG_R15];
 #ifdef CONFIG_SYSTEM_REBOOT_REASON
-	up_reboot_reason_write(REBOOT_SYSTEM_PREFETCHABORT);
+	up_reboot_reason_write_by_addr(regs[REG_R15], REBOOT_SYSTEM_PREFETCHABORT);
 #endif
 
 	/* Crash -- possibly showing diagnostic debug information. */

--- a/os/arch/arm/src/armv7-m/up_busfault.c
+++ b/os/arch/arm/src/armv7-m/up_busfault.c
@@ -134,9 +134,9 @@ int up_busfault(int irq, FAR void *context, FAR void *arg)
 
 #ifdef CONFIG_SYSTEM_REBOOT_REASON
 	if (cfsr & IBUSERR) {
-		up_reboot_reason_write(REBOOT_SYSTEM_PREFETCHABORT);
+		reboot_reason_write_by_addr(system_exception_location, REBOOT_SYSTEM_PREFETCHABORT, REBOOT_USER_PREFETCHABORT);
 	} else {
-		up_reboot_reason_write(REBOOT_SYSTEM_DATAABORT);
+		reboot_reason_write_by_addr(system_exception_location, REBOOT_SYSTEM_DATAABORT, REBOOT_USER_DATAABORT);
 	}
 #endif
 

--- a/os/arch/arm/src/armv7-m/up_busfault.c
+++ b/os/arch/arm/src/armv7-m/up_busfault.c
@@ -134,9 +134,9 @@ int up_busfault(int irq, FAR void *context, FAR void *arg)
 
 #ifdef CONFIG_SYSTEM_REBOOT_REASON
 	if (cfsr & IBUSERR) {
-		up_reboot_reason_write(REBOOT_SYSTEM_PREFETCHABORT);
+		up_reboot_reason_write_by_addr(system_exception_location, REBOOT_SYSTEM_PREFETCHABORT);
 	} else {
-		up_reboot_reason_write(REBOOT_SYSTEM_DATAABORT);
+		up_reboot_reason_write_by_addr(system_exception_location, REBOOT_SYSTEM_DATAABORT);
 	}
 #endif
 

--- a/os/arch/arm/src/armv7-m/up_memfault.c
+++ b/os/arch/arm/src/armv7-m/up_memfault.c
@@ -165,9 +165,9 @@ int up_memfault(int irq, FAR void *context, FAR void *arg)
 
 #ifdef CONFIG_SYSTEM_REBOOT_REASON
 	if (cfsr & IACCVIOL) {
-		up_reboot_reason_write(REBOOT_SYSTEM_PREFETCHABORT);
+		reboot_reason_write_by_addr(system_exception_location, REBOOT_SYSTEM_PREFETCHABORT, REBOOT_USER_PREFETCHABORT);
 	} else {
-		up_reboot_reason_write(REBOOT_SYSTEM_DATAABORT);
+		reboot_reason_write_by_addr(system_exception_location, REBOOT_SYSTEM_DATAABORT, REBOOT_USER_DATAABORT);
 	}
 #endif
 

--- a/os/arch/arm/src/armv7-m/up_memfault.c
+++ b/os/arch/arm/src/armv7-m/up_memfault.c
@@ -165,9 +165,9 @@ int up_memfault(int irq, FAR void *context, FAR void *arg)
 
 #ifdef CONFIG_SYSTEM_REBOOT_REASON
 	if (cfsr & IACCVIOL) {
-		up_reboot_reason_write(REBOOT_SYSTEM_PREFETCHABORT);
+		up_reboot_reason_write_by_addr(system_exception_location, REBOOT_SYSTEM_PREFETCHABORT);
 	} else {
-		up_reboot_reason_write(REBOOT_SYSTEM_DATAABORT);
+		up_reboot_reason_write_by_addr(system_exception_location, REBOOT_SYSTEM_DATAABORT);
 	}
 #endif
 

--- a/os/arch/arm/src/armv7-m/up_usagefault.c
+++ b/os/arch/arm/src/armv7-m/up_usagefault.c
@@ -128,7 +128,7 @@ int up_usagefault(int irq, FAR void *context, FAR void *arg)
 	}
 
 #ifdef CONFIG_SYSTEM_REBOOT_REASON
-	up_reboot_reason_write(REBOOT_SYSTEM_PREFETCHABORT);
+	reboot_reason_write_by_addr(system_exception_location, REBOOT_SYSTEM_PREFETCHABORT, REBOOT_USER_PREFETCHABORT);
 #endif
 
 	PANIC();

--- a/os/arch/arm/src/armv7-m/up_usagefault.c
+++ b/os/arch/arm/src/armv7-m/up_usagefault.c
@@ -128,7 +128,7 @@ int up_usagefault(int irq, FAR void *context, FAR void *arg)
 	}
 
 #ifdef CONFIG_SYSTEM_REBOOT_REASON
-	up_reboot_reason_write(REBOOT_SYSTEM_PREFETCHABORT);
+	up_reboot_reason_write_by_addr(system_exception_location, REBOOT_SYSTEM_PREFETCHABORT);
 #endif
 
 	PANIC();

--- a/os/arch/arm/src/armv8-m/up_assert.c
+++ b/os/arch/arm/src/armv8-m/up_assert.c
@@ -144,8 +144,13 @@ extern int g_irq_nums[3];
 #define CONFIG_BOARD_RESET_ON_ASSERT 0
 #endif
 
-#define IS_FAULT_IN_USER_THREAD(fault_tcb)  ((void *)fault_tcb->uheap != NULL)
-#define IS_FAULT_IN_USER_SPACE(asserted_location)   (is_kernel_space((void *)asserted_location) == false)
+#ifdef CONFIG_APP_BINARY_SEPARATION
+#define IS_FAULT_IN_USER_THREAD(fault_tcb)			((void *)fault_tcb->uheap != NULL)
+#define IS_FAULT_IN_USER_SPACE(asserted_location)	(is_kernel_space((void *)asserted_location) == false)
+#else
+#define IS_FAULT_IN_USER_THREAD(fault_tcb)			(false)
+#define IS_FAULT_IN_USER_SPACE(asserted_location)	(false)
+#endif
 
 #define NORMAL_STATE 0
 #define ABORT_STATE 1
@@ -599,10 +604,6 @@ void up_assert(const uint8_t *filename, int lineno)
 
 	board_led_on(LED_ASSERTION);
 
-#ifdef CONFIG_SYSTEM_REBOOT_REASON
-	reboot_reason_try_write_assert();
-#endif
-
 	uint32_t asserted_location;
 
 	abort_mode = true;
@@ -626,6 +627,10 @@ void up_assert(const uint8_t *filename, int lineno)
 	} else {
 		asserted_location = (uint32_t)GET_RETURN_ADDRESS();
 	}
+
+#ifdef CONFIG_SYSTEM_REBOOT_REASON
+	reboot_reason_try_write_assert(IS_FAULT_IN_USER_SPACE(asserted_location));
+#endif
 
 #ifdef CONFIG_SECURITY_LEVEL
 	lldbg("security level: %d\n", get_security_level());
@@ -664,5 +669,3 @@ void up_assert(const uint8_t *filename, int lineno)
 		_up_assert(EXIT_FAILURE);
 	}
 }
-
-

--- a/os/arch/arm/src/armv8-m/up_assert.c
+++ b/os/arch/arm/src/armv8-m/up_assert.c
@@ -144,8 +144,13 @@ extern int g_irq_nums[3];
 #define CONFIG_BOARD_RESET_ON_ASSERT 0
 #endif
 
-#define IS_FAULT_IN_USER_THREAD(fault_tcb)  ((void *)fault_tcb->uheap != NULL)
-#define IS_FAULT_IN_USER_SPACE(asserted_location)   (is_kernel_space((void *)asserted_location) == false)
+#ifdef CONFIG_APP_BINARY_SEPARATION
+#define IS_FAULT_IN_USER_THREAD(fault_tcb)			((void *)fault_tcb->uheap != NULL)
+#define IS_FAULT_IN_USER_SPACE(asserted_location)	(is_kernel_space((void *)asserted_location) == false)
+#else
+#define IS_FAULT_IN_USER_THREAD(fault_tcb)			(false)
+#define IS_FAULT_IN_USER_SPACE(asserted_location)	(false)
+#endif
 
 #define NORMAL_STATE 0
 #define ABORT_STATE 1
@@ -599,10 +604,6 @@ void up_assert(const uint8_t *filename, int lineno)
 
 	board_led_on(LED_ASSERTION);
 
-#ifdef CONFIG_SYSTEM_REBOOT_REASON
-	reboot_reason_try_write_assert();
-#endif
-
 	uint32_t asserted_location;
 
 	abort_mode = true;
@@ -626,6 +627,10 @@ void up_assert(const uint8_t *filename, int lineno)
 	} else {
 		asserted_location = (uint32_t)GET_RETURN_ADDRESS();
 	}
+
+#ifdef CONFIG_SYSTEM_REBOOT_REASON
+	reboot_reason_try_write_assert(asserted_location);
+#endif
 
 #ifdef CONFIG_SECURITY_LEVEL
 	lldbg("security level: %d\n", get_security_level());
@@ -664,5 +669,3 @@ void up_assert(const uint8_t *filename, int lineno)
 		_up_assert(EXIT_FAILURE);
 	}
 }
-
-

--- a/os/arch/arm/src/armv8-m/up_busfault.c
+++ b/os/arch/arm/src/armv8-m/up_busfault.c
@@ -133,9 +133,9 @@ int up_busfault(int irq, FAR void *context, FAR void *arg)
 
 #ifdef CONFIG_SYSTEM_REBOOT_REASON
 	if (cfsr & IBUSERR) {
-		up_reboot_reason_write(REBOOT_SYSTEM_PREFETCHABORT);
+		reboot_reason_write_by_addr(system_exception_location, REBOOT_SYSTEM_PREFETCHABORT, REBOOT_USER_PREFETCHABORT);
 	} else {
-		up_reboot_reason_write(REBOOT_SYSTEM_DATAABORT);
+		reboot_reason_write_by_addr(system_exception_location, REBOOT_SYSTEM_DATAABORT, REBOOT_USER_DATAABORT);
 	}
 #endif
 

--- a/os/arch/arm/src/armv8-m/up_busfault.c
+++ b/os/arch/arm/src/armv8-m/up_busfault.c
@@ -133,9 +133,9 @@ int up_busfault(int irq, FAR void *context, FAR void *arg)
 
 #ifdef CONFIG_SYSTEM_REBOOT_REASON
 	if (cfsr & IBUSERR) {
-		up_reboot_reason_write(REBOOT_SYSTEM_PREFETCHABORT);
+		up_reboot_reason_write_by_addr(system_exception_location, REBOOT_SYSTEM_PREFETCHABORT);
 	} else {
-		up_reboot_reason_write(REBOOT_SYSTEM_DATAABORT);
+		up_reboot_reason_write_by_addr(system_exception_location, REBOOT_SYSTEM_DATAABORT);
 	}
 #endif
 

--- a/os/arch/arm/src/armv8-m/up_hardfault.c
+++ b/os/arch/arm/src/armv8-m/up_hardfault.c
@@ -210,7 +210,7 @@ int up_hardfault(int irq, FAR void *context, FAR void *arg)
 	(void)irqsave();
 
 #ifdef CONFIG_SYSTEM_REBOOT_REASON
-	up_reboot_reason_write(REBOOT_SYSTEM_PREFETCHABORT);
+	reboot_reason_write_by_addr(system_exception_location, REBOOT_SYSTEM_PREFETCHABORT, REBOOT_USER_PREFETCHABORT);
 #endif
 	PANIC();
 	return OK;

--- a/os/arch/arm/src/armv8-m/up_hardfault.c
+++ b/os/arch/arm/src/armv8-m/up_hardfault.c
@@ -210,7 +210,7 @@ int up_hardfault(int irq, FAR void *context, FAR void *arg)
 	(void)irqsave();
 
 #ifdef CONFIG_SYSTEM_REBOOT_REASON
-	up_reboot_reason_write(REBOOT_SYSTEM_PREFETCHABORT);
+	up_reboot_reason_write_by_addr(system_exception_location, REBOOT_SYSTEM_PREFETCHABORT);
 #endif
 	PANIC();
 	return OK;

--- a/os/arch/arm/src/armv8-m/up_memfault.c
+++ b/os/arch/arm/src/armv8-m/up_memfault.c
@@ -168,9 +168,9 @@ int up_memfault(int irq, FAR void *context, FAR void *arg)
 
 #ifdef CONFIG_SYSTEM_REBOOT_REASON
 	if (cfsr & IACCVIOL) {
-		up_reboot_reason_write(REBOOT_SYSTEM_PREFETCHABORT);
+		reboot_reason_write_by_addr(system_exception_location, REBOOT_SYSTEM_PREFETCHABORT, REBOOT_USER_PREFETCHABORT);
 	} else {
-		up_reboot_reason_write(REBOOT_SYSTEM_DATAABORT);
+		reboot_reason_write_by_addr(system_exception_location, REBOOT_SYSTEM_DATAABORT, REBOOT_USER_DATAABORT);
 	}
 #endif
 	PANIC();

--- a/os/arch/arm/src/armv8-m/up_memfault.c
+++ b/os/arch/arm/src/armv8-m/up_memfault.c
@@ -168,9 +168,9 @@ int up_memfault(int irq, FAR void *context, FAR void *arg)
 
 #ifdef CONFIG_SYSTEM_REBOOT_REASON
 	if (cfsr & IACCVIOL) {
-		up_reboot_reason_write(REBOOT_SYSTEM_PREFETCHABORT);
+		up_reboot_reason_write_by_addr(system_exception_location, REBOOT_SYSTEM_PREFETCHABORT);
 	} else {
-		up_reboot_reason_write(REBOOT_SYSTEM_DATAABORT);
+		up_reboot_reason_write_by_addr(system_exception_location, REBOOT_SYSTEM_DATAABORT);
 	}
 #endif
 	PANIC();

--- a/os/arch/arm/src/armv8-m/up_usagefault.c
+++ b/os/arch/arm/src/armv8-m/up_usagefault.c
@@ -131,7 +131,7 @@ int up_usagefault(int irq, FAR void *context, FAR void *arg)
 	}
 
 #ifdef CONFIG_SYSTEM_REBOOT_REASON
-	 up_reboot_reason_write(REBOOT_SYSTEM_PREFETCHABORT);
+	reboot_reason_write_by_addr(system_exception_location, REBOOT_SYSTEM_PREFETCHABORT, REBOOT_USER_PREFETCHABORT);
 #endif
 
 	PANIC();

--- a/os/arch/arm/src/armv8-m/up_usagefault.c
+++ b/os/arch/arm/src/armv8-m/up_usagefault.c
@@ -131,7 +131,7 @@ int up_usagefault(int irq, FAR void *context, FAR void *arg)
 	}
 
 #ifdef CONFIG_SYSTEM_REBOOT_REASON
-	 up_reboot_reason_write(REBOOT_SYSTEM_PREFETCHABORT);
+	up_reboot_reason_write_by_addr(system_exception_location, REBOOT_SYSTEM_PREFETCHABORT);
 #endif
 
 	PANIC();

--- a/os/arch/arm/src/common/up_reboot_reason.c
+++ b/os/arch/arm/src/common/up_reboot_reason.c
@@ -18,6 +18,7 @@
 
 #include <tinyara/config.h>
 #include <arch/reboot_reason.h>
+#include <tinyara/arch.h>
 #include <tinyara/reboot_reason.h>
 
 /****************************************************************************
@@ -28,11 +29,28 @@
  * Name: reboot_reason_trywrite
  ****************************************************************************/
 #ifdef CONFIG_SYSTEM_REBOOT_REASON
-void reboot_reason_try_write_assert(void)
+void reboot_reason_try_write_assert(bool is_user_assert)
 {
-	/* Write REBOOT_SYSTEM_ASSERT only when there is no written reason before. */
+	/* Write reboot reason only when there is no written reason before. */
 	if (!up_reboot_reason_is_written()) {
-		up_reboot_reason_write(REBOOT_SYSTEM_ASSERT);
+		if (is_user_assert) {
+			up_reboot_reason_write(REBOOT_USER_ASSERT);
+		} else {
+			up_reboot_reason_write(REBOOT_SYSTEM_ASSERT);
+		}
 	}
+}
+
+void reboot_reason_write_by_addr(uintptr_t addr, reboot_reason_code_t system_reason, reboot_reason_code_t user_reason)
+{
+#ifdef CONFIG_APP_BINARY_SEPARATION
+	if (is_kernel_space((void *)addr)) {
+		up_reboot_reason_write(system_reason);
+	} else {
+		up_reboot_reason_write(user_reason);
+	}
+#else
+	up_reboot_reason_write(system_reason);
+#endif
 }
 #endif

--- a/os/arch/arm/src/common/up_reboot_reason.c
+++ b/os/arch/arm/src/common/up_reboot_reason.c
@@ -18,6 +18,7 @@
 
 #include <tinyara/config.h>
 #include <arch/reboot_reason.h>
+#include <tinyara/arch.h>
 #include <tinyara/reboot_reason.h>
 
 /****************************************************************************
@@ -25,14 +26,49 @@
  ****************************************************************************/
 
 /****************************************************************************
- * Name: reboot_reason_trywrite
+ * Name: reboot_reason_try_write_assert
  ****************************************************************************/
 #ifdef CONFIG_SYSTEM_REBOOT_REASON
-void reboot_reason_try_write_assert(void)
+void reboot_reason_try_write_assert(uintptr_t addr)
 {
-	/* Write REBOOT_SYSTEM_ASSERT only when there is no written reason before. */
+	/* Write reboot reason only when there is no written reason before. */
 	if (!up_reboot_reason_is_written()) {
-		up_reboot_reason_write(REBOOT_SYSTEM_ASSERT);
+		up_reboot_reason_write_by_addr(addr, REBOOT_SYSTEM_ASSERT);
 	}
+}
+
+/****************************************************************************
+ * Name: up_reboot_reason_write_by_addr
+ ****************************************************************************/
+void up_reboot_reason_write_by_addr(uintptr_t addr, reboot_reason_code_t reason)
+{
+#ifdef CONFIG_APP_BINARY_SEPARATION
+	if (!is_kernel_space((void *)addr)) {
+		switch (reason) {
+		case REBOOT_SYSTEM_DATAABORT:
+			reason = REBOOT_USER_DATAABORT;
+			break;
+		case REBOOT_SYSTEM_PREFETCHABORT:
+			reason = REBOOT_USER_PREFETCHABORT;
+			break;
+		case REBOOT_SYSTEM_MEMORYALLOCFAIL:
+			reason = REBOOT_USER_MEMORYALLOCFAIL;
+			break;
+		case REBOOT_SYSTEM_WATCHDOG:
+			reason = REBOOT_USER_WATCHDOG;
+			break;
+		case REBOOT_SYSTEM_ASSERT:
+			reason = REBOOT_USER_ASSERT;
+			break;
+		case REBOOT_SYSTEM_WITHOUT_SET_REASON:
+			reason = REBOOT_USER_WITHOUT_SET_REASON;
+			break;
+		default:
+			break;
+		}
+	}
+#endif
+
+	up_reboot_reason_write(reason);
 }
 #endif

--- a/os/arch/boardctl.c
+++ b/os/arch/boardctl.c
@@ -106,7 +106,7 @@ int boardctl(unsigned int cmd, uintptr_t arg)
 {
 	int ret;
 #ifdef CONFIG_BOARDCTL_RESET
-	FAR struct tcb_s *tcb;
+	struct tcb_s *tcb;
 #endif
 
 	switch (cmd) {
@@ -168,7 +168,12 @@ int boardctl(unsigned int cmd, uintptr_t arg)
 			for (int i = 0; i < 10; i++) {
 				lldbg("\n    VIOLATION!!! YOU MUST SET REBOOT REASON!!!\n\n");
 			}
-			up_reboot_reason_write(REBOOT_SYSTEM_WITHOUT_SET_REASON);
+
+			if (tcb && ((tcb->flags & TCB_FLAG_TTYPE_MASK) != TCB_FLAG_TTYPE_KERNEL)) {
+				up_reboot_reason_write(REBOOT_USER_WITHOUT_SET_REASON);
+			} else {
+				up_reboot_reason_write(REBOOT_SYSTEM_WITHOUT_SET_REASON);
+			}
 		}
 #endif
 		/* Add 100ms delay for flushing UART FIFO. */

--- a/os/arch/boardctl.c
+++ b/os/arch/boardctl.c
@@ -67,6 +67,7 @@
 #include <tinyara/board.h>
 #include <tinyara/arch.h>
 #ifdef CONFIG_SYSTEM_REBOOT_REASON
+#include <arch/reboot_reason.h>
 #include <tinyara/reboot_reason.h>
 #endif
 
@@ -168,7 +169,16 @@ int boardctl(unsigned int cmd, uintptr_t arg)
 			for (int i = 0; i < 10; i++) {
 				lldbg("\n    VIOLATION!!! YOU MUST SET REBOOT REASON!!!\n\n");
 			}
+
+#ifdef CONFIG_APP_BINARY_SEPARATION
+			if (((tcb->flags & TCB_FLAG_TTYPE_MASK) != TCB_FLAG_TTYPE_KERNEL)) {
+				up_reboot_reason_write(REBOOT_USER_WITHOUT_SET_REASON);
+			} else {
+				up_reboot_reason_write(REBOOT_SYSTEM_WITHOUT_SET_REASON);
+			}
+#else
 			up_reboot_reason_write(REBOOT_SYSTEM_WITHOUT_SET_REASON);
+#endif
 		}
 #endif
 		/* Add 100ms delay for flushing UART FIFO. */

--- a/os/include/tinyara/reboot_reason.h
+++ b/os/include/tinyara/reboot_reason.h
@@ -44,6 +44,14 @@ typedef enum {
 	REBOOT_SYSTEM_ASSERT               = 60, /* Reboot from ASSERT or PANIC */
 	REBOOT_SYSTEM_WITHOUT_SET_REASON   = 61, /* Software reboot without setting reboot reason beforehand */
 
+	/* User initiated reboot reasons */
+	REBOOT_USER_DATAABORT              = 71, /* Data abort by User */
+	REBOOT_USER_PREFETCHABORT          = 72, /* Prefetch abort by User */
+	REBOOT_USER_MEMORYALLOCFAIL        = 73, /* Memory allocation failure by User */
+	REBOOT_USER_WATCHDOG               = 74, /* Watchdog timeout by User */
+	REBOOT_USER_ASSERT                 = 75, /* Reboot from ASSERT or PANIC by User */
+	REBOOT_USER_WITHOUT_SET_REASON     = 76, /* Software reboot by User without setting reboot reason beforehand */
+
 	REBOOT_NETWORK_WIFICORE_WATCHDOG   = 80, /* Wi-Fi Core Watchdog Reset */
 	REBOOT_NETWORK_WIFICORE_PANIC      = 81, /* Wi-Fi Core Panic */
 	REBOOT_NETWORK_BTCORE_WATCHDOG     = 90, /* BT Core Watchdog Reset */

--- a/os/kernel/task_monitor/task_monitor.c
+++ b/os/kernel/task_monitor/task_monitor.c
@@ -32,6 +32,7 @@
 #include <arch/reboot_reason.h>
 #endif
 
+#include "sched/sched.h"
 #include "task_monitor_internal.h"
 
 static task_monitor_node_t g_monitored_tasks_list[CONFIG_MAX_TASKS];
@@ -53,6 +54,8 @@ int task_monitor_register_list(int pid, int interval)
 	}
 
 	g_monitored_tasks_list[hash_pid].pid = pid;
+	struct tcb_s *tcb = sched_gettcb(pid);
+	g_monitored_tasks_list[hash_pid].is_kernel_task = (tcb && ((tcb->flags & TCB_FLAG_TTYPE_MASK) == TCB_FLAG_TTYPE_KERNEL));
 	if (interval % CONFIG_TASK_MONITOR_INTERVAL == 0) {
 		g_monitored_tasks_list[hash_pid].interval = interval / CONFIG_TASK_MONITOR_INTERVAL;
 	} else {
@@ -84,6 +87,7 @@ void task_monitor_unregester_list(int pid)
 	}
 
 	g_monitored_tasks_list[hash_pid].pid = 0;
+	g_monitored_tasks_list[hash_pid].is_kernel_task = false;
 	interval = g_monitored_tasks_list[hash_pid].interval;
 	g_monitored_tasks_list[hash_pid].interval = 0;
 
@@ -109,6 +113,7 @@ static void task_monitor_init(void)
 		g_monitored_tasks_list[pid_idx].blink = NULL;
 		g_monitored_tasks_list[pid_idx].pid = 0;
 		g_monitored_tasks_list[pid_idx].interval = 0;
+		g_monitored_tasks_list[pid_idx].is_kernel_task = false;
 	}
 
 	g_monitor_cnt = 0;
@@ -160,7 +165,11 @@ int task_monitor(int argc, char *argv[])
 						*  System will be reset.
 						*/
 #ifdef CONFIG_SYSTEM_REBOOT_REASON
-						up_reboot_reason_write(REBOOT_SYSTEM_WATCHDOG);
+						if (next_mon_node->is_kernel_task) {
+							up_reboot_reason_write(REBOOT_SYSTEM_WATCHDOG);
+						} else {
+							up_reboot_reason_write(REBOOT_USER_WATCHDOG);
+						}
 #endif
 						boardctl(BOARDIOC_RESET, 0);
 					} else {

--- a/os/kernel/task_monitor/task_monitor.c
+++ b/os/kernel/task_monitor/task_monitor.c
@@ -32,6 +32,7 @@
 #include <arch/reboot_reason.h>
 #endif
 
+#include "sched/sched.h"
 #include "task_monitor_internal.h"
 
 static task_monitor_node_t g_monitored_tasks_list[CONFIG_MAX_TASKS];
@@ -53,6 +54,10 @@ int task_monitor_register_list(int pid, int interval)
 	}
 
 	g_monitored_tasks_list[hash_pid].pid = pid;
+#ifdef CONFIG_APP_BINARY_SEPARATION
+	struct tcb_s *tcb = sched_gettcb(pid);
+	g_monitored_tasks_list[hash_pid].is_kernel_task = (tcb && ((tcb->flags & TCB_FLAG_TTYPE_MASK) == TCB_FLAG_TTYPE_KERNEL));
+#endif
 	if (interval % CONFIG_TASK_MONITOR_INTERVAL == 0) {
 		g_monitored_tasks_list[hash_pid].interval = interval / CONFIG_TASK_MONITOR_INTERVAL;
 	} else {
@@ -84,6 +89,9 @@ void task_monitor_unregester_list(int pid)
 	}
 
 	g_monitored_tasks_list[hash_pid].pid = 0;
+#ifdef CONFIG_APP_BINARY_SEPARATION
+	g_monitored_tasks_list[hash_pid].is_kernel_task = false;
+#endif
 	interval = g_monitored_tasks_list[hash_pid].interval;
 	g_monitored_tasks_list[hash_pid].interval = 0;
 
@@ -109,6 +117,9 @@ static void task_monitor_init(void)
 		g_monitored_tasks_list[pid_idx].blink = NULL;
 		g_monitored_tasks_list[pid_idx].pid = 0;
 		g_monitored_tasks_list[pid_idx].interval = 0;
+#ifdef CONFIG_APP_BINARY_SEPARATION
+		g_monitored_tasks_list[pid_idx].is_kernel_task = false;
+#endif
 	}
 
 	g_monitor_cnt = 0;
@@ -160,7 +171,15 @@ int task_monitor(int argc, char *argv[])
 						*  System will be reset.
 						*/
 #ifdef CONFIG_SYSTEM_REBOOT_REASON
+#ifdef CONFIG_APP_BINARY_SEPARATION
+						if (next_mon_node->is_kernel_task) {
+							up_reboot_reason_write(REBOOT_SYSTEM_WATCHDOG);
+						} else {
+							up_reboot_reason_write(REBOOT_USER_WATCHDOG);
+						}
+#else
 						up_reboot_reason_write(REBOOT_SYSTEM_WATCHDOG);
+#endif
 #endif
 						boardctl(BOARDIOC_RESET, 0);
 					} else {

--- a/os/kernel/task_monitor/task_monitor_internal.h
+++ b/os/kernel/task_monitor/task_monitor_internal.h
@@ -23,6 +23,7 @@
  * Included Files
  ****************************************************************************/
 #include <queue.h>
+#include <stdbool.h>
 
 #ifdef CONFIG_TASK_MONITOR
 
@@ -33,6 +34,7 @@ struct task_monitor_node_s {
 	FAR struct task_monitor_node_s *blink;
 	int pid;				/* tcb's pid */
 	int interval;
+	bool is_kernel_task;
 };
 
 typedef struct task_monitor_node_s task_monitor_node_t;

--- a/os/kernel/task_monitor/task_monitor_internal.h
+++ b/os/kernel/task_monitor/task_monitor_internal.h
@@ -23,6 +23,7 @@
  * Included Files
  ****************************************************************************/
 #include <queue.h>
+#include <stdbool.h>
 
 #ifdef CONFIG_TASK_MONITOR
 
@@ -33,6 +34,9 @@ struct task_monitor_node_s {
 	FAR struct task_monitor_node_s *blink;
 	int pid;				/* tcb's pid */
 	int interval;
+#ifdef CONFIG_APP_BINARY_SEPARATION
+	bool is_kernel_task;
+#endif
 };
 
 typedef struct task_monitor_node_s task_monitor_node_t;

--- a/os/mm/mm_heap/mm_manage_allocfail.c
+++ b/os/mm/mm_heap/mm_manage_allocfail.c
@@ -196,7 +196,11 @@ void mm_manage_alloc_fail(struct mm_heap_s *heap, int startidx, int endidx, size
 
 #ifdef CONFIG_MM_ASSERT_ON_FAIL
 #ifdef CONFIG_SYSTEM_REBOOT_REASON
-	WRITE_REBOOT_REASON(REBOOT_SYSTEM_MEMORYALLOCFAIL);
+	if (heap_type == KERNEL_HEAP) {
+		WRITE_REBOOT_REASON(REBOOT_SYSTEM_MEMORYALLOCFAIL);
+	} else {
+		WRITE_REBOOT_REASON(REBOOT_USER_MEMORYALLOCFAIL);
+	}
 #endif
 #endif /* CONFIG_MM_ASSERT_ON_FAIL */
 

--- a/os/mm/mm_heap/mm_manage_allocfail.c
+++ b/os/mm/mm_heap/mm_manage_allocfail.c
@@ -196,7 +196,15 @@ void mm_manage_alloc_fail(struct mm_heap_s *heap, int startidx, int endidx, size
 
 #ifdef CONFIG_MM_ASSERT_ON_FAIL
 #ifdef CONFIG_SYSTEM_REBOOT_REASON
+#ifdef CONFIG_APP_BINARY_SEPARATION
+	if (heap_type == KERNEL_HEAP) {
+		WRITE_REBOOT_REASON(REBOOT_SYSTEM_MEMORYALLOCFAIL);
+	} else {
+		WRITE_REBOOT_REASON(REBOOT_USER_MEMORYALLOCFAIL);
+	}
+#else
 	WRITE_REBOOT_REASON(REBOOT_SYSTEM_MEMORYALLOCFAIL);
+#endif
 #endif
 #endif /* CONFIG_MM_ASSERT_ON_FAIL */
 


### PR DESCRIPTION
### 1. os: Distinguish reboot reasons by kernel and user
Separate reboot reason by kernel and user.
Add new reboot reason by user number 71 to 76.
Modify `reboot_reason_try_write_assert` function to get is_user_assert parameter.
Add new function `reboot_reason_write_by_addr` that write right reboot reason using address.

### 2. apps/examples/reboot_reason_test: Fix expected reboot reason
Fix expected reboot reason with user's reboot reason.
When `CONFIG_APP_BINARY_SEPARATION` enabled, we expect `REBOOT_USER_*` because it's user side reboot.