### PR TITLE
os/kernel/semaphore: Fix holder count overflow in sem_releaseholder

### DIFF
--- a/os/kernel/semaphore/sem_holder.c
+++ b/os/kernel/semaphore/sem_holder.c
@@ -733,8 +733,18 @@ void sem_addholder_tcb(FAR struct tcb_s *htcb, FAR sem_t *sem)
 		/* Find or allocate a container for this new holder */
 		pholder = sem_findorallocateholder(sem, htcb);
 		if (pholder != NULL) {
-			/* Increment the number of counts held by this holder */
-			pholder->counts++;
+			/* Reaching the maximum means holder accounting has diverged from
+			 * the semaphore state.  Catch it at the acquisition that exposes
+			 * the problem, while retaining the limit check to prevent a signed
+			 * 16-bit wrap in non-debug builds.
+			 */
+
+			DEBUGASSERT(pholder->counts < SEM_VALUE_MAX);
+			if (pholder->counts < SEM_VALUE_MAX) {
+				/* Increment the number of counts held by this holder */
+
+				pholder->counts++;
+			}
 		}
 #if defined(CONFIG_PRIORITY_INHERITANCE) && !defined(CONFIG_BINMGR_RECOVERY)
 	}
@@ -773,33 +783,71 @@ void sem_addholder(FAR sem_t *sem)
  *
  * Parameters:
  *   sem - A reference to the semaphore being posted
+ *   rtcb - TCB of the task posting the semaphore
  *
  * Return Value:
- *   None
+ *   TCB of the holder whose count was released.  This can differ from
+ *   rtcb when a counting semaphore is posted by a non-holder.
  *
  * Assumptions:
  *
  ****************************************************************************/
 
-void sem_releaseholder(FAR sem_t *sem, FAR struct tcb_s *rtcb)
+FAR struct tcb_s *sem_releaseholder(FAR sem_t *sem, FAR struct tcb_s *rtcb)
 {
 	FAR struct semholder_s *pholder;
+	FAR struct semholder_s *candidate = NULL;
+	unsigned int total = 0;
 
 	if ((sem->flags & FLAGS_SIGSEM) != 0) {
 		/* No saved holder for semaphore used for signaling */
-		return;
+		return rtcb;
 	}
 
-	/* Find the container for this holder */
+	/* Find the container for this holder.  POSIX counting semaphores do not
+	 * require the posting task to be the task that obtained the count.  If
+	 * there is only one recorded holder, it is therefore also the only
+	 * possible holder whose count can be released.
+	 */
 
-	pholder = sem_findholder(sem, rtcb);
+#if CONFIG_SEM_PREALLOCHOLDERS > 0
+	for (pholder = sem->hhead; pholder != NULL; pholder = pholder->flink)
+#else
+	pholder = &sem->holder;
+	if (pholder->htcb != NULL)
+#endif
+	{
+		DEBUGASSERT(pholder->counts > 0);
 
-	if (pholder && pholder->counts > 0) {
-		/* Decrement the counts on this holder -- the holder will be freed
-		 * later in sem_restorebaseprio.
+		if (pholder->htcb == rtcb) {
+			/* Decrement the counts on this holder -- the holder will be freed
+			 * later in sem_restorebaseprio.
+			 */
+
+			pholder->counts--;
+			return rtcb;
+		}
+
+		total++;
+		candidate = pholder;
+	}
+
+	if (total == 1) {
+		/* The posting task is not a holder, but the sole holder is
+		 * unambiguous.  Return its TCB so sem_restorebaseprio() removes the
+		 * correct zero-count entry after priority restoration.
 		 */
-		pholder->counts--;
+
+		candidate->counts--;
+		return candidate->htcb;
 	}
+
+	/* With multiple holders there is not enough information to select the
+	 * released holder.  Keep the existing records rather than attributing
+	 * the release to the wrong task.
+	 */
+
+	return rtcb;
 }
 
 #ifdef CONFIG_PRIORITY_INHERITANCE

--- a/os/kernel/semaphore/sem_post.c
+++ b/os/kernel/semaphore/sem_post.c
@@ -198,6 +198,7 @@ void sem_unblock_task(sem_t *sem, struct tcb_s *htcb)
 
 int sem_post(FAR sem_t *sem)
 {
+	FAR struct tcb_s *htcb;
 	irqstate_t saved_state;
 	int ret = ERROR;
 	size_t caller_retaddr = (size_t)GET_RETURN_ADDRESS();
@@ -213,14 +214,15 @@ int sem_post(FAR sem_t *sem)
 
 		/* Perform the semaphore unlock operation. */
 		ASSERT_INFO(sem->semcount < SEM_VALUE_MAX, "sem = 0x%x, semcount = %d, flags = 0x%x, caller address = 0x%x\n", sem, sem->semcount, sem->flags, caller_retaddr);
-		sem_releaseholder(sem, this_task());
+		htcb = this_task();
+		htcb = sem_releaseholder(sem, htcb);
 		sem->semcount++;
 
 		if ((sem->flags & FLAGS_SEM_MUTEX) != 0) {
 			ASSERT_INFO(sem->semcount < 2, "sem = 0x%x, semcount = %d, flags = 0x%x, caller address = 0x%x\n", sem, sem->semcount, sem->flags, caller_retaddr);
 		}
 
-		sem_unblock_task(sem, this_task());
+		sem_unblock_task(sem, htcb);
 		ret = OK;
 
 		/* Interrupts may now be enabled. */

--- a/os/kernel/semaphore/semaphore.h
+++ b/os/kernel/semaphore/semaphore.h
@@ -115,7 +115,7 @@ void sem_destroyholder(FAR sem_t *sem);
 struct semholder_s *sem_findholder(sem_t *sem, FAR struct tcb_s *htcb);
 void sem_addholder(FAR sem_t *sem);
 void sem_addholder_tcb(FAR struct tcb_s *tcb, FAR sem_t *sem);
-void sem_releaseholder(FAR sem_t *sem, FAR struct tcb_s *htcb);
+FAR struct tcb_s *sem_releaseholder(FAR sem_t *sem, FAR struct tcb_s *htcb);
 #if defined(CONFIG_PRIORITY_INHERITANCE)
 void sem_boostpriority(FAR sem_t *sem);
 void sem_restorebaseprio(FAR struct tcb_s *stcb, FAR struct tcb_s *htcb, FAR sem_t *sem);
@@ -135,7 +135,7 @@ void sem_canceled(FAR struct tcb_s *stcb, FAR sem_t *sem);
 #define sem_addholder(sem)
 #define sem_addholder_tcb(tcb, sem)
 #define sem_boostpriority(sem)
-#define sem_releaseholder(sem, htcb)
+#define sem_releaseholder(sem, htcb) (htcb)
 #define sem_restorebaseprio(stcb, sem)
 #define sem_canceled(stcb, sem)
 #define sem_release_all(stcb)


### PR DESCRIPTION
1. The task which called sem_releaseholder may not be a holder of the semaphore, counts of the holder would not be decreamented. This commit try to resolve the problem if there is only one holder.
2. Avoid counts overflow.