### PR TITLE
os/board/bk7239n:Add beamformee and OFDMA switch APIs

### DIFF
--- a/os/board/bk7239n/src/bsp_adapter/src/net/bk_netmgr.c
+++ b/os/board/bk7239n/src/bsp_adapter/src/net/bk_netmgr.c
@@ -117,6 +117,8 @@ trwifi_result_e bk_wifi_netmgr_get_driver_info(struct netdev *dev, trwifi_driver
 trwifi_result_e bk_wifi_netmgr_get_wpa_supplicant_state(struct netdev *dev, trwifi_wpa_states *wpa_supplicant_state);
 trwifi_result_e bk_wifi_netmgr_disable_11ax_mode(struct netdev *dev, uint8_t disable);
 trwifi_result_e bk_wifi_netmgr_set_bridge(struct netdev *dev, uint8_t control);
+trwifi_result_e bk_wifi_netmgr_disable_bfmee_mode(struct netdev *dev, uint8_t disable);
+trwifi_result_e bk_wifi_netmgr_disable_ofdma_mode(struct netdev *dev, uint8_t disable);
 
 struct trwifi_ops g_trwifi_bk_ops = {
     bk_wifi_netmgr_init,                        /* init */
@@ -1614,6 +1616,34 @@ trwifi_result_e bk_wifi_netmgr_disable_11ax_mode(struct netdev *dev, uint8_t dis
 		return TRWIFI_SUCCESS;
 	}
 }
+trwifi_result_e bk_wifi_netmgr_disable_bfmee_mode(struct netdev *dev, uint8_t disable)
+{
+	uint32_t enable_bfmee = disable ? 0 : 1;
+	int ret = TRWIFI_SUCCESS;
+
+	nvdbg("[BK] Set bfmee mode to %d\n", enable_bfmee);
+	ret = bk_wifi_capa_config(WIFI_CAPA_ID_BEAMFORMEE_EN, enable_bfmee);
+	if (ret != BK_OK) {
+		ndbg("[BK] Failed to set bfmee mode ret: %d\n", ret);
+		return TRWIFI_FAIL;
+	}
+	return TRWIFI_SUCCESS;
+}
+
+trwifi_result_e bk_wifi_netmgr_disable_ofdma_mode(struct netdev *dev, uint8_t disable)
+{
+	uint32_t enable_ofdma = disable ? 0 : 1;
+	int ret = TRWIFI_SUCCESS;
+
+	nvdbg("[BK] Set ofdma mode to %d\n", enable_ofdma);
+	ret = bk_wifi_capa_config(WIFI_CAPA_ID_OFDMA_EN, enable_ofdma);
+	if (ret != BK_OK) {
+		ndbg("[BK] Failed to set ofdma mode ret: %d\n", ret);
+		return TRWIFI_FAIL;
+	}
+	return TRWIFI_SUCCESS;
+}
+
 trwifi_result_e bk_wifi_netmgr_set_bridge(struct netdev *dev, uint8_t control)
 {
     if (control) {

--- a/os/board/bk7239n/src/components/bk_wifi/include/generated/lmac_msg.h
+++ b/os/board/bk7239n/src/components/bk_wifi/include/generated/lmac_msg.h
@@ -2537,6 +2537,8 @@ enum
     #if BK_MAC
     /// Bit indicating that ERP is enabled in the local device
     ME_ERP_CAPA = CO_BIT(4),
+    /// Bit indicating that STA-side TB(UL OFDMA) response is enabled in the local device
+    ME_OFDMA_TB_CAPA = CO_BIT(5),
     #endif
 };
 uint8_t me_env_get_capa_flags(void);
@@ -2660,6 +2662,8 @@ struct me_config_req
     bool he_supp;
     /// Boolean indicating if HE OFDMA UL is enabled or not
     bool he_ul_on;
+    /// Boolean indicating if STA-side TB(UL OFDMA) response is enabled or not
+    bool he_tb_on;
     /// Boolean indicating if PS mode shall be enabled or not
     bool ps_on;
     /// Boolean indicating if Antenna Diversity shall be enabled or not

--- a/os/board/bk7239n/src/components/bk_wifi/include/rwnx_params.h
+++ b/os/board/bk7239n/src/components/bk_wifi/include/rwnx_params.h
@@ -21,7 +21,8 @@ struct rwnx_mod_params {
 	bool he_on;
 	int mcs_map;	// vht mcs map
 	int he_mcs_map;	// he mcs map
-	bool he_ul_on;	// OFDMA UL
+	bool he_ul_on;	// OFDMA UL (AP-side trigger scheduler)
+	bool he_tb_on;	// STA-side TB(UL OFDMA) response switch
 	bool ldpc_on;
 	bool stbc_on;
 	bool gf_rx_on;
@@ -92,6 +93,11 @@ __INLINE void rwnx_update_he_capa(uint32_t he_en)
 {
 	rwnx_mod_params.he_on = he_en;
 	RWNX_LOGI("update HE capa:%d\n", he_en);
+}
+__INLINE void rwnx_update_he_tb(uint32_t he_tb_en)
+{
+	rwnx_mod_params.he_tb_on = he_tb_en;
+	RWNX_LOGI("update HE TB:%d\n", he_tb_en);
 }
 __INLINE void rwnx_update_tx_ampdu_capa(uint32_t tx_ampdu_en)
 {

--- a/os/board/bk7239n/src/components/bk_wifi/src/rw_ieee80211.c
+++ b/os/board/bk7239n/src/components/bk_wifi/src/rw_ieee80211.c
@@ -500,8 +500,6 @@ UINT32 rw_ieee80211_init(void)
 	rwnx_hw->wiphy = wiphy;
 	rwnx_hw->mod_params = &rwnx_mod_params;
 
-	rwnx_hw->mod_params->bfmee = false;
-
 	if (ate_is_enabled())
 		rwnx_hw->mod_params->use_2040 = true;
 

--- a/os/board/bk7239n/src/components/bk_wifi/src/rw_msg_tx.c
+++ b/os/board/bk7239n/src/components/bk_wifi/src/rw_msg_tx.c
@@ -248,9 +248,11 @@ int rw_msg_send_me_config_req(void)
 		for (i = 0; i < MAC_HE_PPE_THRES_MAX_LEN; i++)
 			req->he_cap.ppe_thres[i] = he_cap->ppe_thres[i];
 		req->he_ul_on = rwnx_hw->mod_params->he_ul_on;
+		req->he_tb_on = rwnx_hw->mod_params->he_tb_on;
 	} else {
 		req->he_supp = false;
 		req->he_ul_on = false;
+		req->he_tb_on = false;
 	}
 
 	req->ps_on = rwnx_hw->mod_params->ps_on;		// TODO: BK7236 fix ps

--- a/os/board/bk7239n/src/components/bk_wifi/src/rwnx_params.c
+++ b/os/board/bk7239n/src/components/bk_wifi/src/rwnx_params.c
@@ -39,6 +39,11 @@ struct rwnx_mod_params rwnx_mod_params = {
 	PARAM(mcs_map, IEEE80211_VHT_MCS_SUPPORT_0_9),
 	PARAM(he_mcs_map, IEEE80211_HE_MCS_SUPPORT_0_9),
 	PARAM(he_ul_on, false),
+#if CONFIG_WIFI6
+	PARAM(he_tb_on, true),
+#else
+	PARAM(he_tb_on, false),
+#endif
 	/* reopen ldpc on for solve rx throughput */
 #if CONFIG_WIFI6 && (!CONFIG_SOC_BK7236N) && (!CONFIG_SOC_BK7239XX)
 	PARAM(ldpc_on, true),
@@ -63,7 +68,7 @@ struct rwnx_mod_params rwnx_mod_params = {
 #endif
 	PARAM(nss, 1),
 	PARAM(amsdu_rx_max, 0), // max amsdu size 3839
-	PARAM(bfmee, false),
+	PARAM(bfmee, true),
 	PARAM(bfmer, false),
 	//PARAM(mesh, true),
 	PARAM(murx, true),
@@ -862,6 +867,9 @@ void rwnx_udpate_capability(uint32_t capa_id, uint32_t capa_val)
 			break;
 		case WIFI_CAPA_ID_11B_ONLY_EN:
 			rwnx_update_11b_only(capa_val);
+			break;
+		case WIFI_CAPA_ID_OFDMA_EN:
+			rwnx_update_he_tb(capa_val);
 			break;
 		default:
 			break;

--- a/os/board/bk7239n/src/include/modules/wifi_types.h
+++ b/os/board/bk7239n/src/include/modules/wifi_types.h
@@ -356,6 +356,7 @@ typedef enum {
 	WIFI_CAPA_ID_LDPC_EN,       /**< Update Wi-Fi LDPC support capability */
 	WIFI_CAPA_ID_BEAMFORMEE_EN, /**< Update Wi-Fi Beamforming support capability */
 	WIFI_CAPA_ID_11B_ONLY_EN,   /**< Update Wi-Fi 11b support capability */
+	WIFI_CAPA_ID_OFDMA_EN,      /**< Update Wi-Fi OFDMA (TB UL OFDMA) support capability */
 	WIFI_CAPA_ID_MAX,
 }wifi_capability_t;
 /**


### PR DESCRIPTION
## Summary
- Add beamformee(mu-mimo) and OFDMA switch APIs for bk7239n Wi-Fi capability control.
1. trwifi_result_e bk_wifi_netmgr_disable_bfmee_mode(struct netdev *dev, uint8_t disable);
2. trwifi_result_e bk_wifi_netmgr_disable_ofdma_mode(struct netdev *dev, uint8_t disable);

- Update bk7239n `libwifi.a` to support switch beamformee(mu-mimo) and OFDMA.

## Test plan
- Basic Function
<img width="944" height="247" alt="image" src="https://github.com/user-attachments/assets/77c1a29e-bada-48b0-a3a0-cdc2fb1116d5" />

- Wi-Fi Iperf
<img width="513" height="130" alt="image" src="https://github.com/user-attachments/assets/b1a7ccb7-c148-4581-87b4-727871cde9fe" />

