### PR TITLE
os/arch/arm/src/armv7-a: Fix Thumb operand constraints

### DIFF
--- a/os/arch/arm/src/armv7-a/arm_signal_dispatch.c
+++ b/os/arch/arm/src/armv7-a/arm_signal_dispatch.c
@@ -90,7 +90,12 @@ void up_signal_dispatch(_sa_sigaction_t sighand, int signo, siginfo_t *info, voi
 
 	__asm__ __volatile__ (
         "mov %0, sp\n"
-        "bic sp, sp, #7\n"
+#ifdef CONFIG_ARCH_CORTEXA32
+		"bic sp, sp, #7\n"
+#else
+        "bic %0, %0, #7\n"
+		"mov sp, %0\n"
+#endif
         : "=r"(saved_sp)
         :
         : "memory"

--- a/os/arch/arm/src/armv7-a/arm_signal_handler.S
+++ b/os/arch/arm/src/armv7-a/arm_signal_handler.S
@@ -100,7 +100,12 @@ up_signal_handler:
 	 * like DEBUGPANIC().
 	*/
 
+#ifdef CONFIG_ARCH_CORTEXA32
 	tst		sp, #7			/* SP 8-byte aligned? (low 3 bits == 0) */
+#else
+	mov		r12, sp			/* ARMv7-A: TST cannot use SP directly */
+	tst		r12, #7			/* R12 low 3 bits == 0? */
+#endif
 	beq		1f			/* Yes: proceed to the handler */
 	ldr		r0, =.Lsigsp_file	/* up_assert() filename argument - loads address of string */
 	movw		r1, #103			/* up_assert() linenum argument - immediate value */


### PR DESCRIPTION
Thumb TST does not allow SP as an operand. Use r12 as a scratch register before testing the stack alignment in up_signal_handler().

Likewise, preserve the original SP value in up_signal_dispatch() and calculate the aligned value through r12 so the inline assembly remains valid for Thumb builds.