### PR TITLE
os/board/bk7239n/src: flash write-protect and compatibility improvement

### DIFF
--- a/os/board/bk7239n/src/components/bk_pm/src/services/bk_pm_sleep.c
+++ b/os/board/bk7239n/src/components/bk_pm/src/services/bk_pm_sleep.c
@@ -110,6 +110,7 @@ uint64_t pm_normal_sleep_process()
 		/*When check bt wakeup time comming ,return, not sleep*/
 		if (!pm_check_protect_time(entry_tick, entry_tick))
 		{
+			pm_enable_int(int_level);
 			return sleep_tick;
 		}
 	}

--- a/os/board/bk7239n/src/middleware/driver/flash/flash_driver.c
+++ b/os/board/bk7239n/src/middleware/driver/flash/flash_driver.c
@@ -195,6 +195,51 @@ static flash_ps_callback_t s_flash_ps_resume_cb = NULL;
 static flash_wait_callback_t s_flash_wait_cb[FLASH_MAX_WAIT_CB_CNT] = {NULL};
 static volatile flash_op_status_t s_flash_op_status = 0;
 
+/* Flash families that need a slower clock during program/erase/write-status-reg:
+ * winbond(0xEF), XMC(0x20), GT(0x1C71). Their read clock stays 80M (cksel=2/APLL,
+ * ckdiv=0); write actions temporarily drop to 40M (ckdiv=1, i.e. 80M/2). */
+#ifndef FLASH_ManuFacID_POSI
+#define FLASH_ManuFacID_POSI       (16)
+#endif
+#define FLASH_ManuFacID_WINBOND    (0xEF)
+#define FLASH_ManuFacID_XMC        (0x20)
+#define FLASH_MID_GT               (0x1C71)  /* manufacturer(0x1C)+type(0x71), excludes EON 0x1C70/0x1C41 */
+#define FLASH_CLK_SRC_80M          (2)       /* cksel_flash=2 -> 80M (APLL) source */
+#define FLASH_WRITE_CKDIV_SLOW     (1)       /* 80M / 2 = 40M */
+#define FLASH_WRITE_CKDIV_NORMAL   (0)       /* 80M / 1 = 80M */
+
+static bool s_flash_slow_write_clk = false;
+
+static bool flash_is_slow_write_clk_family(uint32_t flash_id)
+{
+	uint32_t mid = flash_id >> FLASH_ManuFacID_POSI;
+
+	if ((mid == FLASH_ManuFacID_WINBOND) || (mid == FLASH_ManuFacID_XMC)) {
+		return true;
+	}
+	if ((flash_id >> 8) == FLASH_MID_GT) {
+		return true;
+	}
+	return false;
+}
+
+static inline void flash_write_clk_enter(void)
+{
+	if (s_flash_slow_write_clk) {
+		flash_hal_wait_op_done(&s_flash.hal);
+		sys_drv_flash_cksel(FLASH_CLK_SRC_80M);            /* slowing: fix source(80M) first */
+		sys_drv_flash_set_clk_div(FLASH_WRITE_CKDIV_SLOW); /* then /2 -> 40M */
+	}
+}
+
+static inline void flash_write_clk_exit(void)
+{
+	if (s_flash_slow_write_clk) {
+		flash_hal_wait_op_done(&s_flash.hal);
+		sys_drv_flash_set_clk_div(FLASH_WRITE_CKDIV_NORMAL); /* speeding: /1 first */
+		sys_drv_flash_cksel(FLASH_CLK_SRC_80M);              /* then keep 80M source */
+	}
+}
 
 unsigned int arch_is_enter_exception(void);
 
@@ -617,7 +662,7 @@ static bool flash_is_need_update_status_reg(uint32_t protect_cfg, uint32_t cmp_c
 	}
 }
 
-static void flash_set_protect_type(flash_protect_type_t type)
+static void flash_set_protect_type_ex(flash_protect_type_t type, bool nonvolatile)
 {
 	uint32_t protect_cfg = flash_get_protect_cfg(type);
 	uint32_t cmp_cfg = flash_get_cmp_cfg(type);
@@ -628,8 +673,23 @@ static void flash_set_protect_type(flash_protect_type_t type)
 		flash_set_cmp_cfg(&status_reg, cmp_cfg);
 
 		//FLASH_LOGD("write status reg:%x, status_reg_size:%d\r\n", status_reg, s_flash.flash_cfg->status_reg_size);
-		flash_hal_write_status_reg(&s_flash.hal, s_flash.flash_cfg->status_reg_size, status_reg);
+		if (nonvolatile) {
+			flash_hal_write_status_reg_nvol(&s_flash.hal, s_flash.flash_cfg->status_reg_size, status_reg);
+		} else {
+			flash_hal_write_status_reg(&s_flash.hal, s_flash.flash_cfg->status_reg_size, status_reg);
+		}
 	}
+}
+
+static void flash_set_protect_type(flash_protect_type_t type)
+{
+	flash_set_protect_type_ex(type, false);
+}
+
+/* Persist the protection setting across power cycles (non-volatile SR write). */
+static void flash_set_protect_type_nvol(flash_protect_type_t type)
+{
+	flash_set_protect_type_ex(type, true);
 }
 
 static void flash_set_qe(void)
