### PR TITLE
apps/examples/testcase/le_tc/kernel: Fix realloc size reduction and mqueue exit checks

### DIFF
--- a/apps/examples/testcase/le_tc/kernel/tc_memory_safety.c
+++ b/apps/examples/testcase/le_tc/kernel/tc_memory_safety.c
@@ -276,7 +276,6 @@ static void tc_memory_safety_with_mqueue(void)
 	void *result;
 	pthread_attr_t attr;
 	struct sched_param sparam;
-	FAR void *expected;
 	int priority1 = CONFIG_SCHED_LPWORKPRIORITY + 1;
 	int priority2 = CONFIG_SCHED_LPWORKPRIORITY + 2;
 	int priority3 = CONFIG_SCHED_LPWORKPRIORITY + 3;
@@ -357,22 +356,22 @@ static void tc_memory_safety_with_mqueue(void)
 	usleep(HALF_SECOND_USEC_USEC);
 #endif
 
-	/* Then cancel the thread and see if it did */
+	/* Then cancel the thread if it has not terminated yet */
 
-	expected = PTHREAD_CANCELED;
 	status = pthread_cancel(receiver);
+	TC_ASSERT("pthread_cancel", status == OK || status == ESRCH);
 	if (status == ESRCH) {
 		tckndbg("receiver has already terminated\n");
-		expected = (FAR void *)0;
 	}
 
-	/* Check the result.  If the pthread was canceled, PTHREAD_CANCELED is the
-	 * correct result.  Zero might be returned if the thread ran to completion
-	 * before it was canceled.
-	 */
-
-	pthread_join(receiver, &result);
-	TC_ASSERT_EQ("pthread_join", result, expected);
+	status = pthread_join(receiver, &result);
+	TC_ASSERT_EQ("pthread_join", status, OK);
+#ifdef CONFIG_DISABLE_SIGNALS
+	/* The receiver may complete normally or process the cancellation request. */
+	TC_ASSERT("pthread_join", result == NULL || result == PTHREAD_CANCELED);
+#else
+	TC_ASSERT_EQ("pthread_join", result, PTHREAD_CANCELED);
+#endif
 
 	/* Message queues are global resources and persist for the life of the
 	 * task group.  The message queue opened by the sender_thread must be closed

--- a/apps/examples/testcase/le_tc/kernel/tc_umm_heap.c
+++ b/apps/examples/testcase/le_tc/kernel/tc_umm_heap.c
@@ -196,6 +196,7 @@ static void tc_umm_heap_realloc(void)
 	int n_alloc;
 	int n_test_iter;
 	size_t alloc_size = ALLOC_SIZE_VAL * sizeof(int);
+	size_t initial_alloc_size = alloc_size + MM_ALIGN_UP(SIZEOF_MM_FREENODE);
 	struct mallinfo prev;
 	struct mallinfo cur;
 #ifdef CONFIG_DEBUG_MM_HEAPINFO
@@ -280,10 +281,11 @@ static void tc_umm_heap_realloc(void)
 	TC_ASSERT_EQ("mallinfo", cur.uordblks - prev.uordblks, 0);
 	TC_ASSERT_EQ("mallinfo", prev.fordblks - cur.fordblks, 0);
 
-	/* Relloc Free by size 0 */
-	mem_ptr[0] = (int *)malloc(alloc_size);
+	/* Reallocate to a smaller size.
+	 * Ensure that the remaining chunk is large enough to hold a free node.
+	 */
+	mem_ptr[0] = (int *)malloc(initial_alloc_size);
 	TC_ASSERT_NEQ("malloc", mem_ptr[0], NULL);
-	alloc_size /= 2;
 	mem_ptr[1] = (int *)realloc(mem_ptr[0], alloc_size);
 	TC_ASSERT_NEQ_CLEANUP("realloc", mem_ptr[1], NULL, free(mem_ptr[0]));
 


### PR DESCRIPTION
## Summary

This PR updates `tc_umm_heap_realloc()` and
`tc_memory_safety_with_mqueue()`.

### `tc_umm_heap_realloc()`

The test previously allocated 40 bytes and then reallocated the buffer
to 20 bytes.

When MM debug information is enabled, the remaining chunk may be smaller
than `SIZEOF_MM_FREENODE`. If the next physical chunk is allocated, the
allocator cannot create a free node and retains the original chunk size.
This causes the `mallinfo` result to differ from the expected value.

The initial allocation now includes
`MM_ALIGN_UP(SIZEOF_MM_FREENODE)`, ensuring that reallocating to a
smaller size leaves enough space for a valid free node.

### `tc_memory_safety_with_mqueue()`

The mqueue stress scenario itself is unchanged. This update only adjusts
the receiver teardown and exit-result validation.

When signals are enabled, the receiver is terminated by `SIGKILL` or by
the fallback `pthread_cancel()`. Both paths produce
`PTHREAD_CANCELED`.

Previously, if `pthread_cancel()` returned `ESRCH` after the signal had
already terminated the receiver, the test incorrectly expected a normal
exit value.

When signals are disabled, the receiver may either complete all receives
and exit normally or be terminated by `pthread_cancel()`.

The test now validates the actual `pthread_join()` result:

- Require `PTHREAD_CANCELED` when signals are enabled.
- Accept either `NULL` or `PTHREAD_CANCELED` when signals are disabled.
- Validate the return values of `pthread_cancel()` and `pthread_join()`.
