### PR TITLE
os/arch/arm/src/armv8-m/: Add privilege mode check for reserved SVC commands

### DIFF
--- a/os/arch/arm/src/armv8-m/up_svcall.c
+++ b/os/arch/arm/src/armv8-m/up_svcall.c
@@ -60,6 +60,7 @@
 #include <string.h>
 #include <assert.h>
 #include <debug.h>
+#include <errno.h>
 
 #include <arch/irq.h>
 #include <tinyara/arch.h>
@@ -101,6 +102,21 @@
 uint32_t user_assert_location;
 #ifdef CONFIG_SUPPORT_COMMON_BINARY
 extern uint32_t *g_umm_app_id;
+#endif
+
+#ifdef CONFIG_BUILD_PROTECTED
+#define IS_UNPRIVILEGED_CALLER(regs) \
+	(((regs)[REG_EXC_RETURN] & EXC_RETURN_UNPRIVTHR) == EXC_RETURN_UNPRIVTHR)
+#else
+#define IS_UNPRIVILEGED_CALLER(regs) (false)
+#endif
+
+#ifdef CONFIG_BUILD_PROTECTED
+static inline void handle_reserved_svc_violation(uint32_t *regs, uint32_t cmd)
+{
+	slldbg("ERROR: Blocked unprivileged context syscall %d\n", cmd);
+	regs[REG_R0] = (uint32_t)-EACCES;
+}
 #endif
 
 /****************************************************************************
@@ -231,6 +247,12 @@ int up_svcall(int irq, FAR void *context, FAR void *arg)
 	 */
 
 	case SYS_save_context: {
+#ifdef CONFIG_BUILD_PROTECTED
+		if (IS_UNPRIVILEGED_CALLER(regs)) {
+			handle_reserved_svc_violation(regs, cmd);
+			return ERROR;
+		}
+#endif
 		DEBUGASSERT(regs[REG_R1] != 0);
 		memcpy((uint32_t *)regs[REG_R1], regs, XCPTCONTEXT_SIZE);
 #if defined(CONFIG_ARCH_FPU) && !defined(CONFIG_ARM_CMNVECTOR)
@@ -255,6 +277,12 @@ int up_svcall(int irq, FAR void *context, FAR void *arg)
 	 */
 
 	case SYS_restore_context: {
+#ifdef CONFIG_BUILD_PROTECTED
+		if (IS_UNPRIVILEGED_CALLER(regs)) {
+			handle_reserved_svc_violation(regs, cmd);
+			return ERROR;
+		}
+#endif
 		DEBUGASSERT(regs[REG_R1] != 0);
 		current_regs = (uint32_t *)regs[REG_R1];
 
@@ -281,6 +309,12 @@ int up_svcall(int irq, FAR void *context, FAR void *arg)
 	 */
 
 	case SYS_switch_context: {
+#ifdef CONFIG_BUILD_PROTECTED
+		if (IS_UNPRIVILEGED_CALLER(regs)) {
+			handle_reserved_svc_violation(regs, cmd);
+			return ERROR;
+		}
+#endif
 		DEBUGASSERT(regs[REG_R1] != 0 && regs[REG_R2] != 0);
 		memcpy((uint32_t *)regs[REG_R1], regs, XCPTCONTEXT_SIZE);
 #if defined(CONFIG_ARCH_FPU) && !defined(CONFIG_ARM_CMNVECTOR)


### PR DESCRIPTION
    Add validation to ensure reserved SVC commands (SYS_save_context,
    SYS_restore_context, SYS_switch_context) are only accessible from
    privileged kernel mode.

    Changes:
    - Add IS_UNPRIVILEGED_CALLER macro to detect caller privilege level
    - Add handle_reserved_svc_violation handler for unauthorized access
    - Add privilege checks in SYS_save_context, SYS_restore_context, and SYS_switch_context handlers
    - Include task/task.h for task termination support

    This ensures scheduler context-management commands remain restricted
    to kernel-internal use only.