### PR TITLE
os/kernel/semaphore: Fix multi-count recovery in sem_release_all

### DIFF
--- a/apps/examples/testcase/le_tc/stress/stress_sem_prio_inherit.c
+++ b/apps/examples/testcase/le_tc/stress/stress_sem_prio_inherit.c
@@ -22,6 +22,8 @@
 
 #include <tinyara/config.h>
 #include <errno.h>
+#include <stdbool.h>
+#include <time.h>
 #include <sched.h>
 #include <semaphore.h>
 #include <stdio.h>
@@ -42,6 +44,22 @@
 #define PI_T4_A1_PRIO 100
 #define PI_T4_A2_PRIO 95
 #define PI_T4_B_PRIO  80
+
+#define PI_T5_MAIN_PRIO       160
+#define PI_T5_LOW_PRIO        110
+#define PI_T5_A_PRIO          120
+#define PI_T5_B_PRIO          130
+#define PI_T5_C_PRIO          140
+#define PI_T5_D_PRIO          150
+#define PI_T5_STACK           4096
+#define PI_T5_TIMEOUT_SECONDS 2
+#define PI_T5_CPU             0
+
+#define PI_T5_STAGE_INITIAL   0
+#define PI_T5_STAGE_READY     1
+#define PI_T5_STAGE_WAITING   2
+#define PI_T5_STAGE_ACQUIRED  3
+#define PI_T5_STAGE_ERROR    -1
 
 /****************************************************************************
  * Private Data
@@ -65,6 +83,19 @@ static pid_t g_t3_holder = -1;
 static sem_t g_t4_sem_a;
 static sem_t g_t4_sem_b;
 static pid_t g_t4_holder = -1;
+
+static sem_t g_t5_target_sem;
+static sem_t g_t5_a_hold_sem;
+static sem_t g_t5_b_hold_sem;
+static sem_t g_t5_c_hold_sem;
+static sem_t g_t5_d_hold_sem;
+static sem_t g_t5_acquired_sem;
+static sem_t g_t5_start_sem[4];
+static volatile int g_t5_a_stage;
+static volatile int g_t5_b_stage;
+static volatile int g_t5_c_stage;
+static volatile int g_t5_d_stage;
+
 static int g_pi_pass;
 static int g_pi_fail;
 
@@ -575,6 +606,357 @@ static int pi_t4_test(void)
 	return OK;
 }
 
+static int pi_t5_set_self_priority(int priority)
+{
+	struct sched_param param;
+
+	param.sched_priority = priority;
+	return sched_setparam(0, &param);
+}
+
+static int pi_t5_run_until_blocked(void)
+{
+	/* The controller and workers are pinned to one CPU.  Once the controller
+	 * lowers its priority, the newly-created task runs until it blocks.  The
+	 * controller can only resume after that blocking point has been reached.
+	 */
+
+	if (pi_t5_set_self_priority(PI_T5_LOW_PRIO) < 0) {
+		return ERROR;
+	}
+
+	return pi_t5_set_self_priority(PI_T5_MAIN_PRIO);
+}
+
+static pid_t pi_t5_create_task(const char *name, main_t entry, int priority)
+{
+	return task_create(name, priority, PI_T5_STACK, entry, NULL);
+}
+
+static int pi_t5_prepare_task(int index, volatile int *stage)
+{
+#ifdef CONFIG_SMP
+	cpu_set_t cpuset;
+
+	CPU_ZERO(&cpuset);
+	CPU_SET(PI_T5_CPU, &cpuset);
+	if (sched_setaffinity(0, sizeof(cpu_set_t), &cpuset) < 0) {
+		*stage = PI_T5_STAGE_ERROR;
+		return ERROR;
+	}
+#endif
+
+#ifdef CONFIG_CANCELLATION_POINTS
+	(void)task_setcancelstate(TASK_CANCEL_ENABLE, NULL);
+	(void)task_setcanceltype(TASK_CANCEL_ASYNCHRONOUS, NULL);
+#endif
+
+	if (sem_wait(&g_t5_start_sem[index]) < 0) {
+		*stage = PI_T5_STAGE_ERROR;
+		return ERROR;
+	}
+
+	return OK;
+}
+
+static int pi_t5_wait_for_acquisition(void)
+{
+	struct timespec abstime;
+
+	if (clock_gettime(CLOCK_REALTIME, &abstime) < 0) {
+		return ERROR;
+	}
+
+	abstime.tv_sec += PI_T5_TIMEOUT_SECONDS;
+	do {
+		if (sem_timedwait(&g_t5_acquired_sem, &abstime) == OK) {
+			return OK;
+		}
+	} while (errno == EINTR);
+
+	return ERROR;
+}
+
+static void pi_t5_delete_task(pid_t pid)
+{
+	(void)task_delete(pid);
+}
+
+static void pi_t5_check(const char *name, int actual, int expected)
+{
+	printf("[t5] %s=%d expected=%d %s\n",
+		   name, actual, expected, pi_result(actual, expected));
+}
+
+static int pi_t5_task_a(int argc, char *argv[])
+{
+	(void)argc;
+	(void)argv;
+
+	if (pi_t5_prepare_task(0, &g_t5_a_stage) < 0) {
+		return ERROR;
+	}
+
+	if (sem_wait(&g_t5_target_sem) < 0 || sem_wait(&g_t5_target_sem) < 0) {
+		g_t5_a_stage = PI_T5_STAGE_ERROR;
+		return ERROR;
+	}
+
+	g_t5_a_stage = PI_T5_STAGE_READY;
+	(void)sem_wait(&g_t5_a_hold_sem);
+	return OK;
+}
+
+static int pi_t5_task_b(int argc, char *argv[])
+{
+	(void)argc;
+	(void)argv;
+
+	if (pi_t5_prepare_task(1, &g_t5_b_stage) < 0) {
+		return ERROR;
+	}
+
+	if (sem_wait(&g_t5_target_sem) < 0) {
+		g_t5_b_stage = PI_T5_STAGE_ERROR;
+		return ERROR;
+	}
+
+	g_t5_b_stage = PI_T5_STAGE_READY;
+	(void)sem_wait(&g_t5_b_hold_sem);
+	return OK;
+}
+
+static int pi_t5_task_c(int argc, char *argv[])
+{
+	(void)argc;
+	(void)argv;
+
+	if (pi_t5_prepare_task(2, &g_t5_c_stage) < 0) {
+		return ERROR;
+	}
+
+	g_t5_c_stage = PI_T5_STAGE_WAITING;
+	if (sem_wait(&g_t5_target_sem) < 0) {
+		g_t5_c_stage = PI_T5_STAGE_ERROR;
+		return ERROR;
+	}
+
+	g_t5_c_stage = PI_T5_STAGE_ACQUIRED;
+	(void)sem_post(&g_t5_acquired_sem);
+	(void)sem_wait(&g_t5_c_hold_sem);
+	return OK;
+}
+
+static int pi_t5_task_d(int argc, char *argv[])
+{
+	(void)argc;
+	(void)argv;
+
+	if (pi_t5_prepare_task(3, &g_t5_d_stage) < 0) {
+		return ERROR;
+	}
+
+	g_t5_d_stage = PI_T5_STAGE_WAITING;
+	if (sem_wait(&g_t5_target_sem) < 0) {
+		g_t5_d_stage = PI_T5_STAGE_ERROR;
+		return ERROR;
+	}
+
+	g_t5_d_stage = PI_T5_STAGE_ACQUIRED;
+	(void)sem_post(&g_t5_acquired_sem);
+	(void)sem_wait(&g_t5_d_hold_sem);
+	return OK;
+}
+
+static int pi_t5_test(void)
+{
+	FAR sem_t *semaphores[] = {
+		&g_t5_target_sem,
+		&g_t5_a_hold_sem,
+		&g_t5_b_hold_sem,
+		&g_t5_c_hold_sem,
+		&g_t5_d_hold_sem,
+		&g_t5_acquired_sem,
+		&g_t5_start_sem[0],
+		&g_t5_start_sem[1],
+		&g_t5_start_sem[2],
+		&g_t5_start_sem[3],
+	};
+	const unsigned int initial_values[] = { 3, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
+	const char *names[] = {
+		"pi_t5_a",
+		"pi_t5_b",
+		"pi_t5_c",
+		"pi_t5_d",
+	};
+	main_t entries[] = {
+		pi_t5_task_a,
+		pi_t5_task_b,
+		pi_t5_task_c,
+		pi_t5_task_d,
+	};
+	const int priorities[] = {
+		PI_T5_A_PRIO,
+		PI_T5_B_PRIO,
+		PI_T5_C_PRIO,
+		PI_T5_D_PRIO,
+	};
+	volatile int *stages[] = {
+		&g_t5_a_stage,
+		&g_t5_b_stage,
+		&g_t5_c_stage,
+		&g_t5_d_stage,
+	};
+	const int expected_stages[] = {
+		PI_T5_STAGE_READY,
+		PI_T5_STAGE_READY,
+		PI_T5_STAGE_WAITING,
+		PI_T5_STAGE_WAITING,
+	};
+	pid_t tasks[4];
+	bool created[4] = { false, false, false, false };
+	struct sched_param original_param;
+	int initial_failures = g_pi_fail;
+	int initialized = 0;
+	int target_value = 0;
+	int acquired_count = 0;
+	int ret;
+	int i;
+#ifdef CONFIG_SMP
+	cpu_set_t original_affinity;
+	cpu_set_t test_affinity;
+	bool affinity_saved = false;
+#endif
+
+	printf("\n=== Test 5: release all counts held by deleted task ===\n");
+	printf("main=%d A=%d B=%d C=%d D=%d\n",
+		   PI_T5_MAIN_PRIO, PI_T5_A_PRIO, PI_T5_B_PRIO,
+		   PI_T5_C_PRIO, PI_T5_D_PRIO);
+
+	if (sched_getparam(0, &original_param) < 0) {
+		printf("[t5] sched_getparam(main) failed errno=%d\n", errno);
+		g_pi_fail++;
+		return ERROR;
+	}
+
+#ifdef CONFIG_SMP
+	if (sched_getaffinity(0, sizeof(cpu_set_t), &original_affinity) < 0) {
+		printf("[t5] sched_getaffinity(main) failed errno=%d\n", errno);
+		g_pi_fail++;
+		return ERROR;
+	}
+	affinity_saved = true;
+	CPU_ZERO(&test_affinity);
+	CPU_SET(PI_T5_CPU, &test_affinity);
+	if (sched_setaffinity(0, sizeof(cpu_set_t), &test_affinity) < 0) {
+		printf("[t5] sched_setaffinity(main) failed errno=%d\n", errno);
+		g_pi_fail++;
+		return ERROR;
+	}
+#endif
+
+	if (pi_t5_set_self_priority(PI_T5_MAIN_PRIO) < 0) {
+		printf("[t5] set main priority failed errno=%d\n", errno);
+		g_pi_fail++;
+		goto cleanup;
+	}
+
+	g_t5_a_stage = PI_T5_STAGE_INITIAL;
+	g_t5_b_stage = PI_T5_STAGE_INITIAL;
+	g_t5_c_stage = PI_T5_STAGE_INITIAL;
+	g_t5_d_stage = PI_T5_STAGE_INITIAL;
+
+	for (i = 0; i < (int)(sizeof(semaphores) / sizeof(semaphores[0])); i++) {
+		if (sem_init(semaphores[i], 0, initial_values[i]) < 0) {
+			printf("[t5] sem_init[%d] failed errno=%d\n", i, errno);
+			g_pi_fail++;
+			goto cleanup;
+		}
+		initialized++;
+	}
+
+	for (i = 0; i < 4; i++) {
+		tasks[i] = pi_t5_create_task(names[i], entries[i], priorities[i]);
+		if (tasks[i] < 0) {
+			printf("[t5] task_create(%c) failed errno=%d\n", 'A' + i, errno);
+			g_pi_fail++;
+			goto cleanup;
+		}
+		created[i] = true;
+
+		if (sem_post(&g_t5_start_sem[i]) < 0) {
+			printf("[t5] start task %c failed errno=%d\n", 'A' + i, errno);
+			g_pi_fail++;
+			goto cleanup;
+		}
+
+		if (pi_t5_run_until_blocked() < 0 || *stages[i] != expected_stages[i]) {
+			printf("[t5] task %c did not reach its blocking point\n", 'A' + i);
+			g_pi_fail++;
+			goto cleanup;
+		}
+	}
+
+	(void)sem_getvalue(&g_t5_target_sem, &target_value);
+	printf("[t5] before delete: semcount=%d A-prio=%d B-prio=%d\n",
+		   target_value, pi_getprio(tasks[0]), pi_getprio(tasks[1]));
+	if (target_value != -2 || pi_getprio(tasks[1]) != PI_T5_D_PRIO) {
+		printf("[t5] precondition mismatch; expected semcount=-2 B-prio=150\n");
+		g_pi_fail++;
+		goto cleanup;
+	}
+
+	ret = task_delete(tasks[0]);
+	if (ret < 0) {
+		printf("[t5] task_delete(A) failed errno=%d\n", errno);
+		g_pi_fail++;
+		goto cleanup;
+	}
+	created[0] = false;
+
+	if (pi_t5_wait_for_acquisition() == OK) {
+		acquired_count++;
+	}
+	if (pi_t5_wait_for_acquisition() == OK) {
+		acquired_count++;
+	}
+
+	(void)sem_getvalue(&g_t5_target_sem, &target_value);
+	printf("[t5] after delete: semcount=%d acquired=%d C=%s D=%s B-prio=%d\n",
+		   target_value, acquired_count,
+		   g_t5_c_stage == PI_T5_STAGE_ACQUIRED ? "yes" : "no",
+		   g_t5_d_stage == PI_T5_STAGE_ACQUIRED ? "yes" : "no",
+		   pi_getprio(tasks[1]));
+
+	pi_t5_check("semcount", target_value, 0);
+	pi_t5_check("acquired waiters", acquired_count, 2);
+	pi_t5_check("B priority", pi_getprio(tasks[1]), PI_T5_B_PRIO);
+
+cleanup:
+	(void)pi_t5_set_self_priority(PI_T5_MAIN_PRIO);
+	for (i = 3; i >= 0; i--) {
+		if (created[i]) {
+			pi_t5_delete_task(tasks[i]);
+		}
+	}
+
+	while (initialized > 0) {
+		initialized--;
+		(void)sem_destroy(semaphores[initialized]);
+	}
+
+	(void)sched_setparam(0, &original_param);
+#ifdef CONFIG_SMP
+	if (affinity_saved) {
+		(void)sched_setaffinity(0, sizeof(cpu_set_t), &original_affinity);
+	}
+#endif
+
+	printf("=== Test 5 done: %s ===\n",
+		   g_pi_fail == initial_failures ? "PASS" : "FAIL");
+	return g_pi_fail == initial_failures ? OK : ERROR;
+}
+
 static void pi_summary(void)
 {
 	printf("\n=== SUMMARY ===\n");
@@ -603,6 +985,7 @@ int stress_sem_prio_inherit_main(int argc, char *argv[])
 	(void)pi_t2_test();
 	(void)pi_t3_test();
 	(void)pi_t4_test();
+	(void)pi_t5_test();
 	pi_summary();
 #else
 	printf("pi: CONFIG_PRIORITY_INHERITANCE is disabled\n");

--- a/os/kernel/semaphore/sem_holder.c
+++ b/os/kernel/semaphore/sem_holder.c
@@ -62,10 +62,6 @@
 #include <debug.h>
 #include <tinyara/arch.h>
 
-#ifdef CONFIG_SEMAPHORE_HISTORY
-#include <tinyara/debug/sysdbg.h>
-#endif
-
 #include "sched/sched.h"
 #include "semaphore/semaphore.h"
 
@@ -987,43 +983,27 @@ void sem_restorebaseprio(FAR struct tcb_s *stcb, FAR struct tcb_s *htcb, FAR sem
 void sem_release_all(FAR struct tcb_s *htcb)
 {
 	FAR struct semholder_s *pholder;
-	FAR struct tcb_s *stcb;
 
 	while ((pholder = htcb->holdsem) != NULL) {
 		FAR sem_t *sem = pholder->sem;
+		int counts = pholder->counts;
+
+		/* A holder entry represents every count of this semaphore owned by
+		 * the task, so preserve the count before sem_freeholder() clears it.
+		 */
 
 		sem_freeholder(sem, pholder);
 
-		/* Increment the count on the semaphore to release the count that
-		 * was taken by sem_wait() or sem_post().
+		/* Return every count owned by the terminated task.  Use the normal
+		 * post-unblock path for each count so that the highest-priority waiter
+		 * receives it and the priorities of the remaining holders are restored.
 		 */
 
-		sem->semcount++;
+		while (counts-- > 0) {
+			DEBUGASSERT(sem->semcount < SEM_VALUE_MAX);
+			sem->semcount++;
 
-		/* The terminated holder will never post the semaphore. If tasks
-		 * are already blocked waiting for it, wake up the highest priority
-		 * waiter so that the released count is actually consumed, just as
-		 * sem_post() would do.
-		 */
-
-		if (sem->semcount <= 0) {
-			for (stcb = (FAR struct tcb_s *)g_waitingforsemaphore.head; (stcb && stcb->waitsem != sem); stcb = stcb->flink) ;
-
-			if (stcb) {
-				sem_addholder_tcb(stcb, sem);
-
-				/* Let the task take the semaphore */
-
-				stcb->waitsem = NULL;
-
-#ifdef CONFIG_SEMAPHORE_HISTORY
-				save_semaphore_history(sem, (void *)stcb, SEM_ACQUIRE);
-#endif
-
-				/* Restart the waiting task. */
-
-				up_unblock_task(stcb);
-			}
+			sem_unblock_task(sem, htcb);
 		}
 	}
 }


### PR DESCRIPTION
## Summary

A semaphore holder tracks repeated acquisitions in `pholder->counts`,
but `sem_release_all()` restored only one count per holder entry. This
could leave counts lost and waiters blocked after the holder terminates.

Preserve the holder count and return every count. Reuse
`sem_unblock_task()` to wake waiters and restore priority inheritance
through the normal semaphore release path.

Add `stress_pi` regression coverage for multi-count holder recovery.

## Test

Run `stress_pi` and confirm that Test 5 passes.