### PR TITLE
os/arch/arm, os/kernel/task: Unify vfork orchestration and stack preparation

### DIFF
--- a/os/arch/arm/src/amebasmart/Make.defs
+++ b/os/arch/arm/src/amebasmart/Make.defs
@@ -60,7 +60,7 @@ CMN_CSRCS += arm_modifyreg16.c arm_modifyreg32.c
 CMN_CSRCS += arm_modifyreg8.c arm_nputs.c arm_releasepending.c
 CMN_CSRCS += up_releasestack.c arm_reprioritizertr.c arm_saveusercontext.c
 CMN_CSRCS += arm_stackframe.c arm_switchcontext.c
-CMN_CSRCS += arm_vfork.c arm_unblocktask.c up_usestack.c
+CMN_CSRCS += arm_vfork.c up_vfork.c arm_unblocktask.c up_usestack.c
 CMN_CSRCS += up_checkstackoverflow.c
 ifeq ($(CONFIG_SYSTEM_REBOOT_REASON),y)
 CMN_CSRCS += up_reboot_reason.c

--- a/os/arch/arm/src/armv7-a/arm_vfork.c
+++ b/os/arch/arm/src/armv7-a/arm_vfork.c
@@ -52,82 +52,51 @@
 #include <tinyara/arch.h>
 #include <arch/irq.h>
 
-#include "arm_vfork.h"
+#include "up_vfork.h"
 #include "up_internal.h"
 #include "sched/sched.h"
 
 /****************************************************************************
- * Public Functions
+ * Private Functions
  ****************************************************************************/
 
 /****************************************************************************
- * Name: up_vfork
+ * Name: up_vfork_archprepare
  *
  * Description:
- *   The vfork() function has the same effect as fork(), except that the
- *   behavior is undefined if the process created by vfork() either modifies
- *   any data other than a variable of type pid_t used to store the return
- *   value from vfork(), or returns from the function in which vfork() was
- *   called, or calls any other function before successfully calling _exit()
- *   or one of the exec family of functions.
- *
- *   The overall sequence is:
- *
- *   1) User code calls vfork().  vfork() collects context information and
- *      transfers control up up_vfork().
- *   2) up_vfork() and calls nxtask_setup_vfork().
- *   3) nxtask_setup_vfork() allocates and configures the child task's TCB.
- *      This consists of:
- *      - Allocation of the child task's TCB.
- *      - Initialization of file descriptors and streams
- *      - Configuration of environment variables
- *      - Allocate and initialize the stack
- *      - Setup the input parameters for the task.
- *      - Initialization of the TCB (including call to up_initial_state())
- *   4) up_vfork() provides any additional operating context. up_vfork must:
- *      - Initialize special values in any CPU registers that were not
- *        already configured by up_initial_state()
- *   5) up_vfork() then calls nxtask_start_vfork()
- *   6) nxtask_start_vfork() then executes the child thread.
- *
- * nxtask_abort_vfork() may be called if an error occurs between steps 3 and
- * 6.
- *
- * Input Parameters:
- *   context - Caller context information saved by vfork()
- *
- * Returned Value:
- *   Upon successful completion, vfork() returns 0 to the child process and
- *   returns the process ID of the child process to the parent process.
- *   Otherwise, -1 is returned to the parent, no child process is created,
- *   and errno is set to indicate the error.
+ *   Prepare the ARMv7-A full-descending child stack and relocate the
+ *   register-save frame.  The common up_vfork() orchestration supplies the
+ *   TCB and performs the shared register and task-start work.
  *
  ****************************************************************************/
 
