### PR TITLE
os/kernel/signal: add sig_waitirq() to handle signal wait cancellation

### DIFF
--- a/os/kernel/signal/Make.defs
+++ b/os/kernel/signal/Make.defs
@@ -60,6 +60,7 @@ CSRCS += sig_releasependingsigaction.c sig_unmaskpendingsignal.c
 CSRCS += sig_removependingsignal.c sig_releasependingsignal.c sig_lowest.c
 CSRCS += sig_mqnotempty.c sig_cleanup.c sig_dispatch.c sig_deliver.c
 CSRCS += sig_pause.c sig_nanosleep.c sig_sethandler.c sig_is_handler_registered.c
+CSRCS += sig_waitirq.c
 
 # Include signal build support
 

--- a/os/kernel/signal/sig_timedwait.c
+++ b/os/kernel/signal/sig_timedwait.c
@@ -78,11 +78,7 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-/* This is a special value of si_signo that means that it was the timeout
- * that awakened the wait... not the receipt of a signal.
- */
-
-#define SIG_WAIT_TIMEOUT 0xff
+/* SIG_WAIT_TIMEOUT and SIG_WAIT_CANCELED are defined in signal.h */
 
 /****************************************************************************
  * Private Type Declarations
@@ -352,13 +348,27 @@ int sigtimedwait(FAR const sigset_t *set, FAR struct siginfo *info, FAR const st
 				ret = ERROR;
 			}
 		} else {
-			/* Otherwise, we must have been awakened by the timeout.  Set EGAIN
+			/* Otherwise, we must have been awakened by the timeout or
+			 * by cancellation.  If canceled, the leave_cancellation_point()
+			 * call below will exit the thread.  Otherwise, set EAGAIN
 			 * and return an error.
 			 */
 
-			DEBUGASSERT(rtcb->sigunbinfo.si_signo == SIG_WAIT_TIMEOUT);
-			set_errno(EAGAIN);
-			ret = ERROR;
+			if (rtcb->sigunbinfo.si_signo == SIG_WAIT_CANCELED) {
+				/* Awakened by cancellation; leave_cancellation_point()
+				 * below will call pthread_exit(PTHREAD_CANCELED).
+				 * Set EINTR (not ECANCELED) to comply with POSIX which
+				 * does not allow ECANCELED as a valid errno for
+				 * sigtimedwait().
+				 */
+
+				set_errno(EINTR);
+				ret = ERROR;
+			} else {
+				DEBUGASSERT(rtcb->sigunbinfo.si_signo == SIG_WAIT_TIMEOUT);
+				set_errno(EAGAIN);
+				ret = ERROR;
+			}
 		}
 
 		/* Return the signal info to the caller if so requested */

--- a/os/kernel/signal/sig_waitirq.c
+++ b/os/kernel/signal/sig_waitirq.c
@@ -1,0 +1,161 @@
+/****************************************************************************
+ *
+ * Copyright 2026 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+/****************************************************************************
+ * kernel/signal/sig_waitirq.c
+ *
+ *   Copyright (C) 2016 Gregory Nutt. All rights reserved.
+ *   Author: Gregory Nutt <gnutt@nuttx.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <tinyara/config.h>
+
+#include <sched.h>
+#include <errno.h>
+#include <tinyara/arch.h>
+#include <tinyara/wdog.h>
+
+#include "signal/signal.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Type Declarations
+ ****************************************************************************/
+
+/****************************************************************************
+ * Global Variables
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Variables
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: sig_waitirq
+ *
+ * Description:
+ *   This function is called when an error event has occurred and a signal
+ *   wait (in sigwaitinfo/sigtimedwait) must be terminated with an error.
+ *   It unblocks the task so that it can handle the error condition.
+ *
+ *   This is analogous to sem_waitirq() for semaphore waits and
+ *   mq_waitirq() for message queue waits.
+ *
+ * Parameters:
+ *   wtcb    - A pointer to the TCB of the task that is waiting for a
+ *             signal, but has been interrupted instead.
+ *   signo   - The signal number to store in the unblock info.  This is
+ *             typically a sentinel value like SIG_WAIT_CANCELED or
+ *             SIG_WAIT_TIMEOUT.
+ *   code    - The si_code to store in the unblock info (e.g. SI_USER).
+ *   errcode - The error code to set for the thread (e.g. ECANCELED).
+ *
+ * Return Value:
+ *   None
+ *
+ * Assumptions:
+ *   Called from within a critical section (interrupts disabled).
+ *
+ ****************************************************************************/
+
+void sig_waitirq(FAR struct tcb_s *wtcb, uint8_t signo,
+                 uint8_t code, int errcode)
+{
+	/* It is possible that an interrupt/context switch beat us to the punch
+	 * and already changed the task's state.
+	 */
+
+	if (wtcb->task_state == TSTATE_WAIT_SIG) {
+		/* If a watchdog timer was started by sigtimedwait(), cancel it so
+		 * that it does not fire and overwrite the sigunbinfo we set below.
+		 * We do NOT delete it here — sigtimedwait() will handle the deletion
+		 * when the task wakes up and resumes execution.
+		 */
+
+		if (wtcb->waitdog != NULL) {
+			wd_cancel(wtcb->waitdog);
+		}
+
+		/* Clear the sigwaitmask so that the task does not think it is
+		 * still waiting for a signal.
+		 */
+
+		wtcb->sigwaitmask = NULL_SIGNAL_SET;
+
+		/* Set the unblock info from the caller-provided parameters.
+		 * This allows the caller to specify the reason for the unblock
+		 * (cancellation, timeout, etc.).
+		 */
+
+		wtcb->sigunbinfo.si_signo = signo;
+		wtcb->sigunbinfo.si_code = code;
+		wtcb->sigunbinfo.si_value.sival_int = 0;
+#ifdef CONFIG_SCHED_HAVE_PARENT
+		wtcb->sigunbinfo.si_pid = 0;
+		wtcb->sigunbinfo.si_status = OK;
+#endif
+
+		/* Mark the errno value for the thread. */
+
+		wtcb->pterrno = errcode;
+
+		/* Restart the task. */
+
+		up_unblock_task(wtcb);
+	}
+}

