### PR TITLE
build/configs/bk7239n: Move userfs partition after reserved

### DIFF
--- a/build/configs/bk7239n/hello/defconfig
+++ b/build/configs/bk7239n/hello/defconfig
@@ -1050,9 +1050,9 @@ CONFIG_ARCH_BOARD_HAVE_FLASH=y
 #
 CONFIG_FLASH_PARTITION=y
 CONFIG_FLASH_MINOR=0
-CONFIG_FLASH_PART_SIZE="92,8,8,404,1856,1856,2048,10080,24,8,"
-CONFIG_FLASH_PART_TYPE="none,none,none,none,kernel,kernel,smartfs,none,none,bootparam,"
-CONFIG_FLASH_PART_NAME="bl1,sys_its,sys_ps,ss,kernel,kernel,userfs,reserved,easy_flash,bootparam,"
+CONFIG_FLASH_PART_SIZE="92,8,8,404,1856,1856,10080,2048,24,8,"
+CONFIG_FLASH_PART_TYPE="none,none,none,none,kernel,kernel,none,smartfs,none,bootparam,"
+CONFIG_FLASH_PART_NAME="bl1,sys_its,sys_ps,ss,kernel,kernel,reserved,userfs,easy_flash,bootparam,"
 # CONFIG_ARCH_BOARD_HAVE_SECOND_FLASH is not set
 CONFIG_AUTOMOUNT=y
 CONFIG_AUTOMOUNT_USERFS=y

--- a/build/configs/bk7239n/loadable_all/defconfig
+++ b/build/configs/bk7239n/loadable_all/defconfig
@@ -1062,9 +1062,9 @@ CONFIG_ARCH_BOARD_HAVE_FLASH=y
 #
 CONFIG_FLASH_PARTITION=y
 CONFIG_FLASH_MINOR=0
-CONFIG_FLASH_PART_SIZE="92,8,8,404,1624,1024,384,128,1624,1024,384,128,512,9008,24,8,"
-CONFIG_FLASH_PART_TYPE="none,none,none,none,kernel,bin,bin,bin,kernel,bin,bin,bin,smartfs,none,none,bootparam,"
-CONFIG_FLASH_PART_NAME="bl1,sys_its,sys_ps,ss,kernel,common,app1,app2,kernel,common,app1,app2,userfs,reserved,easyflash,bootparam,"
+CONFIG_FLASH_PART_SIZE="92,8,8,404,1624,1024,384,128,1624,1024,384,128,9008,512,24,8,"
+CONFIG_FLASH_PART_TYPE="none,none,none,none,kernel,bin,bin,bin,kernel,bin,bin,bin,none,smartfs,none,bootparam,"
+CONFIG_FLASH_PART_NAME="bl1,sys_its,sys_ps,ss,kernel,common,app1,app2,kernel,common,app1,app2,reserved,userfs,easyflash,bootparam,"
 # CONFIG_ARCH_BOARD_HAVE_SECOND_FLASH is not set
 CONFIG_AUTOMOUNT=y
 CONFIG_AUTOMOUNT_USERFS=y

--- a/build/configs/bk7239n/loadable_apps/defconfig
+++ b/build/configs/bk7239n/loadable_apps/defconfig
@@ -1062,9 +1062,9 @@ CONFIG_ARCH_BOARD_HAVE_FLASH=y
 #
 CONFIG_FLASH_PARTITION=y
 CONFIG_FLASH_MINOR=0
-CONFIG_FLASH_PART_SIZE="92,8,8,404,1624,1024,384,128,1624,1024,384,128,512,9008,24,8,"
-CONFIG_FLASH_PART_TYPE="none,none,none,none,kernel,bin,bin,bin,kernel,bin,bin,bin,smartfs,none,none,bootparam,"
-CONFIG_FLASH_PART_NAME="bl1,sys_its,sys_ps,ss,kernel,common,app1,app2,kernel,common,app1,app2,userfs,reserved,easyflash,bootparam,"
+CONFIG_FLASH_PART_SIZE="92,8,8,404,1624,1024,384,128,1624,1024,384,128,9008,512,24,8,"
+CONFIG_FLASH_PART_TYPE="none,none,none,none,kernel,bin,bin,bin,kernel,bin,bin,bin,none,smartfs,none,bootparam,"
+CONFIG_FLASH_PART_NAME="bl1,sys_its,sys_ps,ss,kernel,common,app1,app2,kernel,common,app1,app2,reserved,userfs,easyflash,bootparam,"
 # CONFIG_ARCH_BOARD_HAVE_SECOND_FLASH is not set
 CONFIG_AUTOMOUNT=y
 CONFIG_AUTOMOUNT_USERFS=y

--- a/build/configs/bk7239n/xip_all/defconfig
+++ b/build/configs/bk7239n/xip_all/defconfig
@@ -1066,9 +1066,9 @@ CONFIG_ARCH_BOARD_HAVE_FLASH=y
 #
 CONFIG_FLASH_PARTITION=y
 CONFIG_FLASH_MINOR=0
-CONFIG_FLASH_PART_SIZE="92,8,8,404,1844,3400,1024,756,1844,3400,1024,756,512,1280,24,8,"
-CONFIG_FLASH_PART_TYPE="none,none,none,none,kernel,bin,bin,resource,kernel,bin,bin,resource,smartfs,none,none,bootparam,"
-CONFIG_FLASH_PART_NAME="bl1,sys_its,sys_ps,ss,kernel,common,app1,resource,kernel,common,app1,resource,userfs,reserved,easyflash,bootparam,"
+CONFIG_FLASH_PART_SIZE="92,8,8,404,1844,3400,1024,756,1844,3400,1024,756,1280,512,24,8,"
+CONFIG_FLASH_PART_TYPE="none,none,none,none,kernel,bin,bin,resource,kernel,bin,bin,resource,none,smartfs,none,bootparam,"
+CONFIG_FLASH_PART_NAME="bl1,sys_its,sys_ps,ss,kernel,common,app1,resource,kernel,common,app1,resource,reserved,userfs,easyflash,bootparam,"
 # CONFIG_ARCH_BOARD_HAVE_SECOND_FLASH is not set
 CONFIG_AUTOMOUNT=y
 CONFIG_AUTOMOUNT_USERFS=y


### PR DESCRIPTION
Reserved partition can be updated in the future, but userfs partitions will not be updated.
And easy_flash and bootparam partitions are also fixed.
Therefore, move the userfs partition to a after to reserved, so the fixed partition is grouped at the end.