### PR TITLE
lib/libc/stdio/lib_libfwrite: Fix fwrite for unbuffered streams

### DIFF
--- a/lib/libc/stdio/lib_libfwrite.c
+++ b/lib/libc/stdio/lib_libfwrite.c
@@ -126,7 +126,13 @@ ssize_t lib_fwrite(FAR const void *ptr, size_t count, FAR FILE *stream)
 	 */
 
 	if (lib_rdflush(stream) < 0) {
-		goto errout_with_semaphore;
+		goto out_with_semaphore;
+	}
+
+	/* If no stream buffer is configured, write directly to the file. */
+	if (stream->fs_bufstart == NULL) {
+		ret = write(stream->fs_fd, ptr, count);
+		goto out_with_semaphore;
 	}
 
 	/* Loop until all of the bytes have been buffered */
@@ -167,7 +173,7 @@ ssize_t lib_fwrite(FAR const void *ptr, size_t count, FAR FILE *stream)
 
 			int bytes_buffered = lib_fflush(stream, false);
 			if (bytes_buffered < 0) {
-				goto errout_with_semaphore;
+				goto out_with_semaphore;
 			}
 		}
 	}
@@ -176,7 +182,7 @@ ssize_t lib_fwrite(FAR const void *ptr, size_t count, FAR FILE *stream)
 
 	ret = src - start;
 
-errout_with_semaphore:
+out_with_semaphore:
 	lib_give_semaphore(stream);
 
 errout:


### PR DESCRIPTION
When `setvbuf()` selects `_IONBF`, the stream buffer pointers are NULL. 
The buffered write loop then makes no progress because its available size is zero. 
Write the data directly to the file descriptor when no stream buffer is configured. 
Rename the common exit label so both successful direct writes and failures release the stream semaphore before returning.