### PR TITLE
os/arch/arm/armv8-m: Guard REG_EXC_RETURN signal state

### DIFF
--- a/os/arch/arm/include/armv8-m/irq.h
+++ b/os/arch/arm/include/armv8-m/irq.h
@@ -157,7 +157,9 @@ struct xcptcontext {
 #ifdef CONFIG_BUILD_PROTECTED
 	uint32_t saved_lr;
 #endif
+#if defined(CONFIG_ARM_CMNVECTOR) || defined(CONFIG_BUILD_PROTECTED)
 	uint32_t saved_exec_ret;
+#endif
 
 #ifdef CONFIG_BUILD_PROTECTED
 	/* This is the saved address to use when returning from a user-space

--- a/os/arch/arm/src/armv8-m/up_schedulesigaction.c
+++ b/os/arch/arm/src/armv8-m/up_schedulesigaction.c
@@ -175,7 +175,9 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 #ifdef CONFIG_BUILD_PROTECTED
 				tcb->xcp.saved_lr = current_regs[REG_LR];
 #endif
+#if defined(CONFIG_ARM_CMNVECTOR) || defined(CONFIG_BUILD_PROTECTED)
 				tcb->xcp.saved_exec_ret = current_regs[REG_EXC_RETURN];
+#endif
 
 				/* Then set up to vector to the trampoline with interrupts
 				 * disabled.  The kernel-space trampoline must run in
@@ -191,7 +193,9 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 #ifdef CONFIG_BUILD_PROTECTED
 				current_regs[REG_LR] = EXC_RETURN_PRIVTHR;
 #endif
+#if defined(CONFIG_ARM_CMNVECTOR) || defined(CONFIG_BUILD_PROTECTED)
 				current_regs[REG_EXC_RETURN] = EXC_RETURN_PRIVTHR;
+#endif
 
 				current_regs[REG_XPSR] = ARMV8M_XPSR_T;
 				/* And make sure that the saved context in the TCB is the same
@@ -225,7 +229,9 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 #ifdef CONFIG_BUILD_PROTECTED
 			tcb->xcp.saved_lr = tcb->xcp.regs[REG_LR];
 #endif
+#if defined(CONFIG_ARM_CMNVECTOR) || defined(CONFIG_BUILD_PROTECTED)
 			tcb->xcp.saved_exec_ret = tcb->xcp.regs[REG_EXC_RETURN];
+#endif
 
 			/* Then set up to vector to the trampoline with interrupts
 			 * disabled.  We must already be in privileged thread mode to be
@@ -241,7 +247,9 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 #ifdef CONFIG_BUILD_PROTECTED
 			tcb->xcp.regs[REG_LR] = EXC_RETURN_PRIVTHR;
 #endif
+#if defined(CONFIG_ARM_CMNVECTOR) || defined(CONFIG_BUILD_PROTECTED)
 			tcb->xcp.regs[REG_EXC_RETURN] = EXC_RETURN_PRIVTHR;
+#endif
 
 			tcb->xcp.regs[REG_XPSR] = ARMV8M_XPSR_T;
 		}

--- a/os/arch/arm/src/armv8-m/up_sigdeliver.c
+++ b/os/arch/arm/src/armv8-m/up_sigdeliver.c
@@ -132,7 +132,9 @@ void up_sigdeliver(void)
 #ifdef CONFIG_BUILD_PROTECTED
 	regs[REG_LR] = rtcb->xcp.saved_lr;
 #endif
+#if defined(CONFIG_ARM_CMNVECTOR) || defined(CONFIG_BUILD_PROTECTED)
 	regs[REG_EXC_RETURN] = rtcb->xcp.saved_exec_ret;
+#endif
 
 	/* Get a local copy of the sigdeliver function pointer. We do this so that
 	 * we can nullify the sigdeliver function pointer in the TCB and accept


### PR DESCRIPTION
`REG_EXC_RETURN` and `saved_exc_ret` is only defined when `CONFIG_ARM_CMNVECTOR=y` or `CONFIG_BUILD_PROTECTED=y`
So guard `REG_EXC_RETURN` to prevent build error when `CONFIG_ARM_CMNVECTOR is not set` and `CONFIG_BUILD_PROTECTED is not set`.

In `CONFIG_ARM_CMNVECTOR is not set` and `CONFIG_BUILD_PROTECTED is not set` case we're setting EXC_RETURN_PRIVTHR in up_lazyexception.S
```
 #ifdef CONFIG_BUILD_PROTECTED
	ldmia	r0!, {r2-r11,r14}		/* Recover R4-R11, r14 + 2 temp values */
 #else
	ldmia	r0!, {r2-r11}			/* Recover R4-R11 + 2 temp values */
	ldr	r14, =EXC_RETURN_PRIVTHR	/* Load the special value */
 #endif
```