### PR TITLE
kernel/timer: Fix security vulnerability #53 - raw kernel pointer handles

### DIFF
--- a/apps/examples/testcase/le_tc/kernel/itc_timer.c
+++ b/apps/examples/testcase/le_tc/kernel/itc_timer.c
@@ -28,6 +28,61 @@
 
 
 /**
+* @fn                   :itc_timer_delete_n_after_delete
+* @brief                :Test double-delete of timer
+* @scenario             :Delete timer twice, second delete should fail with EINVAL
+* API's covered         :timer_create, timer_delete
+* Preconditions         :Creation of timer_id(timer_create)
+* Postconditions        :none
+*/
+static void itc_timer_delete_n_after_delete(void)
+{
+	int ret_chk = ERROR;
+	clockid_t clockid = CLOCK_REALTIME;
+	struct sigevent st_sigevent;
+	timer_t timer_id;
+
+	st_sigevent.sigev_notify = SIGEV_SIGNAL;
+	st_sigevent.sigev_signo = SIGRTMIN;
+	st_sigevent.sigev_value.sival_ptr = &timer_id;
+
+	ret_chk = timer_create(clockid, &st_sigevent, &timer_id);
+	TC_ASSERT_NEQ("timer_create", ret_chk, ERROR);
+	TC_ASSERT_NEQ("timer_create", timer_id, NULL);
+
+	/* First delete should succeed */
+	ret_chk = timer_delete(timer_id);
+	TC_ASSERT_EQ("timer_delete", ret_chk, OK);
+
+	/* Second delete (double-delete) should fail with EINVAL */
+	ret_chk = timer_delete(timer_id);
+	TC_ASSERT_EQ("timer_delete", ret_chk, ERROR);
+	TC_ASSERT_EQ("timer_delete", errno, EINVAL);
+
+	TC_SUCCESS_RESULT();
+}
+
+/**
+* @fn                   :itc_timer_delete_forged_handle
+* @brief                :Test timer_delete() with forged handle
+* @scenario             :Pass forged stack pointer to timer_delete(), verify ERROR/EINVAL
+* API's covered         :timer_delete
+* Preconditions         :none
+* Postconditions        :none
+*/
+static void itc_timer_delete_forged_handle(void)
+{
+	int ret_chk;
+	int stack_var = 0x12345678;
+
+	ret_chk = timer_delete((timer_t)&stack_var);
+	TC_ASSERT_EQ("timer_delete", ret_chk, ERROR);
+	TC_ASSERT_EQ("timer_delete", errno, EINVAL);
+
+	TC_SUCCESS_RESULT();
+}
+
+/**
 * @fn                   :itc_timer_set_time_n_after_delete
 * @brief                :arm/disarm and fetch state of POSIX per-process timer
 * @scenario             :arm/disarm and fetch state of POSIX per-process timer after timer delete
@@ -111,6 +166,11 @@ static void itc_timer_get_time_n_after_delete(void)
 
 int itc_timer_main(void)
 {
+	/* Timer security integration tests */
+	itc_timer_delete_n_after_delete();
+	itc_timer_delete_forged_handle();
+
+	/* Existing tests */
 	itc_timer_set_time_n_after_delete();
 	itc_timer_get_time_n_after_delete();
 

--- a/apps/examples/testcase/le_tc/kernel/tc_timer.c
+++ b/apps/examples/testcase/le_tc/kernel/tc_timer.c
@@ -23,7 +23,9 @@
 #include <errno.h>
 #include <sys/ioctl.h>
 #include <tinyara/os_api_test_drv.h>
+#ifndef CONFIG_BUILD_PROTECTED
 #include "../../os/kernel/timer/timer.h"
+#endif
 #include "tc_internal.h"
 
 #define USECINT 10000000
@@ -272,6 +274,196 @@ static void tc_timer_timer_initialize(void)
  * Name: timer
  ****************************************************************************/
 
