### PR TITLE
os/kernel/pthread: Add bounds check to prevent cond waiter count underflow

### DIFF
--- a/os/kernel/pthread/pthread_condtimedwait.c
+++ b/os/kernel/pthread/pthread_condtimedwait.c
@@ -302,14 +302,25 @@ int pthread_cond_timedwait(FAR pthread_cond_t *cond, FAR pthread_mutex_t *mutex,
 						/* Did we get the condition semaphore. */
 
 						if (status != OK) {
-							/* The wait was not consumed by signal() or broadcast(). */
-							cond->waiters--;
+							/* sem_wait failed */
+							if (cond->waiters > 0) {
+								cond->waiters--;
+							}
 
 							/* NO.. Handle the special case where the semaphore wait was
 							 * awakened by the receipt of a signal -- presumably the
 							 * signal posted by pthread_condtimedout().
 							 */
 							if (get_errno() == EINTR) {
+								/* If a concurrent signal/broadcast gave the semaphore
+								* after timeout already restored semcount via
+								* sem_waitirq(), there will be a leftover semcount.
+								* Consume it to prevent spurious wakeup on next wait.
+								*/
+								if (cond->sem.semcount > 0) {
+									cond->sem.semcount--;
+								}
+
 								sdbg("Timedout!\n");
 								ret = ETIMEDOUT;
 							} else {


### PR DESCRIPTION

When a thread waits in pthread_cond_timedwait() and signal/broadcast and timeout happen at the same time, waiter count could be doubly decremented, which can lead to waiter count underflow when there is only a single waiter. This can lead to inconsistent waiter count and sem count as well.

Logs:
pthread_cond_timedwait: TWAIT INC cond=0x0x63f8a388 waiters=1 semcount=0 pid=79 name=BA_EVENT_WORKER pthread_cond_broadcast: BCAST DEC->0 cond=0x0x63f8a388 semcount=0 pid=65 name=bixbyAgentClientNotiThread pthread_cond_timedwait: TWAIT SEM_WAIT cond=0x0x63f8a388 status=-1 errno=4 waiters=0 semcount=1 pid=79 name=BA_EVENT_WORKER pthread_cond_timedwait: TWAIT DEC cond=0x0x63f8a388 waiters=65535 semcount=1 errno=4 pid=79 name=BA_EVENT_WORKER

Crash scenario:
1. Thread A: wait on timedwait waitercount = 1
2. Thread B: calls broadcast the same condition variable, decrements waitercount = 0.
3. But just before it is about to call pthread_sem_give(), The wait of thread A breaks due to timeout, that's why: TWAIT SEM_WAIT cond=0x0x63f8a388 status=-1 errno=4 waiters=0 semcount=1 pid=79 name=BA_EVENT_WORKER
4. semwaitirq() increments the semcount
5. Since, thread A wakesup due to signal, sem_wait() returns !OK and pthread_cond_timedwait decrements the waiter count further (because there is no bounds check) and it underflows.

Fix:
Add bounds check before decrementing waiters in the error path. Only decrement if waiters > 0, preventing double-decrement when broadcast/signal already decremented it.