### PR TITLE
os/kernel/binary_manager: Fix address in signature failure log

### DIFF
--- a/os/kernel/binary_manager/binary_manager_data.c
+++ b/os/kernel/binary_manager/binary_manager_data.c
@@ -707,7 +707,7 @@ int binary_manager_check_user_update(int bin_idx, bool check_updatable)
 	if (ret == SIGNATURE_VAILD) {
 		bmvdbg("%s Signature Checking Success\n", BIN_NAME(bin_idx));
 	} else {
-		bmdbg("Invalid Signature, name : %s, address : 0x%x\n", BIN_NAME(bin_idx), BIN_PARTADDR(bin_idx, (BIN_USEIDX(bin_idx))));
+		bmdbg("Invalid Signature, name : %s, address : 0x%x\n", BIN_NAME(bin_idx), BIN_PARTADDR(bin_idx, part_idx));
 		return BINMGR_NOT_FOUND;
 	}
 #endif


### PR DESCRIPTION
Print the address of the partition where signature verification actually failed.