### PR TITLE
armv8-m/up_schedulesigaction: Fix INVPC caused by not setting REG_EXC…

### DIFF
--- a/os/arch/arm/src/armv8-m/up_schedulesigaction.c
+++ b/os/arch/arm/src/armv8-m/up_schedulesigaction.c
@@ -241,9 +241,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 #ifdef CONFIG_BUILD_PROTECTED
 			tcb->xcp.regs[REG_LR] = EXC_RETURN_PRIVTHR;
 #endif
-			if (tcb->xcp.regs[REG_EXC_RETURN] == EXC_RETURN_HANDLER) {
-				tcb->xcp.regs[REG_EXC_RETURN] = EXC_RETURN_PRIVTHR;
-			}
+			tcb->xcp.regs[REG_EXC_RETURN] = EXC_RETURN_PRIVTHR;
 
 			tcb->xcp.regs[REG_XPSR] = ARMV8M_XPSR_T;
 		}


### PR DESCRIPTION
…_RETURN

In up_schedule_sigaction() CASE 3 (signal delivered to a non-running task), EXC_RETURN was only changed to EXC_RETURN_PRIVTHR when the task was in Handler mode (EXC_RETURN_HANDLER). If the task was a blocked user-space thread (EXC_RETURN_UNPRIVTHR), EXC_RETURN was left unchanged.

When the blocked task is later scheduled to execute signal trampoline (up_sigdeliver) its EXC_RETURN value should be EXC_RETURN_PRIVTHR.test