### PR TITLE
os/kernel/task: fix race between task_terminate() and mq_dosend()

### DIFF
--- a/os/kernel/task/task_terminate.c
+++ b/os/kernel/task/task_terminate.c
@@ -158,7 +158,8 @@ int task_terminate(pid_t pid, bool nonblocking)
 {
 	FAR struct tcb_s *dtcb;
 	irqstate_t flags;
-	uint8_t task_state;
+	uint8_t orig_task_state;
+	uint8_t final_task_state;
 
 	/* Find for the TCB associated with matching PID */
 
@@ -185,14 +186,17 @@ int task_terminate(pid_t pid, bool nonblocking)
 
 	/* Remove the task from the task list
 	 * before removing the task from the global tasklist, we are preserving its
-	 * task->state because later in the code, task_exithook() is called
-	 * task_exithook() -> task_recover() -> mq_recover() -> performs operations based
-	 * on tcb->task_state.
+	 * task->state because it is needed for task_recover() operations and
+	 * sched_removereadytorun() sets task state as invalid.
+	 * After task_recover() operations are complete, we set the invalid state back.
 	 */
 
-	task_state = dtcb->task_state;
+	orig_task_state = dtcb->task_state;
 	sched_removereadytorun(dtcb);
-	dtcb->task_state = task_state;
+	final_task_state = dtcb->task_state;
+	dtcb->task_state = orig_task_state;
+	task_recover(dtcb);
+	dtcb->task_state = final_task_state;
 
 	/* At this point, the TCB should no longer be accessible to the system */
 


### PR DESCRIPTION
In task_terminate(), sched_removereadytorun() removes the TCB from the blocked task list (e.g. g_waitingformqnotempty) while the corresponding waiter count (e.g. nwaitnotempty) is only decremented later by mq_recover() called via task_exithook() -> task_recover().

This creates a race window where the count is non-zero but the TCB is already gone from the waiting list. If another task calls mq_send() on the same queue during this window, mq_dosend() sees nwaitnotempty > 0, searches the list, finds no matching TCB, and triggers the assert at line 447 in mq_sndinternal.c.

Fix this by calling task_recover() inside the critical section in task_terminate(), right after sched_removereadytorun() and before leave_critical_section(). This ensures the waiter count is decremented right after the TCB removal from the waiting list.

task_recover() is safe to call here because:
- mq_recover() checks task_state == TSTATE_WAIT_MQNOTEMPTY/MQNOTFULL and decrements the count. After the call, task_state is set to TSTATE_TASK_INVALID, so the second call via task_exithook() is a no-op.
- sem_recover() checks task_state == TSTATE_WAIT_SEM and clears waitsem. The second call skips the if-block since task_state is now invalid.
- wd_recover() checks waitdog != NULL and sets it to NULL. Safe for double calls.
- sem_release_all() iterates holdsem which is NULL after the first call.