### PR TITLE
os/: Add user pointer validation to prevent kernel memory access

### DIFF
--- a/os/arch/arm/src/common/up_checkspace.c
+++ b/os/arch/arm/src/common/up_checkspace.c
@@ -23,6 +23,7 @@
 #include <tinyara/config.h>
 #include <stdbool.h>
 #include <stdint.h>
+#include <errno.h>
 #ifdef CONFIG_SUPPORT_COMMON_BINARY
 #include <tinyara/binfmt/binfmt.h>
 #endif
@@ -72,5 +73,66 @@ bool is_kernel_space(void *addr)
 		return true;
 	}
 	return false;
+}
+
+/****************************************************************************
+ * Name: validate_user_pointer
+ *
+ * Description:
+ *   Validate that a pointer provided by user-space lies in a valid user
+ *   address range and does not point to kernel memory. This function is
+ *   intended to be called from syscall stubs in protected builds to prevent
+ *   unprivileged code from accessing kernel memory through syscall interfaces.
+ *
+ *   NULL pointers are always allowed - individual syscall implementations
+ *   handle NULL validation as appropriate.
+ *
+ *   For non-NULL pointers, the function checks:
+ *   - The pointer does not lie in kernel text space
+ *   - The pointer does not lie in kernel data/bss space
+ *   - The pointer does not lie in kernel PSRAM regions
+ *
+ * Input Parameters:
+ *   addr - The pointer address to validate
+ *   len  - Length of the memory region (0 for simple pointer check)
+ *
+ * Returned Value:
+ *   Zero (OK) is returned if the pointer is valid. A negative error value
+ *   is returned on failure:
+ *   -EFAULT  - The pointer points to kernel space
+ *
+ ****************************************************************************/
+
+int validate_user_pointer(const void *addr, size_t len)
+{
+	/* NULL pointers are allowed - syscall implementations handle NULL validation */
+	if (addr == NULL) {
+		return OK;
+	}
+
+	/* Check if the pointer lies in kernel address space.
+	 * This is the critical security check that prevents user-space from
+	 * accessing kernel memory through syscall interfaces.
+	 */
+	if (is_kernel_space((void *)addr)) {
+		return -EFAULT;
+	}
+
+	/* If a length is specified, also validate the end of the buffer.
+	 * This prevents a user from passing a valid start address that extends
+	 * into kernel space.
+	 */
+	if (len > 0) {
+		const void *end_addr = (const void *)((uintptr_t)addr + len);
+
+		/* Check for overflow */
+		if (end_addr <= addr) {
+			return -EFAULT;
+		}
+		if (is_kernel_space((void *)end_addr)) {
+			return -EFAULT;
+		}
+	}
+	return OK;
 }
 #endif							/* CONFIG_BUILD_PROTECTED */

--- a/os/include/tinyara/arch.h
+++ b/os/include/tinyara/arch.h
@@ -2573,6 +2573,18 @@ bool is_kernel_data_space(void *addr);
  ****************************************************************************/
 bool is_kernel_space(void *addr);
 
+/****************************************************************************
+ * Name: validate_user_pointer
+ *
+ * Description:
+ *   Validate that a pointer provided by user-space lies in a valid user
+ *   address range and does not point to kernel memory. This function is
+ *   intended to be called from syscall stubs in protected builds to prevent
+ *   unprivileged code from accessing kernel memory through syscall interfaces.
+ *
+ ****************************************************************************/
+int validate_user_pointer(const void *addr, size_t len);
+
 #endif
 
 #undef EXTERN

--- a/os/tools/mksyscall.c
+++ b/os/tools/mksyscall.c
@@ -417,13 +417,15 @@ static void generate_stub(int nparms)
 	fprintf(stream, "#include <tinyara/config.h>\n");
 	fprintf(stream, "#include <stdint.h>\n");
 	
-	if (cond_parm[0] != '\0') {
-		fprintf(stream, "#include <errno.h>\n");
-		fprintf(stream, "#include <sys/types.h>\n");
-	}
+	/* Always include errno.h for validate_user_pointer in protected builds */
+	fprintf(stream, "#include <errno.h>\n");
+	fprintf(stream, "#include <sys/types.h>\n");
 
 	if (get_parm(HEADER_INDEX) && strlen(get_parm(HEADER_INDEX)) > 0)
 		fprintf(stream, "#include <%s>\n", get_parm(HEADER_INDEX));
+
+	/* Include arch.h for validate_user_pointer in protected builds */
+	fprintf(stream, "#include <tinyara/arch.h>\n");
 
 	putc('\n', stream);
 
@@ -453,6 +455,76 @@ static void generate_stub(int nparms)
 	if (cond_parm[0] != '\0') {
 		fprintf(stream, "#if %s\n", cond_parm);
 	}
