### PR TITLE
os/semaphore: wake waiters when recovering canceled holders

### DIFF
--- a/os/fs/smartfs/smartfs_smart.c
+++ b/os/fs/smartfs/smartfs_smart.c
@@ -1245,18 +1245,21 @@ static int smartfs_bind(FAR struct inode *blkdriver, const void *data, void **ha
 		return -ENOMEM;
 	}
 
-	/* If the global semaphore hasn't been initialized, then
-	 * initialize it now. */
+	/* If the global semaphore hasn't been initialized, then initialize it
+	 * as an available lock.  Initializing it to zero classifies it as a
+	 * signaling semaphore, which prevents holder tracking and recovery when
+	 * the task holding the SmartFS lock is cancelled.
+	 */
 
 	fs->fs_sem = &g_sem;
 	if (!g_seminitialized) {
-		sem_init(&g_sem, 0, 0);	/* Initialize the semaphore that controls access */
+		sem_init(&g_sem, 0, 1);	/* Initialize the semaphore that controls access */
 		g_seminitialized = TRUE;
-	} else {
-		/* Take the semaphore for the mount */
-
-		smartfs_semtake(fs);
 	}
+
+	/* Serialize every mount, including the first one. */
+
+	smartfs_semtake(fs);
 
 	/* Initialize the allocated mountpt state structure.  The filesystem is
 	 * responsible for one reference on the blkdriver inode and does not

--- a/os/kernel/semaphore/sem_holder.c
+++ b/os/kernel/semaphore/sem_holder.c
@@ -986,14 +986,20 @@ void sem_release_all(FAR struct tcb_s *htcb)
 
 	while ((pholder = htcb->holdsem) != NULL) {
 		FAR sem_t *sem = pholder->sem;
+		int16_t counts = pholder->counts;
 
 		sem_freeholder(sem, pholder);
 
-		/* Increment the count on the semaphore to release the count that
-		 * was taken by sem_wait() or sem_post().
+		/* Return every count held by the terminated task.  This must follow
+		 * the same wake-up path as sem_post(): incrementing semcount alone
+		 * leaves an already blocked waiter asleep.
 		 */
 
-		sem->semcount++;
+		while (counts-- > 0) {
+			DEBUGASSERT(sem->semcount < SEM_VALUE_MAX);
+			sem->semcount++;
+			sem_unblock_task(sem, htcb);
+		}
 	}
 }
 #endif


### PR DESCRIPTION
Initialize SmartFS g_sem with a count of one because it is an available lock, not a signaling semaphore. Initializing it with zero sets FLAGS_SIGSEM, skips holder tracking, and prevents cancellation recovery.

When recovering a canceled task, sem_release_all() previously only incremented semcount. If another task was already waiting, its wait queue entry remained blocked despite the returned count. Wake a waiter through sem_unblock_task() for each recovered holder count, matching the release and handoff behavior of sem_post().