-pid_t up_vfork(const struct vfork_s *context)
+int up_vfork_archprepare(struct tcb_s *parent, struct task_tcb_s *child, const struct vfork_s *context, struct up_vfork_stack_s *stack)
 {
-	struct tcb_s *parent = this_task();
-	struct task_tcb_s *child;
+	size_t stackframe;
 	uint32_t newsp;
 	uint32_t newfp;
 	uint32_t newtop;
 	uint32_t stacktop;
 	uint32_t stackutil;
+	FAR void *child_frame;
 
-	svdbg("vfork context [%p]:\n", context);
-	svdbg("  r4:%08" PRIx32 " r5:%08" PRIx32 " r6:%08" PRIx32 " r7:%08" PRIx32 "\n", context->r4, context->r5, context->r6, context->r7);
-	svdbg("  r8:%08" PRIx32 " r9:%08" PRIx32 " r10:%08" PRIx32 "\n", context->r8, context->r9, context->r10);
-	svdbg("  fp:%08" PRIx32 " sp:%08" PRIx32 " lr:%08" PRIx32 "\n", context->fp, context->sp, context->lr);
+	/* The parent argv[] frame is below stack_base_ptr.  Keep an equal frame
+	 * in the child so the argv relocation remains inside the child stack.
+	 */
+	stackframe = (uintptr_t)parent->stack_base_ptr - (uintptr_t)parent->stack_alloc_ptr;
 
-	/* Allocate and initialize a TCB for the child task. */
+	if (stackframe > 0) {
+		/* ARMv7-A's up_stack_frame() reserves space at the bottom of the
+		 * full-descending stack without moving xcp.regs.  Copy the parent's
+		 * argv[] frame before vfork_stackargsetup() adjusts its pointers.
+		 */
+		child_frame = up_stack_frame((FAR struct tcb_s *)child, stackframe);
+		if (child_frame == NULL) {
+			return -ENOMEM;
+		}
 
-	child = task_vforksetup((start_t)(context->lr & ~1));
-	if (!child) {
-		sdbg("ERROR: task_vforksetup failed\n");
-		return (pid_t)ERROR;
+		memcpy(child_frame, parent->stack_alloc_ptr, stackframe);
 	}
-
-	svdbg("TCBs: Parent=%p Child=%p\n", parent, child);
 
 	/* How much of the parent's stack was utilized?  The ARM uses
 	 * a push-down stack so that the current stack pointer should
@@ -172,64 +141,8 @@ pid_t up_vfork(const struct vfork_s *context)
 	svdbg("Old stack top:%08" PRIx32 " SP:%08" PRIx32 " FP:%08" PRIx32 "\n", stacktop, context->sp, context->fp);
 	svdbg("New stack top:%08" PRIx32 " SP:%08" PRIx32 " FP:%08" PRIx32 "\n", newtop, newsp, newfp);
 
-	/* Update the stack pointer, frame pointer, and volatile registers.  When
-	 * the child TCB was initialized, all of the values were set to zero.
-	 * up_initial_state() altered a few values, but the return value in R0
-	 * should be cleared to zero, providing the indication to the newly started
-	 * child thread.
-	 */
-
-	child->cmn.xcp.regs[REG_R4] = context->r4;	/* Volatile register r4 */
-	child->cmn.xcp.regs[REG_R5] = context->r5;	/* Volatile register r5 */
-	child->cmn.xcp.regs[REG_R6] = context->r6;	/* Volatile register r6 */
-	child->cmn.xcp.regs[REG_R7] = context->r7;	/* Volatile register r7 */
-	child->cmn.xcp.regs[REG_R8] = context->r8;	/* Volatile register r8 */
-	child->cmn.xcp.regs[REG_R9] = context->r9;	/* Volatile register r9 */
-	child->cmn.xcp.regs[REG_R10] = context->r10;	/* Volatile register r10 */
-	child->cmn.xcp.regs[REG_FP] = newfp;	/* Frame pointer */
-	child->cmn.xcp.regs[REG_SP] = newsp;	/* Stack pointer */
-
-#ifdef CONFIG_LIB_SYSCALL
-	/* If we got here via a syscall, then we are going to have to setup some
-	 * syscall return information as well.
-	 */
-
-	if (parent->xcp.nsyscalls > 0) {
-		int index;
-		for (index = 0; index < parent->xcp.nsyscalls; index++) {
-			child->cmn.xcp.syscall[index].sysreturn = parent->xcp.syscall[index].sysreturn;
-
-			/* REVISIT:  This logic is *not* common. */
-
-#if defined(CONFIG_ARCH_ARMV7A_FAMILY)
-#ifdef CONFIG_BUILD_PROTECTED
-
-			child->cmn.xcp.syscall[index].cpsr = parent->xcp.syscall[index].cpsr;
-
-#endif
-
-#elif defined(CONFIG_ARCH_ARMV7R)
-#ifdef CONFIG_BUILD_PROTECTED
-
-			child->cmn.xcp.syscall[index].cpsr = parent->xcp.syscall[index].cpsr;
-
-#endif
-#elif defined(CONFIG_ARCH_ARMV6M) || defined(CONFIG_ARCH_ARMV7M) || \
-      defined(CONFIG_ARCH_ARMV8M)
-
-			child->cmn.xcp.syscall[index].excreturn = parent->xcp.syscall[index].excreturn;
-#else
-#error Missing logic
-#endif
-		}
-
-		child->cmn.xcp.nsyscalls = parent->xcp.nsyscalls;
-	}
-#endif
-
-	/* And, finally, start the child task.  On a failure, nxtask_start_vfork()
-	 * will discard the TCB by calling nxtask_abort_vfork().
-	 */
-
-	return task_vforkstart(child);
+	stack->newsp = newsp;
+	stack->newfp = newfp;
+	stack->parent_sp = context->sp;
+	return OK;
 }

--- a/os/arch/arm/src/common/up_vfork.c
+++ b/os/arch/arm/src/common/up_vfork.c
@@ -66,10 +66,6 @@
 #include <tinyara/arch.h>
 #include <arch/irq.h>
 
-#ifdef CONFIG_DEBUG_MM_HEAPINFO
-#include <tinyara/mm/mm.h>
-#endif
-
 #include "up_vfork.h"
 #include "up_internal.h"
 #include "sched/sched.h"
@@ -81,6 +77,57 @@
 /****************************************************************************
  * Private Functions
  ****************************************************************************/
+
+#ifndef CONFIG_ARCH_ARMV7A_FAMILY
+
+/****************************************************************************
+ * Name: up_vfork_archprepare
+ *
+ * Description:
+ *   Prepare the child stack for the ARM families that keep the register
+ *   context in the TCB.  ARMv7-A supplies an architecture-specific Adapter
+ *   because its register context is stored in the child stack itself.
+ *
+ ****************************************************************************/
+
+int up_vfork_archprepare(struct tcb_s *parent, struct task_tcb_s *child, const struct vfork_s *context, struct up_vfork_stack_s *stack)
+{
+	uint32_t newsp;
+	uint32_t newfp;
+	uint32_t stackutil;
+
+	/* How much of the parent's stack was utilized?  The ARM uses a
+	 * push-down stack so that the current stack pointer should be lower
+	 * than the initial, adjusted stack pointer.
+	 */
+
+	DEBUGASSERT((uint32_t)parent->adj_stack_ptr > context->sp);
+	stackutil = (uint32_t)parent->adj_stack_ptr - context->sp;
+
+	svdbg("Parent: stacksize:%d stackutil:%d\n", parent->adj_stack_size, stackutil);
+
+	/* Preserve the active portion of the parent's stack in the child. */
+	newsp = (uint32_t)child->cmn.adj_stack_ptr - stackutil;
+	memcpy((void *)newsp, (const void *)context->sp, stackutil);
+
+	/* Was there a frame pointer in place before? */
+	if (context->fp <= (uint32_t)parent->adj_stack_ptr && context->fp >= (uint32_t)parent->adj_stack_ptr - parent->adj_stack_size) {
+		uint32_t frameutil = (uint32_t)parent->adj_stack_ptr - context->fp;
+		newfp = (uint32_t)child->cmn.adj_stack_ptr - frameutil;
+	} else {
+		newfp = context->fp;
+	}
+
+	svdbg("Parent: stack base:%08x SP:%08x FP:%08x\n", (uint32_t)parent->adj_stack_ptr, context->sp, context->fp);
+	svdbg("Child:  stack base:%08x SP:%08x FP:%08x\n", (uint32_t)child->cmn.adj_stack_ptr, newsp, newfp);
+
+	stack->newsp = newsp;
+	stack->newfp = newfp;
+	stack->parent_sp = 0;
+	return OK;
+}
+
+#endif /* !CONFIG_ARCH_ARMV7A_FAMILY */
 
 /****************************************************************************
  * Public Functions
@@ -100,17 +147,17 @@
  *   The overall sequence is:
  *
  *   1) User code calls vfork().  vfork() collects context information and
- *      transfers control up up_vfork().
- *   2) up_vfork()and calls task_vforksetup().
- *   3) task_vforksetup() allocates and configures the child task's TCB.  This
- *      consists of:
+ *      transfers control to up_vfork().
+ *   2) up_vfork() calls task_vforksetup().
+ *   3) task_vforksetup() allocates and configures the child task's TCB.
+ *      This consists of:
  *      - Allocation of the child task's TCB.
  *      - Initialization of file descriptors and streams
  *      - Configuration of environment variables
- *      - Setup the input parameters for the task.
- *      - Initialization of the TCB (including call to up_initial_state()
- *   4) up_vfork() provides any additional operating context. up_vfork must:
  *      - Allocate and initialize the stack
+ *      - Setup the input parameters for the task.
+ *      - Initialization of the TCB (including call to up_initial_state())
+ *   4) up_vfork() provides any additional operating context. up_vfork must:
  *      - Initialize special values in any CPU registers that were not
  *        already configured by up_initial_state()
  *   5) up_vfork() then calls task_vforkstart()
@@ -133,10 +180,7 @@ pid_t up_vfork(const struct vfork_s *context)
 {
 	struct tcb_s *parent = this_task();
 	struct task_tcb_s *child;
-	size_t stacksize;
-	uint32_t newsp;
-	uint32_t newfp;
-	uint32_t stackutil;
+	struct up_vfork_stack_s stack;
 	int ret;
 
 	svdbg("vfork context [%p]:\n", context);
@@ -154,79 +198,30 @@ pid_t up_vfork(const struct vfork_s *context)
 
 	svdbg("TCBs: Parent=%p Child=%p\n", parent, child);
 
-	/* Get the size of the parent task's stack.  Due to alignment operations,
-	 * the adjusted stack size may be smaller than the stack size originally
-	 * requested.
-	 */
-
-	stacksize = parent->adj_stack_size + STACK_ALIGNMENT - 1;
-
-	/* Allocate the stack for the TCB */
-
-	ret = up_create_stack((FAR struct tcb_s *)child, stacksize, parent->flags & TCB_FLAG_TTYPE_MASK);
-	if (ret != OK) {
-		sdbg("ERROR: up_create_stack failed: %d\n", ret);
+	ret = up_vfork_archprepare(parent, child, context, &stack);
+	if (ret < 0) {
 		task_vforkabort(child, -ret);
 		return (pid_t)ERROR;
 	}
-#ifdef CONFIG_DEBUG_MM_HEAPINFO
-	/* Exclude a stack node from heap usages of current thread.
-	 * This will be shown separately as stack usages.
-	 */
-	heapinfo_exclude_stacksize(child->cmn.stack_alloc_ptr);
-	/* Update the pid information to set a stack node */
-	heapinfo_set_stack_node(child->cmn.stack_alloc_ptr, child->cmn.pid);
-#endif
 
-	/* How much of the parent's stack was utilized?  The ARM uses
-	 * a push-down stack so that the current stack pointer should
-	 * be lower than the initial, adjusted stack pointer.  The
-	 * stack usage should be the difference between those two.
+	/* The architecture hook may relocate the register-save area (as it does
+	 * on ARMv7-A), so populate the inherited registers only after it returns.
 	 */
 
-	DEBUGASSERT((uint32_t)parent->adj_stack_ptr > context->sp);
-	stackutil = (uint32_t)parent->adj_stack_ptr - context->sp;
-
-	svdbg("Parent: stacksize:%d stackutil:%d\n", stacksize, stackutil);
-
-	/* Make some feeble effort to preserve the stack contents.  This is
-	 * feeble because the stack surely contains invalid pointers and other
-	 * content that will not work in the child context.  However, if the
-	 * user follows all of the caveats of vfork() usage, even this feeble
-	 * effort is overkill.
+	/* Update the volatile registers, frame pointer, and stack pointer.  The
+	 * child TCB was initialized by up_initial_state(), so R0 remains zero and
+	 * indicates the child return path.
 	 */
 
-	newsp = (uint32_t)child->cmn.adj_stack_ptr - stackutil;
-	memcpy((void *)newsp, (const void *)context->sp, stackutil);
-
-	/* Was there a frame pointer in place before? */
-
-	if (context->fp <= (uint32_t)parent->adj_stack_ptr && context->fp >= (uint32_t)parent->adj_stack_ptr - stacksize) {
-		uint32_t frameutil = (uint32_t)parent->adj_stack_ptr - context->fp;
-		newfp = (uint32_t)child->cmn.adj_stack_ptr - frameutil;
-	} else {
-		newfp = context->fp;
-	}
-
-	svdbg("Parent: stack base:%08x SP:%08x FP:%08x\n", parent->adj_stack_ptr, context->sp, context->fp);
-	svdbg("Child:  stack base:%08x SP:%08x FP:%08x\n", child->cmn.adj_stack_ptr, newsp, newfp);
-
-	/* Update the stack pointer, frame pointer, and volatile registers.  When
-	 * the child TCB was initialized, all of the values were set to zero.
-	 * up_initial_state() altered a few values, but the return value in R0
-	 * should be cleared to zero, providing the indication to the newly started
-	 * child thread.
-	 */
-
-	child->cmn.xcp.regs[REG_R4] = context->r4;	/* Volatile register r4 */
-	child->cmn.xcp.regs[REG_R5] = context->r5;	/* Volatile register r5 */
-	child->cmn.xcp.regs[REG_R6] = context->r6;	/* Volatile register r6 */
-	child->cmn.xcp.regs[REG_R7] = context->r7;	/* Volatile register r7 */
-	child->cmn.xcp.regs[REG_R8] = context->r8;	/* Volatile register r8 */
-	child->cmn.xcp.regs[REG_R9] = context->r9;	/* Volatile register r9 */
-	child->cmn.xcp.regs[REG_R10] = context->r10;	/* Volatile register r10 */
-	child->cmn.xcp.regs[REG_FP] = newfp;	/* Frame pointer */
-	child->cmn.xcp.regs[REG_SP] = newsp;	/* Stack pointer */
+	child->cmn.xcp.regs[REG_R4] = context->r4;
+	child->cmn.xcp.regs[REG_R5] = context->r5;
+	child->cmn.xcp.regs[REG_R6] = context->r6;
+	child->cmn.xcp.regs[REG_R7] = context->r7;
+	child->cmn.xcp.regs[REG_R8] = context->r8;
+	child->cmn.xcp.regs[REG_R9] = context->r9;
+	child->cmn.xcp.regs[REG_R10] = context->r10;
+	child->cmn.xcp.regs[REG_FP] = stack.newfp;
+	child->cmn.xcp.regs[REG_SP] = stack.newsp;
 
 #ifdef CONFIG_LIB_SYSCALL
 	/* If we got here via a syscall, then we are going to have to setup some
@@ -240,11 +235,12 @@ pid_t up_vfork(const struct vfork_s *context)
 
 			/* REVISIT:  This logic is *not* common. */
 
-#if (defined(CONFIG_ARCH_CORTEXA5) || defined(CONFIG_ARCH_CORTEXA8)) && \
-	 defined(CONFIG_BUILD_KERNEL)
+#if defined(CONFIG_ARCH_ARMV7A_FAMILY)
+#ifdef CONFIG_BUILD_PROTECTED
 
 			child->cmn.xcp.syscall[index].cpsr = parent->xcp.syscall[index].cpsr;
 
+#endif
 #elif defined(CONFIG_ARCH_CORTEXR4) || defined(CONFIG_ARCH_CORTEXR4F)
 #ifdef CONFIG_BUILD_PROTECTED
 
@@ -269,5 +265,5 @@ pid_t up_vfork(const struct vfork_s *context)
 	 * will discard the TCB by calling task_vforkabort().
 	 */
 
-	return task_vforkstart(child);
+	return task_vforkstart(child, stack.parent_sp);
 }

--- a/os/arch/arm/src/common/up_vfork.h
+++ b/os/arch/arm/src/common/up_vfork.h
@@ -99,6 +99,14 @@ struct vfork_s {
 
 	/* Floating point registers (not yet) */
 };
+
+struct up_vfork_stack_s {
+	uintptr_t newsp;      /* Child stack pointer after relocation */
+	uintptr_t newfp;      /* Child frame pointer after relocation */
+	uintptr_t parent_sp;  /* Parent SP for argv relocation, or zero */
+};
+
+int up_vfork_archprepare(struct tcb_s *parent, struct task_tcb_s *child, const struct vfork_s *context, struct up_vfork_stack_s *stack);
 #endif
 
 #endif							/* __ARCH_ARM_SRC_ARM_VFORK_H */

--- a/os/arch/arm/src/imx6/Make.defs
+++ b/os/arch/arm/src/imx6/Make.defs
@@ -28,7 +28,7 @@ CMN_CSRCS += arm_modifyreg16.c arm_modifyreg32.c
 CMN_CSRCS += arm_modifyreg8.c arm_nputs.c arm_releasepending.c
 CMN_CSRCS += up_releasestack.c arm_reprioritizertr.c arm_saveusercontext.c
 CMN_CSRCS += arm_stackframe.c arm_switchcontext.c
-CMN_CSRCS += arm_vfork.c arm_unblocktask.c up_usestack.c
+CMN_CSRCS += arm_vfork.c up_vfork.c arm_unblocktask.c up_usestack.c
 CMN_CSRCS += up_checkstackoverflow.c
 
 ifneq ($(CONFIG_ALARM_ARCH),y)

--- a/os/include/tinyara/sched.h
+++ b/os/include/tinyara/sched.h
@@ -919,20 +919,29 @@ void task_starthook(FAR struct task_tcb_s *tcb, starthook_t starthook, FAR void 
  *
  * 1) User code calls vfork().  vfork() is provided in architecture-specific
  *    code.
- * 2) vfork()and calls task_vforksetup().
+ * 2) vfork() calls task_vforksetup().
  * 3) task_vforksetup() allocates and configures the child task's TCB.  This
  *    consists of:
  *    - Allocation of the child task's TCB.
  *    - Initialization of file descriptors and streams
  *    - Configuration of environment variables
