### PR TITLE
os/arch/arm/src/amebasmart: protect shared IMR from stale restore rac…

### DIFF
--- a/os/arch/arm/src/amebasmart/amebasmart_serial.c
+++ b/os/arch/arm/src/amebasmart/amebasmart_serial.c
@@ -90,7 +90,7 @@
 #include "tinyara/kmalloc.h"
 #include "osdep_service.h"
 #include "ameba_vector.h"
-
+#include <tinyara/spinlock.h>
 /****************************************************************************
  * Preprocessor Definitions
  ****************************************************************************/
@@ -237,7 +237,9 @@ struct rtl8730e_up_dev_s {
 #endif
 	uint8_t tx_level;
 };
-
+#ifdef CONFIG_SMP
+volatile spinlock_t g_loguart_ier_lock = SP_UNLOCKED;
+#endif
 /****************************************************************************
  * Private Function Prototypes
  ****************************************************************************/
@@ -559,8 +561,13 @@ static void rtl8730e_log_up_shutdown(struct uart_dev_s *dev)
 
 static int rtl8730e_log_uart_irq(void *Data)
 {
-
+#ifdef CONFIG_SMP
+	spin_lock(&g_loguart_ier_lock);
+#endif
 	u32 IrqEn = LOGUART_GetIMR();
+#ifdef CONFIG_SMP
+	spin_unlock(&g_loguart_ier_lock);
+#endif
 	u32 reg_lsr = LOGUART_GetStatus(CONSOLE);
 
 	if (reg_lsr & LOGUART_BIT_RXFIFO_INT) {
@@ -1342,10 +1349,19 @@ int up_lowgetc(void)
 {
 	uint8_t rxd;
 #ifdef CONFIG_UART4_SERIAL_CONSOLE
+	/* The save/disable-all/restore of IER below races with rxint()/txint() on
+	 * the other CPU under SMP: a concurrent enable would be lost when IrqEn is
+	 * restored. Serialize the whole sequence (see g_loguart_ier_lock). */
+#ifdef CONFIG_SMP
+	irqstate_t flags = spin_lock_irqsave(&g_loguart_ier_lock);
+#endif
 	u32 IrqEn = LOGUART_GetIMR();
 	LOGUART_SetIMR(0);
 	rxd = LOGUART_GetChar(_FALSE);
 	LOGUART_SetIMR(IrqEn);
+#ifdef CONFIG_SMP
+	spin_unlock_irqrestore(&g_loguart_ier_lock, flags);
+#endif
 #else
 	if (CONSOLE_DEV.isconsole == false)
 		return;

--- a/os/board/rtl8730e/src/component/soc/amebad2/fwlib/ap_peripheral/ameba_loguart.c
+++ b/os/board/rtl8730e/src/component/soc/amebad2/fwlib/ap_peripheral/ameba_loguart.c
@@ -17,6 +17,9 @@
   */
 
 #include "ameba_soc.h"
+#include <tinyara/spinlock.h>
+
+extern volatile spinlock_t g_loguart_ier_lock;
 
 static LOG_UART_PORT LOG_UART_IDX_FLAG[] = {
 	{1, LOGUART_BIT_TP2F_NOT_FULL, LOGUART_BIT_TP2F_EMPTY, 52125, UART_LOG_IRQ},	/* CM0 IDX NOT_FULL EMPTY TX_TIMEOUT IRQ*/
@@ -284,6 +287,9 @@ void LOGUART_AGGPathCmd(LOGUART_TypeDef *UARTLOG, u8 PathIndex, u32 NewState)
   */
 void LOGUART_INTConfig(LOGUART_TypeDef *UARTLOG, u32 UART_IT, u32 newState)
 {
+#ifdef CONFIG_PLATFORM_TIZENRT_OS
+	irqstate_t flags = spin_lock_irqsave(&g_loguart_ier_lock);
+#endif
 	if (newState == ENABLE) {
 		/* Enable the selected UARTx interrupts */
 		UARTLOG->LOGUART_UART_IER |= UART_IT;
@@ -291,6 +297,9 @@ void LOGUART_INTConfig(LOGUART_TypeDef *UARTLOG, u32 UART_IT, u32 newState)
 		/* Disable the selected UARTx interrupts */
 		UARTLOG->LOGUART_UART_IER &= (u32)~UART_IT;
 	}
+#ifdef CONFIG_PLATFORM_TIZENRT_OS
+	spin_unlock_irqrestore(&g_loguart_ier_lock, flags);
+#endif
 }
 
 /**


### PR DESCRIPTION
…e under SMP

1. On SMP, the loguart IMR (interrupt mask register) is shared between both cores. up_lowgetc() performs a save-disable-restore sequence on the IMR (GetIMR → SetIMR(0) → SetIMR(stale))
2. If rxint() or txint() updated the IMR from another core during this sequence, up_lowgetc() could restore a stale IMR value and overwrite the concurrent change.
3. When the saved snapshot did not contain the RX interrupt-enable bit, the stale restore could leave RX interrupts disabled indefinitely.