### PR TITLE
os/board/rtl8730e: Change BLE Stack Callbak Method

### DIFF
--- a/os/board/rtl8730e/src/component/bluetooth/api/rtk_stack/rtk_stack_api.c
+++ b/os/board/rtl8730e/src/component/bluetooth/api/rtk_stack/rtk_stack_api.c
@@ -92,7 +92,8 @@ static void bt_stack_api_taskentry(void *ctx)
 							break;
 
 						case IO_MSG_TYPE_BT_STATUS:
-							bt_stack_le_gap_handle_io_msg(io_msg.subtype, (void *)&io_msg.u.param);
+							/* When le_gap_msg_info_way(false) is called, gap io msg will be excuted in gap callback instead of here. */
+							// bt_stack_le_gap_handle_io_msg(io_msg.subtype, (void *)&io_msg.u.param);
 							break;
 #if defined(RTK_BLE_ISO_SUPPORT) && RTK_BLE_ISO_SUPPORT
 						case IO_MSG_TYPE_LE_MGR:

--- a/os/board/rtl8730e/src/component/bluetooth/api/rtk_stack/rtk_stack_le_gap.c
+++ b/os/board/rtl8730e/src/component/bluetooth/api/rtk_stack/rtk_stack_le_gap.c
@@ -1146,6 +1146,11 @@ static T_APP_RESULT bt_stack_le_gap_callback(uint8_t type, void *data)
 		}
 		break;
 	}
+	case GAP_MSG_LE_GAP_STATE_MSG: {
+		T_IO_MSG *io_msg = (T_IO_MSG *)p_data->p_gap_state_msg;
+		bt_stack_le_gap_handle_io_msg(io_msg->subtype, &io_msg->u.param);
+		break;
+	}
 	default:
 		break;
 	}
@@ -1338,6 +1343,7 @@ uint16_t bt_stack_le_gap_init(void *gap_conf)
 		return RTK_BT_ERR_NO_RESOURCE;
 	}
 
+	le_gap_msg_info_way(false);
 	bt_stack_le_gap_ext_adv_init();
 
 	bt_stack_le_gap_set_config(gap_conf);


### PR DESCRIPTION
- Change BLE Stack callback method from io_msg to stack execute
- This can prevent link information from being cleared before the porting layer receives the msg