### PR TITLE
amebasmart/i2s : Fix persistent noise after long cpu stalls

### DIFF
--- a/os/arch/arm/src/amebasmart/amebasmart_i2s.c
+++ b/os/arch/arm/src/amebasmart/amebasmart_i2s.c
@@ -41,6 +41,8 @@
 #include <tinyara/wqueue.h>
 #include <tinyara/audio/audio.h>
 #include <tinyara/audio/i2s.h>
+#include <pthread.h>
+#include <semaphore.h>
 #ifdef CONFIG_AUDIO_ALC1019
 #include <tinyara/audio/alc1019.h>
 #endif
@@ -119,7 +121,7 @@
 
 #define OVER_SAMPLE_RATE (384U)
 
-#define I2S_DMA_PAGE_SIZE 8192 	/* 4 ~ 16384, set to a factor of APB size */
+#define I2S_DMA_PAGE_SIZE 4096 	/* 4 ~ 16384, set to a factor of APB size */
 #define I2S_DMA_PAGE_NUM 4	/* Vaild number is 2~4 */
 
 #ifdef CONFIG_PM
@@ -145,6 +147,8 @@ struct amebasmart_transport_s {
 	sq_queue_t done;	/* A queue of completed transfers */
 	struct work_s work; /* Supports worker thread operations */
 	int error_state;	/* Channel error state, 0 - OK*/
+	sem_t sem;			/* Semaphore for thread wakeup */
+	volatile bool running; /* Thread state flag */
 };
 
 /* I2S configuration parameters for i2s_param_config function */
@@ -385,7 +389,7 @@ static void i2s_txdma_timeout(int argc, uint32_t arg)
 	/* Then schedule completion of the transfer to occur on the worker thread.
 	 * Set the result with -ETIMEDOUT.
 	 */
-	i2serr("txdma timeout\n");
+	lldbg("txdma timeout\n");
 	i2s_tx_schedule(priv, -ETIMEDOUT);
 }
 
@@ -439,21 +443,21 @@ static int i2s_tx_start(struct amebasmart_i2s_s *priv)
 	int ret;
 	irqstate_t flags;
 
-	//struct ap_buffer_s *apb;
+	flags = enter_critical_section();
 
 	/* Check if the DMA is IDLE */
 	if (!sq_empty(&priv->tx.act)) {
 		i2sinfo("[TX] actived!\n");
+		leave_critical_section(flags);
 		return OK;
 	}
 
 	/* If there are no pending transfer, then bail returning success */
 	if (sq_empty(&priv->tx.pend)) {
 		i2sinfo("[TX] empty!\n");
+		leave_critical_section(flags);
 		return OK;
 	}
-
-	flags = enter_critical_section();
 
 	/* Remove the pending TX transfer at the head of the TX pending queue. */
 	bfcontainer = (struct amebasmart_buffer_s *)sq_remfirst(&priv->tx.pend);
@@ -526,6 +530,38 @@ static void i2s_tx_worker(void *arg)
 	}
 }
 
+static void *i2s_tx_worker_thread(int argc, FAR char *argv[])
+{
+	FAR struct amebasmart_i2s_s *priv = NULL;
+	int ret;
+
+	if (argc >= 1 && argv[0]) {
+	    priv = (FAR struct amebasmart_i2s_s *)(uintptr_t)strtoul(argv[1], NULL, 16);
+	}
+
+	DEBUGASSERT(priv);
+
+	i2sinfo("TX worker thread started\n");
+
+	while (true) {
+		/* Wait for ISR signal.  EINTR is the only expected 'failure'
+		 * (meaning that the wait was interrupted by a signal).
+		 */
+		do {
+			ret = sem_wait(&priv->tx.sem);
+			DEBUGASSERT(ret == OK || errno == EINTR);
+		} while (ret != OK);
+
+		/* Only process if playback is active */
+		if (priv->tx.running) {
+			i2s_tx_worker(priv);
+		}
+	}
+
+	i2sinfo("TX worker thread exited\n");
+	return NULL;
+}
+
 static void i2s_tx_schedule(struct amebasmart_i2s_s *priv, int result)
 {
 	struct amebasmart_buffer_s *bfcontainer;
@@ -575,18 +611,11 @@ static void i2s_tx_schedule(struct amebasmart_i2s_s *priv, int result)
 		}
 	}
 
-	/* If the worker has completed running, then reschedule the working thread.
-	 * REVISIT:  There may be a race condition here.  So we do nothing if the
-	 * worker is not available.
-	 */
+	/* Signal the dedicated TX worker thread */
 
