### PR TITLE
os/kernel/mqueue: add mq_verifydesg() to prevent forged descriptor at…

### DIFF
--- a/os/kernel/log_dump/log_dump.c
+++ b/os/kernel/log_dump/log_dump.c
@@ -39,6 +39,7 @@
 #include <tinyara/clock.h>
 #include <tinyara/log_dump/log_dump.h>
 #include <tinyara/log_dump/log_dump_internal.h>
+#include "mqueue/mqueue.h"
 
 /****************************************************************************
  * Pre-processor Definitions
@@ -607,6 +608,9 @@ int log_dump(int argc, char *argv[])
 		ldpdbg("Fail to open mq, errno %d. EXIT!\n", errno);
 		return 0;
 	}
+
+	/* Cache the descriptor for mq_verifydesg() whitelist */
+	mq_verifydesg_set_logdump_mqdes(mq_fd);
 
 	if (log_dump_init() != LOG_DUMP_OK) {
 		ldpdbg("Fail to init log dump\n");

--- a/os/kernel/mqueue/Make.defs
+++ b/os/kernel/mqueue/Make.defs
@@ -56,7 +56,7 @@ CSRCS += mq_send.c mq_timedsend.c mq_sndinternal.c mq_receive.c
 CSRCS += mq_timedreceive.c mq_rcvinternal.c mq_initialize.c
 CSRCS += mq_descreate.c mq_desclose.c mq_msgfree.c mq_msgqalloc.c
 CSRCS += mq_msgqfree.c mq_release.c mq_recover.c mq_setattr.c
-CSRCS += mq_getattr.c
+CSRCS += mq_getattr.c mq_verifydesg.c
 
 ifneq ($(CONFIG_DISABLE_SIGNALS),y)
 CSRCS += mq_waitirq.c mq_notify.c

--- a/os/kernel/mqueue/mq_desclose.c
+++ b/os/kernel/mqueue/mq_desclose.c
@@ -153,5 +153,12 @@ void mq_desclose_group(mqd_t mqdes, FAR struct task_group_s *group)
 
 	/* Deallocate the message descriptor */
 
+#ifdef CONFIG_LOG_DUMP
+	/* Clear the cached log_dump descriptor if this is it */
+	if (mq_verifydesg_get_logdump_mqdes() == mqdes) {
+		mq_verifydesg_set_logdump_mqdes(NULL);
+	}
+#endif
+
 	mq_desfree(mqdes);
 }

--- a/os/kernel/mqueue/mq_getattr.c
+++ b/os/kernel/mqueue/mq_getattr.c
@@ -58,6 +58,7 @@
 
 #include <mqueue.h>
 #include <tinyara/mqueue.h>
+#include "mqueue/mqueue.h"
 
 /************************************************************************
  * Definitions
@@ -106,6 +107,10 @@ int mq_getattr(mqd_t mqdes, struct mq_attr *mq_stat)
 	int ret = ERROR;
 
 	if (mqdes && mq_stat) {
+		if (mq_verifydesg(mqdes) != OK) {
+			return ERROR;
+		}
+
 		/* Return the attributes */
 
 		mq_stat->mq_maxmsg = mqdes->msgq->maxmsgs;

--- a/os/kernel/mqueue/mq_notify.c
+++ b/os/kernel/mqueue/mq_notify.c
@@ -161,6 +161,11 @@ int mq_notify(mqd_t mqdes, const struct sigevent *notification)
 		return ERROR;
 	}
 
+	if (mq_verifydesg(mqdes) != OK) {
+		leave_critical_section(flags);
+		return ERROR;
+	}
+
 	/* Get a pointer to the message queue */
 
 	msgq = mqdes->msgq;

--- a/os/kernel/mqueue/mq_rcvinternal.c
+++ b/os/kernel/mqueue/mq_rcvinternal.c
@@ -130,6 +130,10 @@ int mq_verifyreceive(mqd_t mqdes, FAR char *msg, size_t msglen)
 		return ERROR;
 	}
 
