### PR TITLE
os/kernel posix: Do not call assert and add posix return values for incorrect api usage

### DIFF
--- a/os/kernel/pthread/pthread_getschedparam.c
+++ b/os/kernel/pthread/pthread_getschedparam.c
@@ -133,14 +133,16 @@ int pthread_getschedparam(pthread_t thread, FAR int *policy, FAR struct sched_pa
 
 		ret = sched_getparam((pid_t)thread, param);
 		if (ret != OK) {
-			ret = EINVAL;
-		}
+			/* Thread does not exist - return ESRCH per POSIX */
+			ret = ESRCH;
+		} else {
+			/* Return the policy. */
 
-		/* Return the policy. */
-
-		*policy = sched_getscheduler((pid_t)thread);
-		if (*policy == ERROR) {
-			ret = get_errno();
+			*policy = sched_getscheduler((pid_t)thread);
+			if (*policy == ERROR) {
+				/* Thread disappeared between getparam and getscheduler */
+				ret = ESRCH;
+			}
 		}
 	}
 

--- a/os/kernel/semaphore/sem_timedwait.c
+++ b/os/kernel/semaphore/sem_timedwait.c
@@ -195,12 +195,10 @@ int sem_timedwait(FAR sem_t *sem, FAR const struct timespec *abstime)
 	 * errno appropriately.
 	 */
 
-#ifdef CONFIG_DEBUG
 	if (!abstime || !sem) {
 		errcode = EINVAL;
 		goto errout;
 	}
-#endif
 
 	/* Create a watchdog.  We will not actually need this watchdog
 	 * unless the semaphore is unavailable, but we will reserve it up

--- a/os/kernel/semaphore/sem_trywait.c
+++ b/os/kernel/semaphore/sem_trywait.c
@@ -123,7 +123,13 @@ int sem_trywait(FAR sem_t *sem)
 
 	/* This API should not be called from interrupt handlers */
 
-	DEBUGASSERT(sem != NULL && up_interrupt_context() == false);
+	DEBUGASSERT(up_interrupt_context() == false);
+
+	/* Return EINVAL for NULL semaphore instead of crashing */
+	if (sem == NULL) {
+		set_errno(EINVAL);
+		return ERROR;
+	}
 
 	if ((sem != NULL) && ((sem->flags & FLAGS_INITIALIZED) != 0)) {
 		/* The following operations must be performed with interrupts disabled

--- a/os/kernel/semaphore/sem_wait.c
+++ b/os/kernel/semaphore/sem_wait.c
@@ -127,14 +127,20 @@ int sem_wait(FAR sem_t *sem)
 	size_t caller_retaddr = (size_t)GET_RETURN_ADDRESS();
 	/* This API should not be called from interrupt handlers */
 #if defined(CONFIG_DEBUG_DISPLAY_SYMBOL) || defined(CONFIG_BINMGR_RECOVERY)
-	DEBUGASSERT((sem != NULL && up_interrupt_context() == false) || abort_mode);
+	DEBUGASSERT(up_interrupt_context() == false || abort_mode);
 
 	if (abort_mode && up_interrupt_context() == true) {
 		return OK;
 	}
 #else
-	DEBUGASSERT(sem != NULL && up_interrupt_context() == false);
+	DEBUGASSERT(up_interrupt_context() == false);
 #endif
+
+	/* Return EINVAL for NULL semaphore instead of crashing */
+	if (sem == NULL) {
+		set_errno(EINVAL);
+		return ERROR;
+	}
 
 	/* The following operations must be performed with interrupts
 	 * disabled because sem_post() may be called from an interrupt


### PR DESCRIPTION
TizenRT can call assert through wrong API usage.
Instead of assert, set the correct err/return value. This avoids system crash due to wrong usage by user space apps.
pthread_getschedparam : return ESRCH
sem_timedwait: return EINVAL if null semaphore is received
 sem_trywait: return EINVAL if null semaphore is received