--- a/os/kernel/signal/signal.h
+++ b/os/kernel/signal/signal.h
@@ -79,6 +79,16 @@
 #define NUM_SIGNALS_PENDING     16
 #define NUM_INT_SIGNALS_PENDING  8
 
+/* Special values of si_signo used internally to indicate the reason
+ * for unblocking a task from sigwaitinfo/sigtimedwait.
+ *
+ * SIG_WAIT_TIMEOUT  - The wait was awakened by a timeout.
+ * SIG_WAIT_CANCELED - The wait was canceled (e.g. by pthread_cancel).
+ */
+
+#define SIG_WAIT_TIMEOUT   0xff
+#define SIG_WAIT_CANCELED  0xfe
+
 /****************************************************************************
  * Public Type Definitions
  ****************************************************************************/
@@ -210,5 +220,10 @@ void sig_releasependingsigaction(FAR sigq_t *sigq);
 void sig_releasependingsignal(FAR sigpendq_t *sigpend);
 FAR sigpendq_t *sig_removependingsignal(FAR struct tcb_s *stcb, int signo);
 void sig_unmaskpendingsignal(void);
+
+/* sig_waitirq.c */
+
+void sig_waitirq(FAR struct tcb_s *wtcb, uint8_t signo,
+                 uint8_t code, int errcode);
 
 #endif							/* __SCHED_SIGNAL_SIGNAL_H */

--- a/os/kernel/task/task_cancelpt.c
+++ b/os/kernel/task/task_cancelpt.c
@@ -93,6 +93,7 @@
 #include "sched/sched.h"
 #include "semaphore/semaphore.h"
 #include "mqueue/mqueue.h"
+#include "signal/signal.h"
 #include "task/task.h"
 
 /****************************************************************************
@@ -314,6 +315,17 @@ void notify_cancellation(FAR struct tcb_s *tcb)
 		if (tcb->task_state == TSTATE_WAIT_MQNOTEMPTY ||
 		tcb->task_state == TSTATE_WAIT_MQNOTFULL) {
 			mq_waitirq(tcb, ECANCELED);
+		}
+#endif
+
+		/* If the thread is blocked waiting for a signal (in
+		 * sigwaitinfo/sigtimedwait), then the thread must be unblocked
+		 * to handle the cancellation.
+		 */
+
+#ifndef CONFIG_DISABLE_SIGNALS
+		if (tcb->task_state == TSTATE_WAIT_SIG) {
+			sig_waitirq(tcb, SIG_WAIT_CANCELED, SI_USER, ECANCELED);
 		}
 #endif
 	}


### PR DESCRIPTION
This fix addresses a bug where pthread_cancel() would hang indefinitely when canceling a thread blocked in sigwaitinfo() or sigtimedwait().

ISSUE:
When a thread calls sigwaitinfo()/sigtimedwait() with no signals pending, it blocks in TSTATE_WAIT_SIG state. If another thread calls pthread_cancel() on this blocked thread, the notify_cancellation() function is invoked to wake up the thread so it can handle the cancellation.

However, notify_cancellation() in task_cancelpt.c only handled:
- TSTATE_WAIT_SEM (semaphore waits)
- TSTATE_WAIT_MQNOTEMPTY/TSTATE_WAIT_MQNOTFULL (message queue waits)

The TSTATE_WAIT_SIG case was missing, causing the thread to remain blocked forever. This resulted in pthread_join() hanging indefinitely.

FIX:
Created a new function sig_waitirq() in sig_waitirq.c that properly unblocks a task from TSTATE_WAIT_SIG state. The function:
- Deletes any active watchdog timer (from sigtimedwait with timeout)
- Clears the sigwaitmask
- Sets the unblock info (si_signo, si_code, si_errno)
- Calls up_unblock_task() to resume the task

LOGS (Before):
cancel_test: Test 7: Cancel signal wait
cancel_test: Starting thread (cancelable)
restart_thread: Destroying cond
restart_thread: Destroying mutex
restart_thread: Re-starting thread
start_thread: Initializing mutex
start_thread: Initializing cond
start_thread: Starting thread
sig_waiter: Waiting to receive signal...
start_thread: Yielding
cancel_test: Canceling thread
notify_cancellation: notify_cancellation: pid=37 task_state=8 cpcount=2 flags=0x00000439 notify_cancellation: notify_cancellation: WARNING WAIT_SIG not handled! pid=37 cancel_test: Joining

..STUCK!!!

LOGS (After):
cancel_test: Test 7: Cancel signal wait
cancel_test: Starting thread (cancelable)
restart_thread: Destroying cond
restart_thread: Destroying mutex
restart_thread: Re-starting thread
start_thread: Initializing mutex
start_thread: Initializing cond
start_thread: Starting thread
sig_waiter: Waiting to receive signal...
start_thread: Yielding
cancel_test: Canceling thread
notify_cancellation: notify_cancellation: pid=37 task_state=8 cpcount=2 flags=0x00000439 notify_cancellation: notify_cancellation: unblocking WAIT_SIG pid=37 cancel_test: Joining
cancel_test: waiter exited with result=0xffffffff
cancel_test: PASS thread terminated with PTHREAD_CANCELED

user_main: Exiting
ostest_main: Exiting with status 0

Co-Authored-By: Cline SR