### PR TITLE
os/mm: Add use-after-free detection to the heap allocator

### DIFF
--- a/os/Kconfig.debug
+++ b/os/Kconfig.debug
@@ -790,6 +790,38 @@ config DEBUG_MM_FREEINFO
 	---help---
 		Enable free debug with free caller information for double free debugging.
 
+config DEBUG_MM_UAF
+	bool "Use-after-free detection option"
+	default n
+	---help---
+		Fill the data area of a chunk with the 0xA5A5A5A5 poison pattern when
+		it is returned to the free list, and verify the pattern again when the
+		chunk is handed out by malloc. A mismatch means somebody wrote into
+		the chunk after it was freed (use-after-free).
+
+if DEBUG_MM_UAF
+
+config DEBUG_MM_UAF_POISON_SIZE
+	int "Poison pattern size (bytes)"
+	default 64
+	---help---
+		Maximum number of bytes of the free chunk data area to fill with the
+		poison pattern. Only the data area which follows the free node
+		bookkeeping fields is poisoned, so chunks smaller than that are not
+		covered. Larger values detect more corruption but slow down every
+		free and every malloc.
+
+config DEBUG_MM_UAF_PANIC
+	bool "Panic when use-after-free is detected"
+	default n
+	---help---
+		Assert as soon as a corrupted poison pattern is found, so that the
+		crash dump is taken close to the allocation which detected it.
+		If disabled, the corruption is only reported and the allocation
+		proceeds.
+
+endif # DEBUG_MM_UAF
+
 config DEBUG_IRQ
 	bool "Interrupt Controller Debug Feature"
 	default n

--- a/os/include/tinyara/mm/mm.h
+++ b/os/include/tinyara/mm/mm.h
@@ -172,6 +172,10 @@
 #define MM_REMAINDER_FREE_CALL_ADDR ((void *)0xFEEEFEEE)
 #define MM_REMAINDER_FREE_CALL_PID 	((pid_t)-1)
 
+#ifdef CONFIG_DEBUG_MM_UAF
+#define MM_UAF_PATTERN	0xA5A5A5A5
+#endif
+
 /****************************************************************************
  * Public Types
  ****************************************************************************/
@@ -656,6 +660,11 @@ void mm_addfreechunk(FAR struct mm_heap_s *heap, FAR struct mm_freenode_s *node)
 /* Functions contained in mm_size2ndx.c.c ***********************************/
 
 int mm_size2ndx(size_t size);
+
+#ifdef CONFIG_DEBUG_MM_UAF
+void mm_uaf_poison(FAR struct mm_freenode_s *node);
+void mm_uaf_verify(FAR struct mm_freenode_s *node);
+#endif
 
 void mm_dump_node(struct mm_allocnode_s *node, char *node_type);
 void mm_dump_heap_region(uint32_t start, uint32_t end);

--- a/os/mm/mm_heap/Make.defs
+++ b/os/mm/mm_heap/Make.defs
@@ -62,6 +62,10 @@ ifeq ($(CONFIG_BUILD_KERNEL),y)
 CSRCS += mm_sbrk.c
 endif
 
+ifeq ($(CONFIG_DEBUG_MM_UAF),y)
+CSRCS += mm_uaf.c
+endif
+
 ifeq ($(CONFIG_DEBUG_MM_HEAPINFO),y)
 CSRCS += mm_heapinfo_parse_heap.c mm_heapinfo_utils.c
 ifeq ($(CONFIG_HEAPINFO_USER_GROUP),y)

--- a/os/mm/mm_heap/mm_addfreechunk.c
+++ b/os/mm/mm_heap/mm_addfreechunk.c
@@ -84,6 +84,10 @@ void mm_addfreechunk(FAR struct mm_heap_s *heap, FAR struct mm_freenode_s *node)
 	FAR struct mm_freenode_s *next;
 	FAR struct mm_freenode_s *prev;
 
+#ifdef CONFIG_DEBUG_MM_UAF
+	mm_uaf_poison(node);
+#endif
+
 	/* Convert the size to a nodelist index */
 
 	int ndx = mm_size2ndx(node->size);