-	if (work_available(&priv->tx.work)) {
-		/* Schedule the TX DMA done processing to occur on the worker thread. */
-
-		ret = work_queue(HPWORK, &priv->tx.work, i2s_tx_worker, priv, 0);
-		if (ret != 0) {
-			i2serr("ERROR: Failed to queue TX primary work: %d\n", ret);
-		}
+	if (priv->tx.running) {
+		/* Wake up the dedicated TX worker thread via semaphore */
+		sem_post(&priv->tx.sem);
 	}
 }
 #endif
@@ -708,6 +737,11 @@ static int i2s_send(struct i2s_dev_s *dev, struct ap_buffer_s *apb, i2s_callback
 	flags = enter_critical_section();
 	sq_addlast((sq_entry_t *)bfcontainer, &priv->tx.pend);
 	leave_critical_section(flags);
+
+	/* Activate worker thread if not already running */
+	if (!priv->tx.running) {
+		priv->tx.running = true;
+	}
 
 	ret = i2s_tx_start(priv);
 
@@ -1520,6 +1554,7 @@ static int i2s_stop(struct i2s_dev_s *dev, i2s_ch_dir_t dir)
 	if (dir == I2S_TX) {
 		i2s_disable(priv->i2s_object, 0);
 		i2s_tx_enabled = 0;
+
 		i2s_set_dma_buffer(priv->i2s_object, (char *)priv->i2s_tx_buf, NULL, I2S_DMA_PAGE_NUM, I2S_DMA_PAGE_SIZE); /* Allocate DMA Buffer for TX */
 		amebasmart_i2s_isr_initialize(priv);
 		while (sq_peek(&priv->tx.pend) != NULL) {
@@ -1544,12 +1579,16 @@ static int i2s_stop(struct i2s_dev_s *dev, i2s_ch_dir_t dir)
 			leave_critical_section(flags);
 			i2s_buf_tx_free(priv, bfcontainer);
 		}
+
+		/* Pause TX processing (keep thread alive for restart) */
+		priv->tx.running = false;
+
 #ifdef CONFIG_PM
 	if (i2s_lock_state) {
 		i2s_lock_state = 0;
 		bsp_pm_domain_control(BSP_I2S_DRV, 0);
 	}
-#endif		
+#endif
 	}
 #endif
 
@@ -1876,6 +1915,7 @@ struct i2s_dev_s *amebasmart_i2s_initialize(uint16_t port)
 		i2serr("I2S initialize: isr fails\n");
 		goto errout_with_alloc;
 	}
+
 	/* Initialize the I2S priv device structure  */
 	sem_init(&priv->exclsem, 0, 1);
 	priv->dev.ops = &g_i2sops;
@@ -1887,6 +1927,30 @@ struct i2s_dev_s *amebasmart_i2s_initialize(uint16_t port)
 	/* Basic settings */
 	//priv->i2s_num = priv->i2s_object->i2s_idx;
 	g_i2sdevice[port] = priv;
+
+#if defined(I2S_HAVE_TX) && (0 < I2S_HAVE_TX)
+	
+	i2sinfo("Creating dedicated TX worker thread\n");
+
+	sem_init(&priv->tx.sem, 0, 0);
+
+	/* The tx.sem semaphore is used for signaling and, hence, should
+	 * not have priority inheritance enabled.
+	 */
+	sem_setprotocol(&priv->tx.sem, SEM_PRIO_NONE);
+	priv->tx.running = true;
+	char argbuf[32];
+	snprintf(argbuf, sizeof(argbuf), "%p", priv);
+	char *argv[] = { argbuf, NULL };
+
+	pid_t pid = kernel_thread("i2s_tx_worker", CONFIG_SCHED_HPWORKPRIORITY, 4096,
+		i2s_tx_worker_thread, (char * const *)argv);
+	if (pid < 0) {
+		i2serr("ERROR: Failed to create TX worker thread: %d\n", pid);
+		sem_destroy(&priv->tx.sem);
+		goto errout_with_alloc;
+	}
+#endif
 
 	/* Success exit */
 	return &priv->dev;
@@ -1992,3 +2056,4 @@ void i2s_pminitialize(void)
 	pmu_register_sleep_callback(PMU_I2S_DEVICE, (PSM_HOOK_FUN)rtk_i2s_suspend, NULL, (PSM_HOOK_FUN)rtk_i2s_resume, NULL);
 }
 #endif
+

--- a/os/board/rtl8730e/src/component/mbed/targets/hal/rtl8730e/i2s_api.c
+++ b/os/board/rtl8730e/src/component/mbed/targets/hal/rtl8730e/i2s_api.c
@@ -22,6 +22,12 @@
 
 #define SP_MAX_DMA_PAGE_NUM 8
 
