### PR TITLE
csifw: fix/improve memory allocation, state check, service handling, and packet monitoring

### DIFF
--- a/framework/src/csimanager/CSIFrameworkMain.c
+++ b/framework/src/csimanager/CSIFrameworkMain.c
@@ -33,6 +33,8 @@
 
 #define RUNNING 1
 #define STOPPED 0
+#define MAX_COUNT 10
+#define WAIT_TIME 100
 
 const static char **CSIFW_TASK_ARGV = NULL;
 const static char *CSIFW_TASK_NAME = "csifw_task_Main";
@@ -76,7 +78,9 @@ int start_csi_framework(csifw_context_t *p_ctx)
 
 	if (handle < 0) {
 		CSIFW_LOGE("Failed to create csifw task to the task manager! Return: %d", handle);
-		sem_destroy(&p_ctx->csifw_task_sema);
+		if (sem_destroy(&p_ctx->csifw_task_sema) < OK) {
+			CSIFW_LOGE("Semaphore destroy failed, errno: %d (%s)", get_errno(), strerror(get_errno()));
+		}
 		CSIFW_LOGD("Destroyed semaphore for %s after failed create", CSIFW_TASK_NAME);
 		return handle;
 	}
@@ -93,16 +97,27 @@ int start_csi_framework(csifw_context_t *p_ctx)
 			CSIFW_LOGE("Failed to unregister csifw task to the task manager! Return: %d", tm_unregister_return);
 			//To-Do: Error handling logic to be addressed later.
 		}
-		sem_destroy(&p_ctx->csifw_task_sema);
+		if (sem_destroy(&p_ctx->csifw_task_sema) < OK) {
+			CSIFW_LOGE("Semaphore destroy failed, errno: %d (%s)", get_errno(), strerror(get_errno()));
+		}
 		CSIFW_LOGD("Destroyed semaphore for %s after failed start", CSIFW_TASK_NAME);
 	} else {
 		p_ctx->task_handle = handle;
-		sem_wait(&p_ctx->csifw_task_sema);
+		while (sem_wait(&p_ctx->csifw_task_sema) < 0) {
+			if (errno != EINTR) {
+				CSIFW_LOGE("Failed to wait for csifw task semaphore, errno: %d (%s)", errno, strerror(errno));
+				break;
+			} else {
+				CSIFW_LOGE("Failed to wait for csifw task semaphore, errno == EINTR, wait continue");
+			}
+		}
 
 		if (!p_ctx->task_run_success) {
 			CSIFW_LOGE("CSI framework task initialization failed");
 			task_manager_stop_and_unregister(p_ctx->task_handle);
-			sem_destroy(&p_ctx->csifw_task_sema);
+			if (sem_destroy(&p_ctx->csifw_task_sema) < OK) {
+				CSIFW_LOGE("Semaphore destroy failed, errno: %d (%s)", get_errno(), strerror(get_errno()));
+			}
 			return -1;
 		}
 		CSIFW_LOGI("Started %s", CSIFW_TASK_NAME);
@@ -119,10 +134,19 @@ int stop_csi_framework(csifw_context_t *p_ctx)
 	
 	p_ctx->task_run_state = STOPPED;			//stop the main loop of the task
 	CSIFW_LOGD("Waiting for csifw_task to complete...");
-	sem_wait(&p_ctx->csifw_task_sema);
+	while (sem_wait(&p_ctx->csifw_task_sema) < 0) {
+		if (errno != EINTR) {
+			CSIFW_LOGE("Failed to wait for csifw task semaphore, errno: %d (%s)", errno, strerror(errno));
+			break;
+		} else {
+			CSIFW_LOGE("Failed to wait for csifw task semaphore, errno == EINTR, wait continue");
+		}
+	}
 	task_manager_stop_and_unregister(p_ctx->task_handle);
 	CSIFW_LOGD("Destroying semaphore for %s", CSIFW_TASK_NAME);
-	sem_destroy(&p_ctx->csifw_task_sema);
+	if (sem_destroy(&p_ctx->csifw_task_sema) < OK) {
+		CSIFW_LOGE("Semaphore destroy failed, errno: %d (%s)", get_errno(), strerror(get_errno()));
+	}
 	return 0;
 }
 
@@ -133,13 +157,17 @@ int csifw_task_Main(int argc, char *argv[])
 
 	if (csi_packet_receiver_initialize() != CSIFW_OK) {
 		CSIFW_LOGE("csi_packet_receiver_initialize failed - cannot start CSI framework");
-		sem_post(&p_csifw_ctx->csifw_task_sema);
+		if (sem_post(&p_csifw_ctx->csifw_task_sema) < OK) {
+			CSIFW_LOGE("Semaphore post failed, errno: %d (%s)", get_errno(), strerror(get_errno()));
+		}
 		return -1;
 	}
 	if (csi_packet_receiver_start_collect() != CSIFW_OK) {
 		CSIFW_LOGE("CSI packet receiver start failed");
 		csi_packet_receiver_cleanup();
-		sem_post(&p_csifw_ctx->csifw_task_sema);
+		if (sem_post(&p_csifw_ctx->csifw_task_sema) < OK) {
+			CSIFW_LOGE("Semaphore post failed, errno: %d (%s)", get_errno(), strerror(get_errno()));
+		}
 		return -1;
 	}
 	if (csi_ping_generator_initialize() != CSIFW_OK) {
@@ -147,7 +175,9 @@ int csifw_task_Main(int argc, char *argv[])
 		csi_packet_receiver_stop_collect();
 		csi_packet_receiver_cleanup();
 		CSIFW_LOGE("CSI packet receiver stopped as Ping Generator failed");
-		sem_post(&p_csifw_ctx->csifw_task_sema);
+		if (sem_post(&p_csifw_ctx->csifw_task_sema) < OK) {
+			CSIFW_LOGE("Semaphore post failed, errno: %d (%s)", get_errno(), strerror(get_errno()));
+		}
 		return -1;
 	}
 	if (ping_generator_start() != CSIFW_OK) {
@@ -156,13 +186,17 @@ int csifw_task_Main(int argc, char *argv[])
 		csi_packet_receiver_cleanup();
 		csi_ping_generator_cleanup();
 		CSIFW_LOGE("CSI packet receiver stopped as Ping Generator start failed");
-		sem_post(&p_csifw_ctx->csifw_task_sema);
+		if (sem_post(&p_csifw_ctx->csifw_task_sema) < OK) {
+			CSIFW_LOGE("Semaphore post failed, errno: %d (%s)", get_errno(), strerror(get_errno()));
+		}
 		return -1;
 	}
 	//to unlock start_csi_framework()
 	p_csifw_ctx->task_run_success = 1;
 	p_csifw_ctx->task_run_state = RUNNING;
-	sem_post(&p_csifw_ctx->csifw_task_sema);
+	if (sem_post(&p_csifw_ctx->csifw_task_sema) < OK) {
+		CSIFW_LOGE("Semaphore post failed, errno: %d (%s)", get_errno(), strerror(get_errno()));
+	}
 
 	while (p_csifw_ctx->task_run_state) {
 		usleep(50 * 1000);		//50 milisecond sleep
@@ -181,20 +215,55 @@ int csifw_task_Main(int argc, char *argv[])
 		CSIFW_LOGE("CSI packet receiver cleanup failed");
 	}
 	//to unlock stop_csi_framework()
-	sem_post(&p_csifw_ctx->csifw_task_sema);
+	if (sem_post(&p_csifw_ctx->csifw_task_sema) < OK) {
+		CSIFW_LOGE("Semaphore post failed, errno: %d (%s)", get_errno(), strerror(get_errno()));
+	}
 	return 0;
 }
 
 static void task_manager_stop_and_unregister(int m_task_handle)
 {
 	CSIFW_LOGD("Stopping task %s (Task_Handle=%d)", CSIFW_TASK_NAME, m_task_handle);
-	int tm_stop_return = task_manager_stop(m_task_handle, TM_RESPONSE_WAIT_INF);
-	if (tm_stop_return == OK) {
-		CSIFW_LOGD("Stopped successfully (Task_Handle=%d). Return: %d.", m_task_handle, tm_stop_return);
-	} else if (tm_stop_return == TM_ALREADY_STOPPED_APP) {
-		CSIFW_LOGD("Task already stopped (Task_Handle=%d)", m_task_handle);
-	} else {
-		CSIFW_LOGE("Failed to stop (Task_Handle=%d). Return: %d.", m_task_handle, tm_stop_return);
+	int retry_count = 0;
+	tm_appinfo_t *info = NULL;
+	const char *status_str;
+	while (retry_count < MAX_COUNT) {
+		info = task_manager_getinfo_with_handle(m_task_handle, TM_RESPONSE_WAIT_INF);
+		if (info == NULL) {
+			CSIFW_LOGE("Failed to get task info for handle %d, proceeding to unregister", m_task_handle);
+			break;
+		}
+		switch (info->status) {
+			case TM_APP_STATE_RUNNING:      	status_str = "RUNNING"; 	break;
+			case TM_APP_STATE_PAUSE:        	status_str = "PAUSE"; 		break;
+			case TM_APP_STATE_STOP:         	status_str = "STOP"; 		break;
+			case TM_APP_STATE_UNREGISTERED: 	status_str = "UNREGISTERED"; 	break;
+			case TM_APP_STATE_CANCELLING:   	status_str = "CANCELLING"; 	break;
+			case TM_APP_STATE_WAIT_UNREGISTER: 	status_str = "WAIT_UNREGISTER"; break;
+			default:                        	status_str = "UNKNOWN"; 	break;
+		}
+		CSIFW_LOGD("Current task status: %s (%d), attempt %d/10", status_str, info->status, retry_count + 1);
+		if (info->status == TM_APP_STATE_STOP) {
+			CSIFW_LOGD("Task state is STOP, proceeding to unregister");
+			break;
+		}
+		retry_count++;
+		if (retry_count < MAX_COUNT) {
+			usleep(WAIT_TIME * 1000); // 100ms
+		}
+	}
+	if (retry_count >= MAX_COUNT) {
+		CSIFW_LOGI("Task did not reach STOP state after 10 attempts (final state: %s)", status_str);
+		info = task_manager_getinfo_with_handle(m_task_handle, TM_RESPONSE_WAIT_INF);
+		if ((info) && (info->status == TM_APP_STATE_RUNNING)) {
+			CSIFW_LOGD("Task state is RUNNING Stopping task %s (Task_Handle=%d)", CSIFW_TASK_NAME, m_task_handle);
+			int tm_stop_return = task_manager_stop(m_task_handle, TM_RESPONSE_WAIT_INF);
+			if (tm_stop_return == OK) {
+				CSIFW_LOGD("Stopped successfully (Task_Handle=%d). Return: %d.", m_task_handle, tm_stop_return);
+			} else {
+				CSIFW_LOGE("Failed to stop (Task_Handle=%d). Return: %d.", m_task_handle, tm_stop_return);
+			}
+		}
 	}
 
 	CSIFW_LOGD("Unregistering task %s (Task_Handle=%d)", CSIFW_TASK_NAME, m_task_handle);
@@ -205,5 +274,6 @@ static void task_manager_stop_and_unregister(int m_task_handle)
 		CSIFW_LOGE("Failed to unregister csifw task to the task manager! Return: %d", tm_unregister_return);
 		//To-Do: Error handling logic to be addressed later.
 	}
+	task_manager_clean_info(&info);
 }
 

