### PR TITLE
os/kernel/pthread: Add cleanup handler to fix cond->waiters leak on cancellation

### DIFF
--- a/os/include/tinyara/sched.h
+++ b/os/include/tinyara/sched.h
@@ -736,13 +736,17 @@ struct pthread_tcb_s {
 	/* Clean-up stack ***************************************************/
 
 #ifdef CONFIG_PTHREAD_CLEANUP
-	/* tos   - The index to the next avaiable entry at the top of the stack.
+	/* tos   - The index to the next available entry at the top of the stack.
 	 * stack - The pre-allocated clean-up stack memory.
+	 *
+	 * NOTE: The stack size includes +1 to reserve one slot for internal
+	 * kernel cleanup handlers (e.g., cond_wait_cleanup in pthread_cond_wait).
 	 */
 
 	uint8_t tos;
-	struct pthread_cleanup_s stack[CONFIG_PTHREAD_CLEANUP_STACKSIZE];
+	struct pthread_cleanup_s stack[CONFIG_PTHREAD_CLEANUP_STACKSIZE + 1];
 #endif
+
 
 	/* POSIX Thread Specific Data ************************************************ */
 

--- a/os/kernel/pthread/pthread.h
+++ b/os/kernel/pthread/pthread.h
@@ -128,6 +128,15 @@ int pthread_sem_trytake(sem_t *sem);
 #endif
 int pthread_sem_give(sem_t *sem);
 
+#if defined(CONFIG_CANCELLATION_POINTS) && defined(CONFIG_PTHREAD_CLEANUP)
+/* Cleanup handler for pthread_cond_wait() and pthread_cond_timedwait().
+ * Decrements cond->waiters when a thread is canceled while waiting on
+ * a condition variable.
+ */
+void cond_wait_cleanup(void *arg);
+#endif
+
+
 #ifndef CONFIG_PTHREAD_MUTEX_UNSAFE
 int pthread_mutex_take(FAR struct pthread_mutex_s *mutex);
 int pthread_mutex_trytake(FAR struct pthread_mutex_s *mutex);

--- a/os/kernel/pthread/pthread_condtimedwait.c
+++ b/os/kernel/pthread/pthread_condtimedwait.c
@@ -314,6 +314,13 @@ int pthread_cond_timedwait(FAR pthread_cond_t *cond, FAR pthread_mutex_t *mutex,
 						/* Increment the waiter count */
 						cond->waiters++;
 
+						/* Register cleanup handler to decrement waiters on
+						 * cancellation.
+						 */
+#if defined(CONFIG_CANCELLATION_POINTS) && defined(CONFIG_PTHREAD_CLEANUP)
+						pthread_cleanup_push(cond_wait_cleanup, cond);
+#endif
+
 						/* Take the condition semaphore.  Do not restore interrupts
 						 * until we return from the wait.  This is necessary to
 						 * make sure that the watchdog timer and the condition wait
@@ -322,7 +329,19 @@ int pthread_cond_timedwait(FAR pthread_cond_t *cond, FAR pthread_mutex_t *mutex,
 
 						status = sem_wait((sem_t *)&cond->sem);
 
+						/* Only pop the cleanup handler if the thread was not
+						 * canceled. sem_wait() treats ECANCELED as "semaphore
+						 * acquired" (returns OK), so status may be OK even when
+						 * canceled. We must check the cancel-pending flag.
+						 */
+#if defined(CONFIG_CANCELLATION_POINTS) && defined(CONFIG_PTHREAD_CLEANUP)
+						if ((rtcb->flags & TCB_FLAG_CANCEL_PENDING) == 0) {
+							pthread_cleanup_pop(0);
+						}
+#endif
+
 						/* Did we get the condition semaphore. */
+
 
 						if (status != OK) {
 							/* Handle the special case where the semaphore wait

--- a/os/kernel/pthread/pthread_condwait.c
+++ b/os/kernel/pthread/pthread_condwait.c
@@ -65,6 +65,41 @@
 
 #include <tinyara/cancelpt.h>
 #include "pthread/pthread.h"
+#include "sched/sched.h"
+
+
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: cond_wait_cleanup
+ *
+ *
+ * Description:
+ *   Cleanup handler called when a thread is canceled while waiting on
+ *   a condition variable. Decrements the waiter count to prevent
+ *   resource leak.
+ *
+ ****************************************************************************/
+
+#if defined(CONFIG_CANCELLATION_POINTS) && defined(CONFIG_PTHREAD_CLEANUP)
+void cond_wait_cleanup(void *arg)
+{
+	FAR pthread_cond_t *cond = (FAR pthread_cond_t *)arg;
+
+	irqstate_t flags;
+
+	/* Decrement waiters counter under critical section */
+	flags = enter_critical_section();
+	if (cond->waiters > 0) {
+		cond->waiters--;
+	}
+	leave_critical_section(flags);
+}
+#endif
+
 
 /****************************************************************************
  * Public Functions
@@ -124,9 +159,27 @@ int pthread_cond_wait(FAR pthread_cond_t *cond, FAR pthread_mutex_t *mutex)
 		mutex->pid = -1;
 		ret = pthread_mutex_give(mutex);
 
+		/* Register cleanup handler to decrement waiters on cancellation */
+#if defined(CONFIG_CANCELLATION_POINTS) && defined(CONFIG_PTHREAD_CLEANUP)
+		pthread_cleanup_push(cond_wait_cleanup, cond);
+#endif
+
 		/* Take the semaphore */
 
 		status = pthread_sem_take((FAR sem_t *)&cond->sem);
+
+		/* Only pop the cleanup handler if the thread was not canceled.
+		 * sem_wait() treats ECANCELED as "semaphore acquired" (it only
+		 * checks for EINTR/ETIMEDOUT), so status may be OK even when
+		 * canceled. We must check the cancel-pending flag instead.
+		 */
+#if defined(CONFIG_CANCELLATION_POINTS) && defined(CONFIG_PTHREAD_CLEANUP)
+		FAR struct tcb_s *rtcb = this_task();
+		if (((rtcb)->flags & TCB_FLAG_CANCEL_PENDING) == 0) {
+			pthread_cleanup_pop(0);
+		}
+#endif
+
 		/* Adding DEBUGASSERT here because
 		 * possible failure cases of sem_wait() are
 		 * already handled inside pthread_sem_take()
@@ -139,9 +192,9 @@ int pthread_cond_wait(FAR pthread_cond_t *cond, FAR pthread_mutex_t *mutex)
 		    "pthread_sem_take failed! errno=%d, sem=%p, waiters=%d, semcount=%d",
 		    get_errno(), &cond->sem, cond->waiters, cond->sem.semcount);
 
+
 		if (ret == OK) {
 			/* Report the first failure that occurs */
-
 			ret = status;
 		}
 


### PR DESCRIPTION
When a thread is canceled while waiting on a condition variable, cond->waiters was not being decremented, causing a resource leak.

This fix adds a cleanup handler (cond_wait_cleanup) that is registered before waiting on the condition semaphore. The handler decrements cond->waiters when the thread is canceled (deferred or async).

The handler is only popped if the wait succeeds without cancellation.

Test cases : https://github.com/Samsung/TizenRT/commit/23ea7b173bf2ddbe25324bfaafc3085941b418c8

Co-Authored-By: Cline SR