### PR TITLE
os/arch/boardctl: Include caller task name in reset log

### DIFF
--- a/os/arch/boardctl.c
+++ b/os/arch/boardctl.c
@@ -105,6 +105,9 @@
 int boardctl(unsigned int cmd, uintptr_t arg)
 {
 	int ret;
+#ifdef CONFIG_BOARDCTL_RESET
+	FAR struct tcb_s *tcb;
+#endif
 
 	switch (cmd) {
 	/*
@@ -154,7 +157,12 @@ int boardctl(unsigned int cmd, uintptr_t arg)
 		sched_lock();
 		/* Add 100ms delay for flushing another logs like printf. */
 		up_mdelay(100);
-		lldbg("Board will Reboot now. pid: %d\n", getpid());
+		tcb = sched_self();
+#if CONFIG_TASK_NAME_SIZE > 0
+		lldbg("Board will Reboot now. pid: %d, task: %s\n", tcb->pid, tcb->name);
+#else
+		lldbg("Board will Reboot now. pid: %d\n", tcb->pid);
+#endif
 #ifdef CONFIG_SYSTEM_REBOOT_REASON
 		if (!up_reboot_reason_is_written()) {
 			for (int i = 0; i < 10; i++) {


### PR DESCRIPTION
- Print the caller task name along with the PID before board reset.
- Keep PID-only logging when task names are disabled.

Tested on AI Lite Plus LCD and confirmed that the caller information is printed
before the board reboots normally.
<img width="558" height="169" alt="Screenshot from 2026-07-15 10-16-45" src="https://github.com/user-attachments/assets/fc4834c1-5309-43cb-9901-db3f516a45c7" />

