### PR TITLE
os/include: Fix PTHREAD_COND_INITIALIZER to set flags

### DIFF
--- a/os/include/pthread.h
+++ b/os/include/pthread.h
@@ -261,7 +261,7 @@ typedef FAR void *pthread_addr_t;
 typedef pthread_addr_t (*pthread_startroutine_t)(pthread_addr_t);
 typedef pthread_startroutine_t pthread_func_t;
 
-#define PTHREAD_COND_INITIALIZER { SEM_INITIALIZER(0) }
+#define PTHREAD_COND_INITIALIZER { COND_SEM_INITIALIZER(0) }
 
 #define __PTHREAD_MUTEX_T_DEFINED 1
 

--- a/os/include/semaphore.h
+++ b/os/include/semaphore.h
@@ -183,22 +183,27 @@ typedef struct sem_s sem_t;
 #if CONFIG_SEM_PREALLOCHOLDERS > 0
 #define SEM_INITIALIZER(c) {NULL, (c), FLAGS_INITIALIZED, NULL} /* flink, semcount, flags, hhead */
 #define MUTEX_SEM_INITIALIZER(c) {NULL, (c), FLAGS_INITIALIZED | FLAGS_SEM_MUTEX, NULL} /* flink, semcount, flags, hhead */
+#define COND_SEM_INITIALIZER(c) {NULL, (c), FLAGS_INITIALIZED | FLAGS_SIGSEM | PRIOINHERIT_FLAGS_DISABLE, NULL} /* flink, semcount, flags, hhead */
 #else
 #define SEM_INITIALIZER(c) {NULL, (c), FLAGS_INITIALIZED, SEMHOLDER_INITIALIZER} /* flink, semcount, flags, holder */
 #define MUTEX_SEM_INITIALIZER(c) {NULL, (c), FLAGS_INITIALIZED | FLAGS_SEM_MUTEX, SEMHOLDER_INITIALIZER} /* flink, semcount, flags, holder */
+#define COND_SEM_INITIALIZER(c) {NULL, (c), FLAGS_INITIALIZED | FLAGS_SIGSEM | PRIOINHERIT_FLAGS_DISABLE, SEMHOLDER_INITIALIZER} /* flink, semcount, flags, holder */
 #endif
 #else // CONFIG_BINARY_MANAGER
 #if CONFIG_SEM_PREALLOCHOLDERS > 0
 #define SEM_INITIALIZER(c) {(c), FLAGS_INITIALIZED, NULL} /* semcount, flags, hhead */
 #define MUTEX_SEM_INITIALIZER(c) {(c), FLAGS_INITIALIZED | FLAGS_SEM_MUTEX, NULL} /* semcount, flags, hhead */
+#define COND_SEM_INITIALIZER(c) {(c), FLAGS_INITIALIZED | FLAGS_SIGSEM | PRIOINHERIT_FLAGS_DISABLE, NULL} /* semcount, flags, hhead */
 #else
 #define SEM_INITIALIZER(c) {(c), FLAGS_INITIALIZED, SEMHOLDER_INITIALIZER} /* semcount, flags, holder */
 #define MUTEX_SEM_INITIALIZER(c) {(c), FLAGS_INITIALIZED | FLAGS_SEM_MUTEX, SEMHOLDER_INITIALIZER} /* semcount, flags, holder */
+#define COND_SEM_INITIALIZER(c) {(c), FLAGS_INITIALIZED | FLAGS_SIGSEM | PRIOINHERIT_FLAGS_DISABLE, SEMHOLDER_INITIALIZER} /* semcount, flags, holder */
 #endif
 #endif
 #else
 #define SEM_INITIALIZER(c) {(c), FLAGS_INITIALIZED}	/* semcount, flags */
 #define MUTEX_SEM_INITIALIZER(c) {(c), FLAGS_INITIALIZED | FLAGS_SEM_MUTEX} /* semcount, flags */
+#define COND_SEM_INITIALIZER(c) {(c), FLAGS_INITIALIZED | FLAGS_SIGSEM | PRIOINHERIT_FLAGS_DISABLE} /* semcount, flags */
 #endif
 
 /****************************************************************************


### PR DESCRIPTION
The condition variable's internal semaphore should have priority inheritance disabled.
And it's only used for signaling primitive with no holder.
So `FLAGS_SIGSEM` should also enabled.
Add new macro `COND_SEM_INITIALIZER` to disable priority inheritance and set `FLAGS_SIGSEM`.
Now, `PTHREAD_COND_INITIALIZER` uses `COND_SEM_INITIALIZER`.
This changes makes `PTHREAD_COND_INITIALIZER` same as pthread_cond_init().