+/* Set to 1 to log TX page-ring recovery events (missed page-complete
+ * interrupts after a long CPU stall, e.g. secure-world calls or flash
+ * writes).  Recovery itself always runs; this only controls the log.
+ */
+#define DEBUG_I2S_TX_RESYNC 0
+
 /** @addtogroup Ameba_Mbed_API
   * @{
   */
@@ -187,7 +193,49 @@ static void i2s_tx_isr(void *sp_data)
 	/* Clear Pending ISR */
 	GDMA_ClearINT(GDMA_InitStruct->GDMA_Index, GDMA_InitStruct->GDMA_ChNum);
 
-	i2s_release_tx_page(i2s_index);
+	/* Release completed pages following the actual HW position (SAR)
+	 * instead of a fixed one-page-per-ISR count.  Under long CPU stalls
+	 * (secure-world calls, flash writes) the GDMA keeps cycling the LLI
+	 * ring and several page-complete interrupts collapse into one; the
+	 * one-release-per-ISR bookkeeping then lags the HW position forever,
+	 * making the CPU overwrite the page the GDMA is currently reading.
+	 * Deriving the release count from SAR makes the ring self-healing.
+	 */
+
+	u32 sar = GDMA_GetSrcAddr(GDMA_InitStruct->GDMA_Index, GDMA_InitStruct->GDMA_ChNum);
+	u32 base = sp_tx_info.tx_block[0].tx_addr;
+	u32 span = (u32)sp_tx_info.tx_page_num * sp_tx_info.tx_page_size;
+
+	if ((sar >= base) && (sar < base + span)) {
+		u32 hw_page = (sar - base) / sp_tx_info.tx_page_size;
+		u32 released = 0;
+
+		while ((sp_tx_info.tx_gdma_cnt != hw_page) && (released < sp_tx_info.tx_page_num)) {
+			pTX_BLOCK ptx_block = &(sp_tx_info.tx_block[sp_tx_info.tx_gdma_cnt]);
+
+			if (ptx_block->tx_gdma_own) {
+				memcpy((void *)ptx_block->tx_addr, (void *)sp_tx_info.tx_zero_block.tx_addr, sp_tx_info.tx_page_size);
+				DCache_CleanInvalidate((uint32_t)ptx_block->tx_addr, sp_tx_info.tx_page_size);
+				ptx_block->tx_gdma_own = 0;
+			}
+			sp_tx_info.tx_gdma_cnt++;
+			if (sp_tx_info.tx_gdma_cnt == sp_tx_info.tx_page_num) {
+				sp_tx_info.tx_gdma_cnt = 0;
+			}
+			released++;
+		}
+#if DEBUG_I2S_TX_RESYNC
+		if (released > 1) {
+			DBG_8195A("[I2S TX RESYNC] recovered %d missed pages (hw_page=%d)\n", released - 1, hw_page);
+		}
+#endif
+	} else {
+		/* SAR is in the zero entry block (ring startup): fall back to
+		 * the original single-page release.
+		 */
+		i2s_release_tx_page(i2s_index);
+	}
+
 	pbuf = i2s_get_ready_tx_page(i2s_index);
 	I2SUserCB.TxCCB(I2SUserCB.TxCBId, (char*)pbuf);
 

--- a/os/drivers/audio/syu645b.c
+++ b/os/drivers/audio/syu645b.c
@@ -63,11 +63,11 @@
  * It's good to match the buffer size with i2s DMA page size
  */
 #ifndef CONFIG_SYU645B_BUFFER_SIZE
-#define CONFIG_SYU645B_BUFFER_SIZE       32768
+#define CONFIG_SYU645B_BUFFER_SIZE       8192
 #endif
 
 #ifndef CONFIG_SYU645B_NUM_BUFFERS
-#define CONFIG_SYU645B_NUM_BUFFERS       2
+#define CONFIG_SYU645B_NUM_BUFFERS       4
 #endif
 
 /****************************************************************************


### PR DESCRIPTION
When the CPU stalls for tens of ms, several page-complete interrupts collapse into one, so the SW ring index permanently lags the HW position. Once the accumulated lag reaches PAGE_NUM-1, the driver keeps writing into the page the GDMA is currently reading, causing a periodic click (~21ms) until playback stops.
1. Recover ring index of LLI page
2. Use thread instead of work_queue, because other module also use work_queue,especially ble. Sometimes it takes over than tens of milliseconds.
3. Adjust i2s dma & audio buffer size(syu645b)