+
+	/* In protected builds, validate pointer arguments to prevent user-space
+	 * from accessing kernel memory through syscall interfaces.
+	 * Generate validation code for pointer-type parameters.
+	 */
+
+	fprintf(stream, "#ifdef CONFIG_BUILD_PROTECTED\n");
+
+	for (i = 0; i < nparms; i++) {
+		get_formalparmtype(get_parm(PARM1_INDEX + i), formal);
+		get_actualparmtype(get_parm(PARM1_INDEX + i), actual);
+
+		/* Check if this parameter is a pointer type (contains '*' or is an array)
+		 * Skip validation for non-pointer types and function pointers used as callbacks
+		 */
+		if (strchr(actual, '*') != NULL || strchr(actual, '[') != NULL) {
+			/* Generate validation call for this pointer parameter
+			 * NULL is allowed - syscall implementations handle NULL validation
+			 * For buffer parameters, also validate the full range to ensure it doesn't extend into kernel space
+			 */
+			const char *func_name = get_parm(NAME_INDEX);
+			int len_parm = 0;
+
+			/* Determine if this buffer has an associated length parameter
+			 * Pattern: buffer is parm[i], length is parm[i+1]
+			 */
+
+			/* read(fd, buf, nbytes), write(fd, buf, nbytes) - buf is parm2 (i=1), nbytes is parm3 */
+			if ((strcmp(func_name, "read") == 0 || strcmp(func_name, "write") == 0 ||
+			     strcmp(func_name, "pread") == 0 || strcmp(func_name, "pwrite") == 0) && i == 1) {
+				len_parm = 3;
+			}
+			/* recv, send, recvfrom, sendto - buf is parm2 (i=1), len is parm3 */
+			else if ((strcmp(func_name, "recv") == 0 || strcmp(func_name, "send") == 0 ||
+			          strcmp(func_name, "recvfrom") == 0 || strcmp(func_name, "sendto") == 0 ||
+			          strcmp(func_name, "recvmsg") == 0 || strcmp(func_name, "sendmsg") == 0) && i == 1) {
+				len_parm = 3;
+			}
+			/* mq_receive, mq_send, mq_timedreceive, mq_timedsend - buf is parm2, len is parm3 */
+			else if ((strcmp(func_name, "mq_receive") == 0 || strcmp(func_name, "mq_send") == 0 ||
+			          strcmp(func_name, "mq_timedreceive") == 0 || strcmp(func_name, "mq_timedsend") == 0) && i == 1) {
+				len_parm = 3;
+			}
+			/* setsockopt - optval is parm4 (i=3), optlen is parm5 */
+			else if (strcmp(func_name, "setsockopt") == 0 && i == 3) {
+				len_parm = 5;
+			}
+			/* getsockopt - optval is parm4 (i=3), but optlen is FAR socklen_t* (pointer), skip */
+			/* clock_gettime, clock_getres - tp is parm2 (i=1), no length param */
+			/* fstat, stat - buf is parm2 (i=1), struct stat size known to kernel */
+
+			if (len_parm > 0) {
+				fprintf(stream, "  if (validate_user_pointer((const void *)parm%d, (size_t)parm%d) != OK) {\n", i + 1, len_parm);
+			} else {
+				fprintf(stream, "  if (validate_user_pointer((const void *)parm%d, 0) != OK) {\n", i + 1);
+			}
+			fprintf(stream, "    set_errno(EFAULT);\n");
+			/* STUB functions always return uintptr_t, so we must return a value even for void syscalls */
+			if (strcmp(get_parm(RETTYPE_INDEX), "int") == 0 ||
+				strcmp(get_parm(RETTYPE_INDEX), "ssize_t") == 0) {
+				fprintf(stream, "    return (uintptr_t)-1;\n");
+			} else {
+				/* For void and pointer return types, return 0/NULL */
+				fprintf(stream, "    return (uintptr_t)0;\n");
+			}
+			fprintf(stream, "  }\n");
+		}
+	}
+
+	fprintf(stream, "#endif /* CONFIG_BUILD_PROTECTED */\n");
 
 	/* Then call the proxied function.  Functions that have no return value are
 	 * a special case.


### PR DESCRIPTION
Fix syscall vulnerability (finding-034) where unprivileged applications could
    pass kernel addresses to syscall interfaces, allowing unauthorized kernel
    memory access.
    - Add validate_user_pointer() function to detect kernel addresses in flash,
      IRAM, SRAM, and PSRAM regions
    - Generate syscall stubs that validate pointer arguments before kernel dispatch
    - Reject pointers that reference kernel memory regions with EFAULT error
    - Apply protection to all pointer-bearing syscalls in CONFIG_BUILD_PROTECTED builds