- *    - Setup the intput parameters for the task.
- *    - Initialization of the TCB (including call to up_initial_state()
- * 4) vfork() provides any additional operating context. vfork must:
  *    - Allocate and initialize the stack
+ *    - Setup the intput parameters for the task.
+ *    - Initialization of the TCB (including call to up_initial_state())
+ * 4) vfork() provides any additional operating context. vfork may:
  *    - Initialize special values in any CPU registers that were not
  *      already configured by up_initial_state()
  * 5) vfork() then calls task_vforkstart()
  * 6) task_vforkstart() then executes the child thread.
+ *
+ * task_vforksetup() parameters:
+ *   retaddr - Return address in the child after vfork().
+ *
+ * task_vforkstart() parameters:
+ *   child     - The initialized child task TCB.
+ *   parent_sp - The parent's current stack pointer when the architecture
+ *               cannot use the saved TCB value while the parent is running.
+ *               A zero value preserves the traditional behavior.
  *
  * task_vforkabort() may be called if an error occurs between steps 3 and 6.
  *
@@ -945,7 +954,7 @@ FAR struct task_tcb_s *task_vforksetup(start_t retaddr);
 /**
  * @internal
  */
-pid_t task_vforkstart(FAR struct task_tcb_s *child);
+pid_t task_vforkstart(FAR struct task_tcb_s *child, uintptr_t parent_sp);
 /**
  * @internal
  */

