### PR TITLE
os/arch/arm/src/armv7-m: Preserve EXC_RETURN across trampoline

### DIFF
--- a/os/arch/arm/include/armv7-m/irq.h
+++ b/os/arch/arm/include/armv7-m/irq.h
@@ -182,7 +182,9 @@ struct xcptcontext {
 #ifdef CONFIG_BUILD_PROTECTED
 	uint32_t saved_lr;
 #endif
+#if defined(CONFIG_ARM_CMNVECTOR) || defined(CONFIG_BUILD_PROTECTED)
 	uint32_t saved_exec_ret;
+#endif
 
 #ifdef CONFIG_BUILD_PROTECTED
 	/* This is the saved address to use when returning from a user-space

--- a/os/arch/arm/src/armv7-m/up_schedulesigaction.c
+++ b/os/arch/arm/src/armv7-m/up_schedulesigaction.c
@@ -174,6 +174,8 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 				tcb->xcp.saved_xpsr = current_regs[REG_XPSR];
 #ifdef CONFIG_BUILD_PROTECTED
 				tcb->xcp.saved_lr = current_regs[REG_LR];
+#endif
+#if defined(CONFIG_ARM_CMNVECTOR) || defined(CONFIG_BUILD_PROTECTED)
 				tcb->xcp.saved_exec_ret = current_regs[REG_EXC_RETURN];
 #endif
 
@@ -190,6 +192,8 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 #endif
 #ifdef CONFIG_BUILD_PROTECTED
 				current_regs[REG_LR] = EXC_RETURN_PRIVTHR;
+#endif
+#if defined(CONFIG_ARM_CMNVECTOR) || defined(CONFIG_BUILD_PROTECTED)
 				current_regs[REG_EXC_RETURN] = EXC_RETURN_PRIVTHR;
 #endif
 
@@ -223,6 +227,8 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 			tcb->xcp.saved_xpsr = tcb->xcp.regs[REG_XPSR];
 #ifdef CONFIG_BUILD_PROTECTED
 			tcb->xcp.saved_lr = tcb->xcp.regs[REG_LR];
+#endif
+#if defined(CONFIG_ARM_CMNVECTOR) || defined(CONFIG_BUILD_PROTECTED)
 			tcb->xcp.saved_exec_ret = tcb->xcp.regs[REG_EXC_RETURN];
 #endif
 
@@ -239,9 +245,9 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 #endif
 #ifdef CONFIG_BUILD_PROTECTED
 			tcb->xcp.regs[REG_LR] = EXC_RETURN_PRIVTHR;
-			if (tcb->xcp.regs[REG_EXC_RETURN] == EXC_RETURN_HANDLER) {
-				tcb->xcp.regs[REG_EXC_RETURN] = EXC_RETURN_PRIVTHR;
-			}
+#endif
+#if defined(CONFIG_ARM_CMNVECTOR) || defined(CONFIG_BUILD_PROTECTED)
+			tcb->xcp.regs[REG_EXC_RETURN] = EXC_RETURN_PRIVTHR;
 #endif
 
 			tcb->xcp.regs[REG_XPSR] = ARMV7M_XPSR_T;

--- a/os/arch/arm/src/armv7-m/up_sigdeliver.c
+++ b/os/arch/arm/src/armv7-m/up_sigdeliver.c
@@ -131,6 +131,8 @@ void up_sigdeliver(void)
 	regs[REG_XPSR] = rtcb->xcp.saved_xpsr;
 #ifdef CONFIG_BUILD_PROTECTED
 	regs[REG_LR] = rtcb->xcp.saved_lr;
+#endif
+#if defined(CONFIG_ARM_CMNVECTOR) || defined(CONFIG_BUILD_PROTECTED)
 	regs[REG_EXC_RETURN] = rtcb->xcp.saved_exec_ret;
 #endif
 


### PR DESCRIPTION
The common-vector register contains REG_EXC_RETURN in both flat and protected builds.
Signal delivery temporarily redirects the saved context to up_sigdeliver, so it must save the original EXC_RETURN, force the trampoline to return through privileged Thread mode, and restore the original value after the handler completes.
Move the EXC_RETURN save, update, and restore outside the protected-build guard while keeping LR handling protected-only.
Always select EXC_RETURN_PRIVTHR for a non-running target instead of only converting handler-mode contexts.
This prevents a blocked task from entering the kernel signal trampoline with an incompatible handler or unprivileged return state and avoids exception-return integrity faults.

In `CONFIG_ARM_CMNVECTOR is not set` and `CONFIG_BUILD_PROTECTED is not set` case we're setting `EXC_RETURN_PRIVTHR` in up_lazyexception.S
```
 #ifdef CONFIG_BUILD_PROTECTED
	ldmia	r0, {r2-r11,r14}		/* Recover R4-R11, r14 + 2 temp values */
 #else
	ldmia	r0, {r2-r11}			/* Recover R4-R11 + 2 temp values */
	ldr	r14, =EXC_RETURN_PRIVTHR	/* Load the special value */
 #endif
```