+#ifndef CONFIG_DISABLE_POSIX_TIMERS
+#ifndef CONFIG_BUILD_PROTECTED
+/**
+ * @fn                   :tc_timer_gethandle_null
+ * @brief                :Test timer_gethandle() with NULL timerid
+ * @scenario             :Pass NULL to timer_gethandle() and verify it returns NULL
+ * API's covered         :timer_gethandle
+ * Preconditions         :none
+ * Postconditions        :none
+ * @return               :void
+ */
+static void tc_timer_gethandle_null(void)
+{
+	struct posix_timer_s *ret;
+
+	ret = timer_gethandle(NULL);
+	TC_ASSERT_EQ("timer_gethandle", ret, NULL);
+
+	TC_SUCCESS_RESULT();
+}
+
+/**
+ * @fn                   :tc_timer_gethandle_valid
+ * @brief                :Test timer_gethandle() with valid timerid
+ * @scenario             :Create valid timer, verify timer_gethandle() returns same pointer
+ * API's covered         :timer_create, timer_gethandle, timer_delete
+ * Preconditions         :none
+ * Postconditions        :none
+ * @return               :void
+ */
+static void tc_timer_gethandle_valid(void)
+{
+	int ret_chk;
+	timer_t timer_id;
+	clockid_t clockid = CLOCK_REALTIME;
+	struct sigevent st_sigevent;
+	struct posix_timer_s *ret;
+
+	st_sigevent.sigev_notify = SIGEV_SIGNAL;
+	st_sigevent.sigev_signo = SIGRTMIN;
+	st_sigevent.sigev_value.sival_ptr = &timer_id;
+
+	ret_chk = timer_create(clockid, &st_sigevent, &timer_id);
+	TC_ASSERT_NEQ("timer_create", ret_chk, ERROR);
+	TC_ASSERT_NEQ("timer_create", timer_id, NULL);
+
+	ret = timer_gethandle(timer_id);
+	TC_ASSERT_NEQ("timer_gethandle", ret, NULL);
+	TC_ASSERT_EQ("timer_gethandle", ret, (struct posix_timer_s *)timer_id);
+
+	timer_delete(timer_id);
+	TC_SUCCESS_RESULT();
+}
+
+/**
+ * @fn                   :tc_timer_gethandle_forged
+ * @brief                :Test timer_gethandle() with forged handle
+ * @scenario             :Pass stack variable address (forged handle), verify NULL return
+ * API's covered         :timer_gethandle
+ * Preconditions         :none
+ * Postconditions        :none
+ * @return               :void
+ */
+static void tc_timer_gethandle_forged(void)
+{
+	struct posix_timer_s *ret;
+	int stack_var = 0x12345678;
+
+	/* Pass address of stack variable as forged timer handle */
+	ret = timer_gethandle((timer_t)&stack_var);
+	TC_ASSERT_EQ("timer_gethandle", ret, NULL);
+
+	/* Also test with completely random pointer */
+	ret = timer_gethandle((timer_t)0x12345678);
+	TC_ASSERT_EQ("timer_gethandle", ret, NULL);
+
+	TC_SUCCESS_RESULT();
+}
+
+/**
+ * @fn                   :tc_timer_gethandle_after_delete
+ * @brief                :Test timer_gethandle() with deleted timer handle
+ * @scenario             :Create timer, delete it, verify timer_gethandle() returns NULL
+ * API's covered         :timer_create, timer_delete, timer_gethandle
+ * Preconditions         :none
+ * Postconditions        :none
+ * @return               :void
+ */
+static void tc_timer_gethandle_after_delete(void)
+{
+	int ret_chk;
+	timer_t timer_id;
+	clockid_t clockid = CLOCK_REALTIME;
+	struct sigevent st_sigevent;
+	struct posix_timer_s *ret;
+
+	st_sigevent.sigev_notify = SIGEV_SIGNAL;
+	st_sigevent.sigev_signo = SIGRTMIN;
+	st_sigevent.sigev_value.sival_ptr = &timer_id;
+
+	ret_chk = timer_create(clockid, &st_sigevent, &timer_id);
+	TC_ASSERT_NEQ("timer_create", ret_chk, ERROR);
+
+	/* Delete the timer */
+	ret_chk = timer_delete(timer_id);
+	TC_ASSERT_EQ("timer_delete", ret_chk, OK);
+
+	/* Verify timer_gethandle returns NULL for deleted timer */
+	ret = timer_gethandle(timer_id);
+	TC_ASSERT_EQ("timer_gethandle", ret, NULL);
+
+	TC_SUCCESS_RESULT();
+}
+#endif /* CONFIG_BUILD_PROTECTED */
+
+/**
+ * @fn                   :tc_timer_delete_forged_handle
+ * @brief                :Test timer_delete() with forged handle
+ * @scenario             :Pass forged handle to timer_delete(), verify ERROR/EINVAL
+ * API's covered         :timer_delete
+ * Preconditions         :none
+ * Postconditions        :none
+ * @return               :void
+ */
+static void tc_timer_delete_forged_handle(void)
+{
+	int ret_chk;
+	int stack_var = 0x12345678;
+
+	ret_chk = timer_delete((timer_t)&stack_var);
+	TC_ASSERT_EQ("timer_delete", ret_chk, ERROR);
+	TC_ASSERT_EQ("timer_delete", errno, EINVAL);
+
+	TC_SUCCESS_RESULT();
+}
+
+/**
+ * @fn                   :tc_timer_settime_forged_handle
+ * @brief                :Test timer_settime() with forged handle
+ * @scenario             :Pass forged handle to timer_settime(), verify ERROR/EINVAL
+ * API's covered         :timer_settime
+ * Preconditions         :none
+ * Postconditions        :none
+ * @return               :void
+ */
+static void tc_timer_settime_forged_handle(void)
+{
+	int ret_chk;
+	int stack_var = 0x12345678;
+	struct itimerspec st_timer_spec;
+
+	st_timer_spec.it_value.tv_sec = 1;
+	st_timer_spec.it_value.tv_nsec = 0;
+	st_timer_spec.it_interval.tv_sec = 0;
+	st_timer_spec.it_interval.tv_nsec = 0;
+
+	ret_chk = timer_settime((timer_t)&stack_var, 0, &st_timer_spec, NULL);
+	TC_ASSERT_EQ("timer_settime", ret_chk, ERROR);
+	TC_ASSERT_EQ("timer_settime", errno, EINVAL);
+
+	TC_SUCCESS_RESULT();
+}
+
+/**
+ * @fn                   :tc_timer_gettime_forged_handle
+ * @brief                :Test timer_gettime() with forged handle
+ * @scenario             :Pass forged handle to timer_gettime(), verify ERROR/EINVAL
+ * API's covered         :timer_gettime
+ * Preconditions         :none
+ * Postconditions        :none
+ * @return               :void
+ */
+static void tc_timer_gettime_forged_handle(void)
+{
+	int ret_chk;
+	int stack_var = 0x12345678;
+	struct itimerspec st_timer_spec;
+
+	ret_chk = timer_gettime((timer_t)&stack_var, &st_timer_spec);
+	TC_ASSERT_EQ("timer_gettime", ret_chk, ERROR);
+	TC_ASSERT_EQ("timer_gettime", errno, EINVAL);
+
+	TC_SUCCESS_RESULT();
+}
+#endif /* CONFIG_DISABLE_POSIX_TIMERS */
+
+/****************************************************************************
+ * Name: timer
+ ****************************************************************************/
+
 int timer_tc_main(void)
 {
 #ifndef CONFIG_BUILD_PROTECTED
@@ -280,6 +472,17 @@ int timer_tc_main(void)
 
 #ifndef CONFIG_DISABLE_POSIX_TIMERS
 	tc_timer_timer_getoverrun();
+
+#ifndef CONFIG_BUILD_PROTECTED
+	/* Timer security tests for timer_gethandle() */
+	tc_timer_gethandle_null();
+	tc_timer_gethandle_valid();
+	tc_timer_gethandle_forged();
+	tc_timer_gethandle_after_delete();
+#endif
+	tc_timer_delete_forged_handle();
+	tc_timer_settime_forged_handle();
+	tc_timer_gettime_forged_handle();
 #endif                     /* CONFIG_DISABLE_POSIX_TIMERS */
 	tc_timer_timer_set_get_time();
 	tc_timer_timer_initialize();

--- a/os/drivers/os_api_test/kernel/test_timer.c
+++ b/os/drivers/os_api_test/kernel/test_timer.c
@@ -90,6 +90,17 @@ static int test_timer_initialize(unsigned long arg)
 		createfree_cnt++;
 	}
 