--- a/os/kernel/task/task_vfork.c
+++ b/os/kernel/task/task_vfork.c
@@ -65,6 +65,10 @@
 #include <debug.h>
 
 #include <tinyara/sched.h>
+#include <tinyara/arch.h>
+#ifdef CONFIG_DEBUG_MM_HEAPINFO
+#include <tinyara/mm/mm.h>
+#endif
 
 #include "sched/sched.h"
 #include "group/group.h"
@@ -121,15 +125,17 @@ static inline void vfork_namesetup(FAR struct tcb_s *parent, FAR struct task_tcb
  *   stack.
  *
  * Input Parameters:
- *   parent - Address of the parent task's TCB
- *   child  - Address of the child task's TCB
+ *   parent    - Address of the parent task's TCB
+ *   child     - Address of the child task's TCB
+ *   parent_sp - The parent's current stack pointer, or zero to use the
+ *               saved value in the parent TCB.
  *
  * Return Value:
  *   Zero (OK) on success; a negated errno on failure.
  *
  ****************************************************************************/
 
-static inline int vfork_stackargsetup(FAR struct tcb_s *parent, FAR struct task_tcb_s *child)
+static inline int vfork_stackargsetup(FAR struct tcb_s *parent, FAR struct task_tcb_s *child, uintptr_t parent_sp)
 {
 	/* Is the parent a task? or a pthread?  Only tasks (and kernel threads)
 	 * have command line arguments.
@@ -141,9 +147,15 @@ static inline int vfork_stackargsetup(FAR struct tcb_s *parent, FAR struct task_
 		uintptr_t offset;
 		int argc;
 
-		/* Get the address correction */
+		/* Get the address correction. On ARMv7-A, parent->xcp.regs is stale
+		 * while the parent is running, so the architecture passes the current
+		 * stack pointer explicitly.
+		 */
+		if (parent_sp == 0) {
+			parent_sp = parent->xcp.regs[REG_SP];
+		}
 
-		offset = child->cmn.xcp.regs[REG_SP] - parent->xcp.regs[REG_SP];
+		offset = child->cmn.xcp.regs[REG_SP] - parent_sp;
 
 		/* Change the child argv[] to point into its stack (instead of its
 		 * parent's stack).
@@ -184,15 +196,17 @@ static inline int vfork_stackargsetup(FAR struct tcb_s *parent, FAR struct task_
  *   Clone the argument list from the parent to the child.
  *
  * Input Parameters:
- *   parent - Address of the parent task's TCB
- *   child  - Address of the child task's TCB
+ *   parent    - Address of the parent task's TCB
+ *   child     - Address of the child task's TCB
+ *   parent_sp - The parent's current stack pointer, or zero to use the
+ *               saved value in the parent TCB.
  *
  * Return Value:
  *   Zero (OK) on success; a negated errno on failure.
  *
  ****************************************************************************/
 
-static inline int vfork_argsetup(FAR struct tcb_s *parent, FAR struct task_tcb_s *child)
+static inline int vfork_argsetup(FAR struct tcb_s *parent, FAR struct task_tcb_s *child, uintptr_t parent_sp)
 {
 	/* Clone the task name */
 
@@ -200,7 +214,7 @@ static inline int vfork_argsetup(FAR struct tcb_s *parent, FAR struct task_tcb_s
 
 	/* Adjust and copy the argv[] array. */
 
-	return vfork_stackargsetup(parent, child);
+	return vfork_stackargsetup(parent, child, parent_sp);
 }
 
 /****************************************************************************
@@ -223,24 +237,23 @@ static inline int vfork_argsetup(FAR struct tcb_s *parent, FAR struct task_tcb_s
  *
  *   1) User code calls vfork().  vfork() is provided in architecture-specific
  *      code.
- *   2) vfork()and calls task_vforksetup().
+ *   2) vfork() calls task_vforksetup().
  *   3) task_vforksetup() allocates and configures the child task's TCB.  This
  *      consists of:
  *      - Allocation of the child task's TCB.
  *      - Initialization of file descriptors and streams
  *      - Configuration of environment variables
- *      - Setup the input parameters for the task.
- *      - Initialization of the TCB (including call to up_initial_state()
- *   4) up_vfork() provides any additional operating context. up_vfork must:
  *      - Allocate and initialize the stack
+ *      - Setup the input parameters for the task.
+ *      - Initialization of the TCB (including call to up_initial_state())
+ *   4) up_vfork() provides any additional operating context. up_vfork may:
  *      - Initialize special values in any CPU registers that were not
  *        already configured by up_initial_state()
  *   5) up_vfork() then calls task_vforkstart()
  *   6) task_vforkstart() then executes the child thread.
  *
  * Input Parameters:
- *   parent - Address of the parent task's TCB
- *   child  - Address of the child task's TCB
+ *   retaddr - Return address in the child after vfork().
  *
  * Returned Value:
  *   Upon successful completion, task_vforksetup() returns a pointer to
@@ -253,6 +266,7 @@ FAR struct task_tcb_s *task_vforksetup(start_t retaddr)
 {
 	struct tcb_s *parent = this_task();
 	struct task_tcb_s *child;
+	size_t stack_size;
 	uint8_t ttype;
 	int priority;
 	int ret;
@@ -298,6 +312,12 @@ FAR struct task_tcb_s *task_vforksetup(start_t retaddr)
 	}
 #endif
 
+	stack_size = (uintptr_t)parent->stack_base_ptr - (uintptr_t)parent->stack_alloc_ptr + parent->adj_stack_size;
+	ret = up_create_stack((FAR struct tcb_s *)child, stack_size, ttype);
+	if (ret < OK) {
+		goto errout_with_tcb;
+	}
+
 	/* Get the priority of the parent task */
 
 #ifdef CONFIG_PRIORITY_INHERITANCE
@@ -314,6 +334,15 @@ FAR struct task_tcb_s *task_vforksetup(start_t retaddr)
 		ret = -get_errno();
 		goto errout_with_tcb;
 	}
+
+#ifdef CONFIG_DEBUG_MM_HEAPINFO
+	/* Exclude a stack node from heap usages of current thread.
+	 * This will be shown separately as stack usages.
+	 */
+	heapinfo_exclude_stacksize(child->cmn.stack_alloc_ptr);
+	/* Update the pid information to set a stack node */
+	heapinfo_set_stack_node(child->cmn.stack_alloc_ptr, child->cmn.pid);
+#endif
 
 	svdbg("parent=%p, returning child=%p\n", parent, child);
 	return child;
@@ -340,24 +369,25 @@ errout_with_tcb:
  *   sequence is:
  *
  *   1) User code calls vfork()
- *   2) Architecture-specific code provides vfork()and calls task_vforksetup().
+ *   2) Architecture-specific code provides vfork() and calls task_vforksetup().
  *   3) task_vforksetup() allocates and configures the child task's TCB.  This
  *      consists of:
  *      - Allocation of the child task's TCB.
  *      - Initialization of file descriptors and streams
  *      - Configuration of environment variables
