### PR TITLE
apps/shell: bound TASH history expansion

### DIFF
--- a/apps/shell/tash_command.c
+++ b/apps/shell/tash_command.c
@@ -431,10 +431,21 @@ bool tash_search_cmd(char *cmd, int *cmd_char_ptr, char direction)
 int check_exclam_cmd(char *buff)
 {
 	int hist_idx;
-	int histcmd_size;
+	size_t histcmd_size;
+	size_t prefix_size;
+	size_t suffix_size;
+	size_t expanded_size;
 	char *histcmd_ptr;
+	char *cmd_start;
 	char *exclam_ptr;
 	char *exclam_nextptr;
+
+	if (!buff) {
+		return ERROR;
+	}
+
+	/* Keep the original start to calculate the expanded command length. */
+	cmd_start = buff;
 
 	/* Find the '!' in the input character */
 
@@ -482,17 +493,35 @@ int check_exclam_cmd(char *buff)
 				return ERROR;
 			} else {
 				histcmd_size = strlen(histcmd_ptr);
-				if (histcmd_size != (int)(buff - exclam_ptr)) {
+
+				/* Split the command as [prefix][!number][suffix].
+				 * strtol() leaves buff at the first suffix byte after !number.
+				 * The expanded length excludes the \0, so a value
+				 * equal to TASH_LINEBUFLEN is already too large for this buffer.
+				 */
+				prefix_size = (size_t)(exclam_ptr - cmd_start);
+				suffix_size = strlen(buff);
+				expanded_size = prefix_size + histcmd_size + suffix_size;
+
+				/* Reject in-place expansion that would exceed the fixed TASH line buffer. */
+				if (expanded_size >= TASH_LINEBUFLEN) {
+					printf("TASH: history expansion is too long, maximum length is %d\n", TASH_LINEBUFLEN - 1);
+					return ERROR;
+				}
+
+				if (histcmd_size != (size_t)(buff - exclam_ptr)) {
 					/* "!number" does not have the same size as the command from the history list.
 					 * Let's adjust the location of next string to replace "!number" to real command string.
 					 */
 
-					memmove(exclam_ptr + histcmd_size, buff, strlen(buff));
+					/* Move the suffix with its \0 before copying history text. */
+					memmove(exclam_ptr + histcmd_size, buff, suffix_size + 1);
 					buff = exclam_ptr + histcmd_size;
 				}
 				/* Replace "!number" to real command string in buff */
 
-				strncpy(exclam_ptr, histcmd_ptr, histcmd_size);
+				memcpy(exclam_ptr, histcmd_ptr, histcmd_size);
+				continue;
 			}
 		}
 

--- a/apps/shell/tash_script.c
+++ b/apps/shell/tash_script.c
@@ -25,7 +25,8 @@
 #include <tinyara/fs/fs_utils.h>
 #include "tash_internal.h"
 
-#define BUFF_SIZE 80
+/* Keep script command buffers aligned with TASH console command buffers. */
+#define BUFF_SIZE TASH_LINEBUFLEN
 #define PATH_ARG_INDEX  1
 
 static void show_usage_tash_script(void)


### PR DESCRIPTION
TASH expands !N history references in-place before command parsing. A near-limit history entry followed by a suffix such as !1;!1 could make the expanded command exceed the fixed TASH line buffer and corrupt shell memory.

Validate the expanded prefix/history/suffix length before moving bytes, reject expansions that do not fit TASH_LINEBUFLEN, and move the suffix with its \0 before copying history text.

Also align script command buffers with the console TASH line buffer to prevent overflow.

[Before]
```
TASH>>history
         TASH command history
         --------------------
 1       sec_level low
 2       history
TASH>>aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
TASH: cmd (aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
TASH>>history
         TASH command history
         --------------------
 1       sec_level low
 2       history
 3       aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 4       history
TASH>>!3;!3
TASH: cmd (aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
TASH: cmd (aaaaa
print_dataabort_detail: #########################################################################
print_dataabort_detail: PANIC!!! Data Abort at instruction : 0x0e17248c
print_dataabort_detail: PC: 0e17248c DFAR: 61616171 DFSR: 00000805
print_dataabort_detail: #########################################################################
```

[After]
```
TASH>>aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
TASH: cmd (aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
TASH>>history
         TASH command history
         --------------------
 1       aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 2       history
TASH>>!1;!1
TASH: history expansion is too long, maximum length is 127
TASH>>!1;
TASH: cmd (aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
TASH>>!1;!2
TASH: history expansion is too long, maximum length is 127
```