@@ -832,8 +892,25 @@ bk_err_t bk_flash_driver_init(void)
 	s_flash.flash_id = flash_hal_get_id(&s_flash.hal);
 	FLASH_LOGI("id=0x%x\r\n", s_flash.flash_id);
 	flash_get_current_config();
+	s_flash_slow_write_clk = flash_is_slow_write_clk_family(s_flash.flash_id);
 	s_flash_runtime_protect_type = FLASH_PROTECT_ALL;
-	flash_set_protect_type(FLASH_PROTECT_ALL);
+
+#if (defined(CONFIG_SOC_BK7239XX))
+	/* winbond/XMC/GT read baseline: cksel=2(APLL/80M), ckdiv=0(/1).
+	 * Establish it before the non-volatile WRSR below so that write no longer
+	 * relies on the boot-time clock source. Read-then-set: skip if matched. */
+	if (s_flash_slow_write_clk) {
+		if ((FLASH_CLK_SRC_80M != sys_drv_flash_get_clk_sel())
+			|| (FLASH_WRITE_CKDIV_NORMAL != sys_drv_flash_get_clk_div())) {
+			sys_drv_flash_set_clk_div(FLASH_WRITE_CKDIV_NORMAL); /* set ckdiv first */
+			sys_drv_flash_cksel(FLASH_CLK_SRC_80M);              /* then clk source */
+		}
+	}
+#endif
+
+	flash_write_clk_enter();
+	flash_set_protect_type_nvol(FLASH_PROTECT_ALL);
+	flash_write_clk_exit();
 #if !defined(CONFIG_JTAG) || (0 == CONFIG_JTAG)
 	flash_hal_disable_cpu_data_wr(&s_flash.hal);
 #endif
@@ -841,22 +918,8 @@ bk_err_t bk_flash_driver_init(void)
 	flash_hal_set_default_clk(&s_flash.hal);
 
 
-#if (defined(CONFIG_SOC_BK7236XX))
-	if((s_flash.flash_id >> FLASH_ManuFacID_POSI) == FLASH_ManuFacID_GD
-	|| (s_flash.flash_id >> FLASH_ManuFacID_POSI) == FLASH_ManuFacID_TH) {
-		if((1 != sys_drv_flash_get_clk_sel()) || (1 != sys_drv_flash_get_clk_div())) {
-			sys_drv_flash_set_clk_div(1); // dpll div 6 = 80M
-			sys_drv_flash_cksel(1);
-		}
-	} else {
-		if((1 != sys_drv_flash_get_clk_sel()) || (3 != sys_drv_flash_get_clk_div())) {
-			sys_drv_flash_set_clk_div(3); // dpll div 10 = 48M
-			sys_drv_flash_cksel(1);
-		}
-	}
-
+#if (defined(CONFIG_SOC_BK7239XX))
 	sys_drv_set_sys2flsh_2wire(1);
-
 #endif
 
 	flash_init_common();
@@ -918,9 +981,11 @@ static bk_err_t flash_erase_block(uint32_t address, int type)
 #endif
 	uint32_t int_level = flash_enter_critical();
 	flash_ps_suspend(NORMAL_PS);
+	flash_write_clk_enter();
 	flash_set_protect_type(FLASH_PROTECT_NONE);
 	flash_hal_erase_block(&s_flash.hal, erase_addr, type);
 	flash_set_protect_type(s_flash_runtime_protect_type);
+	flash_write_clk_exit();
 	flash_ps_resume(NORMAL_PS);
 	flash_exit_critical(int_level);
 
