### PR TITLE
os/kernel: Fix kernel minor errors

### DIFF
--- a/os/kernel/group/group_signal.c
+++ b/os/kernel/group/group_signal.c
@@ -241,7 +241,7 @@ int group_signal(FAR struct task_group_s *group, FAR siginfo_t *siginfo)
 	 */
 
 #ifdef CONFIG_SMP
-	irqstate_t flags = enter_critical_section()
+	irqstate_t flags = enter_critical_section();
 #else
 	sched_lock();
 #endif

--- a/os/kernel/sched/sched_waitid.c
+++ b/os/kernel/sched/sched_waitid.c
@@ -220,7 +220,7 @@ int waitid(idtype_t idtype, id_t id, FAR siginfo_t *info, int options)
 #ifdef CONFIG_SCHED_CHILD_STATUS
 	/* Does this task retain child status? */
 
-	retains = ((rtcb->group->tg_flags && GROUP_FLAG_NOCLDWAIT) == 0);
+	retains = ((rtcb->group->tg_flags & GROUP_FLAG_NOCLDWAIT) == 0);
 
 	if (rtcb->group->tg_children == NULL && retains) {
 		/* There are no children */

--- a/os/kernel/sched/sched_waitpid.c
+++ b/os/kernel/sched/sched_waitpid.c
@@ -341,7 +341,7 @@ pid_t waitpid(pid_t pid, int *stat_loc, int options)
 #ifdef CONFIG_SCHED_CHILD_STATUS
 	/* Does this task retain child status? */
 
-	retains = ((rtcb->group->tg_flags && GROUP_FLAG_NOCLDWAIT) == 0);
+	retains = ((rtcb->group->tg_flags & GROUP_FLAG_NOCLDWAIT) == 0);
 
 	if (rtcb->group->tg_children == NULL && retains) {
 		err = ECHILD;

--- a/os/kernel/sched/sched_waitpid.c
+++ b/os/kernel/sched/sched_waitpid.c
@@ -422,6 +422,7 @@ pid_t waitpid(pid_t pid, int *stat_loc, int options)
 				if (stat_loc != NULL) {
 					*stat_loc = child->ch_status << 8;
 				}
+				pid = child->ch_pid;
 
 				/* Discard the child entry and break out of the loop */
 

--- a/os/kernel/task/task_reparent.c
+++ b/os/kernel/task/task_reparent.c
@@ -174,7 +174,7 @@ int task_reparent(pid_t ppid, pid_t chpid)
 	if (child) {
 		/* Has the new parent's task group supressed child exit status? */
 
-		if ((pgrp->tg_flags && GROUP_FLAG_NOCLDWAIT) == 0) {
+		if ((pgrp->tg_flags & GROUP_FLAG_NOCLDWAIT) == 0) {
 			/* No.. Add the child status entry to the new parent's task group */
 
 			group_addchild(pgrp, child);
@@ -192,7 +192,7 @@ int task_reparent(pid_t ppid, pid_t chpid)
 		 * suppressed child exit status.
 		 */
 
-		ret = ((ogrp->tg_flags && GROUP_FLAG_NOCLDWAIT) == 0) ? -ENOENT : OK;
+		ret = ((ogrp->tg_flags & GROUP_FLAG_NOCLDWAIT) == 0) ? -ENOENT : OK;
 	}
 
 #else							/* CONFIG_SCHED_CHILD_STATUS */
@@ -276,7 +276,7 @@ int task_reparent(pid_t ppid, pid_t chpid)
 	if (child) {
 		/* Has the new parent's task group supressed child exit status? */
 
-		if ((ptcb->group->tg_flags && GROUP_FLAG_NOCLDWAIT) == 0) {
+		if ((ptcb->group->tg_flags & GROUP_FLAG_NOCLDWAIT) == 0) {
 			/* No.. Add the child status entry to the new parent's task group */
 
 			group_addchild(ptcb->group, child);
@@ -294,7 +294,7 @@ int task_reparent(pid_t ppid, pid_t chpid)
 		 * suppressed child exit status.
 		 */
 
-		ret = ((otcb->group->tg_flags && GROUP_FLAG_NOCLDWAIT) == 0) ? -ENOENT : OK;
+		ret = ((otcb->group->tg_flags & GROUP_FLAG_NOCLDWAIT) == 0) ? -ENOENT : OK;
 	}
 
 #else							/* CONFIG_SCHED_CHILD_STATUS */

--- a/os/kernel/task/task_setup.c
+++ b/os/kernel/task/task_setup.c
@@ -295,7 +295,7 @@ static inline void task_saveparent(FAR struct tcb_s *tcb, uint8_t ttype)
 		 * the SA_NOCLDWAIT flag with sigaction().
 		 */
 
-		if ((rtcb->group->tg_flags && GROUP_FLAG_NOCLDWAIT) == 0) {
+		if ((rtcb->group->tg_flags & GROUP_FLAG_NOCLDWAIT) == 0) {
 			FAR struct child_status_s *child;
 
 			/* Make sure that there is not already a structure for this PID in the


### PR DESCRIPTION
### 1. os/kernel/group/group_signal.c: Add missing semicolon

Add missing semicolon in `enter_critical_section`.
This code only complied when `#if defined(CONFIG_SCHED_HAVE_PARENT) && defined(CONFIG_SCHED_CHILD_STATUS)`.
So we're not compiling this code.

### 2. os/kernel: Fix incorrect bitmask operator

The flag check was incorrectly using the logical AND operator && instead of the bitwise AND operator &.
Fix this by using the correct bitwise AND operator &.
It wasn't effect most of our config, because it's only effect when `CONFIG_SCHED_CHILD_STATUS` is enabled.

### 3. os/kernel/sched/sched_waitpid.c: Fix return value.

waitpid should return the process ID of the child whose state has changed even if pid is -1.
It wasn't effect most of our config, because it's only effect when CONFIG_SCHED_CHILD_STATUS is enabled.