### PR TITLE
os/kernel/pthread: Fix waiters counter leak on sem take failure

### DIFF
--- a/os/kernel/pthread/pthread_condtimedwait.c
+++ b/os/kernel/pthread/pthread_condtimedwait.c
@@ -302,18 +302,14 @@ int pthread_cond_timedwait(FAR pthread_cond_t *cond, FAR pthread_mutex_t *mutex,
 						/* Did we get the condition semaphore. */
 
 						if (status != OK) {
+							/* The wait was not consumed by signal() or broadcast(). */
+							cond->waiters--;
+
 							/* NO.. Handle the special case where the semaphore wait was
 							 * awakened by the receipt of a signal -- presumably the
 							 * signal posted by pthread_condtimedout().
 							 */
-
 							if (get_errno() == EINTR) {
-
-								/* Decrement the waiter count for the timeout case
-								 * because it will not be handled by cond_signal()
-								 * or cond_broadcast()
-								 */
-								cond->waiters--;
 								sdbg("Timedout!\n");
 								ret = ETIMEDOUT;
 							} else {

--- a/os/kernel/pthread/pthread_condwait.c
+++ b/os/kernel/pthread/pthread_condwait.c
@@ -127,6 +127,18 @@ int pthread_cond_wait(FAR pthread_cond_t *cond, FAR pthread_mutex_t *mutex)
 		/* Take the semaphore */
 
 		status = pthread_sem_take((FAR sem_t *)&cond->sem);
+		/* Adding DEBUGASSERT here because
+		 * possible failure cases of sem_wait() are
+		 * already handled inside pthread_sem_take()
+		 * i.e EINVAL and EINTR
+		 * ETIMEDOUT is not expected in pthread_cond_wait()
+		 * If pthread_sem_take() fails for other than these,
+		 * we trigger an assert.
+		 */
+		DEBUGASSERT_INFO(status == OK,
+		    "pthread_sem_take failed! errno=%d, sem=%p, waiters=%d, semcount=%d",
+		    get_errno(), &cond->sem, cond->waiters, cond->sem.semcount);
+
 		if (ret == OK) {
 			/* Report the first failure that occurs */
 


### PR DESCRIPTION
When pthread_sem_take() returns an error in pthread_cond_wait() or when sem_wait() returns an error in pthread_cond_timedwait(), the waiters counter was not decremented.
This caused a mismatch between the actual number of waiting threads and the waiters count, potentially causing pthread_cond_signal() to send signals when no valid waiter exists.

The current design decrements waiters in pthread_cond_signal() and pthread_cond_broadcast(). However, when sem_take() fails, the thread never receives a signal, so the decrement never happens.

Fix:
Add defensive decrement of waiters counter in the error path of pthread_sem_take() for  pthread_cond_wait() and in sem_wait() for pthread_cond_timedwait(). Added a safety check (waiters > 0) to prevent underflow.