--- a/framework/src/csimanager/CSIManager.c
+++ b/framework/src/csimanager/CSIManager.c
@@ -30,7 +30,6 @@ static pthread_mutex_t g_api_mutex = PTHREAD_MUTEX_INITIALIZER;
 static int get_empty_idx(void);
 static int all_services_stopped(void);
 static void destroy_csifw_context(void);
-static int get_service_idx(unsigned int id);
 static void nw_state_notify_service(CONNECTION_STATE state);
 static CSIFW_RES check_hnd_validity(csifw_service_handle hnd);
 static void csifw_update_state_and_log(CSI_FRAMEWORK_STATE new_state);
@@ -46,6 +45,32 @@ static const char *csi_framework_state_strings[] =
     "INITIALIZED",
     "STARTED_WAITING_FOR_NW_RECONNECT"
 };
+
+static inline CSIFW_RES validate_register_params(csifw_service_handle *p_hnd, service_callbacks_t *p_svc_cb,
+                                                 csi_config_type_t config_type, unsigned int interval)
+{
+	if (!p_hnd) {
+		CSIFW_LOGE("Invalid argument: Service Handle is NULL");
+		return CSIFW_INVALID_ARG;
+	}
+	if (!p_svc_cb) {
+		CSIFW_LOGE("Invalid argument: Service Callback is NULL");
+		return CSIFW_INVALID_ARG;
+	}
+	if (!p_svc_cb->raw_data_cb && !p_svc_cb->parsed_data_cb) {
+		CSIFW_LOGE("Invalid argument: at least one callback must be provided");
+		return CSIFW_INVALID_ARG;
+	}
+	if (config_type <= MIN_CSI_CONFIG_TYPE || config_type >= MAX_CSI_CONFIG_TYPE) {
+		CSIFW_LOGE("Invalid argument: CSI config type: %d (Valid: %d-%d)", config_type, HT_CSI_DATA, NON_HT_CSI_DATA_ACC1);
+		return CSIFW_INVALID_ARG;
+	}
+	if (interval < CSIFW_MIN_INTERVAL_MS) {
+		CSIFW_LOGE("Invalid argument: Interval: %d ms (Minimum: %d ms)", interval, CSIFW_MIN_INTERVAL_MS);
+		return CSIFW_INVALID_ARG;
+	}
+	return CSIFW_OK;
+}
 
 static void csifw_update_state_and_log(CSI_FRAMEWORK_STATE new_state) 
 {
@@ -63,7 +88,7 @@ static void csifw_update_state_and_log(CSI_FRAMEWORK_STATE new_state)
 
   const char *prev_state_str = (prev_state == CSI_FRAMEWORK_STATE_UNINITIALIZED) ? "UNINITIALIZED" : csi_framework_state_strings[prev_state + 1];
   const char *new_state_str = csi_framework_state_strings[new_state + 1];
-  CSIFW_LOGI("CSIFW state changed from %s to %s", prev_state_str, new_state_str);
+  CSIFW_LOGE("CSIFW state changed from %s to %s", prev_state_str, new_state_str);
 }
 
 static void csi_network_state_listener(CONNECTION_STATE state)
@@ -104,32 +129,22 @@ static void csi_network_state_listener(CONNECTION_STATE state)
   CSIFW_MUTEX_UNLOCK(&g_api_mutex);
 }
 