+	/* Delete the timer before re-initializing, otherwise timer_gethandle()
+	 * validation (which checks g_alloctimers list membership) will reject
+	 * the handle after timer_initialize() clears the allocated list.
+	 */
+	ret_chk = timer_delete(timer_id);
+
+	if (ret_chk == ERROR) {
+		dbg("timer_delete failed.");
+		return ERROR;
+	}
+
 	/* check the count for g_alloctimers and g_freetimers after timer_initialize now they change to original value */
 	timer_initialize();
 
@@ -101,13 +112,6 @@ static int test_timer_initialize(unsigned long arg)
 	for (timer = (FAR struct posix_timer_s *)g_freetimers.head; timer; timer = next) {
 		next = timer->flink;
 		finalfree_cnt++;
-	}
-
-	ret_chk = timer_delete(timer_id);
-
-	if (ret_chk == ERROR) {
-		dbg("timer_delete failed.");
-		return ERROR;
 	}
 
 	if (initalloc_cnt != finalalloc_cnt) {

--- a/os/kernel/timer/timer.h
+++ b/os/kernel/timer/timer.h
@@ -95,7 +95,8 @@ struct posix_timer_s {
 	union sigval pt_value;		/* Data passed with notification */
 };
 
-#define PT_ISVALID(x)         (((x) != NULL) && (((struct posix_timer_s *)(x))->pt_flags & PT_FLAGS_INUSE))
+/* timer_gethandle() validates timer handles by checking list membership */
+FAR struct posix_timer_s *timer_gethandle(timer_t timerid);
 
 /********************************************************************************
  * Public Data

--- a/os/kernel/timer/timer_delete.c
+++ b/os/kernel/timer/timer_delete.c
@@ -110,7 +110,18 @@
 
 int timer_delete(timer_t timerid)
 {
-	int ret = timer_release((FAR struct posix_timer_s *)timerid);
+	FAR struct posix_timer_s *timer;
+	int ret;
+
+	/* Validate the timer handle by checking list membership */
+
+	timer = timer_gethandle(timerid);
+	if (!timer) {
+		set_errno(EINVAL);
+		return ERROR;
+	}
+
+	ret = timer_release(timer);
 	if (ret < 0) {
 		set_errno(-ret);
 		return ERROR;

--- a/os/kernel/timer/timer_gettime.c
+++ b/os/kernel/timer/timer_gettime.c
@@ -117,10 +117,13 @@
 
 int timer_gettime(timer_t timerid, FAR struct itimerspec *value)
 {
-	FAR struct posix_timer_s *timer = (FAR struct posix_timer_s *)timerid;
+	FAR struct posix_timer_s *timer;
 	int ticks;
 
-	if (!PT_ISVALID(timer) || !value) {
+	/* Validate the timer handle by checking list membership */
+
+	timer = timer_gethandle(timerid);
+	if (!timer || !value) {
 		set_errno(EINVAL);
 		return ERROR;
 	}

--- a/os/kernel/timer/timer_initialize.c
+++ b/os/kernel/timer/timer_initialize.c
@@ -179,4 +179,51 @@ void weak_function timer_deleteall(pid_t pid)
 	leave_critical_section(flags);
 }
 
+/********************************************************************************
+ * Name: timer_gethandle
+ *
+ * Description:
+ *   Returns the posix timer in the activity from the corresponding timerid.
+ *   This function validates that the timerid points to a valid timer in the
+ *   allocated timer list, preventing forged or stale handles from being used.
+ *
+ * Parameters:
+ *   timerid - The timer ID returned by timer_create()
+ *
+ * Return Value:
+ *   On success, timer_gethandle() returns pointer to the posix_timer_s;
+ *   On error, NULL is returned.
+ *
+ ********************************************************************************/
+
+FAR struct posix_timer_s *timer_gethandle(timer_t timerid)
+{
+	FAR struct posix_timer_s *timer = NULL;
+	FAR sq_entry_t *entry;
+	irqstate_t flags;
+
+	if (timerid != NULL) {
+		flags = enter_critical_section();
+
+		/* Iterate through all allocated timers to verify the timerid
+		 * is actually in the list. This prevents forged pointers from
+		 * being used as timer handles.
+		 */
+		for (entry = g_alloctimers.head; entry != NULL; entry = entry->flink) {
+			if (entry == (sq_entry_t *)timerid) {
+				/* Verify the timer is marked as in-use */
+				timer = (FAR struct posix_timer_s *)timerid;
+				if (!(timer->pt_flags & PT_FLAGS_INUSE)) {
+					timer = NULL;
+				}
+				break;
+			}
+		}
+
+		leave_critical_section(flags);
+	}
+
+	return timer;
+}
+
 #endif							/* CONFIG_DISABLE_POSIX_TIMERS */

--- a/os/kernel/timer/timer_release.c
+++ b/os/kernel/timer/timer_release.c
@@ -142,8 +142,6 @@ static inline void timer_free(struct posix_timer_s *timer)
 
 int timer_release(FAR struct posix_timer_s *timer)
 {
-	/* Some sanity checks */
-
 	if (!timer) {
 		return -EINVAL;
 	}

--- a/os/kernel/timer/timer_settime.c
+++ b/os/kernel/timer/timer_settime.c
@@ -306,14 +306,15 @@ static void timer_timeout(int argc, uint32_t itimer)
 
 int timer_settime(timer_t timerid, int flags, FAR const struct itimerspec *value, FAR struct itimerspec *ovalue)
 {
-	FAR struct posix_timer_s *timer = (FAR struct posix_timer_s *)timerid;
+	FAR struct posix_timer_s *timer;
 	irqstate_t state;
 	int delay;
 	int ret = OK;
 
-	/* Some sanity checks */
+	/* Validate the timer handle by checking list membership */
 
-	if (!PT_ISVALID(timer) || !value) {
+	timer = timer_gethandle(timerid);
+	if (!timer || !value) {
 		set_errno(EINVAL);
 		return ERROR;
 	}


### PR DESCRIPTION
POSIX timer APIs (timer_delete, timer_settime, timer_gettime) previously accepted arbitrary timerid values without validating that the handle belongs to the allocated timer list. This security vulnerability allowed forged, stale, and crafted handles to be used, leading to memory corruption, use-after-free, and double-free in kernel code.

This PR adds timer_gethandle() — a kernel-internal validation API that verifies timer handles by checking g_alloctimers list membership and PT_FLAGS_INUSE flag. All POSIX timer APIs are updated to use this validation, properly rejecting invalid/stale/forged handles with EINVAL.

**Changes**
Commit 1: apps/testcase: add timer handle security validation test cases
Add kernel TC tests for timer_gethandle() validation (null, valid, forged, after-delete)
Add forged handle tests for timer_delete(), timer_settime(), timer_gettime()
Add ITC tests for double-delete and forged handle rejection
Add TC_KERNEL_TIMER_GETHANDLE Kconfig option
Guard timer_gethandle direct tests with #ifndef CONFIG_BUILD_PROTECTED
Commit 2: os/kernel: add timer_gethandle() to prevent forged handle attacks
Add timer_gethandle() in timer_initialize.c that validates handles via g_alloctimers list iteration
Update timer_delete() to use timer_gethandle() instead of direct pointer cast
Update timer_settime() and timer_gettime() to use timer_gethandle() instead of weak PT_ISVALID() check
Remove PT_ISVALID() macro, replace with timer_gethandle() declaration in timer.h
Fix test_timer_initialize() in os_api_test to call timer_delete() before re-initializing
**Testing Summary**
Table 1: Test Results Comparison
| S.No. | Test (Function Name) | Before (Vulnerable) | After (Fixed) |
|-----|------|---------------------|--------------|
| 1 | tc_timer_timer_getoverrun | PASS | PASS |
| 2 | tc_timer_delete_forged_handle | FAIL | PASS |
| 3 | tc_timer_settime_forged_handle | PASS | PASS |
| 4 | tc_timer_gettime_forged_handle |	PASS | PASS |
| 5 | tc_timer_timer_set_get_time | PASS | PASS |
| 6 | tc_timer_timer_initialize | PASS | PASS |
| 7 | itc_timer_delete_n_after_delete | FAIL | PASS |
| 8 | itc_timer_delete_forged_handle | FAIL | PASS |
| 9 | itc_timer_set_time_n_after_delete | PASS | PASS |
| 10 | itc_timer_get_time_n_after_delete | PASS | PASS |

Table 2: Vulnerability Analysis
| Vulnerability | Before (Exploitable/Blocked - Return Value) | After (Exploitable/Blocked - Return Value) |
|-----|-----|-----|
| Forged handle passed to timer_delete() | Exploitable — Returns OK (0), arbitrary memory freed | Blocked — Returns ERROR (-1), errno=EINVAL |
| Stale/double-deleted handle passed to timer_delete() | Exploitable — Returns OK (0), double-free occurs | Blocked — Returns ERROR (-1), errno=EINVAL |
| Forged handle passed to timer_settime() | Weakly Blocked — Returns ERROR (-1) via PT_ISVALID(), but only checks flag bit at pointer address (bypassable with crafted pointer) | Blocked — Returns ERROR (-1), errno=EINVAL via timer_gethandle() list membership validation |
| Forged handle passed to timer_gettime() | Weakly Blocked — Returns ERROR (-1) via PT_ISVALID(), but only checks flag bit at pointer address (bypassable with crafted pointer) | Blocked — Returns ERROR (-1), errno=EINVAL via timer_gethandle() list membership validation |

**Impact**
No breaking changes for legitimate timer usage — valid handles continue to work as before
Protected build compatible — forged handle tests for public POSIX APIs work through syscalls; timer_gethandle direct tests are guarded with #ifndef CONFIG_BUILD_PROTECTED
All 10 kernel timer TCs pass after the fix (previously 7 pass / 3 fail)

Signed-Off by: Vivek Jain (vivek1.j@samsung.com)