--- a/os/mm/mm_heap/mm_free.c
+++ b/os/mm/mm_heap/mm_free.c
@@ -202,6 +202,10 @@ static void mm_free_internal(FAR struct mm_heap_s *heap, FAR void *mem, mmaddres
 	if ((next->preceding & MM_ALLOC_BIT) == 0) {
 		FAR struct mm_allocnode_s *andbeyond;
 
+#ifdef CONFIG_DEBUG_MM_UAF
+		mm_uaf_verify(next);
+#endif
+
 		/* Get the node following the next node (which will
 		 * become the new next node). We know that we can never
 		 * index past the tail chunk because it is always allocated.
@@ -228,6 +232,10 @@ static void mm_free_internal(FAR struct mm_heap_s *heap, FAR void *mem, mmaddres
 
 	prev = (FAR struct mm_freenode_s *)((char *)node - node->preceding);
 	if ((prev->preceding & MM_ALLOC_BIT) == 0) {
+#ifdef CONFIG_DEBUG_MM_UAF
+		mm_uaf_verify(prev);
+#endif
+
 		/* Remove the node.  There must be a predecessor, but there may
 		 * not be a successor node.
 		 */

--- a/os/mm/mm_heap/mm_malloc.c
+++ b/os/mm/mm_heap/mm_malloc.c
@@ -210,6 +210,10 @@ retry_after_gc:
 		FAR struct mm_freenode_s *next;
 		size_t remaining;
 
+#ifdef CONFIG_DEBUG_MM_UAF
+		mm_uaf_verify(node);
+#endif
+
 		/* Remove the node.  There must be a predecessor, but there may not be
 		 * a successor node.
 		 */

--- a/os/mm/mm_heap/mm_memalign.c
+++ b/os/mm/mm_heap/mm_memalign.c
@@ -214,6 +214,10 @@ retry_after_gc:
 		/* Get the next node after the allocation. */
 		FAR struct mm_allocnode_s *next = (FAR struct mm_allocnode_s *)((char *)node + node->size);
 
+#ifdef CONFIG_DEBUG_MM_UAF
+		mm_uaf_verify(node);
+#endif
+
 		/* Remove the node.  There must be a predecessor, but there may not be
 		 * a successor node.
 		 */

--- a/os/mm/mm_heap/mm_realloc.c
+++ b/os/mm/mm_heap/mm_realloc.c
@@ -183,11 +183,17 @@ FAR void *mm_realloc(FAR struct mm_heap_s *heap, FAR void *oldmem, size_t size, 
 	next = (FAR struct mm_freenode_s *)((FAR char *)oldnode + oldnode->size);
 	if ((next->preceding & MM_ALLOC_BIT) == 0) {
 		nextsize = next->size;
+#ifdef CONFIG_DEBUG_MM_UAF
+		mm_uaf_verify(next);
+#endif
 	}
 
 	prev = (FAR struct mm_freenode_s *)((FAR char *)oldnode - (oldnode->preceding & ~MM_ALLOC_BIT));
 	if ((prev->preceding & MM_ALLOC_BIT) == 0) {
 		prevsize = prev->size;
+#ifdef CONFIG_DEBUG_MM_UAF
+		mm_uaf_verify(prev);
+#endif
 	}
 
 	/* Now, check if we can extend the current allocation or not */

--- a/os/mm/mm_heap/mm_shrinkchunk.c
+++ b/os/mm/mm_heap/mm_shrinkchunk.c
@@ -97,6 +97,10 @@ void mm_shrinkchunk(FAR struct mm_heap_s *heap, FAR struct mm_allocnode_s *node,
 		FAR struct mm_allocnode_s *andbeyond;
 		FAR struct mm_freenode_s *newnode;
 
+#ifdef CONFIG_DEBUG_MM_UAF
+		mm_uaf_verify(next);
+#endif
+
 		/* Get the chunk next the next node (which could be the tail chunk) */
 
 		andbeyond = (FAR struct mm_allocnode_s *)((char *)next + next->size);

--- a/os/mm/mm_heap/mm_uaf.c
+++ b/os/mm/mm_heap/mm_uaf.c
@@ -1,0 +1,155 @@
+/****************************************************************************
+ *
+ * Copyright 2026 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <tinyara/config.h>
+
+#include <stdint.h>
+#include <assert.h>
+#include <debug.h>
+
+#include <tinyara/mm/mm.h>
+
+#include "mm_node.h"
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: mm_uaf_area
+ *
+ * Description:
+ *   Locate the part of the free chunk 'node' which carries the poison
+ *   pattern. It is the data area of the chunk, excluding the free node
+ *   bookkeeping fields (flink/blink and the free debug info) which the
+ *   allocator itself keeps using while the chunk sits in the free list.
+ *
+ *   Those fields are skipped by MM_ALIGN_UP(SIZEOF_MM_FREENODE), the same
+ *   granule alignment the allocator applies to every other offset. Since a
+ *   node address is always a multiple of sizeof(uint32_t), that keeps the
+ *   pattern accessible with aligned 32-bit reads and writes.
+ *
+ *   The size is clamped to CONFIG_DEBUG_MM_UAF_POISON_SIZE and truncated to
+ *   whole words, so nothing is ever written past the end of the chunk.
+ *
+ * Returned Value:
+ *   The number of poisoned words, 0 if the chunk is too small to hold any.
+ *   On a non-zero return, *poison points to the first poisoned word.
+ *
+ ****************************************************************************/
+
+static size_t mm_uaf_area(struct mm_freenode_s *node, uint32_t **poison)
+{
+	size_t offset = MM_ALIGN_UP(SIZEOF_MM_FREENODE);
+	size_t nbytes;
+
+	if (node->size <= offset) {
+		/* The chunk is all bookkeeping, there is no room for the pattern */
+
+		return 0;
+	}
+
+	nbytes = node->size - offset;
+	if (nbytes > CONFIG_DEBUG_MM_UAF_POISON_SIZE) {
+		nbytes = CONFIG_DEBUG_MM_UAF_POISON_SIZE;
+	}
+
+	*poison = (uint32_t *)((char *)node + offset);
+
+	return nbytes / sizeof(uint32_t);
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: mm_uaf_poison
+ *
+ * Description:
+ *   Fill the data area of a chunk which is about to enter the free list with
+ *   the poison pattern. Called for every chunk which becomes free, so that
+ *   mm_uaf_verify() has a known content to compare against.
+ *
+ *   NOTES:
+ *     (1) node->size must already be set to its final value.
+ *     (2) the caller must hold the MM semaphore.
+ *
+ ****************************************************************************/
+
+void mm_uaf_poison(struct mm_freenode_s *node)
+{
+	uint32_t *poison;
+	size_t nwords;
+	size_t i;
+
+	nwords = mm_uaf_area(node, &poison);
+	for (i = 0; i < nwords; i++) {
+		poison[i] = MM_UAF_PATTERN;
+	}
+}
+
+/****************************************************************************
+ * Name: mm_uaf_verify
+ *
+ * Description:
+ *   Check that the poison pattern written by mm_uaf_poison() is still intact
+ *   in the chunk which is about to be handed out. Any difference means that
+ *   the chunk was written while it was free, which is a use-after-free by
+ *   whoever owned it before.
+ *
+ *   NOTES:
+ *     (1) must be called before the chunk is removed from the free list and
+ *         split, so that the poisoned area is still the one which was
+ *         poisoned when the chunk was freed.
+ *     (2) the caller must hold the MM semaphore.
+ *
+ ****************************************************************************/
+
+void mm_uaf_verify(struct mm_freenode_s *node)
+{
+	uint32_t *poison;
+	size_t nwords;
+	size_t i;
+
+	nwords = mm_uaf_area(node, &poison);
+	for (i = 0; i < nwords; i++) {
+		if (poison[i] != MM_UAF_PATTERN) {
+			break;
+		}
+	}
+
+	if (i >= nwords) {
+		/* The pattern is intact, nothing wrote into the chunk while free */
+
+		return;
+	}
+
+	heap_dbg("#########################################################################################\n");
+	mfdbg("ERROR: Use after free detected.\n");
+	mm_dump_node((struct mm_allocnode_s *)node, "FREE NODE");
+	mm_dump_heap_region((uint32_t)node, (uint32_t)node + node->size);
+
+#ifdef CONFIG_DEBUG_MM_UAF_PANIC
+	PANIC();
+#endif
+}

--- a/os/mm/mm_heap/mm_uaf.c
+++ b/os/mm/mm_heap/mm_uaf.c
@@ -1,0 +1,153 @@
+/****************************************************************************
+ *
+ * Copyright 2026 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <tinyara/config.h>
+
+#include <stdint.h>
+#include <assert.h>
+#include <debug.h>
+
+#include <tinyara/mm/mm.h>
+
+#include "mm_node.h"
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: mm_uaf_area
+ *
+ * Description:
+ *   Locate the part of the free chunk 'node' which carries the poison
+ *   pattern. It is the data area of the chunk, excluding the free node
+ *   bookkeeping fields (flink/blink and the free debug info) which the
+ *   allocator itself keeps using while the chunk sits in the free list.
+ *
+ *   Those fields are skipped by MM_ALIGN_UP(SIZEOF_MM_FREENODE), the same
+ *   granule alignment the allocator applies to every other offset. Since a
+ *   node address is always a multiple of sizeof(uint32_t), that keeps the
+ *   pattern accessible with aligned 32-bit reads and writes.
+ *
+ *   The size is clamped to CONFIG_DEBUG_MM_UAF_POISON_SIZE and truncated to
+ *   whole words, so nothing is ever written past the end of the chunk.
+ *
+ * Returned Value:
+ *   The number of poisoned words, 0 if the chunk is too small to hold any.
+ *   On a non-zero return, *poison points to the first poisoned word.
+ *
+ ****************************************************************************/
+
+static size_t mm_uaf_area(struct mm_freenode_s *node, uint32_t **poison)
+{
+	size_t offset = MM_ALIGN_UP(SIZEOF_MM_FREENODE);
+	size_t nbytes;
+
+	if (node->size <= offset) {
+		/* The chunk is all bookkeeping, there is no room for the pattern */
+		return 0;
+	}
+
+	nbytes = node->size - offset;
+	if (nbytes > CONFIG_DEBUG_MM_UAF_POISON_SIZE) {
+		nbytes = CONFIG_DEBUG_MM_UAF_POISON_SIZE;
+	}
+
+	*poison = (uint32_t *)((char *)node + offset);
+
+	return nbytes / sizeof(uint32_t);
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: mm_uaf_poison
+ *
+ * Description:
+ *   Fill the data area of a chunk which is about to enter the free list with
+ *   the poison pattern. Called for every chunk which becomes free, so that
+ *   mm_uaf_verify() has a known content to compare against.
+ *
+ *   NOTES:
+ *     (1) node->size must already be set to its final value.
+ *     (2) the caller must hold the MM semaphore.
+ *
+ ****************************************************************************/
+
+void mm_uaf_poison(struct mm_freenode_s *node)
+{
+	uint32_t *poison;
+	size_t nwords;
+	size_t i;
+
+	nwords = mm_uaf_area(node, &poison);
+	for (i = 0; i < nwords; i++) {
+		poison[i] = MM_UAF_PATTERN;
+	}
+}
+
+/****************************************************************************
+ * Name: mm_uaf_verify
+ *
+ * Description:
+ *   Check that the poison pattern written by mm_uaf_poison() is still intact
+ *   in the chunk which is about to be handed out. Any difference means that
+ *   the chunk was written while it was free, which is a use-after-free by
+ *   whoever owned it before.
+ *
+ *   NOTES:
+ *     (1) must be called before the chunk is removed from the free list and
+ *         split, so that the poisoned area is still the one which was
+ *         poisoned when the chunk was freed.
+ *     (2) the caller must hold the MM semaphore.
+ *
+ ****************************************************************************/
+
+void mm_uaf_verify(struct mm_freenode_s *node)
+{
+	uint32_t *poison;
+	size_t nwords;
+	size_t i;
+
+	nwords = mm_uaf_area(node, &poison);
+	for (i = 0; i < nwords; i++) {
+		if (poison[i] != MM_UAF_PATTERN) {
+			break;
+		}
+	}
+
+	if (i >= nwords) {
+		/* The pattern is intact, nothing wrote into the chunk while free */
+		return;
+	}
+
+	heap_dbg("#########################################################################################\n");
+	mfdbg("ERROR: Use after free detected.\n");
+	mm_dump_node((struct mm_allocnode_s *)node, "FREE NODE");
+	mm_dump_heap_region((uint32_t)node, (uint32_t)node + node->size);
+
+#ifdef CONFIG_DEBUG_MM_UAF_PANIC
+	PANIC();
+#endif
+}


### PR DESCRIPTION

Fill the data area of a chunk with the 0xA5A5A5A5 poison pattern when it enters the free list, and verify the pattern before the chunk is consumed again.
A mismatch means the chunk was written while it was free, which is a use-after-free by whoever owned it previously.

The pattern is written from mm_addfreechunk(), which every chunk passes through on its way into the free list.

Verification happens wherever a free chunk is consumed:
- mm_malloc() and mm_memalign(), before the chunk is split
- mm_free(), mm_realloc() and mm_shrinkchunk(), before a neighbouring free
  chunk is merged or absorbed. Checking here reports the corruption much
  earlier than waiting for the chunk to be handed out again.

On detection the report prints the ERROR line, the node information via mm_dump_node(), and a hex dump of the whole chunk so that the corrupted words stand out against the 0xA5A5A5A5 background.
Only the data area following the free node bookkeeping is covered.
The allocator reuses the first SIZEOF_MM_FREENODE bytes for flink/blink and the free debug info while a chunk is free, so a write there corrupts the free list and is caught by DEBUGASSERT_MM_FREE_NODE instead.
The covered size is capped by CONFIG_DEBUG_MM_UAF_POISON_SIZE to bound the cost added to every free and every allocation.

New configuration options:
- CONFIG_DEBUG_MM_UAF: enable the detector
- CONFIG_DEBUG_MM_UAF_POISON_SIZE: bytes to poison per chunk, default 64
- CONFIG_DEBUG_MM_UAF_PANIC: assert on detection instead of only reporting

[Example Log]
```bash
mm_uaf_verify: ERROR: Use after free detected.
mm_dump_node: FREE NODE: addr = 0x63a94030, type = F, size = 112, preceding size = 112
mm_dump_node: FREE NODE owner pid = 29 (hello), allocated by code at addr = 0x0e26d4fb
Dump heap: 0x63a94030 - 0x63a940a0
63a94030: 00000070 0e26d4fb 0000001d 00000070 00000000 63a81088 0e26d785 0707001d
63a94050: deadbeef cafebabe 12345678 a5a5a5a5 a5a5a5a5 a5a5a5a5 a5a5a5a5 a5a5a5a5
63a94070: a5a5a5a5 a5a5a5a5 a5a5a5a5 a5a5a5a5 a5a5a5a5 a5a5a5a5 a5a5a5a5 a5a5a5a5
63a94090: 07070707 07070707 07070707 07070707 80000070 0e26d503 0000001d 00000070
```

[Example Log Interpretation]
| Address/offset | Value    | Meaning |
|----------------|----------|---------|
| +0x00          | 00000070 | Preceding chunk size = 112; allocation bit clear (free node) |
| +0x04          | 0e26d4fb | Allocation caller address |
| +0x08          | 0000001d | Low 16 bits: PID 29; high 16 bits: memory_state 0 |
| +0x0c          | 00000070 | Current chunk size = 112 |
| +0x10          | 00000000 | Free-list flink |
| +0x14          | 63a81088 | Free-list blink |
| +0x18          | 0e26d785 | Free caller address |
| +0x1c          | 0707001d | Low 16 bits: free PID 29; high 16 bits: reserved 0x0707 |

The poisoned data area begins at offset +0x20. With the default 64-byte poison size, the range from +0x20 through +0x5f is expected to contain 0xA5A5A5A5. In this example:

```text
0x63a94050 (+0x20): deadbeef  <- overwritten
0x63a94054 (+0x24): cafebabe  <- overwritten
0x63a94058 (+0x28): 12345678  <- overwritten
0x63a9405c (+0x2c): a5a5a5a5  <- intact poison
```

Note: The metadata interpretation above is best-effort. A write through a stale pointer can overwrite the free-node bookkeeping fields at +0x10 through +0x1f because they overlay the first 16 bytes of the former user area. An underrun or arbitrary write can also corrupt the header at +0x00 through +0x0f. The poison verifier excludes these metadata fields, so size, PID, caller addresses, and free-list links must not be considered trustworthy once metadata corruption is suspected. The fields in this example are internally consistent, but that does not prove they were untouched.