### PR TITLE
seclink: print help for incomplete commands

### DIFF
--- a/apps/examples/security_test/seclink/sl_test_main.c
+++ b/apps/examples/security_test/seclink/sl_test_main.c
@@ -27,6 +27,7 @@
 #include <tinyara/seclink.h>
 #include <tinyara/seclink_drv.h>
 #include "sl_test.h"
+#include "sl_test_usage.h"
 
 #ifdef SL_TEST_POOL
 #undef SL_TEST_POOL
@@ -66,10 +67,13 @@ typedef enum {
 
 static int _parse_command(sl_options *opt, int argc, char *argv[])
 {
-	if (argc < 3) {
+	if (argc < 2) {
 		return -1;
 	}
 	if (strncmp(argv[1], "all", strlen("all") + 1) == 0) {
+		if (argc < 3) {
+			return -1;
+		}
 		opt->count = atoi(argv[2]);
 		return SL_TYPE_MAX;
 	}
@@ -100,6 +104,7 @@ int sl_test_main(int argc, char *argv[])
 
 	sl_type_e type = _parse_command(&opt, argc, argv);
 	if (type == SL_TYPE_ERR) {
+		printf("%s\n", SL_USAGE);
 		return -1;
 	} else if (type == SL_TYPE_MAX) {
 		/*  run all test */

--- a/apps/examples/security_test/seclink/sl_test_usage.h
+++ b/apps/examples/security_test/seclink/sl_test_usage.h
@@ -47,7 +47,7 @@
 #define SL_USAGE                            \
 	"\n usage: sl_test [options]\n"         \
 	"    run all tests\n"                   \
-	"    TASH> sl_test all\n" \
+	"    TASH> sl_test all [count]\n" \
 	SL_AUTH_USAGE \
 	SL_SS_USAGE\
 	SL_CRYPTO_USAGE\


### PR DESCRIPTION
The argc < 3 guard in _parse_command() was too strict. 
It rejected single-argument commands such as "sl_test auth" that do not need a count, returning SL_TYPE_ERR before the command lookup loop ran. 
Relax the initial guard to argc < 2 so single-argument commands reach the lookup loop, and keep the argc < 3 check only for "all", which needs a count in argv[2]. 
Print SL_USAGE on parse failure and show the count as optional in the usage string ("sl_test all [count]").

```
TASH>>
 sl_test [options]
    run all tests
    TASH> sl_test all [count]

 authentication test
    TASH> sl_test auth [algorithm] [count]
    algorithm:
        all: run all authentication TC
        ecdsav: get ecdsa verification        ecdsas: get ecdsa signature        ed25519v: get ed25519 verification        ed25519s: get ed25519 signature        ecdh: compute ecdh        x25519: compute x25519
 secure storage test
    TASH> sl_test ss [operation] [count]
    operation:
        all: run all secure storage TC
        write: test write operation
        read: test read operation
        delete: test delete operation

 crypto test (Not supported yet)

 key test (Not supported yet)
```