### PR TITLE
os/pm: Fix uninitialized domain_position causing data abort crash in pm_procfs

### DIFF
--- a/os/pm/pm_procfs.c
+++ b/os/pm/pm_procfs.c
@@ -641,7 +641,7 @@ static int power_opendir(FAR const char *relpath, FAR struct fs_dirent_s *dir)
 	/* The path refers to the 1st level subdirectory.  Allocate the powerdir
 	 * dirent structure.
 	 */
-	powerdir = (FAR struct power_dir_s *)kmm_malloc(sizeof(struct power_dir_s));
+	powerdir = (FAR struct power_dir_s *)kmm_zalloc(sizeof(struct power_dir_s));
 
 	if (!powerdir) {
 		fdbg("ERROR: Failed to allocate the directory structure\n");


### PR DESCRIPTION
power_opendir() used kmm_malloc which does not zero-fill memory, leaving domain_position with garbage values. When readdir_domains() checked domain_position == NULL, the check failed on garbage non-NULL pointer, causing a data abort crash when /proc/power/domains was listed after reading /proc/power/domains/info.

Fixed by using kmm_zalloc to zero-initialize the allocated structure, ensuring domain_position starts as NULL.

Co-Authored-By: Cline SR