### PR TITLE
os/mm/mm_heap: Reduce heap fragmentation histogram log

### DIFF
--- a/os/mm/mm_heap/mm_heapinfo_parse_heap.c
+++ b/os/mm/mm_heap/mm_heapinfo_parse_heap.c
@@ -286,6 +286,8 @@ void heapinfo_parse_heap(FAR struct mm_heap_s *heap, int mode, pid_t pid)
 
 #ifdef CONFIG_DEBUG_CHECK_FRAGMENTATION
 	heap_dbg("\nAvailable fragmented memory segments in heap memory\n");
+	heap_dbg("Idx  | Range              | Count | Size(Bytes)\n");
+	heap_dbg("-----|--------------------|-------|-----------\n");
 
 	DEBUGVERIFY(mm_takesemaphore(heap));
 
@@ -299,7 +301,7 @@ void heapinfo_parse_heap(FAR struct mm_heap_s *heap, int mode, pid_t pid)
 	mm_givesemaphore(heap);
 
 	for (ndx = 0; ndx < MM_NNODES; ++ndx) {
-		heap_dbg("Nodelist[%d] ranging [%u, %u] : num %d, size %u [Bytes]\n", ndx, ((ndx > 0 ? (1 << (ndx + MM_MIN_SHIFT)) : 0) + 1), 1 << (ndx + MM_MIN_SHIFT + 1), nodelist_cnt[ndx], nodelist_size[ndx]);
+		heap_dbg("%-4d | %8d, %-8d | %-5d | %u\n", ndx, ((ndx > 0 ? (1 << (ndx + MM_MIN_SHIFT)) : 0) + 1), 1 << (ndx + MM_MIN_SHIFT + 1), nodelist_cnt[ndx], nodelist_size[ndx]);
 	}
 #endif
 


### PR DESCRIPTION
Reduce unnecessary heap fragmentation histogram log.

[Before]
```
Available fragmented memory segments in heap memory
Nodelist[0] ranging [1, 32] : num 0, size 0 [Bytes]
Nodelist[1] ranging [33, 64] : num 0, size 0 [Bytes]
Nodelist[2] ranging [65, 128] : num 0, size 0 [Bytes]
Nodelist[3] ranging [129, 256] : num 0, size 0 [Bytes]
Nodelist[4] ranging [257, 512] : num 0, size 0 [Bytes]
Nodelist[5] ranging [513, 1024] : num 0, size 0 [Bytes]
Nodelist[6] ranging [1025, 2048] : num 0, size 0 [Bytes]
Nodelist[7] ranging [2049, 4096] : num 0, size 0 [Bytes]
Nodelist[8] ranging [4097, 8192] : num 0, size 0 [Bytes]
Nodelist[9] ranging [8193, 16384] : num 0, size 0 [Bytes]
Nodelist[10] ranging [16385, 32768] : num 0, size 0 [Bytes]
Nodelist[11] ranging [32769, 65536] : num 0, size 0 [Bytes]
Nodelist[12] ranging [65537, 131072] : num 0, size 0 [Bytes]
Nodelist[13] ranging [131073, 262144] : num 0, size 0 [Bytes]
Nodelist[14] ranging [262145, 524288] : num 0, size 0 [Bytes]
Nodelist[15] ranging [524289, 1048576] : num 0, size 0 [Bytes]
Nodelist[16] ranging [1048577, 2097152] : num 0, size 0 [Bytes]
Nodelist[17] ranging [2097153, 4194304] : num 0, size 0 [Bytes]
Nodelist[18] ranging [4194305, 8388608] : num 1, size 5171056 [Bytes]
```

[After]
```
Available fragmented memory segments in heap memory
Idx  | Range              | Count | Size(Bytes)
-----|--------------------|-------|-----------
0    |        1, 32       | 0     | 0
1    |       33, 64       | 0     | 0
2    |       65, 128      | 0     | 0
3    |      129, 256      | 0     | 0
4    |      257, 512      | 0     | 0
5    |      513, 1024     | 0     | 0
6    |     1025, 2048     | 0     | 0
7    |     2049, 4096     | 0     | 0
8    |     4097, 8192     | 0     | 0
9    |     8193, 16384    | 0     | 0
10   |    16385, 32768    | 0     | 0
11   |    32769, 65536    | 0     | 0
12   |    65537, 131072   | 0     | 0
13   |   131073, 262144   | 0     | 0
14   |   262145, 524288   | 0     | 0
15   |   524289, 1048576  | 0     | 0
16   |  1048577, 2097152  | 0     | 0
17   |  2097153, 4194304  | 0     | 0
18   |  4194305, 8388608  | 1     | 5171024
```