+	if (mq_verifydesg(mqdes) != OK) {
+		return ERROR;
+	}
+
 	if ((mqdes->oflags & O_RDOK) == 0) {
 		set_errno(EPERM);
 		return ERROR;

--- a/os/kernel/mqueue/mq_setattr.c
+++ b/os/kernel/mqueue/mq_setattr.c
@@ -60,6 +60,7 @@
 #include <mqueue.h>
 
 #include <tinyara/mqueue.h>
+#include "mqueue/mqueue.h"
 
 /************************************************************************
  * Definitions
@@ -115,6 +116,10 @@ int mq_setattr(mqd_t mqdes, const struct mq_attr *mq_stat, struct mq_attr *oldst
 	int ret = ERROR;
 
 	if (mqdes && mq_stat) {
+		if (mq_verifydesg(mqdes) != OK) {
+			return ERROR;
+		}
+
 		/* Return the attributes if so requested */
 
 		if (oldstat) {

--- a/os/kernel/mqueue/mq_sndinternal.c
+++ b/os/kernel/mqueue/mq_sndinternal.c
@@ -135,6 +135,10 @@ int mq_verifysend(mqd_t mqdes, FAR const char *msg, size_t msglen, int prio)
 		return ERROR;
 	}
 
+	if (mq_verifydesg(mqdes) != OK) {
+		return ERROR;
+	}
+
 	if ((mqdes->oflags & O_WROK) == 0) {
 		set_errno(EPERM);
 		return ERROR;

--- a/os/kernel/mqueue/mq_verifydesg.c
+++ b/os/kernel/mqueue/mq_verifydesg.c
@@ -1,0 +1,182 @@
+/****************************************************************************
+ * kernel/mqueue/mq_verifydesg.c
+ *
+ * Copyright 2026 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <tinyara/config.h>
+
+#include <mqueue.h>
+#include <errno.h>
+#include <sched.h>
+#include <debug.h>
+
+#include <tinyara/sched.h>
+#include <tinyara/irq.h>
+
+#include "sched/sched.h"
+#include "mqueue/mqueue.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Type Declarations
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Variables
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Variables
+ ****************************************************************************/
+
+#ifdef CONFIG_LOG_DUMP
+/* Cached log_dump mqueue descriptor, set in log_dump() after mq_open()
+ * and cleared when freed in mq_desclose_group().
+ */
+static mqd_t g_log_dump_mqdes;
+#endif
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: mq_verifydesg_set_logdump_mqdes
+ *
+ * Description:
+ *   Cache or clear the log_dump mqueue descriptor. Called from log_dump()
+ *   after mq_open() to cache the descriptor, and from mq_desclose_group()
+ *   when it is freed.
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_LOG_DUMP
+void mq_verifydesg_set_logdump_mqdes(mqd_t mqdes)
+{
+	g_log_dump_mqdes = mqdes;
+}
+
+mqd_t mq_verifydesg_get_logdump_mqdes(void)
+{
+	return g_log_dump_mqdes;
+}
+#endif
+
+/****************************************************************************
+ * Name: mq_verifydesg
+ *
+ * Description:
+ *   Verify that the given message queue descriptor (mqdes) belongs to the
+ *   calling task's group, preventing forged descriptor attacks where a
+ *   malicious userspace task passes an arbitrary mqd_t pointer into mqueue
+ *   syscalls to access or mutate kernel state it does not own.
+ *
+ *   Verification steps:
+ *     1. Interrupt context and kernel threads are trusted callers and
+ *        bypass the check (they do not enter via the syscall interface
+ *        and may legitimately share descriptors across groups).
+ *     2. Under CONFIG_LOG_DUMP, the log_dump mqueue descriptor is
+ *        whitelisted because it is shared across groups. The descriptor
+ *        is cached in g_log_dump_mqdes (set in log_dump after mq_open,
+ *        cleared in mq_desclose_group).
+ *     3. Otherwise, walk the current task group's tg_msgdesq list and
+ *        return OK only if mqdes is found. The walk uses
+ *        enter_critical_section() for SMP safety (sched_lock alone only
+ *        prevents context switches on the local CPU).
+ *
+ * Parameters:
+ *   mqdes - Message queue descriptor to verify (must be non-NULL)
+ *
+ * Return Value:
+ *   OK (0) if the descriptor belongs to the caller's task group.
+ *   ERROR (-1) with errno set to EPERM if not owned by the caller,
+ *   or EBADF if the caller's TCB/group is invalid.
+ *
+ ****************************************************************************/
+
+int mq_verifydesg(mqd_t mqdes)
+{
+	FAR struct tcb_s *rtcb;
+	FAR struct task_group_s *group;
+	mqd_t mqdes_ptr;
+	irqstate_t flags;
+
+	DEBUGASSERT(mqdes != NULL);
+
+	rtcb = this_task();
+	if (rtcb == NULL) {
+		set_errno(EBADF);
+		return ERROR;
+	}
+
+	/* Interrupt context and kernel threads are trusted callers */
+
+	if (up_interrupt_context()) {
+		return OK;
+	}
+
+	if ((rtcb->flags & TCB_FLAG_TTYPE_MASK) == TCB_FLAG_TTYPE_KERNEL) {
+		return OK;
+	}
+
+	if (rtcb->group == NULL) {
+		set_errno(EBADF);
+		return ERROR;
+	}
+
+	group = rtcb->group;
+
+#ifdef CONFIG_LOG_DUMP
+	/* Whitelist: log_dump descriptor shared across groups */
+
+	if (mqdes == g_log_dump_mqdes) {
+		return OK;
+	}
+#endif
+	/* Walk group's descriptor list (SMP-safe via critical section) */
+
+	flags = enter_critical_section();
+
+	mqdes_ptr = (mqd_t)sq_peek(&group->tg_msgdesq);
+	while (mqdes_ptr) {
+		if (mqdes_ptr == mqdes) {
+			leave_critical_section(flags);
+			return OK;
+		}
+		mqdes_ptr = (mqd_t)sq_next(mqdes_ptr);
+	}
+
+	leave_critical_section(flags);
+#ifdef HAVE_GROUP_MEMBERS
+	lldbg("mqdes=%p not owned by gid=%d pgid=%d pid=%d\n",
+		mqdes, group->tg_gid, group->tg_pgid, rtcb->pid);
+#else
+	lldbg("mqdes=%p not owned by group, task pid=%d\n", mqdes, rtcb->pid);
+#endif
+	set_errno(EPERM);
+	return ERROR;
+}

--- a/os/kernel/mqueue/mqueue.h
+++ b/os/kernel/mqueue/mqueue.h
@@ -167,6 +167,14 @@ int mq_verifyreceive(mqd_t mqdes, FAR char *msg, size_t msglen);
 FAR struct mqueue_msg_s *mq_waitreceive(mqd_t mqdes);
 ssize_t mq_doreceive(mqd_t mqdes, FAR struct mqueue_msg_s *mqmsg, FAR char *ubuffer, FAR int *prio);
 
+/* mq_verifydesg.c *********************************************************/
+
+int mq_verifydesg(mqd_t mqdes);
+#ifdef CONFIG_LOG_DUMP
+void mq_verifydesg_set_logdump_mqdes(mqd_t mqdes);
+mqd_t mq_verifydesg_get_logdump_mqdes(void);
+#endif
+
 /* mq_sndinternal.c ********************************************************/
 
 int mq_verifysend(mqd_t mqdes, FAR const char *msg, size_t msglen, int prio);


### PR DESCRIPTION
…tacks

Vulnerability: Userspace tasks could pass arbitrary mqd_t pointer values into mqueue syscalls (mq_send, mq_receive, mq_getattr, etc.) to access or mutate kernel mqueue state belonging to other task groups.

Fix: Add mq_verifydesg() that validates the caller's ownership of the message queue descriptor before allowing any mqueue operation:

- Walk the caller's task group tg_msgdesq list to confirm mqdes belongs to the calling group (same ownership check pattern as mq_close_group)
- Use enter_critical_section() for SMP safety during the list walk
- Trusted callers bypass the check: interrupt context (up_interrupt_context), kernel threads (TCB_FLAG_TTYPE_KERNEL)
- Whitelist log_dump mqueue descriptor under CONFIG_LOG_DUMP (cached in g_log_dump_mqdes in mq_verifydesg.c, set in mq_descreate when task name is "log_dump", cleared in mq_desclose_group via getter comparison)
- Return EPERM with dbg() diagnostic on ownership failure (prints tg_gid and tg_pgid under HAVE_GROUP_MEMBERS for useful identification)

The log_dump whitelist is necessary because the log_dump kernel thread creates the mqueue descriptor (mq_fd), but any task that triggers logging (e.g. tash via printf -> log_dump_save -> compress_full_bufs -> mq_send) uses this descriptor. Without the whitelist, mq_verifydesg() would reject tash's mq_send() since mq_fd belongs to the log_dump thread's group, not tash's group.

The log_dump descriptor is cached locally in `g_log_dump_mqde`s and managed via mq_verifydesg_set/get_logdump_mqdes() helpers. The setter is called only when mq_descreate() detects the "log_dump" task by name. The getter is used in mq_desclose_group() to compare the descriptor being freed against the cached value, ensuring the cache is cleared correctly even when a non-log_dump task (e.g. kernel worker) cleans up the descriptor after a crash.

Signed-off By: Rishabh Singh <ris.singh@samsung.com>