-static void CSIRawDataListener(CSIFW_RES res, int raw_csi_buff_len, unsigned char *raw_csi_buff, int raw_csi_data_len) 
+static void csi_data_listener(CSIFW_RES res, int raw_csi_buff_len, unsigned char *raw_csi_buff) 
 {
   if (!g_pcsifw_context) {
     return;
   }
-
-  if (g_pcsifw_context->parsed_data_cb_count > 0 && g_pcsifw_context->parsed_data_cb_started_count > 0) {
-        #if defined(CONFIG_WIFI_CSI_RTL8730E)
-          getParsedData(raw_csi_buff,
-                        raw_csi_buff_len,
-                        g_pcsifw_context->csi_config,
-                        g_pcsifw_context->parsed_buffptr,
-                        &g_pcsifw_context->ParsedDataBufferLen);
-        #elif defined(CONFIG_BK_WIFI_CSI_ADAPTER)
-          CSIFW_LOGE("Parsing is not enabled for BEKEN");
-          return;
-        #else
-          CSIFW_LOGE("Unknown CSI board configuration");
-          return;
-        #endif
-  }
-
-  // CSIRawDataListener callback can be invoked from a background thread when CSI data arrives. 
+  // csi_data_listener callback can be invoked from a background thread when CSI data arrives. 
   // Simultaneously, application threads may call `csifw_start()/csifw_stop()` to modify service states. 
   // Without this mutex, race conditions will occur
   CSIFW_MUTEX_LOCK(&g_pcsifw_context->data_receiver_mutex);
+  
+  // Process and parse CSI data
+  if (g_pcsifw_context->parsed_data_cb_count > 0 && g_pcsifw_context->parsed_data_cb_started_count > 0) {
+    CSIFW_LOGE("Parsing not implemented");
+  }
+
+  // Send CSI data to service
   for (int i = 0; i < CSIFW_MAX_NUM_APPS; i++) {
     if (g_pcsifw_context->csi_services[i].svc_id != 0 && g_pcsifw_context->csi_services[i].svc_state == CSI_SERVICE_START) {
       if (g_pcsifw_context->csi_services[i].raw_data_cb) {
@@ -137,12 +152,6 @@ static void CSIRawDataListener(CSIFW_RES res, int raw_csi_buff_len, unsigned cha
                                                       raw_csi_buff_len,
                                                       raw_csi_buff,
                                                       g_pcsifw_context->csi_services[i].service_data);
-      }
-      if (g_pcsifw_context->csi_services[i].parsed_data_cb) {
-        g_pcsifw_context->csi_services[i].parsed_data_cb(res,
-                                                         g_pcsifw_context->ParsedDataBufferLen,
-                                                         g_pcsifw_context->parsed_buffptr,
-                                                         g_pcsifw_context->csi_services[i].service_data);
       }
     }
   }
@@ -153,25 +162,22 @@ CSIFW_RES csifw_registerService(csifw_service_handle *p_hnd, service_callbacks_t
 {
   CSIFW_RES res = CSIFW_OK;
   csifw_service_info_t *p_svc_info = NULL;
-  CSIFW_MUTEX_LOCK(&g_api_mutex);
-
-  if (!p_hnd) {
-    CSIFW_LOGE("Invalid handle argument, should not be a null pointer");
-    res = CSIFW_INVALID_ARG;
-    goto on_error;
+  if (validate_register_params(p_hnd, p_svc_cb, config_type, interval) == CSIFW_INVALID_ARG) {
+	  return CSIFW_INVALID_ARG;
   }
 
+  CSIFW_MUTEX_LOCK(&g_api_mutex);
   if (!g_pcsifw_context) {
     CSIFW_LOGD("Allocating new CSIFW_Context");
     g_pcsifw_context = (csifw_context_t *)calloc(1, sizeof(csifw_context_t));
     if (!g_pcsifw_context) {
-      CSIFW_LOGE("CSIFW_Context Memory allocation Failed");
+      CSIFW_LOGE("CSIFW Registration Fail: Context memory allocation Failed");
       res = CSIFW_NO_MEM;
       goto on_error;
     }
-    CSIFW_LOGD("Context Created Successfully");
+    CSIFW_LOGD("Context Created");
     if (pthread_mutex_init(&g_pcsifw_context->data_receiver_mutex, NULL) != 0) {
-      CSIFW_LOGE("Mutex init failed of data_receiver_mutex");
+      CSIFW_LOGE("CSIFW Registration Fail: Mutex init failed for data_receiver_mutex");
       destroy_csifw_context();
       res = CSIFW_ERROR;
       goto on_error;
@@ -186,14 +192,6 @@ CSIFW_RES csifw_registerService(csifw_service_handle *p_hnd, service_callbacks_t
   }
 
   if (g_pcsifw_context->csifw_state == CSI_FRAMEWORK_STATE_UNINITIALIZED) {
-    if (config_type <= MIN_CSI_CONFIG_TYPE || config_type >= MAX_CSI_CONFIG_TYPE || interval < CSIFW_MIN_INTERVAL_MS) {
-      CSIFW_LOGE("Either invalid CSI config type: %d. (Valid config range: %d-%d)", config_type, HT_CSI_DATA, NON_HT_CSI_DATA_ACC1);
-      CSIFW_LOGE("Or invalid interval: %d ms. (Minimum allowed: %d ms)", interval, CSIFW_MIN_INTERVAL_MS);
-      destroy_csifw_context();
-      res = CSIFW_INVALID_ARG;
-      goto on_error;
-    }
-
     g_pcsifw_context->csi_config = config_type;
     g_pcsifw_context->csi_interval = interval;
     if (config_type == HT_CSI_DATA_ACC1 || config_type == HT_CSI_DATA) {
@@ -201,39 +199,44 @@ CSIFW_RES csifw_registerService(csifw_service_handle *p_hnd, service_callbacks_t
     } else {
       ping_generator_change_interval(0);
     }
-
-    csi_packet_callback_register(CSIRawDataListener);
     if (!network_monitor_init(csi_network_state_listener)) {
-      CSIFW_LOGE("Network_Monitor_Init Failed");
+      CSIFW_LOGE("CSIFW Registration Fail: Network monitor init Failed");
+      pthread_mutex_destroy(&g_pcsifw_context->data_receiver_mutex);
       destroy_csifw_context();
       res = CSIFW_ERROR;
       goto on_error;
     }
+
+    p_svc_info = add_service(g_pcsifw_context, p_svc_cb);
+    if (!p_svc_info) {
+      CSIFW_LOGE("CSIFW Registration Fail: Created context but failed to allocate memory for service.");
+      network_monitor_deinit();
+      pthread_mutex_destroy(&g_pcsifw_context->data_receiver_mutex);
+      destroy_csifw_context();
+      res = CSIFW_ERROR;
+      goto on_error;
+    }
+    
+    csi_packet_callback_register(csi_data_listener);
+    csifw_update_state_and_log(CSI_FRAMEWORK_STATE_INITIALIZED);
   } else {
     if (g_pcsifw_context->csi_config != config_type || g_pcsifw_context->csi_interval != interval) {
-      CSIFW_LOGE("Service already inited with different configuration/interval."
-          		 "Cannot register service with different configuration/interval.");
+      CSIFW_LOGE("Service already inited with configuration: %d, interval: %u."
+                 "Cannot register service with different configuration/interval.",
+                  g_pcsifw_context->csi_config, g_pcsifw_context->csi_interval);
+
       res = CSIFW_ERROR_ALREADY_INIT_WITH_DIFFERENT_CONFIG;
       goto on_error;
     }
-  }
 
-  p_svc_info = add_service(g_pcsifw_context, p_svc_cb);
-  if (!p_svc_info) {
-    if (g_pcsifw_context->csifw_state == CSI_FRAMEWORK_STATE_UNINITIALIZED) {
-      CSIFW_LOGE("Created context but failed to allocate memory.");
-      destroy_csifw_context();
+    p_svc_info = add_service(g_pcsifw_context, p_svc_cb);
+    if (!p_svc_info) {
+      res = CSIFW_ERROR;
+      goto on_error;
     }
-    res = CSIFW_ERROR_MAX_NUM_SERVICE_REGISTERED;
-    goto on_error;
   }
-
   *p_hnd = (csifw_service_handle)p_svc_info;
-
-  if (g_pcsifw_context->csifw_state == CSI_FRAMEWORK_STATE_UNINITIALIZED) {
-    csifw_update_state_and_log(CSI_FRAMEWORK_STATE_INITIALIZED);
-    CSIFW_LOGI("CSIFW Service Registered Successfully.");
-  }
+  CSIFW_LOGE("CSIFW Service Registered Successfully.");
 
 on_error:
   CSIFW_MUTEX_UNLOCK(&g_api_mutex);
@@ -255,8 +258,9 @@ CSIFW_RES csifw_start(csifw_service_handle hnd)
 
   if (g_pcsifw_context->csifw_state == CSI_FRAMEWORK_STATE_STARTED_WAITING_FOR_NW ||
       g_pcsifw_context->csifw_state == CSI_FRAMEWORK_STATE_STARTED_WAITING_FOR_NW_RECONNECT) {
-    CSIFW_LOGI("Waiting for NW, CSI data will start when network will be connected");
+    CSIFW_LOGE("Waiting for Network, CSI data will start upon network connection");
     p_svc_info->svc_state = CSI_SERVICE_START;
+    CSIFW_LOGE("Service started successfully, registered services count is %d", g_pcsifw_context->service_count);
     res = CSIFW_OK_WIFI_NOT_CONNECTED;
     goto on_error;
   }
@@ -275,19 +279,20 @@ CSIFW_RES csifw_start(csifw_service_handle hnd)
         goto on_error;
       }
       csifw_update_state_and_log(CSI_FRAMEWORK_STATE_STARTED);
+      CSIFW_LOGE("CSIFW started successfully");
     } else {
       csifw_update_state_and_log(CSI_FRAMEWORK_STATE_STARTED_WAITING_FOR_NW);
-      CSIFW_LOGE("Waiting for NW, CSI data will start when network will be connected");
+      CSIFW_LOGE("CSIFW started but waiting for Network, CSI data will start upon network connection");
     }
   }
 
   CSIFW_MUTEX_LOCK(&g_pcsifw_context->data_receiver_mutex);
   p_svc_info->svc_state = CSI_SERVICE_START;
+  CSIFW_LOGE("Service started successfully, registered services count is %d", g_pcsifw_context->service_count);
   if (p_svc_info->parsed_data_cb) {
     g_pcsifw_context->parsed_data_cb_started_count++;
   }
   CSIFW_MUTEX_UNLOCK(&g_pcsifw_context->data_receiver_mutex);
-  CSIFW_LOGI("Service [%d] started successfully, services count is %d", p_svc_info->svc_id, g_pcsifw_context->service_count);
 
 on_error:
   CSIFW_MUTEX_UNLOCK(&g_api_mutex);
@@ -310,13 +315,14 @@ CSIFW_RES csifw_stop(csifw_service_handle hnd)
   if (g_pcsifw_context->csifw_state != CSI_FRAMEWORK_STATE_STARTED &&
       g_pcsifw_context->csifw_state != CSI_FRAMEWORK_STATE_STARTED_WAITING_FOR_NW &&
       g_pcsifw_context->csifw_state != CSI_FRAMEWORK_STATE_STARTED_WAITING_FOR_NW_RECONNECT) {
-    CSIFW_LOGI("CSIFW service already stopped");
+    CSIFW_LOGI("CSIFW already stopped");
     res = CSIFW_OK_ALREADY_STOPPED;
     goto on_error;
   }
 
   CSIFW_MUTEX_LOCK(&g_pcsifw_context->data_receiver_mutex);
   p_svc_info->svc_state = CSI_SERVICE_STOP;
+  CSIFW_LOGE("Service stopped successfully, registered services count is %d", g_pcsifw_context->service_count);
   if (p_svc_info->parsed_data_cb) {
     g_pcsifw_context->parsed_data_cb_started_count--;
   }
@@ -335,7 +341,7 @@ CSIFW_RES csifw_stop(csifw_service_handle hnd)
     }
   }
   csifw_update_state_and_log(CSI_FRAMEWORK_STATE_STOPPED);
-  CSIFW_LOGI("Service [%d] stopped successfully, remaining services count is %d", p_svc_info->svc_id, g_pcsifw_context->service_count);
+  CSIFW_LOGE("CSIFW stopped successfully");
 
 on_error:
   CSIFW_MUTEX_UNLOCK(&g_api_mutex);
@@ -361,7 +367,9 @@ CSIFW_RES csifw_unregisterService(csifw_service_handle hnd)
   }
 
   remove_service(g_pcsifw_context, p_svc_info);
-  if (g_pcsifw_context->service_count == 0 && g_pcsifw_context->csifw_state == CSI_FRAMEWORK_STATE_STOPPED) {
+  if (g_pcsifw_context->service_count == 0 &&
+      (g_pcsifw_context->csifw_state == CSI_FRAMEWORK_STATE_STOPPED ||
+       g_pcsifw_context->csifw_state == CSI_FRAMEWORK_STATE_INITIALIZED)) {
     CSIFW_LOGD("No service left, destroying framework context");
     res = csi_packet_receiver_deinit();
     if (res != CSIFW_OK) {
@@ -375,7 +383,7 @@ CSIFW_RES csifw_unregisterService(csifw_service_handle hnd)
     pthread_mutex_destroy(&g_pcsifw_context->data_receiver_mutex);
     destroy_csifw_context();
   }
-  CSIFW_LOGI("CSIFW Service Un-Registered Successfully.");
+  CSIFW_LOGE("CSIFW Service Un-Registered Successfully.");
 
 on_error:
   CSIFW_MUTEX_UNLOCK(&g_api_mutex);
@@ -404,12 +412,14 @@ CSIFW_RES csifw_set_interval(csifw_service_handle hnd, unsigned int interval)
   }
 
   g_pcsifw_context->csi_interval = interval;
-  if (g_pcsifw_context->csifw_state == CSI_FRAMEWORK_STATE_STOPPED || g_pcsifw_context->csifw_state == CSI_FRAMEWORK_STATE_STARTED_WAITING_FOR_NW) {
+  if (g_pcsifw_context->csifw_state == CSI_FRAMEWORK_STATE_STOPPED ||
+      g_pcsifw_context->csifw_state == CSI_FRAMEWORK_STATE_STARTED_WAITING_FOR_NW) {
     CSIFW_LOGI("Interval updated: %u", g_pcsifw_context->csi_interval);
     goto on_error;
   }
 
-  if (g_pcsifw_context->csi_config == HT_CSI_DATA || g_pcsifw_context->csi_config == HT_CSI_DATA_ACC1) {
+  if (g_pcsifw_context->csi_config == HT_CSI_DATA ||
+      g_pcsifw_context->csi_config == HT_CSI_DATA_ACC1) {
     ping_generator_change_interval(g_pcsifw_context->csi_interval);
   } else {
     res = csi_packet_receiver_change_interval();
@@ -518,19 +528,6 @@ CSIFW_RES csifw_force_restart(csifw_service_handle hnd)
 
 /* service handling functions */
 
-static int get_service_idx(unsigned int id) 
-{
-  if ((!g_pcsifw_context) || (g_pcsifw_context->service_count == 0)) {
-    return -1;
-  }
-  for (int i = 0; i < CSIFW_MAX_NUM_APPS; i++) {
-    if (g_pcsifw_context->csi_services[i].svc_id == id) {
-      return i;
-    }
-  }
-  return -1;
-}
-
 static int get_empty_idx(void) 
 {
   if (!g_pcsifw_context) {
@@ -555,43 +552,33 @@ static int get_empty_idx(void)
  */
 csifw_service_info_t *add_service(csifw_context_t *p_csifw_ctx, service_callbacks_t *p_svc_cb) 
 {
-  unsigned int cid = 0;
   int idx = get_empty_idx();
   if (idx < 0) {
     CSIFW_LOGE("Max Number of services already registered");
     return NULL;  // invalid id
   }
 
-  if (!p_svc_cb->raw_data_cb && !p_svc_cb->parsed_data_cb) {
-    CSIFW_LOGE("Invalid service register request, both Raw Data CB and Parse Data CB are NULL");
-    return NULL;
+  for (int i = 0; i < CSIFW_MAX_NUM_APPS; i++) {
+    if ((p_csifw_ctx->csi_services[i].raw_data_cb == p_svc_cb->raw_data_cb) &&
+        (p_csifw_ctx->csi_services[i].parsed_data_cb == p_svc_cb->parsed_data_cb)) {
+      CSIFW_LOGE("Service already registered");
+      return NULL;
+    }
   }
 
+  CSIFW_MUTEX_LOCK(&g_pcsifw_context->data_receiver_mutex);
   if (p_svc_cb->parsed_data_cb) {
-    cid = (unsigned int)p_svc_cb->parsed_data_cb;
-    if (!p_csifw_ctx->parsed_buffptr) {
-      p_csifw_ctx->ParsedDataBufferLen = CSIFW_MAX_RAW_BUFF_LEN;
-      p_csifw_ctx->parsed_buffptr = (float *)malloc(sizeof(float) * p_csifw_ctx->ParsedDataBufferLen);
-      if (!p_csifw_ctx->parsed_buffptr) {
-        CSIFW_LOGE("Failed to allocate memory for parsed data buffer, size: %zu", sizeof(float) * p_csifw_ctx->ParsedDataBufferLen);
-        return NULL;
-      }
-    }
-  }
-  if (p_svc_cb->raw_data_cb) {
-    cid = (unsigned int)p_svc_cb->raw_data_cb;
+	  if (!p_csifw_ctx->parsed_buffptr) {
+		  p_csifw_ctx->ParsedDataBufferLen = CSIFW_MAX_RAW_BUFF_LEN;
+		  p_csifw_ctx->parsed_buffptr = (float *)malloc(sizeof(float) * p_csifw_ctx->ParsedDataBufferLen);
+		  if (!p_csifw_ctx->parsed_buffptr) {
+			  CSIFW_LOGE("Failed to allocate memory for parsed data buffer");
+			  return NULL;
+		  }
+	  }
   }
 
-  if (get_service_idx(cid) != -1) {
-    if (p_csifw_ctx->parsed_buffptr) {
-      free(p_csifw_ctx->parsed_buffptr);
-      p_csifw_ctx->parsed_buffptr = NULL;
-    }
-    CSIFW_LOGE("Service with ID: %d already registered", cid);
-    return NULL;
-  }
-
-  p_csifw_ctx->csi_services[idx].svc_id = cid;
+  p_csifw_ctx->csi_services[idx].svc_id = (int)p_svc_cb; //Use callback structure address as unique service identifier
   p_csifw_ctx->csi_services[idx].svc_state = CSI_SERVICE_REGISTERED;
   p_csifw_ctx->csi_services[idx].raw_data_cb = p_svc_cb->raw_data_cb;
   p_csifw_ctx->csi_services[idx].parsed_data_cb = p_svc_cb->parsed_data_cb;
@@ -600,35 +587,34 @@ csifw_service_info_t *add_service(csifw_context_t *p_csifw_ctx, service_callback
   }
   p_csifw_ctx->csi_services[idx].service_data = p_svc_cb->user_data;
   p_csifw_ctx->service_count++;
+  CSIFW_MUTEX_UNLOCK(&g_pcsifw_context->data_receiver_mutex);
 
-  CSIFW_LOGI("Idx %d: Service(%d) registered with CSIFW. Total services: %d", idx, cid, p_csifw_ctx->service_count);
+  CSIFW_LOGE("Idx %d: Service added successfully. Total registered services: %d", idx, p_csifw_ctx->service_count);
   return &p_csifw_ctx->csi_services[idx];
 }
 
 static CSIFW_RES remove_service(csifw_context_t *p_csifw_ctx, csifw_service_info_t *p_svc_info) 
 {
-  int idx = get_service_idx(p_svc_info->svc_id);
-  if (idx == -1) {
-    CSIFW_LOGE("CSI Service not registered [%d].", p_svc_info->svc_id);
+  int idx = p_svc_info - p_csifw_ctx->csi_services;
+  if (idx < 0 || idx >= CSIFW_MAX_NUM_APPS || p_csifw_ctx->csi_services[idx].svc_id == 0) {
+    CSIFW_LOGE("CSI Service not registered.");
     return CSIFW_ERROR_SERVICE_NOT_REGISTERED;
   }
 
+  CSIFW_MUTEX_LOCK(&g_pcsifw_context->data_receiver_mutex);
   if (p_csifw_ctx->csi_services[idx].parsed_data_cb) {
     p_csifw_ctx->parsed_data_cb_count--;
+    if ((p_csifw_ctx->parsed_data_cb_count == 0) && (p_csifw_ctx->parsed_buffptr)) {
+      p_csifw_ctx->ParsedDataBufferLen = 0;
+      free(p_csifw_ctx->parsed_buffptr);
+      p_csifw_ctx->parsed_buffptr = NULL;
+    }
   }
-
-  if ((p_csifw_ctx->parsed_buffptr) &&
-      (p_csifw_ctx->parsed_data_cb_count <= 0)) {
-    p_csifw_ctx->ParsedDataBufferLen = 0;
-    free(p_csifw_ctx->parsed_buffptr);
-    p_csifw_ctx->parsed_buffptr = NULL;
-  }
-
   memset(&p_csifw_ctx->csi_services[idx], 0, sizeof(csifw_service_info_t));
   p_csifw_ctx->service_count--;
+  CSIFW_MUTEX_UNLOCK(&g_pcsifw_context->data_receiver_mutex);
 
-  CSIFW_LOGI("Service [%d] un-registered successfully", p_svc_info->svc_id);
-  CSIFW_LOGI("Remaining services count is %d", p_csifw_ctx->service_count);
+  CSIFW_LOGE("Service removed successfully. Remaining registered services: %d", p_csifw_ctx->service_count);
   return CSIFW_OK;
 }
 
@@ -667,9 +653,8 @@ static CSIFW_RES check_hnd_validity(csifw_service_handle hnd)
   }
 
   csifw_service_info_t *p_svc_info = (csifw_service_info_t *)hnd;
-
-  if (((uintptr_t)p_svc_info - (uintptr_t)g_pcsifw_context->csi_services) % sizeof(csifw_service_info_t) != 0) {
-    CSIFW_LOGE("Invalid handle alignment");
+  if (((uintptr_t)p_svc_info - (uintptr_t)g_pcsifw_context->csi_services) %sizeof(csifw_service_info_t) != 0) {
+    CSIFW_LOGE("Invalid handle(pointer) alignment");
     return CSIFW_INVALID_ARG;
   }
 
@@ -709,13 +694,15 @@ static int all_services_stopped(void)
   }
 
   for (int i = 0; i < CSIFW_MAX_NUM_APPS; i++) {
-    if ((g_pcsifw_context->csi_services[i].svc_id != 0) && (g_pcsifw_context->csi_services[i].svc_state != CSI_SERVICE_STOP)) {
-      CSIFW_LOGD("Service %d is still running (state: %d)\n", i, g_pcsifw_context->csi_services[i].svc_state);
+    if ((g_pcsifw_context->csi_services[i].svc_id != 0) &&
+        (g_pcsifw_context->csi_services[i].svc_state == CSI_SERVICE_START)) {
+      CSIFW_LOGE("Service %d is still running (state: %d)\n", i,
+                 g_pcsifw_context->csi_services[i].svc_state);
       return 0;
     }
   }
 
-  CSIFW_LOGI("All services are stopped\n");
+  CSIFW_LOGE("All services are stopped\n");
   return 1;
 }
 

--- a/framework/src/csimanager/CSIManager.c
+++ b/framework/src/csimanager/CSIManager.c
@@ -30,7 +30,6 @@ static pthread_mutex_t g_api_mutex = PTHREAD_MUTEX_INITIALIZER;
 static int get_empty_idx(void);
 static int all_services_stopped(void);
 static void destroy_csifw_context(void);
-static int get_service_idx(unsigned int id);
 static void nw_state_notify_service(CONNECTION_STATE state);
 static CSIFW_RES check_hnd_validity(csifw_service_handle hnd);
 static void csifw_update_state_and_log(CSI_FRAMEWORK_STATE new_state);
@@ -46,6 +45,26 @@ static const char *csi_framework_state_strings[] =
     "INITIALIZED",
     "STARTED_WAITING_FOR_NW_RECONNECT"
 };
+
+static inline CSIFW_RES validate_register_params(csifw_service_handle *p_hnd, service_callbacks_t *p_svc_cb,
+                                                 csi_config_type_t config_type, unsigned int interval)
+{
+  CSIFW_RES ret = CSIFW_INVALID_ARG;
+	if (!p_hnd) {
+		CSIFW_LOGE("Invalid argument: Service Handle is NULL");
+	} else if (!p_svc_cb) {
+		CSIFW_LOGE("Invalid argument: Service Callback is NULL");
+	} else if (!p_svc_cb->raw_data_cb && !p_svc_cb->parsed_data_cb) {
+		CSIFW_LOGE("Invalid argument: at least one callback must be provided");
+	} else if (config_type <= MIN_CSI_CONFIG_TYPE || config_type >= MAX_CSI_CONFIG_TYPE) {
+		CSIFW_LOGE("Invalid argument: CSI config type: %d (Valid: %d-%d)", config_type, HT_CSI_DATA, NON_HT_CSI_DATA_ACC1);
+	} else if (interval < CSIFW_MIN_INTERVAL_MS) {
+		CSIFW_LOGE("Invalid argument: Interval: %d ms (Minimum: %d ms)", interval, CSIFW_MIN_INTERVAL_MS);
+	} else {
+		ret = CSIFW_OK;
+	}
+  return ret;
+}
 
 static void csifw_update_state_and_log(CSI_FRAMEWORK_STATE new_state) 
 {
@@ -63,7 +82,7 @@ static void csifw_update_state_and_log(CSI_FRAMEWORK_STATE new_state)
 
   const char *prev_state_str = (prev_state == CSI_FRAMEWORK_STATE_UNINITIALIZED) ? "UNINITIALIZED" : csi_framework_state_strings[prev_state + 1];
   const char *new_state_str = csi_framework_state_strings[new_state + 1];
-  CSIFW_LOGI("CSIFW state changed from %s to %s", prev_state_str, new_state_str);
+  CSIFW_LOGE("CSIFW state changed from %s to %s", prev_state_str, new_state_str);
 }
 
 static void csi_network_state_listener(CONNECTION_STATE state)
@@ -104,32 +123,22 @@ static void csi_network_state_listener(CONNECTION_STATE state)
   CSIFW_MUTEX_UNLOCK(&g_api_mutex);
 }
 
-static void CSIRawDataListener(CSIFW_RES res, int raw_csi_buff_len, unsigned char *raw_csi_buff, int raw_csi_data_len) 
+static void csi_data_listener(CSIFW_RES res, int raw_csi_buff_len, unsigned char *raw_csi_buff) 
 {
   if (!g_pcsifw_context) {
     return;
   }
-
-  if (g_pcsifw_context->parsed_data_cb_count > 0 && g_pcsifw_context->parsed_data_cb_started_count > 0) {
-        #if defined(CONFIG_WIFI_CSI_RTL8730E)
-          getParsedData(raw_csi_buff,
-                        raw_csi_buff_len,
-                        g_pcsifw_context->csi_config,
-                        g_pcsifw_context->parsed_buffptr,
-                        &g_pcsifw_context->ParsedDataBufferLen);
-        #elif defined(CONFIG_BK_WIFI_CSI_ADAPTER)
-          CSIFW_LOGE("Parsing is not enabled for BEKEN");
-          return;
-        #else
-          CSIFW_LOGE("Unknown CSI board configuration");
-          return;
-        #endif
-  }
-
-  // CSIRawDataListener callback can be invoked from a background thread when CSI data arrives. 
+  // csi_data_listener callback can be invoked from a background thread when CSI data arrives. 
   // Simultaneously, application threads may call `csifw_start()/csifw_stop()` to modify service states. 
   // Without this mutex, race conditions will occur
   CSIFW_MUTEX_LOCK(&g_pcsifw_context->data_receiver_mutex);
+  
+  // Process and parse CSI data
+  if (g_pcsifw_context->parsed_data_cb_count > 0 && g_pcsifw_context->parsed_data_cb_started_count > 0) {
+    CSIFW_LOGE("Parsing not implemented");
+  }
+
+  // Send CSI data to service
   for (int i = 0; i < CSIFW_MAX_NUM_APPS; i++) {
     if (g_pcsifw_context->csi_services[i].svc_id != 0 && g_pcsifw_context->csi_services[i].svc_state == CSI_SERVICE_START) {
       if (g_pcsifw_context->csi_services[i].raw_data_cb) {
@@ -137,12 +146,6 @@ static void CSIRawDataListener(CSIFW_RES res, int raw_csi_buff_len, unsigned cha
                                                       raw_csi_buff_len,
                                                       raw_csi_buff,
                                                       g_pcsifw_context->csi_services[i].service_data);
-      }
-      if (g_pcsifw_context->csi_services[i].parsed_data_cb) {
-        g_pcsifw_context->csi_services[i].parsed_data_cb(res,
-                                                         g_pcsifw_context->ParsedDataBufferLen,
-                                                         g_pcsifw_context->parsed_buffptr,
-                                                         g_pcsifw_context->csi_services[i].service_data);
       }
     }
   }
@@ -153,25 +156,22 @@ CSIFW_RES csifw_registerService(csifw_service_handle *p_hnd, service_callbacks_t
 {
   CSIFW_RES res = CSIFW_OK;
   csifw_service_info_t *p_svc_info = NULL;
-  CSIFW_MUTEX_LOCK(&g_api_mutex);
-
-  if (!p_hnd) {
-    CSIFW_LOGE("Invalid handle argument, should not be a null pointer");
-    res = CSIFW_INVALID_ARG;
-    goto on_error;
+  if (validate_register_params(p_hnd, p_svc_cb, config_type, interval) == CSIFW_INVALID_ARG) {
+	  return CSIFW_INVALID_ARG;
   }
 
+  CSIFW_MUTEX_LOCK(&g_api_mutex);
   if (!g_pcsifw_context) {
     CSIFW_LOGD("Allocating new CSIFW_Context");
     g_pcsifw_context = (csifw_context_t *)calloc(1, sizeof(csifw_context_t));
     if (!g_pcsifw_context) {
-      CSIFW_LOGE("CSIFW_Context Memory allocation Failed");
+      CSIFW_LOGE("CSIFW Registration Fail: Context memory allocation Failed");
       res = CSIFW_NO_MEM;
       goto on_error;
     }
-    CSIFW_LOGD("Context Created Successfully");
+    CSIFW_LOGD("Context Created");
     if (pthread_mutex_init(&g_pcsifw_context->data_receiver_mutex, NULL) != 0) {
-      CSIFW_LOGE("Mutex init failed of data_receiver_mutex");
+      CSIFW_LOGE("CSIFW Registration Fail: Mutex init failed for data_receiver_mutex");
       destroy_csifw_context();
       res = CSIFW_ERROR;
       goto on_error;
@@ -186,14 +186,6 @@ CSIFW_RES csifw_registerService(csifw_service_handle *p_hnd, service_callbacks_t
   }
 
   if (g_pcsifw_context->csifw_state == CSI_FRAMEWORK_STATE_UNINITIALIZED) {
-    if (config_type <= MIN_CSI_CONFIG_TYPE || config_type >= MAX_CSI_CONFIG_TYPE || interval < CSIFW_MIN_INTERVAL_MS) {
-      CSIFW_LOGE("Either invalid CSI config type: %d. (Valid config range: %d-%d)", config_type, HT_CSI_DATA, NON_HT_CSI_DATA_ACC1);
-      CSIFW_LOGE("Or invalid interval: %d ms. (Minimum allowed: %d ms)", interval, CSIFW_MIN_INTERVAL_MS);
-      destroy_csifw_context();
-      res = CSIFW_INVALID_ARG;
-      goto on_error;
-    }
-
     g_pcsifw_context->csi_config = config_type;
     g_pcsifw_context->csi_interval = interval;
     if (config_type == HT_CSI_DATA_ACC1 || config_type == HT_CSI_DATA) {
@@ -201,39 +193,44 @@ CSIFW_RES csifw_registerService(csifw_service_handle *p_hnd, service_callbacks_t
     } else {
       ping_generator_change_interval(0);
     }
-
-    csi_packet_callback_register(CSIRawDataListener);
     if (!network_monitor_init(csi_network_state_listener)) {
-      CSIFW_LOGE("Network_Monitor_Init Failed");
+      CSIFW_LOGE("CSIFW Registration Fail: Network monitor init Failed");
+      pthread_mutex_destroy(&g_pcsifw_context->data_receiver_mutex);
       destroy_csifw_context();
       res = CSIFW_ERROR;
       goto on_error;
     }
+
+    p_svc_info = add_service(g_pcsifw_context, p_svc_cb);
+    if (!p_svc_info) {
+      CSIFW_LOGE("CSIFW Registration Fail: Created context but failed to allocate memory for service.");
+      network_monitor_deinit();
+      pthread_mutex_destroy(&g_pcsifw_context->data_receiver_mutex);
+      destroy_csifw_context();
+      res = CSIFW_ERROR;
+      goto on_error;
+    }
+    
+    csi_packet_callback_register(csi_data_listener);
+    csifw_update_state_and_log(CSI_FRAMEWORK_STATE_INITIALIZED);
   } else {
     if (g_pcsifw_context->csi_config != config_type || g_pcsifw_context->csi_interval != interval) {
-      CSIFW_LOGE("Service already inited with different configuration/interval."
-          		 "Cannot register service with different configuration/interval.");
+      CSIFW_LOGE("Service already inited with configuration: %d, interval: %u."
+                 "Cannot register service with different configuration/interval.",
+                  g_pcsifw_context->csi_config, g_pcsifw_context->csi_interval);
+
       res = CSIFW_ERROR_ALREADY_INIT_WITH_DIFFERENT_CONFIG;
       goto on_error;
     }
-  }
 
-  p_svc_info = add_service(g_pcsifw_context, p_svc_cb);
-  if (!p_svc_info) {
-    if (g_pcsifw_context->csifw_state == CSI_FRAMEWORK_STATE_UNINITIALIZED) {
-      CSIFW_LOGE("Created context but failed to allocate memory.");
-      destroy_csifw_context();
+    p_svc_info = add_service(g_pcsifw_context, p_svc_cb);
+    if (!p_svc_info) {
+      res = CSIFW_ERROR;
+      goto on_error;
     }
-    res = CSIFW_ERROR_MAX_NUM_SERVICE_REGISTERED;
-    goto on_error;
   }
-
   *p_hnd = (csifw_service_handle)p_svc_info;
-
-  if (g_pcsifw_context->csifw_state == CSI_FRAMEWORK_STATE_UNINITIALIZED) {
-    csifw_update_state_and_log(CSI_FRAMEWORK_STATE_INITIALIZED);
-    CSIFW_LOGI("CSIFW Service Registered Successfully.");
-  }
+  CSIFW_LOGE("CSIFW Service Registered Successfully.");
 
 on_error:
   CSIFW_MUTEX_UNLOCK(&g_api_mutex);
@@ -255,8 +252,9 @@ CSIFW_RES csifw_start(csifw_service_handle hnd)
 
   if (g_pcsifw_context->csifw_state == CSI_FRAMEWORK_STATE_STARTED_WAITING_FOR_NW ||
       g_pcsifw_context->csifw_state == CSI_FRAMEWORK_STATE_STARTED_WAITING_FOR_NW_RECONNECT) {
-    CSIFW_LOGI("Waiting for NW, CSI data will start when network will be connected");
+    CSIFW_LOGE("Waiting for Network, CSI data will start upon network connection");
     p_svc_info->svc_state = CSI_SERVICE_START;
+    CSIFW_LOGE("Service started successfully, registered services count is %d", g_pcsifw_context->service_count);
     res = CSIFW_OK_WIFI_NOT_CONNECTED;
     goto on_error;
   }
@@ -275,19 +273,20 @@ CSIFW_RES csifw_start(csifw_service_handle hnd)
         goto on_error;
       }
       csifw_update_state_and_log(CSI_FRAMEWORK_STATE_STARTED);
+      CSIFW_LOGE("CSIFW started successfully");
     } else {
       csifw_update_state_and_log(CSI_FRAMEWORK_STATE_STARTED_WAITING_FOR_NW);
-      CSIFW_LOGE("Waiting for NW, CSI data will start when network will be connected");
+      CSIFW_LOGE("CSIFW started but waiting for Network, CSI data will start upon network connection");
     }
   }
 
   CSIFW_MUTEX_LOCK(&g_pcsifw_context->data_receiver_mutex);
   p_svc_info->svc_state = CSI_SERVICE_START;
+  CSIFW_LOGE("Service started successfully, registered services count is %d", g_pcsifw_context->service_count);
   if (p_svc_info->parsed_data_cb) {
     g_pcsifw_context->parsed_data_cb_started_count++;
   }
   CSIFW_MUTEX_UNLOCK(&g_pcsifw_context->data_receiver_mutex);
-  CSIFW_LOGI("Service [%d] started successfully, services count is %d", p_svc_info->svc_id, g_pcsifw_context->service_count);
 
 on_error:
   CSIFW_MUTEX_UNLOCK(&g_api_mutex);
@@ -310,13 +309,14 @@ CSIFW_RES csifw_stop(csifw_service_handle hnd)
   if (g_pcsifw_context->csifw_state != CSI_FRAMEWORK_STATE_STARTED &&
       g_pcsifw_context->csifw_state != CSI_FRAMEWORK_STATE_STARTED_WAITING_FOR_NW &&
       g_pcsifw_context->csifw_state != CSI_FRAMEWORK_STATE_STARTED_WAITING_FOR_NW_RECONNECT) {
-    CSIFW_LOGI("CSIFW service already stopped");
+    CSIFW_LOGI("CSIFW already stopped");
     res = CSIFW_OK_ALREADY_STOPPED;
     goto on_error;
   }
 
   CSIFW_MUTEX_LOCK(&g_pcsifw_context->data_receiver_mutex);
   p_svc_info->svc_state = CSI_SERVICE_STOP;
+  CSIFW_LOGE("Service stopped successfully, registered services count is %d", g_pcsifw_context->service_count);
   if (p_svc_info->parsed_data_cb) {
     g_pcsifw_context->parsed_data_cb_started_count--;
   }
@@ -335,7 +335,7 @@ CSIFW_RES csifw_stop(csifw_service_handle hnd)
     }
   }
   csifw_update_state_and_log(CSI_FRAMEWORK_STATE_STOPPED);
-  CSIFW_LOGI("Service [%d] stopped successfully, remaining services count is %d", p_svc_info->svc_id, g_pcsifw_context->service_count);
+  CSIFW_LOGE("CSIFW stopped successfully");
 
 on_error:
   CSIFW_MUTEX_UNLOCK(&g_api_mutex);
@@ -361,7 +361,9 @@ CSIFW_RES csifw_unregisterService(csifw_service_handle hnd)
   }
 
   remove_service(g_pcsifw_context, p_svc_info);
-  if (g_pcsifw_context->service_count == 0 && g_pcsifw_context->csifw_state == CSI_FRAMEWORK_STATE_STOPPED) {
+  if (g_pcsifw_context->service_count == 0 &&
+      (g_pcsifw_context->csifw_state == CSI_FRAMEWORK_STATE_STOPPED ||
+       g_pcsifw_context->csifw_state == CSI_FRAMEWORK_STATE_INITIALIZED)) {
     CSIFW_LOGD("No service left, destroying framework context");
     res = csi_packet_receiver_deinit();
     if (res != CSIFW_OK) {
@@ -375,7 +377,7 @@ CSIFW_RES csifw_unregisterService(csifw_service_handle hnd)
     pthread_mutex_destroy(&g_pcsifw_context->data_receiver_mutex);
     destroy_csifw_context();
   }
-  CSIFW_LOGI("CSIFW Service Un-Registered Successfully.");
+  CSIFW_LOGE("CSIFW Service Un-Registered Successfully.");
 
 on_error:
   CSIFW_MUTEX_UNLOCK(&g_api_mutex);
@@ -404,12 +406,14 @@ CSIFW_RES csifw_set_interval(csifw_service_handle hnd, unsigned int interval)
   }
 
   g_pcsifw_context->csi_interval = interval;
-  if (g_pcsifw_context->csifw_state == CSI_FRAMEWORK_STATE_STOPPED || g_pcsifw_context->csifw_state == CSI_FRAMEWORK_STATE_STARTED_WAITING_FOR_NW) {
+  if (g_pcsifw_context->csifw_state == CSI_FRAMEWORK_STATE_STOPPED ||
+      g_pcsifw_context->csifw_state == CSI_FRAMEWORK_STATE_STARTED_WAITING_FOR_NW) {
     CSIFW_LOGI("Interval updated: %u", g_pcsifw_context->csi_interval);
     goto on_error;
   }
 
-  if (g_pcsifw_context->csi_config == HT_CSI_DATA || g_pcsifw_context->csi_config == HT_CSI_DATA_ACC1) {
+  if (g_pcsifw_context->csi_config == HT_CSI_DATA ||
+      g_pcsifw_context->csi_config == HT_CSI_DATA_ACC1) {
     ping_generator_change_interval(g_pcsifw_context->csi_interval);
   } else {
     res = csi_packet_receiver_change_interval();
@@ -518,19 +522,6 @@ CSIFW_RES csifw_force_restart(csifw_service_handle hnd)
 
 /* service handling functions */
 
-static int get_service_idx(unsigned int id) 
-{
-  if ((!g_pcsifw_context) || (g_pcsifw_context->service_count == 0)) {
-    return -1;
-  }
-  for (int i = 0; i < CSIFW_MAX_NUM_APPS; i++) {
-    if (g_pcsifw_context->csi_services[i].svc_id == id) {
-      return i;
-    }
-  }
-  return -1;
-}
-
 static int get_empty_idx(void) 
 {
   if (!g_pcsifw_context) {
@@ -555,43 +546,35 @@ static int get_empty_idx(void)
  */
 csifw_service_info_t *add_service(csifw_context_t *p_csifw_ctx, service_callbacks_t *p_svc_cb) 
 {
-  unsigned int cid = 0;
   int idx = get_empty_idx();
   if (idx < 0) {
     CSIFW_LOGE("Max Number of services already registered");
     return NULL;  // invalid id
   }
 
-  if (!p_svc_cb->raw_data_cb && !p_svc_cb->parsed_data_cb) {
-    CSIFW_LOGE("Invalid service register request, both Raw Data CB and Parse Data CB are NULL");
-    return NULL;
+  CSIFW_MUTEX_LOCK(&g_pcsifw_context->data_receiver_mutex);
+  for (int i = 0; i < CSIFW_MAX_NUM_APPS; i++) {
+    if ((p_csifw_ctx->csi_services[i].raw_data_cb == p_svc_cb->raw_data_cb) &&
+        (p_csifw_ctx->csi_services[i].parsed_data_cb == p_svc_cb->parsed_data_cb)) {
+      CSIFW_LOGE("Service already registered");
+      CSIFW_MUTEX_UNLOCK(&g_pcsifw_context->data_receiver_mutex);
+      return NULL;
+    }
   }
 
   if (p_svc_cb->parsed_data_cb) {
-    cid = (unsigned int)p_svc_cb->parsed_data_cb;
-    if (!p_csifw_ctx->parsed_buffptr) {
-      p_csifw_ctx->ParsedDataBufferLen = CSIFW_MAX_RAW_BUFF_LEN;
-      p_csifw_ctx->parsed_buffptr = (float *)malloc(sizeof(float) * p_csifw_ctx->ParsedDataBufferLen);
-      if (!p_csifw_ctx->parsed_buffptr) {
-        CSIFW_LOGE("Failed to allocate memory for parsed data buffer, size: %zu", sizeof(float) * p_csifw_ctx->ParsedDataBufferLen);
-        return NULL;
-      }
-    }
-  }
-  if (p_svc_cb->raw_data_cb) {
-    cid = (unsigned int)p_svc_cb->raw_data_cb;
+	  if (!p_csifw_ctx->parsed_buffptr) {
+		  p_csifw_ctx->ParsedDataBufferLen = CSIFW_MAX_RAW_BUFF_LEN;
+		  p_csifw_ctx->parsed_buffptr = (float *)malloc(sizeof(float) * p_csifw_ctx->ParsedDataBufferLen);
+		  if (!p_csifw_ctx->parsed_buffptr) {
+			  CSIFW_LOGE("Failed to allocate memory for parsed data buffer");
+			  CSIFW_MUTEX_UNLOCK(&g_pcsifw_context->data_receiver_mutex);
+			  return NULL;
+		  }
+	  }
   }
 
-  if (get_service_idx(cid) != -1) {
-    if (p_csifw_ctx->parsed_buffptr) {
-      free(p_csifw_ctx->parsed_buffptr);
-      p_csifw_ctx->parsed_buffptr = NULL;
-    }
-    CSIFW_LOGE("Service with ID: %d already registered", cid);
-    return NULL;
-  }
-
-  p_csifw_ctx->csi_services[idx].svc_id = cid;
+  p_csifw_ctx->csi_services[idx].svc_id = (int)p_svc_cb; //Use callback structure address as unique service identifier
   p_csifw_ctx->csi_services[idx].svc_state = CSI_SERVICE_REGISTERED;
   p_csifw_ctx->csi_services[idx].raw_data_cb = p_svc_cb->raw_data_cb;
   p_csifw_ctx->csi_services[idx].parsed_data_cb = p_svc_cb->parsed_data_cb;
@@ -600,35 +583,34 @@ csifw_service_info_t *add_service(csifw_context_t *p_csifw_ctx, service_callback
   }
   p_csifw_ctx->csi_services[idx].service_data = p_svc_cb->user_data;
   p_csifw_ctx->service_count++;
+  CSIFW_MUTEX_UNLOCK(&g_pcsifw_context->data_receiver_mutex);
 
-  CSIFW_LOGI("Idx %d: Service(%d) registered with CSIFW. Total services: %d", idx, cid, p_csifw_ctx->service_count);
+  CSIFW_LOGE("Idx %d: Service added successfully. Total registered services: %d", idx, p_csifw_ctx->service_count);
   return &p_csifw_ctx->csi_services[idx];
 }
 
 static CSIFW_RES remove_service(csifw_context_t *p_csifw_ctx, csifw_service_info_t *p_svc_info) 
 {
-  int idx = get_service_idx(p_svc_info->svc_id);
-  if (idx == -1) {
-    CSIFW_LOGE("CSI Service not registered [%d].", p_svc_info->svc_id);
+  int idx = p_svc_info - p_csifw_ctx->csi_services;
+  if (idx < 0 || idx >= CSIFW_MAX_NUM_APPS || p_csifw_ctx->csi_services[idx].svc_id == 0) {
+    CSIFW_LOGE("CSI Service not registered.");
     return CSIFW_ERROR_SERVICE_NOT_REGISTERED;
   }
 
+  CSIFW_MUTEX_LOCK(&g_pcsifw_context->data_receiver_mutex);
   if (p_csifw_ctx->csi_services[idx].parsed_data_cb) {
     p_csifw_ctx->parsed_data_cb_count--;
+    if ((p_csifw_ctx->parsed_data_cb_count == 0) && (p_csifw_ctx->parsed_buffptr)) {
+      p_csifw_ctx->ParsedDataBufferLen = 0;
+      free(p_csifw_ctx->parsed_buffptr);
+      p_csifw_ctx->parsed_buffptr = NULL;
+    }
   }
-
-  if ((p_csifw_ctx->parsed_buffptr) &&
-      (p_csifw_ctx->parsed_data_cb_count <= 0)) {
-    p_csifw_ctx->ParsedDataBufferLen = 0;
-    free(p_csifw_ctx->parsed_buffptr);
-    p_csifw_ctx->parsed_buffptr = NULL;
-  }
-
   memset(&p_csifw_ctx->csi_services[idx], 0, sizeof(csifw_service_info_t));
   p_csifw_ctx->service_count--;
+  CSIFW_MUTEX_UNLOCK(&g_pcsifw_context->data_receiver_mutex);
 
-  CSIFW_LOGI("Service [%d] un-registered successfully", p_svc_info->svc_id);
-  CSIFW_LOGI("Remaining services count is %d", p_csifw_ctx->service_count);
+  CSIFW_LOGE("Service removed successfully. Remaining registered services: %d", p_csifw_ctx->service_count);
   return CSIFW_OK;
 }
 
@@ -667,9 +649,8 @@ static CSIFW_RES check_hnd_validity(csifw_service_handle hnd)
   }
 
   csifw_service_info_t *p_svc_info = (csifw_service_info_t *)hnd;
-
-  if (((uintptr_t)p_svc_info - (uintptr_t)g_pcsifw_context->csi_services) % sizeof(csifw_service_info_t) != 0) {
-    CSIFW_LOGE("Invalid handle alignment");
+  if (((uintptr_t)p_svc_info - (uintptr_t)g_pcsifw_context->csi_services) %sizeof(csifw_service_info_t) != 0) {
+    CSIFW_LOGE("Invalid handle(pointer) alignment");
     return CSIFW_INVALID_ARG;
   }
 
@@ -709,13 +690,15 @@ static int all_services_stopped(void)
   }
 
   for (int i = 0; i < CSIFW_MAX_NUM_APPS; i++) {
-    if ((g_pcsifw_context->csi_services[i].svc_id != 0) && (g_pcsifw_context->csi_services[i].svc_state != CSI_SERVICE_STOP)) {
-      CSIFW_LOGD("Service %d is still running (state: %d)\n", i, g_pcsifw_context->csi_services[i].svc_state);
+    if ((g_pcsifw_context->csi_services[i].svc_id != 0) &&
+        (g_pcsifw_context->csi_services[i].svc_state == CSI_SERVICE_START)) {
+      CSIFW_LOGE("Service %d is still running (state: %d)\n", i,
+                 g_pcsifw_context->csi_services[i].svc_state);
       return 0;
     }
   }
 
-  CSIFW_LOGI("All services are stopped\n");
+  CSIFW_LOGE("All services are stopped\n");
   return 1;
 }
 

--- a/framework/src/csimanager/CSIPacketReceiver.c
+++ b/framework/src/csimanager/CSIPacketReceiver.c
@@ -91,6 +91,10 @@ static void *dataReceiverThread(void *vargp)
 	int fd = p_csifw_ctx->data_receiver_fd;
 	mqd_t mq_handle = p_csifw_ctx->mq_handle;
 	unsigned char *get_data_buffptr = p_csifw_ctx->get_data_buffptr;
+	#ifdef CONFIG_CSI_PACKET_MONITORING
+		unsigned int packets_recv_per_second = 0;
+		u64 prev_time = 0;
+	#endif
 
 	while (!p_csifw_ctx->data_receiver_thread_stop) {
 		current_time = get_monotonic_time_ms();
@@ -99,22 +103,27 @@ static void *dataReceiverThread(void *vargp)
 			(current_time - last_data_read_timestamp_ms >= p_csifw_ctx->csi_interval)) {
 			last_data_read_status = false;
 			last_data_read_timestamp_ms = current_time;
-			CSIFW_LOGI("Reading event from MQ %llu", current_time);
+			#ifdef CONFIG_CSI_PACKET_MONITORING
+				CSIFW_LOGI("Reading event from MQ %llu", current_time);
+			#endif
 			clock_gettime(CLOCK_REALTIME, &st_time);
 			st_time.tv_sec += 1;
 			size = mq_timedreceive(mq_handle, (char *)&msg, sizeof(msg), &prio, &st_time);
 			if (size >= 0) {
-				CSIFW_LOGD("Message received - msgId: %d, data_len: %d, size: %zu: %d", msg.msgId, msg.data_len, size);
+				CSIFW_LOGD("Message received - msgId: %d, data_len: %d, size: %zd", msg.msgId, msg.data_len, size);
 				switch (msg.msgId) {
 				case CSI_MSG_DATA_READY_CB:
 					len = readCSIData(fd, get_data_buffptr, CSIFW_MAX_RAW_BUFF_LEN);
-					CSIFW_LOGI("CSI Data read complete %llu", get_monotonic_time_ms());
+					current_time = get_monotonic_time_ms();
+					#ifdef CONFIG_CSI_PACKET_MONITORING
+						CSIFW_LOGI("CSI Data read complete %llu", current_time);
+					#endif
 					if (len < 0) {
 						consecutive_failures++;
 						CSIFW_LOGE("Skipping packet: error: %d", len);
 						if (consecutive_failures >= MAX_CONSECUTIVE_FAILURES) {
 							CSIFW_LOGE("CRITICAL: %d consecutive readCSIData failures detected!", consecutive_failures);
-							p_csifw_ctx->CSI_DataCallback(CSIFW_ERROR_DATA_NOT_AVAILABLE, 0, NULL, 0);
+							p_csifw_ctx->CSI_DataCallback(CSIFW_ERROR_DATA_NOT_AVAILABLE, 0, NULL);
 							break;
 						}
 						continue;
@@ -124,14 +133,26 @@ static void *dataReceiverThread(void *vargp)
 						timeout_count = 0;
 					}
 					last_data_read_status = true;
-					#if defined(CONFIG_WIFI_CSI_RTL8730E)
-					  /* RTL8730E driver returns length without the CSI header*/
-					  p_csifw_ctx->CSI_DataCallback(CSIFW_OK, len + CSIFW_RTK_CSI_HEADER_LEN, get_data_buffptr, len);
-					#elif defined(CONFIG_BK_WIFI_CSI_ADAPTER)
-					  /* Beken driver already includes the CSI header in the length*/
-					  p_csifw_ctx->CSI_DataCallback(CSIFW_OK, len, get_data_buffptr, len);
+
+					#ifdef CONFIG_CSI_PACKET_MONITORING
+						packets_recv_per_second++;
+						if (prev_time == 0) {
+							prev_time = current_time;
+						} else if (current_time - prev_time >= 1000) {
+							CSIFW_LOGD("CSI Packets/sec: %u (interval: %ums, expected: ~%u)", 
+									packets_recv_per_second, p_csifw_ctx->csi_interval,
+									1000 / p_csifw_ctx->csi_interval);
+							packets_recv_per_second = 0;
+							prev_time = current_time;
+						}
+					#endif
+
+					#if defined(CONFIG_BK_WIFI_CSI_ADAPTER)
+						/* Beken driver already includes the CSI header in the length*/
+						p_csifw_ctx->CSI_DataCallback(CSIFW_OK, len, get_data_buffptr);
 					#else
-					  CSIFW_LOGE("Unknown CSI board configuration");
+						/* RTL8730E driver returns length without the CSI header*/
+						p_csifw_ctx->CSI_DataCallback(CSIFW_OK, len + CSIFW_RTK_CSI_HEADER_LEN, get_data_buffptr);
 					#endif
 					break;
 
@@ -150,14 +171,14 @@ static void *dataReceiverThread(void *vargp)
 					if (timeout_count >= CONFIG_CSI_DATA_TIMEOUT_SEC) {
 						CSIFW_LOGE("CRITICAL: No CSI data for %d seconds", timeout_count);
 						timeout_count = 0;
-						p_csifw_ctx->CSI_DataCallback(CSIFW_ERROR_DATA_NOT_AVAILABLE, 0, NULL, 0);
+						p_csifw_ctx->CSI_DataCallback(CSIFW_ERROR_DATA_NOT_AVAILABLE, 0, NULL);
 					}
 				} else {
 					consecutive_failures++;
 					if (consecutive_failures >= MAX_CONSECUTIVE_FAILURES) {
 						CSIFW_LOGE("CRITICAL: %d consecutive failures detected", consecutive_failures);
 						consecutive_failures = 0;
-						p_csifw_ctx->CSI_DataCallback(CSIFW_INTERNAL_ERROR, 0, NULL, 0);
+						p_csifw_ctx->CSI_DataCallback(CSIFW_INTERNAL_ERROR, 0, NULL);
 					}
 				}
 			}

--- a/framework/src/csimanager/CSIPacketReceiver.c
+++ b/framework/src/csimanager/CSIPacketReceiver.c
@@ -91,6 +91,10 @@ static void *dataReceiverThread(void *vargp)
 	int fd = p_csifw_ctx->data_receiver_fd;
 	mqd_t mq_handle = p_csifw_ctx->mq_handle;
 	unsigned char *get_data_buffptr = p_csifw_ctx->get_data_buffptr;
+	#ifdef CONFIG_CSI_PACKET_MONITORING
+		unsigned int packets_recv_per_second = 0;
+		u64 prev_time = 0;
+	#endif
 
 	while (!p_csifw_ctx->data_receiver_thread_stop) {
 		current_time = get_monotonic_time_ms();
@@ -99,22 +103,27 @@ static void *dataReceiverThread(void *vargp)
 			(current_time - last_data_read_timestamp_ms >= p_csifw_ctx->csi_interval)) {
 			last_data_read_status = false;
 			last_data_read_timestamp_ms = current_time;
-			CSIFW_LOGI("Reading event from MQ %llu", current_time);
+			#ifdef CONFIG_CSI_PACKET_MONITORING
+				CSIFW_LOGI("Reading event from MQ %llu", current_time);
+			#endif
 			clock_gettime(CLOCK_REALTIME, &st_time);
 			st_time.tv_sec += 1;
 			size = mq_timedreceive(mq_handle, (char *)&msg, sizeof(msg), &prio, &st_time);
 			if (size >= 0) {
-				CSIFW_LOGD("Message received - msgId: %d, data_len: %d, size: %zu: %d", msg.msgId, msg.data_len, size);
+				CSIFW_LOGD("Message received - msgId: %d, data_len: %d, size: %zd", msg.msgId, msg.data_len, size);
 				switch (msg.msgId) {
 				case CSI_MSG_DATA_READY_CB:
 					len = readCSIData(fd, get_data_buffptr, CSIFW_MAX_RAW_BUFF_LEN);
-					CSIFW_LOGI("CSI Data read complete %llu", get_monotonic_time_ms());
+					current_time = get_monotonic_time_ms();
+					#ifdef CONFIG_CSI_PACKET_MONITORING
+						CSIFW_LOGI("CSI Data read complete %llu", current_time);
+					#endif
 					if (len < 0) {
 						consecutive_failures++;
 						CSIFW_LOGE("Skipping packet: error: %d", len);
 						if (consecutive_failures >= MAX_CONSECUTIVE_FAILURES) {
 							CSIFW_LOGE("CRITICAL: %d consecutive readCSIData failures detected!", consecutive_failures);
-							p_csifw_ctx->CSI_DataCallback(CSIFW_ERROR_DATA_NOT_AVAILABLE, 0, NULL, 0);
+							p_csifw_ctx->CSI_DataCallback(CSIFW_ERROR_DATA_NOT_AVAILABLE, 0, NULL);
 							break;
 						}
 						continue;
@@ -124,14 +133,26 @@ static void *dataReceiverThread(void *vargp)
 						timeout_count = 0;
 					}
 					last_data_read_status = true;
-					#if defined(CONFIG_WIFI_CSI_RTL8730E)
-					  /* RTL8730E driver returns length without the CSI header*/
-					  p_csifw_ctx->CSI_DataCallback(CSIFW_OK, len + CSIFW_RTK_CSI_HEADER_LEN, get_data_buffptr, len);
-					#elif defined(CONFIG_BK_WIFI_CSI_ADAPTER)
-					  /* Beken driver already includes the CSI header in the length*/
-					  p_csifw_ctx->CSI_DataCallback(CSIFW_OK, len, get_data_buffptr, len);
+
+					#ifdef CONFIG_CSI_PACKET_MONITORING
+						packets_recv_per_second++;
+						if (prev_time == 0) {
+							prev_time = current_time;
+						} else if (current_time - prev_time >= 1000) {
+							CSIFW_LOGD("CSI Packets/sec: %u (interval: %ums, expected: ~%u)", 
+									packets_recv_per_second, p_csifw_ctx->csi_interval,
+									1000 / p_csifw_ctx->csi_interval);
+							packets_recv_per_second = 0;
+							prev_time = current_time;
+						}
+					#endif
+
+					#if defined(CONFIG_BK_WIFI_CSI_ADAPTER)
+						/* Beken driver already includes the CSI header in the length*/
+						p_csifw_ctx->CSI_DataCallback(CSIFW_OK, len, get_data_buffptr);
 					#else
-					  CSIFW_LOGE("Unknown CSI board configuration");
+						/* RTL8730E driver returns length without the CSI header*/
+						p_csifw_ctx->CSI_DataCallback(CSIFW_OK, len + CSIFW_RTK_CSI_HEADER_LEN, get_data_buffptr);
 					#endif
 					break;
 
@@ -150,14 +171,14 @@ static void *dataReceiverThread(void *vargp)
 					if (timeout_count >= CONFIG_CSI_DATA_TIMEOUT_SEC) {
 						CSIFW_LOGE("CRITICAL: No CSI data for %d seconds", timeout_count);
 						timeout_count = 0;
-						p_csifw_ctx->CSI_DataCallback(CSIFW_ERROR_DATA_NOT_AVAILABLE, 0, NULL, 0);
+						p_csifw_ctx->CSI_DataCallback(CSIFW_ERROR_DATA_NOT_AVAILABLE, 0, NULL);
 					}
 				} else {
 					consecutive_failures++;
 					if (consecutive_failures >= MAX_CONSECUTIVE_FAILURES) {
 						CSIFW_LOGE("CRITICAL: %d consecutive failures detected", consecutive_failures);
 						consecutive_failures = 0;
-						p_csifw_ctx->CSI_DataCallback(CSIFW_INTERNAL_ERROR, 0, NULL, 0);
+						p_csifw_ctx->CSI_DataCallback(CSIFW_INTERNAL_ERROR, 0, NULL);
 					}
 				}
 			}
@@ -374,21 +395,53 @@ CSIFW_RES csi_packet_receiver_cleanup(void)
 		CSIFW_LOGE("Invalid context pointer (NULL)");
 		return CSIFW_ERROR_NOT_INITIALIZED;
 	}
+
+	CSIFW_RES res;
 	int fd = p_csifw_ctx->data_receiver_fd;
-	mq_close(p_csifw_ctx->mq_handle);
-	p_csifw_ctx->mq_handle = (mqd_t) ERROR;
-	CSIFW_LOGD("Data Receiver MQ closed (fd: %d, mq_handle: %p)", 
-		p_csifw_ctx->data_receiver_fd, p_csifw_ctx->mq_handle);
 	int ret = ioctl(fd, CSIIOC_STOP_CSI, NULL);
 	if (ret < OK) {
 		CSIFW_LOGE("IOCTL : CSIIOC_STOP_CSI Failed errno: %d (%s)", get_errno(), strerror(get_errno()));
-		close_driver(fd);
-		return CSIFW_ERROR;
+		res = CSIFW_ERROR;
 	} else {
 		CSIFW_LOGD("Driver data collect stopped");
+		res = CSIFW_OK;
 	}
+
+	if (p_csifw_ctx->mq_handle != (mqd_t)ERROR) {
+        struct mq_attr attr;
+        if (mq_getattr(p_csifw_ctx->mq_handle, &attr) != OK) {
+            CSIFW_LOGE("mq_getattr failed - errno: %d (%s)", get_errno(), strerror(get_errno()));
+        } else {
+            CSIFW_LOGD("Draining %d messages from MQ", attr.mq_curmsgs);
+            attr.mq_flags |= O_NONBLOCK;
+            if (mq_setattr(p_csifw_ctx->mq_handle, &attr, NULL) != OK) {
+				CSIFW_LOGE("mq_setattr failed - errno: %d (%s)", get_errno(), strerror(get_errno()));
+			} else {
+				struct wifi_csi_msg_s msg;
+				int prio;
+				while (attr.mq_curmsgs > 0) {
+					ssize_t size = mq_receive(p_csifw_ctx->mq_handle, (char *)&msg, sizeof(msg), &prio);
+					if (size < 0) {
+						if (get_errno() == EAGAIN) {
+							CSIFW_LOGD("MQ drain complete (queue empty)");
+						} else {
+							CSIFW_LOGE("mq_receive failed during drain - errno: %d (%s)", get_errno(), strerror(get_errno()));
+						}
+						break;
+					}
+					attr.mq_curmsgs--;
+				}
+			}
+		}
+        mq_close(p_csifw_ctx->mq_handle);
+        p_csifw_ctx->mq_handle = (mqd_t)ERROR;
+        CSIFW_LOGD("Data Receiver MQ closed (fd: %d, mq_handle: %p)", p_csifw_ctx->data_receiver_fd, p_csifw_ctx->mq_handle);
+	} else {
+	    CSIFW_LOGD("MQ handle already invalid, skipping drain and close");
+	}
+
 	close_driver(fd);
-	return CSIFW_OK;
+	return res;
 }
 
 CSIFW_RES csi_packet_receiver_stop_collect(void)
@@ -418,7 +471,9 @@ CSIFW_RES csi_packet_receiver_stop_collect(void)
 	} else {
 		CSIFW_LOGE("Failed to close blocking mq as MQ_Discriptor is Invalid");
 	}
-	pthread_join(p_csifw_ctx->csi_data_receiver_th, NULL);
+	if (pthread_join(p_csifw_ctx->csi_data_receiver_th, NULL) != 0) {
+		CSIFW_LOGD("Pthread join [Receiver Thread] failed, errno=%d (%s)", errno, strerror(errno));
+	}
 	CSIFW_LOGD("Receiver thread join done");
 	if (p_csifw_ctx->get_data_buffptr) {
 		free(p_csifw_ctx->get_data_buffptr);

--- a/framework/src/csimanager/Kconfig
+++ b/framework/src/csimanager/Kconfig
@@ -19,6 +19,12 @@ config CSI_DATA_TIMEOUT_SEC
 	---help---
 		CSI DATA TIMEOUT
 
+config CSI_PACKET_MONITORING
+	bool "CSI PACKET MONITORING"
+	default n
+	---help---
+		CSI PACKET MONITORING
+
 menu "CSIFW Debug Logs"
 
 config CSIFW_LOGS

--- a/framework/src/csimanager/PingGenerator.c
+++ b/framework/src/csimanager/PingGenerator.c
@@ -258,7 +258,9 @@ CSIFW_RES ping_generator_stop(void)
 		return CSIFW_OK;
 	}
 	p_csifw_ctx->ping_thread_stop = true;
-	pthread_join(p_csifw_ctx->csi_ping_thread, NULL);
+	if (pthread_join(p_csifw_ctx->csi_ping_thread, NULL) != 0) {
+		CSIFW_LOGD("Pthread join [Ping Thread] failed, errno=%d (%s)", errno, strerror(errno));
+	}
 	CSIFW_LOGD("[PING Thread] stopped");
 	return CSIFW_OK;
 }

--- a/framework/src/csimanager/inc/CSIManager.h
+++ b/framework/src/csimanager/inc/CSIManager.h
@@ -40,7 +40,7 @@
 #endif
 
 typedef unsigned long long u64;  // for u64
-typedef void (*CSIDataListener)(CSIFW_RES res, int csi_buff_len, unsigned char *csi_buff, int csi_data_len);
+typedef void (*CSIDataListener)(CSIFW_RES res, int csi_data_len, unsigned char *csi_buff);
 
 typedef enum _CSI_FRAMEWORK_STATE {
   CSI_FRAMEWORK_STATE_UNINITIALIZED = -1,                   /* CSI_FRAMEWORK_STATE NOT INITIALIZED  */

--- a/os/drivers/wifi_csi/wifi_csi.c
+++ b/os/drivers/wifi_csi/wifi_csi.c
@@ -478,7 +478,7 @@ static int wifi_csi_mq_open(FAR struct wifi_csi_upperhalf_s *upper)
  * Name: wifi_csi_mq_close
  *
  * Description:
- *   Open message queue for communication with app/framework layers.
+ *  Close and unlink message queue used for communication with app/framework layers.
  *
  ************************************************************************************/
 
@@ -497,6 +497,9 @@ static int wifi_csi_mq_close(FAR struct wifi_csi_upperhalf_s *upper)
 		csidbg("MQ close success\n");
 	}
 	upper->usermq = (mqd_t)ERROR;
+
+	/* Unlink CSI_MQ */
+	mq_unlink(CSI_MQ_NAME);
 	return ret;
 }
 


### PR DESCRIPTION
- Fix logging where required
- Fix service_id check in remove_service()
- Drain remaining messages from mq after stop
- Remove redundant function get_service_idx()
- Ensures proper error detection for pthread API calls
- Fix resource leak issues in csifw_unregisterService()
- Removed premature memory deallocation in add_service()
- Improve memory management for parsed_buffptr in remove_service()
- Removed redundant 4th parameter from CSIDataListener callback typedef
- Remove unnecessary free of parsed_buffptr when duplicate service detected
- Removed dead parsing cb code from CSIDataListener() as it is not implemented
- Fix service state bug in all_services_stopped() and csifw_unregisterService()
- Moved memory allocation of parsed_buff to csifw_registerService() from add_service()
- Refactoring csifw_registerService() removing complexity and improving maintainability
- Fix resource leak issues in csifw_registerService() and csifw_unregisterService() API
- Rename CSIRawDataListener() to csi_data_listener() for better naming consistency with callback conventions
- Add retry loop to wait for task STOP state before unregistering, fixes potential race condition during task unregistration
- Track and log CSI packets received per second to verify interval configuration is working correctly (under tag `CSI_PACKET_MONITORING`)
- Add EINTR handling for sem_wait() calls in start/stop_csi_framework to properly handle signal interruptions and prevent premature failures