### PR TITLE
os/kernel/semaphore: fix timeout+post race in sem_timedwait

### DIFF
--- a/os/kernel/semaphore/sem_timedwait.c
+++ b/os/kernel/semaphore/sem_timedwait.c
@@ -275,6 +275,21 @@ int sem_timedwait(FAR sem_t *sem, FAR const struct timespec *abstime)
 		/* sem_wait() failed.  Save the errno value */
 
 		errcode = get_errno();
+
+		/* Handle timeout+post race condition:
+		 * If timeout fired (sem_waitirq incremented semcount to restore it)
+		 * and a concurrent sem_post() also incremented semcount before we
+		 * got CPU, there will be a leftover semcount that would cause a
+		 * spurious wakeup on the next sem_wait(). Consume it here and
+		 * return OK since the semaphore was successfully acquired.
+		 * POSIX: "Under no circumstance shall the function fail with a
+		 * timeout if the semaphore can be locked immediately."
+		 */
+		if (errcode == ETIMEDOUT && sem->semcount > 0) {
+			sem->semcount--;
+			ret = OK;
+			errcode = OK;
+		}
 	}
 
 	/* Stop the watchdog timer */


### PR DESCRIPTION
Fix a race condition between timeout and sem_post that causes spurious wakeups on subsequent semaphore waits.

Root Cause:
When timeout fires, sem_waitirq() increments semcount to restore the count that was decremented when the thread blocked. If a concurrent sem_post() also increments semcount before the thread gets CPU, there will be a leftover semcount (double increment).

This leftover causes the next sem_wait() on the same semaphore to return immediately without actually waiting (spurious wakeup).

Fix:
In the error path after sem_wait() returns, check if:
- errno is ETIMEDOUT (timeout fired)
- semcount > 0 (concurrent post happened)

If both conditions are true, consume the leftover semcount and return OK since the semaphore was successfully acquired.

This is POSIX-compliant per:
"Under no circumstance shall the function fail with a timeout if the semaphore can be locked immediately."