### PR TITLE
blemgr: Validate BLE LWNL request payloads

### DIFF
--- a/os/net/blemgr/bledev.c
+++ b/os/net/blemgr/bledev.c
@@ -74,7 +74,7 @@ int trble_scan_data_enque(trble_scanned_device *info)
 
 static int _memcpy_safe(void *dest, size_t dest_size, const void *src, size_t src_size)
 {
-	if (src_size > dest_size) {
+	if (dest == NULL || src == NULL || src_size != dest_size) {
 		return -1;
 	}
 	memcpy(dest, src, src_size);
@@ -91,9 +91,7 @@ int bledev_handle(struct bledev *dev, lwnl_req cmd, void *data, uint32_t data_le
 	case LWNL_REQ_BLE_INIT:
 	{
 		lwnl_msg_params param = { 0, };
-		if (data != NULL) {
-			_memcpy_safe(&param, sizeof(lwnl_msg_params), data, data_len);
-		} else {
+		if (_memcpy_safe(&param, sizeof(lwnl_msg_params), data, data_len) != 0) {
 			return TRBLE_INVALID_ARGS;
 		}
 
@@ -132,9 +130,7 @@ int bledev_handle(struct bledev *dev, lwnl_req cmd, void *data, uint32_t data_le
 	case LWNL_REQ_BLE_SEC_PARAM_SET:
 	{
 		trble_sec_param sec_param = { 0, };
-		if (data != NULL) {
-			_memcpy_safe(&sec_param, sizeof(trble_sec_param), data, data_len);
-		} else {
+		if (_memcpy_safe(&sec_param, sizeof(trble_sec_param), data, data_len) != 0) {
 			return TRBLE_INVALID_ARGS;
 		}
 		TRBLE_DRV_CALL(ret, dev, set_sec_param, (dev, &sec_param));
@@ -145,9 +141,7 @@ int bledev_handle(struct bledev *dev, lwnl_req cmd, void *data, uint32_t data_le
 		uint8_t *conn_handle = 0;
 		uint8_t *confirm = 0;
 		lwnl_msg_params param = { 0, };
-		if (data != NULL) {
-			_memcpy_safe(&param, sizeof(lwnl_msg_params), data, data_len);
-		} else {
+		if (_memcpy_safe(&param, sizeof(lwnl_msg_params), data, data_len) != 0) {
 			return TRBLE_INVALID_ARGS;
 		}
 		conn_handle = (uint8_t *)param.param[0];
@@ -172,9 +166,7 @@ int bledev_handle(struct bledev *dev, lwnl_req cmd, void *data, uint32_t data_le
 		uint16_t *device_count = NULL;
 
 		lwnl_msg_params param = { 0, };
-		if (data != NULL) {
-			_memcpy_safe(&param, sizeof(lwnl_msg_params), data, data_len);
-		} else {
+		if (_memcpy_safe(&param, sizeof(lwnl_msg_params), data, data_len) != 0) {
 			return TRBLE_INVALID_ARGS;
 		}
 		device_list = (trble_bonded_device_list_s *)param.param[0];
@@ -207,9 +199,7 @@ int bledev_handle(struct bledev *dev, lwnl_req cmd, void *data, uint32_t data_le
 		trble_conn_handle con_handle = 0;
 
 		lwnl_msg_params param = { 0, };
-		if (data != NULL) {
-			_memcpy_safe(&param, sizeof(lwnl_msg_params), data, data_len);
-		} else {
+		if (_memcpy_safe(&param, sizeof(lwnl_msg_params), data, data_len) != 0) {
 			return TRBLE_INVALID_ARGS;
 		}
 		con_handle = *(trble_conn_handle *)param.param[0];
@@ -222,12 +212,10 @@ int bledev_handle(struct bledev *dev, lwnl_req cmd, void *data, uint32_t data_le
 	{
 		bool *is_active = NULL;
 		lwnl_msg_params param = { 0, };
-		if (data != NULL) {
-			_memcpy_safe(&param, sizeof(lwnl_msg_params), data, data_len);
-			is_active = (bool *)param.param[0];
-		} else {
+		if (_memcpy_safe(&param, sizeof(lwnl_msg_params), data, data_len) != 0) {
 			return TRBLE_INVALID_ARGS;
 		}
+		is_active = (bool *)param.param[0];
 		TRBLE_DRV_CALL(ret, dev, conn_is_any_active, (dev, is_active));
 	}
 	break;
@@ -251,9 +239,7 @@ int bledev_handle(struct bledev *dev, lwnl_req cmd, void *data, uint32_t data_le
 		trble_scan_type scan_type = 0;
 		
 		lwnl_msg_params param = { 0, };
-		if (data != NULL) {
-			_memcpy_safe(&param, sizeof(lwnl_msg_params), data, data_len);
-		} else {
+		if (_memcpy_safe(&param, sizeof(lwnl_msg_params), data, data_len) != 0) {
 			return TRBLE_INVALID_ARGS;
 		}
 		scan_interval = *(uint16_t *)param.param[0];
@@ -267,10 +253,10 @@ int bledev_handle(struct bledev *dev, lwnl_req cmd, void *data, uint32_t data_le
 		/* filter can be NULL */
 		lwnl_msg_params param = { 0, };
 		trble_scan_filter *filter = NULL;
-		if (data != NULL) {
-			_memcpy_safe(&param, sizeof(lwnl_msg_params), data, data_len);
-			filter = (trble_scan_filter *)param.param[0];
+		if (_memcpy_safe(&param, sizeof(lwnl_msg_params), data, data_len) != 0) {
+			return TRBLE_INVALID_ARGS;
 		}
+		filter = (trble_scan_filter *)param.param[0];
 		TRBLE_DRV_CALL(ret, dev, start_scan, (dev, filter));
 	}
 	break;
@@ -302,12 +288,10 @@ int bledev_handle(struct bledev *dev, lwnl_req cmd, void *data, uint32_t data_le
 	{
 		lwnl_msg_params param = { 0, };
 		trble_conn_info *conn_info = NULL;
-		if (data != NULL) {
-			_memcpy_safe(&param, sizeof(lwnl_msg_params), data, data_len);
-			conn_info = (trble_conn_info *)param.param[0];
-		} else {
+		if (_memcpy_safe(&param, sizeof(lwnl_msg_params), data, data_len) != 0) {
 			return TRBLE_INVALID_ARGS;
 		}
+		conn_info = (trble_conn_info *)param.param[0];
 		TRBLE_DRV_CALL(ret, dev, client_connect, (dev, conn_info));
 	}
 	break;
@@ -333,12 +317,10 @@ int bledev_handle(struct bledev *dev, lwnl_req cmd, void *data, uint32_t data_le
 	{
 		trble_connected_list *list = NULL;
 		lwnl_msg_params param = { 0, };
-		if (data != NULL) {
-			_memcpy_safe(&param, sizeof(lwnl_msg_params), data, data_len);
-			list = (trble_connected_list *)param.param[0];
-		} else {
+		if (_memcpy_safe(&param, sizeof(lwnl_msg_params), data, data_len) != 0) {
 			return TRBLE_INVALID_ARGS;
 		}
+		list = (trble_connected_list *)param.param[0];
 		TRBLE_DRV_CALL(ret, dev, conn_dev_list, (dev, list));
 	}
 	break;
@@ -348,9 +330,7 @@ int bledev_handle(struct bledev *dev, lwnl_req cmd, void *data, uint32_t data_le
 		trble_conn_handle handle;
 
 		lwnl_msg_params param = { 0, };
-		if (data != NULL) {
-			_memcpy_safe(&param, sizeof(lwnl_msg_params), data, data_len);
-		} else {
+		if (_memcpy_safe(&param, sizeof(lwnl_msg_params), data, data_len) != 0) {
 			return TRBLE_INVALID_ARGS;
 		}
 		handle = *(trble_conn_handle *)param.param[0];
@@ -403,9 +383,7 @@ int bledev_handle(struct bledev *dev, lwnl_req cmd, void *data, uint32_t data_le
 		trble_data *buf = NULL;
 
 		lwnl_msg_params param = { 0, };
-		if (data != NULL) {
-			_memcpy_safe(&param, sizeof(lwnl_msg_params), data, data_len);
-		} else {
+		if (_memcpy_safe(&param, sizeof(lwnl_msg_params), data, data_len) != 0) {
 			return TRBLE_INVALID_ARGS;
 		}
 		handle = (trble_operation_handle *)param.param[0];
@@ -420,9 +398,7 @@ int bledev_handle(struct bledev *dev, lwnl_req cmd, void *data, uint32_t data_le
 		trble_data *buf = NULL;
 
 		lwnl_msg_params param = { 0, };
-		if (data != NULL) {
-			_memcpy_safe(&param, sizeof(lwnl_msg_params), data, data_len);
-		} else {
+		if (_memcpy_safe(&param, sizeof(lwnl_msg_params), data, data_len) != 0) {
 			return TRBLE_INVALID_ARGS;
 		}
 		handle = (trble_operation_handle *)param.param[0];
@@ -437,9 +413,7 @@ int bledev_handle(struct bledev *dev, lwnl_req cmd, void *data, uint32_t data_le
 		trble_data *buf = NULL;
 
 		lwnl_msg_params param = { 0, };
-		if (data != NULL) {
-			_memcpy_safe(&param, sizeof(lwnl_msg_params), data, data_len);
-		} else {
+		if (_memcpy_safe(&param, sizeof(lwnl_msg_params), data, data_len) != 0) {
 			return TRBLE_INVALID_ARGS;
 		}
 		handle = (trble_operation_handle *)param.param[0];
@@ -454,9 +428,7 @@ int bledev_handle(struct bledev *dev, lwnl_req cmd, void *data, uint32_t data_le
 		uint8_t *count = NULL;
 
 		lwnl_msg_params param = { 0, };
-		if (data != NULL) {
-			_memcpy_safe(&param, sizeof(lwnl_msg_params), data, data_len);
-		} else {
+		if (_memcpy_safe(&param, sizeof(lwnl_msg_params), data, data_len) != 0) {
 			return TRBLE_INVALID_ARGS;
 		}
 		handle = (trble_operation_handle *)param.param[0];
@@ -471,12 +443,10 @@ int bledev_handle(struct bledev *dev, lwnl_req cmd, void *data, uint32_t data_le
 	{
 		trble_server_init_config *t_server = NULL;
 		lwnl_msg_params param = { 0, };
-		if (data != NULL) {
-			_memcpy_safe(&param, sizeof(lwnl_msg_params), data, data_len);
-			t_server = (trble_server_init_config *)param.param[0];
-		} else {
+		if (_memcpy_safe(&param, sizeof(lwnl_msg_params), data, data_len) != 0) {
 			return TRBLE_INVALID_ARGS;
 		}
+		t_server = (trble_server_init_config *)param.param[0];
 		TRBLE_DRV_CALL(ret, dev, set_server_config, (dev, t_server));
 	}
 	break;
@@ -484,12 +454,10 @@ int bledev_handle(struct bledev *dev, lwnl_req cmd, void *data, uint32_t data_le
 	{
 		uint16_t *count = NULL;
 		lwnl_msg_params param = { 0, };
-		if (data != NULL) {
-			_memcpy_safe(&param, sizeof(lwnl_msg_params), data, data_len);
-			count = (uint16_t *)param.param[0];
-		} else {
+		if (_memcpy_safe(&param, sizeof(lwnl_msg_params), data, data_len) != 0) {
 			return TRBLE_INVALID_ARGS;
 		}
+		count = (uint16_t *)param.param[0];
 		TRBLE_DRV_CALL(ret, dev, get_profile_count, (dev, count));
 	}
 	break;
@@ -500,9 +468,7 @@ int bledev_handle(struct bledev *dev, lwnl_req cmd, void *data, uint32_t data_le
 		trble_data *buf = NULL;
 
 		lwnl_msg_params param = { 0, };
-		if (data != NULL) {
-			_memcpy_safe(&param, sizeof(lwnl_msg_params), data, data_len);
-		} else {
+		if (_memcpy_safe(&param, sizeof(lwnl_msg_params), data, data_len) != 0) {
 			return TRBLE_INVALID_ARGS;
 		}
 		attr_handle = *(trble_attr_handle *)param.param[0];
@@ -519,9 +485,7 @@ int bledev_handle(struct bledev *dev, lwnl_req cmd, void *data, uint32_t data_le
 		trble_data *buf = NULL;
 
 		lwnl_msg_params param = { 0, };
-		if (data != NULL) {
-			_memcpy_safe(&param, sizeof(lwnl_msg_params), data, data_len);
-		} else {
+		if (_memcpy_safe(&param, sizeof(lwnl_msg_params), data, data_len) != 0) {
 			return TRBLE_INVALID_ARGS;
 		}
 		attr_handle = *(trble_attr_handle *)param.param[0];
@@ -537,9 +501,7 @@ int bledev_handle(struct bledev *dev, lwnl_req cmd, void *data, uint32_t data_le
 		uint8_t *indicate_count = NULL;
 		
 		lwnl_msg_params param = { 0, };
-		if (data != NULL) {
-			_memcpy_safe(&param, sizeof(lwnl_msg_params), data, data_len);
-		} else {
+		if (_memcpy_safe(&param, sizeof(lwnl_msg_params), data, data_len) != 0) {
 			return TRBLE_INVALID_ARGS;
 		}
 
@@ -555,9 +517,7 @@ int bledev_handle(struct bledev *dev, lwnl_req cmd, void *data, uint32_t data_le
 		trble_data *buf = NULL;
 
 		lwnl_msg_params param = { 0, };
-		if (data != NULL) {
-			_memcpy_safe(&param, sizeof(lwnl_msg_params), data, data_len);
-		} else {
+		if (_memcpy_safe(&param, sizeof(lwnl_msg_params), data, data_len) != 0) {
 			return TRBLE_INVALID_ARGS;
 		}
 		attr_handle = *(trble_attr_handle *)param.param[0];
@@ -572,9 +532,7 @@ int bledev_handle(struct bledev *dev, lwnl_req cmd, void *data, uint32_t data_le
 		trble_data *buf = NULL;
 
 		lwnl_msg_params param = { 0, };
-		if (data != NULL) {
-			_memcpy_safe(&param, sizeof(lwnl_msg_params), data, data_len);
-		} else {
+		if (_memcpy_safe(&param, sizeof(lwnl_msg_params), data, data_len) != 0) {
 			return TRBLE_INVALID_ARGS;
 		}
 		attr_handle = *(trble_attr_handle *)param.param[0];
@@ -589,9 +547,7 @@ int bledev_handle(struct bledev *dev, lwnl_req cmd, void *data, uint32_t data_le
 		uint8_t err_code = 0;
 
 		lwnl_msg_params param = { 0, };
-		if (data != NULL) {
-			_memcpy_safe(&param, sizeof(lwnl_msg_params), data, data_len);
-		} else {
+		if (_memcpy_safe(&param, sizeof(lwnl_msg_params), data, data_len) != 0) {
 			return TRBLE_INVALID_ARGS;
 		}
 		attr_handle = *(trble_attr_handle *)param.param[0];
@@ -605,9 +561,7 @@ int bledev_handle(struct bledev *dev, lwnl_req cmd, void *data, uint32_t data_le
 		trble_conn_handle *conn_handle;
 		trble_conn_param *conn_param;
 		lwnl_msg_params param = { 0, };
-		if (data != NULL) {
-			_memcpy_safe(&param, sizeof(lwnl_msg_params), data, data_len);
-		} else {
+		if (_memcpy_safe(&param, sizeof(lwnl_msg_params), data, data_len) != 0) {
 			return TRBLE_INVALID_ARGS;
 		}
 		conn_handle = (trble_conn_handle *)param.param[0];
@@ -634,9 +588,7 @@ int bledev_handle(struct bledev *dev, lwnl_req cmd, void *data, uint32_t data_le
 		uint8_t *bd_addr;
 
 		lwnl_msg_params param = { 0, };
-		if (data != NULL) {
-			_memcpy_safe(&param, sizeof(lwnl_msg_params), data, data_len);
-		} else {
+		if (_memcpy_safe(&param, sizeof(lwnl_msg_params), data, data_len) != 0) {
 			return TRBLE_INVALID_ARGS;
 		}
 		con_handle = *(trble_conn_handle *)param.param[0];
@@ -651,9 +603,7 @@ int bledev_handle(struct bledev *dev, lwnl_req cmd, void *data, uint32_t data_le
 		trble_conn_handle *con_handle;
 
 		lwnl_msg_params param = { 0, };
-		if (data != NULL) {
-			_memcpy_safe(&param, sizeof(lwnl_msg_params), data, data_len);
-		} else {
+		if (_memcpy_safe(&param, sizeof(lwnl_msg_params), data, data_len) != 0) {
 			return TRBLE_INVALID_ARGS;
 		}
 		bd_addr = (uint8_t *)param.param[0];
@@ -666,12 +616,10 @@ int bledev_handle(struct bledev *dev, lwnl_req cmd, void *data, uint32_t data_le
 	{
 		uint8_t* name;
 		lwnl_msg_params param = { 0, };
-		if (data != NULL) {
-			_memcpy_safe(&param, sizeof(lwnl_msg_params), data, data_len);
-			name = (uint8_t*)param.param[0];
-		} else {
+		if (_memcpy_safe(&param, sizeof(lwnl_msg_params), data, data_len) != 0) {
 			return TRBLE_INVALID_ARGS;
 		}
+		name = (uint8_t*)param.param[0];
 
 		TRBLE_DRV_CALL(ret, dev, set_gap_device_name, (dev, name));
 	}
@@ -724,9 +672,7 @@ int bledev_handle(struct bledev *dev, lwnl_req cmd, void *data, uint32_t data_le
 		trble_addr *addr;
 
 		lwnl_msg_params param = { 0, };
-		if (data != NULL) {
-			_memcpy_safe(&param, sizeof(lwnl_msg_params), data, data_len);
-		} else {
+		if (_memcpy_safe(&param, sizeof(lwnl_msg_params), data, data_len) != 0) {
 			return TRBLE_INVALID_ARGS;
 		}
 
@@ -759,10 +705,7 @@ int bledev_handle(struct bledev *dev, lwnl_req cmd, void *data, uint32_t data_le
 		uint8_t *type;
 
 		lwnl_msg_params param = { 0, };
-		if (data != NULL)
-		{
-			_memcpy_safe(&param, sizeof(lwnl_msg_params), data, data_len);
-		} else {
+		if (_memcpy_safe(&param, sizeof(lwnl_msg_params), data, data_len) != 0) {
 			return TRBLE_INVALID_ARGS;
 		}
 		adv_id = (uint8_t *)param.param[0];
@@ -808,9 +751,7 @@ int bledev_handle(struct bledev *dev, lwnl_req cmd, void *data, uint32_t data_le
 		uint32_t *primary_adv_interval;
 
 		lwnl_msg_params param = { 0, };
-		if (data != NULL) {
-			_memcpy_safe(&param, sizeof(lwnl_msg_params), data, data_len);
-		} else {
+		if (_memcpy_safe(&param, sizeof(lwnl_msg_params), data, data_len) != 0) {
 			return TRBLE_INVALID_ARGS;
 		}
 		adv_event_prop			 = *(uint8_t *)param.param[0];
@@ -836,9 +777,7 @@ int bledev_handle(struct bledev *dev, lwnl_req cmd, void *data, uint32_t data_le
 	case LWNL_REQ_BLE_SET_MULTI_ADV_DATA:
 	{
 		lwnl_msg_params param = { 0, };
-		if (data != NULL) {
-			_memcpy_safe(&param, sizeof(lwnl_msg_params), data, data_len);
-		} else {
+		if (_memcpy_safe(&param, sizeof(lwnl_msg_params), data, data_len) != 0) {
 			return TRBLE_INVALID_ARGS;
 		}
 		uint8_t adv_handle = *(uint8_t *)param.param[0];
@@ -850,9 +789,7 @@ int bledev_handle(struct bledev *dev, lwnl_req cmd, void *data, uint32_t data_le
 	case LWNL_REQ_BLE_SET_MULTI_RESP_DATA:
 	{
 		lwnl_msg_params param = { 0, };
-		if (data != NULL) {
-			_memcpy_safe(&param, sizeof(lwnl_msg_params), data, data_len);
-		} else {
+		if (_memcpy_safe(&param, sizeof(lwnl_msg_params), data, data_len) != 0) {
 			return TRBLE_INVALID_ARGS;
 		}
 		uint8_t adv_handle = *(uint8_t *)param.param[0];
@@ -868,9 +805,7 @@ int bledev_handle(struct bledev *dev, lwnl_req cmd, void *data, uint32_t data_le
 		trble_addr *addr;
 
 		lwnl_msg_params param = { 0, };
-		if (data != NULL) {
-			_memcpy_safe(&param, sizeof(lwnl_msg_params), data, data_len);
-		} else {
+		if (_memcpy_safe(&param, sizeof(lwnl_msg_params), data, data_len) != 0) {
 			return TRBLE_INVALID_ARGS;
 		}
 		adv_handle = *(uint8_t *)param.param[0];
@@ -885,9 +820,7 @@ int bledev_handle(struct bledev *dev, lwnl_req cmd, void *data, uint32_t data_le
 		unsigned int interval;
 
 		lwnl_msg_params param = { 0, };
-		if (data != NULL) {
-			_memcpy_safe(&param, sizeof(lwnl_msg_params), data, data_len);
-		} else {
+		if (_memcpy_safe(&param, sizeof(lwnl_msg_params), data, data_len) != 0) {
 			return TRBLE_INVALID_ARGS;
 		}
 		adv_handle = *(uint8_t *)param.param[0];
@@ -901,9 +834,7 @@ int bledev_handle(struct bledev *dev, lwnl_req cmd, void *data, uint32_t data_le
 		uint8_t txpower;
 
 		lwnl_msg_params param = { 0, };
-		if (data != NULL) {
-			_memcpy_safe(&param, sizeof(lwnl_msg_params), data, data_len);
-		} else {
+		if (_memcpy_safe(&param, sizeof(lwnl_msg_params), data, data_len) != 0) {
 			return TRBLE_INVALID_ARGS;
 		}
 		adv_handle = *(uint8_t *)param.param[0];
@@ -937,21 +868,17 @@ int bledev_handle(struct bledev *dev, lwnl_req cmd, void *data, uint32_t data_le
 	{
 		lwnl_msg_params param = { 0, };
 		trble_le_coc_init_config *t_le_coc = NULL;
-		if (data != NULL) {
-			_memcpy_safe(&param, sizeof(lwnl_msg_params), data, data_len);
-			t_le_coc = (trble_le_coc_init_config *)param.param[0];
-		} else {
+		if (_memcpy_safe(&param, sizeof(lwnl_msg_params), data, data_len) != 0) {
 			return TRBLE_INVALID_ARGS;
 		}
+		t_le_coc = (trble_le_coc_init_config *)param.param[0];
 		TRBLE_DRV_CALL(ret, dev, le_coc_init, (dev, t_le_coc));
 	}
 	break;
 	case LWNL_REQ_BLE_CMD_COC_REG_PSM:
 	{
 		lwnl_msg_params param = { 0, };
-		if (data != NULL) {
-			_memcpy_safe(&param, sizeof(lwnl_msg_params), data, data_len);
-		} else {
+		if (_memcpy_safe(&param, sizeof(lwnl_msg_params), data, data_len) != 0) {
 			return TRBLE_INVALID_ARGS;
 		}
 		uint8_t is_reg = *(uint8_t *)param.param[0];
@@ -962,9 +889,7 @@ int bledev_handle(struct bledev *dev, lwnl_req cmd, void *data, uint32_t data_le
 	case LWNL_REQ_BLE_CMD_COC_SET_PSM_SEC:
 	{
 		lwnl_msg_params param = { 0, };
-		if (data != NULL) {
-			_memcpy_safe(&param, sizeof(lwnl_msg_params), data, data_len);
-		} else {
+		if (_memcpy_safe(&param, sizeof(lwnl_msg_params), data, data_len) != 0) {
 			return TRBLE_INVALID_ARGS;
 		}
 		uint16_t le_psm = *(uint16_t *)param.param[0];
@@ -977,9 +902,7 @@ int bledev_handle(struct bledev *dev, lwnl_req cmd, void *data, uint32_t data_le
 	case LWNL_REQ_BLE_CMD_COC_SET_PARAM:
 	{
 		uint16_t value;
-		if (data != NULL) {
-			_memcpy_safe(&value, sizeof(uint16_t), data, data_len);
-		} else {
+		if (_memcpy_safe(&value, sizeof(uint16_t), data, data_len) != 0) {
 			return TRBLE_INVALID_ARGS;
 		}
 		TRBLE_DRV_CALL(ret, dev, coc_set_param, (dev, value));
@@ -988,9 +911,7 @@ int bledev_handle(struct bledev *dev, lwnl_req cmd, void *data, uint32_t data_le
 	case LWNL_REQ_BLE_CMD_COC_GET_PARAM:
 	{
 		lwnl_msg_params param = { 0, };
-		if (data != NULL) {
-			_memcpy_safe(&param, sizeof(lwnl_msg_params), data, data_len);
-		} else {
+		if (_memcpy_safe(&param, sizeof(lwnl_msg_params), data, data_len) != 0) {
 			return TRBLE_INVALID_ARGS;
 		}
 		uint8_t param_type = *(uint8_t *)param.param[0];
@@ -1002,9 +923,7 @@ int bledev_handle(struct bledev *dev, lwnl_req cmd, void *data, uint32_t data_le
 	case LWNL_REQ_BLE_CMD_COC_CONNECT:
 	{
 		lwnl_msg_params param = { 0, };
-		if (data != NULL) {
-			_memcpy_safe(&param, sizeof(lwnl_msg_params), data, data_len);
-		} else {
+		if (_memcpy_safe(&param, sizeof(lwnl_msg_params), data, data_len) != 0) {
 			return TRBLE_INVALID_ARGS;
 		}
 
@@ -1016,9 +935,7 @@ int bledev_handle(struct bledev *dev, lwnl_req cmd, void *data, uint32_t data_le
 	case LWNL_REQ_BLE_CMD_COC_DISCONNECT:
 	{
 		uint16_t cid;
-		if (data != NULL) {
-			_memcpy_safe(&cid, sizeof(uint16_t), data, data_len);
-		} else {
+		if (_memcpy_safe(&cid, sizeof(uint16_t), data, data_len) != 0) {
 			return TRBLE_INVALID_ARGS;
 		}
 
@@ -1028,9 +945,7 @@ int bledev_handle(struct bledev *dev, lwnl_req cmd, void *data, uint32_t data_le
 	case LWNL_REQ_BLE_CMD_COC_SEND:
 	{
 		lwnl_msg_params param = { 0, };
-		if (data != NULL) {
-			_memcpy_safe(&param, sizeof(lwnl_msg_params), data, data_len);
-		} else {
+		if (_memcpy_safe(&param, sizeof(lwnl_msg_params), data, data_len) != 0) {
 			return TRBLE_INVALID_ARGS;
 		}
 		uint16_t cid = *(uint8_t *)param.param[0];

--- a/os/net/blemgr/bledev.c
+++ b/os/net/blemgr/bledev.c
@@ -269,7 +269,6 @@ int bledev_handle(struct bledev *dev, lwnl_req cmd, void *data, uint32_t data_le
 	break;
 	case LWNL_REQ_BLE_START_SCAN:
 	{
-		/* filter can be NULL */
 		lwnl_msg_params param = { 0, };
 		trble_scan_filter *filter = NULL;
 		if (_copy_lwnl_msg_params(&param, data, data_len, 1, 0) != 0) {
@@ -287,12 +286,18 @@ int bledev_handle(struct bledev *dev, lwnl_req cmd, void *data, uint32_t data_le
 	case LWNL_REQ_BLE_WHITELIST_ADD:
 	{
 		trble_addr *addr = (trble_addr *)data;
+		if (addr == NULL) {
+			return TRBLE_INVALID_ARGS;
+		}
 		TRBLE_DRV_CALL(ret, dev, whitelist_add, (dev, addr));
 	}
 	break;
 	case LWNL_REQ_BLE_WHITELIST_DELETE:
 	{
 		trble_addr *addr = (trble_addr *)data;
+		if (addr == NULL) {
+			return TRBLE_INVALID_ARGS;
+		}
 		TRBLE_DRV_CALL(ret, dev, whitelist_delete, (dev, addr));
 	}
 	break;

--- a/os/net/blemgr/bledev.c
+++ b/os/net/blemgr/bledev.c
@@ -81,6 +81,25 @@ static int _memcpy_safe(void *dest, size_t dest_size, const void *src, size_t sr
 	return 0;
 }
 
+static int _copy_lwnl_msg_params(lwnl_msg_params *dest, const void *src, size_t src_size, uint8_t nullable_param)
+{
+	uint8_t i;
+
+	if (_memcpy_safe(dest, sizeof(lwnl_msg_params), src, src_size) != 0) {
+		return -1;
+	}
+	if (dest->count == 0 || dest->count > LWNL_MAX_PARAM) {
+		return -1;
+	}
+
+	for (i = 0; i < dest->count; i++) {
+		if ((nullable_param & (1U << i)) == 0 && dest->param[i] == NULL) {
+			return -1;
+		}
+	}
+	return 0;
+}
+
 int bledev_handle(struct bledev *dev, lwnl_req cmd, void *data, uint32_t data_len)
 {
 	trble_result_e ret = TRBLE_FAIL;
@@ -91,7 +110,7 @@ int bledev_handle(struct bledev *dev, lwnl_req cmd, void *data, uint32_t data_le
 	case LWNL_REQ_BLE_INIT:
 	{
 		lwnl_msg_params param = { 0, };
-		if (_memcpy_safe(&param, sizeof(lwnl_msg_params), data, data_len) != 0) {
+		if (_copy_lwnl_msg_params(&param, data, data_len, 1U << 0) != 0) {
 			return TRBLE_INVALID_ARGS;
 		}
 
@@ -141,7 +160,7 @@ int bledev_handle(struct bledev *dev, lwnl_req cmd, void *data, uint32_t data_le
 		uint8_t *conn_handle = 0;
 		uint8_t *confirm = 0;
 		lwnl_msg_params param = { 0, };
-		if (_memcpy_safe(&param, sizeof(lwnl_msg_params), data, data_len) != 0) {
+		if (_copy_lwnl_msg_params(&param, data, data_len, 0) != 0) {
 			return TRBLE_INVALID_ARGS;
 		}
 		conn_handle = (uint8_t *)param.param[0];
@@ -166,7 +185,7 @@ int bledev_handle(struct bledev *dev, lwnl_req cmd, void *data, uint32_t data_le
 		uint16_t *device_count = NULL;
 
 		lwnl_msg_params param = { 0, };
-		if (_memcpy_safe(&param, sizeof(lwnl_msg_params), data, data_len) != 0) {
+		if (_copy_lwnl_msg_params(&param, data, data_len, 0) != 0) {
 			return TRBLE_INVALID_ARGS;
 		}
 		device_list = (trble_bonded_device_list_s *)param.param[0];
@@ -199,7 +218,7 @@ int bledev_handle(struct bledev *dev, lwnl_req cmd, void *data, uint32_t data_le
 		trble_conn_handle con_handle = 0;
 
 		lwnl_msg_params param = { 0, };
-		if (_memcpy_safe(&param, sizeof(lwnl_msg_params), data, data_len) != 0) {
+		if (_copy_lwnl_msg_params(&param, data, data_len, 0) != 0) {
 			return TRBLE_INVALID_ARGS;
 		}
 		con_handle = *(trble_conn_handle *)param.param[0];
@@ -212,7 +231,7 @@ int bledev_handle(struct bledev *dev, lwnl_req cmd, void *data, uint32_t data_le
 	{
 		bool *is_active = NULL;
 		lwnl_msg_params param = { 0, };
-		if (_memcpy_safe(&param, sizeof(lwnl_msg_params), data, data_len) != 0) {
+		if (_copy_lwnl_msg_params(&param, data, data_len, 0) != 0) {
 			return TRBLE_INVALID_ARGS;
 		}
 		is_active = (bool *)param.param[0];
@@ -239,7 +258,7 @@ int bledev_handle(struct bledev *dev, lwnl_req cmd, void *data, uint32_t data_le
 		trble_scan_type scan_type = 0;
 		
 		lwnl_msg_params param = { 0, };
-		if (_memcpy_safe(&param, sizeof(lwnl_msg_params), data, data_len) != 0) {
+		if (_copy_lwnl_msg_params(&param, data, data_len, 0) != 0) {
 			return TRBLE_INVALID_ARGS;
 		}
 		scan_interval = *(uint16_t *)param.param[0];
@@ -253,7 +272,7 @@ int bledev_handle(struct bledev *dev, lwnl_req cmd, void *data, uint32_t data_le
 		/* filter can be NULL */
 		lwnl_msg_params param = { 0, };
 		trble_scan_filter *filter = NULL;
-		if (_memcpy_safe(&param, sizeof(lwnl_msg_params), data, data_len) != 0) {
+		if (_copy_lwnl_msg_params(&param, data, data_len, 0) != 0) {
 			return TRBLE_INVALID_ARGS;
 		}
 		filter = (trble_scan_filter *)param.param[0];
@@ -288,7 +307,7 @@ int bledev_handle(struct bledev *dev, lwnl_req cmd, void *data, uint32_t data_le
 	{
 		lwnl_msg_params param = { 0, };
 		trble_conn_info *conn_info = NULL;
-		if (_memcpy_safe(&param, sizeof(lwnl_msg_params), data, data_len) != 0) {
+		if (_copy_lwnl_msg_params(&param, data, data_len, 0) != 0) {
 			return TRBLE_INVALID_ARGS;
 		}
 		conn_info = (trble_conn_info *)param.param[0];
@@ -317,7 +336,7 @@ int bledev_handle(struct bledev *dev, lwnl_req cmd, void *data, uint32_t data_le
 	{
 		trble_connected_list *list = NULL;
 		lwnl_msg_params param = { 0, };
-		if (_memcpy_safe(&param, sizeof(lwnl_msg_params), data, data_len) != 0) {
+		if (_copy_lwnl_msg_params(&param, data, data_len, 0) != 0) {
 			return TRBLE_INVALID_ARGS;
 		}
 		list = (trble_connected_list *)param.param[0];
@@ -330,7 +349,7 @@ int bledev_handle(struct bledev *dev, lwnl_req cmd, void *data, uint32_t data_le
 		trble_conn_handle handle;
 
 		lwnl_msg_params param = { 0, };
-		if (_memcpy_safe(&param, sizeof(lwnl_msg_params), data, data_len) != 0) {
+		if (_copy_lwnl_msg_params(&param, data, data_len, 0) != 0) {
 			return TRBLE_INVALID_ARGS;
 		}
 		handle = *(trble_conn_handle *)param.param[0];
@@ -383,7 +402,7 @@ int bledev_handle(struct bledev *dev, lwnl_req cmd, void *data, uint32_t data_le
 		trble_data *buf = NULL;
 
 		lwnl_msg_params param = { 0, };
-		if (_memcpy_safe(&param, sizeof(lwnl_msg_params), data, data_len) != 0) {
+		if (_copy_lwnl_msg_params(&param, data, data_len, 0) != 0) {
 			return TRBLE_INVALID_ARGS;
 		}
 		handle = (trble_operation_handle *)param.param[0];
@@ -398,7 +417,7 @@ int bledev_handle(struct bledev *dev, lwnl_req cmd, void *data, uint32_t data_le
 		trble_data *buf = NULL;
 
 		lwnl_msg_params param = { 0, };
-		if (_memcpy_safe(&param, sizeof(lwnl_msg_params), data, data_len) != 0) {
+		if (_copy_lwnl_msg_params(&param, data, data_len, 0) != 0) {
 			return TRBLE_INVALID_ARGS;
 		}
 		handle = (trble_operation_handle *)param.param[0];
@@ -413,7 +432,7 @@ int bledev_handle(struct bledev *dev, lwnl_req cmd, void *data, uint32_t data_le
 		trble_data *buf = NULL;
 
 		lwnl_msg_params param = { 0, };
-		if (_memcpy_safe(&param, sizeof(lwnl_msg_params), data, data_len) != 0) {
+		if (_copy_lwnl_msg_params(&param, data, data_len, 0) != 0) {
 			return TRBLE_INVALID_ARGS;
 		}
 		handle = (trble_operation_handle *)param.param[0];
@@ -428,7 +447,7 @@ int bledev_handle(struct bledev *dev, lwnl_req cmd, void *data, uint32_t data_le
 		uint8_t *count = NULL;
 
 		lwnl_msg_params param = { 0, };
-		if (_memcpy_safe(&param, sizeof(lwnl_msg_params), data, data_len) != 0) {
+		if (_copy_lwnl_msg_params(&param, data, data_len, 0) != 0) {
 			return TRBLE_INVALID_ARGS;
 		}
 		handle = (trble_operation_handle *)param.param[0];
@@ -443,7 +462,7 @@ int bledev_handle(struct bledev *dev, lwnl_req cmd, void *data, uint32_t data_le
 	{
 		trble_server_init_config *t_server = NULL;
 		lwnl_msg_params param = { 0, };
-		if (_memcpy_safe(&param, sizeof(lwnl_msg_params), data, data_len) != 0) {
+		if (_copy_lwnl_msg_params(&param, data, data_len, 0) != 0) {
 			return TRBLE_INVALID_ARGS;
 		}
 		t_server = (trble_server_init_config *)param.param[0];
@@ -454,7 +473,7 @@ int bledev_handle(struct bledev *dev, lwnl_req cmd, void *data, uint32_t data_le
 	{
 		uint16_t *count = NULL;
 		lwnl_msg_params param = { 0, };
-		if (_memcpy_safe(&param, sizeof(lwnl_msg_params), data, data_len) != 0) {
+		if (_copy_lwnl_msg_params(&param, data, data_len, 0) != 0) {
 			return TRBLE_INVALID_ARGS;
 		}
 		count = (uint16_t *)param.param[0];
@@ -468,7 +487,7 @@ int bledev_handle(struct bledev *dev, lwnl_req cmd, void *data, uint32_t data_le
 		trble_data *buf = NULL;
 
 		lwnl_msg_params param = { 0, };
-		if (_memcpy_safe(&param, sizeof(lwnl_msg_params), data, data_len) != 0) {
+		if (_copy_lwnl_msg_params(&param, data, data_len, 0) != 0) {
 			return TRBLE_INVALID_ARGS;
 		}
 		attr_handle = *(trble_attr_handle *)param.param[0];
@@ -485,7 +504,7 @@ int bledev_handle(struct bledev *dev, lwnl_req cmd, void *data, uint32_t data_le
 		trble_data *buf = NULL;
 
 		lwnl_msg_params param = { 0, };
-		if (_memcpy_safe(&param, sizeof(lwnl_msg_params), data, data_len) != 0) {
+		if (_copy_lwnl_msg_params(&param, data, data_len, 0) != 0) {
 			return TRBLE_INVALID_ARGS;
 		}
 		attr_handle = *(trble_attr_handle *)param.param[0];
@@ -501,7 +520,7 @@ int bledev_handle(struct bledev *dev, lwnl_req cmd, void *data, uint32_t data_le
 		uint8_t *indicate_count = NULL;
 		
 		lwnl_msg_params param = { 0, };
-		if (_memcpy_safe(&param, sizeof(lwnl_msg_params), data, data_len) != 0) {
+		if (_copy_lwnl_msg_params(&param, data, data_len, 0) != 0) {
 			return TRBLE_INVALID_ARGS;
 		}
 
@@ -517,7 +536,7 @@ int bledev_handle(struct bledev *dev, lwnl_req cmd, void *data, uint32_t data_le
 		trble_data *buf = NULL;
 
 		lwnl_msg_params param = { 0, };
-		if (_memcpy_safe(&param, sizeof(lwnl_msg_params), data, data_len) != 0) {
+		if (_copy_lwnl_msg_params(&param, data, data_len, 0) != 0) {
 			return TRBLE_INVALID_ARGS;
 		}
 		attr_handle = *(trble_attr_handle *)param.param[0];
@@ -532,7 +551,7 @@ int bledev_handle(struct bledev *dev, lwnl_req cmd, void *data, uint32_t data_le
 		trble_data *buf = NULL;
 
 		lwnl_msg_params param = { 0, };
-		if (_memcpy_safe(&param, sizeof(lwnl_msg_params), data, data_len) != 0) {
+		if (_copy_lwnl_msg_params(&param, data, data_len, 0) != 0) {
 			return TRBLE_INVALID_ARGS;
 		}
 		attr_handle = *(trble_attr_handle *)param.param[0];
@@ -547,7 +566,7 @@ int bledev_handle(struct bledev *dev, lwnl_req cmd, void *data, uint32_t data_le
 		uint8_t err_code = 0;
 
 		lwnl_msg_params param = { 0, };
-		if (_memcpy_safe(&param, sizeof(lwnl_msg_params), data, data_len) != 0) {
+		if (_copy_lwnl_msg_params(&param, data, data_len, 0) != 0) {
 			return TRBLE_INVALID_ARGS;
 		}
 		attr_handle = *(trble_attr_handle *)param.param[0];
@@ -561,7 +580,7 @@ int bledev_handle(struct bledev *dev, lwnl_req cmd, void *data, uint32_t data_le
 		trble_conn_handle *conn_handle;
 		trble_conn_param *conn_param;
 		lwnl_msg_params param = { 0, };
-		if (_memcpy_safe(&param, sizeof(lwnl_msg_params), data, data_len) != 0) {
+		if (_copy_lwnl_msg_params(&param, data, data_len, 0) != 0) {
 			return TRBLE_INVALID_ARGS;
 		}
 		conn_handle = (trble_conn_handle *)param.param[0];
@@ -588,7 +607,7 @@ int bledev_handle(struct bledev *dev, lwnl_req cmd, void *data, uint32_t data_le
 		uint8_t *bd_addr;
 
 		lwnl_msg_params param = { 0, };
-		if (_memcpy_safe(&param, sizeof(lwnl_msg_params), data, data_len) != 0) {
+		if (_copy_lwnl_msg_params(&param, data, data_len, 0) != 0) {
 			return TRBLE_INVALID_ARGS;
 		}
 		con_handle = *(trble_conn_handle *)param.param[0];
@@ -603,7 +622,7 @@ int bledev_handle(struct bledev *dev, lwnl_req cmd, void *data, uint32_t data_le
 		trble_conn_handle *con_handle;
 
 		lwnl_msg_params param = { 0, };
-		if (_memcpy_safe(&param, sizeof(lwnl_msg_params), data, data_len) != 0) {
+		if (_copy_lwnl_msg_params(&param, data, data_len, 0) != 0) {
 			return TRBLE_INVALID_ARGS;
 		}
 		bd_addr = (uint8_t *)param.param[0];
@@ -616,7 +635,7 @@ int bledev_handle(struct bledev *dev, lwnl_req cmd, void *data, uint32_t data_le
 	{
 		uint8_t* name;
 		lwnl_msg_params param = { 0, };
-		if (_memcpy_safe(&param, sizeof(lwnl_msg_params), data, data_len) != 0) {
+		if (_copy_lwnl_msg_params(&param, data, data_len, 0) != 0) {
 			return TRBLE_INVALID_ARGS;
 		}
 		name = (uint8_t*)param.param[0];
@@ -672,7 +691,7 @@ int bledev_handle(struct bledev *dev, lwnl_req cmd, void *data, uint32_t data_le
 		trble_addr *addr;
 
 		lwnl_msg_params param = { 0, };
-		if (_memcpy_safe(&param, sizeof(lwnl_msg_params), data, data_len) != 0) {
+		if (_copy_lwnl_msg_params(&param, data, data_len, 0) != 0) {
 			return TRBLE_INVALID_ARGS;
 		}
 
@@ -705,7 +724,7 @@ int bledev_handle(struct bledev *dev, lwnl_req cmd, void *data, uint32_t data_le
 		uint8_t *type;
 
 		lwnl_msg_params param = { 0, };
-		if (_memcpy_safe(&param, sizeof(lwnl_msg_params), data, data_len) != 0) {
+		if (_copy_lwnl_msg_params(&param, data, data_len, 0) != 0) {
 			return TRBLE_INVALID_ARGS;
 		}
 		adv_id = (uint8_t *)param.param[0];
@@ -751,7 +770,7 @@ int bledev_handle(struct bledev *dev, lwnl_req cmd, void *data, uint32_t data_le
 		uint32_t *primary_adv_interval;
 
 		lwnl_msg_params param = { 0, };
-		if (_memcpy_safe(&param, sizeof(lwnl_msg_params), data, data_len) != 0) {
+		if (_copy_lwnl_msg_params(&param, data, data_len, 0) != 0) {
 			return TRBLE_INVALID_ARGS;
 		}
 		adv_event_prop			 = *(uint8_t *)param.param[0];
@@ -777,7 +796,7 @@ int bledev_handle(struct bledev *dev, lwnl_req cmd, void *data, uint32_t data_le
 	case LWNL_REQ_BLE_SET_MULTI_ADV_DATA:
 	{
 		lwnl_msg_params param = { 0, };
-		if (_memcpy_safe(&param, sizeof(lwnl_msg_params), data, data_len) != 0) {
+		if (_copy_lwnl_msg_params(&param, data, data_len, 0) != 0) {
 			return TRBLE_INVALID_ARGS;
 		}
 		uint8_t adv_handle = *(uint8_t *)param.param[0];
@@ -789,7 +808,7 @@ int bledev_handle(struct bledev *dev, lwnl_req cmd, void *data, uint32_t data_le
 	case LWNL_REQ_BLE_SET_MULTI_RESP_DATA:
 	{
 		lwnl_msg_params param = { 0, };
-		if (_memcpy_safe(&param, sizeof(lwnl_msg_params), data, data_len) != 0) {
+		if (_copy_lwnl_msg_params(&param, data, data_len, 0) != 0) {
 			return TRBLE_INVALID_ARGS;
 		}
 		uint8_t adv_handle = *(uint8_t *)param.param[0];
@@ -805,7 +824,7 @@ int bledev_handle(struct bledev *dev, lwnl_req cmd, void *data, uint32_t data_le
 		trble_addr *addr;
 
 		lwnl_msg_params param = { 0, };
-		if (_memcpy_safe(&param, sizeof(lwnl_msg_params), data, data_len) != 0) {
+		if (_copy_lwnl_msg_params(&param, data, data_len, 0) != 0) {
 			return TRBLE_INVALID_ARGS;
 		}
 		adv_handle = *(uint8_t *)param.param[0];
@@ -820,7 +839,7 @@ int bledev_handle(struct bledev *dev, lwnl_req cmd, void *data, uint32_t data_le
 		unsigned int interval;
 
 		lwnl_msg_params param = { 0, };
-		if (_memcpy_safe(&param, sizeof(lwnl_msg_params), data, data_len) != 0) {
+		if (_copy_lwnl_msg_params(&param, data, data_len, 0) != 0) {
 			return TRBLE_INVALID_ARGS;
 		}
 		adv_handle = *(uint8_t *)param.param[0];
@@ -834,7 +853,7 @@ int bledev_handle(struct bledev *dev, lwnl_req cmd, void *data, uint32_t data_le
 		uint8_t txpower;
 
 		lwnl_msg_params param = { 0, };
-		if (_memcpy_safe(&param, sizeof(lwnl_msg_params), data, data_len) != 0) {
+		if (_copy_lwnl_msg_params(&param, data, data_len, 0) != 0) {
 			return TRBLE_INVALID_ARGS;
 		}
 		adv_handle = *(uint8_t *)param.param[0];
@@ -868,7 +887,7 @@ int bledev_handle(struct bledev *dev, lwnl_req cmd, void *data, uint32_t data_le
 	{
 		lwnl_msg_params param = { 0, };
 		trble_le_coc_init_config *t_le_coc = NULL;
-		if (_memcpy_safe(&param, sizeof(lwnl_msg_params), data, data_len) != 0) {
+		if (_copy_lwnl_msg_params(&param, data, data_len, 0) != 0) {
 			return TRBLE_INVALID_ARGS;
 		}
 		t_le_coc = (trble_le_coc_init_config *)param.param[0];
@@ -878,7 +897,7 @@ int bledev_handle(struct bledev *dev, lwnl_req cmd, void *data, uint32_t data_le
 	case LWNL_REQ_BLE_CMD_COC_REG_PSM:
 	{
 		lwnl_msg_params param = { 0, };
-		if (_memcpy_safe(&param, sizeof(lwnl_msg_params), data, data_len) != 0) {
+		if (_copy_lwnl_msg_params(&param, data, data_len, 0) != 0) {
 			return TRBLE_INVALID_ARGS;
 		}
 		uint8_t is_reg = *(uint8_t *)param.param[0];
@@ -889,7 +908,7 @@ int bledev_handle(struct bledev *dev, lwnl_req cmd, void *data, uint32_t data_le
 	case LWNL_REQ_BLE_CMD_COC_SET_PSM_SEC:
 	{
 		lwnl_msg_params param = { 0, };
-		if (_memcpy_safe(&param, sizeof(lwnl_msg_params), data, data_len) != 0) {
+		if (_copy_lwnl_msg_params(&param, data, data_len, 0) != 0) {
 			return TRBLE_INVALID_ARGS;
 		}
 		uint16_t le_psm = *(uint16_t *)param.param[0];
@@ -911,7 +930,7 @@ int bledev_handle(struct bledev *dev, lwnl_req cmd, void *data, uint32_t data_le
 	case LWNL_REQ_BLE_CMD_COC_GET_PARAM:
 	{
 		lwnl_msg_params param = { 0, };
-		if (_memcpy_safe(&param, sizeof(lwnl_msg_params), data, data_len) != 0) {
+		if (_copy_lwnl_msg_params(&param, data, data_len, 0) != 0) {
 			return TRBLE_INVALID_ARGS;
 		}
 		uint8_t param_type = *(uint8_t *)param.param[0];
@@ -923,7 +942,7 @@ int bledev_handle(struct bledev *dev, lwnl_req cmd, void *data, uint32_t data_le
 	case LWNL_REQ_BLE_CMD_COC_CONNECT:
 	{
 		lwnl_msg_params param = { 0, };
-		if (_memcpy_safe(&param, sizeof(lwnl_msg_params), data, data_len) != 0) {
+		if (_copy_lwnl_msg_params(&param, data, data_len, 0) != 0) {
 			return TRBLE_INVALID_ARGS;
 		}
 
@@ -945,7 +964,7 @@ int bledev_handle(struct bledev *dev, lwnl_req cmd, void *data, uint32_t data_le
 	case LWNL_REQ_BLE_CMD_COC_SEND:
 	{
 		lwnl_msg_params param = { 0, };
-		if (_memcpy_safe(&param, sizeof(lwnl_msg_params), data, data_len) != 0) {
+		if (_copy_lwnl_msg_params(&param, data, data_len, 0) != 0) {
 			return TRBLE_INVALID_ARGS;
 		}
 		uint16_t cid = *(uint8_t *)param.param[0];

--- a/os/net/blemgr/bledev.c
+++ b/os/net/blemgr/bledev.c
@@ -81,18 +81,18 @@ static int _memcpy_safe(void *dest, size_t dest_size, const void *src, size_t sr
 	return 0;
 }
 
-static int _copy_lwnl_msg_params(lwnl_msg_params *dest, const void *src, size_t src_size, uint8_t nullable_param)
+static int _copy_lwnl_msg_params(lwnl_msg_params *dest, const void *src, size_t src_size, uint8_t expected_count, uint8_t nullable_param)
 {
 	uint8_t i;
 
 	if (_memcpy_safe(dest, sizeof(lwnl_msg_params), src, src_size) != 0) {
 		return -1;
 	}
-	if (dest->count == 0 || dest->count > LWNL_MAX_PARAM) {
+	if (expected_count == 0 || expected_count > LWNL_MAX_PARAM || dest->count != expected_count) {
 		return -1;
 	}
 
-	for (i = 0; i < dest->count; i++) {
+	for (i = 0; i < expected_count; i++) {
 		if ((nullable_param & (1U << i)) == 0 && dest->param[i] == NULL) {
 			return -1;
 		}
@@ -110,7 +110,7 @@ int bledev_handle(struct bledev *dev, lwnl_req cmd, void *data, uint32_t data_le
 	case LWNL_REQ_BLE_INIT:
 	{
 		lwnl_msg_params param = { 0, };
-		if (_copy_lwnl_msg_params(&param, data, data_len, 1U << 0) != 0) {
+		if (_copy_lwnl_msg_params(&param, data, data_len, 2, 1U << 0) != 0) {
 			return TRBLE_INVALID_ARGS;
 		}
 
@@ -160,7 +160,7 @@ int bledev_handle(struct bledev *dev, lwnl_req cmd, void *data, uint32_t data_le
 		uint8_t *conn_handle = 0;
 		uint8_t *confirm = 0;
 		lwnl_msg_params param = { 0, };
-		if (_copy_lwnl_msg_params(&param, data, data_len, 0) != 0) {
+		if (_copy_lwnl_msg_params(&param, data, data_len, 2, 0) != 0) {
 			return TRBLE_INVALID_ARGS;
 		}
 		conn_handle = (uint8_t *)param.param[0];
@@ -185,7 +185,7 @@ int bledev_handle(struct bledev *dev, lwnl_req cmd, void *data, uint32_t data_le
 		uint16_t *device_count = NULL;
 
 		lwnl_msg_params param = { 0, };
-		if (_copy_lwnl_msg_params(&param, data, data_len, 0) != 0) {
+		if (_copy_lwnl_msg_params(&param, data, data_len, 2, 0) != 0) {
 			return TRBLE_INVALID_ARGS;
 		}
 		device_list = (trble_bonded_device_list_s *)param.param[0];
@@ -218,7 +218,7 @@ int bledev_handle(struct bledev *dev, lwnl_req cmd, void *data, uint32_t data_le
 		trble_conn_handle con_handle = 0;
 
 		lwnl_msg_params param = { 0, };
-		if (_copy_lwnl_msg_params(&param, data, data_len, 0) != 0) {
+		if (_copy_lwnl_msg_params(&param, data, data_len, 2, 0) != 0) {
 			return TRBLE_INVALID_ARGS;
 		}
 		con_handle = *(trble_conn_handle *)param.param[0];
@@ -231,7 +231,7 @@ int bledev_handle(struct bledev *dev, lwnl_req cmd, void *data, uint32_t data_le
 	{
 		bool *is_active = NULL;
 		lwnl_msg_params param = { 0, };
-		if (_copy_lwnl_msg_params(&param, data, data_len, 0) != 0) {
+		if (_copy_lwnl_msg_params(&param, data, data_len, 1, 0) != 0) {
 			return TRBLE_INVALID_ARGS;
 		}
 		is_active = (bool *)param.param[0];
@@ -258,7 +258,7 @@ int bledev_handle(struct bledev *dev, lwnl_req cmd, void *data, uint32_t data_le
 		trble_scan_type scan_type = 0;
 		
 		lwnl_msg_params param = { 0, };
-		if (_copy_lwnl_msg_params(&param, data, data_len, 0) != 0) {
+		if (_copy_lwnl_msg_params(&param, data, data_len, 3, 0) != 0) {
 			return TRBLE_INVALID_ARGS;
 		}
 		scan_interval = *(uint16_t *)param.param[0];
@@ -272,7 +272,7 @@ int bledev_handle(struct bledev *dev, lwnl_req cmd, void *data, uint32_t data_le
 		/* filter can be NULL */
 		lwnl_msg_params param = { 0, };
 		trble_scan_filter *filter = NULL;
-		if (_copy_lwnl_msg_params(&param, data, data_len, 0) != 0) {
+		if (_copy_lwnl_msg_params(&param, data, data_len, 1, 0) != 0) {
 			return TRBLE_INVALID_ARGS;
 		}
 		filter = (trble_scan_filter *)param.param[0];
@@ -307,7 +307,7 @@ int bledev_handle(struct bledev *dev, lwnl_req cmd, void *data, uint32_t data_le
 	{
 		lwnl_msg_params param = { 0, };
 		trble_conn_info *conn_info = NULL;
-		if (_copy_lwnl_msg_params(&param, data, data_len, 0) != 0) {
+		if (_copy_lwnl_msg_params(&param, data, data_len, 1, 0) != 0) {
 			return TRBLE_INVALID_ARGS;
 		}
 		conn_info = (trble_conn_info *)param.param[0];
@@ -336,7 +336,7 @@ int bledev_handle(struct bledev *dev, lwnl_req cmd, void *data, uint32_t data_le
 	{
 		trble_connected_list *list = NULL;
 		lwnl_msg_params param = { 0, };
-		if (_copy_lwnl_msg_params(&param, data, data_len, 0) != 0) {
+		if (_copy_lwnl_msg_params(&param, data, data_len, 1, 0) != 0) {
 			return TRBLE_INVALID_ARGS;
 		}
 		list = (trble_connected_list *)param.param[0];
@@ -349,7 +349,7 @@ int bledev_handle(struct bledev *dev, lwnl_req cmd, void *data, uint32_t data_le
 		trble_conn_handle handle;
 
 		lwnl_msg_params param = { 0, };
-		if (_copy_lwnl_msg_params(&param, data, data_len, 0) != 0) {
+		if (_copy_lwnl_msg_params(&param, data, data_len, 2, 0) != 0) {
 			return TRBLE_INVALID_ARGS;
 		}
 		handle = *(trble_conn_handle *)param.param[0];
@@ -402,7 +402,7 @@ int bledev_handle(struct bledev *dev, lwnl_req cmd, void *data, uint32_t data_le
 		trble_data *buf = NULL;
 
 		lwnl_msg_params param = { 0, };
-		if (_copy_lwnl_msg_params(&param, data, data_len, 0) != 0) {
+		if (_copy_lwnl_msg_params(&param, data, data_len, 2, 0) != 0) {
 			return TRBLE_INVALID_ARGS;
 		}
 		handle = (trble_operation_handle *)param.param[0];
@@ -417,7 +417,7 @@ int bledev_handle(struct bledev *dev, lwnl_req cmd, void *data, uint32_t data_le
 		trble_data *buf = NULL;
 
 		lwnl_msg_params param = { 0, };
-		if (_copy_lwnl_msg_params(&param, data, data_len, 0) != 0) {
+		if (_copy_lwnl_msg_params(&param, data, data_len, 2, 0) != 0) {
 			return TRBLE_INVALID_ARGS;
 		}
 		handle = (trble_operation_handle *)param.param[0];
@@ -432,7 +432,7 @@ int bledev_handle(struct bledev *dev, lwnl_req cmd, void *data, uint32_t data_le
 		trble_data *buf = NULL;
 
 		lwnl_msg_params param = { 0, };
-		if (_copy_lwnl_msg_params(&param, data, data_len, 0) != 0) {
+		if (_copy_lwnl_msg_params(&param, data, data_len, 2, 0) != 0) {
 			return TRBLE_INVALID_ARGS;
 		}
 		handle = (trble_operation_handle *)param.param[0];
@@ -447,7 +447,7 @@ int bledev_handle(struct bledev *dev, lwnl_req cmd, void *data, uint32_t data_le
 		uint8_t *count = NULL;
 
 		lwnl_msg_params param = { 0, };
-		if (_copy_lwnl_msg_params(&param, data, data_len, 0) != 0) {
+		if (_copy_lwnl_msg_params(&param, data, data_len, 2, 0) != 0) {
 			return TRBLE_INVALID_ARGS;
 		}
 		handle = (trble_operation_handle *)param.param[0];
@@ -462,7 +462,7 @@ int bledev_handle(struct bledev *dev, lwnl_req cmd, void *data, uint32_t data_le
 	{
 		trble_server_init_config *t_server = NULL;
 		lwnl_msg_params param = { 0, };
-		if (_copy_lwnl_msg_params(&param, data, data_len, 0) != 0) {
+		if (_copy_lwnl_msg_params(&param, data, data_len, 1, 0) != 0) {
 			return TRBLE_INVALID_ARGS;
 		}
 		t_server = (trble_server_init_config *)param.param[0];
@@ -473,7 +473,7 @@ int bledev_handle(struct bledev *dev, lwnl_req cmd, void *data, uint32_t data_le
 	{
 		uint16_t *count = NULL;
 		lwnl_msg_params param = { 0, };
-		if (_copy_lwnl_msg_params(&param, data, data_len, 0) != 0) {
+		if (_copy_lwnl_msg_params(&param, data, data_len, 1, 0) != 0) {
 			return TRBLE_INVALID_ARGS;
 		}
 		count = (uint16_t *)param.param[0];
@@ -487,7 +487,7 @@ int bledev_handle(struct bledev *dev, lwnl_req cmd, void *data, uint32_t data_le
 		trble_data *buf = NULL;
 
 		lwnl_msg_params param = { 0, };
-		if (_copy_lwnl_msg_params(&param, data, data_len, 0) != 0) {
+		if (_copy_lwnl_msg_params(&param, data, data_len, 3, 0) != 0) {
 			return TRBLE_INVALID_ARGS;
 		}
 		attr_handle = *(trble_attr_handle *)param.param[0];
@@ -504,7 +504,7 @@ int bledev_handle(struct bledev *dev, lwnl_req cmd, void *data, uint32_t data_le
 		trble_data *buf = NULL;
 
 		lwnl_msg_params param = { 0, };
-		if (_copy_lwnl_msg_params(&param, data, data_len, 0) != 0) {
+		if (_copy_lwnl_msg_params(&param, data, data_len, 3, 0) != 0) {
 			return TRBLE_INVALID_ARGS;
 		}
 		attr_handle = *(trble_attr_handle *)param.param[0];
@@ -520,7 +520,7 @@ int bledev_handle(struct bledev *dev, lwnl_req cmd, void *data, uint32_t data_le
 		uint8_t *indicate_count = NULL;
 		
 		lwnl_msg_params param = { 0, };
-		if (_copy_lwnl_msg_params(&param, data, data_len, 0) != 0) {
+		if (_copy_lwnl_msg_params(&param, data, data_len, 2, 0) != 0) {
 			return TRBLE_INVALID_ARGS;
 		}
 
@@ -536,7 +536,7 @@ int bledev_handle(struct bledev *dev, lwnl_req cmd, void *data, uint32_t data_le
 		trble_data *buf = NULL;
 
 		lwnl_msg_params param = { 0, };
-		if (_copy_lwnl_msg_params(&param, data, data_len, 0) != 0) {
+		if (_copy_lwnl_msg_params(&param, data, data_len, 2, 0) != 0) {
 			return TRBLE_INVALID_ARGS;
 		}
 		attr_handle = *(trble_attr_handle *)param.param[0];
@@ -551,7 +551,7 @@ int bledev_handle(struct bledev *dev, lwnl_req cmd, void *data, uint32_t data_le
 		trble_data *buf = NULL;
 
 		lwnl_msg_params param = { 0, };
-		if (_copy_lwnl_msg_params(&param, data, data_len, 0) != 0) {
+		if (_copy_lwnl_msg_params(&param, data, data_len, 2, 0) != 0) {
 			return TRBLE_INVALID_ARGS;
 		}
 		attr_handle = *(trble_attr_handle *)param.param[0];
@@ -566,7 +566,7 @@ int bledev_handle(struct bledev *dev, lwnl_req cmd, void *data, uint32_t data_le
 		uint8_t err_code = 0;
 
 		lwnl_msg_params param = { 0, };
-		if (_copy_lwnl_msg_params(&param, data, data_len, 0) != 0) {
+		if (_copy_lwnl_msg_params(&param, data, data_len, 2, 0) != 0) {
 			return TRBLE_INVALID_ARGS;
 		}
 		attr_handle = *(trble_attr_handle *)param.param[0];
@@ -580,7 +580,7 @@ int bledev_handle(struct bledev *dev, lwnl_req cmd, void *data, uint32_t data_le
 		trble_conn_handle *conn_handle;
 		trble_conn_param *conn_param;
 		lwnl_msg_params param = { 0, };
-		if (_copy_lwnl_msg_params(&param, data, data_len, 0) != 0) {
+		if (_copy_lwnl_msg_params(&param, data, data_len, 2, 0) != 0) {
 			return TRBLE_INVALID_ARGS;
 		}
 		conn_handle = (trble_conn_handle *)param.param[0];
@@ -607,7 +607,7 @@ int bledev_handle(struct bledev *dev, lwnl_req cmd, void *data, uint32_t data_le
 		uint8_t *bd_addr;
 
 		lwnl_msg_params param = { 0, };
-		if (_copy_lwnl_msg_params(&param, data, data_len, 0) != 0) {
+		if (_copy_lwnl_msg_params(&param, data, data_len, 2, 0) != 0) {
 			return TRBLE_INVALID_ARGS;
 		}
 		con_handle = *(trble_conn_handle *)param.param[0];
@@ -622,7 +622,7 @@ int bledev_handle(struct bledev *dev, lwnl_req cmd, void *data, uint32_t data_le
 		trble_conn_handle *con_handle;
 
 		lwnl_msg_params param = { 0, };
-		if (_copy_lwnl_msg_params(&param, data, data_len, 0) != 0) {
+		if (_copy_lwnl_msg_params(&param, data, data_len, 2, 0) != 0) {
 			return TRBLE_INVALID_ARGS;
 		}
 		bd_addr = (uint8_t *)param.param[0];
@@ -635,7 +635,7 @@ int bledev_handle(struct bledev *dev, lwnl_req cmd, void *data, uint32_t data_le
 	{
 		uint8_t* name;
 		lwnl_msg_params param = { 0, };
-		if (_copy_lwnl_msg_params(&param, data, data_len, 0) != 0) {
+		if (_copy_lwnl_msg_params(&param, data, data_len, 1, 0) != 0) {
 			return TRBLE_INVALID_ARGS;
 		}
 		name = (uint8_t*)param.param[0];
@@ -691,7 +691,7 @@ int bledev_handle(struct bledev *dev, lwnl_req cmd, void *data, uint32_t data_le
 		trble_addr *addr;
 
 		lwnl_msg_params param = { 0, };
-		if (_copy_lwnl_msg_params(&param, data, data_len, 0) != 0) {
+		if (_copy_lwnl_msg_params(&param, data, data_len, 2, 0) != 0) {
 			return TRBLE_INVALID_ARGS;
 		}
 
@@ -724,7 +724,7 @@ int bledev_handle(struct bledev *dev, lwnl_req cmd, void *data, uint32_t data_le
 		uint8_t *type;
 
 		lwnl_msg_params param = { 0, };
-		if (_copy_lwnl_msg_params(&param, data, data_len, 0) != 0) {
+		if (_copy_lwnl_msg_params(&param, data, data_len, 4, 0) != 0) {
 			return TRBLE_INVALID_ARGS;
 		}
 		adv_id = (uint8_t *)param.param[0];
@@ -770,7 +770,7 @@ int bledev_handle(struct bledev *dev, lwnl_req cmd, void *data, uint32_t data_le
 		uint32_t *primary_adv_interval;
 
 		lwnl_msg_params param = { 0, };
-		if (_copy_lwnl_msg_params(&param, data, data_len, 0) != 0) {
+		if (_copy_lwnl_msg_params(&param, data, data_len, 5, 0) != 0) {
 			return TRBLE_INVALID_ARGS;
 		}
 		adv_event_prop			 = *(uint8_t *)param.param[0];
@@ -796,7 +796,7 @@ int bledev_handle(struct bledev *dev, lwnl_req cmd, void *data, uint32_t data_le
 	case LWNL_REQ_BLE_SET_MULTI_ADV_DATA:
 	{
 		lwnl_msg_params param = { 0, };
-		if (_copy_lwnl_msg_params(&param, data, data_len, 0) != 0) {
+		if (_copy_lwnl_msg_params(&param, data, data_len, 3, 0) != 0) {
 			return TRBLE_INVALID_ARGS;
 		}
 		uint8_t adv_handle = *(uint8_t *)param.param[0];
@@ -808,7 +808,7 @@ int bledev_handle(struct bledev *dev, lwnl_req cmd, void *data, uint32_t data_le
 	case LWNL_REQ_BLE_SET_MULTI_RESP_DATA:
 	{
 		lwnl_msg_params param = { 0, };
-		if (_copy_lwnl_msg_params(&param, data, data_len, 0) != 0) {
+		if (_copy_lwnl_msg_params(&param, data, data_len, 3, 0) != 0) {
 			return TRBLE_INVALID_ARGS;
 		}
 		uint8_t adv_handle = *(uint8_t *)param.param[0];
@@ -824,7 +824,7 @@ int bledev_handle(struct bledev *dev, lwnl_req cmd, void *data, uint32_t data_le
 		trble_addr *addr;
 
 		lwnl_msg_params param = { 0, };
-		if (_copy_lwnl_msg_params(&param, data, data_len, 0) != 0) {
+		if (_copy_lwnl_msg_params(&param, data, data_len, 3, 0) != 0) {
 			return TRBLE_INVALID_ARGS;
 		}
 		adv_handle = *(uint8_t *)param.param[0];
@@ -839,7 +839,7 @@ int bledev_handle(struct bledev *dev, lwnl_req cmd, void *data, uint32_t data_le
 		unsigned int interval;
 
 		lwnl_msg_params param = { 0, };
-		if (_copy_lwnl_msg_params(&param, data, data_len, 0) != 0) {
+		if (_copy_lwnl_msg_params(&param, data, data_len, 2, 0) != 0) {
 			return TRBLE_INVALID_ARGS;
 		}
 		adv_handle = *(uint8_t *)param.param[0];
@@ -853,7 +853,7 @@ int bledev_handle(struct bledev *dev, lwnl_req cmd, void *data, uint32_t data_le
 		uint8_t txpower;
 
 		lwnl_msg_params param = { 0, };
-		if (_copy_lwnl_msg_params(&param, data, data_len, 0) != 0) {
+		if (_copy_lwnl_msg_params(&param, data, data_len, 2, 0) != 0) {
 			return TRBLE_INVALID_ARGS;
 		}
 		adv_handle = *(uint8_t *)param.param[0];
@@ -887,7 +887,7 @@ int bledev_handle(struct bledev *dev, lwnl_req cmd, void *data, uint32_t data_le
 	{
 		lwnl_msg_params param = { 0, };
 		trble_le_coc_init_config *t_le_coc = NULL;
-		if (_copy_lwnl_msg_params(&param, data, data_len, 0) != 0) {
+		if (_copy_lwnl_msg_params(&param, data, data_len, 1, 0) != 0) {
 			return TRBLE_INVALID_ARGS;
 		}
 		t_le_coc = (trble_le_coc_init_config *)param.param[0];
@@ -897,7 +897,7 @@ int bledev_handle(struct bledev *dev, lwnl_req cmd, void *data, uint32_t data_le
 	case LWNL_REQ_BLE_CMD_COC_REG_PSM:
 	{
 		lwnl_msg_params param = { 0, };
-		if (_copy_lwnl_msg_params(&param, data, data_len, 0) != 0) {
+		if (_copy_lwnl_msg_params(&param, data, data_len, 2, 0) != 0) {
 			return TRBLE_INVALID_ARGS;
 		}
 		uint8_t is_reg = *(uint8_t *)param.param[0];
@@ -908,7 +908,7 @@ int bledev_handle(struct bledev *dev, lwnl_req cmd, void *data, uint32_t data_le
 	case LWNL_REQ_BLE_CMD_COC_SET_PSM_SEC:
 	{
 		lwnl_msg_params param = { 0, };
-		if (_copy_lwnl_msg_params(&param, data, data_len, 0) != 0) {
+		if (_copy_lwnl_msg_params(&param, data, data_len, 4, 0) != 0) {
 			return TRBLE_INVALID_ARGS;
 		}
 		uint16_t le_psm = *(uint16_t *)param.param[0];
@@ -930,7 +930,7 @@ int bledev_handle(struct bledev *dev, lwnl_req cmd, void *data, uint32_t data_le
 	case LWNL_REQ_BLE_CMD_COC_GET_PARAM:
 	{
 		lwnl_msg_params param = { 0, };
-		if (_copy_lwnl_msg_params(&param, data, data_len, 0) != 0) {
+		if (_copy_lwnl_msg_params(&param, data, data_len, 3, 0) != 0) {
 			return TRBLE_INVALID_ARGS;
 		}
 		uint8_t param_type = *(uint8_t *)param.param[0];
@@ -942,7 +942,7 @@ int bledev_handle(struct bledev *dev, lwnl_req cmd, void *data, uint32_t data_le
 	case LWNL_REQ_BLE_CMD_COC_CONNECT:
 	{
 		lwnl_msg_params param = { 0, };
-		if (_copy_lwnl_msg_params(&param, data, data_len, 0) != 0) {
+		if (_copy_lwnl_msg_params(&param, data, data_len, 2, 0) != 0) {
 			return TRBLE_INVALID_ARGS;
 		}
 
@@ -964,7 +964,7 @@ int bledev_handle(struct bledev *dev, lwnl_req cmd, void *data, uint32_t data_le
 	case LWNL_REQ_BLE_CMD_COC_SEND:
 	{
 		lwnl_msg_params param = { 0, };
-		if (_copy_lwnl_msg_params(&param, data, data_len, 0) != 0) {
+		if (_copy_lwnl_msg_params(&param, data, data_len, 3, 0) != 0) {
 			return TRBLE_INVALID_ARGS;
 		}
 		uint16_t cid = *(uint8_t *)param.param[0];


### PR DESCRIPTION
## Summary

- Harden validation of BLE LWNL request payloads before they are dispatched to the BLE driver.
- Reject invalid whitelist address requests with `TRBLE_INVALID_ARGS`.

## Background

- BLE requests that already use `lwnl_msg_params` copy a caller-provided envelope into a fixed-size local object. The envelope must have the exact ABI size and the parameter count expected by each request.
- Raw-payload BLE requests remain unchanged to preserve their existing ABI, including the Virtual BLE IOCTL UTC path.

## Changes

- Make safe copies reject NULL source or destination pointers and mismatched payload sizes.
- Add a shared envelope-copy helper that validates the exact `lwnl_msg_params` size, request-specific parameter count, and required parameters before dispatch.
- Apply the helper only to BLE requests that already send an `lwnl_msg_params` envelope.
- Reject NULL whitelist addresses and remove the stale START_SCAN NULL-allowance comment.