- *      - Setup the input parameters for the task.
- *      - Initialization of the TCB (including call to up_initial_state()
- *   4) vfork() provides any additional operating context. vfork must:
  *      - Allocate and initialize the stack
+ *      - Setup the input parameters for the task.
+ *      - Initialization of the TCB (including call to up_initial_state())
+ *   4) vfork() provides any additional operating context. vfork may:
  *      - Initialize special values in any CPU registers that were not
  *        already configured by up_initial_state()
  *   5) vfork() then calls task_vforkstart()
  *   6) task_vforkstart() then executes the child thread.
  *
  * Input Parameters:
- *   retaddr - The return address from vfork() where the child task
- *     will be started.
+ *   child     - The initialized child task TCB.
+ *   parent_sp - The parent's current stack pointer, or zero to use the
+ *               saved value in the parent TCB.
  *
  * Returned Value:
  *   Upon successful completion, vfork() returns 0 to the child process and
@@ -367,7 +397,7 @@ errout_with_tcb:
  *
  ****************************************************************************/
 
-pid_t task_vforkstart(FAR struct task_tcb_s *child)
+pid_t task_vforkstart(FAR struct task_tcb_s *child, uintptr_t parent_sp)
 {
 	struct tcb_s *parent = this_task();
 	pid_t pid;
@@ -379,7 +409,7 @@ pid_t task_vforkstart(FAR struct task_tcb_s *child)
 
 	/* Duplicate the original argument list in the forked child TCB */
 
-	ret = vfork_argsetup(parent, child);
+	ret = vfork_argsetup(parent, child, parent_sp);
 	if (ret < 0) {
 		task_vforkabort(child, -ret);
 		return ERROR;


### PR DESCRIPTION
Allocate and initialize the child stack in task_vforksetup() before task_schedsetup().
The previous ARMv7-A path could trigger a Data Abort because up_initial_state() wrote the child register context before the stack had been allocated.
Remove deferred stack allocation from common ARM up_vfork() and centralize child stack creation in the task layer.
Unify the ARM vfork orchestration in common/up_vfork.c while keeping only the stack and register-context layout differences in up_vfork_archprepare().
Preserve the ARMv7-A full-descending stack's argv frame and copy the execution stack to the correct location.
Use the actual parent SP captured in the vfork context for ARMv7-A argv relocation instead of the potentially stale SP in the parent TCB.
Keep the saved TCB SP fallback for common ARM targets to account for architecture-specific stack layouts.
Keep architecture-specific syscall return state propagation in the shared orchestration.

[BEFORE]
```
vfork()
`-- vfork.S: capture parent context
  `-- up_vfork(context)
      `-- task_vforksetup(retaddr)
          +-- Allocate child TCB/group/files
          `-- task_schedsetup()
              `-- up_initial_state(child)
                  `-- [ARMv7-A]
                      `-- Write register context through xcp.regs
                          while the child stack is not allocated
                          `-- Data Abort

      +-- [Common ARM only]
      | `-- up_create_stack(child) # stack allocated too late
      |
      +-- Copy parent's active stack
      +-- Relocate child register context
      `-- task_vforkstart(child)
          +-- vfork_argsetup()
          | `-- Relocate argv using parent->xcp.regs[SP]
          +-- group_initialize()
          +-- task_activate()
          `-- waitpid(child)
```

[AFTER]
```
vfork()
`-- vfork.S: capture parent context
  `-- up_vfork(context) [common/up_vfork.c]
      `-- task_vforksetup(retaddr)
          +-- Allocate child TCB/group/files
          +-- Calculate child stack size
          +-- up_create_stack(child)
          `-- task_schedsetup()
              `-- up_initial_state(child)
                  `-- Initialize register context on a valid child stack

      +-- up_vfork_archprepare(parent, child, context, &stack)
      | +-- [ARMv7-A: arm_vfork.c]
      | | +-- Reserve the child argv frame
      | | +-- Copy the parent's argv frame
      | | +-- Copy the parent's active stack
      | | `-- Relocate the ARMv7-A register-save frame
      | `-- [Common ARM: common/up_vfork.c]
      | +-- Copy the parent's active stack
      | `-- Prepare the relocated stack/frame pointers
      |
      +-- Commonly copy inherited registers and syscall return state
      `-- task_vforkstart(child, stack.parent_sp)
          +-- vfork_argsetup(parent_sp)
          | +-- Use context->sp for ARMv7-A
          | `-- Use parent->xcp.regs[SP] when parent_sp is zero
          +-- group_initialize()
          +-- task_activate()
          `-- waitpid(child)
```