### PR TITLE
arch/arm/src/armv8-m/: Add validation to prevent signal handler privilege escalation

### DIFF
--- a/os/arch/arm/src/armv8-m/up_schedulesigaction.c
+++ b/os/arch/arm/src/armv8-m/up_schedulesigaction.c
@@ -148,7 +148,9 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 			if (!current_regs) {
 				/* In this case just deliver the signal now. */
 
+				tcb->xcp.sigdeliver = (FAR void *)sigdeliver;
 				sigdeliver(tcb);
+				tcb->xcp.sigdeliver = NULL;  /* Clear after signal delivery */
 			}
 
 			/* CASE 2:  We are in an interrupt handler AND the interrupted

--- a/os/arch/arm/src/armv8-m/up_svcall.c
+++ b/os/arch/arm/src/armv8-m/up_svcall.c
@@ -74,6 +74,7 @@
 #include <tinyara/tz_context.h>
 #endif
 
+#include <errno.h>
 #include "svcall.h"
 #include "exc_return.h"
 #include "up_internal.h"
@@ -433,6 +434,12 @@ int up_svcall(int irq, FAR void *context, FAR void *arg)
 #if defined(CONFIG_BUILD_PROTECTED) && !defined(CONFIG_DISABLE_SIGNALS)
 	case SYS_signal_handler: {
 
+		/* Verify kernel-initiated signal delivery*/
+		if (rtcb->xcp.sigdeliver == NULL) {
+			svcdbg("SVCall: Unauthorized SYS_signal_handler_return from user code!\n");
+			regs[REG_R0] = (uint32_t)-ENOSYS;
+			break;
+		}
 		/* Remember the caller's return address */
 
 		DEBUGASSERT(rtcb->xcp.sigreturn == 0);
@@ -482,6 +489,12 @@ int up_svcall(int irq, FAR void *context, FAR void *arg)
 #if defined(CONFIG_BUILD_PROTECTED) && !defined(CONFIG_DISABLE_SIGNALS)
 	case SYS_signal_handler_return: {
 
+		/* Verify kernel-initiated signal delivery*/
+		if (rtcb->xcp.sigdeliver == NULL) {
+			svcdbg("SVCall: Unauthorized SYS_signal_handler_return from user code!\n");
+			regs[REG_R0] = (uint32_t)-ENOSYS;
+			break;
+		}
 		/* Set up to return to the kernel-mode signal dispatching logic. */
 
 		DEBUGASSERT(rtcb->xcp.sigreturn != 0);


### PR DESCRIPTION
Unprivileged user applications can trick the system into running their code with kernel privileges.

    1. User's app calls SVC with special command (SYS_signal_handler = 6)
           ↓
    2. User saves the attacker's code address WITHOUT checking if a real signal exists
           ↓
    3. User's app calls SVC again with return command (SYS_signal_handler_return = 7)
           ↓
    4. Kernel restores attacker's address WITH privileged return mode (EXC_RETURN_PRIVTHR)
           ↓
    5. User's code now runs in PRIVILEGED mode - bypassing all security!
