### PR TITLE
os/arch/arm/src/armv8m: Fix config typo

### DIFF
--- a/os/arch/arm/src/armv8-m/up_exception.S
+++ b/os/arch/arm/src/armv8-m/up_exception.S
@@ -277,7 +277,7 @@ exception_common:
 	 */
 
 #ifdef CONFIG_ARCH_NESTED_INTERRUPT
-#ifdef CONFIG_ARMv8M_USEBASEPRI
+#ifdef CONFIG_ARMV8M_USEBASEPRI
 	msr		basepri, r3
 #else
 	cpsie	i

--- a/os/arch/arm/src/armv8-m/up_lazyexception.S
+++ b/os/arch/arm/src/armv8-m/up_lazyexception.S
@@ -292,7 +292,7 @@ exception_common:
 	 */
 
 #ifdef CONFIG_ARCH_NESTED_INTERRUPT
-#ifdef CONFIG_ARMv8M_USEBASEPRI
+#ifdef CONFIG_ARMV8M_USEBASEPRI
 	msr		basepri, r3
 #else
 	cpsie	i


### PR DESCRIPTION
Fix `CONFIG_ARMv8M_USEBASEPRI` to `CONFIG_ARMV8M_USEBASEPRI`.
It wasn't effected our system because it's only effect when `CONFIG_ARCH_NESTED_INTERRUPT` is enabled.
`cpsie	i` is blocking all interrupt, `msr		basepri, r3` blocking only lower priority interrupt.