### PR TITLE
lib/libc/unistd/lib_getopt: Add optional argument support in getopt

### DIFF
--- a/lib/libc/unistd/lib_getopt.c
+++ b/lib/libc/unistd/lib_getopt.c
@@ -271,6 +271,11 @@ int getopt(int argc, FAR char *const argv[], FAR const char *optstring)
 		optarg = NULL;
 		optopt = *optchar;
 		optind++;
+
+		/* Two colons mean that the argument is optional. */
+		if (optchar[2] == ':') {
+			return *optchar;
+		}
 		return noarg_ret;
 	}
 


### PR DESCRIPTION
### 1. lib/libc/unistd/lib_getopt: Add optional argument support in getopt

Add `CONFIG_LIBC_GETOPT_OPTIONAL_ARGUMENT` to enable GNU-style optional short-option arguments denoted by two colons in optstring.
When an optional argument is omitted, return the option character with optarg set to NULL.


### 2. apps/examples/testcase/ostest: Add dependency for getopt test

Add new dependency `CONFIG_LIBC_GETOPT_OPTIONAL_ARGUMENT` to enable `TESTING_OSTEST_GETOPT`.
This test uses optional argument. `static const char *g_optstring = "abc::d:";`