@@ -996,9 +1061,11 @@ bk_err_t bk_flash_write_bytes(uint32_t address, const uint8_t *user_buf, uint32_
 
 	uint32_t int_level = flash_enter_critical();
 	flash_ps_suspend(NORMAL_PS);
+	flash_write_clk_enter();
 	flash_set_protect_type(FLASH_PROTECT_NONE);
 	flash_write_common(user_buf, address, size);
 	flash_set_protect_type(s_flash_runtime_protect_type);
+	flash_write_clk_exit();
 	flash_ps_resume(NORMAL_PS);
 	flash_exit_critical(int_level);
 
@@ -1090,7 +1157,9 @@ bk_err_t bk_flash_write_status_reg(uint16_t status_reg_data)
 {
 	uint32_t int_level = flash_enter_critical();
 	flash_ps_suspend(NORMAL_PS);
+	flash_write_clk_enter();
 	flash_hal_write_status_reg(&s_flash.hal, s_flash.flash_cfg->status_reg_size, status_reg_data);
+	flash_write_clk_exit();
 	flash_ps_resume(NORMAL_PS);
 	flash_exit_critical(int_level);
 	return BK_OK;

--- a/os/board/bk7239n/src/middleware/soc/bk7239n/hal/flash_ll.h
+++ b/os/board/bk7239n/src/middleware/soc/bk7239n/hal/flash_ll.h
@@ -147,14 +147,14 @@ static inline void flash_ll_write_status_reg(flash_hw_t *hw, uint8_t sr_width, u
 		flash_ll_set_op_cmd(hw, FLASH_OP_CMD_WRSR);
 
 		while (flash_ll_is_busy(hw));
-		hw->config.wrsr_data = (sr_data >> LEN_WRSR_S0_S7);
+		hw->config.wrsr_data = (v >> LEN_WRSR_S0_S7);
 		flash_ll_init_wrsr_cmd(hw, CMD_WRSR_S8_S15);
 		// hw->op_ctrl.wp_value = 1;    //  ???
 		flash_ll_set_op_cmd(hw, FLASH_OP_CMD_WRSR);
 
 		#if 0
 		while (flash_ll_is_busy(hw));
-		hw->config.wrsr_data = (sr_data >> LEN_WRSR_S8_S15);
+		hw->config.wrsr_data = (v >> LEN_WRSR_S8_S15);
 		flash_ll_init_wrsr_cmd(hw, CMD_WRSR_S16_S24);
 		flash_ll_set_op_cmd(hw, FLASH_OP_CMD_WRSR);
 		#endif
@@ -167,6 +167,39 @@ static inline void flash_ll_write_status_reg(flash_hw_t *hw, uint8_t sr_width, u
 
 	hw->op_ctrl.wp_value = 0;
 	flash_ll_clear_volatile_status_write(hw);
+}
+
+/* Non-volatile status-register write: no 0x50 volatile-enable wrapper, so the
+ * controller issues the standard WREN (0x06) before WRSR and the value persists
+ * across power cycles. Used for one-time protection setup at init. */
+static inline void flash_ll_write_status_reg_nvol(flash_hw_t *hw, uint8_t sr_width, uint32_t sr_data)
+{
+	uint32_t v = sr_data;
+
+	flash_ll_wait_op_done(hw);
+	/* NOR SR: keep SRP0 set, clear SRP1 */
+	v |= FLASH_SR_SRP0;
+	v &= ~FLASH_SR_SRP1;
+
+	hw->cmd_cfg.v = 0;
+	hw->op_ctrl.wp_value = 1;
+	hw->config.wrsr_data = v;
+	if (sr_width == 1) {
+		flash_ll_set_op_cmd(hw, FLASH_OP_CMD_WRSR);
+	} else {
+		flash_ll_set_op_cmd(hw, FLASH_OP_CMD_WRSR);
+
+		flash_ll_wait_op_done(hw);
+		hw->config.wrsr_data = (v >> LEN_WRSR_S0_S7);
+		flash_ll_init_wrsr_cmd(hw, CMD_WRSR_S8_S15);
+		flash_ll_set_op_cmd(hw, FLASH_OP_CMD_WRSR);
+
+		flash_ll_wait_op_done(hw);
+		hw->cmd_cfg.v = 0;
+	}
+
+	flash_ll_wait_op_done(hw);
+	hw->op_ctrl.wp_value = 0;
 }
 
 static inline void flash_ll_set_qe(flash_hw_t *hw, uint8_t qe_bit, uint8_t qe_bit_post)

--- a/os/board/bk7239n/src/middleware/soc/common/hal/include/flash_hal.h
+++ b/os/board/bk7239n/src/middleware/soc/common/hal/include/flash_hal.h
@@ -34,6 +34,14 @@ typedef struct {
 #define flash_hal_get_mid(hal) flash_ll_get_mid((hal)->hw)
 #define flash_hal_read_status_reg(hal, sr_width) flash_ll_read_status_reg((hal)->hw, sr_width)
 #define flash_hal_write_status_reg(hal, sr_width, sr_data) flash_ll_write_status_reg((hal)->hw, sr_width, sr_data)
+/* Non-volatile status-register write. Only bk7239n uses the volatile (0x50) SR
+ * write path, so other SOCs fall back to the regular write which is already
+ * non-volatile. */
+#if CONFIG_SOC_BK7239XX
+#define flash_hal_write_status_reg_nvol(hal, sr_width, sr_data) flash_ll_write_status_reg_nvol((hal)->hw, sr_width, sr_data)
+#else
+#define flash_hal_write_status_reg_nvol(hal, sr_width, sr_data) flash_hal_write_status_reg(hal, sr_width, sr_data)
+#endif
 #define flash_hal_get_crc_err_num(hal) flash_ll_get_crc_err_num((hal)->hw)
 #define flash_hal_enable_cpu_data_wr(hal) flash_ll_enable_cpu_data_wr((hal)->hw)
 #define flash_hal_disable_cpu_data_wr(hal) flash_ll_disable_cpu_data_wr((hal)->hw)


### PR DESCRIPTION
- Restore interrupts when the Bluetooth protect-time check aborts sleep entry, avoiding IRQ left disabled.
- Persist flash write-protect across reboot and temporarily drop program/erase/WRSR clock to 40M for Winbond/XMC/GT.
- Propagate flash read/write failure status to the MTD layer instead of always returning success.