### PR TITLE
ble_manager_state : Mark conn_handle read as unused in DISCONNECT handler

### DIFF
--- a/framework/src/ble_manager/ble_manager_state.c
+++ b/framework/src/ble_manager/ble_manager_state.c
@@ -128,6 +128,7 @@ static void _event_caller(int evt_pri, void *data) {
 		case BLE_EVT_CLIENT_DISCONNECT: {
 			ble_client_device_disconnected_cb callback = msg->param[0];
 			trble_conn_handle conn = *(trble_conn_handle *)(msg->param[2]);
+			(void)conn; /* conn_handle was already consumed to resolve msg->param[1] as context */
 			uint16_t error = *(uint16_t *)(msg->param[2] + sizeof(trble_conn_handle));
 			callback(msg->param[1], error);
 		} break;


### PR DESCRIPTION
- msg->param[2] still packs conn_handle followed by error, so the read is kept to document that layout, but conn_handle itself is no longer needed here since the earlier handler already consumed it to resolve msg->param[1] as context. Cast to void instead of dropping the read to silence -Wunused-variable while keeping the layout explicit.